### PR TITLE
Properly rebuild the vendored libraries.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -62,7 +62,8 @@ all: build test
 auxiliary: storage/engine/engine.pc roach_proto roach_lib sqlparser
 
 build: auxiliary
-	$(GO) build $(GOFLAGS) -i -o cockroach
+	cd _vendor/src/github.com/coreos/etcd/raft ; $(GO) install $(GOFLAGS)
+	$(GO) build $(GOFLAGS) -o cockroach
 
 storage/engine/engine.pc: storage/engine/engine.pc.in
 	sed -e "s,@PWD@,$(CURDIR),g" -e "s,@LDEXTRA@,$(LDEXTRA),g" < $^ > $@


### PR DESCRIPTION
We were previously relying on 'go install -i' to build (and avoid
unnecessarily rebuilding) the vendored libraries.  Specifically the
raft code from etcd.

So if the raft.a binary is missing, 'go install -i' will properly
build and install it under _vendor/pkg.  However, if there are any
changes to source files in etcd, the library will not be rebuilt.
This has caused build failures as mentioned here:

https://groups.google.com/forum/#!topic/cockroach-db/8mSuJz9oZ_g

I've asked around, but not gotten any indication on how to fix it
easily.  The best solution seems to be to run a separate 'go install'
for the vendored code as part of the normal build process.
