### PR TITLE
Scan queue for range maintenance.

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -65,3 +65,8 @@
     utilized set may have rebalances in effect.
 
 * Cleanup proto files to adhere to proto capitalization instead of go's.
+
+* Consider moving all local keys into two sections, each prefixed by either
+  the Raft ID of the range or the start key of the range. This will allow
+  a less error-prone iteration over the data for a range, instead of having
+  to include each section of local data separately.

--- a/TODO.md
+++ b/TODO.md
@@ -2,6 +2,9 @@
   process with a deferred recover func to prevent HTTP from swallowing
   panics which might otherwise be holding locks, etc.
 
+* Response cache should use 1 hour since last committed log entry for
+  GC.
+
 * Transactions
 
   - Keep a cache of pushed transactions on a store to avoid repushing
@@ -44,47 +47,21 @@
 
 * Propagate errors from storage/id_alloc.go
 
-* Accept a list of acknowledged client command ids in RequestHeader,
-  allowing the server to garbage collect response cache entries.
-
-* StoreFinder using Gossip protocol to filter
-
 * Rebalance range replica. Only fully-replicated ranges may be
   rebalanced.
 
   - Keep a rebalance queue in memory. Range replicas are added to the
-    queue from a store during initial range scan and also during
-    operation as a response to certain conditions. Listed here:
-
-    - A range is split. Each replica in the split range is marked as
-      needing rebalancing.
+    queue from a store during range scan according to certain conditions:
 
     - Replica not matching zone config. When zone config changes happen,
       all ranges are scanned by each store and any mismatched replicas
       are added to the queue.
+
+    - Store is overweight in terms of size or range count.
 
   - Rebalance away from stores finding themselves in top N space
     utilized, taking care to account for fewer than N stores in
     cluster. Only stores finding themselves in the top N space
     utilized set may have rebalances in effect.
 
-  - Rebalance target is selected from available stores in bottom N
-    space utilized. Adjacent stores are exempted.
-
-  - Add rebalance target to replica set and rewrite range addressing
-    indexes.
-
-  - Rebalance targets are added to replica set always exactly one at a
-    time. Targets are marked as REBALANCING. Obsolete sources are
-    marked as PENDING_DELETION. Any time a range becomes fully
-    replicated, the range leader replica will move REBALANCING
-    replicas into state OK and will remove PENDING_DELETION replicas
-    from the RangeDescriptor. The store which owns a removed replica
-    is responsible for clearing the relevant portion of the key space
-    as well as any other housekeeping details.
-
 * Cleanup proto files to adhere to proto capitalization instead of go's.
-
-* Rewrite storage/engine/batch.go functionality to C++, using Viewfinder
-  client C++ code as a starting point. Snapshots and batches should just
-  be new engine types.

--- a/proto/data.proto
+++ b/proto/data.proto
@@ -223,11 +223,8 @@ message MVCCMetadata {
 // GC passes and enable the scheduler to avoid GCing ranges which have
 // very little sufficiently aged data.
 message GCMetadata {
-  // The last GC timestamp in nanoseconds since the Unix epoch.
-  optional int64 last_gc_nanos = 1 [(gogoproto.nullable) = false, (gogoproto.customname) = "LastGCNanos"];
   // The GC TTL for the range at last GC.
-  optional int32 ttl_seconds = 2 [(gogoproto.nullable) = false, (gogoproto.customname) = "TTLSeconds"];
-
+  optional int32 ttl_seconds = 1 [(gogoproto.nullable) = false, (gogoproto.customname) = "TTLSeconds"];
   // Byte_counts is an array of byte counts with 10 entries. Each array
   // entry corresponds to the number of non-live (historical) bytes aged
   // less than some fraction of the TTL. The first entry in the array
@@ -237,5 +234,17 @@ message GCMetadata {
   // These are values at last GC, so given the current time,
   // last_gc_nanos, and ttl_seconds, the count of bytes to be GC'd can
   // be estimated.
-  repeated int64 byte_counts = 3 [(gogoproto.nullable) = false];
+  repeated int64 byte_counts = 2 [(gogoproto.nullable) = false];
+}
+
+// ScanMetadata holds information about last complete key/value scan
+// of a range.
+message ScanMetadata {
+  // The last scan timestamp in nanoseconds since the Unix epoch.
+  optional int64 last_scan_nanos = 1 [(gogoproto.nullable) = false];
+  // The oldest unresolved write intent in nanoseconds since epoch.
+  // Null if there are no unresolved write intents.
+  optional int64 oldest_intent_nanos = 2;
+  // GC information from last scan.
+  optional GCMetadata gc = 3 [(gogoproto.nullable) = false, (gogoproto.customname) = "GC"];
 }

--- a/proto/data_test.go
+++ b/proto/data_test.go
@@ -360,13 +360,13 @@ func TestValueChecksumWithInteger(t *testing.T) {
 
 func TestGCMetadataEstimatedBytes(t *testing.T) {
 	gc := GCMetadata{
-		LastGCNanos: 0,
-		TTLSeconds:  100,
-		ByteCounts:  []int64{10, 9, 8, 7, 6, 5, 4, 3, 2, 1},
+		TTLSeconds: 100,
+		ByteCounts: []int64{10, 9, 8, 7, 6, 5, 4, 3, 2, 1},
 	}
 	for i := int64(-1); i < int64(110); i++ {
 		expBytes := i / 10
-		if eb := gc.EstimatedBytes(time.Unix(i, 0), 0); eb != expBytes {
+		elapsedNanos := time.Unix(i, 0).UnixNano()
+		if eb := gc.EstimatedBytes(elapsedNanos, 0); eb != expBytes {
 			t.Errorf("expected %d @%ds; got %d", expBytes, i, eb)
 		}
 	}
@@ -379,7 +379,8 @@ func TestGCMetadataEstimatedBytes(t *testing.T) {
 	for i := int64(100); i < int64(1000); i += 100 {
 		fraction := (float64(i)/100 - 1) / (float64(i) / 100)
 		expBytes := 10 + int64(100*fraction)
-		if eb := gc.EstimatedBytes(time.Unix(i, 0), 110); eb != expBytes {
+		elapsedNanos := time.Unix(i, 0).UnixNano()
+		if eb := gc.EstimatedBytes(elapsedNanos, 110); eb != expBytes {
 			t.Errorf("expected %d @%ds; got %d", expBytes, i, eb)
 		}
 	}

--- a/storage/engine/batch.go
+++ b/storage/engine/batch.go
@@ -275,7 +275,7 @@ func (bi *batchIterator) Next() {
 	}
 }
 
-func (bi *batchIterator) Key() []byte {
+func (bi *batchIterator) Key() proto.EncodedKey {
 	if !bi.Valid() {
 		debug.PrintStack()
 		bi.err = util.Errorf("access to invalid key")

--- a/storage/engine/engine.go
+++ b/storage/engine/engine.go
@@ -55,7 +55,7 @@ type Iterator interface {
 	// iterator was not positioned at the last key.
 	Next()
 	// Key returns the current key as a byte slice.
-	Key() []byte
+	Key() proto.EncodedKey
 	// Value returns the current value as a byte slice.
 	Value() []byte
 	// Error returns the error, if any, which the iterator encountered.

--- a/storage/engine/in_mem.go
+++ b/storage/engine/in_mem.go
@@ -409,9 +409,9 @@ func (in *inMemIterator) Next() {
 	}, proto.RawKeyValue{Key: start}, proto.RawKeyValue{Key: proto.EncodedKey(KeyMax)})
 }
 
-func (in *inMemIterator) Key() []byte {
+func (in *inMemIterator) Key() proto.EncodedKey {
 	if !in.Valid() {
-		in.err = util.Errorf("access to invalid key")
+		in.err = util.Errorf("invalid iterator")
 		return nil
 	}
 	return in.cur.Key
@@ -419,7 +419,7 @@ func (in *inMemIterator) Key() []byte {
 
 func (in *inMemIterator) Value() []byte {
 	if !in.Valid() {
-		in.err = util.Errorf("access to invalid key")
+		in.err = util.Errorf("invalid iterator")
 		return nil
 	}
 	return in.cur.Value

--- a/storage/engine/keys.go
+++ b/storage/engine/keys.go
@@ -23,6 +23,7 @@ import (
 	"fmt"
 
 	"github.com/cockroachdb/cockroach/proto"
+	"github.com/cockroachdb/cockroach/util/encoding"
 	"github.com/cockroachdb/cockroach/util/log"
 )
 
@@ -68,6 +69,12 @@ func KeyAddress(k proto.Key) proto.Key {
 	return k[KeyLocalPrefixLength:]
 }
 
+// RangeScanMetadataKey returns a system-local key for range scan
+// metadata.
+func RangeScanMetadataKey(startKey proto.Key) proto.Key {
+	return MakeLocalKey(KeyLocalRangeScanMetadataPrefix, startKey)
+}
+
 // RangeDescriptorKey returns a system-local key for the descriptor
 // for the range with specified start key.
 func RangeDescriptorKey(startKey proto.Key) proto.Key {
@@ -97,6 +104,13 @@ func RangeMetaKey(key proto.Key) proto.Key {
 // descriptor should be stored as a value.
 func RangeMetaLookupKey(r *proto.RangeDescriptor) proto.Key {
 	return RangeMetaKey(r.EndKey)
+}
+
+// TransactionKey returns a transaction key based on the provided
+// transaction key and ID. The base key is encoded in order to
+// guarantee that all transaction records for a range sort together.
+func TransactionKey(key proto.Key, id []byte) proto.Key {
+	return MakeKey(KeyLocalTransactionPrefix, encoding.EncodeBinary(nil, key), id)
 }
 
 // ValidateRangeMetaKey validates that the given key is a valid Range Metadata
@@ -186,6 +200,8 @@ var (
 	// KeyLocalRangeDescriptorPrefix is the prefix for keys storing
 	// range descriptors. The value is a struct of type RangeDescriptor.
 	KeyLocalRangeDescriptorPrefix = MakeKey(KeyLocalPrefix, proto.Key("rng-"))
+	// KeyLocalRangeScanMetadataPrefix is the prefix for a range's scan metadata.
+	KeyLocalRangeScanMetadataPrefix = MakeKey(KeyLocalPrefix, proto.Key("rsm-"))
 	// KeyLocalRangeStatPrefix is the prefix for range statistics.
 	KeyLocalRangeStatPrefix = MakeKey(KeyLocalPrefix, proto.Key("rst-"))
 	// KeyLocalResponseCachePrefix is the prefix for keys storing command

--- a/storage/engine/rocksdb.go
+++ b/storage/engine/rocksdb.go
@@ -198,7 +198,7 @@ func (r *RocksDB) iterateInternal(start, end proto.EncodedKey, f func(proto.RawK
 	it.Seek(start)
 	for ; it.Valid(); it.Next() {
 		k := it.Key()
-		if bytes.Compare(it.Key(), end) >= 0 {
+		if !it.Key().Less(end) {
 			break
 		}
 		if done, err := f(proto.RawKeyValue{Key: k, Value: it.Value()}); done || err != nil {
@@ -516,7 +516,7 @@ func (r *rocksDBIterator) Next() {
 	C.DBIterNext(r.iter)
 }
 
-func (r *rocksDBIterator) Key() []byte {
+func (r *rocksDBIterator) Key() proto.EncodedKey {
 	// The data returned by rocksdb_iter_{key,value} is not meant to be
 	// freed by the client. It is a direct reference to the data managed
 	// by the iterator, so it is copied instead of freed.

--- a/storage/queue_test.go
+++ b/storage/queue_test.go
@@ -79,7 +79,7 @@ func TestBaseQueueAddUpdateAndRemove(t *testing.T) {
 		return shouldAddMap[r], priorityMap[r]
 	}
 	process := func(now time.Time, r *Range) error { return nil }
-	bq := newBaseQueue(shouldQ, process, 2)
+	bq := newBaseQueue("test", shouldQ, process, 2)
 	bq.MaybeAdd(r1)
 	bq.MaybeAdd(r2)
 	if bq.Length() != 2 {

--- a/storage/queue_test.go
+++ b/storage/queue_test.go
@@ -20,6 +20,7 @@ package storage
 import (
 	"container/heap"
 	"testing"
+	"time"
 
 	"github.com/cockroachdb/cockroach/proto"
 )
@@ -74,66 +75,67 @@ func TestBaseQueueAddUpdateAndRemove(t *testing.T) {
 		r1: 1.0,
 		r2: 2.0,
 	}
-	shouldQ := func(r *Range) (shouldQueue bool, priority float64) {
+	shouldQ := func(now time.Time, r *Range) (shouldQueue bool, priority float64) {
 		return shouldAddMap[r], priorityMap[r]
 	}
-	bq := newBaseQueue(shouldQ, 2)
-	bq.maybeAdd(r1)
-	bq.maybeAdd(r2)
-	if bq.length() != 2 {
-		t.Fatalf("expected length 2; got %d", bq.length())
+	process := func(now time.Time, r *Range) error { return nil }
+	bq := newBaseQueue(shouldQ, process, 2)
+	bq.MaybeAdd(r1)
+	bq.MaybeAdd(r2)
+	if bq.Length() != 2 {
+		t.Fatalf("expected length 2; got %d", bq.Length())
 	}
-	if bq.next() != r2 {
+	if bq.Pop() != r2 {
 		t.Error("expected r2")
 	}
-	if bq.next() != r1 {
+	if bq.Pop() != r1 {
 		t.Error("expected r1")
 	}
-	if r := bq.next(); r != nil {
+	if r := bq.Pop(); r != nil {
 		t.Errorf("expected empty queue; got %s", r)
 	}
 
 	// Add again, but this time r2 shouldn't add.
 	shouldAddMap[r2] = false
-	bq.maybeAdd(r1)
-	bq.maybeAdd(r2)
-	if bq.length() != 1 {
-		t.Errorf("expected length 1; got %d", bq.length())
+	bq.MaybeAdd(r1)
+	bq.MaybeAdd(r2)
+	if bq.Length() != 1 {
+		t.Errorf("expected length 1; got %d", bq.Length())
 	}
 
 	// Try adding same range twice.
-	bq.maybeAdd(r1)
-	if bq.length() != 1 {
-		t.Errorf("expected length 1; got %d", bq.length())
+	bq.MaybeAdd(r1)
+	if bq.Length() != 1 {
+		t.Errorf("expected length 1; got %d", bq.Length())
 	}
 
 	// Re-add r2 and update priority of r1.
 	shouldAddMap[r2] = true
 	priorityMap[r1] = 3.0
-	bq.maybeAdd(r1)
-	bq.maybeAdd(r2)
-	if bq.length() != 2 {
-		t.Fatalf("expected length 2; got %d", bq.length())
+	bq.MaybeAdd(r1)
+	bq.MaybeAdd(r2)
+	if bq.Length() != 2 {
+		t.Fatalf("expected length 2; got %d", bq.Length())
 	}
-	if bq.next() != r1 {
+	if bq.Pop() != r1 {
 		t.Error("expected r1")
 	}
-	if bq.next() != r2 {
+	if bq.Pop() != r2 {
 		t.Error("expected r2")
 	}
-	if r := bq.next(); r != nil {
+	if r := bq.Pop(); r != nil {
 		t.Errorf("expected empty queue; got %s", r)
 	}
 
 	// Set !shouldAdd for r2 and add it; this has effect of removing it.
-	bq.maybeAdd(r1)
-	bq.maybeAdd(r2)
+	bq.MaybeAdd(r1)
+	bq.MaybeAdd(r2)
 	shouldAddMap[r2] = false
-	bq.maybeAdd(r2)
-	if bq.length() != 1 {
-		t.Fatalf("expected length 1; got %d", bq.length())
+	bq.MaybeAdd(r2)
+	if bq.Length() != 1 {
+		t.Fatalf("expected length 1; got %d", bq.Length())
 	}
-	if bq.next() != r1 {
+	if bq.Pop() != r1 {
 		t.Errorf("expected r1")
 	}
 }

--- a/storage/range_data_iter.go
+++ b/storage/range_data_iter.go
@@ -1,0 +1,132 @@
+// Copyright 2015 The Cockroach Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+// implied. See the License for the specific language governing
+// permissions and limitations under the License. See the AUTHORS file
+// for names of contributors.
+//
+// Author: Spencer Kimball (spencer.kimball@gmail.com)
+
+package storage
+
+import (
+	"github.com/cockroachdb/cockroach/proto"
+	"github.com/cockroachdb/cockroach/storage/engine"
+	"github.com/cockroachdb/cockroach/util/encoding"
+)
+
+// keyRange is a helper struct for the rangeDataIterator.
+type keyRange struct {
+	start, end proto.EncodedKey
+}
+
+// rangeDataIterator provides a complete iteration over all key / value
+// rows in a range, including all system-local metadata and user data.
+// The ranges keyRange slice specifies the key ranges which comprise
+// all of the range's data.
+//
+// A rangeDataIterator provides the same API as an Engine iterator
+// with the exception of the Seek() method.
+type rangeDataIterator struct {
+	curIndex int
+	ranges   []keyRange
+	iter     engine.Iterator
+}
+
+func newRangeDataIterator(r *Range, e engine.Engine) *rangeDataIterator {
+	startKey := r.Desc.StartKey
+	if startKey.Equal(engine.KeyMin) {
+		startKey = engine.KeyLocalMax
+	}
+	ri := &rangeDataIterator{
+		ranges: []keyRange{
+			{
+				start: engine.MVCCEncodeKey(responseCacheKeyPrefix(r.Desc.RaftID)),
+				end:   engine.MVCCEncodeKey(responseCacheKeyPrefix(r.Desc.RaftID + 1)),
+			},
+			{
+				start: engine.MVCCEncodeKey(engine.RangeDescriptorKey(r.Desc.StartKey)),
+				end:   engine.MVCCEncodeKey(engine.RangeDescriptorKey(r.Desc.StartKey).Next()),
+			},
+			{
+				start: engine.MVCCEncodeKey(engine.RangeScanMetadataKey(r.Desc.StartKey)),
+				end:   engine.MVCCEncodeKey(engine.RangeScanMetadataKey(r.Desc.StartKey).Next()),
+			},
+			{
+				start: engine.MVCCEncodeKey(engine.MakeKey(engine.KeyLocalRangeStatPrefix, encoding.EncodeInt(nil, r.Desc.RaftID))),
+				end:   engine.MVCCEncodeKey(engine.MakeKey(engine.KeyLocalRangeStatPrefix, encoding.EncodeInt(nil, r.Desc.RaftID+1))),
+			},
+			{
+				start: engine.MVCCEncodeKey(engine.TransactionKey(r.Desc.StartKey, []byte(nil))),
+				end:   engine.MVCCEncodeKey(engine.TransactionKey(r.Desc.EndKey, []byte(nil))),
+			},
+			{
+				start: engine.MVCCEncodeKey(startKey),
+				end:   engine.MVCCEncodeKey(r.Desc.EndKey),
+			},
+		},
+		iter: e.NewIterator(),
+	}
+	ri.iter.Seek(ri.ranges[ri.curIndex].start)
+	ri.advance()
+	return ri
+}
+
+// Close closes the underlying iterator.
+func (ri *rangeDataIterator) Close() {
+	ri.curIndex = len(ri.ranges)
+	ri.iter.Close()
+}
+
+func (ri *rangeDataIterator) Valid() bool {
+	return ri.iter.Valid()
+}
+
+// Next returns the next raw key value in the iteration, or nil if
+// iteration is done.
+func (ri *rangeDataIterator) Next() {
+	ri.iter.Next()
+	ri.advance()
+}
+
+// Key returns the current Key for the iteration if valid.
+func (ri *rangeDataIterator) Key() proto.EncodedKey {
+	return ri.iter.Key()
+}
+
+// Value returns the current Value for the iteration if valid.
+func (ri *rangeDataIterator) Value() []byte {
+	return ri.iter.Value()
+}
+
+// Error returns the Error for the iteration if applicable.
+func (ri *rangeDataIterator) Error() error {
+	return ri.iter.Error()
+}
+
+// advance moves the iterator forward through the ranges until a valid
+// key is found or the iteration is done and the iterator becomes
+// invalid.
+func (ri *rangeDataIterator) advance() {
+	for {
+		if !ri.iter.Valid() || ri.iter.Key().Less(ri.ranges[ri.curIndex].end) {
+			return
+		}
+		ri.curIndex++
+		if ri.curIndex < len(ri.ranges) {
+			ri.iter.Seek(ri.ranges[ri.curIndex].start)
+		} else {
+			// Otherwise, seek to end to make iterator invalid.
+			ri.iter.Seek(engine.MVCCEncodeKey(engine.KeyMax))
+			return
+		}
+	}
+}

--- a/storage/range_data_iter_test.go
+++ b/storage/range_data_iter_test.go
@@ -1,0 +1,157 @@
+// Copyright 2015 The Cockroach Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+// implied. See the License for the specific language governing
+// permissions and limitations under the License. See the AUTHORS file
+// for names of contributors.
+//
+// Author: Spencer Kimball (spencer.kimball@gmail.com)
+
+package storage
+
+import (
+	"testing"
+
+	"github.com/cockroachdb/cockroach/proto"
+	"github.com/cockroachdb/cockroach/storage/engine"
+)
+
+// createRangeData creates sample range data in all possible areas of
+// the key space. Returns a slice of the encoded keys of all created
+// data.
+func createRangeData(r *Range, t *testing.T) []proto.EncodedKey {
+	ts0 := proto.ZeroTimestamp
+	ts := proto.Timestamp{WallTime: 1}
+	keyTSs := []struct {
+		key proto.Key
+		ts  proto.Timestamp
+	}{
+		{responseCacheKey(r.Desc.RaftID, proto.ClientCmdID{WallTime: 1, Random: 1}), ts0},
+		{responseCacheKey(r.Desc.RaftID, proto.ClientCmdID{WallTime: 2, Random: 2}), ts0},
+		{engine.RangeDescriptorKey(r.Desc.StartKey), ts},
+		{engine.RangeScanMetadataKey(r.Desc.StartKey), ts0},
+		{engine.MakeRangeStatKey(r.Desc.RaftID, engine.StatKeyBytes), ts0},
+		{engine.MakeRangeStatKey(r.Desc.RaftID, engine.StatKeyCount), ts0},
+		{engine.TransactionKey(r.Desc.StartKey, []byte("1234")), ts0},
+		{engine.TransactionKey(r.Desc.StartKey.Next(), []byte("5678")), ts0},
+		{engine.TransactionKey(r.Desc.EndKey.Prev(), []byte("2468")), ts0},
+		{r.Desc.StartKey.Next(), ts},
+		{r.Desc.EndKey.Prev(), ts},
+	}
+
+	keys := []proto.EncodedKey{}
+	for _, keyTS := range keyTSs {
+		if err := engine.MVCCPut(r.rm.Engine(), nil, keyTS.key, keyTS.ts, proto.Value{Bytes: []byte("value")}, nil); err != nil {
+			t.Fatal(err)
+		}
+		keys = append(keys, engine.MVCCEncodeKey(keyTS.key))
+		if !keyTS.ts.Equal(ts0) {
+			keys = append(keys, engine.MVCCEncodeVersionKey(keyTS.key, keyTS.ts))
+		}
+	}
+	return keys
+}
+
+// TestRangeDataIterator verifies correct operation of iterator if
+// a range contains no data and never has.
+func TestRangeDataIteratorEmptyRange(t *testing.T) {
+	s, r, _, _ := createTestRange(t)
+	defer s.Stop()
+	// Adjust the range descriptor to avoid existing data such as meta
+	// records and config entries during the iteration. This is a rather
+	// nasty little hack, but since it's test code, meh.
+	newDesc := *r.Desc
+	newDesc.StartKey = proto.Key("a")
+	r.Desc = &newDesc
+
+	iter := newRangeDataIterator(r, r.rm.Engine())
+	defer iter.Close()
+	for ; iter.Valid(); iter.Next() {
+		t.Error("expected empty iteration")
+	}
+}
+
+// TestRangeDataIterator creates three ranges {"a"-"b" (pre), "b"-"c"
+// (main test range), "c"-"d" (post)} and fills each with data. It
+// first verifies the contents of the "b"-"c" range, then deletes it
+// and verifies it's empty. Finally, it verifies the pre and post
+// ranges still contain the expected data.
+func TestRangeDataIterator(t *testing.T) {
+	s, r, _, _ := createTestRange(t)
+	defer s.Stop()
+	// See notes in EmptyRange test method for adjustment to descriptor.
+	newDesc := *r.Desc
+	newDesc.StartKey = proto.Key("b")
+	newDesc.EndKey = proto.Key("c")
+	r.Desc = &newDesc
+
+	// Create two more ranges, one before the test range and one after.
+	preRng := createRange(s, 2, proto.Key("a"), proto.Key("b"))
+	if err := s.AddRange(preRng); err != nil {
+		t.Fatal(err)
+	}
+	postRng := createRange(s, 3, proto.Key("c"), proto.Key("d"))
+	if err := s.AddRange(postRng); err != nil {
+		t.Fatal(err)
+	}
+
+	// Create range data for all three ranges.
+	preKeys := createRangeData(preRng, t)
+	keys := createRangeData(r, t)
+	postKeys := createRangeData(postRng, t)
+
+	iter := newRangeDataIterator(r, r.rm.Engine())
+	defer iter.Close()
+	for i := 0; iter.Valid(); iter.Next() {
+		if err := iter.Error(); err != nil {
+			t.Fatal(err)
+		}
+		if i >= len(keys) {
+			t.Fatal("there are more keys in the iteration than expected")
+		}
+		if key := iter.Key(); !key.Equal(keys[i]) {
+			k1, ts1, _ := engine.MVCCDecodeKey(key)
+			k2, ts2, _ := engine.MVCCDecodeKey(keys[i])
+			t.Errorf("%d: key mismatch %q(%d) != %q(%d)", i, k1, ts1, k2, ts2)
+		}
+		i++
+	}
+
+	// Destroy range and verify that its data has been completely cleared.
+	if err := r.Destroy(); err != nil {
+		t.Fatal(err)
+	}
+	iter = newRangeDataIterator(r, r.rm.Engine())
+	defer iter.Close()
+	if iter.Valid() {
+		t.Errorf("expected empty iteration; got first key %q", iter.Key())
+	}
+
+	// Verify the keys in pre & post ranges.
+	for _, test := range []struct {
+		r    *Range
+		keys []proto.EncodedKey
+	}{
+		{preRng, preKeys},
+		{postRng, postKeys},
+	} {
+		iter = newRangeDataIterator(test.r, test.r.rm.Engine())
+		defer iter.Close()
+		for i := 0; iter.Valid(); iter.Next() {
+			if key := iter.Key(); !key.Equal(test.keys[i]) {
+				k1, ts1, _ := engine.MVCCDecodeKey(key)
+				k2, ts2, _ := engine.MVCCDecodeKey(test.keys[i])
+				t.Errorf("%d: key mismatch %q(%d) != %q(%d)", i, k1, ts1, k2, ts2)
+			}
+			i++
+		}
+	}
+}

--- a/storage/range_test.go
+++ b/storage/range_test.go
@@ -125,14 +125,14 @@ func TestRangeContains(t *testing.T) {
 	if !r.ContainsKey(proto.Key("aa")) {
 		t.Errorf("expected range to contain key \"aa\"")
 	}
-	if !r.ContainsKey(engine.MakeLocalKey(engine.KeyLocalTransactionPrefix, []byte("aa"))) {
-		t.Errorf("expected range to contain key transaction key for \"aa\"")
+	if !r.ContainsKey(engine.RangeDescriptorKey([]byte("aa"))) {
+		t.Errorf("expected range to contain range descriptor key for \"aa\"")
 	}
 	if !r.ContainsKeyRange(proto.Key("aa"), proto.Key("b")) {
 		t.Errorf("expected range to contain key range \"aa\"-\"b\"")
 	}
-	if !r.ContainsKeyRange(engine.MakeLocalKey(engine.KeyLocalTransactionPrefix, []byte("aa")),
-		engine.MakeLocalKey(engine.KeyLocalTransactionPrefix, []byte("b"))) {
+	if !r.ContainsKeyRange(engine.RangeDescriptorKey([]byte("aa")),
+		engine.RangeDescriptorKey([]byte("b"))) {
 		t.Errorf("expected range to contain key transaction range \"aa\"-\"b\"")
 	}
 }
@@ -1003,7 +1003,7 @@ func TestEndTransactionWithErrors(t *testing.T) {
 		existTxn.Status = test.existStatus
 		existTxn.Epoch = test.existEpoch
 		existTxn.Timestamp = test.existTS
-		txnKey := engine.MakeKey(engine.KeyLocalTransactionPrefix, test.key, txn.ID)
+		txnKey := engine.TransactionKey(test.key, txn.ID)
 		if err := engine.MVCCPutProto(rng.rm.Engine(), nil, txnKey, proto.ZeroTimestamp, nil, &existTxn); err != nil {
 			t.Fatal(err)
 		}

--- a/storage/scan_queue.go
+++ b/storage/scan_queue.go
@@ -1,0 +1,145 @@
+// Copyright 2014 The Cockroach Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+// implied. See the License for the specific language governing
+// permissions and limitations under the License. See the AUTHORS file
+// for names of contributors.
+//
+// Author: Spencer Kimball (spencer.kimball@gmail.com)
+
+package storage
+
+import (
+	"time"
+
+	"github.com/cockroachdb/cockroach/storage/engine"
+	"github.com/cockroachdb/cockroach/util/log"
+)
+
+const (
+	// scanQueueMaxSize is the max size of the scan queue.
+	scanQueueMaxSize = 100
+	// gcByteCountNormalization is the count of GC'able bytes which
+	// amount to a score of "1" added to total range priority.
+	gcByteCountNormalization = 1 << 20 // 1 MB
+	// intentSweepInterval is the target duration for resolving extant
+	// write intents. If this much time has passed since the last scan
+	// and write intents are present, the range should be queue. Cleaning
+	// up intents allows transaction records to be GC'd.
+	intentSweepInterval = 10 * 24 * time.Hour // 10 days
+	// intentAgeThreshold is the threshold after which an extant intent
+	// will be resolved.
+	intentAgeThreshold = 1 * time.Hour // 1 hour
+	// verificationInterval is the target duration for verifying on-disk
+	// checksums via full scan.
+	verificationInterval = 30 * 24 * time.Hour // 30 days
+)
+
+// scanQueue manages a queue of ranges slated to be scanned in their
+// entirety using the MVCC versions iterator. Currently, range scans
+// manage the following tasks:
+//
+//  - GC of version data via TTL expiration (and more complex schemes
+//    as implemented going forward).
+//  - Resolve extant write intents and determine oldest non-resolvable
+//    intent.
+//  - Periodic verification of on-disk checksums to identify bit-rot
+//    in read-only data sets. See http://en.wikipedia.org/wiki/Data_degradation.
+//
+// The shouldQueue function combines the need for all three tasks into
+// a single priority. If any task is overdue, shouldQueue returns true.
+type scanQueue struct {
+	*baseQueue
+}
+
+// newScanQueue returns a new instance of scanQueue.
+func newScanQueue() *scanQueue {
+	sq := &scanQueue{}
+	sq.baseQueue = newBaseQueue(sq.shouldQueue, sq.process, scanQueueMaxSize)
+	return sq
+}
+
+// shouldQueue determines whether a range should be queued for
+// scanning, and if so, at what priority. Returns true for shouldQ in
+// the event that there are GC'able bytes, or it's been longer since
+// the last scan than the intent sweep or verification
+// intervals. Priority is derived from the addition of priority from
+// GC'able bytes and how many multiples of intent or verification
+// intervals have elapsed since the last scan.
+func (sq *scanQueue) shouldQueue(now time.Time, rng *Range) (shouldQ bool, priority float64) {
+	scanMeta, err := rng.GetScanMetadata()
+	if err != nil {
+		log.Errorf("unable to fetch scan metadata: %s", err)
+		return
+	}
+	elapsedNanos := now.UnixNano() - scanMeta.LastScanNanos
+
+	// Compute non-live bytes.
+	bytes, err := engine.GetRangeSize(rng.rm.Engine(), rng.Desc.RaftID)
+	if err != nil {
+		log.Errorf("unable to fetch range size stats: %s", err)
+		return
+	}
+	liveBytes, err := engine.GetRangeStat(rng.rm.Engine(), rng.Desc.RaftID, engine.StatLiveBytes)
+	if err != nil {
+		return
+	}
+	nonLiveBytes := bytes - liveBytes
+
+	// GC score.
+	estGCBytes := scanMeta.GC.EstimatedBytes(elapsedNanos, nonLiveBytes)
+	gcScore := float64(estGCBytes) / float64(gcByteCountNormalization)
+
+	// Intent sweep score. First check for intents. We only compute an
+	// intent score if there are any outstanding intents.
+	intentBytes, err := engine.GetRangeStat(rng.rm.Engine(), rng.Desc.RaftID, engine.StatIntentBytes)
+	if err != nil {
+		return
+	}
+	intentScore := float64(0)
+	if intentBytes > 0 {
+		intentScore = float64(elapsedNanos) / float64(intentSweepInterval.Nanoseconds())
+	}
+
+	// Verify score.
+	verifyScore := float64(elapsedNanos) / float64(verificationInterval.Nanoseconds())
+
+	// Compute priority.
+	if gcScore > 0 {
+		priority += gcScore
+	}
+	if intentScore > 1 {
+		priority += (intentScore - 1)
+	}
+	if verifyScore > 1 {
+		priority += (verifyScore - 1)
+	}
+	shouldQ = priority > 0
+	return
+}
+
+// process iterates through all keys in a range, calling the garbage
+// collector for each key and associated set of values. GC'd keys are
+// batched into InternalGC calls. Extant intents are resolved if
+// intents are older than intentAgeThreshold. The very act of scanning
+// keys verifies on-disk checksums, as each block checksum is checked
+// on load.
+func (sq *scanQueue) process(now time.Time, rng *Range) error {
+	snap := rng.rm.Engine().NewSnapshot()
+	iter := newRangeDataIterator(rng, snap)
+	defer iter.Close()
+	defer snap.Stop()
+
+	for ; iter.Valid(); iter.Next() {
+	}
+
+	return nil
+}

--- a/storage/scan_queue_test.go
+++ b/storage/scan_queue_test.go
@@ -1,0 +1,125 @@
+// Copyright 2015 The Cockroach Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+// implied. See the License for the specific language governing
+// permissions and limitations under the License. See the AUTHORS file
+// for names of contributors.
+//
+// Author: Spencer Kimball (spencer.kimball@gmail.com)
+
+package storage
+
+import (
+	"log"
+	"math"
+	"testing"
+	"time"
+
+	"github.com/cockroachdb/cockroach/proto"
+	"github.com/cockroachdb/cockroach/storage/engine"
+)
+
+// TestScanQueueShouldQueue verifies conditions which inform priority
+// and whether or not the range should be queued into the scan queue.
+// Ranges are queued for scanning based on three conditions. The bytes
+// available to be GC'd, and the time since last GC, the time since
+// last scan for unresolved intents (if there are any active intent
+// bytes), and the time since last scan for verification of checksum
+// data.
+func TestScanQueueShouldQueue(t *testing.T) {
+	s, r, _, _ := createTestRange(t)
+	defer s.Stop()
+
+	day := 1 * 24 * time.Hour // 1 day
+	mb := int64(1 << 20)      // 1 MB
+	scanMeta0 := &proto.ScanMetadata{
+		LastScanNanos: 0,
+		GC: proto.GCMetadata{
+			TTLSeconds: int32(day.Nanoseconds() / 1000000000),
+			ByteCounts: []int64{0, 0, 0, 0, 0, 0, 0, 0, 0, 0},
+		},
+	}
+	scanMeta1 := &proto.ScanMetadata{
+		LastScanNanos: 0,
+		GC: proto.GCMetadata{
+			TTLSeconds: int32(day.Nanoseconds() / 1000000000),
+			ByteCounts: []int64{
+				10 * mb, 9 * mb, 8 * mb, 7 * mb, 6 * mb, 5 * mb, 4 * mb, 3 * mb, 2 * mb, 1 * mb / 2,
+			},
+		},
+	}
+
+	testCases := []struct {
+		scanMeta     *proto.ScanMetadata
+		nonLiveBytes int64
+		intentBytes  int64
+		now          time.Time
+		shouldQ      bool
+		priority     float64
+	}{
+		// No GC'able bytes, no time elapsed.
+		{scanMeta0, 0, 0, time.Unix(0, 0), false, 0},
+		// No GC'able bytes, no intent bytes, but intent interval elapsed.
+		{scanMeta0, 0, 0, time.Unix(intentSweepInterval.Nanoseconds()/1000000000, 0), false, 0},
+		// No GC'able bytes, with intent bytes, intent interval elapsed.
+		{scanMeta0, 0, 1, time.Unix(intentSweepInterval.Nanoseconds()/1000000000, 0), false, 0},
+		// No GC'able bytes, with intent bytes, intent interval * 2 elapsed.
+		{scanMeta0, 0, 1, time.Unix((intentSweepInterval.Nanoseconds()*2)/1000000000, 0), true, 1},
+		// No GC'able bytes, no intent bytes, verification interval elapsed.
+		{scanMeta0, 0, 0, time.Unix(verificationInterval.Nanoseconds()/1000000000, 0), false, 0},
+		// No GC'able bytes, no intent bytes, verification interval * 2 elapsed.
+		{scanMeta0, 0, 0, time.Unix((verificationInterval.Nanoseconds()*2)/1000000000, 0), true, 1},
+		// No GC'able bytes, with combination of intent bytes and verification interval * 2 elapsed.
+		{scanMeta0, 0, 1, time.Unix((verificationInterval.Nanoseconds()*2)/1000000000, 0), true, 6},
+		// GC'able bytes, no time elapsed.
+		{scanMeta1, 0, 0, time.Unix(0, 0), false, 0},
+		// GC'able bytes, TTLSeconds / 10 elapsed (note that 1st 1/10 of bytes is 0.5M).
+		{scanMeta1, 0, 0, time.Unix(24*360, 0), true, 0.5},
+		// GC'able bytes, TTLSeconds / 2 elapsed.
+		{scanMeta1, 0, 0, time.Unix(12*3600, 0), true, 5},
+		// GC'able bytes, TTLSeconds elapsed.
+		{scanMeta1, 0, 0, time.Unix(24*3600, 0), true, 10},
+		// GC'able bytes with non-live bytes, TTLSeconds elapsed.
+		{scanMeta1, 1 * mb, 0, time.Unix(24*3600, 0), true, 10},
+		// GC'able bytes with non-live bytes, TTLSeconds * 2 elapsed.
+		{scanMeta1, 1 * mb, 0, time.Unix(48*3600, 0), true, 10.5},
+		// GC'able bytes with non-live bytes, TTLSeconds * 4 elapsed.
+		{scanMeta1, 1 * mb, 0, time.Unix(96*3600, 0), true, 10.75},
+		// GC'able bytes with non-live bytes, intent bytes, and intent interval * 2 elapsed.
+		{scanMeta1, 1 * mb, 1, time.Unix((intentSweepInterval.Nanoseconds()*2)/1000000000, 0), true, 11.95},
+	}
+
+	scanQ := newScanQueue()
+
+	for i, test := range testCases {
+		// Write scan metadata.
+		if err := r.PutScanMetadata(test.scanMeta); err != nil {
+			t.Fatal(err)
+		}
+		// Write non live bytes as key bytes; since "live" bytes will be zero, this will translate into non live bytes.
+		nonLiveBytes := test.scanMeta.GC.ByteCounts[0] + test.nonLiveBytes
+		if err := engine.SetStat(r.rm.Engine(), r.Desc.RaftID, 0, engine.StatKeyBytes, nonLiveBytes); err != nil {
+			log.Fatal(err)
+		}
+		// Write intent bytes. Note: the actual accounting on bytes is fictional in this test.
+		if err := engine.SetStat(r.rm.Engine(), r.Desc.RaftID, 0, engine.StatIntentBytes, test.intentBytes); err != nil {
+			log.Fatal(err)
+		}
+
+		shouldQ, priority := scanQ.shouldQueue(test.now, r)
+		if shouldQ != test.shouldQ {
+			t.Errorf("%d: should queue expected %t; got %t", i, test.shouldQ, shouldQ)
+		}
+		if math.Abs(priority-test.priority) > 0.00001 {
+			t.Errorf("%d: priority expected %f; got %f", i, test.priority, priority)
+		}
+	}
+}

--- a/storage/store_test.go
+++ b/storage/store_test.go
@@ -385,12 +385,6 @@ func TestStoreVerifyKeys(t *testing.T) {
 	if err := store.ExecuteCmd(proto.Put, pArgs, pReply); err != nil {
 		t.Fatalf("unexpected error on put to meta2 value: %s", err)
 	}
-	// Try a put to txn record for a meta2 key.
-	pArgs, pReply = putArgs(engine.MakeKey(engine.KeyLocalTransactionPrefix,
-		engine.KeyMeta2Prefix, engine.KeyMax), []byte("value"), 1, store.StoreID())
-	if err := store.ExecuteCmd(proto.Put, pArgs, pReply); err != nil {
-		t.Fatalf("unexpected error on put to meta2 value: %s", err)
-	}
 }
 
 // TestStoreExecuteCmdUpdateTime verifies that the node clock is updated.
@@ -596,7 +590,7 @@ func TestStoreResolveWriteIntent(t *testing.T) {
 			if err != nil {
 				t.Errorf("expected intent resolved; got unexpected error: %s", err)
 			}
-			txnKey := engine.MakeKey(engine.KeyLocalTransactionPrefix, pushee.Key, pushee.ID)
+			txnKey := engine.TransactionKey(pushee.Key, pushee.ID)
 			var txn proto.Transaction
 			ok, err := engine.MVCCGetProto(store.Engine(), txnKey, proto.ZeroTimestamp, nil, &txn)
 			if !ok || err != nil {
@@ -849,7 +843,7 @@ func TestStoreResolveWriteIntentNoTxn(t *testing.T) {
 	}
 
 	// Read pushee's txn.
-	txnKey := engine.MakeKey(engine.KeyLocalTransactionPrefix, pushee.Key, pushee.ID)
+	txnKey := engine.TransactionKey(pushee.Key, pushee.ID)
 	var txn proto.Transaction
 	ok, err := engine.MVCCGetProto(store.Engine(), txnKey, proto.ZeroTimestamp, nil, &txn)
 	if !ok || err != nil {


### PR DESCRIPTION
Implementation of a range data iterator which scan through all of the
data in a range. This is now used for Range.Destroy(). It will also be
used for the range snapshot when instantiating a new range Raft replica.
Here, it's used to scan over the complete set of data in the range.
Versions for the same key will be processed for garbage collection.

Changed transaction key to encode base key to guarantee that all txn
records in a range sort together.

Implementation and unittests for scan queue's ShouldQueue method,
which combines priorities from GC'able bytes, last time since
unresolved intents were scanned (if there are any), and last time
since the full range had its checksums verified.

Next up will be implemention of scan queue's Process method, which
will implement garbage collection and intent resolution.
