### PR TITLE
Replace range.firstIndex with on-disk data about truncated log prefix.

### DIFF
--- a/kv/txn_coord_sender.go
+++ b/kv/txn_coord_sender.go
@@ -160,8 +160,9 @@ type TxnCoordSender struct {
 }
 
 // NewTxnCoordSender creates a new TxnCoordSender for use from a KV
-// distributed DB instance. TxnCoordSenders should be closed when no
-// longer in use via Close().
+// distributed DB instance. A TxnCoordSender should be closed when no
+// longer in use via Close(), which also closes the wrapped sender
+// supplied here.
 func NewTxnCoordSender(wrapped client.KVSender, clock *hlc.Clock, linearizable bool) *TxnCoordSender {
 	tc := &TxnCoordSender{
 		wrapped:           wrapped,

--- a/kv/txn_coord_sender.go
+++ b/kv/txn_coord_sender.go
@@ -200,6 +200,7 @@ func (tc *TxnCoordSender) Close() {
 		close(txn.closer)
 	}
 	tc.txns = map[string]*txnMetadata{}
+	tc.wrapped.Close()
 }
 
 // maybeBeginTxn begins a new transaction if a txn has been specified

--- a/kv/txn_coord_sender_test.go
+++ b/kv/txn_coord_sender_test.go
@@ -101,14 +101,13 @@ func createPutRequest(key proto.Key, value []byte, txn *proto.Transaction) *prot
 // transaction metadata and adding multiple requests with same
 // transaction ID updates the last update timestamp.
 func TestTxnCoordSenderAddRequest(t *testing.T) {
-	db, _, clock, manual, ls, transport, err := createTestDB()
+	db, _, clock, manual, _, transport, err := createTestDB()
 	if err != nil {
 		t.Fatal(err)
 	}
 	coord := getCoord(db)
 	defer transport.Close()
 	defer db.Close()
-	defer ls.Close()
 
 	txn := newTxn(db, clock, proto.Key("a"))
 	putReq := createPutRequest(proto.Key("a"), []byte("value"), txn)
@@ -146,13 +145,12 @@ func TestTxnCoordSenderAddRequest(t *testing.T) {
 // TestTxnCoordSenderBeginTransaction verifies that a command sent with a
 // not-nil Txn with empty ID gets a new transaction initialized.
 func TestTxnCoordSenderBeginTransaction(t *testing.T) {
-	db, _, _, _, ls, transport, err := createTestDB()
+	db, _, _, _, _, transport, err := createTestDB()
 	if err != nil {
 		t.Fatal(err)
 	}
 	defer transport.Close()
 	defer db.Close()
-	defer ls.Close()
 
 	reply := &proto.PutResponse{}
 	key := proto.Key("key")
@@ -191,13 +189,12 @@ func TestTxnCoordSenderBeginTransaction(t *testing.T) {
 // TestTxnCoordSenderBeginTransactionMinPriority verifies that when starting
 // a new transaction, a non-zero priority is treated as a minimum value.
 func TestTxnCoordSenderBeginTransactionMinPriority(t *testing.T) {
-	db, _, _, _, ls, transport, err := createTestDB()
+	db, _, _, _, _, transport, err := createTestDB()
 	if err != nil {
 		t.Fatal(err)
 	}
 	defer transport.Close()
 	defer db.Close()
-	defer ls.Close()
 
 	reply := &proto.PutResponse{}
 	db.Sender().Send(&client.Call{
@@ -239,14 +236,13 @@ func TestTxnCoordSenderKeyRanges(t *testing.T) {
 		{proto.Key("b"), proto.Key("c")},
 	}
 
-	db, _, clock, _, ls, transport, err := createTestDB()
+	db, _, clock, _, _, transport, err := createTestDB()
 	if err != nil {
 		t.Fatal(err)
 	}
 	coord := getCoord(db)
 	defer transport.Close()
 	defer db.Close()
-	defer ls.Close()
 	txn := newTxn(db, clock, proto.Key("a"))
 
 	for _, rng := range ranges {
@@ -273,14 +269,13 @@ func TestTxnCoordSenderKeyRanges(t *testing.T) {
 // TestTxnCoordSenderMultipleTxns verifies correct operation with
 // multiple outstanding transactions.
 func TestTxnCoordSenderMultipleTxns(t *testing.T) {
-	db, _, clock, _, ls, transport, err := createTestDB()
+	db, _, clock, _, _, transport, err := createTestDB()
 	if err != nil {
 		t.Fatal(err)
 	}
 	coord := getCoord(db)
 	defer transport.Close()
 	defer db.Close()
-	defer ls.Close()
 
 	txn1 := newTxn(db, clock, proto.Key("a"))
 	txn2 := newTxn(db, clock, proto.Key("b"))
@@ -299,14 +294,13 @@ func TestTxnCoordSenderMultipleTxns(t *testing.T) {
 // TestTxnCoordSenderHeartbeat verifies periodic heartbeat of the
 // transaction record.
 func TestTxnCoordSenderHeartbeat(t *testing.T) {
-	db, _, clock, manual, ls, transport, err := createTestDB()
+	db, _, clock, manual, _, transport, err := createTestDB()
 	if err != nil {
 		t.Fatal(err)
 	}
 	coord := getCoord(db)
 	defer transport.Close()
 	defer db.Close()
-	defer ls.Close()
 
 	// Set heartbeat interval to 1ms for testing.
 	coord.heartbeatInterval = 1 * time.Millisecond
@@ -376,13 +370,12 @@ func verifyCleanup(key proto.Key, db *client.KV, eng engine.Engine, t *testing.T
 // sends resolve write intent requests and removes the transaction
 // from the txns map.
 func TestTxnCoordSenderEndTxn(t *testing.T) {
-	db, eng, clock, _, ls, transport, err := createTestDB()
+	db, eng, clock, _, _, transport, err := createTestDB()
 	if err != nil {
 		t.Fatal(err)
 	}
 	defer transport.Close()
 	defer db.Close()
-	defer ls.Close()
 
 	txn := newTxn(db, clock, proto.Key("a"))
 	pReply := &proto.PutResponse{}
@@ -415,13 +408,12 @@ func TestTxnCoordSenderEndTxn(t *testing.T) {
 // TestTxnCoordSenderCleanupOnAborted verifies that if a txn receives a
 // TransactionAbortedError, the coordinator cleans up the transaction.
 func TestTxnCoordSenderCleanupOnAborted(t *testing.T) {
-	db, eng, clock, _, ls, transport, err := createTestDB()
+	db, eng, clock, _, _, transport, err := createTestDB()
 	if err != nil {
 		t.Fatal(err)
 	}
 	defer transport.Close()
 	defer db.Close()
-	defer ls.Close()
 
 	// Create a transaction with intent at "a".
 	key := proto.Key("a")
@@ -471,14 +463,13 @@ func TestTxnCoordSenderCleanupOnAborted(t *testing.T) {
 // TestTxnCoordSenderGC verifies that the coordinator cleans up extant
 // transactions after the lastUpdateTS exceeds the timeout.
 func TestTxnCoordSenderGC(t *testing.T) {
-	db, _, clock, manual, ls, transport, err := createTestDB()
+	db, _, clock, manual, _, transport, err := createTestDB()
 	if err != nil {
 		t.Fatal(err)
 	}
 	coord := getCoord(db)
 	defer transport.Close()
 	defer db.Close()
-	defer ls.Close()
 
 	// Set heartbeat interval to 1ms for testing.
 	coord.heartbeatInterval = 1 * time.Millisecond

--- a/multiraft/multiraft.go
+++ b/multiraft/multiraft.go
@@ -816,7 +816,7 @@ func (s *state) handleWriteResponse(response *writeResponse, readyGroups map[uin
 			err := s.Transport.Send(NodeID(msg.To), &RaftMessageRequest{groupID, msg})
 			snapStatus := raft.SnapshotFinish
 			if err != nil {
-				log.Warning("node %v failed to send message to %v", s.nodeID, nodeID)
+				log.Warningf("node %v failed to send message to %v", s.nodeID, nodeID)
 				s.multiNode.ReportUnreachable(msg.To, groupID)
 				snapStatus = raft.SnapshotFailure
 			}

--- a/proto/errors.go
+++ b/proto/errors.go
@@ -63,8 +63,8 @@ func NewRangeKeyMismatchError(start, end Key, desc *RangeDescriptor) *RangeKeyMi
 // Error formats error.
 func (e *RangeKeyMismatchError) Error() string {
 	if e.Range != nil {
-		return fmt.Sprintf("key range %q-%q outside of bounds of range %q-%q (%+v)",
-			e.RequestStartKey, e.RequestEndKey, e.Range.StartKey, e.Range.EndKey, e.Range.Replicas[0])
+		return fmt.Sprintf("key range %q-%q outside of bounds of range %q-%q",
+			e.RequestStartKey, e.RequestEndKey, e.Range.StartKey, e.Range.EndKey)
 	}
 	return fmt.Sprintf("key range %q-%q could not be located within a range on store", e.RequestStartKey, e.RequestEndKey)
 }
@@ -94,9 +94,8 @@ func NewTransactionPushError(txn, pusheeTxn *Transaction) *TransactionPushError 
 func (e *TransactionPushError) Error() string {
 	if e.Txn == nil {
 		return fmt.Sprintf("failed to push %s", e.PusheeTxn)
-	} else {
-		return fmt.Sprintf("txn %s failed to push %s", e.Txn, e.PusheeTxn)
 	}
+	return fmt.Sprintf("txn %s failed to push %s", e.Txn, e.PusheeTxn)
 }
 
 // NewTransactionRetryError initializes a new TransactionRetryError.

--- a/proto/internal.pb.go
+++ b/proto/internal.pb.go
@@ -836,6 +836,35 @@ func (m *InternalTimeSeriesSample) GetFloatMin() float32 {
 	return 0
 }
 
+// RaftTruncatedState contains metadata about the truncated portion of the raft log.
+// Raft requires access to the term of the last truncated log entry even after the
+// rest of the entry has been discarded.
+type RaftTruncatedState struct {
+	// The highest index that has been removed from the log.
+	Index uint64 `protobuf:"varint,1,opt,name=index" json:"index"`
+	// The term corresponding to 'index'.
+	Term             uint64 `protobuf:"varint,2,opt,name=term" json:"term"`
+	XXX_unrecognized []byte `json:"-"`
+}
+
+func (m *RaftTruncatedState) Reset()         { *m = RaftTruncatedState{} }
+func (m *RaftTruncatedState) String() string { return proto1.CompactTextString(m) }
+func (*RaftTruncatedState) ProtoMessage()    {}
+
+func (m *RaftTruncatedState) GetIndex() uint64 {
+	if m != nil {
+		return m.Index
+	}
+	return 0
+}
+
+func (m *RaftTruncatedState) GetTerm() uint64 {
+	if m != nil {
+		return m.Term
+	}
+	return 0
+}
+
 func init() {
 	proto1.RegisterEnum("cockroach.proto.InternalValueType", InternalValueType_name, InternalValueType_value)
 }

--- a/proto/internal.proto
+++ b/proto/internal.proto
@@ -314,3 +314,13 @@ message InternalTimeSeriesSample {
     // Minimum encountered floating point measurement in this sample.
     optional float float_min = 9;
 }
+
+// RaftTruncatedState contains metadata about the truncated portion of the raft log.
+// Raft requires access to the term of the last truncated log entry even after the
+// rest of the entry has been discarded.
+message RaftTruncatedState {
+  // The highest index that has been removed from the log.
+  optional uint64 index = 1 [(gogoproto.nullable) = false];
+  // The term corresponding to 'index'.
+  optional uint64 term = 2 [(gogoproto.nullable) = false];
+}

--- a/run/local-cluster.sh
+++ b/run/local-cluster.sh
@@ -139,6 +139,11 @@ fi
 # Fetch the local status contents from node 1 and verify build information is present.
 LOCAL_URL="$DOCKERHOST:${HTTP_PORTS[1]}/_status/local/"
 LOCAL=$(curl --noproxy '*' -s $LOCAL_URL)
+if [[ -z $LOCAL ]]; then
+  echo "Failed to fetch status from node 1"
+  docker logs ${CIDS[1]}
+  fail
+fi
 for key in 'goVersion' 'tag' 'time' 'dependencies'; do
   if [[ -z $(echo $LOCAL | grep "\"$key\":") ]]; then
       echo "Build var missing for '$key' in $LOCAL"

--- a/storage/engine/cockroach/proto/internal.pb.cc
+++ b/storage/engine/cockroach/proto/internal.pb.cc
@@ -81,6 +81,9 @@ const ::google::protobuf::internal::GeneratedMessageReflection*
 const ::google::protobuf::Descriptor* InternalTimeSeriesSample_descriptor_ = NULL;
 const ::google::protobuf::internal::GeneratedMessageReflection*
   InternalTimeSeriesSample_reflection_ = NULL;
+const ::google::protobuf::Descriptor* RaftTruncatedState_descriptor_ = NULL;
+const ::google::protobuf::internal::GeneratedMessageReflection*
+  RaftTruncatedState_reflection_ = NULL;
 const ::google::protobuf::EnumDescriptor* InternalValueType_descriptor_ = NULL;
 
 }  // namespace
@@ -446,6 +449,22 @@ void protobuf_AssignDesc_cockroach_2fproto_2finternal_2eproto() {
       ::google::protobuf::DescriptorPool::generated_pool(),
       ::google::protobuf::MessageFactory::generated_factory(),
       sizeof(InternalTimeSeriesSample));
+  RaftTruncatedState_descriptor_ = file->message_type(19);
+  static const int RaftTruncatedState_offsets_[2] = {
+    GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(RaftTruncatedState, index_),
+    GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(RaftTruncatedState, term_),
+  };
+  RaftTruncatedState_reflection_ =
+    new ::google::protobuf::internal::GeneratedMessageReflection(
+      RaftTruncatedState_descriptor_,
+      RaftTruncatedState::default_instance_,
+      RaftTruncatedState_offsets_,
+      GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(RaftTruncatedState, _has_bits_[0]),
+      GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(RaftTruncatedState, _unknown_fields_),
+      -1,
+      ::google::protobuf::DescriptorPool::generated_pool(),
+      ::google::protobuf::MessageFactory::generated_factory(),
+      sizeof(RaftTruncatedState));
   InternalValueType_descriptor_ = file->enum_type(0);
 }
 
@@ -499,6 +518,8 @@ void protobuf_RegisterTypes(const ::std::string&) {
     InternalTimeSeriesData_descriptor_, &InternalTimeSeriesData::default_instance());
   ::google::protobuf::MessageFactory::InternalRegisterGeneratedMessage(
     InternalTimeSeriesSample_descriptor_, &InternalTimeSeriesSample::default_instance());
+  ::google::protobuf::MessageFactory::InternalRegisterGeneratedMessage(
+    RaftTruncatedState_descriptor_, &RaftTruncatedState::default_instance());
 }
 
 }  // namespace
@@ -544,6 +565,8 @@ void protobuf_ShutdownFile_cockroach_2fproto_2finternal_2eproto() {
   delete InternalTimeSeriesData_reflection_;
   delete InternalTimeSeriesSample::default_instance_;
   delete InternalTimeSeriesSample_reflection_;
+  delete RaftTruncatedState::default_instance_;
+  delete RaftTruncatedState_reflection_;
 }
 
 void protobuf_AddDesc_cockroach_2fproto_2finternal_2eproto() {
@@ -671,8 +694,10 @@ void protobuf_AddDesc_cockroach_2fproto_2finternal_2eproto() {
     "\037\000\022\017\n\007int_sum\030\003 \001(\003\022\017\n\007int_max\030\004 \001(\003\022\017\n\007"
     "int_min\030\005 \001(\003\022\031\n\013float_count\030\006 \001(\rB\004\310\336\037\000"
     "\022\021\n\tfloat_sum\030\007 \001(\002\022\021\n\tfloat_max\030\010 \001(\002\022\021"
-    "\n\tfloat_min\030\t \001(\002*%\n\021InternalValueType\022\n"
-    "\n\006_CR_TS\020\001\032\004\210\243\036\000B\007Z\005proto", 4625);
+    "\n\tfloat_min\030\t \001(\002\"=\n\022RaftTruncatedState\022"
+    "\023\n\005index\030\001 \001(\004B\004\310\336\037\000\022\022\n\004term\030\002 \001(\004B\004\310\336\037\000"
+    "*%\n\021InternalValueType\022\n\n\006_CR_TS\020\001\032\004\210\243\036\000B"
+    "\007Z\005proto", 4688);
   ::google::protobuf::MessageFactory::InternalRegisterGeneratedFile(
     "cockroach/proto/internal.proto", &protobuf_RegisterTypes);
   InternalRangeLookupRequest::default_instance_ = new InternalRangeLookupRequest();
@@ -695,6 +720,7 @@ void protobuf_AddDesc_cockroach_2fproto_2finternal_2eproto() {
   InternalRaftCommand::default_instance_ = new InternalRaftCommand();
   InternalTimeSeriesData::default_instance_ = new InternalTimeSeriesData();
   InternalTimeSeriesSample::default_instance_ = new InternalTimeSeriesSample();
+  RaftTruncatedState::default_instance_ = new RaftTruncatedState();
   InternalRangeLookupRequest::default_instance_->InitAsDefaultInstance();
   InternalRangeLookupResponse::default_instance_->InitAsDefaultInstance();
   InternalHeartbeatTxnRequest::default_instance_->InitAsDefaultInstance();
@@ -715,6 +741,7 @@ void protobuf_AddDesc_cockroach_2fproto_2finternal_2eproto() {
   InternalRaftCommand::default_instance_->InitAsDefaultInstance();
   InternalTimeSeriesData::default_instance_->InitAsDefaultInstance();
   InternalTimeSeriesSample::default_instance_->InitAsDefaultInstance();
+  RaftTruncatedState::default_instance_->InitAsDefaultInstance();
   ::google::protobuf::internal::OnShutdown(&protobuf_ShutdownFile_cockroach_2fproto_2finternal_2eproto);
 }
 
@@ -7620,6 +7647,280 @@ void InternalTimeSeriesSample::Swap(InternalTimeSeriesSample* other) {
   ::google::protobuf::Metadata metadata;
   metadata.descriptor = InternalTimeSeriesSample_descriptor_;
   metadata.reflection = InternalTimeSeriesSample_reflection_;
+  return metadata;
+}
+
+
+// ===================================================================
+
+#ifndef _MSC_VER
+const int RaftTruncatedState::kIndexFieldNumber;
+const int RaftTruncatedState::kTermFieldNumber;
+#endif  // !_MSC_VER
+
+RaftTruncatedState::RaftTruncatedState()
+  : ::google::protobuf::Message() {
+  SharedCtor();
+  // @@protoc_insertion_point(constructor:cockroach.proto.RaftTruncatedState)
+}
+
+void RaftTruncatedState::InitAsDefaultInstance() {
+}
+
+RaftTruncatedState::RaftTruncatedState(const RaftTruncatedState& from)
+  : ::google::protobuf::Message() {
+  SharedCtor();
+  MergeFrom(from);
+  // @@protoc_insertion_point(copy_constructor:cockroach.proto.RaftTruncatedState)
+}
+
+void RaftTruncatedState::SharedCtor() {
+  _cached_size_ = 0;
+  index_ = GOOGLE_ULONGLONG(0);
+  term_ = GOOGLE_ULONGLONG(0);
+  ::memset(_has_bits_, 0, sizeof(_has_bits_));
+}
+
+RaftTruncatedState::~RaftTruncatedState() {
+  // @@protoc_insertion_point(destructor:cockroach.proto.RaftTruncatedState)
+  SharedDtor();
+}
+
+void RaftTruncatedState::SharedDtor() {
+  if (this != default_instance_) {
+  }
+}
+
+void RaftTruncatedState::SetCachedSize(int size) const {
+  GOOGLE_SAFE_CONCURRENT_WRITES_BEGIN();
+  _cached_size_ = size;
+  GOOGLE_SAFE_CONCURRENT_WRITES_END();
+}
+const ::google::protobuf::Descriptor* RaftTruncatedState::descriptor() {
+  protobuf_AssignDescriptorsOnce();
+  return RaftTruncatedState_descriptor_;
+}
+
+const RaftTruncatedState& RaftTruncatedState::default_instance() {
+  if (default_instance_ == NULL) protobuf_AddDesc_cockroach_2fproto_2finternal_2eproto();
+  return *default_instance_;
+}
+
+RaftTruncatedState* RaftTruncatedState::default_instance_ = NULL;
+
+RaftTruncatedState* RaftTruncatedState::New() const {
+  return new RaftTruncatedState;
+}
+
+void RaftTruncatedState::Clear() {
+#define OFFSET_OF_FIELD_(f) (reinterpret_cast<char*>(      \
+  &reinterpret_cast<RaftTruncatedState*>(16)->f) - \
+   reinterpret_cast<char*>(16))
+
+#define ZR_(first, last) do {                              \
+    size_t f = OFFSET_OF_FIELD_(first);                    \
+    size_t n = OFFSET_OF_FIELD_(last) - f + sizeof(last);  \
+    ::memset(&first, 0, n);                                \
+  } while (0)
+
+  ZR_(index_, term_);
+
+#undef OFFSET_OF_FIELD_
+#undef ZR_
+
+  ::memset(_has_bits_, 0, sizeof(_has_bits_));
+  mutable_unknown_fields()->Clear();
+}
+
+bool RaftTruncatedState::MergePartialFromCodedStream(
+    ::google::protobuf::io::CodedInputStream* input) {
+#define DO_(EXPRESSION) if (!(EXPRESSION)) goto failure
+  ::google::protobuf::uint32 tag;
+  // @@protoc_insertion_point(parse_start:cockroach.proto.RaftTruncatedState)
+  for (;;) {
+    ::std::pair< ::google::protobuf::uint32, bool> p = input->ReadTagWithCutoff(127);
+    tag = p.first;
+    if (!p.second) goto handle_unusual;
+    switch (::google::protobuf::internal::WireFormatLite::GetTagFieldNumber(tag)) {
+      // optional uint64 index = 1;
+      case 1: {
+        if (tag == 8) {
+          DO_((::google::protobuf::internal::WireFormatLite::ReadPrimitive<
+                   ::google::protobuf::uint64, ::google::protobuf::internal::WireFormatLite::TYPE_UINT64>(
+                 input, &index_)));
+          set_has_index();
+        } else {
+          goto handle_unusual;
+        }
+        if (input->ExpectTag(16)) goto parse_term;
+        break;
+      }
+
+      // optional uint64 term = 2;
+      case 2: {
+        if (tag == 16) {
+         parse_term:
+          DO_((::google::protobuf::internal::WireFormatLite::ReadPrimitive<
+                   ::google::protobuf::uint64, ::google::protobuf::internal::WireFormatLite::TYPE_UINT64>(
+                 input, &term_)));
+          set_has_term();
+        } else {
+          goto handle_unusual;
+        }
+        if (input->ExpectAtEnd()) goto success;
+        break;
+      }
+
+      default: {
+      handle_unusual:
+        if (tag == 0 ||
+            ::google::protobuf::internal::WireFormatLite::GetTagWireType(tag) ==
+            ::google::protobuf::internal::WireFormatLite::WIRETYPE_END_GROUP) {
+          goto success;
+        }
+        DO_(::google::protobuf::internal::WireFormat::SkipField(
+              input, tag, mutable_unknown_fields()));
+        break;
+      }
+    }
+  }
+success:
+  // @@protoc_insertion_point(parse_success:cockroach.proto.RaftTruncatedState)
+  return true;
+failure:
+  // @@protoc_insertion_point(parse_failure:cockroach.proto.RaftTruncatedState)
+  return false;
+#undef DO_
+}
+
+void RaftTruncatedState::SerializeWithCachedSizes(
+    ::google::protobuf::io::CodedOutputStream* output) const {
+  // @@protoc_insertion_point(serialize_start:cockroach.proto.RaftTruncatedState)
+  // optional uint64 index = 1;
+  if (has_index()) {
+    ::google::protobuf::internal::WireFormatLite::WriteUInt64(1, this->index(), output);
+  }
+
+  // optional uint64 term = 2;
+  if (has_term()) {
+    ::google::protobuf::internal::WireFormatLite::WriteUInt64(2, this->term(), output);
+  }
+
+  if (!unknown_fields().empty()) {
+    ::google::protobuf::internal::WireFormat::SerializeUnknownFields(
+        unknown_fields(), output);
+  }
+  // @@protoc_insertion_point(serialize_end:cockroach.proto.RaftTruncatedState)
+}
+
+::google::protobuf::uint8* RaftTruncatedState::SerializeWithCachedSizesToArray(
+    ::google::protobuf::uint8* target) const {
+  // @@protoc_insertion_point(serialize_to_array_start:cockroach.proto.RaftTruncatedState)
+  // optional uint64 index = 1;
+  if (has_index()) {
+    target = ::google::protobuf::internal::WireFormatLite::WriteUInt64ToArray(1, this->index(), target);
+  }
+
+  // optional uint64 term = 2;
+  if (has_term()) {
+    target = ::google::protobuf::internal::WireFormatLite::WriteUInt64ToArray(2, this->term(), target);
+  }
+
+  if (!unknown_fields().empty()) {
+    target = ::google::protobuf::internal::WireFormat::SerializeUnknownFieldsToArray(
+        unknown_fields(), target);
+  }
+  // @@protoc_insertion_point(serialize_to_array_end:cockroach.proto.RaftTruncatedState)
+  return target;
+}
+
+int RaftTruncatedState::ByteSize() const {
+  int total_size = 0;
+
+  if (_has_bits_[0 / 32] & (0xffu << (0 % 32))) {
+    // optional uint64 index = 1;
+    if (has_index()) {
+      total_size += 1 +
+        ::google::protobuf::internal::WireFormatLite::UInt64Size(
+          this->index());
+    }
+
+    // optional uint64 term = 2;
+    if (has_term()) {
+      total_size += 1 +
+        ::google::protobuf::internal::WireFormatLite::UInt64Size(
+          this->term());
+    }
+
+  }
+  if (!unknown_fields().empty()) {
+    total_size +=
+      ::google::protobuf::internal::WireFormat::ComputeUnknownFieldsSize(
+        unknown_fields());
+  }
+  GOOGLE_SAFE_CONCURRENT_WRITES_BEGIN();
+  _cached_size_ = total_size;
+  GOOGLE_SAFE_CONCURRENT_WRITES_END();
+  return total_size;
+}
+
+void RaftTruncatedState::MergeFrom(const ::google::protobuf::Message& from) {
+  GOOGLE_CHECK_NE(&from, this);
+  const RaftTruncatedState* source =
+    ::google::protobuf::internal::dynamic_cast_if_available<const RaftTruncatedState*>(
+      &from);
+  if (source == NULL) {
+    ::google::protobuf::internal::ReflectionOps::Merge(from, this);
+  } else {
+    MergeFrom(*source);
+  }
+}
+
+void RaftTruncatedState::MergeFrom(const RaftTruncatedState& from) {
+  GOOGLE_CHECK_NE(&from, this);
+  if (from._has_bits_[0 / 32] & (0xffu << (0 % 32))) {
+    if (from.has_index()) {
+      set_index(from.index());
+    }
+    if (from.has_term()) {
+      set_term(from.term());
+    }
+  }
+  mutable_unknown_fields()->MergeFrom(from.unknown_fields());
+}
+
+void RaftTruncatedState::CopyFrom(const ::google::protobuf::Message& from) {
+  if (&from == this) return;
+  Clear();
+  MergeFrom(from);
+}
+
+void RaftTruncatedState::CopyFrom(const RaftTruncatedState& from) {
+  if (&from == this) return;
+  Clear();
+  MergeFrom(from);
+}
+
+bool RaftTruncatedState::IsInitialized() const {
+
+  return true;
+}
+
+void RaftTruncatedState::Swap(RaftTruncatedState* other) {
+  if (other != this) {
+    std::swap(index_, other->index_);
+    std::swap(term_, other->term_);
+    std::swap(_has_bits_[0], other->_has_bits_[0]);
+    _unknown_fields_.Swap(&other->_unknown_fields_);
+    std::swap(_cached_size_, other->_cached_size_);
+  }
+}
+
+::google::protobuf::Metadata RaftTruncatedState::GetMetadata() const {
+  protobuf_AssignDescriptorsOnce();
+  ::google::protobuf::Metadata metadata;
+  metadata.descriptor = RaftTruncatedState_descriptor_;
+  metadata.reflection = RaftTruncatedState_reflection_;
   return metadata;
 }
 

--- a/storage/engine/cockroach/proto/internal.pb.h
+++ b/storage/engine/cockroach/proto/internal.pb.h
@@ -59,6 +59,7 @@ class InternalRaftCommandUnion;
 class InternalRaftCommand;
 class InternalTimeSeriesData;
 class InternalTimeSeriesSample;
+class RaftTruncatedState;
 
 enum InternalValueType {
   _CR_TS = 1
@@ -2323,6 +2324,95 @@ class InternalTimeSeriesSample : public ::google::protobuf::Message {
 
   void InitAsDefaultInstance();
   static InternalTimeSeriesSample* default_instance_;
+};
+// -------------------------------------------------------------------
+
+class RaftTruncatedState : public ::google::protobuf::Message {
+ public:
+  RaftTruncatedState();
+  virtual ~RaftTruncatedState();
+
+  RaftTruncatedState(const RaftTruncatedState& from);
+
+  inline RaftTruncatedState& operator=(const RaftTruncatedState& from) {
+    CopyFrom(from);
+    return *this;
+  }
+
+  inline const ::google::protobuf::UnknownFieldSet& unknown_fields() const {
+    return _unknown_fields_;
+  }
+
+  inline ::google::protobuf::UnknownFieldSet* mutable_unknown_fields() {
+    return &_unknown_fields_;
+  }
+
+  static const ::google::protobuf::Descriptor* descriptor();
+  static const RaftTruncatedState& default_instance();
+
+  void Swap(RaftTruncatedState* other);
+
+  // implements Message ----------------------------------------------
+
+  RaftTruncatedState* New() const;
+  void CopyFrom(const ::google::protobuf::Message& from);
+  void MergeFrom(const ::google::protobuf::Message& from);
+  void CopyFrom(const RaftTruncatedState& from);
+  void MergeFrom(const RaftTruncatedState& from);
+  void Clear();
+  bool IsInitialized() const;
+
+  int ByteSize() const;
+  bool MergePartialFromCodedStream(
+      ::google::protobuf::io::CodedInputStream* input);
+  void SerializeWithCachedSizes(
+      ::google::protobuf::io::CodedOutputStream* output) const;
+  ::google::protobuf::uint8* SerializeWithCachedSizesToArray(::google::protobuf::uint8* output) const;
+  int GetCachedSize() const { return _cached_size_; }
+  private:
+  void SharedCtor();
+  void SharedDtor();
+  void SetCachedSize(int size) const;
+  public:
+  ::google::protobuf::Metadata GetMetadata() const;
+
+  // nested types ----------------------------------------------------
+
+  // accessors -------------------------------------------------------
+
+  // optional uint64 index = 1;
+  inline bool has_index() const;
+  inline void clear_index();
+  static const int kIndexFieldNumber = 1;
+  inline ::google::protobuf::uint64 index() const;
+  inline void set_index(::google::protobuf::uint64 value);
+
+  // optional uint64 term = 2;
+  inline bool has_term() const;
+  inline void clear_term();
+  static const int kTermFieldNumber = 2;
+  inline ::google::protobuf::uint64 term() const;
+  inline void set_term(::google::protobuf::uint64 value);
+
+  // @@protoc_insertion_point(class_scope:cockroach.proto.RaftTruncatedState)
+ private:
+  inline void set_has_index();
+  inline void clear_has_index();
+  inline void set_has_term();
+  inline void clear_has_term();
+
+  ::google::protobuf::UnknownFieldSet _unknown_fields_;
+
+  ::google::protobuf::uint32 _has_bits_[1];
+  mutable int _cached_size_;
+  ::google::protobuf::uint64 index_;
+  ::google::protobuf::uint64 term_;
+  friend void  protobuf_AddDesc_cockroach_2fproto_2finternal_2eproto();
+  friend void protobuf_AssignDesc_cockroach_2fproto_2finternal_2eproto();
+  friend void protobuf_ShutdownFile_cockroach_2fproto_2finternal_2eproto();
+
+  void InitAsDefaultInstance();
+  static RaftTruncatedState* default_instance_;
 };
 // ===================================================================
 
@@ -5186,6 +5276,58 @@ inline void InternalTimeSeriesSample::set_float_min(float value) {
   set_has_float_min();
   float_min_ = value;
   // @@protoc_insertion_point(field_set:cockroach.proto.InternalTimeSeriesSample.float_min)
+}
+
+// -------------------------------------------------------------------
+
+// RaftTruncatedState
+
+// optional uint64 index = 1;
+inline bool RaftTruncatedState::has_index() const {
+  return (_has_bits_[0] & 0x00000001u) != 0;
+}
+inline void RaftTruncatedState::set_has_index() {
+  _has_bits_[0] |= 0x00000001u;
+}
+inline void RaftTruncatedState::clear_has_index() {
+  _has_bits_[0] &= ~0x00000001u;
+}
+inline void RaftTruncatedState::clear_index() {
+  index_ = GOOGLE_ULONGLONG(0);
+  clear_has_index();
+}
+inline ::google::protobuf::uint64 RaftTruncatedState::index() const {
+  // @@protoc_insertion_point(field_get:cockroach.proto.RaftTruncatedState.index)
+  return index_;
+}
+inline void RaftTruncatedState::set_index(::google::protobuf::uint64 value) {
+  set_has_index();
+  index_ = value;
+  // @@protoc_insertion_point(field_set:cockroach.proto.RaftTruncatedState.index)
+}
+
+// optional uint64 term = 2;
+inline bool RaftTruncatedState::has_term() const {
+  return (_has_bits_[0] & 0x00000002u) != 0;
+}
+inline void RaftTruncatedState::set_has_term() {
+  _has_bits_[0] |= 0x00000002u;
+}
+inline void RaftTruncatedState::clear_has_term() {
+  _has_bits_[0] &= ~0x00000002u;
+}
+inline void RaftTruncatedState::clear_term() {
+  term_ = GOOGLE_ULONGLONG(0);
+  clear_has_term();
+}
+inline ::google::protobuf::uint64 RaftTruncatedState::term() const {
+  // @@protoc_insertion_point(field_get:cockroach.proto.RaftTruncatedState.term)
+  return term_;
+}
+inline void RaftTruncatedState::set_term(::google::protobuf::uint64 value) {
+  set_has_term();
+  term_ = value;
+  // @@protoc_insertion_point(field_set:cockroach.proto.RaftTruncatedState.term)
 }
 
 

--- a/storage/engine/keys.go
+++ b/storage/engine/keys.go
@@ -71,9 +71,9 @@ func RaftLogPrefix(raftID int64) proto.Key {
 	return MakeRangeIDKey(raftID, KeyLocalRaftLogSuffix, proto.Key{})
 }
 
-// RaftStateKey returns a system-local key for a Raft HardState.
-func RaftStateKey(raftID int64) proto.Key {
-	return MakeRangeIDKey(raftID, KeyLocalRaftStateSuffix, proto.Key{})
+// RaftHardStateKey returns a system-local key for a Raft HardState.
+func RaftHardStateKey(raftID int64) proto.Key {
+	return MakeRangeIDKey(raftID, KeyLocalRaftHardStateSuffix, proto.Key{})
 }
 
 // DecodeRaftStateKey extracts the Raft ID from a RaftStateKey.
@@ -85,6 +85,11 @@ func DecodeRaftStateKey(key proto.Key) int64 {
 	b := key[len(KeyLocalRangeIDPrefix):]
 	_, raftID := encoding.DecodeUvarint(b)
 	return int64(raftID)
+}
+
+// RaftTruncatedStateKey returns a system-local key for a RaftTruncatedState.
+func RaftTruncatedStateKey(raftID int64) proto.Key {
+	return MakeRangeIDKey(raftID, KeyLocalRaftTruncatedStateSuffix, proto.Key{})
 }
 
 // RangeStatKey returns the key for accessing the named stat
@@ -350,8 +355,10 @@ var (
 	KeyLocalRangeIDPrefix = MakeKey(KeyLocalPrefix, proto.Key("i"))
 	// KeyLocalRaftLogSuffix is the suffix for the raft log.
 	KeyLocalRaftLogSuffix = proto.Key("rftl")
-	// KeyLocalRaftStateSuffix is the Suffix for the raft HardState.
-	KeyLocalRaftStateSuffix = proto.Key("rfts")
+	// KeyLocalRaftHardStateSuffix is the Suffix for the raft HardState.
+	KeyLocalRaftHardStateSuffix = proto.Key("rfth")
+	// KeyLocalRaftTruncatedStateSuffix is the suffix for the RaftTruncatedState.
+	KeyLocalRaftTruncatedStateSuffix = proto.Key("rftt")
 	// KeyLocalRangeGCMetadataSuffix is the suffix for a range's GC metadata.
 	KeyLocalRangeGCMetadataSuffix = proto.Key("rgcm")
 	// KeyLocalRangeLastVerificationTimestampSuffix is the suffix for a range's

--- a/storage/range.go
+++ b/storage/range.go
@@ -1458,7 +1458,7 @@ func (r *Range) InitialState() (raftpb.HardState, raftpb.ConfState, error) {
 	return hs, cs, nil
 }
 
-// loadFirstAndLastIndex looks in the engine to find the first and last log index.
+// loadLastIndex looks in the engine to find the last log index.
 func (r *Range) loadLastIndex() error {
 	logKey := engine.RaftLogPrefix(r.Desc().RaftID)
 	kvs, err := engine.MVCCScan(r.rm.Engine(),
@@ -1553,9 +1553,12 @@ func (r *Range) raftTruncatedState() (proto.RaftTruncatedState, error) {
 	}
 	if !ok {
 		if len(r.Desc().EndKey) > 0 {
+			// If we created this range (and know its start/end keys, set the initial log index/term.
 			ts.Index = raftInitialLogIndex
 			ts.Term = raftInitialLogTerm
 		} else {
+			// If we don't know the start/end keys, this is a new range we are receiving from
+			// another node. Start from zero so we will receive a snapshot.
 			ts.Index = 0
 			ts.Term = 0
 		}

--- a/storage/range.go
+++ b/storage/range.go
@@ -176,8 +176,6 @@ type Range struct {
 	maxBytes int64          // Max bytes before split.
 	// 1 if a split, merge, or replica change is underway; updated atomically
 	metaLock int32
-	// First non-truncated entry in the raft log. Updated atomically.
-	firstIndex uint64
 	// Last index persisted to the raft log (not necessarily committed).
 	// Updated atomically.
 	lastIndex uint64
@@ -204,7 +202,7 @@ func NewRange(desc *proto.RangeDescriptor, rm RangeManager) (*Range, error) {
 	}
 	r.SetDesc(desc)
 
-	err := r.loadFirstAndLastIndex()
+	err := r.loadLastIndex()
 	if err != nil {
 		return nil, err
 	}
@@ -583,7 +581,7 @@ func (r *Range) processRaftCommand(idKey cmdIDKey, raftCmd proto.InternalRaftCom
 	if cmd != nil {
 		cmd.done <- err
 	} else if err != nil {
-		log.Errorf("error executing raft command: %s", err)
+		log.Errorf("error executing raft command %s: %s", method, err)
 	}
 	return err
 }
@@ -1303,15 +1301,30 @@ func (r *Range) InternalMerge(batch engine.Engine, ms *engine.MVCCStats, args *p
 
 // InternalTruncateLog discards a prefix of the raft log.
 func (r *Range) InternalTruncateLog(batch engine.Engine, ms *engine.MVCCStats, args *proto.InternalTruncateLogRequest, reply *proto.InternalTruncateLogResponse) {
+	// args.Index is the first index to keep.
+	term, err := r.Term(args.Index - 1)
+	if err != nil {
+		reply.SetGoError(err)
+		return
+	}
 	start := engine.RaftLogKey(r.Desc().RaftID, args.Index).Next()
 	end := engine.RaftLogKey(r.Desc().RaftID, 0)
-	err := batch.Iterate(engine.MVCCEncodeKey(start), engine.MVCCEncodeKey(end),
+	err = batch.Iterate(engine.MVCCEncodeKey(start), engine.MVCCEncodeKey(end),
 		func(kv proto.RawKeyValue) (bool, error) {
 			err := batch.Clear(kv.Key)
 			return false, err
 		})
+	if err != nil {
+		reply.SetGoError(err)
+		return
+	}
+	ts := proto.RaftTruncatedState{
+		Index: args.Index - 1,
+		Term:  term,
+	}
+	err = engine.MVCCPutProto(batch, nil, engine.RaftTruncatedStateKey(r.Desc().RaftID),
+		proto.ZeroTimestamp, nil, &ts)
 	reply.SetGoError(err)
-	atomic.StoreUint64(&r.firstIndex, args.Index)
 }
 
 // splitTrigger is called on a successful commit of an AdminSplit
@@ -1417,7 +1430,7 @@ func (r *Range) changeReplicasTrigger(change *proto.ChangeReplicasTrigger) error
 // InitialState implements the raft.Storage interface.
 func (r *Range) InitialState() (raftpb.HardState, raftpb.ConfState, error) {
 	var hs raftpb.HardState
-	found, err := engine.MVCCGetProto(r.rm.Engine(), engine.RaftStateKey(r.Desc().RaftID),
+	found, err := engine.MVCCGetProto(r.rm.Engine(), engine.RaftHardStateKey(r.Desc().RaftID),
 		proto.ZeroTimestamp, nil, &hs)
 	if err != nil {
 		return raftpb.HardState{}, raftpb.ConfState{}, err
@@ -1429,15 +1442,10 @@ func (r *Range) InitialState() (raftpb.HardState, raftpb.ConfState, error) {
 			hs.Term = raftInitialLogTerm
 			hs.Commit = raftInitialLogIndex
 
-			// firstIndex and lastIndex are both inclusive, so when the log is empty
-			// firstIndex == lastIndex + 1. raftInitialLogIndex is the dummy term-only
-			// entry; raftInitialLogIndex+1 is the first regular entry.
-			atomic.StoreUint64(&r.firstIndex, raftInitialLogIndex+1)
 			atomic.StoreUint64(&r.lastIndex, raftInitialLogIndex)
 		} else {
 			// If we don't know the start/end keys, this is a new range we are receiving from
 			// another node. Start from zero so we will receive a snapshot.
-			atomic.StoreUint64(&r.firstIndex, 1)
 			atomic.StoreUint64(&r.lastIndex, 0)
 		}
 	}
@@ -1451,13 +1459,11 @@ func (r *Range) InitialState() (raftpb.HardState, raftpb.ConfState, error) {
 }
 
 // loadFirstAndLastIndex looks in the engine to find the first and last log index.
-// TODO(bdarnell): remove unnecessary calls to FirstIndex in etcd/raft and then load
-// the first index lazily (so we don't need to scan the whole range at startup)
-func (r *Range) loadFirstAndLastIndex() error {
+func (r *Range) loadLastIndex() error {
 	logKey := engine.RaftLogPrefix(r.Desc().RaftID)
 	kvs, err := engine.MVCCScan(r.rm.Engine(),
 		logKey, logKey.PrefixEnd(),
-		0, proto.ZeroTimestamp, nil)
+		1, proto.ZeroTimestamp, nil)
 	if err != nil {
 		return err
 	}
@@ -1468,13 +1474,12 @@ func (r *Range) loadFirstAndLastIndex() error {
 			return err
 		}
 		atomic.StoreUint64(&r.lastIndex, lastEnt.Index)
-
-		var firstEnt raftpb.Entry
-		err = gogoproto.Unmarshal(kvs[len(kvs)-1].Value.Bytes, &firstEnt)
+	} else if len(kvs) == 0 {
+		ts, err := r.raftTruncatedState()
 		if err != nil {
-			return err
+			return nil
 		}
-		atomic.StoreUint64(&r.firstIndex, firstEnt.Index)
+		atomic.StoreUint64(&r.lastIndex, ts.Index)
 	}
 	return nil
 }
@@ -1515,14 +1520,17 @@ func (r *Range) Entries(lo, hi uint64) ([]raftpb.Entry, error) {
 
 // Term implements the raft.Storage interface.
 func (r *Range) Term(i uint64) (uint64, error) {
-	if i == 0 {
-		return 0, nil
-	} else if i == raftInitialLogIndex {
-		// TODO(bdarnell): handle the pre-snapshot dummy entry
-		return raftInitialLogTerm, nil
-	}
 	ents, err := r.Entries(i, i+1)
-	if err != nil {
+	if err == raft.ErrUnavailable {
+		ts, err := r.raftTruncatedState()
+		if err != nil {
+			return 0, err
+		}
+		if i == ts.Index {
+			return ts.Term, nil
+		}
+		return 0, raft.ErrUnavailable
+	} else if err != nil {
 		return 0, err
 	}
 	if len(ents) == 0 {
@@ -1536,9 +1544,32 @@ func (r *Range) LastIndex() (uint64, error) {
 	return atomic.LoadUint64(&r.lastIndex), nil
 }
 
+func (r *Range) raftTruncatedState() (proto.RaftTruncatedState, error) {
+	ts := proto.RaftTruncatedState{}
+	ok, err := engine.MVCCGetProto(r.rm.Engine(), engine.RaftTruncatedStateKey(r.Desc().RaftID),
+		proto.ZeroTimestamp, nil, &ts)
+	if err != nil {
+		return ts, err
+	}
+	if !ok {
+		if len(r.Desc().EndKey) > 0 {
+			ts.Index = raftInitialLogIndex
+			ts.Term = raftInitialLogTerm
+		} else {
+			ts.Index = 0
+			ts.Term = 0
+		}
+	}
+	return ts, nil
+}
+
 // FirstIndex implements the raft.Storage interface.
 func (r *Range) FirstIndex() (uint64, error) {
-	return atomic.LoadUint64(&r.firstIndex), nil
+	ts, err := r.raftTruncatedState()
+	if err != nil {
+		return 0, err
+	}
+	return ts.Index + 1, nil
 }
 
 // Snapshot implements the raft.Storage interface.
@@ -1594,15 +1625,23 @@ func (r *Range) ApplySnapshot(snap raftpb.Snapshot) error {
 	// TODO(bdarnell): discard any existing log that is obsoleted by this snapshot.
 	desc := &proto.RangeDescriptor{}
 	err := gogoproto.Unmarshal(snap.Data, desc)
+	if err != nil {
+		return err
+	}
 	r.SetDesc(desc)
-	atomic.StoreUint64(&r.firstIndex, snap.Metadata.Index+1)
 	atomic.StoreUint64(&r.lastIndex, snap.Metadata.Index)
+	ts := proto.RaftTruncatedState{
+		Index: snap.Metadata.Index,
+		Term:  snap.Metadata.Term,
+	}
+	err = engine.MVCCPutProto(r.rm.Engine(), nil, engine.RaftTruncatedStateKey(r.Desc().RaftID),
+		proto.ZeroTimestamp, nil, &ts)
 	return err
 }
 
 // SetHardState implements the multiraft.WriteableGroupStorage interface.
 func (r *Range) SetHardState(st raftpb.HardState) error {
-	return engine.MVCCPutProto(r.rm.Engine(), nil, engine.RaftStateKey(r.Desc().RaftID),
+	return engine.MVCCPutProto(r.rm.Engine(), nil, engine.RaftHardStateKey(r.Desc().RaftID),
 		proto.ZeroTimestamp, nil, &st)
 }
 

--- a/storage/range_data_iter_test.go
+++ b/storage/range_data_iter_test.go
@@ -60,9 +60,9 @@ func createRangeData(r *Range, t *testing.T) []proto.EncodedKey {
 	}{
 		{engine.ResponseCacheKey(r.Desc().RaftID, &proto.ClientCmdID{WallTime: 1, Random: 1}), ts0},
 		{engine.ResponseCacheKey(r.Desc().RaftID, &proto.ClientCmdID{WallTime: 2, Random: 2}), ts0},
+		{engine.RaftHardStateKey(r.Desc().RaftID), ts0},
 		{engine.RaftLogKey(r.Desc().RaftID, 2), ts0},
 		{engine.RaftLogKey(r.Desc().RaftID, 1), ts0},
-		{engine.RaftStateKey(r.Desc().RaftID), ts0},
 		{engine.RangeGCMetadataKey(r.Desc().RaftID), ts0},
 		{engine.RangeLastVerificationTimestampKey(r.Desc().RaftID), ts0},
 		{engine.RangeStatKey(r.Desc().RaftID, engine.StatKeyBytes), ts0},

--- a/storage/range_test.go
+++ b/storage/range_test.go
@@ -1636,7 +1636,7 @@ func TestInternalTruncateLog(t *testing.T) {
 	// The terms of older entries are gone.
 	_, err = tc.rng.Term(indexes[3])
 	if err != raft.ErrUnavailable {
-		t.Errorf("expectedErrUnavailable, got %s", err)
+		t.Errorf("expected ErrUnavailable, got %s", err)
 	}
 }
 

--- a/storage/range_test.go
+++ b/storage/range_test.go
@@ -1623,6 +1623,21 @@ func TestInternalTruncateLog(t *testing.T) {
 	if err != raft.ErrUnavailable {
 		t.Errorf("expected ErrUnavailable, got %s", err)
 	}
+
+	// The term of the last truncated entry is still available.
+	term, err := tc.rng.Term(indexes[4])
+	if err != nil {
+		t.Fatal(err)
+	}
+	if term == 0 {
+		t.Errorf("invalid term 0 for truncated entry")
+	}
+
+	// The terms of older entries are gone.
+	_, err = tc.rng.Term(indexes[3])
+	if err != raft.ErrUnavailable {
+		t.Errorf("expectedErrUnavailable, got %s", err)
+	}
 }
 
 func TestRaftStorage(t *testing.T) {

--- a/storage/scanner_test.go
+++ b/storage/scanner_test.go
@@ -124,7 +124,9 @@ func (tq *testQueue) Start(clock *hlc.Clock, stopper *util.Stopper) {
 				}
 				tq.Unlock()
 			case <-stopper.ShouldStop():
+				tq.Lock()
 				tq.done = true
+				tq.Unlock()
 				stopper.SetStopped()
 				return
 			}


### PR DESCRIPTION
This allows us to store the term of the last truncated log entry
(a prerequisite for proper snapshots) and avoid the expensive scan
over the entire raft log at startup.
