### PR TITLE
Raft Coalesced Heartbeats

### DIFF
--- a/multiraft/events.go
+++ b/multiraft/events.go
@@ -37,8 +37,8 @@ type EventCommandCommitted struct {
 // followed by the payload. This inflexible encoding is used so we can efficiently
 // parse the command id while processing the logs.
 const (
-	commandIDLen           = 16
-	commandEncodingVersion = 0
+	commandIDLen                = 16
+	commandEncodingVersion byte = 0
 )
 
 func encodeCommand(commandID string, command []byte) []byte {

--- a/multiraft/events_test.go
+++ b/multiraft/events_test.go
@@ -64,4 +64,6 @@ func (e *eventDemux) start() {
 
 func (e *eventDemux) stop() {
 	close(e.stopper)
+	close(e.CommandCommitted)
+	close(e.LeaderElection)
 }

--- a/multiraft/heartbeat_test.go
+++ b/multiraft/heartbeat_test.go
@@ -153,13 +153,13 @@ func TestHeartbeatSingleGroup(t *testing.T) {
 // followers, if any, will not experience ticks. All heartbeats and responses
 // sent by nodes in the system are intercepted and validated.
 func validateHeartbeatSingleGroup(nodeCount, tickCount int, t *testing.T) {
-	leaderIndex := 0 // first node is leader.
+	leaderIndex := 0 // first node is leader
 	nc := nodeCount
 	ltc := tickCount // leader tick count
 	ec := 2          // extra ticks; due to election triggering.
 	// Ticks of first follower. Hard coded to one in the test below, since any
 	// higher value can lead to new elections which break the test.
-	// Assigning this to a valuable helps to make sense of the formulae below.
+	// Assigning this to a variable helps to make sense of the formulae below.
 	ftc := 1
 
 	expCnt := heartbeatCountMap{
@@ -186,6 +186,7 @@ func validateHeartbeatSingleGroup(nodeCount, tickCount int, t *testing.T) {
 	go func() {
 		// Create group, elect leader, then send ticks as we want them.
 		cluster.createGroup(1, 0, nc)
+		cluster.triggerElection(leaderIndex)
 		cluster.waitForElection(leaderIndex)
 		cluster.tickers[leaderIndex+1].Tick() // Single tick for first follower.
 		for i := 0; i < ltc; i++ {
@@ -224,5 +225,98 @@ func validateHeartbeatSingleGroup(nodeCount, tickCount int, t *testing.T) {
 			"%d leader ticks:\n%v\n%v",
 			nc, ltc, actCnt, expCnt)
 	}
+	cluster.stop()
+}
+
+func TestHeartbeatMultipleGroupsJointLeader(t *testing.T) {
+	cluster := blockingCluster(6, t)
+	transport := cluster.transport.(*localInterceptableTransport)
+	done := make(chan struct{})
+	firstPhase := make(chan struct{})
+	go func() {
+		// Create group, elect leader, then send ticks as we want them.
+		cluster.createGroup(1, 0, 3)
+		cluster.createGroup(2, 2, 3)
+		// The node at index 2 (nodeID 3) is contained in both groups
+		// Two requests to #1, #2, #4, #5 (from #3).
+		cluster.triggerElection(2)
+		// Wait until it winds up elected twice
+		for i := 0; i < 2; i++ {
+			if el := cluster.waitForElection(2); el.NodeID != 3 {
+				t.Fatalf("wrong leader elected, wanted node 3 but got event %v", el)
+			}
+		}
+		// Same on #4, but mostly to clean out the events channel; this node
+		// will be leader later and we want a clean slate.
+		if el := cluster.waitForElection(3); el.NodeID != 3 {
+			t.Fatalf("wrong leader elected, wanted node 3 but got event %v", el)
+		}
+		// Request to #2, #3 but no response.
+		cluster.tickers[0].Tick()
+		// Request to #1, #3 but no response.
+		cluster.tickers[1].Tick()
+		// Request to #1, #2, #4, #5 with response.
+		cluster.tickers[2].Tick()
+		// No request, no response (#6 not in any group).
+		cluster.tickers[5].Tick()
+		// Request to #3 and #4 but no response.
+		cluster.tickers[4].Tick()
+		// End the first phase. This is necessary to make sure all the pending
+		// ticks are being processed before we elect a new leader for phase two.
+		<-firstPhase
+		// Elect a new leader for the second group.
+		// Two requests to #3, #4
+		cluster.triggerElection(3)
+		if el := cluster.waitForElection(3); el.NodeID != 4 {
+			t.Fatalf("wrong leader elected, wanted node 4 but got event %v", el)
+		}
+		// Requests to #1, #2 with and #4, #5 without responses.
+		cluster.tickers[2].Tick()
+		// Requests to #3, #5 with responses.
+		cluster.tickers[3].Tick()
+		// Requests to #3, #4 without responses.
+		cluster.tickers[4].Tick()
+		close(done)
+	}()
+
+	// The main message processing loop.
+	expCntFirstPhase := heartbeatCountMap{
+		1: {reqOut: 2, reqIn: 4, respOut: 1, respIn: 0},
+		2: {reqOut: 2, reqIn: 4, respOut: 1, respIn: 0},
+		3: {reqOut: 12, reqIn: 3, respOut: 0, respIn: 4},
+		4: {reqOut: 0, reqIn: 4, respOut: 1, respIn: 0},
+		5: {reqOut: 2, reqIn: 3, respOut: 1, respIn: 0},
+		// NodeID 6 is not member of any Raft group, so it has no peers and
+		// consequently must not even show up in the heartbeat count map.
+	}
+	actCnt := countHeartbeats(transport.Events,
+		func(req *RaftMessageRequest, cnt heartbeatCountMap) bool {
+			return cnt.Sum() >= expCntFirstPhase.Sum()
+		})
+
+	if !reflect.DeepEqual(actCnt, expCntFirstPhase) {
+		t.Errorf("phase 1: expected and actual heartbeat counts differ:\n%v\n%v",
+			expCntFirstPhase, actCnt)
+	}
+	close(firstPhase)
+	expCntSecondPhase := heartbeatCountMap{
+		1: {reqOut: 0, reqIn: 1, respOut: 1, respIn: 0},
+		2: {reqOut: 0, reqIn: 1, respOut: 1, respIn: 0},
+		3: {reqOut: 4, reqIn: 4, respOut: 1, respIn: 2},
+		4: {reqOut: 6, reqIn: 2, respOut: 0, respIn: 2},
+		5: {reqOut: 2, reqIn: 4, respOut: 1, respIn: 0},
+	}
+	actCnt = countHeartbeats(transport.Events,
+		func(req *RaftMessageRequest, cnt heartbeatCountMap) bool {
+			return cnt.Sum() >= expCntSecondPhase.Sum()
+		})
+
+	if !reflect.DeepEqual(actCnt, expCntSecondPhase) {
+		t.Errorf("phase 2: expected and actual heartbeat counts differ:\n%v\n%v",
+			expCntSecondPhase, actCnt)
+	}
+	// Keep processing without inspection and shutdown cluster.
+	go processEventsUntil(transport.Events, alwaysFalse)
+	<-done
 	cluster.stop()
 }

--- a/multiraft/heartbeat_test.go
+++ b/multiraft/heartbeat_test.go
@@ -1,0 +1,152 @@
+// Copyright 2014 The Cockroach Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+// implied. See the License for the specific language governing
+// permissions and limitations under the License. See the AUTHORS file
+// for names of contributors.
+//
+// Author: Tobias Schottdorf (tobias.schottdorf@gmail.com)
+
+package multiraft
+
+import (
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/cockroachdb/cockroach/util/log"
+	"github.com/coreos/etcd/raft/raftpb"
+)
+
+func processEventsUntil(ch <-chan *interceptMessage, f func(*RaftMessageRequest) bool) {
+	for e := range ch {
+		e.ack <- struct{}{}
+		if f(e.args.(*RaftMessageRequest)) {
+			return
+		}
+	}
+}
+
+// validateHeartbeatCount receives messages from the given channel and compares
+// the observed number of heartbeat requests and responses.
+// Once the channel closes or enough heartbeat responses have been observed,
+// the function returns.
+func validateHeartbeatCount(ch <-chan *interceptMessage,
+	heartbeatCount, heartbeatResponseCount int, t *testing.T) {
+	// maps nodeID to heartbeats sent by this node minus heartbeat
+	// responses received by this node.
+	outInDelta := make(map[uint64]int)
+	cntH := 0
+	cntR := 0
+	defer func() {
+		for nodeID, delta := range outInDelta {
+			// If one of the checks below fails, this information will be useful.
+			log.Infof("node %v: %d heartbeats without response", nodeID, delta)
+		}
+		if cntH != heartbeatCount {
+			t.Errorf("unexpected total number of heartbeats: %d (expected %d)",
+				cntH, heartbeatCount)
+		}
+		if cntR != heartbeatResponseCount {
+			t.Errorf("unexpected total number of heartbeat responses: %d (expected %d)",
+				cntR, heartbeatResponseCount)
+		}
+	}()
+	for iMsg := range ch {
+		iMsg.ack <- struct{}{}
+		req := iMsg.args.(*RaftMessageRequest)
+		switch req.Message.Type {
+		case raftpb.MsgHeartbeat:
+			cntH++
+			outInDelta[req.Message.From]++
+		case raftpb.MsgHeartbeatResp:
+			cntR++
+			nodeID := req.Message.To
+			outInDelta[nodeID]--
+			if outInDelta[nodeID] < 0 {
+				t.Errorf("node %v: more responses received than heartbeats sent",
+					nodeID)
+			}
+		}
+		// If we've already received all the heartbeat responses that
+		// we have asked for, return. Without this, it's more awkward
+		// to know when to shut down the cluster.
+		if cntR >= heartbeatResponseCount {
+			return
+		}
+	}
+}
+
+func TestHeartbeat(t *testing.T) {
+	nodeCount := 3
+	cluster := newTestCluster(nodeCount, t)
+	// Outgoing messages block the client until we acknowledge them, and
+	// messages are sent synchronously.
+	cluster.transport.EnableEvents()
+
+	cluster.start()
+	leaderTickCount := 18
+	// Since waitForElection() currently triggers two ticks, it also triggers
+	// some heartbeats which remain unanswered (the sender isn't leader yet).
+	unansweredHeartbeats := (nodeCount - 1) * 2 // 2 because of 2 election ticks.
+
+	// How many heartbeats and heartbeat responses we expect in total.
+	expHeartbeatCount := (nodeCount-1)*leaderTickCount + unansweredHeartbeats
+	expHeartbeatRespCount := (nodeCount - 1) * leaderTickCount
+
+	wg := &sync.WaitGroup{}
+	wg.Add(1)
+	go func() {
+		// Run the actual checks, consuming from the Events channel.
+		validateHeartbeatCount(cluster.transport.Events, expHeartbeatCount,
+			expHeartbeatRespCount, t)
+		// Once we're here, we may begin tearing down.
+		wg.Done()
+		// For the rest of this test, simply keep acknowledging messages
+		// so that Raft makes progress. This mostly serves to avoid deadlock
+		// in cases where there is unexpected behaviour.
+		processEventsUntil(cluster.transport.Events, func(r *RaftMessageRequest) bool {
+			return false
+		})
+	}()
+
+	groupID := uint64(1)
+	leaderIndex := 0
+	cluster.createGroup(groupID, 3)
+	election := cluster.waitForElection(leaderIndex)
+
+	for i := 0; i < leaderTickCount; i++ {
+		cluster.tickers[leaderIndex].Tick()
+	}
+
+	wg.Wait()
+
+	cluster.stop()
+
+	// No further elections should have happened in the meantime.
+	for i := 0; i < nodeCount; i++ {
+		for {
+			depleted := false
+			select {
+			case ev := <-cluster.events[i].LeaderElection:
+				if ev.Term != election.Term {
+					t.Errorf("node %v: unexpected election event: %v (original election: %v)", i, ev, election)
+				}
+			case <-time.After(time.Millisecond):
+				depleted = true
+			}
+			if depleted {
+				break
+			}
+		}
+	}
+	close(cluster.transport.Events)
+}

--- a/multiraft/heartbeat_test.go
+++ b/multiraft/heartbeat_test.go
@@ -253,6 +253,8 @@ func TestHeartbeatMultipleGroupsJointLeader(t *testing.T) {
 		}
 		// Request to #2, #3 but no response.
 		cluster.tickers[0].Tick()
+		// We don't tick node 2 to get some asymmetry.
+
 		// Request to #1, #3 but no response.
 		cluster.tickers[1].Tick()
 		// Request to #1, #2, #4, #5 with response.
@@ -270,6 +272,8 @@ func TestHeartbeatMultipleGroupsJointLeader(t *testing.T) {
 		if el := cluster.waitForElection(3); el.NodeID != 4 {
 			t.Fatalf("wrong leader elected, wanted node 4 but got event %v", el)
 		}
+		// Requests to #2, #3 without responses.
+		cluster.tickers[0].Tick()
 		// Requests to #1, #2 with and #4, #5 without responses.
 		cluster.tickers[2].Tick()
 		// Requests to #3, #5 with responses.
@@ -300,9 +304,9 @@ func TestHeartbeatMultipleGroupsJointLeader(t *testing.T) {
 	}
 	close(firstPhase)
 	expCntSecondPhase := heartbeatCountMap{
-		1: {reqOut: 0, reqIn: 1, respOut: 1, respIn: 0},
-		2: {reqOut: 0, reqIn: 1, respOut: 1, respIn: 0},
-		3: {reqOut: 4, reqIn: 4, respOut: 1, respIn: 2},
+		1: {reqOut: 2, reqIn: 1, respOut: 1, respIn: 0},
+		2: {reqOut: 0, reqIn: 2, respOut: 1, respIn: 0},
+		3: {reqOut: 4, reqIn: 5, respOut: 1, respIn: 2},
 		4: {reqOut: 6, reqIn: 2, respOut: 0, respIn: 2},
 		5: {reqOut: 2, reqIn: 4, respOut: 1, respIn: 0},
 	}

--- a/multiraft/multiraft.go
+++ b/multiraft/multiraft.go
@@ -19,6 +19,7 @@ package multiraft
 
 import (
 	"fmt"
+	"math"
 	"time"
 
 	"github.com/cockroachdb/cockroach/util"
@@ -184,6 +185,55 @@ func (m *MultiRaft) sendEvent(event interface{}) {
 	}
 }
 
+// fanoutHeartbeat sends the given heartbeat to all groups which believe that
+// their leader resides on the sending node.
+func (s *state) fanoutHeartbeat(req *RaftMessageRequest) {
+	// A heartbeat message is expanded into a heartbeat for each group
+	// that the remote node is a part of.
+	originNode, _ := s.nodes[req.Message.From]
+	cnt := 0
+	for groupID := range originNode.groupIDs {
+		// If we don't think that the sending node is leading that group, don't
+		// propagate.
+		if s.groups[groupID].leader != req.Message.From || req.Message.From == s.nodeID {
+			log.V(8).Infof("node %v: not fanning out heartbeat to %v, msg is from %d and leader is %d",
+				s.nodeID, req.Message.To, req.Message.From, s.groups[groupID].leader)
+			continue
+		}
+		if err := s.multiNode.Step(context.Background(), groupID, req.Message); err != nil {
+			log.V(4).Infof("node %v: coalesced heartbeat step failed for message %s", s.nodeID, groupID,
+				raft.DescribeMessage(req.Message, s.EntryFormatter))
+		}
+		cnt++
+	}
+	log.V(7).Infof("node %v: received coalesced heartbeat from node %v; "+
+		"fanned out to %d followers in %d overlapping groups",
+		s.nodeID, req.Message.From, cnt, len(originNode.groupIDs))
+}
+
+// fanoutHeartbeatResponse sends the given heartbeat response to all groups
+// which overlap with the sender's groups and consider themselves leader.
+func (s *state) fanoutHeartbeatResponse(req *RaftMessageRequest) {
+	originNode, _ := s.nodes[req.Message.From]
+	cnt := 0
+	for groupID := range originNode.groupIDs {
+		// If we don't think that the local node is leader, don't propagate.
+		if s.groups[groupID].leader != s.nodeID || req.Message.From == s.nodeID {
+			log.V(8).Infof("node %v: not fanning out heartbeat response to %v, msg is from %d and leader is %d",
+				s.nodeID, req.Message.To, req.Message.From, s.groups[groupID].leader)
+			continue
+		}
+		if err := s.multiNode.Step(context.Background(), groupID, req.Message); err != nil {
+			log.V(4).Infof("node %v: coalesced heartbeat response step failed for message %s", s.nodeID, groupID,
+				raft.DescribeMessage(req.Message, s.EntryFormatter))
+		}
+		cnt++
+	}
+	log.V(7).Infof("node %v: received coalesced heartbeat response from node %v; "+
+		"fanned out to %d leaders in %d overlapping groups",
+		s.nodeID, req.Message.From, cnt, len(originNode.groupIDs))
+}
+
 // CreateGroup creates a new consensus group and joins it. The initial membership of this
 // group is determined by the InitialState method of the group's Storage object.
 func (m *MultiRaft) CreateGroup(groupID uint64) error {
@@ -284,7 +334,16 @@ type removeGroupOp struct {
 type node struct {
 	nodeID   NodeID
 	refCount int
+	groupIDs map[uint64]struct{}
 	client   *asyncClient
+}
+
+func (n *node) registerGroup(groupID uint64) {
+	n.groupIDs[groupID] = struct{}{}
+}
+
+func (n *node) unregisterGroup(groupID uint64) {
+	delete(n.groupIDs, groupID)
 }
 
 // state represents the internal state of a MultiRaft object. All variables here
@@ -315,6 +374,8 @@ func (s *state) start() {
 	// way through the rest of the pipeline.
 	var readyGroups map[uint64]raft.Ready
 	var writingGroups map[uint64]raft.Ready
+	// Counts up to heartbeat interval and is then reset.
+	ticks := 0
 	for {
 		// raftReady signals that the Raft state machine has pending
 		// work. That work is supplied over the raftReady channel as a map
@@ -346,13 +407,28 @@ func (s *state) start() {
 			return
 
 		case req := <-s.reqChan:
+			_, groupOK := s.groups[req.GroupID]
+			_, nodeOK := s.nodes[req.Message.From]
+			groupOK = groupOK || req.Message.Type == raftpb.MsgHeartbeat
+			if !groupOK || !nodeOK || req.Message.To != s.nodeID {
+				log.V(4).Infof("node %v: discarding ill-addressed message %s", s.nodeID, req.GroupID,
+					raft.DescribeMessage(req.Message, s.EntryFormatter))
+				break
+			}
 			log.V(5).Infof("node %v: group %v got message %s", s.nodeID, req.GroupID,
 				raft.DescribeMessage(req.Message, s.EntryFormatter))
-			if err := s.multiNode.Step(context.Background(), req.GroupID, req.Message); err != nil {
-				log.Warningf("node %v: multinode step failed for message %s", s.nodeID, req.GroupID,
-					raft.DescribeMessage(req.Message, s.EntryFormatter))
-			}
 
+			switch req.Message.Type {
+			case raftpb.MsgHeartbeat:
+				s.fanoutHeartbeat(req)
+			case raftpb.MsgHeartbeatResp:
+				s.fanoutHeartbeatResponse(req)
+			default:
+				if err := s.multiNode.Step(context.Background(), req.GroupID, req.Message); err != nil {
+					log.V(4).Infof("node %v: multinode step failed for message %s", s.nodeID, req.GroupID,
+						raft.DescribeMessage(req.Message, s.EntryFormatter))
+				}
+			}
 		case op := <-s.createGroupChan:
 			log.V(6).Infof("node %v: got op %#v", s.nodeID, op)
 			s.createGroup(op)
@@ -380,6 +456,33 @@ func (s *state) start() {
 		case <-s.Ticker.Chan():
 			log.V(8).Infof("node %v: got tick", s.nodeID)
 			s.multiNode.Tick()
+			ticks++
+			if ticks < s.HeartbeatIntervalTicks {
+				break
+			}
+			ticks = 0
+			// TODO(Tobias): We don't need to send heartbeats to nodes that have
+			// no group following one of our local groups. But that's unlikely
+			// to be the case for many of our nodes. It could make sense though
+			// to space out the heartbeats over the heartbeat interval so that
+			// we don't try to send for all nodes at once.
+			for nodeID, node := range s.nodes {
+				// Don't heartbeat yourself - it will abort elections and
+				// may efficiently prevent progress.
+				if nodeID == s.nodeID {
+					continue
+				}
+				log.V(6).Infof("node %v: triggering coalesced heartbeat to node %v", s.nodeID, nodeID)
+				msg := raftpb.Message{
+					From: s.nodeID,
+					To:   nodeID,
+					Type: raftpb.MsgHeartbeat,
+				}
+				node.client.raftMessage(&RaftMessageRequest{
+					GroupID: math.MaxUint64, // irrelevant
+					Message: msg,
+				})
+			}
 		}
 	}
 }
@@ -396,17 +499,33 @@ func (s *state) stop() {
 	s.stopper.SetStopped()
 }
 
-// addNode creates a node or increments the refcount on an existing node.
-func (s *state) addNode(nodeID NodeID) error {
-	if node, ok := s.nodes[nodeID]; ok {
-		node.refCount++
-		return nil
+// addNode creates a node and registers the given groupIDs for that
+// node. If the node already exists and possible some of the groups
+// are already registered, only the missing groups will be added in.
+func (s *state) addNode(nodeID uint64, groupIDs ...uint64) error {
+	for _, groupID := range groupIDs {
+		if _, ok := s.groups[groupID]; !ok {
+			return util.Errorf("can not add invalid group %d to node %d",
+				groupID, nodeID)
+		}
 	}
-	conn, err := s.Transport.Connect(nodeID)
-	if err != nil {
-		return err
+	newNode, ok := s.nodes[nodeID]
+	if !ok {
+		conn, err := s.Transport.Connect(nodeID)
+		if err != nil {
+			return err
+		}
+		s.nodes[nodeID] = &node{
+			nodeID:   nodeID,
+			refCount: 1,
+			groupIDs: make(map[uint64]struct{}),
+			client:   &asyncClient{nodeID, conn},
+		}
+		newNode = s.nodes[nodeID]
 	}
-	s.nodes[nodeID] = &node{nodeID, 1, &asyncClient{nodeID, conn}}
+	for _, groupID := range groupIDs {
+		newNode.registerGroup(groupID)
+	}
 	return nil
 }
 
@@ -431,11 +550,23 @@ func (s *state) createGroup(op *createGroupOp) {
 		pending: map[string]*proposal{},
 	}
 
+	for _, nodeID := range state.ConfState.Nodes {
+		s.addNode(nodeID, op.groupID)
+	}
+
 	op.ch <- nil
 }
 
 func (s *state) removeGroup(op *removeGroupOp) {
 	s.multiNode.RemoveGroup(op.groupID)
+	gs := s.Storage.GroupStorage(op.groupID)
+	state, err := gs.InitialState()
+	if err != nil {
+		op.ch <- err
+	}
+	for _, nodeID := range state.ConfState.Nodes {
+		s.nodes[nodeID].unregisterGroup(op.groupID)
+	}
 	delete(s.groups, op.groupID)
 	op.ch <- nil
 }
@@ -546,8 +677,15 @@ func (s *state) handleWriteResponse(response *writeResponse, readyGroups map[uin
 				}
 				log.V(3).Infof("node %v applying configuration change %v", s.nodeID, cc)
 				// TODO(bdarnell): dedupe by keeping a record of recently-applied commandIDs
-				// TODO(bdarnell): support removing nodes; fix double-application of initial entries
-				err = s.addNode(NodeID(cc.NodeID))
+				switch cc.Type {
+				case raftpb.ConfChangeAddNode:
+					err = s.addNode(NodeID(cc.NodeID))
+				case raftpb.ConfChangeRemoveNode:
+					// TODO(bdarnell): support removing nodes; fix double-application of initial entries
+					continue
+				case raftpb.ConfChangeUpdateNode:
+					continue
+				}
 				if err != nil {
 					log.Errorf("error applying configuration change %v: %s", cc, err)
 				}
@@ -567,7 +705,23 @@ func (s *state) handleWriteResponse(response *writeResponse, readyGroups map[uin
 				delete(g.pending, commandID)
 			}
 		}
+
+		noMoreHeartbeats := make(map[uint64]struct{})
 		for _, msg := range ready.Messages {
+			switch msg.Type {
+			case raftpb.MsgHeartbeat:
+				log.V(7).Infof("node %v dropped individual heartbeat to node %v",
+					s.nodeID, msg.To)
+				continue
+			case raftpb.MsgHeartbeatResp:
+				if _, ok := noMoreHeartbeats[msg.To]; ok {
+					log.V(7).Infof("node %v dropped redundant heartbeat response to node %v",
+						s.nodeID, msg.To)
+					continue
+				}
+				noMoreHeartbeats[msg.To] = struct{}{}
+			}
+
 			log.V(6).Infof("node %v sending message %s to %v", s.nodeID,
 				raft.DescribeMessage(msg, s.EntryFormatter), msg.To)
 			s.nodes[NodeID(msg.To)].client.raftMessage(&RaftMessageRequest{groupID, msg})

--- a/multiraft/multiraft_test.go
+++ b/multiraft/multiraft_test.go
@@ -40,13 +40,15 @@ type testCluster struct {
 	tickers   []*manualTicker
 	events    []*eventDemux
 	storages  []*BlockableStorage
-	transport *localRPCTransport
+	transport Transport
 }
 
-func newTestCluster(size int, t *testing.T) *testCluster {
-	transport := NewLocalRPCTransport()
+func newTestCluster(transport Transport, size int, t *testing.T) *testCluster {
+	if transport == nil {
+		transport = NewLocalRPCTransport()
+	}
 	cluster := &testCluster{t: t}
-	cluster.transport = transport.(*localRPCTransport)
+	cluster.transport = transport
 	for i := 0; i < size; i++ {
 		ticker := newManualTicker()
 		storage := &BlockableStorage{storage: NewMemoryStorage()}
@@ -71,6 +73,7 @@ func newTestCluster(size int, t *testing.T) *testCluster {
 		cluster.events = append(cluster.events, demux)
 		cluster.storages = append(cluster.storages, storage)
 	}
+	cluster.start()
 	return cluster
 }
 
@@ -90,14 +93,15 @@ func (c *testCluster) stop() {
 	}
 }
 
-// createGroup replicates a group among the first numReplicas nodes in the cluster
-func (c *testCluster) createGroup(groupID uint64, numReplicas int) {
+// createGroup replicates a group consisting of numReplicas members,
+// the first being the node at index firstNode.
+func (c *testCluster) createGroup(groupID uint64, firstNode, numReplicas int) {
 	var replicaIDs []uint64
 	for i := 0; i < numReplicas; i++ {
-		replicaIDs = append(replicaIDs, uint64(c.nodes[i].nodeID))
+		replicaIDs = append(replicaIDs, uint64(c.nodes[firstNode+i].nodeID))
 	}
 	for i := 0; i < numReplicas; i++ {
-		gs := c.storages[i].GroupStorage(groupID)
+		gs := c.storages[firstNode+i].GroupStorage(groupID)
 		memStorage := gs.(*blockableGroupStorage).s.(*raft.MemoryStorage)
 		memStorage.SetHardState(raftpb.HardState{
 			Commit: 10,
@@ -113,7 +117,7 @@ func (c *testCluster) createGroup(groupID uint64, numReplicas int) {
 			},
 		})
 
-		node := c.nodes[i]
+		node := c.nodes[firstNode+i]
 		err := node.CreateGroup(groupID)
 		if err != nil {
 			c.t.Fatal(err)
@@ -141,10 +145,9 @@ func TestInitialLeaderElection(t *testing.T) {
 	// The node that requests an election first should win.
 	for leaderIndex := 0; leaderIndex < 3; leaderIndex++ {
 		log.Infof("testing leader election for node %v", leaderIndex)
-		cluster := newTestCluster(3, t)
-		cluster.start()
+		cluster := newTestCluster(nil, 3, t)
 		groupID := uint64(1)
-		cluster.createGroup(groupID, 3)
+		cluster.createGroup(groupID, 0, 3)
 
 		event := cluster.waitForElection(leaderIndex)
 		if event.GroupID != groupID {
@@ -161,11 +164,10 @@ func TestInitialLeaderElection(t *testing.T) {
 func TestLeaderElectionEvent(t *testing.T) {
 	// Leader election events are fired when the leader commits an entry, not when it
 	// issues a call for votes.
-	cluster := newTestCluster(3, t)
-	cluster.start()
+	cluster := newTestCluster(nil, 3, t)
 	defer cluster.stop()
 	groupID := uint64(1)
-	cluster.createGroup(groupID, 3)
+	cluster.createGroup(groupID, 0, 3)
 
 	// Send a Ready with a new leader but no new commits.
 	// This happens while an election is in progress.
@@ -213,11 +215,10 @@ func TestLeaderElectionEvent(t *testing.T) {
 }
 
 func TestCommand(t *testing.T) {
-	cluster := newTestCluster(3, t)
-	cluster.start()
+	cluster := newTestCluster(nil, 3, t)
 	defer cluster.stop()
 	groupID := uint64(1)
-	cluster.createGroup(groupID, 3)
+	cluster.createGroup(groupID, 0, 3)
 	cluster.waitForElection(0)
 
 	// Submit a command to the leader
@@ -234,11 +235,10 @@ func TestCommand(t *testing.T) {
 }
 
 func TestSlowStorage(t *testing.T) {
-	cluster := newTestCluster(3, t)
-	cluster.start()
+	cluster := newTestCluster(nil, 3, t)
 	defer cluster.stop()
 	groupID := uint64(1)
-	cluster.createGroup(groupID, 3)
+	cluster.createGroup(groupID, 0, 3)
 
 	cluster.waitForElection(0)
 
@@ -280,13 +280,12 @@ func TestSlowStorage(t *testing.T) {
 
 func TestMembershipChange(t *testing.T) {
 	t.Skip("TODO(bdarnell): arrange for createGroup to be called on joining nodes")
-	cluster := newTestCluster(4, t)
-	cluster.start()
+	cluster := newTestCluster(nil, 4, t)
 	defer cluster.stop()
 
 	// Create a group with a single member, cluster.nodes[0].
 	groupID := uint64(1)
-	cluster.createGroup(groupID, 1)
+	cluster.createGroup(groupID, 0, 1)
 	cluster.waitForElection(0)
 
 	// Add each of the other three nodes to the cluster.

--- a/multiraft/multiraft_test.go
+++ b/multiraft/multiraft_test.go
@@ -28,10 +28,10 @@ import (
 	"github.com/coreos/etcd/raft/raftpb"
 )
 
-var rand = util.NewPseudoRand()
+var testRand = util.NewPseudoRand()
 
 func makeCommandID() string {
-	return util.RandString(rand, commandIDLen)
+	return util.RandString(testRand, commandIDLen)
 }
 
 type testCluster struct {

--- a/multiraft/transport_test.go
+++ b/multiraft/transport_test.go
@@ -1,0 +1,108 @@
+// Copyright 2014 The Cockroach Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+// implied. See the License for the specific language governing
+// permissions and limitations under the License. See the AUTHORS file
+// for names of contributors.
+//
+// Author: Tobias Schottdorf (tobias.schottdorf@gmail.com)
+
+package multiraft
+
+import (
+	"net/rpc"
+	"sync"
+
+	"github.com/cockroachdb/cockroach/util"
+)
+
+type localInterceptableTransport struct {
+	mu        sync.Mutex
+	listeners map[NodeID]ServerInterface
+	messages  chan *RaftMessageRequest
+	Events    chan *interceptMessage
+}
+
+// NewLocalInterceptableTransport creates a Transport for local testing use.
+// MultiRaft instances sharing the same instance of this Transport can find and
+// communicate with each other by ID. Messages are transmitted in the order in
+// which they are queued, intercepted and blocked until acknowledged.
+func NewLocalInterceptableTransport() Transport {
+	lt := &localInterceptableTransport{
+		listeners: make(map[NodeID]ServerInterface),
+		messages:  make(chan *RaftMessageRequest),
+		Events:    make(chan *interceptMessage),
+	}
+	go lt.start()
+	return lt
+}
+
+func (lt *localInterceptableTransport) start() {
+	for msg := range lt.messages {
+		ack := make(chan struct{})
+		iMsg := &interceptMessage{
+			args: msg,
+			ack:  ack,
+		}
+		lt.Events <- iMsg
+		<-ack
+		lt.mu.Lock()
+		srv, ok := lt.listeners[NodeID(msg.Message.To)]
+		lt.mu.Unlock()
+		if !ok {
+			continue
+		}
+		srv.RaftMessage(msg, nil)
+	}
+}
+
+func (lt *localInterceptableTransport) Listen(id NodeID, server ServerInterface) error {
+	lt.mu.Lock()
+	defer lt.mu.Unlock()
+	lt.listeners[id] = server
+	return nil
+}
+
+func (lt *localInterceptableTransport) Stop(id NodeID) {
+	lt.mu.Lock()
+	delete(lt.listeners, id)
+	lt.mu.Unlock()
+}
+
+func (lt *localInterceptableTransport) Connect(id NodeID) (ClientInterface, error) {
+	lt.mu.Lock()
+	defer lt.mu.Unlock()
+	_, ok := lt.listeners[id]
+	if !ok {
+		return nil, util.Errorf("unknown peer: %d", id)
+	}
+	return lt, nil
+}
+
+// an interceptMessage is sent by an interceptableClient when a message is to
+// be sent.
+type interceptMessage struct {
+	args interface{}
+	ack  chan<- struct{}
+}
+
+// Go implements ClientInterface.
+func (lt *localInterceptableTransport) Go(serviceMethod string, args interface{}, reply interface{}, done chan *rpc.Call) *rpc.Call {
+	lt.messages <- args.(*RaftMessageRequest)
+	if done != nil {
+		close(done)
+	}
+	return nil
+}
+
+func (lt *localInterceptableTransport) Close() error {
+	return nil
+}

--- a/storage/range_test.go
+++ b/storage/range_test.go
@@ -871,7 +871,7 @@ func TestRangeIdempotence(t *testing.T) {
 		select {
 		case <-done:
 			// Success.
-		case <-time.After(1000 * time.Millisecond):
+		case <-time.After(2000 * time.Millisecond):
 			t.Fatal("had to wait for increment to complete")
 		}
 	}

--- a/storage/store.go
+++ b/storage/store.go
@@ -247,8 +247,7 @@ type Store struct {
 	raft        raftInterface
 	closer      chan struct{}
 
-	mu sync.RWMutex // Protects variables below...
-	// TODO(Tobias) change int64 to uint64?
+	mu          sync.RWMutex     // Protects variables below...
 	ranges      map[int64]*Range // Map of ranges by Raft ID
 	rangesByKey RangeSlice       // Sorted slice of ranges by StartKey
 }


### PR DESCRIPTION
currently work in progress, see #229 for early discussions (further discussions should be held here).
- [x] basic prototype
- [x] keep group memberships on a per-node basis
- [x] receive heartbeats only from (supposed leader)
- [x] analogous mechanism for heartbeat responses
- [x] basic test setup
- [x] test w/ invalid heartbeats (no leader)
- [x] test w/ multiple partially-overlapping consensus groups
- [ ] consider correctness implications/corner cases (discussion below)

closes #229

cc @cockroachdb/developers 
