### PR TITLE
Clear instead of del; clearRange

### DIFF
--- a/storage/in_mem_test.go
+++ b/storage/in_mem_test.go
@@ -56,7 +56,7 @@ func TestInMemCapacity(t *testing.T) {
 	}
 
 	// Remove key.
-	err = engine.del(Key(bytes))
+	err = engine.clear(Key(bytes))
 	if err != nil {
 		t.Errorf("delete: expected no error, but got %s", err)
 	}

--- a/storage/messages.go
+++ b/storage/messages.go
@@ -166,13 +166,15 @@ type DeleteResponse struct {
 // specifies the range of keys to delete.
 type DeleteRangeRequest struct {
 	RequestHeader
+	// If 0, *all* entries between Key (inclusive) and EndKey (exclusive) are deleted.
+	MaxEntriesToDelete int64 // Must be >= 0
 }
 
 // A DeleteRangeResponse is the return value from the DeleteRange()
 // method.
 type DeleteRangeResponse struct {
 	ResponseHeader
-	NumDeleted uint64
+	NumDeleted int64 // Number of entries removed
 }
 
 // A ScanRequest is arguments to the Scan() method. It specifies the

--- a/storage/range.go
+++ b/storage/range.go
@@ -427,7 +427,8 @@ func (r *Range) Increment(args *IncrementRequest, reply *IncrementResponse) {
 
 // Delete deletes the key and value specified by key.
 func (r *Range) Delete(args *DeleteRequest, reply *DeleteResponse) {
-	if err := r.engine.del(args.Key); err != nil {
+	// TODO(manik) replace this with abstraction to go through MVCC layer rather than talk to the engine directly
+	if err := r.engine.clear(args.Key); err != nil {
 		reply.Error = err
 	}
 }

--- a/storage/rocksdb.go
+++ b/storage/rocksdb.go
@@ -256,8 +256,8 @@ func (r *RocksDB) get(key Key) (Value, error) {
 	return Value{Bytes: C.GoBytes(unsafe.Pointer(cVal), C.int(cValLen))}, nil
 }
 
-// del removes the item from the db with the given key.
-func (r *RocksDB) del(key Key) error {
+// clear removes the item from the db with the given key.
+func (r *RocksDB) clear(key Key) error {
 	if len(key) == 0 {
 		return emptyKeyError()
 	}


### PR DESCRIPTION
Summary:
Rename del() to clear() in engine.go
Add clearRange() to engine.go
Test in engine_test.go

Test Plan: go test

Reviewers: spencerkimball, lancevac

Subscribers: team

Differential Revision: http://phabricator.cockroachdb.org/D104
