### PR TITLE
Remove range ID and use raft ID instead.

### DIFF
--- a/kv/local_sender_test.go
+++ b/kv/local_sender_test.go
@@ -157,7 +157,9 @@ func TestLocalSenderLookupReplica(t *testing.T) {
 			t.Fatal(err)
 		}
 		newRng := storage.NewRange(desc, s[i])
-		s[i].AddRange(newRng)
+		if err := s[i].AddRange(newRng); err != nil {
+			t.Error(err)
+		}
 		ls.AddStore(s[i])
 	}
 

--- a/kv/local_sender_test.go
+++ b/kv/local_sender_test.go
@@ -110,7 +110,7 @@ func splitTestRange(store *storage.Store, key, splitKey proto.Key, t *testing.T)
 	if err != nil {
 		t.Fatal(err)
 	}
-	newRng := storage.NewRange(desc.FindReplica(store.StoreID()).RangeID, desc, store)
+	newRng := storage.NewRange(desc, store)
 	if err := store.SplitRange(rng, newRng); err != nil {
 		t.Fatal(err)
 	}
@@ -156,24 +156,24 @@ func TestLocalSenderLookupReplica(t *testing.T) {
 		if err != nil {
 			t.Fatal(err)
 		}
-		newRng := storage.NewRange(desc.FindReplica(rng.storeID).RangeID, desc, s[i])
+		newRng := storage.NewRange(desc, s[i])
 		s[i].AddRange(newRng)
 		ls.AddStore(s[i])
 	}
 
-	if r, err := ls.lookupReplica(proto.Key("a"), proto.Key("c")); r.StoreID != s[0].Ident.StoreID || err != nil {
+	if _, r, err := ls.lookupReplica(proto.Key("a"), proto.Key("c")); r.StoreID != s[0].Ident.StoreID || err != nil {
 		t.Errorf("expected store %d; got %d: %v", s[0].Ident.StoreID, r.StoreID, err)
 	}
-	if r, err := ls.lookupReplica(proto.Key("b"), nil); r.StoreID != s[0].Ident.StoreID || err != nil {
+	if _, r, err := ls.lookupReplica(proto.Key("b"), nil); r.StoreID != s[0].Ident.StoreID || err != nil {
 		t.Errorf("expected store %d; got %d: %v", s[0].Ident.StoreID, r.StoreID, err)
 	}
-	if r, err := ls.lookupReplica(proto.Key("b"), proto.Key("d")); r != nil || err == nil {
+	if _, r, err := ls.lookupReplica(proto.Key("b"), proto.Key("d")); r != nil || err == nil {
 		t.Errorf("expected store 0 and error got %d", r.StoreID)
 	}
-	if r, err := ls.lookupReplica(proto.Key("x"), proto.Key("z")); r.StoreID != s[1].Ident.StoreID {
+	if _, r, err := ls.lookupReplica(proto.Key("x"), proto.Key("z")); r.StoreID != s[1].Ident.StoreID {
 		t.Errorf("expected store %d; got %d: %v", s[1].Ident.StoreID, r.StoreID, err)
 	}
-	if r, err := ls.lookupReplica(proto.Key("y"), nil); r.StoreID != s[1].Ident.StoreID || err != nil {
+	if _, r, err := ls.lookupReplica(proto.Key("y"), nil); r.StoreID != s[1].Ident.StoreID || err != nil {
 		t.Errorf("expected store %d; got %d: %v", s[1].Ident.StoreID, r.StoreID, err)
 	}
 }

--- a/kv/rest_test.go
+++ b/kv/rest_test.go
@@ -358,7 +358,6 @@ func TestSystemKeys(t *testing.T) {
 			proto.Replica{
 				NodeID:  1,
 				StoreID: 1,
-				RangeID: 1,
 			},
 		},
 	}

--- a/proto/api.proto
+++ b/proto/api.proto
@@ -63,6 +63,10 @@ message RequestHeader {
   // Replica specifies the destination for the request. This is a specific
   // instance of the available replicas belonging to RangeID.
   optional Replica replica = 6 [(gogoproto.nullable) = false];
+  // RaftID specifies the ID of the Raft consensus group which the key
+  // range belongs to. This is used by the receiving node to route the
+  // request to the correct range.
+  optional int64 raft_id = 7 [(gogoproto.nullable) = false, (gogoproto.customname) = "RaftID"];
   // UserPriority specifies priority multiple for non-transactional
   // commands. This value should be a positive integer [1, 2^31-1).
   // It's properly viewed as a multiple for how likely this
@@ -72,13 +76,13 @@ message RequestHeader {
   // with UserPriority=1. This value is ignored if Txn is
   // specified. If neither this value nor Txn is specified, the value
   // defaults to 1.
-  optional int32 user_priority = 7 [default = 1];
+  optional int32 user_priority = 8 [default = 1];
   // Txn is set non-nil if a transaction is underway. To start a txn,
   // the first request should set this field to non-nil with name and
   // isolation level set as desired. The response will contain the
   // fully-initialized transaction with txn ID, priority, initial
   // timestamp, and maximum timestamp.
-  optional Transaction txn = 8;
+  optional Transaction txn = 9;
 }
 
 // ResponseHeader is returned with every storage node response.

--- a/proto/config.proto
+++ b/proto/config.proto
@@ -26,16 +26,14 @@ message Attributes {
 }
 
 // Replica describes a replica location by node ID (corresponds to a
-// host:port via lookup on gossip network), store ID (corresponds to
-// a physical device, unique per node) and range ID. Datacenter and
-// DiskType are provided to optimize reads. Replicas are stored in
-// Range lookup records (meta1, meta2).
+// host:port via lookup on gossip network), store ID (identifies the
+// device) and associated attributes. Replicas are stored in Range
+// lookup records (meta1, meta2).
 message Replica {
   optional int32 node_id = 1 [(gogoproto.nullable) = false, (gogoproto.customname) = "NodeID"];
   optional int32 store_id = 2 [(gogoproto.nullable) = false, (gogoproto.customname) = "StoreID"];
-  optional int64 range_id = 3 [(gogoproto.nullable) = false, (gogoproto.customname) = "RangeID"];
-  // combination of node & store attributes.
-  optional Attributes attrs = 4 [(gogoproto.nullable) = false];
+  // Combination of node & store attributes.
+  optional Attributes attrs = 3 [(gogoproto.nullable) = false];
 }
 
 // RangeDescriptor is the value stored in a range metadata key.

--- a/proto/config_test.go
+++ b/proto/config_test.go
@@ -65,14 +65,14 @@ func TestAttributesSortedString(t *testing.T) {
 func TestRangeDescriptorFindReplica(t *testing.T) {
 	desc := RangeDescriptor{
 		Replicas: []Replica{
-			{StoreID: 1, RangeID: 1},
-			{StoreID: 2, RangeID: 2},
-			{StoreID: 3, RangeID: 3},
+			{NodeID: 1, StoreID: 1},
+			{NodeID: 2, StoreID: 2},
+			{NodeID: 3, StoreID: 3},
 		},
 	}
 	for i, r := range desc.Replicas {
-		if rID := desc.FindReplica(r.StoreID).RangeID; rID != r.RangeID {
-			t.Errorf("%d: expected to find range %d for store %d; got %d", i, r.RangeID, r.StoreID, rID)
+		if nID := desc.FindReplica(r.StoreID).NodeID; nID != r.NodeID {
+			t.Errorf("%d: expected to find node %d for store %d; got %d", i, r.NodeID, r.StoreID, nID)
 		}
 	}
 }

--- a/proto/errors.go
+++ b/proto/errors.go
@@ -35,15 +35,15 @@ func (e *NotLeaderError) Error() string {
 }
 
 // NewRangeNotFoundError initializes a new RangeNotFoundError.
-func NewRangeNotFoundError(rid int64) *RangeNotFoundError {
+func NewRangeNotFoundError(raftID int64) *RangeNotFoundError {
 	return &RangeNotFoundError{
-		RangeID: rid,
+		RaftID: raftID,
 	}
 }
 
 // Error formats error.
 func (e *RangeNotFoundError) Error() string {
-	return fmt.Sprintf("range %d was not found", e.RangeID)
+	return fmt.Sprintf("range %d was not found", e.RaftID)
 }
 
 // CanRetry indicates whether or not this RangeNotFoundError can be retried.

--- a/proto/errors.proto
+++ b/proto/errors.proto
@@ -37,7 +37,7 @@ message NotLeaderError {
 // A RangeNotFoundError indicates that a command was sent to a range
 // which is not hosted on this store.
 message RangeNotFoundError {
-  optional int64 range_id = 1 [(gogoproto.nullable) = false, (gogoproto.customname) = "RangeID"];
+  optional int64 raft_id = 1 [(gogoproto.nullable) = false, (gogoproto.customname) = "RaftID"];
 }
 
 // A RangeKeyMismatchError indicates that a command was sent to a

--- a/storage/db_test.go
+++ b/storage/db_test.go
@@ -68,11 +68,12 @@ func createTestStore(t *testing.T) *storage.Store {
 
 // getArgs returns a GetRequest and GetResponse pair addressed to
 // the default replica for the specified key.
-func getArgs(key []byte, rangeID int64) (*proto.GetRequest, *proto.GetResponse) {
+func getArgs(key []byte, raftID int64, storeID int32) (*proto.GetRequest, *proto.GetResponse) {
 	args := &proto.GetRequest{
 		RequestHeader: proto.RequestHeader{
 			Key:     key,
-			Replica: proto.Replica{RangeID: rangeID},
+			RaftID:  raftID,
+			Replica: proto.Replica{StoreID: storeID},
 		},
 	}
 	reply := &proto.GetResponse{}
@@ -81,11 +82,12 @@ func getArgs(key []byte, rangeID int64) (*proto.GetRequest, *proto.GetResponse) 
 
 // putArgs returns a PutRequest and PutResponse pair addressed to
 // the default replica for the specified key / value.
-func putArgs(key, value []byte, rangeID int64) (*proto.PutRequest, *proto.PutResponse) {
+func putArgs(key, value []byte, raftID int64, storeID int32) (*proto.PutRequest, *proto.PutResponse) {
 	args := &proto.PutRequest{
 		RequestHeader: proto.RequestHeader{
 			Key:     key,
-			Replica: proto.Replica{RangeID: rangeID},
+			RaftID:  raftID,
+			Replica: proto.Replica{StoreID: storeID},
 		},
 		Value: proto.Value{
 			Bytes: value,
@@ -97,11 +99,12 @@ func putArgs(key, value []byte, rangeID int64) (*proto.PutRequest, *proto.PutRes
 
 // incrementArgs returns an IncrementRequest and IncrementResponse pair
 // addressed to the default replica for the specified key / value.
-func incrementArgs(key []byte, inc int64, rangeID int64) (*proto.IncrementRequest, *proto.IncrementResponse) {
+func incrementArgs(key []byte, inc int64, raftID int64, storeID int32) (*proto.IncrementRequest, *proto.IncrementResponse) {
 	args := &proto.IncrementRequest{
 		RequestHeader: proto.RequestHeader{
 			Key:     key,
-			Replica: proto.Replica{RangeID: rangeID},
+			RaftID:  raftID,
+			Replica: proto.Replica{StoreID: storeID},
 		},
 		Increment: inc,
 	}

--- a/storage/engine/engine.go
+++ b/storage/engine/engine.go
@@ -56,7 +56,7 @@ type Iterator interface {
 	Next()
 	// Key returns the current key as a byte slice.
 	Key() []byte
-	// Key returns the current value as a byte slice.
+	// Value returns the current value as a byte slice.
 	Value() []byte
 	// Error returns the error, if any, which the iterator encountered.
 	Error() error

--- a/storage/engine/keys.go
+++ b/storage/engine/keys.go
@@ -228,8 +228,6 @@ var (
 	KeyNodeIDGenerator = MakeKey(KeySystemPrefix, proto.Key("node-idgen"))
 	// KeyRaftIDGenerator is the global Raft consensus group ID generator sequence.
 	KeyRaftIDGenerator = MakeKey(KeySystemPrefix, proto.Key("raft-idgen"))
-	// KeyRangeIDGenerator is the global range ID generator sequence.
-	KeyRangeIDGenerator = MakeKey(KeySystemPrefix, proto.Key("range-idgen"))
 	// KeySchemaPrefix specifies key prefixes for schema definitions.
 	KeySchemaPrefix = MakeKey(KeySystemPrefix, proto.Key("schema"))
 	// KeyStoreIDGeneratorPrefix specifies key prefixes for sequence

--- a/storage/engine/mvcc.go
+++ b/storage/engine/mvcc.go
@@ -51,27 +51,27 @@ type MVCCStats struct {
 
 // MergeStats merges accumulated stats to stat counters for both the
 // affected range and store.
-func (ms *MVCCStats) MergeStats(engine Engine, rangeID int64, storeID int32) {
-	MergeStat(engine, rangeID, storeID, StatLiveBytes, ms.LiveBytes)
-	MergeStat(engine, rangeID, storeID, StatKeyBytes, ms.KeyBytes)
-	MergeStat(engine, rangeID, storeID, StatValBytes, ms.ValBytes)
-	MergeStat(engine, rangeID, storeID, StatIntentBytes, ms.IntentBytes)
-	MergeStat(engine, rangeID, storeID, StatLiveCount, ms.LiveCount)
-	MergeStat(engine, rangeID, storeID, StatKeyCount, ms.KeyCount)
-	MergeStat(engine, rangeID, storeID, StatValCount, ms.ValCount)
-	MergeStat(engine, rangeID, storeID, StatIntentCount, ms.IntentCount)
+func (ms *MVCCStats) MergeStats(engine Engine, raftID int64, storeID int32) {
+	MergeStat(engine, raftID, storeID, StatLiveBytes, ms.LiveBytes)
+	MergeStat(engine, raftID, storeID, StatKeyBytes, ms.KeyBytes)
+	MergeStat(engine, raftID, storeID, StatValBytes, ms.ValBytes)
+	MergeStat(engine, raftID, storeID, StatIntentBytes, ms.IntentBytes)
+	MergeStat(engine, raftID, storeID, StatLiveCount, ms.LiveCount)
+	MergeStat(engine, raftID, storeID, StatKeyCount, ms.KeyCount)
+	MergeStat(engine, raftID, storeID, StatValCount, ms.ValCount)
+	MergeStat(engine, raftID, storeID, StatIntentCount, ms.IntentCount)
 }
 
 // SetStats sets stat counters for both the affected range and store.
-func (ms *MVCCStats) SetStats(engine Engine, rangeID int64, storeID int32) {
-	SetStat(engine, rangeID, storeID, StatLiveBytes, ms.LiveBytes)
-	SetStat(engine, rangeID, storeID, StatKeyBytes, ms.KeyBytes)
-	SetStat(engine, rangeID, storeID, StatValBytes, ms.ValBytes)
-	SetStat(engine, rangeID, storeID, StatIntentBytes, ms.IntentBytes)
-	SetStat(engine, rangeID, storeID, StatLiveCount, ms.LiveCount)
-	SetStat(engine, rangeID, storeID, StatKeyCount, ms.KeyCount)
-	SetStat(engine, rangeID, storeID, StatValCount, ms.ValCount)
-	SetStat(engine, rangeID, storeID, StatIntentCount, ms.IntentCount)
+func (ms *MVCCStats) SetStats(engine Engine, raftID int64, storeID int32) {
+	SetStat(engine, raftID, storeID, StatLiveBytes, ms.LiveBytes)
+	SetStat(engine, raftID, storeID, StatKeyBytes, ms.KeyBytes)
+	SetStat(engine, raftID, storeID, StatValBytes, ms.ValBytes)
+	SetStat(engine, raftID, storeID, StatIntentBytes, ms.IntentBytes)
+	SetStat(engine, raftID, storeID, StatLiveCount, ms.LiveCount)
+	SetStat(engine, raftID, storeID, StatKeyCount, ms.KeyCount)
+	SetStat(engine, raftID, storeID, StatValCount, ms.ValCount)
+	SetStat(engine, raftID, storeID, StatIntentCount, ms.IntentCount)
 }
 
 // updateStatsForKey returns whether or not the bytes and counts for
@@ -231,31 +231,31 @@ func (ms *MVCCStats) updateStatsOnAbort(key proto.Key, origMetaKeySize, origMeta
 
 // MVCCGetRangeStats reads stat counters for the specified range and
 // returns an MVCCStats object on success.
-func MVCCGetRangeStats(engine Engine, rangeID int64) (*MVCCStats, error) {
+func MVCCGetRangeStats(engine Engine, raftID int64) (*MVCCStats, error) {
 	ms := &MVCCStats{}
 	var err error
-	if ms.LiveBytes, err = GetRangeStat(engine, rangeID, StatLiveBytes); err != nil {
+	if ms.LiveBytes, err = GetRangeStat(engine, raftID, StatLiveBytes); err != nil {
 		return nil, err
 	}
-	if ms.KeyBytes, err = GetRangeStat(engine, rangeID, StatKeyBytes); err != nil {
+	if ms.KeyBytes, err = GetRangeStat(engine, raftID, StatKeyBytes); err != nil {
 		return nil, err
 	}
-	if ms.ValBytes, err = GetRangeStat(engine, rangeID, StatValBytes); err != nil {
+	if ms.ValBytes, err = GetRangeStat(engine, raftID, StatValBytes); err != nil {
 		return nil, err
 	}
-	if ms.IntentBytes, err = GetRangeStat(engine, rangeID, StatIntentBytes); err != nil {
+	if ms.IntentBytes, err = GetRangeStat(engine, raftID, StatIntentBytes); err != nil {
 		return nil, err
 	}
-	if ms.LiveCount, err = GetRangeStat(engine, rangeID, StatLiveCount); err != nil {
+	if ms.LiveCount, err = GetRangeStat(engine, raftID, StatLiveCount); err != nil {
 		return nil, err
 	}
-	if ms.KeyCount, err = GetRangeStat(engine, rangeID, StatKeyCount); err != nil {
+	if ms.KeyCount, err = GetRangeStat(engine, raftID, StatKeyCount); err != nil {
 		return nil, err
 	}
-	if ms.ValCount, err = GetRangeStat(engine, rangeID, StatValCount); err != nil {
+	if ms.ValCount, err = GetRangeStat(engine, raftID, StatValCount); err != nil {
 		return nil, err
 	}
-	if ms.IntentCount, err = GetRangeStat(engine, rangeID, StatIntentCount); err != nil {
+	if ms.IntentCount, err = GetRangeStat(engine, raftID, StatIntentCount); err != nil {
 		return nil, err
 	}
 	return ms, nil
@@ -1028,7 +1028,7 @@ func isValidEncodedSplitKey(key proto.EncodedKey) bool {
 //
 // The split key will never be chosen from the key ranges listed in
 // illegalSplitKeyRanges.
-func MVCCFindSplitKey(engine Engine, rangeID int64, key, endKey proto.Key, snapshotID string) (proto.Key, error) {
+func MVCCFindSplitKey(engine Engine, raftID int64, key, endKey proto.Key, snapshotID string) (proto.Key, error) {
 	if key.Less(KeyLocalMax) {
 		key = KeyLocalMax
 	}
@@ -1036,7 +1036,7 @@ func MVCCFindSplitKey(engine Engine, rangeID int64, key, endKey proto.Key, snaps
 	encEndKey := MVCCEncodeKey(endKey)
 
 	// Get range size from stats.
-	rangeSize, err := GetRangeSize(engine, rangeID)
+	rangeSize, err := GetRangeSize(engine, raftID)
 	if err != nil {
 		return nil, err
 	}

--- a/storage/engine/mvcc_test.go
+++ b/storage/engine/mvcc_test.go
@@ -1208,7 +1208,7 @@ func TestValidSplitKeys(t *testing.T) {
 }
 
 func TestFindSplitKey(t *testing.T) {
-	rangeID := int64(1)
+	raftID := int64(1)
 	engine := NewInMem(proto.Attributes{}, 1<<20)
 	ms := &MVCCStats{}
 	// Generate a series of KeyValues, each containing targetLength
@@ -1225,11 +1225,11 @@ func TestFindSplitKey(t *testing.T) {
 			t.Fatal(err)
 		}
 	}
-	ms.MergeStats(engine, rangeID, 0) // write stats
+	ms.MergeStats(engine, raftID, 0) // write stats
 	if err := engine.CreateSnapshot("snap1"); err != nil {
 		t.Fatal(err)
 	}
-	humanSplitKey, err := MVCCFindSplitKey(engine, rangeID, KeyMin, KeyMax, "snap1")
+	humanSplitKey, err := MVCCFindSplitKey(engine, raftID, KeyMin, KeyMax, "snap1")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -1245,7 +1245,7 @@ func TestFindSplitKey(t *testing.T) {
 // TestFindValidSplitKeys verifies split keys are located such that
 // they avoid splits through invalid key ranges.
 func TestFindValidSplitKeys(t *testing.T) {
-	rangeID := int64(1)
+	raftID := int64(1)
 	testCases := []struct {
 		keys     []proto.Key
 		expSplit proto.Key
@@ -1328,13 +1328,13 @@ func TestFindValidSplitKeys(t *testing.T) {
 				t.Fatal(err)
 			}
 		}
-		ms.MergeStats(engine, rangeID, 0) // write stats
+		ms.MergeStats(engine, raftID, 0) // write stats
 		if err := engine.CreateSnapshot("snap1"); err != nil {
 			t.Fatal(err)
 		}
 		rangeStart := test.keys[0]
 		rangeEnd := test.keys[len(test.keys)-1].Next()
-		splitKey, err := MVCCFindSplitKey(engine, rangeID, rangeStart, rangeEnd, "snap1")
+		splitKey, err := MVCCFindSplitKey(engine, raftID, rangeStart, rangeEnd, "snap1")
 		if test.expError {
 			if err == nil {
 				t.Errorf("%d: expected error", i)
@@ -1357,7 +1357,7 @@ func TestFindValidSplitKeys(t *testing.T) {
 // TestFindBalancedSplitKeys verifies split keys are located such that
 // the left and right halves are equally balanced.
 func TestFindBalancedSplitKeys(t *testing.T) {
-	rangeID := int64(1)
+	raftID := int64(1)
 	testCases := []struct {
 		keySizes []int
 		valSizes []int
@@ -1415,11 +1415,11 @@ func TestFindBalancedSplitKeys(t *testing.T) {
 				t.Fatal(err)
 			}
 		}
-		ms.MergeStats(engine, rangeID, 0) // write stats
+		ms.MergeStats(engine, raftID, 0) // write stats
 		if err := engine.CreateSnapshot("snap1"); err != nil {
 			t.Fatal(err)
 		}
-		splitKey, err := MVCCFindSplitKey(engine, rangeID, proto.Key("\x01"), proto.KeyMax, "snap1")
+		splitKey, err := MVCCFindSplitKey(engine, raftID, proto.Key("\x01"), proto.KeyMax, "snap1")
 		if err != nil {
 			t.Errorf("unexpected error: %s", err)
 			continue

--- a/storage/id_alloc.go
+++ b/storage/id_alloc.go
@@ -77,13 +77,7 @@ func (ia *IDAllocator) Allocate() int64 {
 // to occur before IDs run out to hide Increment latency.
 func (ia *IDAllocator) allocateBlock(incr int64) {
 	ir := &proto.IncrementResponse{}
-	if err := ia.db.Call(proto.Increment, &proto.IncrementRequest{
-		RequestHeader: proto.RequestHeader{
-			Key:  ia.idKey,
-			User: UserRoot,
-		},
-		Increment: incr,
-	}, ir); err != nil {
+	if err := ia.db.Call(proto.Increment, proto.IncrementArgs(ia.idKey, incr), ir); err != nil {
 		log.Fatalf("unable to allocate %d %q IDs: %v", ia.blockSize, ia.idKey, err)
 	}
 	if ir.NewValue <= ia.minID {

--- a/storage/range.go
+++ b/storage/range.go
@@ -139,7 +139,7 @@ type RangeManager interface {
 	// Range manipulation methods.
 	NewRangeDescriptor(start, end proto.Key, replicas []proto.Replica) (*proto.RangeDescriptor, error)
 	SplitRange(origRng, newRng *Range) error
-	AddRange(rng *Range)
+	AddRange(rng *Range) error
 	RemoveRange(rng *Range) error
 	CreateSnapshot() (string, error)
 	ProposeRaftCommand(proto.InternalRaftCommand)

--- a/storage/range_test.go
+++ b/storage/range_test.go
@@ -507,12 +507,13 @@ func internalSnapshotCopyArgs(key []byte, endKey []byte, maxResults int64, snaps
 // internalMergeArgs returns a InternalMergeRequest and InternalMergeResponse
 // pair addressed to the default replica for the specified key. The request will
 // contain the given proto.Value.
-func internalMergeArgs(key []byte, value proto.Value, rangeID int64) (
+func internalMergeArgs(key []byte, value proto.Value, raftID int64, storeID int32) (
 	*proto.InternalMergeRequest, *proto.InternalMergeResponse) {
 	args := &proto.InternalMergeRequest{
 		RequestHeader: proto.RequestHeader{
 			Key:     key,
-			Replica: proto.Replica{RangeID: rangeID},
+			RaftID:  raftID,
+			Replica: proto.Replica{StoreID: storeID},
 		},
 		Value: value,
 	}
@@ -1581,14 +1582,14 @@ func TestInternalMerge(t *testing.T) {
 	stringArgs := []string{"a", "b", "c", "d"}
 	stringExpected := "abcd"
 
-	for _, s := range stringArgs {
-		mergeArgs, resp := internalMergeArgs(key, proto.Value{Bytes: []byte(s)}, 1)
+	for _, str := range stringArgs {
+		mergeArgs, resp := internalMergeArgs(key, proto.Value{Bytes: []byte(str)}, 1, s.StoreID())
 		if err := r.AddCmd(proto.InternalMerge, mergeArgs, resp, true); err != nil {
 			t.Fatalf("unexpected error from InternalMerge: %s", err.Error())
 		}
 	}
 
-	getArgs, resp := getArgs(key, 1)
+	getArgs, resp := getArgs(key, 1, s.StoreID())
 	if err := r.AddCmd(proto.Get, getArgs, resp, true); err != nil {
 		t.Fatalf("unexpected error from Get: %s", err.Error())
 	}

--- a/storage/range_test.go
+++ b/storage/range_test.go
@@ -99,7 +99,9 @@ func createTestRange(t *testing.T) (*Store, *Range, *gossip.Gossip, engine.Engin
 	}
 	initConfigs(engine, t)
 	r := NewRange(&testRangeDescriptor, store)
-	store.AddRange(r)
+	if err := store.AddRange(r); err != nil {
+		t.Fatal(err)
+	}
 	return store, r, g, engine
 }
 
@@ -341,7 +343,9 @@ func createTestRangeWithClock(t *testing.T) (*Store, *Range, *hlc.ManualClock, *
 		t.Fatal(err)
 	}
 	rng := NewRange(&testRangeDescriptor, store)
-	store.AddRange(rng)
+	if err := store.AddRange(rng); err != nil {
+		t.Fatal(err)
+	}
 	return store, rng, &manual, clock, engine
 }
 

--- a/storage/range_test.go
+++ b/storage/range_test.go
@@ -46,13 +46,11 @@ var (
 			{
 				NodeID:  1,
 				StoreID: 1,
-				RangeID: 1,
 				Attrs:   proto.Attributes{Attrs: []string{"dc1", "mem"}},
 			},
 			{
 				NodeID:  2,
 				StoreID: 2,
-				RangeID: 2,
 				Attrs:   proto.Attributes{Attrs: []string{"dc2", "mem"}},
 			},
 		},
@@ -100,7 +98,7 @@ func createTestRange(t *testing.T) (*Store, *Range, *gossip.Gossip, engine.Engin
 		t.Fatal(err)
 	}
 	initConfigs(engine, t)
-	r := NewRange(1, &testRangeDescriptor, store)
+	r := NewRange(&testRangeDescriptor, store)
 	store.AddRange(r)
 	return store, r, g, engine
 }
@@ -121,7 +119,7 @@ func TestRangeContains(t *testing.T) {
 	}
 
 	clock := hlc.NewClock(hlc.UnixNano)
-	r := NewRange(0, desc, NewStore(clock, nil, nil, nil))
+	r := NewRange(desc, NewStore(clock, nil, nil, nil))
 	if !r.ContainsKey(proto.Key("aa")) {
 		t.Errorf("expected range to contain key \"aa\"")
 	}
@@ -342,18 +340,19 @@ func createTestRangeWithClock(t *testing.T) (*Store, *Range, *hlc.ManualClock, *
 	if err := store.Start(); err != nil {
 		t.Fatal(err)
 	}
-	rng := NewRange(1, &testRangeDescriptor, store)
+	rng := NewRange(&testRangeDescriptor, store)
 	store.AddRange(rng)
 	return store, rng, &manual, clock, engine
 }
 
 // getArgs returns a GetRequest and GetResponse pair addressed to
 // the default replica for the specified key.
-func getArgs(key []byte, rangeID int64) (*proto.GetRequest, *proto.GetResponse) {
+func getArgs(key []byte, raftID int64, storeID int32) (*proto.GetRequest, *proto.GetResponse) {
 	args := &proto.GetRequest{
 		RequestHeader: proto.RequestHeader{
 			Key:     key,
-			Replica: proto.Replica{RangeID: rangeID},
+			RaftID:  raftID,
+			Replica: proto.Replica{StoreID: storeID},
 		},
 	}
 	reply := &proto.GetResponse{}
@@ -362,12 +361,13 @@ func getArgs(key []byte, rangeID int64) (*proto.GetRequest, *proto.GetResponse) 
 
 // putArgs returns a PutRequest and PutResponse pair addressed to
 // the default replica for the specified key / value.
-func putArgs(key, value []byte, rangeID int64) (*proto.PutRequest, *proto.PutResponse) {
+func putArgs(key, value []byte, raftID int64, storeID int32) (*proto.PutRequest, *proto.PutResponse) {
 	args := &proto.PutRequest{
 		RequestHeader: proto.RequestHeader{
 			Key:       key,
 			Timestamp: proto.MinTimestamp,
-			Replica:   proto.Replica{RangeID: rangeID},
+			RaftID:    raftID,
+			Replica:   proto.Replica{StoreID: storeID},
 		},
 		Value: proto.Value{
 			Bytes: value,
@@ -378,11 +378,12 @@ func putArgs(key, value []byte, rangeID int64) (*proto.PutRequest, *proto.PutRes
 }
 
 // deleteArgs returns a DeleteRequest and DeleteResponse pair.
-func deleteArgs(key proto.Key, rangeID int64) (*proto.DeleteRequest, *proto.DeleteResponse) {
+func deleteArgs(key proto.Key, raftID int64, storeID int32) (*proto.DeleteRequest, *proto.DeleteResponse) {
 	args := &proto.DeleteRequest{
 		RequestHeader: proto.RequestHeader{
 			Key:     key,
-			Replica: proto.Replica{RangeID: rangeID},
+			RaftID:  raftID,
+			Replica: proto.Replica{StoreID: storeID},
 		},
 	}
 	reply := &proto.DeleteResponse{}
@@ -392,22 +393,23 @@ func deleteArgs(key proto.Key, rangeID int64) (*proto.DeleteRequest, *proto.Dele
 // readOrWriteArgs returns either get or put arguments depending on
 // value of "read". Get for true; Put for false. Returns method
 // selected and args & reply.
-func readOrWriteArgs(key proto.Key, read bool) (string, proto.Request, proto.Response) {
+func readOrWriteArgs(key proto.Key, read bool, raftID int64, storeID int32) (string, proto.Request, proto.Response) {
 	if read {
-		gArgs, gReply := getArgs(key, 1)
+		gArgs, gReply := getArgs(key, raftID, storeID)
 		return proto.Get, gArgs, gReply
 	}
-	pArgs, pReply := putArgs(key, []byte("value"), 1)
+	pArgs, pReply := putArgs(key, []byte("value"), raftID, storeID)
 	return proto.Put, pArgs, pReply
 }
 
 // incrementArgs returns an IncrementRequest and IncrementResponse pair
 // addressed to the default replica for the specified key / value.
-func incrementArgs(key []byte, inc int64, rangeID int64) (*proto.IncrementRequest, *proto.IncrementResponse) {
+func incrementArgs(key []byte, inc int64, raftID int64, storeID int32) (*proto.IncrementRequest, *proto.IncrementResponse) {
 	args := &proto.IncrementRequest{
 		RequestHeader: proto.RequestHeader{
 			Key:     key,
-			Replica: proto.Replica{RangeID: rangeID},
+			RaftID:  raftID,
+			Replica: proto.Replica{StoreID: storeID},
 		},
 		Increment: inc,
 	}
@@ -415,12 +417,13 @@ func incrementArgs(key []byte, inc int64, rangeID int64) (*proto.IncrementReques
 	return args, reply
 }
 
-func scanArgs(start, end []byte, rangeID int64) (*proto.ScanRequest, *proto.ScanResponse) {
+func scanArgs(start, end []byte, raftID int64, storeID int32) (*proto.ScanRequest, *proto.ScanResponse) {
 	args := &proto.ScanRequest{
 		RequestHeader: proto.RequestHeader{
 			Key:     start,
 			EndKey:  end,
-			Replica: proto.Replica{RangeID: rangeID},
+			RaftID:  raftID,
+			Replica: proto.Replica{StoreID: storeID},
 		},
 	}
 	reply := &proto.ScanResponse{}
@@ -429,12 +432,13 @@ func scanArgs(start, end []byte, rangeID int64) (*proto.ScanRequest, *proto.Scan
 
 // endTxnArgs returns request/response pair for EndTransaction RPC
 // addressed to the default replica for the specified key.
-func endTxnArgs(txn *proto.Transaction, commit bool, rangeID int64) (
+func endTxnArgs(txn *proto.Transaction, commit bool, raftID int64, storeID int32) (
 	*proto.EndTransactionRequest, *proto.EndTransactionResponse) {
 	args := &proto.EndTransactionRequest{
 		RequestHeader: proto.RequestHeader{
 			Key:     txn.ID,
-			Replica: proto.Replica{RangeID: rangeID},
+			RaftID:  raftID,
+			Replica: proto.Replica{StoreID: storeID},
 			Txn:     txn,
 		},
 		Commit: commit,
@@ -445,13 +449,14 @@ func endTxnArgs(txn *proto.Transaction, commit bool, rangeID int64) (
 
 // pushTxnArgs returns request/response pair for InternalPushTxn RPC
 // addressed to the default replica for the specified key.
-func pushTxnArgs(pusher, pushee *proto.Transaction, abort bool, rangeID int64) (
+func pushTxnArgs(pusher, pushee *proto.Transaction, abort bool, raftID int64, storeID int32) (
 	*proto.InternalPushTxnRequest, *proto.InternalPushTxnResponse) {
 	args := &proto.InternalPushTxnRequest{
 		RequestHeader: proto.RequestHeader{
 			Key:       pushee.ID,
 			Timestamp: pusher.Timestamp,
-			Replica:   proto.Replica{RangeID: rangeID},
+			RaftID:    raftID,
+			Replica:   proto.Replica{StoreID: storeID},
 			Txn:       pusher,
 		},
 		PusheeTxn: *pushee,
@@ -462,12 +467,13 @@ func pushTxnArgs(pusher, pushee *proto.Transaction, abort bool, rangeID int64) (
 }
 
 // heartbeatArgs returns request/response pair for InternalHeartbeatTxn RPC.
-func heartbeatArgs(txn *proto.Transaction, rangeID int64) (
+func heartbeatArgs(txn *proto.Transaction, raftID int64, storeID int32) (
 	*proto.InternalHeartbeatTxnRequest, *proto.InternalHeartbeatTxnResponse) {
 	args := &proto.InternalHeartbeatTxnRequest{
 		RequestHeader: proto.RequestHeader{
 			Key:     txn.ID,
-			Replica: proto.Replica{RangeID: rangeID},
+			RaftID:  raftID,
+			Replica: proto.Replica{StoreID: storeID},
 			Txn:     txn,
 		},
 	}
@@ -478,13 +484,14 @@ func heartbeatArgs(txn *proto.Transaction, rangeID int64) (
 // internalSnapshotCopyArgs returns a InternalSnapshotCopyRequest and
 // InternalSnapshotCopyResponse pair addressed to the default replica
 // for the specified key and endKey.
-func internalSnapshotCopyArgs(key []byte, endKey []byte, maxResults int64, snapshotID string, rangeID int64) (
+func internalSnapshotCopyArgs(key []byte, endKey []byte, maxResults int64, snapshotID string, raftID int64, storeID int32) (
 	*proto.InternalSnapshotCopyRequest, *proto.InternalSnapshotCopyResponse) {
 	args := &proto.InternalSnapshotCopyRequest{
 		RequestHeader: proto.RequestHeader{
 			Key:     key,
 			EndKey:  endKey,
-			Replica: proto.Replica{RangeID: rangeID},
+			RaftID:  raftID,
+			Replica: proto.Replica{StoreID: storeID},
 		},
 		SnapshotID: snapshotID,
 		MaxResults: maxResults,
@@ -546,7 +553,7 @@ func TestRangeUpdateTSCache(t *testing.T) {
 	// Set clock to time 1s and do the read.
 	t0 := 1 * time.Second
 	*mc = hlc.ManualClock(t0.Nanoseconds())
-	gArgs, gReply := getArgs([]byte("a"), 1)
+	gArgs, gReply := getArgs([]byte("a"), 1, s.StoreID())
 	gArgs.Timestamp = clock.Now()
 	err := rng.AddCmd(proto.Get, gArgs, gReply, true)
 	if err != nil {
@@ -555,7 +562,7 @@ func TestRangeUpdateTSCache(t *testing.T) {
 	// Set clock to time 2s for write.
 	t1 := 2 * time.Second
 	*mc = hlc.ManualClock(t1.Nanoseconds())
-	pArgs, pReply := putArgs([]byte("b"), []byte("1"), 1)
+	pArgs, pReply := putArgs([]byte("b"), []byte("1"), 1, s.StoreID())
 	pArgs.Timestamp = clock.Now()
 	err = rng.AddCmd(proto.Put, pArgs, pReply, true)
 	if err != nil {
@@ -605,7 +612,7 @@ func TestRangeCommandQueue(t *testing.T) {
 		be.block(key1)
 		cmd1Done := make(chan struct{})
 		go func() {
-			method, args, reply := readOrWriteArgs(key1, test.cmd1Read)
+			method, args, reply := readOrWriteArgs(key1, test.cmd1Read, rng.Desc.RaftID, s.StoreID())
 			err := rng.AddCmd(method, args, reply, true)
 			if err != nil {
 				t.Fatalf("test %d: %s", i, err)
@@ -616,7 +623,7 @@ func TestRangeCommandQueue(t *testing.T) {
 		// First, try a command for same key as cmd1 to verify it blocks.
 		cmd2Done := make(chan struct{})
 		go func() {
-			method, args, reply := readOrWriteArgs(key1, test.cmd2Read)
+			method, args, reply := readOrWriteArgs(key1, test.cmd2Read, rng.Desc.RaftID, s.StoreID())
 			err := rng.AddCmd(method, args, reply, true)
 			if err != nil {
 				t.Fatalf("test %d: %s", i, err)
@@ -627,7 +634,7 @@ func TestRangeCommandQueue(t *testing.T) {
 		// Next, try read for a non-impacted key--should go through immediately.
 		cmd3Done := make(chan struct{})
 		go func() {
-			method, args, reply := readOrWriteArgs(key2, true)
+			method, args, reply := readOrWriteArgs(key2, true, rng.Desc.RaftID, s.StoreID())
 			err := rng.AddCmd(method, args, reply, true)
 			if err != nil {
 				t.Fatalf("test %d: %s", i, err)
@@ -677,13 +684,13 @@ func TestRangeUseTSCache(t *testing.T) {
 	// Set clock to time 1s and do the read.
 	t0 := 1 * time.Second
 	*mc = hlc.ManualClock(t0.Nanoseconds())
-	args, reply := getArgs([]byte("a"), 1)
+	args, reply := getArgs([]byte("a"), 1, s.StoreID())
 	args.Timestamp = clock.Now()
 	err := rng.AddCmd(proto.Get, args, reply, true)
 	if err != nil {
 		t.Error(err)
 	}
-	pArgs, pReply := putArgs([]byte("a"), []byte("value"), 1)
+	pArgs, pReply := putArgs([]byte("a"), []byte("value"), 1, s.StoreID())
 	err = rng.AddCmd(proto.Put, pArgs, pReply, true)
 	if err != nil {
 		t.Fatal(err)
@@ -705,7 +712,7 @@ func TestRangeNoTSCacheUpdateOnFailure(t *testing.T) {
 		key := proto.Key(fmt.Sprintf("key-%d", i))
 
 		// Start by laying down an intent to trip up future read or write to same key.
-		pArgs, pReply := putArgs(key, []byte("value"), 1)
+		pArgs, pReply := putArgs(key, []byte("value"), 1, s.StoreID())
 		pArgs.Txn = newTransaction("test", key, 1, proto.SERIALIZABLE, clock)
 		pArgs.Timestamp = pArgs.Txn.Timestamp
 		if err := rng.AddCmd(proto.Put, pArgs, pReply, true); err != nil {
@@ -713,7 +720,7 @@ func TestRangeNoTSCacheUpdateOnFailure(t *testing.T) {
 		}
 
 		// Now attempt read or write.
-		method, args, reply := readOrWriteArgs(key, read)
+		method, args, reply := readOrWriteArgs(key, read, rng.Desc.RaftID, s.StoreID())
 		args.Header().Timestamp = clock.Now() // later timestamp
 		if err := rng.AddCmd(method, args, reply, true); err == nil {
 			t.Errorf("test %d: expected failure", i)
@@ -741,7 +748,7 @@ func TestRangeNoTimestampIncrementWithinTxn(t *testing.T) {
 	txn := newTransaction("test", key, 1, proto.SERIALIZABLE, clock)
 
 	// Start with a read to warm the timestamp cache.
-	gArgs, gReply := getArgs(key, 1)
+	gArgs, gReply := getArgs(key, 1, s.StoreID())
 	gArgs.Txn = txn
 	gArgs.Timestamp = txn.Timestamp
 	if err := rng.AddCmd(proto.Get, gArgs, gReply, true); err != nil {
@@ -749,7 +756,7 @@ func TestRangeNoTimestampIncrementWithinTxn(t *testing.T) {
 	}
 
 	// Now try a write and verify timestamp isn't incremented.
-	pArgs, pReply := putArgs(key, []byte("value"), 1)
+	pArgs, pReply := putArgs(key, []byte("value"), 1, s.StoreID())
 	pArgs.Txn = txn
 	pArgs.Timestamp = pArgs.Txn.Timestamp
 	if err := rng.AddCmd(proto.Put, pArgs, pReply, true); err != nil {
@@ -779,7 +786,7 @@ func TestRangeIdempotence(t *testing.T) {
 
 	// Run the same increment 100 times, 50 with identical command ID,
 	// interleaved with 50 using a sequence of different command IDs.
-	goldenArgs, _ := incrementArgs([]byte("a"), 1, 1)
+	goldenArgs, _ := incrementArgs([]byte("a"), 1, 1, s.StoreID())
 	incDones := make([]chan struct{}, 100)
 	var count int64
 	for i := range incDones {
@@ -834,15 +841,15 @@ func TestRangeSnapshot(t *testing.T) {
 	val2 := []byte("2")
 	val3 := []byte("3")
 
-	pArgs, pReply := putArgs(key1, val1, 1)
+	pArgs, pReply := putArgs(key1, val1, 1, s.StoreID())
 	pArgs.Timestamp = clock.Now()
 	err := rng.AddCmd(proto.Put, pArgs, pReply, true)
 
-	pArgs, pReply = putArgs(key2, val2, 1)
+	pArgs, pReply = putArgs(key2, val2, 1, s.StoreID())
 	pArgs.Timestamp = clock.Now()
 	err = rng.AddCmd(proto.Put, pArgs, pReply, true)
 
-	gArgs, gReply := getArgs(key1, 1)
+	gArgs, gReply := getArgs(key1, 1, s.StoreID())
 	gArgs.Timestamp = clock.Now()
 	err = rng.AddCmd(proto.Get, gArgs, gReply, true)
 
@@ -854,7 +861,7 @@ func TestRangeSnapshot(t *testing.T) {
 			gReply.Value.Bytes, val1)
 	}
 
-	iscArgs, iscReply := internalSnapshotCopyArgs(engine.MVCCEncodeKey(engine.KeyLocalPrefix.PrefixEnd()), engine.KeyMax, 50, "", 1)
+	iscArgs, iscReply := internalSnapshotCopyArgs(engine.MVCCEncodeKey(engine.KeyLocalPrefix.PrefixEnd()), engine.KeyMax, 50, "", 1, s.StoreID())
 	iscArgs.Timestamp = clock.Now()
 	err = rng.AddCmd(proto.InternalSnapshotCopy, iscArgs, iscReply, true)
 	if err != nil {
@@ -870,12 +877,12 @@ func TestRangeSnapshot(t *testing.T) {
 			iscReply.Rows[1].Value, iscReply.Rows[0].Key, expectedVal, expectedKey)
 	}
 
-	pArgs, pReply = putArgs(key2, val3, 1)
+	pArgs, pReply = putArgs(key2, val3, 1, s.StoreID())
 	pArgs.Timestamp = clock.Now()
 	err = rng.AddCmd(proto.Put, pArgs, pReply, true)
 
 	// Scan with the previous snapshot will get the old value val2 of key2.
-	iscArgs, iscReply = internalSnapshotCopyArgs(engine.MVCCEncodeKey(engine.KeyLocalPrefix.PrefixEnd()), engine.KeyMax, 50, snapshotID, 1)
+	iscArgs, iscReply = internalSnapshotCopyArgs(engine.MVCCEncodeKey(engine.KeyLocalPrefix.PrefixEnd()), engine.KeyMax, 50, snapshotID, 1, s.StoreID())
 	iscArgs.Timestamp = clock.Now()
 	err = rng.AddCmd(proto.InternalSnapshotCopy, iscArgs, iscReply, true)
 	if err != nil {
@@ -892,7 +899,7 @@ func TestRangeSnapshot(t *testing.T) {
 	snapshotLastKey := proto.Key(iscReply.Rows[3].Key)
 
 	// Create a new snapshot to cover the latest value.
-	iscArgs, iscReply = internalSnapshotCopyArgs(engine.MVCCEncodeKey(engine.KeyLocalPrefix.PrefixEnd()), engine.KeyMax, 50, "", 1)
+	iscArgs, iscReply = internalSnapshotCopyArgs(engine.MVCCEncodeKey(engine.KeyLocalPrefix.PrefixEnd()), engine.KeyMax, 50, "", 1, s.StoreID())
 	iscArgs.Timestamp = clock.Now()
 	err = rng.AddCmd(proto.InternalSnapshotCopy, iscArgs, iscReply, true)
 	if err != nil {
@@ -910,7 +917,7 @@ func TestRangeSnapshot(t *testing.T) {
 	}
 	snapshot2LastKey := proto.Key(iscReply.Rows[4].Key)
 
-	iscArgs, iscReply = internalSnapshotCopyArgs(snapshotLastKey.PrefixEnd(), engine.KeyMax, 50, snapshotID, 1)
+	iscArgs, iscReply = internalSnapshotCopyArgs(snapshotLastKey.PrefixEnd(), engine.KeyMax, 50, snapshotID, 1, s.StoreID())
 	iscArgs.Timestamp = clock.Now()
 	err = rng.AddCmd(proto.InternalSnapshotCopy, iscArgs, iscReply, true)
 	if err != nil {
@@ -919,7 +926,7 @@ func TestRangeSnapshot(t *testing.T) {
 	if len(iscReply.Rows) != 0 {
 		t.Fatalf("error : %d", len(iscReply.Rows))
 	}
-	iscArgs, iscReply = internalSnapshotCopyArgs(snapshot2LastKey.PrefixEnd(), engine.KeyMax, 50, snapshotID2, 1)
+	iscArgs, iscReply = internalSnapshotCopyArgs(snapshot2LastKey.PrefixEnd(), engine.KeyMax, 50, snapshotID2, 1, s.StoreID())
 	iscArgs.Timestamp = clock.Now()
 	err = rng.AddCmd(proto.InternalSnapshotCopy, iscArgs, iscReply, true)
 	if err != nil {
@@ -939,7 +946,7 @@ func TestEndTransactionBeforeHeartbeat(t *testing.T) {
 	key := []byte("a")
 	for _, commit := range []bool{true, false} {
 		txn := newTransaction("test", key, 1, proto.SERIALIZABLE, clock)
-		args, reply := endTxnArgs(txn, commit, 1)
+		args, reply := endTxnArgs(txn, commit, 1, s.StoreID())
 		args.Timestamp = txn.Timestamp
 		if err := rng.AddCmd(proto.EndTransaction, args, reply, true); err != nil {
 			t.Error(err)
@@ -954,7 +961,7 @@ func TestEndTransactionBeforeHeartbeat(t *testing.T) {
 
 		// Try a heartbeat to the already-committed transaction; should get
 		// committed txn back, but without last heartbeat timestamp set.
-		hbArgs, hbReply := heartbeatArgs(txn, 1)
+		hbArgs, hbReply := heartbeatArgs(txn, 1, s.StoreID())
 		if err := rng.AddCmd(proto.InternalHeartbeatTxn, hbArgs, hbReply, true); err != nil {
 			t.Error(err)
 		}
@@ -975,7 +982,7 @@ func TestEndTransactionAfterHeartbeat(t *testing.T) {
 		txn := newTransaction("test", key, 1, proto.SERIALIZABLE, clock)
 
 		// Start out with a heartbeat to the transaction.
-		hbArgs, hbReply := heartbeatArgs(txn, 1)
+		hbArgs, hbReply := heartbeatArgs(txn, 1, s.StoreID())
 		hbArgs.Timestamp = txn.Timestamp
 		if err := rng.AddCmd(proto.InternalHeartbeatTxn, hbArgs, hbReply, true); err != nil {
 			t.Error(err)
@@ -984,7 +991,7 @@ func TestEndTransactionAfterHeartbeat(t *testing.T) {
 			t.Errorf("unexpected heartbeat reply contents: %+v", hbReply)
 		}
 
-		args, reply := endTxnArgs(txn, commit, 1)
+		args, reply := endTxnArgs(txn, commit, 1, s.StoreID())
 		args.Timestamp = txn.Timestamp
 		if err := rng.AddCmd(proto.EndTransaction, args, reply, true); err != nil {
 			t.Error(err)
@@ -1025,7 +1032,7 @@ func TestEndTransactionWithPushedTimestamp(t *testing.T) {
 	for _, test := range testCases {
 		txn := newTransaction("test", key, 1, test.isolation, clock)
 		// End the transaction with args timestamp moved forward in time.
-		args, reply := endTxnArgs(txn, test.commit, 1)
+		args, reply := endTxnArgs(txn, test.commit, 1, s.StoreID())
 		*mc = hlc.ManualClock(1)
 		args.Timestamp = clock.Now()
 		err := rng.AddCmd(proto.EndTransaction, args, reply, true)
@@ -1061,14 +1068,14 @@ func TestEndTransactionWithIncrementedEpoch(t *testing.T) {
 	txn := newTransaction("test", key, 1, proto.SERIALIZABLE, clock)
 
 	// Start out with a heartbeat to the transaction.
-	hbArgs, hbReply := heartbeatArgs(txn, 1)
+	hbArgs, hbReply := heartbeatArgs(txn, 1, s.StoreID())
 	hbArgs.Timestamp = txn.Timestamp
 	if err := rng.AddCmd(proto.InternalHeartbeatTxn, hbArgs, hbReply, true); err != nil {
 		t.Error(err)
 	}
 
 	// Now end the txn with increased epoch and priority.
-	args, reply := endTxnArgs(txn, true, 1)
+	args, reply := endTxnArgs(txn, true, 1, s.StoreID())
 	args.Timestamp = txn.Timestamp
 	args.Txn.Epoch = txn.Epoch + 1
 	args.Txn.Priority = txn.Priority + 1
@@ -1124,7 +1131,7 @@ func TestEndTransactionWithErrors(t *testing.T) {
 
 		// End the transaction, verify expected error.
 		txn.ID = test.key
-		args, reply := endTxnArgs(txn, true, 1)
+		args, reply := endTxnArgs(txn, true, 1, s.StoreID())
 		args.Timestamp = txn.Timestamp
 		verifyErrorMatches(rng.AddCmd(proto.EndTransaction, args, reply, true), test.expErrRegexp, t)
 	}
@@ -1138,7 +1145,7 @@ func TestInternalPushTxnBadKey(t *testing.T) {
 	pusher := newTransaction("test", proto.Key("a"), 1, proto.SERIALIZABLE, clock)
 	pushee := newTransaction("test", proto.Key("b"), 1, proto.SERIALIZABLE, clock)
 
-	args, reply := pushTxnArgs(pusher, pushee, true, 1)
+	args, reply := pushTxnArgs(pusher, pushee, true, 1, s.StoreID())
 	args.Key = pusher.ID
 	verifyErrorMatches(rng.AddCmd(proto.InternalPushTxn, args, reply, true), ".*should match pushee.*", t)
 }
@@ -1157,14 +1164,14 @@ func TestInternalPushTxnAlreadyCommittedOrAborted(t *testing.T) {
 		pushee.Priority = 2 // pusher will lose, meaning we shouldn't push unless pushee is already ended.
 
 		// End the pushee's transaction.
-		etArgs, etReply := endTxnArgs(pushee, status == proto.COMMITTED, 1)
+		etArgs, etReply := endTxnArgs(pushee, status == proto.COMMITTED, 1, s.StoreID())
 		etArgs.Timestamp = pushee.Timestamp
 		if err := rng.AddCmd(proto.EndTransaction, etArgs, etReply, true); err != nil {
 			t.Fatal(err)
 		}
 
 		// Now try to push what's already committed or aborted.
-		args, reply := pushTxnArgs(pusher, pushee, true, 1)
+		args, reply := pushTxnArgs(pusher, pushee, true, 1, s.StoreID())
 		if err := rng.AddCmd(proto.InternalPushTxn, args, reply, true); err != nil {
 			t.Fatal(err)
 		}
@@ -1212,7 +1219,7 @@ func TestInternalPushTxnUpgradeExistingTxn(t *testing.T) {
 		// First, establish "start" of existing pushee's txn via heartbeat.
 		pushee.Epoch = test.startEpoch
 		pushee.Timestamp = test.startTS
-		hbArgs, hbReply := heartbeatArgs(pushee, 1)
+		hbArgs, hbReply := heartbeatArgs(pushee, 1, s.StoreID())
 		hbArgs.Timestamp = pushee.Timestamp
 		if err := rng.AddCmd(proto.InternalHeartbeatTxn, hbArgs, hbReply, true); err != nil {
 			t.Fatal(err)
@@ -1221,7 +1228,7 @@ func TestInternalPushTxnUpgradeExistingTxn(t *testing.T) {
 		// Now, attempt to push the transaction using updated values for epoch & timestamp.
 		pushee.Epoch = test.epoch
 		pushee.Timestamp = test.ts
-		args, reply := pushTxnArgs(pusher, pushee, true, 1)
+		args, reply := pushTxnArgs(pusher, pushee, true, 1, s.StoreID())
 		if err := rng.AddCmd(proto.InternalPushTxn, args, reply, true); err != nil {
 			t.Fatal(err)
 		}
@@ -1268,7 +1275,7 @@ func TestInternalPushTxnHeartbeatTimeout(t *testing.T) {
 
 		// First, establish "start" of existing pushee's txn via heartbeat.
 		if test.heartbeat != nil {
-			hbArgs, hbReply := heartbeatArgs(pushee, 1)
+			hbArgs, hbReply := heartbeatArgs(pushee, 1, s.StoreID())
 			hbArgs.Timestamp = *test.heartbeat
 			if err := rng.AddCmd(proto.InternalHeartbeatTxn, hbArgs, hbReply, true); err != nil {
 				t.Fatal(err)
@@ -1277,7 +1284,7 @@ func TestInternalPushTxnHeartbeatTimeout(t *testing.T) {
 
 		// Now, attempt to push the transaction with clock set to "currentTime".
 		*mc = hlc.ManualClock(test.currentTime)
-		args, reply := pushTxnArgs(pusher, pushee, true, 1)
+		args, reply := pushTxnArgs(pusher, pushee, true, 1, s.StoreID())
 		err := rng.AddCmd(proto.InternalPushTxn, args, reply, true)
 		if test.expSuccess != (err == nil) {
 			t.Errorf("expected success on trial %d? %t; got err %s", i, test.expSuccess, err)
@@ -1317,7 +1324,7 @@ func TestInternalPushTxnOldEpoch(t *testing.T) {
 
 		// First, establish "start" of existing pushee's txn via heartbeat.
 		pushee.Epoch = test.curEpoch
-		hbArgs, hbReply := heartbeatArgs(pushee, 1)
+		hbArgs, hbReply := heartbeatArgs(pushee, 1, s.StoreID())
 		hbArgs.Timestamp = pushee.Timestamp
 		if err := rng.AddCmd(proto.InternalHeartbeatTxn, hbArgs, hbReply, true); err != nil {
 			t.Fatal(err)
@@ -1325,7 +1332,7 @@ func TestInternalPushTxnOldEpoch(t *testing.T) {
 
 		// Now, attempt to push the transaction with intent epoch set appropriately.
 		pushee.Epoch = test.intentEpoch
-		args, reply := pushTxnArgs(pusher, pushee, true, 1)
+		args, reply := pushTxnArgs(pusher, pushee, true, 1, s.StoreID())
 		err := rng.AddCmd(proto.InternalPushTxn, args, reply, true)
 		if test.expSuccess != (err == nil) {
 			t.Errorf("expected success on trial %d? %t; got err %s", i, test.expSuccess, err)
@@ -1383,7 +1390,7 @@ func TestInternalPushTxnPriorities(t *testing.T) {
 		pushee.Timestamp = test.pusheeTS
 
 		// Now, attempt to push the transaction with intent epoch set appropriately.
-		args, reply := pushTxnArgs(pusher, pushee, test.abort, 1)
+		args, reply := pushTxnArgs(pusher, pushee, test.abort, 1, s.StoreID())
 		err := rng.AddCmd(proto.InternalPushTxn, args, reply, true)
 		if test.expSuccess != (err == nil) {
 			t.Errorf("expected success on trial %d? %t; got err %s", i, test.expSuccess, err)
@@ -1412,7 +1419,7 @@ func TestInternalPushTxnPushTimestamp(t *testing.T) {
 	pushee.Timestamp = proto.Timestamp{WallTime: 5, Logical: 1}
 
 	// Now, push the transaction with args.Abort=false.
-	args, reply := pushTxnArgs(pusher, pushee, false /* abort */, 1)
+	args, reply := pushTxnArgs(pusher, pushee, false /* abort */, 1, s.StoreID())
 	if err := rng.AddCmd(proto.InternalPushTxn, args, reply, true); err != nil {
 		t.Errorf("unexpected error on push: %s", err)
 	}
@@ -1442,7 +1449,7 @@ func TestInternalPushTxnPushTimestampAlreadyPushed(t *testing.T) {
 	pushee.Timestamp = proto.Timestamp{WallTime: 50, Logical: 1}
 
 	// Now, push the transaction with args.Abort=false.
-	args, reply := pushTxnArgs(pusher, pushee, false /* abort */, 1)
+	args, reply := pushTxnArgs(pusher, pushee, false /* abort */, 1, s.StoreID())
 	if err := rng.AddCmd(proto.InternalPushTxn, args, reply, true); err != nil {
 		t.Errorf("unexpected error on push: %s", err)
 	}
@@ -1454,8 +1461,8 @@ func TestInternalPushTxnPushTimestampAlreadyPushed(t *testing.T) {
 	}
 }
 
-func verifyRangeStats(eng engine.Engine, rangeID int64, expMS engine.MVCCStats, t *testing.T) {
-	ms, err := engine.MVCCGetRangeStats(eng, rangeID)
+func verifyRangeStats(eng engine.Engine, raftID int64, expMS engine.MVCCStats, t *testing.T) {
+	ms, err := engine.MVCCGetRangeStats(eng, raftID)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -1463,7 +1470,7 @@ func verifyRangeStats(eng engine.Engine, rangeID int64, expMS engine.MVCCStats, 
 		t.Errorf("expected stats %+v; got %+v", expMS, ms)
 	}
 	// Also verify the GetRangeSize method.
-	rangeSize, err := engine.GetRangeSize(eng, rangeID)
+	rangeSize, err := engine.GetRangeSize(eng, raftID)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -1481,30 +1488,31 @@ func TestRangeStats(t *testing.T) {
 	s, rng, _, clock, eng := createTestRangeWithClock(t)
 	defer s.Stop()
 	// Put a value.
-	pArgs, pReply := putArgs([]byte("a"), []byte("value1"), 1)
+	pArgs, pReply := putArgs([]byte("a"), []byte("value1"), 1, s.StoreID())
 	pArgs.Timestamp = clock.Now()
 	if err := rng.AddCmd(proto.Put, pArgs, pReply, true); err != nil {
 		t.Fatal(err)
 	}
 	expMS := engine.MVCCStats{LiveBytes: 44, KeyBytes: 20, ValBytes: 24, IntentBytes: 0, LiveCount: 1, KeyCount: 1, ValCount: 1, IntentCount: 0}
-	verifyRangeStats(eng, rng.RangeID, expMS, t)
+	verifyRangeStats(eng, rng.Desc.RaftID, expMS, t)
 
 	// Put a 2nd value transactionally.
-	pArgs, pReply = putArgs([]byte("b"), []byte("value2"), 1)
+	pArgs, pReply = putArgs([]byte("b"), []byte("value2"), 1, s.StoreID())
 	pArgs.Timestamp = clock.Now()
 	pArgs.Txn = &proto.Transaction{ID: []byte("txn1"), Timestamp: pArgs.Timestamp}
 	if err := rng.AddCmd(proto.Put, pArgs, pReply, true); err != nil {
 		t.Fatal(err)
 	}
 	expMS = engine.MVCCStats{LiveBytes: 124, KeyBytes: 40, ValBytes: 84, IntentBytes: 28, LiveCount: 2, KeyCount: 2, ValCount: 2, IntentCount: 1}
-	verifyRangeStats(eng, rng.RangeID, expMS, t)
+	verifyRangeStats(eng, rng.Desc.RaftID, expMS, t)
 
 	// Resolve the 2nd value.
 	rArgs := &proto.InternalResolveIntentRequest{
 		RequestHeader: proto.RequestHeader{
 			Timestamp: pArgs.Txn.Timestamp,
 			Key:       pArgs.Key,
-			Replica:   proto.Replica{RangeID: 0},
+			RaftID:    rng.Desc.RaftID,
+			Replica:   proto.Replica{StoreID: s.StoreID()},
 			Txn:       pArgs.Txn,
 		},
 	}
@@ -1514,16 +1522,16 @@ func TestRangeStats(t *testing.T) {
 		t.Fatal(err)
 	}
 	expMS = engine.MVCCStats{LiveBytes: 88, KeyBytes: 40, ValBytes: 48, IntentBytes: 0, LiveCount: 2, KeyCount: 2, ValCount: 2, IntentCount: 0}
-	verifyRangeStats(eng, rng.RangeID, expMS, t)
+	verifyRangeStats(eng, rng.Desc.RaftID, expMS, t)
 
 	// Delete the 1st value.
-	dArgs, dReply := deleteArgs([]byte("a"), 1)
+	dArgs, dReply := deleteArgs([]byte("a"), 1, s.StoreID())
 	dArgs.Timestamp = clock.Now()
 	if err := rng.AddCmd(proto.Delete, dArgs, dReply, true); err != nil {
 		t.Fatal(err)
 	}
 	expMS = engine.MVCCStats{LiveBytes: 44, KeyBytes: 56, ValBytes: 50, IntentBytes: 0, LiveCount: 1, KeyCount: 2, ValCount: 3, IntentCount: 0}
-	verifyRangeStats(eng, rng.RangeID, expMS, t)
+	verifyRangeStats(eng, rng.Desc.RaftID, expMS, t)
 }
 
 // TestRemoteRaftCommand ensures that commands entering the raft
@@ -1533,7 +1541,7 @@ func TestRemoteRaftCommand(t *testing.T) {
 	defer s.Stop()
 
 	// Send an increment direct to raft.
-	remoteIncArgs, _ := incrementArgs([]byte("a"), 2, 1)
+	remoteIncArgs, _ := incrementArgs([]byte("a"), 2, 1, s.StoreID())
 	remoteIncArgs.Timestamp = proto.MinTimestamp
 	raftCmd := proto.InternalRaftCommand{
 		CmdID:  proto.ClientCmdID{WallTime: 1, Random: 1},
@@ -1545,7 +1553,7 @@ func TestRemoteRaftCommand(t *testing.T) {
 	// Send an increment through the normal flow, since this is our
 	// simplest way of waiting until this command (and all earlier ones)
 	// have been applied.
-	localIncArgs, localIncReply := incrementArgs([]byte("a"), 3, 1)
+	localIncArgs, localIncReply := incrementArgs([]byte("a"), 3, 1, s.StoreID())
 	err := r.AddCmd(proto.Increment, localIncArgs, localIncReply, true)
 	if err != nil {
 		t.Fatal(err)

--- a/storage/response_cache_test.go
+++ b/storage/response_cache_test.go
@@ -31,9 +31,9 @@ var incR = proto.IncrementResponse{
 }
 
 // createTestResponseCache creates an in-memory engine and
-// returns a response cache using the engine for range ID 1.
-func createTestResponseCache(t *testing.T, rangeID int64) *ResponseCache {
-	return NewResponseCache(rangeID, engine.NewInMem(proto.Attributes{}, 1<<20))
+// returns a response cache using the supplied Raft ID.
+func createTestResponseCache(t *testing.T, raftID int64) *ResponseCache {
+	return NewResponseCache(raftID, engine.NewInMem(proto.Attributes{}, 1<<20))
 }
 
 func makeCmdID(wallTime, random int64) proto.ClientCmdID {
@@ -95,7 +95,7 @@ func TestResponseCacheEmptyCmdID(t *testing.T) {
 // transferred correctly to another cache using CopyInto().
 func TestResposeCacheCopyInto(t *testing.T) {
 	rc1, rc2 := createTestResponseCache(t, 1), createTestResponseCache(t, 2)
-	rc2.rangeID = 2
+	rc2.raftID = 2
 	cmdID := makeCmdID(1, 1)
 	// Store an increment with new value one in the first cache.
 	val := proto.IncrementResponse{}
@@ -103,7 +103,7 @@ func TestResposeCacheCopyInto(t *testing.T) {
 		t.Errorf("unexpected error putting response: %v", err)
 	}
 	// Copy the first cache into the second.
-	if err := rc1.CopyInto(rc2.engine, rc2.rangeID); err != nil {
+	if err := rc1.CopyInto(rc2.engine, rc2.raftID); err != nil {
 		t.Errorf("unexpected error while copying response cache: %v", err)
 	}
 	// Get should return 1 for both caches.

--- a/storage/store_test.go
+++ b/storage/store_test.go
@@ -74,6 +74,7 @@ func (db *testSender) Send(call *client.Call) {
 	// Lookup range and direct request.
 	header := call.Args.Header()
 	if rng := db.store.LookupRange(header.Key, header.EndKey); rng != nil {
+		header.RaftID = rng.Desc.RaftID
 		header.Replica = *rng.GetReplica()
 		db.store.ExecuteCmd(call.Method, call.Args, call.Reply)
 	} else {
@@ -198,13 +199,13 @@ func TestRangeSliceSort(t *testing.T) {
 func TestStoreExecuteCmd(t *testing.T) {
 	store, _ := createTestStore(t)
 	defer store.Stop()
-	gArgs, gReply := getArgs([]byte("a"), 1)
+	gArgs, gReply := getArgs([]byte("a"), 1, store.StoreID())
 
 	// Try a successful get request.
 	if err := store.ExecuteCmd(proto.Get, gArgs, gReply); err != nil {
 		t.Fatal(err)
 	}
-	pArgs, pReply := putArgs([]byte("a"), []byte("aaa"), 1)
+	pArgs, pReply := putArgs([]byte("a"), []byte("aaa"), 1, store.StoreID())
 	if err := store.ExecuteCmd(proto.Put, pArgs, pReply); err != nil {
 		t.Fatal(err)
 	}
@@ -218,7 +219,7 @@ func TestStoreVerifyKeys(t *testing.T) {
 	tooLongKey := engine.MakeKey(engine.KeyMax, []byte{0})
 
 	// Start with a too-long key on a get.
-	gArgs, gReply := getArgs(tooLongKey, 1)
+	gArgs, gReply := getArgs(tooLongKey, 1, store.StoreID())
 	if err := store.ExecuteCmd(proto.Get, gArgs, gReply); err == nil {
 		t.Fatal("expected error for key too long")
 	}
@@ -228,7 +229,7 @@ func TestStoreVerifyKeys(t *testing.T) {
 		t.Fatal("expected error for start key == KeyMax")
 	}
 	// Try a scan with too-long EndKey.
-	sArgs, sReply := scanArgs(engine.KeyMin, tooLongKey, 1)
+	sArgs, sReply := scanArgs(engine.KeyMin, tooLongKey, 1, store.StoreID())
 	if err := store.ExecuteCmd(proto.Scan, sArgs, sReply); err == nil {
 		t.Fatal("expected error for end key too long")
 	}
@@ -240,13 +241,13 @@ func TestStoreVerifyKeys(t *testing.T) {
 	}
 	// Try a put to meta2 key which would otherwise exceed maximum key
 	// length, but is accepted because of the meta prefix.
-	pArgs, pReply := putArgs(engine.MakeKey(engine.KeyMeta2Prefix, engine.KeyMax), []byte("value"), 1)
+	pArgs, pReply := putArgs(engine.MakeKey(engine.KeyMeta2Prefix, engine.KeyMax), []byte("value"), 1, store.StoreID())
 	if err := store.ExecuteCmd(proto.Put, pArgs, pReply); err != nil {
 		t.Fatalf("unexpected error on put to meta2 value: %s", err)
 	}
 	// Try a put to txn record for a meta2 key.
 	pArgs, pReply = putArgs(engine.MakeKey(engine.KeyLocalTransactionPrefix,
-		engine.KeyMeta2Prefix, engine.KeyMax), []byte("value"), 1)
+		engine.KeyMeta2Prefix, engine.KeyMax), []byte("value"), 1, store.StoreID())
 	if err := store.ExecuteCmd(proto.Put, pArgs, pReply); err != nil {
 		t.Fatalf("unexpected error on put to meta2 value: %s", err)
 	}
@@ -256,7 +257,7 @@ func TestStoreVerifyKeys(t *testing.T) {
 func TestStoreExecuteCmdUpdateTime(t *testing.T) {
 	store, _ := createTestStore(t)
 	defer store.Stop()
-	args, reply := getArgs([]byte("a"), 1)
+	args, reply := getArgs([]byte("a"), 1, store.StoreID())
 	args.Timestamp = store.clock.Now()
 	args.Timestamp.WallTime += (100 * time.Millisecond).Nanoseconds()
 	err := store.ExecuteCmd(proto.Get, args, reply)
@@ -274,7 +275,7 @@ func TestStoreExecuteCmdUpdateTime(t *testing.T) {
 func TestStoreExecuteCmdWithZeroTime(t *testing.T) {
 	store, mc := createTestStore(t)
 	defer store.Stop()
-	args, reply := getArgs([]byte("a"), 1)
+	args, reply := getArgs([]byte("a"), 1, store.StoreID())
 
 	// Set clock to time 1.
 	*mc = hlc.ManualClock(1)
@@ -296,7 +297,7 @@ func TestStoreExecuteCmdWithZeroTime(t *testing.T) {
 func TestStoreExecuteCmdWithClockOffset(t *testing.T) {
 	store, mc := createTestStore(t)
 	defer store.Stop()
-	args, reply := getArgs([]byte("a"), 1)
+	args, reply := getArgs([]byte("a"), 1, store.StoreID())
 
 	// Set clock to time 1.
 	*mc = hlc.ManualClock(1)
@@ -316,7 +317,7 @@ func TestStoreExecuteCmdWithClockOffset(t *testing.T) {
 func TestStoreExecuteCmdBadRange(t *testing.T) {
 	store, _ := createTestStore(t)
 	defer store.Stop()
-	args, reply := getArgs([]byte("0"), 2) // no range ID 2
+	args, reply := getArgs([]byte("0"), 2, store.StoreID()) // no range ID 2
 	err := store.ExecuteCmd(proto.Get, args, reply)
 	if err == nil {
 		t.Error("expected invalid range")
@@ -332,7 +333,7 @@ func splitTestRange(store *Store, key, splitKey proto.Key, t *testing.T) *Range 
 	if err != nil {
 		t.Fatal(err)
 	}
-	newRng := NewRange(desc.FindReplica(store.StoreID()).RangeID, desc, store)
+	newRng := NewRange(desc, store)
 	if err := store.SplitRange(rng, newRng); err != nil {
 		t.Fatal(err)
 	}
@@ -351,7 +352,7 @@ func TestStoreExecuteCmdOutOfRange(t *testing.T) {
 	}
 	// Range is from KeyMin to "a", so reading "a" should fail because
 	// it's just outside the range boundary.
-	args, reply := getArgs([]byte("a"), 1)
+	args, reply := getArgs([]byte("a"), 1, store.StoreID())
 	err := store.ExecuteCmd(proto.Get, args, reply)
 	if err == nil {
 		t.Error("expected key to be out of range")
@@ -440,7 +441,7 @@ func TestStoreResolveWriteIntent(t *testing.T) {
 		}
 
 		// First lay down intent using the pushee's txn.
-		pArgs, pReply := putArgs(key, []byte("value"), 1)
+		pArgs, pReply := putArgs(key, []byte("value"), 1, store.StoreID())
 		pArgs.Timestamp = store.clock.Now()
 		pArgs.Txn = pushee
 		if err := store.ExecuteCmd(proto.Put, pArgs, pReply); err != nil {
@@ -493,7 +494,7 @@ func TestStoreResolveWriteIntentRollback(t *testing.T) {
 	pusher.Priority = 2 // Pusher will win.
 
 	// First lay down intent using the pushee's txn.
-	args, reply := incrementArgs(key, 1, 1)
+	args, reply := incrementArgs(key, 1, 1, store.StoreID())
 	args.Timestamp = store.clock.Now()
 	args.Txn = pushee
 	if err := store.ExecuteCmd(proto.Increment, args, reply); err != nil {
@@ -546,7 +547,7 @@ func TestStoreResolveWriteIntentPushOnRead(t *testing.T) {
 		}
 
 		// First, write original value.
-		args, reply := putArgs(key, []byte("value1"), 1)
+		args, reply := putArgs(key, []byte("value1"), 1, store.StoreID())
 		args.Timestamp = store.clock.Now()
 		if err := store.ExecuteCmd(proto.Put, args, reply); err != nil {
 			t.Fatal(err)
@@ -561,7 +562,7 @@ func TestStoreResolveWriteIntentPushOnRead(t *testing.T) {
 		}
 
 		// Now, try to read value using the pusher's txn.
-		gArgs, gReply := getArgs(key, 1)
+		gArgs, gReply := getArgs(key, 1, store.StoreID())
 		gArgs.Timestamp = store.clock.Now()
 		gArgs.Txn = pusher
 		err := store.ExecuteCmd(proto.Get, gArgs, gReply)
@@ -576,7 +577,7 @@ func TestStoreResolveWriteIntentPushOnRead(t *testing.T) {
 			// SNAPSHOT isolation, the commit should work: verify the txn
 			// commit timestamp is equal to gArgs.Timestamp + 1. Otherwise,
 			// verify commit fails with TransactionRetryError.
-			etArgs, etReply := endTxnArgs(pushee, true, 1)
+			etArgs, etReply := endTxnArgs(pushee, true, 1, store.StoreID())
 			etArgs.Timestamp = pushee.Timestamp
 			err := store.ExecuteCmd(proto.EndTransaction, etArgs, etReply)
 
@@ -630,7 +631,7 @@ func TestStoreResolveWriteIntentSnapshotIsolation(t *testing.T) {
 	pusher.Priority = 1 // Pusher would lose based on priority.
 
 	// First, write original value.
-	args, reply := putArgs(key, []byte("value1"), 1)
+	args, reply := putArgs(key, []byte("value1"), 1, store.StoreID())
 	args.Timestamp = store.clock.Now()
 	if err := store.ExecuteCmd(proto.Put, args, reply); err != nil {
 		t.Fatal(err)
@@ -645,7 +646,7 @@ func TestStoreResolveWriteIntentSnapshotIsolation(t *testing.T) {
 	}
 
 	// Now, try to read value using the pusher's txn.
-	gArgs, gReply := getArgs(key, 1)
+	gArgs, gReply := getArgs(key, 1, store.StoreID())
 	gArgs.Timestamp = store.clock.Now()
 	gArgs.Txn = pusher
 	if err := store.ExecuteCmd(proto.Get, gArgs, gReply); err != nil {
@@ -657,7 +658,7 @@ func TestStoreResolveWriteIntentSnapshotIsolation(t *testing.T) {
 	// Finally, try to end the pushee's transaction; since it's got
 	// SNAPSHOT isolation, the end should work, but verify the txn
 	// commit timestamp is equal to gArgs.Timestamp + 1.
-	etArgs, etReply := endTxnArgs(pushee, true, 1)
+	etArgs, etReply := endTxnArgs(pushee, true, 1, store.StoreID())
 	etArgs.Timestamp = pushee.Timestamp
 	if err := store.ExecuteCmd(proto.EndTransaction, etArgs, etReply); err != nil {
 		t.Fatal(err)
@@ -681,7 +682,7 @@ func TestStoreResolveWriteIntentNoTxn(t *testing.T) {
 	pushee.Priority = 0 // pushee should lose all conflicts
 
 	// First, lay down intent from pushee.
-	args, reply := putArgs(key, []byte("value1"), 1)
+	args, reply := putArgs(key, []byte("value1"), 1, store.StoreID())
 	args.Timestamp = pushee.Timestamp
 	args.Txn = pushee
 	if err := store.ExecuteCmd(proto.Put, args, reply); err != nil {
@@ -689,7 +690,7 @@ func TestStoreResolveWriteIntentNoTxn(t *testing.T) {
 	}
 
 	// Now, try to read outside a transaction.
-	gArgs, gReply := getArgs(key, 1)
+	gArgs, gReply := getArgs(key, 1, store.StoreID())
 	gArgs.Timestamp = store.clock.Now()
 	gArgs.UserPriority = gogoproto.Int32(math.MaxInt32)
 	if err := store.ExecuteCmd(proto.Get, gArgs, gReply); err != nil {
@@ -733,7 +734,7 @@ func TestStoreResolveWriteIntentNoTxn(t *testing.T) {
 
 	// Finally, try to end the pushee's transaction; it should have
 	// been aborted.
-	etArgs, etReply := endTxnArgs(pushee, true, 1)
+	etArgs, etReply := endTxnArgs(pushee, true, 1, store.StoreID())
 	etArgs.Timestamp = pushee.Timestamp
 	err = store.ExecuteCmd(proto.EndTransaction, etArgs, etReply)
 	if err == nil {

--- a/storage/store_test.go
+++ b/storage/store_test.go
@@ -252,7 +252,7 @@ func TestStoreAddRemoveRanges(t *testing.T) {
 
 	for i, test := range testCases {
 		if r := store.LookupRange(test.start, test.end); r != test.expRng {
-			t.Error("%d: expected range %s; got %s", i, test.expRng, r)
+			t.Errorf("%d: expected range %s; got %s", i, test.expRng, r)
 		}
 	}
 }
@@ -523,7 +523,7 @@ func TestStoreResolveWriteIntent(t *testing.T) {
 			var txn proto.Transaction
 			ok, err := engine.MVCCGetProto(store.Engine(), txnKey, proto.ZeroTimestamp, nil, &txn)
 			if !ok || err != nil {
-				t.Fatal("not found or err: %s", err)
+				t.Fatalf("not found or err: %s", err)
 			}
 			if txn.Status != proto.ABORTED {
 				t.Errorf("expected pushee to be aborted; got %s", txn.Status)
@@ -776,7 +776,7 @@ func TestStoreResolveWriteIntentNoTxn(t *testing.T) {
 	var txn proto.Transaction
 	ok, err := engine.MVCCGetProto(store.Engine(), txnKey, proto.ZeroTimestamp, nil, &txn)
 	if !ok || err != nil {
-		t.Fatal("not found or err: %s", err)
+		t.Fatalf("not found or err: %s", err)
 	}
 	if txn.Status != proto.ABORTED {
 		t.Errorf("expected pushee to be aborted; got %s", txn.Status)


### PR DESCRIPTION
The idea is we'll combine Node ID and Store ID (both int32) into a
single Raft Node ID (int64). We no longer need the extra 64 bit range
ID as it's obviated by simply utilizing the Raft ID.

There are some problems with this scheme. In particular, The same Raft
group might appear twice on the same store over time. We want to be
sure that when we add ranges, we never allow the same Raft ID twice.
In order to decide which one to delete, we'll need to keep track of
a monotonically increasing sequence number for each range on creation.
If two or more ranges exist for the same raft ID, we'll take the most
recent. Ben suggests using the commit log index of the membership
change command.
