### PR TITLE
Fix a small bug in parseBootstrapAddresses()

### DIFF
--- a/gossip/gossip.go
+++ b/gossip/gossip.go
@@ -318,7 +318,7 @@ func (g *Gossip) parseBootstrapAddresses() {
 	}
 
 	// If we have no bootstrap hosts, fatal exit.
-	if len(addresses) == 0 && g.bootstraps.len() == 0 {
+	if g.gossipBootstrap == "" && g.bootstraps.len() == 0 && !g.isBootstrap {
 		log.Fatalf("no hosts specified for gossip network (use -gossip)")
 	}
 	// Remove our own node address.

--- a/server/server_test.go
+++ b/server/server_test.go
@@ -170,6 +170,13 @@ func TestInitEngines(t *testing.T) {
 	}
 }
 
+// TestSelfBootstrap verifies operation when no bootstrap hosts have
+// been specified.
+func TestSelfBootstrap(t *testing.T) {
+	s := startTestServer(t)
+	s.Stop()
+}
+
 // TestHealthz verifies that /_admin/healthz does, in fact, return "ok"
 // as expected.
 func TestHealthz(t *testing.T) {


### PR DESCRIPTION
len(strings.Spllit("", ",")) returns 1, so the previous 'if' condition for no bootstrap node returns false even if g.gossipBootstrap is an empty string.

When I changed the 'if' condition to check g.gossipBootstrap == "", several tests got a panic in the following case:

1) SetBootstrap([]net.Addr{s.rpc.Addr()}) is called for self-bootstrap and the node's address is added to g.bootstraps.
2) bootstrap() calls parseBootstrapAddresses() and removes the its own node address from g.bootstraps. g.bootstraps becomes empty.
3) g.Gossip() is called and parseBootstrapAddresses() is called again from bootstrap(). The check fails thsi time since g.bootstraps is empty.

Working around this by adding '!g.isBootstrap' to the 'if' condition.
