### PR TITLE
Use full txn struct instead of just txn ID

### DIFF
--- a/kv/coordinator_test.go
+++ b/kv/coordinator_test.go
@@ -53,8 +53,8 @@ func createTestDB(t *testing.T) (*DB, *hlc.Clock, *hlc.ManualClock) {
 func createPutRequest(key engine.Key, value, txnID []byte) *proto.PutRequest {
 	return &proto.PutRequest{
 		RequestHeader: proto.RequestHeader{
-			Key:   key,
-			TxnID: txnID,
+			Key: key,
+			Txn: &proto.Transaction{ID: txnID},
 		},
 		Value: proto.Value{Bytes: value},
 	}
@@ -149,14 +149,14 @@ func TestCoordinatorHeartbeat(t *testing.T) {
 }
 
 // getTxn fetches the requested key and returns the transaction info.
-func getTxn(db *DB, key engine.Key) (bool, proto.Transaction, error) {
+func getTxn(db *DB, key engine.Key) (bool, *proto.Transaction, error) {
 	hr := <-db.InternalHeartbeatTxn(&proto.InternalHeartbeatTxnRequest{
 		RequestHeader: proto.RequestHeader{
 			Key: key,
 		},
 	})
 	if hr.Error != nil {
-		return false, proto.Transaction{}, hr.GoError()
+		return false, nil, hr.GoError()
 	}
 	return true, hr.Txn, nil
 }

--- a/kv/db.go
+++ b/kv/db.go
@@ -150,10 +150,10 @@ func (db *DB) EndTransaction(args *proto.EndTransactionRequest) <-chan *proto.En
 		if reply.Error == nil {
 			switch reply.Status {
 			case proto.COMMITTED:
-				db.coordinator.EndTxn(args.Header().TxnID, true)
+				db.coordinator.EndTxn(args.Header().Txn.ID, true)
 				return
 			case proto.ABORTED:
-				db.coordinator.EndTxn(args.Header().TxnID, false)
+				db.coordinator.EndTxn(args.Header().Txn.ID, false)
 				return
 			}
 		}

--- a/proto/api.proto
+++ b/proto/api.proto
@@ -62,10 +62,7 @@ message RequestHeader {
   optional string user = 5 [(gogoproto.nullable) = false];
   // Replica specifies the destination for the request. See config.go.
   optional Replica replica = 6 [(gogoproto.nullable) = false];
-  // Txn is set non-nil if a transaction is underway. Use an empty
-  // Transaction to start a new transaction; otherwise, Txn should
-  // always be specified using the Txn returned with the previous
-  // response.
+  // Txn is set non-nil if a transaction is underway.
   optional Transaction txn = 7;
 }
 
@@ -74,20 +71,16 @@ message ResponseHeader {
   // Error is non-nil if an error occurred.
   optional Error error = 1;
   // Timestamp specifies time at which read or write actually was
-  // performed. In the case of both reads and writes, if the supplied
-  // timestamp is 0, the node servicing the request will use its
-  // timestamp for the operation and its value will be set
-  // here. Additionally, in the case of writes, this value may be
-  // increased from the timestamp passed with the RequestHeader when
-  // the key being written was either read or updated more recently.
+  // performed. In the case of both reads and writes, if the timestamp
+  // supplied to the request was 0, the wall time of the node
+  // servicing the request will be set here. Additionally, in the case
+  // of writes, this value may be increased from the timestamp passed
+  // with the RequestHeader if the key being written was either read
+  // or written more recently. If multiple requests are sent in
+  // parallel as part of the same transaction, then the timestamp
+  // supplied with subsequent requests should use the maximum of all
+  // returned timestamp values.
   optional Timestamp timestamp = 2 [(gogoproto.nullable) = false];
-  // Txn is non-nil if a transaction is underway. The returned
-  // transaction should always be sent with subsequent requests which
-  // are part of the same transaction. If multiple requests are sent
-  // in parallel as part of the same transaction, then subsequent
-  // specification of Txn should use the maximum of all returned
-  // Txn.Timestamp values.
-  optional Transaction txn = 3;
 }
 
 // A ContainsRequest is arguments to the Contains() method.
@@ -210,6 +203,30 @@ message ScanResponse {
   repeated KeyValue rows = 2 [(gogoproto.nullable) = false];
 }
 
+// A BeginTransactionRequest is arguments to the BeginTransaction()
+// method. It specifies the user priority and isolation level.
+message BeginTransactionRequest {
+  optional RequestHeader header = 1 [(gogoproto.nullable) = false, (gogoproto.embed) = true];
+  // UserPriority should be chosen from the range [1, 2^31-1). It's
+  // properly viewed as a multiple for how likely this transaction
+  // will be to prevail if a write conflict occurs. A UserPriority of
+  // 100 makes a transaction 100x less likely to be aborted if a write
+  // conflict occurs with another transaction with a UserPriority of 1.
+  optional int32 user_priority = 2 [(gogoproto.nullable) = false];
+  // Isolation is one of SERIALIZABLE or SNAPSHOT, indicating the
+  // isolation guarantees provided to concurrent transactions.
+  optional IsolationType isolation = 3 [(gogoproto.nullable) = false];
+}
+
+// A BeginTransactionResponse is the return value from the
+// BeginTransaction() method.
+message BeginTransactionResponse {
+  optional ResponseHeader header = 1 [(gogoproto.nullable) = false, (gogoproto.embed) = true];
+  // Txn is non-nil if the transaction was started. Use the returned
+  // value with subsequent requests which are part of this transaction.
+  optional Transaction txn = 2;
+}
+
 // An EndTransactionRequest is arguments to the EndTransaction() method.
 // It specifies whether to commit or roll back an extant transaction.
 message EndTransactionRequest {
@@ -328,6 +345,9 @@ message InternalHeartbeatTxnRequest {
 // pending).
 message InternalHeartbeatTxnResponse {
   optional ResponseHeader header = 1 [(gogoproto.nullable) = false, (gogoproto.embed) = true];
+  // Txn is non-nil if the transaction could be heartbeat and contains
+  // the current value of the transaction.
+  optional Transaction txn = 2;
 }
 
 // An InternalResolveIntentRequest is arguments to the
@@ -376,13 +396,14 @@ message ReadWriteCmdRequest {
   optional IncrementRequest increment = 3;
   optional DeleteRequest delete = 4;
   optional DeleteRangeRequest delete_range = 5;
-  optional EndTransactionRequest end_transaction = 6;
-  optional AccumulateTSRequest accumulate_ts = 7 [(gogoproto.customname) = "AccumulateTS"];
-  optional ReapQueueRequest reap_queue = 8;
-  optional EnqueueUpdateRequest enqueue_update = 9;
-  optional EnqueueMessageRequest enqueue_message = 10;
-  optional InternalHeartbeatTxnRequest internal_heartbeat_txn = 11;
-  optional InternalResolveIntentRequest internal_resolve_intent = 12;
+  optional BeginTransactionRequest begin_transaction = 6;
+  optional EndTransactionRequest end_transaction = 7;
+  optional AccumulateTSRequest accumulate_ts = 8 [(gogoproto.customname) = "AccumulateTS"];
+  optional ReapQueueRequest reap_queue = 9;
+  optional EnqueueUpdateRequest enqueue_update = 10;
+  optional EnqueueMessageRequest enqueue_message = 11;
+  optional InternalHeartbeatTxnRequest internal_heartbeat_txn = 12;
+  optional InternalResolveIntentRequest internal_resolve_intent = 13;
 }
 
 // A ReadWriteCmdResponse is a union type containing instances of all
@@ -394,11 +415,12 @@ message ReadWriteCmdResponse {
   optional IncrementResponse increment = 3;
   optional DeleteResponse delete = 4;
   optional DeleteRangeResponse delete_range = 5;
-  optional EndTransactionResponse end_transaction = 6;
-  optional AccumulateTSResponse accumulate_ts = 7 [(gogoproto.customname) = "AccumulateTS"];
-  optional ReapQueueResponse reap_queue = 8;
-  optional EnqueueUpdateResponse enqueue_update = 9;
-  optional EnqueueMessageResponse enqueue_message = 10;
-  optional InternalHeartbeatTxnResponse internal_heartbeat_txn = 11;
-  optional InternalResolveIntentResponse internal_resolve_intent = 12;
+  optional BeginTransactionResponse begin_transaction = 6;
+  optional EndTransactionResponse end_transaction = 7;
+  optional AccumulateTSResponse accumulate_ts = 8 [(gogoproto.customname) = "AccumulateTS"];
+  optional ReapQueueResponse reap_queue = 9;
+  optional EnqueueUpdateResponse enqueue_update = 10;
+  optional EnqueueMessageResponse enqueue_message = 11;
+  optional InternalHeartbeatTxnResponse internal_heartbeat_txn = 12;
+  optional InternalResolveIntentResponse internal_resolve_intent = 13;
 }

--- a/proto/api.proto
+++ b/proto/api.proto
@@ -62,9 +62,11 @@ message RequestHeader {
   optional string user = 5 [(gogoproto.nullable) = false];
   // Replica specifies the destination for the request. See config.go.
   optional Replica replica = 6 [(gogoproto.nullable) = false];
-  // TxnID is set non-empty if a transaction is underway. Empty string
-  // to start a new transaction.
-  optional bytes txn_id = 7 [(gogoproto.nullable) = false, (gogoproto.customname) = "TxnID"];
+  // Txn is set non-nil if a transaction is underway. Use an empty
+  // Transaction to start a new transaction; otherwise, Txn should
+  // always be specified using the Txn returned with the previous
+  // response.
+  optional Transaction txn = 7;
 }
 
 // ResponseHeader is returned with every storage node response.
@@ -79,8 +81,13 @@ message ResponseHeader {
   // increased from the timestamp passed with the RequestHeader when
   // the key being written was either read or updated more recently.
   optional Timestamp timestamp = 2 [(gogoproto.nullable) = false];
-  // TxnID is non-empty if a transaction is underway.
-  optional bytes txn_id = 3 [(gogoproto.nullable) = false, (gogoproto.customname) = "TxnID"];
+  // Txn is non-nil if a transaction is underway. The returned
+  // transaction should always be sent with subsequent requests which
+  // are part of the same transaction. If multiple requests are sent
+  // in parallel as part of the same transaction, then subsequent
+  // specification of Txn should use the maximum of all returned
+  // Txn.Timestamp values.
+  optional Transaction txn = 3;
 }
 
 // A ContainsRequest is arguments to the Contains() method.
@@ -315,12 +322,12 @@ message InternalHeartbeatTxnRequest {
 }
 
 // An InternalHeartbeatTxnResponse is the return value from the
-// InternalHeartbeatTxn() method. It returns the transaction info as
-// well. So the transaction coordinator will know quickly when the
-// transaction is aborted by another one.
+// InternalHeartbeatTxn() method. It returns the transaction info in
+// the response header. The returned transaction lets the coordinator
+// know the disposition of the transaction (i.e. aborted, committed or
+// pending).
 message InternalHeartbeatTxnResponse {
   optional ResponseHeader header = 1 [(gogoproto.nullable) = false, (gogoproto.embed) = true];
-  optional Transaction txn = 2 [(gogoproto.nullable) = false];
 }
 
 // An InternalResolveIntentRequest is arguments to the

--- a/proto/data.proto
+++ b/proto/data.proto
@@ -99,11 +99,21 @@ enum IsolationType {
 // TransactionStatus TODO(jiajia) Needs documentation.
 enum TransactionStatus {
   option (gogoproto.goproto_enum_prefix) = false;
-  // PENDING TODO(jiajia) Needs documentation.
+  // PENDING is the default state for a new transaction. Transactions
+  // move from PENDING to one of COMMITTED or ABORTED. Mutations made
+  // as part of a PENDING transactions are recorded as "intents" in
+  // the underlying MVCC model.
   PENDING = 0;
-  // COMMITTED TODO(jiajia) Needs documentation.
+  // COMMITTED is the state for a transaction which has been
+  // committed. Mutations made as part of a transaction which is moved
+  // into COMMITTED state become durable and visible to other
+  // transactions, moving from "intents" to permanent versioned
+  // values.
   COMMITTED = 1;
-  // ABORTED TODO(jiajia) Needs documentation.
+  // ABORTED is the state for a transaction which has been aborted.
+  // Mutations made as part of a transaction which is moved into
+  // ABORTED state are deleted and are never made visible to other
+  // transactions.
   ABORTED = 2;
 }
 
@@ -120,9 +130,12 @@ message Transaction {
   optional TransactionStatus status = 4 [(gogoproto.nullable) = false];
   // Incremented on txn retry.
   optional int32 epoch = 5 [(gogoproto.nullable) = false];
-  // 0 to use timestamp at destination.
+  // The proposed timestamp for the transaction. This starts as
+  // the current wall time on the txn coordinator.
   optional Timestamp timestamp = 6 [(gogoproto.nullable) = false];
-  // Timestamp + clock skew; set to Timestamp for historical read.
+  // Timestamp + clock skew. Reads which encounter values with
+  // timestamps between Timestamp and MaxTimestamp trigger a txn
+  // retry error.
   optional Timestamp max_timestamp = 7 [(gogoproto.nullable) = false];
   // The last hearbeat timestamp.
   optional Timestamp last_heartbeat = 8 [(gogoproto.nullable) = false];

--- a/proto/data.proto
+++ b/proto/data.proto
@@ -114,7 +114,7 @@ enum TransactionStatus {
 // used to decide whether a transaction will be aborted during
 // contention.
 message Transaction {
-  optional string txn_id = 1 [(gogoproto.nullable) = false];
+  optional bytes id = 1 [(gogoproto.nullable) = false, (gogoproto.customname) = "ID"];
   optional int32 priority = 2 [(gogoproto.nullable) = false];
   optional IsolationType isolation = 3 [(gogoproto.nullable) = false];
   optional TransactionStatus status = 4 [(gogoproto.nullable) = false];
@@ -130,6 +130,6 @@ message Transaction {
 
 // MVCCMetadata holds MVCC metadata for a key. Used by storage/engine/mvcc.go.
 message MVCCMetadata {
-  optional bytes txn_id = 1 [(gogoproto.nullable) = false, (gogoproto.customname) = "TxnID"];
+  optional Transaction txn = 1;
   optional Timestamp timestamp = 2 [(gogoproto.nullable) = false];
 }

--- a/server/node.go
+++ b/server/node.go
@@ -458,6 +458,11 @@ func (n *Node) Scan(args *proto.ScanRequest, reply *proto.ScanResponse) error {
 	return n.executeCmd(storage.Scan, args, reply)
 }
 
+// BeginTransaction .
+func (n *Node) BeginTransaction(args *proto.BeginTransactionRequest, reply *proto.BeginTransactionResponse) error {
+	return n.executeCmd(storage.BeginTransaction, args, reply)
+}
+
 // EndTransaction .
 func (n *Node) EndTransaction(args *proto.EndTransactionRequest, reply *proto.EndTransactionResponse) error {
 	return n.executeCmd(storage.EndTransaction, args, reply)

--- a/storage/engine/engine.go
+++ b/storage/engine/engine.go
@@ -105,6 +105,17 @@ type BatchPut proto.RawKeyValue
 // A BatchMerge is a merge operation executed as part of an atomic batch.
 type BatchMerge proto.RawKeyValue
 
+// MakeBatchPutProto serializes the provided message and returns a
+// BatchPut object for use with WriteBatch. Returns an error on
+// protobuf serialization failure.
+func MakeBatchPutProto(key Key, msg gogoproto.Message) (BatchPut, error) {
+	data, err := gogoproto.Marshal(msg)
+	if err != nil {
+		return BatchPut(proto.RawKeyValue{}), err
+	}
+	return BatchPut(proto.RawKeyValue{Key: key, Value: data}), err
+}
+
 // PutI sets the given key to the gob-serialized byte string of the
 // value provided. Used internally.
 func PutI(engine Engine, key Key, value interface{}) error {

--- a/storage/engine/keys.go
+++ b/storage/engine/keys.go
@@ -224,9 +224,6 @@ var (
 	// KeyConfigZonePrefix specifies the key prefix for zone
 	// configurations. The suffix is the affected key prefix.
 	KeyConfigZonePrefix = MakeKey(KeySystemPrefix, Key("zone"))
-	// KeyTransactionPrefix specifies the key prefix for transaction
-	// records. The suffix is the transaction id.
-	KeyTransactionPrefix = MakeKey(KeySystemPrefix, Key("tx"))
 	// KeyNodeIDGenerator contains a sequence generator for node IDs.
 	KeyNodeIDGenerator = MakeKey(KeySystemPrefix, Key("node-idgen"))
 	// KeySchemaPrefix specifies key prefixes for schema definitions.

--- a/storage/engine/mvcc.go
+++ b/storage/engine/mvcc.go
@@ -42,18 +42,22 @@ type MVCC struct {
 
 // writeIntentError is a trivial implementation of error.
 type writeIntentError struct {
-	TxnID []byte
+	Txn *proto.Transaction
 }
 
-type writeTimestampTooOldError struct {
+type writeTooOldError struct {
 	Timestamp proto.Timestamp
+	Txn       *proto.Transaction
 }
 
 func (e *writeIntentError) Error() string {
-	return fmt.Sprintf("there exists a write intent from transaction %s", e.TxnID)
+	return fmt.Sprintf("there exists a write intent from transaction %+v", e.Txn)
 }
 
-func (e *writeTimestampTooOldError) Error() string {
+func (e *writeTooOldError) Error() string {
+	if e.Txn != nil {
+		return fmt.Sprintf("cannot write with a timestamp older than %+v, or older txn epoch: %+v", e.Timestamp, e.Txn)
+	}
 	return fmt.Sprintf("cannot write with a timestamp older than %+v", e.Timestamp)
 }
 
@@ -67,8 +71,8 @@ func NewMVCC(engine Engine) *MVCC {
 // GetProto fetches the value at the specified key and unmarshals it
 // using a protobuf decoder. Returns true on success or false if the
 // key was not found.
-func (mvcc *MVCC) GetProto(key Key, timestamp proto.Timestamp, txnID []byte, msg gogoproto.Message) (bool, error) {
-	value, err := mvcc.Get(key, timestamp, txnID)
+func (mvcc *MVCC) GetProto(key Key, timestamp proto.Timestamp, txn *proto.Transaction, msg gogoproto.Message) (bool, error) {
+	value, err := mvcc.Get(key, timestamp, txn)
 	if err != nil {
 		return false, err
 	}
@@ -85,14 +89,14 @@ func (mvcc *MVCC) GetProto(key Key, timestamp proto.Timestamp, txnID []byte, msg
 
 // PutProto sets the given key to the protobuf-serialized byte string
 // of msg and the provided timestamp.
-func (mvcc *MVCC) PutProto(key Key, timestamp proto.Timestamp, txnID []byte, msg gogoproto.Message) error {
+func (mvcc *MVCC) PutProto(key Key, timestamp proto.Timestamp, txn *proto.Transaction, msg gogoproto.Message) error {
 	data, err := gogoproto.Marshal(msg)
 	if err != nil {
 		return err
 	}
 	value := proto.Value{Bytes: data}
 	value.InitChecksum(key)
-	return mvcc.Put(key, timestamp, value, txnID)
+	return mvcc.Put(key, timestamp, value, txn)
 }
 
 // Get returns the value for the key specified in the request, while
@@ -100,13 +104,7 @@ func (mvcc *MVCC) PutProto(key Key, timestamp proto.Timestamp, txnID []byte, msg
 // arbitrarily encoded; it will be binary-encoded to remove any
 // internal null characters. If no value for the key exists, or has
 // been deleted, returns nil for value.
-func (mvcc *MVCC) Get(key Key, timestamp proto.Timestamp, txnID []byte) (*proto.Value, error) {
-	binKey := encoding.EncodeBinary(nil, key)
-	value, _, err := mvcc.getInternal(binKey, timestamp, txnID)
-	return value, err
-}
-
-// getInternal implements the actual logic of get function.
+//
 // The values of multiple versions for the given key should
 // be organized as follows:
 // ...
@@ -117,46 +115,44 @@ func (mvcc *MVCC) Get(key Key, timestamp proto.Timestamp, txnID []byte) (*proto.
 // keyA_Timestamp_0 : value of version_0
 // keyB : MVCCMetadata of keyB
 // ...
-//
-// Returns nil for the proto.Value in the event that the key has
-// no value or if the value is a deleted tombstone.
-func (mvcc *MVCC) getInternal(key Key, timestamp proto.Timestamp, txnID []byte) (*proto.Value, []byte, error) {
+func (mvcc *MVCC) Get(key Key, timestamp proto.Timestamp, txn *proto.Transaction) (*proto.Value, error) {
+	binKey := encoding.EncodeBinary(nil, key)
 	meta := &proto.MVCCMetadata{}
-	ok, err := GetProto(mvcc.engine, key, meta)
+	ok, err := GetProto(mvcc.engine, binKey, meta)
 	if err != nil || !ok {
-		return nil, nil, err
+		return nil, err
 	}
 	// If the read timestamp is greater than the latest one, we can just
 	// fetch the value without a scan.
 	ts := proto.Timestamp{}
 	var valBytes []byte
 	if !timestamp.Less(meta.Timestamp) {
-		if len(meta.TxnID) > 0 && (len(txnID) == 0 || !bytes.Equal(meta.TxnID, txnID)) {
-			return nil, nil, &writeIntentError{TxnID: meta.TxnID}
+		if meta.Txn != nil && (txn == nil || !bytes.Equal(meta.Txn.ID, txn.ID)) {
+			return nil, &writeIntentError{Txn: meta.Txn}
 		}
 
-		latestKey := mvccEncodeKey(key, meta.Timestamp)
+		latestKey := mvccEncodeKey(binKey, meta.Timestamp)
 		valBytes, err = mvcc.engine.Get(latestKey)
 		ts = meta.Timestamp
 	} else {
-		nextKey := mvccEncodeKey(key, timestamp)
+		nextKey := mvccEncodeKey(binKey, timestamp)
 		// We use the PrefixEndKey(key) as the upper bound for scan.
 		// If there is no other version after nextKey, it won't return
 		// the value of the next key.
-		kvs, err := mvcc.engine.Scan(nextKey, PrefixEndKey(key), 1)
+		kvs, err := mvcc.engine.Scan(nextKey, PrefixEndKey(binKey), 1)
 		if len(kvs) == 0 {
-			return nil, nil, err
+			return nil, err
 		}
 		_, ts, _ = mvccDecodeKey(kvs[0].Key)
 		valBytes = kvs[0].Value
 	}
 	if valBytes == nil {
-		return nil, nil, nil
+		return nil, nil
 	}
 	// Unmarshal the mvcc value.
 	value := &proto.MVCCValue{}
 	if err := gogoproto.Unmarshal(valBytes, value); err != nil {
-		return nil, nil, err
+		return nil, err
 	}
 	// Set the timestamp if the value is not nil (i.e. not a deletion tombstone).
 	if value.Value != nil {
@@ -164,32 +160,32 @@ func (mvcc *MVCC) getInternal(key Key, timestamp proto.Timestamp, txnID []byte) 
 	} else if !value.Deleted {
 		log.Warningf("encountered MVCC value at key %q with a nil proto.Value but with !Deleted: %+v", key, value)
 	}
-	return value.Value, meta.TxnID, nil
+	return value.Value, nil
 }
 
 // Put sets the value for a specified key. It will save the value with
 // different versions according to its timestamp and update the key metadata.
 // We assume the range will check for an existing write intent before
 // executing any Put action at the MVCC level.
-func (mvcc *MVCC) Put(key Key, timestamp proto.Timestamp, value proto.Value, txnID []byte) error {
+func (mvcc *MVCC) Put(key Key, timestamp proto.Timestamp, value proto.Value, txn *proto.Transaction) error {
 	binKey := encoding.EncodeBinary(nil, key)
 	if value.Timestamp != nil && !value.Timestamp.Equal(timestamp) {
 		return util.Errorf(
 			"the timestamp %+v provided in value does not match the timestamp %+v in request",
 			value.Timestamp, timestamp)
 	}
-	return mvcc.putInternal(binKey, timestamp, proto.MVCCValue{Value: &value}, txnID)
+	return mvcc.putInternal(binKey, timestamp, proto.MVCCValue{Value: &value}, txn)
 }
 
 // Delete marks the key deleted and will not return in the next get response.
-func (mvcc *MVCC) Delete(key Key, timestamp proto.Timestamp, txnID []byte) error {
+func (mvcc *MVCC) Delete(key Key, timestamp proto.Timestamp, txn *proto.Transaction) error {
 	binKey := encoding.EncodeBinary(nil, key)
-	return mvcc.putInternal(binKey, timestamp, proto.MVCCValue{Deleted: true}, txnID)
+	return mvcc.putInternal(binKey, timestamp, proto.MVCCValue{Deleted: true}, txn)
 }
 
 // putInternal adds a new timestamped value to the specified key.
 // If value is nil, creates a deletion tombstone value.
-func (mvcc *MVCC) putInternal(key Key, timestamp proto.Timestamp, value proto.MVCCValue, txnID []byte) error {
+func (mvcc *MVCC) putInternal(key Key, timestamp proto.Timestamp, value proto.MVCCValue, txn *proto.Transaction) error {
 	if value.Value != nil && value.Value.Bytes != nil && value.Value.Integer != nil {
 		return util.Errorf("key %q value contains both a byte slice and an integer value: %+v", key, value)
 	}
@@ -206,14 +202,15 @@ func (mvcc *MVCC) putInternal(key Key, timestamp proto.Timestamp, value proto.MV
 		// operation does not come from the same transaction.
 		// This should not happen since range should check the existing
 		// write intent before executing any Put action at MVCC level.
-		if len(meta.TxnID) > 0 && (len(txnID) == 0 || !bytes.Equal(meta.TxnID, txnID)) {
-			return &writeIntentError{TxnID: meta.TxnID}
+		if meta.Txn != nil && (txn == nil || !bytes.Equal(meta.Txn.ID, txn.ID)) {
+			return &writeIntentError{Txn: meta.Txn}
 		}
 
-		if meta.Timestamp.Less(timestamp) ||
-			(timestamp.Equal(meta.Timestamp) && bytes.Equal(meta.TxnID, txnID)) {
-			// Update MVCC metadata.
-			meta = &proto.MVCCMetadata{TxnID: txnID, Timestamp: timestamp}
+		// We can update the current metadata as long as the timestamp is
+		// greater than or equal and if there's a transaction underway,
+		// the current epoch must be greater.
+		if !timestamp.Less(meta.Timestamp) && (meta.Txn == nil || txn.Epoch >= meta.Txn.Epoch) {
+			meta = &proto.MVCCMetadata{Txn: txn, Timestamp: timestamp}
 			if err := PutProto(mvcc.engine, key, meta); err != nil {
 				return err
 			}
@@ -221,11 +218,11 @@ func (mvcc *MVCC) putInternal(key Key, timestamp proto.Timestamp, value proto.MV
 			// In case we receive a Put request to update an old version,
 			// it must be an error since raft should handle any client
 			// retry from timeout.
-			return &writeTimestampTooOldError{Timestamp: meta.Timestamp}
+			return &writeTooOldError{Timestamp: meta.Timestamp, Txn: meta.Txn}
 		}
 	} else { // In case the key metadata does not exist yet.
 		// Create key metadata.
-		meta = &proto.MVCCMetadata{TxnID: txnID, Timestamp: timestamp}
+		meta = &proto.MVCCMetadata{Txn: txn, Timestamp: timestamp}
 		if err := PutProto(mvcc.engine, key, meta); err != nil {
 			return err
 		}
@@ -247,12 +244,12 @@ func (mvcc *MVCC) putInternal(key Key, timestamp proto.Timestamp, value proto.MV
 // Increment fetches the value for key, and assuming the value is an
 // "integer" type, increments it by inc and stores the new value. The
 // newly incremented value is returned.
-func (mvcc *MVCC) Increment(key Key, timestamp proto.Timestamp, txnID []byte, inc int64) (int64, error) {
+func (mvcc *MVCC) Increment(key Key, timestamp proto.Timestamp, txn *proto.Transaction, inc int64) (int64, error) {
 	// Handle check for non-existence of key. In order to detect
 	// the potential write intent by another concurrent transaction
 	// with a newer timestamp, we need to use the max timestamp
 	// while reading.
-	value, err := mvcc.Get(key, proto.MaxTimestamp, txnID)
+	value, err := mvcc.Get(key, proto.MaxTimestamp, txn)
 	if err != nil {
 		return 0, err
 	}
@@ -278,18 +275,18 @@ func (mvcc *MVCC) Increment(key Key, timestamp proto.Timestamp, txnID []byte, in
 	r := int64Val + inc
 	value = &proto.Value{Integer: gogoproto.Int64(r)}
 	value.InitChecksum(key)
-	return r, mvcc.Put(key, timestamp, *value, txnID)
+	return r, mvcc.Put(key, timestamp, *value, txn)
 }
 
 // ConditionalPut sets the value for a specified key only if
 // the expected value matches. If not, the return value contains
 // the actual value.
-func (mvcc *MVCC) ConditionalPut(key Key, timestamp proto.Timestamp, value proto.Value, expValue *proto.Value, txnID []byte) (*proto.Value, error) {
+func (mvcc *MVCC) ConditionalPut(key Key, timestamp proto.Timestamp, value proto.Value, expValue *proto.Value, txn *proto.Transaction) (*proto.Value, error) {
 	// Handle check for non-existence of key. In order to detect
 	// the potential write intent by another concurrent transaction
 	// with a newer timestamp, we need to use the max timestamp
 	// while reading.
-	existVal, err := mvcc.Get(key, proto.MaxTimestamp, txnID)
+	existVal, err := mvcc.Get(key, proto.MaxTimestamp, txn)
 	if err != nil {
 		return nil, err
 	}
@@ -307,23 +304,23 @@ func (mvcc *MVCC) ConditionalPut(key Key, timestamp proto.Timestamp, value proto
 		}
 	}
 
-	return nil, mvcc.Put(key, timestamp, value, txnID)
+	return nil, mvcc.Put(key, timestamp, value, txn)
 }
 
 // DeleteRange deletes the range of key/value pairs specified by
 // start and end keys. Specify max=0 for unbounded deletes.
-func (mvcc *MVCC) DeleteRange(key Key, endKey Key, max int64, timestamp proto.Timestamp, txnID []byte) (int64, error) {
+func (mvcc *MVCC) DeleteRange(key Key, endKey Key, max int64, timestamp proto.Timestamp, txn *proto.Transaction) (int64, error) {
 	// In order to detect the potential write intent by another
 	// concurrent transaction with a newer timestamp, we need
 	// to use the max timestamp for scan.
-	kvs, txnID, err := mvcc.Scan(key, endKey, max, proto.MaxTimestamp, txnID)
+	kvs, err := mvcc.Scan(key, endKey, max, proto.MaxTimestamp, txn)
 	if err != nil {
 		return 0, err
 	}
 
 	num := int64(0)
 	for _, kv := range kvs {
-		err = mvcc.Delete(kv.Key, timestamp, txnID)
+		err = mvcc.Delete(kv.Key, timestamp, txn)
 		if err != nil {
 			return num, err
 		}
@@ -334,7 +331,7 @@ func (mvcc *MVCC) DeleteRange(key Key, endKey Key, max int64, timestamp proto.Ti
 
 // Scan scans the key range specified by start key through end key up
 // to some maximum number of results. Specify max=0 for unbounded scans.
-func (mvcc *MVCC) Scan(key Key, endKey Key, max int64, timestamp proto.Timestamp, txnID []byte) ([]proto.KeyValue, []byte, error) {
+func (mvcc *MVCC) Scan(key Key, endKey Key, max int64, timestamp proto.Timestamp, txn *proto.Transaction) ([]proto.KeyValue, error) {
 	binKey := encoding.EncodeBinary(nil, key)
 	binEndKey := encoding.EncodeBinary(nil, endKey)
 	nextKey := binKey
@@ -343,7 +340,7 @@ func (mvcc *MVCC) Scan(key Key, endKey Key, max int64, timestamp proto.Timestamp
 	for {
 		kvs, err := mvcc.engine.Scan(nextKey, binEndKey, 1)
 		if err != nil {
-			return nil, nil, err
+			return nil, err
 		}
 		// No more keys exists in the given range.
 		if len(kvs) == 0 {
@@ -352,11 +349,11 @@ func (mvcc *MVCC) Scan(key Key, endKey Key, max int64, timestamp proto.Timestamp
 
 		remainder, currentKey := encoding.DecodeBinary(kvs[0].Key)
 		if len(remainder) != 0 {
-			return nil, nil, util.Errorf("expected an MVCC metadata key: %s", kvs[0].Key)
+			return nil, util.Errorf("expected an MVCC metadata key: %s", kvs[0].Key)
 		}
-		value, err := mvcc.Get(currentKey, timestamp, txnID)
+		value, err := mvcc.Get(currentKey, timestamp, txn)
 		if err != nil {
-			return res, nil, err
+			return res, err
 		}
 
 		if value != nil {
@@ -385,15 +382,15 @@ func (mvcc *MVCC) Scan(key Key, endKey Key, max int64, timestamp proto.Timestamp
 		nextKey = encoding.EncodeBinary(nil, NextKey(currentKey))
 	}
 
-	return res, txnID, nil
+	return res, nil
 }
 
 // ResolveWriteIntent either commits or aborts (rolls back) an extant
-// write intent for a given txnID according to commit parameter.
-// ResolveWriteIntent will skip write intents of other txnIDs.
-func (mvcc *MVCC) ResolveWriteIntent(key Key, txnID []byte, commit bool) error {
-	if len(txnID) == 0 {
-		return util.Error("missing txnID in request")
+// write intent for a given txn according to commit parameter.
+// ResolveWriteIntent will skip write intents of other txns.
+func (mvcc *MVCC) ResolveWriteIntent(key Key, txn *proto.Transaction, commit bool) error {
+	if txn == nil {
+		return util.Error("no txn specified")
 	}
 
 	binKey := encoding.EncodeBinary(nil, key)
@@ -402,27 +399,24 @@ func (mvcc *MVCC) ResolveWriteIntent(key Key, txnID []byte, commit bool) error {
 	if err != nil {
 		return err
 	}
-	if !ok {
-		return util.Errorf("key %q does not exist", key)
+	// For cases where there's no write intent to resolve, or one exists
+	// which we can't resolve, this is a noop.
+	if !ok || meta.Txn == nil || !bytes.Equal(meta.Txn.ID, txn.ID) {
+		return nil
+	}
+	// If we're committing the intent and the txn epochs match, the
+	// intent value is good to go and we just set meta.Txn to nil.
+	if commit && meta.Txn.Epoch == txn.Epoch {
+		return PutProto(mvcc.engine, binKey, &proto.MVCCMetadata{Txn: nil, Timestamp: meta.Timestamp})
 	}
 
-	if len(meta.TxnID) == 0 {
-		return util.Errorf("write intent %q does not exist", key)
-	}
-	if !bytes.Equal(meta.TxnID, txnID) {
-		return util.Errorf("cannot commit another TxnID %s from TxnID %s",
-			meta.TxnID, txnID)
-	}
-
-	if commit {
-		return PutProto(mvcc.engine, binKey, &proto.MVCCMetadata{TxnID: nil, Timestamp: meta.Timestamp})
-	}
-
-	// If not committing, we must find the next versioned value and
-	// reset the metadata's latest timestamp. If there are no other
-	// versioned values, we delete the metadata key. Because there are
-	// multiple steps here and we want them all to commit, or none to
-	// commit, we schedule them using a write batch.
+	// If not committing (this can be the case if commit=true, but the
+	// committed epoch is different from this intent's epoch), we must
+	// find the next versioned value and reset the metadata's latest
+	// timestamp. If there are no other versioned values, we delete the
+	// metadata key. Because there are multiple steps here and we want
+	// them all to commit, or none to commit, we schedule them using a
+	// write batch.
 	var batch []interface{}
 
 	// First clear the intent value.
@@ -457,13 +451,12 @@ func (mvcc *MVCC) ResolveWriteIntent(key Key, txnID []byte, commit bool) error {
 }
 
 // ResolveWriteIntentRange commits or aborts (rolls back) the range of
-// write intents specified by start and end keys for a given txnID
+// write intents specified by start and end keys for a given txn
 // according to commit parameter. ResolveWriteIntentRange will skip
-// write intents of other txnIDs. Specify max=0 for unbounded
-// resolves.
-func (mvcc *MVCC) ResolveWriteIntentRange(key Key, endKey Key, max int64, txnID []byte, commit bool) (int64, error) {
-	if len(txnID) == 0 {
-		return 0, util.Error("missing txnID in request")
+// write intents of other txns. Specify max=0 for unbounded resolves.
+func (mvcc *MVCC) ResolveWriteIntentRange(key Key, endKey Key, max int64, txn *proto.Transaction, commit bool) (int64, error) {
+	if txn == nil {
+		return 0, util.Error("no txn specified")
 	}
 
 	binKey := encoding.EncodeBinary(nil, key)
@@ -485,27 +478,14 @@ func (mvcc *MVCC) ResolveWriteIntentRange(key Key, endKey Key, max int64, txnID 
 		if len(remainder) != 0 {
 			return 0, util.Errorf("expected an MVCC metadata key: %s", kvs[0].Key)
 		}
-		_, existingTxnID, err := mvcc.getInternal(kvs[0].Key, proto.MaxTimestamp, txnID)
-		// Return the error unless its a writeIntentError, which
-		// will occur in the event we scan a key with a write
-		// intent belonging to a different transaction.
-		if _, ok := err.(*writeIntentError); err != nil && !ok {
-			return num, err
-		}
-		// ResolveWriteIntent only needs to deal with the write
-		// intents for the given txnID.
-		if err == nil && bytes.Equal(existingTxnID, txnID) {
-			// commits or aborts (rolls back) the write intent of
-			// the given txnID.
-			err = mvcc.ResolveWriteIntent(currentKey, txnID, commit)
-			if err != nil {
-				return num, err
-			}
+		err = mvcc.ResolveWriteIntent(currentKey, txn, commit)
+		if err != nil {
+			log.Warningf("failed to resolve intent for key %q: %v", currentKey, err)
+		} else {
 			num++
-		}
-
-		if max != 0 && max == num {
-			break
+			if max != 0 && max == num {
+				break
+			}
 		}
 
 		// In order to efficiently skip the possibly long list of

--- a/storage/range.go
+++ b/storage/range.go
@@ -98,7 +98,6 @@ var readMethods = map[string]struct{}{
 	ConditionalPut:       struct{}{},
 	Increment:            struct{}{},
 	Scan:                 struct{}{},
-	BeginTransaction:     struct{}{},
 	ReapQueue:            struct{}{},
 	InternalRangeLookup:  struct{}{},
 	InternalSnapshotCopy: struct{}{},
@@ -476,8 +475,6 @@ func (r *Range) executeCmd(method string, args proto.Request, reply proto.Respon
 		r.DeleteRange(args.(*proto.DeleteRangeRequest), reply.(*proto.DeleteRangeResponse))
 	case Scan:
 		r.Scan(args.(*proto.ScanRequest), reply.(*proto.ScanResponse))
-	case BeginTransaction:
-		r.BeginTransaction(args.(*proto.BeginTransactionRequest), reply.(*proto.BeginTransactionResponse))
 	case EndTransaction:
 		r.EndTransaction(args.(*proto.EndTransactionRequest), reply.(*proto.EndTransactionResponse))
 	case AccumulateTS:
@@ -597,12 +594,6 @@ func (r *Range) Scan(args *proto.ScanRequest, reply *proto.ScanResponse) {
 	kvs, err := r.mvcc.Scan(args.Key, args.EndKey, args.MaxResults, args.Timestamp, args.Txn)
 	reply.Rows = kvs
 	reply.SetGoError(err)
-}
-
-// BeginTransaction returns an error, as it's handled trivially at
-// any cockroach node and doesn't need to be addressed to a range.
-func (r *Range) BeginTransaction(args *proto.BeginTransactionRequest, reply *proto.BeginTransactionResponse) {
-	reply.SetGoError(util.Error("should never be invoked on range"))
 }
 
 // EndTransaction either commits or aborts (rolls back) an extant

--- a/storage/range.go
+++ b/storage/range.go
@@ -79,6 +79,7 @@ const (
 	Scan                  = "Scan"
 	Delete                = "Delete"
 	DeleteRange           = "DeleteRange"
+	BeginTransaction      = "BeginTransaction"
 	EndTransaction        = "EndTransaction"
 	AccumulateTS          = "AccumulateTS"
 	ReapQueue             = "ReapQueue"
@@ -97,6 +98,7 @@ var readMethods = map[string]struct{}{
 	ConditionalPut:       struct{}{},
 	Increment:            struct{}{},
 	Scan:                 struct{}{},
+	BeginTransaction:     struct{}{},
 	ReapQueue:            struct{}{},
 	InternalRangeLookup:  struct{}{},
 	InternalSnapshotCopy: struct{}{},
@@ -474,6 +476,8 @@ func (r *Range) executeCmd(method string, args proto.Request, reply proto.Respon
 		r.DeleteRange(args.(*proto.DeleteRangeRequest), reply.(*proto.DeleteRangeResponse))
 	case Scan:
 		r.Scan(args.(*proto.ScanRequest), reply.(*proto.ScanResponse))
+	case BeginTransaction:
+		r.BeginTransaction(args.(*proto.BeginTransactionRequest), reply.(*proto.BeginTransactionResponse))
 	case EndTransaction:
 		r.EndTransaction(args.(*proto.EndTransactionRequest), reply.(*proto.EndTransactionResponse))
 	case AccumulateTS:
@@ -593,6 +597,12 @@ func (r *Range) Scan(args *proto.ScanRequest, reply *proto.ScanResponse) {
 	kvs, err := r.mvcc.Scan(args.Key, args.EndKey, args.MaxResults, args.Timestamp, args.Txn)
 	reply.Rows = kvs
 	reply.SetGoError(err)
+}
+
+// BeginTransaction returns an error, as it's handled trivially at
+// any cockroach node and doesn't need to be addressed to a range.
+func (r *Range) BeginTransaction(args *proto.BeginTransactionRequest, reply *proto.BeginTransactionResponse) {
+	reply.SetGoError(util.Error("should never be invoked on range"))
 }
 
 // EndTransaction either commits or aborts (rolls back) an extant

--- a/storage/range.go
+++ b/storage/range.go
@@ -437,7 +437,7 @@ func (r *Range) maybeGossipConfigs() {
 func (r *Range) loadConfigMap(keyPrefix engine.Key, configI interface{}) (PrefixConfigMap, error) {
 	// TODO(spencer): need to make sure range splitting never
 	// crosses a configuration map's key prefix.
-	kvs, _, err := r.mvcc.Scan(keyPrefix, engine.PrefixEndKey(keyPrefix), 0, proto.MaxTimestamp, nil)
+	kvs, err := r.mvcc.Scan(keyPrefix, engine.PrefixEndKey(keyPrefix), 0, proto.MaxTimestamp, nil)
 	if err != nil {
 		return nil, err
 	}
@@ -514,7 +514,7 @@ func (r *Range) executeCmd(method string, args proto.Request, reply proto.Respon
 
 // Contains verifies the existence of a key in the key value store.
 func (r *Range) Contains(args *proto.ContainsRequest, reply *proto.ContainsResponse) {
-	val, err := r.mvcc.Get(args.Key, args.Timestamp, args.TxnID)
+	val, err := r.mvcc.Get(args.Key, args.Timestamp, args.Txn)
 	if err != nil {
 		reply.SetGoError(err)
 		return
@@ -526,14 +526,14 @@ func (r *Range) Contains(args *proto.ContainsRequest, reply *proto.ContainsRespo
 
 // Get returns the value for a specified key.
 func (r *Range) Get(args *proto.GetRequest, reply *proto.GetResponse) {
-	val, err := r.mvcc.Get(args.Key, args.Timestamp, args.TxnID)
+	val, err := r.mvcc.Get(args.Key, args.Timestamp, args.Txn)
 	reply.Value = val
 	reply.SetGoError(err)
 }
 
 // Put sets the value for a specified key.
 func (r *Range) Put(args *proto.PutRequest, reply *proto.PutResponse) {
-	err := r.mvcc.Put(args.Key, args.Timestamp, args.Value, args.TxnID)
+	err := r.mvcc.Put(args.Key, args.Timestamp, args.Value, args.Txn)
 	if err == nil {
 		r.updateGossipConfigs(args.Key)
 	}
@@ -544,7 +544,7 @@ func (r *Range) Put(args *proto.PutRequest, reply *proto.PutResponse) {
 // the expected value matches. If not, the return value contains
 // the actual value.
 func (r *Range) ConditionalPut(args *proto.ConditionalPutRequest, reply *proto.ConditionalPutResponse) {
-	val, err := r.mvcc.ConditionalPut(args.Key, args.Timestamp, args.Value, args.ExpValue, args.TxnID)
+	val, err := r.mvcc.ConditionalPut(args.Key, args.Timestamp, args.Value, args.ExpValue, args.Txn)
 	if err == nil {
 		r.updateGossipConfigs(args.Key)
 	}
@@ -568,20 +568,20 @@ func (r *Range) updateGossipConfigs(key engine.Key) {
 // returns the newly incremented value (encoded as varint64). If no value
 // exists for the key, zero is incremented.
 func (r *Range) Increment(args *proto.IncrementRequest, reply *proto.IncrementResponse) {
-	val, err := r.mvcc.Increment(args.Key, args.Timestamp, args.TxnID, args.Increment)
+	val, err := r.mvcc.Increment(args.Key, args.Timestamp, args.Txn, args.Increment)
 	reply.NewValue = val
 	reply.SetGoError(err)
 }
 
 // Delete deletes the key and value specified by key.
 func (r *Range) Delete(args *proto.DeleteRequest, reply *proto.DeleteResponse) {
-	reply.SetGoError(r.mvcc.Delete(args.Key, args.Timestamp, args.TxnID))
+	reply.SetGoError(r.mvcc.Delete(args.Key, args.Timestamp, args.Txn))
 }
 
 // DeleteRange deletes the range of key/value pairs specified by
 // start and end keys.
 func (r *Range) DeleteRange(args *proto.DeleteRangeRequest, reply *proto.DeleteRangeResponse) {
-	num, err := r.mvcc.DeleteRange(args.Key, args.EndKey, args.MaxEntriesToDelete, args.Timestamp, args.TxnID)
+	num, err := r.mvcc.DeleteRange(args.Key, args.EndKey, args.MaxEntriesToDelete, args.Timestamp, args.Txn)
 	reply.NumDeleted = num
 	reply.SetGoError(err)
 }
@@ -590,7 +590,7 @@ func (r *Range) DeleteRange(args *proto.DeleteRangeRequest, reply *proto.DeleteR
 // to some maximum number of results. The last key of the iteration is
 // returned with the reply.
 func (r *Range) Scan(args *proto.ScanRequest, reply *proto.ScanResponse) {
-	kvs, _, err := r.mvcc.Scan(args.Key, args.EndKey, args.MaxResults, args.Timestamp, args.TxnID)
+	kvs, err := r.mvcc.Scan(args.Key, args.EndKey, args.MaxResults, args.Timestamp, args.Txn)
 	reply.Rows = kvs
 	reply.SetGoError(err)
 }
@@ -671,7 +671,7 @@ func (r *Range) InternalRangeLookup(args *proto.InternalRangeLookupRequest, repl
 	// MaxRanges.
 	metaPrefix := args.Key[:len(engine.KeyMeta1Prefix)]
 	nextKey := engine.NextKey(args.Key)
-	kvs, _, err := r.mvcc.Scan(nextKey, engine.PrefixEndKey(metaPrefix), rangeCount, args.Timestamp, args.TxnID)
+	kvs, err := r.mvcc.Scan(nextKey, engine.PrefixEndKey(metaPrefix), rangeCount, args.Timestamp, args.Txn)
 	if err != nil {
 		reply.SetGoError(err)
 		return
@@ -724,7 +724,7 @@ func (r *Range) InternalHeartbeatTxn(args *proto.InternalHeartbeatTxnRequest, re
 			return
 		}
 	}
-	reply.Txn = txn
+	reply.Txn = &txn
 }
 
 // InternalResolveIntent updates the transaction status and heartbeat
@@ -732,7 +732,7 @@ func (r *Range) InternalHeartbeatTxn(args *proto.InternalHeartbeatTxnRequest, re
 // coordinator.  The range will return the current status for this
 // transaction to the coordinator.
 func (r *Range) InternalResolveIntent(args *proto.InternalResolveIntentRequest, reply *proto.InternalResolveIntentResponse) {
-	reply.SetGoError(r.mvcc.ResolveWriteIntent(args.Key, args.TxnID, args.Commit))
+	reply.SetGoError(r.mvcc.ResolveWriteIntent(args.Key, args.Txn, args.Commit))
 }
 
 // createSnapshot creates a new snapshot, named using an internal counter.

--- a/storage/range_test.go
+++ b/storage/range_test.go
@@ -19,7 +19,6 @@ package storage
 
 import (
 	"bytes"
-	"fmt"
 	"reflect"
 	"sync"
 	"sync/atomic"
@@ -538,7 +537,6 @@ func TestRangeSnapshot(t *testing.T) {
 	snapshotID := iscReply.SnapshotId
 	expectedKey := encoding.EncodeBinary(nil, key1)
 	expectedVal := getSerializedMVCCValue(&proto.Value{Bytes: val1})
-	fmt.Println(iscReply)
 	if len(iscReply.Rows) != 4 ||
 		!bytes.Equal(iscReply.Rows[0].Key, expectedKey) ||
 		!bytes.Equal(iscReply.Rows[1].Value, expectedVal) {


### PR DESCRIPTION
Move from dealing with just transaction ID to using the full transaction
struct in write intents and in request / response headers.

Cleaned up some code in MVCC that was unnecessarily complex and introduced
concept of transaction epochs for Put() and for ResolveIntent(). Transaction
epochs start at 0 and are incremented every time a transaction is retried.
Transactions are retried (instead of aborted) in the event that a value is
encountered within the "window of uncertainty" between RequestHeader.Timestamp
and RequestHeader.MaxTimestamp, or in the case of an SSI transaction, if
the final transaction timestamp is not equal to the initial transaction
timestamp.

Typically, when a transaction has to restart, it covers all of the same
keys on writes and increments the intents' epochs accordingly. However,
if there's conditional logic in the transaction, it might end up skipping
some keys which were written the previous run--those earlier intents should
then not be committed when the intents are resolved after txn commit.
