### PR TITLE
Explicitly specify which golang tag we want.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang
+FROM golang:latest
 
 MAINTAINER Spencer Kimball <spencer.kimball@gmail.com>
 


### PR DESCRIPTION
Not specifying a tag causes all of the golang containers to be
downloaded even though only golang:latest will be used. This is
excessive in terms of time and disk space.
