### PR TITLE
Always set ClientCmdID, even for reads.

### DIFF
--- a/client/call.go
+++ b/client/call.go
@@ -34,12 +34,8 @@ type Call struct {
 // read-write method. The client command ID provides idempotency
 // protection in conjunction with the server.
 func (c *Call) resetClientCmdID(clock Clock) {
-	// On mutating commands, set a client command ID. This prevents
-	// mutations from being run multiple times on retries.
-	if proto.IsReadWrite(c.Method) {
-		c.Args.Header().CmdID = proto.ClientCmdID{
-			WallTime: clock.Now(),
-			Random:   rand.Int63(),
-		}
+	c.Args.Header().CmdID = proto.ClientCmdID{
+		WallTime: clock.Now(),
+		Random:   rand.Int63(),
 	}
 }


### PR DESCRIPTION
The command ID is harmless for reads, and setting it unconditionally
is a slight simplification for clients in other languages which will
no longer need to maintain a mapping of methods to permissions.
