### PR TITLE
Bake git SHAs of dependencies into the cockroach binary.

### DIFF
--- a/main.go
+++ b/main.go
@@ -23,6 +23,8 @@ import (
 	"math/rand"
 	"os"
 	"runtime"
+	"strings"
+	"text/tabwriter"
 
 	commander "code.google.com/p/go-commander"
 	"github.com/cockroachdb/cockroach/server/cli"
@@ -87,9 +89,14 @@ Output build version information.
 `,
 				Run: func(cmd *commander.Command, args []string) {
 					info := util.GetBuildInfo()
-					fmt.Printf("Build SHA:  %s\n", info.SHA)
-					fmt.Printf("Build Tag:  %s\n", info.Tag)
-					fmt.Printf("Build Time: %s\n", info.Time)
+					w := &tabwriter.Writer{}
+					w.Init(os.Stdout, 2, 1, 2, ' ', 0)
+					fmt.Fprintf(w, "Build SHA:   %s\n", info.SHA)
+					fmt.Fprintf(w, "Build Tag:   %s\n", info.Tag)
+					fmt.Fprintf(w, "Build Time:  %s\n", info.Time)
+					fmt.Fprintf(w, "Build Deps:\n\t%s\n",
+						strings.Replace(strings.Replace(info.Deps, " ", "\n\t", -1), ":", "\t", -1))
+					w.Flush()
 				},
 			},
 		},

--- a/server/cli/start.go
+++ b/server/cli/start.go
@@ -30,6 +30,7 @@ import (
 	"github.com/cockroachdb/cockroach/server"
 	"github.com/cockroachdb/cockroach/storage/engine"
 	"github.com/cockroachdb/cockroach/structured"
+	"github.com/cockroachdb/cockroach/util"
 	"github.com/cockroachdb/cockroach/util/log"
 )
 
@@ -130,6 +131,12 @@ var CmdStart = &commander.Command{
 // of "well-known" hosts used to join this node to the cockroach
 // cluster via the gossip network.
 func runStart(cmd *commander.Command, args []string) {
+	info := util.GetBuildInfo()
+	log.Infof("Build SHA:  %s", info.SHA)
+	log.Infof("Build Tag:  %s", info.Tag)
+	log.Infof("Build Time: %s", info.Time)
+	log.Infof("Build Deps: %s", info.Deps)
+
 	log.Info("Starting cockroach cluster")
 	s, err := server.NewServer(Context)
 	if err != nil {

--- a/util/build.go
+++ b/util/build.go
@@ -23,13 +23,15 @@ var (
 	buildSHA  string // Git SHA
 	buildTag  string // Tag of this build (git describe)
 	buildTime string // Build time in UTC (year/month/day hour:min:sec)
+	buildDeps string // Git SHAs of dependencies
 )
 
 // BuildInfo ...
 type BuildInfo struct {
-	SHA  string `json:"sha"`
-	Tag  string `json:"tag"`
-	Time string `json:"time"`
+	SHA  string
+	Tag  string
+	Time string
+	Deps string
 }
 
 // GetBuildInfo ...
@@ -38,5 +40,6 @@ func GetBuildInfo() BuildInfo {
 		SHA:  buildSHA,
 		Tag:  buildTag,
 		Time: buildTime,
+		Deps: buildDeps,
 	}
 }


### PR DESCRIPTION
Re-add support for displaying build info at the top of the log file when
starting the cockroach binary. This was accidentally removed in
08ab0701ad808b84094e858d0fca53af4c289030.
