### PR TITLE
Change numeric format of keyMaxCapacity from decimal to hexadecimal

### DIFF
--- a/gossip/keys.go
+++ b/gossip/keys.go
@@ -50,9 +50,9 @@ const (
 	KeyNodeCount = "node-count"
 
 	// KeyNodeIDPrefix is the key prefix for gossiping node id
-	// addresses. The actual key is suffixed with the hexadecimal
+	// addresses. The actual key is suffixed with the decimal
 	// representation of the node id and the value is the host:port
-	// string address of the node. E.g. node-1bfa: fwd56.sjcb1:24001
+	// string address of the node. E.g. node-1002: fwd56.sjcb1:24001
 	KeyNodeIDPrefix = "node-"
 
 	// KeySentinel is a key for gossip which must not expire or else the
@@ -68,5 +68,5 @@ const (
 
 // MakeNodeIDGossipKey returns the gossip key for node ID info.
 func MakeNodeIDGossipKey(nodeID proto.NodeID) string {
-	return KeyNodeIDPrefix + strconv.FormatInt(int64(nodeID), 16)
+	return KeyNodeIDPrefix + strconv.FormatInt(int64(nodeID), 10)
 }

--- a/server/node.go
+++ b/server/node.go
@@ -375,8 +375,8 @@ func (n *Node) gossipCapacities() {
 		}
 		// Unique gossip key per store.
 		keyMaxCapacity := gossip.KeyMaxAvailCapacityPrefix +
-			strconv.FormatInt(int64(storeDesc.Node.NodeID), 10) + "-" +
-			strconv.FormatInt(int64(storeDesc.StoreID), 10)
+			strconv.FormatInt(int64(storeDesc.Node.NodeID), 16) + "-" +
+			strconv.FormatInt(int64(storeDesc.StoreID), 16)
 		// Gossip store descriptor.
 		n.gossip.AddInfo(keyMaxCapacity, *storeDesc, ttlCapacityGossip)
 		return nil

--- a/server/node.go
+++ b/server/node.go
@@ -375,8 +375,8 @@ func (n *Node) gossipCapacities() {
 		}
 		// Unique gossip key per store.
 		keyMaxCapacity := gossip.KeyMaxAvailCapacityPrefix +
-			strconv.FormatInt(int64(storeDesc.Node.NodeID), 16) + "-" +
-			strconv.FormatInt(int64(storeDesc.StoreID), 16)
+			strconv.FormatInt(int64(storeDesc.Node.NodeID), 10) + "-" +
+			strconv.FormatInt(int64(storeDesc.StoreID), 10)
 		// Gossip store descriptor.
 		n.gossip.AddInfo(keyMaxCapacity, *storeDesc, ttlCapacityGossip)
 		return nil


### PR DESCRIPTION
In gossip/key.go, MakeNodeIDGossipKey() use hexadecimal as the numeric format, and in the definition of KeyNodeIDPrefix, Hexadecimal is also required explicitly.

But when node starts gossip, it uses decimal as numeric format, better to change it to hexadecimal also.
