### PR TITLE
Move depvers stuff into a bash script.

### DIFF
--- a/build/depvers.sh
+++ b/build/depvers.sh
@@ -1,0 +1,64 @@
+#!/bin/bash
+#
+# Output the revision control version information (git/hg SHA) for the
+# current directory's dependencies. If multiple packages are contained
+# within the same git/hg repo we only output the top-level repo and
+# SHA once.
+#
+# The output is sorted by package name:
+#   <package-repo-root>:<sha>
+
+dirs=()
+function visit() {
+    local dir="$1"
+    for dir in "${dirs[@]}"; do
+	if test "${dir}" = "${toplevel}"; then
+	    return 0
+	fi
+    done
+    dirs+=("${toplevel}")
+    return 1
+}
+
+# List the current package and all of the dependencies which are not
+# part of the standard library (i.e. packages that contain a least one
+# dot in the first component of their name).
+pkgs=$(go list -f '{{printf "%s\n" .ImportPath}}{{range .Deps}}{{printf "%s\n" .}}{{end}}' . 2>/dev/null | \
+	      sort -u | egrep '[^/]+\.[^/]+/')
+
+# For each package, list the package directory and package root.
+pkginfo=($(go list -f '{{.Dir}} {{.Root}}' ${pkgs} 2>/dev/null))
+
+# Loop over the package info which comes in pairs in the pkginfo
+# array.
+for (( i=0; i < ${#pkginfo[@]}; i+=2 )); do
+    dir=${pkginfo[$i]}
+    if ! test -d "${dir}"; then
+	continue
+    fi
+
+    toplevel=$(git -C "${dir}" rev-parse --show-toplevel 2>/dev/null)
+
+    git=1
+    if test "${toplevel}" = ""; then
+	toplevel=$(hg --cwd "${dir}" root 2>/dev/null)
+	if test "${toplevel}" = ""; then
+	    # TODO(pmattis): Handle subversion/bazaar.
+	    continue
+	fi
+	git=0
+    fi
+
+    if visit "${toplevel}"; then
+	continue
+    fi
+
+    if test "${git}" -eq 1; then
+	vers=$(git -C "${dir}" rev-parse HEAD 2>/dev/null )
+    else
+	vers=$(hg --cwd "${dir}" parent --template '{node}')
+    fi
+
+    root=${pkginfo[$i+1]}
+    echo ${toplevel#$root/src/}:${vers}
+done

--- a/main.go
+++ b/main.go
@@ -91,7 +91,7 @@ Output build version information.
 					info := util.GetBuildInfo()
 					w := &tabwriter.Writer{}
 					w.Init(os.Stdout, 2, 1, 2, ' ', 0)
-					fmt.Fprintf(w, "Build SHA:   %s\n", info.SHA)
+					fmt.Fprintf(w, "Build Vers:  %s\n", info.Vers)
 					fmt.Fprintf(w, "Build Tag:   %s\n", info.Tag)
 					fmt.Fprintf(w, "Build Time:  %s\n", info.Time)
 					fmt.Fprintf(w, "Build Deps:\n\t%s\n",

--- a/server/cli/start.go
+++ b/server/cli/start.go
@@ -132,7 +132,7 @@ var CmdStart = &commander.Command{
 // cluster via the gossip network.
 func runStart(cmd *commander.Command, args []string) {
 	info := util.GetBuildInfo()
-	log.Infof("Build SHA:  %s", info.SHA)
+	log.Infof("Build Vers: %s", info.Vers)
 	log.Infof("Build Tag:  %s", info.Tag)
 	log.Infof("Build Time: %s", info.Time)
 	log.Infof("Build Deps: %s", info.Deps)

--- a/util/build.go
+++ b/util/build.go
@@ -17,10 +17,12 @@
 
 package util
 
+import "runtime"
+
 var (
 	// These variables are initialized via the linker -X flag in the
 	// top-level Makefile when compiling release binaries.
-	buildSHA  string // Git SHA
+	buildVers string // Go Version
 	buildTag  string // Tag of this build (git describe)
 	buildTime string // Build time in UTC (year/month/day hour:min:sec)
 	buildDeps string // Git SHAs of dependencies
@@ -28,7 +30,7 @@ var (
 
 // BuildInfo ...
 type BuildInfo struct {
-	SHA  string
+	Vers string
 	Tag  string
 	Time string
 	Deps string
@@ -37,7 +39,7 @@ type BuildInfo struct {
 // GetBuildInfo ...
 func GetBuildInfo() BuildInfo {
 	return BuildInfo{
-		SHA:  buildSHA,
+		Vers: runtime.Version(),
 		Tag:  buildTag,
 		Time: buildTime,
 		Deps: buildDeps,


### PR DESCRIPTION
Add support for outputting version info from mercurial repositories and
for only outputting version info for a given repository once even if it
contains multiple packages.
