### PR TITLE
Implementation of InternalPushTxn operation.

### DIFF
--- a/TODO
+++ b/TODO
@@ -1,24 +1,8 @@
-* Create a new DB type in kv/ which uses a storage.DB implementation,
-  either one of DistDB or LocalDB. The kv.DB deals with coordinator,
-  intercepts, etc.
-
-* Encode basic key value types:
-  - Counter
-  - Bag o' bytes
-  - Error if increment is used on a bag o' bytes
-  - Error if Put/Get used on a counter
-  - Should Scan return counters?
-
 * Construct a base handler for all HTTP servers to glog.Fatal the
   process with a deferred recover func to prevent HTTP from swallowing
   panics which might otherwise be holding locks, etc.
 
-* Add Request/Response interfaces to avoid reflection in getting/setting
-  errors or fetching the Request/Response headers.
-
 * Transactions
-
-  - Generate random priority, pick candidate timestamp.
 
   - Modified ops:
 
@@ -60,42 +44,6 @@
           existing intent and write new intent. If push fails, backoff
           and retry the transaction.
 
-    New operations on transaction table rows:
-
-    - PushTransaction: Moves transaction timestamp forwards.
-
-      If existing txn entry isn't present or its LastHeartbeat
-      timestamp isn't set, use PushTxn.Timestamp as LastHeartbeat.
-      If current time - LastHeartbeat > MaxHeartbeatExpiry, then
-      the existing txn should be either pushed forward or aborted,
-      depending on value of Request.Abort.
-
-      If the txn is committed, return already-committed error. If txn
-      has been aborted, noop and return success.
-
-      Otherwise, Compare PushTxn and Txn priorities:
-
-        - If Txn.Priority < PushTxn.Priority, return retry-txn
-          error. Transaction will be retried with priority =
-          max(random, PushTxn.Priority - 1).
-
-        - If Txn.Priority > PushTxn.Priority, set/add txn entry with
-          new timestamp as max(existing timestamp, push timestamp + 1).
-          If Request.Abort is true, set/add ABORTED txn entry.
-
-      type PushTransactionRequest struct {
-        RequestHeader
-        Key     Key         // derivative of txn table prefix & txn ID
-        Abort   bool        // abort txn on successful push--this is done for puts
-        PushTxn Transaction // from encounted txn intent
-        Txn     Transaction // txn which encountered intent
-      }
-
-      type PushTransactionResponse struct {
-        ResponseHeader
-      }
-
-
 * StoreFinder using Gossip protocol to filter
 
 
@@ -107,12 +55,6 @@
 
     - Need a range-wide "split" intent which blocks all mutating
       ops to range.
-
-  - Copy / split range-local metadata:
-
-    - Write new local range metadata
-
-    - Copy response cache
 
 * Rebalance range replica. Only fully-replicated ranges may be
   rebalanced.
@@ -147,5 +89,3 @@
     from the RangeDescriptor. The store which owns a removed replica
     is responsible for clearing the relevant portion of the key space
     as well as any other housekeeping details.
-
-* Move mvcc + engine files out of storage and into mvcc/

--- a/kv/coordinator_test.go
+++ b/kv/coordinator_test.go
@@ -169,11 +169,12 @@ func TestCoordinatorEndTxn(t *testing.T) {
 	defer db.Close()
 
 	txn := &proto.Transaction{
-		ID: engine.Key("txn"),
+		ID:     engine.Key("txn"),
+		Status: proto.COMMITTED,
 	}
 	<-db.Put(createPutRequest(engine.Key("a"), []byte("value"), txn.ID))
 
-	db.coordinator.EndTxn(txn, true)
+	db.coordinator.EndTxn(txn)
 	if len(db.coordinator.txns) != 0 {
 		t.Errorf("expected empty transactions map; got %d", len(db.coordinator.txns))
 	}

--- a/kv/db.go
+++ b/kv/db.go
@@ -167,7 +167,6 @@ func (db *DB) EndTransaction(args *proto.EndTransactionRequest) <-chan *proto.En
 		reply := <-interceptChan
 		if reply.Error == nil && reply.Txn.Status != proto.PENDING {
 			db.coordinator.EndTxn(reply.Txn)
-			return
 		}
 		// Go ahead and return the result to the client.
 		replyChan <- reply

--- a/proto/api.proto
+++ b/proto/api.proto
@@ -356,7 +356,7 @@ message InternalHeartbeatTxnResponse {
 // method. It's sent by readers or writers which have encountered an
 // "intent" laid down by another transaction. The goal is to resolve
 // the conflict. Note that args.Key should be set to the txn ID of
-// args.PushTxn, not args.Txn, as is usual. This RPC is addressed
+// args.PusheeTxn, not args.Txn, as is usual. This RPC is addressed
 // to the range which owns the pushee's txn record.
 //
 // Resolution is trivial if the txn which owns the intent has either
@@ -367,17 +367,17 @@ message InternalHeartbeatTxnResponse {
 // by comparing priorities.
 message InternalPushTxnRequest {
   optional RequestHeader header = 1 [(gogoproto.nullable) = false, (gogoproto.embed) = true];
-  optional Transaction push_txn = 2 [(gogoproto.nullable) = false];
+  optional Transaction pushee_txn = 2 [(gogoproto.nullable) = false];
   // Set to true to request that the PushTxn be aborted if possible.
-  // This is done in the event of a writer conflicting with PushTxn.
-  // Readers set this to false and instead attempt to move PushTxn's
+  // This is done in the event of a writer conflicting with PusheeTxn.
+  // Readers set this to false and instead attempt to move PusheeTxn's
   // commit timestamp forward.
   optional bool Abort = 3 [(gogoproto.nullable) = false];
 }
 
 // An InternalPushTxnResponse is the return value from the
 // InternalPushTxn() method. It returns success and the resulting
-// state of PushTxn if the conflict was resolved in favor of the
+// state of PusheeTxn if the conflict was resolved in favor of the
 // caller; the caller should subsequently invoke
 // InternalResolveIntent() on the conflicted key. It returns an error
 // otherwise.
@@ -385,7 +385,7 @@ message InternalPushTxnResponse {
   optional ResponseHeader header = 1 [(gogoproto.nullable) = false, (gogoproto.embed) = true];
   // Txn is non-nil if the transaction could be heartbeat and contains
   // the current value of the transaction.
-  optional Transaction push_txn = 2;
+  optional Transaction pushee_txn = 2;
 }
 
 // An InternalResolveIntentRequest is arguments to the

--- a/proto/api.proto
+++ b/proto/api.proto
@@ -239,10 +239,13 @@ message EndTransactionRequest {
 // An EndTransactionResponse is the return value from the
 // EndTransaction() method. If successful, the final transaction
 // record is returned. In particular, transaction status and timestamp
-// will be updated to reflect final committed values. CommitWait
-// specifies the commit wait, which is the remaining time the client
-// MUST wait before signalling completion of the transaction to
-// another distributed node to maintain consistency.
+// will be updated to reflect final committed values. Clients may
+// propagate Txn.Timestamp as the final txn commit timestamp in order
+// to preserve causal ordering between subsequent
+// transactions. CommitWait specifies the commit wait, which is the
+// remaining time the client MUST wait before signalling completion of
+// the transaction to another distributed node to maintain
+// consistency.
 message EndTransactionResponse {
   optional ResponseHeader header = 1 [(gogoproto.nullable) = false, (gogoproto.embed) = true];
   optional Transaction txn = 2;
@@ -329,7 +332,7 @@ message InternalRangeLookupResponse {
 }
 
 // An InternalHeartbeatTxnRequest is arguments to the
-// InternalHeartbeatTxn() method. It is sent by transaction
+// InternalHeartbeatTxn() method. It's sent by transaction
 // coordinators to let the system know that the transaction is still
 // ongoing. Note that this heartbeat message is different from the
 // heartbeat message in the gossip protocol.
@@ -349,14 +352,48 @@ message InternalHeartbeatTxnResponse {
   optional Transaction txn = 2;
 }
 
+// An InternalPushTxnRequest is arguments to the InternalPushTxn()
+// method. It's sent by readers or writers which have encountered an
+// "intent" laid down by another transaction. The goal is to resolve
+// the conflict. Note that args.Key should be set to the txn ID of
+// args.PushTxn, not args.Txn, as is usual. This RPC is addressed
+// to the range which owns the pushee's txn record.
+//
+// Resolution is trivial if the txn which owns the intent has either
+// been committed or aborted already. Otherwise, the existing txn can
+// either be aborted (for write/write conflicts), or its commit
+// timestamp can be moved forward (for read/write conflicts). The
+// course of action is determined by the owning txn's status and also
+// by comparing priorities.
+message InternalPushTxnRequest {
+  optional RequestHeader header = 1 [(gogoproto.nullable) = false, (gogoproto.embed) = true];
+  optional Transaction push_txn = 2 [(gogoproto.nullable) = false];
+  // Set to true to request that the PushTxn be aborted if possible.
+  // This is done in the event of a writer conflicting with PushTxn.
+  // Readers set this to false and instead attempt to move PushTxn's
+  // commit timestamp forward.
+  optional bool Abort = 3 [(gogoproto.nullable) = false];
+}
+
+// An InternalPushTxnResponse is the return value from the
+// InternalPushTxn() method. It returns success and the resulting
+// state of PushTxn if the conflict was resolved in favor of the
+// caller; the caller should subsequently invoke
+// InternalResolveIntent() on the conflicted key. It returns an error
+// otherwise.
+message InternalPushTxnResponse {
+  optional ResponseHeader header = 1 [(gogoproto.nullable) = false, (gogoproto.embed) = true];
+  // Txn is non-nil if the transaction could be heartbeat and contains
+  // the current value of the transaction.
+  optional Transaction push_txn = 2;
+}
+
 // An InternalResolveIntentRequest is arguments to the
 // InternalResolveIntent() method. It is sent by transaction
-// coordinators to clean up write intents: either to remove them or
-// commit them.
+// coordinators and after success calling InternalPushTxn to clean up
+// write intents: either to remove them or commit them.
 message InternalResolveIntentRequest {
   optional RequestHeader header = 1 [(gogoproto.nullable) = false, (gogoproto.embed) = true];
-  // True to commit, false to remove.
-  optional bool commit = 2 [(gogoproto.nullable) = false];
 }
 
 // An InternalResolveIntentResponse is the return value from the
@@ -402,7 +439,8 @@ message ReadWriteCmdRequest {
   optional EnqueueUpdateRequest enqueue_update = 10;
   optional EnqueueMessageRequest enqueue_message = 11;
   optional InternalHeartbeatTxnRequest internal_heartbeat_txn = 12;
-  optional InternalResolveIntentRequest internal_resolve_intent = 13;
+  optional InternalPushTxnRequest internal_push_txn = 13;
+  optional InternalResolveIntentRequest internal_resolve_intent = 14;
 }
 
 // A ReadWriteCmdResponse is a union type containing instances of all
@@ -421,5 +459,6 @@ message ReadWriteCmdResponse {
   optional EnqueueUpdateResponse enqueue_update = 10;
   optional EnqueueMessageResponse enqueue_message = 11;
   optional InternalHeartbeatTxnResponse internal_heartbeat_txn = 12;
-  optional InternalResolveIntentResponse internal_resolve_intent = 13;
+  optional InternalPushTxnResponse internal_push_txn = 13;
+  optional InternalResolveIntentResponse internal_resolve_intent = 14;
 }

--- a/proto/data.proto
+++ b/proto/data.proto
@@ -96,7 +96,7 @@ enum IsolationType {
   SNAPSHOT = 1;
 }
 
-// TransactionStatus TODO(jiajia) Needs documentation.
+// TransactionStatus specifies possible states for a transaction.
 enum TransactionStatus {
   option (gogoproto.goproto_enum_prefix) = false;
   // PENDING is the default state for a new transaction. Transactions

--- a/server/node.go
+++ b/server/node.go
@@ -491,6 +491,11 @@ func (n *Node) InternalHeartbeatTxn(args *proto.InternalHeartbeatTxnRequest, rep
 	return n.executeCmd(storage.InternalHeartbeatTxn, args, reply)
 }
 
+// InternalPushTxn .
+func (n *Node) InternalPushTxn(args *proto.InternalPushTxnRequest, reply *proto.InternalPushTxnResponse) error {
+	return n.executeCmd(storage.InternalPushTxn, args, reply)
+}
+
 // InternalResolveIntent .
 func (n *Node) InternalResolveIntent(args *proto.InternalResolveIntentRequest, reply *proto.InternalResolveIntentResponse) error {
 	return n.executeCmd(storage.InternalResolveIntent, args, reply)

--- a/storage/db.go
+++ b/storage/db.go
@@ -51,6 +51,7 @@ type DB interface {
 	EnqueueUpdate(args *proto.EnqueueUpdateRequest) <-chan *proto.EnqueueUpdateResponse
 	EnqueueMessage(args *proto.EnqueueMessageRequest) <-chan *proto.EnqueueMessageResponse
 	InternalHeartbeatTxn(args *proto.InternalHeartbeatTxnRequest) <-chan *proto.InternalHeartbeatTxnResponse
+	InternalPushTxn(args *proto.InternalPushTxnRequest) <-chan *proto.InternalPushTxnResponse
 	InternalResolveIntent(args *proto.InternalResolveIntentRequest) <-chan *proto.InternalResolveIntentResponse
 	InternalSnapshotCopy(args *proto.InternalSnapshotCopyRequest) <-chan *proto.InternalSnapshotCopyResponse
 }

--- a/storage/db_test.go
+++ b/storage/db_test.go
@@ -145,6 +145,12 @@ func (db *testDB) InternalHeartbeatTxn(args *proto.InternalHeartbeatTxnRequest) 
 	return replyChan
 }
 
+func (db *testDB) InternalPushTxn(args *proto.InternalPushTxnRequest) <-chan *proto.InternalPushTxnResponse {
+	replyChan := make(chan *proto.InternalPushTxnResponse, 1)
+	go db.executeCmd(InternalPushTxn, args, replyChan)
+	return replyChan
+}
+
 func (db *testDB) InternalResolveIntent(args *proto.InternalResolveIntentRequest) <-chan *proto.InternalResolveIntentResponse {
 	replyChan := make(chan *proto.InternalResolveIntentResponse, 1)
 	go db.executeCmd(InternalResolveIntent, args, replyChan)

--- a/storage/range.go
+++ b/storage/range.go
@@ -49,13 +49,22 @@ func init() {
 	gob.Register(proto.Transaction{})
 }
 
-// ttlClusterIDGossip is time-to-live for cluster ID. The cluster ID
-// serves as the sentinel gossip key which informs a node whether or
-// not it's connected to the primary gossip network and not just a
-// partition. As such it must expire on a reasonable basis and be
-// continually re-gossipped. The replica which is the raft leader of
-// the first range gossips it.
-const ttlClusterIDGossip = 30 * time.Second
+const (
+	// DefaultHeartbeatInterval is how often heartbeats are sent from the
+	// transaction coordinator to a live transaction. These keep it from
+	// being preempted by other transactions writing the same keys. If a
+	// transaction fails to be heartbeat within 2x the heartbeat interval,
+	// it may be aborted by conflicting txns.
+	DefaultHeartbeatInterval = 5 * time.Second
+
+	// ttlClusterIDGossip is time-to-live for cluster ID. The cluster ID
+	// serves as the sentinel gossip key which informs a node whether or
+	// not it's connected to the primary gossip network and not just a
+	// partition. As such it must expire on a reasonable basis and be
+	// continually re-gossipped. The replica which is the raft leader of
+	// the first range gossips it.
+	ttlClusterIDGossip = 30 * time.Second
+)
 
 // configPrefixes describes administrative configuration maps
 // affecting ranges of the key-value map by key prefix.
@@ -88,6 +97,7 @@ const (
 	EnqueueMessage        = "EnqueueMessage"
 	InternalRangeLookup   = "InternalRangeLookup"
 	InternalHeartbeatTxn  = "InternalHeartbeatTxn"
+	InternalPushTxn       = "InternalPushTxn"
 	InternalResolveIntent = "InternalResolveIntent"
 	InternalSnapshotCopy  = "InternalSnapshotCopy"
 )
@@ -117,6 +127,7 @@ var writeMethods = map[string]struct{}{
 	EnqueueUpdate:         struct{}{},
 	EnqueueMessage:        struct{}{},
 	InternalHeartbeatTxn:  struct{}{},
+	InternalPushTxn:       struct{}{},
 	InternalResolveIntent: struct{}{},
 }
 
@@ -164,6 +175,7 @@ type Cmd struct {
 // as appropriate.
 type Range struct {
 	Meta      *proto.RangeMetadata
+	clock     *hlc.Clock
 	mvcc      *engine.MVCC
 	engine    engine.Engine  // The underlying key-value store
 	allocator *allocator     // Makes allocation decisions
@@ -182,10 +194,15 @@ type Range struct {
 // no knowledge of a possible store that contains it and thus all rebalancing
 // operations will fail. Use NewRangeFromStore() instead to create ranges
 // contained within a store.
+//
+// TODO(spencer): need to give range just a single instance of Range manager
+// to contain clock, mvcc, engine, allocator & gossip. This will reduce
+// completely unnecessary memory usage per range.
 func NewRange(meta *proto.RangeMetadata, clock *hlc.Clock, eng engine.Engine,
 	allocator *allocator, gossip *gossip.Gossip, rm RangeManager) *Range {
 	r := &Range{
 		Meta:      meta,
+		clock:     clock,
 		mvcc:      engine.NewMVCC(eng),
 		engine:    eng,
 		allocator: allocator,
@@ -500,6 +517,8 @@ func (r *Range) executeCmd(method string, args proto.Request, reply proto.Respon
 		r.InternalRangeLookup(args.(*proto.InternalRangeLookupRequest), reply.(*proto.InternalRangeLookupResponse))
 	case InternalHeartbeatTxn:
 		r.InternalHeartbeatTxn(args.(*proto.InternalHeartbeatTxnRequest), reply.(*proto.InternalHeartbeatTxnResponse))
+	case InternalPushTxn:
+		r.InternalPushTxn(args.(*proto.InternalPushTxnRequest), reply.(*proto.InternalPushTxnResponse))
 	case InternalResolveIntent:
 		r.InternalResolveIntent(args.(*proto.InternalResolveIntentRequest), reply.(*proto.InternalResolveIntentResponse))
 	case InternalSnapshotCopy:
@@ -614,8 +633,6 @@ func (r *Range) Scan(args *proto.ScanRequest, reply *proto.ScanResponse) {
 func (r *Range) EndTransaction(args *proto.EndTransactionRequest, reply *proto.EndTransactionResponse) {
 	// Create the actual key to the system-local transaction table.
 	key := engine.MakeKey(engine.KeyLocalTransactionPrefix, args.Key)
-	// Start with supplied transaction, then possibly load from txn record.
-	reply.Txn = gogoproto.Clone(args.Txn).(*proto.Transaction)
 
 	// Fetch existing transaction if possible.
 	existTxn := &proto.Transaction{}
@@ -628,6 +645,9 @@ func (r *Range) EndTransaction(args *proto.EndTransactionRequest, reply *proto.E
 	// commit it or abort it (according to args.Commit), and also that the
 	// Timestamp and Epoch have not suffered regression.
 	if ok {
+		// Use the persisted transaction record as final transaction.
+		reply.Txn = gogoproto.Clone(existTxn).(*proto.Transaction)
+
 		if existTxn.Status == proto.COMMITTED {
 			reply.SetGoError(proto.NewTransactionStatusError(existTxn, "already committed"))
 			return
@@ -644,8 +664,9 @@ func (r *Range) EndTransaction(args *proto.EndTransactionRequest, reply *proto.E
 			reply.SetGoError(proto.NewTransactionStatusError(existTxn, fmt.Sprintf("timestamp regression: %+v", args.Txn.Timestamp)))
 			return
 		}
-		// Use the persisted transaction record as final transaction.
-		gogoproto.Merge(reply.Txn, existTxn)
+	} else {
+		// The transaction doesn't exist yet on disk; use the supplied version.
+		reply.Txn = gogoproto.Clone(args.Txn).(*proto.Transaction)
 	}
 
 	// Take max of requested timestamp and possibly "pushed" txn
@@ -780,7 +801,7 @@ func (r *Range) InternalRangeLookup(args *proto.InternalRangeLookupRequest, repl
 
 // InternalHeartbeatTxn updates the transaction status and heartbeat
 // timestamp after receiving transaction heartbeat messages from
-// coordinator. Returns the udpated transaction.
+// coordinator. Returns the updated transaction.
 func (r *Range) InternalHeartbeatTxn(args *proto.InternalHeartbeatTxnRequest, reply *proto.InternalHeartbeatTxnResponse) {
 	// Create the actual key to the system-local transaction table.
 	key := engine.MakeKey(engine.KeyLocalTransactionPrefix, args.Key)
@@ -810,12 +831,133 @@ func (r *Range) InternalHeartbeatTxn(args *proto.InternalHeartbeatTxnRequest, re
 	reply.Txn = &txn
 }
 
+// InternalPushTxn resolves conflicts between concurrent txns (or
+// between a non-transactional reader or writer and a txn) in several
+// ways depending on the statuses and priorities of the conflicting
+// transactions. The InternalPushTxn operation is invoked by a
+// "pusher" (the writer trying to abort a conflicting txn or the
+// reader trying to push a conflicting txn's commit timestamp
+// forward), who attempts to resolve a conflict with a "pushee"
+// (args.PushTxn -- the pushee txn whose intent(s) caused the
+// conflict).
+//
+// Txn already committed/aborted: If pushee txn is committed, return
+// already-committed error. If pushee txn has been aborted, return
+// success.
+//
+// Txn Timeout: If pushee txn entry isn't present or its LastHeartbeat
+// timestamp isn't set, use PushTxn.Timestamp as LastHeartbeat. If
+// current time - LastHeartbeat > 2 * DefaultHeartbeatInterval, then
+// the puhsee txn should be either pushed forward or aborted,
+// depending on value of Request.Abort.
+//
+// Old Txn Epoch: If persisted pushee txn entry has a newer Epoch than
+// PushTxn.Epoch, return success, as older epoch may be removed.
+//
+// Lower Txn Priority: If pushee txn has a lower priority than pusher,
+// adjust pushee's persisted txn depending on value of args.Abort. If
+// args.Abort is true, set txn.Status to ABORTED, and priority to one
+// less than the pusher's priority and return success. If args.Abort
+// is false, set txn.Timestamp to pusher's txn.Timestamp + 1.
+//
+// Higher Txn Priority: If pushee txn has a higher priority than
+// pusher, return TransactionRetryError. Transaction will be retried
+// with priority one less than the pushee's higher priority.
+func (r *Range) InternalPushTxn(args *proto.InternalPushTxnRequest, reply *proto.InternalPushTxnResponse) {
+	if !bytes.Equal(args.Key, args.PushTxn.ID) {
+		reply.SetGoError(util.Errorf("push txn not addressed at pushee's txn ID: %q vs. %q", args.Key, args.PushTxn.ID))
+		return
+	}
+	// Create the actual key to the system-local transaction table.
+	key := engine.MakeKey(engine.KeyLocalTransactionPrefix, args.Key)
+
+	// Fetch existing transaction if possible.
+	existTxn := &proto.Transaction{}
+	ok, err := engine.GetProto(r.engine, key, existTxn)
+	if err != nil {
+		reply.SetGoError(err)
+		return
+	}
+	if ok {
+		// Start with the persisted transaction record as final transaction.
+		reply.PushTxn = gogoproto.Clone(existTxn).(*proto.Transaction)
+		// Upgrade the epoch and timestamp as necessary.
+		if reply.PushTxn.Epoch < args.PushTxn.Epoch {
+			reply.PushTxn.Epoch = args.PushTxn.Epoch
+		}
+		if reply.PushTxn.Timestamp.Less(args.PushTxn.Timestamp) {
+			reply.PushTxn.Timestamp = args.PushTxn.Timestamp
+		}
+	} else {
+		// The transaction doesn't exist yet on disk; use the supplied version.
+		reply.PushTxn = gogoproto.Clone(&args.PushTxn).(*proto.Transaction)
+	}
+
+	// If already committed, return already committed error.
+	if reply.PushTxn.Status == proto.COMMITTED {
+		reply.SetGoError(proto.NewTransactionStatusError(reply.PushTxn, "already committed"))
+		return
+	} else if reply.PushTxn.Status == proto.ABORTED {
+		// This is a trivial noop.
+		return
+	}
+
+	// push bool is true in the event the pusher prevails.
+	var push bool
+
+	// Check for txn timeout.
+	if reply.PushTxn.LastHeartbeat == nil {
+		reply.PushTxn.LastHeartbeat = &reply.PushTxn.Timestamp
+	}
+	// Compute heartbeat expiration.
+	expiry := r.clock.Now()
+	expiry.WallTime -= 2 * DefaultHeartbeatInterval.Nanoseconds()
+	if reply.PushTxn.LastHeartbeat.Less(expiry) {
+		log.V(1).Infof("pushing expired txn %+v", reply.PushTxn)
+		push = true
+	} else if args.PushTxn.Epoch < reply.PushTxn.Epoch {
+		// Check for an intent from a prior epoch.
+		log.V(1).Infof("pushing intent from previous epoch for txn %+v", reply.PushTxn)
+		push = true
+	} else if reply.PushTxn.Priority < args.Txn.Priority ||
+		(reply.PushTxn.Priority == args.Txn.Priority && args.Txn.Timestamp.Less(reply.PushTxn.Timestamp)) {
+		// Finally, choose based on priority; if priorities are equal, order by lower txn timestamp.
+		log.V(1).Infof("pushing intent from txn with lower priority %+v vs %+v", reply.PushTxn, args.Txn)
+		push = true
+	}
+
+	if !push {
+		log.V(1).Infof("failed to push intent %+v vs %+v", reply.PushTxn, args.Txn)
+		reply.SetGoError(proto.NewTransactionRetryError(reply.PushTxn))
+		return
+	}
+
+	// If aborting transaction, set new status and return success.
+	if args.Abort {
+		reply.PushTxn.Status = proto.ABORTED
+	} else {
+		// Otherwise, update timestamp to be one greater than the request's timestamp.
+		reply.PushTxn.Timestamp = args.Timestamp
+		reply.PushTxn.Timestamp.Logical++
+	}
+	// Persist the pushed transaction.
+	if err := engine.PutProto(r.engine, key, reply.PushTxn); err != nil {
+		reply.SetGoError(err)
+		return
+	}
+}
+
 // InternalResolveIntent updates the transaction status and heartbeat
 // timestamp after receiving transaction heartbeat messages from
 // coordinator.  The range will return the current status for this
 // transaction to the coordinator.
 func (r *Range) InternalResolveIntent(args *proto.InternalResolveIntentRequest, reply *proto.InternalResolveIntentResponse) {
-	reply.SetGoError(r.mvcc.ResolveWriteIntent(args.Key, args.Txn, args.Commit))
+	if len(args.EndKey) == 0 || bytes.Equal(args.Key, args.EndKey) {
+		reply.SetGoError(r.mvcc.ResolveWriteIntent(args.Key, args.Txn))
+	} else {
+		_, err := r.mvcc.ResolveWriteIntentRange(args.Key, args.EndKey, 0, args.Txn)
+		reply.SetGoError(err)
+	}
 }
 
 // createSnapshot creates a new snapshot, named using an internal counter.

--- a/storage/range.go
+++ b/storage/range.go
@@ -907,6 +907,12 @@ func (r *Range) InternalPushTxn(args *proto.InternalPushTxnRequest, reply *proto
 		// Trivial noop.
 		return
 	}
+	// If we're trying to move the timestamp forward, and it's already
+	// far enough forward, return success.
+	if !args.Abort && args.Timestamp.Less(reply.PusheeTxn.Timestamp) {
+		// Trivial noop.
+		return
+	}
 
 	// pusherWins bool is true in the event the pusher prevails.
 	var pusherWins bool


### PR DESCRIPTION
 The details of the op are spelled out in detail in the Range.InternalPushTxn comments and in the
api.proto comments. Unittests provides full code test coverage including
all error conditions.

Changed MVCC.ResolveWriteIntent to no longer accept a Commit parameter.
Instead, we use more of the provided Txn parameter's fields to correctly
update the MVCC metadata / versioned value. The missing piece here was
handling the case of the timestamp being pushed forward instead of just
having the underlying transaction committed or aborted. In the case of
pushing the timestamp, the MVCC metadata txn field is not set to nil,
it's just updated. We also will end up removing the versioned value with
the previous timestamp and create a new one with the updated timestamp.

Cleaned up TODO file.
