### PR TITLE
Remove all instances in test code which use a zero timestamp.

### DIFF
--- a/client/client_test.go
+++ b/client/client_test.go
@@ -287,7 +287,7 @@ func TestKVClientGetAndPutProto(t *testing.T) {
 	if !ok || err != nil {
 		t.Fatalf("unable to get proto ok? %t: %s", ok, err)
 	}
-	if ts.Equal(proto.MinTimestamp) {
+	if ts.Equal(proto.ZeroTimestamp) {
 		t.Error("expected non-zero timestamp")
 	}
 	if !gogoproto.Equal(zoneConfig, readZoneConfig) {
@@ -324,7 +324,7 @@ func TestKVClientGetAndPutGob(t *testing.T) {
 	if !ok || err != nil {
 		t.Fatalf("unable to get object ok? %t: %s", ok, err)
 	}
-	if ts.Equal(proto.MinTimestamp) {
+	if ts.Equal(proto.ZeroTimestamp) {
 		t.Error("expected non-zero timestamp")
 	}
 	if !reflect.DeepEqual(obj, readObj) {

--- a/proto/data.go
+++ b/proto/data.go
@@ -187,7 +187,9 @@ var (
 	// MaxTimestamp is the max value allowed for Timestamp.
 	MaxTimestamp = Timestamp{WallTime: math.MaxInt64, Logical: math.MaxInt32}
 	// MinTimestamp is the min value allowed for Timestamp.
-	MinTimestamp = Timestamp{WallTime: 0, Logical: 0}
+	MinTimestamp = Timestamp{WallTime: 0, Logical: 1}
+	// ZeroTimestamp is an empty timestamp.
+	ZeroTimestamp = Timestamp{WallTime: 0, Logical: 0}
 	// emptyMD5 is a zero-filled md5 byte array, used to indicate a nil transaction.
 	NoTxnMD5 = [md5.Size]byte{}
 )

--- a/storage/range_test.go
+++ b/storage/range_test.go
@@ -206,7 +206,7 @@ func TestRangeGossipConfigWithMultipleKeyPrefixes(t *testing.T) {
 		t.Fatal(err)
 	}
 	req := &proto.PutRequest{
-		RequestHeader: proto.RequestHeader{Key: key},
+		RequestHeader: proto.RequestHeader{Key: key, Timestamp: proto.MinTimestamp},
 		Value:         proto.Value{Bytes: data},
 	}
 	reply := &proto.PutResponse{}
@@ -246,7 +246,7 @@ func TestRangeGossipConfigUpdates(t *testing.T) {
 		t.Fatal(err)
 	}
 	req := &proto.PutRequest{
-		RequestHeader: proto.RequestHeader{Key: key},
+		RequestHeader: proto.RequestHeader{Key: key, Timestamp: proto.MinTimestamp},
 		Value:         proto.Value{Bytes: data},
 	}
 	reply := &proto.PutResponse{}
@@ -366,8 +366,9 @@ func getArgs(key []byte, rangeID int64) (*proto.GetRequest, *proto.GetResponse) 
 func putArgs(key, value []byte, rangeID int64) (*proto.PutRequest, *proto.PutResponse) {
 	args := &proto.PutRequest{
 		RequestHeader: proto.RequestHeader{
-			Key:     key,
-			Replica: proto.Replica{RangeID: rangeID},
+			Key:       key,
+			Timestamp: proto.MinTimestamp,
+			Replica:   proto.Replica{RangeID: rangeID},
 		},
 		Value: proto.Value{
 			Bytes: value,
@@ -1518,6 +1519,7 @@ func TestRemoteRaftCommand(t *testing.T) {
 
 	// Send an increment direct to raft.
 	remoteIncArgs, _ := incrementArgs([]byte("a"), 2, 1)
+	remoteIncArgs.Timestamp = proto.MinTimestamp
 	raftCmd := proto.InternalRaftCommand{
 		CmdID:  proto.ClientCmdID{WallTime: 1, Random: 1},
 		RaftID: r.Desc.RaftID,

--- a/storage/store.go
+++ b/storage/store.go
@@ -635,7 +635,7 @@ func (s *Store) ExecuteCmd(method string, args proto.Request, reply proto.Respon
 	if err := verifyKeys(header.Key, header.EndKey); err != nil {
 		return err
 	}
-	if header.Timestamp.Equal(proto.MinTimestamp) {
+	if header.Timestamp.Equal(proto.ZeroTimestamp) {
 		// Update the incoming timestamp if unset.
 		header.Timestamp = s.clock.Now()
 	} else {


### PR DESCRIPTION
This is in preparation of using a zero timestamp to mean an inline
MVCC value so we can avoid ever using the engine directly and instead
write all data through the MVCC interface, including merged stat
counters, txn entries, response cache entries, time series data,
and other system-local data.

After some thought, Matt and I ruled out the possibility of not
inlining the value and just using a single version--not much more
efficient and would allow us to use the MVCC code exactly as is.
However, this would have made merging difficult, as there would be
no way to create the MVCC metadata on the first merge.

Support for both types of values is becoming increasingly unwieldy
and the prospect of a parallel interface for querying time series
data and the bifurcation of different regions of the map to be
"mvcc" and "non-mvcc" seems like a pandora's box of troubles.

Follow-on commits in this branch will implement the actual inline
value in proto.MVCCMetadata and the corresponding improvements to
mvcc.go. I intend to take this opportunity to substantially improve
the performance of mvcc scan.
