### PR TITLE
start node in bootstrap mode if invoked from runInit

### DIFF
--- a/server/cli/start.go
+++ b/server/cli/start.go
@@ -150,7 +150,8 @@ func runStart(cmd *commander.Command, args []string) {
 		return
 	}
 
-	err = s.Start(false)
+	isBootstrap := cmd.Name() == "init"
+	err = s.Start(isBootstrap)
 	defer s.Stop()
 	if err != nil {
 		log.Errorf("Cockroach server exited with error: %v", err)


### PR DESCRIPTION
this allows starting the first node without specifying a gossip bootstrap
address.

fixes #590 
