### PR TITLE
Introduce a new Batch struct for use with executing range commands.

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -75,3 +75,5 @@
   Requires transactions. Split the operation addressed to a key range into
   subranges that each hit a single range only, and run all of those as a
   distributed transaction.
+
+* Cleanup proto files to adhere to proto capitalization instead of go's.

--- a/kv/coordinator.go
+++ b/kv/coordinator.go
@@ -42,6 +42,7 @@ var transactionalActions = map[string]struct{}{
 	storage.EnqueueUpdate:  struct{}{},
 	storage.Get:            struct{}{},
 	storage.Increment:      struct{}{},
+	storage.InternalSplit:  struct{}{},
 	storage.Put:            struct{}{},
 	storage.ReapQueue:      struct{}{},
 	storage.Scan:           struct{}{},

--- a/kv/coordinator_test.go
+++ b/kv/coordinator_test.go
@@ -52,7 +52,7 @@ func createTestDB(t *testing.T) (*DB, *hlc.Clock, *hlc.ManualClock) {
 	return db, clock, &manual
 }
 
-// creatPutRequest returns a ready-made request using the
+// createPutRequest returns a ready-made request using the
 // specified key, value & txn ID.
 func createPutRequest(key engine.Key, value, txnID []byte) *proto.PutRequest {
 	return &proto.PutRequest{

--- a/proto/api.proto
+++ b/proto/api.proto
@@ -74,7 +74,7 @@ message RequestHeader {
   // defaults to 1.
   optional int32 user_priority = 7 [default = 1];
   // Txn is set non-nil if a transaction is underway. If set, the value
-  // of Priority is ignored.
+  // of UserPriority is ignored.
   optional Transaction txn = 8;
 }
 
@@ -433,9 +433,17 @@ message InternalSnapshotCopyResponse {
 }
 
 // An InternalSplitRequest is arguments to the InternalSplit() method.
+// The existing range descriptor for the range to be split is adjusted
+// such that end key equal to SplitKey. The new range has range
+// descriptor specified by NewDesc. It starts at SplitKey, with end
+// key equal to the split range's original end key. NewDesc contains
+// newly-allocated range IDs for each replica and a newly-allocated
+// Raft ID. Split requests are done in the context of a distributed
+// transaction which also adjusts meta indexing records.
 message InternalSplitRequest {
   optional RequestHeader header = 1 [(gogoproto.nullable) = false, (gogoproto.embed) = true];
-  optional bytes split_key = 2 [(gogoproto.nullable) = false];
+  optional RangeDescriptor new_desc = 2 [(gogoproto.nullable) = false];
+  optional bytes split_key = 3 [(gogoproto.nullable) = false];
 }
 
 // An InternalSplitResponse is the return value from the InternalSplit()

--- a/proto/config.go
+++ b/proto/config.go
@@ -23,7 +23,6 @@ import (
 	"sort"
 	"strings"
 
-	"code.google.com/p/biogo.store/llrb"
 	yaml "gopkg.in/yaml.v1"
 )
 
@@ -116,9 +115,4 @@ func ParseZoneConfig(in []byte) (*ZoneConfig, error) {
 // ToYAML serializes a ZoneConfig as YAML.
 func (z *ZoneConfig) ToYAML() ([]byte, error) {
 	return yaml.Marshal(z)
-}
-
-// Compare implements the llrb.Comparable interface for tree nodes.
-func (kv RawKeyValue) Compare(b llrb.Comparable) int {
-	return bytes.Compare(kv.Key, b.(RawKeyValue).Key)
 }

--- a/server/node_test.go
+++ b/server/node_test.go
@@ -143,7 +143,7 @@ func TestBootstrapNewStore(t *testing.T) {
 	// store) will be bootstrapped by the node upon start. This happens
 	// in a goroutine, so we'll have to wait a bit (maximum 10ms) until
 	// we can find the new node.
-	if err := util.IsTrueWithin(func() bool { return node.localKV.GetStoreCount() == 3 }, 250*time.Millisecond); err != nil {
+	if err := util.IsTrueWithin(func() bool { return node.localKV.GetStoreCount() == 3 }, 1*time.Second); err != nil {
 		t.Error(err)
 	}
 }

--- a/server/node_test.go
+++ b/server/node_test.go
@@ -141,7 +141,7 @@ func TestBootstrapNewStore(t *testing.T) {
 
 	// Non-initialized stores (in this case the new in-memory-based
 	// store) will be bootstrapped by the node upon start. This happens
-	// in a goroutine, so we'll have to wait a bit (maximum 10ms) until
+	// in a goroutine, so we'll have to wait a bit (maximum 1s) until
 	// we can find the new node.
 	if err := util.IsTrueWithin(func() bool { return node.localKV.GetStoreCount() == 3 }, 1*time.Second); err != nil {
 		t.Error(err)

--- a/storage/db.go
+++ b/storage/db.go
@@ -62,6 +62,7 @@ type DB interface {
 	InternalPushTxn(args *proto.InternalPushTxnRequest) <-chan *proto.InternalPushTxnResponse
 	InternalResolveIntent(args *proto.InternalResolveIntentRequest) <-chan *proto.InternalResolveIntentResponse
 	InternalSnapshotCopy(args *proto.InternalSnapshotCopyRequest) <-chan *proto.InternalSnapshotCopyResponse
+	InternalSplit(args *proto.InternalSplitRequest) <-chan *proto.InternalSplitResponse
 
 	RunTransaction(opts *TransactionOptions, retryable func(db DB) error) error
 }
@@ -243,6 +244,13 @@ func (db *BaseDB) InternalResolveIntent(args *proto.InternalResolveIntentRequest
 func (db *BaseDB) InternalSnapshotCopy(args *proto.InternalSnapshotCopyRequest) <-chan *proto.InternalSnapshotCopyResponse {
 	replyChan := make(chan *proto.InternalSnapshotCopyResponse, 1)
 	go db.Executor(InternalSnapshotCopy, args, replyChan)
+	return replyChan
+}
+
+// InternalSplit is called by a range leader coordinating a split of its range.
+func (db *BaseDB) InternalSplit(args *proto.InternalSplitRequest) <-chan *proto.InternalSplitResponse {
+	replyChan := make(chan *proto.InternalSplitResponse, 1)
+	go db.Executor(InternalSplit, args, replyChan)
 	return replyChan
 }
 

--- a/storage/engine/batch.go
+++ b/storage/engine/batch.go
@@ -1,0 +1,238 @@
+// Copyright 2014 The Cockroach Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+// implied. See the License for the specific language governing
+// permissions and limitations under the License. See the AUTHORS file
+// for names of contributors.
+//
+// Author: Spencer Kimball (spencer.kimball@gmail.com)
+
+package engine
+
+import (
+	"bytes"
+
+	"code.google.com/p/biogo.store/llrb"
+	gogoproto "code.google.com/p/gogoprotobuf/proto"
+	"github.com/cockroachdb/cockroach/proto"
+)
+
+// Batch wrap an instance of Engine and provides a limited subset of
+// Engine functionality. Mutations are added to a write batch
+// transparently and only applied to the wrapped engine on invocation
+// of Commit(). Reads are passed through to the wrapped engine. In the
+// event that reads access keys for which there are already-batched
+// updates, reads from the wrapped engine are combined on the fly with
+// pending write, delete, and merge updates.
+//
+// This struct is not thread safe.
+type Batch struct {
+	engine  Engine
+	updates llrb.Tree
+}
+
+// NewBatch returns a new instance of Batch wrapping engine.
+func NewBatch(engine Engine) *Batch {
+	return &Batch{
+		engine: engine,
+	}
+}
+
+// Commit writes all pending updates to the underlying engine in
+// an atomic write batch.
+func (b *Batch) Commit() error {
+	var batch []interface{}
+	b.updates.DoRange(func(n llrb.Comparable) (done bool) {
+		batch = append(batch, n)
+		return false
+	}, proto.RawKeyValue{Key: KeyMin}, proto.RawKeyValue{Key: KeyMax})
+	return b.engine.WriteBatch(batch)
+}
+
+// Put stores the key / value as a BatchPut in the updates tree.
+func (b *Batch) Put(key Key, value []byte) error {
+	if len(key) == 0 {
+		return emptyKeyError()
+	}
+	b.updates.Insert(BatchPut{proto.RawKeyValue{Key: key, Value: value}})
+	return nil
+}
+
+// Get reads first from the updates tree. If the key is found there
+// and is deleted, then a nil value is returned. If the key is found,
+// and is a Put, returns the value from the tree. If a merge, then
+// merge is performed on the fly to combine with the value from the
+// underlying engine. Otherwise, the Get is simply passed through to
+// the wrapped engine.
+func (b *Batch) Get(key Key) ([]byte, error) {
+	if len(key) == 0 {
+		return nil, emptyKeyError()
+	}
+	val := b.updates.Get(proto.RawKeyValue{Key: key})
+	if val != nil {
+		switch t := val.(type) {
+		case BatchDelete:
+			return nil, nil
+		case BatchPut:
+			return t.Value, nil
+		case BatchMerge:
+			existingVal, err := b.engine.Get(key)
+			if err != nil {
+				return nil, err
+			}
+			return goMerge(existingVal, t.Value)
+		}
+	}
+	return b.engine.Get(key)
+}
+
+// Scan scans from both the updates tree and the underlying engine
+// and combines the results, up to max.
+func (b *Batch) Scan(start, end Key, max int64) ([]proto.RawKeyValue, error) {
+	// First, get up to max key value pairs from the wrapped engine.
+	engs, err := b.engine.Scan(start, end, max)
+	if err != nil {
+		return nil, err
+	}
+	engIdx := 0
+	var kvs []proto.RawKeyValue
+
+	// Now, scan the updates tree for the same range, combining as we go
+	// up to max entries.
+	b.updates.DoRange(func(n llrb.Comparable) (done bool) {
+		// First add all values from engs slice less than the current updates key.
+		for engIdx < len(engs) && bytes.Compare(engs[engIdx].Key, n.(proto.KeyGetter).KeyGet()) < 0 {
+			kvs = append(kvs, engs[engIdx])
+			engIdx++
+			if max != 0 && int64(len(kvs)) >= max {
+				return true
+			}
+		}
+		engKV := proto.RawKeyValue{Key: KeyMax}
+		if engIdx < len(engs) {
+			engKV = engs[engIdx]
+		}
+		switch t := n.(type) {
+		case BatchDelete: // On delete, just skip the corresponding engine entry.
+			if bytes.Equal(t.Key, engKV.Key) {
+				engIdx++
+			}
+		case BatchPut: // On put, reply the corresponding engine entry.
+			if bytes.Equal(t.Key, engKV.Key) {
+				engIdx++
+			}
+			kvs = append(kvs, t.RawKeyValue)
+		case BatchMerge: // On merge, merge with corresponding engine entry.
+			var existingBytes []byte
+			if bytes.Equal(t.Key, engKV.Key) {
+				existingBytes = engKV.Value
+				engIdx++
+			}
+			kv := proto.RawKeyValue{Key: t.Key}
+			kv.Value, err = goMerge(existingBytes, t.Value)
+			if err != nil { // break out of DoRange on error.
+				return true
+			}
+			kvs = append(kvs, kv)
+		}
+		return max != 0 && int64(len(kvs)) >= max
+	}, proto.RawKeyValue{Key: start}, proto.RawKeyValue{Key: end})
+
+	// Check for common case of no matches in the updates map.
+	if len(kvs) == 0 {
+		return engs, err
+	}
+	// Otherwise, append remaining entries in engs up to max.
+	lastIdx := int64(len(engs))
+	if max != 0 {
+		if (lastIdx - int64(engIdx)) > max-int64(len(kvs)) {
+			lastIdx = max - int64(len(kvs)-engIdx)
+		}
+	}
+	return append(kvs, engs[engIdx:lastIdx]...), err
+}
+
+// Clear stores the key as a BatchDelete in the updates tree.
+func (b *Batch) Clear(key Key) error {
+	if len(key) == 0 {
+		return emptyKeyError()
+	}
+	b.updates.Insert(BatchDelete{proto.RawKeyValue{Key: key}})
+	return nil
+}
+
+// Merge stores the key / value as a BatchMerge in the updates tree.
+// If the updates map already contains a BatchPut, then this value is
+// merged with the Put and kept as a BatchPut. If the updates map
+// already contains a BatchMerge, then this value is merged with the
+// existing BatchMerge and kept as a BatchMerge. If the updates map
+// contains a BatchDelete, then this value is merged with a nil byte
+// slice and stored as a BatchPut.
+func (b *Batch) Merge(key Key, value []byte) error {
+	if len(key) == 0 {
+		return emptyKeyError()
+	}
+	val := b.updates.Get(proto.RawKeyValue{Key: key})
+	if val != nil {
+		switch t := val.(type) {
+		case BatchDelete:
+			mergedBytes, err := goMerge(nil, value)
+			if err != nil {
+				return err
+			}
+			b.updates.Insert(BatchPut{proto.RawKeyValue{Key: key, Value: mergedBytes}})
+		case BatchPut:
+			mergedBytes, err := goMerge(t.Value, value)
+			if err != nil {
+				return err
+			}
+			b.updates.Insert(BatchPut{proto.RawKeyValue{Key: key, Value: mergedBytes}})
+		case BatchMerge:
+			mergedBytes, err := goMerge(t.Value, value)
+			if err != nil {
+				return err
+			}
+			b.updates.Insert(BatchMerge{proto.RawKeyValue{Key: key, Value: mergedBytes}})
+		}
+	} else {
+		b.updates.Insert(BatchMerge{proto.RawKeyValue{Key: key, Value: value}})
+	}
+	return nil
+}
+
+// PutProto sets the given key to the protobuf-serialized byte string
+// of msg and the provided timestamp.
+func (b *Batch) PutProto(key Key, msg gogoproto.Message) error {
+	data, err := gogoproto.Marshal(msg)
+	if err != nil {
+		return err
+	}
+	return b.Put(key, data)
+}
+
+// GetProto fetches the value at the specified key and unmarshals it
+// using a protobuf decoder. Returns true on success or false if the
+// key was not found.
+func (b *Batch) GetProto(key Key, msg gogoproto.Message) (bool, error) {
+	val, err := b.Get(key)
+	if err != nil {
+		return false, err
+	}
+	if val == nil {
+		return false, nil
+	}
+	if msg != nil {
+		if err := gogoproto.Unmarshal(val, msg); err != nil {
+			return true, err
+		}
+	}
+	return true, nil
+}

--- a/storage/engine/batch_test.go
+++ b/storage/engine/batch_test.go
@@ -1,0 +1,274 @@
+// Copyright 2014 The Cockroach Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+// implied. See the License for the specific language governing
+// permissions and limitations under the License. See the AUTHORS file
+// for names of contributors.
+//
+// Author: Spencer Kimball (spencer.kimball@gmail.com)
+
+package engine
+
+import (
+	"bytes"
+	"reflect"
+	"testing"
+
+	"github.com/cockroachdb/cockroach/proto"
+	"github.com/cockroachdb/cockroach/util/encoding"
+)
+
+// TestBatchBasics verifies that all commands work in a batch, aren't
+// visible until commit, and then are all visible after commit.
+func TestBatchBasics(t *testing.T) {
+	e := NewInMem(proto.Attributes{}, 1<<20)
+	b := NewBatch(e)
+	if err := b.Put(Key("a"), []byte("value")); err != nil {
+		t.Fatal(err)
+	}
+	// Write an engine value to be deleted.
+	if err := e.Put(Key("b"), []byte("value")); err != nil {
+		t.Fatal(err)
+	}
+	if err := b.Clear(Key("b")); err != nil {
+		t.Fatal(err)
+	}
+	// Write an engine value to be merged.
+	if err := e.Put(Key("c"), encoding.MustGobEncode(Appender("foo"))); err != nil {
+		t.Fatal(err)
+	}
+	if err := b.Merge(Key("c"), encoding.MustGobEncode(Appender("bar"))); err != nil {
+		t.Fatal(err)
+	}
+
+	// Check all keys are in initial state (nothing from batch has gone
+	// through to engine until commit).
+	expValues := []proto.RawKeyValue{
+		{Key: Key("b"), Value: []byte("value")},
+		{Key: Key("c"), Value: encoding.MustGobEncode(Appender("foo"))},
+	}
+	kvs, err := e.Scan(KeyMin, KeyMax, 0)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !reflect.DeepEqual(expValues, kvs) {
+		t.Errorf("%v != %v", kvs, expValues)
+	}
+
+	// Now, merged values should be:
+	expValues = []proto.RawKeyValue{
+		{Key: Key("a"), Value: []byte("value")},
+		{Key: Key("c"), Value: encoding.MustGobEncode(Appender("foobar"))},
+	}
+	// Scan values from batch directly.
+	kvs, err = b.Scan(KeyMin, KeyMax, 0)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !reflect.DeepEqual(expValues, kvs) {
+		t.Errorf("%v != %v", kvs, expValues)
+	}
+
+	// Commit batch and verify direct engine scan yields correct values.
+	if err := b.Commit(); err != nil {
+		t.Fatal(err)
+	}
+	kvs, err = e.Scan(KeyMin, KeyMax, 0)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !reflect.DeepEqual(expValues, kvs) {
+		t.Errorf("%v != %v", kvs, expValues)
+	}
+}
+
+func TestBatchGet(t *testing.T) {
+	e := NewInMem(proto.Attributes{}, 1<<20)
+	b := NewBatch(e)
+	// Write initial values, then write to batch.
+	if err := e.Put(Key("b"), []byte("value")); err != nil {
+		t.Fatal(err)
+	}
+	if err := e.Put(Key("c"), encoding.MustGobEncode(Appender("foo"))); err != nil {
+		t.Fatal(err)
+	}
+	// Write batch values.
+	if err := b.Put(Key("a"), []byte("value")); err != nil {
+		t.Fatal(err)
+	}
+	if err := b.Clear(Key("b")); err != nil {
+		t.Fatal(err)
+	}
+	if err := b.Merge(Key("c"), encoding.MustGobEncode(Appender("bar"))); err != nil {
+		t.Fatal(err)
+	}
+
+	expValues := []proto.RawKeyValue{
+		{Key: Key("a"), Value: []byte("value")},
+		{Key: Key("b"), Value: nil},
+		{Key: Key("c"), Value: encoding.MustGobEncode(Appender("foobar"))},
+	}
+	for i, expKV := range expValues {
+		kv, err := b.Get(expKV.Key)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if !bytes.Equal(kv, expKV.Value) {
+			t.Errorf("%d: expected \"value\", got %q", i, kv)
+		}
+	}
+}
+
+func TestBatchMerge(t *testing.T) {
+	b := NewBatch(NewInMem(proto.Attributes{}, 1<<20))
+
+	// Write batch put, delete & merge.
+	if err := b.Put(Key("a"), encoding.MustGobEncode(Appender("a-value"))); err != nil {
+		t.Fatal(err)
+	}
+	if err := b.Clear(Key("b")); err != nil {
+		t.Fatal(err)
+	}
+	if err := b.Merge(Key("c"), encoding.MustGobEncode(Appender("c-value"))); err != nil {
+		t.Fatal(err)
+	}
+
+	// Now, merge to all three keys.
+	if err := b.Merge(Key("a"), encoding.MustGobEncode(Appender("append"))); err != nil {
+		t.Fatal(err)
+	}
+	if err := b.Merge(Key("b"), encoding.MustGobEncode(Appender("append"))); err != nil {
+		t.Fatal(err)
+	}
+	if err := b.Merge(Key("c"), encoding.MustGobEncode(Appender("append"))); err != nil {
+		t.Fatal(err)
+	}
+
+	// Verify values.
+	val, err := b.Get(Key("a"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !bytes.Equal(val, encoding.MustGobEncode(Appender("a-valueappend"))) {
+		t.Error("mismatch of \"a\"")
+	}
+
+	val, err = b.Get(Key("b"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !bytes.Equal(val, encoding.MustGobEncode(Appender("append"))) {
+		t.Error("mismatch of \"b\"")
+	}
+
+	val, err = b.Get(Key("c"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !bytes.Equal(val, encoding.MustGobEncode(Appender("c-valueappend"))) {
+		t.Error("mismatch of \"c\"")
+	}
+}
+
+func TestBatchProto(t *testing.T) {
+	b := NewBatch(NewInMem(proto.Attributes{}, 1<<20))
+	kv := &proto.RawKeyValue{Key: Key("a"), Value: []byte("value")}
+	b.PutProto(Key("proto"), kv)
+	getKV := &proto.RawKeyValue{}
+	if ok, err := b.GetProto(Key("proto"), getKV); !ok || err != nil {
+		t.Fatalf("expected GetProto to success ok=%t: %s", ok, err)
+	}
+	if !reflect.DeepEqual(getKV, kv) {
+		t.Errorf("expected %v; got %v", kv, getKV)
+	}
+}
+
+func TestBatchScan(t *testing.T) {
+	e := NewInMem(proto.Attributes{}, 1<<20)
+	b := NewBatch(e)
+	existingVals := []proto.RawKeyValue{
+		{Key: Key("a"), Value: []byte("1")},
+		{Key: Key("b"), Value: []byte("2")},
+		{Key: Key("c"), Value: []byte("3")},
+		{Key: Key("d"), Value: []byte("4")},
+		{Key: Key("e"), Value: []byte("5")},
+		{Key: Key("f"), Value: []byte("6")},
+		{Key: Key("g"), Value: []byte("7")},
+		{Key: Key("h"), Value: []byte("8")},
+		{Key: Key("i"), Value: []byte("9")},
+		{Key: Key("j"), Value: []byte("10")},
+	}
+	for _, kv := range existingVals {
+		if err := e.Put(kv.Key, kv.Value); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	batchVals := []proto.RawKeyValue{
+		{Key: Key("a"), Value: []byte("b1")},
+		{Key: Key("bb"), Value: []byte("b2")},
+		{Key: Key("c"), Value: []byte("b3")},
+		{Key: Key("dd"), Value: []byte("b4")},
+		{Key: Key("e"), Value: []byte("b5")},
+		{Key: Key("ff"), Value: []byte("b6")},
+		{Key: Key("g"), Value: []byte("b7")},
+		{Key: Key("hh"), Value: []byte("b8")},
+		{Key: Key("i"), Value: []byte("b9")},
+		{Key: Key("jj"), Value: []byte("b10")},
+	}
+	for _, kv := range batchVals {
+		if err := b.Put(kv.Key, kv.Value); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	scans := []struct {
+		start, end Key
+		max        int64
+	}{
+		// Full monty.
+		{start: Key("a"), end: Key("z"), max: 0},
+		// Select ~half.
+		{start: Key("a"), end: Key("z"), max: 7},
+		// Select one.
+		{start: Key("a"), end: Key("z"), max: 1},
+		// Select half by end key.
+		{start: Key("a"), end: Key("e0"), max: 0},
+		// Start at half and select rest.
+		{start: Key("e"), end: Key("z"), max: 0},
+		// Start at last and select max=10.
+		{start: Key("jj"), end: Key("z"), max: 10},
+	}
+
+	// Scan each case using the batch and store the results.
+	results := map[int][]proto.RawKeyValue{}
+	for i, scan := range scans {
+		kvs, err := b.Scan(scan.start, scan.end, scan.max)
+		if err != nil {
+			t.Fatal(err)
+		}
+		results[i] = kvs
+	}
+
+	// Now, commit batch and re-scan using engine direct to compare results.
+	if err := b.Commit(); err != nil {
+		t.Fatal(err)
+	}
+	for i, scan := range scans {
+		kvs, err := e.Scan(scan.start, scan.end, scan.max)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if !reflect.DeepEqual(kvs, results[i]) {
+			t.Errorf("%d: expected %v; got %v", i, results[i], kvs)
+		}
+	}
+}

--- a/storage/engine/batch_test.go
+++ b/storage/engine/batch_test.go
@@ -205,6 +205,9 @@ func TestBatchScan(t *testing.T) {
 		{Key: Key("h"), Value: []byte("8")},
 		{Key: Key("i"), Value: []byte("9")},
 		{Key: Key("j"), Value: []byte("10")},
+		{Key: Key("k"), Value: []byte("11")},
+		{Key: Key("l"), Value: []byte("12")},
+		{Key: Key("m"), Value: []byte("13")},
 	}
 	for _, kv := range existingVals {
 		if err := e.Put(kv.Key, kv.Value); err != nil {
@@ -237,15 +240,15 @@ func TestBatchScan(t *testing.T) {
 		// Full monty.
 		{start: Key("a"), end: Key("z"), max: 0},
 		// Select ~half.
-		{start: Key("a"), end: Key("z"), max: 7},
+		{start: Key("a"), end: Key("z"), max: 9},
 		// Select one.
 		{start: Key("a"), end: Key("z"), max: 1},
 		// Select half by end key.
-		{start: Key("a"), end: Key("e0"), max: 0},
+		{start: Key("a"), end: Key("f0"), max: 0},
 		// Start at half and select rest.
-		{start: Key("e"), end: Key("z"), max: 0},
+		{start: Key("f"), end: Key("z"), max: 0},
 		// Start at last and select max=10.
-		{start: Key("jj"), end: Key("z"), max: 10},
+		{start: Key("m"), end: Key("z"), max: 10},
 	}
 
 	// Scan each case using the batch and store the results.

--- a/storage/engine/engine.go
+++ b/storage/engine/engine.go
@@ -99,23 +99,18 @@ type Engine interface {
 }
 
 // A BatchDelete is a delete operation executed as part of an atomic batch.
-type BatchDelete Key
+type BatchDelete struct {
+	proto.RawKeyValue
+}
 
 // A BatchPut is a put operation executed as part of an atomic batch.
-type BatchPut proto.RawKeyValue
+type BatchPut struct {
+	proto.RawKeyValue
+}
 
 // A BatchMerge is a merge operation executed as part of an atomic batch.
-type BatchMerge proto.RawKeyValue
-
-// MakeBatchPutProto serializes the provided message and returns a
-// BatchPut object for use with WriteBatch. Returns an error on
-// protobuf serialization failure.
-func MakeBatchPutProto(key Key, msg gogoproto.Message) (BatchPut, error) {
-	data, err := gogoproto.Marshal(msg)
-	if err != nil {
-		return BatchPut(proto.RawKeyValue{}), err
-	}
-	return BatchPut(proto.RawKeyValue{Key: key, Value: data}), err
+type BatchMerge struct {
+	proto.RawKeyValue
 }
 
 // PutI sets the given key to the gob-serialized byte string of the
@@ -237,7 +232,7 @@ func ClearRange(engine Engine, start, end Key, max int64) (int, error) {
 	var deletes = make([]interface{}, numElements, numElements)
 	// Loop over the scanned entries and add to a delete batch
 	for idx, kv := range scanned {
-		deletes[idx] = BatchDelete(kv.Key)
+		deletes[idx] = BatchDelete{proto.RawKeyValue{Key: kv.Key}}
 	}
 
 	err = engine.WriteBatch(deletes)

--- a/storage/engine/engine_test.go
+++ b/storage/engine/engine_test.go
@@ -113,7 +113,7 @@ func TestEngineWriteBatch(t *testing.T) {
 		// Create key/values and put them in a batch to engine.
 		puts := make([]interface{}, numWrites, numWrites)
 		for i := 0; i < numWrites; i++ {
-			puts[i] = BatchPut{Key: key, Value: []byte(strconv.Itoa(i))}
+			puts[i] = BatchPut{proto.RawKeyValue{Key: key, Value: []byte(strconv.Itoa(i))}}
 		}
 		if err := e.WriteBatch(puts); err != nil {
 			t.Fatal(err)
@@ -129,29 +129,29 @@ func TestEngineBatch(t *testing.T) {
 		key := Key("a")
 		// Those are randomized below.
 		batch := []interface{}{
-			BatchPut{Key: key, Value: []byte("~ockroachDB")},
-			BatchPut{Key: key, Value: []byte("C~ckroachDB")},
-			BatchPut{Key: key, Value: []byte("Co~kroachDB")},
-			BatchPut{Key: key, Value: []byte("Coc~roachDB")},
-			BatchPut{Key: key, Value: []byte("Cock~oachDB")},
-			BatchPut{Key: key, Value: []byte("Cockr~achDB")},
-			BatchPut{Key: key, Value: []byte("Cockro~chDB")},
-			BatchPut{Key: key, Value: []byte("Cockroa~hDB")},
-			BatchPut{Key: key, Value: []byte("Cockroac~DB")},
-			BatchPut{Key: key, Value: []byte("Cockroach~B")},
-			BatchPut{Key: key, Value: []byte("CockroachD~")},
-			BatchDelete(key),
-			BatchMerge{Key: key, Value: encoding.MustGobEncode(Appender("C"))},
-			BatchMerge{Key: key, Value: encoding.MustGobEncode(Appender(" o"))},
-			BatchMerge{Key: key, Value: encoding.MustGobEncode(Appender("  c"))},
-			BatchMerge{Key: key, Value: encoding.MustGobEncode(Appender(" k"))},
-			BatchMerge{Key: key, Value: encoding.MustGobEncode(Appender("r"))},
-			BatchMerge{Key: key, Value: encoding.MustGobEncode(Appender(" o"))},
-			BatchMerge{Key: key, Value: encoding.MustGobEncode(Appender("  a"))},
-			BatchMerge{Key: key, Value: encoding.MustGobEncode(Appender(" c"))},
-			BatchMerge{Key: key, Value: encoding.MustGobEncode(Appender("h"))},
-			BatchMerge{Key: key, Value: encoding.MustGobEncode(Appender(" D"))},
-			BatchMerge{Key: key, Value: encoding.MustGobEncode(Appender("  B"))},
+			BatchPut{proto.RawKeyValue{Key: key, Value: []byte("~ockroachDB")}},
+			BatchPut{proto.RawKeyValue{Key: key, Value: []byte("C~ckroachDB")}},
+			BatchPut{proto.RawKeyValue{Key: key, Value: []byte("Co~kroachDB")}},
+			BatchPut{proto.RawKeyValue{Key: key, Value: []byte("Coc~roachDB")}},
+			BatchPut{proto.RawKeyValue{Key: key, Value: []byte("Cock~oachDB")}},
+			BatchPut{proto.RawKeyValue{Key: key, Value: []byte("Cockr~achDB")}},
+			BatchPut{proto.RawKeyValue{Key: key, Value: []byte("Cockro~chDB")}},
+			BatchPut{proto.RawKeyValue{Key: key, Value: []byte("Cockroa~hDB")}},
+			BatchPut{proto.RawKeyValue{Key: key, Value: []byte("Cockroac~DB")}},
+			BatchPut{proto.RawKeyValue{Key: key, Value: []byte("Cockroach~B")}},
+			BatchPut{proto.RawKeyValue{Key: key, Value: []byte("CockroachD~")}},
+			BatchDelete{proto.RawKeyValue{Key: key}},
+			BatchMerge{proto.RawKeyValue{Key: key, Value: encoding.MustGobEncode(Appender("C"))}},
+			BatchMerge{proto.RawKeyValue{Key: key, Value: encoding.MustGobEncode(Appender(" o"))}},
+			BatchMerge{proto.RawKeyValue{Key: key, Value: encoding.MustGobEncode(Appender("  c"))}},
+			BatchMerge{proto.RawKeyValue{Key: key, Value: encoding.MustGobEncode(Appender(" k"))}},
+			BatchMerge{proto.RawKeyValue{Key: key, Value: encoding.MustGobEncode(Appender("r"))}},
+			BatchMerge{proto.RawKeyValue{Key: key, Value: encoding.MustGobEncode(Appender(" o"))}},
+			BatchMerge{proto.RawKeyValue{Key: key, Value: encoding.MustGobEncode(Appender("  a"))}},
+			BatchMerge{proto.RawKeyValue{Key: key, Value: encoding.MustGobEncode(Appender(" c"))}},
+			BatchMerge{proto.RawKeyValue{Key: key, Value: encoding.MustGobEncode(Appender("h"))}},
+			BatchMerge{proto.RawKeyValue{Key: key, Value: encoding.MustGobEncode(Appender(" D"))}},
+			BatchMerge{proto.RawKeyValue{Key: key, Value: encoding.MustGobEncode(Appender("  B"))}},
 		}
 
 		for i := 0; i < numShuffles; i++ {

--- a/storage/engine/in_mem.go
+++ b/storage/engine/in_mem.go
@@ -281,7 +281,7 @@ func (in *InMem) WriteBatch(cmds []interface{}) error {
 	for i, e := range cmds {
 		switch v := e.(type) {
 		case BatchDelete:
-			if err := in.clearLocked(Key(v)); err != nil {
+			if err := in.clearLocked(v.Key); err != nil {
 				return err
 			}
 		case BatchPut:

--- a/storage/engine/mvcc_test.go
+++ b/storage/engine/mvcc_test.go
@@ -52,11 +52,11 @@ var (
 	valueEmpty   = proto.Value{}
 )
 
-// createTestBatch returns a new Batch object which wraps an in-memory
-// engine with 1MB of storage capacity.
-func createTestBatch() *Batch {
+// createTestMVCC returns a new MVCC object wrapping a Batch, wrapping
+// an in-memory engine with 1MB of storage capacity.
+func createTestMVCC() *MVCC {
 	engine := NewInMem(proto.Attributes{}, 1<<20)
-	return NewBatch(engine)
+	return NewMVCC(NewBatch(engine))
 }
 
 // makeTxn creates a new transaction using the specified base
@@ -109,8 +109,8 @@ func TestMVCCKeys(t *testing.T) {
 }
 
 func TestMVCCGetNotExist(t *testing.T) {
-	b := createTestBatch()
-	value, err := MVCCGet(b, testKey1, makeTS(0, 0), nil)
+	mvcc := createTestMVCC()
+	value, err := mvcc.Get(testKey1, makeTS(0, 0), nil)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -120,23 +120,23 @@ func TestMVCCGetNotExist(t *testing.T) {
 }
 
 func TestMVCCPutWithBadValue(t *testing.T) {
-	b := createTestBatch()
+	mvcc := createTestMVCC()
 	badValue := proto.Value{Bytes: []byte("a"), Integer: gogoproto.Int64(1)}
-	err := MVCCPut(b, testKey1, makeTS(0, 0), badValue, nil)
+	err := mvcc.Put(testKey1, makeTS(0, 0), badValue, nil)
 	if err == nil {
 		t.Fatal("expected an error putting a value with both byte slice and integer components")
 	}
 }
 
 func TestMVCCPutWithTxn(t *testing.T) {
-	b := createTestBatch()
-	err := MVCCPut(b, testKey1, makeTS(0, 0), value1, txn1)
+	mvcc := createTestMVCC()
+	err := mvcc.Put(testKey1, makeTS(0, 0), value1, txn1)
 	if err != nil {
 		t.Fatal(err)
 	}
 
 	for _, ts := range []proto.Timestamp{makeTS(0, 0), makeTS(0, 1), makeTS(1, 0)} {
-		value, err := MVCCGet(b, testKey1, ts, txn1)
+		value, err := mvcc.Get(testKey1, ts, txn1)
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -148,14 +148,14 @@ func TestMVCCPutWithTxn(t *testing.T) {
 }
 
 func TestMVCCPutWithoutTxn(t *testing.T) {
-	b := createTestBatch()
-	err := MVCCPut(b, testKey1, makeTS(0, 0), value1, nil)
+	mvcc := createTestMVCC()
+	err := mvcc.Put(testKey1, makeTS(0, 0), value1, nil)
 	if err != nil {
 		t.Fatal(err)
 	}
 
 	for _, ts := range []proto.Timestamp{makeTS(0, 0), makeTS(0, 1), makeTS(1, 0)} {
-		value, err := MVCCGet(b, testKey1, ts, nil)
+		value, err := mvcc.Get(testKey1, ts, nil)
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -167,13 +167,13 @@ func TestMVCCPutWithoutTxn(t *testing.T) {
 }
 
 func TestMVCCUpdateExistingKey(t *testing.T) {
-	b := createTestBatch()
-	err := MVCCPut(b, testKey1, makeTS(0, 0), value1, nil)
+	mvcc := createTestMVCC()
+	err := mvcc.Put(testKey1, makeTS(0, 0), value1, nil)
 	if err != nil {
 		t.Fatal(err)
 	}
 
-	value, err := MVCCGet(b, testKey1, makeTS(1, 0), nil)
+	value, err := mvcc.Get(testKey1, makeTS(1, 0), nil)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -182,13 +182,13 @@ func TestMVCCUpdateExistingKey(t *testing.T) {
 			value1.Bytes, value.Bytes)
 	}
 
-	err = MVCCPut(b, testKey1, makeTS(2, 0), value2, nil)
+	err = mvcc.Put(testKey1, makeTS(2, 0), value2, nil)
 	if err != nil {
 		t.Fatal(err)
 	}
 
 	// Read the latest version.
-	value, err = MVCCGet(b, testKey1, makeTS(3, 0), nil)
+	value, err = mvcc.Get(testKey1, makeTS(3, 0), nil)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -198,7 +198,7 @@ func TestMVCCUpdateExistingKey(t *testing.T) {
 	}
 
 	// Read the old version.
-	value, err = MVCCGet(b, testKey1, makeTS(1, 0), nil)
+	value, err = mvcc.Get(testKey1, makeTS(1, 0), nil)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -209,44 +209,44 @@ func TestMVCCUpdateExistingKey(t *testing.T) {
 }
 
 func TestMVCCUpdateExistingKeyOldVersion(t *testing.T) {
-	b := createTestBatch()
-	err := MVCCPut(b, testKey1, makeTS(1, 1), value1, nil)
+	mvcc := createTestMVCC()
+	err := mvcc.Put(testKey1, makeTS(1, 1), value1, nil)
 	if err != nil {
 		t.Fatal(err)
 	}
 	// Earlier walltime.
-	err = MVCCPut(b, testKey1, makeTS(0, 0), value2, nil)
+	err = mvcc.Put(testKey1, makeTS(0, 0), value2, nil)
 	if err == nil {
 		t.Fatal("expected error on old version")
 	}
 	// Earlier logical time.
-	err = MVCCPut(b, testKey1, makeTS(1, 0), value2, nil)
+	err = mvcc.Put(testKey1, makeTS(1, 0), value2, nil)
 	if err == nil {
 		t.Fatal("expected error on old version")
 	}
 }
 
 func TestMVCCUpdateExistingKeyInTxn(t *testing.T) {
-	b := createTestBatch()
-	err := MVCCPut(b, testKey1, makeTS(0, 0), value1, txn1)
+	mvcc := createTestMVCC()
+	err := mvcc.Put(testKey1, makeTS(0, 0), value1, txn1)
 	if err != nil {
 		t.Fatal(err)
 	}
 
-	err = MVCCPut(b, testKey1, makeTS(1, 0), value1, txn1)
+	err = mvcc.Put(testKey1, makeTS(1, 0), value1, txn1)
 	if err != nil {
 		t.Fatal(err)
 	}
 }
 
 func TestMVCCUpdateExistingKeyDiffTxn(t *testing.T) {
-	b := createTestBatch()
-	err := MVCCPut(b, testKey1, makeTS(0, 0), value1, txn1)
+	mvcc := createTestMVCC()
+	err := mvcc.Put(testKey1, makeTS(0, 0), value1, txn1)
 	if err != nil {
 		t.Fatal(err)
 	}
 
-	err = MVCCPut(b, testKey1, makeTS(1, 0), value2, txn2)
+	err = mvcc.Put(testKey1, makeTS(1, 0), value2, txn2)
 	if err == nil {
 		t.Fatal("expected error on uncommitted write intent")
 	}
@@ -265,11 +265,11 @@ func TestMVCCGetNoMoreOldVersion(t *testing.T) {
 	//
 	// If we search for a<T=2>, the scan should not return "b".
 
-	b := createTestBatch()
-	err := MVCCPut(b, testKey1, makeTS(3, 0), value1, nil)
-	err = MVCCPut(b, testKey2, makeTS(1, 0), value2, nil)
+	mvcc := createTestMVCC()
+	err := mvcc.Put(testKey1, makeTS(3, 0), value1, nil)
+	err = mvcc.Put(testKey2, makeTS(1, 0), value2, nil)
 
-	value, err := MVCCGet(b, testKey1, makeTS(2, 0), nil)
+	value, err := mvcc.Get(testKey1, makeTS(2, 0), nil)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -279,9 +279,9 @@ func TestMVCCGetNoMoreOldVersion(t *testing.T) {
 }
 
 func TestMVCCGetAndDelete(t *testing.T) {
-	b := createTestBatch()
-	err := MVCCPut(b, testKey1, makeTS(1, 0), value1, nil)
-	value, err := MVCCGet(b, testKey1, makeTS(2, 0), nil)
+	mvcc := createTestMVCC()
+	err := mvcc.Put(testKey1, makeTS(1, 0), value1, nil)
+	value, err := mvcc.Get(testKey1, makeTS(2, 0), nil)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -289,13 +289,13 @@ func TestMVCCGetAndDelete(t *testing.T) {
 		t.Fatal("the value should not be empty")
 	}
 
-	err = MVCCDelete(b, testKey1, makeTS(3, 0), nil)
+	err = mvcc.Delete(testKey1, makeTS(3, 0), nil)
 	if err != nil {
 		t.Fatal(err)
 	}
 
 	// Read the latest version which should be deleted.
-	value, err = MVCCGet(b, testKey1, makeTS(4, 0), nil)
+	value, err = mvcc.Get(testKey1, makeTS(4, 0), nil)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -305,7 +305,7 @@ func TestMVCCGetAndDelete(t *testing.T) {
 
 	// Read the old version which should still exist.
 	for _, logical := range []int32{0, math.MaxInt32} {
-		value, err = MVCCGet(b, testKey1, makeTS(2, logical), nil)
+		value, err = mvcc.Get(testKey1, makeTS(2, logical), nil)
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -316,9 +316,9 @@ func TestMVCCGetAndDelete(t *testing.T) {
 }
 
 func TestMVCCGetAndDeleteInTxn(t *testing.T) {
-	b := createTestBatch()
-	err := MVCCPut(b, testKey1, makeTS(1, 0), value1, txn1)
-	value, err := MVCCGet(b, testKey1, makeTS(2, 0), txn1)
+	mvcc := createTestMVCC()
+	err := mvcc.Put(testKey1, makeTS(1, 0), value1, txn1)
+	value, err := mvcc.Get(testKey1, makeTS(2, 0), txn1)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -326,13 +326,13 @@ func TestMVCCGetAndDeleteInTxn(t *testing.T) {
 		t.Fatal("the value should not be empty")
 	}
 
-	err = MVCCDelete(b, testKey1, makeTS(3, 0), txn1)
+	err = mvcc.Delete(testKey1, makeTS(3, 0), txn1)
 	if err != nil {
 		t.Fatal(err)
 	}
 
 	// Read the latest version which should be deleted.
-	value, err = MVCCGet(b, testKey1, makeTS(4, 0), txn1)
+	value, err = mvcc.Get(testKey1, makeTS(4, 0), txn1)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -342,42 +342,42 @@ func TestMVCCGetAndDeleteInTxn(t *testing.T) {
 
 	// Read the old version which shouldn't exist, as within a
 	// transaction, we delete previous values.
-	value, err = MVCCGet(b, testKey1, makeTS(2, 0), nil)
+	value, err = mvcc.Get(testKey1, makeTS(2, 0), nil)
 	if value != nil || err != nil {
 		t.Fatalf("expected value and err to be nil: %+v, %v", value, err)
 	}
 }
 
 func TestMVCCGetWriteIntentError(t *testing.T) {
-	b := createTestBatch()
-	err := MVCCPut(b, testKey1, makeTS(0, 0), value1, txn1)
+	mvcc := createTestMVCC()
+	err := mvcc.Put(testKey1, makeTS(0, 0), value1, txn1)
 	if err != nil {
 		t.Fatal(err)
 	}
 
-	_, err = MVCCGet(b, testKey1, makeTS(1, 0), nil)
+	_, err = mvcc.Get(testKey1, makeTS(1, 0), nil)
 	if err == nil {
 		t.Fatal("cannot read the value of a write intent without TxnID")
 	}
 
-	_, err = MVCCGet(b, testKey1, makeTS(1, 0), txn2)
+	_, err = mvcc.Get(testKey1, makeTS(1, 0), txn2)
 	if err == nil {
 		t.Fatal("cannot read the value of a write intent from a different TxnID")
 	}
 }
 
 func TestMVCCScan(t *testing.T) {
-	b := createTestBatch()
-	err := MVCCPut(b, testKey1, makeTS(1, 0), value1, nil)
-	err = MVCCPut(b, testKey1, makeTS(2, 0), value4, nil)
-	err = MVCCPut(b, testKey2, makeTS(1, 0), value2, nil)
-	err = MVCCPut(b, testKey2, makeTS(3, 0), value3, nil)
-	err = MVCCPut(b, testKey3, makeTS(1, 0), value3, nil)
-	err = MVCCPut(b, testKey3, makeTS(4, 0), value2, nil)
-	err = MVCCPut(b, testKey4, makeTS(1, 0), value4, nil)
-	err = MVCCPut(b, testKey4, makeTS(5, 0), value1, nil)
+	mvcc := createTestMVCC()
+	err := mvcc.Put(testKey1, makeTS(1, 0), value1, nil)
+	err = mvcc.Put(testKey1, makeTS(2, 0), value4, nil)
+	err = mvcc.Put(testKey2, makeTS(1, 0), value2, nil)
+	err = mvcc.Put(testKey2, makeTS(3, 0), value3, nil)
+	err = mvcc.Put(testKey3, makeTS(1, 0), value3, nil)
+	err = mvcc.Put(testKey3, makeTS(4, 0), value2, nil)
+	err = mvcc.Put(testKey4, makeTS(1, 0), value4, nil)
+	err = mvcc.Put(testKey4, makeTS(5, 0), value1, nil)
 
-	kvs, err := MVCCScan(b, testKey2, testKey4, 0, makeTS(1, 0), nil)
+	kvs, err := mvcc.Scan(testKey2, testKey4, 0, makeTS(1, 0), nil)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -389,7 +389,7 @@ func TestMVCCScan(t *testing.T) {
 		t.Fatal("the value should not be empty")
 	}
 
-	kvs, err = MVCCScan(b, testKey2, testKey4, 0, makeTS(4, 0), nil)
+	kvs, err = mvcc.Scan(testKey2, testKey4, 0, makeTS(4, 0), nil)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -401,7 +401,7 @@ func TestMVCCScan(t *testing.T) {
 		t.Fatal("the value should not be empty")
 	}
 
-	kvs, err = MVCCScan(b, testKey4, KeyMax, 0, makeTS(1, 0), nil)
+	kvs, err = mvcc.Scan(testKey4, KeyMax, 0, makeTS(1, 0), nil)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -411,8 +411,8 @@ func TestMVCCScan(t *testing.T) {
 		t.Fatal("the value should not be empty")
 	}
 
-	_, err = MVCCGet(b, testKey1, makeTS(1, 0), txn2)
-	kvs, err = MVCCScan(b, KeyMin, testKey2, 0, makeTS(1, 0), nil)
+	_, err = mvcc.Get(testKey1, makeTS(1, 0), txn2)
+	kvs, err = mvcc.Scan(KeyMin, testKey2, 0, makeTS(1, 0), nil)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -424,13 +424,13 @@ func TestMVCCScan(t *testing.T) {
 }
 
 func TestMVCCScanMaxNum(t *testing.T) {
-	b := createTestBatch()
-	err := MVCCPut(b, testKey1, makeTS(1, 0), value1, nil)
-	err = MVCCPut(b, testKey2, makeTS(1, 0), value2, nil)
-	err = MVCCPut(b, testKey3, makeTS(1, 0), value3, nil)
-	err = MVCCPut(b, testKey4, makeTS(1, 0), value4, nil)
+	mvcc := createTestMVCC()
+	err := mvcc.Put(testKey1, makeTS(1, 0), value1, nil)
+	err = mvcc.Put(testKey2, makeTS(1, 0), value2, nil)
+	err = mvcc.Put(testKey3, makeTS(1, 0), value3, nil)
+	err = mvcc.Put(testKey4, makeTS(1, 0), value4, nil)
 
-	kvs, err := MVCCScan(b, testKey2, testKey4, 1, makeTS(1, 0), nil)
+	kvs, err := mvcc.Scan(testKey2, testKey4, 1, makeTS(1, 0), nil)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -442,7 +442,7 @@ func TestMVCCScanMaxNum(t *testing.T) {
 }
 
 func TestMVCCScanWithKeyPrefix(t *testing.T) {
-	b := createTestBatch()
+	mvcc := createTestMVCC()
 	// Let's say you have:
 	// a
 	// a<T=2>
@@ -454,13 +454,13 @@ func TestMVCCScanWithKeyPrefix(t *testing.T) {
 	// b<T=5>
 	// In this case, if we scan from "a"-"b", we wish to skip
 	// a<T=2> and a<T=1> and find "aa'.
-	err := MVCCPut(b, Key(encoding.EncodeString([]byte{}, "/a")), makeTS(1, 0), value1, nil)
-	err = MVCCPut(b, Key(encoding.EncodeString([]byte{}, "/a")), makeTS(2, 0), value2, nil)
-	err = MVCCPut(b, Key(encoding.EncodeString([]byte{}, "/aa")), makeTS(2, 0), value2, nil)
-	err = MVCCPut(b, Key(encoding.EncodeString([]byte{}, "/aa")), makeTS(3, 0), value3, nil)
-	err = MVCCPut(b, Key(encoding.EncodeString([]byte{}, "/b")), makeTS(1, 0), value3, nil)
+	err := mvcc.Put(Key(encoding.EncodeString([]byte{}, "/a")), makeTS(1, 0), value1, nil)
+	err = mvcc.Put(Key(encoding.EncodeString([]byte{}, "/a")), makeTS(2, 0), value2, nil)
+	err = mvcc.Put(Key(encoding.EncodeString([]byte{}, "/aa")), makeTS(2, 0), value2, nil)
+	err = mvcc.Put(Key(encoding.EncodeString([]byte{}, "/aa")), makeTS(3, 0), value3, nil)
+	err = mvcc.Put(Key(encoding.EncodeString([]byte{}, "/b")), makeTS(1, 0), value3, nil)
 
-	kvs, err := MVCCScan(b, Key(encoding.EncodeString([]byte{}, "/a")),
+	kvs, err := mvcc.Scan(Key(encoding.EncodeString([]byte{}, "/a")),
 		Key(encoding.EncodeString([]byte{}, "/b")), 0, makeTS(2, 0), nil)
 	if err != nil {
 		t.Fatal(err)
@@ -475,13 +475,13 @@ func TestMVCCScanWithKeyPrefix(t *testing.T) {
 }
 
 func TestMVCCScanInTxn(t *testing.T) {
-	b := createTestBatch()
-	err := MVCCPut(b, testKey1, makeTS(1, 0), value1, nil)
-	err = MVCCPut(b, testKey2, makeTS(1, 0), value2, nil)
-	err = MVCCPut(b, testKey3, makeTS(1, 0), value3, txn1)
-	err = MVCCPut(b, testKey4, makeTS(1, 0), value4, nil)
+	mvcc := createTestMVCC()
+	err := mvcc.Put(testKey1, makeTS(1, 0), value1, nil)
+	err = mvcc.Put(testKey2, makeTS(1, 0), value2, nil)
+	err = mvcc.Put(testKey3, makeTS(1, 0), value3, txn1)
+	err = mvcc.Put(testKey4, makeTS(1, 0), value4, nil)
 
-	kvs, err := MVCCScan(b, testKey2, testKey4, 0, makeTS(1, 0), txn1)
+	kvs, err := mvcc.Scan(testKey2, testKey4, 0, makeTS(1, 0), txn1)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -493,27 +493,27 @@ func TestMVCCScanInTxn(t *testing.T) {
 		t.Fatal("the value should not be empty")
 	}
 
-	kvs, err = MVCCScan(b, testKey2, testKey4, 0, makeTS(1, 0), nil)
+	kvs, err = mvcc.Scan(testKey2, testKey4, 0, makeTS(1, 0), nil)
 	if err == nil {
 		t.Fatal("expected error on uncommitted write intent")
 	}
 }
 
 func TestMVCCDeleteRange(t *testing.T) {
-	b := createTestBatch()
-	err := MVCCPut(b, testKey1, makeTS(1, 0), value1, nil)
-	err = MVCCPut(b, testKey2, makeTS(1, 0), value2, nil)
-	err = MVCCPut(b, testKey3, makeTS(1, 0), value3, nil)
-	err = MVCCPut(b, testKey4, makeTS(1, 0), value4, nil)
+	mvcc := createTestMVCC()
+	err := mvcc.Put(testKey1, makeTS(1, 0), value1, nil)
+	err = mvcc.Put(testKey2, makeTS(1, 0), value2, nil)
+	err = mvcc.Put(testKey3, makeTS(1, 0), value3, nil)
+	err = mvcc.Put(testKey4, makeTS(1, 0), value4, nil)
 
-	num, err := MVCCDeleteRange(b, testKey2, testKey4, 0, makeTS(2, 0), nil)
+	num, err := mvcc.DeleteRange(testKey2, testKey4, 0, makeTS(2, 0), nil)
 	if err != nil {
 		t.Fatal(err)
 	}
 	if num != 2 {
 		t.Fatal("the value should not be empty")
 	}
-	kvs, _ := MVCCScan(b, KeyMin, KeyMax, 0, makeTS(2, 0), nil)
+	kvs, _ := mvcc.Scan(KeyMin, KeyMax, 0, makeTS(2, 0), nil)
 	if len(kvs) != 2 ||
 		!bytes.Equal(kvs[0].Key, testKey1) ||
 		!bytes.Equal(kvs[1].Key, testKey4) ||
@@ -522,67 +522,67 @@ func TestMVCCDeleteRange(t *testing.T) {
 		t.Fatal("the value should not be empty")
 	}
 
-	num, err = MVCCDeleteRange(b, testKey4, KeyMax, 0, makeTS(2, 0), nil)
+	num, err = mvcc.DeleteRange(testKey4, KeyMax, 0, makeTS(2, 0), nil)
 	if err != nil {
 		t.Fatal(err)
 	}
 	if num != 1 {
 		t.Fatal("the value should not be empty")
 	}
-	kvs, _ = MVCCScan(b, KeyMin, KeyMax, 0, makeTS(2, 0), nil)
+	kvs, _ = mvcc.Scan(KeyMin, KeyMax, 0, makeTS(2, 0), nil)
 	if len(kvs) != 1 ||
 		!bytes.Equal(kvs[0].Key, testKey1) ||
 		!bytes.Equal(kvs[0].Value.Bytes, value1.Bytes) {
 		t.Fatal("the value should not be empty")
 	}
 
-	num, err = MVCCDeleteRange(b, KeyMin, testKey2, 0, makeTS(2, 0), nil)
+	num, err = mvcc.DeleteRange(KeyMin, testKey2, 0, makeTS(2, 0), nil)
 	if err != nil {
 		t.Fatal(err)
 	}
 	if num != 1 {
 		t.Fatal("the value should not be empty")
 	}
-	kvs, _ = MVCCScan(b, KeyMin, KeyMax, 0, makeTS(2, 0), nil)
+	kvs, _ = mvcc.Scan(KeyMin, KeyMax, 0, makeTS(2, 0), nil)
 	if len(kvs) != 0 {
 		t.Fatal("the value should be empty")
 	}
 }
 
 func TestMVCCDeleteRangeFailed(t *testing.T) {
-	b := createTestBatch()
-	err := MVCCPut(b, testKey1, makeTS(1, 0), value1, nil)
-	err = MVCCPut(b, testKey2, makeTS(1, 0), value2, txn1)
-	err = MVCCPut(b, testKey3, makeTS(1, 0), value3, txn1)
-	err = MVCCPut(b, testKey4, makeTS(1, 0), value4, nil)
+	mvcc := createTestMVCC()
+	err := mvcc.Put(testKey1, makeTS(1, 0), value1, nil)
+	err = mvcc.Put(testKey2, makeTS(1, 0), value2, txn1)
+	err = mvcc.Put(testKey3, makeTS(1, 0), value3, txn1)
+	err = mvcc.Put(testKey4, makeTS(1, 0), value4, nil)
 
-	_, err = MVCCDeleteRange(b, testKey2, testKey4, 0, makeTS(1, 0), nil)
+	_, err = mvcc.DeleteRange(testKey2, testKey4, 0, makeTS(1, 0), nil)
 	if err == nil {
 		t.Fatal("expected error on uncommitted write intent")
 	}
 
-	_, err = MVCCDeleteRange(b, testKey2, testKey4, 0, makeTS(1, 0), txn1)
+	_, err = mvcc.DeleteRange(testKey2, testKey4, 0, makeTS(1, 0), txn1)
 	if err != nil {
 		t.Fatal(err)
 	}
 }
 
 func TestMVCCDeleteRangeConcurrentTxn(t *testing.T) {
-	b := createTestBatch()
-	err := MVCCPut(b, testKey1, makeTS(1, 0), value1, nil)
-	err = MVCCPut(b, testKey2, makeTS(1, 0), value2, txn1)
-	err = MVCCPut(b, testKey3, makeTS(2, 0), value3, txn2)
-	err = MVCCPut(b, testKey4, makeTS(1, 0), value4, nil)
+	mvcc := createTestMVCC()
+	err := mvcc.Put(testKey1, makeTS(1, 0), value1, nil)
+	err = mvcc.Put(testKey2, makeTS(1, 0), value2, txn1)
+	err = mvcc.Put(testKey3, makeTS(2, 0), value3, txn2)
+	err = mvcc.Put(testKey4, makeTS(1, 0), value4, nil)
 
-	_, err = MVCCDeleteRange(b, testKey2, testKey4, 0, makeTS(1, 0), txn1)
+	_, err = mvcc.DeleteRange(testKey2, testKey4, 0, makeTS(1, 0), txn1)
 	if err == nil {
 		t.Fatal("expected error on uncommitted write intent")
 	}
 }
 
 func TestMVCCConditionalPut(t *testing.T) {
-	b := createTestBatch()
-	actualVal, err := MVCCConditionalPut(b, testKey1, makeTS(0, 0), value1, &value2, nil)
+	mvcc := createTestMVCC()
+	actualVal, err := mvcc.ConditionalPut(testKey1, makeTS(0, 0), value1, &value2, nil)
 	if err == nil {
 		t.Fatal("expected error on key not exists")
 	}
@@ -591,7 +591,7 @@ func TestMVCCConditionalPut(t *testing.T) {
 	}
 
 	// Verify the difference between missing value and empty value.
-	actualVal, err = MVCCConditionalPut(b, testKey1, makeTS(0, 0), value1, &valueEmpty, nil)
+	actualVal, err = mvcc.ConditionalPut(testKey1, makeTS(0, 0), value1, &valueEmpty, nil)
 	if err == nil {
 		t.Fatal("expected error on key not exists")
 	}
@@ -600,13 +600,13 @@ func TestMVCCConditionalPut(t *testing.T) {
 	}
 
 	// Do a conditional put with expectation that the value is completely missing; will succeed.
-	_, err = MVCCConditionalPut(b, testKey1, makeTS(0, 0), value1, nil, nil)
+	_, err = mvcc.ConditionalPut(testKey1, makeTS(0, 0), value1, nil, nil)
 	if err != nil {
 		t.Fatalf("expected success with condition that key doesn't yet exist: %v", err)
 	}
 
 	// Another conditional put expecting value missing will fail, now that value1 is written.
-	actualVal, err = MVCCConditionalPut(b, testKey1, makeTS(0, 0), value1, nil, nil)
+	actualVal, err = mvcc.ConditionalPut(testKey1, makeTS(0, 0), value1, nil, nil)
 	if err == nil {
 		t.Fatal("expected error on key already exists")
 	}
@@ -616,7 +616,7 @@ func TestMVCCConditionalPut(t *testing.T) {
 	}
 
 	// Conditional put expecting wrong value2, will fail.
-	actualVal, err = MVCCConditionalPut(b, testKey1, makeTS(0, 0), value1, &value2, nil)
+	actualVal, err = mvcc.ConditionalPut(testKey1, makeTS(0, 0), value1, &value2, nil)
 	if err == nil {
 		t.Fatal("expected error on key does not match")
 	}
@@ -626,17 +626,17 @@ func TestMVCCConditionalPut(t *testing.T) {
 	}
 
 	// Move to a empty value. Will succeed.
-	_, err = MVCCConditionalPut(b, testKey1, makeTS(0, 0), valueEmpty, &value1, nil)
+	_, err = mvcc.ConditionalPut(testKey1, makeTS(0, 0), valueEmpty, &value1, nil)
 	if err != nil {
 		t.Fatal(err)
 	}
 	// Now move to value2 from expected empty value.
-	_, err = MVCCConditionalPut(b, testKey1, makeTS(0, 0), value2, &valueEmpty, nil)
+	_, err = mvcc.ConditionalPut(testKey1, makeTS(0, 0), value2, &valueEmpty, nil)
 	if err != nil {
 		t.Fatal(err)
 	}
 	// Verify we get value2 as expected.
-	value, err := MVCCGet(b, testKey1, makeTS(0, 0), nil)
+	value, err := mvcc.Get(testKey1, makeTS(0, 0), nil)
 	if !bytes.Equal(value2.Bytes, value.Bytes) {
 		t.Fatalf("the value %s in get result does not match the value %s in request",
 			value1.Bytes, value.Bytes)
@@ -644,21 +644,21 @@ func TestMVCCConditionalPut(t *testing.T) {
 }
 
 func TestMVCCResolveTxn(t *testing.T) {
-	b := createTestBatch()
-	err := MVCCPut(b, testKey1, makeTS(0, 0), value1, txn1)
-	value, err := MVCCGet(b, testKey1, makeTS(0, 0), txn1)
+	mvcc := createTestMVCC()
+	err := mvcc.Put(testKey1, makeTS(0, 0), value1, txn1)
+	value, err := mvcc.Get(testKey1, makeTS(0, 0), txn1)
 	if !bytes.Equal(value1.Bytes, value.Bytes) {
 		t.Fatalf("the value %s in get result does not match the value %s in request",
 			value1.Bytes, value.Bytes)
 	}
 
 	// Resolve will write with txn1's timestamp which is 0,0.
-	err = MVCCResolveWriteIntent(b, testKey1, txn1Commit)
+	err = mvcc.ResolveWriteIntent(testKey1, txn1Commit)
 	if err != nil {
 		t.Fatal(err)
 	}
 
-	value, err = MVCCGet(b, testKey1, makeTS(0, 0), nil)
+	value, err = mvcc.Get(testKey1, makeTS(0, 0), nil)
 	if !bytes.Equal(value1.Bytes, value.Bytes) {
 		t.Fatalf("the value %s in get result does not match the value %s in request",
 			value1.Bytes, value.Bytes)
@@ -666,18 +666,18 @@ func TestMVCCResolveTxn(t *testing.T) {
 }
 
 func TestMVCCAbortTxn(t *testing.T) {
-	b := createTestBatch()
-	err := MVCCPut(b, testKey1, makeTS(0, 0), value1, txn1)
-	err = MVCCResolveWriteIntent(b, testKey1, txn1Abort)
+	mvcc := createTestMVCC()
+	err := mvcc.Put(testKey1, makeTS(0, 0), value1, txn1)
+	err = mvcc.ResolveWriteIntent(testKey1, txn1Abort)
 	if err != nil {
 		t.Fatal(err)
 	}
 
-	value, err := MVCCGet(b, testKey1, makeTS(1, 0), nil)
+	value, err := mvcc.Get(testKey1, makeTS(1, 0), nil)
 	if value != nil {
 		t.Fatalf("the value should be empty")
 	}
-	meta, err := b.engine.Get(encoding.EncodeBinary(nil, testKey1))
+	meta, err := mvcc.batch.engine.Get(encoding.EncodeBinary(nil, testKey1))
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -687,16 +687,16 @@ func TestMVCCAbortTxn(t *testing.T) {
 }
 
 func TestMVCCAbortTxnWithPreviousVersion(t *testing.T) {
-	b := createTestBatch()
-	err := MVCCPut(b, testKey1, makeTS(0, 0), value1, nil)
-	err = MVCCPut(b, testKey1, makeTS(1, 0), value2, nil)
-	err = MVCCPut(b, testKey1, makeTS(2, 0), value3, txn1)
-	err = MVCCResolveWriteIntent(b, testKey1, txn1Abort)
-	if err := b.Commit(); err != nil {
+	mvcc := createTestMVCC()
+	err := mvcc.Put(testKey1, makeTS(0, 0), value1, nil)
+	err = mvcc.Put(testKey1, makeTS(1, 0), value2, nil)
+	err = mvcc.Put(testKey1, makeTS(2, 0), value3, txn1)
+	err = mvcc.ResolveWriteIntent(testKey1, txn1Abort)
+	if err := mvcc.batch.Commit(); err != nil {
 		t.Fatal(err)
 	}
 
-	meta, err := b.engine.Get(encoding.EncodeBinary(nil, testKey1))
+	meta, err := mvcc.batch.engine.Get(encoding.EncodeBinary(nil, testKey1))
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -704,7 +704,7 @@ func TestMVCCAbortTxnWithPreviousVersion(t *testing.T) {
 		t.Fatalf("expected the MVCCMetadata")
 	}
 
-	value, err := MVCCGet(b, testKey1, makeTS(3, 0), nil)
+	value, err := mvcc.Get(testKey1, makeTS(3, 0), nil)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -718,42 +718,42 @@ func TestMVCCAbortTxnWithPreviousVersion(t *testing.T) {
 }
 
 func TestMVCCWriteWithDiffTimestampsAndEpochs(t *testing.T) {
-	b := createTestBatch()
+	mvcc := createTestMVCC()
 	// Start with epoch 1.
-	if err := MVCCPut(b, testKey1, makeTS(0, 0), value1, txn1); err != nil {
+	if err := mvcc.Put(testKey1, makeTS(0, 0), value1, txn1); err != nil {
 		t.Fatal(err)
 	}
 	// Now write with greater timestamp and epoch 2.
-	if err := MVCCPut(b, testKey1, makeTS(1, 0), value2, txn1e2); err != nil {
+	if err := mvcc.Put(testKey1, makeTS(1, 0), value2, txn1e2); err != nil {
 		t.Fatal(err)
 	}
 	// Try a write with an earlier timestamp; this is just ignored.
-	if err := MVCCPut(b, testKey1, makeTS(0, 0), value1, txn1e2); err != nil {
+	if err := mvcc.Put(testKey1, makeTS(0, 0), value1, txn1e2); err != nil {
 		t.Fatal(err)
 	}
 	// Try a write with an earlier epoch; again ignored.
-	if err := MVCCPut(b, testKey1, makeTS(1, 0), value1, txn1); err != nil {
+	if err := mvcc.Put(testKey1, makeTS(1, 0), value1, txn1); err != nil {
 		t.Fatal(err)
 	}
 	// Try a write with different value using both later timestamp and epoch.
-	if err := MVCCPut(b, testKey1, makeTS(1, 0), value3, txn1e2); err != nil {
+	if err := mvcc.Put(testKey1, makeTS(1, 0), value3, txn1e2); err != nil {
 		t.Fatal(err)
 	}
 	// Resolve the intent.
-	if err := MVCCResolveWriteIntent(b, testKey1, makeTxn(txn1e2Commit, makeTS(1, 0))); err != nil {
+	if err := mvcc.ResolveWriteIntent(testKey1, makeTxn(txn1e2Commit, makeTS(1, 0))); err != nil {
 		t.Fatal(err)
 	}
 	// Now try writing an earlier intent--should get write too old error.
-	if err := MVCCPut(b, testKey1, makeTS(0, 0), value2, txn2); err == nil {
+	if err := mvcc.Put(testKey1, makeTS(0, 0), value2, txn2); err == nil {
 		t.Fatal("expected write too old error")
 	}
 	// Attempt to read older timestamp; should fail.
-	value, err := MVCCGet(b, testKey1, makeTS(0, 0), nil)
+	value, err := mvcc.Get(testKey1, makeTS(0, 0), nil)
 	if value != nil || err != nil {
 		t.Errorf("expected value nil, err nil; got %+v, %v", value, err)
 	}
 	// Read at correct timestamp.
-	value, err = MVCCGet(b, testKey1, makeTS(1, 0), nil)
+	value, err = mvcc.Get(testKey1, makeTS(1, 0), nil)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -770,13 +770,13 @@ func TestMVCCWriteWithDiffTimestampsAndEpochs(t *testing.T) {
 // reads using epoch 2 to verify that values written during different
 // transaction epochs are not visible.
 func TestMVCCReadWithDiffEpochs(t *testing.T) {
-	b := createTestBatch()
+	mvcc := createTestMVCC()
 	// Write initial value wihtout a txn.
-	if err := MVCCPut(b, testKey1, makeTS(0, 0), value1, nil); err != nil {
+	if err := mvcc.Put(testKey1, makeTS(0, 0), value1, nil); err != nil {
 		t.Fatal(err)
 	}
 	// Now write using txn1, epoch 1.
-	if err := MVCCPut(b, testKey1, makeTS(1, 0), value2, txn1); err != nil {
+	if err := mvcc.Put(testKey1, makeTS(1, 0), value2, txn1); err != nil {
 		t.Fatal(err)
 	}
 	// Try reading using different txns & epochs.
@@ -795,7 +795,7 @@ func TestMVCCReadWithDiffEpochs(t *testing.T) {
 		{txn2, nil, true},
 	}
 	for i, test := range testCases {
-		value, err := MVCCGet(b, testKey1, makeTS(2, 0), test.txn)
+		value, err := mvcc.Get(testKey1, makeTS(2, 0), test.txn)
 		if test.expErr {
 			if err == nil {
 				t.Errorf("test %d: unexpected success", i)
@@ -815,40 +815,40 @@ func TestMVCCReadWithDiffEpochs(t *testing.T) {
 // resolved by other actors; the intents shouldn't become invisible
 // to pushed txn.
 func TestMVCCReadWithPushedTimestamp(t *testing.T) {
-	b := createTestBatch()
+	mvcc := createTestMVCC()
 	// Start with epoch 1.
-	if err := MVCCPut(b, testKey1, makeTS(0, 0), value1, txn1); err != nil {
+	if err := mvcc.Put(testKey1, makeTS(0, 0), value1, txn1); err != nil {
 		t.Fatal(err)
 	}
 	// Resolve the intent, pushing its timestamp forward.
-	if err := MVCCResolveWriteIntent(b, testKey1, makeTxn(txn1, makeTS(1, 0))); err != nil {
+	if err := mvcc.ResolveWriteIntent(testKey1, makeTxn(txn1, makeTS(1, 0))); err != nil {
 		t.Fatal(err)
 	}
 	// Attempt to read using naive txn's previous timestamp.
-	value, err := MVCCGet(b, testKey1, makeTS(0, 0), txn1)
+	value, err := mvcc.Get(testKey1, makeTS(0, 0), txn1)
 	if err != nil || value == nil || !bytes.Equal(value.Bytes, value1.Bytes) {
 		t.Errorf("expected value %q, err nil; got %+v, %v", value.Bytes, value, err)
 	}
 }
 
 func TestMVCCResolveWithDiffEpochs(t *testing.T) {
-	b := createTestBatch()
-	err := MVCCPut(b, testKey1, makeTS(0, 0), value1, txn1)
-	err = MVCCPut(b, testKey2, makeTS(0, 0), value2, txn1e2)
-	num, err := MVCCResolveWriteIntentRange(b, testKey1, testKey2.Next(), 2, txn1e2Commit)
+	mvcc := createTestMVCC()
+	err := mvcc.Put(testKey1, makeTS(0, 0), value1, txn1)
+	err = mvcc.Put(testKey2, makeTS(0, 0), value2, txn1e2)
+	num, err := mvcc.ResolveWriteIntentRange(testKey1, testKey2.Next(), 2, txn1e2Commit)
 	if num != 2 {
 		t.Errorf("expected 2 rows resolved; got %d", num)
 	}
 
 	// Verify key1 is empty, as resolution with epoch 2 would have
 	// aborted the epoch 1 intent.
-	value, err := MVCCGet(b, testKey1, makeTS(0, 0), nil)
+	value, err := mvcc.Get(testKey1, makeTS(0, 0), nil)
 	if value != nil || err != nil {
 		t.Errorf("expected value nil, err nil; got %+v, %v", value, err)
 	}
 
 	// Key2 should be committed.
-	value, err = MVCCGet(b, testKey2, makeTS(0, 0), nil)
+	value, err = mvcc.Get(testKey2, makeTS(0, 0), nil)
 	if !bytes.Equal(value2.Bytes, value.Bytes) {
 		t.Fatalf("the value %s in get result does not match the value %s in request",
 			value2.Bytes, value.Bytes)
@@ -856,9 +856,9 @@ func TestMVCCResolveWithDiffEpochs(t *testing.T) {
 }
 
 func TestMVCCResolveWithUpdatedTimestamp(t *testing.T) {
-	b := createTestBatch()
-	err := MVCCPut(b, testKey1, makeTS(0, 0), value1, txn1)
-	value, err := MVCCGet(b, testKey1, makeTS(1, 0), txn1)
+	mvcc := createTestMVCC()
+	err := mvcc.Put(testKey1, makeTS(0, 0), value1, txn1)
+	value, err := mvcc.Get(testKey1, makeTS(1, 0), txn1)
 	if !bytes.Equal(value1.Bytes, value.Bytes) {
 		t.Fatalf("the value %s in get result does not match the value %s in request",
 			value1.Bytes, value.Bytes)
@@ -866,16 +866,16 @@ func TestMVCCResolveWithUpdatedTimestamp(t *testing.T) {
 
 	// Resolve with a higher commit timestamp -- this should rewrite the
 	// intent when making it permanent.
-	err = MVCCResolveWriteIntent(b, testKey1, makeTxn(txn1Commit, makeTS(1, 0)))
+	err = mvcc.ResolveWriteIntent(testKey1, makeTxn(txn1Commit, makeTS(1, 0)))
 	if err != nil {
 		t.Fatal(err)
 	}
 
-	if value, err := MVCCGet(b, testKey1, makeTS(0, 0), nil); value != nil || err != nil {
+	if value, err := mvcc.Get(testKey1, makeTS(0, 0), nil); value != nil || err != nil {
 		t.Fatalf("expected both value and err to be nil: %+v, %v", value, err)
 	}
 
-	value, err = MVCCGet(b, testKey1, makeTS(1, 0), nil)
+	value, err = mvcc.Get(testKey1, makeTS(1, 0), nil)
 	if !value.Timestamp.Equal(makeTS(1, 0)) {
 		t.Fatalf("expected timestamp %+v == %+v", value.Timestamp, makeTS(1, 0))
 	}
@@ -886,9 +886,9 @@ func TestMVCCResolveWithUpdatedTimestamp(t *testing.T) {
 }
 
 func TestMVCCResolveWithPushedTimestamp(t *testing.T) {
-	b := createTestBatch()
-	err := MVCCPut(b, testKey1, makeTS(0, 0), value1, txn1)
-	value, err := MVCCGet(b, testKey1, makeTS(1, 0), txn1)
+	mvcc := createTestMVCC()
+	err := mvcc.Put(testKey1, makeTS(0, 0), value1, txn1)
+	value, err := mvcc.Get(testKey1, makeTS(1, 0), txn1)
 	if !bytes.Equal(value1.Bytes, value.Bytes) {
 		t.Fatalf("the value %s in get result does not match the value %s in request",
 			value1.Bytes, value.Bytes)
@@ -896,17 +896,17 @@ func TestMVCCResolveWithPushedTimestamp(t *testing.T) {
 
 	// Resolve with a higher commit timestamp, but with still-pending transaction.
 	// This respresents a straightforward push (i.e. from a read/write conflict).
-	err = MVCCResolveWriteIntent(b, testKey1, makeTxn(txn1, makeTS(1, 0)))
+	err = mvcc.ResolveWriteIntent(testKey1, makeTxn(txn1, makeTS(1, 0)))
 	if err != nil {
 		t.Fatal(err)
 	}
 
-	if value, err := MVCCGet(b, testKey1, makeTS(1, 0), nil); value != nil || err == nil {
+	if value, err := mvcc.Get(testKey1, makeTS(1, 0), nil); value != nil || err == nil {
 		t.Fatalf("expected both value nil and err to be a writeIntentError: %+v", value)
 	}
 
 	// Can still fetch the value using txn1.
-	value, err = MVCCGet(b, testKey1, makeTS(1, 0), txn1)
+	value, err = mvcc.Get(testKey1, makeTS(1, 0), txn1)
 	if !value.Timestamp.Equal(makeTS(1, 0)) {
 		t.Fatalf("expected timestamp %+v == %+v", value.Timestamp, makeTS(1, 0))
 	}
@@ -917,37 +917,37 @@ func TestMVCCResolveWithPushedTimestamp(t *testing.T) {
 }
 
 func TestMVCCResolveTxnNoOps(t *testing.T) {
-	b := createTestBatch()
+	mvcc := createTestMVCC()
 
 	// Resolve a non existent key; noop.
-	err := MVCCResolveWriteIntent(b, testKey1, txn1Commit)
+	err := mvcc.ResolveWriteIntent(testKey1, txn1Commit)
 	if err != nil {
 		t.Fatal(err)
 	}
 
 	// Add key and resolve despite there being no intent.
-	err = MVCCPut(b, testKey1, makeTS(0, 0), value1, nil)
-	err = MVCCResolveWriteIntent(b, testKey1, txn2Commit)
+	err = mvcc.Put(testKey1, makeTS(0, 0), value1, nil)
+	err = mvcc.ResolveWriteIntent(testKey1, txn2Commit)
 	if err != nil {
 		t.Fatal(err)
 	}
 
 	// Write intent and resolve with different txn.
-	err = MVCCPut(b, testKey1, makeTS(1, 0), value2, txn1)
-	err = MVCCResolveWriteIntent(b, testKey1, txn2Commit)
+	err = mvcc.Put(testKey1, makeTS(1, 0), value2, txn1)
+	err = mvcc.ResolveWriteIntent(testKey1, txn2Commit)
 	if err != nil {
 		t.Fatal(err)
 	}
 }
 
 func TestMVCCResolveTxnRange(t *testing.T) {
-	b := createTestBatch()
-	err := MVCCPut(b, testKey1, makeTS(0, 0), value1, txn1)
-	err = MVCCPut(b, testKey2, makeTS(0, 0), value2, nil)
-	err = MVCCPut(b, testKey3, makeTS(0, 0), value3, txn2)
-	err = MVCCPut(b, testKey4, makeTS(0, 0), value4, txn1)
+	mvcc := createTestMVCC()
+	err := mvcc.Put(testKey1, makeTS(0, 0), value1, txn1)
+	err = mvcc.Put(testKey2, makeTS(0, 0), value2, nil)
+	err = mvcc.Put(testKey3, makeTS(0, 0), value3, txn2)
+	err = mvcc.Put(testKey4, makeTS(0, 0), value4, txn1)
 
-	num, err := MVCCResolveWriteIntentRange(b, testKey1, testKey4.Next(), 0, txn1Commit)
+	num, err := mvcc.ResolveWriteIntentRange(testKey1, testKey4.Next(), 0, txn1Commit)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -955,25 +955,25 @@ func TestMVCCResolveTxnRange(t *testing.T) {
 		t.Fatalf("expected all keys to process for resolution, even though 2 are noops; got %d", num)
 	}
 
-	value, err := MVCCGet(b, testKey1, makeTS(0, 0), nil)
+	value, err := mvcc.Get(testKey1, makeTS(0, 0), nil)
 	if !bytes.Equal(value1.Bytes, value.Bytes) {
 		t.Fatalf("the value %s in get result does not match the value %s in request",
 			value1.Bytes, value.Bytes)
 	}
 
-	value, err = MVCCGet(b, testKey2, makeTS(0, 0), nil)
+	value, err = mvcc.Get(testKey2, makeTS(0, 0), nil)
 	if !bytes.Equal(value2.Bytes, value.Bytes) {
 		t.Fatalf("the value %s in get result does not match the value %s in request",
 			value2.Bytes, value.Bytes)
 	}
 
-	value, err = MVCCGet(b, testKey3, makeTS(0, 0), txn2)
+	value, err = mvcc.Get(testKey3, makeTS(0, 0), txn2)
 	if !bytes.Equal(value3.Bytes, value.Bytes) {
 		t.Fatalf("the value %s in get result does not match the value %s in request",
 			value3.Bytes, value.Bytes)
 	}
 
-	value, err = MVCCGet(b, testKey4, makeTS(0, 0), nil)
+	value, err = mvcc.Get(testKey4, makeTS(0, 0), nil)
 	if !bytes.Equal(value4.Bytes, value.Bytes) {
 		t.Fatalf("the value %s in get result does not match the value %s in request",
 			value4.Bytes, value.Bytes)
@@ -981,7 +981,7 @@ func TestMVCCResolveTxnRange(t *testing.T) {
 }
 
 func TestFindSplitKey(t *testing.T) {
-	b := createTestBatch()
+	mvcc := createTestMVCC()
 	// Generate a reservoir worth of KeyValues, each containing targetLength
 	// bytes, writing key #i to (encoded) key #i through the MVCC facility.
 	// Assuming that this translates roughly into same-length values after MVCC
@@ -992,15 +992,15 @@ func TestFindSplitKey(t *testing.T) {
 		v := strings.Repeat("X", 10-len(k))
 		val := proto.Value{Bytes: []byte(v)}
 		// Write the key and value through MVCC
-		if err := MVCCPut(b, []byte(k), makeTS(0, 0), val, nil); err != nil {
+		if err := mvcc.Put([]byte(k), makeTS(0, 0), val, nil); err != nil {
 			t.Fatal(err)
 		}
 	}
-	if err := b.Commit(); err != nil {
+	if err := mvcc.batch.Commit(); err != nil {
 		t.Fatal(err)
 	}
 
-	humanSplitKey, err := MVCCFindSplitKey(b.engine, KeyMin, KeyMax, "")
+	humanSplitKey, err := MVCCFindSplitKey(mvcc.batch.engine, KeyMin, KeyMax, "")
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/storage/engine/rocksdb.go
+++ b/storage/engine/rocksdb.go
@@ -465,13 +465,13 @@ func (r *RocksDB) WriteBatch(cmds []interface{}) error {
 	for i, e := range cmds {
 		switch v := e.(type) {
 		case BatchDelete:
-			if len(v) == 0 {
+			if len(v.Key) == 0 {
 				return emptyKeyError()
 			}
 			C.rocksdb_writebatch_delete(
 				batch,
-				bytesPointer(v),
-				C.size_t(len(v)))
+				bytesPointer(v.Key),
+				C.size_t(len(v.Key)))
 		case BatchPut:
 			key, value := v.Key, v.Value
 			// We write the batch before returning from this method, so we

--- a/storage/engine/rocksdb_test.go
+++ b/storage/engine/rocksdb_test.go
@@ -87,11 +87,11 @@ func TestRocksDBCompaction(t *testing.T) {
 	// that exactly one of each should be GC'd based on our GC timeouts.
 	batch := []interface{}{
 		// TODO(spencer): use Transaction and Response protobufs here.
-		BatchPut{Key: MakeLocalKey(rcPre, Key("a")).Encode(nil), Value: encodePutResponse(makeTS(2, 0), t)},
-		BatchPut{Key: MakeLocalKey(rcPre, Key("b")).Encode(nil), Value: encodePutResponse(makeTS(3, 0), t)},
+		BatchPut{proto.RawKeyValue{Key: MakeLocalKey(rcPre, Key("a")).Encode(nil), Value: encodePutResponse(makeTS(2, 0), t)}},
+		BatchPut{proto.RawKeyValue{Key: MakeLocalKey(rcPre, Key("b")).Encode(nil), Value: encodePutResponse(makeTS(3, 0), t)}},
 
-		BatchPut{Key: MakeLocalKey(txnPre, Key("a")).Encode(nil), Value: encodeTransaction(makeTS(1, 0), t)},
-		BatchPut{Key: MakeLocalKey(txnPre, Key("b")).Encode(nil), Value: encodeTransaction(makeTS(2, 0), t)},
+		BatchPut{proto.RawKeyValue{Key: MakeLocalKey(txnPre, Key("a")).Encode(nil), Value: encodeTransaction(makeTS(1, 0), t)}},
+		BatchPut{proto.RawKeyValue{Key: MakeLocalKey(txnPre, Key("b")).Encode(nil), Value: encodeTransaction(makeTS(2, 0), t)}},
 	}
 	if err := rocksdb.WriteBatch(batch); err != nil {
 		t.Fatal(err)

--- a/storage/id_alloc_test.go
+++ b/storage/id_alloc_test.go
@@ -71,8 +71,8 @@ func TestIDAllocator(t *testing.T) {
 func TestIDAllocatorNegativeValue(t *testing.T) {
 	store, _ := createTestStore(false, t)
 	// Increment our key to a negative value.
-	mvcc := engine.NewMVCC(store.engine)
-	newValue, err := mvcc.Increment(engine.KeyRaftIDGenerator.Encode(nil), store.clock.Now(), nil, -1024)
+	b := engine.NewBatch(store.engine)
+	newValue, err := engine.MVCCIncrement(b, engine.KeyRaftIDGenerator.Encode(nil), store.clock.Now(), nil, -1024)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/storage/id_alloc_test.go
+++ b/storage/id_alloc_test.go
@@ -71,8 +71,8 @@ func TestIDAllocator(t *testing.T) {
 func TestIDAllocatorNegativeValue(t *testing.T) {
 	store, _ := createTestStore(false, t)
 	// Increment our key to a negative value.
-	b := engine.NewBatch(store.engine)
-	newValue, err := engine.MVCCIncrement(b, engine.KeyRaftIDGenerator.Encode(nil), store.clock.Now(), nil, -1024)
+	mvcc := engine.NewMVCC(engine.NewBatch(store.engine))
+	newValue, err := mvcc.Increment(engine.KeyRaftIDGenerator.Encode(nil), store.clock.Now(), nil, -1024)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/storage/range.go
+++ b/storage/range.go
@@ -33,7 +33,6 @@ import (
 	"github.com/cockroachdb/cockroach/proto"
 	"github.com/cockroachdb/cockroach/storage/engine"
 	"github.com/cockroachdb/cockroach/util"
-	"github.com/cockroachdb/cockroach/util/hlc"
 	"github.com/cockroachdb/cockroach/util/log"
 )
 
@@ -64,6 +63,12 @@ const (
 	// the first range gossips it.
 	ttlClusterIDGossip = 30 * time.Second
 )
+
+// splitCheckInterval is the duration waited between periodic checks on whether
+// the range is going to split.
+// It is stored as a variable to allow for dynamic adaption (for instance based
+// on write load) and easier testing.
+var splitCheckInterval = 1 * time.Minute
 
 // configPrefixes describes administrative configuration maps
 // affecting ranges of the key-value map by key prefix.
@@ -209,15 +214,10 @@ type Cmd struct {
 // integrity by replacing failed replicas, splitting and merging
 // as appropriate.
 type Range struct {
-	Meta      *proto.RangeMetadata
-	clock     *hlc.Clock
-	mvcc      *engine.MVCC
-	engine    engine.Engine  // The underlying key-value store
-	allocator *allocator     // Makes allocation decisions
-	gossip    *gossip.Gossip // Range may gossip based on contents
-	rm        RangeManager   // Makes some store methods available
-	raft      chan *Cmd      // Raft commands
-	closer    chan struct{}  // Channel for closing the range
+	Meta   *proto.RangeMetadata
+	rm     RangeManager  // Makes some store methods available
+	raft   chan *Cmd     // Raft commands
+	closer chan struct{} // Channel for closing the range
 
 	sync.RWMutex                 // Protects cmdQ, tsCache & respCache
 	cmdQ         *CommandQueue   // Enforce at most one command is running per key(s)
@@ -225,29 +225,16 @@ type Range struct {
 	respCache    *ResponseCache  // Provides idempotence for retries
 }
 
-// NewRange initializes the range using the given metadata. The range will have
-// no knowledge of a possible store that contains it and thus all rebalancing
-// operations will fail. Use NewRangeFromStore() instead to create ranges
-// contained within a store.
-//
-// TODO(spencer): need to give range just a single instance of Range manager
-// to contain clock, mvcc, engine, allocator & gossip. This will reduce
-// completely unnecessary memory usage per range.
-func NewRange(meta *proto.RangeMetadata, clock *hlc.Clock, eng engine.Engine,
-	allocator *allocator, gossip *gossip.Gossip, rm RangeManager) *Range {
+// NewRange initializes the range using the given metadata.
+func NewRange(meta *proto.RangeMetadata, rm RangeManager) *Range {
 	r := &Range{
 		Meta:      meta,
-		clock:     clock,
-		mvcc:      engine.NewMVCC(eng),
-		engine:    eng,
-		allocator: allocator,
-		gossip:    gossip,
-		raft:      make(chan *Cmd, 10), // TODO(spencer): remove
 		rm:        rm,
+		raft:      make(chan *Cmd, 10), // TODO(spencer): remove
 		closer:    make(chan struct{}),
 		cmdQ:      NewCommandQueue(),
-		tsCache:   NewTimestampCache(clock),
-		respCache: NewResponseCache(meta.RangeID, eng),
+		tsCache:   NewTimestampCache(rm.Clock()),
+		respCache: NewResponseCache(meta.RangeID, rm.Engine()),
 	}
 	return r
 }
@@ -560,8 +547,8 @@ func (r *Range) startGossip() {
 // maybeGossipClusterID gossips the cluster ID if this range is
 // the start of the key space and the raft leader.
 func (r *Range) maybeGossipClusterID() {
-	if r.gossip != nil && r.IsFirstRange() && r.IsLeader() {
-		if err := r.gossip.AddInfo(gossip.KeyClusterID, r.Meta.ClusterID, ttlClusterIDGossip); err != nil {
+	if r.rm.Gossip() != nil && r.IsFirstRange() && r.IsLeader() {
+		if err := r.rm.Gossip().AddInfo(gossip.KeyClusterID, r.Meta.ClusterID, ttlClusterIDGossip); err != nil {
 			log.Errorf("failed to gossip cluster ID %s: %s", r.Meta.ClusterID, err)
 		}
 	}
@@ -570,8 +557,8 @@ func (r *Range) maybeGossipClusterID() {
 // maybeGossipFirstRange gossips the range locations if this range is
 // the start of the key space and the raft leader.
 func (r *Range) maybeGossipFirstRange() {
-	if r.gossip != nil && r.IsFirstRange() && r.IsLeader() {
-		if err := r.gossip.AddInfo(gossip.KeyFirstRangeMetadata, r.Meta.RangeDescriptor, 0*time.Second); err != nil {
+	if r.rm.Gossip() != nil && r.IsFirstRange() && r.IsLeader() {
+		if err := r.rm.Gossip().AddInfo(gossip.KeyFirstRangeMetadata, r.Meta.RangeDescriptor, 0*time.Second); err != nil {
 			log.Errorf("failed to gossip first range metadata: %s", err)
 		}
 	}
@@ -582,7 +569,7 @@ func (r *Range) maybeGossipFirstRange() {
 // contents are marked dirty. Configuration maps include accounting,
 // permissions, and zones.
 func (r *Range) maybeGossipConfigs() {
-	if r.gossip != nil && r.IsLeader() {
+	if r.rm.Gossip() != nil && r.IsLeader() {
 		for _, cp := range configPrefixes {
 			if cp.dirty && r.ContainsKey(cp.keyPrefix) {
 				configMap, err := r.loadConfigMap(cp.keyPrefix, cp.configI)
@@ -590,7 +577,7 @@ func (r *Range) maybeGossipConfigs() {
 					log.Errorf("failed loading %s config map: %s", cp.gossipKey, err)
 					continue
 				} else {
-					if err := r.gossip.AddInfo(cp.gossipKey, configMap, 0*time.Second); err != nil {
+					if err := r.rm.Gossip().AddInfo(cp.gossipKey, configMap, 0*time.Second); err != nil {
 						log.Errorf("failed to gossip %s configMap: %s", cp.gossipKey, err)
 						continue
 					}
@@ -607,7 +594,7 @@ func (r *Range) maybeGossipConfigs() {
 func (r *Range) loadConfigMap(keyPrefix engine.Key, configI interface{}) (PrefixConfigMap, error) {
 	// TODO(spencer): need to make sure range splitting never
 	// crosses a configuration map's key prefix.
-	kvs, err := r.mvcc.Scan(keyPrefix, keyPrefix.PrefixEnd(), 0, proto.MaxTimestamp, nil)
+	kvs, err := engine.MVCCScan(engine.NewBatch(r.rm.Engine()), keyPrefix, keyPrefix.PrefixEnd(), 0, proto.MaxTimestamp, nil)
 	if err != nil {
 		return nil, err
 	}
@@ -624,6 +611,18 @@ func (r *Range) loadConfigMap(keyPrefix engine.Key, configI interface{}) (Prefix
 	return NewPrefixConfigMap(configs)
 }
 
+// maybeUpdateGossipConfigs is used to update gossip configs.
+func (r *Range) maybeUpdateGossipConfigs(key engine.Key) {
+	// Check whether this put has modified a configuration map.
+	for _, cp := range configPrefixes {
+		if bytes.HasPrefix(key, cp.keyPrefix) {
+			cp.dirty = true
+			r.maybeGossipConfigs()
+			break
+		}
+	}
+}
+
 // executeCmd switches over the method and multiplexes to execute the
 // appropriate storage API command.
 //
@@ -635,47 +634,61 @@ func (r *Range) loadConfigMap(keyPrefix engine.Key, configI interface{}) (Prefix
 // bubble up to the point where we've just tried to execute a Raft command, the
 // Raft replica would need to stall itself.
 func (r *Range) executeCmd(method string, args proto.Request, reply proto.Response) error {
+	// Create a new batch for the command to ensure all or nothing semantics.
+	b := engine.NewBatch(r.rm.Engine())
+
 	switch method {
 	case Contains:
-		r.Contains(args.(*proto.ContainsRequest), reply.(*proto.ContainsResponse))
+		r.Contains(b, args.(*proto.ContainsRequest), reply.(*proto.ContainsResponse))
 	case Get:
-		r.Get(args.(*proto.GetRequest), reply.(*proto.GetResponse))
+		r.Get(b, args.(*proto.GetRequest), reply.(*proto.GetResponse))
 	case Put:
-		r.Put(args.(*proto.PutRequest), reply.(*proto.PutResponse))
+		r.Put(b, args.(*proto.PutRequest), reply.(*proto.PutResponse))
 	case ConditionalPut:
-		r.ConditionalPut(args.(*proto.ConditionalPutRequest), reply.(*proto.ConditionalPutResponse))
+		r.ConditionalPut(b, args.(*proto.ConditionalPutRequest), reply.(*proto.ConditionalPutResponse))
 	case Increment:
-		r.Increment(args.(*proto.IncrementRequest), reply.(*proto.IncrementResponse))
+		r.Increment(b, args.(*proto.IncrementRequest), reply.(*proto.IncrementResponse))
 	case Delete:
-		r.Delete(args.(*proto.DeleteRequest), reply.(*proto.DeleteResponse))
+		r.Delete(b, args.(*proto.DeleteRequest), reply.(*proto.DeleteResponse))
 	case DeleteRange:
-		r.DeleteRange(args.(*proto.DeleteRangeRequest), reply.(*proto.DeleteRangeResponse))
+		r.DeleteRange(b, args.(*proto.DeleteRangeRequest), reply.(*proto.DeleteRangeResponse))
 	case Scan:
-		r.Scan(args.(*proto.ScanRequest), reply.(*proto.ScanResponse))
+		r.Scan(b, args.(*proto.ScanRequest), reply.(*proto.ScanResponse))
 	case EndTransaction:
-		r.EndTransaction(args.(*proto.EndTransactionRequest), reply.(*proto.EndTransactionResponse))
+		r.EndTransaction(b, args.(*proto.EndTransactionRequest), reply.(*proto.EndTransactionResponse))
 	case AccumulateTS:
-		r.AccumulateTS(args.(*proto.AccumulateTSRequest), reply.(*proto.AccumulateTSResponse))
+		r.AccumulateTS(b, args.(*proto.AccumulateTSRequest), reply.(*proto.AccumulateTSResponse))
 	case ReapQueue:
-		r.ReapQueue(args.(*proto.ReapQueueRequest), reply.(*proto.ReapQueueResponse))
+		r.ReapQueue(b, args.(*proto.ReapQueueRequest), reply.(*proto.ReapQueueResponse))
 	case EnqueueUpdate:
-		r.EnqueueUpdate(args.(*proto.EnqueueUpdateRequest), reply.(*proto.EnqueueUpdateResponse))
+		r.EnqueueUpdate(b, args.(*proto.EnqueueUpdateRequest), reply.(*proto.EnqueueUpdateResponse))
 	case EnqueueMessage:
-		r.EnqueueMessage(args.(*proto.EnqueueMessageRequest), reply.(*proto.EnqueueMessageResponse))
+		r.EnqueueMessage(b, args.(*proto.EnqueueMessageRequest), reply.(*proto.EnqueueMessageResponse))
 	case InternalRangeLookup:
-		r.InternalRangeLookup(args.(*proto.InternalRangeLookupRequest), reply.(*proto.InternalRangeLookupResponse))
+		r.InternalRangeLookup(b, args.(*proto.InternalRangeLookupRequest), reply.(*proto.InternalRangeLookupResponse))
 	case InternalHeartbeatTxn:
-		r.InternalHeartbeatTxn(args.(*proto.InternalHeartbeatTxnRequest), reply.(*proto.InternalHeartbeatTxnResponse))
+		r.InternalHeartbeatTxn(b, args.(*proto.InternalHeartbeatTxnRequest), reply.(*proto.InternalHeartbeatTxnResponse))
 	case InternalPushTxn:
-		r.InternalPushTxn(args.(*proto.InternalPushTxnRequest), reply.(*proto.InternalPushTxnResponse))
+		r.InternalPushTxn(b, args.(*proto.InternalPushTxnRequest), reply.(*proto.InternalPushTxnResponse))
 	case InternalResolveIntent:
-		r.InternalResolveIntent(args.(*proto.InternalResolveIntentRequest), reply.(*proto.InternalResolveIntentResponse))
+		r.InternalResolveIntent(b, args.(*proto.InternalResolveIntentRequest), reply.(*proto.InternalResolveIntentResponse))
 	case InternalSnapshotCopy:
-		r.InternalSnapshotCopy(args.(*proto.InternalSnapshotCopyRequest), reply.(*proto.InternalSnapshotCopyResponse))
+		r.InternalSnapshotCopy(b, args.(*proto.InternalSnapshotCopyRequest), reply.(*proto.InternalSnapshotCopyResponse))
 	case InternalSplit:
-		r.InternalSplit(args.(*proto.InternalSplitRequest), reply.(*proto.InternalSplitResponse))
+		r.InternalSplit(b, args.(*proto.InternalSplitRequest), reply.(*proto.InternalSplitResponse))
 	default:
 		return util.Errorf("unrecognized command type: %s", method)
+	}
+
+	// Commit the batch on success.
+	if reply.Header().Error == nil {
+		reply.Header().SetGoError(b.Commit())
+	}
+
+	// Maybe update gossip configs on a put if there was no error.
+	if (method == Put || method == ConditionalPut) &&
+		reply.Header().Error == nil {
+		r.maybeUpdateGossipConfigs(args.Header().Key)
 	}
 
 	// Propagate the request timestamp (which may have changed).
@@ -699,8 +712,8 @@ func (r *Range) executeCmd(method string, args proto.Request, reply proto.Respon
 }
 
 // Contains verifies the existence of a key in the key value store.
-func (r *Range) Contains(args *proto.ContainsRequest, reply *proto.ContainsResponse) {
-	val, err := r.mvcc.Get(args.Key, args.Timestamp, args.Txn)
+func (r *Range) Contains(b *engine.Batch, args *proto.ContainsRequest, reply *proto.ContainsResponse) {
+	val, err := engine.MVCCGet(b, args.Key, args.Timestamp, args.Txn)
 	if err != nil {
 		reply.SetGoError(err)
 		return
@@ -711,63 +724,45 @@ func (r *Range) Contains(args *proto.ContainsRequest, reply *proto.ContainsRespo
 }
 
 // Get returns the value for a specified key.
-func (r *Range) Get(args *proto.GetRequest, reply *proto.GetResponse) {
-	val, err := r.mvcc.Get(args.Key, args.Timestamp, args.Txn)
+func (r *Range) Get(b *engine.Batch, args *proto.GetRequest, reply *proto.GetResponse) {
+	val, err := engine.MVCCGet(b, args.Key, args.Timestamp, args.Txn)
 	reply.Value = val
 	reply.SetGoError(err)
 }
 
 // Put sets the value for a specified key.
-func (r *Range) Put(args *proto.PutRequest, reply *proto.PutResponse) {
-	err := r.mvcc.Put(args.Key, args.Timestamp, args.Value, args.Txn)
-	if err == nil {
-		r.updateGossipConfigs(args.Key)
-	}
+func (r *Range) Put(b *engine.Batch, args *proto.PutRequest, reply *proto.PutResponse) {
+	err := engine.MVCCPut(b, args.Key, args.Timestamp, args.Value, args.Txn)
 	reply.SetGoError(err)
 }
 
 // ConditionalPut sets the value for a specified key only if
 // the expected value matches. If not, the return value contains
 // the actual value.
-func (r *Range) ConditionalPut(args *proto.ConditionalPutRequest, reply *proto.ConditionalPutResponse) {
-	val, err := r.mvcc.ConditionalPut(args.Key, args.Timestamp, args.Value, args.ExpValue, args.Txn)
-	if err == nil {
-		r.updateGossipConfigs(args.Key)
-	}
+func (r *Range) ConditionalPut(b *engine.Batch, args *proto.ConditionalPutRequest, reply *proto.ConditionalPutResponse) {
+	val, err := engine.MVCCConditionalPut(b, args.Key, args.Timestamp, args.Value, args.ExpValue, args.Txn)
 	reply.ActualValue = val
 	reply.SetGoError(err)
-}
-
-// updateGossipConfigs is used to update gossip configs.
-func (r *Range) updateGossipConfigs(key engine.Key) {
-	// Check whether this put has modified a configuration map.
-	for _, cp := range configPrefixes {
-		if bytes.HasPrefix(key, cp.keyPrefix) {
-			cp.dirty = true
-			r.maybeGossipConfigs()
-			break
-		}
-	}
 }
 
 // Increment increments the value (interpreted as varint64 encoded) and
 // returns the newly incremented value (encoded as varint64). If no value
 // exists for the key, zero is incremented.
-func (r *Range) Increment(args *proto.IncrementRequest, reply *proto.IncrementResponse) {
-	val, err := r.mvcc.Increment(args.Key, args.Timestamp, args.Txn, args.Increment)
+func (r *Range) Increment(b *engine.Batch, args *proto.IncrementRequest, reply *proto.IncrementResponse) {
+	val, err := engine.MVCCIncrement(b, args.Key, args.Timestamp, args.Txn, args.Increment)
 	reply.NewValue = val
 	reply.SetGoError(err)
 }
 
 // Delete deletes the key and value specified by key.
-func (r *Range) Delete(args *proto.DeleteRequest, reply *proto.DeleteResponse) {
-	reply.SetGoError(r.mvcc.Delete(args.Key, args.Timestamp, args.Txn))
+func (r *Range) Delete(b *engine.Batch, args *proto.DeleteRequest, reply *proto.DeleteResponse) {
+	reply.SetGoError(engine.MVCCDelete(b, args.Key, args.Timestamp, args.Txn))
 }
 
 // DeleteRange deletes the range of key/value pairs specified by
 // start and end keys.
-func (r *Range) DeleteRange(args *proto.DeleteRangeRequest, reply *proto.DeleteRangeResponse) {
-	num, err := r.mvcc.DeleteRange(args.Key, args.EndKey, args.MaxEntriesToDelete, args.Timestamp, args.Txn)
+func (r *Range) DeleteRange(b *engine.Batch, args *proto.DeleteRangeRequest, reply *proto.DeleteRangeResponse) {
+	num, err := engine.MVCCDeleteRange(b, args.Key, args.EndKey, args.MaxEntriesToDelete, args.Timestamp, args.Txn)
 	reply.NumDeleted = num
 	reply.SetGoError(err)
 }
@@ -775,21 +770,21 @@ func (r *Range) DeleteRange(args *proto.DeleteRangeRequest, reply *proto.DeleteR
 // Scan scans the key range specified by start key through end key up
 // to some maximum number of results. The last key of the iteration is
 // returned with the reply.
-func (r *Range) Scan(args *proto.ScanRequest, reply *proto.ScanResponse) {
-	kvs, err := r.mvcc.Scan(args.Key, args.EndKey, args.MaxResults, args.Timestamp, args.Txn)
+func (r *Range) Scan(b *engine.Batch, args *proto.ScanRequest, reply *proto.ScanResponse) {
+	kvs, err := engine.MVCCScan(b, args.Key, args.EndKey, args.MaxResults, args.Timestamp, args.Txn)
 	reply.Rows = kvs
 	reply.SetGoError(err)
 }
 
 // EndTransaction either commits or aborts (rolls back) an extant
 // transaction according to the args.Commit parameter.
-func (r *Range) EndTransaction(args *proto.EndTransactionRequest, reply *proto.EndTransactionResponse) {
+func (r *Range) EndTransaction(b *engine.Batch, args *proto.EndTransactionRequest, reply *proto.EndTransactionResponse) {
 	// Encode the key for direct access to/from the engine.
 	encKey := engine.Key(args.Key).Encode(nil)
 
 	// Fetch existing transaction if possible.
 	existTxn := &proto.Transaction{}
-	ok, err := engine.GetProto(r.engine, encKey, existTxn)
+	ok, err := b.GetProto(encKey, existTxn)
 	if err != nil {
 		reply.SetGoError(err)
 		return
@@ -854,7 +849,7 @@ func (r *Range) EndTransaction(args *proto.EndTransactionRequest, reply *proto.E
 	}
 
 	// Persist the transaction record with updated status (& possibly timestmap).
-	if err := engine.PutProto(r.engine, encKey, reply.Txn); err != nil {
+	if err := b.PutProto(encKey, reply.Txn); err != nil {
 		reply.SetGoError(err)
 		return
 	}
@@ -862,13 +857,13 @@ func (r *Range) EndTransaction(args *proto.EndTransactionRequest, reply *proto.E
 
 // AccumulateTS is used internally to aggregate statistics over key
 // ranges throughout the distributed cluster.
-func (r *Range) AccumulateTS(args *proto.AccumulateTSRequest, reply *proto.AccumulateTSResponse) {
+func (r *Range) AccumulateTS(b *engine.Batch, args *proto.AccumulateTSRequest, reply *proto.AccumulateTSResponse) {
 	reply.SetGoError(util.Error("unimplemented"))
 }
 
 // ReapQueue destructively queries messages from a delivery inbox
 // queue. This method must be called from within a transaction.
-func (r *Range) ReapQueue(args *proto.ReapQueueRequest, reply *proto.ReapQueueResponse) {
+func (r *Range) ReapQueue(b *engine.Batch, args *proto.ReapQueueRequest, reply *proto.ReapQueueResponse) {
 	reply.SetGoError(util.Error("unimplemented"))
 }
 
@@ -877,13 +872,13 @@ func (r *Range) ReapQueue(args *proto.ReapQueueRequest, reply *proto.ReapQueueRe
 // are also built using update queues. Crucially, the enqueue happens
 // as part of the caller's transaction, so is guaranteed to be
 // executed if the transaction succeeded.
-func (r *Range) EnqueueUpdate(args *proto.EnqueueUpdateRequest, reply *proto.EnqueueUpdateResponse) {
+func (r *Range) EnqueueUpdate(b *engine.Batch, args *proto.EnqueueUpdateRequest, reply *proto.EnqueueUpdateResponse) {
 	reply.SetGoError(util.Error("unimplemented"))
 }
 
 // EnqueueMessage enqueues a message (Value) for delivery to a
 // recipient inbox.
-func (r *Range) EnqueueMessage(args *proto.EnqueueMessageRequest, reply *proto.EnqueueMessageResponse) {
+func (r *Range) EnqueueMessage(b *engine.Batch, args *proto.EnqueueMessageRequest, reply *proto.EnqueueMessageResponse) {
 	reply.SetGoError(util.Error("unimplemented"))
 }
 
@@ -912,7 +907,7 @@ func (r *Range) EnqueueMessage(args *proto.EnqueueMessageRequest, reply *proto.E
 // intended to serve as a sort of caching pre-fetch, so that the requesting
 // nodes can aggressively cache RangeDescriptors which are likely to be desired
 // by their current workload.
-func (r *Range) InternalRangeLookup(args *proto.InternalRangeLookupRequest, reply *proto.InternalRangeLookupResponse) {
+func (r *Range) InternalRangeLookup(b *engine.Batch, args *proto.InternalRangeLookupRequest, reply *proto.InternalRangeLookupResponse) {
 	if err := engine.ValidateRangeMetaKey(args.Key); err != nil {
 		reply.SetGoError(err)
 		return
@@ -930,7 +925,7 @@ func (r *Range) InternalRangeLookup(args *proto.InternalRangeLookupRequest, repl
 	// MaxRanges.
 	metaPrefix := engine.Key(args.Key[:len(engine.KeyMeta1Prefix)])
 	nextKey := engine.Key(args.Key).Next()
-	kvs, err := r.mvcc.Scan(nextKey, metaPrefix.PrefixEnd(), rangeCount, args.Timestamp, args.Txn)
+	kvs, err := engine.MVCCScan(b, nextKey, metaPrefix.PrefixEnd(), rangeCount, args.Timestamp, args.Txn)
 	if err != nil {
 		reply.SetGoError(err)
 		return
@@ -965,12 +960,12 @@ func (r *Range) InternalRangeLookup(args *proto.InternalRangeLookupRequest, repl
 // InternalHeartbeatTxn updates the transaction status and heartbeat
 // timestamp after receiving transaction heartbeat messages from
 // coordinator. Returns the updated transaction.
-func (r *Range) InternalHeartbeatTxn(args *proto.InternalHeartbeatTxnRequest, reply *proto.InternalHeartbeatTxnResponse) {
+func (r *Range) InternalHeartbeatTxn(b *engine.Batch, args *proto.InternalHeartbeatTxnRequest, reply *proto.InternalHeartbeatTxnResponse) {
 	// Encode the key for direct access to/from the engine.
 	encKey := engine.Key(args.Key).Encode(nil)
 
 	var txn proto.Transaction
-	ok, err := engine.GetProto(r.engine, encKey, &txn)
+	ok, err := b.GetProto(encKey, &txn)
 	if err != nil {
 		reply.SetGoError(err)
 		return
@@ -987,7 +982,7 @@ func (r *Range) InternalHeartbeatTxn(args *proto.InternalHeartbeatTxnRequest, re
 		if txn.LastHeartbeat.Less(args.Header().Timestamp) {
 			*txn.LastHeartbeat = args.Header().Timestamp
 		}
-		if err := engine.PutProto(r.engine, encKey, &txn); err != nil {
+		if err := b.PutProto(encKey, &txn); err != nil {
 			reply.SetGoError(err)
 			return
 		}
@@ -1028,7 +1023,7 @@ func (r *Range) InternalHeartbeatTxn(args *proto.InternalHeartbeatTxnRequest, re
 // Higher Txn Priority: If pushee txn has a higher priority than
 // pusher, return TransactionRetryError. Transaction will be retried
 // with priority one less than the pushee's higher priority.
-func (r *Range) InternalPushTxn(args *proto.InternalPushTxnRequest, reply *proto.InternalPushTxnResponse) {
+func (r *Range) InternalPushTxn(b *engine.Batch, args *proto.InternalPushTxnRequest, reply *proto.InternalPushTxnResponse) {
 	key := engine.Key(args.Key)
 	if !bytes.Equal(key.Address(), args.PusheeTxn.ID) {
 		reply.SetGoError(util.Errorf("request key %q should match pushee's txn ID %q",
@@ -1041,7 +1036,7 @@ func (r *Range) InternalPushTxn(args *proto.InternalPushTxnRequest, reply *proto
 
 	// Fetch existing transaction if possible.
 	existTxn := &proto.Transaction{}
-	ok, err := engine.GetProto(r.engine, encKey, existTxn)
+	ok, err := b.GetProto(encKey, existTxn)
 	if err != nil {
 		reply.SetGoError(err)
 		return
@@ -1104,7 +1099,7 @@ func (r *Range) InternalPushTxn(args *proto.InternalPushTxnRequest, reply *proto
 		reply.PusheeTxn.LastHeartbeat = &reply.PusheeTxn.Timestamp
 	}
 	// Compute heartbeat expiration.
-	expiry := r.clock.Now()
+	expiry := r.rm.Clock().Now()
 	expiry.WallTime -= 2 * DefaultHeartbeatInterval.Nanoseconds()
 	if reply.PusheeTxn.LastHeartbeat.Less(expiry) {
 		log.V(1).Infof("pushing expired txn %s", reply.PusheeTxn)
@@ -1142,7 +1137,7 @@ func (r *Range) InternalPushTxn(args *proto.InternalPushTxnRequest, reply *proto
 	}
 
 	// Persist the pushed transaction.
-	if err := engine.PutProto(r.engine, encKey, reply.PusheeTxn); err != nil {
+	if err := b.PutProto(encKey, reply.PusheeTxn); err != nil {
 		reply.SetGoError(err)
 		return
 	}
@@ -1152,30 +1147,30 @@ func (r *Range) InternalPushTxn(args *proto.InternalPushTxnRequest, reply *proto
 // timestamp after receiving transaction heartbeat messages from
 // coordinator. The range will return the current status for this
 // transaction to the coordinator.
-func (r *Range) InternalResolveIntent(args *proto.InternalResolveIntentRequest, reply *proto.InternalResolveIntentResponse) {
+func (r *Range) InternalResolveIntent(b *engine.Batch, args *proto.InternalResolveIntentRequest, reply *proto.InternalResolveIntentResponse) {
 	if len(args.EndKey) == 0 || bytes.Equal(args.Key, args.EndKey) {
-		reply.SetGoError(r.mvcc.ResolveWriteIntent(args.Key, args.Txn))
+		reply.SetGoError(engine.MVCCResolveWriteIntent(b, args.Key, args.Txn))
 	} else {
-		_, err := r.mvcc.ResolveWriteIntentRange(args.Key, args.EndKey, 0, args.Txn)
+		_, err := engine.MVCCResolveWriteIntentRange(b, args.Key, args.EndKey, 0, args.Txn)
 		reply.SetGoError(err)
 	}
 }
 
 // createSnapshot creates a new snapshot, named using an internal counter.
 func (r *Range) createSnapshot() (string, error) {
-	candidateID, err := engine.Increment(r.engine, engine.KeyLocalSnapshotIDGenerator, 1)
+	candidateID, err := engine.Increment(r.rm.Engine(), engine.KeyLocalSnapshotIDGenerator, 1)
 	if err != nil {
 		return "", err
 	}
 	snapshotID := strconv.FormatInt(candidateID, 10)
-	err = r.engine.CreateSnapshot(snapshotID)
+	err = r.rm.Engine().CreateSnapshot(snapshotID)
 	return snapshotID, err
 }
 
 // InternalSnapshotCopy scans the key range specified by start key through
 // end key up to some maximum number of results from the given snapshot_id.
 // It will create a snapshot if snapshot_id is empty.
-func (r *Range) InternalSnapshotCopy(args *proto.InternalSnapshotCopyRequest, reply *proto.InternalSnapshotCopyResponse) {
+func (r *Range) InternalSnapshotCopy(b *engine.Batch, args *proto.InternalSnapshotCopyRequest, reply *proto.InternalSnapshotCopyResponse) {
 	if len(args.SnapshotId) == 0 {
 		snapshotID, err := r.createSnapshot()
 		if err != nil {
@@ -1185,13 +1180,13 @@ func (r *Range) InternalSnapshotCopy(args *proto.InternalSnapshotCopyRequest, re
 		args.SnapshotId = snapshotID
 	}
 
-	kvs, err := r.engine.ScanSnapshot(args.Key, args.EndKey, args.MaxResults, args.SnapshotId)
+	kvs, err := r.rm.Engine().ScanSnapshot(args.Key, args.EndKey, args.MaxResults, args.SnapshotId)
 	if err != nil {
 		reply.SetGoError(err)
 		return
 	}
 	if len(kvs) == 0 {
-		err = r.engine.ReleaseSnapshot(args.SnapshotId)
+		err = r.rm.Engine().ReleaseSnapshot(args.SnapshotId)
 	}
 
 	reply.Rows = kvs
@@ -1208,7 +1203,7 @@ func (r *Range) InternalSnapshotCopy(args *proto.InternalSnapshotCopyRequest, re
 // TODO(Tobias): This version, as is, is provisional. A correct implementation
 // is much more subtle and requires a transaction. See:
 // https://github.com/cockroachdb/cockroach/pull/64/files#r17667926
-func (r *Range) InternalSplit(args *proto.InternalSplitRequest, reply *proto.InternalSplitResponse) {
+func (r *Range) InternalSplit(b *engine.Batch, args *proto.InternalSplitRequest, reply *proto.InternalSplitResponse) {
 	var err error
 	if r.rm == nil {
 		reply.SetGoError(util.Error("cannot split without an underlying store"))

--- a/storage/range.go
+++ b/storage/range.go
@@ -64,12 +64,6 @@ const (
 	ttlClusterIDGossip = 30 * time.Second
 )
 
-// splitCheckInterval is the duration waited between periodic checks on whether
-// the range is going to split.
-// It is stored as a variable to allow for dynamic adaption (for instance based
-// on write load) and easier testing.
-var splitCheckInterval = 1 * time.Minute
-
 // configPrefixes describes administrative configuration maps
 // affecting ranges of the key-value map by key prefix.
 var configPrefixes = []struct {

--- a/storage/response_cache.go
+++ b/storage/response_cache.go
@@ -154,7 +154,7 @@ func (rc *ResponseCache) CopyInto(destRC *ResponseCache) error {
 		// write it to the corresponding key in the new cache.
 		if cmdID, err := rc.decodeKey(kv.Key); err == nil {
 			encKey := destRC.makeKey(cmdID).Encode(nil)
-			batch = append(batch, engine.BatchPut{Key: encKey, Value: kv.Value})
+			batch = append(batch, engine.BatchPut{proto.RawKeyValue{Key: encKey, Value: kv.Value}})
 			//destRC.engine.Put(destRC.makeKey(cmdID), kv.Value)
 		} else {
 			// This is near impossible to ever happen in practice, so if it happens


### PR DESCRIPTION
A Batch is a minimal subset of the Engine interface which satisfies
the needs of MVCC and in general, the execution of Range/Raft commands.
The idea is to make the write-batch nature explicit, obviating the
need to carefully use WriteBatch inside MVCC code. Further, this lays
the groundwork for implementation of an API batch command, allowing
arbitrary combinations of KV API commands to be executed atomically.
This will be important for both large data tasks (e.g. imports), and
for the structured data API (e.g. many updates to associated indexes
on a table insert/update, collapsing a distributed txn which affects
only a single range into one Raft update without associated txn
record).

Also expanded interface for the RangeManager which provides accessors to
Store data objects so we don't need to senselessly keep copies of the same
pointers for all ranges.
