### PR TITLE
Minor mvcc memory optimizations.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -30,12 +30,6 @@ COCKROACH_IMAGE :=
 
 RUN := run
 
-# TODO(pmattis): Figure out where to clear the CGO_* variables when
-# building "release" binaries.
-export CGO_CFLAGS :=-g
-export CGO_CXXFLAGS :=-g
-export CGO_LDFLAGS :=-g
-
 # Variables to be overridden on the command line, e.g.
 #   make test PKG=./storage TESTFLAGS=--vmodule=multiraft=1
 PKG          := "./..."

--- a/proto/data.go
+++ b/proto/data.go
@@ -336,7 +336,9 @@ func (v *Value) computeChecksum(key []byte) uint32 {
 	} else if v.Integer != nil {
 		c.Write(encoding.EncodeUint64(nil, uint64(v.GetInteger())))
 	}
-	return c.Sum32()
+	sum := c.Sum32()
+	encoding.ReleaseCRC32Checksum(c)
+	return sum
 }
 
 // KeyGetter is a hack to allow Compare() to work for the batch

--- a/storage/engine/mvcc.go
+++ b/storage/engine/mvcc.go
@@ -478,13 +478,7 @@ func MVCCGet(engine Engine, key proto.Key, timestamp proto.Timestamp, consistent
 		return nil, err
 	}
 
-	value, err := mvccGetInternal(engine, key, metaKey, timestamp, consistent, txn, getValue, buf)
-	var rvalue *proto.Value
-	if err == nil && value != nil {
-		rvalue = &proto.Value{}
-		*rvalue = *value
-	}
-	return rvalue, err
+	return mvccGetInternal(engine, key, metaKey, timestamp, consistent, txn, getValue, buf)
 }
 
 // getEarlierFunc fetches an earlier version of a key starting at

--- a/storage/engine/rocksdb_test.go
+++ b/storage/engine/rocksdb_test.go
@@ -184,6 +184,7 @@ func setupMVCCScanData(numVersions, numKeys int, b *testing.B) *RocksDB {
 			// number of versions chosen for this key.
 			if t <= nvs[i] {
 				value := proto.Value{Bytes: util.RandBytes(rng, 1024)}
+				value.InitChecksum(keys[i])
 				if err := MVCCPut(batch, nil, keys[i], ts, value, nil); err != nil {
 					b.Fatal(err)
 				}


### PR DESCRIPTION
Removed an unnecessary allocation and copy of the returned Value in
MVCCGet.

Remove CGO flags. They were a minor build speedup, but caused me
confusion on several occassions about whether rocksdb was built with
optimization or without.
