### PR TITLE
Optimize MVCCPut path.

### DIFF
--- a/storage/engine/batch.go
+++ b/storage/engine/batch.go
@@ -15,6 +15,8 @@
 //
 // Author: Spencer Kimball (spencer.kimball@gmail.com)
 
+// TODO(pmattis): Move this into C++.
+
 package engine
 
 import (
@@ -51,6 +53,10 @@ func (b *Batch) Put(key proto.EncodedKey, value []byte) error {
 	if len(key) == 0 {
 		return emptyKeyError()
 	}
+	// Need to make a copy of key and value as the caller may reuse
+	// them.
+	key = append(proto.EncodedKey(nil), key...)
+	value = append([]byte(nil), value...)
 	b.updates.Insert(BatchPut{proto.RawKeyValue{Key: key, Value: value}})
 	return nil
 }
@@ -123,6 +129,8 @@ func (b *Batch) Clear(key proto.EncodedKey) error {
 	if len(key) == 0 {
 		return emptyKeyError()
 	}
+	// Need to make a copy of key as the caller may reuse it.
+	key = append(proto.EncodedKey(nil), key...)
 	b.updates.Insert(BatchDelete{proto.RawKeyValue{Key: key}})
 	return nil
 }
@@ -138,6 +146,8 @@ func (b *Batch) Merge(key proto.EncodedKey, value []byte) error {
 	if len(key) == 0 {
 		return emptyKeyError()
 	}
+	// Need to make a copy of key as the caller may reuse it.
+	key = append(proto.EncodedKey(nil), key...)
 	val := b.updates.Get(proto.RawKeyValue{Key: key})
 	if val != nil {
 		switch t := val.(type) {
@@ -161,6 +171,8 @@ func (b *Batch) Merge(key proto.EncodedKey, value []byte) error {
 			b.updates.Insert(BatchMerge{proto.RawKeyValue{Key: key, Value: mergedBytes}})
 		}
 	} else {
+		// Need to make a copy of value as the caller may reuse it.
+		value = append([]byte(nil), value...)
 		b.updates.Insert(BatchMerge{proto.RawKeyValue{Key: key, Value: value}})
 	}
 	return nil


### PR DESCRIPTION
Keep a pool of buffers for marshalling protos. Used by
engine.PutProto(). Keep a pool of buffers for data needed by
mvccPutInternal() such as the meta and newMeta protos and a buffer to
use for encoding keys. Together these changes completely eliminate
memory allocations in the put path steady state.

benchmark                         old ns/op     new ns/op     delta
BenchmarkMVCCPut10                6769          4606          -31.95%
BenchmarkMVCCPut100               7298          4923          -32.54%
BenchmarkMVCCPut1000              10333         7638          -26.08%
BenchmarkMVCCPut10000             31731         19575         -38.31%
BenchmarkMVCCBatch1Put10          8606          7066          -17.89%
BenchmarkMVCCBatch100Put10        9171          7345          -19.91%
BenchmarkMVCCBatch10000Put10      10721         9594          -10.51%
BenchmarkMVCCBatch100000Put10     14833         13075         -11.85%

benchmark                         old MB/s     new MB/s     speedup
BenchmarkMVCCPut10                1.48         2.17         1.47x
BenchmarkMVCCPut100               13.70        20.31        1.48x
BenchmarkMVCCPut1000              96.77        130.91       1.35x
BenchmarkMVCCPut10000             315.14       510.85       1.62x
BenchmarkMVCCBatch1Put10          1.16         1.42         1.22x
BenchmarkMVCCBatch100Put10        1.09         1.36         1.25x
BenchmarkMVCCBatch10000Put10      0.93         1.04         1.12x
BenchmarkMVCCBatch100000Put10     0.67         0.76         1.13x
