### PR TITLE
add myself to AUTHORS

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -3,6 +3,6 @@
 
 # Initial version authors:
 Spencer Kimball <spencer.kimball@gmail.com>
+Andrew Bonventre <andybons@gmail.com>
 
 # Partial list of contributors:
-Andrew Bonventre <andybons@gmail.com>

--- a/AUTHORS
+++ b/AUTHORS
@@ -5,3 +5,4 @@
 Spencer Kimball <spencer.kimball@gmail.com>
 
 # Partial list of contributors:
+Andrew Bonventre <andybons@gmail.com>


### PR DESCRIPTION
Wasn’t sure what the difference was between original authors and partial contributors. Since I wasn’t a part of the initial design doc discussion, putting myself in the partial list.
