### PR TITLE
set internalRangeLookup INCONSISTENT in DistSender

### DIFF
--- a/kv/dist_sender.go
+++ b/kv/dist_sender.go
@@ -193,8 +193,9 @@ func (ds *DistSender) nodeIDToAddr(nodeID proto.NodeID) (net.Addr, error) {
 func (ds *DistSender) internalRangeLookup(key proto.Key, info *proto.RangeDescriptor) ([]proto.RangeDescriptor, error) {
 	args := &proto.InternalRangeLookupRequest{
 		RequestHeader: proto.RequestHeader{
-			Key:  key,
-			User: storage.UserRoot,
+			Key:             key,
+			User:            storage.UserRoot,
+			ReadConsistency: proto.INCONSISTENT,
 		},
 		MaxRanges: rangeLookupMaxRanges,
 	}
@@ -376,7 +377,7 @@ func (ds *DistSender) Send(call *client.Call) {
 						return util.RetryBreak, util.Error("illegal cross-range operation", call)
 					}
 					// If there's no transaction and op spans ranges, possibly
-					// re-run as part of a transaction for consistency.  The
+					// re-run as part of a transaction for consistency. The
 					// case where we don't need to re-run is if the read
 					// consistency is not required.
 					if call.Args.Header().Txn == nil && args.Header().ReadConsistency != proto.INCONSISTENT {


### PR DESCRIPTION
and (to avoid confusion) do not do it in the r.InternalRangeLookup
itself. The reason for this change is that we will soon take the
consistency level into account for routing calls to replicas.

related to #543 
