### PR TITLE
Fix TestSnapshotMethods rocksdb assertion failure.

### DIFF
--- a/storage/engine/engine_test.go
+++ b/storage/engine/engine_test.go
@@ -665,6 +665,7 @@ func TestSnapshotMethods(t *testing.T) {
 		if iter.Valid() {
 			t.Error("expected invalid iterator when seeking to element which shouldn't be visible to snapshot")
 		}
+		iter.Close()
 
 		// Verify Commit is error.
 		if err := snap.Commit(); err == nil {


### PR DESCRIPTION
Need to close iterators in order to release rocksdb resources. Failure
to do so triggers a rocksdb assertion when rocksdb is compiled with
-DNDEBUG.

Fixes #352
