### PR TITLE
Bounce rocksdb log messages to the Go logging routines.

### DIFF
--- a/storage/engine/db.h
+++ b/storage/engine/db.h
@@ -18,6 +18,7 @@
 #ifndef ROACHLIB_DB_H
 #define ROACHLIB_DB_H
 
+#include <stdbool.h>
 #include <stdint.h>
 
 #ifdef __cplusplus
@@ -47,14 +48,11 @@ typedef struct DBEngine DBEngine;
 typedef struct DBIterator DBIterator;
 typedef struct DBSnapshot DBSnapshot;
 
-typedef void (*DBLoggerFunc)(void* state, const char* str, int len);
-
 // DBOptions contains local database options.
 typedef struct {
   int64_t cache_size;
   int allow_os_buffer;
-  // A function pointer to direct log messages to.
-  DBLoggerFunc logger;
+  bool logging_enabled;
 } DBOptions;
 
 // Opens the database located in "dir", creating it if it doesn't

--- a/storage/engine/rocksdb.go
+++ b/storage/engine/rocksdb.go
@@ -69,7 +69,7 @@ func (r *RocksDB) Start() error {
 		C.DBOptions{
 			cache_size:      C.int64_t(r.cacheSize),
 			allow_os_buffer: C.int(1),
-			logger:          C.DBLoggerFunc(nil),
+			logging_enabled: C.bool(log.V(1)),
 		})
 	err := statusToError(status)
 	if err != nil {
@@ -513,4 +513,11 @@ func (r *rocksDBIterator) Value() []byte {
 
 func (r *rocksDBIterator) Error() error {
 	return statusToError(C.DBIterError(r.iter))
+}
+
+//export rocksDBLog
+func rocksDBLog(s *C.char, n C.int) {
+	// Note that rocksdb logging is only enabled if log.V(1) is true
+	// when RocksDB.Start() is called.
+	log.Infof("%s", C.GoStringN(s, n))
 }


### PR DESCRIPTION
Only enable rocksdb logging if log.V(1) is true when RocksDB.Start() is
called.
