### PR TITLE
Allow operations to cross range boundaries

### DIFF
--- a/kv/dist_sender.go
+++ b/kv/dist_sender.go
@@ -333,7 +333,7 @@ func (ds *DistSender) Send(call *client.Call) {
 				// get the descriptor of the adjacent range to address next.
 				if desc.EndKey.Less(call.Args.Header().EndKey) {
 					if _, ok := call.Reply.(proto.Combinable); !ok {
-						return util.RetryBreak, util.Errorf("illegal cross-range operation: %v", call)
+						return util.RetryBreak, util.Errorf("illegal cross-range operation", call)
 					}
 					// This next lookup is likely for free since we've read the
 					// previous descriptor and range lookups use cache
@@ -385,7 +385,6 @@ func (ds *DistSender) Send(call *client.Call) {
 		// For multi-range requests, we return the failing range's reply.
 		if err != nil {
 			reply.Header().SetGoError(err)
-			// TODO(Tobias): Merge.
 			gogoproto.Merge(call.Reply, reply) // Only relevant in multi-range case.
 			return
 		}

--- a/kv/txn_coord_sender.go
+++ b/kv/txn_coord_sender.go
@@ -178,7 +178,7 @@ func NewTxnCoordSender(wrapped client.KVSender, clock *hlc.Clock) *TxnCoordSende
 func (tc *TxnCoordSender) Send(call *client.Call) {
 	header := call.Args.Header()
 	// TODO(Tobias): for commands that may access multiple ranges,
-	// make sure to wrap in a txn for consistence.
+	// make sure to wrap in a txn for consistency.
 	tc.maybeBeginTxn(header)
 
 	// Process batch specially; otherwise, send via wrapped sender.

--- a/kv/txn_coord_sender.go
+++ b/kv/txn_coord_sender.go
@@ -177,6 +177,8 @@ func NewTxnCoordSender(wrapped client.KVSender, clock *hlc.Clock) *TxnCoordSende
 // if it's not nil but has an empty ID.
 func (tc *TxnCoordSender) Send(call *client.Call) {
 	header := call.Args.Header()
+	// TODO(Tobias): for commands that may access multiple ranges,
+	// make sure to wrap in a txn for consistence.
 	tc.maybeBeginTxn(header)
 
 	// Process batch specially; otherwise, send via wrapped sender.

--- a/proto/api_test.go
+++ b/proto/api_test.go
@@ -67,9 +67,11 @@ func (i YY) Run() {
 // the Combinable interface, notably {Scan,DeleteRange}Response and
 // ResponseHeader.
 func TestCombinable(t *testing.T) {
-	if _, ok := interface{}(&ResponseHeader{}).(Combinable); !ok {
-		t.Fatalf("RequestHeader does not implement Combinable")
+	// Test that GetResponse doesn't have anything to do with Combinable.
+	if _, ok := interface{}(&GetResponse{}).(Combinable); ok {
+		t.Fatalf("GetResponse implements Combinable, so presumably all Response types will")
 	}
+	// Test that {Scan,DeleteRange}Response properly implement it.
 	sr1 := &ScanResponse{
 		ResponseHeader: ResponseHeader{Timestamp: MinTimestamp},
 		Rows: []KeyValue{

--- a/proto/api_test.go
+++ b/proto/api_test.go
@@ -18,6 +18,7 @@
 package proto
 
 import (
+	"fmt"
 	"reflect"
 	"testing"
 )
@@ -50,5 +51,79 @@ func TestResponseHeaderSetGoError(t *testing.T) {
 	}
 	if !err.(*GenericError).Retryable {
 		t.Error("expected generic error to be retryable")
+	}
+}
+
+type XX interface {
+	Run()
+}
+type YY int
+
+func (i YY) Run() {
+	fmt.Println(i)
+}
+
+// TestCombinable tests the correct behaviour of some types that implement
+// the Combinable interface, notably {Scan,DeleteRange}Response and
+// ResponseHeader.
+func TestCombinable(t *testing.T) {
+	if _, ok := interface{}(&ResponseHeader{}).(Combinable); !ok {
+		t.Fatalf("RequestHeader does not implement Combinable")
+	}
+	sr1 := &ScanResponse{
+		ResponseHeader: ResponseHeader{Timestamp: MinTimestamp},
+		Rows: []KeyValue{
+			{Key: Key("A"), Value: Value{Bytes: []byte("V")}},
+		},
+	}
+
+	if _, ok := interface{}(sr1).(Combinable); !ok {
+		t.Fatalf("ScanResponse does not implement Combinable")
+	}
+
+	sr2 := &ScanResponse{
+		ResponseHeader: ResponseHeader{Timestamp: MinTimestamp},
+		Rows: []KeyValue{
+			{Key: Key("B"), Value: Value{Bytes: []byte("W")}},
+		},
+	}
+	sr2.Timestamp = MaxTimestamp
+
+	wantedSR := &ScanResponse{
+		ResponseHeader: ResponseHeader{Timestamp: MaxTimestamp},
+		Rows:           append(append([]KeyValue(nil), sr1.Rows...), sr2.Rows...),
+	}
+
+	sr1.Combine(sr2)
+	sr1.Combine(&ScanResponse{})
+
+	if !reflect.DeepEqual(sr1, wantedSR) {
+		t.Errorf("wanted %v, got %v", wantedSR, sr1)
+	}
+
+	dr1 := &DeleteRangeResponse{
+		ResponseHeader: ResponseHeader{Timestamp: Timestamp{Logical: 100}},
+		NumDeleted:     5,
+	}
+	if _, ok := interface{}(dr1).(Combinable); !ok {
+		t.Fatalf("DeleteRangeResponse does not implement Combinable")
+	}
+	dr2 := &DeleteRangeResponse{
+		ResponseHeader: ResponseHeader{Timestamp: Timestamp{Logical: 1}},
+		NumDeleted:     12,
+	}
+	dr3 := &DeleteRangeResponse{
+		ResponseHeader: ResponseHeader{Timestamp: Timestamp{Logical: 111}},
+		NumDeleted:     3,
+	}
+	wantedDR := &DeleteRangeResponse{
+		ResponseHeader: ResponseHeader{Timestamp: Timestamp{Logical: 111}},
+		NumDeleted:     20,
+	}
+	dr2.Combine(dr3)
+	dr1.Combine(dr2)
+
+	if !reflect.DeepEqual(dr1, wantedDR) {
+		t.Errorf("wanted %v, got %v", wantedDR, dr1)
 	}
 }

--- a/server/testserver.go
+++ b/server/testserver.go
@@ -21,6 +21,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/cockroachdb/cockroach/gossip"
 	"github.com/cockroachdb/cockroach/proto"
 	"github.com/cockroachdb/cockroach/storage/engine"
 	"github.com/cockroachdb/cockroach/util"
@@ -64,6 +65,11 @@ func StartTestServer(t *testing.T) *TestServer {
 		t.Fatal(err)
 	}
 	return s
+}
+
+// Gossip returns the gossip instance used by the TestServer.
+func (ts *TestServer) Gossip() *gossip.Gossip {
+	return ts.gossip
 }
 
 // Start starts the TestServer by bootstrapping an in-memory store


### PR DESCRIPTION
- add proto.Combinable interface

Combinable is implemented by responses whose requests may access multiple ranges,
such as {Scan,DeleteRange}Response and allows multiple responses to be merged
into a single one transparently.
- allow multi-range Scan and DeleteRange

adapted the distributed sender to split such requests up
and adress them to the individual ranges.
The Combinable interface is used to create a single response
from those parts which is returned with the client.Call.
