### PR TITLE
Implement and unittest EndTransaction.

### DIFF
--- a/TODO
+++ b/TODO
@@ -18,34 +18,11 @@
 
 * Transactions
 
-  - Transaction ID: generated via allocation of block of transaction
-    IDs. Suggested transaction struct:
-
-    type IsolationType int
-
-    const (
-      SERIALIZABLE IsolationType = iota
-      SNAPSHOT     IsolationType
-    )
-
-    type Transaction struct {
-      ID           int64
-      Priority     int32
-      Isolation    IsolationType
-      Epoch        int32       // incremented on txn retry
-      Timestamp    HLTimestamp // 0 to use timestamp at destination
-      MaxTimestamp HLTimestamp // Timestamp + clock skew; set to Timestamp for historical read
-    }
-
   - Generate random priority, pick candidate timestamp.
 
   - Modified ops:
 
     - Get: logic to support clock skew uncertainty and concurrency.
-
-      If Timestamp on transaction is 0, assign current node's wall
-      clock as Timestamp and MaxTimestamp. This timestamp is returned
-      via the ResponseHeader.
 
       Simple, common case: if most recent timestamp for key is less
       than Timestamp and committed, read value.
@@ -74,39 +51,14 @@
 
     - Put: additions to support intent marker.
 
-      If entry doesn't exist, or does exist and is not an intent and
-      has earlier timestamp than Timestamp, add new put value with
-      intent set to true.
-
-      If entry exists, is committed, but has later timestamp, write
-      put intent with existing timestamp + 1 (this new timestamp is
-      returned with response and becomes the new Timestamp for the txn).
-
       If entry exists but is intent:
 
-        - If intent is owned by this txn, continue; update txn settings
-          for intent, including new Epoch, Priority and Timestamp.
-
-        - Otherwise, if intent owned by another txn, try to push
-          transaction (with "Abort"=true). If result of push is
-          already-committed or aborted, resolve the existing intent
-          and retry put. If push succeeds (meaning the other txn is
-          aborted), delete existing intent and write new intent. If
-          push fails, backoff and retry the transaction.
-
-      If read-timestamp-cache has an entry for the key with a later
-      timestamp, write put intent with read timestamp + 1 (the read
-      timestamp becomes the new Timestamp for the txn).
-
-      TODO(spencer): split this logic up into what happens before raft
-      log write and what happens when raft command is executed.
-
-    - Resolve: clear a key's intent status.
-
-      Either marks a put intent as committed or aborted. On abort the
-      put intent is deleted. The resolve method takes the Txn record
-      which includes the Epoch of the txn. If the Epoch doesn't match,
-      a committed txn will still delete the put intent.
+        - If intent owned by another txn, try to push transaction
+          (with "Abort"=true). If result of push is already-committed
+          or aborted, resolve the existing intent and retry put. If
+          push succeeds (meaning the other txn is aborted), delete
+          existing intent and write new intent. If push fails, backoff
+          and retry the transaction.
 
     New operations on transaction table rows:
 
@@ -142,39 +94,6 @@
       type PushTransactionResponse struct {
         ResponseHeader
       }
-
-    - AbortTransaction: called on transaction abort from client
-      connection.
-
-      If txn isn't yet recorded or alive but not committed, add
-      aborted entry. If txn is committed, returns already-committed
-      error.
-
-    - CommitTransaction: called on final commit from client connection.
-
-      If txn isn't yet recorded, or is alive but not committed:
-
-        - If isolation is snapshot: adds committed entry and returns
-          final timestamp, which is the max of any pushed timestamp
-          and the txn's Timestamp.
-
-        - If isolation is serializable: if there is a pushed timestamp
-          which is greater than the txn's Timestamp, txn must retry;
-          returns retry-txn error. If there is no entry or pushed
-          timestamp is <= txn's Timestamp, adds committed entry.
-
-      If txn aborted, returns already-aborted error. If already
-      committed, returns already-committed error.
-
-  - Transaction coordinator must continually heartbeat the transaction
-    table in order to update liveness of txn. On a PushTransaction,
-    the pusher will always succeed if the pushee has not heartbeat the
-    txn table entry within the allotted timeout.
-
-  - On transaction retry, coordinator checks the txn table to verify
-    txn has not been aborted before proceeding.
-
-  - On transaction conclusion, resolve all known intents.
 
 
 * StoreFinder using Gossip protocol to filter

--- a/kv/db.go
+++ b/kv/db.go
@@ -166,12 +166,12 @@ func (db *DB) EndTransaction(args *proto.EndTransactionRequest) <-chan *proto.En
 		// depending on final state.
 		reply := <-interceptChan
 		if reply.Error == nil {
-			switch reply.Status {
+			switch reply.Txn.Status {
 			case proto.COMMITTED:
-				db.coordinator.EndTxn(args.Header().Txn.ID, true)
+				db.coordinator.EndTxn(reply.Txn, true)
 				return
 			case proto.ABORTED:
-				db.coordinator.EndTxn(args.Header().Txn.ID, false)
+				db.coordinator.EndTxn(reply.Txn, false)
 				return
 			}
 		}

--- a/proto/api.go
+++ b/proto/api.go
@@ -70,6 +70,10 @@ func (rh *ResponseHeader) GoError() error {
 		return rh.Error.RangeNotFound
 	case rh.Error.RangeKeyMismatch != nil:
 		return rh.Error.RangeKeyMismatch
+	case rh.Error.TransactionStatus != nil:
+		return rh.Error.TransactionStatus
+	case rh.Error.TransactionRetry != nil:
+		return rh.Error.TransactionRetry
 	default:
 		return nil
 	}
@@ -89,6 +93,10 @@ func (rh *ResponseHeader) SetGoError(err error) {
 		rh.Error = &Error{RangeNotFound: t}
 	case *RangeKeyMismatchError:
 		rh.Error = &Error{RangeKeyMismatch: t}
+	case *TransactionStatusError:
+		rh.Error = &Error{TransactionStatus: t}
+	case *TransactionRetryError:
+		rh.Error = &Error{TransactionRetry: t}
 	default:
 		var canRetry bool
 		if r, ok := err.(util.Retryable); ok {

--- a/proto/api.proto
+++ b/proto/api.proto
@@ -236,19 +236,17 @@ message EndTransactionRequest {
 }
 
 // An EndTransactionResponse is the return value from the
-// EndTransaction() method. Status specifies the final status of the
-// transaction. CommitTimestamp specifies the timestamp at which the
-// transaction is committed (all values written during the txn will
-// have this timestamp). CommitWait specifies the commit wait, which
-// is the remaining time the client MUST wait before signalling
-// completion of the transaction to another distributed node to
-// maintain consistency.
+// EndTransaction() method. If successful, the final transaction
+// record is returned. In particular, transaction status and timestamp
+// will be updated to reflect final committed values. CommitWait
+// specifies the commit wait, which is the remaining time the client
+// MUST wait before signalling completion of the transaction to
+// another distributed node to maintain consistency.
 message EndTransactionResponse {
   optional ResponseHeader header = 1 [(gogoproto.nullable) = false, (gogoproto.embed) = true];
-  optional TransactionStatus status = 2 [(gogoproto.nullable) = false];
-  optional Timestamp commit_timestamp = 3 [(gogoproto.nullable) = false];
-  // Remaining with (us).
-  optional int64 commit_wait = 4 [(gogoproto.nullable) = false];
+  optional Transaction txn = 2;
+  // Remaining time (ns).
+  optional int64 commit_wait = 3 [(gogoproto.nullable) = false];
 }
 
 // An AccumulateTSRequest is arguments to the AccumulateTS() method.

--- a/proto/data.proto
+++ b/proto/data.proto
@@ -138,7 +138,7 @@ message Transaction {
   // retry error.
   optional Timestamp max_timestamp = 7 [(gogoproto.nullable) = false];
   // The last hearbeat timestamp.
-  optional Timestamp last_heartbeat = 8 [(gogoproto.nullable) = false];
+  optional Timestamp last_heartbeat = 8;
 }
 
 // MVCCMetadata holds MVCC metadata for a key. Used by storage/engine/mvcc.go.

--- a/proto/errors.go
+++ b/proto/errors.go
@@ -72,3 +72,31 @@ func (e *RangeKeyMismatchError) Error() string {
 func (e *RangeKeyMismatchError) CanRetry() bool {
 	return true
 }
+
+// NewTransactionStatusError initializes a new TransactionStatusError.
+func NewTransactionStatusError(txn *Transaction, msg string) *TransactionStatusError {
+	return &TransactionStatusError{
+		Txn: *txn,
+		Msg: msg,
+	}
+}
+
+// Error formats error.
+func (e *TransactionStatusError) Error() string {
+	return fmt.Sprintf("txn %+v: %s", e.Txn, e.Msg)
+}
+
+// NewTransactionRetryError initializes a new TransactionRetryError.
+func NewTransactionRetryError(txn *Transaction) *TransactionRetryError {
+	return &TransactionRetryError{Txn: *txn}
+}
+
+// Error formats error.
+func (e *TransactionRetryError) Error() string {
+	return fmt.Sprintf("retry txn: %+v", e.Txn)
+}
+
+// CanRetry indicates whether or not this TransactionRetryError can be retried.
+func (e *TransactionRetryError) CanRetry() bool {
+	return true
+}

--- a/proto/errors.proto
+++ b/proto/errors.proto
@@ -18,6 +18,7 @@
 package proto;
 
 import "config.proto";
+import "data.proto";
 import "code.google.com/p/gogoprotobuf/gogoproto/gogo.proto";
 
 // A GenericError is a generic representation of a go error including
@@ -47,11 +48,31 @@ message RangeKeyMismatchError {
   optional RangeMetadata range = 3 [(gogoproto.nullable) = false];
 }
 
-// Error is a union type containing all available errors.  message and
-// whether or not the error is retryable.
+// TransactionStatusError indicates that the transaction status is
+// incompatible with the requested operation. This means the
+// transaction has already either been committed or aborted. It might
+// also be the case that the request to modify the transaction failed
+// due to a regression in transaction epoch or timestamp, both of
+// which may only monotonically increase.
+message TransactionStatusError {
+  optional Transaction txn = 1 [(gogoproto.nullable) = false];
+  optional string msg = 2 [(gogoproto.nullable) = false];
+}
+
+// TransactionRetryError indicates that the transaction must be
+// retried, usually with an increased transaction timestamp. The
+// transaction struct to use is returned with the error.
+message TransactionRetryError {
+  optional Transaction txn = 1 [(gogoproto.nullable) = false];
+}
+
+// Error is a union type containing all available errors.
+// NOTE: new error types must be added here.
 message Error {
   optional GenericError generic = 1;
   optional NotLeaderError not_leader = 2;
   optional RangeNotFoundError range_not_found = 3;
   optional RangeKeyMismatchError range_key_mismatch = 4;
+  optional TransactionStatusError transaction_status = 5;
+  optional TransactionRetryError transaction_retry = 6;
 }

--- a/storage/store.go
+++ b/storage/store.go
@@ -285,10 +285,9 @@ func (s *Store) ExecuteCmd(method string, args proto.Request, reply proto.Respon
 	// If the request has a zero timestamp, initialize to this node's clock.
 	header := args.Header()
 	if header.Timestamp.WallTime == 0 && header.Timestamp.Logical == 0 {
-		// Update both incoming and outgoing timestamps.
+		// Update the incoming timestamp.
 		now := s.clock.Now()
 		args.Header().Timestamp = now
-		reply.Header().Timestamp = now
 	} else {
 		// Otherwise, update our clock with the incoming request. This
 		// advances the local node's clock to a high water mark from
@@ -317,7 +316,6 @@ func (s *Store) ExecuteCmd(method string, args proto.Request, reply proto.Respon
 	if IsReadOnly(method) {
 		return rng.ReadOnlyCmd(method, args, reply)
 	}
-
 	return rng.ReadWriteCmd(method, args, reply)
 }
 


### PR DESCRIPTION
Added an implementation for EndTransaction which attempts to move a
transaction from PENDING to either COMMITTED or ABORTED depending on
the EndTransactionRequest.Commit argument. Various error conditions
may result, including the txn already being committed or aborted,
Epoch or timestamp regressions, or transaction retry on SSI txns
in the event that the commit timestamp is different from the transaction
timestamp.
