### PR TITLE
Hooked up server to suicide if clock offset is too great

### DIFF
--- a/rpc/clock_offset_test.go
+++ b/rpc/clock_offset_test.go
@@ -22,9 +22,10 @@ import (
 	"testing"
 	"time"
 
-	"github.com/cockroachdb/cockroach/util/log"
+	"github.com/cockroachdb/cockroach/util/hlc"
 )
 
+// Test the sort interface for endpointLists.
 func TestEndpointListSort(t *testing.T) {
 	list := endpointList{
 		endpoint{offset: 5, endType: +1},
@@ -56,17 +57,21 @@ func TestEndpointListSort(t *testing.T) {
 	}
 }
 
+// Test that the map of RemoteOffsets is correctly manipulated into a list of
+// endpoints used in Marzullo's algorithm.
 func TestBuildEndpointList(t *testing.T) {
-	// Build the offsets we will turn into an interval list.
+	// Build the offsets we will turn into an endpoint list.
 	offsets := make(map[string]RemoteOffset)
 	offsets["0"] = RemoteOffset{Offset: 0, Error: 10}
 	offsets["1"] = RemoteOffset{Offset: 1, Error: 10}
 	offsets["2"] = RemoteOffset{Offset: 2, Error: 10}
 	offsets["3"] = RemoteOffset{Offset: 3, Error: 10}
-	log.Infof("base offsets: %v", offsets)
+	manual := hlc.ManualClock(0)
+	clock := hlc.NewClock(manual.UnixNano)
+	clock.SetMaxOffset(5 * time.Nanosecond)
 	remoteClocks := &RemoteClockMonitor{
-		offsets:  offsets,
-		maxDrift: 5 * time.Nanosecond,
+		offsets: offsets,
+		lClock:  clock,
 	}
 
 	expectedList := endpointList{
@@ -96,6 +101,38 @@ func TestBuildEndpointList(t *testing.T) {
 	}
 }
 
+// Test the side effect of removing older offsets when we build an endpoint
+// list.
+func TestBuildEndpointListRemoveStagnantClocks(t *testing.T) {
+	offsets := make(map[string]RemoteOffset)
+	offsets["0"] = RemoteOffset{Offset: 0, Error: 10}
+	offsets["stagnant0"] = RemoteOffset{Offset: 1, Error: 10, MeasuredAt: -11}
+	offsets["1"] = RemoteOffset{Offset: 2, Error: 10}
+	offsets["stagnant1"] = RemoteOffset{Offset: 3, Error: 10, MeasuredAt: -20}
+
+	// The stagnant offsets older than 10ns ago will be removed.
+	monitorInterval = 10 * time.Nanosecond
+
+	manual := hlc.ManualClock(0)
+	clock := hlc.NewClock(manual.UnixNano)
+	clock.SetMaxOffset(5 * time.Nanosecond)
+	remoteClocks := &RemoteClockMonitor{
+		offsets: offsets,
+		lClock:  clock,
+	}
+
+	remoteClocks.buildEndpointList()
+
+	_, ok0 := offsets["stagnant0"]
+	_, ok1 := offsets["stagnant1"]
+
+	if ok0 || ok1 {
+		t.Errorf("expected stagant offsets removed, instead offsets: %v", offsets)
+	}
+}
+
+// Test that we correctly determine the interval that a majority of remote
+// offsets overlap.
 func TestFindOffsetInterval(t *testing.T) {
 	// Build the offsets. We will return the interval that the maximum number
 	// of remote clocks overlap.
@@ -104,19 +141,185 @@ func TestFindOffsetInterval(t *testing.T) {
 	offsets["1"] = RemoteOffset{Offset: 58, Error: 20}
 	offsets["2"] = RemoteOffset{Offset: 71, Error: 25}
 	offsets["3"] = RemoteOffset{Offset: 91, Error: 31}
-	log.Infof("base offsets: %v", offsets)
+
+	manual := hlc.ManualClock(0)
+	clock := hlc.NewClock(manual.UnixNano)
+	clock.SetMaxOffset(0 * time.Nanosecond)
 	remoteClocks := &RemoteClockMonitor{
-		offsets:  offsets,
-		maxDrift: 0 * time.Second,
+		offsets: offsets,
+		lClock:  clock,
+	}
+	expectedInterval := ClusterOffsetInterval{Lowerbound: 60, Upperbound: 78}
+	assertClusterOffset(remoteClocks, expectedInterval, t)
+}
+
+// Test that, if a majority of offsets do not overlap, an error is returned.
+func TestFindOffsetIntervalNoMajorityOverlap(t *testing.T) {
+	// Build the offsets. We will return the interval that the maximum number
+	// of remote clocks overlap.
+	offsets := make(map[string]RemoteOffset)
+	offsets["0"] = RemoteOffset{Offset: 0, Error: 1}
+	offsets["1"] = RemoteOffset{Offset: 1, Error: 1}
+	offsets["2"] = RemoteOffset{Offset: 3, Error: 1}
+	offsets["3"] = RemoteOffset{Offset: 4, Error: 1}
+
+	manual := hlc.ManualClock(0)
+	clock := hlc.NewClock(manual.UnixNano)
+	clock.SetMaxOffset(0 * time.Nanosecond)
+	remoteClocks := &RemoteClockMonitor{
+		offsets: offsets,
+		lClock:  clock,
+	}
+	assertMajorityIntervalError(remoteClocks, t)
+}
+
+// Test that, if most of the clocks have an InfiniteOffset (they missed their
+// last heartbeat), then we get an interval for an infinite offset.
+func TestFindOffsetIntervalWithInfinites(t *testing.T) {
+	offsets := make(map[string]RemoteOffset)
+	offsets["0"] = RemoteOffset{Offset: 0, Error: 1}
+	offsets["1"] = InfiniteOffset
+	offsets["2"] = InfiniteOffset
+	offsets["3"] = InfiniteOffset
+
+	manual := hlc.ManualClock(0)
+	clock := hlc.NewClock(manual.UnixNano)
+	clock.SetMaxOffset(0 * time.Nanosecond)
+	remoteClocks := &RemoteClockMonitor{
+		offsets: offsets,
+		lClock:  clock,
+	}
+	expectedInterval := ClusterOffsetInterval{
+		Lowerbound: InfiniteOffset.Offset,
+		Upperbound: InfiniteOffset.Offset,
+	}
+	assertClusterOffset(remoteClocks, expectedInterval, t)
+}
+
+// Test that we measure 0 offset if there are no recent remote clock readings.
+func TestFindOffsetIntervalNoRemotes(t *testing.T) {
+	offsets := make(map[string]RemoteOffset)
+	manual := hlc.ManualClock(0)
+	clock := hlc.NewClock(manual.UnixNano)
+	clock.SetMaxOffset(10 * time.Nanosecond)
+	remoteClocks := &RemoteClockMonitor{
+		offsets: offsets,
+		lClock:  clock,
+	}
+	expectedInterval := ClusterOffsetInterval{Lowerbound: 0, Upperbound: 0}
+	assertClusterOffset(remoteClocks, expectedInterval, t)
+}
+
+// Test that we return the entire remote offset of the single remote clock.
+func TestFindOffsetIntervalOneClock(t *testing.T) {
+	offsets := make(map[string]RemoteOffset)
+	offsets["0"] = RemoteOffset{Offset: 0, Error: 10}
+
+	manual := hlc.ManualClock(0)
+	clock := hlc.NewClock(manual.UnixNano)
+	// The clock interval will be:
+	// [offset - error - maxOffset, offset + error + maxOffset]
+	clock.SetMaxOffset(10 * time.Nanosecond)
+	remoteClocks := &RemoteClockMonitor{
+		offsets: offsets,
+		lClock:  clock,
+	}
+	expectedInterval := ClusterOffsetInterval{Lowerbound: -20, Upperbound: 20}
+	assertClusterOffset(remoteClocks, expectedInterval, t)
+}
+
+// Test the edge case of having just two remote clocks.
+func TestFindOffsetIntervalTwoClocks(t *testing.T) {
+	offsets := make(map[string]RemoteOffset)
+
+	manual := hlc.ManualClock(0)
+	clock := hlc.NewClock(manual.UnixNano)
+	clock.SetMaxOffset(0 * time.Nanosecond)
+	remoteClocks := &RemoteClockMonitor{
+		offsets: offsets,
+		lClock:  clock,
 	}
 
-	interval := remoteClocks.findOffsetInterval()
-	expectedInterval := ClusterOffsetInterval{Lowerbound: 60, Upperbound: 78}
-	if interval != expectedInterval {
-		t.Errorf("expected interval %v, instead %v", expectedInterval, interval)
+	// Two intervals overlap.
+	offsets["0"] = RemoteOffset{Offset: 0, Error: 10}
+	offsets["1"] = RemoteOffset{Offset: 20, Error: 10}
+	expectedInterval := ClusterOffsetInterval{Lowerbound: 10, Upperbound: 10}
+	assertClusterOffset(remoteClocks, expectedInterval, t)
+
+	// Two intervals don't overlap.
+	offsets["0"] = RemoteOffset{Offset: 0, Error: 10}
+	offsets["1"] = RemoteOffset{Offset: 30, Error: 10}
+	assertMajorityIntervalError(remoteClocks, t)
+}
+
+// Tests if we correctly determine if a ClusterOffsetInterval is healthy or not
+// i.e. if it indicates that the local clock has too great an offset or not.
+func TestIsHealthyOffsetInterval(t *testing.T) {
+	maxOffset := 10 * time.Nanosecond
+
+	interval := ClusterOffsetInterval{
+		Lowerbound: 0,
+		Upperbound: 0,
+	}
+	assertIntervalHealth(true, interval, maxOffset, t)
+
+	interval = ClusterOffsetInterval{
+		Lowerbound: -11,
+		Upperbound: 11,
+	}
+	assertIntervalHealth(true, interval, maxOffset, t)
+
+	interval = ClusterOffsetInterval{
+		Lowerbound: -20,
+		Upperbound: -11,
+	}
+	assertIntervalHealth(false, interval, maxOffset, t)
+
+	interval = ClusterOffsetInterval{
+		Lowerbound: 11,
+		Upperbound: 20,
+	}
+	assertIntervalHealth(false, interval, maxOffset, t)
+
+	interval = ClusterOffsetInterval{
+		Lowerbound: InfiniteOffset.Offset,
+		Upperbound: InfiniteOffset.Offset,
+	}
+	assertIntervalHealth(false, interval, maxOffset, t)
+}
+
+func assertMajorityIntervalError(clocks *RemoteClockMonitor, t *testing.T) {
+	interval, err := clocks.findOffsetInterval()
+	expectedErr := MajorityIntervalNotFoundError{}
+	if err == nil {
+		t.Errorf("expected MajorityIntervalNotFoundError, instead %v", interval)
+	} else if err != expectedErr {
+		t.Errorf("expected MajorityIntervalNotFoundError, instead: %s", err)
 	}
 }
 
-// TODO(embark): once we figure out what we want to do if there is no interval
-// overlapped by a majority of the remote clock offsets, write tests to
-// encompass such situations.
+func assertClusterOffset(clocks *RemoteClockMonitor,
+	expected ClusterOffsetInterval, t *testing.T) {
+	interval, err := clocks.findOffsetInterval()
+	if err != nil {
+		t.Errorf("expected interval %v, instead err: %s",
+			expected, err)
+	} else if interval != expected {
+		t.Errorf("expected interval %v, instead %v", expected, interval)
+	}
+}
+
+func assertIntervalHealth(expectedHealthy bool, i ClusterOffsetInterval,
+	maxOffset time.Duration, t *testing.T) {
+	if expectedHealthy {
+		if !isHealthyOffsetInterval(i, maxOffset) {
+			t.Errorf("expected interval %v for offset %d nanoseconds to be healthy",
+				i, maxOffset.Nanoseconds())
+		}
+	} else {
+		if isHealthyOffsetInterval(i, maxOffset) {
+			t.Errorf("expected interval %v for offset %d nanoseconds to be unhealthy",
+				i, maxOffset.Nanoseconds())
+		}
+	}
+}

--- a/rpc/heartbeat.go
+++ b/rpc/heartbeat.go
@@ -55,7 +55,7 @@ func (hs *HeartbeatService) Ping(args *PingRequest, reply *PingResponse) error {
 	// The server offset should be the opposite of the client offset.
 	serverOffset.Offset = -serverOffset.Offset
 	hs.remoteClockMonitor.UpdateOffset(args.Addr, serverOffset)
-	reply.ServerTime = hs.clock.Now().WallTime
+	reply.ServerTime = hs.clock.PhysicalNow()
 	return nil
 }
 

--- a/rpc/heartbeat_test.go
+++ b/rpc/heartbeat_test.go
@@ -30,7 +30,7 @@ func TestHeartbeatReply(t *testing.T) {
 	clock := hlc.NewClock(manual.UnixNano)
 	heartbeat := &HeartbeatService{
 		clock:              clock,
-		remoteClockMonitor: newRemoteClockMonitor(clock.MaxDrift()),
+		remoteClockMonitor: newRemoteClockMonitor(clock),
 	}
 
 	request := &PingRequest{
@@ -53,12 +53,12 @@ func TestManualHeartbeat(t *testing.T) {
 	clock := hlc.NewClock(manual.UnixNano)
 	manualHeartbeat := &ManualHeartbeatService{
 		clock:              clock,
-		remoteClockMonitor: newRemoteClockMonitor(clock.MaxDrift()),
+		remoteClockMonitor: newRemoteClockMonitor(clock),
 		ready:              make(chan bool, 1),
 	}
 	regularHeartbeat := &HeartbeatService{
 		clock:              clock,
-		remoteClockMonitor: newRemoteClockMonitor(clock.MaxDrift()),
+		remoteClockMonitor: newRemoteClockMonitor(clock),
 	}
 
 	request := &PingRequest{
@@ -111,7 +111,7 @@ func TestUpdateOffset(t *testing.T) {
 	if call.Error != nil {
 		t.Fatal(call.Error)
 	}
-	o := sContext.remoteClocks.offsets[conn.LocalAddr().String()]
+	o := sContext.RemoteClocks.offsets[conn.LocalAddr().String()]
 	if o != serverOffset {
 		t.Errorf("expected updated offset %v, instead %v", serverOffset, o)
 	}

--- a/rpc/rpc.go
+++ b/rpc/rpc.go
@@ -6,7 +6,7 @@ import "github.com/cockroachdb/cockroach/util/hlc"
 type Context struct {
 	localClock   *hlc.Clock
 	tlsConfig    *TLSConfig
-	remoteClocks *RemoteClockMonitor
+	RemoteClocks *RemoteClockMonitor
 }
 
 // NewContext creates an rpc Context with the supplied values.
@@ -14,6 +14,6 @@ func NewContext(clock *hlc.Clock, config *TLSConfig) *Context {
 	return &Context{
 		localClock:   clock,
 		tlsConfig:    config,
-		remoteClocks: newRemoteClockMonitor(clock.MaxDrift()),
+		RemoteClocks: newRemoteClockMonitor(clock),
 	}
 }

--- a/rpc/server.go
+++ b/rpc/server.go
@@ -31,8 +31,7 @@ import (
 // server struct. By default it handles a simple heartbeat protocol
 // to measure link health. It also supports close callbacks.
 //
-// TODO(spencer): heartbeat protocol should also measure link latency
-// and clock skew.
+// TODO(spencer): heartbeat protocol should also measure link latency.
 type Server struct {
 	*rpc.Server              // Embedded RPC server instance
 	listener    net.Listener // Server listener
@@ -54,7 +53,7 @@ func NewServer(addr net.Addr, context *Context) *Server {
 	}
 	heartbeat := &HeartbeatService{
 		clock:              context.localClock,
-		remoteClockMonitor: context.remoteClocks,
+		remoteClockMonitor: context.RemoteClocks,
 	}
 	s.RegisterName("Heartbeat", heartbeat)
 	return s

--- a/storage/db.go
+++ b/storage/db.go
@@ -438,7 +438,7 @@ func NewTransaction(name string, baseKey engine.Key, userPriority int32,
 	// Compute timestamp and max timestamp.
 	now := clock.Now()
 	max := now
-	max.WallTime += clock.MaxDrift().Nanoseconds()
+	max.WallTime += clock.MaxOffset().Nanoseconds()
 
 	return &proto.Transaction{
 		Name:         name,

--- a/storage/store_test.go
+++ b/storage/store_test.go
@@ -264,25 +264,25 @@ func TestStoreExecuteCmdWithZeroTime(t *testing.T) {
 	}
 }
 
-// TestStoreExecuteCmdWithClockDrift verifies that if the request
+// TestStoreExecuteCmdWithClockOffset verifies that if the request
 // specifies a timestamp further into the future than the node's
-// maximum allowed clock drift, the cmd fails with an error.
-func TestStoreExecuteCmdWithClockDrift(t *testing.T) {
+// maximum allowed clock offset, the cmd fails with an error.
+func TestStoreExecuteCmdWithClockOffset(t *testing.T) {
 	store, mc := createTestStore(true, t)
 	defer store.Close()
 	args, reply := getArgs([]byte("a"), 2)
 
 	// Set clock to time 1.
 	*mc = hlc.ManualClock(1)
-	// Set clock max drift to 250ms.
-	maxDrift := 250 * time.Millisecond
-	store.clock.SetMaxDrift(maxDrift)
-	// Set args timestamp to exceed max drift.
+	// Set clock max offset to 250ms.
+	maxOffset := 250 * time.Millisecond
+	store.clock.SetMaxOffset(maxOffset)
+	// Set args timestamp to exceed max offset.
 	args.Timestamp = store.clock.Now()
-	args.Timestamp.WallTime += maxDrift.Nanoseconds() + 1
+	args.Timestamp.WallTime += maxOffset.Nanoseconds() + 1
 	err := store.ExecuteCmd(Get, args, reply)
 	if err == nil {
-		t.Error("expected max drift clock error")
+		t.Error("expected max offset clock error")
 	}
 }
 

--- a/storage/timestamp_cache.go
+++ b/storage/timestamp_cache.go
@@ -78,7 +78,7 @@ func NewTimestampCache(clock *hlc.Clock) *TimestampCache {
 func (tc *TimestampCache) Clear(clock *hlc.Clock) {
 	tc.cache.Clear()
 	tc.lowWater = clock.Now()
-	tc.lowWater.WallTime += clock.MaxDrift().Nanoseconds()
+	tc.lowWater.WallTime += clock.MaxOffset().Nanoseconds()
 	tc.latest = tc.lowWater
 }
 

--- a/util/hlc/hlc_test.go
+++ b/util/hlc/hlc_test.go
@@ -103,11 +103,11 @@ func TestEqual(t *testing.T) {
 }
 
 // TestClock performs a complete test of all basic phenomena,
-// including backward jumps in local physical time and clock drift.
+// including backward jumps in local physical time and clock offset.
 func TestClock(t *testing.T) {
 	var m ManualClock
 	c := NewClock(m.UnixNano)
-	c.SetMaxDrift(1000)
+	c.SetMaxOffset(1000)
 	expectedHistory := []struct {
 		// The physical time that this event should take place at.
 		wallClock int64
@@ -158,18 +158,18 @@ func TestClock(t *testing.T) {
 	c.Now()
 }
 
-// TestSetMaxDrift ensures that checking received timestamps
-// for excessive drifts works correctly.
-func TestSetMaxDrift(t *testing.T) {
+// TestSetMaxOffset ensures that checking received timestamps
+// for excessive offsets works correctly.
+func TestSetMaxOffset(t *testing.T) {
 	var m ManualClock = 123456789
 	skewedTime := int64(123456789 + 51)
 	c := NewClock(m.UnixNano)
-	if c.MaxDrift() != 0 {
-		t.Fatalf("unexpected drift setting")
+	if c.MaxOffset() != 0 {
+		t.Fatalf("unexpected offset setting")
 	}
-	c.SetMaxDrift(50)
-	if c.MaxDrift() != 50 {
-		t.Fatalf("unexpected drift setting")
+	c.SetMaxOffset(50)
+	if c.MaxOffset() != 50 {
+		t.Fatalf("unexpected offset setting")
 	}
 	c.Now()
 	if c.Timestamp().WallTime != int64(m) {
@@ -177,13 +177,13 @@ func TestSetMaxDrift(t *testing.T) {
 	}
 	_, err := c.Update(proto.Timestamp{WallTime: skewedTime})
 	if err == nil {
-		t.Fatalf("clock drift not recognized")
+		t.Fatalf("clock offset not recognized")
 	}
-	// Disable drift checking.
-	c.SetMaxDrift(0)
+	// Disable offset checking.
+	c.SetMaxOffset(0)
 	_, err = c.Update(proto.Timestamp{WallTime: skewedTime})
 	if err != nil || c.Timestamp().WallTime != skewedTime {
-		t.Fatalf("failed to disable drift checking")
+		t.Fatalf("failed to disable offset checking")
 	}
 }
 


### PR DESCRIPTION
Disable offset checking if the maxOffset is set to 0

Rename all instances of Drift to Offset

Note that I switched to Marzullo's algorithm from the intersection algorithm, which still works I can still test that the interval was defined by a majority of clocks.
