### PR TITLE
Copy some logic from net/http's tests to detect goroutine leaks

### DIFF
--- a/kv/local_sender_test.go
+++ b/kv/local_sender_test.go
@@ -127,7 +127,9 @@ func TestLocalSenderLookupReplica(t *testing.T) {
 	eng := engine.NewInMem(proto.Attributes{}, 1<<20)
 	ls := NewLocalSender()
 	db := client.NewKV(NewTxnCoordSender(ls, clock, false), nil)
-	store := storage.NewStore(clock, eng, db, nil, multiraft.NewLocalRPCTransport())
+	transport := multiraft.NewLocalRPCTransport()
+	defer transport.Close()
+	store := storage.NewStore(clock, eng, db, nil, transport)
 	if err := store.Bootstrap(proto.StoreIdent{NodeID: 1, StoreID: 1}); err != nil {
 		t.Fatal(err)
 	}
@@ -156,7 +158,9 @@ func TestLocalSenderLookupReplica(t *testing.T) {
 	}
 	for i, rng := range ranges {
 		e[i] = engine.NewInMem(proto.Attributes{}, 1<<20)
-		s[i] = storage.NewStore(clock, e[i], db, nil, multiraft.NewLocalRPCTransport())
+		transport := multiraft.NewLocalRPCTransport()
+		defer transport.Close()
+		s[i] = storage.NewStore(clock, e[i], db, nil, transport)
 		s[i].Ident.StoreID = rng.storeID
 		if err := s[i].Bootstrap(proto.StoreIdent{NodeID: 1, StoreID: rng.storeID}); err != nil {
 			t.Fatal(err)

--- a/kv/split_test.go
+++ b/kv/split_test.go
@@ -90,10 +90,11 @@ func startTestWriter(db *client.KV, i int64, valBytes int32, wg *sync.WaitGroup,
 // 10 concurrent goroutines are each running successive transactions
 // composed of a random mix of puts.
 func TestRangeSplitsWithConcurrentTxns(t *testing.T) {
-	db, _, _, _, _, err := createTestDB()
+	db, _, _, _, _, transport, err := createTestDB()
 	if err != nil {
 		t.Fatal(err)
 	}
+	defer transport.Close()
 	defer db.Close()
 
 	// This channel shuts the whole apparatus down.
@@ -139,10 +140,11 @@ func TestRangeSplitsWithConcurrentTxns(t *testing.T) {
 // TestRangeSplitsWithWritePressure sets the zone config max bytes for
 // a range to 256K and writes data until there are five ranges.
 func TestRangeSplitsWithWritePressure(t *testing.T) {
-	db, eng, _, _, _, err := createTestDB()
+	db, eng, _, _, _, transport, err := createTestDB()
 	if err != nil {
 		t.Fatal(err)
 	}
+	defer transport.Close()
 	defer db.Close()
 	setTestRetryOptions()
 

--- a/kv/txn_coord_sender_test.go
+++ b/kv/txn_coord_sender_test.go
@@ -40,7 +40,8 @@ import (
 // client and associated clock's manual time.
 // TODO(spencer): return a struct.
 func createTestDB() (db *client.KV, eng engine.Engine, clock *hlc.Clock,
-	manual *hlc.ManualClock, lSender *LocalSender, err error) {
+	manual *hlc.ManualClock, lSender *LocalSender,
+	transport multiraft.Transport, err error) {
 	rpcContext := rpc.NewContext(hlc.NewClock(hlc.UnixNano), rpc.LoadInsecureTLSConfig())
 	g := gossip.New(rpcContext, 250*time.Millisecond, "")
 	manual = hlc.NewManualClock(0)
@@ -50,7 +51,8 @@ func createTestDB() (db *client.KV, eng engine.Engine, clock *hlc.Clock,
 	sender := NewTxnCoordSender(lSender, clock, false)
 	db = client.NewKV(sender, nil)
 	db.User = storage.UserRoot
-	store := storage.NewStore(clock, eng, db, g, multiraft.NewLocalRPCTransport())
+	transport = multiraft.NewLocalRPCTransport()
+	store := storage.NewStore(clock, eng, db, g, transport)
 	if err = store.Bootstrap(proto.StoreIdent{NodeID: 1, StoreID: 1}); err != nil {
 		return
 	}
@@ -99,11 +101,12 @@ func createPutRequest(key proto.Key, value []byte, txn *proto.Transaction) *prot
 // transaction metadata and adding multiple requests with same
 // transaction ID updates the last update timestamp.
 func TestTxnCoordSenderAddRequest(t *testing.T) {
-	db, _, clock, manual, ls, err := createTestDB()
+	db, _, clock, manual, ls, transport, err := createTestDB()
 	if err != nil {
 		t.Fatal(err)
 	}
 	coord := getCoord(db)
+	defer transport.Close()
 	defer db.Close()
 	defer ls.Close()
 
@@ -143,10 +146,11 @@ func TestTxnCoordSenderAddRequest(t *testing.T) {
 // TestTxnCoordSenderBeginTransaction verifies that a command sent with a
 // not-nil Txn with empty ID gets a new transaction initialized.
 func TestTxnCoordSenderBeginTransaction(t *testing.T) {
-	db, _, _, _, ls, err := createTestDB()
+	db, _, _, _, ls, transport, err := createTestDB()
 	if err != nil {
 		t.Fatal(err)
 	}
+	defer transport.Close()
 	defer db.Close()
 	defer ls.Close()
 
@@ -187,10 +191,11 @@ func TestTxnCoordSenderBeginTransaction(t *testing.T) {
 // TestTxnCoordSenderBeginTransactionMinPriority verifies that when starting
 // a new transaction, a non-zero priority is treated as a minimum value.
 func TestTxnCoordSenderBeginTransactionMinPriority(t *testing.T) {
-	db, _, _, _, ls, err := createTestDB()
+	db, _, _, _, ls, transport, err := createTestDB()
 	if err != nil {
 		t.Fatal(err)
 	}
+	defer transport.Close()
 	defer db.Close()
 	defer ls.Close()
 
@@ -234,11 +239,12 @@ func TestTxnCoordSenderKeyRanges(t *testing.T) {
 		{proto.Key("b"), proto.Key("c")},
 	}
 
-	db, _, clock, _, ls, err := createTestDB()
+	db, _, clock, _, ls, transport, err := createTestDB()
 	if err != nil {
 		t.Fatal(err)
 	}
 	coord := getCoord(db)
+	defer transport.Close()
 	defer db.Close()
 	defer ls.Close()
 	txn := newTxn(db, clock, proto.Key("a"))
@@ -267,11 +273,12 @@ func TestTxnCoordSenderKeyRanges(t *testing.T) {
 // TestTxnCoordSenderMultipleTxns verifies correct operation with
 // multiple outstanding transactions.
 func TestTxnCoordSenderMultipleTxns(t *testing.T) {
-	db, _, clock, _, ls, err := createTestDB()
+	db, _, clock, _, ls, transport, err := createTestDB()
 	if err != nil {
 		t.Fatal(err)
 	}
 	coord := getCoord(db)
+	defer transport.Close()
 	defer db.Close()
 	defer ls.Close()
 
@@ -292,11 +299,12 @@ func TestTxnCoordSenderMultipleTxns(t *testing.T) {
 // TestTxnCoordSenderHeartbeat verifies periodic heartbeat of the
 // transaction record.
 func TestTxnCoordSenderHeartbeat(t *testing.T) {
-	db, _, clock, manual, ls, err := createTestDB()
+	db, _, clock, manual, ls, transport, err := createTestDB()
 	if err != nil {
 		t.Fatal(err)
 	}
 	coord := getCoord(db)
+	defer transport.Close()
 	defer db.Close()
 	defer ls.Close()
 
@@ -368,10 +376,11 @@ func verifyCleanup(key proto.Key, db *client.KV, eng engine.Engine, t *testing.T
 // sends resolve write intent requests and removes the transaction
 // from the txns map.
 func TestTxnCoordSenderEndTxn(t *testing.T) {
-	db, eng, clock, _, ls, err := createTestDB()
+	db, eng, clock, _, ls, transport, err := createTestDB()
 	if err != nil {
 		t.Fatal(err)
 	}
+	defer transport.Close()
 	defer db.Close()
 	defer ls.Close()
 
@@ -406,10 +415,11 @@ func TestTxnCoordSenderEndTxn(t *testing.T) {
 // TestTxnCoordSenderCleanupOnAborted verifies that if a txn receives a
 // TransactionAbortedError, the coordinator cleans up the transaction.
 func TestTxnCoordSenderCleanupOnAborted(t *testing.T) {
-	db, eng, clock, _, ls, err := createTestDB()
+	db, eng, clock, _, ls, transport, err := createTestDB()
 	if err != nil {
 		t.Fatal(err)
 	}
+	defer transport.Close()
 	defer db.Close()
 	defer ls.Close()
 
@@ -461,11 +471,12 @@ func TestTxnCoordSenderCleanupOnAborted(t *testing.T) {
 // TestTxnCoordSenderGC verifies that the coordinator cleans up extant
 // transactions after the lastUpdateTS exceeds the timeout.
 func TestTxnCoordSenderGC(t *testing.T) {
-	db, _, clock, manual, ls, err := createTestDB()
+	db, _, clock, manual, ls, transport, err := createTestDB()
 	if err != nil {
 		t.Fatal(err)
 	}
 	coord := getCoord(db)
+	defer transport.Close()
 	defer db.Close()
 	defer ls.Close()
 

--- a/kv/txn_correctness_test.go
+++ b/kv/txn_correctness_test.go
@@ -608,10 +608,11 @@ func (hv *historyVerifier) runCmd(db *client.KV, txnIdx, retry, cmdIdx int, cmds
 func checkConcurrency(name string, isolations []proto.IsolationType, txns []string,
 	verify *verifier, expSuccess bool, t *testing.T) {
 	verifier := newHistoryVerifier(name, txns, verify, expSuccess, t)
-	db, _, _, _, lSender, err := createTestDB()
+	db, _, _, _, lSender, transport, err := createTestDB()
 	if err != nil {
 		t.Fatal(err)
 	}
+	defer transport.Close()
 	setCorrectnessRetryOptions(lSender)
 	verifier.run(isolations, db, t)
 }

--- a/multiraft/main_test.go
+++ b/multiraft/main_test.go
@@ -1,0 +1,28 @@
+// Copyright 2015 The Cockroach Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+// implied. See the License for the specific language governing
+// permissions and limitations under the License. See the AUTHORS file
+// for names of contributors.
+//
+// Author: Ben Darnell
+
+package multiraft
+
+import (
+	"testing"
+
+	"github.com/cockroachdb/cockroach/util/leaktest"
+)
+
+func TestMain(m *testing.M) {
+	leaktest.TestMainWithLeakCheck(m)
+}

--- a/multiraft/multiraft_test.go
+++ b/multiraft/multiraft_test.go
@@ -23,6 +23,7 @@ import (
 	"time"
 
 	"github.com/cockroachdb/cockroach/util"
+	"github.com/cockroachdb/cockroach/util/leaktest"
 	"github.com/cockroachdb/cockroach/util/log"
 	"github.com/coreos/etcd/raft"
 	"github.com/coreos/etcd/raft/raftpb"
@@ -152,6 +153,7 @@ func (c *testCluster) waitForElection(i int) *EventLeaderElection {
 }
 
 func TestInitialLeaderElection(t *testing.T) {
+	defer leaktest.AfterTest(t)
 	// Run the test three times, each time triggering a different node's election clock.
 	// The node that requests an election first should win.
 	for leaderIndex := 0; leaderIndex < 3; leaderIndex++ {
@@ -174,6 +176,7 @@ func TestInitialLeaderElection(t *testing.T) {
 }
 
 func TestLeaderElectionEvent(t *testing.T) {
+	defer leaktest.AfterTest(t)
 	// Leader election events are fired when the leader commits an entry, not when it
 	// issues a call for votes.
 	cluster := newTestCluster(nil, 3, t)
@@ -227,6 +230,7 @@ func TestLeaderElectionEvent(t *testing.T) {
 }
 
 func TestCommand(t *testing.T) {
+	defer leaktest.AfterTest(t)
 	cluster := newTestCluster(nil, 3, t)
 	defer cluster.stop()
 	groupID := uint64(1)
@@ -248,6 +252,7 @@ func TestCommand(t *testing.T) {
 }
 
 func TestSlowStorage(t *testing.T) {
+	defer leaktest.AfterTest(t)
 	cluster := newTestCluster(nil, 3, t)
 	defer cluster.stop()
 	groupID := uint64(1)
@@ -293,6 +298,7 @@ func TestSlowStorage(t *testing.T) {
 }
 
 func TestMembershipChange(t *testing.T) {
+	defer leaktest.AfterTest(t)
 	cluster := newTestCluster(nil, 4, t)
 	defer cluster.stop()
 

--- a/server/node.go
+++ b/server/node.go
@@ -117,6 +117,7 @@ func BootstrapCluster(clusterID string, eng engine.Engine) (*client.KV, error) {
 	// Create a KV DB with a local sender.
 	lSender := kv.NewLocalSender()
 	localDB := client.NewKV(kv.NewTxnCoordSender(lSender, clock, false), nil)
+	// TODO(bdarnell): arrange to have the transport closed.
 	s := storage.NewStore(clock, eng, localDB, nil, multiraft.NewLocalRPCTransport())
 
 	// Verify the store isn't already part of a cluster.
@@ -213,7 +214,8 @@ func (n *Node) initStores(clock *hlc.Clock, engines []engine.Engine) error {
 		return util.Error("no engines")
 	}
 	for _, e := range engines {
-		// TODO(bdarnell): use a real transport here instead of NewLocalRPCTransport
+		// TODO(bdarnell): use a real transport here instead of NewLocalRPCTransport.
+		// TODO(bdarnell): arrange to have the transport closed.
 		s := storage.NewStore(clock, e, n.db, n.gossip, multiraft.NewLocalRPCTransport())
 		// Initialize each store in turn, handling un-bootstrapped errors by
 		// adding the store to the bootstraps list.

--- a/storage/client_test.go
+++ b/storage/client_test.go
@@ -63,6 +63,7 @@ func createTestStoreWithEngine(t *testing.T, eng engine.Engine, clock *hlc.Clock
 	sender := kv.NewTxnCoordSender(lSender, clock, false)
 	db := client.NewKV(sender, nil)
 	db.User = storage.UserRoot
+	// TODO(bdarnell): arrange to have the transport closed.
 	store := storage.NewStore(clock, eng, db, g, multiraft.NewLocalRPCTransport())
 	if bootstrap {
 		if err := store.Bootstrap(proto.StoreIdent{NodeID: 1, StoreID: 1}); err != nil {
@@ -124,6 +125,7 @@ func (m *multiTestContext) Stop() {
 	for _, store := range m.stores {
 		store.Stop()
 	}
+	m.transport.Close()
 }
 
 // AddStore creates a new store on the same Transport but doesn't create any ranges.

--- a/storage/range_test.go
+++ b/storage/range_test.go
@@ -165,6 +165,7 @@ func (tc *testContext) Start(t *testing.T) {
 
 func (tc *testContext) Stop() {
 	tc.store.Stop()
+	tc.transport.Close()
 }
 
 // initConfigs creates default configuration entries.
@@ -210,7 +211,11 @@ func TestRangeContains(t *testing.T) {
 
 	e := engine.NewInMem(proto.Attributes{Attrs: []string{"dc1", "mem"}}, 1<<20)
 	clock := hlc.NewClock(hlc.UnixNano)
-	r, err := NewRange(desc, NewStore(clock, e, nil, nil, multiraft.NewLocalRPCTransport()))
+	transport := multiraft.NewLocalRPCTransport()
+	defer transport.Close()
+	store := NewStore(clock, e, nil, nil, multiraft.NewLocalRPCTransport())
+	defer store.Stop()
+	r, err := NewRange(desc, store)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/storage/store.go
+++ b/storage/store.go
@@ -294,9 +294,6 @@ func (s *Store) Stop() {
 		rng.stop()
 	}
 	s.stopper.Stop()
-	// TODO(bdarnell): we don't necessarily own the Transport here; probably need
-	// to move the Close up to a higher level once we have a real Transport.
-	s.transport.Close()
 }
 
 // String formats a store for debug output.

--- a/util/leaktest/leaktest.go
+++ b/util/leaktest/leaktest.go
@@ -1,0 +1,109 @@
+// Copyright 2013 The Go Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package http_test
+
+import (
+	"fmt"
+	"net/http"
+	"os"
+	"runtime"
+	"sort"
+	"strings"
+	"testing"
+	"time"
+)
+
+func TestMain(m *testing.M) {
+	v := m.Run()
+	if v == 0 && goroutineLeaked() {
+		os.Exit(1)
+	}
+	os.Exit(v)
+}
+
+func interestingGoroutines() (gs []string) {
+	buf := make([]byte, 2<<20)
+	buf = buf[:runtime.Stack(buf, true)]
+	for _, g := range strings.Split(string(buf), "\n\n") {
+		sl := strings.SplitN(g, "\n", 2)
+		if len(sl) != 2 {
+			continue
+		}
+		stack := strings.TrimSpace(sl[1])
+		if stack == "" ||
+			strings.Contains(stack, "created by net.startServer") ||
+			strings.Contains(stack, "created by testing.RunTests") ||
+			strings.Contains(stack, "closeWriteAndWait") ||
+			strings.Contains(stack, "testing.Main(") ||
+			// These only show up with GOTRACEBACK=2; Issue 5005 (comment 28)
+			strings.Contains(stack, "runtime.goexit") ||
+			strings.Contains(stack, "created by runtime.gc") ||
+			strings.Contains(stack, "net/http_test.interestingGoroutines") ||
+			strings.Contains(stack, "runtime.MHeap_Scavenger") {
+			continue
+		}
+		gs = append(gs, stack)
+	}
+	sort.Strings(gs)
+	return
+}
+
+// Verify the other tests didn't leave any goroutines running.
+func goroutineLeaked() bool {
+	if testing.Short() {
+		// not counting goroutines for leakage in -short mode
+		return false
+	}
+	gs := interestingGoroutines()
+
+	n := 0
+	stackCount := make(map[string]int)
+	for _, g := range gs {
+		stackCount[g]++
+		n++
+	}
+
+	if n == 0 {
+		return false
+	}
+	fmt.Fprintf(os.Stderr, "Too many goroutines running after net/http test(s).\n")
+	for stack, count := range stackCount {
+		fmt.Fprintf(os.Stderr, "%d instances of:\n%s\n", count, stack)
+	}
+	return true
+}
+
+func afterTest(t testing.TB) {
+	http.DefaultTransport.(*http.Transport).CloseIdleConnections()
+	if testing.Short() {
+		return
+	}
+	var bad string
+	badSubstring := map[string]string{
+		").readLoop(":                                  "a Transport",
+		").writeLoop(":                                 "a Transport",
+		"created by net/http/httptest.(*Server).Start": "an httptest.Server",
+		"timeoutHandler":                               "a TimeoutHandler",
+		"net.(*netFD).connect(":                        "a timing out dial",
+		").noteClientGone(":                            "a closenotifier sender",
+	}
+	var stacks string
+	for i := 0; i < 4; i++ {
+		bad = ""
+		stacks = strings.Join(interestingGoroutines(), "\n\n")
+		for substr, what := range badSubstring {
+			if strings.Contains(stacks, substr) {
+				bad = what
+			}
+		}
+		if bad == "" {
+			return
+		}
+		// Bad stuff found, but goroutines might just still be
+		// shutting down, so give it some time.
+		time.Sleep(250 * time.Millisecond)
+	}
+	t.Errorf("Test appears to have leaked %s:\n%s", bad, stacks)
+}


### PR DESCRIPTION
We currently leak a lot of goroutines in tests; this is a first step towards cleaning that up. This is pretty hacky but if it's good enough for the standard library...
