### PR TITLE
Enhance the MVCC scan benchmarks to provide more sensical numbers.

### DIFF
--- a/storage/engine/.gitignore
+++ b/storage/engine/.gitignore
@@ -1,0 +1,1 @@
+mvcc_scan_*

--- a/storage/engine/db.h
+++ b/storage/engine/db.h
@@ -51,7 +51,7 @@ typedef struct DBSnapshot DBSnapshot;
 // DBOptions contains local database options.
 typedef struct {
   int64_t cache_size;
-  int allow_os_buffer;
+  bool allow_os_buffer;
   bool logging_enabled;
 } DBOptions;
 

--- a/storage/engine/rocksdb.go
+++ b/storage/engine/rocksdb.go
@@ -68,7 +68,7 @@ func (r *RocksDB) Start() error {
 	status := C.DBOpen(&r.rdb, goToCSlice([]byte(r.dir)),
 		C.DBOptions{
 			cache_size:      C.int64_t(r.cacheSize),
-			allow_os_buffer: C.int(1),
+			allow_os_buffer: C.bool(true),
 			logging_enabled: C.bool(log.V(1)),
 		})
 	err := statusToError(status)


### PR DESCRIPTION
BenchmarkMVCCScan1Version1Row          200000     63040 ns/op  16.24 MB/s
BenchmarkMVCCScan1Version10Rows         50000    221836 ns/op  46.16 MB/s
BenchmarkMVCCScan1Version100Rows        10000   1743848 ns/op  58.72 MB/s
BenchmarkMVCCScan1Version1000Rows        1000  16752715 ns/op  61.12 MB/s
BenchmarkMVCCScan10Versions1Row        100000    116863 ns/op   8.76 MB/s
BenchmarkMVCCScan10Versions10Rows       50000    246588 ns/op  41.53 MB/s
BenchmarkMVCCScan10Versions100Rows      10000   1773393 ns/op  57.74 MB/s
BenchmarkMVCCScan10Versions1000Rows      1000  16506291 ns/op  62.04 MB/s
BenchmarkMVCCScan100Versions1Row       100000    122143 ns/op   8.38 MB/s
BenchmarkMVCCScan100Versions10Rows      20000    602228 ns/op  17.00 MB/s
BenchmarkMVCCScan100Versions100Rows      2000   5094537 ns/op  20.10 MB/s
BenchmarkMVCCScan100Versions1000Rows      300  44314866 ns/op  23.11 MB/s

The setup was reworked so that the benchmark data can be reused between
runs. RocksDB is configured so the data all fits in the cache and the
cache is pre-warmed.

Some items worth investigating:
- Scanning a single row is significantly slower than scannning 10. Is
  that just the overhead of setting up the iterator?
- Why the dramatic fall off in single row scanning when there are
  multiple versions?
- Why the drmatic fall off in multi row scanning when going from 10 to
  100 versions?
