### PR TITLE
A tiny cosmetic change: Move storesRE to context.go from server.go

### DIFF
--- a/server/context.go
+++ b/server/context.go
@@ -18,6 +18,7 @@
 package server
 
 import (
+	"regexp"
 	"sort"
 	"strconv"
 	"strings"
@@ -122,6 +123,7 @@ func NewContext() *Context {
 // Init interprets the stores parameter to initialize a slice of
 // engine.Engine objects and parses node attributes.
 func (ctx *Context) Init() error {
+	storesRE := regexp.MustCompile(`([^=]+)=([^,]+)(,|$)`)
 	// Error if regexp doesn't match.
 	storeSpecs := storesRE.FindAllStringSubmatch(ctx.Stores, -1)
 	if storeSpecs == nil || len(storeSpecs) == 0 {

--- a/server/server.go
+++ b/server/server.go
@@ -24,7 +24,6 @@ import (
 	"net"
 	"net/http"
 	"os"
-	"regexp"
 	"strings"
 	"sync"
 
@@ -41,13 +40,8 @@ import (
 	"github.com/elazarl/go-bindata-assetfs"
 )
 
-var (
-	// Regular expression for capturing data directory specifications.
-	storesRE = regexp.MustCompile(`([^=]+)=([^,]+)(,|$)`)
-
-	// Allocation pool for gzip writers.
-	gzipWriterPool sync.Pool
-)
+// Allocation pool for gzip writers.
+var gzipWriterPool sync.Pool
 
 // Server is the cockroach server node.
 type Server struct {
@@ -94,7 +88,6 @@ func NewServer(ctx *Context) (*Server, error) {
 	if ctx.Certs == "" {
 		tlsConfig = rpc.LoadInsecureTLSConfig()
 	} else {
-		var err error
 		if tlsConfig, err = rpc.LoadTLSConfigFromDir(ctx.Certs); err != nil {
 			return nil, util.Errorf("unable to load TLS config: %v", err)
 		}


### PR DESCRIPTION
The variable is only used in context.go.

Also removed an unnecessary variable definition of 'err' from NewServer().
