### PR TITLE
Disable the split queue in storage tests.

### DIFF
--- a/storage/gc_queue_test.go
+++ b/storage/gc_queue_test.go
@@ -304,14 +304,9 @@ func TestGCQueueLookupGCPolicy(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	// Setup test context and add new zone config map. This actually
-	// starts a split. However, because this store has a mock DB, which
-	// does not support splits, the splits will fail; they usually don't
-	// even get started before the test finishes. However, there may
-	// sometimes be failures in the log about the Batch method not being
-	// supported and the split failing; just ignore these.
-	// TODO(spencer): maybe should be a way to disable splits
-	// functionality for tests like this.
+	// Setup test context and add new zone config map. This would normally
+	// start a split, but splits are disabled in this testing configuration
+	// because the mock DB does not support splits.
 	tc := testContext{}
 	tc.Start(t)
 	defer tc.Stop()

--- a/storage/range_test.go
+++ b/storage/range_test.go
@@ -131,6 +131,8 @@ func (tc *testContext) Start(t *testing.T) {
 		if err := tc.store.Bootstrap(proto.StoreIdent{NodeID: 1, StoreID: 1}); err != nil {
 			t.Fatal(err)
 		}
+		// We created the store without a real KV client, so it can't perform splits.
+		tc.store.splitQueue.disabled = true
 
 		if tc.rng == nil && tc.bootstrapMode == bootstrapRangeWithMetadata {
 			if err := tc.store.BootstrapRange(); err != nil {

--- a/storage/split_queue.go
+++ b/storage/split_queue.go
@@ -41,6 +41,8 @@ type splitQueue struct {
 	*baseQueue
 	db     *client.KV
 	gossip *gossip.Gossip
+	// Some tests in this package disable the split queue.
+	disabled bool
 }
 
 // newSplitQueue returns a new instance of splitQueue.
@@ -59,7 +61,7 @@ func newSplitQueue(db *client.KV, gossip *gossip.Gossip) *splitQueue {
 // bytes exceeds the limit for the zone.
 func (sq *splitQueue) shouldQueue(now proto.Timestamp, rng *Range) (shouldQ bool, priority float64) {
 	// Only queue for Split if this replica is leader.
-	if !rng.IsLeader() {
+	if !rng.IsLeader() || sq.disabled {
 		return
 	}
 


### PR DESCRIPTION
Most storage tests do not run with a configuration in which splits can
succeed, which resulted in panics whenever a test ran long enough for
the split queue to attempt a split (especially in
TestGCQueueLookupGCPolicy, which sets the configuration in a way that
would normally call for a split).
