### PR TITLE
Move common code for loading/deleting configuration to config.go

### DIFF
--- a/server/zone.go
+++ b/server/zone.go
@@ -18,16 +18,12 @@
 package server
 
 import (
-	"bytes"
 	"net/http"
-	"net/url"
 
 	"github.com/cockroachdb/cockroach/client"
 	"github.com/cockroachdb/cockroach/proto"
-	"github.com/cockroachdb/cockroach/storage"
 	"github.com/cockroachdb/cockroach/storage/engine"
 	"github.com/cockroachdb/cockroach/util"
-	"github.com/cockroachdb/cockroach/util/log"
 )
 
 const (
@@ -78,61 +74,10 @@ func (zh *zoneHandler) Put(path string, body []byte, r *http.Request) error {
 // JSON-formatted output for a listing of keys and JSON-formatted
 // output for retrieval of a zone config.
 func (zh *zoneHandler) Get(path string, r *http.Request) (body []byte, contentType string, err error) {
-	// Scan all zones if the key is empty.
-	if len(path) == 0 {
-		sr := &proto.ScanResponse{}
-		if err = zh.db.Call(proto.Scan, &proto.ScanRequest{
-			RequestHeader: proto.RequestHeader{
-				Key:    engine.KeyConfigZonePrefix,
-				EndKey: engine.KeyConfigZonePrefix.PrefixEnd(),
-				User:   storage.UserRoot,
-			},
-			MaxResults: maxGetResults,
-		}, sr); err != nil {
-			return
-		}
-		if len(sr.Rows) == maxGetResults {
-			log.Warningf("retrieved maximum number of results (%d); some may be missing", maxGetResults)
-		}
-		var prefixes []string
-		for _, kv := range sr.Rows {
-			trimmed := bytes.TrimPrefix(kv.Key, engine.KeyConfigZonePrefix)
-			prefixes = append(prefixes, url.QueryEscape(string(trimmed)))
-		}
-		// Encode the response.
-		body, contentType, err = util.MarshalResponse(r, prefixes, util.AllEncodings)
-	} else {
-		zoneKey := engine.MakeKey(engine.KeyConfigZonePrefix, proto.Key(path[1:]))
-		var ok bool
-		config := &proto.ZoneConfig{}
-		if ok, _, err = zh.db.GetProto(zoneKey, config); err != nil {
-			return
-		}
-		// On get, if there's no zone config for the requested prefix,
-		// return a not found error.
-		if !ok {
-			err = util.Errorf("no config found for key prefix %q", path)
-			return
-		}
-		body, contentType, err = util.MarshalResponse(r, config, util.AllEncodings)
-	}
-
-	return
+	return getConfig(zh.db, engine.KeyConfigZonePrefix, &proto.ZoneConfig{}, path, r)
 }
 
 // Delete removes the zone config specified by key.
 func (zh *zoneHandler) Delete(path string, r *http.Request) error {
-	if len(path) == 0 {
-		return util.Errorf("no path specified for zone Delete")
-	}
-	if path == "/" {
-		return util.Errorf("the default zone configuration cannot be deleted")
-	}
-	zoneKey := engine.MakeKey(engine.KeyConfigZonePrefix, proto.Key(path[1:]))
-	return zh.db.Call(proto.Delete, &proto.DeleteRequest{
-		RequestHeader: proto.RequestHeader{
-			Key:  zoneKey,
-			User: storage.UserRoot,
-		},
-	}, &proto.DeleteResponse{})
+	return deleteConfig(zh.db, engine.KeyConfigZonePrefix, path, r)
 }


### PR DESCRIPTION
I guess we can do more code unification, but doing that in an incremental fashion.
