### PR TITLE
Yet another tiny fix: Do not export RegisterHandlers()

### DIFF
--- a/server/admin.go
+++ b/server/admin.go
@@ -85,9 +85,9 @@ func newAdminServer(db *client.KV) *adminServer {
 	}
 }
 
-// RegisterHandlers registers admin handlers with the supplied
+// registerHandlers registers admin handlers with the supplied
 // serve mux.
-func (s *adminServer) RegisterHandlers(mux *http.ServeMux) {
+func (s *adminServer) registerHandlers(mux *http.ServeMux) {
 	// Pass through requests to /debug to the default serve mux so we
 	// get exported variables and pprof tools.
 	mux.HandleFunc(acctPathPrefix, s.handleAcctAction)

--- a/server/admin_test.go
+++ b/server/admin_test.go
@@ -42,7 +42,7 @@ func startAdminServer() *httptest.Server {
 	}
 	admin := newAdminServer(db)
 	mux := http.NewServeMux()
-	admin.RegisterHandlers(mux)
+	admin.registerHandlers(mux)
 	httpServer := httptest.NewServer(mux)
 	if strings.HasPrefix(httpServer.URL, "http://") {
 		testContext.Addr = strings.TrimPrefix(httpServer.URL, "http://")

--- a/server/server.go
+++ b/server/server.go
@@ -168,10 +168,10 @@ func (s *Server) initHTTP() {
 		&assetfs.AssetFS{Asset: resource.Asset, AssetDir: resource.AssetDir, Prefix: "./ui/"}))
 
 	// Admin handlers.
-	s.admin.RegisterHandlers(s.mux)
+	s.admin.registerHandlers(s.mux)
 
 	// Status endpoints:
-	s.status.RegisterHandlers(s.mux)
+	s.status.registerHandlers(s.mux)
 
 	s.mux.Handle(kv.RESTPrefix, s.kvREST)
 	s.mux.Handle(kv.DBPrefix, s.kvDB)

--- a/server/status.go
+++ b/server/status.go
@@ -75,9 +75,9 @@ func newStatusServer(db *client.KV, gossip *gossip.Gossip) *statusServer {
 	}
 }
 
-// RegisterHandlers registers admin handlers with the supplied
+// registerHandlers registers admin handlers with the supplied
 // serve mux.
-func (s *statusServer) RegisterHandlers(mux *http.ServeMux) {
+func (s *statusServer) registerHandlers(mux *http.ServeMux) {
 	mux.HandleFunc(statusKeyPrefix, s.handleStatus)
 	mux.HandleFunc(statusGossipKeyPrefix, s.handleGossipStatus)
 	mux.HandleFunc(statusLocalKeyPrefix, s.handleLocalStatus)

--- a/server/status_test.go
+++ b/server/status_test.go
@@ -41,7 +41,7 @@ func startStatusServer() *httptest.Server {
 	}
 	status := newStatusServer(db, nil)
 	mux := http.NewServeMux()
-	status.RegisterHandlers(mux)
+	status.registerHandlers(mux)
 	httpServer := httptest.NewServer(mux)
 	return httpServer
 }


### PR DESCRIPTION
The methods are not called outside of the 'server' package.
