### PR TITLE
Spencerkimball/inconsistent reads

### DIFF
--- a/kv/dist_sender.go
+++ b/kv/dist_sender.go
@@ -179,8 +179,12 @@ func (ds *DistSender) nodeIDToAddr(nodeID proto.NodeID) (net.Addr, error) {
 	return info.(net.Addr), nil
 }
 
-// internalRangeLookup dispatches an InternalRangeLookup request for the given
-// metadata key to the replicas of the given range.
+// internalRangeLookup dispatches an InternalRangeLookup request for
+// the given metadata key to the replicas of the given range. Note
+// that we allow inconsistent reads when doing range lookups for
+// effiency. Getting stale data is not a correctness problem but
+// instead may infrequently result in additional latency as additional
+// range lookups may be required.
 func (ds *DistSender) internalRangeLookup(key proto.Key, info *proto.RangeDescriptor) ([]proto.RangeDescriptor, error) {
 	args := &proto.InternalRangeLookupRequest{
 		RequestHeader: proto.RequestHeader{

--- a/kv/dist_sender_server_test.go
+++ b/kv/dist_sender_server_test.go
@@ -1,0 +1,84 @@
+// Copyright 2015 The Cockroach Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+// implied. See the License for the specific language governing
+// permissions and limitations under the License. See the AUTHORS file
+// for names of contributors.
+//
+// Author: Spencer Kimball (spencer.kimball@gmail.com)
+
+package kv_test
+
+import (
+	"net/http"
+	"testing"
+	"time"
+
+	"github.com/cockroachdb/cockroach/client"
+	"github.com/cockroachdb/cockroach/proto"
+	"github.com/cockroachdb/cockroach/rpc"
+	"github.com/cockroachdb/cockroach/server"
+	"github.com/cockroachdb/cockroach/storage"
+	"github.com/cockroachdb/cockroach/storage/engine"
+)
+
+// NOTE: these tests are in package kv_test to avoid a circular
+// dependency between the server and kv packages. These tests rely on
+// starting a TestServer, which creates a "real" node and employs a
+// distributed sender server-side.
+
+// TestRangeLookupWithOpenTransaction verifies that range lookups are
+// done in such a way (e.g. using inconsistent reads) that they
+// proceed in the event that a write intent is extant at the meta
+// index record being read.
+func TestRangeLookupWithOpenTransaction(t *testing.T) {
+	s := &server.TestServer{}
+	if err := s.Start(); err != nil {
+		t.Fatal(err)
+	}
+	defer s.Stop()
+	sender := client.NewHTTPSender(s.HTTPAddr, &http.Transport{
+		TLSClientConfig: rpc.LoadInsecureTLSConfig().Config(),
+	})
+	db := client.NewKV(sender, nil)
+	db.User = storage.UserRoot
+
+	// Create an intent on the meta1 record by writing directly to the
+	// engine.
+	key := engine.MakeKey(engine.KeyMeta1Prefix, engine.KeyMax)
+	now := s.Clock().Now()
+	txn := proto.NewTransaction("txn", proto.Key("foobar"), 0, proto.SERIALIZABLE, now, 0)
+	if err := engine.MVCCPutProto(s.Engine, nil, key, now, txn, &proto.RangeDescriptor{}); err != nil {
+		t.Fatal(err)
+	}
+
+	// Now, with an intent pending, attempt (asynchronously) to read
+	// from an arbitrary key. This will cause the distributed sender to
+	// do a range lookup, which will encounter the intent. We're
+	// verifying here that the range lookup doesn't fail with a write
+	// intent error. If it did, it would go into a deadloop attempting
+	// to push the transaction, which in turn requires another range
+	// lookup, etc, ad nauseam.
+	success := make(chan struct{})
+	go func() {
+		if err := db.Call(proto.Get, proto.GetArgs(proto.Key("a")), &proto.GetResponse{}); err != nil {
+			t.Fatal(err)
+		}
+		close(success)
+	}()
+
+	select {
+	case <-success:
+		// Hurrah!
+	case <-time.After(1 * time.Second):
+		t.Errorf("get request did not succeed in face of range metadata intent")
+	}
+}

--- a/kv/dist_sender_server_test.go
+++ b/kv/dist_sender_server_test.go
@@ -115,8 +115,7 @@ func setupMultipleRanges(t *testing.T) (*server.TestServer, *client.KV) {
 	return s, db
 }
 
-// TestMultiRangeScan verifies that a scan across ranges will
-// return an OpRequiresTxn error.
+// TestMultiRangeScan verifies operation of a scan across ranges.
 func TestMultiRangeScan(t *testing.T) {
 	s, db := setupMultipleRanges(t)
 	defer s.Stop()

--- a/kv/dist_sender_test.go
+++ b/kv/dist_sender_test.go
@@ -32,7 +32,7 @@ import (
 
 func TestGetFirstRangeDescriptor(t *testing.T) {
 	n := simulation.NewNetwork(3, "unix", gossip.TestInterval, gossip.TestBootstrap)
-	ds := NewDistSender(n.Nodes[0].Gossip)
+	ds := NewDistSender(nil, n.Nodes[0].Gossip)
 	if _, err := ds.getFirstRangeDescriptor(); err == nil {
 		t.Errorf("expected not to find first range descriptor")
 	}
@@ -70,7 +70,7 @@ func TestGetFirstRangeDescriptor(t *testing.T) {
 // are checked hierarchically.
 func TestVerifyPermissions(t *testing.T) {
 	n := simulation.NewNetwork(1, "unix", gossip.TestInterval, gossip.TestBootstrap)
-	ds := NewDistSender(n.Nodes[0].Gossip)
+	ds := NewDistSender(nil, n.Nodes[0].Gossip)
 	config1 := &proto.PermConfig{
 		Read:  []string{"read1", "readAll", "rw1", "rwAll"},
 		Write: []string{"write1", "writeAll", "rw1", "rwAll"}}

--- a/kv/split_test.go
+++ b/kv/split_test.go
@@ -190,7 +190,7 @@ func TestRangeSplitsWithWritePressure(t *testing.T) {
 	// for timing of finishing the test writer and a possibly-ongoing
 	// asynchronous split.
 	if err := util.IsTrueWithin(func() bool {
-		if _, err := engine.MVCCScan(eng, engine.KeyLocalMax, engine.KeyMax, 0, proto.MaxTimestamp, nil); err != nil {
+		if _, err := engine.MVCCScan(eng, engine.KeyLocalMax, engine.KeyMax, 0, proto.MaxTimestamp, true, nil); err != nil {
 			log.Infof("mvcc scan should be clean: %s", err)
 			return false
 		}

--- a/proto/api.pb.go
+++ b/proto/api.pb.go
@@ -75,8 +75,9 @@ const (
 	//
 	// TODO(spencer): current unimplemented.
 	CONSENSUS ReadConsistencyType = 1
-	// INCONSISTENT reads are not guaranteed to read committed data,
-	// but are more efficient.
+	// INCONSISTENT reads return the latest available, committed values.
+	// They are more efficient, but may read stale values as pending
+	// intents are ignored.
 	INCONSISTENT ReadConsistencyType = 2
 )
 

--- a/proto/api.pb.go
+++ b/proto/api.pb.go
@@ -62,6 +62,52 @@ import math "math"
 var _ = proto1.Marshal
 var _ = math.Inf
 
+// ReadConsistencyType specifies what type of consistency is observed
+// during read operations.
+type ReadConsistencyType int32
+
+const (
+	// CONSISTENT reads are guaranteed to read committed data; the
+	// mechanism relies on clocks to determine lease expirations.
+	CONSISTENT ReadConsistencyType = 0
+	// CONSENSUS requires that reads must achieve consensus. This is a
+	// stronger guarantee of consistency than CONSISTENT.
+	//
+	// TODO(spencer): current unimplemented.
+	CONSENSUS ReadConsistencyType = 1
+	// INCONSISTENT reads are not guaranteed to read committed data,
+	// but are more efficient.
+	INCONSISTENT ReadConsistencyType = 2
+)
+
+var ReadConsistencyType_name = map[int32]string{
+	0: "CONSISTENT",
+	1: "CONSENSUS",
+	2: "INCONSISTENT",
+}
+var ReadConsistencyType_value = map[string]int32{
+	"CONSISTENT":   0,
+	"CONSENSUS":    1,
+	"INCONSISTENT": 2,
+}
+
+func (x ReadConsistencyType) Enum() *ReadConsistencyType {
+	p := new(ReadConsistencyType)
+	*p = x
+	return p
+}
+func (x ReadConsistencyType) String() string {
+	return proto1.EnumName(ReadConsistencyType_name, int32(x))
+}
+func (x *ReadConsistencyType) UnmarshalJSON(data []byte) error {
+	value, err := proto1.UnmarshalJSONEnum(ReadConsistencyType_value, data, "ReadConsistencyType")
+	if err != nil {
+		return err
+	}
+	*x = ReadConsistencyType(value)
+	return nil
+}
+
 // ClientCmdID provides a unique ID for client commands. Clients which
 // provide ClientCmdID gain operation idempotence. In other words,
 // clients can submit the same command multiple times and always
@@ -141,8 +187,12 @@ type RequestHeader struct {
 	// isolation level set as desired. The response will contain the
 	// fully-initialized transaction with txn ID, priority, initial
 	// timestamp, and maximum timestamp.
-	Txn              *Transaction `protobuf:"bytes,9,opt,name=txn" json:"txn,omitempty"`
-	XXX_unrecognized []byte       `json:"-"`
+	Txn *Transaction `protobuf:"bytes,9,opt,name=txn" json:"txn,omitempty"`
+	// ReadConsistency specifies the consistency for read
+	// operations. The default is CONSISTENT. This value is ignored for
+	// write operations.
+	ReadConsistency  ReadConsistencyType `protobuf:"varint,10,opt,name=read_consistency,enum=cockroach.proto.ReadConsistencyType" json:"read_consistency"`
+	XXX_unrecognized []byte              `json:"-"`
 }
 
 func (m *RequestHeader) Reset()         { *m = RequestHeader{} }
@@ -198,6 +248,13 @@ func (m *RequestHeader) GetTxn() *Transaction {
 		return m.Txn
 	}
 	return nil
+}
+
+func (m *RequestHeader) GetReadConsistency() ReadConsistencyType {
+	if m != nil {
+		return m.ReadConsistency
+	}
+	return CONSISTENT
 }
 
 // ResponseHeader is returned with every storage node response.
@@ -1004,6 +1061,7 @@ func (m *AdminMergeResponse) String() string { return proto1.CompactTextString(m
 func (*AdminMergeResponse) ProtoMessage()    {}
 
 func init() {
+	proto1.RegisterEnum("cockroach.proto.ReadConsistencyType", ReadConsistencyType_name, ReadConsistencyType_value)
 }
 func (this *RequestUnion) GetValue() interface{} {
 	if this.Contains != nil {

--- a/proto/api.proto
+++ b/proto/api.proto
@@ -45,6 +45,23 @@ message ClientCmdID {
   optional int64 random = 2 [(gogoproto.nullable) = false];
 }
 
+// ReadConsistencyType specifies what type of consistency is observed
+// during read operations.
+enum ReadConsistencyType {
+  option (gogoproto.goproto_enum_prefix) = false;
+  // CONSISTENT reads are guaranteed to read committed data; the
+  // mechanism relies on clocks to determine lease expirations.
+  CONSISTENT = 0;
+  // CONSENSUS requires that reads must achieve consensus. This is a
+  // stronger guarantee of consistency than CONSISTENT.
+  //
+  // TODO(spencer): current unimplemented.
+  CONSENSUS = 1;
+  // INCONSISTENT reads are not guaranteed to read committed data,
+  // but are more efficient.
+  INCONSISTENT = 2;
+}
+
 // RequestHeader is supplied with every storage node request.
 message RequestHeader {
   // Timestamp specifies time at which read or writes should be
@@ -85,6 +102,10 @@ message RequestHeader {
   // fully-initialized transaction with txn ID, priority, initial
   // timestamp, and maximum timestamp.
   optional Transaction txn = 9;
+  // ReadConsistency specifies the consistency for read
+  // operations. The default is CONSISTENT. This value is ignored for
+  // write operations.
+  optional ReadConsistencyType read_consistency = 10 [(gogoproto.nullable) = false];
 }
 
 // ResponseHeader is returned with every storage node response.

--- a/proto/api.proto
+++ b/proto/api.proto
@@ -57,8 +57,9 @@ enum ReadConsistencyType {
   //
   // TODO(spencer): current unimplemented.
   CONSENSUS = 1;
-  // INCONSISTENT reads are not guaranteed to read committed data,
-  // but are more efficient.
+  // INCONSISTENT reads return the latest available, committed values.
+  // They are more efficient, but may read stale values as pending
+  // intents are ignored.
   INCONSISTENT = 2;
 }
 

--- a/proto/data.go
+++ b/proto/data.go
@@ -234,6 +234,22 @@ func (t Timestamp) Add(wallTime int64, logical int32) Timestamp {
 	}
 }
 
+// Prev returns the next earliest timestamp.
+func (t *Timestamp) Prev() Timestamp {
+	if t.Logical > 0 {
+		return Timestamp{
+			WallTime: t.WallTime,
+			Logical:  t.Logical - 1,
+		}
+	} else if t.WallTime > 0 {
+		return Timestamp{
+			WallTime: t.WallTime - 1,
+			Logical:  math.MaxInt32,
+		}
+	}
+	panic("cannot take the previous value to a zero timestamp")
+}
+
 // Forward updates the timestamp from the one given, if that moves it
 // forwards in time.
 func (t *Timestamp) Forward(s Timestamp) {
@@ -267,11 +283,11 @@ func (v *Value) InitChecksum(key []byte) {
 func (v *Value) Verify(key []byte) error {
 	if v.Checksum != nil {
 		if v.GetChecksum() != v.computeChecksum(key) {
-			return util.Errorf("invalid checksum for key %q, value %+v", key, v)
+			return util.Errorf("invalid checksum for key %s, value %+v", key, v)
 		}
 	}
 	if v.Bytes != nil && v.Integer != nil {
-		return util.Errorf("both the value byte slice and integer fields are set for key %q: %+v", key, v)
+		return util.Errorf("both the value byte slice and integer fields are set for key %s: %+v", key, v)
 	}
 	return nil
 }

--- a/proto/data_test.go
+++ b/proto/data_test.go
@@ -206,6 +206,21 @@ func TestEqual(t *testing.T) {
 	}
 }
 
+func TestTimestampPrev(t *testing.T) {
+	testCases := []struct {
+		ts, expPrev Timestamp
+	}{
+		{makeTS(1, 2), makeTS(1, 1)},
+		{makeTS(1, 1), makeTS(1, 0)},
+		{makeTS(1, 0), makeTS(0, math.MaxInt32)},
+	}
+	for i, c := range testCases {
+		if prev := c.ts.Prev(); !prev.Equal(c.expPrev) {
+			t.Errorf("%d: expected %s; got %s", i, c.expPrev, prev)
+		}
+	}
+}
+
 func TestValueBothBytesAndIntegerSet(t *testing.T) {
 	k := []byte("key")
 	v := Value{Bytes: []byte("a"), Integer: gogoproto.Int64(0)}

--- a/proto/errors.go
+++ b/proto/errors.go
@@ -74,10 +74,10 @@ func NewRangeKeyMismatchError(start, end Key, desc *RangeDescriptor) *RangeKeyMi
 // Error formats error.
 func (e *RangeKeyMismatchError) Error() string {
 	if e.Range != nil {
-		return fmt.Sprintf("key range %q-%q outside of bounds of range %q-%q",
+		return fmt.Sprintf("key range %s-%s outside of bounds of range %s-%s",
 			e.RequestStartKey, e.RequestEndKey, e.Range.StartKey, e.Range.EndKey)
 	}
-	return fmt.Sprintf("key range %q-%q could not be located within a range on store", e.RequestStartKey, e.RequestEndKey)
+	return fmt.Sprintf("key range %s-%s could not be located within a range on store", e.RequestStartKey, e.RequestEndKey)
 }
 
 // CanRetry indicates whether or not this RangeKeyMismatchError can be retried.
@@ -150,7 +150,7 @@ func (e *TransactionStatusError) Error() string {
 
 // Error formats error.
 func (e *WriteIntentError) Error() string {
-	return fmt.Sprintf("conflicting write intent at key %q from transaction %s: resolved? %t", e.Key, e.Txn, e.Resolved)
+	return fmt.Sprintf("conflicting write intent at key %s from transaction %s: resolved? %t", e.Key, e.Txn, e.Resolved)
 }
 
 // Error formats error.

--- a/server/node_test.go
+++ b/server/node_test.go
@@ -63,7 +63,7 @@ func createTestNode(addr net.Addr, engines []engine.Engine, gossipBS net.Addr, t
 		g.SetBootstrap([]net.Addr{gossipBS})
 		g.Start(rpcServer)
 	}
-	db := client.NewKV(kv.NewDistSender(g), nil)
+	db := client.NewKV(kv.NewDistSender(clock, g), nil)
 	node := NewNode(db, g, storage.TestStoreConfig)
 	return rpcServer, clock, node
 }

--- a/server/server.go
+++ b/server/server.go
@@ -37,7 +37,7 @@ import (
 	"github.com/cockroachdb/cockroach/util"
 	"github.com/cockroachdb/cockroach/util/hlc"
 	"github.com/cockroachdb/cockroach/util/log"
-	"github.com/elazarl/go-bindata-assetfs"
+	assetfs "github.com/elazarl/go-bindata-assetfs"
 )
 
 // Allocation pool for gzip writers.
@@ -109,7 +109,8 @@ func NewServer(ctx *Context) (*Server, error) {
 
 	// Create a client.KVSender instance for use with this node's
 	// client to the key value database as well as
-	sender := kv.NewTxnCoordSender(kv.NewDistSender(s.gossip), s.clock, ctx.Linearizable)
+	ds := kv.NewDistSender(s.clock, s.gossip)
+	sender := kv.NewTxnCoordSender(ds, s.clock, ctx.Linearizable)
 	s.kv = client.NewKV(sender, nil)
 	s.kv.User = storage.UserRoot
 

--- a/server/server_test.go
+++ b/server/server_test.go
@@ -259,7 +259,8 @@ func TestGzip(t *testing.T) {
 func TestMultiRangeScanDeleteRange(t *testing.T) {
 	s := startTestServer(t)
 	defer s.Stop()
-	tds := kv.NewTxnCoordSender(kv.NewDistSender(s.Gossip()), s.Clock(), testContext.Linearizable)
+	ds := kv.NewDistSender(s.Clock(), s.Gossip())
+	tds := kv.NewTxnCoordSender(ds, s.Clock(), testContext.Linearizable)
 	defer tds.Close()
 
 	if err := s.node.db.Call(proto.AdminSplit,

--- a/storage/client_test.go
+++ b/storage/client_test.go
@@ -342,7 +342,7 @@ func TestUpdateRangeAddressing(t *testing.T) {
 		}
 		store.DB().Flush()
 		// Scan meta keys directly from engine.
-		kvs, err := engine.MVCCScan(store.Engine(), engine.KeyMetaPrefix, engine.KeyMetaMax, 0, proto.MaxTimestamp, nil)
+		kvs, err := engine.MVCCScan(store.Engine(), engine.KeyMetaPrefix, engine.KeyMetaMax, 0, proto.MaxTimestamp, true, nil)
 		if err != nil {
 			t.Fatal(err)
 		}

--- a/storage/engine/cockroach/proto/api.pb.cc
+++ b/storage/engine/cockroach/proto/api.pb.cc
@@ -154,6 +154,7 @@ const ::google::protobuf::internal::GeneratedMessageReflection*
 const ::google::protobuf::Descriptor* AdminMergeResponse_descriptor_ = NULL;
 const ::google::protobuf::internal::GeneratedMessageReflection*
   AdminMergeResponse_reflection_ = NULL;
+const ::google::protobuf::EnumDescriptor* ReadConsistencyType_descriptor_ = NULL;
 
 }  // namespace
 
@@ -181,7 +182,7 @@ void protobuf_AssignDesc_cockroach_2fproto_2fapi_2eproto() {
       ::google::protobuf::MessageFactory::generated_factory(),
       sizeof(ClientCmdID));
   RequestHeader_descriptor_ = file->message_type(1);
-  static const int RequestHeader_offsets_[9] = {
+  static const int RequestHeader_offsets_[10] = {
     GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(RequestHeader, timestamp_),
     GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(RequestHeader, cmd_id_),
     GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(RequestHeader, key_),
@@ -191,6 +192,7 @@ void protobuf_AssignDesc_cockroach_2fproto_2fapi_2eproto() {
     GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(RequestHeader, raft_id_),
     GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(RequestHeader, user_priority_),
     GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(RequestHeader, txn_),
+    GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(RequestHeader, read_consistency_),
   };
   RequestHeader_reflection_ =
     new ::google::protobuf::internal::GeneratedMessageReflection(
@@ -749,6 +751,7 @@ void protobuf_AssignDesc_cockroach_2fproto_2fapi_2eproto() {
       ::google::protobuf::DescriptorPool::generated_pool(),
       ::google::protobuf::MessageFactory::generated_factory(),
       sizeof(AdminMergeResponse));
+  ReadConsistencyType_descriptor_ = file->enum_type(0);
 }
 
 namespace {
@@ -926,7 +929,7 @@ void protobuf_AddDesc_cockroach_2fproto_2fapi_2eproto() {
     "roach/proto/data.proto\032\034cockroach/proto/"
     "errors.proto\032\024gogoproto/gogo.proto\"<\n\013Cl"
     "ientCmdID\022\027\n\twall_time\030\001 \001(\003B\004\310\336\037\000\022\024\n\006ra"
-    "ndom\030\002 \001(\003B\004\310\336\037\000\"\344\002\n\rRequestHeader\0223\n\tti"
+    "ndom\030\002 \001(\003B\004\310\336\037\000\"\252\003\n\rRequestHeader\0223\n\tti"
     "mestamp\030\001 \001(\0132\032.cockroach.proto.Timestam"
     "pB\004\310\336\037\000\022;\n\006cmd_id\030\002 \001(\0132\034.cockroach.prot"
     "o.ClientCmdIDB\r\310\336\037\000\342\336\037\005CmdID\022\030\n\003key\030\003 \001("
@@ -935,127 +938,130 @@ void protobuf_AddDesc_cockroach_2fproto_2fapi_2eproto() {
     "\0132\030.cockroach.proto.ReplicaB\004\310\336\037\000\022\037\n\007raf"
     "t_id\030\007 \001(\003B\016\310\336\037\000\342\336\037\006RaftID\022\030\n\ruser_prior"
     "ity\030\010 \001(\005:\0011\022)\n\003txn\030\t \001(\0132\034.cockroach.pr"
-    "oto.Transaction\"\227\001\n\016ResponseHeader\022%\n\005er"
-    "ror\030\001 \001(\0132\026.cockroach.proto.Error\0223\n\ttim"
-    "estamp\030\002 \001(\0132\032.cockroach.proto.Timestamp"
-    "B\004\310\336\037\000\022)\n\003txn\030\003 \001(\0132\034.cockroach.proto.Tr"
-    "ansaction\"K\n\017ContainsRequest\0228\n\006header\030\001"
-    " \001(\0132\036.cockroach.proto.RequestHeaderB\010\310\336"
-    "\037\000\320\336\037\001\"c\n\020ContainsResponse\0229\n\006header\030\001 \001"
-    "(\0132\037.cockroach.proto.ResponseHeaderB\010\310\336\037"
-    "\000\320\336\037\001\022\024\n\006exists\030\002 \001(\010B\004\310\336\037\000\"F\n\nGetReques"
-    "t\0228\n\006header\030\001 \001(\0132\036.cockroach.proto.Requ"
-    "estHeaderB\010\310\336\037\000\320\336\037\001\"o\n\013GetResponse\0229\n\006he"
-    "ader\030\001 \001(\0132\037.cockroach.proto.ResponseHea"
-    "derB\010\310\336\037\000\320\336\037\001\022%\n\005value\030\002 \001(\0132\026.cockroach"
-    ".proto.Value\"s\n\nPutRequest\0228\n\006header\030\001 \001"
-    "(\0132\036.cockroach.proto.RequestHeaderB\010\310\336\037\000"
-    "\320\336\037\001\022+\n\005value\030\002 \001(\0132\026.cockroach.proto.Va"
-    "lueB\004\310\336\037\000\"H\n\013PutResponse\0229\n\006header\030\001 \001(\013"
+    "oto.Transaction\022D\n\020read_consistency\030\n \001("
+    "\0162$.cockroach.proto.ReadConsistencyTypeB"
+    "\004\310\336\037\000\"\227\001\n\016ResponseHeader\022%\n\005error\030\001 \001(\0132"
+    "\026.cockroach.proto.Error\0223\n\ttimestamp\030\002 \001"
+    "(\0132\032.cockroach.proto.TimestampB\004\310\336\037\000\022)\n\003"
+    "txn\030\003 \001(\0132\034.cockroach.proto.Transaction\""
+    "K\n\017ContainsRequest\0228\n\006header\030\001 \001(\0132\036.coc"
+    "kroach.proto.RequestHeaderB\010\310\336\037\000\320\336\037\001\"c\n\020"
+    "ContainsResponse\0229\n\006header\030\001 \001(\0132\037.cockr"
+    "oach.proto.ResponseHeaderB\010\310\336\037\000\320\336\037\001\022\024\n\006e"
+    "xists\030\002 \001(\010B\004\310\336\037\000\"F\n\nGetRequest\0228\n\006heade"
+    "r\030\001 \001(\0132\036.cockroach.proto.RequestHeaderB"
+    "\010\310\336\037\000\320\336\037\001\"o\n\013GetResponse\0229\n\006header\030\001 \001(\013"
     "2\037.cockroach.proto.ResponseHeaderB\010\310\336\037\000\320"
-    "\336\037\001\"\251\001\n\025ConditionalPutRequest\0228\n\006header\030"
-    "\001 \001(\0132\036.cockroach.proto.RequestHeaderB\010\310"
-    "\336\037\000\320\336\037\001\022+\n\005value\030\002 \001(\0132\026.cockroach.proto"
-    ".ValueB\004\310\336\037\000\022)\n\texp_value\030\003 \001(\0132\026.cockro"
-    "ach.proto.Value\"S\n\026ConditionalPutRespons"
-    "e\0229\n\006header\030\001 \001(\0132\037.cockroach.proto.Resp"
-    "onseHeaderB\010\310\336\037\000\320\336\037\001\"e\n\020IncrementRequest"
-    "\0228\n\006header\030\001 \001(\0132\036.cockroach.proto.Reque"
-    "stHeaderB\010\310\336\037\000\320\336\037\001\022\027\n\tincrement\030\002 \001(\003B\004\310"
-    "\336\037\000\"g\n\021IncrementResponse\0229\n\006header\030\001 \001(\013"
-    "2\037.cockroach.proto.ResponseHeaderB\010\310\336\037\000\320"
-    "\336\037\001\022\027\n\tnew_value\030\002 \001(\003B\004\310\336\037\000\"I\n\rDeleteRe"
-    "quest\0228\n\006header\030\001 \001(\0132\036.cockroach.proto."
-    "RequestHeaderB\010\310\336\037\000\320\336\037\001\"K\n\016DeleteRespons"
-    "e\0229\n\006header\030\001 \001(\0132\037.cockroach.proto.Resp"
-    "onseHeaderB\010\310\336\037\000\320\336\037\001\"s\n\022DeleteRangeReque"
-    "st\0228\n\006header\030\001 \001(\0132\036.cockroach.proto.Req"
-    "uestHeaderB\010\310\336\037\000\320\336\037\001\022#\n\025max_entries_to_d"
-    "elete\030\002 \001(\003B\004\310\336\037\000\"k\n\023DeleteRangeResponse"
-    "\0229\n\006header\030\001 \001(\0132\037.cockroach.proto.Respo"
-    "nseHeaderB\010\310\336\037\000\320\336\037\001\022\031\n\013num_deleted\030\002 \001(\003"
-    "B\004\310\336\037\000\"b\n\013ScanRequest\0228\n\006header\030\001 \001(\0132\036."
-    "cockroach.proto.RequestHeaderB\010\310\336\037\000\320\336\037\001\022"
-    "\031\n\013max_results\030\002 \001(\003B\004\310\336\037\000\"x\n\014ScanRespon"
-    "se\0229\n\006header\030\001 \001(\0132\037.cockroach.proto.Res"
-    "ponseHeaderB\010\310\336\037\000\320\336\037\001\022-\n\004rows\030\002 \003(\0132\031.co"
-    "ckroach.proto.KeyValueB\004\310\336\037\000\"\260\001\n\025EndTran"
-    "sactionRequest\0228\n\006header\030\001 \001(\0132\036.cockroa"
-    "ch.proto.RequestHeaderB\010\310\336\037\000\320\336\037\001\022\024\n\006comm"
-    "it\030\002 \001(\010B\004\310\336\037\000\022G\n\027internal_commit_trigge"
-    "r\030\003 \001(\0132&.cockroach.proto.InternalCommit"
-    "Trigger\"n\n\026EndTransactionResponse\0229\n\006hea"
-    "der\030\001 \001(\0132\037.cockroach.proto.ResponseHead"
-    "erB\010\310\336\037\000\320\336\037\001\022\031\n\013commit_wait\030\002 \001(\003B\004\310\336\037\000\""
-    "g\n\020ReapQueueRequest\0228\n\006header\030\001 \001(\0132\036.co"
-    "ckroach.proto.RequestHeaderB\010\310\336\037\000\320\336\037\001\022\031\n"
-    "\013max_results\030\002 \001(\003B\004\310\336\037\000\"~\n\021ReapQueueRes"
-    "ponse\0229\n\006header\030\001 \001(\0132\037.cockroach.proto."
-    "ResponseHeaderB\010\310\336\037\000\320\336\037\001\022.\n\010messages\030\002 \003"
-    "(\0132\026.cockroach.proto.ValueB\004\310\336\037\000\"P\n\024Enqu"
-    "eueUpdateRequest\0228\n\006header\030\001 \001(\0132\036.cockr"
-    "oach.proto.RequestHeaderB\010\310\336\037\000\320\336\037\001\"R\n\025En"
-    "queueUpdateResponse\0229\n\006header\030\001 \001(\0132\037.co"
-    "ckroach.proto.ResponseHeaderB\010\310\336\037\000\320\336\037\001\"|"
-    "\n\025EnqueueMessageRequest\0228\n\006header\030\001 \001(\0132"
-    "\036.cockroach.proto.RequestHeaderB\010\310\336\037\000\320\336\037"
-    "\001\022)\n\003msg\030\002 \001(\0132\026.cockroach.proto.ValueB\004"
-    "\310\336\037\000\"S\n\026EnqueueMessageResponse\0229\n\006header"
+    "\336\037\001\022%\n\005value\030\002 \001(\0132\026.cockroach.proto.Val"
+    "ue\"s\n\nPutRequest\0228\n\006header\030\001 \001(\0132\036.cockr"
+    "oach.proto.RequestHeaderB\010\310\336\037\000\320\336\037\001\022+\n\005va"
+    "lue\030\002 \001(\0132\026.cockroach.proto.ValueB\004\310\336\037\000\""
+    "H\n\013PutResponse\0229\n\006header\030\001 \001(\0132\037.cockroa"
+    "ch.proto.ResponseHeaderB\010\310\336\037\000\320\336\037\001\"\251\001\n\025Co"
+    "nditionalPutRequest\0228\n\006header\030\001 \001(\0132\036.co"
+    "ckroach.proto.RequestHeaderB\010\310\336\037\000\320\336\037\001\022+\n"
+    "\005value\030\002 \001(\0132\026.cockroach.proto.ValueB\004\310\336"
+    "\037\000\022)\n\texp_value\030\003 \001(\0132\026.cockroach.proto."
+    "Value\"S\n\026ConditionalPutResponse\0229\n\006heade"
+    "r\030\001 \001(\0132\037.cockroach.proto.ResponseHeader"
+    "B\010\310\336\037\000\320\336\037\001\"e\n\020IncrementRequest\0228\n\006header"
+    "\030\001 \001(\0132\036.cockroach.proto.RequestHeaderB\010"
+    "\310\336\037\000\320\336\037\001\022\027\n\tincrement\030\002 \001(\003B\004\310\336\037\000\"g\n\021Inc"
+    "rementResponse\0229\n\006header\030\001 \001(\0132\037.cockroa"
+    "ch.proto.ResponseHeaderB\010\310\336\037\000\320\336\037\001\022\027\n\tnew"
+    "_value\030\002 \001(\003B\004\310\336\037\000\"I\n\rDeleteRequest\0228\n\006h"
+    "eader\030\001 \001(\0132\036.cockroach.proto.RequestHea"
+    "derB\010\310\336\037\000\320\336\037\001\"K\n\016DeleteResponse\0229\n\006heade"
+    "r\030\001 \001(\0132\037.cockroach.proto.ResponseHeader"
+    "B\010\310\336\037\000\320\336\037\001\"s\n\022DeleteRangeRequest\0228\n\006head"
+    "er\030\001 \001(\0132\036.cockroach.proto.RequestHeader"
+    "B\010\310\336\037\000\320\336\037\001\022#\n\025max_entries_to_delete\030\002 \001("
+    "\003B\004\310\336\037\000\"k\n\023DeleteRangeResponse\0229\n\006header"
     "\030\001 \001(\0132\037.cockroach.proto.ResponseHeaderB"
-    "\010\310\336\037\000\320\336\037\001\"\303\005\n\014RequestUnion\0224\n\010contains\030\001"
-    " \001(\0132 .cockroach.proto.ContainsRequestH\000"
-    "\022*\n\003get\030\002 \001(\0132\033.cockroach.proto.GetReque"
-    "stH\000\022*\n\003put\030\003 \001(\0132\033.cockroach.proto.PutR"
-    "equestH\000\022A\n\017conditional_put\030\004 \001(\0132&.cock"
-    "roach.proto.ConditionalPutRequestH\000\0226\n\ti"
-    "ncrement\030\005 \001(\0132!.cockroach.proto.Increme"
-    "ntRequestH\000\0220\n\006delete\030\006 \001(\0132\036.cockroach."
-    "proto.DeleteRequestH\000\022;\n\014delete_range\030\007 "
-    "\001(\0132#.cockroach.proto.DeleteRangeRequest"
-    "H\000\022,\n\004scan\030\010 \001(\0132\034.cockroach.proto.ScanR"
-    "equestH\000\022A\n\017end_transaction\030\t \001(\0132&.cock"
-    "roach.proto.EndTransactionRequestH\000\0227\n\nr"
-    "eap_queue\030\n \001(\0132!.cockroach.proto.ReapQu"
-    "eueRequestH\000\022\?\n\016enqueue_update\030\013 \001(\0132%.c"
-    "ockroach.proto.EnqueueUpdateRequestH\000\022A\n"
-    "\017enqueue_message\030\014 \001(\0132&.cockroach.proto"
-    ".EnqueueMessageRequestH\000:\004\310\240\037\001B\007\n\005value\""
-    "\320\005\n\rResponseUnion\0225\n\010contains\030\001 \001(\0132!.co"
-    "ckroach.proto.ContainsResponseH\000\022+\n\003get\030"
-    "\002 \001(\0132\034.cockroach.proto.GetResponseH\000\022+\n"
-    "\003put\030\003 \001(\0132\034.cockroach.proto.PutResponse"
-    "H\000\022B\n\017conditional_put\030\004 \001(\0132\'.cockroach."
-    "proto.ConditionalPutResponseH\000\0227\n\tincrem"
-    "ent\030\005 \001(\0132\".cockroach.proto.IncrementRes"
-    "ponseH\000\0221\n\006delete\030\006 \001(\0132\037.cockroach.prot"
-    "o.DeleteResponseH\000\022<\n\014delete_range\030\007 \001(\013"
-    "2$.cockroach.proto.DeleteRangeResponseH\000"
-    "\022-\n\004scan\030\010 \001(\0132\035.cockroach.proto.ScanRes"
-    "ponseH\000\022B\n\017end_transaction\030\t \001(\0132\'.cockr"
-    "oach.proto.EndTransactionResponseH\000\0228\n\nr"
-    "eap_queue\030\n \001(\0132\".cockroach.proto.ReapQu"
-    "eueResponseH\000\022@\n\016enqueue_update\030\013 \001(\0132&."
-    "cockroach.proto.EnqueueUpdateResponseH\000\022"
-    "B\n\017enqueue_message\030\014 \001(\0132\'.cockroach.pro"
-    "to.EnqueueMessageResponseH\000:\004\310\240\037\001B\007\n\005val"
-    "ue\"\177\n\014BatchRequest\0228\n\006header\030\001 \001(\0132\036.coc"
-    "kroach.proto.RequestHeaderB\010\310\336\037\000\320\336\037\001\0225\n\010"
-    "requests\030\002 \003(\0132\035.cockroach.proto.Request"
-    "UnionB\004\310\336\037\000\"\203\001\n\rBatchResponse\0229\n\006header\030"
-    "\001 \001(\0132\037.cockroach.proto.ResponseHeaderB\010"
-    "\310\336\037\000\320\336\037\001\0227\n\tresponses\030\002 \003(\0132\036.cockroach."
-    "proto.ResponseUnionB\004\310\336\037\000\"m\n\021AdminSplitR"
-    "equest\0228\n\006header\030\001 \001(\0132\036.cockroach.proto"
-    ".RequestHeaderB\010\310\336\037\000\320\336\037\001\022\036\n\tsplit_key\030\002 "
-    "\001(\014B\013\310\336\037\000\332\336\037\003Key\"O\n\022AdminSplitResponse\0229"
-    "\n\006header\030\001 \001(\0132\037.cockroach.proto.Respons"
-    "eHeaderB\010\310\336\037\000\320\336\037\001\"\215\001\n\021AdminMergeRequest\022"
-    "8\n\006header\030\001 \001(\0132\036.cockroach.proto.Reques"
-    "tHeaderB\010\310\336\037\000\320\336\037\001\022>\n\016subsumed_range\030\002 \001("
-    "\0132 .cockroach.proto.RangeDescriptorB\004\310\336\037"
-    "\000\"O\n\022AdminMergeResponse\0229\n\006header\030\001 \001(\0132"
+    "\010\310\336\037\000\320\336\037\001\022\031\n\013num_deleted\030\002 \001(\003B\004\310\336\037\000\"b\n\013"
+    "ScanRequest\0228\n\006header\030\001 \001(\0132\036.cockroach."
+    "proto.RequestHeaderB\010\310\336\037\000\320\336\037\001\022\031\n\013max_res"
+    "ults\030\002 \001(\003B\004\310\336\037\000\"x\n\014ScanResponse\0229\n\006head"
+    "er\030\001 \001(\0132\037.cockroach.proto.ResponseHeade"
+    "rB\010\310\336\037\000\320\336\037\001\022-\n\004rows\030\002 \003(\0132\031.cockroach.pr"
+    "oto.KeyValueB\004\310\336\037\000\"\260\001\n\025EndTransactionReq"
+    "uest\0228\n\006header\030\001 \001(\0132\036.cockroach.proto.R"
+    "equestHeaderB\010\310\336\037\000\320\336\037\001\022\024\n\006commit\030\002 \001(\010B\004"
+    "\310\336\037\000\022G\n\027internal_commit_trigger\030\003 \001(\0132&."
+    "cockroach.proto.InternalCommitTrigger\"n\n"
+    "\026EndTransactionResponse\0229\n\006header\030\001 \001(\0132"
     "\037.cockroach.proto.ResponseHeaderB\010\310\336\037\000\320\336"
-    "\037\001B\007Z\005proto", 5371);
+    "\037\001\022\031\n\013commit_wait\030\002 \001(\003B\004\310\336\037\000\"g\n\020ReapQue"
+    "ueRequest\0228\n\006header\030\001 \001(\0132\036.cockroach.pr"
+    "oto.RequestHeaderB\010\310\336\037\000\320\336\037\001\022\031\n\013max_resul"
+    "ts\030\002 \001(\003B\004\310\336\037\000\"~\n\021ReapQueueResponse\0229\n\006h"
+    "eader\030\001 \001(\0132\037.cockroach.proto.ResponseHe"
+    "aderB\010\310\336\037\000\320\336\037\001\022.\n\010messages\030\002 \003(\0132\026.cockr"
+    "oach.proto.ValueB\004\310\336\037\000\"P\n\024EnqueueUpdateR"
+    "equest\0228\n\006header\030\001 \001(\0132\036.cockroach.proto"
+    ".RequestHeaderB\010\310\336\037\000\320\336\037\001\"R\n\025EnqueueUpdat"
+    "eResponse\0229\n\006header\030\001 \001(\0132\037.cockroach.pr"
+    "oto.ResponseHeaderB\010\310\336\037\000\320\336\037\001\"|\n\025EnqueueM"
+    "essageRequest\0228\n\006header\030\001 \001(\0132\036.cockroac"
+    "h.proto.RequestHeaderB\010\310\336\037\000\320\336\037\001\022)\n\003msg\030\002"
+    " \001(\0132\026.cockroach.proto.ValueB\004\310\336\037\000\"S\n\026En"
+    "queueMessageResponse\0229\n\006header\030\001 \001(\0132\037.c"
+    "ockroach.proto.ResponseHeaderB\010\310\336\037\000\320\336\037\001\""
+    "\303\005\n\014RequestUnion\0224\n\010contains\030\001 \001(\0132 .coc"
+    "kroach.proto.ContainsRequestH\000\022*\n\003get\030\002 "
+    "\001(\0132\033.cockroach.proto.GetRequestH\000\022*\n\003pu"
+    "t\030\003 \001(\0132\033.cockroach.proto.PutRequestH\000\022A"
+    "\n\017conditional_put\030\004 \001(\0132&.cockroach.prot"
+    "o.ConditionalPutRequestH\000\0226\n\tincrement\030\005"
+    " \001(\0132!.cockroach.proto.IncrementRequestH"
+    "\000\0220\n\006delete\030\006 \001(\0132\036.cockroach.proto.Dele"
+    "teRequestH\000\022;\n\014delete_range\030\007 \001(\0132#.cock"
+    "roach.proto.DeleteRangeRequestH\000\022,\n\004scan"
+    "\030\010 \001(\0132\034.cockroach.proto.ScanRequestH\000\022A"
+    "\n\017end_transaction\030\t \001(\0132&.cockroach.prot"
+    "o.EndTransactionRequestH\000\0227\n\nreap_queue\030"
+    "\n \001(\0132!.cockroach.proto.ReapQueueRequest"
+    "H\000\022\?\n\016enqueue_update\030\013 \001(\0132%.cockroach.p"
+    "roto.EnqueueUpdateRequestH\000\022A\n\017enqueue_m"
+    "essage\030\014 \001(\0132&.cockroach.proto.EnqueueMe"
+    "ssageRequestH\000:\004\310\240\037\001B\007\n\005value\"\320\005\n\rRespon"
+    "seUnion\0225\n\010contains\030\001 \001(\0132!.cockroach.pr"
+    "oto.ContainsResponseH\000\022+\n\003get\030\002 \001(\0132\034.co"
+    "ckroach.proto.GetResponseH\000\022+\n\003put\030\003 \001(\013"
+    "2\034.cockroach.proto.PutResponseH\000\022B\n\017cond"
+    "itional_put\030\004 \001(\0132\'.cockroach.proto.Cond"
+    "itionalPutResponseH\000\0227\n\tincrement\030\005 \001(\0132"
+    "\".cockroach.proto.IncrementResponseH\000\0221\n"
+    "\006delete\030\006 \001(\0132\037.cockroach.proto.DeleteRe"
+    "sponseH\000\022<\n\014delete_range\030\007 \001(\0132$.cockroa"
+    "ch.proto.DeleteRangeResponseH\000\022-\n\004scan\030\010"
+    " \001(\0132\035.cockroach.proto.ScanResponseH\000\022B\n"
+    "\017end_transaction\030\t \001(\0132\'.cockroach.proto"
+    ".EndTransactionResponseH\000\0228\n\nreap_queue\030"
+    "\n \001(\0132\".cockroach.proto.ReapQueueRespons"
+    "eH\000\022@\n\016enqueue_update\030\013 \001(\0132&.cockroach."
+    "proto.EnqueueUpdateResponseH\000\022B\n\017enqueue"
+    "_message\030\014 \001(\0132\'.cockroach.proto.Enqueue"
+    "MessageResponseH\000:\004\310\240\037\001B\007\n\005value\"\177\n\014Batc"
+    "hRequest\0228\n\006header\030\001 \001(\0132\036.cockroach.pro"
+    "to.RequestHeaderB\010\310\336\037\000\320\336\037\001\0225\n\010requests\030\002"
+    " \003(\0132\035.cockroach.proto.RequestUnionB\004\310\336\037"
+    "\000\"\203\001\n\rBatchResponse\0229\n\006header\030\001 \001(\0132\037.co"
+    "ckroach.proto.ResponseHeaderB\010\310\336\037\000\320\336\037\001\0227"
+    "\n\tresponses\030\002 \003(\0132\036.cockroach.proto.Resp"
+    "onseUnionB\004\310\336\037\000\"m\n\021AdminSplitRequest\0228\n\006"
+    "header\030\001 \001(\0132\036.cockroach.proto.RequestHe"
+    "aderB\010\310\336\037\000\320\336\037\001\022\036\n\tsplit_key\030\002 \001(\014B\013\310\336\037\000\332"
+    "\336\037\003Key\"O\n\022AdminSplitResponse\0229\n\006header\030\001"
+    " \001(\0132\037.cockroach.proto.ResponseHeaderB\010\310"
+    "\336\037\000\320\336\037\001\"\215\001\n\021AdminMergeRequest\0228\n\006header\030"
+    "\001 \001(\0132\036.cockroach.proto.RequestHeaderB\010\310"
+    "\336\037\000\320\336\037\001\022>\n\016subsumed_range\030\002 \001(\0132 .cockro"
+    "ach.proto.RangeDescriptorB\004\310\336\037\000\"O\n\022Admin"
+    "MergeResponse\0229\n\006header\030\001 \001(\0132\037.cockroac"
+    "h.proto.ResponseHeaderB\010\310\336\037\000\320\336\037\001*L\n\023Read"
+    "ConsistencyType\022\016\n\nCONSISTENT\020\000\022\r\n\tCONSE"
+    "NSUS\020\001\022\020\n\014INCONSISTENT\020\002\032\004\210\243\036\000B\007Z\005proto", 5519);
   ::google::protobuf::MessageFactory::InternalRegisterGeneratedFile(
     "cockroach/proto/api.proto", &protobuf_RegisterTypes);
   ClientCmdID::default_instance_ = new ClientCmdID();
@@ -1139,6 +1145,21 @@ struct StaticDescriptorInitializer_cockroach_2fproto_2fapi_2eproto {
     protobuf_AddDesc_cockroach_2fproto_2fapi_2eproto();
   }
 } static_descriptor_initializer_cockroach_2fproto_2fapi_2eproto_;
+const ::google::protobuf::EnumDescriptor* ReadConsistencyType_descriptor() {
+  protobuf_AssignDescriptorsOnce();
+  return ReadConsistencyType_descriptor_;
+}
+bool ReadConsistencyType_IsValid(int value) {
+  switch(value) {
+    case 0:
+    case 1:
+    case 2:
+      return true;
+    default:
+      return false;
+  }
+}
+
 
 // ===================================================================
 
@@ -1426,6 +1447,7 @@ const int RequestHeader::kReplicaFieldNumber;
 const int RequestHeader::kRaftIdFieldNumber;
 const int RequestHeader::kUserPriorityFieldNumber;
 const int RequestHeader::kTxnFieldNumber;
+const int RequestHeader::kReadConsistencyFieldNumber;
 #endif  // !_MSC_VER
 
 RequestHeader::RequestHeader()
@@ -1460,6 +1482,7 @@ void RequestHeader::SharedCtor() {
   raft_id_ = GOOGLE_LONGLONG(0);
   user_priority_ = 1;
   txn_ = NULL;
+  read_consistency_ = 0;
   ::memset(_has_bits_, 0, sizeof(_has_bits_));
 }
 
@@ -1536,8 +1559,11 @@ void RequestHeader::Clear() {
     raft_id_ = GOOGLE_LONGLONG(0);
     user_priority_ = 1;
   }
-  if (has_txn()) {
-    if (txn_ != NULL) txn_->::cockroach::proto::Transaction::Clear();
+  if (_has_bits_[8 / 32] & 768) {
+    if (has_txn()) {
+      if (txn_ != NULL) txn_->::cockroach::proto::Transaction::Clear();
+    }
+    read_consistency_ = 0;
   }
   ::memset(_has_bits_, 0, sizeof(_has_bits_));
   mutable_unknown_fields()->Clear();
@@ -1673,6 +1699,26 @@ bool RequestHeader::MergePartialFromCodedStream(
         } else {
           goto handle_unusual;
         }
+        if (input->ExpectTag(80)) goto parse_read_consistency;
+        break;
+      }
+
+      // optional .cockroach.proto.ReadConsistencyType read_consistency = 10;
+      case 10: {
+        if (tag == 80) {
+         parse_read_consistency:
+          int value;
+          DO_((::google::protobuf::internal::WireFormatLite::ReadPrimitive<
+                   int, ::google::protobuf::internal::WireFormatLite::TYPE_ENUM>(
+                 input, &value)));
+          if (::cockroach::proto::ReadConsistencyType_IsValid(value)) {
+            set_read_consistency(static_cast< ::cockroach::proto::ReadConsistencyType >(value));
+          } else {
+            mutable_unknown_fields()->AddVarint(10, value);
+          }
+        } else {
+          goto handle_unusual;
+        }
         if (input->ExpectAtEnd()) goto success;
         break;
       }
@@ -1758,6 +1804,12 @@ void RequestHeader::SerializeWithCachedSizes(
       9, this->txn(), output);
   }
 
+  // optional .cockroach.proto.ReadConsistencyType read_consistency = 10;
+  if (has_read_consistency()) {
+    ::google::protobuf::internal::WireFormatLite::WriteEnum(
+      10, this->read_consistency(), output);
+  }
+
   if (!unknown_fields().empty()) {
     ::google::protobuf::internal::WireFormat::SerializeUnknownFields(
         unknown_fields(), output);
@@ -1829,6 +1881,12 @@ void RequestHeader::SerializeWithCachedSizes(
     target = ::google::protobuf::internal::WireFormatLite::
       WriteMessageNoVirtualToArray(
         9, this->txn(), target);
+  }
+
+  // optional .cockroach.proto.ReadConsistencyType read_consistency = 10;
+  if (has_read_consistency()) {
+    target = ::google::protobuf::internal::WireFormatLite::WriteEnumToArray(
+      10, this->read_consistency(), target);
   }
 
   if (!unknown_fields().empty()) {
@@ -1908,6 +1966,12 @@ int RequestHeader::ByteSize() const {
           this->txn());
     }
 
+    // optional .cockroach.proto.ReadConsistencyType read_consistency = 10;
+    if (has_read_consistency()) {
+      total_size += 1 +
+        ::google::protobuf::internal::WireFormatLite::EnumSize(this->read_consistency());
+    }
+
   }
   if (!unknown_fields().empty()) {
     total_size +=
@@ -1964,6 +2028,9 @@ void RequestHeader::MergeFrom(const RequestHeader& from) {
     if (from.has_txn()) {
       mutable_txn()->::cockroach::proto::Transaction::MergeFrom(from.txn());
     }
+    if (from.has_read_consistency()) {
+      set_read_consistency(from.read_consistency());
+    }
   }
   mutable_unknown_fields()->MergeFrom(from.unknown_fields());
 }
@@ -1996,6 +2063,7 @@ void RequestHeader::Swap(RequestHeader* other) {
     std::swap(raft_id_, other->raft_id_);
     std::swap(user_priority_, other->user_priority_);
     std::swap(txn_, other->txn_);
+    std::swap(read_consistency_, other->read_consistency_);
     std::swap(_has_bits_[0], other->_has_bits_[0]);
     _unknown_fields_.Swap(&other->_unknown_fields_);
     std::swap(_cached_size_, other->_cached_size_);

--- a/storage/engine/cockroach/proto/api.pb.h
+++ b/storage/engine/cockroach/proto/api.pb.h
@@ -23,6 +23,7 @@
 #include <google/protobuf/message.h>
 #include <google/protobuf/repeated_field.h>
 #include <google/protobuf/extension_set.h>
+#include <google/protobuf/generated_enum_reflection.h>
 #include <google/protobuf/unknown_field_set.h>
 #include "cockroach/proto/config.pb.h"
 #include "cockroach/proto/data.pb.h"
@@ -74,6 +75,26 @@ class AdminSplitResponse;
 class AdminMergeRequest;
 class AdminMergeResponse;
 
+enum ReadConsistencyType {
+  CONSISTENT = 0,
+  CONSENSUS = 1,
+  INCONSISTENT = 2
+};
+bool ReadConsistencyType_IsValid(int value);
+const ReadConsistencyType ReadConsistencyType_MIN = CONSISTENT;
+const ReadConsistencyType ReadConsistencyType_MAX = INCONSISTENT;
+const int ReadConsistencyType_ARRAYSIZE = ReadConsistencyType_MAX + 1;
+
+const ::google::protobuf::EnumDescriptor* ReadConsistencyType_descriptor();
+inline const ::std::string& ReadConsistencyType_Name(ReadConsistencyType value) {
+  return ::google::protobuf::internal::NameOfEnum(
+    ReadConsistencyType_descriptor(), value);
+}
+inline bool ReadConsistencyType_Parse(
+    const ::std::string& name, ReadConsistencyType* value) {
+  return ::google::protobuf::internal::ParseNamedEnum<ReadConsistencyType>(
+    ReadConsistencyType_descriptor(), name, value);
+}
 // ===================================================================
 
 class ClientCmdID : public ::google::protobuf::Message {
@@ -304,6 +325,13 @@ class RequestHeader : public ::google::protobuf::Message {
   inline ::cockroach::proto::Transaction* release_txn();
   inline void set_allocated_txn(::cockroach::proto::Transaction* txn);
 
+  // optional .cockroach.proto.ReadConsistencyType read_consistency = 10;
+  inline bool has_read_consistency() const;
+  inline void clear_read_consistency();
+  static const int kReadConsistencyFieldNumber = 10;
+  inline ::cockroach::proto::ReadConsistencyType read_consistency() const;
+  inline void set_read_consistency(::cockroach::proto::ReadConsistencyType value);
+
   // @@protoc_insertion_point(class_scope:cockroach.proto.RequestHeader)
  private:
   inline void set_has_timestamp();
@@ -324,6 +352,8 @@ class RequestHeader : public ::google::protobuf::Message {
   inline void clear_has_user_priority();
   inline void set_has_txn();
   inline void clear_has_txn();
+  inline void set_has_read_consistency();
+  inline void clear_has_read_consistency();
 
   ::google::protobuf::UnknownFieldSet _unknown_fields_;
 
@@ -338,6 +368,7 @@ class RequestHeader : public ::google::protobuf::Message {
   ::google::protobuf::int64 raft_id_;
   ::cockroach::proto::Transaction* txn_;
   ::google::protobuf::int32 user_priority_;
+  int read_consistency_;
   friend void  protobuf_AddDesc_cockroach_2fproto_2fapi_2eproto();
   friend void protobuf_AssignDesc_cockroach_2fproto_2fapi_2eproto();
   friend void protobuf_ShutdownFile_cockroach_2fproto_2fapi_2eproto();
@@ -4072,6 +4103,31 @@ inline void RequestHeader::set_allocated_txn(::cockroach::proto::Transaction* tx
   // @@protoc_insertion_point(field_set_allocated:cockroach.proto.RequestHeader.txn)
 }
 
+// optional .cockroach.proto.ReadConsistencyType read_consistency = 10;
+inline bool RequestHeader::has_read_consistency() const {
+  return (_has_bits_[0] & 0x00000200u) != 0;
+}
+inline void RequestHeader::set_has_read_consistency() {
+  _has_bits_[0] |= 0x00000200u;
+}
+inline void RequestHeader::clear_has_read_consistency() {
+  _has_bits_[0] &= ~0x00000200u;
+}
+inline void RequestHeader::clear_read_consistency() {
+  read_consistency_ = 0;
+  clear_has_read_consistency();
+}
+inline ::cockroach::proto::ReadConsistencyType RequestHeader::read_consistency() const {
+  // @@protoc_insertion_point(field_get:cockroach.proto.RequestHeader.read_consistency)
+  return static_cast< ::cockroach::proto::ReadConsistencyType >(read_consistency_);
+}
+inline void RequestHeader::set_read_consistency(::cockroach::proto::ReadConsistencyType value) {
+  assert(::cockroach::proto::ReadConsistencyType_IsValid(value));
+  set_has_read_consistency();
+  read_consistency_ = value;
+  // @@protoc_insertion_point(field_set:cockroach.proto.RequestHeader.read_consistency)
+}
+
 // -------------------------------------------------------------------
 
 // ResponseHeader
@@ -7316,6 +7372,11 @@ inline void AdminMergeResponse::set_allocated_header(::cockroach::proto::Respons
 namespace google {
 namespace protobuf {
 
+template <> struct is_proto_enum< ::cockroach::proto::ReadConsistencyType> : ::google::protobuf::internal::true_type {};
+template <>
+inline const EnumDescriptor* GetEnumDescriptor< ::cockroach::proto::ReadConsistencyType>() {
+  return ::cockroach::proto::ReadConsistencyType_descriptor();
+}
 
 }  // namespace google
 }  // namespace protobuf

--- a/storage/engine/mvcc_test.go
+++ b/storage/engine/mvcc_test.go
@@ -517,6 +517,7 @@ func TestMVCCGetWriteIntentError(t *testing.T) {
 // TestMVCCGetInconsistent verifies the behavior of get with
 // consistent set to false.
 func TestMVCCGetInconsistent(t *testing.T) {
+	defer leaktest.AfterTest(t)
 	engine := createTestEngine()
 
 	// Put two values to key 1, the latest with a txn.

--- a/storage/engine/mvcc_test.go
+++ b/storage/engine/mvcc_test.go
@@ -515,7 +515,7 @@ func TestMVCCGetWriteIntentError(t *testing.T) {
 }
 
 // TestMVCCGetInconsistent verifies the behavior of get with
-// inconsistent set to true.
+// consistent set to false.
 func TestMVCCGetInconsistent(t *testing.T) {
 	engine := createTestEngine()
 

--- a/storage/engine/rocksdb_test.go
+++ b/storage/engine/rocksdb_test.go
@@ -117,7 +117,7 @@ func TestRocksDBCompaction(t *testing.T) {
 
 	// Compact range and scan remaining values to compare.
 	rocksdb.CompactRange(nil, nil)
-	actualKVs, err := MVCCScan(rocksdb, KeyMin, KeyMax, 0, proto.ZeroTimestamp, nil)
+	actualKVs, err := MVCCScan(rocksdb, KeyMin, KeyMax, 0, proto.ZeroTimestamp, true, nil)
 	if err != nil {
 		t.Fatalf("could not run scan: %v", err)
 	}
@@ -236,7 +236,7 @@ func runMVCCScan(numRows, numVersions int, b *testing.B) {
 			startKey := proto.Key(encoding.EncodeUvarint(keyBuf[0:4], uint64(keyIdx)))
 			walltime := int64(5 * (rand.Int31n(int32(numVersions)) + 1))
 			ts := makeTS(walltime, 0)
-			kvs, err := MVCCScan(rocksdb, startKey, KeyMax, int64(numRows), ts, nil)
+			kvs, err := MVCCScan(rocksdb, startKey, KeyMax, int64(numRows), ts, true, nil)
 			if err != nil {
 				b.Fatalf("failed scan: %s", err)
 			}
@@ -325,7 +325,7 @@ func runMVCCGet(numVersions int, b *testing.B) {
 			key := proto.Key(encoding.EncodeUvarint(keyBuf[0:4], uint64(keyIdx)))
 			walltime := int64(5 * (rand.Int31n(int32(numVersions)) + 1))
 			ts := makeTS(walltime, 0)
-			if v, err := MVCCGet(rocksdb, key, ts, nil); err != nil {
+			if v, err := MVCCGet(rocksdb, key, ts, true, nil); err != nil {
 				b.Fatalf("failed get: %s", err)
 			} else if len(v.Bytes) != 1024 {
 				b.Fatalf("unexpected value size: %d", len(v.Bytes))
@@ -462,7 +462,7 @@ func runMVCCMerge(value *proto.Value, numKeys int, b *testing.B) {
 
 	// Read values out to force merge.
 	for _, key := range keys {
-		val, err := MVCCGet(rocksdb, key, proto.ZeroTimestamp, nil)
+		val, err := MVCCGet(rocksdb, key, proto.ZeroTimestamp, true, nil)
 		if err != nil {
 			b.Fatal(err)
 		} else if val == nil {

--- a/storage/range_test.go
+++ b/storage/range_test.go
@@ -23,7 +23,6 @@ import (
 	"math"
 	"reflect"
 	"regexp"
-	"sync"
 	"sync/atomic"
 	"testing"
 	"time"
@@ -407,66 +406,6 @@ func TestRangeGossipConfigUpdates(t *testing.T) {
 	}
 }
 
-// A blockingEngine allows us to delay get/put (but not other ops!).
-// It works by allowing a single key to be primed for a delay. When
-// a get/put ops arrives for that key, it's blocked via a mutex
-// until unblock() is invoked.
-type blockingEngine struct {
-	blocker sync.Mutex // blocks Get() and Put()
-	*engine.InMem
-	sync.Mutex // protects key
-	key        proto.EncodedKey
-}
-
-func newBlockingEngine() *blockingEngine {
-	be := &blockingEngine{
-		InMem: engine.NewInMem(proto.Attributes{}, 1<<20),
-	}
-	return be
-}
-
-func (be *blockingEngine) block(key proto.Key) {
-	be.Lock()
-	defer be.Unlock()
-	// Need to binary encode the key so it matches when accessed through MVCC.
-	be.key = engine.MVCCEncodeKey(key)
-	// Get() and Put() will try to get this lock, so they will wait.
-	be.blocker.Lock()
-}
-
-func (be *blockingEngine) unblock() {
-	be.blocker.Unlock()
-}
-
-func (be *blockingEngine) wait() {
-	be.blocker.Lock()
-	be.blocker.Unlock()
-}
-
-func (be *blockingEngine) Get(key proto.EncodedKey) ([]byte, error) {
-	be.Lock()
-	if bytes.Equal(key, be.key) {
-		be.key = nil
-		defer be.wait()
-	}
-	be.Unlock()
-	return be.InMem.Get(key)
-}
-
-func (be *blockingEngine) Put(key proto.EncodedKey, value []byte) error {
-	be.Lock()
-	if bytes.Equal(key, be.key) {
-		be.key = nil
-		defer be.wait()
-	}
-	be.Unlock()
-	return be.InMem.Put(key, value)
-}
-
-func (be *blockingEngine) NewBatch() engine.Engine {
-	return engine.NewBatch(be)
-}
-
 // getArgs returns a GetRequest and GetResponse pair addressed to
 // the default replica for the specified key.
 func getArgs(key []byte, raftID int64, storeID proto.StoreID) (*proto.GetRequest, *proto.GetResponse) {
@@ -709,12 +648,19 @@ func TestRangeUpdateTSCache(t *testing.T) {
 // range.
 func TestRangeCommandQueue(t *testing.T) {
 	defer leaktest.AfterTest(t)
-	be := newBlockingEngine()
-	tc := testContext{
-		engine: be,
-	}
+	tc := testContext{}
 	tc.Start(t)
 	defer tc.Stop()
+	defer func() { TestingCommandFilter = nil }()
+
+	// Intercept commands with matching command IDs and block them.
+	blockingDone := make(chan struct{}, 1)
+	TestingCommandFilter = func(method string, args proto.Request, reply proto.Response) bool {
+		if args.Header().User == "Foo" {
+			<-blockingDone
+		}
+		return false
+	}
 
 	// Test all four combinations of reads & writes waiting.
 	testCases := []struct {
@@ -733,11 +679,10 @@ func TestRangeCommandQueue(t *testing.T) {
 		key1 := proto.Key(fmt.Sprintf("key1-%d", i))
 		key2 := proto.Key(fmt.Sprintf("key2-%d", i))
 		// Asynchronously put a value to the rng with blocking enabled.
-		be.block(key1)
 		cmd1Done := make(chan struct{})
 		go func() {
-			method, args, reply := readOrWriteArgs(key1, test.cmd1Read, tc.rng.Desc().RaftID,
-				tc.store.StoreID())
+			method, args, reply := readOrWriteArgs(key1, test.cmd1Read, tc.rng.Desc().RaftID, tc.store.StoreID())
+			args.Header().User = "Foo"
 			err := tc.rng.AddCmd(method, args, reply, true)
 			if err != nil {
 				t.Fatalf("test %d: %s", i, err)
@@ -748,8 +693,7 @@ func TestRangeCommandQueue(t *testing.T) {
 		// First, try a command for same key as cmd1 to verify it blocks.
 		cmd2Done := make(chan struct{})
 		go func() {
-			method, args, reply := readOrWriteArgs(key1, test.cmd2Read, tc.rng.Desc().RaftID,
-				tc.store.StoreID())
+			method, args, reply := readOrWriteArgs(key1, test.cmd2Read, tc.rng.Desc().RaftID, tc.store.StoreID())
 			err := tc.rng.AddCmd(method, args, reply, true)
 			if err != nil {
 				t.Fatalf("test %d: %s", i, err)
@@ -792,13 +736,71 @@ func TestRangeCommandQueue(t *testing.T) {
 			<-cmd3Done
 		}
 
-		be.unblock()
+		blockingDone <- struct{}{}
 		select {
 		case <-cmd2Done:
 			// success.
 		case <-time.After(500 * time.Millisecond):
 			t.Fatalf("test %d: waited 500ms for cmd2 of key1", i)
 		}
+	}
+}
+
+// TestRangeCommandQueueInconsistent verifies that inconsistent reads need
+// not wait for pending commands to complete through Raft.
+func TestRangeCommandQueueInconsistent(t *testing.T) {
+	defer leaktest.AfterTest(t)
+	tc := testContext{}
+	tc.Start(t)
+	defer tc.Stop()
+	defer func() { TestingCommandFilter = nil }()
+
+	key := proto.Key("key1")
+	blockingDone := make(chan struct{})
+	TestingCommandFilter = func(method string, args proto.Request, reply proto.Response) bool {
+		if args.Header().CmdID.Random == 1 {
+			<-blockingDone
+		}
+		return false
+	}
+	cmd1Done := make(chan struct{})
+	go func() {
+		args, reply := putArgs(key, []byte("value"), tc.rng.Desc().RaftID, tc.store.StoreID())
+		args.CmdID.Random = 1
+		err := tc.rng.AddCmd(proto.Put, args, reply, true)
+		if err != nil {
+			t.Fatal(err)
+		}
+		close(cmd1Done)
+	}()
+
+	// An inconsistent read to the key won't wait.
+	cmd2Done := make(chan struct{})
+	go func() {
+		args, reply := getArgs(key, tc.rng.Desc().RaftID, tc.store.StoreID())
+		args.ReadConsistency = proto.INCONSISTENT
+		err := tc.rng.AddCmd(proto.Get, args, reply, true)
+		if err != nil {
+			t.Fatal(err)
+		}
+		close(cmd2Done)
+	}()
+
+	select {
+	case <-cmd2Done:
+		// success.
+	case <-cmd1Done:
+		t.Fatalf("cmd1 should have been blocked")
+	case <-time.After(500 * time.Millisecond):
+		t.Fatalf("waited 500ms for cmd2 of key")
+	}
+
+	close(blockingDone)
+	select {
+	case <-cmd1Done:
+		// success.
+	case <-time.After(500 * time.Millisecond):
+		t.Fatalf("waited 500ms for cmd2 of key")
 	}
 }
 
@@ -824,7 +826,34 @@ func TestRangeUseTSCache(t *testing.T) {
 		t.Fatal(err)
 	}
 	if pReply.Timestamp.WallTime != tc.clock.Timestamp().WallTime {
-		t.Errorf("expected write timestamp to upgrade to 1s; got %+v", pReply.Timestamp)
+		t.Errorf("expected write timestamp to upgrade to 1s; got %s", pReply.Timestamp)
+	}
+}
+
+// TestRangeNoTSCacheInconsistent verifies that the timestamp cache
+// is no affected by inconsistent reads.
+func TestRangeNoTSCacheInconsistent(t *testing.T) {
+	defer leaktest.AfterTest(t)
+	tc := testContext{}
+	tc.Start(t)
+	defer tc.Stop()
+	// Set clock to time 1s and do the read.
+	t0 := 1 * time.Second
+	tc.manualClock.Set(t0.Nanoseconds())
+	args, reply := getArgs([]byte("a"), 1, tc.store.StoreID())
+	args.Timestamp = tc.clock.Now()
+	args.ReadConsistency = proto.INCONSISTENT
+	err := tc.rng.AddCmd(proto.Get, args, reply, true)
+	if err != nil {
+		t.Error(err)
+	}
+	pArgs, pReply := putArgs([]byte("a"), []byte("value"), 1, tc.store.StoreID())
+	err = tc.rng.AddCmd(proto.Put, pArgs, pReply, true)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if pReply.Timestamp.WallTime == tc.clock.Timestamp().WallTime {
+		t.Errorf("expected write timestamp not to upgrade to 1s; got %s", pReply.Timestamp)
 	}
 }
 

--- a/storage/range_test.go
+++ b/storage/range_test.go
@@ -239,6 +239,7 @@ func TestRangeContains(t *testing.T) {
 }
 
 func TestRangeCanService(t *testing.T) {
+	defer leaktest.AfterTest(t)
 	tc := testContext{}
 	tc.Start(t)
 	defer tc.Stop()

--- a/storage/store_test.go
+++ b/storage/store_test.go
@@ -938,6 +938,7 @@ func TestStoreResolveWriteIntentNoTxn(t *testing.T) {
 // TestStoreReadInconsistent verifies that gets and scans with
 // read consistency set to INCONSISTENT ignore extant intents.
 func TestStoreReadInconsistent(t *testing.T) {
+	defer leaktest.AfterTest(t)
 	store, _ := createTestStore(t)
 	defer store.Stop()
 

--- a/util/testing.go
+++ b/util/testing.go
@@ -78,7 +78,8 @@ func CreateTestAddr(network string) net.Addr {
 
 // IsTrueWithin returns an error if the supplied function fails to
 // evaluate to true within the specified duration. The function is
-// invoked at most 10 times over the course of the specified time
+// invoked immediately at first and then successively with an
+// exponential backoff starting at 1ns and ending at the specified
 // duration.
 func IsTrueWithin(trueFunc func() bool, duration time.Duration) error {
 	total := time.Duration(0)


### PR DESCRIPTION
MVCCGet and MVCCScan now take a "consistent" boolean which, if false,
ignores intents. Moved the guts of MVCCScan into MVCCIterate and MVCCScan
just calls into it. This change allows the removal of the MVCCIterateCommitted
method.

Provides a unittest for "deadloop" issue of encountering an extant intent
at a meta indexing record.

Fixes #343
Fixes #435
