### PR TITLE
clean up cockroach-dev Docker build

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -2,6 +2,8 @@ _vendor
 storage/engine/engine.pc
 cockroach
 build/deploy
+.git/FETCH_HEAD
+.git/modules
 *.test
 */*.test
 */*/*.test

--- a/Dockerfile
+++ b/Dockerfile
@@ -14,9 +14,6 @@ MAINTAINER Tobias Schottdorf <tobias.schottdorf@gmail.com>
 ADD . /cockroach/
 RUN ln -s /cockroach/build/devbase/cockroach.sh /cockroach/cockroach.sh
 
-# Update any submodules that were not already cloned in the
-# cockroach-devbase image.
-RUN cd -P /cockroach && git submodule update --init
 # Build the cockroach executable.
 RUN cd -P /cockroach && make build
 

--- a/Makefile
+++ b/Makefile
@@ -24,6 +24,10 @@ GO ?= go
 GOFLAGS := 
 # Set to 1 to use static linking for all builds (including tests).
 STATIC := $(STATIC)
+# The cockroach image to be used for starting Docker containers
+# during acceptance tests. Usually cockroachdb/cockroach{,-dev}
+# depending on the context.
+COCKROACH_IMAGE :=
 
 RUN  := run
 GOPATH  := $(CURDIR)/_vendor:$(CURDIR)/../../../..
@@ -91,7 +95,7 @@ coverage: build
 
 acceptance:
 # The first `stop` stops and cleans up any containers from previous runs.
-	(cd $(RUN); \
+	(cd $(RUN) && export COCKROACH_IMAGE="$(COCKROACH_IMAGE)" && \
 	  ../build/build-docker-dev.sh && \
 	  ./local-cluster.sh stop && \
 	  ./local-cluster.sh start && \

--- a/build/build-docker-dev.sh
+++ b/build/build-docker-dev.sh
@@ -10,9 +10,15 @@ source "./build/verify-docker.sh"
 # freshly cloned whenever the SHA pointers are updated.
 ROCKSDB_SHA=$(git ls-tree HEAD _vendor/rocksdb | awk '{print $3}')
 ETCD_SHA=$(git ls-tree HEAD _vendor/src/github.com/coreos/etcd | awk '{print $3}')
-sed -e "s/ROCKSDB_SHA/${ROCKSDB_SHA}/g" \
+WANTED_CONTENT=$(sed -e "s/ROCKSDB_SHA/${ROCKSDB_SHA}/g" \
     -e "s/ETCD_SHA/${ETCD_SHA}/g" \
-    < build/devbase/Dockerfile.template > build/devbase/Dockerfile
+    < build/devbase/Dockerfile.template)
+if diff <(echo "${WANTED_CONTENT}") "build/devbase/Dockerfile" &> /dev/null; then
+  echo "Not updating Dockerfile from template, contents are equal"
+else
+  echo "Rewriting Dockerfile"
+  echo "${WANTED_CONTENT}" > build/devbase/Dockerfile
+fi
 
 # Create the docker cockroach image.
 echo "Building Docker Cockroach images..."

--- a/circle.yml
+++ b/circle.yml
@@ -46,4 +46,9 @@ deployment:
     commands:
       # Build small deploy container for master branch.
       - sed "s/<EMAIL>/$DOCKER_EMAIL/;s/<AUTH>/$DOCKER_AUTH/" < "resources/deploy_templates/.dockercfg.template" > ~/.dockercfg
-      - if [ -n "$DOCKER_EMAIL" ]; then ./build/build-docker-deploy.sh && docker push cockroachdb/cockroach; fi
+      - |
+          if [ -n "$DOCKER_EMAIL" ]; then
+            ./build/build-docker-deploy.sh && \
+            make COCKROACH_IMAGE="cockroachdb/cockroach" acceptance && \
+            docker push cockroachdb/cockroach
+          fi

--- a/run/local-cluster.sh
+++ b/run/local-cluster.sh
@@ -46,7 +46,7 @@ $0 stop
 # Doing this here only so that after a cluster has been started and stopped,
 # the containers are still available for debugging.
 echo "Removing any old containers..."
-docker rm $CONTAINERS > /dev/null
+docker rm -f $CONTAINERS &> /dev/null
 
 # Default number of nodes.
 NODES=${NODES:-3}


### PR DESCRIPTION
- remove the submodule update when building cockroach-dev;
  we're not rebuilding RocksDB anyways, so there's no point
  in changing the sources at this point.
- add some files to .dockerignore which tend to break the cache
  and are not required inside the container
- fix cache-breaking in build-docker-dev.sh (caused by Dockerfile
  templating) - since this is called a bunch of times during tests,
  this should shave a good amount of seconds off those runs
- run `make acceptance` again when deploying through CircleCI,
  using the deploy container.
