### PR TITLE
Reimplement snapshots as a new implementation of Engine interface.

### DIFF
--- a/kv/db_test.go
+++ b/kv/db_test.go
@@ -62,7 +62,7 @@ func TestKVDBCoverage(t *testing.T) {
 	containsReq.Key = key
 	containsResp := &proto.ContainsResponse{}
 	if err := kvClient.Call(proto.Contains, containsReq, containsResp); err != nil || containsResp.Error != nil {
-		t.Fatal("%s, %s", err, containsResp.GoError())
+		t.Fatalf("%s, %s", err, containsResp.GoError())
 	}
 	if !containsResp.Exists {
 		t.Error("expected contains to be true")
@@ -109,7 +109,7 @@ func TestKVDBCoverage(t *testing.T) {
 		t.Fatalf("%s, %s", err, delResp.GoError())
 	}
 	if err := kvClient.Call(proto.Contains, containsReq, containsResp); err != nil || containsResp.Error != nil {
-		t.Fatal("%s, %s", err, containsResp.GoError())
+		t.Fatalf("%s, %s", err, containsResp.GoError())
 	}
 	if containsResp.Exists {
 		t.Error("expected contains to be false after delete")
@@ -170,7 +170,6 @@ func TestKVDBInternalMethods(t *testing.T) {
 		{proto.InternalHeartbeatTxn, &proto.InternalHeartbeatTxnRequest{}, &proto.InternalHeartbeatTxnResponse{}},
 		{proto.InternalPushTxn, &proto.InternalPushTxnRequest{}, &proto.InternalPushTxnResponse{}},
 		{proto.InternalResolveIntent, &proto.InternalResolveIntentRequest{}, &proto.InternalResolveIntentResponse{}},
-		{proto.InternalSnapshotCopy, &proto.InternalSnapshotCopyRequest{}, &proto.InternalSnapshotCopyResponse{}},
 		{proto.InternalMerge, &proto.InternalMergeRequest{}, &proto.InternalMergeResponse{}},
 	}
 	// Verify non-public methods experience bad request errors.

--- a/proto/api.go
+++ b/proto/api.go
@@ -102,7 +102,6 @@ var AllMethods = stringSet{
 	InternalHeartbeatTxn:  struct{}{},
 	InternalPushTxn:       struct{}{},
 	InternalResolveIntent: struct{}{},
-	InternalSnapshotCopy:  struct{}{},
 	InternalMerge:         struct{}{},
 }
 
@@ -131,20 +130,18 @@ var InternalMethods = stringSet{
 	InternalHeartbeatTxn:  struct{}{},
 	InternalPushTxn:       struct{}{},
 	InternalResolveIntent: struct{}{},
-	InternalSnapshotCopy:  struct{}{},
 	InternalMerge:         struct{}{},
 }
 
 // ReadMethods specifies the set of methods which read and return data.
 var ReadMethods = stringSet{
-	Contains:             struct{}{},
-	Get:                  struct{}{},
-	ConditionalPut:       struct{}{},
-	Increment:            struct{}{},
-	Scan:                 struct{}{},
-	ReapQueue:            struct{}{},
-	InternalRangeLookup:  struct{}{},
-	InternalSnapshotCopy: struct{}{},
+	Contains:            struct{}{},
+	Get:                 struct{}{},
+	ConditionalPut:      struct{}{},
+	Increment:           struct{}{},
+	Scan:                struct{}{},
+	ReapQueue:           struct{}{},
+	InternalRangeLookup: struct{}{},
 }
 
 // WriteMethods specifies the set of methods which write data.
@@ -336,8 +333,6 @@ func MethodForRequest(req Request) (string, error) {
 		return InternalPushTxn, nil
 	case *InternalResolveIntentRequest:
 		return InternalResolveIntent, nil
-	case *InternalSnapshotCopyRequest:
-		return InternalSnapshotCopy, nil
 	case *InternalMergeRequest:
 		return InternalMerge, nil
 	}
@@ -391,8 +386,6 @@ func CreateArgs(method string) (Request, error) {
 		return &InternalPushTxnRequest{}, nil
 	case InternalResolveIntent:
 		return &InternalResolveIntentRequest{}, nil
-	case InternalSnapshotCopy:
-		return &InternalSnapshotCopyRequest{}, nil
 	case InternalMerge:
 		return &InternalMergeRequest{}, nil
 	}
@@ -436,8 +429,6 @@ func CreateReply(method string) (Response, error) {
 		return &InternalPushTxnResponse{}, nil
 	case InternalResolveIntent:
 		return &InternalResolveIntentResponse{}, nil
-	case InternalSnapshotCopy:
-		return &InternalSnapshotCopyResponse{}, nil
 	case InternalMerge:
 		return &InternalMergeResponse{}, nil
 	}

--- a/proto/internal.go
+++ b/proto/internal.go
@@ -43,10 +43,6 @@ const (
 	// InternalResolveIntent resolves existing write intents for a key or
 	// key range.
 	InternalResolveIntent = "InternalResolveIntent"
-	// InternalSnapshotCopy scans the key range specified by start key through
-	// end key up to some maximum number of results from the given snapshot_id.
-	// It will create a snapshot if snapshot_id is empty.
-	InternalSnapshotCopy = "InternalSnapshotCopy"
 	// InternalMerge merges a given value into the specified key. Merge is a
 	// high-performance operation provided by underlying data storage for values
 	// which are accumulated over several writes. Because it is not

--- a/proto/internal.proto
+++ b/proto/internal.proto
@@ -111,27 +111,6 @@ message InternalResolveIntentResponse {
   optional ResponseHeader header = 1 [(gogoproto.nullable) = false, (gogoproto.embed) = true];
 }
 
-// An InternalSnapshotCopyRequest is arguments to the InternalSnapshotCopy()
-// method. It specifies the start and end keys for the scan and the
-// maximum number of results from the given snapshot_id. It will create
-// a snapshot if snapshot_id is empty.
-message InternalSnapshotCopyRequest {
-  optional RequestHeader header = 1 [(gogoproto.nullable) = false, (gogoproto.embed) = true];
-  // Optional, a new snapshot will be created if it is empty.
-  optional string snapshot_id = 2 [(gogoproto.nullable) = false, (gogoproto.customname) = "SnapshotID"];
-  // Must be > 0.
-  optional int64 max_results = 3 [(gogoproto.nullable) = false];
-}
-
-// An InternalSnapshotCopyResponse is the return value from the
-// InternalSnapshotCopy() method.
-message InternalSnapshotCopyResponse {
-  optional ResponseHeader header = 1 [(gogoproto.nullable) = false, (gogoproto.embed) = true];
-  optional string snapshot_id = 2 [(gogoproto.nullable) = false, (gogoproto.customname) = "SnapshotID"];
-  // Empty if no rows were scanned.
-  repeated RawKeyValue rows = 3 [(gogoproto.nullable) = false];
-}
-
 // An InternalMergeRequest contains arguments to the InternalMerge() method. It
 // specifies a key and a value which should be merged into the existing value at
 // that key.
@@ -190,8 +169,7 @@ message InternalRaftCommandUnion {
   optional InternalHeartbeatTxnRequest internal_heartbeat_txn = 32;
   optional InternalPushTxnRequest internal_push_txn = 33;
   optional InternalResolveIntentRequest internal_resolve_intent = 34;
-  optional InternalSnapshotCopyRequest internal_snapshot_copy = 35;
-  optional InternalMergeRequest internal_merge_response = 36;
+  optional InternalMergeRequest internal_merge_response = 35;
 }
 
 // An InternalRaftCommand is a command which can be serialized and

--- a/server/node.go
+++ b/server/node.go
@@ -476,11 +476,6 @@ func (n *Node) InternalResolveIntent(args *proto.InternalResolveIntentRequest, r
 	return n.executeCmd(proto.InternalResolveIntent, args, reply)
 }
 
-// InternalSnapshotCopy .
-func (n *Node) InternalSnapshotCopy(args *proto.InternalSnapshotCopyRequest, reply *proto.InternalSnapshotCopyResponse) error {
-	return n.executeCmd(proto.InternalSnapshotCopy, args, reply)
-}
-
 // InternalMerge .
 func (n *Node) InternalMerge(args *proto.InternalMergeRequest, reply *proto.InternalMergeResponse) error {
 	return n.executeCmd(proto.InternalMerge, args, reply)

--- a/storage/engine/batch.go
+++ b/storage/engine/batch.go
@@ -209,26 +209,6 @@ func (b *Batch) Capacity() (StoreCapacity, error) {
 func (b *Batch) SetGCTimeouts(minTxnTS, minRCacheTS int64) {
 }
 
-// CreateSnapshot returns an error if called on a Batch.
-func (b *Batch) CreateSnapshot(snapshotID string) error {
-	return util.Errorf("cannot create a snapshot from a Batch")
-}
-
-// ReleaseSnapshot returns an error if called on a Batch.
-func (b *Batch) ReleaseSnapshot(snapshotID string) error {
-	return util.Errorf("cannot release a snapshot from a Batch")
-}
-
-// GetSnapshot returns an error if called on a Batch.
-func (b *Batch) GetSnapshot(key proto.EncodedKey, snapshotID string) ([]byte, error) {
-	return nil, util.Errorf("cannot get with a snapshot from a Batch")
-}
-
-// IterateSnapshot returns an error if called on a Batch.
-func (b *Batch) IterateSnapshot(start, end proto.EncodedKey, snapshotID string, f func(proto.RawKeyValue) (bool, error)) error {
-	return util.Errorf("cannot iterate with a snapshot from a Batch")
-}
-
 // ApproximateSize returns an error if called on a Batch.
 func (b *Batch) ApproximateSize(start, end proto.EncodedKey) (uint64, error) {
 	return 0, util.Errorf("cannot get approximate size from a Batch")
@@ -238,6 +218,11 @@ func (b *Batch) ApproximateSize(start, end proto.EncodedKey) (uint64, error) {
 // not thread safe.
 func (b *Batch) NewIterator() Iterator {
 	return newBatchIterator(b.engine, &b.updates)
+}
+
+// NewSnapshot returns nil if called on a Batch.
+func (b *Batch) NewSnapshot() Engine {
+	return nil
 }
 
 // NewBatch returns a new Batch instance wrapping same underlying engine.

--- a/storage/engine/engine.go
+++ b/storage/engine/engine.go
@@ -64,9 +64,6 @@ type Iterator interface {
 
 // Engine is the interface that wraps the core operations of a
 // key/value store.
-// TODO(Jiang-Ming,Spencer): Remove some of the *Snapshot methods and have
-// their non-snapshot counterparts accept a snapshotID which is used unless
-// empty.
 type Engine interface {
 	// Start initializes and starts the engine.
 	Start() error
@@ -115,17 +112,6 @@ type Engine interface {
 	// Rows with timestamps less than the associated value will be GC'd
 	// during compaction.
 	SetGCTimeouts(minTxnTS, minRCacheTS int64)
-	// CreateSnapshot creates a snapshot handle from engine.
-	CreateSnapshot(snapshotID string) error
-	// ReleaseSnapshot releases the existing snapshot handle for the
-	// given snapshotID.
-	ReleaseSnapshot(snapshotID string) error
-	// GetSnapshot returns the value for the given key from the given
-	// snapshotID, nil otherwise.
-	GetSnapshot(key proto.EncodedKey, snapshotID string) ([]byte, error)
-	// IterateSnapshot scans from start to end keys, visiting at
-	// most max key/value pairs from the specified snapshot ID.
-	IterateSnapshot(start, end proto.EncodedKey, snapshotID string, f func(proto.RawKeyValue) (bool, error)) error
 	// ApproximateSize returns the approximate number of bytes the engine is
 	// using to store data for the given range of keys.
 	ApproximateSize(start, end proto.EncodedKey) (uint64, error)
@@ -133,6 +119,12 @@ type Engine interface {
 	// engine. The caller must invoke Iterator.Close() when finished with
 	// the iterator to free resources.
 	NewIterator() Iterator
+	// NewSnapshot returns a new instance of a read-only snapshot
+	// engine. Snapshots are instantaneous and, as long as they're
+	// released relatively quickly, inexpensive. Snapshots are released
+	// by invoking Stop(). Note that snapshots must not be used after the
+	// original engine has been stopped.
+	NewSnapshot() Engine
 	// NewBatch returns a new instance of a batched engine which wraps
 	// this engine. Batched engines accumulate all mutations and apply
 	// them atomically on a call to Commit().
@@ -140,11 +132,6 @@ type Engine interface {
 	// Commit atomically applies any batched updates to the underlying
 	// engine. This is a noop unless the engine was created via NewBatch().
 	Commit() error
-
-	// TODO(petermattis): Remove the WriteBatch functionality from this
-	//   interface. Add a "NewSnapshot() Engine" method which works
-	//   similarly to NewBatch and remove CreateSnapshot, GetSnapshot,
-	//   IterateSnapshot.
 }
 
 // A BatchDelete is a delete operation executed as part of an atomic batch.
@@ -249,19 +236,6 @@ func Increment(engine Engine, key proto.EncodedKey, inc int64) (int64, error) {
 func Scan(engine Engine, start, end proto.EncodedKey, max int64) ([]proto.RawKeyValue, error) {
 	var kvs []proto.RawKeyValue
 	err := engine.Iterate(start, end, func(kv proto.RawKeyValue) (bool, error) {
-		if max != 0 && int64(len(kvs)) >= max {
-			return true, nil
-		}
-		kvs = append(kvs, kv)
-		return false, nil
-	})
-	return kvs, err
-}
-
-// ScanSnapshot scans using the given snapshot ID.
-func ScanSnapshot(engine Engine, start, end proto.EncodedKey, max int64, snapshotID string) ([]proto.RawKeyValue, error) {
-	var kvs []proto.RawKeyValue
-	err := engine.IterateSnapshot(start, end, snapshotID, func(kv proto.RawKeyValue) (bool, error) {
 		if max != 0 && int64(len(kvs)) >= max {
 			return true, nil
 		}

--- a/storage/engine/engine_test.go
+++ b/storage/engine/engine_test.go
@@ -506,16 +506,11 @@ func TestSnapshot(t *testing.T) {
 				val, val1)
 		}
 
-		snapshotID := strconv.FormatInt(1, 10)
-		error := engine.CreateSnapshot(snapshotID)
-		if error != nil {
-			t.Fatalf("error : %s", error)
-		}
-
+		snap := engine.NewSnapshot()
 		val2 := []byte("2")
 		engine.Put(key, val2)
 		val, _ = engine.Get(key)
-		valSnapshot, error := engine.GetSnapshot(key, snapshotID)
+		valSnapshot, error := snap.Get(key)
 		if error != nil {
 			t.Fatalf("error : %s", error)
 		}
@@ -529,7 +524,7 @@ func TestSnapshot(t *testing.T) {
 		}
 
 		keyvals, _ := Scan(engine, key, proto.EncodedKey(KeyMax), 0)
-		keyvalsSnapshot, error := ScanSnapshot(engine, key, proto.EncodedKey(KeyMax), 0, snapshotID)
+		keyvalsSnapshot, error := Scan(snap, key, proto.EncodedKey(KeyMax), 0)
 		if error != nil {
 			t.Fatalf("error : %s", error)
 		}
@@ -541,8 +536,7 @@ func TestSnapshot(t *testing.T) {
 			t.Fatalf("the value %s in get result does not match the value %s in request",
 				keyvalsSnapshot[0].Value, val1)
 		}
-
-		engine.ReleaseSnapshot(snapshotID)
+		snap.Stop()
 	}, t)
 }
 

--- a/storage/engine/in_mem.go
+++ b/storage/engine/in_mem.go
@@ -305,7 +305,7 @@ func cloneNode(a *llrb.Node) *llrb.Node {
 	return newNode
 }
 
-// Returns a new Batch wrapping this in-memory engine.
+// NewBatch returns a new Batch wrapping this in-memory engine.
 func (in *InMem) NewBatch() Engine {
 	return &Batch{engine: in}
 }
@@ -345,7 +345,13 @@ func (in *inMemSnapshot) Merge(key proto.EncodedKey, value []byte) error {
 func (in *inMemSnapshot) SetGCTimeouts(minTxnTS, minRCacheTS int64) {
 }
 
-// NewBatch is illegal for snapshot and returns an error.
+// NewSnapshot is illegal for snapshot and returns nil.
+func (in *inMemSnapshot) NewSnapshot() Engine {
+	log.Errorf("cannot create a NewSnapshot from a snapshot")
+	return nil
+}
+
+// NewBatch is illegal for snapshot and returns nil.
 func (in *inMemSnapshot) NewBatch() Engine {
 	log.Errorf("cannot create a NewBatch from a snapshot")
 	return nil

--- a/storage/engine/in_mem.go
+++ b/storage/engine/in_mem.go
@@ -28,6 +28,7 @@ import (
 	"code.google.com/p/biogo.store/llrb"
 	"github.com/cockroachdb/cockroach/proto"
 	"github.com/cockroachdb/cockroach/util"
+	"github.com/cockroachdb/cockroach/util/log"
 )
 
 // TODO(petermattis): Remove this file.
@@ -56,15 +57,13 @@ type InMem struct {
 	maxBytes  int64
 	usedBytes int64
 	data      llrb.Tree
-	snapshots map[string]llrb.Tree
 }
 
 // NewInMem allocates and returns a new InMem object.
 func NewInMem(attrs proto.Attributes, maxBytes int64) *InMem {
 	return &InMem{
-		snapshots: map[string]llrb.Tree{},
-		attrs:     attrs,
-		maxBytes:  maxBytes,
+		attrs:    attrs,
+		maxBytes: maxBytes,
 	}
 }
 
@@ -80,48 +79,6 @@ func (in *InMem) Start() error {
 
 // Stop is a noop for the InMem engine.
 func (in *InMem) Stop() {
-}
-
-// CreateSnapshot creates a snapshot handle from engine.
-func (in *InMem) CreateSnapshot(snapshotID string) error {
-	in.Lock()
-	defer in.Unlock()
-	_, ok := in.snapshots[snapshotID]
-	if ok {
-		return util.Errorf("snapshotID %s already exists", snapshotID)
-	}
-	snapshotHandle := cloneTree(in.data)
-	in.snapshots[snapshotID] = snapshotHandle
-	return nil
-}
-
-func cloneTree(a llrb.Tree) llrb.Tree {
-	var newTree = llrb.Tree{Count: a.Count}
-	newTree.Root = cloneNode(a.Root)
-	return newTree
-}
-
-func cloneNode(a *llrb.Node) *llrb.Node {
-	if a == nil {
-		return nil
-	}
-	var newNode = &llrb.Node{Elem: a.Elem, Color: a.Color}
-	newNode.Left = cloneNode(a.Left)
-	newNode.Right = cloneNode(a.Right)
-	return newNode
-}
-
-// ReleaseSnapshot releases the existing snapshot handle for the
-// given snapshotID.
-func (in *InMem) ReleaseSnapshot(snapshotID string) error {
-	in.Lock()
-	defer in.Unlock()
-	_, ok := in.snapshots[snapshotID]
-	if !ok {
-		return util.Errorf("snapshotID %s does not exist", snapshotID)
-	}
-	delete(in.snapshots, snapshotID)
-	return nil
 }
 
 // Attrs returns the list of attributes describing this engine. This
@@ -189,18 +146,6 @@ func (in *InMem) Get(key proto.EncodedKey) ([]byte, error) {
 	return in.getLocked(key, in.data)
 }
 
-// GetSnapshot returns the value for the given key from the given
-// snapshotID, nil otherwise.
-func (in *InMem) GetSnapshot(key proto.EncodedKey, snapshotID string) ([]byte, error) {
-	in.RLock()
-	defer in.RUnlock()
-	snapshotHandle, ok := in.snapshots[snapshotID]
-	if !ok {
-		return nil, util.Errorf("snapshotID %s does not exist", snapshotID)
-	}
-	return in.getLocked(key, snapshotHandle)
-}
-
 // getLocked performs a get operation assuming that the caller
 // is already holding the mutex.
 func (in *InMem) getLocked(key proto.EncodedKey, data llrb.Tree) ([]byte, error) {
@@ -221,18 +166,6 @@ func (in *InMem) Iterate(start, end proto.EncodedKey, f func(proto.RawKeyValue) 
 	in.RLock()
 	defer in.RUnlock()
 	return in.iterateLocked(start, end, f, in.data)
-}
-
-// Iterate iterates from start to end keys using snapshot ID, invoking
-// f on each key/value pair. See engine.IterateSnapshot for details.
-func (in *InMem) IterateSnapshot(start, end proto.EncodedKey, snapshotID string, f func(proto.RawKeyValue) (bool, error)) error {
-	in.RLock()
-	defer in.RUnlock()
-	snapshotHandle, ok := in.snapshots[snapshotID]
-	if !ok {
-		return util.Errorf("snapshotID %s does not exist", snapshotID)
-	}
-	return in.iterateLocked(start, end, f, snapshotHandle)
 }
 
 func (in *InMem) iterateLocked(start, end proto.EncodedKey, f func(proto.RawKeyValue) (bool, error), data llrb.Tree) error {
@@ -342,6 +275,36 @@ func (in *InMem) NewIterator() Iterator {
 	}
 }
 
+// NewSnapshot creates a read-only snapshot engine from this engine.
+func (in *InMem) NewSnapshot() Engine {
+	in.Lock()
+	defer in.Unlock()
+	return &inMemSnapshot{
+		InMem: InMem{
+			attrs:     in.attrs,
+			maxBytes:  in.maxBytes,
+			usedBytes: in.usedBytes,
+			data:      cloneTree(in.data),
+		},
+	}
+}
+
+func cloneTree(a llrb.Tree) llrb.Tree {
+	var newTree = llrb.Tree{Count: a.Count}
+	newTree.Root = cloneNode(a.Root)
+	return newTree
+}
+
+func cloneNode(a *llrb.Node) *llrb.Node {
+	if a == nil {
+		return nil
+	}
+	var newNode = &llrb.Node{Elem: a.Elem, Color: a.Color}
+	newNode.Left = cloneNode(a.Left)
+	newNode.Right = cloneNode(a.Right)
+	return newNode
+}
+
 // Returns a new Batch wrapping this in-memory engine.
 func (in *InMem) NewBatch() Engine {
 	return &Batch{engine: in}
@@ -350,6 +313,47 @@ func (in *InMem) NewBatch() Engine {
 // Commit is a noop for in-memory engine.
 func (in *InMem) Commit() error {
 	return nil
+}
+
+// This implementation restricts operation of the underlying in memory
+// engine to read-only commands.
+type inMemSnapshot struct {
+	InMem
+}
+
+// Put is illegal for snapshot and returns an error.
+func (in *inMemSnapshot) Put(key proto.EncodedKey, value []byte) error {
+	return util.Errorf("cannot Put to a snapshot")
+}
+
+// Clear is illegal for snapshot and returns an error.
+func (in *inMemSnapshot) Clear(key proto.EncodedKey) error {
+	return util.Errorf("cannot Clear from a snapshot")
+}
+
+// WriteBatch is illegal for snapshot and returns an error.
+func (in *inMemSnapshot) WriteBatch([]interface{}) error {
+	return util.Errorf("cannot WriteBatch to a snapshot")
+}
+
+// Merge is illegal for snapshot and returns an error.
+func (in *inMemSnapshot) Merge(key proto.EncodedKey, value []byte) error {
+	return util.Errorf("cannot Merge to a snapshot")
+}
+
+// SetGCTimeouts is a noop for a snapshot.
+func (in *inMemSnapshot) SetGCTimeouts(minTxnTS, minRCacheTS int64) {
+}
+
+// NewBatch is illegal for snapshot and returns an error.
+func (in *inMemSnapshot) NewBatch() Engine {
+	log.Errorf("cannot create a NewBatch from a snapshot")
+	return nil
+}
+
+// Commit is illegal for snapshot and returns an error.
+func (in *inMemSnapshot) Commit() error {
+	return util.Errorf("cannot Commit to a snapshot")
 }
 
 // This implementation is not very efficient because the biogo LLRB

--- a/storage/engine/keys.go
+++ b/storage/engine/keys.go
@@ -196,9 +196,6 @@ var (
 	// KeyLocalTransactionPrefix specifies the key prefix for
 	// transaction records. The suffix is the transaction id.
 	KeyLocalTransactionPrefix = MakeKey(KeyLocalPrefix, proto.Key("txn-"))
-	// KeyLocalSnapshotIDGenerator is a snapshot ID generator sequence.
-	// Snapshot IDs must be unique per store ID.
-	KeyLocalSnapshotIDGenerator = MakeKey(KeyLocalPrefix, proto.Key("ssid"))
 
 	// KeyLocalMax is the end of the local key range.
 	KeyLocalMax = KeyLocalPrefix.PrefixEnd()

--- a/storage/engine/mvcc.go
+++ b/storage/engine/mvcc.go
@@ -1034,13 +1034,12 @@ func isValidEncodedSplitKey(key proto.EncodedKey) bool {
 
 // MVCCFindSplitKey suggests a split key from the given user-space key
 // range that aims to roughly cut into half the total number of bytes
-// used (in raw key and value byte strings) in both subranges. It will
-// operate on a snapshot of the underlying engine if a snapshotID is
-// given, and in that case may safely be invoked in a goroutine.
+// used (in raw key and value byte strings) in both subranges. Specify
+// a snapshot engine to safely invoke this method in a goroutine.
 //
 // The split key will never be chosen from the key ranges listed in
 // illegalSplitKeyRanges.
-func MVCCFindSplitKey(engine Engine, raftID int64, key, endKey proto.Key, snapshotID string) (proto.Key, error) {
+func MVCCFindSplitKey(engine Engine, raftID int64, key, endKey proto.Key) (proto.Key, error) {
 	if key.Less(KeyLocalMax) {
 		key = KeyLocalMax
 	}
@@ -1058,7 +1057,7 @@ func MVCCFindSplitKey(engine Engine, raftID int64, key, endKey proto.Key, snapsh
 	bestSplitKey := encStartKey
 	bestSplitDiff := int64(math.MaxInt64)
 
-	if err := engine.IterateSnapshot(encStartKey, encEndKey, snapshotID, func(kv proto.RawKeyValue) (bool, error) {
+	if err := engine.Iterate(encStartKey, encEndKey, func(kv proto.RawKeyValue) (bool, error) {
 		// Is key within a legal key range?
 		valid := isValidEncodedSplitKey(kv.Key)
 

--- a/storage/engine/rocksdb.go
+++ b/storage/engine/rocksdb.go
@@ -377,7 +377,7 @@ func (r *RocksDB) NewSnapshot() Engine {
 	}
 }
 
-// Returns a new Batch wrapping this rocksdb engine.
+// NewBatch returns a new Batch wrapping this rocksdb engine.
 func (r *RocksDB) NewBatch() Engine {
 	return &Batch{engine: r}
 }
@@ -461,14 +461,13 @@ func (r *rocksDBSnapshot) NewIterator() Iterator {
 	return newRocksDBIterator(r.parent.rdb, r.handle)
 }
 
-// NewSnapshot returns a new instance of a read-only snapshot
-// from the original RocksDB instance. This will be an updated
-// snapshot.
+// NewSnapshot is illegal for snapshot and returns nil.
 func (r *rocksDBSnapshot) NewSnapshot() Engine {
-	return r.parent.NewSnapshot()
+	log.Errorf("cannot create a NewSnapshot from a snapshot")
+	return nil
 }
 
-// NewBatch is illegal for snapshot and returns an error.
+// NewBatch is illegal for snapshot and returns nil.
 func (r *rocksDBSnapshot) NewBatch() Engine {
 	log.Errorf("cannot create a NewBatch from a snapshot")
 	return nil

--- a/storage/store.go
+++ b/storage/store.go
@@ -23,7 +23,6 @@ import (
 	"fmt"
 	"net"
 	"sort"
-	"strconv"
 	"sync"
 	"time"
 
@@ -646,17 +645,9 @@ func (s *Store) RemoveRange(rng *Range) error {
 	return nil
 }
 
-// CreateSnapshot creates a new snapshot, named using an internal counter.
-func (s *Store) CreateSnapshot() (string, error) {
-	s.mu.Lock()
-	defer s.mu.Unlock()
-	key := engine.KeyLocalSnapshotIDGenerator
-	candidateID, err := engine.MVCCIncrement(s.engine, nil, key, proto.ZeroTimestamp, nil, 1)
-	if err != nil {
-		return "", err
-	}
-	snapshotID := strconv.FormatInt(candidateID, 10)
-	return snapshotID, s.engine.CreateSnapshot(snapshotID)
+// NewSnapshot creates a new snapshot engine.
+func (s *Store) NewSnapshot() engine.Engine {
+	return s.engine.NewSnapshot()
 }
 
 // Attrs returns the attributes of the underlying store.


### PR DESCRIPTION
This fixes a TODO in the code and helpful to upcoming changes to
implement asynchronous scans of ranges for custodial work. Without,
more Engine method variants taking snapshot IDs would be necessary.
This change is more in keeping with how we do Batch engines and is
simpler.

Also remove the InternalSnapshotCopy method, which will be replaced
by an in-Raft mechanism whereby the leader feeds the snapshot directly
to a requesting follower.
