### PR TITLE
InternalTimeSeries improvements

### DIFF
--- a/proto/internal.go
+++ b/proto/internal.go
@@ -60,7 +60,7 @@ const (
 // ToValue generates a Value message which contains an encoded copy of this
 // TimeSeriesData in its "bytes" field. The returned Value will also have its
 // "tag" string set to the TIME_SERIES constant.
-func (ts *TimeSeriesData) ToValue() (*Value, error) {
+func (ts *InternalTimeSeriesData) ToValue() (*Value, error) {
 	b, err := gogoproto.Marshal(ts)
 	if err != nil {
 		return nil, err
@@ -71,13 +71,13 @@ func (ts *TimeSeriesData) ToValue() (*Value, error) {
 	}, nil
 }
 
-// TimeSeriesFromValue attempts to extract a TimeSeriesData message from the
-// "bytes" field of the given value.
-func TimeSeriesFromValue(value *Value) (*TimeSeriesData, error) {
+// InternalTimeSeriesDataFromValue attempts to extract an InternalTimeSeriesData
+// message from the "bytes" field of the given value.
+func InternalTimeSeriesDataFromValue(value *Value) (*InternalTimeSeriesData, error) {
 	if value.GetTag() != _CR_TS.String() {
 		return nil, util.Errorf("value is not tagged as containing TimeSeriesData: %v", value)
 	}
-	var ts TimeSeriesData
+	var ts InternalTimeSeriesData
 	err := gogoproto.Unmarshal(value.Bytes, &ts)
 	if err != nil {
 		return nil, util.Errorf("TimeSeriesData could not be unmarshalled from value: %v %s", value, err)

--- a/proto/internal.proto
+++ b/proto/internal.proto
@@ -207,54 +207,88 @@ message InternalRaftCommand {
 // and C code.
 enum InternalValueType {
     option (gogoproto.goproto_enum_prefix) = false;
-    // _CR_TS is applied to values which contain TimeSeriesData.  This tag is
-    // used by the RocksDB Merge Operator to perform a specialized merge for
-    // this data.
+    // _CR_TS is applied to values which contain InternalTimeSeriesData. This
+    // tag is used by the RocksDB Merge Operator to perform a specialized merge
+    // for this data.
     _CR_TS = 1;
 }
 
-// TimeSeriesPrecision is an enumeration which can describe the precision of the
-// time at which data points are taken.  Currently, millisecond or second
-// precision is available.
-enum TimeSeriesPrecision {
-    option (gogoproto.goproto_enum_prefix) = false;
-    MILLISECONDS = 0;
-    SECONDS = 1;
-}
-
-// TimeSeriesData contains time series data collected over a given interval of
-// time. The data is represented as a variable number of distinct data points
-// falling within the interval; each data point is a numeric value paired an
-// offset from the start of the interval.
+// InternalTimeSeriesData is a collection of data samples for some measurable
+// value, where each sample is taken over a uniform time interval.
 //
-// Data points within a TimeSeriesData should correspond to samples of the same
-// statistic at different point in times. Information about the statistic which
-// is being sampled is encoded in the Key at which the TimeSeriesData is stored.
-message TimeSeriesData {
-    // Holds a wall time, expressed as a unix epoch time in seconds. This
-    // represents the start of the interval.
-    optional int64 start_timestamp = 1 [(gogoproto.nullable) = false];
-    // The duration of the interval in seconds.
-    optional int64 duration_in_seconds = 2 [(gogoproto.nullable) = false];
-    // The precision of the samples within this data set.
-    optional TimeSeriesPrecision sample_precision = 3 [(gogoproto.nullable) = false];
-    // A set of data points which fall within the interval.
-    repeated TimeSeriesDataPoint data = 4;
+// The collection itself contains a start timestamp (in seconds since the unix
+// epoch) and a sample duration (in milliseconds). Each sample in the collection
+// will contain a positive integer offset that indicates the length of time
+// between the start_timestamp of the collection and the time when the sample
+// began, expressed as an whole number of sample intervals. For example, if the
+// sample duration is 60000 (indicating 1 minute), then a contained sample with
+// an offset value of 5 begins (5*60000ms = 300000ms = 5 minutes) after the
+// start timestamp of this data.
+//
+// This is meant to be an efficient internal representation of time series data,
+// ensuring that very little redundant data is stored on disk. With this goal in
+// mind, this message does not identify the statistic which is actually being
+// measured; that information is expected be encoded in the key where this
+// message is stored.
+message InternalTimeSeriesData {
+    // Holds a wall time, expressed as a unix epoch time in nanoseconds. This
+    // represents the earliest possible timestamp for a sample within the
+    // collection.
+    optional int64 start_timestamp_nanos = 1 [(gogoproto.nullable) = false];
+    // The duration of each sample interval, expressed in nanoseconds.
+    optional int64 sample_duration_nanos = 2 [(gogoproto.nullable) = false];
+    // The actual data samples for this metric.
+    repeated InternalTimeSeriesSample samples = 3;
 }
 
-// A TimeSeriesDataPoint is a single point of numeric data sampled at particular
-// time. Multiple TimeSeriesDataPoints are grouped into a single TimeSeriesData
-// collection.
-message TimeSeriesDataPoint {
-    // Temporal offset from the "start_timestamp" of the TimeSeriesData
-    // collection this data point is stored in. The units of this value are
-    // determined by the value of the "sample_precision" field of the
-    // TimeSeriesData collection.
-    optional int32 offset = 2 [(gogoproto.nullable) = false];
-    // Value field for integer samples. If this value is present, then
-    // "value_float" must not be present.
-    optional int64 value_int = 4;
-    // Value field for floating point samples. If this value is present, then
-    // "value_int" must not be set.
-    optional float value_float = 5;
+// A InternalTimeSeriesSample represents data gathered from a single measurable
+// statistic over a given period of time. The length of that period of time is
+// stored in an InternalTimeSeriesData message; a sample cannot be interpreted
+// correctly without a start timestamp and sample duration.
+//
+// Each sample may contain data gathered from multiple measurements of the same
+// statistic, as long as all of those measurements occured within the sample
+// period. The sample stores several aggregated values from these measurements:
+// - The sum of all measured values
+// - A count of all measurements taken
+// - The maximum individual measurement seen
+// - The minimum individual measurement seen
+//
+// If zero measurements are present in a sample, then it should be omitted
+// entirely from any collection it would be a part of.
+//
+// If the count of measurements is 1, then max and min fields may be omitted
+// and assumed equal to the sum field.
+//
+// The underlying statistic sampled may be either an integer or a floating
+// point; therefore, there are two fields each for "sum", "max" and "min" to
+// hold either an integer or floating point number. In practice, only one set of
+// these fields should be present for any individual sample; however, int and
+// float values are recorded in parallel, allowing clients to write both floats
+// and integers to the same value. These are recorded separately to retain
+// precision, but are easily combined by higher-level logic at query time.
+message InternalTimeSeriesSample {
+    // Temporal offset from the "start_timestamp" of the InternalTimeSeriesData
+    // collection this data point is part in. The units of this value are
+    // determined by the value of the "sample_duration_milliseconds" field of
+    // the TimeSeriesData collection.
+    optional int32 offset = 1 [(gogoproto.nullable) = false];
+
+    // Count of integer measurements taken within this sample.
+    optional uint32 int_count = 2 [(gogoproto.nullable) = false];
+    // Sum of all integer measurements.
+    optional int64 int_sum = 3; 
+    // Maximum encountered integer measurement in this sample.
+    optional int64 int_max = 4;
+    // Minimum encountered integer measurement in this sample.
+    optional int64 int_min = 5;
+
+    // Count of floating point measurements taken within this sample.
+    optional uint32 float_count = 6 [(gogoproto.nullable) = false];
+    // Sum of all floating point measurements.
+    optional float float_sum = 7;
+    // Maximum encountered floating point measurement in this sample.
+    optional float float_max = 8;
+    // Minimum encountered floating point measurement in this sample.
+    optional float float_min = 9;
 }

--- a/proto/internal_test.go
+++ b/proto/internal_test.go
@@ -25,22 +25,24 @@ import (
 )
 
 func TestTimeSeriesToValue(t *testing.T) {
-	tsOriginal := &TimeSeriesData{
-		StartTimestamp:    1415398729,
-		DurationInSeconds: 3600,
-		SamplePrecision:   SECONDS,
-		Data: []*TimeSeriesDataPoint{
+	tsOriginal := &InternalTimeSeriesData{
+		StartTimestampNanos: 1415398729000000000,
+		SampleDurationNanos: 1000000000,
+		Samples: []*InternalTimeSeriesSample{
 			{
-				Offset:   100,
-				ValueInt: gogoproto.Int64(1),
+				Offset:   1,
+				IntCount: 1,
+				IntSum:   gogoproto.Int64(1),
 			},
 			{
-				Offset:   200,
-				ValueInt: gogoproto.Int64(2),
+				Offset:   2,
+				IntCount: 1,
+				IntSum:   gogoproto.Int64(2),
 			},
 			{
-				Offset:   300,
-				ValueInt: gogoproto.Int64(3),
+				Offset:   3,
+				IntCount: 1,
+				IntSum:   gogoproto.Int64(3),
 			},
 		},
 	}
@@ -48,7 +50,7 @@ func TestTimeSeriesToValue(t *testing.T) {
 	// Wrap the TSD into a Value
 	valueOriginal, err := tsOriginal.ToValue()
 	if err != nil {
-		t.Fatalf("error marshaling TimeSeriesData: %s", err.Error())
+		t.Fatalf("error marshaling InternalTimeSeriesData: %s", err.Error())
 	}
 	if a, e := valueOriginal.GetTag(), _CR_TS.String(); a != e {
 		t.Errorf("Value did not have expected tag value of %s, had %s", e, a)
@@ -64,9 +66,9 @@ func TestTimeSeriesToValue(t *testing.T) {
 	}
 
 	// Extract the TSD from the Value
-	tsNew, err := TimeSeriesFromValue(valueOriginal)
+	tsNew, err := InternalTimeSeriesDataFromValue(valueOriginal)
 	if err != nil {
-		t.Errorf("error extracting Time Series: %s")
+		t.Errorf("error extracting Time Series: %s", err.Error())
 	}
 	if !gogoproto.Equal(tsOriginal, tsNew) {
 		t.Errorf("extracted time series not equivalent to original; %v != %v", tsNew, tsOriginal)
@@ -76,7 +78,7 @@ func TestTimeSeriesToValue(t *testing.T) {
 	valueNotTs := &Value{
 		Bytes: []byte("testvalue"),
 	}
-	if _, err := TimeSeriesFromValue(valueNotTs); err == nil {
+	if _, err := InternalTimeSeriesDataFromValue(valueNotTs); err == nil {
 		t.Errorf("did not receive expected error when extracting TimeSeries from regular Byte value.")
 	}
 }

--- a/storage/engine/engine_test.go
+++ b/storage/engine/engine_test.go
@@ -272,11 +272,28 @@ func TestEngineMerge(t *testing.T) {
 			{
 				proto.EncodedKey("timeseriesmerged"),
 				[][]byte{
-					timeSeries(1415398729, 3600, 100),
-					timeSeries(1415398729, 3600, 200),
-					timeSeries(1415398729, 3600, 300),
+					timeSeriesInt(testtime, 1000, []tsIntSample{
+						{1, 1, 5, 5, 5},
+					}...),
+					timeSeriesInt(testtime, 1000, []tsIntSample{
+						{2, 1, 5, 5, 5},
+						{1, 2, 10, 7, 3},
+					}...),
+					timeSeriesInt(testtime, 1000, []tsIntSample{
+						{10, 1, 5, 5, 5},
+					}...),
+					timeSeriesInt(testtime, 1000, []tsIntSample{
+						{5, 1, 5, 5, 5},
+						{3, 1, 5, 5, 5},
+					}...),
 				},
-				timeSeries(1415398729, 3600, 100, 200, 300),
+				timeSeriesInt(testtime, 1000, []tsIntSample{
+					{1, 3, 15, 7, 3},
+					{2, 1, 5, 5, 5},
+					{3, 1, 5, 5, 5},
+					{5, 1, 5, 5, 5},
+					{10, 1, 5, 5, 5},
+				}...),
 			},
 		}
 		for _, tc := range testcases {

--- a/storage/engine/rocksdb_test.go
+++ b/storage/engine/rocksdb_test.go
@@ -285,12 +285,11 @@ func BenchmarkMVCCMergeInteger(b *testing.B) {
 
 // BenchmarkMVCCMergeTimeSeries computes performance of merging time series data.
 func BenchmarkMVCCMergeTimeSeries(b *testing.B) {
-	ts := &proto.TimeSeriesData{
-		StartTimestamp:    0,
-		DurationInSeconds: 3600,
-		SamplePrecision:   proto.SECONDS,
-		Data: []*proto.TimeSeriesDataPoint{
-			{Offset: 0, ValueInt: gogoproto.Int64(5)},
+	ts := &proto.InternalTimeSeriesData{
+		StartTimestampNanos: 0,
+		SampleDurationNanos: 1000,
+		Samples: []*proto.InternalTimeSeriesSample{
+			{Offset: 0, IntCount: 1, IntSum: gogoproto.Int64(5)},
 		},
 	}
 	value, err := ts.ToValue()


### PR DESCRIPTION
This commit introduces significant improvements to the underlying storage for
time series data.

The existing `TimeSeriesData` has been renamed to `InternalTimeSeriesData`,
indicating that it is used for internal storage of time series; the name
"TimeSeriesData" is reserved for a forthcoming externally-facing protobuffer.
This message has also been simplified; it now contains only a start timestamp
and a "sample duration" expressed in milliseconds, along with the repeated
samples.

`TimeSeriesDataPoint` is now `InternalTimeSeriesSample`, and stores
significantly more data than before.  Each sample represents the aggregated data
from measuring a statistic over an interval of time; the duration of this
interval is the "sample duration" of the InternalTimeSeriesData the sample is a
part of.  Each sample stores the sum of all measurements, the count of all
measurements, and the max and min of any individual measurement taken. Data can
be stored as either integer or floating points.  This new design greatly
enhances our ability to create data rollups. It will also mitigate idempotency
concerns to a degree, as even the smallest interval can have multiple
measurements.

Finally, the merge logic for time series has been significantly altered; it will
now automatically sort and aggregate merged samples. No matter what order
samples are merged into an InternalTimeSeriesData key, when read they will be in
sorted order with duplicates (determined by offset) accumulated into a single
sample.

In order to make this efficient, the merge logic for TimeSeries now behaves
differently for partial merges; partial merges simply "concatenate" consecutive
merged samples, with sorting and aggregation only performed at the FullMerge
phase.  Without this, merging individual samples would result in effectively
O(n^2) behavior.
