### PR TITLE
Fix slowdown of server/ unittests and prevent possible flaky test

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -35,8 +35,6 @@
     kv.DB and invoke db.coordinator.EndTxn(false) to clean up
     intents.
 
-* Investigate slowdown in server/ unittests.
-
 * In find mvcc split key, avoid illegal split keys such as meta1
   records and configuration keys. Probably ought to move to a single
   pass through the data instead of the weighted reservoir sample.

--- a/rpc/client_test.go
+++ b/rpc/client_test.go
@@ -120,6 +120,13 @@ func TestOffsetMeasurement(t *testing.T) {
 	context := NewContext(clientClock, tlsConfig)
 	c := NewClient(s.Addr(), nil, context)
 	<-c.Ready
+
+	// Ensure we get a good heartbeat before continuing.
+	err = util.IsTrueWithin(c.IsHealthy, heartbeatInterval*10)
+	if err != nil {
+		t.Fatal(err)
+	}
+
 	expectedOffset := RemoteOffset{Offset: 5, Error: 5, MeasuredAt: 10}
 	if o := c.RemoteOffset(); o != expectedOffset {
 		t.Errorf("expected offset %v, actual %v", expectedOffset, o)

--- a/rpc/clock_offset.go
+++ b/rpc/clock_offset.go
@@ -29,8 +29,12 @@ import (
 
 var (
 	// How often the cluster offset is measured.
-	monitorInterval = heartbeatInterval * 10
+	monitorInterval time.Duration
 )
+
+func init() {
+	monitorInterval = heartbeatInterval * 10
+}
 
 // RemoteClockMonitor keeps track of the most recent measurements of remote
 // offsets from this node to connected nodes.
@@ -171,6 +175,8 @@ func (r *RemoteClockMonitor) findOffsetInterval() (ClusterOffsetInterval, error)
 	endpoints := r.buildEndpointList()
 	sort.Sort(endpoints)
 	numClocks := len(endpoints) / 2
+	log.V(1).Infof("finding offset interval for monitorInterval: %d, numOffsets %d",
+		monitorInterval, numClocks)
 	if numClocks == 0 {
 		return ClusterOffsetInterval{
 			Lowerbound: 0,


### PR DESCRIPTION
Server tests were running very slowly because monitorInterval was default 0. I didn't realize that variable blocks are run before all init blocks. Since heartbeatInterval is only set in the init block of rpc/client.go, it was only 0 when monitorInterval was being evaluated.

With the monitorInterval now in the init block, the complier is smart enough to set heartbeatInterval before setting monitorInterval, because of the dependency.
