### PR TITLE
Remove the LDEXTRA stuff from the Makefile.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -42,16 +42,6 @@ TESTFLAGS  := -logtostderr -timeout 10s
 RACEFLAGS  := -logtostderr -timeout 1m
 BENCHFLAGS := -logtostderr -timeout 5m
 
-OS := $(shell uname -s)
-
-ifeq ($(OS),Darwin)
-LDEXTRA += -lc++
-endif
-
-ifeq ($(OS),Linux)
-LDEXTRA += -lrt
-endif
-
 ifeq ($(STATIC),1)
 GOFLAGS  += -a -tags netgo -ldflags '-extldflags "-lm -lstdc++ -static"'
 endif
@@ -65,7 +55,7 @@ build: auxiliary
 	$(GO) build $(GOFLAGS) -o cockroach
 
 storage/engine/engine.pc: storage/engine/engine.pc.in
-	sed -e "s,@PWD@,$(CURDIR),g" -e "s,@LDEXTRA@,$(LDEXTRA),g" < $^ > $@
+	sed -e "s,@PWD@,$(CURDIR),g" < $^ > $@
 
 roach_proto:
 	make -C $(ROACH_PROTO) static_lib

--- a/storage/engine/engine.pc.in
+++ b/storage/engine/engine.pc.in
@@ -4,5 +4,5 @@ Name: Cockroach
 Description: Cockroach Engine Dependencies
 Version: 0.1
 Requires: 
-Libs: -L${prefix}/_vendor/usr/lib -L${prefix}/_vendor/rocksdb  -L${prefix}/proto/lib -lrocksdb -lstdc++ -lm -lz -lbz2 -lsnappy -lroachproto -lprotobuf @LDEXTRA@
+Libs: -L${prefix}/_vendor/usr/lib -L${prefix}/_vendor/rocksdb  -L${prefix}/proto/lib -lrocksdb -lstdc++ -lm -lz -lbz2 -lsnappy -lroachproto -lprotobuf
 Cflags: -I${prefix}/_vendor/usr/include -I${prefix}/_vendor/rocksdb/include -I${prefix}/proto/lib

--- a/storage/engine/rocksdb_linux.go
+++ b/storage/engine/rocksdb_linux.go
@@ -1,0 +1,21 @@
+// Copyright 2015 The Cockroach Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+// implied. See the License for the specific language governing
+// permissions and limitations under the License. See the AUTHORS file
+// for names of contributors.
+//
+// Author: Peter Mattis (petermattis@gmail.com)
+
+package engine
+
+// #cgo LDFLAGS: -lrt
+import "C"


### PR DESCRIPTION
We can accomplish the same affect using build tags. Note that it appears
the -lc++ library was not needed on darwin as it is linked implicitly.
