### PR TITLE
Add TimeSeriesData proto message

### DIFF
--- a/proto/data.go
+++ b/proto/data.go
@@ -553,3 +553,87 @@ type Int32Slice []int32
 func (s Int32Slice) Len() int           { return len(s) }
 func (s Int32Slice) Swap(i, j int)      { s[i], s[j] = s[j], s[i] }
 func (s Int32Slice) Less(i, j int) bool { return s[i] < s[j] }
+
+// ToInternal places the datapoints in a TimeSeriesData message into one or
+// more InternalTimeSeriesData messages. The structure and number of messages
+// returned depends on two variables: a key duration, and a sample duration.
+//
+// The key duration is an interval length in nanoseconds used to determine
+// how many intervals are grouped into a single InternalTimeSeriesData
+// message.
+//
+// The sample duration is also an interval length in nanoseconds; it must be
+// less than or equal to the key duration, and must also evenly divide the key
+// duration. Datapoints which fall into the same sample interval will be
+// aggregated together into a single Sample.
+//
+// Example: Assume the desired result is to aggregate individual datapoints into
+// the same sample if they occurred within the same second; additionally, all
+// samples which occur within the same hour should be stored at the same key
+// location within the same InternalTimeSeriesValue. The sample duration should
+// be 10^9 nanoseconds (value of time.Second), and the key duration should be
+// (3600*10^9) nanoseconds (value of time.Hour).
+//
+// Note that this method does not accumulate data into individual samples in the
+// case where multiple datapoints fall into the same sample period. Internal
+// data should be merged into the cockroach data store before being read; the
+// engine is responsible for accumulating samples.
+//
+// The returned slice of InternalTimeSeriesData objects will not be sorted.
+//
+// For more information on how time series data is stored, see
+// InternalTimeSeriesData and its related structures.
+func (ts TimeSeriesData) ToInternal(keyDuration int64, sampleDuration int64) (
+	[]*InternalTimeSeriesData, error) {
+	if keyDuration%sampleDuration != 0 {
+		return nil, util.Errorf(
+			"sample duration %d does not evenly divide key duration %d.",
+			sampleDuration, keyDuration)
+	}
+	if keyDuration < sampleDuration {
+		return nil, util.Errorf(
+			"sample duration %d is not less than or equal to key duration %d.",
+			sampleDuration, keyDuration)
+	}
+
+	result := []*InternalTimeSeriesData{}
+	resultByKeyTime := map[int64]*InternalTimeSeriesData{}
+
+	for _, dp := range ts.Datapoints {
+		// Validate the datapoint.
+		if dp.IntValue == nil && dp.FloatValue == nil {
+			return nil, util.Errorf("datapoint %v has no value.", dp)
+		}
+		if dp.IntValue != nil && dp.FloatValue != nil {
+			return nil, util.Errorf("datapoint %v has both integer and float data.", dp)
+		}
+
+		// Determine which InternalTimeSeriesData this datapoint belongs to,
+		// creating if it has not already been created for a previous sample.
+		keyTime := (dp.TimestampNanos / keyDuration) * keyDuration
+		itsd, ok := resultByKeyTime[keyTime]
+		if !ok {
+			itsd = &InternalTimeSeriesData{
+				StartTimestampNanos: keyTime,
+				SampleDurationNanos: sampleDuration,
+			}
+			result = append(result, itsd)
+			resultByKeyTime[keyTime] = itsd
+		}
+
+		// Create a new sample for this datapoint and place it into the
+		// InternalTimeSeriesData.
+		sampleOffset := int32((dp.TimestampNanos - keyTime) / sampleDuration)
+		sample := &InternalTimeSeriesSample{Offset: sampleOffset}
+		if dp.IntValue != nil {
+			sample.IntCount = 1
+			sample.IntSum = dp.IntValue
+		} else {
+			sample.FloatCount = 1
+			sample.FloatSum = dp.FloatValue
+		}
+		itsd.Samples = append(itsd.Samples, sample)
+	}
+
+	return result, nil
+}

--- a/proto/data.proto
+++ b/proto/data.proto
@@ -248,3 +248,29 @@ message ScanMetadata {
   // GC information from last scan.
   optional GCMetadata gc = 3 [(gogoproto.nullable) = false, (gogoproto.customname) = "GC"];
 }
+
+// TimeSeriesDatapoint is a single point of time series data; a value associated
+// with a timestamp.
+message TimeSeriesDatapoint {
+    // The timestamp when this datapoint is located, expressed in nanoseconds
+    // since the unix epoch.
+    optional int64 timestamp_nanos = 1 [(gogoproto.nullable) = false];
+    // An integer representation of the value of this datapoint. If this field
+    // is set, then 'float_value' must not be set.
+    optional int64 int_value = 2;
+    // A floating point representation of the value of this datapoint. If this
+    // field is set, then 'int_value' must not be set.
+    optional float float_value = 3;
+}
+
+// TimeSeriesData is a set of observations of a single variable value at
+// multiple points in time. This message contains a string which uniquely
+// identifies the source variable, and a repeated set of TimeSeriesDatapoint
+// messages representing distinct measurements of that variable. 
+message TimeSeriesData {
+    // A string which uniquely identifies the variable from which this data was
+    // measured.
+    optional string name = 1 [(gogoproto.nullable) = false];
+    // Datapoints representing one or more measurements taken from the variable.
+    repeated TimeSeriesDatapoint datapoints = 2;
+}

--- a/proto/internal.proto
+++ b/proto/internal.proto
@@ -205,7 +205,7 @@ enum InternalValueType {
 //
 // This is meant to be an efficient internal representation of time series data,
 // ensuring that very little redundant data is stored on disk. With this goal in
-// mind, this message does not identify the statistic which is actually being
+// mind, this message does not identify the variable which is actually being
 // measured; that information is expected be encoded in the key where this
 // message is stored.
 message InternalTimeSeriesData {
@@ -219,13 +219,14 @@ message InternalTimeSeriesData {
     repeated InternalTimeSeriesSample samples = 3;
 }
 
-// A InternalTimeSeriesSample represents data gathered from a single measurable
-// statistic over a given period of time. The length of that period of time is
-// stored in an InternalTimeSeriesData message; a sample cannot be interpreted
-// correctly without a start timestamp and sample duration.
+// A InternalTimeSeriesSample represents data gathered from multiple
+// measurements of a variable value over a given period of time. The length of
+// that period of time is stored in an InternalTimeSeriesData message; a sample
+// cannot be interpreted correctly without a start timestamp and sample
+// duration.
 //
 // Each sample may contain data gathered from multiple measurements of the same
-// statistic, as long as all of those measurements occured within the sample
+// variable, as long as all of those measurements occured within the sample
 // period. The sample stores several aggregated values from these measurements:
 // - The sum of all measured values
 // - A count of all measurements taken
@@ -238,9 +239,9 @@ message InternalTimeSeriesData {
 // If the count of measurements is 1, then max and min fields may be omitted
 // and assumed equal to the sum field.
 //
-// The underlying statistic sampled may be either an integer or a floating
-// point; therefore, there are two fields each for "sum", "max" and "min" to
-// hold either an integer or floating point number. In practice, only one set of
+// The variable being measured may be either an integer or a floating point;
+// therefore, there are two fields each for "sum", "max" and "min" to hold
+// either an integer or floating point number. In practice, only one set of
 // these fields should be present for any individual sample; however, int and
 // float values are recorded in parallel, allowing clients to write both floats
 // and integers to the same value. These are recorded separately to retain


### PR DESCRIPTION
Commit adds the TimeSeriesData and TimeSeriesDatapoint messages, simple
messages which contain time series data as it would be input from external or
internal sources. The TimeSeriesData message is a series name paired with
several TimeSeriesDatapoints, which are simply (timestamp, value) tuples.

Included is the `ToInternal()` method, which converts a TimeSeriesData
message into one or more InternalTimeSeriesData messages which are used to
efficiently store TimeSeriesData in cockroach.
