### PR TITLE
Put string value in REST Explorer

### DIFF
--- a/ui/js/controllers/rest_explorer.js
+++ b/ui/js/controllers/rest_explorer.js
@@ -42,6 +42,9 @@ crApp.controller('RestExplorerCtrl', ['$scope', '$http',
     var req = {
       method: method,
       url: endpoint,
+      headers: {
+        'Content-Type': 'text/plain; charset=UTF-8'
+      },
       data: data
     };
     if (endpoint.indexOf('/kv/rest/counter/') != -1) {

--- a/ui/js/controllers/rest_explorer.js
+++ b/ui/js/controllers/rest_explorer.js
@@ -35,9 +35,9 @@ crApp.controller('RestExplorerCtrl', ['$scope', '$http',
     } else if (!!scope.kvKey) {
       endpoint += scope.kvKey;
     }
-    var data = {};
+    var data = '';
     if (!!scope.kvValue) {
-      data['value'] = scope.kvValue;
+      data = scope.kvValue;
     }
     var req = {
       method: method,


### PR DESCRIPTION
The REST explorer wraps value in JSON object, leading to unexpected results when reading values back with other clients.

Unfortunately, empty strings still end up as {} in the request body.
