### PR TITLE
up the timeout for heartbeat test processing

### DIFF
--- a/multiraft/heartbeat_test.go
+++ b/multiraft/heartbeat_test.go
@@ -36,7 +36,7 @@ func processEventsUntil(ch <-chan *interceptMessage, stopper *util.Stopper,
 	if stopper != nil {
 		defer stopper.SetStopped()
 	}
-	t := time.After(500 * time.Millisecond)
+	t := time.After(time.Second)
 	for {
 		select {
 		case e, ok := <-ch:


### PR DESCRIPTION
probably fixes #472 (unless there is a hidden deadlock/... involved
or the recent PR #475 introduced a subtle change).
