### PR TITLE
Add 'oneof' to all protos using gogoproto.onlyone.

### DIFF
--- a/proto/api.proto
+++ b/proto/api.proto
@@ -302,35 +302,39 @@ message EnqueueMessageResponse {
 // A RequestUnion contains exactly one of the optional requests.
 message RequestUnion {
   option (gogoproto.onlyone) = true;
-  optional ContainsRequest contains = 1;
-  optional GetRequest get = 2;
-  optional PutRequest put = 3;
-  optional ConditionalPutRequest conditional_put = 4;
-  optional IncrementRequest increment = 5;
-  optional DeleteRequest delete = 6;
-  optional DeleteRangeRequest delete_range = 7;
-  optional ScanRequest scan = 8;
-  optional EndTransactionRequest end_transaction = 9;
-  optional ReapQueueRequest reap_queue = 10;
-  optional EnqueueUpdateRequest enqueue_update = 11;
-  optional EnqueueMessageRequest enqueue_message = 12;
+  oneof value {
+    ContainsRequest contains = 1;
+    GetRequest get = 2;
+    PutRequest put = 3;
+    ConditionalPutRequest conditional_put = 4;
+    IncrementRequest increment = 5;
+    DeleteRequest delete = 6;
+    DeleteRangeRequest delete_range = 7;
+    ScanRequest scan = 8;
+    EndTransactionRequest end_transaction = 9;
+    ReapQueueRequest reap_queue = 10;
+    EnqueueUpdateRequest enqueue_update = 11;
+    EnqueueMessageRequest enqueue_message = 12;
+  }
 }
 
 // A ResponseUnion contains exactly one of the optional responses.
 message ResponseUnion {
   option (gogoproto.onlyone) = true;
-  optional ContainsResponse contains = 1;
-  optional GetResponse get = 2;
-  optional PutResponse put = 3;
-  optional ConditionalPutResponse conditional_put = 4;
-  optional IncrementResponse increment = 5;
-  optional DeleteResponse delete = 6;
-  optional DeleteRangeResponse delete_range = 7;
-  optional ScanResponse scan = 8;
-  optional EndTransactionResponse end_transaction = 9;
-  optional ReapQueueResponse reap_queue = 10;
-  optional EnqueueUpdateResponse enqueue_update = 11;
-  optional EnqueueMessageResponse enqueue_message = 12;
+  oneof value {
+    ContainsResponse contains = 1;
+    GetResponse get = 2;
+    PutResponse put = 3;
+    ConditionalPutResponse conditional_put = 4;
+    IncrementResponse increment = 5;
+    DeleteResponse delete = 6;
+    DeleteRangeResponse delete_range = 7;
+    ScanResponse scan = 8;
+    EndTransactionResponse end_transaction = 9;
+    ReapQueueResponse reap_queue = 10;
+    EnqueueUpdateResponse enqueue_update = 11;
+    EnqueueMessageResponse enqueue_message = 12;
+  }
 }
 
 // A BatchRequest contains one or more requests to be executed in

--- a/proto/errors.proto
+++ b/proto/errors.proto
@@ -125,18 +125,20 @@ message ConditionFailedError {
 // ErrorDetail is a union type containing all available errors.
 message ErrorDetail {
   option (gogoproto.onlyone) = true;
-  optional NotLeaderError not_leader = 1;
-  optional RangeNotFoundError range_not_found = 2;
-  optional RangeKeyMismatchError range_key_mismatch = 3;
-  optional ReadWithinUncertaintyIntervalError read_within_uncertainty_interval = 4;
-  optional TransactionAbortedError transaction_aborted = 5;
-  optional TransactionPushError transaction_push = 6;
-  optional TransactionRetryError transaction_retry = 7;
-  optional TransactionStatusError transaction_status = 8;
-  optional WriteIntentError write_intent = 9;
-  optional WriteTooOldError write_too_old = 10;
-  optional OpRequiresTxnError op_requires_txn = 11;
-  optional ConditionFailedError condition_failed = 12;
+  oneof value {
+    NotLeaderError not_leader = 1;
+    RangeNotFoundError range_not_found = 2;
+    RangeKeyMismatchError range_key_mismatch = 3;
+    ReadWithinUncertaintyIntervalError read_within_uncertainty_interval = 4;
+    TransactionAbortedError transaction_aborted = 5;
+    TransactionPushError transaction_push = 6;
+    TransactionRetryError transaction_retry = 7;
+    TransactionStatusError transaction_status = 8;
+    WriteIntentError write_intent = 9;
+    WriteTooOldError write_too_old = 10;
+    OpRequiresTxnError op_requires_txn = 11;
+    ConditionFailedError condition_failed = 12;
+  }
 }
 
 // TransactionRestart indicates how an error should be handled in a

--- a/proto/internal.proto
+++ b/proto/internal.proto
@@ -168,51 +168,55 @@ message InternalTruncateLogResponse {
 // in storage/engine/db.cc in GetResponseHeader().
 message ReadWriteCmdResponse {
   option (gogoproto.onlyone) = true;
-  optional PutResponse put = 1;
-  optional ConditionalPutResponse conditional_put = 2;
-  optional IncrementResponse increment = 3;
-  optional DeleteResponse delete = 4;
-  optional DeleteRangeResponse delete_range = 5;
-  optional EndTransactionResponse end_transaction = 6;
-  optional ReapQueueResponse reap_queue = 7;
-  optional EnqueueUpdateResponse enqueue_update = 8;
-  optional EnqueueMessageResponse enqueue_message = 9;
-  optional InternalHeartbeatTxnResponse internal_heartbeat_txn = 10;
-  optional InternalPushTxnResponse internal_push_txn = 11;
-  optional InternalResolveIntentResponse internal_resolve_intent = 12;
-  optional InternalMergeResponse internal_merge = 13;
-  optional InternalTruncateLogResponse internal_truncate_log = 14;
-  optional InternalGCResponse internal_gc = 15;
+  oneof value {
+    PutResponse put = 1;
+    ConditionalPutResponse conditional_put = 2;
+    IncrementResponse increment = 3;
+    DeleteResponse delete = 4;
+    DeleteRangeResponse delete_range = 5;
+    EndTransactionResponse end_transaction = 6;
+    ReapQueueResponse reap_queue = 7;
+    EnqueueUpdateResponse enqueue_update = 8;
+    EnqueueMessageResponse enqueue_message = 9;
+    InternalHeartbeatTxnResponse internal_heartbeat_txn = 10;
+    InternalPushTxnResponse internal_push_txn = 11;
+    InternalResolveIntentResponse internal_resolve_intent = 12;
+    InternalMergeResponse internal_merge = 13;
+    InternalTruncateLogResponse internal_truncate_log = 14;
+    InternalGCResponse internal_gc = 15;
+  }
 }
 
 // An InternalRaftCommandUnion is the union of all commands which can be
 // sent via raft.
 message InternalRaftCommandUnion {
   option (gogoproto.onlyone) = true;
-  // Non-batched external requests. This section is the same as RequestUnion.
-  optional ContainsRequest contains = 1;
-  optional GetRequest get = 2;
-  optional PutRequest put = 3;
-  optional ConditionalPutRequest conditional_put = 4;
-  optional IncrementRequest increment = 5;
-  optional DeleteRequest delete = 6;
-  optional DeleteRangeRequest delete_range = 7;
-  optional ScanRequest scan = 8;
-  optional EndTransactionRequest end_transaction = 9;
-  optional ReapQueueRequest reap_queue = 10;
-  optional EnqueueUpdateRequest enqueue_update = 11;
-  optional EnqueueMessageRequest enqueue_message = 12;
+  oneof value {
+    // Non-batched external requests. This section is the same as RequestUnion.
+    ContainsRequest contains = 1;
+    GetRequest get = 2;
+    PutRequest put = 3;
+    ConditionalPutRequest conditional_put = 4;
+    IncrementRequest increment = 5;
+    DeleteRequest delete = 6;
+    DeleteRangeRequest delete_range = 7;
+    ScanRequest scan = 8;
+    EndTransactionRequest end_transaction = 9;
+    ReapQueueRequest reap_queue = 10;
+    EnqueueUpdateRequest enqueue_update = 11;
+    EnqueueMessageRequest enqueue_message = 12;
 
-  // Other requests. Allow a gap in tag numbers so the previous list can
-  // be copy/pasted from RequestUnion.
-  optional BatchRequest batch = 30;
-  optional InternalRangeLookupRequest internal_range_lookup = 31;
-  optional InternalHeartbeatTxnRequest internal_heartbeat_txn = 32;
-  optional InternalPushTxnRequest internal_push_txn = 33;
-  optional InternalResolveIntentRequest internal_resolve_intent = 34;
-  optional InternalMergeRequest internal_merge_response = 35;
-  optional InternalTruncateLogRequest internal_truncate_log = 36;
-  optional InternalGCRequest internal_gc = 37;
+    // Other requests. Allow a gap in tag numbers so the previous list can
+    // be copy/pasted from RequestUnion.
+    BatchRequest batch = 30;
+    InternalRangeLookupRequest internal_range_lookup = 31;
+    InternalHeartbeatTxnRequest internal_heartbeat_txn = 32;
+    InternalPushTxnRequest internal_push_txn = 33;
+    InternalResolveIntentRequest internal_resolve_intent = 34;
+    InternalMergeRequest internal_merge_response = 35;
+    InternalTruncateLogRequest internal_truncate_log = 36;
+    InternalGCRequest internal_gc = 37;
+  }
 }
 
 // An InternalRaftCommand is a command which can be serialized and

--- a/storage/engine/cockroach/proto/api.pb.cc
+++ b/storage/engine/cockroach/proto/api.pb.cc
@@ -105,9 +105,37 @@ const ::google::protobuf::internal::GeneratedMessageReflection*
 const ::google::protobuf::Descriptor* RequestUnion_descriptor_ = NULL;
 const ::google::protobuf::internal::GeneratedMessageReflection*
   RequestUnion_reflection_ = NULL;
+struct RequestUnionOneofInstance {
+  const ::cockroach::proto::ContainsRequest* contains_;
+  const ::cockroach::proto::GetRequest* get_;
+  const ::cockroach::proto::PutRequest* put_;
+  const ::cockroach::proto::ConditionalPutRequest* conditional_put_;
+  const ::cockroach::proto::IncrementRequest* increment_;
+  const ::cockroach::proto::DeleteRequest* delete__;
+  const ::cockroach::proto::DeleteRangeRequest* delete_range_;
+  const ::cockroach::proto::ScanRequest* scan_;
+  const ::cockroach::proto::EndTransactionRequest* end_transaction_;
+  const ::cockroach::proto::ReapQueueRequest* reap_queue_;
+  const ::cockroach::proto::EnqueueUpdateRequest* enqueue_update_;
+  const ::cockroach::proto::EnqueueMessageRequest* enqueue_message_;
+}* RequestUnion_default_oneof_instance_ = NULL;
 const ::google::protobuf::Descriptor* ResponseUnion_descriptor_ = NULL;
 const ::google::protobuf::internal::GeneratedMessageReflection*
   ResponseUnion_reflection_ = NULL;
+struct ResponseUnionOneofInstance {
+  const ::cockroach::proto::ContainsResponse* contains_;
+  const ::cockroach::proto::GetResponse* get_;
+  const ::cockroach::proto::PutResponse* put_;
+  const ::cockroach::proto::ConditionalPutResponse* conditional_put_;
+  const ::cockroach::proto::IncrementResponse* increment_;
+  const ::cockroach::proto::DeleteResponse* delete__;
+  const ::cockroach::proto::DeleteRangeResponse* delete_range_;
+  const ::cockroach::proto::ScanResponse* scan_;
+  const ::cockroach::proto::EndTransactionResponse* end_transaction_;
+  const ::cockroach::proto::ReapQueueResponse* reap_queue_;
+  const ::cockroach::proto::EnqueueUpdateResponse* enqueue_update_;
+  const ::cockroach::proto::EnqueueMessageResponse* enqueue_message_;
+}* ResponseUnion_default_oneof_instance_ = NULL;
 const ::google::protobuf::Descriptor* BatchRequest_descriptor_ = NULL;
 const ::google::protobuf::internal::GeneratedMessageReflection*
   BatchRequest_reflection_ = NULL;
@@ -570,19 +598,20 @@ void protobuf_AssignDesc_cockroach_2fproto_2fapi_2eproto() {
       ::google::protobuf::MessageFactory::generated_factory(),
       sizeof(EnqueueMessageResponse));
   RequestUnion_descriptor_ = file->message_type(27);
-  static const int RequestUnion_offsets_[12] = {
-    GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(RequestUnion, contains_),
-    GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(RequestUnion, get_),
-    GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(RequestUnion, put_),
-    GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(RequestUnion, conditional_put_),
-    GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(RequestUnion, increment_),
-    GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(RequestUnion, delete__),
-    GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(RequestUnion, delete_range_),
-    GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(RequestUnion, scan_),
-    GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(RequestUnion, end_transaction_),
-    GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(RequestUnion, reap_queue_),
-    GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(RequestUnion, enqueue_update_),
-    GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(RequestUnion, enqueue_message_),
+  static const int RequestUnion_offsets_[13] = {
+    PROTO2_GENERATED_DEFAULT_ONEOF_FIELD_OFFSET(RequestUnion_default_oneof_instance_, contains_),
+    PROTO2_GENERATED_DEFAULT_ONEOF_FIELD_OFFSET(RequestUnion_default_oneof_instance_, get_),
+    PROTO2_GENERATED_DEFAULT_ONEOF_FIELD_OFFSET(RequestUnion_default_oneof_instance_, put_),
+    PROTO2_GENERATED_DEFAULT_ONEOF_FIELD_OFFSET(RequestUnion_default_oneof_instance_, conditional_put_),
+    PROTO2_GENERATED_DEFAULT_ONEOF_FIELD_OFFSET(RequestUnion_default_oneof_instance_, increment_),
+    PROTO2_GENERATED_DEFAULT_ONEOF_FIELD_OFFSET(RequestUnion_default_oneof_instance_, delete__),
+    PROTO2_GENERATED_DEFAULT_ONEOF_FIELD_OFFSET(RequestUnion_default_oneof_instance_, delete_range_),
+    PROTO2_GENERATED_DEFAULT_ONEOF_FIELD_OFFSET(RequestUnion_default_oneof_instance_, scan_),
+    PROTO2_GENERATED_DEFAULT_ONEOF_FIELD_OFFSET(RequestUnion_default_oneof_instance_, end_transaction_),
+    PROTO2_GENERATED_DEFAULT_ONEOF_FIELD_OFFSET(RequestUnion_default_oneof_instance_, reap_queue_),
+    PROTO2_GENERATED_DEFAULT_ONEOF_FIELD_OFFSET(RequestUnion_default_oneof_instance_, enqueue_update_),
+    PROTO2_GENERATED_DEFAULT_ONEOF_FIELD_OFFSET(RequestUnion_default_oneof_instance_, enqueue_message_),
+    GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(RequestUnion, value_),
   };
   RequestUnion_reflection_ =
     new ::google::protobuf::internal::GeneratedMessageReflection(
@@ -592,23 +621,26 @@ void protobuf_AssignDesc_cockroach_2fproto_2fapi_2eproto() {
       GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(RequestUnion, _has_bits_[0]),
       GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(RequestUnion, _unknown_fields_),
       -1,
+      RequestUnion_default_oneof_instance_,
+      GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(RequestUnion, _oneof_case_[0]),
       ::google::protobuf::DescriptorPool::generated_pool(),
       ::google::protobuf::MessageFactory::generated_factory(),
       sizeof(RequestUnion));
   ResponseUnion_descriptor_ = file->message_type(28);
-  static const int ResponseUnion_offsets_[12] = {
-    GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(ResponseUnion, contains_),
-    GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(ResponseUnion, get_),
-    GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(ResponseUnion, put_),
-    GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(ResponseUnion, conditional_put_),
-    GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(ResponseUnion, increment_),
-    GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(ResponseUnion, delete__),
-    GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(ResponseUnion, delete_range_),
-    GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(ResponseUnion, scan_),
-    GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(ResponseUnion, end_transaction_),
-    GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(ResponseUnion, reap_queue_),
-    GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(ResponseUnion, enqueue_update_),
-    GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(ResponseUnion, enqueue_message_),
+  static const int ResponseUnion_offsets_[13] = {
+    PROTO2_GENERATED_DEFAULT_ONEOF_FIELD_OFFSET(ResponseUnion_default_oneof_instance_, contains_),
+    PROTO2_GENERATED_DEFAULT_ONEOF_FIELD_OFFSET(ResponseUnion_default_oneof_instance_, get_),
+    PROTO2_GENERATED_DEFAULT_ONEOF_FIELD_OFFSET(ResponseUnion_default_oneof_instance_, put_),
+    PROTO2_GENERATED_DEFAULT_ONEOF_FIELD_OFFSET(ResponseUnion_default_oneof_instance_, conditional_put_),
+    PROTO2_GENERATED_DEFAULT_ONEOF_FIELD_OFFSET(ResponseUnion_default_oneof_instance_, increment_),
+    PROTO2_GENERATED_DEFAULT_ONEOF_FIELD_OFFSET(ResponseUnion_default_oneof_instance_, delete__),
+    PROTO2_GENERATED_DEFAULT_ONEOF_FIELD_OFFSET(ResponseUnion_default_oneof_instance_, delete_range_),
+    PROTO2_GENERATED_DEFAULT_ONEOF_FIELD_OFFSET(ResponseUnion_default_oneof_instance_, scan_),
+    PROTO2_GENERATED_DEFAULT_ONEOF_FIELD_OFFSET(ResponseUnion_default_oneof_instance_, end_transaction_),
+    PROTO2_GENERATED_DEFAULT_ONEOF_FIELD_OFFSET(ResponseUnion_default_oneof_instance_, reap_queue_),
+    PROTO2_GENERATED_DEFAULT_ONEOF_FIELD_OFFSET(ResponseUnion_default_oneof_instance_, enqueue_update_),
+    PROTO2_GENERATED_DEFAULT_ONEOF_FIELD_OFFSET(ResponseUnion_default_oneof_instance_, enqueue_message_),
+    GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(ResponseUnion, value_),
   };
   ResponseUnion_reflection_ =
     new ::google::protobuf::internal::GeneratedMessageReflection(
@@ -618,6 +650,8 @@ void protobuf_AssignDesc_cockroach_2fproto_2fapi_2eproto() {
       GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(ResponseUnion, _has_bits_[0]),
       GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(ResponseUnion, _unknown_fields_),
       -1,
+      ResponseUnion_default_oneof_instance_,
+      GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(ResponseUnion, _oneof_case_[0]),
       ::google::protobuf::DescriptorPool::generated_pool(),
       ::google::protobuf::MessageFactory::generated_factory(),
       sizeof(ResponseUnion));
@@ -857,8 +891,10 @@ void protobuf_ShutdownFile_cockroach_2fproto_2fapi_2eproto() {
   delete EnqueueMessageResponse::default_instance_;
   delete EnqueueMessageResponse_reflection_;
   delete RequestUnion::default_instance_;
+  delete RequestUnion_default_oneof_instance_;
   delete RequestUnion_reflection_;
   delete ResponseUnion::default_instance_;
+  delete ResponseUnion_default_oneof_instance_;
   delete ResponseUnion_reflection_;
   delete BatchRequest::default_instance_;
   delete BatchRequest_reflection_;
@@ -966,58 +1002,60 @@ void protobuf_AddDesc_cockroach_2fproto_2fapi_2eproto() {
     "\001\022)\n\003msg\030\002 \001(\0132\026.cockroach.proto.ValueB\004"
     "\310\336\037\000\"S\n\026EnqueueMessageResponse\0229\n\006header"
     "\030\001 \001(\0132\037.cockroach.proto.ResponseHeaderB"
-    "\010\310\336\037\000\320\336\037\001\"\242\005\n\014RequestUnion\0222\n\010contains\030\001"
-    " \001(\0132 .cockroach.proto.ContainsRequest\022("
-    "\n\003get\030\002 \001(\0132\033.cockroach.proto.GetRequest"
-    "\022(\n\003put\030\003 \001(\0132\033.cockroach.proto.PutReque"
-    "st\022\?\n\017conditional_put\030\004 \001(\0132&.cockroach."
-    "proto.ConditionalPutRequest\0224\n\tincrement"
-    "\030\005 \001(\0132!.cockroach.proto.IncrementReques"
-    "t\022.\n\006delete\030\006 \001(\0132\036.cockroach.proto.Dele"
-    "teRequest\0229\n\014delete_range\030\007 \001(\0132#.cockro"
-    "ach.proto.DeleteRangeRequest\022*\n\004scan\030\010 \001"
-    "(\0132\034.cockroach.proto.ScanRequest\022\?\n\017end_"
-    "transaction\030\t \001(\0132&.cockroach.proto.EndT"
-    "ransactionRequest\0225\n\nreap_queue\030\n \001(\0132!."
-    "cockroach.proto.ReapQueueRequest\022=\n\016enqu"
-    "eue_update\030\013 \001(\0132%.cockroach.proto.Enque"
-    "ueUpdateRequest\022\?\n\017enqueue_message\030\014 \001(\013"
-    "2&.cockroach.proto.EnqueueMessageRequest"
-    ":\004\310\240\037\001\"\257\005\n\rResponseUnion\0223\n\010contains\030\001 \001"
-    "(\0132!.cockroach.proto.ContainsResponse\022)\n"
-    "\003get\030\002 \001(\0132\034.cockroach.proto.GetResponse"
-    "\022)\n\003put\030\003 \001(\0132\034.cockroach.proto.PutRespo"
-    "nse\022@\n\017conditional_put\030\004 \001(\0132\'.cockroach"
-    ".proto.ConditionalPutResponse\0225\n\tincreme"
-    "nt\030\005 \001(\0132\".cockroach.proto.IncrementResp"
-    "onse\022/\n\006delete\030\006 \001(\0132\037.cockroach.proto.D"
-    "eleteResponse\022:\n\014delete_range\030\007 \001(\0132$.co"
-    "ckroach.proto.DeleteRangeResponse\022+\n\004sca"
-    "n\030\010 \001(\0132\035.cockroach.proto.ScanResponse\022@"
-    "\n\017end_transaction\030\t \001(\0132\'.cockroach.prot"
-    "o.EndTransactionResponse\0226\n\nreap_queue\030\n"
-    " \001(\0132\".cockroach.proto.ReapQueueResponse"
-    "\022>\n\016enqueue_update\030\013 \001(\0132&.cockroach.pro"
-    "to.EnqueueUpdateResponse\022@\n\017enqueue_mess"
-    "age\030\014 \001(\0132\'.cockroach.proto.EnqueueMessa"
-    "geResponse:\004\310\240\037\001\"\177\n\014BatchRequest\0228\n\006head"
-    "er\030\001 \001(\0132\036.cockroach.proto.RequestHeader"
-    "B\010\310\336\037\000\320\336\037\001\0225\n\010requests\030\002 \003(\0132\035.cockroach"
-    ".proto.RequestUnionB\004\310\336\037\000\"\203\001\n\rBatchRespo"
-    "nse\0229\n\006header\030\001 \001(\0132\037.cockroach.proto.Re"
-    "sponseHeaderB\010\310\336\037\000\320\336\037\001\0227\n\tresponses\030\002 \003("
-    "\0132\036.cockroach.proto.ResponseUnionB\004\310\336\037\000\""
-    "m\n\021AdminSplitRequest\0228\n\006header\030\001 \001(\0132\036.c"
-    "ockroach.proto.RequestHeaderB\010\310\336\037\000\320\336\037\001\022\036"
-    "\n\tsplit_key\030\002 \001(\014B\013\310\336\037\000\332\336\037\003Key\"O\n\022AdminS"
-    "plitResponse\0229\n\006header\030\001 \001(\0132\037.cockroach"
-    ".proto.ResponseHeaderB\010\310\336\037\000\320\336\037\001\"\215\001\n\021Admi"
-    "nMergeRequest\0228\n\006header\030\001 \001(\0132\036.cockroac"
-    "h.proto.RequestHeaderB\010\310\336\037\000\320\336\037\001\022>\n\016subsu"
-    "med_range\030\002 \001(\0132 .cockroach.proto.RangeD"
-    "escriptorB\004\310\336\037\000\"O\n\022AdminMergeResponse\0229\n"
-    "\006header\030\001 \001(\0132\037.cockroach.proto.Response"
-    "HeaderB\010\310\336\037\000\320\336\037\001B\007Z\005proto", 5305);
+    "\010\310\336\037\000\320\336\037\001\"\303\005\n\014RequestUnion\0224\n\010contains\030\001"
+    " \001(\0132 .cockroach.proto.ContainsRequestH\000"
+    "\022*\n\003get\030\002 \001(\0132\033.cockroach.proto.GetReque"
+    "stH\000\022*\n\003put\030\003 \001(\0132\033.cockroach.proto.PutR"
+    "equestH\000\022A\n\017conditional_put\030\004 \001(\0132&.cock"
+    "roach.proto.ConditionalPutRequestH\000\0226\n\ti"
+    "ncrement\030\005 \001(\0132!.cockroach.proto.Increme"
+    "ntRequestH\000\0220\n\006delete\030\006 \001(\0132\036.cockroach."
+    "proto.DeleteRequestH\000\022;\n\014delete_range\030\007 "
+    "\001(\0132#.cockroach.proto.DeleteRangeRequest"
+    "H\000\022,\n\004scan\030\010 \001(\0132\034.cockroach.proto.ScanR"
+    "equestH\000\022A\n\017end_transaction\030\t \001(\0132&.cock"
+    "roach.proto.EndTransactionRequestH\000\0227\n\nr"
+    "eap_queue\030\n \001(\0132!.cockroach.proto.ReapQu"
+    "eueRequestH\000\022\?\n\016enqueue_update\030\013 \001(\0132%.c"
+    "ockroach.proto.EnqueueUpdateRequestH\000\022A\n"
+    "\017enqueue_message\030\014 \001(\0132&.cockroach.proto"
+    ".EnqueueMessageRequestH\000:\004\310\240\037\001B\007\n\005value\""
+    "\320\005\n\rResponseUnion\0225\n\010contains\030\001 \001(\0132!.co"
+    "ckroach.proto.ContainsResponseH\000\022+\n\003get\030"
+    "\002 \001(\0132\034.cockroach.proto.GetResponseH\000\022+\n"
+    "\003put\030\003 \001(\0132\034.cockroach.proto.PutResponse"
+    "H\000\022B\n\017conditional_put\030\004 \001(\0132\'.cockroach."
+    "proto.ConditionalPutResponseH\000\0227\n\tincrem"
+    "ent\030\005 \001(\0132\".cockroach.proto.IncrementRes"
+    "ponseH\000\0221\n\006delete\030\006 \001(\0132\037.cockroach.prot"
+    "o.DeleteResponseH\000\022<\n\014delete_range\030\007 \001(\013"
+    "2$.cockroach.proto.DeleteRangeResponseH\000"
+    "\022-\n\004scan\030\010 \001(\0132\035.cockroach.proto.ScanRes"
+    "ponseH\000\022B\n\017end_transaction\030\t \001(\0132\'.cockr"
+    "oach.proto.EndTransactionResponseH\000\0228\n\nr"
+    "eap_queue\030\n \001(\0132\".cockroach.proto.ReapQu"
+    "eueResponseH\000\022@\n\016enqueue_update\030\013 \001(\0132&."
+    "cockroach.proto.EnqueueUpdateResponseH\000\022"
+    "B\n\017enqueue_message\030\014 \001(\0132\'.cockroach.pro"
+    "to.EnqueueMessageResponseH\000:\004\310\240\037\001B\007\n\005val"
+    "ue\"\177\n\014BatchRequest\0228\n\006header\030\001 \001(\0132\036.coc"
+    "kroach.proto.RequestHeaderB\010\310\336\037\000\320\336\037\001\0225\n\010"
+    "requests\030\002 \003(\0132\035.cockroach.proto.Request"
+    "UnionB\004\310\336\037\000\"\203\001\n\rBatchResponse\0229\n\006header\030"
+    "\001 \001(\0132\037.cockroach.proto.ResponseHeaderB\010"
+    "\310\336\037\000\320\336\037\001\0227\n\tresponses\030\002 \003(\0132\036.cockroach."
+    "proto.ResponseUnionB\004\310\336\037\000\"m\n\021AdminSplitR"
+    "equest\0228\n\006header\030\001 \001(\0132\036.cockroach.proto"
+    ".RequestHeaderB\010\310\336\037\000\320\336\037\001\022\036\n\tsplit_key\030\002 "
+    "\001(\014B\013\310\336\037\000\332\336\037\003Key\"O\n\022AdminSplitResponse\0229"
+    "\n\006header\030\001 \001(\0132\037.cockroach.proto.Respons"
+    "eHeaderB\010\310\336\037\000\320\336\037\001\"\215\001\n\021AdminMergeRequest\022"
+    "8\n\006header\030\001 \001(\0132\036.cockroach.proto.Reques"
+    "tHeaderB\010\310\336\037\000\320\336\037\001\022>\n\016subsumed_range\030\002 \001("
+    "\0132 .cockroach.proto.RangeDescriptorB\004\310\336\037"
+    "\000\"O\n\022AdminMergeResponse\0229\n\006header\030\001 \001(\0132"
+    "\037.cockroach.proto.ResponseHeaderB\010\310\336\037\000\320\336"
+    "\037\001B\007Z\005proto", 5371);
   ::google::protobuf::MessageFactory::InternalRegisterGeneratedFile(
     "cockroach/proto/api.proto", &protobuf_RegisterTypes);
   ClientCmdID::default_instance_ = new ClientCmdID();
@@ -1048,7 +1086,9 @@ void protobuf_AddDesc_cockroach_2fproto_2fapi_2eproto() {
   EnqueueMessageRequest::default_instance_ = new EnqueueMessageRequest();
   EnqueueMessageResponse::default_instance_ = new EnqueueMessageResponse();
   RequestUnion::default_instance_ = new RequestUnion();
+  RequestUnion_default_oneof_instance_ = new RequestUnionOneofInstance;
   ResponseUnion::default_instance_ = new ResponseUnion();
+  ResponseUnion_default_oneof_instance_ = new ResponseUnionOneofInstance;
   BatchRequest::default_instance_ = new BatchRequest();
   BatchResponse::default_instance_ = new BatchResponse();
   AdminSplitRequest::default_instance_ = new AdminSplitRequest();
@@ -8475,18 +8515,18 @@ RequestUnion::RequestUnion()
 }
 
 void RequestUnion::InitAsDefaultInstance() {
-  contains_ = const_cast< ::cockroach::proto::ContainsRequest*>(&::cockroach::proto::ContainsRequest::default_instance());
-  get_ = const_cast< ::cockroach::proto::GetRequest*>(&::cockroach::proto::GetRequest::default_instance());
-  put_ = const_cast< ::cockroach::proto::PutRequest*>(&::cockroach::proto::PutRequest::default_instance());
-  conditional_put_ = const_cast< ::cockroach::proto::ConditionalPutRequest*>(&::cockroach::proto::ConditionalPutRequest::default_instance());
-  increment_ = const_cast< ::cockroach::proto::IncrementRequest*>(&::cockroach::proto::IncrementRequest::default_instance());
-  delete__ = const_cast< ::cockroach::proto::DeleteRequest*>(&::cockroach::proto::DeleteRequest::default_instance());
-  delete_range_ = const_cast< ::cockroach::proto::DeleteRangeRequest*>(&::cockroach::proto::DeleteRangeRequest::default_instance());
-  scan_ = const_cast< ::cockroach::proto::ScanRequest*>(&::cockroach::proto::ScanRequest::default_instance());
-  end_transaction_ = const_cast< ::cockroach::proto::EndTransactionRequest*>(&::cockroach::proto::EndTransactionRequest::default_instance());
-  reap_queue_ = const_cast< ::cockroach::proto::ReapQueueRequest*>(&::cockroach::proto::ReapQueueRequest::default_instance());
-  enqueue_update_ = const_cast< ::cockroach::proto::EnqueueUpdateRequest*>(&::cockroach::proto::EnqueueUpdateRequest::default_instance());
-  enqueue_message_ = const_cast< ::cockroach::proto::EnqueueMessageRequest*>(&::cockroach::proto::EnqueueMessageRequest::default_instance());
+  RequestUnion_default_oneof_instance_->contains_ = const_cast< ::cockroach::proto::ContainsRequest*>(&::cockroach::proto::ContainsRequest::default_instance());
+  RequestUnion_default_oneof_instance_->get_ = const_cast< ::cockroach::proto::GetRequest*>(&::cockroach::proto::GetRequest::default_instance());
+  RequestUnion_default_oneof_instance_->put_ = const_cast< ::cockroach::proto::PutRequest*>(&::cockroach::proto::PutRequest::default_instance());
+  RequestUnion_default_oneof_instance_->conditional_put_ = const_cast< ::cockroach::proto::ConditionalPutRequest*>(&::cockroach::proto::ConditionalPutRequest::default_instance());
+  RequestUnion_default_oneof_instance_->increment_ = const_cast< ::cockroach::proto::IncrementRequest*>(&::cockroach::proto::IncrementRequest::default_instance());
+  RequestUnion_default_oneof_instance_->delete__ = const_cast< ::cockroach::proto::DeleteRequest*>(&::cockroach::proto::DeleteRequest::default_instance());
+  RequestUnion_default_oneof_instance_->delete_range_ = const_cast< ::cockroach::proto::DeleteRangeRequest*>(&::cockroach::proto::DeleteRangeRequest::default_instance());
+  RequestUnion_default_oneof_instance_->scan_ = const_cast< ::cockroach::proto::ScanRequest*>(&::cockroach::proto::ScanRequest::default_instance());
+  RequestUnion_default_oneof_instance_->end_transaction_ = const_cast< ::cockroach::proto::EndTransactionRequest*>(&::cockroach::proto::EndTransactionRequest::default_instance());
+  RequestUnion_default_oneof_instance_->reap_queue_ = const_cast< ::cockroach::proto::ReapQueueRequest*>(&::cockroach::proto::ReapQueueRequest::default_instance());
+  RequestUnion_default_oneof_instance_->enqueue_update_ = const_cast< ::cockroach::proto::EnqueueUpdateRequest*>(&::cockroach::proto::EnqueueUpdateRequest::default_instance());
+  RequestUnion_default_oneof_instance_->enqueue_message_ = const_cast< ::cockroach::proto::EnqueueMessageRequest*>(&::cockroach::proto::EnqueueMessageRequest::default_instance());
 }
 
 RequestUnion::RequestUnion(const RequestUnion& from)
@@ -8498,19 +8538,8 @@ RequestUnion::RequestUnion(const RequestUnion& from)
 
 void RequestUnion::SharedCtor() {
   _cached_size_ = 0;
-  contains_ = NULL;
-  get_ = NULL;
-  put_ = NULL;
-  conditional_put_ = NULL;
-  increment_ = NULL;
-  delete__ = NULL;
-  delete_range_ = NULL;
-  scan_ = NULL;
-  end_transaction_ = NULL;
-  reap_queue_ = NULL;
-  enqueue_update_ = NULL;
-  enqueue_message_ = NULL;
   ::memset(_has_bits_, 0, sizeof(_has_bits_));
+  clear_has_value();
 }
 
 RequestUnion::~RequestUnion() {
@@ -8519,19 +8548,10 @@ RequestUnion::~RequestUnion() {
 }
 
 void RequestUnion::SharedDtor() {
+  if (has_value()) {
+    clear_value();
+  }
   if (this != default_instance_) {
-    delete contains_;
-    delete get_;
-    delete put_;
-    delete conditional_put_;
-    delete increment_;
-    delete delete__;
-    delete delete_range_;
-    delete scan_;
-    delete end_transaction_;
-    delete reap_queue_;
-    delete enqueue_update_;
-    delete enqueue_message_;
   }
 }
 
@@ -8556,47 +8576,66 @@ RequestUnion* RequestUnion::New() const {
   return new RequestUnion;
 }
 
+void RequestUnion::clear_value() {
+  switch(value_case()) {
+    case kContains: {
+      delete value_.contains_;
+      break;
+    }
+    case kGet: {
+      delete value_.get_;
+      break;
+    }
+    case kPut: {
+      delete value_.put_;
+      break;
+    }
+    case kConditionalPut: {
+      delete value_.conditional_put_;
+      break;
+    }
+    case kIncrement: {
+      delete value_.increment_;
+      break;
+    }
+    case kDelete: {
+      delete value_.delete__;
+      break;
+    }
+    case kDeleteRange: {
+      delete value_.delete_range_;
+      break;
+    }
+    case kScan: {
+      delete value_.scan_;
+      break;
+    }
+    case kEndTransaction: {
+      delete value_.end_transaction_;
+      break;
+    }
+    case kReapQueue: {
+      delete value_.reap_queue_;
+      break;
+    }
+    case kEnqueueUpdate: {
+      delete value_.enqueue_update_;
+      break;
+    }
+    case kEnqueueMessage: {
+      delete value_.enqueue_message_;
+      break;
+    }
+    case VALUE_NOT_SET: {
+      break;
+    }
+  }
+  _oneof_case_[0] = VALUE_NOT_SET;
+}
+
+
 void RequestUnion::Clear() {
-  if (_has_bits_[0 / 32] & 255) {
-    if (has_contains()) {
-      if (contains_ != NULL) contains_->::cockroach::proto::ContainsRequest::Clear();
-    }
-    if (has_get()) {
-      if (get_ != NULL) get_->::cockroach::proto::GetRequest::Clear();
-    }
-    if (has_put()) {
-      if (put_ != NULL) put_->::cockroach::proto::PutRequest::Clear();
-    }
-    if (has_conditional_put()) {
-      if (conditional_put_ != NULL) conditional_put_->::cockroach::proto::ConditionalPutRequest::Clear();
-    }
-    if (has_increment()) {
-      if (increment_ != NULL) increment_->::cockroach::proto::IncrementRequest::Clear();
-    }
-    if (has_delete_()) {
-      if (delete__ != NULL) delete__->::cockroach::proto::DeleteRequest::Clear();
-    }
-    if (has_delete_range()) {
-      if (delete_range_ != NULL) delete_range_->::cockroach::proto::DeleteRangeRequest::Clear();
-    }
-    if (has_scan()) {
-      if (scan_ != NULL) scan_->::cockroach::proto::ScanRequest::Clear();
-    }
-  }
-  if (_has_bits_[8 / 32] & 3840) {
-    if (has_end_transaction()) {
-      if (end_transaction_ != NULL) end_transaction_->::cockroach::proto::EndTransactionRequest::Clear();
-    }
-    if (has_reap_queue()) {
-      if (reap_queue_ != NULL) reap_queue_->::cockroach::proto::ReapQueueRequest::Clear();
-    }
-    if (has_enqueue_update()) {
-      if (enqueue_update_ != NULL) enqueue_update_->::cockroach::proto::EnqueueUpdateRequest::Clear();
-    }
-    if (has_enqueue_message()) {
-      if (enqueue_message_ != NULL) enqueue_message_->::cockroach::proto::EnqueueMessageRequest::Clear();
-    }
-  }
+  clear_value();
   ::memset(_has_bits_, 0, sizeof(_has_bits_));
   mutable_unknown_fields()->Clear();
 }
@@ -8968,93 +9007,94 @@ void RequestUnion::SerializeWithCachedSizes(
 int RequestUnion::ByteSize() const {
   int total_size = 0;
 
-  if (_has_bits_[0 / 32] & (0xffu << (0 % 32))) {
+  switch (value_case()) {
     // optional .cockroach.proto.ContainsRequest contains = 1;
-    if (has_contains()) {
+    case kContains: {
       total_size += 1 +
         ::google::protobuf::internal::WireFormatLite::MessageSizeNoVirtual(
           this->contains());
+      break;
     }
-
     // optional .cockroach.proto.GetRequest get = 2;
-    if (has_get()) {
+    case kGet: {
       total_size += 1 +
         ::google::protobuf::internal::WireFormatLite::MessageSizeNoVirtual(
           this->get());
+      break;
     }
-
     // optional .cockroach.proto.PutRequest put = 3;
-    if (has_put()) {
+    case kPut: {
       total_size += 1 +
         ::google::protobuf::internal::WireFormatLite::MessageSizeNoVirtual(
           this->put());
+      break;
     }
-
     // optional .cockroach.proto.ConditionalPutRequest conditional_put = 4;
-    if (has_conditional_put()) {
+    case kConditionalPut: {
       total_size += 1 +
         ::google::protobuf::internal::WireFormatLite::MessageSizeNoVirtual(
           this->conditional_put());
+      break;
     }
-
     // optional .cockroach.proto.IncrementRequest increment = 5;
-    if (has_increment()) {
+    case kIncrement: {
       total_size += 1 +
         ::google::protobuf::internal::WireFormatLite::MessageSizeNoVirtual(
           this->increment());
+      break;
     }
-
     // optional .cockroach.proto.DeleteRequest delete = 6;
-    if (has_delete_()) {
+    case kDelete: {
       total_size += 1 +
         ::google::protobuf::internal::WireFormatLite::MessageSizeNoVirtual(
           this->delete_());
+      break;
     }
-
     // optional .cockroach.proto.DeleteRangeRequest delete_range = 7;
-    if (has_delete_range()) {
+    case kDeleteRange: {
       total_size += 1 +
         ::google::protobuf::internal::WireFormatLite::MessageSizeNoVirtual(
           this->delete_range());
+      break;
     }
-
     // optional .cockroach.proto.ScanRequest scan = 8;
-    if (has_scan()) {
+    case kScan: {
       total_size += 1 +
         ::google::protobuf::internal::WireFormatLite::MessageSizeNoVirtual(
           this->scan());
+      break;
     }
-
-  }
-  if (_has_bits_[8 / 32] & (0xffu << (8 % 32))) {
     // optional .cockroach.proto.EndTransactionRequest end_transaction = 9;
-    if (has_end_transaction()) {
+    case kEndTransaction: {
       total_size += 1 +
         ::google::protobuf::internal::WireFormatLite::MessageSizeNoVirtual(
           this->end_transaction());
+      break;
     }
-
     // optional .cockroach.proto.ReapQueueRequest reap_queue = 10;
-    if (has_reap_queue()) {
+    case kReapQueue: {
       total_size += 1 +
         ::google::protobuf::internal::WireFormatLite::MessageSizeNoVirtual(
           this->reap_queue());
+      break;
     }
-
     // optional .cockroach.proto.EnqueueUpdateRequest enqueue_update = 11;
-    if (has_enqueue_update()) {
+    case kEnqueueUpdate: {
       total_size += 1 +
         ::google::protobuf::internal::WireFormatLite::MessageSizeNoVirtual(
           this->enqueue_update());
+      break;
     }
-
     // optional .cockroach.proto.EnqueueMessageRequest enqueue_message = 12;
-    if (has_enqueue_message()) {
+    case kEnqueueMessage: {
       total_size += 1 +
         ::google::protobuf::internal::WireFormatLite::MessageSizeNoVirtual(
           this->enqueue_message());
+      break;
     }
-
+    case VALUE_NOT_SET: {
+      break;
+    }
   }
   if (!unknown_fields().empty()) {
     total_size +=
@@ -9081,44 +9121,57 @@ void RequestUnion::MergeFrom(const ::google::protobuf::Message& from) {
 
 void RequestUnion::MergeFrom(const RequestUnion& from) {
   GOOGLE_CHECK_NE(&from, this);
-  if (from._has_bits_[0 / 32] & (0xffu << (0 % 32))) {
-    if (from.has_contains()) {
+  switch (from.value_case()) {
+    case kContains: {
       mutable_contains()->::cockroach::proto::ContainsRequest::MergeFrom(from.contains());
+      break;
     }
-    if (from.has_get()) {
+    case kGet: {
       mutable_get()->::cockroach::proto::GetRequest::MergeFrom(from.get());
+      break;
     }
-    if (from.has_put()) {
+    case kPut: {
       mutable_put()->::cockroach::proto::PutRequest::MergeFrom(from.put());
+      break;
     }
-    if (from.has_conditional_put()) {
+    case kConditionalPut: {
       mutable_conditional_put()->::cockroach::proto::ConditionalPutRequest::MergeFrom(from.conditional_put());
+      break;
     }
-    if (from.has_increment()) {
+    case kIncrement: {
       mutable_increment()->::cockroach::proto::IncrementRequest::MergeFrom(from.increment());
+      break;
     }
-    if (from.has_delete_()) {
+    case kDelete: {
       mutable_delete_()->::cockroach::proto::DeleteRequest::MergeFrom(from.delete_());
+      break;
     }
-    if (from.has_delete_range()) {
+    case kDeleteRange: {
       mutable_delete_range()->::cockroach::proto::DeleteRangeRequest::MergeFrom(from.delete_range());
+      break;
     }
-    if (from.has_scan()) {
+    case kScan: {
       mutable_scan()->::cockroach::proto::ScanRequest::MergeFrom(from.scan());
+      break;
     }
-  }
-  if (from._has_bits_[8 / 32] & (0xffu << (8 % 32))) {
-    if (from.has_end_transaction()) {
+    case kEndTransaction: {
       mutable_end_transaction()->::cockroach::proto::EndTransactionRequest::MergeFrom(from.end_transaction());
+      break;
     }
-    if (from.has_reap_queue()) {
+    case kReapQueue: {
       mutable_reap_queue()->::cockroach::proto::ReapQueueRequest::MergeFrom(from.reap_queue());
+      break;
     }
-    if (from.has_enqueue_update()) {
+    case kEnqueueUpdate: {
       mutable_enqueue_update()->::cockroach::proto::EnqueueUpdateRequest::MergeFrom(from.enqueue_update());
+      break;
     }
-    if (from.has_enqueue_message()) {
+    case kEnqueueMessage: {
       mutable_enqueue_message()->::cockroach::proto::EnqueueMessageRequest::MergeFrom(from.enqueue_message());
+      break;
+    }
+    case VALUE_NOT_SET: {
+      break;
     }
   }
   mutable_unknown_fields()->MergeFrom(from.unknown_fields());
@@ -9143,18 +9196,8 @@ bool RequestUnion::IsInitialized() const {
 
 void RequestUnion::Swap(RequestUnion* other) {
   if (other != this) {
-    std::swap(contains_, other->contains_);
-    std::swap(get_, other->get_);
-    std::swap(put_, other->put_);
-    std::swap(conditional_put_, other->conditional_put_);
-    std::swap(increment_, other->increment_);
-    std::swap(delete__, other->delete__);
-    std::swap(delete_range_, other->delete_range_);
-    std::swap(scan_, other->scan_);
-    std::swap(end_transaction_, other->end_transaction_);
-    std::swap(reap_queue_, other->reap_queue_);
-    std::swap(enqueue_update_, other->enqueue_update_);
-    std::swap(enqueue_message_, other->enqueue_message_);
+    std::swap(value_, other->value_);
+    std::swap(_oneof_case_[0], other->_oneof_case_[0]);
     std::swap(_has_bits_[0], other->_has_bits_[0]);
     _unknown_fields_.Swap(&other->_unknown_fields_);
     std::swap(_cached_size_, other->_cached_size_);
@@ -9194,18 +9237,18 @@ ResponseUnion::ResponseUnion()
 }
 
 void ResponseUnion::InitAsDefaultInstance() {
-  contains_ = const_cast< ::cockroach::proto::ContainsResponse*>(&::cockroach::proto::ContainsResponse::default_instance());
-  get_ = const_cast< ::cockroach::proto::GetResponse*>(&::cockroach::proto::GetResponse::default_instance());
-  put_ = const_cast< ::cockroach::proto::PutResponse*>(&::cockroach::proto::PutResponse::default_instance());
-  conditional_put_ = const_cast< ::cockroach::proto::ConditionalPutResponse*>(&::cockroach::proto::ConditionalPutResponse::default_instance());
-  increment_ = const_cast< ::cockroach::proto::IncrementResponse*>(&::cockroach::proto::IncrementResponse::default_instance());
-  delete__ = const_cast< ::cockroach::proto::DeleteResponse*>(&::cockroach::proto::DeleteResponse::default_instance());
-  delete_range_ = const_cast< ::cockroach::proto::DeleteRangeResponse*>(&::cockroach::proto::DeleteRangeResponse::default_instance());
-  scan_ = const_cast< ::cockroach::proto::ScanResponse*>(&::cockroach::proto::ScanResponse::default_instance());
-  end_transaction_ = const_cast< ::cockroach::proto::EndTransactionResponse*>(&::cockroach::proto::EndTransactionResponse::default_instance());
-  reap_queue_ = const_cast< ::cockroach::proto::ReapQueueResponse*>(&::cockroach::proto::ReapQueueResponse::default_instance());
-  enqueue_update_ = const_cast< ::cockroach::proto::EnqueueUpdateResponse*>(&::cockroach::proto::EnqueueUpdateResponse::default_instance());
-  enqueue_message_ = const_cast< ::cockroach::proto::EnqueueMessageResponse*>(&::cockroach::proto::EnqueueMessageResponse::default_instance());
+  ResponseUnion_default_oneof_instance_->contains_ = const_cast< ::cockroach::proto::ContainsResponse*>(&::cockroach::proto::ContainsResponse::default_instance());
+  ResponseUnion_default_oneof_instance_->get_ = const_cast< ::cockroach::proto::GetResponse*>(&::cockroach::proto::GetResponse::default_instance());
+  ResponseUnion_default_oneof_instance_->put_ = const_cast< ::cockroach::proto::PutResponse*>(&::cockroach::proto::PutResponse::default_instance());
+  ResponseUnion_default_oneof_instance_->conditional_put_ = const_cast< ::cockroach::proto::ConditionalPutResponse*>(&::cockroach::proto::ConditionalPutResponse::default_instance());
+  ResponseUnion_default_oneof_instance_->increment_ = const_cast< ::cockroach::proto::IncrementResponse*>(&::cockroach::proto::IncrementResponse::default_instance());
+  ResponseUnion_default_oneof_instance_->delete__ = const_cast< ::cockroach::proto::DeleteResponse*>(&::cockroach::proto::DeleteResponse::default_instance());
+  ResponseUnion_default_oneof_instance_->delete_range_ = const_cast< ::cockroach::proto::DeleteRangeResponse*>(&::cockroach::proto::DeleteRangeResponse::default_instance());
+  ResponseUnion_default_oneof_instance_->scan_ = const_cast< ::cockroach::proto::ScanResponse*>(&::cockroach::proto::ScanResponse::default_instance());
+  ResponseUnion_default_oneof_instance_->end_transaction_ = const_cast< ::cockroach::proto::EndTransactionResponse*>(&::cockroach::proto::EndTransactionResponse::default_instance());
+  ResponseUnion_default_oneof_instance_->reap_queue_ = const_cast< ::cockroach::proto::ReapQueueResponse*>(&::cockroach::proto::ReapQueueResponse::default_instance());
+  ResponseUnion_default_oneof_instance_->enqueue_update_ = const_cast< ::cockroach::proto::EnqueueUpdateResponse*>(&::cockroach::proto::EnqueueUpdateResponse::default_instance());
+  ResponseUnion_default_oneof_instance_->enqueue_message_ = const_cast< ::cockroach::proto::EnqueueMessageResponse*>(&::cockroach::proto::EnqueueMessageResponse::default_instance());
 }
 
 ResponseUnion::ResponseUnion(const ResponseUnion& from)
@@ -9217,19 +9260,8 @@ ResponseUnion::ResponseUnion(const ResponseUnion& from)
 
 void ResponseUnion::SharedCtor() {
   _cached_size_ = 0;
-  contains_ = NULL;
-  get_ = NULL;
-  put_ = NULL;
-  conditional_put_ = NULL;
-  increment_ = NULL;
-  delete__ = NULL;
-  delete_range_ = NULL;
-  scan_ = NULL;
-  end_transaction_ = NULL;
-  reap_queue_ = NULL;
-  enqueue_update_ = NULL;
-  enqueue_message_ = NULL;
   ::memset(_has_bits_, 0, sizeof(_has_bits_));
+  clear_has_value();
 }
 
 ResponseUnion::~ResponseUnion() {
@@ -9238,19 +9270,10 @@ ResponseUnion::~ResponseUnion() {
 }
 
 void ResponseUnion::SharedDtor() {
+  if (has_value()) {
+    clear_value();
+  }
   if (this != default_instance_) {
-    delete contains_;
-    delete get_;
-    delete put_;
-    delete conditional_put_;
-    delete increment_;
-    delete delete__;
-    delete delete_range_;
-    delete scan_;
-    delete end_transaction_;
-    delete reap_queue_;
-    delete enqueue_update_;
-    delete enqueue_message_;
   }
 }
 
@@ -9275,47 +9298,66 @@ ResponseUnion* ResponseUnion::New() const {
   return new ResponseUnion;
 }
 
+void ResponseUnion::clear_value() {
+  switch(value_case()) {
+    case kContains: {
+      delete value_.contains_;
+      break;
+    }
+    case kGet: {
+      delete value_.get_;
+      break;
+    }
+    case kPut: {
+      delete value_.put_;
+      break;
+    }
+    case kConditionalPut: {
+      delete value_.conditional_put_;
+      break;
+    }
+    case kIncrement: {
+      delete value_.increment_;
+      break;
+    }
+    case kDelete: {
+      delete value_.delete__;
+      break;
+    }
+    case kDeleteRange: {
+      delete value_.delete_range_;
+      break;
+    }
+    case kScan: {
+      delete value_.scan_;
+      break;
+    }
+    case kEndTransaction: {
+      delete value_.end_transaction_;
+      break;
+    }
+    case kReapQueue: {
+      delete value_.reap_queue_;
+      break;
+    }
+    case kEnqueueUpdate: {
+      delete value_.enqueue_update_;
+      break;
+    }
+    case kEnqueueMessage: {
+      delete value_.enqueue_message_;
+      break;
+    }
+    case VALUE_NOT_SET: {
+      break;
+    }
+  }
+  _oneof_case_[0] = VALUE_NOT_SET;
+}
+
+
 void ResponseUnion::Clear() {
-  if (_has_bits_[0 / 32] & 255) {
-    if (has_contains()) {
-      if (contains_ != NULL) contains_->::cockroach::proto::ContainsResponse::Clear();
-    }
-    if (has_get()) {
-      if (get_ != NULL) get_->::cockroach::proto::GetResponse::Clear();
-    }
-    if (has_put()) {
-      if (put_ != NULL) put_->::cockroach::proto::PutResponse::Clear();
-    }
-    if (has_conditional_put()) {
-      if (conditional_put_ != NULL) conditional_put_->::cockroach::proto::ConditionalPutResponse::Clear();
-    }
-    if (has_increment()) {
-      if (increment_ != NULL) increment_->::cockroach::proto::IncrementResponse::Clear();
-    }
-    if (has_delete_()) {
-      if (delete__ != NULL) delete__->::cockroach::proto::DeleteResponse::Clear();
-    }
-    if (has_delete_range()) {
-      if (delete_range_ != NULL) delete_range_->::cockroach::proto::DeleteRangeResponse::Clear();
-    }
-    if (has_scan()) {
-      if (scan_ != NULL) scan_->::cockroach::proto::ScanResponse::Clear();
-    }
-  }
-  if (_has_bits_[8 / 32] & 3840) {
-    if (has_end_transaction()) {
-      if (end_transaction_ != NULL) end_transaction_->::cockroach::proto::EndTransactionResponse::Clear();
-    }
-    if (has_reap_queue()) {
-      if (reap_queue_ != NULL) reap_queue_->::cockroach::proto::ReapQueueResponse::Clear();
-    }
-    if (has_enqueue_update()) {
-      if (enqueue_update_ != NULL) enqueue_update_->::cockroach::proto::EnqueueUpdateResponse::Clear();
-    }
-    if (has_enqueue_message()) {
-      if (enqueue_message_ != NULL) enqueue_message_->::cockroach::proto::EnqueueMessageResponse::Clear();
-    }
-  }
+  clear_value();
   ::memset(_has_bits_, 0, sizeof(_has_bits_));
   mutable_unknown_fields()->Clear();
 }
@@ -9687,93 +9729,94 @@ void ResponseUnion::SerializeWithCachedSizes(
 int ResponseUnion::ByteSize() const {
   int total_size = 0;
 
-  if (_has_bits_[0 / 32] & (0xffu << (0 % 32))) {
+  switch (value_case()) {
     // optional .cockroach.proto.ContainsResponse contains = 1;
-    if (has_contains()) {
+    case kContains: {
       total_size += 1 +
         ::google::protobuf::internal::WireFormatLite::MessageSizeNoVirtual(
           this->contains());
+      break;
     }
-
     // optional .cockroach.proto.GetResponse get = 2;
-    if (has_get()) {
+    case kGet: {
       total_size += 1 +
         ::google::protobuf::internal::WireFormatLite::MessageSizeNoVirtual(
           this->get());
+      break;
     }
-
     // optional .cockroach.proto.PutResponse put = 3;
-    if (has_put()) {
+    case kPut: {
       total_size += 1 +
         ::google::protobuf::internal::WireFormatLite::MessageSizeNoVirtual(
           this->put());
+      break;
     }
-
     // optional .cockroach.proto.ConditionalPutResponse conditional_put = 4;
-    if (has_conditional_put()) {
+    case kConditionalPut: {
       total_size += 1 +
         ::google::protobuf::internal::WireFormatLite::MessageSizeNoVirtual(
           this->conditional_put());
+      break;
     }
-
     // optional .cockroach.proto.IncrementResponse increment = 5;
-    if (has_increment()) {
+    case kIncrement: {
       total_size += 1 +
         ::google::protobuf::internal::WireFormatLite::MessageSizeNoVirtual(
           this->increment());
+      break;
     }
-
     // optional .cockroach.proto.DeleteResponse delete = 6;
-    if (has_delete_()) {
+    case kDelete: {
       total_size += 1 +
         ::google::protobuf::internal::WireFormatLite::MessageSizeNoVirtual(
           this->delete_());
+      break;
     }
-
     // optional .cockroach.proto.DeleteRangeResponse delete_range = 7;
-    if (has_delete_range()) {
+    case kDeleteRange: {
       total_size += 1 +
         ::google::protobuf::internal::WireFormatLite::MessageSizeNoVirtual(
           this->delete_range());
+      break;
     }
-
     // optional .cockroach.proto.ScanResponse scan = 8;
-    if (has_scan()) {
+    case kScan: {
       total_size += 1 +
         ::google::protobuf::internal::WireFormatLite::MessageSizeNoVirtual(
           this->scan());
+      break;
     }
-
-  }
-  if (_has_bits_[8 / 32] & (0xffu << (8 % 32))) {
     // optional .cockroach.proto.EndTransactionResponse end_transaction = 9;
-    if (has_end_transaction()) {
+    case kEndTransaction: {
       total_size += 1 +
         ::google::protobuf::internal::WireFormatLite::MessageSizeNoVirtual(
           this->end_transaction());
+      break;
     }
-
     // optional .cockroach.proto.ReapQueueResponse reap_queue = 10;
-    if (has_reap_queue()) {
+    case kReapQueue: {
       total_size += 1 +
         ::google::protobuf::internal::WireFormatLite::MessageSizeNoVirtual(
           this->reap_queue());
+      break;
     }
-
     // optional .cockroach.proto.EnqueueUpdateResponse enqueue_update = 11;
-    if (has_enqueue_update()) {
+    case kEnqueueUpdate: {
       total_size += 1 +
         ::google::protobuf::internal::WireFormatLite::MessageSizeNoVirtual(
           this->enqueue_update());
+      break;
     }
-
     // optional .cockroach.proto.EnqueueMessageResponse enqueue_message = 12;
-    if (has_enqueue_message()) {
+    case kEnqueueMessage: {
       total_size += 1 +
         ::google::protobuf::internal::WireFormatLite::MessageSizeNoVirtual(
           this->enqueue_message());
+      break;
     }
-
+    case VALUE_NOT_SET: {
+      break;
+    }
   }
   if (!unknown_fields().empty()) {
     total_size +=
@@ -9800,44 +9843,57 @@ void ResponseUnion::MergeFrom(const ::google::protobuf::Message& from) {
 
 void ResponseUnion::MergeFrom(const ResponseUnion& from) {
   GOOGLE_CHECK_NE(&from, this);
-  if (from._has_bits_[0 / 32] & (0xffu << (0 % 32))) {
-    if (from.has_contains()) {
+  switch (from.value_case()) {
+    case kContains: {
       mutable_contains()->::cockroach::proto::ContainsResponse::MergeFrom(from.contains());
+      break;
     }
-    if (from.has_get()) {
+    case kGet: {
       mutable_get()->::cockroach::proto::GetResponse::MergeFrom(from.get());
+      break;
     }
-    if (from.has_put()) {
+    case kPut: {
       mutable_put()->::cockroach::proto::PutResponse::MergeFrom(from.put());
+      break;
     }
-    if (from.has_conditional_put()) {
+    case kConditionalPut: {
       mutable_conditional_put()->::cockroach::proto::ConditionalPutResponse::MergeFrom(from.conditional_put());
+      break;
     }
-    if (from.has_increment()) {
+    case kIncrement: {
       mutable_increment()->::cockroach::proto::IncrementResponse::MergeFrom(from.increment());
+      break;
     }
-    if (from.has_delete_()) {
+    case kDelete: {
       mutable_delete_()->::cockroach::proto::DeleteResponse::MergeFrom(from.delete_());
+      break;
     }
-    if (from.has_delete_range()) {
+    case kDeleteRange: {
       mutable_delete_range()->::cockroach::proto::DeleteRangeResponse::MergeFrom(from.delete_range());
+      break;
     }
-    if (from.has_scan()) {
+    case kScan: {
       mutable_scan()->::cockroach::proto::ScanResponse::MergeFrom(from.scan());
+      break;
     }
-  }
-  if (from._has_bits_[8 / 32] & (0xffu << (8 % 32))) {
-    if (from.has_end_transaction()) {
+    case kEndTransaction: {
       mutable_end_transaction()->::cockroach::proto::EndTransactionResponse::MergeFrom(from.end_transaction());
+      break;
     }
-    if (from.has_reap_queue()) {
+    case kReapQueue: {
       mutable_reap_queue()->::cockroach::proto::ReapQueueResponse::MergeFrom(from.reap_queue());
+      break;
     }
-    if (from.has_enqueue_update()) {
+    case kEnqueueUpdate: {
       mutable_enqueue_update()->::cockroach::proto::EnqueueUpdateResponse::MergeFrom(from.enqueue_update());
+      break;
     }
-    if (from.has_enqueue_message()) {
+    case kEnqueueMessage: {
       mutable_enqueue_message()->::cockroach::proto::EnqueueMessageResponse::MergeFrom(from.enqueue_message());
+      break;
+    }
+    case VALUE_NOT_SET: {
+      break;
     }
   }
   mutable_unknown_fields()->MergeFrom(from.unknown_fields());
@@ -9862,18 +9918,8 @@ bool ResponseUnion::IsInitialized() const {
 
 void ResponseUnion::Swap(ResponseUnion* other) {
   if (other != this) {
-    std::swap(contains_, other->contains_);
-    std::swap(get_, other->get_);
-    std::swap(put_, other->put_);
-    std::swap(conditional_put_, other->conditional_put_);
-    std::swap(increment_, other->increment_);
-    std::swap(delete__, other->delete__);
-    std::swap(delete_range_, other->delete_range_);
-    std::swap(scan_, other->scan_);
-    std::swap(end_transaction_, other->end_transaction_);
-    std::swap(reap_queue_, other->reap_queue_);
-    std::swap(enqueue_update_, other->enqueue_update_);
-    std::swap(enqueue_message_, other->enqueue_message_);
+    std::swap(value_, other->value_);
+    std::swap(_oneof_case_[0], other->_oneof_case_[0]);
     std::swap(_has_bits_[0], other->_has_bits_[0]);
     _unknown_fields_.Swap(&other->_unknown_fields_);
     std::swap(_cached_size_, other->_cached_size_);

--- a/storage/engine/cockroach/proto/api.pb.h
+++ b/storage/engine/cockroach/proto/api.pb.h
@@ -2607,6 +2607,22 @@ class RequestUnion : public ::google::protobuf::Message {
   static const ::google::protobuf::Descriptor* descriptor();
   static const RequestUnion& default_instance();
 
+  enum ValueCase {
+    kContains = 1,
+    kGet = 2,
+    kPut = 3,
+    kConditionalPut = 4,
+    kIncrement = 5,
+    kDelete = 6,
+    kDeleteRange = 7,
+    kScan = 8,
+    kEndTransaction = 9,
+    kReapQueue = 10,
+    kEnqueueUpdate = 11,
+    kEnqueueMessage = 12,
+    VALUE_NOT_SET = 0,
+  };
+
   void Swap(RequestUnion* other);
 
   // implements Message ----------------------------------------------
@@ -2745,49 +2761,46 @@ class RequestUnion : public ::google::protobuf::Message {
   inline ::cockroach::proto::EnqueueMessageRequest* release_enqueue_message();
   inline void set_allocated_enqueue_message(::cockroach::proto::EnqueueMessageRequest* enqueue_message);
 
+  inline ValueCase value_case() const;
   // @@protoc_insertion_point(class_scope:cockroach.proto.RequestUnion)
  private:
   inline void set_has_contains();
-  inline void clear_has_contains();
   inline void set_has_get();
-  inline void clear_has_get();
   inline void set_has_put();
-  inline void clear_has_put();
   inline void set_has_conditional_put();
-  inline void clear_has_conditional_put();
   inline void set_has_increment();
-  inline void clear_has_increment();
   inline void set_has_delete_();
-  inline void clear_has_delete_();
   inline void set_has_delete_range();
-  inline void clear_has_delete_range();
   inline void set_has_scan();
-  inline void clear_has_scan();
   inline void set_has_end_transaction();
-  inline void clear_has_end_transaction();
   inline void set_has_reap_queue();
-  inline void clear_has_reap_queue();
   inline void set_has_enqueue_update();
-  inline void clear_has_enqueue_update();
   inline void set_has_enqueue_message();
-  inline void clear_has_enqueue_message();
+
+  inline bool has_value();
+  void clear_value();
+  inline void clear_has_value();
 
   ::google::protobuf::UnknownFieldSet _unknown_fields_;
 
   ::google::protobuf::uint32 _has_bits_[1];
   mutable int _cached_size_;
-  ::cockroach::proto::ContainsRequest* contains_;
-  ::cockroach::proto::GetRequest* get_;
-  ::cockroach::proto::PutRequest* put_;
-  ::cockroach::proto::ConditionalPutRequest* conditional_put_;
-  ::cockroach::proto::IncrementRequest* increment_;
-  ::cockroach::proto::DeleteRequest* delete__;
-  ::cockroach::proto::DeleteRangeRequest* delete_range_;
-  ::cockroach::proto::ScanRequest* scan_;
-  ::cockroach::proto::EndTransactionRequest* end_transaction_;
-  ::cockroach::proto::ReapQueueRequest* reap_queue_;
-  ::cockroach::proto::EnqueueUpdateRequest* enqueue_update_;
-  ::cockroach::proto::EnqueueMessageRequest* enqueue_message_;
+  union ValueUnion {
+    ::cockroach::proto::ContainsRequest* contains_;
+    ::cockroach::proto::GetRequest* get_;
+    ::cockroach::proto::PutRequest* put_;
+    ::cockroach::proto::ConditionalPutRequest* conditional_put_;
+    ::cockroach::proto::IncrementRequest* increment_;
+    ::cockroach::proto::DeleteRequest* delete__;
+    ::cockroach::proto::DeleteRangeRequest* delete_range_;
+    ::cockroach::proto::ScanRequest* scan_;
+    ::cockroach::proto::EndTransactionRequest* end_transaction_;
+    ::cockroach::proto::ReapQueueRequest* reap_queue_;
+    ::cockroach::proto::EnqueueUpdateRequest* enqueue_update_;
+    ::cockroach::proto::EnqueueMessageRequest* enqueue_message_;
+  } value_;
+  ::google::protobuf::uint32 _oneof_case_[1];
+
   friend void  protobuf_AddDesc_cockroach_2fproto_2fapi_2eproto();
   friend void protobuf_AssignDesc_cockroach_2fproto_2fapi_2eproto();
   friend void protobuf_ShutdownFile_cockroach_2fproto_2fapi_2eproto();
@@ -2819,6 +2832,22 @@ class ResponseUnion : public ::google::protobuf::Message {
 
   static const ::google::protobuf::Descriptor* descriptor();
   static const ResponseUnion& default_instance();
+
+  enum ValueCase {
+    kContains = 1,
+    kGet = 2,
+    kPut = 3,
+    kConditionalPut = 4,
+    kIncrement = 5,
+    kDelete = 6,
+    kDeleteRange = 7,
+    kScan = 8,
+    kEndTransaction = 9,
+    kReapQueue = 10,
+    kEnqueueUpdate = 11,
+    kEnqueueMessage = 12,
+    VALUE_NOT_SET = 0,
+  };
 
   void Swap(ResponseUnion* other);
 
@@ -2958,49 +2987,46 @@ class ResponseUnion : public ::google::protobuf::Message {
   inline ::cockroach::proto::EnqueueMessageResponse* release_enqueue_message();
   inline void set_allocated_enqueue_message(::cockroach::proto::EnqueueMessageResponse* enqueue_message);
 
+  inline ValueCase value_case() const;
   // @@protoc_insertion_point(class_scope:cockroach.proto.ResponseUnion)
  private:
   inline void set_has_contains();
-  inline void clear_has_contains();
   inline void set_has_get();
-  inline void clear_has_get();
   inline void set_has_put();
-  inline void clear_has_put();
   inline void set_has_conditional_put();
-  inline void clear_has_conditional_put();
   inline void set_has_increment();
-  inline void clear_has_increment();
   inline void set_has_delete_();
-  inline void clear_has_delete_();
   inline void set_has_delete_range();
-  inline void clear_has_delete_range();
   inline void set_has_scan();
-  inline void clear_has_scan();
   inline void set_has_end_transaction();
-  inline void clear_has_end_transaction();
   inline void set_has_reap_queue();
-  inline void clear_has_reap_queue();
   inline void set_has_enqueue_update();
-  inline void clear_has_enqueue_update();
   inline void set_has_enqueue_message();
-  inline void clear_has_enqueue_message();
+
+  inline bool has_value();
+  void clear_value();
+  inline void clear_has_value();
 
   ::google::protobuf::UnknownFieldSet _unknown_fields_;
 
   ::google::protobuf::uint32 _has_bits_[1];
   mutable int _cached_size_;
-  ::cockroach::proto::ContainsResponse* contains_;
-  ::cockroach::proto::GetResponse* get_;
-  ::cockroach::proto::PutResponse* put_;
-  ::cockroach::proto::ConditionalPutResponse* conditional_put_;
-  ::cockroach::proto::IncrementResponse* increment_;
-  ::cockroach::proto::DeleteResponse* delete__;
-  ::cockroach::proto::DeleteRangeResponse* delete_range_;
-  ::cockroach::proto::ScanResponse* scan_;
-  ::cockroach::proto::EndTransactionResponse* end_transaction_;
-  ::cockroach::proto::ReapQueueResponse* reap_queue_;
-  ::cockroach::proto::EnqueueUpdateResponse* enqueue_update_;
-  ::cockroach::proto::EnqueueMessageResponse* enqueue_message_;
+  union ValueUnion {
+    ::cockroach::proto::ContainsResponse* contains_;
+    ::cockroach::proto::GetResponse* get_;
+    ::cockroach::proto::PutResponse* put_;
+    ::cockroach::proto::ConditionalPutResponse* conditional_put_;
+    ::cockroach::proto::IncrementResponse* increment_;
+    ::cockroach::proto::DeleteResponse* delete__;
+    ::cockroach::proto::DeleteRangeResponse* delete_range_;
+    ::cockroach::proto::ScanResponse* scan_;
+    ::cockroach::proto::EndTransactionResponse* end_transaction_;
+    ::cockroach::proto::ReapQueueResponse* reap_queue_;
+    ::cockroach::proto::EnqueueUpdateResponse* enqueue_update_;
+    ::cockroach::proto::EnqueueMessageResponse* enqueue_message_;
+  } value_;
+  ::google::protobuf::uint32 _oneof_case_[1];
+
   friend void  protobuf_AddDesc_cockroach_2fproto_2fapi_2eproto();
   friend void protobuf_AssignDesc_cockroach_2fproto_2fapi_2eproto();
   friend void protobuf_ShutdownFile_cockroach_2fproto_2fapi_2eproto();
@@ -5781,992 +5807,1058 @@ inline void EnqueueMessageResponse::set_allocated_header(::cockroach::proto::Res
 
 // optional .cockroach.proto.ContainsRequest contains = 1;
 inline bool RequestUnion::has_contains() const {
-  return (_has_bits_[0] & 0x00000001u) != 0;
+  return value_case() == kContains;
 }
 inline void RequestUnion::set_has_contains() {
-  _has_bits_[0] |= 0x00000001u;
-}
-inline void RequestUnion::clear_has_contains() {
-  _has_bits_[0] &= ~0x00000001u;
+  _oneof_case_[0] = kContains;
 }
 inline void RequestUnion::clear_contains() {
-  if (contains_ != NULL) contains_->::cockroach::proto::ContainsRequest::Clear();
-  clear_has_contains();
+  if (has_contains()) {
+    delete value_.contains_;
+    clear_has_value();
+  }
 }
 inline const ::cockroach::proto::ContainsRequest& RequestUnion::contains() const {
-  // @@protoc_insertion_point(field_get:cockroach.proto.RequestUnion.contains)
-  return contains_ != NULL ? *contains_ : *default_instance_->contains_;
+  return has_contains() ? *value_.contains_
+                      : ::cockroach::proto::ContainsRequest::default_instance();
 }
 inline ::cockroach::proto::ContainsRequest* RequestUnion::mutable_contains() {
-  set_has_contains();
-  if (contains_ == NULL) contains_ = new ::cockroach::proto::ContainsRequest;
-  // @@protoc_insertion_point(field_mutable:cockroach.proto.RequestUnion.contains)
-  return contains_;
+  if (!has_contains()) {
+    clear_value();
+    set_has_contains();
+    value_.contains_ = new ::cockroach::proto::ContainsRequest;
+  }
+  return value_.contains_;
 }
 inline ::cockroach::proto::ContainsRequest* RequestUnion::release_contains() {
-  clear_has_contains();
-  ::cockroach::proto::ContainsRequest* temp = contains_;
-  contains_ = NULL;
-  return temp;
+  if (has_contains()) {
+    clear_has_value();
+    ::cockroach::proto::ContainsRequest* temp = value_.contains_;
+    value_.contains_ = NULL;
+    return temp;
+  } else {
+    return NULL;
+  }
 }
 inline void RequestUnion::set_allocated_contains(::cockroach::proto::ContainsRequest* contains) {
-  delete contains_;
-  contains_ = contains;
+  clear_value();
   if (contains) {
     set_has_contains();
-  } else {
-    clear_has_contains();
+    value_.contains_ = contains;
   }
-  // @@protoc_insertion_point(field_set_allocated:cockroach.proto.RequestUnion.contains)
 }
 
 // optional .cockroach.proto.GetRequest get = 2;
 inline bool RequestUnion::has_get() const {
-  return (_has_bits_[0] & 0x00000002u) != 0;
+  return value_case() == kGet;
 }
 inline void RequestUnion::set_has_get() {
-  _has_bits_[0] |= 0x00000002u;
-}
-inline void RequestUnion::clear_has_get() {
-  _has_bits_[0] &= ~0x00000002u;
+  _oneof_case_[0] = kGet;
 }
 inline void RequestUnion::clear_get() {
-  if (get_ != NULL) get_->::cockroach::proto::GetRequest::Clear();
-  clear_has_get();
+  if (has_get()) {
+    delete value_.get_;
+    clear_has_value();
+  }
 }
 inline const ::cockroach::proto::GetRequest& RequestUnion::get() const {
-  // @@protoc_insertion_point(field_get:cockroach.proto.RequestUnion.get)
-  return get_ != NULL ? *get_ : *default_instance_->get_;
+  return has_get() ? *value_.get_
+                      : ::cockroach::proto::GetRequest::default_instance();
 }
 inline ::cockroach::proto::GetRequest* RequestUnion::mutable_get() {
-  set_has_get();
-  if (get_ == NULL) get_ = new ::cockroach::proto::GetRequest;
-  // @@protoc_insertion_point(field_mutable:cockroach.proto.RequestUnion.get)
-  return get_;
+  if (!has_get()) {
+    clear_value();
+    set_has_get();
+    value_.get_ = new ::cockroach::proto::GetRequest;
+  }
+  return value_.get_;
 }
 inline ::cockroach::proto::GetRequest* RequestUnion::release_get() {
-  clear_has_get();
-  ::cockroach::proto::GetRequest* temp = get_;
-  get_ = NULL;
-  return temp;
+  if (has_get()) {
+    clear_has_value();
+    ::cockroach::proto::GetRequest* temp = value_.get_;
+    value_.get_ = NULL;
+    return temp;
+  } else {
+    return NULL;
+  }
 }
 inline void RequestUnion::set_allocated_get(::cockroach::proto::GetRequest* get) {
-  delete get_;
-  get_ = get;
+  clear_value();
   if (get) {
     set_has_get();
-  } else {
-    clear_has_get();
+    value_.get_ = get;
   }
-  // @@protoc_insertion_point(field_set_allocated:cockroach.proto.RequestUnion.get)
 }
 
 // optional .cockroach.proto.PutRequest put = 3;
 inline bool RequestUnion::has_put() const {
-  return (_has_bits_[0] & 0x00000004u) != 0;
+  return value_case() == kPut;
 }
 inline void RequestUnion::set_has_put() {
-  _has_bits_[0] |= 0x00000004u;
-}
-inline void RequestUnion::clear_has_put() {
-  _has_bits_[0] &= ~0x00000004u;
+  _oneof_case_[0] = kPut;
 }
 inline void RequestUnion::clear_put() {
-  if (put_ != NULL) put_->::cockroach::proto::PutRequest::Clear();
-  clear_has_put();
+  if (has_put()) {
+    delete value_.put_;
+    clear_has_value();
+  }
 }
 inline const ::cockroach::proto::PutRequest& RequestUnion::put() const {
-  // @@protoc_insertion_point(field_get:cockroach.proto.RequestUnion.put)
-  return put_ != NULL ? *put_ : *default_instance_->put_;
+  return has_put() ? *value_.put_
+                      : ::cockroach::proto::PutRequest::default_instance();
 }
 inline ::cockroach::proto::PutRequest* RequestUnion::mutable_put() {
-  set_has_put();
-  if (put_ == NULL) put_ = new ::cockroach::proto::PutRequest;
-  // @@protoc_insertion_point(field_mutable:cockroach.proto.RequestUnion.put)
-  return put_;
+  if (!has_put()) {
+    clear_value();
+    set_has_put();
+    value_.put_ = new ::cockroach::proto::PutRequest;
+  }
+  return value_.put_;
 }
 inline ::cockroach::proto::PutRequest* RequestUnion::release_put() {
-  clear_has_put();
-  ::cockroach::proto::PutRequest* temp = put_;
-  put_ = NULL;
-  return temp;
+  if (has_put()) {
+    clear_has_value();
+    ::cockroach::proto::PutRequest* temp = value_.put_;
+    value_.put_ = NULL;
+    return temp;
+  } else {
+    return NULL;
+  }
 }
 inline void RequestUnion::set_allocated_put(::cockroach::proto::PutRequest* put) {
-  delete put_;
-  put_ = put;
+  clear_value();
   if (put) {
     set_has_put();
-  } else {
-    clear_has_put();
+    value_.put_ = put;
   }
-  // @@protoc_insertion_point(field_set_allocated:cockroach.proto.RequestUnion.put)
 }
 
 // optional .cockroach.proto.ConditionalPutRequest conditional_put = 4;
 inline bool RequestUnion::has_conditional_put() const {
-  return (_has_bits_[0] & 0x00000008u) != 0;
+  return value_case() == kConditionalPut;
 }
 inline void RequestUnion::set_has_conditional_put() {
-  _has_bits_[0] |= 0x00000008u;
-}
-inline void RequestUnion::clear_has_conditional_put() {
-  _has_bits_[0] &= ~0x00000008u;
+  _oneof_case_[0] = kConditionalPut;
 }
 inline void RequestUnion::clear_conditional_put() {
-  if (conditional_put_ != NULL) conditional_put_->::cockroach::proto::ConditionalPutRequest::Clear();
-  clear_has_conditional_put();
+  if (has_conditional_put()) {
+    delete value_.conditional_put_;
+    clear_has_value();
+  }
 }
 inline const ::cockroach::proto::ConditionalPutRequest& RequestUnion::conditional_put() const {
-  // @@protoc_insertion_point(field_get:cockroach.proto.RequestUnion.conditional_put)
-  return conditional_put_ != NULL ? *conditional_put_ : *default_instance_->conditional_put_;
+  return has_conditional_put() ? *value_.conditional_put_
+                      : ::cockroach::proto::ConditionalPutRequest::default_instance();
 }
 inline ::cockroach::proto::ConditionalPutRequest* RequestUnion::mutable_conditional_put() {
-  set_has_conditional_put();
-  if (conditional_put_ == NULL) conditional_put_ = new ::cockroach::proto::ConditionalPutRequest;
-  // @@protoc_insertion_point(field_mutable:cockroach.proto.RequestUnion.conditional_put)
-  return conditional_put_;
+  if (!has_conditional_put()) {
+    clear_value();
+    set_has_conditional_put();
+    value_.conditional_put_ = new ::cockroach::proto::ConditionalPutRequest;
+  }
+  return value_.conditional_put_;
 }
 inline ::cockroach::proto::ConditionalPutRequest* RequestUnion::release_conditional_put() {
-  clear_has_conditional_put();
-  ::cockroach::proto::ConditionalPutRequest* temp = conditional_put_;
-  conditional_put_ = NULL;
-  return temp;
+  if (has_conditional_put()) {
+    clear_has_value();
+    ::cockroach::proto::ConditionalPutRequest* temp = value_.conditional_put_;
+    value_.conditional_put_ = NULL;
+    return temp;
+  } else {
+    return NULL;
+  }
 }
 inline void RequestUnion::set_allocated_conditional_put(::cockroach::proto::ConditionalPutRequest* conditional_put) {
-  delete conditional_put_;
-  conditional_put_ = conditional_put;
+  clear_value();
   if (conditional_put) {
     set_has_conditional_put();
-  } else {
-    clear_has_conditional_put();
+    value_.conditional_put_ = conditional_put;
   }
-  // @@protoc_insertion_point(field_set_allocated:cockroach.proto.RequestUnion.conditional_put)
 }
 
 // optional .cockroach.proto.IncrementRequest increment = 5;
 inline bool RequestUnion::has_increment() const {
-  return (_has_bits_[0] & 0x00000010u) != 0;
+  return value_case() == kIncrement;
 }
 inline void RequestUnion::set_has_increment() {
-  _has_bits_[0] |= 0x00000010u;
-}
-inline void RequestUnion::clear_has_increment() {
-  _has_bits_[0] &= ~0x00000010u;
+  _oneof_case_[0] = kIncrement;
 }
 inline void RequestUnion::clear_increment() {
-  if (increment_ != NULL) increment_->::cockroach::proto::IncrementRequest::Clear();
-  clear_has_increment();
+  if (has_increment()) {
+    delete value_.increment_;
+    clear_has_value();
+  }
 }
 inline const ::cockroach::proto::IncrementRequest& RequestUnion::increment() const {
-  // @@protoc_insertion_point(field_get:cockroach.proto.RequestUnion.increment)
-  return increment_ != NULL ? *increment_ : *default_instance_->increment_;
+  return has_increment() ? *value_.increment_
+                      : ::cockroach::proto::IncrementRequest::default_instance();
 }
 inline ::cockroach::proto::IncrementRequest* RequestUnion::mutable_increment() {
-  set_has_increment();
-  if (increment_ == NULL) increment_ = new ::cockroach::proto::IncrementRequest;
-  // @@protoc_insertion_point(field_mutable:cockroach.proto.RequestUnion.increment)
-  return increment_;
+  if (!has_increment()) {
+    clear_value();
+    set_has_increment();
+    value_.increment_ = new ::cockroach::proto::IncrementRequest;
+  }
+  return value_.increment_;
 }
 inline ::cockroach::proto::IncrementRequest* RequestUnion::release_increment() {
-  clear_has_increment();
-  ::cockroach::proto::IncrementRequest* temp = increment_;
-  increment_ = NULL;
-  return temp;
+  if (has_increment()) {
+    clear_has_value();
+    ::cockroach::proto::IncrementRequest* temp = value_.increment_;
+    value_.increment_ = NULL;
+    return temp;
+  } else {
+    return NULL;
+  }
 }
 inline void RequestUnion::set_allocated_increment(::cockroach::proto::IncrementRequest* increment) {
-  delete increment_;
-  increment_ = increment;
+  clear_value();
   if (increment) {
     set_has_increment();
-  } else {
-    clear_has_increment();
+    value_.increment_ = increment;
   }
-  // @@protoc_insertion_point(field_set_allocated:cockroach.proto.RequestUnion.increment)
 }
 
 // optional .cockroach.proto.DeleteRequest delete = 6;
 inline bool RequestUnion::has_delete_() const {
-  return (_has_bits_[0] & 0x00000020u) != 0;
+  return value_case() == kDelete;
 }
 inline void RequestUnion::set_has_delete_() {
-  _has_bits_[0] |= 0x00000020u;
-}
-inline void RequestUnion::clear_has_delete_() {
-  _has_bits_[0] &= ~0x00000020u;
+  _oneof_case_[0] = kDelete;
 }
 inline void RequestUnion::clear_delete_() {
-  if (delete__ != NULL) delete__->::cockroach::proto::DeleteRequest::Clear();
-  clear_has_delete_();
+  if (has_delete_()) {
+    delete value_.delete__;
+    clear_has_value();
+  }
 }
 inline const ::cockroach::proto::DeleteRequest& RequestUnion::delete_() const {
-  // @@protoc_insertion_point(field_get:cockroach.proto.RequestUnion.delete)
-  return delete__ != NULL ? *delete__ : *default_instance_->delete__;
+  return has_delete_() ? *value_.delete__
+                      : ::cockroach::proto::DeleteRequest::default_instance();
 }
 inline ::cockroach::proto::DeleteRequest* RequestUnion::mutable_delete_() {
-  set_has_delete_();
-  if (delete__ == NULL) delete__ = new ::cockroach::proto::DeleteRequest;
-  // @@protoc_insertion_point(field_mutable:cockroach.proto.RequestUnion.delete)
-  return delete__;
+  if (!has_delete_()) {
+    clear_value();
+    set_has_delete_();
+    value_.delete__ = new ::cockroach::proto::DeleteRequest;
+  }
+  return value_.delete__;
 }
 inline ::cockroach::proto::DeleteRequest* RequestUnion::release_delete_() {
-  clear_has_delete_();
-  ::cockroach::proto::DeleteRequest* temp = delete__;
-  delete__ = NULL;
-  return temp;
+  if (has_delete_()) {
+    clear_has_value();
+    ::cockroach::proto::DeleteRequest* temp = value_.delete__;
+    value_.delete__ = NULL;
+    return temp;
+  } else {
+    return NULL;
+  }
 }
 inline void RequestUnion::set_allocated_delete_(::cockroach::proto::DeleteRequest* delete_) {
-  delete delete__;
-  delete__ = delete_;
+  clear_value();
   if (delete_) {
     set_has_delete_();
-  } else {
-    clear_has_delete_();
+    value_.delete__ = delete_;
   }
-  // @@protoc_insertion_point(field_set_allocated:cockroach.proto.RequestUnion.delete)
 }
 
 // optional .cockroach.proto.DeleteRangeRequest delete_range = 7;
 inline bool RequestUnion::has_delete_range() const {
-  return (_has_bits_[0] & 0x00000040u) != 0;
+  return value_case() == kDeleteRange;
 }
 inline void RequestUnion::set_has_delete_range() {
-  _has_bits_[0] |= 0x00000040u;
-}
-inline void RequestUnion::clear_has_delete_range() {
-  _has_bits_[0] &= ~0x00000040u;
+  _oneof_case_[0] = kDeleteRange;
 }
 inline void RequestUnion::clear_delete_range() {
-  if (delete_range_ != NULL) delete_range_->::cockroach::proto::DeleteRangeRequest::Clear();
-  clear_has_delete_range();
+  if (has_delete_range()) {
+    delete value_.delete_range_;
+    clear_has_value();
+  }
 }
 inline const ::cockroach::proto::DeleteRangeRequest& RequestUnion::delete_range() const {
-  // @@protoc_insertion_point(field_get:cockroach.proto.RequestUnion.delete_range)
-  return delete_range_ != NULL ? *delete_range_ : *default_instance_->delete_range_;
+  return has_delete_range() ? *value_.delete_range_
+                      : ::cockroach::proto::DeleteRangeRequest::default_instance();
 }
 inline ::cockroach::proto::DeleteRangeRequest* RequestUnion::mutable_delete_range() {
-  set_has_delete_range();
-  if (delete_range_ == NULL) delete_range_ = new ::cockroach::proto::DeleteRangeRequest;
-  // @@protoc_insertion_point(field_mutable:cockroach.proto.RequestUnion.delete_range)
-  return delete_range_;
+  if (!has_delete_range()) {
+    clear_value();
+    set_has_delete_range();
+    value_.delete_range_ = new ::cockroach::proto::DeleteRangeRequest;
+  }
+  return value_.delete_range_;
 }
 inline ::cockroach::proto::DeleteRangeRequest* RequestUnion::release_delete_range() {
-  clear_has_delete_range();
-  ::cockroach::proto::DeleteRangeRequest* temp = delete_range_;
-  delete_range_ = NULL;
-  return temp;
+  if (has_delete_range()) {
+    clear_has_value();
+    ::cockroach::proto::DeleteRangeRequest* temp = value_.delete_range_;
+    value_.delete_range_ = NULL;
+    return temp;
+  } else {
+    return NULL;
+  }
 }
 inline void RequestUnion::set_allocated_delete_range(::cockroach::proto::DeleteRangeRequest* delete_range) {
-  delete delete_range_;
-  delete_range_ = delete_range;
+  clear_value();
   if (delete_range) {
     set_has_delete_range();
-  } else {
-    clear_has_delete_range();
+    value_.delete_range_ = delete_range;
   }
-  // @@protoc_insertion_point(field_set_allocated:cockroach.proto.RequestUnion.delete_range)
 }
 
 // optional .cockroach.proto.ScanRequest scan = 8;
 inline bool RequestUnion::has_scan() const {
-  return (_has_bits_[0] & 0x00000080u) != 0;
+  return value_case() == kScan;
 }
 inline void RequestUnion::set_has_scan() {
-  _has_bits_[0] |= 0x00000080u;
-}
-inline void RequestUnion::clear_has_scan() {
-  _has_bits_[0] &= ~0x00000080u;
+  _oneof_case_[0] = kScan;
 }
 inline void RequestUnion::clear_scan() {
-  if (scan_ != NULL) scan_->::cockroach::proto::ScanRequest::Clear();
-  clear_has_scan();
+  if (has_scan()) {
+    delete value_.scan_;
+    clear_has_value();
+  }
 }
 inline const ::cockroach::proto::ScanRequest& RequestUnion::scan() const {
-  // @@protoc_insertion_point(field_get:cockroach.proto.RequestUnion.scan)
-  return scan_ != NULL ? *scan_ : *default_instance_->scan_;
+  return has_scan() ? *value_.scan_
+                      : ::cockroach::proto::ScanRequest::default_instance();
 }
 inline ::cockroach::proto::ScanRequest* RequestUnion::mutable_scan() {
-  set_has_scan();
-  if (scan_ == NULL) scan_ = new ::cockroach::proto::ScanRequest;
-  // @@protoc_insertion_point(field_mutable:cockroach.proto.RequestUnion.scan)
-  return scan_;
+  if (!has_scan()) {
+    clear_value();
+    set_has_scan();
+    value_.scan_ = new ::cockroach::proto::ScanRequest;
+  }
+  return value_.scan_;
 }
 inline ::cockroach::proto::ScanRequest* RequestUnion::release_scan() {
-  clear_has_scan();
-  ::cockroach::proto::ScanRequest* temp = scan_;
-  scan_ = NULL;
-  return temp;
+  if (has_scan()) {
+    clear_has_value();
+    ::cockroach::proto::ScanRequest* temp = value_.scan_;
+    value_.scan_ = NULL;
+    return temp;
+  } else {
+    return NULL;
+  }
 }
 inline void RequestUnion::set_allocated_scan(::cockroach::proto::ScanRequest* scan) {
-  delete scan_;
-  scan_ = scan;
+  clear_value();
   if (scan) {
     set_has_scan();
-  } else {
-    clear_has_scan();
+    value_.scan_ = scan;
   }
-  // @@protoc_insertion_point(field_set_allocated:cockroach.proto.RequestUnion.scan)
 }
 
 // optional .cockroach.proto.EndTransactionRequest end_transaction = 9;
 inline bool RequestUnion::has_end_transaction() const {
-  return (_has_bits_[0] & 0x00000100u) != 0;
+  return value_case() == kEndTransaction;
 }
 inline void RequestUnion::set_has_end_transaction() {
-  _has_bits_[0] |= 0x00000100u;
-}
-inline void RequestUnion::clear_has_end_transaction() {
-  _has_bits_[0] &= ~0x00000100u;
+  _oneof_case_[0] = kEndTransaction;
 }
 inline void RequestUnion::clear_end_transaction() {
-  if (end_transaction_ != NULL) end_transaction_->::cockroach::proto::EndTransactionRequest::Clear();
-  clear_has_end_transaction();
+  if (has_end_transaction()) {
+    delete value_.end_transaction_;
+    clear_has_value();
+  }
 }
 inline const ::cockroach::proto::EndTransactionRequest& RequestUnion::end_transaction() const {
-  // @@protoc_insertion_point(field_get:cockroach.proto.RequestUnion.end_transaction)
-  return end_transaction_ != NULL ? *end_transaction_ : *default_instance_->end_transaction_;
+  return has_end_transaction() ? *value_.end_transaction_
+                      : ::cockroach::proto::EndTransactionRequest::default_instance();
 }
 inline ::cockroach::proto::EndTransactionRequest* RequestUnion::mutable_end_transaction() {
-  set_has_end_transaction();
-  if (end_transaction_ == NULL) end_transaction_ = new ::cockroach::proto::EndTransactionRequest;
-  // @@protoc_insertion_point(field_mutable:cockroach.proto.RequestUnion.end_transaction)
-  return end_transaction_;
+  if (!has_end_transaction()) {
+    clear_value();
+    set_has_end_transaction();
+    value_.end_transaction_ = new ::cockroach::proto::EndTransactionRequest;
+  }
+  return value_.end_transaction_;
 }
 inline ::cockroach::proto::EndTransactionRequest* RequestUnion::release_end_transaction() {
-  clear_has_end_transaction();
-  ::cockroach::proto::EndTransactionRequest* temp = end_transaction_;
-  end_transaction_ = NULL;
-  return temp;
+  if (has_end_transaction()) {
+    clear_has_value();
+    ::cockroach::proto::EndTransactionRequest* temp = value_.end_transaction_;
+    value_.end_transaction_ = NULL;
+    return temp;
+  } else {
+    return NULL;
+  }
 }
 inline void RequestUnion::set_allocated_end_transaction(::cockroach::proto::EndTransactionRequest* end_transaction) {
-  delete end_transaction_;
-  end_transaction_ = end_transaction;
+  clear_value();
   if (end_transaction) {
     set_has_end_transaction();
-  } else {
-    clear_has_end_transaction();
+    value_.end_transaction_ = end_transaction;
   }
-  // @@protoc_insertion_point(field_set_allocated:cockroach.proto.RequestUnion.end_transaction)
 }
 
 // optional .cockroach.proto.ReapQueueRequest reap_queue = 10;
 inline bool RequestUnion::has_reap_queue() const {
-  return (_has_bits_[0] & 0x00000200u) != 0;
+  return value_case() == kReapQueue;
 }
 inline void RequestUnion::set_has_reap_queue() {
-  _has_bits_[0] |= 0x00000200u;
-}
-inline void RequestUnion::clear_has_reap_queue() {
-  _has_bits_[0] &= ~0x00000200u;
+  _oneof_case_[0] = kReapQueue;
 }
 inline void RequestUnion::clear_reap_queue() {
-  if (reap_queue_ != NULL) reap_queue_->::cockroach::proto::ReapQueueRequest::Clear();
-  clear_has_reap_queue();
+  if (has_reap_queue()) {
+    delete value_.reap_queue_;
+    clear_has_value();
+  }
 }
 inline const ::cockroach::proto::ReapQueueRequest& RequestUnion::reap_queue() const {
-  // @@protoc_insertion_point(field_get:cockroach.proto.RequestUnion.reap_queue)
-  return reap_queue_ != NULL ? *reap_queue_ : *default_instance_->reap_queue_;
+  return has_reap_queue() ? *value_.reap_queue_
+                      : ::cockroach::proto::ReapQueueRequest::default_instance();
 }
 inline ::cockroach::proto::ReapQueueRequest* RequestUnion::mutable_reap_queue() {
-  set_has_reap_queue();
-  if (reap_queue_ == NULL) reap_queue_ = new ::cockroach::proto::ReapQueueRequest;
-  // @@protoc_insertion_point(field_mutable:cockroach.proto.RequestUnion.reap_queue)
-  return reap_queue_;
+  if (!has_reap_queue()) {
+    clear_value();
+    set_has_reap_queue();
+    value_.reap_queue_ = new ::cockroach::proto::ReapQueueRequest;
+  }
+  return value_.reap_queue_;
 }
 inline ::cockroach::proto::ReapQueueRequest* RequestUnion::release_reap_queue() {
-  clear_has_reap_queue();
-  ::cockroach::proto::ReapQueueRequest* temp = reap_queue_;
-  reap_queue_ = NULL;
-  return temp;
+  if (has_reap_queue()) {
+    clear_has_value();
+    ::cockroach::proto::ReapQueueRequest* temp = value_.reap_queue_;
+    value_.reap_queue_ = NULL;
+    return temp;
+  } else {
+    return NULL;
+  }
 }
 inline void RequestUnion::set_allocated_reap_queue(::cockroach::proto::ReapQueueRequest* reap_queue) {
-  delete reap_queue_;
-  reap_queue_ = reap_queue;
+  clear_value();
   if (reap_queue) {
     set_has_reap_queue();
-  } else {
-    clear_has_reap_queue();
+    value_.reap_queue_ = reap_queue;
   }
-  // @@protoc_insertion_point(field_set_allocated:cockroach.proto.RequestUnion.reap_queue)
 }
 
 // optional .cockroach.proto.EnqueueUpdateRequest enqueue_update = 11;
 inline bool RequestUnion::has_enqueue_update() const {
-  return (_has_bits_[0] & 0x00000400u) != 0;
+  return value_case() == kEnqueueUpdate;
 }
 inline void RequestUnion::set_has_enqueue_update() {
-  _has_bits_[0] |= 0x00000400u;
-}
-inline void RequestUnion::clear_has_enqueue_update() {
-  _has_bits_[0] &= ~0x00000400u;
+  _oneof_case_[0] = kEnqueueUpdate;
 }
 inline void RequestUnion::clear_enqueue_update() {
-  if (enqueue_update_ != NULL) enqueue_update_->::cockroach::proto::EnqueueUpdateRequest::Clear();
-  clear_has_enqueue_update();
+  if (has_enqueue_update()) {
+    delete value_.enqueue_update_;
+    clear_has_value();
+  }
 }
 inline const ::cockroach::proto::EnqueueUpdateRequest& RequestUnion::enqueue_update() const {
-  // @@protoc_insertion_point(field_get:cockroach.proto.RequestUnion.enqueue_update)
-  return enqueue_update_ != NULL ? *enqueue_update_ : *default_instance_->enqueue_update_;
+  return has_enqueue_update() ? *value_.enqueue_update_
+                      : ::cockroach::proto::EnqueueUpdateRequest::default_instance();
 }
 inline ::cockroach::proto::EnqueueUpdateRequest* RequestUnion::mutable_enqueue_update() {
-  set_has_enqueue_update();
-  if (enqueue_update_ == NULL) enqueue_update_ = new ::cockroach::proto::EnqueueUpdateRequest;
-  // @@protoc_insertion_point(field_mutable:cockroach.proto.RequestUnion.enqueue_update)
-  return enqueue_update_;
+  if (!has_enqueue_update()) {
+    clear_value();
+    set_has_enqueue_update();
+    value_.enqueue_update_ = new ::cockroach::proto::EnqueueUpdateRequest;
+  }
+  return value_.enqueue_update_;
 }
 inline ::cockroach::proto::EnqueueUpdateRequest* RequestUnion::release_enqueue_update() {
-  clear_has_enqueue_update();
-  ::cockroach::proto::EnqueueUpdateRequest* temp = enqueue_update_;
-  enqueue_update_ = NULL;
-  return temp;
+  if (has_enqueue_update()) {
+    clear_has_value();
+    ::cockroach::proto::EnqueueUpdateRequest* temp = value_.enqueue_update_;
+    value_.enqueue_update_ = NULL;
+    return temp;
+  } else {
+    return NULL;
+  }
 }
 inline void RequestUnion::set_allocated_enqueue_update(::cockroach::proto::EnqueueUpdateRequest* enqueue_update) {
-  delete enqueue_update_;
-  enqueue_update_ = enqueue_update;
+  clear_value();
   if (enqueue_update) {
     set_has_enqueue_update();
-  } else {
-    clear_has_enqueue_update();
+    value_.enqueue_update_ = enqueue_update;
   }
-  // @@protoc_insertion_point(field_set_allocated:cockroach.proto.RequestUnion.enqueue_update)
 }
 
 // optional .cockroach.proto.EnqueueMessageRequest enqueue_message = 12;
 inline bool RequestUnion::has_enqueue_message() const {
-  return (_has_bits_[0] & 0x00000800u) != 0;
+  return value_case() == kEnqueueMessage;
 }
 inline void RequestUnion::set_has_enqueue_message() {
-  _has_bits_[0] |= 0x00000800u;
-}
-inline void RequestUnion::clear_has_enqueue_message() {
-  _has_bits_[0] &= ~0x00000800u;
+  _oneof_case_[0] = kEnqueueMessage;
 }
 inline void RequestUnion::clear_enqueue_message() {
-  if (enqueue_message_ != NULL) enqueue_message_->::cockroach::proto::EnqueueMessageRequest::Clear();
-  clear_has_enqueue_message();
+  if (has_enqueue_message()) {
+    delete value_.enqueue_message_;
+    clear_has_value();
+  }
 }
 inline const ::cockroach::proto::EnqueueMessageRequest& RequestUnion::enqueue_message() const {
-  // @@protoc_insertion_point(field_get:cockroach.proto.RequestUnion.enqueue_message)
-  return enqueue_message_ != NULL ? *enqueue_message_ : *default_instance_->enqueue_message_;
+  return has_enqueue_message() ? *value_.enqueue_message_
+                      : ::cockroach::proto::EnqueueMessageRequest::default_instance();
 }
 inline ::cockroach::proto::EnqueueMessageRequest* RequestUnion::mutable_enqueue_message() {
-  set_has_enqueue_message();
-  if (enqueue_message_ == NULL) enqueue_message_ = new ::cockroach::proto::EnqueueMessageRequest;
-  // @@protoc_insertion_point(field_mutable:cockroach.proto.RequestUnion.enqueue_message)
-  return enqueue_message_;
+  if (!has_enqueue_message()) {
+    clear_value();
+    set_has_enqueue_message();
+    value_.enqueue_message_ = new ::cockroach::proto::EnqueueMessageRequest;
+  }
+  return value_.enqueue_message_;
 }
 inline ::cockroach::proto::EnqueueMessageRequest* RequestUnion::release_enqueue_message() {
-  clear_has_enqueue_message();
-  ::cockroach::proto::EnqueueMessageRequest* temp = enqueue_message_;
-  enqueue_message_ = NULL;
-  return temp;
+  if (has_enqueue_message()) {
+    clear_has_value();
+    ::cockroach::proto::EnqueueMessageRequest* temp = value_.enqueue_message_;
+    value_.enqueue_message_ = NULL;
+    return temp;
+  } else {
+    return NULL;
+  }
 }
 inline void RequestUnion::set_allocated_enqueue_message(::cockroach::proto::EnqueueMessageRequest* enqueue_message) {
-  delete enqueue_message_;
-  enqueue_message_ = enqueue_message;
+  clear_value();
   if (enqueue_message) {
     set_has_enqueue_message();
-  } else {
-    clear_has_enqueue_message();
+    value_.enqueue_message_ = enqueue_message;
   }
-  // @@protoc_insertion_point(field_set_allocated:cockroach.proto.RequestUnion.enqueue_message)
 }
 
+inline bool RequestUnion::has_value() {
+  return value_case() != VALUE_NOT_SET;
+}
+inline void RequestUnion::clear_has_value() {
+  _oneof_case_[0] = VALUE_NOT_SET;
+}
+inline RequestUnion::ValueCase RequestUnion::value_case() const {
+  return RequestUnion::ValueCase(_oneof_case_[0]);
+}
 // -------------------------------------------------------------------
 
 // ResponseUnion
 
 // optional .cockroach.proto.ContainsResponse contains = 1;
 inline bool ResponseUnion::has_contains() const {
-  return (_has_bits_[0] & 0x00000001u) != 0;
+  return value_case() == kContains;
 }
 inline void ResponseUnion::set_has_contains() {
-  _has_bits_[0] |= 0x00000001u;
-}
-inline void ResponseUnion::clear_has_contains() {
-  _has_bits_[0] &= ~0x00000001u;
+  _oneof_case_[0] = kContains;
 }
 inline void ResponseUnion::clear_contains() {
-  if (contains_ != NULL) contains_->::cockroach::proto::ContainsResponse::Clear();
-  clear_has_contains();
+  if (has_contains()) {
+    delete value_.contains_;
+    clear_has_value();
+  }
 }
 inline const ::cockroach::proto::ContainsResponse& ResponseUnion::contains() const {
-  // @@protoc_insertion_point(field_get:cockroach.proto.ResponseUnion.contains)
-  return contains_ != NULL ? *contains_ : *default_instance_->contains_;
+  return has_contains() ? *value_.contains_
+                      : ::cockroach::proto::ContainsResponse::default_instance();
 }
 inline ::cockroach::proto::ContainsResponse* ResponseUnion::mutable_contains() {
-  set_has_contains();
-  if (contains_ == NULL) contains_ = new ::cockroach::proto::ContainsResponse;
-  // @@protoc_insertion_point(field_mutable:cockroach.proto.ResponseUnion.contains)
-  return contains_;
+  if (!has_contains()) {
+    clear_value();
+    set_has_contains();
+    value_.contains_ = new ::cockroach::proto::ContainsResponse;
+  }
+  return value_.contains_;
 }
 inline ::cockroach::proto::ContainsResponse* ResponseUnion::release_contains() {
-  clear_has_contains();
-  ::cockroach::proto::ContainsResponse* temp = contains_;
-  contains_ = NULL;
-  return temp;
+  if (has_contains()) {
+    clear_has_value();
+    ::cockroach::proto::ContainsResponse* temp = value_.contains_;
+    value_.contains_ = NULL;
+    return temp;
+  } else {
+    return NULL;
+  }
 }
 inline void ResponseUnion::set_allocated_contains(::cockroach::proto::ContainsResponse* contains) {
-  delete contains_;
-  contains_ = contains;
+  clear_value();
   if (contains) {
     set_has_contains();
-  } else {
-    clear_has_contains();
+    value_.contains_ = contains;
   }
-  // @@protoc_insertion_point(field_set_allocated:cockroach.proto.ResponseUnion.contains)
 }
 
 // optional .cockroach.proto.GetResponse get = 2;
 inline bool ResponseUnion::has_get() const {
-  return (_has_bits_[0] & 0x00000002u) != 0;
+  return value_case() == kGet;
 }
 inline void ResponseUnion::set_has_get() {
-  _has_bits_[0] |= 0x00000002u;
-}
-inline void ResponseUnion::clear_has_get() {
-  _has_bits_[0] &= ~0x00000002u;
+  _oneof_case_[0] = kGet;
 }
 inline void ResponseUnion::clear_get() {
-  if (get_ != NULL) get_->::cockroach::proto::GetResponse::Clear();
-  clear_has_get();
+  if (has_get()) {
+    delete value_.get_;
+    clear_has_value();
+  }
 }
 inline const ::cockroach::proto::GetResponse& ResponseUnion::get() const {
-  // @@protoc_insertion_point(field_get:cockroach.proto.ResponseUnion.get)
-  return get_ != NULL ? *get_ : *default_instance_->get_;
+  return has_get() ? *value_.get_
+                      : ::cockroach::proto::GetResponse::default_instance();
 }
 inline ::cockroach::proto::GetResponse* ResponseUnion::mutable_get() {
-  set_has_get();
-  if (get_ == NULL) get_ = new ::cockroach::proto::GetResponse;
-  // @@protoc_insertion_point(field_mutable:cockroach.proto.ResponseUnion.get)
-  return get_;
+  if (!has_get()) {
+    clear_value();
+    set_has_get();
+    value_.get_ = new ::cockroach::proto::GetResponse;
+  }
+  return value_.get_;
 }
 inline ::cockroach::proto::GetResponse* ResponseUnion::release_get() {
-  clear_has_get();
-  ::cockroach::proto::GetResponse* temp = get_;
-  get_ = NULL;
-  return temp;
+  if (has_get()) {
+    clear_has_value();
+    ::cockroach::proto::GetResponse* temp = value_.get_;
+    value_.get_ = NULL;
+    return temp;
+  } else {
+    return NULL;
+  }
 }
 inline void ResponseUnion::set_allocated_get(::cockroach::proto::GetResponse* get) {
-  delete get_;
-  get_ = get;
+  clear_value();
   if (get) {
     set_has_get();
-  } else {
-    clear_has_get();
+    value_.get_ = get;
   }
-  // @@protoc_insertion_point(field_set_allocated:cockroach.proto.ResponseUnion.get)
 }
 
 // optional .cockroach.proto.PutResponse put = 3;
 inline bool ResponseUnion::has_put() const {
-  return (_has_bits_[0] & 0x00000004u) != 0;
+  return value_case() == kPut;
 }
 inline void ResponseUnion::set_has_put() {
-  _has_bits_[0] |= 0x00000004u;
-}
-inline void ResponseUnion::clear_has_put() {
-  _has_bits_[0] &= ~0x00000004u;
+  _oneof_case_[0] = kPut;
 }
 inline void ResponseUnion::clear_put() {
-  if (put_ != NULL) put_->::cockroach::proto::PutResponse::Clear();
-  clear_has_put();
+  if (has_put()) {
+    delete value_.put_;
+    clear_has_value();
+  }
 }
 inline const ::cockroach::proto::PutResponse& ResponseUnion::put() const {
-  // @@protoc_insertion_point(field_get:cockroach.proto.ResponseUnion.put)
-  return put_ != NULL ? *put_ : *default_instance_->put_;
+  return has_put() ? *value_.put_
+                      : ::cockroach::proto::PutResponse::default_instance();
 }
 inline ::cockroach::proto::PutResponse* ResponseUnion::mutable_put() {
-  set_has_put();
-  if (put_ == NULL) put_ = new ::cockroach::proto::PutResponse;
-  // @@protoc_insertion_point(field_mutable:cockroach.proto.ResponseUnion.put)
-  return put_;
+  if (!has_put()) {
+    clear_value();
+    set_has_put();
+    value_.put_ = new ::cockroach::proto::PutResponse;
+  }
+  return value_.put_;
 }
 inline ::cockroach::proto::PutResponse* ResponseUnion::release_put() {
-  clear_has_put();
-  ::cockroach::proto::PutResponse* temp = put_;
-  put_ = NULL;
-  return temp;
+  if (has_put()) {
+    clear_has_value();
+    ::cockroach::proto::PutResponse* temp = value_.put_;
+    value_.put_ = NULL;
+    return temp;
+  } else {
+    return NULL;
+  }
 }
 inline void ResponseUnion::set_allocated_put(::cockroach::proto::PutResponse* put) {
-  delete put_;
-  put_ = put;
+  clear_value();
   if (put) {
     set_has_put();
-  } else {
-    clear_has_put();
+    value_.put_ = put;
   }
-  // @@protoc_insertion_point(field_set_allocated:cockroach.proto.ResponseUnion.put)
 }
 
 // optional .cockroach.proto.ConditionalPutResponse conditional_put = 4;
 inline bool ResponseUnion::has_conditional_put() const {
-  return (_has_bits_[0] & 0x00000008u) != 0;
+  return value_case() == kConditionalPut;
 }
 inline void ResponseUnion::set_has_conditional_put() {
-  _has_bits_[0] |= 0x00000008u;
-}
-inline void ResponseUnion::clear_has_conditional_put() {
-  _has_bits_[0] &= ~0x00000008u;
+  _oneof_case_[0] = kConditionalPut;
 }
 inline void ResponseUnion::clear_conditional_put() {
-  if (conditional_put_ != NULL) conditional_put_->::cockroach::proto::ConditionalPutResponse::Clear();
-  clear_has_conditional_put();
+  if (has_conditional_put()) {
+    delete value_.conditional_put_;
+    clear_has_value();
+  }
 }
 inline const ::cockroach::proto::ConditionalPutResponse& ResponseUnion::conditional_put() const {
-  // @@protoc_insertion_point(field_get:cockroach.proto.ResponseUnion.conditional_put)
-  return conditional_put_ != NULL ? *conditional_put_ : *default_instance_->conditional_put_;
+  return has_conditional_put() ? *value_.conditional_put_
+                      : ::cockroach::proto::ConditionalPutResponse::default_instance();
 }
 inline ::cockroach::proto::ConditionalPutResponse* ResponseUnion::mutable_conditional_put() {
-  set_has_conditional_put();
-  if (conditional_put_ == NULL) conditional_put_ = new ::cockroach::proto::ConditionalPutResponse;
-  // @@protoc_insertion_point(field_mutable:cockroach.proto.ResponseUnion.conditional_put)
-  return conditional_put_;
+  if (!has_conditional_put()) {
+    clear_value();
+    set_has_conditional_put();
+    value_.conditional_put_ = new ::cockroach::proto::ConditionalPutResponse;
+  }
+  return value_.conditional_put_;
 }
 inline ::cockroach::proto::ConditionalPutResponse* ResponseUnion::release_conditional_put() {
-  clear_has_conditional_put();
-  ::cockroach::proto::ConditionalPutResponse* temp = conditional_put_;
-  conditional_put_ = NULL;
-  return temp;
+  if (has_conditional_put()) {
+    clear_has_value();
+    ::cockroach::proto::ConditionalPutResponse* temp = value_.conditional_put_;
+    value_.conditional_put_ = NULL;
+    return temp;
+  } else {
+    return NULL;
+  }
 }
 inline void ResponseUnion::set_allocated_conditional_put(::cockroach::proto::ConditionalPutResponse* conditional_put) {
-  delete conditional_put_;
-  conditional_put_ = conditional_put;
+  clear_value();
   if (conditional_put) {
     set_has_conditional_put();
-  } else {
-    clear_has_conditional_put();
+    value_.conditional_put_ = conditional_put;
   }
-  // @@protoc_insertion_point(field_set_allocated:cockroach.proto.ResponseUnion.conditional_put)
 }
 
 // optional .cockroach.proto.IncrementResponse increment = 5;
 inline bool ResponseUnion::has_increment() const {
-  return (_has_bits_[0] & 0x00000010u) != 0;
+  return value_case() == kIncrement;
 }
 inline void ResponseUnion::set_has_increment() {
-  _has_bits_[0] |= 0x00000010u;
-}
-inline void ResponseUnion::clear_has_increment() {
-  _has_bits_[0] &= ~0x00000010u;
+  _oneof_case_[0] = kIncrement;
 }
 inline void ResponseUnion::clear_increment() {
-  if (increment_ != NULL) increment_->::cockroach::proto::IncrementResponse::Clear();
-  clear_has_increment();
+  if (has_increment()) {
+    delete value_.increment_;
+    clear_has_value();
+  }
 }
 inline const ::cockroach::proto::IncrementResponse& ResponseUnion::increment() const {
-  // @@protoc_insertion_point(field_get:cockroach.proto.ResponseUnion.increment)
-  return increment_ != NULL ? *increment_ : *default_instance_->increment_;
+  return has_increment() ? *value_.increment_
+                      : ::cockroach::proto::IncrementResponse::default_instance();
 }
 inline ::cockroach::proto::IncrementResponse* ResponseUnion::mutable_increment() {
-  set_has_increment();
-  if (increment_ == NULL) increment_ = new ::cockroach::proto::IncrementResponse;
-  // @@protoc_insertion_point(field_mutable:cockroach.proto.ResponseUnion.increment)
-  return increment_;
+  if (!has_increment()) {
+    clear_value();
+    set_has_increment();
+    value_.increment_ = new ::cockroach::proto::IncrementResponse;
+  }
+  return value_.increment_;
 }
 inline ::cockroach::proto::IncrementResponse* ResponseUnion::release_increment() {
-  clear_has_increment();
-  ::cockroach::proto::IncrementResponse* temp = increment_;
-  increment_ = NULL;
-  return temp;
+  if (has_increment()) {
+    clear_has_value();
+    ::cockroach::proto::IncrementResponse* temp = value_.increment_;
+    value_.increment_ = NULL;
+    return temp;
+  } else {
+    return NULL;
+  }
 }
 inline void ResponseUnion::set_allocated_increment(::cockroach::proto::IncrementResponse* increment) {
-  delete increment_;
-  increment_ = increment;
+  clear_value();
   if (increment) {
     set_has_increment();
-  } else {
-    clear_has_increment();
+    value_.increment_ = increment;
   }
-  // @@protoc_insertion_point(field_set_allocated:cockroach.proto.ResponseUnion.increment)
 }
 
 // optional .cockroach.proto.DeleteResponse delete = 6;
 inline bool ResponseUnion::has_delete_() const {
-  return (_has_bits_[0] & 0x00000020u) != 0;
+  return value_case() == kDelete;
 }
 inline void ResponseUnion::set_has_delete_() {
-  _has_bits_[0] |= 0x00000020u;
-}
-inline void ResponseUnion::clear_has_delete_() {
-  _has_bits_[0] &= ~0x00000020u;
+  _oneof_case_[0] = kDelete;
 }
 inline void ResponseUnion::clear_delete_() {
-  if (delete__ != NULL) delete__->::cockroach::proto::DeleteResponse::Clear();
-  clear_has_delete_();
+  if (has_delete_()) {
+    delete value_.delete__;
+    clear_has_value();
+  }
 }
 inline const ::cockroach::proto::DeleteResponse& ResponseUnion::delete_() const {
-  // @@protoc_insertion_point(field_get:cockroach.proto.ResponseUnion.delete)
-  return delete__ != NULL ? *delete__ : *default_instance_->delete__;
+  return has_delete_() ? *value_.delete__
+                      : ::cockroach::proto::DeleteResponse::default_instance();
 }
 inline ::cockroach::proto::DeleteResponse* ResponseUnion::mutable_delete_() {
-  set_has_delete_();
-  if (delete__ == NULL) delete__ = new ::cockroach::proto::DeleteResponse;
-  // @@protoc_insertion_point(field_mutable:cockroach.proto.ResponseUnion.delete)
-  return delete__;
+  if (!has_delete_()) {
+    clear_value();
+    set_has_delete_();
+    value_.delete__ = new ::cockroach::proto::DeleteResponse;
+  }
+  return value_.delete__;
 }
 inline ::cockroach::proto::DeleteResponse* ResponseUnion::release_delete_() {
-  clear_has_delete_();
-  ::cockroach::proto::DeleteResponse* temp = delete__;
-  delete__ = NULL;
-  return temp;
+  if (has_delete_()) {
+    clear_has_value();
+    ::cockroach::proto::DeleteResponse* temp = value_.delete__;
+    value_.delete__ = NULL;
+    return temp;
+  } else {
+    return NULL;
+  }
 }
 inline void ResponseUnion::set_allocated_delete_(::cockroach::proto::DeleteResponse* delete_) {
-  delete delete__;
-  delete__ = delete_;
+  clear_value();
   if (delete_) {
     set_has_delete_();
-  } else {
-    clear_has_delete_();
+    value_.delete__ = delete_;
   }
-  // @@protoc_insertion_point(field_set_allocated:cockroach.proto.ResponseUnion.delete)
 }
 
 // optional .cockroach.proto.DeleteRangeResponse delete_range = 7;
 inline bool ResponseUnion::has_delete_range() const {
-  return (_has_bits_[0] & 0x00000040u) != 0;
+  return value_case() == kDeleteRange;
 }
 inline void ResponseUnion::set_has_delete_range() {
-  _has_bits_[0] |= 0x00000040u;
-}
-inline void ResponseUnion::clear_has_delete_range() {
-  _has_bits_[0] &= ~0x00000040u;
+  _oneof_case_[0] = kDeleteRange;
 }
 inline void ResponseUnion::clear_delete_range() {
-  if (delete_range_ != NULL) delete_range_->::cockroach::proto::DeleteRangeResponse::Clear();
-  clear_has_delete_range();
+  if (has_delete_range()) {
+    delete value_.delete_range_;
+    clear_has_value();
+  }
 }
 inline const ::cockroach::proto::DeleteRangeResponse& ResponseUnion::delete_range() const {
-  // @@protoc_insertion_point(field_get:cockroach.proto.ResponseUnion.delete_range)
-  return delete_range_ != NULL ? *delete_range_ : *default_instance_->delete_range_;
+  return has_delete_range() ? *value_.delete_range_
+                      : ::cockroach::proto::DeleteRangeResponse::default_instance();
 }
 inline ::cockroach::proto::DeleteRangeResponse* ResponseUnion::mutable_delete_range() {
-  set_has_delete_range();
-  if (delete_range_ == NULL) delete_range_ = new ::cockroach::proto::DeleteRangeResponse;
-  // @@protoc_insertion_point(field_mutable:cockroach.proto.ResponseUnion.delete_range)
-  return delete_range_;
+  if (!has_delete_range()) {
+    clear_value();
+    set_has_delete_range();
+    value_.delete_range_ = new ::cockroach::proto::DeleteRangeResponse;
+  }
+  return value_.delete_range_;
 }
 inline ::cockroach::proto::DeleteRangeResponse* ResponseUnion::release_delete_range() {
-  clear_has_delete_range();
-  ::cockroach::proto::DeleteRangeResponse* temp = delete_range_;
-  delete_range_ = NULL;
-  return temp;
+  if (has_delete_range()) {
+    clear_has_value();
+    ::cockroach::proto::DeleteRangeResponse* temp = value_.delete_range_;
+    value_.delete_range_ = NULL;
+    return temp;
+  } else {
+    return NULL;
+  }
 }
 inline void ResponseUnion::set_allocated_delete_range(::cockroach::proto::DeleteRangeResponse* delete_range) {
-  delete delete_range_;
-  delete_range_ = delete_range;
+  clear_value();
   if (delete_range) {
     set_has_delete_range();
-  } else {
-    clear_has_delete_range();
+    value_.delete_range_ = delete_range;
   }
-  // @@protoc_insertion_point(field_set_allocated:cockroach.proto.ResponseUnion.delete_range)
 }
 
 // optional .cockroach.proto.ScanResponse scan = 8;
 inline bool ResponseUnion::has_scan() const {
-  return (_has_bits_[0] & 0x00000080u) != 0;
+  return value_case() == kScan;
 }
 inline void ResponseUnion::set_has_scan() {
-  _has_bits_[0] |= 0x00000080u;
-}
-inline void ResponseUnion::clear_has_scan() {
-  _has_bits_[0] &= ~0x00000080u;
+  _oneof_case_[0] = kScan;
 }
 inline void ResponseUnion::clear_scan() {
-  if (scan_ != NULL) scan_->::cockroach::proto::ScanResponse::Clear();
-  clear_has_scan();
+  if (has_scan()) {
+    delete value_.scan_;
+    clear_has_value();
+  }
 }
 inline const ::cockroach::proto::ScanResponse& ResponseUnion::scan() const {
-  // @@protoc_insertion_point(field_get:cockroach.proto.ResponseUnion.scan)
-  return scan_ != NULL ? *scan_ : *default_instance_->scan_;
+  return has_scan() ? *value_.scan_
+                      : ::cockroach::proto::ScanResponse::default_instance();
 }
 inline ::cockroach::proto::ScanResponse* ResponseUnion::mutable_scan() {
-  set_has_scan();
-  if (scan_ == NULL) scan_ = new ::cockroach::proto::ScanResponse;
-  // @@protoc_insertion_point(field_mutable:cockroach.proto.ResponseUnion.scan)
-  return scan_;
+  if (!has_scan()) {
+    clear_value();
+    set_has_scan();
+    value_.scan_ = new ::cockroach::proto::ScanResponse;
+  }
+  return value_.scan_;
 }
 inline ::cockroach::proto::ScanResponse* ResponseUnion::release_scan() {
-  clear_has_scan();
-  ::cockroach::proto::ScanResponse* temp = scan_;
-  scan_ = NULL;
-  return temp;
+  if (has_scan()) {
+    clear_has_value();
+    ::cockroach::proto::ScanResponse* temp = value_.scan_;
+    value_.scan_ = NULL;
+    return temp;
+  } else {
+    return NULL;
+  }
 }
 inline void ResponseUnion::set_allocated_scan(::cockroach::proto::ScanResponse* scan) {
-  delete scan_;
-  scan_ = scan;
+  clear_value();
   if (scan) {
     set_has_scan();
-  } else {
-    clear_has_scan();
+    value_.scan_ = scan;
   }
-  // @@protoc_insertion_point(field_set_allocated:cockroach.proto.ResponseUnion.scan)
 }
 
 // optional .cockroach.proto.EndTransactionResponse end_transaction = 9;
 inline bool ResponseUnion::has_end_transaction() const {
-  return (_has_bits_[0] & 0x00000100u) != 0;
+  return value_case() == kEndTransaction;
 }
 inline void ResponseUnion::set_has_end_transaction() {
-  _has_bits_[0] |= 0x00000100u;
-}
-inline void ResponseUnion::clear_has_end_transaction() {
-  _has_bits_[0] &= ~0x00000100u;
+  _oneof_case_[0] = kEndTransaction;
 }
 inline void ResponseUnion::clear_end_transaction() {
-  if (end_transaction_ != NULL) end_transaction_->::cockroach::proto::EndTransactionResponse::Clear();
-  clear_has_end_transaction();
+  if (has_end_transaction()) {
+    delete value_.end_transaction_;
+    clear_has_value();
+  }
 }
 inline const ::cockroach::proto::EndTransactionResponse& ResponseUnion::end_transaction() const {
-  // @@protoc_insertion_point(field_get:cockroach.proto.ResponseUnion.end_transaction)
-  return end_transaction_ != NULL ? *end_transaction_ : *default_instance_->end_transaction_;
+  return has_end_transaction() ? *value_.end_transaction_
+                      : ::cockroach::proto::EndTransactionResponse::default_instance();
 }
 inline ::cockroach::proto::EndTransactionResponse* ResponseUnion::mutable_end_transaction() {
-  set_has_end_transaction();
-  if (end_transaction_ == NULL) end_transaction_ = new ::cockroach::proto::EndTransactionResponse;
-  // @@protoc_insertion_point(field_mutable:cockroach.proto.ResponseUnion.end_transaction)
-  return end_transaction_;
+  if (!has_end_transaction()) {
+    clear_value();
+    set_has_end_transaction();
+    value_.end_transaction_ = new ::cockroach::proto::EndTransactionResponse;
+  }
+  return value_.end_transaction_;
 }
 inline ::cockroach::proto::EndTransactionResponse* ResponseUnion::release_end_transaction() {
-  clear_has_end_transaction();
-  ::cockroach::proto::EndTransactionResponse* temp = end_transaction_;
-  end_transaction_ = NULL;
-  return temp;
+  if (has_end_transaction()) {
+    clear_has_value();
+    ::cockroach::proto::EndTransactionResponse* temp = value_.end_transaction_;
+    value_.end_transaction_ = NULL;
+    return temp;
+  } else {
+    return NULL;
+  }
 }
 inline void ResponseUnion::set_allocated_end_transaction(::cockroach::proto::EndTransactionResponse* end_transaction) {
-  delete end_transaction_;
-  end_transaction_ = end_transaction;
+  clear_value();
   if (end_transaction) {
     set_has_end_transaction();
-  } else {
-    clear_has_end_transaction();
+    value_.end_transaction_ = end_transaction;
   }
-  // @@protoc_insertion_point(field_set_allocated:cockroach.proto.ResponseUnion.end_transaction)
 }
 
 // optional .cockroach.proto.ReapQueueResponse reap_queue = 10;
 inline bool ResponseUnion::has_reap_queue() const {
-  return (_has_bits_[0] & 0x00000200u) != 0;
+  return value_case() == kReapQueue;
 }
 inline void ResponseUnion::set_has_reap_queue() {
-  _has_bits_[0] |= 0x00000200u;
-}
-inline void ResponseUnion::clear_has_reap_queue() {
-  _has_bits_[0] &= ~0x00000200u;
+  _oneof_case_[0] = kReapQueue;
 }
 inline void ResponseUnion::clear_reap_queue() {
-  if (reap_queue_ != NULL) reap_queue_->::cockroach::proto::ReapQueueResponse::Clear();
-  clear_has_reap_queue();
+  if (has_reap_queue()) {
+    delete value_.reap_queue_;
+    clear_has_value();
+  }
 }
 inline const ::cockroach::proto::ReapQueueResponse& ResponseUnion::reap_queue() const {
-  // @@protoc_insertion_point(field_get:cockroach.proto.ResponseUnion.reap_queue)
-  return reap_queue_ != NULL ? *reap_queue_ : *default_instance_->reap_queue_;
+  return has_reap_queue() ? *value_.reap_queue_
+                      : ::cockroach::proto::ReapQueueResponse::default_instance();
 }
 inline ::cockroach::proto::ReapQueueResponse* ResponseUnion::mutable_reap_queue() {
-  set_has_reap_queue();
-  if (reap_queue_ == NULL) reap_queue_ = new ::cockroach::proto::ReapQueueResponse;
-  // @@protoc_insertion_point(field_mutable:cockroach.proto.ResponseUnion.reap_queue)
-  return reap_queue_;
+  if (!has_reap_queue()) {
+    clear_value();
+    set_has_reap_queue();
+    value_.reap_queue_ = new ::cockroach::proto::ReapQueueResponse;
+  }
+  return value_.reap_queue_;
 }
 inline ::cockroach::proto::ReapQueueResponse* ResponseUnion::release_reap_queue() {
-  clear_has_reap_queue();
-  ::cockroach::proto::ReapQueueResponse* temp = reap_queue_;
-  reap_queue_ = NULL;
-  return temp;
+  if (has_reap_queue()) {
+    clear_has_value();
+    ::cockroach::proto::ReapQueueResponse* temp = value_.reap_queue_;
+    value_.reap_queue_ = NULL;
+    return temp;
+  } else {
+    return NULL;
+  }
 }
 inline void ResponseUnion::set_allocated_reap_queue(::cockroach::proto::ReapQueueResponse* reap_queue) {
-  delete reap_queue_;
-  reap_queue_ = reap_queue;
+  clear_value();
   if (reap_queue) {
     set_has_reap_queue();
-  } else {
-    clear_has_reap_queue();
+    value_.reap_queue_ = reap_queue;
   }
-  // @@protoc_insertion_point(field_set_allocated:cockroach.proto.ResponseUnion.reap_queue)
 }
 
 // optional .cockroach.proto.EnqueueUpdateResponse enqueue_update = 11;
 inline bool ResponseUnion::has_enqueue_update() const {
-  return (_has_bits_[0] & 0x00000400u) != 0;
+  return value_case() == kEnqueueUpdate;
 }
 inline void ResponseUnion::set_has_enqueue_update() {
-  _has_bits_[0] |= 0x00000400u;
-}
-inline void ResponseUnion::clear_has_enqueue_update() {
-  _has_bits_[0] &= ~0x00000400u;
+  _oneof_case_[0] = kEnqueueUpdate;
 }
 inline void ResponseUnion::clear_enqueue_update() {
-  if (enqueue_update_ != NULL) enqueue_update_->::cockroach::proto::EnqueueUpdateResponse::Clear();
-  clear_has_enqueue_update();
+  if (has_enqueue_update()) {
+    delete value_.enqueue_update_;
+    clear_has_value();
+  }
 }
 inline const ::cockroach::proto::EnqueueUpdateResponse& ResponseUnion::enqueue_update() const {
-  // @@protoc_insertion_point(field_get:cockroach.proto.ResponseUnion.enqueue_update)
-  return enqueue_update_ != NULL ? *enqueue_update_ : *default_instance_->enqueue_update_;
+  return has_enqueue_update() ? *value_.enqueue_update_
+                      : ::cockroach::proto::EnqueueUpdateResponse::default_instance();
 }
 inline ::cockroach::proto::EnqueueUpdateResponse* ResponseUnion::mutable_enqueue_update() {
-  set_has_enqueue_update();
-  if (enqueue_update_ == NULL) enqueue_update_ = new ::cockroach::proto::EnqueueUpdateResponse;
-  // @@protoc_insertion_point(field_mutable:cockroach.proto.ResponseUnion.enqueue_update)
-  return enqueue_update_;
+  if (!has_enqueue_update()) {
+    clear_value();
+    set_has_enqueue_update();
+    value_.enqueue_update_ = new ::cockroach::proto::EnqueueUpdateResponse;
+  }
+  return value_.enqueue_update_;
 }
 inline ::cockroach::proto::EnqueueUpdateResponse* ResponseUnion::release_enqueue_update() {
-  clear_has_enqueue_update();
-  ::cockroach::proto::EnqueueUpdateResponse* temp = enqueue_update_;
-  enqueue_update_ = NULL;
-  return temp;
+  if (has_enqueue_update()) {
+    clear_has_value();
+    ::cockroach::proto::EnqueueUpdateResponse* temp = value_.enqueue_update_;
+    value_.enqueue_update_ = NULL;
+    return temp;
+  } else {
+    return NULL;
+  }
 }
 inline void ResponseUnion::set_allocated_enqueue_update(::cockroach::proto::EnqueueUpdateResponse* enqueue_update) {
-  delete enqueue_update_;
-  enqueue_update_ = enqueue_update;
+  clear_value();
   if (enqueue_update) {
     set_has_enqueue_update();
-  } else {
-    clear_has_enqueue_update();
+    value_.enqueue_update_ = enqueue_update;
   }
-  // @@protoc_insertion_point(field_set_allocated:cockroach.proto.ResponseUnion.enqueue_update)
 }
 
 // optional .cockroach.proto.EnqueueMessageResponse enqueue_message = 12;
 inline bool ResponseUnion::has_enqueue_message() const {
-  return (_has_bits_[0] & 0x00000800u) != 0;
+  return value_case() == kEnqueueMessage;
 }
 inline void ResponseUnion::set_has_enqueue_message() {
-  _has_bits_[0] |= 0x00000800u;
-}
-inline void ResponseUnion::clear_has_enqueue_message() {
-  _has_bits_[0] &= ~0x00000800u;
+  _oneof_case_[0] = kEnqueueMessage;
 }
 inline void ResponseUnion::clear_enqueue_message() {
-  if (enqueue_message_ != NULL) enqueue_message_->::cockroach::proto::EnqueueMessageResponse::Clear();
-  clear_has_enqueue_message();
+  if (has_enqueue_message()) {
+    delete value_.enqueue_message_;
+    clear_has_value();
+  }
 }
 inline const ::cockroach::proto::EnqueueMessageResponse& ResponseUnion::enqueue_message() const {
-  // @@protoc_insertion_point(field_get:cockroach.proto.ResponseUnion.enqueue_message)
-  return enqueue_message_ != NULL ? *enqueue_message_ : *default_instance_->enqueue_message_;
+  return has_enqueue_message() ? *value_.enqueue_message_
+                      : ::cockroach::proto::EnqueueMessageResponse::default_instance();
 }
 inline ::cockroach::proto::EnqueueMessageResponse* ResponseUnion::mutable_enqueue_message() {
-  set_has_enqueue_message();
-  if (enqueue_message_ == NULL) enqueue_message_ = new ::cockroach::proto::EnqueueMessageResponse;
-  // @@protoc_insertion_point(field_mutable:cockroach.proto.ResponseUnion.enqueue_message)
-  return enqueue_message_;
+  if (!has_enqueue_message()) {
+    clear_value();
+    set_has_enqueue_message();
+    value_.enqueue_message_ = new ::cockroach::proto::EnqueueMessageResponse;
+  }
+  return value_.enqueue_message_;
 }
 inline ::cockroach::proto::EnqueueMessageResponse* ResponseUnion::release_enqueue_message() {
-  clear_has_enqueue_message();
-  ::cockroach::proto::EnqueueMessageResponse* temp = enqueue_message_;
-  enqueue_message_ = NULL;
-  return temp;
+  if (has_enqueue_message()) {
+    clear_has_value();
+    ::cockroach::proto::EnqueueMessageResponse* temp = value_.enqueue_message_;
+    value_.enqueue_message_ = NULL;
+    return temp;
+  } else {
+    return NULL;
+  }
 }
 inline void ResponseUnion::set_allocated_enqueue_message(::cockroach::proto::EnqueueMessageResponse* enqueue_message) {
-  delete enqueue_message_;
-  enqueue_message_ = enqueue_message;
+  clear_value();
   if (enqueue_message) {
     set_has_enqueue_message();
-  } else {
-    clear_has_enqueue_message();
+    value_.enqueue_message_ = enqueue_message;
   }
-  // @@protoc_insertion_point(field_set_allocated:cockroach.proto.ResponseUnion.enqueue_message)
 }
 
+inline bool ResponseUnion::has_value() {
+  return value_case() != VALUE_NOT_SET;
+}
+inline void ResponseUnion::clear_has_value() {
+  _oneof_case_[0] = VALUE_NOT_SET;
+}
+inline ResponseUnion::ValueCase ResponseUnion::value_case() const {
+  return ResponseUnion::ValueCase(_oneof_case_[0]);
+}
 // -------------------------------------------------------------------
 
 // BatchRequest

--- a/storage/engine/cockroach/proto/errors.pb.cc
+++ b/storage/engine/cockroach/proto/errors.pb.cc
@@ -60,6 +60,20 @@ const ::google::protobuf::internal::GeneratedMessageReflection*
 const ::google::protobuf::Descriptor* ErrorDetail_descriptor_ = NULL;
 const ::google::protobuf::internal::GeneratedMessageReflection*
   ErrorDetail_reflection_ = NULL;
+struct ErrorDetailOneofInstance {
+  const ::cockroach::proto::NotLeaderError* not_leader_;
+  const ::cockroach::proto::RangeNotFoundError* range_not_found_;
+  const ::cockroach::proto::RangeKeyMismatchError* range_key_mismatch_;
+  const ::cockroach::proto::ReadWithinUncertaintyIntervalError* read_within_uncertainty_interval_;
+  const ::cockroach::proto::TransactionAbortedError* transaction_aborted_;
+  const ::cockroach::proto::TransactionPushError* transaction_push_;
+  const ::cockroach::proto::TransactionRetryError* transaction_retry_;
+  const ::cockroach::proto::TransactionStatusError* transaction_status_;
+  const ::cockroach::proto::WriteIntentError* write_intent_;
+  const ::cockroach::proto::WriteTooOldError* write_too_old_;
+  const ::cockroach::proto::OpRequiresTxnError* op_requires_txn_;
+  const ::cockroach::proto::ConditionFailedError* condition_failed_;
+}* ErrorDetail_default_oneof_instance_ = NULL;
 const ::google::protobuf::Descriptor* Error_descriptor_ = NULL;
 const ::google::protobuf::internal::GeneratedMessageReflection*
   Error_reflection_ = NULL;
@@ -262,19 +276,20 @@ void protobuf_AssignDesc_cockroach_2fproto_2ferrors_2eproto() {
       ::google::protobuf::MessageFactory::generated_factory(),
       sizeof(ConditionFailedError));
   ErrorDetail_descriptor_ = file->message_type(12);
-  static const int ErrorDetail_offsets_[12] = {
-    GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(ErrorDetail, not_leader_),
-    GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(ErrorDetail, range_not_found_),
-    GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(ErrorDetail, range_key_mismatch_),
-    GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(ErrorDetail, read_within_uncertainty_interval_),
-    GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(ErrorDetail, transaction_aborted_),
-    GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(ErrorDetail, transaction_push_),
-    GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(ErrorDetail, transaction_retry_),
-    GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(ErrorDetail, transaction_status_),
-    GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(ErrorDetail, write_intent_),
-    GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(ErrorDetail, write_too_old_),
-    GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(ErrorDetail, op_requires_txn_),
-    GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(ErrorDetail, condition_failed_),
+  static const int ErrorDetail_offsets_[13] = {
+    PROTO2_GENERATED_DEFAULT_ONEOF_FIELD_OFFSET(ErrorDetail_default_oneof_instance_, not_leader_),
+    PROTO2_GENERATED_DEFAULT_ONEOF_FIELD_OFFSET(ErrorDetail_default_oneof_instance_, range_not_found_),
+    PROTO2_GENERATED_DEFAULT_ONEOF_FIELD_OFFSET(ErrorDetail_default_oneof_instance_, range_key_mismatch_),
+    PROTO2_GENERATED_DEFAULT_ONEOF_FIELD_OFFSET(ErrorDetail_default_oneof_instance_, read_within_uncertainty_interval_),
+    PROTO2_GENERATED_DEFAULT_ONEOF_FIELD_OFFSET(ErrorDetail_default_oneof_instance_, transaction_aborted_),
+    PROTO2_GENERATED_DEFAULT_ONEOF_FIELD_OFFSET(ErrorDetail_default_oneof_instance_, transaction_push_),
+    PROTO2_GENERATED_DEFAULT_ONEOF_FIELD_OFFSET(ErrorDetail_default_oneof_instance_, transaction_retry_),
+    PROTO2_GENERATED_DEFAULT_ONEOF_FIELD_OFFSET(ErrorDetail_default_oneof_instance_, transaction_status_),
+    PROTO2_GENERATED_DEFAULT_ONEOF_FIELD_OFFSET(ErrorDetail_default_oneof_instance_, write_intent_),
+    PROTO2_GENERATED_DEFAULT_ONEOF_FIELD_OFFSET(ErrorDetail_default_oneof_instance_, write_too_old_),
+    PROTO2_GENERATED_DEFAULT_ONEOF_FIELD_OFFSET(ErrorDetail_default_oneof_instance_, op_requires_txn_),
+    PROTO2_GENERATED_DEFAULT_ONEOF_FIELD_OFFSET(ErrorDetail_default_oneof_instance_, condition_failed_),
+    GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(ErrorDetail, value_),
   };
   ErrorDetail_reflection_ =
     new ::google::protobuf::internal::GeneratedMessageReflection(
@@ -284,6 +299,8 @@ void protobuf_AssignDesc_cockroach_2fproto_2ferrors_2eproto() {
       GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(ErrorDetail, _has_bits_[0]),
       GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(ErrorDetail, _unknown_fields_),
       -1,
+      ErrorDetail_default_oneof_instance_,
+      GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(ErrorDetail, _oneof_case_[0]),
       ::google::protobuf::DescriptorPool::generated_pool(),
       ::google::protobuf::MessageFactory::generated_factory(),
       sizeof(ErrorDetail));
@@ -376,6 +393,7 @@ void protobuf_ShutdownFile_cockroach_2fproto_2ferrors_2eproto() {
   delete ConditionFailedError::default_instance_;
   delete ConditionFailedError_reflection_;
   delete ErrorDetail::default_instance_;
+  delete ErrorDetail_default_oneof_instance_;
   delete ErrorDetail_reflection_;
   delete Error::default_instance_;
   delete Error_reflection_;
@@ -422,34 +440,35 @@ void protobuf_AddDesc_cockroach_2fproto_2ferrors_2eproto() {
     "xisting_timestamp\030\002 \001(\0132\032.cockroach.prot"
     "o.TimestampB\004\310\336\037\000\"\024\n\022OpRequiresTxnError\""
     "D\n\024ConditionFailedError\022,\n\014actual_value\030"
-    "\001 \001(\0132\026.cockroach.proto.Value\"\253\006\n\013ErrorD"
-    "etail\0223\n\nnot_leader\030\001 \001(\0132\037.cockroach.pr"
-    "oto.NotLeaderError\022<\n\017range_not_found\030\002 "
-    "\001(\0132#.cockroach.proto.RangeNotFoundError"
-    "\022B\n\022range_key_mismatch\030\003 \001(\0132&.cockroach"
-    ".proto.RangeKeyMismatchError\022]\n read_wit"
-    "hin_uncertainty_interval\030\004 \001(\01323.cockroa"
-    "ch.proto.ReadWithinUncertaintyIntervalEr"
-    "ror\022E\n\023transaction_aborted\030\005 \001(\0132(.cockr"
-    "oach.proto.TransactionAbortedError\022\?\n\020tr"
-    "ansaction_push\030\006 \001(\0132%.cockroach.proto.T"
-    "ransactionPushError\022A\n\021transaction_retry"
-    "\030\007 \001(\0132&.cockroach.proto.TransactionRetr"
-    "yError\022C\n\022transaction_status\030\010 \001(\0132\'.coc"
-    "kroach.proto.TransactionStatusError\0227\n\014w"
-    "rite_intent\030\t \001(\0132!.cockroach.proto.Writ"
-    "eIntentError\0228\n\rwrite_too_old\030\n \001(\0132!.co"
-    "ckroach.proto.WriteTooOldError\022<\n\017op_req"
-    "uires_txn\030\013 \001(\0132#.cockroach.proto.OpRequ"
-    "iresTxnError\022\?\n\020condition_failed\030\014 \001(\0132%"
-    ".cockroach.proto.ConditionFailedError:\004\310"
-    "\240\037\001\"\255\001\n\005Error\022\025\n\007message\030\001 \001(\tB\004\310\336\037\000\022\027\n\t"
-    "retryable\030\002 \001(\010B\004\310\336\037\000\022F\n\023transaction_res"
-    "tart\030\004 \001(\0162#.cockroach.proto.Transaction"
-    "RestartB\004\310\336\037\000\022,\n\006detail\030\003 \001(\0132\034.cockroac"
-    "h.proto.ErrorDetail*;\n\022TransactionRestar"
-    "t\022\t\n\005ABORT\020\000\022\013\n\007BACKOFF\020\001\022\r\n\tIMMEDIATE\020\002"
-    "B\007Z\005proto", 2329);
+    "\001 \001(\0132\026.cockroach.proto.Value\"\314\006\n\013ErrorD"
+    "etail\0225\n\nnot_leader\030\001 \001(\0132\037.cockroach.pr"
+    "oto.NotLeaderErrorH\000\022>\n\017range_not_found\030"
+    "\002 \001(\0132#.cockroach.proto.RangeNotFoundErr"
+    "orH\000\022D\n\022range_key_mismatch\030\003 \001(\0132&.cockr"
+    "oach.proto.RangeKeyMismatchErrorH\000\022_\n re"
+    "ad_within_uncertainty_interval\030\004 \001(\01323.c"
+    "ockroach.proto.ReadWithinUncertaintyInte"
+    "rvalErrorH\000\022G\n\023transaction_aborted\030\005 \001(\013"
+    "2(.cockroach.proto.TransactionAbortedErr"
+    "orH\000\022A\n\020transaction_push\030\006 \001(\0132%.cockroa"
+    "ch.proto.TransactionPushErrorH\000\022C\n\021trans"
+    "action_retry\030\007 \001(\0132&.cockroach.proto.Tra"
+    "nsactionRetryErrorH\000\022E\n\022transaction_stat"
+    "us\030\010 \001(\0132\'.cockroach.proto.TransactionSt"
+    "atusErrorH\000\0229\n\014write_intent\030\t \001(\0132!.cock"
+    "roach.proto.WriteIntentErrorH\000\022:\n\rwrite_"
+    "too_old\030\n \001(\0132!.cockroach.proto.WriteToo"
+    "OldErrorH\000\022>\n\017op_requires_txn\030\013 \001(\0132#.co"
+    "ckroach.proto.OpRequiresTxnErrorH\000\022A\n\020co"
+    "ndition_failed\030\014 \001(\0132%.cockroach.proto.C"
+    "onditionFailedErrorH\000:\004\310\240\037\001B\007\n\005value\"\255\001\n"
+    "\005Error\022\025\n\007message\030\001 \001(\tB\004\310\336\037\000\022\027\n\tretryab"
+    "le\030\002 \001(\010B\004\310\336\037\000\022F\n\023transaction_restart\030\004 "
+    "\001(\0162#.cockroach.proto.TransactionRestart"
+    "B\004\310\336\037\000\022,\n\006detail\030\003 \001(\0132\034.cockroach.proto"
+    ".ErrorDetail*;\n\022TransactionRestart\022\t\n\005AB"
+    "ORT\020\000\022\013\n\007BACKOFF\020\001\022\r\n\tIMMEDIATE\020\002B\007Z\005pro"
+    "to", 2362);
   ::google::protobuf::MessageFactory::InternalRegisterGeneratedFile(
     "cockroach/proto/errors.proto", &protobuf_RegisterTypes);
   NotLeaderError::default_instance_ = new NotLeaderError();
@@ -465,6 +484,7 @@ void protobuf_AddDesc_cockroach_2fproto_2ferrors_2eproto() {
   OpRequiresTxnError::default_instance_ = new OpRequiresTxnError();
   ConditionFailedError::default_instance_ = new ConditionFailedError();
   ErrorDetail::default_instance_ = new ErrorDetail();
+  ErrorDetail_default_oneof_instance_ = new ErrorDetailOneofInstance;
   Error::default_instance_ = new Error();
   NotLeaderError::default_instance_->InitAsDefaultInstance();
   RangeNotFoundError::default_instance_->InitAsDefaultInstance();
@@ -3579,18 +3599,18 @@ ErrorDetail::ErrorDetail()
 }
 
 void ErrorDetail::InitAsDefaultInstance() {
-  not_leader_ = const_cast< ::cockroach::proto::NotLeaderError*>(&::cockroach::proto::NotLeaderError::default_instance());
-  range_not_found_ = const_cast< ::cockroach::proto::RangeNotFoundError*>(&::cockroach::proto::RangeNotFoundError::default_instance());
-  range_key_mismatch_ = const_cast< ::cockroach::proto::RangeKeyMismatchError*>(&::cockroach::proto::RangeKeyMismatchError::default_instance());
-  read_within_uncertainty_interval_ = const_cast< ::cockroach::proto::ReadWithinUncertaintyIntervalError*>(&::cockroach::proto::ReadWithinUncertaintyIntervalError::default_instance());
-  transaction_aborted_ = const_cast< ::cockroach::proto::TransactionAbortedError*>(&::cockroach::proto::TransactionAbortedError::default_instance());
-  transaction_push_ = const_cast< ::cockroach::proto::TransactionPushError*>(&::cockroach::proto::TransactionPushError::default_instance());
-  transaction_retry_ = const_cast< ::cockroach::proto::TransactionRetryError*>(&::cockroach::proto::TransactionRetryError::default_instance());
-  transaction_status_ = const_cast< ::cockroach::proto::TransactionStatusError*>(&::cockroach::proto::TransactionStatusError::default_instance());
-  write_intent_ = const_cast< ::cockroach::proto::WriteIntentError*>(&::cockroach::proto::WriteIntentError::default_instance());
-  write_too_old_ = const_cast< ::cockroach::proto::WriteTooOldError*>(&::cockroach::proto::WriteTooOldError::default_instance());
-  op_requires_txn_ = const_cast< ::cockroach::proto::OpRequiresTxnError*>(&::cockroach::proto::OpRequiresTxnError::default_instance());
-  condition_failed_ = const_cast< ::cockroach::proto::ConditionFailedError*>(&::cockroach::proto::ConditionFailedError::default_instance());
+  ErrorDetail_default_oneof_instance_->not_leader_ = const_cast< ::cockroach::proto::NotLeaderError*>(&::cockroach::proto::NotLeaderError::default_instance());
+  ErrorDetail_default_oneof_instance_->range_not_found_ = const_cast< ::cockroach::proto::RangeNotFoundError*>(&::cockroach::proto::RangeNotFoundError::default_instance());
+  ErrorDetail_default_oneof_instance_->range_key_mismatch_ = const_cast< ::cockroach::proto::RangeKeyMismatchError*>(&::cockroach::proto::RangeKeyMismatchError::default_instance());
+  ErrorDetail_default_oneof_instance_->read_within_uncertainty_interval_ = const_cast< ::cockroach::proto::ReadWithinUncertaintyIntervalError*>(&::cockroach::proto::ReadWithinUncertaintyIntervalError::default_instance());
+  ErrorDetail_default_oneof_instance_->transaction_aborted_ = const_cast< ::cockroach::proto::TransactionAbortedError*>(&::cockroach::proto::TransactionAbortedError::default_instance());
+  ErrorDetail_default_oneof_instance_->transaction_push_ = const_cast< ::cockroach::proto::TransactionPushError*>(&::cockroach::proto::TransactionPushError::default_instance());
+  ErrorDetail_default_oneof_instance_->transaction_retry_ = const_cast< ::cockroach::proto::TransactionRetryError*>(&::cockroach::proto::TransactionRetryError::default_instance());
+  ErrorDetail_default_oneof_instance_->transaction_status_ = const_cast< ::cockroach::proto::TransactionStatusError*>(&::cockroach::proto::TransactionStatusError::default_instance());
+  ErrorDetail_default_oneof_instance_->write_intent_ = const_cast< ::cockroach::proto::WriteIntentError*>(&::cockroach::proto::WriteIntentError::default_instance());
+  ErrorDetail_default_oneof_instance_->write_too_old_ = const_cast< ::cockroach::proto::WriteTooOldError*>(&::cockroach::proto::WriteTooOldError::default_instance());
+  ErrorDetail_default_oneof_instance_->op_requires_txn_ = const_cast< ::cockroach::proto::OpRequiresTxnError*>(&::cockroach::proto::OpRequiresTxnError::default_instance());
+  ErrorDetail_default_oneof_instance_->condition_failed_ = const_cast< ::cockroach::proto::ConditionFailedError*>(&::cockroach::proto::ConditionFailedError::default_instance());
 }
 
 ErrorDetail::ErrorDetail(const ErrorDetail& from)
@@ -3602,19 +3622,8 @@ ErrorDetail::ErrorDetail(const ErrorDetail& from)
 
 void ErrorDetail::SharedCtor() {
   _cached_size_ = 0;
-  not_leader_ = NULL;
-  range_not_found_ = NULL;
-  range_key_mismatch_ = NULL;
-  read_within_uncertainty_interval_ = NULL;
-  transaction_aborted_ = NULL;
-  transaction_push_ = NULL;
-  transaction_retry_ = NULL;
-  transaction_status_ = NULL;
-  write_intent_ = NULL;
-  write_too_old_ = NULL;
-  op_requires_txn_ = NULL;
-  condition_failed_ = NULL;
   ::memset(_has_bits_, 0, sizeof(_has_bits_));
+  clear_has_value();
 }
 
 ErrorDetail::~ErrorDetail() {
@@ -3623,19 +3632,10 @@ ErrorDetail::~ErrorDetail() {
 }
 
 void ErrorDetail::SharedDtor() {
+  if (has_value()) {
+    clear_value();
+  }
   if (this != default_instance_) {
-    delete not_leader_;
-    delete range_not_found_;
-    delete range_key_mismatch_;
-    delete read_within_uncertainty_interval_;
-    delete transaction_aborted_;
-    delete transaction_push_;
-    delete transaction_retry_;
-    delete transaction_status_;
-    delete write_intent_;
-    delete write_too_old_;
-    delete op_requires_txn_;
-    delete condition_failed_;
   }
 }
 
@@ -3660,47 +3660,66 @@ ErrorDetail* ErrorDetail::New() const {
   return new ErrorDetail;
 }
 
+void ErrorDetail::clear_value() {
+  switch(value_case()) {
+    case kNotLeader: {
+      delete value_.not_leader_;
+      break;
+    }
+    case kRangeNotFound: {
+      delete value_.range_not_found_;
+      break;
+    }
+    case kRangeKeyMismatch: {
+      delete value_.range_key_mismatch_;
+      break;
+    }
+    case kReadWithinUncertaintyInterval: {
+      delete value_.read_within_uncertainty_interval_;
+      break;
+    }
+    case kTransactionAborted: {
+      delete value_.transaction_aborted_;
+      break;
+    }
+    case kTransactionPush: {
+      delete value_.transaction_push_;
+      break;
+    }
+    case kTransactionRetry: {
+      delete value_.transaction_retry_;
+      break;
+    }
+    case kTransactionStatus: {
+      delete value_.transaction_status_;
+      break;
+    }
+    case kWriteIntent: {
+      delete value_.write_intent_;
+      break;
+    }
+    case kWriteTooOld: {
+      delete value_.write_too_old_;
+      break;
+    }
+    case kOpRequiresTxn: {
+      delete value_.op_requires_txn_;
+      break;
+    }
+    case kConditionFailed: {
+      delete value_.condition_failed_;
+      break;
+    }
+    case VALUE_NOT_SET: {
+      break;
+    }
+  }
+  _oneof_case_[0] = VALUE_NOT_SET;
+}
+
+
 void ErrorDetail::Clear() {
-  if (_has_bits_[0 / 32] & 255) {
-    if (has_not_leader()) {
-      if (not_leader_ != NULL) not_leader_->::cockroach::proto::NotLeaderError::Clear();
-    }
-    if (has_range_not_found()) {
-      if (range_not_found_ != NULL) range_not_found_->::cockroach::proto::RangeNotFoundError::Clear();
-    }
-    if (has_range_key_mismatch()) {
-      if (range_key_mismatch_ != NULL) range_key_mismatch_->::cockroach::proto::RangeKeyMismatchError::Clear();
-    }
-    if (has_read_within_uncertainty_interval()) {
-      if (read_within_uncertainty_interval_ != NULL) read_within_uncertainty_interval_->::cockroach::proto::ReadWithinUncertaintyIntervalError::Clear();
-    }
-    if (has_transaction_aborted()) {
-      if (transaction_aborted_ != NULL) transaction_aborted_->::cockroach::proto::TransactionAbortedError::Clear();
-    }
-    if (has_transaction_push()) {
-      if (transaction_push_ != NULL) transaction_push_->::cockroach::proto::TransactionPushError::Clear();
-    }
-    if (has_transaction_retry()) {
-      if (transaction_retry_ != NULL) transaction_retry_->::cockroach::proto::TransactionRetryError::Clear();
-    }
-    if (has_transaction_status()) {
-      if (transaction_status_ != NULL) transaction_status_->::cockroach::proto::TransactionStatusError::Clear();
-    }
-  }
-  if (_has_bits_[8 / 32] & 3840) {
-    if (has_write_intent()) {
-      if (write_intent_ != NULL) write_intent_->::cockroach::proto::WriteIntentError::Clear();
-    }
-    if (has_write_too_old()) {
-      if (write_too_old_ != NULL) write_too_old_->::cockroach::proto::WriteTooOldError::Clear();
-    }
-    if (has_op_requires_txn()) {
-      if (op_requires_txn_ != NULL) op_requires_txn_->::cockroach::proto::OpRequiresTxnError::Clear();
-    }
-    if (has_condition_failed()) {
-      if (condition_failed_ != NULL) condition_failed_->::cockroach::proto::ConditionFailedError::Clear();
-    }
-  }
+  clear_value();
   ::memset(_has_bits_, 0, sizeof(_has_bits_));
   mutable_unknown_fields()->Clear();
 }
@@ -4072,93 +4091,94 @@ void ErrorDetail::SerializeWithCachedSizes(
 int ErrorDetail::ByteSize() const {
   int total_size = 0;
 
-  if (_has_bits_[0 / 32] & (0xffu << (0 % 32))) {
+  switch (value_case()) {
     // optional .cockroach.proto.NotLeaderError not_leader = 1;
-    if (has_not_leader()) {
+    case kNotLeader: {
       total_size += 1 +
         ::google::protobuf::internal::WireFormatLite::MessageSizeNoVirtual(
           this->not_leader());
+      break;
     }
-
     // optional .cockroach.proto.RangeNotFoundError range_not_found = 2;
-    if (has_range_not_found()) {
+    case kRangeNotFound: {
       total_size += 1 +
         ::google::protobuf::internal::WireFormatLite::MessageSizeNoVirtual(
           this->range_not_found());
+      break;
     }
-
     // optional .cockroach.proto.RangeKeyMismatchError range_key_mismatch = 3;
-    if (has_range_key_mismatch()) {
+    case kRangeKeyMismatch: {
       total_size += 1 +
         ::google::protobuf::internal::WireFormatLite::MessageSizeNoVirtual(
           this->range_key_mismatch());
+      break;
     }
-
     // optional .cockroach.proto.ReadWithinUncertaintyIntervalError read_within_uncertainty_interval = 4;
-    if (has_read_within_uncertainty_interval()) {
+    case kReadWithinUncertaintyInterval: {
       total_size += 1 +
         ::google::protobuf::internal::WireFormatLite::MessageSizeNoVirtual(
           this->read_within_uncertainty_interval());
+      break;
     }
-
     // optional .cockroach.proto.TransactionAbortedError transaction_aborted = 5;
-    if (has_transaction_aborted()) {
+    case kTransactionAborted: {
       total_size += 1 +
         ::google::protobuf::internal::WireFormatLite::MessageSizeNoVirtual(
           this->transaction_aborted());
+      break;
     }
-
     // optional .cockroach.proto.TransactionPushError transaction_push = 6;
-    if (has_transaction_push()) {
+    case kTransactionPush: {
       total_size += 1 +
         ::google::protobuf::internal::WireFormatLite::MessageSizeNoVirtual(
           this->transaction_push());
+      break;
     }
-
     // optional .cockroach.proto.TransactionRetryError transaction_retry = 7;
-    if (has_transaction_retry()) {
+    case kTransactionRetry: {
       total_size += 1 +
         ::google::protobuf::internal::WireFormatLite::MessageSizeNoVirtual(
           this->transaction_retry());
+      break;
     }
-
     // optional .cockroach.proto.TransactionStatusError transaction_status = 8;
-    if (has_transaction_status()) {
+    case kTransactionStatus: {
       total_size += 1 +
         ::google::protobuf::internal::WireFormatLite::MessageSizeNoVirtual(
           this->transaction_status());
+      break;
     }
-
-  }
-  if (_has_bits_[8 / 32] & (0xffu << (8 % 32))) {
     // optional .cockroach.proto.WriteIntentError write_intent = 9;
-    if (has_write_intent()) {
+    case kWriteIntent: {
       total_size += 1 +
         ::google::protobuf::internal::WireFormatLite::MessageSizeNoVirtual(
           this->write_intent());
+      break;
     }
-
     // optional .cockroach.proto.WriteTooOldError write_too_old = 10;
-    if (has_write_too_old()) {
+    case kWriteTooOld: {
       total_size += 1 +
         ::google::protobuf::internal::WireFormatLite::MessageSizeNoVirtual(
           this->write_too_old());
+      break;
     }
-
     // optional .cockroach.proto.OpRequiresTxnError op_requires_txn = 11;
-    if (has_op_requires_txn()) {
+    case kOpRequiresTxn: {
       total_size += 1 +
         ::google::protobuf::internal::WireFormatLite::MessageSizeNoVirtual(
           this->op_requires_txn());
+      break;
     }
-
     // optional .cockroach.proto.ConditionFailedError condition_failed = 12;
-    if (has_condition_failed()) {
+    case kConditionFailed: {
       total_size += 1 +
         ::google::protobuf::internal::WireFormatLite::MessageSizeNoVirtual(
           this->condition_failed());
+      break;
     }
-
+    case VALUE_NOT_SET: {
+      break;
+    }
   }
   if (!unknown_fields().empty()) {
     total_size +=
@@ -4185,44 +4205,57 @@ void ErrorDetail::MergeFrom(const ::google::protobuf::Message& from) {
 
 void ErrorDetail::MergeFrom(const ErrorDetail& from) {
   GOOGLE_CHECK_NE(&from, this);
-  if (from._has_bits_[0 / 32] & (0xffu << (0 % 32))) {
-    if (from.has_not_leader()) {
+  switch (from.value_case()) {
+    case kNotLeader: {
       mutable_not_leader()->::cockroach::proto::NotLeaderError::MergeFrom(from.not_leader());
+      break;
     }
-    if (from.has_range_not_found()) {
+    case kRangeNotFound: {
       mutable_range_not_found()->::cockroach::proto::RangeNotFoundError::MergeFrom(from.range_not_found());
+      break;
     }
-    if (from.has_range_key_mismatch()) {
+    case kRangeKeyMismatch: {
       mutable_range_key_mismatch()->::cockroach::proto::RangeKeyMismatchError::MergeFrom(from.range_key_mismatch());
+      break;
     }
-    if (from.has_read_within_uncertainty_interval()) {
+    case kReadWithinUncertaintyInterval: {
       mutable_read_within_uncertainty_interval()->::cockroach::proto::ReadWithinUncertaintyIntervalError::MergeFrom(from.read_within_uncertainty_interval());
+      break;
     }
-    if (from.has_transaction_aborted()) {
+    case kTransactionAborted: {
       mutable_transaction_aborted()->::cockroach::proto::TransactionAbortedError::MergeFrom(from.transaction_aborted());
+      break;
     }
-    if (from.has_transaction_push()) {
+    case kTransactionPush: {
       mutable_transaction_push()->::cockroach::proto::TransactionPushError::MergeFrom(from.transaction_push());
+      break;
     }
-    if (from.has_transaction_retry()) {
+    case kTransactionRetry: {
       mutable_transaction_retry()->::cockroach::proto::TransactionRetryError::MergeFrom(from.transaction_retry());
+      break;
     }
-    if (from.has_transaction_status()) {
+    case kTransactionStatus: {
       mutable_transaction_status()->::cockroach::proto::TransactionStatusError::MergeFrom(from.transaction_status());
+      break;
     }
-  }
-  if (from._has_bits_[8 / 32] & (0xffu << (8 % 32))) {
-    if (from.has_write_intent()) {
+    case kWriteIntent: {
       mutable_write_intent()->::cockroach::proto::WriteIntentError::MergeFrom(from.write_intent());
+      break;
     }
-    if (from.has_write_too_old()) {
+    case kWriteTooOld: {
       mutable_write_too_old()->::cockroach::proto::WriteTooOldError::MergeFrom(from.write_too_old());
+      break;
     }
-    if (from.has_op_requires_txn()) {
+    case kOpRequiresTxn: {
       mutable_op_requires_txn()->::cockroach::proto::OpRequiresTxnError::MergeFrom(from.op_requires_txn());
+      break;
     }
-    if (from.has_condition_failed()) {
+    case kConditionFailed: {
       mutable_condition_failed()->::cockroach::proto::ConditionFailedError::MergeFrom(from.condition_failed());
+      break;
+    }
+    case VALUE_NOT_SET: {
+      break;
     }
   }
   mutable_unknown_fields()->MergeFrom(from.unknown_fields());
@@ -4247,18 +4280,8 @@ bool ErrorDetail::IsInitialized() const {
 
 void ErrorDetail::Swap(ErrorDetail* other) {
   if (other != this) {
-    std::swap(not_leader_, other->not_leader_);
-    std::swap(range_not_found_, other->range_not_found_);
-    std::swap(range_key_mismatch_, other->range_key_mismatch_);
-    std::swap(read_within_uncertainty_interval_, other->read_within_uncertainty_interval_);
-    std::swap(transaction_aborted_, other->transaction_aborted_);
-    std::swap(transaction_push_, other->transaction_push_);
-    std::swap(transaction_retry_, other->transaction_retry_);
-    std::swap(transaction_status_, other->transaction_status_);
-    std::swap(write_intent_, other->write_intent_);
-    std::swap(write_too_old_, other->write_too_old_);
-    std::swap(op_requires_txn_, other->op_requires_txn_);
-    std::swap(condition_failed_, other->condition_failed_);
+    std::swap(value_, other->value_);
+    std::swap(_oneof_case_[0], other->_oneof_case_[0]);
     std::swap(_has_bits_[0], other->_has_bits_[0]);
     _unknown_fields_.Swap(&other->_unknown_fields_);
     std::swap(_cached_size_, other->_cached_size_);

--- a/storage/engine/cockroach/proto/errors.pb.h
+++ b/storage/engine/cockroach/proto/errors.pb.h
@@ -1162,6 +1162,22 @@ class ErrorDetail : public ::google::protobuf::Message {
   static const ::google::protobuf::Descriptor* descriptor();
   static const ErrorDetail& default_instance();
 
+  enum ValueCase {
+    kNotLeader = 1,
+    kRangeNotFound = 2,
+    kRangeKeyMismatch = 3,
+    kReadWithinUncertaintyInterval = 4,
+    kTransactionAborted = 5,
+    kTransactionPush = 6,
+    kTransactionRetry = 7,
+    kTransactionStatus = 8,
+    kWriteIntent = 9,
+    kWriteTooOld = 10,
+    kOpRequiresTxn = 11,
+    kConditionFailed = 12,
+    VALUE_NOT_SET = 0,
+  };
+
   void Swap(ErrorDetail* other);
 
   // implements Message ----------------------------------------------
@@ -1300,49 +1316,46 @@ class ErrorDetail : public ::google::protobuf::Message {
   inline ::cockroach::proto::ConditionFailedError* release_condition_failed();
   inline void set_allocated_condition_failed(::cockroach::proto::ConditionFailedError* condition_failed);
 
+  inline ValueCase value_case() const;
   // @@protoc_insertion_point(class_scope:cockroach.proto.ErrorDetail)
  private:
   inline void set_has_not_leader();
-  inline void clear_has_not_leader();
   inline void set_has_range_not_found();
-  inline void clear_has_range_not_found();
   inline void set_has_range_key_mismatch();
-  inline void clear_has_range_key_mismatch();
   inline void set_has_read_within_uncertainty_interval();
-  inline void clear_has_read_within_uncertainty_interval();
   inline void set_has_transaction_aborted();
-  inline void clear_has_transaction_aborted();
   inline void set_has_transaction_push();
-  inline void clear_has_transaction_push();
   inline void set_has_transaction_retry();
-  inline void clear_has_transaction_retry();
   inline void set_has_transaction_status();
-  inline void clear_has_transaction_status();
   inline void set_has_write_intent();
-  inline void clear_has_write_intent();
   inline void set_has_write_too_old();
-  inline void clear_has_write_too_old();
   inline void set_has_op_requires_txn();
-  inline void clear_has_op_requires_txn();
   inline void set_has_condition_failed();
-  inline void clear_has_condition_failed();
+
+  inline bool has_value();
+  void clear_value();
+  inline void clear_has_value();
 
   ::google::protobuf::UnknownFieldSet _unknown_fields_;
 
   ::google::protobuf::uint32 _has_bits_[1];
   mutable int _cached_size_;
-  ::cockroach::proto::NotLeaderError* not_leader_;
-  ::cockroach::proto::RangeNotFoundError* range_not_found_;
-  ::cockroach::proto::RangeKeyMismatchError* range_key_mismatch_;
-  ::cockroach::proto::ReadWithinUncertaintyIntervalError* read_within_uncertainty_interval_;
-  ::cockroach::proto::TransactionAbortedError* transaction_aborted_;
-  ::cockroach::proto::TransactionPushError* transaction_push_;
-  ::cockroach::proto::TransactionRetryError* transaction_retry_;
-  ::cockroach::proto::TransactionStatusError* transaction_status_;
-  ::cockroach::proto::WriteIntentError* write_intent_;
-  ::cockroach::proto::WriteTooOldError* write_too_old_;
-  ::cockroach::proto::OpRequiresTxnError* op_requires_txn_;
-  ::cockroach::proto::ConditionFailedError* condition_failed_;
+  union ValueUnion {
+    ::cockroach::proto::NotLeaderError* not_leader_;
+    ::cockroach::proto::RangeNotFoundError* range_not_found_;
+    ::cockroach::proto::RangeKeyMismatchError* range_key_mismatch_;
+    ::cockroach::proto::ReadWithinUncertaintyIntervalError* read_within_uncertainty_interval_;
+    ::cockroach::proto::TransactionAbortedError* transaction_aborted_;
+    ::cockroach::proto::TransactionPushError* transaction_push_;
+    ::cockroach::proto::TransactionRetryError* transaction_retry_;
+    ::cockroach::proto::TransactionStatusError* transaction_status_;
+    ::cockroach::proto::WriteIntentError* write_intent_;
+    ::cockroach::proto::WriteTooOldError* write_too_old_;
+    ::cockroach::proto::OpRequiresTxnError* op_requires_txn_;
+    ::cockroach::proto::ConditionFailedError* condition_failed_;
+  } value_;
+  ::google::protobuf::uint32 _oneof_case_[1];
+
   friend void  protobuf_AddDesc_cockroach_2fproto_2ferrors_2eproto();
   friend void protobuf_AssignDesc_cockroach_2fproto_2ferrors_2eproto();
   friend void protobuf_ShutdownFile_cockroach_2fproto_2ferrors_2eproto();
@@ -2408,496 +2421,529 @@ inline void ConditionFailedError::set_allocated_actual_value(::cockroach::proto:
 
 // optional .cockroach.proto.NotLeaderError not_leader = 1;
 inline bool ErrorDetail::has_not_leader() const {
-  return (_has_bits_[0] & 0x00000001u) != 0;
+  return value_case() == kNotLeader;
 }
 inline void ErrorDetail::set_has_not_leader() {
-  _has_bits_[0] |= 0x00000001u;
-}
-inline void ErrorDetail::clear_has_not_leader() {
-  _has_bits_[0] &= ~0x00000001u;
+  _oneof_case_[0] = kNotLeader;
 }
 inline void ErrorDetail::clear_not_leader() {
-  if (not_leader_ != NULL) not_leader_->::cockroach::proto::NotLeaderError::Clear();
-  clear_has_not_leader();
+  if (has_not_leader()) {
+    delete value_.not_leader_;
+    clear_has_value();
+  }
 }
 inline const ::cockroach::proto::NotLeaderError& ErrorDetail::not_leader() const {
-  // @@protoc_insertion_point(field_get:cockroach.proto.ErrorDetail.not_leader)
-  return not_leader_ != NULL ? *not_leader_ : *default_instance_->not_leader_;
+  return has_not_leader() ? *value_.not_leader_
+                      : ::cockroach::proto::NotLeaderError::default_instance();
 }
 inline ::cockroach::proto::NotLeaderError* ErrorDetail::mutable_not_leader() {
-  set_has_not_leader();
-  if (not_leader_ == NULL) not_leader_ = new ::cockroach::proto::NotLeaderError;
-  // @@protoc_insertion_point(field_mutable:cockroach.proto.ErrorDetail.not_leader)
-  return not_leader_;
+  if (!has_not_leader()) {
+    clear_value();
+    set_has_not_leader();
+    value_.not_leader_ = new ::cockroach::proto::NotLeaderError;
+  }
+  return value_.not_leader_;
 }
 inline ::cockroach::proto::NotLeaderError* ErrorDetail::release_not_leader() {
-  clear_has_not_leader();
-  ::cockroach::proto::NotLeaderError* temp = not_leader_;
-  not_leader_ = NULL;
-  return temp;
+  if (has_not_leader()) {
+    clear_has_value();
+    ::cockroach::proto::NotLeaderError* temp = value_.not_leader_;
+    value_.not_leader_ = NULL;
+    return temp;
+  } else {
+    return NULL;
+  }
 }
 inline void ErrorDetail::set_allocated_not_leader(::cockroach::proto::NotLeaderError* not_leader) {
-  delete not_leader_;
-  not_leader_ = not_leader;
+  clear_value();
   if (not_leader) {
     set_has_not_leader();
-  } else {
-    clear_has_not_leader();
+    value_.not_leader_ = not_leader;
   }
-  // @@protoc_insertion_point(field_set_allocated:cockroach.proto.ErrorDetail.not_leader)
 }
 
 // optional .cockroach.proto.RangeNotFoundError range_not_found = 2;
 inline bool ErrorDetail::has_range_not_found() const {
-  return (_has_bits_[0] & 0x00000002u) != 0;
+  return value_case() == kRangeNotFound;
 }
 inline void ErrorDetail::set_has_range_not_found() {
-  _has_bits_[0] |= 0x00000002u;
-}
-inline void ErrorDetail::clear_has_range_not_found() {
-  _has_bits_[0] &= ~0x00000002u;
+  _oneof_case_[0] = kRangeNotFound;
 }
 inline void ErrorDetail::clear_range_not_found() {
-  if (range_not_found_ != NULL) range_not_found_->::cockroach::proto::RangeNotFoundError::Clear();
-  clear_has_range_not_found();
+  if (has_range_not_found()) {
+    delete value_.range_not_found_;
+    clear_has_value();
+  }
 }
 inline const ::cockroach::proto::RangeNotFoundError& ErrorDetail::range_not_found() const {
-  // @@protoc_insertion_point(field_get:cockroach.proto.ErrorDetail.range_not_found)
-  return range_not_found_ != NULL ? *range_not_found_ : *default_instance_->range_not_found_;
+  return has_range_not_found() ? *value_.range_not_found_
+                      : ::cockroach::proto::RangeNotFoundError::default_instance();
 }
 inline ::cockroach::proto::RangeNotFoundError* ErrorDetail::mutable_range_not_found() {
-  set_has_range_not_found();
-  if (range_not_found_ == NULL) range_not_found_ = new ::cockroach::proto::RangeNotFoundError;
-  // @@protoc_insertion_point(field_mutable:cockroach.proto.ErrorDetail.range_not_found)
-  return range_not_found_;
+  if (!has_range_not_found()) {
+    clear_value();
+    set_has_range_not_found();
+    value_.range_not_found_ = new ::cockroach::proto::RangeNotFoundError;
+  }
+  return value_.range_not_found_;
 }
 inline ::cockroach::proto::RangeNotFoundError* ErrorDetail::release_range_not_found() {
-  clear_has_range_not_found();
-  ::cockroach::proto::RangeNotFoundError* temp = range_not_found_;
-  range_not_found_ = NULL;
-  return temp;
+  if (has_range_not_found()) {
+    clear_has_value();
+    ::cockroach::proto::RangeNotFoundError* temp = value_.range_not_found_;
+    value_.range_not_found_ = NULL;
+    return temp;
+  } else {
+    return NULL;
+  }
 }
 inline void ErrorDetail::set_allocated_range_not_found(::cockroach::proto::RangeNotFoundError* range_not_found) {
-  delete range_not_found_;
-  range_not_found_ = range_not_found;
+  clear_value();
   if (range_not_found) {
     set_has_range_not_found();
-  } else {
-    clear_has_range_not_found();
+    value_.range_not_found_ = range_not_found;
   }
-  // @@protoc_insertion_point(field_set_allocated:cockroach.proto.ErrorDetail.range_not_found)
 }
 
 // optional .cockroach.proto.RangeKeyMismatchError range_key_mismatch = 3;
 inline bool ErrorDetail::has_range_key_mismatch() const {
-  return (_has_bits_[0] & 0x00000004u) != 0;
+  return value_case() == kRangeKeyMismatch;
 }
 inline void ErrorDetail::set_has_range_key_mismatch() {
-  _has_bits_[0] |= 0x00000004u;
-}
-inline void ErrorDetail::clear_has_range_key_mismatch() {
-  _has_bits_[0] &= ~0x00000004u;
+  _oneof_case_[0] = kRangeKeyMismatch;
 }
 inline void ErrorDetail::clear_range_key_mismatch() {
-  if (range_key_mismatch_ != NULL) range_key_mismatch_->::cockroach::proto::RangeKeyMismatchError::Clear();
-  clear_has_range_key_mismatch();
+  if (has_range_key_mismatch()) {
+    delete value_.range_key_mismatch_;
+    clear_has_value();
+  }
 }
 inline const ::cockroach::proto::RangeKeyMismatchError& ErrorDetail::range_key_mismatch() const {
-  // @@protoc_insertion_point(field_get:cockroach.proto.ErrorDetail.range_key_mismatch)
-  return range_key_mismatch_ != NULL ? *range_key_mismatch_ : *default_instance_->range_key_mismatch_;
+  return has_range_key_mismatch() ? *value_.range_key_mismatch_
+                      : ::cockroach::proto::RangeKeyMismatchError::default_instance();
 }
 inline ::cockroach::proto::RangeKeyMismatchError* ErrorDetail::mutable_range_key_mismatch() {
-  set_has_range_key_mismatch();
-  if (range_key_mismatch_ == NULL) range_key_mismatch_ = new ::cockroach::proto::RangeKeyMismatchError;
-  // @@protoc_insertion_point(field_mutable:cockroach.proto.ErrorDetail.range_key_mismatch)
-  return range_key_mismatch_;
+  if (!has_range_key_mismatch()) {
+    clear_value();
+    set_has_range_key_mismatch();
+    value_.range_key_mismatch_ = new ::cockroach::proto::RangeKeyMismatchError;
+  }
+  return value_.range_key_mismatch_;
 }
 inline ::cockroach::proto::RangeKeyMismatchError* ErrorDetail::release_range_key_mismatch() {
-  clear_has_range_key_mismatch();
-  ::cockroach::proto::RangeKeyMismatchError* temp = range_key_mismatch_;
-  range_key_mismatch_ = NULL;
-  return temp;
+  if (has_range_key_mismatch()) {
+    clear_has_value();
+    ::cockroach::proto::RangeKeyMismatchError* temp = value_.range_key_mismatch_;
+    value_.range_key_mismatch_ = NULL;
+    return temp;
+  } else {
+    return NULL;
+  }
 }
 inline void ErrorDetail::set_allocated_range_key_mismatch(::cockroach::proto::RangeKeyMismatchError* range_key_mismatch) {
-  delete range_key_mismatch_;
-  range_key_mismatch_ = range_key_mismatch;
+  clear_value();
   if (range_key_mismatch) {
     set_has_range_key_mismatch();
-  } else {
-    clear_has_range_key_mismatch();
+    value_.range_key_mismatch_ = range_key_mismatch;
   }
-  // @@protoc_insertion_point(field_set_allocated:cockroach.proto.ErrorDetail.range_key_mismatch)
 }
 
 // optional .cockroach.proto.ReadWithinUncertaintyIntervalError read_within_uncertainty_interval = 4;
 inline bool ErrorDetail::has_read_within_uncertainty_interval() const {
-  return (_has_bits_[0] & 0x00000008u) != 0;
+  return value_case() == kReadWithinUncertaintyInterval;
 }
 inline void ErrorDetail::set_has_read_within_uncertainty_interval() {
-  _has_bits_[0] |= 0x00000008u;
-}
-inline void ErrorDetail::clear_has_read_within_uncertainty_interval() {
-  _has_bits_[0] &= ~0x00000008u;
+  _oneof_case_[0] = kReadWithinUncertaintyInterval;
 }
 inline void ErrorDetail::clear_read_within_uncertainty_interval() {
-  if (read_within_uncertainty_interval_ != NULL) read_within_uncertainty_interval_->::cockroach::proto::ReadWithinUncertaintyIntervalError::Clear();
-  clear_has_read_within_uncertainty_interval();
+  if (has_read_within_uncertainty_interval()) {
+    delete value_.read_within_uncertainty_interval_;
+    clear_has_value();
+  }
 }
 inline const ::cockroach::proto::ReadWithinUncertaintyIntervalError& ErrorDetail::read_within_uncertainty_interval() const {
-  // @@protoc_insertion_point(field_get:cockroach.proto.ErrorDetail.read_within_uncertainty_interval)
-  return read_within_uncertainty_interval_ != NULL ? *read_within_uncertainty_interval_ : *default_instance_->read_within_uncertainty_interval_;
+  return has_read_within_uncertainty_interval() ? *value_.read_within_uncertainty_interval_
+                      : ::cockroach::proto::ReadWithinUncertaintyIntervalError::default_instance();
 }
 inline ::cockroach::proto::ReadWithinUncertaintyIntervalError* ErrorDetail::mutable_read_within_uncertainty_interval() {
-  set_has_read_within_uncertainty_interval();
-  if (read_within_uncertainty_interval_ == NULL) read_within_uncertainty_interval_ = new ::cockroach::proto::ReadWithinUncertaintyIntervalError;
-  // @@protoc_insertion_point(field_mutable:cockroach.proto.ErrorDetail.read_within_uncertainty_interval)
-  return read_within_uncertainty_interval_;
+  if (!has_read_within_uncertainty_interval()) {
+    clear_value();
+    set_has_read_within_uncertainty_interval();
+    value_.read_within_uncertainty_interval_ = new ::cockroach::proto::ReadWithinUncertaintyIntervalError;
+  }
+  return value_.read_within_uncertainty_interval_;
 }
 inline ::cockroach::proto::ReadWithinUncertaintyIntervalError* ErrorDetail::release_read_within_uncertainty_interval() {
-  clear_has_read_within_uncertainty_interval();
-  ::cockroach::proto::ReadWithinUncertaintyIntervalError* temp = read_within_uncertainty_interval_;
-  read_within_uncertainty_interval_ = NULL;
-  return temp;
+  if (has_read_within_uncertainty_interval()) {
+    clear_has_value();
+    ::cockroach::proto::ReadWithinUncertaintyIntervalError* temp = value_.read_within_uncertainty_interval_;
+    value_.read_within_uncertainty_interval_ = NULL;
+    return temp;
+  } else {
+    return NULL;
+  }
 }
 inline void ErrorDetail::set_allocated_read_within_uncertainty_interval(::cockroach::proto::ReadWithinUncertaintyIntervalError* read_within_uncertainty_interval) {
-  delete read_within_uncertainty_interval_;
-  read_within_uncertainty_interval_ = read_within_uncertainty_interval;
+  clear_value();
   if (read_within_uncertainty_interval) {
     set_has_read_within_uncertainty_interval();
-  } else {
-    clear_has_read_within_uncertainty_interval();
+    value_.read_within_uncertainty_interval_ = read_within_uncertainty_interval;
   }
-  // @@protoc_insertion_point(field_set_allocated:cockroach.proto.ErrorDetail.read_within_uncertainty_interval)
 }
 
 // optional .cockroach.proto.TransactionAbortedError transaction_aborted = 5;
 inline bool ErrorDetail::has_transaction_aborted() const {
-  return (_has_bits_[0] & 0x00000010u) != 0;
+  return value_case() == kTransactionAborted;
 }
 inline void ErrorDetail::set_has_transaction_aborted() {
-  _has_bits_[0] |= 0x00000010u;
-}
-inline void ErrorDetail::clear_has_transaction_aborted() {
-  _has_bits_[0] &= ~0x00000010u;
+  _oneof_case_[0] = kTransactionAborted;
 }
 inline void ErrorDetail::clear_transaction_aborted() {
-  if (transaction_aborted_ != NULL) transaction_aborted_->::cockroach::proto::TransactionAbortedError::Clear();
-  clear_has_transaction_aborted();
+  if (has_transaction_aborted()) {
+    delete value_.transaction_aborted_;
+    clear_has_value();
+  }
 }
 inline const ::cockroach::proto::TransactionAbortedError& ErrorDetail::transaction_aborted() const {
-  // @@protoc_insertion_point(field_get:cockroach.proto.ErrorDetail.transaction_aborted)
-  return transaction_aborted_ != NULL ? *transaction_aborted_ : *default_instance_->transaction_aborted_;
+  return has_transaction_aborted() ? *value_.transaction_aborted_
+                      : ::cockroach::proto::TransactionAbortedError::default_instance();
 }
 inline ::cockroach::proto::TransactionAbortedError* ErrorDetail::mutable_transaction_aborted() {
-  set_has_transaction_aborted();
-  if (transaction_aborted_ == NULL) transaction_aborted_ = new ::cockroach::proto::TransactionAbortedError;
-  // @@protoc_insertion_point(field_mutable:cockroach.proto.ErrorDetail.transaction_aborted)
-  return transaction_aborted_;
+  if (!has_transaction_aborted()) {
+    clear_value();
+    set_has_transaction_aborted();
+    value_.transaction_aborted_ = new ::cockroach::proto::TransactionAbortedError;
+  }
+  return value_.transaction_aborted_;
 }
 inline ::cockroach::proto::TransactionAbortedError* ErrorDetail::release_transaction_aborted() {
-  clear_has_transaction_aborted();
-  ::cockroach::proto::TransactionAbortedError* temp = transaction_aborted_;
-  transaction_aborted_ = NULL;
-  return temp;
+  if (has_transaction_aborted()) {
+    clear_has_value();
+    ::cockroach::proto::TransactionAbortedError* temp = value_.transaction_aborted_;
+    value_.transaction_aborted_ = NULL;
+    return temp;
+  } else {
+    return NULL;
+  }
 }
 inline void ErrorDetail::set_allocated_transaction_aborted(::cockroach::proto::TransactionAbortedError* transaction_aborted) {
-  delete transaction_aborted_;
-  transaction_aborted_ = transaction_aborted;
+  clear_value();
   if (transaction_aborted) {
     set_has_transaction_aborted();
-  } else {
-    clear_has_transaction_aborted();
+    value_.transaction_aborted_ = transaction_aborted;
   }
-  // @@protoc_insertion_point(field_set_allocated:cockroach.proto.ErrorDetail.transaction_aborted)
 }
 
 // optional .cockroach.proto.TransactionPushError transaction_push = 6;
 inline bool ErrorDetail::has_transaction_push() const {
-  return (_has_bits_[0] & 0x00000020u) != 0;
+  return value_case() == kTransactionPush;
 }
 inline void ErrorDetail::set_has_transaction_push() {
-  _has_bits_[0] |= 0x00000020u;
-}
-inline void ErrorDetail::clear_has_transaction_push() {
-  _has_bits_[0] &= ~0x00000020u;
+  _oneof_case_[0] = kTransactionPush;
 }
 inline void ErrorDetail::clear_transaction_push() {
-  if (transaction_push_ != NULL) transaction_push_->::cockroach::proto::TransactionPushError::Clear();
-  clear_has_transaction_push();
+  if (has_transaction_push()) {
+    delete value_.transaction_push_;
+    clear_has_value();
+  }
 }
 inline const ::cockroach::proto::TransactionPushError& ErrorDetail::transaction_push() const {
-  // @@protoc_insertion_point(field_get:cockroach.proto.ErrorDetail.transaction_push)
-  return transaction_push_ != NULL ? *transaction_push_ : *default_instance_->transaction_push_;
+  return has_transaction_push() ? *value_.transaction_push_
+                      : ::cockroach::proto::TransactionPushError::default_instance();
 }
 inline ::cockroach::proto::TransactionPushError* ErrorDetail::mutable_transaction_push() {
-  set_has_transaction_push();
-  if (transaction_push_ == NULL) transaction_push_ = new ::cockroach::proto::TransactionPushError;
-  // @@protoc_insertion_point(field_mutable:cockroach.proto.ErrorDetail.transaction_push)
-  return transaction_push_;
+  if (!has_transaction_push()) {
+    clear_value();
+    set_has_transaction_push();
+    value_.transaction_push_ = new ::cockroach::proto::TransactionPushError;
+  }
+  return value_.transaction_push_;
 }
 inline ::cockroach::proto::TransactionPushError* ErrorDetail::release_transaction_push() {
-  clear_has_transaction_push();
-  ::cockroach::proto::TransactionPushError* temp = transaction_push_;
-  transaction_push_ = NULL;
-  return temp;
+  if (has_transaction_push()) {
+    clear_has_value();
+    ::cockroach::proto::TransactionPushError* temp = value_.transaction_push_;
+    value_.transaction_push_ = NULL;
+    return temp;
+  } else {
+    return NULL;
+  }
 }
 inline void ErrorDetail::set_allocated_transaction_push(::cockroach::proto::TransactionPushError* transaction_push) {
-  delete transaction_push_;
-  transaction_push_ = transaction_push;
+  clear_value();
   if (transaction_push) {
     set_has_transaction_push();
-  } else {
-    clear_has_transaction_push();
+    value_.transaction_push_ = transaction_push;
   }
-  // @@protoc_insertion_point(field_set_allocated:cockroach.proto.ErrorDetail.transaction_push)
 }
 
 // optional .cockroach.proto.TransactionRetryError transaction_retry = 7;
 inline bool ErrorDetail::has_transaction_retry() const {
-  return (_has_bits_[0] & 0x00000040u) != 0;
+  return value_case() == kTransactionRetry;
 }
 inline void ErrorDetail::set_has_transaction_retry() {
-  _has_bits_[0] |= 0x00000040u;
-}
-inline void ErrorDetail::clear_has_transaction_retry() {
-  _has_bits_[0] &= ~0x00000040u;
+  _oneof_case_[0] = kTransactionRetry;
 }
 inline void ErrorDetail::clear_transaction_retry() {
-  if (transaction_retry_ != NULL) transaction_retry_->::cockroach::proto::TransactionRetryError::Clear();
-  clear_has_transaction_retry();
+  if (has_transaction_retry()) {
+    delete value_.transaction_retry_;
+    clear_has_value();
+  }
 }
 inline const ::cockroach::proto::TransactionRetryError& ErrorDetail::transaction_retry() const {
-  // @@protoc_insertion_point(field_get:cockroach.proto.ErrorDetail.transaction_retry)
-  return transaction_retry_ != NULL ? *transaction_retry_ : *default_instance_->transaction_retry_;
+  return has_transaction_retry() ? *value_.transaction_retry_
+                      : ::cockroach::proto::TransactionRetryError::default_instance();
 }
 inline ::cockroach::proto::TransactionRetryError* ErrorDetail::mutable_transaction_retry() {
-  set_has_transaction_retry();
-  if (transaction_retry_ == NULL) transaction_retry_ = new ::cockroach::proto::TransactionRetryError;
-  // @@protoc_insertion_point(field_mutable:cockroach.proto.ErrorDetail.transaction_retry)
-  return transaction_retry_;
+  if (!has_transaction_retry()) {
+    clear_value();
+    set_has_transaction_retry();
+    value_.transaction_retry_ = new ::cockroach::proto::TransactionRetryError;
+  }
+  return value_.transaction_retry_;
 }
 inline ::cockroach::proto::TransactionRetryError* ErrorDetail::release_transaction_retry() {
-  clear_has_transaction_retry();
-  ::cockroach::proto::TransactionRetryError* temp = transaction_retry_;
-  transaction_retry_ = NULL;
-  return temp;
+  if (has_transaction_retry()) {
+    clear_has_value();
+    ::cockroach::proto::TransactionRetryError* temp = value_.transaction_retry_;
+    value_.transaction_retry_ = NULL;
+    return temp;
+  } else {
+    return NULL;
+  }
 }
 inline void ErrorDetail::set_allocated_transaction_retry(::cockroach::proto::TransactionRetryError* transaction_retry) {
-  delete transaction_retry_;
-  transaction_retry_ = transaction_retry;
+  clear_value();
   if (transaction_retry) {
     set_has_transaction_retry();
-  } else {
-    clear_has_transaction_retry();
+    value_.transaction_retry_ = transaction_retry;
   }
-  // @@protoc_insertion_point(field_set_allocated:cockroach.proto.ErrorDetail.transaction_retry)
 }
 
 // optional .cockroach.proto.TransactionStatusError transaction_status = 8;
 inline bool ErrorDetail::has_transaction_status() const {
-  return (_has_bits_[0] & 0x00000080u) != 0;
+  return value_case() == kTransactionStatus;
 }
 inline void ErrorDetail::set_has_transaction_status() {
-  _has_bits_[0] |= 0x00000080u;
-}
-inline void ErrorDetail::clear_has_transaction_status() {
-  _has_bits_[0] &= ~0x00000080u;
+  _oneof_case_[0] = kTransactionStatus;
 }
 inline void ErrorDetail::clear_transaction_status() {
-  if (transaction_status_ != NULL) transaction_status_->::cockroach::proto::TransactionStatusError::Clear();
-  clear_has_transaction_status();
+  if (has_transaction_status()) {
+    delete value_.transaction_status_;
+    clear_has_value();
+  }
 }
 inline const ::cockroach::proto::TransactionStatusError& ErrorDetail::transaction_status() const {
-  // @@protoc_insertion_point(field_get:cockroach.proto.ErrorDetail.transaction_status)
-  return transaction_status_ != NULL ? *transaction_status_ : *default_instance_->transaction_status_;
+  return has_transaction_status() ? *value_.transaction_status_
+                      : ::cockroach::proto::TransactionStatusError::default_instance();
 }
 inline ::cockroach::proto::TransactionStatusError* ErrorDetail::mutable_transaction_status() {
-  set_has_transaction_status();
-  if (transaction_status_ == NULL) transaction_status_ = new ::cockroach::proto::TransactionStatusError;
-  // @@protoc_insertion_point(field_mutable:cockroach.proto.ErrorDetail.transaction_status)
-  return transaction_status_;
+  if (!has_transaction_status()) {
+    clear_value();
+    set_has_transaction_status();
+    value_.transaction_status_ = new ::cockroach::proto::TransactionStatusError;
+  }
+  return value_.transaction_status_;
 }
 inline ::cockroach::proto::TransactionStatusError* ErrorDetail::release_transaction_status() {
-  clear_has_transaction_status();
-  ::cockroach::proto::TransactionStatusError* temp = transaction_status_;
-  transaction_status_ = NULL;
-  return temp;
+  if (has_transaction_status()) {
+    clear_has_value();
+    ::cockroach::proto::TransactionStatusError* temp = value_.transaction_status_;
+    value_.transaction_status_ = NULL;
+    return temp;
+  } else {
+    return NULL;
+  }
 }
 inline void ErrorDetail::set_allocated_transaction_status(::cockroach::proto::TransactionStatusError* transaction_status) {
-  delete transaction_status_;
-  transaction_status_ = transaction_status;
+  clear_value();
   if (transaction_status) {
     set_has_transaction_status();
-  } else {
-    clear_has_transaction_status();
+    value_.transaction_status_ = transaction_status;
   }
-  // @@protoc_insertion_point(field_set_allocated:cockroach.proto.ErrorDetail.transaction_status)
 }
 
 // optional .cockroach.proto.WriteIntentError write_intent = 9;
 inline bool ErrorDetail::has_write_intent() const {
-  return (_has_bits_[0] & 0x00000100u) != 0;
+  return value_case() == kWriteIntent;
 }
 inline void ErrorDetail::set_has_write_intent() {
-  _has_bits_[0] |= 0x00000100u;
-}
-inline void ErrorDetail::clear_has_write_intent() {
-  _has_bits_[0] &= ~0x00000100u;
+  _oneof_case_[0] = kWriteIntent;
 }
 inline void ErrorDetail::clear_write_intent() {
-  if (write_intent_ != NULL) write_intent_->::cockroach::proto::WriteIntentError::Clear();
-  clear_has_write_intent();
+  if (has_write_intent()) {
+    delete value_.write_intent_;
+    clear_has_value();
+  }
 }
 inline const ::cockroach::proto::WriteIntentError& ErrorDetail::write_intent() const {
-  // @@protoc_insertion_point(field_get:cockroach.proto.ErrorDetail.write_intent)
-  return write_intent_ != NULL ? *write_intent_ : *default_instance_->write_intent_;
+  return has_write_intent() ? *value_.write_intent_
+                      : ::cockroach::proto::WriteIntentError::default_instance();
 }
 inline ::cockroach::proto::WriteIntentError* ErrorDetail::mutable_write_intent() {
-  set_has_write_intent();
-  if (write_intent_ == NULL) write_intent_ = new ::cockroach::proto::WriteIntentError;
-  // @@protoc_insertion_point(field_mutable:cockroach.proto.ErrorDetail.write_intent)
-  return write_intent_;
+  if (!has_write_intent()) {
+    clear_value();
+    set_has_write_intent();
+    value_.write_intent_ = new ::cockroach::proto::WriteIntentError;
+  }
+  return value_.write_intent_;
 }
 inline ::cockroach::proto::WriteIntentError* ErrorDetail::release_write_intent() {
-  clear_has_write_intent();
-  ::cockroach::proto::WriteIntentError* temp = write_intent_;
-  write_intent_ = NULL;
-  return temp;
+  if (has_write_intent()) {
+    clear_has_value();
+    ::cockroach::proto::WriteIntentError* temp = value_.write_intent_;
+    value_.write_intent_ = NULL;
+    return temp;
+  } else {
+    return NULL;
+  }
 }
 inline void ErrorDetail::set_allocated_write_intent(::cockroach::proto::WriteIntentError* write_intent) {
-  delete write_intent_;
-  write_intent_ = write_intent;
+  clear_value();
   if (write_intent) {
     set_has_write_intent();
-  } else {
-    clear_has_write_intent();
+    value_.write_intent_ = write_intent;
   }
-  // @@protoc_insertion_point(field_set_allocated:cockroach.proto.ErrorDetail.write_intent)
 }
 
 // optional .cockroach.proto.WriteTooOldError write_too_old = 10;
 inline bool ErrorDetail::has_write_too_old() const {
-  return (_has_bits_[0] & 0x00000200u) != 0;
+  return value_case() == kWriteTooOld;
 }
 inline void ErrorDetail::set_has_write_too_old() {
-  _has_bits_[0] |= 0x00000200u;
-}
-inline void ErrorDetail::clear_has_write_too_old() {
-  _has_bits_[0] &= ~0x00000200u;
+  _oneof_case_[0] = kWriteTooOld;
 }
 inline void ErrorDetail::clear_write_too_old() {
-  if (write_too_old_ != NULL) write_too_old_->::cockroach::proto::WriteTooOldError::Clear();
-  clear_has_write_too_old();
+  if (has_write_too_old()) {
+    delete value_.write_too_old_;
+    clear_has_value();
+  }
 }
 inline const ::cockroach::proto::WriteTooOldError& ErrorDetail::write_too_old() const {
-  // @@protoc_insertion_point(field_get:cockroach.proto.ErrorDetail.write_too_old)
-  return write_too_old_ != NULL ? *write_too_old_ : *default_instance_->write_too_old_;
+  return has_write_too_old() ? *value_.write_too_old_
+                      : ::cockroach::proto::WriteTooOldError::default_instance();
 }
 inline ::cockroach::proto::WriteTooOldError* ErrorDetail::mutable_write_too_old() {
-  set_has_write_too_old();
-  if (write_too_old_ == NULL) write_too_old_ = new ::cockroach::proto::WriteTooOldError;
-  // @@protoc_insertion_point(field_mutable:cockroach.proto.ErrorDetail.write_too_old)
-  return write_too_old_;
+  if (!has_write_too_old()) {
+    clear_value();
+    set_has_write_too_old();
+    value_.write_too_old_ = new ::cockroach::proto::WriteTooOldError;
+  }
+  return value_.write_too_old_;
 }
 inline ::cockroach::proto::WriteTooOldError* ErrorDetail::release_write_too_old() {
-  clear_has_write_too_old();
-  ::cockroach::proto::WriteTooOldError* temp = write_too_old_;
-  write_too_old_ = NULL;
-  return temp;
+  if (has_write_too_old()) {
+    clear_has_value();
+    ::cockroach::proto::WriteTooOldError* temp = value_.write_too_old_;
+    value_.write_too_old_ = NULL;
+    return temp;
+  } else {
+    return NULL;
+  }
 }
 inline void ErrorDetail::set_allocated_write_too_old(::cockroach::proto::WriteTooOldError* write_too_old) {
-  delete write_too_old_;
-  write_too_old_ = write_too_old;
+  clear_value();
   if (write_too_old) {
     set_has_write_too_old();
-  } else {
-    clear_has_write_too_old();
+    value_.write_too_old_ = write_too_old;
   }
-  // @@protoc_insertion_point(field_set_allocated:cockroach.proto.ErrorDetail.write_too_old)
 }
 
 // optional .cockroach.proto.OpRequiresTxnError op_requires_txn = 11;
 inline bool ErrorDetail::has_op_requires_txn() const {
-  return (_has_bits_[0] & 0x00000400u) != 0;
+  return value_case() == kOpRequiresTxn;
 }
 inline void ErrorDetail::set_has_op_requires_txn() {
-  _has_bits_[0] |= 0x00000400u;
-}
-inline void ErrorDetail::clear_has_op_requires_txn() {
-  _has_bits_[0] &= ~0x00000400u;
+  _oneof_case_[0] = kOpRequiresTxn;
 }
 inline void ErrorDetail::clear_op_requires_txn() {
-  if (op_requires_txn_ != NULL) op_requires_txn_->::cockroach::proto::OpRequiresTxnError::Clear();
-  clear_has_op_requires_txn();
+  if (has_op_requires_txn()) {
+    delete value_.op_requires_txn_;
+    clear_has_value();
+  }
 }
 inline const ::cockroach::proto::OpRequiresTxnError& ErrorDetail::op_requires_txn() const {
-  // @@protoc_insertion_point(field_get:cockroach.proto.ErrorDetail.op_requires_txn)
-  return op_requires_txn_ != NULL ? *op_requires_txn_ : *default_instance_->op_requires_txn_;
+  return has_op_requires_txn() ? *value_.op_requires_txn_
+                      : ::cockroach::proto::OpRequiresTxnError::default_instance();
 }
 inline ::cockroach::proto::OpRequiresTxnError* ErrorDetail::mutable_op_requires_txn() {
-  set_has_op_requires_txn();
-  if (op_requires_txn_ == NULL) op_requires_txn_ = new ::cockroach::proto::OpRequiresTxnError;
-  // @@protoc_insertion_point(field_mutable:cockroach.proto.ErrorDetail.op_requires_txn)
-  return op_requires_txn_;
+  if (!has_op_requires_txn()) {
+    clear_value();
+    set_has_op_requires_txn();
+    value_.op_requires_txn_ = new ::cockroach::proto::OpRequiresTxnError;
+  }
+  return value_.op_requires_txn_;
 }
 inline ::cockroach::proto::OpRequiresTxnError* ErrorDetail::release_op_requires_txn() {
-  clear_has_op_requires_txn();
-  ::cockroach::proto::OpRequiresTxnError* temp = op_requires_txn_;
-  op_requires_txn_ = NULL;
-  return temp;
+  if (has_op_requires_txn()) {
+    clear_has_value();
+    ::cockroach::proto::OpRequiresTxnError* temp = value_.op_requires_txn_;
+    value_.op_requires_txn_ = NULL;
+    return temp;
+  } else {
+    return NULL;
+  }
 }
 inline void ErrorDetail::set_allocated_op_requires_txn(::cockroach::proto::OpRequiresTxnError* op_requires_txn) {
-  delete op_requires_txn_;
-  op_requires_txn_ = op_requires_txn;
+  clear_value();
   if (op_requires_txn) {
     set_has_op_requires_txn();
-  } else {
-    clear_has_op_requires_txn();
+    value_.op_requires_txn_ = op_requires_txn;
   }
-  // @@protoc_insertion_point(field_set_allocated:cockroach.proto.ErrorDetail.op_requires_txn)
 }
 
 // optional .cockroach.proto.ConditionFailedError condition_failed = 12;
 inline bool ErrorDetail::has_condition_failed() const {
-  return (_has_bits_[0] & 0x00000800u) != 0;
+  return value_case() == kConditionFailed;
 }
 inline void ErrorDetail::set_has_condition_failed() {
-  _has_bits_[0] |= 0x00000800u;
-}
-inline void ErrorDetail::clear_has_condition_failed() {
-  _has_bits_[0] &= ~0x00000800u;
+  _oneof_case_[0] = kConditionFailed;
 }
 inline void ErrorDetail::clear_condition_failed() {
-  if (condition_failed_ != NULL) condition_failed_->::cockroach::proto::ConditionFailedError::Clear();
-  clear_has_condition_failed();
+  if (has_condition_failed()) {
+    delete value_.condition_failed_;
+    clear_has_value();
+  }
 }
 inline const ::cockroach::proto::ConditionFailedError& ErrorDetail::condition_failed() const {
-  // @@protoc_insertion_point(field_get:cockroach.proto.ErrorDetail.condition_failed)
-  return condition_failed_ != NULL ? *condition_failed_ : *default_instance_->condition_failed_;
+  return has_condition_failed() ? *value_.condition_failed_
+                      : ::cockroach::proto::ConditionFailedError::default_instance();
 }
 inline ::cockroach::proto::ConditionFailedError* ErrorDetail::mutable_condition_failed() {
-  set_has_condition_failed();
-  if (condition_failed_ == NULL) condition_failed_ = new ::cockroach::proto::ConditionFailedError;
-  // @@protoc_insertion_point(field_mutable:cockroach.proto.ErrorDetail.condition_failed)
-  return condition_failed_;
+  if (!has_condition_failed()) {
+    clear_value();
+    set_has_condition_failed();
+    value_.condition_failed_ = new ::cockroach::proto::ConditionFailedError;
+  }
+  return value_.condition_failed_;
 }
 inline ::cockroach::proto::ConditionFailedError* ErrorDetail::release_condition_failed() {
-  clear_has_condition_failed();
-  ::cockroach::proto::ConditionFailedError* temp = condition_failed_;
-  condition_failed_ = NULL;
-  return temp;
+  if (has_condition_failed()) {
+    clear_has_value();
+    ::cockroach::proto::ConditionFailedError* temp = value_.condition_failed_;
+    value_.condition_failed_ = NULL;
+    return temp;
+  } else {
+    return NULL;
+  }
 }
 inline void ErrorDetail::set_allocated_condition_failed(::cockroach::proto::ConditionFailedError* condition_failed) {
-  delete condition_failed_;
-  condition_failed_ = condition_failed;
+  clear_value();
   if (condition_failed) {
     set_has_condition_failed();
-  } else {
-    clear_has_condition_failed();
+    value_.condition_failed_ = condition_failed;
   }
-  // @@protoc_insertion_point(field_set_allocated:cockroach.proto.ErrorDetail.condition_failed)
 }
 
+inline bool ErrorDetail::has_value() {
+  return value_case() != VALUE_NOT_SET;
+}
+inline void ErrorDetail::clear_has_value() {
+  _oneof_case_[0] = VALUE_NOT_SET;
+}
+inline ErrorDetail::ValueCase ErrorDetail::value_case() const {
+  return ErrorDetail::ValueCase(_oneof_case_[0]);
+}
 // -------------------------------------------------------------------
 
 // Error

--- a/storage/engine/cockroach/proto/internal.pb.cc
+++ b/storage/engine/cockroach/proto/internal.pb.cc
@@ -69,9 +69,48 @@ const ::google::protobuf::internal::GeneratedMessageReflection*
 const ::google::protobuf::Descriptor* ReadWriteCmdResponse_descriptor_ = NULL;
 const ::google::protobuf::internal::GeneratedMessageReflection*
   ReadWriteCmdResponse_reflection_ = NULL;
+struct ReadWriteCmdResponseOneofInstance {
+  const ::cockroach::proto::PutResponse* put_;
+  const ::cockroach::proto::ConditionalPutResponse* conditional_put_;
+  const ::cockroach::proto::IncrementResponse* increment_;
+  const ::cockroach::proto::DeleteResponse* delete__;
+  const ::cockroach::proto::DeleteRangeResponse* delete_range_;
+  const ::cockroach::proto::EndTransactionResponse* end_transaction_;
+  const ::cockroach::proto::ReapQueueResponse* reap_queue_;
+  const ::cockroach::proto::EnqueueUpdateResponse* enqueue_update_;
+  const ::cockroach::proto::EnqueueMessageResponse* enqueue_message_;
+  const ::cockroach::proto::InternalHeartbeatTxnResponse* internal_heartbeat_txn_;
+  const ::cockroach::proto::InternalPushTxnResponse* internal_push_txn_;
+  const ::cockroach::proto::InternalResolveIntentResponse* internal_resolve_intent_;
+  const ::cockroach::proto::InternalMergeResponse* internal_merge_;
+  const ::cockroach::proto::InternalTruncateLogResponse* internal_truncate_log_;
+  const ::cockroach::proto::InternalGCResponse* internal_gc_;
+}* ReadWriteCmdResponse_default_oneof_instance_ = NULL;
 const ::google::protobuf::Descriptor* InternalRaftCommandUnion_descriptor_ = NULL;
 const ::google::protobuf::internal::GeneratedMessageReflection*
   InternalRaftCommandUnion_reflection_ = NULL;
+struct InternalRaftCommandUnionOneofInstance {
+  const ::cockroach::proto::ContainsRequest* contains_;
+  const ::cockroach::proto::GetRequest* get_;
+  const ::cockroach::proto::PutRequest* put_;
+  const ::cockroach::proto::ConditionalPutRequest* conditional_put_;
+  const ::cockroach::proto::IncrementRequest* increment_;
+  const ::cockroach::proto::DeleteRequest* delete__;
+  const ::cockroach::proto::DeleteRangeRequest* delete_range_;
+  const ::cockroach::proto::ScanRequest* scan_;
+  const ::cockroach::proto::EndTransactionRequest* end_transaction_;
+  const ::cockroach::proto::ReapQueueRequest* reap_queue_;
+  const ::cockroach::proto::EnqueueUpdateRequest* enqueue_update_;
+  const ::cockroach::proto::EnqueueMessageRequest* enqueue_message_;
+  const ::cockroach::proto::BatchRequest* batch_;
+  const ::cockroach::proto::InternalRangeLookupRequest* internal_range_lookup_;
+  const ::cockroach::proto::InternalHeartbeatTxnRequest* internal_heartbeat_txn_;
+  const ::cockroach::proto::InternalPushTxnRequest* internal_push_txn_;
+  const ::cockroach::proto::InternalResolveIntentRequest* internal_resolve_intent_;
+  const ::cockroach::proto::InternalMergeRequest* internal_merge_response_;
+  const ::cockroach::proto::InternalTruncateLogRequest* internal_truncate_log_;
+  const ::cockroach::proto::InternalGCRequest* internal_gc_;
+}* InternalRaftCommandUnion_default_oneof_instance_ = NULL;
 const ::google::protobuf::Descriptor* InternalRaftCommand_descriptor_ = NULL;
 const ::google::protobuf::internal::GeneratedMessageReflection*
   InternalRaftCommand_reflection_ = NULL;
@@ -343,22 +382,23 @@ void protobuf_AssignDesc_cockroach_2fproto_2finternal_2eproto() {
       ::google::protobuf::MessageFactory::generated_factory(),
       sizeof(InternalTruncateLogResponse));
   ReadWriteCmdResponse_descriptor_ = file->message_type(14);
-  static const int ReadWriteCmdResponse_offsets_[15] = {
-    GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(ReadWriteCmdResponse, put_),
-    GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(ReadWriteCmdResponse, conditional_put_),
-    GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(ReadWriteCmdResponse, increment_),
-    GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(ReadWriteCmdResponse, delete__),
-    GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(ReadWriteCmdResponse, delete_range_),
-    GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(ReadWriteCmdResponse, end_transaction_),
-    GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(ReadWriteCmdResponse, reap_queue_),
-    GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(ReadWriteCmdResponse, enqueue_update_),
-    GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(ReadWriteCmdResponse, enqueue_message_),
-    GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(ReadWriteCmdResponse, internal_heartbeat_txn_),
-    GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(ReadWriteCmdResponse, internal_push_txn_),
-    GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(ReadWriteCmdResponse, internal_resolve_intent_),
-    GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(ReadWriteCmdResponse, internal_merge_),
-    GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(ReadWriteCmdResponse, internal_truncate_log_),
-    GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(ReadWriteCmdResponse, internal_gc_),
+  static const int ReadWriteCmdResponse_offsets_[16] = {
+    PROTO2_GENERATED_DEFAULT_ONEOF_FIELD_OFFSET(ReadWriteCmdResponse_default_oneof_instance_, put_),
+    PROTO2_GENERATED_DEFAULT_ONEOF_FIELD_OFFSET(ReadWriteCmdResponse_default_oneof_instance_, conditional_put_),
+    PROTO2_GENERATED_DEFAULT_ONEOF_FIELD_OFFSET(ReadWriteCmdResponse_default_oneof_instance_, increment_),
+    PROTO2_GENERATED_DEFAULT_ONEOF_FIELD_OFFSET(ReadWriteCmdResponse_default_oneof_instance_, delete__),
+    PROTO2_GENERATED_DEFAULT_ONEOF_FIELD_OFFSET(ReadWriteCmdResponse_default_oneof_instance_, delete_range_),
+    PROTO2_GENERATED_DEFAULT_ONEOF_FIELD_OFFSET(ReadWriteCmdResponse_default_oneof_instance_, end_transaction_),
+    PROTO2_GENERATED_DEFAULT_ONEOF_FIELD_OFFSET(ReadWriteCmdResponse_default_oneof_instance_, reap_queue_),
+    PROTO2_GENERATED_DEFAULT_ONEOF_FIELD_OFFSET(ReadWriteCmdResponse_default_oneof_instance_, enqueue_update_),
+    PROTO2_GENERATED_DEFAULT_ONEOF_FIELD_OFFSET(ReadWriteCmdResponse_default_oneof_instance_, enqueue_message_),
+    PROTO2_GENERATED_DEFAULT_ONEOF_FIELD_OFFSET(ReadWriteCmdResponse_default_oneof_instance_, internal_heartbeat_txn_),
+    PROTO2_GENERATED_DEFAULT_ONEOF_FIELD_OFFSET(ReadWriteCmdResponse_default_oneof_instance_, internal_push_txn_),
+    PROTO2_GENERATED_DEFAULT_ONEOF_FIELD_OFFSET(ReadWriteCmdResponse_default_oneof_instance_, internal_resolve_intent_),
+    PROTO2_GENERATED_DEFAULT_ONEOF_FIELD_OFFSET(ReadWriteCmdResponse_default_oneof_instance_, internal_merge_),
+    PROTO2_GENERATED_DEFAULT_ONEOF_FIELD_OFFSET(ReadWriteCmdResponse_default_oneof_instance_, internal_truncate_log_),
+    PROTO2_GENERATED_DEFAULT_ONEOF_FIELD_OFFSET(ReadWriteCmdResponse_default_oneof_instance_, internal_gc_),
+    GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(ReadWriteCmdResponse, value_),
   };
   ReadWriteCmdResponse_reflection_ =
     new ::google::protobuf::internal::GeneratedMessageReflection(
@@ -368,31 +408,34 @@ void protobuf_AssignDesc_cockroach_2fproto_2finternal_2eproto() {
       GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(ReadWriteCmdResponse, _has_bits_[0]),
       GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(ReadWriteCmdResponse, _unknown_fields_),
       -1,
+      ReadWriteCmdResponse_default_oneof_instance_,
+      GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(ReadWriteCmdResponse, _oneof_case_[0]),
       ::google::protobuf::DescriptorPool::generated_pool(),
       ::google::protobuf::MessageFactory::generated_factory(),
       sizeof(ReadWriteCmdResponse));
   InternalRaftCommandUnion_descriptor_ = file->message_type(15);
-  static const int InternalRaftCommandUnion_offsets_[20] = {
-    GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(InternalRaftCommandUnion, contains_),
-    GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(InternalRaftCommandUnion, get_),
-    GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(InternalRaftCommandUnion, put_),
-    GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(InternalRaftCommandUnion, conditional_put_),
-    GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(InternalRaftCommandUnion, increment_),
-    GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(InternalRaftCommandUnion, delete__),
-    GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(InternalRaftCommandUnion, delete_range_),
-    GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(InternalRaftCommandUnion, scan_),
-    GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(InternalRaftCommandUnion, end_transaction_),
-    GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(InternalRaftCommandUnion, reap_queue_),
-    GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(InternalRaftCommandUnion, enqueue_update_),
-    GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(InternalRaftCommandUnion, enqueue_message_),
-    GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(InternalRaftCommandUnion, batch_),
-    GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(InternalRaftCommandUnion, internal_range_lookup_),
-    GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(InternalRaftCommandUnion, internal_heartbeat_txn_),
-    GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(InternalRaftCommandUnion, internal_push_txn_),
-    GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(InternalRaftCommandUnion, internal_resolve_intent_),
-    GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(InternalRaftCommandUnion, internal_merge_response_),
-    GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(InternalRaftCommandUnion, internal_truncate_log_),
-    GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(InternalRaftCommandUnion, internal_gc_),
+  static const int InternalRaftCommandUnion_offsets_[21] = {
+    PROTO2_GENERATED_DEFAULT_ONEOF_FIELD_OFFSET(InternalRaftCommandUnion_default_oneof_instance_, contains_),
+    PROTO2_GENERATED_DEFAULT_ONEOF_FIELD_OFFSET(InternalRaftCommandUnion_default_oneof_instance_, get_),
+    PROTO2_GENERATED_DEFAULT_ONEOF_FIELD_OFFSET(InternalRaftCommandUnion_default_oneof_instance_, put_),
+    PROTO2_GENERATED_DEFAULT_ONEOF_FIELD_OFFSET(InternalRaftCommandUnion_default_oneof_instance_, conditional_put_),
+    PROTO2_GENERATED_DEFAULT_ONEOF_FIELD_OFFSET(InternalRaftCommandUnion_default_oneof_instance_, increment_),
+    PROTO2_GENERATED_DEFAULT_ONEOF_FIELD_OFFSET(InternalRaftCommandUnion_default_oneof_instance_, delete__),
+    PROTO2_GENERATED_DEFAULT_ONEOF_FIELD_OFFSET(InternalRaftCommandUnion_default_oneof_instance_, delete_range_),
+    PROTO2_GENERATED_DEFAULT_ONEOF_FIELD_OFFSET(InternalRaftCommandUnion_default_oneof_instance_, scan_),
+    PROTO2_GENERATED_DEFAULT_ONEOF_FIELD_OFFSET(InternalRaftCommandUnion_default_oneof_instance_, end_transaction_),
+    PROTO2_GENERATED_DEFAULT_ONEOF_FIELD_OFFSET(InternalRaftCommandUnion_default_oneof_instance_, reap_queue_),
+    PROTO2_GENERATED_DEFAULT_ONEOF_FIELD_OFFSET(InternalRaftCommandUnion_default_oneof_instance_, enqueue_update_),
+    PROTO2_GENERATED_DEFAULT_ONEOF_FIELD_OFFSET(InternalRaftCommandUnion_default_oneof_instance_, enqueue_message_),
+    PROTO2_GENERATED_DEFAULT_ONEOF_FIELD_OFFSET(InternalRaftCommandUnion_default_oneof_instance_, batch_),
+    PROTO2_GENERATED_DEFAULT_ONEOF_FIELD_OFFSET(InternalRaftCommandUnion_default_oneof_instance_, internal_range_lookup_),
+    PROTO2_GENERATED_DEFAULT_ONEOF_FIELD_OFFSET(InternalRaftCommandUnion_default_oneof_instance_, internal_heartbeat_txn_),
+    PROTO2_GENERATED_DEFAULT_ONEOF_FIELD_OFFSET(InternalRaftCommandUnion_default_oneof_instance_, internal_push_txn_),
+    PROTO2_GENERATED_DEFAULT_ONEOF_FIELD_OFFSET(InternalRaftCommandUnion_default_oneof_instance_, internal_resolve_intent_),
+    PROTO2_GENERATED_DEFAULT_ONEOF_FIELD_OFFSET(InternalRaftCommandUnion_default_oneof_instance_, internal_merge_response_),
+    PROTO2_GENERATED_DEFAULT_ONEOF_FIELD_OFFSET(InternalRaftCommandUnion_default_oneof_instance_, internal_truncate_log_),
+    PROTO2_GENERATED_DEFAULT_ONEOF_FIELD_OFFSET(InternalRaftCommandUnion_default_oneof_instance_, internal_gc_),
+    GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(InternalRaftCommandUnion, value_),
   };
   InternalRaftCommandUnion_reflection_ =
     new ::google::protobuf::internal::GeneratedMessageReflection(
@@ -402,6 +445,8 @@ void protobuf_AssignDesc_cockroach_2fproto_2finternal_2eproto() {
       GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(InternalRaftCommandUnion, _has_bits_[0]),
       GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(InternalRaftCommandUnion, _unknown_fields_),
       -1,
+      InternalRaftCommandUnion_default_oneof_instance_,
+      GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(InternalRaftCommandUnion, _oneof_case_[0]),
       ::google::protobuf::DescriptorPool::generated_pool(),
       ::google::protobuf::MessageFactory::generated_factory(),
       sizeof(InternalRaftCommandUnion));
@@ -637,8 +682,10 @@ void protobuf_ShutdownFile_cockroach_2fproto_2finternal_2eproto() {
   delete InternalTruncateLogResponse::default_instance_;
   delete InternalTruncateLogResponse_reflection_;
   delete ReadWriteCmdResponse::default_instance_;
+  delete ReadWriteCmdResponse_default_oneof_instance_;
   delete ReadWriteCmdResponse_reflection_;
   delete InternalRaftCommandUnion::default_instance_;
+  delete InternalRaftCommandUnion_default_oneof_instance_;
   delete InternalRaftCommandUnion_reflection_;
   delete InternalRaftCommand::default_instance_;
   delete InternalRaftCommand_reflection_;
@@ -715,83 +762,85 @@ void protobuf_AddDesc_cockroach_2fproto_2finternal_2eproto() {
     ".proto.RequestHeaderB\010\310\336\037\000\320\336\037\001\022\023\n\005index\030"
     "\002 \001(\004B\004\310\336\037\000\"X\n\033InternalTruncateLogRespon"
     "se\0229\n\006header\030\001 \001(\0132\037.cockroach.proto.Res"
-    "ponseHeaderB\010\310\336\037\000\320\336\037\001\"\325\007\n\024ReadWriteCmdRe"
-    "sponse\022)\n\003put\030\001 \001(\0132\034.cockroach.proto.Pu"
-    "tResponse\022@\n\017conditional_put\030\002 \001(\0132\'.coc"
-    "kroach.proto.ConditionalPutResponse\0225\n\ti"
-    "ncrement\030\003 \001(\0132\".cockroach.proto.Increme"
-    "ntResponse\022/\n\006delete\030\004 \001(\0132\037.cockroach.p"
-    "roto.DeleteResponse\022:\n\014delete_range\030\005 \001("
-    "\0132$.cockroach.proto.DeleteRangeResponse\022"
-    "@\n\017end_transaction\030\006 \001(\0132\'.cockroach.pro"
-    "to.EndTransactionResponse\0226\n\nreap_queue\030"
-    "\007 \001(\0132\".cockroach.proto.ReapQueueRespons"
-    "e\022>\n\016enqueue_update\030\010 \001(\0132&.cockroach.pr"
-    "oto.EnqueueUpdateResponse\022@\n\017enqueue_mes"
-    "sage\030\t \001(\0132\'.cockroach.proto.EnqueueMess"
-    "ageResponse\022M\n\026internal_heartbeat_txn\030\n "
-    "\001(\0132-.cockroach.proto.InternalHeartbeatT"
-    "xnResponse\022C\n\021internal_push_txn\030\013 \001(\0132(."
-    "cockroach.proto.InternalPushTxnResponse\022"
-    "O\n\027internal_resolve_intent\030\014 \001(\0132..cockr"
-    "oach.proto.InternalResolveIntentResponse"
-    "\022>\n\016internal_merge\030\r \001(\0132&.cockroach.pro"
-    "to.InternalMergeResponse\022K\n\025internal_tru"
-    "ncate_log\030\016 \001(\0132,.cockroach.proto.Intern"
-    "alTruncateLogResponse\0228\n\013internal_gc\030\017 \001"
-    "(\0132#.cockroach.proto.InternalGCResponse:"
-    "\004\310\240\037\001\"\327\t\n\030InternalRaftCommandUnion\0222\n\010co"
-    "ntains\030\001 \001(\0132 .cockroach.proto.ContainsR"
-    "equest\022(\n\003get\030\002 \001(\0132\033.cockroach.proto.Ge"
-    "tRequest\022(\n\003put\030\003 \001(\0132\033.cockroach.proto."
-    "PutRequest\022\?\n\017conditional_put\030\004 \001(\0132&.co"
-    "ckroach.proto.ConditionalPutRequest\0224\n\ti"
-    "ncrement\030\005 \001(\0132!.cockroach.proto.Increme"
-    "ntRequest\022.\n\006delete\030\006 \001(\0132\036.cockroach.pr"
-    "oto.DeleteRequest\0229\n\014delete_range\030\007 \001(\0132"
-    "#.cockroach.proto.DeleteRangeRequest\022*\n\004"
-    "scan\030\010 \001(\0132\034.cockroach.proto.ScanRequest"
-    "\022\?\n\017end_transaction\030\t \001(\0132&.cockroach.pr"
-    "oto.EndTransactionRequest\0225\n\nreap_queue\030"
-    "\n \001(\0132!.cockroach.proto.ReapQueueRequest"
-    "\022=\n\016enqueue_update\030\013 \001(\0132%.cockroach.pro"
-    "to.EnqueueUpdateRequest\022\?\n\017enqueue_messa"
-    "ge\030\014 \001(\0132&.cockroach.proto.EnqueueMessag"
-    "eRequest\022,\n\005batch\030\036 \001(\0132\035.cockroach.prot"
-    "o.BatchRequest\022J\n\025internal_range_lookup\030"
-    "\037 \001(\0132+.cockroach.proto.InternalRangeLoo"
-    "kupRequest\022L\n\026internal_heartbeat_txn\030  \001"
-    "(\0132,.cockroach.proto.InternalHeartbeatTx"
-    "nRequest\022B\n\021internal_push_txn\030! \001(\0132\'.co"
-    "ckroach.proto.InternalPushTxnRequest\022N\n\027"
-    "internal_resolve_intent\030\" \001(\0132-.cockroac"
-    "h.proto.InternalResolveIntentRequest\022F\n\027"
-    "internal_merge_response\030# \001(\0132%.cockroac"
-    "h.proto.InternalMergeRequest\022J\n\025internal"
-    "_truncate_log\030$ \001(\0132+.cockroach.proto.In"
-    "ternalTruncateLogRequest\0227\n\013internal_gc\030"
-    "% \001(\0132\".cockroach.proto.InternalGCReques"
-    "t:\004\310\240\037\001\"t\n\023InternalRaftCommand\022\037\n\007raft_i"
-    "d\030\002 \001(\003B\016\310\336\037\000\342\336\037\006RaftID\022<\n\003cmd\030\003 \001(\0132).c"
-    "ockroach.proto.InternalRaftCommandUnionB"
-    "\004\310\336\037\000\"D\n\022RaftMessageRequest\022!\n\010group_id\030"
-    "\001 \001(\004B\017\310\336\037\000\342\336\037\007GroupID\022\013\n\003msg\030\002 \001(\014\"\025\n\023R"
-    "aftMessageResponse\"\236\001\n\026InternalTimeSerie"
-    "sData\022#\n\025start_timestamp_nanos\030\001 \001(\003B\004\310\336"
-    "\037\000\022#\n\025sample_duration_nanos\030\002 \001(\003B\004\310\336\037\000\022"
-    ":\n\007samples\030\003 \003(\0132).cockroach.proto.Inter"
-    "nalTimeSeriesSample\"\320\001\n\030InternalTimeSeri"
-    "esSample\022\024\n\006offset\030\001 \001(\005B\004\310\336\037\000\022\027\n\tint_co"
-    "unt\030\002 \001(\rB\004\310\336\037\000\022\017\n\007int_sum\030\003 \001(\003\022\017\n\007int_"
-    "max\030\004 \001(\003\022\017\n\007int_min\030\005 \001(\003\022\031\n\013float_coun"
-    "t\030\006 \001(\rB\004\310\336\037\000\022\021\n\tfloat_sum\030\007 \001(\002\022\021\n\tfloa"
-    "t_max\030\010 \001(\002\022\021\n\tfloat_min\030\t \001(\002\"=\n\022RaftTr"
-    "uncatedState\022\023\n\005index\030\001 \001(\004B\004\310\336\037\000\022\022\n\004ter"
-    "m\030\002 \001(\004B\004\310\336\037\000\"z\n\020RaftSnapshotData\022>\n\002KV\030"
-    "\001 \003(\0132*.cockroach.proto.RaftSnapshotData"
-    ".KeyValueB\006\342\336\037\002KV\032&\n\010KeyValue\022\013\n\003key\030\001 \001"
-    "(\014\022\r\n\005value\030\002 \001(\014*%\n\021InternalValueType\022\n"
-    "\n\006_CR_TS\020\001\032\004\210\243\036\000B\007Z\005proto", 4905);
+    "ponseHeaderB\010\310\336\037\000\320\336\037\001\"\374\007\n\024ReadWriteCmdRe"
+    "sponse\022+\n\003put\030\001 \001(\0132\034.cockroach.proto.Pu"
+    "tResponseH\000\022B\n\017conditional_put\030\002 \001(\0132\'.c"
+    "ockroach.proto.ConditionalPutResponseH\000\022"
+    "7\n\tincrement\030\003 \001(\0132\".cockroach.proto.Inc"
+    "rementResponseH\000\0221\n\006delete\030\004 \001(\0132\037.cockr"
+    "oach.proto.DeleteResponseH\000\022<\n\014delete_ra"
+    "nge\030\005 \001(\0132$.cockroach.proto.DeleteRangeR"
+    "esponseH\000\022B\n\017end_transaction\030\006 \001(\0132\'.coc"
+    "kroach.proto.EndTransactionResponseH\000\0228\n"
+    "\nreap_queue\030\007 \001(\0132\".cockroach.proto.Reap"
+    "QueueResponseH\000\022@\n\016enqueue_update\030\010 \001(\0132"
+    "&.cockroach.proto.EnqueueUpdateResponseH"
+    "\000\022B\n\017enqueue_message\030\t \001(\0132\'.cockroach.p"
+    "roto.EnqueueMessageResponseH\000\022O\n\026interna"
+    "l_heartbeat_txn\030\n \001(\0132-.cockroach.proto."
+    "InternalHeartbeatTxnResponseH\000\022E\n\021intern"
+    "al_push_txn\030\013 \001(\0132(.cockroach.proto.Inte"
+    "rnalPushTxnResponseH\000\022Q\n\027internal_resolv"
+    "e_intent\030\014 \001(\0132..cockroach.proto.Interna"
+    "lResolveIntentResponseH\000\022@\n\016internal_mer"
+    "ge\030\r \001(\0132&.cockroach.proto.InternalMerge"
+    "ResponseH\000\022M\n\025internal_truncate_log\030\016 \001("
+    "\0132,.cockroach.proto.InternalTruncateLogR"
+    "esponseH\000\022:\n\013internal_gc\030\017 \001(\0132#.cockroa"
+    "ch.proto.InternalGCResponseH\000:\004\310\240\037\001B\007\n\005v"
+    "alue\"\210\n\n\030InternalRaftCommandUnion\0224\n\010con"
+    "tains\030\001 \001(\0132 .cockroach.proto.ContainsRe"
+    "questH\000\022*\n\003get\030\002 \001(\0132\033.cockroach.proto.G"
+    "etRequestH\000\022*\n\003put\030\003 \001(\0132\033.cockroach.pro"
+    "to.PutRequestH\000\022A\n\017conditional_put\030\004 \001(\013"
+    "2&.cockroach.proto.ConditionalPutRequest"
+    "H\000\0226\n\tincrement\030\005 \001(\0132!.cockroach.proto."
+    "IncrementRequestH\000\0220\n\006delete\030\006 \001(\0132\036.coc"
+    "kroach.proto.DeleteRequestH\000\022;\n\014delete_r"
+    "ange\030\007 \001(\0132#.cockroach.proto.DeleteRange"
+    "RequestH\000\022,\n\004scan\030\010 \001(\0132\034.cockroach.prot"
+    "o.ScanRequestH\000\022A\n\017end_transaction\030\t \001(\013"
+    "2&.cockroach.proto.EndTransactionRequest"
+    "H\000\0227\n\nreap_queue\030\n \001(\0132!.cockroach.proto"
+    ".ReapQueueRequestH\000\022\?\n\016enqueue_update\030\013 "
+    "\001(\0132%.cockroach.proto.EnqueueUpdateReque"
+    "stH\000\022A\n\017enqueue_message\030\014 \001(\0132&.cockroac"
+    "h.proto.EnqueueMessageRequestH\000\022.\n\005batch"
+    "\030\036 \001(\0132\035.cockroach.proto.BatchRequestH\000\022"
+    "L\n\025internal_range_lookup\030\037 \001(\0132+.cockroa"
+    "ch.proto.InternalRangeLookupRequestH\000\022N\n"
+    "\026internal_heartbeat_txn\030  \001(\0132,.cockroac"
+    "h.proto.InternalHeartbeatTxnRequestH\000\022D\n"
+    "\021internal_push_txn\030! \001(\0132\'.cockroach.pro"
+    "to.InternalPushTxnRequestH\000\022P\n\027internal_"
+    "resolve_intent\030\" \001(\0132-.cockroach.proto.I"
+    "nternalResolveIntentRequestH\000\022H\n\027interna"
+    "l_merge_response\030# \001(\0132%.cockroach.proto"
+    ".InternalMergeRequestH\000\022L\n\025internal_trun"
+    "cate_log\030$ \001(\0132+.cockroach.proto.Interna"
+    "lTruncateLogRequestH\000\0229\n\013internal_gc\030% \001"
+    "(\0132\".cockroach.proto.InternalGCRequestH\000"
+    ":\004\310\240\037\001B\007\n\005value\"t\n\023InternalRaftCommand\022\037"
+    "\n\007raft_id\030\002 \001(\003B\016\310\336\037\000\342\336\037\006RaftID\022<\n\003cmd\030\003"
+    " \001(\0132).cockroach.proto.InternalRaftComma"
+    "ndUnionB\004\310\336\037\000\"D\n\022RaftMessageRequest\022!\n\010g"
+    "roup_id\030\001 \001(\004B\017\310\336\037\000\342\336\037\007GroupID\022\013\n\003msg\030\002 "
+    "\001(\014\"\025\n\023RaftMessageResponse\"\236\001\n\026InternalT"
+    "imeSeriesData\022#\n\025start_timestamp_nanos\030\001"
+    " \001(\003B\004\310\336\037\000\022#\n\025sample_duration_nanos\030\002 \001("
+    "\003B\004\310\336\037\000\022:\n\007samples\030\003 \003(\0132).cockroach.pro"
+    "to.InternalTimeSeriesSample\"\320\001\n\030Internal"
+    "TimeSeriesSample\022\024\n\006offset\030\001 \001(\005B\004\310\336\037\000\022\027"
+    "\n\tint_count\030\002 \001(\rB\004\310\336\037\000\022\017\n\007int_sum\030\003 \001(\003"
+    "\022\017\n\007int_max\030\004 \001(\003\022\017\n\007int_min\030\005 \001(\003\022\031\n\013fl"
+    "oat_count\030\006 \001(\rB\004\310\336\037\000\022\021\n\tfloat_sum\030\007 \001(\002"
+    "\022\021\n\tfloat_max\030\010 \001(\002\022\021\n\tfloat_min\030\t \001(\002\"="
+    "\n\022RaftTruncatedState\022\023\n\005index\030\001 \001(\004B\004\310\336\037"
+    "\000\022\022\n\004term\030\002 \001(\004B\004\310\336\037\000\"z\n\020RaftSnapshotDat"
+    "a\022>\n\002KV\030\001 \003(\0132*.cockroach.proto.RaftSnap"
+    "shotData.KeyValueB\006\342\336\037\002KV\032&\n\010KeyValue\022\013\n"
+    "\003key\030\001 \001(\014\022\r\n\005value\030\002 \001(\014*%\n\021InternalVal"
+    "ueType\022\n\n\006_CR_TS\020\001\032\004\210\243\036\000B\007Z\005proto", 4993);
   ::google::protobuf::MessageFactory::InternalRegisterGeneratedFile(
     "cockroach/proto/internal.proto", &protobuf_RegisterTypes);
   InternalRangeLookupRequest::default_instance_ = new InternalRangeLookupRequest();
@@ -810,7 +859,9 @@ void protobuf_AddDesc_cockroach_2fproto_2finternal_2eproto() {
   InternalTruncateLogRequest::default_instance_ = new InternalTruncateLogRequest();
   InternalTruncateLogResponse::default_instance_ = new InternalTruncateLogResponse();
   ReadWriteCmdResponse::default_instance_ = new ReadWriteCmdResponse();
+  ReadWriteCmdResponse_default_oneof_instance_ = new ReadWriteCmdResponseOneofInstance;
   InternalRaftCommandUnion::default_instance_ = new InternalRaftCommandUnion();
+  InternalRaftCommandUnion_default_oneof_instance_ = new InternalRaftCommandUnionOneofInstance;
   InternalRaftCommand::default_instance_ = new InternalRaftCommand();
   RaftMessageRequest::default_instance_ = new RaftMessageRequest();
   RaftMessageResponse::default_instance_ = new RaftMessageResponse();
@@ -4730,21 +4781,21 @@ ReadWriteCmdResponse::ReadWriteCmdResponse()
 }
 
 void ReadWriteCmdResponse::InitAsDefaultInstance() {
-  put_ = const_cast< ::cockroach::proto::PutResponse*>(&::cockroach::proto::PutResponse::default_instance());
-  conditional_put_ = const_cast< ::cockroach::proto::ConditionalPutResponse*>(&::cockroach::proto::ConditionalPutResponse::default_instance());
-  increment_ = const_cast< ::cockroach::proto::IncrementResponse*>(&::cockroach::proto::IncrementResponse::default_instance());
-  delete__ = const_cast< ::cockroach::proto::DeleteResponse*>(&::cockroach::proto::DeleteResponse::default_instance());
-  delete_range_ = const_cast< ::cockroach::proto::DeleteRangeResponse*>(&::cockroach::proto::DeleteRangeResponse::default_instance());
-  end_transaction_ = const_cast< ::cockroach::proto::EndTransactionResponse*>(&::cockroach::proto::EndTransactionResponse::default_instance());
-  reap_queue_ = const_cast< ::cockroach::proto::ReapQueueResponse*>(&::cockroach::proto::ReapQueueResponse::default_instance());
-  enqueue_update_ = const_cast< ::cockroach::proto::EnqueueUpdateResponse*>(&::cockroach::proto::EnqueueUpdateResponse::default_instance());
-  enqueue_message_ = const_cast< ::cockroach::proto::EnqueueMessageResponse*>(&::cockroach::proto::EnqueueMessageResponse::default_instance());
-  internal_heartbeat_txn_ = const_cast< ::cockroach::proto::InternalHeartbeatTxnResponse*>(&::cockroach::proto::InternalHeartbeatTxnResponse::default_instance());
-  internal_push_txn_ = const_cast< ::cockroach::proto::InternalPushTxnResponse*>(&::cockroach::proto::InternalPushTxnResponse::default_instance());
-  internal_resolve_intent_ = const_cast< ::cockroach::proto::InternalResolveIntentResponse*>(&::cockroach::proto::InternalResolveIntentResponse::default_instance());
-  internal_merge_ = const_cast< ::cockroach::proto::InternalMergeResponse*>(&::cockroach::proto::InternalMergeResponse::default_instance());
-  internal_truncate_log_ = const_cast< ::cockroach::proto::InternalTruncateLogResponse*>(&::cockroach::proto::InternalTruncateLogResponse::default_instance());
-  internal_gc_ = const_cast< ::cockroach::proto::InternalGCResponse*>(&::cockroach::proto::InternalGCResponse::default_instance());
+  ReadWriteCmdResponse_default_oneof_instance_->put_ = const_cast< ::cockroach::proto::PutResponse*>(&::cockroach::proto::PutResponse::default_instance());
+  ReadWriteCmdResponse_default_oneof_instance_->conditional_put_ = const_cast< ::cockroach::proto::ConditionalPutResponse*>(&::cockroach::proto::ConditionalPutResponse::default_instance());
+  ReadWriteCmdResponse_default_oneof_instance_->increment_ = const_cast< ::cockroach::proto::IncrementResponse*>(&::cockroach::proto::IncrementResponse::default_instance());
+  ReadWriteCmdResponse_default_oneof_instance_->delete__ = const_cast< ::cockroach::proto::DeleteResponse*>(&::cockroach::proto::DeleteResponse::default_instance());
+  ReadWriteCmdResponse_default_oneof_instance_->delete_range_ = const_cast< ::cockroach::proto::DeleteRangeResponse*>(&::cockroach::proto::DeleteRangeResponse::default_instance());
+  ReadWriteCmdResponse_default_oneof_instance_->end_transaction_ = const_cast< ::cockroach::proto::EndTransactionResponse*>(&::cockroach::proto::EndTransactionResponse::default_instance());
+  ReadWriteCmdResponse_default_oneof_instance_->reap_queue_ = const_cast< ::cockroach::proto::ReapQueueResponse*>(&::cockroach::proto::ReapQueueResponse::default_instance());
+  ReadWriteCmdResponse_default_oneof_instance_->enqueue_update_ = const_cast< ::cockroach::proto::EnqueueUpdateResponse*>(&::cockroach::proto::EnqueueUpdateResponse::default_instance());
+  ReadWriteCmdResponse_default_oneof_instance_->enqueue_message_ = const_cast< ::cockroach::proto::EnqueueMessageResponse*>(&::cockroach::proto::EnqueueMessageResponse::default_instance());
+  ReadWriteCmdResponse_default_oneof_instance_->internal_heartbeat_txn_ = const_cast< ::cockroach::proto::InternalHeartbeatTxnResponse*>(&::cockroach::proto::InternalHeartbeatTxnResponse::default_instance());
+  ReadWriteCmdResponse_default_oneof_instance_->internal_push_txn_ = const_cast< ::cockroach::proto::InternalPushTxnResponse*>(&::cockroach::proto::InternalPushTxnResponse::default_instance());
+  ReadWriteCmdResponse_default_oneof_instance_->internal_resolve_intent_ = const_cast< ::cockroach::proto::InternalResolveIntentResponse*>(&::cockroach::proto::InternalResolveIntentResponse::default_instance());
+  ReadWriteCmdResponse_default_oneof_instance_->internal_merge_ = const_cast< ::cockroach::proto::InternalMergeResponse*>(&::cockroach::proto::InternalMergeResponse::default_instance());
+  ReadWriteCmdResponse_default_oneof_instance_->internal_truncate_log_ = const_cast< ::cockroach::proto::InternalTruncateLogResponse*>(&::cockroach::proto::InternalTruncateLogResponse::default_instance());
+  ReadWriteCmdResponse_default_oneof_instance_->internal_gc_ = const_cast< ::cockroach::proto::InternalGCResponse*>(&::cockroach::proto::InternalGCResponse::default_instance());
 }
 
 ReadWriteCmdResponse::ReadWriteCmdResponse(const ReadWriteCmdResponse& from)
@@ -4756,22 +4807,8 @@ ReadWriteCmdResponse::ReadWriteCmdResponse(const ReadWriteCmdResponse& from)
 
 void ReadWriteCmdResponse::SharedCtor() {
   _cached_size_ = 0;
-  put_ = NULL;
-  conditional_put_ = NULL;
-  increment_ = NULL;
-  delete__ = NULL;
-  delete_range_ = NULL;
-  end_transaction_ = NULL;
-  reap_queue_ = NULL;
-  enqueue_update_ = NULL;
-  enqueue_message_ = NULL;
-  internal_heartbeat_txn_ = NULL;
-  internal_push_txn_ = NULL;
-  internal_resolve_intent_ = NULL;
-  internal_merge_ = NULL;
-  internal_truncate_log_ = NULL;
-  internal_gc_ = NULL;
   ::memset(_has_bits_, 0, sizeof(_has_bits_));
+  clear_has_value();
 }
 
 ReadWriteCmdResponse::~ReadWriteCmdResponse() {
@@ -4780,22 +4817,10 @@ ReadWriteCmdResponse::~ReadWriteCmdResponse() {
 }
 
 void ReadWriteCmdResponse::SharedDtor() {
+  if (has_value()) {
+    clear_value();
+  }
   if (this != default_instance_) {
-    delete put_;
-    delete conditional_put_;
-    delete increment_;
-    delete delete__;
-    delete delete_range_;
-    delete end_transaction_;
-    delete reap_queue_;
-    delete enqueue_update_;
-    delete enqueue_message_;
-    delete internal_heartbeat_txn_;
-    delete internal_push_txn_;
-    delete internal_resolve_intent_;
-    delete internal_merge_;
-    delete internal_truncate_log_;
-    delete internal_gc_;
   }
 }
 
@@ -4820,56 +4845,78 @@ ReadWriteCmdResponse* ReadWriteCmdResponse::New() const {
   return new ReadWriteCmdResponse;
 }
 
+void ReadWriteCmdResponse::clear_value() {
+  switch(value_case()) {
+    case kPut: {
+      delete value_.put_;
+      break;
+    }
+    case kConditionalPut: {
+      delete value_.conditional_put_;
+      break;
+    }
+    case kIncrement: {
+      delete value_.increment_;
+      break;
+    }
+    case kDelete: {
+      delete value_.delete__;
+      break;
+    }
+    case kDeleteRange: {
+      delete value_.delete_range_;
+      break;
+    }
+    case kEndTransaction: {
+      delete value_.end_transaction_;
+      break;
+    }
+    case kReapQueue: {
+      delete value_.reap_queue_;
+      break;
+    }
+    case kEnqueueUpdate: {
+      delete value_.enqueue_update_;
+      break;
+    }
+    case kEnqueueMessage: {
+      delete value_.enqueue_message_;
+      break;
+    }
+    case kInternalHeartbeatTxn: {
+      delete value_.internal_heartbeat_txn_;
+      break;
+    }
+    case kInternalPushTxn: {
+      delete value_.internal_push_txn_;
+      break;
+    }
+    case kInternalResolveIntent: {
+      delete value_.internal_resolve_intent_;
+      break;
+    }
+    case kInternalMerge: {
+      delete value_.internal_merge_;
+      break;
+    }
+    case kInternalTruncateLog: {
+      delete value_.internal_truncate_log_;
+      break;
+    }
+    case kInternalGc: {
+      delete value_.internal_gc_;
+      break;
+    }
+    case VALUE_NOT_SET: {
+      break;
+    }
+  }
+  _oneof_case_[0] = VALUE_NOT_SET;
+}
+
+
 void ReadWriteCmdResponse::Clear() {
-  if (_has_bits_[0 / 32] & 255) {
-    if (has_put()) {
-      if (put_ != NULL) put_->::cockroach::proto::PutResponse::Clear();
-    }
-    if (has_conditional_put()) {
-      if (conditional_put_ != NULL) conditional_put_->::cockroach::proto::ConditionalPutResponse::Clear();
-    }
-    if (has_increment()) {
-      if (increment_ != NULL) increment_->::cockroach::proto::IncrementResponse::Clear();
-    }
-    if (has_delete_()) {
-      if (delete__ != NULL) delete__->::cockroach::proto::DeleteResponse::Clear();
-    }
-    if (has_delete_range()) {
-      if (delete_range_ != NULL) delete_range_->::cockroach::proto::DeleteRangeResponse::Clear();
-    }
-    if (has_end_transaction()) {
-      if (end_transaction_ != NULL) end_transaction_->::cockroach::proto::EndTransactionResponse::Clear();
-    }
-    if (has_reap_queue()) {
-      if (reap_queue_ != NULL) reap_queue_->::cockroach::proto::ReapQueueResponse::Clear();
-    }
-    if (has_enqueue_update()) {
-      if (enqueue_update_ != NULL) enqueue_update_->::cockroach::proto::EnqueueUpdateResponse::Clear();
-    }
-  }
-  if (_has_bits_[8 / 32] & 32512) {
-    if (has_enqueue_message()) {
-      if (enqueue_message_ != NULL) enqueue_message_->::cockroach::proto::EnqueueMessageResponse::Clear();
-    }
-    if (has_internal_heartbeat_txn()) {
-      if (internal_heartbeat_txn_ != NULL) internal_heartbeat_txn_->::cockroach::proto::InternalHeartbeatTxnResponse::Clear();
-    }
-    if (has_internal_push_txn()) {
-      if (internal_push_txn_ != NULL) internal_push_txn_->::cockroach::proto::InternalPushTxnResponse::Clear();
-    }
-    if (has_internal_resolve_intent()) {
-      if (internal_resolve_intent_ != NULL) internal_resolve_intent_->::cockroach::proto::InternalResolveIntentResponse::Clear();
-    }
-    if (has_internal_merge()) {
-      if (internal_merge_ != NULL) internal_merge_->::cockroach::proto::InternalMergeResponse::Clear();
-    }
-    if (has_internal_truncate_log()) {
-      if (internal_truncate_log_ != NULL) internal_truncate_log_->::cockroach::proto::InternalTruncateLogResponse::Clear();
-    }
-    if (has_internal_gc()) {
-      if (internal_gc_ != NULL) internal_gc_->::cockroach::proto::InternalGCResponse::Clear();
-    }
-  }
+  clear_value();
   ::memset(_has_bits_, 0, sizeof(_has_bits_));
   mutable_unknown_fields()->Clear();
 }
@@ -5319,114 +5366,115 @@ void ReadWriteCmdResponse::SerializeWithCachedSizes(
 int ReadWriteCmdResponse::ByteSize() const {
   int total_size = 0;
 
-  if (_has_bits_[0 / 32] & (0xffu << (0 % 32))) {
+  switch (value_case()) {
     // optional .cockroach.proto.PutResponse put = 1;
-    if (has_put()) {
+    case kPut: {
       total_size += 1 +
         ::google::protobuf::internal::WireFormatLite::MessageSizeNoVirtual(
           this->put());
+      break;
     }
-
     // optional .cockroach.proto.ConditionalPutResponse conditional_put = 2;
-    if (has_conditional_put()) {
+    case kConditionalPut: {
       total_size += 1 +
         ::google::protobuf::internal::WireFormatLite::MessageSizeNoVirtual(
           this->conditional_put());
+      break;
     }
-
     // optional .cockroach.proto.IncrementResponse increment = 3;
-    if (has_increment()) {
+    case kIncrement: {
       total_size += 1 +
         ::google::protobuf::internal::WireFormatLite::MessageSizeNoVirtual(
           this->increment());
+      break;
     }
-
     // optional .cockroach.proto.DeleteResponse delete = 4;
-    if (has_delete_()) {
+    case kDelete: {
       total_size += 1 +
         ::google::protobuf::internal::WireFormatLite::MessageSizeNoVirtual(
           this->delete_());
+      break;
     }
-
     // optional .cockroach.proto.DeleteRangeResponse delete_range = 5;
-    if (has_delete_range()) {
+    case kDeleteRange: {
       total_size += 1 +
         ::google::protobuf::internal::WireFormatLite::MessageSizeNoVirtual(
           this->delete_range());
+      break;
     }
-
     // optional .cockroach.proto.EndTransactionResponse end_transaction = 6;
-    if (has_end_transaction()) {
+    case kEndTransaction: {
       total_size += 1 +
         ::google::protobuf::internal::WireFormatLite::MessageSizeNoVirtual(
           this->end_transaction());
+      break;
     }
-
     // optional .cockroach.proto.ReapQueueResponse reap_queue = 7;
-    if (has_reap_queue()) {
+    case kReapQueue: {
       total_size += 1 +
         ::google::protobuf::internal::WireFormatLite::MessageSizeNoVirtual(
           this->reap_queue());
+      break;
     }
-
     // optional .cockroach.proto.EnqueueUpdateResponse enqueue_update = 8;
-    if (has_enqueue_update()) {
+    case kEnqueueUpdate: {
       total_size += 1 +
         ::google::protobuf::internal::WireFormatLite::MessageSizeNoVirtual(
           this->enqueue_update());
+      break;
     }
-
-  }
-  if (_has_bits_[8 / 32] & (0xffu << (8 % 32))) {
     // optional .cockroach.proto.EnqueueMessageResponse enqueue_message = 9;
-    if (has_enqueue_message()) {
+    case kEnqueueMessage: {
       total_size += 1 +
         ::google::protobuf::internal::WireFormatLite::MessageSizeNoVirtual(
           this->enqueue_message());
+      break;
     }
-
     // optional .cockroach.proto.InternalHeartbeatTxnResponse internal_heartbeat_txn = 10;
-    if (has_internal_heartbeat_txn()) {
+    case kInternalHeartbeatTxn: {
       total_size += 1 +
         ::google::protobuf::internal::WireFormatLite::MessageSizeNoVirtual(
           this->internal_heartbeat_txn());
+      break;
     }
-
     // optional .cockroach.proto.InternalPushTxnResponse internal_push_txn = 11;
-    if (has_internal_push_txn()) {
+    case kInternalPushTxn: {
       total_size += 1 +
         ::google::protobuf::internal::WireFormatLite::MessageSizeNoVirtual(
           this->internal_push_txn());
+      break;
     }
-
     // optional .cockroach.proto.InternalResolveIntentResponse internal_resolve_intent = 12;
-    if (has_internal_resolve_intent()) {
+    case kInternalResolveIntent: {
       total_size += 1 +
         ::google::protobuf::internal::WireFormatLite::MessageSizeNoVirtual(
           this->internal_resolve_intent());
+      break;
     }
-
     // optional .cockroach.proto.InternalMergeResponse internal_merge = 13;
-    if (has_internal_merge()) {
+    case kInternalMerge: {
       total_size += 1 +
         ::google::protobuf::internal::WireFormatLite::MessageSizeNoVirtual(
           this->internal_merge());
+      break;
     }
-
     // optional .cockroach.proto.InternalTruncateLogResponse internal_truncate_log = 14;
-    if (has_internal_truncate_log()) {
+    case kInternalTruncateLog: {
       total_size += 1 +
         ::google::protobuf::internal::WireFormatLite::MessageSizeNoVirtual(
           this->internal_truncate_log());
+      break;
     }
-
     // optional .cockroach.proto.InternalGCResponse internal_gc = 15;
-    if (has_internal_gc()) {
+    case kInternalGc: {
       total_size += 1 +
         ::google::protobuf::internal::WireFormatLite::MessageSizeNoVirtual(
           this->internal_gc());
+      break;
     }
-
+    case VALUE_NOT_SET: {
+      break;
+    }
   }
   if (!unknown_fields().empty()) {
     total_size +=
@@ -5453,53 +5501,69 @@ void ReadWriteCmdResponse::MergeFrom(const ::google::protobuf::Message& from) {
 
 void ReadWriteCmdResponse::MergeFrom(const ReadWriteCmdResponse& from) {
   GOOGLE_CHECK_NE(&from, this);
-  if (from._has_bits_[0 / 32] & (0xffu << (0 % 32))) {
-    if (from.has_put()) {
+  switch (from.value_case()) {
+    case kPut: {
       mutable_put()->::cockroach::proto::PutResponse::MergeFrom(from.put());
+      break;
     }
-    if (from.has_conditional_put()) {
+    case kConditionalPut: {
       mutable_conditional_put()->::cockroach::proto::ConditionalPutResponse::MergeFrom(from.conditional_put());
+      break;
     }
-    if (from.has_increment()) {
+    case kIncrement: {
       mutable_increment()->::cockroach::proto::IncrementResponse::MergeFrom(from.increment());
+      break;
     }
-    if (from.has_delete_()) {
+    case kDelete: {
       mutable_delete_()->::cockroach::proto::DeleteResponse::MergeFrom(from.delete_());
+      break;
     }
-    if (from.has_delete_range()) {
+    case kDeleteRange: {
       mutable_delete_range()->::cockroach::proto::DeleteRangeResponse::MergeFrom(from.delete_range());
+      break;
     }
-    if (from.has_end_transaction()) {
+    case kEndTransaction: {
       mutable_end_transaction()->::cockroach::proto::EndTransactionResponse::MergeFrom(from.end_transaction());
+      break;
     }
-    if (from.has_reap_queue()) {
+    case kReapQueue: {
       mutable_reap_queue()->::cockroach::proto::ReapQueueResponse::MergeFrom(from.reap_queue());
+      break;
     }
-    if (from.has_enqueue_update()) {
+    case kEnqueueUpdate: {
       mutable_enqueue_update()->::cockroach::proto::EnqueueUpdateResponse::MergeFrom(from.enqueue_update());
+      break;
     }
-  }
-  if (from._has_bits_[8 / 32] & (0xffu << (8 % 32))) {
-    if (from.has_enqueue_message()) {
+    case kEnqueueMessage: {
       mutable_enqueue_message()->::cockroach::proto::EnqueueMessageResponse::MergeFrom(from.enqueue_message());
+      break;
     }
-    if (from.has_internal_heartbeat_txn()) {
+    case kInternalHeartbeatTxn: {
       mutable_internal_heartbeat_txn()->::cockroach::proto::InternalHeartbeatTxnResponse::MergeFrom(from.internal_heartbeat_txn());
+      break;
     }
-    if (from.has_internal_push_txn()) {
+    case kInternalPushTxn: {
       mutable_internal_push_txn()->::cockroach::proto::InternalPushTxnResponse::MergeFrom(from.internal_push_txn());
+      break;
     }
-    if (from.has_internal_resolve_intent()) {
+    case kInternalResolveIntent: {
       mutable_internal_resolve_intent()->::cockroach::proto::InternalResolveIntentResponse::MergeFrom(from.internal_resolve_intent());
+      break;
     }
-    if (from.has_internal_merge()) {
+    case kInternalMerge: {
       mutable_internal_merge()->::cockroach::proto::InternalMergeResponse::MergeFrom(from.internal_merge());
+      break;
     }
-    if (from.has_internal_truncate_log()) {
+    case kInternalTruncateLog: {
       mutable_internal_truncate_log()->::cockroach::proto::InternalTruncateLogResponse::MergeFrom(from.internal_truncate_log());
+      break;
     }
-    if (from.has_internal_gc()) {
+    case kInternalGc: {
       mutable_internal_gc()->::cockroach::proto::InternalGCResponse::MergeFrom(from.internal_gc());
+      break;
+    }
+    case VALUE_NOT_SET: {
+      break;
     }
   }
   mutable_unknown_fields()->MergeFrom(from.unknown_fields());
@@ -5524,21 +5588,8 @@ bool ReadWriteCmdResponse::IsInitialized() const {
 
 void ReadWriteCmdResponse::Swap(ReadWriteCmdResponse* other) {
   if (other != this) {
-    std::swap(put_, other->put_);
-    std::swap(conditional_put_, other->conditional_put_);
-    std::swap(increment_, other->increment_);
-    std::swap(delete__, other->delete__);
-    std::swap(delete_range_, other->delete_range_);
-    std::swap(end_transaction_, other->end_transaction_);
-    std::swap(reap_queue_, other->reap_queue_);
-    std::swap(enqueue_update_, other->enqueue_update_);
-    std::swap(enqueue_message_, other->enqueue_message_);
-    std::swap(internal_heartbeat_txn_, other->internal_heartbeat_txn_);
-    std::swap(internal_push_txn_, other->internal_push_txn_);
-    std::swap(internal_resolve_intent_, other->internal_resolve_intent_);
-    std::swap(internal_merge_, other->internal_merge_);
-    std::swap(internal_truncate_log_, other->internal_truncate_log_);
-    std::swap(internal_gc_, other->internal_gc_);
+    std::swap(value_, other->value_);
+    std::swap(_oneof_case_[0], other->_oneof_case_[0]);
     std::swap(_has_bits_[0], other->_has_bits_[0]);
     _unknown_fields_.Swap(&other->_unknown_fields_);
     std::swap(_cached_size_, other->_cached_size_);
@@ -5586,26 +5637,26 @@ InternalRaftCommandUnion::InternalRaftCommandUnion()
 }
 
 void InternalRaftCommandUnion::InitAsDefaultInstance() {
-  contains_ = const_cast< ::cockroach::proto::ContainsRequest*>(&::cockroach::proto::ContainsRequest::default_instance());
-  get_ = const_cast< ::cockroach::proto::GetRequest*>(&::cockroach::proto::GetRequest::default_instance());
-  put_ = const_cast< ::cockroach::proto::PutRequest*>(&::cockroach::proto::PutRequest::default_instance());
-  conditional_put_ = const_cast< ::cockroach::proto::ConditionalPutRequest*>(&::cockroach::proto::ConditionalPutRequest::default_instance());
-  increment_ = const_cast< ::cockroach::proto::IncrementRequest*>(&::cockroach::proto::IncrementRequest::default_instance());
-  delete__ = const_cast< ::cockroach::proto::DeleteRequest*>(&::cockroach::proto::DeleteRequest::default_instance());
-  delete_range_ = const_cast< ::cockroach::proto::DeleteRangeRequest*>(&::cockroach::proto::DeleteRangeRequest::default_instance());
-  scan_ = const_cast< ::cockroach::proto::ScanRequest*>(&::cockroach::proto::ScanRequest::default_instance());
-  end_transaction_ = const_cast< ::cockroach::proto::EndTransactionRequest*>(&::cockroach::proto::EndTransactionRequest::default_instance());
-  reap_queue_ = const_cast< ::cockroach::proto::ReapQueueRequest*>(&::cockroach::proto::ReapQueueRequest::default_instance());
-  enqueue_update_ = const_cast< ::cockroach::proto::EnqueueUpdateRequest*>(&::cockroach::proto::EnqueueUpdateRequest::default_instance());
-  enqueue_message_ = const_cast< ::cockroach::proto::EnqueueMessageRequest*>(&::cockroach::proto::EnqueueMessageRequest::default_instance());
-  batch_ = const_cast< ::cockroach::proto::BatchRequest*>(&::cockroach::proto::BatchRequest::default_instance());
-  internal_range_lookup_ = const_cast< ::cockroach::proto::InternalRangeLookupRequest*>(&::cockroach::proto::InternalRangeLookupRequest::default_instance());
-  internal_heartbeat_txn_ = const_cast< ::cockroach::proto::InternalHeartbeatTxnRequest*>(&::cockroach::proto::InternalHeartbeatTxnRequest::default_instance());
-  internal_push_txn_ = const_cast< ::cockroach::proto::InternalPushTxnRequest*>(&::cockroach::proto::InternalPushTxnRequest::default_instance());
-  internal_resolve_intent_ = const_cast< ::cockroach::proto::InternalResolveIntentRequest*>(&::cockroach::proto::InternalResolveIntentRequest::default_instance());
-  internal_merge_response_ = const_cast< ::cockroach::proto::InternalMergeRequest*>(&::cockroach::proto::InternalMergeRequest::default_instance());
-  internal_truncate_log_ = const_cast< ::cockroach::proto::InternalTruncateLogRequest*>(&::cockroach::proto::InternalTruncateLogRequest::default_instance());
-  internal_gc_ = const_cast< ::cockroach::proto::InternalGCRequest*>(&::cockroach::proto::InternalGCRequest::default_instance());
+  InternalRaftCommandUnion_default_oneof_instance_->contains_ = const_cast< ::cockroach::proto::ContainsRequest*>(&::cockroach::proto::ContainsRequest::default_instance());
+  InternalRaftCommandUnion_default_oneof_instance_->get_ = const_cast< ::cockroach::proto::GetRequest*>(&::cockroach::proto::GetRequest::default_instance());
+  InternalRaftCommandUnion_default_oneof_instance_->put_ = const_cast< ::cockroach::proto::PutRequest*>(&::cockroach::proto::PutRequest::default_instance());
+  InternalRaftCommandUnion_default_oneof_instance_->conditional_put_ = const_cast< ::cockroach::proto::ConditionalPutRequest*>(&::cockroach::proto::ConditionalPutRequest::default_instance());
+  InternalRaftCommandUnion_default_oneof_instance_->increment_ = const_cast< ::cockroach::proto::IncrementRequest*>(&::cockroach::proto::IncrementRequest::default_instance());
+  InternalRaftCommandUnion_default_oneof_instance_->delete__ = const_cast< ::cockroach::proto::DeleteRequest*>(&::cockroach::proto::DeleteRequest::default_instance());
+  InternalRaftCommandUnion_default_oneof_instance_->delete_range_ = const_cast< ::cockroach::proto::DeleteRangeRequest*>(&::cockroach::proto::DeleteRangeRequest::default_instance());
+  InternalRaftCommandUnion_default_oneof_instance_->scan_ = const_cast< ::cockroach::proto::ScanRequest*>(&::cockroach::proto::ScanRequest::default_instance());
+  InternalRaftCommandUnion_default_oneof_instance_->end_transaction_ = const_cast< ::cockroach::proto::EndTransactionRequest*>(&::cockroach::proto::EndTransactionRequest::default_instance());
+  InternalRaftCommandUnion_default_oneof_instance_->reap_queue_ = const_cast< ::cockroach::proto::ReapQueueRequest*>(&::cockroach::proto::ReapQueueRequest::default_instance());
+  InternalRaftCommandUnion_default_oneof_instance_->enqueue_update_ = const_cast< ::cockroach::proto::EnqueueUpdateRequest*>(&::cockroach::proto::EnqueueUpdateRequest::default_instance());
+  InternalRaftCommandUnion_default_oneof_instance_->enqueue_message_ = const_cast< ::cockroach::proto::EnqueueMessageRequest*>(&::cockroach::proto::EnqueueMessageRequest::default_instance());
+  InternalRaftCommandUnion_default_oneof_instance_->batch_ = const_cast< ::cockroach::proto::BatchRequest*>(&::cockroach::proto::BatchRequest::default_instance());
+  InternalRaftCommandUnion_default_oneof_instance_->internal_range_lookup_ = const_cast< ::cockroach::proto::InternalRangeLookupRequest*>(&::cockroach::proto::InternalRangeLookupRequest::default_instance());
+  InternalRaftCommandUnion_default_oneof_instance_->internal_heartbeat_txn_ = const_cast< ::cockroach::proto::InternalHeartbeatTxnRequest*>(&::cockroach::proto::InternalHeartbeatTxnRequest::default_instance());
+  InternalRaftCommandUnion_default_oneof_instance_->internal_push_txn_ = const_cast< ::cockroach::proto::InternalPushTxnRequest*>(&::cockroach::proto::InternalPushTxnRequest::default_instance());
+  InternalRaftCommandUnion_default_oneof_instance_->internal_resolve_intent_ = const_cast< ::cockroach::proto::InternalResolveIntentRequest*>(&::cockroach::proto::InternalResolveIntentRequest::default_instance());
+  InternalRaftCommandUnion_default_oneof_instance_->internal_merge_response_ = const_cast< ::cockroach::proto::InternalMergeRequest*>(&::cockroach::proto::InternalMergeRequest::default_instance());
+  InternalRaftCommandUnion_default_oneof_instance_->internal_truncate_log_ = const_cast< ::cockroach::proto::InternalTruncateLogRequest*>(&::cockroach::proto::InternalTruncateLogRequest::default_instance());
+  InternalRaftCommandUnion_default_oneof_instance_->internal_gc_ = const_cast< ::cockroach::proto::InternalGCRequest*>(&::cockroach::proto::InternalGCRequest::default_instance());
 }
 
 InternalRaftCommandUnion::InternalRaftCommandUnion(const InternalRaftCommandUnion& from)
@@ -5617,27 +5668,8 @@ InternalRaftCommandUnion::InternalRaftCommandUnion(const InternalRaftCommandUnio
 
 void InternalRaftCommandUnion::SharedCtor() {
   _cached_size_ = 0;
-  contains_ = NULL;
-  get_ = NULL;
-  put_ = NULL;
-  conditional_put_ = NULL;
-  increment_ = NULL;
-  delete__ = NULL;
-  delete_range_ = NULL;
-  scan_ = NULL;
-  end_transaction_ = NULL;
-  reap_queue_ = NULL;
-  enqueue_update_ = NULL;
-  enqueue_message_ = NULL;
-  batch_ = NULL;
-  internal_range_lookup_ = NULL;
-  internal_heartbeat_txn_ = NULL;
-  internal_push_txn_ = NULL;
-  internal_resolve_intent_ = NULL;
-  internal_merge_response_ = NULL;
-  internal_truncate_log_ = NULL;
-  internal_gc_ = NULL;
   ::memset(_has_bits_, 0, sizeof(_has_bits_));
+  clear_has_value();
 }
 
 InternalRaftCommandUnion::~InternalRaftCommandUnion() {
@@ -5646,27 +5678,10 @@ InternalRaftCommandUnion::~InternalRaftCommandUnion() {
 }
 
 void InternalRaftCommandUnion::SharedDtor() {
+  if (has_value()) {
+    clear_value();
+  }
   if (this != default_instance_) {
-    delete contains_;
-    delete get_;
-    delete put_;
-    delete conditional_put_;
-    delete increment_;
-    delete delete__;
-    delete delete_range_;
-    delete scan_;
-    delete end_transaction_;
-    delete reap_queue_;
-    delete enqueue_update_;
-    delete enqueue_message_;
-    delete batch_;
-    delete internal_range_lookup_;
-    delete internal_heartbeat_txn_;
-    delete internal_push_txn_;
-    delete internal_resolve_intent_;
-    delete internal_merge_response_;
-    delete internal_truncate_log_;
-    delete internal_gc_;
   }
 }
 
@@ -5691,73 +5706,98 @@ InternalRaftCommandUnion* InternalRaftCommandUnion::New() const {
   return new InternalRaftCommandUnion;
 }
 
+void InternalRaftCommandUnion::clear_value() {
+  switch(value_case()) {
+    case kContains: {
+      delete value_.contains_;
+      break;
+    }
+    case kGet: {
+      delete value_.get_;
+      break;
+    }
+    case kPut: {
+      delete value_.put_;
+      break;
+    }
+    case kConditionalPut: {
+      delete value_.conditional_put_;
+      break;
+    }
+    case kIncrement: {
+      delete value_.increment_;
+      break;
+    }
+    case kDelete: {
+      delete value_.delete__;
+      break;
+    }
+    case kDeleteRange: {
+      delete value_.delete_range_;
+      break;
+    }
+    case kScan: {
+      delete value_.scan_;
+      break;
+    }
+    case kEndTransaction: {
+      delete value_.end_transaction_;
+      break;
+    }
+    case kReapQueue: {
+      delete value_.reap_queue_;
+      break;
+    }
+    case kEnqueueUpdate: {
+      delete value_.enqueue_update_;
+      break;
+    }
+    case kEnqueueMessage: {
+      delete value_.enqueue_message_;
+      break;
+    }
+    case kBatch: {
+      delete value_.batch_;
+      break;
+    }
+    case kInternalRangeLookup: {
+      delete value_.internal_range_lookup_;
+      break;
+    }
+    case kInternalHeartbeatTxn: {
+      delete value_.internal_heartbeat_txn_;
+      break;
+    }
+    case kInternalPushTxn: {
+      delete value_.internal_push_txn_;
+      break;
+    }
+    case kInternalResolveIntent: {
+      delete value_.internal_resolve_intent_;
+      break;
+    }
+    case kInternalMergeResponse: {
+      delete value_.internal_merge_response_;
+      break;
+    }
+    case kInternalTruncateLog: {
+      delete value_.internal_truncate_log_;
+      break;
+    }
+    case kInternalGc: {
+      delete value_.internal_gc_;
+      break;
+    }
+    case VALUE_NOT_SET: {
+      break;
+    }
+  }
+  _oneof_case_[0] = VALUE_NOT_SET;
+}
+
+
 void InternalRaftCommandUnion::Clear() {
-  if (_has_bits_[0 / 32] & 255) {
-    if (has_contains()) {
-      if (contains_ != NULL) contains_->::cockroach::proto::ContainsRequest::Clear();
-    }
-    if (has_get()) {
-      if (get_ != NULL) get_->::cockroach::proto::GetRequest::Clear();
-    }
-    if (has_put()) {
-      if (put_ != NULL) put_->::cockroach::proto::PutRequest::Clear();
-    }
-    if (has_conditional_put()) {
-      if (conditional_put_ != NULL) conditional_put_->::cockroach::proto::ConditionalPutRequest::Clear();
-    }
-    if (has_increment()) {
-      if (increment_ != NULL) increment_->::cockroach::proto::IncrementRequest::Clear();
-    }
-    if (has_delete_()) {
-      if (delete__ != NULL) delete__->::cockroach::proto::DeleteRequest::Clear();
-    }
-    if (has_delete_range()) {
-      if (delete_range_ != NULL) delete_range_->::cockroach::proto::DeleteRangeRequest::Clear();
-    }
-    if (has_scan()) {
-      if (scan_ != NULL) scan_->::cockroach::proto::ScanRequest::Clear();
-    }
-  }
-  if (_has_bits_[8 / 32] & 65280) {
-    if (has_end_transaction()) {
-      if (end_transaction_ != NULL) end_transaction_->::cockroach::proto::EndTransactionRequest::Clear();
-    }
-    if (has_reap_queue()) {
-      if (reap_queue_ != NULL) reap_queue_->::cockroach::proto::ReapQueueRequest::Clear();
-    }
-    if (has_enqueue_update()) {
-      if (enqueue_update_ != NULL) enqueue_update_->::cockroach::proto::EnqueueUpdateRequest::Clear();
-    }
-    if (has_enqueue_message()) {
-      if (enqueue_message_ != NULL) enqueue_message_->::cockroach::proto::EnqueueMessageRequest::Clear();
-    }
-    if (has_batch()) {
-      if (batch_ != NULL) batch_->::cockroach::proto::BatchRequest::Clear();
-    }
-    if (has_internal_range_lookup()) {
-      if (internal_range_lookup_ != NULL) internal_range_lookup_->::cockroach::proto::InternalRangeLookupRequest::Clear();
-    }
-    if (has_internal_heartbeat_txn()) {
-      if (internal_heartbeat_txn_ != NULL) internal_heartbeat_txn_->::cockroach::proto::InternalHeartbeatTxnRequest::Clear();
-    }
-    if (has_internal_push_txn()) {
-      if (internal_push_txn_ != NULL) internal_push_txn_->::cockroach::proto::InternalPushTxnRequest::Clear();
-    }
-  }
-  if (_has_bits_[16 / 32] & 983040) {
-    if (has_internal_resolve_intent()) {
-      if (internal_resolve_intent_ != NULL) internal_resolve_intent_->::cockroach::proto::InternalResolveIntentRequest::Clear();
-    }
-    if (has_internal_merge_response()) {
-      if (internal_merge_response_ != NULL) internal_merge_response_->::cockroach::proto::InternalMergeRequest::Clear();
-    }
-    if (has_internal_truncate_log()) {
-      if (internal_truncate_log_ != NULL) internal_truncate_log_->::cockroach::proto::InternalTruncateLogRequest::Clear();
-    }
-    if (has_internal_gc()) {
-      if (internal_gc_ != NULL) internal_gc_->::cockroach::proto::InternalGCRequest::Clear();
-    }
-  }
+  clear_value();
   ::memset(_has_bits_, 0, sizeof(_has_bits_));
   mutable_unknown_fields()->Clear();
 }
@@ -6337,151 +6377,150 @@ void InternalRaftCommandUnion::SerializeWithCachedSizes(
 int InternalRaftCommandUnion::ByteSize() const {
   int total_size = 0;
 
-  if (_has_bits_[0 / 32] & (0xffu << (0 % 32))) {
+  switch (value_case()) {
     // optional .cockroach.proto.ContainsRequest contains = 1;
-    if (has_contains()) {
+    case kContains: {
       total_size += 1 +
         ::google::protobuf::internal::WireFormatLite::MessageSizeNoVirtual(
           this->contains());
+      break;
     }
-
     // optional .cockroach.proto.GetRequest get = 2;
-    if (has_get()) {
+    case kGet: {
       total_size += 1 +
         ::google::protobuf::internal::WireFormatLite::MessageSizeNoVirtual(
           this->get());
+      break;
     }
-
     // optional .cockroach.proto.PutRequest put = 3;
-    if (has_put()) {
+    case kPut: {
       total_size += 1 +
         ::google::protobuf::internal::WireFormatLite::MessageSizeNoVirtual(
           this->put());
+      break;
     }
-
     // optional .cockroach.proto.ConditionalPutRequest conditional_put = 4;
-    if (has_conditional_put()) {
+    case kConditionalPut: {
       total_size += 1 +
         ::google::protobuf::internal::WireFormatLite::MessageSizeNoVirtual(
           this->conditional_put());
+      break;
     }
-
     // optional .cockroach.proto.IncrementRequest increment = 5;
-    if (has_increment()) {
+    case kIncrement: {
       total_size += 1 +
         ::google::protobuf::internal::WireFormatLite::MessageSizeNoVirtual(
           this->increment());
+      break;
     }
-
     // optional .cockroach.proto.DeleteRequest delete = 6;
-    if (has_delete_()) {
+    case kDelete: {
       total_size += 1 +
         ::google::protobuf::internal::WireFormatLite::MessageSizeNoVirtual(
           this->delete_());
+      break;
     }
-
     // optional .cockroach.proto.DeleteRangeRequest delete_range = 7;
-    if (has_delete_range()) {
+    case kDeleteRange: {
       total_size += 1 +
         ::google::protobuf::internal::WireFormatLite::MessageSizeNoVirtual(
           this->delete_range());
+      break;
     }
-
     // optional .cockroach.proto.ScanRequest scan = 8;
-    if (has_scan()) {
+    case kScan: {
       total_size += 1 +
         ::google::protobuf::internal::WireFormatLite::MessageSizeNoVirtual(
           this->scan());
+      break;
     }
-
-  }
-  if (_has_bits_[8 / 32] & (0xffu << (8 % 32))) {
     // optional .cockroach.proto.EndTransactionRequest end_transaction = 9;
-    if (has_end_transaction()) {
+    case kEndTransaction: {
       total_size += 1 +
         ::google::protobuf::internal::WireFormatLite::MessageSizeNoVirtual(
           this->end_transaction());
+      break;
     }
-
     // optional .cockroach.proto.ReapQueueRequest reap_queue = 10;
-    if (has_reap_queue()) {
+    case kReapQueue: {
       total_size += 1 +
         ::google::protobuf::internal::WireFormatLite::MessageSizeNoVirtual(
           this->reap_queue());
+      break;
     }
-
     // optional .cockroach.proto.EnqueueUpdateRequest enqueue_update = 11;
-    if (has_enqueue_update()) {
+    case kEnqueueUpdate: {
       total_size += 1 +
         ::google::protobuf::internal::WireFormatLite::MessageSizeNoVirtual(
           this->enqueue_update());
+      break;
     }
-
     // optional .cockroach.proto.EnqueueMessageRequest enqueue_message = 12;
-    if (has_enqueue_message()) {
+    case kEnqueueMessage: {
       total_size += 1 +
         ::google::protobuf::internal::WireFormatLite::MessageSizeNoVirtual(
           this->enqueue_message());
+      break;
     }
-
     // optional .cockroach.proto.BatchRequest batch = 30;
-    if (has_batch()) {
+    case kBatch: {
       total_size += 2 +
         ::google::protobuf::internal::WireFormatLite::MessageSizeNoVirtual(
           this->batch());
+      break;
     }
-
     // optional .cockroach.proto.InternalRangeLookupRequest internal_range_lookup = 31;
-    if (has_internal_range_lookup()) {
+    case kInternalRangeLookup: {
       total_size += 2 +
         ::google::protobuf::internal::WireFormatLite::MessageSizeNoVirtual(
           this->internal_range_lookup());
+      break;
     }
-
     // optional .cockroach.proto.InternalHeartbeatTxnRequest internal_heartbeat_txn = 32;
-    if (has_internal_heartbeat_txn()) {
+    case kInternalHeartbeatTxn: {
       total_size += 2 +
         ::google::protobuf::internal::WireFormatLite::MessageSizeNoVirtual(
           this->internal_heartbeat_txn());
+      break;
     }
-
     // optional .cockroach.proto.InternalPushTxnRequest internal_push_txn = 33;
-    if (has_internal_push_txn()) {
+    case kInternalPushTxn: {
       total_size += 2 +
         ::google::protobuf::internal::WireFormatLite::MessageSizeNoVirtual(
           this->internal_push_txn());
+      break;
     }
-
-  }
-  if (_has_bits_[16 / 32] & (0xffu << (16 % 32))) {
     // optional .cockroach.proto.InternalResolveIntentRequest internal_resolve_intent = 34;
-    if (has_internal_resolve_intent()) {
+    case kInternalResolveIntent: {
       total_size += 2 +
         ::google::protobuf::internal::WireFormatLite::MessageSizeNoVirtual(
           this->internal_resolve_intent());
+      break;
     }
-
     // optional .cockroach.proto.InternalMergeRequest internal_merge_response = 35;
-    if (has_internal_merge_response()) {
+    case kInternalMergeResponse: {
       total_size += 2 +
         ::google::protobuf::internal::WireFormatLite::MessageSizeNoVirtual(
           this->internal_merge_response());
+      break;
     }
-
     // optional .cockroach.proto.InternalTruncateLogRequest internal_truncate_log = 36;
-    if (has_internal_truncate_log()) {
+    case kInternalTruncateLog: {
       total_size += 2 +
         ::google::protobuf::internal::WireFormatLite::MessageSizeNoVirtual(
           this->internal_truncate_log());
+      break;
     }
-
     // optional .cockroach.proto.InternalGCRequest internal_gc = 37;
-    if (has_internal_gc()) {
+    case kInternalGc: {
       total_size += 2 +
         ::google::protobuf::internal::WireFormatLite::MessageSizeNoVirtual(
           this->internal_gc());
+      break;
     }
-
+    case VALUE_NOT_SET: {
+      break;
+    }
   }
   if (!unknown_fields().empty()) {
     total_size +=
@@ -6508,70 +6547,89 @@ void InternalRaftCommandUnion::MergeFrom(const ::google::protobuf::Message& from
 
 void InternalRaftCommandUnion::MergeFrom(const InternalRaftCommandUnion& from) {
   GOOGLE_CHECK_NE(&from, this);
-  if (from._has_bits_[0 / 32] & (0xffu << (0 % 32))) {
-    if (from.has_contains()) {
+  switch (from.value_case()) {
+    case kContains: {
       mutable_contains()->::cockroach::proto::ContainsRequest::MergeFrom(from.contains());
+      break;
     }
-    if (from.has_get()) {
+    case kGet: {
       mutable_get()->::cockroach::proto::GetRequest::MergeFrom(from.get());
+      break;
     }
-    if (from.has_put()) {
+    case kPut: {
       mutable_put()->::cockroach::proto::PutRequest::MergeFrom(from.put());
+      break;
     }
-    if (from.has_conditional_put()) {
+    case kConditionalPut: {
       mutable_conditional_put()->::cockroach::proto::ConditionalPutRequest::MergeFrom(from.conditional_put());
+      break;
     }
-    if (from.has_increment()) {
+    case kIncrement: {
       mutable_increment()->::cockroach::proto::IncrementRequest::MergeFrom(from.increment());
+      break;
     }
-    if (from.has_delete_()) {
+    case kDelete: {
       mutable_delete_()->::cockroach::proto::DeleteRequest::MergeFrom(from.delete_());
+      break;
     }
-    if (from.has_delete_range()) {
+    case kDeleteRange: {
       mutable_delete_range()->::cockroach::proto::DeleteRangeRequest::MergeFrom(from.delete_range());
+      break;
     }
-    if (from.has_scan()) {
+    case kScan: {
       mutable_scan()->::cockroach::proto::ScanRequest::MergeFrom(from.scan());
+      break;
     }
-  }
-  if (from._has_bits_[8 / 32] & (0xffu << (8 % 32))) {
-    if (from.has_end_transaction()) {
+    case kEndTransaction: {
       mutable_end_transaction()->::cockroach::proto::EndTransactionRequest::MergeFrom(from.end_transaction());
+      break;
     }
-    if (from.has_reap_queue()) {
+    case kReapQueue: {
       mutable_reap_queue()->::cockroach::proto::ReapQueueRequest::MergeFrom(from.reap_queue());
+      break;
     }
-    if (from.has_enqueue_update()) {
+    case kEnqueueUpdate: {
       mutable_enqueue_update()->::cockroach::proto::EnqueueUpdateRequest::MergeFrom(from.enqueue_update());
+      break;
     }
-    if (from.has_enqueue_message()) {
+    case kEnqueueMessage: {
       mutable_enqueue_message()->::cockroach::proto::EnqueueMessageRequest::MergeFrom(from.enqueue_message());
+      break;
     }
-    if (from.has_batch()) {
+    case kBatch: {
       mutable_batch()->::cockroach::proto::BatchRequest::MergeFrom(from.batch());
+      break;
     }
-    if (from.has_internal_range_lookup()) {
+    case kInternalRangeLookup: {
       mutable_internal_range_lookup()->::cockroach::proto::InternalRangeLookupRequest::MergeFrom(from.internal_range_lookup());
+      break;
     }
-    if (from.has_internal_heartbeat_txn()) {
+    case kInternalHeartbeatTxn: {
       mutable_internal_heartbeat_txn()->::cockroach::proto::InternalHeartbeatTxnRequest::MergeFrom(from.internal_heartbeat_txn());
+      break;
     }
-    if (from.has_internal_push_txn()) {
+    case kInternalPushTxn: {
       mutable_internal_push_txn()->::cockroach::proto::InternalPushTxnRequest::MergeFrom(from.internal_push_txn());
+      break;
     }
-  }
-  if (from._has_bits_[16 / 32] & (0xffu << (16 % 32))) {
-    if (from.has_internal_resolve_intent()) {
+    case kInternalResolveIntent: {
       mutable_internal_resolve_intent()->::cockroach::proto::InternalResolveIntentRequest::MergeFrom(from.internal_resolve_intent());
+      break;
     }
-    if (from.has_internal_merge_response()) {
+    case kInternalMergeResponse: {
       mutable_internal_merge_response()->::cockroach::proto::InternalMergeRequest::MergeFrom(from.internal_merge_response());
+      break;
     }
-    if (from.has_internal_truncate_log()) {
+    case kInternalTruncateLog: {
       mutable_internal_truncate_log()->::cockroach::proto::InternalTruncateLogRequest::MergeFrom(from.internal_truncate_log());
+      break;
     }
-    if (from.has_internal_gc()) {
+    case kInternalGc: {
       mutable_internal_gc()->::cockroach::proto::InternalGCRequest::MergeFrom(from.internal_gc());
+      break;
+    }
+    case VALUE_NOT_SET: {
+      break;
     }
   }
   mutable_unknown_fields()->MergeFrom(from.unknown_fields());
@@ -6596,26 +6654,8 @@ bool InternalRaftCommandUnion::IsInitialized() const {
 
 void InternalRaftCommandUnion::Swap(InternalRaftCommandUnion* other) {
   if (other != this) {
-    std::swap(contains_, other->contains_);
-    std::swap(get_, other->get_);
-    std::swap(put_, other->put_);
-    std::swap(conditional_put_, other->conditional_put_);
-    std::swap(increment_, other->increment_);
-    std::swap(delete__, other->delete__);
-    std::swap(delete_range_, other->delete_range_);
-    std::swap(scan_, other->scan_);
-    std::swap(end_transaction_, other->end_transaction_);
-    std::swap(reap_queue_, other->reap_queue_);
-    std::swap(enqueue_update_, other->enqueue_update_);
-    std::swap(enqueue_message_, other->enqueue_message_);
-    std::swap(batch_, other->batch_);
-    std::swap(internal_range_lookup_, other->internal_range_lookup_);
-    std::swap(internal_heartbeat_txn_, other->internal_heartbeat_txn_);
-    std::swap(internal_push_txn_, other->internal_push_txn_);
-    std::swap(internal_resolve_intent_, other->internal_resolve_intent_);
-    std::swap(internal_merge_response_, other->internal_merge_response_);
-    std::swap(internal_truncate_log_, other->internal_truncate_log_);
-    std::swap(internal_gc_, other->internal_gc_);
+    std::swap(value_, other->value_);
+    std::swap(_oneof_case_[0], other->_oneof_case_[0]);
     std::swap(_has_bits_[0], other->_has_bits_[0]);
     _unknown_fields_.Swap(&other->_unknown_fields_);
     std::swap(_cached_size_, other->_cached_size_);

--- a/storage/engine/cockroach/proto/internal.pb.h
+++ b/storage/engine/cockroach/proto/internal.pb.h
@@ -1444,6 +1444,25 @@ class ReadWriteCmdResponse : public ::google::protobuf::Message {
   static const ::google::protobuf::Descriptor* descriptor();
   static const ReadWriteCmdResponse& default_instance();
 
+  enum ValueCase {
+    kPut = 1,
+    kConditionalPut = 2,
+    kIncrement = 3,
+    kDelete = 4,
+    kDeleteRange = 5,
+    kEndTransaction = 6,
+    kReapQueue = 7,
+    kEnqueueUpdate = 8,
+    kEnqueueMessage = 9,
+    kInternalHeartbeatTxn = 10,
+    kInternalPushTxn = 11,
+    kInternalResolveIntent = 12,
+    kInternalMerge = 13,
+    kInternalTruncateLog = 14,
+    kInternalGc = 15,
+    VALUE_NOT_SET = 0,
+  };
+
   void Swap(ReadWriteCmdResponse* other);
 
   // implements Message ----------------------------------------------
@@ -1609,58 +1628,52 @@ class ReadWriteCmdResponse : public ::google::protobuf::Message {
   inline ::cockroach::proto::InternalGCResponse* release_internal_gc();
   inline void set_allocated_internal_gc(::cockroach::proto::InternalGCResponse* internal_gc);
 
+  inline ValueCase value_case() const;
   // @@protoc_insertion_point(class_scope:cockroach.proto.ReadWriteCmdResponse)
  private:
   inline void set_has_put();
-  inline void clear_has_put();
   inline void set_has_conditional_put();
-  inline void clear_has_conditional_put();
   inline void set_has_increment();
-  inline void clear_has_increment();
   inline void set_has_delete_();
-  inline void clear_has_delete_();
   inline void set_has_delete_range();
-  inline void clear_has_delete_range();
   inline void set_has_end_transaction();
-  inline void clear_has_end_transaction();
   inline void set_has_reap_queue();
-  inline void clear_has_reap_queue();
   inline void set_has_enqueue_update();
-  inline void clear_has_enqueue_update();
   inline void set_has_enqueue_message();
-  inline void clear_has_enqueue_message();
   inline void set_has_internal_heartbeat_txn();
-  inline void clear_has_internal_heartbeat_txn();
   inline void set_has_internal_push_txn();
-  inline void clear_has_internal_push_txn();
   inline void set_has_internal_resolve_intent();
-  inline void clear_has_internal_resolve_intent();
   inline void set_has_internal_merge();
-  inline void clear_has_internal_merge();
   inline void set_has_internal_truncate_log();
-  inline void clear_has_internal_truncate_log();
   inline void set_has_internal_gc();
-  inline void clear_has_internal_gc();
+
+  inline bool has_value();
+  void clear_value();
+  inline void clear_has_value();
 
   ::google::protobuf::UnknownFieldSet _unknown_fields_;
 
   ::google::protobuf::uint32 _has_bits_[1];
   mutable int _cached_size_;
-  ::cockroach::proto::PutResponse* put_;
-  ::cockroach::proto::ConditionalPutResponse* conditional_put_;
-  ::cockroach::proto::IncrementResponse* increment_;
-  ::cockroach::proto::DeleteResponse* delete__;
-  ::cockroach::proto::DeleteRangeResponse* delete_range_;
-  ::cockroach::proto::EndTransactionResponse* end_transaction_;
-  ::cockroach::proto::ReapQueueResponse* reap_queue_;
-  ::cockroach::proto::EnqueueUpdateResponse* enqueue_update_;
-  ::cockroach::proto::EnqueueMessageResponse* enqueue_message_;
-  ::cockroach::proto::InternalHeartbeatTxnResponse* internal_heartbeat_txn_;
-  ::cockroach::proto::InternalPushTxnResponse* internal_push_txn_;
-  ::cockroach::proto::InternalResolveIntentResponse* internal_resolve_intent_;
-  ::cockroach::proto::InternalMergeResponse* internal_merge_;
-  ::cockroach::proto::InternalTruncateLogResponse* internal_truncate_log_;
-  ::cockroach::proto::InternalGCResponse* internal_gc_;
+  union ValueUnion {
+    ::cockroach::proto::PutResponse* put_;
+    ::cockroach::proto::ConditionalPutResponse* conditional_put_;
+    ::cockroach::proto::IncrementResponse* increment_;
+    ::cockroach::proto::DeleteResponse* delete__;
+    ::cockroach::proto::DeleteRangeResponse* delete_range_;
+    ::cockroach::proto::EndTransactionResponse* end_transaction_;
+    ::cockroach::proto::ReapQueueResponse* reap_queue_;
+    ::cockroach::proto::EnqueueUpdateResponse* enqueue_update_;
+    ::cockroach::proto::EnqueueMessageResponse* enqueue_message_;
+    ::cockroach::proto::InternalHeartbeatTxnResponse* internal_heartbeat_txn_;
+    ::cockroach::proto::InternalPushTxnResponse* internal_push_txn_;
+    ::cockroach::proto::InternalResolveIntentResponse* internal_resolve_intent_;
+    ::cockroach::proto::InternalMergeResponse* internal_merge_;
+    ::cockroach::proto::InternalTruncateLogResponse* internal_truncate_log_;
+    ::cockroach::proto::InternalGCResponse* internal_gc_;
+  } value_;
+  ::google::protobuf::uint32 _oneof_case_[1];
+
   friend void  protobuf_AddDesc_cockroach_2fproto_2finternal_2eproto();
   friend void protobuf_AssignDesc_cockroach_2fproto_2finternal_2eproto();
   friend void protobuf_ShutdownFile_cockroach_2fproto_2finternal_2eproto();
@@ -1692,6 +1705,30 @@ class InternalRaftCommandUnion : public ::google::protobuf::Message {
 
   static const ::google::protobuf::Descriptor* descriptor();
   static const InternalRaftCommandUnion& default_instance();
+
+  enum ValueCase {
+    kContains = 1,
+    kGet = 2,
+    kPut = 3,
+    kConditionalPut = 4,
+    kIncrement = 5,
+    kDelete = 6,
+    kDeleteRange = 7,
+    kScan = 8,
+    kEndTransaction = 9,
+    kReapQueue = 10,
+    kEnqueueUpdate = 11,
+    kEnqueueMessage = 12,
+    kBatch = 30,
+    kInternalRangeLookup = 31,
+    kInternalHeartbeatTxn = 32,
+    kInternalPushTxn = 33,
+    kInternalResolveIntent = 34,
+    kInternalMergeResponse = 35,
+    kInternalTruncateLog = 36,
+    kInternalGc = 37,
+    VALUE_NOT_SET = 0,
+  };
 
   void Swap(InternalRaftCommandUnion* other);
 
@@ -1903,73 +1940,62 @@ class InternalRaftCommandUnion : public ::google::protobuf::Message {
   inline ::cockroach::proto::InternalGCRequest* release_internal_gc();
   inline void set_allocated_internal_gc(::cockroach::proto::InternalGCRequest* internal_gc);
 
+  inline ValueCase value_case() const;
   // @@protoc_insertion_point(class_scope:cockroach.proto.InternalRaftCommandUnion)
  private:
   inline void set_has_contains();
-  inline void clear_has_contains();
   inline void set_has_get();
-  inline void clear_has_get();
   inline void set_has_put();
-  inline void clear_has_put();
   inline void set_has_conditional_put();
-  inline void clear_has_conditional_put();
   inline void set_has_increment();
-  inline void clear_has_increment();
   inline void set_has_delete_();
-  inline void clear_has_delete_();
   inline void set_has_delete_range();
-  inline void clear_has_delete_range();
   inline void set_has_scan();
-  inline void clear_has_scan();
   inline void set_has_end_transaction();
-  inline void clear_has_end_transaction();
   inline void set_has_reap_queue();
-  inline void clear_has_reap_queue();
   inline void set_has_enqueue_update();
-  inline void clear_has_enqueue_update();
   inline void set_has_enqueue_message();
-  inline void clear_has_enqueue_message();
   inline void set_has_batch();
-  inline void clear_has_batch();
   inline void set_has_internal_range_lookup();
-  inline void clear_has_internal_range_lookup();
   inline void set_has_internal_heartbeat_txn();
-  inline void clear_has_internal_heartbeat_txn();
   inline void set_has_internal_push_txn();
-  inline void clear_has_internal_push_txn();
   inline void set_has_internal_resolve_intent();
-  inline void clear_has_internal_resolve_intent();
   inline void set_has_internal_merge_response();
-  inline void clear_has_internal_merge_response();
   inline void set_has_internal_truncate_log();
-  inline void clear_has_internal_truncate_log();
   inline void set_has_internal_gc();
-  inline void clear_has_internal_gc();
+
+  inline bool has_value();
+  void clear_value();
+  inline void clear_has_value();
 
   ::google::protobuf::UnknownFieldSet _unknown_fields_;
 
   ::google::protobuf::uint32 _has_bits_[1];
   mutable int _cached_size_;
-  ::cockroach::proto::ContainsRequest* contains_;
-  ::cockroach::proto::GetRequest* get_;
-  ::cockroach::proto::PutRequest* put_;
-  ::cockroach::proto::ConditionalPutRequest* conditional_put_;
-  ::cockroach::proto::IncrementRequest* increment_;
-  ::cockroach::proto::DeleteRequest* delete__;
-  ::cockroach::proto::DeleteRangeRequest* delete_range_;
-  ::cockroach::proto::ScanRequest* scan_;
-  ::cockroach::proto::EndTransactionRequest* end_transaction_;
-  ::cockroach::proto::ReapQueueRequest* reap_queue_;
-  ::cockroach::proto::EnqueueUpdateRequest* enqueue_update_;
-  ::cockroach::proto::EnqueueMessageRequest* enqueue_message_;
-  ::cockroach::proto::BatchRequest* batch_;
-  ::cockroach::proto::InternalRangeLookupRequest* internal_range_lookup_;
-  ::cockroach::proto::InternalHeartbeatTxnRequest* internal_heartbeat_txn_;
-  ::cockroach::proto::InternalPushTxnRequest* internal_push_txn_;
-  ::cockroach::proto::InternalResolveIntentRequest* internal_resolve_intent_;
-  ::cockroach::proto::InternalMergeRequest* internal_merge_response_;
-  ::cockroach::proto::InternalTruncateLogRequest* internal_truncate_log_;
-  ::cockroach::proto::InternalGCRequest* internal_gc_;
+  union ValueUnion {
+    ::cockroach::proto::ContainsRequest* contains_;
+    ::cockroach::proto::GetRequest* get_;
+    ::cockroach::proto::PutRequest* put_;
+    ::cockroach::proto::ConditionalPutRequest* conditional_put_;
+    ::cockroach::proto::IncrementRequest* increment_;
+    ::cockroach::proto::DeleteRequest* delete__;
+    ::cockroach::proto::DeleteRangeRequest* delete_range_;
+    ::cockroach::proto::ScanRequest* scan_;
+    ::cockroach::proto::EndTransactionRequest* end_transaction_;
+    ::cockroach::proto::ReapQueueRequest* reap_queue_;
+    ::cockroach::proto::EnqueueUpdateRequest* enqueue_update_;
+    ::cockroach::proto::EnqueueMessageRequest* enqueue_message_;
+    ::cockroach::proto::BatchRequest* batch_;
+    ::cockroach::proto::InternalRangeLookupRequest* internal_range_lookup_;
+    ::cockroach::proto::InternalHeartbeatTxnRequest* internal_heartbeat_txn_;
+    ::cockroach::proto::InternalPushTxnRequest* internal_push_txn_;
+    ::cockroach::proto::InternalResolveIntentRequest* internal_resolve_intent_;
+    ::cockroach::proto::InternalMergeRequest* internal_merge_response_;
+    ::cockroach::proto::InternalTruncateLogRequest* internal_truncate_log_;
+    ::cockroach::proto::InternalGCRequest* internal_gc_;
+  } value_;
+  ::google::protobuf::uint32 _oneof_case_[1];
+
   friend void  protobuf_AddDesc_cockroach_2fproto_2finternal_2eproto();
   friend void protobuf_AssignDesc_cockroach_2fproto_2finternal_2eproto();
   friend void protobuf_ShutdownFile_cockroach_2fproto_2finternal_2eproto();
@@ -3820,1443 +3846,1531 @@ inline void InternalTruncateLogResponse::set_allocated_header(::cockroach::proto
 
 // optional .cockroach.proto.PutResponse put = 1;
 inline bool ReadWriteCmdResponse::has_put() const {
-  return (_has_bits_[0] & 0x00000001u) != 0;
+  return value_case() == kPut;
 }
 inline void ReadWriteCmdResponse::set_has_put() {
-  _has_bits_[0] |= 0x00000001u;
-}
-inline void ReadWriteCmdResponse::clear_has_put() {
-  _has_bits_[0] &= ~0x00000001u;
+  _oneof_case_[0] = kPut;
 }
 inline void ReadWriteCmdResponse::clear_put() {
-  if (put_ != NULL) put_->::cockroach::proto::PutResponse::Clear();
-  clear_has_put();
+  if (has_put()) {
+    delete value_.put_;
+    clear_has_value();
+  }
 }
 inline const ::cockroach::proto::PutResponse& ReadWriteCmdResponse::put() const {
-  // @@protoc_insertion_point(field_get:cockroach.proto.ReadWriteCmdResponse.put)
-  return put_ != NULL ? *put_ : *default_instance_->put_;
+  return has_put() ? *value_.put_
+                      : ::cockroach::proto::PutResponse::default_instance();
 }
 inline ::cockroach::proto::PutResponse* ReadWriteCmdResponse::mutable_put() {
-  set_has_put();
-  if (put_ == NULL) put_ = new ::cockroach::proto::PutResponse;
-  // @@protoc_insertion_point(field_mutable:cockroach.proto.ReadWriteCmdResponse.put)
-  return put_;
+  if (!has_put()) {
+    clear_value();
+    set_has_put();
+    value_.put_ = new ::cockroach::proto::PutResponse;
+  }
+  return value_.put_;
 }
 inline ::cockroach::proto::PutResponse* ReadWriteCmdResponse::release_put() {
-  clear_has_put();
-  ::cockroach::proto::PutResponse* temp = put_;
-  put_ = NULL;
-  return temp;
+  if (has_put()) {
+    clear_has_value();
+    ::cockroach::proto::PutResponse* temp = value_.put_;
+    value_.put_ = NULL;
+    return temp;
+  } else {
+    return NULL;
+  }
 }
 inline void ReadWriteCmdResponse::set_allocated_put(::cockroach::proto::PutResponse* put) {
-  delete put_;
-  put_ = put;
+  clear_value();
   if (put) {
     set_has_put();
-  } else {
-    clear_has_put();
+    value_.put_ = put;
   }
-  // @@protoc_insertion_point(field_set_allocated:cockroach.proto.ReadWriteCmdResponse.put)
 }
 
 // optional .cockroach.proto.ConditionalPutResponse conditional_put = 2;
 inline bool ReadWriteCmdResponse::has_conditional_put() const {
-  return (_has_bits_[0] & 0x00000002u) != 0;
+  return value_case() == kConditionalPut;
 }
 inline void ReadWriteCmdResponse::set_has_conditional_put() {
-  _has_bits_[0] |= 0x00000002u;
-}
-inline void ReadWriteCmdResponse::clear_has_conditional_put() {
-  _has_bits_[0] &= ~0x00000002u;
+  _oneof_case_[0] = kConditionalPut;
 }
 inline void ReadWriteCmdResponse::clear_conditional_put() {
-  if (conditional_put_ != NULL) conditional_put_->::cockroach::proto::ConditionalPutResponse::Clear();
-  clear_has_conditional_put();
+  if (has_conditional_put()) {
+    delete value_.conditional_put_;
+    clear_has_value();
+  }
 }
 inline const ::cockroach::proto::ConditionalPutResponse& ReadWriteCmdResponse::conditional_put() const {
-  // @@protoc_insertion_point(field_get:cockroach.proto.ReadWriteCmdResponse.conditional_put)
-  return conditional_put_ != NULL ? *conditional_put_ : *default_instance_->conditional_put_;
+  return has_conditional_put() ? *value_.conditional_put_
+                      : ::cockroach::proto::ConditionalPutResponse::default_instance();
 }
 inline ::cockroach::proto::ConditionalPutResponse* ReadWriteCmdResponse::mutable_conditional_put() {
-  set_has_conditional_put();
-  if (conditional_put_ == NULL) conditional_put_ = new ::cockroach::proto::ConditionalPutResponse;
-  // @@protoc_insertion_point(field_mutable:cockroach.proto.ReadWriteCmdResponse.conditional_put)
-  return conditional_put_;
+  if (!has_conditional_put()) {
+    clear_value();
+    set_has_conditional_put();
+    value_.conditional_put_ = new ::cockroach::proto::ConditionalPutResponse;
+  }
+  return value_.conditional_put_;
 }
 inline ::cockroach::proto::ConditionalPutResponse* ReadWriteCmdResponse::release_conditional_put() {
-  clear_has_conditional_put();
-  ::cockroach::proto::ConditionalPutResponse* temp = conditional_put_;
-  conditional_put_ = NULL;
-  return temp;
+  if (has_conditional_put()) {
+    clear_has_value();
+    ::cockroach::proto::ConditionalPutResponse* temp = value_.conditional_put_;
+    value_.conditional_put_ = NULL;
+    return temp;
+  } else {
+    return NULL;
+  }
 }
 inline void ReadWriteCmdResponse::set_allocated_conditional_put(::cockroach::proto::ConditionalPutResponse* conditional_put) {
-  delete conditional_put_;
-  conditional_put_ = conditional_put;
+  clear_value();
   if (conditional_put) {
     set_has_conditional_put();
-  } else {
-    clear_has_conditional_put();
+    value_.conditional_put_ = conditional_put;
   }
-  // @@protoc_insertion_point(field_set_allocated:cockroach.proto.ReadWriteCmdResponse.conditional_put)
 }
 
 // optional .cockroach.proto.IncrementResponse increment = 3;
 inline bool ReadWriteCmdResponse::has_increment() const {
-  return (_has_bits_[0] & 0x00000004u) != 0;
+  return value_case() == kIncrement;
 }
 inline void ReadWriteCmdResponse::set_has_increment() {
-  _has_bits_[0] |= 0x00000004u;
-}
-inline void ReadWriteCmdResponse::clear_has_increment() {
-  _has_bits_[0] &= ~0x00000004u;
+  _oneof_case_[0] = kIncrement;
 }
 inline void ReadWriteCmdResponse::clear_increment() {
-  if (increment_ != NULL) increment_->::cockroach::proto::IncrementResponse::Clear();
-  clear_has_increment();
+  if (has_increment()) {
+    delete value_.increment_;
+    clear_has_value();
+  }
 }
 inline const ::cockroach::proto::IncrementResponse& ReadWriteCmdResponse::increment() const {
-  // @@protoc_insertion_point(field_get:cockroach.proto.ReadWriteCmdResponse.increment)
-  return increment_ != NULL ? *increment_ : *default_instance_->increment_;
+  return has_increment() ? *value_.increment_
+                      : ::cockroach::proto::IncrementResponse::default_instance();
 }
 inline ::cockroach::proto::IncrementResponse* ReadWriteCmdResponse::mutable_increment() {
-  set_has_increment();
-  if (increment_ == NULL) increment_ = new ::cockroach::proto::IncrementResponse;
-  // @@protoc_insertion_point(field_mutable:cockroach.proto.ReadWriteCmdResponse.increment)
-  return increment_;
+  if (!has_increment()) {
+    clear_value();
+    set_has_increment();
+    value_.increment_ = new ::cockroach::proto::IncrementResponse;
+  }
+  return value_.increment_;
 }
 inline ::cockroach::proto::IncrementResponse* ReadWriteCmdResponse::release_increment() {
-  clear_has_increment();
-  ::cockroach::proto::IncrementResponse* temp = increment_;
-  increment_ = NULL;
-  return temp;
+  if (has_increment()) {
+    clear_has_value();
+    ::cockroach::proto::IncrementResponse* temp = value_.increment_;
+    value_.increment_ = NULL;
+    return temp;
+  } else {
+    return NULL;
+  }
 }
 inline void ReadWriteCmdResponse::set_allocated_increment(::cockroach::proto::IncrementResponse* increment) {
-  delete increment_;
-  increment_ = increment;
+  clear_value();
   if (increment) {
     set_has_increment();
-  } else {
-    clear_has_increment();
+    value_.increment_ = increment;
   }
-  // @@protoc_insertion_point(field_set_allocated:cockroach.proto.ReadWriteCmdResponse.increment)
 }
 
 // optional .cockroach.proto.DeleteResponse delete = 4;
 inline bool ReadWriteCmdResponse::has_delete_() const {
-  return (_has_bits_[0] & 0x00000008u) != 0;
+  return value_case() == kDelete;
 }
 inline void ReadWriteCmdResponse::set_has_delete_() {
-  _has_bits_[0] |= 0x00000008u;
-}
-inline void ReadWriteCmdResponse::clear_has_delete_() {
-  _has_bits_[0] &= ~0x00000008u;
+  _oneof_case_[0] = kDelete;
 }
 inline void ReadWriteCmdResponse::clear_delete_() {
-  if (delete__ != NULL) delete__->::cockroach::proto::DeleteResponse::Clear();
-  clear_has_delete_();
+  if (has_delete_()) {
+    delete value_.delete__;
+    clear_has_value();
+  }
 }
 inline const ::cockroach::proto::DeleteResponse& ReadWriteCmdResponse::delete_() const {
-  // @@protoc_insertion_point(field_get:cockroach.proto.ReadWriteCmdResponse.delete)
-  return delete__ != NULL ? *delete__ : *default_instance_->delete__;
+  return has_delete_() ? *value_.delete__
+                      : ::cockroach::proto::DeleteResponse::default_instance();
 }
 inline ::cockroach::proto::DeleteResponse* ReadWriteCmdResponse::mutable_delete_() {
-  set_has_delete_();
-  if (delete__ == NULL) delete__ = new ::cockroach::proto::DeleteResponse;
-  // @@protoc_insertion_point(field_mutable:cockroach.proto.ReadWriteCmdResponse.delete)
-  return delete__;
+  if (!has_delete_()) {
+    clear_value();
+    set_has_delete_();
+    value_.delete__ = new ::cockroach::proto::DeleteResponse;
+  }
+  return value_.delete__;
 }
 inline ::cockroach::proto::DeleteResponse* ReadWriteCmdResponse::release_delete_() {
-  clear_has_delete_();
-  ::cockroach::proto::DeleteResponse* temp = delete__;
-  delete__ = NULL;
-  return temp;
+  if (has_delete_()) {
+    clear_has_value();
+    ::cockroach::proto::DeleteResponse* temp = value_.delete__;
+    value_.delete__ = NULL;
+    return temp;
+  } else {
+    return NULL;
+  }
 }
 inline void ReadWriteCmdResponse::set_allocated_delete_(::cockroach::proto::DeleteResponse* delete_) {
-  delete delete__;
-  delete__ = delete_;
+  clear_value();
   if (delete_) {
     set_has_delete_();
-  } else {
-    clear_has_delete_();
+    value_.delete__ = delete_;
   }
-  // @@protoc_insertion_point(field_set_allocated:cockroach.proto.ReadWriteCmdResponse.delete)
 }
 
 // optional .cockroach.proto.DeleteRangeResponse delete_range = 5;
 inline bool ReadWriteCmdResponse::has_delete_range() const {
-  return (_has_bits_[0] & 0x00000010u) != 0;
+  return value_case() == kDeleteRange;
 }
 inline void ReadWriteCmdResponse::set_has_delete_range() {
-  _has_bits_[0] |= 0x00000010u;
-}
-inline void ReadWriteCmdResponse::clear_has_delete_range() {
-  _has_bits_[0] &= ~0x00000010u;
+  _oneof_case_[0] = kDeleteRange;
 }
 inline void ReadWriteCmdResponse::clear_delete_range() {
-  if (delete_range_ != NULL) delete_range_->::cockroach::proto::DeleteRangeResponse::Clear();
-  clear_has_delete_range();
+  if (has_delete_range()) {
+    delete value_.delete_range_;
+    clear_has_value();
+  }
 }
 inline const ::cockroach::proto::DeleteRangeResponse& ReadWriteCmdResponse::delete_range() const {
-  // @@protoc_insertion_point(field_get:cockroach.proto.ReadWriteCmdResponse.delete_range)
-  return delete_range_ != NULL ? *delete_range_ : *default_instance_->delete_range_;
+  return has_delete_range() ? *value_.delete_range_
+                      : ::cockroach::proto::DeleteRangeResponse::default_instance();
 }
 inline ::cockroach::proto::DeleteRangeResponse* ReadWriteCmdResponse::mutable_delete_range() {
-  set_has_delete_range();
-  if (delete_range_ == NULL) delete_range_ = new ::cockroach::proto::DeleteRangeResponse;
-  // @@protoc_insertion_point(field_mutable:cockroach.proto.ReadWriteCmdResponse.delete_range)
-  return delete_range_;
+  if (!has_delete_range()) {
+    clear_value();
+    set_has_delete_range();
+    value_.delete_range_ = new ::cockroach::proto::DeleteRangeResponse;
+  }
+  return value_.delete_range_;
 }
 inline ::cockroach::proto::DeleteRangeResponse* ReadWriteCmdResponse::release_delete_range() {
-  clear_has_delete_range();
-  ::cockroach::proto::DeleteRangeResponse* temp = delete_range_;
-  delete_range_ = NULL;
-  return temp;
+  if (has_delete_range()) {
+    clear_has_value();
+    ::cockroach::proto::DeleteRangeResponse* temp = value_.delete_range_;
+    value_.delete_range_ = NULL;
+    return temp;
+  } else {
+    return NULL;
+  }
 }
 inline void ReadWriteCmdResponse::set_allocated_delete_range(::cockroach::proto::DeleteRangeResponse* delete_range) {
-  delete delete_range_;
-  delete_range_ = delete_range;
+  clear_value();
   if (delete_range) {
     set_has_delete_range();
-  } else {
-    clear_has_delete_range();
+    value_.delete_range_ = delete_range;
   }
-  // @@protoc_insertion_point(field_set_allocated:cockroach.proto.ReadWriteCmdResponse.delete_range)
 }
 
 // optional .cockroach.proto.EndTransactionResponse end_transaction = 6;
 inline bool ReadWriteCmdResponse::has_end_transaction() const {
-  return (_has_bits_[0] & 0x00000020u) != 0;
+  return value_case() == kEndTransaction;
 }
 inline void ReadWriteCmdResponse::set_has_end_transaction() {
-  _has_bits_[0] |= 0x00000020u;
-}
-inline void ReadWriteCmdResponse::clear_has_end_transaction() {
-  _has_bits_[0] &= ~0x00000020u;
+  _oneof_case_[0] = kEndTransaction;
 }
 inline void ReadWriteCmdResponse::clear_end_transaction() {
-  if (end_transaction_ != NULL) end_transaction_->::cockroach::proto::EndTransactionResponse::Clear();
-  clear_has_end_transaction();
+  if (has_end_transaction()) {
+    delete value_.end_transaction_;
+    clear_has_value();
+  }
 }
 inline const ::cockroach::proto::EndTransactionResponse& ReadWriteCmdResponse::end_transaction() const {
-  // @@protoc_insertion_point(field_get:cockroach.proto.ReadWriteCmdResponse.end_transaction)
-  return end_transaction_ != NULL ? *end_transaction_ : *default_instance_->end_transaction_;
+  return has_end_transaction() ? *value_.end_transaction_
+                      : ::cockroach::proto::EndTransactionResponse::default_instance();
 }
 inline ::cockroach::proto::EndTransactionResponse* ReadWriteCmdResponse::mutable_end_transaction() {
-  set_has_end_transaction();
-  if (end_transaction_ == NULL) end_transaction_ = new ::cockroach::proto::EndTransactionResponse;
-  // @@protoc_insertion_point(field_mutable:cockroach.proto.ReadWriteCmdResponse.end_transaction)
-  return end_transaction_;
+  if (!has_end_transaction()) {
+    clear_value();
+    set_has_end_transaction();
+    value_.end_transaction_ = new ::cockroach::proto::EndTransactionResponse;
+  }
+  return value_.end_transaction_;
 }
 inline ::cockroach::proto::EndTransactionResponse* ReadWriteCmdResponse::release_end_transaction() {
-  clear_has_end_transaction();
-  ::cockroach::proto::EndTransactionResponse* temp = end_transaction_;
-  end_transaction_ = NULL;
-  return temp;
+  if (has_end_transaction()) {
+    clear_has_value();
+    ::cockroach::proto::EndTransactionResponse* temp = value_.end_transaction_;
+    value_.end_transaction_ = NULL;
+    return temp;
+  } else {
+    return NULL;
+  }
 }
 inline void ReadWriteCmdResponse::set_allocated_end_transaction(::cockroach::proto::EndTransactionResponse* end_transaction) {
-  delete end_transaction_;
-  end_transaction_ = end_transaction;
+  clear_value();
   if (end_transaction) {
     set_has_end_transaction();
-  } else {
-    clear_has_end_transaction();
+    value_.end_transaction_ = end_transaction;
   }
-  // @@protoc_insertion_point(field_set_allocated:cockroach.proto.ReadWriteCmdResponse.end_transaction)
 }
 
 // optional .cockroach.proto.ReapQueueResponse reap_queue = 7;
 inline bool ReadWriteCmdResponse::has_reap_queue() const {
-  return (_has_bits_[0] & 0x00000040u) != 0;
+  return value_case() == kReapQueue;
 }
 inline void ReadWriteCmdResponse::set_has_reap_queue() {
-  _has_bits_[0] |= 0x00000040u;
-}
-inline void ReadWriteCmdResponse::clear_has_reap_queue() {
-  _has_bits_[0] &= ~0x00000040u;
+  _oneof_case_[0] = kReapQueue;
 }
 inline void ReadWriteCmdResponse::clear_reap_queue() {
-  if (reap_queue_ != NULL) reap_queue_->::cockroach::proto::ReapQueueResponse::Clear();
-  clear_has_reap_queue();
+  if (has_reap_queue()) {
+    delete value_.reap_queue_;
+    clear_has_value();
+  }
 }
 inline const ::cockroach::proto::ReapQueueResponse& ReadWriteCmdResponse::reap_queue() const {
-  // @@protoc_insertion_point(field_get:cockroach.proto.ReadWriteCmdResponse.reap_queue)
-  return reap_queue_ != NULL ? *reap_queue_ : *default_instance_->reap_queue_;
+  return has_reap_queue() ? *value_.reap_queue_
+                      : ::cockroach::proto::ReapQueueResponse::default_instance();
 }
 inline ::cockroach::proto::ReapQueueResponse* ReadWriteCmdResponse::mutable_reap_queue() {
-  set_has_reap_queue();
-  if (reap_queue_ == NULL) reap_queue_ = new ::cockroach::proto::ReapQueueResponse;
-  // @@protoc_insertion_point(field_mutable:cockroach.proto.ReadWriteCmdResponse.reap_queue)
-  return reap_queue_;
+  if (!has_reap_queue()) {
+    clear_value();
+    set_has_reap_queue();
+    value_.reap_queue_ = new ::cockroach::proto::ReapQueueResponse;
+  }
+  return value_.reap_queue_;
 }
 inline ::cockroach::proto::ReapQueueResponse* ReadWriteCmdResponse::release_reap_queue() {
-  clear_has_reap_queue();
-  ::cockroach::proto::ReapQueueResponse* temp = reap_queue_;
-  reap_queue_ = NULL;
-  return temp;
+  if (has_reap_queue()) {
+    clear_has_value();
+    ::cockroach::proto::ReapQueueResponse* temp = value_.reap_queue_;
+    value_.reap_queue_ = NULL;
+    return temp;
+  } else {
+    return NULL;
+  }
 }
 inline void ReadWriteCmdResponse::set_allocated_reap_queue(::cockroach::proto::ReapQueueResponse* reap_queue) {
-  delete reap_queue_;
-  reap_queue_ = reap_queue;
+  clear_value();
   if (reap_queue) {
     set_has_reap_queue();
-  } else {
-    clear_has_reap_queue();
+    value_.reap_queue_ = reap_queue;
   }
-  // @@protoc_insertion_point(field_set_allocated:cockroach.proto.ReadWriteCmdResponse.reap_queue)
 }
 
 // optional .cockroach.proto.EnqueueUpdateResponse enqueue_update = 8;
 inline bool ReadWriteCmdResponse::has_enqueue_update() const {
-  return (_has_bits_[0] & 0x00000080u) != 0;
+  return value_case() == kEnqueueUpdate;
 }
 inline void ReadWriteCmdResponse::set_has_enqueue_update() {
-  _has_bits_[0] |= 0x00000080u;
-}
-inline void ReadWriteCmdResponse::clear_has_enqueue_update() {
-  _has_bits_[0] &= ~0x00000080u;
+  _oneof_case_[0] = kEnqueueUpdate;
 }
 inline void ReadWriteCmdResponse::clear_enqueue_update() {
-  if (enqueue_update_ != NULL) enqueue_update_->::cockroach::proto::EnqueueUpdateResponse::Clear();
-  clear_has_enqueue_update();
+  if (has_enqueue_update()) {
+    delete value_.enqueue_update_;
+    clear_has_value();
+  }
 }
 inline const ::cockroach::proto::EnqueueUpdateResponse& ReadWriteCmdResponse::enqueue_update() const {
-  // @@protoc_insertion_point(field_get:cockroach.proto.ReadWriteCmdResponse.enqueue_update)
-  return enqueue_update_ != NULL ? *enqueue_update_ : *default_instance_->enqueue_update_;
+  return has_enqueue_update() ? *value_.enqueue_update_
+                      : ::cockroach::proto::EnqueueUpdateResponse::default_instance();
 }
 inline ::cockroach::proto::EnqueueUpdateResponse* ReadWriteCmdResponse::mutable_enqueue_update() {
-  set_has_enqueue_update();
-  if (enqueue_update_ == NULL) enqueue_update_ = new ::cockroach::proto::EnqueueUpdateResponse;
-  // @@protoc_insertion_point(field_mutable:cockroach.proto.ReadWriteCmdResponse.enqueue_update)
-  return enqueue_update_;
+  if (!has_enqueue_update()) {
+    clear_value();
+    set_has_enqueue_update();
+    value_.enqueue_update_ = new ::cockroach::proto::EnqueueUpdateResponse;
+  }
+  return value_.enqueue_update_;
 }
 inline ::cockroach::proto::EnqueueUpdateResponse* ReadWriteCmdResponse::release_enqueue_update() {
-  clear_has_enqueue_update();
-  ::cockroach::proto::EnqueueUpdateResponse* temp = enqueue_update_;
-  enqueue_update_ = NULL;
-  return temp;
+  if (has_enqueue_update()) {
+    clear_has_value();
+    ::cockroach::proto::EnqueueUpdateResponse* temp = value_.enqueue_update_;
+    value_.enqueue_update_ = NULL;
+    return temp;
+  } else {
+    return NULL;
+  }
 }
 inline void ReadWriteCmdResponse::set_allocated_enqueue_update(::cockroach::proto::EnqueueUpdateResponse* enqueue_update) {
-  delete enqueue_update_;
-  enqueue_update_ = enqueue_update;
+  clear_value();
   if (enqueue_update) {
     set_has_enqueue_update();
-  } else {
-    clear_has_enqueue_update();
+    value_.enqueue_update_ = enqueue_update;
   }
-  // @@protoc_insertion_point(field_set_allocated:cockroach.proto.ReadWriteCmdResponse.enqueue_update)
 }
 
 // optional .cockroach.proto.EnqueueMessageResponse enqueue_message = 9;
 inline bool ReadWriteCmdResponse::has_enqueue_message() const {
-  return (_has_bits_[0] & 0x00000100u) != 0;
+  return value_case() == kEnqueueMessage;
 }
 inline void ReadWriteCmdResponse::set_has_enqueue_message() {
-  _has_bits_[0] |= 0x00000100u;
-}
-inline void ReadWriteCmdResponse::clear_has_enqueue_message() {
-  _has_bits_[0] &= ~0x00000100u;
+  _oneof_case_[0] = kEnqueueMessage;
 }
 inline void ReadWriteCmdResponse::clear_enqueue_message() {
-  if (enqueue_message_ != NULL) enqueue_message_->::cockroach::proto::EnqueueMessageResponse::Clear();
-  clear_has_enqueue_message();
+  if (has_enqueue_message()) {
+    delete value_.enqueue_message_;
+    clear_has_value();
+  }
 }
 inline const ::cockroach::proto::EnqueueMessageResponse& ReadWriteCmdResponse::enqueue_message() const {
-  // @@protoc_insertion_point(field_get:cockroach.proto.ReadWriteCmdResponse.enqueue_message)
-  return enqueue_message_ != NULL ? *enqueue_message_ : *default_instance_->enqueue_message_;
+  return has_enqueue_message() ? *value_.enqueue_message_
+                      : ::cockroach::proto::EnqueueMessageResponse::default_instance();
 }
 inline ::cockroach::proto::EnqueueMessageResponse* ReadWriteCmdResponse::mutable_enqueue_message() {
-  set_has_enqueue_message();
-  if (enqueue_message_ == NULL) enqueue_message_ = new ::cockroach::proto::EnqueueMessageResponse;
-  // @@protoc_insertion_point(field_mutable:cockroach.proto.ReadWriteCmdResponse.enqueue_message)
-  return enqueue_message_;
+  if (!has_enqueue_message()) {
+    clear_value();
+    set_has_enqueue_message();
+    value_.enqueue_message_ = new ::cockroach::proto::EnqueueMessageResponse;
+  }
+  return value_.enqueue_message_;
 }
 inline ::cockroach::proto::EnqueueMessageResponse* ReadWriteCmdResponse::release_enqueue_message() {
-  clear_has_enqueue_message();
-  ::cockroach::proto::EnqueueMessageResponse* temp = enqueue_message_;
-  enqueue_message_ = NULL;
-  return temp;
+  if (has_enqueue_message()) {
+    clear_has_value();
+    ::cockroach::proto::EnqueueMessageResponse* temp = value_.enqueue_message_;
+    value_.enqueue_message_ = NULL;
+    return temp;
+  } else {
+    return NULL;
+  }
 }
 inline void ReadWriteCmdResponse::set_allocated_enqueue_message(::cockroach::proto::EnqueueMessageResponse* enqueue_message) {
-  delete enqueue_message_;
-  enqueue_message_ = enqueue_message;
+  clear_value();
   if (enqueue_message) {
     set_has_enqueue_message();
-  } else {
-    clear_has_enqueue_message();
+    value_.enqueue_message_ = enqueue_message;
   }
-  // @@protoc_insertion_point(field_set_allocated:cockroach.proto.ReadWriteCmdResponse.enqueue_message)
 }
 
 // optional .cockroach.proto.InternalHeartbeatTxnResponse internal_heartbeat_txn = 10;
 inline bool ReadWriteCmdResponse::has_internal_heartbeat_txn() const {
-  return (_has_bits_[0] & 0x00000200u) != 0;
+  return value_case() == kInternalHeartbeatTxn;
 }
 inline void ReadWriteCmdResponse::set_has_internal_heartbeat_txn() {
-  _has_bits_[0] |= 0x00000200u;
-}
-inline void ReadWriteCmdResponse::clear_has_internal_heartbeat_txn() {
-  _has_bits_[0] &= ~0x00000200u;
+  _oneof_case_[0] = kInternalHeartbeatTxn;
 }
 inline void ReadWriteCmdResponse::clear_internal_heartbeat_txn() {
-  if (internal_heartbeat_txn_ != NULL) internal_heartbeat_txn_->::cockroach::proto::InternalHeartbeatTxnResponse::Clear();
-  clear_has_internal_heartbeat_txn();
+  if (has_internal_heartbeat_txn()) {
+    delete value_.internal_heartbeat_txn_;
+    clear_has_value();
+  }
 }
 inline const ::cockroach::proto::InternalHeartbeatTxnResponse& ReadWriteCmdResponse::internal_heartbeat_txn() const {
-  // @@protoc_insertion_point(field_get:cockroach.proto.ReadWriteCmdResponse.internal_heartbeat_txn)
-  return internal_heartbeat_txn_ != NULL ? *internal_heartbeat_txn_ : *default_instance_->internal_heartbeat_txn_;
+  return has_internal_heartbeat_txn() ? *value_.internal_heartbeat_txn_
+                      : ::cockroach::proto::InternalHeartbeatTxnResponse::default_instance();
 }
 inline ::cockroach::proto::InternalHeartbeatTxnResponse* ReadWriteCmdResponse::mutable_internal_heartbeat_txn() {
-  set_has_internal_heartbeat_txn();
-  if (internal_heartbeat_txn_ == NULL) internal_heartbeat_txn_ = new ::cockroach::proto::InternalHeartbeatTxnResponse;
-  // @@protoc_insertion_point(field_mutable:cockroach.proto.ReadWriteCmdResponse.internal_heartbeat_txn)
-  return internal_heartbeat_txn_;
+  if (!has_internal_heartbeat_txn()) {
+    clear_value();
+    set_has_internal_heartbeat_txn();
+    value_.internal_heartbeat_txn_ = new ::cockroach::proto::InternalHeartbeatTxnResponse;
+  }
+  return value_.internal_heartbeat_txn_;
 }
 inline ::cockroach::proto::InternalHeartbeatTxnResponse* ReadWriteCmdResponse::release_internal_heartbeat_txn() {
-  clear_has_internal_heartbeat_txn();
-  ::cockroach::proto::InternalHeartbeatTxnResponse* temp = internal_heartbeat_txn_;
-  internal_heartbeat_txn_ = NULL;
-  return temp;
+  if (has_internal_heartbeat_txn()) {
+    clear_has_value();
+    ::cockroach::proto::InternalHeartbeatTxnResponse* temp = value_.internal_heartbeat_txn_;
+    value_.internal_heartbeat_txn_ = NULL;
+    return temp;
+  } else {
+    return NULL;
+  }
 }
 inline void ReadWriteCmdResponse::set_allocated_internal_heartbeat_txn(::cockroach::proto::InternalHeartbeatTxnResponse* internal_heartbeat_txn) {
-  delete internal_heartbeat_txn_;
-  internal_heartbeat_txn_ = internal_heartbeat_txn;
+  clear_value();
   if (internal_heartbeat_txn) {
     set_has_internal_heartbeat_txn();
-  } else {
-    clear_has_internal_heartbeat_txn();
+    value_.internal_heartbeat_txn_ = internal_heartbeat_txn;
   }
-  // @@protoc_insertion_point(field_set_allocated:cockroach.proto.ReadWriteCmdResponse.internal_heartbeat_txn)
 }
 
 // optional .cockroach.proto.InternalPushTxnResponse internal_push_txn = 11;
 inline bool ReadWriteCmdResponse::has_internal_push_txn() const {
-  return (_has_bits_[0] & 0x00000400u) != 0;
+  return value_case() == kInternalPushTxn;
 }
 inline void ReadWriteCmdResponse::set_has_internal_push_txn() {
-  _has_bits_[0] |= 0x00000400u;
-}
-inline void ReadWriteCmdResponse::clear_has_internal_push_txn() {
-  _has_bits_[0] &= ~0x00000400u;
+  _oneof_case_[0] = kInternalPushTxn;
 }
 inline void ReadWriteCmdResponse::clear_internal_push_txn() {
-  if (internal_push_txn_ != NULL) internal_push_txn_->::cockroach::proto::InternalPushTxnResponse::Clear();
-  clear_has_internal_push_txn();
+  if (has_internal_push_txn()) {
+    delete value_.internal_push_txn_;
+    clear_has_value();
+  }
 }
 inline const ::cockroach::proto::InternalPushTxnResponse& ReadWriteCmdResponse::internal_push_txn() const {
-  // @@protoc_insertion_point(field_get:cockroach.proto.ReadWriteCmdResponse.internal_push_txn)
-  return internal_push_txn_ != NULL ? *internal_push_txn_ : *default_instance_->internal_push_txn_;
+  return has_internal_push_txn() ? *value_.internal_push_txn_
+                      : ::cockroach::proto::InternalPushTxnResponse::default_instance();
 }
 inline ::cockroach::proto::InternalPushTxnResponse* ReadWriteCmdResponse::mutable_internal_push_txn() {
-  set_has_internal_push_txn();
-  if (internal_push_txn_ == NULL) internal_push_txn_ = new ::cockroach::proto::InternalPushTxnResponse;
-  // @@protoc_insertion_point(field_mutable:cockroach.proto.ReadWriteCmdResponse.internal_push_txn)
-  return internal_push_txn_;
+  if (!has_internal_push_txn()) {
+    clear_value();
+    set_has_internal_push_txn();
+    value_.internal_push_txn_ = new ::cockroach::proto::InternalPushTxnResponse;
+  }
+  return value_.internal_push_txn_;
 }
 inline ::cockroach::proto::InternalPushTxnResponse* ReadWriteCmdResponse::release_internal_push_txn() {
-  clear_has_internal_push_txn();
-  ::cockroach::proto::InternalPushTxnResponse* temp = internal_push_txn_;
-  internal_push_txn_ = NULL;
-  return temp;
+  if (has_internal_push_txn()) {
+    clear_has_value();
+    ::cockroach::proto::InternalPushTxnResponse* temp = value_.internal_push_txn_;
+    value_.internal_push_txn_ = NULL;
+    return temp;
+  } else {
+    return NULL;
+  }
 }
 inline void ReadWriteCmdResponse::set_allocated_internal_push_txn(::cockroach::proto::InternalPushTxnResponse* internal_push_txn) {
-  delete internal_push_txn_;
-  internal_push_txn_ = internal_push_txn;
+  clear_value();
   if (internal_push_txn) {
     set_has_internal_push_txn();
-  } else {
-    clear_has_internal_push_txn();
+    value_.internal_push_txn_ = internal_push_txn;
   }
-  // @@protoc_insertion_point(field_set_allocated:cockroach.proto.ReadWriteCmdResponse.internal_push_txn)
 }
 
 // optional .cockroach.proto.InternalResolveIntentResponse internal_resolve_intent = 12;
 inline bool ReadWriteCmdResponse::has_internal_resolve_intent() const {
-  return (_has_bits_[0] & 0x00000800u) != 0;
+  return value_case() == kInternalResolveIntent;
 }
 inline void ReadWriteCmdResponse::set_has_internal_resolve_intent() {
-  _has_bits_[0] |= 0x00000800u;
-}
-inline void ReadWriteCmdResponse::clear_has_internal_resolve_intent() {
-  _has_bits_[0] &= ~0x00000800u;
+  _oneof_case_[0] = kInternalResolveIntent;
 }
 inline void ReadWriteCmdResponse::clear_internal_resolve_intent() {
-  if (internal_resolve_intent_ != NULL) internal_resolve_intent_->::cockroach::proto::InternalResolveIntentResponse::Clear();
-  clear_has_internal_resolve_intent();
+  if (has_internal_resolve_intent()) {
+    delete value_.internal_resolve_intent_;
+    clear_has_value();
+  }
 }
 inline const ::cockroach::proto::InternalResolveIntentResponse& ReadWriteCmdResponse::internal_resolve_intent() const {
-  // @@protoc_insertion_point(field_get:cockroach.proto.ReadWriteCmdResponse.internal_resolve_intent)
-  return internal_resolve_intent_ != NULL ? *internal_resolve_intent_ : *default_instance_->internal_resolve_intent_;
+  return has_internal_resolve_intent() ? *value_.internal_resolve_intent_
+                      : ::cockroach::proto::InternalResolveIntentResponse::default_instance();
 }
 inline ::cockroach::proto::InternalResolveIntentResponse* ReadWriteCmdResponse::mutable_internal_resolve_intent() {
-  set_has_internal_resolve_intent();
-  if (internal_resolve_intent_ == NULL) internal_resolve_intent_ = new ::cockroach::proto::InternalResolveIntentResponse;
-  // @@protoc_insertion_point(field_mutable:cockroach.proto.ReadWriteCmdResponse.internal_resolve_intent)
-  return internal_resolve_intent_;
+  if (!has_internal_resolve_intent()) {
+    clear_value();
+    set_has_internal_resolve_intent();
+    value_.internal_resolve_intent_ = new ::cockroach::proto::InternalResolveIntentResponse;
+  }
+  return value_.internal_resolve_intent_;
 }
 inline ::cockroach::proto::InternalResolveIntentResponse* ReadWriteCmdResponse::release_internal_resolve_intent() {
-  clear_has_internal_resolve_intent();
-  ::cockroach::proto::InternalResolveIntentResponse* temp = internal_resolve_intent_;
-  internal_resolve_intent_ = NULL;
-  return temp;
+  if (has_internal_resolve_intent()) {
+    clear_has_value();
+    ::cockroach::proto::InternalResolveIntentResponse* temp = value_.internal_resolve_intent_;
+    value_.internal_resolve_intent_ = NULL;
+    return temp;
+  } else {
+    return NULL;
+  }
 }
 inline void ReadWriteCmdResponse::set_allocated_internal_resolve_intent(::cockroach::proto::InternalResolveIntentResponse* internal_resolve_intent) {
-  delete internal_resolve_intent_;
-  internal_resolve_intent_ = internal_resolve_intent;
+  clear_value();
   if (internal_resolve_intent) {
     set_has_internal_resolve_intent();
-  } else {
-    clear_has_internal_resolve_intent();
+    value_.internal_resolve_intent_ = internal_resolve_intent;
   }
-  // @@protoc_insertion_point(field_set_allocated:cockroach.proto.ReadWriteCmdResponse.internal_resolve_intent)
 }
 
 // optional .cockroach.proto.InternalMergeResponse internal_merge = 13;
 inline bool ReadWriteCmdResponse::has_internal_merge() const {
-  return (_has_bits_[0] & 0x00001000u) != 0;
+  return value_case() == kInternalMerge;
 }
 inline void ReadWriteCmdResponse::set_has_internal_merge() {
-  _has_bits_[0] |= 0x00001000u;
-}
-inline void ReadWriteCmdResponse::clear_has_internal_merge() {
-  _has_bits_[0] &= ~0x00001000u;
+  _oneof_case_[0] = kInternalMerge;
 }
 inline void ReadWriteCmdResponse::clear_internal_merge() {
-  if (internal_merge_ != NULL) internal_merge_->::cockroach::proto::InternalMergeResponse::Clear();
-  clear_has_internal_merge();
+  if (has_internal_merge()) {
+    delete value_.internal_merge_;
+    clear_has_value();
+  }
 }
 inline const ::cockroach::proto::InternalMergeResponse& ReadWriteCmdResponse::internal_merge() const {
-  // @@protoc_insertion_point(field_get:cockroach.proto.ReadWriteCmdResponse.internal_merge)
-  return internal_merge_ != NULL ? *internal_merge_ : *default_instance_->internal_merge_;
+  return has_internal_merge() ? *value_.internal_merge_
+                      : ::cockroach::proto::InternalMergeResponse::default_instance();
 }
 inline ::cockroach::proto::InternalMergeResponse* ReadWriteCmdResponse::mutable_internal_merge() {
-  set_has_internal_merge();
-  if (internal_merge_ == NULL) internal_merge_ = new ::cockroach::proto::InternalMergeResponse;
-  // @@protoc_insertion_point(field_mutable:cockroach.proto.ReadWriteCmdResponse.internal_merge)
-  return internal_merge_;
+  if (!has_internal_merge()) {
+    clear_value();
+    set_has_internal_merge();
+    value_.internal_merge_ = new ::cockroach::proto::InternalMergeResponse;
+  }
+  return value_.internal_merge_;
 }
 inline ::cockroach::proto::InternalMergeResponse* ReadWriteCmdResponse::release_internal_merge() {
-  clear_has_internal_merge();
-  ::cockroach::proto::InternalMergeResponse* temp = internal_merge_;
-  internal_merge_ = NULL;
-  return temp;
+  if (has_internal_merge()) {
+    clear_has_value();
+    ::cockroach::proto::InternalMergeResponse* temp = value_.internal_merge_;
+    value_.internal_merge_ = NULL;
+    return temp;
+  } else {
+    return NULL;
+  }
 }
 inline void ReadWriteCmdResponse::set_allocated_internal_merge(::cockroach::proto::InternalMergeResponse* internal_merge) {
-  delete internal_merge_;
-  internal_merge_ = internal_merge;
+  clear_value();
   if (internal_merge) {
     set_has_internal_merge();
-  } else {
-    clear_has_internal_merge();
+    value_.internal_merge_ = internal_merge;
   }
-  // @@protoc_insertion_point(field_set_allocated:cockroach.proto.ReadWriteCmdResponse.internal_merge)
 }
 
 // optional .cockroach.proto.InternalTruncateLogResponse internal_truncate_log = 14;
 inline bool ReadWriteCmdResponse::has_internal_truncate_log() const {
-  return (_has_bits_[0] & 0x00002000u) != 0;
+  return value_case() == kInternalTruncateLog;
 }
 inline void ReadWriteCmdResponse::set_has_internal_truncate_log() {
-  _has_bits_[0] |= 0x00002000u;
-}
-inline void ReadWriteCmdResponse::clear_has_internal_truncate_log() {
-  _has_bits_[0] &= ~0x00002000u;
+  _oneof_case_[0] = kInternalTruncateLog;
 }
 inline void ReadWriteCmdResponse::clear_internal_truncate_log() {
-  if (internal_truncate_log_ != NULL) internal_truncate_log_->::cockroach::proto::InternalTruncateLogResponse::Clear();
-  clear_has_internal_truncate_log();
+  if (has_internal_truncate_log()) {
+    delete value_.internal_truncate_log_;
+    clear_has_value();
+  }
 }
 inline const ::cockroach::proto::InternalTruncateLogResponse& ReadWriteCmdResponse::internal_truncate_log() const {
-  // @@protoc_insertion_point(field_get:cockroach.proto.ReadWriteCmdResponse.internal_truncate_log)
-  return internal_truncate_log_ != NULL ? *internal_truncate_log_ : *default_instance_->internal_truncate_log_;
+  return has_internal_truncate_log() ? *value_.internal_truncate_log_
+                      : ::cockroach::proto::InternalTruncateLogResponse::default_instance();
 }
 inline ::cockroach::proto::InternalTruncateLogResponse* ReadWriteCmdResponse::mutable_internal_truncate_log() {
-  set_has_internal_truncate_log();
-  if (internal_truncate_log_ == NULL) internal_truncate_log_ = new ::cockroach::proto::InternalTruncateLogResponse;
-  // @@protoc_insertion_point(field_mutable:cockroach.proto.ReadWriteCmdResponse.internal_truncate_log)
-  return internal_truncate_log_;
+  if (!has_internal_truncate_log()) {
+    clear_value();
+    set_has_internal_truncate_log();
+    value_.internal_truncate_log_ = new ::cockroach::proto::InternalTruncateLogResponse;
+  }
+  return value_.internal_truncate_log_;
 }
 inline ::cockroach::proto::InternalTruncateLogResponse* ReadWriteCmdResponse::release_internal_truncate_log() {
-  clear_has_internal_truncate_log();
-  ::cockroach::proto::InternalTruncateLogResponse* temp = internal_truncate_log_;
-  internal_truncate_log_ = NULL;
-  return temp;
+  if (has_internal_truncate_log()) {
+    clear_has_value();
+    ::cockroach::proto::InternalTruncateLogResponse* temp = value_.internal_truncate_log_;
+    value_.internal_truncate_log_ = NULL;
+    return temp;
+  } else {
+    return NULL;
+  }
 }
 inline void ReadWriteCmdResponse::set_allocated_internal_truncate_log(::cockroach::proto::InternalTruncateLogResponse* internal_truncate_log) {
-  delete internal_truncate_log_;
-  internal_truncate_log_ = internal_truncate_log;
+  clear_value();
   if (internal_truncate_log) {
     set_has_internal_truncate_log();
-  } else {
-    clear_has_internal_truncate_log();
+    value_.internal_truncate_log_ = internal_truncate_log;
   }
-  // @@protoc_insertion_point(field_set_allocated:cockroach.proto.ReadWriteCmdResponse.internal_truncate_log)
 }
 
 // optional .cockroach.proto.InternalGCResponse internal_gc = 15;
 inline bool ReadWriteCmdResponse::has_internal_gc() const {
-  return (_has_bits_[0] & 0x00004000u) != 0;
+  return value_case() == kInternalGc;
 }
 inline void ReadWriteCmdResponse::set_has_internal_gc() {
-  _has_bits_[0] |= 0x00004000u;
-}
-inline void ReadWriteCmdResponse::clear_has_internal_gc() {
-  _has_bits_[0] &= ~0x00004000u;
+  _oneof_case_[0] = kInternalGc;
 }
 inline void ReadWriteCmdResponse::clear_internal_gc() {
-  if (internal_gc_ != NULL) internal_gc_->::cockroach::proto::InternalGCResponse::Clear();
-  clear_has_internal_gc();
+  if (has_internal_gc()) {
+    delete value_.internal_gc_;
+    clear_has_value();
+  }
 }
 inline const ::cockroach::proto::InternalGCResponse& ReadWriteCmdResponse::internal_gc() const {
-  // @@protoc_insertion_point(field_get:cockroach.proto.ReadWriteCmdResponse.internal_gc)
-  return internal_gc_ != NULL ? *internal_gc_ : *default_instance_->internal_gc_;
+  return has_internal_gc() ? *value_.internal_gc_
+                      : ::cockroach::proto::InternalGCResponse::default_instance();
 }
 inline ::cockroach::proto::InternalGCResponse* ReadWriteCmdResponse::mutable_internal_gc() {
-  set_has_internal_gc();
-  if (internal_gc_ == NULL) internal_gc_ = new ::cockroach::proto::InternalGCResponse;
-  // @@protoc_insertion_point(field_mutable:cockroach.proto.ReadWriteCmdResponse.internal_gc)
-  return internal_gc_;
+  if (!has_internal_gc()) {
+    clear_value();
+    set_has_internal_gc();
+    value_.internal_gc_ = new ::cockroach::proto::InternalGCResponse;
+  }
+  return value_.internal_gc_;
 }
 inline ::cockroach::proto::InternalGCResponse* ReadWriteCmdResponse::release_internal_gc() {
-  clear_has_internal_gc();
-  ::cockroach::proto::InternalGCResponse* temp = internal_gc_;
-  internal_gc_ = NULL;
-  return temp;
+  if (has_internal_gc()) {
+    clear_has_value();
+    ::cockroach::proto::InternalGCResponse* temp = value_.internal_gc_;
+    value_.internal_gc_ = NULL;
+    return temp;
+  } else {
+    return NULL;
+  }
 }
 inline void ReadWriteCmdResponse::set_allocated_internal_gc(::cockroach::proto::InternalGCResponse* internal_gc) {
-  delete internal_gc_;
-  internal_gc_ = internal_gc;
+  clear_value();
   if (internal_gc) {
     set_has_internal_gc();
-  } else {
-    clear_has_internal_gc();
+    value_.internal_gc_ = internal_gc;
   }
-  // @@protoc_insertion_point(field_set_allocated:cockroach.proto.ReadWriteCmdResponse.internal_gc)
 }
 
+inline bool ReadWriteCmdResponse::has_value() {
+  return value_case() != VALUE_NOT_SET;
+}
+inline void ReadWriteCmdResponse::clear_has_value() {
+  _oneof_case_[0] = VALUE_NOT_SET;
+}
+inline ReadWriteCmdResponse::ValueCase ReadWriteCmdResponse::value_case() const {
+  return ReadWriteCmdResponse::ValueCase(_oneof_case_[0]);
+}
 // -------------------------------------------------------------------
 
 // InternalRaftCommandUnion
 
 // optional .cockroach.proto.ContainsRequest contains = 1;
 inline bool InternalRaftCommandUnion::has_contains() const {
-  return (_has_bits_[0] & 0x00000001u) != 0;
+  return value_case() == kContains;
 }
 inline void InternalRaftCommandUnion::set_has_contains() {
-  _has_bits_[0] |= 0x00000001u;
-}
-inline void InternalRaftCommandUnion::clear_has_contains() {
-  _has_bits_[0] &= ~0x00000001u;
+  _oneof_case_[0] = kContains;
 }
 inline void InternalRaftCommandUnion::clear_contains() {
-  if (contains_ != NULL) contains_->::cockroach::proto::ContainsRequest::Clear();
-  clear_has_contains();
+  if (has_contains()) {
+    delete value_.contains_;
+    clear_has_value();
+  }
 }
 inline const ::cockroach::proto::ContainsRequest& InternalRaftCommandUnion::contains() const {
-  // @@protoc_insertion_point(field_get:cockroach.proto.InternalRaftCommandUnion.contains)
-  return contains_ != NULL ? *contains_ : *default_instance_->contains_;
+  return has_contains() ? *value_.contains_
+                      : ::cockroach::proto::ContainsRequest::default_instance();
 }
 inline ::cockroach::proto::ContainsRequest* InternalRaftCommandUnion::mutable_contains() {
-  set_has_contains();
-  if (contains_ == NULL) contains_ = new ::cockroach::proto::ContainsRequest;
-  // @@protoc_insertion_point(field_mutable:cockroach.proto.InternalRaftCommandUnion.contains)
-  return contains_;
+  if (!has_contains()) {
+    clear_value();
+    set_has_contains();
+    value_.contains_ = new ::cockroach::proto::ContainsRequest;
+  }
+  return value_.contains_;
 }
 inline ::cockroach::proto::ContainsRequest* InternalRaftCommandUnion::release_contains() {
-  clear_has_contains();
-  ::cockroach::proto::ContainsRequest* temp = contains_;
-  contains_ = NULL;
-  return temp;
+  if (has_contains()) {
+    clear_has_value();
+    ::cockroach::proto::ContainsRequest* temp = value_.contains_;
+    value_.contains_ = NULL;
+    return temp;
+  } else {
+    return NULL;
+  }
 }
 inline void InternalRaftCommandUnion::set_allocated_contains(::cockroach::proto::ContainsRequest* contains) {
-  delete contains_;
-  contains_ = contains;
+  clear_value();
   if (contains) {
     set_has_contains();
-  } else {
-    clear_has_contains();
+    value_.contains_ = contains;
   }
-  // @@protoc_insertion_point(field_set_allocated:cockroach.proto.InternalRaftCommandUnion.contains)
 }
 
 // optional .cockroach.proto.GetRequest get = 2;
 inline bool InternalRaftCommandUnion::has_get() const {
-  return (_has_bits_[0] & 0x00000002u) != 0;
+  return value_case() == kGet;
 }
 inline void InternalRaftCommandUnion::set_has_get() {
-  _has_bits_[0] |= 0x00000002u;
-}
-inline void InternalRaftCommandUnion::clear_has_get() {
-  _has_bits_[0] &= ~0x00000002u;
+  _oneof_case_[0] = kGet;
 }
 inline void InternalRaftCommandUnion::clear_get() {
-  if (get_ != NULL) get_->::cockroach::proto::GetRequest::Clear();
-  clear_has_get();
+  if (has_get()) {
+    delete value_.get_;
+    clear_has_value();
+  }
 }
 inline const ::cockroach::proto::GetRequest& InternalRaftCommandUnion::get() const {
-  // @@protoc_insertion_point(field_get:cockroach.proto.InternalRaftCommandUnion.get)
-  return get_ != NULL ? *get_ : *default_instance_->get_;
+  return has_get() ? *value_.get_
+                      : ::cockroach::proto::GetRequest::default_instance();
 }
 inline ::cockroach::proto::GetRequest* InternalRaftCommandUnion::mutable_get() {
-  set_has_get();
-  if (get_ == NULL) get_ = new ::cockroach::proto::GetRequest;
-  // @@protoc_insertion_point(field_mutable:cockroach.proto.InternalRaftCommandUnion.get)
-  return get_;
+  if (!has_get()) {
+    clear_value();
+    set_has_get();
+    value_.get_ = new ::cockroach::proto::GetRequest;
+  }
+  return value_.get_;
 }
 inline ::cockroach::proto::GetRequest* InternalRaftCommandUnion::release_get() {
-  clear_has_get();
-  ::cockroach::proto::GetRequest* temp = get_;
-  get_ = NULL;
-  return temp;
+  if (has_get()) {
+    clear_has_value();
+    ::cockroach::proto::GetRequest* temp = value_.get_;
+    value_.get_ = NULL;
+    return temp;
+  } else {
+    return NULL;
+  }
 }
 inline void InternalRaftCommandUnion::set_allocated_get(::cockroach::proto::GetRequest* get) {
-  delete get_;
-  get_ = get;
+  clear_value();
   if (get) {
     set_has_get();
-  } else {
-    clear_has_get();
+    value_.get_ = get;
   }
-  // @@protoc_insertion_point(field_set_allocated:cockroach.proto.InternalRaftCommandUnion.get)
 }
 
 // optional .cockroach.proto.PutRequest put = 3;
 inline bool InternalRaftCommandUnion::has_put() const {
-  return (_has_bits_[0] & 0x00000004u) != 0;
+  return value_case() == kPut;
 }
 inline void InternalRaftCommandUnion::set_has_put() {
-  _has_bits_[0] |= 0x00000004u;
-}
-inline void InternalRaftCommandUnion::clear_has_put() {
-  _has_bits_[0] &= ~0x00000004u;
+  _oneof_case_[0] = kPut;
 }
 inline void InternalRaftCommandUnion::clear_put() {
-  if (put_ != NULL) put_->::cockroach::proto::PutRequest::Clear();
-  clear_has_put();
+  if (has_put()) {
+    delete value_.put_;
+    clear_has_value();
+  }
 }
 inline const ::cockroach::proto::PutRequest& InternalRaftCommandUnion::put() const {
-  // @@protoc_insertion_point(field_get:cockroach.proto.InternalRaftCommandUnion.put)
-  return put_ != NULL ? *put_ : *default_instance_->put_;
+  return has_put() ? *value_.put_
+                      : ::cockroach::proto::PutRequest::default_instance();
 }
 inline ::cockroach::proto::PutRequest* InternalRaftCommandUnion::mutable_put() {
-  set_has_put();
-  if (put_ == NULL) put_ = new ::cockroach::proto::PutRequest;
-  // @@protoc_insertion_point(field_mutable:cockroach.proto.InternalRaftCommandUnion.put)
-  return put_;
+  if (!has_put()) {
+    clear_value();
+    set_has_put();
+    value_.put_ = new ::cockroach::proto::PutRequest;
+  }
+  return value_.put_;
 }
 inline ::cockroach::proto::PutRequest* InternalRaftCommandUnion::release_put() {
-  clear_has_put();
-  ::cockroach::proto::PutRequest* temp = put_;
-  put_ = NULL;
-  return temp;
+  if (has_put()) {
+    clear_has_value();
+    ::cockroach::proto::PutRequest* temp = value_.put_;
+    value_.put_ = NULL;
+    return temp;
+  } else {
+    return NULL;
+  }
 }
 inline void InternalRaftCommandUnion::set_allocated_put(::cockroach::proto::PutRequest* put) {
-  delete put_;
-  put_ = put;
+  clear_value();
   if (put) {
     set_has_put();
-  } else {
-    clear_has_put();
+    value_.put_ = put;
   }
-  // @@protoc_insertion_point(field_set_allocated:cockroach.proto.InternalRaftCommandUnion.put)
 }
 
 // optional .cockroach.proto.ConditionalPutRequest conditional_put = 4;
 inline bool InternalRaftCommandUnion::has_conditional_put() const {
-  return (_has_bits_[0] & 0x00000008u) != 0;
+  return value_case() == kConditionalPut;
 }
 inline void InternalRaftCommandUnion::set_has_conditional_put() {
-  _has_bits_[0] |= 0x00000008u;
-}
-inline void InternalRaftCommandUnion::clear_has_conditional_put() {
-  _has_bits_[0] &= ~0x00000008u;
+  _oneof_case_[0] = kConditionalPut;
 }
 inline void InternalRaftCommandUnion::clear_conditional_put() {
-  if (conditional_put_ != NULL) conditional_put_->::cockroach::proto::ConditionalPutRequest::Clear();
-  clear_has_conditional_put();
+  if (has_conditional_put()) {
+    delete value_.conditional_put_;
+    clear_has_value();
+  }
 }
 inline const ::cockroach::proto::ConditionalPutRequest& InternalRaftCommandUnion::conditional_put() const {
-  // @@protoc_insertion_point(field_get:cockroach.proto.InternalRaftCommandUnion.conditional_put)
-  return conditional_put_ != NULL ? *conditional_put_ : *default_instance_->conditional_put_;
+  return has_conditional_put() ? *value_.conditional_put_
+                      : ::cockroach::proto::ConditionalPutRequest::default_instance();
 }
 inline ::cockroach::proto::ConditionalPutRequest* InternalRaftCommandUnion::mutable_conditional_put() {
-  set_has_conditional_put();
-  if (conditional_put_ == NULL) conditional_put_ = new ::cockroach::proto::ConditionalPutRequest;
-  // @@protoc_insertion_point(field_mutable:cockroach.proto.InternalRaftCommandUnion.conditional_put)
-  return conditional_put_;
+  if (!has_conditional_put()) {
+    clear_value();
+    set_has_conditional_put();
+    value_.conditional_put_ = new ::cockroach::proto::ConditionalPutRequest;
+  }
+  return value_.conditional_put_;
 }
 inline ::cockroach::proto::ConditionalPutRequest* InternalRaftCommandUnion::release_conditional_put() {
-  clear_has_conditional_put();
-  ::cockroach::proto::ConditionalPutRequest* temp = conditional_put_;
-  conditional_put_ = NULL;
-  return temp;
+  if (has_conditional_put()) {
+    clear_has_value();
+    ::cockroach::proto::ConditionalPutRequest* temp = value_.conditional_put_;
+    value_.conditional_put_ = NULL;
+    return temp;
+  } else {
+    return NULL;
+  }
 }
 inline void InternalRaftCommandUnion::set_allocated_conditional_put(::cockroach::proto::ConditionalPutRequest* conditional_put) {
-  delete conditional_put_;
-  conditional_put_ = conditional_put;
+  clear_value();
   if (conditional_put) {
     set_has_conditional_put();
-  } else {
-    clear_has_conditional_put();
+    value_.conditional_put_ = conditional_put;
   }
-  // @@protoc_insertion_point(field_set_allocated:cockroach.proto.InternalRaftCommandUnion.conditional_put)
 }
 
 // optional .cockroach.proto.IncrementRequest increment = 5;
 inline bool InternalRaftCommandUnion::has_increment() const {
-  return (_has_bits_[0] & 0x00000010u) != 0;
+  return value_case() == kIncrement;
 }
 inline void InternalRaftCommandUnion::set_has_increment() {
-  _has_bits_[0] |= 0x00000010u;
-}
-inline void InternalRaftCommandUnion::clear_has_increment() {
-  _has_bits_[0] &= ~0x00000010u;
+  _oneof_case_[0] = kIncrement;
 }
 inline void InternalRaftCommandUnion::clear_increment() {
-  if (increment_ != NULL) increment_->::cockroach::proto::IncrementRequest::Clear();
-  clear_has_increment();
+  if (has_increment()) {
+    delete value_.increment_;
+    clear_has_value();
+  }
 }
 inline const ::cockroach::proto::IncrementRequest& InternalRaftCommandUnion::increment() const {
-  // @@protoc_insertion_point(field_get:cockroach.proto.InternalRaftCommandUnion.increment)
-  return increment_ != NULL ? *increment_ : *default_instance_->increment_;
+  return has_increment() ? *value_.increment_
+                      : ::cockroach::proto::IncrementRequest::default_instance();
 }
 inline ::cockroach::proto::IncrementRequest* InternalRaftCommandUnion::mutable_increment() {
-  set_has_increment();
-  if (increment_ == NULL) increment_ = new ::cockroach::proto::IncrementRequest;
-  // @@protoc_insertion_point(field_mutable:cockroach.proto.InternalRaftCommandUnion.increment)
-  return increment_;
+  if (!has_increment()) {
+    clear_value();
+    set_has_increment();
+    value_.increment_ = new ::cockroach::proto::IncrementRequest;
+  }
+  return value_.increment_;
 }
 inline ::cockroach::proto::IncrementRequest* InternalRaftCommandUnion::release_increment() {
-  clear_has_increment();
-  ::cockroach::proto::IncrementRequest* temp = increment_;
-  increment_ = NULL;
-  return temp;
+  if (has_increment()) {
+    clear_has_value();
+    ::cockroach::proto::IncrementRequest* temp = value_.increment_;
+    value_.increment_ = NULL;
+    return temp;
+  } else {
+    return NULL;
+  }
 }
 inline void InternalRaftCommandUnion::set_allocated_increment(::cockroach::proto::IncrementRequest* increment) {
-  delete increment_;
-  increment_ = increment;
+  clear_value();
   if (increment) {
     set_has_increment();
-  } else {
-    clear_has_increment();
+    value_.increment_ = increment;
   }
-  // @@protoc_insertion_point(field_set_allocated:cockroach.proto.InternalRaftCommandUnion.increment)
 }
 
 // optional .cockroach.proto.DeleteRequest delete = 6;
 inline bool InternalRaftCommandUnion::has_delete_() const {
-  return (_has_bits_[0] & 0x00000020u) != 0;
+  return value_case() == kDelete;
 }
 inline void InternalRaftCommandUnion::set_has_delete_() {
-  _has_bits_[0] |= 0x00000020u;
-}
-inline void InternalRaftCommandUnion::clear_has_delete_() {
-  _has_bits_[0] &= ~0x00000020u;
+  _oneof_case_[0] = kDelete;
 }
 inline void InternalRaftCommandUnion::clear_delete_() {
-  if (delete__ != NULL) delete__->::cockroach::proto::DeleteRequest::Clear();
-  clear_has_delete_();
+  if (has_delete_()) {
+    delete value_.delete__;
+    clear_has_value();
+  }
 }
 inline const ::cockroach::proto::DeleteRequest& InternalRaftCommandUnion::delete_() const {
-  // @@protoc_insertion_point(field_get:cockroach.proto.InternalRaftCommandUnion.delete)
-  return delete__ != NULL ? *delete__ : *default_instance_->delete__;
+  return has_delete_() ? *value_.delete__
+                      : ::cockroach::proto::DeleteRequest::default_instance();
 }
 inline ::cockroach::proto::DeleteRequest* InternalRaftCommandUnion::mutable_delete_() {
-  set_has_delete_();
-  if (delete__ == NULL) delete__ = new ::cockroach::proto::DeleteRequest;
-  // @@protoc_insertion_point(field_mutable:cockroach.proto.InternalRaftCommandUnion.delete)
-  return delete__;
+  if (!has_delete_()) {
+    clear_value();
+    set_has_delete_();
+    value_.delete__ = new ::cockroach::proto::DeleteRequest;
+  }
+  return value_.delete__;
 }
 inline ::cockroach::proto::DeleteRequest* InternalRaftCommandUnion::release_delete_() {
-  clear_has_delete_();
-  ::cockroach::proto::DeleteRequest* temp = delete__;
-  delete__ = NULL;
-  return temp;
+  if (has_delete_()) {
+    clear_has_value();
+    ::cockroach::proto::DeleteRequest* temp = value_.delete__;
+    value_.delete__ = NULL;
+    return temp;
+  } else {
+    return NULL;
+  }
 }
 inline void InternalRaftCommandUnion::set_allocated_delete_(::cockroach::proto::DeleteRequest* delete_) {
-  delete delete__;
-  delete__ = delete_;
+  clear_value();
   if (delete_) {
     set_has_delete_();
-  } else {
-    clear_has_delete_();
+    value_.delete__ = delete_;
   }
-  // @@protoc_insertion_point(field_set_allocated:cockroach.proto.InternalRaftCommandUnion.delete)
 }
 
 // optional .cockroach.proto.DeleteRangeRequest delete_range = 7;
 inline bool InternalRaftCommandUnion::has_delete_range() const {
-  return (_has_bits_[0] & 0x00000040u) != 0;
+  return value_case() == kDeleteRange;
 }
 inline void InternalRaftCommandUnion::set_has_delete_range() {
-  _has_bits_[0] |= 0x00000040u;
-}
-inline void InternalRaftCommandUnion::clear_has_delete_range() {
-  _has_bits_[0] &= ~0x00000040u;
+  _oneof_case_[0] = kDeleteRange;
 }
 inline void InternalRaftCommandUnion::clear_delete_range() {
-  if (delete_range_ != NULL) delete_range_->::cockroach::proto::DeleteRangeRequest::Clear();
-  clear_has_delete_range();
+  if (has_delete_range()) {
+    delete value_.delete_range_;
+    clear_has_value();
+  }
 }
 inline const ::cockroach::proto::DeleteRangeRequest& InternalRaftCommandUnion::delete_range() const {
-  // @@protoc_insertion_point(field_get:cockroach.proto.InternalRaftCommandUnion.delete_range)
-  return delete_range_ != NULL ? *delete_range_ : *default_instance_->delete_range_;
+  return has_delete_range() ? *value_.delete_range_
+                      : ::cockroach::proto::DeleteRangeRequest::default_instance();
 }
 inline ::cockroach::proto::DeleteRangeRequest* InternalRaftCommandUnion::mutable_delete_range() {
-  set_has_delete_range();
-  if (delete_range_ == NULL) delete_range_ = new ::cockroach::proto::DeleteRangeRequest;
-  // @@protoc_insertion_point(field_mutable:cockroach.proto.InternalRaftCommandUnion.delete_range)
-  return delete_range_;
+  if (!has_delete_range()) {
+    clear_value();
+    set_has_delete_range();
+    value_.delete_range_ = new ::cockroach::proto::DeleteRangeRequest;
+  }
+  return value_.delete_range_;
 }
 inline ::cockroach::proto::DeleteRangeRequest* InternalRaftCommandUnion::release_delete_range() {
-  clear_has_delete_range();
-  ::cockroach::proto::DeleteRangeRequest* temp = delete_range_;
-  delete_range_ = NULL;
-  return temp;
+  if (has_delete_range()) {
+    clear_has_value();
+    ::cockroach::proto::DeleteRangeRequest* temp = value_.delete_range_;
+    value_.delete_range_ = NULL;
+    return temp;
+  } else {
+    return NULL;
+  }
 }
 inline void InternalRaftCommandUnion::set_allocated_delete_range(::cockroach::proto::DeleteRangeRequest* delete_range) {
-  delete delete_range_;
-  delete_range_ = delete_range;
+  clear_value();
   if (delete_range) {
     set_has_delete_range();
-  } else {
-    clear_has_delete_range();
+    value_.delete_range_ = delete_range;
   }
-  // @@protoc_insertion_point(field_set_allocated:cockroach.proto.InternalRaftCommandUnion.delete_range)
 }
 
 // optional .cockroach.proto.ScanRequest scan = 8;
 inline bool InternalRaftCommandUnion::has_scan() const {
-  return (_has_bits_[0] & 0x00000080u) != 0;
+  return value_case() == kScan;
 }
 inline void InternalRaftCommandUnion::set_has_scan() {
-  _has_bits_[0] |= 0x00000080u;
-}
-inline void InternalRaftCommandUnion::clear_has_scan() {
-  _has_bits_[0] &= ~0x00000080u;
+  _oneof_case_[0] = kScan;
 }
 inline void InternalRaftCommandUnion::clear_scan() {
-  if (scan_ != NULL) scan_->::cockroach::proto::ScanRequest::Clear();
-  clear_has_scan();
+  if (has_scan()) {
+    delete value_.scan_;
+    clear_has_value();
+  }
 }
 inline const ::cockroach::proto::ScanRequest& InternalRaftCommandUnion::scan() const {
-  // @@protoc_insertion_point(field_get:cockroach.proto.InternalRaftCommandUnion.scan)
-  return scan_ != NULL ? *scan_ : *default_instance_->scan_;
+  return has_scan() ? *value_.scan_
+                      : ::cockroach::proto::ScanRequest::default_instance();
 }
 inline ::cockroach::proto::ScanRequest* InternalRaftCommandUnion::mutable_scan() {
-  set_has_scan();
-  if (scan_ == NULL) scan_ = new ::cockroach::proto::ScanRequest;
-  // @@protoc_insertion_point(field_mutable:cockroach.proto.InternalRaftCommandUnion.scan)
-  return scan_;
+  if (!has_scan()) {
+    clear_value();
+    set_has_scan();
+    value_.scan_ = new ::cockroach::proto::ScanRequest;
+  }
+  return value_.scan_;
 }
 inline ::cockroach::proto::ScanRequest* InternalRaftCommandUnion::release_scan() {
-  clear_has_scan();
-  ::cockroach::proto::ScanRequest* temp = scan_;
-  scan_ = NULL;
-  return temp;
+  if (has_scan()) {
+    clear_has_value();
+    ::cockroach::proto::ScanRequest* temp = value_.scan_;
+    value_.scan_ = NULL;
+    return temp;
+  } else {
+    return NULL;
+  }
 }
 inline void InternalRaftCommandUnion::set_allocated_scan(::cockroach::proto::ScanRequest* scan) {
-  delete scan_;
-  scan_ = scan;
+  clear_value();
   if (scan) {
     set_has_scan();
-  } else {
-    clear_has_scan();
+    value_.scan_ = scan;
   }
-  // @@protoc_insertion_point(field_set_allocated:cockroach.proto.InternalRaftCommandUnion.scan)
 }
 
 // optional .cockroach.proto.EndTransactionRequest end_transaction = 9;
 inline bool InternalRaftCommandUnion::has_end_transaction() const {
-  return (_has_bits_[0] & 0x00000100u) != 0;
+  return value_case() == kEndTransaction;
 }
 inline void InternalRaftCommandUnion::set_has_end_transaction() {
-  _has_bits_[0] |= 0x00000100u;
-}
-inline void InternalRaftCommandUnion::clear_has_end_transaction() {
-  _has_bits_[0] &= ~0x00000100u;
+  _oneof_case_[0] = kEndTransaction;
 }
 inline void InternalRaftCommandUnion::clear_end_transaction() {
-  if (end_transaction_ != NULL) end_transaction_->::cockroach::proto::EndTransactionRequest::Clear();
-  clear_has_end_transaction();
+  if (has_end_transaction()) {
+    delete value_.end_transaction_;
+    clear_has_value();
+  }
 }
 inline const ::cockroach::proto::EndTransactionRequest& InternalRaftCommandUnion::end_transaction() const {
-  // @@protoc_insertion_point(field_get:cockroach.proto.InternalRaftCommandUnion.end_transaction)
-  return end_transaction_ != NULL ? *end_transaction_ : *default_instance_->end_transaction_;
+  return has_end_transaction() ? *value_.end_transaction_
+                      : ::cockroach::proto::EndTransactionRequest::default_instance();
 }
 inline ::cockroach::proto::EndTransactionRequest* InternalRaftCommandUnion::mutable_end_transaction() {
-  set_has_end_transaction();
-  if (end_transaction_ == NULL) end_transaction_ = new ::cockroach::proto::EndTransactionRequest;
-  // @@protoc_insertion_point(field_mutable:cockroach.proto.InternalRaftCommandUnion.end_transaction)
-  return end_transaction_;
+  if (!has_end_transaction()) {
+    clear_value();
+    set_has_end_transaction();
+    value_.end_transaction_ = new ::cockroach::proto::EndTransactionRequest;
+  }
+  return value_.end_transaction_;
 }
 inline ::cockroach::proto::EndTransactionRequest* InternalRaftCommandUnion::release_end_transaction() {
-  clear_has_end_transaction();
-  ::cockroach::proto::EndTransactionRequest* temp = end_transaction_;
-  end_transaction_ = NULL;
-  return temp;
+  if (has_end_transaction()) {
+    clear_has_value();
+    ::cockroach::proto::EndTransactionRequest* temp = value_.end_transaction_;
+    value_.end_transaction_ = NULL;
+    return temp;
+  } else {
+    return NULL;
+  }
 }
 inline void InternalRaftCommandUnion::set_allocated_end_transaction(::cockroach::proto::EndTransactionRequest* end_transaction) {
-  delete end_transaction_;
-  end_transaction_ = end_transaction;
+  clear_value();
   if (end_transaction) {
     set_has_end_transaction();
-  } else {
-    clear_has_end_transaction();
+    value_.end_transaction_ = end_transaction;
   }
-  // @@protoc_insertion_point(field_set_allocated:cockroach.proto.InternalRaftCommandUnion.end_transaction)
 }
 
 // optional .cockroach.proto.ReapQueueRequest reap_queue = 10;
 inline bool InternalRaftCommandUnion::has_reap_queue() const {
-  return (_has_bits_[0] & 0x00000200u) != 0;
+  return value_case() == kReapQueue;
 }
 inline void InternalRaftCommandUnion::set_has_reap_queue() {
-  _has_bits_[0] |= 0x00000200u;
-}
-inline void InternalRaftCommandUnion::clear_has_reap_queue() {
-  _has_bits_[0] &= ~0x00000200u;
+  _oneof_case_[0] = kReapQueue;
 }
 inline void InternalRaftCommandUnion::clear_reap_queue() {
-  if (reap_queue_ != NULL) reap_queue_->::cockroach::proto::ReapQueueRequest::Clear();
-  clear_has_reap_queue();
+  if (has_reap_queue()) {
+    delete value_.reap_queue_;
+    clear_has_value();
+  }
 }
 inline const ::cockroach::proto::ReapQueueRequest& InternalRaftCommandUnion::reap_queue() const {
-  // @@protoc_insertion_point(field_get:cockroach.proto.InternalRaftCommandUnion.reap_queue)
-  return reap_queue_ != NULL ? *reap_queue_ : *default_instance_->reap_queue_;
+  return has_reap_queue() ? *value_.reap_queue_
+                      : ::cockroach::proto::ReapQueueRequest::default_instance();
 }
 inline ::cockroach::proto::ReapQueueRequest* InternalRaftCommandUnion::mutable_reap_queue() {
-  set_has_reap_queue();
-  if (reap_queue_ == NULL) reap_queue_ = new ::cockroach::proto::ReapQueueRequest;
-  // @@protoc_insertion_point(field_mutable:cockroach.proto.InternalRaftCommandUnion.reap_queue)
-  return reap_queue_;
+  if (!has_reap_queue()) {
+    clear_value();
+    set_has_reap_queue();
+    value_.reap_queue_ = new ::cockroach::proto::ReapQueueRequest;
+  }
+  return value_.reap_queue_;
 }
 inline ::cockroach::proto::ReapQueueRequest* InternalRaftCommandUnion::release_reap_queue() {
-  clear_has_reap_queue();
-  ::cockroach::proto::ReapQueueRequest* temp = reap_queue_;
-  reap_queue_ = NULL;
-  return temp;
+  if (has_reap_queue()) {
+    clear_has_value();
+    ::cockroach::proto::ReapQueueRequest* temp = value_.reap_queue_;
+    value_.reap_queue_ = NULL;
+    return temp;
+  } else {
+    return NULL;
+  }
 }
 inline void InternalRaftCommandUnion::set_allocated_reap_queue(::cockroach::proto::ReapQueueRequest* reap_queue) {
-  delete reap_queue_;
-  reap_queue_ = reap_queue;
+  clear_value();
   if (reap_queue) {
     set_has_reap_queue();
-  } else {
-    clear_has_reap_queue();
+    value_.reap_queue_ = reap_queue;
   }
-  // @@protoc_insertion_point(field_set_allocated:cockroach.proto.InternalRaftCommandUnion.reap_queue)
 }
 
 // optional .cockroach.proto.EnqueueUpdateRequest enqueue_update = 11;
 inline bool InternalRaftCommandUnion::has_enqueue_update() const {
-  return (_has_bits_[0] & 0x00000400u) != 0;
+  return value_case() == kEnqueueUpdate;
 }
 inline void InternalRaftCommandUnion::set_has_enqueue_update() {
-  _has_bits_[0] |= 0x00000400u;
-}
-inline void InternalRaftCommandUnion::clear_has_enqueue_update() {
-  _has_bits_[0] &= ~0x00000400u;
+  _oneof_case_[0] = kEnqueueUpdate;
 }
 inline void InternalRaftCommandUnion::clear_enqueue_update() {
-  if (enqueue_update_ != NULL) enqueue_update_->::cockroach::proto::EnqueueUpdateRequest::Clear();
-  clear_has_enqueue_update();
+  if (has_enqueue_update()) {
+    delete value_.enqueue_update_;
+    clear_has_value();
+  }
 }
 inline const ::cockroach::proto::EnqueueUpdateRequest& InternalRaftCommandUnion::enqueue_update() const {
-  // @@protoc_insertion_point(field_get:cockroach.proto.InternalRaftCommandUnion.enqueue_update)
-  return enqueue_update_ != NULL ? *enqueue_update_ : *default_instance_->enqueue_update_;
+  return has_enqueue_update() ? *value_.enqueue_update_
+                      : ::cockroach::proto::EnqueueUpdateRequest::default_instance();
 }
 inline ::cockroach::proto::EnqueueUpdateRequest* InternalRaftCommandUnion::mutable_enqueue_update() {
-  set_has_enqueue_update();
-  if (enqueue_update_ == NULL) enqueue_update_ = new ::cockroach::proto::EnqueueUpdateRequest;
-  // @@protoc_insertion_point(field_mutable:cockroach.proto.InternalRaftCommandUnion.enqueue_update)
-  return enqueue_update_;
+  if (!has_enqueue_update()) {
+    clear_value();
+    set_has_enqueue_update();
+    value_.enqueue_update_ = new ::cockroach::proto::EnqueueUpdateRequest;
+  }
+  return value_.enqueue_update_;
 }
 inline ::cockroach::proto::EnqueueUpdateRequest* InternalRaftCommandUnion::release_enqueue_update() {
-  clear_has_enqueue_update();
-  ::cockroach::proto::EnqueueUpdateRequest* temp = enqueue_update_;
-  enqueue_update_ = NULL;
-  return temp;
+  if (has_enqueue_update()) {
+    clear_has_value();
+    ::cockroach::proto::EnqueueUpdateRequest* temp = value_.enqueue_update_;
+    value_.enqueue_update_ = NULL;
+    return temp;
+  } else {
+    return NULL;
+  }
 }
 inline void InternalRaftCommandUnion::set_allocated_enqueue_update(::cockroach::proto::EnqueueUpdateRequest* enqueue_update) {
-  delete enqueue_update_;
-  enqueue_update_ = enqueue_update;
+  clear_value();
   if (enqueue_update) {
     set_has_enqueue_update();
-  } else {
-    clear_has_enqueue_update();
+    value_.enqueue_update_ = enqueue_update;
   }
-  // @@protoc_insertion_point(field_set_allocated:cockroach.proto.InternalRaftCommandUnion.enqueue_update)
 }
 
 // optional .cockroach.proto.EnqueueMessageRequest enqueue_message = 12;
 inline bool InternalRaftCommandUnion::has_enqueue_message() const {
-  return (_has_bits_[0] & 0x00000800u) != 0;
+  return value_case() == kEnqueueMessage;
 }
 inline void InternalRaftCommandUnion::set_has_enqueue_message() {
-  _has_bits_[0] |= 0x00000800u;
-}
-inline void InternalRaftCommandUnion::clear_has_enqueue_message() {
-  _has_bits_[0] &= ~0x00000800u;
+  _oneof_case_[0] = kEnqueueMessage;
 }
 inline void InternalRaftCommandUnion::clear_enqueue_message() {
-  if (enqueue_message_ != NULL) enqueue_message_->::cockroach::proto::EnqueueMessageRequest::Clear();
-  clear_has_enqueue_message();
+  if (has_enqueue_message()) {
+    delete value_.enqueue_message_;
+    clear_has_value();
+  }
 }
 inline const ::cockroach::proto::EnqueueMessageRequest& InternalRaftCommandUnion::enqueue_message() const {
-  // @@protoc_insertion_point(field_get:cockroach.proto.InternalRaftCommandUnion.enqueue_message)
-  return enqueue_message_ != NULL ? *enqueue_message_ : *default_instance_->enqueue_message_;
+  return has_enqueue_message() ? *value_.enqueue_message_
+                      : ::cockroach::proto::EnqueueMessageRequest::default_instance();
 }
 inline ::cockroach::proto::EnqueueMessageRequest* InternalRaftCommandUnion::mutable_enqueue_message() {
-  set_has_enqueue_message();
-  if (enqueue_message_ == NULL) enqueue_message_ = new ::cockroach::proto::EnqueueMessageRequest;
-  // @@protoc_insertion_point(field_mutable:cockroach.proto.InternalRaftCommandUnion.enqueue_message)
-  return enqueue_message_;
+  if (!has_enqueue_message()) {
+    clear_value();
+    set_has_enqueue_message();
+    value_.enqueue_message_ = new ::cockroach::proto::EnqueueMessageRequest;
+  }
+  return value_.enqueue_message_;
 }
 inline ::cockroach::proto::EnqueueMessageRequest* InternalRaftCommandUnion::release_enqueue_message() {
-  clear_has_enqueue_message();
-  ::cockroach::proto::EnqueueMessageRequest* temp = enqueue_message_;
-  enqueue_message_ = NULL;
-  return temp;
+  if (has_enqueue_message()) {
+    clear_has_value();
+    ::cockroach::proto::EnqueueMessageRequest* temp = value_.enqueue_message_;
+    value_.enqueue_message_ = NULL;
+    return temp;
+  } else {
+    return NULL;
+  }
 }
 inline void InternalRaftCommandUnion::set_allocated_enqueue_message(::cockroach::proto::EnqueueMessageRequest* enqueue_message) {
-  delete enqueue_message_;
-  enqueue_message_ = enqueue_message;
+  clear_value();
   if (enqueue_message) {
     set_has_enqueue_message();
-  } else {
-    clear_has_enqueue_message();
+    value_.enqueue_message_ = enqueue_message;
   }
-  // @@protoc_insertion_point(field_set_allocated:cockroach.proto.InternalRaftCommandUnion.enqueue_message)
 }
 
 // optional .cockroach.proto.BatchRequest batch = 30;
 inline bool InternalRaftCommandUnion::has_batch() const {
-  return (_has_bits_[0] & 0x00001000u) != 0;
+  return value_case() == kBatch;
 }
 inline void InternalRaftCommandUnion::set_has_batch() {
-  _has_bits_[0] |= 0x00001000u;
-}
-inline void InternalRaftCommandUnion::clear_has_batch() {
-  _has_bits_[0] &= ~0x00001000u;
+  _oneof_case_[0] = kBatch;
 }
 inline void InternalRaftCommandUnion::clear_batch() {
-  if (batch_ != NULL) batch_->::cockroach::proto::BatchRequest::Clear();
-  clear_has_batch();
+  if (has_batch()) {
+    delete value_.batch_;
+    clear_has_value();
+  }
 }
 inline const ::cockroach::proto::BatchRequest& InternalRaftCommandUnion::batch() const {
-  // @@protoc_insertion_point(field_get:cockroach.proto.InternalRaftCommandUnion.batch)
-  return batch_ != NULL ? *batch_ : *default_instance_->batch_;
+  return has_batch() ? *value_.batch_
+                      : ::cockroach::proto::BatchRequest::default_instance();
 }
 inline ::cockroach::proto::BatchRequest* InternalRaftCommandUnion::mutable_batch() {
-  set_has_batch();
-  if (batch_ == NULL) batch_ = new ::cockroach::proto::BatchRequest;
-  // @@protoc_insertion_point(field_mutable:cockroach.proto.InternalRaftCommandUnion.batch)
-  return batch_;
+  if (!has_batch()) {
+    clear_value();
+    set_has_batch();
+    value_.batch_ = new ::cockroach::proto::BatchRequest;
+  }
+  return value_.batch_;
 }
 inline ::cockroach::proto::BatchRequest* InternalRaftCommandUnion::release_batch() {
-  clear_has_batch();
-  ::cockroach::proto::BatchRequest* temp = batch_;
-  batch_ = NULL;
-  return temp;
+  if (has_batch()) {
+    clear_has_value();
+    ::cockroach::proto::BatchRequest* temp = value_.batch_;
+    value_.batch_ = NULL;
+    return temp;
+  } else {
+    return NULL;
+  }
 }
 inline void InternalRaftCommandUnion::set_allocated_batch(::cockroach::proto::BatchRequest* batch) {
-  delete batch_;
-  batch_ = batch;
+  clear_value();
   if (batch) {
     set_has_batch();
-  } else {
-    clear_has_batch();
+    value_.batch_ = batch;
   }
-  // @@protoc_insertion_point(field_set_allocated:cockroach.proto.InternalRaftCommandUnion.batch)
 }
 
 // optional .cockroach.proto.InternalRangeLookupRequest internal_range_lookup = 31;
 inline bool InternalRaftCommandUnion::has_internal_range_lookup() const {
-  return (_has_bits_[0] & 0x00002000u) != 0;
+  return value_case() == kInternalRangeLookup;
 }
 inline void InternalRaftCommandUnion::set_has_internal_range_lookup() {
-  _has_bits_[0] |= 0x00002000u;
-}
-inline void InternalRaftCommandUnion::clear_has_internal_range_lookup() {
-  _has_bits_[0] &= ~0x00002000u;
+  _oneof_case_[0] = kInternalRangeLookup;
 }
 inline void InternalRaftCommandUnion::clear_internal_range_lookup() {
-  if (internal_range_lookup_ != NULL) internal_range_lookup_->::cockroach::proto::InternalRangeLookupRequest::Clear();
-  clear_has_internal_range_lookup();
+  if (has_internal_range_lookup()) {
+    delete value_.internal_range_lookup_;
+    clear_has_value();
+  }
 }
 inline const ::cockroach::proto::InternalRangeLookupRequest& InternalRaftCommandUnion::internal_range_lookup() const {
-  // @@protoc_insertion_point(field_get:cockroach.proto.InternalRaftCommandUnion.internal_range_lookup)
-  return internal_range_lookup_ != NULL ? *internal_range_lookup_ : *default_instance_->internal_range_lookup_;
+  return has_internal_range_lookup() ? *value_.internal_range_lookup_
+                      : ::cockroach::proto::InternalRangeLookupRequest::default_instance();
 }
 inline ::cockroach::proto::InternalRangeLookupRequest* InternalRaftCommandUnion::mutable_internal_range_lookup() {
-  set_has_internal_range_lookup();
-  if (internal_range_lookup_ == NULL) internal_range_lookup_ = new ::cockroach::proto::InternalRangeLookupRequest;
-  // @@protoc_insertion_point(field_mutable:cockroach.proto.InternalRaftCommandUnion.internal_range_lookup)
-  return internal_range_lookup_;
+  if (!has_internal_range_lookup()) {
+    clear_value();
+    set_has_internal_range_lookup();
+    value_.internal_range_lookup_ = new ::cockroach::proto::InternalRangeLookupRequest;
+  }
+  return value_.internal_range_lookup_;
 }
 inline ::cockroach::proto::InternalRangeLookupRequest* InternalRaftCommandUnion::release_internal_range_lookup() {
-  clear_has_internal_range_lookup();
-  ::cockroach::proto::InternalRangeLookupRequest* temp = internal_range_lookup_;
-  internal_range_lookup_ = NULL;
-  return temp;
+  if (has_internal_range_lookup()) {
+    clear_has_value();
+    ::cockroach::proto::InternalRangeLookupRequest* temp = value_.internal_range_lookup_;
+    value_.internal_range_lookup_ = NULL;
+    return temp;
+  } else {
+    return NULL;
+  }
 }
 inline void InternalRaftCommandUnion::set_allocated_internal_range_lookup(::cockroach::proto::InternalRangeLookupRequest* internal_range_lookup) {
-  delete internal_range_lookup_;
-  internal_range_lookup_ = internal_range_lookup;
+  clear_value();
   if (internal_range_lookup) {
     set_has_internal_range_lookup();
-  } else {
-    clear_has_internal_range_lookup();
+    value_.internal_range_lookup_ = internal_range_lookup;
   }
-  // @@protoc_insertion_point(field_set_allocated:cockroach.proto.InternalRaftCommandUnion.internal_range_lookup)
 }
 
 // optional .cockroach.proto.InternalHeartbeatTxnRequest internal_heartbeat_txn = 32;
 inline bool InternalRaftCommandUnion::has_internal_heartbeat_txn() const {
-  return (_has_bits_[0] & 0x00004000u) != 0;
+  return value_case() == kInternalHeartbeatTxn;
 }
 inline void InternalRaftCommandUnion::set_has_internal_heartbeat_txn() {
-  _has_bits_[0] |= 0x00004000u;
-}
-inline void InternalRaftCommandUnion::clear_has_internal_heartbeat_txn() {
-  _has_bits_[0] &= ~0x00004000u;
+  _oneof_case_[0] = kInternalHeartbeatTxn;
 }
 inline void InternalRaftCommandUnion::clear_internal_heartbeat_txn() {
-  if (internal_heartbeat_txn_ != NULL) internal_heartbeat_txn_->::cockroach::proto::InternalHeartbeatTxnRequest::Clear();
-  clear_has_internal_heartbeat_txn();
+  if (has_internal_heartbeat_txn()) {
+    delete value_.internal_heartbeat_txn_;
+    clear_has_value();
+  }
 }
 inline const ::cockroach::proto::InternalHeartbeatTxnRequest& InternalRaftCommandUnion::internal_heartbeat_txn() const {
-  // @@protoc_insertion_point(field_get:cockroach.proto.InternalRaftCommandUnion.internal_heartbeat_txn)
-  return internal_heartbeat_txn_ != NULL ? *internal_heartbeat_txn_ : *default_instance_->internal_heartbeat_txn_;
+  return has_internal_heartbeat_txn() ? *value_.internal_heartbeat_txn_
+                      : ::cockroach::proto::InternalHeartbeatTxnRequest::default_instance();
 }
 inline ::cockroach::proto::InternalHeartbeatTxnRequest* InternalRaftCommandUnion::mutable_internal_heartbeat_txn() {
-  set_has_internal_heartbeat_txn();
-  if (internal_heartbeat_txn_ == NULL) internal_heartbeat_txn_ = new ::cockroach::proto::InternalHeartbeatTxnRequest;
-  // @@protoc_insertion_point(field_mutable:cockroach.proto.InternalRaftCommandUnion.internal_heartbeat_txn)
-  return internal_heartbeat_txn_;
+  if (!has_internal_heartbeat_txn()) {
+    clear_value();
+    set_has_internal_heartbeat_txn();
+    value_.internal_heartbeat_txn_ = new ::cockroach::proto::InternalHeartbeatTxnRequest;
+  }
+  return value_.internal_heartbeat_txn_;
 }
 inline ::cockroach::proto::InternalHeartbeatTxnRequest* InternalRaftCommandUnion::release_internal_heartbeat_txn() {
-  clear_has_internal_heartbeat_txn();
-  ::cockroach::proto::InternalHeartbeatTxnRequest* temp = internal_heartbeat_txn_;
-  internal_heartbeat_txn_ = NULL;
-  return temp;
+  if (has_internal_heartbeat_txn()) {
+    clear_has_value();
+    ::cockroach::proto::InternalHeartbeatTxnRequest* temp = value_.internal_heartbeat_txn_;
+    value_.internal_heartbeat_txn_ = NULL;
+    return temp;
+  } else {
+    return NULL;
+  }
 }
 inline void InternalRaftCommandUnion::set_allocated_internal_heartbeat_txn(::cockroach::proto::InternalHeartbeatTxnRequest* internal_heartbeat_txn) {
-  delete internal_heartbeat_txn_;
-  internal_heartbeat_txn_ = internal_heartbeat_txn;
+  clear_value();
   if (internal_heartbeat_txn) {
     set_has_internal_heartbeat_txn();
-  } else {
-    clear_has_internal_heartbeat_txn();
+    value_.internal_heartbeat_txn_ = internal_heartbeat_txn;
   }
-  // @@protoc_insertion_point(field_set_allocated:cockroach.proto.InternalRaftCommandUnion.internal_heartbeat_txn)
 }
 
 // optional .cockroach.proto.InternalPushTxnRequest internal_push_txn = 33;
 inline bool InternalRaftCommandUnion::has_internal_push_txn() const {
-  return (_has_bits_[0] & 0x00008000u) != 0;
+  return value_case() == kInternalPushTxn;
 }
 inline void InternalRaftCommandUnion::set_has_internal_push_txn() {
-  _has_bits_[0] |= 0x00008000u;
-}
-inline void InternalRaftCommandUnion::clear_has_internal_push_txn() {
-  _has_bits_[0] &= ~0x00008000u;
+  _oneof_case_[0] = kInternalPushTxn;
 }
 inline void InternalRaftCommandUnion::clear_internal_push_txn() {
-  if (internal_push_txn_ != NULL) internal_push_txn_->::cockroach::proto::InternalPushTxnRequest::Clear();
-  clear_has_internal_push_txn();
+  if (has_internal_push_txn()) {
+    delete value_.internal_push_txn_;
+    clear_has_value();
+  }
 }
 inline const ::cockroach::proto::InternalPushTxnRequest& InternalRaftCommandUnion::internal_push_txn() const {
-  // @@protoc_insertion_point(field_get:cockroach.proto.InternalRaftCommandUnion.internal_push_txn)
-  return internal_push_txn_ != NULL ? *internal_push_txn_ : *default_instance_->internal_push_txn_;
+  return has_internal_push_txn() ? *value_.internal_push_txn_
+                      : ::cockroach::proto::InternalPushTxnRequest::default_instance();
 }
 inline ::cockroach::proto::InternalPushTxnRequest* InternalRaftCommandUnion::mutable_internal_push_txn() {
-  set_has_internal_push_txn();
-  if (internal_push_txn_ == NULL) internal_push_txn_ = new ::cockroach::proto::InternalPushTxnRequest;
-  // @@protoc_insertion_point(field_mutable:cockroach.proto.InternalRaftCommandUnion.internal_push_txn)
-  return internal_push_txn_;
+  if (!has_internal_push_txn()) {
+    clear_value();
+    set_has_internal_push_txn();
+    value_.internal_push_txn_ = new ::cockroach::proto::InternalPushTxnRequest;
+  }
+  return value_.internal_push_txn_;
 }
 inline ::cockroach::proto::InternalPushTxnRequest* InternalRaftCommandUnion::release_internal_push_txn() {
-  clear_has_internal_push_txn();
-  ::cockroach::proto::InternalPushTxnRequest* temp = internal_push_txn_;
-  internal_push_txn_ = NULL;
-  return temp;
+  if (has_internal_push_txn()) {
+    clear_has_value();
+    ::cockroach::proto::InternalPushTxnRequest* temp = value_.internal_push_txn_;
+    value_.internal_push_txn_ = NULL;
+    return temp;
+  } else {
+    return NULL;
+  }
 }
 inline void InternalRaftCommandUnion::set_allocated_internal_push_txn(::cockroach::proto::InternalPushTxnRequest* internal_push_txn) {
-  delete internal_push_txn_;
-  internal_push_txn_ = internal_push_txn;
+  clear_value();
   if (internal_push_txn) {
     set_has_internal_push_txn();
-  } else {
-    clear_has_internal_push_txn();
+    value_.internal_push_txn_ = internal_push_txn;
   }
-  // @@protoc_insertion_point(field_set_allocated:cockroach.proto.InternalRaftCommandUnion.internal_push_txn)
 }
 
 // optional .cockroach.proto.InternalResolveIntentRequest internal_resolve_intent = 34;
 inline bool InternalRaftCommandUnion::has_internal_resolve_intent() const {
-  return (_has_bits_[0] & 0x00010000u) != 0;
+  return value_case() == kInternalResolveIntent;
 }
 inline void InternalRaftCommandUnion::set_has_internal_resolve_intent() {
-  _has_bits_[0] |= 0x00010000u;
-}
-inline void InternalRaftCommandUnion::clear_has_internal_resolve_intent() {
-  _has_bits_[0] &= ~0x00010000u;
+  _oneof_case_[0] = kInternalResolveIntent;
 }
 inline void InternalRaftCommandUnion::clear_internal_resolve_intent() {
-  if (internal_resolve_intent_ != NULL) internal_resolve_intent_->::cockroach::proto::InternalResolveIntentRequest::Clear();
-  clear_has_internal_resolve_intent();
+  if (has_internal_resolve_intent()) {
+    delete value_.internal_resolve_intent_;
+    clear_has_value();
+  }
 }
 inline const ::cockroach::proto::InternalResolveIntentRequest& InternalRaftCommandUnion::internal_resolve_intent() const {
-  // @@protoc_insertion_point(field_get:cockroach.proto.InternalRaftCommandUnion.internal_resolve_intent)
-  return internal_resolve_intent_ != NULL ? *internal_resolve_intent_ : *default_instance_->internal_resolve_intent_;
+  return has_internal_resolve_intent() ? *value_.internal_resolve_intent_
+                      : ::cockroach::proto::InternalResolveIntentRequest::default_instance();
 }
 inline ::cockroach::proto::InternalResolveIntentRequest* InternalRaftCommandUnion::mutable_internal_resolve_intent() {
-  set_has_internal_resolve_intent();
-  if (internal_resolve_intent_ == NULL) internal_resolve_intent_ = new ::cockroach::proto::InternalResolveIntentRequest;
-  // @@protoc_insertion_point(field_mutable:cockroach.proto.InternalRaftCommandUnion.internal_resolve_intent)
-  return internal_resolve_intent_;
+  if (!has_internal_resolve_intent()) {
+    clear_value();
+    set_has_internal_resolve_intent();
+    value_.internal_resolve_intent_ = new ::cockroach::proto::InternalResolveIntentRequest;
+  }
+  return value_.internal_resolve_intent_;
 }
 inline ::cockroach::proto::InternalResolveIntentRequest* InternalRaftCommandUnion::release_internal_resolve_intent() {
-  clear_has_internal_resolve_intent();
-  ::cockroach::proto::InternalResolveIntentRequest* temp = internal_resolve_intent_;
-  internal_resolve_intent_ = NULL;
-  return temp;
+  if (has_internal_resolve_intent()) {
+    clear_has_value();
+    ::cockroach::proto::InternalResolveIntentRequest* temp = value_.internal_resolve_intent_;
+    value_.internal_resolve_intent_ = NULL;
+    return temp;
+  } else {
+    return NULL;
+  }
 }
 inline void InternalRaftCommandUnion::set_allocated_internal_resolve_intent(::cockroach::proto::InternalResolveIntentRequest* internal_resolve_intent) {
-  delete internal_resolve_intent_;
-  internal_resolve_intent_ = internal_resolve_intent;
+  clear_value();
   if (internal_resolve_intent) {
     set_has_internal_resolve_intent();
-  } else {
-    clear_has_internal_resolve_intent();
+    value_.internal_resolve_intent_ = internal_resolve_intent;
   }
-  // @@protoc_insertion_point(field_set_allocated:cockroach.proto.InternalRaftCommandUnion.internal_resolve_intent)
 }
 
 // optional .cockroach.proto.InternalMergeRequest internal_merge_response = 35;
 inline bool InternalRaftCommandUnion::has_internal_merge_response() const {
-  return (_has_bits_[0] & 0x00020000u) != 0;
+  return value_case() == kInternalMergeResponse;
 }
 inline void InternalRaftCommandUnion::set_has_internal_merge_response() {
-  _has_bits_[0] |= 0x00020000u;
-}
-inline void InternalRaftCommandUnion::clear_has_internal_merge_response() {
-  _has_bits_[0] &= ~0x00020000u;
+  _oneof_case_[0] = kInternalMergeResponse;
 }
 inline void InternalRaftCommandUnion::clear_internal_merge_response() {
-  if (internal_merge_response_ != NULL) internal_merge_response_->::cockroach::proto::InternalMergeRequest::Clear();
-  clear_has_internal_merge_response();
+  if (has_internal_merge_response()) {
+    delete value_.internal_merge_response_;
+    clear_has_value();
+  }
 }
 inline const ::cockroach::proto::InternalMergeRequest& InternalRaftCommandUnion::internal_merge_response() const {
-  // @@protoc_insertion_point(field_get:cockroach.proto.InternalRaftCommandUnion.internal_merge_response)
-  return internal_merge_response_ != NULL ? *internal_merge_response_ : *default_instance_->internal_merge_response_;
+  return has_internal_merge_response() ? *value_.internal_merge_response_
+                      : ::cockroach::proto::InternalMergeRequest::default_instance();
 }
 inline ::cockroach::proto::InternalMergeRequest* InternalRaftCommandUnion::mutable_internal_merge_response() {
-  set_has_internal_merge_response();
-  if (internal_merge_response_ == NULL) internal_merge_response_ = new ::cockroach::proto::InternalMergeRequest;
-  // @@protoc_insertion_point(field_mutable:cockroach.proto.InternalRaftCommandUnion.internal_merge_response)
-  return internal_merge_response_;
+  if (!has_internal_merge_response()) {
+    clear_value();
+    set_has_internal_merge_response();
+    value_.internal_merge_response_ = new ::cockroach::proto::InternalMergeRequest;
+  }
+  return value_.internal_merge_response_;
 }
 inline ::cockroach::proto::InternalMergeRequest* InternalRaftCommandUnion::release_internal_merge_response() {
-  clear_has_internal_merge_response();
-  ::cockroach::proto::InternalMergeRequest* temp = internal_merge_response_;
-  internal_merge_response_ = NULL;
-  return temp;
+  if (has_internal_merge_response()) {
+    clear_has_value();
+    ::cockroach::proto::InternalMergeRequest* temp = value_.internal_merge_response_;
+    value_.internal_merge_response_ = NULL;
+    return temp;
+  } else {
+    return NULL;
+  }
 }
 inline void InternalRaftCommandUnion::set_allocated_internal_merge_response(::cockroach::proto::InternalMergeRequest* internal_merge_response) {
-  delete internal_merge_response_;
-  internal_merge_response_ = internal_merge_response;
+  clear_value();
   if (internal_merge_response) {
     set_has_internal_merge_response();
-  } else {
-    clear_has_internal_merge_response();
+    value_.internal_merge_response_ = internal_merge_response;
   }
-  // @@protoc_insertion_point(field_set_allocated:cockroach.proto.InternalRaftCommandUnion.internal_merge_response)
 }
 
 // optional .cockroach.proto.InternalTruncateLogRequest internal_truncate_log = 36;
 inline bool InternalRaftCommandUnion::has_internal_truncate_log() const {
-  return (_has_bits_[0] & 0x00040000u) != 0;
+  return value_case() == kInternalTruncateLog;
 }
 inline void InternalRaftCommandUnion::set_has_internal_truncate_log() {
-  _has_bits_[0] |= 0x00040000u;
-}
-inline void InternalRaftCommandUnion::clear_has_internal_truncate_log() {
-  _has_bits_[0] &= ~0x00040000u;
+  _oneof_case_[0] = kInternalTruncateLog;
 }
 inline void InternalRaftCommandUnion::clear_internal_truncate_log() {
-  if (internal_truncate_log_ != NULL) internal_truncate_log_->::cockroach::proto::InternalTruncateLogRequest::Clear();
-  clear_has_internal_truncate_log();
+  if (has_internal_truncate_log()) {
+    delete value_.internal_truncate_log_;
+    clear_has_value();
+  }
 }
 inline const ::cockroach::proto::InternalTruncateLogRequest& InternalRaftCommandUnion::internal_truncate_log() const {
-  // @@protoc_insertion_point(field_get:cockroach.proto.InternalRaftCommandUnion.internal_truncate_log)
-  return internal_truncate_log_ != NULL ? *internal_truncate_log_ : *default_instance_->internal_truncate_log_;
+  return has_internal_truncate_log() ? *value_.internal_truncate_log_
+                      : ::cockroach::proto::InternalTruncateLogRequest::default_instance();
 }
 inline ::cockroach::proto::InternalTruncateLogRequest* InternalRaftCommandUnion::mutable_internal_truncate_log() {
-  set_has_internal_truncate_log();
-  if (internal_truncate_log_ == NULL) internal_truncate_log_ = new ::cockroach::proto::InternalTruncateLogRequest;
-  // @@protoc_insertion_point(field_mutable:cockroach.proto.InternalRaftCommandUnion.internal_truncate_log)
-  return internal_truncate_log_;
+  if (!has_internal_truncate_log()) {
+    clear_value();
+    set_has_internal_truncate_log();
+    value_.internal_truncate_log_ = new ::cockroach::proto::InternalTruncateLogRequest;
+  }
+  return value_.internal_truncate_log_;
 }
 inline ::cockroach::proto::InternalTruncateLogRequest* InternalRaftCommandUnion::release_internal_truncate_log() {
-  clear_has_internal_truncate_log();
-  ::cockroach::proto::InternalTruncateLogRequest* temp = internal_truncate_log_;
-  internal_truncate_log_ = NULL;
-  return temp;
+  if (has_internal_truncate_log()) {
+    clear_has_value();
+    ::cockroach::proto::InternalTruncateLogRequest* temp = value_.internal_truncate_log_;
+    value_.internal_truncate_log_ = NULL;
+    return temp;
+  } else {
+    return NULL;
+  }
 }
 inline void InternalRaftCommandUnion::set_allocated_internal_truncate_log(::cockroach::proto::InternalTruncateLogRequest* internal_truncate_log) {
-  delete internal_truncate_log_;
-  internal_truncate_log_ = internal_truncate_log;
+  clear_value();
   if (internal_truncate_log) {
     set_has_internal_truncate_log();
-  } else {
-    clear_has_internal_truncate_log();
+    value_.internal_truncate_log_ = internal_truncate_log;
   }
-  // @@protoc_insertion_point(field_set_allocated:cockroach.proto.InternalRaftCommandUnion.internal_truncate_log)
 }
 
 // optional .cockroach.proto.InternalGCRequest internal_gc = 37;
 inline bool InternalRaftCommandUnion::has_internal_gc() const {
-  return (_has_bits_[0] & 0x00080000u) != 0;
+  return value_case() == kInternalGc;
 }
 inline void InternalRaftCommandUnion::set_has_internal_gc() {
-  _has_bits_[0] |= 0x00080000u;
-}
-inline void InternalRaftCommandUnion::clear_has_internal_gc() {
-  _has_bits_[0] &= ~0x00080000u;
+  _oneof_case_[0] = kInternalGc;
 }
 inline void InternalRaftCommandUnion::clear_internal_gc() {
-  if (internal_gc_ != NULL) internal_gc_->::cockroach::proto::InternalGCRequest::Clear();
-  clear_has_internal_gc();
+  if (has_internal_gc()) {
+    delete value_.internal_gc_;
+    clear_has_value();
+  }
 }
 inline const ::cockroach::proto::InternalGCRequest& InternalRaftCommandUnion::internal_gc() const {
-  // @@protoc_insertion_point(field_get:cockroach.proto.InternalRaftCommandUnion.internal_gc)
-  return internal_gc_ != NULL ? *internal_gc_ : *default_instance_->internal_gc_;
+  return has_internal_gc() ? *value_.internal_gc_
+                      : ::cockroach::proto::InternalGCRequest::default_instance();
 }
 inline ::cockroach::proto::InternalGCRequest* InternalRaftCommandUnion::mutable_internal_gc() {
-  set_has_internal_gc();
-  if (internal_gc_ == NULL) internal_gc_ = new ::cockroach::proto::InternalGCRequest;
-  // @@protoc_insertion_point(field_mutable:cockroach.proto.InternalRaftCommandUnion.internal_gc)
-  return internal_gc_;
+  if (!has_internal_gc()) {
+    clear_value();
+    set_has_internal_gc();
+    value_.internal_gc_ = new ::cockroach::proto::InternalGCRequest;
+  }
+  return value_.internal_gc_;
 }
 inline ::cockroach::proto::InternalGCRequest* InternalRaftCommandUnion::release_internal_gc() {
-  clear_has_internal_gc();
-  ::cockroach::proto::InternalGCRequest* temp = internal_gc_;
-  internal_gc_ = NULL;
-  return temp;
+  if (has_internal_gc()) {
+    clear_has_value();
+    ::cockroach::proto::InternalGCRequest* temp = value_.internal_gc_;
+    value_.internal_gc_ = NULL;
+    return temp;
+  } else {
+    return NULL;
+  }
 }
 inline void InternalRaftCommandUnion::set_allocated_internal_gc(::cockroach::proto::InternalGCRequest* internal_gc) {
-  delete internal_gc_;
-  internal_gc_ = internal_gc;
+  clear_value();
   if (internal_gc) {
     set_has_internal_gc();
-  } else {
-    clear_has_internal_gc();
+    value_.internal_gc_ = internal_gc;
   }
-  // @@protoc_insertion_point(field_set_allocated:cockroach.proto.InternalRaftCommandUnion.internal_gc)
 }
 
+inline bool InternalRaftCommandUnion::has_value() {
+  return value_case() != VALUE_NOT_SET;
+}
+inline void InternalRaftCommandUnion::clear_has_value() {
+  _oneof_case_[0] = VALUE_NOT_SET;
+}
+inline InternalRaftCommandUnion::ValueCase InternalRaftCommandUnion::value_case() const {
+  return InternalRaftCommandUnion::ValueCase(_oneof_case_[0]);
+}
 // -------------------------------------------------------------------
 
 // InternalRaftCommand


### PR DESCRIPTION
This does not actually affect the go generated code (either with
gogoproto or standard go protobufs) so we still need to use
gogoproto.onlyone, but the use of the standard 'oneof' may help other
languages.
