### PR TITLE
CircleCI Docker testing with caching

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,56 +1,6 @@
-FROM golang:latest
+FROM cockroachdb/docker_base:latest
 
 MAINTAINER Spencer Kimball <spencer.kimball@gmail.com>
-
-# Setup the toolchain. Make a lame attempt to reduce image size
-# by cleaning up right away.
-# TODO(pmattis): Use the vendored snappy and gflags.
-RUN apt-get update -y && \
- apt-get dist-upgrade -y && \
- apt-get install --auto-remove -y git mercurial build-essential pkg-config bzr zlib1g-dev libbz2-dev libsnappy-dev libgflags-dev libprotobuf-dev protobuf-compiler && \
- apt-get clean autoclean && apt-get autoremove -y && rm -rf /var/lib/{apt,dpkg,cache,log}
-
-
-ENV GOPATH /go
-ENV ROACHPATH $GOPATH/src/github.com/cockroachdb
-ENV VENDORPATH $ROACHPATH/cockroach/_vendor
-ENV ROCKSDBPATH $VENDORPATH
-ENV VENDORGOPATH $VENDORPATH/src
-ENV COREOSPATH $VENDORGOPATH/github.com/coreos
-
-RUN mkdir -p $ROACHPATH && \
- mkdir -p $ROCKSDBPATH && \
- mkdir -p $COREOSPATH
-
-# TODO(pmattis): Switch to using bootstrap.sh for retrieving go
-# dependencies and building rocksdb. The current road block is that
-# doing so causes rocksdb/snappy/etc to be rebuilt any time there is a
-# change to the cockroach directory.
-
-# Get Cockroach Go dependencies.
-RUN go get code.google.com/p/biogo.store/llrb && \
- go get code.google.com/p/go-commander && \
- go get code.google.com/p/go-uuid/uuid && \
- go get code.google.com/p/gogoprotobuf/proto && \
- go get code.google.com/p/gogoprotobuf/protoc-gen-gogo && \
- go get code.google.com/p/gogoprotobuf/gogoproto && \
- go get github.com/golang/glog && \
- go get gopkg.in/yaml.v1
-
-# Get RocksDB, Etcd sources from github.
-# We will run 'git submodule update' below which will ensure we have the correct
-# version, but running an initial download here speeds things up by baking
-# the bulk of the download into a lower layer of the image.
-# See the NOTE below if hacking directly on the _vendor/
-# submodules. In that case, uncomment the "_vendor" exclude from
-# .dockerignore and comment out the following lines.
-# Build rocksdb before adding the current directory. If there are
-# changes made by 'git submodule update' it will get rebuilt below but
-# this lets us reuse most of the results of an earlier build of the
-# image.
-RUN cd $ROCKSDBPATH && git clone https://github.com/cockroachdb/rocksdb.git && \
- cd $COREOSPATH && git clone https://github.com/cockroachdb/etcd.git && \
- cd $ROCKSDBPATH/rocksdb && make static_lib
 
 # Copy the contents of the cockroach source directory to the image.
 # Any changes which have been made to the source directory will cause
@@ -60,21 +10,21 @@ RUN cd $ROCKSDBPATH && git clone https://github.com/cockroachdb/rocksdb.git && \
 # is done to avoid rebuilding rocksdb in the common case where changes
 # are only made to cockroach. If rocksdb is being hacked, remove the
 # "_vendor" exclude from .dockerignore.
-ADD . $ROACHPATH/cockroach
+ADD . /cockroach/
 
 # Update to the correct version of our submodules and rebuild any changes
 # in rocksdb (in case the submodule revision is different from the current
 # master)
 # Build the cockroach executable and run the tests.
-RUN cd $ROACHPATH/cockroach && git submodule update --init && \
- cd $ROCKSDBPATH/rocksdb && make static_lib && \
- cd $ROACHPATH/cockroach && make
+RUN cd -P /cockroach && git submodule update --init && \
+ cd -P /cockroach/_vendor/rocksdb && make static_lib && \
+ cd -P /cockroach && make build
 
 # Expose the http status port.
 EXPOSE 8080
 
 # This is the command to run when this image is launched as a container.
-ENTRYPOINT ["/go/src/github.com/cockroachdb/cockroach/deploy/wrapper.sh"]
+ENTRYPOINT ["/cockroach/deploy/wrapper.sh"]
 
 # These are default arguments to the cockroach binary.
 CMD ["--help"]

--- a/circle.yml
+++ b/circle.yml
@@ -6,12 +6,17 @@ dependencies:
   cache_directories:
     - "~/docker"
   override:
-    - if [[ -e ~/docker/image.tar ]]; then docker load -i ~/docker/image.tar; fi
+    # If there's a base image cached, load it. A click on CircleCI's "Clear
+    # Cache" will make sure we start with a clean slate.
+    - mkdir -p ~/docker
+    - if [[ -e ~/docker/base.tar ]]; then docker load -i ~/docker/base.tar; fi
     - ./deploy/build-docker.sh
-    - if [[ ! -e ~/docker/image.tar ]]; then mkdir -p ~/docker; docker save "cockroachdb/cockroach" > ~/docker/image.tar; fi
+    # Otherwise, we built one above, and save it.
+    - if [[ ! -e ~/docker/base.tar ]]; then docker save "cockroachdb/docker_base" > ~/docker/base.tar; fi
+    # Print the history so that we can investigate potential steps which fatten
+    # the image needlessly.
     - docker history "cockroachdb/cockroach"
 
 test:
   override:
     - docker run "cockroachdb/cockroach" test
-    - make acceptance

--- a/circle.yml
+++ b/circle.yml
@@ -1,22 +1,17 @@
-## Customize checkout
-checkout:
-  post:
-    - sudo apt-get update -qq
-    - sudo apt-get install -qy python-software-properties
-    - sudo add-apt-repository -y ppa:ubuntu-toolchain-r/test
-    - sudo apt-get update -qq
-    - sudo apt-get install -y -qq gcc-4.8 g++-4.8 libprotobuf-dev protobuf-compiler
-    - sudo update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-4.8 50
-    - sudo update-alternatives --install /usr/bin/g++ g++ /usr/bin/g++-4.8 50
+machine:
+    services:
+          - docker
 
 dependencies:
+  cache_directories:
+    - "~/docker"
   override:
-    - ./bootstrap.sh
-    - make build GOFLAGS=-x
+    - if [[ -e ~/docker/image.tar ]]; then docker load -i ~/docker/image.tar; fi
+    - ./deploy/build-docker.sh
+    - if [[ ! -e ~/docker/image.tar ]]; then mkdir -p ~/docker; docker save "cockroachdb/cockroach" > ~/docker/image.tar; fi
+    - docker history "cockroachdb/cockroach"
 
 test:
   override:
-    # Note that testrace runs with some tests excluded for performance
-    # This means that we should always run both test and testrace.
-    - make test TESTFLAGS="-logtostderr -timeout 30s"
-    - make testrace
+    - docker run "cockroachdb/cockroach" test
+    - make acceptance

--- a/deploy/build-docker.sh
+++ b/deploy/build-docker.sh
@@ -1,8 +1,16 @@
 #!/bin/bash
 
+REQUIRED_IMAGES="cockroachdb/docker_base"
+
 # Verify docker installation.
 source "$(dirname $0)/verify-docker.sh"
 
 # Create the docker cockroach image.
 echo "Building Docker Cockroach image..."
-docker build -t="cockroachdb/cockroach" "$(dirname $0)/../"
+for IMG in ${REQUIRED_IMAGES}; do
+  if [ $(docker images | awk '{ print $1 }' | grep -c "${IMG}") -eq 0 ]; then
+    docker build -t "${IMG}" "github.com/${IMG}.git"
+  fi
+done
+
+docker build -t "cockroachdb/cockroach" "$(dirname $0)/.."

--- a/deploy/build-docker.sh
+++ b/deploy/build-docker.sh
@@ -1,8 +1,8 @@
 #!/bin/bash
 
 # Verify docker installation.
-source ./verify-docker.sh
+source "$(dirname $0)/verify-docker.sh"
 
 # Create the docker cockroach image.
 echo "Building Docker Cockroach image..."
-docker build -t="cockroachdb/cockroach" ../
+docker build -t="cockroachdb/cockroach" "$(dirname $0)/../"

--- a/deploy/wrapper.sh
+++ b/deploy/wrapper.sh
@@ -1,0 +1,14 @@
+#!/bin/sh
+# This file serves as an entrypoint for the docker image.
+# Its sole purpose is to allow running of "./cockroach test"
+# to run the tests, and redirect everything else to the
+# cockroach binary.
+
+cd "$(dirname $0)/.."
+
+if [ $# -eq 1 ] && [ "$1" = "test" ]; then
+  make test && make testrace
+  exit $?
+fi
+
+./cockroach "$@"


### PR DESCRIPTION
Moved parts of the Dockerfile to https://github.com/cockroachdb/docker_base. This allows for a clean CircleCI build that caches the base image (=our prereqs for "make build"), bringing the total build time to around a minute and the tests to maybe another minute or two (our race tests are getting slower these days, especially kv).

We may want to move the base Dockerfile around a bit but since I haven't been added to our Docker organization (https://registry.hub.docker.com/u/cockroachdb/cockroach/, who runs this and can add me by the way?) yet, I kept it simple for now and didn't register it yet (which also means that from a fresh repo, you can't just "docker build ."). We'll want to have automated builds from the base and deploy images after a push.
In the process of changing this we should also migrate this into the organization:
https://registry.hub.docker.com/u/spencerkimball/dnsmasq/

Feel free to play around with this, this is the result of a 10hr session late last night and probably not perfect.
