### PR TITLE
Reverse the elements in GOPATH.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -26,7 +26,7 @@ GOFLAGS :=
 STATIC := $(STATIC)
 
 RUN  := run
-GOPATH  := $(CURDIR)/../../../..:$(CURDIR)/_vendor
+GOPATH  := $(CURDIR)/_vendor:$(CURDIR)/../../../..
 
 # TODO(pmattis): Figure out where to clear the CGO_* variables when
 # building "release" binaries.

--- a/build/devbase/godeps.sh
+++ b/build/devbase/godeps.sh
@@ -2,6 +2,17 @@
 # Grab Go-related dependencies.
 # TODO(bdarnell): make these submodules like etcd/raft, so we can pin versions?
 
+# We normally use a GOPATH with two elements: the directory containing
+# cockroach and our _vendor directory. The _vendor directory appears
+# first in the GOPATH when it is used (it is typically not present
+# when bootstrap.sh is being run), but it is treated specially during
+# the docker build so we want to install all our other dependencies
+# into the outer GOPATH whether the _vendor directory is present or not.
+#
+# The cd/pwd dance converts the possibly-relative $(dirname $0) into
+# an absolute path.
+export GOPATH=$(cd $(dirname $0)/../../../../../.. && pwd)
+
 function go_get() {
   go get -u -v "$@"
 }


### PR DESCRIPTION
Install go dependencies with a known GOPATH instead of inheriting from
the environment.

Fixes #335.

@tschottdorf @cockroachdb/developers 
