### PR TITLE
Optimize MVCC key encoding.

### DIFF
--- a/storage/client_test.go
+++ b/storage/client_test.go
@@ -48,7 +48,7 @@ import (
 // engine. The caller is responsible for closing the store on exit.
 func createTestStore(t *testing.T) *storage.Store {
 	return createTestStoreWithEngine(t,
-		engine.NewInMem(proto.Attributes{}, 1<<20),
+		engine.NewInMem(proto.Attributes{}, 10<<20),
 		hlc.NewClock(hlc.NewManualClock(0).UnixNano),
 		true)
 }

--- a/storage/engine/encoding.cc
+++ b/storage/engine/encoding.cc
@@ -20,23 +20,23 @@
 
 namespace {
 
-const unsigned char kEscape = 0x00;
-const unsigned char kTerm   = 0x01;
-const unsigned char kNull   = 0xff;
+const unsigned char kEscape      = 0x00;
+const unsigned char kEscapedTerm = 0x01;
+const unsigned char kEscapedNul  = 0xff;
 
 }  // namespace
 
 bool DecodeBytes(const rocksdb::Slice& buf, std::string* decoded) {
   int copyStart = 0;
-  for (int i = 0; i < buf.size(); ++i) {
+  for (int i = 0, n = int(buf.size()) - 1; i < n; ++i) {
     unsigned char v = buf[i];
     if (v == kEscape) {
       decoded->append(buf.data() + copyStart, i-copyStart);
       v = buf[++i];
-      if (v == kTerm) {
+      if (v == kEscapedTerm) {
         return true;
       }
-      if (v == kNull) {
+      if (v == kEscapedNul) {
         decoded->append("\0", 1);
       }
       copyStart = i + 1;

--- a/storage/engine/encoding.cc
+++ b/storage/engine/encoding.cc
@@ -14,62 +14,33 @@
 // for names of contributors.
 //
 // Author: Spencer Kimball (spencer.kimball@gmail.com)
+// Author: Peter Mattis (petermattis@gmail.com)
 
 #include "rocksdb/slice.h"
 
 namespace {
 
-const unsigned char kOrderedEncodingBinary     = 0x25;
-const unsigned char kOrderedEncodingTerminator = 0x00;
+const unsigned char kEscape = 0x00;
+const unsigned char kTerm   = 0x01;
+const unsigned char kNull   = 0xff;
 
-}
+}  // namespace
 
-bool DecodeBinary(const rocksdb::Slice& buf, std::string* decoded, std::string* remainder) {
-  if (buf[0] != kOrderedEncodingBinary) {
-    fprintf(stderr, "%s doesn't begin with binary encoding byte\n", buf.ToString().c_str());
-    return false;
-  }
-  decoded->clear();
-  int s = 6;
-  int i = 1;
-  if (buf[i] == kOrderedEncodingTerminator) {
-    if (remainder != NULL) {
-      rocksdb::Slice remSlice(buf);
-      remSlice.remove_prefix(2);
-      *remainder = remSlice.ToString();
-    }
-    return true;
-  }
-
-  int t = (buf[i] << 1) & 0xff;
-  for (i = 2; buf[i] != kOrderedEncodingTerminator; i++) {
-    if (s == 7) {
-      decoded->push_back(t | (buf[i] & 0x7f));
-      i++;
-    } else {
-      decoded->push_back(t | ((buf[i] & 0x7f) >> s));
-    }
-
-    t = (buf[i] << (8 - s)) & 0xff;
-
-    if (buf[i] == kOrderedEncodingTerminator) {
-      break;
-    }
-
-    if (s == 1) {
-      s = 7;
-    } else {
-      s--;
+bool DecodeBytes(const rocksdb::Slice& buf, std::string* decoded) {
+  int copyStart = 0;
+  for (int i = 0; i < buf.size(); ++i) {
+    unsigned char v = buf[i];
+    if (v == kEscape) {
+      decoded->append(buf.data() + copyStart, i-copyStart);
+      v = buf[++i];
+      if (v == kTerm) {
+        return true;
+      }
+      if (v == kNull) {
+        decoded->append("\0", 1);
+      }
+      copyStart = i + 1;
     }
   }
-  if (t != 0) {
-    fprintf(stderr, "%s doesn't begin with binary encoding byte\n", buf.ToString().c_str());
-    return false;
-  }
-  if (remainder != NULL) {
-    rocksdb::Slice remSlice(buf);
-    remSlice.remove_prefix(i+1);
-    *remainder = remSlice.ToString();
-  }
-  return true;
+  return false;
 }

--- a/storage/engine/encoding.h
+++ b/storage/engine/encoding.h
@@ -20,11 +20,10 @@
 
 #include <stdint.h>
 
-// DecodeBinary decodes the given key-encoded buf slice, returning
-// true on a successful decode. The the unencoded bytes are returned
-// in *decoded, and if not NULL, any remaining bytes are returned in
-// *remainder.
-bool DecodeBinary(const rocksdb::Slice& buf, std::string* decoded, std::string* remainder);
+// DecodeBytes decodes the given key-encoded buf slice, returning true
+// on a successful decode. The unencoded bytes are returned in
+// *decoded.
+bool DecodeBytes(const rocksdb::Slice& buf, std::string* decoded);
 
 #endif // ROACHLIB_ENCODING_H
 

--- a/storage/engine/in_mem.go
+++ b/storage/engine/in_mem.go
@@ -382,11 +382,12 @@ func (in *inMemIterator) Seek(key []byte) {
 	}
 	in.mu.RLock()
 	defer in.mu.RUnlock()
+
 	in.data.DoRange(func(c llrb.Comparable) (done bool) {
 		kv := c.(proto.RawKeyValue)
 		in.cur = &kv
 		return true
-	}, proto.RawKeyValue{Key: key}, proto.RawKeyValue{Key: proto.EncodedKey(KeyMax)})
+	}, proto.RawKeyValue{Key: key}, proto.RawKeyValue{Key: proto.EncodedKey(MVCCKeyMax)})
 }
 
 func (in *inMemIterator) Valid() bool {
@@ -406,7 +407,7 @@ func (in *inMemIterator) Next() {
 		kv := c.(proto.RawKeyValue)
 		in.cur = &kv
 		return true
-	}, proto.RawKeyValue{Key: start}, proto.RawKeyValue{Key: proto.EncodedKey(KeyMax)})
+	}, proto.RawKeyValue{Key: start}, proto.RawKeyValue{Key: proto.EncodedKey(MVCCKeyMax)})
 }
 
 func (in *inMemIterator) Key() proto.EncodedKey {

--- a/storage/engine/keys.go
+++ b/storage/engine/keys.go
@@ -112,7 +112,7 @@ func MakeRangeKey(key, suffix, detail proto.Key) proto.Key {
 	if len(suffix) != KeyLocalSuffixLength {
 		panic(fmt.Sprintf("suffix len(%q) != %d", suffix, KeyLocalSuffixLength))
 	}
-	return MakeKey(KeyLocalRangeKeyPrefix, encoding.EncodeBinary(nil, key), suffix, detail)
+	return MakeKey(KeyLocalRangeKeyPrefix, encoding.EncodeBytes(nil, key), suffix, detail)
 }
 
 // DecodeRangeKey decodes the range key into range start key,
@@ -123,7 +123,7 @@ func DecodeRangeKey(key proto.Key) (startKey, suffix, detail proto.Key) {
 	}
 	// Cut the prefix and the Raft ID.
 	b := key[len(KeyLocalRangeKeyPrefix):]
-	b, startKey = encoding.DecodeBinary(b)
+	b, startKey = encoding.DecodeBytes(b)
 	if len(b) < KeyLocalSuffixLength {
 		panic(fmt.Sprintf("key %q does not have suffix of length %d", key, KeyLocalSuffixLength))
 	}
@@ -178,7 +178,7 @@ func KeyAddress(k proto.Key) proto.Key {
 	}
 	if bytes.HasPrefix(k, KeyLocalRangeKeyPrefix) {
 		k = k[len(KeyLocalRangeKeyPrefix):]
-		_, k = encoding.DecodeBinary(k)
+		_, k = encoding.DecodeBytes(k)
 		return k
 	}
 	log.Fatalf("local key %q malformed; should contain prefix %q", k, KeyLocalRangeKeyPrefix)
@@ -296,6 +296,10 @@ var (
 	// KeyMax is a maximum key value which sorts after all other keys.
 	KeyMax = proto.KeyMax
 
+	// MVCCKeyMax is a maximum mvcc-encoded key value which sorts after
+	// all other keys.
+	MVCCKeyMax = MVCCEncodeKey(KeyMax)
+
 	// KeyLocalPrefix is the prefix for keys which hold data local to a
 	// RocksDB instance, such as store and range-specific metadata which
 	// must not pollute the user key space, but must be collocate with
@@ -362,7 +366,7 @@ var (
 	// KeyLocalRangeKeyPrefix is the prefix identifying per-range data
 	// indexed by range key (either start key, or some key in the
 	// range). The key is appended to this prefix, encoded using
-	// EncodeBinary. The specific sort of per-range metadata is
+	// EncodeBytes. The specific sort of per-range metadata is
 	// identified by one of the suffixes listed below, along with
 	// potentially additional encoded key info, such as the txn UUID in
 	// the case of a transaction record.

--- a/storage/engine/mvcc.go
+++ b/storage/engine/mvcc.go
@@ -1352,7 +1352,7 @@ func MVCCComputeStats(engine Engine, key, endKey proto.Key, nowNanos int64) (MVC
 // for storing raw values directly. Use MVCCEncodeVersionValue for
 // storing timestamped version values.
 func MVCCEncodeKey(key proto.Key) proto.EncodedKey {
-	return encoding.EncodeBinary(nil, key)
+	return encoding.EncodeBytes(nil, key)
 }
 
 // MVCCEncodeVersionKey makes an MVCC version key, which consists
@@ -1362,7 +1362,7 @@ func MVCCEncodeVersionKey(key proto.Key, timestamp proto.Timestamp) proto.Encode
 	if timestamp.WallTime < 0 || timestamp.Logical < 0 {
 		panic(fmt.Sprintf("negative values disallowed in timestamps: %+v", timestamp))
 	}
-	k := encoding.EncodeBinary(nil, key)
+	k := encoding.EncodeBytes(nil, key)
 	k = encoding.EncodeUint64Decreasing(k, uint64(timestamp.WallTime))
 	k = encoding.EncodeUint32Decreasing(k, uint32(timestamp.Logical))
 	return k
@@ -1376,7 +1376,7 @@ func MVCCEncodeVersionKey(key proto.Key, timestamp proto.Timestamp) proto.Encode
 // The decoded key, timestamp and true are returned to indicate the
 // key is for an MVCC versioned value.
 func MVCCDecodeKey(encodedKey proto.EncodedKey) (proto.Key, proto.Timestamp, bool) {
-	tsBytes, key := encoding.DecodeBinary(encodedKey)
+	tsBytes, key := encoding.DecodeBytes(encodedKey)
 	if len(tsBytes) == 0 {
 		return key, proto.Timestamp{}, false
 	} else if len(tsBytes) != 12 {

--- a/storage/engine/rocksdb_test.go
+++ b/storage/engine/rocksdb_test.go
@@ -233,9 +233,12 @@ func runMVCCScan(numRows, numVersions int, b *testing.B) {
 			startKey := proto.Key(encoding.EncodeInt([]byte("key-"), int64(keyIdx)))
 			walltime := int64(5 * (rand.Int31n(int32(numVersions)) + 1))
 			ts := makeTS(walltime, 0)
-			_, err := MVCCScan(rocksdb, startKey, KeyMax, int64(numRows), ts, nil)
+			kvs, err := MVCCScan(rocksdb, startKey, KeyMax, int64(numRows), ts, nil)
 			if err != nil {
 				b.Fatalf("failed scan: %s", err)
+			}
+			if len(kvs) != numRows {
+				b.Fatalf("failed to scan: %d != %d", len(kvs), numRows)
 			}
 		}
 	})

--- a/storage/range_data_iter.go
+++ b/storage/range_data_iter.go
@@ -56,8 +56,8 @@ func newRangeDataIterator(r *Range, e engine.Engine) *rangeDataIterator {
 				end:   engine.MVCCEncodeKey(engine.MakeKey(engine.KeyLocalRangeIDPrefix, encoding.EncodeInt(nil, r.Desc().RaftID+1))),
 			},
 			{
-				start: engine.MVCCEncodeKey(engine.MakeKey(engine.KeyLocalRangeKeyPrefix, encoding.EncodeBinary(nil, startKey))),
-				end:   engine.MVCCEncodeKey(engine.MakeKey(engine.KeyLocalRangeKeyPrefix, encoding.EncodeBinary(nil, endKey))),
+				start: engine.MVCCEncodeKey(engine.MakeKey(engine.KeyLocalRangeKeyPrefix, encoding.EncodeBytes(nil, startKey))),
+				end:   engine.MVCCEncodeKey(engine.MakeKey(engine.KeyLocalRangeKeyPrefix, encoding.EncodeBytes(nil, endKey))),
 			},
 			{
 				start: engine.MVCCEncodeKey(startKey),
@@ -116,7 +116,7 @@ func (ri *rangeDataIterator) advance() {
 			ri.iter.Seek(ri.ranges[ri.curIndex].start)
 		} else {
 			// Otherwise, seek to end to make iterator invalid.
-			ri.iter.Seek(engine.MVCCEncodeKey(engine.KeyMax))
+			ri.iter.Seek(engine.MVCCKeyMax)
 			return
 		}
 	}

--- a/storage/range_test.go
+++ b/storage/range_test.go
@@ -1493,7 +1493,7 @@ func TestRangeStatsComputation(t *testing.T) {
 	if err := tc.rng.AddCmd(proto.Put, pArgs, pReply, true); err != nil {
 		t.Fatal(err)
 	}
-	expMS := engine.MVCCStats{LiveBytes: 40, KeyBytes: 16, ValBytes: 24, IntentBytes: 0, LiveCount: 1, KeyCount: 1, ValCount: 1, IntentCount: 0}
+	expMS := engine.MVCCStats{LiveBytes: 39, KeyBytes: 15, ValBytes: 24, IntentBytes: 0, LiveCount: 1, KeyCount: 1, ValCount: 1, IntentCount: 0}
 	verifyRangeStats(tc.engine, tc.rng.Desc().RaftID, expMS, t)
 
 	// Put a 2nd value transactionally.
@@ -1503,7 +1503,7 @@ func TestRangeStatsComputation(t *testing.T) {
 	if err := tc.rng.AddCmd(proto.Put, pArgs, pReply, true); err != nil {
 		t.Fatal(err)
 	}
-	expMS = engine.MVCCStats{LiveBytes: 116 + 2, KeyBytes: 32, ValBytes: 84 + 2, IntentBytes: 24, LiveCount: 2, KeyCount: 2, ValCount: 2, IntentCount: 1}
+	expMS = engine.MVCCStats{LiveBytes: 116, KeyBytes: 30, ValBytes: 86, IntentBytes: 24, LiveCount: 2, KeyCount: 2, ValCount: 2, IntentCount: 1}
 	verifyRangeStats(tc.engine, tc.rng.Desc().RaftID, expMS, t)
 
 	// Resolve the 2nd value.
@@ -1521,7 +1521,7 @@ func TestRangeStatsComputation(t *testing.T) {
 	if err := tc.rng.AddCmd(proto.InternalResolveIntent, rArgs, rReply, true); err != nil {
 		t.Fatal(err)
 	}
-	expMS = engine.MVCCStats{LiveBytes: 80, KeyBytes: 32, ValBytes: 48, IntentBytes: 0, LiveCount: 2, KeyCount: 2, ValCount: 2, IntentCount: 0}
+	expMS = engine.MVCCStats{LiveBytes: 78, KeyBytes: 30, ValBytes: 48, IntentBytes: 0, LiveCount: 2, KeyCount: 2, ValCount: 2, IntentCount: 0}
 	verifyRangeStats(tc.engine, tc.rng.Desc().RaftID, expMS, t)
 
 	// Delete the 1st value.
@@ -1530,7 +1530,7 @@ func TestRangeStatsComputation(t *testing.T) {
 	if err := tc.rng.AddCmd(proto.Delete, dArgs, dReply, true); err != nil {
 		t.Fatal(err)
 	}
-	expMS = engine.MVCCStats{LiveBytes: 40, KeyBytes: 44, ValBytes: 50, IntentBytes: 0, LiveCount: 1, KeyCount: 2, ValCount: 3, IntentCount: 0}
+	expMS = engine.MVCCStats{LiveBytes: 39, KeyBytes: 42, ValBytes: 50, IntentBytes: 0, LiveCount: 1, KeyCount: 2, ValCount: 3, IntentCount: 0}
 	verifyRangeStats(tc.engine, tc.rng.Desc().RaftID, expMS, t)
 }
 

--- a/storage/store.go
+++ b/storage/store.go
@@ -87,7 +87,7 @@ func verifyKeyLength(key proto.Key) error {
 	maxLength := engine.KeyMaxLength
 	if bytes.HasPrefix(key, engine.KeyLocalRangeKeyPrefix) {
 		key = key[len(engine.KeyLocalRangeKeyPrefix):]
-		_, key = encoding.DecodeBinary(key)
+		_, key = encoding.DecodeBytes(key)
 	}
 	if bytes.HasPrefix(key, engine.KeyMetaPrefix) {
 		key = key[len(engine.KeyMeta1Prefix):]

--- a/storage/store_test.go
+++ b/storage/store_test.go
@@ -96,7 +96,7 @@ func createTestStore(t *testing.T) (*Store, *hlc.ManualClock) {
 	g := gossip.New(rpcContext, gossip.TestInterval, "")
 	manual := hlc.NewManualClock(0)
 	clock := hlc.NewClock(manual.UnixNano)
-	eng := engine.NewInMem(proto.Attributes{}, 1<<20)
+	eng := engine.NewInMem(proto.Attributes{}, 10<<20)
 	store := NewStore(clock, eng, nil, g, multiraft.NewLocalRPCTransport())
 	if err := store.Bootstrap(proto.StoreIdent{NodeID: 1, StoreID: 1}); err != nil {
 		t.Fatal(err)

--- a/util/encoding/encoding.go
+++ b/util/encoding/encoding.go
@@ -173,12 +173,12 @@ func WillOverflow(a, b int64) bool {
 // representation. The bytes are appended to the supplied buffer and
 // the final buffer is returned.
 func EncodeUint32(b []byte, v uint32) []byte {
-	enc := make([]byte, 4)
+	var enc [4]byte
 	for i := 3; i >= 0; i-- {
 		enc[i] = byte(v & 0xff)
 		v >>= 8
 	}
-	return append(b, enc...)
+	return append(b, enc[:]...)
 }
 
 // EncodeUint32Decreasing encodes the uint32 value so that it sorts in
@@ -212,12 +212,12 @@ func DecodeUint32Decreasing(b []byte) ([]byte, uint32) {
 // representation. The bytes are appended to the supplied buffer and
 // the final buffer is returned.
 func EncodeUint64(b []byte, v uint64) []byte {
-	enc := make([]byte, 8)
+	var enc [8]byte
 	for i := 7; i >= 0; i-- {
 		enc[i] = byte(v & 0xff)
 		v >>= 8
 	}
-	return append(b, enc...)
+	return append(b, enc[:]...)
 }
 
 // EncodeUint64Decreasing encodes the uint64 value so that it sorts in
@@ -251,19 +251,15 @@ func DecodeUint64Decreasing(b []byte) ([]byte, uint64) {
 // (length-prefixed) big-endian 8 byte representation. The bytes are
 // appended to the supplied buffer and the final buffer is returned.
 func EncodeVarUint64(b []byte, v uint64) []byte {
-	enc := make([]byte, 9)
-	var length int
+	var enc [9]byte
+	i := 8
 	for v > 0 {
-		enc[length+1] = byte(v & 0xff)
-		length++
+		enc[i] = byte(v & 0xff)
+		i--
 		v >>= 8
 	}
-	// Reverse the bytes.
-	for i := 0; i < length/2; i++ {
-		enc[i+1], enc[length-i] = enc[length-i], enc[i+1]
-	}
-	enc[0] = byte(length)
-	return append(b, enc[:length+1]...)
+	enc[i] = byte(8 - i)
+	return append(b, enc[i:]...)
 }
 
 // EncodeVarUint64Decreasing encodes the uint64 value so that it sorts in
@@ -296,4 +292,50 @@ func DecodeVarUint64(b []byte) ([]byte, uint64) {
 func DecodeVarUint64Decreasing(b []byte) ([]byte, uint64) {
 	leftover, v := DecodeVarUint64(b)
 	return leftover, ^v
+}
+
+const (
+	escape = 0x00
+	term   = 0x01
+	null   = 0xff
+)
+
+// EncodeBytes ...
+func EncodeBytes(b []byte, data []byte) []byte {
+	copyStart := 0
+	for i, v := range data {
+		if v == escape {
+			b = append(b, data[copyStart:i]...)
+			b = append(b, escape, null)
+			copyStart = i + 1
+		}
+	}
+	b = append(b, data[copyStart:]...)
+	return append(b, escape, term)
+}
+
+// DecodeBytes ...
+func DecodeBytes(b []byte) ([]byte, []byte) {
+	var r []byte
+	copyStart := 0
+	for i := 0; i < len(b); i++ {
+		v := b[i]
+		if v == escape {
+			v = b[i+1]
+			if v == term {
+				if r == nil {
+					return b[i+2:], b[:i]
+				}
+				r = append(r, b[copyStart:i]...)
+				return b[i+2:], r
+			}
+			r = append(r, b[copyStart:i]...)
+			i++
+			if v == null {
+				r = append(r, 0)
+			}
+			copyStart = i + 1
+		}
+	}
+	panic("did not find terminator")
 }

--- a/util/encoding/encoding_test.go
+++ b/util/encoding/encoding_test.go
@@ -22,6 +22,8 @@ import (
 	"math"
 	"reflect"
 	"testing"
+
+	"github.com/cockroachdb/cockroach/util"
 )
 
 func TestEncoding(t *testing.T) {
@@ -263,4 +265,54 @@ func TestEncodeDecodeVarUint64Decreasing(t *testing.T) {
 		{math.MaxUint64, []byte{0x00}},
 	}
 	testCustomEncode64(testCases, EncodeVarUint64Decreasing, t)
+}
+
+func TestEncodeDecodeBytes(t *testing.T) {
+	testCases := []struct {
+		value   []byte
+		encoded []byte
+	}{
+		{[]byte{'a'}, []byte{'a', 0x00, 0x01}},
+		{[]byte{'b'}, []byte{'b', 0x00, 0x01}},
+		{[]byte{'b', 0}, []byte{'b', 0x00, 0xff, 0x00, 0x01}},
+		{[]byte{'b', 0xff}, []byte{'b', 0xff, 0x00, 0x01}},
+		{[]byte("hello"), []byte{'h', 'e', 'l', 'l', 'o', 0x00, 0x01}},
+	}
+	for i, c := range testCases {
+		enc := EncodeBytes(nil, c.value)
+		if !bytes.Equal(enc, c.encoded) {
+			t.Errorf("unexpected encoding mismatch for %v. expected %v, got %v",
+				c.value, prettyBytes(c.encoded), prettyBytes(enc))
+		}
+		if i > 0 {
+			if bytes.Compare(testCases[i-1].encoded, enc) >= 0 {
+				t.Errorf("%v: expected %v to be less than %v",
+					c.value, prettyBytes(testCases[i-1].encoded), prettyBytes(enc))
+			}
+		}
+		remainder, dec := DecodeBytes(enc)
+		if !bytes.Equal(c.value, dec) {
+			t.Errorf("unexpected decoding mismatch for %v. got %v", c.value, dec)
+		}
+		if len(remainder) != 0 {
+			t.Errorf("unexpected remaining bytes: %v", remainder)
+		}
+	}
+}
+
+func BenchmarkEncodeDecodeBytes(b *testing.B) {
+	rng := util.NewPseudoRand()
+
+	keys := make([][]byte, 10000)
+	for i := range keys {
+		keys[i] = util.RandBytes(rng, 100)
+	}
+
+	buf := make([]byte, 0, 1000)
+
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		enc := EncodeBytes(buf, keys[rng.Intn(len(keys))])
+		_, _ = DecodeBytes(enc)
+	}
 }

--- a/util/encoding/encoding_test.go
+++ b/util/encoding/encoding_test.go
@@ -272,9 +272,14 @@ func TestEncodeDecodeBytes(t *testing.T) {
 		value   []byte
 		encoded []byte
 	}{
+		{[]byte{0, 1, 'a'}, []byte{0x00, 0xff, 1, 'a', 0x00, 0x01}},
+		{[]byte{0, 'a'}, []byte{0x00, 0xff, 'a', 0x00, 0x01}},
+		{[]byte{0, 0xff, 'a'}, []byte{0x00, 0xff, 0xff, 'a', 0x00, 0x01}},
 		{[]byte{'a'}, []byte{'a', 0x00, 0x01}},
 		{[]byte{'b'}, []byte{'b', 0x00, 0x01}},
 		{[]byte{'b', 0}, []byte{'b', 0x00, 0xff, 0x00, 0x01}},
+		{[]byte{'b', 0, 0}, []byte{'b', 0x00, 0xff, 0x00, 0xff, 0x00, 0x01}},
+		{[]byte{'b', 0, 0, 'a'}, []byte{'b', 0x00, 0xff, 0x00, 0xff, 'a', 0x00, 0x01}},
 		{[]byte{'b', 0xff}, []byte{'b', 0xff, 0x00, 0x01}},
 		{[]byte("hello"), []byte{'h', 'e', 'l', 'l', 'o', 0x00, 0x01}},
 	}
@@ -295,6 +300,12 @@ func TestEncodeDecodeBytes(t *testing.T) {
 			t.Errorf("unexpected decoding mismatch for %v. got %v", c.value, dec)
 		}
 		if len(remainder) != 0 {
+			t.Errorf("unexpected remaining bytes: %v", remainder)
+		}
+
+		enc = append(enc, []byte("remainder")...)
+		remainder, dec = DecodeBytes(enc)
+		if string(remainder) != "remainder" {
 			t.Errorf("unexpected remaining bytes: %v", remainder)
 		}
 	}


### PR DESCRIPTION
{Encode,Decode}Binary are fairly slow as they encode 7-bits per encoded
byte. Add {Encode,Decode}Bytes which is an escape-based encoding and
significantly faster:

BenchmarkEncodeDecodeBytes   10000000    185 ns/op
BenchmarkEncodeDecodeBinary   1000000   1674 ns/op

EncodeBinary was the top cpu consumer for the mvcc scan benchmarks:

benchmark                                old ns/op     new ns/op     delta
BenchmarkMVCCScan1Version1Row            21744         16043         -26.22%
BenchmarkMVCCScan1Version10Rows          57813         46158         -20.16%
BenchmarkMVCCScan1Version100Rows         355850        328217        -7.77%
BenchmarkMVCCScan1Version1000Rows        2782325       2650386       -4.74%
BenchmarkMVCCScan10Versions1Row          21235         10406         -51.00%
BenchmarkMVCCScan10Versions10Rows        57624         46647         -19.05%
BenchmarkMVCCScan10Versions100Rows       360243        342487        -4.93%
BenchmarkMVCCScan10Versions1000Rows      2907575       2797684       -3.78%
BenchmarkMVCCScan100Versions1Row         25074         13208         -47.32%
BenchmarkMVCCScan100Versions10Rows       129250        66729         -48.37%
BenchmarkMVCCScan100Versions100Rows      839957        516967        -38.45%
BenchmarkMVCCScan100Versions1000Rows     6850055       4333966       -36.73%

benchmark                                old MB/s     new MB/s     speedup
BenchmarkMVCCScan1Version1Row            47.09        63.83        1.36x
BenchmarkMVCCScan1Version10Rows          177.12       221.84       1.25x
BenchmarkMVCCScan1Version100Rows         287.76       311.99       1.08x
BenchmarkMVCCScan1Version1000Rows        368.04       386.36       1.05x
BenchmarkMVCCScan10Versions1Row          48.22        98.40        2.04x
BenchmarkMVCCScan10Versions10Rows        177.70       219.52       1.24x
BenchmarkMVCCScan10Versions100Rows       284.25       298.99       1.05x
BenchmarkMVCCScan10Versions1000Rows      352.18       366.02       1.04x
BenchmarkMVCCScan100Versions1Row         40.84        77.52        1.90x
BenchmarkMVCCScan100Versions10Rows       79.23        153.46       1.94x
BenchmarkMVCCScan100Versions100Rows      121.91       198.08       1.62x
BenchmarkMVCCScan100Versions1000Rows     149.49       236.27       1.58x
