### PR TITLE
Persist the log index of the last applied command.

### DIFF
--- a/multiraft/events.go
+++ b/multiraft/events.go
@@ -47,6 +47,7 @@ type EventCommandCommitted struct {
 // An EventMembershipChangeCommitted is broadcast whenever a membership change
 // has been committed.
 type EventMembershipChangeCommitted struct {
+	// GroupID, CommandID, and Index are the same as for EventCommandCommitted.
 	GroupID    uint64
 	CommandID  string
 	Index      uint64

--- a/multiraft/events.go
+++ b/multiraft/events.go
@@ -32,9 +32,16 @@ type EventLeaderElection struct {
 
 // An EventCommandCommitted is broadcast whenever a command has been committed.
 type EventCommandCommitted struct {
-	GroupID   uint64
+	GroupID uint64
+	// CommandID is the application-supplied ID for this command. The same CommandID
+	// may be seen multiple times, so the application should remember this CommandID
+	// for deduping.
 	CommandID string
-	Command   []byte
+	// Index is the raft log index for this event. The application should persist
+	// the Index of the last applied command atomically with any effects of that
+	// command.
+	Index   uint64
+	Command []byte
 }
 
 // An EventMembershipChangeCommitted is broadcast whenever a membership change
@@ -42,6 +49,7 @@ type EventCommandCommitted struct {
 type EventMembershipChangeCommitted struct {
 	GroupID    uint64
 	CommandID  string
+	Index      uint64
 	NodeID     NodeID
 	ChangeType raftpb.ConfChangeType
 	Payload    []byte

--- a/multiraft/multiraft.go
+++ b/multiraft/multiraft.go
@@ -717,6 +717,7 @@ func (s *state) handleWriteResponse(response *writeResponse, readyGroups map[uin
 						GroupID:   groupID,
 						CommandID: commandID,
 						Command:   command,
+						Index:     entry.Index,
 					})
 				}
 
@@ -733,6 +734,7 @@ func (s *state) handleWriteResponse(response *writeResponse, readyGroups map[uin
 				s.sendEvent(&EventMembershipChangeCommitted{
 					GroupID:    groupID,
 					CommandID:  commandID,
+					Index:      entry.Index,
 					NodeID:     NodeID(cc.NodeID),
 					ChangeType: cc.Type,
 					Payload:    payload,

--- a/storage/engine/keys.go
+++ b/storage/engine/keys.go
@@ -92,6 +92,11 @@ func RaftTruncatedStateKey(raftID int64) proto.Key {
 	return MakeRangeIDKey(raftID, KeyLocalRaftTruncatedStateSuffix, proto.Key{})
 }
 
+// RaftAppliedIndexKey returns a system-local key for a raft applied index.
+func RaftAppliedIndexKey(raftID int64) proto.Key {
+	return MakeRangeIDKey(raftID, KeyLocalRaftAppliedIndexSuffix, proto.Key{})
+}
+
 // RangeStatKey returns the key for accessing the named stat
 // for the specified Raft ID.
 func RangeStatKey(raftID int64, stat proto.Key) proto.Key {
@@ -359,6 +364,8 @@ var (
 	KeyLocalRaftHardStateSuffix = proto.Key("rfth")
 	// KeyLocalRaftTruncatedStateSuffix is the suffix for the RaftTruncatedState.
 	KeyLocalRaftTruncatedStateSuffix = proto.Key("rftt")
+	// KeyLocalRaftAppliedIndexSuffix is the suffix for the raft applied index.
+	KeyLocalRaftAppliedIndexSuffix = proto.Key("rfta")
 	// KeyLocalRangeGCMetadataSuffix is the suffix for a range's GC metadata.
 	KeyLocalRangeGCMetadataSuffix = proto.Key("rgcm")
 	// KeyLocalRangeLastVerificationTimestampSuffix is the suffix for a range's

--- a/storage/range.go
+++ b/storage/range.go
@@ -37,6 +37,7 @@ import (
 	"github.com/cockroachdb/cockroach/proto"
 	"github.com/cockroachdb/cockroach/storage/engine"
 	"github.com/cockroachdb/cockroach/util"
+	"github.com/cockroachdb/cockroach/util/encoding"
 	"github.com/cockroachdb/cockroach/util/hlc"
 	"github.com/cockroachdb/cockroach/util/log"
 	"github.com/coreos/etcd/raft"
@@ -179,7 +180,10 @@ type Range struct {
 	// Last index persisted to the raft log (not necessarily committed).
 	// Updated atomically.
 	lastIndex uint64
-	closer    chan struct{} // Channel for closing the range
+	// Last index applied to the state machine. Only used in the raft processing
+	// thread to assert that it is monotonically increasing.
+	appliedIndex uint64
+	closer       chan struct{} // Channel for closing the range
 
 	sync.RWMutex                 // Protects the following fields (and Desc)
 	cmdQ         *CommandQueue   // Enforce at most one command is running per key(s)
@@ -420,7 +424,7 @@ func (r *Range) addReadOnlyCmd(method string, args proto.Request, reply proto.Re
 		// TODO(spencer): when we happen to know the leader, fill it in here via replica.
 		return &proto.NotLeaderError{}
 	}
-	err := r.executeCmd(method, args, reply)
+	err := r.executeCmd(0, method, args, reply)
 
 	// Only update the timestamp cache if the command succeeded.
 	r.Lock()
@@ -562,7 +566,11 @@ func (r *Range) addReadWriteCmd(method string, args proto.Request, reply proto.R
 	return nil
 }
 
-func (r *Range) processRaftCommand(idKey cmdIDKey, raftCmd proto.InternalRaftCommand) error {
+func (r *Range) processRaftCommand(idKey cmdIDKey, index uint64,
+	raftCmd proto.InternalRaftCommand) error {
+	if index == 0 {
+		log.Fatal("processRaftCommand requires a non-zero index")
+	}
 	r.Lock()
 	cmd := r.pendingCmds[idKey]
 	delete(r.pendingCmds, idKey)
@@ -585,7 +593,7 @@ func (r *Range) processRaftCommand(idKey cmdIDKey, raftCmd proto.InternalRaftCom
 			log.Fatal(err)
 		}
 	}
-	err = r.executeCmd(method, args, reply)
+	err = r.executeCmd(index, method, args, reply)
 	if cmd != nil {
 		cmd.done <- err
 	} else if err != nil {
@@ -712,7 +720,8 @@ func (r *Range) maybeSplit() {
 // errors which should be classified as a ReplicaCorruptionError--when those
 // bubble up to the point where we've just tried to execute a Raft command, the
 // Raft replica would need to stall itself.
-func (r *Range) executeCmd(method string, args proto.Request, reply proto.Response) error {
+func (r *Range) executeCmd(index uint64, method string, args proto.Request,
+	reply proto.Response) error {
 	// Verify key is contained within range here to catch any range split
 	// or merge activity.
 	header := args.Header()
@@ -772,6 +781,19 @@ func (r *Range) executeCmd(method string, args proto.Request, reply proto.Respon
 		r.InternalTruncateLog(batch, &ms, args.(*proto.InternalTruncateLogRequest), reply.(*proto.InternalTruncateLogResponse))
 	default:
 		return util.Errorf("unrecognized command %q", method)
+	}
+
+	// If we are applying a raft command, update the applied index.
+	if reply.Header().GoError() == nil && index > 0 {
+		if r.appliedIndex >= index {
+			log.Fatalf("applied index moved backwards: %d >= %d", r.appliedIndex, index)
+		}
+		r.appliedIndex = index
+		err := engine.MVCCPut(batch, &ms, engine.RaftAppliedIndexKey(r.Desc().RaftID),
+			proto.ZeroTimestamp, proto.Value{Bytes: encoding.EncodeUint64(nil, index)}, nil)
+		if err != nil {
+			reply.Header().SetGoError(err)
+		}
 	}
 
 	// On success, flush the MVCC stats to the batch and commit.

--- a/storage/range_test.go
+++ b/storage/range_test.go
@@ -314,7 +314,7 @@ func TestRangeGossipConfigWithMultipleKeyPrefixes(t *testing.T) {
 	}
 	reply := &proto.PutResponse{}
 
-	if err := tc.rng.executeCmd(proto.Put, req, reply); err != nil {
+	if err := tc.rng.executeCmd(0, proto.Put, req, reply); err != nil {
 		t.Fatal(err)
 	}
 
@@ -355,7 +355,7 @@ func TestRangeGossipConfigUpdates(t *testing.T) {
 	}
 	reply := &proto.PutResponse{}
 
-	if err := tc.rng.executeCmd(proto.Put, req, reply); err != nil {
+	if err := tc.rng.executeCmd(0, proto.Put, req, reply); err != nil {
 		t.Fatal(err)
 	}
 
@@ -1663,7 +1663,7 @@ func TestConditionFailedError(t *testing.T) {
 	key := []byte("k")
 	value := []byte("quack")
 	pArgs, pReply := putArgs(key, value, 1, tc.store.StoreID())
-	if err := tc.rng.executeCmd(proto.Put, pArgs, pReply); err != nil {
+	if err := tc.rng.executeCmd(0, proto.Put, pArgs, pReply); err != nil {
 		t.Fatal(err)
 	}
 	args := &proto.ConditionalPutRequest{
@@ -1681,7 +1681,7 @@ func TestConditionFailedError(t *testing.T) {
 		},
 	}
 	reply := &proto.ConditionalPutResponse{}
-	err := tc.rng.executeCmd(proto.ConditionalPut, args, reply)
+	err := tc.rng.executeCmd(0, proto.ConditionalPut, args, reply)
 	if cErr, ok := err.(*proto.ConditionFailedError); err == nil || !ok {
 		t.Fatalf("expected ConditionFailedError, got %T with content %+v",
 			err, err)

--- a/storage/store.go
+++ b/storage/store.go
@@ -1010,12 +1010,14 @@ func (s *Store) processRaft() {
 			var cmd proto.InternalRaftCommand
 			var groupID int64
 			var commandID string
+			var index uint64
 			var callback func(error)
 
 			switch e := e.(type) {
 			case *multiraft.EventCommandCommitted:
 				groupID = int64(e.GroupID)
 				commandID = e.CommandID
+				index = e.Index
 				err := gogoproto.Unmarshal(e.Command, &cmd)
 				if err != nil {
 					log.Fatal(err)
@@ -1024,6 +1026,7 @@ func (s *Store) processRaft() {
 			case *multiraft.EventMembershipChangeCommitted:
 				groupID = int64(e.GroupID)
 				commandID = e.CommandID
+				index = e.Index
 				callback = e.Callback
 				err := gogoproto.Unmarshal(e.Payload, &cmd)
 				if err != nil {
@@ -1047,7 +1050,7 @@ func (s *Store) processRaft() {
 					groupID, cmd)
 				log.Error(err)
 			} else {
-				err = r.processRaftCommand(cmdIDKey(commandID), cmd)
+				err = r.processRaftCommand(cmdIDKey(commandID), index, cmd)
 			}
 			if callback != nil {
 				callback(err)


### PR DESCRIPTION
This will be used to synchronize a new replica with a snapshot.
