### PR TITLE
Introduce new split queue, instantiate and hookup scanner to store.

### DIFF
--- a/gossip/infostore.go
+++ b/gossip/infostore.go
@@ -266,7 +266,7 @@ func (is *infoStore) registerCallback(pattern string, method Callback) {
 	}); err != nil {
 		log.Errorf("failed to properly run registered callback while visiting pre-existing info: %s", err)
 	}
-	// Run callbacks in a goroutin to avoid mutex reentry.
+	// Run callbacks in a goroutine to avoid mutex reentry.
 	go func() {
 		for _, i := range infos {
 			method(i.Key, true /* contentsChanged */)

--- a/gossip/infostore.go
+++ b/gossip/infostore.go
@@ -28,6 +28,7 @@ import (
 	"time"
 
 	"github.com/cockroachdb/cockroach/util"
+	"github.com/cockroachdb/cockroach/util/log"
 )
 
 // callback holds regexp pattern match and GossipCallback method.
@@ -256,6 +257,21 @@ func (is *infoStore) maxHops() uint32 {
 func (is *infoStore) registerCallback(pattern string, method Callback) {
 	re := regexp.MustCompile(pattern)
 	is.callbacks = append(is.callbacks, callback{pattern: re, method: method})
+	var infos []*info
+	if err := is.visitInfos(nil, func(i *info) error {
+		if re.MatchString(i.Key) {
+			infos = append(infos, i)
+		}
+		return nil
+	}); err != nil {
+		log.Errorf("failed to properly run registered callback while visiting pre-existing info: %s", err)
+	}
+	// Run callbacks in a goroutin to avoid mutex reentry.
+	go func() {
+		for _, i := range infos {
+			method(i.Key, true /* contentsChanged */)
+		}
+	}()
 }
 
 // processCallbacks processes callbacks for the specified key by

--- a/proto/data.go
+++ b/proto/data.go
@@ -65,6 +65,13 @@ func MakeKey(keys ...Key) Key {
 	return Key(bytes.Join(byteSlices, nil))
 }
 
+// KeySlice implements sort.Interface.
+type KeySlice []Key
+
+func (s KeySlice) Len() int           { return len(s) }
+func (s KeySlice) Swap(i, j int)      { s[i], s[j] = s[j], s[i] }
+func (s KeySlice) Less(i, j int) bool { return s[i].Less(s[j]) }
+
 // Returns the next possible byte by appending an \x00.
 func bytesNext(b []byte) []byte {
 	// TODO(spencer): Do we need to enforce KeyMaxLength here?

--- a/server/config_test.go
+++ b/server/config_test.go
@@ -1,0 +1,70 @@
+// Copyright 2014 The Cockroach Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+// implied. See the License for the specific language governing
+// permissions and limitations under the License. See the AUTHORS file
+// for names of contributors.
+//
+// Author: Spencer Kimball (spencer.kimball@gmail.com)
+
+package server
+
+import (
+	"fmt"
+	"net/http"
+	"regexp"
+	"strings"
+	"testing"
+)
+
+// TestSetZoneInvalid sets invalid zone configs and verifies error
+// responses.
+func TestSetZoneInvalid(t *testing.T) {
+	httpServer := startAdminServer()
+	defer httpServer.Close()
+
+	testData := []struct {
+		zone   string
+		expErr string
+	}{
+		{`
+replicas:
+  - attrs: [dc1, ssd]
+range_min_bytes: 128
+range_max_bytes: 524288
+`, "RangeMaxBytes 524288 less than minimum allowed"},
+		{`
+replicas:
+  - attrs: [dc1, ssd]
+range_min_bytes: 67108864
+range_max_bytes: 67108864
+`, "RangeMinBytes 67108864 is greater than or equal to RangeMaxBytes 67108864"},
+		{`
+range_min_bytes: 1048576
+range_max_bytes: 67108864
+`, "attributes for at least one replica must be specified in zone config"},
+	}
+
+	for i, test := range testData {
+		re := regexp.MustCompile(test.expErr)
+		req, err := http.NewRequest("POST", fmt.Sprintf("%s%s/%s", httpServer.URL, zonePathPrefix, "foo"), strings.NewReader(test.zone))
+		if err != nil {
+			t.Fatal(err)
+		}
+		req.Header.Add("Content-Type", "text/yaml")
+		_, err = sendAdminRequest(req)
+		if err == nil {
+			t.Errorf("%d: expected error", i)
+		} else if !re.MatchString(err.Error()) {
+			t.Errorf("%d: expected error matching %q; got %s", i, test.expErr, err)
+		}
+	}
+}

--- a/server/zone_test.go
+++ b/server/zone_test.go
@@ -100,39 +100,6 @@ func ExampleSetAndGetZone() {
 	// range_max_bytes: 67108864
 }
 
-// ExampleSetZoneInvalid sets invalid zone configs and verifies error
-// responses.
-func ExampleSetZoneInvalid() {
-	httpServer := startAdminServer()
-	defer httpServer.Close()
-
-	testData := []string{
-		`
-replicas:
-  - attrs: [dc1, ssd]
-range_min_bytes: 128
-range_max_bytes: 524288
-`,
-		`
-replicas:
-  - attrs: [dc1, ssd]
-range_min_bytes: 67108864
-range_max_bytes: 67108864
-`,
-		`
-range_min_bytes: 1048576
-range_max_bytes: 67108864
-`,
-	}
-
-	for _, data := range testData {
-		testConfigFn := createTestConfigFile(data)
-		RunSetZone(testContext, "db1", testConfigFn)
-		os.Remove(testConfigFn)
-	}
-	// Output:
-}
-
 // ExampleLsZones creates a series of zone configs and verifies
 // zone-ls works. First, no regexp lists all zone configs. Second,
 // regexp properly matches results.

--- a/server/zone_test.go
+++ b/server/zone_test.go
@@ -100,6 +100,39 @@ func ExampleSetAndGetZone() {
 	// range_max_bytes: 67108864
 }
 
+// ExampleSetZoneInvalid sets invalid zone configs and verifies error
+// responses.
+func ExampleSetZoneInvalid() {
+	httpServer := startAdminServer()
+	defer httpServer.Close()
+
+	testData := []string{
+		`
+replicas:
+  - attrs: [dc1, ssd]
+range_min_bytes: 128
+range_max_bytes: 524288
+`,
+		`
+replicas:
+  - attrs: [dc1, ssd]
+range_min_bytes: 67108864
+range_max_bytes: 67108864
+`,
+		`
+range_min_bytes: 1048576
+range_max_bytes: 67108864
+`,
+	}
+
+	for _, data := range testData {
+		testConfigFn := createTestConfigFile(data)
+		RunSetZone(testContext, "db1", testConfigFn)
+		os.Remove(testConfigFn)
+	}
+	// Output:
+}
+
 // ExampleLsZones creates a series of zone configs and verifies
 // zone-ls works. First, no regexp lists all zone configs. Second,
 // regexp properly matches results.

--- a/storage/client_raft_test.go
+++ b/storage/client_raft_test.go
@@ -231,9 +231,8 @@ func TestFailedReplicaChange(t *testing.T) {
 	defer func() {
 		storage.TestingCommandFilter = nil
 	}()
-	storage.TestingCommandFilter = func(method string, args proto.Request,
-		reply proto.Response) bool {
-		if method == proto.EndTransaction {
+	storage.TestingCommandFilter = func(method string, args proto.Request, reply proto.Response) bool {
+		if method == proto.EndTransaction && args.(*proto.EndTransactionRequest).Commit == true {
 			reply.Header().SetGoError(util.Errorf("boom"))
 			return true
 		}

--- a/storage/client_split_test.go
+++ b/storage/client_split_test.go
@@ -359,7 +359,7 @@ func TestStoreZoneUpdateAndRangeSplit(t *testing.T) {
 	store := createTestStore(t)
 	defer store.Stop()
 
-	// Rewrite zone config with range max bytes set to 256K.
+	// Rewrite zone config with range max bytes set to 64K.
 	zoneConfig := &proto.ZoneConfig{
 		ReplicaAttrs: []proto.Attributes{
 			{},
@@ -376,7 +376,7 @@ func TestStoreZoneUpdateAndRangeSplit(t *testing.T) {
 	// See if the range's max bytes is modified via gossip callback within 50ms.
 	rng := store.LookupRange(engine.KeyMin, nil)
 	if err := util.IsTrueWithin(func() bool {
-		return rng.GetMaxBytes() == 1<<18
+		return rng.GetMaxBytes() == zoneConfig.RangeMaxBytes
 	}, 50*time.Millisecond); err != nil {
 		t.Fatalf("failed to notice range max bytes update: %s", err)
 	}

--- a/storage/gc_queue.go
+++ b/storage/gc_queue.go
@@ -73,6 +73,10 @@ func newGCQueue() *gcQueue {
 // in the event that the cumulative ages of GC'able bytes or extant
 // intents exceed thresholds.
 func (gcq *gcQueue) shouldQueue(now proto.Timestamp, rng *Range) (shouldQ bool, priority float64) {
+	// Only queue for GC if this replica is leader.
+	if !rng.IsLeader() {
+		return
+	}
 	// Lookup GC policy for this range.
 	policy, err := gcq.lookupGCPolicy(rng)
 	if err != nil {

--- a/storage/prefix.go
+++ b/storage/prefix.go
@@ -45,6 +45,11 @@ type PrefixConfig struct {
 	Config    interface{} // the config object
 }
 
+// String returns a human readable description.
+func (pc *PrefixConfig) String() string {
+	return fmt.Sprintf("prefix=%s: %s", pc.Prefix, pc.Config)
+}
+
 // PrefixConfigMap is a slice of prefix configs, sorted by
 // prefix. Along with various accessor methods, the config map
 // also contains additional prefix configs in the slice to

--- a/storage/queue.go
+++ b/storage/queue.go
@@ -155,7 +155,7 @@ func (bq *baseQueue) MaybeAdd(rng *Range, now proto.Timestamp) {
 		return
 	}
 
-	log.Infof("adding range %s from %s queue", rng, bq.name)
+	log.Infof("adding range %s to %s queue", rng, bq.name)
 	item = &rangeItem{value: rng, priority: priority}
 	heap.Push(&bq.priorityQ, item)
 	bq.ranges[rng.Desc().RaftID] = item

--- a/storage/scanner.go
+++ b/storage/scanner.go
@@ -22,6 +22,7 @@ import (
 	"time"
 	"unsafe"
 
+	"github.com/cockroachdb/cockroach/proto"
 	"github.com/cockroachdb/cockroach/storage/engine"
 	"github.com/cockroachdb/cockroach/util"
 	"github.com/cockroachdb/cockroach/util/hlc"
@@ -40,7 +41,7 @@ type rangeQueue interface {
 	// MaybeAdd adds the range to the queue if the range meets
 	// the queue's inclusion criteria and the queue is not already
 	// too full, etc.
-	MaybeAdd(*Range)
+	MaybeAdd(*Range, proto.Timestamp)
 	// MaybeRemove removes the range from the queue if it is present.
 	MaybeRemove(*Range)
 }
@@ -76,33 +77,32 @@ type rangeScanner struct {
 	removed  chan *Range    // Ranges to remove from queues
 	count    int64          // Count of times through the scanning loop
 	stats    unsafe.Pointer // Latest store stats object; updated atomically
-	stopper  *util.Stopper
 }
 
 // newRangeScanner creates a new range scanner with the provided
 // loop interval, range iterator, and range queues.
-func newRangeScanner(interval time.Duration, iter rangeIterator, queues []rangeQueue) *rangeScanner {
+func newRangeScanner(interval time.Duration, iter rangeIterator) *rangeScanner {
 	return &rangeScanner{
 		interval: interval,
 		iter:     iter,
-		queues:   queues,
 		removed:  make(chan *Range, 10),
 		stats:    unsafe.Pointer(&storeStats{RangeCount: iter.EstimatedCount()}),
-		stopper:  util.NewStopper(1),
 	}
+}
+
+// AddQueues adds a variable arg list of queues to the range scanner.
+// This method may only be called before Start().
+func (rs *rangeScanner) AddQueues(queues ...rangeQueue) {
+	rs.queues = append(rs.queues, queues...)
 }
 
 // Start spins up the scanning loop. Call Stop() to exit the loop.
-func (rs *rangeScanner) Start(clock *hlc.Clock) {
+func (rs *rangeScanner) Start(clock *hlc.Clock, stopper *util.Stopper) {
+	stopper.Add(1)
 	for _, queue := range rs.queues {
-		queue.Start(clock, rs.stopper)
+		queue.Start(clock, stopper)
 	}
-	go rs.scanLoop()
-}
-
-// Stop stops the scanning loop.
-func (rs *rangeScanner) Stop() {
-	rs.stopper.Stop()
+	go rs.scanLoop(clock, stopper)
 }
 
 // Stats returns store stats from the most recently completed scan of
@@ -129,7 +129,7 @@ func (rs *rangeScanner) RemoveRange(rng *Range) {
 // scanLoop loops endlessly, scanning through ranges available via
 // the range iterator, or until the scanner is stopped. The iteration
 // is paced to complete a full scan in approximately the scan interval.
-func (rs *rangeScanner) scanLoop() {
+func (rs *rangeScanner) scanLoop(clock *hlc.Clock, stopper *util.Stopper) {
 	start := time.Now()
 	stats := &storeStats{}
 
@@ -151,7 +151,7 @@ func (rs *rangeScanner) scanLoop() {
 			if rng != nil {
 				// Try adding range to all queues.
 				for _, q := range rs.queues {
-					q.MaybeAdd(rng)
+					q.MaybeAdd(rng, clock.Now())
 				}
 				stats.RangeCount++
 				stats.MVCC.Accumulate(rng.stats.GetMVCC())
@@ -174,9 +174,9 @@ func (rs *rangeScanner) scanLoop() {
 			}
 			log.V(6).Infof("removed range %s", rng)
 
-		case <-rs.stopper.ShouldStop():
+		case <-stopper.ShouldStop():
 			// Exit the loop.
-			rs.stopper.SetStopped()
+			stopper.SetStopped()
 			return
 		}
 	}

--- a/storage/split_queue.go
+++ b/storage/split_queue.go
@@ -1,0 +1,172 @@
+// Copyright 2015 The Cockroach Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+// implied. See the License for the specific language governing
+// permissions and limitations under the License. See the AUTHORS file
+// for names of contributors.
+//
+// Author: Spencer Kimball (spencer.kimball@gmail.com)
+
+package storage
+
+import (
+	"sort"
+	"time"
+
+	"github.com/cockroachdb/cockroach/client"
+	"github.com/cockroachdb/cockroach/gossip"
+	"github.com/cockroachdb/cockroach/proto"
+	"github.com/cockroachdb/cockroach/util"
+	"github.com/cockroachdb/cockroach/util/log"
+)
+
+const (
+	// splitQueueMaxSize is the max size of the split queue.
+	splitQueueMaxSize = 100
+	// splitQueueTimerDuration is the duration between splits of queued ranges.
+	splitQueueTimerDuration = 0 * time.Second // zero duration to process splits greedily
+)
+
+// splitQueue manages a queue of ranges slated to be split due to size
+// or along intersecting accounting or zone config boundaries.
+type splitQueue struct {
+	*baseQueue
+	db     *client.KV
+	gossip *gossip.Gossip
+}
+
+// newSplitQueue returns a new instance of splitQueue.
+func newSplitQueue(db *client.KV, gossip *gossip.Gossip) *splitQueue {
+	sq := &splitQueue{
+		db:     db,
+		gossip: gossip,
+	}
+	sq.baseQueue = newBaseQueue("split", sq.shouldQueue, sq.process, sq.timer, splitQueueMaxSize)
+	return sq
+}
+
+// shouldQueue determines whether a range should be queued for
+// splitting. This is true if the range is intersected by any
+// accounting or zone config prefix or if the range's size in
+// bytes exceeds the limit for the zone.
+func (sq *splitQueue) shouldQueue(now proto.Timestamp, rng *Range) (shouldQ bool, priority float64) {
+	// Only queue for Split if this replica is leader.
+	if !rng.IsLeader() {
+		return
+	}
+
+	// Set priority to 1 in the event the range is split by acct or zone configs.
+	if len(sq.computeSplitKeys(rng)) > 0 {
+		priority = 1
+		shouldQ = true
+	}
+
+	// Add priority based on the size of range compared to the max
+	// size for the zone it's in.
+	zone, err := sq.lookupZoneConfig(rng)
+	if err != nil {
+		log.Error(err)
+		return
+	}
+	if ratio := float64(rng.stats.GetSize()) / float64(zone.RangeMaxBytes); ratio > 1 {
+		priority += ratio
+		shouldQ = true
+	}
+	return
+}
+
+// process synchronously invokes admin split for each proposed split key.
+func (sq *splitQueue) process(now proto.Timestamp, rng *Range) error {
+	if !rng.IsLeader() {
+		log.Infof("not leader of range %s; skipping split", rng)
+		return nil
+	}
+	// First handle case of splitting due to accounting and zone config maps.
+	splitKeys := sq.computeSplitKeys(rng)
+	if len(splitKeys) > 0 {
+		log.Infof("splitting range %q-%q at keys %v", rng.Desc().StartKey, rng.Desc().EndKey, splitKeys)
+		for _, splitKey := range splitKeys {
+			req := &proto.AdminSplitRequest{
+				RequestHeader: proto.RequestHeader{Key: splitKey},
+				SplitKey:      splitKey,
+			}
+			if err := sq.db.Call(proto.AdminSplit, req, &proto.AdminSplitResponse{}); err != nil {
+				return util.Errorf("unable to split at key %q: %s", splitKey, err)
+			}
+		}
+		return nil
+	}
+	// Next handle case of splitting due to size.
+	zone, err := sq.lookupZoneConfig(rng)
+	if err != nil {
+		return err
+	}
+	if float64(rng.stats.GetSize())/float64(zone.RangeMaxBytes) > 1 {
+		rng.AddCmd(proto.AdminSplit, &proto.AdminSplitRequest{
+			RequestHeader: proto.RequestHeader{Key: rng.Desc().StartKey},
+		}, &proto.AdminSplitResponse{}, true)
+	}
+	return nil
+}
+
+// timer returns interval between processing successive queued splits.
+func (sq *splitQueue) timer() time.Duration {
+	return splitQueueTimerDuration
+}
+
+// computeSplitKeys returns an array of keys at which the supplied
+// range should be split, as computed by intersecting the range with
+// accounting and zone config map boundaries.
+func (sq *splitQueue) computeSplitKeys(rng *Range) []proto.Key {
+	// Now split the range into pieces by intersecting it with the
+	// boundaries of the config map.
+	splitKeys := proto.KeySlice{}
+	for _, configKey := range []string{gossip.KeyConfigAccounting, gossip.KeyConfigZone} {
+		info, err := sq.gossip.GetInfo(configKey)
+		if err != nil {
+			log.Errorf("unable to fetch %s config from gossip: %s", configKey, err)
+			continue
+		}
+		configMap := info.(PrefixConfigMap)
+		splits, err := configMap.SplitRangeByPrefixes(rng.Desc().StartKey, rng.Desc().EndKey)
+		if err != nil {
+			log.Errorf("unable to split range %q-%q by prefix map %s", rng.Desc().StartKey, rng.Desc().EndKey, configMap)
+			continue
+		}
+		// Gather new splits.
+		for _, split := range splits {
+			if split.end.Less(rng.Desc().EndKey) {
+				splitKeys = append(splitKeys, split.end)
+			}
+		}
+	}
+
+	// Sort and unique the combined split keys from intersections with
+	// both the accounting and zone config maps.
+	sort.Sort(splitKeys)
+	var unique []proto.Key
+	for i, key := range splitKeys {
+		if i == 0 || !key.Equal(splitKeys[i-1]) {
+			unique = append(unique, key)
+		}
+	}
+	return unique
+}
+
+// lookupZoneConfig returns the zone config matching the range.
+func (sq *splitQueue) lookupZoneConfig(rng *Range) (proto.ZoneConfig, error) {
+	zoneMap, err := sq.gossip.GetInfo(gossip.KeyConfigZone)
+	if err != nil || zoneMap == nil {
+		return proto.ZoneConfig{}, util.Errorf("unable to lookup zone config for range %s: %s", rng, err)
+	}
+	prefixConfig := zoneMap.(PrefixConfigMap).MatchByPrefix(rng.Desc().StartKey)
+	return *prefixConfig.Config.(*proto.ZoneConfig), nil
+}

--- a/storage/split_queue_test.go
+++ b/storage/split_queue_test.go
@@ -1,0 +1,106 @@
+// Copyright 2015 The Cockroach Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+// implied. See the License for the specific language governing
+// permissions and limitations under the License. See the AUTHORS file
+// for names of contributors.
+//
+// Author: Spencer Kimball (spencer.kimball@gmail.com)
+
+package storage
+
+import (
+	"math"
+	"testing"
+	"time"
+
+	"github.com/cockroachdb/cockroach/gossip"
+	"github.com/cockroachdb/cockroach/proto"
+	"github.com/cockroachdb/cockroach/storage/engine"
+)
+
+// TestSplitQueueShouldQueue verifies shouldQueue method correctly
+// combines splits in accounting and zone configs with the size of
+// the range.
+func TestSplitQueueShouldQueue(t *testing.T) {
+	tc := testContext{}
+	tc.Start(t)
+	defer tc.Stop()
+
+	// Set accounting and zone configs.
+	acctMap, err := NewPrefixConfigMap([]*PrefixConfig{
+		{engine.KeyMin, nil, 1},
+		{proto.Key("/dbA"), nil, 2},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := tc.gossip.AddInfo(gossip.KeyConfigAccounting, acctMap, 0*time.Second); err != nil {
+		t.Fatal(err)
+	}
+
+	zoneMap, err := NewPrefixConfigMap([]*PrefixConfig{
+		{engine.KeyMin, nil, &proto.ZoneConfig{RangeMaxBytes: 64 << 20}},
+		{proto.Key("/dbB"), nil, &proto.ZoneConfig{RangeMaxBytes: 64 << 20}},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := tc.gossip.AddInfo(gossip.KeyConfigZone, zoneMap, 0*time.Second); err != nil {
+		t.Fatal(err)
+	}
+
+	testCases := []struct {
+		start, end proto.Key
+		bytes      int64
+		shouldQ    bool
+		priority   float64
+	}{
+		// No intersection, no bytes.
+		{proto.KeyMin, proto.Key("/"), 0, false, 0},
+		// Intersection in accounting, no bytes.
+		{proto.Key("/"), proto.Key("/dbA1"), 0, true, 1},
+		// Intersection in zone, no bytes.
+		{proto.Key("/dbA"), proto.Key("/dbC"), 0, true, 1},
+		// Multiple intersections, no bytes.
+		{proto.KeyMin, proto.KeyMax, 0, true, 1},
+		// No intersection, max bytes.
+		{proto.KeyMin, proto.Key("/"), 64 << 20, false, 0},
+		// No intersection, max bytes+1.
+		{proto.KeyMin, proto.Key("/"), 64<<20 + 1, true, 1},
+		// No intersection, max bytes * 2.
+		{proto.KeyMin, proto.Key("/"), 64 << 21, true, 2},
+		// Intersection, max bytes +1.
+		{proto.KeyMin, proto.KeyMax, 64<<20 + 1, true, 2},
+	}
+
+	splitQ := newSplitQueue(nil, tc.gossip)
+
+	for i, test := range testCases {
+		tc.rng.stats.SetMVCCStats(tc.rng.rm.Engine(), engine.MVCCStats{KeyBytes: test.bytes})
+		copy := *tc.rng.Desc()
+		copy.StartKey = test.start
+		copy.EndKey = test.end
+		tc.rng.SetDesc(&copy)
+		shouldQ, priority := splitQ.shouldQueue(proto.ZeroTimestamp, tc.rng)
+		if shouldQ != test.shouldQ {
+			t.Errorf("%d: should queue expected %t; got %t", i, test.shouldQ, shouldQ)
+		}
+		if math.Abs(priority-test.priority) > 0.00001 {
+			t.Errorf("%d: priority expected %f; got %f", i, test.priority, priority)
+		}
+	}
+}
+
+////
+// NOTE: tests which actually verify processing of the split queue are
+// in client_split_test.go, which is in a different test package in
+// order to allow for distributed transactions with a proper client.

--- a/storage/stats.go
+++ b/storage/stats.go
@@ -62,6 +62,8 @@ func (rs *rangeStats) GetMVCC() engine.MVCCStats {
 // GetSize returns the range size as the sum of the key and value
 // bytes. This includes all non-live keys and all versioned values.
 func (rs *rangeStats) GetSize() int64 {
+	rs.Lock()
+	defer rs.Unlock()
 	return rs.KeyBytes + rs.ValBytes
 }
 
@@ -98,6 +100,8 @@ func (rs *rangeStats) Update(ms engine.MVCCStats) {
 // GetAvgIntentAge returns the average age of outstanding intents,
 // based on current wall time specified via nowNanos.
 func (rs *rangeStats) GetAvgIntentAge(nowNanos int64) float64 {
+	rs.Lock()
+	defer rs.Unlock()
 	if rs.IntentCount == 0 {
 		return 0
 	}
@@ -110,6 +114,8 @@ func (rs *rangeStats) GetAvgIntentAge(nowNanos int64) float64 {
 // GetGCBytesAge returns the total age of outstanding gc'able
 // bytes, based on current wall time specified via nowNanos.
 func (rs *rangeStats) GetGCBytesAge(nowNanos int64) int64 {
+	rs.Lock()
+	defer rs.Unlock()
 	gcBytes := (rs.KeyBytes + rs.ValBytes - rs.LiveBytes)
 	if gcBytes == 0 {
 		return 0

--- a/storage/store_test.go
+++ b/storage/store_test.go
@@ -296,17 +296,17 @@ func TestStoreRangeIterator(t *testing.T) {
 	// Verify two passes of the iteration.
 	iter := newStoreRangeIterator(store)
 	for pass := 0; pass < 2; pass++ {
-		for i := 1; iter.estimatedCount() > 0; i++ {
-			if rng := iter.next(); rng == nil || rng.Desc().RaftID != int64(i) {
+		for i := 1; iter.EstimatedCount() > 0; i++ {
+			if rng := iter.Next(); rng == nil || rng.Desc().RaftID != int64(i) {
 				t.Errorf("expected range with Raft ID %d; got %v", i, rng)
 			}
 		}
-		iter.reset()
+		iter.Reset()
 	}
 
 	// Try iterating with an addition.
-	iter.next()
-	if ec := iter.estimatedCount(); ec != 9 {
+	iter.Next()
+	if ec := iter.EstimatedCount(); ec != 9 {
 		t.Errorf("expected 9 remaining; got %d", ec)
 	}
 	// Insert range as second range.
@@ -315,13 +315,13 @@ func TestStoreRangeIterator(t *testing.T) {
 		t.Fatal(err)
 	}
 	// Estimated count will still be 9, as it's cached, but next() will refresh.
-	if ec := iter.estimatedCount(); ec != 9 {
+	if ec := iter.EstimatedCount(); ec != 9 {
 		t.Errorf("expected 9 remaining; got %d", ec)
 	}
-	if r := iter.next(); r == nil || r != rng {
+	if r := iter.Next(); r == nil || r != rng {
 		t.Errorf("expected r==rng; got %d", r.Desc().RaftID)
 	}
-	if ec := iter.estimatedCount(); ec != 9 {
+	if ec := iter.EstimatedCount(); ec != 9 {
 		t.Errorf("expected 9 remaining; got %d", ec)
 	}
 
@@ -334,14 +334,14 @@ func TestStoreRangeIterator(t *testing.T) {
 	if err := store.RemoveRange(rng); err != nil {
 		t.Error(err)
 	}
-	if ec := iter.estimatedCount(); ec != 9 {
+	if ec := iter.EstimatedCount(); ec != 9 {
 		t.Errorf("expected 9 remaining; got %d", ec)
 	}
 	// Verify we skip removed range (id=2).
-	if r := iter.next(); r.Desc().RaftID != 3 {
+	if r := iter.Next(); r.Desc().RaftID != 3 {
 		t.Errorf("expected raftID=3; got %d", r.Desc().RaftID)
 	}
-	if ec := iter.estimatedCount(); ec != 7 {
+	if ec := iter.EstimatedCount(); ec != 7 {
 		t.Errorf("expected 7 remaining; got %d", ec)
 	}
 }


### PR DESCRIPTION
New split queue now serially splits ranges which cross accounting or
zone configuration boundaries or that exceed the maximum number of bytes.

Aside from the normal scanner picking up ranges which need splitting,
write pressure and gossip config map callbacks both manually add to the
split queue as necessary.

The check for a range's size exceeding limits is now more efficient.
Instead of looking up the zone config one every write, each range caches
the max bytes parameter from its zone config. New zone configs being
gossiped invalidate the cached values.
