### PR TITLE
Add _vendor to the end of GOPATH instead of the beginning.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -26,7 +26,7 @@ GOFLAGS :=
 STATIC := $(STATIC)
 
 RUN  := run
-GOPATH  := $(CURDIR)/_vendor:$(CURDIR)/../../../..
+GOPATH  := $(CURDIR)/../../../..:$(CURDIR)/_vendor
 # Exposes protoc.
 PATH := $(CURDIR)/_vendor/usr/bin:$(PATH)
 # Expose protobuf.

--- a/proto/Makefile
+++ b/proto/Makefile
@@ -27,6 +27,7 @@ LIBOBJECTS  := $(SOURCES:.cc=.o)
 CXXFLAGS += -Ilib
 
 PROTO_PATH := ../../../../:../../../../github.com/gogo/protobuf/protobuf:../../../../github.com/gogo/protobuf/gogoproto
+PROTOC_GEN_GOGO :=../../../../../bin/protoc-gen-gogo
 
 all: static_lib
 
@@ -37,7 +38,7 @@ $(PROTO_LIB): $(PROTO_GO) $(SOURCES) $(LIBOBJECTS)
 	ar -rsv $(PROTO_LIB) $(LIBOBJECTS)
 
 $(PROTO_GO): $(PROTOS)
-	protoc --gogo_out=. --cpp_out=lib --proto_path=.:$(PROTO_PATH) $(PROTOS)
+	protoc --plugin=protoc-gen-gogo=$(PROTOC_GEN_GOGO) --gogo_out=. --cpp_out=lib --proto_path=.:$(PROTO_PATH) $(PROTOS)
 
 $(SOURCES): $(GOGO_PROTOS)
 	protoc --cpp_out=lib --proto_path=$(PROTO_PATH) $(GOGO_PROTOS)


### PR DESCRIPTION
Pass an explicit path to protoc-gen-gogo.

Both of these changes are motivated by compatibility with the emacs go-projectile package and supporting an isolated per-project GOPATH.

@tschottdorf @cockroachdb/developers 
