### PR TITLE
Always start/stop Range background goroutines via the Store.

### DIFF
--- a/kv/local_sender.go
+++ b/kv/local_sender.go
@@ -150,7 +150,7 @@ func (ls *LocalSender) Close() {
 	ls.mu.RLock()
 	defer ls.mu.RUnlock()
 	for _, store := range ls.storeMap {
-		store.Close()
+		store.Stop()
 	}
 }
 

--- a/kv/local_sender_test.go
+++ b/kv/local_sender_test.go
@@ -131,9 +131,10 @@ func TestLocalSenderLookupReplica(t *testing.T) {
 	if _, err := store.BootstrapRange(); err != nil {
 		t.Fatal(err)
 	}
-	if err := store.Init(); err != nil {
+	if err := store.Start(); err != nil {
 		t.Fatal(err)
 	}
+	defer store.Stop()
 	rng := splitTestRange(store, engine.KeyMin, proto.Key("a"), t)
 	if err := store.RemoveRange(rng); err != nil {
 		t.Fatal(err)

--- a/server/node.go
+++ b/server/node.go
@@ -211,7 +211,7 @@ func (n *Node) initStores(clock *hlc.Clock, engines []engine.Engine) error {
 		s := storage.NewStore(clock, e, n.db, n.gossip)
 		// Initialize each store in turn, handling un-bootstrapped errors by
 		// adding the store to the bootstraps list.
-		if err := s.Init(); err != nil {
+		if err := s.Start(); err != nil {
 			if _, ok := err.(*storage.NotBootstrappedError); ok {
 				bootstraps.PushBack(s)
 				continue

--- a/storage/db_test.go
+++ b/storage/db_test.go
@@ -60,7 +60,7 @@ func createTestStore(t *testing.T) *storage.Store {
 	if _, err := store.BootstrapRange(); err != nil {
 		t.Fatal(err)
 	}
-	if err := store.Init(); err != nil {
+	if err := store.Start(); err != nil {
 		t.Fatal(err)
 	}
 	return store

--- a/storage/range.go
+++ b/storage/range.go
@@ -181,7 +181,7 @@ func NewRange(rangeID int64, desc *proto.RangeDescriptor, rm RangeManager) *Rang
 
 // Start begins gossiping and starts the raft command processing
 // loop in a goroutine.
-func (r *Range) Start() {
+func (r *Range) start() {
 	r.maybeGossipClusterID()
 	r.maybeGossipFirstRange()
 	r.maybeGossipConfigs()
@@ -193,7 +193,7 @@ func (r *Range) Start() {
 }
 
 // Stop ends the log processing loop.
-func (r *Range) Stop() {
+func (r *Range) stop() {
 	close(r.closer)
 }
 

--- a/storage/store_split_test.go
+++ b/storage/store_split_test.go
@@ -59,7 +59,7 @@ func verifyRangeStats(eng engine.Engine, rangeID int64, expMS engine.MVCCStats, 
 // a meta1 key.
 func TestStoreRangeSplitAtMeta1(t *testing.T) {
 	store := createTestStore(t)
-	defer store.Close()
+	defer store.Stop()
 
 	args, reply := adminSplitArgs(engine.KeyMin, engine.MakeKey(engine.KeyMeta1Prefix, engine.KeyMax), 1)
 	err := store.ExecuteCmd(proto.AdminSplit, args, reply)
@@ -75,7 +75,7 @@ func TestStoreRangeSplitAtMeta1(t *testing.T) {
 // split at the start of the newly split range.
 func TestStoreRangeSplitAtRangeBounds(t *testing.T) {
 	store := createTestStore(t)
-	defer store.Close()
+	defer store.Stop()
 
 	args, reply := adminSplitArgs(engine.KeyMin, []byte("a"), 1)
 	if err := store.ExecuteCmd(proto.AdminSplit, args, reply); err != nil {
@@ -96,7 +96,7 @@ func TestStoreRangeSplitAtRangeBounds(t *testing.T) {
 // of the same range are disallowed.
 func TestStoreRangeSplitConcurrent(t *testing.T) {
 	store := createTestStore(t)
-	defer store.Close()
+	defer store.Stop()
 
 	concurrentCount := int32(10)
 	wg := sync.WaitGroup{}
@@ -127,7 +127,7 @@ func TestStoreRangeSplitConcurrent(t *testing.T) {
 // and response caches have been properly accounted for.
 func TestStoreRangeSplit(t *testing.T) {
 	store := createTestStore(t)
-	defer store.Close()
+	defer store.Stop()
 	rangeID := int64(1)
 	splitKey := proto.Key("m")
 	content := proto.Key("asdvb")
@@ -254,7 +254,7 @@ func TestStoreRangeSplit(t *testing.T) {
 // the pre-split.
 func TestStoreRangeSplitStats(t *testing.T) {
 	store := createTestStore(t)
-	defer store.Close()
+	defer store.Stop()
 
 	// Split the range at the first user key.
 	args, reply := adminSplitArgs(engine.KeyMin, proto.Key("\x01"), 1)
@@ -346,7 +346,7 @@ func fillRange(store *storage.Store, rangeID int64, prefix proto.Key, bytes int6
 // zone's RangeMaxBytes.
 func TestStoreShouldSplit(t *testing.T) {
 	store := createTestStore(t)
-	defer store.Close()
+	defer store.Stop()
 
 	// Rewrite zone config with range max bytes set to 256K.
 	zoneConfig := &proto.ZoneConfig{


### PR DESCRIPTION
Rename Store.Init and Close to Start and Stop to match other
methods that manage background goroutines.

This change ensures that we are always calling Store.Start
(and hopefully always calling Store.Stop, although I haven't
verified that we have 100% coverage), in preparation for
adding a new Store-level background goroutine.

@cockroachdb/developers @spencerkimball 
