### PR TITLE
Set Header.RaftID in RPCs sent by DistSender.

### DIFF
--- a/kv/dist_sender.go
+++ b/kv/dist_sender.go
@@ -291,6 +291,11 @@ func (ds *DistSender) sendRPC(desc *proto.RangeDescriptor, method string, args p
 		return noNodeAddrsAvailError{}
 	}
 
+	// TODO(pmattis): This needs to be tested. If it isn't set we'll
+	// still route the request appropriately by key, but won't receive
+	// RangeNotFoundErrors.
+	args.Header().RaftID = desc.RaftID
+
 	// Set RPC opts with stipulation that one of N RPCs must succeed.
 	rpcOpts := rpc.Options{
 		N:               1,

--- a/storage/engine/keys.go
+++ b/storage/engine/keys.go
@@ -220,12 +220,6 @@ func RangeMetaKey(key proto.Key) proto.Key {
 	return KeyMin
 }
 
-// RangeMetaLookupKey returns the metadata key at which this range
-// descriptor should be stored as a value.
-func RangeMetaLookupKey(r *proto.RangeDescriptor) proto.Key {
-	return RangeMetaKey(r.EndKey)
-}
-
 // ValidateRangeMetaKey validates that the given key is a valid Range Metadata
 // key. It must have an appropriate metadata range prefix, and the original key
 // value must be less than KeyMax. As a special case, KeyMin is considered a

--- a/storage/range.go
+++ b/storage/range.go
@@ -1077,6 +1077,13 @@ func (r *Range) EnqueueMessage(batch engine.Engine, args *proto.EnqueueMessageRe
 // ordinary key which was originally used to generate the Range Metadata Key
 // sent to InternalRangeLookup.
 //
+// The "Range Metadata Key" for a range is built by appending the end key of
+// the range to the meta[12] prefix because the RocksDB iterator only supports
+// a Seek() interface which acts as a Ceil(). Using the start key of the range
+// would cause Seek() to find the key after the meta indexing record we're
+// looking for, which would result in having to back the iterator up, an option
+// which is both less efficient and not available in all cases.
+//
 // This method has an important optimization: instead of just returning the
 // request RangeDescriptor, it also returns a slice of additional range
 // descriptors immediately consecutive to the desired RangeDescriptor. This is

--- a/storage/store.go
+++ b/storage/store.go
@@ -631,12 +631,14 @@ func (s *Store) BootstrapRange() error {
 	if err := engine.MVCCPutProto(batch, ms, engine.RangeLastVerificationTimestampKey(desc.RaftID), proto.ZeroTimestamp, nil, &now); err != nil {
 		return err
 	}
-	// Range addressing for meta1.
-	if err := engine.MVCCPutProto(batch, ms, engine.MakeKey(engine.KeyMeta1Prefix, engine.KeyMax), now, nil, desc); err != nil {
+	// Range addressing for meta2.
+	meta2Key := engine.RangeMetaKey(engine.KeyMax)
+	if err := engine.MVCCPutProto(batch, ms, meta2Key, now, nil, desc); err != nil {
 		return err
 	}
-	// Range addressing for meta2.
-	if err := engine.MVCCPutProto(batch, ms, engine.MakeKey(engine.KeyMeta2Prefix, engine.KeyMax), now, nil, desc); err != nil {
+	// Range addressing for meta1.
+	meta1Key := engine.RangeMetaKey(meta2Key)
+	if err := engine.MVCCPutProto(batch, ms, meta1Key, now, nil, desc); err != nil {
 		return err
 	}
 	// Accounting config.


### PR DESCRIPTION
This speeds up handling of RPCs on the server since the range can be
looked up by ID instead of by key. It also allows DistSender to
determine when its range descriptor cache is out of date since the
recipient of the rpc will return an error causing the cache entry to be
evicted if the range does not exist on the node.

Note quite sure how to test this. Thoughts?
