### PR TITLE
add -linearizable flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,13 +36,6 @@ See [TODO.md](https://github.com/cockroachdb/cockroach/blob/master/TODO.md)
 
 Don't have (a recent version > 1.2 of) Docker? Follow the [instructions for installing Docker on your host system](http://docs.docker.com/installation/). If you run into trouble below, check first that you're not running an old version.
 
-Now, pick your `$IMAGE`:
-* `cockroachdb/cockroach` for the small, deploy-only image - ideal if you just
-  want to play around
-* `cockroachdb/cockroach-dev` if you want the development image - comes with
-  a complete build toolchain and support for running the tests but is large.
-
-We'll use `cockroachdb/cockroach` below for simplicity.
 If you don't want to use Docker,
 * set up the dev environment (see [CONTRIBUTING.md](CONTRIBUTING.md))
 * `make build`
@@ -57,7 +50,8 @@ $ docker run -d -p 8080:8080 "cockroachdb/cockroach" \
     -stores="ssd=/tmp/db"
 ```
 This bootstraps and starts a single node with one temporary RocksDB instance at /tmp/db in the background (remove the `-d` flag if you want to see stdout).
-Now let's talk to this node:
+Now let's talk to this node. You can use the [REST Explorer at
+localhost:8080](http://localhost:8080) or talk directly to the API:
 ```bash
 $ curl -X POST -d "Hello" http://localhost:8080/kv/rest/entry/Cockroach
 ```
@@ -86,7 +80,9 @@ Note that `Q29ja3JvYWNo` equals `base64("Cockroach")`.
 *        (cd run; ./local-cluster.sh [start|stop])
 
 #### Building the Docker images yourself
-you can build both of the above images yourself:
+See [build/README.md](build/) for more information on the available Docker
+images `cockroachdb/cockroach` and `cockroachdb/cockroach-dev`.
+You can build both of these images yourself:
 
 * `cockroachdb/cockroach-dev`: `(cd build ; ./build-docker-dev.sh)`
 * `cockroachdb/cockroach`: `(cd build ; ./build-docker-deploy.sh)`

--- a/build/deploy/mkimage.sh
+++ b/build/deploy/mkimage.sh
@@ -1,13 +1,12 @@
 #!/bin/bash
 # Build a statically linked Cockroach binary
 #
-# Requires a working cockroach/cockroach-dev image, in which a statically
-# linked (linux64) binary is built. Using this binary, a deploy image
-# based on BusyBox is created.
-# Additionally, we built statically linked tests which are mounted into
-# the appropriate location on the deploy image, running them once. These
-# are not a part of the resulting image but make sure that at least on
-# the machine that creates the deploy image, the tests all pass.
+# Requires a working cockroach/cockroach-dev image from which the cockroach
+# binary and some other necessary resources are taken. Additionally, we built
+# test binaries which are mounted into the appropriate location on the deploy
+# image, running them once. These are not a part of the resulting image but
+# make sure that at least on the machine that creates the deploy image, the
+# tests all pass.
 #
 # Author: Tobias Schottdorf (tobias.schottdorf@gmail.com)
 set -ex

--- a/kv/txn_coord_sender.go
+++ b/kv/txn_coord_sender.go
@@ -34,8 +34,8 @@ import (
 )
 
 var linearizable = flag.Bool("linearizable", false, "enables linearizable behaviour "+
-	"of operations on this node by making sure that no commit timestamp is "+
-	"reported back to the client until all other node's clocks have passed it.")
+	"of operations on this node by making sure that no commit timestamp is reported "+
+	"back to the client until all other node clocks have necessarily passed it.")
 
 // txnMetadata holds information about an ongoing transaction, as
 // seen from the perspective of this coordinator. It records all
@@ -327,7 +327,7 @@ func (tc *TxnCoordSender) sendOne(call *client.Call) {
 			// of the transaction. This is guaranteed if either
 			// - the commit timestamp is MaxOffset behind startNS
 			// - MaxOffset ns were spent in this function
-			// when returning to the client. Below we chose the option
+			// when returning to the client. Below we choose the option
 			// that involves less waiting, which is likely the first one
 			// unless a transaction commits with an odd timestamp.
 			if tsNS := txn.Timestamp.WallTime; startNS > tsNS {
@@ -337,7 +337,7 @@ func (tc *TxnCoordSender) sendOne(call *client.Call) {
 				time.Duration(tc.clock.PhysicalNow()-startNS)
 			if *linearizable && sleepNS > 0 {
 				defer func() {
-					log.Infof("%v: waiting %dms on EndTransaction for linearizability", txn.ID, sleepNS/1000000)
+					log.V(1).Infof("%v: waiting %dms on EndTransaction for linearizability", txn.ID, sleepNS/1000000)
 					time.Sleep(sleepNS)
 				}()
 			}

--- a/kv/txn_coord_sender.go
+++ b/kv/txn_coord_sender.go
@@ -19,6 +19,7 @@
 package kv
 
 import (
+	"flag"
 	"sync"
 	"time"
 
@@ -31,6 +32,10 @@ import (
 	"github.com/cockroachdb/cockroach/util/hlc"
 	"github.com/cockroachdb/cockroach/util/log"
 )
+
+var linearizable = flag.Bool("linearizable", false, "enables linearizable behaviour "+
+	"of operations on this node by making sure that no commit timestamp is "+
+	"reported back to the client until all other node's clocks have passed it.")
 
 // txnMetadata holds information about an ongoing transaction, as
 // seen from the perspective of this coordinator. It records all
@@ -233,6 +238,7 @@ func (tc *TxnCoordSender) maybeBeginTxn(header *proto.RequestHeader) {
 // transaction commit. Upon successful txn commit, initiates cleanup
 // of intents.
 func (tc *TxnCoordSender) sendOne(call *client.Call) {
+	var startNS int64
 	header := call.Args.Header()
 	// If this call is part of a transaction...
 	if header.Txn != nil {
@@ -247,6 +253,9 @@ func (tc *TxnCoordSender) sendOne(call *client.Call) {
 		// End transaction must have its key set to the txn ID.
 		if call.Method == proto.EndTransaction {
 			header.Key = header.Txn.Key
+			// Remember when EndTransaction started in case we want to
+			// be linearizable.
+			startNS = tc.clock.PhysicalNow()
 		}
 	}
 
@@ -313,6 +322,25 @@ func (tc *TxnCoordSender) sendOne(call *client.Call) {
 		var txn *proto.Transaction
 		if call.Method == proto.EndTransaction {
 			txn = call.Reply.Header().Txn
+			// If the -linearizable flag is set, we want to make sure that
+			// all the clocks in the system are past the commit timestamp
+			// of the transaction. This is guaranteed if either
+			// - the commit timestamp is MaxOffset behind startNS
+			// - MaxOffset ns were spent in this function
+			// when returning to the client. Below we chose the option
+			// that involves less waiting, which is likely the first one
+			// unless a transaction commits with an odd timestamp.
+			if tsNS := txn.Timestamp.WallTime; startNS > tsNS {
+				startNS = tsNS
+			}
+			sleepNS := tc.clock.MaxOffset() -
+				time.Duration(tc.clock.PhysicalNow()-startNS)
+			if *linearizable && sleepNS > 0 {
+				defer func() {
+					log.Infof("%v: waiting %dms on EndTransaction for linearizability", txn.ID, sleepNS/1000000)
+					time.Sleep(sleepNS)
+				}()
+			}
 		}
 		if txn != nil && txn.Status != proto.PENDING {
 			tc.cleanupTxn(txn)


### PR DESCRIPTION
when the -linearizable flag is set, the coordinator receiving the
EndTransaction request will make a note of the local wall time
before dispatching the request further, reexamining the local
clock and txn commit timestamp when the call completes successfully.

if either MaxOffset ns were spent between those two events, or
the transaction's commit timestamp is MaxOffset behind the
local clock after the EndTransaction call has been carried
out successfully, control is returned to the client immediately.
Otherwise, the smaller of the two durations described above
is waited before returning control.

This ensures that at the point of returning control, all nodes
in the system are ahead of the commit timestamp in the transaction.
