### PR TITLE
Start adding support for Prepare/Flush in KV client.

### DIFF
--- a/client/txn_sender.go
+++ b/client/txn_sender.go
@@ -101,7 +101,7 @@ func (ts *txnSender) Send(call *Call) {
 			ts.txn.Priority = ts.minPriority
 		}
 	}
-	if call.Method == proto.EndTransaction || call.Method == proto.InternalEndTxn {
+	if call.Method == proto.EndTransaction {
 		// For EndTransaction, make sure key is set to txn ID.
 		call.Args.Header().Key = ts.txn.ID
 	} else if !proto.IsTransactional(call.Method) {
@@ -205,7 +205,7 @@ func (ts *txnSender) Send(call *Call) {
 			// Make sure to upgrade our priority to the conflicting txn's - 1.
 			return util.RetryContinue, nil
 		case nil:
-			if call.Method == proto.EndTransaction || call.Method == proto.InternalEndTxn {
+			if call.Method == proto.EndTransaction {
 				ts.txnEnd = true // set this txn as having been ended
 			}
 		}

--- a/kv/coordinator.go
+++ b/kv/coordinator.go
@@ -233,8 +233,6 @@ func (tc *Coordinator) Send(call *client.Call) {
 		var txn *proto.Transaction
 		if call.Method == proto.EndTransaction {
 			txn = call.Reply.(*proto.EndTransactionResponse).Txn
-		} else if call.Method == proto.InternalEndTxn {
-			txn = call.Reply.(*proto.InternalEndTxnResponse).Txn
 		}
 		if txn != nil && txn.Status != proto.PENDING {
 			tc.cleanupTxn(txn)

--- a/kv/db_test.go
+++ b/kv/db_test.go
@@ -167,7 +167,6 @@ func TestKVDBInternalMethods(t *testing.T) {
 		reply  proto.Response
 	}{
 		{proto.InternalRangeLookup, &proto.InternalRangeLookupRequest{}, &proto.InternalRangeLookupResponse{}},
-		{proto.InternalEndTxn, &proto.InternalEndTxnRequest{}, &proto.InternalEndTxnResponse{}},
 		{proto.InternalHeartbeatTxn, &proto.InternalHeartbeatTxnRequest{}, &proto.InternalHeartbeatTxnResponse{}},
 		{proto.InternalPushTxn, &proto.InternalPushTxnRequest{}, &proto.InternalPushTxnResponse{}},
 		{proto.InternalResolveIntent, &proto.InternalResolveIntentRequest{}, &proto.InternalResolveIntentResponse{}},
@@ -183,6 +182,31 @@ func TestKVDBInternalMethods(t *testing.T) {
 		} else if err.Error() != "404 Not Found" {
 			t.Errorf("%d: expected 404; got %s", i, err)
 		}
+	}
+}
+
+// TestKVDBEndTransactionWithTriggers verifies that triggers are
+// stripped on call to EndTransaction.
+func TestKVDBEndTransactionWithTriggers(t *testing.T) {
+	addr, server, _ := startServer(t)
+	defer server.Close()
+
+	kvClient := createTestClient(addr)
+	txnOpts := &client.TransactionOptions{Name: "test"}
+	err := kvClient.RunTransaction(txnOpts, func(txn *client.KV) error {
+		// Make an EndTransaction request which would fail if not
+		// stripped. In this case, we set the start key to "bar" for a
+		// split of the default range; start key must be "" in this case.
+		return txn.Call(proto.EndTransaction, &proto.EndTransactionRequest{
+			RequestHeader: proto.RequestHeader{Key: proto.Key("foo")},
+			Commit:        true,
+			SplitTrigger: &proto.SplitTrigger{
+				UpdatedDesc: proto.RangeDescriptor{StartKey: proto.Key("bar")},
+			},
+		}, &proto.EndTransactionResponse{})
+	})
+	if err != nil {
+		t.Errorf("expected success on commit; got %s", err)
 	}
 }
 

--- a/kv/db_test.go
+++ b/kv/db_test.go
@@ -206,7 +206,7 @@ func TestKVDBEndTransactionWithTriggers(t *testing.T) {
 		}, &proto.EndTransactionResponse{})
 	})
 	if err == nil {
-		t.Errorf("expected error on commit")
+		t.Errorf("expected 400 bad request error on commit")
 	}
 }
 

--- a/kv/db_test.go
+++ b/kv/db_test.go
@@ -205,8 +205,8 @@ func TestKVDBEndTransactionWithTriggers(t *testing.T) {
 			},
 		}, &proto.EndTransactionResponse{})
 	})
-	if err != nil {
-		t.Errorf("expected success on commit; got %s", err)
+	if err == nil {
+		t.Errorf("expected error on commit")
 	}
 }
 

--- a/proto/api.go
+++ b/proto/api.go
@@ -75,6 +75,8 @@ const (
 	EnqueueUpdate = "EnqueueUpdate"
 	// EnqueueMessage enqueues a message for delivery to an inbox.
 	EnqueueMessage = "EnqueueMessage"
+	// Batch executes a set of commands in parallel.
+	Batch = "Batch"
 	// AdminSplit is called to coordinate a split of a range.
 	AdminSplit = "AdminSplit"
 )
@@ -109,7 +111,7 @@ var AllMethods = stringSet{
 	EnqueueUpdate:         struct{}{},
 	EnqueueMessage:        struct{}{},
 	AdminSplit:            struct{}{},
-	InternalEndTxn:        struct{}{},
+	Batch:                 struct{}{},
 	InternalHeartbeatTxn:  struct{}{},
 	InternalPushTxn:       struct{}{},
 	InternalResolveIntent: struct{}{},
@@ -133,13 +135,13 @@ var PublicMethods = stringSet{
 	ReapQueue:        struct{}{},
 	EnqueueUpdate:    struct{}{},
 	EnqueueMessage:   struct{}{},
+	Batch:            struct{}{},
 	AdminSplit:       struct{}{},
 }
 
 // InternalMethods specifies the set of methods accessible only
 // via the internal node RPC API.
 var InternalMethods = stringSet{
-	InternalEndTxn:        struct{}{},
 	InternalHeartbeatTxn:  struct{}{},
 	InternalPushTxn:       struct{}{},
 	InternalResolveIntent: struct{}{},
@@ -170,7 +172,6 @@ var WriteMethods = stringSet{
 	ReapQueue:             struct{}{},
 	EnqueueUpdate:         struct{}{},
 	EnqueueMessage:        struct{}{},
-	InternalEndTxn:        struct{}{},
 	InternalHeartbeatTxn:  struct{}{},
 	InternalPushTxn:       struct{}{},
 	InternalResolveIntent: struct{}{},
@@ -312,10 +313,10 @@ func CreateArgsAndReply(method string) (Request, Response, error) {
 		return &EnqueueUpdateRequest{}, &EnqueueUpdateResponse{}, nil
 	case EnqueueMessage:
 		return &EnqueueMessageRequest{}, &EnqueueMessageResponse{}, nil
+	case Batch:
+		return &BatchRequest{}, &BatchResponse{}, nil
 	case AdminSplit:
 		return &AdminSplitRequest{}, &AdminSplitResponse{}, nil
-	case InternalEndTxn:
-		return &InternalEndTxnRequest{}, &InternalEndTxnResponse{}, nil
 	case InternalHeartbeatTxn:
 		return &InternalHeartbeatTxnRequest{}, &InternalHeartbeatTxnResponse{}, nil
 	case InternalPushTxn:

--- a/proto/api.proto
+++ b/proto/api.proto
@@ -243,6 +243,11 @@ message EndTransactionRequest {
   optional RequestHeader header = 1 [(gogoproto.nullable) = false, (gogoproto.embed) = true];
   // False to abort and rollback.
   optional bool commit = 2 [(gogoproto.nullable) = false];
+
+  // Optional commit triggers. Note that commit triggers are for
+  // internal use only and will be ignored if requested through the
+  // public-facing KV API.
+  optional SplitTrigger split_trigger = 3;
 }
 
 // An EndTransactionResponse is the return value from the
@@ -321,6 +326,61 @@ message EnqueueMessageRequest {
 // EnqueueMessage() method.
 message EnqueueMessageResponse {
   optional ResponseHeader header = 1 [(gogoproto.nullable) = false, (gogoproto.embed) = true];
+}
+
+// A RequestUnion contains exactly one of the optional requests.
+message RequestUnion {
+  option (gogoproto.onlyone) = true;
+  optional ContainsRequest contains = 1;
+  optional GetRequest get = 2;
+  optional PutRequest put = 3;
+  optional ConditionalPutRequest conditional_put = 4;
+  optional IncrementRequest increment = 5;
+  optional DeleteRequest delete = 6;
+  optional DeleteRangeRequest delete_range = 7;
+  optional ScanRequest scan = 8;
+  optional BeginTransactionRequest begin_transaction = 9;
+  optional EndTransactionRequest end_transaction = 10;
+  optional AccumulateTSRequest accumulate_ts = 11;
+  optional ReapQueueRequest reap_queue = 12;
+  optional EnqueueUpdateRequest enqueue_update = 13;
+  optional EnqueueMessageRequest enqueue_message = 14;
+}
+
+// A ResponseUnion contains exactly one of the optional responses.
+message ResponseUnion {
+  option (gogoproto.onlyone) = true;
+  optional ContainsResponse contains = 1;
+  optional GetResponse get = 2;
+  optional PutResponse put = 3;
+  optional ConditionalPutResponse conditional_put = 4;
+  optional IncrementResponse increment = 5;
+  optional DeleteResponse delete = 6;
+  optional DeleteRangeResponse delete_range = 7;
+  optional ScanResponse scan = 8;
+  optional BeginTransactionResponse begin_transaction = 9;
+  optional EndTransactionResponse end_transaction = 10;
+  optional AccumulateTSResponse accumulate_ts = 11;
+  optional ReapQueueResponse reap_queue = 12;
+  optional EnqueueUpdateResponse enqueue_update = 13;
+  optional EnqueueMessageResponse enqueue_message = 14;
+}
+
+// A BatchRequest contains one or more requests to be executed in
+// parallel, or if applicable (based on write-only commands and
+// range-locality), as a single update.
+message BatchRequest {
+  optional RequestHeader header = 1 [(gogoproto.nullable) = false, (gogoproto.embed) = true];
+  repeated RequestUnion requests = 2 [(gogoproto.nullable) = false];
+}
+
+// A BatchResponse contains one or more responses, one per request
+// corresponding to the requests in the matching BatchRequest. The
+// error in the response header is set to the first error from the
+// slice of responses, if applicable.
+message BatchResponse {
+  optional ResponseHeader header = 1 [(gogoproto.nullable) = false, (gogoproto.embed) = true];
+  repeated ResponseUnion responses = 2 [(gogoproto.nullable) = false];
 }
 
 // An AdminSplitRequest is arguments to the AdminSplit() method. The

--- a/proto/internal.go
+++ b/proto/internal.go
@@ -21,9 +21,6 @@ const (
 	// InternalRangeLookup looks up range descriptors, containing the
 	// locations of replicas for the range containing the specified key.
 	InternalRangeLookup = "InternalRangeLookup"
-	// InternalEndTxn is similar to EndTransaction, except additionally
-	// provides support for system-specific triggers on successful commit.
-	InternalEndTxn = "InternalEndTxn"
 	// InternalHeartbeatTxn sends a periodic heartbeat to extant
 	// transaction rows to indicate the client is still alive and
 	// the transaction should not be considered abandoned.

--- a/proto/internal.proto
+++ b/proto/internal.proto
@@ -43,27 +43,6 @@ message InternalRangeLookupResponse {
   repeated RangeDescriptor ranges = 2 [(gogoproto.nullable) = false];
 }
 
-// An InternalEndTxnRequest is arguments to the InternalEndTxn()
-// method. It is sent internally to commit transactions which have
-// accompanying system-specific triggers.  In all other ways the
-// method behaves exactly as EndTransaction.
-message InternalEndTxnRequest {
-  optional RequestHeader header = 1 [(gogoproto.nullable) = false, (gogoproto.embed) = true];
-  // False to abort and rollback.
-  optional bool commit = 2 [(gogoproto.nullable) = false];
-  // Optional commit triggers.
-  optional SplitTrigger split_trigger = 3;
-}
-
-// An InternalEndTxnResponse is the return value from the
-// InternalEndTxn() method. See EndTransactionRequest for
-// additional details.
-message InternalEndTxnResponse {
-  optional ResponseHeader header = 1 [(gogoproto.nullable) = false, (gogoproto.embed) = true];
-  optional Transaction txn = 2;
-  optional int64 commit_wait = 3 [(gogoproto.nullable) = false];
-}
-
 // An InternalHeartbeatTxnRequest is arguments to the
 // InternalHeartbeatTxn() method. It's sent by transaction
 // coordinators to let the system know that the transaction is still
@@ -171,8 +150,7 @@ message ReadWriteCmdResponse {
   optional ReapQueueResponse reap_queue = 8;
   optional EnqueueUpdateResponse enqueue_update = 9;
   optional EnqueueMessageResponse enqueue_message = 10;
-  optional InternalEndTxnResponse internal_end_txn = 11;
-  optional InternalHeartbeatTxnResponse internal_heartbeat_txn = 12;
-  optional InternalPushTxnResponse internal_push_txn = 13;
-  optional InternalResolveIntentResponse internal_resolve_intent = 14;
+  optional InternalHeartbeatTxnResponse internal_heartbeat_txn = 11;
+  optional InternalPushTxnResponse internal_push_txn = 12;
+  optional InternalResolveIntentResponse internal_resolve_intent = 13;
 }

--- a/roachlib/db.cc
+++ b/roachlib/db.cc
@@ -115,8 +115,6 @@ const proto::ResponseHeader* GetResponseHeader(const proto::ReadWriteCmdResponse
     return &rwResp.enqueue_update().header();
   } else if (rwResp.has_enqueue_message()) {
     return &rwResp.enqueue_message().header();
-  } else if (rwResp.has_internal_end_txn()) {
-    return &rwResp.internal_end_txn().header();
   } else if (rwResp.has_internal_heartbeat_txn()) {
     return &rwResp.internal_heartbeat_txn().header();
   } else if (rwResp.has_internal_push_txn()) {

--- a/server/node.go
+++ b/server/node.go
@@ -469,11 +469,6 @@ func (n *Node) InternalRangeLookup(args *proto.InternalRangeLookupRequest, reply
 	return n.executeCmd(proto.InternalRangeLookup, args, reply)
 }
 
-// InternalEndTxn .
-func (n *Node) InternalEndTxn(args *proto.InternalEndTxnRequest, reply *proto.InternalEndTxnResponse) error {
-	return n.executeCmd(proto.InternalEndTxn, args, reply)
-}
-
 // InternalHeartbeatTxn .
 func (n *Node) InternalHeartbeatTxn(args *proto.InternalHeartbeatTxnRequest, reply *proto.InternalHeartbeatTxnResponse) error {
 	return n.executeCmd(proto.InternalHeartbeatTxn, args, reply)

--- a/storage/db_test.go
+++ b/storage/db_test.go
@@ -33,9 +33,8 @@ import (
 // testSender is an implementation of the client.KVSender interface
 // which passes all requests through to a single store. A map keeps
 // track of keys with intents for each transaction. Intents are
-// resolved on invocation of EndTransaction or InternalEndTxn. NOTE:
-// this does not properly handle resolving intents from DeleteRange
-// commands.
+// resolved on invocation of EndTransaction. NOTE: this does not
+// properly handle resolving intents from DeleteRange commands.
 type testSender struct {
 	store   *Store
 	intents map[string][]proto.Key
@@ -82,8 +81,6 @@ func (db *testSender) Send(call *client.Call) {
 		txn = nil
 		if call.Method == proto.EndTransaction {
 			txn = call.Reply.(*proto.EndTransactionResponse).Txn
-		} else if call.Method == proto.InternalEndTxn {
-			txn = call.Reply.(*proto.InternalEndTxnResponse).Txn
 		}
 		if txn != nil && txn.Status != proto.PENDING {
 			id := string(txn.ID)


### PR DESCRIPTION
Added api.proto BatchRequest/BatchResponse support. In the process,
decided that the InternalEndTxn call was a mistake and removed it.
This necessitated a sanitization mechanism in the public KV DB to
strip out any commit triggers and associated unittest.

The Prepare/Flush work is still unimplemented, but thought I'd send
this as the removal of InternalEndTxn was significant enough to be
confusing.
