### PR TITLE
Remove the raft.InitialState type.

### DIFF
--- a/multiraft/multiraft.go
+++ b/multiraft/multiraft.go
@@ -549,11 +549,11 @@ func (s *state) createGroup(groupID uint64) error {
 	log.V(6).Infof("node %v creating group %v", s.nodeID, groupID)
 
 	gs := s.Storage.GroupStorage(groupID)
-	state, err := gs.InitialState()
+	_, cs, err := gs.InitialState()
 	if err != nil {
 		return err
 	}
-	for _, nodeID := range state.ConfState.Nodes {
+	for _, nodeID := range cs.Nodes {
 		s.addNode(NodeID(nodeID), groupID)
 	}
 
@@ -562,7 +562,7 @@ func (s *state) createGroup(groupID uint64) error {
 		pending: map[string]*proposal{},
 	}
 
-	for _, nodeID := range state.ConfState.Nodes {
+	for _, nodeID := range cs.Nodes {
 		s.addNode(NodeID(nodeID), groupID)
 	}
 
@@ -572,11 +572,11 @@ func (s *state) createGroup(groupID uint64) error {
 func (s *state) removeGroup(op *removeGroupOp) {
 	s.multiNode.RemoveGroup(op.groupID)
 	gs := s.Storage.GroupStorage(op.groupID)
-	state, err := gs.InitialState()
+	_, cs, err := gs.InitialState()
 	if err != nil {
 		op.ch <- err
 	}
-	for _, nodeID := range state.ConfState.Nodes {
+	for _, nodeID := range cs.Nodes {
 		s.nodes[NodeID(nodeID)].unregisterGroup(op.groupID)
 	}
 	delete(s.groups, op.groupID)

--- a/multiraft/storage_test.go
+++ b/multiraft/storage_test.go
@@ -6,7 +6,6 @@ package multiraft
 import (
 	"sync"
 
-	"github.com/coreos/etcd/raft"
 	"github.com/coreos/etcd/raft/raftpb"
 )
 
@@ -60,7 +59,7 @@ func (b *blockableGroupStorage) SetHardState(st raftpb.HardState) error {
 	return b.s.SetHardState(st)
 }
 
-func (b *blockableGroupStorage) InitialState() (raft.InitialState, error) {
+func (b *blockableGroupStorage) InitialState() (raftpb.HardState, raftpb.ConfState, error) {
 	b.b.wait()
 	return b.s.InitialState()
 }

--- a/multiraft/storagetest/storagetest.go
+++ b/multiraft/storagetest/storagetest.go
@@ -47,7 +47,7 @@ func RunTests(t *testing.T, setUp func(*testing.T) WriteableStorage,
 // testEmptyLog calls all the read methods on an empty log and verifies the expected
 // state. Note that an empty log need not start from index zero.
 func testEmptyLog(t *testing.T, s WriteableStorage) {
-	state, err := s.InitialState()
+	hs, _, err := s.InitialState()
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -79,8 +79,8 @@ func testEmptyLog(t *testing.T, s WriteableStorage) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if term != state.HardState.Term {
-		t.Errorf("expected Term(firstIndex) to be hs.Term (%d), got %d", state.HardState.Term, term)
+	if term != hs.Term {
+		t.Errorf("expected Term(firstIndex) to be hs.Term (%d), got %d", hs.Term, term)
 	}
 
 }

--- a/storage/range.go
+++ b/storage/range.go
@@ -1464,12 +1464,12 @@ func (r *Range) AdminSplit(args *proto.AdminSplitRequest, reply *proto.AdminSpli
 }
 
 // InitialState implements the raft.Storage interface.
-func (r *Range) InitialState() (raft.InitialState, error) {
+func (r *Range) InitialState() (raftpb.HardState, raftpb.ConfState, error) {
 	var hs raftpb.HardState
 	found, err := engine.MVCCGetProto(r.rm.Engine(), engine.RaftStateKey(r.Desc.RaftID),
 		proto.ZeroTimestamp, nil, &hs)
 	if err != nil {
-		return raft.InitialState{}, err
+		return raftpb.HardState{}, raftpb.ConfState{}, err
 	}
 	if !found {
 		// We don't have a saved HardState, so set up the defaults.
@@ -1495,12 +1495,7 @@ func (r *Range) InitialState() (raft.InitialState, error) {
 		Nodes: []uint64{uint64(r.rm.RaftNodeID())},
 	}
 
-	return raft.InitialState{
-		HardState: hs,
-		ConfState: cs,
-		// TODO(bdarnell): account for skew between Commit and Applied.
-		AppliedIndex: hs.Commit,
-	}, nil
+	return hs, cs, nil
 }
 
 // loadFirstAndLastIndex looks in the engine to find the first and last log index.


### PR DESCRIPTION
This was a change in our fork that was never merged upstream,
so this commit brings us closer to upstream raft.
