### PR TITLE
add explicit SSI test for @plaflamme

### DIFF
--- a/proto/api.go
+++ b/proto/api.go
@@ -286,6 +286,17 @@ func DeleteArgs(key Key) *DeleteRequest {
 	}
 }
 
+// DeleteRangeArgs returns a DeleteRangeRequest object initialized to delete
+// the values in the given key range (excluding the endpoint).
+func DeleteRangeArgs(startKey, endKey Key) *DeleteRangeRequest {
+	return &DeleteRangeRequest{
+		RequestHeader: RequestHeader{
+			Key:    startKey,
+			EndKey: endKey,
+		},
+	}
+}
+
 // ScanArgs returns a ScanRequest object initialized to scan
 // from start to end keys with max results.
 func ScanArgs(key, endKey Key, maxResults int64) *ScanRequest {


### PR DESCRIPTION
added a simple test verifiying a situation in which Cockroach seemed to display non-serializable behaviour. The test has passed for me numerous times and is hopefully helpful in tracking down the issue described below.

see https://groups.google.com/forum/#!topic/cockroach-db/LdrC5_T0VNw

via @plaflamme:

```
There are 2 keys involved: k1 and k2. Each has no associated value in the database to start with.

There are 2 values involved: v1 and v2.

There are 2 threads: t1 and t2.

Each thread does this (pseudo code):

work(myKey, otherKey, value) {
  doInTx { // The following calls are within a transaction
    otherValue = get(otherKey) // assume otherValue is null if absent
    myValue = concat(value, otherValue)  // assume that concat(v,null) yields v
    put(myKey, myValue)
  }
}

For t1, we invoke it like so: work(k1, k2, v1)
For t2, we invoke it like so: work(k2, k1, v2)

They run concurrently.

My assumption is that one of the threads will read an empty cell and write a single value to its key (k1 -> v1 or k2 -> v2) while the second will read the other's value, concatenate it to its own and write that (k1 -> v1v2 or k2 -> v2v1). I'm not sure how valid this assumption is in regards to SSI.

I'm using my scala client to run this. The code is here[1] but currently prints the result instead of asserting since I couldn't make it work consistently.

Running this test using the latest cockroachdb/cockroach-dev image still produces inconsistent results. Sometimes I get the expected result and sometimes both transactions succeed, but neither read the other's value (end result is: k1 -> v1 AND k2 -> v2).

Philippe
[1] https://github.com/plaflamme/scroach/blob/ea89a8/src/test/scala/scroach/ClientSpecs.scala#L257
```
