### PR TITLE
add weighted reservoir sampling (AE-S)

### DIFF
--- a/util/sampling.go
+++ b/util/sampling.go
@@ -1,0 +1,133 @@
+// Copyright 2014 The Cockroach Authors.float64
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+// implied. See the License for the specific language governing
+// permissions and limitations under the License. See the AUTHORS file
+// for names of contributors.
+//
+// Author: Tobias Schottdorf (tobias.schottdorf@gmail.com)
+
+package util
+
+import (
+	"container/heap"
+	"math"
+	"math/rand"
+
+	"github.com/golang/glog"
+)
+
+// A WeightedValue is used to represent the items sampled by
+// WeightedReservoirSample.
+type WeightedValue struct {
+	Value interface{}
+	key   float64
+}
+
+// Less implements the Ordered interface.
+func (wv WeightedValue) Less(zv WeightedValue) bool {
+	return wv.key < zv.key
+}
+
+// A WeightedValueHeap implements a heap structure on a slice of weighted
+// values for use in in-memory weighted reservoir sampling.
+type WeightedValueHeap []WeightedValue
+
+// Len, Less and Swap implement sort.Interface.
+func (h WeightedValueHeap) Len() int           { return len(h) }
+func (h WeightedValueHeap) Less(i, j int) bool { return h[i].Less(h[j]) }
+func (h WeightedValueHeap) Swap(i, j int)      { h[i], h[j] = h[j], h[i] }
+
+// Push appends an element to the slice.
+func (h *WeightedValueHeap) Push(x interface{}) { *h = append(*h, x.(WeightedValue)) }
+
+// Pop removes the last element of the slice.
+func (h *WeightedValueHeap) Pop() interface{} {
+	old := *h
+	n := len(old)
+	x := old[n-1]
+	*h = old[0 : n-1]
+	return x
+}
+
+// A WeightedReservoirSample implements the weighted reservoir sampling
+// algorithm as proposed by Efraimidis-Spirakis (2005).
+type WeightedReservoirSample struct {
+	size      int
+	Heap      heap.Interface
+	threshold float64 // keeps track of the minimal key.
+}
+
+// NewWeightedReservoirSample creates a new reservoir sample on the given
+// heap. If minHeap is nil, an in-memory heap is created and used.
+func NewWeightedReservoirSample(size int, minHeap heap.Interface) *WeightedReservoirSample {
+	if size < 1 {
+		panic("attempt to create a reservoir sample with invalid size")
+	}
+	if minHeap == nil {
+		h := make(WeightedValueHeap, 0, size)
+		minHeap = &h
+	}
+	rs := &WeightedReservoirSample{
+		size:      size,
+		Heap:      minHeap,
+		threshold: 0,
+	}
+	return rs
+}
+
+// Consider offers a new value to the underlying reservoir using weight one.
+// Using the same weight for all values considered throughout the lifetime of
+// a sample is equivalent to a non-weighted reservoir sampling algorithm.
+func (rs *WeightedReservoirSample) Consider(value interface{}) {
+	rs.ConsiderWeighted(value, 1)
+}
+
+// ConsiderWeighted lets the sample inspect a new value with a positive given
+// weight. A weight of one corresponds to the unweighted reservoir sampling
+// algorithm. A nonpositive weight will lead to the item being rejected without
+// having been observed. To avoid numerical instabilities, it is advisable to
+// stay away from zero and infinity, or more generally from regions in which
+// computing x**1/weight may be ill-behaved.
+func (rs *WeightedReservoirSample) ConsiderWeighted(value interface{}, weight float64) {
+	if weight <= 0 {
+		glog.Warningf("reservoir sample received non-positive weight %f", weight)
+		return
+	}
+	h := rs.Heap
+	wv := WeightedValue{
+		Value: value,
+		key:   rs.makeKey(weight),
+	}
+	if h.Len() < rs.size {
+		heap.Push(h, wv)
+		if rs.threshold == 0 || wv.key < rs.threshold {
+			rs.threshold = wv.key
+		}
+		return
+	}
+
+	if wv.key > rs.threshold {
+		// Remove the element with threshold key.
+		heap.Pop(h)
+		// Add in the new element (which has a higher key).
+		heap.Push(h, wv)
+		// Update the threshold to reflect the new threshold.
+		twv := heap.Pop(h).(WeightedValue)
+		rs.threshold = twv.key
+		heap.Push(h, twv)
+	}
+}
+
+// makeKey is used internally by ConsiderWeighted for probabilistic sampling.
+func (rs *WeightedReservoirSample) makeKey(weight float64) float64 {
+	return math.Pow(rand.Float64(), 1.0/weight)
+}

--- a/util/sampling_test.go
+++ b/util/sampling_test.go
@@ -1,0 +1,111 @@
+// Copyright 2014 The Cockroach Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+// implied. See the License for the specific language governing
+// permissions and limitations under the License. See the AUTHORS file
+// for names of contributors.
+//
+// Author: Tobias Schottdorf (tobias.schottdorf@gmail.com)
+
+package util
+
+import (
+	"math"
+	"testing"
+)
+
+func average(sl WeightedValueHeap) float64 {
+	if len(sl) == 0 {
+		panic("average of empty slice requested")
+	}
+	res := float64(0)
+	for _, v := range sl {
+		res += v.Value.(float64)
+	}
+	return res / float64(len(sl))
+}
+
+// TestWeightedReservoirSample repeatedly constructs size one reservoir samples
+// from a very small set of weighted data and checks that the distribution of
+// sampled values behaves as expected.
+func TestWeightedReservoirSample(t *testing.T) {
+	// First test whether the sample correctly ignores invalid weights.
+	rs := NewWeightedReservoirSample(1, nil)
+	h := rs.Heap.(*WeightedValueHeap)
+	rs.ConsiderWeighted(2000.0, 0.0)
+	rs.ConsiderWeighted(1234.5, -3.141259)
+	if len(*h) != 0 {
+		t.Fatalf("values with invalid weights were not ignored")
+	}
+
+	weightedValues := []struct {
+		v string
+		w float64
+	}{
+		{"a", 0.1},
+		{"b", 0.4},
+		{"c", 0.8},
+		{"d", 5.0},
+		{"e", 7.0},
+	}
+
+	totalWeight := float64(0)
+	for _, wv := range weightedValues {
+		totalWeight += wv.w
+	}
+	expected := make(map[string]float64)
+	counts := make(map[string]int)
+	for _, wv := range weightedValues {
+		expected[wv.v] = wv.w / totalWeight
+		counts[wv.v] = 0
+	}
+	numTrials := 100000
+	for i := 0; i < numTrials; i++ {
+		rs := NewWeightedReservoirSample(1, nil)
+		h := rs.Heap.(*WeightedValueHeap)
+		for _, wv := range weightedValues {
+			rs.ConsiderWeighted(wv.v, wv.w)
+		}
+		outcome := (*h)[0].Value.(string)
+		counts[outcome]++
+	}
+
+	for _, wv := range weightedValues {
+		actual := float64(counts[wv.v]) / float64(numTrials)
+		diff := math.Abs(expected[wv.v] - actual)
+		if math.IsNaN(diff) || diff > 0.005 {
+			t.Errorf("value %s: got %f, want %f (%f off)", wv.v, actual, expected[wv.v], diff)
+		}
+	}
+}
+
+// TestUniformReservoirSample compares the expected average of a uniformly weighted large sample.
+func TestUniformReservoirSample(t *testing.T) {
+	for r := 0; r < 20; r++ {
+		reservoirSize := 500
+		rs := NewWeightedReservoirSample(reservoirSize, nil)
+		h := rs.Heap.(*WeightedValueHeap)
+		offerCount := 10000
+		for i := 0; i < offerCount; i++ {
+			rs.Consider(2.0)
+		}
+		for i := 0; i < offerCount; i++ {
+			rs.Consider(1.0)
+		}
+		// This is mostly a sanity check, making sure that the average is no
+		// more than roughly one standard deviation off the actual result.
+		maxOff := 3. / math.Sqrt(float64(reservoirSize))
+		mean := 1.5
+		if avg := average(*h); math.IsNaN(avg) || math.Abs(avg-mean) > maxOff {
+			t.Errorf("suspicious average: |%f-%f| > %f", avg, mean, maxOff)
+		}
+	}
+}


### PR DESCRIPTION
Implemented algorithm A-Res from http://utopia.duth.gr/~pefraimi/research/data/2007EncOfAlg.pdf, offering a reservoir sampling algorithm with the chance of each element being in the final sample being proportional to the (positive) weight assigned to each element.
If need arises we will fairly easily be able to implement A-ExpJ using this (but I don't think we'll ever need it) to save some random numbers.
The careful reviewer will observe that really I would have wanted a priority queue instead of an abstract heap (to get "peek") but in this version the exposition is clearer and the performance hit isn't more than a slightly worse constant depending on the reservoir size.
A-Res will be used to generate the split key when it is needed, taking the size of key-value pairs as their weight. Other metrics are possible, allowing for a range of interesting split key criteria.
