### PR TITLE
Remove unused encoding routines.

### DIFF
--- a/storage/engine/rocksdb_test.go
+++ b/storage/engine/rocksdb_test.go
@@ -174,7 +174,7 @@ func setupMVCCScanData(numVersions, numKeys int, b *testing.B) *RocksDB {
 		batch := rocksdb.NewBatch()
 		for i := 0; i < numKeys; i++ {
 			if t == 1 {
-				keys[i] = proto.Key(encoding.EncodeInt([]byte("key-"), int64(i)))
+				keys[i] = proto.Key(encoding.EncodeVarUint32([]byte("key-"), uint32(i)))
 				nvs[i] = int(rand.Int31n(int32(numVersions)) + 1)
 			}
 			// Only write values if this iteration is less than the random
@@ -230,7 +230,7 @@ func runMVCCScan(numRows, numVersions int, b *testing.B) {
 		for pb.Next() {
 			// Choose a random key to start scan.
 			keyIdx := rand.Int31n(int32(numKeys - numRows))
-			startKey := proto.Key(encoding.EncodeInt([]byte("key-"), int64(keyIdx)))
+			startKey := proto.Key(encoding.EncodeVarUint32([]byte("key-"), uint32(keyIdx)))
 			walltime := int64(5 * (rand.Int31n(int32(numVersions)) + 1))
 			ts := makeTS(walltime, 0)
 			kvs, err := MVCCScan(rocksdb, startKey, KeyMax, int64(numRows), ts, nil)

--- a/storage/range_data_iter.go
+++ b/storage/range_data_iter.go
@@ -52,8 +52,8 @@ func newRangeDataIterator(r *Range, e engine.Engine) *rangeDataIterator {
 	ri := &rangeDataIterator{
 		ranges: []keyRange{
 			{
-				start: engine.MVCCEncodeKey(engine.MakeKey(engine.KeyLocalRangeIDPrefix, encoding.EncodeInt(nil, r.Desc().RaftID))),
-				end:   engine.MVCCEncodeKey(engine.MakeKey(engine.KeyLocalRangeIDPrefix, encoding.EncodeInt(nil, r.Desc().RaftID+1))),
+				start: engine.MVCCEncodeKey(engine.MakeKey(engine.KeyLocalRangeIDPrefix, encoding.EncodeNumericInt(nil, r.Desc().RaftID))),
+				end:   engine.MVCCEncodeKey(engine.MakeKey(engine.KeyLocalRangeIDPrefix, encoding.EncodeNumericInt(nil, r.Desc().RaftID+1))),
 			},
 			{
 				start: engine.MVCCEncodeKey(engine.MakeKey(engine.KeyLocalRangeKeyPrefix, encoding.EncodeBytes(nil, startKey))),

--- a/storage/response_cache.go
+++ b/storage/response_cache.go
@@ -254,19 +254,19 @@ func (rc *ResponseCache) decodeResponseCacheKey(encKey proto.EncodedKey) (proto.
 	}
 	// Cut the prefix and the Raft ID.
 	b := key[len(engine.KeyLocalRangeIDPrefix):]
-	b, _ = encoding.DecodeInt(b)
+	b, _ = encoding.DecodeNumericInt(b)
 	if !bytes.HasPrefix(b, engine.KeyLocalResponseCacheSuffix) {
 		return ret, util.Errorf("key %q does not contain the response cache suffix %q", key, engine.KeyLocalResponseCacheSuffix)
 	}
 	// Cut the response cache suffix.
 	b = b[len(engine.KeyLocalResponseCacheSuffix):]
 	// Now, decode the command ID.
-	b, wt := encoding.DecodeInt(b)
-	b, rd := encoding.DecodeInt(b)
+	b, wt := encoding.DecodeVarUint64(b)
+	b, rd := encoding.DecodeUint64(b)
 	if len(b) > 0 {
 		return ret, util.Errorf("key %q has leftover bytes after decode: %q; indicates corrupt key", encKey, b)
 	}
-	ret.WallTime = wt
-	ret.Random = rd
+	ret.WallTime = int64(wt)
+	ret.Random = int64(rd)
 	return ret, nil
 }


### PR DESCRIPTION
Rename {Encode,Decode}{Int,Float} to {Encode,Decode}Numeric{Int,Float}
to help indicate that these routines are related. Replace the response
cache key usage of EncodeNumericInt with EncodeVarUint64 and
EncodeUint64.

Add additional benchmarks and tests.

BenchmarkEncodeUint32        200000000   18.0 ns/op
BenchmarkDecodeUint32        200000000   17.2 ns/op
BenchmarkEncodeUint64        100000000   21.6 ns/op
BenchmarkDecodeUint64        100000000   21.1 ns/op
BenchmarkEncodeVarUint32     200000000   19.9 ns/op
BenchmarkDecodeVarUint32     200000000   19.5 ns/op
BenchmarkEncodeVarUint64     100000000   24.0 ns/op
BenchmarkDecodeVarUint64     100000000   23.0 ns/op
BenchmarkEncodeBytes          30000000   83.8 ns/op
BenchmarkDecodeBytes          30000000   83.9 ns/op
BenchmarkEncodeNumericInt     30000000    120 ns/op
BenchmarkDecodeNumericInt     30000000    101 ns/op
BenchmarkEncodeNumericFloat    5000000    570 ns/op
BenchmarkDecodeNumericFloat   10000000    418 ns/op
