### PR TITLE
gossip a NodeDescriptor instead of a net.Addr

### DIFF
--- a/server/node.go
+++ b/server/node.go
@@ -289,7 +289,7 @@ func (n *Node) bootstrapStores(bootstraps *list.List) {
 		}
 		// Gossip node address keyed by node ID.
 		nodeIDKey := gossip.MakeNodeIDKey(n.Descriptor.NodeID)
-		if err := n.gossip.AddInfo(nodeIDKey, n.Descriptor.Address, ttlNodeIDGossip); err != nil {
+		if err := n.gossip.AddInfo(nodeIDKey, &n.Descriptor, ttlNodeIDGossip); err != nil {
 			log.Errorf("couldn't gossip address for node %d: %v", n.Descriptor.NodeID, err)
 		}
 	}
@@ -342,7 +342,7 @@ func (n *Node) connectGossip() {
 	// Gossip node address keyed by node ID.
 	if n.Descriptor.NodeID != 0 {
 		nodeIDKey := gossip.MakeNodeIDKey(n.Descriptor.NodeID)
-		if err := n.gossip.AddInfo(nodeIDKey, n.Descriptor.Address, ttlNodeIDGossip); err != nil {
+		if err := n.gossip.AddInfo(nodeIDKey, &n.Descriptor, ttlNodeIDGossip); err != nil {
 			log.Errorf("couldn't gossip address for node %d: %v", n.Descriptor.NodeID, err)
 		}
 	}

--- a/server/node_test.go
+++ b/server/node_test.go
@@ -194,13 +194,13 @@ func TestNodeJoin(t *testing.T) {
 	if err := util.IsTrueWithin(func() bool {
 		if val, err := node1.gossip.GetInfo(node2Key); err != nil {
 			return false
-		} else if val.(net.Addr).String() != server2.Addr().String() {
-			t.Errorf("addr2 gossip %s doesn't match addr2 address %s", val.(net.Addr).String(), server2.Addr().String())
+		} else if addr2 := val.(*storage.NodeDescriptor).Address.String(); addr2 != server2.Addr().String() {
+			t.Errorf("addr2 gossip %s doesn't match addr2 address %s", addr2, server2.Addr().String())
 		}
 		if val, err := node2.gossip.GetInfo(node1Key); err != nil {
 			return false
-		} else if val.(net.Addr).String() != server1.Addr().String() {
-			t.Errorf("addr1 gossip %s doesn't match addr1 address %s", val.(net.Addr).String(), server1.Addr().String())
+		} else if addr1 := val.(*storage.NodeDescriptor).Address.String(); addr1 != server1.Addr().String() {
+			t.Errorf("addr1 gossip %s doesn't match addr1 address %s", addr1, server1.Addr().String())
 		}
 		return true
 	}, 50*time.Millisecond); err != nil {

--- a/server/raft_transport_test.go
+++ b/server/raft_transport_test.go
@@ -78,7 +78,9 @@ func TestSendAndReceive(t *testing.T) {
 				t.Fatal(err)
 			}
 
-			if err := g.AddInfo(gossip.MakeNodeIDKey(protoNodeID), server.Addr(), time.Hour); err != nil {
+			if err := g.AddInfo(gossip.MakeNodeIDKey(protoNodeID),
+				&storage.NodeDescriptor{Address: server.Addr()},
+				time.Hour); err != nil {
 				t.Fatal(err)
 			}
 

--- a/storage/range.go
+++ b/storage/range.go
@@ -54,6 +54,7 @@ func init() {
 	gob.Register(&proto.ZoneConfig{})
 	gob.Register(proto.RangeDescriptor{})
 	gob.Register(proto.Transaction{})
+	gob.Register(&NodeDescriptor{})
 }
 
 var (

--- a/storage/store.go
+++ b/storage/store.go
@@ -184,6 +184,16 @@ type NodeDescriptor struct {
 	Attrs   proto.Attributes // node specific attributes (e.g. datacenter, machine info)
 }
 
+// NodeIDToAddress looks up the address of the node from the given Gossip instance.
+func NodeIDToAddress(g *gossip.Gossip, nodeID proto.NodeID) (net.Addr, error) {
+	nodeIDKey := gossip.MakeNodeIDKey(nodeID)
+	info, err := g.GetInfo(nodeIDKey)
+	if info == nil || err != nil {
+		return nil, util.Errorf("Unable to lookup address for node: %d. Error: %s", nodeID, err)
+	}
+	return info.(*NodeDescriptor).Address, nil
+}
+
 // StoreDescriptor holds store information including store attributes,
 // node descriptor and store capacity.
 type StoreDescriptor struct {


### PR DESCRIPTION
also removed some duplicate code.

related to #543.
