### PR TITLE
Provide atomic methods to get and set range descriptor.

### DIFF
--- a/kv/local_sender.go
+++ b/kv/local_sender.go
@@ -182,7 +182,7 @@ func (ls *LocalSender) lookupReplica(start, end proto.Key) (int64, *proto.Replic
 	defer ls.mu.RUnlock()
 	for _, store := range ls.storeMap {
 		if rng := store.LookupRange(start, end); rng != nil {
-			return rng.Desc.RaftID, rng.GetReplica(), nil
+			return rng.Desc().RaftID, rng.GetReplica(), nil
 		}
 	}
 	return 0, nil, proto.NewRangeKeyMismatchError(start, end, nil)

--- a/kv/local_sender_test.go
+++ b/kv/local_sender_test.go
@@ -107,7 +107,7 @@ func splitTestRange(store *storage.Store, key, splitKey proto.Key, t *testing.T)
 	if rng == nil {
 		t.Fatalf("couldn't lookup range for key %q", key)
 	}
-	desc, err := store.NewRangeDescriptor(splitKey, rng.Desc.EndKey, rng.Desc.Replicas)
+	desc, err := store.NewRangeDescriptor(splitKey, rng.Desc().EndKey, rng.Desc().Replicas)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/storage/client_merge_test.go
+++ b/storage/client_merge_test.go
@@ -50,11 +50,11 @@ func createSplitRanges(store *storage.Store) (*proto.RangeDescriptor, *proto.Ran
 	rangeA := store.LookupRange([]byte("a"), nil)
 	rangeB := store.LookupRange([]byte("c"), nil)
 
-	if bytes.Equal(rangeA.Desc.StartKey, rangeB.Desc.StartKey) {
-		log.Errorf("split ranges keys are equal %q!=%q", rangeA.Desc.StartKey, rangeB.Desc.StartKey)
+	if bytes.Equal(rangeA.Desc().StartKey, rangeB.Desc().StartKey) {
+		log.Errorf("split ranges keys are equal %q!=%q", rangeA.Desc().StartKey, rangeB.Desc().StartKey)
 	}
 
-	return rangeA.Desc, rangeB.Desc, nil
+	return rangeA.Desc(), rangeB.Desc(), nil
 }
 
 // TestStoreRangeMergeTwoEmptyRanges tries to merge two empty ranges
@@ -80,7 +80,7 @@ func TestStoreRangeMergeTwoEmptyRanges(t *testing.T) {
 	rangeB := store.LookupRange([]byte("c"), nil)
 
 	if !reflect.DeepEqual(rangeA, rangeB) {
-		t.Fatalf("ranges were not merged %+v=%+v", rangeA.Desc, rangeB.Desc)
+		t.Fatalf("ranges were not merged %+v=%+v", rangeA.Desc(), rangeB.Desc())
 	}
 }
 
@@ -130,43 +130,43 @@ func TestStoreRangeMergeWithData(t *testing.T) {
 	rangeB := store.LookupRange([]byte("c"), nil)
 
 	if !reflect.DeepEqual(rangeA, rangeB) {
-		t.Fatalf("ranges were not merged %+v=%+v", rangeA.Desc, rangeB.Desc)
+		t.Fatalf("ranges were not merged %+v=%+v", rangeA.Desc(), rangeB.Desc())
 	}
-	if !bytes.Equal(rangeA.Desc.StartKey, engine.KeyMin) {
-		t.Fatalf("The start key is not equal to KeyMin %q=%q", rangeA.Desc.StartKey, engine.KeyMin)
+	if !bytes.Equal(rangeA.Desc().StartKey, engine.KeyMin) {
+		t.Fatalf("The start key is not equal to KeyMin %q=%q", rangeA.Desc().StartKey, engine.KeyMin)
 	}
-	if !bytes.Equal(rangeA.Desc.EndKey, engine.KeyMax) {
-		t.Fatalf("The end key is not equal to KeyMax %q=%q", rangeA.Desc.EndKey, engine.KeyMax)
+	if !bytes.Equal(rangeA.Desc().EndKey, engine.KeyMax) {
+		t.Fatalf("The end key is not equal to KeyMax %q=%q", rangeA.Desc().EndKey, engine.KeyMax)
 	}
 
 	// Try to get values from after the merge.
-	gArgs, gReply = getArgs([]byte("aaa"), rangeA.Desc.RaftID, store.StoreID())
+	gArgs, gReply = getArgs([]byte("aaa"), rangeA.Desc().RaftID, store.StoreID())
 	if err := store.ExecuteCmd(proto.Get, gArgs, gReply); err != nil ||
 		!bytes.Equal(gReply.Value.Bytes, content) {
 		t.Fatal(err)
 	}
-	gArgs, gReply = getArgs([]byte("ccc"), rangeB.Desc.RaftID, store.StoreID())
+	gArgs, gReply = getArgs([]byte("ccc"), rangeB.Desc().RaftID, store.StoreID())
 	if err := store.ExecuteCmd(proto.Get, gArgs, gReply); err != nil ||
 		!bytes.Equal(gReply.Value.Bytes, content) {
 		t.Fatal(err)
 	}
 
 	// Put new values after the merge on both sides.
-	pArgs, pReply = putArgs([]byte("aaaa"), content, rangeA.Desc.RaftID, store.StoreID())
+	pArgs, pReply = putArgs([]byte("aaaa"), content, rangeA.Desc().RaftID, store.StoreID())
 	if err = store.ExecuteCmd(proto.Put, pArgs, pReply); err != nil {
 		t.Fatal(err)
 	}
-	pArgs, pReply = putArgs([]byte("cccc"), content, rangeB.Desc.RaftID, store.StoreID())
+	pArgs, pReply = putArgs([]byte("cccc"), content, rangeB.Desc().RaftID, store.StoreID())
 	if err = store.ExecuteCmd(proto.Put, pArgs, pReply); err != nil {
 		t.Fatal(err)
 	}
 
 	// Try to get the newly placed values.
-	gArgs, gReply = getArgs([]byte("aaaa"), rangeA.Desc.RaftID, store.StoreID())
+	gArgs, gReply = getArgs([]byte("aaaa"), rangeA.Desc().RaftID, store.StoreID())
 	if err := store.ExecuteCmd(proto.Get, gArgs, gReply); err != nil || !bytes.Equal(gReply.Value.Bytes, content) {
 		t.Fatal(err)
 	}
-	gArgs, gReply = getArgs([]byte("cccc"), rangeA.Desc.RaftID, store.StoreID())
+	gArgs, gReply = getArgs([]byte("cccc"), rangeA.Desc().RaftID, store.StoreID())
 	if err := store.ExecuteCmd(proto.Get, gArgs, gReply); err != nil ||
 		!bytes.Equal(gReply.Value.Bytes, content) {
 		t.Fatal(err)
@@ -212,17 +212,17 @@ func TestStoreRangeMergeDistantRanges(t *testing.T) {
 	rangeB := store.LookupRange([]byte("c"), nil)
 	rangeC := store.LookupRange([]byte("e"), nil)
 
-	if bytes.Equal(rangeA.Desc.StartKey, rangeB.Desc.StartKey) {
-		log.Errorf("split ranges keys are equal %q!=%q", rangeA.Desc.StartKey, rangeB.Desc.StartKey)
+	if bytes.Equal(rangeA.Desc().StartKey, rangeB.Desc().StartKey) {
+		log.Errorf("split ranges keys are equal %q!=%q", rangeA.Desc().StartKey, rangeB.Desc().StartKey)
 	}
-	if bytes.Equal(rangeB.Desc.StartKey, rangeC.Desc.StartKey) {
-		log.Errorf("split ranges keys are equal %q!=%q", rangeB.Desc.StartKey, rangeC.Desc.StartKey)
+	if bytes.Equal(rangeB.Desc().StartKey, rangeC.Desc().StartKey) {
+		log.Errorf("split ranges keys are equal %q!=%q", rangeB.Desc().StartKey, rangeC.Desc().StartKey)
 	}
-	if bytes.Equal(rangeA.Desc.StartKey, rangeC.Desc.StartKey) {
-		log.Errorf("split ranges keys are equal %q!=%q", rangeA.Desc.StartKey, rangeC.Desc.StartKey)
+	if bytes.Equal(rangeA.Desc().StartKey, rangeC.Desc().StartKey) {
+		log.Errorf("split ranges keys are equal %q!=%q", rangeA.Desc().StartKey, rangeC.Desc().StartKey)
 	}
 
-	argsMerge, replyMerge := adminMergeArgs(rangeC.Desc.StartKey, *rangeC.Desc, 1, store.StoreID())
+	argsMerge, replyMerge := adminMergeArgs(rangeC.Desc().StartKey, *rangeC.Desc(), 1, store.StoreID())
 	rangeA.AdminMerge(argsMerge, replyMerge)
 	if replyMerge.Error == nil {
 		t.Fatal("Should not be able to merge two ranges that are not adjacent.")

--- a/storage/client_raft_test.go
+++ b/storage/client_raft_test.go
@@ -81,7 +81,7 @@ func TestStoreRecoverFromEngine(t *testing.T) {
 		if err := store.ExecuteCmd(proto.AdminSplit, splitArgs, splitResp); err != nil {
 			t.Fatal(err)
 		}
-		raftID2 = store.LookupRange(key2, nil).Desc.RaftID
+		raftID2 = store.LookupRange(key2, nil).Desc().RaftID
 		if raftID2 == raftID {
 			t.Errorf("got same raft id after split")
 		}
@@ -207,12 +207,12 @@ func TestRestoreReplicas(t *testing.T) {
 			t.Fatal(err)
 		}
 		rng.RLock()
-		if len(rng.Desc.Replicas) != 2 {
-			t.Fatalf("store %d: expected 2 replicas, found %d", i, len(rng.Desc.Replicas))
+		if len(rng.Desc().Replicas) != 2 {
+			t.Fatalf("store %d: expected 2 replicas, found %d", i, len(rng.Desc().Replicas))
 		}
-		if rng.Desc.Replicas[0].NodeID != mtc.stores[0].Ident.NodeID {
+		if rng.Desc().Replicas[0].NodeID != mtc.stores[0].Ident.NodeID {
 			t.Errorf("store %d: expected replica[0].NodeID == %d, was %d",
-				i, mtc.stores[0].Ident.NodeID, rng.Desc.Replicas[0].NodeID)
+				i, mtc.stores[0].Ident.NodeID, rng.Desc().Replicas[0].NodeID)
 		}
 		rng.RUnlock()
 	}
@@ -252,8 +252,8 @@ func TestFailedReplicaChange(t *testing.T) {
 
 	// After the aborted transaction, r.Desc was not updated.
 	// TODO(bdarnell): expose and inspect raft's internal state.
-	if len(rng.Desc.Replicas) != 1 {
-		t.Fatalf("expected 1 replica, found %d", len(rng.Desc.Replicas))
+	if len(rng.Desc().Replicas) != 1 {
+		t.Fatalf("expected 1 replica, found %d", len(rng.Desc().Replicas))
 	}
 
 	// The pending config change flag was cleared, so a subsequent attempt

--- a/storage/gc_queue.go
+++ b/storage/gc_queue.go
@@ -128,9 +128,9 @@ func (gcq *gcQueue) process(now proto.Timestamp, rng *Range) error {
 
 	gcArgs := &proto.InternalGCRequest{
 		RequestHeader: proto.RequestHeader{
-			Key:       rng.Desc.StartKey,
+			Key:       rng.Desc().StartKey,
 			Timestamp: now,
-			RaftID:    rng.Desc.RaftID,
+			RaftID:    rng.Desc().RaftID,
 		},
 	}
 	var mu sync.Mutex
@@ -300,11 +300,11 @@ func (gcq *gcQueue) lookupGCPolicy(rng *Range) (proto.GCPolicy, error) {
 	// This could be the case if the zone config is new and the range
 	// hasn't been split yet along the new boundary.
 	var gc *proto.GCPolicy
-	if err = configMap.VisitPrefixesHierarchically(rng.Desc.StartKey, func(start, end proto.Key, config interface{}) (bool, error) {
+	if err = configMap.VisitPrefixesHierarchically(rng.Desc().StartKey, func(start, end proto.Key, config interface{}) (bool, error) {
 		zone := config.(*proto.ZoneConfig)
 		if zone.GC != nil {
 			rng.RLock()
-			isCovered := !end.Less(rng.Desc.EndKey)
+			isCovered := !end.Less(rng.Desc().EndKey)
 			rng.RUnlock()
 			if !isCovered {
 				return false, util.Errorf("range is only partially covered by zone %s (%q-%q); must wait for range split", config, start, end)
@@ -320,7 +320,7 @@ func (gcq *gcQueue) lookupGCPolicy(rng *Range) (proto.GCPolicy, error) {
 
 	// We should always match _at least_ the default GC.
 	if gc == nil {
-		return proto.GCPolicy{}, util.Errorf("no zone for range with start key %q", rng.Desc.StartKey)
+		return proto.GCPolicy{}, util.Errorf("no zone for range with start key %q", rng.Desc().StartKey)
 	}
 	return *gc, nil
 }

--- a/storage/gc_queue_test.go
+++ b/storage/gc_queue_test.go
@@ -46,7 +46,7 @@ func TestGCQueueShouldQueue(t *testing.T) {
 	defer tc.Stop()
 
 	// Put an empty GC metadata; all that's read from it is last scan nanos.
-	key := engine.RangeGCMetadataKey(tc.rng.Desc.RaftID)
+	key := engine.RangeGCMetadataKey(tc.rng.Desc().RaftID)
 	if err := engine.MVCCPutProto(tc.rng.rm.Engine(), nil, key, proto.ZeroTimestamp, nil, &proto.GCMetadata{}); err != nil {
 		t.Fatal(err)
 	}
@@ -176,7 +176,7 @@ func TestGCQueueProcess(t *testing.T) {
 
 	for _, datum := range data {
 		if datum.del {
-			dArgs, dReply := deleteArgs(datum.key, tc.rng.Desc.RaftID, tc.store.StoreID())
+			dArgs, dReply := deleteArgs(datum.key, tc.rng.Desc().RaftID, tc.store.StoreID())
 			dArgs.Timestamp = datum.ts
 			if datum.txn {
 				dArgs.Txn = newTransaction("test", datum.key, 1, proto.SERIALIZABLE, tc.clock)
@@ -186,7 +186,7 @@ func TestGCQueueProcess(t *testing.T) {
 				t.Fatal(err)
 			}
 		} else {
-			pArgs, pReply := putArgs(datum.key, []byte("value"), tc.rng.Desc.RaftID, tc.store.StoreID())
+			pArgs, pReply := putArgs(datum.key, []byte("value"), tc.rng.Desc().RaftID, tc.store.StoreID())
 			pArgs.Timestamp = datum.ts
 			if datum.txn {
 				pArgs.Txn = newTransaction("test", datum.key, 1, proto.SERIALIZABLE, tc.clock)

--- a/storage/queue.go
+++ b/storage/queue.go
@@ -143,7 +143,7 @@ func (bq *baseQueue) MaybeAdd(rng *Range, now proto.Timestamp) {
 	bq.Lock()
 	defer bq.Unlock()
 	should, priority := bq.shouldQ(now, rng)
-	item, ok := bq.ranges[rng.Desc.RaftID]
+	item, ok := bq.ranges[rng.Desc().RaftID]
 	if !should {
 		if ok {
 			bq.remove(item.index)
@@ -158,7 +158,7 @@ func (bq *baseQueue) MaybeAdd(rng *Range, now proto.Timestamp) {
 	log.Infof("adding range %s from %s queue", rng, bq.name)
 	item = &rangeItem{value: rng, priority: priority}
 	heap.Push(&bq.priorityQ, item)
-	bq.ranges[rng.Desc.RaftID] = item
+	bq.ranges[rng.Desc().RaftID] = item
 
 	// If adding this range has pushed the queue past its maximum size,
 	// remove the lowest priority element.
@@ -173,7 +173,7 @@ func (bq *baseQueue) MaybeAdd(rng *Range, now proto.Timestamp) {
 func (bq *baseQueue) MaybeRemove(rng *Range) {
 	bq.Lock()
 	defer bq.Unlock()
-	if item, ok := bq.ranges[rng.Desc.RaftID]; ok {
+	if item, ok := bq.ranges[rng.Desc().RaftID]; ok {
 		log.Infof("removing range %s from %s queue", item.value, bq.name)
 		bq.remove(item.index)
 	}
@@ -237,7 +237,7 @@ func (bq *baseQueue) pop() *Range {
 		return nil
 	}
 	item := heap.Pop(&bq.priorityQ).(*rangeItem)
-	delete(bq.ranges, item.value.Desc.RaftID)
+	delete(bq.ranges, item.value.Desc().RaftID)
 	return item.value
 }
 
@@ -245,5 +245,5 @@ func (bq *baseQueue) pop() *Range {
 // mutex to be locked.
 func (bq *baseQueue) remove(index int) {
 	item := heap.Remove(&bq.priorityQ, index).(*rangeItem)
-	delete(bq.ranges, item.value.Desc.RaftID)
+	delete(bq.ranges, item.value.Desc().RaftID)
 }

--- a/storage/queue_test.go
+++ b/storage/queue_test.go
@@ -68,8 +68,10 @@ func TestQueuePriorityQueue(t *testing.T) {
 // queue including adding ranges which both should and shouldn't be
 // queued, updating an existing range, and removing a range.
 func TestBaseQueueAddUpdateAndRemove(t *testing.T) {
-	r1 := &Range{Desc: &proto.RangeDescriptor{RaftID: 1}}
-	r2 := &Range{Desc: &proto.RangeDescriptor{RaftID: 2}}
+	r1 := &Range{}
+	r1.SetDesc(&proto.RangeDescriptor{RaftID: 1})
+	r2 := &Range{}
+	r2.SetDesc(&proto.RangeDescriptor{RaftID: 2})
 	shouldAddMap := map[*Range]bool{
 		r1: true,
 		r2: true,
@@ -149,11 +151,13 @@ func TestBaseQueueAddUpdateAndRemove(t *testing.T) {
 // TestBaseQueueProcess verifies that items from the queue are
 // processed according to the timer function.
 func TestBaseQueueProcess(t *testing.T) {
-	r1 := &Range{Desc: &proto.RangeDescriptor{RaftID: 1}}
-	r2 := &Range{Desc: &proto.RangeDescriptor{RaftID: 2}}
+	r1 := &Range{}
+	r1.SetDesc(&proto.RangeDescriptor{RaftID: 1})
+	r2 := &Range{}
+	r2.SetDesc(&proto.RangeDescriptor{RaftID: 2})
 	shouldQ := func(now proto.Timestamp, r *Range) (shouldQueue bool, priority float64) {
 		shouldQueue = true
-		priority = float64(r.Desc.RaftID)
+		priority = float64(r.Desc().RaftID)
 		return
 	}
 	timer := func() time.Duration {
@@ -194,7 +198,8 @@ func TestBaseQueueProcess(t *testing.T) {
 
 // TestBaseQueueAddRemove adds then removes a range; ensure range is not processed.
 func TestBaseQueueAddRemove(t *testing.T) {
-	r := &Range{Desc: &proto.RangeDescriptor{RaftID: 1}}
+	r := &Range{}
+	r.SetDesc(&proto.RangeDescriptor{RaftID: 1})
 	shouldQ := func(now proto.Timestamp, r *Range) (shouldQueue bool, priority float64) {
 		shouldQueue = true
 		priority = 1.0

--- a/storage/range.go
+++ b/storage/range.go
@@ -258,12 +258,14 @@ func (r *Range) IsLeader() bool {
 	return true
 }
 
-// Desc returns the range's descriptor. This method is thread-safe.
+// Desc atomically returns the range's descriptor.
 func (r *Range) Desc() *proto.RangeDescriptor {
 	return (*proto.RangeDescriptor)(atomic.LoadPointer(&r.desc))
 }
 
-// SetDesc sets the range's descriptor. This method is thread-safe.
+// SetDesc atomically sets the range's descriptor. This method should
+// be called in the context of having metaLock held, as is the case
+// for merging, splitting and updating the replica set.
 func (r *Range) SetDesc(desc *proto.RangeDescriptor) {
 	atomic.StorePointer(&r.desc, unsafe.Pointer(desc))
 }

--- a/storage/range_data_iter.go
+++ b/storage/range_data_iter.go
@@ -43,17 +43,17 @@ type rangeDataIterator struct {
 
 func newRangeDataIterator(r *Range, e engine.Engine) *rangeDataIterator {
 	r.RLock()
-	startKey := r.Desc.StartKey
+	startKey := r.Desc().StartKey
 	if startKey.Equal(engine.KeyMin) {
 		startKey = engine.KeyLocalMax
 	}
-	endKey := r.Desc.EndKey
+	endKey := r.Desc().EndKey
 	r.RUnlock()
 	ri := &rangeDataIterator{
 		ranges: []keyRange{
 			{
-				start: engine.MVCCEncodeKey(engine.MakeKey(engine.KeyLocalRangeIDPrefix, encoding.EncodeInt(nil, r.Desc.RaftID))),
-				end:   engine.MVCCEncodeKey(engine.MakeKey(engine.KeyLocalRangeIDPrefix, encoding.EncodeInt(nil, r.Desc.RaftID+1))),
+				start: engine.MVCCEncodeKey(engine.MakeKey(engine.KeyLocalRangeIDPrefix, encoding.EncodeInt(nil, r.Desc().RaftID))),
+				end:   engine.MVCCEncodeKey(engine.MakeKey(engine.KeyLocalRangeIDPrefix, encoding.EncodeInt(nil, r.Desc().RaftID+1))),
 			},
 			{
 				start: engine.MVCCEncodeKey(engine.MakeKey(engine.KeyLocalRangeKeyPrefix, encoding.EncodeBinary(nil, startKey))),

--- a/storage/scanner_test.go
+++ b/storage/scanner_test.go
@@ -182,7 +182,7 @@ func TestScannerAddToQueues(t *testing.T) {
 	s.Start(clock)
 	if err := util.IsTrueWithin(func() bool {
 		return q1.count() == count && q2.count() == count
-	}, 10*time.Millisecond); err != nil {
+	}, 50*time.Millisecond); err != nil {
 		t.Error(err)
 	}
 

--- a/storage/verify_queue_test.go
+++ b/storage/verify_queue_test.go
@@ -34,7 +34,7 @@ func TestVerifyQueueShouldQueue(t *testing.T) {
 	defer tc.Stop()
 
 	// Put empty verification timestamp
-	key := engine.RangeLastVerificationTimestampKey(tc.rng.Desc.RaftID)
+	key := engine.RangeLastVerificationTimestampKey(tc.rng.Desc().RaftID)
 	if err := engine.MVCCPutProto(tc.rng.rm.Engine(), nil, key, proto.ZeroTimestamp, nil, &proto.Timestamp{}); err != nil {
 		t.Fatal(err)
 	}


### PR DESCRIPTION
This prevents the very clumsy and inconsistent locking we were doing
before, caused by the move from immutable RangeDescriptor to mutable
ones due to updating replicas, merging & splitting.
