### PR TITLE
Install race enabled versions of packages as well.

### DIFF
--- a/build/devbase/godeps.sh
+++ b/build/devbase/godeps.sh
@@ -13,19 +13,24 @@
 # an absolute path.
 export GOPATH=$(cd $(dirname $0)/../../../../../.. && pwd)
 
-set -ex
-
 # NOTE: Use "make godeps" to update this list. We can't just use "go
 # list" here because this script is run during docker container builds
 # before the cockroach code is present.
-go get -u \
-   code.google.com/p/biogo.store/interval \
-   code.google.com/p/biogo.store/llrb  \
-   code.google.com/p/go-commander \
-   code.google.com/p/go-uuid/uuid \
-   code.google.com/p/snappy-go/snappy \
-   github.com/cockroachdb/c-protobuf \
-   github.com/cockroachdb/c-rocksdb \
-   github.com/gogo/protobuf/proto \
-   github.com/golang/glog \
-   gopkg.in/yaml.v1
+pkgs="code.google.com/p/biogo.store/interval
+      code.google.com/p/biogo.store/llrb
+      code.google.com/p/go-commander
+      code.google.com/p/go-uuid/uuid
+      code.google.com/p/snappy-go/snappy
+      github.com/cockroachdb/c-protobuf
+      github.com/cockroachdb/c-rocksdb
+      github.com/gogo/protobuf/proto
+      github.com/golang/glog
+      gopkg.in/yaml.v1"
+
+set -ex
+
+# NOTE: "go get" does a "go install" for the listed packages. We also
+# explicitly "go install -race" in order to cache race builds of these
+# packages.
+go get -u ${pkgs}
+go install -race ${pkgs}


### PR DESCRIPTION
This will dramatically speed up the "testrace" portion of circle-ci
builds which are currently rebuilding all of the dependencies for every
test run.
