### PR TITLE
Log instead of panicking when ProposeRaftCommand called after shutdown.

### DIFF
--- a/storage/range_test.go
+++ b/storage/range_test.go
@@ -824,7 +824,7 @@ func TestRangeIdempotence(t *testing.T) {
 		select {
 		case <-done:
 			// Success.
-		case <-time.After(500 * time.Millisecond):
+		case <-time.After(1000 * time.Millisecond):
 			t.Fatal("had to wait for increment to complete")
 		}
 	}

--- a/storage/store.go
+++ b/storage/store.go
@@ -843,6 +843,10 @@ func (s *Store) ProposeRaftCommand(idKey cmdIDKey, cmd proto.InternalRaftCommand
 	s.mu.RLock()
 	defer s.mu.RUnlock()
 
+	if s.raft == nil {
+		log.Error("ignoring raft command proposed after shutdown")
+		return
+	}
 	s.raft.propose(idKey, cmd)
 }
 


### PR DESCRIPTION
When a test that uses goroutines fails, these goroutines may continue
to try to use the store after it is shut down. The panic occurs during a
subsequent test function and obscures the true cause of the failure.

This problem appears to occur most often with TestRangeIdempotence,
so I've increased its timeout.

Fixes #222.
