### PR TITLE
Move proto.Transaction to a separation between Key and ID.

### DIFF
--- a/client/txn_sender_test.go
+++ b/client/txn_sender_test.go
@@ -26,7 +26,8 @@ import (
 )
 
 var (
-	txnID = append([]byte("test-txn"), []byte(uuid.New())...)
+	txnKey = proto.Key("test-txn")
+	txnID  = []byte(uuid.New())
 )
 
 func makeTS(walltime int64, logical int32) proto.Timestamp {
@@ -50,6 +51,7 @@ func (ts *testSender) Send(call *Call) {
 	header := call.Args.Header()
 	header.UserPriority = gogoproto.Int32(-1)
 	if header.Txn != nil && len(header.Txn.ID) == 0 {
+		header.Txn.Key = txnKey
 		header.Txn.ID = txnID
 	}
 	call.Reply.Reset()

--- a/proto/data.go
+++ b/proto/data.go
@@ -352,7 +352,8 @@ func NewTransaction(name string, baseKey Key, userPriority int32,
 
 	return &Transaction{
 		Name:          name,
-		ID:            append(append([]byte(nil), baseKey...), []byte(uuid.New())...),
+		Key:           baseKey,
+		ID:            []byte(uuid.New()),
 		Priority:      priority,
 		Isolation:     isolation,
 		Timestamp:     now,
@@ -455,8 +456,8 @@ func (t *Transaction) UpgradePriority(minPriority int32) {
 	}
 }
 
-// MD5 returns the MD5 digest of the transaction ID as a string.
-// This method returns an empty string if the transaction is nil.
+// MD5 returns the MD5 digest of the transaction ID. This method
+// returns an empty string if the transaction is nil.
 func (t *Transaction) MD5() [md5.Size]byte {
 	if t == nil {
 		return NoTxnMD5

--- a/proto/data.proto
+++ b/proto/data.proto
@@ -150,28 +150,34 @@ message Transaction {
   option (gogoproto.goproto_stringer) = false;
 
   optional string name = 1 [(gogoproto.nullable) = false];
-  optional bytes id = 2 [(gogoproto.nullable) = false, (gogoproto.customname) = "ID"];
-  optional int32 priority = 3 [(gogoproto.nullable) = false];
-  optional IsolationType isolation = 4 [(gogoproto.nullable) = false];
-  optional TransactionStatus status = 5 [(gogoproto.nullable) = false];
+  // Key is the key which anchors the transaction. This is typically
+  // the first key read or written during the transaction and
+  // determines which range in the cluster will hold the transaction
+  // record.
+  optional bytes key = 2 [(gogoproto.nullable) = false, (gogoproto.customtype) = "Key"];
+  // ID is a unique UUID value which identifies the transaction.
+  optional bytes id = 3 [(gogoproto.nullable) = false, (gogoproto.customname) = "ID"];
+  optional int32 priority = 4 [(gogoproto.nullable) = false];
+  optional IsolationType isolation = 5 [(gogoproto.nullable) = false];
+  optional TransactionStatus status = 6 [(gogoproto.nullable) = false];
   // Incremented on txn retry.
-  optional int32 epoch = 6 [(gogoproto.nullable) = false];
+  optional int32 epoch = 7 [(gogoproto.nullable) = false];
   // The last heartbeat timestamp.
-  optional Timestamp last_heartbeat = 7;
+  optional Timestamp last_heartbeat = 8;
   // The proposed timestamp for the transaction. This starts as
   // the current wall time on the txn coordinator.
-  optional Timestamp timestamp = 8 [(gogoproto.nullable) = false];
+  optional Timestamp timestamp = 9 [(gogoproto.nullable) = false];
   // The original timestamp at which the transaction started. For serializable
   // transactions, if the timestamp drifts from the original timestamp, the
   // transaction will retry.
-  optional Timestamp orig_timestamp = 9 [(gogoproto.nullable) = false];
+  optional Timestamp orig_timestamp = 10 [(gogoproto.nullable) = false];
   // Initial Timestamp + clock skew. Reads which encounter values with
   // timestamps between Timestamp and MaxTimestamp trigger a txn
   // retry error, unless the node being read is listed in nodes_read
   // (in which case no more read uncertainty can occur).
   // The case MaxTimestamp < Timestamp is possible for transactions which have
   // been pushed; in this case, MaxTimestamp should be ignored.
-  optional Timestamp max_timestamp = 10 [(gogoproto.nullable) = false];
+  optional Timestamp max_timestamp = 11 [(gogoproto.nullable) = false];
   // A sorted list of ids of nodes for which a ReadWithinUncertaintyIntervalError
   // occurred during a prior read. The purpose of keeping this information is
   // that as a reaction to this error, the transaction's timestamp is forwarded
@@ -190,7 +196,7 @@ message Transaction {
   // Bits of this mechanism are found in the local sender, the range and the
   // txn_coord_sender, with brief comments referring here.
   // See https://github.com/cockroachdb/cockroach/pull/221.
-  optional NodeList certain_nodes = 11 [(gogoproto.nullable) = false];
+  optional NodeList certain_nodes = 12 [(gogoproto.nullable) = false];
 }
 
 // MVCCMetadata holds MVCC metadata for a key. Used by storage/engine/mvcc.go.

--- a/storage/range_test.go
+++ b/storage/range_test.go
@@ -440,7 +440,7 @@ func endTxnArgs(txn *proto.Transaction, commit bool, raftID int64, storeID int32
 	*proto.EndTransactionRequest, *proto.EndTransactionResponse) {
 	args := &proto.EndTransactionRequest{
 		RequestHeader: proto.RequestHeader{
-			Key:     txn.ID,
+			Key:     txn.Key,
 			RaftID:  raftID,
 			Replica: proto.Replica{StoreID: storeID},
 			Txn:     txn,
@@ -457,7 +457,7 @@ func pushTxnArgs(pusher, pushee *proto.Transaction, abort bool, raftID int64, st
 	*proto.InternalPushTxnRequest, *proto.InternalPushTxnResponse) {
 	args := &proto.InternalPushTxnRequest{
 		RequestHeader: proto.RequestHeader{
-			Key:       pushee.ID,
+			Key:       pushee.Key,
 			Timestamp: pusher.Timestamp,
 			RaftID:    raftID,
 			Replica:   proto.Replica{StoreID: storeID},
@@ -475,7 +475,7 @@ func heartbeatArgs(txn *proto.Transaction, raftID int64, storeID int32) (
 	*proto.InternalHeartbeatTxnRequest, *proto.InternalHeartbeatTxnResponse) {
 	args := &proto.InternalHeartbeatTxnRequest{
 		RequestHeader: proto.RequestHeader{
-			Key:     txn.ID,
+			Key:     txn.Key,
 			RaftID:  raftID,
 			Replica: proto.Replica{StoreID: storeID},
 			Txn:     txn,
@@ -1125,17 +1125,17 @@ func TestEndTransactionWithErrors(t *testing.T) {
 		// Establish existing txn state by writing directly to range engine.
 		var existTxn proto.Transaction
 		gogoproto.Merge(&existTxn, txn)
-		existTxn.ID = test.key
+		existTxn.Key = test.key
 		existTxn.Status = test.existStatus
 		existTxn.Epoch = test.existEpoch
 		existTxn.Timestamp = test.existTS
-		txnKey := engine.MakeKey(engine.KeyLocalTransactionPrefix, test.key)
+		txnKey := engine.MakeKey(engine.KeyLocalTransactionPrefix, test.key, txn.ID)
 		if err := engine.MVCCPutProto(rng.rm.Engine(), nil, txnKey, proto.ZeroTimestamp, nil, &existTxn); err != nil {
 			t.Fatal(err)
 		}
 
 		// End the transaction, verify expected error.
-		txn.ID = test.key
+		txn.Key = test.key
 		args, reply := endTxnArgs(txn, true, 1, s.StoreID())
 		args.Timestamp = txn.Timestamp
 		verifyErrorMatches(rng.AddCmd(proto.EndTransaction, args, reply, true), test.expErrRegexp, t)
@@ -1151,7 +1151,7 @@ func TestInternalPushTxnBadKey(t *testing.T) {
 	pushee := newTransaction("test", proto.Key("b"), 1, proto.SERIALIZABLE, clock)
 
 	args, reply := pushTxnArgs(pusher, pushee, true, 1, s.StoreID())
-	args.Key = pusher.ID
+	args.Key = pusher.Key
 	verifyErrorMatches(rng.AddCmd(proto.InternalPushTxn, args, reply, true), ".*should match pushee.*", t)
 }
 

--- a/storage/store.go
+++ b/storage/store.go
@@ -75,10 +75,6 @@ var (
 // special case for both key-local AND meta1 or meta2 addressing prefixes.
 func verifyKeyLength(key proto.Key) error {
 	maxLength := engine.KeyMaxLength
-	// Transaction records get a UUID appended, so we increase allowed max length.
-	if bytes.HasPrefix(key, engine.KeyLocalTransactionPrefix) {
-		maxLength += uuidLength
-	}
 	if bytes.HasPrefix(key, engine.KeyLocalPrefix) {
 		key = key[engine.KeyLocalPrefixLength:]
 	}
@@ -787,7 +783,7 @@ func (s *Store) maybeResolveWriteIntentError(rng *Range, method string, args pro
 	pushArgs := &proto.InternalPushTxnRequest{
 		RequestHeader: proto.RequestHeader{
 			Timestamp:    args.Header().Timestamp,
-			Key:          wiErr.Txn.ID,
+			Key:          wiErr.Txn.Key,
 			User:         args.Header().User,
 			UserPriority: args.Header().UserPriority,
 			Txn:          args.Header().Txn,

--- a/storage/store_test.go
+++ b/storage/store_test.go
@@ -596,7 +596,7 @@ func TestStoreResolveWriteIntent(t *testing.T) {
 			if err != nil {
 				t.Errorf("expected intent resolved; got unexpected error: %s", err)
 			}
-			txnKey := engine.MakeKey(engine.KeyLocalTransactionPrefix, pushee.ID)
+			txnKey := engine.MakeKey(engine.KeyLocalTransactionPrefix, pushee.Key, pushee.ID)
 			var txn proto.Transaction
 			ok, err := engine.MVCCGetProto(store.Engine(), txnKey, proto.ZeroTimestamp, nil, &txn)
 			if !ok || err != nil {
@@ -849,7 +849,7 @@ func TestStoreResolveWriteIntentNoTxn(t *testing.T) {
 	}
 
 	// Read pushee's txn.
-	txnKey := engine.MakeKey(engine.KeyLocalTransactionPrefix, pushee.ID)
+	txnKey := engine.MakeKey(engine.KeyLocalTransactionPrefix, pushee.Key, pushee.ID)
 	var txn proto.Transaction
 	ok, err := engine.MVCCGetProto(store.Engine(), txnKey, proto.ZeroTimestamp, nil, &txn)
 	if !ok || err != nil {


### PR DESCRIPTION
Previously, there were two problems involved with concatenating Key & ID.
1. For KeyMin (""), the resulting concatenation wouldn't be directed to
   the first range, but to the range which encompassed the random UUID!
2. Appending the UUID would direct to the incorrect range in cases where
   the range ended before the first character of the UUID. For example.
   For a txn with key "a" and UUID "cccc-..." in range "a"-"b", the
   resulting txn key would be "acccc-...", which would actually end up
   going to the wrong range.
