### PR TITLE
Push Txns & Resolve Intents on Conflicts

### DIFF
--- a/proto/api.go
+++ b/proto/api.go
@@ -55,8 +55,7 @@ func (rh *ResponseHeader) Verify(req Request) error {
 	return nil
 }
 
-// GoError converts the Error field of the response header to a
-// GenericError.
+// GoError returns the non-nil error from the proto.Error union.
 func (rh *ResponseHeader) GoError() error {
 	if rh.Error == nil {
 		return nil
@@ -74,6 +73,10 @@ func (rh *ResponseHeader) GoError() error {
 		return rh.Error.TransactionStatus
 	case rh.Error.TransactionRetry != nil:
 		return rh.Error.TransactionRetry
+	case rh.Error.WriteIntent != nil:
+		return rh.Error.WriteIntent
+	case rh.Error.WriteTooOld != nil:
+		return rh.Error.WriteTooOld
 	default:
 		return nil
 	}
@@ -97,6 +100,10 @@ func (rh *ResponseHeader) SetGoError(err error) {
 		rh.Error = &Error{TransactionStatus: t}
 	case *TransactionRetryError:
 		rh.Error = &Error{TransactionRetry: t}
+	case *WriteIntentError:
+		rh.Error = &Error{WriteIntent: t}
+	case *WriteTooOldError:
+		rh.Error = &Error{WriteTooOld: t}
 	default:
 		var canRetry bool
 		if r, ok := err.(util.Retryable); ok {

--- a/proto/errors.go
+++ b/proto/errors.go
@@ -63,9 +63,8 @@ func NewRangeKeyMismatchError(start, end []byte, meta *RangeMetadata) *RangeKeyM
 // Error formats error.
 func (e *RangeKeyMismatchError) Error() string {
 	if e.Range != nil {
-		return fmt.Sprintf("key range %q-%q outside of bounds of range %q: %q-%q",
-			string(e.RequestStartKey), string(e.RequestEndKey),
-			string(e.Range.RangeID),
+		return fmt.Sprintf("key range %q-%q outside of bounds of range %d: %q-%q",
+			string(e.RequestStartKey), string(e.RequestEndKey), e.Range.RangeID,
 			string(e.Range.StartKey), string(e.Range.EndKey))
 	}
 	return fmt.Sprintf("key range %q-%q could not be located within a range on store",
@@ -103,4 +102,17 @@ func (e *TransactionRetryError) Error() string {
 // CanRetry indicates whether or not this TransactionRetryError can be retried.
 func (e *TransactionRetryError) CanRetry() bool {
 	return true
+}
+
+// Error formats error.
+func (e *WriteIntentError) Error() string {
+	return fmt.Sprintf("conflicting write intent at key %q from transaction %+v", e.Key, e.Txn)
+}
+
+// Error formats error.
+func (e *WriteTooOldError) Error() string {
+	if e.Txn != nil {
+		return fmt.Sprintf("cannot write with a timestamp older than %+v, or older txn epoch: %+v", e.Timestamp, e.Txn)
+	}
+	return fmt.Sprintf("cannot write with a timestamp older than %+v", e.Timestamp)
 }

--- a/proto/errors.proto
+++ b/proto/errors.proto
@@ -34,21 +34,21 @@ message NotLeaderError {
   optional Replica leader = 1 [(gogoproto.nullable) = false];
 }
 
-// RangeNotFoundError indicates that a command was sent to a range
+// A RangeNotFoundError indicates that a command was sent to a range
 // which is not hosted on this store.
 message RangeNotFoundError {
   optional int64 range_id = 1 [(gogoproto.nullable) = false, (gogoproto.customname) = "RangeID"];
 }
 
-// RangeKeyMismatchError indicates that a command was sent to a range which did
-// not contain the key(s) specified by the command.
+// A RangeKeyMismatchError indicates that a command was sent to a
+// range which did not contain the key(s) specified by the command.
 message RangeKeyMismatchError {
   optional bytes request_start_key = 1 [(gogoproto.nullable) = false];
   optional bytes request_end_key = 2 [(gogoproto.nullable) = false];
   optional RangeMetadata range = 3;
 }
 
-// TransactionStatusError indicates that the transaction status is
+// A TransactionStatusError indicates that the transaction status is
 // incompatible with the requested operation. This means the
 // transaction has already either been committed or aborted. It might
 // also be the case that the request to modify the transaction failed
@@ -59,11 +59,32 @@ message TransactionStatusError {
   optional string msg = 2 [(gogoproto.nullable) = false];
 }
 
-// TransactionRetryError indicates that the transaction must be
+// A TransactionRetryError indicates that the transaction must be
 // retried, usually with an increased transaction timestamp. The
 // transaction struct to use is returned with the error.
 message TransactionRetryError {
   optional Transaction txn = 1 [(gogoproto.nullable) = false];
+}
+
+// A WriteIntentError indicates that a write intent belonging to
+// another transaction was encountered leading to a read/write or
+// write/write conflict. The Key at which the intent was encountered
+// is set, as is the Txn record for the intent's transaction.
+// Resolved is set if the intent was successfully resolved, meaning
+// the client may retry the operation immediately. If Resolved is
+// false, the client should back off and retry.
+message WriteIntentError {
+  optional bytes key = 1 [(gogoproto.nullable) = false];
+  optional Transaction txn = 2 [(gogoproto.nullable) = false];
+  optional bool resolved = 3 [(gogoproto.nullable) = false];
+}
+
+// A WriteTooOldError indicates that a write encountered a versioned
+// value newer than its timestamp, making it impossible to rewrite
+// history. The write should be retried at the Timestamp + 1.
+message WriteTooOldError {
+  optional Timestamp timestamp = 1 [(gogoproto.nullable) = false];
+  optional Transaction txn = 2;
 }
 
 // Error is a union type containing all available errors.
@@ -75,4 +96,7 @@ message Error {
   optional RangeKeyMismatchError range_key_mismatch = 4;
   optional TransactionStatusError transaction_status = 5;
   optional TransactionRetryError transaction_retry = 6;
+  optional WriteIntentError write_intent = 7;
+  optional WriteTooOldError write_too_old = 8;
 }
+

--- a/storage/range.go
+++ b/storage/range.go
@@ -257,16 +257,40 @@ func (r *Range) ContainsKeyRange(start, end engine.Key) bool {
 	return r.Meta.ContainsKeyRange(start, end)
 }
 
-// EnqueueCmd enqueues a command to Raft.
-func (r *Range) EnqueueCmd(cmd *Cmd) error {
-	r.raft <- cmd
-	return <-cmd.done
+// AddCmd adds a command for execution on this range. The command's
+// affected keys are verified to be contained within the range and the
+// range's leadership is confirmed. The command is then dispatched
+// either along the read-only execution path or the read-write Raft
+// command queue. If wait is false, read-write commands are added to
+// Raft without waiting for their completion.
+func (r *Range) AddCmd(method string, args proto.Request, reply proto.Response, wait bool) error {
+	header := args.Header()
+	var err error
+	if !r.ContainsKeyRange(header.Key, header.EndKey) {
+		err = proto.NewRangeKeyMismatchError(header.Key, header.EndKey, r.Meta)
+	} else if !r.IsLeader() {
+		// TODO(spencer): when we happen to know the leader, fill it in here via replica.
+		err = &proto.NotLeaderError{}
+	}
+	if err != nil {
+		reply.Header().SetGoError(err)
+		return err
+	}
+
+	// Differentiate between read-only and read-write.
+	if IsReadOnly(method) {
+		if !wait {
+			return util.Errorf("cannot specify !wait for read-only requests")
+		}
+		return r.addReadOnlyCmd(method, args, reply)
+	}
+	return r.addReadWriteCmd(method, args, reply, wait)
 }
 
-// ReadOnlyCmd updates the read timestamp cache and waits for any
+// addReadOnlyCmd updates the read timestamp cache and waits for any
 // overlapping writes currently processing through Raft ahead of us to
 // clear via the read queue.
-func (r *Range) ReadOnlyCmd(method string, args proto.Request, reply proto.Response) error {
+func (r *Range) addReadOnlyCmd(method string, args proto.Request, reply proto.Response) error {
 	header := args.Header()
 	r.Lock()
 	r.tsCache.Add(header.Key, header.EndKey, header.Timestamp)
@@ -297,7 +321,7 @@ func (r *Range) ReadOnlyCmd(method string, args proto.Request, reply proto.Respo
 	return r.executeCmd(method, args, reply)
 }
 
-// ReadWriteCmd first consults the response cache to determine whether
+// addReadWriteCmd first consults the response cache to determine whether
 // this command has already been sent to the range. If a response is
 // found, it's returned immediately and not submitted to raft. Next,
 // the timestamp cache is checked to determine if any newer accesses to
@@ -306,7 +330,8 @@ func (r *Range) ReadOnlyCmd(method string, args proto.Request, reply proto.Respo
 // command are added as pending writes to the read queue and the
 // command is submitted to Raft. Upon completion, the write is removed
 // from the read queue and the reply is added to the repsonse cache.
-func (r *Range) ReadWriteCmd(method string, args proto.Request, reply proto.Response) error {
+// If wait is true, will block until the command is complete.
+func (r *Range) addReadWriteCmd(method string, args proto.Request, reply proto.Response, wait bool) error {
 	// Check the response cache in case this is a replay. This call
 	// may block if the same command is already underway.
 	header := args.Header()
@@ -356,15 +381,29 @@ func (r *Range) ReadWriteCmd(method string, args proto.Request, reply proto.Resp
 		Reply:  reply,
 		done:   make(chan error, 1),
 	}
-	// This waits for the command to complete.
-	err := r.EnqueueCmd(cmd)
+	r.raft <- cmd
 
-	// Now that the command has completed, remove the pending write.
-	r.Lock()
-	r.readQ.RemoveWrite(wKey)
-	r.Unlock()
+	// Create a completion func for mandatory cleanups which we either
+	// run synchronously if we're waiting or in a goroutine otherwise.
+	completionFunc := func() error {
+		err := <-cmd.done
+		// Now that the command has completed, remove the pending write.
+		r.Lock()
+		r.readQ.RemoveWrite(wKey)
+		r.Unlock()
+		// If the original client didn't wait, log execution errors so they're
+		// surfaced somewhere.
+		if !wait && err != nil {
+			log.V(1).Infof("non-synchronous execution of %s with %+v failed: %v", cmd.Method, cmd.Args, err)
+		}
+		return err
+	}
 
-	return err
+	if wait {
+		return completionFunc()
+	}
+	go completionFunc()
+	return nil
 }
 
 // processRaft processes read/write commands, sending them to the Raft
@@ -857,7 +896,9 @@ func (r *Range) InternalHeartbeatTxn(args *proto.InternalHeartbeatTxnRequest, re
 // adjust pushee's persisted txn depending on value of args.Abort. If
 // args.Abort is true, set txn.Status to ABORTED, and priority to one
 // less than the pusher's priority and return success. If args.Abort
-// is false, set txn.Timestamp to pusher's txn.Timestamp + 1.
+// is false, set txn.Timestamp to pusher's Timestamp + 1 (note that
+// we use the pusher's Args.Timestamp, not Txn.Timestamp because the
+// args timestamp can advance during the txn).
 //
 // Higher Txn Priority: If pushee txn has a higher priority than
 // pusher, return TransactionRetryError. Transaction will be retried

--- a/storage/store.go
+++ b/storage/store.go
@@ -32,6 +32,7 @@ import (
 	"github.com/cockroachdb/cockroach/storage/engine"
 	"github.com/cockroachdb/cockroach/util"
 	"github.com/cockroachdb/cockroach/util/hlc"
+	"github.com/cockroachdb/cockroach/util/log"
 )
 
 const (
@@ -385,24 +386,83 @@ func (s *Store) ExecuteCmd(method string, args proto.Request, reply proto.Respon
 		}
 	}
 
-	// Verify specified range contains the command's implicated keys.
+	// Get range and add command to the range for execution.
 	rng, err := s.GetRange(header.Replica.RangeID)
 	if err != nil {
 		return err
 	}
-	if !rng.ContainsKeyRange(header.Key, header.EndKey) {
-		return proto.NewRangeKeyMismatchError(header.Key, header.EndKey, rng.Meta)
+	if err := rng.AddCmd(method, args, reply, true); err == nil {
+		return nil
 	}
-	if !rng.IsLeader() {
-		// TODO(spencer): when we happen to know the leader, fill it in here via replica.
-		return &proto.NotLeaderError{}
+	// Maybe resolve a potential write intent error. We do this here
+	// because this is the code path with the requesting client
+	// waiting. We don't want every replica to attempt to resolve the
+	// intent independently, so we can't do it in Range.executeCmd.
+	return s.maybeResolveWriteIntentError(rng, method, args, reply)
+}
+
+// maybeResolveWriteIntentError checks the reply's error. If the error
+// is a writeIntentError, it tries to push the conflicting
+// transaction: either move its timestamp forward on a read/write
+// conflict, or abort it on a write/write conflict. If the push
+// succeeds, we immediately issue a resolve intent command and set the
+// error's Resolved flag to true so the client retries the command
+// immediately. If the push fails, we set the error's Resolved flag to
+// false so that the client backs off before reissuing the command.
+func (s *Store) maybeResolveWriteIntentError(rng *Range, method string, args proto.Request, reply proto.Response) error {
+	err := reply.Header().GoError()
+	wiErr, ok := err.(*proto.WriteIntentError)
+	if !ok {
+		return err
 	}
 
-	// Differentiate between read-only and read-write.
-	if IsReadOnly(method) {
-		return rng.ReadOnlyCmd(method, args, reply)
+	// Attempt to push the transaction which created the conflicting intent.
+	pushArgs := &proto.InternalPushTxnRequest{
+		RequestHeader: proto.RequestHeader{
+			Timestamp: args.Header().Timestamp,
+			Key:       wiErr.Txn.ID, // Address to pushee's txn
+			User:      args.Header().User,
+			Txn:       args.Header().Txn,
+		},
+		PusheeTxn: wiErr.Txn,
+		Abort:     !IsReadOnly(method), // abort if cmd isn't read-only
 	}
-	return rng.ReadWriteCmd(method, args, reply)
+	pushReply := <-s.db.InternalPushTxn(pushArgs)
+	if pushReply.Header().GoError() != nil {
+		log.V(1).Infof("push %+v failed: %v", pushArgs, pushReply.Header().GoError())
+		return wiErr
+	}
+
+	// Note that even though we're setting Resolved = true here, it'll never
+	// be set in the response cache that way (the response containing this
+	// write intent error was cached right after the command was executed
+	// in Range.executeCmd). This means that a client which retries the request
+	// will always backoff, even if backoff isn't necessary. This doesn't
+	// affect correctness, only possibly adds minor latency for an unusual case.
+	wiErr.Resolved = true
+
+	resolveArgs := &proto.InternalResolveIntentRequest{
+		RequestHeader: proto.RequestHeader{
+			Timestamp: args.Header().Timestamp,
+			Key:       wiErr.Key,
+			User:      UserRoot,
+			Txn:       pushReply.PusheeTxn,
+		},
+	}
+	resolveReply := &proto.InternalResolveIntentResponse{}
+	// Add resolve command with wait=false to add to Raft but not wait for completion.
+	if resolveErr := rng.AddCmd(InternalResolveIntent, resolveArgs, resolveReply, false); resolveErr != nil {
+		log.Warningf("resolve %+v failed: %v", resolveArgs, resolveErr)
+	}
+
+	// If the command is read-write, we must return the error to the
+	// client so it can resubmit the command with a new ClientCmdID. For
+	// read-only commands, we can resubmit immediately instead.
+	if IsReadOnly(method) {
+		return rng.AddCmd(method, args, reply, true)
+	}
+
+	return wiErr
 }
 
 // RangeManager is an interface satisfied by Store through which ranges

--- a/storage/store.go
+++ b/storage/store.go
@@ -416,6 +416,8 @@ func (s *Store) maybeResolveWriteIntentError(rng *Range, method string, args pro
 		return err
 	}
 
+	log.V(1).Infof("resolving write intent on %s %+v: %v", method, args, wiErr)
+
 	// Attempt to push the transaction which created the conflicting intent.
 	pushArgs := &proto.InternalPushTxnRequest{
 		RequestHeader: proto.RequestHeader{
@@ -461,7 +463,6 @@ func (s *Store) maybeResolveWriteIntentError(rng *Range, method string, args pro
 	if IsReadOnly(method) {
 		return rng.AddCmd(method, args, reply, true)
 	}
-
 	return wiErr
 }
 


### PR DESCRIPTION
Automatically push transactions on write intent failures and resolve
conflicting write intents. This is done at the level of
Store.ExecuteCmd on command failure. Write/write conflicts are
pushed and resolved but then must still return the write intent
error to the client so the client can retry with a new client command
ID, ensuring idempotence. This way, all original requests (the one
which hit the conflict) will always return a write intent error via
the response cache. Follow-on requests with the new client command
ID can succeed, and with new ClientCmdID, will always succeed on
retries. Read/write conflicts are automatically retried instead of
returning the write intent error, because they don't have the same
idempotency issues with client command ID.

Reorg'd a bit of code between store and range to move range-specific
checks into range (addition of Range.AddCmd method). Also, added an
ability to submit commands to Raft without having to always wait for
completion. This is used to "fire and forget" resolve intent cmds.
Making sure we cleanup entries pending in the "read queue" is slightly
tricky in Range.addReadWriteCmd.

Moved writeIntentError and writeTooOldError from mvcc.go to the proto/
subdirectory as they're communicated across RPCs from server to clients.
Add the conflicting Key and also a Resolved flag to WriteIntentError.
This allows the client to decide whether to backoff (if resolve failed)
or retry immediately.
