### PR TITLE
Improve submodule versioning in Dockerfile.

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,4 +1,3 @@
-.git
 _vendor
 roachlib/*.o
 roachlib/*.a


### PR DESCRIPTION
Previously we would build against whatever revision was 'master' at the
time the docker image was built; now we use 'git submodule update'
to find the right version (while preserving as much as possible the
ability to build rocksdb only once)

@spencerkimball @cockroachdb/developers 
