### PR TITLE
Fix a race in TestStoreShouldSplit.

### DIFF
--- a/storage/client_split_test.go
+++ b/storage/client_split_test.go
@@ -366,7 +366,7 @@ func TestStoreShouldSplit(t *testing.T) {
 			{},
 		},
 		RangeMinBytes: 1 << 8,
-		RangeMaxBytes: 1 << 18,
+		RangeMaxBytes: 1 << 16,
 	}
 	if err := store.DB().PutProto(engine.MakeKey(engine.KeyConfigZonePrefix, engine.KeyMin), zoneConfig); err != nil {
 		t.Fatal(err)
@@ -379,10 +379,6 @@ func TestStoreShouldSplit(t *testing.T) {
 
 	maxBytes := zoneConfig.RangeMaxBytes
 	fillRange(store, rng.Desc().RaftID, proto.Key("test"), maxBytes, t)
-
-	if ok := rng.ShouldSplit(); !ok {
-		t.Errorf("range should split after writing %d bytes", maxBytes)
-	}
 
 	// Verify that the range is in fact split (give it a second for very slow test machines).
 	if err := util.IsTrueWithin(func() bool {


### PR DESCRIPTION
After filling the range we can't check Range.ShouldSplit() as the range
might have already been split. This check was also redundant as we next
check that the range has split.

Speed up the test by setting reducing the max size of the range from
256K to 64K.
