### PR TITLE
Replace Engine.Scan with Engine.Iterate

### DIFF
--- a/storage/engine/batch.go
+++ b/storage/engine/batch.go
@@ -98,7 +98,7 @@ func (b *Batch) Get(key Key) ([]byte, error) {
 }
 
 // iterateUpdates scans the updates tree from start to end, invoking f
-// on each value.
+// on each value until f returns false or an error.
 func (b *Batch) iterateUpdates(start, end Key, f func(proto.RawKeyValue) (bool, error)) (bool, error) {
 	var done bool
 	var err error
@@ -123,6 +123,11 @@ func (b *Batch) iterateUpdates(start, end Key, f func(proto.RawKeyValue) (bool, 
 // Iterate invokes f on key/value pairs merged from the underlying
 // engine and pending batch updates. If f returns done or an error,
 // the iteration ends and propagates the error.
+//
+// TODO(spencer): this implementation could benefit from an
+// iterator-style interface to the update map. If/when one is
+// provided by the llrb implementation it should be used here
+// to make this code more efficient.
 func (b *Batch) Iterate(start, end Key, f func(proto.RawKeyValue) (bool, error)) error {
 	last := start
 	if err := b.engine.Iterate(start, end, func(kv proto.RawKeyValue) (bool, error) {

--- a/storage/engine/engine_test.go
+++ b/storage/engine/engine_test.go
@@ -296,20 +296,20 @@ func TestEngineScan1(t *testing.T) {
 		}
 		sort.Strings(sortedKeys)
 
-		keyvals, err := engine.Scan([]byte("chinese"), []byte("german"), 0)
+		keyvals, err := Scan(engine, []byte("chinese"), []byte("german"), 0)
 		if err != nil {
 			t.Fatalf("could not run scan: %v", err)
 		}
 		ensureRangeEqual(t, sortedKeys[1:4], keyMap, keyvals)
 
 		// Check an end of range which does not equal an existing key.
-		keyvals, err = engine.Scan([]byte("chinese"), []byte("german1"), 0)
+		keyvals, err = Scan(engine, []byte("chinese"), []byte("german1"), 0)
 		if err != nil {
 			t.Fatalf("could not run scan: %v", err)
 		}
 		ensureRangeEqual(t, sortedKeys[1:5], keyMap, keyvals)
 
-		keyvals, err = engine.Scan([]byte("chinese"), []byte("german"), 2)
+		keyvals, err = Scan(engine, []byte("chinese"), []byte("german"), 2)
 		if err != nil {
 			t.Fatalf("could not run scan: %v", err)
 		}
@@ -320,7 +320,7 @@ func TestEngineScan1(t *testing.T) {
 		// a special case in engine.scan, that's why we test it here.
 		startKeys := []Key{Key("cat"), Key("")}
 		for _, startKey := range startKeys {
-			keyvals, err := engine.Scan(startKey, KeyMax, 0)
+			keyvals, err := Scan(engine, startKey, KeyMax, 0)
 			if err != nil {
 				t.Fatalf("could not run scan: %v", err)
 			}
@@ -374,7 +374,7 @@ func TestEngineIncrement(t *testing.T) {
 }
 
 func verifyScan(start, end Key, max int64, expKeys []Key, engine Engine, t *testing.T) {
-	kvs, err := engine.Scan(start, end, max)
+	kvs, err := Scan(engine, start, end, max)
 	if err != nil {
 		t.Errorf("scan %q-%q: expected no error, but got %s", string(start), string(end), err)
 	}
@@ -496,8 +496,8 @@ func TestSnapshot(t *testing.T) {
 				valSnapshot, val1)
 		}
 
-		keyvals, _ := engine.Scan(key, KeyMax, 0)
-		keyvalsSnapshot, error := engine.ScanSnapshot(key, KeyMax, 0, snapshotID)
+		keyvals, _ := Scan(engine, key, KeyMax, 0)
+		keyvalsSnapshot, error := ScanSnapshot(engine, key, KeyMax, 0, snapshotID)
 		if error != nil {
 			t.Fatalf("error : %s", error)
 		}

--- a/storage/engine/mvcc_test.go
+++ b/storage/engine/mvcc_test.go
@@ -1015,14 +1015,19 @@ func TestFindSplitKey(t *testing.T) {
 	if err := mvcc.batch.Commit(); err != nil {
 		t.Fatal(err)
 	}
-
-	humanSplitKey, err := MVCCFindSplitKey(mvcc.batch.engine, KeyMin, KeyMax, "")
+	if err := mvcc.batch.engine.CreateSnapshot("snap1"); err != nil {
+		t.Fatal(err)
+	}
+	humanSplitKey, err := MVCCFindSplitKey(mvcc.batch.engine, KeyMin, KeyMax, "snap1")
 	if err != nil {
 		t.Fatal(err)
 	}
 	ind, _ := strconv.Atoi(string(humanSplitKey))
 	if diff := splitReservoirSize/2 - ind; diff > 1 || diff < -1 {
 		t.Fatalf("wanted key #%d+-1, but got %d (diff %d)", ind+diff, ind, diff)
+	}
+	if err := mvcc.batch.engine.ReleaseSnapshot("snap1"); err != nil {
+		t.Fatal(err)
 	}
 }
 

--- a/storage/engine/rocksdb_test.go
+++ b/storage/engine/rocksdb_test.go
@@ -99,7 +99,7 @@ func TestRocksDBCompaction(t *testing.T) {
 
 	// Compact range and scan remaining values to compare.
 	rocksdb.CompactRange(nil, nil)
-	keyvals, err := rocksdb.Scan(KeyMin, KeyMax, 0)
+	keyvals, err := Scan(rocksdb, KeyMin, KeyMax, 0)
 	if err != nil {
 		t.Fatalf("could not run scan: %v", err)
 	}

--- a/storage/range.go
+++ b/storage/range.go
@@ -1178,7 +1178,7 @@ func (r *Range) InternalSnapshotCopy(e engine.Engine, args *proto.InternalSnapsh
 		args.SnapshotId = snapshotID
 	}
 
-	kvs, err := e.ScanSnapshot(args.Key, args.EndKey, args.MaxResults, args.SnapshotId)
+	kvs, err := engine.ScanSnapshot(e, args.Key, args.EndKey, args.MaxResults, args.SnapshotId)
 	if err != nil {
 		reply.SetGoError(err)
 		return

--- a/storage/store.go
+++ b/storage/store.go
@@ -229,7 +229,7 @@ func (s *Store) Init() error {
 	end := endKey.Encode(nil)
 	const rows = 64
 	for {
-		kvs, err := s.engine.Scan(start, end, rows)
+		kvs, err := engine.Scan(s.engine, start, end, rows)
 		if err != nil {
 			return err
 		}
@@ -265,7 +265,7 @@ func (s *Store) Bootstrap(ident proto.StoreIdent) error {
 		return err
 	}
 	s.Ident = ident
-	kvs, err := s.engine.Scan(engine.KeyMin, engine.KeyMax, 1 /* only need one entry to fail! */)
+	kvs, err := engine.Scan(s.engine, engine.KeyMin, engine.KeyMax, 1 /* only need one entry to fail! */)
 	if err != nil {
 		return util.Errorf("unable to scan engine to verify empty: %s", err)
 	} else if len(kvs) > 0 {


### PR DESCRIPTION
Move to iteration-based primitive for efficiency. This is going to be
particularly useful when we start to optimize mvcc.Scan, which
currently is very, very inefficient.

Scan and ScanSnapshot are still provided as convenience functions
which take an Engine instance as a parameter. Most existing code
has been moved to use those. Other bits of code have been moved
to use the new iteration-based approach.

Fixed a bug in Batch.Scan where insufficient entries would be
returned in the event a deletion in the updates map overrode
a value in the underlying engine and the max scan parameter was
exceeded.

Also added synchronization to protect the snapshots map in the
in-memory and rocksdb engines.
