### PR TITLE
Add client scan benchmark.

### DIFF
--- a/client/.gitignore
+++ b/client/.gitignore
@@ -1,0 +1,1 @@
+client_bench_*


### PR DESCRIPTION
Fix storage.Store to only start the underlying engine once when
initializing via Store.Bootstrap followed by Store.Start.
