### PR TITLE
CircleCI: update submodules and less timestamp magic

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -7,7 +7,7 @@ checkout:
     - git fetch --unshallow 2>/dev/null || true
     - git submodule update --init --recursive
     - git fetch --tags
-    # Nasty hack: Because we get a freshly restored repo, timestamps don't
+    # Nasty hack: Because we get a freshly restored repo, timestamps do not
     # correspond any more to when the file was last changed. To rectify this,
     # first set everything to a timestamp in the past and then update the
     # timestamp for all git-tracked files based on their last committed change.

--- a/circle.yml
+++ b/circle.yml
@@ -4,15 +4,15 @@ machine:
 
 checkout:
   post:
-    # Nasty hack: Because we get a new clone of the repo, timestamps don't
-    # correspond any more to when the file was last changed.
-    # To rectify this, first set everything to a timestamp in the past and then
-    # update the timestamp for all git-tracked files based on their last
-    # committed change.
+    - git fetch --unshallow 2>/dev/null || true
+    - git submodule update --init --recursive
+    - git fetch --tags
+    # Nasty hack: Because we get a freshly restored repo, timestamps don't
+    # correspond any more to when the file was last changed. To rectify this,
+    # first set everything to a timestamp in the past and then update the
+    # timestamp for all git-tracked files based on their last committed change.
     - find . -exec touch -t 201401010000 {} \;
     - for x in $(git ls-tree --full-tree --name-only -r HEAD); do touch -t $(date -d "$(git log -1 --format=%ci "${x}")" +%y%m%d%H%M.%S) "${x}"; done
-    - git fetch --unshallow 2>/dev/null || true
-    - git fetch --tags
 
 dependencies:
   cache_directories:


### PR DESCRIPTION
in #309, we realized that there was a weird dependency problem where
the docker images ended up with the wrong version of RocksDB baked in,
despite earlier efforts to bake the SHA into the lower layers.

this commit fixes a possible reason for this, namely the fact that submodules
may not have been updated appropriately when the git repo was cached by
CircleCI.

prior to this change, all files' timestamps were reset and then updated
according to their last commit. this did not apply to submodules though,
so what could have happened is that a submodule containing an earlier build
would be forwarded, and the build files' timestamp reset.

then, rocksdb may have been built from the correct version, but old build files
with reset timestamps may have confused make into building a broken version
of rocksdb.

i suspect that this fixes #309. we have since removed rocksdb here, and it's
a rare-ish issue only apparent when updating submodules inbetween cached
builds, but with this change we should be safe in the future.
