### PR TITLE
use Go 1.4.2 in Docker builds

### DIFF
--- a/build/devbase/Dockerfile.template
+++ b/build/devbase/Dockerfile.template
@@ -1,4 +1,4 @@
-FROM golang:1.4.1
+FROM golang:1.4.2
 
 MAINTAINER Tobias Schottdorf <tobias.schottdorf@gmail.com>
 


### PR DESCRIPTION
the upgrade 1.4.1->1.4.2 contains some internal fixes to Go only
and no changes worth mentioning here.
