### PR TITLE
Optimize MVCCGet path.

### DIFF
--- a/kv/txn_coord_sender_test.go
+++ b/kv/txn_coord_sender_test.go
@@ -356,7 +356,7 @@ func verifyCleanup(key proto.Key, db *client.KV, eng engine.Engine, t *testing.T
 
 	if err := util.IsTrueWithin(func() bool {
 		meta := &proto.MVCCMetadata{}
-		ok, _, _, err := engine.GetProto(eng, engine.MVCCEncodeKey(key), meta)
+		ok, _, _, err := eng.GetProto(engine.MVCCEncodeKey(key), meta)
 		if err != nil {
 			t.Errorf("error getting MVCC metadata: %s", err)
 		}

--- a/storage/engine/batch_test.go
+++ b/storage/engine/batch_test.go
@@ -198,7 +198,7 @@ func TestBatchProto(t *testing.T) {
 	kv := &proto.RawKeyValue{Key: proto.EncodedKey("a"), Value: []byte("value")}
 	PutProto(b, proto.EncodedKey("proto"), kv)
 	getKV := &proto.RawKeyValue{}
-	ok, keySize, valSize, err := GetProto(b, proto.EncodedKey("proto"), getKV)
+	ok, keySize, valSize, err := b.GetProto(proto.EncodedKey("proto"), getKV)
 	if !ok || err != nil {
 		t.Fatalf("expected GetProto to success ok=%t: %s", ok, err)
 	}
@@ -216,14 +216,14 @@ func TestBatchProto(t *testing.T) {
 		t.Errorf("expected %v; got %v", kv, getKV)
 	}
 	// Before commit, proto will not be available via engine.
-	if ok, _, _, err := GetProto(e, proto.EncodedKey("proto"), getKV); ok || err != nil {
+	if ok, _, _, err := e.GetProto(proto.EncodedKey("proto"), getKV); ok || err != nil {
 		t.Fatalf("expected GetProto to fail ok=%t: %s", ok, err)
 	}
 	// Commit and verify the proto can be read directly from the engine.
 	if err := b.Commit(); err != nil {
 		t.Fatal(err)
 	}
-	if ok, _, _, err := GetProto(e, proto.EncodedKey("proto"), getKV); !ok || err != nil {
+	if ok, _, _, err := e.GetProto(proto.EncodedKey("proto"), getKV); !ok || err != nil {
 		t.Fatalf("expected GetProto to success ok=%t: %s", ok, err)
 	}
 	if !reflect.DeepEqual(getKV, kv) {

--- a/storage/engine/engine.go
+++ b/storage/engine/engine.go
@@ -60,6 +60,9 @@ type Iterator interface {
 	Key() proto.EncodedKey
 	// Value returns the current value as a byte slice.
 	Value() []byte
+	// ValueProto unmarshals the value the iterator is currently
+	// pointing to using a protobuf decoder.
+	ValueProto(msg gogoproto.Message) error
 	// Error returns the error, if any, which the iterator encountered.
 	Error() error
 }
@@ -77,6 +80,11 @@ type Engine interface {
 	Put(key proto.EncodedKey, value []byte) error
 	// Get returns the value for the given key, nil otherwise.
 	Get(key proto.EncodedKey) ([]byte, error)
+	// GetProto fetches the value at the specified key and unmarshals it
+	// using a protobuf decoder. Returns true on success or false if the
+	// key was not found. On success, returns the length in bytes of the
+	// key and the value.
+	GetProto(key proto.EncodedKey, msg gogoproto.Message) (ok bool, keyBytes, valBytes int64, err error)
 	// Iterate scans from start to end keys, visiting at most max
 	// key/value pairs. On each key value pair, the function f is
 	// invoked. If f returns an error or if the scan itself encounters
@@ -181,48 +189,6 @@ func PutProto(engine Engine, key proto.EncodedKey, msg gogoproto.Message) (keyBy
 
 	bufferPool.Put(buf)
 	return
-}
-
-// GetProto fetches the value at the specified key and unmarshals it
-// using a protobuf decoder. Returns true on success or false if the
-// key was not found. On success, returns the length in bytes of the
-// key and the value.
-func GetProto(engine Engine, key proto.EncodedKey, msg gogoproto.Message) (ok bool, keyBytes, valBytes int64, err error) {
-	type protoGetter interface {
-		GetProto(key proto.EncodedKey, msg gogoproto.Message) (ok bool, keyBytes, valBytes int64, err error)
-	}
-	if g, ok := engine.(protoGetter); ok {
-		return g.GetProto(key, msg)
-	}
-
-	var data []byte
-	if data, err = engine.Get(key); err != nil {
-		return
-	}
-	if data == nil {
-		return
-	}
-	ok = true
-	if msg != nil {
-		if err = gogoproto.Unmarshal(data, msg); err != nil {
-			return
-		}
-	}
-	keyBytes = int64(len(key))
-	valBytes = int64(len(data))
-	return
-}
-
-// valueUnmarshal unmarshals the value the iterator is currently
-// pointing to using a protobuf decoder.
-func valueUnmarshal(iter Iterator, msg gogoproto.Message) error {
-	type unmarshaler interface {
-		valueUnmarshal(msg gogoproto.Message) error
-	}
-	if g, ok := iter.(unmarshaler); ok {
-		return g.valueUnmarshal(msg)
-	}
-	return gogoproto.Unmarshal(iter.Value(), msg)
 }
 
 // Increment fetches the varint encoded int64 value specified by key

--- a/storage/engine/mvcc.go
+++ b/storage/engine/mvcc.go
@@ -467,11 +467,11 @@ func MVCCGet(engine Engine, key proto.Key, timestamp proto.Timestamp,
 	}
 
 	buf := getBufferPool.Get().(*getBuffer)
+	defer getBufferPool.Put(buf)
 
 	metaKey := mvccEncodeKey(buf.key[0:0], key)
 	ok, _, _, err := engine.GetProto(metaKey, &buf.meta)
 	if err != nil || !ok {
-		getBufferPool.Put(buf)
 		return nil, err
 	}
 
@@ -481,7 +481,6 @@ func MVCCGet(engine Engine, key proto.Key, timestamp proto.Timestamp,
 		rvalue = &proto.Value{}
 		*rvalue = *value
 	}
-	getBufferPool.Put(buf)
 	return rvalue, err
 }
 

--- a/storage/engine/mvcc.go
+++ b/storage/engine/mvcc.go
@@ -909,8 +909,10 @@ func MVCCScan(engine Engine, key, endKey proto.Key, max int64, timestamp proto.T
 	buf := getBufferPool.Get().(*getBuffer)
 	defer getBufferPool.Put(buf)
 
+	// We store encEndKey and encKey in the same buffer to avoid memory
+	// allocations.
 	encEndKey := mvccEncodeKey(buf.key[0:0], endKey)
-	keyBuf := buf.key[len(encEndKey):len(encEndKey)]
+	keyBuf := encEndKey[len(encEndKey):]
 	encKey := mvccEncodeKey(keyBuf, key)
 
 	// Get a new iterator and define our getEarlierFunc using iter.Seek.

--- a/storage/engine/rocksdb.go
+++ b/storage/engine/rocksdb.go
@@ -449,6 +449,11 @@ func (r *rocksDBSnapshot) Get(key proto.EncodedKey) ([]byte, error) {
 	return r.parent.getInternal(key, r.handle)
 }
 
+func (r *rocksDBSnapshot) GetProto(key proto.EncodedKey, msg gogoproto.Message) (
+	ok bool, keyBytes, valBytes int64, err error) {
+	return r.parent.getProtoInternal(key, msg, r.handle)
+}
+
 // Iterate iterates over the keys between start inclusive and end
 // exclusive, invoking f() on each key/value pair using the snapshot
 // handle.
@@ -566,7 +571,7 @@ func (r *rocksDBIterator) Value() []byte {
 	return cSliceToGoBytes(data)
 }
 
-func (r *rocksDBIterator) valueUnmarshal(msg gogoproto.Message) error {
+func (r *rocksDBIterator) ValueProto(msg gogoproto.Message) error {
 	result := C.DBIterValue(r.iter)
 	if result.len <= 0 {
 		return nil

--- a/storage/engine/rocksdb.go
+++ b/storage/engine/rocksdb.go
@@ -33,6 +33,7 @@ import (
 	"github.com/cockroachdb/cockroach/proto"
 	"github.com/cockroachdb/cockroach/util"
 	"github.com/cockroachdb/cockroach/util/log"
+	gogoproto "github.com/gogo/protobuf/proto"
 )
 
 // RocksDB is a wrapper around a RocksDB database instance.
@@ -153,7 +154,7 @@ func (r *RocksDB) Get(key proto.EncodedKey) ([]byte, error) {
 	return r.getInternal(key, nil)
 }
 
-// Get returns the value for the given key.
+// getInternal returns the value for the given key.
 func (r *RocksDB) getInternal(key proto.EncodedKey, snapshotHandle *C.DBSnapshot) ([]byte, error) {
 	if len(key) == 0 {
 		return nil, emptyKeyError()
@@ -164,6 +165,40 @@ func (r *RocksDB) getInternal(key proto.EncodedKey, snapshotHandle *C.DBSnapshot
 		return nil, err
 	}
 	return cStringToGoBytes(result), nil
+}
+
+// GetProto fetches the value at the specified key and unmarshals it.
+func (r *RocksDB) GetProto(key proto.EncodedKey, msg gogoproto.Message) (
+	ok bool, keyBytes, valBytes int64, err error) {
+	return r.getProtoInternal(key, msg, nil)
+}
+
+func (r *RocksDB) getProtoInternal(key proto.EncodedKey, msg gogoproto.Message,
+	snapshotHandle *C.DBSnapshot) (ok bool, keyBytes, valBytes int64, err error) {
+	if len(key) == 0 {
+		err = emptyKeyError()
+		return
+	}
+	var result C.DBString
+	if err = statusToError(C.DBGet(r.rdb, snapshotHandle, goToCSlice(key), &result)); err != nil {
+		return
+	}
+	if result.len <= 0 {
+		return
+	}
+	ok = true
+	if msg != nil {
+		// Make a byte slice that is backed by result.data. This slice
+		// cannot live past the lifetime of this method, but we're only
+		// using it to unmarshal the proto.
+		// data := C.GoBytes(unsafe.Pointer(result.data), result.len)
+		data := (*[0x7fffffff]byte)(unsafe.Pointer(result.data))[:result.len:result.len]
+		err = gogoproto.Unmarshal(data, msg)
+	}
+	C.free(unsafe.Pointer(result.data))
+	keyBytes = int64(len(key))
+	valBytes = int64(result.len)
+	return
 }
 
 // Clear removes the item from the db with the given key.
@@ -529,6 +564,19 @@ func (r *rocksDBIterator) Key() proto.EncodedKey {
 func (r *rocksDBIterator) Value() []byte {
 	data := C.DBIterValue(r.iter)
 	return cSliceToGoBytes(data)
+}
+
+func (r *rocksDBIterator) valueUnmarshal(msg gogoproto.Message) error {
+	result := C.DBIterValue(r.iter)
+	if result.len <= 0 {
+		return nil
+	}
+	// Make a byte slice that is backed by result.data. This slice
+	// cannot live past the lifetime of this method, but we're only
+	// using it to unmarshal the proto.
+	// data := cSliceToGoBytes(result)
+	data := (*[0x7fffffff]byte)(unsafe.Pointer(result.data))[:result.len:result.len]
+	return gogoproto.Unmarshal(data, msg)
 }
 
 func (r *rocksDBIterator) Error() error {

--- a/storage/engine/rocksdb_test.go
+++ b/storage/engine/rocksdb_test.go
@@ -227,10 +227,11 @@ func runMVCCScan(numRows, numVersions int, b *testing.B) {
 	b.ResetTimer()
 
 	b.RunParallel(func(pb *testing.PB) {
+		keyBuf := append(make([]byte, 0, 64), []byte("key-")...)
 		for pb.Next() {
 			// Choose a random key to start scan.
 			keyIdx := rand.Int31n(int32(numKeys - numRows))
-			startKey := proto.Key(encoding.EncodeUvarint([]byte("key-"), uint64(keyIdx)))
+			startKey := proto.Key(encoding.EncodeUvarint(keyBuf[0:4], uint64(keyIdx)))
 			walltime := int64(5 * (rand.Int31n(int32(numVersions)) + 1))
 			ts := makeTS(walltime, 0)
 			kvs, err := MVCCScan(rocksdb, startKey, KeyMax, int64(numRows), ts, nil)
@@ -315,10 +316,11 @@ func runMVCCGet(numVersions int, b *testing.B) {
 	b.ResetTimer()
 
 	b.RunParallel(func(pb *testing.PB) {
+		keyBuf := append(make([]byte, 0, 64), []byte("key-")...)
 		for pb.Next() {
 			// Choose a random key to retrieve.
 			keyIdx := rand.Int31n(int32(numKeys))
-			key := proto.Key(encoding.EncodeUvarint([]byte("key-"), uint64(keyIdx)))
+			key := proto.Key(encoding.EncodeUvarint(keyBuf[0:4], uint64(keyIdx)))
 			walltime := int64(5 * (rand.Int31n(int32(numVersions)) + 1))
 			ts := makeTS(walltime, 0)
 			if v, err := MVCCGet(rocksdb, key, ts, nil); err != nil {


### PR DESCRIPTION
Provide fast-paths for retrieving unmarshalling proto values that do not
copy the data into a Go slice. Avoid unnecessary allocations when
encoding mvcc keys.

benchmark                             old ns/op     new ns/op     delta
BenchmarkMVCCScan1Version1Row         11322         10721         -5.31%
BenchmarkMVCCScan1Version10Rows       36566         27190         -25.64%
BenchmarkMVCCScan1Version100Rows      276241        217066        -21.42%
BenchmarkMVCCScan1Version1000Rows     2205243       1834826       -16.80%
BenchmarkMVCCGet1Version              3739          3153          -15.67%

benchmark                             old MB/s     new MB/s     speedup
BenchmarkMVCCScan1Version1Row         90.44        95.51        1.06x
BenchmarkMVCCScan1Version10Rows       280.04       376.60       1.34x
BenchmarkMVCCScan1Version100Rows      370.69       471.74       1.27x
BenchmarkMVCCScan1Version1000Rows     464.35       558.09       1.20x
BenchmarkMVCCGet1Version              273.83       324.77       1.19x
