### PR TITLE
Call g.mu.Unlock() before calling break

### DIFF
--- a/gossip/gossip.go
+++ b/gossip/gossip.go
@@ -352,6 +352,7 @@ func (g *Gossip) bootstrap() {
 		g.mu.Lock()
 		g.parseBootstrapAddresses()
 		if g.closed {
+			g.mu.Unlock()
 			break
 		}
 		// Find list of available bootstrap hosts.
@@ -443,6 +444,7 @@ func (g *Gossip) manage() {
 
 		// The exit condition.
 		if g.closed && g.outgoing.len() == 0 {
+			g.mu.Unlock()
 			break
 		}
 		g.mu.Unlock()


### PR DESCRIPTION
I haven't written a test case, but I'm guessing some of the goroutines might get into deadlock during shutdown. (We cannot use `defer` as `Lock` is called inside a `for` loop.)
