### PR TITLE
Address naked access of Range.Desc.EndKey.

### DIFF
--- a/storage/range.go
+++ b/storage/range.go
@@ -240,9 +240,9 @@ func (r *Range) GetReplica() *proto.Replica {
 }
 
 // ContainsKey returns whether this range contains the specified key.
+// Read-lock the mutex to protect access to Desc, which might be changed
+// concurrently via range split.
 func (r *Range) ContainsKey(key proto.Key) bool {
-	// Read-lock the mutex to protect access to Desc, which might be changed
-	// concurrently via range split.
 	r.RLock()
 	defer r.RUnlock()
 	return r.Desc.ContainsKey(engine.KeyAddress(key))

--- a/storage/range_data_iter_test.go
+++ b/storage/range_data_iter_test.go
@@ -74,9 +74,11 @@ func TestRangeDataIteratorEmptyRange(t *testing.T) {
 	// records and config entries during the iteration. This is a rather
 	// nasty little hack, but since it's test code, meh.
 	tc.rng.Lock()
+	tc.store.mu.Lock()
 	newDesc := *tc.rng.Desc
 	newDesc.StartKey = proto.Key("a")
 	tc.rng.Desc = &newDesc
+	tc.store.mu.Unlock()
 	tc.rng.Unlock()
 
 	iter := newRangeDataIterator(tc.rng, tc.rng.rm.Engine())
@@ -98,10 +100,12 @@ func TestRangeDataIterator(t *testing.T) {
 
 	// See notes in EmptyRange test method for adjustment to descriptor.
 	tc.rng.Lock()
+	tc.store.mu.Lock()
 	newDesc := *tc.rng.Desc
 	newDesc.StartKey = proto.Key("b")
 	newDesc.EndKey = proto.Key("c")
 	tc.rng.Desc = &newDesc
+	tc.store.mu.Unlock()
 	tc.rng.Unlock()
 
 	// Create two more ranges, one before the test range and one after.


### PR DESCRIPTION
Note this is a unittest-only bug, as in the real world, EndKey wouldn't
have been modified only holding the range's mutex.

Fixes #270
