### PR TITLE
Added diff of an InfoStore with a supplied Filter

### DIFF
--- a/gossip/filter.go
+++ b/gossip/filter.go
@@ -60,6 +60,9 @@ func computeOptimalValues(N uint32, maxFP float64) (uint32, uint32) {
 // insertions N, Number of bits per slot B, and expected value of a false
 // positive < maxFP.
 func NewFilter(N uint32, B uint32, maxFP float64) (*Filter, error) {
+	if N == 0 {
+		return nil, fmt.Errorf("number of insertions (N) must be > 0")
+	}
 	// TODO(spencer): we probably would be well-served using a 3-bit
 	// filter, so we should relax the following constraint and get a
 	// little bit fancier with the bit arithmetic to handle cross-byte

--- a/gossip/filter_test.go
+++ b/gossip/filter_test.go
@@ -53,6 +53,9 @@ func TestOptimalValues(t *testing.T) {
 
 // TestNewFilter verifies bad inputs, optimal values, size of slots data.
 func TestNewFilter(t *testing.T) {
+	if _, err := NewFilter(0, 3, 0.10); err == nil {
+		t.Error("NewFilter should not accept N == 0")
+	}
 	if _, err := NewFilter(1, 3, 0.10); err == nil {
 		t.Error("NewFilter should not accept bits B which are non-divisor of 8")
 	}

--- a/gossip/group.go
+++ b/gossip/group.go
@@ -25,8 +25,10 @@ import (
 type GroupType int
 
 const (
-	minGroup GroupType = iota
-	maxGroup
+	// MinGroup maintains minimum values for keys matching group prefix.
+	MinGroup GroupType = iota
+	// MaxGroup maintains maximum values for keys matching group prefix.
+	MaxGroup
 )
 
 // Group organizes a collection of Info objects sharing a common key
@@ -34,7 +36,7 @@ const (
 // Groups maintain a limited-size set of Info objects with set
 // inclusion determined by group type. Two types are implemented here:
 //
-// minGroup, maxGroup: maintain only minimum/maximum values added
+// MinGroup, MaxGroup: maintain only minimum/maximum values added
 // to group respectively.
 type Group struct {
 	Prefix      string    // Key prefix for Info items in group
@@ -55,9 +57,9 @@ func (g *Group) shouldInclude(info *Info) bool {
 		return true
 	}
 	switch g.TypeOf {
-	case minGroup:
+	case MinGroup:
 		return info.Val.Less(g.Gatekeeper.Val)
-	case maxGroup:
+	case MaxGroup:
 		return !info.Val.Less(g.Gatekeeper.Val)
 	default:
 		panic(fmt.Errorf("unknown group type %d", g.TypeOf))

--- a/gossip/group.go
+++ b/gossip/group.go
@@ -199,21 +199,3 @@ func (g *Group) AddInfo(info *Info) bool {
 
 	return false
 }
-
-// Delta returns a delta of the group since the specified sequence number.
-// Returns an error if the delta is empty.
-func (g *Group) Delta(seq int64) (*Group, error) {
-	delta, err := NewGroup(g.Prefix, g.Limit, g.TypeOf)
-	if err != nil {
-		return nil, err
-	}
-	for _, info := range g.Infos {
-		if info.Seq > seq {
-			delta.addInternal(info)
-		}
-	}
-	if len(delta.Infos) == 0 {
-		return nil, fmt.Errorf("no deltas to group since sequence number %d", seq)
-	}
-	return delta, nil
-}

--- a/gossip/group_test.go
+++ b/gossip/group_test.go
@@ -39,18 +39,18 @@ func newGroup(prefix string, limit int, typeOf GroupType, t *testing.T) *Group {
 
 // TestNewGroup verifies NewGroup behavior.
 func TestNewGroup(t *testing.T) {
-	if _, err := NewGroup("a", 0, minGroup); err == nil {
+	if _, err := NewGroup("a", 0, MinGroup); err == nil {
 		t.Error("new group with limit=0 should be illegal")
 	}
-	if _, err := NewGroup("a", -1, minGroup); err == nil {
+	if _, err := NewGroup("a", -1, MinGroup); err == nil {
 		t.Error("new group with limit=-1 should be illegal")
 	}
 }
 
-// TestMinGroupShouldInclude tests minGroup type groups
+// TestMinGroupShouldInclude tests MinGroup type groups
 // and group.shouldInclude() behavior.
 func TestMinGroupShouldInclude(t *testing.T) {
-	group := newGroup("a", 2, minGroup, t)
+	group := newGroup("a", 2, MinGroup, t)
 
 	// First two inserts work fine.
 	info1 := newInfo("a.a", 1)
@@ -75,10 +75,10 @@ func TestMinGroupShouldInclude(t *testing.T) {
 	}
 }
 
-// TestMaxGroupShouldInclude tests maxGroup type groups and
+// TestMaxGroupShouldInclude tests MaxGroup type groups and
 // group.shouldInclude() behavior.
 func TestMaxGroupShouldInclude(t *testing.T) {
-	group := newGroup("a", 2, maxGroup, t)
+	group := newGroup("a", 2, MaxGroup, t)
 
 	// First two inserts work fine.
 	info1 := newInfo("a.a", 1)
@@ -106,7 +106,7 @@ func TestMaxGroupShouldInclude(t *testing.T) {
 // TestSameKeyInserts inserts the same key into group and verifies
 // earlier timestamps are ignored and later timestamps always replace it.
 func TestSameKeyInserts(t *testing.T) {
-	group := newGroup("a", 1, minGroup, t)
+	group := newGroup("a", 1, MinGroup, t)
 	info1 := newInfo("a.a", 1)
 	if !group.AddInfo(info1) {
 		t.Error("could not insert")
@@ -135,7 +135,7 @@ func TestSameKeyInserts(t *testing.T) {
 // TestGroupCompactAfterTTL verifies group compaction after TTL by
 // waiting and verifying a full group can be inserted into again.
 func TestGroupCompactAfterTTL(t *testing.T) {
-	group := newGroup("a", 2, minGroup, t)
+	group := newGroup("a", 2, MinGroup, t)
 
 	// First two inserts work fine.
 	info1 := newInfo("a.a", 1)
@@ -181,24 +181,24 @@ func insertRandomInfos(group *Group, count int) InfoArray {
 	return infos
 }
 
-// TestGroups100Keys verifies behavior of minGroup and maxGroup with a
+// TestGroups100Keys verifies behavior of MinGroup and MaxGroup with a
 // limit of 100 keys after inserting 1000.
 func TestGroups100Keys(t *testing.T) {
 	// Start by adding random infos to min group.
-	minGroup := newGroup("a", 100, minGroup, t)
-	infos := insertRandomInfos(minGroup, 1000)
+	MinGroup := newGroup("a", 100, MinGroup, t)
+	infos := insertRandomInfos(MinGroup, 1000)
 
 	// Insert same infos into the max group.
-	maxGroup := newGroup("a", 100, maxGroup, t)
+	MaxGroup := newGroup("a", 100, MaxGroup, t)
 	for _, info := range infos {
-		maxGroup.AddInfo(info)
+		MaxGroup.AddInfo(info)
 	}
 	sort.Sort(infos)
 
-	minInfos := minGroup.InfosAsArray()
+	minInfos := MinGroup.InfosAsArray()
 	sort.Sort(minInfos)
 
-	maxInfos := maxGroup.InfosAsArray()
+	maxInfos := MaxGroup.InfosAsArray()
 	sort.Sort(maxInfos)
 
 	for i := 0; i < 100; i++ {
@@ -217,7 +217,7 @@ func TestGroups100Keys(t *testing.T) {
 // information. We don't want each new update with overlap to generate
 // unnecessary delta info.
 func TestSameKeySameTimestamp(t *testing.T) {
-	group := newGroup("a", 2, minGroup, t)
+	group := newGroup("a", 2, MinGroup, t)
 	info1 := newInfo("a.a", 1.0)
 	info2 := newInfo("a.a", 1.0)
 	info2.Timestamp = info1.Timestamp
@@ -238,7 +238,7 @@ func TestSameKeyDifferentHops(t *testing.T) {
 	info2.Hops = 2
 
 	// Add info1 first, then info2.
-	group1 := newGroup("a", 1, minGroup, t)
+	group1 := newGroup("a", 1, MinGroup, t)
 	if !group1.AddInfo(info1) || !group1.AddInfo(info2) {
 		t.Error("failed insertions", info1, info2)
 	}
@@ -247,7 +247,7 @@ func TestSameKeyDifferentHops(t *testing.T) {
 	}
 
 	// Add info1 first, then info2.
-	group2 := newGroup("a", 1, minGroup, t)
+	group2 := newGroup("a", 1, MinGroup, t)
 	if !group2.AddInfo(info1) || !group2.AddInfo(info2) {
 		t.Error("failed insertions")
 	}
@@ -258,7 +258,7 @@ func TestSameKeyDifferentHops(t *testing.T) {
 
 // TestGroupGetInfo verifies info selection by key.
 func TestGroupGetInfo(t *testing.T) {
-	group := newGroup("a", 10, minGroup, t)
+	group := newGroup("a", 10, MinGroup, t)
 	infos := insertRandomInfos(group, 10)
 	for _, info := range infos {
 		if info != group.GetInfo(info.Key) {
@@ -274,7 +274,7 @@ func TestGroupGetInfo(t *testing.T) {
 
 // TestGroupGetInfoTTL verifies GetInfo with a short TTL.
 func TestGroupGetInfoTTL(t *testing.T) {
-	group := newGroup("a", 10, minGroup, t)
+	group := newGroup("a", 10, MinGroup, t)
 	info := newInfo("a.a", 1)
 	info.TTLStamp = info.Timestamp + int64(time.Nanosecond)
 	group.AddInfo(info)

--- a/gossip/group_test.go
+++ b/gossip/group_test.go
@@ -297,38 +297,3 @@ func TestGroupGetInfoTTL(t *testing.T) {
 		t.Error("only one info should be returned", infos)
 	}
 }
-
-// TestGroupDelta checks delta groups based on info sequence numbers.
-func TestGroupDelta(t *testing.T) {
-	group := newGroup("a", 10, minGroup, t)
-
-	// Insert keys with sequence numbers 1..10.
-	for i := 0; i < 10; i++ {
-		info := newInfo(fmt.Sprintf("a.%d", i), float64(i))
-		info.Seq = int64(i + 1)
-		group.AddInfo(info)
-	}
-
-	// Verify deltas with successive sequence numbers.
-	for i := 0; i < 10; i++ {
-		delta, err := group.Delta(int64(i))
-		if err != nil {
-			t.Error("delta failed at sequence number", i)
-		}
-		infos := delta.InfosAsArray()
-		if len(infos) != 10-i {
-			t.Errorf("expected %d infos, not %d", 10-i, len(infos))
-		}
-		sort.Sort(infos)
-		for j := 0; j < 10-i; j++ {
-			expKey := fmt.Sprintf("a.%d", j+i)
-			if infos[j].Key != expKey {
-				t.Errorf("run %d: key mismatch at index %d: %s != %s", i, j, infos[j].Key, expKey)
-			}
-		}
-	}
-
-	if _, err := group.Delta(int64(10)); err == nil {
-		t.Error("fetching delta of group at maximum sequence number should return error")
-	}
-}

--- a/gossip/infostore.go
+++ b/gossip/infostore.go
@@ -121,15 +121,15 @@ func (is *InfoStore) GetInfo(key string) *Info {
 
 // GetGroupInfos returns an array of info objects from specified group,
 // sorted by value; sort order is dependent on group type
-// (minGroup: ascending, maxGroup: descending).
+// (MinGroup: ascending, MaxGroup: descending).
 // Returns nil if group is not registered.
 func (is *InfoStore) GetGroupInfos(prefix string) InfoArray {
 	if group, ok := is.Groups[prefix]; ok {
 		infos := group.InfosAsArray()
 		switch group.TypeOf {
-		case minGroup:
+		case MinGroup:
 			sort.Sort(infos)
-		case maxGroup:
+		case MaxGroup:
 			sort.Sort(sort.Reverse(infos))
 		}
 		return infos

--- a/gossip/infostore_test.go
+++ b/gossip/infostore_test.go
@@ -28,11 +28,11 @@ import (
 func TestRegisterGroup(t *testing.T) {
 	is := NewInfoStore()
 
-	groupA := newGroup("a", 1, minGroup, t)
+	groupA := newGroup("a", 1, MinGroup, t)
 	if is.RegisterGroup(groupA) != nil {
 		t.Error("could not register group A")
 	}
-	groupB := newGroup("b", 1, minGroup, t)
+	groupB := newGroup("b", 1, MinGroup, t)
 	if is.RegisterGroup(groupB) != nil {
 		t.Error("could not register group B")
 	}
@@ -169,7 +169,7 @@ func TestAddInfoSameKeyDifferentHops(t *testing.T) {
 func TestAddGroupInfos(t *testing.T) {
 	is := NewInfoStore()
 
-	group := newGroup("a", 10, minGroup, t)
+	group := newGroup("a", 10, MinGroup, t)
 	if is.RegisterGroup(group) != nil {
 		t.Error("could not register group")
 	}
@@ -195,8 +195,8 @@ func TestAddGroupInfos(t *testing.T) {
 	}
 
 	// Try with a max group.
-	maxGroup := newGroup("b", 10, maxGroup, t)
-	if is.RegisterGroup(maxGroup) != nil {
+	MaxGroup := newGroup("b", 10, MaxGroup, t)
+	if is.RegisterGroup(MaxGroup) != nil {
 		t.Error("could not register group")
 	}
 	info3 := is.NewInfo("b.a", Float64Value(1), time.Second)
@@ -244,8 +244,8 @@ func TestAddGroupInfos(t *testing.T) {
 func TestCombine(t *testing.T) {
 	is1 := NewInfoStore()
 
-	group1 := newGroup("a", 10, minGroup, t)
-	group1Overlap := newGroup("b", 10, minGroup, t)
+	group1 := newGroup("a", 10, MinGroup, t)
+	group1Overlap := newGroup("b", 10, MinGroup, t)
 	if is1.RegisterGroup(group1) != nil || is1.RegisterGroup(group1Overlap) != nil {
 		t.Error("could not register group1 or group1Overlap")
 	}
@@ -263,8 +263,8 @@ func TestCombine(t *testing.T) {
 
 	is2 := NewInfoStore()
 
-	group2 := newGroup("c", 10, minGroup, t)
-	group2Overlap := newGroup("b", 10, minGroup, t)
+	group2 := newGroup("c", 10, MinGroup, t)
+	group2Overlap := newGroup("b", 10, MinGroup, t)
 	if is2.RegisterGroup(group2) != nil || is2.RegisterGroup(group2Overlap) != nil {
 		t.Error("could not register group2 or group2Overlap")
 	}
@@ -312,8 +312,8 @@ func TestCombine(t *testing.T) {
 func createTestInfoStore(t *testing.T) *InfoStore {
 	is := NewInfoStore()
 
-	groupA := newGroup("a", 10, minGroup, t)
-	groupB := newGroup("b", 10, minGroup, t)
+	groupA := newGroup("a", 10, MinGroup, t)
+	groupB := newGroup("b", 10, MinGroup, t)
 	if is.RegisterGroup(groupA) != nil || is.RegisterGroup(groupB) != nil {
 		t.Error("unable to register groups")
 	}
@@ -339,7 +339,7 @@ func createTestInfoStore(t *testing.T) *InfoStore {
 func createTestInfoStoreWithHops(t *testing.T) *InfoStore {
 	is := NewInfoStore()
 
-	group := newGroup("a", 10, MIN_GROUP, t)
+	group := newGroup("a", 10, MinGroup, t)
 	if is.RegisterGroup(group) != nil {
 		t.Fatal("unable to register group:", group)
 	}


### PR DESCRIPTION
Diffs determine approximate difference in number of keys known by the builder of the
Filter but unknown to the InfoStore. It's an heuristic for how good of
a gossip peer the builder of the Filter would be. A greater diff is
better.

Introduced a visitor pattern "visitInfos" for InfoStore to remove
boilerplate iteration code that had cropped up in 4 or 5 places.

Added unittests for diffing.
