### PR TITLE
add REST example and TOC to readme

### DIFF
--- a/build/deploy/Dockerfile
+++ b/build/deploy/Dockerfile
@@ -6,6 +6,11 @@ RUN mkdir -p /test /cockroach
 ADD cockroach /cockroach/
 ADD cockroach.sh /cockroach/
 ADD test.sh /test/
+ADD resources /cockroach/resources/
+
+# Set working directory  so that relative paths
+# are resolved appropriately when passed as args.
+WORKDIR /cockroach/
 
 EXPOSE 8080
 ENTRYPOINT ["/cockroach/cockroach.sh"]

--- a/build/deploy/cockroach.sh
+++ b/build/deploy/cockroach.sh
@@ -1,7 +1,6 @@
 #!/bin/sh
-set -ex
+set -e
 if [ -f /test/test.sh ]; then
-  2>&1 echo "running tests"
   (cd /test && ./test.sh) || exit $?
 fi
 /cockroach/cockroach "$@"


### PR DESCRIPTION
- Updated the README to contain a simple example of how to fire up a node via Docker and talk to it via `curl`.
- Added TOC and changed the awkwardly floating Cockroach logo
- snuck in a minor improvement for the deploy image as well (req'd by the readme update though)
