### PR TITLE
Introduce InternalTruncateLog method to discard a prefix of the raft log

### DIFF
--- a/kv/db_test.go
+++ b/kv/db_test.go
@@ -171,6 +171,7 @@ func TestKVDBInternalMethods(t *testing.T) {
 		{proto.InternalPushTxn, &proto.InternalPushTxnRequest{}, &proto.InternalPushTxnResponse{}},
 		{proto.InternalResolveIntent, &proto.InternalResolveIntentRequest{}, &proto.InternalResolveIntentResponse{}},
 		{proto.InternalMerge, &proto.InternalMergeRequest{}, &proto.InternalMergeResponse{}},
+		{proto.InternalTruncateLog, &proto.InternalTruncateLogRequest{}, &proto.InternalTruncateLogResponse{}},
 	}
 	// Verify non-public methods experience bad request errors.
 	kvClient := createTestClient(addr)

--- a/proto/api.go
+++ b/proto/api.go
@@ -103,6 +103,7 @@ var AllMethods = stringSet{
 	InternalPushTxn:       struct{}{},
 	InternalResolveIntent: struct{}{},
 	InternalMerge:         struct{}{},
+	InternalTruncateLog:   struct{}{},
 }
 
 // PublicMethods specifies the set of methods accessible via the
@@ -131,6 +132,7 @@ var InternalMethods = stringSet{
 	InternalPushTxn:       struct{}{},
 	InternalResolveIntent: struct{}{},
 	InternalMerge:         struct{}{},
+	InternalTruncateLog:   struct{}{},
 }
 
 // ReadMethods specifies the set of methods which read and return data.
@@ -160,6 +162,7 @@ var WriteMethods = stringSet{
 	InternalPushTxn:       struct{}{},
 	InternalResolveIntent: struct{}{},
 	InternalMerge:         struct{}{},
+	InternalTruncateLog:   struct{}{},
 }
 
 // TxnMethods specifies the set of methods which leave key intents
@@ -346,6 +349,8 @@ func MethodForRequest(req Request) (string, error) {
 		return InternalResolveIntent, nil
 	case *InternalMergeRequest:
 		return InternalMerge, nil
+	case *InternalTruncateLogRequest:
+		return InternalTruncateLog, nil
 	}
 	return "", util.Errorf("unhandled request %T", req)
 }
@@ -399,6 +404,8 @@ func CreateArgs(method string) (Request, error) {
 		return &InternalResolveIntentRequest{}, nil
 	case InternalMerge:
 		return &InternalMergeRequest{}, nil
+	case InternalTruncateLog:
+		return &InternalTruncateLogRequest{}, nil
 	}
 	return nil, util.Errorf("unhandled method %s", method)
 }
@@ -442,6 +449,8 @@ func CreateReply(method string) (Response, error) {
 		return &InternalResolveIntentResponse{}, nil
 	case InternalMerge:
 		return &InternalMergeResponse{}, nil
+	case InternalTruncateLog:
+		return &InternalTruncateLogResponse{}, nil
 	}
 	return nil, util.Errorf("unhandled method %s", method)
 }

--- a/proto/internal.go
+++ b/proto/internal.go
@@ -51,6 +51,8 @@ const (
 	// The logic used to merge values of different types is described in more
 	// detail by the "Merge" method of engine.Engine.
 	InternalMerge = "InternalMerge"
+	// InternalTruncateLog discards a prefix of the raft log.
+	InternalTruncateLog = "InternalTruncateLog"
 )
 
 // ToValue generates a Value message which contains an encoded copy of this

--- a/proto/internal.proto
+++ b/proto/internal.proto
@@ -124,6 +124,23 @@ message InternalMergeResponse {
   optional ResponseHeader header = 1 [(gogoproto.nullable) = false, (gogoproto.embed) = true];
 }
 
+// InternalTruncateLogRequest is used to remove a prefix of the raft log. While there
+// is no requirement for correctness that the raft log truncation be synchronized across
+// replicas, it is nice to preserve the property that all replicas of a range are as close
+// to identical as possible. The raft leader can also inform decisions about the cutoff point
+// with its knowledge of the replicas' acknowledgement status.
+message InternalTruncateLogRequest {
+  optional RequestHeader header = 1 [(gogoproto.nullable) = false, (gogoproto.embed) = true];
+
+  // Log entries < this index are to be discarded.
+  optional uint64 index = 2 [(gogoproto.nullable) = false];
+}
+
+// InternalTruncateLogResponse is the response to an InternalTruncateLog() operation.
+message InternalTruncateLogResponse {
+  optional ResponseHeader header = 1 [(gogoproto.nullable) = false, (gogoproto.embed) = true];
+}
+
 // A ReadWriteCmdResponse is a union type containing instances of all
 // mutating commands. Note that any entry added here must be handled
 // in roachlib/db.cc in GetResponseHeader().
@@ -142,6 +159,7 @@ message ReadWriteCmdResponse {
   optional InternalPushTxnResponse internal_push_txn = 11;
   optional InternalResolveIntentResponse internal_resolve_intent = 12;
   optional InternalMergeResponse internal_merge = 13;
+  optional InternalTruncateLogResponse internal_truncate_log = 14;
 }
 
 // An InternalRaftCommandUnion is the union of all commands which can be
@@ -170,6 +188,7 @@ message InternalRaftCommandUnion {
   optional InternalPushTxnRequest internal_push_txn = 33;
   optional InternalResolveIntentRequest internal_resolve_intent = 34;
   optional InternalMergeRequest internal_merge_response = 35;
+  optional InternalTruncateLogRequest internal_truncate_log = 36;
 }
 
 // An InternalRaftCommand is a command which can be serialized and

--- a/roachlib/db.cc
+++ b/roachlib/db.cc
@@ -130,6 +130,8 @@ const proto::ResponseHeader* GetResponseHeader(const proto::ReadWriteCmdResponse
     return &rwResp.internal_resolve_intent().header();
   } else if (rwResp.has_internal_merge()) {
     return &rwResp.internal_merge().header();
+  } else if (rwResp.has_internal_truncate_log()) {
+    return &rwResp.internal_truncate_log().header();
   }
   return NULL;
 }

--- a/server/node.go
+++ b/server/node.go
@@ -480,3 +480,7 @@ func (n *Node) InternalResolveIntent(args *proto.InternalResolveIntentRequest, r
 func (n *Node) InternalMerge(args *proto.InternalMergeRequest, reply *proto.InternalMergeResponse) error {
 	return n.executeCmd(proto.InternalMerge, args, reply)
 }
+
+func (n *Node) InternalTruncateLog(args *proto.InternalTruncateLogRequest, reply *proto.InternalTruncateLogResponse) error {
+	return n.executeCmd(proto.InternalTruncateLog, args, reply)
+}


### PR DESCRIPTION
@spencerkimball @cockroachdb/developers 
