### PR TITLE
Enables gogoproto custom type Key to be used with auto-generated marshal.

### DIFF
--- a/proto/config.pb.go
+++ b/proto/config.pb.go
@@ -9,6 +9,10 @@ import math "math"
 
 // discarding unused import gogoproto "gogoproto/gogo.pb"
 
+import io "io"
+import fmt "fmt"
+import github_com_gogo_protobuf_proto "github.com/gogo/protobuf/proto"
+
 // Reference imports to suppress errors if they are not otherwise used.
 var _ = proto1.Marshal
 var _ = math.Inf
@@ -238,4 +242,288 @@ func (m *RangeTreeNode) GetBlack() bool {
 }
 
 func init() {
+}
+func (m *RangeTreeNode) Unmarshal(data []byte) error {
+	l := len(data)
+	index := 0
+	for index < l {
+		var wire uint64
+		for shift := uint(0); ; shift += 7 {
+			if index >= l {
+				return io.ErrUnexpectedEOF
+			}
+			b := data[index]
+			index++
+			wire |= (uint64(b) & 0x7F) << shift
+			if b < 0x80 {
+				break
+			}
+		}
+		fieldNum := int32(wire >> 3)
+		wireType := int(wire & 0x7)
+		switch fieldNum {
+		case 1:
+			if wireType != 2 {
+				return fmt.Errorf("proto: wrong wireType = %d for field Key", wireType)
+			}
+			var byteLen int
+			for shift := uint(0); ; shift += 7 {
+				if index >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := data[index]
+				index++
+				byteLen |= (int(b) & 0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			postIndex := index + byteLen
+			if postIndex > l {
+				return io.ErrUnexpectedEOF
+			}
+			if err := m.Key.Unmarshal(data[index:postIndex]); err != nil {
+				return err
+			}
+			index = postIndex
+		case 2:
+			if wireType != 0 {
+				return fmt.Errorf("proto: wrong wireType = %d for field Black", wireType)
+			}
+			var v int
+			for shift := uint(0); ; shift += 7 {
+				if index >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := data[index]
+				index++
+				v |= (int(b) & 0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			m.Black = bool(v != 0)
+		case 3:
+			if wireType != 2 {
+				return fmt.Errorf("proto: wrong wireType = %d for field ParentKey", wireType)
+			}
+			var byteLen int
+			for shift := uint(0); ; shift += 7 {
+				if index >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := data[index]
+				index++
+				byteLen |= (int(b) & 0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			postIndex := index + byteLen
+			if postIndex > l {
+				return io.ErrUnexpectedEOF
+			}
+			if err := m.ParentKey.Unmarshal(data[index:postIndex]); err != nil {
+				return err
+			}
+			index = postIndex
+		case 4:
+			if wireType != 2 {
+				return fmt.Errorf("proto: wrong wireType = %d for field LeftKey", wireType)
+			}
+			var byteLen int
+			for shift := uint(0); ; shift += 7 {
+				if index >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := data[index]
+				index++
+				byteLen |= (int(b) & 0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			postIndex := index + byteLen
+			if postIndex > l {
+				return io.ErrUnexpectedEOF
+			}
+			m.LeftKey = &Key{}
+			if err := m.LeftKey.Unmarshal(data[index:postIndex]); err != nil {
+				return err
+			}
+			index = postIndex
+		case 5:
+			if wireType != 2 {
+				return fmt.Errorf("proto: wrong wireType = %d for field RightKey", wireType)
+			}
+			var byteLen int
+			for shift := uint(0); ; shift += 7 {
+				if index >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := data[index]
+				index++
+				byteLen |= (int(b) & 0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			postIndex := index + byteLen
+			if postIndex > l {
+				return io.ErrUnexpectedEOF
+			}
+			m.RightKey = &Key{}
+			if err := m.RightKey.Unmarshal(data[index:postIndex]); err != nil {
+				return err
+			}
+			index = postIndex
+		default:
+			var sizeOfWire int
+			for {
+				sizeOfWire++
+				wire >>= 7
+				if wire == 0 {
+					break
+				}
+			}
+			index -= sizeOfWire
+			skippy, err := github_com_gogo_protobuf_proto.Skip(data[index:])
+			if err != nil {
+				return err
+			}
+			if (index + skippy) > l {
+				return io.ErrUnexpectedEOF
+			}
+			m.XXX_unrecognized = append(m.XXX_unrecognized, data[index:index+skippy]...)
+			index += skippy
+		}
+	}
+	return nil
+}
+func (m *RangeTreeNode) Size() (n int) {
+	var l int
+	_ = l
+	l = m.Key.Size()
+	n += 1 + l + sovConfig(uint64(l))
+	n += 2
+	l = m.ParentKey.Size()
+	n += 1 + l + sovConfig(uint64(l))
+	if m.LeftKey != nil {
+		l = m.LeftKey.Size()
+		n += 1 + l + sovConfig(uint64(l))
+	}
+	if m.RightKey != nil {
+		l = m.RightKey.Size()
+		n += 1 + l + sovConfig(uint64(l))
+	}
+	if m.XXX_unrecognized != nil {
+		n += len(m.XXX_unrecognized)
+	}
+	return n
+}
+
+func sovConfig(x uint64) (n int) {
+	for {
+		n++
+		x >>= 7
+		if x == 0 {
+			break
+		}
+	}
+	return n
+}
+func sozConfig(x uint64) (n int) {
+	return sovConfig(uint64((x << 1) ^ uint64((int64(x) >> 63))))
+}
+func (m *RangeTreeNode) Marshal() (data []byte, err error) {
+	size := m.Size()
+	data = make([]byte, size)
+	n, err := m.MarshalTo(data)
+	if err != nil {
+		return nil, err
+	}
+	return data[:n], nil
+}
+
+func (m *RangeTreeNode) MarshalTo(data []byte) (n int, err error) {
+	var i int
+	_ = i
+	var l int
+	_ = l
+	data[i] = 0xa
+	i++
+	i = encodeVarintConfig(data, i, uint64(m.Key.Size()))
+	n1, err := m.Key.MarshalTo(data[i:])
+	if err != nil {
+		return 0, err
+	}
+	i += n1
+	data[i] = 0x10
+	i++
+	if m.Black {
+		data[i] = 1
+	} else {
+		data[i] = 0
+	}
+	i++
+	data[i] = 0x1a
+	i++
+	i = encodeVarintConfig(data, i, uint64(m.ParentKey.Size()))
+	n2, err := m.ParentKey.MarshalTo(data[i:])
+	if err != nil {
+		return 0, err
+	}
+	i += n2
+	if m.LeftKey != nil {
+		data[i] = 0x22
+		i++
+		i = encodeVarintConfig(data, i, uint64(m.LeftKey.Size()))
+		n3, err := m.LeftKey.MarshalTo(data[i:])
+		if err != nil {
+			return 0, err
+		}
+		i += n3
+	}
+	if m.RightKey != nil {
+		data[i] = 0x2a
+		i++
+		i = encodeVarintConfig(data, i, uint64(m.RightKey.Size()))
+		n4, err := m.RightKey.MarshalTo(data[i:])
+		if err != nil {
+			return 0, err
+		}
+		i += n4
+	}
+	if m.XXX_unrecognized != nil {
+		i += copy(data[i:], m.XXX_unrecognized)
+	}
+	return i, nil
+}
+
+func encodeFixed64Config(data []byte, offset int, v uint64) int {
+	data[offset] = uint8(v)
+	data[offset+1] = uint8(v >> 8)
+	data[offset+2] = uint8(v >> 16)
+	data[offset+3] = uint8(v >> 24)
+	data[offset+4] = uint8(v >> 32)
+	data[offset+5] = uint8(v >> 40)
+	data[offset+6] = uint8(v >> 48)
+	data[offset+7] = uint8(v >> 56)
+	return offset + 8
+}
+func encodeFixed32Config(data []byte, offset int, v uint32) int {
+	data[offset] = uint8(v)
+	data[offset+1] = uint8(v >> 8)
+	data[offset+2] = uint8(v >> 16)
+	data[offset+3] = uint8(v >> 24)
+	return offset + 4
+}
+func encodeVarintConfig(data []byte, offset int, v uint64) int {
+	for v >= 1<<7 {
+		data[offset] = uint8(v&0x7f | 0x80)
+		v >>= 7
+		offset++
+	}
+	data[offset] = uint8(v)
+	return offset + 1
 }

--- a/proto/config.proto
+++ b/proto/config.proto
@@ -103,6 +103,9 @@ message RangeTree {
 
 // RangeTreeNode holds the configuration for each node of the Red-Black Tree that references all ranges.
 message RangeTreeNode {
+  option (gogoproto.marshaler) = true;
+  option (gogoproto.sizer) = true;
+  option (gogoproto.unmarshaler) = true;
   optional bytes key = 1 [(gogoproto.nullable) = false, (gogoproto.customtype) = "Key"];
 
   // Color is black if true, red if false.

--- a/proto/data_test.go
+++ b/proto/data_test.go
@@ -229,6 +229,25 @@ func TestValueBothBytesAndIntegerSet(t *testing.T) {
 	}
 }
 
+// TestUnmarshal expects key unmarshaling to never return nil.
+func TestUnmarshal(t *testing.T) {
+	testCases := []struct {
+		input       []byte
+		expectedNil bool
+	}{
+		{[]byte(nil), false},
+		{[]byte(""), false},
+		{[]byte("test"), false},
+	}
+	for i, c := range testCases {
+		key := &Key{}
+		key.Unmarshal(c.input)
+		if (key == nil) != c.expectedNil {
+			t.Errorf("%d: Expect result to not to be %v.", i, c.expectedNil)
+		}
+	}
+}
+
 // TestValueZeroIntegerSerialization verifies that a value with
 // integer=0 set can be marshalled and unmarshalled successfully.
 // This tests exists because gob serialization treats integers

--- a/storage/engine/cockroach/proto/config.pb.cc
+++ b/storage/engine/cockroach/proto/config.pb.cc
@@ -294,11 +294,11 @@ void protobuf_AddDesc_cockroach_2fproto_2fconfig_2eproto() {
     "\"range_max_bytes,omitempty\"\022D\n\002gc\030\004 \001(\0132"
     "\031.cockroach.proto.GCPolicyB\035\342\336\037\002GC\362\336\037\023ya"
     "ml:\"gc,omitempty\"\"*\n\tRangeTree\022\035\n\010root_k"
-    "ey\030\001 \001(\014B\013\310\336\037\000\332\336\037\003Key\"\226\001\n\rRangeTreeNode\022"
+    "ey\030\001 \001(\014B\013\310\336\037\000\332\336\037\003Key\"\244\001\n\rRangeTreeNode\022"
     "\030\n\003key\030\001 \001(\014B\013\310\336\037\000\332\336\037\003Key\022\023\n\005black\030\002 \001(\010"
     "B\004\310\336\037\000\022\037\n\nparent_key\030\003 \001(\014B\013\310\336\037\000\332\336\037\003Key\022"
     "\031\n\010left_key\030\004 \001(\014B\007\332\336\037\003Key\022\032\n\tright_key\030"
-    "\005 \001(\014B\007\332\336\037\003KeyB\007Z\005proto", 1183);
+    "\005 \001(\014B\007\332\336\037\003Key:\014\210\241\037\001\240\241\037\001\220\241\037\001B\007Z\005proto", 1197);
   ::google::protobuf::MessageFactory::InternalRegisterGeneratedFile(
     "cockroach/proto/config.proto", &protobuf_RegisterTypes);
   Attributes::default_instance_ = new Attributes();

--- a/storage/range_tree_test.go
+++ b/storage/range_tree_test.go
@@ -52,8 +52,9 @@ func TestSetupRangeTree(t *testing.T) {
 
 	// Check to make sure the first range tree node is stored correctly.
 	expectedNode := &proto.RangeTreeNode{
-		Key:   engine.KeyMin,
-		Black: true,
+		Key:       engine.KeyMin,
+		Black:     true,
+		ParentKey: engine.KeyMin,
 	}
 	// To read the local key, we need to use MVCCGetProto.
 	actualNode := &proto.RangeTreeNode{}


### PR DESCRIPTION
This also fixes a bug in (k *Key) Unmarshal(bytes []byte).
