### PR TITLE
Minor code reorg.

### DIFF
--- a/gossip/simulation/gossip.go
+++ b/gossip/simulation/gossip.go
@@ -15,6 +15,10 @@
 //
 // Author: Spencer Kimball (spencer.kimball@gmail.com)
 
+// We mark this file as "build ignore" so that it won't be built as
+// part of the simulation package, but can still be run using "go run
+// gossip.go".
+
 // +build ignore
 
 /*

--- a/gossip/simulation/gossip.go
+++ b/gossip/simulation/gossip.go
@@ -15,6 +15,8 @@
 //
 // Author: Spencer Kimball (spencer.kimball@gmail.com)
 
+// +build ignore
+
 /*
 Package simulation provides tools meant to visualize or test aspects
 of a Cockroach cluster on a single host.
@@ -30,7 +32,7 @@ simulation.
 
 To run:
 
-    go run simulation/gossip.go -size=(small|medium|large|huge|ginormous)
+    go run gossip.go -size=(small|medium|large|huge|ginormous)
 
 Log output includes instructions for displaying the graph output as a
 series of images to visualize the evolution of the network.
@@ -71,6 +73,7 @@ import (
 	"time"
 
 	"github.com/cockroachdb/cockroach/gossip"
+	"github.com/cockroachdb/cockroach/gossip/simulation"
 	"github.com/cockroachdb/cockroach/util/log"
 )
 
@@ -140,7 +143,7 @@ func (em edgeMap) addEdge(addr string, e edge) {
 //        node5 -> node2
 //        node5 -> node3
 //   }
-func outputDotFile(dotFN string, cycle int, network *gossip.SimulationNetwork, edgeSet map[string]edge) string {
+func outputDotFile(dotFN string, cycle int, network *simulation.Network, edgeSet map[string]edge) string {
 	f, err := os.Create(dotFN)
 	if err != nil {
 		log.Fatalf("unable to create temp file: %s", err)
@@ -291,9 +294,9 @@ func main() {
 
 	edgeSet := make(map[string]edge)
 
-	n := gossip.NewSimulationNetwork(nodeCount, *networkType, gossipInterval)
+	n := simulation.NewNetwork(nodeCount, *networkType, gossipInterval)
 	n.SimulateNetwork(
-		func(cycle int, network *gossip.SimulationNetwork) bool {
+		func(cycle int, network *simulation.Network) bool {
 			if cycle == numCycles {
 				return false
 			}

--- a/kv/dist_sender_test.go
+++ b/kv/dist_sender_test.go
@@ -24,13 +24,14 @@ import (
 	"time"
 
 	"github.com/cockroachdb/cockroach/gossip"
+	"github.com/cockroachdb/cockroach/gossip/simulation"
 	"github.com/cockroachdb/cockroach/proto"
 	"github.com/cockroachdb/cockroach/storage"
 	"github.com/cockroachdb/cockroach/storage/engine"
 )
 
 func TestGetFirstRangeDescriptor(t *testing.T) {
-	n := gossip.NewSimulationNetwork(3, "unix", gossip.DefaultTestGossipInterval)
+	n := simulation.NewNetwork(3, "unix", simulation.DefaultTestGossipInterval)
 	ds := NewDistSender(n.Nodes[0].Gossip)
 	if _, err := ds.getFirstRangeDescriptor(); err == nil {
 		t.Errorf("expected not to find first range descriptor")
@@ -45,7 +46,7 @@ func TestGetFirstRangeDescriptor(t *testing.T) {
 	n.Nodes[1].Gossip.AddInfo(
 		gossip.KeyFirstRangeDescriptor, *expectedDesc, time.Hour)
 	maxCycles := 10
-	n.SimulateNetwork(func(cycle int, network *gossip.SimulationNetwork) bool {
+	n.SimulateNetwork(func(cycle int, network *simulation.Network) bool {
 		desc, err := ds.getFirstRangeDescriptor()
 		if err != nil {
 			if cycle >= maxCycles {
@@ -65,7 +66,7 @@ func TestGetFirstRangeDescriptor(t *testing.T) {
 }
 
 func TestVerifyPermissions(t *testing.T) {
-	n := gossip.NewSimulationNetwork(1, "unix", gossip.DefaultTestGossipInterval)
+	n := simulation.NewNetwork(1, "unix", simulation.DefaultTestGossipInterval)
 	ds := NewDistSender(n.Nodes[0].Gossip)
 	config1 := &proto.PermConfig{
 		Read:  []string{"read1", "readAll", "rw", "rwAll"},


### PR DESCRIPTION
Move the gossip SimulationNetwork code (used only for testing) out of
the gossip package and into a new gossip/simulation package.
