### PR TITLE
turn failure into warning for heartbeat test

### DIFF
--- a/multiraft/heartbeat_test.go
+++ b/multiraft/heartbeat_test.go
@@ -38,7 +38,7 @@ func processEventsUntil(ch <-chan *interceptMessage, stopper *util.Stopper,
 		defer stopper.SetStopped()
 	}
 	for {
-		t := time.After(time.Second)
+		t := time.After(500 * time.Millisecond)
 		select {
 		case e, ok := <-ch:
 			if !ok {
@@ -49,8 +49,7 @@ func processEventsUntil(ch <-chan *interceptMessage, stopper *util.Stopper,
 				return
 			}
 		case <-t:
-			log.Error("timeout when reading from intercept channel")
-			return
+			log.Warning("timeout when reading from intercept channel")
 		case <-stopper.ShouldStop():
 			return
 		}


### PR DESCRIPTION
the evidence still hints at the vms on CircleCI simply freezing
the thread for >1 sec:

```
I0401 15:24:08.772733      76 multiraft.go:448] node 1: group 1 got message 3->1 MsgAppResp Term:6 Log:0/11
I0401 15:24:08.772762      76 multiraft.go:448] node 1: group 1 got message 4->1 MsgAppResp Term:6 Log:0/11
I0401 15:24:08.772775      76 multiraft.go:448] node 1: group 1 got message 3->1 MsgHeartbeatResp Term:6 Log:0/0
I0401 15:24:10.219840      76 multiraft.go:448] node 1: group 1 got message 2->1 MsgAppResp Term:6 Log:0/11
I0401 15:24:10.219928      76 multiraft.go:448] node 1: group 1 got message 4->1 MsgHeartbeatResp Term:6 Log:0/0
I0401 15:24:10.219955      76 multiraft.go:448] node 1: group 1 got message 5->1 MsgHeartbeatResp Term:6 Log:0/0
```

with this change, what would previously abort the wait will
simply output warnings and give the test a change at running
through.

closes #473 (hopefully for good).
