### PR TITLE
CRDB Rails adapter is not currently equipped to process the different format being used by the customer

### DIFF
--- a/client/client_test.go
+++ b/client/client_test.go
@@ -87,12 +87,14 @@ func createTestClient(addr string) *client.KV {
 // where the non-transactional put can push the txn, we expect the
 // transaction's value to be written after all retries are complete.
 func TestKVClientRetryNonTxn(t *testing.T) {
-	storage.RangeRetryOptions.Backoff = 1 * time.Millisecond
-	storage.RangeRetryOptions.MaxAttempts = 2
-	client.TxnRetryOptions.Backoff = 1 * time.Millisecond
-
 	s := server.StartTestServer(t)
 	defer s.Stop()
+	s.SetRangeRetryOptions(util.RetryOptions{
+		Backoff:     1 * time.Millisecond,
+		MaxBackoff:  5 * time.Millisecond,
+		Constant:    2,
+		MaxAttempts: 2,
+	})
 	kvClient := createTestClient(s.HTTPAddr)
 	kvClient.User = storage.UserRoot
 

--- a/kv/txn_coord_sender.go
+++ b/kv/txn_coord_sender.go
@@ -355,6 +355,7 @@ func (tc *TxnCoordSender) sendBatch(batchArgs *proto.BatchRequest, batchReply *p
 	// pre-initialized with replies, use those; otherwise create replies
 	// as needed.
 	// TODO(spencer): send calls in parallel.
+	batchReply.Txn = batchArgs.Txn
 	for i := range batchArgs.Requests {
 		// Initialize args header values where appropriate.
 		args := batchArgs.Requests[i].GetValue().(proto.Request)

--- a/server/testserver.go
+++ b/server/testserver.go
@@ -23,6 +23,7 @@ import (
 
 	"github.com/cockroachdb/cockroach/gossip"
 	"github.com/cockroachdb/cockroach/proto"
+	"github.com/cockroachdb/cockroach/storage"
 	"github.com/cockroachdb/cockroach/storage/engine"
 	"github.com/cockroachdb/cockroach/util"
 	"github.com/cockroachdb/cockroach/util/hlc"
@@ -121,4 +122,12 @@ func (ts *TestServer) Start() error {
 // Stop stops the TestServer.
 func (ts *TestServer) Stop() {
 	ts.stop()
+}
+
+// Sets the retry options for stores in TestServer.
+func (ts *TestServer) SetRangeRetryOptions(ro util.RetryOptions) {
+	ts.server.node.lSender.VisitStores(func(s *storage.Store) error {
+		s.RetryOpts = ro
+		return nil
+	})
 }

--- a/storage/store_test.go
+++ b/storage/store_test.go
@@ -48,8 +48,8 @@ var testIdent = proto.StoreIdent{
 // setTestRetryOptions sets aggressive retries with a limit on number
 // of attempts so we don't get stuck behind indefinite backoff/retry
 // loops.
-func setTestRetryOptions() {
-	RangeRetryOptions = util.RetryOptions{
+func setTestRetryOptions(s *Store) {
+	s.RetryOpts = util.RetryOptions{
 		Backoff:     1 * time.Millisecond,
 		MaxBackoff:  2 * time.Millisecond,
 		Constant:    2,
@@ -687,7 +687,7 @@ func TestStoreResolveWriteIntentRollback(t *testing.T) {
 func TestStoreResolveWriteIntentPushOnRead(t *testing.T) {
 	store, _ := createTestStore(t)
 	defer store.Stop()
-	setTestRetryOptions()
+	setTestRetryOptions(store)
 
 	testCases := []struct {
 		resolvable bool


### PR DESCRIPTION
**Is your feature request related to a problem? Please describe.**
The CRDB Rails adapter is not currently equipped to process the different format being used by the customer for hinting no_zigzag_join/force_zig_zag. Customer wants to minimize the amount of effort required to migrate from Aurora to CRDB.

**Describe the solution you'd like**
Integrate the PR created by the customer into our CRDB Rails adapter.

**Describe alternatives you've considered**
The customer is manually incorporating RAW SQL queries into the ActiveRecord adapter which is a labor-intensive

Current ticket open 
https://github.com/cockroachlabs/support/issues/2155#issuecomment-1485671733




Jira issue: CRDB-26266