### PR TITLE
Add InternalMerge Command

### DIFF
--- a/kv/db_test.go
+++ b/kv/db_test.go
@@ -171,6 +171,7 @@ func TestKVDBInternalMethods(t *testing.T) {
 		{proto.InternalPushTxn, &proto.InternalPushTxnRequest{}, &proto.InternalPushTxnResponse{}},
 		{proto.InternalResolveIntent, &proto.InternalResolveIntentRequest{}, &proto.InternalResolveIntentResponse{}},
 		{proto.InternalSnapshotCopy, &proto.InternalSnapshotCopyRequest{}, &proto.InternalSnapshotCopyResponse{}},
+		{proto.InternalMerge, &proto.InternalMergeRequest{}, &proto.InternalMergeResponse{}},
 	}
 	// Verify non-public methods experience bad request errors.
 	kvClient := createTestClient(addr)

--- a/proto/api.go
+++ b/proto/api.go
@@ -54,11 +54,6 @@ const (
 	Scan = "Scan"
 	// EndTransaction either commits or aborts an ongoing transaction.
 	EndTransaction = "EndTransaction"
-	// AccumulateTS is used to efficiently accumulate a time series of
-	// int64 quantities representing discrete subtimes. For example, a
-	// key/value might represent a minute of data. Each would contain 60
-	// int64 counts, each representing a second.
-	AccumulateTS = "AccumulateTS"
 	// ReapQueue scans and deletes messages from a recipient message
 	// queue. ReapQueueRequest invocations must be part of an extant
 	// transaction or they fail. Returns the reaped queue messsages, up to
@@ -99,7 +94,6 @@ var AllMethods = stringSet{
 	DeleteRange:           struct{}{},
 	Scan:                  struct{}{},
 	EndTransaction:        struct{}{},
-	AccumulateTS:          struct{}{},
 	ReapQueue:             struct{}{},
 	EnqueueUpdate:         struct{}{},
 	EnqueueMessage:        struct{}{},
@@ -109,6 +103,7 @@ var AllMethods = stringSet{
 	InternalPushTxn:       struct{}{},
 	InternalResolveIntent: struct{}{},
 	InternalSnapshotCopy:  struct{}{},
+	InternalMerge:         struct{}{},
 }
 
 // PublicMethods specifies the set of methods accessible via the
@@ -123,7 +118,6 @@ var PublicMethods = stringSet{
 	DeleteRange:    struct{}{},
 	Scan:           struct{}{},
 	EndTransaction: struct{}{},
-	AccumulateTS:   struct{}{},
 	ReapQueue:      struct{}{},
 	EnqueueUpdate:  struct{}{},
 	EnqueueMessage: struct{}{},
@@ -138,6 +132,7 @@ var InternalMethods = stringSet{
 	InternalPushTxn:       struct{}{},
 	InternalResolveIntent: struct{}{},
 	InternalSnapshotCopy:  struct{}{},
+	InternalMerge:         struct{}{},
 }
 
 // ReadMethods specifies the set of methods which read and return data.
@@ -160,7 +155,6 @@ var WriteMethods = stringSet{
 	Delete:                struct{}{},
 	DeleteRange:           struct{}{},
 	EndTransaction:        struct{}{},
-	AccumulateTS:          struct{}{},
 	ReapQueue:             struct{}{},
 	EnqueueUpdate:         struct{}{},
 	EnqueueMessage:        struct{}{},
@@ -168,6 +162,7 @@ var WriteMethods = stringSet{
 	InternalHeartbeatTxn:  struct{}{},
 	InternalPushTxn:       struct{}{},
 	InternalResolveIntent: struct{}{},
+	InternalMerge:         struct{}{},
 }
 
 // TxnMethods specifies the set of methods which leave key intents
@@ -178,7 +173,6 @@ var TxnMethods = stringSet{
 	Increment:      struct{}{},
 	Delete:         struct{}{},
 	DeleteRange:    struct{}{},
-	AccumulateTS:   struct{}{},
 	ReapQueue:      struct{}{},
 	EnqueueUpdate:  struct{}{},
 	EnqueueMessage: struct{}{},
@@ -316,8 +310,6 @@ func MethodForRequest(req Request) (string, error) {
 		return Scan, nil
 	case *EndTransactionRequest:
 		return EndTransaction, nil
-	case *AccumulateTSRequest:
-		return AccumulateTS, nil
 	case *ReapQueueRequest:
 		return ReapQueue, nil
 	case *EnqueueUpdateRequest:
@@ -336,6 +328,8 @@ func MethodForRequest(req Request) (string, error) {
 		return InternalResolveIntent, nil
 	case *InternalSnapshotCopyRequest:
 		return InternalSnapshotCopy, nil
+	case *InternalMergeRequest:
+		return InternalMerge, nil
 	}
 	return "", util.Errorf("unhandled request %T", req)
 }
@@ -371,8 +365,6 @@ func CreateArgs(method string) (Request, error) {
 		return &ScanRequest{}, nil
 	case EndTransaction:
 		return &EndTransactionRequest{}, nil
-	case AccumulateTS:
-		return &AccumulateTSRequest{}, nil
 	case ReapQueue:
 		return &ReapQueueRequest{}, nil
 	case EnqueueUpdate:
@@ -391,6 +383,8 @@ func CreateArgs(method string) (Request, error) {
 		return &InternalResolveIntentRequest{}, nil
 	case InternalSnapshotCopy:
 		return &InternalSnapshotCopyRequest{}, nil
+	case InternalMerge:
+		return &InternalMergeRequest{}, nil
 	}
 	return nil, util.Errorf("unhandled method %s", method)
 }
@@ -416,8 +410,6 @@ func CreateReply(method string) (Response, error) {
 		return &ScanResponse{}, nil
 	case EndTransaction:
 		return &EndTransactionResponse{}, nil
-	case AccumulateTS:
-		return &AccumulateTSResponse{}, nil
 	case ReapQueue:
 		return &ReapQueueResponse{}, nil
 	case EnqueueUpdate:
@@ -436,6 +428,8 @@ func CreateReply(method string) (Response, error) {
 		return &InternalResolveIntentResponse{}, nil
 	case InternalSnapshotCopy:
 		return &InternalSnapshotCopyResponse{}, nil
+	case InternalMerge:
+		return &InternalMergeResponse{}, nil
 	}
 	return nil, util.Errorf("unhandled method %s", method)
 }

--- a/proto/api.proto
+++ b/proto/api.proto
@@ -249,21 +249,6 @@ message EndTransactionResponse {
   optional int64 commit_wait = 2 [(gogoproto.nullable) = false];
 }
 
-// An AccumulateTSRequest is arguments to the AccumulateTS() method.
-// It specifies the key at which to accumulate TS values, and the
-// time series counts for this discrete time interval.
-message AccumulateTSRequest {
-  optional RequestHeader header = 1 [(gogoproto.nullable) = false, (gogoproto.embed) = true];
-  // One per discrete subtime period (e.g. one/minute or one/second)
-  repeated int64 counts = 2 [(gogoproto.nullable) = false];
-}
-
-// An AccumulateTSResponse is the return value from the AccumulateTS()
-// method.
-message AccumulateTSResponse {
-  optional ResponseHeader header = 1 [(gogoproto.nullable) = false, (gogoproto.embed) = true];
-}
-
 // A ReapQueueRequest is arguments to the ReapQueue() method. It
 // specifies the recipient inbox key to which messages are waiting
 // to be reapted and also the maximum number of results to return.
@@ -322,10 +307,9 @@ message RequestUnion {
   optional DeleteRangeRequest delete_range = 7;
   optional ScanRequest scan = 8;
   optional EndTransactionRequest end_transaction = 9;
-  optional AccumulateTSRequest accumulate_ts = 10;
-  optional ReapQueueRequest reap_queue = 11;
-  optional EnqueueUpdateRequest enqueue_update = 12;
-  optional EnqueueMessageRequest enqueue_message = 13;
+  optional ReapQueueRequest reap_queue = 10;
+  optional EnqueueUpdateRequest enqueue_update = 11;
+  optional EnqueueMessageRequest enqueue_message = 12;
 }
 
 // A ResponseUnion contains exactly one of the optional responses.
@@ -340,10 +324,9 @@ message ResponseUnion {
   optional DeleteRangeResponse delete_range = 7;
   optional ScanResponse scan = 8;
   optional EndTransactionResponse end_transaction = 9;
-  optional AccumulateTSResponse accumulate_ts = 10;
-  optional ReapQueueResponse reap_queue = 11;
-  optional EnqueueUpdateResponse enqueue_update = 12;
-  optional EnqueueMessageResponse enqueue_message = 13;
+  optional ReapQueueResponse reap_queue = 10;
+  optional EnqueueUpdateResponse enqueue_update = 11;
+  optional EnqueueMessageResponse enqueue_message = 12;
 }
 
 // A BatchRequest contains one or more requests to be executed in

--- a/proto/internal.go
+++ b/proto/internal.go
@@ -47,6 +47,14 @@ const (
 	// end key up to some maximum number of results from the given snapshot_id.
 	// It will create a snapshot if snapshot_id is empty.
 	InternalSnapshotCopy = "InternalSnapshotCopy"
+	// InternalMerge merges a given value into the specified key. Merge is a
+	// high-performance operation provided by underlying data storage for values
+	// which are accumulated over several writes. Because it is not
+	// transactional, Merge is currently not made available to external clients.
+	//
+	// The logic used to merge values of different types is described in more
+	// detail by the "Merge" method of engine.Engine.
+	InternalMerge = "InternalMerge"
 )
 
 // ToValue generates a Value message which contains an encoded copy of this

--- a/proto/internal.proto
+++ b/proto/internal.proto
@@ -132,6 +132,19 @@ message InternalSnapshotCopyResponse {
   repeated RawKeyValue rows = 3 [(gogoproto.nullable) = false];
 }
 
+// An InternalMergeRequest contains arguments to the InternalMerge() method. It
+// specifies a key and a value which should be merged into the existing value at
+// that key.
+message InternalMergeRequest {
+  optional RequestHeader header = 1 [(gogoproto.nullable) = false, (gogoproto.embed) = true];
+  optional Value value = 2 [(gogoproto.nullable) = false];
+}
+
+// InternalMergeResponse is the response to an InternalMerge() operation.
+message InternalMergeResponse {
+  optional ResponseHeader header = 1 [(gogoproto.nullable) = false, (gogoproto.embed) = true];
+}
+
 // A ReadWriteCmdResponse is a union type containing instances of all
 // mutating commands. Note that any entry added here must be handled
 // in roachlib/db.cc in GetResponseHeader().
@@ -143,13 +156,13 @@ message ReadWriteCmdResponse {
   optional DeleteResponse delete = 4;
   optional DeleteRangeResponse delete_range = 5;
   optional EndTransactionResponse end_transaction = 6;
-  optional AccumulateTSResponse accumulate_ts = 7 [(gogoproto.customname) = "AccumulateTS"];
-  optional ReapQueueResponse reap_queue = 8;
-  optional EnqueueUpdateResponse enqueue_update = 9;
-  optional EnqueueMessageResponse enqueue_message = 10;
-  optional InternalHeartbeatTxnResponse internal_heartbeat_txn = 11;
-  optional InternalPushTxnResponse internal_push_txn = 12;
-  optional InternalResolveIntentResponse internal_resolve_intent = 13;
+  optional ReapQueueResponse reap_queue = 7;
+  optional EnqueueUpdateResponse enqueue_update = 8;
+  optional EnqueueMessageResponse enqueue_message = 9;
+  optional InternalHeartbeatTxnResponse internal_heartbeat_txn = 10;
+  optional InternalPushTxnResponse internal_push_txn = 11;
+  optional InternalResolveIntentResponse internal_resolve_intent = 12;
+  optional InternalMergeResponse internal_merge = 13;
 }
 
 // An InternalRaftCommandUnion is the union of all commands which can be
@@ -166,10 +179,9 @@ message InternalRaftCommandUnion {
   optional DeleteRangeRequest delete_range = 7;
   optional ScanRequest scan = 8;
   optional EndTransactionRequest end_transaction = 9;
-  optional AccumulateTSRequest accumulate_ts = 10;
-  optional ReapQueueRequest reap_queue = 11;
-  optional EnqueueUpdateRequest enqueue_update = 12;
-  optional EnqueueMessageRequest enqueue_message = 13;
+  optional ReapQueueRequest reap_queue = 10;
+  optional EnqueueUpdateRequest enqueue_update = 11;
+  optional EnqueueMessageRequest enqueue_message = 12;
 
   // Other requests. Allow a gap in tag numbers so the previous list can
   // be copy/pasted from RequestUnion.
@@ -179,6 +191,7 @@ message InternalRaftCommandUnion {
   optional InternalPushTxnRequest internal_push_txn = 33;
   optional InternalResolveIntentRequest internal_resolve_intent = 34;
   optional InternalSnapshotCopyRequest internal_snapshot_copy = 35;
+  optional InternalMergeRequest internal_merge_response = 36;
 }
 
 // An InternalRaftCommand is a command which can be serialized and
@@ -232,7 +245,6 @@ message TimeSeriesData {
     // A set of data points which fall within the interval.
     repeated TimeSeriesDataPoint data = 4;
 }
-
 
 // A TimeSeriesDataPoint is a single point of numeric data sampled at particular
 // time. Multiple TimeSeriesDataPoints are grouped into a single TimeSeriesData

--- a/roachlib/db.cc
+++ b/roachlib/db.cc
@@ -107,8 +107,6 @@ const proto::ResponseHeader* GetResponseHeader(const proto::ReadWriteCmdResponse
     return &rwResp.delete_range().header();
   } else if (rwResp.has_end_transaction()) {
     return &rwResp.end_transaction().header();
-  } else if (rwResp.has_accumulate_ts()) {
-    return &rwResp.accumulate_ts().header();
   } else if (rwResp.has_reap_queue()) {
     return &rwResp.reap_queue().header();
   } else if (rwResp.has_enqueue_update()) {
@@ -121,6 +119,8 @@ const proto::ResponseHeader* GetResponseHeader(const proto::ReadWriteCmdResponse
     return &rwResp.internal_push_txn().header();
   } else if (rwResp.has_internal_resolve_intent()) {
     return &rwResp.internal_resolve_intent().header();
+  } else if (rwResp.has_internal_merge()) {
+    return &rwResp.internal_merge().header();
   }
   return NULL;
 }

--- a/server/node.go
+++ b/server/node.go
@@ -436,11 +436,6 @@ func (n *Node) EndTransaction(args *proto.EndTransactionRequest, reply *proto.En
 	return n.executeCmd(proto.EndTransaction, args, reply)
 }
 
-// AccumulateTS .
-func (n *Node) AccumulateTS(args *proto.AccumulateTSRequest, reply *proto.AccumulateTSResponse) error {
-	return n.executeCmd(proto.AccumulateTS, args, reply)
-}
-
 // ReapQueue .
 func (n *Node) ReapQueue(args *proto.ReapQueueRequest, reply *proto.ReapQueueResponse) error {
 	return n.executeCmd(proto.ReapQueue, args, reply)
@@ -484,4 +479,9 @@ func (n *Node) InternalResolveIntent(args *proto.InternalResolveIntentRequest, r
 // InternalSnapshotCopy .
 func (n *Node) InternalSnapshotCopy(args *proto.InternalSnapshotCopyRequest, reply *proto.InternalSnapshotCopyResponse) error {
 	return n.executeCmd(proto.InternalSnapshotCopy, args, reply)
+}
+
+// InternalMerge .
+func (n *Node) InternalMerge(args *proto.InternalMergeRequest, reply *proto.InternalMergeResponse) error {
+	return n.executeCmd(proto.InternalMerge, args, reply)
 }

--- a/storage/engine/engine.go
+++ b/storage/engine/engine.go
@@ -66,8 +66,20 @@ type Engine interface {
 	// merges. The list passed to WriteBatch must only contain elements
 	// of type Batch{Put,Merge,Delete}.
 	WriteBatch([]interface{}) error
-	// Merge implements a merge operation with counter semantics.
-	// See the docs for goMergeInit and goMerge for details.
+	// Merge is a high-performance write operation used for values which are
+	// accumulated over several writes. Multiple values can be merged
+	// sequentially into a single key; a subsequent read will return a "merged"
+	// value which is computed from the original merged values.
+	//
+	// Merge currently provides specialized behavior for three data types:
+	// integers, byte slices, and time series observations. Merged integers are
+	// summed, acting as a high-performance accumulator.  Byte slices are simply
+	// concatenated in the order they are merged. Time series observations
+	// (stored as byte slices with a special tag on the proto.Value) are
+	// combined with specialized logic beyond that of simple byte slices.
+	//
+	// The logic for merges is written in our C++ "roachlib" library in order to
+	// be compatible with RocksDB.
 	Merge(key proto.EncodedKey, value []byte) error
 	// Capacity returns capacity details for the engine's available storage.
 	Capacity() (StoreCapacity, error)


### PR DESCRIPTION
Add the InternalMerge command, which is replacing the anticipated (but never
implemented) AccumulateTS command.  InternalMerge is similar to a put in that it
writes a single value to a key - however, the supplied value is _merged_ into
the existing value instead of replacing it.

Merging is not transactional, and thus it is only exposed internally for usage
in certain operations which require a high write performance (such as the
accumulation of time series data).
