### PR TITLE
Refactor client side of multiraft.Transport interface.

### DIFF
--- a/multiraft/multiraft.go
+++ b/multiraft/multiraft.go
@@ -337,7 +337,6 @@ type node struct {
 	nodeID   NodeID
 	refCount int
 	groupIDs map[uint64]struct{}
-	client   *asyncClient
 }
 
 func (n *node) registerGroup(groupID uint64) {
@@ -473,7 +472,7 @@ func (s *state) coalescedHeartbeat() {
 	// to be the case for many of our nodes. It could make sense though
 	// to space out the heartbeats over the heartbeat interval so that
 	// we don't try to send for all nodes at once.
-	for nodeID, node := range s.nodes {
+	for nodeID := range s.nodes {
 		// Don't heartbeat yourself.
 		if nodeID == s.nodeID {
 			continue
@@ -484,21 +483,16 @@ func (s *state) coalescedHeartbeat() {
 			To:   uint64(nodeID),
 			Type: raftpb.MsgHeartbeat,
 		}
-		node.client.raftMessage(&RaftMessageRequest{
-			GroupID: math.MaxUint64, // irrelevant
-			Message: msg,
-		})
+		s.Transport.Send(nodeID,
+			&RaftMessageRequest{
+				GroupID: math.MaxUint64, // irrelevant
+				Message: msg,
+			})
 	}
 }
 
 func (s *state) stop() {
 	log.V(6).Infof("node %v stopping", s.nodeID)
-	for _, n := range s.nodes {
-		err := n.client.conn.Close()
-		if err != nil {
-			log.Warning("error stopping client:", err)
-		}
-	}
 	s.writeTask.stop()
 	s.stopper.SetStopped()
 }
@@ -515,15 +509,10 @@ func (s *state) addNode(nodeID NodeID, groupIDs ...uint64) error {
 	}
 	newNode, ok := s.nodes[nodeID]
 	if !ok {
-		conn, err := s.Transport.Connect(nodeID)
-		if err != nil {
-			return err
-		}
 		s.nodes[nodeID] = &node{
 			nodeID:   nodeID,
 			refCount: 1,
 			groupIDs: make(map[uint64]struct{}),
-			client:   &asyncClient{nodeID, conn},
 		}
 		newNode = s.nodes[nodeID]
 	}
@@ -728,7 +717,7 @@ func (s *state) handleWriteResponse(response *writeResponse, readyGroups map[uin
 
 			log.V(6).Infof("node %v sending message %s to %v", s.nodeID,
 				raft.DescribeMessage(msg, s.EntryFormatter), msg.To)
-			s.nodes[NodeID(msg.To)].client.raftMessage(&RaftMessageRequest{groupID, msg})
+			s.Transport.Send(NodeID(msg.To), &RaftMessageRequest{groupID, msg})
 		}
 	}
 }

--- a/multiraft/multiraft_test.go
+++ b/multiraft/multiraft_test.go
@@ -91,6 +91,7 @@ func (c *testCluster) stop() {
 	for _, demux := range c.events {
 		demux.stop()
 	}
+	c.transport.Close()
 }
 
 // createGroup replicates a group consisting of numReplicas members,

--- a/storage/store.go
+++ b/storage/store.go
@@ -283,6 +283,9 @@ func (s *Store) Stop() {
 	if s.raft != nil {
 		s.raft.stop()
 	}
+	// TODO(bdarnell): we don't necessarily own the Transport here; probably need
+	// to move the Close up to a higher level once we have a real Transport.
+	s.transport.Close()
 }
 
 // String formats a store for debug output.


### PR DESCRIPTION
The old Connect/ClientInterface pattern assumed that nodes' network
addresses never changed and were known as soon as they were needed.
Instead of a persistent ClientInterface object, the Transport now
has a Send method which takes a node id and a message and lazily
resolves the address and manages a connection as needed.

@tschottdorf @tnachen @cockroachdb/developers 
