### PR TITLE
A couple of no-brainer style fixes

### DIFF
--- a/githooks/pre-commit
+++ b/githooks/pre-commit
@@ -26,7 +26,7 @@ if [ "${GO_SKIP_PRECOMMIT_CHECKS}" != "1" -a -n "${gofiles}" ]; then
   fi
 
   # Check for vet errors.
-  unvetted=$(go vet ${gofiles} | awk -F: '{print $1}' | uniq)
+  unvetted=$(go tool vet ${gofiles} | awk -F: '{print $1}' | uniq)
   if [ -n "${unvetted}" ]; then
     echo -e >&2 "\nGo files with vet errors:"
     for fn in ${unvetted}; do

--- a/gossip/group.go
+++ b/gossip/group.go
@@ -194,7 +194,7 @@ func (g *group) infosAsSlice() infoSlice {
 // currently have.
 func (g *group) addInfo(i *info) error {
 	// First, see if info is already in the group. If so, and this
-	// info timestamp is newer, remove existing info.  If the
+	// info timestamp is newer, remove existing info. If the
 	// timestamps are equal (i.e. this is the same info), but hops
 	// value of prospective info is lower, take the minimum of the two
 	// Hops values.

--- a/gossip/infostore.go
+++ b/gossip/infostore.go
@@ -238,7 +238,7 @@ func (is *infoStore) maxHops() uint32 {
 // course of visiting all groups, all group infos, and all non-group
 // infos. The visitGroup function is run against each group in
 // turn. After each group is visited, the visitInfo function is run
-// against each of its infos.  Finally, after all groups have been
+// against each of its infos. Finally, after all groups have been
 // visitied, the visitInfo function is run against each non-group info
 // in turn. Be sure to skip over any expired infos.
 func (is *infoStore) visitInfos(visitGroup func(*group) error, visitInfo func(*info) error) error {

--- a/gossip/keys.go
+++ b/gossip/keys.go
@@ -40,7 +40,7 @@ const (
 	// storage.StoreDescriptor struct.
 	KeyMaxAvailCapacityPrefix = "max-avail-capacity-"
 
-	// KeyNodeCount is the count of gossip nodes in the network.  The
+	// KeyNodeCount is the count of gossip nodes in the network. The
 	// value is an int64 containing the count of nodes in the cluster.
 	// TODO(spencer): should remove this and instead just count the
 	//   number of node ids being gossiped.

--- a/kv/db.go
+++ b/kv/db.go
@@ -112,7 +112,8 @@ func (db *DB) EndTransaction(args *proto.EndTransactionRequest) <-chan *proto.En
 
 // RunTransaction executes retryable in the context of a distributed
 // transaction.
-
+// TODO(Spencer): write or copy a more descriptive comment here as various
+// references to this comment exist.
 func (db *DB) RunTransaction(opts *storage.TransactionOptions, retryable func(db storage.DB) error) error {
 	return runTransaction(db, opts, retryable)
 }

--- a/kv/dist_kv.go
+++ b/kv/dist_kv.go
@@ -195,7 +195,7 @@ func (kv *DistKV) getRangeMetadata(key engine.Key) ([]proto.RangeDescriptor, err
 	)
 	if len(metadataKey) == 0 {
 		// In this case, the requested key is stored in the cluster's first
-		// range.  Return the first range, which is always gossiped and not
+		// range. Return the first range, which is always gossiped and not
 		// queried from the datastore.
 		rd, err := kv.getFirstRangeDescriptor()
 		if err != nil {

--- a/kv/range_cache.go
+++ b/kv/range_cache.go
@@ -132,7 +132,7 @@ func (rmc *RangeMetadataCache) EvictCachedRangeMetadata(key engine.Key) {
 			rmc.rangeCacheMu.Unlock()
 		}
 		// Retrieve the metadata range key for the next level of metadata, and
-		// evict that key as well.  This loop ends after the meta1 range, which
+		// evict that key as well. This loop ends after the meta1 range, which
 		// returns KeyMin as its metadata key.
 		key = engine.RangeMetaKey(key)
 		if len(key) == 0 {

--- a/kv/txn_db_correctness_test.go
+++ b/kv/txn_db_correctness_test.go
@@ -343,7 +343,7 @@ func TestEnumeratePriorities(t *testing.T) {
 	}
 	enum := enumeratePriorities([]int32{p1, p2, p3})
 	if !reflect.DeepEqual(enum, expPriorities) {
-		t.Errorf("expected enumeration to match %s; got %s", expPriorities, enum)
+		t.Errorf("expected enumeration to match %v; got %v", expPriorities, enum)
 	}
 }
 

--- a/multiraft/clock.go
+++ b/multiraft/clock.go
@@ -28,7 +28,7 @@ import (
 type Clock interface {
 	Now() time.Time
 
-	// NewElectionTimer returns a timer to be used for triggering elections.  The resulting
+	// NewElectionTimer returns a timer to be used for triggering elections. The resulting
 	// Timer struct will have its C field filled out, but may not be a "real" timer, so it
 	// must be stopped with StopElectionTimer instead of t.Stop()
 	NewElectionTimer(time.Duration) *time.Timer
@@ -52,7 +52,7 @@ func (realClock) StopElectionTimer(t *time.Timer) {
 	t.Stop()
 }
 
-// manualClock is a fake implementation of the Clock interface.  With this clock
+// manualClock is a fake implementation of the Clock interface. With this clock
 // time does not flow normally, but time-based events can be triggered manually with
 // methods like triggerElection.
 type manualClock struct {

--- a/multiraft/doc.go
+++ b/multiraft/doc.go
@@ -23,8 +23,8 @@ where one server is a part of many Raft consensus groups (likely with overlappin
 This entails the use of a shared log and coalesced timers for heartbeats.
 
 A cluster consists of a collection of nodes; the local node is represented by a MultiRaft
-object.  Each node may participate in any number of groups.  Nodes must have a globally
-unique ID (a string), and groups have a globally unique name.  The application is responsible
+object. Each node may participate in any number of groups. Nodes must have a globally
+unique ID (a string), and groups have a globally unique name. The application is responsible
 for providing a Transport interface that knows how to communicate with other nodes
 based on their IDs, and a Storage interface to manage persistent data.
 

--- a/multiraft/events_test.go
+++ b/multiraft/events_test.go
@@ -18,7 +18,7 @@
 package multiraft
 
 // eventDemux turns the unified MultiRaft.Events stream into a set of type-safe
-// channels for ease of testing.  It is not suitable for non-test use because
+// channels for ease of testing. It is not suitable for non-test use because
 // unconsumed channels can become backlogged and block.
 type eventDemux struct {
 	LeaderElection   chan *EventLeaderElection

--- a/multiraft/storage.go
+++ b/multiraft/storage.go
@@ -32,7 +32,7 @@ const (
 	LogEntryChangeMembership
 )
 
-// LogEntry represents a persistent log entry.  Payloads are interpreted according to
+// LogEntry represents a persistent log entry. Payloads are interpreted according to
 // the Type field; Payloads of LogEntryCommand are opaque to the raft system.
 type LogEntry struct {
 	Term    int
@@ -58,7 +58,7 @@ const (
 	// TODO(bdarnell): enforce the requirement that a node be added as an observer first.
 	ChangeMembershipAddMember
 
-	// ChangeMembershipRemoveMember removes a voting node.  It is not possible to remove the
+	// ChangeMembershipRemoveMember removes a voting node. It is not possible to remove the
 	// last node; the result of attempting to do so is undefined.
 	ChangeMembershipRemoveMember
 )
@@ -77,7 +77,7 @@ type GroupElectionState struct {
 	// CurrentTerm is the highest term this node has seen.
 	CurrentTerm int
 
-	// VotedFor is the node this node has voted for in CurrentTerm's election.  It is zero
+	// VotedFor is the node this node has voted for in CurrentTerm's election. It is zero
 	// If this node has not yet voted in CurrentTerm.
 	VotedFor NodeID
 }
@@ -126,7 +126,7 @@ type Storage interface {
 	// SetGroupElectionState is called to update the election state for the given group.
 	SetGroupElectionState(groupID GroupID, electionState *GroupElectionState) error
 
-	// AppendLogEntries is called to add entries to the log.  The entries will always span
+	// AppendLogEntries is called to add entries to the log. The entries will always span
 	// a contiguous range of indices just after the current end of the log.
 	AppendLogEntries(groupID GroupID, entries []*LogEntry) error
 
@@ -137,7 +137,7 @@ type Storage interface {
 	GetLogEntry(groupID GroupID, index int) (*LogEntry, error)
 
 	// GetLogEntries is called to asynchronously retrieve entries from the log,
-	// from firstIndex to lastIndex inclusive.  If there is an error the storage
+	// from firstIndex to lastIndex inclusive. If there is an error the storage
 	// layer should send one LogEntryState with a non-nil error and then close the
 	// channel.
 	GetLogEntries(groupID GroupID, firstIndex, lastIndex int, ch chan<- *LogEntryState)
@@ -259,7 +259,7 @@ type writeTask struct {
 	storage Storage
 	stopper chan struct{}
 
-	// ready is an unbuffered channel used for synchronization.  If writes to this channel do not
+	// ready is an unbuffered channel used for synchronization. If writes to this channel do not
 	// block, the writeTask is ready to receive a request.
 	ready chan struct{}
 
@@ -268,7 +268,7 @@ type writeTask struct {
 	out chan *writeResponse
 }
 
-// newWriteTask creates a writeTask.  The caller should start the task after creating it.
+// newWriteTask creates a writeTask. The caller should start the task after creating it.
 func newWriteTask(storage Storage) *writeTask {
 	return &writeTask{
 		storage: storage,
@@ -279,7 +279,7 @@ func newWriteTask(storage Storage) *writeTask {
 	}
 }
 
-// start runs the storage loop.  Blocks until stopped, so should be run in a goroutine.
+// start runs the storage loop. Blocks until stopped, so should be run in a goroutine.
 func (w *writeTask) start() {
 	for {
 		var request *writeRequest

--- a/multiraft/transport.go
+++ b/multiraft/transport.go
@@ -25,7 +25,7 @@ import (
 )
 
 // The Transport interface is supplied by the application to manage communication with
-// other nodes.  It is responsible for mapping from IDs to some communication channel
+// other nodes. It is responsible for mapping from IDs to some communication channel
 // (in the simplest case, a host:port pair could be used as an ID, although this would
 // make it impossible to move an instance from one host to another except by syncing
 // up a new node from scratch).
@@ -46,9 +46,9 @@ type localRPCTransport struct {
 	listeners map[NodeID]net.Listener
 }
 
-// NewLocalRPCTransport creates a Transport for local testing use.  MultiRaft instances
+// NewLocalRPCTransport creates a Transport for local testing use. MultiRaft instances
 // sharing the same local Transport can find and communicate with each other by ID (which
-// can be an arbitrary string).  Each instance binds to a different unused port on
+// can be an arbitrary string). Each instance binds to a different unused port on
 // localhost.
 // Because this is just for local testing, it doesn't use TLS.
 func NewLocalRPCTransport() Transport {
@@ -107,7 +107,7 @@ type RequestHeader struct {
 	DestNode NodeID
 }
 
-// RequestVoteRequest is a part of the Raft protocol.  It is public so it can be used
+// RequestVoteRequest is a part of the Raft protocol. It is public so it can be used
 // by the net/rpc system but should not be used outside this package except to serialize it.
 type RequestVoteRequest struct {
 	RequestHeader
@@ -118,14 +118,14 @@ type RequestVoteRequest struct {
 	LastLogTerm  int
 }
 
-// RequestVoteResponse is a part of the Raft protocol.  It is public so it can be used
+// RequestVoteResponse is a part of the Raft protocol. It is public so it can be used
 // by the net/rpc system but should not be used outside this package except to serialize it.
 type RequestVoteResponse struct {
 	Term        int
 	VoteGranted bool
 }
 
-// AppendEntriesRequest is a part of the Raft protocol.  It is public so it can be used
+// AppendEntriesRequest is a part of the Raft protocol. It is public so it can be used
 // by the net/rpc system but should not be used outside this package except to serialize it.
 type AppendEntriesRequest struct {
 	RequestHeader
@@ -138,7 +138,7 @@ type AppendEntriesRequest struct {
 	LeaderCommit int
 }
 
-// AppendEntriesResponse is a part of the Raft protocol.  It is public so it can be used
+// AppendEntriesResponse is a part of the Raft protocol. It is public so it can be used
 // by the net/rpc system but should not be used outside this package except to serialize it.
 type AppendEntriesResponse struct {
 	Term    int

--- a/server/node.go
+++ b/server/node.go
@@ -50,7 +50,7 @@ const (
 // traffic. A node is the top-level data structure. There is one node
 // instance per process. A node accepts incoming RPCs and services
 // them by directing the commands contained within RPCs to local
-// stores, which in turn direct the commands to specific ranges.  Each
+// stores, which in turn direct the commands to specific ranges. Each
 // node has access to the global, monolithic Key-Value abstraction via
 // its kv.DB reference. Nodes use this to allocate node and store
 // IDs for bootstrapping the node itself or new stores as they're added

--- a/server/zone.go
+++ b/server/zone.go
@@ -41,7 +41,7 @@ type zoneHandler struct {
 	db storage.DB // Key-value database client
 }
 
-// Put writes a zone config for the specified key prefix "key".  The
+// Put writes a zone config for the specified key prefix "key". The
 // zone config is parsed from the input "body". The zone config is
 // stored gob-encoded. The specified body must be valid utf8 and must
 // validly parse into a zone config struct.

--- a/storage/engine/engine.go
+++ b/storage/engine/engine.go
@@ -220,11 +220,11 @@ func Increment(engine Engine, key Key, inc int64) (int64, error) {
 }
 
 // ClearRange removes a set of entries, from start (inclusive)
-// to end (exclusive), up to max entries.  If max is 0, all
-// entries between start and end are deleted.  This function
-// returns the number of entries removed.  Either all entries
+// to end (exclusive), up to max entries. If max is 0, all
+// entries between start and end are deleted. This function
+// returns the number of entries removed. Either all entries
 // within the range, up to max, will be deleted, or none, and
-// an error will be returned.  Note that this function actually
+// an error will be returned. Note that this function actually
 // removes entries from the storage engine, rather than inserting
 // tombstones.
 func ClearRange(engine Engine, start, end Key, max int64) (int, error) {

--- a/storage/engine/gc.go
+++ b/storage/engine/gc.go
@@ -9,7 +9,7 @@
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
-// implied.  See the License for the specific language governing
+// implied. See the License for the specific language governing
 // permissions and limitations under the License. See the AUTHORS file
 // for names of contributors.
 //

--- a/storage/engine/gc_test.go
+++ b/storage/engine/gc_test.go
@@ -9,7 +9,7 @@
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
-// implied.  See the License for the specific language governing
+// implied. See the License for the specific language governing
 // permissions and limitations under the License. See the AUTHORS file
 // for names of contributors.
 //

--- a/storage/engine/in_mem.go
+++ b/storage/engine/in_mem.go
@@ -119,7 +119,7 @@ func (in *InMem) ReleaseSnapshot(snapshotID string) error {
 	return nil
 }
 
-// Attrs returns the list of attributes describing this engine.  This
+// Attrs returns the list of attributes describing this engine. This
 // includes the disk type (always "mem") and potentially other labels
 // to identify important attributes of the engine.
 func (in *InMem) Attrs() proto.Attributes {

--- a/storage/engine/keys.go
+++ b/storage/engine/keys.go
@@ -97,7 +97,7 @@ func (k Key) Next() Key {
 
 // PrefixEnd determines the end key given key as a prefix, that is
 // the key that sorts precisely behind all keys starting with prefix:
-// "1" is added to the final byte and the carry propagated.  The
+// "1" is added to the final byte and the carry propagated. The
 // special cases of nil and KeyMin ("") always returns KeyMax
 // ("\xff").
 func (k Key) PrefixEnd() Key {
@@ -153,9 +153,9 @@ type KeyValue struct {
 	Value
 }
 
-// RangeMetaKey returns a range metadata key for the given key.  For ordinary
+// RangeMetaKey returns a range metadata key for the given key. For ordinary
 // keys this returns a level 2 metadata key - for level 2 keys, it returns a
-// level 1 key.  For level 1 keys and local keys, KeyMin is returned.
+// level 1 key. For level 1 keys and local keys, KeyMin is returned.
 func RangeMetaKey(key Key) Key {
 	if len(key) == 0 {
 		return KeyMin
@@ -178,8 +178,8 @@ func RangeMetadataLookupKey(r *proto.RangeDescriptor) Key {
 }
 
 // ValidateRangeMetaKey validates that the given key is a valid Range Metadata
-// key.  It must have an appropriate metadata range prefix, and the original key
-// value must be less thas KeyMax.  As a special case, KeyMin is considered a
+// key. It must have an appropriate metadata range prefix, and the original key
+// value must be less thas KeyMax. As a special case, KeyMin is considered a
 // valid Range Metadata Key.
 func ValidateRangeMetaKey(key Key) error {
 	// KeyMin is a valid key.

--- a/storage/engine/keys.go
+++ b/storage/engine/keys.go
@@ -46,10 +46,10 @@ func MakeKey(prefix Key, keys ...Key) Key {
 // seven.
 func MakeLocalKey(prefix Key, keys ...Key) Key {
 	if KeyLocalPrefixLength%7 != 0 {
-		log.Fatal("local key prefix is not a multiple of 7: %d", KeyLocalPrefixLength)
+		log.Fatalf("local key prefix is not a multiple of 7: %d", KeyLocalPrefixLength)
 	}
 	if len(prefix) != KeyLocalPrefixLength {
-		log.Fatal("local key prefix length must be %d: %q", KeyLocalPrefixLength, prefix)
+		log.Fatalf("local key prefix length must be %d: %q", KeyLocalPrefixLength, prefix)
 	}
 	return MakeKey(prefix, keys...)
 }
@@ -95,7 +95,7 @@ func (k Key) Next() Key {
 	return MakeKey(k, Key{0})
 }
 
-// PrefixEndKey determines the end key given key as a prefix, that is
+// PrefixEnd determines the end key given key as a prefix, that is
 // the key that sorts precisely behind all keys starting with prefix:
 // "1" is added to the final byte and the carry propagated.  The
 // special cases of nil and KeyMin ("") always returns KeyMax

--- a/storage/engine/rocksdb.go
+++ b/storage/engine/rocksdb.go
@@ -218,7 +218,7 @@ func (r *RocksDB) ReleaseSnapshot(snapshotID string) error {
 	return nil
 }
 
-// Attrs returns the list of attributes describing this engine.  This
+// Attrs returns the list of attributes describing this engine. This
 // may include a specification of disk type (e.g. hdd, ssd, fio, etc.)
 // and potentially other labels to identify important attributes of
 // the engine.

--- a/storage/engine/rocksdb_test.go
+++ b/storage/engine/rocksdb_test.go
@@ -9,7 +9,7 @@
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
-// implied.  See the License for the specific language governing
+// implied. See the License for the specific language governing
 // permissions and limitations under the License. See the AUTHORS file
 // for names of contributors.
 //

--- a/storage/prefix.go
+++ b/storage/prefix.go
@@ -29,7 +29,7 @@ import (
 
 // PrefixConfig relate a string prefix to a config object. Config
 // objects include accounting, permissions, and zones. PrefixConfig
-// objects are the constituents of PrefixConfigMap objects.  In order
+// objects are the constituents of PrefixConfigMap objects. In order
 // to support binary searches of hierarchical prefixes (see the
 // comments in NewPrefixConfigMap), PrefixConfig objects are
 // additionally added to a PrefixConfigMap to demarcate the end of a

--- a/storage/range.go
+++ b/storage/range.go
@@ -915,7 +915,7 @@ func (r *Range) InternalRangeLookup(args *proto.InternalRangeLookupRequest, repl
 		return
 	}
 
-	// We want to search for the metadata key just greater than args.Key.  Scan
+	// We want to search for the metadata key just greater than args.Key. Scan
 	// for both the requested key and the keys immediately afterwards, up to
 	// MaxRanges.
 	metaPrefix := engine.Key(args.Key[:len(engine.KeyMeta1Prefix)])
@@ -1140,7 +1140,7 @@ func (r *Range) InternalPushTxn(args *proto.InternalPushTxnRequest, reply *proto
 
 // InternalResolveIntent updates the transaction status and heartbeat
 // timestamp after receiving transaction heartbeat messages from
-// coordinator.  The range will return the current status for this
+// coordinator. The range will return the current status for this
 // transaction to the coordinator.
 func (r *Range) InternalResolveIntent(args *proto.InternalResolveIntentRequest, reply *proto.InternalResolveIntentResponse) {
 	if len(args.EndKey) == 0 || bytes.Equal(args.Key, args.EndKey) {

--- a/storage/range.go
+++ b/storage/range.go
@@ -1259,7 +1259,7 @@ func (r *Range) InternalSplit(args *proto.InternalSplitRequest, reply *proto.Int
 		r.Meta.RangeDescriptor.EndKey = oldEndKey
 		newRange.Stop()
 		if err = newRange.Destroy(); err != nil {
-			log.Errorf("unable to drop obsolete range (error: %s), manual cleanup necessary: %s", err, newRange)
+			log.Errorf("unable to drop obsolete range (error: %s), manual cleanup necessary: %v", err, newRange)
 		}
 		return
 	}

--- a/storage/range_test.go
+++ b/storage/range_test.go
@@ -635,7 +635,7 @@ func TestRangeNoTSCacheUpdateOnFailure(t *testing.T) {
 		pArgs.Txn = NewTransaction("test", key, 1, proto.SERIALIZABLE, clock)
 		pArgs.Timestamp = pArgs.Txn.Timestamp
 		if err := rng.AddCmd(Put, pArgs, pReply, true); err != nil {
-			t.Fatal("test %d: %s", i, err)
+			t.Fatalf("test %d: %s", i, err)
 		}
 
 		// Now attempt read or write.
@@ -647,7 +647,7 @@ func TestRangeNoTSCacheUpdateOnFailure(t *testing.T) {
 
 		// Write the intent again -- should not have its timestamp upgraded!
 		if err := rng.AddCmd(Put, pArgs, pReply, true); err != nil {
-			t.Fatal("test %d: %s", i, err)
+			t.Fatalf("test %d: %s", i, err)
 		}
 		if !pReply.Timestamp.Equal(pArgs.Timestamp) {
 			t.Errorf("expected timestamp not to advance %s != %s", pReply.Timestamp, pArgs.Timestamp)

--- a/storage/store_test.go
+++ b/storage/store_test.go
@@ -396,7 +396,7 @@ func TestStoreResolveWriteIntent(t *testing.T) {
 			}
 			// Trying again should fail again.
 			if err = store.ExecuteCmd(Put, pArgs, pReply); err == nil {
-				t.Errorf("resolvable? %d, expected write intent error but succeeded", resolvable)
+				t.Errorf("resolvable? %t, expected write intent error but succeeded", resolvable)
 			}
 		}
 	}

--- a/util/metrics/metrics.go
+++ b/util/metrics/metrics.go
@@ -67,7 +67,7 @@ type timerToken struct {
 }
 
 // One occurrence of a continuous value for which rich metrics such as
-// percentiles may be generated.  This is what the below timers utilize.
+// percentiles may be generated. This is what the below timers utilize.
 type histogramType struct {
 	Name  string
 	Value float64
@@ -134,7 +134,7 @@ type MetricSystem struct {
 }
 
 // Metrics is the default metric system, which collects and broadcasts metrics
-// to subscribers once every 60 seconds.  Also includes default system stats.
+// to subscribers once every 60 seconds. Also includes default system stats.
 var Metrics = NewMetricSystem(60*time.Second, true)
 
 // NewMetricSystem returns a new metric system that collects and broadcasts
@@ -210,7 +210,7 @@ func (ms *MetricSystem) UnsubscribeFromProcessedMetrics(
 }
 
 // StartTimer begins a timer and returns a token which is required for halting
-// the timer.  This allows for concurrent timings under the same name.
+// the timer. This allows for concurrent timings under the same name.
 func (ms *MetricSystem) StartTimer(name string) timerToken {
 	return timerToken{
 		Name:  name,
@@ -228,7 +228,7 @@ func (ms *MetricSystem) StopTimer(token timerToken) time.Duration {
 }
 
 // Counter is used for recording a running count of the total occurrences of
-// a particular event.  A rate is also exported for the amount that a counter
+// a particular event. A rate is also exported for the amount that a counter
 // has increased during an interval of this MetricSystem.
 func (ms *MetricSystem) Counter(name string, amount uint64) {
 	ms.counterMu.RLock()
@@ -312,7 +312,7 @@ func (ms *MetricSystem) DeregisterGaugeFunc(name string) {
 }
 
 // compress takes a float64 and lossily shrinks it to an int16 to facilitate
-// bucketing of histogram values, staying within 1% of the true value.  This
+// bucketing of histogram values, staying within 1% of the true value. This
 // fails for large values of 1e142 and above, and is inaccurate for values
 // closer to 0 than +/- 0.51 or +/- math.Inf.
 func compress(value float64) int16 {
@@ -388,7 +388,7 @@ func (s proportionArray) Swap(i, j int) {
 }
 
 // percentile calculates a percentile represented as a float64 between 0 and 1
-// inclusive from a proportionArray.  totalCount is the sum of all counts of
+// inclusive from a proportionArray. totalCount is the sum of all counts of
 // elements in the proportionArray.
 func percentile(totalCount uint64, proportions proportionArray,
 	percentile float64) (float64, error) {
@@ -401,7 +401,7 @@ func percentile(totalCount uint64, proportions proportionArray,
 			return proportion.Value, nil
 		}
 	}
-	return 0, errors.New("Invalid percentile.  Should be between 0 and 1.")
+	return 0, errors.New("invalid percentile, should be between 0 and 1")
 }
 
 func (ms *MetricSystem) collectRawMetrics() *RawMetricSet {
@@ -566,7 +566,7 @@ func (ms *MetricSystem) reaper() {
 					"dropping their metrics on the floor rather than blocking.")
 				if ms.rawBadSubscribers[subscriber] >= 2 {
 					log.Error("this raw subscriber has caused dropped metrics at ",
-						"least 3 times in a row.  closing the channel.")
+						"least 3 times in a row. closing the channel.")
 					delete(ms.rawSubscribers, subscriber)
 					close(subscriber)
 				}
@@ -610,7 +610,7 @@ func (ms *MetricSystem) reaper() {
 						"dropping their metrics on the floor rather than blocking.")
 					if ms.processedBadSubscribers[subscriber] >= 2 {
 						log.Error("this subscriber has caused dropped metrics at ",
-							"least 3 times in a row.  closing the channel.")
+							"least 3 times in a row. closing the channel.")
 						delete(ms.processedSubscribers, subscriber)
 						close(subscriber)
 					}
@@ -623,7 +623,7 @@ func (ms *MetricSystem) reaper() {
 		default:
 			// processChan has filled up, this metric load is not sustainable
 			log.Errorf("processing of metrics is taking longer than this node can "+
-				"handle.  dropping this entire interval of %s metrics on the "+
+				"handle. dropping this entire interval of %s metrics on the "+
 				"floor rather than blocking the reaper.", rawMetrics.Time)
 		}
 	} // end main reaper loop

--- a/util/retry_test.go
+++ b/util/retry_test.go
@@ -47,7 +47,7 @@ func TestRetryExceedsMaxBackoff(t *testing.T) {
 		return RetryContinue, nil
 	})
 	if _, ok := err.(*RetryMaxAttemptsError); !ok {
-		t.Error("should receive max attempts error on retry: %s", err)
+		t.Errorf("should receive max attempts error on retry: %s", err)
 	}
 	timer.Stop()
 }
@@ -60,7 +60,7 @@ func TestRetryExceedsMaxAttempts(t *testing.T) {
 		return RetryContinue, nil
 	})
 	if _, ok := err.(*RetryMaxAttemptsError); !ok {
-		t.Error("should receive max attempts error on retry: %s", err)
+		t.Errorf("should receive max attempts error on retry: %s", err)
 	}
 	if retries != 3 {
 		t.Error("expected 3 retries, got", retries)


### PR DESCRIPTION
fixed a small bug in the pre-commit hook and on that occasion removed a bunch of "go vet" warnings as well as some comment double spaces. PR mostly for myself to make sure I didn't accidentally `sed` anything else.
