### PR TITLE
rename RebalanceAccess

### DIFF
--- a/storage/range_test.go
+++ b/storage/range_test.go
@@ -93,7 +93,7 @@ func createTestRange(engine engine.Engine, t *testing.T) (*Range, *gossip.Gossip
 	}
 	g := gossip.New(rpc.LoadInsecureTLSConfig())
 	clock := hlc.NewClock(hlc.UnixNano)
-	r := NewRange(rm, clock, engine, nil, g)
+	r := NewRange(rm, clock, engine, nil, g, nil)
 	r.Start()
 	return r, g
 }
@@ -251,7 +251,7 @@ func createTestRangeWithClock(t *testing.T) (*Range, *hlc.ManualClock, *hlc.Cloc
 	manual := hlc.ManualClock(0)
 	clock := hlc.NewClock(manual.UnixNano)
 	engine := newBlockingEngine()
-	rng := NewRange(&proto.RangeMetadata{}, clock, engine, nil, nil)
+	rng := NewRange(&proto.RangeMetadata{}, clock, engine, nil, nil, nil)
 	rng.Start()
 	return rng, &manual, clock, engine
 }

--- a/storage/store.go
+++ b/storage/store.go
@@ -167,7 +167,7 @@ func (s *Store) Init() error {
 		return err
 	}
 
-	rng := NewRange(&meta, s.clock, s.engine, s.allocator, s.gossip)
+	rng := NewRange(&meta, s.clock, s.engine, s.allocator, s.gossip, s)
 	rng.Start()
 
 	s.mu.Lock()
@@ -244,7 +244,7 @@ func (s *Store) CreateRange(startKey, endKey engine.Key, replicas []proto.Replic
 	if err != nil {
 		return nil, err
 	}
-	rng := NewRangeFromStore(meta, s)
+	rng := NewRange(meta, s.clock, s.engine, s.allocator, s.gossip, s)
 	rng.Start()
 	s.mu.Lock()
 	defer s.mu.Unlock()
@@ -321,25 +321,10 @@ func (s *Store) ExecuteCmd(method string, args proto.Request, reply proto.Respon
 	return rng.ReadWriteCmd(method, args, reply)
 }
 
-// RebalanceAccess is an interface satisfied by Store through which ranges
+// RangeManager is an interface satisfied by Store through which ranges
 // contained in the store can access the methods required for rebalancing
 // (i.e. splitting and merging) operations.
 // TODO(Tobias): add necessary operations as we need them.
-type RebalanceAccess interface {
-	GetRange(rangeID int64) (*Range, error)
+type RangeManager interface {
 	CreateRange(startKey, endKey engine.Key, replicas []proto.Replica) (*Range, error)
-}
-
-// StubRebalanceAccess is a trivial implementation of RebalanceAccess that
-// returns an error for every operation.
-type StubRebalanceAccess struct{}
-
-// GetRange .
-func (d *StubRebalanceAccess) GetRange(rangeID int64) (*Range, error) {
-	return nil, util.Errorf("unimplemented")
-}
-
-// CreateRange .
-func (d *StubRebalanceAccess) CreateRange(startKey, endKey engine.Key, replicas []proto.Replica) (*Range, error) {
-	return nil, util.Errorf("unimplemented")
 }


### PR DESCRIPTION
For the discussion, see
https://github.com/cockroachdb/cockroach/pull/45

Gist:
- name it StoreManager?
- fix nomenclature for Rebalancing, Splitting and Merging, ...
