### PR TITLE
Make hlc.ManualClock atomic and hide underlying int64.

### DIFF
--- a/kv/local_sender_test.go
+++ b/kv/local_sender_test.go
@@ -118,7 +118,7 @@ func splitTestRange(store *storage.Store, key, splitKey proto.Key, t *testing.T)
 }
 
 func TestLocalSenderLookupReplica(t *testing.T) {
-	manualClock := hlc.ManualClock(0)
+	manualClock := hlc.NewManualClock(0)
 	clock := hlc.NewClock(manualClock.UnixNano)
 	eng := engine.NewInMem(proto.Attributes{}, 1<<20)
 	ls := NewLocalSender()

--- a/kv/txn_test.go
+++ b/kv/txn_test.go
@@ -106,8 +106,7 @@ func TestTxnDBBasics(t *testing.T) {
 // the maximumOffset given, verifying in the process that the correct values
 // are read (usually after one transaction restart).
 func verifyUncertainty(concurrency int, maxOffset time.Duration, t *testing.T) {
-	db, _, clock, manualClock, lSender := createTestDB(t)
-	*manualClock = 0
+	db, _, clock, _, lSender := createTestDB(t)
 
 	txnOpts := &client.TransactionOptions{
 		Name: "test",
@@ -160,7 +159,7 @@ func verifyUncertainty(concurrency int, maxOffset time.Duration, t *testing.T) {
 			// Wait until the other goroutines are running.
 			wgStart.Wait()
 
-			txnManual := hlc.ManualClock(futureTS.WallTime)
+			txnManual := hlc.NewManualClock(futureTS.WallTime)
 			txnClock := hlc.NewClock(txnManual.UnixNano)
 			// Make sure to incorporate the logical component if the wall time
 			// hasn't changed (i=0). The logical component will change

--- a/rpc/client_test.go
+++ b/rpc/client_test.go
@@ -73,7 +73,7 @@ func TestClientHeartbeatBadServer(t *testing.T) {
 }
 
 func TestOffsetMeasurement(t *testing.T) {
-	serverManual := hlc.ManualClock(10)
+	serverManual := hlc.NewManualClock(10)
 	serverClock := hlc.NewClock(serverManual.UnixNano)
 	s := createTestServer(serverClock, t)
 	defer s.Close()
@@ -113,7 +113,7 @@ func TestOffsetMeasurement(t *testing.T) {
 // InfiniteOffset if the heartbeat reply exceeds the maximumClockReadingDelay,
 // but not the heartbeat timeout.
 func TestDelayedOffsetMeasurement(t *testing.T) {
-	serverManual := hlc.ManualClock(10)
+	serverManual := hlc.NewManualClock(10)
 	serverClock := hlc.NewClock(serverManual.UnixNano)
 	s := createTestServer(serverClock, t)
 	defer s.Close()
@@ -156,7 +156,7 @@ func TestDelayedOffsetMeasurement(t *testing.T) {
 }
 
 func TestFailedOffestMeasurement(t *testing.T) {
-	serverManual := hlc.ManualClock(0)
+	serverManual := hlc.NewManualClock(0)
 	serverClock := hlc.NewClock(serverManual.UnixNano)
 	s := createTestServer(serverClock, t)
 	defer s.Close()
@@ -169,7 +169,7 @@ func TestFailedOffestMeasurement(t *testing.T) {
 	s.RegisterName("Heartbeat", heartbeat)
 
 	// Create a client that never receives a heartbeat after the first.
-	clientManual := hlc.ManualClock(0)
+	clientManual := hlc.NewManualClock(0)
 	clientClock := hlc.NewClock(clientManual.UnixNano)
 	context := NewContext(clientClock, s.context.tlsConfig)
 	c := NewClient(s.Addr(), nil, context)

--- a/rpc/clock_offset_test.go
+++ b/rpc/clock_offset_test.go
@@ -123,7 +123,7 @@ func TestBuildEndpointList(t *testing.T) {
 		"2": proto.RemoteOffset{Offset: 2, Error: 10},
 		"3": proto.RemoteOffset{Offset: 3, Error: 10},
 	}
-	manual := hlc.ManualClock(0)
+	manual := hlc.NewManualClock(0)
 	clock := hlc.NewClock(manual.UnixNano)
 	clock.SetMaxOffset(5 * time.Nanosecond)
 	remoteClocks := &RemoteClockMonitor{
@@ -171,7 +171,7 @@ func TestBuildEndpointListRemoveStagnantClocks(t *testing.T) {
 	// The stagnant offsets older than 10ns ago will be removed.
 	monitorInterval = 10 * time.Nanosecond
 
-	manual := hlc.ManualClock(0)
+	manual := hlc.NewManualClock(0)
 	clock := hlc.NewClock(manual.UnixNano)
 	clock.SetMaxOffset(5 * time.Nanosecond)
 	remoteClocks := &RemoteClockMonitor{
@@ -202,7 +202,7 @@ func TestFindOffsetInterval(t *testing.T) {
 		"3": proto.RemoteOffset{Offset: 91, Error: 31},
 	}
 
-	manual := hlc.ManualClock(0)
+	manual := hlc.NewManualClock(0)
 	clock := hlc.NewClock(manual.UnixNano)
 	clock.SetMaxOffset(0 * time.Nanosecond)
 	remoteClocks := &RemoteClockMonitor{
@@ -225,7 +225,7 @@ func TestFindOffsetIntervalNoMajorityOverlap(t *testing.T) {
 		"3": proto.RemoteOffset{Offset: 4, Error: 1},
 	}
 
-	manual := hlc.ManualClock(0)
+	manual := hlc.NewManualClock(0)
 	clock := hlc.NewClock(manual.UnixNano)
 	clock.SetMaxOffset(0 * time.Nanosecond)
 	remoteClocks := &RemoteClockMonitor{
@@ -246,7 +246,7 @@ func TestFindOffsetIntervalWithInfinites(t *testing.T) {
 		"3": proto.InfiniteOffset,
 	}
 
-	manual := hlc.ManualClock(0)
+	manual := hlc.NewManualClock(0)
 	clock := hlc.NewClock(manual.UnixNano)
 	clock.SetMaxOffset(0 * time.Nanosecond)
 	remoteClocks := &RemoteClockMonitor{
@@ -264,7 +264,7 @@ func TestFindOffsetIntervalWithInfinites(t *testing.T) {
 // no recent remote clock readings.
 func TestFindOffsetIntervalNoRemotes(t *testing.T) {
 	offsets := map[string]proto.RemoteOffset{}
-	manual := hlc.ManualClock(0)
+	manual := hlc.NewManualClock(0)
 	clock := hlc.NewClock(manual.UnixNano)
 	clock.SetMaxOffset(10 * time.Nanosecond)
 	remoteClocks := &RemoteClockMonitor{
@@ -282,7 +282,7 @@ func TestFindOffsetIntervalOneClock(t *testing.T) {
 		"0": proto.RemoteOffset{Offset: 0, Error: 10},
 	}
 
-	manual := hlc.ManualClock(0)
+	manual := hlc.NewManualClock(0)
 	clock := hlc.NewClock(manual.UnixNano)
 	// The clock interval will be:
 	// [offset - error - maxOffset, offset + error + maxOffset]
@@ -299,7 +299,7 @@ func TestFindOffsetIntervalOneClock(t *testing.T) {
 func TestFindOffsetIntervalTwoClocks(t *testing.T) {
 	offsets := map[string]proto.RemoteOffset{}
 
-	manual := hlc.ManualClock(0)
+	manual := hlc.NewManualClock(0)
 	clock := hlc.NewClock(manual.UnixNano)
 	clock.SetMaxOffset(0 * time.Nanosecond)
 	remoteClocks := &RemoteClockMonitor{

--- a/rpc/heartbeat_test.go
+++ b/rpc/heartbeat_test.go
@@ -26,7 +26,7 @@ import (
 )
 
 func TestHeartbeatReply(t *testing.T) {
-	manual := hlc.ManualClock(5)
+	manual := hlc.NewManualClock(5)
 	clock := hlc.NewClock(manual.UnixNano)
 	heartbeat := &HeartbeatService{
 		clock:              clock,
@@ -49,7 +49,7 @@ func TestHeartbeatReply(t *testing.T) {
 }
 
 func TestManualHeartbeat(t *testing.T) {
-	manual := hlc.ManualClock(5)
+	manual := hlc.NewManualClock(5)
 	clock := hlc.NewClock(manual.UnixNano)
 	manualHeartbeat := &ManualHeartbeatService{
 		clock:              clock,

--- a/storage/db_test.go
+++ b/storage/db_test.go
@@ -45,7 +45,7 @@ import (
 func createTestStore(t *testing.T) *storage.Store {
 	rpcContext := rpc.NewContext(hlc.NewClock(hlc.UnixNano), rpc.LoadInsecureTLSConfig())
 	g := gossip.New(rpcContext)
-	manual := hlc.ManualClock(0)
+	manual := hlc.NewManualClock(0)
 	clock := hlc.NewClock(manual.UnixNano)
 	eng := engine.NewInMem(proto.Attributes{}, 1<<20)
 	lSender := kv.NewLocalSender()

--- a/storage/store_test.go
+++ b/storage/store_test.go
@@ -91,7 +91,7 @@ func (db *testSender) Close() {}
 func createTestStore(t *testing.T) (*Store, *hlc.ManualClock) {
 	rpcContext := rpc.NewContext(hlc.NewClock(hlc.UnixNano), rpc.LoadInsecureTLSConfig())
 	g := gossip.New(rpcContext)
-	manual := hlc.ManualClock(0)
+	manual := hlc.NewManualClock(0)
 	clock := hlc.NewClock(manual.UnixNano)
 	eng := engine.NewInMem(proto.Attributes{}, 1<<20)
 	store := NewStore(clock, eng, nil, g)
@@ -108,13 +108,13 @@ func createTestStore(t *testing.T) (*Store, *hlc.ManualClock) {
 	if err := store.Start(); err != nil {
 		t.Fatal(err)
 	}
-	return store, &manual
+	return store, manual
 }
 
 // TestStoreInitAndBootstrap verifies store initialization and
 // bootstrap.
 func TestStoreInitAndBootstrap(t *testing.T) {
-	manual := hlc.ManualClock(0)
+	manual := hlc.NewManualClock(0)
 	clock := hlc.NewClock(manual.UnixNano)
 	eng := engine.NewInMem(proto.Attributes{}, 1<<20)
 	store := NewStore(clock, eng, nil, nil)
@@ -161,7 +161,7 @@ func TestBootstrapOfNonEmptyStore(t *testing.T) {
 	if err := eng.Put(proto.EncodedKey("foo"), []byte("bar")); err != nil {
 		t.Errorf("failure putting key foo into engine: %s", err)
 	}
-	manual := hlc.ManualClock(0)
+	manual := hlc.NewManualClock(0)
 	clock := hlc.NewClock(manual.UnixNano)
 	store := NewStore(clock, eng, nil, nil)
 
@@ -341,7 +341,7 @@ func TestStoreExecuteCmdWithZeroTime(t *testing.T) {
 	args, reply := getArgs([]byte("a"), 1, store.StoreID())
 
 	// Set clock to time 1.
-	*mc = hlc.ManualClock(1)
+	mc.Set(1)
 	err := store.ExecuteCmd(proto.Get, args, reply)
 	if err != nil {
 		t.Fatal(err)
@@ -363,7 +363,7 @@ func TestStoreExecuteCmdWithClockOffset(t *testing.T) {
 	args, reply := getArgs([]byte("a"), 1, store.StoreID())
 
 	// Set clock to time 1.
-	*mc = hlc.ManualClock(1)
+	mc.Set(1)
 	// Set clock max offset to 250ms.
 	maxOffset := 250 * time.Millisecond
 	store.clock.SetMaxOffset(maxOffset)

--- a/storage/timestamp_cache_test.go
+++ b/storage/timestamp_cache_test.go
@@ -31,7 +31,7 @@ const (
 )
 
 func TestTimestampCache(t *testing.T) {
-	manual := hlc.ManualClock(0)
+	manual := hlc.NewManualClock(0)
 	clock := hlc.NewClock(manual.UnixNano)
 	clock.SetMaxOffset(maxClockOffset)
 	tc := NewTimestampCache(clock)
@@ -52,7 +52,7 @@ func TestTimestampCache(t *testing.T) {
 	}
 
 	// Advance the clock and verify same low water mark.
-	manual = hlc.ManualClock(maxClockOffset.Nanoseconds() + 1)
+	manual.Set(maxClockOffset.Nanoseconds() + 1)
 	if rTS, _ := tc.GetMax(proto.Key("a"), nil, proto.NoTxnMD5); rTS.WallTime != maxClockOffset.Nanoseconds() {
 		t.Error("expected maxClockOffset for key \"a\"")
 	}
@@ -103,18 +103,18 @@ func TestTimestampCache(t *testing.T) {
 // TestTimestampCacheEviction verifies the eviction of
 // timestamp cache entries after minCacheWindow interval.
 func TestTimestampCacheEviction(t *testing.T) {
-	manual := hlc.ManualClock(0)
+	manual := hlc.NewManualClock(0)
 	clock := hlc.NewClock(manual.UnixNano)
 	clock.SetMaxOffset(maxClockOffset)
 	tc := NewTimestampCache(clock)
 
 	// Increment time to the maxClockOffset low water mark + 1.
-	manual = hlc.ManualClock(maxClockOffset.Nanoseconds() + 1)
+	manual.Set(maxClockOffset.Nanoseconds() + 1)
 	aTS := clock.Now()
 	tc.Add(proto.Key("a"), nil, aTS, proto.NoTxnMD5, true)
 
 	// Increment time by the minCacheWindow and add another key.
-	manual = hlc.ManualClock(int64(manual) + minCacheWindow.Nanoseconds())
+	manual.Increment(minCacheWindow.Nanoseconds())
 	tc.Add(proto.Key("b"), nil, clock.Now(), proto.NoTxnMD5, true)
 
 	// Verify looking up key "c" returns the new low water mark ("a"'s timestamp).
@@ -127,11 +127,11 @@ func TestTimestampCacheEviction(t *testing.T) {
 // is chosen if previous entries have ranges which are layered over
 // each other.
 func TestTimestampCacheLayeredIntervals(t *testing.T) {
-	manual := hlc.ManualClock(0)
+	manual := hlc.NewManualClock(0)
 	clock := hlc.NewClock(manual.UnixNano)
 	clock.SetMaxOffset(maxClockOffset)
 	tc := NewTimestampCache(clock)
-	manual = hlc.ManualClock(maxClockOffset.Nanoseconds() + 1)
+	manual.Set(maxClockOffset.Nanoseconds() + 1)
 
 	adTS := clock.Now()
 	tc.Add(proto.Key("a"), proto.Key("d"), adTS, proto.NoTxnMD5, true)
@@ -176,13 +176,13 @@ func TestTimestampCacheLayeredIntervals(t *testing.T) {
 }
 
 func TestTimestampCacheClear(t *testing.T) {
-	manual := hlc.ManualClock(0)
+	manual := hlc.NewManualClock(0)
 	clock := hlc.NewClock(manual.UnixNano)
 	clock.SetMaxOffset(maxClockOffset)
 	tc := NewTimestampCache(clock)
 
 	// Increment time to the maxClockOffset low water mark + 1.
-	manual = hlc.ManualClock(maxClockOffset.Nanoseconds() + 1)
+	manual.Set(maxClockOffset.Nanoseconds() + 1)
 	ts := clock.Now()
 	tc.Add(proto.Key("a"), nil, ts, proto.NoTxnMD5, true)
 
@@ -202,7 +202,7 @@ func TestTimestampCacheClear(t *testing.T) {
 // in the timestamp cache which completely "covers" an older
 // entry will replace it.
 func TestTimestampCacheReplacements(t *testing.T) {
-	manual := hlc.ManualClock(0)
+	manual := hlc.NewManualClock(0)
 	clock := hlc.NewClock(manual.UnixNano)
 	tc := NewTimestampCache(clock)
 
@@ -253,7 +253,7 @@ func TestTimestampCacheReplacements(t *testing.T) {
 // TestTimestampCacheWithTxnMD5 verifies that timestamps matching
 // a specified MD5 of the txn ID are ignored.
 func TestTimestampCacheWithTxnMD5(t *testing.T) {
-	manual := hlc.ManualClock(0)
+	manual := hlc.NewManualClock(0)
 	clock := hlc.NewClock(manual.UnixNano)
 	tc := NewTimestampCache(clock)
 
@@ -283,7 +283,7 @@ func TestTimestampCacheWithTxnMD5(t *testing.T) {
 // TestTimestampCacheReadVsWrite verifies that the timestamp cache
 // can differentiate between read and write timestamp.
 func TestTimestampCacheReadVsWrite(t *testing.T) {
-	manual := hlc.ManualClock(0)
+	manual := hlc.NewManualClock(0)
 	clock := hlc.NewClock(manual.UnixNano)
 	tc := NewTimestampCache(clock)
 

--- a/util/hlc/hlc.go
+++ b/util/hlc/hlc.go
@@ -62,28 +62,28 @@ type Clock struct {
 // creating a hybrid logical clock whose physical clock
 // is manually controlled. ManualClock is thread safe.
 type ManualClock struct {
-	timestamp int64
+	nanos int64
 }
 
 // NewManualClock returns a new instance, initialized with
 // specified timestamp.
-func NewManualClock(timestamp int64) *ManualClock {
-	return &ManualClock{timestamp: timestamp}
+func NewManualClock(nanos int64) *ManualClock {
+	return &ManualClock{nanos: nanos}
 }
 
 // UnixNano returns the underlying manual clock's timestamp.
 func (m *ManualClock) UnixNano() int64 {
-	return atomic.LoadInt64(&m.timestamp)
+	return atomic.LoadInt64(&m.nanos)
 }
 
 // Increment atomically increments the manual clock's timestamp.
 func (m *ManualClock) Increment(incr int64) {
-	atomic.AddInt64(&m.timestamp, incr)
+	atomic.AddInt64(&m.nanos, incr)
 }
 
 // Set atomically sets the manual clock's timestamp.
-func (m *ManualClock) Set(timestamp int64) {
-	atomic.StoreInt64(&m.timestamp, timestamp)
+func (m *ManualClock) Set(nanos int64) {
+	atomic.StoreInt64(&m.nanos, nanos)
 }
 
 // UnixNano returns the local machine's physical nanosecond

--- a/util/hlc/hlc_test.go
+++ b/util/hlc/hlc_test.go
@@ -65,14 +65,14 @@ func ExampleNewClock() {
 }
 
 func TestLess(t *testing.T) {
-	var m ManualClock
+	m := NewManualClock(0)
 	c := NewClock(m.UnixNano)
 	a := c.Timestamp()
 	b := c.Timestamp()
 	if a.Less(b) || b.Less(a) {
 		t.Errorf("expected %+v == %+v", a, b)
 	}
-	m = ManualClock(1)
+	m.Set(1)
 	b = c.Now()
 	if !a.Less(b) {
 		t.Errorf("expected %+v < %+v", a, b)
@@ -84,14 +84,14 @@ func TestLess(t *testing.T) {
 }
 
 func TestEqual(t *testing.T) {
-	var m ManualClock
+	m := NewManualClock(0)
 	c := NewClock(m.UnixNano)
 	a := c.Timestamp()
 	b := c.Timestamp()
 	if !a.Equal(b) {
 		t.Errorf("expected %+v == %+v", a, b)
 	}
-	m = ManualClock(1)
+	m.Set(1)
 	b = c.Now()
 	if a.Equal(b) {
 		t.Errorf("expected %+v < %+v", a, b)
@@ -105,7 +105,7 @@ func TestEqual(t *testing.T) {
 // TestClock performs a complete test of all basic phenomena,
 // including backward jumps in local physical time and clock offset.
 func TestClock(t *testing.T) {
-	var m ManualClock
+	m := NewManualClock(0)
 	c := NewClock(m.UnixNano)
 	c.SetMaxOffset(1000)
 	expectedHistory := []struct {
@@ -138,7 +138,7 @@ func TestClock(t *testing.T) {
 	var current proto.Timestamp
 	var err error
 	for i, step := range expectedHistory {
-		m = ManualClock(step.wallClock)
+		m.Set(step.wallClock)
 		switch step.event {
 		case SEND:
 			current = c.Now()
@@ -161,7 +161,7 @@ func TestClock(t *testing.T) {
 // TestSetMaxOffset ensures that checking received timestamps
 // for excessive offsets works correctly.
 func TestSetMaxOffset(t *testing.T) {
-	var m ManualClock = 123456789
+	m := NewManualClock(123456789)
 	skewedTime := int64(123456789 + 51)
 	c := NewClock(m.UnixNano)
 	if c.MaxOffset() != 0 {
@@ -172,7 +172,7 @@ func TestSetMaxOffset(t *testing.T) {
 		t.Fatalf("unexpected offset setting")
 	}
 	c.Now()
-	if c.Timestamp().WallTime != int64(m) {
+	if c.Timestamp().WallTime != m.UnixNano() {
 		t.Fatalf("unexpected clock value")
 	}
 	_, err := c.Update(proto.Timestamp{WallTime: skewedTime})
@@ -190,13 +190,13 @@ func TestSetMaxOffset(t *testing.T) {
 // ExampleManualClock shows how a manual clock can be
 // used as a physical clock. This is useful for testing.
 func ExampleManualClock() {
-	var m ManualClock = 10
+	m := NewManualClock(10)
 	c := NewClock(m.UnixNano)
 	c.Now()
 	if c.Timestamp().WallTime != 10 {
 		log.Fatalf("manual clock error")
 	}
-	m = 20
+	m.Set(20)
 	c.Now()
 	if c.Timestamp().WallTime != 20 {
 		log.Fatalf("manual clock error")


### PR DESCRIPTION
Fixes issue #201
