### PR TITLE
Remove maxAvailPrefix from Node

### DIFF
--- a/server/node.go
+++ b/server/node.go
@@ -65,8 +65,6 @@ type Node struct {
 	db          *client.KV             // KV DB client; used to access global id generators
 	lSender     *kv.LocalSender        // Local KV sender for access to node-local stores
 	closer      chan struct{}
-
-	maxAvailPrefix string // Prefix for max avail capacity gossip topic
 }
 
 // allocateNodeID increments the node id generator key to allocate


### PR DESCRIPTION
This is currently unused, and it seems we will not need it since the key is constructed from a fixed prefix and node/store ID.
