### PR TITLE
Reorganized all local keys into two sections/range: by ID & by Key.

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -65,8 +65,3 @@
     utilized set may have rebalances in effect.
 
 * Cleanup proto files to adhere to proto capitalization instead of go's.
-
-* Consider moving all local keys into two sections, each prefixed by either
-  the Raft ID of the range or the start key of the range. This will allow
-  a less error-prone iteration over the data for a range, instead of having
-  to include each section of local data separately.

--- a/roachlib/Makefile
+++ b/roachlib/Makefile
@@ -17,7 +17,7 @@
 # Author: Andrew Bonventre (andybons@gmail.com)
 
 ROACH_LIB := libroach.a
-SOURCES   := db.cc
+SOURCES   := db.cc encoding.cc
 OBJECTS   := $(SOURCES:.cc=.o)
 
 CXXFLAGS += -std=c++11 -I../proto/lib -I../_vendor/rocksdb/include

--- a/roachlib/db.h
+++ b/roachlib/db.h
@@ -53,10 +53,6 @@ typedef void (*DBLoggerFunc)(void* state, const char* str, int len);
 typedef struct {
   int64_t cache_size;
   int allow_os_buffer;
-  // The key prefix for transaction keys.
-  DBSlice txn_prefix;
-  // The key prefix for response cache keys.
-  DBSlice rcache_prefix;
   // A function pointer to direct log messages to.
   DBLoggerFunc logger;
 } DBOptions;

--- a/roachlib/encoding.cc
+++ b/roachlib/encoding.cc
@@ -1,0 +1,75 @@
+// Copyright 2014 The Cockroach Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+// implied.  See the License for the specific language governing
+// permissions and limitations under the License. See the AUTHORS file
+// for names of contributors.
+//
+// Author: Spencer Kimball (spencer.kimball@gmail.com)
+
+#include "rocksdb/slice.h"
+
+namespace {
+
+const unsigned char kOrderedEncodingBinary     = 0x25;
+const unsigned char kOrderedEncodingTerminator = 0x00;
+
+}
+
+bool DecodeBinary(const rocksdb::Slice& buf, std::string* decoded, std::string* remainder) {
+  if (buf[0] != kOrderedEncodingBinary) {
+    fprintf(stderr, "%s doesn't begin with binary encoding byte\n", buf.ToString().c_str());
+    return false;
+  }
+  decoded->clear();
+  int s = 6;
+  int i = 1;
+  if (buf[i] == kOrderedEncodingTerminator) {
+    if (remainder != NULL) {
+      rocksdb::Slice remSlice(buf);
+      remSlice.remove_prefix(2);
+      *remainder = remSlice.ToString();
+    }
+    return true;
+  }
+
+  int t = (buf[i] << 1) & 0xff;
+  for (i = 2; buf[i] != kOrderedEncodingTerminator; i++) {
+    if (s == 7) {
+      decoded->push_back(t | (buf[i] & 0x7f));
+      i++;
+    } else {
+      decoded->push_back(t | ((buf[i] & 0x7f) >> s));
+    }
+
+    t = (buf[i] << (8 - s)) & 0xff;
+
+    if (buf[i] == kOrderedEncodingTerminator) {
+      break;
+    }
+
+    if (s == 1) {
+      s = 7;
+    } else {
+      s--;
+    }
+  }
+  if (t != 0) {
+    fprintf(stderr, "%s doesn't begin with binary encoding byte\n", buf.ToString().c_str());
+    return false;
+  }
+  if (remainder != NULL) {
+    rocksdb::Slice remSlice(buf);
+    remSlice.remove_prefix(i+1);
+    *remainder = remSlice.ToString();
+  }
+  return true;
+}

--- a/roachlib/encoding.h
+++ b/roachlib/encoding.h
@@ -1,0 +1,33 @@
+// Copyright 2015 The Cockroach Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+// implied.  See the License for the specific language governing
+// permissions and limitations under the License. See the AUTHORS file
+// for names of contributors.
+//
+// Author: Spencer Kimball (spencer.kimball@gmail.com)
+
+#ifndef ROACHLIB_ENCODING_H
+#define ROACHLIB_ENCODING_H
+
+#include <stdint.h>
+
+// DecodeBinary decodes the given key-encoded buf slice, returning
+// true on a successful decode. The the unencoded bytes are returned
+// in *decoded, and if not NULL, any remaining bytes are returned in
+// *remainder.
+bool DecodeBinary(const rocksdb::Slice& buf, std::string* decoded, std::string* remainder);
+
+#endif // ROACHLIB_ENCODING_H
+
+// local variables:
+// mode: c++
+// end:

--- a/storage/engine/keys.go
+++ b/storage/engine/keys.go
@@ -62,7 +62,7 @@ func RaftLogKey(raftID int64, logIndex uint64) proto.Key {
 
 // RaftLogPrefix returns the system-local prefix shared by all entries in a Raft log.
 func RaftLogPrefix(raftID int64) proto.Key {
-	return MakeKey(KeyLocalRangeIDPrefix, encoding.EncodeInt(nil, raftID), KeyLocalRaftLogSuffix)
+	return MakeRangeIDKey(raftID, KeyLocalRaftLogSuffix, proto.Key{})
 }
 
 // RaftStateKey returns a system-local key for a Raft HardState.

--- a/storage/engine/keys.go
+++ b/storage/engine/keys.go
@@ -33,16 +33,111 @@ func MakeKey(keys ...proto.Key) proto.Key {
 	return proto.MakeKey(keys...)
 }
 
-// MakeLocalKey is a simple passthrough to MakeKey, with verification
-// that the first key has length KeyLocalPrefixLength.
-func MakeLocalKey(keys ...proto.Key) proto.Key {
-	if len(keys) == 0 {
-		log.Fatal("no key components specified in call to MakeLocalKey")
+// MakeStoreKey creates a store-local key based on the metadata key
+// suffix, and optional detail.
+func MakeStoreKey(suffix, detail proto.Key) proto.Key {
+	return MakeKey(KeyLocalStorePrefix, suffix, detail)
+}
+
+// StoreIdentKey returns a store-local key for the store metadata.
+func StoreIdentKey() proto.Key {
+	return MakeStoreKey(KeyLocalStoreIdentSuffix, proto.Key{})
+}
+
+// MakeRangeIDKey creates a range-local key based on the range's
+// Raft ID, metadata key suffix, and optional detail (e.g. the
+// encoded command ID for a response cache entry, etc.).
+func MakeRangeIDKey(raftID int64, suffix, detail proto.Key) proto.Key {
+	if len(suffix) != KeyLocalSuffixLength {
+		panic(fmt.Sprintf("suffix len(%q) != %d", suffix, KeyLocalSuffixLength))
 	}
-	if len(keys[0]) != KeyLocalPrefixLength {
-		log.Fatalf("local key prefix length must be %d: %q", KeyLocalPrefixLength, keys[0])
+	return MakeKey(KeyLocalRangeIDPrefix, encoding.EncodeInt(nil, raftID), suffix, detail)
+}
+
+// RaftLogKey returns a system-local key for a Raft log entry.
+func RaftLogKey(raftID int64, logIndex uint64) proto.Key {
+	// The log is stored "backwards" so we can easily find the highest index stored.
+	return MakeRangeIDKey(raftID, KeyLocalRaftLogSuffix, encoding.EncodeUint64Decreasing(nil, logIndex))
+}
+
+// RaftLogPrefix returns the system-local prefix shared by all entries in a Raft log.
+func RaftLogPrefix(raftID int64) proto.Key {
+	return MakeKey(KeyLocalRangeIDPrefix, encoding.EncodeInt(nil, raftID), KeyLocalRaftLogSuffix)
+}
+
+// RaftStateKey returns a system-local key for a Raft HardState.
+func RaftStateKey(raftID int64) proto.Key {
+	return MakeRangeIDKey(raftID, KeyLocalRaftStateSuffix, proto.Key{})
+}
+
+// DecodeRaftStateKey extracts the Raft ID from a RaftStateKey.
+func DecodeRaftStateKey(key proto.Key) int64 {
+	if !bytes.HasPrefix(key, KeyLocalRangeIDPrefix) {
+		panic(fmt.Sprintf("key %q does not have %q prefix", key, KeyLocalRangeIDPrefix))
 	}
-	return proto.MakeKey(keys...)
+	// Cut the prefix and the Raft ID.
+	b := key[len(KeyLocalRangeIDPrefix):]
+	_, raftID := encoding.DecodeInt(b)
+	return raftID
+}
+
+// ResponseCacheKey returns a range-local key by Raft ID for a
+// response cache entry, with detail specified by encoding the
+// supplied client command ID.
+func ResponseCacheKey(raftID int64, cmdID *proto.ClientCmdID) proto.Key {
+	detail := proto.Key{}
+	if cmdID != nil {
+		detail = encoding.EncodeInt(nil, cmdID.WallTime)  // wall time helps sort for locality
+		detail = encoding.EncodeInt(detail, cmdID.Random) // TODO(spencer): encode as Fixed64
+	}
+	return MakeRangeIDKey(raftID, KeyLocalResponseCacheSuffix, detail)
+}
+
+// MakeRangeKey creates a range-local key based on the range
+// start key, metadata key suffix, and optional detail (e.g. the
+// transaction UUID for a txn record, etc.).
+func MakeRangeKey(key, suffix, detail proto.Key) proto.Key {
+	if len(suffix) != KeyLocalSuffixLength {
+		panic(fmt.Sprintf("suffix len(%q) != %d", suffix, KeyLocalSuffixLength))
+	}
+	return MakeKey(KeyLocalRangeKeyPrefix, encoding.EncodeBinary(nil, key), suffix, detail)
+}
+
+// DecodeRangeKey decodes the range key into range start key,
+// suffix and optional detail (may be nil).
+func DecodeRangeKey(key proto.Key) (startKey, suffix, detail proto.Key) {
+	if !bytes.HasPrefix(key, KeyLocalRangeKeyPrefix) {
+		panic(fmt.Sprintf("key %q does not have %q prefix", key, KeyLocalRangeKeyPrefix))
+	}
+	// Cut the prefix and the Raft ID.
+	b := key[len(KeyLocalRangeKeyPrefix):]
+	b, startKey = encoding.DecodeBinary(b)
+	if len(b) < KeyLocalSuffixLength {
+		panic(fmt.Sprintf("key %q does not have suffix of length %d", key, KeyLocalSuffixLength))
+	}
+	// Cut the response cache suffix.
+	suffix = b[:KeyLocalSuffixLength]
+	detail = b[KeyLocalSuffixLength:]
+	return
+}
+
+// RangeScanMetadataKey returns a range-local key for range scan
+// metadata.
+func RangeScanMetadataKey(key proto.Key) proto.Key {
+	return MakeRangeKey(key, KeyLocalRangeScanMetadataSuffix, proto.Key{})
+}
+
+// RangeDescriptorKey returns a range-local key for the descriptor
+// for the range with specified key.
+func RangeDescriptorKey(key proto.Key) proto.Key {
+	return MakeRangeKey(key, KeyLocalRangeDescriptorSuffix, proto.Key{})
+}
+
+// TransactionKey returns a transaction key based on the provided
+// transaction key and ID. The base key is encoded in order to
+// guarantee that all transaction records for a range sort together.
+func TransactionKey(key proto.Key, id []byte) proto.Key {
+	return MakeRangeKey(key, KeyLocalTransactionSuffix, proto.Key(id))
 }
 
 // KeyAddress returns the address for the key, used to lookup the
@@ -54,31 +149,22 @@ func MakeLocalKey(keys ...proto.Key) proto.Key {
 // as non-local keys, but are stored separately so that they don't
 // collide with user-space or global system keys.
 //
-// However, not all local keys are addressable in the global map.
-// Range metadata, response cache entries, and various other keys are
-// strictly local, as the non-local suffix is not itself a key
-// (e.g. in the case of range metadata, it's the encoded range ID) and
-// so are not globally addressable.
+// However, not all local keys are addressable in the global map. Only
+// range local keys incorporating a range key (start key or transaction
+// key) are addressable (e.g. range metadata and txn records). Range
+// local keys incorporating the Raft ID are not (e.g. response cache
+// entries, and range stats).
 func KeyAddress(k proto.Key) proto.Key {
 	if !bytes.HasPrefix(k, KeyLocalPrefix) {
 		return k
 	}
-	if len(k) < KeyLocalPrefixLength {
-		log.Fatalf("local key %q malformed; should contain prefix %q and four-character designation", k, KeyLocalPrefix)
+	if bytes.HasPrefix(k, KeyLocalRangeKeyPrefix) {
+		k = k[len(KeyLocalRangeKeyPrefix):]
+		_, k = encoding.DecodeBinary(k)
+		return k
 	}
-	return k[KeyLocalPrefixLength:]
-}
-
-// RangeScanMetadataKey returns a system-local key for range scan
-// metadata.
-func RangeScanMetadataKey(startKey proto.Key) proto.Key {
-	return MakeLocalKey(KeyLocalRangeScanMetadataPrefix, startKey)
-}
-
-// RangeDescriptorKey returns a system-local key for the descriptor
-// for the range with specified start key.
-func RangeDescriptorKey(startKey proto.Key) proto.Key {
-	return MakeLocalKey(KeyLocalRangeDescriptorPrefix, startKey)
+	log.Fatalf("local key %q malformed; should contain prefix %q", k, KeyLocalRangeKeyPrefix)
+	return nil
 }
 
 // RangeMetaKey returns a range metadata (meta1, meta2) indexing key
@@ -104,13 +190,6 @@ func RangeMetaKey(key proto.Key) proto.Key {
 // descriptor should be stored as a value.
 func RangeMetaLookupKey(r *proto.RangeDescriptor) proto.Key {
 	return RangeMetaKey(r.EndKey)
-}
-
-// TransactionKey returns a transaction key based on the provided
-// transaction key and ID. The base key is encoded in order to
-// guarantee that all transaction records for a range sort together.
-func TransactionKey(key proto.Key, id []byte) proto.Key {
-	return MakeKey(KeyLocalTransactionPrefix, encoding.EncodeBinary(nil, key), id)
 }
 
 // ValidateRangeMetaKey validates that the given key is a valid Range Metadata
@@ -144,40 +223,6 @@ func ValidateRangeMetaKey(key proto.Key) error {
 	return nil
 }
 
-// RaftLogKey returns a system-local key for a raft log entry.
-func RaftLogKey(raftID, logIndex uint64) proto.Key {
-	b := RaftLogPrefix(raftID)
-	// The log is stored "backwards" so we can easily find the highest index stored.
-	b = encoding.EncodeUint64Decreasing(b, logIndex)
-	return b
-}
-
-// RaftLogPrefix returns the system-local prefix shared by all entries in a raft log.
-func RaftLogPrefix(raftID uint64) proto.Key {
-	b := MakeLocalKey(KeyLocalRaftLogPrefix)
-	b = encoding.EncodeUint64(b, raftID)
-	return b
-}
-
-// RaftStateKey returns a system-local key for a raft HardState.
-func RaftStateKey(raftID uint64) proto.Key {
-	b := MakeLocalKey(KeyLocalRaftStatePrefix)
-	b = encoding.EncodeUint64(b, raftID)
-	return b
-}
-
-// DecodeRaftStateKey extracts the raft ID from a RaftStateKey.
-func DecodeRaftStateKey(k proto.Key) uint64 {
-	_, raftID := encoding.DecodeUint64(k[len(KeyLocalRaftStatePrefix):])
-	return raftID
-}
-
-func init() {
-	if KeyLocalPrefixLength%7 != 0 {
-		log.Fatalf("local key prefix is not a multiple of 7: %d", KeyLocalPrefixLength)
-	}
-}
-
 // Constants for system-reserved keys in the KV map.
 var (
 	// KeyMaxLength is the maximum key length in bytes. This value is
@@ -194,56 +239,81 @@ var (
 	KeyMax = proto.KeyMax
 
 	// KeyLocalPrefix is the prefix for keys which hold data local to a
-	// RocksDB instance, such as range accounting information
-	// (e.g. range metadata, range-spanning binary tree node pointers),
-	// response cache values, transaction records, and message
-	// queues. Some local data are replicated, such as transaction rows,
-	// but are located in the local area so that they remain in
-	// proximity to one or more keys which they affect, but without
-	// unnecessarily polluting the key space. Further, some local data
-	// are stored with MVCC and contribute to distributed transactions,
-	// such as range metadata, range-spanning binary tree node pointers,
-	// and message queues.
+	// RocksDB instance, such as store and range-specific metadata which
+	// must not pollute the user key space, but must be colocated with
+	// the store and/or ranges which they refer to. Storing this
+	// information in the normal system keyspace would place the data on
+	// an arbitrary set of stores, with no guarantee of colocation.
+	// Local data includes store metadata, range metadata, response
+	// cache values, transaction records, range-spanning binary tree
+	// node pointers, and message queues.
 	//
 	// The local key prefix has been deliberately chosen to sort before
 	// the KeySystemPrefix, because these local keys are not addressable
 	// via the meta range addressing indexes.
+	//
+	// Some local data are not replicated, such as the store's 'ident'
+	// record. Most local data are replicated, such as response cache
+	// entries and transaction rows, but are not addressable as normal
+	// MVCC values as part of transactions. Finally, some local data are
+	// stored as MVCC values and are addressable as part of distributed
+	// transactions, such as range metadata, range-spanning binary tree
+	// node pointers, and message queues.
 	KeyLocalPrefix = proto.Key("\x00\x00\x00")
 
-	// KeyLocalPrefixLength is the maximum length of the local prefix.
-	// It includes both the standard prefix and an additional four
-	// characters to designate the type of local data.
-	//
-	// NOTE: this is very important! In order to support prefix matches
-	//   (e.g. for garbage collection of transaction and response cache
-	//   rows), the number of bytes in the key local prefix must be a
-	//   multiple of 7. This provides an encoded binary string with no
-	//   leftover bits to "bleed" into the next byte in the non-prefix
-	//   part of the local key.
-	KeyLocalPrefixLength = len(KeyLocalPrefix) + 4
+	// KeyLocalSuffixLength specifies the length in bytes of all local
+	// key suffixes.
+	KeyLocalSuffixLength = 4
 
-	// KeyLocalIdent stores an immutable identifier for this store,
-	// created when the store is first bootstrapped.
-	KeyLocalIdent = MakeKey(KeyLocalPrefix, proto.Key("iden"))
-	// KeyLocalRangeDescriptorPrefix is the prefix for keys storing
+	// There are three types of local key data enumerated below:
+	// store-local, range-local by ID, and range-local by key.
+
+	// KeyLocalStorePrefix is the prefix identifying per-store data.
+	KeyLocalStorePrefix = MakeKey(KeyLocalPrefix, proto.Key("s"))
+	// KeyLocalStoreIdentSuffix stores an immutable identifier for this
+	// store, created when the store is first bootstrapped.
+	KeyLocalStoreIdentSuffix = proto.Key("iden")
+	// KeyLocalStoreStatSuffix is the suffix for store statistics.
+	KeyLocalStoreStatSuffix = proto.Key("sst-")
+
+	// KeyLocalRangeIDPrefix is the prefix identifying per-range data
+	// indexed by Raft ID. The Raft ID is appended to this prefix,
+	// encoded using EncodeInt. The specific sort of per-range metadata
+	// is identified by one of the suffixes listed below, along with
+	// potentially additional encoded key info, such as a command ID in
+	// the case of response cache entry.
+	KeyLocalRangeIDPrefix = MakeKey(KeyLocalPrefix, proto.Key("i"))
+	// KeyLocalRaftLogSuffix is the suffix for the raft log.
+	KeyLocalRaftLogSuffix = proto.Key("rftl")
+	// KeyLocalRaftStateSuffix is the Suffix for the raft HardState.
+	KeyLocalRaftStateSuffix = proto.Key("rfts")
+	// KeyLocalRangeStatSuffix is the suffix for range statistics.
+	KeyLocalRangeStatSuffix = proto.Key("rst-")
+	// KeyLocalResponseCacheSuffix is the suffix for keys storing
+	// command responses used to guarantee idempotency (see
+	// ResponseCache).
+	// NOTE: if this value changes, it must be updated in C++
+	// (roachlib/db.cc).
+	KeyLocalResponseCacheSuffix = proto.Key("res-")
+
+	// KeyLocalRangeKeyPrefix is the prefix identifying per-range data
+	// indexed by range key (either start key, or some key in the
+	// range). The key is appended to this prefix, encoded using
+	// EncodeBinary. The specific sort of per-range metadata is
+	// identified by one of the suffixes listed below, along with
+	// potentially additional encoded key info, such as the txn UUID in
+	// the case of a transaction record.
+	KeyLocalRangeKeyPrefix = MakeKey(KeyLocalPrefix, proto.Key("k"))
+	// KeyLocalRangeDescriptorSuffix is the suffix for keys storing
 	// range descriptors. The value is a struct of type RangeDescriptor.
-	KeyLocalRangeDescriptorPrefix = MakeKey(KeyLocalPrefix, proto.Key("rng-"))
-	// KeyLocalRangeScanMetadataPrefix is the prefix for a range's scan metadata.
-	KeyLocalRangeScanMetadataPrefix = MakeKey(KeyLocalPrefix, proto.Key("rsm-"))
-	// KeyLocalRangeStatPrefix is the prefix for range statistics.
-	KeyLocalRangeStatPrefix = MakeKey(KeyLocalPrefix, proto.Key("rst-"))
-	// KeyLocalResponseCachePrefix is the prefix for keys storing command
-	// responses used to guarantee idempotency (see ResponseCache).
-	KeyLocalResponseCachePrefix = MakeKey(KeyLocalPrefix, proto.Key("res-"))
-	// KeyLocalStoreStatPrefix is the prefix for store statistics.
-	KeyLocalStoreStatPrefix = MakeKey(KeyLocalPrefix, proto.Key("sst-"))
-	// KeyLocalTransactionPrefix specifies the key prefix for
-	// transaction records. The suffix is the transaction id.
-	KeyLocalTransactionPrefix = MakeKey(KeyLocalPrefix, proto.Key("txn-"))
-	// KeyLocalRaftLogPrefix is the prefix for the raft log.
-	KeyLocalRaftLogPrefix = MakeKey(KeyLocalPrefix, proto.Key("rftl"))
-	// KeyLocalRaftStatePrefix is the prefix for the raft HardState.
-	KeyLocalRaftStatePrefix = MakeKey(KeyLocalPrefix, proto.Key("rfts"))
+	KeyLocalRangeDescriptorSuffix = proto.Key("rdsc")
+	// KeyLocalRangeScanMetadataSuffix is the suffix for a range's scan metadata.
+	KeyLocalRangeScanMetadataSuffix = proto.Key("rscm")
+	// KeyLocalTransactionSuffix specifies the key suffix for
+	// transaction records. The additional detail is the transaction id.
+	// NOTE: if this value changes, it must be updated in C++
+	// (roachlib/db.cc).
+	KeyLocalTransactionSuffix = proto.Key("txn-")
 
 	// KeyLocalMax is the end of the local key range.
 	KeyLocalMax = KeyLocalPrefix.PrefixEnd()

--- a/storage/engine/rocksdb.go
+++ b/storage/engine/rocksdb.go
@@ -73,20 +73,10 @@ func (r *RocksDB) Start() error {
 		return nil
 	}
 
-	// Encoded keys have a nul-byte suffix as part of their encoding. We
-	// need to trim this suffix in order to get the prefix that is
-	// common to transaction and response cache keys.
-	txnPrefix := goToCSlice(MVCCEncodeKey(KeyLocalTransactionPrefix))
-	txnPrefix.len-- // Trim nul-byte suffix
-	rcachePrefix := goToCSlice(MVCCEncodeKey(KeyLocalResponseCachePrefix))
-	rcachePrefix.len-- // Trim nul-byte suffix
-
 	status := C.DBOpen(&r.rdb, goToCSlice([]byte(r.dir)),
 		C.DBOptions{
 			cache_size:      C.int64_t(*cacheSize),
 			allow_os_buffer: C.int(1),
-			txn_prefix:      txnPrefix,
-			rcache_prefix:   rcachePrefix,
 			logger:          C.DBLoggerFunc(nil),
 		})
 	err := statusToError(status)

--- a/storage/range.go
+++ b/storage/range.go
@@ -1401,7 +1401,7 @@ func (r *Range) InitialState() (raftpb.HardState, raftpb.ConfState, error) {
 	cs := raftpb.ConfState{
 		Nodes: []uint64{1},
 	}
-	_, err := engine.MVCCGetProto(r.rm.Engine(), engine.RaftStateKey(uint64(r.Desc.RaftID)),
+	_, err := engine.MVCCGetProto(r.rm.Engine(), engine.RaftStateKey(r.Desc.RaftID),
 		proto.ZeroTimestamp, nil, &hs)
 	if err != nil {
 		return hs, cs, err
@@ -1412,7 +1412,7 @@ func (r *Range) InitialState() (raftpb.HardState, raftpb.ConfState, error) {
 
 // loadLastIndex looks in the engine to find the last log index.
 func (r *Range) loadLastIndex() error {
-	logKey := engine.RaftLogPrefix(uint64(r.Desc.RaftID))
+	logKey := engine.RaftLogPrefix(r.Desc.RaftID)
 	kvs, err := engine.MVCCScan(r.rm.Engine(),
 		logKey, logKey.PrefixEnd(),
 		1, // only the first (i.e. newest) result)
@@ -1440,8 +1440,8 @@ func (r *Range) Entries(lo, hi uint64) ([]raftpb.Entry, error) {
 	// MVCCScan is inclusive in the other direction we must increment both the
 	// start and end keys.
 	kvs, err := engine.MVCCScan(r.rm.Engine(),
-		engine.RaftLogKey(uint64(r.Desc.RaftID), hi).Next(),
-		engine.RaftLogKey(uint64(r.Desc.RaftID), lo).Next(),
+		engine.RaftLogKey(r.Desc.RaftID, hi).Next(),
+		engine.RaftLogKey(r.Desc.RaftID, lo).Next(),
 		0, proto.ZeroTimestamp, nil)
 	if err != nil {
 		return nil, err
@@ -1501,7 +1501,7 @@ func (r *Range) Snapshot() (raftpb.Snapshot, error) {
 func (r *Range) Append(entries []raftpb.Entry) error {
 	batch := r.rm.Engine().NewBatch()
 	for _, ent := range entries {
-		err := engine.MVCCPutProto(batch, nil, engine.RaftLogKey(uint64(r.Desc.RaftID), ent.Index),
+		err := engine.MVCCPutProto(batch, nil, engine.RaftLogKey(r.Desc.RaftID, ent.Index),
 			proto.ZeroTimestamp, nil, &ent)
 		if err != nil {
 			return err
@@ -1518,6 +1518,6 @@ func (r *Range) Append(entries []raftpb.Entry) error {
 
 // SetHardState implements the multiraft.WriteableGroupStorage interface.
 func (r *Range) SetHardState(st raftpb.HardState) error {
-	return engine.MVCCPutProto(r.rm.Engine(), nil, engine.RaftStateKey(uint64(r.Desc.RaftID)),
+	return engine.MVCCPutProto(r.rm.Engine(), nil, engine.RaftStateKey(r.Desc.RaftID),
 		proto.ZeroTimestamp, nil, &st)
 }

--- a/storage/range_data_iter.go
+++ b/storage/range_data_iter.go
@@ -49,24 +49,12 @@ func newRangeDataIterator(r *Range, e engine.Engine) *rangeDataIterator {
 	ri := &rangeDataIterator{
 		ranges: []keyRange{
 			{
-				start: engine.MVCCEncodeKey(responseCacheKeyPrefix(r.Desc.RaftID)),
-				end:   engine.MVCCEncodeKey(responseCacheKeyPrefix(r.Desc.RaftID + 1)),
+				start: engine.MVCCEncodeKey(engine.MakeKey(engine.KeyLocalRangeIDPrefix, encoding.EncodeInt(nil, r.Desc.RaftID))),
+				end:   engine.MVCCEncodeKey(engine.MakeKey(engine.KeyLocalRangeIDPrefix, encoding.EncodeInt(nil, r.Desc.RaftID+1))),
 			},
 			{
-				start: engine.MVCCEncodeKey(engine.RangeDescriptorKey(r.Desc.StartKey)),
-				end:   engine.MVCCEncodeKey(engine.RangeDescriptorKey(r.Desc.StartKey).Next()),
-			},
-			{
-				start: engine.MVCCEncodeKey(engine.RangeScanMetadataKey(r.Desc.StartKey)),
-				end:   engine.MVCCEncodeKey(engine.RangeScanMetadataKey(r.Desc.StartKey).Next()),
-			},
-			{
-				start: engine.MVCCEncodeKey(engine.MakeKey(engine.KeyLocalRangeStatPrefix, encoding.EncodeInt(nil, r.Desc.RaftID))),
-				end:   engine.MVCCEncodeKey(engine.MakeKey(engine.KeyLocalRangeStatPrefix, encoding.EncodeInt(nil, r.Desc.RaftID+1))),
-			},
-			{
-				start: engine.MVCCEncodeKey(engine.TransactionKey(r.Desc.StartKey, []byte(nil))),
-				end:   engine.MVCCEncodeKey(engine.TransactionKey(r.Desc.EndKey, []byte(nil))),
+				start: engine.MVCCEncodeKey(engine.MakeKey(engine.KeyLocalRangeKeyPrefix, encoding.EncodeBinary(nil, r.Desc.StartKey))),
+				end:   engine.MVCCEncodeKey(engine.MakeKey(engine.KeyLocalRangeKeyPrefix, encoding.EncodeBinary(nil, r.Desc.EndKey))),
 			},
 			{
 				start: engine.MVCCEncodeKey(startKey),

--- a/storage/range_data_iter_test.go
+++ b/storage/range_data_iter_test.go
@@ -34,12 +34,15 @@ func createRangeData(r *Range, t *testing.T) []proto.EncodedKey {
 		key proto.Key
 		ts  proto.Timestamp
 	}{
-		{responseCacheKey(r.Desc.RaftID, proto.ClientCmdID{WallTime: 1, Random: 1}), ts0},
-		{responseCacheKey(r.Desc.RaftID, proto.ClientCmdID{WallTime: 2, Random: 2}), ts0},
+		{engine.ResponseCacheKey(r.Desc.RaftID, &proto.ClientCmdID{WallTime: 1, Random: 1}), ts0},
+		{engine.ResponseCacheKey(r.Desc.RaftID, &proto.ClientCmdID{WallTime: 2, Random: 2}), ts0},
+		{engine.RaftLogKey(r.Desc.RaftID, 2), ts0},
+		{engine.RaftLogKey(r.Desc.RaftID, 1), ts0},
+		{engine.RaftStateKey(r.Desc.RaftID), ts0},
+		{engine.RangeStatKey(r.Desc.RaftID, engine.StatKeyBytes), ts0},
+		{engine.RangeStatKey(r.Desc.RaftID, engine.StatKeyCount), ts0},
 		{engine.RangeDescriptorKey(r.Desc.StartKey), ts},
 		{engine.RangeScanMetadataKey(r.Desc.StartKey), ts0},
-		{engine.MakeRangeStatKey(r.Desc.RaftID, engine.StatKeyBytes), ts0},
-		{engine.MakeRangeStatKey(r.Desc.RaftID, engine.StatKeyCount), ts0},
 		{engine.TransactionKey(r.Desc.StartKey, []byte("1234")), ts0},
 		{engine.TransactionKey(r.Desc.StartKey.Next(), []byte("5678")), ts0},
 		{engine.TransactionKey(r.Desc.EndKey.Prev(), []byte("2468")), ts0},

--- a/storage/response_cache_test.go
+++ b/storage/response_cache_test.go
@@ -92,7 +92,7 @@ func TestResponseCacheEmptyCmdID(t *testing.T) {
 
 // TestResponseCacheCopyInto tests that responses cached in one cache get
 // transferred correctly to another cache using CopyInto().
-func TestResposeCacheCopyInto(t *testing.T) {
+func TestResponseCacheCopyInto(t *testing.T) {
 	rc1, rc2 := createTestResponseCache(t, 1), createTestResponseCache(t, 2)
 	cmdID := makeCmdID(1, 1)
 	// Store an increment with new value one in the first cache.
@@ -115,7 +115,7 @@ func TestResposeCacheCopyInto(t *testing.T) {
 
 // TestResponseCacheCopyFrom tests that responses cached in one cache get
 // transferred correctly to another cache using CopyFrom().
-func TestResposeCacheCopyFrom(t *testing.T) {
+func TestResponseCacheCopyFrom(t *testing.T) {
 	rc1, rc2 := createTestResponseCache(t, 1), createTestResponseCache(t, 2)
 	cmdID := makeCmdID(1, 1)
 	// Store an increment with new value one in the first cache.

--- a/storage/store_split_test.go
+++ b/storage/store_split_test.go
@@ -32,7 +32,6 @@ import (
 	"github.com/cockroachdb/cockroach/storage/engine"
 	"github.com/cockroachdb/cockroach/util"
 	"github.com/cockroachdb/cockroach/util/log"
-	gogoproto "github.com/gogo/protobuf/proto"
 )
 
 func adminSplitArgs(key, splitKey []byte, raftID int64, storeID int32) (*proto.AdminSplitRequest, *proto.AdminSplitResponse) {
@@ -405,15 +404,13 @@ func TestStoreRangeSplitOnConfigs(t *testing.T) {
 	acctConfig := &proto.AcctConfig{}
 	zoneConfig := &proto.ZoneConfig{}
 
-	// Write accounting configs for db1 & db2 and zone configs for db3 & db4.
-	for _, k := range []string{"db4", "db3", "db2", "db1"} {
-		prefix := engine.KeyConfigAccountingPrefix
-		var config gogoproto.Message = acctConfig
-		if k == "db3" || k == "db4" {
-			prefix = engine.KeyConfigZonePrefix
-			config = zoneConfig
-		}
-		store.DB().PreparePutProto(engine.MakeKey(prefix, proto.Key(k)), config)
+	// Write zone configs for db3 & db4.
+	for _, k := range []string{"db4", "db3"} {
+		store.DB().PreparePutProto(engine.MakeKey(engine.KeyConfigZonePrefix, proto.Key(k)), zoneConfig)
+	}
+	// Write accounting configs for db1 & db2.
+	for _, k := range []string{"db2", "db1"} {
+		store.DB().PreparePutProto(engine.MakeKey(engine.KeyConfigAccountingPrefix, proto.Key(k)), acctConfig)
 	}
 	if err := store.DB().Flush(); err != nil {
 		t.Fatal(err)

--- a/util/encoding/key_encoding.go
+++ b/util/encoding/key_encoding.go
@@ -173,7 +173,7 @@ func DecodeBinary(buf []byte) ([]byte, []byte) {
 		}
 
 		t = (buf[i] << (8 - s)) & 0xff
-		
+
 		if buf[i] == orderedEncodingTerminator {
 			break
 		}


### PR DESCRIPTION
This groups all of the range-local data contiguously into two sections,
making range traversals require less seeks and more importantly, less
maintenance as new range-local data is added going forward.

The trickiest part of this was upgrading the C++ code to properly
account for encoded keys, since it now has to decode the key and skip
the range ID or range Key to determine whether the tuple being compacted
is a transaction record or response cache entry.
