### PR TITLE
Increase timeout for goroutines to exit in leaktest.

### DIFF
--- a/util/leaktest/leaktest.go
+++ b/util/leaktest/leaktest.go
@@ -117,7 +117,7 @@ func AfterTest(t testing.TB) {
 		"(*Range).AddCmd":                              "a range command",
 	}
 	var stacks string
-	for i := 0; i < 4; i++ {
+	for i := 0; i < 8; i++ {
 		bad = ""
 		stacks = strings.Join(interestingGoroutines(), "\n\n")
 		for substr, what := range badSubstring {


### PR DESCRIPTION
We see occasional failures on circleci in race mode in which
threads are counted as leaked but appear to be making progress.

Closes #592.
