### PR TITLE
Refactor storage package's raft interface.

### DIFF
--- a/proto/api.go
+++ b/proto/api.go
@@ -281,6 +281,54 @@ func PutArgs(key Key, valueBytes []byte) *PutRequest {
 	}
 }
 
+// MethodForRequest returns the method name corresponding to the type
+// of the request.
+func MethodForRequest(req Request) (string, error) {
+	switch req.(type) {
+	case *ContainsRequest:
+		return Contains, nil
+	case *GetRequest:
+		return Get, nil
+	case *PutRequest:
+		return Put, nil
+	case *ConditionalPutRequest:
+		return ConditionalPut, nil
+	case *IncrementRequest:
+		return Increment, nil
+	case *DeleteRequest:
+		return Delete, nil
+	case *DeleteRangeRequest:
+		return DeleteRange, nil
+	case *ScanRequest:
+		return Scan, nil
+	case *BeginTransactionRequest:
+		return BeginTransaction, nil
+	case *EndTransactionRequest:
+		return EndTransaction, nil
+	case *AccumulateTSRequest:
+		return AccumulateTS, nil
+	case *ReapQueueRequest:
+		return ReapQueue, nil
+	case *EnqueueUpdateRequest:
+		return EnqueueUpdate, nil
+	case *EnqueueMessageRequest:
+		return EnqueueMessage, nil
+	case *BatchRequest:
+		return Batch, nil
+	case *AdminSplitRequest:
+		return AdminSplit, nil
+	case *InternalHeartbeatTxnRequest:
+		return InternalHeartbeatTxn, nil
+	case *InternalPushTxnRequest:
+		return InternalPushTxn, nil
+	case *InternalResolveIntentRequest:
+		return InternalResolveIntent, nil
+	case *InternalSnapshotCopyRequest:
+		return InternalSnapshotCopy, nil
+	}
+	return "", util.Errorf("unhandled request %T", req)
+}
+
 // CreateArgsAndReply returns allocated request and response pairs
 // according to the specified method.
 func CreateArgsAndReply(method string) (Request, Response, error) {

--- a/proto/internal.proto
+++ b/proto/internal.proto
@@ -154,3 +154,43 @@ message ReadWriteCmdResponse {
   optional InternalPushTxnResponse internal_push_txn = 12;
   optional InternalResolveIntentResponse internal_resolve_intent = 13;
 }
+
+// An InternalRaftCommandUnion is the union of all commands which can be
+// sent via raft.
+message InternalRaftCommandUnion {
+  option (gogoproto.onlyone) = true;
+  // Non-batched external requests. This section is the same as RequestUnion.
+  optional ContainsRequest contains = 1;
+  optional GetRequest get = 2;
+  optional PutRequest put = 3;
+  optional ConditionalPutRequest conditional_put = 4;
+  optional IncrementRequest increment = 5;
+  optional DeleteRequest delete = 6;
+  optional DeleteRangeRequest delete_range = 7;
+  optional ScanRequest scan = 8;
+  optional BeginTransactionRequest begin_transaction = 9;
+  optional EndTransactionRequest end_transaction = 10;
+  optional AccumulateTSRequest accumulate_ts = 11;
+  optional ReapQueueRequest reap_queue = 12;
+  optional EnqueueUpdateRequest enqueue_update = 13;
+  optional EnqueueMessageRequest enqueue_message = 14;
+
+  // Other requests. Allow a gap in tag numbers so the previous list can
+  // be copy/pasted from RequestUnion.
+  optional BatchRequest batch = 30;
+  optional InternalRangeLookupRequest internal_range_lookup = 31;
+  optional InternalHeartbeatTxnRequest internal_heartbeat_txn = 32;
+  optional InternalPushTxnRequest internal_push_txn = 33;
+  optional InternalResolveIntentRequest internal_resolve_intent = 34;
+  optional InternalSnapshotCopyRequest internal_snapshot_copy = 35;
+}
+
+// An InternalRaftCommand is a command which can be serialized and
+// sent via raft.
+message InternalRaftCommand {
+  // CmdID is used to identify a command when it has been
+  // committed. If the client specified a CmdID in its RequestHeader,
+  // that is used; otherwise the server generates an ID.
+  optional ClientCmdID cmd_id = 1 [(gogoproto.nullable) = false, (gogoproto.customname) = "CmdID"] ;
+  optional InternalRaftCommandUnion cmd = 2 [(gogoproto.nullable) = false];
+}

--- a/storage/raft.go
+++ b/storage/raft.go
@@ -13,7 +13,7 @@
 // permissions and limitations under the License. See the AUTHORS file
 // for names of contributors.
 //
-// Autor: Ben Darnell
+// Author: Ben Darnell
 
 package storage
 

--- a/storage/raft.go
+++ b/storage/raft.go
@@ -1,0 +1,48 @@
+// Copyright 2014 The Cockroach Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+// implied. See the License for the specific language governing
+// permissions and limitations under the License. See the AUTHORS file
+// for names of contributors.
+//
+// Autor: Ben Darnell
+
+package storage
+
+import "github.com/cockroachdb/cockroach/proto"
+
+// raft is the interface exposed by a raft implementation.
+type raft interface {
+	// propose a command to raft. If accepted by the consensus protocol it will
+	// eventually appear in the committed channel, but this is not guaranteed
+	// so callers may need to retry.
+	propose(proto.InternalRaftCommand)
+
+	// committed returns a channel that yields commands as they are
+	// committed. Note that this includes commands proposed by this node
+	// and others.
+	committed() <-chan proto.InternalRaftCommand
+}
+
+// noopRaft is a trivial implementation of the raft interface for testing.
+type noopRaft chan proto.InternalRaftCommand
+
+func newNoopRaft() noopRaft {
+	return make(noopRaft, 10)
+}
+
+func (nr noopRaft) propose(req proto.InternalRaftCommand) {
+	nr <- req
+}
+
+func (nr noopRaft) committed() <-chan proto.InternalRaftCommand {
+	return nr
+}

--- a/storage/store.go
+++ b/storage/store.go
@@ -428,6 +428,10 @@ func (s *Store) NewRangeDescriptor(start, end proto.Key, replicas []proto.Replic
 	return desc, nil
 }
 
+func (s *Store) CreateRaftGroup(id int64) raft {
+	return newNoopRaft()
+}
+
 // SplitRange shortens the original range to accommodate the new
 // range. The new range is added to the ranges map and the rangesByKey
 // sorted slice.
@@ -663,6 +667,7 @@ type RangeManager interface {
 
 	// Range manipulation methods.
 	NewRangeDescriptor(start, end proto.Key, replicas []proto.Replica) (*proto.RangeDescriptor, error)
+	CreateRaftGroup(id int64) raft
 	SplitRange(origRng, newRng *Range) error
 	AddRange(rng *Range)
 	RemoveRange(rng *Range) error


### PR DESCRIPTION
It's still using a dummy implementation, but it no longer relies on
sending channels and mutable reply buffers through raft.

@spencerkimball @cockroachdb/developers 
