### PR TITLE
Allow extra time for TestRangeSplitsWithWritePressure in race mode.

### DIFF
--- a/kv/split_test.go
+++ b/kv/split_test.go
@@ -176,7 +176,7 @@ func TestRangeSplitsWithWritePressure(t *testing.T) {
 			t.Fatalf("failed to scan meta2 keys: %s", err)
 		}
 		return len(resp.Rows) >= 5
-	}, 3*time.Second); err != nil {
+	}, 6*time.Second); err != nil {
 		t.Errorf("failed to split 5 times: %s", err)
 	}
 	close(done)


### PR DESCRIPTION
This test often runs over time, especially with the more verbose
logging added by #436.
