### PR TITLE
Add "make gopath" build target.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -26,7 +26,7 @@ GOFLAGS :=
 STATIC := $(STATIC)
 
 RUN  := run
-GOPATH  := $(CURDIR)/_vendor:$(GOPATH)
+GOPATH  := $(CURDIR)/_vendor:$(CURDIR)/../../../..
 # Exposes protoc.
 PATH := $(CURDIR)/_vendor/usr/bin:$(PATH)
 # Expose protobuf.
@@ -123,3 +123,9 @@ clean:
 	make -C $(ROACH_PROTO) clean
 	make -C $(ROACH_LIB) clean
 	make -C $(SQL_PARSER) clean
+
+# The gopath target outputs the GOPATH that should be used for building this
+# package. It is used by the emacs go-projectile package for automatic
+# configuration.
+gopath:
+	@echo -n $(GOPATH)


### PR DESCRIPTION
Define GOPATH relative to the Makefile's location instead of relying
on an inherited GOPATH.

These two changes are motivated by compatibility with the emacs
go-projectile package, which uses "make gopath" to auto-configure a
bundle of go tools.

@spencerkimball @cockroachdb/developers 
