### PR TITLE
Dockerfile now uses the golang-docker image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,29 +1,22 @@
-# The resulting docker image is suitable for testing.
-# Do NOT use this docker image in a production setting.
-
-FROM ubuntu:14.04
+FROM golang
 
 MAINTAINER Spencer Kimball <spencer.kimball@gmail.com>
 
 # Setup the toolchain.
 RUN apt-get update -y -qq
 RUN apt-get dist-upgrade -y -qq
-RUN apt-get install -y -qq wget curl git mercurial build-essential bzr zlib1g-dev libbz2-dev libsnappy-dev libjemalloc-dev libprotobuf-dev protobuf-compiler g++-4.8 libgflags-dev
-RUN update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-4.8 50
-RUN update-alternatives --install /usr/bin/g++ g++ /usr/bin/g++-4.8 50
+RUN apt-get install --auto-remove -y -qq git mercurial build-essential bzr zlib1g-dev libbz2-dev libsnappy-dev libjemalloc-dev libprotobuf-dev protobuf-compiler libgflags-dev
 
-# Get Go and set PATH and GO* env variables.
-RUN curl -L -s http://golang.org/dl/go1.3.1.linux-amd64.tar.gz | tar -v -C /usr/local/ -xz
-ENV PATH /usr/local/go/bin:/usr/local/bin:/usr/local/sbin:/usr/bin:/usr/sbin:/bin:/sbin:/go/bin
+RUN update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-4.7 50
+RUN update-alternatives --install /usr/bin/g++ g++ /usr/bin/g++-4.7 50
+
 ENV GOPATH /go
-ENV GOROOT /usr/local/go
 ENV ROACHPATH $GOPATH/src/github.com/cockroachdb
 ENV VENDORPATH $ROACHPATH/cockroach/_vendor
 ENV ROCKSDBPATH $VENDORPATH
 ENV VENDORGOPATH $VENDORPATH/src
 ENV COREOSPATH $VENDORGOPATH/github.com/coreos
 
-# Symlink our mounted source directory to appropriate go src location.
 RUN mkdir -p $ROACHPATH
 RUN mkdir -p $ROCKSDBPATH
 RUN mkdir -p $COREOSPATH
@@ -42,9 +35,9 @@ RUN go get gopkg.in/yaml.v1
 # See the NOTE below if hacking directly on the _vendor/
 # submodules. In that case, uncomment the "_vendor" exclude from
 # .dockerignore and comment out the following lines.
-RUN cd $ROCKSDBPATH && git clone --depth=1 https://github.com/facebook/rocksdb.git
+RUN cd $ROCKSDBPATH && git clone --depth=1 https://github.com/cockroachdb/rocksdb.git
 RUN cd $ROCKSDBPATH/rocksdb && make static_lib
-RUN cd $COREOSPATH && git clone --depth=1 https://github.com/coreos/etcd.git
+RUN cd $COREOSPATH && git clone --depth=1 https://github.com/cockroachdb/etcd.git
 
 # Copy the contents of the cockroach source directory to the image.
 # Any changes which have been made to the source directory will cause


### PR DESCRIPTION
 Additionally, the rocksdb and etcd repos are now pulled from the forks in our repo as opposed to the latest master.
The image is based on Debian Wheezy and hence there's only gcc-4.7, but that's exactly the minimum version required for RocksDB.

'make acceptance' works as expected.
