### PR TITLE
Move raft timeout parameters into a storage.StoreConfig struct.

### DIFF
--- a/kv/local_sender_test.go
+++ b/kv/local_sender_test.go
@@ -41,7 +41,7 @@ func TestLocalSenderAddStore(t *testing.T) {
 	}
 }
 
-func TesLocalSendertGetStoreCount(t *testing.T) {
+func TestLocalSenderGetStoreCount(t *testing.T) {
 	ls := NewLocalSender()
 	if ls.GetStoreCount() != 0 {
 		t.Errorf("expected 0 stores in new local sender")
@@ -129,7 +129,7 @@ func TestLocalSenderLookupReplica(t *testing.T) {
 	db := client.NewKV(NewTxnCoordSender(ls, clock, false), nil)
 	transport := multiraft.NewLocalRPCTransport()
 	defer transport.Close()
-	store := storage.NewStore(clock, eng, db, nil, transport)
+	store := storage.NewStore(clock, eng, db, nil, transport, storage.TestStoreConfig)
 	if err := store.Bootstrap(proto.StoreIdent{NodeID: 1, StoreID: 1}); err != nil {
 		t.Fatal(err)
 	}
@@ -160,7 +160,7 @@ func TestLocalSenderLookupReplica(t *testing.T) {
 		e[i] = engine.NewInMem(proto.Attributes{}, 1<<20)
 		transport := multiraft.NewLocalRPCTransport()
 		defer transport.Close()
-		s[i] = storage.NewStore(clock, e[i], db, nil, transport)
+		s[i] = storage.NewStore(clock, e[i], db, nil, transport, storage.TestStoreConfig)
 		s[i].Ident.StoreID = rng.storeID
 		if err := s[i].Bootstrap(proto.StoreIdent{NodeID: 1, StoreID: rng.storeID}); err != nil {
 			t.Fatal(err)

--- a/kv/txn_coord_sender_test.go
+++ b/kv/txn_coord_sender_test.go
@@ -52,7 +52,7 @@ func createTestDB() (db *client.KV, eng engine.Engine, clock *hlc.Clock,
 	db = client.NewKV(sender, nil)
 	db.User = storage.UserRoot
 	transport = multiraft.NewLocalRPCTransport()
-	store := storage.NewStore(clock, eng, db, g, transport)
+	store := storage.NewStore(clock, eng, db, g, transport, storage.TestStoreConfig)
 	if err = store.Bootstrap(proto.StoreIdent{NodeID: 1, StoreID: 1}); err != nil {
 		return
 	}

--- a/server/node_test.go
+++ b/server/node_test.go
@@ -64,7 +64,7 @@ func createTestNode(addr net.Addr, engines []engine.Engine, gossipBS net.Addr, t
 		g.Start(rpcServer)
 	}
 	db := client.NewKV(kv.NewDistSender(g), nil)
-	node := NewNode(db, g)
+	node := NewNode(db, g, storage.TestStoreConfig)
 	if err := node.start(rpcServer, clock, engines, proto.Attributes{}); err != nil {
 		t.Fatal(err)
 	}

--- a/server/server.go
+++ b/server/server.go
@@ -115,7 +115,8 @@ func NewServer(ctx *Context) (*Server, error) {
 
 	s.kvDB = kv.NewDBServer(sender)
 	s.kvREST = kv.NewRESTServer(s.kv)
-	s.node = NewNode(s.kv, s.gossip)
+	// TODO(bdarnell): make StoreConfig configurable.
+	s.node = NewNode(s.kv, s.gossip, storage.StoreConfig{})
 	s.admin = newAdminServer(s.kv)
 	s.status = newStatusServer(s.kv, s.gossip)
 	s.structuredDB = structured.NewDB(s.kv)

--- a/storage/client_test.go
+++ b/storage/client_test.go
@@ -64,7 +64,8 @@ func createTestStoreWithEngine(t *testing.T, eng engine.Engine, clock *hlc.Clock
 	db := client.NewKV(sender, nil)
 	db.User = storage.UserRoot
 	// TODO(bdarnell): arrange to have the transport closed.
-	store := storage.NewStore(clock, eng, db, g, multiraft.NewLocalRPCTransport())
+	store := storage.NewStore(clock, eng, db, g, multiraft.NewLocalRPCTransport(),
+		storage.TestStoreConfig)
 	if bootstrap {
 		if err := store.Bootstrap(proto.StoreIdent{NodeID: 1, StoreID: 1}); err != nil {
 			t.Fatal(err)
@@ -131,7 +132,7 @@ func (m *multiTestContext) Stop() {
 // AddStore creates a new store on the same Transport but doesn't create any ranges.
 func (m *multiTestContext) addStore(t *testing.T) {
 	eng := engine.NewInMem(proto.Attributes{}, 1<<20)
-	store := storage.NewStore(m.clock, eng, m.db, m.gossip, m.transport)
+	store := storage.NewStore(m.clock, eng, m.db, m.gossip, m.transport, storage.TestStoreConfig)
 	err := store.Bootstrap(proto.StoreIdent{
 		NodeID:  proto.NodeID(len(m.stores) + 1),
 		StoreID: proto.StoreID(len(m.stores) + 1),
@@ -163,7 +164,8 @@ func (m *multiTestContext) StopStore(i int) {
 
 // RetartStore restarts a store previously stopped with StopStore.
 func (m *multiTestContext) RestartStore(i int, t *testing.T) {
-	m.stores[i] = storage.NewStore(m.clock, m.engines[i], m.db, m.gossip, m.transport)
+	m.stores[i] = storage.NewStore(m.clock, m.engines[i], m.db, m.gossip, m.transport,
+		storage.TestStoreConfig)
 	if err := m.stores[i].Start(); err != nil {
 		t.Fatal(err)
 	}

--- a/storage/range_test.go
+++ b/storage/range_test.go
@@ -127,7 +127,7 @@ func (tc *testContext) Start(t *testing.T) {
 	}
 
 	if tc.store == nil {
-		tc.store = NewStore(tc.clock, tc.engine, nil, tc.gossip, tc.transport)
+		tc.store = NewStore(tc.clock, tc.engine, nil, tc.gossip, tc.transport, TestStoreConfig)
 		if err := tc.store.Bootstrap(proto.StoreIdent{NodeID: 1, StoreID: 1}); err != nil {
 			t.Fatal(err)
 		}
@@ -214,7 +214,7 @@ func TestRangeContains(t *testing.T) {
 	clock := hlc.NewClock(hlc.UnixNano)
 	transport := multiraft.NewLocalRPCTransport()
 	defer transport.Close()
-	store := NewStore(clock, e, nil, nil, multiraft.NewLocalRPCTransport())
+	store := NewStore(clock, e, nil, nil, multiraft.NewLocalRPCTransport(), TestStoreConfig)
 	defer store.Stop()
 	r, err := NewRange(desc, store)
 	if err != nil {

--- a/storage/store_test.go
+++ b/storage/store_test.go
@@ -98,7 +98,7 @@ func createTestStore(t *testing.T) (*Store, *hlc.ManualClock) {
 	clock := hlc.NewClock(manual.UnixNano)
 	eng := engine.NewInMem(proto.Attributes{}, 10<<20)
 	// TODO(bdarnell): arrange to have the transport closed.
-	store := NewStore(clock, eng, nil, g, multiraft.NewLocalRPCTransport())
+	store := NewStore(clock, eng, nil, g, multiraft.NewLocalRPCTransport(), TestStoreConfig)
 	if err := store.Bootstrap(proto.StoreIdent{NodeID: 1, StoreID: 1}); err != nil {
 		t.Fatal(err)
 	}
@@ -120,7 +120,7 @@ func TestStoreInitAndBootstrap(t *testing.T) {
 	eng := engine.NewInMem(proto.Attributes{}, 1<<20)
 	transport := multiraft.NewLocalRPCTransport()
 	defer transport.Close()
-	store := NewStore(clock, eng, nil, nil, transport)
+	store := NewStore(clock, eng, nil, nil, transport, TestStoreConfig)
 
 	// Can't start as haven't bootstrapped.
 	if err := store.Start(); err == nil {
@@ -144,7 +144,7 @@ func TestStoreInitAndBootstrap(t *testing.T) {
 	}
 
 	// Now, attempt to initialize a store with a now-bootstrapped range.
-	store = NewStore(clock, eng, nil, nil, transport)
+	store = NewStore(clock, eng, nil, nil, transport, TestStoreConfig)
 	if err := store.Start(); err != nil {
 		t.Errorf("failure initializing bootstrapped store: %s", err)
 	}
@@ -167,7 +167,7 @@ func TestBootstrapOfNonEmptyStore(t *testing.T) {
 	manual := hlc.NewManualClock(0)
 	clock := hlc.NewClock(manual.UnixNano)
 	transport := multiraft.NewLocalRPCTransport()
-	store := NewStore(clock, eng, nil, nil, transport)
+	store := NewStore(clock, eng, nil, nil, transport, TestStoreConfig)
 
 	// Can't init as haven't bootstrapped.
 	if err := store.Start(); err == nil {


### PR DESCRIPTION
Increase the defaults to something a little more sane for non-test use.
