### PR TITLE
Split ranges along accounting and zone configuration prefix boundaries.

### DIFF
--- a/gossip/gossip.go
+++ b/gossip/gossip.go
@@ -209,11 +209,17 @@ func (g *Gossip) RegisterGroup(prefix string, limit int, typeOf GroupType) error
 	return g.is.registerGroup(newGroup(prefix, limit, typeOf))
 }
 
+// GossipCallback is a callback method to be invoked on gossip update
+// of info denoted by key. The contentsChanged bool indicates whether
+// the info contents were updated. False indicates the info timestamp
+// was refreshed, but its contents remained unchanged.
+type GossipCallback func(key string, contentsChanged bool)
+
 // RegisterCallback registers a callback for a key pattern to be
 // invoked whenever new info for a gossip key matching pattern is
 // received. The callback method is invoked with the info key which
 // matched pattern.
-func (g *Gossip) RegisterCallback(pattern string, method func(string)) {
+func (g *Gossip) RegisterCallback(pattern string, method GossipCallback) {
 	g.mu.Lock()
 	defer g.mu.Unlock()
 	g.is.registerCallback(pattern, method)

--- a/gossip/group.go
+++ b/gossip/group.go
@@ -190,9 +190,11 @@ func (g *group) infosAsSlice() infoSlice {
 // group according to the group type.
 //
 // Returns contentsChanged bool and an error. contentsChanged is true
-// if this info updates the contents of a preexisting info with the
-// same key. An error is returned if the info types don't match an
-// existing group or the info was older than what we currently have.
+// if this info is new or updates the contents of a preexisting info
+// with the same key; if just the timestamp or number of hops changes,
+// contentsChanged is false. An error is returned if the info types
+// don't match an existing group or the info was older than what we
+// currently have.
 func (g *group) addInfo(i *info) (contentsChanged bool, err error) {
 	// First, see if info is already in the group. If so, and this
 	// info timestamp is newer, remove existing info. If the

--- a/kv/local_sender_test.go
+++ b/kv/local_sender_test.go
@@ -128,7 +128,7 @@ func TestLocalSenderLookupReplica(t *testing.T) {
 		t.Fatal(err)
 	}
 	ls.AddStore(store)
-	if _, err := store.BootstrapRange(); err != nil {
+	if err := store.BootstrapRange(); err != nil {
 		t.Fatal(err)
 	}
 	if err := store.Start(); err != nil {

--- a/kv/split_test.go
+++ b/kv/split_test.go
@@ -165,7 +165,7 @@ func TestRangeSplitsWithWritePressure(t *testing.T) {
 		// Scan the txn records.
 		resp := &proto.ScanResponse{}
 		if err := db.Call(proto.Scan, proto.ScanArgs(engine.KeyMeta2Prefix, engine.KeyMetaMax, 0), resp); err != nil {
-			t.Fatalf("failed to scan meta1 keys: %s", err)
+			t.Fatalf("failed to scan meta2 keys: %s", err)
 		}
 		return len(resp.Rows) >= 5
 	}, 2*time.Second); err != nil {

--- a/kv/txn_coord_sender_test.go
+++ b/kv/txn_coord_sender_test.go
@@ -56,7 +56,7 @@ func createTestDB(t *testing.T) (*client.KV, engine.Engine, *hlc.Clock, *hlc.Man
 		t.Fatal(err)
 	}
 	lSender.AddStore(store)
-	if _, err := store.BootstrapRange(); err != nil {
+	if err := store.BootstrapRange(); err != nil {
 		t.Fatal(err)
 	}
 	if err := store.Start(); err != nil {

--- a/server/node.go
+++ b/server/node.go
@@ -127,16 +127,14 @@ func BootstrapCluster(clusterID string, eng engine.Engine) (*client.KV, error) {
 	if err := s.Bootstrap(sIdent); err != nil {
 		return nil, err
 	}
+	// Create first range.
+	if err := s.BootstrapRange(); err != nil {
+		return nil, err
+	}
 	if err := s.Start(); err != nil {
 		return nil, err
 	}
 	lSender.AddStore(s)
-
-	// Create first range.
-	_, err := s.BootstrapRange()
-	if err != nil {
-		return nil, err
-	}
 
 	// Initialize node and store ids after the fact to account
 	// for use of node ID = 1 and store ID = 1.

--- a/storage/db_test.go
+++ b/storage/db_test.go
@@ -57,7 +57,7 @@ func createTestStore(t *testing.T) *storage.Store {
 		t.Fatal(err)
 	}
 	lSender.AddStore(store)
-	if _, err := store.BootstrapRange(); err != nil {
+	if err := store.BootstrapRange(); err != nil {
 		t.Fatal(err)
 	}
 	if err := store.Start(); err != nil {

--- a/storage/prefix.go
+++ b/storage/prefix.go
@@ -86,8 +86,8 @@ func (p PrefixConfigMap) Less(i, j int) bool {
 //
 // These additional entries allow for simple lookups by prefix and
 // provide a way to split a range by prefixes which affect it. This
-// last is necessary for zone configs; ranges must not span zone
-// config boundaries.
+// last is necessary for accounting and zone configs; ranges must not
+// span accounting or zone config boundaries.
 func NewPrefixConfigMap(configs []*PrefixConfig) (PrefixConfigMap, error) {
 	p := PrefixConfigMap(configs)
 	sort.Sort(p)

--- a/storage/prefix_test.go
+++ b/storage/prefix_test.go
@@ -32,6 +32,7 @@ const (
 	config2 = 2
 	config3 = 3
 	config4 = 4
+	config5 = 5
 )
 
 func buildTestPrefixConfigMap() PrefixConfigMap {
@@ -148,8 +149,9 @@ func TestPrefixConfigSuccessivePrefixes(t *testing.T) {
 	configs := []*PrefixConfig{
 		{engine.KeyMin, nil, config1},
 		{proto.Key("/db2"), nil, config2},
-		{proto.Key("/db2/table"), nil, config3},
-		{proto.Key("/db3"), nil, config4},
+		{proto.Key("/db2/table1"), nil, config3},
+		{proto.Key("/db2/table2"), nil, config4},
+		{proto.Key("/db3"), nil, config5},
 	}
 	pcc, err := NewPrefixConfigMap(configs)
 	if err != nil {
@@ -158,9 +160,10 @@ func TestPrefixConfigSuccessivePrefixes(t *testing.T) {
 	expPrefixConfigs := []PrefixConfig{
 		{engine.KeyMin, nil, config1},
 		{proto.Key("/db2"), nil, config2},
-		{proto.Key("/db2/table"), nil, config3},
-		{proto.Key("/db2/tablf"), nil, config2},
-		{proto.Key("/db3"), nil, config4},
+		{proto.Key("/db2/table1"), nil, config3},
+		{proto.Key("/db2/table2"), nil, config4},
+		{proto.Key("/db2/table3"), nil, config2},
+		{proto.Key("/db3"), nil, config5},
 		{proto.Key("/db4"), nil, config1},
 	}
 	verifyPrefixConfigMap(pcc, expPrefixConfigs, t)

--- a/storage/range.go
+++ b/storage/range.go
@@ -50,7 +50,7 @@ func init() {
 	gob.Register(proto.Transaction{})
 }
 
-const (
+var (
 	// DefaultHeartbeatInterval is how often heartbeats are sent from the
 	// transaction coordinator to a live transaction. These keep it from
 	// being preempted by other transactions writing the same keys. If a
@@ -67,17 +67,20 @@ const (
 	ttlClusterIDGossip = 30 * time.Second
 )
 
-// configPrefixes describes administrative configuration maps
+// configDescriptor describes administrative configuration maps
 // affecting ranges of the key-value map by key prefix.
-var configPrefixes = []struct {
+type configDescriptor struct {
 	keyPrefix proto.Key   // Range key prefix
 	gossipKey string      // Gossip key
 	configI   interface{} // Config struct interface
-	dirty     bool        // Info in this config has changed; need to re-init and gossip
-}{
-	{engine.KeyConfigAccountingPrefix, gossip.KeyConfigAccounting, proto.AcctConfig{}, true},
-	{engine.KeyConfigPermissionPrefix, gossip.KeyConfigPermission, proto.PermConfig{}, true},
-	{engine.KeyConfigZonePrefix, gossip.KeyConfigZone, proto.ZoneConfig{}, true},
+}
+
+// configDescriptors is a slice containing the accounting, permissions
+// and zone configuration descriptors.
+var configDescriptors = []*configDescriptor{
+	{engine.KeyConfigAccountingPrefix, gossip.KeyConfigAccounting, proto.AcctConfig{}},
+	{engine.KeyConfigPermissionPrefix, gossip.KeyConfigPermission, proto.PermConfig{}},
+	{engine.KeyConfigZonePrefix, gossip.KeyConfigZone, proto.ZoneConfig{}},
 }
 
 // tsCacheMethods specifies the set of methods which affect the
@@ -181,7 +184,9 @@ func NewRange(rangeID int64, desc *proto.RangeDescriptor, rm RangeManager) *Rang
 // range in the map and gossips config information if the range
 // contains any of the configuration maps.
 func (r *Range) start() {
-	r.maybeGossipConfigs()
+	r.maybeGossipClusterID()
+	r.maybeGossipFirstRange()
+	r.maybeGossipConfigs(configDescriptors...)
 	// Only start gossiping if this range is the first range.
 	if r.IsFirstRange() {
 		go r.startGossip()
@@ -510,11 +515,10 @@ func (r *Range) processRaftCommand(raftCmd proto.InternalRaftCommand) {
 func (r *Range) startGossip() {
 	ticker := time.NewTicker(ttlClusterIDGossip / 2)
 	for {
-		r.maybeGossipClusterID()
-		r.maybeGossipFirstRange()
 		select {
 		case <-ticker.C:
-			break
+			r.maybeGossipClusterID()
+			r.maybeGossipFirstRange()
 		case <-r.closer:
 			return
 		}
@@ -545,25 +549,24 @@ func (r *Range) maybeGossipFirstRange() {
 // within the range, this replica is the raft leader, and their
 // contents are marked dirty. Configuration maps include accounting,
 // permissions, and zones.
-func (r *Range) maybeGossipConfigs() {
+func (r *Range) maybeGossipConfigs(dirtyConfigs ...*configDescriptor) {
 	if r.rm.Gossip() != nil && r.IsLeader() {
-		for _, cp := range configPrefixes {
-			if cp.dirty && r.ContainsKey(cp.keyPrefix) {
+		for _, cd := range dirtyConfigs {
+			if r.ContainsKey(cd.keyPrefix) {
 				// Check for a bad range split.
-				if !r.ContainsKey(cp.keyPrefix.PrefixEnd()) {
-					log.Fatalf("range splits configuration values for %q", cp.keyPrefix)
+				if !r.ContainsKey(cd.keyPrefix.PrefixEnd()) {
+					log.Fatalf("range splits configuration values for %q", cd.keyPrefix)
 				}
-				configMap, err := r.loadConfigMap(cp.keyPrefix, cp.configI)
+				configMap, err := r.loadConfigMap(cd.keyPrefix, cd.configI)
 				if err != nil {
-					log.Errorf("failed loading %s config map: %s", cp.gossipKey, err)
+					log.Errorf("failed loading %s config map: %s", cd.gossipKey, err)
 					continue
 				} else {
-					if err := r.rm.Gossip().AddInfo(cp.gossipKey, configMap, 0*time.Second); err != nil {
-						log.Errorf("failed to gossip %s configMap: %s", cp.gossipKey, err)
+					if err := r.rm.Gossip().AddInfo(cd.gossipKey, configMap, 0*time.Second); err != nil {
+						log.Errorf("failed to gossip %s configMap: %s", cd.gossipKey, err)
 						continue
 					}
 				}
-				cp.dirty = false
 			}
 		}
 	}
@@ -596,10 +599,9 @@ func (r *Range) loadConfigMap(keyPrefix proto.Key, configI interface{}) (PrefixC
 // maybeUpdateGossipConfigs is used to update gossip configs.
 func (r *Range) maybeUpdateGossipConfigs(key proto.Key) {
 	// Check whether this put has modified a configuration map.
-	for _, cp := range configPrefixes {
-		if bytes.HasPrefix(key, cp.keyPrefix) {
-			cp.dirty = true
-			r.maybeGossipConfigs()
+	for _, cd := range configDescriptors {
+		if bytes.HasPrefix(key, cd.keyPrefix) {
+			r.maybeGossipConfigs(cd)
 			break
 		}
 	}
@@ -729,7 +731,8 @@ func (r *Range) executeCmd(method string, args proto.Request, reply proto.Respon
 	}
 
 	// Maybe update gossip configs on a put if there was no error.
-	if (method == proto.Put || method == proto.ConditionalPut) && reply.Header().Error == nil {
+	if (method == proto.Put || method == proto.ConditionalPut) &&
+		header.Key.Less(engine.KeySystemMax) && reply.Header().Error == nil {
 		r.maybeUpdateGossipConfigs(args.Header().Key)
 	}
 

--- a/storage/range.go
+++ b/storage/range.go
@@ -553,7 +553,8 @@ func (r *Range) maybeGossipConfigs(dirtyConfigs ...*configDescriptor) {
 	if r.rm.Gossip() != nil && r.IsLeader() {
 		for _, cd := range dirtyConfigs {
 			if r.ContainsKey(cd.keyPrefix) {
-				// Check for a bad range split.
+				// Check for a bad range split. This should never happen as ranges
+				// cannot be split mid-config.
 				if !r.ContainsKey(cd.keyPrefix.PrefixEnd()) {
 					log.Fatalf("range splits configuration values for %q", cd.keyPrefix)
 				}

--- a/storage/range_test.go
+++ b/storage/range_test.go
@@ -147,7 +147,7 @@ func TestRangeGossipFirstRange(t *testing.T) {
 		for _, key := range []string{gossip.KeyClusterID, gossip.KeyFirstRangeDescriptor} {
 			info, err := g.GetInfo(key)
 			if err != nil {
-				log.Warningf("still waiting for first range gosssip of key %s...", key)
+				log.Warningf("still waiting for first range gossip of key %s...", key)
 				return false
 			}
 			if key == gossip.KeyFirstRangeDescriptor &&

--- a/storage/store.go
+++ b/storage/store.go
@@ -333,6 +333,10 @@ func (s *Store) maybeSplitRangesByConfigs(configMap PrefixConfigMap) {
 			s.mu.Unlock()
 			continue
 		}
+		// If this range isn't the leader of its consensus group, continue.
+		if !s.rangesByKey[n].IsLeader() {
+			continue
+		}
 		desc := *s.rangesByKey[n].Desc
 		s.mu.Unlock()
 

--- a/storage/store.go
+++ b/storage/store.go
@@ -330,7 +330,7 @@ func (s *Store) maybeSplitRangesByConfigs(configMap PrefixConfigMap) {
 			s.mu.Unlock()
 			continue
 		}
-		desc := s.rangesByKey[n].Desc
+		desc := *s.rangesByKey[n].Desc
 		s.mu.Unlock()
 
 		// Now split the range by the config map; we might have multiple

--- a/storage/store_split_test.go
+++ b/storage/store_split_test.go
@@ -404,11 +404,11 @@ func TestStoreRangeSplitOnConfigs(t *testing.T) {
 	acctConfig := &proto.AcctConfig{}
 	zoneConfig := &proto.ZoneConfig{}
 
-	// Write two accounting configs for db1 & db2 and two zone configs for db3 & db4.
-	for i, k := range []string{"db4", "db3", "db2", "db1"} {
+	// Write accounting configs for db1 & db2 and zone configs for db3 & db4.
+	for _, k := range []string{"db4", "db3", "db2", "db1"} {
 		prefix := engine.KeyConfigAccountingPrefix
 		var config gogoproto.Message = acctConfig
-		if i >= 2 {
+		if k == "db3" || k == "db4" {
 			prefix = engine.KeyConfigZonePrefix
 			config = zoneConfig
 		}

--- a/storage/store_test.go
+++ b/storage/store_test.go
@@ -101,7 +101,7 @@ func createTestStore(t *testing.T) (*Store, *hlc.ManualClock) {
 	if err := store.Start(); err != nil {
 		t.Fatal(err)
 	}
-	if _, err := store.BootstrapRange(); err != nil {
+	if err := store.BootstrapRange(); err != nil {
 		t.Fatal(err)
 	}
 	if err := store.Start(); err != nil {
@@ -134,15 +134,12 @@ func TestStoreInitAndBootstrap(t *testing.T) {
 		t.Error("expected error fetching non-existent range")
 	}
 
-	// Create range and fetch.
-	if rng, err := store.BootstrapRange(); rng == nil || err != nil {
+	// Bootstrap first range.
+	if err := store.BootstrapRange(); err != nil {
 		t.Errorf("failure to create first range: %s", err)
 	}
-	if _, err := store.GetRange(1); err != nil {
-		t.Errorf("failure fetching 1st range: %s", err)
-	}
 
-	// Now, attempt to initialize a store with a now-bootstrapped engine.
+	// Now, attempt to initialize a store with a now-bootstrapped range.
 	store = NewStore(clock, eng, nil, nil)
 	if err := store.Start(); err != nil {
 		t.Errorf("failure initializing bootstrapped store: %s", err)


### PR DESCRIPTION
Each store registers a gossip callback for accounting and zone config
maps. On callback, the zone does a binary search using the rangesByKey
sorted slice to find possible ranges which might be intersected by
config map prefixes. On possible hits, the range is dissected along
prefix boundary lines and if there's a necessary split, the range is
split and the process retried.

This allows new zones or accounting prefixes to be specified and ranges
will automatically be split to fit.
