### PR TITLE
add test for eviction of stale range descriptors & retry logic

### DIFF
--- a/server/cli/range.go
+++ b/server/cli/range.go
@@ -124,7 +124,8 @@ var mergeRangeCmd = &commander.Command{
 	UsageLine: "merge-range [options] <key>",
 	Short:     "merges a range\n",
 	Long: `
-Merges the range containing <key> with the immediate successor range.
+Extends the range containing <key> to contain its immediate successor range.
+The two ranges must be co-located on the same set of replicas.
 `,
 	Run:  runMergeRange,
 	Flag: *flag.CommandLine,

--- a/storage/range.go
+++ b/storage/range.go
@@ -1980,6 +1980,7 @@ func (r *Range) AdminMerge(args *proto.AdminMergeRequest, reply *proto.AdminMerg
 
 	// Make sure the range being subsumed follows this one.
 	if !bytes.Equal(desc.EndKey, subsumedDesc.StartKey) {
+		// TODO why is %d used for printing here?
 		reply.SetGoError(util.Errorf("Ranges that are not adjacent cannot be merged, %d = %d",
 			desc.EndKey, subsumedDesc.StartKey))
 		return
@@ -1988,7 +1989,7 @@ func (r *Range) AdminMerge(args *proto.AdminMergeRequest, reply *proto.AdminMerg
 	// Ensure that both ranges are collocate by intersecting the store ids from
 	// their replicas.
 	if !ReplicaSetsEqual(subsumedDesc.GetReplicas(), desc.GetReplicas()) {
-		reply.SetGoError(util.Error("The two ranges replicas are not collocate"))
+		reply.SetGoError(util.Error("The two ranges replicas are not collocated"))
 		return
 	}
 


### PR DESCRIPTION
Starting to add some more tests for the `DistSender#Send` logic.

I've found that it's slightly awkward that we have to pass a `Replica` into `AdminMerge` via the `AdminMergeRequest`. Could specifying the next replica be optional instead?

I've also wondered about the use of `%d` in

```
reply.SetGoError(util.Errorf("Ranges that are not adjacent cannot be merged, %d = %d",
            desc.EndKey, subsumedDesc.StartKey))
```
