### PR TITLE
Rename VarUint -> Uvarint to match Go stdlib naming.

### DIFF
--- a/storage/engine/db.cc
+++ b/storage/engine/db.cc
@@ -194,7 +194,7 @@ class DBCompactionFilter : public rocksdb::CompactionFilter {
     decKey.remove_prefix(kKeyLocalRangePrefixSize);
 
     uint64_t dummy;
-    if (!DecodeVarint64(&decKey, &dummy)) {
+    if (!DecodeUvarint64(&decKey, &dummy)) {
       return false;
     }
 

--- a/storage/engine/encoding.cc
+++ b/storage/engine/encoding.cc
@@ -25,11 +25,14 @@ const unsigned char kEscapedTerm = 0x01;
 const unsigned char kEscapedNul  = 0xff;
 
 template <typename T>
-bool DecodeVarint(rocksdb::Slice* buf, T* value) {
+bool DecodeUvarint(rocksdb::Slice* buf, T* value) {
   if (buf->empty()) {
     return false;
   }
-  int len = (*buf)[0];
+  int len = (*buf)[0] - 8;
+  if (len < 0) {
+    return false;
+  }
   if ((len + 1) > buf->size()) {
     return false;
   }
@@ -70,6 +73,6 @@ bool DecodeBytes(rocksdb::Slice* buf, std::string* decoded) {
   return false;
 }
 
-bool DecodeVarint64(rocksdb::Slice* buf, uint64_t* value) {
-  return DecodeVarint(buf, value);
+bool DecodeUvarint64(rocksdb::Slice* buf, uint64_t* value) {
+  return DecodeUvarint(buf, value);
 }

--- a/storage/engine/encoding.h
+++ b/storage/engine/encoding.h
@@ -24,10 +24,10 @@
 // successful decode. The decoded bytes are returned in *decoded.
 bool DecodeBytes(rocksdb::Slice* buf, std::string* decoded);
 
-// DecodeVarint64 decodes a varint encoded uint64 from a buffer,
+// DecodeUvarint64 decodes a varint encoded uint64 from a buffer,
 // returning true on a successful decode. The decoded value is
 // returned in *decoded.
-bool DecodeVarint64(rocksdb::Slice* buf, uint64_t* value);
+bool DecodeUvarint64(rocksdb::Slice* buf, uint64_t* value);
 
 #endif // ROACHLIB_ENCODING_H
 

--- a/storage/engine/keys.go
+++ b/storage/engine/keys.go
@@ -57,7 +57,7 @@ func MakeRangeIDKey(raftID int64, suffix, detail proto.Key) proto.Key {
 	if len(suffix) != KeyLocalSuffixLength {
 		panic(fmt.Sprintf("suffix len(%q) != %d", suffix, KeyLocalSuffixLength))
 	}
-	return MakeKey(KeyLocalRangeIDPrefix, encoding.EncodeVarUint64(nil, uint64(raftID)), suffix, detail)
+	return MakeKey(KeyLocalRangeIDPrefix, encoding.EncodeUvarint(nil, uint64(raftID)), suffix, detail)
 }
 
 // RaftLogKey returns a system-local key for a Raft log entry.
@@ -83,7 +83,7 @@ func DecodeRaftStateKey(key proto.Key) int64 {
 	}
 	// Cut the prefix and the Raft ID.
 	b := key[len(KeyLocalRangeIDPrefix):]
-	_, raftID := encoding.DecodeVarUint64(b)
+	_, raftID := encoding.DecodeUvarint(b)
 	return int64(raftID)
 }
 
@@ -99,7 +99,7 @@ func RangeStatKey(raftID int64, stat proto.Key) proto.Key {
 func ResponseCacheKey(raftID int64, cmdID *proto.ClientCmdID) proto.Key {
 	detail := proto.Key{}
 	if cmdID != nil {
-		detail = encoding.EncodeVarUint64(nil, uint64(cmdID.WallTime)) // wall time helps sort for locality
+		detail = encoding.EncodeUvarint(nil, uint64(cmdID.WallTime)) // wall time helps sort for locality
 		detail = encoding.EncodeUint64(detail, uint64(cmdID.Random))
 	}
 	return MakeRangeIDKey(raftID, KeyLocalResponseCacheSuffix, detail)
@@ -340,7 +340,7 @@ var (
 
 	// KeyLocalRangeIDPrefix is the prefix identifying per-range data
 	// indexed by Raft ID. The Raft ID is appended to this prefix,
-	// encoded using EncodeVarUint64. The specific sort of per-range
+	// encoded using EncodeUvarint. The specific sort of per-range
 	// metadata is identified by one of the suffixes listed below, along
 	// with potentially additional encoded key info, such as a command
 	// ID in the case of response cache entry.

--- a/storage/engine/rocksdb_test.go
+++ b/storage/engine/rocksdb_test.go
@@ -174,7 +174,7 @@ func setupMVCCScanData(numVersions, numKeys int, b *testing.B) *RocksDB {
 		batch := rocksdb.NewBatch()
 		for i := 0; i < numKeys; i++ {
 			if t == 1 {
-				keys[i] = proto.Key(encoding.EncodeVarUint32([]byte("key-"), uint32(i)))
+				keys[i] = proto.Key(encoding.EncodeUvarint([]byte("key-"), uint64(i)))
 				nvs[i] = int(rand.Int31n(int32(numVersions)) + 1)
 			}
 			// Only write values if this iteration is less than the random
@@ -229,7 +229,7 @@ func runMVCCScan(numRows, numVersions int, b *testing.B) {
 		for pb.Next() {
 			// Choose a random key to start scan.
 			keyIdx := rand.Int31n(int32(numKeys - numRows))
-			startKey := proto.Key(encoding.EncodeVarUint32([]byte("key-"), uint32(keyIdx)))
+			startKey := proto.Key(encoding.EncodeUvarint([]byte("key-"), uint64(keyIdx)))
 			walltime := int64(5 * (rand.Int31n(int32(numVersions)) + 1))
 			ts := makeTS(walltime, 0)
 			kvs, err := MVCCScan(rocksdb, startKey, KeyMax, int64(numRows), ts, nil)
@@ -317,7 +317,7 @@ func runMVCCGet(numVersions int, b *testing.B) {
 		for pb.Next() {
 			// Choose a random key to retrieve.
 			keyIdx := rand.Int31n(int32(numKeys))
-			key := proto.Key(encoding.EncodeVarUint32([]byte("key-"), uint32(keyIdx)))
+			key := proto.Key(encoding.EncodeUvarint([]byte("key-"), uint64(keyIdx)))
 			walltime := int64(5 * (rand.Int31n(int32(numVersions)) + 1))
 			ts := makeTS(walltime, 0)
 			if v, err := MVCCGet(rocksdb, key, ts, nil); err != nil {

--- a/storage/range_data_iter.go
+++ b/storage/range_data_iter.go
@@ -52,8 +52,8 @@ func newRangeDataIterator(r *Range, e engine.Engine) *rangeDataIterator {
 	ri := &rangeDataIterator{
 		ranges: []keyRange{
 			{
-				start: engine.MVCCEncodeKey(engine.MakeKey(engine.KeyLocalRangeIDPrefix, encoding.EncodeVarUint64(nil, uint64(r.Desc().RaftID)))),
-				end:   engine.MVCCEncodeKey(engine.MakeKey(engine.KeyLocalRangeIDPrefix, encoding.EncodeVarUint64(nil, uint64(r.Desc().RaftID+1)))),
+				start: engine.MVCCEncodeKey(engine.MakeKey(engine.KeyLocalRangeIDPrefix, encoding.EncodeUvarint(nil, uint64(r.Desc().RaftID)))),
+				end:   engine.MVCCEncodeKey(engine.MakeKey(engine.KeyLocalRangeIDPrefix, encoding.EncodeUvarint(nil, uint64(r.Desc().RaftID+1)))),
 			},
 			{
 				start: engine.MVCCEncodeKey(engine.MakeKey(engine.KeyLocalRangeKeyPrefix, encoding.EncodeBytes(nil, startKey))),

--- a/storage/response_cache.go
+++ b/storage/response_cache.go
@@ -254,14 +254,14 @@ func (rc *ResponseCache) decodeResponseCacheKey(encKey proto.EncodedKey) (proto.
 	}
 	// Cut the prefix and the Raft ID.
 	b := key[len(engine.KeyLocalRangeIDPrefix):]
-	b, _ = encoding.DecodeVarUint64(b)
+	b, _ = encoding.DecodeUvarint(b)
 	if !bytes.HasPrefix(b, engine.KeyLocalResponseCacheSuffix) {
 		return ret, util.Errorf("key %q does not contain the response cache suffix %q", key, engine.KeyLocalResponseCacheSuffix)
 	}
 	// Cut the response cache suffix.
 	b = b[len(engine.KeyLocalResponseCacheSuffix):]
 	// Now, decode the command ID.
-	b, wt := encoding.DecodeVarUint64(b)
+	b, wt := encoding.DecodeUvarint(b)
 	b, rd := encoding.DecodeUint64(b)
 	if len(b) > 0 {
 		return ret, util.Errorf("key %q has leftover bytes after decode: %q; indicates corrupt key", encKey, b)

--- a/util/encoding/numeric.go
+++ b/util/encoding/numeric.go
@@ -177,9 +177,9 @@ func makeIntFromMandE(negative bool, e int, m []byte) int64 {
 // consist of the single byte 0x08 followed by the ones-complement of the
 // varint encoding of E followed by the ones-complement of M.
 //
-// The results numeric encodings are all comparable. That is, the result from
+// The resulting numeric encodings are all comparable. That is, the result from
 // EncodeNumericInt is comparable with the result from EncodeNumericFloat. But
-// this flexibility comes at the cost of speed. Prefer the EncodeVarUint{32,64}
+// this flexibility comes at the cost of speed. Prefer the EncodeUvarint{32,64}
 // routines for speed.
 func EncodeNumericFloat(b []byte, f float64) []byte {
 	// Handle the simplistic cases first.


### PR DESCRIPTION
Removed the "_32" variations as they provided almost no speed
improvement over the "_64" variations when both routines were
benchmarked using 32-bit values.

Added {Decode,Encode}Varint{,Decreasing} and adjusted the Uvarint
encoding so that positive int64 values are encoded the same by both the
Varint and Uvarint routines.
