### PR TITLE
WIP: Raft Storage implementation.

### DIFF
--- a/kv/local_sender_test.go
+++ b/kv/local_sender_test.go
@@ -110,7 +110,10 @@ func splitTestRange(store *storage.Store, key, splitKey proto.Key, t *testing.T)
 	if err != nil {
 		t.Fatal(err)
 	}
-	newRng := storage.NewRange(desc, store)
+	newRng, err := storage.NewRange(desc, store)
+	if err != nil {
+		t.Fatal(err)
+	}
 	if err := store.SplitRange(rng, newRng); err != nil {
 		t.Fatal(err)
 	}
@@ -156,7 +159,10 @@ func TestLocalSenderLookupReplica(t *testing.T) {
 		if err != nil {
 			t.Fatal(err)
 		}
-		newRng := storage.NewRange(desc, s[i])
+		newRng, err := storage.NewRange(desc, s[i])
+		if err != nil {
+			t.Fatal(err)
+		}
 		if err := s[i].AddRange(newRng); err != nil {
 			t.Error(err)
 		}

--- a/multiraft/multiraft.go
+++ b/multiraft/multiraft.go
@@ -190,6 +190,9 @@ func (m *MultiRaft) RemoveGroup(groupID uint64) error {
 // SubmitCommand sends a command (a binary blob) to the cluster. This method returns
 // when the command has been successfully sent, not when it has been committed.
 // The returned channel is closed when the command is committed.
+// As long as this node is alive, the command will be retried until committed
+// (e.g. in the event of leader failover). There is no guarantee that commands will be
+// committed in the same order as they were originally submitted.
 func (m *MultiRaft) SubmitCommand(groupID uint64, commandID string, command []byte) chan struct{} {
 	log.V(6).Infof("node %v submitting command to group %v", m.nodeID, groupID)
 	ch := make(chan struct{})

--- a/multiraft/multiraft.go
+++ b/multiraft/multiraft.go
@@ -389,7 +389,16 @@ func (s *state) createGroup(op *createGroupOp) {
 	}
 	log.V(6).Infof("node %v creating group %v", s.nodeID, op.groupID)
 
-	s.multiNode.CreateGroup(op.groupID, nil, s.Storage.GroupStorage(op.groupID))
+	gs := s.Storage.GroupStorage(op.groupID)
+	_, cs, err := gs.InitialState()
+	if err != nil {
+		op.ch <- err
+	}
+	for _, nodeID := range cs.Nodes {
+		s.addNode(nodeID)
+	}
+
+	s.multiNode.CreateGroup(op.groupID, nil, gs)
 	s.groups[op.groupID] = &group{
 		pending: map[string]proposal{},
 	}

--- a/multiraft/multiraft_test.go
+++ b/multiraft/multiraft_test.go
@@ -191,6 +191,7 @@ func TestSlowStorage(t *testing.T) {
 
 	// After unblocking the third node, it will catch up.
 	cluster.storages[2].Unblock()
+	cluster.tickers[0].Tick()
 	log.Infof("waiting for event to be commited on node 2")
 	commit := <-cluster.events[2].CommandCommitted
 	if string(commit.Command) != "command" {

--- a/multiraft/storage.go
+++ b/multiraft/storage.go
@@ -145,6 +145,10 @@ func (w *writeTask) start() {
 
 		for groupID, groupReq := range request.groups {
 			group := w.storage.GroupStorage(groupID)
+			if group == nil {
+				log.V(4).Infof("dropping write to group %v", groupID)
+				continue
+			}
 			groupResp := &groupWriteResponse{raftpb.HardState{}, -1, -1, groupReq.entries}
 			response.groups[groupID] = groupResp
 			if !raft.IsEmptyHardState(groupReq.state) {

--- a/multiraft/storage_test.go
+++ b/multiraft/storage_test.go
@@ -6,7 +6,6 @@ package multiraft
 import (
 	"sync"
 
-	"github.com/coreos/etcd/raft"
 	"github.com/coreos/etcd/raft/raftpb"
 )
 
@@ -34,11 +33,6 @@ func (b *BlockableStorage) Block() {
 // Unblock undoes the effect of Block() and allows blocked operations to proceed.
 func (b *BlockableStorage) Unblock() {
 	b.mu.Unlock()
-}
-
-func (b *BlockableStorage) LoadGroups() map[uint64]raft.Storage {
-	b.wait()
-	return b.storage.LoadGroups()
 }
 
 func (b *BlockableStorage) GroupStorage(g uint64) WriteableGroupStorage {

--- a/multiraft/storagetest/memorystorage_test.go
+++ b/multiraft/storagetest/memorystorage_test.go
@@ -1,0 +1,26 @@
+// Copyright 2014 Square, Inc
+// Author: Ben Darnell (bdarnell@)
+
+package storagetest
+
+import (
+	"testing"
+
+	"github.com/coreos/etcd/raft"
+
+	// TODO(bdarnell): this is necessary to run this test with cockroach's "make test";
+	// remove it when moving to coreos repo.
+	_ "github.com/cockroachdb/cockroach/util/log"
+)
+
+func setUp(*testing.T) WriteableStorage {
+	return raft.NewMemoryStorage()
+}
+
+func tearDown(*testing.T, WriteableStorage) {
+}
+
+// TestMemoryStorage runs the storage tests on raft.MemoryStorage.
+func TestMemoryStorage(t *testing.T) {
+	RunTests(t, setUp, tearDown)
+}

--- a/multiraft/storagetest/storagetest.go
+++ b/multiraft/storagetest/storagetest.go
@@ -1,0 +1,89 @@
+// Copyright 2014 Square, Inc
+// Author: Ben Darnell (bdarnell@)
+
+/*
+Package storagetest is a test suite for raft.Storage implementations.
+
+The otherwise read-only storage interface is augmented with write
+methods for use in the tests.
+*/
+package storagetest
+
+import (
+	"testing"
+
+	"github.com/coreos/etcd/raft"
+	"github.com/coreos/etcd/raft/raftpb"
+)
+
+type testFunc func(*testing.T, WriteableStorage)
+
+var testFuncs = []testFunc{
+	testEmptyLog,
+}
+
+// WriteableStorage is a raft.Storage with some additional write methods
+// for testing.
+type WriteableStorage interface {
+	raft.Storage
+	Append(entries []raftpb.Entry) error
+	SetHardState(st raftpb.HardState) error
+}
+
+// RunTests runs the test suite. The setUp and tearDown functions will be called
+// at the beginning and end of each test case.
+func RunTests(t *testing.T, setUp func(*testing.T) WriteableStorage,
+	tearDown func(*testing.T, WriteableStorage)) {
+	for _, f := range testFuncs {
+		// Use a nested function to create an inline defer scope.
+		func() {
+			s := setUp(t)
+			defer tearDown(t, s)
+			f(t, s)
+		}()
+	}
+}
+
+// testEmptyLog calls all the read methods on an empty log and verifies the expected
+// state.
+func testEmptyLog(t *testing.T, s WriteableStorage) {
+	hs, _, err := s.InitialState()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !raft.IsEmptyHardState(hs) {
+		t.Errorf("expected empty HardState, got %v", hs)
+	}
+
+	ents, err := s.Entries(1, 2)
+	if err != raft.ErrUnavailable {
+		t.Errorf("expected ErrUnavailable, got %v, %v", ents, err)
+	}
+
+	term, err := s.Term(0)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if term != 0 {
+		t.Errorf("expected Term(0) to be 0, got %d", term)
+	}
+
+	// FirstIndex starts at 1; LastIndex starts at 0.
+	// This is because both indices are inclusive so
+	// len == 1 + last - first
+	firstIndex, err := s.FirstIndex()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if firstIndex != 1 {
+		t.Errorf("expected FirstIndex to be 1, got %d", firstIndex)
+	}
+
+	lastIndex, err := s.LastIndex()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if lastIndex != 0 {
+		t.Errorf("expected LastIndex to be 0, got %d", lastIndex)
+	}
+}

--- a/multiraft/transport.go
+++ b/multiraft/transport.go
@@ -113,6 +113,9 @@ func (lt *localRPCTransport) Listen(id uint64, server ServerInterface) error {
 	}
 
 	lt.mu.Lock()
+	if _, ok := lt.listeners[id]; ok {
+		log.Fatalf("node %d already listening", id)
+	}
 	lt.listeners[id] = listener
 	lt.mu.Unlock()
 	go lt.accept(rpcServer, listener)

--- a/storage/engine/engine.go
+++ b/storage/engine/engine.go
@@ -81,7 +81,8 @@ type Engine interface {
 	// Iterate scans from start to end keys, visiting at most max
 	// key/value pairs. On each key value pair, the function f is
 	// invoked. If f returns an error or if the scan itself encounters
-	// an error, the iteration will stop and return f.
+	// an error, the iteration will stop and return the error.
+	// If the first result of f is true, the iteration stops.
 	Iterate(start, end proto.EncodedKey, f func(proto.RawKeyValue) (bool, error)) error
 	// Clear removes the item from the db with the given key.
 	// Note that clear actually removes entries from the storage

--- a/storage/engine/keys.go
+++ b/storage/engine/keys.go
@@ -23,6 +23,7 @@ import (
 	"fmt"
 
 	"github.com/cockroachdb/cockroach/proto"
+	"github.com/cockroachdb/cockroach/util/encoding"
 	"github.com/cockroachdb/cockroach/util/log"
 )
 
@@ -130,6 +131,35 @@ func ValidateRangeMetaKey(key proto.Key) error {
 	return nil
 }
 
+// RaftLogKey returns a system-local key for a raft log entry.
+func RaftLogKey(raftID, logIndex uint64) proto.Key {
+	b := MakeLocalKey(KeyLocalRaftLogPrefix)
+	b = encoding.EncodeUint64(b, raftID)
+	// The log is stored "backwards" so we can easily find the highest index stored.
+	b = encoding.EncodeUint64Decreasing(b, logIndex)
+	return b
+}
+
+// RaftLogPrefix returns the system-local prefix shared by all entries in a raft log.
+func RaftLogPrefix(raftID uint64) proto.Key {
+	b := MakeLocalKey(KeyLocalRaftLogPrefix)
+	b = encoding.EncodeUint64(b, raftID)
+	return b
+}
+
+// RaftStateKey returns a system-local key for a raft HardState.
+func RaftStateKey(raftID uint64) proto.Key {
+	b := MakeLocalKey(KeyLocalRaftStatePrefix)
+	b = encoding.EncodeUint64(b, raftID)
+	return b
+}
+
+// DecodeRaftStateKey extracts the raft ID from a RaftStateKey.
+func DecodeRaftStateKey(k proto.Key) uint64 {
+	_, raftID := encoding.DecodeUint64(k[len(KeyLocalRaftStatePrefix):])
+	return raftID
+}
+
 func init() {
 	if KeyLocalPrefixLength%7 != 0 {
 		log.Fatalf("local key prefix is not a multiple of 7: %d", KeyLocalPrefixLength)
@@ -199,6 +229,10 @@ var (
 	// KeyLocalSnapshotIDGenerator is a snapshot ID generator sequence.
 	// Snapshot IDs must be unique per store ID.
 	KeyLocalSnapshotIDGenerator = MakeKey(KeyLocalPrefix, proto.Key("ssid"))
+	// KeyLocalRaftLogPrefix is the prefix for the raft log.
+	KeyLocalRaftLogPrefix = MakeKey(KeyLocalPrefix, proto.Key("rftl"))
+	// KeyLocalRaftStatePrefix is the prefix for the raft HardState.
+	KeyLocalRaftStatePrefix = MakeKey(KeyLocalPrefix, proto.Key("rfts"))
 
 	// KeyLocalMax is the end of the local key range.
 	KeyLocalMax = KeyLocalPrefix.PrefixEnd()

--- a/storage/engine/keys.go
+++ b/storage/engine/keys.go
@@ -133,8 +133,7 @@ func ValidateRangeMetaKey(key proto.Key) error {
 
 // RaftLogKey returns a system-local key for a raft log entry.
 func RaftLogKey(raftID, logIndex uint64) proto.Key {
-	b := MakeLocalKey(KeyLocalRaftLogPrefix)
-	b = encoding.EncodeUint64(b, raftID)
+	b := RaftLogPrefix(raftID)
 	// The log is stored "backwards" so we can easily find the highest index stored.
 	b = encoding.EncodeUint64Decreasing(b, logIndex)
 	return b

--- a/storage/raft.go
+++ b/storage/raft.go
@@ -38,6 +38,8 @@ type raftInterface interface {
 	// createGroup initializes a raft group with the given id.
 	createGroup(int64) error
 
+	removeGroup(int64) error
+
 	// restoreGroup informs raft of an existing group with on-disk state.
 	restoreGroup(int64) error
 
@@ -90,6 +92,14 @@ func (snr *singleNodeRaft) createGroup(id int64) error {
 	if _, ok := snr.groups[id]; !ok {
 		snr.groups[id] = struct{}{}
 		return snr.mr.CreateGroup(uint64(id), []uint64{1})
+	}
+	return nil
+}
+
+func (snr *singleNodeRaft) removeGroup(id int64) error {
+	if _, ok := snr.groups[id]; ok {
+		delete(snr.groups, id)
+		return snr.mr.RemoveGroup(uint64(id))
 	}
 	return nil
 }

--- a/storage/raft.go
+++ b/storage/raft.go
@@ -93,7 +93,7 @@ func (snr *singleNodeRaft) createGroup(id int64) error {
 	if _, ok := snr.groups[id]; !ok {
 		snr.groups[id] = struct{}{}
 		snr.mu.Unlock()
-		return snr.mr.CreateGroup(uint64(id), []uint64{1})
+		return snr.mr.CreateGroup(uint64(id))
 	}
 	snr.mu.Unlock()
 	return nil
@@ -115,12 +115,7 @@ func (snr *singleNodeRaft) restoreGroup(id int64) error {
 	if _, ok := snr.groups[id]; !ok {
 		snr.groups[id] = struct{}{}
 		snr.mu.Unlock()
-		// TODO(bdarnell): don't create initial members here.
-		// restoreGroup is to be used when there is already state on disk,
-		// but we don't get the magic pre-commit behavior if we don't pass
-		// in members here. I think this should change to always start from a
-		// constructed snapshot.
-		return snr.mr.CreateGroup(uint64(id), []uint64{1})
+		return snr.mr.CreateGroup(uint64(id))
 	}
 	snr.mu.Unlock()
 	return nil

--- a/storage/range.go
+++ b/storage/range.go
@@ -1422,16 +1422,13 @@ func (r *Range) InitialState() (raftpb.HardState, raftpb.ConfState, error) {
 		Vote:   raft.None,
 		Commit: raftInitialLogIndex,
 	}
-	cs := raftpb.ConfState{}
+	cs := raftpb.ConfState{
+		Nodes: []uint64{1},
+	}
 	_, err := engine.MVCCGetProto(r.rm.Engine(), engine.RaftStateKey(uint64(r.Desc.RaftID)),
 		proto.ZeroTimestamp, nil, &hs)
 	if err != nil {
 		return hs, cs, err
-	}
-
-	for _, rep := range r.Desc.Replicas {
-		// TODO(bdarnell): encode rep.NodeID and rep.StoreID into the raft NodeID.
-		cs.Nodes = append(cs.Nodes, uint64(rep.NodeID))
 	}
 
 	return hs, cs, nil

--- a/storage/range_test.go
+++ b/storage/range_test.go
@@ -50,11 +50,6 @@ var (
 				StoreID: 1,
 				Attrs:   proto.Attributes{Attrs: []string{"dc1", "mem"}},
 			},
-			{
-				NodeID:  2,
-				StoreID: 2,
-				Attrs:   proto.Attributes{Attrs: []string{"dc2", "mem"}},
-			},
 		},
 	}
 	testDefaultAcctConfig = proto.AcctConfig{}

--- a/storage/range_test.go
+++ b/storage/range_test.go
@@ -20,6 +20,7 @@ package storage
 import (
 	"bytes"
 	"fmt"
+	"math/rand"
 	"reflect"
 	"regexp"
 	"sync"
@@ -1559,7 +1560,10 @@ func TestRemoteRaftCommand(t *testing.T) {
 	// Send an increment direct to raft.
 	remoteIncArgs, _ := incrementArgs([]byte("a"), 2, 1, s.StoreID())
 	remoteIncArgs.Timestamp = proto.MinTimestamp
-	idKey := makeCmdIDKey(proto.ClientCmdID{WallTime: 1, Random: 1})
+	idKey := makeCmdIDKey(proto.ClientCmdID{
+		WallTime: s.Clock().PhysicalNow(),
+		Random:   rand.Int63(),
+	})
 	raftCmd := proto.InternalRaftCommand{
 		RaftID: r.Desc.RaftID,
 	}

--- a/storage/store.go
+++ b/storage/store.go
@@ -30,6 +30,7 @@ import (
 	gogoproto "code.google.com/p/gogoprotobuf/proto"
 	"github.com/cockroachdb/cockroach/client"
 	"github.com/cockroachdb/cockroach/gossip"
+	"github.com/cockroachdb/cockroach/multiraft"
 	"github.com/cockroachdb/cockroach/proto"
 	"github.com/cockroachdb/cockroach/storage/engine"
 	"github.com/cockroachdb/cockroach/util"
@@ -230,13 +231,15 @@ type Store struct {
 	gossip      *gossip.Gossip // Configs and store capacities
 	raftIDAlloc *IDAllocator   // Raft ID allocator
 	configMu    sync.Mutex     // Limit config update processing
-	raft        raft
+	raft        raftInterface
 	closer      chan struct{}
 
 	mu          sync.RWMutex     // Protects variables below...
 	ranges      map[int64]*Range // Map of ranges by Raft ID
 	rangesByKey RangeSlice       // Sorted slice of ranges by StartKey
 }
+
+var _ multiraft.Storage = &Store{}
 
 // NewStore returns a new instance of a store.
 func NewStore(clock *hlc.Clock, eng engine.Engine, db *client.KV, gossip *gossip.Gossip) *Store {
@@ -258,11 +261,16 @@ func NewStore(clock *hlc.Clock, eng engine.Engine, db *client.KV, gossip *gossip
 // Stop calls Range.Stop() on all active ranges.
 func (s *Store) Stop() {
 	s.mu.Lock()
-	defer s.mu.Unlock()
-	if s.raft != nil {
-		s.raft.stop()
-		s.raft = nil
+	r := s.raft
+	s.mu.Unlock()
+	if r != nil {
+		// Must be called while unlocked.
+		r.stop()
 	}
+
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.raft = nil
 	for _, rng := range s.ranges {
 		rng.stop()
 	}
@@ -306,10 +314,12 @@ func (s *Store) Start() error {
 		return &NotBootstrappedError{}
 	}
 
-	s.mu.Lock()
-	defer s.mu.Unlock()
 	start := engine.KeyLocalRangeDescriptorPrefix
 	end := start.PrefixEnd()
+
+	s.raft = newSingleNodeRaft(s)
+	// Start Raft processing goroutine.
+	go s.processRaft(s.raft, s.closer)
 
 	// Iterate over all range descriptors, using just committed
 	// versions. Uncommitted intents which have been abandoned due to a
@@ -320,8 +330,17 @@ func (s *Store) Start() error {
 		if err := gogoproto.Unmarshal(kv.Value.Bytes, &desc); err != nil {
 			return false, err
 		}
-		rng := NewRange(&desc, s)
-		if err := s.addRangeInternal(rng, false /* don't sort on each addition */); err != nil {
+		rng, err := NewRange(&desc, s)
+		if err != nil {
+			return false, err
+		}
+		s.mu.Lock()
+		err = s.addRangeInternal(rng, false /* don't sort on each addition */)
+		s.mu.Unlock()
+		if err != nil {
+			return false, err
+		}
+		if err = s.raft.restoreGroup(rng.Desc.RaftID); err != nil {
 			return false, err
 		}
 		return false, nil
@@ -330,11 +349,6 @@ func (s *Store) Start() error {
 	}
 	// Sort the rangesByKey slice after they've all been added.
 	sort.Sort(s.rangesByKey)
-
-	s.raft = newSingleNodeRaft()
-
-	// Start Raft processing goroutine.
-	go s.processRaft(s.raft, s.closer)
 
 	// Register callbacks for any changes to accounting and zone
 	// configurations; we split ranges along prefix boundaries.
@@ -597,17 +611,31 @@ func (s *Store) SplitRange(origRng, newRng *Range) error {
 	// within a command execution, Desc.EndKey is protected from other
 	// concurrent range accesses.
 	s.mu.Lock()
-	defer s.mu.Unlock()
 	origRng.Desc.EndKey = append([]byte(nil), newRng.Desc.StartKey...)
-	return s.addRangeInternal(newRng, true)
+	err := s.addRangeInternal(newRng, true)
+	s.mu.Unlock()
+	if err != nil {
+		return err
+	}
+	if err := s.raft.createGroup(newRng.Desc.RaftID); err != nil {
+		return err
+	}
+	return nil
 }
 
 // AddRange adds the range to the store's range map and to the sorted
 // rangesByKey slice.
 func (s *Store) AddRange(rng *Range) error {
 	s.mu.Lock()
-	defer s.mu.Unlock()
-	return s.addRangeInternal(rng, true)
+	err := s.addRangeInternal(rng, true)
+	s.mu.Unlock()
+	if err != nil {
+		return err
+	}
+	if err := s.raft.createGroup(rng.Desc.RaftID); err != nil {
+		return err
+	}
+	return nil
 }
 
 // addRangeInternal starts the range and adds it to the ranges map and
@@ -872,7 +900,7 @@ func (s *Store) ProposeRaftCommand(idKey cmdIDKey, cmd proto.InternalRaftCommand
 //
 // TODO(bdarnell): remove the closer argument and access s.closer directly
 // when we no longer reassign s.closer in s.Stop.
-func (s *Store) processRaft(r raft, closer chan struct{}) {
+func (s *Store) processRaft(r raftInterface, closer chan struct{}) {
 	for {
 		select {
 		case raftCmd := <-r.committed():
@@ -890,4 +918,15 @@ func (s *Store) processRaft(r raft, closer chan struct{}) {
 			return
 		}
 	}
+}
+
+// GroupStorage implements the multiraft.Storage interface.
+func (s *Store) GroupStorage(groupID uint64) multiraft.WriteableGroupStorage {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	r, ok := s.ranges[int64(groupID)]
+	if !ok {
+		log.Warningf("%p requested nonexistent range with raft ID %d", s, groupID)
+	}
+	return r
 }

--- a/storage/store.go
+++ b/storage/store.go
@@ -664,6 +664,9 @@ func (s *Store) addRangeInternal(rng *Range, resort bool) error {
 func (s *Store) RemoveRange(rng *Range) error {
 	s.mu.Lock()
 	defer s.mu.Unlock()
+	if err := s.raft.removeGroup(rng.Desc.RaftID); err != nil {
+		return err
+	}
 	rng.stop()
 	delete(s.ranges, rng.Desc.RaftID)
 	// Find the range in rangesByKey slice and swap it to end of slice
@@ -927,6 +930,7 @@ func (s *Store) GroupStorage(groupID uint64) multiraft.WriteableGroupStorage {
 	r, ok := s.ranges[int64(groupID)]
 	if !ok {
 		log.Warningf("%p requested nonexistent range with raft ID %d", s, groupID)
+		return nil
 	}
 	return r
 }

--- a/storage/store_test.go
+++ b/storage/store_test.go
@@ -228,7 +228,15 @@ func TestStoreAddRemoveRanges(t *testing.T) {
 	if err := store.AddRange(rng2); err != nil {
 		t.Fatal(err)
 	}
-	// Try to add a range with preexisting ID.
+	// Try to add the same range twice
+	err = store.AddRange(rng2)
+	if err == nil {
+		t.Fatal("expected error re-adding same range")
+	}
+	if _, ok := err.(*rangeAlreadyExists); !ok {
+		t.Fatalf("expected rangeAlreadyExists error; got %s", err)
+	}
+	// Try to add a range with previously-used (but now removed) ID.
 	rng2Dup := createRange(store, 1, proto.Key("a"), proto.Key("b"))
 	if err := store.AddRange(rng2Dup); err != nil {
 		t.Fatal(err)

--- a/storage/store_test.go
+++ b/storage/store_test.go
@@ -22,6 +22,7 @@ package storage
 import (
 	"bytes"
 	"fmt"
+	"log"
 	"math"
 	"sort"
 	"testing"
@@ -200,7 +201,11 @@ func createRange(s *Store, raftID int64, start, end proto.Key) *Range {
 		StartKey: start,
 		EndKey:   end,
 	}
-	return NewRange(desc, s)
+	r, err := NewRange(desc, s)
+	if err != nil {
+		log.Fatal(err)
+	}
+	return r
 }
 
 func TestStoreAddRemoveRanges(t *testing.T) {
@@ -210,24 +215,24 @@ func TestStoreAddRemoveRanges(t *testing.T) {
 		t.Error("expected GetRange to fail on missing range")
 	}
 	// Range 1 already exists. Make sure we can fetch it.
-	rng1, err := store.GetRange(1)
+	/*rng1*/ _, err := store.GetRange(1)
 	if err != nil {
 		t.Error(err)
 	}
 	// Remove range 1.
-	if err := store.RemoveRange(rng1); err != nil {
+	/*if err := store.RemoveRange(rng1); err != nil {
 		t.Error(err)
-	}
+	}*/
 	// Create a new range (id=2).
 	rng2 := createRange(store, 2, proto.Key("a"), proto.Key("b"))
 	if err := store.AddRange(rng2); err != nil {
 		t.Fatal(err)
 	}
 	// Try to add a range with preexisting ID.
-	rng2Dup := createRange(store, 1, proto.Key("a"), proto.Key("b"))
+	/*rng2Dup := createRange(store, 1, proto.Key("a"), proto.Key("b"))
 	if err := store.AddRange(rng2Dup); err != nil {
 		t.Fatal(err)
-	}
+	}*/
 	// Add another range with different key range and then test lookup.
 	rng3 := createRange(store, 3, proto.Key("c"), proto.Key("d"))
 	if err := store.AddRange(rng3); err != nil {
@@ -473,8 +478,11 @@ func splitTestRange(store *Store, key, splitKey proto.Key, t *testing.T) *Range 
 	if err != nil {
 		t.Fatal(err)
 	}
-	newRng := NewRange(desc, store)
-	if err := store.SplitRange(rng, newRng); err != nil {
+	newRng, err := NewRange(desc, store)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err = store.SplitRange(rng, newRng); err != nil {
 		t.Fatal(err)
 	}
 	return newRng

--- a/storage/store_test.go
+++ b/storage/store_test.go
@@ -215,24 +215,24 @@ func TestStoreAddRemoveRanges(t *testing.T) {
 		t.Error("expected GetRange to fail on missing range")
 	}
 	// Range 1 already exists. Make sure we can fetch it.
-	/*rng1*/ _, err := store.GetRange(1)
+	rng1, err := store.GetRange(1)
 	if err != nil {
 		t.Error(err)
 	}
 	// Remove range 1.
-	/*if err := store.RemoveRange(rng1); err != nil {
+	if err := store.RemoveRange(rng1); err != nil {
 		t.Error(err)
-	}*/
+	}
 	// Create a new range (id=2).
 	rng2 := createRange(store, 2, proto.Key("a"), proto.Key("b"))
 	if err := store.AddRange(rng2); err != nil {
 		t.Fatal(err)
 	}
 	// Try to add a range with preexisting ID.
-	/*rng2Dup := createRange(store, 1, proto.Key("a"), proto.Key("b"))
+	rng2Dup := createRange(store, 1, proto.Key("a"), proto.Key("b"))
 	if err := store.AddRange(rng2Dup); err != nil {
 		t.Fatal(err)
-	}*/
+	}
 	// Add another range with different key range and then test lookup.
 	rng3 := createRange(store, 3, proto.Key("c"), proto.Key("d"))
 	if err := store.AddRange(rng3); err != nil {


### PR DESCRIPTION
[I'm sending this out even though it's incomplete in case anyone wants to pick it up while I'm out]

storage.Store now implements the multiraft.Storage interface, and
storage.Range implements raft.Storage.

This change is not ready to merge; the tests are still failing.  The
failures appear to mostly relate to the bootstrapping of the group
members. I think the solution is to construct an initial snapshot
instead of bootstrapping by appending to the log.

More details:
- storage.NewRange now reads the current raft log position, so it can
  return an error.
- Converted to two-phase util.Stoppers in several places.
- Locking of Store.mu is somewhat delicate; raft operations cannot be
  performed while this lock is held.
- multiraft.storage.LoadGroups is gone; we can't have raft initialize
  itself independent of the application.
- Made a small tweak to the RPC interface to reduce log spam.
- All pending proposals are now re-submitted on leader elections.
- Added the beginnings of a raft.Storage test suite; this will be moved
  into the etcd repo when it has stabilized.
- Range removal is not yet implemented.

@spencerkimball @cockroachdb/developers 
