### PR TITLE
Change proto.Error to use onlyone gogoproto option.

### DIFF
--- a/proto/api_test.go
+++ b/proto/api_test.go
@@ -54,6 +54,16 @@ func TestResponseHeaderSetGoError(t *testing.T) {
 	}
 }
 
+// TestResponseHeaderNilError verifies that a nil error can be set
+// and retrieved from a response header.
+func TestResponseHeaderNilError(t *testing.T) {
+	rh := ResponseHeader{}
+	rh.SetGoError(nil)
+	if err := rh.GoError(); err != nil {
+		t.Errorf("expected nil error; got %s", err)
+	}
+}
+
 type XX interface {
 	Run()
 }

--- a/proto/errors.proto
+++ b/proto/errors.proto
@@ -131,6 +131,7 @@ message ConditionFailedError {
 // NOTE: new error types must be added here, and potentially in
 // the two locations (*ResponseHeader).{,Set}GoError().
 message Error {
+  option (gogoproto.onlyone) = true;
   optional GenericError generic = 1;
   optional NotLeaderError not_leader = 2;
   optional RangeNotFoundError range_not_found = 3;


### PR DESCRIPTION
Something didn't quite work with the more standardized protobuf "oneof" directive, even though I followed the details in https://developers.google.com/protocol-buffers/docs/proto exactly. Consider this step one to remove the hand-tooled code used for errors. We can move to "oneof" at some future point.
