### PR TITLE
Add ApproximateSize() method to Engine

### DIFF
--- a/storage/engine/engine.go
+++ b/storage/engine/engine.go
@@ -94,6 +94,9 @@ type Engine interface {
 	// given snapshotID.
 	// Specify max=0 for unbounded scans.
 	ScanSnapshot(start, end Key, max int64, snapshotID string) ([]proto.RawKeyValue, error)
+	// ApproximateSize returns the approximate number of bytes the engine is
+	// using to store data for the given range of keys.
+	ApproximateSize(start, end Key) (uint64, error)
 }
 
 // A BatchDelete is a delete operation executed as part of an atomic batch.

--- a/util/rand.go
+++ b/util/rand.go
@@ -39,6 +39,21 @@ func RandIntInRange(r *rand.Rand, min, max int) int {
 	return min + r.Intn(max-min)
 }
 
+var randLetters = []rune("abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ")
+
+// RandString returns a string of the given length with random data.
+func RandString(r *rand.Rand, size int) string {
+	if size <= 0 {
+		return ""
+	}
+
+	arr := make([]rune, size)
+	for i := 0; i < len(arr); i++ {
+		arr[i] = randLetters[r.Intn(len(randLetters))]
+	}
+	return string(arr)
+}
+
 // CachedRand is a global singleton rand.Rand object cached for
 // one-off purposes to generate random numbers.
 var CachedRand = NewPseudoRand()

--- a/util/rand_test.go
+++ b/util/rand_test.go
@@ -43,3 +43,13 @@ func TestRandIntInRange(t *testing.T) {
 		}
 	}
 }
+
+func TestRandString(t *testing.T) {
+	rand := NewPseudoRand()
+	for i := 0; i < 100; i++ {
+		x := RandString(rand, i)
+		if len(x) != i {
+			t.Errorf("got array with unexpected length: %d (expected %d)", len(x), i)
+		}
+	}
+}


### PR DESCRIPTION
Commit adds ApproximateSize() method on the Engine interface, designed to
utilize the GetApproximateSize() method of the rocksdb engine.
- Implemented in both rocksdb and inMem Engine structs
- Adds compression-aware test for the method.
