### PR TITLE
Replace the GroupID typedef with plain uint64.

### DIFF
--- a/multiraft/events.go
+++ b/multiraft/events.go
@@ -20,7 +20,7 @@ package multiraft
 // An EventLeaderElection is broadcast when a group completes an election.
 // TODO(bdarnell): emit EventLeaderElection from follower nodes as well.
 type EventLeaderElection struct {
-	GroupID GroupID
+	GroupID uint64
 	NodeID  uint64
 }
 

--- a/multiraft/multiraft_test.go
+++ b/multiraft/multiraft_test.go
@@ -76,7 +76,7 @@ func (c *testCluster) stop() {
 }
 
 // createGroup replicates a group among the first numReplicas nodes in the cluster
-func (c *testCluster) createGroup(groupID GroupID, numReplicas int) {
+func (c *testCluster) createGroup(groupID uint64, numReplicas int) {
 	var replicaIDs []uint64
 	var replicaNodes []*state
 	for i := 0; i < numReplicas; i++ {
@@ -105,7 +105,7 @@ func TestInitialLeaderElection(t *testing.T) {
 	// The node that requests an election first should win.
 	for leaderIndex := 0; leaderIndex < 3; leaderIndex++ {
 		cluster := newTestCluster(3, t)
-		groupID := GroupID(1)
+		groupID := uint64(1)
 		cluster.createGroup(groupID, 3)
 
 		event := cluster.waitForElection(leaderIndex)
@@ -123,7 +123,7 @@ func TestInitialLeaderElection(t *testing.T) {
 func TestCommand(t *testing.T) {
 	cluster := newTestCluster(3, t)
 	defer cluster.stop()
-	groupID := GroupID(1)
+	groupID := uint64(1)
 	cluster.createGroup(groupID, 3)
 	cluster.waitForElection(0)
 
@@ -144,7 +144,7 @@ func TestCommand(t *testing.T) {
 func disabledTestSlowStorage(t *testing.T) {
 	cluster := newTestCluster(3, t)
 	defer cluster.stop()
-	groupID := GroupID(1)
+	groupID := uint64(1)
 	cluster.createGroup(groupID, 3)
 
 	cluster.waitForElection(0)
@@ -189,7 +189,7 @@ func TestMembershipChange(t *testing.T) {
 	defer cluster.stop()
 
 	// Create a group with a single member, cluster.nodes[0].
-	groupID := GroupID(1)
+	groupID := uint64(1)
 	cluster.createGroup(groupID, 1)
 	cluster.waitForElection(0)
 

--- a/multiraft/storage_test.go
+++ b/multiraft/storage_test.go
@@ -36,28 +36,28 @@ func (b *BlockableStorage) Unblock() {
 	return b.storage.LoadGroups()
 }*/
 
-func (b *BlockableStorage) SetGroupState(groupID GroupID,
+func (b *BlockableStorage) SetGroupState(groupID uint64,
 	state *GroupPersistentState) error {
 	b.wait()
 	return b.storage.SetGroupState(groupID, state)
 }
 
-func (b *BlockableStorage) AppendLogEntries(groupID GroupID, entries []*LogEntry) error {
+func (b *BlockableStorage) AppendLogEntries(groupID uint64, entries []*LogEntry) error {
 	b.wait()
 	return b.storage.AppendLogEntries(groupID, entries)
 }
 
-/*func (b *BlockableStorage) TruncateLog(groupID GroupID, lastIndex int) error {
+/*func (b *BlockableStorage) TruncateLog(groupID uint64, lastIndex int) error {
 	b.wait()
 	return b.storage.TruncateLog(groupID, lastIndex)
 }
 
-func (b *BlockableStorage) GetLogEntry(groupID GroupID, index int) (*LogEntry, error) {
+func (b *BlockableStorage) GetLogEntry(groupID uint64, index int) (*LogEntry, error) {
 	b.wait()
 	return b.storage.GetLogEntry(groupID, index)
 }
 
-func (b *BlockableStorage) GetLogEntries(groupID GroupID, firstIndex, lastIndex int,
+func (b *BlockableStorage) GetLogEntries(groupID uint64, firstIndex, lastIndex int,
 	ch chan<- *LogEntryState) {
 	b.wait()
 	b.storage.GetLogEntries(groupID, firstIndex, lastIndex, ch)

--- a/multiraft/transport.go
+++ b/multiraft/transport.go
@@ -43,7 +43,7 @@ type Transport interface {
 
 // SendMessageRequest wraps a raft message.
 type SendMessageRequest struct {
-	GroupID GroupID
+	GroupID uint64
 	Message raftpb.Message
 }
 


### PR DESCRIPTION
This mirrors the earlier removal of NodeID and prepares for moving to
etcd/raft (which uses raw integer types instead of named types everywhere).

@spencerkimball @cockroachdb/developers 
