### PR TITLE
add InternalSplit command & tests

### DIFF
--- a/proto/api.proto
+++ b/proto/api.proto
@@ -429,6 +429,18 @@ message InternalSnapshotCopyResponse {
   repeated RawKeyValue rows = 3 [(gogoproto.nullable) = false];
 }
 
+// An InternalSplitRequest is arguments to the InternalSplit() method.
+message InternalSplitRequest {
+  optional RequestHeader header = 1 [(gogoproto.nullable) = false, (gogoproto.embed) = true];
+  optional bytes split_key = 2 [(gogoproto.nullable) = false];
+}
+
+// An InternalSplitResponse is the return value from the InternalSplit()
+// method.
+message InternalSplitResponse {
+  optional ResponseHeader header = 1 [(gogoproto.nullable) = false, (gogoproto.embed) = true];
+}
+
 // A ReadWriteCmdRequest is a union type containing instances of all
 // mutating commands.
 message ReadWriteCmdRequest {

--- a/server/node.go
+++ b/server/node.go
@@ -130,6 +130,7 @@ func BootstrapCluster(clusterID string, eng engine.Engine) (*kv.DB, error) {
 	if err != nil {
 		return nil, err
 	}
+	rng.Start()
 
 	// Create a KV DB with a local KV to directly modify the new range.
 	localKV := kv.NewLocalKV()


### PR DESCRIPTION
- added a method CopyInto to the response cache, req'd for initializing a new range during a split.
- added an InternalSplit command. Making the split happen without a transitory period in which things can go wrong is subtle so this needs a good review and likely some changes.
- added some basic tests, but the transition should be bulletproofed using more tests eventually.
