### PR TITLE
Use Store.BootstrapRange to create the initial range in tests.

### DIFF
--- a/storage/range_data_iter_test.go
+++ b/storage/range_data_iter_test.go
@@ -66,7 +66,9 @@ func createRangeData(r *Range, t *testing.T) []proto.EncodedKey {
 // TestRangeDataIterator verifies correct operation of iterator if
 // a range contains no data and never has.
 func TestRangeDataIteratorEmptyRange(t *testing.T) {
-	tc := testContext{}
+	tc := testContext{
+		bootstrapMode: bootstrapRangeOnly,
+	}
 	tc.Start(t)
 	defer tc.Stop()
 
@@ -94,7 +96,9 @@ func TestRangeDataIteratorEmptyRange(t *testing.T) {
 // and verifies it's empty. Finally, it verifies the pre and post
 // ranges still contain the expected data.
 func TestRangeDataIterator(t *testing.T) {
-	tc := testContext{}
+	tc := testContext{
+		bootstrapMode: bootstrapRangeOnly,
+	}
 	tc.Start(t)
 	defer tc.Stop()
 

--- a/storage/stats_test.go
+++ b/storage/stats_test.go
@@ -25,7 +25,9 @@ import (
 )
 
 func TestRangeStatsEmpty(t *testing.T) {
-	tc := testContext{}
+	tc := testContext{
+		bootstrapMode: bootstrapRangeOnly,
+	}
 	tc.Start(t)
 	defer tc.Stop()
 
@@ -64,7 +66,9 @@ func TestRangeStatsInit(t *testing.T) {
 }
 
 func TestRangeStatsMerge(t *testing.T) {
-	tc := testContext{}
+	tc := testContext{
+		bootstrapMode: bootstrapRangeOnly,
+	}
 	tc.Start(t)
 	defer tc.Stop()
 	ms := engine.MVCCStats{


### PR DESCRIPTION
This ensures that the range descriptor is persisted, which will
be necessary in upcoming raft tests.
