### PR TITLE
Send real snapshots when catching up a new node.

### DIFF
--- a/proto/internal.pb.go
+++ b/proto/internal.pb.go
@@ -868,39 +868,39 @@ func (m *RaftTruncatedState) GetTerm() uint64 {
 // RaftSnapshotData is the payload of a raftpb.Snapshot. It contains a raw copy of
 // all of the range's data and metadata, including the raft log, response cache, etc.
 type RaftSnapshotData struct {
-	KV               []*RaftSnapshotData_KV `protobuf:"group,1,rep,name=KV" json:"kv,omitempty"`
-	XXX_unrecognized []byte                 `json:"-"`
+	KV               []*RaftSnapshotData_KeyValue `protobuf:"bytes,1,rep" json:"KV,omitempty"`
+	XXX_unrecognized []byte                       `json:"-"`
 }
 
 func (m *RaftSnapshotData) Reset()         { *m = RaftSnapshotData{} }
 func (m *RaftSnapshotData) String() string { return proto1.CompactTextString(m) }
 func (*RaftSnapshotData) ProtoMessage()    {}
 
-func (m *RaftSnapshotData) GetKV() []*RaftSnapshotData_KV {
+func (m *RaftSnapshotData) GetKV() []*RaftSnapshotData_KeyValue {
 	if m != nil {
 		return m.KV
 	}
 	return nil
 }
 
-type RaftSnapshotData_KV struct {
-	Key              []byte `protobuf:"bytes,2,opt,name=key" json:"key,omitempty"`
-	Value            []byte `protobuf:"bytes,3,opt,name=value" json:"value,omitempty"`
+type RaftSnapshotData_KeyValue struct {
+	Key              []byte `protobuf:"bytes,1,opt,name=key" json:"key,omitempty"`
+	Value            []byte `protobuf:"bytes,2,opt,name=value" json:"value,omitempty"`
 	XXX_unrecognized []byte `json:"-"`
 }
 
-func (m *RaftSnapshotData_KV) Reset()         { *m = RaftSnapshotData_KV{} }
-func (m *RaftSnapshotData_KV) String() string { return proto1.CompactTextString(m) }
-func (*RaftSnapshotData_KV) ProtoMessage()    {}
+func (m *RaftSnapshotData_KeyValue) Reset()         { *m = RaftSnapshotData_KeyValue{} }
+func (m *RaftSnapshotData_KeyValue) String() string { return proto1.CompactTextString(m) }
+func (*RaftSnapshotData_KeyValue) ProtoMessage()    {}
 
-func (m *RaftSnapshotData_KV) GetKey() []byte {
+func (m *RaftSnapshotData_KeyValue) GetKey() []byte {
 	if m != nil {
 		return m.Key
 	}
 	return nil
 }
 
-func (m *RaftSnapshotData_KV) GetValue() []byte {
+func (m *RaftSnapshotData_KeyValue) GetValue() []byte {
 	if m != nil {
 		return m.Value
 	}

--- a/proto/internal.pb.go
+++ b/proto/internal.pb.go
@@ -865,6 +865,48 @@ func (m *RaftTruncatedState) GetTerm() uint64 {
 	return 0
 }
 
+// RaftSnapshotData is the payload of a raftpb.Snapshot. It contains a raw copy of
+// all of the range's data and metadata, including the raft log, response cache, etc.
+type RaftSnapshotData struct {
+	KV               []*RaftSnapshotData_KV `protobuf:"group,1,rep,name=KV" json:"kv,omitempty"`
+	XXX_unrecognized []byte                 `json:"-"`
+}
+
+func (m *RaftSnapshotData) Reset()         { *m = RaftSnapshotData{} }
+func (m *RaftSnapshotData) String() string { return proto1.CompactTextString(m) }
+func (*RaftSnapshotData) ProtoMessage()    {}
+
+func (m *RaftSnapshotData) GetKV() []*RaftSnapshotData_KV {
+	if m != nil {
+		return m.KV
+	}
+	return nil
+}
+
+type RaftSnapshotData_KV struct {
+	Key              []byte `protobuf:"bytes,2,opt,name=key" json:"key,omitempty"`
+	Value            []byte `protobuf:"bytes,3,opt,name=value" json:"value,omitempty"`
+	XXX_unrecognized []byte `json:"-"`
+}
+
+func (m *RaftSnapshotData_KV) Reset()         { *m = RaftSnapshotData_KV{} }
+func (m *RaftSnapshotData_KV) String() string { return proto1.CompactTextString(m) }
+func (*RaftSnapshotData_KV) ProtoMessage()    {}
+
+func (m *RaftSnapshotData_KV) GetKey() []byte {
+	if m != nil {
+		return m.Key
+	}
+	return nil
+}
+
+func (m *RaftSnapshotData_KV) GetValue() []byte {
+	if m != nil {
+		return m.Value
+	}
+	return nil
+}
+
 func init() {
 	proto1.RegisterEnum("cockroach.proto.InternalValueType", InternalValueType_name, InternalValueType_value)
 }

--- a/proto/internal.proto
+++ b/proto/internal.proto
@@ -328,8 +328,9 @@ message RaftTruncatedState {
 // RaftSnapshotData is the payload of a raftpb.Snapshot. It contains a raw copy of
 // all of the range's data and metadata, including the raft log, response cache, etc.
 message RaftSnapshotData {
-  repeated group KV = 1 [(gogoproto.customname) = "KV"]{
-    optional bytes key = 2;
-    optional bytes value = 3;
+  message KeyValue {
+    optional bytes key = 1;
+    optional bytes value = 2;
   }
+  repeated KeyValue KV = 1 [(gogoproto.customname) = "KV"];
 }

--- a/proto/internal.proto
+++ b/proto/internal.proto
@@ -324,3 +324,12 @@ message RaftTruncatedState {
   // The term corresponding to 'index'.
   optional uint64 term = 2 [(gogoproto.nullable) = false];
 }
+
+// RaftSnapshotData is the payload of a raftpb.Snapshot. It contains a raw copy of
+// all of the range's data and metadata, including the raft log, response cache, etc.
+message RaftSnapshotData {
+  repeated group KV = 1 [(gogoproto.customname) = "KV"]{
+    optional bytes key = 2;
+    optional bytes value = 3;
+  }
+}

--- a/storage/client_raft_test.go
+++ b/storage/client_raft_test.go
@@ -27,6 +27,7 @@ import (
 	"github.com/cockroachdb/cockroach/storage/engine"
 	"github.com/cockroachdb/cockroach/util"
 	"github.com/cockroachdb/cockroach/util/hlc"
+	"github.com/cockroachdb/cockroach/util/log"
 )
 
 // TestStoreRecoverFromEngine verifies that the store recovers all ranges and their contents
@@ -266,6 +267,82 @@ func TestFailedReplicaChange(t *testing.T) {
 			Attrs:   proto.Attributes{},
 		})
 	if err != nil {
+		t.Fatal(err)
+	}
+}
+
+// We can truncate the old log entries and a new replica will be brought up from a snapshot.
+func TestReplicateAfterTruncation(t *testing.T) {
+	mtc := multiTestContext{}
+	mtc.Start(t, 2)
+	defer mtc.Stop()
+
+	rng, err := mtc.stores[0].GetRange(1)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Issue a command on the first node before replicating.
+	incArgs, incResp := incrementArgs([]byte("a"), 5, 1, mtc.stores[0].StoreID())
+	if err := mtc.stores[0].ExecuteCmd(proto.Increment, incArgs, incResp); err != nil {
+		t.Fatal(err)
+	}
+
+	// Get that command's log index.
+	index, err := rng.LastIndex()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Truncate the log.
+	truncArgs, truncResp := internalTruncateLogArgs(index, 1, mtc.stores[0].StoreID())
+	if err := mtc.stores[0].ExecuteCmd(proto.InternalTruncateLog, truncArgs, truncResp); err != nil {
+		t.Fatal(err)
+	}
+
+	// Issue a second command post-truncation.
+	incArgs, incResp = incrementArgs([]byte("a"), 11, 1, mtc.stores[0].StoreID())
+	if err := mtc.stores[0].ExecuteCmd(proto.Increment, incArgs, incResp); err != nil {
+		t.Fatal(err)
+	}
+
+	// Now add the second replica.
+	if err := rng.ChangeReplicas(proto.ADD_REPLICA,
+		proto.Replica{
+			NodeID:  mtc.stores[1].Ident.NodeID,
+			StoreID: mtc.stores[1].Ident.StoreID,
+			Attrs:   proto.Attributes{},
+		}); err != nil {
+		t.Fatal(err)
+	}
+
+	// Once it catches up, the effects of both commands can be seen.
+	if err := util.IsTrueWithin(func() bool {
+		getArgs, getResp := getArgs([]byte("a"), 1, mtc.stores[1].StoreID())
+		if err := mtc.stores[1].ExecuteCmd(proto.Get, getArgs, getResp); err != nil {
+			return false
+		}
+		log.Infof("read value %d", getResp.Value.GetInteger())
+		return getResp.Value.GetInteger() == 16
+	}, 1*time.Second); err != nil {
+		t.Fatal(err)
+	}
+
+	// Send a third command to verify that the log states are synced up so the
+	// new node can accept new commands.
+	incArgs, incResp = incrementArgs([]byte("a"), 23, 1, mtc.stores[0].StoreID())
+	if err := mtc.stores[0].ExecuteCmd(proto.Increment, incArgs, incResp); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := util.IsTrueWithin(func() bool {
+		getArgs, getResp := getArgs([]byte("a"), 1, mtc.stores[1].StoreID())
+		if err := mtc.stores[1].ExecuteCmd(proto.Get, getArgs, getResp); err != nil {
+			return false
+		}
+		log.Infof("read value %d", getResp.Value.GetInteger())
+		return getResp.Value.GetInteger() == 39
+	}, 1*time.Second); err != nil {
 		t.Fatal(err)
 	}
 }

--- a/storage/client_raft_test.go
+++ b/storage/client_raft_test.go
@@ -294,8 +294,9 @@ func TestReplicateAfterTruncation(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	// Truncate the log.
-	truncArgs, truncResp := internalTruncateLogArgs(index, 1, mtc.stores[0].StoreID())
+	// Truncate the log at index+1 (log entries < N are removed, so this includes
+	// the increment).
+	truncArgs, truncResp := internalTruncateLogArgs(index+1, 1, mtc.stores[0].StoreID())
 	if err := mtc.stores[0].ExecuteCmd(proto.InternalTruncateLog, truncArgs, truncResp); err != nil {
 		t.Fatal(err)
 	}

--- a/storage/client_test.go
+++ b/storage/client_test.go
@@ -215,6 +215,19 @@ func incrementArgs(key []byte, inc int64, raftID int64, storeID proto.StoreID) (
 	return args, reply
 }
 
+func internalTruncateLogArgs(index uint64, raftID int64, storeID proto.StoreID) (
+	*proto.InternalTruncateLogRequest, *proto.InternalTruncateLogResponse) {
+	args := &proto.InternalTruncateLogRequest{
+		RequestHeader: proto.RequestHeader{
+			RaftID:  raftID,
+			Replica: proto.Replica{StoreID: storeID},
+		},
+		Index: index,
+	}
+	reply := &proto.InternalTruncateLogResponse{}
+	return args, reply
+}
+
 type metaRecord struct {
 	key  proto.Key
 	desc *proto.RangeDescriptor

--- a/storage/engine/cockroach/proto/internal.pb.cc
+++ b/storage/engine/cockroach/proto/internal.pb.cc
@@ -87,9 +87,9 @@ const ::google::protobuf::internal::GeneratedMessageReflection*
 const ::google::protobuf::Descriptor* RaftSnapshotData_descriptor_ = NULL;
 const ::google::protobuf::internal::GeneratedMessageReflection*
   RaftSnapshotData_reflection_ = NULL;
-const ::google::protobuf::Descriptor* RaftSnapshotData_KV_descriptor_ = NULL;
+const ::google::protobuf::Descriptor* RaftSnapshotData_KeyValue_descriptor_ = NULL;
 const ::google::protobuf::internal::GeneratedMessageReflection*
-  RaftSnapshotData_KV_reflection_ = NULL;
+  RaftSnapshotData_KeyValue_reflection_ = NULL;
 const ::google::protobuf::EnumDescriptor* InternalValueType_descriptor_ = NULL;
 
 }  // namespace
@@ -486,22 +486,22 @@ void protobuf_AssignDesc_cockroach_2fproto_2finternal_2eproto() {
       ::google::protobuf::DescriptorPool::generated_pool(),
       ::google::protobuf::MessageFactory::generated_factory(),
       sizeof(RaftSnapshotData));
-  RaftSnapshotData_KV_descriptor_ = RaftSnapshotData_descriptor_->nested_type(0);
-  static const int RaftSnapshotData_KV_offsets_[2] = {
-    GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(RaftSnapshotData_KV, key_),
-    GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(RaftSnapshotData_KV, value_),
+  RaftSnapshotData_KeyValue_descriptor_ = RaftSnapshotData_descriptor_->nested_type(0);
+  static const int RaftSnapshotData_KeyValue_offsets_[2] = {
+    GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(RaftSnapshotData_KeyValue, key_),
+    GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(RaftSnapshotData_KeyValue, value_),
   };
-  RaftSnapshotData_KV_reflection_ =
+  RaftSnapshotData_KeyValue_reflection_ =
     new ::google::protobuf::internal::GeneratedMessageReflection(
-      RaftSnapshotData_KV_descriptor_,
-      RaftSnapshotData_KV::default_instance_,
-      RaftSnapshotData_KV_offsets_,
-      GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(RaftSnapshotData_KV, _has_bits_[0]),
-      GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(RaftSnapshotData_KV, _unknown_fields_),
+      RaftSnapshotData_KeyValue_descriptor_,
+      RaftSnapshotData_KeyValue::default_instance_,
+      RaftSnapshotData_KeyValue_offsets_,
+      GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(RaftSnapshotData_KeyValue, _has_bits_[0]),
+      GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(RaftSnapshotData_KeyValue, _unknown_fields_),
       -1,
       ::google::protobuf::DescriptorPool::generated_pool(),
       ::google::protobuf::MessageFactory::generated_factory(),
-      sizeof(RaftSnapshotData_KV));
+      sizeof(RaftSnapshotData_KeyValue));
   InternalValueType_descriptor_ = file->enum_type(0);
 }
 
@@ -560,7 +560,7 @@ void protobuf_RegisterTypes(const ::std::string&) {
   ::google::protobuf::MessageFactory::InternalRegisterGeneratedMessage(
     RaftSnapshotData_descriptor_, &RaftSnapshotData::default_instance());
   ::google::protobuf::MessageFactory::InternalRegisterGeneratedMessage(
-    RaftSnapshotData_KV_descriptor_, &RaftSnapshotData_KV::default_instance());
+    RaftSnapshotData_KeyValue_descriptor_, &RaftSnapshotData_KeyValue::default_instance());
 }
 
 }  // namespace
@@ -610,8 +610,8 @@ void protobuf_ShutdownFile_cockroach_2fproto_2finternal_2eproto() {
   delete RaftTruncatedState_reflection_;
   delete RaftSnapshotData::default_instance_;
   delete RaftSnapshotData_reflection_;
-  delete RaftSnapshotData_KV::default_instance_;
-  delete RaftSnapshotData_KV_reflection_;
+  delete RaftSnapshotData_KeyValue::default_instance_;
+  delete RaftSnapshotData_KeyValue_reflection_;
 }
 
 void protobuf_AddDesc_cockroach_2fproto_2finternal_2eproto() {
@@ -741,10 +741,11 @@ void protobuf_AddDesc_cockroach_2fproto_2finternal_2eproto() {
     "\022\021\n\tfloat_sum\030\007 \001(\002\022\021\n\tfloat_max\030\010 \001(\002\022\021"
     "\n\tfloat_min\030\t \001(\002\"=\n\022RaftTruncatedState\022"
     "\023\n\005index\030\001 \001(\004B\004\310\336\037\000\022\022\n\004term\030\002 \001(\004B\004\310\336\037\000"
-    "\"n\n\020RaftSnapshotData\0228\n\002kv\030\001 \003(\n2$.cockr"
-    "oach.proto.RaftSnapshotData.KVB\006\342\336\037\002KV\032 "
-    "\n\002KV\022\013\n\003key\030\002 \001(\014\022\r\n\005value\030\003 \001(\014*%\n\021Inte"
-    "rnalValueType\022\n\n\006_CR_TS\020\001\032\004\210\243\036\000B\007Z\005proto", 4800);
+    "\"z\n\020RaftSnapshotData\022>\n\002KV\030\001 \003(\0132*.cockr"
+    "oach.proto.RaftSnapshotData.KeyValueB\006\342\336"
+    "\037\002KV\032&\n\010KeyValue\022\013\n\003key\030\001 \001(\014\022\r\n\005value\030\002"
+    " \001(\014*%\n\021InternalValueType\022\n\n\006_CR_TS\020\001\032\004\210"
+    "\243\036\000B\007Z\005proto", 4812);
   ::google::protobuf::MessageFactory::InternalRegisterGeneratedFile(
     "cockroach/proto/internal.proto", &protobuf_RegisterTypes);
   InternalRangeLookupRequest::default_instance_ = new InternalRangeLookupRequest();
@@ -769,7 +770,7 @@ void protobuf_AddDesc_cockroach_2fproto_2finternal_2eproto() {
   InternalTimeSeriesSample::default_instance_ = new InternalTimeSeriesSample();
   RaftTruncatedState::default_instance_ = new RaftTruncatedState();
   RaftSnapshotData::default_instance_ = new RaftSnapshotData();
-  RaftSnapshotData_KV::default_instance_ = new RaftSnapshotData_KV();
+  RaftSnapshotData_KeyValue::default_instance_ = new RaftSnapshotData_KeyValue();
   InternalRangeLookupRequest::default_instance_->InitAsDefaultInstance();
   InternalRangeLookupResponse::default_instance_->InitAsDefaultInstance();
   InternalHeartbeatTxnRequest::default_instance_->InitAsDefaultInstance();
@@ -792,7 +793,7 @@ void protobuf_AddDesc_cockroach_2fproto_2finternal_2eproto() {
   InternalTimeSeriesSample::default_instance_->InitAsDefaultInstance();
   RaftTruncatedState::default_instance_->InitAsDefaultInstance();
   RaftSnapshotData::default_instance_->InitAsDefaultInstance();
-  RaftSnapshotData_KV::default_instance_->InitAsDefaultInstance();
+  RaftSnapshotData_KeyValue::default_instance_->InitAsDefaultInstance();
   ::google::protobuf::internal::OnShutdown(&protobuf_ShutdownFile_cockroach_2fproto_2finternal_2eproto);
 }
 
@@ -7979,27 +7980,27 @@ void RaftTruncatedState::Swap(RaftTruncatedState* other) {
 // ===================================================================
 
 #ifndef _MSC_VER
-const int RaftSnapshotData_KV::kKeyFieldNumber;
-const int RaftSnapshotData_KV::kValueFieldNumber;
+const int RaftSnapshotData_KeyValue::kKeyFieldNumber;
+const int RaftSnapshotData_KeyValue::kValueFieldNumber;
 #endif  // !_MSC_VER
 
-RaftSnapshotData_KV::RaftSnapshotData_KV()
+RaftSnapshotData_KeyValue::RaftSnapshotData_KeyValue()
   : ::google::protobuf::Message() {
   SharedCtor();
-  // @@protoc_insertion_point(constructor:cockroach.proto.RaftSnapshotData.KV)
+  // @@protoc_insertion_point(constructor:cockroach.proto.RaftSnapshotData.KeyValue)
 }
 
-void RaftSnapshotData_KV::InitAsDefaultInstance() {
+void RaftSnapshotData_KeyValue::InitAsDefaultInstance() {
 }
 
-RaftSnapshotData_KV::RaftSnapshotData_KV(const RaftSnapshotData_KV& from)
+RaftSnapshotData_KeyValue::RaftSnapshotData_KeyValue(const RaftSnapshotData_KeyValue& from)
   : ::google::protobuf::Message() {
   SharedCtor();
   MergeFrom(from);
-  // @@protoc_insertion_point(copy_constructor:cockroach.proto.RaftSnapshotData.KV)
+  // @@protoc_insertion_point(copy_constructor:cockroach.proto.RaftSnapshotData.KeyValue)
 }
 
-void RaftSnapshotData_KV::SharedCtor() {
+void RaftSnapshotData_KeyValue::SharedCtor() {
   ::google::protobuf::internal::GetEmptyString();
   _cached_size_ = 0;
   key_ = const_cast< ::std::string*>(&::google::protobuf::internal::GetEmptyStringAlreadyInited());
@@ -8007,12 +8008,12 @@ void RaftSnapshotData_KV::SharedCtor() {
   ::memset(_has_bits_, 0, sizeof(_has_bits_));
 }
 
-RaftSnapshotData_KV::~RaftSnapshotData_KV() {
-  // @@protoc_insertion_point(destructor:cockroach.proto.RaftSnapshotData.KV)
+RaftSnapshotData_KeyValue::~RaftSnapshotData_KeyValue() {
+  // @@protoc_insertion_point(destructor:cockroach.proto.RaftSnapshotData.KeyValue)
   SharedDtor();
 }
 
-void RaftSnapshotData_KV::SharedDtor() {
+void RaftSnapshotData_KeyValue::SharedDtor() {
   if (key_ != &::google::protobuf::internal::GetEmptyStringAlreadyInited()) {
     delete key_;
   }
@@ -8023,28 +8024,28 @@ void RaftSnapshotData_KV::SharedDtor() {
   }
 }
 
-void RaftSnapshotData_KV::SetCachedSize(int size) const {
+void RaftSnapshotData_KeyValue::SetCachedSize(int size) const {
   GOOGLE_SAFE_CONCURRENT_WRITES_BEGIN();
   _cached_size_ = size;
   GOOGLE_SAFE_CONCURRENT_WRITES_END();
 }
-const ::google::protobuf::Descriptor* RaftSnapshotData_KV::descriptor() {
+const ::google::protobuf::Descriptor* RaftSnapshotData_KeyValue::descriptor() {
   protobuf_AssignDescriptorsOnce();
-  return RaftSnapshotData_KV_descriptor_;
+  return RaftSnapshotData_KeyValue_descriptor_;
 }
 
-const RaftSnapshotData_KV& RaftSnapshotData_KV::default_instance() {
+const RaftSnapshotData_KeyValue& RaftSnapshotData_KeyValue::default_instance() {
   if (default_instance_ == NULL) protobuf_AddDesc_cockroach_2fproto_2finternal_2eproto();
   return *default_instance_;
 }
 
-RaftSnapshotData_KV* RaftSnapshotData_KV::default_instance_ = NULL;
+RaftSnapshotData_KeyValue* RaftSnapshotData_KeyValue::default_instance_ = NULL;
 
-RaftSnapshotData_KV* RaftSnapshotData_KV::New() const {
-  return new RaftSnapshotData_KV;
+RaftSnapshotData_KeyValue* RaftSnapshotData_KeyValue::New() const {
+  return new RaftSnapshotData_KeyValue;
 }
 
-void RaftSnapshotData_KV::Clear() {
+void RaftSnapshotData_KeyValue::Clear() {
   if (_has_bits_[0 / 32] & 3) {
     if (has_key()) {
       if (key_ != &::google::protobuf::internal::GetEmptyStringAlreadyInited()) {
@@ -8061,31 +8062,31 @@ void RaftSnapshotData_KV::Clear() {
   mutable_unknown_fields()->Clear();
 }
 
-bool RaftSnapshotData_KV::MergePartialFromCodedStream(
+bool RaftSnapshotData_KeyValue::MergePartialFromCodedStream(
     ::google::protobuf::io::CodedInputStream* input) {
 #define DO_(EXPRESSION) if (!(EXPRESSION)) goto failure
   ::google::protobuf::uint32 tag;
-  // @@protoc_insertion_point(parse_start:cockroach.proto.RaftSnapshotData.KV)
+  // @@protoc_insertion_point(parse_start:cockroach.proto.RaftSnapshotData.KeyValue)
   for (;;) {
     ::std::pair< ::google::protobuf::uint32, bool> p = input->ReadTagWithCutoff(127);
     tag = p.first;
     if (!p.second) goto handle_unusual;
     switch (::google::protobuf::internal::WireFormatLite::GetTagFieldNumber(tag)) {
-      // optional bytes key = 2;
-      case 2: {
-        if (tag == 18) {
+      // optional bytes key = 1;
+      case 1: {
+        if (tag == 10) {
           DO_(::google::protobuf::internal::WireFormatLite::ReadBytes(
                 input, this->mutable_key()));
         } else {
           goto handle_unusual;
         }
-        if (input->ExpectTag(26)) goto parse_value;
+        if (input->ExpectTag(18)) goto parse_value;
         break;
       }
 
-      // optional bytes value = 3;
-      case 3: {
-        if (tag == 26) {
+      // optional bytes value = 2;
+      case 2: {
+        if (tag == 18) {
          parse_value:
           DO_(::google::protobuf::internal::WireFormatLite::ReadBytes(
                 input, this->mutable_value()));
@@ -8110,73 +8111,73 @@ bool RaftSnapshotData_KV::MergePartialFromCodedStream(
     }
   }
 success:
-  // @@protoc_insertion_point(parse_success:cockroach.proto.RaftSnapshotData.KV)
+  // @@protoc_insertion_point(parse_success:cockroach.proto.RaftSnapshotData.KeyValue)
   return true;
 failure:
-  // @@protoc_insertion_point(parse_failure:cockroach.proto.RaftSnapshotData.KV)
+  // @@protoc_insertion_point(parse_failure:cockroach.proto.RaftSnapshotData.KeyValue)
   return false;
 #undef DO_
 }
 
-void RaftSnapshotData_KV::SerializeWithCachedSizes(
+void RaftSnapshotData_KeyValue::SerializeWithCachedSizes(
     ::google::protobuf::io::CodedOutputStream* output) const {
-  // @@protoc_insertion_point(serialize_start:cockroach.proto.RaftSnapshotData.KV)
-  // optional bytes key = 2;
+  // @@protoc_insertion_point(serialize_start:cockroach.proto.RaftSnapshotData.KeyValue)
+  // optional bytes key = 1;
   if (has_key()) {
     ::google::protobuf::internal::WireFormatLite::WriteBytesMaybeAliased(
-      2, this->key(), output);
+      1, this->key(), output);
   }
 
-  // optional bytes value = 3;
+  // optional bytes value = 2;
   if (has_value()) {
     ::google::protobuf::internal::WireFormatLite::WriteBytesMaybeAliased(
-      3, this->value(), output);
+      2, this->value(), output);
   }
 
   if (!unknown_fields().empty()) {
     ::google::protobuf::internal::WireFormat::SerializeUnknownFields(
         unknown_fields(), output);
   }
-  // @@protoc_insertion_point(serialize_end:cockroach.proto.RaftSnapshotData.KV)
+  // @@protoc_insertion_point(serialize_end:cockroach.proto.RaftSnapshotData.KeyValue)
 }
 
-::google::protobuf::uint8* RaftSnapshotData_KV::SerializeWithCachedSizesToArray(
+::google::protobuf::uint8* RaftSnapshotData_KeyValue::SerializeWithCachedSizesToArray(
     ::google::protobuf::uint8* target) const {
-  // @@protoc_insertion_point(serialize_to_array_start:cockroach.proto.RaftSnapshotData.KV)
-  // optional bytes key = 2;
+  // @@protoc_insertion_point(serialize_to_array_start:cockroach.proto.RaftSnapshotData.KeyValue)
+  // optional bytes key = 1;
   if (has_key()) {
     target =
       ::google::protobuf::internal::WireFormatLite::WriteBytesToArray(
-        2, this->key(), target);
+        1, this->key(), target);
   }
 
-  // optional bytes value = 3;
+  // optional bytes value = 2;
   if (has_value()) {
     target =
       ::google::protobuf::internal::WireFormatLite::WriteBytesToArray(
-        3, this->value(), target);
+        2, this->value(), target);
   }
 
   if (!unknown_fields().empty()) {
     target = ::google::protobuf::internal::WireFormat::SerializeUnknownFieldsToArray(
         unknown_fields(), target);
   }
-  // @@protoc_insertion_point(serialize_to_array_end:cockroach.proto.RaftSnapshotData.KV)
+  // @@protoc_insertion_point(serialize_to_array_end:cockroach.proto.RaftSnapshotData.KeyValue)
   return target;
 }
 
-int RaftSnapshotData_KV::ByteSize() const {
+int RaftSnapshotData_KeyValue::ByteSize() const {
   int total_size = 0;
 
   if (_has_bits_[0 / 32] & (0xffu << (0 % 32))) {
-    // optional bytes key = 2;
+    // optional bytes key = 1;
     if (has_key()) {
       total_size += 1 +
         ::google::protobuf::internal::WireFormatLite::BytesSize(
           this->key());
     }
 
-    // optional bytes value = 3;
+    // optional bytes value = 2;
     if (has_value()) {
       total_size += 1 +
         ::google::protobuf::internal::WireFormatLite::BytesSize(
@@ -8195,10 +8196,10 @@ int RaftSnapshotData_KV::ByteSize() const {
   return total_size;
 }
 
-void RaftSnapshotData_KV::MergeFrom(const ::google::protobuf::Message& from) {
+void RaftSnapshotData_KeyValue::MergeFrom(const ::google::protobuf::Message& from) {
   GOOGLE_CHECK_NE(&from, this);
-  const RaftSnapshotData_KV* source =
-    ::google::protobuf::internal::dynamic_cast_if_available<const RaftSnapshotData_KV*>(
+  const RaftSnapshotData_KeyValue* source =
+    ::google::protobuf::internal::dynamic_cast_if_available<const RaftSnapshotData_KeyValue*>(
       &from);
   if (source == NULL) {
     ::google::protobuf::internal::ReflectionOps::Merge(from, this);
@@ -8207,7 +8208,7 @@ void RaftSnapshotData_KV::MergeFrom(const ::google::protobuf::Message& from) {
   }
 }
 
-void RaftSnapshotData_KV::MergeFrom(const RaftSnapshotData_KV& from) {
+void RaftSnapshotData_KeyValue::MergeFrom(const RaftSnapshotData_KeyValue& from) {
   GOOGLE_CHECK_NE(&from, this);
   if (from._has_bits_[0 / 32] & (0xffu << (0 % 32))) {
     if (from.has_key()) {
@@ -8220,24 +8221,24 @@ void RaftSnapshotData_KV::MergeFrom(const RaftSnapshotData_KV& from) {
   mutable_unknown_fields()->MergeFrom(from.unknown_fields());
 }
 
-void RaftSnapshotData_KV::CopyFrom(const ::google::protobuf::Message& from) {
+void RaftSnapshotData_KeyValue::CopyFrom(const ::google::protobuf::Message& from) {
   if (&from == this) return;
   Clear();
   MergeFrom(from);
 }
 
-void RaftSnapshotData_KV::CopyFrom(const RaftSnapshotData_KV& from) {
+void RaftSnapshotData_KeyValue::CopyFrom(const RaftSnapshotData_KeyValue& from) {
   if (&from == this) return;
   Clear();
   MergeFrom(from);
 }
 
-bool RaftSnapshotData_KV::IsInitialized() const {
+bool RaftSnapshotData_KeyValue::IsInitialized() const {
 
   return true;
 }
 
-void RaftSnapshotData_KV::Swap(RaftSnapshotData_KV* other) {
+void RaftSnapshotData_KeyValue::Swap(RaftSnapshotData_KeyValue* other) {
   if (other != this) {
     std::swap(key_, other->key_);
     std::swap(value_, other->value_);
@@ -8247,11 +8248,11 @@ void RaftSnapshotData_KV::Swap(RaftSnapshotData_KV* other) {
   }
 }
 
-::google::protobuf::Metadata RaftSnapshotData_KV::GetMetadata() const {
+::google::protobuf::Metadata RaftSnapshotData_KeyValue::GetMetadata() const {
   protobuf_AssignDescriptorsOnce();
   ::google::protobuf::Metadata metadata;
-  metadata.descriptor = RaftSnapshotData_KV_descriptor_;
-  metadata.reflection = RaftSnapshotData_KV_reflection_;
+  metadata.descriptor = RaftSnapshotData_KeyValue_descriptor_;
+  metadata.reflection = RaftSnapshotData_KeyValue_reflection_;
   return metadata;
 }
 
@@ -8259,7 +8260,7 @@ void RaftSnapshotData_KV::Swap(RaftSnapshotData_KV* other) {
 // -------------------------------------------------------------------
 
 #ifndef _MSC_VER
-const int RaftSnapshotData::kKvFieldNumber;
+const int RaftSnapshotData::kKVFieldNumber;
 #endif  // !_MSC_VER
 
 RaftSnapshotData::RaftSnapshotData()
@@ -8330,16 +8331,16 @@ bool RaftSnapshotData::MergePartialFromCodedStream(
     tag = p.first;
     if (!p.second) goto handle_unusual;
     switch (::google::protobuf::internal::WireFormatLite::GetTagFieldNumber(tag)) {
-      // repeated group KV = 1 {
+      // repeated .cockroach.proto.RaftSnapshotData.KeyValue KV = 1;
       case 1: {
-        if (tag == 11) {
-         parse_kv:
-          DO_(::google::protobuf::internal::WireFormatLite::ReadGroupNoVirtual(
-                1, input, add_kv()));
+        if (tag == 10) {
+         parse_KV:
+          DO_(::google::protobuf::internal::WireFormatLite::ReadMessageNoVirtual(
+                input, add_kv()));
         } else {
           goto handle_unusual;
         }
-        if (input->ExpectTag(11)) goto parse_kv;
+        if (input->ExpectTag(10)) goto parse_KV;
         if (input->ExpectAtEnd()) goto success;
         break;
       }
@@ -8369,9 +8370,9 @@ failure:
 void RaftSnapshotData::SerializeWithCachedSizes(
     ::google::protobuf::io::CodedOutputStream* output) const {
   // @@protoc_insertion_point(serialize_start:cockroach.proto.RaftSnapshotData)
-  // repeated group KV = 1 {
+  // repeated .cockroach.proto.RaftSnapshotData.KeyValue KV = 1;
   for (int i = 0; i < this->kv_size(); i++) {
-    ::google::protobuf::internal::WireFormatLite::WriteGroupMaybeToArray(
+    ::google::protobuf::internal::WireFormatLite::WriteMessageMaybeToArray(
       1, this->kv(i), output);
   }
 
@@ -8385,10 +8386,10 @@ void RaftSnapshotData::SerializeWithCachedSizes(
 ::google::protobuf::uint8* RaftSnapshotData::SerializeWithCachedSizesToArray(
     ::google::protobuf::uint8* target) const {
   // @@protoc_insertion_point(serialize_to_array_start:cockroach.proto.RaftSnapshotData)
-  // repeated group KV = 1 {
+  // repeated .cockroach.proto.RaftSnapshotData.KeyValue KV = 1;
   for (int i = 0; i < this->kv_size(); i++) {
     target = ::google::protobuf::internal::WireFormatLite::
-      WriteGroupNoVirtualToArray(
+      WriteMessageNoVirtualToArray(
         1, this->kv(i), target);
   }
 
@@ -8403,11 +8404,11 @@ void RaftSnapshotData::SerializeWithCachedSizes(
 int RaftSnapshotData::ByteSize() const {
   int total_size = 0;
 
-  // repeated group KV = 1 {
-  total_size += 2 * this->kv_size();
+  // repeated .cockroach.proto.RaftSnapshotData.KeyValue KV = 1;
+  total_size += 1 * this->kv_size();
   for (int i = 0; i < this->kv_size(); i++) {
     total_size +=
-      ::google::protobuf::internal::WireFormatLite::GroupSizeNoVirtual(
+      ::google::protobuf::internal::WireFormatLite::MessageSizeNoVirtual(
         this->kv(i));
   }
 

--- a/storage/engine/cockroach/proto/internal.pb.cc
+++ b/storage/engine/cockroach/proto/internal.pb.cc
@@ -84,6 +84,12 @@ const ::google::protobuf::internal::GeneratedMessageReflection*
 const ::google::protobuf::Descriptor* RaftTruncatedState_descriptor_ = NULL;
 const ::google::protobuf::internal::GeneratedMessageReflection*
   RaftTruncatedState_reflection_ = NULL;
+const ::google::protobuf::Descriptor* RaftSnapshotData_descriptor_ = NULL;
+const ::google::protobuf::internal::GeneratedMessageReflection*
+  RaftSnapshotData_reflection_ = NULL;
+const ::google::protobuf::Descriptor* RaftSnapshotData_KV_descriptor_ = NULL;
+const ::google::protobuf::internal::GeneratedMessageReflection*
+  RaftSnapshotData_KV_reflection_ = NULL;
 const ::google::protobuf::EnumDescriptor* InternalValueType_descriptor_ = NULL;
 
 }  // namespace
@@ -465,6 +471,37 @@ void protobuf_AssignDesc_cockroach_2fproto_2finternal_2eproto() {
       ::google::protobuf::DescriptorPool::generated_pool(),
       ::google::protobuf::MessageFactory::generated_factory(),
       sizeof(RaftTruncatedState));
+  RaftSnapshotData_descriptor_ = file->message_type(20);
+  static const int RaftSnapshotData_offsets_[1] = {
+    GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(RaftSnapshotData, kv_),
+  };
+  RaftSnapshotData_reflection_ =
+    new ::google::protobuf::internal::GeneratedMessageReflection(
+      RaftSnapshotData_descriptor_,
+      RaftSnapshotData::default_instance_,
+      RaftSnapshotData_offsets_,
+      GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(RaftSnapshotData, _has_bits_[0]),
+      GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(RaftSnapshotData, _unknown_fields_),
+      -1,
+      ::google::protobuf::DescriptorPool::generated_pool(),
+      ::google::protobuf::MessageFactory::generated_factory(),
+      sizeof(RaftSnapshotData));
+  RaftSnapshotData_KV_descriptor_ = RaftSnapshotData_descriptor_->nested_type(0);
+  static const int RaftSnapshotData_KV_offsets_[2] = {
+    GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(RaftSnapshotData_KV, key_),
+    GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(RaftSnapshotData_KV, value_),
+  };
+  RaftSnapshotData_KV_reflection_ =
+    new ::google::protobuf::internal::GeneratedMessageReflection(
+      RaftSnapshotData_KV_descriptor_,
+      RaftSnapshotData_KV::default_instance_,
+      RaftSnapshotData_KV_offsets_,
+      GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(RaftSnapshotData_KV, _has_bits_[0]),
+      GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(RaftSnapshotData_KV, _unknown_fields_),
+      -1,
+      ::google::protobuf::DescriptorPool::generated_pool(),
+      ::google::protobuf::MessageFactory::generated_factory(),
+      sizeof(RaftSnapshotData_KV));
   InternalValueType_descriptor_ = file->enum_type(0);
 }
 
@@ -520,6 +557,10 @@ void protobuf_RegisterTypes(const ::std::string&) {
     InternalTimeSeriesSample_descriptor_, &InternalTimeSeriesSample::default_instance());
   ::google::protobuf::MessageFactory::InternalRegisterGeneratedMessage(
     RaftTruncatedState_descriptor_, &RaftTruncatedState::default_instance());
+  ::google::protobuf::MessageFactory::InternalRegisterGeneratedMessage(
+    RaftSnapshotData_descriptor_, &RaftSnapshotData::default_instance());
+  ::google::protobuf::MessageFactory::InternalRegisterGeneratedMessage(
+    RaftSnapshotData_KV_descriptor_, &RaftSnapshotData_KV::default_instance());
 }
 
 }  // namespace
@@ -567,6 +608,10 @@ void protobuf_ShutdownFile_cockroach_2fproto_2finternal_2eproto() {
   delete InternalTimeSeriesSample_reflection_;
   delete RaftTruncatedState::default_instance_;
   delete RaftTruncatedState_reflection_;
+  delete RaftSnapshotData::default_instance_;
+  delete RaftSnapshotData_reflection_;
+  delete RaftSnapshotData_KV::default_instance_;
+  delete RaftSnapshotData_KV_reflection_;
 }
 
 void protobuf_AddDesc_cockroach_2fproto_2finternal_2eproto() {
@@ -696,8 +741,10 @@ void protobuf_AddDesc_cockroach_2fproto_2finternal_2eproto() {
     "\022\021\n\tfloat_sum\030\007 \001(\002\022\021\n\tfloat_max\030\010 \001(\002\022\021"
     "\n\tfloat_min\030\t \001(\002\"=\n\022RaftTruncatedState\022"
     "\023\n\005index\030\001 \001(\004B\004\310\336\037\000\022\022\n\004term\030\002 \001(\004B\004\310\336\037\000"
-    "*%\n\021InternalValueType\022\n\n\006_CR_TS\020\001\032\004\210\243\036\000B"
-    "\007Z\005proto", 4688);
+    "\"n\n\020RaftSnapshotData\0228\n\002kv\030\001 \003(\n2$.cockr"
+    "oach.proto.RaftSnapshotData.KVB\006\342\336\037\002KV\032 "
+    "\n\002KV\022\013\n\003key\030\002 \001(\014\022\r\n\005value\030\003 \001(\014*%\n\021Inte"
+    "rnalValueType\022\n\n\006_CR_TS\020\001\032\004\210\243\036\000B\007Z\005proto", 4800);
   ::google::protobuf::MessageFactory::InternalRegisterGeneratedFile(
     "cockroach/proto/internal.proto", &protobuf_RegisterTypes);
   InternalRangeLookupRequest::default_instance_ = new InternalRangeLookupRequest();
@@ -721,6 +768,8 @@ void protobuf_AddDesc_cockroach_2fproto_2finternal_2eproto() {
   InternalTimeSeriesData::default_instance_ = new InternalTimeSeriesData();
   InternalTimeSeriesSample::default_instance_ = new InternalTimeSeriesSample();
   RaftTruncatedState::default_instance_ = new RaftTruncatedState();
+  RaftSnapshotData::default_instance_ = new RaftSnapshotData();
+  RaftSnapshotData_KV::default_instance_ = new RaftSnapshotData_KV();
   InternalRangeLookupRequest::default_instance_->InitAsDefaultInstance();
   InternalRangeLookupResponse::default_instance_->InitAsDefaultInstance();
   InternalHeartbeatTxnRequest::default_instance_->InitAsDefaultInstance();
@@ -742,6 +791,8 @@ void protobuf_AddDesc_cockroach_2fproto_2finternal_2eproto() {
   InternalTimeSeriesData::default_instance_->InitAsDefaultInstance();
   InternalTimeSeriesSample::default_instance_->InitAsDefaultInstance();
   RaftTruncatedState::default_instance_->InitAsDefaultInstance();
+  RaftSnapshotData::default_instance_->InitAsDefaultInstance();
+  RaftSnapshotData_KV::default_instance_->InitAsDefaultInstance();
   ::google::protobuf::internal::OnShutdown(&protobuf_ShutdownFile_cockroach_2fproto_2finternal_2eproto);
 }
 
@@ -7921,6 +7972,505 @@ void RaftTruncatedState::Swap(RaftTruncatedState* other) {
   ::google::protobuf::Metadata metadata;
   metadata.descriptor = RaftTruncatedState_descriptor_;
   metadata.reflection = RaftTruncatedState_reflection_;
+  return metadata;
+}
+
+
+// ===================================================================
+
+#ifndef _MSC_VER
+const int RaftSnapshotData_KV::kKeyFieldNumber;
+const int RaftSnapshotData_KV::kValueFieldNumber;
+#endif  // !_MSC_VER
+
+RaftSnapshotData_KV::RaftSnapshotData_KV()
+  : ::google::protobuf::Message() {
+  SharedCtor();
+  // @@protoc_insertion_point(constructor:cockroach.proto.RaftSnapshotData.KV)
+}
+
+void RaftSnapshotData_KV::InitAsDefaultInstance() {
+}
+
+RaftSnapshotData_KV::RaftSnapshotData_KV(const RaftSnapshotData_KV& from)
+  : ::google::protobuf::Message() {
+  SharedCtor();
+  MergeFrom(from);
+  // @@protoc_insertion_point(copy_constructor:cockroach.proto.RaftSnapshotData.KV)
+}
+
+void RaftSnapshotData_KV::SharedCtor() {
+  ::google::protobuf::internal::GetEmptyString();
+  _cached_size_ = 0;
+  key_ = const_cast< ::std::string*>(&::google::protobuf::internal::GetEmptyStringAlreadyInited());
+  value_ = const_cast< ::std::string*>(&::google::protobuf::internal::GetEmptyStringAlreadyInited());
+  ::memset(_has_bits_, 0, sizeof(_has_bits_));
+}
+
+RaftSnapshotData_KV::~RaftSnapshotData_KV() {
+  // @@protoc_insertion_point(destructor:cockroach.proto.RaftSnapshotData.KV)
+  SharedDtor();
+}
+
+void RaftSnapshotData_KV::SharedDtor() {
+  if (key_ != &::google::protobuf::internal::GetEmptyStringAlreadyInited()) {
+    delete key_;
+  }
+  if (value_ != &::google::protobuf::internal::GetEmptyStringAlreadyInited()) {
+    delete value_;
+  }
+  if (this != default_instance_) {
+  }
+}
+
+void RaftSnapshotData_KV::SetCachedSize(int size) const {
+  GOOGLE_SAFE_CONCURRENT_WRITES_BEGIN();
+  _cached_size_ = size;
+  GOOGLE_SAFE_CONCURRENT_WRITES_END();
+}
+const ::google::protobuf::Descriptor* RaftSnapshotData_KV::descriptor() {
+  protobuf_AssignDescriptorsOnce();
+  return RaftSnapshotData_KV_descriptor_;
+}
+
+const RaftSnapshotData_KV& RaftSnapshotData_KV::default_instance() {
+  if (default_instance_ == NULL) protobuf_AddDesc_cockroach_2fproto_2finternal_2eproto();
+  return *default_instance_;
+}
+
+RaftSnapshotData_KV* RaftSnapshotData_KV::default_instance_ = NULL;
+
+RaftSnapshotData_KV* RaftSnapshotData_KV::New() const {
+  return new RaftSnapshotData_KV;
+}
+
+void RaftSnapshotData_KV::Clear() {
+  if (_has_bits_[0 / 32] & 3) {
+    if (has_key()) {
+      if (key_ != &::google::protobuf::internal::GetEmptyStringAlreadyInited()) {
+        key_->clear();
+      }
+    }
+    if (has_value()) {
+      if (value_ != &::google::protobuf::internal::GetEmptyStringAlreadyInited()) {
+        value_->clear();
+      }
+    }
+  }
+  ::memset(_has_bits_, 0, sizeof(_has_bits_));
+  mutable_unknown_fields()->Clear();
+}
+
+bool RaftSnapshotData_KV::MergePartialFromCodedStream(
+    ::google::protobuf::io::CodedInputStream* input) {
+#define DO_(EXPRESSION) if (!(EXPRESSION)) goto failure
+  ::google::protobuf::uint32 tag;
+  // @@protoc_insertion_point(parse_start:cockroach.proto.RaftSnapshotData.KV)
+  for (;;) {
+    ::std::pair< ::google::protobuf::uint32, bool> p = input->ReadTagWithCutoff(127);
+    tag = p.first;
+    if (!p.second) goto handle_unusual;
+    switch (::google::protobuf::internal::WireFormatLite::GetTagFieldNumber(tag)) {
+      // optional bytes key = 2;
+      case 2: {
+        if (tag == 18) {
+          DO_(::google::protobuf::internal::WireFormatLite::ReadBytes(
+                input, this->mutable_key()));
+        } else {
+          goto handle_unusual;
+        }
+        if (input->ExpectTag(26)) goto parse_value;
+        break;
+      }
+
+      // optional bytes value = 3;
+      case 3: {
+        if (tag == 26) {
+         parse_value:
+          DO_(::google::protobuf::internal::WireFormatLite::ReadBytes(
+                input, this->mutable_value()));
+        } else {
+          goto handle_unusual;
+        }
+        if (input->ExpectAtEnd()) goto success;
+        break;
+      }
+
+      default: {
+      handle_unusual:
+        if (tag == 0 ||
+            ::google::protobuf::internal::WireFormatLite::GetTagWireType(tag) ==
+            ::google::protobuf::internal::WireFormatLite::WIRETYPE_END_GROUP) {
+          goto success;
+        }
+        DO_(::google::protobuf::internal::WireFormat::SkipField(
+              input, tag, mutable_unknown_fields()));
+        break;
+      }
+    }
+  }
+success:
+  // @@protoc_insertion_point(parse_success:cockroach.proto.RaftSnapshotData.KV)
+  return true;
+failure:
+  // @@protoc_insertion_point(parse_failure:cockroach.proto.RaftSnapshotData.KV)
+  return false;
+#undef DO_
+}
+
+void RaftSnapshotData_KV::SerializeWithCachedSizes(
+    ::google::protobuf::io::CodedOutputStream* output) const {
+  // @@protoc_insertion_point(serialize_start:cockroach.proto.RaftSnapshotData.KV)
+  // optional bytes key = 2;
+  if (has_key()) {
+    ::google::protobuf::internal::WireFormatLite::WriteBytesMaybeAliased(
+      2, this->key(), output);
+  }
+
+  // optional bytes value = 3;
+  if (has_value()) {
+    ::google::protobuf::internal::WireFormatLite::WriteBytesMaybeAliased(
+      3, this->value(), output);
+  }
+
+  if (!unknown_fields().empty()) {
+    ::google::protobuf::internal::WireFormat::SerializeUnknownFields(
+        unknown_fields(), output);
+  }
+  // @@protoc_insertion_point(serialize_end:cockroach.proto.RaftSnapshotData.KV)
+}
+
+::google::protobuf::uint8* RaftSnapshotData_KV::SerializeWithCachedSizesToArray(
+    ::google::protobuf::uint8* target) const {
+  // @@protoc_insertion_point(serialize_to_array_start:cockroach.proto.RaftSnapshotData.KV)
+  // optional bytes key = 2;
+  if (has_key()) {
+    target =
+      ::google::protobuf::internal::WireFormatLite::WriteBytesToArray(
+        2, this->key(), target);
+  }
+
+  // optional bytes value = 3;
+  if (has_value()) {
+    target =
+      ::google::protobuf::internal::WireFormatLite::WriteBytesToArray(
+        3, this->value(), target);
+  }
+
+  if (!unknown_fields().empty()) {
+    target = ::google::protobuf::internal::WireFormat::SerializeUnknownFieldsToArray(
+        unknown_fields(), target);
+  }
+  // @@protoc_insertion_point(serialize_to_array_end:cockroach.proto.RaftSnapshotData.KV)
+  return target;
+}
+
+int RaftSnapshotData_KV::ByteSize() const {
+  int total_size = 0;
+
+  if (_has_bits_[0 / 32] & (0xffu << (0 % 32))) {
+    // optional bytes key = 2;
+    if (has_key()) {
+      total_size += 1 +
+        ::google::protobuf::internal::WireFormatLite::BytesSize(
+          this->key());
+    }
+
+    // optional bytes value = 3;
+    if (has_value()) {
+      total_size += 1 +
+        ::google::protobuf::internal::WireFormatLite::BytesSize(
+          this->value());
+    }
+
+  }
+  if (!unknown_fields().empty()) {
+    total_size +=
+      ::google::protobuf::internal::WireFormat::ComputeUnknownFieldsSize(
+        unknown_fields());
+  }
+  GOOGLE_SAFE_CONCURRENT_WRITES_BEGIN();
+  _cached_size_ = total_size;
+  GOOGLE_SAFE_CONCURRENT_WRITES_END();
+  return total_size;
+}
+
+void RaftSnapshotData_KV::MergeFrom(const ::google::protobuf::Message& from) {
+  GOOGLE_CHECK_NE(&from, this);
+  const RaftSnapshotData_KV* source =
+    ::google::protobuf::internal::dynamic_cast_if_available<const RaftSnapshotData_KV*>(
+      &from);
+  if (source == NULL) {
+    ::google::protobuf::internal::ReflectionOps::Merge(from, this);
+  } else {
+    MergeFrom(*source);
+  }
+}
+
+void RaftSnapshotData_KV::MergeFrom(const RaftSnapshotData_KV& from) {
+  GOOGLE_CHECK_NE(&from, this);
+  if (from._has_bits_[0 / 32] & (0xffu << (0 % 32))) {
+    if (from.has_key()) {
+      set_key(from.key());
+    }
+    if (from.has_value()) {
+      set_value(from.value());
+    }
+  }
+  mutable_unknown_fields()->MergeFrom(from.unknown_fields());
+}
+
+void RaftSnapshotData_KV::CopyFrom(const ::google::protobuf::Message& from) {
+  if (&from == this) return;
+  Clear();
+  MergeFrom(from);
+}
+
+void RaftSnapshotData_KV::CopyFrom(const RaftSnapshotData_KV& from) {
+  if (&from == this) return;
+  Clear();
+  MergeFrom(from);
+}
+
+bool RaftSnapshotData_KV::IsInitialized() const {
+
+  return true;
+}
+
+void RaftSnapshotData_KV::Swap(RaftSnapshotData_KV* other) {
+  if (other != this) {
+    std::swap(key_, other->key_);
+    std::swap(value_, other->value_);
+    std::swap(_has_bits_[0], other->_has_bits_[0]);
+    _unknown_fields_.Swap(&other->_unknown_fields_);
+    std::swap(_cached_size_, other->_cached_size_);
+  }
+}
+
+::google::protobuf::Metadata RaftSnapshotData_KV::GetMetadata() const {
+  protobuf_AssignDescriptorsOnce();
+  ::google::protobuf::Metadata metadata;
+  metadata.descriptor = RaftSnapshotData_KV_descriptor_;
+  metadata.reflection = RaftSnapshotData_KV_reflection_;
+  return metadata;
+}
+
+
+// -------------------------------------------------------------------
+
+#ifndef _MSC_VER
+const int RaftSnapshotData::kKvFieldNumber;
+#endif  // !_MSC_VER
+
+RaftSnapshotData::RaftSnapshotData()
+  : ::google::protobuf::Message() {
+  SharedCtor();
+  // @@protoc_insertion_point(constructor:cockroach.proto.RaftSnapshotData)
+}
+
+void RaftSnapshotData::InitAsDefaultInstance() {
+}
+
+RaftSnapshotData::RaftSnapshotData(const RaftSnapshotData& from)
+  : ::google::protobuf::Message() {
+  SharedCtor();
+  MergeFrom(from);
+  // @@protoc_insertion_point(copy_constructor:cockroach.proto.RaftSnapshotData)
+}
+
+void RaftSnapshotData::SharedCtor() {
+  _cached_size_ = 0;
+  ::memset(_has_bits_, 0, sizeof(_has_bits_));
+}
+
+RaftSnapshotData::~RaftSnapshotData() {
+  // @@protoc_insertion_point(destructor:cockroach.proto.RaftSnapshotData)
+  SharedDtor();
+}
+
+void RaftSnapshotData::SharedDtor() {
+  if (this != default_instance_) {
+  }
+}
+
+void RaftSnapshotData::SetCachedSize(int size) const {
+  GOOGLE_SAFE_CONCURRENT_WRITES_BEGIN();
+  _cached_size_ = size;
+  GOOGLE_SAFE_CONCURRENT_WRITES_END();
+}
+const ::google::protobuf::Descriptor* RaftSnapshotData::descriptor() {
+  protobuf_AssignDescriptorsOnce();
+  return RaftSnapshotData_descriptor_;
+}
+
+const RaftSnapshotData& RaftSnapshotData::default_instance() {
+  if (default_instance_ == NULL) protobuf_AddDesc_cockroach_2fproto_2finternal_2eproto();
+  return *default_instance_;
+}
+
+RaftSnapshotData* RaftSnapshotData::default_instance_ = NULL;
+
+RaftSnapshotData* RaftSnapshotData::New() const {
+  return new RaftSnapshotData;
+}
+
+void RaftSnapshotData::Clear() {
+  kv_.Clear();
+  ::memset(_has_bits_, 0, sizeof(_has_bits_));
+  mutable_unknown_fields()->Clear();
+}
+
+bool RaftSnapshotData::MergePartialFromCodedStream(
+    ::google::protobuf::io::CodedInputStream* input) {
+#define DO_(EXPRESSION) if (!(EXPRESSION)) goto failure
+  ::google::protobuf::uint32 tag;
+  // @@protoc_insertion_point(parse_start:cockroach.proto.RaftSnapshotData)
+  for (;;) {
+    ::std::pair< ::google::protobuf::uint32, bool> p = input->ReadTagWithCutoff(127);
+    tag = p.first;
+    if (!p.second) goto handle_unusual;
+    switch (::google::protobuf::internal::WireFormatLite::GetTagFieldNumber(tag)) {
+      // repeated group KV = 1 {
+      case 1: {
+        if (tag == 11) {
+         parse_kv:
+          DO_(::google::protobuf::internal::WireFormatLite::ReadGroupNoVirtual(
+                1, input, add_kv()));
+        } else {
+          goto handle_unusual;
+        }
+        if (input->ExpectTag(11)) goto parse_kv;
+        if (input->ExpectAtEnd()) goto success;
+        break;
+      }
+
+      default: {
+      handle_unusual:
+        if (tag == 0 ||
+            ::google::protobuf::internal::WireFormatLite::GetTagWireType(tag) ==
+            ::google::protobuf::internal::WireFormatLite::WIRETYPE_END_GROUP) {
+          goto success;
+        }
+        DO_(::google::protobuf::internal::WireFormat::SkipField(
+              input, tag, mutable_unknown_fields()));
+        break;
+      }
+    }
+  }
+success:
+  // @@protoc_insertion_point(parse_success:cockroach.proto.RaftSnapshotData)
+  return true;
+failure:
+  // @@protoc_insertion_point(parse_failure:cockroach.proto.RaftSnapshotData)
+  return false;
+#undef DO_
+}
+
+void RaftSnapshotData::SerializeWithCachedSizes(
+    ::google::protobuf::io::CodedOutputStream* output) const {
+  // @@protoc_insertion_point(serialize_start:cockroach.proto.RaftSnapshotData)
+  // repeated group KV = 1 {
+  for (int i = 0; i < this->kv_size(); i++) {
+    ::google::protobuf::internal::WireFormatLite::WriteGroupMaybeToArray(
+      1, this->kv(i), output);
+  }
+
+  if (!unknown_fields().empty()) {
+    ::google::protobuf::internal::WireFormat::SerializeUnknownFields(
+        unknown_fields(), output);
+  }
+  // @@protoc_insertion_point(serialize_end:cockroach.proto.RaftSnapshotData)
+}
+
+::google::protobuf::uint8* RaftSnapshotData::SerializeWithCachedSizesToArray(
+    ::google::protobuf::uint8* target) const {
+  // @@protoc_insertion_point(serialize_to_array_start:cockroach.proto.RaftSnapshotData)
+  // repeated group KV = 1 {
+  for (int i = 0; i < this->kv_size(); i++) {
+    target = ::google::protobuf::internal::WireFormatLite::
+      WriteGroupNoVirtualToArray(
+        1, this->kv(i), target);
+  }
+
+  if (!unknown_fields().empty()) {
+    target = ::google::protobuf::internal::WireFormat::SerializeUnknownFieldsToArray(
+        unknown_fields(), target);
+  }
+  // @@protoc_insertion_point(serialize_to_array_end:cockroach.proto.RaftSnapshotData)
+  return target;
+}
+
+int RaftSnapshotData::ByteSize() const {
+  int total_size = 0;
+
+  // repeated group KV = 1 {
+  total_size += 2 * this->kv_size();
+  for (int i = 0; i < this->kv_size(); i++) {
+    total_size +=
+      ::google::protobuf::internal::WireFormatLite::GroupSizeNoVirtual(
+        this->kv(i));
+  }
+
+  if (!unknown_fields().empty()) {
+    total_size +=
+      ::google::protobuf::internal::WireFormat::ComputeUnknownFieldsSize(
+        unknown_fields());
+  }
+  GOOGLE_SAFE_CONCURRENT_WRITES_BEGIN();
+  _cached_size_ = total_size;
+  GOOGLE_SAFE_CONCURRENT_WRITES_END();
+  return total_size;
+}
+
+void RaftSnapshotData::MergeFrom(const ::google::protobuf::Message& from) {
+  GOOGLE_CHECK_NE(&from, this);
+  const RaftSnapshotData* source =
+    ::google::protobuf::internal::dynamic_cast_if_available<const RaftSnapshotData*>(
+      &from);
+  if (source == NULL) {
+    ::google::protobuf::internal::ReflectionOps::Merge(from, this);
+  } else {
+    MergeFrom(*source);
+  }
+}
+
+void RaftSnapshotData::MergeFrom(const RaftSnapshotData& from) {
+  GOOGLE_CHECK_NE(&from, this);
+  kv_.MergeFrom(from.kv_);
+  mutable_unknown_fields()->MergeFrom(from.unknown_fields());
+}
+
+void RaftSnapshotData::CopyFrom(const ::google::protobuf::Message& from) {
+  if (&from == this) return;
+  Clear();
+  MergeFrom(from);
+}
+
+void RaftSnapshotData::CopyFrom(const RaftSnapshotData& from) {
+  if (&from == this) return;
+  Clear();
+  MergeFrom(from);
+}
+
+bool RaftSnapshotData::IsInitialized() const {
+
+  return true;
+}
+
+void RaftSnapshotData::Swap(RaftSnapshotData* other) {
+  if (other != this) {
+    kv_.Swap(&other->kv_);
+    std::swap(_has_bits_[0], other->_has_bits_[0]);
+    _unknown_fields_.Swap(&other->_unknown_fields_);
+    std::swap(_cached_size_, other->_cached_size_);
+  }
+}
+
+::google::protobuf::Metadata RaftSnapshotData::GetMetadata() const {
+  protobuf_AssignDescriptorsOnce();
+  ::google::protobuf::Metadata metadata;
+  metadata.descriptor = RaftSnapshotData_descriptor_;
+  metadata.reflection = RaftSnapshotData_reflection_;
   return metadata;
 }
 

--- a/storage/engine/cockroach/proto/internal.pb.h
+++ b/storage/engine/cockroach/proto/internal.pb.h
@@ -61,7 +61,7 @@ class InternalTimeSeriesData;
 class InternalTimeSeriesSample;
 class RaftTruncatedState;
 class RaftSnapshotData;
-class RaftSnapshotData_KV;
+class RaftSnapshotData_KeyValue;
 
 enum InternalValueType {
   _CR_TS = 1
@@ -2418,14 +2418,14 @@ class RaftTruncatedState : public ::google::protobuf::Message {
 };
 // -------------------------------------------------------------------
 
-class RaftSnapshotData_KV : public ::google::protobuf::Message {
+class RaftSnapshotData_KeyValue : public ::google::protobuf::Message {
  public:
-  RaftSnapshotData_KV();
-  virtual ~RaftSnapshotData_KV();
+  RaftSnapshotData_KeyValue();
+  virtual ~RaftSnapshotData_KeyValue();
 
-  RaftSnapshotData_KV(const RaftSnapshotData_KV& from);
+  RaftSnapshotData_KeyValue(const RaftSnapshotData_KeyValue& from);
 
-  inline RaftSnapshotData_KV& operator=(const RaftSnapshotData_KV& from) {
+  inline RaftSnapshotData_KeyValue& operator=(const RaftSnapshotData_KeyValue& from) {
     CopyFrom(from);
     return *this;
   }
@@ -2439,17 +2439,17 @@ class RaftSnapshotData_KV : public ::google::protobuf::Message {
   }
 
   static const ::google::protobuf::Descriptor* descriptor();
-  static const RaftSnapshotData_KV& default_instance();
+  static const RaftSnapshotData_KeyValue& default_instance();
 
-  void Swap(RaftSnapshotData_KV* other);
+  void Swap(RaftSnapshotData_KeyValue* other);
 
   // implements Message ----------------------------------------------
 
-  RaftSnapshotData_KV* New() const;
+  RaftSnapshotData_KeyValue* New() const;
   void CopyFrom(const ::google::protobuf::Message& from);
   void MergeFrom(const ::google::protobuf::Message& from);
-  void CopyFrom(const RaftSnapshotData_KV& from);
-  void MergeFrom(const RaftSnapshotData_KV& from);
+  void CopyFrom(const RaftSnapshotData_KeyValue& from);
+  void MergeFrom(const RaftSnapshotData_KeyValue& from);
   void Clear();
   bool IsInitialized() const;
 
@@ -2471,10 +2471,10 @@ class RaftSnapshotData_KV : public ::google::protobuf::Message {
 
   // accessors -------------------------------------------------------
 
-  // optional bytes key = 2;
+  // optional bytes key = 1;
   inline bool has_key() const;
   inline void clear_key();
-  static const int kKeyFieldNumber = 2;
+  static const int kKeyFieldNumber = 1;
   inline const ::std::string& key() const;
   inline void set_key(const ::std::string& value);
   inline void set_key(const char* value);
@@ -2483,10 +2483,10 @@ class RaftSnapshotData_KV : public ::google::protobuf::Message {
   inline ::std::string* release_key();
   inline void set_allocated_key(::std::string* key);
 
-  // optional bytes value = 3;
+  // optional bytes value = 2;
   inline bool has_value() const;
   inline void clear_value();
-  static const int kValueFieldNumber = 3;
+  static const int kValueFieldNumber = 2;
   inline const ::std::string& value() const;
   inline void set_value(const ::std::string& value);
   inline void set_value(const char* value);
@@ -2495,7 +2495,7 @@ class RaftSnapshotData_KV : public ::google::protobuf::Message {
   inline ::std::string* release_value();
   inline void set_allocated_value(::std::string* value);
 
-  // @@protoc_insertion_point(class_scope:cockroach.proto.RaftSnapshotData.KV)
+  // @@protoc_insertion_point(class_scope:cockroach.proto.RaftSnapshotData.KeyValue)
  private:
   inline void set_has_key();
   inline void clear_has_key();
@@ -2513,7 +2513,7 @@ class RaftSnapshotData_KV : public ::google::protobuf::Message {
   friend void protobuf_ShutdownFile_cockroach_2fproto_2finternal_2eproto();
 
   void InitAsDefaultInstance();
-  static RaftSnapshotData_KV* default_instance_;
+  static RaftSnapshotData_KeyValue* default_instance_;
 };
 // -------------------------------------------------------------------
 
@@ -2568,20 +2568,20 @@ class RaftSnapshotData : public ::google::protobuf::Message {
 
   // nested types ----------------------------------------------------
 
-  typedef RaftSnapshotData_KV KV;
+  typedef RaftSnapshotData_KeyValue KeyValue;
 
   // accessors -------------------------------------------------------
 
-  // repeated group KV = 1 {
+  // repeated .cockroach.proto.RaftSnapshotData.KeyValue KV = 1;
   inline int kv_size() const;
   inline void clear_kv();
-  static const int kKvFieldNumber = 1;
-  inline const ::cockroach::proto::RaftSnapshotData_KV& kv(int index) const;
-  inline ::cockroach::proto::RaftSnapshotData_KV* mutable_kv(int index);
-  inline ::cockroach::proto::RaftSnapshotData_KV* add_kv();
-  inline const ::google::protobuf::RepeatedPtrField< ::cockroach::proto::RaftSnapshotData_KV >&
+  static const int kKVFieldNumber = 1;
+  inline const ::cockroach::proto::RaftSnapshotData_KeyValue& kv(int index) const;
+  inline ::cockroach::proto::RaftSnapshotData_KeyValue* mutable_kv(int index);
+  inline ::cockroach::proto::RaftSnapshotData_KeyValue* add_kv();
+  inline const ::google::protobuf::RepeatedPtrField< ::cockroach::proto::RaftSnapshotData_KeyValue >&
       kv() const;
-  inline ::google::protobuf::RepeatedPtrField< ::cockroach::proto::RaftSnapshotData_KV >*
+  inline ::google::protobuf::RepeatedPtrField< ::cockroach::proto::RaftSnapshotData_KeyValue >*
       mutable_kv();
 
   // @@protoc_insertion_point(class_scope:cockroach.proto.RaftSnapshotData)
@@ -2591,7 +2591,7 @@ class RaftSnapshotData : public ::google::protobuf::Message {
 
   ::google::protobuf::uint32 _has_bits_[1];
   mutable int _cached_size_;
-  ::google::protobuf::RepeatedPtrField< ::cockroach::proto::RaftSnapshotData_KV > kv_;
+  ::google::protobuf::RepeatedPtrField< ::cockroach::proto::RaftSnapshotData_KeyValue > kv_;
   friend void  protobuf_AddDesc_cockroach_2fproto_2finternal_2eproto();
   friend void protobuf_AssignDesc_cockroach_2fproto_2finternal_2eproto();
   friend void protobuf_ShutdownFile_cockroach_2fproto_2finternal_2eproto();
@@ -5517,61 +5517,61 @@ inline void RaftTruncatedState::set_term(::google::protobuf::uint64 value) {
 
 // -------------------------------------------------------------------
 
-// RaftSnapshotData_KV
+// RaftSnapshotData_KeyValue
 
-// optional bytes key = 2;
-inline bool RaftSnapshotData_KV::has_key() const {
+// optional bytes key = 1;
+inline bool RaftSnapshotData_KeyValue::has_key() const {
   return (_has_bits_[0] & 0x00000001u) != 0;
 }
-inline void RaftSnapshotData_KV::set_has_key() {
+inline void RaftSnapshotData_KeyValue::set_has_key() {
   _has_bits_[0] |= 0x00000001u;
 }
-inline void RaftSnapshotData_KV::clear_has_key() {
+inline void RaftSnapshotData_KeyValue::clear_has_key() {
   _has_bits_[0] &= ~0x00000001u;
 }
-inline void RaftSnapshotData_KV::clear_key() {
+inline void RaftSnapshotData_KeyValue::clear_key() {
   if (key_ != &::google::protobuf::internal::GetEmptyStringAlreadyInited()) {
     key_->clear();
   }
   clear_has_key();
 }
-inline const ::std::string& RaftSnapshotData_KV::key() const {
-  // @@protoc_insertion_point(field_get:cockroach.proto.RaftSnapshotData.KV.key)
+inline const ::std::string& RaftSnapshotData_KeyValue::key() const {
+  // @@protoc_insertion_point(field_get:cockroach.proto.RaftSnapshotData.KeyValue.key)
   return *key_;
 }
-inline void RaftSnapshotData_KV::set_key(const ::std::string& value) {
+inline void RaftSnapshotData_KeyValue::set_key(const ::std::string& value) {
   set_has_key();
   if (key_ == &::google::protobuf::internal::GetEmptyStringAlreadyInited()) {
     key_ = new ::std::string;
   }
   key_->assign(value);
-  // @@protoc_insertion_point(field_set:cockroach.proto.RaftSnapshotData.KV.key)
+  // @@protoc_insertion_point(field_set:cockroach.proto.RaftSnapshotData.KeyValue.key)
 }
-inline void RaftSnapshotData_KV::set_key(const char* value) {
+inline void RaftSnapshotData_KeyValue::set_key(const char* value) {
   set_has_key();
   if (key_ == &::google::protobuf::internal::GetEmptyStringAlreadyInited()) {
     key_ = new ::std::string;
   }
   key_->assign(value);
-  // @@protoc_insertion_point(field_set_char:cockroach.proto.RaftSnapshotData.KV.key)
+  // @@protoc_insertion_point(field_set_char:cockroach.proto.RaftSnapshotData.KeyValue.key)
 }
-inline void RaftSnapshotData_KV::set_key(const void* value, size_t size) {
+inline void RaftSnapshotData_KeyValue::set_key(const void* value, size_t size) {
   set_has_key();
   if (key_ == &::google::protobuf::internal::GetEmptyStringAlreadyInited()) {
     key_ = new ::std::string;
   }
   key_->assign(reinterpret_cast<const char*>(value), size);
-  // @@protoc_insertion_point(field_set_pointer:cockroach.proto.RaftSnapshotData.KV.key)
+  // @@protoc_insertion_point(field_set_pointer:cockroach.proto.RaftSnapshotData.KeyValue.key)
 }
-inline ::std::string* RaftSnapshotData_KV::mutable_key() {
+inline ::std::string* RaftSnapshotData_KeyValue::mutable_key() {
   set_has_key();
   if (key_ == &::google::protobuf::internal::GetEmptyStringAlreadyInited()) {
     key_ = new ::std::string;
   }
-  // @@protoc_insertion_point(field_mutable:cockroach.proto.RaftSnapshotData.KV.key)
+  // @@protoc_insertion_point(field_mutable:cockroach.proto.RaftSnapshotData.KeyValue.key)
   return key_;
 }
-inline ::std::string* RaftSnapshotData_KV::release_key() {
+inline ::std::string* RaftSnapshotData_KeyValue::release_key() {
   clear_has_key();
   if (key_ == &::google::protobuf::internal::GetEmptyStringAlreadyInited()) {
     return NULL;
@@ -5581,7 +5581,7 @@ inline ::std::string* RaftSnapshotData_KV::release_key() {
     return temp;
   }
 }
-inline void RaftSnapshotData_KV::set_allocated_key(::std::string* key) {
+inline void RaftSnapshotData_KeyValue::set_allocated_key(::std::string* key) {
   if (key_ != &::google::protobuf::internal::GetEmptyStringAlreadyInited()) {
     delete key_;
   }
@@ -5592,62 +5592,62 @@ inline void RaftSnapshotData_KV::set_allocated_key(::std::string* key) {
     clear_has_key();
     key_ = const_cast< ::std::string*>(&::google::protobuf::internal::GetEmptyStringAlreadyInited());
   }
-  // @@protoc_insertion_point(field_set_allocated:cockroach.proto.RaftSnapshotData.KV.key)
+  // @@protoc_insertion_point(field_set_allocated:cockroach.proto.RaftSnapshotData.KeyValue.key)
 }
 
-// optional bytes value = 3;
-inline bool RaftSnapshotData_KV::has_value() const {
+// optional bytes value = 2;
+inline bool RaftSnapshotData_KeyValue::has_value() const {
   return (_has_bits_[0] & 0x00000002u) != 0;
 }
-inline void RaftSnapshotData_KV::set_has_value() {
+inline void RaftSnapshotData_KeyValue::set_has_value() {
   _has_bits_[0] |= 0x00000002u;
 }
-inline void RaftSnapshotData_KV::clear_has_value() {
+inline void RaftSnapshotData_KeyValue::clear_has_value() {
   _has_bits_[0] &= ~0x00000002u;
 }
-inline void RaftSnapshotData_KV::clear_value() {
+inline void RaftSnapshotData_KeyValue::clear_value() {
   if (value_ != &::google::protobuf::internal::GetEmptyStringAlreadyInited()) {
     value_->clear();
   }
   clear_has_value();
 }
-inline const ::std::string& RaftSnapshotData_KV::value() const {
-  // @@protoc_insertion_point(field_get:cockroach.proto.RaftSnapshotData.KV.value)
+inline const ::std::string& RaftSnapshotData_KeyValue::value() const {
+  // @@protoc_insertion_point(field_get:cockroach.proto.RaftSnapshotData.KeyValue.value)
   return *value_;
 }
-inline void RaftSnapshotData_KV::set_value(const ::std::string& value) {
+inline void RaftSnapshotData_KeyValue::set_value(const ::std::string& value) {
   set_has_value();
   if (value_ == &::google::protobuf::internal::GetEmptyStringAlreadyInited()) {
     value_ = new ::std::string;
   }
   value_->assign(value);
-  // @@protoc_insertion_point(field_set:cockroach.proto.RaftSnapshotData.KV.value)
+  // @@protoc_insertion_point(field_set:cockroach.proto.RaftSnapshotData.KeyValue.value)
 }
-inline void RaftSnapshotData_KV::set_value(const char* value) {
+inline void RaftSnapshotData_KeyValue::set_value(const char* value) {
   set_has_value();
   if (value_ == &::google::protobuf::internal::GetEmptyStringAlreadyInited()) {
     value_ = new ::std::string;
   }
   value_->assign(value);
-  // @@protoc_insertion_point(field_set_char:cockroach.proto.RaftSnapshotData.KV.value)
+  // @@protoc_insertion_point(field_set_char:cockroach.proto.RaftSnapshotData.KeyValue.value)
 }
-inline void RaftSnapshotData_KV::set_value(const void* value, size_t size) {
+inline void RaftSnapshotData_KeyValue::set_value(const void* value, size_t size) {
   set_has_value();
   if (value_ == &::google::protobuf::internal::GetEmptyStringAlreadyInited()) {
     value_ = new ::std::string;
   }
   value_->assign(reinterpret_cast<const char*>(value), size);
-  // @@protoc_insertion_point(field_set_pointer:cockroach.proto.RaftSnapshotData.KV.value)
+  // @@protoc_insertion_point(field_set_pointer:cockroach.proto.RaftSnapshotData.KeyValue.value)
 }
-inline ::std::string* RaftSnapshotData_KV::mutable_value() {
+inline ::std::string* RaftSnapshotData_KeyValue::mutable_value() {
   set_has_value();
   if (value_ == &::google::protobuf::internal::GetEmptyStringAlreadyInited()) {
     value_ = new ::std::string;
   }
-  // @@protoc_insertion_point(field_mutable:cockroach.proto.RaftSnapshotData.KV.value)
+  // @@protoc_insertion_point(field_mutable:cockroach.proto.RaftSnapshotData.KeyValue.value)
   return value_;
 }
-inline ::std::string* RaftSnapshotData_KV::release_value() {
+inline ::std::string* RaftSnapshotData_KeyValue::release_value() {
   clear_has_value();
   if (value_ == &::google::protobuf::internal::GetEmptyStringAlreadyInited()) {
     return NULL;
@@ -5657,7 +5657,7 @@ inline ::std::string* RaftSnapshotData_KV::release_value() {
     return temp;
   }
 }
-inline void RaftSnapshotData_KV::set_allocated_value(::std::string* value) {
+inline void RaftSnapshotData_KeyValue::set_allocated_value(::std::string* value) {
   if (value_ != &::google::protobuf::internal::GetEmptyStringAlreadyInited()) {
     delete value_;
   }
@@ -5668,40 +5668,40 @@ inline void RaftSnapshotData_KV::set_allocated_value(::std::string* value) {
     clear_has_value();
     value_ = const_cast< ::std::string*>(&::google::protobuf::internal::GetEmptyStringAlreadyInited());
   }
-  // @@protoc_insertion_point(field_set_allocated:cockroach.proto.RaftSnapshotData.KV.value)
+  // @@protoc_insertion_point(field_set_allocated:cockroach.proto.RaftSnapshotData.KeyValue.value)
 }
 
 // -------------------------------------------------------------------
 
 // RaftSnapshotData
 
-// repeated group KV = 1 {
+// repeated .cockroach.proto.RaftSnapshotData.KeyValue KV = 1;
 inline int RaftSnapshotData::kv_size() const {
   return kv_.size();
 }
 inline void RaftSnapshotData::clear_kv() {
   kv_.Clear();
 }
-inline const ::cockroach::proto::RaftSnapshotData_KV& RaftSnapshotData::kv(int index) const {
-  // @@protoc_insertion_point(field_get:cockroach.proto.RaftSnapshotData.kv)
+inline const ::cockroach::proto::RaftSnapshotData_KeyValue& RaftSnapshotData::kv(int index) const {
+  // @@protoc_insertion_point(field_get:cockroach.proto.RaftSnapshotData.KV)
   return kv_.Get(index);
 }
-inline ::cockroach::proto::RaftSnapshotData_KV* RaftSnapshotData::mutable_kv(int index) {
-  // @@protoc_insertion_point(field_mutable:cockroach.proto.RaftSnapshotData.kv)
+inline ::cockroach::proto::RaftSnapshotData_KeyValue* RaftSnapshotData::mutable_kv(int index) {
+  // @@protoc_insertion_point(field_mutable:cockroach.proto.RaftSnapshotData.KV)
   return kv_.Mutable(index);
 }
-inline ::cockroach::proto::RaftSnapshotData_KV* RaftSnapshotData::add_kv() {
-  // @@protoc_insertion_point(field_add:cockroach.proto.RaftSnapshotData.kv)
+inline ::cockroach::proto::RaftSnapshotData_KeyValue* RaftSnapshotData::add_kv() {
+  // @@protoc_insertion_point(field_add:cockroach.proto.RaftSnapshotData.KV)
   return kv_.Add();
 }
-inline const ::google::protobuf::RepeatedPtrField< ::cockroach::proto::RaftSnapshotData_KV >&
+inline const ::google::protobuf::RepeatedPtrField< ::cockroach::proto::RaftSnapshotData_KeyValue >&
 RaftSnapshotData::kv() const {
-  // @@protoc_insertion_point(field_list:cockroach.proto.RaftSnapshotData.kv)
+  // @@protoc_insertion_point(field_list:cockroach.proto.RaftSnapshotData.KV)
   return kv_;
 }
-inline ::google::protobuf::RepeatedPtrField< ::cockroach::proto::RaftSnapshotData_KV >*
+inline ::google::protobuf::RepeatedPtrField< ::cockroach::proto::RaftSnapshotData_KeyValue >*
 RaftSnapshotData::mutable_kv() {
-  // @@protoc_insertion_point(field_mutable_list:cockroach.proto.RaftSnapshotData.kv)
+  // @@protoc_insertion_point(field_mutable_list:cockroach.proto.RaftSnapshotData.KV)
   return &kv_;
 }
 

--- a/storage/engine/cockroach/proto/internal.pb.h
+++ b/storage/engine/cockroach/proto/internal.pb.h
@@ -60,6 +60,8 @@ class InternalRaftCommand;
 class InternalTimeSeriesData;
 class InternalTimeSeriesSample;
 class RaftTruncatedState;
+class RaftSnapshotData;
+class RaftSnapshotData_KV;
 
 enum InternalValueType {
   _CR_TS = 1
@@ -2413,6 +2415,189 @@ class RaftTruncatedState : public ::google::protobuf::Message {
 
   void InitAsDefaultInstance();
   static RaftTruncatedState* default_instance_;
+};
+// -------------------------------------------------------------------
+
+class RaftSnapshotData_KV : public ::google::protobuf::Message {
+ public:
+  RaftSnapshotData_KV();
+  virtual ~RaftSnapshotData_KV();
+
+  RaftSnapshotData_KV(const RaftSnapshotData_KV& from);
+
+  inline RaftSnapshotData_KV& operator=(const RaftSnapshotData_KV& from) {
+    CopyFrom(from);
+    return *this;
+  }
+
+  inline const ::google::protobuf::UnknownFieldSet& unknown_fields() const {
+    return _unknown_fields_;
+  }
+
+  inline ::google::protobuf::UnknownFieldSet* mutable_unknown_fields() {
+    return &_unknown_fields_;
+  }
+
+  static const ::google::protobuf::Descriptor* descriptor();
+  static const RaftSnapshotData_KV& default_instance();
+
+  void Swap(RaftSnapshotData_KV* other);
+
+  // implements Message ----------------------------------------------
+
+  RaftSnapshotData_KV* New() const;
+  void CopyFrom(const ::google::protobuf::Message& from);
+  void MergeFrom(const ::google::protobuf::Message& from);
+  void CopyFrom(const RaftSnapshotData_KV& from);
+  void MergeFrom(const RaftSnapshotData_KV& from);
+  void Clear();
+  bool IsInitialized() const;
+
+  int ByteSize() const;
+  bool MergePartialFromCodedStream(
+      ::google::protobuf::io::CodedInputStream* input);
+  void SerializeWithCachedSizes(
+      ::google::protobuf::io::CodedOutputStream* output) const;
+  ::google::protobuf::uint8* SerializeWithCachedSizesToArray(::google::protobuf::uint8* output) const;
+  int GetCachedSize() const { return _cached_size_; }
+  private:
+  void SharedCtor();
+  void SharedDtor();
+  void SetCachedSize(int size) const;
+  public:
+  ::google::protobuf::Metadata GetMetadata() const;
+
+  // nested types ----------------------------------------------------
+
+  // accessors -------------------------------------------------------
+
+  // optional bytes key = 2;
+  inline bool has_key() const;
+  inline void clear_key();
+  static const int kKeyFieldNumber = 2;
+  inline const ::std::string& key() const;
+  inline void set_key(const ::std::string& value);
+  inline void set_key(const char* value);
+  inline void set_key(const void* value, size_t size);
+  inline ::std::string* mutable_key();
+  inline ::std::string* release_key();
+  inline void set_allocated_key(::std::string* key);
+
+  // optional bytes value = 3;
+  inline bool has_value() const;
+  inline void clear_value();
+  static const int kValueFieldNumber = 3;
+  inline const ::std::string& value() const;
+  inline void set_value(const ::std::string& value);
+  inline void set_value(const char* value);
+  inline void set_value(const void* value, size_t size);
+  inline ::std::string* mutable_value();
+  inline ::std::string* release_value();
+  inline void set_allocated_value(::std::string* value);
+
+  // @@protoc_insertion_point(class_scope:cockroach.proto.RaftSnapshotData.KV)
+ private:
+  inline void set_has_key();
+  inline void clear_has_key();
+  inline void set_has_value();
+  inline void clear_has_value();
+
+  ::google::protobuf::UnknownFieldSet _unknown_fields_;
+
+  ::google::protobuf::uint32 _has_bits_[1];
+  mutable int _cached_size_;
+  ::std::string* key_;
+  ::std::string* value_;
+  friend void  protobuf_AddDesc_cockroach_2fproto_2finternal_2eproto();
+  friend void protobuf_AssignDesc_cockroach_2fproto_2finternal_2eproto();
+  friend void protobuf_ShutdownFile_cockroach_2fproto_2finternal_2eproto();
+
+  void InitAsDefaultInstance();
+  static RaftSnapshotData_KV* default_instance_;
+};
+// -------------------------------------------------------------------
+
+class RaftSnapshotData : public ::google::protobuf::Message {
+ public:
+  RaftSnapshotData();
+  virtual ~RaftSnapshotData();
+
+  RaftSnapshotData(const RaftSnapshotData& from);
+
+  inline RaftSnapshotData& operator=(const RaftSnapshotData& from) {
+    CopyFrom(from);
+    return *this;
+  }
+
+  inline const ::google::protobuf::UnknownFieldSet& unknown_fields() const {
+    return _unknown_fields_;
+  }
+
+  inline ::google::protobuf::UnknownFieldSet* mutable_unknown_fields() {
+    return &_unknown_fields_;
+  }
+
+  static const ::google::protobuf::Descriptor* descriptor();
+  static const RaftSnapshotData& default_instance();
+
+  void Swap(RaftSnapshotData* other);
+
+  // implements Message ----------------------------------------------
+
+  RaftSnapshotData* New() const;
+  void CopyFrom(const ::google::protobuf::Message& from);
+  void MergeFrom(const ::google::protobuf::Message& from);
+  void CopyFrom(const RaftSnapshotData& from);
+  void MergeFrom(const RaftSnapshotData& from);
+  void Clear();
+  bool IsInitialized() const;
+
+  int ByteSize() const;
+  bool MergePartialFromCodedStream(
+      ::google::protobuf::io::CodedInputStream* input);
+  void SerializeWithCachedSizes(
+      ::google::protobuf::io::CodedOutputStream* output) const;
+  ::google::protobuf::uint8* SerializeWithCachedSizesToArray(::google::protobuf::uint8* output) const;
+  int GetCachedSize() const { return _cached_size_; }
+  private:
+  void SharedCtor();
+  void SharedDtor();
+  void SetCachedSize(int size) const;
+  public:
+  ::google::protobuf::Metadata GetMetadata() const;
+
+  // nested types ----------------------------------------------------
+
+  typedef RaftSnapshotData_KV KV;
+
+  // accessors -------------------------------------------------------
+
+  // repeated group KV = 1 {
+  inline int kv_size() const;
+  inline void clear_kv();
+  static const int kKvFieldNumber = 1;
+  inline const ::cockroach::proto::RaftSnapshotData_KV& kv(int index) const;
+  inline ::cockroach::proto::RaftSnapshotData_KV* mutable_kv(int index);
+  inline ::cockroach::proto::RaftSnapshotData_KV* add_kv();
+  inline const ::google::protobuf::RepeatedPtrField< ::cockroach::proto::RaftSnapshotData_KV >&
+      kv() const;
+  inline ::google::protobuf::RepeatedPtrField< ::cockroach::proto::RaftSnapshotData_KV >*
+      mutable_kv();
+
+  // @@protoc_insertion_point(class_scope:cockroach.proto.RaftSnapshotData)
+ private:
+
+  ::google::protobuf::UnknownFieldSet _unknown_fields_;
+
+  ::google::protobuf::uint32 _has_bits_[1];
+  mutable int _cached_size_;
+  ::google::protobuf::RepeatedPtrField< ::cockroach::proto::RaftSnapshotData_KV > kv_;
+  friend void  protobuf_AddDesc_cockroach_2fproto_2finternal_2eproto();
+  friend void protobuf_AssignDesc_cockroach_2fproto_2finternal_2eproto();
+  friend void protobuf_ShutdownFile_cockroach_2fproto_2finternal_2eproto();
+
+  void InitAsDefaultInstance();
+  static RaftSnapshotData* default_instance_;
 };
 // ===================================================================
 
@@ -5328,6 +5513,196 @@ inline void RaftTruncatedState::set_term(::google::protobuf::uint64 value) {
   set_has_term();
   term_ = value;
   // @@protoc_insertion_point(field_set:cockroach.proto.RaftTruncatedState.term)
+}
+
+// -------------------------------------------------------------------
+
+// RaftSnapshotData_KV
+
+// optional bytes key = 2;
+inline bool RaftSnapshotData_KV::has_key() const {
+  return (_has_bits_[0] & 0x00000001u) != 0;
+}
+inline void RaftSnapshotData_KV::set_has_key() {
+  _has_bits_[0] |= 0x00000001u;
+}
+inline void RaftSnapshotData_KV::clear_has_key() {
+  _has_bits_[0] &= ~0x00000001u;
+}
+inline void RaftSnapshotData_KV::clear_key() {
+  if (key_ != &::google::protobuf::internal::GetEmptyStringAlreadyInited()) {
+    key_->clear();
+  }
+  clear_has_key();
+}
+inline const ::std::string& RaftSnapshotData_KV::key() const {
+  // @@protoc_insertion_point(field_get:cockroach.proto.RaftSnapshotData.KV.key)
+  return *key_;
+}
+inline void RaftSnapshotData_KV::set_key(const ::std::string& value) {
+  set_has_key();
+  if (key_ == &::google::protobuf::internal::GetEmptyStringAlreadyInited()) {
+    key_ = new ::std::string;
+  }
+  key_->assign(value);
+  // @@protoc_insertion_point(field_set:cockroach.proto.RaftSnapshotData.KV.key)
+}
+inline void RaftSnapshotData_KV::set_key(const char* value) {
+  set_has_key();
+  if (key_ == &::google::protobuf::internal::GetEmptyStringAlreadyInited()) {
+    key_ = new ::std::string;
+  }
+  key_->assign(value);
+  // @@protoc_insertion_point(field_set_char:cockroach.proto.RaftSnapshotData.KV.key)
+}
+inline void RaftSnapshotData_KV::set_key(const void* value, size_t size) {
+  set_has_key();
+  if (key_ == &::google::protobuf::internal::GetEmptyStringAlreadyInited()) {
+    key_ = new ::std::string;
+  }
+  key_->assign(reinterpret_cast<const char*>(value), size);
+  // @@protoc_insertion_point(field_set_pointer:cockroach.proto.RaftSnapshotData.KV.key)
+}
+inline ::std::string* RaftSnapshotData_KV::mutable_key() {
+  set_has_key();
+  if (key_ == &::google::protobuf::internal::GetEmptyStringAlreadyInited()) {
+    key_ = new ::std::string;
+  }
+  // @@protoc_insertion_point(field_mutable:cockroach.proto.RaftSnapshotData.KV.key)
+  return key_;
+}
+inline ::std::string* RaftSnapshotData_KV::release_key() {
+  clear_has_key();
+  if (key_ == &::google::protobuf::internal::GetEmptyStringAlreadyInited()) {
+    return NULL;
+  } else {
+    ::std::string* temp = key_;
+    key_ = const_cast< ::std::string*>(&::google::protobuf::internal::GetEmptyStringAlreadyInited());
+    return temp;
+  }
+}
+inline void RaftSnapshotData_KV::set_allocated_key(::std::string* key) {
+  if (key_ != &::google::protobuf::internal::GetEmptyStringAlreadyInited()) {
+    delete key_;
+  }
+  if (key) {
+    set_has_key();
+    key_ = key;
+  } else {
+    clear_has_key();
+    key_ = const_cast< ::std::string*>(&::google::protobuf::internal::GetEmptyStringAlreadyInited());
+  }
+  // @@protoc_insertion_point(field_set_allocated:cockroach.proto.RaftSnapshotData.KV.key)
+}
+
+// optional bytes value = 3;
+inline bool RaftSnapshotData_KV::has_value() const {
+  return (_has_bits_[0] & 0x00000002u) != 0;
+}
+inline void RaftSnapshotData_KV::set_has_value() {
+  _has_bits_[0] |= 0x00000002u;
+}
+inline void RaftSnapshotData_KV::clear_has_value() {
+  _has_bits_[0] &= ~0x00000002u;
+}
+inline void RaftSnapshotData_KV::clear_value() {
+  if (value_ != &::google::protobuf::internal::GetEmptyStringAlreadyInited()) {
+    value_->clear();
+  }
+  clear_has_value();
+}
+inline const ::std::string& RaftSnapshotData_KV::value() const {
+  // @@protoc_insertion_point(field_get:cockroach.proto.RaftSnapshotData.KV.value)
+  return *value_;
+}
+inline void RaftSnapshotData_KV::set_value(const ::std::string& value) {
+  set_has_value();
+  if (value_ == &::google::protobuf::internal::GetEmptyStringAlreadyInited()) {
+    value_ = new ::std::string;
+  }
+  value_->assign(value);
+  // @@protoc_insertion_point(field_set:cockroach.proto.RaftSnapshotData.KV.value)
+}
+inline void RaftSnapshotData_KV::set_value(const char* value) {
+  set_has_value();
+  if (value_ == &::google::protobuf::internal::GetEmptyStringAlreadyInited()) {
+    value_ = new ::std::string;
+  }
+  value_->assign(value);
+  // @@protoc_insertion_point(field_set_char:cockroach.proto.RaftSnapshotData.KV.value)
+}
+inline void RaftSnapshotData_KV::set_value(const void* value, size_t size) {
+  set_has_value();
+  if (value_ == &::google::protobuf::internal::GetEmptyStringAlreadyInited()) {
+    value_ = new ::std::string;
+  }
+  value_->assign(reinterpret_cast<const char*>(value), size);
+  // @@protoc_insertion_point(field_set_pointer:cockroach.proto.RaftSnapshotData.KV.value)
+}
+inline ::std::string* RaftSnapshotData_KV::mutable_value() {
+  set_has_value();
+  if (value_ == &::google::protobuf::internal::GetEmptyStringAlreadyInited()) {
+    value_ = new ::std::string;
+  }
+  // @@protoc_insertion_point(field_mutable:cockroach.proto.RaftSnapshotData.KV.value)
+  return value_;
+}
+inline ::std::string* RaftSnapshotData_KV::release_value() {
+  clear_has_value();
+  if (value_ == &::google::protobuf::internal::GetEmptyStringAlreadyInited()) {
+    return NULL;
+  } else {
+    ::std::string* temp = value_;
+    value_ = const_cast< ::std::string*>(&::google::protobuf::internal::GetEmptyStringAlreadyInited());
+    return temp;
+  }
+}
+inline void RaftSnapshotData_KV::set_allocated_value(::std::string* value) {
+  if (value_ != &::google::protobuf::internal::GetEmptyStringAlreadyInited()) {
+    delete value_;
+  }
+  if (value) {
+    set_has_value();
+    value_ = value;
+  } else {
+    clear_has_value();
+    value_ = const_cast< ::std::string*>(&::google::protobuf::internal::GetEmptyStringAlreadyInited());
+  }
+  // @@protoc_insertion_point(field_set_allocated:cockroach.proto.RaftSnapshotData.KV.value)
+}
+
+// -------------------------------------------------------------------
+
+// RaftSnapshotData
+
+// repeated group KV = 1 {
+inline int RaftSnapshotData::kv_size() const {
+  return kv_.size();
+}
+inline void RaftSnapshotData::clear_kv() {
+  kv_.Clear();
+}
+inline const ::cockroach::proto::RaftSnapshotData_KV& RaftSnapshotData::kv(int index) const {
+  // @@protoc_insertion_point(field_get:cockroach.proto.RaftSnapshotData.kv)
+  return kv_.Get(index);
+}
+inline ::cockroach::proto::RaftSnapshotData_KV* RaftSnapshotData::mutable_kv(int index) {
+  // @@protoc_insertion_point(field_mutable:cockroach.proto.RaftSnapshotData.kv)
+  return kv_.Mutable(index);
+}
+inline ::cockroach::proto::RaftSnapshotData_KV* RaftSnapshotData::add_kv() {
+  // @@protoc_insertion_point(field_add:cockroach.proto.RaftSnapshotData.kv)
+  return kv_.Add();
+}
+inline const ::google::protobuf::RepeatedPtrField< ::cockroach::proto::RaftSnapshotData_KV >&
+RaftSnapshotData::kv() const {
+  // @@protoc_insertion_point(field_list:cockroach.proto.RaftSnapshotData.kv)
+  return kv_;
+}
+inline ::google::protobuf::RepeatedPtrField< ::cockroach::proto::RaftSnapshotData_KV >*
+RaftSnapshotData::mutable_kv() {
+  // @@protoc_insertion_point(field_mutable_list:cockroach.proto.RaftSnapshotData.kv)
+  return &kv_;
 }
 
 

--- a/storage/range.go
+++ b/storage/range.go
@@ -1683,7 +1683,7 @@ func (r *Range) Snapshot() (raftpb.Snapshot, error) {
 		}
 
 		snapData.KV = append(snapData.KV,
-			&proto.RaftSnapshotData_KV{Key: iter.Key(), Value: iter.Value()})
+			&proto.RaftSnapshotData_KeyValue{Key: iter.Key(), Value: iter.Value()})
 	}
 
 	data, err := gogoproto.Marshal(&snapData)

--- a/storage/range.go
+++ b/storage/range.go
@@ -1629,28 +1629,84 @@ func (r *Range) FirstIndex() (uint64, error) {
 
 // Snapshot implements the raft.Storage interface.
 func (r *Range) Snapshot() (raftpb.Snapshot, error) {
-	// TODO(bdarnell): package up all the data in the range, not just
-	// the descriptor (and send the appropriate log index).
-	data, err := gogoproto.Marshal(r.Desc())
+	// Copy all the data from a consistent RocksDB snapshot into a RaftSnapshotData.
+	snap := r.rm.NewSnapshot()
+	defer snap.Stop()
+	var snapData proto.RaftSnapshotData
+
+	// Certain keys are treated specially while building the snapshot;
+	// see the switch statement below for details.
+	hardStateKey := engine.RaftHardStateKey(r.Desc().RaftID)
+	appliedKey := engine.RaftAppliedIndexKey(r.Desc().RaftID)
+	descKey := engine.RangeDescriptorKey(r.Desc().StartKey)
+
+	// Save the range metadata while iterating. Use the values read from
+	// the snapshot instead of the members of the Range struct because
+	// they might be changed concurrently.
+	appliedIndex := uint64(raftInitialLogIndex)
+	var desc proto.RangeDescriptor
+	seenDesc := false
+
+	// Iterate over all the data in the range, including local-only data like
+	// the response cache.
+	for iter := newRangeDataIterator(r, snap); iter.Valid(); iter.Next() {
+		key, _, isValue := engine.MVCCDecodeKey(iter.Key())
+		switch {
+		case bytes.Equal(key, hardStateKey):
+			// The raft HardState must not be transmitted via snapshot,
+			// because the receiving node may have already cast a vote in this term.
+			continue
+		case bytes.Equal(key, appliedKey):
+			// Raft uses the applied index to synchronize the snapshot with the log.
+			var v proto.MVCCMetadata
+			err := gogoproto.Unmarshal(iter.Value(), &v)
+			if err != nil {
+				return raftpb.Snapshot{}, err
+			}
+			_, appliedIndex = encoding.DecodeUint64(v.Value.Bytes)
+		case bytes.Equal(key, descKey) && isValue && !seenDesc:
+			// Extract the descriptor so we can tell raft about the range membership at
+			// the time of the snapshot.
+			// TODO(bdarnell): Correctly handle pending transactions on the descriptor.
+			// Should we just skip the descriptor while iterating and call engine.MVCCGet
+			// on the snapshot?
+			seenDesc = true
+			var v proto.MVCCValue
+			err := gogoproto.Unmarshal(iter.Value(), &v)
+			if err != nil {
+				return raftpb.Snapshot{}, err
+			}
+			err = gogoproto.Unmarshal(v.Value.Bytes, &desc)
+			if err != nil {
+				return raftpb.Snapshot{}, err
+			}
+		}
+
+		snapData.KV = append(snapData.KV,
+			&proto.RaftSnapshotData_KV{Key: iter.Key(), Value: iter.Value()})
+	}
+
+	data, err := gogoproto.Marshal(&snapData)
 	if err != nil {
 		return raftpb.Snapshot{}, err
 	}
 
-	// Synthesize our raftpb.ConfState from Desc.
+	// Synthesize our raftpb.ConfState from desc.
 	var cs raftpb.ConfState
-	cs.Nodes = []uint64{uint64(r.rm.RaftNodeID())}
-	// TODO(bdarnell): cs.Nodes must give the replicas as of the log index we
-	// put in the SnapshotMetadata. When we produce a snapshot of the current
-	// time, replace the previous line with the following block.
-	/*for _, rep := range r.Desc().Replicas {
+	for _, rep := range desc.Replicas {
 		cs.Nodes = append(cs.Nodes, uint64(makeRaftNodeID(rep.NodeID, rep.StoreID)))
-	}*/
+	}
+
+	term, err := r.Term(appliedIndex)
+	if err != nil {
+		return raftpb.Snapshot{}, err
+	}
 
 	return raftpb.Snapshot{
 		Data: data,
 		Metadata: raftpb.SnapshotMetadata{
-			Index:     raftInitialLogIndex,
-			Term:      raftInitialLogTerm,
+			Index:     appliedIndex,
+			Term:      term,
 			ConfState: cs,
 		},
 	}, nil
@@ -1677,20 +1733,66 @@ func (r *Range) Append(entries []raftpb.Entry) error {
 
 // ApplySnapshot implements the multiraft.WriteableGroupStorage interface.
 func (r *Range) ApplySnapshot(snap raftpb.Snapshot) error {
-	// TODO(bdarnell): discard any existing log that is obsoleted by this snapshot.
-	desc := &proto.RangeDescriptor{}
-	err := gogoproto.Unmarshal(snap.Data, desc)
+	snapData := proto.RaftSnapshotData{}
+	err := gogoproto.Unmarshal(snap.Data, &snapData)
 	if err != nil {
+		return nil
+	}
+
+	hardStateKey := engine.RaftHardStateKey(r.Desc().RaftID)
+	encodedHardStateKey := engine.MVCCEncodeKey(hardStateKey)
+	descKey := engine.RangeDescriptorKey(r.Desc().StartKey)
+	var desc proto.RangeDescriptor
+	seenDesc := false
+	batch := engine.NewBatch(r.rm.Engine())
+
+	// Delete everything in the range and recreate it from the snapshot.
+	for iter := newRangeDataIterator(r, r.rm.Engine()); iter.Valid(); iter.Next() {
+		if bytes.Equal(encodedHardStateKey, iter.Key()) {
+			// Don't replace the raft HardState.
+			continue
+		}
+		if err := batch.Clear(iter.Key()); err != nil {
+			return err
+		}
+	}
+
+	for _, kv := range snapData.KV {
+		key, _, isValue := engine.MVCCDecodeKey(kv.Key)
+		switch {
+		case bytes.Equal(descKey, key) && isValue && !seenDesc:
+			// Save the descriptor so we can assign it to r.Desc.
+			// TODO(bdarnell): handle pending transactions on the descriptor.
+			seenDesc = true
+			var v proto.MVCCValue
+			err := gogoproto.Unmarshal(kv.Value, &v)
+			if err != nil {
+				return err
+			}
+			err = gogoproto.Unmarshal(v.Value.Bytes, &desc)
+			if err != nil {
+				return err
+			}
+		case bytes.Equal(hardStateKey, key):
+			// Don't replace the raft HardState. The leader shouldn't be sending a
+			// HardState in the snapshot, but just in case reject it on the receiving
+			// side as well.
+			continue
+		}
+		if err := batch.Put(kv.Key, kv.Value); err != nil {
+			return err
+		}
+	}
+
+	if err := batch.Commit(); err != nil {
 		return err
 	}
-	r.SetDesc(desc)
+	r.SetDesc(&desc)
+	// TODO(bdarnell): extract the real last index.
+	// snap.Metadata.Index is the last applied index, but our snapshot may have given us
+	// some unapplied entries too. It's safe to set lastIndex too low (the entries will
+	// be re-sent), but it would be better to set this to the last entry in the log.
 	atomic.StoreUint64(&r.lastIndex, snap.Metadata.Index)
-	ts := proto.RaftTruncatedState{
-		Index: snap.Metadata.Index,
-		Term:  snap.Metadata.Term,
-	}
-	err = engine.MVCCPutProto(r.rm.Engine(), nil, engine.RaftTruncatedStateKey(r.Desc().RaftID),
-		proto.ZeroTimestamp, nil, &ts)
 	return err
 }
 


### PR DESCRIPTION
This allows for ranges to be replicated after the raft log has been
truncated.
