### PR TITLE
Replace coordinator's naive slice of keys with an interval tree.

### DIFF
--- a/kv/txn_db_correctness_test.go
+++ b/kv/txn_db_correctness_test.go
@@ -133,7 +133,7 @@ func readCmd(c *cmd, db storage.DB, t *testing.T) error {
 	if r.GoError() == nil {
 		if r.Value != nil {
 			c.env[c.key] = r.Value.GetInteger()
-			c.debug = fmt.Sprintf("[%d]", r.Value.GetInteger())
+			c.debug = fmt.Sprintf("[%d ts=%d]", r.Value.GetInteger(), r.Timestamp.Logical)
 		}
 	}
 	return r.GoError()
@@ -160,7 +160,7 @@ func scanCmd(c *cmd, db storage.DB, t *testing.T) error {
 			c.env[string(key)] = kv.Value.GetInteger()
 			vals = append(vals, fmt.Sprintf("%d", kv.Value.GetInteger()))
 		}
-		c.debug = fmt.Sprintf("[%s]", strings.Join(vals, " "))
+		c.debug = fmt.Sprintf("[%s ts=%d]", strings.Join(vals, " "), r.Timestamp.Logical)
 	}
 	return r.GoError()
 }
@@ -174,7 +174,7 @@ func incCmd(c *cmd, db storage.DB, t *testing.T) error {
 	})
 	if r.GoError() == nil {
 		c.env[c.key] = r.NewValue
-		c.debug = fmt.Sprintf("[%d]", r.NewValue)
+		c.debug = fmt.Sprintf("[%d ts=%d]", r.NewValue, r.Timestamp.Logical)
 	}
 	return r.GoError()
 }
@@ -190,13 +190,14 @@ func sumCmd(c *cmd, db storage.DB, t *testing.T) error {
 		RequestHeader: proto.RequestHeader{Key: c.getKey()},
 		Value:         proto.Value{Integer: gogoproto.Int64(sum)},
 	})
-	c.debug = fmt.Sprintf("[%d]", sum)
+	c.debug = fmt.Sprintf("[%d ts=%d]", sum, r.Timestamp.Logical)
 	return r.GoError()
 }
 
 // commitCmd commits the transaction.
 func commitCmd(c *cmd, db storage.DB, t *testing.T) error {
 	r := <-db.EndTransaction(&proto.EndTransactionRequest{Commit: true})
+	c.debug = fmt.Sprintf("[ts=%d]", r.Timestamp.Logical)
 	return r.GoError()
 }
 
@@ -535,7 +536,8 @@ func (hv *historyVerifier) runHistory(historyIdx int, priorities []int32,
 	}
 	if hv.expSuccess && err != nil {
 		verifyStr := strings.Join(verifyStrs, " ")
-		t.Errorf("iso=%v, pri=%v, history=%q: actual=%q, verify=%q: %s", isolations, priorities, plannedStr, actualStr, verifyStr, err)
+		t.Errorf("%d: iso=%v, pri=%v, history=%q: actual=%q, verify=%q: %s",
+			historyIdx, isolations, priorities, plannedStr, actualStr, verifyStr, err)
 	}
 	return err
 }

--- a/proto/config.proto
+++ b/proto/config.proto
@@ -83,9 +83,9 @@ message AcctConfig {
 // PermConfig holds permission configuration, specifying read/write ACLs.
 message PermConfig {
   // ACL lists users with read permissions.
-  repeated string Read= 1 [(gogoproto.nullable) = false, (gogoproto.moretags) = "yaml:\"read,omitempty\""];
+  repeated string Read = 1 [(gogoproto.nullable) = false, (gogoproto.moretags) = "yaml:\"read,omitempty\""];
   // ACL lists users with write permissions.
-  repeated string Write= 2 [(gogoproto.nullable) = false, (gogoproto.moretags) = "yaml:\"write,omitempty\""];
+  repeated string Write = 2 [(gogoproto.nullable) = false, (gogoproto.moretags) = "yaml:\"write,omitempty\""];
 }
 
 // ZoneConfig holds configuration that is needed for a range of KV pairs.

--- a/server/zone_cli.go
+++ b/server/zone_cli.go
@@ -62,12 +62,12 @@ Fetches and displays the zone configuration for <key-prefix>. The key
 prefix should be escaped via URL query escaping if it contains
 non-ascii bytes or spaces.
 `,
-	Run:  runGetZones,
+	Run:  runGetZone,
 	Flag: *flag.CommandLine,
 }
 
-// runGetZones invokes the REST API with GET action and key prefix as path.
-func runGetZones(cmd *commander.Command, args []string) {
+// runGetZone invokes the REST API with GET action and key prefix as path.
+func runGetZone(cmd *commander.Command, args []string) {
 	if len(args) != 1 {
 		cmd.Usage()
 		return

--- a/server/zone_test.go
+++ b/server/zone_test.go
@@ -71,7 +71,7 @@ func ExampleSetAndGetZone() {
 	for _, test := range testData {
 		prefix := url.QueryEscape(string(test.prefix))
 		runSetZone(CmdSetZone, []string{prefix, testConfigFn})
-		runGetZones(CmdGetZone, []string{prefix})
+		runGetZone(CmdGetZone, []string{prefix})
 	}
 	// Output:
 	// set zone config for key prefix ""

--- a/storage/engine/keys.go
+++ b/storage/engine/keys.go
@@ -30,12 +30,6 @@ import (
 // Key defines the key in the key-value datastore.
 type Key []byte
 
-// KeyRange provides a key range from start to end.  If end is nil,
-// the key range is defined only for a single key: start.
-type KeyRange struct {
-	Start, End Key
-}
-
 // MakeKey makes a new key which is the concatenation of the
 // given inputs, in order.
 func MakeKey(prefix Key, keys ...Key) Key {

--- a/util/cache_test.go
+++ b/util/cache_test.go
@@ -269,9 +269,12 @@ func TestIntervalCacheOverlap(t *testing.T) {
 	ic.Add(ic.NewKey(rangeKey("i"), rangeKey("j")), 10)
 
 	expValues := []interface{}{3, 2, 4, 6, 7, 9}
-	vs := ic.GetOverlaps(rangeKey("d"), rangeKey("g"))
-	if !reflect.DeepEqual(expValues, vs) {
-		t.Errorf("expected overlap values %+v, got %+v", expValues, vs)
+	values := []interface{}{}
+	for _, o := range ic.GetOverlaps(rangeKey("d"), rangeKey("g")) {
+		values = append(values, o.Value)
+	}
+	if !reflect.DeepEqual(expValues, values) {
+		t.Errorf("expected overlap values %+v, got %+v", expValues, values)
 	}
 }
 


### PR DESCRIPTION
In many instances, txns were sending 3-4 identical resolve intents.
Seemed worthwhile to make this change.

Also, over the course of debugging, I noticed that we were keeping way
too many timestamp entries in the timestamp cache. This change also
includes code to keep that cache pruned on inserts so it should be
much more memory-efficient now.

Finally, I noticed a bug in the interval tree implementation from biogo.
This change works around it by pruning the timestamp cache, but this is
pretty serious and I've mailed the biogo user group and will get it
resolved one way or another.
