### PR TITLE
Directly resolve intents for keys in special circumstances.

### DIFF
--- a/kv/txn_coord_sender.go
+++ b/kv/txn_coord_sender.go
@@ -102,8 +102,9 @@ func (tm *txnMetadata) addKeyRange(start, end proto.Key) {
 
 // close sends resolve intent commands for all key ranges this
 // transaction has covered, clears the keys cache and closes the
-// metadata heartbeat.
-func (tm *txnMetadata) close(txn *proto.Transaction, sender client.KVSender) {
+// metadata heartbeat. Any keys listed in the resolved slice have
+// already been resolved and do not receive resolve intent commands.
+func (tm *txnMetadata) close(txn *proto.Transaction, resolved []proto.Key, sender client.KVSender) {
 	if tm.keys.Len() > 0 {
 		log.V(1).Infof("cleaning up %d intent(s) for transaction %s", tm.keys.Len(), txn)
 	}
@@ -125,6 +126,17 @@ func (tm *txnMetadata) close(txn *proto.Transaction, sender client.KVSender) {
 		endKey := o.Key.End().(proto.Key)
 		if !call.Args.Header().Key.Next().Equal(endKey) {
 			call.Args.Header().EndKey = endKey
+		} else {
+			// Check if the key has already been resolved; skip if yes.
+			found := false
+			for _, k := range resolved {
+				if call.Args.Header().Key.Equal(k) {
+					found = true
+				}
+			}
+			if found {
+				continue
+			}
 		}
 		// We don't care about the reply channel; these are best
 		// effort. We simply fire and forget, each in its own goroutine.
@@ -305,7 +317,7 @@ func (tc *TxnCoordSender) sendOne(call *client.Call) {
 	switch t := call.Reply.Header().GoError().(type) {
 	case *proto.TransactionAbortedError:
 		// If already aborted, cleanup the txn on this TxnCoordSender.
-		tc.cleanupTxn(&t.Txn)
+		tc.cleanupTxn(&t.Txn, nil)
 	case *proto.OpRequiresTxnError:
 		// Run a one-off transaction with that single command.
 		log.Infof("%s: auto-wrapping in txn and re-executing", call.Method)
@@ -323,6 +335,7 @@ func (tc *TxnCoordSender) sendOne(call *client.Call) {
 		})
 	case nil:
 		var txn *proto.Transaction
+		var resolved []proto.Key
 		if call.Method == proto.EndTransaction {
 			txn = call.Reply.Header().Txn
 			// If the -linearizable flag is set, we want to make sure that
@@ -344,9 +357,10 @@ func (tc *TxnCoordSender) sendOne(call *client.Call) {
 					time.Sleep(sleepNS)
 				}()
 			}
+			resolved = call.Reply.(*proto.EndTransactionResponse).Resolved
 		}
 		if txn != nil && txn.Status != proto.PENDING {
-			tc.cleanupTxn(txn)
+			tc.cleanupTxn(txn, resolved)
 		}
 	}
 }
@@ -455,14 +469,14 @@ func (tc *TxnCoordSender) updateResponseTxn(argsHeader *proto.RequestHeader, rep
 // cleanupTxn is called to resolve write intents which were set down over
 // the course of the transaction. The txnMetadata object is removed from
 // the txns map.
-func (tc *TxnCoordSender) cleanupTxn(txn *proto.Transaction) {
+func (tc *TxnCoordSender) cleanupTxn(txn *proto.Transaction, resolved []proto.Key) {
 	tc.Lock()
 	defer tc.Unlock()
 	txnMeta, ok := tc.txns[string(txn.ID)]
 	if !ok {
 		return
 	}
-	txnMeta.close(txn, tc.wrapped)
+	txnMeta.close(txn, resolved, tc.wrapped)
 	delete(tc.txns, string(txn.ID))
 }
 
@@ -523,7 +537,7 @@ func (tc *TxnCoordSender) heartbeat(txn *proto.Transaction, closer chan struct{}
 			if reply.GoError() != nil {
 				log.Warningf("heartbeat to %q:%q failed: %s", txn.Key, txn.ID, reply.GoError())
 			} else if reply.Txn.Status != proto.PENDING {
-				tc.cleanupTxn(reply.Txn)
+				tc.cleanupTxn(reply.Txn, nil)
 				return
 			}
 		case <-closer:

--- a/proto/api.pb.go
+++ b/proto/api.pb.go
@@ -622,7 +622,9 @@ func (m *EndTransactionRequest) GetInternalCommitTrigger() *InternalCommitTrigge
 type EndTransactionResponse struct {
 	ResponseHeader `protobuf:"bytes,1,opt,name=header,embedded=header" json:"header"`
 	// Remaining time (ns).
-	CommitWait       int64  `protobuf:"varint,2,opt,name=commit_wait" json:"commit_wait"`
+	CommitWait int64 `protobuf:"varint,2,opt,name=commit_wait" json:"commit_wait"`
+	// List of intents resolved by EndTransaction call.
+	Resolved         []Key  `protobuf:"bytes,3,rep,name=resolved,customtype=Key" json:"resolved,omitempty"`
 	XXX_unrecognized []byte `json:"-"`
 }
 

--- a/proto/api.proto
+++ b/proto/api.proto
@@ -252,7 +252,6 @@ message EndTransactionRequest {
   optional RequestHeader header = 1 [(gogoproto.nullable) = false, (gogoproto.embed) = true];
   // False to abort and rollback.
   optional bool commit = 2 [(gogoproto.nullable) = false];
-
   // Optional commit triggers. Note that commit triggers are for
   // internal use only and will be ignored if requested through the
   // public-facing KV API.
@@ -273,6 +272,8 @@ message EndTransactionResponse {
   optional ResponseHeader header = 1 [(gogoproto.nullable) = false, (gogoproto.embed) = true];
   // Remaining time (ns).
   optional int64 commit_wait = 2 [(gogoproto.nullable) = false];
+  // List of intents resolved by EndTransaction call.
+  repeated bytes resolved = 3 [(gogoproto.customtype) = "Key"];
 }
 
 // A ReapQueueRequest is arguments to the ReapQueue() method. It

--- a/proto/data.pb.go
+++ b/proto/data.pb.go
@@ -410,7 +410,11 @@ type InternalCommitTrigger struct {
 	SplitTrigger          *SplitTrigger          `protobuf:"bytes,1,opt,name=split_trigger" json:"split_trigger,omitempty"`
 	MergeTrigger          *MergeTrigger          `protobuf:"bytes,2,opt,name=merge_trigger" json:"merge_trigger,omitempty"`
 	ChangeReplicasTrigger *ChangeReplicasTrigger `protobuf:"bytes,3,opt,name=change_replicas_trigger" json:"change_replicas_trigger,omitempty"`
-	XXX_unrecognized      []byte                 `json:"-"`
+	// List of intents to resolve on commit or abort. Note that keys
+	// listed here will only be resolved if they fall on the same range
+	// that the transaction was started on.
+	Intents          []Key  `protobuf:"bytes,4,rep,name=intents,customtype=Key" json:"intents,omitempty"`
+	XXX_unrecognized []byte `json:"-"`
 }
 
 func (m *InternalCommitTrigger) Reset()         { *m = InternalCommitTrigger{} }

--- a/proto/data.proto
+++ b/proto/data.proto
@@ -145,6 +145,11 @@ message InternalCommitTrigger {
   optional SplitTrigger split_trigger = 1;
   optional MergeTrigger merge_trigger = 2;
   optional ChangeReplicasTrigger change_replicas_trigger = 3;
+
+  // List of intents to resolve on commit or abort. Note that keys
+  // listed here will only be resolved if they fall on the same range
+  // that the transaction was started on.
+  repeated bytes intents = 4 [(gogoproto.customtype) = "Key"];
 }
 
 // IsolationType TODO(jiajia) Needs documentation.

--- a/storage/client_merge_test.go
+++ b/storage/client_merge_test.go
@@ -128,6 +128,13 @@ func TestStoreRangeMergeWithData(t *testing.T) {
 		t.Fatal(err)
 	}
 
+	// Verify no intents remains on range descriptor keys.
+	for _, key := range []proto.Key{engine.RangeDescriptorKey(aDesc.StartKey), engine.RangeDescriptorKey(bDesc.StartKey)} {
+		if _, err := engine.MVCCGet(store.Engine(), key, store.Clock().Now(), true, nil); err != nil {
+			t.Fatal(err)
+		}
+	}
+
 	// Verify the merge by looking up keys from both ranges.
 	rangeA := store.LookupRange([]byte("a"), nil)
 	rangeB := store.LookupRange([]byte("c"), nil)

--- a/storage/client_raft_test.go
+++ b/storage/client_raft_test.go
@@ -133,6 +133,11 @@ func TestReplicateRange(t *testing.T) {
 		}); err != nil {
 		t.Fatal(err)
 	}
+	// Verify no intent remain on range descriptor key.
+	key := engine.RangeDescriptorKey(rng.Desc().StartKey)
+	if _, err := engine.MVCCGet(mtc.stores[0].Engine(), key, mtc.stores[0].Clock().Now(), true, nil); err != nil {
+		t.Fatal(err)
+	}
 
 	// Verify that the same data is available on the replica.
 	// TODO(bdarnell): relies on the fact that we allow reads from followers.

--- a/storage/client_split_test.go
+++ b/storage/client_split_test.go
@@ -189,6 +189,13 @@ func TestStoreRangeSplit(t *testing.T) {
 		t.Fatal(err)
 	}
 
+	// Verify no intents remains on range descriptor keys.
+	for _, key := range []proto.Key{engine.RangeDescriptorKey(engine.KeyMin), engine.RangeDescriptorKey(splitKey)} {
+		if _, err := engine.MVCCGet(store.Engine(), key, store.Clock().Now(), true, nil); err != nil {
+			t.Fatal(err)
+		}
+	}
+
 	rng := store.LookupRange(engine.KeyMin, nil)
 	newRng := store.LookupRange([]byte("m"), nil)
 	if !bytes.Equal(newRng.Desc().StartKey, splitKey) || !bytes.Equal(splitKey, rng.Desc().EndKey) {

--- a/storage/engine/cockroach/proto/api.pb.cc
+++ b/storage/engine/cockroach/proto/api.pb.cc
@@ -491,9 +491,10 @@ void protobuf_AssignDesc_cockroach_2fproto_2fapi_2eproto() {
       ::google::protobuf::MessageFactory::generated_factory(),
       sizeof(EndTransactionRequest));
   EndTransactionResponse_descriptor_ = file->message_type(20);
-  static const int EndTransactionResponse_offsets_[2] = {
+  static const int EndTransactionResponse_offsets_[3] = {
     GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(EndTransactionResponse, header_),
     GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(EndTransactionResponse, commit_wait_),
+    GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(EndTransactionResponse, resolved_),
   };
   EndTransactionResponse_reflection_ =
     new ::google::protobuf::internal::GeneratedMessageReflection(
@@ -988,80 +989,81 @@ void protobuf_AddDesc_cockroach_2fproto_2fapi_2eproto() {
     "uest\0228\n\006header\030\001 \001(\0132\036.cockroach.proto.R"
     "equestHeaderB\010\310\336\037\000\320\336\037\001\022\024\n\006commit\030\002 \001(\010B\004"
     "\310\336\037\000\022G\n\027internal_commit_trigger\030\003 \001(\0132&."
-    "cockroach.proto.InternalCommitTrigger\"n\n"
-    "\026EndTransactionResponse\0229\n\006header\030\001 \001(\0132"
+    "cockroach.proto.InternalCommitTrigger\"\211\001"
+    "\n\026EndTransactionResponse\0229\n\006header\030\001 \001(\013"
+    "2\037.cockroach.proto.ResponseHeaderB\010\310\336\037\000\320"
+    "\336\037\001\022\031\n\013commit_wait\030\002 \001(\003B\004\310\336\037\000\022\031\n\010resolv"
+    "ed\030\003 \003(\014B\007\332\336\037\003Key\"g\n\020ReapQueueRequest\0228\n"
+    "\006header\030\001 \001(\0132\036.cockroach.proto.RequestH"
+    "eaderB\010\310\336\037\000\320\336\037\001\022\031\n\013max_results\030\002 \001(\003B\004\310\336"
+    "\037\000\"~\n\021ReapQueueResponse\0229\n\006header\030\001 \001(\0132"
     "\037.cockroach.proto.ResponseHeaderB\010\310\336\037\000\320\336"
-    "\037\001\022\031\n\013commit_wait\030\002 \001(\003B\004\310\336\037\000\"g\n\020ReapQue"
-    "ueRequest\0228\n\006header\030\001 \001(\0132\036.cockroach.pr"
-    "oto.RequestHeaderB\010\310\336\037\000\320\336\037\001\022\031\n\013max_resul"
-    "ts\030\002 \001(\003B\004\310\336\037\000\"~\n\021ReapQueueResponse\0229\n\006h"
-    "eader\030\001 \001(\0132\037.cockroach.proto.ResponseHe"
-    "aderB\010\310\336\037\000\320\336\037\001\022.\n\010messages\030\002 \003(\0132\026.cockr"
-    "oach.proto.ValueB\004\310\336\037\000\"P\n\024EnqueueUpdateR"
-    "equest\0228\n\006header\030\001 \001(\0132\036.cockroach.proto"
-    ".RequestHeaderB\010\310\336\037\000\320\336\037\001\"R\n\025EnqueueUpdat"
-    "eResponse\0229\n\006header\030\001 \001(\0132\037.cockroach.pr"
-    "oto.ResponseHeaderB\010\310\336\037\000\320\336\037\001\"|\n\025EnqueueM"
-    "essageRequest\0228\n\006header\030\001 \001(\0132\036.cockroac"
-    "h.proto.RequestHeaderB\010\310\336\037\000\320\336\037\001\022)\n\003msg\030\002"
-    " \001(\0132\026.cockroach.proto.ValueB\004\310\336\037\000\"S\n\026En"
-    "queueMessageResponse\0229\n\006header\030\001 \001(\0132\037.c"
-    "ockroach.proto.ResponseHeaderB\010\310\336\037\000\320\336\037\001\""
-    "\303\005\n\014RequestUnion\0224\n\010contains\030\001 \001(\0132 .coc"
-    "kroach.proto.ContainsRequestH\000\022*\n\003get\030\002 "
-    "\001(\0132\033.cockroach.proto.GetRequestH\000\022*\n\003pu"
-    "t\030\003 \001(\0132\033.cockroach.proto.PutRequestH\000\022A"
-    "\n\017conditional_put\030\004 \001(\0132&.cockroach.prot"
-    "o.ConditionalPutRequestH\000\0226\n\tincrement\030\005"
-    " \001(\0132!.cockroach.proto.IncrementRequestH"
-    "\000\0220\n\006delete\030\006 \001(\0132\036.cockroach.proto.Dele"
-    "teRequestH\000\022;\n\014delete_range\030\007 \001(\0132#.cock"
-    "roach.proto.DeleteRangeRequestH\000\022,\n\004scan"
-    "\030\010 \001(\0132\034.cockroach.proto.ScanRequestH\000\022A"
-    "\n\017end_transaction\030\t \001(\0132&.cockroach.prot"
-    "o.EndTransactionRequestH\000\0227\n\nreap_queue\030"
-    "\n \001(\0132!.cockroach.proto.ReapQueueRequest"
-    "H\000\022\?\n\016enqueue_update\030\013 \001(\0132%.cockroach.p"
-    "roto.EnqueueUpdateRequestH\000\022A\n\017enqueue_m"
-    "essage\030\014 \001(\0132&.cockroach.proto.EnqueueMe"
-    "ssageRequestH\000:\004\310\240\037\001B\007\n\005value\"\320\005\n\rRespon"
-    "seUnion\0225\n\010contains\030\001 \001(\0132!.cockroach.pr"
-    "oto.ContainsResponseH\000\022+\n\003get\030\002 \001(\0132\034.co"
-    "ckroach.proto.GetResponseH\000\022+\n\003put\030\003 \001(\013"
-    "2\034.cockroach.proto.PutResponseH\000\022B\n\017cond"
-    "itional_put\030\004 \001(\0132\'.cockroach.proto.Cond"
-    "itionalPutResponseH\000\0227\n\tincrement\030\005 \001(\0132"
-    "\".cockroach.proto.IncrementResponseH\000\0221\n"
-    "\006delete\030\006 \001(\0132\037.cockroach.proto.DeleteRe"
-    "sponseH\000\022<\n\014delete_range\030\007 \001(\0132$.cockroa"
-    "ch.proto.DeleteRangeResponseH\000\022-\n\004scan\030\010"
-    " \001(\0132\035.cockroach.proto.ScanResponseH\000\022B\n"
-    "\017end_transaction\030\t \001(\0132\'.cockroach.proto"
-    ".EndTransactionResponseH\000\0228\n\nreap_queue\030"
-    "\n \001(\0132\".cockroach.proto.ReapQueueRespons"
-    "eH\000\022@\n\016enqueue_update\030\013 \001(\0132&.cockroach."
-    "proto.EnqueueUpdateResponseH\000\022B\n\017enqueue"
-    "_message\030\014 \001(\0132\'.cockroach.proto.Enqueue"
-    "MessageResponseH\000:\004\310\240\037\001B\007\n\005value\"\177\n\014Batc"
-    "hRequest\0228\n\006header\030\001 \001(\0132\036.cockroach.pro"
-    "to.RequestHeaderB\010\310\336\037\000\320\336\037\001\0225\n\010requests\030\002"
-    " \003(\0132\035.cockroach.proto.RequestUnionB\004\310\336\037"
-    "\000\"\203\001\n\rBatchResponse\0229\n\006header\030\001 \001(\0132\037.co"
-    "ckroach.proto.ResponseHeaderB\010\310\336\037\000\320\336\037\001\0227"
-    "\n\tresponses\030\002 \003(\0132\036.cockroach.proto.Resp"
-    "onseUnionB\004\310\336\037\000\"m\n\021AdminSplitRequest\0228\n\006"
+    "\037\001\022.\n\010messages\030\002 \003(\0132\026.cockroach.proto.V"
+    "alueB\004\310\336\037\000\"P\n\024EnqueueUpdateRequest\0228\n\006he"
+    "ader\030\001 \001(\0132\036.cockroach.proto.RequestHead"
+    "erB\010\310\336\037\000\320\336\037\001\"R\n\025EnqueueUpdateResponse\0229\n"
+    "\006header\030\001 \001(\0132\037.cockroach.proto.Response"
+    "HeaderB\010\310\336\037\000\320\336\037\001\"|\n\025EnqueueMessageReques"
+    "t\0228\n\006header\030\001 \001(\0132\036.cockroach.proto.Requ"
+    "estHeaderB\010\310\336\037\000\320\336\037\001\022)\n\003msg\030\002 \001(\0132\026.cockr"
+    "oach.proto.ValueB\004\310\336\037\000\"S\n\026EnqueueMessage"
+    "Response\0229\n\006header\030\001 \001(\0132\037.cockroach.pro"
+    "to.ResponseHeaderB\010\310\336\037\000\320\336\037\001\"\303\005\n\014RequestU"
+    "nion\0224\n\010contains\030\001 \001(\0132 .cockroach.proto"
+    ".ContainsRequestH\000\022*\n\003get\030\002 \001(\0132\033.cockro"
+    "ach.proto.GetRequestH\000\022*\n\003put\030\003 \001(\0132\033.co"
+    "ckroach.proto.PutRequestH\000\022A\n\017conditiona"
+    "l_put\030\004 \001(\0132&.cockroach.proto.Conditiona"
+    "lPutRequestH\000\0226\n\tincrement\030\005 \001(\0132!.cockr"
+    "oach.proto.IncrementRequestH\000\0220\n\006delete\030"
+    "\006 \001(\0132\036.cockroach.proto.DeleteRequestH\000\022"
+    ";\n\014delete_range\030\007 \001(\0132#.cockroach.proto."
+    "DeleteRangeRequestH\000\022,\n\004scan\030\010 \001(\0132\034.coc"
+    "kroach.proto.ScanRequestH\000\022A\n\017end_transa"
+    "ction\030\t \001(\0132&.cockroach.proto.EndTransac"
+    "tionRequestH\000\0227\n\nreap_queue\030\n \001(\0132!.cock"
+    "roach.proto.ReapQueueRequestH\000\022\?\n\016enqueu"
+    "e_update\030\013 \001(\0132%.cockroach.proto.Enqueue"
+    "UpdateRequestH\000\022A\n\017enqueue_message\030\014 \001(\013"
+    "2&.cockroach.proto.EnqueueMessageRequest"
+    "H\000:\004\310\240\037\001B\007\n\005value\"\320\005\n\rResponseUnion\0225\n\010c"
+    "ontains\030\001 \001(\0132!.cockroach.proto.Contains"
+    "ResponseH\000\022+\n\003get\030\002 \001(\0132\034.cockroach.prot"
+    "o.GetResponseH\000\022+\n\003put\030\003 \001(\0132\034.cockroach"
+    ".proto.PutResponseH\000\022B\n\017conditional_put\030"
+    "\004 \001(\0132\'.cockroach.proto.ConditionalPutRe"
+    "sponseH\000\0227\n\tincrement\030\005 \001(\0132\".cockroach."
+    "proto.IncrementResponseH\000\0221\n\006delete\030\006 \001("
+    "\0132\037.cockroach.proto.DeleteResponseH\000\022<\n\014"
+    "delete_range\030\007 \001(\0132$.cockroach.proto.Del"
+    "eteRangeResponseH\000\022-\n\004scan\030\010 \001(\0132\035.cockr"
+    "oach.proto.ScanResponseH\000\022B\n\017end_transac"
+    "tion\030\t \001(\0132\'.cockroach.proto.EndTransact"
+    "ionResponseH\000\0228\n\nreap_queue\030\n \001(\0132\".cock"
+    "roach.proto.ReapQueueResponseH\000\022@\n\016enque"
+    "ue_update\030\013 \001(\0132&.cockroach.proto.Enqueu"
+    "eUpdateResponseH\000\022B\n\017enqueue_message\030\014 \001"
+    "(\0132\'.cockroach.proto.EnqueueMessageRespo"
+    "nseH\000:\004\310\240\037\001B\007\n\005value\"\177\n\014BatchRequest\0228\n\006"
     "header\030\001 \001(\0132\036.cockroach.proto.RequestHe"
-    "aderB\010\310\336\037\000\320\336\037\001\022\036\n\tsplit_key\030\002 \001(\014B\013\310\336\037\000\332"
-    "\336\037\003Key\"O\n\022AdminSplitResponse\0229\n\006header\030\001"
-    " \001(\0132\037.cockroach.proto.ResponseHeaderB\010\310"
-    "\336\037\000\320\336\037\001\"\215\001\n\021AdminMergeRequest\0228\n\006header\030"
-    "\001 \001(\0132\036.cockroach.proto.RequestHeaderB\010\310"
-    "\336\037\000\320\336\037\001\022>\n\016subsumed_range\030\002 \001(\0132 .cockro"
-    "ach.proto.RangeDescriptorB\004\310\336\037\000\"O\n\022Admin"
-    "MergeResponse\0229\n\006header\030\001 \001(\0132\037.cockroac"
-    "h.proto.ResponseHeaderB\010\310\336\037\000\320\336\037\001*L\n\023Read"
-    "ConsistencyType\022\016\n\nCONSISTENT\020\000\022\r\n\tCONSE"
-    "NSUS\020\001\022\020\n\014INCONSISTENT\020\002\032\004\210\243\036\000B\007Z\005proto", 5519);
+    "aderB\010\310\336\037\000\320\336\037\001\0225\n\010requests\030\002 \003(\0132\035.cockr"
+    "oach.proto.RequestUnionB\004\310\336\037\000\"\203\001\n\rBatchR"
+    "esponse\0229\n\006header\030\001 \001(\0132\037.cockroach.prot"
+    "o.ResponseHeaderB\010\310\336\037\000\320\336\037\001\0227\n\tresponses\030"
+    "\002 \003(\0132\036.cockroach.proto.ResponseUnionB\004\310"
+    "\336\037\000\"m\n\021AdminSplitRequest\0228\n\006header\030\001 \001(\013"
+    "2\036.cockroach.proto.RequestHeaderB\010\310\336\037\000\320\336"
+    "\037\001\022\036\n\tsplit_key\030\002 \001(\014B\013\310\336\037\000\332\336\037\003Key\"O\n\022Ad"
+    "minSplitResponse\0229\n\006header\030\001 \001(\0132\037.cockr"
+    "oach.proto.ResponseHeaderB\010\310\336\037\000\320\336\037\001\"\215\001\n\021"
+    "AdminMergeRequest\0228\n\006header\030\001 \001(\0132\036.cock"
+    "roach.proto.RequestHeaderB\010\310\336\037\000\320\336\037\001\022>\n\016s"
+    "ubsumed_range\030\002 \001(\0132 .cockroach.proto.Ra"
+    "ngeDescriptorB\004\310\336\037\000\"O\n\022AdminMergeRespons"
+    "e\0229\n\006header\030\001 \001(\0132\037.cockroach.proto.Resp"
+    "onseHeaderB\010\310\336\037\000\320\336\037\001*L\n\023ReadConsistencyT"
+    "ype\022\016\n\nCONSISTENT\020\000\022\r\n\tCONSENSUS\020\001\022\020\n\014IN"
+    "CONSISTENT\020\002\032\004\210\243\036\000B\007Z\005proto", 5547);
   ::google::protobuf::MessageFactory::InternalRegisterGeneratedFile(
     "cockroach/proto/api.proto", &protobuf_RegisterTypes);
   ClientCmdID::default_instance_ = new ClientCmdID();
@@ -6808,6 +6810,7 @@ void EndTransactionRequest::Swap(EndTransactionRequest* other) {
 #ifndef _MSC_VER
 const int EndTransactionResponse::kHeaderFieldNumber;
 const int EndTransactionResponse::kCommitWaitFieldNumber;
+const int EndTransactionResponse::kResolvedFieldNumber;
 #endif  // !_MSC_VER
 
 EndTransactionResponse::EndTransactionResponse()
@@ -6828,6 +6831,7 @@ EndTransactionResponse::EndTransactionResponse(const EndTransactionResponse& fro
 }
 
 void EndTransactionResponse::SharedCtor() {
+  ::google::protobuf::internal::GetEmptyString();
   _cached_size_ = 0;
   header_ = NULL;
   commit_wait_ = GOOGLE_LONGLONG(0);
@@ -6873,6 +6877,7 @@ void EndTransactionResponse::Clear() {
     }
     commit_wait_ = GOOGLE_LONGLONG(0);
   }
+  resolved_.Clear();
   ::memset(_has_bits_, 0, sizeof(_has_bits_));
   mutable_unknown_fields()->Clear();
 }
@@ -6910,6 +6915,20 @@ bool EndTransactionResponse::MergePartialFromCodedStream(
         } else {
           goto handle_unusual;
         }
+        if (input->ExpectTag(26)) goto parse_resolved;
+        break;
+      }
+
+      // repeated bytes resolved = 3;
+      case 3: {
+        if (tag == 26) {
+         parse_resolved:
+          DO_(::google::protobuf::internal::WireFormatLite::ReadBytes(
+                input, this->add_resolved()));
+        } else {
+          goto handle_unusual;
+        }
+        if (input->ExpectTag(26)) goto parse_resolved;
         if (input->ExpectAtEnd()) goto success;
         break;
       }
@@ -6950,6 +6969,12 @@ void EndTransactionResponse::SerializeWithCachedSizes(
     ::google::protobuf::internal::WireFormatLite::WriteInt64(2, this->commit_wait(), output);
   }
 
+  // repeated bytes resolved = 3;
+  for (int i = 0; i < this->resolved_size(); i++) {
+    ::google::protobuf::internal::WireFormatLite::WriteBytes(
+      3, this->resolved(i), output);
+  }
+
   if (!unknown_fields().empty()) {
     ::google::protobuf::internal::WireFormat::SerializeUnknownFields(
         unknown_fields(), output);
@@ -6970,6 +6995,12 @@ void EndTransactionResponse::SerializeWithCachedSizes(
   // optional int64 commit_wait = 2;
   if (has_commit_wait()) {
     target = ::google::protobuf::internal::WireFormatLite::WriteInt64ToArray(2, this->commit_wait(), target);
+  }
+
+  // repeated bytes resolved = 3;
+  for (int i = 0; i < this->resolved_size(); i++) {
+    target = ::google::protobuf::internal::WireFormatLite::
+      WriteBytesToArray(3, this->resolved(i), target);
   }
 
   if (!unknown_fields().empty()) {
@@ -6999,6 +7030,13 @@ int EndTransactionResponse::ByteSize() const {
     }
 
   }
+  // repeated bytes resolved = 3;
+  total_size += 1 * this->resolved_size();
+  for (int i = 0; i < this->resolved_size(); i++) {
+    total_size += ::google::protobuf::internal::WireFormatLite::BytesSize(
+      this->resolved(i));
+  }
+
   if (!unknown_fields().empty()) {
     total_size +=
       ::google::protobuf::internal::WireFormat::ComputeUnknownFieldsSize(
@@ -7024,6 +7062,7 @@ void EndTransactionResponse::MergeFrom(const ::google::protobuf::Message& from) 
 
 void EndTransactionResponse::MergeFrom(const EndTransactionResponse& from) {
   GOOGLE_CHECK_NE(&from, this);
+  resolved_.MergeFrom(from.resolved_);
   if (from._has_bits_[0 / 32] & (0xffu << (0 % 32))) {
     if (from.has_header()) {
       mutable_header()->::cockroach::proto::ResponseHeader::MergeFrom(from.header());
@@ -7056,6 +7095,7 @@ void EndTransactionResponse::Swap(EndTransactionResponse* other) {
   if (other != this) {
     std::swap(header_, other->header_);
     std::swap(commit_wait_, other->commit_wait_);
+    resolved_.Swap(&other->resolved_);
     std::swap(_has_bits_[0], other->_has_bits_[0]);
     _unknown_fields_.Swap(&other->_unknown_fields_);
     std::swap(_cached_size_, other->_cached_size_);

--- a/storage/engine/cockroach/proto/api.pb.h
+++ b/storage/engine/cockroach/proto/api.pb.h
@@ -2072,6 +2072,22 @@ class EndTransactionResponse : public ::google::protobuf::Message {
   inline ::google::protobuf::int64 commit_wait() const;
   inline void set_commit_wait(::google::protobuf::int64 value);
 
+  // repeated bytes resolved = 3;
+  inline int resolved_size() const;
+  inline void clear_resolved();
+  static const int kResolvedFieldNumber = 3;
+  inline const ::std::string& resolved(int index) const;
+  inline ::std::string* mutable_resolved(int index);
+  inline void set_resolved(int index, const ::std::string& value);
+  inline void set_resolved(int index, const char* value);
+  inline void set_resolved(int index, const void* value, size_t size);
+  inline ::std::string* add_resolved();
+  inline void add_resolved(const ::std::string& value);
+  inline void add_resolved(const char* value);
+  inline void add_resolved(const void* value, size_t size);
+  inline const ::google::protobuf::RepeatedPtrField< ::std::string>& resolved() const;
+  inline ::google::protobuf::RepeatedPtrField< ::std::string>* mutable_resolved();
+
   // @@protoc_insertion_point(class_scope:cockroach.proto.EndTransactionResponse)
  private:
   inline void set_has_header();
@@ -2085,6 +2101,7 @@ class EndTransactionResponse : public ::google::protobuf::Message {
   mutable int _cached_size_;
   ::cockroach::proto::ResponseHeader* header_;
   ::google::protobuf::int64 commit_wait_;
+  ::google::protobuf::RepeatedPtrField< ::std::string> resolved_;
   friend void  protobuf_AddDesc_cockroach_2fproto_2fapi_2eproto();
   friend void protobuf_AssignDesc_cockroach_2fproto_2fapi_2eproto();
   friend void protobuf_ShutdownFile_cockroach_2fproto_2fapi_2eproto();
@@ -5490,6 +5507,60 @@ inline void EndTransactionResponse::set_commit_wait(::google::protobuf::int64 va
   set_has_commit_wait();
   commit_wait_ = value;
   // @@protoc_insertion_point(field_set:cockroach.proto.EndTransactionResponse.commit_wait)
+}
+
+// repeated bytes resolved = 3;
+inline int EndTransactionResponse::resolved_size() const {
+  return resolved_.size();
+}
+inline void EndTransactionResponse::clear_resolved() {
+  resolved_.Clear();
+}
+inline const ::std::string& EndTransactionResponse::resolved(int index) const {
+  // @@protoc_insertion_point(field_get:cockroach.proto.EndTransactionResponse.resolved)
+  return resolved_.Get(index);
+}
+inline ::std::string* EndTransactionResponse::mutable_resolved(int index) {
+  // @@protoc_insertion_point(field_mutable:cockroach.proto.EndTransactionResponse.resolved)
+  return resolved_.Mutable(index);
+}
+inline void EndTransactionResponse::set_resolved(int index, const ::std::string& value) {
+  // @@protoc_insertion_point(field_set:cockroach.proto.EndTransactionResponse.resolved)
+  resolved_.Mutable(index)->assign(value);
+}
+inline void EndTransactionResponse::set_resolved(int index, const char* value) {
+  resolved_.Mutable(index)->assign(value);
+  // @@protoc_insertion_point(field_set_char:cockroach.proto.EndTransactionResponse.resolved)
+}
+inline void EndTransactionResponse::set_resolved(int index, const void* value, size_t size) {
+  resolved_.Mutable(index)->assign(
+    reinterpret_cast<const char*>(value), size);
+  // @@protoc_insertion_point(field_set_pointer:cockroach.proto.EndTransactionResponse.resolved)
+}
+inline ::std::string* EndTransactionResponse::add_resolved() {
+  return resolved_.Add();
+}
+inline void EndTransactionResponse::add_resolved(const ::std::string& value) {
+  resolved_.Add()->assign(value);
+  // @@protoc_insertion_point(field_add:cockroach.proto.EndTransactionResponse.resolved)
+}
+inline void EndTransactionResponse::add_resolved(const char* value) {
+  resolved_.Add()->assign(value);
+  // @@protoc_insertion_point(field_add_char:cockroach.proto.EndTransactionResponse.resolved)
+}
+inline void EndTransactionResponse::add_resolved(const void* value, size_t size) {
+  resolved_.Add()->assign(reinterpret_cast<const char*>(value), size);
+  // @@protoc_insertion_point(field_add_pointer:cockroach.proto.EndTransactionResponse.resolved)
+}
+inline const ::google::protobuf::RepeatedPtrField< ::std::string>&
+EndTransactionResponse::resolved() const {
+  // @@protoc_insertion_point(field_list:cockroach.proto.EndTransactionResponse.resolved)
+  return resolved_;
+}
+inline ::google::protobuf::RepeatedPtrField< ::std::string>*
+EndTransactionResponse::mutable_resolved() {
+  // @@protoc_insertion_point(field_mutable_list:cockroach.proto.EndTransactionResponse.resolved)
+  return &resolved_;
 }
 
 // -------------------------------------------------------------------

--- a/storage/engine/cockroach/proto/data.pb.cc
+++ b/storage/engine/cockroach/proto/data.pb.cc
@@ -233,10 +233,11 @@ void protobuf_AssignDesc_cockroach_2fproto_2fdata_2eproto() {
       ::google::protobuf::MessageFactory::generated_factory(),
       sizeof(ChangeReplicasTrigger));
   InternalCommitTrigger_descriptor_ = file->message_type(9);
-  static const int InternalCommitTrigger_offsets_[3] = {
+  static const int InternalCommitTrigger_offsets_[4] = {
     GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(InternalCommitTrigger, split_trigger_),
     GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(InternalCommitTrigger, merge_trigger_),
     GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(InternalCommitTrigger, change_replicas_trigger_),
+    GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(InternalCommitTrigger, intents_),
   };
   InternalCommitTrigger_reflection_ =
     new ::google::protobuf::internal::GeneratedMessageReflection(
@@ -483,44 +484,45 @@ void protobuf_AddDesc_cockroach_2fproto_2fdata_2eproto() {
     "\037\007StoreID\022=\n\013change_type\030\003 \001(\0162\".cockroa"
     "ch.proto.ReplicaChangeTypeB\004\310\336\037\000\0228\n\020upda"
     "ted_replicas\030\004 \003(\0132\030.cockroach.proto.Rep"
-    "licaB\004\310\336\037\000\"\314\001\n\025InternalCommitTrigger\0224\n\r"
+    "licaB\004\310\336\037\000\"\346\001\n\025InternalCommitTrigger\0224\n\r"
     "split_trigger\030\001 \001(\0132\035.cockroach.proto.Sp"
     "litTrigger\0224\n\rmerge_trigger\030\002 \001(\0132\035.cock"
     "roach.proto.MergeTrigger\022G\n\027change_repli"
     "cas_trigger\030\003 \001(\0132&.cockroach.proto.Chan"
-    "geReplicasTrigger\"#\n\010NodeList\022\021\n\005nodes\030\001"
-    " \003(\005B\002\020\001:\004\220\241\037\001\"\221\004\n\013Transaction\022\022\n\004name\030\001"
-    " \001(\tB\004\310\336\037\000\022\030\n\003key\030\002 \001(\014B\013\310\336\037\000\332\336\037\003Key\022\026\n\002"
-    "id\030\003 \001(\014B\n\310\336\037\000\342\336\037\002ID\022\026\n\010priority\030\004 \001(\005B\004"
-    "\310\336\037\000\0227\n\tisolation\030\005 \001(\0162\036.cockroach.prot"
-    "o.IsolationTypeB\004\310\336\037\000\0228\n\006status\030\006 \001(\0162\"."
-    "cockroach.proto.TransactionStatusB\004\310\336\037\000\022"
-    "\023\n\005epoch\030\007 \001(\005B\004\310\336\037\000\0222\n\016last_heartbeat\030\010"
-    " \001(\0132\032.cockroach.proto.Timestamp\0223\n\ttime"
-    "stamp\030\t \001(\0132\032.cockroach.proto.TimestampB"
-    "\004\310\336\037\000\0228\n\016orig_timestamp\030\n \001(\0132\032.cockroac"
-    "h.proto.TimestampB\004\310\336\037\000\0227\n\rmax_timestamp"
-    "\030\013 \001(\0132\032.cockroach.proto.TimestampB\004\310\336\037\000"
-    "\0226\n\rcertain_nodes\030\014 \001(\0132\031.cockroach.prot"
-    "o.NodeListB\004\310\336\037\000:\010\230\240\037\000\220\241\037\001\"\344\001\n\014MVCCMetad"
-    "ata\022)\n\003txn\030\001 \001(\0132\034.cockroach.proto.Trans"
-    "action\0223\n\ttimestamp\030\002 \001(\0132\032.cockroach.pr"
-    "oto.TimestampB\004\310\336\037\000\022\025\n\007deleted\030\003 \001(\010B\004\310\336"
-    "\037\000\022\027\n\tkey_bytes\030\004 \001(\003B\004\310\336\037\000\022\027\n\tval_bytes"
-    "\030\005 \001(\003B\004\310\336\037\000\022%\n\005value\030\006 \001(\0132\026.cockroach."
-    "proto.Value:\004\220\241\037\001\"N\n\nGCMetadata\022\035\n\017last_"
-    "scan_nanos\030\001 \001(\003B\004\310\336\037\000\022\033\n\023oldest_intent_"
-    "nanos\030\002 \001(\003:\004\220\241\037\001\"b\n\023TimeSeriesDatapoint"
-    "\022\035\n\017timestamp_nanos\030\001 \001(\003B\004\310\336\037\000\022\021\n\tint_v"
-    "alue\030\002 \001(\003\022\023\n\013float_value\030\003 \001(\002:\004\220\241\037\001\"d\n"
-    "\016TimeSeriesData\022\022\n\004name\030\001 \001(\tB\004\310\336\037\000\0228\n\nd"
-    "atapoints\030\002 \003(\0132$.cockroach.proto.TimeSe"
-    "riesDatapoint:\004\220\241\037\001*>\n\021ReplicaChangeType"
-    "\022\017\n\013ADD_REPLICA\020\000\022\022\n\016REMOVE_REPLICA\020\001\032\004\210"
-    "\243\036\000*5\n\rIsolationType\022\020\n\014SERIALIZABLE\020\000\022\014"
-    "\n\010SNAPSHOT\020\001\032\004\210\243\036\000*B\n\021TransactionStatus\022"
-    "\013\n\007PENDING\020\000\022\r\n\tCOMMITTED\020\001\022\013\n\007ABORTED\020\002"
-    "\032\004\210\243\036\000B\007Z\005proto", 2655);
+    "geReplicasTrigger\022\030\n\007intents\030\004 \003(\014B\007\332\336\037\003"
+    "Key\"#\n\010NodeList\022\021\n\005nodes\030\001 \003(\005B\002\020\001:\004\220\241\037\001"
+    "\"\221\004\n\013Transaction\022\022\n\004name\030\001 \001(\tB\004\310\336\037\000\022\030\n\003"
+    "key\030\002 \001(\014B\013\310\336\037\000\332\336\037\003Key\022\026\n\002id\030\003 \001(\014B\n\310\336\037\000"
+    "\342\336\037\002ID\022\026\n\010priority\030\004 \001(\005B\004\310\336\037\000\0227\n\tisolat"
+    "ion\030\005 \001(\0162\036.cockroach.proto.IsolationTyp"
+    "eB\004\310\336\037\000\0228\n\006status\030\006 \001(\0162\".cockroach.prot"
+    "o.TransactionStatusB\004\310\336\037\000\022\023\n\005epoch\030\007 \001(\005"
+    "B\004\310\336\037\000\0222\n\016last_heartbeat\030\010 \001(\0132\032.cockroa"
+    "ch.proto.Timestamp\0223\n\ttimestamp\030\t \001(\0132\032."
+    "cockroach.proto.TimestampB\004\310\336\037\000\0228\n\016orig_"
+    "timestamp\030\n \001(\0132\032.cockroach.proto.Timest"
+    "ampB\004\310\336\037\000\0227\n\rmax_timestamp\030\013 \001(\0132\032.cockr"
+    "oach.proto.TimestampB\004\310\336\037\000\0226\n\rcertain_no"
+    "des\030\014 \001(\0132\031.cockroach.proto.NodeListB\004\310\336"
+    "\037\000:\010\230\240\037\000\220\241\037\001\"\344\001\n\014MVCCMetadata\022)\n\003txn\030\001 \001"
+    "(\0132\034.cockroach.proto.Transaction\0223\n\ttime"
+    "stamp\030\002 \001(\0132\032.cockroach.proto.TimestampB"
+    "\004\310\336\037\000\022\025\n\007deleted\030\003 \001(\010B\004\310\336\037\000\022\027\n\tkey_byte"
+    "s\030\004 \001(\003B\004\310\336\037\000\022\027\n\tval_bytes\030\005 \001(\003B\004\310\336\037\000\022%"
+    "\n\005value\030\006 \001(\0132\026.cockroach.proto.Value:\004\220"
+    "\241\037\001\"N\n\nGCMetadata\022\035\n\017last_scan_nanos\030\001 \001"
+    "(\003B\004\310\336\037\000\022\033\n\023oldest_intent_nanos\030\002 \001(\003:\004\220"
+    "\241\037\001\"b\n\023TimeSeriesDatapoint\022\035\n\017timestamp_"
+    "nanos\030\001 \001(\003B\004\310\336\037\000\022\021\n\tint_value\030\002 \001(\003\022\023\n\013"
+    "float_value\030\003 \001(\002:\004\220\241\037\001\"d\n\016TimeSeriesDat"
+    "a\022\022\n\004name\030\001 \001(\tB\004\310\336\037\000\0228\n\ndatapoints\030\002 \003("
+    "\0132$.cockroach.proto.TimeSeriesDatapoint:"
+    "\004\220\241\037\001*>\n\021ReplicaChangeType\022\017\n\013ADD_REPLIC"
+    "A\020\000\022\022\n\016REMOVE_REPLICA\020\001\032\004\210\243\036\000*5\n\rIsolati"
+    "onType\022\020\n\014SERIALIZABLE\020\000\022\014\n\010SNAPSHOT\020\001\032\004"
+    "\210\243\036\000*B\n\021TransactionStatus\022\013\n\007PENDING\020\000\022\r"
+    "\n\tCOMMITTED\020\001\022\013\n\007ABORTED\020\002\032\004\210\243\036\000B\007Z\005prot"
+    "o", 2681);
   ::google::protobuf::MessageFactory::InternalRegisterGeneratedFile(
     "cockroach/proto/data.proto", &protobuf_RegisterTypes);
   Timestamp::default_instance_ = new Timestamp();
@@ -3360,6 +3362,7 @@ void ChangeReplicasTrigger::Swap(ChangeReplicasTrigger* other) {
 const int InternalCommitTrigger::kSplitTriggerFieldNumber;
 const int InternalCommitTrigger::kMergeTriggerFieldNumber;
 const int InternalCommitTrigger::kChangeReplicasTriggerFieldNumber;
+const int InternalCommitTrigger::kIntentsFieldNumber;
 #endif  // !_MSC_VER
 
 InternalCommitTrigger::InternalCommitTrigger()
@@ -3382,6 +3385,7 @@ InternalCommitTrigger::InternalCommitTrigger(const InternalCommitTrigger& from)
 }
 
 void InternalCommitTrigger::SharedCtor() {
+  ::google::protobuf::internal::GetEmptyString();
   _cached_size_ = 0;
   split_trigger_ = NULL;
   merge_trigger_ = NULL;
@@ -3435,6 +3439,7 @@ void InternalCommitTrigger::Clear() {
       if (change_replicas_trigger_ != NULL) change_replicas_trigger_->::cockroach::proto::ChangeReplicasTrigger::Clear();
     }
   }
+  intents_.Clear();
   ::memset(_has_bits_, 0, sizeof(_has_bits_));
   mutable_unknown_fields()->Clear();
 }
@@ -3483,6 +3488,20 @@ bool InternalCommitTrigger::MergePartialFromCodedStream(
         } else {
           goto handle_unusual;
         }
+        if (input->ExpectTag(34)) goto parse_intents;
+        break;
+      }
+
+      // repeated bytes intents = 4;
+      case 4: {
+        if (tag == 34) {
+         parse_intents:
+          DO_(::google::protobuf::internal::WireFormatLite::ReadBytes(
+                input, this->add_intents()));
+        } else {
+          goto handle_unusual;
+        }
+        if (input->ExpectTag(34)) goto parse_intents;
         if (input->ExpectAtEnd()) goto success;
         break;
       }
@@ -3530,6 +3549,12 @@ void InternalCommitTrigger::SerializeWithCachedSizes(
       3, this->change_replicas_trigger(), output);
   }
 
+  // repeated bytes intents = 4;
+  for (int i = 0; i < this->intents_size(); i++) {
+    ::google::protobuf::internal::WireFormatLite::WriteBytes(
+      4, this->intents(i), output);
+  }
+
   if (!unknown_fields().empty()) {
     ::google::protobuf::internal::WireFormat::SerializeUnknownFields(
         unknown_fields(), output);
@@ -3559,6 +3584,12 @@ void InternalCommitTrigger::SerializeWithCachedSizes(
     target = ::google::protobuf::internal::WireFormatLite::
       WriteMessageNoVirtualToArray(
         3, this->change_replicas_trigger(), target);
+  }
+
+  // repeated bytes intents = 4;
+  for (int i = 0; i < this->intents_size(); i++) {
+    target = ::google::protobuf::internal::WireFormatLite::
+      WriteBytesToArray(4, this->intents(i), target);
   }
 
   if (!unknown_fields().empty()) {
@@ -3595,6 +3626,13 @@ int InternalCommitTrigger::ByteSize() const {
     }
 
   }
+  // repeated bytes intents = 4;
+  total_size += 1 * this->intents_size();
+  for (int i = 0; i < this->intents_size(); i++) {
+    total_size += ::google::protobuf::internal::WireFormatLite::BytesSize(
+      this->intents(i));
+  }
+
   if (!unknown_fields().empty()) {
     total_size +=
       ::google::protobuf::internal::WireFormat::ComputeUnknownFieldsSize(
@@ -3620,6 +3658,7 @@ void InternalCommitTrigger::MergeFrom(const ::google::protobuf::Message& from) {
 
 void InternalCommitTrigger::MergeFrom(const InternalCommitTrigger& from) {
   GOOGLE_CHECK_NE(&from, this);
+  intents_.MergeFrom(from.intents_);
   if (from._has_bits_[0 / 32] & (0xffu << (0 % 32))) {
     if (from.has_split_trigger()) {
       mutable_split_trigger()->::cockroach::proto::SplitTrigger::MergeFrom(from.split_trigger());
@@ -3656,6 +3695,7 @@ void InternalCommitTrigger::Swap(InternalCommitTrigger* other) {
     std::swap(split_trigger_, other->split_trigger_);
     std::swap(merge_trigger_, other->merge_trigger_);
     std::swap(change_replicas_trigger_, other->change_replicas_trigger_);
+    intents_.Swap(&other->intents_);
     std::swap(_has_bits_[0], other->_has_bits_[0]);
     _unknown_fields_.Swap(&other->_unknown_fields_);
     std::swap(_cached_size_, other->_cached_size_);

--- a/storage/engine/cockroach/proto/data.pb.h
+++ b/storage/engine/cockroach/proto/data.pb.h
@@ -1100,6 +1100,22 @@ class InternalCommitTrigger : public ::google::protobuf::Message {
   inline ::cockroach::proto::ChangeReplicasTrigger* release_change_replicas_trigger();
   inline void set_allocated_change_replicas_trigger(::cockroach::proto::ChangeReplicasTrigger* change_replicas_trigger);
 
+  // repeated bytes intents = 4;
+  inline int intents_size() const;
+  inline void clear_intents();
+  static const int kIntentsFieldNumber = 4;
+  inline const ::std::string& intents(int index) const;
+  inline ::std::string* mutable_intents(int index);
+  inline void set_intents(int index, const ::std::string& value);
+  inline void set_intents(int index, const char* value);
+  inline void set_intents(int index, const void* value, size_t size);
+  inline ::std::string* add_intents();
+  inline void add_intents(const ::std::string& value);
+  inline void add_intents(const char* value);
+  inline void add_intents(const void* value, size_t size);
+  inline const ::google::protobuf::RepeatedPtrField< ::std::string>& intents() const;
+  inline ::google::protobuf::RepeatedPtrField< ::std::string>* mutable_intents();
+
   // @@protoc_insertion_point(class_scope:cockroach.proto.InternalCommitTrigger)
  private:
   inline void set_has_split_trigger();
@@ -1116,6 +1132,7 @@ class InternalCommitTrigger : public ::google::protobuf::Message {
   ::cockroach::proto::SplitTrigger* split_trigger_;
   ::cockroach::proto::MergeTrigger* merge_trigger_;
   ::cockroach::proto::ChangeReplicasTrigger* change_replicas_trigger_;
+  ::google::protobuf::RepeatedPtrField< ::std::string> intents_;
   friend void  protobuf_AddDesc_cockroach_2fproto_2fdata_2eproto();
   friend void protobuf_AssignDesc_cockroach_2fproto_2fdata_2eproto();
   friend void protobuf_ShutdownFile_cockroach_2fproto_2fdata_2eproto();
@@ -3001,6 +3018,60 @@ inline void InternalCommitTrigger::set_allocated_change_replicas_trigger(::cockr
     clear_has_change_replicas_trigger();
   }
   // @@protoc_insertion_point(field_set_allocated:cockroach.proto.InternalCommitTrigger.change_replicas_trigger)
+}
+
+// repeated bytes intents = 4;
+inline int InternalCommitTrigger::intents_size() const {
+  return intents_.size();
+}
+inline void InternalCommitTrigger::clear_intents() {
+  intents_.Clear();
+}
+inline const ::std::string& InternalCommitTrigger::intents(int index) const {
+  // @@protoc_insertion_point(field_get:cockroach.proto.InternalCommitTrigger.intents)
+  return intents_.Get(index);
+}
+inline ::std::string* InternalCommitTrigger::mutable_intents(int index) {
+  // @@protoc_insertion_point(field_mutable:cockroach.proto.InternalCommitTrigger.intents)
+  return intents_.Mutable(index);
+}
+inline void InternalCommitTrigger::set_intents(int index, const ::std::string& value) {
+  // @@protoc_insertion_point(field_set:cockroach.proto.InternalCommitTrigger.intents)
+  intents_.Mutable(index)->assign(value);
+}
+inline void InternalCommitTrigger::set_intents(int index, const char* value) {
+  intents_.Mutable(index)->assign(value);
+  // @@protoc_insertion_point(field_set_char:cockroach.proto.InternalCommitTrigger.intents)
+}
+inline void InternalCommitTrigger::set_intents(int index, const void* value, size_t size) {
+  intents_.Mutable(index)->assign(
+    reinterpret_cast<const char*>(value), size);
+  // @@protoc_insertion_point(field_set_pointer:cockroach.proto.InternalCommitTrigger.intents)
+}
+inline ::std::string* InternalCommitTrigger::add_intents() {
+  return intents_.Add();
+}
+inline void InternalCommitTrigger::add_intents(const ::std::string& value) {
+  intents_.Add()->assign(value);
+  // @@protoc_insertion_point(field_add:cockroach.proto.InternalCommitTrigger.intents)
+}
+inline void InternalCommitTrigger::add_intents(const char* value) {
+  intents_.Add()->assign(value);
+  // @@protoc_insertion_point(field_add_char:cockroach.proto.InternalCommitTrigger.intents)
+}
+inline void InternalCommitTrigger::add_intents(const void* value, size_t size) {
+  intents_.Add()->assign(reinterpret_cast<const char*>(value), size);
+  // @@protoc_insertion_point(field_add_pointer:cockroach.proto.InternalCommitTrigger.intents)
+}
+inline const ::google::protobuf::RepeatedPtrField< ::std::string>&
+InternalCommitTrigger::intents() const {
+  // @@protoc_insertion_point(field_list:cockroach.proto.InternalCommitTrigger.intents)
+  return intents_;
+}
+inline ::google::protobuf::RepeatedPtrField< ::std::string>*
+InternalCommitTrigger::mutable_intents() {
+  // @@protoc_insertion_point(field_mutable_list:cockroach.proto.InternalCommitTrigger.intents)
+  return &intents_;
 }
 
 // -------------------------------------------------------------------

--- a/storage/range.go
+++ b/storage/range.go
@@ -790,7 +790,7 @@ func (r *Range) executeCmd(index uint64, method string, args proto.Request,
 	case proto.Scan:
 		r.Scan(batch, args.(*proto.ScanRequest), reply.(*proto.ScanResponse))
 	case proto.EndTransaction:
-		r.EndTransaction(batch, args.(*proto.EndTransactionRequest), reply.(*proto.EndTransactionResponse))
+		r.EndTransaction(batch, &ms, args.(*proto.EndTransactionRequest), reply.(*proto.EndTransactionResponse))
 	case proto.ReapQueue:
 		r.ReapQueue(batch, args.(*proto.ReapQueueRequest), reply.(*proto.ReapQueueResponse))
 	case proto.EnqueueUpdate:
@@ -944,7 +944,7 @@ func (r *Range) Scan(batch engine.Engine, args *proto.ScanRequest, reply *proto.
 
 // EndTransaction either commits or aborts (rolls back) an extant
 // transaction according to the args.Commit parameter.
-func (r *Range) EndTransaction(batch engine.Engine, args *proto.EndTransactionRequest, reply *proto.EndTransactionResponse) {
+func (r *Range) EndTransaction(batch engine.Engine, ms *engine.MVCCStats, args *proto.EndTransactionRequest, reply *proto.EndTransactionResponse) {
 	if args.Txn == nil {
 		reply.SetGoError(util.Errorf("no transaction specified to EndTransaction"))
 		return
@@ -1025,8 +1025,18 @@ func (r *Range) EndTransaction(batch engine.Engine, args *proto.EndTransactionRe
 
 	// Run triggers if successfully committed. Any failures running
 	// triggers will set an error and prevent the batch from committing.
-	if reply.Txn.Status == proto.COMMITTED {
-		if ct := args.InternalCommitTrigger; ct != nil {
+	if ct := args.InternalCommitTrigger; ct != nil {
+		// Resolve any explicit intents.
+		for _, key := range ct.Intents {
+			log.V(1).Infof("resolving intent at %s on end transaction [%s]", key, reply.Txn.Status)
+			if err := engine.MVCCResolveWriteIntent(batch, ms, key, reply.Txn.Timestamp, reply.Txn); err != nil {
+				reply.SetGoError(err)
+				return
+			}
+			reply.Resolved = append(reply.Resolved, key)
+		}
+		// Run appropriate trigger.
+		if reply.Txn.Status == proto.COMMITTED {
 			if ct.SplitTrigger != nil {
 				reply.SetGoError(r.splitTrigger(batch, ct.SplitTrigger))
 			} else if ct.MergeTrigger != nil {
@@ -1903,11 +1913,13 @@ func (r *Range) AdminSplit(args *proto.AdminSplitRequest, reply *proto.AdminSpli
 		// Create range descriptor for second half of split.
 		// Note that this put must go first in order to locate the
 		// transaction record on the correct range.
-		if err := txn.PreparePutProto(engine.RangeDescriptorKey(newDesc.StartKey), newDesc); err != nil {
+		desc1Key := engine.RangeDescriptorKey(newDesc.StartKey)
+		if err := txn.PreparePutProto(desc1Key, newDesc); err != nil {
 			return err
 		}
 		// Update existing range descriptor for first half of split.
-		if err := txn.PreparePutProto(engine.RangeDescriptorKey(updatedDesc.StartKey), &updatedDesc); err != nil {
+		desc2Key := engine.RangeDescriptorKey(updatedDesc.StartKey)
+		if err := txn.PreparePutProto(desc2Key, &updatedDesc); err != nil {
 			return err
 		}
 		// Update range descriptor addressing record(s).
@@ -1928,6 +1940,7 @@ func (r *Range) AdminSplit(args *proto.AdminSplitRequest, reply *proto.AdminSpli
 					UpdatedDesc: updatedDesc,
 					NewDesc:     *newDesc,
 				},
+				Intents: []proto.Key{desc1Key, desc2Key},
 			},
 		}, &proto.EndTransactionResponse{})
 	}); err != nil {
@@ -2005,13 +2018,15 @@ func (r *Range) AdminMerge(args *proto.AdminMergeRequest, reply *proto.AdminMerg
 	}
 	if err := r.rm.DB().RunTransaction(txnOpts, func(txn *client.KV) error {
 		// Update the range descriptor for the receiving range.
-		if err := txn.PreparePutProto(engine.RangeDescriptorKey(updatedDesc.StartKey), &updatedDesc); err != nil {
+		desc1Key := engine.RangeDescriptorKey(updatedDesc.StartKey)
+		if err := txn.PreparePutProto(desc1Key, &updatedDesc); err != nil {
 			return err
 		}
 
 		// Remove the range descriptor for the deleted range.
+		desc2Key := engine.RangeDescriptorKey(subsumedDesc.StartKey)
 		deleteResponse := &proto.DeleteResponse{}
-		txn.Prepare(proto.Delete, proto.DeleteArgs(engine.RangeDescriptorKey(subsumedDesc.StartKey)),
+		txn.Prepare(proto.Delete, proto.DeleteArgs(desc2Key),
 			deleteResponse)
 
 		if err := MergeRangeAddressing(txn, desc, &updatedDesc); err != nil {
@@ -2028,6 +2043,7 @@ func (r *Range) AdminMerge(args *proto.AdminMergeRequest, reply *proto.AdminMerg
 					UpdatedDesc:    updatedDesc,
 					SubsumedRaftID: subsumedDesc.RaftID,
 				},
+				Intents: []proto.Key{desc1Key, desc2Key},
 			},
 		}, &proto.EndTransactionResponse{})
 	}); err != nil {
@@ -2076,7 +2092,8 @@ func (r *Range) ChangeReplicas(changeType proto.ReplicaChangeType, replica proto
 	err := r.rm.DB().RunTransaction(txnOpts, func(txn *client.KV) error {
 		// Important: the range descriptor must be the first thing touched in the transaction
 		// so the transaction record is co-located with the range being modified.
-		if err := txn.PreparePutProto(engine.RangeDescriptorKey(updatedDesc.StartKey), &updatedDesc); err != nil {
+		descKey := engine.RangeDescriptorKey(updatedDesc.StartKey)
+		if err := txn.PreparePutProto(descKey, &updatedDesc); err != nil {
 			return err
 		}
 
@@ -2094,6 +2111,7 @@ func (r *Range) ChangeReplicas(changeType proto.ReplicaChangeType, replica proto
 					ChangeType:      changeType,
 					UpdatedReplicas: updatedDesc.Replicas,
 				},
+				Intents: []proto.Key{descKey},
 			},
 		}, &proto.EndTransactionResponse{})
 	})


### PR DESCRIPTION
Using the InternalCommitTrigger option inside of EndTransaction, keys
which are known to fall within the same range as the transaction may
be preemptively resolved at commit time. This prevents the possibility
of any intents existing on certain keys after their transaction has been
committed. This is important for the case of transactions which modify
range descriptors, including splits, merges & replica changes.

When the range descriptors are scanned at startup and when read during
raft snapshot replays, dangling intents are very problematic, if there's
a chance that the transaction which created them might have already been
committed. This change prevents that.
