### PR TITLE
auto-open issues for failed tests

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -46,6 +46,19 @@ test:
     - mkdir -p ${CIRCLE_TEST_REPORTS}/{go,race}
     - "[ -f ${CIRCLE_ARTIFACTS}/test.log ] && docker run -i cockroachdb/cockroach-dev shell /go/bin/go2xunit < ${CIRCLE_ARTIFACTS}/test.log > ${CIRCLE_TEST_REPORTS}/go/test.xml"
     - "[ -f ${CIRCLE_ARTIFACTS}/testrace.log ] && docker run -i cockroachdb/cockroach-dev shell /go/bin/go2xunit < ${CIRCLE_ARTIFACTS}/testrace.log > ${CIRCLE_TEST_REPORTS}/race/testrace.xml"
+    - |
+      find "${CIRCLE_ARTIFACTS}" -name '*.log' -type f -exec \
+        grep -B 5 -A 10 -E '^\-{0,3} *FAIL|^panic|^[Gg]oroutine \d+|(read|write) by.*goroutine|DATA RACE' {} ';' \
+        > "${CIRCLE_ARTIFACTS}/excerpt.txt"
+    - |
+      if [ "${CIRCLE_BRANCH}" = "master" ] && [ -n "${GITHUB_API_TOKEN}" ] && [ -s "${CIRCLE_ARTIFACTS}/excerpt.txt" ]; then
+        curl -X POST -H "Authorization: token ${GITHUB_API_TOKEN}" \
+          "https://api.github.com/repos/${CIRCLE_PROJECT_USERNAME}/${CIRCLE_PROJECT_REPONAME}/issues" \
+          -d "{ \"title\": \"test failure #${CIRCLE_BUILD_NUM}\", \"body\": \"The following test appears to have failed:\n\n[#${CIRCLE_BUILD_NUM}](https://circleci.com/gh/${CIRCLE_PROJECT_USERNAME}/${CIRCLE_PROJECT_REPONAME}/${CIRCLE_BUILD_NUM}):\n\n\`\`\`\n$(sed -e 's/"/\\"/g' -e 's/$/\\n/' ${CIRCLE_ARTIFACTS}/excerpt.txt | tr -d '\n')\n\`\`\`\nPlease assign, take a look and update the issue accordingly.\", \"labels\": [\"test-failure\"] }"
+      else
+        echo "Not posting an issue."
+      fi
+
 
 deployment:
   docker:


### PR DESCRIPTION
this is a little experiment to make it easier to deal with test failures on the master branch.
using issues, it will be easier to assign to fixing a particular build.

unfortunately, CircleCI as of now has no way of checking via circle.yml what the test status is (unless we add a hack for each test, which is clumsy), so we grep the log files for interesting info and open issues whenever something that looks like a test failure is found.

until we set a GITHUB_API_TOKEN environment variable, this will not create issues. Once we do, the result will look something like this:

https://github.com/tschottdorf/cockroach/issues/11
