### PR TITLE
add a leader cache for use in DistSender

### DIFF
--- a/kv/leader_cache.go
+++ b/kv/leader_cache.go
@@ -1,0 +1,71 @@
+// Copyright 2015 The Cockroach Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+// implied. See the License for the specific language governing
+// permissions and limitations under the License. See the AUTHORS file
+// for names of contributors.
+//
+// Author: Tobias Schottdorf (tobias.schottdorf@gmail.com)
+
+package kv
+
+import (
+	"sync"
+
+	"github.com/cockroachdb/cockroach/proto"
+	"github.com/cockroachdb/cockroach/util"
+)
+
+// A LeaderCache is a cache used to keep track of the leader
+// replica of Raft consensus groups.
+type LeaderCache struct {
+	mu    sync.RWMutex
+	cache *util.UnorderedCache
+}
+
+// NewLeaderCache creates a new LeaderCache of the given size.
+// The underlying cache internally uses a hash map, so lookups
+// are cheap.
+func NewLeaderCache(size int) *LeaderCache {
+	return &LeaderCache{
+		cache: util.NewUnorderedCache(util.CacheConfig{
+			Policy: util.CacheLRU,
+			ShouldEvict: func(s int, key, value interface{}) bool {
+				return s > size
+			},
+		}),
+	}
+}
+
+// Lookup consults the cache for the replica cached as the leader of
+// the given Raft consensus group.
+func (lc *LeaderCache) Lookup(group proto.RaftID) *proto.Replica {
+	lc.mu.RLock()
+	v, ok := lc.cache.Get(group)
+	lc.mu.RUnlock()
+	if !ok {
+		return nil
+	}
+	return v.(*proto.Replica)
+}
+
+// EvictOrUpdate invalidates the cached leader for the given Raft group.
+// If a new replica is passed in, and that replica does not match the
+// freshly evicted one's StoreID, it is inserted into the cache.
+func (lc *LeaderCache) EvictOrUpdate(group proto.RaftID, r *proto.Replica) {
+	old := lc.Lookup(group)
+	lc.mu.Lock()
+	lc.cache.Del(group)
+	if r != nil && (old == nil || old.StoreID != r.StoreID) {
+		lc.cache.Add(group, r)
+	}
+	lc.mu.Unlock()
+}

--- a/kv/leader_cache_test.go
+++ b/kv/leader_cache_test.go
@@ -15,41 +15,39 @@
 //
 // Author: Tobias Schottdorf (tobias.schottdorf@gmail.com)
 
-package kv_test
+package kv
 
 import (
 	"reflect"
 	"testing"
 
-	"github.com/cockroachdb/cockroach/kv"
 	"github.com/cockroachdb/cockroach/proto"
 )
 
 func TestLeaderCache(t *testing.T) {
-	lc := kv.NewLeaderCache(3)
+	lc := newLeaderCache(3)
 	if r := lc.Lookup(12); r != nil {
 		t.Fatalf("lookup of missing key returned replica: %v", r)
 	}
 	replica := &proto.Replica{StoreID: 1}
-	lc.EvictOrUpdate(5, replica)
+	lc.Update(5, replica)
 	if r := lc.Lookup(5); !reflect.DeepEqual(replica, r) {
 		t.Errorf("expected %v, got %v", replica, r)
 	}
 	newReplica := &proto.Replica{StoreID: 7}
-	lc.EvictOrUpdate(5, newReplica)
+	lc.Update(5, newReplica)
 	r := lc.Lookup(5)
 	if !reflect.DeepEqual(newReplica, r) {
 		t.Errorf("expected %v, got %v", newReplica, r)
 	}
-	rCopy := *r
-	// Updating with the same replica (or a copy thereof) should
-	// throw the entry out.
-	lc.EvictOrUpdate(5, &rCopy)
-	if r := lc.Lookup(5); r != nil {
-		t.Fatalf("unexpected leader cache hit: %v", r)
+	lc.Update(5, nil)
+	r = lc.Lookup(5)
+	if r != nil {
+		t.Fatalf("evicted leader returned: %v", r)
 	}
+
 	for i := 10; i < 20; i++ {
-		lc.EvictOrUpdate(proto.RaftID(i), &rCopy)
+		lc.Update(proto.RaftID(i), replica)
 	}
 	if lc.Lookup(16) != nil || lc.Lookup(17) == nil {
 		t.Errorf("unexpected policy used in cache")

--- a/kv/leader_cache_test.go
+++ b/kv/leader_cache_test.go
@@ -1,0 +1,57 @@
+// Copyright 2015 The Cockroach Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+// implied. See the License for the specific language governing
+// permissions and limitations under the License. See the AUTHORS file
+// for names of contributors.
+//
+// Author: Tobias Schottdorf (tobias.schottdorf@gmail.com)
+
+package kv_test
+
+import (
+	"reflect"
+	"testing"
+
+	"github.com/cockroachdb/cockroach/kv"
+	"github.com/cockroachdb/cockroach/proto"
+)
+
+func TestLeaderCache(t *testing.T) {
+	lc := kv.NewLeaderCache(3)
+	if r := lc.Lookup(12); r != nil {
+		t.Fatalf("lookup of missing key returned replica: %v", r)
+	}
+	replica := &proto.Replica{StoreID: 1}
+	lc.EvictOrUpdate(5, replica)
+	if r := lc.Lookup(5); !reflect.DeepEqual(replica, r) {
+		t.Errorf("expected %v, got %v", replica, r)
+	}
+	newReplica := &proto.Replica{StoreID: 7}
+	lc.EvictOrUpdate(5, newReplica)
+	r := lc.Lookup(5)
+	if !reflect.DeepEqual(newReplica, r) {
+		t.Errorf("expected %v, got %v", newReplica, r)
+	}
+	rCopy := *r
+	// Updating with the same replica (or a copy thereof) should
+	// throw the entry out.
+	lc.EvictOrUpdate(5, &rCopy)
+	if r := lc.Lookup(5); r != nil {
+		t.Fatalf("unexpected leader cache hit: %v", r)
+	}
+	for i := 10; i < 20; i++ {
+		lc.EvictOrUpdate(proto.RaftID(i), &rCopy)
+	}
+	if lc.Lookup(16) != nil || lc.Lookup(17) == nil {
+		t.Errorf("unexpected policy used in cache")
+	}
+}

--- a/proto/api.go
+++ b/proto/api.go
@@ -84,6 +84,9 @@ func (s stringSet) keys() []string {
 	return keys
 }
 
+// A RaftID is a unique ID associated to a Raft consensus group.
+type RaftID int64
+
 // TODO(spencer): replaces these individual maps with a bitmask or
 //   equivalent listing each method's attributes.
 


### PR DESCRIPTION
to keep track of the replica leading a given Raft group,
the distributed sender will populate and maintain this cache
from NotLeaderErrors received during RPC requests.
