### PR TITLE
Raft cleanup

### DIFF
--- a/multiraft/events.go
+++ b/multiraft/events.go
@@ -18,7 +18,6 @@
 package multiraft
 
 // An EventLeaderElection is broadcast when a group completes an election.
-// TODO(bdarnell): emit EventLeaderElection from follower nodes as well.
 type EventLeaderElection struct {
 	GroupID uint64
 	NodeID  uint64

--- a/multiraft/storage_test.go
+++ b/multiraft/storage_test.go
@@ -6,6 +6,7 @@ package multiraft
 import (
 	"sync"
 
+	"github.com/coreos/etcd/raft"
 	"github.com/coreos/etcd/raft/raftpb"
 )
 
@@ -35,10 +36,10 @@ func (b *BlockableStorage) Unblock() {
 	b.mu.Unlock()
 }
 
-/*func (b *BlockableStorage) LoadGroups() <-chan *GroupPersistentState {
+func (b *BlockableStorage) LoadGroups() map[uint64]raft.Storage {
 	b.wait()
 	return b.storage.LoadGroups()
-}*/
+}
 
 func (b *BlockableStorage) GroupStorage(g uint64) WriteableGroupStorage {
 	return &blockableGroupStorage{b, b.storage.GroupStorage(g)}


### PR DESCRIPTION
(This diff will get easier to read once #198 is merged; you only need to look at the last two commits in this PR)

```
commit 971b50efb72f5bda95137c1126071672533225b2
Author: Ben Darnell <ben@bendarnell.com>
Date:   Mon Dec 8 17:28:24 2014 -0500

    Streamline Multiraft.start select loop.

    raft.MultiNode is thread-safe, so we no longer need to route everything
    through our own goroutine.

    Remove some unneeded generality in the transport interface.

commit e982b0487f14fc75f41e5d773a369354dd3f537b
Author: Ben Darnell <ben@bendarnell.com>
Date:   Mon Dec 8 15:42:44 2014 -0500

    Remove unused cruft from multiraft.

    Just expose the underlying raftpb types directly instead of creating our
    own wrappers.

    Also clean up some obsolete todos.
```

@spencerkimball @cockroachdb/developers 
