### PR TITLE
Download directory name for protobuf releases.

### DIFF
--- a/build/devbase/vendor.sh
+++ b/build/devbase/vendor.sh
@@ -45,7 +45,7 @@ cd bzip2-1.0.6
 make && make install PREFIX="${VENDOR}/usr"
 
 cd ${TMP}
-curl -L https://github.com/google/protobuf/releases/download/2.6.1/protobuf-2.6.1.tar.bz2 | ${TAR} -xj
+curl -L https://github.com/google/protobuf/releases/download/v2.6.1/protobuf-2.6.1.tar.bz2 | ${TAR} -xj
 cd protobuf-2.6.1
 ./configure --prefix ${USR} --disable-shared --enable-static && make && make install
 


### PR DESCRIPTION
Just ran a full bootstrap and noticed that Google renamed the download directory for protobuf releases.  The releases now have a 'v' as part of the version number for the directory name.
