### PR TITLE
Replace log.Fatal with error return in id_alloc

### DIFF
--- a/storage/id_alloc.go
+++ b/storage/id_alloc.go
@@ -31,7 +31,7 @@ import (
 const allocationTrigger = 0
 
 // IDAllocationRetryOpts sets the retry options for handling RaftID
-// allocation error
+// allocation errors.
 var IDAllocationRetryOpts = util.RetryOptions{
 	Backoff:     50 * time.Millisecond,
 	MaxBackoff:  5 * time.Second,
@@ -71,8 +71,7 @@ func NewIDAllocator(idKey proto.Key, db *client.KV, minID int64, blockSize int64
 	return ia, nil
 }
 
-// Allocate allocates a new ID from the global KV DB, and it will
-// start allocateBlock in background to prefetch ID
+// Allocate allocates a new ID from the global KV DB.
 func (ia *IDAllocator) Allocate() int64 {
 	for {
 		id := <-ia.ids

--- a/storage/id_alloc_test.go
+++ b/storage/id_alloc_test.go
@@ -108,10 +108,10 @@ func TestNewIDAllocatorInvalidArgs(t *testing.T) {
 	}
 }
 
-// TestAllocateErrorHandling creates a invalid IDAllocator which will
+// TestAllocateError creates a invalid IDAllocator which will
 // return error when fetch ID from KV DB. Because there isn't existing
 // allocated ID, Allocate() will directly return error
-func TestAllocateErrorHandling(t *testing.T) {
+func TestAllocateError(t *testing.T) {
 	store, _ := createTestStore(t)
 	// set nil idKey to trigger KV DB increment error
 	idAlloc, err := NewIDAllocator(nil, store.db, 2, 10)
@@ -125,11 +125,11 @@ func TestAllocateErrorHandling(t *testing.T) {
 	}
 }
 
-// TestAllocateErrorWithExistingIDAndRecovery has three steps:
+// TestAllocateErrorAndRecovery has three steps:
 // 1) allocates a set of ID firstly and check
 // 2) then makes IDAllocator invalid, error should happen for subsequent call
 // 3) set IDAllocator to valid again, can continue to allocate ID
-func TestAllocateErrorWithExistingIDAndRecovery(t *testing.T) {
+func TestAllocateErrorAndRecovery(t *testing.T) {
 	store, _ := createTestStore(t)
 
 	// firstly create a valid IDAllocator to get some ID

--- a/storage/id_alloc_test.go
+++ b/storage/id_alloc_test.go
@@ -92,7 +92,7 @@ func TestIDAllocatorNegativeValue(t *testing.T) {
 	}
 }
 
-// TestNewIDAllocatorInvalidArgs checks validation logic of NewIDAllocator
+// TestNewIDAllocatorInvalidArgs checks validation logic of NewIDAllocator.
 func TestNewIDAllocatorInvalidArgs(t *testing.T) {
 	args := [][]int64{
 		{0, 10}, // minID <= 0
@@ -106,16 +106,16 @@ func TestNewIDAllocatorInvalidArgs(t *testing.T) {
 }
 
 // TestAllocateErrorAndRecovery has several steps:
-// 1) allocate a set of ID firstly and check
-// 2) then make IDAllocator invalid, should be able to return existing one
-// 3) after channel becomes empty, allocation will be blocked
-// 4) make IDAllocator valid again, the blocked allocations return correct ID
-// 5) check if the following allocations return correctly
+// 1) Allocate a set of ID firstly and check.
+// 2) Then make IDAllocator invalid, should be able to return existing one.
+// 3) After channel becomes empty, allocation will be blocked.
+// 4) Make IDAllocator valid again, the blocked allocations return correct ID.
+// 5) Check if the following allocations return correctly.
 func TestAllocateErrorAndRecovery(t *testing.T) {
 	store, _ := createTestStore(t)
 	allocd := make(chan int, 10)
 
-	// firstly create a valid IDAllocator to get some ID
+	// Firstly create a valid IDAllocator to get some ID.
 	idAlloc, err := NewIDAllocator(engine.KeyRaftIDGenerator, store.db, 2, 10)
 	if err != nil {
 		t.Errorf("failed to create IDAllocator: %v", err)
@@ -125,33 +125,33 @@ func TestAllocateErrorAndRecovery(t *testing.T) {
 		t.Errorf("expected ID is 2, but got: %d", id)
 	}
 
-	// make Allocator invalid
+	// Make Allocator invalid.
 	idAlloc.idKey = nil
 
-	// should be able to get the allocated IDs, and there will be one
-	// background allocateBlock to get ID continously
+	// Should be able to get the allocated IDs, and there will be one
+	// background allocateBlock to get ID continuously.
 	for i := 0; i < 8; i++ {
 		if id := int(idAlloc.Allocate()); id != i+3 {
 			t.Errorf("expected ID is %d, but got: %d", i+3, id)
 		}
 	}
 
-	// then the paralleled allocations should be blocked until Allocator
-	// is recovered
+	// Then the paralleled allocations should be blocked until Allocator
+	// is recovered.
 	for i := 0; i < 10; i++ {
 		go func() {
 			allocd <- int(idAlloc.Allocate())
 		}()
 	}
-	// make sure no allocation returns
+	// Make sure no allocation returns.
 	time.Sleep(10 * time.Millisecond)
 	if len(allocd) != 0 {
 		t.Errorf("Allocate() should be blocked until allocateBlock return ID")
 	}
 
-	// make the IDAllocator valid again
+	// Make the IDAllocator valid again.
 	idAlloc.idKey = engine.KeyRaftIDGenerator
-	// check if the blocked allocations return the expected ID
+	// Check if the blocked allocations return expected ID.
 	ids := make([]int, 10)
 	for i := 0; i < 10; i++ {
 		ids[i] = <-allocd
@@ -163,7 +163,7 @@ func TestAllocateErrorAndRecovery(t *testing.T) {
 		}
 	}
 
-	// check if the following allocations return expected ID
+	// Check if the following allocations return expected ID.
 	for i := 0; i < 10; i++ {
 		if id := int(idAlloc.Allocate()); id != i+21 {
 			t.Errorf("expected ID is %d, but got: %d", i+21, id)

--- a/storage/store.go
+++ b/storage/store.go
@@ -652,15 +652,11 @@ func (s *Store) SplitQueue() *splitQueue { return s.splitQueue }
 // and range IDs to fill out the supplied replicas.
 func (s *Store) NewRangeDescriptor(start, end proto.Key, replicas []proto.Replica) (*proto.RangeDescriptor, error) {
 	desc := &proto.RangeDescriptor{
+		RaftID:   s.raftIDAlloc.Allocate(),
 		StartKey: start,
 		EndKey:   end,
 		Replicas: append([]proto.Replica(nil), replicas...),
 	}
-	raftID, err := s.raftIDAlloc.Allocate()
-	if err != nil {
-		return nil, err
-	}
-	desc.RaftID = raftID
 	return desc, nil
 }
 


### PR DESCRIPTION
This modification is accoding to "Propagate errors from storage/id_alloc.go" in TODO.md. Previously in id_alloc.go, if error happens, log.Fatal will directly close the process, better to use error handling mechanism.

There are two points in the code: 
1) Use channel to return error. Actually RaftID allocation is samilar to NodeID allocation, only one small difference is the background allocateBlock goroutine. This goroutine needs to return error if unable to get id from KV DB, so it has to use channel to return error.

2) If allocateBlock() return error, instead of return error in next Allocate() directly, maybe it is better to use the existing allocated IDs firstly, and finally return error when the channel is empty. 

BTW, The design of this project is cool, I'm going through the issues and TODO, hope to contribute more :-)
