### PR TITLE
add store access interface to ranges

### DIFF
--- a/storage/range.go
+++ b/storage/range.go
@@ -153,11 +153,12 @@ type Cmd struct {
 type Range struct {
 	Meta      *proto.RangeMetadata
 	mvcc      *engine.MVCC
-	engine    engine.Engine  // The underlying key-value store
-	allocator *allocator     // Makes allocation decisions
-	gossip    *gossip.Gossip // Range may gossip based on contents
-	raft      chan *Cmd      // Raft commands
-	closer    chan struct{}  // Channel for closing the range
+	engine    engine.Engine   // The underlying key-value store
+	allocator *allocator      // Makes allocation decisions
+	gossip    *gossip.Gossip  // Range may gossip based on contents
+	rba       RebalanceAccess // Makes some store methods available
+	raft      chan *Cmd       // Raft commands
+	closer    chan struct{}   // Channel for closing the range
 
 	sync.RWMutex                     // Protects readQ, tsCache & respCache.
 	readQ        *ReadQueue          // Reads queued behind pending writes
@@ -165,7 +166,10 @@ type Range struct {
 	respCache    *ResponseCache      // Provides idempotence for retries
 }
 
-// NewRange initializes the range starting at key.
+// NewRange initializes the range using the given metadata. The range will have
+// no knowledge of a possible store that contains it and thus all rebalancing
+// operations will fail. Use NewRangeFromStore() instead to create ranges
+// contained within a store.
 func NewRange(meta *proto.RangeMetadata, clock *hlc.Clock, eng engine.Engine,
 	allocator *allocator, gossip *gossip.Gossip) *Range {
 	r := &Range{
@@ -175,12 +179,22 @@ func NewRange(meta *proto.RangeMetadata, clock *hlc.Clock, eng engine.Engine,
 		allocator: allocator,
 		gossip:    gossip,
 		raft:      make(chan *Cmd, 10), // TODO(spencer): remove
+		rba:       &StubRebalanceAccess{},
 		closer:    make(chan struct{}),
 		readQ:     NewReadQueue(),
 		tsCache:   NewReadTimestampCache(clock),
 		respCache: NewResponseCache(meta.RangeID, eng),
 	}
 	return r
+}
+
+// NewRangeFromStore initializes a range from the given metadata and the clock,
+// engine, allocator, and gossip from the given store and enables the range to
+// access rebalancing operations from the store.
+func NewRangeFromStore(meta *proto.RangeMetadata, s *Store) *Range {
+	rng := NewRange(meta, s.clock, s.engine, s.allocator, s.gossip)
+	rng.rba = s
+	return rng
 }
 
 // Start begins gossiping and starts the raft command processing

--- a/storage/store.go
+++ b/storage/store.go
@@ -244,7 +244,7 @@ func (s *Store) CreateRange(startKey, endKey engine.Key, replicas []proto.Replic
 	if err != nil {
 		return nil, err
 	}
-	rng := NewRange(meta, s.clock, s.engine, s.allocator, s.gossip)
+	rng := NewRangeFromStore(meta, s)
 	rng.Start()
 	s.mu.Lock()
 	defer s.mu.Unlock()
@@ -319,4 +319,27 @@ func (s *Store) ExecuteCmd(method string, args proto.Request, reply proto.Respon
 	}
 
 	return rng.ReadWriteCmd(method, args, reply)
+}
+
+// RebalanceAccess is an interface satisfied by Store through which ranges
+// contained in the store can access the methods required for rebalancing
+// (i.e. splitting and merging) operations.
+// TODO(Tobias): add necessary operations as we need them.
+type RebalanceAccess interface {
+	GetRange(rangeID int64) (*Range, error)
+	CreateRange(startKey, endKey engine.Key, replicas []proto.Replica) (*Range, error)
+}
+
+// StubRebalanceAccess is a trivial implementation of RebalanceAccess that
+// returns an error for every operation.
+type StubRebalanceAccess struct{}
+
+// GetRange .
+func (d *StubRebalanceAccess) GetRange(rangeID int64) (*Range, error) {
+	return nil, util.Errorf("unimplemented")
+}
+
+// CreateRange .
+func (d *StubRebalanceAccess) CreateRange(startKey, endKey engine.Key, replicas []proto.Replica) (*Range, error) {
+	return nil, util.Errorf("unimplemented")
 }


### PR DESCRIPTION
For rebalancing operations, stores need to keep track of changes (creation, etc) in the underlying ranges.
Since rebalancing needs to be synchronized through raft, it makes sense to have the bulk of the business logic in the range itself.
That necessitates an interface into the owning store. This is my attempt of providing one that keeps ranges relatively autonomous, makes it easier to initialize a range from a store and also allows the calls into the store to be mocked out completely, which makes for fun testing possibilities.
