### PR TITLE
Some additional renames in timestamp cache and also a fix to not cache

### DIFF
--- a/storage/timestamp_cache_test.go
+++ b/storage/timestamp_cache_test.go
@@ -33,63 +33,68 @@ func TestTimestampCache(t *testing.T) {
 	manual := hlc.ManualClock(0)
 	clock := hlc.NewClock(manual.UnixNano)
 	clock.SetMaxDrift(maxClockSkew)
-	rtc := NewTimestampCache(clock)
+	tc := NewTimestampCache(clock)
 
 	// First simulate a read of just "a" at time 0.
-	rtc.Add(engine.Key("a"), nil, clock.Now())
+	tc.Add(engine.Key("a"), nil, clock.Now())
+	// Although we added "a" at time 0, the internal cache should still
+	// be empty because the t=0 < highWater.
+	if tc.cache.Len() > 0 {
+		t.Errorf("expected cache to be empty, but contains %d elements", tc.cache.Len())
+	}
 	// Verify GetMax returns the highWater mark which is maxClockSkew.
-	if rtc.GetMax(engine.Key("a"), nil).WallTime != maxClockSkew.Nanoseconds() {
+	if tc.GetMax(engine.Key("a"), nil).WallTime != maxClockSkew.Nanoseconds() {
 		t.Error("expected maxClockSkew for key \"a\"")
 	}
-	if rtc.GetMax(engine.Key("notincache"), nil).WallTime != maxClockSkew.Nanoseconds() {
+	if tc.GetMax(engine.Key("notincache"), nil).WallTime != maxClockSkew.Nanoseconds() {
 		t.Error("expected maxClockSkew for key \"notincache\"")
 	}
 
 	// Advance the clock and verify same high water mark.
 	manual = hlc.ManualClock(maxClockSkew.Nanoseconds() + 1)
-	if rtc.GetMax(engine.Key("a"), nil).WallTime != maxClockSkew.Nanoseconds() {
+	if tc.GetMax(engine.Key("a"), nil).WallTime != maxClockSkew.Nanoseconds() {
 		t.Error("expected maxClockSkew for key \"a\"")
 	}
-	if rtc.GetMax(engine.Key("notincache"), nil).WallTime != maxClockSkew.Nanoseconds() {
+	if tc.GetMax(engine.Key("notincache"), nil).WallTime != maxClockSkew.Nanoseconds() {
 		t.Error("expected maxClockSkew for key \"notincache\"")
 	}
 
 	// Sim a read of "b"-"c" at time maxClockSkew + 1.
 	ts := clock.Now()
-	rtc.Add(engine.Key("b"), engine.Key("c"), ts)
+	tc.Add(engine.Key("b"), engine.Key("c"), ts)
 
 	// Verify all permutations of direct and range access.
-	if !rtc.GetMax(engine.Key("b"), nil).Equal(ts) {
-		t.Errorf("expected current time for key \"b\"; got %+v", rtc.GetMax(engine.Key("b"), nil))
+	if !tc.GetMax(engine.Key("b"), nil).Equal(ts) {
+		t.Errorf("expected current time for key \"b\"; got %+v", tc.GetMax(engine.Key("b"), nil))
 	}
-	if !rtc.GetMax(engine.Key("bb"), nil).Equal(ts) {
+	if !tc.GetMax(engine.Key("bb"), nil).Equal(ts) {
 		t.Error("expected current time for key \"bb\"")
 	}
-	if rtc.GetMax(engine.Key("c"), nil).WallTime != maxClockSkew.Nanoseconds() {
+	if tc.GetMax(engine.Key("c"), nil).WallTime != maxClockSkew.Nanoseconds() {
 		t.Error("expected maxClockSkew for key \"c\"")
 	}
-	if !rtc.GetMax(engine.Key("b"), engine.Key("c")).Equal(ts) {
+	if !tc.GetMax(engine.Key("b"), engine.Key("c")).Equal(ts) {
 		t.Error("expected current time for key \"b\"-\"c\"")
 	}
-	if !rtc.GetMax(engine.Key("bb"), engine.Key("bz")).Equal(ts) {
+	if !tc.GetMax(engine.Key("bb"), engine.Key("bz")).Equal(ts) {
 		t.Error("expected current time for key \"bb\"-\"bz\"")
 	}
-	if rtc.GetMax(engine.Key("a"), engine.Key("b")).WallTime != maxClockSkew.Nanoseconds() {
+	if tc.GetMax(engine.Key("a"), engine.Key("b")).WallTime != maxClockSkew.Nanoseconds() {
 		t.Error("expected maxClockSkew for key \"a\"-\"b\"")
 	}
-	if !rtc.GetMax(engine.Key("a"), engine.Key("bb")).Equal(ts) {
+	if !tc.GetMax(engine.Key("a"), engine.Key("bb")).Equal(ts) {
 		t.Error("expected current time for key \"a\"-\"bb\"")
 	}
-	if !rtc.GetMax(engine.Key("a"), engine.Key("d")).Equal(ts) {
+	if !tc.GetMax(engine.Key("a"), engine.Key("d")).Equal(ts) {
 		t.Error("expected current time for key \"a\"-\"d\"")
 	}
-	if !rtc.GetMax(engine.Key("bz"), engine.Key("c")).Equal(ts) {
+	if !tc.GetMax(engine.Key("bz"), engine.Key("c")).Equal(ts) {
 		t.Error("expected current time for key \"bz\"-\"c\"")
 	}
-	if !rtc.GetMax(engine.Key("bz"), engine.Key("d")).Equal(ts) {
+	if !tc.GetMax(engine.Key("bz"), engine.Key("d")).Equal(ts) {
 		t.Error("expected current time for key \"bz\"-\"d\"")
 	}
-	if rtc.GetMax(engine.Key("c"), engine.Key("d")).WallTime != maxClockSkew.Nanoseconds() {
+	if tc.GetMax(engine.Key("c"), engine.Key("d")).WallTime != maxClockSkew.Nanoseconds() {
 		t.Error("expected maxClockSkew for key \"c\"-\"d\"")
 	}
 }
@@ -100,20 +105,20 @@ func TestTimestampCacheEviction(t *testing.T) {
 	manual := hlc.ManualClock(0)
 	clock := hlc.NewClock(manual.UnixNano)
 	clock.SetMaxDrift(maxClockSkew)
-	rtc := NewTimestampCache(clock)
+	tc := NewTimestampCache(clock)
 
 	// Increment time to the maxClockSkew high water mark + 1.
 	manual = hlc.ManualClock(maxClockSkew.Nanoseconds() + 1)
 	aTS := clock.Now()
-	rtc.Add(engine.Key("a"), nil, aTS)
+	tc.Add(engine.Key("a"), nil, aTS)
 
 	// Increment time by the minCacheWindow and add another key.
 	manual = hlc.ManualClock(int64(manual) + minCacheWindow.Nanoseconds())
-	rtc.Add(engine.Key("b"), nil, clock.Now())
+	tc.Add(engine.Key("b"), nil, clock.Now())
 
 	// Verify looking up key "c" returns the new high water mark ("a"'s timestamp).
-	if !rtc.GetMax(engine.Key("c"), nil).Equal(aTS) {
-		t.Errorf("expected high water mark %+v, got %+v", aTS, rtc.GetMax(engine.Key("c"), nil))
+	if !tc.GetMax(engine.Key("c"), nil).Equal(aTS) {
+		t.Errorf("expected high water mark %+v, got %+v", aTS, tc.GetMax(engine.Key("c"), nil))
 	}
 }
 
@@ -124,47 +129,47 @@ func TestTimestampCacheLayeredIntervals(t *testing.T) {
 	manual := hlc.ManualClock(0)
 	clock := hlc.NewClock(manual.UnixNano)
 	clock.SetMaxDrift(maxClockSkew)
-	rtc := NewTimestampCache(clock)
+	tc := NewTimestampCache(clock)
 	manual = hlc.ManualClock(maxClockSkew.Nanoseconds() + 1)
 
 	adTS := clock.Now()
-	rtc.Add(engine.Key("a"), engine.Key("d"), adTS)
+	tc.Add(engine.Key("a"), engine.Key("d"), adTS)
 
 	beTS := clock.Now()
-	rtc.Add(engine.Key("b"), engine.Key("e"), beTS)
+	tc.Add(engine.Key("b"), engine.Key("e"), beTS)
 
 	cTS := clock.Now()
-	rtc.Add(engine.Key("c"), nil, cTS)
+	tc.Add(engine.Key("c"), nil, cTS)
 
 	// Try different sub ranges.
-	if !rtc.GetMax(engine.Key("a"), nil).Equal(adTS) {
+	if !tc.GetMax(engine.Key("a"), nil).Equal(adTS) {
 		t.Error("expected \"a\" to have adTS timestamp")
 	}
-	if !rtc.GetMax(engine.Key("b"), nil).Equal(beTS) {
+	if !tc.GetMax(engine.Key("b"), nil).Equal(beTS) {
 		t.Error("expected \"b\" to have beTS timestamp")
 	}
-	if !rtc.GetMax(engine.Key("c"), nil).Equal(cTS) {
+	if !tc.GetMax(engine.Key("c"), nil).Equal(cTS) {
 		t.Error("expected \"b\" to have cTS timestamp")
 	}
-	if !rtc.GetMax(engine.Key("d"), nil).Equal(beTS) {
+	if !tc.GetMax(engine.Key("d"), nil).Equal(beTS) {
 		t.Error("expected \"d\" to have beTS timestamp")
 	}
-	if !rtc.GetMax(engine.Key("a"), engine.Key("b")).Equal(adTS) {
+	if !tc.GetMax(engine.Key("a"), engine.Key("b")).Equal(adTS) {
 		t.Error("expected \"a\"-\"b\" to have adTS timestamp")
 	}
-	if !rtc.GetMax(engine.Key("a"), engine.Key("c")).Equal(beTS) {
+	if !tc.GetMax(engine.Key("a"), engine.Key("c")).Equal(beTS) {
 		t.Error("expected \"a\"-\"c\" to have beTS timestamp")
 	}
-	if !rtc.GetMax(engine.Key("a"), engine.Key("d")).Equal(cTS) {
+	if !tc.GetMax(engine.Key("a"), engine.Key("d")).Equal(cTS) {
 		t.Error("expected \"a\"-\"d\" to have cTS timestamp")
 	}
-	if !rtc.GetMax(engine.Key("b"), engine.Key("d")).Equal(cTS) {
+	if !tc.GetMax(engine.Key("b"), engine.Key("d")).Equal(cTS) {
 		t.Error("expected \"b\"-\"d\" to have cTS timestamp")
 	}
-	if !rtc.GetMax(engine.Key("c"), engine.Key("d")).Equal(cTS) {
+	if !tc.GetMax(engine.Key("c"), engine.Key("d")).Equal(cTS) {
 		t.Error("expected \"c\"-\"d\" to have cTS timestamp")
 	}
-	if !rtc.GetMax(engine.Key("c0"), engine.Key("d")).Equal(beTS) {
+	if !tc.GetMax(engine.Key("c0"), engine.Key("d")).Equal(beTS) {
 		t.Error("expected \"c0\"-\"d\" to have beTS timestamp")
 	}
 }
@@ -173,21 +178,21 @@ func TestTimestampCacheClear(t *testing.T) {
 	manual := hlc.ManualClock(0)
 	clock := hlc.NewClock(manual.UnixNano)
 	clock.SetMaxDrift(maxClockSkew)
-	rtc := NewTimestampCache(clock)
+	tc := NewTimestampCache(clock)
 
 	// Increment time to the maxClockSkew high water mark + 1.
 	manual = hlc.ManualClock(maxClockSkew.Nanoseconds() + 1)
 	ts := clock.Now()
-	rtc.Add(engine.Key("a"), nil, ts)
+	tc.Add(engine.Key("a"), nil, ts)
 
 	// Clear the cache, which will reset the high water mark to
 	// the current time + maxClockSkew.
-	rtc.Clear(clock)
+	tc.Clear(clock)
 
 	// Fetching any keys should give current time + maxClockSkew
 	expTS := clock.Timestamp()
 	expTS.WallTime += maxClockSkew.Nanoseconds()
-	if !rtc.GetMax(engine.Key("a"), nil).Equal(expTS) {
+	if !tc.GetMax(engine.Key("a"), nil).Equal(expTS) {
 		t.Error("expected \"a\" to have cleared timestamp")
 	}
 }


### PR DESCRIPTION
timestamps earlier than the high water mark. This doesn't affect
correctness, just is slightly more efficient. No need to cache old
timestamps (e.g. from historical reads).
