### PR TITLE
Add engine.Key.Address() method for addressing local keys.

### DIFF
--- a/kv/coordinator.go
+++ b/kv/coordinator.go
@@ -229,7 +229,7 @@ func (tc *coordinator) heartbeat(txn *proto.Transaction, closer chan struct{}) {
 	ticker := time.NewTicker(tc.heartbeatInterval)
 	request := &proto.InternalHeartbeatTxnRequest{
 		RequestHeader: proto.RequestHeader{
-			Key:  txn.ID,
+			Key:  engine.MakeLocalKey(engine.KeyLocalTransactionPrefix, txn.ID),
 			User: storage.UserRoot,
 			Txn:  txn,
 		},

--- a/kv/coordinator_test.go
+++ b/kv/coordinator_test.go
@@ -183,7 +183,7 @@ func TestCoordinatorEndTxn(t *testing.T) {
 		t.Errorf("expected empty transactions map; got %d", len(db.coordinator.txns))
 	}
 
-	// TODO(spencer): need to test that write intents were sent to key "a".
+	// TODO(spencer): need to test that resolve intents were sent to key "a".
 }
 
 // TestCoordinatorGC verifies that the coordinator cleans up extant

--- a/kv/local_kv_test.go
+++ b/kv/local_kv_test.go
@@ -113,7 +113,7 @@ func TestLocalKVLookupReplica(t *testing.T) {
 	kv.AddStore(store)
 	meta := store.BootstrapRangeMetadata()
 	meta.StartKey = engine.KeySystemPrefix
-	meta.EndKey = engine.PrefixEndKey(engine.KeySystemPrefix)
+	meta.EndKey = engine.KeySystemPrefix.PrefixEnd()
 	if _, err := store.CreateRange(meta); err != nil {
 		t.Fatal(err)
 	}

--- a/kv/range_cache.go
+++ b/kv/range_cache.go
@@ -157,7 +157,7 @@ func (rmc *RangeMetadataCache) getCachedRangeMetadata(key engine.Key) (
 	rd := v.(*proto.RangeDescriptor)
 
 	// Check that key actually belongs to range
-	if !rd.ContainsKey(key) {
+	if !rd.ContainsKey(key.Address()) {
 		return nil, nil
 	}
 	return metaEndKey, rd

--- a/kv/range_cache_test.go
+++ b/kv/range_cache_test.go
@@ -47,14 +47,14 @@ func (db *testMetadataDB) getMetadata(key engine.Key) []proto.RangeDescriptor {
 	for i := 0; i < 3; i++ {
 		v := db.data.Ceil(testMetadataNode{
 			&proto.RangeDescriptor{
-				EndKey: engine.NextKey(key),
+				EndKey: key.Next(),
 			},
 		})
 		if v == nil {
 			break
 		}
 		response = append(response, *(v.(testMetadataNode).RangeDescriptor))
-		key = engine.NextKey(response[i].EndKey)
+		key = engine.Key(response[i].EndKey).Next()
 	}
 	return response
 }
@@ -123,7 +123,7 @@ func doLookup(t *testing.T, rc *RangeMetadataCache, key string) {
 	if err != nil {
 		t.Fatalf("Unexpected error from LookupRangeMetadata: %s", err.Error())
 	}
-	if !r.ContainsKey(engine.Key(key)) {
+	if !r.ContainsKey(engine.Key(key).Address()) {
 		t.Fatalf("Returned range did not contain key: %s-%s, %s", r.StartKey, r.EndKey, key)
 	}
 }

--- a/kv/rest.go
+++ b/kv/rest.go
@@ -131,6 +131,9 @@ func dbKey(path, apiPrefix string) (engine.Key, error) {
 		if len(k) == 0 {
 			return nil, errors.New("empty key not allowed")
 		}
+		if k[0] == byte(0) {
+			return nil, errors.New("keys may not start with null characters")
+		}
 		return k, nil
 	}
 	return nil, err
@@ -151,6 +154,10 @@ func (s *Server) handleRangeAction(w http.ResponseWriter, r *http.Request) {
 	endKey := engine.Key(r.FormValue(rangeParamEnd))
 	if len(startKey) == 0 {
 		http.Error(w, "start key must be non-empty", http.StatusBadRequest)
+		return
+	}
+	if startKey[0] == byte(0) {
+		http.Error(w, "keys may not start with null characters", http.StatusBadRequest)
 		return
 	}
 	if len(endKey) == 0 {

--- a/kv/rest.go
+++ b/kv/rest.go
@@ -131,9 +131,6 @@ func dbKey(path, apiPrefix string) (engine.Key, error) {
 		if len(k) == 0 {
 			return nil, errors.New("empty key not allowed")
 		}
-		if k[0] == byte(0) {
-			return nil, errors.New("keys may not start with null characters")
-		}
 		return k, nil
 	}
 	return nil, err
@@ -154,10 +151,6 @@ func (s *Server) handleRangeAction(w http.ResponseWriter, r *http.Request) {
 	endKey := engine.Key(r.FormValue(rangeParamEnd))
 	if len(startKey) == 0 {
 		http.Error(w, "start key must be non-empty", http.StatusBadRequest)
-		return
-	}
-	if startKey[0] == byte(0) {
-		http.Error(w, "keys may not start with null characters", http.StatusBadRequest)
 		return
 	}
 	if len(endKey) == 0 {

--- a/kv/txn_db.go
+++ b/kv/txn_db.go
@@ -26,6 +26,7 @@ import (
 
 	"github.com/cockroachdb/cockroach/proto"
 	"github.com/cockroachdb/cockroach/storage"
+	"github.com/cockroachdb/cockroach/storage/engine"
 	"github.com/cockroachdb/cockroach/util"
 	"github.com/cockroachdb/cockroach/util/log"
 )
@@ -128,7 +129,7 @@ func (tdb *txnDB) executeCmd(method string, args proto.Request, replyChan interf
 	tdb.Lock()
 	if method == storage.EndTransaction {
 		// For EndTransaction, make sure key is set to txn ID.
-		args.Header().Key = tdb.txn.ID
+		args.Header().Key = engine.MakeLocalKey(engine.KeyLocalTransactionPrefix, tdb.txn.ID)
 		tdb.txnEnd = true // set this txn as having been ended
 	} else if !isTransactional(method) {
 		tdb.DB.executeCmd(method, args, replyChan)

--- a/roachlib/roach_c.h
+++ b/roachlib/roach_c.h
@@ -18,6 +18,10 @@
 #include "rocksdb/c.h"
 
 struct FilterState {
+  // The key prefix identifying transaction records.
+  const char* txn_prefix;
+  // The key prefix identifying response cache records.
+  const char* rcache_prefix;
   // The minimum timestamp for transaction rows. Any transaction with
   // a timestamp prior to min_txn_ts can be discarded.
   int64_t min_txn_ts;

--- a/server/node_test.go
+++ b/server/node_test.go
@@ -90,7 +90,7 @@ func TestBootstrapCluster(t *testing.T) {
 	// Scan the complete contents of the local database.
 	sr := <-localDB.Scan(&proto.ScanRequest{
 		RequestHeader: proto.RequestHeader{
-			Key:    engine.KeyMin,
+			Key:    engine.KeyLocalPrefix.PrefixEnd(), // skip local keys
 			EndKey: engine.KeyMax,
 			User:   storage.UserRoot,
 		},

--- a/server/zone.go
+++ b/server/zone.go
@@ -78,7 +78,7 @@ func (zh *zoneHandler) Get(path string, r *http.Request) (body []byte, contentTy
 		sr := <-zh.db.Scan(&proto.ScanRequest{
 			RequestHeader: proto.RequestHeader{
 				Key:    engine.KeyConfigZonePrefix,
-				EndKey: engine.PrefixEndKey(engine.KeyConfigZonePrefix),
+				EndKey: engine.KeyConfigZonePrefix.PrefixEnd(),
 				User:   storage.UserRoot,
 			},
 			MaxResults: maxGetResults,

--- a/storage/command_queue.go
+++ b/storage/command_queue.go
@@ -82,9 +82,9 @@ func (cq *CommandQueue) onEvicted(key, value interface{}) {
 // the requester is a read-only command; false for read-write.
 func (cq *CommandQueue) GetWait(start, end engine.Key, readOnly bool, wg *sync.WaitGroup) {
 	if end == nil {
-		end = engine.NextKey(start)
+		end = start.Next()
 	}
-	for _, c := range cq.cache.GetOverlaps(rangeKey(start), rangeKey(end)) {
+	for _, c := range cq.cache.GetOverlaps(start, end) {
 		c := c.(*cmd)
 		// Only add to the wait group if one of the commands isn't read-only.
 		if !readOnly || !c.readOnly {
@@ -105,9 +105,9 @@ func (cq *CommandQueue) GetWait(start, end engine.Key, readOnly bool, wg *sync.W
 // GetWait().
 func (cq *CommandQueue) Add(start, end engine.Key, readOnly bool) interface{} {
 	if end == nil {
-		end = engine.NextKey(start)
+		end = start.Next()
 	}
-	key := cq.cache.NewKey(rangeKey(start), rangeKey(end))
+	key := cq.cache.NewKey(start, end)
 	cq.cache.Add(key, &cmd{readOnly: readOnly})
 	return key
 }

--- a/storage/db.go
+++ b/storage/db.go
@@ -434,7 +434,7 @@ func NewTransaction(name string, baseKey engine.Key, userPriority int32,
 
 	return &proto.Transaction{
 		Name:         name,
-		ID:           append(baseKey, []byte(uuid.New())...),
+		ID:           append(append([]byte(nil), baseKey...), []byte(uuid.New())...),
 		Priority:     priority,
 		Isolation:    isolation,
 		Timestamp:    now,

--- a/storage/engine/engine.go
+++ b/storage/engine/engine.go
@@ -272,7 +272,7 @@ func iterateRangeSnapshot(eng Engine, startKey, endKey Key, chunkSize int64, sna
 		if len(kvs) == 0 {
 			break
 		}
-		startKey = NextKey(kvs[len(kvs)-1].Key)
+		startKey = Key(kvs[len(kvs)-1].Key).Next()
 	}
 	return nil
 }

--- a/storage/engine/errors.go
+++ b/storage/engine/errors.go
@@ -35,7 +35,7 @@ func NewInvalidRangeMetaKeyError(k Key) *InvalidRangeMetaKeyError {
 
 // Error formats error string.
 func (i *InvalidRangeMetaKeyError) Error() string {
-	return fmt.Sprintf("'%s' is not valid range metadata key.", string(i.Key))
+	return fmt.Sprintf("%q is not valid range metadata key.", string(i.Key))
 }
 
 // Init registers engine error types with Gob.

--- a/storage/engine/gc.go
+++ b/storage/engine/gc.go
@@ -20,7 +20,6 @@ package engine
 import (
 	gogoproto "code.google.com/p/gogoprotobuf/proto"
 	"github.com/cockroachdb/cockroach/proto"
-	"github.com/cockroachdb/cockroach/util/encoding"
 	"github.com/cockroachdb/cockroach/util/log"
 )
 
@@ -60,7 +59,7 @@ func (gc *GarbageCollector) Filter(keys []Key, values [][]byte) []bool {
 		return nil
 	}
 	// Look up the policy which applies to this set of MVCC values.
-	_, decKey := encoding.DecodeBinary(keys[0])
+	_, decKey := DecodeKey(keys[0])
 	policy := gc.policyFn(decKey)
 	if policy == nil || policy.TTLSeconds <= 0 {
 		return nil

--- a/storage/engine/gc_test.go
+++ b/storage/engine/gc_test.go
@@ -24,13 +24,12 @@ import (
 
 	gogoproto "code.google.com/p/gogoprotobuf/proto"
 	"github.com/cockroachdb/cockroach/proto"
-	"github.com/cockroachdb/cockroach/util/encoding"
 )
 
 var (
-	aKey  = encoding.EncodeBinary(nil, Key("a"))
-	bKey  = encoding.EncodeBinary(nil, Key("b"))
-	cKey  = encoding.EncodeBinary(nil, Key("c"))
+	aKey  = Key("a").Encode(nil)
+	bKey  = Key("b").Encode(nil)
+	cKey  = Key("c").Encode(nil)
 	aKeys = []Key{
 		aKey,
 		mvccEncodeKey(aKey, makeTS(2E9, 0)),

--- a/storage/engine/keys.go
+++ b/storage/engine/keys.go
@@ -21,7 +21,10 @@ package engine
 import (
 	"bytes"
 
+	"code.google.com/p/biogo.store/interval"
 	"github.com/cockroachdb/cockroach/proto"
+	"github.com/cockroachdb/cockroach/util/encoding"
+	"github.com/cockroachdb/cockroach/util/log"
 )
 
 // Key defines the key in the key-value datastore.
@@ -33,9 +36,104 @@ type KeyRange struct {
 	Start, End Key
 }
 
+// MakeKey makes a new key which is the concatenation of the
+// given inputs, in order.
+func MakeKey(prefix Key, keys ...Key) Key {
+	suffix := []byte(nil)
+	for _, k := range keys {
+		suffix = append(suffix, []byte(k)...)
+	}
+	return Key(bytes.Join([][]byte{prefix, suffix}, []byte{}))
+}
+
+// MakeLocalKey concatenates KeyLocalPrefix with the specified key
+// value, verifying in the process that the length of key is two bytes.
+func MakeLocalKey(prefix Key, keys ...Key) Key {
+	if KeyLocalPrefixLength%7 != 0 {
+		log.Fatal("local key prefix is not a multiple of 7: %d", KeyLocalPrefixLength)
+	}
+	if len(prefix) != KeyLocalPrefixLength {
+		log.Fatal("local key prefix length must be %d: %q", KeyLocalPrefixLength, prefix)
+	}
+	return MakeKey(prefix, keys...)
+}
+
+// Address returns the address for the key, used to lookup the range
+// containing the key. In the normal case, this is simply the key's
+// value. However, for local keys, such as transaction records,
+// range-spanning binary tree node pointers, and message queues, the
+// address is the trailing suffix of the key, with the local key
+// prefix removed. In this way, local keys address to the same range
+// as non-local keys, but are stored separately so that they don't
+// collide with user-space or global system keys.
+func (k Key) Address() Key {
+	if !bytes.HasPrefix(k, KeyLocalPrefix) {
+		return k
+	}
+	if len(k) < KeyLocalPrefixLength {
+		log.Fatalf("local key %q malformed; should contain prefix %q and two-character designation", k, KeyLocalPrefix)
+	}
+	return k[KeyLocalPrefixLength:]
+}
+
+// DecodeKey returns a Key initialized by decoding two binary-encoded
+// prefixes from the passed in bytes slice. Any leftover bytes are
+// returned with the key. Note that if a key has a local prefix, it's
+// encoded first so that it will sort properly with respect to
+func DecodeKey(b []byte) ([]byte, Key) {
+	if len(b) == 0 {
+		panic("cannot decode an empty key")
+	}
+	var keyBytes []byte
+	b, keyBytes = encoding.DecodeBinary(b)
+	return b, Key(keyBytes)
+}
+
+// Encode returns a binary-encoded version of the key appended to the
+// prefix byte string "b".
+func (k Key) Encode(b []byte) []byte {
+	return encoding.EncodeBinary(b, []byte(k))
+}
+
+// Next returns the next key in lexicographic sort order.
+func (k Key) Next() Key {
+	return MakeKey(k, Key{0})
+}
+
+// PrefixEndKey determines the end key given key as a prefix, that is
+// the key that sorts precisely behind all keys starting with prefix:
+// "1" is added to the final byte and the carry propagated.  The
+// special cases of nil and KeyMin ("") always returns KeyMax
+// ("\xff").
+func (k Key) PrefixEnd() Key {
+	if len(k) == 0 {
+		return KeyMax
+	}
+	end := append([]byte(nil), k...)
+	for i := len(end) - 1; i >= 0; i-- {
+		end[i] = end[i] + 1
+		if end[i] != 0 {
+			return end
+		}
+	}
+	// This statement will only be reached if the key is already a
+	// maximal byte string (i.e. already \xff...).
+	return k
+}
+
 // Less implements the util.Ordered interface.
 func (k Key) Less(l Key) bool {
-	return bytes.Compare(k, l) == -1
+	return bytes.Compare(k, l) < 0
+}
+
+// Equal returns whether two keys are identical.
+func (k Key) Equal(l Key) bool {
+	return bytes.Compare(k, l) == 0
+}
+
+// Compare implements the llrb.Comparable interface for tree nodes.
+func (k Key) Compare(b interval.Comparable) int {
+	return bytes.Compare(k, b.(Key))
 }
 
 // Value specifies the value at a key. Multiple values at the same key
@@ -60,44 +158,6 @@ type KeyValue struct {
 	Value
 }
 
-// MakeKey makes a new key which is the concatenation of the
-// given inputs, in order.
-func MakeKey(prefix Key, keys ...Key) Key {
-	suffix := []byte(nil)
-	for _, k := range keys {
-		suffix = append(suffix, []byte(k)...)
-	}
-	return Key(bytes.Join([][]byte{prefix, suffix}, []byte{}))
-}
-
-// PrefixEndKey determines the end key given a start key as a prefix,
-// that is the key that sorts precisely behind all keys starting with
-// prefix: "1" is added to the final byte and the carry propagated.
-// The special cases of nil and KeyMin ("") always returns KeyMax ("\xff").
-func PrefixEndKey(prefix Key) Key {
-	if bytes.Equal(prefix, KeyMin) || len(prefix) == 0 {
-		return KeyMax
-	}
-	end := make([]byte, len(prefix))
-	copy(end, prefix)
-	for i := len(end) - 1; i >= 0; i-- {
-		end[i] = end[i] + 1
-		if end[i] != 0 {
-			return end
-		}
-	}
-	// This statement will only be reached if the key is already a
-	// maximal byte string (i.e. already \xff...).
-	return prefix
-}
-
-// NextKey returns a new Key that sorts immediately after the given
-// key. No special behaviour applies for KeyMax. nil is treated like
-// the empty key.
-func NextKey(k Key) Key {
-	return MakeKey(k, Key{0})
-}
-
 // RangeMetaKey returns a range metadata key for the given key.  For ordinary
 // keys this returns a level 2 metadata key - for level 2 keys, it returns a
 // level 1 key.  For level 1 keys and local keys, KeyMin is returned.
@@ -105,11 +165,12 @@ func RangeMetaKey(key Key) Key {
 	if len(key) == 0 {
 		return KeyMin
 	}
-	if !bytes.HasPrefix(key, KeySystemPrefix) {
-		return MakeKey(KeyMeta2Prefix, key)
+	addr := key.Address()
+	if !bytes.HasPrefix(addr, KeyMetaPrefix) {
+		return MakeKey(KeyMeta2Prefix, addr)
 	}
-	if bytes.HasPrefix(key, KeyMeta2Prefix) {
-		return MakeKey(KeyMeta1Prefix, key[len(KeyMeta2Prefix):])
+	if bytes.HasPrefix(addr, KeyMeta2Prefix) {
+		return MakeKey(KeyMeta1Prefix, addr[len(KeyMeta2Prefix):])
 	}
 
 	return KeyMin
@@ -162,29 +223,45 @@ var (
 	KeyMax = Key("\xff")
 
 	// KeyLocalPrefix is the prefix for keys which hold data local to a
-	// RocksDB instance, such as range accounting information (e.g. key
-	// samples), response cache values and transaction records. Some
-	// local data are replicated, such as transaction rows, but are
-	// located in the local area so that they remain in proximity to one
-	// or more keys which they affect, but without unnecessarily
-	// polluting the key space.
+	// RocksDB instance, such as range accounting information
+	// (e.g. range metadata, range-spanning binary tree node pointers),
+	// response cache values, transaction records, and message
+	// queues. Some local data are replicated, such as transaction rows,
+	// but are located in the local area so that they remain in
+	// proximity to one or more keys which they affect, but without
+	// unnecessarily polluting the key space. Further, some local data
+	// are stored with MVCC and contribute to distributed transactions,
+	// such as range metadata, range-spanning binary tree node pointers,
+	// and message queues.
 	//
 	// The local key prefix has been deliberately chosen to sort before
 	// the KeySystemPrefix, because these local keys are not addressable
 	// via the meta range addressing indexes.
 	KeyLocalPrefix = Key("\x00\x00\x00")
 
+	// KeyLocalPrefixLength is the maximum length of the local prefix.
+	// It includes both the standard prefix and an additional two
+	// characters to designate the type of local data.
+	//
+	// NOTE: this is very important! In order to support prefix matches
+	//   (e.g. for garbage collection of transaction and response cache
+	//   rows), the number of bytes in the key local prefix must be a
+	//   multiple of 7. This provides an encoded binary string with no
+	//   leftover bits to "bleed" into the next byte in the non-prefix
+	//   part of the local key.
+	KeyLocalPrefixLength = len(KeyLocalPrefix) + 4
+
 	// KeyLocalIdent stores an immutable identifier for this store,
 	// created when the store is first bootstrapped.
-	KeyLocalIdent = MakeKey(KeyLocalPrefix, Key("store-ident"))
+	KeyLocalIdent = MakeKey(KeyLocalPrefix, Key("iden"))
 	// KeyLocalRangeMetadataPrefix is the prefix for keys storing range metadata.
 	// The value is a struct of type RangeMetadata.
-	KeyLocalRangeMetadataPrefix = MakeKey(KeyLocalPrefix, Key("range-"))
-	// KeyLocalRangeResponseCachePrefix is the prefix for keys storing command
+	KeyLocalRangeMetadataPrefix = MakeKey(KeyLocalPrefix, Key("rng-"))
+	// KeyLocalResponseCachePrefix is the prefix for keys storing command
 	// responses used to guarantee idempotency (see ResponseCache). This key
 	// prefix is duplicated in rocksdb_compaction.cc and must be kept in sync
 	// if modified here.
-	KeyLocalRangeResponseCachePrefix = MakeKey(KeyLocalPrefix, Key("respcache-"))
+	KeyLocalResponseCachePrefix = MakeKey(KeyLocalPrefix, Key("res-"))
 	// KeyLocalTransactionPrefix specifies the key prefix for
 	// transaction records. The suffix is the transaction id. This key
 	// prefix is duplicated in rocksdb_compaction.cc and must be kept in
@@ -192,7 +269,7 @@ var (
 	KeyLocalTransactionPrefix = MakeKey(KeyLocalPrefix, Key("txn-"))
 	// KeyLocalSnapshotIDGenerator is a snapshot ID generator sequence.
 	// Snapshot IDs must be unique per store ID.
-	KeyLocalSnapshotIDGenerator = MakeKey(KeyLocalPrefix, Key("snapshot-idgen"))
+	KeyLocalSnapshotIDGenerator = MakeKey(KeyLocalPrefix, Key("ssid"))
 
 	// KeySystemPrefix indicates the beginning of the key range for
 	// global, system data which are replicated across the cluster.

--- a/storage/engine/keys_test.go
+++ b/storage/engine/keys_test.go
@@ -38,6 +38,132 @@ func TestKeySorting(t *testing.T) {
 	}
 }
 
+func TestKeyEncodeDecode(t *testing.T) {
+	a := Key("a")
+	aEnc := a.Encode(nil)
+	b := Key("b")
+	bEnc := b.Encode(nil)
+	if bytes.Compare(bEnc, aEnc) < 0 {
+		t.Errorf("expected bEnc > aEnc")
+	}
+	aLeftover, aDec := DecodeKey(aEnc)
+	if !aDec.Equal(a) {
+		t.Errorf("exected a == aDec")
+	}
+	if len(aLeftover) != 0 {
+		t.Errorf("expected leftover to be empty; got %q", aLeftover)
+	}
+}
+
+// TestKeyNext tests that the method for creating lexicographic
+// successors to byte slices works as expected.
+func TestKeyNext(t *testing.T) {
+	a := Key("a")
+	aNext := a.Next()
+	if a.Equal(aNext) {
+		t.Errorf("expected key not equal to next")
+	}
+	if !a.Less(aNext) {
+		t.Errorf("expected next key to be greater")
+	}
+
+	testCases := []struct {
+		key  Key
+		next Key
+	}{
+		{nil, Key("\x00")},
+		{Key(""), Key("\x00")},
+		{Key("test key"), Key("test key\x00")},
+		{Key("\xff"), Key("\xff\x00")},
+		{Key("xoxo\x00"), Key("xoxo\x00\x00")},
+	}
+	for i, c := range testCases {
+		if !bytes.Equal(c.key.Next(), c.next) {
+			t.Errorf("%d: unexpected next bytes for %q: %q", i, c.key, c.key.Next())
+		}
+	}
+}
+
+func TestKeyPrefixEnd(t *testing.T) {
+	a := Key("a1")
+	aNext := a.Next()
+	aEnd := a.PrefixEnd()
+	if !a.Less(aEnd) {
+		t.Errorf("expected end key to be greater")
+	}
+	if !aNext.Less(aEnd) {
+		t.Errorf("expected end key to be greater than next")
+	}
+
+	testCases := []struct {
+		key Key
+		end Key
+	}{
+		{Key{}, Key{0xff}},
+		{Key{0}, Key{0x01}},
+		{Key{0xff}, Key{0xff}},
+		{Key{0xff, 0xff}, Key{0xff, 0xff}},
+		{Key{0xff, 0xfe}, Key{0xff, 0xff}},
+		{Key{0x00, 0x00}, Key{0x00, 0x01}},
+		{Key{0x00, 0xff}, Key{0x01, 0x00}},
+		{Key{0x00, 0xff, 0xff}, Key{0x01, 0x00, 0x00}},
+	}
+	for i, c := range testCases {
+		if !bytes.Equal(c.key.PrefixEnd(), c.end) {
+			t.Errorf("%d: unexpected prefix end bytes for %q: %q", i, c.key, c.key.PrefixEnd())
+		}
+	}
+}
+
+func TestKeyEqual(t *testing.T) {
+	a1 := Key("a1")
+	a2 := Key("a2")
+	if !a1.Equal(a1) {
+		t.Errorf("expected keys equal")
+	}
+	if a1.Equal(a2) {
+		t.Errorf("expected different keys not equal")
+	}
+}
+
+func TestKeyLess(t *testing.T) {
+	testCases := []struct {
+		a, b Key
+		less bool
+	}{
+		{nil, Key("\x00"), true},
+		{Key(""), Key("\x00"), true},
+		{Key("a"), Key("b"), true},
+		{Key("a\x00"), Key("a"), false},
+		{Key("a\x00"), Key("a\x01"), true},
+	}
+	for i, c := range testCases {
+		if c.a.Less(c.b) != c.less {
+			t.Fatalf("%d: unexpected %q < %q: %t", i, c.a, c.b, c.less)
+		}
+	}
+}
+
+func TestKeyCompare(t *testing.T) {
+	testCases := []struct {
+		a, b    Key
+		compare int
+	}{
+		{nil, nil, 0},
+		{nil, Key("\x00"), -1},
+		{Key("\x00"), Key("\x00"), 0},
+		{Key(""), Key("\x00"), -1},
+		{Key("a"), Key("b"), -1},
+		{Key("a\x00"), Key("a"), 1},
+		{Key("a\x00"), Key("a\x01"), -1},
+	}
+	for i, c := range testCases {
+		if c.a.Compare(c.b) != c.compare {
+			t.Fatalf("%d: unexpected %q.Compare(%q): %d", i, c.a, c.b, c.compare)
+		}
+	}
+}
+
 // TestNextKey tests that the method for creating successors of a Key
 // works as expected.
 func TestNextKey(t *testing.T) {
@@ -52,8 +178,8 @@ func TestNextKey(t *testing.T) {
 		{Key("xoxo\x00"), Key("xoxo\x00\x00")},
 	}
 	for i, c := range testCases {
-		if !bytes.Equal(NextKey(c.key), c.next) {
-			t.Fatalf("%d: unexpected next key for %q: %s", i, c.key, NextKey(c.key))
+		if !c.key.Next().Equal(c.next) {
+			t.Fatalf("%d: unexpected next key for %q: %s", i, c.key, c.key.Next())
 		}
 	}
 }
@@ -63,5 +189,58 @@ func TestMakeKey(t *testing.T) {
 		!bytes.Equal(MakeKey(Key("A")), Key("A")) ||
 		!bytes.Equal(MakeKey(Key("A"), Key("B"), Key("C")), Key("ABC")) {
 		t.Fatalf("MakeKey is broken")
+	}
+}
+
+func TestRangeMetaKey(t *testing.T) {
+	testCases := []struct {
+		key, expKey Key
+	}{
+		{
+			key:    Key{},
+			expKey: KeyMin,
+		},
+		{
+			key:    MakeLocalKey(KeyLocalTransactionPrefix, Key("foo")),
+			expKey: Key("\x00\x00meta2foo"),
+		},
+		{
+			key:    MakeLocalKey(KeyLocalResponseCachePrefix, Key("bar")),
+			expKey: Key("\x00\x00meta2bar"),
+		},
+		{
+			key:    MakeKey(KeyConfigAccountingPrefix, Key("foo")),
+			expKey: Key("\x00\x00meta2\x00acctfoo"),
+		},
+		{
+			key:    Key("\x00\x00meta2\x00acctfoo"),
+			expKey: Key("\x00\x00meta1\x00acctfoo"),
+		},
+		{
+			key:    Key("\x00\x00meta1\x00acctfoo"),
+			expKey: KeyMin,
+		},
+		{
+			key:    Key("foo"),
+			expKey: Key("\x00\x00meta2foo"),
+		},
+		{
+			key:    Key("foo"),
+			expKey: Key("\x00\x00meta2foo"),
+		},
+		{
+			key:    Key("\x00\x00meta2foo"),
+			expKey: Key("\x00\x00meta1foo"),
+		},
+		{
+			key:    Key("\x00\x00meta1foo"),
+			expKey: KeyMin,
+		},
+	}
+	for i, test := range testCases {
+		result := RangeMetaKey(test.key)
+		if !result.Equal(test.expKey) {
+			t.Errorf("%d: expected range meta for key %q doesn't match %q", i, test.key, test.expKey)
+		}
 	}
 }

--- a/storage/engine/mvcc_test.go
+++ b/storage/engine/mvcc_test.go
@@ -832,7 +832,7 @@ func TestMVCCResolveWithDiffEpochs(t *testing.T) {
 	mvcc := createTestMVCC(t)
 	err := mvcc.Put(testKey1, makeTS(0, 0), value1, txn1)
 	err = mvcc.Put(testKey2, makeTS(0, 0), value2, txn1e2)
-	num, err := mvcc.ResolveWriteIntentRange(testKey1, NextKey(testKey2), 2, txn1e2Commit)
+	num, err := mvcc.ResolveWriteIntentRange(testKey1, testKey2.Next(), 2, txn1e2Commit)
 	if num != 2 {
 		t.Errorf("expected 2 rows resolved; got %d", num)
 	}
@@ -944,7 +944,7 @@ func TestMVCCResolveTxnRange(t *testing.T) {
 	err = mvcc.Put(testKey3, makeTS(0, 0), value3, txn2)
 	err = mvcc.Put(testKey4, makeTS(0, 0), value4, txn1)
 
-	num, err := mvcc.ResolveWriteIntentRange(testKey1, NextKey(testKey4), 0, txn1Commit)
+	num, err := mvcc.ResolveWriteIntentRange(testKey1, testKey4.Next(), 0, txn1Commit)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/storage/engine/rocksdb.go
+++ b/storage/engine/rocksdb.go
@@ -85,6 +85,24 @@ func getGCTimeouts(rocksdbPtr unsafe.Pointer) (minTxnTS, minRCacheTS int64) {
 	return rocksdb.gcTimeouts()
 }
 
+//export getGCPrefixes
+// getGCPrefixes returns key prefixes for transaction and response
+// cache rows, in that order. Each prefix is encoded to match the raw
+// keys in the underlying storage engine. Ownership for the returned
+// strings is assumed by the caller. They should be deallocated using
+// free().
+func getGCPrefixes() (*C.char, *C.char) {
+	// Since we're converting to a C-string, the prefixes which we'll
+	// match against will end at the first null character, or just after
+	// the encoded transaction prefix, up to but not including the
+	// terminating null character.
+	// TODO(spencer): it's fragile to rely on this behavior. Should
+	// consider changing.
+	txnPrefix := KeyLocalTransactionPrefix.Encode(nil)
+	rcachePrefix := KeyLocalResponseCachePrefix.Encode(nil)
+	return C.CString(string(txnPrefix)), C.CString(string(rcachePrefix))
+}
+
 //export reportGCError
 // reportGCError is a callback for the rocksdb custom compaction filter
 // to log errors encountered while trying to parse response cache entries

--- a/storage/engine/rocksdb_compaction.c
+++ b/storage/engine/rocksdb_compaction.c
@@ -59,8 +59,12 @@ unsigned char gc_compaction_filter_filter(
 
 rocksdb_compactionfilter_t* gc_compaction_filter_factory_create_filter(
     void* rocksdb, rocksdb_compactionfiltercontext_t* context) {
+  struct getGCPrefixes_return prefixes = getGCPrefixes();
   struct getGCTimeouts_return timeouts = getGCTimeouts(rocksdb);
   struct FilterState* fs = (struct FilterState*)malloc(sizeof(struct FilterState));
+
+  fs->txn_prefix = prefixes.r0;
+  fs->rcache_prefix = prefixes.r1;
   fs->min_txn_ts = timeouts.r0;
   fs->min_rcache_ts = timeouts.r1;
 

--- a/storage/engine/rocksdb_test.go
+++ b/storage/engine/rocksdb_test.go
@@ -80,18 +80,18 @@ func TestRocksDBCompaction(t *testing.T) {
 		}
 	}(t)
 
-	rcPre := KeyLocalRangeResponseCachePrefix
+	rcPre := KeyLocalResponseCachePrefix
 	txnPre := KeyLocalTransactionPrefix
 
-	// Write a two transaction values and two response cache values such
+	// Write two transaction values and two response cache values such
 	// that exactly one of each should be GC'd based on our GC timeouts.
 	batch := []interface{}{
 		// TODO(spencer): use Transaction and Response protobufs here.
-		BatchPut{Key: MakeKey(rcPre, Key("a")), Value: encodePutResponse(makeTS(2, 0), t)},
-		BatchPut{Key: MakeKey(rcPre, Key("b")), Value: encodePutResponse(makeTS(3, 0), t)},
+		BatchPut{Key: MakeLocalKey(rcPre, Key("a")).Encode(nil), Value: encodePutResponse(makeTS(2, 0), t)},
+		BatchPut{Key: MakeLocalKey(rcPre, Key("b")).Encode(nil), Value: encodePutResponse(makeTS(3, 0), t)},
 
-		BatchPut{Key: MakeKey(txnPre, Key("a")), Value: encodeTransaction(makeTS(1, 0), t)},
-		BatchPut{Key: MakeKey(txnPre, Key("b")), Value: encodeTransaction(makeTS(2, 0), t)},
+		BatchPut{Key: MakeLocalKey(txnPre, Key("a")).Encode(nil), Value: encodeTransaction(makeTS(1, 0), t)},
+		BatchPut{Key: MakeLocalKey(txnPre, Key("b")).Encode(nil), Value: encodeTransaction(makeTS(2, 0), t)},
 	}
 	if err := rocksdb.WriteBatch(batch); err != nil {
 		t.Fatal(err)
@@ -108,8 +108,8 @@ func TestRocksDBCompaction(t *testing.T) {
 		keys = append(keys, kv.Key)
 	}
 	expKeys := []Key{
-		MakeKey(rcPre, Key("b")),
-		MakeKey(txnPre, Key("b")),
+		MakeLocalKey(rcPre, Key("b")).Encode(nil),
+		MakeLocalKey(txnPre, Key("b")).Encode(nil),
 	}
 	if !reflect.DeepEqual(expKeys, keys) {
 		t.Errorf("expected keys %s, got keys %s", expKeys, keys)

--- a/storage/id_alloc.go
+++ b/storage/id_alloc.go
@@ -84,7 +84,7 @@ func (ia *IDAllocator) allocateBlock(incr int64) {
 		Increment: ia.blockSize,
 	})
 	if ir.Error != nil {
-		log.Errorf("unable to allocate %d %q IDs: %v", ia.blockSize, ia.idKey, ir.Error)
+		log.Fatalf("unable to allocate %d %q IDs: %v", ia.blockSize, ia.idKey, ir.Error)
 	}
 	if ir.NewValue <= ia.minID {
 		log.Warningf("allocator key is currently set at %d; minID is %d; allocating again to skip %d IDs",

--- a/storage/id_alloc_test.go
+++ b/storage/id_alloc_test.go
@@ -71,7 +71,8 @@ func TestIDAllocator(t *testing.T) {
 func TestIDAllocatorNegativeValue(t *testing.T) {
 	store, _ := createTestStore(false, t)
 	// Increment our key to a negative value.
-	newValue, err := engine.Increment(store.engine, engine.KeyRaftIDGenerator, -1024)
+	mvcc := engine.NewMVCC(store.engine)
+	newValue, err := mvcc.Increment(engine.KeyRaftIDGenerator.Encode(nil), store.clock.Now(), nil, -1024)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/storage/prefix.go
+++ b/storage/prefix.go
@@ -91,7 +91,7 @@ func NewPrefixConfigMap(configs []*PrefixConfig) (PrefixConfigMap, error) {
 	p := PrefixConfigMap(configs)
 	sort.Sort(p)
 
-	if len(p) == 0 || bytes.Compare(p[0].Prefix, engine.KeyMin) != 0 {
+	if len(p) == 0 || p[0].Prefix.Compare(engine.KeyMin) != 0 {
 		return nil, util.Errorf("no default prefix specified")
 	}
 
@@ -105,7 +105,7 @@ func NewPrefixConfigMap(configs []*PrefixConfig) (PrefixConfigMap, error) {
 		}
 		if stack.Len() != 0 {
 			newConfigs = append(newConfigs, &PrefixConfig{
-				Prefix:    engine.PrefixEndKey(entry.Prefix),
+				Prefix:    entry.Prefix.PrefixEnd(),
 				Canonical: stack.Back().Value.(*PrefixConfig).Prefix,
 				Config:    stack.Back().Value.(*PrefixConfig).Config,
 			})
@@ -139,7 +139,7 @@ func NewPrefixConfigMap(configs []*PrefixConfig) (PrefixConfigMap, error) {
 // specified key.
 func (p PrefixConfigMap) MatchByPrefix(key engine.Key) *PrefixConfig {
 	n := sort.Search(len(p), func(i int) bool {
-		return bytes.Compare(key, p[i].Prefix) < 0
+		return key.Compare(p[i].Prefix) < 0
 	})
 	if n == 0 || n > len(p) {
 		panic("should never match a key outside of default range")
@@ -151,10 +151,10 @@ func (p PrefixConfigMap) MatchByPrefix(key engine.Key) *PrefixConfig {
 	}
 	// Otherwise, search for the canonical prefix config.
 	n = sort.Search(len(p), func(i int) bool {
-		return bytes.Compare(pc.Canonical, p[i].Prefix) <= 0
+		return pc.Canonical.Compare(p[i].Prefix) <= 0
 	})
 	// Should find an exact match every time.
-	if n >= len(p) || !bytes.Equal(pc.Canonical, p[n].Prefix) {
+	if n >= len(p) || !pc.Canonical.Equal(p[n].Prefix) {
 		panic(fmt.Sprintf("canonical lookup for key %q failed", string(pc.Canonical)))
 	}
 	return p[n]
@@ -182,18 +182,18 @@ func (p PrefixConfigMap) MatchesByPrefix(key engine.Key) []*PrefixConfig {
 // by the specified key range [start, end).
 func (p PrefixConfigMap) VisitPrefixes(start, end engine.Key,
 	visitor func(start, end engine.Key, config interface{}) error) error {
-	comp := bytes.Compare(start, end)
+	comp := start.Compare(end)
 	if comp > 0 {
 		return util.Errorf("start key %q not less than or equal to end key %q", start, end)
 	}
 	startIdx := sort.Search(len(p), func(i int) bool {
-		return bytes.Compare(start, p[i].Prefix) < 0
+		return start.Compare(p[i].Prefix) < 0
 	})
 	// Common case of start == end.
 	endIdx := startIdx
 	if comp != 0 {
 		endIdx = sort.Search(len(p), func(i int) bool {
-			return bytes.Compare(end, p[i].Prefix) < 0
+			return end.Compare(p[i].Prefix) < 0
 		})
 	}
 
@@ -209,7 +209,7 @@ func (p PrefixConfigMap) VisitPrefixes(start, end engine.Key,
 		if err := visitor(start, p[i].Prefix, p[i-1].Config); err != nil {
 			return err
 		}
-		if bytes.Equal(p[i].Prefix, end) {
+		if p[i].Prefix.Equal(end) {
 			return nil
 		}
 		start = p[i].Prefix

--- a/storage/prefix_test.go
+++ b/storage/prefix_test.go
@@ -62,8 +62,8 @@ func TestPrefixEndKey(t *testing.T) {
 	}
 
 	for i, test := range testData {
-		if bytes.Compare(engine.PrefixEndKey(test.prefix), test.expEnd) != 0 {
-			t.Errorf("%d: %q end key %q != %q", i, test.prefix, engine.PrefixEndKey(test.prefix), test.expEnd)
+		if !test.prefix.PrefixEnd().Equal(test.expEnd) {
+			t.Errorf("%d: %q end key %q != %q", i, test.prefix, test.prefix.PrefixEnd(), test.expEnd)
 		}
 	}
 }

--- a/storage/store.go
+++ b/storage/store.go
@@ -49,7 +49,7 @@ const (
 
 // rangeMetadataKeyPrefix and hexadecimal-formatted range ID.
 func makeRangeKey(rangeID int64) engine.Key {
-	return engine.MakeKey(engine.KeyLocalRangeMetadataPrefix, engine.Key(strconv.FormatInt(rangeID, 10)))
+	return engine.MakeLocalKey(engine.KeyLocalRangeMetadataPrefix, engine.Key(strconv.FormatInt(rangeID, 10)))
 }
 
 // A RangeSlice is a slice of Range pointers used for replica lookups
@@ -163,8 +163,8 @@ func (s *Store) Init() error {
 	}
 
 	// Create ID allocators.
-	s.raftIDAlloc = NewIDAllocator(engine.KeyRaftIDGenerator, s.db, 2, raftIDAllocCount)
-	s.rangeIDAlloc = NewIDAllocator(engine.KeyRangeIDGenerator, s.db, 2, rangeIDAllocCount)
+	s.raftIDAlloc = NewIDAllocator(engine.KeyRaftIDGenerator, s.db, 2 /* min ID */, raftIDAllocCount)
+	s.rangeIDAlloc = NewIDAllocator(engine.KeyRangeIDGenerator, s.db, 2 /* min ID */, rangeIDAllocCount)
 
 	// GCTimeouts method is called each time an engine compaction is
 	// underway. It sets minimum timeouts for transaction records and
@@ -186,8 +186,10 @@ func (s *Store) Init() error {
 
 	s.mu.Lock()
 	defer s.mu.Unlock()
-	start := engine.KeyLocalRangeMetadataPrefix
-	end := engine.PrefixEndKey(start)
+	startKey := engine.KeyLocalRangeMetadataPrefix
+	endKey := startKey.PrefixEnd()
+	start := startKey.Encode(nil)
+	end := endKey.Encode(nil)
 	const rows = 64
 	for {
 		kvs, err := s.engine.Scan(start, end, rows)
@@ -207,7 +209,7 @@ func (s *Store) Init() error {
 		if len(kvs) < rows {
 			break
 		}
-		start = engine.NextKey(kvs[rows-1].Key)
+		start = engine.Key(kvs[rows-1].Key).Next()
 	}
 
 	// Ensure that ranges are sorted.
@@ -247,14 +249,18 @@ func (s *Store) GetRange(rangeID int64) (*Range, error) {
 
 // LookupRange looks up a range via binary search over the sorted
 // "rangesByKey" RangeSlice. Returns nil if no range is found for
-// specified key range.
+// specified key range. Note that the specified keys are transformed
+// using Key.Address() to ensure we lookup ranges correctly for local
+// keys.
 func (s *Store) LookupRange(start, end engine.Key) *Range {
 	s.mu.RLock()
 	defer s.mu.RUnlock()
+	startAddr := start.Address()
+	endAddr := end.Address()
 	n := sort.Search(len(s.rangesByKey), func(i int) bool {
-		return bytes.Compare(start, s.rangesByKey[i].Meta.EndKey) < 0
+		return startAddr.Less(s.rangesByKey[i].Meta.EndKey)
 	})
-	if n >= len(s.rangesByKey) || !s.rangesByKey[n].Meta.ContainsKeyRange(start, end) {
+	if n >= len(s.rangesByKey) || !s.rangesByKey[n].Meta.ContainsKeyRange(startAddr, endAddr) {
 		return nil
 	}
 	return s.rangesByKey[n]
@@ -352,7 +358,7 @@ func (s *Store) writeRangeToEngine(rng *Range) error {
 	if rng == nil {
 		return util.Error("no range given")
 	}
-	return engine.PutProto(s.engine, makeRangeKey(rng.Meta.RangeID), rng.Meta)
+	return engine.PutProto(s.engine, makeRangeKey(rng.Meta.RangeID).Encode(nil), rng.Meta)
 }
 
 // DropRange removes the specified range from the store's map, and also
@@ -368,7 +374,7 @@ func (s *Store) DropRange(rangeID int64) error {
 		rng.Stop()
 	}
 	delete(s.ranges, rangeID)
-	if err := s.engine.Clear(makeRangeKey(rangeID)); err != nil {
+	if err := s.engine.Clear(makeRangeKey(rangeID).Encode(nil)); err != nil {
 		return err
 	}
 	return nil
@@ -457,7 +463,7 @@ func (s *Store) maybeResolveWriteIntentError(rng *Range, method string, args pro
 	pushArgs := &proto.InternalPushTxnRequest{
 		RequestHeader: proto.RequestHeader{
 			Timestamp:    args.Header().Timestamp,
-			Key:          wiErr.Txn.ID, // Address to pushee's txn
+			Key:          engine.MakeLocalKey(engine.KeyLocalTransactionPrefix, wiErr.Txn.ID), // Address to pushee's txn
 			User:         args.Header().User,
 			UserPriority: args.Header().UserPriority,
 			Txn:          args.Header().Txn,

--- a/storage/store_test.go
+++ b/storage/store_test.go
@@ -149,7 +149,7 @@ func createTestStore(createDefaultRange bool, t *testing.T) (*Store, *hlc.Manual
 	// Create system key range for allocations.
 	meta := store.BootstrapRangeMetadata()
 	meta.StartKey = engine.KeySystemPrefix
-	meta.EndKey = engine.PrefixEndKey(engine.KeySystemPrefix)
+	meta.EndKey = engine.KeySystemPrefix.PrefixEnd()
 	rng, err := store.CreateRange(meta)
 	if err != nil {
 		t.Fatal(err)
@@ -375,7 +375,7 @@ func TestStoreResolveWriteIntent(t *testing.T) {
 		if resolvable {
 			wiErr, ok := err.(*proto.WriteIntentError)
 			if !ok {
-				t.Errorf("resolvable? %t, expected write intent error; got %s", resolvable, err)
+				t.Fatalf("resolvable? %t, expected write intent error; got %s", resolvable, err)
 			}
 			if !bytes.Equal(wiErr.Key, key) || !bytes.Equal(wiErr.Txn.ID, pushee.ID) ||
 				wiErr.Resolved != resolvable {


### PR DESCRIPTION
Local keys are keys which are located on the same range as other keys
minus a local key prefix. Local key prefixes take the form:
"\x00\x00\x00[4 characters]". Any commands addressed to keys of this
form are direct to the range containing the same key minus the prefix.
Transaction records, response cache entries, range metadata (and
in the future others) all have local keys.

Changed cases where we write directly to the underlying engine to use
binary-encoded keys. Now that we binary encode all keys, need to pass
correct prefixes to the C++ custom compaction filter for GC. In this
way, we avoid having C++ need implementations of our decoding methods.

Moved a number of methods into methods of struct engine.Key. Added
associated unittests.
