### PR TITLE
Fix bug where we were iterating over ranges instead of rangesByKey.

### DIFF
--- a/storage/range.go
+++ b/storage/range.go
@@ -228,6 +228,9 @@ func (r *Range) String() string {
 // range in the map and gossips config information if the range
 // contains any of the configuration maps.
 func (r *Range) start() {
+	// TODO(spencer): gossiping should only commence when the range gains
+	// the leader lease and it should stop when the range no longer holds
+	// the leader lease.
 	r.maybeGossipClusterID()
 	r.maybeGossipFirstRange()
 	r.maybeGossipConfigs(configDescriptors...)

--- a/storage/store.go
+++ b/storage/store.go
@@ -571,7 +571,9 @@ func (s *Store) setRangesMaxBytes(zoneMap PrefixConfigMap) {
 	defer s.mu.Unlock()
 	zone := zoneMap[0].Config.(*proto.ZoneConfig)
 	idx := 0
-	for _, rng := range s.ranges {
+	// Note that we must iterate through the ranges in lexicographic
+	// order to match the ordering of the zoneMap.
+	for _, rng := range s.rangesByKey {
 		if idx < len(zoneMap)-1 && !rng.Desc().StartKey.Less(zoneMap[idx+1].Prefix) {
 			idx++
 			zone = zoneMap[idx].Config.(*proto.ZoneConfig)


### PR DESCRIPTION
This was for the previously untested setRangesMaxBytes() method. Added a
unittest as well as a comment regarding gossiping in ranges, which needs
to be hooked up once we have callbacks for leader lease acquisition and
loss.
