### PR TITLE
Actually send commands to raft, not just command IDs.

### DIFF
--- a/storage/raft.go
+++ b/storage/raft.go
@@ -111,6 +111,9 @@ func (snr *singleNodeRaft) removeGroup(id int64) error {
 }
 
 func (snr *singleNodeRaft) propose(cmdIDKey cmdIDKey, cmd proto.InternalRaftCommand) {
+	if cmd.Cmd.GetValue() == nil {
+		panic("proposed a nil command")
+	}
 	// Lazily create group. TODO(bdarnell): make this non-lazy
 	err := snr.createGroup(cmd.RaftID)
 	if err != nil {

--- a/storage/range.go
+++ b/storage/range.go
@@ -120,14 +120,12 @@ func UsesTimestampCache(method string) bool {
 	return ok
 }
 
-// A pendingCmd holds method, args, reply and a done channel for a command
+// A pendingCmd holds the reply buffer and a done channel for a command
 // sent to Raft. Once committed to the Raft log, the command is
 // executed and the result returned via the done channel.
 type pendingCmd struct {
-	Method string
-	Args   proto.Request
-	Reply  proto.Response
-	done   chan error // Used to signal waiting RPC handler
+	Reply proto.Response
+	done  chan error // Used to signal waiting RPC handler
 }
 
 // A RangeManager is an interface satisfied by Store through which ranges
@@ -439,10 +437,8 @@ func (r *Range) addReadWriteCmd(method string, args proto.Request, reply proto.R
 
 	// Create command and enqueue for Raft.
 	pendingCmd := &pendingCmd{
-		Method: method,
-		Args:   args,
-		Reply:  reply,
-		done:   make(chan error, 1),
+		Reply: reply,
+		done:  make(chan error, 1),
 	}
 	raftCmd := proto.InternalRaftCommand{
 		RaftID: r.Desc.RaftID,
@@ -455,6 +451,10 @@ func (r *Range) addReadWriteCmd(method string, args proto.Request, reply proto.R
 			WallTime: r.rm.Clock().PhysicalNow(),
 			Random:   rand.Int63(),
 		}
+	}
+	ok := raftCmd.Cmd.SetValue(args)
+	if !ok {
+		log.Fatalf("unknown command type %T", args)
 	}
 	idKey := makeCmdIDKey(cmdID)
 	r.Lock()
@@ -484,7 +484,7 @@ func (r *Range) addReadWriteCmd(method string, args proto.Request, reply proto.R
 		// log execution errors so they're surfaced somewhere.
 		if !wait && err != nil {
 			log.Warningf("non-synchronous execution of %s with %+v failed: %s",
-				pendingCmd.Method, pendingCmd.Args, err)
+				method, args, err)
 		}
 		return err
 	}
@@ -501,27 +501,19 @@ func (r *Range) processRaftCommand(idKey cmdIDKey, raftCmd proto.InternalRaftCom
 	cmd := r.pendingCmds[idKey]
 	delete(r.pendingCmds, idKey)
 	r.Unlock()
-	var method string
-	var args proto.Request
+
+	args := raftCmd.Cmd.GetValue().(proto.Request)
+	method, err := proto.MethodForRequest(args)
+	if err != nil {
+		log.Fatal(err)
+	}
+
 	var reply proto.Response
-	var err error
 	if cmd != nil {
 		// We initiated this command, so use the caller-supplied reply.
-		method = cmd.Method
-		args = cmd.Args
 		reply = cmd.Reply
 	} else {
-		if raftCmd.Cmd.GetValue() == nil {
-			// This is a no-op.
-			return
-		}
-		// This command originated elsewhere so we must create a new
-		// reply buffer and reconstruct the method name.
-		args = raftCmd.Cmd.GetValue().(proto.Request)
-		method, err = proto.MethodForRequest(args)
-		if err != nil {
-			log.Fatal(err)
-		}
+		// This command originated elsewhere so we must create a new reply buffer.
 		_, reply, err = proto.CreateArgsAndReply(method)
 		if err != nil {
 			log.Fatal(err)


### PR DESCRIPTION
Remove pendingCmd.{Method,Args}, which allowed handling of local and
remote commands to diverge (which is why local commands were working
before).

@spencerkimball @cockroachdb/developers 

@MycroftH , this is why you were seeing committed commands that appeared to be empty.
