### PR TITLE
Mergeable Time Series Data

### DIFF
--- a/proto/data.proto
+++ b/proto/data.proto
@@ -40,12 +40,12 @@ message Timestamp {
 // basic types: a "bag o' bytes" generic byte slice and an incrementable
 // int64, for use with the Increment API call.
 message Value {
-  // Bytes is the byte slice value. If this value is present,
-  // "integer" should not be.
+  // Bytes is the byte slice value. If this field is set, the integer field
+  // should not be.
   optional bytes bytes = 1;
-  // Integer is an integer value type. If this value is present,
-  // "bytes" should not be. Only Integer values may exist at a key
-  // when making the Increment API call.
+  // Integer is an integer value type. If this field is set, the bytes field
+  // should not be. Only Integer values may exist at a key when making the
+  // Increment API call.
   optional int64 integer = 2;
   // Checksum is a CRC-32-IEEE checksum of the key + value, in that order.
   // If this is an integer value, then the value is interpreted as an 8
@@ -56,6 +56,10 @@ message Value {
   optional fixed32 checksum = 3;
   // Timestamp of value.
   optional Timestamp timestamp = 4;
+  // Tag is an optional string value which can be used to add additional
+  // metadata to this value. For example, Tag might provide information on how
+  // the bytes in the "bytes" field should be interpreted.
+  optional string tag = 5;
 }
 
 // MVCCValue differentiates between normal versioned values and

--- a/proto/internal.proto
+++ b/proto/internal.proto
@@ -190,3 +190,62 @@ message InternalRaftCommand {
   optional ClientCmdID cmd_id = 1 [(gogoproto.nullable) = false, (gogoproto.customname) = "CmdID"] ;
   optional InternalRaftCommandUnion cmd = 2 [(gogoproto.nullable) = false];
 }
+
+// InternalValueType defines a set of string constants placed in the "tag" field
+// of Value messages which are created internally. These are defined as a
+// protocol buffer enumeration so that they can be used portably between our Go
+// and C code.
+enum InternalValueType {
+    option (gogoproto.goproto_enum_prefix) = false;
+    // _CR_TS is applied to values which contain TimeSeriesData.  This tag is
+    // used by the RocksDB Merge Operator to perform a specialized merge for
+    // this data.
+    _CR_TS = 1;
+}
+
+// TimeSeriesPrecision is an enumeration which can describe the precision of the
+// time at which data points are taken.  Currently, millisecond or second
+// precision is available.
+enum TimeSeriesPrecision {
+    option (gogoproto.goproto_enum_prefix) = false;
+    MILLISECONDS = 0;
+    SECONDS = 1;
+}
+
+// TimeSeriesData contains time series data collected over a given interval of
+// time. The data is represented as a variable number of distinct data points
+// falling within the interval; each data point is a numeric value paired an
+// offset from the start of the interval.
+//
+// Data points within a TimeSeriesData should correspond to samples of the same
+// statistic at different point in times. Information about the statistic which
+// is being sampled is encoded in the Key at which the TimeSeriesData is stored.
+message TimeSeriesData {
+    // Holds a wall time, expressed as a unix epoch time in seconds. This
+    // represents the start of the interval.
+    optional int64 start_timestamp = 1 [(gogoproto.nullable) = false]; 
+    // The duration of the interval in seconds.
+    optional int64 duration_in_seconds = 2 [(gogoproto.nullable) = false];
+    // The precision of the samples within this data set.
+    optional TimeSeriesPrecision sample_precision = 3 [(gogoproto.nullable) = false];
+    // A set of data points which fall within the interval.
+    repeated TimeSeriesDataPoint data = 4;
+}
+
+
+// A TimeSeriesDataPoint is a single point of numeric data sampled at particular
+// time. Multiple TimeSeriesDataPoints are grouped into a single TimeSeriesData
+// collection.
+message TimeSeriesDataPoint {
+    // Temporal offset from the "start_timestamp" of the TimeSeriesData
+    // collection this data point is stored in. The units of this value are
+    // determined by the value of the "sample_precision" field of the
+    // TimeSeriesData collection.
+    optional int32 offset = 2 [(gogoproto.nullable) = false];
+    // Value field for integer samples. If this value is present, then
+    // "value_float" must not be present.
+    optional int64 value_int = 4;
+    // Value field for floating point samples. If this value is present, then
+    // "value_int" must not be set.
+    optional float value_float = 5;
+}

--- a/proto/internal_test.go
+++ b/proto/internal_test.go
@@ -1,0 +1,82 @@
+// Copyright 2014 The Cockroach Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+// implied. See the License for the specific language governing
+// permissions and limitations under the License. See the AUTHORS file
+// for names of contributors.
+//
+// Author: Matt Tracy (matt.r.tracy@gmail.com)
+
+package proto
+
+import (
+	"bytes"
+	"testing"
+
+	gogoproto "code.google.com/p/gogoprotobuf/proto"
+)
+
+func TestTimeSeriesToValue(t *testing.T) {
+	tsOriginal := &TimeSeriesData{
+		StartTimestamp:    1415398729,
+		DurationInSeconds: 3600,
+		SamplePrecision:   SECONDS,
+		Data: []*TimeSeriesDataPoint{
+			{
+				Offset:   100,
+				ValueInt: gogoproto.Int64(1),
+			},
+			{
+				Offset:   200,
+				ValueInt: gogoproto.Int64(2),
+			},
+			{
+				Offset:   300,
+				ValueInt: gogoproto.Int64(3),
+			},
+		},
+	}
+
+	// Wrap the TSD into a Value
+	valueOriginal, err := tsOriginal.ToValue()
+	if err != nil {
+		t.Fatalf("error marshaling TimeSeriesData: %s", err.Error())
+	}
+	if a, e := valueOriginal.GetTag(), _CR_TS.String(); a != e {
+		t.Errorf("Value did not have expected tag value of %s, had %s", e, a)
+	}
+
+	// Ensure the Value's 'bytes' field contains the marshalled TSD
+	tsEncoded, err := gogoproto.Marshal(tsOriginal)
+	if err != nil {
+		t.Fatalf("error marshaling TimeSeriesData: %s", err.Error())
+	}
+	if a, e := valueOriginal.Bytes, tsEncoded; !bytes.Equal(a, e) {
+		t.Errorf("bytes field was not properly encoded: expected %v, got %v", e, a)
+	}
+
+	// Extract the TSD from the Value
+	tsNew, err := TimeSeriesFromValue(valueOriginal)
+	if err != nil {
+		t.Errorf("error extracting Time Series: %s")
+	}
+	if !gogoproto.Equal(tsOriginal, tsNew) {
+		t.Errorf("extracted time series not equivalent to original; %v != %v", tsNew, tsOriginal)
+	}
+
+	// Make sure ExtractTimeSeries doesn't work on non-TimeSeries values
+	valueNotTs := &Value{
+		Bytes: []byte("testvalue"),
+	}
+	if _, err := TimeSeriesFromValue(valueNotTs); err == nil {
+		t.Errorf("did not receive expected error when extracting TimeSeries from regular Byte value.")
+	}
+}


### PR DESCRIPTION
This commit defines a new "TimeSeriesData" message which is used to record time
series data in an efficient way.  It also defines a custom "merge" operation for
TimeSeriesData within our existing RocksDB MergeOperator.

Background:
A "Time Series" is a set of data samples taken from the same statistic at
different points in time - for example, a common use of Time Series is the
recording of metrics for an application. Because of specialized query
requirements and necessarily high write performance, many specialized Database
solutions have been created specifically to handle Time Series data.

In Cockroach, multiple samples of a single statistic will be stored at a single
key; a key will contain all samples taken from a metric during over a well
defined time period such as a wall-clock hour. Based on our research into other
TS database solutions, this grouping is very effective in improving read
performance.

High write performance is enabled by creating a custom Merge operation for Time
Series data.  Whenever metric data samples are written, a Merge operation is
utilized instead of a put; for example, a single metric source will merge
samples into the same key at several points over the course of an hour.  The
resulting "merged" value will appear as if all samples had been written together
as a single value.
