### PR TITLE
Jessie now has gcc 4.9 not 4.7.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,10 +6,10 @@ MAINTAINER Spencer Kimball <spencer.kimball@gmail.com>
 RUN apt-get update -y -qq
 RUN apt-get dist-upgrade -y -qq
 # TODO(pmattis): Use the vendored snappy and gflags.
-RUN apt-get install --auto-remove -y -qq git mercurial build-essential pkg-config bzr zlib1g-dev libbz2-dev libsnappy-dev libgflags-dev libprotobuf-dev protobuf-compiler gcc-4.7 g++-4.7
+RUN apt-get install --auto-remove -y -qq git mercurial build-essential pkg-config bzr zlib1g-dev libbz2-dev libsnappy-dev libgflags-dev libprotobuf-dev protobuf-compiler gcc-4.9 g++-4.9
 
-RUN update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-4.7 50
-RUN update-alternatives --install /usr/bin/g++ g++ /usr/bin/g++-4.7 50
+RUN update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-4.9 50
+RUN update-alternatives --install /usr/bin/g++ g++ /usr/bin/g++-4.9 50
 
 ENV GOPATH /go
 ENV ROACHPATH $GOPATH/src/github.com/cockroachdb


### PR DESCRIPTION
At least for me, the current Dockerfile build fails since the base image can't find candidate for g++-4.7 and even the gcc-4.7 request here actually installs gcc-4.9 for me right now which causes the update-alternatives command to fail.

I didn't see any particular reason to use 4.7 mentioned although there may well be one.

After making this change, whole build runs smoothly for me.

(If it helps my host machine is OS X but docker should make that immaterial as far as I understand).

If this is not desirable overall, any hints on how to get it to build with 4.7 would be appreciated.
