### PR TITLE
Rename {Put,Get}Uvarint to {put,get}Uvarint.

### DIFF
--- a/util/encoding/key_encoding.go
+++ b/util/encoding/key_encoding.go
@@ -581,7 +581,7 @@ func onesComplement(buf []byte, start, end int) {
 }
 
 func encodeSmallNumber(negative bool, e int, m []byte, buf []byte) []byte {
-	n := PutUvarint(buf[1:], uint64(-e))
+	n := putUvarint(buf[1:], uint64(-e))
 	copy(buf[n+1:], m)
 	l := 1 + n + len(m)
 	if negative {
@@ -609,7 +609,7 @@ func encodeMediumNumber(negative bool, e int, m []byte, buf []byte) []byte {
 }
 
 func encodeLargeNumber(negative bool, e int, m []byte, buf []byte) []byte {
-	n := PutUvarint(buf[1:], uint64(e))
+	n := putUvarint(buf[1:], uint64(e))
 	copy(buf[n+1:], m)
 	l := 1 + n + len(m)
 	if negative {
@@ -626,10 +626,10 @@ func decodeSmallNumber(negative bool, buf []byte) (int, []byte) {
 	var e uint64
 	var n int
 	if negative {
-		e, n = GetUvarint(buf[1:])
+		e, n = getUvarint(buf[1:])
 	} else {
 		tmp := []byte{^buf[1]}
-		e, n = GetUvarint(tmp)
+		e, n = getUvarint(tmp)
 	}
 
 	// We don't need the prefix and last terminator.
@@ -663,7 +663,7 @@ func decodeLargeNumber(negative bool, buf []byte) (int, []byte) {
 	if negative {
 		onesComplement(m, 1, len(m))
 	}
-	e, l := GetUvarint(m[1:])
+	e, l := getUvarint(m[1:])
 
 	// We don't need the prefix and last terminator.
 	return int(e), m[l+1 : len(m)-1]

--- a/util/encoding/varint.go
+++ b/util/encoding/varint.go
@@ -60,10 +60,11 @@ func readBigEndian(buf []byte) uint64 {
 
 const maxVarintSize = 9
 
-// PutUvarint encodes a uint64 into buf and returns the
-// number of bytes written. If the buffer is too small,
-// a panic will ensue.
-func PutUvarint(buf []byte, x uint64) int {
+// putUvarint encodes a uint64 into buf and returns the number of
+// bytes written. If the buffer is too small, a panic will ensue. Note
+// that this varint encoding matches the sqlite4 definition but
+// differs from the encoding/binary.{Put,Read}Uvarint() definitions.
+func putUvarint(buf []byte, x uint64) int {
 	// Treat each byte of the encoding as an unsigned integer
 	// between 0 and 255.
 	// Let the bytes of the encoding be called A0, A1, A2, ..., A8.
@@ -116,9 +117,9 @@ func PutUvarint(buf []byte, x uint64) int {
 	}
 }
 
-// GetUvarint decodes a varint-encoded byte slice and returns the result
+// getUvarint decodes a varint-encoded byte slice and returns the result
 // and the length of byte slice been used.
-func GetUvarint(b []byte) (uint64, int) {
+func getUvarint(b []byte) (uint64, int) {
 	// Treat each byte of the encoding as an unsigned integer
 	// between 0 and 255.
 	// Let the bytes of the encoding be called A0, A1, A2, ..., A8.

--- a/util/encoding/varint_test.go
+++ b/util/encoding/varint_test.go
@@ -47,14 +47,14 @@ func TestVarint(t *testing.T) {
 	}
 	for _, c := range testCases {
 		buf := make([]byte, len(c.encoded))
-		n := PutUvarint(buf, c.val)
+		n := putUvarint(buf, c.val)
 		if n != len(c.encoded) {
 			t.Errorf("short write: %d bytes written; %d expected", n, len(c.encoded))
 		}
 		if !bytes.Equal(buf, c.encoded) {
 			t.Errorf("byte mismatch: expected %v, got %v", c.encoded, buf)
 		}
-		decoded, _ := GetUvarint(buf)
+		decoded, _ := getUvarint(buf)
 		if decoded != c.val {
 			t.Errorf("decoded value mismatch: expected %v, got %v", c.val, decoded)
 		}
@@ -90,12 +90,12 @@ func TestVarintOrdering(t *testing.T) {
 		val := uint64(rand.Uint32())<<32 + uint64(rand.Uint32())
 		ints[i] = val
 		varints[i] = make([]byte, maxVarintSize)
-		PutUvarint(varints[i], val)
+		putUvarint(varints[i], val)
 	}
 	sort.Sort(ints)
 	sort.Sort(varints)
 	for i := range ints {
-		decoded, _ := GetUvarint(varints[i])
+		decoded, _ := getUvarint(varints[i])
 		if decoded != ints[i] {
 			t.Errorf("mismatched ordering at index %d: expected: %d, got %d [seed: %d]", i, ints[i], decoded, seed)
 		}


### PR DESCRIPTION
These varint encodings are different than the standard lib varint
encodings in encodings/varint. They are not used outside of the
util/encoding package, so don't export them.
