### PR TITLE
Minor fixes in the way of init & start

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -29,3 +29,4 @@ _testmain.go
 .vagrant
 
 cockroach
+*.swp

--- a/server/init.go
+++ b/server/init.go
@@ -18,6 +18,8 @@
 package server
 
 import (
+	"flag"
+
 	commander "code.google.com/p/go-commander"
 	"code.google.com/p/go-uuid/uuid"
 	"github.com/cockroachdb/cockroach/storage"
@@ -46,7 +48,9 @@ to the correct level upon start.
 
 To start the cluster after initialization, run "cockroach start".
 `,
-	Run: runInit}
+	Run:  runInit,
+	Flag: *flag.CommandLine,
+}
 
 // runInit.
 func runInit(cmd *commander.Command, args []string) {

--- a/server/init.go
+++ b/server/init.go
@@ -57,11 +57,11 @@ func runInit(cmd *commander.Command, args []string) {
 	// Specifying the disk type as HDD may be incorrect, but doesn't
 	// matter for this bootstrap step.
 	engine, err := initEngine(args[0])
-	if engine.Type() == storage.MEM {
-		glog.Fatal("Cannot initialize a cockroach cluster using an in-memory storage device")
-	}
 	if err != nil {
 		glog.Fatal(err)
+	}
+	if engine.Type() == storage.MEM {
+		glog.Fatal("Cannot initialize a cockroach cluster using an in-memory storage device")
 	}
 	// Generate a new cluster UUID.
 	clusterID := uuid.New()

--- a/server/server.go
+++ b/server/server.go
@@ -82,7 +82,8 @@ A node exports an HTTP API with the following endpoints:
   Key-value REST:         http://%s%s
   Structured Schema REST: http://%s%s
 `, *httpAddr, *httpAddr, kv.KVKeyPrefix, *httpAddr, structured.StructuredKeyPrefix),
-	Run: runStart,
+	Run:  runStart,
+	Flag: *flag.CommandLine,
 }
 
 type server struct {

--- a/server/server.go
+++ b/server/server.go
@@ -107,7 +107,14 @@ func runStart(cmd *commander.Command, args []string) {
 	if err != nil {
 		glog.Fatal(err)
 	}
-	err = s.start(nil /* init engines from -data_dirs */)
+	// init engines from -data_dirs
+	engines, err := initEngines()
+	if err != nil {
+		glog.Fatal(err)
+	}
+
+	err = s.start(engines)
+
 	s.stop()
 	if err != nil {
 		glog.Fatal(err)

--- a/server/server.go
+++ b/server/server.go
@@ -134,7 +134,7 @@ func initEngines() ([]storage.Engine, error) {
 func initEngine(spec string) (storage.Engine, error) {
 	// Error if regexp doesn't match.
 	matches := dataDirRE.FindStringSubmatch(spec)
-	if matches == nil || len(matches) != 3 {
+	if matches == nil || len(matches) != 5 {
 		return nil, util.Errorf("invalid engine specification %q", spec)
 	}
 
@@ -147,21 +147,21 @@ func initEngine(spec string) (storage.Engine, error) {
 		}
 		engine = storage.NewInMem(size)
 	} else {
+		// type, file = matches[3], matches[4]
 		var typ storage.DiskType
-		switch matches[2] {
+		switch matches[3] {
 		case "hdd":
 			typ = storage.HDD
 		case "ssd":
 			typ = storage.SSD
 		default:
-			return nil, util.Errorf("unhandled disk type %q", matches[1])
+			return nil, util.Errorf("unhandled disk type %q", matches[3])
 		}
-		engine, err = storage.NewRocksDB(typ, matches[2])
+		engine, err = storage.NewRocksDB(typ, matches[4])
 		if err != nil {
-			return nil, util.Errorf("unable to init rocksdb with data dir %q", matches[2])
+			return nil, util.Errorf("unable to init rocksdb with data dir %q", matches[4])
 		}
 	}
-
 	return engine, nil
 }
 

--- a/server/zone_cli.go
+++ b/server/zone_cli.go
@@ -20,6 +20,7 @@ package server
 import (
 	"bytes"
 	"encoding/json"
+	"flag"
 	"fmt"
 	"io/ioutil"
 	"net/http"
@@ -61,7 +62,9 @@ Fetches and displays the zone configuration for <key-prefix>. The key
 prefix should be escaped via URL query escaping if it contains
 non-ascii bytes or spaces.
 `,
-	Run: runGetZones}
+	Run:  runGetZones,
+	Flag: *flag.CommandLine,
+}
 
 // runGetZones invokes the REST API with GET action and key prefix as path.
 func runGetZones(cmd *commander.Command, args []string) {
@@ -93,7 +96,9 @@ the listing are filtered by key prefixes matching the regexp. The key
 prefix should be escaped via URL query escaping if it contains
 non-ascii bytes or spaces.
 `,
-	Run: runLsZones}
+	Run:  runLsZones,
+	Flag: *flag.CommandLine,
+}
 
 // runLsZones invokes the REST API with GET action and no path, which
 // fetches a list of all zone configuration prefixes. The optional
@@ -150,7 +155,9 @@ command can affect only a single zone config with an exactly matching
 prefix. The key prefix should be escaped via URL query escaping if it
 contains non-ascii bytes or spaces.
 `,
-	Run: runRmZone}
+	Run:  runRmZone,
+	Flag: *flag.CommandLine,
+}
 
 // runRmZone invokes the REST API with DELETE action and key prefix as
 // path.
@@ -204,7 +211,9 @@ Setting zone configs will guarantee that key ranges will be split
 such that no key range straddles two zone config specifications.
 This feature can be taken advantage of to pre-split ranges.
 `,
-	Run: runSetZone}
+	Run:  runSetZone,
+	Flag: *flag.CommandLine,
+}
 
 // runSetZone invokes the REST API with POST action and key prefix as
 // path. The specified configuration file is read from disk and sent

--- a/storage/rocksdb.go
+++ b/storage/rocksdb.go
@@ -30,6 +30,7 @@ import (
 	"flag"
 	"syscall"
 	"unsafe"
+
 	"github.com/golang/glog"
 )
 
@@ -210,7 +211,7 @@ func (r *RocksDB) scan(start, end Key, max int64) ([]KeyValue, error) {
 	defer C.rocksdb_iter_destroy(it)
 
 	keyVals := []KeyValue{}
-	C.rocksdb_iter_seek(it, (*C.char)(unsafe.Pointer(&start[0])), C.size_t(len(start)))
+	C.rocksdb_iter_seek(it, (*C.char)(unsafe.Pointer(&start)), C.size_t(len(start)))
 	for i := int64(1); C.rocksdb_iter_valid(it) == 1; C.rocksdb_iter_next(it) {
 		if max > 0 && i > max {
 			break


### PR DESCRIPTION
Played around with it trying to boot it up, and fixed what I think were some fairly self-explanatory bugs on the way. With these changes,  I can init a cluster (apparently successfully so), upon booting it complains about a missing default prefix in storage/prefix.go.
