### PR TITLE
Update etcd submodule.

### DIFF
--- a/multiraft/storagetest/storagetest.go
+++ b/multiraft/storagetest/storagetest.go
@@ -70,11 +70,6 @@ func testEmptyLog(t *testing.T, s WriteableStorage) {
 		t.Errorf("expected LastIndex to be firstIndex - 1 (%d), got %d", firstIndex-1, lastIndex)
 	}
 
-	ents, err := s.Entries(firstIndex, firstIndex+1)
-	if err != raft.ErrUnavailable {
-		t.Errorf("expected ErrUnavailable, got %v, %v", ents, err)
-	}
-
 	term, err := s.Term(firstIndex - 1)
 	if err != nil {
 		t.Fatal(err)


### PR DESCRIPTION
This revision is the upstream master branch; our fork is now obsolete.
The .gitmodules file still points to cockroachdb/etcd.git because
it is not possible to change a submodule url without manual intervention
by all developers, and the submodule is going away soon anyway.

Fix multiraft/storagetest which was broken by upstream changes to
MemoryStorage.
