### PR TITLE
Verify bzip2 and zlib downloads.

### DIFF
--- a/build/devbase/md5sum.go
+++ b/build/devbase/md5sum.go
@@ -1,0 +1,45 @@
+// Copyright 2014 The Cockroach Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+// implied. See the License for the specific language governing
+// permissions and limitations under the License. See the AUTHORS file
+// for names of contributors.
+//
+// Author: James Graves (james.c.graves.jr@gmail.com)
+
+/*
+Compute MD5 sum from standard input.
+*/
+package main
+
+import (
+	"crypto/md5"
+	"fmt"
+	"os"
+)
+
+func main() {
+	maxlen := 5000000
+	buf := make([]byte, maxlen)
+	n, err := os.Stdin.Read(buf)
+	if err != nil {
+		os.Exit(1)
+	}
+	if n == maxlen {
+		os.Exit(2)
+	}
+
+	sum := md5.Sum(buf[:n])
+	for _, b := range sum {
+		fmt.Printf("%02x", b)
+	}
+	fmt.Println("")
+}

--- a/build/devbase/vendor.sh
+++ b/build/devbase/vendor.sh
@@ -23,6 +23,24 @@ mkdir -p "${USR}" "${TMP}" "${LIB}" "${INCLUDE}" "${ROCKSDB}"
 make clean || true
 (cd _vendor/rocksdb && make clean) || true
 
+# Download and verify a file.
+# ${1} is the URL
+# ${2} is the expected md5sum
+function download_verify()
+{
+    curl -LOs ${1}
+    filename=`echo ${1} | sed 's/.*\///'`
+    if [ -f ${filename} ]; then
+        dl_md5sum=`md5sum ${filename} | cut -c-32`
+        if [ ${dl_md5sum} != ${2} ]; then
+            echo "$filename md5sum did not match."
+            exit 1
+        fi
+    else
+        echo "${1} download failed"
+        exit 1
+    fi
+}
 
 cd ${TMP}
 curl -L https://gflags.googlecode.com/files/gflags-2.0-no-svn-files.tar.gz | ${TAR} -xz
@@ -35,14 +53,18 @@ cd snappy-1.1.1
 ./configure --prefix ${USR} --disable-shared --enable-static && make && make install
 
 cd ${TMP}
-# TODO: find an https download url for zlib or verify checksums.
-curl -L http://zlib.net/zlib-1.2.8.tar.gz | ${TAR} -xz
+download_verify \
+    http://zlib.net/zlib-1.2.8.tar.gz \
+    44d667c142d7cda120332623eab69f40
+${TAR} -xzf zlib-1.2.8.tar.gz
 cd zlib-1.2.8
 ./configure --static && make test && make && make install prefix="${USR}"
 
 cd ${TMP}
-# TODO: find an https download url for bzip or verify checksums.
-curl -L http://www.bzip.org/1.0.6/bzip2-1.0.6.tar.gz | ${TAR} -xz
+download_verify \
+    http://www.bzip.org/1.0.6/bzip2-1.0.6.tar.gz \
+    00b516f4704d4a7cb50a1d97e6e8e15b
+${TAR} -xzf bzip2-1.0.6.tar.gz
 cd bzip2-1.0.6
 make && make install PREFIX="${VENDOR}/usr"
 

--- a/build/devbase/vendor.sh
+++ b/build/devbase/vendor.sh
@@ -7,6 +7,7 @@ cd -P "$(dirname $0)/../.."
 
 # Build dependencies into our shadow environment.
 VENDOR="$(pwd -P)/_vendor"
+GO_MD5SUM="$(pwd -P)/build/devbase/md5sum.go"
 USR="${VENDOR}/usr"
 LIB="${USR}/lib"
 INCLUDE="${USR}/include"
@@ -31,7 +32,7 @@ function download_verify()
     curl -LOs ${1}
     filename=`echo ${1} | sed 's/.*\///'`
     if [ -f ${filename} ]; then
-        dl_md5sum=`md5sum ${filename} | cut -c-32`
+        dl_md5sum=`go run ${GO_MD5SUM} < ${filename}`
         if [ ${dl_md5sum} != ${2} ]; then
             echo "$filename md5sum did not match."
             exit 1


### PR DESCRIPTION
The bzip2 and zlib authors don't provide https links to download
releases.  However, they do provide md5sums for the releases
on their webpages.
