### PR TITLE
Introduce type aliases for node and store IDs.

### DIFF
--- a/gossip/keys.go
+++ b/gossip/keys.go
@@ -17,7 +17,11 @@
 
 package gossip
 
-import "strconv"
+import (
+	"strconv"
+
+	"github.com/cockroachdb/cockroach/proto"
+)
 
 // Constants for gossip keys.
 const (
@@ -63,6 +67,6 @@ const (
 )
 
 // MakeNodeIDGossipKey returns the gossip key for node ID info.
-func MakeNodeIDGossipKey(nodeID int32) string {
+func MakeNodeIDGossipKey(nodeID proto.NodeID) string {
 	return KeyNodeIDPrefix + strconv.FormatInt(int64(nodeID), 16)
 }

--- a/kv/dist_sender.go
+++ b/kv/dist_sender.go
@@ -154,7 +154,7 @@ func (ds *DistSender) verifyPermissions(method string, header *proto.RequestHead
 
 // nodeIDToAddr uses the gossip network to translate from node ID
 // to a host:port address pair.
-func (ds *DistSender) nodeIDToAddr(nodeID int32) (net.Addr, error) {
+func (ds *DistSender) nodeIDToAddr(nodeID proto.NodeID) (net.Addr, error) {
 	nodeIDKey := gossip.MakeNodeIDGossipKey(nodeID)
 	info, err := ds.gossip.GetInfo(nodeIDKey)
 	if info == nil || err != nil {

--- a/kv/local_sender.go
+++ b/kv/local_sender.go
@@ -29,14 +29,14 @@ import (
 
 // A LocalSender provides methods to access a collection of local stores.
 type LocalSender struct {
-	mu       sync.RWMutex             // Protects storeMap and addrs
-	storeMap map[int32]*storage.Store // Map from StoreID to Store
+	mu       sync.RWMutex                     // Protects storeMap and addrs
+	storeMap map[proto.StoreID]*storage.Store // Map from StoreID to Store
 }
 
 // NewLocalSender returns a local-only sender which directly accesses
 // a collection of stores.
 func NewLocalSender() *LocalSender {
-	return &LocalSender{storeMap: map[int32]*storage.Store{}}
+	return &LocalSender{storeMap: map[proto.StoreID]*storage.Store{}}
 }
 
 // GetStoreCount returns the number of stores this node is exporting.
@@ -47,7 +47,7 @@ func (ls *LocalSender) GetStoreCount() int {
 }
 
 // HasStore returns true if the specified store is owned by this LocalSender.
-func (ls *LocalSender) HasStore(storeID int32) bool {
+func (ls *LocalSender) HasStore(storeID proto.StoreID) bool {
 	ls.mu.RLock()
 	defer ls.mu.RUnlock()
 	_, ok := ls.storeMap[storeID]
@@ -56,7 +56,7 @@ func (ls *LocalSender) HasStore(storeID int32) bool {
 
 // GetStore looks up the store by store ID. Returns an error
 // if not found.
-func (ls *LocalSender) GetStore(storeID int32) (*storage.Store, error) {
+func (ls *LocalSender) GetStore(storeID proto.StoreID) (*storage.Store, error) {
 	ls.mu.RLock()
 	store, ok := ls.storeMap[storeID]
 	ls.mu.RUnlock()

--- a/kv/local_sender_test.go
+++ b/kv/local_sender_test.go
@@ -48,7 +48,7 @@ func TesLocalSendertGetStoreCount(t *testing.T) {
 
 	expectedCount := 10
 	for i := 0; i < expectedCount; i++ {
-		ls.AddStore(&storage.Store{Ident: proto.StoreIdent{StoreID: int32(i)}})
+		ls.AddStore(&storage.Store{Ident: proto.StoreIdent{StoreID: proto.StoreID(i)}})
 	}
 	if count := ls.GetStoreCount(); count != expectedCount {
 		t.Errorf("expected store count to be %d but was %d", expectedCount, count)
@@ -59,7 +59,7 @@ func TestLocalSenderVisitStores(t *testing.T) {
 	ls := NewLocalSender()
 	numStores := 10
 	for i := 0; i < numStores; i++ {
-		ls.AddStore(&storage.Store{Ident: proto.StoreIdent{StoreID: int32(i)}})
+		ls.AddStore(&storage.Store{Ident: proto.StoreIdent{StoreID: proto.StoreID(i)}})
 	}
 
 	visit := make([]bool, numStores)
@@ -147,7 +147,7 @@ func TestLocalSenderLookupReplica(t *testing.T) {
 	var e [2]engine.Engine
 	var s [2]*storage.Store
 	ranges := []struct {
-		storeID    int32
+		storeID    proto.StoreID
 		start, end proto.Key
 	}{
 		{2, proto.Key("a"), proto.Key("c")},

--- a/kv/txn_coord_sender_test.go
+++ b/kv/txn_coord_sender_test.go
@@ -583,7 +583,7 @@ func TestTxnCoordSenderTxnUpdatedOnError(t *testing.T) {
 			t.Errorf("%d: expected orig timestamp to be %s + 1; got %s",
 				i, test.expOrigTS, reply.Txn.OrigTimestamp)
 		}
-		if nodes := reply.Txn.CertainNodes.GetNodes(); (len(nodes) != 0) != test.nodeSeen {
+		if nodes := reply.Txn.CertainNodes.Nodes; (len(nodes) != 0) != test.nodeSeen {
 			t.Errorf("%d: expected nodeSeen=%t, but list of hosts is %v",
 				i, test.nodeSeen, nodes)
 		}

--- a/multiraft/events.go
+++ b/multiraft/events.go
@@ -23,7 +23,7 @@ import "github.com/cockroachdb/cockroach/util/log"
 // an election. NodeID is zero when an election is in progress.
 type EventLeaderElection struct {
 	GroupID uint64
-	NodeID  uint64
+	NodeID  NodeID
 	Term    uint64
 }
 

--- a/multiraft/multiraft_test.go
+++ b/multiraft/multiraft_test.go
@@ -57,7 +57,7 @@ func newTestCluster(size int, t *testing.T) *testCluster {
 			TickInterval:           time.Millisecond,
 			Strict:                 true,
 		}
-		mr, err := NewMultiRaft(uint64(i+1), config)
+		mr, err := NewMultiRaft(NodeID(i+1), config)
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -89,7 +89,7 @@ func (c *testCluster) stop() {
 func (c *testCluster) createGroup(groupID uint64, numReplicas int) {
 	var replicaIDs []uint64
 	for i := 0; i < numReplicas; i++ {
-		replicaIDs = append(replicaIDs, c.nodes[i].nodeID)
+		replicaIDs = append(replicaIDs, uint64(c.nodes[i].nodeID))
 	}
 	for i := 0; i < numReplicas; i++ {
 		gs := c.storages[i].GroupStorage(groupID)

--- a/proto/config.go
+++ b/proto/config.go
@@ -23,7 +23,46 @@ import (
 	"fmt"
 	"sort"
 	"strings"
+
+	"github.com/cockroachdb/cockroach/util"
+	"github.com/gogo/protobuf/proto"
 )
+
+// NodeID is a custom type for a cockroach node ID. (not a raft node ID)
+type NodeID int32
+
+// Marshal implements the gogoproto Marshaler interface.
+func (n NodeID) Marshal() ([]byte, error) {
+	return proto.EncodeVarint(uint64(n)), nil
+}
+
+// Unmarshal implements the gogoproto Unmarshaler interface.
+func (n *NodeID) Unmarshal(bytes []byte) error {
+	x, length := proto.DecodeVarint(bytes)
+	if length != len(bytes) {
+		return util.Errorf("invalid varint")
+	}
+	*n = NodeID(x)
+	return nil
+}
+
+// StoreID is a custom type for a cockroach store ID.
+type StoreID int32
+
+// Marshal implements the gogoproto Marshaler interface.
+func (n StoreID) Marshal() ([]byte, error) {
+	return proto.EncodeVarint(uint64(n)), nil
+}
+
+// Unmarshal implements the gogoproto Unmarshaler interface.
+func (n *StoreID) Unmarshal(bytes []byte) error {
+	x, length := proto.DecodeVarint(bytes)
+	if length != len(bytes) {
+		return util.Errorf("invalid varint")
+	}
+	*n = StoreID(x)
+	return nil
+}
 
 // IsSubset returns whether attributes list a is a subset of
 // attributes list b.
@@ -74,7 +113,7 @@ func (r *RangeDescriptor) ContainsKeyRange(start, end []byte) bool {
 
 // FindReplica returns the replica which matches the specified store
 // ID. Panic in the event that no replica matches.
-func (r *RangeDescriptor) FindReplica(storeID int32) *Replica {
+func (r *RangeDescriptor) FindReplica(storeID StoreID) *Replica {
 	for i := range r.Replicas {
 		if r.Replicas[i].StoreID == storeID {
 			return &r.Replicas[i]

--- a/proto/config.proto
+++ b/proto/config.proto
@@ -30,8 +30,10 @@ message Attributes {
 // device) and associated attributes. Replicas are stored in Range
 // lookup records (meta1, meta2).
 message Replica {
-  optional int32 node_id = 1 [(gogoproto.nullable) = false, (gogoproto.customname) = "NodeID"];
-  optional int32 store_id = 2 [(gogoproto.nullable) = false, (gogoproto.customname) = "StoreID"];
+  optional int32 node_id = 1 [(gogoproto.nullable) = false,
+      (gogoproto.customname) = "NodeID", (gogoproto.customtype) = "NodeID"];
+  optional int32 store_id = 2 [(gogoproto.nullable) = false,
+      (gogoproto.customname) = "StoreID", (gogoproto.customtype) = "StoreID"];
   // Combination of node & store attributes.
   optional Attributes attrs = 3 [(gogoproto.nullable) = false];
 }

--- a/proto/data.go
+++ b/proto/data.go
@@ -491,18 +491,18 @@ func NewScanMetadata(nowNanos int64) *ScanMetadata {
 
 // Add adds the given NodeID to the interface (unless already present)
 // and restores ordering.
-func (s *NodeList) Add(nodeID int32) {
+func (s *NodeList) Add(nodeID NodeID) {
 	if !s.Contains(nodeID) {
-		(*s).Nodes = append(s.Nodes, nodeID)
+		(*s).Nodes = append(s.Nodes, int32(nodeID))
 		sort.Sort(Int32Slice(s.Nodes))
 	}
 }
 
 // Contains returns true if the underlying slice contains the given NodeID.
-func (s NodeList) Contains(nodeID int32) bool {
-	ns := s.GetNodes()
-	i := sort.Search(len(ns), func(i int) bool { return ns[i] >= nodeID })
-	return i < len(ns) && ns[i] == nodeID
+func (s NodeList) Contains(nodeID NodeID) bool {
+	ns := s.Nodes
+	i := sort.Search(len(ns), func(i int) bool { return NodeID(ns[i]) >= nodeID })
+	return i < len(ns) && NodeID(ns[i]) == nodeID
 }
 
 // Int32Slice implements sort.Interface.

--- a/proto/data.proto
+++ b/proto/data.proto
@@ -90,8 +90,10 @@ message RawKeyValue {
 // store-reserved system key (KeyLocalIdent).
 message StoreIdent {
   optional string cluster_id = 1 [(gogoproto.nullable) = false, (gogoproto.customname) = "ClusterID"];
-  optional int32 node_id = 2 [(gogoproto.nullable) = false, (gogoproto.customname) = "NodeID"];
-  optional int32 store_id = 3 [(gogoproto.nullable) = false, (gogoproto.customname) = "StoreID"];
+  optional int32 node_id = 2 [(gogoproto.nullable) = false,
+      (gogoproto.customname) = "NodeID", (gogoproto.customtype) = "NodeID"];
+  optional int32 store_id = 3 [(gogoproto.nullable) = false,
+      (gogoproto.customname) = "StoreID", (gogoproto.customtype) = "StoreID"];
 }
 
 // A SplitTrigger is run after a successful commit of an AdminSplit
@@ -146,6 +148,8 @@ enum TransactionStatus {
 // NodeList keeps a growing set of NodeIDs as a sorted slice, with Add()
 // adding to the set and Contains() verifying membership.
 message NodeList {
+  // Note that this does not use the NodeID custom type because that appears
+  // to interact badly with the repeated and/or packed options.
   repeated int32 nodes = 1 [packed=true];
 }
 

--- a/proto/data_test.go
+++ b/proto/data_test.go
@@ -365,22 +365,22 @@ func TestNodeList(t *testing.T) {
 	sn := NodeList{}
 	items := append([]int{109, 104, 102, 108, 1000}, rand.Perm(100)...)
 	for i := range items {
-		n := int32(items[i])
+		n := NodeID(items[i])
 		if sn.Contains(n) {
 			t.Fatalf("%d: false positive hit for %d on slice %v",
-				i, n, sn.GetNodes())
+				i, n, sn.Nodes)
 		}
 		// Add this item and, for good measure, all the previous ones.
 		for j := i; j >= 0; j-- {
-			sn.Add(int32(items[j]))
+			sn.Add(NodeID(items[j]))
 		}
-		if nodes := sn.GetNodes(); len(nodes) != i+1 {
+		if nodes := sn.Nodes; len(nodes) != i+1 {
 			t.Fatalf("%d: missing values or duplicates: %v",
 				i, nodes)
 		}
 		if !sn.Contains(n) {
 			t.Fatalf("%d: false negative hit for %d on slice %v",
-				i, n, sn.GetNodes())
+				i, n, sn.Nodes)
 		}
 	}
 }

--- a/server/node.go
+++ b/server/node.go
@@ -69,7 +69,7 @@ type Node struct {
 
 // allocateNodeID increments the node id generator key to allocate
 // a new, unique node id.
-func allocateNodeID(db *client.KV) (int32, error) {
+func allocateNodeID(db *client.KV) (proto.NodeID, error) {
 	iReply := &proto.IncrementResponse{}
 	if err := db.Call(proto.Increment, &proto.IncrementRequest{
 		RequestHeader: proto.RequestHeader{
@@ -80,13 +80,13 @@ func allocateNodeID(db *client.KV) (int32, error) {
 	}, iReply); err != nil {
 		return 0, util.Errorf("unable to allocate node ID: %v", err)
 	}
-	return int32(iReply.NewValue), nil
+	return proto.NodeID(iReply.NewValue), nil
 }
 
 // allocateStoreIDs increments the store id generator key for the
 // specified node to allocate "inc" new, unique store ids. The
 // first ID in a contiguous range is returned on success.
-func allocateStoreIDs(nodeID int32, inc int64, db *client.KV) (int32, error) {
+func allocateStoreIDs(nodeID proto.NodeID, inc int64, db *client.KV) (proto.StoreID, error) {
 	iReply := &proto.IncrementResponse{}
 	if err := db.Call(proto.Increment, &proto.IncrementRequest{
 		RequestHeader: proto.RequestHeader{
@@ -97,7 +97,7 @@ func allocateStoreIDs(nodeID int32, inc int64, db *client.KV) (int32, error) {
 	}, iReply); err != nil {
 		return 0, util.Errorf("unable to allocate %d store IDs for node %d: %v", inc, nodeID, err)
 	}
-	return int32(iReply.NewValue - inc + 1), nil
+	return proto.StoreID(iReply.NewValue - inc + 1), nil
 }
 
 // BootstrapCluster bootstraps a store using the provided engine and

--- a/storage/allocator.go
+++ b/storage/allocator.go
@@ -43,7 +43,7 @@ type allocator struct {
 func (a *allocator) allocate(required proto.Attributes, existingReplicas []proto.Replica) (
 	*StoreDescriptor, error) {
 	// Get a set of current nodes -- we never want to allocate on an existing node.
-	usedNodes := make(map[int32]struct{})
+	usedNodes := make(map[proto.NodeID]struct{})
 	for _, replica := range existingReplicas {
 		usedNodes[replica.NodeID] = struct{}{}
 	}

--- a/storage/db_test.go
+++ b/storage/db_test.go
@@ -79,7 +79,7 @@ func createTestStoreWithEngine(t *testing.T, eng engine.Engine, clock *hlc.Clock
 
 // getArgs returns a GetRequest and GetResponse pair addressed to
 // the default replica for the specified key.
-func getArgs(key []byte, raftID int64, storeID int32) (*proto.GetRequest, *proto.GetResponse) {
+func getArgs(key []byte, raftID int64, storeID proto.StoreID) (*proto.GetRequest, *proto.GetResponse) {
 	args := &proto.GetRequest{
 		RequestHeader: proto.RequestHeader{
 			Key:     key,
@@ -93,7 +93,7 @@ func getArgs(key []byte, raftID int64, storeID int32) (*proto.GetRequest, *proto
 
 // putArgs returns a PutRequest and PutResponse pair addressed to
 // the default replica for the specified key / value.
-func putArgs(key, value []byte, raftID int64, storeID int32) (*proto.PutRequest, *proto.PutResponse) {
+func putArgs(key, value []byte, raftID int64, storeID proto.StoreID) (*proto.PutRequest, *proto.PutResponse) {
 	args := &proto.PutRequest{
 		RequestHeader: proto.RequestHeader{
 			Key:     key,
@@ -110,7 +110,7 @@ func putArgs(key, value []byte, raftID int64, storeID int32) (*proto.PutRequest,
 
 // incrementArgs returns an IncrementRequest and IncrementResponse pair
 // addressed to the default replica for the specified key / value.
-func incrementArgs(key []byte, inc int64, raftID int64, storeID int32) (*proto.IncrementRequest, *proto.IncrementResponse) {
+func incrementArgs(key []byte, inc int64, raftID int64, storeID proto.StoreID) (*proto.IncrementRequest, *proto.IncrementResponse) {
 	args := &proto.IncrementRequest{
 		RequestHeader: proto.RequestHeader{
 			Key:     key,

--- a/storage/range.go
+++ b/storage/range.go
@@ -139,7 +139,7 @@ type RangeManager interface {
 	DB() *client.KV
 	Engine() engine.Engine
 	Gossip() *gossip.Gossip
-	StoreID() int32
+	StoreID() proto.StoreID
 
 	// Range manipulation methods.
 	AddRange(rng *Range) error
@@ -1616,7 +1616,7 @@ func ReplicaSetsEqual(a, b []proto.Replica) bool {
 		return false
 	}
 
-	set := make(map[int32]int)
+	set := make(map[proto.StoreID]int)
 	for _, replica := range a {
 		set[replica.StoreID]++
 	}

--- a/storage/range_test.go
+++ b/storage/range_test.go
@@ -155,7 +155,7 @@ func newTransaction(name string, baseKey proto.Key, userPriority int32,
 // CreateReplicaSets creates new proto.Replica protos based on an array of integers
 // to aid in testing. Note that this does not actualy produce any actual replicas, it
 // just creates the proto.
-func createReplicaSets(replicaNumbers []int32) []proto.Replica {
+func createReplicaSets(replicaNumbers []proto.StoreID) []proto.Replica {
 	result := []proto.Replica{}
 	for _, replicaNumber := range replicaNumbers {
 		result = append(result, proto.Replica{
@@ -393,7 +393,7 @@ func (be *blockingEngine) NewBatch() engine.Engine {
 
 // getArgs returns a GetRequest and GetResponse pair addressed to
 // the default replica for the specified key.
-func getArgs(key []byte, raftID int64, storeID int32) (*proto.GetRequest, *proto.GetResponse) {
+func getArgs(key []byte, raftID int64, storeID proto.StoreID) (*proto.GetRequest, *proto.GetResponse) {
 	args := &proto.GetRequest{
 		RequestHeader: proto.RequestHeader{
 			Key:     key,
@@ -407,7 +407,7 @@ func getArgs(key []byte, raftID int64, storeID int32) (*proto.GetRequest, *proto
 
 // putArgs returns a PutRequest and PutResponse pair addressed to
 // the default replica for the specified key / value.
-func putArgs(key, value []byte, raftID int64, storeID int32) (*proto.PutRequest, *proto.PutResponse) {
+func putArgs(key, value []byte, raftID int64, storeID proto.StoreID) (*proto.PutRequest, *proto.PutResponse) {
 	args := &proto.PutRequest{
 		RequestHeader: proto.RequestHeader{
 			Key:       key,
@@ -424,7 +424,7 @@ func putArgs(key, value []byte, raftID int64, storeID int32) (*proto.PutRequest,
 }
 
 // deleteArgs returns a DeleteRequest and DeleteResponse pair.
-func deleteArgs(key proto.Key, raftID int64, storeID int32) (*proto.DeleteRequest, *proto.DeleteResponse) {
+func deleteArgs(key proto.Key, raftID int64, storeID proto.StoreID) (*proto.DeleteRequest, *proto.DeleteResponse) {
 	args := &proto.DeleteRequest{
 		RequestHeader: proto.RequestHeader{
 			Key:     key,
@@ -439,7 +439,7 @@ func deleteArgs(key proto.Key, raftID int64, storeID int32) (*proto.DeleteReques
 // readOrWriteArgs returns either get or put arguments depending on
 // value of "read". Get for true; Put for false. Returns method
 // selected and args & reply.
-func readOrWriteArgs(key proto.Key, read bool, raftID int64, storeID int32) (string, proto.Request, proto.Response) {
+func readOrWriteArgs(key proto.Key, read bool, raftID int64, storeID proto.StoreID) (string, proto.Request, proto.Response) {
 	if read {
 		gArgs, gReply := getArgs(key, raftID, storeID)
 		return proto.Get, gArgs, gReply
@@ -450,7 +450,7 @@ func readOrWriteArgs(key proto.Key, read bool, raftID int64, storeID int32) (str
 
 // incrementArgs returns an IncrementRequest and IncrementResponse pair
 // addressed to the default replica for the specified key / value.
-func incrementArgs(key []byte, inc int64, raftID int64, storeID int32) (*proto.IncrementRequest, *proto.IncrementResponse) {
+func incrementArgs(key []byte, inc int64, raftID int64, storeID proto.StoreID) (*proto.IncrementRequest, *proto.IncrementResponse) {
 	args := &proto.IncrementRequest{
 		RequestHeader: proto.RequestHeader{
 			Key:     key,
@@ -463,7 +463,7 @@ func incrementArgs(key []byte, inc int64, raftID int64, storeID int32) (*proto.I
 	return args, reply
 }
 
-func scanArgs(start, end []byte, raftID int64, storeID int32) (*proto.ScanRequest, *proto.ScanResponse) {
+func scanArgs(start, end []byte, raftID int64, storeID proto.StoreID) (*proto.ScanRequest, *proto.ScanResponse) {
 	args := &proto.ScanRequest{
 		RequestHeader: proto.RequestHeader{
 			Key:     start,
@@ -478,7 +478,7 @@ func scanArgs(start, end []byte, raftID int64, storeID int32) (*proto.ScanReques
 
 // endTxnArgs returns request/response pair for EndTransaction RPC
 // addressed to the default replica for the specified key.
-func endTxnArgs(txn *proto.Transaction, commit bool, raftID int64, storeID int32) (
+func endTxnArgs(txn *proto.Transaction, commit bool, raftID int64, storeID proto.StoreID) (
 	*proto.EndTransactionRequest, *proto.EndTransactionResponse) {
 	args := &proto.EndTransactionRequest{
 		RequestHeader: proto.RequestHeader{
@@ -495,7 +495,7 @@ func endTxnArgs(txn *proto.Transaction, commit bool, raftID int64, storeID int32
 
 // pushTxnArgs returns request/response pair for InternalPushTxn RPC
 // addressed to the default replica for the specified key.
-func pushTxnArgs(pusher, pushee *proto.Transaction, abort bool, raftID int64, storeID int32) (
+func pushTxnArgs(pusher, pushee *proto.Transaction, abort bool, raftID int64, storeID proto.StoreID) (
 	*proto.InternalPushTxnRequest, *proto.InternalPushTxnResponse) {
 	args := &proto.InternalPushTxnRequest{
 		RequestHeader: proto.RequestHeader{
@@ -513,7 +513,7 @@ func pushTxnArgs(pusher, pushee *proto.Transaction, abort bool, raftID int64, st
 }
 
 // heartbeatArgs returns request/response pair for InternalHeartbeatTxn RPC.
-func heartbeatArgs(txn *proto.Transaction, raftID int64, storeID int32) (
+func heartbeatArgs(txn *proto.Transaction, raftID int64, storeID proto.StoreID) (
 	*proto.InternalHeartbeatTxnRequest, *proto.InternalHeartbeatTxnResponse) {
 	args := &proto.InternalHeartbeatTxnRequest{
 		RequestHeader: proto.RequestHeader{
@@ -530,7 +530,7 @@ func heartbeatArgs(txn *proto.Transaction, raftID int64, storeID int32) (
 // internalMergeArgs returns a InternalMergeRequest and InternalMergeResponse
 // pair addressed to the default replica for the specified key. The request will
 // contain the given proto.Value.
-func internalMergeArgs(key []byte, value proto.Value, raftID int64, storeID int32) (
+func internalMergeArgs(key []byte, value proto.Value, raftID int64, storeID proto.StoreID) (
 	*proto.InternalMergeRequest, *proto.InternalMergeResponse) {
 	args := &proto.InternalMergeRequest{
 		RequestHeader: proto.RequestHeader{
@@ -544,7 +544,7 @@ func internalMergeArgs(key []byte, value proto.Value, raftID int64, storeID int3
 	return args, reply
 }
 
-func internalTruncateLogArgs(index uint64, raftID int64, storeID int32) (
+func internalTruncateLogArgs(index uint64, raftID int64, storeID proto.StoreID) (
 	*proto.InternalTruncateLogRequest, *proto.InternalTruncateLogResponse) {
 	args := &proto.InternalTruncateLogRequest{
 		RequestHeader: proto.RequestHeader{
@@ -1640,17 +1640,17 @@ func TestReplicaSetsEqual(t *testing.T) {
 		b        []proto.Replica
 	}{
 		{true, []proto.Replica{}, []proto.Replica{}},
-		{true, createReplicaSets([]int32{1}), createReplicaSets([]int32{1})},
-		{true, createReplicaSets([]int32{1, 2}), createReplicaSets([]int32{1, 2})},
-		{true, createReplicaSets([]int32{1, 2}), createReplicaSets([]int32{2, 1})},
-		{false, createReplicaSets([]int32{1}), createReplicaSets([]int32{2})},
-		{false, createReplicaSets([]int32{1, 2}), createReplicaSets([]int32{2})},
-		{false, createReplicaSets([]int32{1, 2}), createReplicaSets([]int32{1})},
-		{false, createReplicaSets([]int32{}), createReplicaSets([]int32{1})},
-		{true, createReplicaSets([]int32{1, 2, 3}), createReplicaSets([]int32{2, 3, 1})},
-		{true, createReplicaSets([]int32{1, 1}), createReplicaSets([]int32{1, 1})},
-		{false, createReplicaSets([]int32{1, 1}), createReplicaSets([]int32{1, 1, 1})},
-		{true, createReplicaSets([]int32{1, 2, 3, 1, 2, 3}), createReplicaSets([]int32{1, 1, 2, 2, 3, 3})},
+		{true, createReplicaSets([]proto.StoreID{1}), createReplicaSets([]proto.StoreID{1})},
+		{true, createReplicaSets([]proto.StoreID{1, 2}), createReplicaSets([]proto.StoreID{1, 2})},
+		{true, createReplicaSets([]proto.StoreID{1, 2}), createReplicaSets([]proto.StoreID{2, 1})},
+		{false, createReplicaSets([]proto.StoreID{1}), createReplicaSets([]proto.StoreID{2})},
+		{false, createReplicaSets([]proto.StoreID{1, 2}), createReplicaSets([]proto.StoreID{2})},
+		{false, createReplicaSets([]proto.StoreID{1, 2}), createReplicaSets([]proto.StoreID{1})},
+		{false, createReplicaSets([]proto.StoreID{}), createReplicaSets([]proto.StoreID{1})},
+		{true, createReplicaSets([]proto.StoreID{1, 2, 3}), createReplicaSets([]proto.StoreID{2, 3, 1})},
+		{true, createReplicaSets([]proto.StoreID{1, 1}), createReplicaSets([]proto.StoreID{1, 1})},
+		{false, createReplicaSets([]proto.StoreID{1, 1}), createReplicaSets([]proto.StoreID{1, 1, 1})},
+		{true, createReplicaSets([]proto.StoreID{1, 2, 3, 1, 2, 3}), createReplicaSets([]proto.StoreID{1, 1, 2, 2, 3, 3})},
 	}
 	for _, test := range testData {
 		if ReplicaSetsEqual(test.a, test.b) != test.expected {

--- a/storage/store.go
+++ b/storage/store.go
@@ -146,7 +146,7 @@ func (e *NotBootstrappedError) Error() string {
 
 // NodeDescriptor holds details on node physical/network topology.
 type NodeDescriptor struct {
-	NodeID  int32
+	NodeID  proto.NodeID
 	Address net.Addr
 	Attrs   proto.Attributes // node specific attributes (e.g. datacenter, machine info)
 }
@@ -154,7 +154,7 @@ type NodeDescriptor struct {
 // StoreDescriptor holds store information including store attributes,
 // node descriptor and store capacity.
 type StoreDescriptor struct {
-	StoreID  int32
+	StoreID  proto.StoreID
 	Attrs    proto.Attributes // store specific attributes (e.g. ssd, hdd, mem)
 	Node     NodeDescriptor
 	Capacity engine.StoreCapacity
@@ -564,7 +564,7 @@ func (s *Store) BootstrapRange() error {
 func (s *Store) ClusterID() string { return s.Ident.ClusterID }
 
 // StoreID accessor.
-func (s *Store) StoreID() int32 { return s.Ident.StoreID }
+func (s *Store) StoreID() proto.StoreID { return s.Ident.StoreID }
 
 // Clock accessor.
 func (s *Store) Clock() *hlc.Clock { return s.clock }

--- a/storage/store_merge_test.go
+++ b/storage/store_merge_test.go
@@ -28,7 +28,7 @@ import (
 	"github.com/cockroachdb/cockroach/util/log"
 )
 
-func adminMergeArgs(key []byte, subsumedRangeDesc proto.RangeDescriptor, raftID int64, storeID int32) (*proto.AdminMergeRequest, *proto.AdminMergeResponse) {
+func adminMergeArgs(key []byte, subsumedRangeDesc proto.RangeDescriptor, raftID int64, storeID proto.StoreID) (*proto.AdminMergeRequest, *proto.AdminMergeResponse) {
 	args := &proto.AdminMergeRequest{
 		RequestHeader: proto.RequestHeader{
 			Key:     key,

--- a/storage/store_split_test.go
+++ b/storage/store_split_test.go
@@ -35,7 +35,7 @@ import (
 	"github.com/cockroachdb/cockroach/util/log"
 )
 
-func adminSplitArgs(key, splitKey []byte, raftID int64, storeID int32) (*proto.AdminSplitRequest, *proto.AdminSplitResponse) {
+func adminSplitArgs(key, splitKey []byte, raftID int64, storeID proto.StoreID) (*proto.AdminSplitRequest, *proto.AdminSplitResponse) {
 	args := &proto.AdminSplitRequest{
 		RequestHeader: proto.RequestHeader{
 			Key:     key,


### PR DESCRIPTION
This prepares for the conversions that will be necessary between
cockroach node/store ids and raft node ids.

@spencerkimball @cockroachdb/developers 
