### PR TITLE
Added ability to measure clock offset from cluster

### DIFF
--- a/gossip/client.go
+++ b/gossip/client.go
@@ -65,7 +65,7 @@ func newClient(addr net.Addr) *client {
 // channel. If the client experienced an error, its err field will
 // be set. This method blocks and should be invoked via goroutine.
 func (c *client) start(g *Gossip, done chan *client) {
-	c.rpcClient = rpc.NewClient(c.addr, nil, g.tlsConfig, g.clock)
+	c.rpcClient = rpc.NewClient(c.addr, nil, g.rpcContext)
 	select {
 	case <-c.rpcClient.Ready:
 		// Success!

--- a/gossip/client.go
+++ b/gossip/client.go
@@ -65,7 +65,7 @@ func newClient(addr net.Addr) *client {
 // channel. If the client experienced an error, its err field will
 // be set. This method blocks and should be invoked via goroutine.
 func (c *client) start(g *Gossip, done chan *client) {
-	c.rpcClient = rpc.NewClient(c.addr, nil, g.rpcContext)
+	c.rpcClient = rpc.NewClient(c.addr, nil, g.RPCContext)
 	select {
 	case <-c.rpcClient.Ready:
 		// Success!

--- a/gossip/client_test.go
+++ b/gossip/client_test.go
@@ -38,20 +38,22 @@ func init() {
 func startGossip(t *testing.T) (local, remote *Gossip, lserver, rserver *rpc.Server) {
 	tlsConfig := rpc.LoadInsecureTLSConfig()
 	lclock := hlc.NewClock(hlc.UnixNano)
+	lRPCContext := rpc.NewContext(lclock, tlsConfig)
 
 	laddr := util.CreateTestAddr("unix")
-	lserver = rpc.NewServer(laddr, tlsConfig, lclock)
+	lserver = rpc.NewServer(laddr, lRPCContext)
 	if err := lserver.Start(); err != nil {
 		t.Fatal(err)
 	}
-	local = New(tlsConfig, lclock)
+	local = New(lRPCContext)
 	rclock := hlc.NewClock(hlc.UnixNano)
 	raddr := util.CreateTestAddr("unix")
-	rserver = rpc.NewServer(raddr, tlsConfig, rclock)
+	rRPCContext := rpc.NewContext(rclock, tlsConfig)
+	rserver = rpc.NewServer(raddr, rRPCContext)
 	if err := rserver.Start(); err != nil {
 		t.Fatal(err)
 	}
-	remote = New(tlsConfig, rclock)
+	remote = New(rRPCContext)
 	local.start(lserver)
 	remote.start(rserver)
 	time.Sleep(time.Millisecond)

--- a/gossip/gossip.go
+++ b/gossip/gossip.go
@@ -109,7 +109,7 @@ type Gossip struct {
 	Connected    chan struct{}      // Closed upon initial connection
 	hasConnected bool               // Set first time network is connected
 	isBootstrap  bool               // True if this node is a bootstrap host
-	rpcContext   *rpc.Context       // The context required for RPC
+	RPCContext   *rpc.Context       // The context required for RPC
 	*server                         // Embedded gossip RPC server
 	bootstraps   *addrSet           // Bootstrap host addresses
 	outgoing     *addrSet           // Set of outgoing client addresses
@@ -125,7 +125,7 @@ type Gossip struct {
 func New(rpcContext *rpc.Context) *Gossip {
 	g := &Gossip{
 		Connected:    make(chan struct{}),
-		rpcContext:   rpcContext,
+		RPCContext:   rpcContext,
 		server:       newServer(*GossipInterval),
 		bootstraps:   newAddrSet(MaxPeers),
 		outgoing:     newAddrSet(MaxPeers),
@@ -509,10 +509,4 @@ func (g *Gossip) closeClient(addr net.Addr) {
 		delete(g.clients, addr.String())
 	}
 	g.clientsMu.Unlock()
-}
-
-// RPCContext returns the Gossip's rpc.Context; this is a bit hacky but reduces
-// the number of places we have to pass the context around.
-func (g *Gossip) RPCContext() *rpc.Context {
-	return g.rpcContext
 }

--- a/gossip/gossip.go
+++ b/gossip/gossip.go
@@ -109,7 +109,7 @@ type Gossip struct {
 	Connected    chan struct{}      // Closed upon initial connection
 	hasConnected bool               // Set first time network is connected
 	isBootstrap  bool               // True if this node is a bootstrap host
-	tlsConfig    *rpc.TLSConfig     // Config for RPC TLS
+	rpcContext   *rpc.Context       // The context required for RPC
 	*server                         // Embedded gossip RPC server
 	bootstraps   *addrSet           // Bootstrap host addresses
 	outgoing     *addrSet           // Set of outgoing client addresses
@@ -122,16 +122,15 @@ type Gossip struct {
 }
 
 // New creates an instance of a gossip node.
-func New(tlsConfig *rpc.TLSConfig, clock *hlc.Clock) *Gossip {
+func New(rpcContext *rpc.Context) *Gossip {
 	g := &Gossip{
 		Connected:    make(chan struct{}),
-		tlsConfig:    tlsConfig,
+		rpcContext:   rpcContext,
 		server:       newServer(*GossipInterval),
 		bootstraps:   newAddrSet(MaxPeers),
 		outgoing:     newAddrSet(MaxPeers),
 		clients:      map[string]*client{},
 		disconnected: make(chan *client, MaxPeers),
-		clock:        clock,
 	}
 	g.stalled = sync.NewCond(&g.mu)
 	return g
@@ -512,13 +511,8 @@ func (g *Gossip) closeClient(addr net.Addr) {
 	g.clientsMu.Unlock()
 }
 
-// TLSConfig returns the Gossip's TLS config; this is a bit hacky but reduces
-// the number of places we have to pass the config around.
-func (g *Gossip) TLSConfig() *rpc.TLSConfig {
-	return g.tlsConfig
-}
-
-// Clock returns the Gossip's hybrid logical clock instance.
-func (g *Gossip) Clock() *hlc.Clock {
-	return g.clock
+// RPCContext returns the Gossip's rpc.Context; this is a bit hacky but reduces
+// the number of places we have to pass the context around.
+func (g *Gossip) RPCContext() *rpc.Context {
+	return g.rpcContext
 }

--- a/gossip/gossip_test.go
+++ b/gossip/gossip_test.go
@@ -48,7 +48,8 @@ func TestConvergence(t *testing.T) {
 
 // TestGossipInfoStore verifies operation of gossip instance infostore.
 func TestGossipInfoStore(t *testing.T) {
-	g := New(rpc.LoadInsecureTLSConfig(), hlc.NewClock(hlc.UnixNano))
+	rpcContext := rpc.NewContext(hlc.NewClock(hlc.UnixNano), rpc.LoadInsecureTLSConfig())
+	g := New(rpcContext)
 	g.AddInfo("i", int64(1), time.Hour)
 	if val, err := g.GetInfo("i"); val.(int64) != int64(1) || err != nil {
 		t.Errorf("error fetching int64: %v", err)
@@ -75,7 +76,8 @@ func TestGossipInfoStore(t *testing.T) {
 // TestGossipGroupsInfoStore verifies gossiping of groups via the
 // gossip instance infostore.
 func TestGossipGroupsInfoStore(t *testing.T) {
-	g := New(rpc.LoadInsecureTLSConfig(), hlc.NewClock(hlc.UnixNano))
+	rpcContext := rpc.NewContext(hlc.NewClock(hlc.UnixNano), rpc.LoadInsecureTLSConfig())
+	g := New(rpcContext)
 
 	// For int64.
 	g.RegisterGroup("i", 3, MinGroup)

--- a/gossip/simulation.go
+++ b/gossip/simulation.go
@@ -60,13 +60,14 @@ func NewSimulationNetwork(nodeCount int, networkType string,
 
 	tlsConfig := rpc.LoadInsecureTLSConfig()
 	clock := hlc.NewClock(hlc.UnixNano)
+	rpcContext := rpc.NewContext(clock, tlsConfig)
 
 	log.Infof("simulating gossip network with %d nodes", nodeCount)
 	servers := make([]*rpc.Server, nodeCount)
 	addrs := make([]net.Addr, nodeCount)
 	for i := 0; i < nodeCount; i++ {
 		addr := util.CreateTestAddr(networkType)
-		servers[i] = rpc.NewServer(addr, tlsConfig, clock)
+		servers[i] = rpc.NewServer(addr, rpcContext)
 		if err := servers[i].Start(); err != nil {
 			log.Fatal(err)
 		}
@@ -81,7 +82,7 @@ func NewSimulationNetwork(nodeCount int, networkType string,
 
 	nodes := make([]*SimulationNode, nodeCount)
 	for i := 0; i < nodeCount; i++ {
-		node := New(tlsConfig, clock)
+		node := New(rpcContext)
 		node.Name = fmt.Sprintf("Node%d", i)
 		node.SetBootstrap(bootstrap)
 		node.SetInterval(gossipInterval)

--- a/kv/dist_kv.go
+++ b/kv/dist_kv.go
@@ -251,8 +251,7 @@ func (kv *DistKV) sendRPC(desc *proto.RangeDescriptor, method string, args proto
 		SendNextTimeout: defaultSendNextTimeout,
 		Timeout:         defaultRPCTimeout,
 	}
-	return rpc.Send(argsMap, method, replyChan, rpcOpts,
-		kv.gossip.TLSConfig(), kv.gossip.Clock())
+	return rpc.Send(argsMap, method, replyChan, rpcOpts, kv.gossip.RPCContext())
 }
 
 // ExecuteCmd verifies permissions and looks up the appropriate range

--- a/kv/dist_kv.go
+++ b/kv/dist_kv.go
@@ -251,7 +251,7 @@ func (kv *DistKV) sendRPC(desc *proto.RangeDescriptor, method string, args proto
 		SendNextTimeout: defaultSendNextTimeout,
 		Timeout:         defaultRPCTimeout,
 	}
-	return rpc.Send(argsMap, method, replyChan, rpcOpts, kv.gossip.RPCContext())
+	return rpc.Send(argsMap, method, replyChan, rpcOpts, kv.gossip.RPCContext)
 }
 
 // ExecuteCmd verifies permissions and looks up the appropriate range

--- a/rpc/client.go
+++ b/rpc/client.go
@@ -72,7 +72,7 @@ type Client struct {
 	remoteClocks *RemoteClockMonitor
 }
 
-// RemoteOffset keeps track of this client's estimate of its offset from it's
+// RemoteOffset keeps track of this client's estimate of its offset from a
 // remote server. Error is the maximum error in the reading of this offset, so
 // that the real offset should be in the interval [Offset - Error, Offset
 // + Error]. If the last heartbeat timed out, Offset = InfiniteOffset.

--- a/rpc/client.go
+++ b/rpc/client.go
@@ -61,36 +61,34 @@ type Client struct {
 	Ready  chan struct{} // Closed when client is connected
 	Closed chan struct{} // Closed when connection has closed
 
-	mu          sync.Mutex // Mutex protects the fields below
-	*rpc.Client            // Embedded RPC client
-	addr        net.Addr   // Remote address of client
-	lAddr       net.Addr   // Local address of client
-	healthy     bool
-	closed      bool
-	offset      Offset // Latest measured clock offset from the server
-	clock       *hlc.Clock
+	mu           sync.Mutex // Mutex protects the fields below
+	*rpc.Client             // Embedded RPC client
+	addr         net.Addr   // Remote address of client
+	lAddr        net.Addr   // Local address of client
+	healthy      bool
+	closed       bool
+	offset       RemoteOffset // Latest measured clock offset from the server
+	clock        *hlc.Clock
+	remoteClocks *RemoteClockMonitor
 }
 
-// Offset keeps track of this client's estimate of its offset from it's
-// connected server. Delay is the roundtrip delay in the last offset
-// measurement. The real offset should be in the interval [Offset - Delay/2,
-// Offset + Delay/2]. If the last heartbeat timed out, Offset = InfiniteOffset.
+// RemoteOffset keeps track of this client's estimate of its offset from it's
+// remote server. Error is the maximum error in the reading of this offset, so
+// that the real offset should be in the interval [Offset - Error, Offset
+// + Error]. If the last heartbeat timed out, Offset = InfiniteOffset.
 //
-// Offset and delay are measured as an adaptation of the remote clock reading
-// technique described in
-// https://www.eecis.udel.edu/~mills/ntp/html/warp.html#arch. Note that we
-// don't have the fined grained notion of a "server receive time" and "server
-// send time", but only the time that the server reads before responding to
-// a heartbeat.
-type Offset struct {
-	Offset int64
-	Delay  int64
+// Offset and error are measured using the remote clock reading technique
+// described in http://se.inf.tu-dresden.de/pubs/papers/SRDS1994.pdf, page 6.
+type RemoteOffset struct {
+	Offset     int64 // The estimated offset from the remote server, in nanoseconds.
+	Error      int64 // The maximum error of the measured offset, in nanoseconds.
+	MeasuredAt int64 // Measurement time, in nanoseconds from unix epoch.
 }
 
 // InfiniteOffset is the offset value used if we fail to detect a heartbeat.
-var InfiniteOffset = Offset{
+var InfiniteOffset = RemoteOffset{
 	Offset: math.MaxInt64,
-	Delay:  0,
+	Error:  0,
 }
 
 // NewClient returns a client RPC stub for the specified address
@@ -105,18 +103,18 @@ var InfiniteOffset = Offset{
 // and completed one successful heartbeat. The Closed channel is
 // closed if the client fails to connect or if the client's Close()
 // method is invoked.
-func NewClient(addr net.Addr, opts *util.RetryOptions, tlsConfig *TLSConfig,
-	clock *hlc.Clock) *Client {
+func NewClient(addr net.Addr, opts *util.RetryOptions, context *Context) *Client {
 	clientMu.Lock()
 	if c, ok := clients[addr.String()]; ok {
 		clientMu.Unlock()
 		return c
 	}
 	c := &Client{
-		addr:   addr,
-		Ready:  make(chan struct{}),
-		Closed: make(chan struct{}),
-		clock:  clock,
+		addr:         addr,
+		Ready:        make(chan struct{}),
+		Closed:       make(chan struct{}),
+		clock:        context.localClock,
+		remoteClocks: context.remoteClocks,
 	}
 	clients[c.Addr().String()] = c
 	clientMu.Unlock()
@@ -130,7 +128,7 @@ func NewClient(addr net.Addr, opts *util.RetryOptions, tlsConfig *TLSConfig,
 
 	go func() {
 		err := util.RetryWithBackoff(retryOpts, func() (util.RetryStatus, error) {
-			conn, err := tlsDial(addr.Network(), addr.String(), tlsConfig)
+			conn, err := tlsDial(addr.Network(), addr.String(), context.tlsConfig)
 			if err != nil {
 				log.Info(err)
 				return util.RetryContinue, nil
@@ -194,9 +192,9 @@ func (c *Client) LocalAddr() net.Addr {
 	return c.lAddr
 }
 
-// Offset returns the most recently measured offset of the client clock
-// from the server clock.
-func (c *Client) Offset() Offset {
+// RemoteOffset returns the most recently measured offset of the client clock
+// from the remote server clock.
+func (c *Client) RemoteOffset() RemoteOffset {
 	c.mu.Lock()
 	defer c.mu.Unlock()
 	return c.offset
@@ -236,27 +234,35 @@ func (c *Client) startHeartbeat() {
 
 // heartbeat sends a single heartbeat RPC.
 func (c *Client) heartbeat() error {
+	request := &PingRequest{Offset: c.RemoteOffset(), Addr: c.LocalAddr().String()}
 	response := &PingResponse{}
 	sendTime := c.clock.Now().WallTime
-	call := c.Go("Heartbeat.Ping", &PingRequest{}, response, nil)
+	call := c.Go("Heartbeat.Ping", request, response, nil)
 	select {
 	case <-call.Done:
 		receiveTime := c.clock.Now().WallTime
 		log.V(1).Infof("client %s heartbeat: %v", c.Addr(), call.Error)
 		c.mu.Lock()
 		c.healthy = true
-		c.offset.Offset =
-			(response.ServerTime - sendTime +
-				response.ServerTime - receiveTime) / 2
-		c.offset.Delay = receiveTime - sendTime
+		// TODO(embark) consider max clock drift and min message delivery time
+		// Not including clock drift might decrease accuracy, while not
+		// including min message delivery time might increase the error
+		// estimate.
+		c.offset.Error = (receiveTime - sendTime) / 2
+		remoteTimeNow := response.ServerTime + (receiveTime-sendTime)/2
+		c.offset.Offset = remoteTimeNow - receiveTime
+		c.offset.MeasuredAt = receiveTime
 		c.mu.Unlock()
+		c.remoteClocks.UpdateOffset(c.addr.String(), c.offset)
 		return call.Error
 	case <-time.After(heartbeatInterval * 2):
 		// Allowed twice gossip interval.
 		c.mu.Lock()
 		c.healthy = false
 		c.offset = InfiniteOffset
+		c.offset.MeasuredAt = c.clock.Now().WallTime
 		c.mu.Unlock()
+		c.remoteClocks.UpdateOffset(c.addr.String(), c.offset)
 		log.Warningf("client %s unhealthy after %s", c.Addr(), heartbeatInterval)
 	}
 

--- a/rpc/client_test.go
+++ b/rpc/client_test.go
@@ -123,10 +123,14 @@ func TestOffsetMeasurement(t *testing.T) {
 	if o := c.RemoteOffset(); o != expectedOffset {
 		t.Errorf("expected offset %v, actual %v", expectedOffset, o)
 	}
+
 	// Ensure the offsets map was updated properly too.
+	context.remoteClocks.mu.Lock()
 	if o := context.remoteClocks.offsets[c.addr.String()]; o != expectedOffset {
 		t.Errorf("espected offset %v, actual %v", expectedOffset, o)
 	}
+	context.remoteClocks.mu.Unlock()
+
 	s.Close()
 }
 
@@ -174,10 +178,14 @@ func TestFailedOffestMeasurement(t *testing.T) {
 		t.Errorf("expected offset %v, actual %v",
 			InfiniteOffset, c.RemoteOffset())
 	}
+
 	// Ensure the general offsets map was updated properly too.
+	context.remoteClocks.mu.Lock()
 	if o := context.remoteClocks.offsets[c.addr.String()]; o != InfiniteOffset {
 		t.Errorf("espected offset %v, actual %v", InfiniteOffset, o)
 	}
+	context.remoteClocks.mu.Unlock()
+
 	s.Close()
 }
 

--- a/rpc/clock_offset.go
+++ b/rpc/clock_offset.go
@@ -1,0 +1,190 @@
+// Copyright 2014 The Cockroach Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+// implied. See the License for the specific language governing
+// permissions and limitations under the License. See the AUTHORS file
+// for names of contributors.
+//
+// Author: Kathy Spradlin (kathyspradlin@gmail.com)
+
+package rpc
+
+import (
+	"sort"
+	"sync"
+	"time"
+
+	"github.com/cockroachdb/cockroach/util/log"
+)
+
+// RemoteClockMonitor keeps track of the most recent measurements of remote
+// offsets from this node to connected nodes.
+type RemoteClockMonitor struct {
+	offsets  map[string]RemoteOffset // Maps remote string addr to offset.
+	maxDrift time.Duration           // The max drift of a node in the cluster.
+	mu       sync.Mutex
+}
+
+// ClusterOffsetInterval is the best interval we can construct to estimate this
+// node's offset from the cluster.
+type ClusterOffsetInterval struct {
+	Lowerbound int64 // The lowerbound on the offset in nanoseconds.
+	Upperbound int64 // The upperbound on the offset in nanoseconds.
+}
+
+// endpoint represents an endpoint in the interval estimation of a single
+// remote clock. It could be either the lowpoint or the highpoint of the
+// interval.
+//
+// For example, if the remote clock offset bounds are [-5, 10], then it
+// will be converted into two endpoints:
+// endpoint{offset: -5, endType: -1}
+// endpoint{offset: 10, endType: +1}
+type endpoint struct {
+	offset  int64 // The boundary offset represented by this endpoint.
+	endType int   // -1 if lowpoint, +1 if highpoint.
+}
+
+// endpointList is a slice of endpoints, sorted by endpoint offset.
+type endpointList []endpoint
+
+// Implementation of sort.Interface.
+func (l endpointList) Len() int {
+	return len(l)
+}
+func (l endpointList) Swap(i, j int) {
+	l[i], l[j] = l[j], l[i]
+}
+func (l endpointList) Less(i, j int) bool {
+	if l[i].offset == l[j].offset {
+		return l[i].endType < l[j].endType
+	}
+	return l[i].offset < l[j].offset
+}
+
+// newRemoteClockMonitor returns a monitor with the value of maxDrift, which
+// should be the maximum drift of all nodes in the server's cluster.
+func newRemoteClockMonitor(maxDrift time.Duration) *RemoteClockMonitor {
+	return &RemoteClockMonitor{
+		offsets:  make(map[string]RemoteOffset),
+		maxDrift: maxDrift,
+	}
+}
+
+// UpdateOffset is a thread-safe way to update the remote clock measurements.
+// It only updates if the new measurement is no older than the value currently
+// in the map.
+func (r *RemoteClockMonitor) UpdateOffset(addr string, offset RemoteOffset) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	oldOffset, ok := r.offsets[addr]
+	if !ok {
+		r.offsets[addr] = offset
+	}
+
+	if offset.MeasuredAt >= oldOffset.MeasuredAt {
+		r.offsets[addr] = offset
+	}
+}
+
+// The routine that measures this node's probable offset from the rest of the
+// cluster. This offset is measured as a ClusterOffsetInterval. For example,
+// the output might be [-5, 10], which would indicate that this node's offset
+// is likely between -5 and 10 nanoseconds from the average clock of the
+// cluster.
+//
+// The intersection algorithm used here is documented at:
+// https://www.eecis.udel.edu/~mills/ntp/html/select.html
+// If a remote clock is correct, its offset interval should encompass this
+// clock's offset from the cluster time (see buildEndpointList()).
+// If the majority of remote clock are correct, then their intevals should
+// overlap over some region, which should include the true offset from the
+// cluster time. This algorithm ought to return this region.
+func (r *RemoteClockMonitor) findOffsetInterval() ClusterOffsetInterval {
+	log.Infof("in offsets: %v", r.offsets)
+	endpoints := r.buildEndpointList()
+	sort.Sort(endpoints)
+	log.Infof("endpoints: %v", endpoints)
+	numClocks := len(endpoints) / 2
+	// falsechimers are remote clocks which appear to have too great an offset
+	// from the cluster time. Their offset measurement is probably misleading,
+	// and should be ignored.
+	falsechimers := 0
+	endcount := 0
+	var lowerBound int64
+	var upperBound int64
+	for falsechimers = 0; falsechimers < numClocks/2; falsechimers++ {
+		// Find lowerbound of the interval.
+		endcount = 0
+		for _, endpoint := range endpoints {
+			endcount -= endpoint.endType
+			lowerBound = endpoint.offset
+			if endcount >= numClocks-falsechimers {
+				break
+			}
+		}
+
+		// Find upperbound of the interval.
+		endcount = 0
+		for i := len(endpoints) - 1; i >= 0; i-- {
+			endpoint := endpoints[i]
+			endcount += endpoint.endType
+			upperBound = endpoint.offset
+			if endcount >= numClocks-falsechimers {
+				break
+			}
+		}
+
+		if lowerBound < upperBound {
+			return ClusterOffsetInterval{
+				Lowerbound: lowerBound,
+				Upperbound: upperBound,
+			}
+		}
+	}
+	// TODO(embark): If execution gets to here, that indicates that fewer than
+	// a majority of connected remote clocks seem to encompass the central
+	// time of the cluster. It's not clear what should be done in this case.
+	return ClusterOffsetInterval{}
+}
+
+// buildEndpointList() takes all the RemoteOffsets that are in the monitor, and
+// turns these offsets into intervals which should encompass this node's true
+// offset from the cluster time. It returns a list including the two endpoints
+// of each interval.
+//
+// A RemoteOffset r is represented by this interval:
+// [r.Offset - r.Error - MaxDrift, r.Offset + r.Error + MaxDrift],
+// where MaxDrift is the furthest a node's clock can deviate from the cluster
+// time. While the offset between this node and the remote time is actually
+// within [r.Offset - r.Error, r.Offset + r.Error], we also must expand the
+// interval by MaxDrift. This accounts for the fact that the remote clock is at
+// most MaxDrift distance from the cluster time. Thus the expanded interval
+// ought to contain this node's offset from the true cluster time, not just the
+// offset from the remote clock's time.
+func (r *RemoteClockMonitor) buildEndpointList() endpointList {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	// TODO(embark) Figure out when we need to remove entries from r.offsets.
+	endpoints := make(endpointList, 0, len(r.offsets)*2)
+	for _, o := range r.offsets {
+		lowpoint := endpoint{
+			offset:  o.Offset - o.Error - r.maxDrift.Nanoseconds(),
+			endType: -1,
+		}
+		highpoint := endpoint{
+			offset:  o.Offset + o.Error + r.maxDrift.Nanoseconds(),
+			endType: +1,
+		}
+		endpoints = append(endpoints, lowpoint, highpoint)
+	}
+	return endpoints
+}

--- a/rpc/clock_offset_test.go
+++ b/rpc/clock_offset_test.go
@@ -1,0 +1,122 @@
+// Copyright 2014 The Cockroach Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+// implied. See the License for the specific language governing
+// permissions and limitations under the License. See the AUTHORS file
+// for names of contributors.
+//
+// Author: Kathy Spradlin (kathyspradlin@gmail.com)
+
+package rpc
+
+import (
+	"sort"
+	"testing"
+	"time"
+
+	"github.com/cockroachdb/cockroach/util/log"
+)
+
+func TestEndpointListSort(t *testing.T) {
+	list := endpointList{
+		endpoint{offset: 5, endType: +1},
+		endpoint{offset: 3, endType: -1},
+		endpoint{offset: 3, endType: +1},
+		endpoint{offset: 1, endType: -1},
+		endpoint{offset: 4, endType: +1},
+	}
+
+	sortedList := endpointList{
+		endpoint{offset: 1, endType: -1},
+		endpoint{offset: 3, endType: -1},
+		endpoint{offset: 3, endType: +1},
+		endpoint{offset: 4, endType: +1},
+		endpoint{offset: 5, endType: +1},
+	}
+
+	sort.Sort(list)
+	for i := range sortedList {
+		if list[i] != sortedList[i] {
+			t.Errorf("expected index %d of sorted list to be %v, instead %v",
+				i, sortedList[i], list[i])
+		}
+	}
+
+	if len(list) != len(sortedList) {
+		t.Errorf("exptected endpoint list to be size %d, instead %d",
+			len(sortedList), len(list))
+	}
+}
+
+func TestBuildEndpointList(t *testing.T) {
+	// Build the offsets we will turn into an interval list.
+	offsets := make(map[string]RemoteOffset)
+	offsets["0"] = RemoteOffset{Offset: 0, Error: 10}
+	offsets["1"] = RemoteOffset{Offset: 1, Error: 10}
+	offsets["2"] = RemoteOffset{Offset: 2, Error: 10}
+	offsets["3"] = RemoteOffset{Offset: 3, Error: 10}
+	log.Infof("base offsets: %v", offsets)
+	remoteClocks := &RemoteClockMonitor{
+		offsets:  offsets,
+		maxDrift: 5 * time.Nanosecond,
+	}
+
+	expectedList := endpointList{
+		endpoint{offset: -15, endType: -1},
+		endpoint{offset: -14, endType: -1},
+		endpoint{offset: -13, endType: -1},
+		endpoint{offset: -12, endType: -1},
+		endpoint{offset: 15, endType: 1},
+		endpoint{offset: 16, endType: 1},
+		endpoint{offset: 17, endType: 1},
+		endpoint{offset: 18, endType: 1},
+	}
+
+	list := remoteClocks.buildEndpointList()
+	sort.Sort(list)
+
+	for i := range expectedList {
+		if list[i] != expectedList[i] {
+			t.Errorf("expected index %d of list to be %v, instead %v",
+				i, expectedList[i], list[i])
+		}
+	}
+
+	if len(list) != len(expectedList) {
+		t.Errorf("exptected endpoint list to be size %d, instead %d",
+			len(expectedList), len(list))
+	}
+}
+
+func TestFindOffsetInterval(t *testing.T) {
+	// Build the offsets. We will return the interval that the maximum number
+	// of remote clocks overlap.
+	offsets := make(map[string]RemoteOffset)
+	offsets["0"] = RemoteOffset{Offset: 20, Error: 10}
+	offsets["1"] = RemoteOffset{Offset: 58, Error: 20}
+	offsets["2"] = RemoteOffset{Offset: 71, Error: 25}
+	offsets["3"] = RemoteOffset{Offset: 91, Error: 31}
+	log.Infof("base offsets: %v", offsets)
+	remoteClocks := &RemoteClockMonitor{
+		offsets:  offsets,
+		maxDrift: 0 * time.Second,
+	}
+
+	interval := remoteClocks.findOffsetInterval()
+	expectedInterval := ClusterOffsetInterval{Lowerbound: 60, Upperbound: 78}
+	if interval != expectedInterval {
+		t.Errorf("expected interval %v, instead %v", expectedInterval, interval)
+	}
+}
+
+// TODO(embark): once we figure out what we want to do if there is no interval
+// overlapped by a majority of the remote clock offsets, write tests to
+// encompass such situations.

--- a/rpc/heartbeat.go
+++ b/rpc/heartbeat.go
@@ -20,8 +20,11 @@ package rpc
 import "github.com/cockroachdb/cockroach/util/hlc"
 
 // A PingRequest specifies the string to echo in response.
+// Fields are exported so that they will be serialized in the rpc call.
 type PingRequest struct {
-	Ping string // Echo this string with PingResponse.
+	Ping   string       // Echo this string with PingResponse.
+	Offset RemoteOffset // The last offset the client measured with the server.
+	Addr   string       // The address of the client.
 }
 
 // A PingResponse contains the echoed ping request string.
@@ -33,12 +36,17 @@ type PingResponse struct {
 // A HeartbeatService exposes a method to echo its request params.
 type HeartbeatService struct {
 	// Provides the nanosecond unix epoch timestamp of the processor.
-	clock *hlc.Clock
+	clock              *hlc.Clock
+	remoteClockMonitor *RemoteClockMonitor
 }
 
 // Ping echos the contents of the request to the response.
 func (hs *HeartbeatService) Ping(args *PingRequest, reply *PingResponse) error {
 	reply.Pong = args.Ping
+	serverOffset := args.Offset
+	// The server offset should be the opposite of the client offset.
+	serverOffset.Offset = -serverOffset.Offset
+	hs.remoteClockMonitor.UpdateOffset(args.Addr, serverOffset)
 	reply.ServerTime = hs.clock.Now().WallTime
 	return nil
 }
@@ -46,14 +54,17 @@ func (hs *HeartbeatService) Ping(args *PingRequest, reply *PingResponse) error {
 // A ManualHeartbeatService allows manual control of when heartbeats occur, to
 // facilitate testing.
 type ManualHeartbeatService struct {
-	clock *hlc.Clock
-	ready chan bool // Heartbeats are processed when a value is sent here.
+	clock              *hlc.Clock
+	remoteClockMonitor *RemoteClockMonitor
+	ready              chan bool // Heartbeats are processed when a value is sent here.
 }
 
 // Ping waits until the heartbeat service is ready to respond to a Heartbeat.
 func (mhs *ManualHeartbeatService) Ping(args *PingRequest, reply *PingResponse) error {
 	<-mhs.ready
-	reply.Pong = args.Ping
-	reply.ServerTime = mhs.clock.Now().WallTime
-	return nil
+	hs := HeartbeatService{
+		clock:              mhs.clock,
+		remoteClockMonitor: mhs.remoteClockMonitor,
+	}
+	return hs.Ping(args, reply)
 }

--- a/rpc/heartbeat_test.go
+++ b/rpc/heartbeat_test.go
@@ -1,0 +1,119 @@
+// Copyright 2014 The Cockroach Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+// implied. See the License for the specific language governing
+// permissions and limitations under the License. See the AUTHORS file
+// for names of contributors.
+//
+// Author: Kathy Spradlin (kathyspradlin@gmail.com)
+
+package rpc
+
+import (
+	"net/rpc"
+	"testing"
+
+	"github.com/cockroachdb/cockroach/util"
+	"github.com/cockroachdb/cockroach/util/hlc"
+)
+
+func TestHeartbeatReply(t *testing.T) {
+	manual := hlc.ManualClock(5)
+	clock := hlc.NewClock(manual.UnixNano)
+	heartbeat := &HeartbeatService{
+		clock:              clock,
+		remoteClockMonitor: newRemoteClockMonitor(clock.MaxDrift()),
+	}
+
+	request := &PingRequest{
+		Ping: "testPing",
+	}
+	response := &PingResponse{}
+	heartbeat.Ping(request, response)
+
+	if response.Pong != request.Ping {
+		t.Errorf("expected %s to be equal to %s", response.Pong, request.Ping)
+	}
+
+	if response.ServerTime != 5 {
+		t.Errorf("expected server time 5, instead %d", response.ServerTime)
+	}
+}
+
+func TestManualHeartbeat(t *testing.T) {
+	manual := hlc.ManualClock(5)
+	clock := hlc.NewClock(manual.UnixNano)
+	manualHeartbeat := &ManualHeartbeatService{
+		clock:              clock,
+		remoteClockMonitor: newRemoteClockMonitor(clock.MaxDrift()),
+		ready:              make(chan bool, 1),
+	}
+	regularHeartbeat := &HeartbeatService{
+		clock:              clock,
+		remoteClockMonitor: newRemoteClockMonitor(clock.MaxDrift()),
+	}
+
+	request := &PingRequest{
+		Ping: "testManual",
+	}
+	manualHeartbeat.ready <- true
+	manualResponse := &PingResponse{}
+	regularResponse := &PingResponse{}
+	regularHeartbeat.Ping(request, regularResponse)
+	manualHeartbeat.Ping(request, manualResponse)
+
+	// Ensure that the response is the same as with a normal heartbeat.
+	if manualResponse.Pong != regularResponse.Pong {
+		t.Errorf("expected pong %s, instead %s",
+			manualResponse.Pong, regularResponse.Pong)
+	}
+	if manualResponse.ServerTime != regularResponse.ServerTime {
+		t.Errorf("expected ServerTime %d, instead %d",
+			manualResponse.ServerTime, regularResponse.ServerTime)
+	}
+}
+
+func TestUpdateOffset(t *testing.T) {
+	tlsConfig, err := LoadTestTLSConfig("..")
+	if err != nil {
+		t.Fatal(err)
+	}
+	serverAddr := util.CreateTestAddr("tcp")
+	// Start heartbeat.
+	sContext := NewContext(hlc.NewClock(hlc.UnixNano), tlsConfig)
+	s := NewServer(serverAddr, sContext)
+	if err := s.Start(); err != nil {
+		t.Fatal(err)
+	}
+	conn, err := tlsDial(s.Addr().Network(), s.Addr().String(), tlsConfig)
+	if err != nil {
+		t.Fatal(err)
+	}
+	client := rpc.NewClient(conn)
+
+	clientOffset := RemoteOffset{Offset: 10, Error: 5, MeasuredAt: 20}
+	serverOffset := RemoteOffset{Offset: -10, Error: 5, MeasuredAt: 20}
+	heartbeatRequest := &PingRequest{
+		Offset: clientOffset,
+		Addr:   conn.LocalAddr().String(),
+	}
+	response := &PingResponse{}
+	call := client.Go("Heartbeat.Ping", heartbeatRequest, response, nil)
+	<-call.Done
+	if call.Error != nil {
+		t.Fatal(call.Error)
+	}
+	o := sContext.remoteClocks.offsets[conn.LocalAddr().String()]
+	if o != serverOffset {
+		t.Errorf("expected updated offset %v, instead %v", serverOffset, o)
+	}
+	s.Close()
+}

--- a/rpc/rpc.go
+++ b/rpc/rpc.go
@@ -1,0 +1,19 @@
+package rpc
+
+import "github.com/cockroachdb/cockroach/util/hlc"
+
+// Context contains the fields required by the rpc framework.
+type Context struct {
+	localClock   *hlc.Clock
+	tlsConfig    *TLSConfig
+	remoteClocks *RemoteClockMonitor
+}
+
+// NewContext creates an rpc Context with the supplied values.
+func NewContext(clock *hlc.Clock, config *TLSConfig) *Context {
+	return &Context{
+		localClock:   clock,
+		tlsConfig:    config,
+		remoteClocks: newRemoteClockMonitor(clock.MaxDrift()),
+	}
+}

--- a/rpc/send.go
+++ b/rpc/send.go
@@ -27,7 +27,6 @@ import (
 
 	"github.com/cockroachdb/cockroach/proto"
 	"github.com/cockroachdb/cockroach/util"
-	"github.com/cockroachdb/cockroach/util/hlc"
 	"github.com/cockroachdb/cockroach/util/log"
 )
 
@@ -82,7 +81,7 @@ func (s SendError) CanRetry() bool { return s.canRetry }
 // channel. Send returns an error if the number of errors exceeds the
 // possibility of attaining the required successful responses.
 func Send(argsMap map[net.Addr]interface{}, method string, replyChanI interface{},
-	opts Options, tlsConfig *TLSConfig, clock *hlc.Clock) error {
+	opts Options, context *Context) error {
 	if opts.N < len(argsMap) {
 		return SendError{
 			errMsg:   fmt.Sprintf("insufficient replicas (%d) to satisfy send request of %d", len(argsMap), opts.N),
@@ -93,7 +92,7 @@ func Send(argsMap map[net.Addr]interface{}, method string, replyChanI interface{
 	// Build the slice of clients.
 	var healthy, unhealthy []*Client
 	for addr, args := range argsMap {
-		client := NewClient(addr, nil, tlsConfig, clock)
+		client := NewClient(addr, nil, context)
 		delete(argsMap, addr)
 		argsMap[client.Addr()] = args
 		if client.IsHealthy() {

--- a/server/node_test.go
+++ b/server/node_test.go
@@ -48,11 +48,12 @@ func createTestNode(addr net.Addr, engines []engine.Engine, gossipBS net.Addr, t
 	}
 
 	clock := hlc.NewClock(hlc.UnixNano)
-	rpcServer := rpc.NewServer(addr, tlsConfig, clock)
+	rpcContext := rpc.NewContext(clock, tlsConfig)
+	rpcServer := rpc.NewServer(addr, rpcContext)
 	if err := rpcServer.Start(); err != nil {
 		t.Fatal(err)
 	}
-	g := gossip.New(tlsConfig, clock)
+	g := gossip.New(rpcContext)
 	if gossipBS != nil {
 		// Handle possibility of a :0 port specification.
 		if gossipBS == addr {

--- a/server/server.go
+++ b/server/server.go
@@ -319,8 +319,10 @@ func newServer() (*server, error) {
 	}
 	s.clock.SetMaxDrift(*maxDrift)
 
-	s.rpc = rpc.NewServer(util.MakeRawAddr("tcp", *rpcAddr), tlsConfig, s.clock)
-	s.gossip = gossip.New(tlsConfig, s.clock)
+	rpcContext := rpc.NewContext(s.clock, tlsConfig)
+
+	s.rpc = rpc.NewServer(util.MakeRawAddr("tcp", *rpcAddr), rpcContext)
+	s.gossip = gossip.New(rpcContext)
 	s.kvDB = kv.NewDB(kv.NewDistKV(s.gossip), s.clock)
 	s.kvREST = kv.NewRESTServer(s.kvDB)
 	s.node = NewNode(s.kvDB, s.gossip)

--- a/server/server.go
+++ b/server/server.go
@@ -317,6 +317,8 @@ func newServer() (*server, error) {
 		mux:   http.NewServeMux(),
 		clock: hlc.NewClock(hlc.UnixNano),
 	}
+	// TODO(embark): use rpc/clock_offset.go to periodically test that the
+	// server's clock offset is within maxDrift
 	s.clock.SetMaxDrift(*maxDrift)
 
 	rpcContext := rpc.NewContext(s.clock, tlsConfig)

--- a/storage/range_test.go
+++ b/storage/range_test.go
@@ -94,7 +94,8 @@ func createTestRange(engine engine.Engine, t *testing.T) (*Range, *gossip.Gossip
 		RangeDescriptor: testRangeDescriptor,
 		RangeID:         0,
 	}
-	g := gossip.New(rpc.LoadInsecureTLSConfig(), hlc.NewClock(hlc.UnixNano))
+	rpcContext := rpc.NewContext(hlc.NewClock(hlc.UnixNano), rpc.LoadInsecureTLSConfig())
+	g := gossip.New(rpcContext)
 	clock := hlc.NewClock(hlc.UnixNano)
 	r := NewRange(rm, clock, engine, nil, g, nil)
 	r.Start()


### PR DESCRIPTION
RPC servers and clients now both update a shared map of measured remote offsets.
Servers get this measurement from their attached clients. Servers
are given this ability because they don't always have their own client to the
remote node if that remote node has a client to them.

The server now passes a Context object to the rpc frameworks rather
than passing all 3 required fields individually.

Though the algorithm for measuring cluster offset is now implemented, the server does not yet actively measure cluster offset nor does it do anything with any offset measuring.
