### PR TITLE
quick fix to avoid rebuilding librocksdb.a over and over

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -51,7 +51,11 @@ build: auxiliary
 	$(CGO_FLAGS) $(GO) build -o cockroach
 
 rocksdb:
-	cd $(ROCKSDB); make static_lib
+	# There is a hiccup in RocksDB's Makefile which causes build_version.cc to
+	# be "newer" than build_version.o for each run of `make static_lib` even
+	# though before invoking make, this is not the case. This is a quick fix
+	# for this, simply telling make that build_version.cc hasn't changed.
+	cd $(ROCKSDB); make -o util/build_version.cc static_lib
 
 roach_proto:
 	cd $(ROACH_PROTO); $(FLAGS) make static_lib


### PR DESCRIPTION
A dirty little trick but since we're never gonna be changing _vendor/rocksdb/build_version.cc as much as running tests over and over and over... I think this is well worth our time for now.
We'll still want someone to go over the Makefile at some point, but at least this addresses immediate parts of #38.
