### PR TITLE
proto.Key and proto.EncKey for better static type checking!

### DIFF
--- a/kv/coordinator.go
+++ b/kv/coordinator.go
@@ -97,7 +97,7 @@ type txnMetadata struct {
 // addKeyRange adds the specified key range to the interval cache,
 // taking care not to add this range if existing entries already
 // completely cover the range.
-func (tm *txnMetadata) addKeyRange(start, end engine.Key) {
+func (tm *txnMetadata) addKeyRange(start, end proto.Key) {
 	if len(end) == 0 {
 		end = start.Next()
 	}
@@ -124,8 +124,8 @@ func (tm *txnMetadata) close(txn *proto.Transaction, db *DB) {
 		db.InternalResolveIntent(&proto.InternalResolveIntentRequest{
 			RequestHeader: proto.RequestHeader{
 				Timestamp: txn.Timestamp,
-				Key:       o.Key.Start().(engine.Key),
-				EndKey:    o.Key.End().(engine.Key),
+				Key:       o.Key.Start().(proto.Key),
+				EndKey:    o.Key.End().(proto.Key),
 				User:      storage.UserRoot,
 				Txn:       txn,
 			},
@@ -234,7 +234,7 @@ func (tc *coordinator) EndTxn(txn *proto.Transaction) {
 // txnID has not been updated by the client adding a request within
 // the allowed timeout. If abandoned, the transaction is removed from
 // the txns map.
-func (tc *coordinator) hasClientAbandonedCoord(txnID engine.Key) bool {
+func (tc *coordinator) hasClientAbandonedCoord(txnID proto.Key) bool {
 	tc.Lock()
 	defer tc.Unlock()
 	txnMeta, ok := tc.txns[string(txnID)]

--- a/kv/dist_kv.go
+++ b/kv/dist_kv.go
@@ -123,7 +123,7 @@ func (kv *DistKV) verifyPermissions(method string, header *proto.RequestHeader) 
 		end = header.Key
 	}
 	return permMap.(storage.PrefixConfigMap).VisitPrefixes(
-		header.Key, end, func(start, end engine.Key, config interface{}) error {
+		header.Key, end, func(start, end proto.Key, config interface{}) error {
 			perm := config.(*proto.PermConfig)
 			if storage.NeedReadPerm(method) && !perm.CanRead(header.User) {
 				return util.Errorf("user %q cannot invoke %s on range %q-%q; permissions: %+v",
@@ -150,7 +150,7 @@ func (kv *DistKV) nodeIDToAddr(nodeID int32) (net.Addr, error) {
 
 // internalRangeLookup dispatches an InternalRangeLookup request for the given
 // metadata key to the replicas of the given range.
-func (kv *DistKV) internalRangeLookup(key engine.Key,
+func (kv *DistKV) internalRangeLookup(key proto.Key,
 	info *proto.RangeDescriptor) ([]proto.RangeDescriptor, error) {
 	args := &proto.InternalRangeLookupRequest{
 		RequestHeader: proto.RequestHeader{
@@ -189,7 +189,7 @@ func (kv *DistKV) getFirstRangeDescriptor() (*proto.RangeDescriptor, error) {
 // RangeDescriptors are returned with the intent of pre-caching
 // subsequent ranges which are likely to be requested soon by the
 // current workload.
-func (kv *DistKV) getRangeDescriptor(key engine.Key) ([]proto.RangeDescriptor, error) {
+func (kv *DistKV) getRangeDescriptor(key proto.Key) ([]proto.RangeDescriptor, error) {
 	var (
 		// metadataKey is sent to InternalRangeLookup to find the
 		// RangeDescriptor which contains key.

--- a/kv/dist_kv_test.go
+++ b/kv/dist_kv_test.go
@@ -35,8 +35,8 @@ func TestGetFirstRangeDescriptor(t *testing.T) {
 		t.Errorf("expected not to find first range descriptor")
 	}
 	expectedDesc := &proto.RangeDescriptor{}
-	expectedDesc.StartKey = engine.Key("a")
-	expectedDesc.EndKey = engine.Key("c")
+	expectedDesc.StartKey = proto.Key("a")
+	expectedDesc.EndKey = proto.Key("c")
 
 	// Add first RangeDescriptor to a node different from the node for this kv
 	// and ensure that this kv has the information within a given time.
@@ -73,7 +73,7 @@ func TestVerifyPermissions(t *testing.T) {
 		Write: []string{"write2", "writeAll", "rw2", "rwAll"}}
 	configs := []*storage.PrefixConfig{
 		{engine.KeyMin, nil, config1},
-		{engine.Key("a"), nil, config2},
+		{proto.Key("a"), nil, config2},
 	}
 	configMap, err := storage.NewPrefixConfigMap(configs)
 	if err != nil {
@@ -103,7 +103,7 @@ func TestVerifyPermissions(t *testing.T) {
 		// Permission-based db methods from the storage package.
 		methods          []string
 		user             string
-		startKey, endKey engine.Key
+		startKey, endKey proto.Key
 		hasPermission    bool
 	}{
 		// Test permissions within a single range
@@ -119,26 +119,26 @@ func TestVerifyPermissions(t *testing.T) {
 		{writeOnlyMethods, "read1", engine.KeyMin, engine.KeyMin, false},
 		{writeOnlyMethods, "random", engine.KeyMin, engine.KeyMin, false},
 		// Test permissions across both ranges
-		{readOnlyMethods, "readAll", engine.KeyMin, engine.Key("b"), true},
-		{readOnlyMethods, "read1", engine.KeyMin, engine.Key("b"), false},
-		{readOnlyMethods, "read2", engine.KeyMin, engine.Key("b"), false},
-		{readOnlyMethods, "random", engine.KeyMin, engine.Key("b"), false},
-		{readWriteMethods, "rwAll", engine.KeyMin, engine.Key("b"), true},
-		{readWriteMethods, "rw", engine.KeyMin, engine.Key("b"), false},
-		{readWriteMethods, "random", engine.KeyMin, engine.Key("b"), false},
-		{writeOnlyMethods, "writeAll", engine.KeyMin, engine.Key("b"), true},
-		{writeOnlyMethods, "write1", engine.KeyMin, engine.Key("b"), false},
-		{writeOnlyMethods, "write2", engine.KeyMin, engine.Key("b"), false},
-		{writeOnlyMethods, "random", engine.KeyMin, engine.Key("b"), false},
+		{readOnlyMethods, "readAll", engine.KeyMin, proto.Key("b"), true},
+		{readOnlyMethods, "read1", engine.KeyMin, proto.Key("b"), false},
+		{readOnlyMethods, "read2", engine.KeyMin, proto.Key("b"), false},
+		{readOnlyMethods, "random", engine.KeyMin, proto.Key("b"), false},
+		{readWriteMethods, "rwAll", engine.KeyMin, proto.Key("b"), true},
+		{readWriteMethods, "rw", engine.KeyMin, proto.Key("b"), false},
+		{readWriteMethods, "random", engine.KeyMin, proto.Key("b"), false},
+		{writeOnlyMethods, "writeAll", engine.KeyMin, proto.Key("b"), true},
+		{writeOnlyMethods, "write1", engine.KeyMin, proto.Key("b"), false},
+		{writeOnlyMethods, "write2", engine.KeyMin, proto.Key("b"), false},
+		{writeOnlyMethods, "random", engine.KeyMin, proto.Key("b"), false},
 		// Test permissions within and around the boundaries of a range,
 		// representatively using rw methods.
-		{readWriteMethods, "rw2", engine.Key("a"), engine.Key("b"), true},
-		{readWriteMethods, "rwAll", engine.Key("a"), engine.Key("b"), true},
-		{readWriteMethods, "rw2", engine.Key("a"), engine.Key("a"), true},
-		{readWriteMethods, "rw2", engine.Key("a"), engine.Key("a1"), true},
-		{readWriteMethods, "rw2", engine.Key("a"), engine.Key("b1"), false},
-		{readWriteMethods, "rw2", engine.Key("a3"), engine.Key("a4"), true},
-		{readWriteMethods, "rw2", engine.Key("a3"), engine.Key("b1"), false},
+		{readWriteMethods, "rw2", proto.Key("a"), proto.Key("b"), true},
+		{readWriteMethods, "rwAll", proto.Key("a"), proto.Key("b"), true},
+		{readWriteMethods, "rw2", proto.Key("a"), proto.Key("a"), true},
+		{readWriteMethods, "rw2", proto.Key("a"), proto.Key("a1"), true},
+		{readWriteMethods, "rw2", proto.Key("a"), proto.Key("b1"), false},
+		{readWriteMethods, "rw2", proto.Key("a3"), proto.Key("a4"), true},
+		{readWriteMethods, "rw2", proto.Key("a3"), proto.Key("b1"), false},
 	}
 
 	for _, test := range testData {

--- a/kv/local_kv.go
+++ b/kv/local_kv.go
@@ -23,7 +23,6 @@ import (
 
 	"github.com/cockroachdb/cockroach/proto"
 	"github.com/cockroachdb/cockroach/storage"
-	"github.com/cockroachdb/cockroach/storage/engine"
 	"github.com/cockroachdb/cockroach/util"
 )
 
@@ -149,7 +148,7 @@ func (kv *LocalKV) Close() {
 
 // lookupReplica looks up replica by key [range]. Lookups are done
 // by consulting each store in turn via Store.LookupRange(key).
-func (kv *LocalKV) lookupReplica(start, end engine.Key) (*proto.Replica, error) {
+func (kv *LocalKV) lookupReplica(start, end proto.Key) (*proto.Replica, error) {
 	kv.mu.RLock()
 	defer kv.mu.RUnlock()
 	for _, store := range kv.storeMap {

--- a/kv/local_kv_test.go
+++ b/kv/local_kv_test.go
@@ -100,7 +100,7 @@ func TestLocalKVGetStore(t *testing.T) {
 	}
 }
 
-func splitTestRange(store *storage.Store, key, splitKey engine.Key, t *testing.T) *storage.Range {
+func splitTestRange(store *storage.Store, key, splitKey proto.Key, t *testing.T) *storage.Range {
 	rng := store.LookupRange(key, key)
 	if rng == nil {
 		t.Fatalf("couldn't lookup range for key %q", key)
@@ -133,7 +133,7 @@ func TestLocalKVLookupReplica(t *testing.T) {
 	if err := store.Init(); err != nil {
 		t.Fatal(err)
 	}
-	rng := splitTestRange(store, engine.KeyMin, engine.Key("a"), t)
+	rng := splitTestRange(store, engine.KeyMin, proto.Key("a"), t)
 	if err := store.RemoveRange(rng); err != nil {
 		t.Fatal(err)
 	}
@@ -142,10 +142,10 @@ func TestLocalKVLookupReplica(t *testing.T) {
 	var s [2]*storage.Store
 	ranges := []struct {
 		storeID    int32
-		start, end engine.Key
+		start, end proto.Key
 	}{
-		{2, engine.Key("a"), engine.Key("c")},
-		{3, engine.Key("x"), engine.Key("z")},
+		{2, proto.Key("a"), proto.Key("c")},
+		{3, proto.Key("x"), proto.Key("z")},
 	}
 	for i, rng := range ranges {
 		s[i] = storage.NewStore(clock, eng, db, nil)
@@ -159,19 +159,19 @@ func TestLocalKVLookupReplica(t *testing.T) {
 		kv.AddStore(s[i])
 	}
 
-	if r, err := kv.lookupReplica(engine.Key("a"), engine.Key("c")); r.StoreID != s[0].Ident.StoreID || err != nil {
+	if r, err := kv.lookupReplica(proto.Key("a"), proto.Key("c")); r.StoreID != s[0].Ident.StoreID || err != nil {
 		t.Errorf("expected store %d; got %d: %v", s[0].Ident.StoreID, r.StoreID, err)
 	}
-	if r, err := kv.lookupReplica(engine.Key("b"), nil); r.StoreID != s[0].Ident.StoreID || err != nil {
+	if r, err := kv.lookupReplica(proto.Key("b"), nil); r.StoreID != s[0].Ident.StoreID || err != nil {
 		t.Errorf("expected store %d; got %d: %v", s[0].Ident.StoreID, r.StoreID, err)
 	}
-	if r, err := kv.lookupReplica(engine.Key("b"), engine.Key("d")); r != nil || err == nil {
+	if r, err := kv.lookupReplica(proto.Key("b"), proto.Key("d")); r != nil || err == nil {
 		t.Errorf("expected store 0 and error got %d", r.StoreID)
 	}
-	if r, err := kv.lookupReplica(engine.Key("x"), engine.Key("z")); r.StoreID != s[1].Ident.StoreID {
+	if r, err := kv.lookupReplica(proto.Key("x"), proto.Key("z")); r.StoreID != s[1].Ident.StoreID {
 		t.Errorf("expected store %d; got %d: %v", s[1].Ident.StoreID, r.StoreID, err)
 	}
-	if r, err := kv.lookupReplica(engine.Key("y"), nil); r.StoreID != s[1].Ident.StoreID || err != nil {
+	if r, err := kv.lookupReplica(proto.Key("y"), nil); r.StoreID != s[1].Ident.StoreID || err != nil {
 		t.Errorf("expected store %d; got %d: %v", s[1].Ident.StoreID, r.StoreID, err)
 	}
 }

--- a/kv/range_cache.go
+++ b/kv/range_cache.go
@@ -35,7 +35,7 @@ const (
 
 // rangeCacheKey is the key type used to store and sort values in the
 // RangeCache.
-type rangeCacheKey engine.Key
+type rangeCacheKey proto.Key
 
 // Compare implements the llrb.Comparable interface for rangeCacheKey, so that
 // it can be used as a key for util.OrderedCache.
@@ -60,7 +60,7 @@ type rangeDescriptorDB interface {
 	// RangeDescriptors are returned with the intent of pre-caching
 	// subsequent ranges which are likely to be requested soon by the
 	// current workload.
-	getRangeDescriptor(engine.Key) ([]proto.RangeDescriptor, error)
+	getRangeDescriptor(proto.Key) ([]proto.RangeDescriptor, error)
 }
 
 // RangeDescriptorCache is used to retrieve range descriptors for
@@ -104,7 +104,7 @@ func NewRangeDescriptorCache(db rangeDescriptorDB) *RangeDescriptorCache {
 //
 // This method returns the RangeDescriptor for the range containing
 // the key's data, or an error if any occurred.
-func (rmc *RangeDescriptorCache) LookupRangeDescriptor(key engine.Key) (*proto.RangeDescriptor, error) {
+func (rmc *RangeDescriptorCache) LookupRangeDescriptor(key proto.Key) (*proto.RangeDescriptor, error) {
 	_, r := rmc.getCachedRangeDescriptor(key)
 	if r != nil {
 		return r, nil
@@ -126,7 +126,7 @@ func (rmc *RangeDescriptorCache) LookupRangeDescriptor(key engine.Key) (*proto.R
 // for the given key. It is intended that this method be called from a
 // consumer of RangeDescriptorCache if the returned range descriptor is
 // discovered to be stale.
-func (rmc *RangeDescriptorCache) EvictCachedRangeDescriptor(key engine.Key) {
+func (rmc *RangeDescriptorCache) EvictCachedRangeDescriptor(key proto.Key) {
 	for {
 		k, _ := rmc.getCachedRangeDescriptor(key)
 		if k != nil {
@@ -147,7 +147,7 @@ func (rmc *RangeDescriptorCache) EvictCachedRangeDescriptor(key engine.Key) {
 // getCachedRangeDescriptor is a helper function to retrieve the
 // descriptor of the range which contains the given key, if present in
 // the cache.
-func (rmc *RangeDescriptorCache) getCachedRangeDescriptor(key engine.Key) (
+func (rmc *RangeDescriptorCache) getCachedRangeDescriptor(key proto.Key) (
 	rangeCacheKey, *proto.RangeDescriptor) {
 	metaKey := engine.RangeMetaKey(key)
 	rmc.rangeCacheMu.RLock()
@@ -161,7 +161,7 @@ func (rmc *RangeDescriptorCache) getCachedRangeDescriptor(key engine.Key) (
 	rd := v.(*proto.RangeDescriptor)
 
 	// Check that key actually belongs to range
-	if !rd.ContainsKey(key.Address()) {
+	if !rd.ContainsKey(engine.KeyAddress(key)) {
 		return nil, nil
 	}
 	return metaEndKey, rd

--- a/kv/rest_test.go
+++ b/kv/rest_test.go
@@ -398,7 +398,7 @@ func TestKeysAndBodyArePreserved(t *testing.T) {
 	}
 	gr := <-testDB.Get(&proto.GetRequest{
 		RequestHeader: proto.RequestHeader{
-			Key:  engine.Key("\x00some/key that encodes世界"),
+			Key:  proto.Key("\x00some/key that encodes世界"),
 			User: storage.UserRoot,
 		},
 	})

--- a/kv/split_test.go
+++ b/kv/split_test.go
@@ -95,7 +95,7 @@ func TestRangeSplitsWithConcurrentTxns(t *testing.T) {
 	txnChannel := make(chan struct{}, 1000)
 
 	// Set five split keys, about evenly spaced along the range of random keys.
-	splitKeys := []engine.Key{engine.Key("G"), engine.Key("R"), engine.Key("a"), engine.Key("l"), engine.Key("s")}
+	splitKeys := []proto.Key{proto.Key("G"), proto.Key("R"), proto.Key("a"), proto.Key("l"), proto.Key("s")}
 
 	// Start up the concurrent goroutines which run transactions.
 	const concurrency = 10

--- a/kv/txn_db.go
+++ b/kv/txn_db.go
@@ -135,7 +135,7 @@ func (tdb *txnDB) executeCmd(method string, args proto.Request, replyChan interf
 	if tdb.txn == nil {
 		// Use Key.Address() for base key or else the txn record isn't
 		// guaranteed to be located on the same range as the first key.
-		tdb.txn = storage.NewTransaction(tdb.Name, engine.Key(args.Header().Key).Address(),
+		tdb.txn = storage.NewTransaction(tdb.Name, engine.KeyAddress(args.Header().Key),
 			tdb.UserPriority, tdb.Isolation, tdb.clock)
 		tdb.timestamp = tdb.txn.Timestamp
 	}

--- a/proto/api.proto
+++ b/proto/api.proto
@@ -54,9 +54,9 @@ message RequestHeader {
   optional ClientCmdID cmd_id = 2 [(gogoproto.nullable) = false, (gogoproto.customname) = "CmdID"];
   // The key for request. If the request operates on a range, this
   // represents the starting key for the range.
-  optional bytes key = 3 [(gogoproto.nullable) = false];
+  optional bytes key = 3 [(gogoproto.nullable) = false, (gogoproto.customtype) = "Key"];
   // End key is empty if request spans only a single key.
-  optional bytes end_key = 4 [(gogoproto.nullable) = false];
+  optional bytes end_key = 4 [(gogoproto.nullable) = false, (gogoproto.customtype) = "Key"];
   // User is the originating user. Used to lookup priority when
   // scheduling queued operations at target node.
   optional string user = 5 [(gogoproto.nullable) = false];
@@ -345,7 +345,7 @@ message EnqueueMessageResponse {
 // recomputed).
 message AdminSplitRequest {
   optional RequestHeader header = 1 [(gogoproto.nullable) = false, (gogoproto.embed) = true];
-  optional bytes split_key = 2;
+  optional bytes split_key = 2 [(gogoproto.nullable) = false, (gogoproto.customtype) = "Key"];
 }
 
 // An AdminSplitResponse is the return value from the AdminSplit()

--- a/proto/config.proto
+++ b/proto/config.proto
@@ -44,11 +44,11 @@ message Replica {
 message RangeDescriptor {
   optional int64 raft_id = 1 [(gogoproto.nullable) = false, (gogoproto.customname) = "RaftID"];
   // StartKey is the first key which may be contained by this range.
-  optional bytes start_key = 2 [(gogoproto.nullable) = false];
+  optional bytes start_key = 2 [(gogoproto.nullable) = false, (gogoproto.customtype) = "Key"];
   // EndKey marks the end of the range's possible keys.  EndKey itself is not
   // contained in this range - it will be contained in the immediately
   // subsequent range.
-  optional bytes end_key = 3 [(gogoproto.nullable) = false];
+  optional bytes end_key = 3 [(gogoproto.nullable) = false, (gogoproto.customtype) = "Key"];
   // List of replicas where this range is stored.
   repeated Replica replicas = 4 [(gogoproto.nullable) = false];
 }

--- a/proto/data.proto
+++ b/proto/data.proto
@@ -71,13 +71,13 @@ message MVCCValue {
 // KeyValue is a pair of Key and Value for returned Key/Value pairs
 // from ScanRequest/ScanResponse. It embeds a Key and a Value.
 message KeyValue {
-  optional bytes key = 1 [(gogoproto.nullable) = false];
+  optional bytes key = 1 [(gogoproto.nullable) = false, (gogoproto.customtype) = "Key"];
   optional Value value = 2 [(gogoproto.nullable) = false];
 }
 
 // RawKeyValue contains the raw bytes of the value for a key.
 message RawKeyValue {
-  optional bytes key = 1 [(gogoproto.nullable) = false];
+  optional bytes key = 1 [(gogoproto.nullable) = false, (gogoproto.customtype) = "EncodedKey"];
   optional bytes value = 2 [(gogoproto.nullable) = false];
 }
 

--- a/proto/errors.proto
+++ b/proto/errors.proto
@@ -43,8 +43,8 @@ message RangeNotFoundError {
 // A RangeKeyMismatchError indicates that a command was sent to a
 // range which did not contain the key(s) specified by the command.
 message RangeKeyMismatchError {
-  optional bytes request_start_key = 1 [(gogoproto.nullable) = false];
-  optional bytes request_end_key = 2 [(gogoproto.nullable) = false];
+  optional bytes request_start_key = 1 [(gogoproto.nullable) = false, (gogoproto.customtype) = "Key"];
+  optional bytes request_end_key = 2 [(gogoproto.nullable) = false, (gogoproto.customtype) = "Key"];
   optional RangeDescriptor range = 3;
 }
 
@@ -82,7 +82,7 @@ message TransactionStatusError {
 // the client may retry the operation immediately. If Resolved is
 // false, the client should back off and retry.
 message WriteIntentError {
-  optional bytes key = 1 [(gogoproto.nullable) = false];
+  optional bytes key = 1 [(gogoproto.nullable) = false, (gogoproto.customtype) = "Key"];
   optional Transaction txn = 2 [(gogoproto.nullable) = false];
   optional bool resolved = 3 [(gogoproto.nullable) = false];
 }

--- a/server/accounting.go
+++ b/server/accounting.go
@@ -58,7 +58,7 @@ func (ah *acctHandler) Put(path string, body []byte, r *http.Request) error {
 	if err != nil {
 		return util.Errorf("accounting config has invalid format: %s: %s", configStr, err)
 	}
-	acctKey := engine.MakeKey(engine.KeyConfigAccountingPrefix, engine.Key(path[1:]))
+	acctKey := engine.MakeKey(engine.KeyConfigAccountingPrefix, proto.Key(path[1:]))
 	if err := storage.PutProto(ah.db, acctKey, config); err != nil {
 		return err
 	}
@@ -102,7 +102,7 @@ func (ah *acctHandler) Get(path string, r *http.Request) (body []byte, contentTy
 			err = util.Errorf("unable to format accouting configurations: %s", err)
 		}
 	} else {
-		acctKey := engine.MakeKey(engine.KeyConfigAccountingPrefix, engine.Key(path[1:]))
+		acctKey := engine.MakeKey(engine.KeyConfigAccountingPrefix, proto.Key(path[1:]))
 		var ok bool
 		config := &proto.AcctConfig{}
 		if ok, _, err = storage.GetProto(ah.db, acctKey, config); err != nil {
@@ -149,7 +149,7 @@ func (ah *acctHandler) Delete(path string, r *http.Request) error {
 	if path == "/" {
 		return util.Errorf("the default accounting configuration cannot be deleted")
 	}
-	acctKey := engine.MakeKey(engine.KeyConfigAccountingPrefix, engine.Key(path[1:]))
+	acctKey := engine.MakeKey(engine.KeyConfigAccountingPrefix, proto.Key(path[1:]))
 	dr := <-ah.db.Delete(&proto.DeleteRequest{
 		RequestHeader: proto.RequestHeader{
 			Key:  acctKey,

--- a/server/accounting_test.go
+++ b/server/accounting_test.go
@@ -40,13 +40,13 @@ func ExampleSetAndGetAccts() {
 	defer os.Remove(testConfigFn)
 
 	testData := []struct {
-		prefix engine.Key
+		prefix proto.Key
 		yaml   string
 	}{
 		{engine.KeyMin, testAcctConfig},
-		{engine.Key("db1"), testAcctConfig},
-		{engine.Key("db 2"), testAcctConfig},
-		{engine.Key("\xfe"), testAcctConfig},
+		{proto.Key("db1"), testAcctConfig},
+		{proto.Key("db 2"), testAcctConfig},
+		{proto.Key("\xfe"), testAcctConfig},
 	}
 
 	for _, test := range testData {
@@ -81,12 +81,12 @@ func ExampleLsAccts() {
 	testConfigFn := createTestConfigFile(testAcctConfig)
 	defer os.Remove(testConfigFn)
 
-	keys := []engine.Key{
+	keys := []proto.Key{
 		engine.KeyMin,
-		engine.Key("db1"),
-		engine.Key("db2"),
-		engine.Key("db3"),
-		engine.Key("user"),
+		proto.Key("db1"),
+		proto.Key("db2"),
+		proto.Key("db3"),
+		proto.Key("user"),
 	}
 
 	regexps := []string{
@@ -139,9 +139,9 @@ func ExampleRmAccts() {
 	testConfigFn := createTestConfigFile(testAcctConfig)
 	defer os.Remove(testConfigFn)
 
-	keys := []engine.Key{
+	keys := []proto.Key{
 		engine.KeyMin,
-		engine.Key("db1"),
+		proto.Key("db1"),
 	}
 
 	for _, key := range keys {

--- a/server/node_test.go
+++ b/server/node_test.go
@@ -70,7 +70,7 @@ func createTestNode(addr net.Addr, engines []engine.Engine, gossipBS net.Addr, t
 	return rpcServer, node
 }
 
-func formatKeys(keys []engine.Key) string {
+func formatKeys(keys []proto.Key) string {
 	var buf bytes.Buffer
 	for i, key := range keys {
 		buf.WriteString(fmt.Sprintf("%d: %s\n", i, key))
@@ -100,18 +100,18 @@ func TestBootstrapCluster(t *testing.T) {
 	if sr.Error != nil {
 		t.Fatal(sr.Error)
 	}
-	var keys []engine.Key
+	var keys []proto.Key
 	for _, kv := range sr.Rows {
 		keys = append(keys, kv.Key)
 	}
-	var expectedKeys = []engine.Key{
-		engine.MakeKey(engine.Key("\x00\x00meta1"), engine.KeyMax),
-		engine.MakeKey(engine.Key("\x00\x00meta2"), engine.KeyMax),
-		engine.Key("\x00acct"),
-		engine.Key("\x00node-idgen"),
-		engine.Key("\x00perm"),
-		engine.Key("\x00store-idgen-1"),
-		engine.Key("\x00zone"),
+	var expectedKeys = []proto.Key{
+		engine.MakeKey(proto.Key("\x00\x00meta1"), engine.KeyMax),
+		engine.MakeKey(proto.Key("\x00\x00meta2"), engine.KeyMax),
+		proto.Key("\x00acct"),
+		proto.Key("\x00node-idgen"),
+		proto.Key("\x00perm"),
+		proto.Key("\x00store-idgen-1"),
+		proto.Key("\x00zone"),
 	}
 	if !reflect.DeepEqual(keys, expectedKeys) {
 		t.Errorf("expected keys mismatch:\n%s\n  -- vs. -- \n\n%s",

--- a/server/permission.go
+++ b/server/permission.go
@@ -58,7 +58,7 @@ func (ph *permHandler) Put(path string, body []byte, r *http.Request) error {
 	if err != nil {
 		return util.Errorf("permission config has invalid format: %s: %s", configStr, err)
 	}
-	permKey := engine.MakeKey(engine.KeyConfigPermissionPrefix, engine.Key(path[1:]))
+	permKey := engine.MakeKey(engine.KeyConfigPermissionPrefix, proto.Key(path[1:]))
 	if err := storage.PutProto(ph.db, permKey, config); err != nil {
 		return err
 	}
@@ -102,7 +102,7 @@ func (ph *permHandler) Get(path string, r *http.Request) (body []byte, contentTy
 			err = util.Errorf("unable to format permission configurations: %s", err)
 		}
 	} else {
-		permKey := engine.MakeKey(engine.KeyConfigPermissionPrefix, engine.Key(path[1:]))
+		permKey := engine.MakeKey(engine.KeyConfigPermissionPrefix, proto.Key(path[1:]))
 		var ok bool
 		config := &proto.PermConfig{}
 		if ok, _, err = storage.GetProto(ph.db, permKey, config); err != nil {
@@ -149,7 +149,7 @@ func (ph *permHandler) Delete(path string, r *http.Request) error {
 	if path == "/" {
 		return util.Errorf("the default permission configuration cannot be deleted")
 	}
-	permKey := engine.MakeKey(engine.KeyConfigPermissionPrefix, engine.Key(path[1:]))
+	permKey := engine.MakeKey(engine.KeyConfigPermissionPrefix, proto.Key(path[1:]))
 	dr := <-ph.db.Delete(&proto.DeleteRequest{
 		RequestHeader: proto.RequestHeader{
 			Key:  permKey,

--- a/server/permission_test.go
+++ b/server/permission_test.go
@@ -43,13 +43,13 @@ func ExampleSetAndGetPerms() {
 	defer os.Remove(testConfigFn)
 
 	testData := []struct {
-		prefix engine.Key
+		prefix proto.Key
 		yaml   string
 	}{
 		{engine.KeyMin, testPermConfig},
-		{engine.Key("db1"), testPermConfig},
-		{engine.Key("db 2"), testPermConfig},
-		{engine.Key("\xfe"), testPermConfig},
+		{proto.Key("db1"), testPermConfig},
+		{proto.Key("db 2"), testPermConfig},
+		{proto.Key("\xfe"), testPermConfig},
 	}
 
 	for _, test := range testData {
@@ -104,12 +104,12 @@ func ExampleLsPerms() {
 	testConfigFn := createTestConfigFile(testPermConfig)
 	defer os.Remove(testConfigFn)
 
-	keys := []engine.Key{
+	keys := []proto.Key{
 		engine.KeyMin,
-		engine.Key("db1"),
-		engine.Key("db2"),
-		engine.Key("db3"),
-		engine.Key("user"),
+		proto.Key("db1"),
+		proto.Key("db2"),
+		proto.Key("db3"),
+		proto.Key("user"),
 	}
 
 	regexps := []string{
@@ -162,9 +162,9 @@ func ExampleRmPerms() {
 	testConfigFn := createTestConfigFile(testPermConfig)
 	defer os.Remove(testConfigFn)
 
-	keys := []engine.Key{
+	keys := []proto.Key{
 		engine.KeyMin,
-		engine.Key("db1"),
+		proto.Key("db1"),
 	}
 
 	for _, key := range keys {

--- a/server/zone.go
+++ b/server/zone.go
@@ -58,7 +58,7 @@ func (zh *zoneHandler) Put(path string, body []byte, r *http.Request) error {
 	if err != nil {
 		return util.Errorf("zone config has invalid format: %s: %s", configStr, err)
 	}
-	zoneKey := engine.MakeKey(engine.KeyConfigZonePrefix, engine.Key(path[1:]))
+	zoneKey := engine.MakeKey(engine.KeyConfigZonePrefix, proto.Key(path[1:]))
 	if err := storage.PutProto(zh.db, zoneKey, config); err != nil {
 		return err
 	}
@@ -102,7 +102,7 @@ func (zh *zoneHandler) Get(path string, r *http.Request) (body []byte, contentTy
 			err = util.Errorf("unable to format zone configurations: %s", err)
 		}
 	} else {
-		zoneKey := engine.MakeKey(engine.KeyConfigZonePrefix, engine.Key(path[1:]))
+		zoneKey := engine.MakeKey(engine.KeyConfigZonePrefix, proto.Key(path[1:]))
 		var ok bool
 		config := &proto.ZoneConfig{}
 		if ok, _, err = storage.GetProto(zh.db, zoneKey, config); err != nil {
@@ -149,7 +149,7 @@ func (zh *zoneHandler) Delete(path string, r *http.Request) error {
 	if path == "/" {
 		return util.Errorf("the default zone configuration cannot be deleted")
 	}
-	zoneKey := engine.MakeKey(engine.KeyConfigZonePrefix, engine.Key(path[1:]))
+	zoneKey := engine.MakeKey(engine.KeyConfigZonePrefix, proto.Key(path[1:]))
 	dr := <-zh.db.Delete(&proto.DeleteRequest{
 		RequestHeader: proto.RequestHeader{
 			Key:  zoneKey,

--- a/server/zone_test.go
+++ b/server/zone_test.go
@@ -47,13 +47,13 @@ func ExampleSetAndGetZone() {
 	defer os.Remove(testConfigFn)
 
 	testData := []struct {
-		prefix engine.Key
+		prefix proto.Key
 		yaml   string
 	}{
 		{engine.KeyMin, testZoneConfig},
-		{engine.Key("db1"), testZoneConfig},
-		{engine.Key("db 2"), testZoneConfig},
-		{engine.Key("\xfe"), testZoneConfig},
+		{proto.Key("db1"), testZoneConfig},
+		{proto.Key("db 2"), testZoneConfig},
+		{proto.Key("\xfe"), testZoneConfig},
 	}
 
 	for _, test := range testData {
@@ -108,12 +108,12 @@ func ExampleLsZones() {
 	testConfigFn := createTestConfigFile(testZoneConfig)
 	defer os.Remove(testConfigFn)
 
-	keys := []engine.Key{
+	keys := []proto.Key{
 		engine.KeyMin,
-		engine.Key("db1"),
-		engine.Key("db2"),
-		engine.Key("db3"),
-		engine.Key("user"),
+		proto.Key("db1"),
+		proto.Key("db2"),
+		proto.Key("db3"),
+		proto.Key("user"),
 	}
 
 	regexps := []string{
@@ -166,9 +166,9 @@ func ExampleRmZones() {
 	testConfigFn := createTestConfigFile(testZoneConfig)
 	defer os.Remove(testConfigFn)
 
-	keys := []engine.Key{
+	keys := []proto.Key{
 		engine.KeyMin,
-		engine.Key("db1"),
+		proto.Key("db1"),
 	}
 
 	for _, key := range keys {

--- a/storage/command_queue.go
+++ b/storage/command_queue.go
@@ -20,7 +20,7 @@ package storage
 import (
 	"sync"
 
-	"github.com/cockroachdb/cockroach/storage/engine"
+	"github.com/cockroachdb/cockroach/proto"
 	"github.com/cockroachdb/cockroach/util"
 )
 
@@ -81,7 +81,7 @@ func (cq *CommandQueue) onEvicted(key, value interface{}) {
 // confirmation that all gating commands have completed or
 // failed. readOnly is true if the requester is a read-only command;
 // false for read-write.
-func (cq *CommandQueue) GetWait(start, end engine.Key, readOnly bool, wg *sync.WaitGroup) {
+func (cq *CommandQueue) GetWait(start, end proto.Key, readOnly bool, wg *sync.WaitGroup) {
 	if len(end) == 0 {
 		end = start.Next()
 	}
@@ -104,7 +104,7 @@ func (cq *CommandQueue) GetWait(start, end engine.Key, readOnly bool, wg *sync.W
 // Add should be invoked after waiting on already-executing,
 // overlapping commands via the WaitGroup initialized through
 // GetWait().
-func (cq *CommandQueue) Add(start, end engine.Key, readOnly bool) interface{} {
+func (cq *CommandQueue) Add(start, end proto.Key, readOnly bool) interface{} {
 	if len(end) == 0 {
 		end = start.Next()
 	}

--- a/storage/engine/batch_test.go
+++ b/storage/engine/batch_test.go
@@ -31,31 +31,31 @@ import (
 func TestBatchBasics(t *testing.T) {
 	e := NewInMem(proto.Attributes{}, 1<<20)
 	b := e.NewBatch()
-	if err := b.Put(Key("a"), []byte("value")); err != nil {
+	if err := b.Put(proto.EncodedKey("a"), []byte("value")); err != nil {
 		t.Fatal(err)
 	}
 	// Write an engine value to be deleted.
-	if err := e.Put(Key("b"), []byte("value")); err != nil {
+	if err := e.Put(proto.EncodedKey("b"), []byte("value")); err != nil {
 		t.Fatal(err)
 	}
-	if err := b.Clear(Key("b")); err != nil {
+	if err := b.Clear(proto.EncodedKey("b")); err != nil {
 		t.Fatal(err)
 	}
 	// Write an engine value to be merged.
-	if err := e.Put(Key("c"), appender("foo")); err != nil {
+	if err := e.Put(proto.EncodedKey("c"), appender("foo")); err != nil {
 		t.Fatal(err)
 	}
-	if err := b.Merge(Key("c"), appender("bar")); err != nil {
+	if err := b.Merge(proto.EncodedKey("c"), appender("bar")); err != nil {
 		t.Fatal(err)
 	}
 
 	// Check all keys are in initial state (nothing from batch has gone
 	// through to engine until commit).
 	expValues := []proto.RawKeyValue{
-		{Key: Key("b"), Value: []byte("value")},
-		{Key: Key("c"), Value: appender("foo")},
+		{Key: proto.EncodedKey("b"), Value: []byte("value")},
+		{Key: proto.EncodedKey("c"), Value: appender("foo")},
 	}
-	kvs, err := Scan(e, KeyMin, KeyMax, 0)
+	kvs, err := Scan(e, proto.EncodedKey(KeyMin), proto.EncodedKey(KeyMax), 0)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -65,11 +65,11 @@ func TestBatchBasics(t *testing.T) {
 
 	// Now, merged values should be:
 	expValues = []proto.RawKeyValue{
-		{Key: Key("a"), Value: []byte("value")},
-		{Key: Key("c"), Value: appender("foobar")},
+		{Key: proto.EncodedKey("a"), Value: []byte("value")},
+		{Key: proto.EncodedKey("c"), Value: appender("foobar")},
 	}
 	// Scan values from batch directly.
-	kvs, err = Scan(b, KeyMin, KeyMax, 0)
+	kvs, err = Scan(b, proto.EncodedKey(KeyMin), proto.EncodedKey(KeyMax), 0)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -81,7 +81,7 @@ func TestBatchBasics(t *testing.T) {
 	if err := b.Commit(); err != nil {
 		t.Fatal(err)
 	}
-	kvs, err = Scan(e, KeyMin, KeyMax, 0)
+	kvs, err = Scan(e, proto.EncodedKey(KeyMin), proto.EncodedKey(KeyMax), 0)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -94,27 +94,27 @@ func TestBatchGet(t *testing.T) {
 	e := NewInMem(proto.Attributes{}, 1<<20)
 	b := e.NewBatch()
 	// Write initial values, then write to batch.
-	if err := e.Put(Key("b"), []byte("value")); err != nil {
+	if err := e.Put(proto.EncodedKey("b"), []byte("value")); err != nil {
 		t.Fatal(err)
 	}
-	if err := e.Put(Key("c"), appender("foo")); err != nil {
+	if err := e.Put(proto.EncodedKey("c"), appender("foo")); err != nil {
 		t.Fatal(err)
 	}
 	// Write batch values.
-	if err := b.Put(Key("a"), []byte("value")); err != nil {
+	if err := b.Put(proto.EncodedKey("a"), []byte("value")); err != nil {
 		t.Fatal(err)
 	}
-	if err := b.Clear(Key("b")); err != nil {
+	if err := b.Clear(proto.EncodedKey("b")); err != nil {
 		t.Fatal(err)
 	}
-	if err := b.Merge(Key("c"), appender("bar")); err != nil {
+	if err := b.Merge(proto.EncodedKey("c"), appender("bar")); err != nil {
 		t.Fatal(err)
 	}
 
 	expValues := []proto.RawKeyValue{
-		{Key: Key("a"), Value: []byte("value")},
-		{Key: Key("b"), Value: nil},
-		{Key: Key("c"), Value: appender("foobar")},
+		{Key: proto.EncodedKey("a"), Value: []byte("value")},
+		{Key: proto.EncodedKey("b"), Value: nil},
+		{Key: proto.EncodedKey("c"), Value: appender("foobar")},
 	}
 	for i, expKV := range expValues {
 		kv, err := b.Get(expKV.Key)
@@ -131,29 +131,29 @@ func TestBatchMerge(t *testing.T) {
 	b := NewInMem(proto.Attributes{}, 1<<20).NewBatch()
 
 	// Write batch put, delete & merge.
-	if err := b.Put(Key("a"), appender("a-value")); err != nil {
+	if err := b.Put(proto.EncodedKey("a"), appender("a-value")); err != nil {
 		t.Fatal(err)
 	}
-	if err := b.Clear(Key("b")); err != nil {
+	if err := b.Clear(proto.EncodedKey("b")); err != nil {
 		t.Fatal(err)
 	}
-	if err := b.Merge(Key("c"), appender("c-value")); err != nil {
+	if err := b.Merge(proto.EncodedKey("c"), appender("c-value")); err != nil {
 		t.Fatal(err)
 	}
 
 	// Now, merge to all three keys.
-	if err := b.Merge(Key("a"), appender("append")); err != nil {
+	if err := b.Merge(proto.EncodedKey("a"), appender("append")); err != nil {
 		t.Fatal(err)
 	}
-	if err := b.Merge(Key("b"), appender("append")); err != nil {
+	if err := b.Merge(proto.EncodedKey("b"), appender("append")); err != nil {
 		t.Fatal(err)
 	}
-	if err := b.Merge(Key("c"), appender("append")); err != nil {
+	if err := b.Merge(proto.EncodedKey("c"), appender("append")); err != nil {
 		t.Fatal(err)
 	}
 
 	// Verify values.
-	val, err := b.Get(Key("a"))
+	val, err := b.Get(proto.EncodedKey("a"))
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -161,7 +161,7 @@ func TestBatchMerge(t *testing.T) {
 		t.Error("mismatch of \"a\"")
 	}
 
-	val, err = b.Get(Key("b"))
+	val, err = b.Get(proto.EncodedKey("b"))
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -169,7 +169,7 @@ func TestBatchMerge(t *testing.T) {
 		t.Error("mismatch of \"b\"")
 	}
 
-	val, err = b.Get(Key("c"))
+	val, err = b.Get(proto.EncodedKey("c"))
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -181,10 +181,10 @@ func TestBatchMerge(t *testing.T) {
 func TestBatchProto(t *testing.T) {
 	e := NewInMem(proto.Attributes{}, 1<<20)
 	b := e.NewBatch()
-	kv := &proto.RawKeyValue{Key: Key("a"), Value: []byte("value")}
-	PutProto(b, Key("proto"), kv)
+	kv := &proto.RawKeyValue{Key: proto.EncodedKey("a"), Value: []byte("value")}
+	PutProto(b, proto.EncodedKey("proto"), kv)
 	getKV := &proto.RawKeyValue{}
-	ok, keySize, valSize, err := GetProto(b, Key("proto"), getKV)
+	ok, keySize, valSize, err := GetProto(b, proto.EncodedKey("proto"), getKV)
 	if !ok || err != nil {
 		t.Fatalf("expected GetProto to success ok=%t: %s", ok, err)
 	}
@@ -202,14 +202,14 @@ func TestBatchProto(t *testing.T) {
 		t.Errorf("expected %v; got %v", kv, getKV)
 	}
 	// Before commit, proto will not be available via engine.
-	if ok, _, _, err := GetProto(e, Key("proto"), getKV); ok || err != nil {
+	if ok, _, _, err := GetProto(e, proto.EncodedKey("proto"), getKV); ok || err != nil {
 		t.Fatalf("expected GetProto to fail ok=%t: %s", ok, err)
 	}
 	// Commit and verify the proto can be read directly from the engine.
 	if err := b.Commit(); err != nil {
 		t.Fatal(err)
 	}
-	if ok, _, _, err := GetProto(e, Key("proto"), getKV); !ok || err != nil {
+	if ok, _, _, err := GetProto(e, proto.EncodedKey("proto"), getKV); !ok || err != nil {
 		t.Fatalf("expected GetProto to success ok=%t: %s", ok, err)
 	}
 	if !reflect.DeepEqual(getKV, kv) {
@@ -221,19 +221,19 @@ func TestBatchScan(t *testing.T) {
 	e := NewInMem(proto.Attributes{}, 1<<20)
 	b := e.NewBatch()
 	existingVals := []proto.RawKeyValue{
-		{Key: Key("a"), Value: []byte("1")},
-		{Key: Key("b"), Value: []byte("2")},
-		{Key: Key("c"), Value: []byte("3")},
-		{Key: Key("d"), Value: []byte("4")},
-		{Key: Key("e"), Value: []byte("5")},
-		{Key: Key("f"), Value: []byte("6")},
-		{Key: Key("g"), Value: []byte("7")},
-		{Key: Key("h"), Value: []byte("8")},
-		{Key: Key("i"), Value: []byte("9")},
-		{Key: Key("j"), Value: []byte("10")},
-		{Key: Key("k"), Value: []byte("11")},
-		{Key: Key("l"), Value: []byte("12")},
-		{Key: Key("m"), Value: []byte("13")},
+		{Key: proto.EncodedKey("a"), Value: []byte("1")},
+		{Key: proto.EncodedKey("b"), Value: []byte("2")},
+		{Key: proto.EncodedKey("c"), Value: []byte("3")},
+		{Key: proto.EncodedKey("d"), Value: []byte("4")},
+		{Key: proto.EncodedKey("e"), Value: []byte("5")},
+		{Key: proto.EncodedKey("f"), Value: []byte("6")},
+		{Key: proto.EncodedKey("g"), Value: []byte("7")},
+		{Key: proto.EncodedKey("h"), Value: []byte("8")},
+		{Key: proto.EncodedKey("i"), Value: []byte("9")},
+		{Key: proto.EncodedKey("j"), Value: []byte("10")},
+		{Key: proto.EncodedKey("k"), Value: []byte("11")},
+		{Key: proto.EncodedKey("l"), Value: []byte("12")},
+		{Key: proto.EncodedKey("m"), Value: []byte("13")},
 	}
 	for _, kv := range existingVals {
 		if err := e.Put(kv.Key, kv.Value); err != nil {
@@ -242,16 +242,16 @@ func TestBatchScan(t *testing.T) {
 	}
 
 	batchVals := []proto.RawKeyValue{
-		{Key: Key("a"), Value: []byte("b1")},
-		{Key: Key("bb"), Value: []byte("b2")},
-		{Key: Key("c"), Value: []byte("b3")},
-		{Key: Key("dd"), Value: []byte("b4")},
-		{Key: Key("e"), Value: []byte("b5")},
-		{Key: Key("ff"), Value: []byte("b6")},
-		{Key: Key("g"), Value: []byte("b7")},
-		{Key: Key("hh"), Value: []byte("b8")},
-		{Key: Key("i"), Value: []byte("b9")},
-		{Key: Key("jj"), Value: []byte("b10")},
+		{Key: proto.EncodedKey("a"), Value: []byte("b1")},
+		{Key: proto.EncodedKey("bb"), Value: []byte("b2")},
+		{Key: proto.EncodedKey("c"), Value: []byte("b3")},
+		{Key: proto.EncodedKey("dd"), Value: []byte("b4")},
+		{Key: proto.EncodedKey("e"), Value: []byte("b5")},
+		{Key: proto.EncodedKey("ff"), Value: []byte("b6")},
+		{Key: proto.EncodedKey("g"), Value: []byte("b7")},
+		{Key: proto.EncodedKey("hh"), Value: []byte("b8")},
+		{Key: proto.EncodedKey("i"), Value: []byte("b9")},
+		{Key: proto.EncodedKey("jj"), Value: []byte("b10")},
 	}
 	for _, kv := range batchVals {
 		if err := b.Put(kv.Key, kv.Value); err != nil {
@@ -260,21 +260,21 @@ func TestBatchScan(t *testing.T) {
 	}
 
 	scans := []struct {
-		start, end Key
+		start, end proto.EncodedKey
 		max        int64
 	}{
 		// Full monty.
-		{start: Key("a"), end: Key("z"), max: 0},
+		{start: proto.EncodedKey("a"), end: proto.EncodedKey("z"), max: 0},
 		// Select ~half.
-		{start: Key("a"), end: Key("z"), max: 9},
+		{start: proto.EncodedKey("a"), end: proto.EncodedKey("z"), max: 9},
 		// Select one.
-		{start: Key("a"), end: Key("z"), max: 1},
+		{start: proto.EncodedKey("a"), end: proto.EncodedKey("z"), max: 1},
 		// Select half by end key.
-		{start: Key("a"), end: Key("f0"), max: 0},
+		{start: proto.EncodedKey("a"), end: proto.EncodedKey("f0"), max: 0},
 		// Start at half and select rest.
-		{start: Key("f"), end: Key("z"), max: 0},
+		{start: proto.EncodedKey("f"), end: proto.EncodedKey("z"), max: 0},
 		// Start at last and select max=10.
-		{start: Key("m"), end: Key("z"), max: 10},
+		{start: proto.EncodedKey("m"), end: proto.EncodedKey("z"), max: 10},
 	}
 
 	// Scan each case using the batch and store the results.
@@ -308,13 +308,13 @@ func TestBatchScanWithDelete(t *testing.T) {
 	e := NewInMem(proto.Attributes{}, 1<<20)
 	b := e.NewBatch()
 	// Write initial value, then delete via batch.
-	if err := e.Put(Key("a"), []byte("value")); err != nil {
+	if err := e.Put(proto.EncodedKey("a"), []byte("value")); err != nil {
 		t.Fatal(err)
 	}
-	if err := b.Clear(Key("a")); err != nil {
+	if err := b.Clear(proto.EncodedKey("a")); err != nil {
 		t.Fatal(err)
 	}
-	kvs, err := Scan(b, KeyMin, KeyMax, 0)
+	kvs, err := Scan(b, proto.EncodedKey(KeyMin), proto.EncodedKey(KeyMax), 0)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -330,18 +330,18 @@ func TestBatchScanMaxWithDeleted(t *testing.T) {
 	e := NewInMem(proto.Attributes{}, 1<<20)
 	b := e.NewBatch()
 	// Write two values.
-	if err := e.Put(Key("a"), []byte("value1")); err != nil {
+	if err := e.Put(proto.EncodedKey("a"), []byte("value1")); err != nil {
 		t.Fatal(err)
 	}
-	if err := e.Put(Key("b"), []byte("value2")); err != nil {
+	if err := e.Put(proto.EncodedKey("b"), []byte("value2")); err != nil {
 		t.Fatal(err)
 	}
 	// Now, delete "a" in batch.
-	if err := b.Clear(Key("a")); err != nil {
+	if err := b.Clear(proto.EncodedKey("a")); err != nil {
 		t.Fatal(err)
 	}
 	// A scan with max=1 should scan "b".
-	kvs, err := Scan(b, KeyMin, KeyMax, 1)
+	kvs, err := Scan(b, proto.EncodedKey(KeyMin), proto.EncodedKey(KeyMax), 1)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -358,10 +358,10 @@ func TestBatchConcurrency(t *testing.T) {
 	e := NewInMem(proto.Attributes{}, 1<<20)
 	b := e.NewBatch()
 	// Write a merge to the batch.
-	if err := b.Merge(Key("a"), appender("bar")); err != nil {
+	if err := b.Merge(proto.EncodedKey("a"), appender("bar")); err != nil {
 		t.Fatal(err)
 	}
-	val, err := b.Get(Key("a"))
+	val, err := b.Get(proto.EncodedKey("a"))
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -369,11 +369,11 @@ func TestBatchConcurrency(t *testing.T) {
 		t.Error("mismatch of \"a\"")
 	}
 	// Write an engine value.
-	if err := e.Put(Key("a"), appender("foo")); err != nil {
+	if err := e.Put(proto.EncodedKey("a"), appender("foo")); err != nil {
 		t.Fatal(err)
 	}
 	// Now, read again and verify that the merge happens on top of the mod.
-	val, err = b.Get(Key("a"))
+	val, err = b.Get(proto.EncodedKey("a"))
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/storage/engine/errors.go
+++ b/storage/engine/errors.go
@@ -20,17 +20,19 @@ package engine
 import (
 	"encoding/gob"
 	"fmt"
+
+	"github.com/cockroachdb/cockroach/proto"
 )
 
 // InvalidRangeMetaKeyError indicates that a Range Metadata key is somehow
 // invalid.
 type InvalidRangeMetaKeyError struct {
 	Msg string
-	Key Key
+	Key proto.Key
 }
 
 // NewInvalidRangeMetaKeyError returns a new InvalidRangeMetaKeyError
-func NewInvalidRangeMetaKeyError(msg string, k Key) *InvalidRangeMetaKeyError {
+func NewInvalidRangeMetaKeyError(msg string, k proto.Key) *InvalidRangeMetaKeyError {
 	return &InvalidRangeMetaKeyError{Msg: msg, Key: k}
 }
 

--- a/storage/engine/gc.go
+++ b/storage/engine/gc.go
@@ -29,11 +29,11 @@ import (
 // versions and maximum age.
 type GarbageCollector struct {
 	now      proto.Timestamp // time at start of GC
-	policyFn func(key Key) *proto.GCPolicy
+	policyFn func(key proto.Key) *proto.GCPolicy
 }
 
 // NewGarbageCollector allocates and returns a new GC.
-func NewGarbageCollector(now proto.Timestamp, policyFn func(key Key) *proto.GCPolicy) *GarbageCollector {
+func NewGarbageCollector(now proto.Timestamp, policyFn func(key proto.Key) *proto.GCPolicy) *GarbageCollector {
 	return &GarbageCollector{
 		now:      now,
 		policyFn: policyFn,
@@ -42,7 +42,7 @@ func NewGarbageCollector(now proto.Timestamp, policyFn func(key Key) *proto.GCPo
 
 // MVCCPrefix returns the full key as prefix for non-version MVCC
 // keys and otherwise just the encoded key portion of version MVCC keys.
-func (gc *GarbageCollector) MVCCPrefix(key Key) int {
+func (gc *GarbageCollector) MVCCPrefix(key proto.EncodedKey) int {
 	remaining, _ := encoding.DecodeBinary(key)
 	return len(key) - len(remaining)
 }
@@ -53,7 +53,7 @@ func (gc *GarbageCollector) MVCCPrefix(key Key) int {
 // GarbageCollector was created. Returns a slice of deletions, one
 // per incoming keys. If an index in the returned array is set to
 // true, then that value will be garbage collected.
-func (gc *GarbageCollector) Filter(keys []Key, values [][]byte) []bool {
+func (gc *GarbageCollector) Filter(keys []proto.EncodedKey, values [][]byte) []bool {
 	if len(keys) == 1 {
 		return nil
 	}

--- a/storage/engine/gc_test.go
+++ b/storage/engine/gc_test.go
@@ -27,21 +27,21 @@ import (
 )
 
 var (
-	aKey  = Key("a")
-	bKey  = Key("b")
-	cKey  = Key("c")
-	aKeys = []Key{
+	aKey  = proto.Key("a")
+	bKey  = proto.Key("b")
+	cKey  = proto.Key("c")
+	aKeys = []proto.EncodedKey{
 		MVCCEncodeKey(aKey),
 		MVCCEncodeVersionKey(aKey, makeTS(2E9, 0)),
 		MVCCEncodeVersionKey(aKey, makeTS(1E9, 1)),
 		MVCCEncodeVersionKey(aKey, makeTS(1E9, 0)),
 	}
-	bKeys = []Key{
+	bKeys = []proto.EncodedKey{
 		MVCCEncodeKey(bKey),
 		MVCCEncodeVersionKey(bKey, makeTS(2E9, 0)),
 		MVCCEncodeVersionKey(bKey, makeTS(1E9, 0)),
 	}
-	cKeys = []Key{
+	cKeys = []proto.EncodedKey{
 		MVCCEncodeKey(cKey),
 	}
 	keys = append(aKeys, append(bKeys, cKeys...)...)
@@ -58,7 +58,7 @@ func serializedMVCCValue(deleted bool, t *testing.T) []byte {
 // TestGarbageCollectorMVCCPrefix verifies that MVCC variants of same
 // key are grouped together and non-MVCC keys are considered singly.
 func TestGarbageCollectorMVCCPrefix(t *testing.T) {
-	expPrefixes := []Key{
+	expPrefixes := []proto.EncodedKey{
 		MVCCEncodeKey(aKey),
 		MVCCEncodeKey(aKey),
 		MVCCEncodeKey(aKey),
@@ -69,7 +69,7 @@ func TestGarbageCollectorMVCCPrefix(t *testing.T) {
 		MVCCEncodeKey(cKey),
 	}
 	gc := NewGarbageCollector(makeTS(0, 0), nil)
-	prefixes := []Key{}
+	prefixes := []proto.EncodedKey{}
 	for _, key := range keys {
 		prefixes = append(prefixes, key[:gc.MVCCPrefix(key)])
 	}
@@ -81,11 +81,11 @@ func TestGarbageCollectorMVCCPrefix(t *testing.T) {
 // TestGarbageCollectorFilter verifies the filter policies for
 // different sorts of MVCC keys.
 func TestGarbageCollectorFilter(t *testing.T) {
-	gc := NewGarbageCollector(makeTS(0, 0), func(key Key) *proto.GCPolicy {
+	gc := NewGarbageCollector(makeTS(0, 0), func(key proto.Key) *proto.GCPolicy {
 		var seconds int32
-		if bytes.Compare(key, Key("b")) < 0 {
+		if bytes.Compare(key, proto.Key("b")) < 0 {
 			seconds = 1
-		} else if bytes.Compare(key, Key("c")) < 0 {
+		} else if bytes.Compare(key, proto.Key("c")) < 0 {
 			seconds = 2
 		} else {
 			seconds = 0
@@ -99,7 +99,7 @@ func TestGarbageCollectorFilter(t *testing.T) {
 	d := serializedMVCCValue(true, t)
 	testData := []struct {
 		time      proto.Timestamp
-		keys      []Key
+		keys      []proto.EncodedKey
 		values    [][]byte
 		expDelete []bool
 	}{

--- a/storage/engine/in_mem.go
+++ b/storage/engine/in_mem.go
@@ -132,14 +132,14 @@ func (in *InMem) Attrs() proto.Attributes {
 }
 
 // Put sets the given key to the value provided.
-func (in *InMem) Put(key Key, value []byte) error {
+func (in *InMem) Put(key proto.EncodedKey, value []byte) error {
 	in.Lock()
 	defer in.Unlock()
 	return in.putLocked(key, value)
 }
 
 // putLocked assumes mutex is already held by caller. See Put().
-func (in *InMem) putLocked(key Key, value []byte) error {
+func (in *InMem) putLocked(key proto.EncodedKey, value []byte) error {
 	if len(key) == 0 {
 		return emptyKeyError()
 	}
@@ -162,14 +162,14 @@ func (in *InMem) putLocked(key Key, value []byte) error {
 // Merge implements a merge operation which updates the existing value stored
 // under key based on the value passed.
 // See the documentation of goMerge and goMergeInit for details.
-func (in *InMem) Merge(key Key, value []byte) error {
+func (in *InMem) Merge(key proto.EncodedKey, value []byte) error {
 	in.Lock()
 	defer in.Unlock()
 	return in.mergeLocked(key, value)
 }
 
 // mergeLocked assumes the mutex is already held by the caller. See merge().
-func (in *InMem) mergeLocked(key Key, value []byte) error {
+func (in *InMem) mergeLocked(key proto.EncodedKey, value []byte) error {
 	if len(key) == 0 {
 		return emptyKeyError()
 	}
@@ -183,7 +183,7 @@ func (in *InMem) mergeLocked(key Key, value []byte) error {
 }
 
 // Get returns the value for the given key, nil otherwise.
-func (in *InMem) Get(key Key) ([]byte, error) {
+func (in *InMem) Get(key proto.EncodedKey) ([]byte, error) {
 	in.RLock()
 	defer in.RUnlock()
 	return in.getLocked(key, in.data)
@@ -191,7 +191,7 @@ func (in *InMem) Get(key Key) ([]byte, error) {
 
 // GetSnapshot returns the value for the given key from the given
 // snapshotID, nil otherwise.
-func (in *InMem) GetSnapshot(key Key, snapshotID string) ([]byte, error) {
+func (in *InMem) GetSnapshot(key proto.EncodedKey, snapshotID string) ([]byte, error) {
 	in.RLock()
 	defer in.RUnlock()
 	snapshotHandle, ok := in.snapshots[snapshotID]
@@ -203,7 +203,7 @@ func (in *InMem) GetSnapshot(key Key, snapshotID string) ([]byte, error) {
 
 // getLocked performs a get operation assuming that the caller
 // is already holding the mutex.
-func (in *InMem) getLocked(key Key, data llrb.Tree) ([]byte, error) {
+func (in *InMem) getLocked(key proto.EncodedKey, data llrb.Tree) ([]byte, error) {
 	if len(key) == 0 {
 		return nil, emptyKeyError()
 	}
@@ -217,7 +217,7 @@ func (in *InMem) getLocked(key Key, data llrb.Tree) ([]byte, error) {
 
 // Iterate iterates from start to end keys, invoking f on each
 // key/value pair. See engine.Iterate for details.
-func (in *InMem) Iterate(start, end Key, f func(proto.RawKeyValue) (bool, error)) error {
+func (in *InMem) Iterate(start, end proto.EncodedKey, f func(proto.RawKeyValue) (bool, error)) error {
 	in.RLock()
 	defer in.RUnlock()
 	return in.iterateLocked(start, end, f, in.data)
@@ -225,7 +225,7 @@ func (in *InMem) Iterate(start, end Key, f func(proto.RawKeyValue) (bool, error)
 
 // Iterate iterates from start to end keys using snapshot ID, invoking
 // f on each key/value pair. See engine.IterateSnapshot for details.
-func (in *InMem) IterateSnapshot(start, end Key, snapshotID string, f func(proto.RawKeyValue) (bool, error)) error {
+func (in *InMem) IterateSnapshot(start, end proto.EncodedKey, snapshotID string, f func(proto.RawKeyValue) (bool, error)) error {
 	in.RLock()
 	defer in.RUnlock()
 	snapshotHandle, ok := in.snapshots[snapshotID]
@@ -235,7 +235,7 @@ func (in *InMem) IterateSnapshot(start, end Key, snapshotID string, f func(proto
 	return in.iterateLocked(start, end, f, snapshotHandle)
 }
 
-func (in *InMem) iterateLocked(start, end Key, f func(proto.RawKeyValue) (bool, error), data llrb.Tree) error {
+func (in *InMem) iterateLocked(start, end proto.EncodedKey, f func(proto.RawKeyValue) (bool, error), data llrb.Tree) error {
 	if bytes.Compare(start, end) >= 0 {
 		return nil
 	}
@@ -252,14 +252,14 @@ func (in *InMem) iterateLocked(start, end Key, f func(proto.RawKeyValue) (bool, 
 }
 
 // Clear removes the item from the db with the given key.
-func (in *InMem) Clear(key Key) error {
+func (in *InMem) Clear(key proto.EncodedKey) error {
 	in.Lock()
 	defer in.Unlock()
 	return in.clearLocked(key)
 }
 
 // clearLocked assumes mutex is already held by caller. See clear().
-func (in *InMem) clearLocked(key Key) error {
+func (in *InMem) clearLocked(key proto.EncodedKey) error {
 	if len(key) == 0 {
 		return emptyKeyError()
 	}
@@ -321,7 +321,7 @@ func (in *InMem) SetGCTimeouts(gcTimeouts func() (minTxnTS, minRCacheTS int64)) 
 
 // ApproximateSize computes the size of data used to store all keys in the given
 // key range.
-func (in *InMem) ApproximateSize(start, end Key) (uint64, error) {
+func (in *InMem) ApproximateSize(start, end proto.EncodedKey) (uint64, error) {
 	var size uint64
 	in.RLock()
 	defer in.RUnlock()

--- a/storage/engine/in_mem_test.go
+++ b/storage/engine/in_mem_test.go
@@ -43,7 +43,7 @@ func TestInMemCapacity(t *testing.T) {
 	bytes := []byte("0123456789")
 
 	// Add a key.
-	err = engine.Put(Key(bytes), bytes)
+	err = engine.Put(proto.EncodedKey(bytes), bytes)
 	if err != nil {
 		t.Errorf("put: expected no error, but got %s", err)
 	}
@@ -58,7 +58,7 @@ func TestInMemCapacity(t *testing.T) {
 	}
 
 	// Remove key.
-	err = engine.Clear(Key(bytes))
+	err = engine.Clear(proto.EncodedKey(bytes))
 	if err != nil {
 		t.Errorf("delete: expected no error, but got %s", err)
 	}
@@ -74,12 +74,12 @@ func TestInMemOverCapacity(t *testing.T) {
 	value := []byte("0123456789")
 	// Create an engine with enough space for one, but not two, nodes.
 	engine := NewInMem(proto.Attributes{},
-		int64(float64(computeSize(proto.RawKeyValue{Key: Key("X"), Value: value}))*1.5))
+		int64(float64(computeSize(proto.RawKeyValue{Key: proto.EncodedKey("X"), Value: value}))*1.5))
 	var err error
-	if err = engine.Put(Key("1"), value); err != nil {
+	if err = engine.Put(proto.EncodedKey("1"), value); err != nil {
 		t.Errorf("put: expected no error, but got %s", err)
 	}
-	if err = engine.Put(Key("2"), value); err == nil {
+	if err = engine.Put(proto.EncodedKey("2"), value); err == nil {
 		t.Error("put: expected error, but got none")
 	}
 }
@@ -88,7 +88,7 @@ func BenchmarkCapacity(b *testing.B) {
 	engine := NewInMem(proto.Attributes{}, 1<<30)
 	bytes := []byte("0123456789")
 	for i := 0; i < b.N; i++ {
-		if err := engine.Put(Key(fmt.Sprintf("%d", i)), bytes); err != nil {
+		if err := engine.Put(proto.EncodedKey(fmt.Sprintf("%d", i)), bytes); err != nil {
 			b.Fatalf("put: expected no error, but got %s", err)
 		}
 		if i%10000 == 0 {

--- a/storage/engine/keys_test.go
+++ b/storage/engine/keys_test.go
@@ -20,204 +20,76 @@ package engine
 import (
 	"bytes"
 	"testing"
+
+	"github.com/cockroachdb/cockroach/proto"
 )
 
 // TestLocalKeySorting is a sanity check to make sure that
 // the non-replicated part of a store sorts before the meta.
 func TestKeySorting(t *testing.T) {
 	// Reminder: Increasing the last byte by one < adding a null byte.
-	if !(Key("").Less(Key("\x00")) && Key("\x00").Less(Key("\x01")) &&
-		Key("\x01").Less(Key("\x01\x00"))) {
+	if !(proto.Key("").Less(proto.Key("\x00")) && proto.Key("\x00").Less(proto.Key("\x01")) &&
+		proto.Key("\x01").Less(proto.Key("\x01\x00"))) {
 		t.Fatalf("something is seriously wrong with this machine")
 	}
 	if !KeyLocalPrefix.Less(KeyMetaPrefix) {
 		t.Fatalf("local key spilling into replicable ranges")
 	}
-	if !bytes.Equal(Key(""), Key(nil)) || !bytes.Equal(Key(""), Key(nil)) {
+	if !bytes.Equal(proto.Key(""), proto.Key(nil)) || !bytes.Equal(proto.Key(""), proto.Key(nil)) {
 		t.Fatalf("equality between keys failed")
 	}
 }
 
-// TestKeyNext tests that the method for creating lexicographic
-// successors to byte slices works as expected.
-func TestKeyNext(t *testing.T) {
-	a := Key("a")
-	aNext := a.Next()
-	if a.Equal(aNext) {
-		t.Errorf("expected key not equal to next")
-	}
-	if !a.Less(aNext) {
-		t.Errorf("expected next key to be greater")
-	}
-
-	testCases := []struct {
-		key  Key
-		next Key
-	}{
-		{nil, Key("\x00")},
-		{Key(""), Key("\x00")},
-		{Key("test key"), Key("test key\x00")},
-		{Key("\xff"), Key("\xff\x00")},
-		{Key("xoxo\x00"), Key("xoxo\x00\x00")},
-	}
-	for i, c := range testCases {
-		if !bytes.Equal(c.key.Next(), c.next) {
-			t.Errorf("%d: unexpected next bytes for %q: %q", i, c.key, c.key.Next())
-		}
-	}
-}
-
-func TestKeyPrefixEnd(t *testing.T) {
-	a := Key("a1")
-	aNext := a.Next()
-	aEnd := a.PrefixEnd()
-	if !a.Less(aEnd) {
-		t.Errorf("expected end key to be greater")
-	}
-	if !aNext.Less(aEnd) {
-		t.Errorf("expected end key to be greater than next")
-	}
-
-	testCases := []struct {
-		key Key
-		end Key
-	}{
-		{Key{}, KeyMax},
-		{Key{0}, Key{0x01}},
-		{Key{0xff}, Key{0xff}},
-		{Key{0xff, 0xff}, Key{0xff, 0xff}},
-		{KeyMax, KeyMax},
-		{Key{0xff, 0xfe}, Key{0xff, 0xff}},
-		{Key{0x00, 0x00}, Key{0x00, 0x01}},
-		{Key{0x00, 0xff}, Key{0x01, 0x00}},
-		{Key{0x00, 0xff, 0xff}, Key{0x01, 0x00, 0x00}},
-	}
-	for i, c := range testCases {
-		if !bytes.Equal(c.key.PrefixEnd(), c.end) {
-			t.Errorf("%d: unexpected prefix end bytes for %q: %q", i, c.key, c.key.PrefixEnd())
-		}
-	}
-}
-
-func TestKeyEqual(t *testing.T) {
-	a1 := Key("a1")
-	a2 := Key("a2")
-	if !a1.Equal(a1) {
-		t.Errorf("expected keys equal")
-	}
-	if a1.Equal(a2) {
-		t.Errorf("expected different keys not equal")
-	}
-}
-
-func TestKeyLess(t *testing.T) {
-	testCases := []struct {
-		a, b Key
-		less bool
-	}{
-		{nil, Key("\x00"), true},
-		{Key(""), Key("\x00"), true},
-		{Key("a"), Key("b"), true},
-		{Key("a\x00"), Key("a"), false},
-		{Key("a\x00"), Key("a\x01"), true},
-	}
-	for i, c := range testCases {
-		if c.a.Less(c.b) != c.less {
-			t.Fatalf("%d: unexpected %q < %q: %t", i, c.a, c.b, c.less)
-		}
-	}
-}
-
-func TestKeyCompare(t *testing.T) {
-	testCases := []struct {
-		a, b    Key
-		compare int
-	}{
-		{nil, nil, 0},
-		{nil, Key("\x00"), -1},
-		{Key("\x00"), Key("\x00"), 0},
-		{Key(""), Key("\x00"), -1},
-		{Key("a"), Key("b"), -1},
-		{Key("a\x00"), Key("a"), 1},
-		{Key("a\x00"), Key("a\x01"), -1},
-	}
-	for i, c := range testCases {
-		if c.a.Compare(c.b) != c.compare {
-			t.Fatalf("%d: unexpected %q.Compare(%q): %d", i, c.a, c.b, c.compare)
-		}
-	}
-}
-
-// TestNextKey tests that the method for creating successors of a Key
-// works as expected.
-func TestNextKey(t *testing.T) {
-	testCases := []struct {
-		key  Key
-		next Key
-	}{
-		{nil, Key("\x00")},
-		{Key(""), Key("\x00")},
-		{Key("test key"), Key("test key\x00")},
-		{Key(KeyMax), MakeKey(KeyMax, []byte("\x00"))},
-		{Key("xoxo\x00"), Key("xoxo\x00\x00")},
-	}
-	for i, c := range testCases {
-		if !c.key.Next().Equal(c.next) {
-			t.Fatalf("%d: unexpected next key for %q: %s", i, c.key, c.key.Next())
-		}
-	}
-}
-
 func TestMakeKey(t *testing.T) {
-	if !bytes.Equal(MakeKey(Key("A"), Key("B")), Key("AB")) ||
-		!bytes.Equal(MakeKey(Key("A")), Key("A")) ||
-		!bytes.Equal(MakeKey(Key("A"), Key("B"), Key("C")), Key("ABC")) {
+	if !bytes.Equal(MakeKey(proto.Key("A"), proto.Key("B")), proto.Key("AB")) ||
+		!bytes.Equal(MakeKey(proto.Key("A")), proto.Key("A")) ||
+		!bytes.Equal(MakeKey(proto.Key("A"), proto.Key("B"), proto.Key("C")), proto.Key("ABC")) {
 		t.Fatalf("MakeKey is broken")
 	}
 }
 
 func TestRangeMetaKey(t *testing.T) {
 	testCases := []struct {
-		key, expKey Key
+		key, expKey proto.Key
 	}{
 		{
-			key:    Key{},
+			key:    proto.Key{},
 			expKey: KeyMin,
 		},
 		{
-			key:    MakeLocalKey(KeyLocalTransactionPrefix, Key("foo")),
-			expKey: Key("\x00\x00meta2foo"),
+			key:    MakeLocalKey(KeyLocalTransactionPrefix, proto.Key("foo")),
+			expKey: proto.Key("\x00\x00meta2foo"),
 		},
 		{
-			key:    MakeLocalKey(KeyLocalResponseCachePrefix, Key("bar")),
-			expKey: Key("\x00\x00meta2bar"),
+			key:    MakeLocalKey(KeyLocalResponseCachePrefix, proto.Key("bar")),
+			expKey: proto.Key("\x00\x00meta2bar"),
 		},
 		{
-			key:    MakeKey(KeyConfigAccountingPrefix, Key("foo")),
-			expKey: Key("\x00\x00meta2\x00acctfoo"),
+			key:    MakeKey(KeyConfigAccountingPrefix, proto.Key("foo")),
+			expKey: proto.Key("\x00\x00meta2\x00acctfoo"),
 		},
 		{
-			key:    Key("\x00\x00meta2\x00acctfoo"),
-			expKey: Key("\x00\x00meta1\x00acctfoo"),
+			key:    proto.Key("\x00\x00meta2\x00acctfoo"),
+			expKey: proto.Key("\x00\x00meta1\x00acctfoo"),
 		},
 		{
-			key:    Key("\x00\x00meta1\x00acctfoo"),
+			key:    proto.Key("\x00\x00meta1\x00acctfoo"),
 			expKey: KeyMin,
 		},
 		{
-			key:    Key("foo"),
-			expKey: Key("\x00\x00meta2foo"),
+			key:    proto.Key("foo"),
+			expKey: proto.Key("\x00\x00meta2foo"),
 		},
 		{
-			key:    Key("foo"),
-			expKey: Key("\x00\x00meta2foo"),
+			key:    proto.Key("foo"),
+			expKey: proto.Key("\x00\x00meta2foo"),
 		},
 		{
-			key:    Key("\x00\x00meta2foo"),
-			expKey: Key("\x00\x00meta1foo"),
+			key:    proto.Key("\x00\x00meta2foo"),
+			expKey: proto.Key("\x00\x00meta1foo"),
 		},
 		{
-			key:    Key("\x00\x00meta1foo"),
+			key:    proto.Key("\x00\x00meta1foo"),
 			expKey: KeyMin,
 		},
 	}
@@ -226,11 +98,5 @@ func TestRangeMetaKey(t *testing.T) {
 		if !result.Equal(test.expKey) {
 			t.Errorf("%d: expected range meta for key %q doesn't match %q", i, test.key, test.expKey)
 		}
-	}
-}
-
-func TestKeyString(t *testing.T) {
-	if KeyMax.String() != "\xff..." {
-		t.Errorf("expected key max to display a compact version: %s", KeyMax.String())
 	}
 }

--- a/storage/engine/mvcc_test.go
+++ b/storage/engine/mvcc_test.go
@@ -38,10 +38,10 @@ import (
 
 // Constants for system-reserved keys in the KV map.
 var (
-	testKey1     = Key("/db1")
-	testKey2     = Key("/db2")
-	testKey3     = Key("/db3")
-	testKey4     = Key("/db4")
+	testKey1     = proto.Key("/db1")
+	testKey2     = proto.Key("/db2")
+	testKey3     = proto.Key("/db3")
+	testKey4     = proto.Key("/db4")
 	txn1         = &proto.Transaction{ID: []byte("Txn1"), Epoch: 1}
 	txn1Commit   = &proto.Transaction{ID: []byte("Txn1"), Epoch: 1, Status: proto.COMMITTED}
 	txn1Abort    = &proto.Transaction{ID: []byte("Txn1"), Epoch: 1, Status: proto.ABORTED}
@@ -93,8 +93,8 @@ func makeTS(nanos int64, logical int32) proto.Timestamp {
 // a\x00<t=1>
 // a\x00<t=0>
 func TestMVCCKeys(t *testing.T) {
-	aKey := []byte("a")
-	a0Key := []byte("a\x00")
+	aKey := proto.Key("a")
+	a0Key := proto.Key("a\x00")
 	keys := []string{
 		string(MVCCEncodeKey(aKey)),
 		string(MVCCEncodeVersionKey(aKey, makeTS(math.MaxInt64, 0))),
@@ -544,19 +544,19 @@ func TestMVCCScanWithKeyPrefix(t *testing.T) {
 	// b<T=5>
 	// In this case, if we scan from "a"-"b", we wish to skip
 	// a<T=2> and a<T=1> and find "aa'.
-	err := mvcc.Put(Key("/a"), makeTS(1, 0), value1, nil)
-	err = mvcc.Put(Key("/a"), makeTS(2, 0), value2, nil)
-	err = mvcc.Put(Key("/aa"), makeTS(2, 0), value2, nil)
-	err = mvcc.Put(Key("/aa"), makeTS(3, 0), value3, nil)
-	err = mvcc.Put(Key("/b"), makeTS(1, 0), value3, nil)
+	err := mvcc.Put(proto.Key("/a"), makeTS(1, 0), value1, nil)
+	err = mvcc.Put(proto.Key("/a"), makeTS(2, 0), value2, nil)
+	err = mvcc.Put(proto.Key("/aa"), makeTS(2, 0), value2, nil)
+	err = mvcc.Put(proto.Key("/aa"), makeTS(3, 0), value3, nil)
+	err = mvcc.Put(proto.Key("/b"), makeTS(1, 0), value3, nil)
 
-	kvs, err := mvcc.Scan(Key("/a"), Key("/b"), 0, makeTS(2, 0), nil)
+	kvs, err := mvcc.Scan(proto.Key("/a"), proto.Key("/b"), 0, makeTS(2, 0), nil)
 	if err != nil {
 		t.Fatal(err)
 	}
 	if len(kvs) != 2 ||
-		!bytes.Equal(kvs[0].Key, Key("/a")) ||
-		!bytes.Equal(kvs[1].Key, Key("/aa")) ||
+		!bytes.Equal(kvs[0].Key, proto.Key("/a")) ||
+		!bytes.Equal(kvs[1].Key, proto.Key("/aa")) ||
 		!bytes.Equal(kvs[0].Value.Bytes, value2.Bytes) ||
 		!bytes.Equal(kvs[1].Value.Bytes, value2.Bytes) {
 		t.Fatal("the value should not be empty")
@@ -1199,7 +1199,7 @@ func TestMVCCStatsBasic(t *testing.T) {
 
 	// Put a value.
 	ts := makeTS(0, 1)
-	key := Key("a")
+	key := proto.Key("a")
 	value := proto.Value{Bytes: []byte("value")}
 	if err := mvcc.Put(key, ts, value, nil); err != nil {
 		t.Fatal(err)

--- a/storage/engine/rocksdb.go
+++ b/storage/engine/rocksdb.go
@@ -175,7 +175,7 @@ func emptyKeyError() error {
 //
 // The key and value byte slices may be reused safely. put takes a copy of
 // them before returning.
-func (r *RocksDB) Put(key Key, value []byte) error {
+func (r *RocksDB) Put(key proto.EncodedKey, value []byte) error {
 	if len(key) == 0 {
 		return emptyKeyError()
 	}
@@ -194,7 +194,7 @@ func (r *RocksDB) Put(key Key, value []byte) error {
 //
 // The key and value byte slices may be reused safely. merge takes a copy
 // of them before returning.
-func (r *RocksDB) Merge(key Key, value []byte) error {
+func (r *RocksDB) Merge(key proto.EncodedKey, value []byte) error {
 	if len(key) == 0 {
 		return emptyKeyError()
 	}
@@ -206,13 +206,13 @@ func (r *RocksDB) Merge(key Key, value []byte) error {
 }
 
 // Get returns the value for the given key.
-func (r *RocksDB) Get(key Key) ([]byte, error) {
+func (r *RocksDB) Get(key proto.EncodedKey) ([]byte, error) {
 	return r.getInternal(key, nil)
 }
 
 // GetSnapshot returns the value for the given key from the given
 // snapshotID, nil otherwise.
-func (r *RocksDB) GetSnapshot(key Key, snapshotID string) ([]byte, error) {
+func (r *RocksDB) GetSnapshot(key proto.EncodedKey, snapshotID string) ([]byte, error) {
 	r.Lock()
 	snapshotHandle, ok := r.snapshots[snapshotID]
 	if !ok {
@@ -224,7 +224,7 @@ func (r *RocksDB) GetSnapshot(key Key, snapshotID string) ([]byte, error) {
 }
 
 // Get returns the value for the given key.
-func (r *RocksDB) getInternal(key Key, snapshotHandle *C.DBSnapshot) ([]byte, error) {
+func (r *RocksDB) getInternal(key proto.EncodedKey, snapshotHandle *C.DBSnapshot) ([]byte, error) {
 	if len(key) == 0 {
 		return nil, emptyKeyError()
 	}
@@ -237,7 +237,7 @@ func (r *RocksDB) getInternal(key Key, snapshotHandle *C.DBSnapshot) ([]byte, er
 }
 
 // Clear removes the item from the db with the given key.
-func (r *RocksDB) Clear(key Key) error {
+func (r *RocksDB) Clear(key proto.EncodedKey) error {
 	if len(key) == 0 {
 		return emptyKeyError()
 	}
@@ -246,13 +246,13 @@ func (r *RocksDB) Clear(key Key) error {
 
 // Iterate iterates from start to end keys, invoking f on each
 // key/value pair. See engine.Iterate for details.
-func (r *RocksDB) Iterate(start, end Key, f func(proto.RawKeyValue) (bool, error)) error {
+func (r *RocksDB) Iterate(start, end proto.EncodedKey, f func(proto.RawKeyValue) (bool, error)) error {
 	return r.iterateInternal(start, end, f, nil)
 }
 
 // IterateSnapshot iterates from start to end keys, invoking f on
 // each key/value pair. See engine.IterateSnapshot for details.
-func (r *RocksDB) IterateSnapshot(start, end Key, snapshotID string, f func(proto.RawKeyValue) (bool, error)) error {
+func (r *RocksDB) IterateSnapshot(start, end proto.EncodedKey, snapshotID string, f func(proto.RawKeyValue) (bool, error)) error {
 	r.Lock()
 	snapshotHandle, ok := r.snapshots[snapshotID]
 	if !ok {
@@ -263,7 +263,7 @@ func (r *RocksDB) IterateSnapshot(start, end Key, snapshotID string, f func(prot
 	return r.iterateInternal(start, end, f, snapshotHandle)
 }
 
-func (r *RocksDB) iterateInternal(start, end Key, f func(proto.RawKeyValue) (bool, error),
+func (r *RocksDB) iterateInternal(start, end proto.EncodedKey, f func(proto.RawKeyValue) (bool, error),
 	snapshotHandle *C.DBSnapshot) error {
 	if bytes.Compare(start, end) >= 0 {
 		return nil
@@ -355,7 +355,7 @@ func (r *RocksDB) SetGCTimeouts(gcTimeouts func() (minTxnTS, minRCacheTS int64))
 // Similarly, specifying nil for the end key will compact through the
 // last key. Note that the use of the word "Range" here does not refer
 // to Cockroach ranges, just to a generalized key range.
-func (r *RocksDB) CompactRange(start, end Key) {
+func (r *RocksDB) CompactRange(start, end proto.EncodedKey) {
 	var (
 		s, e       C.DBSlice
 		sPtr, ePtr *C.DBSlice
@@ -381,7 +381,7 @@ func (r *RocksDB) Destroy() error {
 
 // ApproximateSize returns the approximate number of bytes on disk that RocksDB
 // is using to store data for the given range of keys.
-func (r *RocksDB) ApproximateSize(start, end Key) (uint64, error) {
+func (r *RocksDB) ApproximateSize(start, end proto.EncodedKey) (uint64, error) {
 	return uint64(C.DBApproximateSize(r.rdb, goToCSlice(start), goToCSlice(end))), nil
 }
 

--- a/storage/engine/rocksdb_test.go
+++ b/storage/engine/rocksdb_test.go
@@ -89,26 +89,26 @@ func TestRocksDBCompaction(t *testing.T) {
 		// TODO(spencer): use Transaction and Response protobufs here.
 		BatchPut{
 			proto.RawKeyValue{
-				Key:   MVCCEncodeKey(MakeLocalKey(rcPre, Key("a"))),
+				Key:   MVCCEncodeKey(MakeLocalKey(rcPre, proto.Key("a"))),
 				Value: encodePutResponse(makeTS(2, 0), t),
 			},
 		},
 		BatchPut{
 			proto.RawKeyValue{
-				Key:   MVCCEncodeKey(MakeLocalKey(rcPre, Key("b"))),
+				Key:   MVCCEncodeKey(MakeLocalKey(rcPre, proto.Key("b"))),
 				Value: encodePutResponse(makeTS(3, 0), t),
 			},
 		},
 
 		BatchPut{
 			proto.RawKeyValue{
-				Key:   MVCCEncodeKey(MakeLocalKey(txnPre, Key("a"))),
+				Key:   MVCCEncodeKey(MakeLocalKey(txnPre, proto.Key("a"))),
 				Value: encodeTransaction(makeTS(1, 0), t),
 			},
 		},
 		BatchPut{
 			proto.RawKeyValue{
-				Key:   MVCCEncodeKey(MakeLocalKey(txnPre, Key("b"))),
+				Key:   MVCCEncodeKey(MakeLocalKey(txnPre, proto.Key("b"))),
 				Value: encodeTransaction(makeTS(2, 0), t),
 			},
 		},
@@ -119,17 +119,17 @@ func TestRocksDBCompaction(t *testing.T) {
 
 	// Compact range and scan remaining values to compare.
 	rocksdb.CompactRange(nil, nil)
-	keyvals, err := Scan(rocksdb, KeyMin, KeyMax, 0)
+	keyvals, err := Scan(rocksdb, proto.EncodedKey(KeyMin), proto.EncodedKey(KeyMax), 0)
 	if err != nil {
 		t.Fatalf("could not run scan: %v", err)
 	}
-	var keys []Key
+	var keys []proto.EncodedKey
 	for _, kv := range keyvals {
 		keys = append(keys, kv.Key)
 	}
-	expKeys := []Key{
-		MVCCEncodeKey(MakeLocalKey(rcPre, Key("b"))),
-		MVCCEncodeKey(MakeLocalKey(txnPre, Key("b"))),
+	expKeys := []proto.EncodedKey{
+		MVCCEncodeKey(MakeLocalKey(rcPre, proto.Key("b"))),
+		MVCCEncodeKey(MakeLocalKey(txnPre, proto.Key("b"))),
 	}
 	if !reflect.DeepEqual(expKeys, keys) {
 		t.Errorf("expected keys %+v, got keys %+v", expKeys, keys)

--- a/storage/engine/stat.go
+++ b/storage/engine/stat.go
@@ -30,29 +30,29 @@ var (
 	// StatLiveBytes counts how many bytes are "live", including bytes
 	// from both keys and values. Live rows include only non-deleted
 	// keys and only the most recent value.
-	StatLiveBytes = Key("live-bytes")
+	StatLiveBytes = proto.Key("live-bytes")
 	// StatKeyBytes counts how many bytes are used to store all keys,
 	// including bytes from deleted keys. Key bytes are re-counted for
 	// each versioned value.
-	StatKeyBytes = Key("key-bytes")
+	StatKeyBytes = proto.Key("key-bytes")
 	// StatValBytes counts how many bytes are used to store all values,
 	// including all historical versions and deleted tombstones.
-	StatValBytes = Key("val-bytes")
+	StatValBytes = proto.Key("val-bytes")
 	// StatIntentBytes counts how many bytes are used to store values
 	// which are unresolved intents. Includes bytes used for both intent
 	// keys and values.
-	StatIntentBytes = Key("intent-bytes")
+	StatIntentBytes = proto.Key("intent-bytes")
 	// StatLiveCount counts how many keys are "live". This includes only
 	// non-deleted keys.
-	StatLiveCount = Key("live-count")
+	StatLiveCount = proto.Key("live-count")
 	// StatKeyCount counts the total number of keys, including both live
 	// and deleted keys.
-	StatKeyCount = Key("key-count")
+	StatKeyCount = proto.Key("key-count")
 	// StatValCount counts the total number of values, including all
 	// historical versions and deleted tombstones.
-	StatValCount = Key("val-count")
+	StatValCount = proto.Key("val-count")
 	// StatIntentCount counts the number of unresolved intents.
-	StatIntentCount = Key("intent-count")
+	StatIntentCount = proto.Key("intent-count")
 )
 
 // encodeStatValue constructs a proto.Value using the supplied stat
@@ -72,14 +72,14 @@ func encodeStatValue(stat int64) (ok bool, enc []byte) {
 
 // MakeRangeStatKey returns the key for accessing the named stat
 // for the specified range ID.
-func MakeRangeStatKey(rangeID int64, stat Key) Key {
+func MakeRangeStatKey(rangeID int64, stat proto.Key) proto.Key {
 	encRangeID := encoding.EncodeInt(nil, rangeID)
 	return MakeKey(KeyLocalRangeStatPrefix, encRangeID, stat)
 }
 
 // MakeStoreStatKey returns the key for accessing the named stat
 // for the specified store ID.
-func MakeStoreStatKey(storeID int32, stat Key) Key {
+func MakeStoreStatKey(storeID int32, stat proto.Key) proto.Key {
 	encStoreID := encoding.EncodeInt(nil, int64(storeID))
 	return MakeKey(KeyLocalStoreStatPrefix, encStoreID, stat)
 }
@@ -87,7 +87,7 @@ func MakeStoreStatKey(storeID int32, stat Key) Key {
 // GetRangeStat fetches the specified stat from the provided engine.
 // If the stat could not be found, returns 0. An error is returned
 // on stat decode error.
-func GetRangeStat(engine Engine, rangeID int64, stat Key) (int64, error) {
+func GetRangeStat(engine Engine, rangeID int64, stat proto.Key) (int64, error) {
 	val := &proto.Value{}
 	ok, _, _, err := GetProto(engine, MVCCEncodeKey(MakeRangeStatKey(rangeID, stat)), val)
 	if err != nil || !ok {
@@ -99,7 +99,7 @@ func GetRangeStat(engine Engine, rangeID int64, stat Key) (int64, error) {
 // MergeStat flushes the specified stat to merge counters via the
 // provided engine for both the affected range and store. Only
 // updates range or store stats if the corresponding ID is non-zero.
-func MergeStat(engine Engine, rangeID int64, storeID int32, stat Key, statVal int64) {
+func MergeStat(engine Engine, rangeID int64, storeID int32, stat proto.Key, statVal int64) {
 	if ok, encStat := encodeStatValue(statVal); ok {
 		if rangeID != 0 {
 			engine.Merge(MVCCEncodeKey(MakeRangeStatKey(rangeID, stat)), encStat)
@@ -113,7 +113,7 @@ func MergeStat(engine Engine, rangeID int64, storeID int32, stat Key, statVal in
 // SetStat writes the specified stat to counters via the provided
 // engine for both the affected range and store. Only updates range or
 // store stats if the corresponding ID is non-zero.
-func SetStat(engine Engine, rangeID int64, storeID int32, stat Key, statVal int64) {
+func SetStat(engine Engine, rangeID int64, storeID int32, stat proto.Key, statVal int64) {
 	if ok, encStat := encodeStatValue(statVal); ok {
 		if rangeID != 0 {
 			engine.Put(MVCCEncodeKey(MakeRangeStatKey(rangeID, stat)), encStat)

--- a/storage/id_alloc.go
+++ b/storage/id_alloc.go
@@ -19,7 +19,6 @@ package storage
 
 import (
 	"github.com/cockroachdb/cockroach/proto"
-	"github.com/cockroachdb/cockroach/storage/engine"
 	"github.com/cockroachdb/cockroach/util/log"
 )
 
@@ -30,7 +29,7 @@ const allocationTrigger = 0
 // An IDAllocator is used to increment a key in allocation blocks
 // of arbitrary size starting at a minimum ID.
 type IDAllocator struct {
-	idKey     engine.Key
+	idKey     proto.Key
 	db        DB
 	minID     int64      // Minimum ID to return
 	blockSize int64      // Block allocation size
@@ -41,7 +40,7 @@ type IDAllocator struct {
 // specified key in allocation blocks of size blockSize, with
 // allocated IDs starting at minID. Allocated IDs are positive
 // integers.
-func NewIDAllocator(idKey engine.Key, db DB, minID int64, blockSize int64) *IDAllocator {
+func NewIDAllocator(idKey proto.Key, db DB, minID int64, blockSize int64) *IDAllocator {
 	if minID <= allocationTrigger {
 		log.Fatalf("minID must be > %d", allocationTrigger)
 	}

--- a/storage/response_cache.go
+++ b/storage/response_cache.go
@@ -206,7 +206,7 @@ func (rc *ResponseCache) removeInflightLocked(cmdID proto.ClientCmdID) {
 
 // responseCacheKeyPrefix generates the prefix under which all entries
 // for the given range are stored in the engine.
-func responseCacheKeyPrefix(rangeID int64) engine.Key {
+func responseCacheKeyPrefix(rangeID int64) proto.Key {
 	b := append([]byte(nil), engine.KeyLocalResponseCachePrefix...)
 	return encoding.EncodeInt(b, rangeID)
 }
@@ -215,7 +215,7 @@ func responseCacheKeyPrefix(rangeID int64) engine.Key {
 // key for storage in the underlying engine. Note that the prefix for
 // response cache keys sorts them at the very top of the engine's
 // keyspace.
-func responseCacheKey(rangeID int64, cmdID proto.ClientCmdID) engine.Key {
+func responseCacheKey(rangeID int64, cmdID proto.ClientCmdID) proto.Key {
 	b := responseCacheKeyPrefix(rangeID)
 	b = encoding.EncodeInt(b, cmdID.WallTime) // wall time helps sort for locality
 	b = encoding.EncodeInt(b, cmdID.Random)   // TODO(spencer): encode as Fixed64

--- a/storage/timestamp_cache.go
+++ b/storage/timestamp_cache.go
@@ -23,7 +23,6 @@ import (
 	"crypto/md5"
 
 	"github.com/cockroachdb/cockroach/proto"
-	"github.com/cockroachdb/cockroach/storage/engine"
 	"github.com/cockroachdb/cockroach/util"
 	"github.com/cockroachdb/cockroach/util/hlc"
 )
@@ -86,7 +85,7 @@ func (tc *TimestampCache) Clear(clock *hlc.Clock) {
 // keys from start to end. If end is nil, the range covers the start
 // key only. txnMD5 is empty for no transaction. readOnly specifies
 // whether the command adding this timestamp was read-only or not.
-func (tc *TimestampCache) Add(start, end engine.Key, timestamp proto.Timestamp, txnMD5 [md5.Size]byte, readOnly bool) {
+func (tc *TimestampCache) Add(start, end proto.Key, timestamp proto.Timestamp, txnMD5 [md5.Size]byte, readOnly bool) {
 	if len(end) == 0 {
 		end = start.Next()
 	}
@@ -126,7 +125,7 @@ func (tc *TimestampCache) Add(start, end engine.Key, timestamp proto.Timestamp, 
 // timestamp for "a". Then the write (for the same transaction) would
 // get that as the max timestamp and be forced to increment it. The MD5
 // allows timestamps from the same txn to be ignored.
-func (tc *TimestampCache) GetMax(start, end engine.Key, txnMD5 [md5.Size]byte) (proto.Timestamp, proto.Timestamp) {
+func (tc *TimestampCache) GetMax(start, end proto.Key, txnMD5 [md5.Size]byte) (proto.Timestamp, proto.Timestamp) {
 	if len(end) == 0 {
 		end = start.Next()
 	}

--- a/structured/db.go
+++ b/structured/db.go
@@ -51,7 +51,7 @@ func (db *structuredDB) PutSchema(s *Schema) error {
 	if err := s.Validate(); err != nil {
 		return err
 	}
-	k := engine.MakeKey(engine.KeySchemaPrefix, engine.Key(s.Key))
+	k := engine.MakeKey(engine.KeySchemaPrefix, proto.Key(s.Key))
 	return storage.PutI(db.kvDB, k, s)
 }
 
@@ -59,7 +59,7 @@ func (db *structuredDB) PutSchema(s *Schema) error {
 func (db *structuredDB) DeleteSchema(s *Schema) error {
 	return (<-db.kvDB.Delete(&proto.DeleteRequest{
 		RequestHeader: proto.RequestHeader{
-			Key: engine.MakeKey(engine.KeySchemaPrefix, engine.Key(s.Key)),
+			Key: engine.MakeKey(engine.KeySchemaPrefix, proto.Key(s.Key)),
 		},
 	})).GoError()
 }
@@ -69,7 +69,7 @@ func (db *structuredDB) DeleteSchema(s *Schema) error {
 // with the given key cannot be found.
 func (db *structuredDB) GetSchema(key string) (*Schema, error) {
 	s := &Schema{}
-	k := engine.MakeKey(engine.KeySchemaPrefix, engine.Key(key))
+	k := engine.MakeKey(engine.KeySchemaPrefix, proto.Key(key))
 	found, _, err := storage.GetI(db.kvDB, k, s)
 	if err != nil || !found {
 		s = nil


### PR DESCRIPTION
Moved engine.Key to proto.Key and introduced a new proto.EncKey to
differentiate between unencoded keys and encoded keys. All engine
interfaces (lowest level) expected proto.EncKey. Higher level interface,
such as storage.MVCCC and storage.DB accept proto.Key.

These are now custom gogoproto types in the .proto files.
