### PR TITLE
Fix the 'go vet' pre-commit hook and disable golint hook

### DIFF
--- a/client/kv.go
+++ b/client/kv.go
@@ -96,7 +96,6 @@ func (kv *KV) Sender() KVSender {
 	default:
 		return t
 	}
-	return nil
 }
 
 // Call invokes the KV command synchronously and returns the response

--- a/client/kv_test.go
+++ b/client/kv_test.go
@@ -71,7 +71,7 @@ func TestKVPrepareAndFlush(t *testing.T) {
 					t.Error("expected batch for > 1 buffered calls")
 				}
 				if call.Args.Header().CmdID.WallTime == 0 {
-					t.Errorf("expected batch client command ID to be initialized: %s", call.Args.Header().CmdID)
+					t.Errorf("expected batch client command ID to be initialized: %v", call.Args.Header().CmdID)
 				}
 			}
 		}), nil)
@@ -264,7 +264,7 @@ func TestKVRunTransactionRetryOnErrors(t *testing.T) {
 				t.Errorf("%d: expected one retry; got %d", i, count)
 			}
 			if err != nil {
-				t.Errorf("%d: expected success on retry; got %S", i, err)
+				t.Errorf("%d: expected success on retry; got %s", i, err)
 			}
 		} else {
 			if count != 1 {

--- a/githooks/pre-commit
+++ b/githooks/pre-commit
@@ -16,17 +16,21 @@ if [ "${GO_SKIP_PRECOMMIT_CHECKS}" != "1" -a -n "${gofiles}" ]; then
   fi
 
   # Check for lint errors.
-  unlinted=$(golint ${gofiles} | awk -F: '{print $1}' | uniq)
-  if [ -n "${unlinted}" ]; then
-    echo -e >&2 "\nGo files with lint errors:"
-    for fn in ${unlinted}; do
-      echo >&2 "  golint $fn"
-    done
-    exit 1
-  fi
+  # TODO(bdarnell): golint does not accept files from multiple packages in the same
+  # invocation, so to re-enable this we need to split ${gofiles} by package and combine
+  # multiple runs of golint.
+  #
+  #unlinted=$(golint ${gofiles} 2>&1 | awk -F: '{print $1}' | uniq)
+  #if [ -n "${unlinted}" ]; then
+  #  echo -e >&2 "\nGo files with lint errors:"
+  #  for fn in ${unlinted}; do
+  #    echo >&2 "  golint $fn"
+  #  done
+  #  exit 1
+  #fi
 
   # Check for vet errors.
-  unvetted=$(go tool vet ${gofiles} | awk -F: '{print $1}' | uniq)
+  unvetted=$(go tool vet ${gofiles} 2>&1 | awk -F: '{print $1}' | uniq)
   if [ -n "${unvetted}" ]; then
     echo -e >&2 "\nGo files with vet errors:"
     for fn in ${unvetted}; do

--- a/gossip/group_test.go
+++ b/gossip/group_test.go
@@ -59,7 +59,7 @@ func TestMinGroupShouldInclude(t *testing.T) {
 		t.Error("could not insert")
 	}
 	if _, err := group.addInfo(info3); err != nil {
-		t.Error("could not insert: %s", err)
+		t.Errorf("could not insert: %s", err)
 	}
 	// A larger insert shouldn't include.
 	info4 := newTestInfo("a.d", int64(3))

--- a/gossip/infostore_test.go
+++ b/gossip/infostore_test.go
@@ -531,7 +531,7 @@ func TestCallbacks(t *testing.T) {
 			t.Errorf("expected %v, got %v", expKeys, cb2.Keys())
 		}
 		if expKeys := []string{"key1-true", "key2-true", "key3-true"}; !reflect.DeepEqual(cbAll.Keys(), expKeys) {
-			t.Errorf("expected expKeys, got %v", expKeys, cbAll.Keys())
+			t.Errorf("expected %v, got %v", expKeys, cbAll.Keys())
 		}
 	}
 

--- a/rpc/codec/rpc_test.go
+++ b/rpc/codec/rpc_test.go
@@ -210,7 +210,7 @@ func testArithClientAsync(t *testing.T, client *rpc.Client) {
 		got := calls[i].Reply.(*msg.ArithResponse).GetC()
 		expected := callInfoList[i].reply.GetC()
 		if got != expected {
-			t.Fatalf(`%d: expected %v, Got = %v`,
+			t.Fatalf(`%s: expected %v, Got = %v`,
 				callInfoList[i].method, got, expected,
 			)
 		}

--- a/storage/engine/engine_test.go
+++ b/storage/engine/engine_test.go
@@ -600,7 +600,8 @@ func TestSnapshotMethods(t *testing.T) {
 		index := 0
 		if err := snap.Iterate(proto.EncodedKey(KeyMin), proto.EncodedKey(KeyMax), func(kv proto.RawKeyValue) (bool, error) {
 			if !bytes.Equal(kv.Key, keys[index]) || !bytes.Equal(kv.Value, vals[index]) {
-				t.Errorf("%d: key/value not equal between expected and snapshot: %s/%s, %s/%s", keys[index], vals[index], kv.Key, kv.Value)
+				t.Errorf("%d: key/value not equal between expected and snapshot: %s/%s, %s/%s",
+					index, keys[index], vals[index], kv.Key, kv.Value)
 			}
 			index++
 			return false, nil

--- a/storage/queue_test.go
+++ b/storage/queue_test.go
@@ -92,7 +92,7 @@ func TestBaseQueueAddUpdateAndRemove(t *testing.T) {
 		t.Error("expected r1")
 	}
 	if r := bq.Pop(); r != nil {
-		t.Errorf("expected empty queue; got %s", r)
+		t.Errorf("expected empty queue; got %v", r)
 	}
 
 	// Add again, but this time r2 shouldn't add.
@@ -124,7 +124,7 @@ func TestBaseQueueAddUpdateAndRemove(t *testing.T) {
 		t.Error("expected r2")
 	}
 	if r := bq.Pop(); r != nil {
-		t.Errorf("expected empty queue; got %s", r)
+		t.Errorf("expected empty queue; got %v", r)
 	}
 
 	// Set !shouldAdd for r2 and add it; this has effect of removing it.

--- a/storage/range.go
+++ b/storage/range.go
@@ -222,7 +222,7 @@ func (r *Range) Destroy() error {
 	iter := newRangeDataIterator(r, r.rm.Engine())
 	defer iter.Close()
 	for ; iter.Valid(); iter.Next() {
-		deletes = append(deletes, engine.BatchDelete{proto.RawKeyValue{Key: iter.Key()}})
+		deletes = append(deletes, engine.BatchDelete{RawKeyValue: proto.RawKeyValue{Key: iter.Key()}})
 	}
 	return r.rm.Engine().WriteBatch(deletes)
 }

--- a/storage/store_test.go
+++ b/storage/store_test.go
@@ -266,7 +266,7 @@ func TestStoreAddRemoveRanges(t *testing.T) {
 
 	for i, test := range testCases {
 		if r := store.LookupRange(test.start, test.end); r != test.expRng {
-			t.Errorf("%d: expected range %s; got %s", i, test.expRng, r)
+			t.Errorf("%d: expected range %v; got %v", i, test.expRng, r)
 		}
 	}
 }
@@ -297,7 +297,7 @@ func TestStoreRangeIterator(t *testing.T) {
 	for pass := 0; pass < 2; pass++ {
 		for i := 1; iter.estimatedCount() > 0; i++ {
 			if rng := iter.next(); rng == nil || rng.Desc.RaftID != int64(i) {
-				t.Errorf("expected range with Raft ID %d; got %s", i, rng)
+				t.Errorf("expected range with Raft ID %d; got %v", i, rng)
 			}
 		}
 		iter.reset()


### PR DESCRIPTION
Both of these tools produce output on stderr instead of stdout, so they
were being ignored. Golint reports errors whenever it is given filenames
instead of package names and it is given files from multiple packages,
so it cannot be enabled without further work to refactor the script.

Fix all existing 'go vet' errors.

@spencerkimball @cockroachdb/developers 
