### PR TITLE
Store value protobuf directly for MVCC values

### DIFF
--- a/kv/db.go
+++ b/kv/db.go
@@ -84,6 +84,8 @@ func (db *DB) Get(args *proto.GetRequest) <-chan *proto.GetResponse {
 // Put sets the value for a key at the specified timestamp. If the
 // timestamp is 0, the value is set with the current time as timestamp.
 func (db *DB) Put(args *proto.PutRequest) <-chan *proto.PutResponse {
+	// Init the value checksum if not set by requesting client.
+	args.Value.InitChecksum(args.Key)
 	replyChan := make(chan *proto.PutResponse, 1)
 	go db.executeCmd(storage.Put, args, replyChan)
 	return replyChan
@@ -93,6 +95,8 @@ func (db *DB) Put(args *proto.PutRequest) <-chan *proto.PutResponse {
 // matches the value specified in the request. Specifying a null value
 // for existing means the value must not yet exist.
 func (db *DB) ConditionalPut(args *proto.ConditionalPutRequest) <-chan *proto.ConditionalPutResponse {
+	// Init the value checksum if not set by requesting client.
+	args.Value.InitChecksum(args.Key)
 	replyChan := make(chan *proto.ConditionalPutResponse, 1)
 	go db.executeCmd(storage.ConditionalPut, args, replyChan)
 	return replyChan

--- a/kv/local_kv.go
+++ b/kv/local_kv.go
@@ -127,6 +127,9 @@ func (kv *LocalKV) ExecuteCmd(method string, args proto.Request, replyChan inter
 		reply.Header().SetGoError(err)
 	} else {
 		store.ExecuteCmd(method, args, reply)
+		if err := reply.Verify(args); err != nil {
+			reply.Header().SetGoError(err)
+		}
 	}
 	reflect.ValueOf(replyChan).Send(reflect.ValueOf(reply))
 }

--- a/kv/rest/rest.go
+++ b/kv/rest/rest.go
@@ -164,14 +164,12 @@ func (s *Server) handleEntryPutAction(w http.ResponseWriter, r *http.Request, ke
 		return
 	}
 	defer r.Body.Close()
-	value := proto.Value{Bytes: b}
-	value.InitChecksum(key)
 	pr := <-s.db.Put(&proto.PutRequest{
 		RequestHeader: proto.RequestHeader{
 			Key:  key,
 			User: storage.UserRoot,
 		},
-		Value: value,
+		Value: proto.Value{Bytes: b},
 	})
 	if pr.Error != nil {
 		http.Error(w, pr.GoError().Error(), http.StatusInternalServerError)
@@ -194,10 +192,6 @@ func (s *Server) handleEntryGetAction(w http.ResponseWriter, r *http.Request, ke
 	// An empty key will not be nil, but have zero length.
 	if gr.Value == nil {
 		http.Error(w, http.StatusText(http.StatusNotFound), http.StatusNotFound)
-		return
-	}
-	if err := gr.Value.VerifyChecksum(key); err != nil {
-		http.Error(w, err.Error(), http.StatusInternalServerError)
 		return
 	}
 	w.Header().Set("Content-Type", "application/octet-stream")

--- a/proto/api.proto
+++ b/proto/api.proto
@@ -103,10 +103,12 @@ message GetRequest {
 // If the key doesn't exist, returns nil for Value.Bytes.
 message GetResponse {
   optional ResponseHeader header = 1 [(gogoproto.nullable) = false, (gogoproto.embed) = true];
-  optional Value value = 2 [(gogoproto.nullable) = false];
+  optional Value value = 2;
 }
 
-// A PutRequest is arguments to the Put() method.
+// A PutRequest is arguments to the Put() method. Note that to write
+// an empty value, the value parameter is still specified, but both
+// Bytes and Integer are set to nil.
 message PutRequest {
   optional RequestHeader header = 1 [(gogoproto.nullable) = false, (gogoproto.embed) = true];
   optional Value value = 2 [(gogoproto.nullable) = false];
@@ -126,8 +128,10 @@ message ConditionalPutRequest {
   optional RequestHeader header = 1 [(gogoproto.nullable) = false, (gogoproto.embed) = true];
   // The value to put.
   optional Value value = 2 [(gogoproto.nullable) = false];
-  // ExpValue.Bytes empty to test for non-existence.
-  optional Value exp_value = 3 [(gogoproto.nullable) = false];
+  // ExpValue.Bytes empty to test for non-existence. Specify as nil
+  // to indicate there should be no existing entry. This is different
+  // from the expectation that the value exists but is empty.
+  optional Value exp_value = 3;
 }
 
 // A ConditionalPutResponse is the return value from the

--- a/proto/api.proto
+++ b/proto/api.proto
@@ -119,11 +119,12 @@ message PutResponse {
   optional ResponseHeader header = 1 [(gogoproto.nullable) = false, (gogoproto.embed) = true];
 }
 
-// A ConditionalPutRequest is arguments to the ConditionalPut()
-// method.
+// A ConditionalPutRequest is arguments to the ConditionalPut() method.
+//
 // - Returns true and sets value if ExpValue equals existing value.
-// - If key doesn't exist and ExpValue is empty, sets value.
-// - Otherwise, returns error.
+// - If key doesn't exist and ExpValue is nil, sets value.
+// - If key exists, but value is empty and ExpValue is not nil but empty, sets value.
+// - Otherwise, returns error and the actual value of the key in the response.
 message ConditionalPutRequest {
   optional RequestHeader header = 1 [(gogoproto.nullable) = false, (gogoproto.embed) = true];
   // The value to put.

--- a/proto/data.go
+++ b/proto/data.go
@@ -17,7 +17,13 @@
 
 package proto
 
-import "math"
+import (
+	"math"
+
+	gogoproto "code.google.com/p/gogoprotobuf/proto"
+	"github.com/cockroachdb/cockroach/util"
+	"github.com/cockroachdb/cockroach/util/encoding"
+)
 
 // Timestamp constant values.
 var (
@@ -36,4 +42,38 @@ func (t Timestamp) Less(s Timestamp) bool {
 // Equal returns whether two timestamps are the same.
 func (t Timestamp) Equal(s Timestamp) bool {
 	return t.WallTime == s.WallTime && t.Logical == s.Logical
+}
+
+// InitChecksum initializes a checksum based on the provided key and
+// the contents of the value. If the value contains a byte slice, the
+// checksum includes it directly; if the value contains an integer,
+// the checksum includes the integer as 8 bytes in big-endian order.
+func (v *Value) InitChecksum(key []byte) {
+	v.Checksum = gogoproto.Uint32(v.computeChecksum(key))
+}
+
+// VerifyChecksum verifies the value's Checksum matches a newly-computed
+// checksum of the value's contents. If the value's Checksum is not set
+// the verification is a noop.
+func (v *Value) VerifyChecksum(key []byte) error {
+	if v.Checksum != nil {
+		if v.GetChecksum() != v.computeChecksum(key) {
+			return util.Errorf("invalid checksum for key %q, value %+v", key, v)
+		}
+	}
+	return nil
+}
+
+// computeChecksum computes a checksum based on the provided key and
+// the contents of the value. If the value contains a byte slice, the
+// checksum includes it directly; if the value contains an integer,
+// the checksum includes the integer as 8 bytes in big-endian order.
+func (v *Value) computeChecksum(key []byte) uint32 {
+	c := encoding.NewCRC32Checksum(key)
+	if v.Bytes != nil {
+		c.Write(v.Bytes)
+	} else if v.Integer != nil {
+		c.Write(encoding.EncodeUint64(nil, uint64(v.GetInteger())))
+	}
+	return c.Sum32()
 }

--- a/proto/data.proto
+++ b/proto/data.proto
@@ -50,9 +50,19 @@ message Value {
   // writes to do end-to-end integrity verification. If the checksum is
   // incorrect, the write operation will fail. If the client does not
   // wish to use end-to-end checksumming, this value should be nil.
-  optional uint32 checksum = 3;
+  optional fixed32 checksum = 3;
   // Timestamp of value.
-  optional Timestamp timestamp = 4 [(gogoproto.nullable) = false];
+  optional Timestamp timestamp = 4;
+}
+
+// MVCCValue differentiates between normal versioned values and
+// deletion tombstones.
+message MVCCValue {
+  // True to indicate a deletion tombstone. If false, value should not
+  // be nil.
+  optional bool deleted = 1 [(gogoproto.nullable) = false];
+  // The value. Nil if deleted is true; not nil otherwise.
+  optional Value value = 2;
 }
 
 // KeyValue is a pair of Key and Value for returned Key/Value pairs

--- a/proto/data.proto
+++ b/proto/data.proto
@@ -33,18 +33,26 @@ message Timestamp {
 }
 
 // Value specifies the value at a key. Multiple values at the same key
-// are supported based on timestamp.
+// are supported based on timestamp. Values support the union of two
+// basic types: a "bag o' bytes" generic byte slice and an incrementable
+// int64, for use with the Increment API call.
 message Value {
-  // Bytes is the byte string value.
-  optional bytes bytes = 1 [(gogoproto.nullable) = false];
-  // Checksum is a CRC-32-IEEE checksum. A Value will only be used in
-  // a write operation by the database if either its checksum is zero
-  // or the CRC checksum of Bytes matches it.
-  // Values returned by the database will contain a checksum of the
-  // contained value.
-  optional uint32 checksum = 2 [(gogoproto.nullable) = false];
+  // Bytes is the byte slice value. If this value is present,
+  // "integer" should not be.
+  optional bytes bytes = 1;
+  // Integer is an integer value type. If this value is present,
+  // "bytes" should not be. Only Integer values may exist at a key
+  // when making the Increment API call.
+  optional int64 integer = 2;
+  // Checksum is a CRC-32-IEEE checksum of the key + value, in that order.
+  // If this is an integer value, then the value is interpreted as an 8
+  // byte, big-endian encoded value. This value is set by the client on
+  // writes to do end-to-end integrity verification. If the checksum is
+  // incorrect, the write operation will fail. If the client does not
+  // wish to use end-to-end checksumming, this value should be nil.
+  optional uint32 checksum = 3;
   // Timestamp of value.
-  optional Timestamp timestamp = 3 [(gogoproto.nullable) = false];
+  optional Timestamp timestamp = 4 [(gogoproto.nullable) = false];
 }
 
 // KeyValue is a pair of Key and Value for returned Key/Value pairs

--- a/proto/data_test.go
+++ b/proto/data_test.go
@@ -63,18 +63,26 @@ func TestEqual(t *testing.T) {
 	}
 }
 
+func TestValueBothBytesAndIntegerSet(t *testing.T) {
+	k := []byte("key")
+	v := Value{Bytes: []byte("a"), Integer: gogoproto.Int64(0)}
+	if err := v.Verify(k); err == nil {
+		t.Error("expected error with both byte slice and integer fields set")
+	}
+}
+
 func TestValueChecksumEmpty(t *testing.T) {
 	k := []byte("key")
 	v := Value{}
 	// Before initializing checksum, always works.
-	if err := v.VerifyChecksum(k); err != nil {
+	if err := v.Verify(k); err != nil {
 		t.Error(err)
 	}
-	if err := v.VerifyChecksum([]byte("key2")); err != nil {
+	if err := v.Verify([]byte("key2")); err != nil {
 		t.Error(err)
 	}
 	v.InitChecksum(k)
-	if err := v.VerifyChecksum(k); err != nil {
+	if err := v.Verify(k); err != nil {
 		t.Error(err)
 	}
 }
@@ -83,16 +91,16 @@ func TestValueChecksumWithBytes(t *testing.T) {
 	k := []byte("key")
 	v := Value{Bytes: []byte("abc")}
 	v.InitChecksum(k)
-	if err := v.VerifyChecksum(k); err != nil {
+	if err := v.Verify(k); err != nil {
 		t.Error(err)
 	}
 	// Try a different key; should fail.
-	if err := v.VerifyChecksum([]byte("key2")); err == nil {
+	if err := v.Verify([]byte("key2")); err == nil {
 		t.Error("expected checksum verification failure on different key")
 	}
 	// Mess with value.
 	v.Bytes = []byte("abcd")
-	if err := v.VerifyChecksum(k); err == nil {
+	if err := v.Verify(k); err == nil {
 		t.Error("expected checksum verification failure on different value")
 	}
 }
@@ -103,16 +111,16 @@ func TestValueChecksumWithInteger(t *testing.T) {
 	for _, i := range testValues {
 		v := Value{Integer: gogoproto.Int64(i)}
 		v.InitChecksum(k)
-		if err := v.VerifyChecksum(k); err != nil {
+		if err := v.Verify(k); err != nil {
 			t.Error(err)
 		}
 		// Try a different key; should fail.
-		if err := v.VerifyChecksum([]byte("key2")); err == nil {
+		if err := v.Verify([]byte("key2")); err == nil {
 			t.Error("expected checksum verification failure on different key")
 		}
 		// Mess with value.
 		v.Integer = gogoproto.Int64(i + 1)
-		if err := v.VerifyChecksum(k); err == nil {
+		if err := v.Verify(k); err == nil {
 			t.Error("expected checksum verification failure on different value")
 		}
 	}

--- a/proto/data_test.go
+++ b/proto/data_test.go
@@ -18,7 +18,10 @@
 package proto
 
 import (
+	"math"
 	"testing"
+
+	gogoproto "code.google.com/p/gogoprotobuf/proto"
 )
 
 func makeTS(walltime int64, logical int32) Timestamp {
@@ -57,5 +60,60 @@ func TestEqual(t *testing.T) {
 	a = makeTS(1, 1)
 	if b.Equal(a) {
 		t.Errorf("expected %+v < %+v", b, a)
+	}
+}
+
+func TestValueChecksumEmpty(t *testing.T) {
+	k := []byte("key")
+	v := Value{}
+	// Before initializing checksum, always works.
+	if err := v.VerifyChecksum(k); err != nil {
+		t.Error(err)
+	}
+	if err := v.VerifyChecksum([]byte("key2")); err != nil {
+		t.Error(err)
+	}
+	v.InitChecksum(k)
+	if err := v.VerifyChecksum(k); err != nil {
+		t.Error(err)
+	}
+}
+
+func TestValueChecksumWithBytes(t *testing.T) {
+	k := []byte("key")
+	v := Value{Bytes: []byte("abc")}
+	v.InitChecksum(k)
+	if err := v.VerifyChecksum(k); err != nil {
+		t.Error(err)
+	}
+	// Try a different key; should fail.
+	if err := v.VerifyChecksum([]byte("key2")); err == nil {
+		t.Error("expected checksum verification failure on different key")
+	}
+	// Mess with value.
+	v.Bytes = []byte("abcd")
+	if err := v.VerifyChecksum(k); err == nil {
+		t.Error("expected checksum verification failure on different value")
+	}
+}
+
+func TestValueChecksumWithInteger(t *testing.T) {
+	k := []byte("key")
+	testValues := []int64{0, 1, -1, math.MinInt64, math.MaxInt64}
+	for _, i := range testValues {
+		v := Value{Integer: gogoproto.Int64(i)}
+		v.InitChecksum(k)
+		if err := v.VerifyChecksum(k); err != nil {
+			t.Error(err)
+		}
+		// Try a different key; should fail.
+		if err := v.VerifyChecksum([]byte("key2")); err == nil {
+			t.Error("expected checksum verification failure on different key")
+		}
+		// Mess with value.
+		v.Integer = gogoproto.Int64(i + 1)
+		if err := v.VerifyChecksum(k); err == nil {
+			t.Error("expected checksum verification failure on different value")
+		}
 	}
 }

--- a/storage/db.go
+++ b/storage/db.go
@@ -24,6 +24,7 @@ import (
 	gogoproto "code.google.com/p/gogoprotobuf/proto"
 	"github.com/cockroachdb/cockroach/proto"
 	"github.com/cockroachdb/cockroach/storage/engine"
+	"github.com/cockroachdb/cockroach/util"
 )
 
 // A DB interface provides asynchronous methods to access a key value
@@ -57,9 +58,12 @@ type DB interface {
 // found for the requested key; false otherwise. An error is returned
 // on error fetching from underlying storage or deserializing value.
 func GetI(db DB, key engine.Key, iface interface{}) (bool, proto.Timestamp, error) {
-	ok, value, err := getInternal(db, key)
-	if !ok || err != nil {
+	value, err := getInternal(db, key)
+	if err != nil || value == nil {
 		return false, proto.Timestamp{}, err
+	}
+	if value.Integer != nil {
+		return false, proto.Timestamp{}, util.Errorf("unexpected integer value at key %q: %+v", key, value)
 	}
 	if err := gob.NewDecoder(bytes.NewBuffer(value.Bytes)).Decode(iface); err != nil {
 		return true, value.Timestamp, err
@@ -71,9 +75,12 @@ func GetI(db DB, key engine.Key, iface interface{}) (bool, proto.Timestamp, erro
 // using a protobuf decoder. See comments for GetI for details on
 // return values.
 func GetProto(db DB, key engine.Key, msg gogoproto.Message) (bool, proto.Timestamp, error) {
-	ok, value, err := getInternal(db, key)
-	if !ok || err != nil {
+	value, err := getInternal(db, key)
+	if err != nil || value == nil {
 		return false, proto.Timestamp{}, err
+	}
+	if value.Integer != nil {
+		return false, proto.Timestamp{}, util.Errorf("unexpected integer value at key %q: %+v", key, value)
 	}
 	if err := gogoproto.Unmarshal(value.Bytes, msg); err != nil {
 		return true, value.Timestamp, err
@@ -82,7 +89,7 @@ func GetProto(db DB, key engine.Key, msg gogoproto.Message) (bool, proto.Timesta
 }
 
 // getInternal fetches the requested key and returns the value.
-func getInternal(db DB, key engine.Key) (bool, proto.Value, error) {
+func getInternal(db DB, key engine.Key) (*proto.Value, error) {
 	gr := <-db.Get(&proto.GetRequest{
 		RequestHeader: proto.RequestHeader{
 			Key:  key,
@@ -90,12 +97,12 @@ func getInternal(db DB, key engine.Key) (bool, proto.Value, error) {
 		},
 	})
 	if gr.Error != nil {
-		return false, proto.Value{}, gr.GoError()
+		return nil, gr.GoError()
 	}
-	if len(gr.Value.Bytes) == 0 {
-		return false, proto.Value{}, nil
+	if gr.Value != nil {
+		return gr.Value, gr.Value.VerifyChecksum(key)
 	}
-	return true, gr.Value, nil
+	return nil, nil
 }
 
 // PutI sets the given key to the gob-serialized byte string of value
@@ -105,7 +112,6 @@ func PutI(db DB, key engine.Key, iface interface{}, timestamp proto.Timestamp) e
 	if err := gob.NewEncoder(&buf).Encode(iface); err != nil {
 		return err
 	}
-	// TODO(spencer): set checksum.
 	return putInternal(db, key, proto.Value{Bytes: buf.Bytes(), Timestamp: timestamp})
 }
 
@@ -116,12 +122,12 @@ func PutProto(db DB, key engine.Key, msg gogoproto.Message, timestamp proto.Time
 	if err != nil {
 		return err
 	}
-	// TODO(spencer): set checksum.
 	return putInternal(db, key, proto.Value{Bytes: data, Timestamp: timestamp})
 }
 
 // putInternal writes the specified value to key.
 func putInternal(db DB, key engine.Key, value proto.Value) error {
+	value.InitChecksum(key)
 	pr := <-db.Put(&proto.PutRequest{
 		RequestHeader: proto.RequestHeader{
 			Key:       key,

--- a/storage/engine/gc_test.go
+++ b/storage/engine/gc_test.go
@@ -22,6 +22,7 @@ import (
 	"reflect"
 	"testing"
 
+	gogoproto "code.google.com/p/gogoprotobuf/proto"
 	"github.com/cockroachdb/cockroach/proto"
 	"github.com/cockroachdb/cockroach/util/encoding"
 )
@@ -46,6 +47,14 @@ var (
 	}
 	keys = append(aKeys, append(bKeys, cKeys...)...)
 )
+
+func serializedMVCCValue(deleted bool, t *testing.T) []byte {
+	data, err := gogoproto.Marshal(&proto.MVCCValue{Deleted: deleted})
+	if err != nil {
+		t.Fatalf("unexpected marshal error: %v", err)
+	}
+	return data
+}
 
 // TestGarbageCollectorMVCCPrefix verifies that MVCC variants of same
 // key are grouped together and non-MVCC keys are considered singly.
@@ -87,8 +96,8 @@ func TestGarbageCollectorFilter(t *testing.T) {
 		}
 	})
 	e := []byte{}
-	n := []byte{valueNormalPrefix}
-	d := []byte{valueDeletedPrefix}
+	n := serializedMVCCValue(false, t)
+	d := serializedMVCCValue(true, t)
 	testData := []struct {
 		time      proto.Timestamp
 		keys      []Key

--- a/storage/range.go
+++ b/storage/range.go
@@ -316,12 +316,6 @@ func (r *Range) ReadWriteCmd(method string, args proto.Request, reply proto.Resp
 		ts.Logical++ // increment logical component by one to differentiate.
 		header.Timestamp = ts
 		reply.Header().Timestamp = ts
-		switch args.(type) {
-		case *proto.PutRequest:
-			(args.(*proto.PutRequest)).Value.Timestamp = ts
-		case *proto.ConditionalPutRequest:
-			(args.(*proto.ConditionalPutRequest)).Value.Timestamp = ts
-		}
 	}
 
 	// The next step is to add the write to the read queue to inform

--- a/storage/range.go
+++ b/storage/range.go
@@ -529,7 +529,7 @@ func (r *Range) Contains(args *proto.ContainsRequest, reply *proto.ContainsRespo
 		reply.SetGoError(err)
 		return
 	}
-	if val.Bytes != nil {
+	if val != nil {
 		reply.Exists = true
 	}
 }
@@ -558,7 +558,7 @@ func (r *Range) ConditionalPut(args *proto.ConditionalPutRequest, reply *proto.C
 	if err == nil {
 		r.updateGossipConfigs(args.Key)
 	}
-	reply.ActualValue = &val
+	reply.ActualValue = val
 	reply.SetGoError(err)
 }
 

--- a/storage/store_test.go
+++ b/storage/store_test.go
@@ -146,7 +146,7 @@ func createTestStore(t *testing.T) (*Store, *hlc.ManualClock) {
 func TestStoreExecuteCmd(t *testing.T) {
 	store, _ := createTestStore(t)
 	defer store.Close()
-	args, reply := getArgs("a", 1)
+	args, reply := getArgs([]byte("a"), 1)
 
 	// Try a successful get request.
 	err := store.ExecuteCmd("Get", args, reply)
@@ -159,7 +159,7 @@ func TestStoreExecuteCmd(t *testing.T) {
 func TestStoreExecuteCmdUpdateTime(t *testing.T) {
 	store, _ := createTestStore(t)
 	defer store.Close()
-	args, reply := getArgs("a", 1)
+	args, reply := getArgs([]byte("a"), 1)
 	args.Timestamp = store.clock.Now()
 	args.Timestamp.WallTime += (100 * time.Millisecond).Nanoseconds()
 	err := store.ExecuteCmd("Get", args, reply)
@@ -177,7 +177,7 @@ func TestStoreExecuteCmdUpdateTime(t *testing.T) {
 func TestStoreExecuteCmdWithZeroTime(t *testing.T) {
 	store, mc := createTestStore(t)
 	defer store.Close()
-	args, reply := getArgs("a", 1)
+	args, reply := getArgs([]byte("a"), 1)
 
 	// Set clock to time 1.
 	*mc = hlc.ManualClock(1)
@@ -199,7 +199,7 @@ func TestStoreExecuteCmdWithZeroTime(t *testing.T) {
 func TestStoreExecuteCmdWithClockDrift(t *testing.T) {
 	store, mc := createTestStore(t)
 	defer store.Close()
-	args, reply := getArgs("a", 1)
+	args, reply := getArgs([]byte("a"), 1)
 
 	// Set clock to time 1.
 	*mc = hlc.ManualClock(1)
@@ -220,7 +220,7 @@ func TestStoreExecuteCmdBadRange(t *testing.T) {
 	store, _ := createTestStore(t)
 	defer store.Close()
 	// Range is from "a" to "z", so this value should fail.
-	args, reply := getArgs("0", 1)
+	args, reply := getArgs([]byte("0"), 1)
 	args.Replica.RangeID = 2
 	err := store.ExecuteCmd("Get", args, reply)
 	if err == nil {
@@ -234,7 +234,7 @@ func TestStoreExecuteCmdOutOfRange(t *testing.T) {
 	store, _ := createTestStore(t)
 	defer store.Close()
 	// Range is from "a" to "z", so this value should fail.
-	args, reply := getArgs("0", 1)
+	args, reply := getArgs([]byte("0"), 1)
 	err := store.ExecuteCmd("Get", args, reply)
 	if err == nil {
 		t.Error("expected key to be out of range")

--- a/util/encoding/encoding.go
+++ b/util/encoding/encoding.go
@@ -72,8 +72,8 @@ func MustGobEncode(o interface{}) []byte {
 	return oEncoded
 }
 
-// newChecksum returns a CRC32 checksum computed from the input byte slice.
-func newChecksum(b []byte) hash.Hash32 {
+// NewCRC32Checksum returns a CRC32 checksum computed from the input byte slice.
+func NewCRC32Checksum(b []byte) hash.Hash32 {
 	crc := crc32.NewIEEE()
 	crc.Write(b)
 	return crc
@@ -86,7 +86,7 @@ func newChecksum(b []byte) hash.Hash32 {
 // otherwise.
 func unwrapChecksum(k []byte, b []byte) ([]byte, error) {
 	// Compute the first part of the expected checksum.
-	c := newChecksum(k)
+	c := NewCRC32Checksum(k)
 	size := c.Size()
 	if size > len(b) {
 		return nil, util.Errorf("not enough bytes for %d character checksum", size)
@@ -107,7 +107,7 @@ func unwrapChecksum(k []byte, b []byte) ([]byte, error) {
 // wrapChecksum computes the checksum of the byte slice b appended to k.
 // The output is b with the checksum appended.
 func wrapChecksum(k []byte, b []byte) []byte {
-	chk := newChecksum(k)
+	chk := NewCRC32Checksum(k)
 	chk.Write(b)
 	return chk.Sum(b)
 }


### PR DESCRIPTION
Instead of storing byte strings manually and manually varint encoding
integer values for incrementable keys, we now marshal and unmarshal the
Value protobuf directly. This allows us to Get incrementable keys and
to scan them. It also allows us to correctly discern an error incrementing
a key which is not a varint encoded value.

Implemented value checksums and checksum verification, although only
doing the verification now through kv/rest. Probably want to do the
same elsewhere.
