### PR TITLE
GC stats to compute likely GC'able bytes from elapsed time.

### DIFF
--- a/proto/data.go
+++ b/proto/data.go
@@ -24,6 +24,7 @@ import (
 	"math"
 	"math/rand"
 	"strings"
+	"time"
 
 	"code.google.com/p/biogo.store/interval"
 	"code.google.com/p/biogo.store/llrb"
@@ -450,4 +451,44 @@ func (t Transaction) String() string {
 // IsInline returns true if the value is inlined in the metadata.
 func (mvcc *MVCCMetadata) IsInline() bool {
 	return mvcc.Value != nil
+}
+
+// EstimatedBytes computes the estimated count of bytes which a GC run
+// is likely to free based on the current time, current non-live
+// bytes, and the details of the GCMetadata.
+//
+// The difference between the non-live bytes as recorded in GCMetadata
+// as of the last GC and the current non-live bytes are the newly
+// non-live bytes. These are prorated according to (elapsed fraction
+// of TTL - 1) to determine which portion, if any, of the newly
+// non-live bytes are likely to be GC'able.
+//
+// If the TTL changed between the last run and the current time, the
+// estimate will of course be inaccurate, but that's OK for the
+// purposes of deciding the priority of a range for GC.
+func (gc *GCMetadata) EstimatedBytes(now time.Time, currentNonLiveBytes int64) int64 {
+	elapsed := now.UnixNano() - gc.LastGCNanos
+	ttlNanos := int64(gc.TTLSeconds) * 1000000000
+	if elapsed < ttlNanos/10 || len(gc.ByteCounts) != 10 {
+		return 0
+	}
+	// Fraction of TTL we've advanced since last GC.
+	ttlFraction := float64(elapsed) / float64(ttlNanos)
+	// Compute index into the byte counts array. Think of this as: which
+	// fraction of TTL (e.g. <10%, <20%, ...) that bytes would already
+	// need to have been aged in order to be GC'able now.
+	index := 10 - int(ttlFraction*10)
+	if index < 0 {
+		index = 0
+	}
+	expGCBytes := gc.ByteCounts[index]
+
+	// If the ttlFraction is >= 1, prorate the fraction of current
+	// non-live bytes we might expect to GC.
+	if ttlFraction >= 1 {
+		newNonLiveBytes := currentNonLiveBytes - gc.ByteCounts[0]
+		return int64(((ttlFraction-1)/ttlFraction)*float64(newNonLiveBytes)) + expGCBytes
+	}
+	// Otherwise, just return the expGCBytes.
+	return expGCBytes
 }

--- a/proto/data.go
+++ b/proto/data.go
@@ -453,6 +453,14 @@ func (mvcc *MVCCMetadata) IsInline() bool {
 	return mvcc.Value != nil
 }
 
+// NewGCMetadata returns a GCMetadata with ByteCounts slice
+// initialized to ten byte count values set to zero.
+func NewGCMetadata() *GCMetadata {
+	return &GCMetadata{
+		ByteCounts: make([]int64, 10),
+	}
+}
+
 // EstimatedBytes computes the estimated count of bytes which a GC run
 // is likely to free based on the current time, current non-live
 // bytes, and the details of the GCMetadata.
@@ -469,7 +477,7 @@ func (mvcc *MVCCMetadata) IsInline() bool {
 func (gc *GCMetadata) EstimatedBytes(now time.Time, currentNonLiveBytes int64) int64 {
 	elapsed := now.UnixNano() - gc.LastGCNanos
 	ttlNanos := int64(gc.TTLSeconds) * 1000000000
-	if elapsed < ttlNanos/10 || len(gc.ByteCounts) != 10 {
+	if elapsed < ttlNanos/10 || len(gc.ByteCounts) != 10 || ttlNanos == 0 {
 		return 0
 	}
 	// Fraction of TTL we've advanced since last GC.

--- a/proto/data.proto
+++ b/proto/data.proto
@@ -185,3 +185,25 @@ message MVCCMetadata {
   // empty timestamp, key_bytes, and val_bytes.
   optional Value value = 6;
 }
+
+// GCMetadata holds stats describing the state of data on disk after a
+// garbage collection pass. These stats are used to prioritize system
+// GC passes and enable the scheduler to avoid GCing ranges which have
+// very little sufficiently aged data.
+message GCMetadata {
+  // The last GC timestamp in nanoseconds since the Unix epoch.
+  optional int64 last_gc_nanos = 1 [(gogoproto.nullable) = false, (gogoproto.customname) = "LastGCNanos"];
+  // The GC TTL for the range at last GC.
+  optional int32 ttl_seconds = 2 [(gogoproto.nullable) = false, (gogoproto.customname) = "TTLSeconds"];
+
+  // Byte_counts is an array of byte counts with 10 entries. Each array
+  // entry corresponds to the number of non-live (historical) bytes aged
+  // less than some fraction of the TTL. The first entry in the array
+  // is the number of bytes aged less than 10% of the TTL; the second,
+  // the number aged less than 20%; etc...
+  //
+  // These are values at last GC, so given the current time,
+  // last_gc_nanos, and ttl_seconds, the count of bytes to be GC'd can
+  // be estimated.
+  repeated int64 byte_counts = 3 [(gogoproto.nullable) = false];
+}


### PR DESCRIPTION
A GCMetadata record will be written after every GC scan of a range. That,
combined with the current non-live bytes count and current time can be
used to estimate the expected count of GC'able bytes.

This will allow us to avoid constantly scanning ranges which have had no
churn, while using the range stats as well as a detailed picture of the
aging bytes on last GC scan to prioritize ranges for GC.
