### PR TITLE
Split ScanQueue into GCQueue and VerifyQueue.

### DIFF
--- a/proto/data.go
+++ b/proto/data.go
@@ -479,11 +479,11 @@ func (mvcc *MVCCMetadata) IsInline() bool {
 	return mvcc.Value != nil
 }
 
-// NewScanMetadata returns a ScanMetadata with GCMetadata initialized
+// NewGCMetadata returns a GCMetadata with GCMetadata initialized
 // to have a ByteCounts slice with ten byte count values set to zero.
 // Now is specified as nanoseconds since the Unix epoch.
-func NewScanMetadata(nowNanos int64) *ScanMetadata {
-	return &ScanMetadata{
+func NewGCMetadata(nowNanos int64) *GCMetadata {
+	return &GCMetadata{
 		LastScanNanos:     nowNanos,
 		OldestIntentNanos: gogoproto.Int64(nowNanos),
 	}

--- a/proto/data.go
+++ b/proto/data.go
@@ -479,9 +479,9 @@ func (mvcc *MVCCMetadata) IsInline() bool {
 	return mvcc.Value != nil
 }
 
-// NewGCMetadata returns a GCMetadata with GCMetadata initialized
-// to have a ByteCounts slice with ten byte count values set to zero.
-// Now is specified as nanoseconds since the Unix epoch.
+// NewGCMetadata returns a GCMetadata initialized to have a ByteCounts
+// slice with ten byte count values set to zero.  Now is specified as
+// nanoseconds since the Unix epoch.
 func NewGCMetadata(nowNanos int64) *GCMetadata {
 	return &GCMetadata{
 		LastScanNanos:     nowNanos,

--- a/proto/data.pb.go
+++ b/proto/data.pb.go
@@ -564,10 +564,10 @@ func (m *MVCCMetadata) GetValue() *Value {
 	return nil
 }
 
-// ScanMetadata holds information about last complete key/value scan
-// of a range.
-type ScanMetadata struct {
-	// The last scan timestamp in nanoseconds since the Unix epoch.
+// GCMetadata holds information about last complete key/value garbage
+// collection scan of a range.
+type GCMetadata struct {
+	// The last GC scan timestamp in nanoseconds since the Unix epoch.
 	LastScanNanos int64 `protobuf:"varint,1,opt,name=last_scan_nanos" json:"last_scan_nanos"`
 	// The oldest unresolved write intent in nanoseconds since epoch.
 	// Null if there are no unresolved write intents.
@@ -575,18 +575,18 @@ type ScanMetadata struct {
 	XXX_unrecognized  []byte `json:"-"`
 }
 
-func (m *ScanMetadata) Reset()         { *m = ScanMetadata{} }
-func (m *ScanMetadata) String() string { return proto1.CompactTextString(m) }
-func (*ScanMetadata) ProtoMessage()    {}
+func (m *GCMetadata) Reset()         { *m = GCMetadata{} }
+func (m *GCMetadata) String() string { return proto1.CompactTextString(m) }
+func (*GCMetadata) ProtoMessage()    {}
 
-func (m *ScanMetadata) GetLastScanNanos() int64 {
+func (m *GCMetadata) GetLastScanNanos() int64 {
 	if m != nil {
 		return m.LastScanNanos
 	}
 	return 0
 }
 
-func (m *ScanMetadata) GetOldestIntentNanos() int64 {
+func (m *GCMetadata) GetOldestIntentNanos() int64 {
 	if m != nil && m.OldestIntentNanos != nil {
 		return *m.OldestIntentNanos
 	}

--- a/proto/data.proto
+++ b/proto/data.proto
@@ -231,8 +231,8 @@ message MVCCMetadata {
   optional Value value = 6;
 }
 
-// GCMetadata holds information about last complete key/value garbage
-// collection scan of a range.
+// GCMetadata holds information about the last complete key/value
+// garbage collection scan of a range.
 message GCMetadata {
   // The last GC scan timestamp in nanoseconds since the Unix epoch.
   optional int64 last_scan_nanos = 1 [(gogoproto.nullable) = false];

--- a/proto/data.proto
+++ b/proto/data.proto
@@ -231,10 +231,10 @@ message MVCCMetadata {
   optional Value value = 6;
 }
 
-// ScanMetadata holds information about last complete key/value scan
-// of a range.
-message ScanMetadata {
-  // The last scan timestamp in nanoseconds since the Unix epoch.
+// GCMetadata holds information about last complete key/value garbage
+// collection scan of a range.
+message GCMetadata {
+  // The last GC scan timestamp in nanoseconds since the Unix epoch.
   optional int64 last_scan_nanos = 1 [(gogoproto.nullable) = false];
   // The oldest unresolved write intent in nanoseconds since epoch.
   // Null if there are no unresolved write intents.

--- a/proto/internal.pb.go
+++ b/proto/internal.pb.go
@@ -162,7 +162,7 @@ func (*InternalHeartbeatTxnResponse) ProtoMessage()    {}
 // MVCC values.
 type InternalGCRequest struct {
 	RequestHeader    `protobuf:"bytes,1,opt,name=header,embedded=header" json:"header"`
-	ScanMeta         ScanMetadata              `protobuf:"bytes,2,opt,name=scan_meta" json:"scan_meta"`
+	GCMeta           GCMetadata                `protobuf:"bytes,2,opt,name=gc_meta" json:"gc_meta"`
 	Keys             []InternalGCRequest_GCKey `protobuf:"bytes,3,rep,name=keys" json:"keys"`
 	XXX_unrecognized []byte                    `json:"-"`
 }
@@ -171,11 +171,11 @@ func (m *InternalGCRequest) Reset()         { *m = InternalGCRequest{} }
 func (m *InternalGCRequest) String() string { return proto1.CompactTextString(m) }
 func (*InternalGCRequest) ProtoMessage()    {}
 
-func (m *InternalGCRequest) GetScanMeta() ScanMetadata {
+func (m *InternalGCRequest) GetGCMeta() GCMetadata {
 	if m != nil {
-		return m.ScanMeta
+		return m.GCMeta
 	}
-	return ScanMetadata{}
+	return GCMetadata{}
 }
 
 func (m *InternalGCRequest) GetKeys() []InternalGCRequest_GCKey {

--- a/proto/internal.proto
+++ b/proto/internal.proto
@@ -66,7 +66,7 @@ message InternalHeartbeatTxnResponse {
 // MVCC values.
 message InternalGCRequest {
   optional RequestHeader header = 1 [(gogoproto.nullable) = false, (gogoproto.embed) = true];
-  optional ScanMetadata scan_meta = 2 [(gogoproto.nullable) = false];
+  optional GCMetadata gc_meta = 2 [(gogoproto.nullable) = false, (gogoproto.customname) = "GCMeta"];
 
   message GCKey {
     optional bytes key = 1 [(gogoproto.nullable) = false, (gogoproto.customtype) = "Key"];

--- a/storage/engine/keys.go
+++ b/storage/engine/keys.go
@@ -133,10 +133,16 @@ func DecodeRangeKey(key proto.Key) (startKey, suffix, detail proto.Key) {
 	return
 }
 
-// RangeScanMetadataKey returns a range-local key for range scan
-// metadata.
-func RangeScanMetadataKey(key proto.Key) proto.Key {
-	return MakeRangeKey(key, KeyLocalRangeScanMetadataSuffix, proto.Key{})
+// RangeGCMetadataKey returns a range-local key for range garbage
+// collection metadata.
+func RangeGCMetadataKey(raftID int64) proto.Key {
+	return MakeRangeIDKey(raftID, KeyLocalRangeGCMetadataSuffix, proto.Key{})
+}
+
+// RangeLastVerificationTimestampKey returns a range-local key for
+// the range's last verification timestamp.
+func RangeLastVerificationTimestampKey(raftID int64) proto.Key {
+	return MakeRangeIDKey(raftID, KeyLocalRangeLastVerificationTimestampSuffix, proto.Key{})
 }
 
 // RangeDescriptorKey returns a range-local key for the descriptor
@@ -339,6 +345,11 @@ var (
 	KeyLocalRaftLogSuffix = proto.Key("rftl")
 	// KeyLocalRaftStateSuffix is the Suffix for the raft HardState.
 	KeyLocalRaftStateSuffix = proto.Key("rfts")
+	// KeyLocalRangeGCMetadataSuffix is the suffix for a range's GC metadata.
+	KeyLocalRangeGCMetadataSuffix = proto.Key("rgcm")
+	// KeyLocalRangeLastVerificationTimestampSuffix is the suffix for a range's
+	// last verification timestamp (for checking integrity of on-disk data).
+	KeyLocalRangeLastVerificationTimestampSuffix = proto.Key("rlvt")
 	// KeyLocalRangeStatSuffix is the suffix for range statistics.
 	KeyLocalRangeStatSuffix = proto.Key("rst-")
 	// KeyLocalResponseCacheSuffix is the suffix for keys storing
@@ -359,8 +370,6 @@ var (
 	// KeyLocalRangeDescriptorSuffix is the suffix for keys storing
 	// range descriptors. The value is a struct of type RangeDescriptor.
 	KeyLocalRangeDescriptorSuffix = proto.Key("rdsc")
-	// KeyLocalRangeScanMetadataSuffix is the suffix for a range's scan metadata.
-	KeyLocalRangeScanMetadataSuffix = proto.Key("rscm")
 	// KeyLocalTransactionSuffix specifies the key suffix for
 	// transaction records. The additional detail is the transaction id.
 	// NOTE: if this value changes, it must be updated in C++

--- a/storage/engine/keys_test.go
+++ b/storage/engine/keys_test.go
@@ -57,7 +57,6 @@ func TestKeyAddress(t *testing.T) {
 		{proto.Key("123"), proto.Key("123")},
 		{MakeKey(KeyConfigAccountingPrefix, proto.Key("foo")), proto.Key("\x00acctfoo")},
 		{RangeDescriptorKey(proto.Key("foo")), proto.Key("foo")},
-		{RangeScanMetadataKey(proto.Key("bar")), proto.Key("bar")},
 		{TransactionKey(proto.Key("baz"), proto.Key(uuid.New())), proto.Key("baz")},
 		{TransactionKey(KeyMax, proto.Key(uuid.New())), KeyMax},
 	}

--- a/storage/engine/mvcc.go
+++ b/storage/engine/mvcc.go
@@ -82,6 +82,21 @@ func (ms *MVCCStats) SetStats(engine Engine, raftID int64) {
 	MVCCSetRangeStat(engine, raftID, StatLastUpdateNanos, ms.LastUpdateNanos)
 }
 
+// Accumulate adds values from oms to ms.
+func (ms *MVCCStats) Accumulate(oms MVCCStats) {
+	ms.LiveBytes += oms.LiveBytes
+	ms.KeyBytes += oms.KeyBytes
+	ms.ValBytes += oms.ValBytes
+	ms.IntentBytes += oms.IntentBytes
+	ms.LiveCount += oms.LiveCount
+	ms.KeyCount += oms.KeyCount
+	ms.ValCount += oms.ValCount
+	ms.IntentCount += oms.IntentCount
+	ms.IntentAge += oms.IntentAge
+	ms.GCBytesAge += oms.GCBytesAge
+	ms.LastUpdateNanos += oms.LastUpdateNanos
+}
+
 // updateStatsForKey returns whether or not the bytes and counts for
 // the specified key should be tracked. Local keys are excluded.
 func (ms *MVCCStats) updateStatsForKey(key proto.Key) bool {

--- a/storage/gc_queue.go
+++ b/storage/gc_queue.go
@@ -223,7 +223,6 @@ func (gcq *gcQueue) process(now proto.Timestamp, rng *Range) error {
 
 	// Store current timestamp as last verification for this range, as
 	// we've just successfully scanned.
-	// TODO(spencer): TEST THIS BEFORE CHECKIN.
 	if err := rng.SetLastVerificationTimestamp(now); err != nil {
 		log.Errorf("failed to set last verification timestamp for range %s: %s", rng, err)
 	}

--- a/storage/queue.go
+++ b/storage/queue.go
@@ -19,8 +19,12 @@ package storage
 
 import (
 	"container/heap"
+	"sync"
+	"time"
 
 	"github.com/cockroachdb/cockroach/proto"
+	"github.com/cockroachdb/cockroach/util"
+	"github.com/cockroachdb/cockroach/util/hlc"
 	"github.com/cockroachdb/cockroach/util/log"
 )
 
@@ -69,26 +73,34 @@ func (pq *priorityQueue) update(item *rangeItem, priority float64) {
 	heap.Fix(pq, item.index)
 }
 
-// shouldQueue accepts current time and a Range and returns whether it
-// should be queued and if so, at what priority.
+// shouldQueueFn accepts current time and a Range and returns whether
+// it should be queued and if so, at what priority.
 type shouldQueueFn func(proto.Timestamp, *Range) (shouldQueue bool, priority float64)
 
 // processFn accepts current time and a range and executes
 // queue-specific work on it.
 type processFn func(proto.Timestamp, *Range) error
 
+// timerFn returns a duration to wait between processing the next item
+// from the queue.
+type timerFn func() time.Duration
+
 // baseQueue is the base implementation of the rangeQueue interface.
 // Queue implementations should embed a baseQueue and provide it
 // with shouldQueueFn.
 //
-// baseQueue is not thread safe.
+// baseQueue is not thread safe and is intended for usage only from
+// the scanner's goroutine.
 type baseQueue struct {
-	name      string
-	shouldQ   shouldQueueFn        // Should a range be queued?
-	process   processFn            // Executes queue-specific work on range
-	maxSize   int                  // Maximum number of ranges to queue
-	priorityQ priorityQueue        // The priority queue
-	ranges    map[int64]*rangeItem // Map from RaftID to rangeItem (for updating priority)
+	name       string
+	shouldQ    shouldQueueFn        // Should a range be queued?
+	process    processFn            // Executes queue-specific work on range
+	timer      timerFn              // Returns duration for queue processing
+	maxSize    int                  // Maximum number of ranges to queue
+	incoming   chan *Range          // Channel for ranges to be queued
+	sync.Mutex                      // Mutex protects priorityQ and ranges
+	priorityQ  priorityQueue        // The priority queue
+	ranges     map[int64]*rangeItem // Map from RaftID to rangeItem (for updating priority)
 }
 
 // newBaseQueue returns a new instance of baseQueue with the
@@ -97,43 +109,39 @@ type baseQueue struct {
 // maxSize doesn't prevent new ranges from being added, it just
 // limits the total size. Higher priority ranges can still be
 // added; their addition simply removes the lowest priority range.
-func newBaseQueue(name string, shouldQ shouldQueueFn, process processFn, maxSize int) *baseQueue {
+func newBaseQueue(name string, shouldQ shouldQueueFn, process processFn, timer timerFn, maxSize int) *baseQueue {
 	return &baseQueue{
-		name:    name,
-		shouldQ: shouldQ,
-		process: process,
-		maxSize: maxSize,
-		ranges:  map[int64]*rangeItem{},
+		name:     name,
+		shouldQ:  shouldQ,
+		process:  process,
+		timer:    timer,
+		maxSize:  maxSize,
+		incoming: make(chan *Range, 10),
+		ranges:   map[int64]*rangeItem{},
 	}
 }
 
 // Length returns the current size of the queue.
 func (bq *baseQueue) Length() int {
+	bq.Lock()
+	defer bq.Unlock()
 	return bq.priorityQ.Len()
 }
 
-// Pop dequeues and processes the highest priority range in the queue.
-// Returns the range if not empty; otherwise, returns nil.
-func (bq *baseQueue) Pop(now proto.Timestamp) *Range {
-	if bq.priorityQ.Len() == 0 {
-		return nil
-	}
-	item := heap.Pop(&bq.priorityQ).(*rangeItem)
-	delete(bq.ranges, item.value.Desc.RaftID)
-	log.Infof("processing range %d from %s queue with priority %f...",
-		item.value.Desc.RaftID, bq.name, item.priority)
-	if err := bq.process(now, item.value); err != nil {
-		log.Errorf("failure processing range %d from %s queue: %s",
-			item.value.Desc.RaftID, bq.name, err)
-	}
-	return item.value
+// Start launches a goroutine to process entries in the queue. The
+// provided stopper is used to finish processing.
+func (bq *baseQueue) Start(clock *hlc.Clock, stopper *util.Stopper) {
+	stopper.Add(1)
+	go bq.processLoop(clock, stopper)
 }
 
 // MaybeAdd adds the specified range if bq.shouldQ specifies it should
 // be queued. Ranges are added to the queue using the priority
 // returned by bq.shouldQ. If the queue is too full, an already-queued
 // range with the lowest priority may be dropped.
-func (bq *baseQueue) MaybeAdd(now proto.Timestamp, rng *Range) {
+func (bq *baseQueue) MaybeAdd(rng *Range, now proto.Timestamp) {
+	bq.Lock()
+	defer bq.Unlock()
 	should, priority := bq.shouldQ(now, rng)
 	item, ok := bq.ranges[rng.Desc.RaftID]
 	if !should {
@@ -146,6 +154,8 @@ func (bq *baseQueue) MaybeAdd(now proto.Timestamp, rng *Range) {
 		bq.priorityQ.update(item, priority)
 		return
 	}
+
+	log.Infof("adding range %s from %s queue", rng, bq.name)
 	item = &rangeItem{value: rng, priority: priority}
 	heap.Push(&bq.priorityQ, item)
 	bq.ranges[rng.Desc.RaftID] = item
@@ -155,21 +165,84 @@ func (bq *baseQueue) MaybeAdd(now proto.Timestamp, rng *Range) {
 	if pqLen := bq.priorityQ.Len(); pqLen > bq.maxSize {
 		bq.remove(pqLen - 1)
 	}
+	// Signal the processLoop that a range has been added.
+	bq.incoming <- rng
 }
 
 // MaybeRemove removes the specified range from the queue if enqueued.
 func (bq *baseQueue) MaybeRemove(rng *Range) {
+	bq.Lock()
+	defer bq.Unlock()
 	if item, ok := bq.ranges[rng.Desc.RaftID]; ok {
+		log.Infof("removing range %s from %s queue", item.value, bq.name)
 		bq.remove(item.index)
 	}
 }
 
-// Clear removes all ranges from the queue.
-func (bq *baseQueue) Clear() {
-	bq.ranges = map[int64]*rangeItem{}
-	bq.priorityQ = nil
+// process processes the entries in the queue until the provided
+// stopper signals exit.
+//
+// TODO(spencer): current load should factor into range processing timer.
+func (bq *baseQueue) processLoop(clock *hlc.Clock, stopper *util.Stopper) {
+	// nextTime is set arbitrarily far into the future so that we don't
+	// unecessarily check for a range to dequeue if the timer function
+	// returns a short duration but the priority queue is empty.
+	emptyQueue := true
+	nextTime := time.Now().Add(24 * time.Hour)
+
+	for {
+		select {
+		// Incoming ranges set the next time to process in the event that
+		// there were previously no ranges in the queue.
+		case <-bq.incoming:
+			if emptyQueue {
+				emptyQueue = false
+				nextTime = time.Now().Add(bq.timer())
+			}
+		// Process ranges as the timer expires.
+		case <-time.After(nextTime.Sub(time.Now())):
+			start := time.Now()
+			nextTime = start.Add(bq.timer())
+			bq.Lock()
+			rng := bq.pop()
+			bq.Unlock()
+			if rng != nil {
+				log.Infof("processing range %s from %s queue...", rng, bq.name)
+				if err := bq.process(clock.Now(), rng); err != nil {
+					log.Errorf("failure processing range %s from %s queue: %s", rng, bq.name, err)
+				}
+				log.Infof("processed range %s from %s queue in %s", rng, bq.name, time.Now().Sub(start))
+			}
+			if bq.Length() == 0 {
+				emptyQueue = true
+				nextTime = time.Now().Add(24 * time.Hour)
+			}
+		// Exit on stopper.
+		case <-stopper.ShouldStop():
+			stopper.SetStopped()
+			bq.Lock()
+			bq.Unlock()
+			bq.ranges = map[int64]*rangeItem{}
+			bq.priorityQ = nil
+			return
+		}
+	}
 }
 
+// pop dequeues the highest priority range in the queue. Returns the
+// range if not empty; otherwise, returns nil. Expects mutex to be
+// locked.
+func (bq *baseQueue) pop() *Range {
+	if bq.priorityQ.Len() == 0 {
+		return nil
+	}
+	item := heap.Pop(&bq.priorityQ).(*rangeItem)
+	delete(bq.ranges, item.value.Desc.RaftID)
+	return item.value
+}
+
+// remove removes an element from teh priority queue by index. Expects
+// mutex to be locked.
 func (bq *baseQueue) remove(index int) {
 	item := heap.Remove(&bq.priorityQ, index).(*rangeItem)
 	delete(bq.ranges, item.value.Desc.RaftID)

--- a/storage/queue.go
+++ b/storage/queue.go
@@ -241,7 +241,7 @@ func (bq *baseQueue) pop() *Range {
 	return item.value
 }
 
-// remove removes an element from teh priority queue by index. Expects
+// remove removes an element from the priority queue by index. Expects
 // mutex to be locked.
 func (bq *baseQueue) remove(index int) {
 	item := heap.Remove(&bq.priorityQ, index).(*rangeItem)

--- a/storage/range_data_iter_test.go
+++ b/storage/range_data_iter_test.go
@@ -39,10 +39,11 @@ func createRangeData(r *Range, t *testing.T) []proto.EncodedKey {
 		{engine.RaftLogKey(r.Desc.RaftID, 2), ts0},
 		{engine.RaftLogKey(r.Desc.RaftID, 1), ts0},
 		{engine.RaftStateKey(r.Desc.RaftID), ts0},
+		{engine.RangeGCMetadataKey(r.Desc.RaftID), ts0},
+		{engine.RangeLastVerificationTimestampKey(r.Desc.RaftID), ts0},
 		{engine.RangeStatKey(r.Desc.RaftID, engine.StatKeyBytes), ts0},
 		{engine.RangeStatKey(r.Desc.RaftID, engine.StatKeyCount), ts0},
 		{engine.RangeDescriptorKey(r.Desc.StartKey), ts},
-		{engine.RangeScanMetadataKey(r.Desc.StartKey), ts0},
 		{engine.TransactionKey(r.Desc.StartKey, []byte("1234")), ts0},
 		{engine.TransactionKey(r.Desc.StartKey.Next(), []byte("5678")), ts0},
 		{engine.TransactionKey(r.Desc.EndKey.Prev(), []byte("2468")), ts0},
@@ -139,7 +140,7 @@ func TestRangeDataIterator(t *testing.T) {
 		if key := iter.Key(); !key.Equal(keys[i]) {
 			k1, ts1, _ := engine.MVCCDecodeKey(key)
 			k2, ts2, _ := engine.MVCCDecodeKey(keys[i])
-			t.Errorf("%d: key mismatch %q(%d) != %q(%d)", i, k1, ts1, k2, ts2)
+			t.Errorf("%d: expected %q(%d); got %q(%d)", i, k2, ts2, k1, ts1)
 		}
 		i++
 	}

--- a/storage/scanner_test.go
+++ b/storage/scanner_test.go
@@ -22,7 +22,9 @@ import (
 	"testing"
 	"time"
 
+	"github.com/cockroachdb/cockroach/storage/engine"
 	"github.com/cockroachdb/cockroach/util"
+	"github.com/cockroachdb/cockroach/util/hlc"
 	"github.com/cockroachdb/cockroach/util/log"
 )
 
@@ -42,6 +44,18 @@ func newTestIterator(count int) *testIterator {
 		start: time.Now(),
 	}
 	ti.ranges = make([]Range, count)
+	// Initialize range stats for each range so the scanner can use them.
+	for i := range ti.ranges {
+		ti.ranges[i].stats = &rangeStats{
+			raftID: int64(i),
+			MVCCStats: engine.MVCCStats{
+				KeyBytes:  1,
+				ValBytes:  2,
+				KeyCount:  1,
+				LiveCount: 1,
+			},
+		}
+	}
 	return ti
 }
 
@@ -90,19 +104,31 @@ func (ti *testIterator) avgScan() time.Duration {
 // Test implementation of a range queue which adds range to an
 // internal slice.
 type testQueue struct {
-	ranges []*Range
-	sync.Mutex
+	sync.Mutex // Protects ranges, done & processed count
+	ranges     []*Range
+	done       bool
+	processed  int
 }
 
-func (tq *testQueue) Next() *Range {
-	tq.Lock()
-	defer tq.Unlock()
-	if len(tq.ranges) == 0 {
-		return nil
-	}
-	rng := tq.ranges[0]
-	tq.ranges = tq.ranges[1:]
-	return rng
+func (tq *testQueue) Start(clock *hlc.Clock, stopper *util.Stopper) {
+	stopper.Add(1)
+	go func() {
+		for {
+			select {
+			case <-time.After(1 * time.Millisecond):
+				tq.Lock()
+				if len(tq.ranges) > 0 {
+					tq.ranges = tq.ranges[1:]
+					tq.processed++
+				}
+				tq.Unlock()
+			case <-stopper.ShouldStop():
+				stopper.SetStopped()
+				tq.done = true
+				return
+			}
+		}
+	}()
 }
 
 func (tq *testQueue) MaybeAdd(rng *Range) {
@@ -121,12 +147,6 @@ func (tq *testQueue) MaybeRemove(rng *Range) {
 	}
 }
 
-func (tq *testQueue) Clear() {
-	tq.Lock()
-	defer tq.Unlock()
-	tq.ranges = []*Range(nil)
-}
-
 func (tq *testQueue) count() int {
 	tq.Lock()
 	defer tq.Unlock()
@@ -142,6 +162,12 @@ func (tq *testQueue) indexOf(rng *Range) int {
 	return -1
 }
 
+func (tq *testQueue) isDone() bool {
+	tq.Lock()
+	defer tq.Unlock()
+	return tq.done
+}
+
 // TestScannerAddToQueues verifies that ranges are added to and
 // removed from multiple queues.
 func TestScannerAddToQueues(t *testing.T) {
@@ -149,9 +175,11 @@ func TestScannerAddToQueues(t *testing.T) {
 	iter := newTestIterator(count)
 	q1, q2 := &testQueue{}, &testQueue{}
 	s := newRangeScanner(1*time.Millisecond, iter, []rangeQueue{q1, q2})
+	mc := hlc.NewManualClock(0)
+	clock := hlc.NewClock(mc.UnixNano)
 
 	// Start queue and verify that all ranges are added to both queues.
-	s.Start()
+	s.Start(clock)
 	if err := util.IsTrueWithin(func() bool {
 		return q1.count() == count && q2.count() == count
 	}, 10*time.Millisecond); err != nil {
@@ -167,10 +195,10 @@ func TestScannerAddToQueues(t *testing.T) {
 		t.Error(err)
 	}
 
-	// Stop queue and verify all ranges are removed from both queues.
+	// Stop scanner and verify both queues are stopped.
 	s.Stop()
-	if len(q1.ranges) != 0 || len(q2.ranges) != 0 {
-		t.Errorf("expected all ranges to have been removed on stop; got %d, %d", len(q1.ranges), len(q2.ranges))
+	if !q1.isDone() || !q2.isDone() {
+		t.Errorf("expected all queues to stop; got %t, %t", q1.isDone(), q2.isDone())
 	}
 }
 
@@ -192,7 +220,9 @@ func TestScannerTiming(t *testing.T) {
 		iter := newTestIterator(count)
 		q := &testQueue{}
 		s := newRangeScanner(duration, iter, []rangeQueue{q})
-		s.Start()
+		mc := hlc.NewManualClock(0)
+		clock := hlc.NewClock(mc.UnixNano)
+		s.Start(clock)
 		time.Sleep(runTime)
 		s.Stop()
 
@@ -205,15 +235,48 @@ func TestScannerTiming(t *testing.T) {
 	}
 }
 
-// Verify that an empty iterator doesn't busy loop.
+// TestScannerEmptyIterator verifies that an empty iterator doesn't busy loop.
 func TestScannerEmptyIterator(t *testing.T) {
 	iter := newTestIterator(0)
 	q := &testQueue{}
 	s := newRangeScanner(1*time.Millisecond, iter, []rangeQueue{q})
-	s.Start()
+	mc := hlc.NewManualClock(0)
+	clock := hlc.NewClock(mc.UnixNano)
+	s.Start(clock)
 	time.Sleep(3 * time.Millisecond)
 	s.Stop()
 	if count := s.Count(); count > 3 {
 		t.Errorf("expected three loops; got %d", count)
 	}
+}
+
+// TestScannerStats verifies that stats accumulate from all ranges.
+func TestScannerStats(t *testing.T) {
+	const count = 3
+	iter := newTestIterator(count)
+	q := &testQueue{}
+	s := newRangeScanner(1*time.Millisecond, iter, []rangeQueue{q})
+	mc := hlc.NewManualClock(0)
+	clock := hlc.NewClock(mc.UnixNano)
+	// At start, scanner stats should be blank for MVCC, but have accurate number of ranges.
+	if rc := s.Stats().RangeCount; rc != count {
+		t.Errorf("range count expected %d; got %d", count, rc)
+	}
+	if vb := s.Stats().MVCC.ValBytes; vb != 0 {
+		t.Errorf("value bytes expected %d; got %d", 0, vb)
+	}
+	s.Start(clock)
+	// We expect a full run to accumulate stats from all ranges.
+	if err := util.IsTrueWithin(func() bool {
+		if rc := s.Stats().RangeCount; rc != count {
+			return false
+		}
+		if vb := s.Stats().MVCC.ValBytes; vb != count*2 {
+			return false
+		}
+		return true
+	}, 100*time.Millisecond); err != nil {
+		t.Error(err)
+	}
+	s.Stop()
 }

--- a/storage/store.go
+++ b/storage/store.go
@@ -555,9 +555,13 @@ func (s *Store) BootstrapRange() error {
 	if err := engine.MVCCPutProto(batch, ms, engine.RangeDescriptorKey(desc.StartKey), now, nil, desc); err != nil {
 		return err
 	}
-	// Scan Metadata.
-	scanMeta := proto.NewScanMetadata(now.WallTime)
-	if err := engine.MVCCPutProto(batch, ms, engine.RangeScanMetadataKey(desc.StartKey), proto.ZeroTimestamp, nil, scanMeta); err != nil {
+	// GC Metadata.
+	gcMeta := proto.NewGCMetadata(now.WallTime)
+	if err := engine.MVCCPutProto(batch, ms, engine.RangeGCMetadataKey(desc.RaftID), proto.ZeroTimestamp, nil, gcMeta); err != nil {
+		return err
+	}
+	// Verification timestamp.
+	if err := engine.MVCCPutProto(batch, ms, engine.RangeLastVerificationTimestampKey(desc.RaftID), proto.ZeroTimestamp, nil, &now); err != nil {
 		return err
 	}
 	// Range addressing for meta1.

--- a/storage/verify_queue.go
+++ b/storage/verify_queue.go
@@ -1,0 +1,103 @@
+// Copyright 2014 The Cockroach Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+// implied. See the License for the specific language governing
+// permissions and limitations under the License. See the AUTHORS file
+// for names of contributors.
+//
+// Author: Spencer Kimball (spencer.kimball@gmail.com)
+
+package storage
+
+import (
+	"time"
+
+	"github.com/cockroachdb/cockroach/proto"
+	"github.com/cockroachdb/cockroach/util/log"
+)
+
+const (
+	// verifyQueueMaxSize is the max size of the verification queue.
+	verifyQueueMaxSize = 100
+	// verificationInterval is the target duration for verifying on-disk
+	// checksums via full scan.
+	verificationInterval = 60 * 24 * time.Hour // 60 days
+)
+
+// storeStatsFn returns the store stats for the store which owns this
+// verification queue.
+type storeStatsFn func() storeStats
+
+// verifyQueue periodically verifies on-disk checksums to identify
+// bit-rot in read-only data sets. See
+// http://en.wikipedia.org/wiki/Data_degradation.
+type verifyQueue struct {
+	stats storeStatsFn
+	*baseQueue
+}
+
+// newVerifyQueue returns a new instance of verifyQueue.
+func newVerifyQueue(stats storeStatsFn) *verifyQueue {
+	vq := &verifyQueue{stats: stats}
+	vq.baseQueue = newBaseQueue("verify", vq.shouldQueue, vq.process, vq.timer, verifyQueueMaxSize)
+	return vq
+}
+
+// shouldQueue determines whether a range should be queued for
+// verification scanning, and if so, at what priority. Returns true
+// for shouldQ in the event that it's been longer since the last scan
+// than the verification interval.
+func (vq *verifyQueue) shouldQueue(now proto.Timestamp, rng *Range) (shouldQ bool, priority float64) {
+	// Get last verification timestamp.
+	lastVerify, err := rng.GetLastVerificationTimestamp()
+	if err != nil {
+		log.Errorf("unable to fetch last verification timestamp: %s", err)
+		return
+	}
+	verifyScore := float64(now.WallTime-lastVerify.WallTime) / float64(verificationInterval.Nanoseconds())
+	if verifyScore > 1 {
+		priority = verifyScore
+		shouldQ = true
+	}
+	return
+}
+
+// process iterates through all keys and values in a range. The very
+// act of scanning keys verifies on-disk checksums, as each block
+// checksum is checked on load.
+func (vq *verifyQueue) process(now proto.Timestamp, rng *Range) error {
+	snap := rng.rm.Engine().NewSnapshot()
+	iter := newRangeDataIterator(rng, snap)
+	defer iter.Close()
+	defer snap.Stop()
+
+	// Iterate through all keys & values.
+	for ; iter.Valid(); iter.Next() {
+	}
+	// An error during iteration is presumed to mean a checksum failure
+	// while iterating over the underlying key/value data.
+	if iter.Error() != nil {
+		// TODO(spencer): do something other than fatal error here. We
+		// want to quarantine this range, make it a non-participating raft
+		// follower until it can be replaced and then destroyed.
+		log.Fatalf("unhandled failure when scanning range %s; probable data corruption: %s", rng, iter.Error())
+	}
+
+	// Store current timestamp as last verification for this range.
+	return rng.SetLastVerificationTimestamp(now)
+}
+
+// timer returns the duration of intervals between successive range
+// verification scans. The durations are sized so that the full
+// complement of ranges can be scanned within verificationInterval.
+func (vq *verifyQueue) timer() time.Duration {
+	return time.Duration(verificationInterval.Nanoseconds() / int64((vq.stats().RangeCount + 1)))
+}

--- a/storage/verify_queue_test.go
+++ b/storage/verify_queue_test.go
@@ -1,0 +1,64 @@
+// Copyright 2015 The Cockroach Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+// implied. See the License for the specific language governing
+// permissions and limitations under the License. See the AUTHORS file
+// for names of contributors.
+//
+// Author: Spencer Kimball (spencer.kimball@gmail.com)
+
+package storage
+
+import (
+	"math"
+	"testing"
+
+	"github.com/cockroachdb/cockroach/proto"
+	"github.com/cockroachdb/cockroach/storage/engine"
+)
+
+// TestVerifyQueueShouldQueue verifies shouldQueue method correctly
+// indicates that a range should be queued for verification if the
+// time since last verification exceeds the threshold limit.
+func TestVerifyQueueShouldQueue(t *testing.T) {
+	tc := testContext{}
+	tc.Start(t)
+	defer tc.Stop()
+
+	// Put empty verification timestamp
+	key := engine.RangeLastVerificationTimestampKey(tc.rng.Desc.RaftID)
+	if err := engine.MVCCPutProto(tc.rng.rm.Engine(), nil, key, proto.ZeroTimestamp, nil, &proto.Timestamp{}); err != nil {
+		t.Fatal(err)
+	}
+
+	testCases := []struct {
+		now      proto.Timestamp
+		shouldQ  bool
+		priority float64
+	}{
+		// No GC'able bytes, no intent bytes, verification interval elapsed.
+		{makeTS(verificationInterval.Nanoseconds(), 0), false, 0},
+		// No GC'able bytes, no intent bytes, verification interval * 2 elapsed.
+		{makeTS(verificationInterval.Nanoseconds()*2, 0), true, 2},
+	}
+
+	verifyQ := newVerifyQueue(nil)
+
+	for i, test := range testCases {
+		shouldQ, priority := verifyQ.shouldQueue(test.now, tc.rng)
+		if shouldQ != test.shouldQ {
+			t.Errorf("%d: should queue expected %t; got %t", i, test.shouldQ, shouldQ)
+		}
+		if math.Abs(priority-test.priority) > 0.00001 {
+			t.Errorf("%d: priority expected %f; got %f", i, test.priority, priority)
+		}
+	}
+}

--- a/util/hlc/hlc.go
+++ b/util/hlc/hlc.go
@@ -180,6 +180,12 @@ func (c *Clock) PhysicalNow() int64 {
 	return wallTime
 }
 
+// PhysicalTime returns a time.Time struct using the local wall time.
+func (c *Clock) PhysicalTime() time.Time {
+	physNow := c.PhysicalNow()
+	return time.Unix(physNow/1E9, physNow%1E9)
+}
+
 // Update takes a hybrid timestamp, usually originating from
 // an event received from another member of a distributed
 // system. The clock is updated and the hybrid timestamp


### PR DESCRIPTION
ScanQueue used to try to treat GC and verification scan in the same
pass, but this only works for the leader. The GC scan, which handles
old MVCC values and finds the oldest extant intent age, is only done
on the leader replica. However, verification must be done independently
on each replica, as checksum failures can of course occur on all replicas.

Added processing functionality to baseQueue. This starts up a goroutine
per queue to process entries and ties the speed of processing to a new
timer function which is passed during queue creation. In this manner,
verification of range on-disk checksums can be spaced over the course
of the entire verification interval (current 60 days), so the system
doesn't try to greedily process verifications.
