### PR TITLE
Disable cgo optimization flags (-O2) by default.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -36,6 +36,12 @@ export LIBRARY_PATH := $(CURDIR)/_vendor/usr/lib:$(LIBRARY_PATH)
 ROACH_PROTO := proto
 SQL_PARSER  := sql/parser
 
+# TODO(pmattis): Figure out where to clear the CGO_* variables when
+# building "release" binaries.
+export CGO_CFLAGS :=-g
+export CGO_CXXFLAGS :=-g
+export CGO_LDFLAGS :=-g
+
 PKG        := "./..."
 TESTS      := ".*"
 TESTFLAGS  := -logtostderr -timeout 10s


### PR DESCRIPTION
This speeds up build, especially that we're now using cgo for building more C++ files.
