### PR TITLE
add missing `go-bindata` installation

### DIFF
--- a/GLOCKFILE
+++ b/GLOCKFILE
@@ -1,7 +1,7 @@
 cmd github.com/cockroachdb/c-protobuf/cmd/protoc
 cmd github.com/gogo/protobuf/protoc-gen-gogo
 cmd github.com/golang/lint/golint
-cmd github.com/jteeuwen/go-bindata
+cmd github.com/jteeuwen/go-bindata/go-bindata
 cmd github.com/kisielk/errcheck
 cmd github.com/robfig/glock
 cmd golang.org/x/tools/cmd/goimports

--- a/build/devbase/godeps.sh
+++ b/build/devbase/godeps.sh
@@ -26,6 +26,7 @@ code.google.com/p/snappy-go/snappy
 github.com/cockroachdb/c-protobuf
 github.com/cockroachdb/c-rocksdb
 github.com/cockroachdb/c-snappy
+github.com/jteeuwen/go-bindata/go-bindata
 github.com/coreos/etcd/Godeps/_workspace/src/code.google.com/p/gogoprotobuf/proto
 github.com/coreos/etcd/Godeps/_workspace/src/golang.org/x/net/context
 github.com/coreos/etcd/raft


### PR DESCRIPTION
this is responsible for breaking master after the merge of #394.
Merge at will once the test goes green.
