### PR TITLE
Check for nil response before using the value.

### DIFF
--- a/server/cli/kv.go
+++ b/server/cli/kv.go
@@ -71,11 +71,10 @@ func runGet(cmd *commander.Command, args []string) {
 		fmt.Fprintf(os.Stderr, "get failed: %s\n", err)
 		os.Exit(1)
 	}
-	if resp.Value.Integer != nil {
-		fmt.Printf("%d\n", *resp.Value.Integer)
-	} else if resp.Value == nil {
+	if resp.Value == nil {
 		fmt.Fprintf(os.Stderr, "%s not found\n", key)
-		os.Exit(1)
+	} else if resp.Value.Integer != nil {
+		fmt.Printf("%d\n", *resp.Value.Integer)
 	} else {
 		fmt.Printf("%s\n", resp.Value.Bytes)
 	}

--- a/server/cli/kv.go
+++ b/server/cli/kv.go
@@ -69,10 +69,11 @@ func runGet(cmd *commander.Command, args []string) {
 	resp := &proto.GetResponse{}
 	if err := kv.Call(proto.Get, proto.GetArgs(key), resp); err != nil {
 		fmt.Fprintf(os.Stderr, "get failed: %s\n", err)
-		os.Exit(1)
+		os.Exit(2)
 	}
 	if resp.Value == nil {
 		fmt.Fprintf(os.Stderr, "%s not found\n", key)
+		os.Exit(1)
 	} else if resp.Value.Integer != nil {
 		fmt.Printf("%d\n", *resp.Value.Integer)
 	} else {
@@ -124,7 +125,7 @@ func runPut(cmd *commander.Command, args []string) {
 	})
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "put failed: %s\n", err)
-		os.Exit(1)
+		os.Exit(2)
 	}
 }
 
@@ -167,7 +168,7 @@ func runInc(cmd *commander.Command, args []string) {
 	resp := &proto.IncrementResponse{}
 	if err := kv.Call(proto.Increment, proto.IncrementArgs(key, int64(amount)), resp); err != nil {
 		fmt.Fprintf(os.Stderr, "increment failed: %s\n", err)
-		os.Exit(1)
+		os.Exit(2)
 	}
 	fmt.Printf("%d\n", resp.NewValue)
 }
@@ -210,7 +211,7 @@ func runDel(cmd *commander.Command, args []string) {
 	})
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "delete failed: %s\n", err)
-		os.Exit(1)
+		os.Exit(2)
 	}
 }
 
@@ -262,7 +263,7 @@ func runScan(cmd *commander.Command, args []string) {
 	resp := &proto.ScanResponse{}
 	if err := kv.Call(proto.Scan, req, resp); err != nil {
 		fmt.Fprintf(os.Stderr, "scan failed: %s\n", err)
-		os.Exit(1)
+		os.Exit(2)
 	}
 
 	for _, r := range resp.Rows {

--- a/server/cli/range.go
+++ b/server/cli/range.go
@@ -61,7 +61,7 @@ func runLsRanges(cmd *commander.Command, args []string) {
 	resp := &proto.ScanResponse{}
 	if err := kv.Call(proto.Scan, req, resp); err != nil {
 		fmt.Fprintf(os.Stderr, "scan failed: %s\n", err)
-		os.Exit(1)
+		os.Exit(2)
 	}
 
 	for _, r := range resp.Rows {
@@ -115,7 +115,7 @@ func runSplitRange(cmd *commander.Command, args []string) {
 	resp := &proto.AdminSplitResponse{}
 	if err := kv.Call(proto.AdminSplit, req, resp); err != nil {
 		fmt.Fprintf(os.Stderr, "split failed: %s\n", err)
-		os.Exit(1)
+		os.Exit(2)
 	}
 }
 
@@ -145,7 +145,7 @@ func runMergeRange(cmd *commander.Command, args []string) {
 	scanResp := &proto.ScanResponse{}
 	if err := kv.Call(proto.Scan, scanReq, scanResp); err != nil {
 		fmt.Fprintf(os.Stderr, "scan failed: %s\n", err)
-		os.Exit(1)
+		os.Exit(2)
 	}
 	switch len(scanResp.Rows) {
 	case 0:
@@ -174,6 +174,6 @@ func runMergeRange(cmd *commander.Command, args []string) {
 	resp := &proto.AdminMergeResponse{}
 	if err := kv.Call(proto.AdminMerge, req, resp); err != nil {
 		fmt.Fprintf(os.Stderr, "merge failed: %s\n", err)
-		os.Exit(1)
+		os.Exit(2)
 	}
 }


### PR DESCRIPTION
Small bug fix for server cli.

I don't view a key not existing as an error, so I also removed the os.Exit(1).
