### PR TITLE
Make multiraft.Transport an input to NewStore.

### DIFF
--- a/kv/local_sender_test.go
+++ b/kv/local_sender_test.go
@@ -22,6 +22,7 @@ import (
 	"testing"
 
 	"github.com/cockroachdb/cockroach/client"
+	"github.com/cockroachdb/cockroach/multiraft"
 	"github.com/cockroachdb/cockroach/proto"
 	"github.com/cockroachdb/cockroach/storage"
 	"github.com/cockroachdb/cockroach/storage/engine"
@@ -126,7 +127,7 @@ func TestLocalSenderLookupReplica(t *testing.T) {
 	eng := engine.NewInMem(proto.Attributes{}, 1<<20)
 	ls := NewLocalSender()
 	db := client.NewKV(NewTxnCoordSender(ls, clock), nil)
-	store := storage.NewStore(clock, eng, db, nil)
+	store := storage.NewStore(clock, eng, db, nil, multiraft.NewLocalRPCTransport())
 	if err := store.Bootstrap(proto.StoreIdent{NodeID: 1, StoreID: 1}); err != nil {
 		t.Fatal(err)
 	}
@@ -155,7 +156,7 @@ func TestLocalSenderLookupReplica(t *testing.T) {
 	}
 	for i, rng := range ranges {
 		e[i] = engine.NewInMem(proto.Attributes{}, 1<<20)
-		s[i] = storage.NewStore(clock, e[i], db, nil)
+		s[i] = storage.NewStore(clock, e[i], db, nil, multiraft.NewLocalRPCTransport())
 		s[i].Ident.StoreID = rng.storeID
 		if err := s[i].Bootstrap(proto.StoreIdent{NodeID: 1, StoreID: rng.storeID}); err != nil {
 			t.Fatal(err)

--- a/kv/txn_coord_sender_test.go
+++ b/kv/txn_coord_sender_test.go
@@ -25,6 +25,7 @@ import (
 
 	"github.com/cockroachdb/cockroach/client"
 	"github.com/cockroachdb/cockroach/gossip"
+	"github.com/cockroachdb/cockroach/multiraft"
 	"github.com/cockroachdb/cockroach/proto"
 	"github.com/cockroachdb/cockroach/rpc"
 	"github.com/cockroachdb/cockroach/storage"
@@ -49,11 +50,8 @@ func createTestDB() (db *client.KV, eng engine.Engine, clock *hlc.Clock,
 	sender := NewTxnCoordSender(lSender, clock)
 	db = client.NewKV(sender, nil)
 	db.User = storage.UserRoot
-	store := storage.NewStore(clock, eng, db, g)
+	store := storage.NewStore(clock, eng, db, g, multiraft.NewLocalRPCTransport())
 	if err = store.Bootstrap(proto.StoreIdent{NodeID: 1, StoreID: 1}); err != nil {
-		return
-	}
-	if err = store.Start(); err != nil {
 		return
 	}
 	lSender.AddStore(store)

--- a/storage/db_test.go
+++ b/storage/db_test.go
@@ -31,6 +31,7 @@ import (
 	"github.com/cockroachdb/cockroach/client"
 	"github.com/cockroachdb/cockroach/gossip"
 	"github.com/cockroachdb/cockroach/kv"
+	"github.com/cockroachdb/cockroach/multiraft"
 	"github.com/cockroachdb/cockroach/proto"
 	"github.com/cockroachdb/cockroach/rpc"
 	"github.com/cockroachdb/cockroach/storage"
@@ -59,7 +60,7 @@ func createTestStoreWithEngine(t *testing.T, eng engine.Engine, clock *hlc.Clock
 	sender := kv.NewTxnCoordSender(lSender, clock)
 	db := client.NewKV(sender, nil)
 	db.User = storage.UserRoot
-	store := storage.NewStore(clock, eng, db, g)
+	store := storage.NewStore(clock, eng, db, g, multiraft.NewLocalRPCTransport())
 	if bootstrap {
 		if err := store.Bootstrap(proto.StoreIdent{NodeID: 1, StoreID: 1}); err != nil {
 			t.Fatal(err)

--- a/storage/range_test.go
+++ b/storage/range_test.go
@@ -29,6 +29,7 @@ import (
 
 	"github.com/cockroachdb/cockroach/client"
 	"github.com/cockroachdb/cockroach/gossip"
+	"github.com/cockroachdb/cockroach/multiraft"
 	"github.com/cockroachdb/cockroach/multiraft/storagetest"
 	"github.com/cockroachdb/cockroach/proto"
 	"github.com/cockroachdb/cockroach/rpc"
@@ -103,7 +104,7 @@ func (tc *testContext) Start(t *testing.T) {
 	}
 
 	if tc.store == nil {
-		tc.store = NewStore(tc.clock, tc.engine, nil, tc.gossip)
+		tc.store = NewStore(tc.clock, tc.engine, nil, tc.gossip, multiraft.NewLocalRPCTransport())
 		if !tc.skipBootstrap {
 			if err := tc.store.Bootstrap(proto.StoreIdent{NodeID: 1, StoreID: 1}); err != nil {
 				t.Fatal(err)
@@ -176,7 +177,7 @@ func TestRangeContains(t *testing.T) {
 
 	e := engine.NewInMem(proto.Attributes{Attrs: []string{"dc1", "mem"}}, 1<<20)
 	clock := hlc.NewClock(hlc.UnixNano)
-	r, err := NewRange(desc, NewStore(clock, e, nil, nil))
+	r, err := NewRange(desc, NewStore(clock, e, nil, nil, multiraft.NewLocalRPCTransport()))
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/storage/store_test.go
+++ b/storage/store_test.go
@@ -97,14 +97,11 @@ func createTestStore(t *testing.T) (*Store, *hlc.ManualClock) {
 	manual := hlc.NewManualClock(0)
 	clock := hlc.NewClock(manual.UnixNano)
 	eng := engine.NewInMem(proto.Attributes{}, 1<<20)
-	store := NewStore(clock, eng, nil, g)
+	store := NewStore(clock, eng, nil, g, multiraft.NewLocalRPCTransport())
 	if err := store.Bootstrap(proto.StoreIdent{NodeID: 1, StoreID: 1}); err != nil {
 		t.Fatal(err)
 	}
 	store.db = client.NewKV(&testSender{store: store}, nil)
-	if err := store.Start(); err != nil {
-		t.Fatal(err)
-	}
 	if err := store.BootstrapRange(); err != nil {
 		t.Fatal(err)
 	}
@@ -120,7 +117,7 @@ func TestStoreInitAndBootstrap(t *testing.T) {
 	manual := hlc.NewManualClock(0)
 	clock := hlc.NewClock(manual.UnixNano)
 	eng := engine.NewInMem(proto.Attributes{}, 1<<20)
-	store := NewStore(clock, eng, nil, nil)
+	store := NewStore(clock, eng, nil, nil, multiraft.NewLocalRPCTransport())
 
 	// Can't start as haven't bootstrapped.
 	if err := store.Start(); err == nil {
@@ -144,7 +141,7 @@ func TestStoreInitAndBootstrap(t *testing.T) {
 	}
 
 	// Now, attempt to initialize a store with a now-bootstrapped range.
-	store = NewStore(clock, eng, nil, nil)
+	store = NewStore(clock, eng, nil, nil, multiraft.NewLocalRPCTransport())
 	if err := store.Start(); err != nil {
 		t.Errorf("failure initializing bootstrapped store: %s", err)
 	}
@@ -166,7 +163,7 @@ func TestBootstrapOfNonEmptyStore(t *testing.T) {
 	}
 	manual := hlc.NewManualClock(0)
 	clock := hlc.NewClock(manual.UnixNano)
-	store := NewStore(clock, eng, nil, nil)
+	store := NewStore(clock, eng, nil, nil, multiraft.NewLocalRPCTransport())
 
 	// Can't init as haven't bootstrapped.
 	if err := store.Start(); err == nil {


### PR DESCRIPTION
Fix some tests where we were calling Store.Start twice.

@spencerkimball @cockroachdb/developers 
