### PR TITLE
Replace use of pkg-config with environment variables in Makefile.

### DIFF
--- a/storage/engine/.gitignore
+++ b/storage/engine/.gitignore
@@ -1,1 +1,0 @@
-engine.pc

--- a/storage/engine/engine.pc.in
+++ b/storage/engine/engine.pc.in
@@ -1,8 +1,0 @@
-prefix=@PWD@
-
-Name: Cockroach
-Description: Cockroach Engine Dependencies
-Version: 0.1
-Requires: 
-Libs: -L${prefix}/_vendor/usr/lib -L${prefix}/_vendor/rocksdb -lrocksdb -lstdc++ -lm -lz -lbz2 -lsnappy -lprotobuf
-Cflags: -I${prefix}/_vendor/usr/include -I${prefix}/_vendor/rocksdb/include

--- a/storage/engine/rocksdb.go
+++ b/storage/engine/rocksdb.go
@@ -21,7 +21,7 @@
 package engine
 
 // #cgo CXXFLAGS: -std=c++11
-// #cgo pkg-config: ./engine.pc
+// #cgo LDFLAGS: -lrocksdb -lstdc++ -lm -lz -lbz2 -lsnappy -lprotobuf
 // #include <stdlib.h>
 // #include "db.h"
 import "C"


### PR DESCRIPTION
Some go tools (such as go oracle and gorename) do not understand files
that use the pkg-config feature or even depend on it indirectly. With
this change, such tools can be used, although in exchange the
CGO_{CPP,LD}FLAGS environment variables must be set. This is done
automatically in the Makefile (along with the GOPATH) but it must be set
separately to use 'go test' directly.

Submitted for discussion since this basically trades one kind of magic for another, and I don't really like either solution. In the long term go 1.5 will have a cleaner solution since (I think) you'll be able to do some variable expansion in `#cgo` lines. 

One potential point in favor of the environment-variable solution is that the variables can go away if rocksdb and its dependencies are installed system-wide. That's obviously not good in all cases, but in a container "system-wide" is actually the scope we want. Containerized build environments (or even just chroot) offer an opportunity to unwind a lot of complexity around vendoring dependencies.

@petermattis @cockroachdb/developers 
