### PR TITLE
Wrap all the commit triggers in a single message.

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -64,14 +64,5 @@
     cluster. Only stores finding themselves in the top N space
     utilized set may have rebalances in effect.
 
-* Cleanup proto files to adhere to proto capitalization instead of go's.
-
 * Implement split / merge range queue and remove check for split on
   every read/write range command.
-
-* Move split/merge trigger into a submessage in internal.proto / api.proto.
-  This will simplify the logic in kv/db.go for neutering any public-facing
-  request which specifies triggers.
-
-* Unexport range.Desc and make func (r *Range) Desc() proto.RangeDescriptor
-  mutex-protected accessor method.

--- a/kv/db.go
+++ b/kv/db.go
@@ -40,14 +40,8 @@ var allowedEncodings = []util.EncodingType{util.JSONEncoding, util.ProtoEncoding
 func verifyRequest(args proto.Request) error {
 	switch t := args.(type) {
 	case *proto.EndTransactionRequest:
-		if t.SplitTrigger != nil {
-			return util.Errorf("EndTransaction request from public KV API contains split trigger: %+v", t.GetSplitTrigger())
-		}
-		if t.MergeTrigger != nil {
-			return util.Errorf("EndTransaction request from public KV API contains merge trigger: %+v", t.GetMergeTrigger())
-		}
-		if t.ChangeReplicasTrigger != nil {
-			return util.Errorf("EndTransaction request from public KV API contains change replicas trigger: %+v", t.GetChangeReplicasTrigger())
+		if t.InternalCommitTrigger != nil {
+			return util.Errorf("EndTransaction request from public KV API contains commit trigger: %+v", t.GetInternalCommitTrigger())
 		}
 	}
 	return nil

--- a/kv/db_test.go
+++ b/kv/db_test.go
@@ -188,7 +188,7 @@ func TestKVDBInternalMethods(t *testing.T) {
 }
 
 // TestKVDBEndTransactionWithTriggers verifies that triggers are
-// stripped on call to EndTransaction.
+// disallowed on call to EndTransaction.
 func TestKVDBEndTransactionWithTriggers(t *testing.T) {
 	addr, server, _ := startServer(t)
 	defer server.Close()
@@ -202,8 +202,10 @@ func TestKVDBEndTransactionWithTriggers(t *testing.T) {
 		return txn.Call(proto.EndTransaction, &proto.EndTransactionRequest{
 			RequestHeader: proto.RequestHeader{Key: proto.Key("foo")},
 			Commit:        true,
-			SplitTrigger: &proto.SplitTrigger{
-				UpdatedDesc: proto.RangeDescriptor{StartKey: proto.Key("bar")},
+			InternalCommitTrigger: &proto.InternalCommitTrigger{
+				SplitTrigger: &proto.SplitTrigger{
+					UpdatedDesc: proto.RangeDescriptor{StartKey: proto.Key("bar")},
+				},
 			},
 		}, &proto.EndTransactionResponse{})
 	})

--- a/proto/api.pb.go
+++ b/proto/api.pb.go
@@ -529,12 +529,7 @@ type EndTransactionRequest struct {
 	// Optional commit triggers. Note that commit triggers are for
 	// internal use only and will be ignored if requested through the
 	// public-facing KV API.
-	// All trigger fields must be added to verifyRequest in kv/db.go.
-	// TODO(bdarnell): add a wrapper object for triggers so we don't have to
-	// check for them individually.
-	SplitTrigger          *SplitTrigger          `protobuf:"bytes,3,opt,name=split_trigger" json:"split_trigger,omitempty"`
-	MergeTrigger          *MergeTrigger          `protobuf:"bytes,4,opt,name=merge_trigger" json:"merge_trigger,omitempty"`
-	ChangeReplicasTrigger *ChangeReplicasTrigger `protobuf:"bytes,5,opt,name=change_replicas_trigger" json:"change_replicas_trigger,omitempty"`
+	InternalCommitTrigger *InternalCommitTrigger `protobuf:"bytes,3,opt,name=internal_commit_trigger" json:"internal_commit_trigger,omitempty"`
 	XXX_unrecognized      []byte                 `json:"-"`
 }
 
@@ -549,23 +544,9 @@ func (m *EndTransactionRequest) GetCommit() bool {
 	return false
 }
 
-func (m *EndTransactionRequest) GetSplitTrigger() *SplitTrigger {
+func (m *EndTransactionRequest) GetInternalCommitTrigger() *InternalCommitTrigger {
 	if m != nil {
-		return m.SplitTrigger
-	}
-	return nil
-}
-
-func (m *EndTransactionRequest) GetMergeTrigger() *MergeTrigger {
-	if m != nil {
-		return m.MergeTrigger
-	}
-	return nil
-}
-
-func (m *EndTransactionRequest) GetChangeReplicasTrigger() *ChangeReplicasTrigger {
-	if m != nil {
-		return m.ChangeReplicasTrigger
+		return m.InternalCommitTrigger
 	}
 	return nil
 }

--- a/proto/api.proto
+++ b/proto/api.proto
@@ -232,12 +232,7 @@ message EndTransactionRequest {
   // Optional commit triggers. Note that commit triggers are for
   // internal use only and will be ignored if requested through the
   // public-facing KV API.
-  // All trigger fields must be added to verifyRequest in kv/db.go.
-  // TODO(bdarnell): add a wrapper object for triggers so we don't have to
-  // check for them individually.
-  optional SplitTrigger split_trigger = 3;
-  optional MergeTrigger merge_trigger = 4;
-  optional ChangeReplicasTrigger change_replicas_trigger = 5;
+  optional InternalCommitTrigger internal_commit_trigger = 3;
 }
 
 // An EndTransactionResponse is the return value from the

--- a/proto/data.pb.go
+++ b/proto/data.pb.go
@@ -401,6 +401,39 @@ func (m *ChangeReplicasTrigger) GetUpdatedReplicas() []Replica {
 	return nil
 }
 
+// CommitTrigger encapsulates all of the internal-only commit triggers.
+type InternalCommitTrigger struct {
+	SplitTrigger          *SplitTrigger          `protobuf:"bytes,1,opt,name=split_trigger" json:"split_trigger,omitempty"`
+	MergeTrigger          *MergeTrigger          `protobuf:"bytes,2,opt,name=merge_trigger" json:"merge_trigger,omitempty"`
+	ChangeReplicasTrigger *ChangeReplicasTrigger `protobuf:"bytes,3,opt,name=change_replicas_trigger" json:"change_replicas_trigger,omitempty"`
+	XXX_unrecognized      []byte                 `json:"-"`
+}
+
+func (m *InternalCommitTrigger) Reset()         { *m = InternalCommitTrigger{} }
+func (m *InternalCommitTrigger) String() string { return proto1.CompactTextString(m) }
+func (*InternalCommitTrigger) ProtoMessage()    {}
+
+func (m *InternalCommitTrigger) GetSplitTrigger() *SplitTrigger {
+	if m != nil {
+		return m.SplitTrigger
+	}
+	return nil
+}
+
+func (m *InternalCommitTrigger) GetMergeTrigger() *MergeTrigger {
+	if m != nil {
+		return m.MergeTrigger
+	}
+	return nil
+}
+
+func (m *InternalCommitTrigger) GetChangeReplicasTrigger() *ChangeReplicasTrigger {
+	if m != nil {
+		return m.ChangeReplicasTrigger
+	}
+	return nil
+}
+
 // NodeList keeps a growing set of NodeIDs as a sorted slice, with Add()
 // adding to the set and Contains() verifying membership.
 type NodeList struct {

--- a/proto/data.proto
+++ b/proto/data.proto
@@ -133,6 +133,13 @@ message ChangeReplicasTrigger {
   repeated Replica updated_replicas = 4 [(gogoproto.nullable) = false];
 }
 
+// CommitTrigger encapsulates all of the internal-only commit triggers.
+message InternalCommitTrigger {
+  optional SplitTrigger split_trigger = 1;
+  optional MergeTrigger merge_trigger = 2;
+  optional ChangeReplicasTrigger change_replicas_trigger = 3;
+}
+
 // IsolationType TODO(jiajia) Needs documentation.
 enum IsolationType {
   option (gogoproto.goproto_enum_prefix) = false;

--- a/proto/errors.pb.go
+++ b/proto/errors.pb.go
@@ -142,7 +142,7 @@ func (m *TransactionAbortedError) GetTxn() Transaction {
 }
 
 // A TransactionPushError indicates that the transaction could not
-// continu because it encountered a write intent from another
+// continue because it encountered a write intent from another
 // transaction which it was unable to push.
 type TransactionPushError struct {
 	// txn can be null in the event the push error happened to a

--- a/storage/engine/api.pb.cc
+++ b/storage/engine/api.pb.cc
@@ -443,12 +443,10 @@ void protobuf_AssignDesc_api_2eproto() {
       ::google::protobuf::MessageFactory::generated_factory(),
       sizeof(ScanResponse));
   EndTransactionRequest_descriptor_ = file->message_type(19);
-  static const int EndTransactionRequest_offsets_[5] = {
+  static const int EndTransactionRequest_offsets_[3] = {
     GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(EndTransactionRequest, header_),
     GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(EndTransactionRequest, commit_),
-    GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(EndTransactionRequest, split_trigger_),
-    GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(EndTransactionRequest, merge_trigger_),
-    GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(EndTransactionRequest, change_replicas_trigger_),
+    GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(EndTransactionRequest, internal_commit_trigger_),
   };
   EndTransactionRequest_reflection_ =
     new ::google::protobuf::internal::GeneratedMessageReflection(
@@ -936,72 +934,70 @@ void protobuf_AddDesc_api_2eproto() {
     "\010\310\336\037\000\320\336\037\001\022\031\n\013max_results\030\002 \001(\003B\004\310\336\037\000\"d\n\014"
     "ScanResponse\022/\n\006header\030\001 \001(\0132\025.proto.Res"
     "ponseHeaderB\010\310\336\037\000\320\336\037\001\022#\n\004rows\030\002 \003(\0132\017.pr"
-    "oto.KeyValueB\004\310\336\037\000\"\364\001\n\025EndTransactionReq"
+    "oto.KeyValueB\004\310\336\037\000\"\234\001\n\025EndTransactionReq"
     "uest\022.\n\006header\030\001 \001(\0132\024.proto.RequestHead"
-    "erB\010\310\336\037\000\320\336\037\001\022\024\n\006commit\030\002 \001(\010B\004\310\336\037\000\022*\n\rsp"
-    "lit_trigger\030\003 \001(\0132\023.proto.SplitTrigger\022*"
-    "\n\rmerge_trigger\030\004 \001(\0132\023.proto.MergeTrigg"
-    "er\022=\n\027change_replicas_trigger\030\005 \001(\0132\034.pr"
-    "oto.ChangeReplicasTrigger\"d\n\026EndTransact"
-    "ionResponse\022/\n\006header\030\001 \001(\0132\025.proto.Resp"
-    "onseHeaderB\010\310\336\037\000\320\336\037\001\022\031\n\013commit_wait\030\002 \001("
-    "\003B\004\310\336\037\000\"]\n\020ReapQueueRequest\022.\n\006header\030\001 "
-    "\001(\0132\024.proto.RequestHeaderB\010\310\336\037\000\320\336\037\001\022\031\n\013m"
-    "ax_results\030\002 \001(\003B\004\310\336\037\000\"j\n\021ReapQueueRespo"
+    "erB\010\310\336\037\000\320\336\037\001\022\024\n\006commit\030\002 \001(\010B\004\310\336\037\000\022=\n\027in"
+    "ternal_commit_trigger\030\003 \001(\0132\034.proto.Inte"
+    "rnalCommitTrigger\"d\n\026EndTransactionRespo"
     "nse\022/\n\006header\030\001 \001(\0132\025.proto.ResponseHead"
-    "erB\010\310\336\037\000\320\336\037\001\022$\n\010messages\030\002 \003(\0132\014.proto.V"
-    "alueB\004\310\336\037\000\"F\n\024EnqueueUpdateRequest\022.\n\006he"
-    "ader\030\001 \001(\0132\024.proto.RequestHeaderB\010\310\336\037\000\320\336"
-    "\037\001\"H\n\025EnqueueUpdateResponse\022/\n\006header\030\001 "
-    "\001(\0132\025.proto.ResponseHeaderB\010\310\336\037\000\320\336\037\001\"h\n\025"
-    "EnqueueMessageRequest\022.\n\006header\030\001 \001(\0132\024."
-    "proto.RequestHeaderB\010\310\336\037\000\320\336\037\001\022\037\n\003msg\030\002 \001"
-    "(\0132\014.proto.ValueB\004\310\336\037\000\"I\n\026EnqueueMessage"
-    "Response\022/\n\006header\030\001 \001(\0132\025.proto.Respons"
-    "eHeaderB\010\310\336\037\000\320\336\037\001\"\252\004\n\014RequestUnion\022(\n\010co"
-    "ntains\030\001 \001(\0132\026.proto.ContainsRequest\022\036\n\003"
-    "get\030\002 \001(\0132\021.proto.GetRequest\022\036\n\003put\030\003 \001("
-    "\0132\021.proto.PutRequest\0225\n\017conditional_put\030"
-    "\004 \001(\0132\034.proto.ConditionalPutRequest\022*\n\ti"
-    "ncrement\030\005 \001(\0132\027.proto.IncrementRequest\022"
-    "$\n\006delete\030\006 \001(\0132\024.proto.DeleteRequest\022/\n"
-    "\014delete_range\030\007 \001(\0132\031.proto.DeleteRangeR"
-    "equest\022 \n\004scan\030\010 \001(\0132\022.proto.ScanRequest"
-    "\0225\n\017end_transaction\030\t \001(\0132\034.proto.EndTra"
-    "nsactionRequest\022+\n\nreap_queue\030\n \001(\0132\027.pr"
-    "oto.ReapQueueRequest\0223\n\016enqueue_update\030\013"
-    " \001(\0132\033.proto.EnqueueUpdateRequest\0225\n\017enq"
-    "ueue_message\030\014 \001(\0132\034.proto.EnqueueMessag"
-    "eRequest:\004\310\240\037\001\"\267\004\n\rResponseUnion\022)\n\010cont"
-    "ains\030\001 \001(\0132\027.proto.ContainsResponse\022\037\n\003g"
-    "et\030\002 \001(\0132\022.proto.GetResponse\022\037\n\003put\030\003 \001("
-    "\0132\022.proto.PutResponse\0226\n\017conditional_put"
-    "\030\004 \001(\0132\035.proto.ConditionalPutResponse\022+\n"
-    "\tincrement\030\005 \001(\0132\030.proto.IncrementRespon"
-    "se\022%\n\006delete\030\006 \001(\0132\025.proto.DeleteRespons"
-    "e\0220\n\014delete_range\030\007 \001(\0132\032.proto.DeleteRa"
-    "ngeResponse\022!\n\004scan\030\010 \001(\0132\023.proto.ScanRe"
-    "sponse\0226\n\017end_transaction\030\t \001(\0132\035.proto."
-    "EndTransactionResponse\022,\n\nreap_queue\030\n \001"
-    "(\0132\030.proto.ReapQueueResponse\0224\n\016enqueue_"
-    "update\030\013 \001(\0132\034.proto.EnqueueUpdateRespon"
-    "se\0226\n\017enqueue_message\030\014 \001(\0132\035.proto.Enqu"
-    "eueMessageResponse:\004\310\240\037\001\"k\n\014BatchRequest"
-    "\022.\n\006header\030\001 \001(\0132\024.proto.RequestHeaderB\010"
-    "\310\336\037\000\320\336\037\001\022+\n\010requests\030\002 \003(\0132\023.proto.Reque"
-    "stUnionB\004\310\336\037\000\"o\n\rBatchResponse\022/\n\006header"
-    "\030\001 \001(\0132\025.proto.ResponseHeaderB\010\310\336\037\000\320\336\037\001\022"
-    "-\n\tresponses\030\002 \003(\0132\024.proto.ResponseUnion"
-    "B\004\310\336\037\000\"c\n\021AdminSplitRequest\022.\n\006header\030\001 "
-    "\001(\0132\024.proto.RequestHeaderB\010\310\336\037\000\320\336\037\001\022\036\n\ts"
-    "plit_key\030\002 \001(\014B\013\310\336\037\000\332\336\037\003Key\"E\n\022AdminSpli"
-    "tResponse\022/\n\006header\030\001 \001(\0132\025.proto.Respon"
-    "seHeaderB\010\310\336\037\000\320\336\037\001\"y\n\021AdminMergeRequest\022"
-    ".\n\006header\030\001 \001(\0132\024.proto.RequestHeaderB\010\310"
-    "\336\037\000\320\336\037\001\0224\n\016subsumed_range\030\002 \001(\0132\026.proto."
-    "RangeDescriptorB\004\310\336\037\000\"E\n\022AdminMergeRespo"
-    "nse\022/\n\006header\030\001 \001(\0132\025.proto.ResponseHead"
-    "erB\010\310\336\037\000\320\336\037\001", 4612);
+    "erB\010\310\336\037\000\320\336\037\001\022\031\n\013commit_wait\030\002 \001(\003B\004\310\336\037\000\""
+    "]\n\020ReapQueueRequest\022.\n\006header\030\001 \001(\0132\024.pr"
+    "oto.RequestHeaderB\010\310\336\037\000\320\336\037\001\022\031\n\013max_resul"
+    "ts\030\002 \001(\003B\004\310\336\037\000\"j\n\021ReapQueueResponse\022/\n\006h"
+    "eader\030\001 \001(\0132\025.proto.ResponseHeaderB\010\310\336\037\000"
+    "\320\336\037\001\022$\n\010messages\030\002 \003(\0132\014.proto.ValueB\004\310\336"
+    "\037\000\"F\n\024EnqueueUpdateRequest\022.\n\006header\030\001 \001"
+    "(\0132\024.proto.RequestHeaderB\010\310\336\037\000\320\336\037\001\"H\n\025En"
+    "queueUpdateResponse\022/\n\006header\030\001 \001(\0132\025.pr"
+    "oto.ResponseHeaderB\010\310\336\037\000\320\336\037\001\"h\n\025EnqueueM"
+    "essageRequest\022.\n\006header\030\001 \001(\0132\024.proto.Re"
+    "questHeaderB\010\310\336\037\000\320\336\037\001\022\037\n\003msg\030\002 \001(\0132\014.pro"
+    "to.ValueB\004\310\336\037\000\"I\n\026EnqueueMessageResponse"
+    "\022/\n\006header\030\001 \001(\0132\025.proto.ResponseHeaderB"
+    "\010\310\336\037\000\320\336\037\001\"\252\004\n\014RequestUnion\022(\n\010contains\030\001"
+    " \001(\0132\026.proto.ContainsRequest\022\036\n\003get\030\002 \001("
+    "\0132\021.proto.GetRequest\022\036\n\003put\030\003 \001(\0132\021.prot"
+    "o.PutRequest\0225\n\017conditional_put\030\004 \001(\0132\034."
+    "proto.ConditionalPutRequest\022*\n\tincrement"
+    "\030\005 \001(\0132\027.proto.IncrementRequest\022$\n\006delet"
+    "e\030\006 \001(\0132\024.proto.DeleteRequest\022/\n\014delete_"
+    "range\030\007 \001(\0132\031.proto.DeleteRangeRequest\022 "
+    "\n\004scan\030\010 \001(\0132\022.proto.ScanRequest\0225\n\017end_"
+    "transaction\030\t \001(\0132\034.proto.EndTransaction"
+    "Request\022+\n\nreap_queue\030\n \001(\0132\027.proto.Reap"
+    "QueueRequest\0223\n\016enqueue_update\030\013 \001(\0132\033.p"
+    "roto.EnqueueUpdateRequest\0225\n\017enqueue_mes"
+    "sage\030\014 \001(\0132\034.proto.EnqueueMessageRequest"
+    ":\004\310\240\037\001\"\267\004\n\rResponseUnion\022)\n\010contains\030\001 \001"
+    "(\0132\027.proto.ContainsResponse\022\037\n\003get\030\002 \001(\013"
+    "2\022.proto.GetResponse\022\037\n\003put\030\003 \001(\0132\022.prot"
+    "o.PutResponse\0226\n\017conditional_put\030\004 \001(\0132\035"
+    ".proto.ConditionalPutResponse\022+\n\tincreme"
+    "nt\030\005 \001(\0132\030.proto.IncrementResponse\022%\n\006de"
+    "lete\030\006 \001(\0132\025.proto.DeleteResponse\0220\n\014del"
+    "ete_range\030\007 \001(\0132\032.proto.DeleteRangeRespo"
+    "nse\022!\n\004scan\030\010 \001(\0132\023.proto.ScanResponse\0226"
+    "\n\017end_transaction\030\t \001(\0132\035.proto.EndTrans"
+    "actionResponse\022,\n\nreap_queue\030\n \001(\0132\030.pro"
+    "to.ReapQueueResponse\0224\n\016enqueue_update\030\013"
+    " \001(\0132\034.proto.EnqueueUpdateResponse\0226\n\017en"
+    "queue_message\030\014 \001(\0132\035.proto.EnqueueMessa"
+    "geResponse:\004\310\240\037\001\"k\n\014BatchRequest\022.\n\006head"
+    "er\030\001 \001(\0132\024.proto.RequestHeaderB\010\310\336\037\000\320\336\037\001"
+    "\022+\n\010requests\030\002 \003(\0132\023.proto.RequestUnionB"
+    "\004\310\336\037\000\"o\n\rBatchResponse\022/\n\006header\030\001 \001(\0132\025"
+    ".proto.ResponseHeaderB\010\310\336\037\000\320\336\037\001\022-\n\trespo"
+    "nses\030\002 \003(\0132\024.proto.ResponseUnionB\004\310\336\037\000\"c"
+    "\n\021AdminSplitRequest\022.\n\006header\030\001 \001(\0132\024.pr"
+    "oto.RequestHeaderB\010\310\336\037\000\320\336\037\001\022\036\n\tsplit_key"
+    "\030\002 \001(\014B\013\310\336\037\000\332\336\037\003Key\"E\n\022AdminSplitRespons"
+    "e\022/\n\006header\030\001 \001(\0132\025.proto.ResponseHeader"
+    "B\010\310\336\037\000\320\336\037\001\"y\n\021AdminMergeRequest\022.\n\006heade"
+    "r\030\001 \001(\0132\024.proto.RequestHeaderB\010\310\336\037\000\320\336\037\001\022"
+    "4\n\016subsumed_range\030\002 \001(\0132\026.proto.RangeDes"
+    "criptorB\004\310\336\037\000\"E\n\022AdminMergeResponse\022/\n\006h"
+    "eader\030\001 \001(\0132\025.proto.ResponseHeaderB\010\310\336\037\000"
+    "\320\336\037\001", 4524);
   ::google::protobuf::MessageFactory::InternalRegisterGeneratedFile(
     "api.proto", &protobuf_RegisterTypes);
   ClientCmdID::default_instance_ = new ClientCmdID();
@@ -6374,9 +6370,7 @@ void ScanResponse::Swap(ScanResponse* other) {
 #ifndef _MSC_VER
 const int EndTransactionRequest::kHeaderFieldNumber;
 const int EndTransactionRequest::kCommitFieldNumber;
-const int EndTransactionRequest::kSplitTriggerFieldNumber;
-const int EndTransactionRequest::kMergeTriggerFieldNumber;
-const int EndTransactionRequest::kChangeReplicasTriggerFieldNumber;
+const int EndTransactionRequest::kInternalCommitTriggerFieldNumber;
 #endif  // !_MSC_VER
 
 EndTransactionRequest::EndTransactionRequest()
@@ -6387,9 +6381,7 @@ EndTransactionRequest::EndTransactionRequest()
 
 void EndTransactionRequest::InitAsDefaultInstance() {
   header_ = const_cast< ::proto::RequestHeader*>(&::proto::RequestHeader::default_instance());
-  split_trigger_ = const_cast< ::proto::SplitTrigger*>(&::proto::SplitTrigger::default_instance());
-  merge_trigger_ = const_cast< ::proto::MergeTrigger*>(&::proto::MergeTrigger::default_instance());
-  change_replicas_trigger_ = const_cast< ::proto::ChangeReplicasTrigger*>(&::proto::ChangeReplicasTrigger::default_instance());
+  internal_commit_trigger_ = const_cast< ::proto::InternalCommitTrigger*>(&::proto::InternalCommitTrigger::default_instance());
 }
 
 EndTransactionRequest::EndTransactionRequest(const EndTransactionRequest& from)
@@ -6403,9 +6395,7 @@ void EndTransactionRequest::SharedCtor() {
   _cached_size_ = 0;
   header_ = NULL;
   commit_ = false;
-  split_trigger_ = NULL;
-  merge_trigger_ = NULL;
-  change_replicas_trigger_ = NULL;
+  internal_commit_trigger_ = NULL;
   ::memset(_has_bits_, 0, sizeof(_has_bits_));
 }
 
@@ -6417,9 +6407,7 @@ EndTransactionRequest::~EndTransactionRequest() {
 void EndTransactionRequest::SharedDtor() {
   if (this != default_instance_) {
     delete header_;
-    delete split_trigger_;
-    delete merge_trigger_;
-    delete change_replicas_trigger_;
+    delete internal_commit_trigger_;
   }
 }
 
@@ -6445,19 +6433,13 @@ EndTransactionRequest* EndTransactionRequest::New() const {
 }
 
 void EndTransactionRequest::Clear() {
-  if (_has_bits_[0 / 32] & 31) {
+  if (_has_bits_[0 / 32] & 7) {
     if (has_header()) {
       if (header_ != NULL) header_->::proto::RequestHeader::Clear();
     }
     commit_ = false;
-    if (has_split_trigger()) {
-      if (split_trigger_ != NULL) split_trigger_->::proto::SplitTrigger::Clear();
-    }
-    if (has_merge_trigger()) {
-      if (merge_trigger_ != NULL) merge_trigger_->::proto::MergeTrigger::Clear();
-    }
-    if (has_change_replicas_trigger()) {
-      if (change_replicas_trigger_ != NULL) change_replicas_trigger_->::proto::ChangeReplicasTrigger::Clear();
+    if (has_internal_commit_trigger()) {
+      if (internal_commit_trigger_ != NULL) internal_commit_trigger_->::proto::InternalCommitTrigger::Clear();
     }
   }
   ::memset(_has_bits_, 0, sizeof(_has_bits_));
@@ -6497,42 +6479,16 @@ bool EndTransactionRequest::MergePartialFromCodedStream(
         } else {
           goto handle_unusual;
         }
-        if (input->ExpectTag(26)) goto parse_split_trigger;
+        if (input->ExpectTag(26)) goto parse_internal_commit_trigger;
         break;
       }
 
-      // optional .proto.SplitTrigger split_trigger = 3;
+      // optional .proto.InternalCommitTrigger internal_commit_trigger = 3;
       case 3: {
         if (tag == 26) {
-         parse_split_trigger:
+         parse_internal_commit_trigger:
           DO_(::google::protobuf::internal::WireFormatLite::ReadMessageNoVirtual(
-               input, mutable_split_trigger()));
-        } else {
-          goto handle_unusual;
-        }
-        if (input->ExpectTag(34)) goto parse_merge_trigger;
-        break;
-      }
-
-      // optional .proto.MergeTrigger merge_trigger = 4;
-      case 4: {
-        if (tag == 34) {
-         parse_merge_trigger:
-          DO_(::google::protobuf::internal::WireFormatLite::ReadMessageNoVirtual(
-               input, mutable_merge_trigger()));
-        } else {
-          goto handle_unusual;
-        }
-        if (input->ExpectTag(42)) goto parse_change_replicas_trigger;
-        break;
-      }
-
-      // optional .proto.ChangeReplicasTrigger change_replicas_trigger = 5;
-      case 5: {
-        if (tag == 42) {
-         parse_change_replicas_trigger:
-          DO_(::google::protobuf::internal::WireFormatLite::ReadMessageNoVirtual(
-               input, mutable_change_replicas_trigger()));
+               input, mutable_internal_commit_trigger()));
         } else {
           goto handle_unusual;
         }
@@ -6576,22 +6532,10 @@ void EndTransactionRequest::SerializeWithCachedSizes(
     ::google::protobuf::internal::WireFormatLite::WriteBool(2, this->commit(), output);
   }
 
-  // optional .proto.SplitTrigger split_trigger = 3;
-  if (has_split_trigger()) {
+  // optional .proto.InternalCommitTrigger internal_commit_trigger = 3;
+  if (has_internal_commit_trigger()) {
     ::google::protobuf::internal::WireFormatLite::WriteMessageMaybeToArray(
-      3, this->split_trigger(), output);
-  }
-
-  // optional .proto.MergeTrigger merge_trigger = 4;
-  if (has_merge_trigger()) {
-    ::google::protobuf::internal::WireFormatLite::WriteMessageMaybeToArray(
-      4, this->merge_trigger(), output);
-  }
-
-  // optional .proto.ChangeReplicasTrigger change_replicas_trigger = 5;
-  if (has_change_replicas_trigger()) {
-    ::google::protobuf::internal::WireFormatLite::WriteMessageMaybeToArray(
-      5, this->change_replicas_trigger(), output);
+      3, this->internal_commit_trigger(), output);
   }
 
   if (!unknown_fields().empty()) {
@@ -6616,25 +6560,11 @@ void EndTransactionRequest::SerializeWithCachedSizes(
     target = ::google::protobuf::internal::WireFormatLite::WriteBoolToArray(2, this->commit(), target);
   }
 
-  // optional .proto.SplitTrigger split_trigger = 3;
-  if (has_split_trigger()) {
+  // optional .proto.InternalCommitTrigger internal_commit_trigger = 3;
+  if (has_internal_commit_trigger()) {
     target = ::google::protobuf::internal::WireFormatLite::
       WriteMessageNoVirtualToArray(
-        3, this->split_trigger(), target);
-  }
-
-  // optional .proto.MergeTrigger merge_trigger = 4;
-  if (has_merge_trigger()) {
-    target = ::google::protobuf::internal::WireFormatLite::
-      WriteMessageNoVirtualToArray(
-        4, this->merge_trigger(), target);
-  }
-
-  // optional .proto.ChangeReplicasTrigger change_replicas_trigger = 5;
-  if (has_change_replicas_trigger()) {
-    target = ::google::protobuf::internal::WireFormatLite::
-      WriteMessageNoVirtualToArray(
-        5, this->change_replicas_trigger(), target);
+        3, this->internal_commit_trigger(), target);
   }
 
   if (!unknown_fields().empty()) {
@@ -6661,25 +6591,11 @@ int EndTransactionRequest::ByteSize() const {
       total_size += 1 + 1;
     }
 
-    // optional .proto.SplitTrigger split_trigger = 3;
-    if (has_split_trigger()) {
+    // optional .proto.InternalCommitTrigger internal_commit_trigger = 3;
+    if (has_internal_commit_trigger()) {
       total_size += 1 +
         ::google::protobuf::internal::WireFormatLite::MessageSizeNoVirtual(
-          this->split_trigger());
-    }
-
-    // optional .proto.MergeTrigger merge_trigger = 4;
-    if (has_merge_trigger()) {
-      total_size += 1 +
-        ::google::protobuf::internal::WireFormatLite::MessageSizeNoVirtual(
-          this->merge_trigger());
-    }
-
-    // optional .proto.ChangeReplicasTrigger change_replicas_trigger = 5;
-    if (has_change_replicas_trigger()) {
-      total_size += 1 +
-        ::google::protobuf::internal::WireFormatLite::MessageSizeNoVirtual(
-          this->change_replicas_trigger());
+          this->internal_commit_trigger());
     }
 
   }
@@ -6715,14 +6631,8 @@ void EndTransactionRequest::MergeFrom(const EndTransactionRequest& from) {
     if (from.has_commit()) {
       set_commit(from.commit());
     }
-    if (from.has_split_trigger()) {
-      mutable_split_trigger()->::proto::SplitTrigger::MergeFrom(from.split_trigger());
-    }
-    if (from.has_merge_trigger()) {
-      mutable_merge_trigger()->::proto::MergeTrigger::MergeFrom(from.merge_trigger());
-    }
-    if (from.has_change_replicas_trigger()) {
-      mutable_change_replicas_trigger()->::proto::ChangeReplicasTrigger::MergeFrom(from.change_replicas_trigger());
+    if (from.has_internal_commit_trigger()) {
+      mutable_internal_commit_trigger()->::proto::InternalCommitTrigger::MergeFrom(from.internal_commit_trigger());
     }
   }
   mutable_unknown_fields()->MergeFrom(from.unknown_fields());
@@ -6749,9 +6659,7 @@ void EndTransactionRequest::Swap(EndTransactionRequest* other) {
   if (other != this) {
     std::swap(header_, other->header_);
     std::swap(commit_, other->commit_);
-    std::swap(split_trigger_, other->split_trigger_);
-    std::swap(merge_trigger_, other->merge_trigger_);
-    std::swap(change_replicas_trigger_, other->change_replicas_trigger_);
+    std::swap(internal_commit_trigger_, other->internal_commit_trigger_);
     std::swap(_has_bits_[0], other->_has_bits_[0]);
     _unknown_fields_.Swap(&other->_unknown_fields_);
     std::swap(_cached_size_, other->_cached_size_);

--- a/storage/engine/api.pb.h
+++ b/storage/engine/api.pb.h
@@ -1937,32 +1937,14 @@ class EndTransactionRequest : public ::google::protobuf::Message {
   inline bool commit() const;
   inline void set_commit(bool value);
 
-  // optional .proto.SplitTrigger split_trigger = 3;
-  inline bool has_split_trigger() const;
-  inline void clear_split_trigger();
-  static const int kSplitTriggerFieldNumber = 3;
-  inline const ::proto::SplitTrigger& split_trigger() const;
-  inline ::proto::SplitTrigger* mutable_split_trigger();
-  inline ::proto::SplitTrigger* release_split_trigger();
-  inline void set_allocated_split_trigger(::proto::SplitTrigger* split_trigger);
-
-  // optional .proto.MergeTrigger merge_trigger = 4;
-  inline bool has_merge_trigger() const;
-  inline void clear_merge_trigger();
-  static const int kMergeTriggerFieldNumber = 4;
-  inline const ::proto::MergeTrigger& merge_trigger() const;
-  inline ::proto::MergeTrigger* mutable_merge_trigger();
-  inline ::proto::MergeTrigger* release_merge_trigger();
-  inline void set_allocated_merge_trigger(::proto::MergeTrigger* merge_trigger);
-
-  // optional .proto.ChangeReplicasTrigger change_replicas_trigger = 5;
-  inline bool has_change_replicas_trigger() const;
-  inline void clear_change_replicas_trigger();
-  static const int kChangeReplicasTriggerFieldNumber = 5;
-  inline const ::proto::ChangeReplicasTrigger& change_replicas_trigger() const;
-  inline ::proto::ChangeReplicasTrigger* mutable_change_replicas_trigger();
-  inline ::proto::ChangeReplicasTrigger* release_change_replicas_trigger();
-  inline void set_allocated_change_replicas_trigger(::proto::ChangeReplicasTrigger* change_replicas_trigger);
+  // optional .proto.InternalCommitTrigger internal_commit_trigger = 3;
+  inline bool has_internal_commit_trigger() const;
+  inline void clear_internal_commit_trigger();
+  static const int kInternalCommitTriggerFieldNumber = 3;
+  inline const ::proto::InternalCommitTrigger& internal_commit_trigger() const;
+  inline ::proto::InternalCommitTrigger* mutable_internal_commit_trigger();
+  inline ::proto::InternalCommitTrigger* release_internal_commit_trigger();
+  inline void set_allocated_internal_commit_trigger(::proto::InternalCommitTrigger* internal_commit_trigger);
 
   // @@protoc_insertion_point(class_scope:proto.EndTransactionRequest)
  private:
@@ -1970,21 +1952,15 @@ class EndTransactionRequest : public ::google::protobuf::Message {
   inline void clear_has_header();
   inline void set_has_commit();
   inline void clear_has_commit();
-  inline void set_has_split_trigger();
-  inline void clear_has_split_trigger();
-  inline void set_has_merge_trigger();
-  inline void clear_has_merge_trigger();
-  inline void set_has_change_replicas_trigger();
-  inline void clear_has_change_replicas_trigger();
+  inline void set_has_internal_commit_trigger();
+  inline void clear_has_internal_commit_trigger();
 
   ::google::protobuf::UnknownFieldSet _unknown_fields_;
 
   ::google::protobuf::uint32 _has_bits_[1];
   mutable int _cached_size_;
   ::proto::RequestHeader* header_;
-  ::proto::SplitTrigger* split_trigger_;
-  ::proto::MergeTrigger* merge_trigger_;
-  ::proto::ChangeReplicasTrigger* change_replicas_trigger_;
+  ::proto::InternalCommitTrigger* internal_commit_trigger_;
   bool commit_;
   friend void  protobuf_AddDesc_api_2eproto();
   friend void protobuf_AssignDesc_api_2eproto();
@@ -5323,127 +5299,45 @@ inline void EndTransactionRequest::set_commit(bool value) {
   // @@protoc_insertion_point(field_set:proto.EndTransactionRequest.commit)
 }
 
-// optional .proto.SplitTrigger split_trigger = 3;
-inline bool EndTransactionRequest::has_split_trigger() const {
+// optional .proto.InternalCommitTrigger internal_commit_trigger = 3;
+inline bool EndTransactionRequest::has_internal_commit_trigger() const {
   return (_has_bits_[0] & 0x00000004u) != 0;
 }
-inline void EndTransactionRequest::set_has_split_trigger() {
+inline void EndTransactionRequest::set_has_internal_commit_trigger() {
   _has_bits_[0] |= 0x00000004u;
 }
-inline void EndTransactionRequest::clear_has_split_trigger() {
+inline void EndTransactionRequest::clear_has_internal_commit_trigger() {
   _has_bits_[0] &= ~0x00000004u;
 }
-inline void EndTransactionRequest::clear_split_trigger() {
-  if (split_trigger_ != NULL) split_trigger_->::proto::SplitTrigger::Clear();
-  clear_has_split_trigger();
+inline void EndTransactionRequest::clear_internal_commit_trigger() {
+  if (internal_commit_trigger_ != NULL) internal_commit_trigger_->::proto::InternalCommitTrigger::Clear();
+  clear_has_internal_commit_trigger();
 }
-inline const ::proto::SplitTrigger& EndTransactionRequest::split_trigger() const {
-  // @@protoc_insertion_point(field_get:proto.EndTransactionRequest.split_trigger)
-  return split_trigger_ != NULL ? *split_trigger_ : *default_instance_->split_trigger_;
+inline const ::proto::InternalCommitTrigger& EndTransactionRequest::internal_commit_trigger() const {
+  // @@protoc_insertion_point(field_get:proto.EndTransactionRequest.internal_commit_trigger)
+  return internal_commit_trigger_ != NULL ? *internal_commit_trigger_ : *default_instance_->internal_commit_trigger_;
 }
-inline ::proto::SplitTrigger* EndTransactionRequest::mutable_split_trigger() {
-  set_has_split_trigger();
-  if (split_trigger_ == NULL) split_trigger_ = new ::proto::SplitTrigger;
-  // @@protoc_insertion_point(field_mutable:proto.EndTransactionRequest.split_trigger)
-  return split_trigger_;
+inline ::proto::InternalCommitTrigger* EndTransactionRequest::mutable_internal_commit_trigger() {
+  set_has_internal_commit_trigger();
+  if (internal_commit_trigger_ == NULL) internal_commit_trigger_ = new ::proto::InternalCommitTrigger;
+  // @@protoc_insertion_point(field_mutable:proto.EndTransactionRequest.internal_commit_trigger)
+  return internal_commit_trigger_;
 }
-inline ::proto::SplitTrigger* EndTransactionRequest::release_split_trigger() {
-  clear_has_split_trigger();
-  ::proto::SplitTrigger* temp = split_trigger_;
-  split_trigger_ = NULL;
+inline ::proto::InternalCommitTrigger* EndTransactionRequest::release_internal_commit_trigger() {
+  clear_has_internal_commit_trigger();
+  ::proto::InternalCommitTrigger* temp = internal_commit_trigger_;
+  internal_commit_trigger_ = NULL;
   return temp;
 }
-inline void EndTransactionRequest::set_allocated_split_trigger(::proto::SplitTrigger* split_trigger) {
-  delete split_trigger_;
-  split_trigger_ = split_trigger;
-  if (split_trigger) {
-    set_has_split_trigger();
+inline void EndTransactionRequest::set_allocated_internal_commit_trigger(::proto::InternalCommitTrigger* internal_commit_trigger) {
+  delete internal_commit_trigger_;
+  internal_commit_trigger_ = internal_commit_trigger;
+  if (internal_commit_trigger) {
+    set_has_internal_commit_trigger();
   } else {
-    clear_has_split_trigger();
+    clear_has_internal_commit_trigger();
   }
-  // @@protoc_insertion_point(field_set_allocated:proto.EndTransactionRequest.split_trigger)
-}
-
-// optional .proto.MergeTrigger merge_trigger = 4;
-inline bool EndTransactionRequest::has_merge_trigger() const {
-  return (_has_bits_[0] & 0x00000008u) != 0;
-}
-inline void EndTransactionRequest::set_has_merge_trigger() {
-  _has_bits_[0] |= 0x00000008u;
-}
-inline void EndTransactionRequest::clear_has_merge_trigger() {
-  _has_bits_[0] &= ~0x00000008u;
-}
-inline void EndTransactionRequest::clear_merge_trigger() {
-  if (merge_trigger_ != NULL) merge_trigger_->::proto::MergeTrigger::Clear();
-  clear_has_merge_trigger();
-}
-inline const ::proto::MergeTrigger& EndTransactionRequest::merge_trigger() const {
-  // @@protoc_insertion_point(field_get:proto.EndTransactionRequest.merge_trigger)
-  return merge_trigger_ != NULL ? *merge_trigger_ : *default_instance_->merge_trigger_;
-}
-inline ::proto::MergeTrigger* EndTransactionRequest::mutable_merge_trigger() {
-  set_has_merge_trigger();
-  if (merge_trigger_ == NULL) merge_trigger_ = new ::proto::MergeTrigger;
-  // @@protoc_insertion_point(field_mutable:proto.EndTransactionRequest.merge_trigger)
-  return merge_trigger_;
-}
-inline ::proto::MergeTrigger* EndTransactionRequest::release_merge_trigger() {
-  clear_has_merge_trigger();
-  ::proto::MergeTrigger* temp = merge_trigger_;
-  merge_trigger_ = NULL;
-  return temp;
-}
-inline void EndTransactionRequest::set_allocated_merge_trigger(::proto::MergeTrigger* merge_trigger) {
-  delete merge_trigger_;
-  merge_trigger_ = merge_trigger;
-  if (merge_trigger) {
-    set_has_merge_trigger();
-  } else {
-    clear_has_merge_trigger();
-  }
-  // @@protoc_insertion_point(field_set_allocated:proto.EndTransactionRequest.merge_trigger)
-}
-
-// optional .proto.ChangeReplicasTrigger change_replicas_trigger = 5;
-inline bool EndTransactionRequest::has_change_replicas_trigger() const {
-  return (_has_bits_[0] & 0x00000010u) != 0;
-}
-inline void EndTransactionRequest::set_has_change_replicas_trigger() {
-  _has_bits_[0] |= 0x00000010u;
-}
-inline void EndTransactionRequest::clear_has_change_replicas_trigger() {
-  _has_bits_[0] &= ~0x00000010u;
-}
-inline void EndTransactionRequest::clear_change_replicas_trigger() {
-  if (change_replicas_trigger_ != NULL) change_replicas_trigger_->::proto::ChangeReplicasTrigger::Clear();
-  clear_has_change_replicas_trigger();
-}
-inline const ::proto::ChangeReplicasTrigger& EndTransactionRequest::change_replicas_trigger() const {
-  // @@protoc_insertion_point(field_get:proto.EndTransactionRequest.change_replicas_trigger)
-  return change_replicas_trigger_ != NULL ? *change_replicas_trigger_ : *default_instance_->change_replicas_trigger_;
-}
-inline ::proto::ChangeReplicasTrigger* EndTransactionRequest::mutable_change_replicas_trigger() {
-  set_has_change_replicas_trigger();
-  if (change_replicas_trigger_ == NULL) change_replicas_trigger_ = new ::proto::ChangeReplicasTrigger;
-  // @@protoc_insertion_point(field_mutable:proto.EndTransactionRequest.change_replicas_trigger)
-  return change_replicas_trigger_;
-}
-inline ::proto::ChangeReplicasTrigger* EndTransactionRequest::release_change_replicas_trigger() {
-  clear_has_change_replicas_trigger();
-  ::proto::ChangeReplicasTrigger* temp = change_replicas_trigger_;
-  change_replicas_trigger_ = NULL;
-  return temp;
-}
-inline void EndTransactionRequest::set_allocated_change_replicas_trigger(::proto::ChangeReplicasTrigger* change_replicas_trigger) {
-  delete change_replicas_trigger_;
-  change_replicas_trigger_ = change_replicas_trigger;
-  if (change_replicas_trigger) {
-    set_has_change_replicas_trigger();
-  } else {
-    clear_has_change_replicas_trigger();
-  }
-  // @@protoc_insertion_point(field_set_allocated:proto.EndTransactionRequest.change_replicas_trigger)
+  // @@protoc_insertion_point(field_set_allocated:proto.EndTransactionRequest.internal_commit_trigger)
 }
 
 // -------------------------------------------------------------------

--- a/storage/engine/data.pb.cc
+++ b/storage/engine/data.pb.cc
@@ -47,6 +47,9 @@ const ::google::protobuf::internal::GeneratedMessageReflection*
 const ::google::protobuf::Descriptor* ChangeReplicasTrigger_descriptor_ = NULL;
 const ::google::protobuf::internal::GeneratedMessageReflection*
   ChangeReplicasTrigger_reflection_ = NULL;
+const ::google::protobuf::Descriptor* InternalCommitTrigger_descriptor_ = NULL;
+const ::google::protobuf::internal::GeneratedMessageReflection*
+  InternalCommitTrigger_reflection_ = NULL;
 const ::google::protobuf::Descriptor* NodeList_descriptor_ = NULL;
 const ::google::protobuf::internal::GeneratedMessageReflection*
   NodeList_reflection_ = NULL;
@@ -228,7 +231,24 @@ void protobuf_AssignDesc_data_2eproto() {
       ::google::protobuf::DescriptorPool::generated_pool(),
       ::google::protobuf::MessageFactory::generated_factory(),
       sizeof(ChangeReplicasTrigger));
-  NodeList_descriptor_ = file->message_type(9);
+  InternalCommitTrigger_descriptor_ = file->message_type(9);
+  static const int InternalCommitTrigger_offsets_[3] = {
+    GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(InternalCommitTrigger, split_trigger_),
+    GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(InternalCommitTrigger, merge_trigger_),
+    GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(InternalCommitTrigger, change_replicas_trigger_),
+  };
+  InternalCommitTrigger_reflection_ =
+    new ::google::protobuf::internal::GeneratedMessageReflection(
+      InternalCommitTrigger_descriptor_,
+      InternalCommitTrigger::default_instance_,
+      InternalCommitTrigger_offsets_,
+      GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(InternalCommitTrigger, _has_bits_[0]),
+      GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(InternalCommitTrigger, _unknown_fields_),
+      -1,
+      ::google::protobuf::DescriptorPool::generated_pool(),
+      ::google::protobuf::MessageFactory::generated_factory(),
+      sizeof(InternalCommitTrigger));
+  NodeList_descriptor_ = file->message_type(10);
   static const int NodeList_offsets_[1] = {
     GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(NodeList, nodes_),
   };
@@ -243,7 +263,7 @@ void protobuf_AssignDesc_data_2eproto() {
       ::google::protobuf::DescriptorPool::generated_pool(),
       ::google::protobuf::MessageFactory::generated_factory(),
       sizeof(NodeList));
-  Transaction_descriptor_ = file->message_type(10);
+  Transaction_descriptor_ = file->message_type(11);
   static const int Transaction_offsets_[12] = {
     GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(Transaction, name_),
     GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(Transaction, key_),
@@ -269,7 +289,7 @@ void protobuf_AssignDesc_data_2eproto() {
       ::google::protobuf::DescriptorPool::generated_pool(),
       ::google::protobuf::MessageFactory::generated_factory(),
       sizeof(Transaction));
-  MVCCMetadata_descriptor_ = file->message_type(11);
+  MVCCMetadata_descriptor_ = file->message_type(12);
   static const int MVCCMetadata_offsets_[6] = {
     GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(MVCCMetadata, txn_),
     GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(MVCCMetadata, timestamp_),
@@ -289,7 +309,7 @@ void protobuf_AssignDesc_data_2eproto() {
       ::google::protobuf::DescriptorPool::generated_pool(),
       ::google::protobuf::MessageFactory::generated_factory(),
       sizeof(MVCCMetadata));
-  GCMetadata_descriptor_ = file->message_type(12);
+  GCMetadata_descriptor_ = file->message_type(13);
   static const int GCMetadata_offsets_[2] = {
     GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(GCMetadata, last_scan_nanos_),
     GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(GCMetadata, oldest_intent_nanos_),
@@ -305,7 +325,7 @@ void protobuf_AssignDesc_data_2eproto() {
       ::google::protobuf::DescriptorPool::generated_pool(),
       ::google::protobuf::MessageFactory::generated_factory(),
       sizeof(GCMetadata));
-  TimeSeriesDatapoint_descriptor_ = file->message_type(13);
+  TimeSeriesDatapoint_descriptor_ = file->message_type(14);
   static const int TimeSeriesDatapoint_offsets_[3] = {
     GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(TimeSeriesDatapoint, timestamp_nanos_),
     GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(TimeSeriesDatapoint, int_value_),
@@ -322,7 +342,7 @@ void protobuf_AssignDesc_data_2eproto() {
       ::google::protobuf::DescriptorPool::generated_pool(),
       ::google::protobuf::MessageFactory::generated_factory(),
       sizeof(TimeSeriesDatapoint));
-  TimeSeriesData_descriptor_ = file->message_type(14);
+  TimeSeriesData_descriptor_ = file->message_type(15);
   static const int TimeSeriesData_offsets_[2] = {
     GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(TimeSeriesData, name_),
     GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(TimeSeriesData, datapoints_),
@@ -372,6 +392,8 @@ void protobuf_RegisterTypes(const ::std::string&) {
   ::google::protobuf::MessageFactory::InternalRegisterGeneratedMessage(
     ChangeReplicasTrigger_descriptor_, &ChangeReplicasTrigger::default_instance());
   ::google::protobuf::MessageFactory::InternalRegisterGeneratedMessage(
+    InternalCommitTrigger_descriptor_, &InternalCommitTrigger::default_instance());
+  ::google::protobuf::MessageFactory::InternalRegisterGeneratedMessage(
     NodeList_descriptor_, &NodeList::default_instance());
   ::google::protobuf::MessageFactory::InternalRegisterGeneratedMessage(
     Transaction_descriptor_, &Transaction::default_instance());
@@ -406,6 +428,8 @@ void protobuf_ShutdownFile_data_2eproto() {
   delete MergeTrigger_reflection_;
   delete ChangeReplicasTrigger::default_instance_;
   delete ChangeReplicasTrigger_reflection_;
+  delete InternalCommitTrigger::default_instance_;
+  delete InternalCommitTrigger_reflection_;
   delete NodeList::default_instance_;
   delete NodeList_reflection_;
   delete Transaction::default_instance_;
@@ -455,35 +479,39 @@ void protobuf_AddDesc_data_2eproto() {
     "d\030\002 \001(\005B\032\310\336\037\000\342\336\037\007StoreID\332\336\037\007StoreID\0223\n\013c"
     "hange_type\030\003 \001(\0162\030.proto.ReplicaChangeTy"
     "peB\004\310\336\037\000\022.\n\020updated_replicas\030\004 \003(\0132\016.pro"
-    "to.ReplicaB\004\310\336\037\000\"\035\n\010NodeList\022\021\n\005nodes\030\001 "
-    "\003(\005B\002\020\001\"\307\003\n\013Transaction\022\022\n\004name\030\001 \001(\tB\004\310"
-    "\336\037\000\022\030\n\003key\030\002 \001(\014B\013\310\336\037\000\332\336\037\003Key\022\026\n\002id\030\003 \001("
-    "\014B\n\310\336\037\000\342\336\037\002ID\022\026\n\010priority\030\004 \001(\005B\004\310\336\037\000\022-\n"
-    "\tisolation\030\005 \001(\0162\024.proto.IsolationTypeB\004"
-    "\310\336\037\000\022.\n\006status\030\006 \001(\0162\030.proto.Transaction"
-    "StatusB\004\310\336\037\000\022\023\n\005epoch\030\007 \001(\005B\004\310\336\037\000\022(\n\016las"
-    "t_heartbeat\030\010 \001(\0132\020.proto.Timestamp\022)\n\tt"
-    "imestamp\030\t \001(\0132\020.proto.TimestampB\004\310\336\037\000\022."
-    "\n\016orig_timestamp\030\n \001(\0132\020.proto.Timestamp"
-    "B\004\310\336\037\000\022-\n\rmax_timestamp\030\013 \001(\0132\020.proto.Ti"
-    "mestampB\004\310\336\037\000\022,\n\rcertain_nodes\030\014 \001(\0132\017.p"
-    "roto.NodeListB\004\310\336\037\000:\004\230\240\037\000\"\300\001\n\014MVCCMetada"
-    "ta\022\037\n\003txn\030\001 \001(\0132\022.proto.Transaction\022)\n\tt"
-    "imestamp\030\002 \001(\0132\020.proto.TimestampB\004\310\336\037\000\022\025"
-    "\n\007deleted\030\003 \001(\010B\004\310\336\037\000\022\027\n\tkey_bytes\030\004 \001(\003"
-    "B\004\310\336\037\000\022\027\n\tval_bytes\030\005 \001(\003B\004\310\336\037\000\022\033\n\005value"
-    "\030\006 \001(\0132\014.proto.Value\"H\n\nGCMetadata\022\035\n\017la"
-    "st_scan_nanos\030\001 \001(\003B\004\310\336\037\000\022\033\n\023oldest_inte"
-    "nt_nanos\030\002 \001(\003\"\\\n\023TimeSeriesDatapoint\022\035\n"
-    "\017timestamp_nanos\030\001 \001(\003B\004\310\336\037\000\022\021\n\tint_valu"
-    "e\030\002 \001(\003\022\023\n\013float_value\030\003 \001(\002\"T\n\016TimeSeri"
-    "esData\022\022\n\004name\030\001 \001(\tB\004\310\336\037\000\022.\n\ndatapoints"
-    "\030\002 \003(\0132\032.proto.TimeSeriesDatapoint*>\n\021Re"
-    "plicaChangeType\022\017\n\013ADD_REPLICA\020\000\022\022\n\016REMO"
-    "VE_REPLICA\020\001\032\004\210\243\036\000*5\n\rIsolationType\022\020\n\014S"
-    "ERIALIZABLE\020\000\022\014\n\010SNAPSHOT\020\001\032\004\210\243\036\000*B\n\021Tra"
-    "nsactionStatus\022\013\n\007PENDING\020\000\022\r\n\tCOMMITTED"
-    "\020\001\022\013\n\007ABORTED\020\002\032\004\210\243\036\000", 2181);
+    "to.ReplicaB\004\310\336\037\000\"\256\001\n\025InternalCommitTrigg"
+    "er\022*\n\rsplit_trigger\030\001 \001(\0132\023.proto.SplitT"
+    "rigger\022*\n\rmerge_trigger\030\002 \001(\0132\023.proto.Me"
+    "rgeTrigger\022=\n\027change_replicas_trigger\030\003 "
+    "\001(\0132\034.proto.ChangeReplicasTrigger\"\035\n\010Nod"
+    "eList\022\021\n\005nodes\030\001 \003(\005B\002\020\001\"\307\003\n\013Transaction"
+    "\022\022\n\004name\030\001 \001(\tB\004\310\336\037\000\022\030\n\003key\030\002 \001(\014B\013\310\336\037\000\332"
+    "\336\037\003Key\022\026\n\002id\030\003 \001(\014B\n\310\336\037\000\342\336\037\002ID\022\026\n\010priori"
+    "ty\030\004 \001(\005B\004\310\336\037\000\022-\n\tisolation\030\005 \001(\0162\024.prot"
+    "o.IsolationTypeB\004\310\336\037\000\022.\n\006status\030\006 \001(\0162\030."
+    "proto.TransactionStatusB\004\310\336\037\000\022\023\n\005epoch\030\007"
+    " \001(\005B\004\310\336\037\000\022(\n\016last_heartbeat\030\010 \001(\0132\020.pro"
+    "to.Timestamp\022)\n\ttimestamp\030\t \001(\0132\020.proto."
+    "TimestampB\004\310\336\037\000\022.\n\016orig_timestamp\030\n \001(\0132"
+    "\020.proto.TimestampB\004\310\336\037\000\022-\n\rmax_timestamp"
+    "\030\013 \001(\0132\020.proto.TimestampB\004\310\336\037\000\022,\n\rcertai"
+    "n_nodes\030\014 \001(\0132\017.proto.NodeListB\004\310\336\037\000:\004\230\240"
+    "\037\000\"\300\001\n\014MVCCMetadata\022\037\n\003txn\030\001 \001(\0132\022.proto"
+    ".Transaction\022)\n\ttimestamp\030\002 \001(\0132\020.proto."
+    "TimestampB\004\310\336\037\000\022\025\n\007deleted\030\003 \001(\010B\004\310\336\037\000\022\027"
+    "\n\tkey_bytes\030\004 \001(\003B\004\310\336\037\000\022\027\n\tval_bytes\030\005 \001"
+    "(\003B\004\310\336\037\000\022\033\n\005value\030\006 \001(\0132\014.proto.Value\"H\n"
+    "\nGCMetadata\022\035\n\017last_scan_nanos\030\001 \001(\003B\004\310\336"
+    "\037\000\022\033\n\023oldest_intent_nanos\030\002 \001(\003\"\\\n\023TimeS"
+    "eriesDatapoint\022\035\n\017timestamp_nanos\030\001 \001(\003B"
+    "\004\310\336\037\000\022\021\n\tint_value\030\002 \001(\003\022\023\n\013float_value\030"
+    "\003 \001(\002\"T\n\016TimeSeriesData\022\022\n\004name\030\001 \001(\tB\004\310"
+    "\336\037\000\022.\n\ndatapoints\030\002 \003(\0132\032.proto.TimeSeri"
+    "esDatapoint*>\n\021ReplicaChangeType\022\017\n\013ADD_"
+    "REPLICA\020\000\022\022\n\016REMOVE_REPLICA\020\001\032\004\210\243\036\000*5\n\rI"
+    "solationType\022\020\n\014SERIALIZABLE\020\000\022\014\n\010SNAPSH"
+    "OT\020\001\032\004\210\243\036\000*B\n\021TransactionStatus\022\013\n\007PENDI"
+    "NG\020\000\022\r\n\tCOMMITTED\020\001\022\013\n\007ABORTED\020\002\032\004\210\243\036\000", 2358);
   ::google::protobuf::MessageFactory::InternalRegisterGeneratedFile(
     "data.proto", &protobuf_RegisterTypes);
   Timestamp::default_instance_ = new Timestamp();
@@ -495,6 +523,7 @@ void protobuf_AddDesc_data_2eproto() {
   SplitTrigger::default_instance_ = new SplitTrigger();
   MergeTrigger::default_instance_ = new MergeTrigger();
   ChangeReplicasTrigger::default_instance_ = new ChangeReplicasTrigger();
+  InternalCommitTrigger::default_instance_ = new InternalCommitTrigger();
   NodeList::default_instance_ = new NodeList();
   Transaction::default_instance_ = new Transaction();
   MVCCMetadata::default_instance_ = new MVCCMetadata();
@@ -510,6 +539,7 @@ void protobuf_AddDesc_data_2eproto() {
   SplitTrigger::default_instance_->InitAsDefaultInstance();
   MergeTrigger::default_instance_->InitAsDefaultInstance();
   ChangeReplicasTrigger::default_instance_->InitAsDefaultInstance();
+  InternalCommitTrigger::default_instance_->InitAsDefaultInstance();
   NodeList::default_instance_->InitAsDefaultInstance();
   Transaction::default_instance_->InitAsDefaultInstance();
   MVCCMetadata::default_instance_->InitAsDefaultInstance();
@@ -3311,6 +3341,323 @@ void ChangeReplicasTrigger::Swap(ChangeReplicasTrigger* other) {
   ::google::protobuf::Metadata metadata;
   metadata.descriptor = ChangeReplicasTrigger_descriptor_;
   metadata.reflection = ChangeReplicasTrigger_reflection_;
+  return metadata;
+}
+
+
+// ===================================================================
+
+#ifndef _MSC_VER
+const int InternalCommitTrigger::kSplitTriggerFieldNumber;
+const int InternalCommitTrigger::kMergeTriggerFieldNumber;
+const int InternalCommitTrigger::kChangeReplicasTriggerFieldNumber;
+#endif  // !_MSC_VER
+
+InternalCommitTrigger::InternalCommitTrigger()
+  : ::google::protobuf::Message() {
+  SharedCtor();
+  // @@protoc_insertion_point(constructor:proto.InternalCommitTrigger)
+}
+
+void InternalCommitTrigger::InitAsDefaultInstance() {
+  split_trigger_ = const_cast< ::proto::SplitTrigger*>(&::proto::SplitTrigger::default_instance());
+  merge_trigger_ = const_cast< ::proto::MergeTrigger*>(&::proto::MergeTrigger::default_instance());
+  change_replicas_trigger_ = const_cast< ::proto::ChangeReplicasTrigger*>(&::proto::ChangeReplicasTrigger::default_instance());
+}
+
+InternalCommitTrigger::InternalCommitTrigger(const InternalCommitTrigger& from)
+  : ::google::protobuf::Message() {
+  SharedCtor();
+  MergeFrom(from);
+  // @@protoc_insertion_point(copy_constructor:proto.InternalCommitTrigger)
+}
+
+void InternalCommitTrigger::SharedCtor() {
+  _cached_size_ = 0;
+  split_trigger_ = NULL;
+  merge_trigger_ = NULL;
+  change_replicas_trigger_ = NULL;
+  ::memset(_has_bits_, 0, sizeof(_has_bits_));
+}
+
+InternalCommitTrigger::~InternalCommitTrigger() {
+  // @@protoc_insertion_point(destructor:proto.InternalCommitTrigger)
+  SharedDtor();
+}
+
+void InternalCommitTrigger::SharedDtor() {
+  if (this != default_instance_) {
+    delete split_trigger_;
+    delete merge_trigger_;
+    delete change_replicas_trigger_;
+  }
+}
+
+void InternalCommitTrigger::SetCachedSize(int size) const {
+  GOOGLE_SAFE_CONCURRENT_WRITES_BEGIN();
+  _cached_size_ = size;
+  GOOGLE_SAFE_CONCURRENT_WRITES_END();
+}
+const ::google::protobuf::Descriptor* InternalCommitTrigger::descriptor() {
+  protobuf_AssignDescriptorsOnce();
+  return InternalCommitTrigger_descriptor_;
+}
+
+const InternalCommitTrigger& InternalCommitTrigger::default_instance() {
+  if (default_instance_ == NULL) protobuf_AddDesc_data_2eproto();
+  return *default_instance_;
+}
+
+InternalCommitTrigger* InternalCommitTrigger::default_instance_ = NULL;
+
+InternalCommitTrigger* InternalCommitTrigger::New() const {
+  return new InternalCommitTrigger;
+}
+
+void InternalCommitTrigger::Clear() {
+  if (_has_bits_[0 / 32] & 7) {
+    if (has_split_trigger()) {
+      if (split_trigger_ != NULL) split_trigger_->::proto::SplitTrigger::Clear();
+    }
+    if (has_merge_trigger()) {
+      if (merge_trigger_ != NULL) merge_trigger_->::proto::MergeTrigger::Clear();
+    }
+    if (has_change_replicas_trigger()) {
+      if (change_replicas_trigger_ != NULL) change_replicas_trigger_->::proto::ChangeReplicasTrigger::Clear();
+    }
+  }
+  ::memset(_has_bits_, 0, sizeof(_has_bits_));
+  mutable_unknown_fields()->Clear();
+}
+
+bool InternalCommitTrigger::MergePartialFromCodedStream(
+    ::google::protobuf::io::CodedInputStream* input) {
+#define DO_(EXPRESSION) if (!(EXPRESSION)) goto failure
+  ::google::protobuf::uint32 tag;
+  // @@protoc_insertion_point(parse_start:proto.InternalCommitTrigger)
+  for (;;) {
+    ::std::pair< ::google::protobuf::uint32, bool> p = input->ReadTagWithCutoff(127);
+    tag = p.first;
+    if (!p.second) goto handle_unusual;
+    switch (::google::protobuf::internal::WireFormatLite::GetTagFieldNumber(tag)) {
+      // optional .proto.SplitTrigger split_trigger = 1;
+      case 1: {
+        if (tag == 10) {
+          DO_(::google::protobuf::internal::WireFormatLite::ReadMessageNoVirtual(
+               input, mutable_split_trigger()));
+        } else {
+          goto handle_unusual;
+        }
+        if (input->ExpectTag(18)) goto parse_merge_trigger;
+        break;
+      }
+
+      // optional .proto.MergeTrigger merge_trigger = 2;
+      case 2: {
+        if (tag == 18) {
+         parse_merge_trigger:
+          DO_(::google::protobuf::internal::WireFormatLite::ReadMessageNoVirtual(
+               input, mutable_merge_trigger()));
+        } else {
+          goto handle_unusual;
+        }
+        if (input->ExpectTag(26)) goto parse_change_replicas_trigger;
+        break;
+      }
+
+      // optional .proto.ChangeReplicasTrigger change_replicas_trigger = 3;
+      case 3: {
+        if (tag == 26) {
+         parse_change_replicas_trigger:
+          DO_(::google::protobuf::internal::WireFormatLite::ReadMessageNoVirtual(
+               input, mutable_change_replicas_trigger()));
+        } else {
+          goto handle_unusual;
+        }
+        if (input->ExpectAtEnd()) goto success;
+        break;
+      }
+
+      default: {
+      handle_unusual:
+        if (tag == 0 ||
+            ::google::protobuf::internal::WireFormatLite::GetTagWireType(tag) ==
+            ::google::protobuf::internal::WireFormatLite::WIRETYPE_END_GROUP) {
+          goto success;
+        }
+        DO_(::google::protobuf::internal::WireFormat::SkipField(
+              input, tag, mutable_unknown_fields()));
+        break;
+      }
+    }
+  }
+success:
+  // @@protoc_insertion_point(parse_success:proto.InternalCommitTrigger)
+  return true;
+failure:
+  // @@protoc_insertion_point(parse_failure:proto.InternalCommitTrigger)
+  return false;
+#undef DO_
+}
+
+void InternalCommitTrigger::SerializeWithCachedSizes(
+    ::google::protobuf::io::CodedOutputStream* output) const {
+  // @@protoc_insertion_point(serialize_start:proto.InternalCommitTrigger)
+  // optional .proto.SplitTrigger split_trigger = 1;
+  if (has_split_trigger()) {
+    ::google::protobuf::internal::WireFormatLite::WriteMessageMaybeToArray(
+      1, this->split_trigger(), output);
+  }
+
+  // optional .proto.MergeTrigger merge_trigger = 2;
+  if (has_merge_trigger()) {
+    ::google::protobuf::internal::WireFormatLite::WriteMessageMaybeToArray(
+      2, this->merge_trigger(), output);
+  }
+
+  // optional .proto.ChangeReplicasTrigger change_replicas_trigger = 3;
+  if (has_change_replicas_trigger()) {
+    ::google::protobuf::internal::WireFormatLite::WriteMessageMaybeToArray(
+      3, this->change_replicas_trigger(), output);
+  }
+
+  if (!unknown_fields().empty()) {
+    ::google::protobuf::internal::WireFormat::SerializeUnknownFields(
+        unknown_fields(), output);
+  }
+  // @@protoc_insertion_point(serialize_end:proto.InternalCommitTrigger)
+}
+
+::google::protobuf::uint8* InternalCommitTrigger::SerializeWithCachedSizesToArray(
+    ::google::protobuf::uint8* target) const {
+  // @@protoc_insertion_point(serialize_to_array_start:proto.InternalCommitTrigger)
+  // optional .proto.SplitTrigger split_trigger = 1;
+  if (has_split_trigger()) {
+    target = ::google::protobuf::internal::WireFormatLite::
+      WriteMessageNoVirtualToArray(
+        1, this->split_trigger(), target);
+  }
+
+  // optional .proto.MergeTrigger merge_trigger = 2;
+  if (has_merge_trigger()) {
+    target = ::google::protobuf::internal::WireFormatLite::
+      WriteMessageNoVirtualToArray(
+        2, this->merge_trigger(), target);
+  }
+
+  // optional .proto.ChangeReplicasTrigger change_replicas_trigger = 3;
+  if (has_change_replicas_trigger()) {
+    target = ::google::protobuf::internal::WireFormatLite::
+      WriteMessageNoVirtualToArray(
+        3, this->change_replicas_trigger(), target);
+  }
+
+  if (!unknown_fields().empty()) {
+    target = ::google::protobuf::internal::WireFormat::SerializeUnknownFieldsToArray(
+        unknown_fields(), target);
+  }
+  // @@protoc_insertion_point(serialize_to_array_end:proto.InternalCommitTrigger)
+  return target;
+}
+
+int InternalCommitTrigger::ByteSize() const {
+  int total_size = 0;
+
+  if (_has_bits_[0 / 32] & (0xffu << (0 % 32))) {
+    // optional .proto.SplitTrigger split_trigger = 1;
+    if (has_split_trigger()) {
+      total_size += 1 +
+        ::google::protobuf::internal::WireFormatLite::MessageSizeNoVirtual(
+          this->split_trigger());
+    }
+
+    // optional .proto.MergeTrigger merge_trigger = 2;
+    if (has_merge_trigger()) {
+      total_size += 1 +
+        ::google::protobuf::internal::WireFormatLite::MessageSizeNoVirtual(
+          this->merge_trigger());
+    }
+
+    // optional .proto.ChangeReplicasTrigger change_replicas_trigger = 3;
+    if (has_change_replicas_trigger()) {
+      total_size += 1 +
+        ::google::protobuf::internal::WireFormatLite::MessageSizeNoVirtual(
+          this->change_replicas_trigger());
+    }
+
+  }
+  if (!unknown_fields().empty()) {
+    total_size +=
+      ::google::protobuf::internal::WireFormat::ComputeUnknownFieldsSize(
+        unknown_fields());
+  }
+  GOOGLE_SAFE_CONCURRENT_WRITES_BEGIN();
+  _cached_size_ = total_size;
+  GOOGLE_SAFE_CONCURRENT_WRITES_END();
+  return total_size;
+}
+
+void InternalCommitTrigger::MergeFrom(const ::google::protobuf::Message& from) {
+  GOOGLE_CHECK_NE(&from, this);
+  const InternalCommitTrigger* source =
+    ::google::protobuf::internal::dynamic_cast_if_available<const InternalCommitTrigger*>(
+      &from);
+  if (source == NULL) {
+    ::google::protobuf::internal::ReflectionOps::Merge(from, this);
+  } else {
+    MergeFrom(*source);
+  }
+}
+
+void InternalCommitTrigger::MergeFrom(const InternalCommitTrigger& from) {
+  GOOGLE_CHECK_NE(&from, this);
+  if (from._has_bits_[0 / 32] & (0xffu << (0 % 32))) {
+    if (from.has_split_trigger()) {
+      mutable_split_trigger()->::proto::SplitTrigger::MergeFrom(from.split_trigger());
+    }
+    if (from.has_merge_trigger()) {
+      mutable_merge_trigger()->::proto::MergeTrigger::MergeFrom(from.merge_trigger());
+    }
+    if (from.has_change_replicas_trigger()) {
+      mutable_change_replicas_trigger()->::proto::ChangeReplicasTrigger::MergeFrom(from.change_replicas_trigger());
+    }
+  }
+  mutable_unknown_fields()->MergeFrom(from.unknown_fields());
+}
+
+void InternalCommitTrigger::CopyFrom(const ::google::protobuf::Message& from) {
+  if (&from == this) return;
+  Clear();
+  MergeFrom(from);
+}
+
+void InternalCommitTrigger::CopyFrom(const InternalCommitTrigger& from) {
+  if (&from == this) return;
+  Clear();
+  MergeFrom(from);
+}
+
+bool InternalCommitTrigger::IsInitialized() const {
+
+  return true;
+}
+
+void InternalCommitTrigger::Swap(InternalCommitTrigger* other) {
+  if (other != this) {
+    std::swap(split_trigger_, other->split_trigger_);
+    std::swap(merge_trigger_, other->merge_trigger_);
+    std::swap(change_replicas_trigger_, other->change_replicas_trigger_);
+    std::swap(_has_bits_[0], other->_has_bits_[0]);
+    _unknown_fields_.Swap(&other->_unknown_fields_);
+    std::swap(_cached_size_, other->_cached_size_);
+  }
+}
+
+::google::protobuf::Metadata InternalCommitTrigger::GetMetadata() const {
+  protobuf_AssignDescriptorsOnce();
+  ::google::protobuf::Metadata metadata;
+  metadata.descriptor = InternalCommitTrigger_descriptor_;
+  metadata.reflection = InternalCommitTrigger_reflection_;
   return metadata;
 }
 

--- a/storage/engine/data.pb.h
+++ b/storage/engine/data.pb.h
@@ -45,6 +45,7 @@ class StoreIdent;
 class SplitTrigger;
 class MergeTrigger;
 class ChangeReplicasTrigger;
+class InternalCommitTrigger;
 class NodeList;
 class Transaction;
 class MVCCMetadata;
@@ -1015,6 +1016,111 @@ class ChangeReplicasTrigger : public ::google::protobuf::Message {
 
   void InitAsDefaultInstance();
   static ChangeReplicasTrigger* default_instance_;
+};
+// -------------------------------------------------------------------
+
+class InternalCommitTrigger : public ::google::protobuf::Message {
+ public:
+  InternalCommitTrigger();
+  virtual ~InternalCommitTrigger();
+
+  InternalCommitTrigger(const InternalCommitTrigger& from);
+
+  inline InternalCommitTrigger& operator=(const InternalCommitTrigger& from) {
+    CopyFrom(from);
+    return *this;
+  }
+
+  inline const ::google::protobuf::UnknownFieldSet& unknown_fields() const {
+    return _unknown_fields_;
+  }
+
+  inline ::google::protobuf::UnknownFieldSet* mutable_unknown_fields() {
+    return &_unknown_fields_;
+  }
+
+  static const ::google::protobuf::Descriptor* descriptor();
+  static const InternalCommitTrigger& default_instance();
+
+  void Swap(InternalCommitTrigger* other);
+
+  // implements Message ----------------------------------------------
+
+  InternalCommitTrigger* New() const;
+  void CopyFrom(const ::google::protobuf::Message& from);
+  void MergeFrom(const ::google::protobuf::Message& from);
+  void CopyFrom(const InternalCommitTrigger& from);
+  void MergeFrom(const InternalCommitTrigger& from);
+  void Clear();
+  bool IsInitialized() const;
+
+  int ByteSize() const;
+  bool MergePartialFromCodedStream(
+      ::google::protobuf::io::CodedInputStream* input);
+  void SerializeWithCachedSizes(
+      ::google::protobuf::io::CodedOutputStream* output) const;
+  ::google::protobuf::uint8* SerializeWithCachedSizesToArray(::google::protobuf::uint8* output) const;
+  int GetCachedSize() const { return _cached_size_; }
+  private:
+  void SharedCtor();
+  void SharedDtor();
+  void SetCachedSize(int size) const;
+  public:
+  ::google::protobuf::Metadata GetMetadata() const;
+
+  // nested types ----------------------------------------------------
+
+  // accessors -------------------------------------------------------
+
+  // optional .proto.SplitTrigger split_trigger = 1;
+  inline bool has_split_trigger() const;
+  inline void clear_split_trigger();
+  static const int kSplitTriggerFieldNumber = 1;
+  inline const ::proto::SplitTrigger& split_trigger() const;
+  inline ::proto::SplitTrigger* mutable_split_trigger();
+  inline ::proto::SplitTrigger* release_split_trigger();
+  inline void set_allocated_split_trigger(::proto::SplitTrigger* split_trigger);
+
+  // optional .proto.MergeTrigger merge_trigger = 2;
+  inline bool has_merge_trigger() const;
+  inline void clear_merge_trigger();
+  static const int kMergeTriggerFieldNumber = 2;
+  inline const ::proto::MergeTrigger& merge_trigger() const;
+  inline ::proto::MergeTrigger* mutable_merge_trigger();
+  inline ::proto::MergeTrigger* release_merge_trigger();
+  inline void set_allocated_merge_trigger(::proto::MergeTrigger* merge_trigger);
+
+  // optional .proto.ChangeReplicasTrigger change_replicas_trigger = 3;
+  inline bool has_change_replicas_trigger() const;
+  inline void clear_change_replicas_trigger();
+  static const int kChangeReplicasTriggerFieldNumber = 3;
+  inline const ::proto::ChangeReplicasTrigger& change_replicas_trigger() const;
+  inline ::proto::ChangeReplicasTrigger* mutable_change_replicas_trigger();
+  inline ::proto::ChangeReplicasTrigger* release_change_replicas_trigger();
+  inline void set_allocated_change_replicas_trigger(::proto::ChangeReplicasTrigger* change_replicas_trigger);
+
+  // @@protoc_insertion_point(class_scope:proto.InternalCommitTrigger)
+ private:
+  inline void set_has_split_trigger();
+  inline void clear_has_split_trigger();
+  inline void set_has_merge_trigger();
+  inline void clear_has_merge_trigger();
+  inline void set_has_change_replicas_trigger();
+  inline void clear_has_change_replicas_trigger();
+
+  ::google::protobuf::UnknownFieldSet _unknown_fields_;
+
+  ::google::protobuf::uint32 _has_bits_[1];
+  mutable int _cached_size_;
+  ::proto::SplitTrigger* split_trigger_;
+  ::proto::MergeTrigger* merge_trigger_;
+  ::proto::ChangeReplicasTrigger* change_replicas_trigger_;
+  friend void  protobuf_AddDesc_data_2eproto();
+  friend void protobuf_AssignDesc_data_2eproto();
+  friend void protobuf_ShutdownFile_data_2eproto();
+
+  void InitAsDefaultInstance();
+  static InternalCommitTrigger* default_instance_;
 };
 // -------------------------------------------------------------------
 
@@ -2767,6 +2873,133 @@ inline ::google::protobuf::RepeatedPtrField< ::proto::Replica >*
 ChangeReplicasTrigger::mutable_updated_replicas() {
   // @@protoc_insertion_point(field_mutable_list:proto.ChangeReplicasTrigger.updated_replicas)
   return &updated_replicas_;
+}
+
+// -------------------------------------------------------------------
+
+// InternalCommitTrigger
+
+// optional .proto.SplitTrigger split_trigger = 1;
+inline bool InternalCommitTrigger::has_split_trigger() const {
+  return (_has_bits_[0] & 0x00000001u) != 0;
+}
+inline void InternalCommitTrigger::set_has_split_trigger() {
+  _has_bits_[0] |= 0x00000001u;
+}
+inline void InternalCommitTrigger::clear_has_split_trigger() {
+  _has_bits_[0] &= ~0x00000001u;
+}
+inline void InternalCommitTrigger::clear_split_trigger() {
+  if (split_trigger_ != NULL) split_trigger_->::proto::SplitTrigger::Clear();
+  clear_has_split_trigger();
+}
+inline const ::proto::SplitTrigger& InternalCommitTrigger::split_trigger() const {
+  // @@protoc_insertion_point(field_get:proto.InternalCommitTrigger.split_trigger)
+  return split_trigger_ != NULL ? *split_trigger_ : *default_instance_->split_trigger_;
+}
+inline ::proto::SplitTrigger* InternalCommitTrigger::mutable_split_trigger() {
+  set_has_split_trigger();
+  if (split_trigger_ == NULL) split_trigger_ = new ::proto::SplitTrigger;
+  // @@protoc_insertion_point(field_mutable:proto.InternalCommitTrigger.split_trigger)
+  return split_trigger_;
+}
+inline ::proto::SplitTrigger* InternalCommitTrigger::release_split_trigger() {
+  clear_has_split_trigger();
+  ::proto::SplitTrigger* temp = split_trigger_;
+  split_trigger_ = NULL;
+  return temp;
+}
+inline void InternalCommitTrigger::set_allocated_split_trigger(::proto::SplitTrigger* split_trigger) {
+  delete split_trigger_;
+  split_trigger_ = split_trigger;
+  if (split_trigger) {
+    set_has_split_trigger();
+  } else {
+    clear_has_split_trigger();
+  }
+  // @@protoc_insertion_point(field_set_allocated:proto.InternalCommitTrigger.split_trigger)
+}
+
+// optional .proto.MergeTrigger merge_trigger = 2;
+inline bool InternalCommitTrigger::has_merge_trigger() const {
+  return (_has_bits_[0] & 0x00000002u) != 0;
+}
+inline void InternalCommitTrigger::set_has_merge_trigger() {
+  _has_bits_[0] |= 0x00000002u;
+}
+inline void InternalCommitTrigger::clear_has_merge_trigger() {
+  _has_bits_[0] &= ~0x00000002u;
+}
+inline void InternalCommitTrigger::clear_merge_trigger() {
+  if (merge_trigger_ != NULL) merge_trigger_->::proto::MergeTrigger::Clear();
+  clear_has_merge_trigger();
+}
+inline const ::proto::MergeTrigger& InternalCommitTrigger::merge_trigger() const {
+  // @@protoc_insertion_point(field_get:proto.InternalCommitTrigger.merge_trigger)
+  return merge_trigger_ != NULL ? *merge_trigger_ : *default_instance_->merge_trigger_;
+}
+inline ::proto::MergeTrigger* InternalCommitTrigger::mutable_merge_trigger() {
+  set_has_merge_trigger();
+  if (merge_trigger_ == NULL) merge_trigger_ = new ::proto::MergeTrigger;
+  // @@protoc_insertion_point(field_mutable:proto.InternalCommitTrigger.merge_trigger)
+  return merge_trigger_;
+}
+inline ::proto::MergeTrigger* InternalCommitTrigger::release_merge_trigger() {
+  clear_has_merge_trigger();
+  ::proto::MergeTrigger* temp = merge_trigger_;
+  merge_trigger_ = NULL;
+  return temp;
+}
+inline void InternalCommitTrigger::set_allocated_merge_trigger(::proto::MergeTrigger* merge_trigger) {
+  delete merge_trigger_;
+  merge_trigger_ = merge_trigger;
+  if (merge_trigger) {
+    set_has_merge_trigger();
+  } else {
+    clear_has_merge_trigger();
+  }
+  // @@protoc_insertion_point(field_set_allocated:proto.InternalCommitTrigger.merge_trigger)
+}
+
+// optional .proto.ChangeReplicasTrigger change_replicas_trigger = 3;
+inline bool InternalCommitTrigger::has_change_replicas_trigger() const {
+  return (_has_bits_[0] & 0x00000004u) != 0;
+}
+inline void InternalCommitTrigger::set_has_change_replicas_trigger() {
+  _has_bits_[0] |= 0x00000004u;
+}
+inline void InternalCommitTrigger::clear_has_change_replicas_trigger() {
+  _has_bits_[0] &= ~0x00000004u;
+}
+inline void InternalCommitTrigger::clear_change_replicas_trigger() {
+  if (change_replicas_trigger_ != NULL) change_replicas_trigger_->::proto::ChangeReplicasTrigger::Clear();
+  clear_has_change_replicas_trigger();
+}
+inline const ::proto::ChangeReplicasTrigger& InternalCommitTrigger::change_replicas_trigger() const {
+  // @@protoc_insertion_point(field_get:proto.InternalCommitTrigger.change_replicas_trigger)
+  return change_replicas_trigger_ != NULL ? *change_replicas_trigger_ : *default_instance_->change_replicas_trigger_;
+}
+inline ::proto::ChangeReplicasTrigger* InternalCommitTrigger::mutable_change_replicas_trigger() {
+  set_has_change_replicas_trigger();
+  if (change_replicas_trigger_ == NULL) change_replicas_trigger_ = new ::proto::ChangeReplicasTrigger;
+  // @@protoc_insertion_point(field_mutable:proto.InternalCommitTrigger.change_replicas_trigger)
+  return change_replicas_trigger_;
+}
+inline ::proto::ChangeReplicasTrigger* InternalCommitTrigger::release_change_replicas_trigger() {
+  clear_has_change_replicas_trigger();
+  ::proto::ChangeReplicasTrigger* temp = change_replicas_trigger_;
+  change_replicas_trigger_ = NULL;
+  return temp;
+}
+inline void InternalCommitTrigger::set_allocated_change_replicas_trigger(::proto::ChangeReplicasTrigger* change_replicas_trigger) {
+  delete change_replicas_trigger_;
+  change_replicas_trigger_ = change_replicas_trigger;
+  if (change_replicas_trigger) {
+    set_has_change_replicas_trigger();
+  } else {
+    clear_has_change_replicas_trigger();
+  }
+  // @@protoc_insertion_point(field_set_allocated:proto.InternalCommitTrigger.change_replicas_trigger)
 }
 
 // -------------------------------------------------------------------

--- a/storage/store.go
+++ b/storage/store.go
@@ -971,10 +971,12 @@ func (s *Store) ProposeRaftCommand(idKey cmdIDKey, cmd proto.InternalRaftCommand
 	if err != nil {
 		log.Fatal(err)
 	}
-	if etr, ok := value.(*proto.EndTransactionRequest); ok && etr.ChangeReplicasTrigger != nil {
+	etr, ok := value.(*proto.EndTransactionRequest)
+	if ok && etr.InternalCommitTrigger != nil &&
+		etr.InternalCommitTrigger.ChangeReplicasTrigger != nil {
 		// EndTransactionRequest with a ChangeReplicasTrigger is special because raft
 		// needs to understand it; it cannot simply be an opaque command.
-		crt := etr.ChangeReplicasTrigger
+		crt := etr.InternalCommitTrigger.ChangeReplicasTrigger
 		s.multiraft.ChangeGroupMembership(uint64(cmd.RaftID), string(idKey),
 			changeTypeInternalToRaft[crt.ChangeType],
 			makeRaftNodeID(crt.NodeID, crt.StoreID),


### PR DESCRIPTION
This eliminates the requirement to enumerate all types of triggers
in kv/db.go.

Update TODO.md.
