### PR TITLE
Generate a .go file for cgo flags instead of a .pc file

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -46,7 +46,7 @@ endif
 
 all: build test
 
-auxiliary: storage/engine/engine.pc
+auxiliary: storage/engine/cgo_flags.go
 
 # "go build -i" explicitly does not rebuild dependent packages that
 # have a different root directory than the package being built, hence
@@ -55,8 +55,8 @@ build: auxiliary
 	$(GO) build $(GOFLAGS) -i github.com/coreos/etcd/raft
 	$(GO) build $(GOFLAGS) -i -o cockroach
 
-storage/engine/engine.pc: storage/engine/engine.pc.in
-	sed -e "s,@PWD@,$(CURDIR),g" < $^ > $@
+storage/engine/cgo_flags.go: storage/engine/cgo_flags.go.in
+	sed -e "s,@ROOT@,$(CURDIR),g" < $^ > $@
 
 test: auxiliary
 	$(GO) test $(GOFLAGS) -run $(TESTS) $(PKG) $(TESTFLAGS)
@@ -100,7 +100,7 @@ acceptance:
 clean:
 	$(GO) clean -i -r ./...
 	find . -name '*.test' -type f -exec rm -f {} \;
-	rm -f storage/engine/engine.pc
+	rm -f storage/engine/cgo_flags.go
 
 # The gopath target outputs the GOPATH that should be used for building this
 # package. It is used by the emacs go-projectile package for automatic

--- a/build/devbase/vendor.sh
+++ b/build/devbase/vendor.sh
@@ -80,5 +80,6 @@ cd protobuf-2.6.1
 
 cd ${ROCKSDB}
 LIBRARY_PATH="${LIB}" CPLUS_INCLUDE_PATH="${INCLUDE}" ${MAKE} static_lib
+${MAKE} install INSTALL_PATH=${USR}
 
 rm -rf ${TMP}

--- a/storage/engine/.gitignore
+++ b/storage/engine/.gitignore
@@ -1,1 +1,1 @@
-engine.pc
+cgo_flags.go

--- a/storage/engine/cgo_flags.go.in
+++ b/storage/engine/cgo_flags.go.in
@@ -1,0 +1,10 @@
+package engine
+
+// This file is generated because in go 1.4, there is no way to
+// include a relative path in cgo's LDFLAGS. (go 1.5 will include
+// variable expansion in these flags).
+
+// #cgo CXXFLAGS: -std=c++11
+// #cgo CPPFLAGS: -I ../../_vendor/usr/include
+// #cgo LDFLAGS: -L @ROOT@/_vendor/usr/lib -lrocksdb -lstdc++ -lm -lz -lbz2 -lsnappy -lprotobuf
+import "C"

--- a/storage/engine/engine.pc.in
+++ b/storage/engine/engine.pc.in
@@ -1,8 +1,0 @@
-prefix=@PWD@
-
-Name: Cockroach
-Description: Cockroach Engine Dependencies
-Version: 0.1
-Requires: 
-Libs: -L${prefix}/_vendor/usr/lib -lrocksdb -lstdc++ -lm -lz -lbz2 -lsnappy -lprotobuf
-Cflags: -I${prefix}/_vendor/usr/include

--- a/storage/engine/engine.pc.in
+++ b/storage/engine/engine.pc.in
@@ -4,5 +4,5 @@ Name: Cockroach
 Description: Cockroach Engine Dependencies
 Version: 0.1
 Requires: 
-Libs: -L${prefix}/_vendor/usr/lib -L${prefix}/_vendor/rocksdb -lrocksdb -lstdc++ -lm -lz -lbz2 -lsnappy -lprotobuf
-Cflags: -I${prefix}/_vendor/usr/include -I${prefix}/_vendor/rocksdb/include
+Libs: -L${prefix}/_vendor/usr/lib -lrocksdb -lstdc++ -lm -lz -lbz2 -lsnappy -lprotobuf
+Cflags: -I${prefix}/_vendor/usr/include

--- a/storage/engine/rocksdb.go
+++ b/storage/engine/rocksdb.go
@@ -20,8 +20,6 @@
 
 package engine
 
-// #cgo CXXFLAGS: -std=c++11
-// #cgo pkg-config: ./engine.pc
 // #include <stdlib.h>
 // #include "db.h"
 import "C"


### PR DESCRIPTION
This improves compatibility with tools such as go oracle.

@petermattis @cockroachdb/developers 
