### PR TITLE
Introduce ConditionFailedError

### DIFF
--- a/proto/api.go
+++ b/proto/api.go
@@ -621,15 +621,6 @@ func (gr *GetResponse) Verify(req Request) error {
 	return nil
 }
 
-// Verify verifies the integrity of the conditional put response's
-// actual value, if not nil.
-func (cpr *ConditionalPutResponse) Verify(req Request) error {
-	if cpr.ActualValue != nil {
-		return cpr.ActualValue.Verify(req.Header().Key)
-	}
-	return nil
-}
-
 // Verify verifies the integrity of every value returned in the scan.
 func (sr *ScanResponse) Verify(req Request) error {
 	for _, kv := range sr.Rows {

--- a/proto/api.proto
+++ b/proto/api.proto
@@ -159,8 +159,6 @@ message ConditionalPutRequest {
 // ConditionalPut() method.
 message ConditionalPutResponse {
   optional ResponseHeader header = 1 [(gogoproto.nullable) = false, (gogoproto.embed) = true];
-  // ActualValue.Bytes set if conditional put failed.
-  optional Value actual_value = 2;
 }
 
 // An IncrementRequest is arguments to the Increment() method. It

--- a/proto/errors.go
+++ b/proto/errors.go
@@ -142,3 +142,8 @@ func (e *ReadWithinUncertaintyIntervalError) Error() string {
 func (e *OpRequiresTxnError) Error() string {
 	return "the operation requires transactional context"
 }
+
+// Error formats error.
+func (e *ConditionFailedError) Error() string {
+	return fmt.Sprintf("unexpected value: %s", e.ActualValue)
+}

--- a/proto/errors.proto
+++ b/proto/errors.proto
@@ -119,6 +119,13 @@ message WriteTooOldError {
 message OpRequiresTxnError {
 }
 
+// A ConditionFailedError indicates that the expected value
+// of a ConditionalPutRequest was not found, either
+// because it was missing or was not equal. The error will
+// contain the actual value found.
+message ConditionFailedError {
+  optional Value actual_value = 1;
+}
 
 // Error is a union type containing all available errors.
 // NOTE: new error types must be added here, and potentially in
@@ -136,5 +143,6 @@ message Error {
   optional WriteIntentError write_intent = 10;
   optional WriteTooOldError write_too_old = 11;
   optional OpRequiresTxnError op_requires_txn = 12;
+  optional ConditionFailedError condition_failed = 13;
 }
 

--- a/storage/engine/mvcc.go
+++ b/storage/engine/mvcc.go
@@ -613,33 +613,39 @@ func MVCCIncrement(engine Engine, ms *MVCCStats, key proto.Key, timestamp proto.
 }
 
 // MVCCConditionalPut sets the value for a specified key only if the
-// expected value matches. If not, the return value contains the
-// actual value.
+// expected value matches. If not, the return a ConditionFailedError
+// containing the actual value.
 func MVCCConditionalPut(engine Engine, ms *MVCCStats, key proto.Key, timestamp proto.Timestamp, value proto.Value,
-	expValue *proto.Value, txn *proto.Transaction) (*proto.Value, error) {
+	expValue *proto.Value, txn *proto.Transaction) error {
 	// Handle check for non-existence of key. In order to detect
 	// the potential write intent by another concurrent transaction
 	// with a newer timestamp, we need to use the max timestamp
 	// while reading.
 	existVal, err := MVCCGet(engine, key, proto.MaxTimestamp, txn)
 	if err != nil {
-		return nil, err
+		return err
 	}
 
 	if expValue == nil && existVal != nil {
-		return existVal, util.Errorf("key %q already exists", key)
+		return &proto.ConditionFailedError{
+			ActualValue: existVal,
+		}
 	} else if expValue != nil {
 		// Handle check for existence when there is no key.
 		if existVal == nil {
-			return nil, util.Errorf("key %q does not exist", key)
+			return &proto.ConditionFailedError{}
 		} else if expValue.Bytes != nil && !bytes.Equal(expValue.Bytes, existVal.Bytes) {
-			return existVal, util.Errorf("key %q does not match existing", key)
+			return &proto.ConditionFailedError{
+				ActualValue: existVal,
+			}
 		} else if expValue.Integer != nil && (existVal.Integer == nil || expValue.GetInteger() != existVal.GetInteger()) {
-			return existVal, util.Errorf("key %q does not match existing", key)
+			return &proto.ConditionFailedError{
+				ActualValue: existVal,
+			}
 		}
 	}
 
-	return nil, MVCCPut(engine, ms, key, timestamp, value, txn)
+	return MVCCPut(engine, ms, key, timestamp, value, txn)
 }
 
 // MVCCMerge implements a merge operation. Merge adds integer values,

--- a/storage/range.go
+++ b/storage/range.go
@@ -791,8 +791,7 @@ func (r *Range) Put(batch engine.Engine, ms *engine.MVCCStats, args *proto.PutRe
 // the expected value matches. If not, the return value contains
 // the actual value.
 func (r *Range) ConditionalPut(batch engine.Engine, ms *engine.MVCCStats, args *proto.ConditionalPutRequest, reply *proto.ConditionalPutResponse) {
-	val, err := engine.MVCCConditionalPut(batch, ms, args.Key, args.Timestamp, args.Value, args.ExpValue, args.Txn)
-	reply.ActualValue = val
+	err := engine.MVCCConditionalPut(batch, ms, args.Key, args.Timestamp, args.Value, args.ExpValue, args.Txn)
 	reply.SetGoError(err)
 }
 


### PR DESCRIPTION
When a `ConditionalPutRequest` is issued to a key and the condition fails, the request fails with a `GenericError` and provides the current value under that key in the `actual_value` field of the `ConditionalPutResponse`.

If the key associtated with the request has no value and the request is expecting one, then this will result in a `ConditionalPutResponse` with a `GenericError` and an empty `actual_value`. This response cannot be distinguished from a response with another failure caused by something unrelated to the condition.

Introducing another error type (e.g.: `ConditionFailedError`) would provide the proper semantics to the clients. It could also be used to hold `actual_value` instead of having that on the `ContionalPutResponse` since it is only useful when the condition fails anyway:

``` protobuf
message ConditionFailedError {
  optional Value actual_value = 0
}
```
