### PR TITLE
Add an explicit shutdown in IDAllocator to fix a leak of the Store.

### DIFF
--- a/storage/id_alloc_test.go
+++ b/storage/id_alloc_test.go
@@ -100,6 +100,7 @@ func TestIDAllocatorNegativeValue(t *testing.T) {
 
 // TestNewIDAllocatorInvalidArgs checks validation logic of NewIDAllocator.
 func TestNewIDAllocatorInvalidArgs(t *testing.T) {
+	defer leaktest.AfterTest(t)
 	args := [][]int64{
 		{0, 10}, // minID <= 0
 		{2, 0},  // blockSize < 1
@@ -118,7 +119,9 @@ func TestNewIDAllocatorInvalidArgs(t *testing.T) {
 // 4) Make IDAllocator valid again, the blocked allocations return correct ID.
 // 5) Check if the following allocations return correctly.
 func TestAllocateErrorAndRecovery(t *testing.T) {
+	defer leaktest.AfterTest(t)
 	store, _ := createTestStore(t)
+	defer store.Stop()
 	allocd := make(chan int, 10)
 
 	// Firstly create a valid IDAllocator to get some ID.
@@ -175,4 +178,5 @@ func TestAllocateErrorAndRecovery(t *testing.T) {
 			t.Errorf("expected ID is %d, but got: %d", i+21, id)
 		}
 	}
+	idAlloc.Stop()
 }

--- a/storage/store.go
+++ b/storage/store.go
@@ -341,6 +341,10 @@ func NewStore(clock *hlc.Clock, eng engine.Engine, db *client.KV, gossip *gossip
 
 // Stop calls Range.Stop() on all active ranges.
 func (s *Store) Stop() {
+	// Stop the id allocator first since it may need the ranges to be up to finish.
+	if s.raftIDAlloc != nil {
+		s.raftIDAlloc.Stop()
+	}
 	for _, rng := range s.ranges {
 		rng.stop()
 	}

--- a/util/leaktest/add-leaktest.sh
+++ b/util/leaktest/add-leaktest.sh
@@ -10,7 +10,7 @@
 # Usage: add-leaktest.sh pkg/*_test.go
 
 for i in "$@"; do
-    sed -i '' -e '
+    sed -i'~' -e '
         /^func Test.*(t \*testing.T) {/ {
             # Skip past the test declaration
             n


### PR DESCRIPTION
Closes #497.
Closes #498.
