### PR TITLE
Rename InternalRangeScan to InternalSnapshotCopy.

### DIFF
--- a/kv/db.go
+++ b/kv/db.go
@@ -211,11 +211,11 @@ func (db *DB) InternalResolveIntent(args *proto.InternalResolveIntentRequest) <-
 	return replyChan
 }
 
-// InternalRangeScan scans the key range specified by start key through
+// InternalSnapshotCopy scans the key range specified by start key through
 // end key up to some maximum number of results from the given snapshot_id.
 // It will create a snapshot if snapshot_id is empty.
-func (db *DB) InternalRangeScan(args *proto.InternalRangeScanRequest) <-chan *proto.InternalRangeScanResponse {
-	replyChan := make(chan *proto.InternalRangeScanResponse, 1)
-	go db.executeCmd(storage.InternalRangeScan, args, replyChan)
+func (db *DB) InternalSnapshotCopy(args *proto.InternalSnapshotCopyRequest) <-chan *proto.InternalSnapshotCopyResponse {
+	replyChan := make(chan *proto.InternalSnapshotCopyResponse, 1)
+	go db.executeCmd(storage.InternalSnapshotCopy, args, replyChan)
 	return replyChan
 }

--- a/proto/api.proto
+++ b/proto/api.proto
@@ -334,11 +334,11 @@ message InternalResolveIntentResponse {
   optional ResponseHeader header = 1 [(gogoproto.nullable) = false, (gogoproto.embed) = true];
 }
 
-// An InternalRangeScanRequest is arguments to the InternalRangeScan()
+// An InternalSnapshotCopyRequest is arguments to the InternalSnapshotCopy()
 // method. It specifies the start and end keys for the scan and the
 // maximum number of results from the given snapshot_id. It will create
 // a snapshot if snapshot_id is empty.
-message InternalRangeScanRequest {
+message InternalSnapshotCopyRequest {
   optional RequestHeader header = 1 [(gogoproto.nullable) = false, (gogoproto.embed) = true];
   // Optional, a new snapshot will be created if it is empty.
   optional string snapshot_id = 2 [(gogoproto.nullable) = false];
@@ -346,9 +346,9 @@ message InternalRangeScanRequest {
   optional int64 max_results = 3 [(gogoproto.nullable) = false];
 }
 
-// An InternalRangeScanResponse is the return value from the
-// InternalRangeScan() method.
-message InternalRangeScanResponse {
+// An InternalSnapshotCopyResponse is the return value from the
+// InternalSnapshotCopy() method.
+message InternalSnapshotCopyResponse {
   optional ResponseHeader header = 1 [(gogoproto.nullable) = false, (gogoproto.embed) = true];
   optional string snapshot_id = 2 [(gogoproto.nullable) = false];
   // Empty if no rows were scanned.

--- a/server/node.go
+++ b/server/node.go
@@ -498,7 +498,7 @@ func (n *Node) InternalResolveIntent(args *proto.InternalResolveIntentRequest, r
 	return n.executeCmd(storage.InternalResolveIntent, args, reply)
 }
 
-// InternalRangeScan .
-func (n *Node) InternalRangeScan(args *proto.InternalRangeScanRequest, reply *proto.InternalRangeScanResponse) error {
-	return n.executeCmd(storage.InternalRangeScan, args, reply)
+// InternalSnapshotCopy .
+func (n *Node) InternalSnapshotCopy(args *proto.InternalSnapshotCopyRequest, reply *proto.InternalSnapshotCopyResponse) error {
+	return n.executeCmd(storage.InternalSnapshotCopy, args, reply)
 }

--- a/storage/db.go
+++ b/storage/db.go
@@ -47,7 +47,7 @@ type DB interface {
 	EnqueueMessage(args *proto.EnqueueMessageRequest) <-chan *proto.EnqueueMessageResponse
 	InternalHeartbeatTxn(args *proto.InternalHeartbeatTxnRequest) <-chan *proto.InternalHeartbeatTxnResponse
 	InternalResolveIntent(args *proto.InternalResolveIntentRequest) <-chan *proto.InternalResolveIntentResponse
-	InternalRangeScan(args *proto.InternalRangeScanRequest) <-chan *proto.InternalRangeScanResponse
+	InternalSnapshotCopy(args *proto.InternalSnapshotCopyRequest) <-chan *proto.InternalSnapshotCopyResponse
 }
 
 // GetI fetches the value at the specified key and gob-deserializes it

--- a/storage/range.go
+++ b/storage/range.go
@@ -86,19 +86,19 @@ const (
 	InternalRangeLookup   = "InternalRangeLookup"
 	InternalHeartbeatTxn  = "InternalHeartbeatTxn"
 	InternalResolveIntent = "InternalResolveIntent"
-	InternalRangeScan     = "InternalRangeScan"
+	InternalSnapshotCopy  = "InternalSnapshotCopy"
 )
 
 // readMethods specifies the set of methods which read and return data.
 var readMethods = map[string]struct{}{
-	Contains:            struct{}{},
-	Get:                 struct{}{},
-	ConditionalPut:      struct{}{},
-	Increment:           struct{}{},
-	Scan:                struct{}{},
-	ReapQueue:           struct{}{},
-	InternalRangeLookup: struct{}{},
-	InternalRangeScan:   struct{}{},
+	Contains:             struct{}{},
+	Get:                  struct{}{},
+	ConditionalPut:       struct{}{},
+	Increment:            struct{}{},
+	Scan:                 struct{}{},
+	ReapQueue:            struct{}{},
+	InternalRangeLookup:  struct{}{},
+	InternalSnapshotCopy: struct{}{},
 }
 
 // writeMethods specifies the set of methods which write data.
@@ -500,8 +500,8 @@ func (r *Range) executeCmd(method string, args proto.Request, reply proto.Respon
 		r.InternalHeartbeatTxn(args.(*proto.InternalHeartbeatTxnRequest), reply.(*proto.InternalHeartbeatTxnResponse))
 	case InternalResolveIntent:
 		r.InternalResolveIntent(args.(*proto.InternalResolveIntentRequest), reply.(*proto.InternalResolveIntentResponse))
-	case InternalRangeScan:
-		r.InternalRangeScan(args.(*proto.InternalRangeScanRequest), reply.(*proto.InternalRangeScanResponse))
+	case InternalSnapshotCopy:
+		r.InternalSnapshotCopy(args.(*proto.InternalSnapshotCopyRequest), reply.(*proto.InternalSnapshotCopyResponse))
 	default:
 		return util.Errorf("unrecognized command type: %s", method)
 	}
@@ -745,10 +745,10 @@ func (r *Range) InternalResolveIntent(args *proto.InternalResolveIntentRequest, 
 	reply.SetGoError(r.mvcc.ResolveWriteIntent(args.Key, args.TxnID, args.Commit))
 }
 
-// InternalRangeScan scans the key range specified by start key through
+// InternalSnapshotCopy scans the key range specified by start key through
 // end key up to some maximum number of results from the given snapshot_id.
 // It will create a snapshot if snapshot_id is empty.
-func (r *Range) InternalRangeScan(args *proto.InternalRangeScanRequest, reply *proto.InternalRangeScanResponse) {
+func (r *Range) InternalSnapshotCopy(args *proto.InternalSnapshotCopyRequest, reply *proto.InternalSnapshotCopyResponse) {
 	if len(args.SnapshotId) == 0 {
 		candidateID, err := engine.Increment(r.engine, engine.KeyLocalSnapshotIDGenerator, 1)
 		if err != nil {

--- a/storage/range_test.go
+++ b/storage/range_test.go
@@ -298,11 +298,11 @@ func incrementArgs(key string, inc int64, rangeID int64) (*proto.IncrementReques
 	return args, reply
 }
 
-// internalRangeScanArgs returns a InternalRangeScanRequest and
-// InternalRangeScanResponse pair addressed to the default replica
+// internalRangeScanArgs returns a InternalSnapshotCopyRequest and
+// InternalSnapshotCopyResponse pair addressed to the default replica
 // for the specified key and endKey.
-func internalRangeScanArgs(key []byte, endKey []byte, maxResults int64, snapshotID string, rangeID int64) (*proto.InternalRangeScanRequest, *proto.InternalRangeScanResponse) {
-	args := &proto.InternalRangeScanRequest{
+func internalRangeScanArgs(key []byte, endKey []byte, maxResults int64, snapshotID string, rangeID int64) (*proto.InternalSnapshotCopyRequest, *proto.InternalSnapshotCopyResponse) {
+	args := &proto.InternalSnapshotCopyRequest{
 		RequestHeader: proto.RequestHeader{
 			Key:     key,
 			EndKey:  endKey,
@@ -311,7 +311,7 @@ func internalRangeScanArgs(key []byte, endKey []byte, maxResults int64, snapshot
 		SnapshotId: snapshotID,
 		MaxResults: maxResults,
 	}
-	reply := &proto.InternalRangeScanResponse{}
+	reply := &proto.InternalSnapshotCopyResponse{}
 	return args, reply
 }
 
@@ -513,7 +513,7 @@ func TestRangeSnapshot(t *testing.T) {
 
 	irsArgs, irsReply := internalRangeScanArgs(engine.PrefixEndKey(engine.KeyLocalPrefix), engine.KeyMax, 50, "", 0)
 	irsArgs.Timestamp = clock.Now()
-	err = rng.ReadOnlyCmd("InternalRangeScan", irsArgs, irsReply)
+	err = rng.ReadOnlyCmd("InternalSnapshotCopy", irsArgs, irsReply)
 	if err != nil {
 		t.Fatalf("error : %s", err)
 	}
@@ -535,7 +535,7 @@ func TestRangeSnapshot(t *testing.T) {
 	// Scan with the previous snapshot will get the old value val2 of key2.
 	irsArgs, irsReply = internalRangeScanArgs(engine.PrefixEndKey(engine.KeyLocalPrefix), engine.KeyMax, 50, snapshotID, 0)
 	irsArgs.Timestamp = clock.Now()
-	err = rng.ReadOnlyCmd("InternalRangeScan", irsArgs, irsReply)
+	err = rng.ReadOnlyCmd("InternalSnapshotCopy", irsArgs, irsReply)
 	if err != nil {
 		t.Fatalf("error : %s", err)
 	}
@@ -552,7 +552,7 @@ func TestRangeSnapshot(t *testing.T) {
 	// Create a new snapshot to cover the latest value.
 	irsArgs, irsReply = internalRangeScanArgs(engine.PrefixEndKey(engine.KeyLocalPrefix), engine.KeyMax, 50, "", 0)
 	irsArgs.Timestamp = clock.Now()
-	err = rng.ReadOnlyCmd("InternalRangeScan", irsArgs, irsReply)
+	err = rng.ReadOnlyCmd("InternalSnapshotCopy", irsArgs, irsReply)
 	if err != nil {
 		t.Fatalf("error : %s", err)
 	}
@@ -570,7 +570,7 @@ func TestRangeSnapshot(t *testing.T) {
 
 	irsArgs, irsReply = internalRangeScanArgs(engine.PrefixEndKey(snapshotLastKey), engine.KeyMax, 50, snapshotID, 0)
 	irsArgs.Timestamp = clock.Now()
-	err = rng.ReadOnlyCmd("InternalRangeScan", irsArgs, irsReply)
+	err = rng.ReadOnlyCmd("InternalSnapshotCopy", irsArgs, irsReply)
 	if err != nil {
 		t.Fatalf("error : %s", err)
 	}
@@ -579,7 +579,7 @@ func TestRangeSnapshot(t *testing.T) {
 	}
 	irsArgs, irsReply = internalRangeScanArgs(engine.PrefixEndKey(snapshot2LastKey), engine.KeyMax, 50, snapshotID2, 0)
 	irsArgs.Timestamp = clock.Now()
-	err = rng.ReadOnlyCmd("InternalRangeScan", irsArgs, irsReply)
+	err = rng.ReadOnlyCmd("InternalSnapshotCopy", irsArgs, irsReply)
 	if err != nil {
 		t.Fatalf("error : %s", err)
 	}


### PR DESCRIPTION
This eliminates some confusion between scanning as with MVCC and doing a raw scan of engine
contents. The "snapshot copy" gives a much better idea of the proper use
and limits of this RPC.
