### PR TITLE
Add a util.Stopper to heartbeat_test for orderly shutdown.

### DIFF
--- a/multiraft/transport_test.go
+++ b/multiraft/transport_test.go
@@ -29,38 +29,51 @@ type localInterceptableTransport struct {
 	listeners map[NodeID]ServerInterface
 	messages  chan *RaftMessageRequest
 	Events    chan *interceptMessage
+	stopper   *util.Stopper
 }
 
 // NewLocalInterceptableTransport creates a Transport for local testing use.
 // MultiRaft instances sharing the same instance of this Transport can find and
 // communicate with each other by ID. Messages are transmitted in the order in
 // which they are queued, intercepted and blocked until acknowledged.
-func NewLocalInterceptableTransport() Transport {
+func NewLocalInterceptableTransport(stopper *util.Stopper) Transport {
 	lt := &localInterceptableTransport{
 		listeners: make(map[NodeID]ServerInterface),
 		messages:  make(chan *RaftMessageRequest),
 		Events:    make(chan *interceptMessage),
+		stopper:   stopper,
 	}
+	stopper.Add(1)
 	go lt.start()
 	return lt
 }
 
 func (lt *localInterceptableTransport) start() {
-	for msg := range lt.messages {
-		ack := make(chan struct{})
-		iMsg := &interceptMessage{
-			args: msg,
-			ack:  ack,
+	defer lt.stopper.SetStopped()
+	for {
+		select {
+		case msg := <-lt.messages:
+			ack := make(chan struct{})
+			iMsg := &interceptMessage{
+				args: msg,
+				ack:  ack,
+			}
+			// The following channel ops are not protected by a select with ShouldStop
+			// since leaving things partially complete here could prevent other components
+			// from shutting down cleanly.
+			lt.Events <- iMsg
+			<-ack
+			lt.mu.Lock()
+			srv, ok := lt.listeners[NodeID(msg.Message.To)]
+			lt.mu.Unlock()
+			if !ok {
+				continue
+			}
+			srv.RaftMessage(msg, nil)
+
+		case <-lt.stopper.ShouldStop():
+			return
 		}
-		lt.Events <- iMsg
-		<-ack
-		lt.mu.Lock()
-		srv, ok := lt.listeners[NodeID(msg.Message.To)]
-		lt.mu.Unlock()
-		if !ok {
-			continue
-		}
-		srv.RaftMessage(msg, nil)
 	}
 }
 
@@ -96,7 +109,10 @@ type interceptMessage struct {
 
 // Go implements ClientInterface.
 func (lt *localInterceptableTransport) Go(serviceMethod string, args interface{}, reply interface{}, done chan *rpc.Call) *rpc.Call {
-	lt.messages <- args.(*RaftMessageRequest)
+	select {
+	case lt.messages <- args.(*RaftMessageRequest):
+	case <-lt.stopper.ShouldStop():
+	}
 	if done != nil {
 		close(done)
 	}

--- a/util/stopper.go
+++ b/util/stopper.go
@@ -35,8 +35,13 @@ func NewStopper(count int) *Stopper {
 	s := &Stopper{
 		stopper: make(chan struct{}),
 	}
-	s.wg.Add(count)
+	s.Add(count)
 	return s
+}
+
+// Add a new goroutine to the stopper.
+func (s *Stopper) Add(count int) {
+	s.wg.Add(count)
 }
 
 // Stop signals the waiting goroutine to stop and then waits
@@ -50,11 +55,17 @@ func (s *Stopper) Stop() {
 // ShouldStop returns a channel which will be closed when Stop() has
 // been invoked. SetStopped() should be called to confirm.
 func (s *Stopper) ShouldStop() <-chan struct{} {
+	if s == nil {
+		// A nil stopper will never signal ShouldStop, but will also never panic.
+		return nil
+	}
 	return s.stopper
 }
 
 // SetStopped should be called after the ShouldStop() channel has
 // been closed to confirm the goroutine has stopped.
 func (s *Stopper) SetStopped() {
-	s.wg.Done()
+	if s != nil {
+		s.wg.Done()
+	}
 }


### PR DESCRIPTION
I suspect stale goroutines from this test were responsible for
https://circleci.com/gh/cockroachdb/cockroach/440

@tschottdorf @cockroachdb/developers 
