### PR TITLE
Enforce valid range split keys.

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -30,10 +30,6 @@
   entire batch as a single batch command to the range. In all other
   cases, we split batch request at DistSender into individual requests.
 
-* In find mvcc split key, avoid illegal split keys such as meta1
-  records and configuration keys. Probably ought to move to a single
-  pass through the data instead of the weighted reservoir sample.
-
 * Propagate errors from storage/id_alloc.go
 
 * Accept a list of acknowledged client command ids in RequestHeader,

--- a/proto/data.go
+++ b/proto/data.go
@@ -113,8 +113,18 @@ func (k Key) Less(l Key) bool {
 	return bytes.Compare(k, l) < 0
 }
 
+// Less implements the util.Ordered interface.
+func (k EncodedKey) Less(l EncodedKey) bool {
+	return bytes.Compare(k, l) < 0
+}
+
 // Equal returns whether two keys are identical.
 func (k Key) Equal(l Key) bool {
+	return bytes.Equal(k, l)
+}
+
+// Equal returns whether two keys are identical.
+func (k EncodedKey) Equal(l EncodedKey) bool {
 	return bytes.Equal(k, l)
 }
 

--- a/storage/engine/mvcc.go
+++ b/storage/engine/mvcc.go
@@ -865,9 +865,7 @@ func MVCCFindSplitKey(engine Engine, rangeID int64, key, endKey proto.Key, snaps
 	bestSplitDiff := int64(math.MaxInt64)
 
 	if err := engine.IterateSnapshot(encStartKey, encEndKey, snapshotID, func(kv proto.RawKeyValue) (bool, error) {
-		sizeSoFar += int64(len(kv.Key) + len(kv.Value))
-
-		// Skip this key if it's within an illegal key range.
+		// Is key within a legal key range?
 		valid := isValidEncodedSplitKey(kv.Key)
 
 		// Determine if this key would make a better split than last "best" key.
@@ -882,6 +880,9 @@ func MVCCFindSplitKey(engine Engine, rangeID int64, key, endKey proto.Key, snaps
 
 		// Determine whether we've found best key and can exit iteration.
 		done := !bestSplitKey.Equal(encStartKey) && diff > bestSplitDiff
+
+		// Add this key/value to the size scanned so far.
+		sizeSoFar += int64(len(kv.Key) + len(kv.Value))
 
 		return done, nil
 	}); err != nil {

--- a/storage/engine/stat.go
+++ b/storage/engine/stat.go
@@ -124,6 +124,20 @@ func SetStat(engine Engine, rangeID int64, storeID int32, stat proto.Key, statVa
 	}
 }
 
+// GetRangeSize returns the range size as the sum of the key and value
+// bytes. This includes all non-live keys and all versioned values.
+func GetRangeSize(engine Engine, rangeID int64) (int64, error) {
+	keyBytes, err := GetRangeStat(engine, rangeID, StatKeyBytes)
+	if err != nil {
+		return 0, err
+	}
+	valBytes, err := GetRangeStat(engine, rangeID, StatValBytes)
+	if err != nil {
+		return 0, err
+	}
+	return keyBytes + valBytes, nil
+}
+
 // ClearRangeStats clears stats for the specified range.
 func ClearRangeStats(engine Engine, rangeID int64) error {
 	statStartKey := MakeKey(KeyLocalRangeStatPrefix, encoding.EncodeInt(nil, rangeID))

--- a/storage/range.go
+++ b/storage/range.go
@@ -654,18 +654,13 @@ func (r *Range) ShouldSplit() bool {
 	zone := prefixConfig.Config.(*proto.ZoneConfig)
 
 	// Fetch the current size of this range in total bytes.
-	keyBytes, err := engine.GetRangeStat(r.rm.Engine(), r.RangeID, engine.StatKeyBytes)
+	rangeSize, err := engine.GetRangeSize(r.rm.Engine(), r.RangeID)
 	if err != nil {
-		log.Errorf("unable to fetch key bytes for range %d: %s", r.RangeID, err)
-		return false
-	}
-	valBytes, err := engine.GetRangeStat(r.rm.Engine(), r.RangeID, engine.StatValBytes)
-	if err != nil {
-		log.Errorf("unable to fetch value bytes for range %d: %s", r.RangeID, err)
+		log.Errorf("unable to compute size from stats for range %d: %s", r.RangeID, err)
 		return false
 	}
 
-	return keyBytes+valBytes > zone.RangeMaxBytes
+	return rangeSize > zone.RangeMaxBytes
 }
 
 // maybeSplit initiates an asynchronous split via AdminSplit request
@@ -1333,9 +1328,9 @@ func (r *Range) AdminSplit(args *proto.AdminSplitRequest, reply *proto.AdminSpli
 	}
 	defer func() { atomic.StoreInt32(&r.splitting, int32(0)) }()
 
-	// Determine split key if not provided with args. This scan can be
-	// relatively slow because admin commands do not prevent any other
-	// concurrent commands from executing.
+	// Determine split key if not provided with args. This scan is
+	// allowed to be relatively slow because admin commands don't block
+	// other commands.
 	splitKey := proto.Key(args.SplitKey)
 	if len(splitKey) == 0 {
 		snapshotID, err := r.rm.CreateSnapshot()
@@ -1343,7 +1338,7 @@ func (r *Range) AdminSplit(args *proto.AdminSplitRequest, reply *proto.AdminSpli
 			reply.SetGoError(util.Errorf("unable to create snapshot: %s", err))
 			return
 		}
-		splitKey, err = engine.MVCCFindSplitKey(r.rm.Engine(), r.Desc.StartKey, r.Desc.EndKey, snapshotID)
+		splitKey, err = engine.MVCCFindSplitKey(r.rm.Engine(), r.RangeID, r.Desc.StartKey, r.Desc.EndKey, snapshotID)
 		if releaseErr := r.rm.Engine().ReleaseSnapshot(snapshotID); releaseErr != nil {
 			log.Errorf("unable to release snapshot: %s", releaseErr)
 		}
@@ -1358,8 +1353,8 @@ func (r *Range) AdminSplit(args *proto.AdminSplitRequest, reply *proto.AdminSpli
 		reply.SetGoError(proto.NewRangeKeyMismatchError(splitKey, splitKey, r.Desc))
 		return
 	}
-	if splitKey.Less(engine.KeyMeta2Prefix) {
-		reply.SetGoError(util.Errorf("cannot split meta1 addressing keys: %q", splitKey))
+	if !engine.IsValidSplitKey(splitKey) {
+		reply.SetGoError(util.Errorf("cannot split range at key %q", splitKey))
 		return
 	}
 	if splitKey.Equal(r.Desc.StartKey) || splitKey.Equal(r.Desc.EndKey) {

--- a/storage/range_test.go
+++ b/storage/range_test.go
@@ -1421,6 +1421,14 @@ func verifyRangeStats(eng engine.Engine, rangeID int64, expMS engine.MVCCStats, 
 	if !reflect.DeepEqual(expMS, *ms) {
 		t.Errorf("expected stats %+v; got %+v", expMS, ms)
 	}
+	// Also verify the GetRangeSize method.
+	rangeSize, err := engine.GetRangeSize(eng, rangeID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if expSize := expMS.KeyBytes + expMS.ValBytes; expSize != rangeSize {
+		t.Errorf("expected range size %d; got %d", expSize, rangeSize)
+	}
 }
 
 // TestRangeStats verifies that commands executed against a range


### PR DESCRIPTION
Switched MVCCFindSplitKey to do a simpler scan using the recorded range
stats to determine half-way size and finding the closest key to the
halfway mark that does violate any illegal key ranges.
