### PR TITLE
Add support for merging range addressing records.

### DIFF
--- a/storage/db_test.go
+++ b/storage/db_test.go
@@ -135,56 +135,71 @@ func meta2Key(key proto.Key) proto.Key {
 // correctly updated on creation of new range descriptors.
 func TestUpdateRangeAddressing(t *testing.T) {
 	store := createTestStore(t)
+	// When split is false, merging treats the right range as the merged
+	// range. With merging, expNewLeft indicates the addressing keys we
+	// expect to be removed.
 	testCases := []struct {
-		start, end proto.Key
-		expNew     []proto.Key
+		split                   bool
+		leftStart, leftEnd      proto.Key
+		rightStart, rightEnd    proto.Key
+		leftExpNew, rightExpNew []proto.Key
 	}{
 		// Start out with whole range.
-		{engine.KeyMin, engine.KeyMax,
-			[]proto.Key{meta1Key(engine.KeyMax), meta2Key(engine.KeyMax)}},
-		// First half of splitting the range at key "a".
-		{engine.KeyMin, proto.Key("a"),
-			[]proto.Key{meta1Key(engine.KeyMax), meta2Key(proto.Key("a"))}},
-		// Second half of splitting the range at key "a".
-		{proto.Key("a"), engine.KeyMax,
-			[]proto.Key{meta2Key(engine.KeyMax)}},
-		// First half of splitting the range at key "z".
-		{proto.Key("a"), proto.Key("z"),
-			[]proto.Key{meta2Key(proto.Key("z"))}},
-		// Second half of splitting the range at key "z"
-		{proto.Key("z"), engine.KeyMax,
-			[]proto.Key{meta2Key(engine.KeyMax)}},
-		// First half of splitting the range at key "m".
-		{proto.Key("a"), proto.Key("m"),
-			[]proto.Key{meta2Key(proto.Key("m"))}},
-		// Second half of splitting the range at key "m"
-		{proto.Key("m"), proto.Key("z"),
-			[]proto.Key{meta2Key(proto.Key("z"))}},
-		// First half of splitting at meta2(m).
-		{engine.KeyMin, engine.RangeMetaKey(proto.Key("m")),
-			[]proto.Key{meta1Key(proto.Key("m"))}},
-		// Second half of splitting at meta2(m).
-		{engine.RangeMetaKey(proto.Key("m")), proto.Key("a"),
-			[]proto.Key{meta1Key(engine.KeyMax), meta2Key(proto.Key("a"))}},
-		// First half of splitting at meta2(z).
-		{engine.RangeMetaKey(proto.Key("m")), engine.RangeMetaKey(proto.Key("z")),
-			[]proto.Key{meta1Key(proto.Key("z"))}},
-		// Second half of splitting at meta2(z).
-		{engine.RangeMetaKey(proto.Key("z")), proto.Key("a"),
-			[]proto.Key{meta1Key(engine.KeyMax), meta2Key(proto.Key("a"))}},
-		// First half of splitting at meta2(r).
-		{engine.RangeMetaKey(proto.Key("m")), engine.RangeMetaKey(proto.Key("r")),
-			[]proto.Key{meta1Key(proto.Key("r"))}},
-		// Second half of splitting at meta2(r).
-		{engine.RangeMetaKey(proto.Key("r")), engine.RangeMetaKey(proto.Key("z")),
-			[]proto.Key{meta1Key(proto.Key("z"))}},
+		{false, engine.KeyMin, engine.KeyMax, engine.KeyMin, engine.KeyMax,
+			[]proto.Key{}, []proto.Key{meta1Key(engine.KeyMax), meta2Key(engine.KeyMax)}},
+		// Split KeyMin-KeyMax at key "a".
+		{true, engine.KeyMin, proto.Key("a"), proto.Key("a"), engine.KeyMax,
+			[]proto.Key{meta1Key(engine.KeyMax), meta2Key(proto.Key("a"))}, []proto.Key{meta2Key(engine.KeyMax)}},
+		// Split "a"-KeyMax at key "z".
+		{true, proto.Key("a"), proto.Key("z"), proto.Key("z"), engine.KeyMax,
+			[]proto.Key{meta2Key(proto.Key("z"))}, []proto.Key{meta2Key(engine.KeyMax)}},
+		// Split "a"-"z" at key "m".
+		{true, proto.Key("a"), proto.Key("m"), proto.Key("m"), proto.Key("z"),
+			[]proto.Key{meta2Key(proto.Key("m"))}, []proto.Key{meta2Key(proto.Key("z"))}},
+		// Split KeyMin-"a" at meta2(m).
+		{true, engine.KeyMin, engine.RangeMetaKey(proto.Key("m")), engine.RangeMetaKey(proto.Key("m")), proto.Key("a"),
+			[]proto.Key{meta1Key(proto.Key("m"))}, []proto.Key{meta1Key(engine.KeyMax), meta2Key(proto.Key("a"))}},
+		// Split meta2(m)-"a" at meta2(z).
+		{true, engine.RangeMetaKey(proto.Key("m")), engine.RangeMetaKey(proto.Key("z")), engine.RangeMetaKey(proto.Key("z")), proto.Key("a"),
+			[]proto.Key{meta1Key(proto.Key("z"))}, []proto.Key{meta1Key(engine.KeyMax), meta2Key(proto.Key("a"))}},
+		// Split meta2(m)-meta2(z) at meta2(r).
+		{true, engine.RangeMetaKey(proto.Key("m")), engine.RangeMetaKey(proto.Key("r")), engine.RangeMetaKey(proto.Key("r")), engine.RangeMetaKey(proto.Key("z")),
+			[]proto.Key{meta1Key(proto.Key("r"))}, []proto.Key{meta1Key(proto.Key("z"))}},
+
+		// Now, merge all of our splits backwards...
+
+		// Merge meta2(m)-meta2(z).
+		{true, engine.RangeMetaKey(proto.Key("m")), engine.RangeMetaKey(proto.Key("r")), engine.RangeMetaKey(proto.Key("m")), engine.RangeMetaKey(proto.Key("z")),
+			[]proto.Key{meta1Key(proto.Key("r"))}, []proto.Key{meta1Key(proto.Key("z"))}},
+		// Merge meta2(m)-"a".
+		{true, engine.RangeMetaKey(proto.Key("m")), engine.RangeMetaKey(proto.Key("z")), engine.RangeMetaKey(proto.Key("m")), proto.Key("a"),
+			[]proto.Key{meta1Key(proto.Key("z"))}, []proto.Key{meta1Key(engine.KeyMax), meta2Key(proto.Key("a"))}},
+		// Merge KeyMin-"a".
+		{true, engine.KeyMin, engine.RangeMetaKey(proto.Key("m")), engine.KeyMin, proto.Key("a"),
+			[]proto.Key{meta1Key(proto.Key("m"))}, []proto.Key{meta1Key(engine.KeyMax), meta2Key(proto.Key("a"))}},
+		// Merge "a"-"z".
+		{true, proto.Key("a"), proto.Key("m"), proto.Key("a"), proto.Key("z"),
+			[]proto.Key{meta2Key(proto.Key("m"))}, []proto.Key{meta2Key(proto.Key("z"))}},
+		// Merge "a"-KeyMax.
+		{true, proto.Key("a"), proto.Key("z"), proto.Key("a"), engine.KeyMax,
+			[]proto.Key{meta2Key(proto.Key("z"))}, []proto.Key{meta2Key(engine.KeyMax)}},
+		// Merge KeyMin-KeyMax.
+		{true, engine.KeyMin, proto.Key("a"), engine.KeyMin, engine.KeyMax,
+			[]proto.Key{meta2Key(proto.Key("a"))}, []proto.Key{meta1Key(engine.KeyMax), meta2Key(engine.KeyMax)}},
 	}
 	expMetas := metaSlice{}
 
 	for i, test := range testCases {
-		desc := &proto.RangeDescriptor{RaftID: int64(i), StartKey: test.start, EndKey: test.end}
-		if err := storage.UpdateRangeAddressing(store.DB(), desc); err != nil {
-			t.Fatal(err)
+		left := &proto.RangeDescriptor{RaftID: int64(i), StartKey: test.leftStart, EndKey: test.leftEnd}
+		right := &proto.RangeDescriptor{RaftID: int64(i), StartKey: test.rightStart, EndKey: test.rightEnd}
+		if test.split {
+			if err := storage.SplitRangeAddressing(store.DB(), left, right); err != nil {
+				t.Fatal(err)
+			}
+		} else {
+			if err := storage.MergeRangeAddressing(store.DB(), left, right); err != nil {
+				t.Fatal(err)
+			}
 		}
 		store.DB().Flush()
 		// Scan meta keys directly from engine.
@@ -203,24 +218,36 @@ func TestUpdateRangeAddressing(t *testing.T) {
 
 		// Continue to build up the expected metas slice, replacing any earlier
 		// version of same key.
-		for _, n := range test.expNew {
-			found := false
-			for i := range expMetas {
-				if expMetas[i].key.Equal(n) {
-					found = true
-					expMetas[i].desc = desc
-					break
+		addOrRemoveNew := func(keys []proto.Key, desc *proto.RangeDescriptor, add bool) {
+			for _, n := range keys {
+				found := -1
+				for i := range expMetas {
+					if expMetas[i].key.Equal(n) {
+						found = i
+						expMetas[i].desc = desc
+						break
+					}
+				}
+				if found == -1 && add {
+					expMetas = append(expMetas, metaRecord{key: n, desc: desc})
+				} else if found != -1 && !add {
+					expMetas = append(expMetas[:i], expMetas[i+1:]...)
 				}
 			}
-			if !found {
-				expMetas = append(expMetas, metaRecord{key: n, desc: desc})
-			}
 		}
+		addOrRemoveNew(test.leftExpNew, left, test.split /* on split, add; on merge, remove */)
+		addOrRemoveNew(test.rightExpNew, right, true)
 		sort.Sort(expMetas)
+
 		if !reflect.DeepEqual(expMetas, metas) {
 			t.Errorf("expected metas don't match")
 			for i, meta := range expMetas {
-				fmt.Printf("%d: expected %q vs %q\n", i, meta.key, metas[i].key)
+				if !meta.key.Equal(metas[i].key) {
+					fmt.Printf("%d: expected %q vs %q\n", i, meta.key, metas[i].key)
+				}
+				if !reflect.DeepEqual(meta.desc, metas[i].desc) {
+					fmt.Printf("%d: expected %q vs %q and %s vs %s\n", i, meta.key, metas[i].key, meta.desc, metas[i].desc)
+				}
 			}
 		}
 	}
@@ -231,12 +258,9 @@ func TestUpdateRangeAddressing(t *testing.T) {
 // of meta1 records.
 func TestUpdateRangeAddressingSplitMeta1(t *testing.T) {
 	store := createTestStore(t)
-	desc := &proto.RangeDescriptor{StartKey: meta1Key(proto.Key("a")), EndKey: engine.KeyMax}
-	if err := storage.UpdateRangeAddressing(store.DB(), desc); err == nil {
-		t.Error("expected failure trying to update addressing records for meta1 split")
-	}
-	desc = &proto.RangeDescriptor{StartKey: engine.KeyMin, EndKey: meta1Key(proto.Key("a"))}
-	if err := storage.UpdateRangeAddressing(store.DB(), desc); err == nil {
+	left := &proto.RangeDescriptor{StartKey: engine.KeyMin, EndKey: meta1Key(proto.Key("a"))}
+	right := &proto.RangeDescriptor{StartKey: meta1Key(proto.Key("a")), EndKey: engine.KeyMax}
+	if err := storage.SplitRangeAddressing(store.DB(), left, right); err == nil {
 		t.Error("expected failure trying to update addressing records for meta1 split")
 	}
 }

--- a/storage/engine/keys.go
+++ b/storage/engine/keys.go
@@ -68,9 +68,16 @@ func KeyAddress(k proto.Key) proto.Key {
 	return k[KeyLocalPrefixLength:]
 }
 
-// RangeMetaKey returns a range metadata key for the given key. For ordinary
-// keys this returns a level 2 metadata key - for level 2 keys, it returns a
-// level 1 key. For level 1 keys and local keys, KeyMin is returned.
+// RangeDescriptorKey returns a system-local key for the descriptor
+// for the range with specified start key.
+func RangeDescriptorKey(startKey proto.Key) proto.Key {
+	return MakeLocalKey(KeyLocalRangeDescriptorPrefix, startKey)
+}
+
+// RangeMetaKey returns a range metadata (meta1, meta2) indexing key
+// for the given key. For ordinary keys this returns a level 2
+// metadata key - for level 2 keys, it returns a level 1 key. For
+// level 1 keys and local keys, KeyMin is returned.
 func RangeMetaKey(key proto.Key) proto.Key {
 	if len(key) == 0 {
 		return KeyMin

--- a/storage/range.go
+++ b/storage/range.go
@@ -1358,10 +1358,7 @@ func (r *Range) AdminSplit(args *proto.AdminSplitRequest, reply *proto.AdminSpli
 			return err
 		}
 		// Update range descriptor addressing record(s).
-		if err := UpdateRangeAddressing(txn, newDesc); err != nil {
-			return err
-		}
-		if err := UpdateRangeAddressing(txn, &updatedDesc); err != nil {
+		if err := SplitRangeAddressing(txn, newDesc, &updatedDesc); err != nil {
 			return err
 		}
 		// End the transaction manually, instead of letting RunTransaction

--- a/storage/range.go
+++ b/storage/range.go
@@ -118,12 +118,6 @@ type pendingCmd struct {
 	done   chan error // Used to signal waiting RPC handler
 }
 
-// makeRangeKey returns a key addressing the range descriptor for the range
-// with specified start key.
-func makeRangeKey(startKey proto.Key) proto.Key {
-	return engine.MakeLocalKey(engine.KeyLocalRangeDescriptorPrefix, startKey)
-}
-
 // A RangeManager is an interface satisfied by Store through which ranges
 // contained in the store can access the methods required for splitting.
 type RangeManager interface {
@@ -214,8 +208,8 @@ func (r *Range) Destroy() error {
 	if err := engine.ClearRangeStats(r.rm.Engine(), r.Desc.RaftID); err != nil {
 		return util.Errorf("unable to clear range stats for range %d: %s", r.Desc.RaftID, err)
 	}
-	start = engine.MVCCEncodeKey(makeRangeKey(r.Desc.StartKey))
-	end = engine.MVCCEncodeKey(makeRangeKey(r.Desc.StartKey).Next())
+	start = engine.MVCCEncodeKey(engine.RangeDescriptorKey(r.Desc.StartKey))
+	end = engine.MVCCEncodeKey(engine.RangeDescriptorKey(r.Desc.StartKey).Next())
 	if _, err := engine.ClearRange(r.rm.Engine(), start, end); err != nil {
 		return util.Errorf("unable to clear metadata for range %d: %s", r.Desc.RaftID, err)
 	}
@@ -1350,11 +1344,11 @@ func (r *Range) AdminSplit(args *proto.AdminSplitRequest, reply *proto.AdminSpli
 		// Create range descriptor for second half of split.
 		// Note that this put must go first in order to locate the
 		// transaction record on the correct range.
-		if err := txn.PreparePutProto(makeRangeKey(newDesc.StartKey), newDesc); err != nil {
+		if err := txn.PreparePutProto(engine.RangeDescriptorKey(newDesc.StartKey), newDesc); err != nil {
 			return err
 		}
 		// Update existing range descriptor for first half of split.
-		if err := txn.PreparePutProto(makeRangeKey(updatedDesc.StartKey), &updatedDesc); err != nil {
+		if err := txn.PreparePutProto(engine.RangeDescriptorKey(updatedDesc.StartKey), &updatedDesc); err != nil {
 			return err
 		}
 		// Update range descriptor addressing record(s).

--- a/storage/store.go
+++ b/storage/store.go
@@ -450,7 +450,7 @@ func (s *Store) BootstrapRange() error {
 	batch := s.engine.NewBatch()
 	ms := &engine.MVCCStats{}
 	now := s.clock.Now()
-	if err := engine.MVCCPutProto(batch, ms, makeRangeKey(desc.StartKey), now, nil, desc); err != nil {
+	if err := engine.MVCCPutProto(batch, ms, engine.RangeDescriptorKey(desc.StartKey), now, nil, desc); err != nil {
 		return err
 	}
 	// Write meta1.


### PR DESCRIPTION
This change generalizes the code in UpdateRangeAddressing to support
removing implicated range addressing records instead of just adding
them. UpdateRangeAddressing has been unexported by renaming to
updateRangeAddressing, and its logic better documented and simplified.

The exported methods are SplitRangeAddressing and MergeRangeAddressing.
Split takes left and right. Merge takes the original left and the
updated, merged result of left + right. Merge actually ended up being
simpler than I thought it might be. In effect, you remove any records
associated with the original left side of the merge (remember that
range addressing records are always indexing the END of the range),
and update the new complete range.

The unittest is pretty hairy. It's been rewritten to support both
split and merge and each step takes both left and right ranges.
In the case of split=false (merge), the left range specifies the
original pre-merge left side and the right range specifies the new
merged range. A further complication here is that when split=false,
the left slice of "expected new" meta keys is actually the slice
of meta keys we expect to see removed.
