### PR TITLE
Always read writes from same txn epoch.

### DIFF
--- a/proto/data.go
+++ b/proto/data.go
@@ -83,3 +83,11 @@ func (v *Value) computeChecksum(key []byte) uint32 {
 	}
 	return c.Sum32()
 }
+
+// UpgradePriority sets transaction priority to the maximum of current
+// priority and the specified minPriority.
+func (t *Transaction) UpgradePriority(minPriority int32) {
+	if minPriority > t.Priority {
+		t.Priority = minPriority
+	}
+}

--- a/storage/engine/mvcc.go
+++ b/storage/engine/mvcc.go
@@ -107,7 +107,10 @@ func (mvcc *MVCC) Get(key Key, timestamp proto.Timestamp, txn *proto.Transaction
 	ts := proto.Timestamp{}
 	var valBytes []byte
 	var isValue bool
-	if !timestamp.Less(meta.Timestamp) {
+
+	// Always read latest value in the event the txns match.
+	if !timestamp.Less(meta.Timestamp) ||
+		(meta.Txn != nil && txn != nil && bytes.Equal(meta.Txn.ID, txn.ID)) {
 		if meta.Txn != nil && (txn == nil || !bytes.Equal(meta.Txn.ID, txn.ID)) {
 			return nil, &proto.WriteIntentError{Key: key, Txn: *meta.Txn}
 		}


### PR DESCRIPTION
We must do this even in the event that the timestamp of a write from our
own txn gets pushed forward so txn is attempting to read earlier
timestamp. We can't have a txn intent getting pushed forward by another
txn only to have it become invisible to the current txn, which isn't yet
aware the txn commit timestamp has been pushed.

Allow non-transactional reads and writes to push intents. This is
done by generating a random priority for the non-transactional actor.
We could consider allowing priority to be set as an optional field of
RequestHeader, outside of RequestHeader.Txn for non-transactional commands.

Change push txn code to always allow pushing the timestamp forward on
txn intents where isolation level is SNAPSHOT. Since snapshot isolation
txns don't mind having their timestamp advanced, this is better overall
for system performance--readers never block on snapshot isolation txns.

Added unittests for all cases.
