### PR TITLE
Improving kv test coverage

### DIFF
--- a/gossip/info.go
+++ b/gossip/info.go
@@ -29,7 +29,7 @@ import (
 // network.
 type info struct {
 	Key string // Info key
-	// Info value: must be one of {int65, float64, string} or
+	// Info value: must be one of {int64, float64, string} or
 	// implement the util.Ordered interface to be used with groups.
 	// For single infos any type is allowed.
 	Val       interface{}

--- a/kv/dist_kv_test.go
+++ b/kv/dist_kv_test.go
@@ -1,0 +1,160 @@
+// Copyright 2014 The Cockroach Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+// implied. See the License for the specific language governing
+// permissions and limitations under the License. See the AUTHORS file
+// for names of contributors.
+//
+// Author: Kathy Spradlin (kathyspradlin@gmail.com)
+
+package kv
+
+import (
+	"bytes"
+	"testing"
+	"time"
+
+	"github.com/cockroachdb/cockroach/gossip"
+	"github.com/cockroachdb/cockroach/proto"
+	"github.com/cockroachdb/cockroach/storage"
+	"github.com/cockroachdb/cockroach/storage/engine"
+)
+
+func TestGetFirstRangeDescriptor(t *testing.T) {
+	n := gossip.NewSimulationNetwork(3, "unix", gossip.DefaultTestGossipInterval)
+	kv := NewDistKV(n.Nodes[0].Gossip)
+	if _, err := kv.getFirstRangeDescriptor(); err == nil {
+		t.Errorf("expected not to find first range descriptor")
+	}
+	expectedDesc := &proto.RangeDescriptor{}
+	expectedDesc.StartKey = engine.Key("a")
+	expectedDesc.EndKey = engine.Key("c")
+
+	// Add first RangeDescriptor to a node different from the node for this kv
+	// and ensure that this kv has the information within a given time.
+	n.Nodes[1].Gossip.AddInfo(
+		gossip.KeyFirstRangeMetadata, *expectedDesc, time.Hour)
+	maxCycles := 10
+	n.SimulateNetwork(func(cycle int, network *gossip.SimulationNetwork) bool {
+		desc, err := kv.getFirstRangeDescriptor()
+		if err != nil {
+			if cycle >= maxCycles {
+				t.Errorf("could not get range descriptor after %d cycles", cycle)
+				return false
+			}
+			return true
+		}
+		if !bytes.Equal(desc.StartKey, expectedDesc.StartKey) ||
+			!bytes.Equal(desc.EndKey, expectedDesc.EndKey) {
+			t.Errorf("expected first range descriptor %v, instead was %v",
+				expectedDesc, desc)
+		}
+		return false
+	})
+	n.Stop()
+}
+
+func TestVerifyPermissions(t *testing.T) {
+	n := gossip.NewSimulationNetwork(1, "unix", gossip.DefaultTestGossipInterval)
+	kv := NewDistKV(n.Nodes[0].Gossip)
+	config1 := &proto.PermConfig{
+		Read:  []string{"read1", "readAll", "rw", "rwAll"},
+		Write: []string{"write1", "writeAll", "rw", "rwAll"}}
+	config2 := &proto.PermConfig{
+		Read:  []string{"read2", "readAll", "rw2", "rwAll"},
+		Write: []string{"write2", "writeAll", "rw2", "rwAll"}}
+	configs := []*storage.PrefixConfig{
+		{engine.KeyMin, nil, config1},
+		{engine.Key("a"), nil, config2},
+	}
+	configMap, err := storage.NewPrefixConfigMap(configs)
+	if err != nil {
+		t.Fatalf("failed to make prefix config map, err: %s", err.Error())
+	}
+	kv.gossip.AddInfo(gossip.KeyConfigPermission, configMap, time.Hour)
+
+	readMethods := storage.ReadMethods
+	writeMethods := storage.WriteMethods
+	readOnlyMethods := make([]string, 0, len(readMethods))
+	writeOnlyMethods := make([]string, 0, len(writeMethods))
+	readWriteMethods := make([]string, 0, len(readMethods)+len(writeMethods))
+	for _, readM := range readMethods {
+		if storage.IsReadOnly(readM) {
+			readOnlyMethods = append(readOnlyMethods, readM)
+		} else {
+			readWriteMethods = append(readWriteMethods, readM)
+		}
+	}
+	for _, writeM := range writeMethods {
+		if !storage.NeedReadPerm(writeM) {
+			writeOnlyMethods = append(writeOnlyMethods, writeM)
+		}
+	}
+
+	testData := []struct {
+		// Permission-based db methods from the storage package.
+		methods          []string
+		user             string
+		startKey, endKey engine.Key
+		hasPermission    bool
+	}{
+		// Test permissions within a single range
+		{readOnlyMethods, "read1", engine.KeyMin, engine.KeyMin, true},
+		{readOnlyMethods, "rw", engine.KeyMin, engine.KeyMin, true},
+		{readOnlyMethods, "write1", engine.KeyMin, engine.KeyMin, false},
+		{readOnlyMethods, "random", engine.KeyMin, engine.KeyMin, false},
+		{readWriteMethods, "rw", engine.KeyMin, engine.KeyMin, true},
+		{readWriteMethods, "read1", engine.KeyMin, engine.KeyMin, false},
+		{readWriteMethods, "write1", engine.KeyMin, engine.KeyMin, false},
+		{writeOnlyMethods, "write1", engine.KeyMin, engine.KeyMin, true},
+		{writeOnlyMethods, "rw", engine.KeyMin, engine.KeyMin, true},
+		{writeOnlyMethods, "read1", engine.KeyMin, engine.KeyMin, false},
+		{writeOnlyMethods, "random", engine.KeyMin, engine.KeyMin, false},
+		// Test permissions across both ranges
+		{readOnlyMethods, "readAll", engine.KeyMin, engine.Key("b"), true},
+		{readOnlyMethods, "read1", engine.KeyMin, engine.Key("b"), false},
+		{readOnlyMethods, "read2", engine.KeyMin, engine.Key("b"), false},
+		{readOnlyMethods, "random", engine.KeyMin, engine.Key("b"), false},
+		{readWriteMethods, "rwAll", engine.KeyMin, engine.Key("b"), true},
+		{readWriteMethods, "rw", engine.KeyMin, engine.Key("b"), false},
+		{readWriteMethods, "random", engine.KeyMin, engine.Key("b"), false},
+		{writeOnlyMethods, "writeAll", engine.KeyMin, engine.Key("b"), true},
+		{writeOnlyMethods, "write1", engine.KeyMin, engine.Key("b"), false},
+		{writeOnlyMethods, "write2", engine.KeyMin, engine.Key("b"), false},
+		{writeOnlyMethods, "random", engine.KeyMin, engine.Key("b"), false},
+		// Test permissions within and around the boundaries of a range,
+		// representatively using rw methods.
+		{readWriteMethods, "rw2", engine.Key("a"), engine.Key("b"), true},
+		{readWriteMethods, "rwAll", engine.Key("a"), engine.Key("b"), true},
+		{readWriteMethods, "rw2", engine.Key("a"), engine.Key("a"), true},
+		{readWriteMethods, "rw2", engine.Key("a"), engine.Key("a1"), true},
+		{readWriteMethods, "rw2", engine.Key("a"), engine.Key("b1"), false},
+		{readWriteMethods, "rw2", engine.Key("a3"), engine.Key("a4"), true},
+		{readWriteMethods, "rw2", engine.Key("a3"), engine.Key("b1"), false},
+	}
+
+	for _, test := range testData {
+		for _, method := range test.methods {
+			err := kv.verifyPermissions(
+				method,
+				&proto.RequestHeader{
+					User: test.user, Key: test.startKey, EndKey: test.endKey})
+			if err != nil && test.hasPermission {
+				t.Errorf("user: %s should have had permission to %s, err: %s",
+					test.user, method, err.Error())
+			} else if err == nil && !test.hasPermission {
+				t.Errorf("user: %s should not have had permission to %s",
+					test.user, method)
+			}
+		}
+	}
+	n.Stop()
+}

--- a/kv/local_kv_test.go
+++ b/kv/local_kv_test.go
@@ -19,6 +19,7 @@
 package kv
 
 import (
+	"errors"
 	"testing"
 
 	"github.com/cockroachdb/cockroach/proto"
@@ -26,13 +27,86 @@ import (
 	"github.com/cockroachdb/cockroach/storage/engine"
 )
 
+func TestAddStore(t *testing.T) {
+	kv := NewLocalKV()
+	store := storage.Store{}
+	kv.AddStore(&store)
+	if !kv.HasStore(store.Ident.StoreID) {
+		t.Errorf("expected kv to contain storeID=%d", store.Ident.StoreID)
+	}
+	if kv.HasStore(store.Ident.StoreID + 1) {
+		t.Errorf("expected kv to not contain storeID=%d", store.Ident.StoreID+1)
+	}
+}
+
+func TestGetStoreCount(t *testing.T) {
+	kv := NewLocalKV()
+	if kv.GetStoreCount() != 0 {
+		t.Errorf("expected 0 stores in new kv")
+	}
+
+	expectedCount := 10
+	for i := 0; i < expectedCount; i++ {
+		kv.AddStore(&storage.Store{Ident: proto.StoreIdent{StoreID: int32(i)}})
+	}
+	if count := kv.GetStoreCount(); count != expectedCount {
+		t.Errorf("expected store count to be %d but was %d", expectedCount, count)
+	}
+}
+
+func TestVisitStores(t *testing.T) {
+	kv := NewLocalKV()
+	numStores := 10
+	for i := 0; i < numStores; i++ {
+		kv.AddStore(&storage.Store{Ident: proto.StoreIdent{StoreID: int32(i)}})
+	}
+
+	visit := make([]bool, numStores)
+	err := kv.VisitStores(func(s *storage.Store) error { visit[s.Ident.StoreID] = true; return nil })
+	if err != nil {
+		t.Errorf("unexpected error on visit: %s", err.Error())
+	}
+
+	for i, visited := range visit {
+		if !visited {
+			t.Errorf("store %d was not visited", i)
+		}
+	}
+
+	err = kv.VisitStores(func(s *storage.Store) error { return errors.New("") })
+	if err == nil {
+		t.Errorf("expected visit error")
+	}
+}
+
+func TestGetStore(t *testing.T) {
+	kv := NewLocalKV()
+	store := storage.Store{}
+	replica := proto.Replica{StoreID: store.Ident.StoreID}
+	s, err := kv.GetStore(&replica)
+	if s != nil || err == nil {
+		t.Errorf("expected no stores in new local kv.")
+	}
+
+	kv.AddStore(&store)
+	s, err = kv.GetStore(&replica)
+	if s == nil {
+		t.Errorf("expected store")
+	} else if s.Ident.StoreID != store.Ident.StoreID {
+		t.Errorf("expected storeID to be %d but was %d",
+			s.Ident.StoreID, store.Ident.StoreID)
+	} else if err != nil {
+		t.Errorf("expected no error, instead had err=%s", err.Error())
+	}
+}
+
 func TestReplicaLookup(t *testing.T) {
 	kv := NewLocalKV()
 	r1 := addTestRange(kv, engine.KeyMin, engine.Key("C"))
 	r2 := addTestRange(kv, engine.Key("C"), engine.Key("X"))
 	r3 := addTestRange(kv, engine.Key("X"), engine.KeyMax)
 	if len(kv.ranges) != 3 {
-		t.Errorf("Pre-condition failed! Expected ranges to be size 3, got %d", len(kv.ranges))
+		t.Errorf("pre-condition failed-expected ranges to be size 3, got %d", len(kv.ranges))
 	}
 
 	assertReplicaForRange(t, kv.lookupReplica(engine.KeyMin), r1)
@@ -42,15 +116,16 @@ func TestReplicaLookup(t *testing.T) {
 	assertReplicaForRange(t, kv.lookupReplica(engine.Key("X")), r3)
 	assertReplicaForRange(t, kv.lookupReplica(engine.Key("Z")), r3)
 	if kv.lookupReplica(engine.KeyMax) != nil {
-		t.Errorf("Expected engine.KeyMax to not have an associated Replica.")
+		t.Errorf("expected engine.KeyMax to not have an associated Replica")
 	}
 }
 
 func assertReplicaForRange(t *testing.T, repl *proto.Replica, rng *storage.Range) {
 	if repl == nil {
-		t.Errorf("No replica returned!")
+		t.Errorf("no replica returned")
 	} else if repl.RangeID != rng.Meta.RangeID {
-		t.Errorf("Wrong replica returned! Expected %+v and %+v to have the same RangeID", rng.Meta, repl)
+		t.Errorf("wrong replica returned-expected %+v and %+v to have the same RangeID",
+			rng.Meta, repl)
 	}
 }
 

--- a/storage/prefix.go
+++ b/storage/prefix.go
@@ -206,7 +206,9 @@ func (p PrefixConfigMap) VisitPrefixes(start, end engine.Key,
 		return visitor(start, end, p[startIdx-1].Config)
 	}
 	for i := startIdx; i < endIdx; i++ {
-		visitor(start, p[i].Prefix, p[i-1].Config)
+		if err := visitor(start, p[i].Prefix, p[i-1].Config); err != nil {
+			return err
+		}
 		if bytes.Equal(p[i].Prefix, end) {
 			return nil
 		}

--- a/storage/range.go
+++ b/storage/range.go
@@ -120,6 +120,15 @@ var writeMethods = map[string]struct{}{
 	InternalResolveIntent: struct{}{},
 }
 
+// ReadMethods lists the read-only methods supported by a range.
+var ReadMethods = util.MapKeys(readMethods).([]string)
+
+// WriteMethods lists the methods supported by a range which write data.
+var WriteMethods = util.MapKeys(writeMethods).([]string)
+
+// Methods lists all the methods supported by a range.
+var Methods = append(ReadMethods, WriteMethods...)
+
 // NeedReadPerm returns true if the specified method requires read permissions.
 func NeedReadPerm(method string) bool {
 	_, ok := readMethods[method]


### PR DESCRIPTION
- Adds unit tests to kv/local_kv.go and kv/dist_kv.go
- Generalizes gossip network simulation so that it can be used in tests which require gossip networks
- The unit tests for kv/dist_kv found a user permission bug which led to false positives. This is fixed in storage/prefix.go.

I'm brand new to Go, so I would appreciate any advice!
