### PR TITLE
RandString -> RandBytes.

### DIFF
--- a/kv/split_test.go
+++ b/kv/split_test.go
@@ -66,8 +66,8 @@ func startTestWriter(db *client.KV, i int64, valBytes int32, wg *sync.WaitGroup,
 				}
 				first = false
 				for j := 0; j <= int(src.Int31n(10)); j++ {
-					key := []byte(util.RandString(src, 10))
-					val := []byte(util.RandString(src, int(src.Int31n(valBytes))))
+					key := util.RandBytes(src, 10)
+					val := util.RandBytes(src, int(src.Int31n(valBytes)))
 					req := &proto.PutRequest{RequestHeader: proto.RequestHeader{Key: key}, Value: proto.Value{Bytes: val}}
 					resp := &proto.PutResponse{}
 					if err := txn.Call(proto.Put, req, resp); err != nil {

--- a/multiraft/multiraft_test.go
+++ b/multiraft/multiraft_test.go
@@ -31,7 +31,7 @@ import (
 var testRand = util.NewPseudoRand()
 
 func makeCommandID() string {
-	return util.RandString(testRand, commandIDLen)
+	return string(util.RandBytes(testRand, commandIDLen))
 }
 
 type testCluster struct {

--- a/storage/client_split_test.go
+++ b/storage/client_split_test.go
@@ -279,8 +279,8 @@ func TestStoreRangeSplitStats(t *testing.T) {
 	// Write random data.
 	src := rand.New(rand.NewSource(0))
 	for i := 0; i < 100; i++ {
-		key := []byte(util.RandString(src, int(src.Int31n(1<<7))))
-		val := []byte(util.RandString(src, int(src.Int31n(1<<8))))
+		key := util.RandBytes(src, int(src.Int31n(1<<7)))
+		val := util.RandBytes(src, int(src.Int31n(1<<8)))
 		pArgs, pReply := putArgs(key, val, rng.Desc.RaftID, store.StoreID())
 		pArgs.Timestamp = store.Clock().Now()
 		if err := store.ExecuteCmd(proto.Put, pArgs, pReply); err != nil {
@@ -340,8 +340,8 @@ func fillRange(store *storage.Store, raftID int64, prefix proto.Key, bytes int64
 		if keyBytes+valBytes >= bytes {
 			return
 		}
-		key := append(append([]byte(nil), prefix...), []byte(util.RandString(src, 100))...)
-		val := []byte(util.RandString(src, int(src.Int31n(1<<8))))
+		key := append(append([]byte(nil), prefix...), util.RandBytes(src, 100)...)
+		val := util.RandBytes(src, int(src.Int31n(1<<8)))
 		pArgs, pReply := putArgs(key, val, raftID, store.StoreID())
 		pArgs.Timestamp = store.Clock().Now()
 		if err := store.ExecuteCmd(proto.Put, pArgs, pReply); err != nil {

--- a/storage/engine/engine_test.go
+++ b/storage/engine/engine_test.go
@@ -713,7 +713,7 @@ func TestApproximateSize(t *testing.T) {
 		)
 		for i := 0; i < count; i++ {
 			keys[i] = []byte(fmt.Sprintf("key%8d", i))
-			values[i] = []byte(util.RandString(rand, valueLen))
+			values[i] = util.RandBytes(rand, valueLen)
 		}
 
 		insertKeysAndValues(keys, values, engine, t)

--- a/storage/engine/mvcc_test.go
+++ b/storage/engine/mvcc_test.go
@@ -1635,7 +1635,7 @@ func TestMVCCStatsWithRandomRuns(t *testing.T) {
 		// Same for aggregate gc'able bytes age.
 		ms.GCBytesAge += ms.KeyBytes + ms.ValBytes - ms.LiveBytes
 
-		key := []byte(fmt.Sprintf("%s-%d", util.RandString(rng, int(rng.Int31n(32))), i))
+		key := []byte(fmt.Sprintf("%s-%d", util.RandBytes(rng, int(rng.Int31n(32))), i))
 		keys[i] = key
 		var txn *proto.Transaction
 		if rng.Int31n(2) == 0 { // create a txn with 50% prob
@@ -1667,7 +1667,7 @@ func TestMVCCStatsWithRandomRuns(t *testing.T) {
 				}
 			}
 		} else {
-			rngVal := proto.Value{Bytes: []byte(util.RandString(rng, int(rng.Int31n(128))))}
+			rngVal := proto.Value{Bytes: util.RandBytes(rng, int(rng.Int31n(128)))}
 			log.V(1).Infof("*** PUT index %d; TXN=%t", i, txn != nil)
 			if err := MVCCPut(engine, ms, key, makeTS(int64(i+1)*1E9, 0), rngVal, txn); err != nil {
 				t.Fatal(err)

--- a/util/rand.go
+++ b/util/rand.go
@@ -45,17 +45,18 @@ func RandIntInRange(r *rand.Rand, min, max int) int {
 	return min + r.Intn(max-min)
 }
 
-var randLetters = []rune("abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ")
+var randLetters = []byte("abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ")
 
-// RandString returns a string of the given length with random data.
-func RandString(r *rand.Rand, size int) string {
+// RandBytes returns a byte slice of the given length with random
+// data.
+func RandBytes(r *rand.Rand, size int) []byte {
 	if size <= 0 {
-		return ""
+		return nil
 	}
 
-	arr := make([]rune, size)
+	arr := make([]byte, size)
 	for i := 0; i < len(arr); i++ {
 		arr[i] = randLetters[r.Intn(len(randLetters))]
 	}
-	return string(arr)
+	return arr
 }

--- a/util/rand_test.go
+++ b/util/rand_test.go
@@ -44,10 +44,10 @@ func TestRandIntInRange(t *testing.T) {
 	}
 }
 
-func TestRandString(t *testing.T) {
+func TestRandBytes(t *testing.T) {
 	rand := NewPseudoRand()
 	for i := 0; i < 100; i++ {
-		x := RandString(rand, i)
+		x := RandBytes(rand, i)
 		if len(x) != i {
 			t.Errorf("got array with unexpected length: %d (expected %d)", len(x), i)
 		}


### PR DESCRIPTION
Casting a []byte to a string requires an allocation and copying. Almost
all existing uses of RandString wanted a []byte, so better to target
that case.
