### PR TITLE
Fix a small parsing bug with Context.Attrs

### DIFF
--- a/server/cli/flags.go
+++ b/server/cli/flags.go
@@ -41,7 +41,7 @@ func InitFlags(ctx *server.Context) {
 		"attributes might also include speeds and other specs (7200rpm, 200kiops, etc.). "+
 		"For example, -store=hdd:7200rpm=/mnt/hda1,ssd=/mnt/ssd01,ssd=/mnt/ssd02,mem=1073741824")
 
-	flag.StringVar(&ctx.Attrs, "attrs", ctx.Attrs, "specify a comma-separated list of node "+
+	flag.StringVar(&ctx.Attrs, "attrs", ctx.Attrs, "specify a colon-separated list of node "+
 		"attributes. Attributes are arbitrary strings specifying topography or "+
 		"machine capabilities. Topography might include datacenter designation (e.g. "+
 		"\"us-west-1a\", \"us-west-1b\", \"us-east-1c\"). Machine capabilities "+

--- a/server/cli/start.go
+++ b/server/cli/start.go
@@ -63,7 +63,7 @@ A node exports an HTTP API with the following endpoints:
 var CmdInit = &commander.Command{
 	UsageLine: "init -gossip=host1:port1[,host2:port2...] " +
 		"-certs=<cert-dir> " +
-		"-stores=(ssd=<data-dir>,hdd|7200rpm=<data-dir>,mem=<capacity-in-bytes>)[,...]",
+		"-stores=(ssd=<data-dir>,hdd:7200rpm=<data-dir>,mem=<capacity-in-bytes>)[,...]",
 	Short: "init new Cockroach cluster and start server",
 	Long: `
 Initialize a new Cockroach cluster on this node using the first
@@ -119,7 +119,7 @@ func runInit(cmd *commander.Command, args []string) {
 var CmdStart = &commander.Command{
 	UsageLine: "start -gossip=host1:port1[,host2:port2...] " +
 		"-certs=<cert-dir> " +
-		"-stores=(ssd=<data-dir>,hdd|7200rpm=<data-dir>|mem=<capacity-in-bytes>)[,...]",
+		"-stores=(ssd=<data-dir>,hdd:7200rpm=<data-dir>|mem=<capacity-in-bytes>)[,...]",
 	Short: "start node by joining the gossip network",
 	Long:  cmdStartLongDescription,
 	Run:   runStart,

--- a/server/context.go
+++ b/server/context.go
@@ -68,8 +68,9 @@ type Context struct {
 	// For example, -store=hdd:7200rpm=/mnt/hda1,ssd=/mnt/ssd01,ssd=/mnt/ssd02,mem=1073741824
 	Stores string
 
-	// Attrs specifies node topography or machine capabilities, used to
-	// match capabilities or location preferences specified in zone configs.
+	// Attrs specifies a colon-separated list of node topography or machine
+	// capabilities, used to match capabilities or location preferences specified
+	// in zone configs.
 	Attrs string
 
 	// Maximum clock offset for the cluster.
@@ -166,7 +167,7 @@ func (ctx *Context) initEngine(attrsStr, path string) (engine.Engine, error) {
 }
 
 // parseAttributes parses a colon-separated list of strings,
-// filtering empty strings (i.e. ",," will yield no attributes.
+// filtering empty strings (i.e. "::" will yield no attributes.
 // Returns the list of strings as Attributes.
 func parseAttributes(attrsStr string) proto.Attributes {
 	var filtered []string

--- a/server/context_test.go
+++ b/server/context_test.go
@@ -1,0 +1,36 @@
+// Copyright 2015 The Cockroach Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+// implied. See the License for the specific language governing
+// permissions and limitations under the License. See the AUTHORS file
+// for names of contributors.
+//
+// Author: Kenji Kaneda (kenji.kaneda@gmail.com)
+
+package server
+
+import (
+	"reflect"
+	"testing"
+)
+
+func TestParseNodeAttributes(t *testing.T) {
+	ctx := NewContext()
+	ctx.Attrs = "attr1=val1::attr2=val2"
+	ctx.Stores = "mem=1"
+	if err := ctx.Init(); err != nil {
+		t.Fatalf("Failed to initialize the context: %v", err)
+	}
+	expected := []string{"attr1=val1", "attr2=val2"}
+	if !reflect.DeepEqual(ctx.NodeAttributes.GetAttrs(), expected) {
+		t.Fatalf("Unexpected attributes: %v", ctx.NodeAttributes.GetAttrs())
+	}
+}


### PR DESCRIPTION
It used ":" as a separator while a comment in flags.go says Attrs is a comma-separated list.
