### PR TITLE
fix flaky heartbeat test

### DIFF
--- a/multiraft/heartbeat_test.go
+++ b/multiraft/heartbeat_test.go
@@ -37,8 +37,8 @@ func processEventsUntil(ch <-chan *interceptMessage, stopper *util.Stopper,
 	if stopper != nil {
 		defer stopper.SetStopped()
 	}
-	t := time.After(time.Second)
 	for {
+		t := time.After(time.Second)
 		select {
 		case e, ok := <-ch:
 			if !ok {


### PR DESCRIPTION
a mistake so obvious it just had to be overlooked.
existing code limited the total runtime of the
interceptor, where really we wanted to reset the
timeout whenever a message is received.

closes #523, closes #473
