### PR TITLE
Switch admin REST API to always return configs as JSON.

### DIFF
--- a/proto/config.go
+++ b/proto/config.go
@@ -115,9 +115,9 @@ func ZoneConfigFromJSON(in []byte) (*ZoneConfig, error) {
 	return z, err
 }
 
-// ToJSON serializes a ZoneConfig as JSON.
+// ToJSON serializes a ZoneConfig as "pretty", indented JSON.
 func (z *ZoneConfig) ToJSON() ([]byte, error) {
-	return json.Marshal(z)
+	return json.MarshalIndent(z, "", "  ")
 }
 
 // ZoneConfigFromYAML parses a YAML serialized ZoneConfig.

--- a/proto/config.go
+++ b/proto/config.go
@@ -19,7 +19,9 @@ package proto
 
 import (
 	"bytes"
+	"encoding/json"
 	"fmt"
+	"regexp"
 	"sort"
 	"strings"
 
@@ -106,16 +108,38 @@ func (p *PermConfig) CanWrite(user string) bool {
 	return false
 }
 
-// ParseZoneConfig parses a YAML serialized ZoneConfig.
-func ParseZoneConfig(in []byte) (*ZoneConfig, error) {
+// ZoneConfigFromJSON parses a JSON serialized ZoneConfig.
+func ZoneConfigFromJSON(in []byte) (*ZoneConfig, error) {
+	z := &ZoneConfig{}
+	err := json.Unmarshal(in, z)
+	return z, err
+}
+
+// ToJSON serializes a ZoneConfig as JSON.
+func (z *ZoneConfig) ToJSON() ([]byte, error) {
+	return json.Marshal(z)
+}
+
+// ZoneConfigFromYAML parses a YAML serialized ZoneConfig.
+func ZoneConfigFromYAML(in []byte) (*ZoneConfig, error) {
 	z := &ZoneConfig{}
 	err := yaml.Unmarshal(in, z)
 	return z, err
 }
 
+var yamlXXXUnrecognizedRE = regexp.MustCompile(` *xxx_unrecognized: \[\]\n?`)
+
 // ToYAML serializes a ZoneConfig as YAML.
 func (z *ZoneConfig) ToYAML() ([]byte, error) {
-	return yaml.Marshal(z)
+	b, err := yaml.Marshal(z)
+	if err != nil {
+		return b, err
+	}
+	// Filter out any lines in the input which match xxx_unrecognized, a
+	// truly-annoying public member of proto Message structs, which we
+	// cannot specify yaml output tags for.
+	// TODO(spencer): there's got to be a better way to do this.
+	return yamlXXXUnrecognizedRE.ReplaceAll(b, []byte{}), nil
 }
 
 // Compare implements the llrb.Comparable interface for tree nodes.

--- a/proto/config.proto
+++ b/proto/config.proto
@@ -92,7 +92,7 @@ message PermConfig {
 message ZoneConfig {
   // ReplicaAttrs is a slice of Attributes, each describing required
   // attributes for each replica in the zone.
-  repeated Attributes replica_attrs = 1 [(gogoproto.nullable) = false, (gogoproto.moretags) = "yaml:\"replicas,omitempty,flow\""];
+  repeated Attributes replica_attrs = 1 [(gogoproto.nullable) = false, (gogoproto.moretags) = "yaml:\"replicas,omitempty\""];
   optional int64 range_min_bytes = 2 [(gogoproto.nullable) = false, (gogoproto.moretags) = "yaml:\"range_min_bytes,omitempty\""];
   optional int64 range_max_bytes = 3 [(gogoproto.nullable) = false, (gogoproto.moretags) = "yaml:\"range_max_bytes,omitempty\""];
   optional GCPolicy gc = 4 [(gogoproto.customname) = "GC", (gogoproto.moretags) = "yaml:\"gc,omitempty\""];

--- a/proto/config_test.go
+++ b/proto/config_test.go
@@ -124,12 +124,26 @@ range_min_bytes: 1048576
 range_max_bytes: 67108864
 `
 
-func TestZoneConfigRoundTrip(t *testing.T) {
+func TestZoneConfigJSONRoundTrip(t *testing.T) {
+	js, err := testConfig.ToJSON()
+	if err != nil {
+		t.Fatalf("failed converting to json: %v", err)
+	}
+	parsedZoneConfig, err := ZoneConfigFromJSON(json)
+	if err != nil {
+		t.Errorf("failed parsing config: %v", err)
+	}
+	if !reflect.DeepEqual(testConfig, *parsedZoneConfig) {
+		t.Errorf("json round trip configs differ.\nOriginal: %+v\nParse: %+v\n", testConfig, parsedZoneConfig)
+	}
+}
+
+func TestZoneConfigYAMLRoundTrip(t *testing.T) {
 	yaml, err := testConfig.ToYAML()
 	if err != nil {
 		t.Fatalf("failed converting to yaml: %v", err)
 	}
-	parsedZoneConfig, err := ParseZoneConfig(yaml)
+	parsedZoneConfig, err := ZoneConfigFromYAML(yaml)
 	if err != nil {
 		t.Errorf("failed parsing config: %v", err)
 	}
@@ -139,7 +153,7 @@ func TestZoneConfigRoundTrip(t *testing.T) {
 }
 
 func TestZoneConfigYAMLParsing(t *testing.T) {
-	parsedZoneConfig, err := ParseZoneConfig([]byte(yamlConfig))
+	parsedZoneConfig, err := ZoneConfigFromYAML([]byte(yamlConfig))
 	if err != nil {
 		t.Fatalf("failed parsing config: %v", err)
 	}

--- a/proto/config_test.go
+++ b/proto/config_test.go
@@ -125,7 +125,7 @@ range_max_bytes: 67108864
 `
 
 func TestZoneConfigJSONRoundTrip(t *testing.T) {
-	js, err := testConfig.ToJSON()
+	json, err := testConfig.ToJSON()
 	if err != nil {
 		t.Fatalf("failed converting to json: %v", err)
 	}

--- a/server/zone_test.go
+++ b/server/zone_test.go
@@ -30,7 +30,9 @@ import (
 const (
 	testConfig = `
 replicas:
-  - [dc1, ssd]
+  - attrs: [dc1, ssd]
+  - attrs: [dc2, ssd]
+  - attrs: [dc3, ssd]
 range_min_bytes: 1048576
 range_max_bytes: 67108864
 `
@@ -76,25 +78,37 @@ func ExampleSetAndGetZone() {
 	// Output:
 	// set zone config for key prefix ""
 	// zone config for key prefix "":
-	// replicas: [[dc1, ssd]]
+	// replicas:
+	// - attrs: [dc1, ssd]
+	// - attrs: [dc2, ssd]
+	// - attrs: [dc3, ssd]
 	// range_min_bytes: 1048576
 	// range_max_bytes: 67108864
-
+	//
 	// set zone config for key prefix "db1"
 	// zone config for key prefix "db1":
-	// replicas: [[dc1, ssd]]
+	// replicas:
+	// - attrs: [dc1, ssd]
+	// - attrs: [dc2, ssd]
+	// - attrs: [dc3, ssd]
 	// range_min_bytes: 1048576
 	// range_max_bytes: 67108864
-
+	//
 	// set zone config for key prefix "db+2"
 	// zone config for key prefix "db+2":
-	// replicas: [[dc1, ssd]]
+	// replicas:
+	// - attrs: [dc1, ssd]
+	// - attrs: [dc2, ssd]
+	// - attrs: [dc3, ssd]
 	// range_min_bytes: 1048576
 	// range_max_bytes: 67108864
-
+	//
 	// set zone config for key prefix "%FE"
 	// zone config for key prefix "%FE":
-	// replicas: [[dc1, ssd]]
+	// replicas:
+	// - attrs: [dc1, ssd]
+	// - attrs: [dc2, ssd]
+	// - attrs: [dc3, ssd]
 	// range_min_bytes: 1048576
 	// range_max_bytes: 67108864
 }


### PR DESCRIPTION
Convert to and from YAML for command-line usage only when setting
and getting ZoneConfigs. JSON seems more appropriate for use through
HTTP REST API.

Elide "xxx_unrecognized: []" entries from YAML output via a regexp
search and replace.
