### PR TITLE
Adding ability to read/write Permission Configs and cli to access them

### DIFF
--- a/proto/config.go
+++ b/proto/config.go
@@ -148,17 +148,21 @@ func PermConfigFromYAML(in []byte) (*PermConfig, error) {
 
 var yamlXXXUnrecognizedRE = regexp.MustCompile(` *xxx_unrecognized: \[\]\n?`)
 
+// sanitizeYAML filters lines in the input which match xxx_unrecognized, a
+// truly-annoying public member of proto Message structs, which we
+// cannot specify yaml output tags for.
+// TODO(spencer): there's got to be a better way to do this.
+func sanitizeYAML(b []byte) []byte {
+	return yamlXXXUnrecognizedRE.ReplaceAll(b, []byte{})
+}
+
 // ToYAML serializes a ZoneConfig as YAML.
 func (z *ZoneConfig) ToYAML() ([]byte, error) {
 	b, err := yaml.Marshal(z)
 	if err != nil {
 		return b, err
 	}
-	// Filter out any lines in the input which match xxx_unrecognized, a
-	// truly-annoying public member of proto Message structs, which we
-	// cannot specify yaml output tags for.
-	// TODO(spencer): there's got to be a better way to do this.
-	return yamlXXXUnrecognizedRE.ReplaceAll(b, []byte{}), nil
+	return sanitizeYAML(b), nil
 }
 
 // ToYAML serializes a PermConfig as YAML.
@@ -167,9 +171,5 @@ func (z *PermConfig) ToYAML() ([]byte, error) {
 	if err != nil {
 		return b, err
 	}
-	// Filter out any lines in the input which match xxx_unrecognized, a
-	// truly-annoying public member of proto Message structs, which we
-	// cannot specify yaml output tags for.
-	// TODO(spencer): there's got to be a better way to do this.
-	return yamlXXXUnrecognizedRE.ReplaceAll(b, []byte{}), nil
+	return sanitizeYAML(b), nil
 }

--- a/proto/config.go
+++ b/proto/config.go
@@ -14,6 +14,7 @@
 // for names of contributors.
 //
 // Author: Spencer Kimball (spencer.kimball@gmail.com)
+// Author: Bram Gruneir (bram.gruneir@gmail.com)
 
 package proto
 
@@ -114,8 +115,20 @@ func ZoneConfigFromJSON(in []byte) (*ZoneConfig, error) {
 	return z, err
 }
 
+// PermConfigFromJSON parses a JSON serialized PermConfig.
+func PermConfigFromJSON(in []byte) (*PermConfig, error) {
+	z := &PermConfig{}
+	err := json.Unmarshal(in, z)
+	return z, err
+}
+
 // ToJSON serializes a ZoneConfig as "pretty", indented JSON.
 func (z *ZoneConfig) ToJSON() ([]byte, error) {
+	return json.MarshalIndent(z, "", "  ")
+}
+
+// ToJSON serializes a PermConfig as "pretty", indented JSON.
+func (z *PermConfig) ToJSON() ([]byte, error) {
 	return json.MarshalIndent(z, "", "  ")
 }
 
@@ -126,10 +139,30 @@ func ZoneConfigFromYAML(in []byte) (*ZoneConfig, error) {
 	return z, err
 }
 
+// PermConfigFromYAML parses a YAML serialized PermConfig.
+func PermConfigFromYAML(in []byte) (*PermConfig, error) {
+	z := &PermConfig{}
+	err := yaml.Unmarshal(in, z)
+	return z, err
+}
+
 var yamlXXXUnrecognizedRE = regexp.MustCompile(` *xxx_unrecognized: \[\]\n?`)
 
 // ToYAML serializes a ZoneConfig as YAML.
 func (z *ZoneConfig) ToYAML() ([]byte, error) {
+	b, err := yaml.Marshal(z)
+	if err != nil {
+		return b, err
+	}
+	// Filter out any lines in the input which match xxx_unrecognized, a
+	// truly-annoying public member of proto Message structs, which we
+	// cannot specify yaml output tags for.
+	// TODO(spencer): there's got to be a better way to do this.
+	return yamlXXXUnrecognizedRE.ReplaceAll(b, []byte{}), nil
+}
+
+// ToYAML serializes a PermConfig as YAML.
+func (z *PermConfig) ToYAML() ([]byte, error) {
 	b, err := yaml.Marshal(z)
 	if err != nil {
 		return b, err

--- a/server/permission.go
+++ b/server/permission.go
@@ -32,16 +32,16 @@ import (
 	"github.com/cockroachdb/cockroach/util/log"
 )
 
-// A permissionHandler implements the adminHandler interface
-type permissionHandler struct {
+// A permHandler implements the adminHandler interface
+type permHandler struct {
 	db storage.DB // Key-value database client
 }
 
-// Put writes a permission config for the specified key prefix "key". The
-// permission config is parsed from the input "body". The permission config is
+// Put writes a perm config for the specified key prefix "key". The
+// perm config is parsed from the input "body". The perm config is
 // stored gob-encoded. The specified body must be valid utf8 and must
-// validly parse into a permission config struct.
-func (ph *permissionHandler) Put(path string, body []byte, r *http.Request) error {
+// validly parse into a perm config struct.
+func (ph *permHandler) Put(path string, body []byte, r *http.Request) error {
 	if len(path) == 0 {
 		return util.Errorf("no path specified for permission Put")
 	}
@@ -69,16 +69,16 @@ func (ph *permissionHandler) Put(path string, body []byte, r *http.Request) erro
 	return nil
 }
 
-// Get retrieves the permission configuration for the specified key. If the
-// key is empty, all permission configurations are returned. Otherwise, the
-// leading "/" path delimiter is stripped and the permission configuration
+// Get retrieves the perm configuration for the specified key. If the
+// key is empty, all perm configurations are returned. Otherwise, the
+// leading "/" path delimiter is stripped and the perm configuration
 // matching the remainder is retrieved. Note that this will retrieve
-// the default permission config if "key" is equal to "/", and will list all
+// the default perm config if "key" is equal to "/", and will list all
 // configs if "key" is equal to "". The body result contains
 // JSON-formatted output for a listing of keys and JSON-formatted
-// output for retrieval of a permission config.
-func (ph *permissionHandler) Get(path string, r *http.Request) (body []byte, contentType string, err error) {
-	// Scan all permissions if the key is empty.
+// output for retrieval of a perm config.
+func (ph *permHandler) Get(path string, r *http.Request) (body []byte, contentType string, err error) {
+	// Scan all perms if the key is empty.
 	if len(path) == 0 {
 		sr := <-ph.db.Scan(&proto.ScanRequest{
 			RequestHeader: proto.RequestHeader{
@@ -112,7 +112,7 @@ func (ph *permissionHandler) Get(path string, r *http.Request) (body []byte, con
 		if ok, _, err = storage.GetProto(ph.db, permKey, config); err != nil {
 			return
 		}
-		// On get, if there's no permission config for the requested prefix,
+		// On get, if there's no perm config for the requested prefix,
 		// return a not found error.
 		if !ok {
 			err = util.Errorf("no config found for key prefix %q", path)
@@ -129,14 +129,14 @@ func (ph *permissionHandler) Get(path string, r *http.Request) (body []byte, con
 			// YAML-encode the config.
 			contentType = "text/yaml"
 			if body, err = config.ToYAML(); err != nil {
-				err = util.Errorf("unable to marshal permission config %+v to json: %s", config, err)
+				err = util.Errorf("unable to marshal perm config %+v to json: %s", config, err)
 				return
 			}
 		} else {
 			// JSON-encode the config.
 			contentType = "application/json"
 			if body, err = config.ToJSON(); err != nil {
-				err = util.Errorf("unable to marshal permission config %+v to json: %s", config, err)
+				err = util.Errorf("unable to marshal perm config %+v to json: %s", config, err)
 				return
 			}
 		}
@@ -149,8 +149,8 @@ func (ph *permissionHandler) Get(path string, r *http.Request) (body []byte, con
 	return
 }
 
-// Delete removes the permission config specified by key.
-func (ph *permissionHandler) Delete(path string, r *http.Request) error {
+// Delete removes the perm config specified by key.
+func (ph *permHandler) Delete(path string, r *http.Request) error {
 	if len(path) == 0 {
 		return util.Errorf("no path specified for permission Delete")
 	}

--- a/server/permission.go
+++ b/server/permission.go
@@ -13,7 +13,7 @@
 // permissions and limitations under the License. See the AUTHORS file
 // for names of contributors.
 //
-// Author: Spencer Kimball (spencer.kimball@gmail.com)
+// Author: Bram Gruneir (bram.gruneir@gmail.com)
 
 package server
 
@@ -32,58 +32,58 @@ import (
 	"github.com/cockroachdb/cockroach/util/log"
 )
 
-// A zoneHandler implements the adminHandler interface
-type zoneHandler struct {
+// A permissionHandler implements the adminHandler interface
+type permissionHandler struct {
 	db storage.DB // Key-value database client
 }
 
-// Put writes a zone config for the specified key prefix "key". The
-// zone config is parsed from the input "body". The zone config is
+// Put writes a permission config for the specified key prefix "key". The
+// permission config is parsed from the input "body". The permission config is
 // stored gob-encoded. The specified body must be valid utf8 and must
-// validly parse into a zone config struct.
-func (zh *zoneHandler) Put(path string, body []byte, r *http.Request) error {
+// validly parse into a permission config struct.
+func (ph *permissionHandler) Put(path string, body []byte, r *http.Request) error {
 	if len(path) == 0 {
-		return util.Errorf("no path specified for zone Put")
+		return util.Errorf("no path specified for permission Put")
 	}
 	configStr := string(body)
 	if !utf8.ValidString(configStr) {
 		return util.Errorf("config contents not valid utf8: %q", body)
 	}
 	var err error
-	var config *proto.ZoneConfig
+	var config *proto.PermConfig
 	switch r.Header.Get("Content-Type") {
 	case "application/json", "application/x-json":
-		config, err = proto.ZoneConfigFromJSON(body)
+		config, err = proto.PermConfigFromJSON(body)
 	case "text/yaml", "application/x-yaml":
-		config, err = proto.ZoneConfigFromYAML(body)
+		config, err = proto.PermConfigFromYAML(body)
 	default:
 		err = util.Errorf("invalid content type: %q", r.Header.Get("Content-Type"))
 	}
 	if err != nil {
-		return util.Errorf("zone config has invalid format: %s: %s", configStr, err)
+		return util.Errorf("permission config has invalid format: %s: %s", configStr, err)
 	}
-	zoneKey := engine.MakeKey(engine.KeyConfigZonePrefix, engine.Key(path[1:]))
-	if err := storage.PutProto(zh.db, zoneKey, config, proto.Timestamp{}); err != nil {
+	permKey := engine.MakeKey(engine.KeyConfigPermissionPrefix, engine.Key(path[1:]))
+	if err := storage.PutProto(ph.db, permKey, config, proto.Timestamp{}); err != nil {
 		return err
 	}
 	return nil
 }
 
-// Get retrieves the zone configuration for the specified key. If the
-// key is empty, all zone configurations are returned. Otherwise, the
-// leading "/" path delimiter is stripped and the zone configuration
+// Get retrieves the permission configuration for the specified key. If the
+// key is empty, all permission configurations are returned. Otherwise, the
+// leading "/" path delimiter is stripped and the permission configuration
 // matching the remainder is retrieved. Note that this will retrieve
-// the default zone config if "key" is equal to "/", and will list all
+// the default permission config if "key" is equal to "/", and will list all
 // configs if "key" is equal to "". The body result contains
 // JSON-formatted output for a listing of keys and JSON-formatted
-// output for retrieval of a zone config.
-func (zh *zoneHandler) Get(path string, r *http.Request) (body []byte, contentType string, err error) {
-	// Scan all zones if the key is empty.
+// output for retrieval of a permission config.
+func (ph *permissionHandler) Get(path string, r *http.Request) (body []byte, contentType string, err error) {
+	// Scan all permissions if the key is empty.
 	if len(path) == 0 {
-		sr := <-zh.db.Scan(&proto.ScanRequest{
+		sr := <-ph.db.Scan(&proto.ScanRequest{
 			RequestHeader: proto.RequestHeader{
-				Key:    engine.KeyConfigZonePrefix,
-				EndKey: engine.KeyConfigZonePrefix.PrefixEnd(),
+				Key:    engine.KeyConfigPermissionPrefix,
+				EndKey: engine.KeyConfigPermissionPrefix.PrefixEnd(),
 				User:   storage.UserRoot,
 			},
 			MaxResults: maxGetResults,
@@ -97,22 +97,22 @@ func (zh *zoneHandler) Get(path string, r *http.Request) (body []byte, contentTy
 		}
 		var prefixes []string
 		for _, kv := range sr.Rows {
-			trimmed := bytes.TrimPrefix(kv.Key, engine.KeyConfigZonePrefix)
+			trimmed := bytes.TrimPrefix(kv.Key, engine.KeyConfigPermissionPrefix)
 			prefixes = append(prefixes, url.QueryEscape(string(trimmed)))
 		}
 		// JSON-encode the prefixes array.
 		contentType = "application/json"
 		if body, err = json.Marshal(prefixes); err != nil {
-			err = util.Errorf("unable to format zone configurations: %s", err)
+			err = util.Errorf("unable to format permission configurations: %s", err)
 		}
 	} else {
-		zoneKey := engine.MakeKey(engine.KeyConfigZonePrefix, engine.Key(path[1:]))
+		permKey := engine.MakeKey(engine.KeyConfigPermissionPrefix, engine.Key(path[1:]))
 		var ok bool
-		config := &proto.ZoneConfig{}
-		if ok, _, err = storage.GetProto(zh.db, zoneKey, config); err != nil {
+		config := &proto.PermConfig{}
+		if ok, _, err = storage.GetProto(ph.db, permKey, config); err != nil {
 			return
 		}
-		// On get, if there's no zone config for the requested prefix,
+		// On get, if there's no permission config for the requested prefix,
 		// return a not found error.
 		if !ok {
 			err = util.Errorf("no config found for key prefix %q", path)
@@ -129,14 +129,14 @@ func (zh *zoneHandler) Get(path string, r *http.Request) (body []byte, contentTy
 			// YAML-encode the config.
 			contentType = "text/yaml"
 			if body, err = config.ToYAML(); err != nil {
-				err = util.Errorf("unable to marshal zone config %+v to json: %s", config, err)
+				err = util.Errorf("unable to marshal permission config %+v to json: %s", config, err)
 				return
 			}
 		} else {
 			// JSON-encode the config.
 			contentType = "application/json"
 			if body, err = config.ToJSON(); err != nil {
-				err = util.Errorf("unable to marshal zone config %+v to json: %s", config, err)
+				err = util.Errorf("unable to marshal permission config %+v to json: %s", config, err)
 				return
 			}
 		}
@@ -149,18 +149,18 @@ func (zh *zoneHandler) Get(path string, r *http.Request) (body []byte, contentTy
 	return
 }
 
-// Delete removes the zone config specified by key.
-func (zh *zoneHandler) Delete(path string, r *http.Request) error {
+// Delete removes the permission config specified by key.
+func (ph *permissionHandler) Delete(path string, r *http.Request) error {
 	if len(path) == 0 {
-		return util.Errorf("no path specified for zone Delete")
+		return util.Errorf("no path specified for permission Delete")
 	}
 	if path == "/" {
-		return util.Errorf("the default zone configuration cannot be deleted")
+		return util.Errorf("the default permission configuration cannot be deleted")
 	}
-	zoneKey := engine.MakeKey(engine.KeyConfigZonePrefix, engine.Key(path[1:]))
-	dr := <-zh.db.Delete(&proto.DeleteRequest{
+	permKey := engine.MakeKey(engine.KeyConfigPermissionPrefix, engine.Key(path[1:]))
+	dr := <-ph.db.Delete(&proto.DeleteRequest{
 		RequestHeader: proto.RequestHeader{
-			Key:  zoneKey,
+			Key:  permKey,
 			User: storage.UserRoot,
 		},
 	})

--- a/server/permission_cli.go
+++ b/server/permission_cli.go
@@ -1,0 +1,133 @@
+// Copyright 2014 The Cockroach Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+// implied. See the License for the specific language governing
+// permissions and limitations under the License. See the AUTHORS file
+// for names of contributors.
+//
+// Author: Bram Gruneir (bram.gruneir@gmail.com)
+
+package server
+
+import (
+	"flag"
+
+	commander "code.google.com/p/go-commander"
+)
+
+// A CmdGetPermission command displays the permission config for the specified
+// prefix.
+var CmdGetPermission = &commander.Command{
+	UsageLine: "get-permission [options] <key-prefix>",
+	Short:     "fetches and displays the permission config",
+	Long: `
+Fetches and displays the permission configuration for <key-prefix>. The key
+prefix should be escaped via URL query escaping if it contains
+non-ascii bytes or spaces.
+`,
+	Run:  runGetPermission,
+	Flag: *flag.CommandLine,
+}
+
+// runGetPermission invokes the REST API with GET action and key prefix as path.
+func runGetPermission(cmd *commander.Command, args []string) {
+	runGetConfig(permissionKeyPrefix, cmd, args)
+}
+
+// A CmdLsPermissions command displays a list of permission configs by prefix.
+var CmdLsPermissions = &commander.Command{
+	UsageLine: "ls-permissions [options] [key-regexp]",
+	Short:     "list all permission configs by key prefix",
+	Long: `
+List permission configs. If a regular expression is given, the results of
+the listing are filtered by key prefixes matching the regexp. The key
+prefix should be escaped via URL query escaping if it contains
+non-ascii bytes or spaces.
+`,
+	Run:  runLsPermissions,
+	Flag: *flag.CommandLine,
+}
+
+// runLsPermissions invokes the REST API with GET action and no path, which
+// fetches a list of all permission configuration prefixes. The optional
+// regexp is applied to the complete list and matching prefixes
+// displayed.
+func runLsPermissions(cmd *commander.Command, args []string) {
+	runLsConfigs(permissionKeyPrefix, cmd, args)
+
+}
+
+// A CmdRmPermission command removes a permission config by prefix.
+var CmdRmPermission = &commander.Command{
+	UsageLine: "rm-permission [options] <key-prefix>",
+	Short:     "remove a permission config by key prefix",
+	Long: `
+Remove an existing permission config by key prefix. No action is taken if no
+permission configuration exists for the specified key prefix. Note that this
+command can affect only a single permission config with an exactly matching
+prefix. The key prefix should be escaped via URL query escaping if it
+contains non-ascii bytes or spaces.
+`,
+	Run:  runRmPermission,
+	Flag: *flag.CommandLine,
+}
+
+// runRmPermission invokes the REST API with DELETE action and key prefix as
+// path.
+func runRmPermission(cmd *commander.Command, args []string) {
+	runRmConfig(permissionKeyPrefix, cmd, args)
+}
+
+// A CmdSetPermission command creates a new or updates an existing permission
+// config.
+var CmdSetPermission = &commander.Command{
+	UsageLine: "set-permission [options] <key-prefix> <permission-config-file>",
+	Short:     "create or update permission config for key prefix",
+	Long: `
+Create or update a permission config for the specified key prefix (first
+argument: <key-prefix>) to the contents of the specified file
+(second argument: <permission-config-file>). The key prefix should be
+escaped via URL query escaping if it contains non-ascii bytes or
+spaces.
+
+The permission config format has the following YAML schema:
+
+  read:
+    - user1
+    - user2
+    - ...
+  write:
+  	- user1
+  	- user2
+  	- ...
+
+For example:
+
+  read:
+    - readOnlyUser
+    - readWriteUser
+  write:
+    - readWriteUser
+    - WriteOnlyUser
+
+Setting permission configs will guarantee that users will have permissions for
+this key prefix and all sub prefixes of the one that is set
+`,
+	Run:  runSetPermission,
+	Flag: *flag.CommandLine,
+}
+
+// runSetPermission invokes the REST API with POST action and key prefix as
+// path. The specified configuration file is read from disk and sent
+// as the POST body.
+func runSetPermission(cmd *commander.Command, args []string) {
+	runSetConfig(permissionKeyPrefix, cmd, args)
+}

--- a/server/permission_cli.go
+++ b/server/permission_cli.go
@@ -23,78 +23,78 @@ import (
 	commander "code.google.com/p/go-commander"
 )
 
-// A CmdGetPermission command displays the permission config for the specified
+// A CmdGetPerms command displays the perm config for the specified
 // prefix.
-var CmdGetPermission = &commander.Command{
-	UsageLine: "get-permission [options] <key-prefix>",
+var CmdGetPerms = &commander.Command{
+	UsageLine: "get-perms [options] <key-prefix>",
 	Short:     "fetches and displays the permission config",
 	Long: `
 Fetches and displays the permission configuration for <key-prefix>. The key
 prefix should be escaped via URL query escaping if it contains
 non-ascii bytes or spaces.
 `,
-	Run:  runGetPermission,
+	Run:  runGetPerms,
 	Flag: *flag.CommandLine,
 }
 
-// runGetPermission invokes the REST API with GET action and key prefix as path.
-func runGetPermission(cmd *commander.Command, args []string) {
-	runGetConfig(permissionKeyPrefix, cmd, args)
+// runGetPerms invokes the REST API with GET action and key prefix as path.
+func runGetPerms(cmd *commander.Command, args []string) {
+	runGetConfig(permKeyPrefix, cmd, args)
 }
 
-// A CmdLsPermissions command displays a list of permission configs by prefix.
-var CmdLsPermissions = &commander.Command{
-	UsageLine: "ls-permissions [options] [key-regexp]",
-	Short:     "list all permission configs by key prefix",
+// A CmdLsPerms command displays a list of perm configs by prefix.
+var CmdLsPerms = &commander.Command{
+	UsageLine: "ls-perms [options] [key-regexp]",
+	Short:     "list all permisison configs by key prefix",
 	Long: `
 List permission configs. If a regular expression is given, the results of
 the listing are filtered by key prefixes matching the regexp. The key
 prefix should be escaped via URL query escaping if it contains
 non-ascii bytes or spaces.
 `,
-	Run:  runLsPermissions,
+	Run:  runLsPerms,
 	Flag: *flag.CommandLine,
 }
 
-// runLsPermissions invokes the REST API with GET action and no path, which
-// fetches a list of all permission configuration prefixes. The optional
+// runLsPerms invokes the REST API with GET action and no path, which
+// fetches a list of all perm configuration prefixes. The optional
 // regexp is applied to the complete list and matching prefixes
 // displayed.
-func runLsPermissions(cmd *commander.Command, args []string) {
-	runLsConfigs(permissionKeyPrefix, cmd, args)
+func runLsPerms(cmd *commander.Command, args []string) {
+	runLsConfigs(permKeyPrefix, cmd, args)
 
 }
 
-// A CmdRmPermission command removes a permission config by prefix.
-var CmdRmPermission = &commander.Command{
-	UsageLine: "rm-permission [options] <key-prefix>",
+// A CmdRmPerms command removes a perm config by prefix.
+var CmdRmPerms = &commander.Command{
+	UsageLine: "rm-perms [options] <key-prefix>",
 	Short:     "remove a permission config by key prefix",
 	Long: `
 Remove an existing permission config by key prefix. No action is taken if no
 permission configuration exists for the specified key prefix. Note that this
-command can affect only a single permission config with an exactly matching
+command can affect only a single perm config with an exactly matching
 prefix. The key prefix should be escaped via URL query escaping if it
 contains non-ascii bytes or spaces.
 `,
-	Run:  runRmPermission,
+	Run:  runRmPerms,
 	Flag: *flag.CommandLine,
 }
 
-// runRmPermission invokes the REST API with DELETE action and key prefix as
+// runRmPerms invokes the REST API with DELETE action and key prefix as
 // path.
-func runRmPermission(cmd *commander.Command, args []string) {
-	runRmConfig(permissionKeyPrefix, cmd, args)
+func runRmPerms(cmd *commander.Command, args []string) {
+	runRmConfig(permKeyPrefix, cmd, args)
 }
 
-// A CmdSetPermission command creates a new or updates an existing permission
+// A CmdSetPerms command creates a new or updates an existing perm
 // config.
-var CmdSetPermission = &commander.Command{
-	UsageLine: "set-permission [options] <key-prefix> <permission-config-file>",
+var CmdSetPerms = &commander.Command{
+	UsageLine: "set-perm [options] <key-prefix> <perm-config-file>",
 	Short:     "create or update permission config for key prefix",
 	Long: `
-Create or update a permission config for the specified key prefix (first
+Create or update a perm config for the specified key prefix (first
 argument: <key-prefix>) to the contents of the specified file
-(second argument: <permission-config-file>). The key prefix should be
+(second argument: <perm-config-file>). The key prefix should be
 escaped via URL query escaping if it contains non-ascii bytes or
 spaces.
 
@@ -121,13 +121,16 @@ For example:
 Setting permission configs will guarantee that users will have permissions for
 this key prefix and all sub prefixes of the one that is set
 `,
-	Run:  runSetPermission,
+	Run:  runSetPerms,
 	Flag: *flag.CommandLine,
 }
 
-// runSetPermission invokes the REST API with POST action and key prefix as
+// runSetPerm invokes the REST API with POST action and key prefix as
 // path. The specified configuration file is read from disk and sent
 // as the POST body.
-func runSetPermission(cmd *commander.Command, args []string) {
-	runSetConfig(permissionKeyPrefix, cmd, args)
+func runSetPerms(cmd *commander.Command, args []string) {
+	runSetConfig(permKeyPrefix, cmd, args)
 }
+
+// TODO:(bram) Add inline json for setting
+// TODO:(bram) Add ability to add/remove a single user's read or write permission on a prefix

--- a/server/permission_test.go
+++ b/server/permission_test.go
@@ -1,0 +1,270 @@
+// Copyright 2014 The Cockroach Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+// implied. See the License for the specific language governing
+// permissions and limitations under the License. See the AUTHORS file
+// for names of contributors.
+//
+// Author: Bram Gruneir (bram.gruneir@gmail.com)
+
+package server
+
+import (
+	"bytes"
+	"fmt"
+	"net/http"
+	"net/url"
+	"os"
+
+	"github.com/cockroachdb/cockroach/kv"
+	"github.com/cockroachdb/cockroach/proto"
+	"github.com/cockroachdb/cockroach/storage/engine"
+)
+
+const (
+	testPermissionConfig = `
+read: [readonly, readwrite]
+write: [readwrite, writeonly]
+`
+)
+
+// ExampleSetAndGetPermission sets permission configs for a variety of key
+// prefixes and verifies they can be fetched directly.
+func ExampleSetAndGetPermission() {
+	httpServer := startAdminServer()
+	defer httpServer.Close()
+	testConfigFn := createTestConfigFile(testPermissionConfig)
+	defer os.Remove(testConfigFn)
+
+	testData := []struct {
+		prefix engine.Key
+		yaml   string
+	}{
+		{engine.KeyMin, testPermissionConfig},
+		{engine.Key("db1"), testPermissionConfig},
+		{engine.Key("db 2"), testPermissionConfig},
+		{engine.Key("\xfe"), testPermissionConfig},
+	}
+
+	for _, test := range testData {
+		prefix := url.QueryEscape(string(test.prefix))
+		runSetPermission(CmdSetPermission, []string{prefix, testConfigFn})
+		runGetPermission(CmdGetPermission, []string{prefix})
+	}
+	// Output:
+	// set permission config for key prefix ""
+	// permission config for key prefix "":
+	// read:
+	// - readonly
+	// - readwrite
+	// write:
+	// - readwrite
+	// - writeonly
+	//
+	// set permission config for key prefix "db1"
+	// permission config for key prefix "db1":
+	// read:
+	// - readonly
+	// - readwrite
+	// write:
+	// - readwrite
+	// - writeonly
+	//
+	// set permission config for key prefix "db+2"
+	// permission config for key prefix "db+2":
+	// read:
+	// - readonly
+	// - readwrite
+	// write:
+	// - readwrite
+	// - writeonly
+	//
+	// set permission config for key prefix "%FE"
+	// permission config for key prefix "%FE":
+	// read:
+	// - readonly
+	// - readwrite
+	// write:
+	// - readwrite
+	// - writeonly
+}
+
+// ExampleLsPermissions creates a series of permission configs and verifies
+// permission-ls works. First, no regexp lists all permission configs. Second,
+// regexp properly matches results.
+func ExampleLsPermissions() {
+	httpServer := startAdminServer()
+	defer httpServer.Close()
+	testConfigFn := createTestConfigFile(testPermissionConfig)
+	defer os.Remove(testConfigFn)
+
+	keys := []engine.Key{
+		engine.KeyMin,
+		engine.Key("db1"),
+		engine.Key("db2"),
+		engine.Key("db3"),
+		engine.Key("user"),
+	}
+
+	regexps := []string{
+		"",
+		"db*",
+		"db[12]",
+	}
+
+	for _, key := range keys {
+		prefix := url.QueryEscape(string(key))
+		runSetPermission(CmdSetPermission, []string{prefix, testConfigFn})
+	}
+
+	for i, regexp := range regexps {
+		fmt.Fprintf(os.Stdout, "test case %d: %q\n", i, regexp)
+		if regexp == "" {
+			runLsPermissions(CmdLsPermissions, []string{})
+		} else {
+			runLsPermissions(CmdLsPermissions, []string{regexp})
+		}
+	}
+	// Output:
+	// set permission config for key prefix ""
+	// set permission config for key prefix "db1"
+	// set permission config for key prefix "db2"
+	// set permission config for key prefix "db3"
+	// set permission config for key prefix "user"
+	// test case 0: ""
+	// [default]
+	// db1
+	// db2
+	// db3
+	// user
+	// test case 1: "db*"
+	// db1
+	// db2
+	// db3
+	// test case 2: "db[12]"
+	// db1
+	// db2
+}
+
+// ExampleRmPermissions creates a series of permisison configs and verifies
+// permission-rm works by deleting some and then all and verifying entries
+// have been removed via permission-ls. Also verify the default perission cannot
+// be removed.
+func ExampleRmPermissions() {
+	httpServer := startAdminServer()
+	defer httpServer.Close()
+	testConfigFn := createTestConfigFile(testPermissionConfig)
+	defer os.Remove(testConfigFn)
+
+	keys := []engine.Key{
+		engine.KeyMin,
+		engine.Key("db1"),
+	}
+
+	for _, key := range keys {
+		prefix := url.QueryEscape(string(key))
+		runSetPermission(CmdSetPermission, []string{prefix, testConfigFn})
+	}
+
+	for _, key := range keys {
+		prefix := url.QueryEscape(string(key))
+		runRmPermission(CmdRmPermission, []string{prefix})
+		runLsPermissions(CmdLsPermissions, []string{})
+	}
+	// Output:
+	// set permission config for key prefix ""
+	// set permission config for key prefix "db1"
+	// [default]
+	// db1
+	// removed permission config for key prefix "db1"
+	// [default]
+}
+
+// ExamplePermissionContentTypes verifies that the Accept header can be used
+// to control the format of the response and the Content-Type header
+// can be used to specify the format of the request.
+func ExamplePermissionContentTypes() {
+	httpServer := startAdminServer()
+	defer httpServer.Close()
+
+	config, err := proto.PermConfigFromYAML([]byte(testPermissionConfig))
+	if err != nil {
+		fmt.Println(err)
+	}
+	testCases := []struct {
+		contentType, accept string
+	}{
+		{"application/json", "application/json"},
+		{"text/yaml", "application/json"},
+		{"application/json", "text/yaml"},
+		{"text/yaml", "text/yaml"},
+	}
+	for i, test := range testCases {
+		key := fmt.Sprintf("/test%d", i)
+
+		var body []byte
+		if test.contentType == "application/json" {
+			if body, err = config.ToJSON(); err != nil {
+				fmt.Println(err)
+			}
+		} else {
+			if body, err = config.ToYAML(); err != nil {
+				fmt.Println(err)
+			}
+		}
+		req, err := http.NewRequest("POST", kv.HTTPAddr()+permissionKeyPrefix+key, bytes.NewReader(body))
+		req.Header.Add("Content-Type", test.contentType)
+		if _, err = sendAdminRequest(req); err != nil {
+			fmt.Println(err)
+		}
+
+		req, err = http.NewRequest("GET", kv.HTTPAddr()+permissionKeyPrefix+key, nil)
+		req.Header.Add("Accept", test.accept)
+		if body, err = sendAdminRequest(req); err != nil {
+			fmt.Println(err)
+		}
+		fmt.Println(string(body))
+	}
+	// Output:
+	// {
+	//   "Read": [
+	//     "readonly",
+	//     "readwrite"
+	//   ],
+	//   "Write": [
+	//     "readwrite",
+	//     "writeonly"
+	//   ]
+	// }
+	// {
+	//   "Read": [
+	//     "readonly",
+	//     "readwrite"
+	//   ],
+	//   "Write": [
+	//     "readwrite",
+	//     "writeonly"
+	//   ]
+	// }
+	// read:
+	// - readonly
+	// - readwrite
+	// write:
+	// - readwrite
+	// - writeonly
+	//
+	// read:
+	// - readonly
+	// - readwrite
+	// write:
+	// - readwrite
+	// - writeonly
+}

--- a/server/server_cli.go
+++ b/server/server_cli.go
@@ -56,7 +56,7 @@ func getFriendlyNameFromPrefix(prefix string) string {
 	switch prefix {
 	case zoneKeyPrefix:
 		return "zone"
-	case permissionKeyPrefix:
+	case permKeyPrefix:
 		return "permission"
 	default:
 		return "unknown"

--- a/server/server_cli.go
+++ b/server/server_cli.go
@@ -1,0 +1,187 @@
+// Copyright 2014 The Cockroach Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+// implied. See the License for the specific language governing
+// permissions and limitations under the License. See the AUTHORS file
+// for names of contributors.
+//
+// Author: Bram Gruneir (bram.gruneir@gmail.com)
+
+package server
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"io/ioutil"
+	"net/http"
+	"net/url"
+	"os"
+	"regexp"
+
+	commander "code.google.com/p/go-commander"
+	"github.com/cockroachdb/cockroach/kv"
+	"github.com/cockroachdb/cockroach/util"
+	"github.com/cockroachdb/cockroach/util/log"
+)
+
+// sendAdminRequest send an HTTP request and processes the response for
+// its body or error message if a non-200 response code.
+func sendAdminRequest(req *http.Request) ([]byte, error) {
+	resp, err := http.DefaultClient.Do(req)
+	defer resp.Body.Close()
+	if err != nil {
+		return nil, util.Errorf("admin REST request failed: %s", err)
+	}
+	b, err := ioutil.ReadAll(resp.Body)
+	if err != nil {
+		return nil, util.Errorf("unable to read admin REST response: %s", err)
+	}
+	if resp.StatusCode != 200 {
+		return nil, util.Errorf("%s: %s", resp.Status, string(b))
+	}
+	return b, nil
+}
+
+// Gets a friendly name for output based on the passed in config prefix.
+func getFriendlyNameFromPrefix(prefix string) string {
+	switch prefix {
+	case zoneKeyPrefix:
+		return "zone"
+	case permissionKeyPrefix:
+		return "permission"
+	default:
+		return "unknown"
+	}
+}
+
+// runGetConfig invokes the REST API with GET action and key prefix as path.
+func runGetConfig(prefix string, cmd *commander.Command, args []string) {
+	if len(args) != 1 {
+		cmd.Usage()
+		return
+	}
+	friendlyName := getFriendlyNameFromPrefix(prefix)
+	req, err := http.NewRequest("GET", kv.HTTPAddr()+prefix+"/"+args[0], nil)
+	req.Header.Add("Accept", "text/yaml")
+	if err != nil {
+		log.Errorf("unable to create request to admin REST endpoint: %s", err)
+		return
+	}
+	// TODO(spencer): need to move to SSL.
+	b, err := sendAdminRequest(req)
+	if err != nil {
+		log.Errorf("admin REST request failed: %s", err)
+		return
+	}
+	fmt.Fprintf(os.Stdout, "%s config for key prefix %q:\n%s\n", friendlyName, args[0], string(b))
+}
+
+// runLsConfigs invokes the REST API with GET action and no path, which
+// fetches a list of all configuration prefixes.
+// The type of config that is listed is based on the passed in prefix.
+// The optional regexp is applied to the complete list and matching prefixes
+// displayed.
+func runLsConfigs(prefix string, cmd *commander.Command, args []string) {
+	if len(args) > 1 {
+		cmd.Usage()
+		return
+	}
+	friendlyName := getFriendlyNameFromPrefix(prefix)
+	req, err := http.NewRequest("GET", kv.HTTPAddr()+prefix, nil)
+	if err != nil {
+		log.Errorf("unable to create request to admin REST endpoint: %s", err)
+		return
+	}
+	b, err := sendAdminRequest(req)
+	if err != nil {
+		log.Errorf("admin REST request failed: %s", err)
+		return
+	}
+	var prefixes []string
+	if err = json.Unmarshal(b, &prefixes); err != nil {
+		log.Errorf("unable to parse admin REST response: %s", err)
+		return
+	}
+	var re *regexp.Regexp
+	if len(args) == 1 {
+		if re, err = regexp.Compile(args[0]); err != nil {
+			log.Warningf("invalid regular expression %q; skipping regexp match and listing all %s prefixes", args[0], friendlyName)
+			re = nil
+		}
+	}
+	for _, prefix := range prefixes {
+		if re != nil {
+			unescaped, err := url.QueryUnescape(prefix)
+			if err != nil || !re.MatchString(unescaped) {
+				continue
+			}
+		}
+		if prefix == "" {
+			prefix = "[default]"
+		}
+		fmt.Fprintf(os.Stdout, "%s\n", prefix)
+	}
+}
+
+// runRmConfig invokes the REST API with DELETE action and key prefix as path.
+// The type of config that is removed is based on the passed in prefix.
+func runRmConfig(prefix string, cmd *commander.Command, args []string) {
+	if len(args) != 1 {
+		cmd.Usage()
+		return
+	}
+	friendlyName := getFriendlyNameFromPrefix(prefix)
+	req, err := http.NewRequest("DELETE", kv.HTTPAddr()+prefix+"/"+args[0], nil)
+	if err != nil {
+		log.Errorf("unable to create request to admin REST endpoint: %s", err)
+		return
+	}
+	// TODO(spencer): need to move to SSL.
+	_, err = sendAdminRequest(req)
+	if err != nil {
+		log.Errorf("admin REST request failed: %s", err)
+		return
+	}
+	fmt.Fprintf(os.Stdout, "removed %s config for key prefix %q\n", friendlyName, args[0])
+}
+
+// runSetConfig invokes the REST API with POST action and key prefix as
+// path. The specified configuration file is read from disk and sent
+// as the POST body.
+// The type of config that is set is based on the passed in prefix.
+func runSetConfig(prefix string, cmd *commander.Command, args []string) {
+	if len(args) != 2 {
+		cmd.Usage()
+		return
+	}
+	friendlyName := getFriendlyNameFromPrefix(prefix)
+	// Read in the config file.
+	body, err := ioutil.ReadFile(args[1])
+	if err != nil {
+		log.Errorf("unable to read %s config file %q: %s", friendlyName, args[1], err)
+		return
+	}
+	// Send to admin REST API.
+	req, err := http.NewRequest("POST", kv.HTTPAddr()+prefix+"/"+args[0], bytes.NewReader(body))
+	req.Header.Add("Content-Type", "text/yaml")
+	if err != nil {
+		log.Errorf("unable to create request to admin REST endpoint: %s", err)
+		return
+	}
+	// TODO(spencer): need to move to SSL.
+	_, err = sendAdminRequest(req)
+	if err != nil {
+		log.Errorf("admin REST request failed: %s", err)
+		return
+	}
+	fmt.Fprintf(os.Stdout, "set %s config for key prefix %q\n", friendlyName, args[0])
+}

--- a/server/server_test.go
+++ b/server/server_test.go
@@ -68,6 +68,20 @@ func startServer() *server {
 	return s
 }
 
+// createTestConfigFile creates a temporary file and writes the
+// testConfig yaml data to it. The caller is responsible for
+// removing it. Returns the filename for a subsequent call to
+// os.Remove().
+func createTestConfigFile(body string) string {
+	f, err := ioutil.TempFile("", "test-config")
+	if err != nil {
+		log.Fatalf("failed to open temporary file: %v", err)
+	}
+	defer f.Close()
+	f.Write([]byte(body))
+	return f.Name()
+}
+
 // createTempDirs creates "count" temporary directories and returns
 // the paths to each as a slice.
 func createTempDirs(count int, t *testing.T) []string {


### PR DESCRIPTION
- Added the ability to set/list/remove permission configurations from prefixes.
- Most of this was a mimic of what Spencer wrote for the zone configurations.
- Also consolidated some of the repeated code where I could.

Once this is merged, I'll create a similar treatment for Accounting Configurations.
