### PR TITLE
Update raft to latest upstream.

### DIFF
--- a/GLOCKFILE
+++ b/GLOCKFILE
@@ -15,7 +15,7 @@ github.com/biogo/store cb1ae010c5c75b7ce4f5c5d0ef92defcafdfdce4
 github.com/cockroachdb/c-protobuf 9e8dac59ca2a3fc82cd0665ad32b1a36f3df40b8
 github.com/cockroachdb/c-rocksdb 72de025ca13dd4ab2dce63e8e19c6a59b8388ffd
 github.com/cockroachdb/c-snappy af73b00e85e6f0e3c1fcc51f73f1d036df1e99ff
-github.com/coreos/etcd a2be25cba4bb74756890dcd21dd67c66decdfd77
+github.com/coreos/etcd ed81ccc1bbcdaa22b30a35d7e91271125844a9c5
 github.com/elazarl/go-bindata-assetfs 09ba9c6a7e9a5ee35586127fdf88bb20bb4990b7
 github.com/gogo/protobuf bc946d07d1016848dfd2507f90f0859c9471681e
 github.com/golang/glog 44145f04b68cf362d9c4df2182967c2275eaefed

--- a/multiraft/storage_test.go
+++ b/multiraft/storage_test.go
@@ -64,9 +64,9 @@ func (b *blockableGroupStorage) InitialState() (raftpb.HardState, raftpb.ConfSta
 	return b.s.InitialState()
 }
 
-func (b *blockableGroupStorage) Entries(lo, hi uint64) ([]raftpb.Entry, error) {
+func (b *blockableGroupStorage) Entries(lo, hi, maxBytes uint64) ([]raftpb.Entry, error) {
 	b.b.wait()
-	return b.s.Entries(lo, hi)
+	return b.s.Entries(lo, hi, maxBytes)
 }
 
 func (b *blockableGroupStorage) Term(i uint64) (uint64, error) {

--- a/storage/range_test.go
+++ b/storage/range_test.go
@@ -20,6 +20,7 @@ package storage
 import (
 	"bytes"
 	"fmt"
+	"math"
 	"reflect"
 	"regexp"
 	"sync"
@@ -1610,7 +1611,7 @@ func TestInternalTruncateLog(t *testing.T) {
 	}
 
 	// We can still get what remains of the log.
-	entries, err := tc.rng.Entries(indexes[5], indexes[9])
+	entries, err := tc.rng.Entries(indexes[5], indexes[9], math.MaxUint64)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -1619,7 +1620,7 @@ func TestInternalTruncateLog(t *testing.T) {
 	}
 
 	// But any range that includes the truncated entries returns an error.
-	_, err = tc.rng.Entries(indexes[4], indexes[9])
+	_, err = tc.rng.Entries(indexes[4], indexes[9], math.MaxUint64)
 	if err != raft.ErrUnavailable {
 		t.Errorf("expected ErrUnavailable, got %s", err)
 	}


### PR DESCRIPTION
Adapt to new maxBytes parameter to raft.Storage.Entries.

This includes a fix in MultiNode for restoring from a snapshot
with an empty log.
