### PR TITLE
Add CopyFrom() to response cache

### DIFF
--- a/storage/response_cache.go
+++ b/storage/response_cache.go
@@ -158,6 +158,28 @@ func (rc *ResponseCache) CopyInto(e engine.Engine, destRaftID int64) error {
 	})
 }
 
+// CopyFrom copies all the cached results from another response cache
+// into this one. Note that the cache will not be locked while copying
+// is in progress. Failures decoding individual cache entries return an
+// error. The copy is done directly using the engine instead of interpreting
+// values through MVCC for efficiency.
+func (rc *ResponseCache) CopyFrom(e engine.Engine, originRaftID int64) error {
+	prefix := responseCacheKeyPrefix(originRaftID)
+	start := engine.MVCCEncodeKey(prefix)
+	end := engine.MVCCEncodeKey(prefix.PrefixEnd())
+
+	return e.Iterate(start, end, func(kv proto.RawKeyValue) (bool, error) {
+		// Decode the key into a cmd, skipping on error. Otherwise,
+		// write it to the corresponding key in the new cache.
+		cmdID, err := rc.decodeKey(kv.Key)
+		if err != nil {
+			return false, util.Errorf("could not decode a response cache key %q: %s", kv.Key, err)
+		}
+		encKey := engine.MVCCEncodeKey(responseCacheKey(rc.raftID, cmdID))
+		return false, rc.engine.Put(encKey, kv.Value)
+	})
+}
+
 // PutResponse writes a response to the cache for the specified cmdID.
 // The inflight entry corresponding to cmdID is removed from the
 // inflight map. Any requests waiting on the outcome of the inflight


### PR DESCRIPTION
This adds CopyFrom() to a response cache.
This is needed for AdminMerge() and performs the opposite operation from CopyInto()
