### PR TITLE
add missing leaktests; fix sed invocation

### DIFF
--- a/storage/id_alloc_test.go
+++ b/storage/id_alloc_test.go
@@ -100,6 +100,7 @@ func TestIDAllocatorNegativeValue(t *testing.T) {
 
 // TestNewIDAllocatorInvalidArgs checks validation logic of NewIDAllocator.
 func TestNewIDAllocatorInvalidArgs(t *testing.T) {
+	defer leaktest.AfterTest(t)
 	args := [][]int64{
 		{0, 10}, // minID <= 0
 		{2, 0},  // blockSize < 1
@@ -118,6 +119,7 @@ func TestNewIDAllocatorInvalidArgs(t *testing.T) {
 // 4) Make IDAllocator valid again, the blocked allocations return correct ID.
 // 5) Check if the following allocations return correctly.
 func TestAllocateErrorAndRecovery(t *testing.T) {
+	defer leaktest.AfterTest(t)
 	store, _ := createTestStore(t)
 	allocd := make(chan int, 10)
 

--- a/util/leaktest/add-leaktest.sh
+++ b/util/leaktest/add-leaktest.sh
@@ -10,7 +10,7 @@
 # Usage: add-leaktest.sh pkg/*_test.go
 
 for i in "$@"; do
-    sed -i '' -e '
+    sed -i'' -e '
         /^func Test.*(t \*testing.T) {/ {
             # Skip past the test declaration
             n


### PR DESCRIPTION
sed invoked with `-i ''` would always return an error, and the man page indicates no space in between.
If that is an issue for other versions of `sed`, we should simply invoke `-i`.
