### PR TITLE
Remove CmdID from InternalRaftCommand and pass it to raft separately.

### DIFF
--- a/multiraft/multiraft.go
+++ b/multiraft/multiraft.go
@@ -176,14 +176,14 @@ func (m *MultiRaft) CreateGroup(groupID uint64, initialMembers []uint64) error {
 // when the command has been successfully sent, not when it has been committed.
 // TODO(bdarnell): should SubmitCommand wait until the commit?
 // TODO(bdarnell): what do we do if we lose leadership before a command we proposed commits?
-func (m *MultiRaft) SubmitCommand(commandID []byte, groupID uint64, command []byte) error {
+func (m *MultiRaft) SubmitCommand(groupID uint64, commandID []byte, command []byte) error {
 	log.V(6).Infof("node %v submitting command to group %v", m.nodeID, groupID)
 	return m.multiNode.Propose(context.Background(), groupID, encodeCommand(commandID, command))
 }
 
 // ChangeGroupMembership submits a proposed membership change to the cluster.
 // TODO(bdarnell): same concerns as SubmitCommand
-func (m *MultiRaft) ChangeGroupMembership(commandID []byte, groupID uint64,
+func (m *MultiRaft) ChangeGroupMembership(groupID uint64, commandID []byte,
 	changeType raftpb.ConfChangeType, nodeID uint64) error {
 	log.V(6).Infof("node %v proposing membership change to group %v", m.nodeID, groupID)
 	return m.multiNode.ProposeConfChange(context.Background(), groupID,

--- a/multiraft/multiraft.go
+++ b/multiraft/multiraft.go
@@ -176,20 +176,21 @@ func (m *MultiRaft) CreateGroup(groupID uint64, initialMembers []uint64) error {
 // when the command has been successfully sent, not when it has been committed.
 // TODO(bdarnell): should SubmitCommand wait until the commit?
 // TODO(bdarnell): what do we do if we lose leadership before a command we proposed commits?
-func (m *MultiRaft) SubmitCommand(groupID uint64, command []byte) error {
+func (m *MultiRaft) SubmitCommand(commandID []byte, groupID uint64, command []byte) error {
 	log.V(6).Infof("node %v submitting command to group %v", m.nodeID, groupID)
-	return m.multiNode.Propose(context.Background(), groupID, command)
+	return m.multiNode.Propose(context.Background(), groupID, encodeCommand(commandID, command))
 }
 
 // ChangeGroupMembership submits a proposed membership change to the cluster.
 // TODO(bdarnell): same concerns as SubmitCommand
-func (m *MultiRaft) ChangeGroupMembership(groupID uint64, changeType raftpb.ConfChangeType,
-	nodeID uint64) error {
+func (m *MultiRaft) ChangeGroupMembership(commandID []byte, groupID uint64,
+	changeType raftpb.ConfChangeType, nodeID uint64) error {
 	log.V(6).Infof("node %v proposing membership change to group %v", m.nodeID, groupID)
 	return m.multiNode.ProposeConfChange(context.Background(), groupID,
 		raftpb.ConfChange{
-			Type:   changeType,
-			NodeID: nodeID,
+			Type:    changeType,
+			NodeID:  nodeID,
+			Context: encodeCommand(commandID, nil),
 		})
 }
 
@@ -403,9 +404,10 @@ func (s *state) handleWriteResponse(response *writeResponse, readyGroups map[uin
 		for _, entry := range ready.CommittedEntries {
 			switch entry.Type {
 			case raftpb.EntryNormal:
-				// TODO(bdarnell): etcd raft adds a nil entry upon election; should this be given a different Type?
+				// etcd raft occasionally adds a nil entry (e.g. upon election); ignore these.
 				if entry.Data != nil {
-					s.sendEvent(&EventCommandCommitted{entry.Data})
+					commandID, command := decodeCommand(entry.Data)
+					s.sendEvent(&EventCommandCommitted{commandID, command})
 				}
 			case raftpb.EntryConfChange:
 				cc := raftpb.ConfChange{}
@@ -414,6 +416,7 @@ func (s *state) handleWriteResponse(response *writeResponse, readyGroups map[uin
 					log.Fatalf("invalid ConfChange data: %s", err)
 				}
 				log.V(3).Infof("node %v applying configuration change %v", s.nodeID, cc)
+				// TODO(bdarnell): dedupe by extracting commandID from cc.Context.
 				s.multiNode.ApplyConfChange(groupID, cc)
 			}
 		}

--- a/multiraft/multiraft_test.go
+++ b/multiraft/multiraft_test.go
@@ -137,7 +137,7 @@ func TestCommand(t *testing.T) {
 	cluster.waitForElection(0)
 
 	// Submit a command to the leader
-	cluster.nodes[0].SubmitCommand(makeCommandID(), groupID, []byte("command"))
+	cluster.nodes[0].SubmitCommand(groupID, makeCommandID(), []byte("command"))
 
 	// The command will be committed on each node.
 	for i, events := range cluster.events {
@@ -163,7 +163,7 @@ func TestSlowStorage(t *testing.T) {
 	cluster.storages[2].Block()
 
 	// Submit a command to the leader
-	cluster.nodes[0].SubmitCommand(makeCommandID(), groupID, []byte("command"))
+	cluster.nodes[0].SubmitCommand(groupID, makeCommandID(), []byte("command"))
 
 	// Even with the third node blocked, the other nodes can make progress.
 	for i := 0; i < 2; i++ {
@@ -203,7 +203,7 @@ func TestMembershipChange(t *testing.T) {
 
 	// Add each of the other three nodes to the cluster.
 	for i := 1; i < 4; i++ {
-		err := cluster.nodes[0].ChangeGroupMembership(makeCommandID(), groupID,
+		err := cluster.nodes[0].ChangeGroupMembership(groupID, makeCommandID(),
 			raftpb.ConfChangeAddNode,
 			cluster.nodes[i].nodeID)
 		if err != nil {

--- a/multiraft/multiraft_test.go
+++ b/multiraft/multiraft_test.go
@@ -21,9 +21,16 @@ import (
 	"testing"
 	"time"
 
+	"github.com/cockroachdb/cockroach/util"
 	"github.com/cockroachdb/cockroach/util/log"
 	"github.com/coreos/etcd/raft/raftpb"
 )
+
+var rand = util.NewPseudoRand()
+
+func makeCommandID() []byte {
+	return []byte(util.RandString(rand, commandIDLen))
+}
 
 type testCluster struct {
 	t        *testing.T
@@ -130,7 +137,7 @@ func TestCommand(t *testing.T) {
 	cluster.waitForElection(0)
 
 	// Submit a command to the leader
-	cluster.nodes[0].SubmitCommand(groupID, []byte("command"))
+	cluster.nodes[0].SubmitCommand(makeCommandID(), groupID, []byte("command"))
 
 	// The command will be committed on each node.
 	for i, events := range cluster.events {
@@ -156,7 +163,7 @@ func TestSlowStorage(t *testing.T) {
 	cluster.storages[2].Block()
 
 	// Submit a command to the leader
-	cluster.nodes[0].SubmitCommand(groupID, []byte("command"))
+	cluster.nodes[0].SubmitCommand(makeCommandID(), groupID, []byte("command"))
 
 	// Even with the third node blocked, the other nodes can make progress.
 	for i := 0; i < 2; i++ {
@@ -196,7 +203,8 @@ func TestMembershipChange(t *testing.T) {
 
 	// Add each of the other three nodes to the cluster.
 	for i := 1; i < 4; i++ {
-		err := cluster.nodes[0].ChangeGroupMembership(groupID, raftpb.ConfChangeAddNode,
+		err := cluster.nodes[0].ChangeGroupMembership(makeCommandID(), groupID,
+			raftpb.ConfChangeAddNode,
 			cluster.nodes[i].nodeID)
 		if err != nil {
 			t.Fatal(err)

--- a/proto/internal.proto
+++ b/proto/internal.proto
@@ -197,10 +197,6 @@ message InternalRaftCommandUnion {
 // An InternalRaftCommand is a command which can be serialized and
 // sent via raft.
 message InternalRaftCommand {
-  // CmdID is used to identify a command when it has been
-  // committed. If the client specified a CmdID in its RequestHeader,
-  // that is used; otherwise the server generates an ID.
-  //optional ClientCmdID cmd_id = 1 [(gogoproto.nullable) = false, (gogoproto.customname) = "CmdID"];
   optional int64 raft_id = 2 [(gogoproto.nullable) = false, (gogoproto.customname) = "RaftID"];
   optional InternalRaftCommandUnion cmd = 3 [(gogoproto.nullable) = false];
 }

--- a/proto/internal.proto
+++ b/proto/internal.proto
@@ -200,7 +200,7 @@ message InternalRaftCommand {
   // CmdID is used to identify a command when it has been
   // committed. If the client specified a CmdID in its RequestHeader,
   // that is used; otherwise the server generates an ID.
-  optional ClientCmdID cmd_id = 1 [(gogoproto.nullable) = false, (gogoproto.customname) = "CmdID"];
+  //optional ClientCmdID cmd_id = 1 [(gogoproto.nullable) = false, (gogoproto.customname) = "CmdID"];
   optional int64 raft_id = 2 [(gogoproto.nullable) = false, (gogoproto.customname) = "RaftID"];
   optional InternalRaftCommandUnion cmd = 3 [(gogoproto.nullable) = false];
 }

--- a/storage/raft.go
+++ b/storage/raft.go
@@ -94,7 +94,7 @@ func (snr *singleNodeRaft) propose(cmdIDKey cmdIDKey, cmd proto.InternalRaftComm
 	if err != nil {
 		log.Fatal(err)
 	}
-	snr.mr.SubmitCommand([]byte(cmdIDKey), uint64(cmd.RaftID), data)
+	snr.mr.SubmitCommand(uint64(cmd.RaftID), []byte(cmdIDKey), data)
 }
 
 func (snr *singleNodeRaft) committed() <-chan committedCommand {

--- a/storage/range_test.go
+++ b/storage/range_test.go
@@ -1548,12 +1548,12 @@ func TestRemoteRaftCommand(t *testing.T) {
 	// Send an increment direct to raft.
 	remoteIncArgs, _ := incrementArgs([]byte("a"), 2, 1, s.StoreID())
 	remoteIncArgs.Timestamp = proto.MinTimestamp
+	idKey := makeCmdIDKey(proto.ClientCmdID{WallTime: 1, Random: 1})
 	raftCmd := proto.InternalRaftCommand{
-		CmdID:  proto.ClientCmdID{WallTime: 1, Random: 1},
 		RaftID: r.Desc.RaftID,
 	}
 	raftCmd.Cmd.SetValue(remoteIncArgs)
-	r.rm.ProposeRaftCommand(raftCmd)
+	r.rm.ProposeRaftCommand(idKey, raftCmd)
 
 	// Send an increment through the normal flow, since this is our
 	// simplest way of waiting until this command (and all earlier ones)

--- a/storage/response_cache.go
+++ b/storage/response_cache.go
@@ -18,8 +18,6 @@
 package storage
 
 import (
-	"bytes"
-	"encoding/binary"
 	"fmt"
 	"sync"
 
@@ -34,16 +32,10 @@ import (
 type cmdIDKey string
 
 func makeCmdIDKey(cmdID proto.ClientCmdID) cmdIDKey {
-	buf := bytes.NewBuffer(make([]byte, 0, 16))
-	err := binary.Write(buf, binary.BigEndian, cmdID.WallTime)
-	if err != nil {
-		panic(err)
-	}
-	err = binary.Write(buf, binary.BigEndian, cmdID.Random)
-	if err != nil {
-		panic(err)
-	}
-	return cmdIDKey(buf.String())
+	buf := make([]byte, 0, 16)
+	buf = encoding.EncodeUint64(buf, uint64(cmdID.WallTime))
+	buf = encoding.EncodeUint64(buf, uint64(cmdID.Random))
+	return cmdIDKey(string(buf))
 }
 
 // A ResponseCache provides idempotence for request retries. Each


### PR DESCRIPTION
Multiraft needs a command identifier so it can track pending commands
and resubmit them when an election has caused them to be dropped.

@spencerkimball @cockroachdb/developers 
