### PR TITLE
Implementation of GC-able bytes age stat.

### DIFF
--- a/storage/engine/keys.go
+++ b/storage/engine/keys.go
@@ -265,12 +265,16 @@ var (
 	StatIntentCount = proto.Key("intent-count")
 	// StatIntentAge counts the total age of unresolved intents.
 	StatIntentAge = proto.Key("intent-age")
-	// StatIntentLastUpdateNanos counts nanoseconds since the unix epoch
-	// for the last update to the intent age. This really is tracking
-	// the wall time as at last update, but is a merged stat, with
-	// successive counts of elapsed nanos being added at each stat
-	// computation.
-	StatIntentLastUpdateNanos = proto.Key("intent-nanos")
+	// StatGCBytes counts the gc'able bytes.
+	StatGCBytes = proto.Key("gc-bytes")
+	// StatGCBytesAge counts the total age of gc'able bytes.
+	StatGCBytesAge = proto.Key("gc-age")
+	// StatLastUpdateNanos counts nanoseconds since the unix epoch for
+	// the last update to the intent / GC'able bytes ages. This really
+	// is tracking the wall time as at last update, but is a merged
+	// stat, with successive counts of elapsed nanos being added at each
+	// stat computation.
+	StatLastUpdateNanos = proto.Key("update-nanos")
 )
 
 // Constants for system-reserved keys in the KV map.

--- a/storage/engine/keys.go
+++ b/storage/engine/keys.go
@@ -265,8 +265,6 @@ var (
 	StatIntentCount = proto.Key("intent-count")
 	// StatIntentAge counts the total age of unresolved intents.
 	StatIntentAge = proto.Key("intent-age")
-	// StatGCBytes counts the gc'able bytes.
-	StatGCBytes = proto.Key("gc-bytes")
 	// StatGCBytesAge counts the total age of gc'able bytes.
 	StatGCBytesAge = proto.Key("gc-age")
 	// StatLastUpdateNanos counts nanoseconds since the unix epoch for

--- a/storage/range.go
+++ b/storage/range.go
@@ -650,13 +650,7 @@ func (r *Range) ShouldSplit() bool {
 	zone := prefixConfig.Config.(*proto.ZoneConfig)
 
 	// Fetch the current size of this range in total bytes.
-	rangeSize, err := r.stats.GetSize(r.rm.Engine())
-	if err != nil {
-		log.Errorf("unable to compute size from stats for range %d: %s", r.Desc.RaftID, err)
-		return false
-	}
-
-	return rangeSize > zone.RangeMaxBytes
+	return r.stats.GetSize() > zone.RangeMaxBytes
 }
 
 // maybeSplit initiates an asynchronous split via AdminSplit request

--- a/storage/range_test.go
+++ b/storage/range_test.go
@@ -1404,11 +1404,11 @@ func TestInternalPushTxnPushTimestampAlreadyPushed(t *testing.T) {
 }
 
 func verifyRangeStats(eng engine.Engine, raftID int64, expMS engine.MVCCStats, t *testing.T) {
-	ms, err := engine.MVCCGetRangeStats(eng, raftID)
-	if err != nil {
+	var ms engine.MVCCStats
+	if err := engine.MVCCGetRangeStats(eng, raftID, &ms); err != nil {
 		t.Fatal(err)
 	}
-	if !reflect.DeepEqual(expMS, *ms) {
+	if !reflect.DeepEqual(expMS, ms) {
 		t.Errorf("expected stats %+v; got %+v", expMS, ms)
 	}
 	// Also verify the GetRangeSize method.

--- a/storage/stats.go
+++ b/storage/stats.go
@@ -56,7 +56,7 @@ func (rs *rangeStats) MergeMVCCStats(e engine.Engine, ms *engine.MVCCStats, nowN
 	diffSeconds := nowNanos/1E9 - rs.LastUpdateNanos/1E9
 	ms.LastUpdateNanos = nowNanos - rs.LastUpdateNanos
 	ms.IntentAge += rs.IntentCount * diffSeconds
-	ms.GCBytesAge += (rs.KeyBytes + rs.ValBytes - rs.LiveBytes) * diffSeconds
+	ms.GCBytesAge += engine.MVCCComputeGCBytesAge(rs.KeyBytes+rs.ValBytes-rs.LiveBytes, diffSeconds)
 	ms.MergeStats(e, rs.raftID)
 }
 

--- a/storage/stats_test.go
+++ b/storage/stats_test.go
@@ -47,8 +47,8 @@ func TestRangeStatsInit(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if !reflect.DeepEqual(ms, s.cached) {
-		t.Errorf("mvcc stats mismatch %+v != %+v", ms, s.cached)
+	if !reflect.DeepEqual(ms, s.MVCCStats) {
+		t.Errorf("mvcc stats mismatch %+v != %+v", ms, s.MVCCStats)
 	}
 }
 
@@ -113,7 +113,7 @@ func TestRangeStatsMerge(t *testing.T) {
 	if !reflect.DeepEqual(ms, expMS) {
 		t.Errorf("expected %+v; got %+v", expMS, ms)
 	}
-	if !reflect.DeepEqual(tc.rng.stats.cached, expMS) {
-		t.Errorf("expected %+v; got %+v", expMS, tc.rng.stats.cached)
+	if !reflect.DeepEqual(tc.rng.stats.MVCCStats, expMS) {
+		t.Errorf("expected %+v; got %+v", expMS, tc.rng.stats.MVCCStats)
 	}
 }

--- a/storage/stats_test.go
+++ b/storage/stats_test.go
@@ -24,6 +24,17 @@ import (
 	"github.com/cockroachdb/cockroach/storage/engine"
 )
 
+func TestRangeStatsEmpty(t *testing.T) {
+	tc := testContext{}
+	tc.Start(t)
+	defer tc.Stop()
+
+	s := tc.rng.stats
+	if !reflect.DeepEqual(s.MVCCStats, engine.MVCCStats{}) {
+		t.Errorf("expected empty stats; got %+v", s.MVCCStats)
+	}
+}
+
 func TestRangeStatsInit(t *testing.T) {
 	tc := testContext{}
 	tc.Start(t)


### PR DESCRIPTION
This stat measures the total age of gc'able bytes. That is, the sum of
every byte \* its age in seconds. This stat will be used to prioritize
garbage collection of ranges.
