### PR TITLE
Fix a race in restoring from on-disk state.

### DIFF
--- a/multiraft/multiraft.go
+++ b/multiraft/multiraft.go
@@ -570,6 +570,11 @@ func (s *state) createGroup(groupID uint64) error {
 }
 
 func (s *state) removeGroup(op *removeGroupOp) {
+	// Group creation is lazy and idempotent; so is removal.
+	if _, ok := s.groups[op.groupID]; !ok {
+		op.ch <- nil
+		return
+	}
 	s.multiNode.RemoveGroup(op.groupID)
 	gs := s.Storage.GroupStorage(op.groupID)
 	_, cs, err := gs.InitialState()

--- a/storage/store.go
+++ b/storage/store.go
@@ -375,6 +375,11 @@ func (s *Store) Start() error {
 		// Note that we do not create raft groups at this time; they will be created
 		// on-demand the first time they are needed. This helps reduce the amount of
 		// election-related traffic in a cold start.
+		// Raft initialization occurs when we propose a command on this range or
+		// receive a raft message addressed to it.
+		// TODO(bdarnell): Also initialize raft groups when read leases are needed.
+		// TODO(bdarnell): Scan all ranges at startup for unapplied log entries
+		// and initialize those groups.
 		return false, nil
 	}); err != nil {
 		return err

--- a/storage/store.go
+++ b/storage/store.go
@@ -348,11 +348,6 @@ func (s *Store) Start() error {
 	}
 	s.multiraft = mr
 
-	// Start Raft processing goroutines.
-	s.multiraft.Start()
-	s.stopper.Add(1)
-	go s.processRaft()
-
 	// Iterate over all range descriptors, using just committed
 	// versions. Uncommitted intents which have been abandoned due to a
 	// split crashing halfway will simply be resolved on the next split
@@ -377,15 +372,20 @@ func (s *Store) Start() error {
 		if err != nil {
 			return false, err
 		}
-		if err = s.multiraft.CreateGroup(uint64(rng.Desc.RaftID)); err != nil {
-			return false, err
-		}
+		// Note that we do not create raft groups at this time; they will be created
+		// on-demand the first time they are needed. This helps reduce the amount of
+		// election-related traffic in a cold start.
 		return false, nil
 	}); err != nil {
 		return err
 	}
 	// Sort the rangesByKey slice after they've all been added.
 	sort.Sort(s.rangesByKey)
+
+	// Start Raft processing goroutines
+	mr.Start()
+	s.stopper.Add(1)
+	go s.processRaft()
 
 	// Register callbacks for any changes to accounting and zone
 	// configurations; we split ranges along prefix boundaries.


### PR DESCRIPTION
Don't start the raft threads until we have loaded all the ranges.
Raft was sometimes starting to operate on ranges that hadn't been
initialized yet.

Lazily initialize the consensus groups for each range. This was
a necessary side effect of this change but also addresses the
election storm on cold start as discussed in #357.
