### PR TITLE
Move protobuf import to github.com/gogo/protobuf.

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -3,7 +3,7 @@ roachlib/*.o
 roachlib/*.a
 proto/*.pb.go
 proto/lib/*
-proto/lib/code.google.com/p/gogoprotobuf/gogoproto/*
+proto/lib/github.com/gogo/protobuf/gogoproto/*
 storage/engine/engine.pc
 cockroach
 build/deploy

--- a/build/devbase/godeps.sh
+++ b/build/devbase/godeps.sh
@@ -9,7 +9,7 @@ function go_get() {
 go_get code.google.com/p/biogo.store/llrb
 go_get code.google.com/p/go-commander
 go_get code.google.com/p/go-uuid/uuid
-go_get code.google.com/p/gogoprotobuf/{proto,protoc-gen-gogo,gogoproto}
+go_get github.com/gogo/protobuf/{proto,protoc-gen-gogo,gogoproto}
 go_get code.google.com/p/snappy-go/snappy
 go_get github.com/golang/glog
 go_get gopkg.in/yaml.v1

--- a/client/client_test.go
+++ b/client/client_test.go
@@ -30,7 +30,6 @@ import (
 	"testing"
 	"time"
 
-	gogoproto "code.google.com/p/gogoprotobuf/proto"
 	"github.com/cockroachdb/cockroach/client"
 	"github.com/cockroachdb/cockroach/proto"
 	"github.com/cockroachdb/cockroach/rpc"
@@ -38,6 +37,7 @@ import (
 	"github.com/cockroachdb/cockroach/storage"
 	"github.com/cockroachdb/cockroach/util"
 	"github.com/cockroachdb/cockroach/util/log"
+	gogoproto "github.com/gogo/protobuf/proto"
 )
 
 // notifyingSender is a sender which can set up a notification channel

--- a/client/http_sender.go
+++ b/client/http_sender.go
@@ -25,9 +25,9 @@ import (
 	"net/http"
 	"time"
 
-	gogoproto "code.google.com/p/gogoprotobuf/proto"
 	"github.com/cockroachdb/cockroach/util"
 	"github.com/cockroachdb/cockroach/util/log"
+	gogoproto "github.com/gogo/protobuf/proto"
 )
 
 const (

--- a/client/kv.go
+++ b/client/kv.go
@@ -22,10 +22,10 @@ import (
 	"encoding/gob"
 	"time"
 
-	gogoproto "code.google.com/p/gogoprotobuf/proto"
 	"github.com/cockroachdb/cockroach/proto"
 	"github.com/cockroachdb/cockroach/util"
 	"github.com/cockroachdb/cockroach/util/log"
+	gogoproto "github.com/gogo/protobuf/proto"
 )
 
 // TxnRetryOptions sets the retry options for handling write conflicts.

--- a/client/txn_sender_test.go
+++ b/client/txn_sender_test.go
@@ -21,8 +21,8 @@ import (
 	"testing"
 
 	"code.google.com/p/go-uuid/uuid"
-	gogoproto "code.google.com/p/gogoprotobuf/proto"
 	"github.com/cockroachdb/cockroach/proto"
+	gogoproto "github.com/gogo/protobuf/proto"
 )
 
 var (

--- a/kv/db_test.go
+++ b/kv/db_test.go
@@ -23,12 +23,12 @@ import (
 	"net/http"
 	"testing"
 
-	gogoproto "code.google.com/p/gogoprotobuf/proto"
 	"github.com/cockroachdb/cockroach/client"
 	"github.com/cockroachdb/cockroach/kv"
 	"github.com/cockroachdb/cockroach/proto"
 	"github.com/cockroachdb/cockroach/rpc"
 	"github.com/cockroachdb/cockroach/util"
+	gogoproto "github.com/gogo/protobuf/proto"
 	yaml "gopkg.in/yaml.v1"
 )
 

--- a/kv/dist_sender.go
+++ b/kv/dist_sender.go
@@ -32,7 +32,7 @@ import (
 	"github.com/cockroachdb/cockroach/util"
 	"github.com/cockroachdb/cockroach/util/log"
 
-	gogoproto "code.google.com/p/gogoprotobuf/proto"
+	gogoproto "github.com/gogo/protobuf/proto"
 )
 
 // Default constants for timeouts.

--- a/kv/rest_test.go
+++ b/kv/rest_test.go
@@ -35,13 +35,13 @@ import (
 	"strings"
 	"testing"
 
-	gogoproto "code.google.com/p/gogoprotobuf/proto"
 	"github.com/cockroachdb/cockroach/client"
 	. "github.com/cockroachdb/cockroach/kv"
 	"github.com/cockroachdb/cockroach/proto"
 	"github.com/cockroachdb/cockroach/server"
 	"github.com/cockroachdb/cockroach/storage"
 	"github.com/cockroachdb/cockroach/storage/engine"
+	gogoproto "github.com/gogo/protobuf/proto"
 )
 
 // startServer returns the server, server address and a KV client for

--- a/kv/txn_coord_sender.go
+++ b/kv/txn_coord_sender.go
@@ -23,7 +23,6 @@ import (
 	"sync"
 	"time"
 
-	gogoproto "code.google.com/p/gogoprotobuf/proto"
 	"github.com/cockroachdb/cockroach/client"
 	"github.com/cockroachdb/cockroach/proto"
 	"github.com/cockroachdb/cockroach/storage"
@@ -31,6 +30,7 @@ import (
 	"github.com/cockroachdb/cockroach/util"
 	"github.com/cockroachdb/cockroach/util/hlc"
 	"github.com/cockroachdb/cockroach/util/log"
+	gogoproto "github.com/gogo/protobuf/proto"
 )
 
 var linearizable = flag.Bool("linearizable", false, "enables linearizable behaviour "+

--- a/kv/txn_coord_sender_test.go
+++ b/kv/txn_coord_sender_test.go
@@ -23,7 +23,6 @@ import (
 	"testing"
 	"time"
 
-	gogoproto "code.google.com/p/gogoprotobuf/proto"
 	"github.com/cockroachdb/cockroach/client"
 	"github.com/cockroachdb/cockroach/gossip"
 	"github.com/cockroachdb/cockroach/proto"
@@ -32,6 +31,7 @@ import (
 	"github.com/cockroachdb/cockroach/storage/engine"
 	"github.com/cockroachdb/cockroach/util"
 	"github.com/cockroachdb/cockroach/util/hlc"
+	gogoproto "github.com/gogo/protobuf/proto"
 )
 
 // createTestDB creates a *client.KV using a LocalSender object built

--- a/kv/txn_correctness_test.go
+++ b/kv/txn_correctness_test.go
@@ -28,12 +28,12 @@ import (
 	"testing"
 	"time"
 
-	gogoproto "code.google.com/p/gogoprotobuf/proto"
 	"github.com/cockroachdb/cockroach/client"
 	"github.com/cockroachdb/cockroach/proto"
 	"github.com/cockroachdb/cockroach/storage"
 	"github.com/cockroachdb/cockroach/util"
 	"github.com/cockroachdb/cockroach/util/log"
+	gogoproto "github.com/gogo/protobuf/proto"
 )
 
 // setCorrectnessRetryOptions sets client for aggressive retries with a

--- a/proto/Makefile
+++ b/proto/Makefile
@@ -19,14 +19,14 @@
 PROTO_LIB   := lib/libroachproto.a
 PROTOS      := api.proto config.proto data.proto errors.proto gossip.proto heartbeat.proto internal.proto
 PROTO_GO    := $(PROTOS:.proto=.pb.go)
-GOGO_PROTOS := ../../../../code.google.com/p/gogoprotobuf/gogoproto/gogo.proto
-SOURCES     := lib/api.pb.cc lib/config.pb.cc lib/data.pb.cc lib/errors.pb.cc lib/gossip.pb.cc lib/heartbeat.pb.cc lib/internal.pb.cc lib/code.google.com/p/gogoprotobuf/gogoproto/gogo.pb.cc
-HEADERS     := lib/api.pb.h lib/config.pb.h lib/data.pb.h lib/errors.pb.h lib/gossip.pb.h lib/heartbeat.pb.h lib/internal.pb.h lib/code.google.com/p/gogoprotobuf/gogoproto/gogo.pb.h
+GOGO_PROTOS := ../../../../github.com/gogo/protobuf/gogoproto/gogo.proto
+SOURCES     := lib/api.pb.cc lib/config.pb.cc lib/data.pb.cc lib/errors.pb.cc lib/gossip.pb.cc lib/heartbeat.pb.cc lib/internal.pb.cc lib/github.com/gogo/protobuf/gogoproto/gogo.pb.cc
+HEADERS     := lib/api.pb.h lib/config.pb.h lib/data.pb.h lib/errors.pb.h lib/gossip.pb.h lib/heartbeat.pb.h lib/internal.pb.h lib/github.com/gogo/protobuf/gogoproto/gogo.pb.h
 LIBOBJECTS  := $(SOURCES:.cc=.o)
 
 CXXFLAGS += -Ilib
 
-PROTO_PATH := ../../../../:../../../../code.google.com/p/gogoprotobuf/protobuf:../../../../code.google.com/p/gogoprotobuf/gogoproto
+PROTO_PATH := ../../../../:../../../../github.com/gogo/protobuf/protobuf:../../../../github.com/gogo/protobuf/gogoproto
 
 all: static_lib
 

--- a/proto/api.go
+++ b/proto/api.go
@@ -18,8 +18,8 @@
 package proto
 
 import (
-	gogoproto "code.google.com/p/gogoprotobuf/proto"
 	"github.com/cockroachdb/cockroach/util"
+	gogoproto "github.com/gogo/protobuf/proto"
 )
 
 // TODO(spencer): change these string constants into a type.

--- a/proto/api.proto
+++ b/proto/api.proto
@@ -20,7 +20,7 @@ package proto;
 import "config.proto";
 import "data.proto";
 import "errors.proto";
-import "code.google.com/p/gogoprotobuf/gogoproto/gogo.proto";
+import "github.com/gogo/protobuf/gogoproto/gogo.proto";
 
 // ClientCmdID provides a unique ID for client commands. Clients which
 // provide ClientCmdID gain operation idempotence. In other words,

--- a/proto/config.proto
+++ b/proto/config.proto
@@ -17,7 +17,7 @@
 
 package proto;
 
-import "code.google.com/p/gogoprotobuf/gogoproto/gogo.proto";
+import "github.com/gogo/protobuf/gogoproto/gogo.proto";
 
 // Attributes specifies a list of arbitrary strings describing
 // node topology, store type, and machine capabilities.

--- a/proto/data.go
+++ b/proto/data.go
@@ -30,9 +30,9 @@ import (
 	"code.google.com/p/biogo.store/interval"
 	"code.google.com/p/biogo.store/llrb"
 	"code.google.com/p/go-uuid/uuid"
-	gogoproto "code.google.com/p/gogoprotobuf/proto"
 	"github.com/cockroachdb/cockroach/util"
 	"github.com/cockroachdb/cockroach/util/encoding"
+	gogoproto "github.com/gogo/protobuf/proto"
 )
 
 // KeyMaxLength is the maximum length of a Key in bytes.

--- a/proto/data.proto
+++ b/proto/data.proto
@@ -19,7 +19,7 @@
 package proto;
 
 import "config.proto";
-import "code.google.com/p/gogoprotobuf/gogoproto/gogo.proto";
+import "github.com/gogo/protobuf/gogoproto/gogo.proto";
 
 // Timestamp represents a state of the hybrid logical clock.
 message Timestamp {

--- a/proto/data_test.go
+++ b/proto/data_test.go
@@ -25,7 +25,7 @@ import (
 	"testing"
 	"time"
 
-	gogoproto "code.google.com/p/gogoprotobuf/proto"
+	gogoproto "github.com/gogo/protobuf/proto"
 )
 
 // TestKeyNext tests that the method for creating lexicographic

--- a/proto/errors.proto
+++ b/proto/errors.proto
@@ -19,7 +19,7 @@ package proto;
 
 import "config.proto";
 import "data.proto";
-import "code.google.com/p/gogoprotobuf/gogoproto/gogo.proto";
+import "github.com/gogo/protobuf/gogoproto/gogo.proto";
 
 // A GenericError is a generic representation of a go error including
 // the string message and whether or not the error is retryable.

--- a/proto/gossip.proto
+++ b/proto/gossip.proto
@@ -17,7 +17,7 @@
 
 package proto;
 
-import "code.google.com/p/gogoprotobuf/gogoproto/gogo.proto";
+import "github.com/gogo/protobuf/gogoproto/gogo.proto";
 
 message Addr {
   optional string network = 1 [(gogoproto.nullable) = false];

--- a/proto/heartbeat.proto
+++ b/proto/heartbeat.proto
@@ -18,7 +18,7 @@
 
 package proto;
 
-import "code.google.com/p/gogoprotobuf/gogoproto/gogo.proto";
+import "github.com/gogo/protobuf/gogoproto/gogo.proto";
 
 // RemoteOffset keeps track of this client's estimate of its offset from a
 // remote server. Error is the maximum error in the reading of this offset, so

--- a/proto/internal.go
+++ b/proto/internal.go
@@ -18,8 +18,8 @@
 package proto
 
 import (
-	gogoproto "code.google.com/p/gogoprotobuf/proto"
 	"github.com/cockroachdb/cockroach/util"
+	gogoproto "github.com/gogo/protobuf/proto"
 )
 
 const (

--- a/proto/internal.proto
+++ b/proto/internal.proto
@@ -20,7 +20,7 @@ package proto;
 import "api.proto";
 import "config.proto";
 import "data.proto";
-import "code.google.com/p/gogoprotobuf/gogoproto/gogo.proto";
+import "github.com/gogo/protobuf/gogoproto/gogo.proto";
 
 // An InternalRangeLookupRequest is arguments to the
 // InternalRangeLookup() method. It specifies the key for which the

--- a/proto/internal_test.go
+++ b/proto/internal_test.go
@@ -21,7 +21,7 @@ import (
 	"bytes"
 	"testing"
 
-	gogoproto "code.google.com/p/gogoprotobuf/proto"
+	gogoproto "github.com/gogo/protobuf/proto"
 )
 
 func TestTimeSeriesToValue(t *testing.T) {

--- a/rpc/codec/client.go
+++ b/rpc/codec/client.go
@@ -12,8 +12,8 @@ import (
 	"sync"
 	"time"
 
-	"code.google.com/p/gogoprotobuf/proto"
 	wire "github.com/cockroachdb/cockroach/rpc/codec/wire.pb"
+	"github.com/gogo/protobuf/proto"
 )
 
 type clientCodec struct {

--- a/rpc/codec/message.pb/Makefile
+++ b/rpc/codec/message.pb/Makefile
@@ -17,9 +17,9 @@
 
 PROTOS      := arith.proto echo.proto
 PROTO_GO    := $(PROTOS:.proto=.pb.go)
-GOGO_PROTOS := ../../../../code.google.com/p/gogoprotobuf/gogoproto/gogo.proto
+GOGO_PROTOS := ../../../../github.com/gogo/protobuf/gogoproto/gogo.proto
 
-PROTO_PATH := ../../../../../../:../../../../../../code.google.com/p/gogoprotobuf/protobuf:../../../../../../code.google.com/p/gogoprotobuf/gogoproto
+PROTO_PATH := ../../../../../../:../../../../../../github.com/gogo/protobuf/protobuf:../../../../../../github.com/gogo/protobuf/gogoproto
 
 all: $(PROTO_GO)
 

--- a/rpc/codec/message.pb/arith.pb.go
+++ b/rpc/codec/message.pb/arith.pb.go
@@ -15,7 +15,7 @@ It has these top-level messages:
 */
 package message
 
-import proto "code.google.com/p/gogoprotobuf/proto"
+import proto "github.com/gogo/protobuf/proto"
 import math "math"
 
 // discarding unused import gogoproto "code.google.com/p/gogoprotobuf/gogoproto/gogo.pb"

--- a/rpc/codec/message.pb/arith.proto
+++ b/rpc/codec/message.pb/arith.proto
@@ -4,7 +4,7 @@
 
 package message;
 
-import "code.google.com/p/gogoprotobuf/gogoproto/gogo.proto";
+import "github.com/gogo/protobuf/gogoproto/gogo.proto";
 
 message ArithRequest {
 	optional int32 a = 1 [(gogoproto.nullable) = false];

--- a/rpc/codec/message.pb/echo.pb.go
+++ b/rpc/codec/message.pb/echo.pb.go
@@ -4,7 +4,7 @@
 
 package message
 
-import proto "code.google.com/p/gogoprotobuf/proto"
+import proto "github.com/gogo/protobuf/proto"
 import math "math"
 
 // discarding unused import gogoproto "code.google.com/p/gogoprotobuf/gogoproto/gogo.pb"

--- a/rpc/codec/message.pb/echo.proto
+++ b/rpc/codec/message.pb/echo.proto
@@ -4,7 +4,7 @@
 
 package message;
 
-import "code.google.com/p/gogoprotobuf/gogoproto/gogo.proto";
+import "github.com/gogo/protobuf/gogoproto/gogo.proto";
 
 message EchoRequest {
 	optional string msg = 1 [(gogoproto.nullable) = false];

--- a/rpc/codec/server.go
+++ b/rpc/codec/server.go
@@ -11,8 +11,8 @@ import (
 	"net/rpc"
 	"sync"
 
-	"code.google.com/p/gogoprotobuf/proto"
 	wire "github.com/cockroachdb/cockroach/rpc/codec/wire.pb"
+	"github.com/gogo/protobuf/proto"
 )
 
 type serverCodec struct {

--- a/rpc/codec/wire.go
+++ b/rpc/codec/wire.go
@@ -9,9 +9,9 @@ import (
 	"hash/crc32"
 	"io"
 
-	"code.google.com/p/gogoprotobuf/proto"
 	"code.google.com/p/snappy-go/snappy"
 	wire "github.com/cockroachdb/cockroach/rpc/codec/wire.pb"
+	"github.com/gogo/protobuf/proto"
 )
 
 func writeRequest(w io.Writer, id uint64, method string, request proto.Message) error {

--- a/rpc/codec/wire.pb/Makefile
+++ b/rpc/codec/wire.pb/Makefile
@@ -17,9 +17,9 @@
 
 PROTOS      := wire.proto
 PROTO_GO    := $(PROTOS:.proto=.pb.go)
-GOGO_PROTOS := ../../../../code.google.com/p/gogoprotobuf/gogoproto/gogo.proto
+GOGO_PROTOS := ../../../../github.com/gogo/protobuf/gogoproto/gogo.proto
 
-PROTO_PATH := ../../../../../../:../../../../../../code.google.com/p/gogoprotobuf/protobuf:../../../../../../code.google.com/p/gogoprotobuf/gogoproto
+PROTO_PATH := ../../../../../../:../../../../../../github.com/gogo/protobuf/protobuf:../../../../../../github.com/gogo/protobuf/gogoproto
 
 all: $(PROTO_GO)
 

--- a/rpc/codec/wire.pb/wire.pb.go
+++ b/rpc/codec/wire.pb/wire.pb.go
@@ -41,7 +41,7 @@ It has these top-level messages:
 */
 package google_protobuf_rpc_wire
 
-import proto "code.google.com/p/gogoprotobuf/proto"
+import proto "github.com/gogo/protobuf/proto"
 import math "math"
 
 // discarding unused import gogoproto "code.google.com/p/gogoprotobuf/gogoproto/gogo.pb"

--- a/rpc/codec/wire.pb/wire.proto
+++ b/rpc/codec/wire.pb/wire.proto
@@ -29,7 +29,7 @@
 //	len(ResponseHeader) < Const.max_header_len.default
 package wire;
 
-import "code.google.com/p/gogoprotobuf/gogoproto/gogo.proto";
+import "github.com/gogo/protobuf/gogoproto/gogo.proto";
 
 message Const {
   optional uint32 max_header_len = 1 [default = 1024];

--- a/storage/db_test.go
+++ b/storage/db_test.go
@@ -28,7 +28,6 @@ import (
 	"sort"
 	"testing"
 
-	gogoproto "code.google.com/p/gogoprotobuf/proto"
 	"github.com/cockroachdb/cockroach/client"
 	"github.com/cockroachdb/cockroach/gossip"
 	"github.com/cockroachdb/cockroach/kv"
@@ -38,6 +37,7 @@ import (
 	"github.com/cockroachdb/cockroach/storage/engine"
 	"github.com/cockroachdb/cockroach/util/hlc"
 	"github.com/cockroachdb/cockroach/util/log"
+	gogoproto "github.com/gogo/protobuf/proto"
 )
 
 // createTestStore creates a test store using an in-memory

--- a/storage/engine/batch_test.go
+++ b/storage/engine/batch_test.go
@@ -22,8 +22,8 @@ import (
 	"reflect"
 	"testing"
 
-	gogoproto "code.google.com/p/gogoprotobuf/proto"
 	"github.com/cockroachdb/cockroach/proto"
+	gogoproto "github.com/gogo/protobuf/proto"
 )
 
 // TestBatchBasics verifies that all commands work in a batch, aren't

--- a/storage/engine/engine.go
+++ b/storage/engine/engine.go
@@ -20,10 +20,10 @@
 package engine
 
 import (
-	gogoproto "code.google.com/p/gogoprotobuf/proto"
 	"github.com/cockroachdb/cockroach/proto"
 	"github.com/cockroachdb/cockroach/util"
 	"github.com/cockroachdb/cockroach/util/encoding"
+	gogoproto "github.com/gogo/protobuf/proto"
 )
 
 // StoreCapacity contains capacity information for a storage device.

--- a/storage/engine/engine_test.go
+++ b/storage/engine/engine_test.go
@@ -30,9 +30,9 @@ import (
 	"testing"
 	"time"
 
-	gogoproto "code.google.com/p/gogoprotobuf/proto"
 	"github.com/cockroachdb/cockroach/proto"
 	"github.com/cockroachdb/cockroach/util"
+	gogoproto "github.com/gogo/protobuf/proto"
 )
 
 func ensureRangeEqual(t *testing.T, sortedKeys []string, keyMap map[string][]byte, keyvals []proto.RawKeyValue) {

--- a/storage/engine/gc.go
+++ b/storage/engine/gc.go
@@ -18,10 +18,10 @@
 package engine
 
 import (
-	gogoproto "code.google.com/p/gogoprotobuf/proto"
 	"github.com/cockroachdb/cockroach/proto"
 	"github.com/cockroachdb/cockroach/util/encoding"
 	"github.com/cockroachdb/cockroach/util/log"
+	gogoproto "github.com/gogo/protobuf/proto"
 )
 
 // GarbageCollector GCs MVCC key/values using a zone-specific GC

--- a/storage/engine/gc_test.go
+++ b/storage/engine/gc_test.go
@@ -22,8 +22,8 @@ import (
 	"reflect"
 	"testing"
 
-	gogoproto "code.google.com/p/gogoprotobuf/proto"
 	"github.com/cockroachdb/cockroach/proto"
+	gogoproto "github.com/gogo/protobuf/proto"
 )
 
 var (

--- a/storage/engine/merge_test.go
+++ b/storage/engine/merge_test.go
@@ -24,8 +24,8 @@ import (
 	"reflect"
 	"testing"
 
-	gogoproto "code.google.com/p/gogoprotobuf/proto"
 	"github.com/cockroachdb/cockroach/proto"
+	gogoproto "github.com/gogo/protobuf/proto"
 )
 
 var testtime = int64(-446061360000000000)

--- a/storage/engine/mvcc.go
+++ b/storage/engine/mvcc.go
@@ -23,11 +23,11 @@ import (
 	"fmt"
 	"math"
 
-	gogoproto "code.google.com/p/gogoprotobuf/proto"
 	"github.com/cockroachdb/cockroach/proto"
 	"github.com/cockroachdb/cockroach/util"
 	"github.com/cockroachdb/cockroach/util/encoding"
 	"github.com/cockroachdb/cockroach/util/log"
+	gogoproto "github.com/gogo/protobuf/proto"
 )
 
 const (

--- a/storage/engine/mvcc_test.go
+++ b/storage/engine/mvcc_test.go
@@ -31,10 +31,10 @@ import (
 	"strings"
 	"testing"
 
-	gogoproto "code.google.com/p/gogoprotobuf/proto"
 	"github.com/cockroachdb/cockroach/proto"
 	"github.com/cockroachdb/cockroach/util"
 	"github.com/cockroachdb/cockroach/util/log"
+	gogoproto "github.com/gogo/protobuf/proto"
 )
 
 // Constants for system-reserved keys in the KV map.

--- a/storage/engine/rocksdb_test.go
+++ b/storage/engine/rocksdb_test.go
@@ -25,11 +25,11 @@ import (
 	"reflect"
 	"testing"
 
-	gogoproto "code.google.com/p/gogoprotobuf/proto"
 	"github.com/cockroachdb/cockroach/proto"
 	"github.com/cockroachdb/cockroach/util"
 	"github.com/cockroachdb/cockroach/util/encoding"
 	"github.com/cockroachdb/cockroach/util/log"
+	gogoproto "github.com/gogo/protobuf/proto"
 )
 
 // encodePutResponse creates a put response using the specified

--- a/storage/engine/stat.go
+++ b/storage/engine/stat.go
@@ -18,9 +18,9 @@
 package engine
 
 import (
-	gogoproto "code.google.com/p/gogoprotobuf/proto"
 	"github.com/cockroachdb/cockroach/proto"
 	"github.com/cockroachdb/cockroach/util/encoding"
+	gogoproto "github.com/gogo/protobuf/proto"
 )
 
 // Constants for stat key construction.

--- a/storage/raft.go
+++ b/storage/raft.go
@@ -22,9 +22,9 @@ import (
 	"sync"
 	"time"
 
-	gogoproto "code.google.com/p/gogoprotobuf/proto"
 	"github.com/cockroachdb/cockroach/multiraft"
 	"github.com/cockroachdb/cockroach/proto"
+	gogoproto "github.com/gogo/protobuf/proto"
 )
 
 type committedCommand struct {

--- a/storage/range.go
+++ b/storage/range.go
@@ -29,7 +29,6 @@ import (
 	"sync/atomic"
 	"time"
 
-	gogoproto "code.google.com/p/gogoprotobuf/proto"
 	"github.com/cockroachdb/cockroach/client"
 	"github.com/cockroachdb/cockroach/gossip"
 	"github.com/cockroachdb/cockroach/proto"
@@ -37,6 +36,7 @@ import (
 	"github.com/cockroachdb/cockroach/util"
 	"github.com/cockroachdb/cockroach/util/hlc"
 	"github.com/cockroachdb/cockroach/util/log"
+	gogoproto "github.com/gogo/protobuf/proto"
 )
 
 // init pre-registers RangeDescriptor, PrefixConfigMap types and Transaction.

--- a/storage/range_test.go
+++ b/storage/range_test.go
@@ -27,7 +27,6 @@ import (
 	"testing"
 	"time"
 
-	gogoproto "code.google.com/p/gogoprotobuf/proto"
 	"github.com/cockroachdb/cockroach/gossip"
 	"github.com/cockroachdb/cockroach/proto"
 	"github.com/cockroachdb/cockroach/rpc"
@@ -35,6 +34,7 @@ import (
 	"github.com/cockroachdb/cockroach/util"
 	"github.com/cockroachdb/cockroach/util/hlc"
 	"github.com/cockroachdb/cockroach/util/log"
+	gogoproto "github.com/gogo/protobuf/proto"
 )
 
 var (

--- a/storage/response_cache.go
+++ b/storage/response_cache.go
@@ -21,12 +21,12 @@ import (
 	"fmt"
 	"sync"
 
-	gogoproto "code.google.com/p/gogoprotobuf/proto"
 	"github.com/cockroachdb/cockroach/proto"
 	"github.com/cockroachdb/cockroach/storage/engine"
 	"github.com/cockroachdb/cockroach/util"
 	"github.com/cockroachdb/cockroach/util/encoding"
 	"github.com/cockroachdb/cockroach/util/log"
+	gogoproto "github.com/gogo/protobuf/proto"
 )
 
 type cmdIDKey string

--- a/storage/store.go
+++ b/storage/store.go
@@ -27,7 +27,6 @@ import (
 	"sync"
 	"time"
 
-	gogoproto "code.google.com/p/gogoprotobuf/proto"
 	"github.com/cockroachdb/cockroach/client"
 	"github.com/cockroachdb/cockroach/gossip"
 	"github.com/cockroachdb/cockroach/proto"
@@ -35,6 +34,7 @@ import (
 	"github.com/cockroachdb/cockroach/util"
 	"github.com/cockroachdb/cockroach/util/hlc"
 	"github.com/cockroachdb/cockroach/util/log"
+	gogoproto "github.com/gogo/protobuf/proto"
 )
 
 const (

--- a/storage/store_split_test.go
+++ b/storage/store_split_test.go
@@ -27,12 +27,12 @@ import (
 	"testing"
 	"time"
 
-	gogoproto "code.google.com/p/gogoprotobuf/proto"
 	"github.com/cockroachdb/cockroach/proto"
 	"github.com/cockroachdb/cockroach/storage"
 	"github.com/cockroachdb/cockroach/storage/engine"
 	"github.com/cockroachdb/cockroach/util"
 	"github.com/cockroachdb/cockroach/util/log"
+	gogoproto "github.com/gogo/protobuf/proto"
 )
 
 func adminSplitArgs(key, splitKey []byte, raftID int64, storeID int32) (*proto.AdminSplitRequest, *proto.AdminSplitResponse) {

--- a/storage/store_test.go
+++ b/storage/store_test.go
@@ -27,7 +27,6 @@ import (
 	"testing"
 	"time"
 
-	gogoproto "code.google.com/p/gogoprotobuf/proto"
 	"github.com/cockroachdb/cockroach/client"
 	"github.com/cockroachdb/cockroach/gossip"
 	"github.com/cockroachdb/cockroach/proto"
@@ -35,6 +34,7 @@ import (
 	"github.com/cockroachdb/cockroach/storage/engine"
 	"github.com/cockroachdb/cockroach/util"
 	"github.com/cockroachdb/cockroach/util/hlc"
+	gogoproto "github.com/gogo/protobuf/proto"
 )
 
 var testIdent = proto.StoreIdent{

--- a/util/http.go
+++ b/util/http.go
@@ -24,7 +24,7 @@ import (
 	"regexp"
 	"strings"
 
-	gogoproto "code.google.com/p/gogoprotobuf/proto"
+	gogoproto "github.com/gogo/protobuf/proto"
 	yaml "gopkg.in/yaml.v1"
 )
 

--- a/util/http_test.go
+++ b/util/http_test.go
@@ -23,10 +23,10 @@ import (
 	"reflect"
 	"testing"
 
-	gogoproto "code.google.com/p/gogoprotobuf/proto"
 	"github.com/cockroachdb/cockroach/proto"
 	"github.com/cockroachdb/cockroach/util"
 	"github.com/cockroachdb/cockroach/util/log"
+	gogoproto "github.com/gogo/protobuf/proto"
 )
 
 var testConfig = proto.ZoneConfig{


### PR DESCRIPTION
For issue #248.

I ran a full build for the current master vs. this update, and comparing the output of the two, I didn't see any problems with the bootstrap or the main build process after updating the all references.

Didn't touch the vendored stuff, so etcd still uses the old location.

By the way, there does exist a library in "github.com/gogo/protobuf/gogoproto", so I find that renaming the "github.com/gogo/protobuf/proto" import as "gogoproto" a bit confusing.

Let me know if I missed anything.
