### PR TITLE
Run the tests twice on travis-ci, instead of three times.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,7 +12,7 @@ before_install:
 
 install:
   - ./bootstrap.sh
-  - make GOFLAGS=-x
+  - make build GOFLAGS=-x
 
 script:
   # Note that testrace runs with some tests excluded for performance


### PR DESCRIPTION
"make" is equivalent to "make test", not "make build".

@spencerkimball @cockroachdb/developers 
