### PR TITLE
Downgrade raft's info logging to glog.V(1).

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -33,8 +33,8 @@ test:
     # Check whether the committer forgot to run `go generate`.
     # Either `go generate` does not change any files or it does, in which case we print the diff and fail.
     - docker run cockroachdb/cockroach-dev shell "(go generate ./... && git ls-files --modified --deleted --others --exclude-standard | diff /dev/null -) || (git add -A && git diff -u HEAD && false)" | tee "${CIRCLE_ARTIFACTS}/generate.log"; test ${PIPESTATUS[0]} -eq 0
-    - docker run "cockroachdb/cockroach-dev" test TESTFLAGS='-v -logtostderr -timeout 30s -vmodule=multiraft=5' > "${CIRCLE_ARTIFACTS}/test.log"
-    - docker run "cockroachdb/cockroach-dev" testrace RACEFLAGS='-v -logtostderr -timeout 5m -vmodule=multiraft=5' > "${CIRCLE_ARTIFACTS}/testrace.log"
+    - docker run "cockroachdb/cockroach-dev" test TESTFLAGS='-v -logtostderr -timeout 30s -vmodule=multiraft=5,raft=1' > "${CIRCLE_ARTIFACTS}/test.log"
+    - docker run "cockroachdb/cockroach-dev" testrace RACEFLAGS='-v -logtostderr -timeout 5m -vmodule=multiraft=5,raft=1' > "${CIRCLE_ARTIFACTS}/testrace.log"
       # Kill off the previous images since we don't care for them any more,
       # but we do want to save the logs for the following ones.
       # `docker rm` actually errors on CircleCI but still works, hence the ';'.

--- a/multiraft/raft.go
+++ b/multiraft/raft.go
@@ -34,28 +34,38 @@ func init() {
 // (at least in the go 1.4 compiler), methods on a value type called through
 // an interface pointer go through an additional layer of indirection that
 // appears on the stack, and would make all our stack frame offsets incorrect.
+//
+// Raft is fairly verbose at the "info" level, so we map "info" messages to
+// glog.V(1) and "debug" messages to glog.V(2).
+//
+// This file is named raft.go instead of something like logger.go because this
+// file's name is used to determine the vmodule parameter: --vmodule=raft=1
 type glogLogger struct{}
 
 func (*glogLogger) Debug(v ...interface{}) {
-	if log.V(1) {
+	if log.V(2) {
 		log.InfoDepth(1, v...)
 	}
 }
 
 func (*glogLogger) Debugf(format string, v ...interface{}) {
-	s := fmt.Sprintf(format, v...)
-	if log.V(1) {
+	if log.V(2) {
+		s := fmt.Sprintf(format, v...)
 		log.InfoDepth(1, s)
 	}
 }
 
 func (*glogLogger) Info(v ...interface{}) {
-	log.InfoDepth(1, v...)
+	if log.V(1) {
+		log.InfoDepth(1, v...)
+	}
 }
 
 func (*glogLogger) Infof(format string, v ...interface{}) {
-	s := fmt.Sprintf(format, v...)
-	log.InfoDepth(1, s)
+	if log.V(1) {
+		s := fmt.Sprintf(format, v...)
+		log.InfoDepth(1, s)
+	}
 }
 
 func (*glogLogger) Warning(v ...interface{}) {


### PR DESCRIPTION
With many consensus groups, raft's logging can be quite verbose.

Turn on raft=1 logging in the tests that use --vmodule=multiraft=5.
