### PR TITLE
rest ui: use default value instead of confusing placeholder

### DIFF
--- a/ui/js/controllers/rest_explorer.js
+++ b/ui/js/controllers/rest_explorer.js
@@ -18,6 +18,7 @@
 var crApp = angular.module('cockroach');
 crApp.controller('RestExplorerCtrl', ['$scope', '$http',
     function(scope, http) {
+  scope.kvCounterVal = 0;
   scope.responseLog = [];
   scope.clearResponseLog = function(e) {
     scope.responseLog = [];

--- a/ui/templates/rest_explorer.html
+++ b/ui/templates/rest_explorer.html
@@ -45,7 +45,7 @@ Author: Andrew Bonventre (andybons@gmail.com)
       <form>
         <input type="text" ng-model="kvKey" ng-disabled="responsePending" placeholder="Key">
         &rarr;
-        <input type="number" ng-model="kvCounterVal" ng-disabled="responsePending" placeholder="0">
+        <input type="number" ng-model="kvCounterVal" ng-disabled="responsePending">
         <input type="button" ng-click="handleClick($event)" ng-disabled="responsePending" value="Get" data-endpoint="/kv/rest/counter/" data-method="GET">
         <input type="button" ng-click="handleClick($event)" ng-disabled="responsePending" value="Head" data-endpoint="/kv/rest/counter/" data-method="HEAD">
         <input type="button" ng-click="handleClick($event)" ng-disabled="responsePending" value="Post" data-endpoint="/kv/rest/counter/" data-method="POST">


### PR DESCRIPTION
Per #287, confusion could be caused by assuming that the input placeholder value ("0" in this cause) actually represents the value being passed, which isn’t true. Setting a default value to prevent this confusion in the future.
