### PR TITLE
Remove the call to Stop() at the beginning of Store.Start().

### DIFF
--- a/storage/engine/engine_test.go
+++ b/storage/engine/engine_test.go
@@ -632,8 +632,10 @@ func TestSnapshotMethods(t *testing.T) {
 		if err != nil {
 			t.Fatal(err)
 		}
-		if !reflect.DeepEqual(capacity, capacitySnapshot) {
-			t.Errorf("expected capacities to be equal: %v != %v", capacity, capacitySnapshot)
+		// The Available fields of capacity may differ due to processes beyond our control.
+		if capacity.Capacity != capacitySnapshot.Capacity {
+			t.Errorf("expected capacities to be equal: %v != %v",
+				capacity.Capacity, capacitySnapshot.Capacity)
 		}
 
 		// Verify ApproximateSize.


### PR DESCRIPTION
This does not appear to be necessary for any tests and allows
a simplification of Stop(), which also fixes an occasional panic.

@spencerkimball @cockroachdb/developers 
