### PR TITLE
Adapt to upstream changes in etcd/raft.

### DIFF
--- a/multiraft/events.go
+++ b/multiraft/events.go
@@ -21,7 +21,7 @@ package multiraft
 // TODO(bdarnell): emit EventLeaderElection from follower nodes as well.
 type EventLeaderElection struct {
 	GroupID GroupID
-	NodeID  int64
+	NodeID  uint64
 }
 
 // An EventCommandCommitted is broadcast whenever a command has been committed.

--- a/multiraft/multiraft_test.go
+++ b/multiraft/multiraft_test.go
@@ -47,7 +47,7 @@ func newTestCluster(size int, t *testing.T) *testCluster {
 			TickInterval:           time.Millisecond,
 			Strict:                 true,
 		}
-		mr, err := NewMultiRaft(int64(i+1), config)
+		mr, err := NewMultiRaft(uint64(i+1), config)
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -77,7 +77,7 @@ func (c *testCluster) stop() {
 
 // createGroup replicates a group among the first numReplicas nodes in the cluster
 func (c *testCluster) createGroup(groupID GroupID, numReplicas int) {
-	var replicaIDs []int64
+	var replicaIDs []uint64
 	var replicaNodes []*state
 	for i := 0; i < numReplicas; i++ {
 		replicaNodes = append(replicaNodes, c.nodes[i])

--- a/multiraft/storage.go
+++ b/multiraft/storage.go
@@ -49,7 +49,7 @@ const (
 // the new configuration.
 type ChangeMembershipPayload struct {
 	Operation ChangeMembershipOperation
-	Node      int64
+	Node      uint64
 }
 
 // LogEntry is the persistent form of a raft log entry.

--- a/multiraft/transport.go
+++ b/multiraft/transport.go
@@ -32,13 +32,13 @@ type Transport interface {
 	// Listen informs the Transport of the local node's ID and callback interface.
 	// The Transport should associate the given id with the server object so other Transport's
 	// Connect methods can find it.
-	Listen(id int64, server ServerInterface) error
+	Listen(id uint64, server ServerInterface) error
 
 	// Stop undoes a previous Listen.
-	Stop(id int64)
+	Stop(id uint64)
 
 	// Connect looks up a node by id and returns a stub interface to submit RPCs to it.
-	Connect(id int64) (ClientInterface, error)
+	Connect(id uint64) (ClientInterface, error)
 }
 
 // SendMessageRequest wraps a raft message.
@@ -87,7 +87,7 @@ func (r *rpcAdapter) SendMessage(req *SendMessageRequest, resp *SendMessageRespo
 // Outgoing requests are run in a goroutine and their response ops are returned on the
 // given channel.
 type asyncClient struct {
-	nodeID int64
+	nodeID uint64
 	conn   ClientInterface
 	ch     chan *rpc.Call
 }

--- a/multiraft/transport_test.go
+++ b/multiraft/transport_test.go
@@ -11,7 +11,7 @@ import (
 )
 
 type localRPCTransport struct {
-	listeners map[int64]net.Listener
+	listeners map[uint64]net.Listener
 }
 
 // NewLocalRPCTransport creates a Transport for local testing use. MultiRaft instances
@@ -20,10 +20,10 @@ type localRPCTransport struct {
 // localhost.
 // Because this is just for local testing, it doesn't use TLS.
 func NewLocalRPCTransport() Transport {
-	return &localRPCTransport{make(map[int64]net.Listener)}
+	return &localRPCTransport{make(map[uint64]net.Listener)}
 }
 
-func (lt *localRPCTransport) Listen(id int64, server ServerInterface) error {
+func (lt *localRPCTransport) Listen(id uint64, server ServerInterface) error {
 	rpcServer := rpc.NewServer()
 	err := rpcServer.RegisterName("MultiRaft", &rpcAdapter{server})
 	if err != nil {
@@ -55,12 +55,12 @@ func (lt *localRPCTransport) accept(server *rpc.Server, listener net.Listener) {
 	}
 }
 
-func (lt *localRPCTransport) Stop(id int64) {
+func (lt *localRPCTransport) Stop(id uint64) {
 	lt.listeners[id].Close()
 	delete(lt.listeners, id)
 }
 
-func (lt *localRPCTransport) Connect(id int64) (ClientInterface, error) {
+func (lt *localRPCTransport) Connect(id uint64) (ClientInterface, error) {
 	address := lt.listeners[id].Addr().String()
 	client, err := rpc.Dial("tcp", address)
 	if err != nil {


### PR DESCRIPTION
Node ids are now uint64, and the application is required to send
committed EntryConfChanges back into the raft system.

@cockroachdb/developers 
