### PR TITLE
Removes the -q option from sysctl

### DIFF
--- a/build/devbase/vendor.sh
+++ b/build/devbase/vendor.sh
@@ -50,7 +50,7 @@ case $(uname) in
         ncpus=$(grep processor /proc/cpuinfo | wc -l)
 	;;
     Darwin)
-	ncpus=$(sysctl -q -n hw.logicalcpu)
+	ncpus=$(sysctl -n hw.logicalcpu)
 	;;
 esac
 


### PR DESCRIPTION
Removes the -q option from sysctl which is not compatible with earlier versions of OSX
