### PR TITLE
Simple clock offset measurement between two connected nodes

### DIFF
--- a/gossip/client.go
+++ b/gossip/client.go
@@ -65,7 +65,7 @@ func newClient(addr net.Addr) *client {
 // channel. If the client experienced an error, its err field will
 // be set. This method blocks and should be invoked via goroutine.
 func (c *client) start(g *Gossip, done chan *client) {
-	c.rpcClient = rpc.NewClient(c.addr, nil, g.tlsConfig)
+	c.rpcClient = rpc.NewClient(c.addr, nil, g.tlsConfig, g.clock)
 	select {
 	case <-c.rpcClient.Ready:
 		// Success!

--- a/gossip/gossip_test.go
+++ b/gossip/gossip_test.go
@@ -23,6 +23,7 @@ import (
 	"time"
 
 	"github.com/cockroachdb/cockroach/rpc"
+	"github.com/cockroachdb/cockroach/util/hlc"
 )
 
 // verifyConvergence verifies that info from each node is visible from
@@ -47,7 +48,7 @@ func TestConvergence(t *testing.T) {
 
 // TestGossipInfoStore verifies operation of gossip instance infostore.
 func TestGossipInfoStore(t *testing.T) {
-	g := New(rpc.LoadInsecureTLSConfig())
+	g := New(rpc.LoadInsecureTLSConfig(), hlc.NewClock(hlc.UnixNano))
 	g.AddInfo("i", int64(1), time.Hour)
 	if val, err := g.GetInfo("i"); val.(int64) != int64(1) || err != nil {
 		t.Errorf("error fetching int64: %v", err)
@@ -74,7 +75,7 @@ func TestGossipInfoStore(t *testing.T) {
 // TestGossipGroupsInfoStore verifies gossiping of groups via the
 // gossip instance infostore.
 func TestGossipGroupsInfoStore(t *testing.T) {
-	g := New(rpc.LoadInsecureTLSConfig())
+	g := New(rpc.LoadInsecureTLSConfig(), hlc.NewClock(hlc.UnixNano))
 
 	// For int64.
 	g.RegisterGroup("i", 3, MinGroup)

--- a/kv/dist_kv.go
+++ b/kv/dist_kv.go
@@ -251,7 +251,8 @@ func (kv *DistKV) sendRPC(desc *proto.RangeDescriptor, method string, args proto
 		SendNextTimeout: defaultSendNextTimeout,
 		Timeout:         defaultRPCTimeout,
 	}
-	return rpc.Send(argsMap, method, replyChan, rpcOpts, kv.gossip.TLSConfig())
+	return rpc.Send(argsMap, method, replyChan, rpcOpts,
+		kv.gossip.TLSConfig(), kv.gossip.Clock())
 }
 
 // ExecuteCmd verifies permissions and looks up the appropriate range

--- a/rpc/client_test.go
+++ b/rpc/client_test.go
@@ -24,12 +24,13 @@ import (
 	"time"
 
 	"github.com/cockroachdb/cockroach/util"
+	"github.com/cockroachdb/cockroach/util/hlc"
 )
 
 func init() {
 	// Setting the heartbeat interval in individual tests
 	// triggers the race detector, so this is better for now.
-	heartbeatInterval = 10 * time.Millisecond
+	heartbeatInterval = 5 * time.Millisecond
 }
 
 func TestClientHeartbeat(t *testing.T) {
@@ -38,14 +39,15 @@ func TestClientHeartbeat(t *testing.T) {
 		t.Fatal(err)
 	}
 
+	clock := hlc.NewClock(hlc.UnixNano)
 	addr := util.CreateTestAddr("tcp")
-	s := NewServer(addr, tlsConfig)
+	s := NewServer(addr, tlsConfig, clock)
 	if err := s.Start(); err != nil {
 		t.Fatal(err)
 	}
-	c := NewClient(s.Addr(), nil, tlsConfig)
-	time.Sleep(heartbeatInterval * 2)
-	if c != NewClient(s.Addr(), nil, tlsConfig) {
+	c := NewClient(s.Addr(), nil, tlsConfig, clock)
+	<-c.Ready
+	if c != NewClient(s.Addr(), nil, tlsConfig, clock) {
 		t.Fatal("expected cached client to be returned while healthy")
 	}
 	<-c.Ready
@@ -74,11 +76,98 @@ func TestClientHeartbeatBadServer(t *testing.T) {
 
 	// Now, create a client. It should attempt a heartbeat and fail,
 	// causing retry loop to activate.
-	c := NewClient(s.Addr(), nil, tlsConfig)
+	clock := hlc.NewClock(hlc.UnixNano)
+	c := NewClient(s.Addr(), nil, tlsConfig, clock)
 	select {
 	case <-c.Ready:
 		t.Error("unexpected client heartbeat success")
 	case <-c.Closed:
 	}
 	s.Close()
+}
+
+func TestOffsetMeasurement(t *testing.T) {
+	tlsConfig, err := LoadTestTLSConfig("..")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Create the server so that we can register a manual clock.
+	addr := util.CreateTestAddr("tcp")
+	s := &Server{
+		Server:    rpc.NewServer(),
+		tlsConfig: tlsConfig,
+		addr:      addr,
+	}
+	serverManual := hlc.ManualClock(10)
+	serverClock := hlc.NewClock(serverManual.UnixNano)
+	heartbeat := &HeartbeatService{
+		clock: serverClock,
+	}
+	s.RegisterName("Heartbeat", heartbeat)
+	if err := s.Start(); err != nil {
+		t.Fatal(err)
+	}
+
+	// Create a client that is 10 nanoseconds behind the server.
+	advancing := AdvancingClock{time: 0, advancementInterval: 10}
+	clientClock := hlc.NewClock(advancing.UnixNano)
+	c := NewClient(s.Addr(), nil, tlsConfig, clientClock)
+	<-c.Ready
+	expectedOffset := Offset{Offset: 5, Delay: 10}
+	if c.Offset().Offset != expectedOffset.Offset ||
+		c.Offset().Delay != expectedOffset.Delay {
+		t.Errorf("expected offset %v, actual %v",
+			expectedOffset, c.Offset())
+	}
+}
+
+func TestFailedOffestMeasurement(t *testing.T) {
+	tlsConfig, err := LoadTestTLSConfig("..")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Create the server so that we can register the heartbeat manually.
+	addr := util.CreateTestAddr("tcp")
+	s := &Server{
+		Server:    rpc.NewServer(),
+		tlsConfig: tlsConfig,
+		addr:      addr,
+	}
+	serverManual := hlc.ManualClock(10)
+	serverClock := hlc.NewClock(serverManual.UnixNano)
+	heartbeat := &ManualHeartbeatService{
+		clock: serverClock,
+		ready: make(chan bool),
+	}
+	s.RegisterName("Heartbeat", heartbeat)
+	if err := s.Start(); err != nil {
+		t.Fatal(err)
+	}
+
+	// Create a client that never receives a heartbeat after the first.
+	clientManual := hlc.ManualClock(0)
+	clientClock := hlc.NewClock(clientManual.UnixNano)
+	c := NewClient(s.Addr(), nil, tlsConfig, clientClock)
+	heartbeat.ready <- true // Allow one heartbeat for initialization.
+	<-c.Ready
+	// Wait until there must have been a missed heartbeat.
+	time.Sleep(heartbeatInterval * 4)
+	if c.Offset() != InfiniteOffset {
+		t.Errorf("expected offset %v, actual %v",
+			InfiniteOffset, c.Offset())
+	}
+	s.Close()
+}
+
+type AdvancingClock struct {
+	time                int64
+	advancementInterval int64
+}
+
+func (ac *AdvancingClock) UnixNano() int64 {
+	time := ac.time
+	ac.time = time + ac.advancementInterval
+	return time
 }

--- a/rpc/send.go
+++ b/rpc/send.go
@@ -27,6 +27,7 @@ import (
 
 	"github.com/cockroachdb/cockroach/proto"
 	"github.com/cockroachdb/cockroach/util"
+	"github.com/cockroachdb/cockroach/util/hlc"
 	"github.com/cockroachdb/cockroach/util/log"
 )
 
@@ -80,7 +81,8 @@ func (s SendError) CanRetry() bool { return s.canRetry }
 // failure. Note that on error, some replies may have been sent on the
 // channel. Send returns an error if the number of errors exceeds the
 // possibility of attaining the required successful responses.
-func Send(argsMap map[net.Addr]interface{}, method string, replyChanI interface{}, opts Options, tlsConfig *TLSConfig) error {
+func Send(argsMap map[net.Addr]interface{}, method string, replyChanI interface{},
+	opts Options, tlsConfig *TLSConfig, clock *hlc.Clock) error {
 	if opts.N < len(argsMap) {
 		return SendError{
 			errMsg:   fmt.Sprintf("insufficient replicas (%d) to satisfy send request of %d", len(argsMap), opts.N),
@@ -91,7 +93,7 @@ func Send(argsMap map[net.Addr]interface{}, method string, replyChanI interface{
 	// Build the slice of clients.
 	var healthy, unhealthy []*Client
 	for addr, args := range argsMap {
-		client := NewClient(addr, nil, tlsConfig)
+		client := NewClient(addr, nil, tlsConfig, clock)
 		delete(argsMap, addr)
 		argsMap[client.Addr()] = args
 		if client.IsHealthy() {

--- a/rpc/server.go
+++ b/rpc/server.go
@@ -24,6 +24,7 @@ import (
 	"sync"
 
 	"github.com/cockroachdb/cockroach/util"
+	"github.com/cockroachdb/cockroach/util/hlc"
 	"github.com/cockroachdb/cockroach/util/log"
 )
 
@@ -46,13 +47,15 @@ type Server struct {
 }
 
 // NewServer creates a new instance of Server.
-func NewServer(addr net.Addr, tlsConfig *TLSConfig) *Server {
+func NewServer(addr net.Addr, tlsConfig *TLSConfig, clock *hlc.Clock) *Server {
 	s := &Server{
 		Server:    rpc.NewServer(),
 		tlsConfig: tlsConfig,
 		addr:      addr,
 	}
-	heartbeat := &HeartbeatService{}
+	heartbeat := &HeartbeatService{
+		clock: clock,
+	}
 	s.RegisterName("Heartbeat", heartbeat)
 	return s
 }

--- a/server/server.go
+++ b/server/server.go
@@ -316,11 +316,11 @@ func newServer() (*server, error) {
 		host:  host,
 		mux:   http.NewServeMux(),
 		clock: hlc.NewClock(hlc.UnixNano),
-		rpc:   rpc.NewServer(util.MakeRawAddr("tcp", *rpcAddr), tlsConfig),
 	}
 	s.clock.SetMaxDrift(*maxDrift)
 
-	s.gossip = gossip.New(tlsConfig)
+	s.rpc = rpc.NewServer(util.MakeRawAddr("tcp", *rpcAddr), tlsConfig, s.clock)
+	s.gossip = gossip.New(tlsConfig, s.clock)
 	s.kvDB = kv.NewDB(kv.NewDistKV(s.gossip), s.clock)
 	s.kvREST = kv.NewRESTServer(s.kvDB)
 	s.node = NewNode(s.kvDB, s.gossip)

--- a/storage/range_test.go
+++ b/storage/range_test.go
@@ -94,7 +94,7 @@ func createTestRange(engine engine.Engine, t *testing.T) (*Range, *gossip.Gossip
 		RangeDescriptor: testRangeDescriptor,
 		RangeID:         0,
 	}
-	g := gossip.New(rpc.LoadInsecureTLSConfig())
+	g := gossip.New(rpc.LoadInsecureTLSConfig(), hlc.NewClock(hlc.UnixNano))
 	clock := hlc.NewClock(hlc.UnixNano)
 	r := NewRange(rm, clock, engine, nil, g, nil)
 	r.Start()


### PR DESCRIPTION
The beginnings of measuring a node's clock offset compared to the rest of it's connected nodes.

This change enables the client connections between two nodes to estimate their relative offset. Note that if node A has a client connection to node B, then it is likely that node B will not establish a connection with node A because their communication is already covered by A's client. Thus the next step might be to have A send its offset measurement to B. Then B will be updated on the latest offset measurement, though this requires the heartbeat to have three messages. 

What I plan to do from here is largely based on the NTP algorithm:
- Have clients keep track of the more accurate offset measurement among the last x samples (the most accurate should be the offset with the smallest round-trip delay time). This will help to reduce noise in measurements (https://www.eecis.udel.edu/~mills/ntp/html/filter.html)
- Have a routine that collects all the active offset interval measurements from the heartbeat service and use an intersection algorithm to find the most likely interval for the true offset (https://www.eecis.udel.edu/~mills/ntp/html/select.html)
- There are more statistical techniques to clean up the data even more, but I'm not sure yet if it is necessary. 

Please let me know if my plan seems reasonable! Sorry I got to this later than I expected, but I have been blocked until recently.
