### PR TITLE
DistSender replica selection refinements

### DIFF
--- a/gossip/gossip.go
+++ b/gossip/gossip.go
@@ -62,6 +62,7 @@ import (
 	"sync"
 	"time"
 
+	"github.com/cockroachdb/cockroach/proto"
 	"github.com/cockroachdb/cockroach/rpc"
 	"github.com/cockroachdb/cockroach/util"
 	"github.com/cockroachdb/cockroach/util/log"
@@ -97,7 +98,7 @@ var (
 // During bootstrapping, the bootstrap list contains candidates for
 // entry to the gossip network.
 type Gossip struct {
-	NodeID       int32              // Optional node ID
+	nodeID       proto.NodeID       // Optional node ID
 	Connected    chan struct{}      // Closed upon initial connection
 	hasConnected bool               // Set first time network is connected
 	isBootstrap  bool               // True if this node is a bootstrap host
@@ -130,6 +131,23 @@ func New(rpcContext *rpc.Context, gossipInterval time.Duration, gossipBootstrap 
 		gossipBootstrap: gossipBootstrap,
 	}
 	return g
+}
+
+// GetNodeID returns the instance's saved NodeID.
+func (g *Gossip) GetNodeID() proto.NodeID {
+	g.mu.Lock()
+	id := g.nodeID
+	g.mu.Unlock()
+	return id
+}
+
+// SetNodeID sets the Gossip instance's NodeID.
+// It is typically only set once, but is only obtained
+// after creating the instance.
+func (g *Gossip) SetNodeID(id proto.NodeID) {
+	g.mu.Lock()
+	g.nodeID = id
+	g.mu.Unlock()
 }
 
 // SetBootstrap initializes the set of gossip node addresses used to

--- a/gossip/gossip.go
+++ b/gossip/gossip.go
@@ -97,7 +97,7 @@ var (
 // During bootstrapping, the bootstrap list contains candidates for
 // entry to the gossip network.
 type Gossip struct {
-	Name         string             // Optional node name
+	NodeID       int32              // Optional node ID
 	Connected    chan struct{}      // Closed upon initial connection
 	hasConnected bool               // Set first time network is connected
 	isBootstrap  bool               // True if this node is a bootstrap host

--- a/gossip/gossip.go
+++ b/gossip/gossip.go
@@ -136,8 +136,8 @@ func New(rpcContext *rpc.Context, gossipInterval time.Duration, gossipBootstrap 
 // GetNodeID returns the instance's saved NodeID.
 func (g *Gossip) GetNodeID() proto.NodeID {
 	g.mu.Lock()
+	defer g.mu.Unlock()
 	id := g.nodeID
-	g.mu.Unlock()
 	return id
 }
 
@@ -146,8 +146,8 @@ func (g *Gossip) GetNodeID() proto.NodeID {
 // after creating the instance.
 func (g *Gossip) SetNodeID(id proto.NodeID) {
 	g.mu.Lock()
+	defer g.mu.Unlock()
 	g.nodeID = id
-	g.mu.Unlock()
 }
 
 // SetBootstrap initializes the set of gossip node addresses used to

--- a/gossip/simulation/gossip.go
+++ b/gossip/simulation/gossip.go
@@ -226,7 +226,7 @@ func outputDotFile(dotFN string, cycle int, network *simulation.Network, edgeSet
 				(maxDotFontSize-minDotFontSize))/float64(maxIncoming)))
 		}
 		f.WriteString(fmt.Sprintf("\t%s [%sfontsize=%d,label=\"{%s|MH=%d, AA=%s, SA=%d}\"]\n",
-			node.Name, nodeColor, fontSize, node.Name, node.MaxHops(), age, sentinelAge))
+			node.GetNodeID(), nodeColor, fontSize, node.GetNodeID(), node.MaxHops(), age, sentinelAge))
 		outgoing := outgoingMap[simNode.Addr.String()]
 		for _, e := range outgoing {
 			destSimNode, ok := network.GetNodeFromAddr(e.dest)
@@ -240,7 +240,7 @@ func outputDotFile(dotFN string, cycle int, network *simulation.Network, edgeSet
 			} else if e.deleted {
 				style = " [color=red,style=dotted]"
 			}
-			f.WriteString(fmt.Sprintf("\t%s -> %s%s\n", node.Name, dest.Name, style))
+			f.WriteString(fmt.Sprintf("\t%s -> %s%s\n", node.GetNodeID(), dest.GetNodeID(), style))
 			if !e.deleted {
 				edgeSet[fmt.Sprintf("%s:%s", simNode.Addr, e.dest)] = e
 			}
@@ -298,7 +298,7 @@ func main() {
 
 	edgeSet := make(map[string]edge)
 
-	n := simulation.NewNetwork(nodeCount, *networkType, gossipInterval)
+	n := simulation.NewNetwork(nodeCount, *networkType, gossipInterval, "")
 	n.SimulateNetwork(
 		func(cycle int, network *simulation.Network) bool {
 			if cycle == numCycles {

--- a/gossip/simulation/network.go
+++ b/gossip/simulation/network.go
@@ -18,7 +18,6 @@
 package simulation
 
 import (
-	"fmt"
 	"net"
 	"time"
 
@@ -82,7 +81,7 @@ func NewNetwork(nodeCount int, networkType string,
 	nodes := make([]*Node, nodeCount)
 	for i := 0; i < nodeCount; i++ {
 		node := gossip.New(rpcContext, gossipInterval, bootstrap)
-		node.Name = fmt.Sprintf("Node%d", i)
+		node.NodeID = int32(i)
 		node.Start(servers[i], stopper)
 		stopper.AddCloser(servers[i])
 		// Node 0 gossips node count.

--- a/gossip/simulation/network.go
+++ b/gossip/simulation/network.go
@@ -22,6 +22,7 @@ import (
 	"time"
 
 	"github.com/cockroachdb/cockroach/gossip"
+	"github.com/cockroachdb/cockroach/proto"
 	"github.com/cockroachdb/cockroach/rpc"
 	"github.com/cockroachdb/cockroach/util"
 	"github.com/cockroachdb/cockroach/util/hlc"
@@ -81,7 +82,7 @@ func NewNetwork(nodeCount int, networkType string,
 	nodes := make([]*Node, nodeCount)
 	for i := 0; i < nodeCount; i++ {
 		node := gossip.New(rpcContext, gossipInterval, bootstrap)
-		node.NodeID = int32(i)
+		node.SetNodeID(proto.NodeID(i))
 		node.Start(servers[i], stopper)
 		stopper.AddCloser(servers[i])
 		// Node 0 gossips node count.

--- a/kv/dist_sender.go
+++ b/kv/dist_sender.go
@@ -48,7 +48,7 @@ const (
 	// from an internal range lookup.
 	defaultRangeLookupMaxRanges = 8
 	// The default size of the leader cache.
-	defaultLeaderCacheSize = 1 << 20
+	defaultLeaderCacheSize = 1 << 16
 	// The default size of the range descriptor cache.
 	defaultRangeDescriptorCacheSize = 1 << 20
 )

--- a/kv/dist_sender.go
+++ b/kv/dist_sender.go
@@ -555,7 +555,7 @@ func (ds *DistSender) Send(call *client.Call) {
 					return util.RetryReset, nil
 				case *proto.NotLeaderError:
 					ds.updateLeaderCache(proto.RaftID(desc.RaftID),
-						err.(*proto.NotLeaderError).Leader)
+						err.(*proto.NotLeaderError).GetLeader())
 					return util.RetryReset, nil
 				default:
 					if retryErr, ok := err.(util.Retryable); ok && retryErr.CanRetry() {

--- a/kv/dist_sender.go
+++ b/kv/dist_sender.go
@@ -245,12 +245,14 @@ func (ds *DistSender) verifyPermissions(method string, header *proto.RequestHead
 		})
 }
 
-// internalRangeLookup dispatches an InternalRangeLookup request for
-// the given metadata key to the replicas of the given range. Note
-// that we allow inconsistent reads when doing range lookups for
-// effiency. Getting stale data is not a correctness problem but
-// instead may infrequently result in additional latency as additional
-// range lookups may be required.
+// internalRangeLookup dispatches an InternalRangeLookup request for the given
+// metadata key to the replicas of the given range. Note that we allow
+// inconsistent reads when doing range lookups for effiency. Getting stale data
+// is not a correctness problem but instead may infrequently result in
+// additional latency as additional range lookups may be required. Note also
+// that internalRangeLookup bypasses the DistSender's Send() method, so there
+// is no error inspection and retry logic here; this is not an issue here since
+// the lookup performs a single inconsistent read only.
 func (ds *DistSender) internalRangeLookup(key proto.Key, info *proto.RangeDescriptor) ([]proto.RangeDescriptor, error) {
 	args := &proto.InternalRangeLookupRequest{
 		RequestHeader: proto.RequestHeader{

--- a/kv/dist_sender.go
+++ b/kv/dist_sender.go
@@ -356,10 +356,10 @@ func (ds *DistSender) sendRPC(desc *proto.RangeDescriptor, method string,
 			// us and hence better candidates.
 			order = rpc.OrderStable
 		}
-	} else {
+	} else if ds.gossip.NodeID > 0 {
 		// A normal node should always have that information set in Gossip when
-		// booting, so this is worth complaining about.
-		log.Warningf("own NodeDescriptor node available via Gossip, rpcs will be sent randomly")
+		// bootstrapped, so this is worth complaining about.
+		log.Warningf("own NodeDescriptor %d not available via Gossip", ds.gossip.NodeID)
 	}
 
 	// If this request needs to go to a leader and we know who that is, move

--- a/kv/leader_cache.go
+++ b/kv/leader_cache.go
@@ -63,7 +63,10 @@ func (lc *leaderCache) Update(group proto.RaftID, r *proto.Replica) {
 	lc.mu.Lock()
 	lc.cache.Del(group)
 	if r != nil {
-		lc.cache.Add(group, r)
+		// Replicas reside inside of slices that are subject to rearrangements,
+		// so let's avoid trouble here.
+		rCopy := *r
+		lc.cache.Add(group, &rCopy)
 	}
 	lc.mu.Unlock()
 }

--- a/kv/leader_cache.go
+++ b/kv/leader_cache.go
@@ -59,14 +59,11 @@ func (lc *leaderCache) Lookup(group proto.RaftID) *proto.Replica {
 
 // Update invalidates the cached leader for the given Raft group.
 // If a replica is passed in, it is inserted into the cache.
-func (lc *leaderCache) Update(group proto.RaftID, r *proto.Replica) {
+func (lc *leaderCache) Update(group proto.RaftID, r proto.Replica) {
 	lc.mu.Lock()
 	lc.cache.Del(group)
-	if r != nil {
-		// Replicas reside inside of slices that are subject to rearrangements,
-		// so let's avoid trouble here.
-		rCopy := *r
-		lc.cache.Add(group, &rCopy)
+	if r.StoreID != 0 {
+		lc.cache.Add(group, &r)
 	}
 	lc.mu.Unlock()
 }

--- a/kv/leader_cache.go
+++ b/kv/leader_cache.go
@@ -59,6 +59,7 @@ func (lc *leaderCache) Lookup(group proto.RaftID) *proto.Replica {
 
 // Update invalidates the cached leader for the given Raft group.
 // If a replica is passed in, it is inserted into the cache.
+// A StoreID of 0 (empty replica) means evict.
 func (lc *leaderCache) Update(group proto.RaftID, r proto.Replica) {
 	lc.mu.Lock()
 	lc.cache.Del(group)

--- a/kv/leader_cache_test.go
+++ b/kv/leader_cache_test.go
@@ -29,18 +29,18 @@ func TestLeaderCache(t *testing.T) {
 	if r := lc.Lookup(12); r != nil {
 		t.Fatalf("lookup of missing key returned replica: %v", r)
 	}
-	replica := &proto.Replica{StoreID: 1}
+	replica := proto.Replica{StoreID: 1}
 	lc.Update(5, replica)
-	if r := lc.Lookup(5); !reflect.DeepEqual(replica, r) {
+	if r := lc.Lookup(5); !reflect.DeepEqual(&replica, r) {
 		t.Errorf("expected %v, got %v", replica, r)
 	}
-	newReplica := &proto.Replica{StoreID: 7}
+	newReplica := proto.Replica{StoreID: 7}
 	lc.Update(5, newReplica)
 	r := lc.Lookup(5)
-	if !reflect.DeepEqual(newReplica, r) {
+	if !reflect.DeepEqual(&newReplica, r) {
 		t.Errorf("expected %v, got %v", newReplica, r)
 	}
-	lc.Update(5, nil)
+	lc.Update(5, proto.Replica{})
 	r = lc.Lookup(5)
 	if r != nil {
 		t.Fatalf("evicted leader returned: %v", r)
@@ -51,15 +51,5 @@ func TestLeaderCache(t *testing.T) {
 	}
 	if lc.Lookup(16) != nil || lc.Lookup(17) == nil {
 		t.Errorf("unexpected policy used in cache")
-	}
-}
-
-func TestLeaderCachePointers(t *testing.T) {
-	lc := newLeaderCache(3)
-	r := &proto.Replica{StoreID: 1}
-	lc.Update(1, r)
-	r.StoreID = 2
-	if lc.Lookup(1).StoreID != 1 {
-		t.Errorf("leader cache did not copy the supplied replica")
 	}
 }

--- a/kv/leader_cache_test.go
+++ b/kv/leader_cache_test.go
@@ -53,3 +53,13 @@ func TestLeaderCache(t *testing.T) {
 		t.Errorf("unexpected policy used in cache")
 	}
 }
+
+func TestLeaderCachePointers(t *testing.T) {
+	lc := newLeaderCache(3)
+	r := &proto.Replica{StoreID: 1}
+	lc.Update(1, r)
+	r.StoreID = 2
+	if lc.Lookup(1).StoreID != 1 {
+		t.Errorf("leader cache did not copy the supplied replica")
+	}
+}

--- a/proto/config.go
+++ b/proto/config.go
@@ -127,12 +127,7 @@ func (r *RangeDescriptor) ContainsKeyRange(start, end []byte) bool {
 // FindReplica returns the replica which matches the specified store
 // ID. If no replica matches, (-1, nil) is returned.
 func (r *RangeDescriptor) FindReplica(storeID StoreID) (int, *Replica) {
-	for i := range r.Replicas {
-		if r.Replicas[i].StoreID == storeID {
-			return i, &r.Replicas[i]
-		}
-	}
-	return -1, nil
+	return ReplicaSlice(r.Replicas).FindReplica(storeID)
 }
 
 // CanRead does a linear search for user to verify read permission.
@@ -161,6 +156,17 @@ type ReplicaSlice []Replica
 // Swap interchanges the replicas stored at the given indices.
 func (rs ReplicaSlice) Swap(i, j int) {
 	rs[i], rs[j] = rs[j], rs[i]
+}
+
+// FindReplica returns the replica which matches the specified store
+// ID. If no replica matches, (-1, nil) is returned.
+func (rs ReplicaSlice) FindReplica(storeID StoreID) (int, *Replica) {
+	for i := range rs {
+		if rs[i].StoreID == storeID {
+			return i, &rs[i]
+		}
+	}
+	return -1, nil
 }
 
 // SortByCommonAttributePrefix rearranges the ReplicaSlice by comparing the

--- a/proto/config_test.go
+++ b/proto/config_test.go
@@ -19,6 +19,7 @@ package proto
 
 import (
 	"bytes"
+	"reflect"
 	"testing"
 )
 
@@ -149,5 +150,85 @@ func TestPermConfig(t *testing.T) {
 	}
 	if p.CanWrite("bar") {
 		t.Errorf("unexpected read access for user \"bar\"")
+	}
+}
+
+func verifyOrdering(attrs []string, rs ReplicaSlice, prefixLen int) bool {
+	prevMatchIndex := len(attrs)
+	for i := range rs {
+		matchIndex := -1
+		for j := range attrs {
+			if j >= len(rs[i].Attrs.Attrs) || rs[i].Attrs.Attrs[j] != attrs[j] {
+				break
+			}
+			matchIndex = j
+		}
+		if matchIndex != -1 && matchIndex > prevMatchIndex {
+			return false
+		}
+		if i == 0 && matchIndex+1 != prefixLen {
+			return false
+		}
+		prevMatchIndex = matchIndex
+	}
+	return true
+}
+
+func TestReplicaSetSortByCommonAttributePrefix(t *testing.T) {
+	replicaAttrs := [][]string{
+		[]string{"us-west-1a", "gpu"},
+		[]string{"us-east-1a", "pdu1", "gpu"},
+		[]string{"us-east-1a", "pdu1", "fio"},
+		[]string{"breaker", "us-east-1a", "pdu1", "fio"},
+		[]string{""},
+		[]string{"us-west-1a", "pdu1", "fio"},
+		[]string{"us-west-1a", "pdu1", "fio", "aux"},
+	}
+	attrs := [][]string{
+		[]string{"us-carl"},
+		[]string{"us-west-1a", "pdu1", "fio"},
+		[]string{"us-west-1a"},
+		[]string{"", "pdu1", "fio"},
+	}
+
+	for i, attr := range attrs {
+		rs := ReplicaSlice{}
+		for _, c := range replicaAttrs {
+			rs = append(rs, Replica{Attrs: Attributes{Attrs: c}})
+		}
+		prefixLen := rs.SortByCommonAttributePrefix(attr)
+		if !verifyOrdering(attr, rs, prefixLen) {
+			t.Errorf("%d: attributes not ordered by %s or prefix length %d incorrect:\n%v", i, attr, prefixLen, rs)
+		}
+	}
+
+}
+
+func getStores(rs ReplicaSlice) (r []StoreID) {
+	for i := range rs {
+		r = append(r, rs[i].StoreID)
+	}
+	return
+}
+
+func TestReplicaSetMoveToFront(t *testing.T) {
+	rs := ReplicaSlice(nil)
+	for i := 0; i < 5; i++ {
+		rs = append(rs, Replica{StoreID: StoreID(i + 1)})
+	}
+	rs.MoveToFront(0)
+	exp := []StoreID{1, 2, 3, 4, 5}
+	if stores := getStores(rs); !reflect.DeepEqual(stores, exp) {
+		t.Errorf("expected order %s, got %s", exp, stores)
+	}
+	rs.MoveToFront(2)
+	exp = []StoreID{3, 1, 2, 4, 5}
+	if stores := getStores(rs); !reflect.DeepEqual(stores, exp) {
+		t.Errorf("expected order %s, got %s", exp, stores)
+	}
+	rs.MoveToFront(4)
+	exp = []StoreID{5, 3, 1, 2, 4}
+	if stores := getStores(rs); !reflect.DeepEqual(stores, exp) {
+		t.Errorf("expected order %s, got %s", exp, stores)
 	}
 }

--- a/proto/config_test.go
+++ b/proto/config_test.go
@@ -72,20 +72,18 @@ func TestRangeDescriptorFindReplica(t *testing.T) {
 		},
 	}
 	for i, r := range desc.Replicas {
-		if nID := desc.FindReplica(r.StoreID).NodeID; nID != r.NodeID {
-			t.Errorf("%d: expected to find node %d for store %d; got %d", i, r.NodeID, r.StoreID, nID)
+		if i2, r2 := desc.FindReplica(r.StoreID); r2.NodeID != r.NodeID || i2 != i {
+			t.Errorf("%d: expected to find node %d for store %d; got %d", i, r.NodeID, r.StoreID, r2.StoreID)
 		}
 	}
 }
 
 func TestRangeDescriptorMissingReplica(t *testing.T) {
-	defer func() {
-		if r := recover(); r == nil {
-			t.Error("expected panic due to no matching replica")
-		}
-	}()
 	desc := RangeDescriptor{}
-	desc.FindReplica(0)
+	i, r := desc.FindReplica(0)
+	if i >= 0 || r != nil {
+		t.Fatalf("unexpected return (%s, %s) on missing replica", i, r)
+	}
 }
 
 // TestRangeDescriptorContains verifies methods to check whether a key

--- a/server/cli/flags.go
+++ b/server/cli/flags.go
@@ -41,12 +41,16 @@ func initFlags(ctx *server.Context) {
 		"attributes might also include speeds and other specs (7200rpm, 200kiops, etc.). "+
 		"For example, -store=hdd:7200rpm=/mnt/hda1,ssd=/mnt/ssd01,ssd=/mnt/ssd02,mem=1073741824")
 
-	flag.StringVar(&ctx.Attrs, "attrs", ctx.Attrs, "specify a colon-separated list of node "+
+	flag.StringVar(&ctx.Attrs, "attrs", ctx.Attrs, "specify an ordered, colon-separated list of node "+
 		"attributes. Attributes are arbitrary strings specifying topography or "+
-		"machine capabilities. Topography might include datacenter designation (e.g. "+
-		"\"us-west-1a\", \"us-west-1b\", \"us-east-1c\"). Machine capabilities "+
+		"machine capabilities. Topography might include datacenter designation "+
+		"(e.g. \"us-west-1a\", \"us-west-1b\", \"us-east-1c\"). Machine capabilities "+
 		"might include specialized hardware or number of cores (e.g. \"gpu\", "+
-		"\"x16c\"). For example: -attrs=us-west-1b,gpu")
+		"\"x16c\"). "+
+		"The relative geographic proximity of two nodes is inferred from the "+
+		"common prefix of the attributes list, so topographic attributes should be "+
+		"specified first and in the same order for all nodes. "+
+		"For example: -attrs=us-west-1b,gpu.")
 
 	flag.DurationVar(&ctx.MaxOffset, "max_offset", ctx.MaxOffset, "specify "+
 		"the maximum clock offset for the cluster. Clock offset is measured on all "+

--- a/server/context.go
+++ b/server/context.go
@@ -20,7 +20,6 @@ package server
 import (
 	"net"
 	"regexp"
-	"sort"
 	"strconv"
 	"strings"
 	"time"
@@ -175,7 +174,6 @@ func parseAttributes(attrsStr string) proto.Attributes {
 			filtered = append(filtered, attr)
 		}
 	}
-	sort.Strings(filtered)
 	return proto.Attributes{Attrs: filtered}
 }
 

--- a/server/node.go
+++ b/server/node.go
@@ -167,11 +167,52 @@ func NewNode(db *client.KV, gossip *gossip.Gossip, storeConfig storage.StoreConf
 // initDescriptor initializes the node descriptor with the server
 // address and the node attributes.
 func (n *Node) initDescriptor(addr net.Addr, attrs proto.Attributes) {
-	n.Descriptor = storage.NodeDescriptor{
-		// NodeID is set after invocation of start()
-		Address: addr,
-		Attrs:   attrs,
+	n.Descriptor.Address = addr
+	n.Descriptor.Attrs = attrs
+}
+
+// initNodeID updates the internal NodeDescriptor with the given ID. If zero is
+// supplied, a new NodeID is allocated with the first invocation. For all other
+// values, the supplied ID is stored into the descriptor (unless one has been
+// set previously, in which case a fatal error occurs).
+//
+// Upon setting a new NodeID, the descriptor is gossiped and the NodeID is
+// stored into the gossip instance.
+func (n *Node) initNodeID(id proto.NodeID) {
+	if id < 0 {
+		log.Fatalf("NodeID must not be negative")
 	}
+
+	if o := n.Descriptor.NodeID; o > 0 {
+		if id == 0 {
+			return
+		}
+		log.Fatalf("cannot initialize NodeID to %d, already have %d", id, o)
+	}
+	var err error
+	if id == 0 {
+		id, err = allocateNodeID(n.db)
+		if err != nil {
+			log.Fatal(err)
+		}
+		if id == 0 {
+			log.Fatal("new node allocated illegal ID 0")
+		}
+
+		log.Infof("new node allocated ID %d", n.Descriptor.NodeID)
+	}
+
+	n.Descriptor.NodeID = id
+
+	nodeIDKey := gossip.MakeNodeIDKey(n.Descriptor.NodeID)
+	if err = n.gossip.AddInfo(nodeIDKey, &n.Descriptor, ttlNodeIDGossip); err != nil {
+		log.Fatalf("couldn't gossip address for node %d: %v", n.Descriptor.NodeID, err)
+	}
+	// Setting the NodeID as the name of the gossip instance allows the
+	// DistSender to look up the own node's descriptor from the gossip network.
+	// The field is touched only once, so the atomic update isn't necessary but
+	// it feels better.
+	atomic.StoreInt32(&n.gossip.NodeID, int32(n.Descriptor.NodeID))
 }
 
 // start starts the node by registering the storage instance for the
@@ -239,6 +280,8 @@ func (n *Node) initStores(clock *hlc.Clock, engines []engine.Engine, stopper *ut
 
 	// Bootstrap any uninitialized stores asynchronously.
 	if bootstraps.Len() > 0 {
+		// If no NodeID has been assigned yet, make sure this happens first.
+		n.initNodeID(0)
 		go n.bootstrapStores(bootstraps, stopper)
 	}
 
@@ -252,7 +295,7 @@ func (n *Node) validateStores() error {
 	return n.lSender.VisitStores(func(s *storage.Store) error {
 		if n.ClusterID == "" {
 			n.ClusterID = s.Ident.ClusterID
-			n.Descriptor.NodeID = s.Ident.NodeID
+			n.initNodeID(s.Ident.NodeID)
 		} else if n.ClusterID != s.Ident.ClusterID {
 			return util.Errorf("store %s cluster ID doesn't match node cluster %q", s, n.ClusterID)
 		} else if n.Descriptor.NodeID != s.Ident.NodeID {
@@ -268,25 +311,9 @@ func (n *Node) validateStores() error {
 // node.
 func (n *Node) bootstrapStores(bootstraps *list.List, stopper *util.Stopper) {
 	log.Infof("bootstrapping %d store(s)", bootstraps.Len())
-
-	// Allocate a new node ID if necessary.
-	if n.Descriptor.NodeID == 0 {
-		var err error
-		n.Descriptor.NodeID, err = allocateNodeID(n.db)
-		log.Infof("new node allocated ID %d", n.Descriptor.NodeID)
-		if err != nil {
-			log.Fatal(err)
-		}
-		// Gossip node address keyed by node ID.
-		nodeIDKey := gossip.MakeNodeIDKey(n.Descriptor.NodeID)
-		if err := n.gossip.AddInfo(nodeIDKey, &n.Descriptor, ttlNodeIDGossip); err != nil {
-			log.Errorf("couldn't gossip address for node %d: %v", n.Descriptor.NodeID, err)
-		}
+	if n.ClusterID == "" {
+		panic("ClusterID missing during store bootstrap of auxiliary store")
 	}
-	// Setting the NodeID as the name of the gossip instance
-	// allows the DistSender to look up the own node's descriptor
-	// from the gossip network.
-	atomic.StoreInt32(&n.gossip.NodeID, int32(n.Descriptor.NodeID))
 
 	// Bootstrap all waiting stores by allocating a new store id for
 	// each and invoking store.Bootstrap() to persist.

--- a/server/node.go
+++ b/server/node.go
@@ -21,6 +21,7 @@ import (
 	"container/list"
 	"net"
 	"strconv"
+	"sync/atomic"
 	"time"
 
 	"github.com/cockroachdb/cockroach/client"
@@ -282,6 +283,10 @@ func (n *Node) bootstrapStores(bootstraps *list.List, stopper *util.Stopper) {
 			log.Errorf("couldn't gossip address for node %d: %v", n.Descriptor.NodeID, err)
 		}
 	}
+	// Setting the NodeID as the name of the gossip instance
+	// allows the DistSender to look up the own node's descriptor
+	// from the gossip network.
+	atomic.StoreInt32(&n.gossip.NodeID, int32(n.Descriptor.NodeID))
 
 	// Bootstrap all waiting stores by allocating a new store id for
 	// each and invoking store.Bootstrap() to persist.

--- a/server/server.go
+++ b/server/server.go
@@ -111,8 +111,6 @@ func NewServer(ctx *Context, stopper *util.Stopper) (*Server, error) {
 	s.stopper.AddCloser(s.rpc)
 	s.gossip = gossip.New(rpcContext, s.ctx.GossipInterval, s.ctx.GossipBootstrapAddrs)
 
-	// Create a client.KVSender instance for use with this node's
-	// client to the key value database as well as
 	ds := kv.NewDistSender(&kv.DistSenderContext{Clock: s.clock}, s.gossip)
 	sender := kv.NewTxnCoordSender(ds, s.clock, ctx.Linearizable, s.stopper)
 	s.kv = client.NewKV(nil, sender)

--- a/storage/range.go
+++ b/storage/range.go
@@ -318,8 +318,13 @@ func (r *Range) SetDesc(desc *proto.RangeDescriptor) {
 }
 
 // GetReplica returns the replica for this range from the range descriptor.
+// A fatal error occurs if the replica is not found.
 func (r *Range) GetReplica() *proto.Replica {
-	return r.Desc().FindReplica(r.rm.StoreID())
+	_, replica := r.Desc().FindReplica(r.rm.StoreID())
+	if replica == nil {
+		log.Fatalf("own replica missing in range at store %d", r.rm.StoreID())
+	}
+	return replica
 }
 
 // ContainsKey returns whether this range contains the specified key.


### PR DESCRIPTION
~~Haven't had a chance to give this a good second look, but I wanted to put it up today so expect minor tweaks.~~ Ready for review.

DistSender#sendRPC now tries to send a request to the leader when that is necessary, and optimizes the replica order based on the attributes (where order matters now - they were previously sorted). Whenever we know the leader or some replicas have been selected based on attributes, RPCs are sent in stable order. Otherwise, it is random (exactly how it had been done previously).
Leader information is taken from NotLeaderErrors only for now.

Caveats:
- I don't think we have a method for marking replicas as down yet, so this change increases the likelyhood that a node will try a dead node regularly when not required to go to a leader. I could've shuffled the replicas with the same attribute prefix length, but that hides the problem rather than removing it (the longest prefix might be a single node).
- In the future we'll want to deal with leader leases so we'll have to think about how these are cached. For the most part that will mean that there can be multiple "legit" leaders per group that need to be tracked for the purpose of doing consistent reads.

This work is related to #543.
