### PR TITLE
Deal with clock uncertainty for transactional readers

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -4,23 +4,6 @@
 
 * Transactions
 
-  - Modified ops:
-
-    - Get: logic to support clock skew uncertainty and concurrency.
-
-      If most recent timestamp for key is greater than MaxTimestamp
-      (it can be either committed or an intent), and there are no
-      versions of key between Timestamp and MaxTimestamp, read value
-      for key at Timestamp.
-
-      If there are version(s) of the key (can include most recent
-      intent) with timestamp between Timestamp and MaxTimestamp,
-      return WriteWithinUncertaintyInterval error. The ResponseHeader
-      will contain the latest version's timestamp (actually, just the
-      latest version with timestamp <= MaxTimestamp); on transaction
-      retry, Timestamp will be min(key's timestamp + 1, MaxTimestamp),
-      and MaxTimestamp will be max(key's timestamp + 1, MaxTimestamp).
-
   - Keep a cache of pushed transactions on a store to avoid repushing
     further intents after a txn has already been aborted or its
     timestamp moved forward.

--- a/kv/txn_db_correctness_test.go
+++ b/kv/txn_db_correctness_test.go
@@ -58,15 +58,18 @@ var testTxnRetryOpts = &util.RetryOptions{
 // enforce an ordering. If a previous wait channel is set, the
 // command waits on it before execution.
 type cmd struct {
-	name        string                                          // name of the cmd for debug output
-	key, endKey string                                          // key and optional endKey
-	debug       string                                          // optional debug string
-	txnIdx      int                                             // transaction index in the history
-	historyIdx  int                                             // this suffixes key so tests get unique keys
-	fn          func(c *cmd, db storage.DB, t *testing.T) error // execution function
-	ch          chan struct{}                                   // channel for other commands to wait
-	prev        <-chan struct{}                                 // channel this command must wait on before executing
-	env         map[string]int64                                // contains all previously read values
+	name        string // name of the cmd for debug output
+	key, endKey string // key and optional endKey
+	debug       string // optional debug string
+	txnIdx      int    // transaction index in the history
+	historyIdx  int    // this suffixes key so tests get unique keys
+	fn          func(
+		c *cmd,
+		db storage.DB,
+		t *testing.T) error // execution function
+	ch   chan struct{}    // channel for other commands to wait
+	prev <-chan struct{}  // channel this command must wait on before executing
+	env  map[string]int64 // contains all previously read values
 }
 
 func (c *cmd) init(prevCmd *cmd) {

--- a/proto/data.proto
+++ b/proto/data.proto
@@ -149,9 +149,11 @@ message Transaction {
   // The proposed timestamp for the transaction. This starts as
   // the current wall time on the txn coordinator.
   optional Timestamp timestamp = 7 [(gogoproto.nullable) = false];
-  // Timestamp + clock skew. Reads which encounter values with
+  // Initial Timestamp + clock skew. Reads which encounter values with
   // timestamps between Timestamp and MaxTimestamp trigger a txn
   // retry error.
+  // The case MaxTimestamp < Timestamp is possible for transactions which have
+  // been pushed; in this case, MaxTimestamp should be ignored.
   optional Timestamp max_timestamp = 8 [(gogoproto.nullable) = false];
   // The last hearbeat timestamp.
   optional Timestamp last_heartbeat = 9;

--- a/proto/errors.go
+++ b/proto/errors.go
@@ -118,3 +118,8 @@ func (e *WriteIntentError) Error() string {
 func (e *WriteTooOldError) Error() string {
 	return fmt.Sprintf("failed write with timestamp %s < %s", e.Timestamp, e.ExistingTimestamp)
 }
+
+// Error formats error.
+func (e *ReadWithinUncertaintyIntervalError) Error() string {
+	return fmt.Sprintf("read at time %s encountered previous write with future timestamp %s within uncertainty interval", e.Timestamp, e.ExistingTimestamp)
+}

--- a/proto/errors.proto
+++ b/proto/errors.proto
@@ -89,8 +89,17 @@ message WriteIntentError {
 
 // A WriteTooOldError indicates that a write encountered a versioned
 // value newer than its timestamp, making it impossible to rewrite
-// history. The write should be retried at the Timestamp + 1.
+// history. The write should be retried at existing_timestamp+1.
 message WriteTooOldError {
+  optional Timestamp timestamp = 1 [(gogoproto.nullable) = false];
+  optional Timestamp existing_timestamp = 2 [(gogoproto.nullable) = false];
+}
+
+// A ReadWithinUncertaintyIntervalError indicates that a read at timestamp
+// encountered a versioned value at existing_timestamp within the uncertainty
+// interval of the reader.
+// The read should be retried at existing_timestamp+1.
+message ReadWithinUncertaintyIntervalError {
   optional Timestamp timestamp = 1 [(gogoproto.nullable) = false];
   optional Timestamp existing_timestamp = 2 [(gogoproto.nullable) = false];
 }

--- a/server/server.go
+++ b/server/server.go
@@ -75,7 +75,8 @@ var (
 	maxOffset = flag.Duration("max_offset", 250*time.Millisecond, "specify "+
 		"the maximum clock offset for the cluster. Clock offset is measured on all "+
 		"node-to-node links and if any node notices it has clock offset in excess "+
-		"of -max_drift, it will commit suicide.")
+		"of -max_drift, it will commit suicide. Setting this value too high may "+
+		"decrease transaction performance in the presence of contention.")
 
 	bootstrapOnly = flag.Bool("bootstrap_only", false, "specify --bootstrap_only "+
 		"to avoid starting the server after bootstrapping with the init command.")


### PR DESCRIPTION
Taking care of what Spencer describes in the last slide of
https://www.youtube.com/watch?v=MEAuFgsmND0&feature=youtu.be
and the corresponding entry in the TODO (which describes slightly different semantics),
namely the case in which a reader stumbles upon a write which has a timestamp in the near future.
