### PR TITLE
Move heartbeat and gossip request/responses to protobuf.

### DIFF
--- a/build/godeps.sh
+++ b/build/godeps.sh
@@ -12,4 +12,3 @@ go_get code.google.com/p/go-uuid/uuid
 go_get code.google.com/p/gogoprotobuf/{proto,protoc-gen-gogo,gogoproto}
 go_get github.com/golang/glog
 go_get gopkg.in/yaml.v1
-

--- a/proto/Makefile
+++ b/proto/Makefile
@@ -17,11 +17,11 @@
 # Author: Andrew Bonventre (andybons@gmail.com)
 
 PROTO_LIB   := lib/libroachproto.a
-PROTOS      := api.proto config.proto data.proto errors.proto internal.proto
+PROTOS      := api.proto config.proto data.proto errors.proto gossip.proto heartbeat.proto internal.proto
 PROTO_GO    := $(PROTOS:.proto=.pb.go)
 GOGO_PROTOS := ../../../../code.google.com/p/gogoprotobuf/gogoproto/gogo.proto
-SOURCES     := lib/api.pb.cc lib/config.pb.cc lib/data.pb.cc lib/errors.pb.cc lib/internal.pb.cc lib/code.google.com/p/gogoprotobuf/gogoproto/gogo.pb.cc
-HEADERS     := lib/api.pb.h lib/config.pb.h lib/data.pb.h lib/errors.pb.h lib/internal.pb.h lib/code.google.com/p/gogoprotobuf/gogoproto/gogo.pb.h
+SOURCES     := lib/api.pb.cc lib/config.pb.cc lib/data.pb.cc lib/errors.pb.cc lib/gossip.pb.cc lib/heartbeat.pb.cc lib/internal.pb.cc lib/code.google.com/p/gogoprotobuf/gogoproto/gogo.pb.cc
+HEADERS     := lib/api.pb.h lib/config.pb.h lib/data.pb.h lib/errors.pb.h lib/gossip.pb.h lib/heartbeat.pb.h lib/internal.pb.h lib/code.google.com/p/gogoprotobuf/gogoproto/gogo.pb.h
 LIBOBJECTS  := $(SOURCES:.cc=.o)
 
 CXXFLAGS += -Ilib

--- a/proto/gossip.go
+++ b/proto/gossip.go
@@ -1,0 +1,45 @@
+// Copyright 2014 The Cockroach Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+// implied. See the License for the specific language governing
+// permissions and limitations under the License. See the AUTHORS file
+// for names of contributors.
+//
+// Author: Spencer Kimball (spencer.kimball@gmail.com)
+
+package proto
+
+import (
+	"net"
+
+	"github.com/cockroachdb/cockroach/util"
+)
+
+// FromNetAddr returns an Addr object based on the supplied net.Addr.
+func FromNetAddr(addr net.Addr) *Addr {
+	return &Addr{
+		Network: addr.Network(),
+		Address: addr.String(),
+	}
+}
+
+// NetAddr returns a net.Addr object.
+func (a Addr) NetAddr() (net.Addr, error) {
+	switch a.Network {
+	case "tcp", "tcp4", "tcp6":
+		return net.ResolveTCPAddr(a.Network, a.Address)
+	case "udp", "udp4", "udp6":
+		return net.ResolveUDPAddr(a.Network, a.Address)
+	case "unix", "unixgram", "unixpacket":
+		return net.ResolveUnixAddr(a.Network, a.Address)
+	}
+	return nil, util.Errorf("network %s not supported", a.Network)
+}

--- a/proto/gossip.proto
+++ b/proto/gossip.proto
@@ -1,0 +1,46 @@
+// Copyright 2014 The Cockroach Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+// implied. See the License for the specific language governing
+// permissions and limitations under the License. See the AUTHORS file
+// for names of contributors.
+//
+// Author: Spencer Kimball (spencer.kimball@gmail.com)
+
+package proto;
+
+import "code.google.com/p/gogoprotobuf/gogoproto/gogo.proto";
+
+message Addr {
+  optional string network = 1 [(gogoproto.nullable) = false];
+  optional string address = 2 [(gogoproto.nullable) = false];
+}
+
+// GossipRequest is the request struct passed with the Gossip RPC.
+message GossipRequest {
+  // Address of requesting node's server.
+  optional Addr addr = 1 [(gogoproto.nullable) = false];
+  // Local address of client on requesting node.
+  optional Addr l_addr = 2 [(gogoproto.nullable) = false];
+  // Maximum sequence number of gossip from this peer.
+  optional int64 max_seq = 3 [(gogoproto.nullable) = false];
+  // Reciprocal delta of new info since last gossip.
+  optional bytes delta = 4 [(gogoproto.nullable) = false];
+}
+
+// GossipResponse is returned from the Gossip.Gossip RPC.
+// Delta will be nil in the event that Alternate is set.
+message GossipResponse {
+  // Requested delta of server's infostore.
+  optional bytes delta = 1 [(gogoproto.nullable) = false];
+  // Non-nil means client should retry with this address.
+  optional Addr alternate = 2;
+}

--- a/proto/gossip_test.go
+++ b/proto/gossip_test.go
@@ -15,22 +15,27 @@
 //
 // Author: Spencer Kimball (spencer.kimball@gmail.com)
 
-package gossip
+package proto
 
-import "net"
+import (
+	"net"
+	"testing"
+)
 
-// Request is passed to the Gossip.Gossip RPC.
-type Request struct {
-	Addr   net.Addr // Address of requesting node's server
-	LAddr  net.Addr // Local address of client on requesting node
-	MaxSeq int64    // Maximum sequence number of gossip from this peer
-
-	Delta *infoStore // Reciprocal delta of new info since last gossip
-}
-
-// Response is returned from the Gossip.Gossip RPC.
-// Delta will be nil in the event that Alternate is set.
-type Response struct {
-	Delta     *infoStore // Requested delta of server's infostore
-	Alternate net.Addr   // Non-nil means client should retry with this address
+func TestAddrToFrom(t *testing.T) {
+	tcpAddr, err := net.ResolveTCPAddr("tcp", "127.0.0.1:8080")
+	if err != nil {
+		t.Fatal(err)
+	}
+	addr := FromNetAddr(tcpAddr)
+	tcpAddr2, err := addr.NetAddr()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if tcpAddr2.Network() != tcpAddr.Network() {
+		t.Errorf("networks differ: %s != %s", tcpAddr2.Network(), tcpAddr.Network())
+	}
+	if tcpAddr2.String() != tcpAddr.String() {
+		t.Errorf("strings differ: %s != %s", tcpAddr2.String(), tcpAddr.String())
+	}
 }

--- a/proto/heartbeat.go
+++ b/proto/heartbeat.go
@@ -1,0 +1,32 @@
+// Copyright 2014 The Cockroach Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+// implied. See the License for the specific language governing
+// permissions and limitations under the License. See the AUTHORS file
+// for names of contributors.
+//
+// Author: Kathy Spradlin (kathyspradlin@gmail.com)
+// Author: Spencer Kimball (spencer.kimball@gmail.com)
+
+package proto
+
+import "math"
+
+// InfiniteOffset is the offset value used if we fail to detect a heartbeat.
+var InfiniteOffset = RemoteOffset{
+	Offset: math.MaxInt64,
+	Error:  0,
+}
+
+// Equal is a equality comparison between remote offsets.
+func (r RemoteOffset) Equal(o RemoteOffset) bool {
+	return r.Offset == o.Offset && r.Error == o.Error && r.MeasuredAt == o.MeasuredAt
+}

--- a/proto/heartbeat.proto
+++ b/proto/heartbeat.proto
@@ -1,0 +1,55 @@
+// Copyright 2014 The Cockroach Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+// implied. See the License for the specific language governing
+// permissions and limitations under the License. See the AUTHORS file
+// for names of contributors.
+//
+// Author: Kathy Spradlin (kathyspradlin@gmail.com)
+// Author: Spencer Kimball (spencer.kimball@gmail.com)
+
+package proto;
+
+import "code.google.com/p/gogoprotobuf/gogoproto/gogo.proto";
+
+// RemoteOffset keeps track of this client's estimate of its offset from a
+// remote server. Error is the maximum error in the reading of this offset, so
+// that the real offset should be in the interval [Offset - Error, Offset
+// + Error]. If the last heartbeat timed out, Offset = InfiniteOffset.
+//
+// Offset and error are measured using the remote clock reading technique
+// described in http://se.inf.tu-dresden.de/pubs/papers/SRDS1994.pdf, page 6.
+message RemoteOffset {
+  // The estimated offset from the remote server, in nanoseconds.
+  optional int64 offset = 1 [(gogoproto.nullable) = false];
+  // The maximum error of the measured offset, in nanoseconds.
+  optional int64 error = 2 [(gogoproto.nullable) = false];
+  // Measurement time, in nanoseconds from unix epoch.
+  optional int64 measured_at = 3 [(gogoproto.nullable) = false];
+}
+
+// A PingRequest specifies the string to echo in response.
+// Fields are exported so that they will be serialized in the rpc call.
+message PingRequest {
+  // Echo this string with PingResponse.
+  optional string ping = 1 [(gogoproto.nullable) = false];
+  // The last offset the client measured with the server.
+  optional RemoteOffset offset = 2 [(gogoproto.nullable) = false];
+  // The address of the client.
+  optional string addr = 3 [(gogoproto.nullable) = false];
+}
+
+// A PingResponse contains the echoed ping request string.
+message PingResponse {
+  // An echo of value sent with PingRequest.
+  optional string pong = 1 [(gogoproto.nullable) = false];
+  optional int64 server_time = 2 [(gogoproto.nullable) = false];
+}

--- a/rpc/client_test.go
+++ b/rpc/client_test.go
@@ -22,6 +22,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/cockroachdb/cockroach/proto"
 	"github.com/cockroachdb/cockroach/util"
 	"github.com/cockroachdb/cockroach/util/hlc"
 )
@@ -95,14 +96,14 @@ func TestOffsetMeasurement(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	expectedOffset := RemoteOffset{Offset: 5, Error: 5, MeasuredAt: 10}
-	if o := c.RemoteOffset(); o != expectedOffset {
+	expectedOffset := proto.RemoteOffset{Offset: 5, Error: 5, MeasuredAt: 10}
+	if o := c.RemoteOffset(); !o.Equal(expectedOffset) {
 		t.Errorf("expected offset %v, actual %v", expectedOffset, o)
 	}
 
 	// Ensure the offsets map was updated properly too.
 	context.RemoteClocks.mu.Lock()
-	if o := context.RemoteClocks.offsets[c.addr.String()]; o != expectedOffset {
+	if o := context.RemoteClocks.offsets[c.addr.String()]; !o.Equal(expectedOffset) {
 		t.Errorf("expected offset %v, actual %v", expectedOffset, o)
 	}
 	context.RemoteClocks.mu.Unlock()
@@ -142,14 +143,14 @@ func TestDelayedOffsetMeasurement(t *testing.T) {
 	// Since the reply took too long, we should have an InfiniteOffset, even
 	// though the client is still healthy because it received a heartbeat
 	// reply.
-	if o := c.RemoteOffset(); o != InfiniteOffset {
-		t.Errorf("expected offset %v, actual %v", InfiniteOffset, o)
+	if o := c.RemoteOffset(); !o.Equal(proto.InfiniteOffset) {
+		t.Errorf("expected offset %v, actual %v", proto.InfiniteOffset, o)
 	}
 
 	// Ensure the general offsets map was updated properly too.
 	context.RemoteClocks.mu.Lock()
-	if o := context.RemoteClocks.offsets[c.addr.String()]; o != InfiniteOffset {
-		t.Errorf("expected offset %v, actual %v", InfiniteOffset, o)
+	if o := context.RemoteClocks.offsets[c.addr.String()]; !o.Equal(proto.InfiniteOffset) {
+		t.Errorf("expected offset %v, actual %v", proto.InfiniteOffset, o)
 	}
 	context.RemoteClocks.mu.Unlock()
 }
@@ -181,9 +182,9 @@ func TestFailedOffestMeasurement(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if c.RemoteOffset() != InfiniteOffset {
+	if !c.RemoteOffset().Equal(proto.InfiniteOffset) {
 		t.Errorf("expected offset %v, actual %v",
-			InfiniteOffset, c.RemoteOffset())
+			proto.InfiniteOffset, c.RemoteOffset())
 	}
 }
 

--- a/rpc/heartbeat.go
+++ b/rpc/heartbeat.go
@@ -17,21 +17,10 @@
 
 package rpc
 
-import "github.com/cockroachdb/cockroach/util/hlc"
-
-// A PingRequest specifies the string to echo in response.
-// Fields are exported so that they will be serialized in the rpc call.
-type PingRequest struct {
-	Ping   string       // Echo this string with PingResponse.
-	Offset RemoteOffset // The last offset the client measured with the server.
-	Addr   string       // The address of the client.
-}
-
-// A PingResponse contains the echoed ping request string.
-type PingResponse struct {
-	Pong       string // An echo of value sent with PingRequest.
-	ServerTime int64
-}
+import (
+	"github.com/cockroachdb/cockroach/proto"
+	"github.com/cockroachdb/cockroach/util/hlc"
+)
 
 // A HeartbeatService exposes a method to echo its request params. It doubles
 // as a way to measure the offset of the server from other nodes. It uses the
@@ -49,7 +38,7 @@ type HeartbeatService struct {
 // server's current clock value, allowing the requester to measure its clock.
 // The reqeuster should also an estimate of their offset from this server along
 // with their address.
-func (hs *HeartbeatService) Ping(args *PingRequest, reply *PingResponse) error {
+func (hs *HeartbeatService) Ping(args *proto.PingRequest, reply *proto.PingResponse) error {
 	reply.Pong = args.Ping
 	serverOffset := args.Offset
 	// The server offset should be the opposite of the client offset.
@@ -69,7 +58,7 @@ type ManualHeartbeatService struct {
 }
 
 // Ping waits until the heartbeat service is ready to respond to a Heartbeat.
-func (mhs *ManualHeartbeatService) Ping(args *PingRequest, reply *PingResponse) error {
+func (mhs *ManualHeartbeatService) Ping(args *proto.PingRequest, reply *proto.PingResponse) error {
 	<-mhs.ready
 	hs := HeartbeatService{
 		clock:              mhs.clock,

--- a/rpc/server.go
+++ b/rpc/server.go
@@ -55,7 +55,9 @@ func NewServer(addr net.Addr, context *Context) *Server {
 		clock:              context.localClock,
 		remoteClockMonitor: context.RemoteClocks,
 	}
-	s.RegisterName("Heartbeat", heartbeat)
+	if err := s.RegisterName("Heartbeat", heartbeat); err != nil {
+		log.Fatalf("unable to register heartbeat service with RPC server: %s", err)
+	}
 	return s
 }
 

--- a/server/node.go
+++ b/server/node.go
@@ -180,7 +180,9 @@ func (n *Node) initDescriptor(addr net.Addr, attrs proto.Attributes) {
 func (n *Node) start(rpcServer *rpc.Server, clock *hlc.Clock,
 	engines []engine.Engine, attrs proto.Attributes) error {
 	n.initDescriptor(rpcServer.Addr(), attrs)
-	rpcServer.RegisterName("Node", n)
+	if err := rpcServer.RegisterName("Node", n); err != nil {
+		log.Fatalf("unable to register node service with RPC server: %s", err)
+	}
 
 	// Initialize stores, including bootstrapping new ones.
 	if err := n.initStores(clock, engines); err != nil {


### PR DESCRIPTION
This is anticipation of using other RPC codecs or an entirely different
transport (HTTP/2).

The remaining "icky" bit of this is that infostore deltas are still
encoded using gob. We're going to want to create a protobuf description
of infostore deltas.

I had originally included a protobuf codec but it felt very iffy since
the tests were weak, etc. I feel safer with gob still.
