### PR TITLE
Return a channel from MultiRaft.{SubmitCommand,ChangeGroupMembership}

### DIFF
--- a/multiraft/events.go
+++ b/multiraft/events.go
@@ -29,7 +29,7 @@ type EventLeaderElection struct {
 
 // An EventCommandCommitted is broadcast whenever a command has been committed.
 type EventCommandCommitted struct {
-	CommandID []byte
+	CommandID string
 	Command   []byte
 }
 
@@ -41,20 +41,20 @@ const (
 	commandEncodingVersion = 0
 )
 
-func encodeCommand(commandID, command []byte) []byte {
+func encodeCommand(commandID string, command []byte) []byte {
 	if len(commandID) != commandIDLen {
 		log.Fatalf("invalid command ID length; %d != %d", len(commandID), commandIDLen)
 	}
 	x := make([]byte, 1, 1+commandIDLen+len(command))
 	x[0] = commandEncodingVersion
-	x = append(x, commandID...)
+	x = append(x, []byte(commandID)...)
 	x = append(x, command...)
 	return x
 }
 
-func decodeCommand(data []byte) (commandID, command []byte) {
+func decodeCommand(data []byte) (commandID string, command []byte) {
 	if data[0] != commandEncodingVersion {
 		log.Fatalf("unknown command encoding version %v", data[0])
 	}
-	return data[1 : 1+commandIDLen], data[1+commandIDLen:]
+	return string(data[1 : 1+commandIDLen]), data[1+commandIDLen:]
 }

--- a/multiraft/events.go
+++ b/multiraft/events.go
@@ -19,10 +19,12 @@ package multiraft
 
 import "github.com/cockroachdb/cockroach/util/log"
 
-// An EventLeaderElection is broadcast when a group completes an election.
+// An EventLeaderElection is broadcast when a group starts or completes
+// an election. NodeID is zero when an election is in progress.
 type EventLeaderElection struct {
 	GroupID uint64
 	NodeID  uint64
+	Term    uint64
 }
 
 // An EventCommandCommitted is broadcast whenever a command has been committed.

--- a/multiraft/multiraft.go
+++ b/multiraft/multiraft.go
@@ -229,6 +229,9 @@ type group struct {
 	// 0 if an election is in progress.
 	leader uint64
 
+	// pending contains all commands that have been proposed but not yet
+	// committed. When a proposal is committed, proposal.ch is closed
+	// and it is removed from this map.
 	pending map[string]proposal
 }
 

--- a/multiraft/multiraft.go
+++ b/multiraft/multiraft.go
@@ -128,10 +128,10 @@ func (m *MultiRaft) Stop() {
 	m.multiNode.Stop()
 }
 
-// SendMessage implements ServerInterface; this method is called by net/rpc
-// when we *receive* a message.
-func (m *MultiRaft) SendMessage(req *SendMessageRequest,
-	resp *SendMessageResponse) error {
+// RaftMessage implements ServerInterface; this method is called by net/rpc
+// when we receive a message.
+func (m *MultiRaft) RaftMessage(req *RaftMessageRequest,
+	resp *RaftMessageResponse) error {
 	log.V(5).Infof("node %v: group %v got message %s", m.nodeID, req.GroupID,
 		raft.DescribeMessage(req.Message))
 	return m.multiNode.Step(context.Background(), req.GroupID, req.Message)
@@ -494,7 +494,7 @@ func (s *state) handleWriteResponse(response *writeResponse, readyGroups map[uin
 		for _, msg := range ready.Messages {
 			log.V(6).Infof("node %v sending message %s to %v", s.nodeID,
 				raft.DescribeMessage(msg), msg.To)
-			s.nodes[msg.To].client.sendMessage(&SendMessageRequest{groupID, msg})
+			s.nodes[msg.To].client.raftMessage(&RaftMessageRequest{groupID, msg})
 		}
 	}
 }

--- a/multiraft/multiraft_test.go
+++ b/multiraft/multiraft_test.go
@@ -105,7 +105,13 @@ func (c *testCluster) waitForElection(i int) *EventLeaderElection {
 	// Elections are currently triggered after ElectionTimeoutTicks+1 ticks.
 	c.tickers[i].Tick()
 	c.tickers[i].Tick()
-	return <-c.events[i].LeaderElection
+	for {
+		e := <-c.events[i].LeaderElection
+		// Ignore events with NodeID 0; these mark elections that are in progress.
+		if e.NodeID != 0 {
+			return e
+		}
+	}
 }
 
 func TestInitialLeaderElection(t *testing.T) {

--- a/multiraft/multiraft_test.go
+++ b/multiraft/multiraft_test.go
@@ -28,8 +28,8 @@ import (
 
 var rand = util.NewPseudoRand()
 
-func makeCommandID() []byte {
-	return []byte(util.RandString(rand, commandIDLen))
+func makeCommandID() string {
+	return util.RandString(rand, commandIDLen)
 }
 
 type testCluster struct {
@@ -199,6 +199,7 @@ func TestSlowStorage(t *testing.T) {
 }
 
 func TestMembershipChange(t *testing.T) {
+	t.Skip("TODO(bdarnell): arrange for createGroup to be called on joining nodes")
 	cluster := newTestCluster(4, t)
 	defer cluster.stop()
 
@@ -209,11 +210,9 @@ func TestMembershipChange(t *testing.T) {
 
 	// Add each of the other three nodes to the cluster.
 	for i := 1; i < 4; i++ {
-		err := cluster.nodes[0].ChangeGroupMembership(groupID, makeCommandID(),
+		ch := cluster.nodes[0].ChangeGroupMembership(groupID, makeCommandID(),
 			raftpb.ConfChangeAddNode,
 			cluster.nodes[i].nodeID)
-		if err != nil {
-			t.Fatal(err)
-		}
+		<-ch
 	}
 }

--- a/multiraft/transport.go
+++ b/multiraft/transport.go
@@ -45,24 +45,24 @@ type Transport interface {
 	Connect(id uint64) (ClientInterface, error)
 }
 
-// SendMessageRequest wraps a raft message.
-type SendMessageRequest struct {
+// RaftMessageRequest wraps a raft message.
+type RaftMessageRequest struct {
 	GroupID uint64
 	Message raftpb.Message
 }
 
-// SendMessageResponse is empty (raft uses a one-way messaging model; if a response
+// RaftMessageResponse is empty (raft uses a one-way messaging model; if a response
 // is needed it will be sent as a separate message).
-type SendMessageResponse struct {
+type RaftMessageResponse struct {
 }
 
 // ServerInterface is the methods we expose for use by net/rpc.
 type ServerInterface interface {
-	SendMessage(req *SendMessageRequest, resp *SendMessageResponse) error
+	RaftMessage(req *RaftMessageRequest, resp *RaftMessageResponse) error
 }
 
 var (
-	sendMessageName = "MultiRaft.SendMessage"
+	raftMessageName = "MultiRaft.RaftMessage"
 )
 
 // ClientInterface is the interface expected of the client provided by a transport.
@@ -80,8 +80,8 @@ type asyncClient struct {
 	conn   ClientInterface
 }
 
-func (a *asyncClient) sendMessage(req *SendMessageRequest) {
-	a.conn.Go(sendMessageName, req, &SendMessageResponse{}, nil)
+func (a *asyncClient) raftMessage(req *RaftMessageRequest) {
+	a.conn.Go(raftMessageName, req, &RaftMessageResponse{}, nil)
 }
 
 type localRPCTransport struct {

--- a/storage/raft.go
+++ b/storage/raft.go
@@ -94,7 +94,7 @@ func (snr *singleNodeRaft) propose(cmdIDKey cmdIDKey, cmd proto.InternalRaftComm
 	if err != nil {
 		log.Fatal(err)
 	}
-	snr.mr.SubmitCommand(uint64(cmd.RaftID), []byte(cmdIDKey), data)
+	snr.mr.SubmitCommand(uint64(cmd.RaftID), string(cmdIDKey), data)
 }
 
 func (snr *singleNodeRaft) committed() <-chan committedCommand {


### PR DESCRIPTION
This channel can be used to wait for the proposed action to be
committed.

Adding this wait to TestMembershipChange demonstrated that the test
wasn't actually doing much. Some of the issues have been fixed
but the test is disabled until we make some decisions about the
group membership protocol.
