### PR TITLE
Replace hard-coded NodeID 1 with actual node/store IDs.

### DIFF
--- a/kv/local_sender_test.go
+++ b/kv/local_sender_test.go
@@ -127,7 +127,7 @@ func TestLocalSenderLookupReplica(t *testing.T) {
 	ls := NewLocalSender()
 	db := client.NewKV(NewTxnCoordSender(ls, clock), nil)
 	store := storage.NewStore(clock, eng, db, nil)
-	if err := store.Bootstrap(proto.StoreIdent{StoreID: 1}); err != nil {
+	if err := store.Bootstrap(proto.StoreIdent{NodeID: 1, StoreID: 1}); err != nil {
 		t.Fatal(err)
 	}
 	ls.AddStore(store)
@@ -157,7 +157,7 @@ func TestLocalSenderLookupReplica(t *testing.T) {
 		e[i] = engine.NewInMem(proto.Attributes{}, 1<<20)
 		s[i] = storage.NewStore(clock, e[i], db, nil)
 		s[i].Ident.StoreID = rng.storeID
-		if err := s[i].Bootstrap(proto.StoreIdent{StoreID: rng.storeID}); err != nil {
+		if err := s[i].Bootstrap(proto.StoreIdent{NodeID: 1, StoreID: rng.storeID}); err != nil {
 			t.Fatal(err)
 		}
 		if err := s[i].Start(); err != nil {

--- a/kv/txn_coord_sender_test.go
+++ b/kv/txn_coord_sender_test.go
@@ -50,7 +50,7 @@ func createTestDB() (db *client.KV, eng engine.Engine, clock *hlc.Clock,
 	db = client.NewKV(sender, nil)
 	db.User = storage.UserRoot
 	store := storage.NewStore(clock, eng, db, g)
-	if err = store.Bootstrap(proto.StoreIdent{StoreID: 1}); err != nil {
+	if err = store.Bootstrap(proto.StoreIdent{NodeID: 1, StoreID: 1}); err != nil {
 		return
 	}
 	if err = store.Start(); err != nil {

--- a/storage/db_test.go
+++ b/storage/db_test.go
@@ -61,7 +61,7 @@ func createTestStoreWithEngine(t *testing.T, eng engine.Engine, clock *hlc.Clock
 	db.User = storage.UserRoot
 	store := storage.NewStore(clock, eng, db, g)
 	if bootstrap {
-		if err := store.Bootstrap(proto.StoreIdent{StoreID: 1}); err != nil {
+		if err := store.Bootstrap(proto.StoreIdent{NodeID: 1, StoreID: 1}); err != nil {
 			t.Fatal(err)
 		}
 	}

--- a/storage/range.go
+++ b/storage/range.go
@@ -140,6 +140,7 @@ type RangeManager interface {
 	Engine() engine.Engine
 	Gossip() *gossip.Gossip
 	StoreID() proto.StoreID
+	RaftNodeID() multiraft.NodeID
 
 	// Range manipulation methods.
 	AddRange(rng *Range) error
@@ -1474,7 +1475,7 @@ func (r *Range) InitialState() (raft.InitialState, error) {
 		Commit: raftInitialLogIndex,
 	}
 	cs := raftpb.ConfState{
-		Nodes: []uint64{1},
+		Nodes: []uint64{uint64(r.rm.RaftNodeID())},
 	}
 	_, err := engine.MVCCGetProto(r.rm.Engine(), engine.RaftStateKey(r.Desc.RaftID),
 		proto.ZeroTimestamp, nil, &hs)

--- a/storage/range_test.go
+++ b/storage/range_test.go
@@ -105,7 +105,7 @@ func (tc *testContext) Start(t *testing.T) {
 	if tc.store == nil {
 		tc.store = NewStore(tc.clock, tc.engine, nil, tc.gossip)
 		if !tc.skipBootstrap {
-			if err := tc.store.Bootstrap(proto.StoreIdent{StoreID: 1}); err != nil {
+			if err := tc.store.Bootstrap(proto.StoreIdent{NodeID: 1, StoreID: 1}); err != nil {
 				t.Fatal(err)
 			}
 		}


### PR DESCRIPTION
This makes it possible for multiple stores to address each other
with a suitable multiraft.Transport (which will be provided by #292)

@cockroachdb/developers
