### PR TITLE
Block during raft group creation.

### DIFF
--- a/storage/store.go
+++ b/storage/store.go
@@ -925,8 +925,8 @@ func (s *Store) processRaft(r raftInterface, closer chan struct{}) {
 
 // GroupStorage implements the multiraft.Storage interface.
 func (s *Store) GroupStorage(groupID uint64) multiraft.WriteableGroupStorage {
-	s.mu.Lock()
-	defer s.mu.Unlock()
+	s.mu.RLock()
+	defer s.mu.RUnlock()
 	r, ok := s.ranges[int64(groupID)]
 	if !ok {
 		log.Warningf("%p requested nonexistent range with raft ID %d", s, groupID)


### PR DESCRIPTION
This fixes an occasional panic when a propose() is allowed to proceed
before an earlier group creation has completed. (The proposal really
shouldn't even be getting this far but I was unsuccessful at untangling
the circular dependencies between Store and raft without deadlocking).

@spencerkimball @cockroachdb/developers 
