### PR TITLE
CircleCI `go generate` improvements

### DIFF
--- a/GLOCKFILE
+++ b/GLOCKFILE
@@ -18,7 +18,7 @@ github.com/elazarl/go-bindata-assetfs 09ba9c6a7e9a5ee35586127fdf88bb20bb4990b7
 github.com/gogo/protobuf bc946d07d1016848dfd2507f90f0859c9471681e
 github.com/golang/glog 44145f04b68cf362d9c4df2182967c2275eaefed
 github.com/golang/lint 39d15d55e9777df34cdffde4f406ab27fd2e60c0
-github.com/jteeuwen/go-bindata 8ee21af0fa554ff13f12acd730a7b40a106965f0
+github.com/jteeuwen/go-bindata 7362d4b6b2ce6a7d3c28b523a6e40629f4d81116
 github.com/kisielk/errcheck eb516cb958915b69ad14384890b4d37bd910c9f3
 github.com/kisielk/gotool d678387370a2eb9b5b0a33218bc8c9d8de15b6be
 github.com/robfig/glock 78c45da050a4d993d12ad07e8ddb10a4891ac701

--- a/circle.yml
+++ b/circle.yml
@@ -31,7 +31,8 @@ dependencies:
 test:
   override:
     # Check whether the committer forgot to run `go generate`.
-    - docker run cockroachdb/cockroach-dev shell "go generate ./... && git ls-files --modified --deleted --untracked | diff /dev/null -"
+    # Either `go generate` does not change any files or it does, in which case we print the diff and fail.
+    - docker run cockroachdb/cockroach-dev shell "(go generate ./... && git ls-files --modified --deleted --others --exclude-standard | diff /dev/null -) || (git add -A && git diff -u HEAD && false)" | tee "${CIRCLE_ARTIFACTS}/generate.log"; test ${PIPESTATUS[0]} -eq 0
     - docker run "cockroachdb/cockroach-dev" test TESTFLAGS='-logtostderr -timeout 30s -vmodule=multiraft=5' | tee "${CIRCLE_ARTIFACTS}/test.log"; test ${PIPESTATUS[0]} -eq 0
     - docker run "cockroachdb/cockroach-dev" testrace RACEFLAGS='-logtostderr -timeout 5m -vmodule=multiraft=5' | tee "${CIRCLE_ARTIFACTS}/testrace.log"; test ${PIPESTATUS[0]} -eq 0
       # Kill off the previous images since we don't care for them any more,

--- a/proto/config.pb.go
+++ b/proto/config.pb.go
@@ -65,7 +65,8 @@ type RangeDescriptor struct {
 	// contained in this range - it will be contained in the immediately
 	// subsequent range.
 	EndKey Key `protobuf:"bytes,3,opt,name=end_key,customtype=Key" json:"end_key"`
-	// List of replicas where this range is stored.
+	// Replicas is the set of replicas on which this range is stored, the
+	// ordering being arbitrary and subject to permutation.
 	Replicas         []Replica `protobuf:"bytes,4,rep,name=replicas" json:"replicas"`
 	XXX_unrecognized []byte    `json:"-"`
 }
@@ -159,8 +160,9 @@ func (m *PermConfig) GetWrite() []string {
 
 // ZoneConfig holds configuration that is needed for a range of KV pairs.
 type ZoneConfig struct {
-	// ReplicaAttrs is a slice of Attributes, each describing required
-	// attributes for each replica in the zone.
+	// ReplicaAttrs is a slice of Attributes, each describing required attributes
+	// for each replica in the zone. The order in which the attributes are stored
+	// in ReplicaAttrs is arbitrary and may change.
 	ReplicaAttrs  []Attributes `protobuf:"bytes,1,rep,name=replica_attrs" json:"replica_attrs" yaml:"replicas,omitempty"`
 	RangeMinBytes int64        `protobuf:"varint,2,opt,name=range_min_bytes" json:"range_min_bytes" yaml:"range_min_bytes,omitempty"`
 	RangeMaxBytes int64        `protobuf:"varint,3,opt,name=range_max_bytes" json:"range_max_bytes" yaml:"range_max_bytes,omitempty"`

--- a/proto/config.proto
+++ b/proto/config.proto
@@ -49,7 +49,8 @@ message RangeDescriptor {
   // contained in this range - it will be contained in the immediately
   // subsequent range.
   optional bytes end_key = 3 [(gogoproto.nullable) = false, (gogoproto.customtype) = "Key"];
-  // List of replicas where this range is stored.
+  // Replicas is the set of replicas on which this range is stored, the
+  // ordering being arbitrary and subject to permutation.
   repeated Replica replicas = 4 [(gogoproto.nullable) = false];
 }
 
@@ -81,8 +82,9 @@ message PermConfig {
 
 // ZoneConfig holds configuration that is needed for a range of KV pairs.
 message ZoneConfig {
-  // ReplicaAttrs is a slice of Attributes, each describing required
-  // attributes for each replica in the zone.
+  // ReplicaAttrs is a slice of Attributes, each describing required attributes
+  // for each replica in the zone. The order in which the attributes are stored
+  // in ReplicaAttrs is arbitrary and may change.
   repeated Attributes replica_attrs = 1 [(gogoproto.nullable) = false, (gogoproto.moretags) = "yaml:\"replicas,omitempty\""];
   optional int64 range_min_bytes = 2 [(gogoproto.nullable) = false, (gogoproto.moretags) = "yaml:\"range_min_bytes,omitempty\""];
   optional int64 range_max_bytes = 3 [(gogoproto.nullable) = false, (gogoproto.moretags) = "yaml:\"range_max_bytes,omitempty\""];

--- a/resource/embedded.go
+++ b/resource/embedded.go
@@ -76,7 +76,7 @@ func ui_css_main_css() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindata_file_info{name: "ui/css/main.css", size: 1472, mode: os.FileMode(436), modTime: time.Unix(1419191781, 0)}
+	info := bindata_file_info{name: "ui/css/main.css", size: 1472, mode: os.FileMode(420), modTime: time.Unix(1400000000, 0)}
 	a := &asset{bytes: bytes, info: info}
 	return a, nil
 }
@@ -96,7 +96,7 @@ func ui_css_rest_explorer_css() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindata_file_info{name: "ui/css/rest_explorer.css", size: 1309, mode: os.FileMode(436), modTime: time.Unix(1419191781, 0)}
+	info := bindata_file_info{name: "ui/css/rest_explorer.css", size: 1309, mode: os.FileMode(420), modTime: time.Unix(1400000000, 0)}
 	a := &asset{bytes: bytes, info: info}
 	return a, nil
 }
@@ -116,7 +116,7 @@ func ui_index_html() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindata_file_info{name: "ui/index.html", size: 1681, mode: os.FileMode(436), modTime: time.Unix(1419191781, 0)}
+	info := bindata_file_info{name: "ui/index.html", size: 1681, mode: os.FileMode(420), modTime: time.Unix(1400000000, 0)}
 	a := &asset{bytes: bytes, info: info}
 	return a, nil
 }
@@ -136,7 +136,7 @@ func ui_js_controllers_rest_explorer_js() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindata_file_info{name: "ui/js/controllers/rest_explorer.js", size: 2298, mode: os.FileMode(436), modTime: time.Unix(1423816307, 0)}
+	info := bindata_file_info{name: "ui/js/controllers/rest_explorer.js", size: 2298, mode: os.FileMode(420), modTime: time.Unix(1400000000, 0)}
 	a := &asset{bytes: bytes, info: info}
 	return a, nil
 }
@@ -156,7 +156,7 @@ func ui_js_main_js() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindata_file_info{name: "ui/js/main.js", size: 986, mode: os.FileMode(436), modTime: time.Unix(1419191781, 0)}
+	info := bindata_file_info{name: "ui/js/main.js", size: 986, mode: os.FileMode(420), modTime: time.Unix(1400000000, 0)}
 	a := &asset{bytes: bytes, info: info}
 	return a, nil
 }
@@ -176,7 +176,7 @@ func ui_templates_rest_explorer_html() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindata_file_info{name: "ui/templates/rest_explorer.html", size: 3522, mode: os.FileMode(436), modTime: time.Unix(1423816307, 0)}
+	info := bindata_file_info{name: "ui/templates/rest_explorer.html", size: 3522, mode: os.FileMode(420), modTime: time.Unix(1400000000, 0)}
 	a := &asset{bytes: bytes, info: info}
 	return a, nil
 }
@@ -194,6 +194,17 @@ func Asset(name string) ([]byte, error) {
 		return a.bytes, nil
 	}
 	return nil, fmt.Errorf("Asset %s not found", name)
+}
+
+// MustAsset is like Asset but panics when Asset would return an error.
+// It simplifies safe initialization of global variables.
+func MustAsset(name string) []byte {
+	a, err := Asset(name)
+	if err != nil {
+		panic("asset: Asset(" + name + "): " + err.Error())
+	}
+
+	return a
 }
 
 // AssetInfo loads and returns the asset info for the given name.

--- a/resource/resource.go
+++ b/resource/resource.go
@@ -22,6 +22,6 @@ package resource
 // When changing files included here, you may add the `-debug` flag, which will
 // avoid embedding any files (but instead passes them through from disk). This
 // avoids having to recompile before testing changes.
-//go:generate go-bindata -pkg resource -o ./embedded.go ./ui/...
+//go:generate go-bindata -pkg resource -mode 0644 -modtime 1400000000 -o ./embedded.go ./ui/...
 // `go vet` complains about the go file created by go-bindata, so we groom it.
 //go:generate goimports -w embedded.go


### PR DESCRIPTION
- [landed a PR on the go-bindata repo](https://github.com/jteeuwen/go-bindata/pull/74) which removes an obvious issue with the `go generate` checker, namely that the mtime and mode of embedded files are stored, but those aren't versioned through git. The PR allows overriding those two pieces of data with a global constant.
  Updated the `GLOCKFILE` to that effect.
- adapted the generate call to `go-bindata` to make use of the above.
- adapted `circle.yml` to log the diff of the repo after `go generate ./...` to the `generate.log` build artifact and fixed a bug (it wasn't actually checking anything before due to passing the illegal `--untracked` option).
- added a comment about replica ordering (somewhat of an outlier in this PR, but it's a good test for the above).
