### PR TITLE
resuscitate makefile `STATIC` flag

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -49,7 +49,9 @@ STANDARDTESTFLAGS := -logtostderr
 TESTFLAGS         :=
 
 ifeq ($(STATIC),1)
-GOFLAGS  += -tags netgo
+# The installsuffix makes sure we actually get the netgo build, see
+# https://github.com/golang/go/issues/9369#issuecomment-69864440
+GOFLAGS  += -a -tags netgo -installsuffix netgo
 LDFLAGS += -extldflags "-lm -lstdc++ -static"
 endif
 

--- a/Makefile
+++ b/Makefile
@@ -49,7 +49,8 @@ STANDARDTESTFLAGS := -logtostderr
 TESTFLAGS         :=
 
 ifeq ($(STATIC),1)
-GOFLAGS  += -a -tags netgo -ldflags '-extldflags "-lm -lstdc++ -static"'
+GOFLAGS  += -tags netgo
+LDFLAGS += -extldflags "-lm -lstdc++ -static"
 endif
 
 .PHONY: all

--- a/build/deploy/.dockerignore
+++ b/build/deploy/.dockerignore
@@ -1,0 +1,1 @@
+build/*.test

--- a/build/deploy/Dockerfile
+++ b/build/deploy/Dockerfile
@@ -3,8 +3,6 @@ FROM debian:jessie
 MAINTAINER Tobias Schottdorf <tobias.schottdorf@gmail.com>
 
 RUN mkdir -p /cockroach
-# TODO remove this next copy once the tests do not need the test cert any more.
-COPY build/resource /cockroach/resource
 COPY cockroach.sh test.sh build/cockroach /cockroach/
 # Set working directory  so that relative paths
 # are resolved appropriately when passed as args.

--- a/build/deploy/mkimage.sh
+++ b/build/deploy/mkimage.sh
@@ -21,9 +21,15 @@ trap cleanup EXIT
 
 mkdir -p build
 docker run -v "${DIR}/build":/build "cockroachdb/cockroach-dev" shell "cd /cockroach && \
-  rm -rf /build/*
-  make build testbuild && \
-  cp -r resource cockroach *.test /build/"
+  rm -rf /build/* && \
+  make testbuild && \
+  make STATIC=1 build && \
+  cp -r cockroach *.test /build/"
+
+# Make sure the created binary is statically linked.
+# Seems awkward to do this programmatically, but
+# this should work.
+file build/cockroach | grep 'statically linked' &>/dev/null
 
 docker build -t cockroachdb/cockroach .
 docker run -v "${DIR}/build":/build cockroachdb/cockroach


### PR DESCRIPTION
since the build info also passed -ldflags, STATIC=1 did not
have an effect any more.
