### PR TITLE
wrap range-spanning ops in txn

### DIFF
--- a/kv/dist_sender.go
+++ b/kv/dist_sender.go
@@ -333,7 +333,10 @@ func (ds *DistSender) Send(call *client.Call) {
 				// get the descriptor of the adjacent range to address next.
 				if desc.EndKey.Less(call.Args.Header().EndKey) {
 					if _, ok := call.Reply.(proto.Combinable); !ok {
-						return util.RetryBreak, util.Errorf("illegal cross-range operation", call)
+						return util.RetryBreak, util.Error("illegal cross-range operation", call)
+					}
+					if call.Args.Header().Txn == nil {
+						return util.RetryBreak, &proto.OpRequiresTxnError{}
 					}
 					// This next lookup is likely for free since we've read the
 					// previous descriptor and range lookups use cache

--- a/kv/txn_coord_sender.go
+++ b/kv/txn_coord_sender.go
@@ -305,9 +305,7 @@ func (tc *TxnCoordSender) sendOne(call *client.Call) {
 		tmpKV := client.NewKV(tc, nil)
 		tmpKV.User = call.Args.Header().User
 		tmpKV.UserPriority = call.Args.Header().GetUserPriority()
-		// This is nasty, really want a clean request for this- but
-		// the reply has already been used. We'd need a fresh one.
-		call.Reply.Header().SetGoError(nil)
+		call.Reply.Reset()
 		tmpKV.RunTransaction(txnOpts, func(txn *client.KV) error {
 			return txn.Call(call.Method, call.Args, call.Reply)
 		})

--- a/multiraft/multiraft_test.go
+++ b/multiraft/multiraft_test.go
@@ -138,7 +138,7 @@ func TestCommand(t *testing.T) {
 
 	// The command will be committed on each node.
 	for i, events := range cluster.events {
-		log.Infof("waiting for event to be commited on node %v", i)
+		log.Infof("waiting for event to be committed on node %v", i)
 		commit := <-events.CommandCommitted
 		if string(commit.Command) != "command" {
 			t.Errorf("unexpected value in committed command: %v", commit.Command)

--- a/proto/api.go
+++ b/proto/api.go
@@ -496,6 +496,15 @@ func (dr *DeleteRangeResponse) Combine(c Response) {
 	}
 }
 
+// Combine implements the Combinable interface for
+// InternalResolveIntentResponse.
+func (rr *InternalResolveIntentResponse) Combine(c Response) {
+	otherRR := c.(*InternalResolveIntentResponse)
+	if rr != nil {
+		rr.Header().Combine(otherRR.Header())
+	}
+}
+
 // Header implements the Request interface for RequestHeader.
 func (rh *RequestHeader) Header() *RequestHeader {
 	return rh
@@ -543,6 +552,8 @@ func (rh *ResponseHeader) GoError() error {
 		return rh.Error.WriteTooOld
 	case rh.Error.ReadWithinUncertaintyInterval != nil:
 		return rh.Error.ReadWithinUncertaintyInterval
+	case rh.Error.OpRequiresTxn != nil:
+		return rh.Error.OpRequiresTxn
 	default:
 		return nil
 	}
@@ -576,6 +587,8 @@ func (rh *ResponseHeader) SetGoError(err error) {
 		rh.Error = &Error{WriteIntent: t}
 	case *WriteTooOldError:
 		rh.Error = &Error{WriteTooOld: t}
+	case *OpRequiresTxnError:
+		rh.Error = &Error{OpRequiresTxn: t}
 	default:
 		var canRetry bool
 		if r, ok := err.(util.Retryable); ok {

--- a/proto/errors.go
+++ b/proto/errors.go
@@ -137,3 +137,8 @@ func (e *WriteTooOldError) Error() string {
 func (e *ReadWithinUncertaintyIntervalError) Error() string {
 	return fmt.Sprintf("read at time %s encountered previous write with future timestamp %s within uncertainty interval", e.Timestamp, e.ExistingTimestamp)
 }
+
+// Error formats error.
+func (e *OpRequiresTxnError) Error() string {
+	return "the operation requires transactional context"
+}

--- a/proto/errors.proto
+++ b/proto/errors.proto
@@ -112,6 +112,14 @@ message WriteTooOldError {
   optional Timestamp existing_timestamp = 2 [(gogoproto.nullable) = false];
 }
 
+// An OpRequiresTxnError indicates that a command required to be
+// carried out in a transactional context but was not.
+// For example, a Scan which spans ranges requires a transaction.
+// The operation should be retried inside of a transaction.
+message OpRequiresTxnError {
+}
+
+
 // Error is a union type containing all available errors.
 // NOTE: new error types must be added here, and potentially in
 // the two locations (*ResponseHeader).{,Set}GoError().
@@ -127,5 +135,6 @@ message Error {
   optional TransactionStatusError transaction_status = 9;
   optional WriteIntentError write_intent = 10;
   optional WriteTooOldError write_too_old = 11;
+  optional OpRequiresTxnError op_requires_txn = 12;
 }
 

--- a/server/testserver.go
+++ b/server/testserver.go
@@ -25,6 +25,7 @@ import (
 	"github.com/cockroachdb/cockroach/proto"
 	"github.com/cockroachdb/cockroach/storage/engine"
 	"github.com/cockroachdb/cockroach/util"
+	"github.com/cockroachdb/cockroach/util/hlc"
 )
 
 const (
@@ -69,7 +70,18 @@ func StartTestServer(t *testing.T) *TestServer {
 
 // Gossip returns the gossip instance used by the TestServer.
 func (ts *TestServer) Gossip() *gossip.Gossip {
-	return ts.gossip
+	if ts != nil {
+		return ts.gossip
+	}
+	return nil
+}
+
+// Clock returns the clock used by the TestServer.
+func (ts *TestServer) Clock() *hlc.Clock {
+	if ts != nil {
+		return ts.clock
+	}
+	return nil
 }
 
 // Start starts the TestServer by bootstrapping an in-memory store

--- a/storage/engine/mvcc.go
+++ b/storage/engine/mvcc.go
@@ -520,7 +520,8 @@ func mvccPutInternal(engine Engine, ms *MVCCStats, key proto.Key, timestamp prot
 		// existing. If either of these conditions doesn't hold, it's
 		// likely the case that an older RPC is arriving out of order.
 		//
-		// Note that meta.Txn!=nil implies txn!=nil.
+		// Note that if meta.Txn!=nil and txn==nil, a WriteIntentError was
+		// returned above.
 		if !timestamp.Less(meta.Timestamp) &&
 			(meta.Txn == nil || txn.Epoch >= meta.Txn.Epoch) {
 			// If this is an intent and timestamps have changed,


### PR DESCRIPTION
added a new OpRequiresTxn error which can be returned if an operation
requires to be carried out in a Txn but is not.
Upon encountering such an error, the txn_coord_sender will re-send
the operation within a transaction.

The way in which this is done currently feels extremely clumsy and
should be improved.

implemented the proto.Combinable interface for InternalResolveIntentResponse,
which can be addressed to ranges.
