### PR TITLE
Provide a String() implementation for engine.Key.

### DIFF
--- a/storage/engine/keys.go
+++ b/storage/engine/keys.go
@@ -136,6 +136,13 @@ func (k Key) Compare(b interval.Comparable) int {
 	return bytes.Compare(k, b.(Key))
 }
 
+func (k Key) String() string {
+	if k.Equal(KeyMax) {
+		return "\xff..."
+	}
+	return string(k)
+}
+
 // Value specifies the value at a key. Multiple values at the same key
 // are supported based on timestamp.
 type Value struct {

--- a/storage/engine/keys_test.go
+++ b/storage/engine/keys_test.go
@@ -245,3 +245,9 @@ func TestRangeMetaKey(t *testing.T) {
 		}
 	}
 }
+
+func TestKeyString(t *testing.T) {
+	if KeyMax.String() != "\xff..." {
+		t.Errorf("expected key max to display a compact version: %s", KeyMax.String())
+	}
+}

--- a/storage/range.go
+++ b/storage/range.go
@@ -1454,7 +1454,7 @@ func (r *Range) AdminSplit(args *proto.AdminSplitRequest, reply *proto.AdminSpli
 	updatedDesc.EndKey = splitKey
 
 	log.Infof("initiating a split of range %d %q-%q at key %q", r.RangeID,
-		r.Desc.StartKey, r.Desc.EndKey, splitKey)
+		engine.Key(r.Desc.StartKey), engine.Key(r.Desc.EndKey), splitKey)
 
 	txnOpts := &TransactionOptions{
 		Name:         fmt.Sprintf("split range %d at %q", r.RangeID, splitKey),


### PR DESCRIPTION
In particular, display "\xff..." for keys equal to engine.KeyMax.
