### PR TITLE
Fix deadlock in TestRangeSplitsWithWritePressure.

### DIFF
--- a/kv/split_test.go
+++ b/kv/split_test.go
@@ -144,8 +144,8 @@ func TestRangeSplitsWithWritePressure(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	defer transport.Close()
 	defer db.Close()
+	defer transport.Close()
 	setTestRetryOptions()
 
 	// Rewrite a zone config with low max bytes.

--- a/kv/txn_coord_sender.go
+++ b/kv/txn_coord_sender.go
@@ -196,11 +196,15 @@ func (tc *TxnCoordSender) Send(call *client.Call) {
 // TxnCoordSender has been managing.
 func (tc *TxnCoordSender) Close() {
 	tc.Lock()
-	defer tc.Unlock()
 	for _, txn := range tc.txns {
 		close(txn.closer)
 	}
 	tc.txns = map[string]*txnMetadata{}
+	tc.Unlock()
+	// TODO(bdarnell): closing the wrapped sender may close the underlying
+	// Store, which may call back into TxnCoordSender and cause deadlocks if
+	// the lock is held. The shutdown process needs to be refactored to clean
+	// this up.
 	tc.wrapped.Close()
 }
 


### PR DESCRIPTION
The shutdown sequence is delicate; we need to stop everything that might
generate new work before stopping the parts that are necessary to
complete that work. I think that ultimately we'll need to have multiple
stop-like methods for different phases of the shutdown process but for
now this appears to eliminate the deadlocks we've been seeing recently.

Fixes #480.
