### PR TITLE
Slight cleanup to raft logging.

### DIFF
--- a/multiraft/multiraft.go
+++ b/multiraft/multiraft.go
@@ -52,9 +52,9 @@ type Config struct {
 	EntryFormatter raft.EntryFormatter
 }
 
-// Validate returns an error if any required elements of the Config are missing or invalid.
+// validate returns an error if any required elements of the Config are missing or invalid.
 // Called automatically by NewMultiRaft.
-func (c *Config) Validate() error {
+func (c *Config) validate() error {
 	if c.Transport == nil {
 		return util.Error("Transport is required")
 	}
@@ -92,7 +92,7 @@ func NewMultiRaft(nodeID uint64, config *Config) (*MultiRaft, error) {
 	if nodeID == 0 {
 		return nil, util.Error("Invalid NodeID")
 	}
-	err := config.Validate()
+	err := config.validate()
 	if err != nil {
 		return nil, err
 	}

--- a/util/log/log.go
+++ b/util/log/log.go
@@ -19,6 +19,11 @@ package log
 
 import "github.com/golang/glog"
 
+func init() {
+	// Raft logs verbosely with log.Printf.
+	glog.CopyStandardLogTo("INFO")
+}
+
 // FatalOnPanic recovers from a panic and exits the process with a
 // Fatal log. This is useful for avoiding a panic being caught through
 // a CGo exported function or preventing HTTP handlers from recovering


### PR DESCRIPTION
Remove the "Validate has wrong number of inputs" log line (due to a
quirk of the way methods from anonymous structs get promoted, the split
we have between MultiRaft and multiraftServer doesn't completely do the
job).

Redirect all log.Printf() calls (which are used by raft) to glog.Infof.

@spencerkimball @cockroachdb/developers 
