### PR TITLE
fix data races and have travis check for them in the future

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -25,6 +25,7 @@ install:
 
 script:
   - make test
+  - make testrace
 
 notifications:
   email:

--- a/gossip/gossip.go
+++ b/gossip/gossip.go
@@ -257,9 +257,11 @@ func (g *Gossip) Stop() <-chan error {
 	// Wake up bootstrap goroutine so it can exit.
 	g.stalled.Signal()
 	// Close all outgoing clients.
+	g.mu.Lock()
 	for _, addr := range g.outgoing.asSlice() {
 		g.closeClient(addr)
 	}
+	g.mu.Unlock()
 	return g.exited
 }
 

--- a/server/node_test.go
+++ b/server/node_test.go
@@ -143,7 +143,7 @@ func TestBootstrapNewStore(t *testing.T) {
 	// store) will be bootstrapped by the node upon start. This happens
 	// in a goroutine, so we'll have to wait a bit (maximum 10ms) until
 	// we can find the new node.
-	if err := util.IsTrueWithin(func() bool { return node.localKV.GetStoreCount() == 3 }, 50*time.Millisecond); err != nil {
+	if err := util.IsTrueWithin(func() bool { return node.localKV.GetStoreCount() == 3 }, 250*time.Millisecond); err != nil {
 		t.Error(err)
 	}
 }

--- a/storage/range.go
+++ b/storage/range.go
@@ -445,12 +445,12 @@ func (r *Range) addReadWriteCmd(method string, args proto.Request, reply proto.R
 		// Just as for reads, we update the timestamp cache with the timestamp
 		// of this write on success. This ensures a strictly higher timestamp
 		// for successive writes to the same key or key range.
+		r.Lock()
 		if err == nil {
-			r.Lock()
 			r.tsCache.Add(header.Key, header.EndKey, header.Timestamp, txnMD5)
-			r.Unlock()
 		}
 		r.cmdQ.Remove(cmdKey)
+		r.Unlock()
 
 		// If the original client didn't wait (e.g. resolve write intent),
 		// log execution errors so they're surfaced somewhere.

--- a/storage/range_test.go
+++ b/storage/range_test.go
@@ -215,13 +215,13 @@ func TestInternalRangeLookup(t *testing.T) {
 
 // A blockingEngine allows us to delay get/put (but not other ops!).
 // It works by allowing a single key to be primed for a delay. When
-// a get/put ops arrives for that key, it's blocked via wait group
+// a get/put ops arrives for that key, it's blocked via a mutex
 // until unblock() is invoked.
 type blockingEngine struct {
-	sync.Mutex
+	blocker sync.Mutex // blocks Get() and Put()
 	*engine.InMem
-	key engine.Key
-	wg  sync.WaitGroup
+	sync.Mutex // protects key
+	key        engine.Key
 }
 
 func newBlockingEngine() *blockingEngine {
@@ -232,22 +232,30 @@ func newBlockingEngine() *blockingEngine {
 }
 
 func (be *blockingEngine) block(key engine.Key) {
+	be.Lock()
+	defer be.Unlock()
 	// Need to binary encode the key so it matches when accessed through MVCC.
 	be.key = encoding.EncodeBinary(nil, key)
-	be.wg.Add(1)
+	// Get() and Put() will try to get this lock, so they will wait.
+	be.blocker.Lock()
 }
 
 func (be *blockingEngine) unblock() {
-	be.wg.Done()
+	be.blocker.Unlock()
+}
+
+func (be *blockingEngine) wait() {
+	be.blocker.Lock()
+	be.blocker.Unlock()
 }
 
 func (be *blockingEngine) Get(key engine.Key) ([]byte, error) {
 	be.Lock()
 	if bytes.Equal(key, be.key) {
 		be.key = nil
-		defer be.wg.Wait()
+		defer be.wait()
 	}
-	defer be.Unlock()
+	be.Unlock()
 	return be.InMem.Get(key)
 }
 
@@ -255,9 +263,9 @@ func (be *blockingEngine) Put(key engine.Key, value []byte) error {
 	be.Lock()
 	if bytes.Equal(key, be.key) {
 		be.key = nil
-		defer be.wg.Wait()
+		defer be.wait()
 	}
-	defer be.Unlock()
+	be.Unlock()
 	return be.InMem.Put(key, value)
 }
 

--- a/storage/store.go
+++ b/storage/store.go
@@ -138,8 +138,8 @@ func NewStore(clock *hlc.Clock, eng engine.Engine, db DB, gossip *gossip.Gossip)
 
 // Close calls Range.Stop() on all active ranges.
 func (s *Store) Close() {
-	s.mu.RLock()
-	defer s.mu.RUnlock()
+	s.mu.Lock()
+	defer s.mu.Unlock()
 	for _, rng := range s.ranges {
 		rng.Stop()
 	}


### PR DESCRIPTION
Closes #54 and fixes #84. Ran `make testrace` > 20 times locally without seeing any more races.
There's a slight chance that once in a blue moon we'll see a random failure because of IsTrueWithin() failing, but there are easy remedies for that.
