### PR TITLE
Add etcd as a submodule so we can use its raft implementation.

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,6 @@
 [submodule "_vendor/rocksdb"]
 	path = _vendor/rocksdb
 	url = https://github.com/cockroachdb/rocksdb.git
+[submodule "_vendor/src/github.com/coreos/etcd"]
+	path = _vendor/src/github.com/coreos/etcd
+	url = https://github.com/cockroachdb/etcd.git

--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -15,6 +15,7 @@ $GO_GET $GO_GET_FLAGS code.google.com/p/go.tools/cmd/vet
 $GO_GET $GO_GET_FLAGS code.google.com/p/go.tools/cmd/goimports
 
 # Grab dependencies.
+# TODO(bdarnell): make these submodules like etcd/raft, so we can pin versions?
 $GO_GET $GO_GET_FLAGS code.google.com/p/biogo.store/llrb
 $GO_GET $GO_GET_FLAGS code.google.com/p/go-commander
 $GO_GET $GO_GET_FLAGS code.google.com/p/go-uuid/uuid

--- a/multiraft/multiraft.go
+++ b/multiraft/multiraft.go
@@ -27,6 +27,10 @@ import (
 
 	"github.com/cockroachdb/cockroach/util"
 	"github.com/cockroachdb/cockroach/util/log"
+	// TODO(bdarnell) remove this when we are actually using etcd/raft.
+	// For now I'm just doing a dummy import to make sure the submodule setup
+	// doesn't break anything.
+	_ "github.com/coreos/etcd/raft"
 )
 
 // NodeID is a unique non-zero identifier for the node within the cluster.


### PR DESCRIPTION
This commit adds the dependency without really using it so we can make
sure that the submodule process works for everyone without causing
problems. Everyone will need to `git submodule update --init`
after pulling this commit.

Note that we use the import path 'coreos/etcd' but create the submodule
from 'cockroachdb/etcd'. This allows us to maintain and use our own
changes without waiting for everything to be merged upstream by etcd.
We keep the import path because otherwise raft internally uses multiple
packages and we don't want to rewrite its internal imports.
