### PR TITLE
Get rid of dnsmasq from local-cluster.sh.

### DIFF
--- a/deploy/local-cluster.sh
+++ b/deploy/local-cluster.sh
@@ -3,15 +3,13 @@
 source ./verify-docker.sh
 
 # Image names.
-DNSMASQ_IMAGE="spencerkimball/dnsmasq"
 COCKROACH_IMAGE="cockroachdb/cockroach"
 
 # Container names.
-DNSMASQ_NAME="${HOSTNAME:-local}-cockroach-dns"
 COCKROACH_NAME="${HOSTNAME:-local}-roachnode"
 
 # Determine running containers.
-CONTAINERS=$(docker ps -a | egrep -e '-roachnode|-cockroach-dns' -e "$COCKROACH_IMAGE|$DNSMASQ_IMAGE" | awk '{print $1}')
+CONTAINERS=$(docker ps -a | egrep -e '-roachnode' -e "$COCKROACH_IMAGE" | awk '{print $1}')
 
 # Parse [start|stop] directive.
 if [[ $1 == "start" ]]; then
@@ -46,26 +44,6 @@ echo "Starting Cockroach cluster with $NODES nodes..."
 # Standard arguments for running containers.
 STD_ARGS="-P -d"
 
-# Shell script cleanup for DNS.
-function finish {
-  rm -rf $DNS_DIR
-  # NOTE: this is a hack due to boot2docker's incomplete support
-  # for sharing volumes from the host OS down through to the VM.
-  if [[ $DOCKERHOST != "127.0.0.1" ]]; then
-    boot2docker ssh "sudo -u root rm -rf $DNS_DIR"
-  fi
-}
-trap finish EXIT
-
-# Create temporary file for DNS hosts.
-DNS_DIR=$(mktemp -d "/tmp/dnsmasq.hosts.XXXXXXXX" || exit 1)
-DNS_FILE="$DNS_DIR/addn-hosts"
-
-# Start dnsmasq container. We wait in a loop until the DNS additional
-# hosts file appears before starting the dnsmasq process.
-DNS_CID=$(docker run -d -v "$DNS_DIR:/dnsmasq.hosts" --name=$DNSMASQ_NAME $DNSMASQ_IMAGE /bin/sh -c "while true; do if [ -f /dnsmasq.hosts/addn-hosts ]; then break; else echo 'waiting 1s for DNS address info...'; sleep 1; fi; done; /usr/sbin/dnsmasq -d")
-DNS_IP=$(docker inspect --format '{{ .NetworkSettings.IPAddress }}' $DNS_CID)
-
 # Local rpc and http ports.
 RPC_PORT=9000
 HTTP_PORT=8080
@@ -84,30 +62,18 @@ for i in $(seq 1 $NODES); do
   CMD_ARGS="-gossip=${HOSTS[1]}:$RPC_PORT -stores=hdd=/tmp/disk1,hdd=/tmp/disk2 -rpc=${HOSTS[$i]}:$RPC_PORT -http=${HOSTS[$i]}:$HTTP_PORT"
 
   # Node-specific arguments for node container.
-  NODE_ARGS="--hostname=${HOSTS[$i]} --name=${HOSTS[$i]} --dns=$DNS_IP"
+  NODE_ARGS="--hostname=${HOSTS[$i]} --name=${HOSTS[$i]}"
+  if [[ $i != 1 ]]; then
+      # If this is not the first node then link to the first node for
+      # gossip bootstrapping.
+      NODE_ARGS="${NODE_ARGS} --link=${HOSTS[1]}:${HOSTS[1]}"
+  fi
 
-  # Start Cockroach docker container and corral HTTP port and docker
-  # IP address for container-local DNS.
+  # Start Cockroach docker container and corral HTTP port for later
+  # verification of cluster health.
   CIDS[$i]=$(docker run $STD_ARGS $NODE_ARGS $COCKROACH_IMAGE $CMD $CMD_ARGS)
   HTTP_PORTS[$i]=$(echo $(docker port ${CIDS[$i]} 8080) | sed 's/.*://')
-  IP=$(docker inspect --format '{{ .NetworkSettings.IPAddress }}' ${CIDS[$i]})
-  IP_HOST[$i]="$IP ${HOSTS[$i]}"
 done
-
-# Write the DNS_FILE in one fell swoop.
-printf -- '%s\n' "${IP_HOST[@]}" > $DNS_FILE
-
-# If the docker host is not local, use boot2docker ssh to write
-# the data locally.
-#
-# NOTE: once boot2docker has better support for sharing volumes
-# this step will not be necessary. However, what currently happens
-# is that the share folder on the boot2docker VM is simply empty,
-# regardless of what we write to the local folder.
-if [[ $DOCKERHOST != "127.0.0.1" ]]; then
-  echo "writing $DNS_FILE to boot2docker VM"
-  cat $DNS_FILE | boot2docker ssh "sudo -u root /bin/sh -c 'cat - > $DNS_FILE'"
-fi
 
 # Get gossip network contents from each node in turn.
 MAX_WAIT=20 # seconds
@@ -142,13 +108,6 @@ for i in $(seq 1 $NODES); do
   docker logs ${CIDS[$i]}
 done
 
-echo ""
-echo "Output for dnsmasq..."
-echo "====================="
-docker logs $DNS_CID
-
 docker kill ${CIDS[*]} > /dev/null
 docker rm ${CIDS[*]} > /dev/null
-docker kill $DNS_CID > /dev/null
-docker rm $DNS_CID > /dev/null
 exit 1

--- a/server/server.go
+++ b/server/server.go
@@ -297,10 +297,11 @@ func newServer() (*server, error) {
 	if strings.HasPrefix(*rpcAddr, ":") {
 		*rpcAddr = host + *rpcAddr
 	}
-	_, err = net.ResolveTCPAddr("tcp", *rpcAddr)
+	addr, err := net.ResolveTCPAddr("tcp", *rpcAddr)
 	if err != nil {
 		return nil, util.Errorf("unable to resolve RPC address %q: %v", *rpcAddr, err)
 	}
+	*rpcAddr = addr.String() // use resolved ip address to identify ourselves
 
 	var tlsConfig *rpc.TLSConfig
 	if *certDir == "" {


### PR DESCRIPTION
Use docker container linking to allow nodes other than 1 to find node 1
for gossip bootstrapping.

Change server startup to convert the value supplied to the --rpc flag
from a host:port to an ipaddr:port.
