### PR TITLE
add txn uncertainty test & fix a bug

### DIFF
--- a/kv/split_test.go
+++ b/kv/split_test.go
@@ -90,7 +90,7 @@ func startTestWriter(db *client.KV, i int64, valBytes int32, wg *sync.WaitGroup,
 // 10 concurrent goroutines are each running successive transactions
 // composed of a random mix of puts.
 func TestRangeSplitsWithConcurrentTxns(t *testing.T) {
-	db, _, _, _ := createTestDB(t)
+	db, _, _, _, _ := createTestDB(t)
 	defer db.Close()
 
 	// This channel shuts the whole apparatus down.
@@ -136,7 +136,7 @@ func TestRangeSplitsWithConcurrentTxns(t *testing.T) {
 // TestRangeSplitsWithWritePressure sets the zone config max bytes for
 // a range to 256K and writes data until there are five ranges.
 func TestRangeSplitsWithWritePressure(t *testing.T) {
-	db, eng, _, _ := createTestDB(t)
+	db, eng, _, _, _ := createTestDB(t)
 	defer db.Close()
 	setTestRetryOptions()
 

--- a/kv/txn_correctness_test.go
+++ b/kv/txn_correctness_test.go
@@ -605,7 +605,7 @@ func checkConcurrency(name string, isolations []proto.IsolationType, txns []stri
 	verify *verifier, expSuccess bool, t *testing.T) {
 	setCorrectnessRetryOptions()
 	verifier := newHistoryVerifier(name, txns, verify, expSuccess, t)
-	db, _, _, _ := createTestDB(t)
+	db, _, _, _, _ := createTestDB(t)
 	verifier.run(isolations, db, t)
 }
 

--- a/kv/txn_test.go
+++ b/kv/txn_test.go
@@ -14,6 +14,7 @@
 // for names of contributors.
 //
 // Author: Spencer Kimball (spencer.kimball@gmail.com)
+// Author: Tobias Schottdorf (tobias.schottdorf@gmail.com)
 
 package kv
 
@@ -21,11 +22,15 @@ import (
 	"bytes"
 	"errors"
 	"fmt"
+	"reflect"
+	"sync"
 	"testing"
+	"time"
 
 	"github.com/cockroachdb/cockroach/client"
 	"github.com/cockroachdb/cockroach/proto"
 	"github.com/cockroachdb/cockroach/util"
+	"github.com/cockroachdb/cockroach/util/hlc"
 )
 
 // TestTxnDBBasics verifies that a simple transaction can be run and
@@ -93,4 +98,128 @@ func TestTxnDBBasics(t *testing.T) {
 			}
 		}
 	}
+}
+
+func addTS(ts proto.Timestamp, d time.Duration) proto.Timestamp {
+	return proto.Timestamp{
+		WallTime: ts.WallTime + d.Nanoseconds(),
+		Logical:  ts.Logical + 1,
+	}
+}
+
+// verifyUncertainty writes values to a key in 5ns intervals and then launches
+// a transaction at each value's timestamp reading that value with
+// the maximumOffset given, verifying in the process that the correct values
+// are read (usually after one transaction restart).
+func verifyUncertainty(concurrency int, maxOffset time.Duration, t *testing.T) {
+	db, clock, manualClock := createTestDB(t)
+	*manualClock = 0
+
+	txnOpts := &storage.TransactionOptions{
+		Name:         "test",
+		User:         storage.UserRoot,
+		UserPriority: 1,
+		Retry: &util.RetryOptions{
+			// Nothing should backoff here.
+			Backoff:     10 * time.Second,
+			MaxBackoff:  10 * time.Second,
+			Constant:    2,
+			MaxAttempts: 10,
+		},
+	}
+
+	key := []byte("key-test")
+	var wgI, wgO sync.WaitGroup
+	wgO.Add(concurrency)
+	wgI.Add(concurrency + 1)
+
+	// Initial high offset to allow for future writes.
+	clock.SetMaxOffset(999 * time.Nanosecond)
+	for i := 0; i < concurrency; i++ {
+		value := []byte(fmt.Sprintf("value-%d", i))
+		// Values will be written with 5ns spacing.
+		futureTS := addTS(clock.Now(), 5*time.Nanosecond)
+		// Expected number of versions skipped.
+		skipCount := int(maxOffset) / 5 * (1 - (i+1)/concurrency)
+		if i+skipCount >= concurrency {
+			skipCount = concurrency - i - 1
+		}
+		readValue := []byte(fmt.Sprintf("value-%d", i+skipCount))
+		if err := (<-db.Put(&proto.PutRequest{
+			RequestHeader: proto.RequestHeader{
+				Key:       key,
+				Timestamp: futureTS,
+			},
+			Value: proto.Value{Bytes: value},
+		})).GoError(); err != nil {
+			t.Errorf("%d: got write error: %v", i, err)
+		}
+		if gr := <-db.Get(&proto.GetRequest{
+			RequestHeader: proto.RequestHeader{
+				Key:       key,
+				Timestamp: futureTS,
+			},
+		}); gr.GoError() != nil || gr.Value == nil || !bytes.Equal(gr.Value.Bytes, value) {
+			t.Fatalf("%d: expected success reading value %+v: %v", i, gr.Value, gr.GoError())
+		}
+
+		go func(i int) {
+			defer wgO.Done()
+			wgI.Wait()
+			txnManual := hlc.ManualClock(futureTS.WallTime)
+			txnClock := hlc.NewClock(txnManual.UnixNano)
+			// Make sure to incorporate the logical component if the wall time
+			// hasn't changed (i=0).
+			txnClock.Update(futureTS)
+			// The written values are spaced out in intervals of 5ns, so
+			// setting <5ns here should make do without any restarts while
+			// higher values require roughly offset/5 restarts.
+			txnClock.SetMaxOffset(maxOffset)
+
+			if err := runTransaction(NewDB(db.kv, txnClock), txnOpts, func(txn storage.DB) error {
+				// Read within the transaction.
+				gr := <-txn.Get(&proto.GetRequest{
+					RequestHeader: proto.RequestHeader{
+						Key:       key,
+						Timestamp: futureTS,
+					},
+				})
+				if err := gr.GoError(); err != nil {
+					if _, ok := gr.GoError().(*proto.ReadWithinUncertaintyIntervalError); ok {
+						return err
+					}
+					return util.Errorf("unexpected read error of type %s: %v", reflect.TypeOf(err), err)
+				}
+				// TODO: figure out correct values and compare them.
+				if gr.Value == nil || gr.Value.Bytes == nil {
+					return util.Errorf("no value read")
+				}
+				if !bytes.Equal(gr.Value.Bytes, readValue) {
+					return util.Errorf("%d: read wrong value %q at %v, wanted %q", i, gr.Value.Bytes, futureTS, readValue)
+				}
+				return nil
+			}); err != nil {
+				t.Error(err)
+			}
+		}(i)
+		wgI.Done()
+	}
+	// Kick the goroutines loose.
+	wgI.Done()
+	// Wait for the goroutines to finish.
+	wgO.Wait()
+}
+
+// TestTxnDBUncertainty verifies that transactions restart correctly and
+// finally read the correct value when encountering writes in the near future.
+func TestTxnDBUncertainty(t *testing.T) {
+	// < 5ns means no uncertainty & no restarts.
+	// Those run very fast since no restarts are required.
+	verifyUncertainty(1, 3*time.Nanosecond, t)
+	verifyUncertainty(8, 4*time.Nanosecond, t)
+	verifyUncertainty(80, 3*time.Nanosecond, t)
+	// Below we'll see restarts.
+	// TODO(Spencer): This is awfully slow for a single restart (even with the
+	// first parameter set to 2). Anything to be done?
+	verifyUncertainty(7, 12*time.Nanosecond, t)
 }

--- a/main.go
+++ b/main.go
@@ -19,11 +19,13 @@ package main
 
 import (
 	"flag"
+	"math/rand"
 	"os"
 	"runtime"
 
 	commander "code.google.com/p/go-commander"
 	"github.com/cockroachdb/cockroach/server"
+	"github.com/cockroachdb/cockroach/util"
 	"github.com/cockroachdb/cockroach/util/log"
 )
 
@@ -50,6 +52,7 @@ func main() {
 	// production workloads.
 	numCPU := runtime.NumCPU()
 	runtime.GOMAXPROCS(numCPU)
+	rand.Seed(util.NewPseudoSeed())
 	log.V(1).Infof("running using %d processor cores", numCPU)
 
 	c := commander.Commander{

--- a/proto/api.go
+++ b/proto/api.go
@@ -429,8 +429,6 @@ func (rh *ResponseHeader) SetGoError(err error) {
 		rh.Error = &Error{WriteIntent: t}
 	case *WriteTooOldError:
 		rh.Error = &Error{WriteTooOld: t}
-	case *ReadWithinUncertaintyIntervalError:
-		rh.Error = &Error{ReadWithinUncertaintyInterval: t}
 	default:
 		var canRetry bool
 		if r, ok := err.(util.Retryable); ok {

--- a/proto/api.go
+++ b/proto/api.go
@@ -394,6 +394,8 @@ func (rh *ResponseHeader) GoError() error {
 		return rh.Error.WriteIntent
 	case rh.Error.WriteTooOld != nil:
 		return rh.Error.WriteTooOld
+	case rh.Error.ReadWithinUncertaintyInterval != nil:
+		return rh.Error.ReadWithinUncertaintyInterval
 	default:
 		return nil
 	}
@@ -427,6 +429,8 @@ func (rh *ResponseHeader) SetGoError(err error) {
 		rh.Error = &Error{WriteIntent: t}
 	case *WriteTooOldError:
 		rh.Error = &Error{WriteTooOld: t}
+	case *ReadWithinUncertaintyIntervalError:
+		rh.Error = &Error{ReadWithinUncertaintyInterval: t}
 	default:
 		var canRetry bool
 		if r, ok := err.(util.Retryable); ok {

--- a/proto/data.go
+++ b/proto/data.go
@@ -197,6 +197,14 @@ func (t Timestamp) String() string {
 	return fmt.Sprintf("%d.%09d,%d", t.WallTime/1E9, t.WallTime%1E9, t.Logical)
 }
 
+// Add returns a timestamp with the WallTime and Logical components increased.
+func (t Timestamp) Add(wallTime int64, logical int32) Timestamp {
+	return Timestamp{
+		WallTime: t.WallTime + wallTime,
+		Logical:  t.Logical + logical,
+	}
+}
+
 // InitChecksum initializes a checksum based on the provided key and
 // the contents of the value. If the value contains a byte slice, the
 // checksum includes it directly; if the value contains an integer,

--- a/proto/data.go
+++ b/proto/data.go
@@ -351,6 +351,6 @@ func (t *Transaction) MD5() [md5.Size]byte {
 
 // String formats transaction into human readable string.
 func (t Transaction) String() string {
-	return fmt.Sprintf("%q {id=%s pri=%d, iso=%s, stat=%s, epo=%d, ts=%s}",
-		t.Name, t.ID, t.Priority, t.Isolation, t.Status, t.Epoch, t.Timestamp)
+	return fmt.Sprintf("%q {id=%s pri=%d, iso=%s, stat=%s, epo=%d, ts=%s maxts=%s}",
+		t.Name, t.ID, t.Priority, t.Isolation, t.Status, t.Epoch, t.Timestamp, t.MaxTimestamp)
 }

--- a/proto/data.go
+++ b/proto/data.go
@@ -22,6 +22,7 @@ import (
 	"crypto/md5"
 	"fmt"
 	"math"
+	"math/rand"
 	"strings"
 
 	"code.google.com/p/biogo.store/interval"
@@ -304,7 +305,7 @@ func MakePriority(userPriority int32) int32 {
 	//   100           |  top 99/100ths of positive int32s
 	//   1000          |  top 999/1000ths of positive int32s
 	//   ...etc
-	return math.MaxInt32 - util.CachedRand.Int31n(math.MaxInt32/userPriority)
+	return math.MaxInt32 - rand.Int31n(math.MaxInt32/userPriority)
 }
 
 // MD5Equal returns whether the specified md5.Size byte arrays are equal.

--- a/proto/errors.proto
+++ b/proto/errors.proto
@@ -113,7 +113,8 @@ message WriteTooOldError {
 }
 
 // Error is a union type containing all available errors.
-// NOTE: new error types must be added here.
+// NOTE: new error types must be added here, and potentially in
+// the two locations (*ResponseHeader).{,Set}GoError().
 message Error {
   optional GenericError generic = 1;
   optional NotLeaderError not_leader = 2;

--- a/storage/engine/mvcc.go
+++ b/storage/engine/mvcc.go
@@ -153,7 +153,7 @@ func (mvcc *MVCC) PutProto(key proto.Key, timestamp proto.Timestamp, txn *proto.
 
 // Get returns the value for the key specified in the request, while
 // satisfying the given timestamp condition. The key may contain
-// arbitrary bytes. If no value for the key exists, or has been
+// arbitrary bytes. If no value for the key exists, or it has been
 // deleted, returns nil for value.
 //
 // The values of multiple versions for the given key should

--- a/util/rand.go
+++ b/util/rand.go
@@ -23,15 +23,21 @@ import (
 	"math/rand"
 )
 
-// NewPseudoRand returns an instance of math/rand.Rand seeded from crypto/rand
-// so we can easily and cheaply generate unique streams of numbers.
-func NewPseudoRand() *rand.Rand {
+// NewPseudoSeed generates a seed from crypto/rand.
+func NewPseudoSeed() int64 {
 	var seed int64
 	err := binary.Read(crypto_rand.Reader, binary.LittleEndian, &seed)
 	if err != nil {
 		panic(Errorf("could not read from crypto/rand: %s", err))
 	}
-	return rand.New(rand.NewSource(seed))
+	return seed
+}
+
+// NewPseudoRand returns an instance of math/rand.Rand seeded from crypto/rand
+// so we can easily and cheaply generate unique streams of numbers.
+// The created object is not safe for concurrent access.
+func NewPseudoRand() *rand.Rand {
+	return rand.New(rand.NewSource(NewPseudoSeed()))
 }
 
 // RandIntInRange returns a value in [min, max)
@@ -53,7 +59,3 @@ func RandString(r *rand.Rand, size int) string {
 	}
 	return string(arr)
 }
-
-// CachedRand is a global singleton rand.Rand object cached for
-// one-off purposes to generate random numbers.
-var CachedRand = NewPseudoRand()

--- a/util/retry.go
+++ b/util/retry.go
@@ -19,7 +19,6 @@ package util
 
 import (
 	"fmt"
-	"math"
 	"math/rand"
 	"time"
 
@@ -88,10 +87,10 @@ func RetryWithBackoff(opts RetryOptions, fn func() (RetryStatus, error)) error {
 		var wait time.Duration
 		if status == RetryReset {
 			backoff = opts.Backoff
-			wait = time.Duration(math.Abs(rand.Float64()) * float64(backoff.Nanoseconds()) * retryJitter)
+			wait = 0
 			count = 0
 			if !opts.UseV1Info || log.V(1) == true {
-				log.Infof("%s failed; retrying in 0ms", opts.Tag)
+				log.Infof("%s failed; retrying immediately", opts.Tag)
 			}
 		} else {
 			if opts.MaxAttempts > 0 && count >= opts.MaxAttempts {


### PR DESCRIPTION
Added missing Txn Uncertainty test and along the way realized that forgetting to add ReadWithinUncertaintyIntervalError to GoError() is not a great thing to do as the error simply evaporates.
