### PR TITLE
Bugfix for multi-range scan with MaxResults parameter

### DIFF
--- a/proto/api.go
+++ b/proto/api.go
@@ -663,3 +663,33 @@ func (br *BatchResponse) Add(reply Response) {
 	union.SetValue(reply)
 	br.Responses = append(br.Responses, union)
 }
+
+// Bounded is implemented by request types which have a bounded number of
+// result rows, such as Scan.
+type Bounded interface {
+	GetBound() int64
+}
+
+// GetBound returns the MaxResults field in ScanRequest.
+func (sr *ScanRequest) GetBound() int64 {
+	return sr.GetMaxResults()
+}
+
+// Truncatable is implemented by response types whose corresponding
+// requests have a bounded number of result rows, such as Scan.
+type Truncatable interface {
+	Truncate(maxResults int64)
+	RowCount() int64
+}
+
+// Truncate truncates ScanResponse with maxResults.
+func (sr *ScanResponse) Truncate(maxResults int64) {
+	if maxResults < int64(len(sr.Rows)) {
+		sr.Rows = sr.Rows[:maxResults]
+	}
+}
+
+// RowCount returns the number of rows in ScanResponse.
+func (sr *ScanResponse) RowCount() int64 {
+	return int64(len(sr.Rows))
+}


### PR DESCRIPTION
In existing code, when dist_sender processes one multi-range ScanRequest, it will dispatch the request with MaxResults parameter to each range one by one, and the return results will be combined and returned. The problem is if there are 2 ranges, MaxResults is set to 2, so each individual ScanRequest will return 2 rows, and finally 4 rows will be returned, it does not satisfy the MaxResults parameter "2". and if ScanRequest in range1 already got enough results, it need not to access range2.

Because dist_sender should focus on the dispatching mechanism, directly putting ScanRequest/ScanReponse into dist_sender seems not good, so I add two interfaces into api.go, please check whether it is ok. Thanks.
