### PR TITLE
Added a grace interval to split_test when verifying there are no danglin...

### DIFF
--- a/gossip/addr_set_test.go
+++ b/gossip/addr_set_test.go
@@ -18,7 +18,6 @@
 package gossip
 
 import (
-	"fmt"
 	"net"
 	"testing"
 )
@@ -31,29 +30,6 @@ func TestMaxSize(t *testing.T) {
 	addrs.addAddr(emptyAddr)
 	if addrs.hasSpace() {
 		t.Error("set should have no space")
-	}
-}
-
-func TestSelectRandom(t *testing.T) {
-	const numAddrs = 10
-	addrs := newAddrSet(numAddrs)
-	found := make(map[string]bool)
-	for i := 0; i < numAddrs; i++ {
-		addrs.addAddr(testAddr(fmt.Sprintf("<test-addr:%d>", i)))
-	}
-
-	// Select randomly until we've found all addresses.
-	var count int
-	for count = 0; true; count++ {
-		if len(found) == numAddrs {
-			break
-		}
-		found[addrs.selectRandom().String()] = true
-	}
-
-	// With default test random seed, we select 41 times for 10 addresses.
-	if count == numAddrs {
-		t.Errorf("expected > %d attempts to randomly select all addresses", numAddrs)
 	}
 }
 


### PR DESCRIPTION
...g

intents. This allows the test writer to finish up and also any ongoing
split to complete.

Removed useless test from gossip/addr_set_test which could occasionally
fail after selecting the 10 addresses with no overlaps in 10 tries. The
test originally was predicated on a consistent seed in random number
generator, but that's apparently no longer the case with the unittests.
It wasn't a test worth keeping, though we may want to look into our test
random number generator so that at least we are logging the random seed.
