### PR TITLE
Give all replicas of a range the same Range ID

### DIFF
--- a/kv/coordinator_test.go
+++ b/kv/coordinator_test.go
@@ -35,9 +35,9 @@ func createTestDB(t *testing.T) (*DB, *hlc.Clock, *hlc.ManualClock) {
 	manual := hlc.ManualClock(0)
 	clock := hlc.NewClock(manual.UnixNano)
 	eng := engine.NewInMem(proto.Attributes{}, 1<<20)
-	store := storage.NewStore(clock, eng, nil)
+	store := storage.NewStore(clock, eng, nil, nil)
 	store.Ident.StoreID = 1
-	replica := proto.Replica{StoreID: 1, RangeID: 1}
+	replica := proto.Replica{NodeID: 1, StoreID: 1}
 	_, err := store.CreateRange(engine.KeyMin, engine.KeyMax, []proto.Replica{replica})
 	if err != nil {
 		t.Fatal(err)

--- a/kv/coordinator_test.go
+++ b/kv/coordinator_test.go
@@ -37,7 +37,7 @@ func createTestDB(t *testing.T) (*DB, *hlc.Clock, *hlc.ManualClock) {
 	eng := engine.NewInMem(proto.Attributes{}, 1<<20)
 	store := storage.NewStore(clock, eng, nil, nil)
 	store.Ident.StoreID = 1
-	replica := proto.Replica{NodeID: 1, StoreID: 1}
+	replica := proto.Replica{NodeID: 1, StoreID: 1, RangeID: 1}
 	_, err := store.CreateRange(engine.KeyMin, engine.KeyMax, []proto.Replica{replica})
 	if err != nil {
 		t.Fatal(err)

--- a/kv/dist_kv.go
+++ b/kv/dist_kv.go
@@ -279,7 +279,6 @@ func (kv *DistKV) ExecuteCmd(method string, args proto.Request, replyChan interf
 	err := util.RetryWithBackoff(retryOpts, func() (bool, error) {
 		desc, err := kv.rangeCache.LookupRangeMetadata(args.Header().Key)
 		if err == nil {
-			args.Header().RangeID = desc.RangeID
 			err = kv.sendRPC(desc, method, args, replyChan)
 		}
 		if err != nil {

--- a/kv/dist_kv.go
+++ b/kv/dist_kv.go
@@ -155,7 +155,7 @@ func (kv *DistKV) internalRangeLookup(key engine.Key,
 		MaxRanges: rangeLookupMaxRanges,
 	}
 	replyChan := make(chan *proto.InternalRangeLookupResponse, len(info.Replicas))
-	if err := kv.sendRPC(info.Replicas, "Node.InternalRangeLookup", args, replyChan); err != nil {
+	if err := kv.sendRPC(info, "Node.InternalRangeLookup", args, replyChan); err != nil {
 		return nil, err
 	}
 	reply := <-replyChan
@@ -224,14 +224,14 @@ func (kv *DistKV) getRangeMetadata(key engine.Key) ([]proto.RangeDescriptor, err
 // proto.Replica slice. First, replicas which have gossipped
 // addresses are corraled and then sent via rpc.Send, with requirement
 // that one RPC to a server must succeed.
-func (kv *DistKV) sendRPC(replicas []proto.Replica, method string, args proto.Request, replyChan interface{}) error {
-	if len(replicas) == 0 {
+func (kv *DistKV) sendRPC(desc *proto.RangeDescriptor, method string, args proto.Request, replyChan interface{}) error {
+	if len(desc.Replicas) == 0 {
 		return util.Errorf("%s: replicas set is empty", method)
 	}
 	// Build a map from replica address (if gossipped) to args struct
 	// with replica set in header.
 	argsMap := map[net.Addr]interface{}{}
-	for _, replica := range replicas {
+	for _, replica := range desc.Replicas {
 		addr, err := kv.nodeIDToAddr(replica.NodeID)
 		if err != nil {
 			log.V(1).Infof("node %d address is not gossipped", replica.NodeID)
@@ -277,9 +277,10 @@ func (kv *DistKV) ExecuteCmd(method string, args proto.Request, replyChan interf
 		MaxAttempts: 0, // retry indefinitely
 	}
 	err := util.RetryWithBackoff(retryOpts, func() (bool, error) {
-		rangeMeta, err := kv.rangeCache.LookupRangeMetadata(args.Header().Key)
+		desc, err := kv.rangeCache.LookupRangeMetadata(args.Header().Key)
 		if err == nil {
-			err = kv.sendRPC(rangeMeta.Replicas, method, args, replyChan)
+			args.Header().RangeID = desc.RangeID
+			err = kv.sendRPC(desc, method, args, replyChan)
 		}
 		if err != nil {
 			// Range metadata might be out of date - evict it.

--- a/kv/rest/rest_test.go
+++ b/kv/rest/rest_test.go
@@ -343,12 +343,13 @@ func TestSystemKeys(t *testing.T) {
 
 	// Compute expected system key.
 	desc := &proto.RangeDescriptor{
+		RangeID:  1,
 		StartKey: engine.KeyMin,
+		EndKey:   engine.KeyMax,
 		Replicas: []proto.Replica{
 			proto.Replica{
 				NodeID:  1,
 				StoreID: 1,
-				RangeID: 1,
 			},
 		},
 	}

--- a/kv/rest/rest_test.go
+++ b/kv/rest/rest_test.go
@@ -343,13 +343,14 @@ func TestSystemKeys(t *testing.T) {
 
 	// Compute expected system key.
 	desc := &proto.RangeDescriptor{
-		RangeID:  1,
+		RaftID:   1,
 		StartKey: engine.KeyMin,
 		EndKey:   engine.KeyMax,
 		Replicas: []proto.Replica{
 			proto.Replica{
 				NodeID:  1,
 				StoreID: 1,
+				RangeID: 1,
 			},
 		},
 	}

--- a/proto/api.proto
+++ b/proto/api.proto
@@ -60,10 +60,13 @@ message RequestHeader {
   // User is the originating user. Used to lookup priority when
   // scheduling queued operations at target node.
   optional string user = 5 [(gogoproto.nullable) = false];
-  // Replica specifies the destination for the request. See config.go.
-  optional Replica replica = 6 [(gogoproto.nullable) = false];
+  // RangeID specifies the range containing the keys between Key and EndKey.
+  optional int64 range_id = 6 [(gogoproto.nullable) = false, (gogoproto.customname) = "RangeID"];
+  // Replica specifies the destination for the request. This is a specific
+  // instance of the available replicas belonging to RangeID.
+  optional Replica replica = 7 [(gogoproto.nullable) = false];
   // Txn is set non-nil if a transaction is underway.
-  optional Transaction txn = 7;
+  optional Transaction txn = 8;
 }
 
 // ResponseHeader is returned with every storage node response.

--- a/proto/api.proto
+++ b/proto/api.proto
@@ -60,13 +60,11 @@ message RequestHeader {
   // User is the originating user. Used to lookup priority when
   // scheduling queued operations at target node.
   optional string user = 5 [(gogoproto.nullable) = false];
-  // RangeID specifies the range containing the keys between Key and EndKey.
-  optional int64 range_id = 6 [(gogoproto.nullable) = false, (gogoproto.customname) = "RangeID"];
   // Replica specifies the destination for the request. This is a specific
   // instance of the available replicas belonging to RangeID.
-  optional Replica replica = 7 [(gogoproto.nullable) = false];
+  optional Replica replica = 6 [(gogoproto.nullable) = false];
   // Txn is set non-nil if a transaction is underway.
-  optional Transaction txn = 8;
+  optional Transaction txn = 7;
 }
 
 // ResponseHeader is returned with every storage node response.

--- a/proto/config.go
+++ b/proto/config.go
@@ -74,6 +74,18 @@ func (r *RangeDescriptor) ContainsKeyRange(start, end []byte) bool {
 	return bytes.Compare(start, r.StartKey) >= 0 && bytes.Compare(r.EndKey, end) >= 0
 }
 
+// GetReplica returns the replica matching this RangeMetadata's RangeID.
+// Each RangeMetadata is keyed to just one of the replicas based on
+// RangeID. We simply find the matching entry in the replicas slice.
+func (r *RangeMetadata) GetReplica() *Replica {
+	for i := range r.Replicas {
+		if r.Replicas[i].RangeID == r.RangeID {
+			return &r.Replicas[i]
+		}
+	}
+	panic(fmt.Sprintf("could not locate replica matching range %d: %s", r.RangeID, r.Replicas))
+}
+
 // CanRead does a linear search for user to verify read permission.
 func (p *PermConfig) CanRead(user string) bool {
 	for _, u := range p.Read {

--- a/proto/config.proto
+++ b/proto/config.proto
@@ -33,32 +33,31 @@ message Attributes {
 message Replica {
   optional int32 node_id = 1 [(gogoproto.nullable) = false, (gogoproto.customname) = "NodeID"];
   optional int32 store_id = 2 [(gogoproto.nullable) = false, (gogoproto.customname) = "StoreID"];
-  optional int64 range_id = 3 [(gogoproto.nullable) = false, (gogoproto.customname) = "RangeID"];
   // combination of node & store attributes.
-  optional Attributes attrs = 4 [(gogoproto.nullable) = false];
+  optional Attributes attrs = 3 [(gogoproto.nullable) = false];
 }
 
 // RangeDescriptor is the value stored in a range metadata key.
 // A range is described using an inclusive start key, a non-inclusive end key,
 // and a list of replicas where the range is stored.
 message RangeDescriptor {
+  optional int64 range_id = 1 [(gogoproto.nullable) = false, (gogoproto.customname) = "RangeID"];
   // StartKey is the first key which may be contained by this range.
-  optional bytes start_key = 1 [(gogoproto.nullable) = false];
+  optional bytes start_key = 2 [(gogoproto.nullable) = false];
   // EndKey marks the end of the range's possible keys.  EndKey itself is not
   // contained in this range - it will be contained in the immediately
   // subsequent range.
-  optional bytes end_key = 2 [(gogoproto.nullable) = false];
+  optional bytes end_key = 3 [(gogoproto.nullable) = false];
   // List of replicas where this range is stored.
-  repeated Replica replicas = 3 [(gogoproto.nullable) = false];
+  repeated Replica replicas = 4 [(gogoproto.nullable) = false];
 }
 
 // A RangeMetadata holds information about the range. This includes
-// the cluster ID, the range ID, and a RangeDescriptor describing the
+// the cluster ID, and a RangeDescriptor describing the
 // contents of the range.
 message RangeMetadata {
-  optional RangeDescriptor desc = 1 [(gogoproto.nullable) = false, (gogoproto.embed) = true];
-  optional string cluster_id = 2 [(gogoproto.nullable) = false, (gogoproto.customname) = "ClusterID"];
-  optional int64 range_id = 3 [(gogoproto.nullable) = false, (gogoproto.customname) = "RangeID"];
+  optional string cluster_id = 1 [(gogoproto.nullable) = false, (gogoproto.customname) = "ClusterID"];
+  optional RangeDescriptor desc = 2 [(gogoproto.nullable) = false, (gogoproto.embed) = true];
 }
 
 // GCPolicy defines garbage collection policies which apply to MVCC
@@ -89,10 +88,10 @@ message PermConfig {
 
 // ZoneConfig holds configuration that is needed for a range of KV pairs.
 message ZoneConfig {
-  // Replicas is a slice of Attributes, each describing required
-  // capabilities of each replica in the zone.
-  repeated Attributes Replicas = 1 [(gogoproto.nullable) = false, (gogoproto.moretags) = "yaml:\"replicas,omitempty,flow\""];
-  optional int64 RangeMinBytes = 2 [(gogoproto.nullable) = false, (gogoproto.moretags) = "yaml:\"range_min_bytes,omitempty\""];
-  optional int64 RangeMaxBytes = 3 [(gogoproto.nullable) = false, (gogoproto.moretags) = "yaml:\"range_max_bytes,omitempty\""];
+  // ReplicaAttrs is a slice of Attributes, each describing required
+  // attributes for each replica in the zone.
+  repeated Attributes replica_attrs = 1 [(gogoproto.nullable) = false, (gogoproto.moretags) = "yaml:\"replicas,omitempty,flow\""];
+  optional int64 range_min_bytes = 2 [(gogoproto.nullable) = false, (gogoproto.moretags) = "yaml:\"range_min_bytes,omitempty\""];
+  optional int64 range_max_bytes = 3 [(gogoproto.nullable) = false, (gogoproto.moretags) = "yaml:\"range_max_bytes,omitempty\""];
   optional GCPolicy gc = 4 [(gogoproto.customname) = "GC", (gogoproto.moretags) = "yaml:\"gc,omitempty\""];
 }

--- a/proto/config.proto
+++ b/proto/config.proto
@@ -33,15 +33,16 @@ message Attributes {
 message Replica {
   optional int32 node_id = 1 [(gogoproto.nullable) = false, (gogoproto.customname) = "NodeID"];
   optional int32 store_id = 2 [(gogoproto.nullable) = false, (gogoproto.customname) = "StoreID"];
+  optional int64 range_id = 3 [(gogoproto.nullable) = false, (gogoproto.customname) = "RangeID"];
   // combination of node & store attributes.
-  optional Attributes attrs = 3 [(gogoproto.nullable) = false];
+  optional Attributes attrs = 4 [(gogoproto.nullable) = false];
 }
 
 // RangeDescriptor is the value stored in a range metadata key.
 // A range is described using an inclusive start key, a non-inclusive end key,
 // and a list of replicas where the range is stored.
 message RangeDescriptor {
-  optional int64 range_id = 1 [(gogoproto.nullable) = false, (gogoproto.customname) = "RangeID"];
+  optional int64 raft_id = 1 [(gogoproto.nullable) = false, (gogoproto.customname) = "RaftID"];
   // StartKey is the first key which may be contained by this range.
   optional bytes start_key = 2 [(gogoproto.nullable) = false];
   // EndKey marks the end of the range's possible keys.  EndKey itself is not
@@ -53,11 +54,12 @@ message RangeDescriptor {
 }
 
 // A RangeMetadata holds information about the range. This includes
-// the cluster ID, and a RangeDescriptor describing the
-// contents of the range.
+// the cluster ID, a RangeDescriptor describing the contents of the
+// range, and the range ID which owns the metadata.
 message RangeMetadata {
   optional string cluster_id = 1 [(gogoproto.nullable) = false, (gogoproto.customname) = "ClusterID"];
   optional RangeDescriptor desc = 2 [(gogoproto.nullable) = false, (gogoproto.embed) = true];
+  optional int64 range_id = 3 [(gogoproto.nullable) = false, (gogoproto.customname) = "RangeID"];
 }
 
 // GCPolicy defines garbage collection policies which apply to MVCC

--- a/proto/config_test.go
+++ b/proto/config_test.go
@@ -104,7 +104,7 @@ func TestRangeDescriptorContains(t *testing.T) {
 }
 
 var testConfig = ZoneConfig{
-	Replicas: []Attributes{
+	ReplicaAttrs: []Attributes{
 		Attributes{Attrs: []string{"a", "ssd"}},
 		Attributes{Attrs: []string{"a", "hdd"}},
 		Attributes{Attrs: []string{"b", "ssd"}},

--- a/proto/errors.go
+++ b/proto/errors.go
@@ -56,16 +56,20 @@ func NewRangeKeyMismatchError(start, end []byte, meta *RangeMetadata) *RangeKeyM
 	return &RangeKeyMismatchError{
 		RequestStartKey: start,
 		RequestEndKey:   end,
-		Range:           *meta,
+		Range:           meta,
 	}
 }
 
 // Error formats error.
 func (e *RangeKeyMismatchError) Error() string {
-	return fmt.Sprintf("key range %q-%q outside of bounds of range %q: %q-%q",
-		string(e.RequestStartKey), string(e.RequestEndKey),
-		string(e.Range.RangeID),
-		string(e.Range.StartKey), string(e.Range.EndKey))
+	if e.Range != nil {
+		return fmt.Sprintf("key range %q-%q outside of bounds of range %q: %q-%q",
+			string(e.RequestStartKey), string(e.RequestEndKey),
+			string(e.Range.RangeID),
+			string(e.Range.StartKey), string(e.Range.EndKey))
+	}
+	return fmt.Sprintf("key range %q-%q could not be located within a range on store",
+		string(e.RequestStartKey), string(e.RequestEndKey))
 }
 
 // CanRetry indicates whether or not this RangeKeyMismatchError can be retried.

--- a/proto/errors.proto
+++ b/proto/errors.proto
@@ -45,7 +45,7 @@ message RangeNotFoundError {
 message RangeKeyMismatchError {
   optional bytes request_start_key = 1 [(gogoproto.nullable) = false];
   optional bytes request_end_key = 2 [(gogoproto.nullable) = false];
-  optional RangeMetadata range = 3 [(gogoproto.nullable) = false];
+  optional RangeMetadata range = 3;
 }
 
 // TransactionStatusError indicates that the transaction status is

--- a/server/node.go
+++ b/server/node.go
@@ -129,6 +129,7 @@ func BootstrapCluster(clusterID string, eng engine.Engine) (*kv.DB, error) {
 	replica := proto.Replica{
 		NodeID:  1,
 		StoreID: 1,
+		RangeID: 1,
 		Attrs:   proto.Attributes{},
 	}
 	rng, err := s.CreateRange(engine.KeyMin, engine.KeyMax, []proto.Replica{replica})

--- a/server/node.go
+++ b/server/node.go
@@ -113,7 +113,7 @@ func BootstrapCluster(clusterID string, eng engine.Engine) (*kv.DB, error) {
 	}
 	clock := hlc.NewClock(hlc.UnixNano)
 	now := clock.Now()
-	s := storage.NewStore(clock, eng, nil)
+	s := storage.NewStore(clock, eng, nil, nil)
 
 	// Verify the store isn't already part of a cluster.
 	if len(s.Ident.ClusterID) > 0 {
@@ -125,15 +125,10 @@ func BootstrapCluster(clusterID string, eng engine.Engine) (*kv.DB, error) {
 		return nil, err
 	}
 
-	if err := s.Init(); err != nil {
-		return nil, err
-	}
-
 	// Create first range.
 	replica := proto.Replica{
 		NodeID:  1,
 		StoreID: 1,
-		RangeID: 1,
 		Attrs:   proto.Attributes{},
 	}
 	rng, err := s.CreateRange(engine.KeyMin, engine.KeyMax, []proto.Replica{replica})
@@ -150,10 +145,7 @@ func BootstrapCluster(clusterID string, eng engine.Engine) (*kv.DB, error) {
 	localDB := kv.NewDB(localKV, clock)
 
 	// Initialize range addressing records and default administrative configs.
-	desc := &proto.RangeDescriptor{
-		StartKey: engine.KeyMin,
-		Replicas: []proto.Replica{replica},
-	}
+	desc := &rng.Meta.RangeDescriptor
 	if err := storage.BootstrapRangeDescriptor(localDB, desc, now); err != nil {
 		return nil, err
 	}
@@ -235,7 +227,7 @@ func (n *Node) initStores(clock *hlc.Clock, engines []engine.Engine) error {
 	bootstraps := list.New()
 
 	for _, e := range engines {
-		s := storage.NewStore(clock, e, n.gossip)
+		s := storage.NewStore(clock, e, n.db, n.gossip)
 		// Initialize each store in turn, handling un-bootstrapped errors by
 		// adding the store to the bootstraps list.
 		if err := s.Init(); err != nil {
@@ -408,7 +400,7 @@ func (n *Node) gossipCapacities() {
 // executeCmd looks up the store specified by header.Replica, and runs
 // Store.ExecuteCmd.
 func (n *Node) executeCmd(method string, args proto.Request, reply proto.Response) error {
-	store, err := n.localKV.GetStore(&args.Header().Replica)
+	store, err := n.localKV.GetStore(args.Header().Replica.StoreID)
 	if err != nil {
 		return err
 	}

--- a/storage/allocator_test.go
+++ b/storage/allocator_test.go
@@ -26,13 +26,13 @@ import (
 )
 
 var simpleZoneConfig = proto.ZoneConfig{
-	Replicas: []proto.Attributes{
+	ReplicaAttrs: []proto.Attributes{
 		proto.Attributes{Attrs: []string{"a", "ssd"}},
 	},
 }
 
 var multiDisksConfig = proto.ZoneConfig{
-	Replicas: []proto.Attributes{
+	ReplicaAttrs: []proto.Attributes{
 		proto.Attributes{Attrs: []string{"a", "ssd"}},
 		proto.Attributes{Attrs: []string{"a", "hdd"}},
 		proto.Attributes{Attrs: []string{"a", "mem"}},
@@ -40,7 +40,7 @@ var multiDisksConfig = proto.ZoneConfig{
 }
 
 var multiDCConfig = proto.ZoneConfig{
-	Replicas: []proto.Attributes{
+	ReplicaAttrs: []proto.Attributes{
 		proto.Attributes{Attrs: []string{"a", "ssd"}},
 		proto.Attributes{Attrs: []string{"b", "ssd"}},
 	},
@@ -180,7 +180,7 @@ func TestSimpleRetrieval(t *testing.T) {
 		storeFinder: singleStore,
 		rand:        *rand.New(rand.NewSource(0)),
 	}
-	result, err := a.allocate(simpleZoneConfig.Replicas[0], []proto.Replica{})
+	result, err := a.allocate(simpleZoneConfig.ReplicaAttrs[0], []proto.Replica{})
 	if err != nil {
 		t.Errorf("Unable to perform allocation: %v", err)
 	}
@@ -194,7 +194,7 @@ func TestNoAvailableDisks(t *testing.T) {
 		storeFinder: noStores,
 		rand:        *rand.New(rand.NewSource(0)),
 	}
-	result, err := a.allocate(simpleZoneConfig.Replicas[0], []proto.Replica{})
+	result, err := a.allocate(simpleZoneConfig.ReplicaAttrs[0], []proto.Replica{})
 	if result != nil {
 		t.Errorf("expected nil result: %+v", result)
 	}
@@ -208,7 +208,7 @@ func TestThreeDisksSameDC(t *testing.T) {
 		storeFinder: sameDCStores,
 		rand:        *rand.New(rand.NewSource(0)),
 	}
-	result1, err := a.allocate(multiDisksConfig.Replicas[0], []proto.Replica{})
+	result1, err := a.allocate(multiDisksConfig.ReplicaAttrs[0], []proto.Replica{})
 	if err != nil {
 		t.Fatalf("Unable to perform allocation: %v", err)
 	}
@@ -219,10 +219,10 @@ func TestThreeDisksSameDC(t *testing.T) {
 		proto.Replica{
 			NodeID:  result1.Node.NodeID,
 			StoreID: result1.StoreID,
-			Attrs:   multiDisksConfig.Replicas[0],
+			Attrs:   multiDisksConfig.ReplicaAttrs[0],
 		},
 	}
-	result2, err := a.allocate(multiDisksConfig.Replicas[1], exReplicas)
+	result2, err := a.allocate(multiDisksConfig.ReplicaAttrs[1], exReplicas)
 	if err != nil {
 		t.Errorf("Unable to perform allocation: %v", err)
 	}
@@ -232,7 +232,7 @@ func TestThreeDisksSameDC(t *testing.T) {
 	if result1.Node.NodeID == result2.Node.NodeID {
 		t.Errorf("Expected node ids to be different %+v vs %+v", result1, result2)
 	}
-	result3, err := a.allocate(multiDisksConfig.Replicas[2], []proto.Replica{})
+	result3, err := a.allocate(multiDisksConfig.ReplicaAttrs[2], []proto.Replica{})
 	if err != nil {
 		t.Errorf("Unable to perform allocation: %v", err)
 	}
@@ -246,11 +246,11 @@ func TestTwoDatacenters(t *testing.T) {
 		storeFinder: multiDCStores,
 		rand:        *rand.New(rand.NewSource(0)),
 	}
-	result1, err := a.allocate(multiDCConfig.Replicas[0], []proto.Replica{})
+	result1, err := a.allocate(multiDCConfig.ReplicaAttrs[0], []proto.Replica{})
 	if err != nil {
 		t.Fatalf("Unable to perform allocation: %v", err)
 	}
-	result2, err := a.allocate(multiDCConfig.Replicas[1], []proto.Replica{})
+	result2, err := a.allocate(multiDCConfig.ReplicaAttrs[1], []proto.Replica{})
 	if err != nil {
 		t.Fatalf("Unable to perform allocation: %v", err)
 	}
@@ -258,11 +258,11 @@ func TestTwoDatacenters(t *testing.T) {
 		t.Errorf("Expected nodes 1 & 2: %+v vs %+v", result1.Node, result2.Node)
 	}
 	// Verify that no result is forthcoming if we already have a replica.
-	_, err = a.allocate(multiDCConfig.Replicas[1], []proto.Replica{
+	_, err = a.allocate(multiDCConfig.ReplicaAttrs[1], []proto.Replica{
 		proto.Replica{
 			NodeID:  result2.Node.NodeID,
 			StoreID: result2.StoreID,
-			Attrs:   multiDCConfig.Replicas[1],
+			Attrs:   multiDCConfig.ReplicaAttrs[1],
 		},
 	})
 	if err == nil {
@@ -275,11 +275,11 @@ func TestExistingReplica(t *testing.T) {
 		storeFinder: sameDCStores,
 		rand:        *rand.New(rand.NewSource(0)),
 	}
-	result, err := a.allocate(multiDisksConfig.Replicas[1], []proto.Replica{
+	result, err := a.allocate(multiDisksConfig.ReplicaAttrs[1], []proto.Replica{
 		proto.Replica{
 			NodeID:  1,
 			StoreID: 1,
-			Attrs:   multiDisksConfig.Replicas[0],
+			Attrs:   multiDisksConfig.ReplicaAttrs[0],
 		},
 	})
 	if err != nil {

--- a/storage/db.go
+++ b/storage/db.go
@@ -182,7 +182,7 @@ func BootstrapConfigs(db DB, timestamp proto.Timestamp) error {
 	// TODO(spencer): change this when zone specifications change to elect for three
 	// replicas with no specific features set.
 	zoneConfig := &proto.ZoneConfig{
-		Replicas: []proto.Attributes{
+		ReplicaAttrs: []proto.Attributes{
 			proto.Attributes{},
 			proto.Attributes{},
 			proto.Attributes{},

--- a/storage/db_test.go
+++ b/storage/db_test.go
@@ -40,7 +40,7 @@ func newTestDB(store *Store) (*testDB, *hlc.ManualClock) {
 func (db *testDB) executeCmd(method string, args proto.Request, replyChan interface{}) {
 	reply := reflect.New(reflect.TypeOf(replyChan).Elem().Elem()).Interface().(proto.Response)
 	if rng := db.store.LookupRange(args.Header().Key, args.Header().EndKey); rng != nil {
-		args.Header().RangeID = rng.Meta.RangeID
+		args.Header().Replica = *rng.Meta.GetReplica()
 		db.store.ExecuteCmd(method, args, reply)
 	} else {
 		reply.Header().SetGoError(proto.NewRangeKeyMismatchError(args.Header().Key, args.Header().EndKey, nil))

--- a/storage/db_test.go
+++ b/storage/db_test.go
@@ -1,0 +1,158 @@
+// Copyright 2014 The Cockroach Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+// implied. See the License for the specific language governing
+// permissions and limitations under the License. See the AUTHORS file
+// for names of contributors.
+//
+// Author: Spencer Kimball (spencer.kimball@gmail.com)
+
+package storage
+
+import (
+	"reflect"
+
+	"github.com/cockroachdb/cockroach/proto"
+	"github.com/cockroachdb/cockroach/util/hlc"
+)
+
+// testDB is an implementation of the DB interface which
+// passes all requests through to a single store.
+type testDB struct {
+	store *Store
+	clock *hlc.Clock
+}
+
+func newTestDB(store *Store) (*testDB, *hlc.ManualClock) {
+	manual := hlc.ManualClock(0)
+	clock := hlc.NewClock(manual.UnixNano)
+	return &testDB{store: store, clock: clock}, &manual
+}
+
+func (db *testDB) executeCmd(method string, args proto.Request, replyChan interface{}) {
+	reply := reflect.New(reflect.TypeOf(replyChan).Elem().Elem()).Interface().(proto.Response)
+	if rng := db.store.LookupRange(args.Header().Key, args.Header().EndKey); rng != nil {
+		args.Header().RangeID = rng.Meta.RangeID
+		db.store.ExecuteCmd(method, args, reply)
+	} else {
+		reply.Header().SetGoError(proto.NewRangeKeyMismatchError(args.Header().Key, args.Header().EndKey, nil))
+	}
+	reflect.ValueOf(replyChan).Send(reflect.ValueOf(reply))
+}
+
+func (db *testDB) Contains(args *proto.ContainsRequest) <-chan *proto.ContainsResponse {
+	replyChan := make(chan *proto.ContainsResponse, 1)
+	go db.executeCmd(Contains, args, replyChan)
+	return replyChan
+}
+
+func (db *testDB) Get(args *proto.GetRequest) <-chan *proto.GetResponse {
+	replyChan := make(chan *proto.GetResponse, 1)
+	go db.executeCmd(Get, args, replyChan)
+	return replyChan
+}
+
+func (db *testDB) Put(args *proto.PutRequest) <-chan *proto.PutResponse {
+	replyChan := make(chan *proto.PutResponse, 1)
+	go db.executeCmd(Put, args, replyChan)
+	return replyChan
+}
+
+func (db *testDB) ConditionalPut(args *proto.ConditionalPutRequest) <-chan *proto.ConditionalPutResponse {
+	replyChan := make(chan *proto.ConditionalPutResponse, 1)
+	go db.executeCmd(ConditionalPut, args, replyChan)
+	return replyChan
+}
+
+func (db *testDB) Increment(args *proto.IncrementRequest) <-chan *proto.IncrementResponse {
+	replyChan := make(chan *proto.IncrementResponse, 1)
+	go db.executeCmd(Increment, args, replyChan)
+	return replyChan
+}
+
+func (db *testDB) Delete(args *proto.DeleteRequest) <-chan *proto.DeleteResponse {
+	replyChan := make(chan *proto.DeleteResponse, 1)
+	go db.executeCmd(Delete, args, replyChan)
+	return replyChan
+}
+
+func (db *testDB) DeleteRange(args *proto.DeleteRangeRequest) <-chan *proto.DeleteRangeResponse {
+	replyChan := make(chan *proto.DeleteRangeResponse, 1)
+	go db.executeCmd(DeleteRange, args, replyChan)
+	return replyChan
+}
+
+func (db *testDB) Scan(args *proto.ScanRequest) <-chan *proto.ScanResponse {
+	replyChan := make(chan *proto.ScanResponse, 1)
+	go db.executeCmd(Scan, args, replyChan)
+	return replyChan
+}
+
+func (db *testDB) BeginTransaction(args *proto.BeginTransactionRequest) <-chan *proto.BeginTransactionResponse {
+	txn := NewTransaction(args.Key, args.UserPriority, args.Isolation, db.clock)
+	reply := &proto.BeginTransactionResponse{
+		ResponseHeader: proto.ResponseHeader{
+			Timestamp: txn.Timestamp,
+		},
+		Txn: txn,
+	}
+	replyChan := make(chan *proto.BeginTransactionResponse, 1)
+	replyChan <- reply
+	return replyChan
+}
+
+func (db *testDB) EndTransaction(args *proto.EndTransactionRequest) <-chan *proto.EndTransactionResponse {
+	replyChan := make(chan *proto.EndTransactionResponse, 1)
+	go db.executeCmd(EndTransaction, args, replyChan)
+	return replyChan
+}
+
+func (db *testDB) AccumulateTS(args *proto.AccumulateTSRequest) <-chan *proto.AccumulateTSResponse {
+	replyChan := make(chan *proto.AccumulateTSResponse, 1)
+	go db.executeCmd(AccumulateTS, args, replyChan)
+	return replyChan
+}
+
+func (db *testDB) ReapQueue(args *proto.ReapQueueRequest) <-chan *proto.ReapQueueResponse {
+	replyChan := make(chan *proto.ReapQueueResponse, 1)
+	go db.executeCmd(ReapQueue, args, replyChan)
+	return replyChan
+}
+
+func (db *testDB) EnqueueUpdate(args *proto.EnqueueUpdateRequest) <-chan *proto.EnqueueUpdateResponse {
+	replyChan := make(chan *proto.EnqueueUpdateResponse, 1)
+	go db.executeCmd(EnqueueUpdate, args, replyChan)
+	return replyChan
+}
+
+func (db *testDB) EnqueueMessage(args *proto.EnqueueMessageRequest) <-chan *proto.EnqueueMessageResponse {
+	replyChan := make(chan *proto.EnqueueMessageResponse, 1)
+	go db.executeCmd(EnqueueMessage, args, replyChan)
+	return replyChan
+}
+
+func (db *testDB) InternalHeartbeatTxn(args *proto.InternalHeartbeatTxnRequest) <-chan *proto.InternalHeartbeatTxnResponse {
+	replyChan := make(chan *proto.InternalHeartbeatTxnResponse, 1)
+	go db.executeCmd(InternalHeartbeatTxn, args, replyChan)
+	return replyChan
+}
+
+func (db *testDB) InternalResolveIntent(args *proto.InternalResolveIntentRequest) <-chan *proto.InternalResolveIntentResponse {
+	replyChan := make(chan *proto.InternalResolveIntentResponse, 1)
+	go db.executeCmd(InternalResolveIntent, args, replyChan)
+	return replyChan
+}
+
+func (db *testDB) InternalSnapshotCopy(args *proto.InternalSnapshotCopyRequest) <-chan *proto.InternalSnapshotCopyResponse {
+	replyChan := make(chan *proto.InternalSnapshotCopyResponse, 1)
+	go db.executeCmd(InternalSnapshotCopy, args, replyChan)
+	return replyChan
+}

--- a/storage/engine/keys.go
+++ b/storage/engine/keys.go
@@ -177,6 +177,9 @@ var (
 	// KeyLocalIdent stores an immutable identifier for this store,
 	// created when the store is first bootstrapped.
 	KeyLocalIdent = MakeKey(KeyLocalPrefix, Key("store-ident"))
+	// KeyLocalRangeIDGenerator is a range ID generator sequence. Range
+	// IDs must be unique per node ID.
+	KeyLocalRangeIDGenerator = MakeKey(KeyLocalPrefix, Key("range-idgen"))
 	// KeyLocalRangeMetadataPrefix is the prefix for keys storing range metadata.
 	// The value is a struct of type RangeMetadata.
 	KeyLocalRangeMetadataPrefix = MakeKey(KeyLocalPrefix, Key("range-"))
@@ -223,8 +226,8 @@ var (
 	KeyConfigZonePrefix = MakeKey(KeySystemPrefix, Key("zone"))
 	// KeyNodeIDGenerator contains a sequence generator for node IDs.
 	KeyNodeIDGenerator = MakeKey(KeySystemPrefix, Key("node-idgen"))
-	// KeyRangeIDGenerator is a range ID generator sequence.
-	KeyRangeIDGenerator = MakeKey(KeySystemPrefix, Key("range-idgen"))
+	// KeyRaftIDGenerator is a Raft consensus group ID generator sequence.
+	KeyRaftIDGenerator = MakeKey(KeySystemPrefix, Key("raft-idgen"))
 	// KeySchemaPrefix specifies key prefixes for schema definitions.
 	KeySchemaPrefix = MakeKey(KeySystemPrefix, Key("schema"))
 	// KeyStoreIDGeneratorPrefix specifies key prefixes for sequence

--- a/storage/engine/keys.go
+++ b/storage/engine/keys.go
@@ -177,9 +177,6 @@ var (
 	// KeyLocalIdent stores an immutable identifier for this store,
 	// created when the store is first bootstrapped.
 	KeyLocalIdent = MakeKey(KeyLocalPrefix, Key("store-ident"))
-	// KeyLocalRangeIDGenerator is a range ID generator sequence. Range IDs
-	// must be unique per node ID.
-	KeyLocalRangeIDGenerator = MakeKey(KeyLocalPrefix, Key("range-idgen"))
 	// KeyLocalRangeMetadataPrefix is the prefix for keys storing range metadata.
 	// The value is a struct of type RangeMetadata.
 	KeyLocalRangeMetadataPrefix = MakeKey(KeyLocalPrefix, Key("range-"))
@@ -226,6 +223,8 @@ var (
 	KeyConfigZonePrefix = MakeKey(KeySystemPrefix, Key("zone"))
 	// KeyNodeIDGenerator contains a sequence generator for node IDs.
 	KeyNodeIDGenerator = MakeKey(KeySystemPrefix, Key("node-idgen"))
+	// KeyRangeIDGenerator is a range ID generator sequence.
+	KeyRangeIDGenerator = MakeKey(KeySystemPrefix, Key("range-idgen"))
 	// KeySchemaPrefix specifies key prefixes for schema definitions.
 	KeySchemaPrefix = MakeKey(KeySystemPrefix, Key("schema"))
 	// KeyStoreIDGeneratorPrefix specifies key prefixes for sequence

--- a/storage/range_test.go
+++ b/storage/range_test.go
@@ -37,19 +37,18 @@ import (
 
 var (
 	testRangeDescriptor = proto.RangeDescriptor{
+		RangeID:  1,
 		StartKey: engine.KeyMin,
 		EndKey:   engine.KeyMax,
 		Replicas: []proto.Replica{
 			{
 				NodeID:  1,
 				StoreID: 1,
-				RangeID: 1,
 				Attrs:   proto.Attributes{Attrs: []string{"dc1", "mem"}},
 			},
 			{
 				NodeID:  2,
 				StoreID: 1,
-				RangeID: 1,
 				Attrs:   proto.Attributes{Attrs: []string{"dc2", "mem"}},
 			},
 		},
@@ -60,7 +59,7 @@ var (
 		Write: []string{"root"},
 	}
 	testDefaultZoneConfig = proto.ZoneConfig{
-		Replicas: []proto.Attributes{
+		ReplicaAttrs: []proto.Attributes{
 			proto.Attributes{Attrs: []string{"dc1", "mem"}},
 			proto.Attributes{Attrs: []string{"dc2", "mem"}},
 		},
@@ -88,7 +87,7 @@ func createTestEngine(t *testing.T) engine.Engine {
 // of the keyspace. The gossip instance is also returned for testing.
 func createTestRange(engine engine.Engine, t *testing.T) (*Range, *gossip.Gossip) {
 	rm := &proto.RangeMetadata{
-		RangeID:         0,
+		ClusterID:       "cluster1",
 		RangeDescriptor: testRangeDescriptor,
 	}
 	g := gossip.New(rpc.LoadInsecureTLSConfig())
@@ -262,7 +261,7 @@ func getArgs(key []byte, rangeID int64) (*proto.GetRequest, *proto.GetResponse) 
 	args := &proto.GetRequest{
 		RequestHeader: proto.RequestHeader{
 			Key:     key,
-			Replica: proto.Replica{RangeID: rangeID},
+			RangeID: rangeID,
 		},
 	}
 	reply := &proto.GetResponse{}
@@ -275,7 +274,7 @@ func putArgs(key, value []byte, rangeID int64) (*proto.PutRequest, *proto.PutRes
 	args := &proto.PutRequest{
 		RequestHeader: proto.RequestHeader{
 			Key:     key,
-			Replica: proto.Replica{RangeID: rangeID},
+			RangeID: rangeID,
 		},
 		Value: proto.Value{
 			Bytes: value,
@@ -291,7 +290,7 @@ func incrementArgs(key []byte, inc int64, rangeID int64) (*proto.IncrementReques
 	args := &proto.IncrementRequest{
 		RequestHeader: proto.RequestHeader{
 			Key:     key,
-			Replica: proto.Replica{RangeID: rangeID},
+			RangeID: rangeID,
 		},
 		Increment: inc,
 	}
@@ -306,7 +305,7 @@ func endTxnArgs(txn *proto.Transaction, commit bool, rangeID int64) (
 	args := &proto.EndTransactionRequest{
 		RequestHeader: proto.RequestHeader{
 			Key:     txn.ID,
-			Replica: proto.Replica{RangeID: rangeID},
+			RangeID: rangeID,
 			Txn:     txn,
 		},
 		Commit: commit,
@@ -321,7 +320,7 @@ func heartbeatArgs(txn *proto.Transaction, rangeID int64) (
 	args := &proto.InternalHeartbeatTxnRequest{
 		RequestHeader: proto.RequestHeader{
 			Key:     txn.ID,
-			Replica: proto.Replica{RangeID: rangeID},
+			RangeID: rangeID,
 			Txn:     txn,
 		},
 	}
@@ -337,7 +336,7 @@ func internalSnapshotCopyArgs(key []byte, endKey []byte, maxResults int64, snaps
 		RequestHeader: proto.RequestHeader{
 			Key:     key,
 			EndKey:  endKey,
-			Replica: proto.Replica{RangeID: rangeID},
+			RangeID: rangeID,
 		},
 		SnapshotId: snapshotID,
 		MaxResults: maxResults,

--- a/storage/range_test.go
+++ b/storage/range_test.go
@@ -37,18 +37,20 @@ import (
 
 var (
 	testRangeDescriptor = proto.RangeDescriptor{
-		RangeID:  1,
+		RaftID:   1,
 		StartKey: engine.KeyMin,
 		EndKey:   engine.KeyMax,
 		Replicas: []proto.Replica{
 			{
 				NodeID:  1,
 				StoreID: 1,
+				RangeID: 1,
 				Attrs:   proto.Attributes{Attrs: []string{"dc1", "mem"}},
 			},
 			{
 				NodeID:  2,
 				StoreID: 1,
+				RangeID: 1,
 				Attrs:   proto.Attributes{Attrs: []string{"dc2", "mem"}},
 			},
 		},
@@ -89,6 +91,7 @@ func createTestRange(engine engine.Engine, t *testing.T) (*Range, *gossip.Gossip
 	rm := &proto.RangeMetadata{
 		ClusterID:       "cluster1",
 		RangeDescriptor: testRangeDescriptor,
+		RangeID:         0,
 	}
 	g := gossip.New(rpc.LoadInsecureTLSConfig())
 	clock := hlc.NewClock(hlc.UnixNano)
@@ -261,7 +264,7 @@ func getArgs(key []byte, rangeID int64) (*proto.GetRequest, *proto.GetResponse) 
 	args := &proto.GetRequest{
 		RequestHeader: proto.RequestHeader{
 			Key:     key,
-			RangeID: rangeID,
+			Replica: proto.Replica{RangeID: rangeID},
 		},
 	}
 	reply := &proto.GetResponse{}
@@ -274,7 +277,7 @@ func putArgs(key, value []byte, rangeID int64) (*proto.PutRequest, *proto.PutRes
 	args := &proto.PutRequest{
 		RequestHeader: proto.RequestHeader{
 			Key:     key,
-			RangeID: rangeID,
+			Replica: proto.Replica{RangeID: rangeID},
 		},
 		Value: proto.Value{
 			Bytes: value,
@@ -290,7 +293,7 @@ func incrementArgs(key []byte, inc int64, rangeID int64) (*proto.IncrementReques
 	args := &proto.IncrementRequest{
 		RequestHeader: proto.RequestHeader{
 			Key:     key,
-			RangeID: rangeID,
+			Replica: proto.Replica{RangeID: rangeID},
 		},
 		Increment: inc,
 	}
@@ -305,7 +308,7 @@ func endTxnArgs(txn *proto.Transaction, commit bool, rangeID int64) (
 	args := &proto.EndTransactionRequest{
 		RequestHeader: proto.RequestHeader{
 			Key:     txn.ID,
-			RangeID: rangeID,
+			Replica: proto.Replica{RangeID: rangeID},
 			Txn:     txn,
 		},
 		Commit: commit,
@@ -320,7 +323,7 @@ func heartbeatArgs(txn *proto.Transaction, rangeID int64) (
 	args := &proto.InternalHeartbeatTxnRequest{
 		RequestHeader: proto.RequestHeader{
 			Key:     txn.ID,
-			RangeID: rangeID,
+			Replica: proto.Replica{RangeID: rangeID},
 			Txn:     txn,
 		},
 	}
@@ -336,7 +339,7 @@ func internalSnapshotCopyArgs(key []byte, endKey []byte, maxResults int64, snaps
 		RequestHeader: proto.RequestHeader{
 			Key:     key,
 			EndKey:  endKey,
-			RangeID: rangeID,
+			Replica: proto.Replica{RangeID: rangeID},
 		},
 		SnapshotId: snapshotID,
 		MaxResults: maxResults,

--- a/storage/store.go
+++ b/storage/store.go
@@ -21,6 +21,7 @@ import (
 	"bytes"
 	"fmt"
 	"net"
+	"sort"
 	"strconv"
 	"sync"
 	"time"
@@ -38,7 +39,17 @@ const (
 	// GCResponseCacheExpiration is the expiration duration for response
 	// cache entries.
 	GCResponseCacheExpiration = 1 * time.Hour
+	// rangeIDAllocCount is the number of range IDs to allocate per allocation.
+	rangeIDAllocCount = 10
 )
+
+func init() {
+	// rangeIDAllocCount should be high enough to allow us to advance
+	// it; if not just panic here.
+	if rangeIDAllocCount <= 1 {
+		panic("rangeIDAllocCount must be greater than 1")
+	}
+}
 
 // rangeMetadataKeyPrefix and hexadecimal-formatted range ID.
 func makeRangeKey(rangeID int64) engine.Key {
@@ -106,18 +117,23 @@ type Store struct {
 	Ident     proto.StoreIdent
 	clock     *hlc.Clock
 	engine    engine.Engine  // The underlying key-value store
+	db        DB             // Cockroach KV DB
 	allocator *allocator     // Makes allocation decisions
 	gossip    *gossip.Gossip // Passed to new ranges
 
-	mu     sync.RWMutex     // Protects ranges
-	ranges map[int64]*Range // Map of ranges by range ID
+	mu          sync.RWMutex     // Protects variables below...
+	ranges      map[int64]*Range // Map of ranges by range ID
+	rangesByKey RangeSlice       // Sorted slice of ranges by StartKey
+	nextRangeID int64            // Next available range ID
+	lastRangeID int64            // Last available range ID in pre-alloc'd block
 }
 
 // NewStore returns a new instance of a store.
-func NewStore(clock *hlc.Clock, engine engine.Engine, gossip *gossip.Gossip) *Store {
+func NewStore(clock *hlc.Clock, engine engine.Engine, db DB, gossip *gossip.Gossip) *Store {
 	return &Store{
 		clock:     clock,
 		engine:    engine,
+		db:        db,
 		allocator: &allocator{},
 		gossip:    gossip,
 		ranges:    map[int64]*Range{},
@@ -131,6 +147,8 @@ func (s *Store) Close() {
 	for _, rng := range s.ranges {
 		rng.Stop()
 	}
+	s.ranges = map[int64]*Range{}
+	s.rangesByKey = nil
 }
 
 // String formats a store for debug output.
@@ -144,6 +162,9 @@ func (s *Store) Init() error {
 	if err := s.engine.Start(); err != nil {
 		return err
 	}
+	// GCTimeouts method is called each time an engine compaction is
+	// underway. It sets minimum timeouts for transaction records and
+	// response cache entries.
 	s.engine.SetGCTimeouts(func() (minTxnTS, minRCacheTS int64) {
 		now := s.clock.Now()
 		minTxnTS = 0 // disable GC of transactions until we know minimum write intent age
@@ -162,9 +183,8 @@ func (s *Store) Init() error {
 	// TODO(spencer): scan through all range metadata and instantiate
 	// ranges. Right now we just get range ID hardcoded as 1.
 	var meta proto.RangeMetadata
-	ok, err = engine.GetProto(s.engine, makeRangeKey(1), &meta)
-	if err != nil || !ok {
-		return err
+	if ok, err = engine.GetProto(s.engine, makeRangeKey(1), &meta); err != nil || !ok {
+		return util.Errorf("unable to read range 1: %v", err)
 	}
 
 	rng := NewRange(&meta, s.clock, s.engine, s.allocator, s.gossip, s)
@@ -173,6 +193,7 @@ func (s *Store) Init() error {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 	s.ranges[meta.RangeID] = rng
+	s.rangesByKey = append(s.rangesByKey, rng)
 	return nil
 }
 
@@ -205,36 +226,38 @@ func (s *Store) GetRange(rangeID int64) (*Range, error) {
 	return nil, proto.NewRangeNotFoundError(rangeID)
 }
 
-// GetRanges fetches all ranges.
-func (s *Store) GetRanges() RangeSlice {
+// LookupRange looks up a range via binary search over the sorted
+// "rangesByKey" RangeSlice. Returns nil if no range is found for
+// specified key range.
+func (s *Store) LookupRange(start, end engine.Key) *Range {
 	s.mu.RLock()
 	defer s.mu.RUnlock()
-	var ranges RangeSlice
-	for _, rng := range s.ranges {
-		ranges = append(ranges, rng)
+	n := sort.Search(len(s.rangesByKey), func(i int) bool {
+		return bytes.Compare(start, s.rangesByKey[i].Meta.EndKey) < 0
+	})
+	if n >= len(s.rangesByKey) || !s.rangesByKey[n].Meta.ContainsKeyRange(start, end) {
+		return nil
 	}
-	return ranges
-	// TODO(spencer): any changes to the ranges map will need to also
-	// update the caller of this method. This can probably be done
-	// using a listener for a store's range changes.
+	return s.rangesByKey[n]
 }
 
-// CreateRange allocates a new range ID and stores range metadata.
-// On success, returns the new range.
+// CreateRange creates a new range by allocating a new range ID and
+// storing range metadata. On success, returns the new range.
 func (s *Store) CreateRange(startKey, endKey engine.Key, replicas []proto.Replica) (*Range, error) {
-	rangeID, err := engine.Increment(s.engine, engine.KeyLocalRangeIDGenerator, 1)
+	rangeID, err := s.allocateRangeID()
 	if err != nil {
 		return nil, err
 	}
+
 	if ok, _ := engine.GetProto(s.engine, makeRangeKey(rangeID), nil); ok {
-		return nil, util.Error("newly allocated range ID already in use")
+		return nil, util.Error("range ID already in use")
 	}
 	// RangeMetadata is stored local to this store only. It is neither
 	// replicated via raft nor available via the global kv store.
 	meta := &proto.RangeMetadata{
 		ClusterID: s.Ident.ClusterID,
-		RangeID:   rangeID,
 		RangeDescriptor: proto.RangeDescriptor{
+			RangeID:  rangeID,
 			StartKey: startKey,
 			EndKey:   endKey,
 			Replicas: replicas,
@@ -249,6 +272,9 @@ func (s *Store) CreateRange(startKey, endKey engine.Key, replicas []proto.Replic
 	s.mu.Lock()
 	defer s.mu.Unlock()
 	s.ranges[rangeID] = rng
+	// Append new ranges to rangesByKey and keep sorted.
+	s.rangesByKey = append(s.rangesByKey, rng)
+	sort.Sort(s.rangesByKey)
 	return rng, nil
 }
 
@@ -300,7 +326,7 @@ func (s *Store) ExecuteCmd(method string, args proto.Request, reply proto.Respon
 	}
 
 	// Verify specified range contains the command's implicated keys.
-	rng, err := s.GetRange(header.Replica.RangeID)
+	rng, err := s.GetRange(header.RangeID)
 	if err != nil {
 		return err
 	}
@@ -317,6 +343,53 @@ func (s *Store) ExecuteCmd(method string, args proto.Request, reply proto.Respon
 		return rng.ReadOnlyCmd(method, args, reply)
 	}
 	return rng.ReadWriteCmd(method, args, reply)
+}
+
+// allocateRangeID allocates a new range ID from the global KV DB.
+// Each store allocates blocks of IDS in rangeIDAllocCount increments
+// for efficiency.
+func (s *Store) allocateRangeID() (int64, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	// Handle the bootstrapping case where db is nil; bootstrap range ID is 1.
+	if s.db == nil {
+		return 1, nil
+	}
+	// If we have pre-alloc'd range IDs available, return one.
+	if s.nextRangeID < s.lastRangeID {
+		s.nextRangeID++
+		return s.nextRangeID - 1, nil
+	}
+
+	// Unlock mutex in anticipation of increment.
+	s.mu.Unlock()
+	ir := <-s.db.Increment(&proto.IncrementRequest{
+		RequestHeader: proto.RequestHeader{
+			Key:  engine.KeyRangeIDGenerator,
+			User: UserRoot,
+		},
+		Increment: rangeIDAllocCount,
+	})
+	// Re-lock mutex after call to increment. The deferred unlock is
+	// still in effect.
+	s.mu.Lock()
+	if ir.Error != nil {
+		return 0, util.Errorf("unable to allocate range IDs: %v", ir.Error)
+	}
+	if ir.NewValue <= 1 {
+		return 0, util.Errorf("range ID allocation returned invalid allocation: %+v", ir)
+	}
+
+	s.lastRangeID = ir.NewValue + 1
+	s.nextRangeID = ir.NewValue - rangeIDAllocCount + 1
+	// Range ID 1 is reserved for the bootstrap range.
+	if s.nextRangeID <= 1 {
+		s.nextRangeID = 2
+	}
+	s.nextRangeID++
+	return s.nextRangeID - 1, nil
+
 }
 
 // RangeManager is an interface satisfied by Store through which ranges

--- a/storage/store_test.go
+++ b/storage/store_test.go
@@ -14,6 +14,8 @@
 // for names of contributors.
 //
 // Author: Spencer Kimball (spencer.kimball@gmail.com)
+// Author: Matthew O'Connor (matthew.t.oconnor@gmail.com)
+// Author: Zach Brock (zbrock@gmail.com)
 
 package storage
 
@@ -41,7 +43,7 @@ func TestStoreInitAndBootstrap(t *testing.T) {
 	manual := hlc.ManualClock(0)
 	clock := hlc.NewClock(manual.UnixNano)
 	eng := engine.NewInMem(proto.Attributes{}, 1<<20)
-	store := NewStore(clock, eng, nil)
+	store := NewStore(clock, eng, nil, nil)
 	defer store.Close()
 
 	// Can't init as haven't bootstrapped.
@@ -68,7 +70,7 @@ func TestStoreInitAndBootstrap(t *testing.T) {
 	}
 
 	// Now, attempt to initialize a store with a now-bootstrapped engine.
-	store = NewStore(clock, eng, nil)
+	store = NewStore(clock, eng, nil, nil)
 	if err := store.Init(); err != nil {
 		t.Errorf("failure initializing bootstrapped store: %v", err)
 	}
@@ -89,7 +91,7 @@ func TestBootstrapOfNonEmptyStore(t *testing.T) {
 	}
 	manual := hlc.ManualClock(0)
 	clock := hlc.NewClock(manual.UnixNano)
-	store := NewStore(clock, eng, nil)
+	store := NewStore(clock, eng, nil, nil)
 	defer store.Close()
 
 	// Can't init as haven't bootstrapped.
@@ -125,18 +127,32 @@ func TestRangeSliceSort(t *testing.T) {
 
 // createTestStore creates a test store using an in-memory
 // engine. Returns the store clock's manual unix nanos time and the
-// store. A single range from key "a" to key "z" is setup in the store
-// with a default replica descriptor (i.e. StoreID = 0, RangeID = 1,
-// etc.). The caller is responsible for closing the store on exit.
-func createTestStore(t *testing.T) (*Store, *hlc.ManualClock) {
+// store. If createDefaultRange is true, creates a single range from
+// key "a" to key "z" with a default replica descriptor (i.e. StoreID
+// = 0, RangeID = 1, etc.). The caller is responsible for closing the
+// store on exit.
+func createTestStore(createDefaultRange bool, t *testing.T) (*Store, *hlc.ManualClock) {
 	manual := hlc.ManualClock(0)
 	clock := hlc.NewClock(manual.UnixNano)
 	eng := engine.NewInMem(proto.Attributes{}, 1<<20)
-	store := NewStore(clock, eng, nil)
-	replica := proto.Replica{RangeID: 1}
-	_, err := store.CreateRange(engine.Key("a"), engine.Key("z"), []proto.Replica{replica})
+	store := NewStore(clock, eng, nil, nil)
+	store.Ident.StoreID = 1
+	replica := proto.Replica{StoreID: 1}
+	// Create system key range for allocations.
+	_, err := store.CreateRange(engine.KeySystemPrefix, engine.PrefixEndKey(engine.KeySystemPrefix), []proto.Replica{replica})
 	if err != nil {
 		t.Fatal(err)
+	}
+	// Now that the system key range is available, set store DB so new
+	// ranges can be allocated as needed for tests.
+	db, _ := newTestDB(store)
+	store.db = db
+	// If requested, create a default range for tests from "a"-"z".
+	if createDefaultRange {
+		_, err := store.CreateRange(engine.Key("a"), engine.Key("z"), []proto.Replica{replica})
+		if err != nil {
+			t.Fatal(err)
+		}
 	}
 	return store, &manual
 }
@@ -144,9 +160,9 @@ func createTestStore(t *testing.T) (*Store, *hlc.ManualClock) {
 // TestStoreExecuteCmd verifies straightforward command execution
 // of both a read-only and a read-write command.
 func TestStoreExecuteCmd(t *testing.T) {
-	store, _ := createTestStore(t)
+	store, _ := createTestStore(true, t)
 	defer store.Close()
-	args, reply := getArgs([]byte("a"), 1)
+	args, reply := getArgs([]byte("a"), 2)
 
 	// Try a successful get request.
 	err := store.ExecuteCmd("Get", args, reply)
@@ -157,9 +173,9 @@ func TestStoreExecuteCmd(t *testing.T) {
 
 // TestStoreExecuteCmdUpdateTime verifies that the node clock is updated.
 func TestStoreExecuteCmdUpdateTime(t *testing.T) {
-	store, _ := createTestStore(t)
+	store, _ := createTestStore(true, t)
 	defer store.Close()
-	args, reply := getArgs([]byte("a"), 1)
+	args, reply := getArgs([]byte("a"), 2)
 	args.Timestamp = store.clock.Now()
 	args.Timestamp.WallTime += (100 * time.Millisecond).Nanoseconds()
 	err := store.ExecuteCmd("Get", args, reply)
@@ -175,9 +191,9 @@ func TestStoreExecuteCmdUpdateTime(t *testing.T) {
 // TestStoreExecuteCmdWithZeroTime verifies that no timestamp causes
 // the command to assume the node's wall time.
 func TestStoreExecuteCmdWithZeroTime(t *testing.T) {
-	store, mc := createTestStore(t)
+	store, mc := createTestStore(true, t)
 	defer store.Close()
-	args, reply := getArgs([]byte("a"), 1)
+	args, reply := getArgs([]byte("a"), 2)
 
 	// Set clock to time 1.
 	*mc = hlc.ManualClock(1)
@@ -197,9 +213,9 @@ func TestStoreExecuteCmdWithZeroTime(t *testing.T) {
 // specifies a timestamp further into the future than the node's
 // maximum allowed clock drift, the cmd fails with an error.
 func TestStoreExecuteCmdWithClockDrift(t *testing.T) {
-	store, mc := createTestStore(t)
+	store, mc := createTestStore(true, t)
 	defer store.Close()
-	args, reply := getArgs([]byte("a"), 1)
+	args, reply := getArgs([]byte("a"), 2)
 
 	// Set clock to time 1.
 	*mc = hlc.ManualClock(1)
@@ -215,13 +231,13 @@ func TestStoreExecuteCmdWithClockDrift(t *testing.T) {
 	}
 }
 
-// TestStoreExecuteCmdBadRange passes a bad range replica.
+// TestStoreExecuteCmdBadRange passes a bad range.
 func TestStoreExecuteCmdBadRange(t *testing.T) {
-	store, _ := createTestStore(t)
+	store, _ := createTestStore(true, t)
 	defer store.Close()
 	// Range is from "a" to "z", so this value should fail.
-	args, reply := getArgs([]byte("0"), 1)
-	args.Replica.RangeID = 2
+	args, reply := getArgs([]byte("0"), 2)
+	args.RangeID = 2
 	err := store.ExecuteCmd("Get", args, reply)
 	if err == nil {
 		t.Error("expected invalid range")
@@ -231,12 +247,56 @@ func TestStoreExecuteCmdBadRange(t *testing.T) {
 // TestStoreExecuteCmdOutOfRange passes a key not contained
 // within the range's key range.
 func TestStoreExecuteCmdOutOfRange(t *testing.T) {
-	store, _ := createTestStore(t)
+	store, _ := createTestStore(true, t)
 	defer store.Close()
 	// Range is from "a" to "z", so this value should fail.
-	args, reply := getArgs([]byte("0"), 1)
+	args, reply := getArgs([]byte("0"), 2)
 	err := store.ExecuteCmd("Get", args, reply)
 	if err == nil {
 		t.Error("expected key to be out of range")
+	}
+}
+
+func addTestRange(store *Store, start, end engine.Key, t *testing.T) *Range {
+	replicas := []proto.Replica{
+		proto.Replica{StoreID: store.Ident.StoreID},
+	}
+	r, err := store.CreateRange(start, end, replicas)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return r
+}
+
+// TestStoreRangesByKey verifies we can lookup ranges by key using
+// the sorted rangesByKey slice.
+func TestStoreRangesByKey(t *testing.T) {
+	store, _ := createTestStore(false, t)
+	defer store.Close()
+
+	r1 := addTestRange(store, engine.Key("A"), engine.Key("C"), t)
+	r2 := addTestRange(store, engine.Key("C"), engine.Key("X"), t)
+	r3 := addTestRange(store, engine.Key("X"), engine.Key("ZZ"), t)
+
+	if store.LookupRange(engine.Key("a"), nil) != nil {
+		t.Errorf("expected \"a\" to not have an associated range")
+	}
+	if r := store.LookupRange(engine.Key("B"), nil); r != r1 {
+		t.Errorf("mismatched range %+v != %+v", r, r1.Meta)
+	}
+	if r := store.LookupRange(engine.Key("C"), nil); r != r2 {
+		t.Errorf("mismatched range %+v != %+v", r, r2.Meta)
+	}
+	if r := store.LookupRange(engine.Key("M"), nil); r != r2 {
+		t.Errorf("mismatched range %+v != %+v", r, r2.Meta)
+	}
+	if r := store.LookupRange(engine.Key("X"), nil); r != r3 {
+		t.Errorf("mismatched range %+v != %+v", r, r3.Meta)
+	}
+	if r := store.LookupRange(engine.Key("Z"), nil); r != r3 {
+		t.Errorf("mismatched range %+v != %+v", r, r3.Meta)
+	}
+	if store.LookupRange(engine.KeyMax, nil) != nil {
+		t.Errorf("expected engine.KeyMax to not have an associated range")
 	}
 }

--- a/storage/store_test.go
+++ b/storage/store_test.go
@@ -257,6 +257,22 @@ func TestStoreExecuteCmdOutOfRange(t *testing.T) {
 	}
 }
 
+// TestStoreRangeIDAllocation verifies that range IDs are
+// allocated in successive blocks.
+func TestStoreRangeIDAllocation(t *testing.T) {
+	store, _ := createTestStore(false, t)
+	defer store.Close()
+
+	// Range IDs should be allocated from ID 2 (first alloc'd range)
+	// to rangeIDCount * 3 + 1.
+	for i := 0; i < rangeIDAllocCount*3; i++ {
+		r := addTestRange(store, engine.Key(fmt.Sprintf("%03d", i)), engine.Key(fmt.Sprintf("%03d", i+1)), t)
+		if r.Meta.RangeID != int64(2+i) {
+			t.Error("expected range id %d; got %d", 2+i, r.Meta.RangeID)
+		}
+	}
+}
+
 func addTestRange(store *Store, start, end engine.Key, t *testing.T) *Range {
 	replicas := []proto.Replica{
 		proto.Replica{StoreID: store.Ident.StoreID},


### PR DESCRIPTION
Previously, the range ID was chosen as unique / store for every new range
replica created on a store. This means that there was previously no way
to refer to a Raft consensus group by ID. The only way would have been to
use StartKey->EndKey.

Now, ranges are allocated from a global id allocator in blocks by stores.
When new ranges are created, an ID is taken from the pre-alloc'd block.

Range ID has now been moved out of proto.Replica and moved into RangeDescriptor.
Replica no only specifies NodeID and StoreID, which is enough information to
locate the device where a replica of the range can be found.

RangeID was not needed in RangeMetadata, so was removed from there.
Also, ZoneConfig.Replicas was renamed ZoneConfig.ReplicaAttrs to eliminate
confusion.
