### PR TITLE
Added MVCC stats.

### DIFF
--- a/proto/data.proto
+++ b/proto/data.proto
@@ -149,5 +149,12 @@ message Transaction {
 // MVCCMetadata holds MVCC metadata for a key. Used by storage/engine/mvcc.go.
 message MVCCMetadata {
   optional Transaction txn = 1;
+  // The timestamp of the most recent versioned value.
   optional Timestamp timestamp = 2 [(gogoproto.nullable) = false];
+  // Is the most recent value a deletion tombstone?
+  optional bool deleted = 3 [(gogoproto.nullable) = false];
+  // The size in bytes of the most recent encoded key.
+  optional int64 key_bytes = 4 [(gogoproto.nullable) = false];
+  // The size in bytes of the most recent versioned value.
+  optional int64 val_bytes = 5 [(gogoproto.nullable) = false];
 }

--- a/storage/engine/batch_test.go
+++ b/storage/engine/batch_test.go
@@ -22,6 +22,7 @@ import (
 	"reflect"
 	"testing"
 
+	gogoproto "code.google.com/p/gogoprotobuf/proto"
 	"github.com/cockroachdb/cockroach/proto"
 	"github.com/cockroachdb/cockroach/util/encoding"
 )
@@ -184,8 +185,19 @@ func TestBatchProto(t *testing.T) {
 	kv := &proto.RawKeyValue{Key: Key("a"), Value: []byte("value")}
 	b.PutProto(Key("proto"), kv)
 	getKV := &proto.RawKeyValue{}
-	if ok, err := b.GetProto(Key("proto"), getKV); !ok || err != nil {
+	ok, kSize, vSize, err := b.GetProto(Key("proto"), getKV)
+	if !ok || err != nil {
 		t.Fatalf("expected GetProto to success ok=%t: %s", ok, err)
+	}
+	if kSize != 5 {
+		t.Errorf("expected key size 5; got %d", kSize)
+	}
+	var data []byte
+	if data, err = gogoproto.Marshal(kv); err != nil {
+		t.Fatal(err)
+	}
+	if vSize != int64(len(data)) {
+		t.Errorf("expected value size %d; got %d", len(data), vSize)
 	}
 	if !reflect.DeepEqual(getKV, kv) {
 		t.Errorf("expected %v; got %v", kv, getKV)

--- a/storage/engine/engine.go
+++ b/storage/engine/engine.go
@@ -242,12 +242,14 @@ func ClearRange(engine Engine, start, end Key, max int64) (int, error) {
 	return numElements, nil
 }
 
-// iterateRange scans the given key range using the underlying engine in blocks
-// of at most chunkSize results, invoking f for each chunk read, until there
-// are no more results. An error is returned if an underlying scan returns an
-// error, or if f does. The read is executed using the specified snapshotID,
-// which is assumed to be valid and managed by the caller.
-func iterateRangeSnapshot(eng Engine, startKey, endKey Key, chunkSize int64, snapshotID string, f func([]proto.RawKeyValue) error) error {
+// iterateRange scans the given key range using the underlying engine
+// in blocks of at most chunkSize results, invoking f for each chunk
+// read, until there are no more results. An error is returned if an
+// underlying scan returns an error, or if f does. The read is
+// executed against a snapshot if the specified snapshotID is
+// non-empty.
+func iterateRange(eng Engine, startKey, endKey Key, chunkSize int64,
+	snapshotID string, f func([]proto.RawKeyValue) error) error {
 	var kvs []proto.RawKeyValue
 	var err error
 	hasSnap := len(snapshotID) > 0

--- a/storage/engine/mvcc.go
+++ b/storage/engine/mvcc.go
@@ -32,27 +32,31 @@ import (
 const (
 	// The size of the reservoir used by FindSplitKey.
 	splitReservoirSize = 100
-	// How many keys are read at once when scanning for a split key.
-	splitScanRowCount = int64(1 << 8)
+	// How many keys are read at once when scanning for a split key
+	// or recomputing MVCC stats.
+	scanRowCount = int64(1 << 8)
 )
+
+// MVCCStats tracks byte and instance counts for:
+//  - Live key/values (i.e. what a scan at current time will reveal;
+//    note that this includes intent keys and values, but not keys and
+//    values with most recent value deleted)
+//  - Key bytes (includes all keys, even those with most recent value deleted)
+//  - Value bytes (includes all versions)
+//  - Key count (count of all keys, including keys with deleted tombstones)
+//  - Value count (all versions, including deleted tombstones)
+//  - Intents (provisional values written during txns)
+type MVCCStats struct {
+	LiveBytes, KeyBytes, ValBytes, IntentBytes int64
+	LiveCount, KeyCount, ValCount, IntentCount int64
+}
 
 // MVCC wraps the mvcc operations of a key/value store. MVCC instances
 // are instantiated with a Batch object, meant to carry out a single
 // operation and commit the results to the underlying engine atomically.
-//
-// TODO(spencer): add prefix for storing counter values for:
-//  - bytes added as intent values
-//  - bytes added as keys
-//  - bytes added as non-intent values (either no txn or resolved)
-//  - bytes aborted (think of an intent deleted)
-//  - versions added
-//  - versions deleted
-//  - keys added
-//  - bytes GCd
-//  - versions GCd
-//  - keys GCd
 type MVCC struct {
 	batch *Batch
+	MVCCStats
 }
 
 // NewMVCC returns a new instance of MVCC, wrapping batch.
@@ -112,14 +116,14 @@ func (mvcc *MVCC) PutProto(key Key, timestamp proto.Timestamp, txn *proto.Transa
 func (mvcc *MVCC) Get(key Key, timestamp proto.Timestamp, txn *proto.Transaction) (*proto.Value, error) {
 	binKey := key.Encode(nil)
 	meta := &proto.MVCCMetadata{}
-	ok, err := mvcc.batch.GetProto(binKey, meta)
+	ok, _, _, err := mvcc.batch.GetProto(binKey, meta)
 	if err != nil || !ok {
 		return nil, err
 	}
 	// If the read timestamp is greater than the latest one, we can just
 	// fetch the value without a scan.
 	ts := proto.Timestamp{}
-	var valBytes []byte
+	var ValBytes []byte
 	var isValue bool
 
 	// Always read latest value in the event the txns match.
@@ -135,26 +139,26 @@ func (mvcc *MVCC) Get(key Key, timestamp proto.Timestamp, txn *proto.Transaction
 		// txn was restarted and an earlier iteration wrote the value
 		// we're now reading. In this case, we skip the intent.
 		if meta.Txn != nil && txn.Epoch != meta.Txn.Epoch {
-			valBytes, ts, isValue, err = mvcc.scanNextVersion(latestKey.Next(), Key(binKey).PrefixEnd())
+			ValBytes, ts, isValue, err = mvcc.scanNextVersion(latestKey.Next(), Key(binKey).PrefixEnd())
 		} else {
-			valBytes, err = mvcc.batch.Get(latestKey)
+			ValBytes, err = mvcc.batch.Get(latestKey)
 			ts = meta.Timestamp
 			isValue = true
 		}
 	} else {
 		nextKey := mvccEncodeKey(binKey, timestamp)
-		valBytes, ts, isValue, err = mvcc.scanNextVersion(nextKey, Key(binKey).PrefixEnd())
+		ValBytes, ts, isValue, err = mvcc.scanNextVersion(nextKey, Key(binKey).PrefixEnd())
 	}
-	if valBytes == nil || err != nil {
+	if ValBytes == nil || err != nil {
 		return nil, err
 	}
 	if !isValue {
-		return nil, util.Errorf("expected scan to versioned value reading key %q: %s", key, valBytes)
+		return nil, util.Errorf("expected scan to versioned value reading key %q: %s", key, ValBytes)
 	}
 
 	// Unmarshal the mvcc value.
 	value := &proto.MVCCValue{}
-	if err := gogoproto.Unmarshal(valBytes, value); err != nil {
+	if err := gogoproto.Unmarshal(ValBytes, value); err != nil {
 		return nil, err
 	}
 	// Set the timestamp if the value is not nil (i.e. not a deletion tombstone).
@@ -209,11 +213,12 @@ func (mvcc *MVCC) putInternal(key Key, timestamp proto.Timestamp, value proto.MV
 	}
 
 	meta := &proto.MVCCMetadata{}
-	ok, err := mvcc.batch.GetProto(binKey, meta)
+	ok, oKey, oVal, err := mvcc.batch.GetProto(binKey, meta)
 	if err != nil {
 		return err
 	}
 
+	var newMeta *proto.MVCCMetadata
 	// In case the key metadata exists.
 	if ok {
 		// There is an uncommitted write intent and the current Put
@@ -233,10 +238,7 @@ func (mvcc *MVCC) putInternal(key Key, timestamp proto.Timestamp, value proto.MV
 			if meta.Txn != nil && !timestamp.Equal(meta.Timestamp) {
 				mvcc.batch.Clear(mvccEncodeKey(binKey, meta.Timestamp))
 			}
-			meta = &proto.MVCCMetadata{Txn: txn, Timestamp: timestamp}
-			if err := mvcc.batch.PutProto(binKey, meta); err != nil {
-				return err
-			}
+			newMeta = &proto.MVCCMetadata{Txn: txn, Timestamp: timestamp}
 		} else if timestamp.Less(meta.Timestamp) && meta.Txn == nil {
 			// If we receive a Put request to write before an already-
 			// committed version, send write tool old error.
@@ -246,11 +248,13 @@ func (mvcc *MVCC) putInternal(key Key, timestamp proto.Timestamp, value proto.MV
 			return nil
 		}
 	} else { // In case the key metadata does not exist yet.
-		// Create key metadata.
-		meta = &proto.MVCCMetadata{Txn: txn, Timestamp: timestamp}
-		if err := mvcc.batch.PutProto(binKey, meta); err != nil {
-			return err
+		// If this is a delete, do nothing!
+		if value.Deleted {
+			return nil
 		}
+		// Create key metadata.
+		meta = nil
+		newMeta = &proto.MVCCMetadata{Txn: txn, Timestamp: timestamp}
 	}
 
 	// Make sure to zero the redundant timestamp (timestamp is encoded
@@ -258,7 +262,24 @@ func (mvcc *MVCC) putInternal(key Key, timestamp proto.Timestamp, value proto.MV
 	if value.Value != nil {
 		value.Value.Timestamp = nil
 	}
-	return mvcc.batch.PutProto(mvccEncodeKey(binKey, timestamp), &value)
+	vKey, vVal, err := mvcc.batch.PutProto(mvccEncodeKey(binKey, timestamp), &value)
+	if err != nil {
+		return err
+	}
+
+	// Write the mvcc metadata now that we have sizes for the latest versioned value.
+	newMeta.KeyBytes = vKey
+	newMeta.ValBytes = vVal
+	newMeta.Deleted = value.Deleted
+	mKey, mVal, err := mvcc.batch.PutProto(binKey, newMeta)
+	if err != nil {
+		return err
+	}
+
+	// Update MVCC stats.
+	mvcc.updateStatsOnPut(oKey, oVal, mKey, mVal, meta, newMeta)
+
+	return nil
 }
 
 // Increment fetches the value for key, and assuming the value is
@@ -412,7 +433,7 @@ func (mvcc *MVCC) Scan(key Key, endKey Key, max int64, timestamp proto.Timestamp
 	return res, nil
 }
 
-// MVCCResolveWriteIntent either commits or aborts (rolls back) an
+// ResolveWriteIntent either commits or aborts (rolls back) an
 // extant write intent for a given txn according to commit parameter.
 // ResolveWriteIntent will skip write intents of other txns.
 //
@@ -439,7 +460,7 @@ func (mvcc *MVCC) ResolveWriteIntent(key Key, txn *proto.Transaction) error {
 
 	binKey := key.Encode(nil)
 	meta := &proto.MVCCMetadata{}
-	ok, err := mvcc.batch.GetProto(binKey, meta)
+	ok, oKey, oVal, err := mvcc.batch.GetProto(binKey, meta)
 	if err != nil {
 		return err
 	}
@@ -458,13 +479,21 @@ func (mvcc *MVCC) ResolveWriteIntent(key Key, txn *proto.Transaction) error {
 	pushed := txn.Status == proto.PENDING && meta.Txn.Timestamp.Less(txn.Timestamp)
 	if (commit || pushed) && meta.Txn.Epoch == txn.Epoch {
 		origTimestamp := meta.Timestamp
-		var metaTxn *proto.Transaction
+		newMeta := *meta
+		newMeta.Timestamp = txn.Timestamp
 		if pushed { // keep intent if we're pushing timestamp
-			metaTxn = txn
+			newMeta.Txn = txn
+		} else {
+			newMeta.Txn = nil
 		}
-		if err := mvcc.batch.PutProto(binKey, &proto.MVCCMetadata{Timestamp: txn.Timestamp, Txn: metaTxn}); err != nil {
+		mKey, mVal, err := mvcc.batch.PutProto(binKey, &newMeta)
+		if err != nil {
 			return err
 		}
+
+		// Update stat counters related to resolving the intent.
+		mvcc.updateStatsOnResolve(oKey, oVal, mKey, mVal, &newMeta, commit)
+
 		// If timestamp of value changed, need to rewrite versioned value.
 		// TODO(spencer,tobias): think about a new merge operator for
 		// updating key of intent value to new timestamp instead of
@@ -472,12 +501,12 @@ func (mvcc *MVCC) ResolveWriteIntent(key Key, txn *proto.Transaction) error {
 		if !origTimestamp.Equal(txn.Timestamp) {
 			origKey := mvccEncodeKey(binKey, origTimestamp)
 			newKey := mvccEncodeKey(binKey, txn.Timestamp)
-			valBytes, err := mvcc.batch.Get(origKey)
+			ValBytes, err := mvcc.batch.Get(origKey)
 			if err != nil {
 				return err
 			}
 			mvcc.batch.Clear(origKey)
-			mvcc.batch.Put(newKey, valBytes)
+			mvcc.batch.Put(newKey, ValBytes)
 		}
 		return nil
 	}
@@ -508,15 +537,33 @@ func (mvcc *MVCC) ResolveWriteIntent(key Key, txn *proto.Transaction) error {
 	// If there is no other version, we should just clean up the key entirely.
 	if len(kvs) == 0 {
 		mvcc.batch.Clear(binKey)
+		// Clear stat counters attributable to the intent we're aborting.
+		mvcc.updateStatsOnAbort(oKey, oVal, 0, 0, meta, nil)
 	} else {
 		_, ts, isValue := mvccDecodeKey(kvs[0].Key)
 		if !isValue {
 			return util.Errorf("expected an MVCC value key: %s", kvs[0].Key)
 		}
+		// Get the bytes for the next version so we have size for stat counts.
+		value := proto.MVCCValue{}
+		ok, vKey, vVal, err := mvcc.batch.GetProto(kvs[0].Key, &value)
+		if err != nil || !ok {
+			return util.Errorf("unable to fetch previous version for key %q (%t): %s", kvs[0].Key, ok, err)
+		}
 		// Update the keyMetadata with the next version.
-		if err := mvcc.batch.PutProto(binKey, &proto.MVCCMetadata{Timestamp: ts}); err != nil {
+		newMeta := &proto.MVCCMetadata{
+			Timestamp: ts,
+			Deleted:   value.Deleted,
+			KeyBytes:  vKey,
+			ValBytes:  vVal,
+		}
+		mKey, mVal, err := mvcc.batch.PutProto(binKey, newMeta)
+		if err != nil {
 			return err
 		}
+
+		// Update stat counters with older version.
+		mvcc.updateStatsOnAbort(oKey, oVal, mKey, mVal, meta, newMeta)
 	}
 
 	return nil
@@ -581,7 +628,7 @@ type splitSampleItem struct {
 // operate on a snapshot of the underlying engine if a snapshotID is
 // given, and in that case may safely be invoked in a goroutine.
 // TODO(Tobias): leverage the work done here anyways to gather stats.
-func MVCCFindSplitKey(engine Engine, key Key, endKey Key, snapshotID string) (Key, error) {
+func MVCCFindSplitKey(engine Engine, key, endKey Key, snapshotID string) (Key, error) {
 	rs := util.NewWeightedReservoirSample(splitReservoirSize, nil)
 	h := rs.Heap.(*util.WeightedValueHeap)
 
@@ -592,8 +639,8 @@ func MVCCFindSplitKey(engine Engine, key Key, endKey Key, snapshotID string) (Ke
 	binStartKey := key.Encode(nil)
 	binEndKey := endKey.Encode(nil)
 	totalSize := 0
-	err := iterateRangeSnapshot(engine, binStartKey, binEndKey,
-		splitScanRowCount, snapshotID, func(kvs []proto.RawKeyValue) error {
+	err := iterateRange(engine, binStartKey, binEndKey,
+		scanRowCount, snapshotID, func(kvs []proto.RawKeyValue) error {
 			for _, kv := range kvs {
 				byteCount := len(kv.Key) + len(kv.Value)
 				rs.ConsiderWeighted(splitSampleItem{kv.Key, totalSize}, float64(byteCount)/normalize)
@@ -631,6 +678,156 @@ func MVCCFindSplitKey(engine Engine, key Key, endKey Key, snapshotID string) (Ke
 		return nil, util.Errorf("corrupt key encountered")
 	}
 	return humanKey, nil
+}
+
+// MVCCComputeStats scans the underlying engine from start to end keys
+// and computes stats counters based on the values. This method is used
+// after a range is split to recompute stats for each subrange.
+func MVCCComputeStats(engine Engine, key, endKey Key) (MVCCStats, error) {
+	binStartKey := key.Encode(nil)
+	binEndKey := endKey.Encode(nil)
+
+	ms := MVCCStats{}
+	first := false
+	meta := &proto.MVCCMetadata{}
+	err := iterateRange(engine, binStartKey, binEndKey,
+		scanRowCount, "", func(kvs []proto.RawKeyValue) error {
+			for _, kv := range kvs {
+				_, _, isValue := mvccDecodeKey(kv.Key)
+				if !isValue {
+					first = true
+					if err := gogoproto.Unmarshal(kv.Value, meta); err != nil {
+						return util.Errorf("unable to unmarshal MVCC metadata %q: %s", kv.Value, err)
+					}
+					if !meta.Deleted {
+						ms.LiveBytes += int64(len(kv.Value)) + int64(len(kv.Key))
+						ms.LiveCount++
+					}
+					ms.KeyBytes += int64(len(kv.Key))
+					ms.ValBytes += int64(len(kv.Value))
+					ms.KeyCount++
+				} else {
+					if first {
+						first = false
+						if !meta.Deleted {
+							ms.LiveBytes += int64(len(kv.Value)) + int64(len(kv.Key))
+						}
+						if meta.Txn != nil {
+							ms.IntentBytes += int64(len(kv.Key)) + int64(len(kv.Value))
+							ms.IntentCount++
+						}
+						if meta.KeyBytes != int64(len(kv.Key)) {
+							return util.Errorf("expected mvcc metadata key bytes to equal %d; got %d", len(kv.Key), meta.KeyBytes)
+						}
+						if meta.ValBytes != int64(len(kv.Value)) {
+							return util.Errorf("expected mvcc metadata val bytes to equal %d; got %d", len(kv.Value), meta.ValBytes)
+						}
+					}
+					ms.KeyBytes += int64(len(kv.Key))
+					ms.ValBytes += int64(len(kv.Value))
+					ms.ValCount++
+				}
+			}
+			return nil
+		})
+	return ms, err
+}
+
+// updateStatsOnPut updates stat counters for a newly put value,
+// including both the metadata key & value bytes and the mvcc
+// versioned value's key & value bytes. If the value is not a
+// deletion tombstone, updates the live stat counters as well.
+// If this value is an intent, updates the intent counters.
+func (mvcc *MVCC) updateStatsOnPut(oKey, oVal, mKey, mVal int64, orig, meta *proto.MVCCMetadata) {
+	// Remove current live counts for this key.
+	if orig != nil {
+		// If original version value for this key wasn't deleted, subtract
+		// its contribution from live bytes in anticipation of adding in
+		// contribution from new version below.
+		if !orig.Deleted {
+			mvcc.LiveBytes -= (orig.KeyBytes + orig.ValBytes + oKey + oVal)
+			mvcc.LiveCount--
+		}
+		mvcc.KeyBytes -= oKey
+		mvcc.ValBytes -= oVal
+		mvcc.KeyCount--
+		// If the original metadata for this key was an intent, subtract
+		// its contribution from stat counters as it's being replaced.
+		if orig.Txn != nil {
+			// Subtract counts attributable to intent we're replacing.
+			mvcc.KeyBytes -= orig.KeyBytes
+			mvcc.ValBytes -= orig.ValBytes
+			mvcc.ValCount--
+			mvcc.IntentBytes -= (orig.KeyBytes + orig.ValBytes)
+			mvcc.IntentCount--
+		}
+	}
+
+	// If new version isn't a deletion tombstone, add it to live counters.
+	if !meta.Deleted {
+		mvcc.LiveBytes += meta.KeyBytes + meta.ValBytes + mKey + mVal
+		mvcc.LiveCount++
+	}
+	mvcc.KeyBytes += meta.KeyBytes + mKey
+	mvcc.ValBytes += meta.ValBytes + mVal
+	mvcc.KeyCount++
+	mvcc.ValCount++
+	if meta.Txn != nil {
+		mvcc.IntentBytes += meta.KeyBytes + meta.ValBytes
+		mvcc.IntentCount++
+	}
+}
+
+// updateStatsOnResolve updates stat counters with the difference
+// between the original and new metadata sizes. The size of the
+// resolved value (key & bytes) are subtracted from the intents
+// counters if commit=true.
+func (mvcc *MVCC) updateStatsOnResolve(oKey, oVal, mKey, mVal int64, meta *proto.MVCCMetadata, commit bool) {
+	// We're pushing or committing an intent; update counts with
+	// difference in bytes between old metadata and new.
+	keyDiff := mKey - oKey
+	valDiff := mVal - oVal
+	if !meta.Deleted {
+		mvcc.LiveBytes += keyDiff + valDiff
+	}
+	mvcc.KeyBytes += keyDiff
+	mvcc.ValBytes += valDiff
+	// If committing, subtract out intent counts.
+	if commit {
+		mvcc.IntentBytes -= (meta.KeyBytes + meta.ValBytes)
+		mvcc.IntentCount--
+	}
+}
+
+// updateStatsOnAbort updates stat counters by subtracting an
+// aborted value's key and value byte sizes. If an earlier version
+// was restored, the restored values are added to live bytes and
+// count if the restored value isn't a deletion tombstone.
+func (mvcc *MVCC) updateStatsOnAbort(oKey, oVal, rKey, rVal int64, orig, restored *proto.MVCCMetadata) {
+	if !orig.Deleted {
+		mvcc.LiveBytes -= (orig.KeyBytes + orig.ValBytes + oKey + oVal)
+		mvcc.LiveCount--
+	}
+	mvcc.KeyBytes -= (orig.KeyBytes + oKey)
+	mvcc.ValBytes -= (orig.ValBytes + oVal)
+	mvcc.KeyCount--
+	mvcc.ValCount--
+	mvcc.IntentBytes -= (orig.KeyBytes + orig.ValBytes)
+	mvcc.IntentCount--
+
+	// If restored version isn't a deletion tombstone, add it to live counters.
+	if restored != nil {
+		if !restored.Deleted {
+			mvcc.LiveBytes += restored.KeyBytes + restored.ValBytes + rKey + rVal
+			mvcc.LiveCount++
+		}
+		mvcc.KeyBytes += rKey
+		mvcc.ValBytes += rVal
+		mvcc.KeyCount++
+		if restored.Txn != nil {
+			panic("restored version should never be an intent")
+		}
+	}
 }
 
 // mvccEncodeKey makes a timestamped key which is the concatenation of

--- a/storage/engine/mvcc_test.go
+++ b/storage/engine/mvcc_test.go
@@ -19,8 +19,11 @@ package engine
 
 import (
 	"bytes"
+	crypto_rand "crypto/rand"
+	"encoding/binary"
 	"fmt"
 	"math"
+	"math/rand"
 	"reflect"
 	"sort"
 	"strconv"
@@ -1023,23 +1026,16 @@ func TestFindSplitKey(t *testing.T) {
 	}
 }
 
-// verifyStats scans the underlying engine and manually computes the
-// stat counters. It then compares those to the stats in the mvcc
-// object.
-func verifyStats(debug string, mvcc *MVCC, t *testing.T) {
-	// Since MVCCComputeStats reads directly from underlying engine, we
-	// must commit the batch. We just do this out from underneat the
-	// MVCC instance and reset with a new batch.
-	if err := mvcc.batch.Commit(); err != nil {
-		t.Fatal(err)
-	}
-	mvcc.batch = NewBatch(mvcc.batch.engine)
-
-	// Compute the stats manually.
-	ms, err := MVCCComputeStats(mvcc.batch.engine, KeyMin, KeyMax)
+// encodedSize returns the encoded size of the protobuf message.
+func encodedSize(msg gogoproto.Message, t *testing.T) int64 {
+	data, err := gogoproto.Marshal(msg)
 	if err != nil {
 		t.Fatal(err)
 	}
+	return int64(len(data))
+}
+
+func verifyStats(debug string, mvcc *MVCC, ms MVCCStats, t *testing.T) {
 	// ...And verify stats.
 	if ms.LiveBytes != mvcc.LiveBytes {
 		t.Errorf("%s: mvcc live bytes %d; measured %d", debug, mvcc.LiveBytes, ms.LiveBytes)
@@ -1067,34 +1063,119 @@ func verifyStats(debug string, mvcc *MVCC, t *testing.T) {
 	}
 }
 
-// TestMVCCStats creates a random sequence of puts, deletes and delete
-// ranges and at each step verifies that the mvcc stats match a manual
-// computation of range stats via a scan of the underlying engine.
-func TestMVCCStats(t *testing.T) {
-	rand := util.NewPseudoRand()
+// TestMVCCStatsBasic writes a value, then deletes it as an intent via
+// a transaction, then resolves the intent, manually verifying the
+// mvcc stats at each step.
+func TestMVCCStatsBasic(t *testing.T) {
+	mvcc := createTestMVCC()
+
+	// Put a value.
+	ts := makeTS(0, 1)
+	key := Key("a")
+	value := proto.Value{Bytes: []byte("value")}
+	if err := mvcc.Put(key, ts, value, nil); err != nil {
+		t.Fatal(err)
+	}
+	mKeySize := int64(len(key.Encode(nil)))
+	mValSize := encodedSize(&proto.MVCCMetadata{Timestamp: ts}, t)
+	vKeySize := int64(len(mvccEncodeKey(key.Encode(nil), ts)))
+	vValSize := encodedSize(&proto.MVCCValue{Value: &value}, t)
+
+	ms := MVCCStats{
+		LiveBytes: mKeySize + mValSize + vKeySize + vValSize,
+		LiveCount: 1,
+		KeyBytes:  mKeySize + vKeySize,
+		KeyCount:  1,
+		ValBytes:  mValSize + vValSize,
+		ValCount:  1,
+	}
+	verifyStats("after put", mvcc, ms, t)
+
+	// Delete the value using a transaction.
+	txn := &proto.Transaction{ID: []byte("txn1"), Timestamp: makeTS(0, 1)}
+	ts2 := makeTS(0, 2)
+	if err := mvcc.Delete(key, ts2, txn); err != nil {
+		t.Fatal(err)
+	}
+	m2ValSize := encodedSize(&proto.MVCCMetadata{Timestamp: ts2, Deleted: true, Txn: txn}, t)
+	v2KeySize := int64(len(mvccEncodeKey(key.Encode(nil), ts2)))
+	v2ValSize := encodedSize(&proto.MVCCValue{Deleted: true}, t)
+	ms2 := MVCCStats{
+		KeyBytes:    mKeySize + vKeySize + v2KeySize,
+		KeyCount:    1,
+		ValBytes:    m2ValSize + vValSize + v2ValSize,
+		ValCount:    2,
+		IntentBytes: v2KeySize + v2ValSize,
+		IntentCount: 1,
+	}
+	verifyStats("after delete", mvcc, ms2, t)
+
+	// Resolve the deletion by aborting it.
+	txn.Status = proto.ABORTED
+	if err := mvcc.ResolveWriteIntent(key, txn); err != nil {
+		t.Fatal(err)
+	}
+	// Stats should equal same as before the deletion after aborting the intent.
+	verifyStats("after abort", mvcc, ms, t)
+
+	// Re-delete, but this time commit it.
+	txn.Status = proto.PENDING
+	ts3 := makeTS(0, 3)
+	if err := mvcc.Delete(key, ts3, txn); err != nil {
+		t.Fatal(err)
+	}
+	verifyStats("after 2nd delete", mvcc, ms2, t) // should be same as before.
+
+	// Now commit.
+	txn.Status = proto.COMMITTED
+	if err := mvcc.ResolveWriteIntent(key, txn); err != nil {
+		t.Fatal(err)
+	}
+	m3ValSize := encodedSize(&proto.MVCCMetadata{Timestamp: ts3, Deleted: true}, t)
+	ms3 := MVCCStats{
+		KeyBytes: mKeySize + vKeySize + v2KeySize,
+		KeyCount: 1,
+		ValBytes: m3ValSize + vValSize + v2ValSize,
+		ValCount: 2,
+	}
+	verifyStats("after abort", mvcc, ms3, t)
+}
+
+// TestMVCCStatsWithRandomRuns creates a random sequence of puts,
+// deletes and delete ranges and at each step verifies that the mvcc
+// stats match a manual computation of range stats via a scan of the
+// underlying engine.
+func TestMVCCStatsWithRandomRuns(t *testing.T) {
+	var seed int64
+	err := binary.Read(crypto_rand.Reader, binary.LittleEndian, &seed)
+	if err != nil {
+		t.Fatalf("could not read from crypto/rand: %s", err)
+	}
+	log.Infof("using pseudo random number generator with seed %d", seed)
+	rng := rand.New(rand.NewSource(seed))
 	mvcc := createTestMVCC()
 
 	// Test with empty mvcc.
-	verifyStats("empty test", mvcc, t)
+	verifyStats("empty test", mvcc, MVCCStats{}, t)
 
-	// Now, generate a random sequence of puts, deletes and resolves.
+	// Now, generate a rngom sequence of puts, deletes and resolves.
 	// Each put and delete may or may not involve a txn. Resolves may
 	// either commit or abort.
 	keys := map[int32][]byte{}
 	for i := int32(0); i < int32(1000); i++ {
-		key := []byte(fmt.Sprintf("%s-%d", util.RandString(rand, int(rand.Int31n(32))), i))
+		key := []byte(fmt.Sprintf("%s-%d", util.RandString(rng, int(rng.Int31n(32))), i))
 		keys[i] = key
 		var txn *proto.Transaction
-		if rand.Int31n(2) == 0 { // create a txn with 50% prob
+		if rng.Int31n(2) == 0 { // create a txn with 50% prob
 			txn = &proto.Transaction{ID: []byte(fmt.Sprintf("txn-%d", i)), Timestamp: makeTS(0, i)}
 		}
 		// With 25% probability, put a new value; otherwise, delete an earlier
 		// key. Because an earlier step in this process may have itself been
 		// a delete, we could end up deleting a non-existent key, which is good;
 		// we don't mind testing that case as well.
-		isDelete := rand.Int31n(4) == 0
+		isDelete := rng.Int31n(4) == 0
 		if i > 0 && isDelete {
-			idx := rand.Int31n(i)
+			idx := rng.Int31n(i)
 			log.V(1).Infof("*** DELETE index %d", idx)
 			if err := mvcc.Delete(keys[idx], makeTS(0, i), txn); err != nil {
 				// Abort any write intent on an earlier, unresolved txn.
@@ -1114,15 +1195,15 @@ func TestMVCCStats(t *testing.T) {
 				}
 			}
 		} else {
-			randVal := proto.Value{Bytes: []byte(util.RandString(rand, int(rand.Int31n(128))))}
+			rngVal := proto.Value{Bytes: []byte(util.RandString(rng, int(rng.Int31n(128))))}
 			log.V(1).Infof("*** PUT index %d; TXN=%t", i, txn != nil)
-			if err := mvcc.Put(key, makeTS(0, i), randVal, txn); err != nil {
+			if err := mvcc.Put(key, makeTS(0, i), rngVal, txn); err != nil {
 				t.Fatal(err)
 			}
 		}
-		if !isDelete && txn != nil && rand.Int31n(2) == 0 { // resolve txn with 50% prob
+		if !isDelete && txn != nil && rng.Int31n(2) == 0 { // resolve txn with 50% prob
 			txn.Status = proto.COMMITTED
-			if rand.Int31n(10) == 0 { // abort txn with 10% prob
+			if rng.Int31n(10) == 0 { // abort txn with 10% prob
 				txn.Status = proto.ABORTED
 			}
 			log.V(1).Infof("*** RESOLVE index %d; COMMIT=%t", i, txn.Status == proto.COMMITTED)
@@ -1133,7 +1214,20 @@ func TestMVCCStats(t *testing.T) {
 
 		// Every 10th step, verify the stats via manual engine scan.
 		if i%10 == 0 {
-			verifyStats(fmt.Sprintf("cycle %d", i), mvcc, t)
+			// Since MVCCComputeStats reads directly from underlying engine, we
+			// must commit the batch. We just do this out from underneath the
+			// MVCC instance and reset with a new batch.
+			if err := mvcc.batch.Commit(); err != nil {
+				t.Fatal(err)
+			}
+			mvcc.batch = NewBatch(mvcc.batch.engine)
+
+			// Compute the stats manually.
+			ms, err := MVCCComputeStats(mvcc.batch.engine, KeyMin, KeyMax)
+			if err != nil {
+				t.Fatal(err)
+			}
+			verifyStats(fmt.Sprintf("cycle %d", i), mvcc, ms, t)
 		}
 	}
 }

--- a/storage/range.go
+++ b/storage/range.go
@@ -782,7 +782,7 @@ func (r *Range) EndTransaction(batch *engine.Batch, args *proto.EndTransactionRe
 
 	// Fetch existing transaction if possible.
 	existTxn := &proto.Transaction{}
-	ok, err := batch.GetProto(encKey, existTxn)
+	ok, _, _, err := batch.GetProto(encKey, existTxn)
 	if err != nil {
 		reply.SetGoError(err)
 		return
@@ -847,7 +847,7 @@ func (r *Range) EndTransaction(batch *engine.Batch, args *proto.EndTransactionRe
 	}
 
 	// Persist the transaction record with updated status (& possibly timestmap).
-	if err := batch.PutProto(encKey, reply.Txn); err != nil {
+	if _, _, err := batch.PutProto(encKey, reply.Txn); err != nil {
 		reply.SetGoError(err)
 		return
 	}
@@ -963,7 +963,7 @@ func (r *Range) InternalHeartbeatTxn(batch *engine.Batch, args *proto.InternalHe
 	encKey := engine.Key(args.Key).Encode(nil)
 
 	var txn proto.Transaction
-	ok, err := batch.GetProto(encKey, &txn)
+	ok, _, _, err := batch.GetProto(encKey, &txn)
 	if err != nil {
 		reply.SetGoError(err)
 		return
@@ -980,7 +980,7 @@ func (r *Range) InternalHeartbeatTxn(batch *engine.Batch, args *proto.InternalHe
 		if txn.LastHeartbeat.Less(args.Header().Timestamp) {
 			*txn.LastHeartbeat = args.Header().Timestamp
 		}
-		if err := batch.PutProto(encKey, &txn); err != nil {
+		if _, _, err := batch.PutProto(encKey, &txn); err != nil {
 			reply.SetGoError(err)
 			return
 		}
@@ -1034,7 +1034,7 @@ func (r *Range) InternalPushTxn(batch *engine.Batch, args *proto.InternalPushTxn
 
 	// Fetch existing transaction if possible.
 	existTxn := &proto.Transaction{}
-	ok, err := batch.GetProto(encKey, existTxn)
+	ok, _, _, err := batch.GetProto(encKey, existTxn)
 	if err != nil {
 		reply.SetGoError(err)
 		return
@@ -1135,7 +1135,7 @@ func (r *Range) InternalPushTxn(batch *engine.Batch, args *proto.InternalPushTxn
 	}
 
 	// Persist the pushed transaction.
-	if err := batch.PutProto(encKey, reply.PusheeTxn); err != nil {
+	if _, _, err := batch.PutProto(encKey, reply.PusheeTxn); err != nil {
 		reply.SetGoError(err)
 		return
 	}


### PR DESCRIPTION
Stats include the following:
- Live key/values (i.e. what a scan at current time will reveal;
  note that this includes intent keys and values, but not keys and
  values with most recent value deleted)
- Key bytes (includes all keys, even those with most recent value deleted)
- Value bytes (includes all versions)
- Key count (count of all keys, including keys with deleted tombstones)
- Value count (all versions, including deleted tombstones)
- Intents (provisional values written during txns)

They are computed by MVCC incrementally on all updates to be applied
by the range after a successful execution of a command. Stats will be
applied as merged counters to efficiently track stats for ranges in
order to decide whether to split.

There is also a means to recompute stats for an arbitrary key range.
In this mode, the engine is directly scanned and the stats are computed
from the raw data. This method is used to compare against the incremental
counts in a randomized unittest.
