### PR TITLE
Replace existing gob-based merge impl with proto-based impl.

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -77,3 +77,8 @@
   distributed transaction.
 
 * Cleanup proto files to adhere to proto capitalization instead of go's.
+
+* Replace the usage of the rocksdb C interface with the C++
+  interface. This will both avoid some overhead present in the C
+  interface (various memory allocations) as well as allow us to use
+  more convenient C++ notation for various bits of functionality.

--- a/roachlib/Makefile
+++ b/roachlib/Makefile
@@ -17,7 +17,7 @@
 # Author: Andrew Bonventre (andybons@gmail.com)
 
 ROACH_LIB := libroach.a
-SOURCES   := compaction.cc
+SOURCES   := compaction.cc merge.cc
 OBJECTS   := $(SOURCES:.cc=.o)
 
 CXXFLAGS += -std=c++11 -I../proto/lib -I../_vendor/rocksdb/include

--- a/roachlib/compaction.cc
+++ b/roachlib/compaction.cc
@@ -15,7 +15,7 @@
 //
 // Author: Spencer Kimball (spencer.kimball@gmail.com)
 
-// Style settings: indent -kr -ci2 -cli2 -i2 -l80 -nut storage/rocksdb_compaction.cc
+// Style settings: indent -kr -ci2 -cli2 -i2 -l80 -nut roachlib/compaction.cc
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>             // For memcpy

--- a/roachlib/merge.cc
+++ b/roachlib/merge.cc
@@ -1,0 +1,143 @@
+// Copyright 2014 The Cockroach Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+// implied.  See the License for the specific language governing
+// permissions and limitations under the License. See the AUTHORS file
+// for names of contributors.
+//
+// Author: Peter Mattis (peter.mattis@gmail.com)
+
+// Style settings: indent -kr -ci2 -cli2 -i2 -l80 -nut roachlib/merge.cc
+
+#include <string>
+#include <limits>
+#include "data.pb.h"
+#include "rocksdb/slice.h"
+#include "roach_c.h"
+
+namespace {
+
+bool WillOverflow(int64_t a, int64_t b) {
+  // Morally MinInt64 < a+b < MaxInt64, but without overflows.
+  // First make sure that a <= b. If not, swap them.
+  if (a > b) {
+    std::swap(a, b);
+  }
+  // Now b is the larger of the numbers, and we compare sizes
+  // in a way that can never over- or underflow.
+  if (b > 0) {
+    return a > (std::numeric_limits<int64_t>::max() - b);
+  }
+  return (std::numeric_limits<int64_t>::min() - b) > a;
+}
+
+bool MergeValues(proto::Value *left, const proto::Value &right) {
+  printf("MergeValues left=%d,%d right=%d,%d\n",
+         int(left->has_bytes()), int(left->has_integer()),
+         int(right.has_bytes()), int(right.has_integer()));
+  if (left->has_bytes()) {
+    if (right.has_bytes()) {
+      *left->mutable_bytes() += right.bytes();
+      return true;
+    }
+  } else if (left->has_integer()) {
+    if (right.has_integer()) {
+      if (WillOverflow(left->integer(), right.integer())) {
+        return false;
+      }
+      left->set_integer(left->integer() + right.integer());
+      return true;
+    }
+  } else {
+    *left = right;
+    return true;
+  }
+  return false;
+}
+
+char* MergeResult(const proto::Value& result, size_t *length) {
+  *length = result.ByteSize();
+  char *value = static_cast<char*>(malloc(*length));
+  if (!result.SerializeToArray(value, *length)) {
+    return NULL;
+  }
+  return value;
+}
+
+}  // namespace
+
+char* MergeOne(
+    const char* existing, size_t existing_length,
+    const char* update, size_t update_length,
+    size_t* new_value_length, char** error_msg) {
+  proto::Value result;
+  if (!result.ParseFromArray(existing, existing_length)) {
+    // Corrupted existing value.
+    *error_msg = (char*)"corrupted existing value";
+    return NULL;
+  }
+
+  proto::Value value;
+  if (!value.ParseFromArray(update, update_length)) {
+    // Corrupted update value.
+    *error_msg = (char*)"corrupted update value";
+    return NULL;
+  }
+
+  if (!MergeValues(&result, value)) {
+    *error_msg = (char*)"incompatible merge values";
+    return NULL;
+  }
+
+  char *new_value = MergeResult(result, new_value_length);
+  if (!new_value) {
+    *error_msg = (char*)"serialization error";
+    return NULL;
+  }
+  return new_value;
+}
+
+char* MergeOperator(
+    const char* key, size_t key_length,
+    const char* existing_value,
+    size_t existing_value_length,
+    const char* const* operands_list,
+    const size_t* operands_list_length,
+    int num_operands, unsigned char* success,
+    size_t* new_value_length)
+{
+  *success = false;
+
+  proto::Value result;
+  if (!result.ParseFromArray(existing_value, existing_value_length)) {
+    // Corrupted existing value.
+    return NULL;
+  }
+
+  for (int i = 0; i < num_operands; ++i) {
+    proto::Value value;
+    if (!value.ParseFromArray(operands_list[i], operands_list_length[i])) {
+      // Corrupted operand.
+      return NULL;
+    }
+    if (!MergeValues(&result, value)) {
+      // Invalid merge operation.
+      return NULL;
+    }
+  }
+
+  char *new_value = MergeResult(result, new_value_length);
+  if (!new_value) {
+    return NULL;
+  }
+  *success = true;
+  return new_value;
+}

--- a/roachlib/merge.cc
+++ b/roachlib/merge.cc
@@ -126,6 +126,23 @@ char* MergeOperator(
     int num_operands, unsigned char* success,
     size_t* new_value_length)
 {
+  // TODO(pmattis): Taken from the old merger code, below are some
+  // details about how errors returned by the merge operator are
+  // handled. Need to test various error scenarios and decide on
+  // desired behavior. Clear the key and it's gone. Corrupt it
+  // properly and RocksDB might refuse to work with it at all until
+  // you clear it manually, which may also not be what we want. The
+  // problem with merges is that RocksDB won't really carry them out
+  // while we have a chance to talk back to clients.
+  //
+  // If we indicate failure (*success = false), then the call to the
+  // merger via rocksdb_merge will not return an error, but simply
+  // remove or truncate the offending key (at least when the settings
+  // specify that missing keys should be created; otherwise a
+  // corruption error will be returned, but likely only after the next
+  // read of the key). In effect, there is no propagation of error
+  // information to the client.
+
   // TODO(pmattis): We should not be silent about errors. It's
   // currently irritating to get them logged in Go, but we should get
   // it fixed up so that such logging from C++ is straightforward.

--- a/roachlib/merge.cc
+++ b/roachlib/merge.cc
@@ -84,6 +84,8 @@ char* MergeOne(
     const char* existing, size_t existing_length,
     const char* update, size_t update_length,
     size_t* new_value_length, char** error_msg) {
+  *new_value_length = 0;
+
   proto::Value result;
   if (!result.ParseFromArray(existing, existing_length)) {
     // Corrupted existing value.
@@ -128,6 +130,7 @@ char* MergeOperator(
   // currently irritating to get them logged in Go, but we should get
   // it fixed up so that such logging from C++ is straightforward.
   *success = false;
+  *new_value_length = 0;
 
   proto::Value result;
   if (!result.ParseFromArray(existing_value, existing_value_length)) {

--- a/roachlib/roach_c.h
+++ b/roachlib/roach_c.h
@@ -15,7 +15,14 @@
 //
 // Author: Spencer Kimball (spencer.kimball@gmail.com)
 
+#ifndef ROACHLIB_ROACH_C_H
+#define ROACHLIB_ROACH_C_H
+
 #include "rocksdb/c.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
 
 struct FilterState {
   // The key prefix identifying transaction records.
@@ -30,10 +37,6 @@ struct FilterState {
   int64_t min_rcache_ts;
 };
 
-#ifdef __cplusplus
-extern "C" {
-#endif
-
 unsigned char GCCompactionFilter(
     void* state, int level, const char* key,
     size_t key_length,
@@ -43,6 +46,21 @@ unsigned char GCCompactionFilter(
     unsigned char* value_changed,
     char** error_msg);
 
+char* MergeOne(
+    const char* existing, size_t existing_length,
+    const char* update, size_t update_length,
+    size_t* new_value_length, char** error_msg);
+char* MergeOperator(
+    const char* key, size_t key_length,
+    const char* existing_value,
+    size_t existing_value_length,
+    const char* const* operands_list,
+    const size_t* operands_list_length,
+    int num_operands, unsigned char* success,
+    size_t* new_value_length);
+
 #ifdef __cplusplus
-}
+}  // extern "C"
 #endif
+
+#endif // ROACHLIB_ROACH_C_H

--- a/storage/engine/engine_test.go
+++ b/storage/engine/engine_test.go
@@ -31,7 +31,6 @@ import (
 
 	"github.com/cockroachdb/cockroach/proto"
 	"github.com/cockroachdb/cockroach/util"
-	"github.com/cockroachdb/cockroach/util/encoding"
 )
 
 func ensureRangeEqual(t *testing.T, sortedKeys []string, keyMap map[string][]byte, keyvals []proto.RawKeyValue) {
@@ -129,29 +128,29 @@ func TestEngineBatch(t *testing.T) {
 		key := Key("a")
 		// Those are randomized below.
 		batch := []interface{}{
-			BatchPut{proto.RawKeyValue{Key: key, Value: []byte("~ockroachDB")}},
-			BatchPut{proto.RawKeyValue{Key: key, Value: []byte("C~ckroachDB")}},
-			BatchPut{proto.RawKeyValue{Key: key, Value: []byte("Co~kroachDB")}},
-			BatchPut{proto.RawKeyValue{Key: key, Value: []byte("Coc~roachDB")}},
-			BatchPut{proto.RawKeyValue{Key: key, Value: []byte("Cock~oachDB")}},
-			BatchPut{proto.RawKeyValue{Key: key, Value: []byte("Cockr~achDB")}},
-			BatchPut{proto.RawKeyValue{Key: key, Value: []byte("Cockro~chDB")}},
-			BatchPut{proto.RawKeyValue{Key: key, Value: []byte("Cockroa~hDB")}},
-			BatchPut{proto.RawKeyValue{Key: key, Value: []byte("Cockroac~DB")}},
-			BatchPut{proto.RawKeyValue{Key: key, Value: []byte("Cockroach~B")}},
-			BatchPut{proto.RawKeyValue{Key: key, Value: []byte("CockroachD~")}},
+			BatchPut{proto.RawKeyValue{Key: key, Value: appender("~ockroachDB")}},
+			BatchPut{proto.RawKeyValue{Key: key, Value: appender("C~ckroachDB")}},
+			BatchPut{proto.RawKeyValue{Key: key, Value: appender("Co~kroachDB")}},
+			BatchPut{proto.RawKeyValue{Key: key, Value: appender("Coc~roachDB")}},
+			BatchPut{proto.RawKeyValue{Key: key, Value: appender("Cock~oachDB")}},
+			BatchPut{proto.RawKeyValue{Key: key, Value: appender("Cockr~achDB")}},
+			BatchPut{proto.RawKeyValue{Key: key, Value: appender("Cockro~chDB")}},
+			BatchPut{proto.RawKeyValue{Key: key, Value: appender("Cockroa~hDB")}},
+			BatchPut{proto.RawKeyValue{Key: key, Value: appender("Cockroac~DB")}},
+			BatchPut{proto.RawKeyValue{Key: key, Value: appender("Cockroach~B")}},
+			BatchPut{proto.RawKeyValue{Key: key, Value: appender("CockroachD~")}},
 			BatchDelete{proto.RawKeyValue{Key: key}},
-			BatchMerge{proto.RawKeyValue{Key: key, Value: encoding.MustGobEncode(Appender("C"))}},
-			BatchMerge{proto.RawKeyValue{Key: key, Value: encoding.MustGobEncode(Appender(" o"))}},
-			BatchMerge{proto.RawKeyValue{Key: key, Value: encoding.MustGobEncode(Appender("  c"))}},
-			BatchMerge{proto.RawKeyValue{Key: key, Value: encoding.MustGobEncode(Appender(" k"))}},
-			BatchMerge{proto.RawKeyValue{Key: key, Value: encoding.MustGobEncode(Appender("r"))}},
-			BatchMerge{proto.RawKeyValue{Key: key, Value: encoding.MustGobEncode(Appender(" o"))}},
-			BatchMerge{proto.RawKeyValue{Key: key, Value: encoding.MustGobEncode(Appender("  a"))}},
-			BatchMerge{proto.RawKeyValue{Key: key, Value: encoding.MustGobEncode(Appender(" c"))}},
-			BatchMerge{proto.RawKeyValue{Key: key, Value: encoding.MustGobEncode(Appender("h"))}},
-			BatchMerge{proto.RawKeyValue{Key: key, Value: encoding.MustGobEncode(Appender(" D"))}},
-			BatchMerge{proto.RawKeyValue{Key: key, Value: encoding.MustGobEncode(Appender("  B"))}},
+			BatchMerge{proto.RawKeyValue{Key: key, Value: appender("C")}},
+			BatchMerge{proto.RawKeyValue{Key: key, Value: appender(" o")}},
+			BatchMerge{proto.RawKeyValue{Key: key, Value: appender("  c")}},
+			BatchMerge{proto.RawKeyValue{Key: key, Value: appender(" k")}},
+			BatchMerge{proto.RawKeyValue{Key: key, Value: appender("r")}},
+			BatchMerge{proto.RawKeyValue{Key: key, Value: appender(" o")}},
+			BatchMerge{proto.RawKeyValue{Key: key, Value: appender("  a")}},
+			BatchMerge{proto.RawKeyValue{Key: key, Value: appender(" c")}},
+			BatchMerge{proto.RawKeyValue{Key: key, Value: appender("h")}},
+			BatchMerge{proto.RawKeyValue{Key: key, Value: appender(" D")}},
+			BatchMerge{proto.RawKeyValue{Key: key, Value: appender("  B")}},
 		}
 
 		for i := 0; i < numShuffles; i++ {
@@ -164,7 +163,7 @@ func TestEngineBatch(t *testing.T) {
 			// Reset the key
 			engine.Clear(key)
 			// Run it once with individual operations and remember the result.
-			for _, op := range currentBatch {
+			for i, op := range currentBatch {
 				if err := engine.WriteBatch([]interface{}{op}); err != nil {
 					t.Errorf("batch test: %d: op %v: %v", i, op, err)
 					continue
@@ -256,9 +255,9 @@ func TestEngineMerge(t *testing.T) {
 	runWithAllEngines(func(engine Engine, t *testing.T) {
 		testKey := Key("haste not in life")
 		merges := [][]byte{
-			[]byte(encoding.MustGobEncode(Appender("x"))),
-			[]byte(encoding.MustGobEncode(Appender("y"))),
-			[]byte(encoding.MustGobEncode(Appender("z"))),
+			appender("x"),
+			appender("y"),
+			appender("z"),
 		}
 		for i, update := range merges {
 			if err := engine.Merge(testKey, update); err != nil {
@@ -266,7 +265,7 @@ func TestEngineMerge(t *testing.T) {
 			}
 		}
 		result, _ := engine.Get(testKey)
-		if !bytes.Equal(encoding.MustGobDecode(result).(Appender), Appender("xyz")) {
+		if !bytes.Equal(result, appender("xyz")) {
 			t.Errorf("unexpected append-merge result")
 		}
 	}, t)

--- a/storage/engine/merge.go
+++ b/storage/engine/merge.go
@@ -14,135 +14,34 @@
 // for names of contributors.
 //
 // Author: Tobias Schottdorf (tobias.schottdorf@gmail.com)
+// Author: Peter Mattis (peter.mattis@gmail.com)
 
 package engine
 
 // #include <stdlib.h>
+// #include "roach_c.h"
 import "C"
 import (
-	"encoding/gob"
-	"reflect"
 	"unsafe"
 
 	"github.com/cockroachdb/cockroach/util"
-	"github.com/cockroachdb/cockroach/util/encoding"
 )
 
-func init() {
-	gob.Register(Counter(0))
-	gob.Register(Appender(nil))
-}
-
-// Mergable types specify two operations:
-// 1) Init, used to generate a default value to use as an existing
-// value for an update that needs to be carried out on a key that
-// could not be decoded into a Mergable of the corresponding type,
-// for instance when the base key is not initialized.
-//
-// 2) Merge, the operation which maps the existing value and the
-// update to a new Mergable. If the merge operation signals an
-// error, that error is propagated to the underlying engine.
-type Mergable interface {
-	Init([]byte) Mergable
-	Merge(Mergable) (Mergable, error)
-}
-
-// A Counter is a mergable data type that stores an int64 and
-// implements a merge operation that increments the counter.
-// It is initially zero.
-type Counter int64
-
-// Init returns a Counter with value 0 as a Mergable.
-func (n Counter) Init(s []byte) Mergable {
-	return Counter(0)
-}
-
-// Merge updates the value of this Counter with the supplied
-// update and returns an error in case of an integer overflow.
-func (n Counter) Merge(o Mergable) (Mergable, error) {
-	m, ok := o.(Counter)
-	if !ok {
-		return n, util.Error("parameter is of wrong type")
-	}
-	if encoding.WillOverflow(int64(n), int64(m)) {
-		return n, util.Errorf("merge error: %d + %d overflows", n, m)
-	}
-	result := Counter(n + m)
-	return result, nil
-}
-
-// An Appender is a mergable data type initializing to an empty
-// byte slice and using concatenation as the merge operation.
-type Appender []byte
-
-// Init returns an Appender storing the empty string.
-func (s Appender) Init(t []byte) Mergable {
-	return Appender(nil)
-}
-
-// Merge appends the input value to the string and returns the result.
-func (s Appender) Merge(t Mergable) (Mergable, error) {
-	m, ok := t.(Appender)
-	if !ok {
-		return s, util.Error("parameter is of wrong type")
-	}
-	return append(s, m...), nil
-}
-
-// goMerge takes existing and update byte slices. It first attempts
-// to gob-unmarshal the update string, returning an error on failure.
-// The unmarshaled value must satisfy the Mergable interface.
-// Next, it unmarshals the existing string, falling back to the init
-// value supplied by the update value's Init() method if necessary.
-// The two values obtained in this way are merged and the result, or
-// an error, returned.
+// goMerge takes existing and update byte slices that are expected to
+// be marshalled proto.Values and merges the two values returning a
+// marshalled proto.Value or an error.
 func goMerge(existing, update []byte) ([]byte, error) {
-	// TODO(pmattis): This should almost certainly not be using gob for
-	// encoding as gob has overhead each time it sends a new type over a
-	// "connection" and the usage here is creating a new "connection"
-	// per value stored. Better to use a proto with optional Counter and
-	// Appender fields.
-	u, err := encoding.GobDecode(update)
-	if err != nil {
-		return nil, util.Errorf("merge: %v", err)
+	var cValLen C.size_t
+	var cErr *C.char
+	cVal := C.MergeOne(
+		bytesPointer(existing), C.size_t(len(existing)),
+		bytesPointer(update), C.size_t(len(update)),
+		&cValLen, &cErr)
+	if cErr != nil {
+		return nil, util.ErrorSkipFrames(0, C.GoString(cErr))
 	}
-	if _, ok := u.(Mergable); !ok {
-		return nil, util.Error("update is not Mergable")
+	if cVal != nil {
+		defer C.free(unsafe.Pointer(cVal))
 	}
-	e, err := encoding.GobDecode(existing)
-	if err != nil {
-		e = u.(Mergable).Init(existing)
-	}
-	if reflect.TypeOf(u) != reflect.TypeOf(e) {
-		return nil, util.Error("cannot merge values of different type")
-	}
-	newValue, err := e.(Mergable).Merge(u.(Mergable))
-	if err != nil {
-		return nil, err
-	}
-	return encoding.GobEncode(newValue)
-}
-
-//export mergeInit
-// mergeInit returns a C string that the C glue code will use as existing
-// value if NULL is encountered.
-// The return value is not garbage collected.
-func mergeInit(a *C.char, aLen C.size_t) (*C.char, C.size_t) {
-	// As it stands we don't even need to allocate an empty string.
-	return nil, 0
-}
-
-//export merge
-// merge is a wrapper around goMerge, returning the result
-// as a non-garbage collected C string.
-// It is used by C code in this package.
-func merge(a, b *C.char, aLen, bLen C.size_t) (*C.char, C.size_t) {
-	result, err := goMerge(C.GoBytes(unsafe.Pointer(a), C.int(aLen)),
-		C.GoBytes(unsafe.Pointer(b), C.int(bLen)))
-	if err != nil {
-		return nil, 0
-	}
-	// As above, the first return value will have to be manually freed
-	// by the receiver.
-	return C.CString(string(result)), C.size_t(len(result))
+	return C.GoBytes(unsafe.Pointer(cVal), C.int(cValLen)), nil
 }

--- a/storage/engine/merge.go
+++ b/storage/engine/merge.go
@@ -38,7 +38,8 @@ func goMerge(existing, update []byte) ([]byte, error) {
 		bytesPointer(update), C.size_t(len(update)),
 		&cValLen, &cErr)
 	if cErr != nil {
-		return nil, util.ErrorSkipFrames(0, C.GoString(cErr))
+		return nil, util.Errorf("%s: existing=%q, update=%q",
+			C.GoString(cErr), existing, update)
 	}
 	if cVal != nil {
 		defer C.free(unsafe.Pointer(cVal))


### PR DESCRIPTION
Merging now takes fully in C/C++ land with no callback to Go. Mildly
less flexible, but the the proto encoding is much more compact than the
gob encoding.
