### PR TITLE
Send all raft log messages directly to glog.

### DIFF
--- a/GLOCKFILE
+++ b/GLOCKFILE
@@ -12,7 +12,7 @@ github.com/agtorre/gocolorize f42b554bf7f006936130c9bb4f971afd2d87f671
 github.com/cockroachdb/c-protobuf 9e8dac59ca2a3fc82cd0665ad32b1a36f3df40b8
 github.com/cockroachdb/c-rocksdb 7e314cc04e9ac55d353ba7c7c7e68e13311324f6
 github.com/cockroachdb/c-snappy af73b00e85e6f0e3c1fcc51f73f1d036df1e99ff
-github.com/coreos/etcd 0a04eec481f24ec616eed8ad52e59eb6d203263e
+github.com/coreos/etcd a2be25cba4bb74756890dcd21dd67c66decdfd77
 github.com/gogo/protobuf bc946d07d1016848dfd2507f90f0859c9471681e
 github.com/golang/glog 44145f04b68cf362d9c4df2182967c2275eaefed
 github.com/golang/lint 39d15d55e9777df34cdffde4f406ab27fd2e60c0

--- a/multiraft/logger.go
+++ b/multiraft/logger.go
@@ -1,0 +1,98 @@
+// Copyright 2015 The Cockroach Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+// implied. See the License for the specific language governing
+// permissions and limitations under the License. See the AUTHORS file
+// for names of contributors.
+//
+// Author: Ben Darnell
+
+package multiraft
+
+import (
+	"fmt"
+
+	"github.com/cockroachdb/cockroach/util/log"
+	"github.com/coreos/etcd/raft"
+)
+
+// init installs an adapter to use glog for all log messages from raft.
+func init() {
+	raft.SetLogger(&glogLogger{})
+}
+
+// *glogLogger implements the raft.Logger interface. Note that all methods
+// must be defined on the pointer type rather than the value type because
+// (at least in the go 1.4 compiler), methods on a value type called through
+// an interface pointer go through an additional layer of indirection that
+// appears on the stack, and would make all our stack frame offsets incorrect.
+type glogLogger struct{}
+
+func (*glogLogger) Debug(v ...interface{}) {
+	if log.V(1) {
+		log.InfoDepth(1, v...)
+	}
+}
+
+func (*glogLogger) Debugf(format string, v ...interface{}) {
+	s := fmt.Sprintf(format, v...)
+	if log.V(1) {
+		log.InfoDepth(1, s)
+	}
+}
+
+func (*glogLogger) Info(v ...interface{}) {
+	log.InfoDepth(1, v...)
+}
+
+func (*glogLogger) Infof(format string, v ...interface{}) {
+	s := fmt.Sprintf(format, v...)
+	log.InfoDepth(1, s)
+}
+
+func (*glogLogger) Warning(v ...interface{}) {
+	log.WarningDepth(1, v...)
+}
+
+func (*glogLogger) Warningf(format string, v ...interface{}) {
+	s := fmt.Sprintf(format, v...)
+	log.WarningDepth(1, s)
+}
+
+func (*glogLogger) Error(v ...interface{}) {
+	log.ErrorDepth(1, v...)
+}
+
+func (*glogLogger) Errorf(format string, v ...interface{}) {
+	s := fmt.Sprintf(format, v...)
+	log.ErrorDepth(1, s)
+}
+
+func (*glogLogger) Fatal(v ...interface{}) {
+	log.FatalDepth(1, v...)
+}
+
+func (*glogLogger) Fatalf(format string, v ...interface{}) {
+	s := fmt.Sprintf(format, v...)
+	log.FatalDepth(1, s)
+}
+
+func (*glogLogger) Panic(v ...interface{}) {
+	s := fmt.Sprint(v...)
+	log.ErrorDepth(1, s)
+	panic(s)
+}
+
+func (*glogLogger) Panicf(format string, v ...interface{}) {
+	s := fmt.Sprintf(format, v...)
+	log.ErrorDepth(1, s)
+	panic(s)
+}

--- a/util/log/log.go
+++ b/util/log/log.go
@@ -20,7 +20,6 @@ package log
 import "github.com/golang/glog"
 
 func init() {
-	// Raft logs verbosely with log.Printf.
 	glog.CopyStandardLogTo("INFO")
 }
 
@@ -46,6 +45,9 @@ var Infof = glog.Infof
 // Arguments are handled in the manner of fmt.Println; a newline is appended if missing.
 var Infoln = glog.Infoln
 
+// InfoDepth logs to the INFO log, ofsetting the caller's stack frame by 'depth'
+var InfoDepth = glog.InfoDepth
+
 // Warning logs to the INFO and WARNING logs.
 // Arguments are handled in the manner of fmt.Print; a newline is appended if missing.
 var Warning = glog.Warning
@@ -58,6 +60,9 @@ var Warningf = glog.Warningf
 // Arguments are handled in the manner of fmt.Println; a newline is appended if missing.
 var Warningln = glog.Warningln
 
+// WarningDepth logs to the INFO and WARNING logs, ofsetting the caller's stack frame by 'depth'
+var WarningDepth = glog.WarningDepth
+
 // Error logs to the INFO, WARNING, and ERROR logs.
 // Arguments are handled in the manner of fmt.Print; a newline is appended if missing.
 var Error = glog.Error
@@ -69,6 +74,10 @@ var Errorf = glog.Errorf
 // Errorln logs to the INFO, WARNING, and ERROR logs.
 // Arguments are handled in the manner of fmt.Println; a newline is appended if missing.
 var Errorln = glog.Errorln
+
+// ErrorDepth logs to the INFO, WARNING, and ERROR logs, ofsetting the caller's stack
+// frame by 'depth'
+var ErrorDepth = glog.ErrorDepth
 
 // Fatal logs to the INFO, WARNING, ERROR, and FATAL logs,
 // including a stack trace of all running goroutines, then calls os.Exit(255).
@@ -84,6 +93,10 @@ var Fatalf = glog.Fatalf
 // including a stack trace of all running goroutines, then calls os.Exit(255).
 // Arguments are handled in the manner of fmt.Println; a newline is appended if missing.
 var Fatalln = glog.Fatalln
+
+// FatalDepth logs to the INFO, WARNING, and ERROR, and FATAL logs, ofsetting the caller's stack
+// frame by 'depth', then calls os.Exit(255).
+var FatalDepth = glog.FatalDepth
 
 // V wraps glog.V. See that documentation for details.
 var V = glog.V


### PR DESCRIPTION
Raft now has a pluggable logger interface instead of using log.Printf
directly.
