### PR TITLE
atomically update error in TestFailedReplicaChange

### DIFF
--- a/kv/dist_sender.go
+++ b/kv/dist_sender.go
@@ -365,7 +365,7 @@ func (ds *DistSender) Send(call *client.Call) {
 	for {
 		reply := call.Reply
 		err := util.RetryWithBackoff(retryOpts, func() (util.RetryStatus, error) {
-			reply.Header().Error = nil
+			reply.Header().Reset()
 			descNext = nil
 			desc, err := ds.rangeCache.LookupRangeDescriptor(args.Header().Key)
 			if err == nil {

--- a/proto/api.go
+++ b/proto/api.go
@@ -607,9 +607,7 @@ func (rh *ResponseHeader) SetGoError(err error) {
 		rh.Error = nil
 		return
 	}
-	if rh.Error == nil {
-		rh.Error = &Error{}
-	}
+	rh.Error = &Error{}
 	rh.Error.Message = err.Error()
 	if r, ok := err.(util.Retryable); ok {
 		rh.Error.Retryable = r.CanRetry()

--- a/proto/api_test.go
+++ b/proto/api_test.go
@@ -139,3 +139,13 @@ func TestCombinable(t *testing.T) {
 		t.Errorf("wanted %v, got %v", wantedDR, dr1)
 	}
 }
+
+func TestSetGoErrorCopy(t *testing.T) {
+	rh := ResponseHeader{}
+	err := &Error{Message: "test123"}
+	rh.SetGoError(err)
+	err.Message = "321tset"
+	if rh.Error.Message != "test123" {
+		t.Fatalf("SetGoError did not create a new error")
+	}
+}


### PR DESCRIPTION
possibly SetGoError() should always update errors atomically
to prevent similar issues in the future. I can add that to this
PR if it sounds like a good idea.

closes #525
