### PR TITLE
Move all cases of direct "engine" access to inline-MVCC.

### DIFF
--- a/kv/split_test.go
+++ b/kv/split_test.go
@@ -181,9 +181,8 @@ func TestRangeSplitsWithWritePressure(t *testing.T) {
 	// intents. We do this using an IsTrueWithin construct to account
 	// for timing of finishing the test writer and a possibly-ongoing
 	// asynchronous split.
-	mvcc := engine.NewMVCC(eng)
 	if err := util.IsTrueWithin(func() bool {
-		if _, err := mvcc.Scan(engine.KeyLocalMax, engine.KeyMax, 0, proto.MaxTimestamp, nil); err != nil {
+		if _, err := engine.MVCCScan(eng, engine.KeyLocalMax, engine.KeyMax, 0, proto.MaxTimestamp, nil); err != nil {
 			log.Infof("mvcc scan should be clean: %s", err)
 			return false
 		}

--- a/proto/data.go
+++ b/proto/data.go
@@ -404,3 +404,8 @@ func (t Transaction) String() string {
 	return fmt.Sprintf("%q {id=%s pri=%d, iso=%s, stat=%s, epo=%d, ts=%s orig=%s max=%s}",
 		t.Name, t.ID, t.Priority, t.Isolation, t.Status, t.Epoch, t.Timestamp, t.OrigTimestamp, t.MaxTimestamp)
 }
+
+// IsInline returns true if the value is inlined in the metadata.
+func (mvcc *MVCCMetadata) IsInline() bool {
+	return mvcc.Value != nil
+}

--- a/proto/data.proto
+++ b/proto/data.proto
@@ -178,4 +178,10 @@ message MVCCMetadata {
   optional int64 key_bytes = 4 [(gogoproto.nullable) = false];
   // The size in bytes of the most recent versioned value.
   optional int64 val_bytes = 5 [(gogoproto.nullable) = false];
+  // Inline value, used for values with zero timestamp. This provides
+  // an efficient short circuit of the normal MVCC metadata sentinel
+  // and subsequent version rows. If timestamp == (0, 0), then there
+  // is only a single MVCC metadata row with value inlined, and with
+  // empty timestamp, key_bytes, and val_bytes.
+  optional Value value = 6;
 }

--- a/storage/db_test.go
+++ b/storage/db_test.go
@@ -185,8 +185,7 @@ func TestUpdateRangeAddressing(t *testing.T) {
 		}
 		store.DB().Flush()
 		// Scan meta keys directly from engine.
-		mvcc := engine.NewMVCC(store.Engine())
-		kvs, err := mvcc.Scan(engine.KeyMetaPrefix, engine.KeyMetaMax, 0, proto.MaxTimestamp, nil)
+		kvs, err := engine.MVCCScan(store.Engine(), engine.KeyMetaPrefix, engine.KeyMetaMax, 0, proto.MaxTimestamp, nil)
 		if err != nil {
 			t.Fatal(err)
 		}

--- a/storage/engine/batch_test.go
+++ b/storage/engine/batch_test.go
@@ -127,6 +127,13 @@ func TestBatchGet(t *testing.T) {
 	}
 }
 
+func compareMergedValues(result, expected []byte) bool {
+	var resultV, expectedV proto.MVCCMetadata
+	gogoproto.Unmarshal(result, &resultV)
+	gogoproto.Unmarshal(expected, &expectedV)
+	return reflect.DeepEqual(resultV, expectedV)
+}
+
 func TestBatchMerge(t *testing.T) {
 	b := NewInMem(proto.Attributes{}, 1<<20).NewBatch()
 
@@ -157,7 +164,7 @@ func TestBatchMerge(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if !bytes.Equal(val, appender("a-valueappend")) {
+	if !compareMergedValues(val, appender("a-valueappend")) {
 		t.Error("mismatch of \"a\"")
 	}
 
@@ -165,7 +172,7 @@ func TestBatchMerge(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if !bytes.Equal(val, appender("append")) {
+	if !compareMergedValues(val, appender("append")) {
 		t.Error("mismatch of \"b\"")
 	}
 
@@ -173,7 +180,7 @@ func TestBatchMerge(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if !bytes.Equal(val, appender("c-valueappend")) {
+	if !compareMergedValues(val, appender("c-valueappend")) {
 		t.Error("mismatch of \"c\"")
 	}
 }
@@ -365,7 +372,7 @@ func TestBatchConcurrency(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if !bytes.Equal(val, appender("bar")) {
+	if !compareMergedValues(val, appender("bar")) {
 		t.Error("mismatch of \"a\"")
 	}
 	// Write an engine value.

--- a/storage/engine/doc.go
+++ b/storage/engine/doc.go
@@ -86,5 +86,17 @@ into its versioned key. Preliminary benchmarks have not shown enough
 performance improvement to justify this change, although we may
 revisit this decision if it turns out that multiple versions of the
 same key are rare in practice.
+
+However, we do allow inlining in order to use the MVCC interface to
+store non-versioned values. It turns out that not everything which
+Cockroach needs to store would be efficient or possible using MVCC.
+Examples include transaction records, response cache entries, stats
+counters, time series data, and system-local config values. However,
+supporting a mix of encodings is problematic in terms of resulting
+complexity. So Cockroach treats an MVCC timestamp of zero to mean an
+inlined, non-versioned value. These values are replaced if they exist
+on a Put operation and are cleared from the engine on a delete.
+Importantly, zero-timestamped MVCC values may be merged, as is
+necessary for stats counters and time series data.
 */
 package engine

--- a/storage/engine/engine_test.go
+++ b/storage/engine/engine_test.go
@@ -24,11 +24,13 @@ import (
 	"math"
 	"math/rand"
 	"os"
+	"reflect"
 	"sort"
 	"strconv"
 	"testing"
 	"time"
 
+	gogoproto "code.google.com/p/gogoprotobuf/proto"
 	"github.com/cockroachdb/cockroach/proto"
 	"github.com/cockroachdb/cockroach/util"
 )
@@ -284,8 +286,11 @@ func TestEngineMerge(t *testing.T) {
 				}
 			}
 			result, _ := engine.Get(tc.testKey)
-			if !bytes.Equal(result, tc.expected) {
-				t.Errorf("unexpected append-merge result: %v != %v", result, tc.expected)
+			var resultV, expectedV proto.MVCCMetadata
+			gogoproto.Unmarshal(result, &resultV)
+			gogoproto.Unmarshal(tc.expected, &expectedV)
+			if !reflect.DeepEqual(resultV, expectedV) {
+				t.Errorf("unexpected append-merge result: %v != %v", resultV, expectedV)
 			}
 		}
 	}, t)

--- a/storage/id_alloc_test.go
+++ b/storage/id_alloc_test.go
@@ -71,8 +71,7 @@ func TestIDAllocator(t *testing.T) {
 func TestIDAllocatorNegativeValue(t *testing.T) {
 	store, _ := createTestStore(t)
 	// Increment our key to a negative value.
-	mvcc := engine.NewMVCC(store.engine)
-	newValue, err := mvcc.Increment(engine.KeyRaftIDGenerator, store.clock.Now(), nil, -1024)
+	newValue, err := engine.MVCCIncrement(store.Engine(), nil, engine.KeyRaftIDGenerator, store.clock.Now(), nil, -1024)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/storage/range_test.go
+++ b/storage/range_test.go
@@ -74,14 +74,13 @@ var (
 
 // initConfigs creates default configuration entries.
 func initConfigs(e engine.Engine, t *testing.T) {
-	mvcc := engine.NewMVCC(e)
-	if err := mvcc.PutProto(engine.KeyConfigAccountingPrefix, proto.MinTimestamp, nil, &testDefaultAcctConfig); err != nil {
+	if err := engine.MVCCPutProto(e, nil, engine.KeyConfigAccountingPrefix, proto.MinTimestamp, nil, &testDefaultAcctConfig); err != nil {
 		t.Fatal(err)
 	}
-	if err := mvcc.PutProto(engine.KeyConfigPermissionPrefix, proto.MinTimestamp, nil, &testDefaultPermConfig); err != nil {
+	if err := engine.MVCCPutProto(e, nil, engine.KeyConfigPermissionPrefix, proto.MinTimestamp, nil, &testDefaultPermConfig); err != nil {
 		t.Fatal(err)
 	}
-	if err := mvcc.PutProto(engine.KeyConfigZonePrefix, proto.MinTimestamp, nil, &testDefaultZoneConfig); err != nil {
+	if err := engine.MVCCPutProto(e, nil, engine.KeyConfigZonePrefix, proto.MinTimestamp, nil, &testDefaultZoneConfig); err != nil {
 		t.Fatal(err)
 	}
 }
@@ -1102,8 +1101,8 @@ func TestEndTransactionWithErrors(t *testing.T) {
 		existTxn.Status = test.existStatus
 		existTxn.Epoch = test.existEpoch
 		existTxn.Timestamp = test.existTS
-		txnKey := engine.MVCCEncodeKey(engine.MakeKey(engine.KeyLocalTransactionPrefix, test.key))
-		if _, _, err := engine.PutProto(rng.rm.Engine(), txnKey, &existTxn); err != nil {
+		txnKey := engine.MakeKey(engine.KeyLocalTransactionPrefix, test.key)
+		if err := engine.MVCCPutProto(rng.rm.Engine(), nil, txnKey, proto.ZeroTimestamp, nil, &existTxn); err != nil {
 			t.Fatal(err)
 		}
 
@@ -1440,7 +1439,7 @@ func TestInternalPushTxnPushTimestampAlreadyPushed(t *testing.T) {
 }
 
 func verifyRangeStats(eng engine.Engine, rangeID int64, expMS engine.MVCCStats, t *testing.T) {
-	ms, err := engine.GetRangeMVCCStats(eng, rangeID)
+	ms, err := engine.MVCCGetRangeStats(eng, rangeID)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/storage/store_split_test.go
+++ b/storage/store_split_test.go
@@ -48,7 +48,7 @@ func adminSplitArgs(key, splitKey []byte, rangeID int64) (*proto.AdminSplitReque
 }
 
 func verifyRangeStats(eng engine.Engine, rangeID int64, expMS engine.MVCCStats, t *testing.T) {
-	ms, err := engine.GetRangeMVCCStats(eng, rangeID)
+	ms, err := engine.MVCCGetRangeStats(eng, rangeID)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -288,7 +288,7 @@ func TestStoreRangeSplitStats(t *testing.T) {
 		}
 	}
 	// Get the range stats now that we have data.
-	ms, err := engine.GetRangeMVCCStats(store.Engine(), rng.RangeID)
+	ms, err := engine.MVCCGetRangeStats(store.Engine(), rng.RangeID)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -299,12 +299,12 @@ func TestStoreRangeSplitStats(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	msLeft, err := engine.GetRangeMVCCStats(store.Engine(), rng.RangeID)
+	msLeft, err := engine.MVCCGetRangeStats(store.Engine(), rng.RangeID)
 	if err != nil {
 		t.Fatal(err)
 	}
 	rngRight := store.LookupRange(proto.Key("Z"), nil)
-	msRight, err := engine.GetRangeMVCCStats(store.Engine(), rngRight.RangeID)
+	msRight, err := engine.MVCCGetRangeStats(store.Engine(), rngRight.RangeID)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/storage/store_test.go
+++ b/storage/store_test.go
@@ -455,9 +455,9 @@ func TestStoreResolveWriteIntent(t *testing.T) {
 			if err != nil {
 				t.Errorf("expected intent resolved; got unexpected error: %s", err)
 			}
-			encTxnKey := engine.MVCCEncodeKey(engine.MakeKey(engine.KeyLocalTransactionPrefix, pushee.ID))
+			txnKey := engine.MakeKey(engine.KeyLocalTransactionPrefix, pushee.ID)
 			var txn proto.Transaction
-			ok, _, _, err := engine.GetProto(store.Engine(), encTxnKey, &txn)
+			ok, err := engine.MVCCGetProto(store.Engine(), txnKey, proto.ZeroTimestamp, nil, &txn)
 			if !ok || err != nil {
 				t.Fatal("not found or err: %s", err)
 			}
@@ -708,9 +708,9 @@ func TestStoreResolveWriteIntentNoTxn(t *testing.T) {
 	}
 
 	// Read pushee's txn.
-	encTxnKey := engine.MVCCEncodeKey(engine.MakeKey(engine.KeyLocalTransactionPrefix, pushee.ID))
+	txnKey := engine.MakeKey(engine.KeyLocalTransactionPrefix, pushee.ID)
 	var txn proto.Transaction
-	ok, _, _, err := engine.GetProto(store.Engine(), encTxnKey, &txn)
+	ok, err := engine.MVCCGetProto(store.Engine(), txnKey, proto.ZeroTimestamp, nil, &txn)
 	if !ok || err != nil {
 		t.Fatal("not found or err: %s", err)
 	}


### PR DESCRIPTION
This is a necessary step towards ranges which will contain time series
data, which requires merging. Efficient merging cannot be done using
our multi-row MVCC model. This change provides an inline value in the
MVCCMetadata which is used instead of a versioned value if the timestamp
is specified as zero. Inline values are replaced on successive puts and
are cleared on deletes.

The inlined values can be accessed just like versioned values, and all
MVCC operations work, modulo differences in how timestamps are interpreted.
Once a value has been written as inline, it may not be overwritten using
a timestamp for version values. Inlined values support merge.

Currently, the stats are inaccurately kept for merge, though the next
change will do benchmarks to ascertain the cost of keeping accurate
stats.
