### PR TITLE
Make shutdown more robust.

### DIFF
--- a/storage/store.go
+++ b/storage/store.go
@@ -1079,7 +1079,9 @@ func (s *Store) ProposeRaftCommand(idKey cmdIDKey, cmd proto.InternalRaftCommand
 	// Lazily create group. TODO(bdarnell): make this non-lazy
 	err := s.multiraft.CreateGroup(uint64(cmd.RaftID))
 	if err != nil {
-		log.Fatal(err)
+		ch := make(chan error, 1)
+		ch <- err
+		return ch
 	}
 
 	data, err := gogoproto.Marshal(&cmd)

--- a/util/leaktest/leaktest.go
+++ b/util/leaktest/leaktest.go
@@ -57,11 +57,7 @@ func interestingGoroutines() (gs []string) {
 			strings.Contains(stack, "created by runtime.gc") ||
 			strings.Contains(stack, "github.com/cockroachdb/cockroach/util/leaktest.interestingGoroutines") ||
 			strings.Contains(stack, "runtime.MHeap_Scavenger") ||
-			strings.Contains(stack, "golang/glog.init") ||
-			// Fire-and-forget write intent cleanups. These end up deadlocked
-			// because the store is already stopped by the time they run.
-			// TODO(bdarnell): clean these up better.
-			strings.Contains(stack, "*txnMetadata).close") {
+			strings.Contains(stack, "golang/glog.init") {
 			continue
 		}
 		gs = append(gs, stack)


### PR DESCRIPTION
We had whitelisted the txnMetadata.close goroutines in leaktest, but
the fact that they were still running after shutdown would sometimes
leave other threads to be leaked, or cause nil pointer panics.

This commit adds additional checks in retry loops that may be running
after shutdown to end the loop cleanly and allow all goroutines to
exit. This lets us remove the whitelisting of txnMetadata.close.

Closes #597
