### PR TITLE
Enable snappy compression in rocksdb.

### DIFF
--- a/GLOCKFILE
+++ b/GLOCKFILE
@@ -9,7 +9,8 @@ code.google.com/p/go-uuid 35bc42037350
 code.google.com/p/snappy-go 8850bd446ad6
 github.com/agtorre/gocolorize f42b554bf7f006936130c9bb4f971afd2d87f671
 github.com/cockroachdb/c-protobuf 9e8dac59ca2a3fc82cd0665ad32b1a36f3df40b8
-github.com/cockroachdb/c-rocksdb 08ed1489772c2c06d721621eb763a44462b9741a
+github.com/cockroachdb/c-rocksdb 7e314cc04e9ac55d353ba7c7c7e68e13311324f6
+github.com/cockroachdb/c-snappy af73b00e85e6f0e3c1fcc51f73f1d036df1e99ff
 github.com/coreos/etcd 0a04eec481f24ec616eed8ad52e59eb6d203263e
 github.com/gogo/protobuf bc946d07d1016848dfd2507f90f0859c9471681e
 github.com/golang/glog 44145f04b68cf362d9c4df2182967c2275eaefed

--- a/build/devbase/godeps.sh
+++ b/build/devbase/godeps.sh
@@ -25,6 +25,7 @@ code.google.com/p/go-uuid/uuid
 code.google.com/p/snappy-go/snappy
 github.com/cockroachdb/c-protobuf
 github.com/cockroachdb/c-rocksdb
+github.com/cockroachdb/c-snappy
 github.com/coreos/etcd/Godeps/_workspace/src/code.google.com/p/gogoprotobuf/proto
 github.com/coreos/etcd/Godeps/_workspace/src/golang.org/x/net/context
 github.com/coreos/etcd/raft

--- a/storage/engine/cgo_flags.go
+++ b/storage/engine/cgo_flags.go
@@ -6,6 +6,7 @@ import (
 	// symbols.
 	_ "github.com/cockroachdb/c-protobuf"
 	_ "github.com/cockroachdb/c-rocksdb"
+	_ "github.com/cockroachdb/c-snappy"
 )
 
 // #cgo CXXFLAGS: -std=c++11

--- a/storage/engine/db.cc
+++ b/storage/engine/db.cc
@@ -676,6 +676,7 @@ DBStatus DBOpen(DBEngine **db, DBSlice dir, DBOptions db_opts) {
 
   rocksdb::Options options;
   options.allow_os_buffer = db_opts.allow_os_buffer;
+  options.compression = rocksdb::kSnappyCompression;
   options.compaction_filter_factory.reset(new DBCompactionFilterFactory());
   options.create_if_missing = true;
   options.info_log.reset(new DBLogger(db_opts.logging_enabled));


### PR DESCRIPTION
Compile rocksdb with optimization before running benchmarks which
accounts for all of the performance difference seen below. The slow down
in the 100 version numbers are strange, but are unrelated to
snappy. Possibly Mac OS X related. Need to get these benchmarks running
on VMs in the cloud.

benchmark                                old ns/op     new ns/op     delta
BenchmarkMVCCScan1Version1Row            63040         44320         -29.70%
BenchmarkMVCCScan1Version10Rows          221836        130027        -41.39%
BenchmarkMVCCScan1Version100Rows         1743848       947750        -45.65%
BenchmarkMVCCScan1Version1000Rows        16752715      8532566       -49.07%
BenchmarkMVCCScan10Versions1Row          116863        47123         -59.68%
BenchmarkMVCCScan10Versions10Rows        246588        144845        -41.26%
BenchmarkMVCCScan10Versions100Rows       1773393       1078586       -39.18%
BenchmarkMVCCScan10Versions1000Rows      16506291      9210180       -44.20%
BenchmarkMVCCScan100Versions1Row         122143        107067        -12.34%
BenchmarkMVCCScan100Versions10Rows       602228        633307        +5.16%
BenchmarkMVCCScan100Versions100Rows      5094537       5882393       +15.46%
BenchmarkMVCCScan100Versions1000Rows     44314866      56404415      +27.28%

benchmark                                old MB/s     new MB/s     speedup
BenchmarkMVCCScan1Version1Row            16.24        23.10        1.42x
BenchmarkMVCCScan1Version10Rows          46.16        78.75        1.71x
BenchmarkMVCCScan1Version100Rows         58.72        108.05       1.84x
BenchmarkMVCCScan1Version1000Rows        61.12        120.01       1.96x
BenchmarkMVCCScan10Versions1Row          8.76         21.73        2.48x
BenchmarkMVCCScan10Versions10Rows        41.53        70.70        1.70x
BenchmarkMVCCScan10Versions100Rows       57.74        94.94        1.64x
BenchmarkMVCCScan10Versions1000Rows      62.04        111.18       1.79x
BenchmarkMVCCScan100Versions1Row         8.38         9.56         1.14x
BenchmarkMVCCScan100Versions10Rows       17.00        16.17        0.95x
BenchmarkMVCCScan100Versions100Rows      20.10        17.41        0.87x
BenchmarkMVCCScan100Versions1000Rows     23.11        18.15        0.79x
