### PR TITLE
Minor client documentation updates.

### DIFF
--- a/client/client_test.go
+++ b/client/client_test.go
@@ -439,6 +439,7 @@ func ExampleKV_Call() {
 	})
 	kvClient := client.NewKV(sender, nil)
 	kvClient.User = storage.UserRoot
+	defer kvClient.Close()
 
 	key := proto.Key("a")
 	value := []byte{1, 2, 3, 4}
@@ -484,6 +485,7 @@ func ExampleKV_Prepare() {
 	})
 	kvClient := client.NewKV(sender, nil)
 	kvClient.User = storage.UserRoot
+	defer kvClient.Close()
 
 	// Insert test data.
 	batchSize := 12
@@ -554,6 +556,7 @@ func ExampleKV_RunTransaction() {
 	})
 	kvClient := client.NewKV(sender, nil)
 	kvClient.User = storage.UserRoot
+	defer kvClient.Close()
 
 	// Create test data.
 	numKVPairs := 10
@@ -565,7 +568,7 @@ func ExampleKV_RunTransaction() {
 	}
 
 	// Insert all KV pairs inside a transaction.
-	putOpts := client.TransactionOptions{Name: "example put", Isolation: proto.SERIALIZABLE}
+	putOpts := client.TransactionOptions{Name: "example put"}
 	err := kvClient.RunTransaction(&putOpts, func(txn *client.KV) error {
 		for i := 0; i < numKVPairs; i++ {
 			txn.Prepare(proto.Put, proto.PutArgs(proto.Key(keys[i]), values[i]), &proto.PutResponse{})

--- a/client/doc.go
+++ b/client/doc.go
@@ -35,7 +35,8 @@ error. The example below shows a get and a put.
   if err := kv.Call(proto.Get, proto.GetArgs(proto.Key("a")), getResp); err != nil {
     log.Fatal(err)
   }
-  if _, err := kv.Call(proto.Put, proto.PutArgs(proto.Key("b"), getResp.Value.Bytes)) err != nil {
+  putResp := &proto.PutResponse{}
+  if _, err := kv.Call(proto.Put, proto.PutArgs(proto.Key("b"), getResp.Value.Bytes), putResp) err != nil {
     log.Fatal(err)
   }
 
@@ -53,8 +54,8 @@ sequence of puts in parallel:
   kv := client.NewKV(client.NewHTTPSender("localhost:8080", tlsConfig))
 
   acResp, xzResp := &proto.ScanResponse{}, &proto.ScanResponse{}
-  kv.Prepare(proto.Scan, proto.ScanArgs(proto.Key("a"), proto.Key("c")), acResp)
-  kv.Prepare(proto.Scan, proto.ScanArgs(proto.Key("x"), proto.Key("z")), xzResp)
+  kv.Prepare(proto.Scan, proto.ScanArgs(proto.Key("a"), proto.Key("c").Next()), acResp)
+  kv.Prepare(proto.Scan, proto.ScanArgs(proto.Key("x"), proto.Key("z").Next()), xzResp)
 
   // Flush sends both scans in parallel and returns first error or nil.
   if err := kv.Flush(); err != nil {


### PR DESCRIPTION
Trying to set a good example by closing the client object when we're done with it in the examples.

Omit setting the isolation level for the transaction, since Spencer said it was not necessary
in normal usage.

Also fixed the example code in the main documentation to work correctly.
