### PR TITLE
Add field names to composite literals

### DIFF
--- a/gossip/filter.go
+++ b/gossip/filter.go
@@ -74,7 +74,14 @@ func NewFilter(N uint32, B uint32, maxFP float64) (*Filter, error) {
 	maxCount := uint32((1 << B) - 1)
 	numBytes := (M*B + 7) / 8
 	bytes := make([]byte, numBytes, numBytes)
-	return &Filter{K, 0, 0, B, M, maxCount, bytes, NewHasher()}, nil
+	return &Filter{
+		K:        K,
+		B:        B,
+		M:        M,
+		MaxCount: maxCount,
+		Data:     bytes,
+		hasher:   NewHasher(),
+	}, nil
 }
 
 // incrementSlot increments slot value by the specified amount, bounding at

--- a/gossip/group.go
+++ b/gossip/group.go
@@ -130,7 +130,13 @@ func NewGroup(prefix string, limit int, typeOf GroupType) (*Group, error) {
 	if limit <= 0 {
 		return nil, fmt.Errorf("group size limit must be a positive number (%d <= 0)", limit)
 	}
-	return &Group{prefix, limit, typeOf, math.MaxInt64, nil, make(InfoMap)}, nil
+	return &Group{
+		Prefix:      prefix,
+		Limit:       limit,
+		TypeOf:      typeOf,
+		MinTTLStamp: math.MaxInt64,
+		Infos:       make(InfoMap),
+	}, nil
 }
 
 // GetInfo returns an info by key.

--- a/gossip/group_test.go
+++ b/gossip/group_test.go
@@ -26,7 +26,12 @@ import (
 func newInfo(key string, val float64) *Info {
 	now := MonotonicUnixNano()
 	ttl := now + int64(time.Minute)
-	return &Info{key, Float64Value(val), now, ttl, 0, "", 0}
+	return &Info{
+		Key:       key,
+		Val:       Float64Value(val),
+		Timestamp: now,
+		TTLStamp:  ttl,
+	}
 }
 
 func newGroup(prefix string, limit int, typeOf GroupType, t *testing.T) *Group {

--- a/gossip/hasher.go
+++ b/gossip/hasher.go
@@ -39,7 +39,7 @@ type Hasher struct {
 
 // NewHasher allocates and return a new Hasher.
 func NewHasher() *Hasher {
-	return &Hasher{murmur3.New64(), false, 0, 0}
+	return &Hasher{mmh3: murmur3.New64()}
 }
 
 // HashKey writes the given key string to the hasher.

--- a/gossip/infostore.go
+++ b/gossip/infostore.go
@@ -79,7 +79,10 @@ func MonotonicUnixNano() int64 {
 
 // NewInfoStore allocates and returns a new InfoStore.
 func NewInfoStore() *InfoStore {
-	return &InfoStore{make(InfoMap), make(GroupMap), 0, 0}
+	return &InfoStore{
+		Infos:  InfoMap{},
+		Groups: GroupMap{},
+	}
 }
 
 // InfoCount returns the count of infos stored in groups and the
@@ -99,7 +102,14 @@ func (is *InfoStore) NewInfo(key string, val Value, ttl time.Duration) *Info {
 	is.SeqGen++
 	now := MonotonicUnixNano()
 	node := "localhost" // TODO(spencer): fix this
-	return &Info{key, val, now, now + int64(ttl), is.SeqGen, node, 0}
+	return &Info{
+		Key:       key,
+		Val:       val,
+		Timestamp: now,
+		TTLStamp:  now + int64(ttl),
+		Seq:       is.SeqGen,
+		Node:      node,
+	}
 }
 
 // GetInfo returns an Info object by key or nil if it doesn't exist.


### PR DESCRIPTION
While more verbose, composite literals with explicit field names are a good idea because:
- Bugs (sometimes very subtle) can arise simply by changing the order of fields in a struct type declaration.
- You don’t have to specify the values for every field, and so those that are equivalent to the zero value of the field type can be omitted.
- Readability is a bit better because you don’t have to refer to the type decl to see which value corresponds to what.
