### PR TITLE
use a context struct for client.KV

### DIFF
--- a/client/call.go
+++ b/client/call.go
@@ -19,7 +19,6 @@ package client
 
 import (
 	"math/rand"
-	"time"
 
 	"github.com/cockroachdb/cockroach/proto"
 )
@@ -31,15 +30,6 @@ type Call struct {
 	Reply  proto.Response // The reply from the command
 }
 
-// now returns clock.Now() if clock is not nil; otherwise uses the
-// system wall time.
-func now(clock Clock) int64 {
-	if clock == nil {
-		return time.Now().UnixNano()
-	}
-	return clock.Now()
-}
-
 // resetClientCmdID sets the client command ID if the call is for a
 // read-write method. The client command ID provides idempotency
 // protection in conjunction with the server.
@@ -48,7 +38,7 @@ func (c *Call) resetClientCmdID(clock Clock) {
 	// mutations from being run multiple times on retries.
 	if proto.IsReadWrite(c.Method) {
 		c.Args.Header().CmdID = proto.ClientCmdID{
-			WallTime: now(clock),
+			WallTime: clock.Now(),
 			Random:   rand.Int63(),
 		}
 	}

--- a/client/client_test.go
+++ b/client/client_test.go
@@ -92,7 +92,7 @@ func createTestClient(addr string) *client.KV {
 	sender := newNotifyingSender(client.NewHTTPSender(addr, &http.Transport{
 		TLSClientConfig: rpc.LoadInsecureTLSConfig().Config(),
 	}))
-	return client.NewKV(sender, nil)
+	return client.NewKV(nil, sender)
 }
 
 // TestKVClientRetryNonTxn verifies that non-transactional client will
@@ -216,11 +216,10 @@ func TestKVClientRetryNonTxn(t *testing.T) {
 // TestKVClientRunTransaction verifies some simple transaction isolation
 // semantics.
 func TestKVClientRunTransaction(t *testing.T) {
-	client.TxnRetryOptions.Backoff = 1 * time.Millisecond
-
 	s := StartTestServer(t)
 	defer s.Stop()
 	kvClient := createTestClient(s.HTTPAddr)
+	kvClient.TxnRetryOptions.Backoff = 1 * time.Millisecond
 	kvClient.User = storage.UserRoot
 
 	for _, commit := range []bool{true, false} {
@@ -452,7 +451,7 @@ func ExampleKV_Call() {
 	sender := client.NewHTTPSender(serverAddress, &http.Transport{
 		TLSClientConfig: rpc.LoadInsecureTLSConfig().Config(),
 	})
-	kvClient := client.NewKV(sender, nil)
+	kvClient := client.NewKV(nil, sender)
 	kvClient.User = storage.UserRoot
 	defer kvClient.Close()
 
@@ -498,7 +497,7 @@ func ExampleKV_Prepare() {
 	sender := client.NewHTTPSender(serverAddress, &http.Transport{
 		TLSClientConfig: rpc.LoadInsecureTLSConfig().Config(),
 	})
-	kvClient := client.NewKV(sender, nil)
+	kvClient := client.NewKV(nil, sender)
 	kvClient.User = storage.UserRoot
 	defer kvClient.Close()
 
@@ -569,7 +568,7 @@ func ExampleKV_RunTransaction() {
 	sender := client.NewHTTPSender(serverAddress, &http.Transport{
 		TLSClientConfig: rpc.LoadInsecureTLSConfig().Config(),
 	})
-	kvClient := client.NewKV(sender, nil)
+	kvClient := client.NewKV(nil, sender)
 	kvClient.User = storage.UserRoot
 	defer kvClient.Close()
 

--- a/client/context.go
+++ b/client/context.go
@@ -23,13 +23,13 @@ import (
 	"github.com/cockroachdb/cockroach/util"
 )
 
-// A SystemClock is an implementation of the Clock interface that
+// A systemClock is an implementation of the Clock interface that
 // returns the node's wall time.
 // It is used by default when creating a new Context.
-type SystemClock struct{}
+type systemClock struct{}
 
 // Now implements the Clock interface, returning the node's wall time.
-func (*SystemClock) Now() int64 {
+func (systemClock) Now() int64 {
 	return time.Now().UnixNano()
 }
 
@@ -44,7 +44,7 @@ var (
 		Constant:    2,
 		MaxAttempts: 0, // retry indefinitely
 	}
-	defaultClock = Clock(&SystemClock{})
+	DefaultClock = systemClock{}
 )
 
 // A Context stores configuration to be used when creating a KV object.
@@ -58,7 +58,7 @@ type Context struct {
 // NewContext creates a new context with default values.
 func NewContext() *Context {
 	return &Context{
-		Clock:           defaultClock,
+		Clock:           DefaultClock,
 		TxnRetryOptions: DefaultTxnRetryOptions,
 	}
 }

--- a/client/context.go
+++ b/client/context.go
@@ -1,0 +1,64 @@
+// Copyright 2014 The Cockroach Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+// implied. See the License for the specific language governing
+// permissions and limitations under the License. See the AUTHORS file
+// for names of contributors.
+//
+// Author: Tobias Schottdorf (tobias.schottdorf@gmail.com)
+
+package client
+
+import (
+	"time"
+
+	"github.com/cockroachdb/cockroach/util"
+)
+
+// A SystemClock is an implementation of the Clock interface that
+// returns the node's wall time.
+// It is used by default when creating a new Context.
+type SystemClock struct{}
+
+// Now implements the Clock interface, returning the node's wall time.
+func (*SystemClock) Now() int64 {
+	return time.Now().UnixNano()
+}
+
+// Context defaults.
+var (
+	// DefaultTxnRetryOptions are the standard retry options used
+	// for transactions.
+	// This is exported for testing purposes only.
+	DefaultTxnRetryOptions = util.RetryOptions{
+		Backoff:     50 * time.Millisecond,
+		MaxBackoff:  5 * time.Second,
+		Constant:    2,
+		MaxAttempts: 0, // retry indefinitely
+	}
+	defaultClock = Clock(&SystemClock{})
+)
+
+// A Context stores configuration to be used when creating a KV object.
+type Context struct {
+	User            string
+	UserPriority    int32
+	TxnRetryOptions util.RetryOptions
+	Clock           Clock
+}
+
+// NewContext creates a new context with default values.
+func NewContext() *Context {
+	return &Context{
+		Clock:           defaultClock,
+		TxnRetryOptions: DefaultTxnRetryOptions,
+	}
+}

--- a/client/doc.go
+++ b/client/doc.go
@@ -29,7 +29,7 @@ The simplest way to use the client is through the Call method. Call
 synchronously invokes the method and returns the reply and an
 error. The example below shows a get and a put.
 
-  kv := client.NewKV(client.NewHTTPSender("localhost:8080", tlsConfig), nil)
+  kv := client.NewKV(nil, client.NewHTTPSender("localhost:8080", tlsConfig))
 
   getResp := &proto.GetResponse{}
   if err := kv.Call(proto.Get, proto.GetArgs(proto.Key("a")), getResp); err != nil {
@@ -51,7 +51,7 @@ transaction must be used to guarantee atomicity. A simple example of
 using the API which does two scans in parallel and then sends a
 sequence of puts in parallel:
 
-  kv := client.NewKV(client.NewHTTPSender("localhost:8080", tlsConfig), nil)
+  kv := client.NewKV(nil, client.NewHTTPSender("localhost:8080", tlsConfig))
 
   acResp, xzResp := &proto.ScanResponse{}, &proto.ScanResponse{}
   kv.Prepare(proto.Scan, proto.ScanArgs(proto.Key("a"), proto.Key("c").Next()), acResp)
@@ -87,7 +87,7 @@ given necessary transactional details, and conflicts are handled with
 backoff/retry loops and transaction restarts as necessary. An example
 of using transactions with parallel writes:
 
-  kv := client.NewKV(client.NewHTTPSender("localhost:8080", tlsConfig), nil)
+  kv := client.NewKV(nil, client.NewHTTPSender("localhost:8080", tlsConfig))
 
   opts := &client.TransactionOptions{Name: "test", Isolation: proto.SERIALIZABLE}
   err := kv.RunTransaction(opts, func(txn *client.KV) error {

--- a/kv/db_test.go
+++ b/kv/db_test.go
@@ -34,7 +34,7 @@ import (
 
 func createTestClient(addr string) *client.KV {
 	transport := &http.Transport{TLSClientConfig: rpc.LoadInsecureTLSConfig().Config()}
-	return client.NewKV(client.NewHTTPSender(addr, transport), nil)
+	return client.NewKV(nil, client.NewHTTPSender(addr, transport))
 }
 
 // TestKVDBCoverage verifies that all methods may be invoked on the

--- a/kv/dist_sender_server_test.go
+++ b/kv/dist_sender_server_test.go
@@ -50,7 +50,7 @@ func TestRangeLookupWithOpenTransaction(t *testing.T) {
 	sender := client.NewHTTPSender(s.HTTPAddr, &http.Transport{
 		TLSClientConfig: rpc.LoadInsecureTLSConfig().Config(),
 	})
-	db := client.NewKV(sender, nil)
+	db := client.NewKV(nil, sender)
 	db.User = storage.UserRoot
 	defer db.Close()
 
@@ -98,7 +98,7 @@ func setupMultipleRanges(t *testing.T) (*server.TestServer, *client.KV) {
 	sender := client.NewHTTPSender(s.HTTPAddr, &http.Transport{
 		TLSClientConfig: rpc.LoadInsecureTLSConfig().Config(),
 	})
-	db := client.NewKV(sender, nil)
+	db := client.NewKV(nil, sender)
 	db.User = storage.UserRoot
 
 	// Split the keyspace at "b".

--- a/kv/local_sender_test.go
+++ b/kv/local_sender_test.go
@@ -126,7 +126,7 @@ func TestLocalSenderLookupReplica(t *testing.T) {
 	clock := hlc.NewClock(manualClock.UnixNano)
 	eng := engine.NewInMem(proto.Attributes{}, 1<<20)
 	ls := NewLocalSender()
-	db := client.NewKV(NewTxnCoordSender(ls, clock, false), nil)
+	db := client.NewKV(nil, NewTxnCoordSender(ls, clock, false))
 	transport := multiraft.NewLocalRPCTransport()
 	defer transport.Close()
 	store := storage.NewStore(clock, eng, db, nil, transport, storage.TestStoreConfig)

--- a/kv/split_test.go
+++ b/kv/split_test.go
@@ -34,7 +34,7 @@ import (
 
 // setTestRetryOptions sets client retry options for speedier testing.
 func setTestRetryOptions() {
-	client.TxnRetryOptions = util.RetryOptions{
+	client.DefaultTxnRetryOptions = util.RetryOptions{
 		Backoff:    1 * time.Millisecond,
 		MaxBackoff: 10 * time.Millisecond,
 		Constant:   2,

--- a/kv/txn_coord_sender.go
+++ b/kv/txn_coord_sender.go
@@ -314,7 +314,7 @@ func (tc *TxnCoordSender) sendOne(call *client.Call) {
 		}
 		// Must not call Close() on this KV - that would call
 		// tc.Close().
-		tmpKV := client.NewKV(tc, nil)
+		tmpKV := client.NewKV(nil, tc)
 		tmpKV.User = call.Args.Header().User
 		tmpKV.UserPriority = call.Args.Header().GetUserPriority()
 		call.Reply.Reset()

--- a/kv/txn_coord_sender_test.go
+++ b/kv/txn_coord_sender_test.go
@@ -49,7 +49,7 @@ func createTestDB() (db *client.KV, eng engine.Engine, clock *hlc.Clock,
 	eng = engine.NewInMem(proto.Attributes{}, 50<<20)
 	lSender = NewLocalSender()
 	sender := NewTxnCoordSender(lSender, clock, false)
-	db = client.NewKV(sender, nil)
+	db = client.NewKV(nil, sender)
 	db.User = storage.UserRoot
 	transport = multiraft.NewLocalRPCTransport()
 	store := storage.NewStore(clock, eng, db, g, transport, storage.TestStoreConfig)

--- a/kv/txn_correctness_test.go
+++ b/kv/txn_correctness_test.go
@@ -41,14 +41,16 @@ import (
 // backoff/retry loops. If MaxAttempts is reached, transaction will
 // return retry error.
 func setCorrectnessRetryOptions(lSender *LocalSender) {
+	client.DefaultTxnRetryOptions = util.RetryOptions{
+		Backoff:     1 * time.Millisecond,
+		MaxBackoff:  5 * time.Millisecond,
+		Constant:    2,
+		MaxAttempts: 3,
+		UseV1Info:   true,
+	}
+
 	lSender.VisitStores(func(s *storage.Store) error {
-		s.RetryOpts = util.RetryOptions{
-			Backoff:     1 * time.Millisecond,
-			MaxBackoff:  10 * time.Millisecond,
-			Constant:    2,
-			MaxAttempts: 3,
-			UseV1Info:   true,
-		}
+		s.RetryOpts = client.DefaultTxnRetryOptions
 		return nil
 	})
 }

--- a/kv/txn_test.go
+++ b/kv/txn_test.go
@@ -209,7 +209,7 @@ func verifyUncertainty(concurrency int, maxOffset time.Duration, t *testing.T) {
 			txnClock.SetMaxOffset(maxOffset)
 
 			sender := NewTxnCoordSender(lSender, txnClock, false)
-			txnDB := client.NewKV(sender, nil)
+			txnDB := client.NewKV(nil, sender)
 			txnDB.User = storage.UserRoot
 
 			if err := txnDB.RunTransaction(txnOpts, func(txn *client.KV) error {
@@ -251,12 +251,12 @@ func TestTxnDBUncertainty(t *testing.T) {
 	// Make sure that we notice immediately if any kind of backing off is
 	// happening. Restore the previous options after this test is done to avoid
 	// interfering with other tests.
-	defaultRetryOptions := client.TxnRetryOptions
+	defaultRetryOptions := client.DefaultTxnRetryOptions
 	defer func() {
-		client.TxnRetryOptions = defaultRetryOptions
+		client.DefaultTxnRetryOptions = defaultRetryOptions
 	}()
-	client.TxnRetryOptions.Backoff = 100 * time.Second
-	client.TxnRetryOptions.MaxBackoff = 100 * time.Second
+	client.DefaultTxnRetryOptions.Backoff = 100 * time.Second
+	client.DefaultTxnRetryOptions.MaxBackoff = 100 * time.Second
 
 	// < 5ns means no uncertainty & no restarts.
 	verifyUncertainty(1, 3*time.Nanosecond, t)

--- a/rpc/client.go
+++ b/rpc/client.go
@@ -260,6 +260,8 @@ func (c *Client) heartbeat() error {
 		c.mu.Unlock()
 		c.remoteClocks.UpdateOffset(c.addr.String(), c.offset)
 		log.Warningf("client %s unhealthy after %s", c.Addr(), heartbeatInterval)
+	case <-c.Closed:
+		return util.Errorf("client is closed")
 	}
 
 	<-call.Done

--- a/server/cli/kv.go
+++ b/server/cli/kv.go
@@ -40,7 +40,7 @@ func makeKVClient() *client.KV {
 	transport := &http.Transport{
 		TLSClientConfig: rpc.LoadInsecureTLSConfig().Config(),
 	}
-	kv := client.NewKV(client.NewHTTPSender(Context.HTTP, transport), nil)
+	kv := client.NewKV(nil, client.NewHTTPSender(Context.HTTP, transport))
 	// TODO(pmattis): Initialize this to something more reasonable
 	kv.User = "root"
 	return kv

--- a/server/node.go
+++ b/server/node.go
@@ -116,7 +116,7 @@ func BootstrapCluster(clusterID string, eng engine.Engine) (*client.KV, error) {
 	clock := hlc.NewClock(hlc.UnixNano)
 	// Create a KV DB with a local sender.
 	lSender := kv.NewLocalSender()
-	localDB := client.NewKV(kv.NewTxnCoordSender(lSender, clock, false), nil)
+	localDB := client.NewKV(nil, kv.NewTxnCoordSender(lSender, clock, false))
 	// TODO(bdarnell): arrange to have the transport closed.
 	// The bootstrapping store will not connect to other nodes so its StoreConfig
 	// doesn't really matter.

--- a/server/node_test.go
+++ b/server/node_test.go
@@ -64,7 +64,7 @@ func createTestNode(addr net.Addr, engines []engine.Engine, gossipBS net.Addr, t
 		g.SetBootstrap([]net.Addr{gossipBS})
 		g.Start(rpcServer)
 	}
-	db := client.NewKV(kv.NewDistSender(clock, g), nil)
+	db := client.NewKV(nil, kv.NewDistSender(clock, g))
 	// TODO(bdarnell): arrange to have the transport closed.
 	node := NewNode(db, g, storage.TestStoreConfig, multiraft.NewLocalRPCTransport())
 	return rpcServer, clock, node

--- a/server/server.go
+++ b/server/server.go
@@ -113,7 +113,7 @@ func NewServer(ctx *Context) (*Server, error) {
 	// client to the key value database as well as
 	ds := kv.NewDistSender(s.clock, s.gossip)
 	sender := kv.NewTxnCoordSender(ds, s.clock, ctx.Linearizable)
-	s.kv = client.NewKV(sender, nil)
+	s.kv = client.NewKV(nil, sender)
 	s.kv.User = storage.UserRoot
 
 	s.raftTransport, err = newRPCTransport(s.gossip, s.rpc, rpcContext)

--- a/storage/client_test.go
+++ b/storage/client_test.go
@@ -72,7 +72,7 @@ func createTestStoreWithEngine(t *testing.T, eng engine.Engine, clock *hlc.Clock
 	g := gossip.New(rpcContext, gossip.TestInterval, "")
 	lSender := kv.NewLocalSender()
 	sender := kv.NewTxnCoordSender(lSender, clock, false)
-	db := client.NewKV(sender, nil)
+	db := client.NewKV(nil, sender)
 	db.User = storage.UserRoot
 	// TODO(bdarnell): arrange to have the transport closed.
 	store := storage.NewStore(clock, eng, db, g, multiraft.NewLocalRPCTransport(),
@@ -124,7 +124,7 @@ func (m *multiTestContext) Start(t *testing.T, numStores int) {
 	}
 	if m.db == nil {
 		txnSender := kv.NewTxnCoordSender(m.sender, m.clock, false)
-		m.db = client.NewKV(txnSender, nil)
+		m.db = client.NewKV(nil, txnSender)
 		m.db.User = storage.UserRoot
 	}
 

--- a/storage/range_test.go
+++ b/storage/range_test.go
@@ -139,7 +139,7 @@ func (tc *testContext) Start(t *testing.T) {
 				t.Fatal(err)
 			}
 		}
-		tc.store.db = client.NewKV(&testSender{store: tc.store}, nil)
+		tc.store.db = client.NewKV(nil, &testSender{store: tc.store})
 		if err := tc.store.Start(); err != nil {
 			t.Fatal(err)
 		}

--- a/storage/store_test.go
+++ b/storage/store_test.go
@@ -103,7 +103,7 @@ func createTestStore(t *testing.T) (*Store, *hlc.ManualClock) {
 	if err := store.Bootstrap(proto.StoreIdent{NodeID: 1, StoreID: 1}); err != nil {
 		t.Fatal(err)
 	}
-	store.db = client.NewKV(&testSender{store: store}, nil)
+	store.db = client.NewKV(nil, &testSender{store: store})
 	if err := store.BootstrapRange(); err != nil {
 		t.Fatal(err)
 	}


### PR DESCRIPTION
this came out of trying to untangle the `txn_correctness_test` from the rest (unsuccessfully), during which there were some oddities regarding parameter handling.

In this change, all `client.KV` options are collected into a `Context`, which is passed to a wrapped KV created during `kv.RunTransaction`.

This should be more failsafe and convenient to use.
