### PR TITLE
Export GOPATH in the Makefile.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -29,8 +29,8 @@ STATIC := $(STATIC)
 # depending on the context.
 COCKROACH_IMAGE :=
 
-RUN  := run
-GOPATH  := $(CURDIR)/_vendor:$(CURDIR)/../../../..
+RUN := run
+export GOPATH := $(CURDIR)/_vendor:$(CURDIR)/../../../..
 
 # TODO(pmattis): Figure out where to clear the CGO_* variables when
 # building "release" binaries.


### PR DESCRIPTION
This line did not previously have any effect (except via `make gopath`).

Has everyone just been manually setting their GOPATH to include _vendor, or is there some other layer of magic I'm missing?
