### PR TITLE
Another attempt at fixing #592.

### DIFF
--- a/multiraft/transport.go
+++ b/multiraft/transport.go
@@ -150,6 +150,12 @@ func (lt *localRPCTransport) getClient(id NodeID) (*rpc.Client, error) {
 	lt.mu.Lock()
 	defer lt.mu.Unlock()
 
+	select {
+	case <-lt.closed:
+		return nil, util.Errorf("transport is closed")
+	default:
+	}
+
 	client, ok := lt.clients[id]
 	if ok {
 		return client, nil


### PR DESCRIPTION
I suspect that the txnMeta shutdown operations are creating new
connections after the store is shutting down, and these connections
are getting flagged by leaktest.
