### PR TITLE
Properly stop the underlying engine in Store.Stop().

### DIFF
--- a/client/doc.go
+++ b/client/doc.go
@@ -36,7 +36,7 @@ error. The example below shows a get and a put.
     log.Fatal(err)
   }
   putResp := &proto.PutResponse{}
-  if _, err := kv.Call(proto.Put, proto.PutArgs(proto.Key("b"), getResp.Value.Bytes), putResp) err != nil {
+  if err := kv.Call(proto.Put, proto.PutArgs(proto.Key("b"), getResp.Value.Bytes), putResp) err != nil {
     log.Fatal(err)
   }
 
@@ -75,7 +75,7 @@ sequence of puts in parallel:
   }
 
   // Flush all puts for parallel execution.
-  if _, err := kv.Flush(); err != nil {
+  if err := kv.Flush(); err != nil {
     log.Fatal(err)
   }
 

--- a/server/node.go
+++ b/server/node.go
@@ -204,6 +204,7 @@ func (n *Node) start(rpcServer *rpc.Server, clock *hlc.Clock,
 // stop cleanly stops the node.
 func (n *Node) stop() {
 	close(n.closer)
+	n.lSender.Close()
 }
 
 // initStores initializes the Stores map from id to Store. Stores are

--- a/storage/store.go
+++ b/storage/store.go
@@ -345,6 +345,7 @@ func (s *Store) Stop() {
 		rng.stop()
 	}
 	s.stopper.Stop()
+	s.engine.Stop()
 }
 
 // String formats a store for debug output.


### PR DESCRIPTION
Add referencing counting to RocksDB.{Start,Stop} so that the underlying
rocksdb instance is only closed when the reference count falls to
0. This allows easy reuse of in-memory rocksdb instances by
multiTestContext.

Minor documentation fixes.
