### PR TITLE
Use varint encoding for range ids in keys.

### DIFF
--- a/storage/engine/encoding.h
+++ b/storage/engine/encoding.h
@@ -20,10 +20,14 @@
 
 #include <stdint.h>
 
-// DecodeBytes decodes the given key-encoded buf slice, returning true
-// on a successful decode. The unencoded bytes are returned in
-// *decoded.
-bool DecodeBytes(const rocksdb::Slice& buf, std::string* decoded);
+// DecodeBytes decodes a byte slice from a buffer, returning true on a
+// successful decode. The decoded bytes are returned in *decoded.
+bool DecodeBytes(rocksdb::Slice* buf, std::string* decoded);
+
+// DecodeVarint64 decodes a varint encoded uint64 from a buffer,
+// returning true on a successful decode. The decoded value is
+// returned in *decoded.
+bool DecodeVarint64(rocksdb::Slice* buf, uint64_t* value);
 
 #endif // ROACHLIB_ENCODING_H
 

--- a/storage/range_data_iter.go
+++ b/storage/range_data_iter.go
@@ -52,8 +52,8 @@ func newRangeDataIterator(r *Range, e engine.Engine) *rangeDataIterator {
 	ri := &rangeDataIterator{
 		ranges: []keyRange{
 			{
-				start: engine.MVCCEncodeKey(engine.MakeKey(engine.KeyLocalRangeIDPrefix, encoding.EncodeNumericInt(nil, r.Desc().RaftID))),
-				end:   engine.MVCCEncodeKey(engine.MakeKey(engine.KeyLocalRangeIDPrefix, encoding.EncodeNumericInt(nil, r.Desc().RaftID+1))),
+				start: engine.MVCCEncodeKey(engine.MakeKey(engine.KeyLocalRangeIDPrefix, encoding.EncodeVarUint64(nil, uint64(r.Desc().RaftID)))),
+				end:   engine.MVCCEncodeKey(engine.MakeKey(engine.KeyLocalRangeIDPrefix, encoding.EncodeVarUint64(nil, uint64(r.Desc().RaftID+1)))),
 			},
 			{
 				start: engine.MVCCEncodeKey(engine.MakeKey(engine.KeyLocalRangeKeyPrefix, encoding.EncodeBytes(nil, startKey))),

--- a/storage/response_cache.go
+++ b/storage/response_cache.go
@@ -254,7 +254,7 @@ func (rc *ResponseCache) decodeResponseCacheKey(encKey proto.EncodedKey) (proto.
 	}
 	// Cut the prefix and the Raft ID.
 	b := key[len(engine.KeyLocalRangeIDPrefix):]
-	b, _ = encoding.DecodeNumericInt(b)
+	b, _ = encoding.DecodeVarUint64(b)
 	if !bytes.HasPrefix(b, engine.KeyLocalResponseCacheSuffix) {
 		return ret, util.Errorf("key %q does not contain the response cache suffix %q", key, engine.KeyLocalResponseCacheSuffix)
 	}


### PR DESCRIPTION
The varint encoding and decoding is significantly faster than the
numeric encoding.
