### PR TITLE
Last clock offset cleanup.

### DIFF
--- a/rpc/heartbeat.go
+++ b/rpc/heartbeat.go
@@ -64,7 +64,8 @@ func (hs *HeartbeatService) Ping(args *PingRequest, reply *PingResponse) error {
 type ManualHeartbeatService struct {
 	clock              *hlc.Clock
 	remoteClockMonitor *RemoteClockMonitor
-	ready              chan bool // Heartbeats are processed when a value is sent here.
+	// Heartbeats are processed when a value is sent here.
+	ready chan struct{}
 }
 
 // Ping waits until the heartbeat service is ready to respond to a Heartbeat.

--- a/rpc/heartbeat_test.go
+++ b/rpc/heartbeat_test.go
@@ -54,7 +54,7 @@ func TestManualHeartbeat(t *testing.T) {
 	manualHeartbeat := &ManualHeartbeatService{
 		clock:              clock,
 		remoteClockMonitor: newRemoteClockMonitor(clock),
-		ready:              make(chan bool, 1),
+		ready:              make(chan struct{}, 1),
 	}
 	regularHeartbeat := &HeartbeatService{
 		clock:              clock,
@@ -64,7 +64,7 @@ func TestManualHeartbeat(t *testing.T) {
 	request := &PingRequest{
 		Ping: "testManual",
 	}
-	manualHeartbeat.ready <- true
+	manualHeartbeat.ready <- struct{}{}
 	manualResponse := &PingResponse{}
 	regularResponse := &PingResponse{}
 	regularHeartbeat.Ping(request, regularResponse)
@@ -81,7 +81,7 @@ func TestManualHeartbeat(t *testing.T) {
 	}
 }
 
-func TestUpdateOffset(t *testing.T) {
+func TestUpdateOffsetOnHeartbeat(t *testing.T) {
 	tlsConfig, err := LoadTestTLSConfig("..")
 	if err != nil {
 		t.Fatal(err)


### PR DESCRIPTION
Limit of 1.5 seconds for measuring clock offset,
to limit the maximum error on a read.

The remote clock reading with smallest error since the last cluster
offset measurement is now used, rather than the latest reading. 
