### PR TITLE
clean up gossip key handling

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -40,7 +40,7 @@ export CGO_LDFLAGS :=-g
 #   make test PKG=./storage TESTFLAGS=--vmodule=multiraft=1
 PKG          := "./..."
 TESTS        := ".*"
-TESTTIMEOUT  := 10s
+TESTTIMEOUT  := 15s
 RACETIMEOUT  := 1m
 BENCHTIMEOUT := 5m
 # STANDARDTESTFLAGS contains flags that you probably don't want to override;

--- a/kv/dist_sender.go
+++ b/kv/dist_sender.go
@@ -176,7 +176,7 @@ func (ds *DistSender) verifyPermissions(method string, header *proto.RequestHead
 // nodeIDToAddr uses the gossip network to translate from node ID
 // to a host:port address pair.
 func (ds *DistSender) nodeIDToAddr(nodeID proto.NodeID) (net.Addr, error) {
-	nodeIDKey := gossip.MakeNodeIDGossipKey(nodeID)
+	nodeIDKey := gossip.MakeNodeIDKey(nodeID)
 	info, err := ds.gossip.GetInfo(nodeIDKey)
 	if info == nil || err != nil {
 		return nil, util.Errorf("Unable to lookup address for node: %d. Error: %s", nodeID, err)

--- a/proto/config.go
+++ b/proto/config.go
@@ -22,6 +22,7 @@ import (
 	"bytes"
 	"fmt"
 	"sort"
+	"strconv"
 	"strings"
 
 	"github.com/cockroachdb/cockroach/util"
@@ -30,6 +31,12 @@ import (
 
 // NodeID is a custom type for a cockroach node ID. (not a raft node ID)
 type NodeID int32
+
+// String implements the fmt.Stringer interface.
+// It is used to format the ID for use in Gossip keys.
+func (n NodeID) String() string {
+	return strconv.FormatInt(int64(n), 10)
+}
 
 // Marshal implements the gogoproto Marshaler interface.
 func (n NodeID) Marshal() ([]byte, error) {
@@ -48,6 +55,12 @@ func (n *NodeID) Unmarshal(bytes []byte) error {
 
 // StoreID is a custom type for a cockroach store ID.
 type StoreID int32
+
+// String implements the fmt.Stringer interface.
+// It is used to format the ID for use in Gossip keys.
+func (n StoreID) String() string {
+	return strconv.FormatInt(int64(n), 10)
+}
 
 // Marshal implements the gogoproto Marshaler interface.
 func (n StoreID) Marshal() ([]byte, error) {

--- a/run/local-cluster.sh
+++ b/run/local-cluster.sh
@@ -42,7 +42,7 @@ else
 fi
 
 # Make sure to clean up any remaining containers
-$0 stop
+./$(basename $0) stop
 # Doing this here only so that after a cluster has been started and stopped,
 # the containers are still available for debugging.
 echo "Removing any old containers..."
@@ -165,7 +165,7 @@ for ATTEMPT in $(seq 1 $MAX_WAIT); do
     GOSSIP_URL="$DOCKERHOST:${HTTP_PORTS[$i]}/_status/gossip"
     GOSSIP=$(curl --noproxy '*' -s $GOSSIP_URL)
     for j in $(seq 1 $((2*NODES))); do
-      if [[ ! -z $(echo $GOSSIP | grep "node-$j") ]]; then
+      if [[ ! -z $(echo $GOSSIP | grep "node:$j") ]]; then
         FOUND=$((FOUND+1))
         FOUND_NAMES="$FOUND_NAMES node-$j"
       fi

--- a/server/node.go
+++ b/server/node.go
@@ -288,7 +288,7 @@ func (n *Node) bootstrapStores(bootstraps *list.List) {
 			log.Fatal(err)
 		}
 		// Gossip node address keyed by node ID.
-		nodeIDKey := gossip.MakeNodeIDGossipKey(n.Descriptor.NodeID)
+		nodeIDKey := gossip.MakeNodeIDKey(n.Descriptor.NodeID)
 		if err := n.gossip.AddInfo(nodeIDKey, n.Descriptor.Address, ttlNodeIDGossip); err != nil {
 			log.Errorf("couldn't gossip address for node %d: %v", n.Descriptor.NodeID, err)
 		}
@@ -341,7 +341,7 @@ func (n *Node) connectGossip() {
 
 	// Gossip node address keyed by node ID.
 	if n.Descriptor.NodeID != 0 {
-		nodeIDKey := gossip.MakeNodeIDGossipKey(n.Descriptor.NodeID)
+		nodeIDKey := gossip.MakeNodeIDKey(n.Descriptor.NodeID)
 		if err := n.gossip.AddInfo(nodeIDKey, n.Descriptor.Address, ttlNodeIDGossip); err != nil {
 			log.Errorf("couldn't gossip address for node %d: %v", n.Descriptor.NodeID, err)
 		}
@@ -374,9 +374,7 @@ func (n *Node) gossipCapacities() {
 			return nil
 		}
 		// Unique gossip key per store.
-		keyMaxCapacity := gossip.KeyMaxAvailCapacityPrefix +
-			strconv.FormatInt(int64(storeDesc.Node.NodeID), 10) + "-" +
-			strconv.FormatInt(int64(storeDesc.StoreID), 10)
+		keyMaxCapacity := gossip.MakeMaxAvailCapacityKey(storeDesc.Node.NodeID, storeDesc.StoreID)
 		// Gossip store descriptor.
 		n.gossip.AddInfo(keyMaxCapacity, *storeDesc, ttlCapacityGossip)
 		return nil

--- a/server/node_test.go
+++ b/server/node_test.go
@@ -189,8 +189,8 @@ func TestNodeJoin(t *testing.T) {
 	}
 
 	// Verify node1 sees node2 via gossip and vice versa.
-	node1Key := gossip.MakeNodeIDGossipKey(node1.Descriptor.NodeID)
-	node2Key := gossip.MakeNodeIDGossipKey(node2.Descriptor.NodeID)
+	node1Key := gossip.MakeNodeIDKey(node1.Descriptor.NodeID)
+	node2Key := gossip.MakeNodeIDKey(node2.Descriptor.NodeID)
 	if err := util.IsTrueWithin(func() bool {
 		if val, err := node1.gossip.GetInfo(node2Key); err != nil {
 			return false

--- a/server/raft_transport.go
+++ b/server/raft_transport.go
@@ -104,7 +104,7 @@ func (t *rpcTransport) Stop(id multiraft.NodeID) {
 }
 
 func (t *rpcTransport) nodeIDToAddr(nodeID proto.NodeID) (net.Addr, error) {
-	nodeIDKey := gossip.MakeNodeIDGossipKey(nodeID)
+	nodeIDKey := gossip.MakeNodeIDKey(nodeID)
 	info, err := t.gossip.GetInfo(nodeIDKey)
 	if info == nil || err != nil {
 		return nil, util.Errorf("Unable to lookup address for node: %d. Error: %s", nodeID, err)

--- a/server/raft_transport_test.go
+++ b/server/raft_transport_test.go
@@ -18,7 +18,6 @@
 package server
 
 import (
-	"fmt"
 	"testing"
 	"time"
 
@@ -42,7 +41,7 @@ func (s ChannelServer) RaftMessage(req *multiraft.RaftMessageRequest,
 
 func TestSendAndReceive(t *testing.T) {
 	rpcContext := rpc.NewContext(hlc.NewClock(hlc.UnixNano), rpc.LoadInsecureTLSConfig())
-	gossip := gossip.New(rpcContext, gossip.TestInterval, "")
+	g := gossip.New(rpcContext, gossip.TestInterval, "")
 
 	// Create several servers, each of which has two stores (A multiraft node ID addresses
 	// a store).
@@ -63,7 +62,7 @@ func TestSendAndReceive(t *testing.T) {
 		}
 		defer server.Close()
 
-		transport, err := newRPCTransport(gossip, server, rpcContext)
+		transport, err := newRPCTransport(g, server, rpcContext)
 		if err != nil {
 			t.Fatalf("Unexpected error creating transport, Error: %s", err)
 		}
@@ -79,7 +78,7 @@ func TestSendAndReceive(t *testing.T) {
 				t.Fatal(err)
 			}
 
-			if err := gossip.AddInfo(fmt.Sprintf("node-%d", protoNodeID), server.Addr(), time.Hour); err != nil {
+			if err := g.AddInfo(gossip.MakeNodeIDKey(protoNodeID), server.Addr(), time.Hour); err != nil {
 				t.Fatal(err)
 			}
 

--- a/storage/store.go
+++ b/storage/store.go
@@ -472,7 +472,7 @@ func (s *Store) Start() error {
 		s.gossip.RegisterCallback(gossip.KeyConfigAccounting, s.configGossipUpdate)
 		s.gossip.RegisterCallback(gossip.KeyConfigZone, s.configGossipUpdate)
 		// Callback triggers on capacity gossip from all stores.
-		capacityRegex := fmt.Sprintf("%s.*", gossip.KeyMaxAvailCapacityPrefix)
+		capacityRegex := gossip.MakePrefixPattern(gossip.KeyMaxAvailCapacityPrefix)
 		s.gossip.RegisterCallback(capacityRegex, s.capacityGossipUpdate)
 	}
 


### PR DESCRIPTION
keys, patterns and their creating methods are now located in a central
place.
nodeID and storeID are converted to decimal strings.

I've also added a commit upping the test timeout to 15s. Unfortunately the `kv` test is getting rather slow and should be refactored.
