### PR TITLE
Grant leader lease to ranges; implement HasLeaderLease.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -36,7 +36,7 @@ PKG          := ./...
 TAGS         :=
 TESTS        := ".*"
 TESTTIMEOUT  := 15s
-RACETIMEOUT  := 1m
+RACETIMEOUT  := 5m
 BENCHTIMEOUT := 5m
 # STANDARDTESTFLAGS contains flags that you probably don't want to override;
 # TESTFLAGS defaults to empty so setting it doesn't clobber anything standard.

--- a/client/client_test.go
+++ b/client/client_test.go
@@ -737,7 +737,7 @@ func setupClientBenchData(useRPC, useSSL bool, numVersions, numKeys int, b *test
 	}
 	s.Engines = []engine.Engine{engine.NewRocksDB(proto.Attributes{Attrs: []string{"ssd"}}, loc, cacheSize)}
 	if err := s.Start(); err != nil {
-		b.Fatalf("Could not start server: %v", err)
+		b.Fatal(err)
 	}
 
 	var kv *client.KV

--- a/kv/dist_sender_server_test.go
+++ b/kv/dist_sender_server_test.go
@@ -40,10 +40,7 @@ import (
 // proceed in the event that a write intent is extant at the meta
 // index record being read.
 func TestRangeLookupWithOpenTransaction(t *testing.T) {
-	s := &server.TestServer{}
-	if err := s.Start(); err != nil {
-		t.Fatal(err)
-	}
+	s := startServer(t)
 	defer s.Stop()
 	db := createTestClient(t, s.ServingAddr())
 	db.User = storage.UserRoot
@@ -85,10 +82,7 @@ func TestRangeLookupWithOpenTransaction(t *testing.T) {
 // The caller is responsible for stopping the server and
 // closing the client.
 func setupMultipleRanges(t *testing.T) (*server.TestServer, *client.KV) {
-	s := &server.TestServer{}
-	if err := s.Start(); err != nil {
-		t.Fatal(err)
-	}
+	s := startServer(t)
 	db := createTestClient(t, s.ServingAddr())
 	db.User = storage.UserRoot
 
@@ -150,7 +144,7 @@ func TestMultiRangeScanInconsistent(t *testing.T) {
 	}
 
 	// Do an inconsistent scan from a new dist sender and verify it does
-	// the read at it's local clock and doesn't receive an
+	// the read at its local clock and doesn't receive an
 	// OpRequiresTxnError. We set the local clock to the timestamp of
 	// the first key to verify it's used to read only key "a".
 	manual := hlc.NewManualClock(ts[1].WallTime - 1)

--- a/kv/dist_sender_test.go
+++ b/kv/dist_sender_test.go
@@ -267,7 +267,7 @@ func TestRetryOnNotLeaderError(t *testing.T) {
 	var testFn rpcSendFn = func(_ rpc.Options, method string, addrs []net.Addr, getArgs func(addr net.Addr) interface{}, getReply func() interface{}, _ *rpc.Context) ([]interface{}, error) {
 		if first {
 			getReply().(proto.Response).Header().SetGoError(
-				&proto.NotLeaderError{Leader: leader})
+				&proto.NotLeaderError{Leader: &leader})
 		}
 		first = false
 		return nil, nil

--- a/kv/local_sender_test.go
+++ b/kv/local_sender_test.go
@@ -21,14 +21,11 @@ import (
 	"errors"
 	"testing"
 
-	"github.com/cockroachdb/cockroach/client"
 	"github.com/cockroachdb/cockroach/multiraft"
 	"github.com/cockroachdb/cockroach/proto"
 	"github.com/cockroachdb/cockroach/storage"
 	"github.com/cockroachdb/cockroach/storage/engine"
-	"github.com/cockroachdb/cockroach/util"
 	"github.com/cockroachdb/cockroach/util/hlc"
-	"golang.org/x/net/context"
 )
 
 func TestLocalSenderAddStore(t *testing.T) {
@@ -104,55 +101,11 @@ func TestLocalSenderGetStore(t *testing.T) {
 	}
 }
 
-func splitTestRange(store *storage.Store, key, splitKey proto.Key, t *testing.T) *storage.Range {
-	rng := store.LookupRange(key, key)
-	if rng == nil {
-		t.Fatalf("couldn't lookup range for key %q", key)
-	}
-	desc, err := store.NewRangeDescriptor(splitKey, rng.Desc().EndKey, rng.Desc().Replicas)
-	if err != nil {
-		t.Fatal(err)
-	}
-	newRng, err := storage.NewRange(desc, store)
-	if err != nil {
-		t.Fatal(err)
-	}
-	if err := store.SplitRange(rng, newRng); err != nil {
-		t.Fatal(err)
-	}
-	return newRng
-}
-
 func TestLocalSenderLookupReplica(t *testing.T) {
 	ctx := storage.TestStoreContext
 	manualClock := hlc.NewManualClock(0)
 	ctx.Clock = hlc.NewClock(manualClock.UnixNano)
-	ctx.Context = context.Background()
-	eng := engine.NewInMem(proto.Attributes{}, 1<<20)
 	ls := NewLocalSender()
-	stopper := util.NewStopper()
-	defer stopper.Stop()
-	ctx.DB = client.NewKV(nil, NewTxnCoordSender(ls, ctx.Clock, false, stopper))
-	ctx.Transport = multiraft.NewLocalRPCTransport()
-	defer ctx.Transport.Close()
-	store := storage.NewStore(ctx, eng)
-	if err := store.Bootstrap(proto.StoreIdent{NodeID: 1, StoreID: 1}, stopper); err != nil {
-		t.Fatal(err)
-	}
-	ls.AddStore(store)
-	if err := store.BootstrapRange(); err != nil {
-		t.Fatal(err)
-	}
-	if err := store.Start(stopper); err != nil {
-		t.Fatal(err)
-	}
-	rng := splitTestRange(store, engine.KeyMin, proto.Key("a"), t)
-	// Make sure to wait for elections before removing; see #702.
-	// TODO(tschottdorf) maybe remove once #702 closes.
-	rng.WaitForElection()
-	if err := store.RemoveRange(rng); err != nil {
-		t.Fatal(err)
-	}
 
 	// Create two new stores with ranges we care about.
 	var e [2]engine.Engine
@@ -170,16 +123,12 @@ func TestLocalSenderLookupReplica(t *testing.T) {
 		defer ctx.Transport.Close()
 		s[i] = storage.NewStore(ctx, e[i])
 		s[i].Ident.StoreID = rng.storeID
-		if err := s[i].Bootstrap(proto.StoreIdent{NodeID: 1, StoreID: rng.storeID}, stopper); err != nil {
-			t.Fatal(err)
-		}
-		if err := s[i].Start(stopper); err != nil {
-			t.Fatal(err)
-		}
 
-		desc, err := store.NewRangeDescriptor(rng.start, rng.end, []proto.Replica{{StoreID: rng.storeID}})
-		if err != nil {
-			t.Fatal(err)
+		desc := &proto.RangeDescriptor{
+			RaftID:   int64(i),
+			StartKey: rng.start,
+			EndKey:   rng.end,
+			Replicas: []proto.Replica{{StoreID: rng.storeID}},
 		}
 		newRng, err := storage.NewRange(desc, s[i])
 		if err != nil {

--- a/kv/rest_test.go
+++ b/kv/rest_test.go
@@ -454,7 +454,7 @@ func TestKeysAndBodyArePreserved(t *testing.T) {
 	}
 	// Lookup results direclty from the underlying engine.
 	key := proto.Key("\x00some/key that encodes世界")
-	val, err := engine.MVCCGet(s.Engine, key, s.Clock().Now(), false, nil)
+	val, err := engine.MVCCGet(s.Engines[0], key, s.Clock().Now(), false, nil)
 	if err != nil {
 		t.Errorf("unable to fetch value for key %s: %s", key, err)
 	}

--- a/kv/rest_test.go
+++ b/kv/rest_test.go
@@ -29,21 +29,17 @@ import (
 	"io"
 	"io/ioutil"
 	"net/http"
-	"net/http/httptest"
 	"net/url"
 	"strconv"
 	"strings"
 	"testing"
 
 	"github.com/cockroachdb/cockroach/base"
-	"github.com/cockroachdb/cockroach/client"
 	. "github.com/cockroachdb/cockroach/kv"
 	"github.com/cockroachdb/cockroach/proto"
 	"github.com/cockroachdb/cockroach/server"
-	"github.com/cockroachdb/cockroach/storage"
 	"github.com/cockroachdb/cockroach/storage/engine"
 	"github.com/cockroachdb/cockroach/testutils"
-	"github.com/cockroachdb/cockroach/util"
 	gogoproto "github.com/gogo/protobuf/proto"
 )
 
@@ -52,21 +48,8 @@ var testContext = testutils.NewTestBaseContext()
 // startServer returns the server, server address and a KV client for
 // access to the underlying database. The server should be closed by
 // the caller.
-func startServer(t *testing.T) (string, *client.KV, *util.Stopper) {
-	// Initialize engine, store, and localDB.
-	e := engine.NewInMem(proto.Attributes{}, 1<<20)
-	stopper := util.NewStopper()
-	db, err := server.BootstrapCluster("test-cluster", e, stopper)
-	if err != nil {
-		t.Fatalf("could not bootstrap test cluster: %s", err)
-	}
-	mux := http.NewServeMux()
-	mux.Handle(RESTPrefix, NewRESTServer(db))
-	mux.Handle(DBPrefix, NewDBServer(db.Sender))
-	server := httptest.NewTLSServer(mux)
-	stopper.AddCloser(server)
-	addr := server.Listener.Addr().String()
-	return addr, db, stopper
+func startServer(t testing.TB) *server.TestServer {
+	return server.StartTestServer(t)
 }
 
 // HTTP methods, defined in RFC 2616.
@@ -85,8 +68,8 @@ type protoResp struct {
 }
 
 func TestMethods(t *testing.T) {
-	addr, _, stopper := startServer(t)
-	defer stopper.Stop()
+	s := startServer(t)
+	defer s.Stop()
 
 	testKey, testVal := "Hello, 世界", "世界 is cool"
 	testCases := []struct {
@@ -123,7 +106,7 @@ func TestMethods(t *testing.T) {
 		{methodGet, testKey, nil, http.StatusNotFound, nil},
 	}
 	for _, tc := range testCases {
-		resp, err := httpDo(testContext, addr, tc.method, EntryPrefix+tc.key, tc.body)
+		resp, err := httpDo(testContext, s.ServingAddr(), tc.method, EntryPrefix+tc.key, tc.body)
 		if err != nil {
 			t.Errorf("[%s] %s: error making request: %s", tc.method, tc.key, err)
 			continue
@@ -158,11 +141,11 @@ func TestMethods(t *testing.T) {
 }
 
 func TestRange(t *testing.T) {
-	addr, _, stopper := startServer(t)
-	defer stopper.Stop()
+	s := startServer(t)
+	defer s.Stop()
 
 	// Create range of keys (with counters interspersed).
-	baseURL := testContext.RequestScheme() + "://" + addr
+	baseURL := testContext.RequestScheme() + "://" + s.ServingAddr()
 	for i := 0; i < 100; i++ {
 		key := fmt.Sprintf("key_%.2d", i)
 		val := fmt.Sprintf("value_%.2d", i)
@@ -206,7 +189,7 @@ func TestRange(t *testing.T) {
 	}
 	// Delete limit of that range. Start: 5, end: 99, limit: 25 –> keys 5-30 deleted.
 	path := fmt.Sprintf("%s?start=key_%.2d&end=key_%.2d&limit=%d", RangePrefix, start, end, limit)
-	resp, err := httpDo(testContext, addr, methodDelete, path, nil)
+	resp, err := httpDo(testContext, s.ServingAddr(), methodDelete, path, nil)
 	if err != nil {
 		t.Errorf("error attempting to delete range: %s", err)
 	}
@@ -236,7 +219,7 @@ func TestRange(t *testing.T) {
 	// Delete remaining range.
 	start, end = 0, 99
 	path = fmt.Sprintf("%s?start=key_%.2d&end=key_%.2d", RangePrefix, start, end)
-	resp, err = httpDo(testContext, addr, methodDelete, path, nil)
+	resp, err = httpDo(testContext, s.ServingAddr(), methodDelete, path, nil)
 	if err != nil {
 		t.Errorf("error attempting to delete range: %s", err)
 	}
@@ -292,8 +275,8 @@ func checkStatus(resp *http.Response, t *testing.T) {
 }
 
 func TestIncrement(t *testing.T) {
-	addr, _, stopper := startServer(t)
-	defer stopper.Stop()
+	s := startServer(t)
+	defer s.Stop()
 
 	testKey := "Hello, 世界"
 	testCases := []struct {
@@ -319,7 +302,7 @@ func TestIncrement(t *testing.T) {
 		if tc.statusCode == http.StatusOK && tc.method == methodPost {
 			body = strings.NewReader(strconv.Itoa(tc.val))
 		}
-		resp, err := httpDo(testContext, addr, tc.method, CounterPrefix+tc.key, body)
+		resp, err := httpDo(testContext, s.ServingAddr(), tc.method, CounterPrefix+tc.key, body)
 		if err != nil {
 			t.Errorf("[%s] %s: error making request: %s", tc.method, tc.key, err)
 			continue
@@ -349,8 +332,8 @@ func TestIncrement(t *testing.T) {
 }
 
 func TestMixingCounters(t *testing.T) {
-	addr, _, stopper := startServer(t)
-	defer stopper.Stop()
+	s := startServer(t)
+	defer s.Stop()
 
 	entryKey := "value"
 	counterKey := "counter"
@@ -388,7 +371,7 @@ func TestMixingCounters(t *testing.T) {
 		if tc.statusCode == http.StatusOK && tc.method == methodPost {
 			body = strings.NewReader("1")
 		}
-		resp, err := httpDo(testContext, addr, tc.method, prefix+key, body)
+		resp, err := httpDo(testContext, s.ServingAddr(), tc.method, prefix+key, body)
 		if err != nil {
 			t.Errorf("[%s] %s: error making request: %s", tc.method, key, err)
 			continue
@@ -409,8 +392,8 @@ func TestMixingCounters(t *testing.T) {
 // TODO(spencer): we need to ensure proper permissions through the
 // HTTP API.
 func TestSystemKeys(t *testing.T) {
-	addr, _, stopper := startServer(t)
-	defer stopper.Stop()
+	s := startServer(t)
+	defer s.Stop()
 
 	// Compute expected system key.
 	desc := &proto.RangeDescriptor{
@@ -432,7 +415,7 @@ func TestSystemKeys(t *testing.T) {
 	// Manipulate the meta1 key.
 	metaKey := engine.MakeKey(engine.KeyMeta1Prefix, engine.KeyMax)
 	encMeta1Key := url.QueryEscape(string(metaKey))
-	url := testContext.RequestScheme() + "://" + addr + EntryPrefix + encMeta1Key
+	url := testContext.RequestScheme() + "://" + s.ServingAddr() + EntryPrefix + encMeta1Key
 	resp := getURL(testContext, url, t)
 	var pr protoResp
 	if err := json.Unmarshal([]byte(resp), &pr); err != nil {
@@ -454,12 +437,12 @@ func TestSystemKeys(t *testing.T) {
 }
 
 func TestKeysAndBodyArePreserved(t *testing.T) {
-	addr, db, stopper := startServer(t)
-	defer stopper.Stop()
+	s := startServer(t)
+	defer s.Stop()
 
 	encKey := "%00some%2Fkey%20that%20encodes%E4%B8%96%E7%95%8C"
 	encBody := "%00some%2FBODY%20that%20encodes"
-	url := testContext.RequestScheme() + "://" + addr + EntryPrefix + encKey
+	url := testContext.RequestScheme() + "://" + s.ServingAddr() + EntryPrefix + encKey
 	postURL(testContext, url, strings.NewReader(encBody), t)
 	resp := getURL(testContext, url, t)
 	var pr protoResp
@@ -469,18 +452,14 @@ func TestKeysAndBodyArePreserved(t *testing.T) {
 	if !bytes.Equal([]byte(encBody), pr.Value.Bytes) {
 		t.Fatalf("expected body to be %q; got %q", encBody, string(pr.Value.Bytes))
 	}
-	gr := &proto.GetResponse{}
-	if err := db.Run(client.Call{
-		Args: &proto.GetRequest{
-			RequestHeader: proto.RequestHeader{
-				Key:  proto.Key("\x00some/key that encodes世界"),
-				User: storage.UserRoot,
-			},
-		}, Reply: gr}); err != nil {
-		t.Errorf("unable to fetch values from local db: %s", err)
+	// Lookup results direclty from the underlying engine.
+	key := proto.Key("\x00some/key that encodes世界")
+	val, err := engine.MVCCGet(s.Engine, key, s.Clock().Now(), false, nil)
+	if err != nil {
+		t.Errorf("unable to fetch value for key %s: %s", key, err)
 	}
-	if !bytes.Equal(gr.Value.Bytes, []byte(encBody)) {
-		t.Errorf("expected %q; got %q", encBody, gr.Value.Bytes)
+	if !bytes.Equal(val.Bytes, []byte(encBody)) {
+		t.Errorf("expected %q; got %q", encBody, val.Bytes)
 	}
 }
 

--- a/kv/txn_coord_sender_test.go
+++ b/kv/txn_coord_sender_test.go
@@ -36,9 +36,7 @@ import (
 // is responsible for stopping the test server.
 func createTestDB(t testing.TB) *LocalTestCluster {
 	s := &LocalTestCluster{}
-	if err := s.Start(); err != nil {
-		t.Fatal(err)
-	}
+	s.Start(t)
 	return s
 }
 

--- a/proto/api.go
+++ b/proto/api.go
@@ -19,6 +19,7 @@ package proto
 
 import (
 	"log"
+	"math/rand"
 
 	"github.com/cockroachdb/cockroach/util"
 	gogoproto "github.com/gogo/protobuf/proto"
@@ -95,6 +96,21 @@ type Response interface {
 // should be done by the caller instead.
 type Combinable interface {
 	Combine(Response)
+}
+
+// GetOrCreateCmdID returns the request header's command ID if available.
+// Otherwise, creates a new ClientCmdID, initialized with current time
+// and random salt.
+func (rh *RequestHeader) GetOrCreateCmdID(walltime int64) (cmdID ClientCmdID) {
+	if !rh.CmdID.IsEmpty() {
+		cmdID = rh.CmdID
+	} else {
+		cmdID = ClientCmdID{
+			WallTime: walltime,
+			Random:   rand.Int63(),
+		}
+	}
+	return
 }
 
 // Combine is used by range-spanning Response types (e.g. Scan or DeleteRange)

--- a/proto/data.proto
+++ b/proto/data.proto
@@ -251,20 +251,14 @@ message Transaction {
 // Lease contains information about leader leases including the
 // expiration and lease holder.
 message Lease {
-  // The expiration is a unix nanos timestamp and is set when requesting the
-  // lease according to the wall clock plus the Duration below at the lease
-  // requestor / grantee, which is also the only node that uses it directly.
-  // Granters must always substitute their local walltime plus the Duration
-  // below instead.
-  optional int64 expiration = 1 [(gogoproto.nullable) = false];
-  // The duration, specified in nanoseconds, is the duration for which lease
-  // granters guarantee not to participate in elections, beginning right after
-  // the command has been accepted.
-  optional int64 duration = 2 [(gogoproto.nullable) = false];
-  // The leadership term for this lease.
-  optional uint64 term = 3 [(gogoproto.nullable) = false];
+  // The start is a timestamp at which the lease begins. This value
+  // must be greater than the last lease expiration or this call will
+  // fail.
+  optional Timestamp start = 1 [(gogoproto.nullable) = false];
+  // The expiration is a timestamp at which the lease will expire.
+  optional Timestamp expiration = 2 [(gogoproto.nullable) = false];
   // The Raft NodeID on which the would-be lease holder lives.
-  optional uint64 raft_node_id = 4 [(gogoproto.nullable) = false, (gogoproto.customname) = "RaftNodeID" ];
+  optional uint64 raft_node_id = 3 [(gogoproto.nullable) = false, (gogoproto.customname) = "RaftNodeID" ];
 }
 
 // MVCCMetadata holds MVCC metadata for a key. Used by storage/engine/mvcc.go.

--- a/proto/errors.go
+++ b/proto/errors.go
@@ -42,7 +42,7 @@ func (e *Error) CanRestartTransaction() TransactionRestart {
 
 // Error formats error.
 func (e *NotLeaderError) Error() string {
-	return fmt.Sprintf("range not leader; leader is %+v", e.Leader)
+	return fmt.Sprintf("replica %s not leader; leader is %s", e.Replica, e.Leader)
 }
 
 // NewRangeNotFoundError initializes a new RangeNotFoundError.

--- a/proto/errors.pb.go
+++ b/proto/errors.pb.go
@@ -64,19 +64,27 @@ func (x *TransactionRestart) UnmarshalJSON(data []byte) error {
 // A NotLeaderError indicates that the current range is not the
 // leader. If the leader is known, its Replica is set in the error.
 type NotLeaderError struct {
-	Leader           Replica `protobuf:"bytes,1,opt,name=leader" json:"leader"`
-	XXX_unrecognized []byte  `json:"-"`
+	Replica          *Replica `protobuf:"bytes,1,opt,name=replica" json:"replica,omitempty"`
+	Leader           *Replica `protobuf:"bytes,2,opt,name=leader" json:"leader,omitempty"`
+	XXX_unrecognized []byte   `json:"-"`
 }
 
 func (m *NotLeaderError) Reset()         { *m = NotLeaderError{} }
 func (m *NotLeaderError) String() string { return proto1.CompactTextString(m) }
 func (*NotLeaderError) ProtoMessage()    {}
 
-func (m *NotLeaderError) GetLeader() Replica {
+func (m *NotLeaderError) GetReplica() *Replica {
+	if m != nil {
+		return m.Replica
+	}
+	return nil
+}
+
+func (m *NotLeaderError) GetLeader() *Replica {
 	if m != nil {
 		return m.Leader
 	}
-	return Replica{}
+	return nil
 }
 
 // A RangeNotFoundError indicates that a command was sent to a range
@@ -510,6 +518,33 @@ func (m *NotLeaderError) Unmarshal(data []byte) error {
 		switch fieldNum {
 		case 1:
 			if wireType != 2 {
+				return fmt.Errorf("proto: wrong wireType = %d for field Replica", wireType)
+			}
+			var msglen int
+			for shift := uint(0); ; shift += 7 {
+				if index >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := data[index]
+				index++
+				msglen |= (int(b) & 0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			postIndex := index + msglen
+			if postIndex > l {
+				return io.ErrUnexpectedEOF
+			}
+			if m.Replica == nil {
+				m.Replica = &Replica{}
+			}
+			if err := m.Replica.Unmarshal(data[index:postIndex]); err != nil {
+				return err
+			}
+			index = postIndex
+		case 2:
+			if wireType != 2 {
 				return fmt.Errorf("proto: wrong wireType = %d for field Leader", wireType)
 			}
 			var msglen int
@@ -527,6 +562,9 @@ func (m *NotLeaderError) Unmarshal(data []byte) error {
 			postIndex := index + msglen
 			if postIndex > l {
 				return io.ErrUnexpectedEOF
+			}
+			if m.Leader == nil {
+				m.Leader = &Replica{}
 			}
 			if err := m.Leader.Unmarshal(data[index:postIndex]); err != nil {
 				return err
@@ -2002,8 +2040,14 @@ func (this *ErrorDetail) SetValue(value interface{}) bool {
 func (m *NotLeaderError) Size() (n int) {
 	var l int
 	_ = l
-	l = m.Leader.Size()
-	n += 1 + l + sovErrors(uint64(l))
+	if m.Replica != nil {
+		l = m.Replica.Size()
+		n += 1 + l + sovErrors(uint64(l))
+	}
+	if m.Leader != nil {
+		l = m.Leader.Size()
+		n += 1 + l + sovErrors(uint64(l))
+	}
 	if m.XXX_unrecognized != nil {
 		n += len(m.XXX_unrecognized)
 	}
@@ -2251,14 +2295,26 @@ func (m *NotLeaderError) MarshalTo(data []byte) (n int, err error) {
 	_ = i
 	var l int
 	_ = l
-	data[i] = 0xa
-	i++
-	i = encodeVarintErrors(data, i, uint64(m.Leader.Size()))
-	n1, err := m.Leader.MarshalTo(data[i:])
-	if err != nil {
-		return 0, err
+	if m.Replica != nil {
+		data[i] = 0xa
+		i++
+		i = encodeVarintErrors(data, i, uint64(m.Replica.Size()))
+		n1, err := m.Replica.MarshalTo(data[i:])
+		if err != nil {
+			return 0, err
+		}
+		i += n1
 	}
-	i += n1
+	if m.Leader != nil {
+		data[i] = 0x12
+		i++
+		i = encodeVarintErrors(data, i, uint64(m.Leader.Size()))
+		n2, err := m.Leader.MarshalTo(data[i:])
+		if err != nil {
+			return 0, err
+		}
+		i += n2
+	}
 	if m.XXX_unrecognized != nil {
 		i += copy(data[i:], m.XXX_unrecognized)
 	}
@@ -2307,28 +2363,28 @@ func (m *RangeKeyMismatchError) MarshalTo(data []byte) (n int, err error) {
 	data[i] = 0xa
 	i++
 	i = encodeVarintErrors(data, i, uint64(m.RequestStartKey.Size()))
-	n2, err := m.RequestStartKey.MarshalTo(data[i:])
-	if err != nil {
-		return 0, err
-	}
-	i += n2
-	data[i] = 0x12
-	i++
-	i = encodeVarintErrors(data, i, uint64(m.RequestEndKey.Size()))
-	n3, err := m.RequestEndKey.MarshalTo(data[i:])
+	n3, err := m.RequestStartKey.MarshalTo(data[i:])
 	if err != nil {
 		return 0, err
 	}
 	i += n3
+	data[i] = 0x12
+	i++
+	i = encodeVarintErrors(data, i, uint64(m.RequestEndKey.Size()))
+	n4, err := m.RequestEndKey.MarshalTo(data[i:])
+	if err != nil {
+		return 0, err
+	}
+	i += n4
 	if m.Range != nil {
 		data[i] = 0x1a
 		i++
 		i = encodeVarintErrors(data, i, uint64(m.Range.Size()))
-		n4, err := m.Range.MarshalTo(data[i:])
+		n5, err := m.Range.MarshalTo(data[i:])
 		if err != nil {
 			return 0, err
 		}
-		i += n4
+		i += n5
 	}
 	if m.XXX_unrecognized != nil {
 		i += copy(data[i:], m.XXX_unrecognized)
@@ -2354,19 +2410,19 @@ func (m *ReadWithinUncertaintyIntervalError) MarshalTo(data []byte) (n int, err 
 	data[i] = 0xa
 	i++
 	i = encodeVarintErrors(data, i, uint64(m.Timestamp.Size()))
-	n5, err := m.Timestamp.MarshalTo(data[i:])
-	if err != nil {
-		return 0, err
-	}
-	i += n5
-	data[i] = 0x12
-	i++
-	i = encodeVarintErrors(data, i, uint64(m.ExistingTimestamp.Size()))
-	n6, err := m.ExistingTimestamp.MarshalTo(data[i:])
+	n6, err := m.Timestamp.MarshalTo(data[i:])
 	if err != nil {
 		return 0, err
 	}
 	i += n6
+	data[i] = 0x12
+	i++
+	i = encodeVarintErrors(data, i, uint64(m.ExistingTimestamp.Size()))
+	n7, err := m.ExistingTimestamp.MarshalTo(data[i:])
+	if err != nil {
+		return 0, err
+	}
+	i += n7
 	if m.XXX_unrecognized != nil {
 		i += copy(data[i:], m.XXX_unrecognized)
 	}
@@ -2391,11 +2447,11 @@ func (m *TransactionAbortedError) MarshalTo(data []byte) (n int, err error) {
 	data[i] = 0xa
 	i++
 	i = encodeVarintErrors(data, i, uint64(m.Txn.Size()))
-	n7, err := m.Txn.MarshalTo(data[i:])
+	n8, err := m.Txn.MarshalTo(data[i:])
 	if err != nil {
 		return 0, err
 	}
-	i += n7
+	i += n8
 	if m.XXX_unrecognized != nil {
 		i += copy(data[i:], m.XXX_unrecognized)
 	}
@@ -2421,20 +2477,20 @@ func (m *TransactionPushError) MarshalTo(data []byte) (n int, err error) {
 		data[i] = 0xa
 		i++
 		i = encodeVarintErrors(data, i, uint64(m.Txn.Size()))
-		n8, err := m.Txn.MarshalTo(data[i:])
+		n9, err := m.Txn.MarshalTo(data[i:])
 		if err != nil {
 			return 0, err
 		}
-		i += n8
+		i += n9
 	}
 	data[i] = 0x12
 	i++
 	i = encodeVarintErrors(data, i, uint64(m.PusheeTxn.Size()))
-	n9, err := m.PusheeTxn.MarshalTo(data[i:])
+	n10, err := m.PusheeTxn.MarshalTo(data[i:])
 	if err != nil {
 		return 0, err
 	}
-	i += n9
+	i += n10
 	if m.XXX_unrecognized != nil {
 		i += copy(data[i:], m.XXX_unrecognized)
 	}
@@ -2459,11 +2515,11 @@ func (m *TransactionRetryError) MarshalTo(data []byte) (n int, err error) {
 	data[i] = 0xa
 	i++
 	i = encodeVarintErrors(data, i, uint64(m.Txn.Size()))
-	n10, err := m.Txn.MarshalTo(data[i:])
+	n11, err := m.Txn.MarshalTo(data[i:])
 	if err != nil {
 		return 0, err
 	}
-	i += n10
+	i += n11
 	if m.XXX_unrecognized != nil {
 		i += copy(data[i:], m.XXX_unrecognized)
 	}
@@ -2488,11 +2544,11 @@ func (m *TransactionStatusError) MarshalTo(data []byte) (n int, err error) {
 	data[i] = 0xa
 	i++
 	i = encodeVarintErrors(data, i, uint64(m.Txn.Size()))
-	n11, err := m.Txn.MarshalTo(data[i:])
+	n12, err := m.Txn.MarshalTo(data[i:])
 	if err != nil {
 		return 0, err
 	}
-	i += n11
+	i += n12
 	data[i] = 0x12
 	i++
 	i = encodeVarintErrors(data, i, uint64(len(m.Msg)))
@@ -2521,19 +2577,19 @@ func (m *WriteIntentError) MarshalTo(data []byte) (n int, err error) {
 	data[i] = 0xa
 	i++
 	i = encodeVarintErrors(data, i, uint64(m.Key.Size()))
-	n12, err := m.Key.MarshalTo(data[i:])
-	if err != nil {
-		return 0, err
-	}
-	i += n12
-	data[i] = 0x12
-	i++
-	i = encodeVarintErrors(data, i, uint64(m.Txn.Size()))
-	n13, err := m.Txn.MarshalTo(data[i:])
+	n13, err := m.Key.MarshalTo(data[i:])
 	if err != nil {
 		return 0, err
 	}
 	i += n13
+	data[i] = 0x12
+	i++
+	i = encodeVarintErrors(data, i, uint64(m.Txn.Size()))
+	n14, err := m.Txn.MarshalTo(data[i:])
+	if err != nil {
+		return 0, err
+	}
+	i += n14
 	data[i] = 0x18
 	i++
 	if m.Resolved {
@@ -2566,19 +2622,19 @@ func (m *WriteTooOldError) MarshalTo(data []byte) (n int, err error) {
 	data[i] = 0xa
 	i++
 	i = encodeVarintErrors(data, i, uint64(m.Timestamp.Size()))
-	n14, err := m.Timestamp.MarshalTo(data[i:])
-	if err != nil {
-		return 0, err
-	}
-	i += n14
-	data[i] = 0x12
-	i++
-	i = encodeVarintErrors(data, i, uint64(m.ExistingTimestamp.Size()))
-	n15, err := m.ExistingTimestamp.MarshalTo(data[i:])
+	n15, err := m.Timestamp.MarshalTo(data[i:])
 	if err != nil {
 		return 0, err
 	}
 	i += n15
+	data[i] = 0x12
+	i++
+	i = encodeVarintErrors(data, i, uint64(m.ExistingTimestamp.Size()))
+	n16, err := m.ExistingTimestamp.MarshalTo(data[i:])
+	if err != nil {
+		return 0, err
+	}
+	i += n16
 	if m.XXX_unrecognized != nil {
 		i += copy(data[i:], m.XXX_unrecognized)
 	}
@@ -2625,11 +2681,11 @@ func (m *ConditionFailedError) MarshalTo(data []byte) (n int, err error) {
 		data[i] = 0xa
 		i++
 		i = encodeVarintErrors(data, i, uint64(m.ActualValue.Size()))
-		n16, err := m.ActualValue.MarshalTo(data[i:])
+		n17, err := m.ActualValue.MarshalTo(data[i:])
 		if err != nil {
 			return 0, err
 		}
-		i += n16
+		i += n17
 	}
 	if m.XXX_unrecognized != nil {
 		i += copy(data[i:], m.XXX_unrecognized)
@@ -2656,121 +2712,121 @@ func (m *ErrorDetail) MarshalTo(data []byte) (n int, err error) {
 		data[i] = 0xa
 		i++
 		i = encodeVarintErrors(data, i, uint64(m.NotLeader.Size()))
-		n17, err := m.NotLeader.MarshalTo(data[i:])
-		if err != nil {
-			return 0, err
-		}
-		i += n17
-	}
-	if m.RangeNotFound != nil {
-		data[i] = 0x12
-		i++
-		i = encodeVarintErrors(data, i, uint64(m.RangeNotFound.Size()))
-		n18, err := m.RangeNotFound.MarshalTo(data[i:])
+		n18, err := m.NotLeader.MarshalTo(data[i:])
 		if err != nil {
 			return 0, err
 		}
 		i += n18
 	}
-	if m.RangeKeyMismatch != nil {
-		data[i] = 0x1a
+	if m.RangeNotFound != nil {
+		data[i] = 0x12
 		i++
-		i = encodeVarintErrors(data, i, uint64(m.RangeKeyMismatch.Size()))
-		n19, err := m.RangeKeyMismatch.MarshalTo(data[i:])
+		i = encodeVarintErrors(data, i, uint64(m.RangeNotFound.Size()))
+		n19, err := m.RangeNotFound.MarshalTo(data[i:])
 		if err != nil {
 			return 0, err
 		}
 		i += n19
 	}
-	if m.ReadWithinUncertaintyInterval != nil {
-		data[i] = 0x22
+	if m.RangeKeyMismatch != nil {
+		data[i] = 0x1a
 		i++
-		i = encodeVarintErrors(data, i, uint64(m.ReadWithinUncertaintyInterval.Size()))
-		n20, err := m.ReadWithinUncertaintyInterval.MarshalTo(data[i:])
+		i = encodeVarintErrors(data, i, uint64(m.RangeKeyMismatch.Size()))
+		n20, err := m.RangeKeyMismatch.MarshalTo(data[i:])
 		if err != nil {
 			return 0, err
 		}
 		i += n20
 	}
-	if m.TransactionAborted != nil {
-		data[i] = 0x2a
+	if m.ReadWithinUncertaintyInterval != nil {
+		data[i] = 0x22
 		i++
-		i = encodeVarintErrors(data, i, uint64(m.TransactionAborted.Size()))
-		n21, err := m.TransactionAborted.MarshalTo(data[i:])
+		i = encodeVarintErrors(data, i, uint64(m.ReadWithinUncertaintyInterval.Size()))
+		n21, err := m.ReadWithinUncertaintyInterval.MarshalTo(data[i:])
 		if err != nil {
 			return 0, err
 		}
 		i += n21
 	}
-	if m.TransactionPush != nil {
-		data[i] = 0x32
+	if m.TransactionAborted != nil {
+		data[i] = 0x2a
 		i++
-		i = encodeVarintErrors(data, i, uint64(m.TransactionPush.Size()))
-		n22, err := m.TransactionPush.MarshalTo(data[i:])
+		i = encodeVarintErrors(data, i, uint64(m.TransactionAborted.Size()))
+		n22, err := m.TransactionAborted.MarshalTo(data[i:])
 		if err != nil {
 			return 0, err
 		}
 		i += n22
 	}
-	if m.TransactionRetry != nil {
-		data[i] = 0x3a
+	if m.TransactionPush != nil {
+		data[i] = 0x32
 		i++
-		i = encodeVarintErrors(data, i, uint64(m.TransactionRetry.Size()))
-		n23, err := m.TransactionRetry.MarshalTo(data[i:])
+		i = encodeVarintErrors(data, i, uint64(m.TransactionPush.Size()))
+		n23, err := m.TransactionPush.MarshalTo(data[i:])
 		if err != nil {
 			return 0, err
 		}
 		i += n23
 	}
-	if m.TransactionStatus != nil {
-		data[i] = 0x42
+	if m.TransactionRetry != nil {
+		data[i] = 0x3a
 		i++
-		i = encodeVarintErrors(data, i, uint64(m.TransactionStatus.Size()))
-		n24, err := m.TransactionStatus.MarshalTo(data[i:])
+		i = encodeVarintErrors(data, i, uint64(m.TransactionRetry.Size()))
+		n24, err := m.TransactionRetry.MarshalTo(data[i:])
 		if err != nil {
 			return 0, err
 		}
 		i += n24
 	}
-	if m.WriteIntent != nil {
-		data[i] = 0x4a
+	if m.TransactionStatus != nil {
+		data[i] = 0x42
 		i++
-		i = encodeVarintErrors(data, i, uint64(m.WriteIntent.Size()))
-		n25, err := m.WriteIntent.MarshalTo(data[i:])
+		i = encodeVarintErrors(data, i, uint64(m.TransactionStatus.Size()))
+		n25, err := m.TransactionStatus.MarshalTo(data[i:])
 		if err != nil {
 			return 0, err
 		}
 		i += n25
 	}
-	if m.WriteTooOld != nil {
-		data[i] = 0x52
+	if m.WriteIntent != nil {
+		data[i] = 0x4a
 		i++
-		i = encodeVarintErrors(data, i, uint64(m.WriteTooOld.Size()))
-		n26, err := m.WriteTooOld.MarshalTo(data[i:])
+		i = encodeVarintErrors(data, i, uint64(m.WriteIntent.Size()))
+		n26, err := m.WriteIntent.MarshalTo(data[i:])
 		if err != nil {
 			return 0, err
 		}
 		i += n26
 	}
-	if m.OpRequiresTxn != nil {
-		data[i] = 0x5a
+	if m.WriteTooOld != nil {
+		data[i] = 0x52
 		i++
-		i = encodeVarintErrors(data, i, uint64(m.OpRequiresTxn.Size()))
-		n27, err := m.OpRequiresTxn.MarshalTo(data[i:])
+		i = encodeVarintErrors(data, i, uint64(m.WriteTooOld.Size()))
+		n27, err := m.WriteTooOld.MarshalTo(data[i:])
 		if err != nil {
 			return 0, err
 		}
 		i += n27
 	}
-	if m.ConditionFailed != nil {
-		data[i] = 0x62
+	if m.OpRequiresTxn != nil {
+		data[i] = 0x5a
 		i++
-		i = encodeVarintErrors(data, i, uint64(m.ConditionFailed.Size()))
-		n28, err := m.ConditionFailed.MarshalTo(data[i:])
+		i = encodeVarintErrors(data, i, uint64(m.OpRequiresTxn.Size()))
+		n28, err := m.OpRequiresTxn.MarshalTo(data[i:])
 		if err != nil {
 			return 0, err
 		}
 		i += n28
+	}
+	if m.ConditionFailed != nil {
+		data[i] = 0x62
+		i++
+		i = encodeVarintErrors(data, i, uint64(m.ConditionFailed.Size()))
+		n29, err := m.ConditionFailed.MarshalTo(data[i:])
+		if err != nil {
+			return 0, err
+		}
+		i += n29
 	}
 	if m.XXX_unrecognized != nil {
 		i += copy(data[i:], m.XXX_unrecognized)
@@ -2812,11 +2868,11 @@ func (m *Error) MarshalTo(data []byte) (n int, err error) {
 		data[i] = 0x1a
 		i++
 		i = encodeVarintErrors(data, i, uint64(m.Detail.Size()))
-		n29, err := m.Detail.MarshalTo(data[i:])
+		n30, err := m.Detail.MarshalTo(data[i:])
 		if err != nil {
 			return 0, err
 		}
-		i += n29
+		i += n30
 	}
 	if m.XXX_unrecognized != nil {
 		i += copy(data[i:], m.XXX_unrecognized)

--- a/proto/errors.proto
+++ b/proto/errors.proto
@@ -30,7 +30,8 @@ option (gogoproto.unmarshaler_all) = true;
 // A NotLeaderError indicates that the current range is not the
 // leader. If the leader is known, its Replica is set in the error.
 message NotLeaderError {
-  optional Replica leader = 1 [(gogoproto.nullable) = false];
+  optional Replica replica = 1;
+  optional Replica leader = 2;
 }
 
 // A RangeNotFoundError indicates that a command was sent to a range

--- a/proto/internal.proto
+++ b/proto/internal.proto
@@ -201,6 +201,7 @@ message ReadWriteCmdResponse {
     InternalMergeResponse internal_merge = 13;
     InternalTruncateLogResponse internal_truncate_log = 14;
     InternalGCResponse internal_gc = 15;
+    InternalLeaderLeaseResponse internal_leader_lease = 16;
   }
 }
 
@@ -237,7 +238,8 @@ message InternalRaftCommandUnion {
 // An InternalRaftCommand is a command which can be serialized and
 // sent via raft.
 message InternalRaftCommand {
-  optional int64 raft_id = 2 [(gogoproto.nullable) = false, (gogoproto.customname) = "RaftID"];
+  optional int64 raft_id = 1 [(gogoproto.nullable) = false, (gogoproto.customname) = "RaftID"];
+  optional uint64 origin_node_id = 2 [(gogoproto.nullable) = false, (gogoproto.customname) = "OriginNodeID" ];
   optional InternalRaftCommandUnion cmd = 3 [(gogoproto.nullable) = false];
 }
 

--- a/proto/method.go
+++ b/proto/method.go
@@ -20,7 +20,6 @@ package proto
 // Method is the enumerated type for methods.
 type Method int
 
-//go:generate stringer -type=Method
 const (
 	// Contains determines whether the KV map contains the specified key.
 	Contains Method = iota

--- a/proto/proto.go
+++ b/proto/proto.go
@@ -18,3 +18,4 @@
 package proto
 
 //go:generate make all
+//go:generate stringer -type=Method

--- a/server/testserver.go
+++ b/server/testserver.go
@@ -31,7 +31,7 @@ import (
 )
 
 // StartTestServer starts a in-memory test server.
-func StartTestServer(t *testing.T) *TestServer {
+func StartTestServer(t testing.TB) *TestServer {
 	s := &TestServer{}
 	if err := s.Start(); err != nil {
 		if t != nil {
@@ -71,10 +71,7 @@ func NewTestContext() *Context {
 // A TestServer encapsulates an in-memory instantiation of a cockroach
 // node with a single store. Example usage of a TestServer follows:
 //
-//   s := &server.TestServer{}
-//   if err := s.Start(); err != nil {
-//     t.Fatal(err)
-//   }
+//   s := server.StartTestServer(t)
 //   defer s.Stop()
 //
 type TestServer struct {
@@ -117,7 +114,7 @@ func (ts *TestServer) Start() error {
 	var err error
 	ts.Server, err = NewServer(ts.Ctx, util.NewStopper())
 	if err != nil {
-		return util.Errorf("could not init server: %s", err)
+		return err
 	}
 
 	// Ensure we have the correct number of engines. Add in in-memory ones where
@@ -150,7 +147,7 @@ func (ts *TestServer) Start() error {
 	}
 	err = ts.Server.Start(true)
 	if err != nil {
-		return util.Errorf("could not start server: %s", err)
+		return err
 	}
 
 	return nil

--- a/storage/engine/cockroach/proto/data.pb.cc
+++ b/storage/engine/cockroach/proto/data.pb.cc
@@ -298,10 +298,9 @@ void protobuf_AssignDesc_cockroach_2fproto_2fdata_2eproto() {
       ::google::protobuf::MessageFactory::generated_factory(),
       sizeof(Transaction));
   Lease_descriptor_ = file->message_type(12);
-  static const int Lease_offsets_[4] = {
+  static const int Lease_offsets_[3] = {
+    GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(Lease, start_),
     GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(Lease, expiration_),
-    GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(Lease, duration_),
-    GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(Lease, term_),
     GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(Lease, raft_node_id_),
   };
   Lease_reflection_ =
@@ -561,36 +560,37 @@ void protobuf_AddDesc_cockroach_2fproto_2fdata_2eproto() {
     "roach.proto.TimestampB\004\310\336\037\000\0227\n\rmax_times"
     "tamp\030\013 \001(\0132\032.cockroach.proto.TimestampB\004"
     "\310\336\037\000\0226\n\rcertain_nodes\030\014 \001(\0132\031.cockroach."
-    "proto.NodeListB\004\310\336\037\000:\004\230\240\037\000\"w\n\005Lease\022\030\n\ne"
-    "xpiration\030\001 \001(\003B\004\310\336\037\000\022\026\n\010duration\030\002 \001(\003B"
-    "\004\310\336\037\000\022\022\n\004term\030\003 \001(\004B\004\310\336\037\000\022(\n\014raft_node_i"
-    "d\030\004 \001(\004B\022\310\336\037\000\342\336\037\nRaftNodeID\"\336\001\n\014MVCCMeta"
-    "data\022)\n\003txn\030\001 \001(\0132\034.cockroach.proto.Tran"
-    "saction\0223\n\ttimestamp\030\002 \001(\0132\032.cockroach.p"
-    "roto.TimestampB\004\310\336\037\000\022\025\n\007deleted\030\003 \001(\010B\004\310"
-    "\336\037\000\022\027\n\tkey_bytes\030\004 \001(\003B\004\310\336\037\000\022\027\n\tval_byte"
-    "s\030\005 \001(\003B\004\310\336\037\000\022%\n\005value\030\006 \001(\0132\026.cockroach"
-    ".proto.Value\"H\n\nGCMetadata\022\035\n\017last_scan_"
-    "nanos\030\001 \001(\003B\004\310\336\037\000\022\033\n\023oldest_intent_nanos"
-    "\030\002 \001(\003\"\\\n\023TimeSeriesDatapoint\022\035\n\017timesta"
-    "mp_nanos\030\001 \001(\003B\004\310\336\037\000\022\021\n\tint_value\030\002 \001(\003\022"
-    "\023\n\013float_value\030\003 \001(\002\"t\n\016TimeSeriesData\022\022"
-    "\n\004name\030\001 \001(\tB\004\310\336\037\000\022\024\n\006source\030\002 \001(\tB\004\310\336\037\000"
-    "\0228\n\ndatapoints\030\003 \003(\0132$.cockroach.proto.T"
-    "imeSeriesDatapoint\"\300\002\n\tMVCCStats\022\030\n\nlive"
-    "_bytes\030\001 \001(\003B\004\310\336\037\000\022\027\n\tkey_bytes\030\002 \001(\003B\004\310"
-    "\336\037\000\022\027\n\tval_bytes\030\003 \001(\003B\004\310\336\037\000\022\032\n\014intent_b"
-    "ytes\030\004 \001(\003B\004\310\336\037\000\022\030\n\nlive_count\030\005 \001(\003B\004\310\336"
-    "\037\000\022\027\n\tkey_count\030\006 \001(\003B\004\310\336\037\000\022\027\n\tval_count"
-    "\030\007 \001(\003B\004\310\336\037\000\022\032\n\014intent_count\030\010 \001(\003B\004\310\336\037\000"
-    "\022\030\n\nintent_age\030\t \001(\003B\004\310\336\037\000\022(\n\014gc_bytes_a"
-    "ge\030\n \001(\003B\022\310\336\037\000\342\336\037\nGCBytesAge\022\037\n\021last_upd"
-    "ate_nanos\030\013 \001(\003B\004\310\336\037\000*>\n\021ReplicaChangeTy"
-    "pe\022\017\n\013ADD_REPLICA\020\000\022\022\n\016REMOVE_REPLICA\020\001\032"
-    "\004\210\243\036\000*5\n\rIsolationType\022\020\n\014SERIALIZABLE\020\000"
-    "\022\014\n\010SNAPSHOT\020\001\032\004\210\243\036\000*B\n\021TransactionStatu"
-    "s\022\013\n\007PENDING\020\000\022\r\n\tCOMMITTED\020\001\022\013\n\007ABORTED"
-    "\020\002\032\004\210\243\036\000B\023Z\005proto\340\342\036\001\310\342\036\001\320\342\036\001", 3109);
+    "proto.NodeListB\004\310\336\037\000:\004\230\240\037\000\"\230\001\n\005Lease\022/\n\005"
+    "start\030\001 \001(\0132\032.cockroach.proto.TimestampB"
+    "\004\310\336\037\000\0224\n\nexpiration\030\002 \001(\0132\032.cockroach.pr"
+    "oto.TimestampB\004\310\336\037\000\022(\n\014raft_node_id\030\003 \001("
+    "\004B\022\310\336\037\000\342\336\037\nRaftNodeID\"\336\001\n\014MVCCMetadata\022)"
+    "\n\003txn\030\001 \001(\0132\034.cockroach.proto.Transactio"
+    "n\0223\n\ttimestamp\030\002 \001(\0132\032.cockroach.proto.T"
+    "imestampB\004\310\336\037\000\022\025\n\007deleted\030\003 \001(\010B\004\310\336\037\000\022\027\n"
+    "\tkey_bytes\030\004 \001(\003B\004\310\336\037\000\022\027\n\tval_bytes\030\005 \001("
+    "\003B\004\310\336\037\000\022%\n\005value\030\006 \001(\0132\026.cockroach.proto"
+    ".Value\"H\n\nGCMetadata\022\035\n\017last_scan_nanos\030"
+    "\001 \001(\003B\004\310\336\037\000\022\033\n\023oldest_intent_nanos\030\002 \001(\003"
+    "\"\\\n\023TimeSeriesDatapoint\022\035\n\017timestamp_nan"
+    "os\030\001 \001(\003B\004\310\336\037\000\022\021\n\tint_value\030\002 \001(\003\022\023\n\013flo"
+    "at_value\030\003 \001(\002\"t\n\016TimeSeriesData\022\022\n\004name"
+    "\030\001 \001(\tB\004\310\336\037\000\022\024\n\006source\030\002 \001(\tB\004\310\336\037\000\0228\n\nda"
+    "tapoints\030\003 \003(\0132$.cockroach.proto.TimeSer"
+    "iesDatapoint\"\300\002\n\tMVCCStats\022\030\n\nlive_bytes"
+    "\030\001 \001(\003B\004\310\336\037\000\022\027\n\tkey_bytes\030\002 \001(\003B\004\310\336\037\000\022\027\n"
+    "\tval_bytes\030\003 \001(\003B\004\310\336\037\000\022\032\n\014intent_bytes\030\004"
+    " \001(\003B\004\310\336\037\000\022\030\n\nlive_count\030\005 \001(\003B\004\310\336\037\000\022\027\n\t"
+    "key_count\030\006 \001(\003B\004\310\336\037\000\022\027\n\tval_count\030\007 \001(\003"
+    "B\004\310\336\037\000\022\032\n\014intent_count\030\010 \001(\003B\004\310\336\037\000\022\030\n\nin"
+    "tent_age\030\t \001(\003B\004\310\336\037\000\022(\n\014gc_bytes_age\030\n \001"
+    "(\003B\022\310\336\037\000\342\336\037\nGCBytesAge\022\037\n\021last_update_na"
+    "nos\030\013 \001(\003B\004\310\336\037\000*>\n\021ReplicaChangeType\022\017\n\013"
+    "ADD_REPLICA\020\000\022\022\n\016REMOVE_REPLICA\020\001\032\004\210\243\036\000*"
+    "5\n\rIsolationType\022\020\n\014SERIALIZABLE\020\000\022\014\n\010SN"
+    "APSHOT\020\001\032\004\210\243\036\000*B\n\021TransactionStatus\022\013\n\007P"
+    "ENDING\020\000\022\r\n\tCOMMITTED\020\001\022\013\n\007ABORTED\020\002\032\004\210\243"
+    "\036\000B\023Z\005proto\340\342\036\001\310\342\036\001\320\342\036\001", 3143);
   ::google::protobuf::MessageFactory::InternalRegisterGeneratedFile(
     "cockroach/proto/data.proto", &protobuf_RegisterTypes);
   Timestamp::default_instance_ = new Timestamp();
@@ -4772,9 +4772,8 @@ void Transaction::Swap(Transaction* other) {
 // ===================================================================
 
 #ifndef _MSC_VER
+const int Lease::kStartFieldNumber;
 const int Lease::kExpirationFieldNumber;
-const int Lease::kDurationFieldNumber;
-const int Lease::kTermFieldNumber;
 const int Lease::kRaftNodeIdFieldNumber;
 #endif  // !_MSC_VER
 
@@ -4785,6 +4784,8 @@ Lease::Lease()
 }
 
 void Lease::InitAsDefaultInstance() {
+  start_ = const_cast< ::cockroach::proto::Timestamp*>(&::cockroach::proto::Timestamp::default_instance());
+  expiration_ = const_cast< ::cockroach::proto::Timestamp*>(&::cockroach::proto::Timestamp::default_instance());
 }
 
 Lease::Lease(const Lease& from)
@@ -4796,9 +4797,8 @@ Lease::Lease(const Lease& from)
 
 void Lease::SharedCtor() {
   _cached_size_ = 0;
-  expiration_ = GOOGLE_LONGLONG(0);
-  duration_ = GOOGLE_LONGLONG(0);
-  term_ = GOOGLE_ULONGLONG(0);
+  start_ = NULL;
+  expiration_ = NULL;
   raft_node_id_ = GOOGLE_ULONGLONG(0);
   ::memset(_has_bits_, 0, sizeof(_has_bits_));
 }
@@ -4810,6 +4810,8 @@ Lease::~Lease() {
 
 void Lease::SharedDtor() {
   if (this != default_instance_) {
+    delete start_;
+    delete expiration_;
   }
 }
 
@@ -4835,21 +4837,15 @@ Lease* Lease::New() const {
 }
 
 void Lease::Clear() {
-#define OFFSET_OF_FIELD_(f) (reinterpret_cast<char*>(      \
-  &reinterpret_cast<Lease*>(16)->f) - \
-   reinterpret_cast<char*>(16))
-
-#define ZR_(first, last) do {                              \
-    size_t f = OFFSET_OF_FIELD_(first);                    \
-    size_t n = OFFSET_OF_FIELD_(last) - f + sizeof(last);  \
-    ::memset(&first, 0, n);                                \
-  } while (0)
-
-  ZR_(expiration_, raft_node_id_);
-
-#undef OFFSET_OF_FIELD_
-#undef ZR_
-
+  if (_has_bits_[0 / 32] & 7) {
+    if (has_start()) {
+      if (start_ != NULL) start_->::cockroach::proto::Timestamp::Clear();
+    }
+    if (has_expiration()) {
+      if (expiration_ != NULL) expiration_->::cockroach::proto::Timestamp::Clear();
+    }
+    raft_node_id_ = GOOGLE_ULONGLONG(0);
+  }
   ::memset(_has_bits_, 0, sizeof(_has_bits_));
   mutable_unknown_fields()->Clear();
 }
@@ -4864,53 +4860,34 @@ bool Lease::MergePartialFromCodedStream(
     tag = p.first;
     if (!p.second) goto handle_unusual;
     switch (::google::protobuf::internal::WireFormatLite::GetTagFieldNumber(tag)) {
-      // optional int64 expiration = 1;
+      // optional .cockroach.proto.Timestamp start = 1;
       case 1: {
-        if (tag == 8) {
-          DO_((::google::protobuf::internal::WireFormatLite::ReadPrimitive<
-                   ::google::protobuf::int64, ::google::protobuf::internal::WireFormatLite::TYPE_INT64>(
-                 input, &expiration_)));
-          set_has_expiration();
+        if (tag == 10) {
+          DO_(::google::protobuf::internal::WireFormatLite::ReadMessageNoVirtual(
+               input, mutable_start()));
         } else {
           goto handle_unusual;
         }
-        if (input->ExpectTag(16)) goto parse_duration;
+        if (input->ExpectTag(18)) goto parse_expiration;
         break;
       }
 
-      // optional int64 duration = 2;
+      // optional .cockroach.proto.Timestamp expiration = 2;
       case 2: {
-        if (tag == 16) {
-         parse_duration:
-          DO_((::google::protobuf::internal::WireFormatLite::ReadPrimitive<
-                   ::google::protobuf::int64, ::google::protobuf::internal::WireFormatLite::TYPE_INT64>(
-                 input, &duration_)));
-          set_has_duration();
+        if (tag == 18) {
+         parse_expiration:
+          DO_(::google::protobuf::internal::WireFormatLite::ReadMessageNoVirtual(
+               input, mutable_expiration()));
         } else {
           goto handle_unusual;
         }
-        if (input->ExpectTag(24)) goto parse_term;
+        if (input->ExpectTag(24)) goto parse_raft_node_id;
         break;
       }
 
-      // optional uint64 term = 3;
+      // optional uint64 raft_node_id = 3;
       case 3: {
         if (tag == 24) {
-         parse_term:
-          DO_((::google::protobuf::internal::WireFormatLite::ReadPrimitive<
-                   ::google::protobuf::uint64, ::google::protobuf::internal::WireFormatLite::TYPE_UINT64>(
-                 input, &term_)));
-          set_has_term();
-        } else {
-          goto handle_unusual;
-        }
-        if (input->ExpectTag(32)) goto parse_raft_node_id;
-        break;
-      }
-
-      // optional uint64 raft_node_id = 4;
-      case 4: {
-        if (tag == 32) {
          parse_raft_node_id:
           DO_((::google::protobuf::internal::WireFormatLite::ReadPrimitive<
                    ::google::protobuf::uint64, ::google::protobuf::internal::WireFormatLite::TYPE_UINT64>(
@@ -4948,24 +4925,21 @@ failure:
 void Lease::SerializeWithCachedSizes(
     ::google::protobuf::io::CodedOutputStream* output) const {
   // @@protoc_insertion_point(serialize_start:cockroach.proto.Lease)
-  // optional int64 expiration = 1;
+  // optional .cockroach.proto.Timestamp start = 1;
+  if (has_start()) {
+    ::google::protobuf::internal::WireFormatLite::WriteMessageMaybeToArray(
+      1, this->start(), output);
+  }
+
+  // optional .cockroach.proto.Timestamp expiration = 2;
   if (has_expiration()) {
-    ::google::protobuf::internal::WireFormatLite::WriteInt64(1, this->expiration(), output);
+    ::google::protobuf::internal::WireFormatLite::WriteMessageMaybeToArray(
+      2, this->expiration(), output);
   }
 
-  // optional int64 duration = 2;
-  if (has_duration()) {
-    ::google::protobuf::internal::WireFormatLite::WriteInt64(2, this->duration(), output);
-  }
-
-  // optional uint64 term = 3;
-  if (has_term()) {
-    ::google::protobuf::internal::WireFormatLite::WriteUInt64(3, this->term(), output);
-  }
-
-  // optional uint64 raft_node_id = 4;
+  // optional uint64 raft_node_id = 3;
   if (has_raft_node_id()) {
-    ::google::protobuf::internal::WireFormatLite::WriteUInt64(4, this->raft_node_id(), output);
+    ::google::protobuf::internal::WireFormatLite::WriteUInt64(3, this->raft_node_id(), output);
   }
 
   if (!unknown_fields().empty()) {
@@ -4978,24 +4952,23 @@ void Lease::SerializeWithCachedSizes(
 ::google::protobuf::uint8* Lease::SerializeWithCachedSizesToArray(
     ::google::protobuf::uint8* target) const {
   // @@protoc_insertion_point(serialize_to_array_start:cockroach.proto.Lease)
-  // optional int64 expiration = 1;
+  // optional .cockroach.proto.Timestamp start = 1;
+  if (has_start()) {
+    target = ::google::protobuf::internal::WireFormatLite::
+      WriteMessageNoVirtualToArray(
+        1, this->start(), target);
+  }
+
+  // optional .cockroach.proto.Timestamp expiration = 2;
   if (has_expiration()) {
-    target = ::google::protobuf::internal::WireFormatLite::WriteInt64ToArray(1, this->expiration(), target);
+    target = ::google::protobuf::internal::WireFormatLite::
+      WriteMessageNoVirtualToArray(
+        2, this->expiration(), target);
   }
 
-  // optional int64 duration = 2;
-  if (has_duration()) {
-    target = ::google::protobuf::internal::WireFormatLite::WriteInt64ToArray(2, this->duration(), target);
-  }
-
-  // optional uint64 term = 3;
-  if (has_term()) {
-    target = ::google::protobuf::internal::WireFormatLite::WriteUInt64ToArray(3, this->term(), target);
-  }
-
-  // optional uint64 raft_node_id = 4;
+  // optional uint64 raft_node_id = 3;
   if (has_raft_node_id()) {
-    target = ::google::protobuf::internal::WireFormatLite::WriteUInt64ToArray(4, this->raft_node_id(), target);
+    target = ::google::protobuf::internal::WireFormatLite::WriteUInt64ToArray(3, this->raft_node_id(), target);
   }
 
   if (!unknown_fields().empty()) {
@@ -5010,28 +4983,21 @@ int Lease::ByteSize() const {
   int total_size = 0;
 
   if (_has_bits_[0 / 32] & (0xffu << (0 % 32))) {
-    // optional int64 expiration = 1;
+    // optional .cockroach.proto.Timestamp start = 1;
+    if (has_start()) {
+      total_size += 1 +
+        ::google::protobuf::internal::WireFormatLite::MessageSizeNoVirtual(
+          this->start());
+    }
+
+    // optional .cockroach.proto.Timestamp expiration = 2;
     if (has_expiration()) {
       total_size += 1 +
-        ::google::protobuf::internal::WireFormatLite::Int64Size(
+        ::google::protobuf::internal::WireFormatLite::MessageSizeNoVirtual(
           this->expiration());
     }
 
-    // optional int64 duration = 2;
-    if (has_duration()) {
-      total_size += 1 +
-        ::google::protobuf::internal::WireFormatLite::Int64Size(
-          this->duration());
-    }
-
-    // optional uint64 term = 3;
-    if (has_term()) {
-      total_size += 1 +
-        ::google::protobuf::internal::WireFormatLite::UInt64Size(
-          this->term());
-    }
-
-    // optional uint64 raft_node_id = 4;
+    // optional uint64 raft_node_id = 3;
     if (has_raft_node_id()) {
       total_size += 1 +
         ::google::protobuf::internal::WireFormatLite::UInt64Size(
@@ -5065,14 +5031,11 @@ void Lease::MergeFrom(const ::google::protobuf::Message& from) {
 void Lease::MergeFrom(const Lease& from) {
   GOOGLE_CHECK_NE(&from, this);
   if (from._has_bits_[0 / 32] & (0xffu << (0 % 32))) {
+    if (from.has_start()) {
+      mutable_start()->::cockroach::proto::Timestamp::MergeFrom(from.start());
+    }
     if (from.has_expiration()) {
-      set_expiration(from.expiration());
-    }
-    if (from.has_duration()) {
-      set_duration(from.duration());
-    }
-    if (from.has_term()) {
-      set_term(from.term());
+      mutable_expiration()->::cockroach::proto::Timestamp::MergeFrom(from.expiration());
     }
     if (from.has_raft_node_id()) {
       set_raft_node_id(from.raft_node_id());
@@ -5100,9 +5063,8 @@ bool Lease::IsInitialized() const {
 
 void Lease::Swap(Lease* other) {
   if (other != this) {
+    std::swap(start_, other->start_);
     std::swap(expiration_, other->expiration_);
-    std::swap(duration_, other->duration_);
-    std::swap(term_, other->term_);
     std::swap(raft_node_id_, other->raft_node_id_);
     std::swap(_has_bits_[0], other->_has_bits_[0]);
     _unknown_fields_.Swap(&other->_unknown_fields_);

--- a/storage/engine/cockroach/proto/data.pb.h
+++ b/storage/engine/cockroach/proto/data.pb.h
@@ -1494,42 +1494,37 @@ class Lease : public ::google::protobuf::Message {
 
   // accessors -------------------------------------------------------
 
-  // optional int64 expiration = 1;
+  // optional .cockroach.proto.Timestamp start = 1;
+  inline bool has_start() const;
+  inline void clear_start();
+  static const int kStartFieldNumber = 1;
+  inline const ::cockroach::proto::Timestamp& start() const;
+  inline ::cockroach::proto::Timestamp* mutable_start();
+  inline ::cockroach::proto::Timestamp* release_start();
+  inline void set_allocated_start(::cockroach::proto::Timestamp* start);
+
+  // optional .cockroach.proto.Timestamp expiration = 2;
   inline bool has_expiration() const;
   inline void clear_expiration();
-  static const int kExpirationFieldNumber = 1;
-  inline ::google::protobuf::int64 expiration() const;
-  inline void set_expiration(::google::protobuf::int64 value);
+  static const int kExpirationFieldNumber = 2;
+  inline const ::cockroach::proto::Timestamp& expiration() const;
+  inline ::cockroach::proto::Timestamp* mutable_expiration();
+  inline ::cockroach::proto::Timestamp* release_expiration();
+  inline void set_allocated_expiration(::cockroach::proto::Timestamp* expiration);
 
-  // optional int64 duration = 2;
-  inline bool has_duration() const;
-  inline void clear_duration();
-  static const int kDurationFieldNumber = 2;
-  inline ::google::protobuf::int64 duration() const;
-  inline void set_duration(::google::protobuf::int64 value);
-
-  // optional uint64 term = 3;
-  inline bool has_term() const;
-  inline void clear_term();
-  static const int kTermFieldNumber = 3;
-  inline ::google::protobuf::uint64 term() const;
-  inline void set_term(::google::protobuf::uint64 value);
-
-  // optional uint64 raft_node_id = 4;
+  // optional uint64 raft_node_id = 3;
   inline bool has_raft_node_id() const;
   inline void clear_raft_node_id();
-  static const int kRaftNodeIdFieldNumber = 4;
+  static const int kRaftNodeIdFieldNumber = 3;
   inline ::google::protobuf::uint64 raft_node_id() const;
   inline void set_raft_node_id(::google::protobuf::uint64 value);
 
   // @@protoc_insertion_point(class_scope:cockroach.proto.Lease)
  private:
+  inline void set_has_start();
+  inline void clear_has_start();
   inline void set_has_expiration();
   inline void clear_has_expiration();
-  inline void set_has_duration();
-  inline void clear_has_duration();
-  inline void set_has_term();
-  inline void clear_has_term();
   inline void set_has_raft_node_id();
   inline void clear_has_raft_node_id();
 
@@ -1537,9 +1532,8 @@ class Lease : public ::google::protobuf::Message {
 
   ::google::protobuf::uint32 _has_bits_[1];
   mutable int _cached_size_;
-  ::google::protobuf::int64 expiration_;
-  ::google::protobuf::int64 duration_;
-  ::google::protobuf::uint64 term_;
+  ::cockroach::proto::Timestamp* start_;
+  ::cockroach::proto::Timestamp* expiration_;
   ::google::protobuf::uint64 raft_node_id_;
   friend void  protobuf_AddDesc_cockroach_2fproto_2fdata_2eproto();
   friend void protobuf_AssignDesc_cockroach_2fproto_2fdata_2eproto();
@@ -3952,87 +3946,97 @@ inline void Transaction::set_allocated_certain_nodes(::cockroach::proto::NodeLis
 
 // Lease
 
-// optional int64 expiration = 1;
-inline bool Lease::has_expiration() const {
+// optional .cockroach.proto.Timestamp start = 1;
+inline bool Lease::has_start() const {
   return (_has_bits_[0] & 0x00000001u) != 0;
 }
-inline void Lease::set_has_expiration() {
+inline void Lease::set_has_start() {
   _has_bits_[0] |= 0x00000001u;
 }
-inline void Lease::clear_has_expiration() {
+inline void Lease::clear_has_start() {
   _has_bits_[0] &= ~0x00000001u;
 }
-inline void Lease::clear_expiration() {
-  expiration_ = GOOGLE_LONGLONG(0);
-  clear_has_expiration();
+inline void Lease::clear_start() {
+  if (start_ != NULL) start_->::cockroach::proto::Timestamp::Clear();
+  clear_has_start();
 }
-inline ::google::protobuf::int64 Lease::expiration() const {
-  // @@protoc_insertion_point(field_get:cockroach.proto.Lease.expiration)
-  return expiration_;
+inline const ::cockroach::proto::Timestamp& Lease::start() const {
+  // @@protoc_insertion_point(field_get:cockroach.proto.Lease.start)
+  return start_ != NULL ? *start_ : *default_instance_->start_;
 }
-inline void Lease::set_expiration(::google::protobuf::int64 value) {
-  set_has_expiration();
-  expiration_ = value;
-  // @@protoc_insertion_point(field_set:cockroach.proto.Lease.expiration)
+inline ::cockroach::proto::Timestamp* Lease::mutable_start() {
+  set_has_start();
+  if (start_ == NULL) start_ = new ::cockroach::proto::Timestamp;
+  // @@protoc_insertion_point(field_mutable:cockroach.proto.Lease.start)
+  return start_;
+}
+inline ::cockroach::proto::Timestamp* Lease::release_start() {
+  clear_has_start();
+  ::cockroach::proto::Timestamp* temp = start_;
+  start_ = NULL;
+  return temp;
+}
+inline void Lease::set_allocated_start(::cockroach::proto::Timestamp* start) {
+  delete start_;
+  start_ = start;
+  if (start) {
+    set_has_start();
+  } else {
+    clear_has_start();
+  }
+  // @@protoc_insertion_point(field_set_allocated:cockroach.proto.Lease.start)
 }
 
-// optional int64 duration = 2;
-inline bool Lease::has_duration() const {
+// optional .cockroach.proto.Timestamp expiration = 2;
+inline bool Lease::has_expiration() const {
   return (_has_bits_[0] & 0x00000002u) != 0;
 }
-inline void Lease::set_has_duration() {
+inline void Lease::set_has_expiration() {
   _has_bits_[0] |= 0x00000002u;
 }
-inline void Lease::clear_has_duration() {
+inline void Lease::clear_has_expiration() {
   _has_bits_[0] &= ~0x00000002u;
 }
-inline void Lease::clear_duration() {
-  duration_ = GOOGLE_LONGLONG(0);
-  clear_has_duration();
+inline void Lease::clear_expiration() {
+  if (expiration_ != NULL) expiration_->::cockroach::proto::Timestamp::Clear();
+  clear_has_expiration();
 }
-inline ::google::protobuf::int64 Lease::duration() const {
-  // @@protoc_insertion_point(field_get:cockroach.proto.Lease.duration)
-  return duration_;
+inline const ::cockroach::proto::Timestamp& Lease::expiration() const {
+  // @@protoc_insertion_point(field_get:cockroach.proto.Lease.expiration)
+  return expiration_ != NULL ? *expiration_ : *default_instance_->expiration_;
 }
-inline void Lease::set_duration(::google::protobuf::int64 value) {
-  set_has_duration();
-  duration_ = value;
-  // @@protoc_insertion_point(field_set:cockroach.proto.Lease.duration)
+inline ::cockroach::proto::Timestamp* Lease::mutable_expiration() {
+  set_has_expiration();
+  if (expiration_ == NULL) expiration_ = new ::cockroach::proto::Timestamp;
+  // @@protoc_insertion_point(field_mutable:cockroach.proto.Lease.expiration)
+  return expiration_;
+}
+inline ::cockroach::proto::Timestamp* Lease::release_expiration() {
+  clear_has_expiration();
+  ::cockroach::proto::Timestamp* temp = expiration_;
+  expiration_ = NULL;
+  return temp;
+}
+inline void Lease::set_allocated_expiration(::cockroach::proto::Timestamp* expiration) {
+  delete expiration_;
+  expiration_ = expiration;
+  if (expiration) {
+    set_has_expiration();
+  } else {
+    clear_has_expiration();
+  }
+  // @@protoc_insertion_point(field_set_allocated:cockroach.proto.Lease.expiration)
 }
 
-// optional uint64 term = 3;
-inline bool Lease::has_term() const {
+// optional uint64 raft_node_id = 3;
+inline bool Lease::has_raft_node_id() const {
   return (_has_bits_[0] & 0x00000004u) != 0;
 }
-inline void Lease::set_has_term() {
+inline void Lease::set_has_raft_node_id() {
   _has_bits_[0] |= 0x00000004u;
 }
-inline void Lease::clear_has_term() {
-  _has_bits_[0] &= ~0x00000004u;
-}
-inline void Lease::clear_term() {
-  term_ = GOOGLE_ULONGLONG(0);
-  clear_has_term();
-}
-inline ::google::protobuf::uint64 Lease::term() const {
-  // @@protoc_insertion_point(field_get:cockroach.proto.Lease.term)
-  return term_;
-}
-inline void Lease::set_term(::google::protobuf::uint64 value) {
-  set_has_term();
-  term_ = value;
-  // @@protoc_insertion_point(field_set:cockroach.proto.Lease.term)
-}
-
-// optional uint64 raft_node_id = 4;
-inline bool Lease::has_raft_node_id() const {
-  return (_has_bits_[0] & 0x00000008u) != 0;
-}
-inline void Lease::set_has_raft_node_id() {
-  _has_bits_[0] |= 0x00000008u;
-}
 inline void Lease::clear_has_raft_node_id() {
-  _has_bits_[0] &= ~0x00000008u;
+  _has_bits_[0] &= ~0x00000004u;
 }
 inline void Lease::clear_raft_node_id() {
   raft_node_id_ = GOOGLE_ULONGLONG(0);

--- a/storage/engine/cockroach/proto/errors.pb.cc
+++ b/storage/engine/cockroach/proto/errors.pb.cc
@@ -89,7 +89,8 @@ void protobuf_AssignDesc_cockroach_2fproto_2ferrors_2eproto() {
       "cockroach/proto/errors.proto");
   GOOGLE_CHECK(file != NULL);
   NotLeaderError_descriptor_ = file->message_type(0);
-  static const int NotLeaderError_offsets_[1] = {
+  static const int NotLeaderError_offsets_[2] = {
+    GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(NotLeaderError, replica_),
     GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(NotLeaderError, leader_),
   };
   NotLeaderError_reflection_ =
@@ -412,63 +413,64 @@ void protobuf_AddDesc_cockroach_2fproto_2ferrors_2eproto() {
     "\n\034cockroach/proto/errors.proto\022\017cockroac"
     "h.proto\032\034cockroach/proto/config.proto\032\032c"
     "ockroach/proto/data.proto\032\024gogoproto/gog"
-    "o.proto\"@\n\016NotLeaderError\022.\n\006leader\030\001 \001("
-    "\0132\030.cockroach.proto.ReplicaB\004\310\336\037\000\"5\n\022Ran"
-    "geNotFoundError\022\037\n\007raft_id\030\001 \001(\003B\016\310\336\037\000\342\336"
-    "\037\006RaftID\"\226\001\n\025RangeKeyMismatchError\022&\n\021re"
-    "quest_start_key\030\001 \001(\014B\013\310\336\037\000\332\336\037\003Key\022$\n\017re"
-    "quest_end_key\030\002 \001(\014B\013\310\336\037\000\332\336\037\003Key\022/\n\005rang"
-    "e\030\003 \001(\0132 .cockroach.proto.RangeDescripto"
-    "r\"\227\001\n\"ReadWithinUncertaintyIntervalError"
-    "\0223\n\ttimestamp\030\001 \001(\0132\032.cockroach.proto.Ti"
-    "mestampB\004\310\336\037\000\022<\n\022existing_timestamp\030\002 \001("
-    "\0132\032.cockroach.proto.TimestampB\004\310\336\037\000\"J\n\027T"
-    "ransactionAbortedError\022/\n\003txn\030\001 \001(\0132\034.co"
-    "ckroach.proto.TransactionB\004\310\336\037\000\"y\n\024Trans"
-    "actionPushError\022)\n\003txn\030\001 \001(\0132\034.cockroach"
-    ".proto.Transaction\0226\n\npushee_txn\030\002 \001(\0132\034"
-    ".cockroach.proto.TransactionB\004\310\336\037\000\"H\n\025Tr"
-    "ansactionRetryError\022/\n\003txn\030\001 \001(\0132\034.cockr"
-    "oach.proto.TransactionB\004\310\336\037\000\"\\\n\026Transact"
-    "ionStatusError\022/\n\003txn\030\001 \001(\0132\034.cockroach."
-    "proto.TransactionB\004\310\336\037\000\022\021\n\003msg\030\002 \001(\tB\004\310\336"
-    "\037\000\"u\n\020WriteIntentError\022\030\n\003key\030\001 \001(\014B\013\310\336\037"
-    "\000\332\336\037\003Key\022/\n\003txn\030\002 \001(\0132\034.cockroach.proto."
-    "TransactionB\004\310\336\037\000\022\026\n\010resolved\030\003 \001(\010B\004\310\336\037"
-    "\000\"\205\001\n\020WriteTooOldError\0223\n\ttimestamp\030\001 \001("
-    "\0132\032.cockroach.proto.TimestampB\004\310\336\037\000\022<\n\022e"
-    "xisting_timestamp\030\002 \001(\0132\032.cockroach.prot"
-    "o.TimestampB\004\310\336\037\000\"\024\n\022OpRequiresTxnError\""
-    "D\n\024ConditionFailedError\022,\n\014actual_value\030"
-    "\001 \001(\0132\026.cockroach.proto.Value\"\314\006\n\013ErrorD"
-    "etail\0225\n\nnot_leader\030\001 \001(\0132\037.cockroach.pr"
-    "oto.NotLeaderErrorH\000\022>\n\017range_not_found\030"
-    "\002 \001(\0132#.cockroach.proto.RangeNotFoundErr"
-    "orH\000\022D\n\022range_key_mismatch\030\003 \001(\0132&.cockr"
-    "oach.proto.RangeKeyMismatchErrorH\000\022_\n re"
-    "ad_within_uncertainty_interval\030\004 \001(\01323.c"
-    "ockroach.proto.ReadWithinUncertaintyInte"
-    "rvalErrorH\000\022G\n\023transaction_aborted\030\005 \001(\013"
-    "2(.cockroach.proto.TransactionAbortedErr"
-    "orH\000\022A\n\020transaction_push\030\006 \001(\0132%.cockroa"
-    "ch.proto.TransactionPushErrorH\000\022C\n\021trans"
-    "action_retry\030\007 \001(\0132&.cockroach.proto.Tra"
-    "nsactionRetryErrorH\000\022E\n\022transaction_stat"
-    "us\030\010 \001(\0132\'.cockroach.proto.TransactionSt"
-    "atusErrorH\000\0229\n\014write_intent\030\t \001(\0132!.cock"
-    "roach.proto.WriteIntentErrorH\000\022:\n\rwrite_"
-    "too_old\030\n \001(\0132!.cockroach.proto.WriteToo"
-    "OldErrorH\000\022>\n\017op_requires_txn\030\013 \001(\0132#.co"
-    "ckroach.proto.OpRequiresTxnErrorH\000\022A\n\020co"
-    "ndition_failed\030\014 \001(\0132%.cockroach.proto.C"
-    "onditionFailedErrorH\000:\004\310\240\037\001B\007\n\005value\"\255\001\n"
-    "\005Error\022\025\n\007message\030\001 \001(\tB\004\310\336\037\000\022\027\n\tretryab"
-    "le\030\002 \001(\010B\004\310\336\037\000\022F\n\023transaction_restart\030\004 "
-    "\001(\0162#.cockroach.proto.TransactionRestart"
-    "B\004\310\336\037\000\022,\n\006detail\030\003 \001(\0132\034.cockroach.proto"
-    ".ErrorDetail*;\n\022TransactionRestart\022\t\n\005AB"
-    "ORT\020\000\022\013\n\007BACKOFF\020\001\022\r\n\tIMMEDIATE\020\002B\023Z\005pro"
-    "to\340\342\036\001\310\342\036\001\320\342\036\001", 2374);
+    "o.proto\"e\n\016NotLeaderError\022)\n\007replica\030\001 \001"
+    "(\0132\030.cockroach.proto.Replica\022(\n\006leader\030\002"
+    " \001(\0132\030.cockroach.proto.Replica\"5\n\022RangeN"
+    "otFoundError\022\037\n\007raft_id\030\001 \001(\003B\016\310\336\037\000\342\336\037\006R"
+    "aftID\"\226\001\n\025RangeKeyMismatchError\022&\n\021reque"
+    "st_start_key\030\001 \001(\014B\013\310\336\037\000\332\336\037\003Key\022$\n\017reque"
+    "st_end_key\030\002 \001(\014B\013\310\336\037\000\332\336\037\003Key\022/\n\005range\030\003"
+    " \001(\0132 .cockroach.proto.RangeDescriptor\"\227"
+    "\001\n\"ReadWithinUncertaintyIntervalError\0223\n"
+    "\ttimestamp\030\001 \001(\0132\032.cockroach.proto.Times"
+    "tampB\004\310\336\037\000\022<\n\022existing_timestamp\030\002 \001(\0132\032"
+    ".cockroach.proto.TimestampB\004\310\336\037\000\"J\n\027Tran"
+    "sactionAbortedError\022/\n\003txn\030\001 \001(\0132\034.cockr"
+    "oach.proto.TransactionB\004\310\336\037\000\"y\n\024Transact"
+    "ionPushError\022)\n\003txn\030\001 \001(\0132\034.cockroach.pr"
+    "oto.Transaction\0226\n\npushee_txn\030\002 \001(\0132\034.co"
+    "ckroach.proto.TransactionB\004\310\336\037\000\"H\n\025Trans"
+    "actionRetryError\022/\n\003txn\030\001 \001(\0132\034.cockroac"
+    "h.proto.TransactionB\004\310\336\037\000\"\\\n\026Transaction"
+    "StatusError\022/\n\003txn\030\001 \001(\0132\034.cockroach.pro"
+    "to.TransactionB\004\310\336\037\000\022\021\n\003msg\030\002 \001(\tB\004\310\336\037\000\""
+    "u\n\020WriteIntentError\022\030\n\003key\030\001 \001(\014B\013\310\336\037\000\332\336"
+    "\037\003Key\022/\n\003txn\030\002 \001(\0132\034.cockroach.proto.Tra"
+    "nsactionB\004\310\336\037\000\022\026\n\010resolved\030\003 \001(\010B\004\310\336\037\000\"\205"
+    "\001\n\020WriteTooOldError\0223\n\ttimestamp\030\001 \001(\0132\032"
+    ".cockroach.proto.TimestampB\004\310\336\037\000\022<\n\022exis"
+    "ting_timestamp\030\002 \001(\0132\032.cockroach.proto.T"
+    "imestampB\004\310\336\037\000\"\024\n\022OpRequiresTxnError\"D\n\024"
+    "ConditionFailedError\022,\n\014actual_value\030\001 \001"
+    "(\0132\026.cockroach.proto.Value\"\314\006\n\013ErrorDeta"
+    "il\0225\n\nnot_leader\030\001 \001(\0132\037.cockroach.proto"
+    ".NotLeaderErrorH\000\022>\n\017range_not_found\030\002 \001"
+    "(\0132#.cockroach.proto.RangeNotFoundErrorH"
+    "\000\022D\n\022range_key_mismatch\030\003 \001(\0132&.cockroac"
+    "h.proto.RangeKeyMismatchErrorH\000\022_\n read_"
+    "within_uncertainty_interval\030\004 \001(\01323.cock"
+    "roach.proto.ReadWithinUncertaintyInterva"
+    "lErrorH\000\022G\n\023transaction_aborted\030\005 \001(\0132(."
+    "cockroach.proto.TransactionAbortedErrorH"
+    "\000\022A\n\020transaction_push\030\006 \001(\0132%.cockroach."
+    "proto.TransactionPushErrorH\000\022C\n\021transact"
+    "ion_retry\030\007 \001(\0132&.cockroach.proto.Transa"
+    "ctionRetryErrorH\000\022E\n\022transaction_status\030"
+    "\010 \001(\0132\'.cockroach.proto.TransactionStatu"
+    "sErrorH\000\0229\n\014write_intent\030\t \001(\0132!.cockroa"
+    "ch.proto.WriteIntentErrorH\000\022:\n\rwrite_too"
+    "_old\030\n \001(\0132!.cockroach.proto.WriteTooOld"
+    "ErrorH\000\022>\n\017op_requires_txn\030\013 \001(\0132#.cockr"
+    "oach.proto.OpRequiresTxnErrorH\000\022A\n\020condi"
+    "tion_failed\030\014 \001(\0132%.cockroach.proto.Cond"
+    "itionFailedErrorH\000:\004\310\240\037\001B\007\n\005value\"\255\001\n\005Er"
+    "ror\022\025\n\007message\030\001 \001(\tB\004\310\336\037\000\022\027\n\tretryable\030"
+    "\002 \001(\010B\004\310\336\037\000\022F\n\023transaction_restart\030\004 \001(\016"
+    "2#.cockroach.proto.TransactionRestartB\004\310"
+    "\336\037\000\022,\n\006detail\030\003 \001(\0132\034.cockroach.proto.Er"
+    "rorDetail*;\n\022TransactionRestart\022\t\n\005ABORT"
+    "\020\000\022\013\n\007BACKOFF\020\001\022\r\n\tIMMEDIATE\020\002B\023Z\005proto\340"
+    "\342\036\001\310\342\036\001\320\342\036\001", 2411);
   ::google::protobuf::MessageFactory::InternalRegisterGeneratedFile(
     "cockroach/proto/errors.proto", &protobuf_RegisterTypes);
   NotLeaderError::default_instance_ = new NotLeaderError();
@@ -528,6 +530,7 @@ bool TransactionRestart_IsValid(int value) {
 // ===================================================================
 
 #ifndef _MSC_VER
+const int NotLeaderError::kReplicaFieldNumber;
 const int NotLeaderError::kLeaderFieldNumber;
 #endif  // !_MSC_VER
 
@@ -538,6 +541,7 @@ NotLeaderError::NotLeaderError()
 }
 
 void NotLeaderError::InitAsDefaultInstance() {
+  replica_ = const_cast< ::cockroach::proto::Replica*>(&::cockroach::proto::Replica::default_instance());
   leader_ = const_cast< ::cockroach::proto::Replica*>(&::cockroach::proto::Replica::default_instance());
 }
 
@@ -550,6 +554,7 @@ NotLeaderError::NotLeaderError(const NotLeaderError& from)
 
 void NotLeaderError::SharedCtor() {
   _cached_size_ = 0;
+  replica_ = NULL;
   leader_ = NULL;
   ::memset(_has_bits_, 0, sizeof(_has_bits_));
 }
@@ -561,6 +566,7 @@ NotLeaderError::~NotLeaderError() {
 
 void NotLeaderError::SharedDtor() {
   if (this != default_instance_) {
+    delete replica_;
     delete leader_;
   }
 }
@@ -587,8 +593,13 @@ NotLeaderError* NotLeaderError::New() const {
 }
 
 void NotLeaderError::Clear() {
-  if (has_leader()) {
-    if (leader_ != NULL) leader_->::cockroach::proto::Replica::Clear();
+  if (_has_bits_[0 / 32] & 3) {
+    if (has_replica()) {
+      if (replica_ != NULL) replica_->::cockroach::proto::Replica::Clear();
+    }
+    if (has_leader()) {
+      if (leader_ != NULL) leader_->::cockroach::proto::Replica::Clear();
+    }
   }
   ::memset(_has_bits_, 0, sizeof(_has_bits_));
   mutable_unknown_fields()->Clear();
@@ -604,9 +615,22 @@ bool NotLeaderError::MergePartialFromCodedStream(
     tag = p.first;
     if (!p.second) goto handle_unusual;
     switch (::google::protobuf::internal::WireFormatLite::GetTagFieldNumber(tag)) {
-      // optional .cockroach.proto.Replica leader = 1;
+      // optional .cockroach.proto.Replica replica = 1;
       case 1: {
         if (tag == 10) {
+          DO_(::google::protobuf::internal::WireFormatLite::ReadMessageNoVirtual(
+               input, mutable_replica()));
+        } else {
+          goto handle_unusual;
+        }
+        if (input->ExpectTag(18)) goto parse_leader;
+        break;
+      }
+
+      // optional .cockroach.proto.Replica leader = 2;
+      case 2: {
+        if (tag == 18) {
+         parse_leader:
           DO_(::google::protobuf::internal::WireFormatLite::ReadMessageNoVirtual(
                input, mutable_leader()));
         } else {
@@ -641,10 +665,16 @@ failure:
 void NotLeaderError::SerializeWithCachedSizes(
     ::google::protobuf::io::CodedOutputStream* output) const {
   // @@protoc_insertion_point(serialize_start:cockroach.proto.NotLeaderError)
-  // optional .cockroach.proto.Replica leader = 1;
+  // optional .cockroach.proto.Replica replica = 1;
+  if (has_replica()) {
+    ::google::protobuf::internal::WireFormatLite::WriteMessageMaybeToArray(
+      1, this->replica(), output);
+  }
+
+  // optional .cockroach.proto.Replica leader = 2;
   if (has_leader()) {
     ::google::protobuf::internal::WireFormatLite::WriteMessageMaybeToArray(
-      1, this->leader(), output);
+      2, this->leader(), output);
   }
 
   if (!unknown_fields().empty()) {
@@ -657,11 +687,18 @@ void NotLeaderError::SerializeWithCachedSizes(
 ::google::protobuf::uint8* NotLeaderError::SerializeWithCachedSizesToArray(
     ::google::protobuf::uint8* target) const {
   // @@protoc_insertion_point(serialize_to_array_start:cockroach.proto.NotLeaderError)
-  // optional .cockroach.proto.Replica leader = 1;
+  // optional .cockroach.proto.Replica replica = 1;
+  if (has_replica()) {
+    target = ::google::protobuf::internal::WireFormatLite::
+      WriteMessageNoVirtualToArray(
+        1, this->replica(), target);
+  }
+
+  // optional .cockroach.proto.Replica leader = 2;
   if (has_leader()) {
     target = ::google::protobuf::internal::WireFormatLite::
       WriteMessageNoVirtualToArray(
-        1, this->leader(), target);
+        2, this->leader(), target);
   }
 
   if (!unknown_fields().empty()) {
@@ -676,7 +713,14 @@ int NotLeaderError::ByteSize() const {
   int total_size = 0;
 
   if (_has_bits_[0 / 32] & (0xffu << (0 % 32))) {
-    // optional .cockroach.proto.Replica leader = 1;
+    // optional .cockroach.proto.Replica replica = 1;
+    if (has_replica()) {
+      total_size += 1 +
+        ::google::protobuf::internal::WireFormatLite::MessageSizeNoVirtual(
+          this->replica());
+    }
+
+    // optional .cockroach.proto.Replica leader = 2;
     if (has_leader()) {
       total_size += 1 +
         ::google::protobuf::internal::WireFormatLite::MessageSizeNoVirtual(
@@ -710,6 +754,9 @@ void NotLeaderError::MergeFrom(const ::google::protobuf::Message& from) {
 void NotLeaderError::MergeFrom(const NotLeaderError& from) {
   GOOGLE_CHECK_NE(&from, this);
   if (from._has_bits_[0 / 32] & (0xffu << (0 % 32))) {
+    if (from.has_replica()) {
+      mutable_replica()->::cockroach::proto::Replica::MergeFrom(from.replica());
+    }
     if (from.has_leader()) {
       mutable_leader()->::cockroach::proto::Replica::MergeFrom(from.leader());
     }
@@ -736,6 +783,7 @@ bool NotLeaderError::IsInitialized() const {
 
 void NotLeaderError::Swap(NotLeaderError* other) {
   if (other != this) {
+    std::swap(replica_, other->replica_);
     std::swap(leader_, other->leader_);
     std::swap(_has_bits_[0], other->_has_bits_[0]);
     _unknown_fields_.Swap(&other->_unknown_fields_);

--- a/storage/engine/cockroach/proto/errors.pb.h
+++ b/storage/engine/cockroach/proto/errors.pb.h
@@ -128,10 +128,19 @@ class NotLeaderError : public ::google::protobuf::Message {
 
   // accessors -------------------------------------------------------
 
-  // optional .cockroach.proto.Replica leader = 1;
+  // optional .cockroach.proto.Replica replica = 1;
+  inline bool has_replica() const;
+  inline void clear_replica();
+  static const int kReplicaFieldNumber = 1;
+  inline const ::cockroach::proto::Replica& replica() const;
+  inline ::cockroach::proto::Replica* mutable_replica();
+  inline ::cockroach::proto::Replica* release_replica();
+  inline void set_allocated_replica(::cockroach::proto::Replica* replica);
+
+  // optional .cockroach.proto.Replica leader = 2;
   inline bool has_leader() const;
   inline void clear_leader();
-  static const int kLeaderFieldNumber = 1;
+  static const int kLeaderFieldNumber = 2;
   inline const ::cockroach::proto::Replica& leader() const;
   inline ::cockroach::proto::Replica* mutable_leader();
   inline ::cockroach::proto::Replica* release_leader();
@@ -139,6 +148,8 @@ class NotLeaderError : public ::google::protobuf::Message {
 
   // @@protoc_insertion_point(class_scope:cockroach.proto.NotLeaderError)
  private:
+  inline void set_has_replica();
+  inline void clear_has_replica();
   inline void set_has_leader();
   inline void clear_has_leader();
 
@@ -146,6 +157,7 @@ class NotLeaderError : public ::google::protobuf::Message {
 
   ::google::protobuf::uint32 _has_bits_[1];
   mutable int _cached_size_;
+  ::cockroach::proto::Replica* replica_;
   ::cockroach::proto::Replica* leader_;
   friend void  protobuf_AddDesc_cockroach_2fproto_2ferrors_2eproto();
   friend void protobuf_AssignDesc_cockroach_2fproto_2ferrors_2eproto();
@@ -1486,15 +1498,56 @@ class Error : public ::google::protobuf::Message {
 
 // NotLeaderError
 
-// optional .cockroach.proto.Replica leader = 1;
-inline bool NotLeaderError::has_leader() const {
+// optional .cockroach.proto.Replica replica = 1;
+inline bool NotLeaderError::has_replica() const {
   return (_has_bits_[0] & 0x00000001u) != 0;
 }
-inline void NotLeaderError::set_has_leader() {
+inline void NotLeaderError::set_has_replica() {
   _has_bits_[0] |= 0x00000001u;
 }
-inline void NotLeaderError::clear_has_leader() {
+inline void NotLeaderError::clear_has_replica() {
   _has_bits_[0] &= ~0x00000001u;
+}
+inline void NotLeaderError::clear_replica() {
+  if (replica_ != NULL) replica_->::cockroach::proto::Replica::Clear();
+  clear_has_replica();
+}
+inline const ::cockroach::proto::Replica& NotLeaderError::replica() const {
+  // @@protoc_insertion_point(field_get:cockroach.proto.NotLeaderError.replica)
+  return replica_ != NULL ? *replica_ : *default_instance_->replica_;
+}
+inline ::cockroach::proto::Replica* NotLeaderError::mutable_replica() {
+  set_has_replica();
+  if (replica_ == NULL) replica_ = new ::cockroach::proto::Replica;
+  // @@protoc_insertion_point(field_mutable:cockroach.proto.NotLeaderError.replica)
+  return replica_;
+}
+inline ::cockroach::proto::Replica* NotLeaderError::release_replica() {
+  clear_has_replica();
+  ::cockroach::proto::Replica* temp = replica_;
+  replica_ = NULL;
+  return temp;
+}
+inline void NotLeaderError::set_allocated_replica(::cockroach::proto::Replica* replica) {
+  delete replica_;
+  replica_ = replica;
+  if (replica) {
+    set_has_replica();
+  } else {
+    clear_has_replica();
+  }
+  // @@protoc_insertion_point(field_set_allocated:cockroach.proto.NotLeaderError.replica)
+}
+
+// optional .cockroach.proto.Replica leader = 2;
+inline bool NotLeaderError::has_leader() const {
+  return (_has_bits_[0] & 0x00000002u) != 0;
+}
+inline void NotLeaderError::set_has_leader() {
+  _has_bits_[0] |= 0x00000002u;
+}
+inline void NotLeaderError::clear_has_leader() {
+  _has_bits_[0] &= ~0x00000002u;
 }
 inline void NotLeaderError::clear_leader() {
   if (leader_ != NULL) leader_->::cockroach::proto::Replica::Clear();

--- a/storage/engine/cockroach/proto/internal.pb.cc
+++ b/storage/engine/cockroach/proto/internal.pb.cc
@@ -88,6 +88,7 @@ struct ReadWriteCmdResponseOneofInstance {
   const ::cockroach::proto::InternalMergeResponse* internal_merge_;
   const ::cockroach::proto::InternalTruncateLogResponse* internal_truncate_log_;
   const ::cockroach::proto::InternalGCResponse* internal_gc_;
+  const ::cockroach::proto::InternalLeaderLeaseResponse* internal_leader_lease_;
 }* ReadWriteCmdResponse_default_oneof_instance_ = NULL;
 const ::google::protobuf::Descriptor* InternalRaftCommandUnion_descriptor_ = NULL;
 const ::google::protobuf::internal::GeneratedMessageReflection*
@@ -414,7 +415,7 @@ void protobuf_AssignDesc_cockroach_2fproto_2finternal_2eproto() {
       ::google::protobuf::MessageFactory::generated_factory(),
       sizeof(InternalLeaderLeaseResponse));
   ReadWriteCmdResponse_descriptor_ = file->message_type(16);
-  static const int ReadWriteCmdResponse_offsets_[13] = {
+  static const int ReadWriteCmdResponse_offsets_[14] = {
     PROTO2_GENERATED_DEFAULT_ONEOF_FIELD_OFFSET(ReadWriteCmdResponse_default_oneof_instance_, put_),
     PROTO2_GENERATED_DEFAULT_ONEOF_FIELD_OFFSET(ReadWriteCmdResponse_default_oneof_instance_, conditional_put_),
     PROTO2_GENERATED_DEFAULT_ONEOF_FIELD_OFFSET(ReadWriteCmdResponse_default_oneof_instance_, increment_),
@@ -427,6 +428,7 @@ void protobuf_AssignDesc_cockroach_2fproto_2finternal_2eproto() {
     PROTO2_GENERATED_DEFAULT_ONEOF_FIELD_OFFSET(ReadWriteCmdResponse_default_oneof_instance_, internal_merge_),
     PROTO2_GENERATED_DEFAULT_ONEOF_FIELD_OFFSET(ReadWriteCmdResponse_default_oneof_instance_, internal_truncate_log_),
     PROTO2_GENERATED_DEFAULT_ONEOF_FIELD_OFFSET(ReadWriteCmdResponse_default_oneof_instance_, internal_gc_),
+    PROTO2_GENERATED_DEFAULT_ONEOF_FIELD_OFFSET(ReadWriteCmdResponse_default_oneof_instance_, internal_leader_lease_),
     GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(ReadWriteCmdResponse, value_),
   };
   ReadWriteCmdResponse_reflection_ =
@@ -478,8 +480,9 @@ void protobuf_AssignDesc_cockroach_2fproto_2finternal_2eproto() {
       ::google::protobuf::MessageFactory::generated_factory(),
       sizeof(InternalRaftCommandUnion));
   InternalRaftCommand_descriptor_ = file->message_type(18);
-  static const int InternalRaftCommand_offsets_[2] = {
+  static const int InternalRaftCommand_offsets_[3] = {
     GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(InternalRaftCommand, raft_id_),
+    GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(InternalRaftCommand, origin_node_id_),
     GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(InternalRaftCommand, cmd_),
   };
   InternalRaftCommand_reflection_ =
@@ -803,7 +806,7 @@ void protobuf_AddDesc_cockroach_2fproto_2finternal_2eproto() {
     "\002 \001(\0132\026.cockroach.proto.LeaseB\004\310\336\037\000\"X\n\033I"
     "nternalLeaderLeaseResponse\0229\n\006header\030\001 \001"
     "(\0132\037.cockroach.proto.ResponseHeaderB\010\310\336\037"
-    "\000\320\336\037\001\"\274\006\n\024ReadWriteCmdResponse\022+\n\003put\030\001 "
+    "\000\320\336\037\001\"\213\007\n\024ReadWriteCmdResponse\022+\n\003put\030\001 "
     "\001(\0132\034.cockroach.proto.PutResponseH\000\022B\n\017c"
     "onditional_put\030\002 \001(\0132\'.cockroach.proto.C"
     "onditionalPutResponseH\000\0227\n\tincrement\030\003 \001"
@@ -823,58 +826,61 @@ void protobuf_AddDesc_cockroach_2fproto_2finternal_2eproto() {
     "H\000\022M\n\025internal_truncate_log\030\016 \001(\0132,.cock"
     "roach.proto.InternalTruncateLogResponseH"
     "\000\022:\n\013internal_gc\030\017 \001(\0132#.cockroach.proto"
-    ".InternalGCResponseH\000:\004\310\240\037\001B\007\n\005value\"\242\t\n"
-    "\030InternalRaftCommandUnion\0224\n\010contains\030\001 "
-    "\001(\0132 .cockroach.proto.ContainsRequestH\000\022"
-    "*\n\003get\030\002 \001(\0132\033.cockroach.proto.GetReques"
-    "tH\000\022*\n\003put\030\003 \001(\0132\033.cockroach.proto.PutRe"
-    "questH\000\022A\n\017conditional_put\030\004 \001(\0132&.cockr"
-    "oach.proto.ConditionalPutRequestH\000\0226\n\tin"
-    "crement\030\005 \001(\0132!.cockroach.proto.Incremen"
-    "tRequestH\000\0220\n\006delete\030\006 \001(\0132\036.cockroach.p"
-    "roto.DeleteRequestH\000\022;\n\014delete_range\030\007 \001"
-    "(\0132#.cockroach.proto.DeleteRangeRequestH"
-    "\000\022,\n\004scan\030\010 \001(\0132\034.cockroach.proto.ScanRe"
-    "questH\000\022A\n\017end_transaction\030\t \001(\0132&.cockr"
-    "oach.proto.EndTransactionRequestH\000\022.\n\005ba"
-    "tch\030\036 \001(\0132\035.cockroach.proto.BatchRequest"
-    "H\000\022L\n\025internal_range_lookup\030\037 \001(\0132+.cock"
-    "roach.proto.InternalRangeLookupRequestH\000"
-    "\022N\n\026internal_heartbeat_txn\030  \001(\0132,.cockr"
-    "oach.proto.InternalHeartbeatTxnRequestH\000"
-    "\022D\n\021internal_push_txn\030! \001(\0132\'.cockroach."
-    "proto.InternalPushTxnRequestH\000\022P\n\027intern"
-    "al_resolve_intent\030\" \001(\0132-.cockroach.prot"
-    "o.InternalResolveIntentRequestH\000\022H\n\027inte"
-    "rnal_merge_response\030# \001(\0132%.cockroach.pr"
-    "oto.InternalMergeRequestH\000\022L\n\025internal_t"
-    "runcate_log\030$ \001(\0132+.cockroach.proto.Inte"
-    "rnalTruncateLogRequestH\000\022I\n\013internal_gc\030"
-    "% \001(\0132\".cockroach.proto.InternalGCReques"
-    "tB\016\342\336\037\nInternalGCH\000\022E\n\016internal_lease\030& "
-    "\001(\0132+.cockroach.proto.InternalLeaderLeas"
-    "eRequestH\000:\004\310\240\037\001B\007\n\005value\"t\n\023InternalRaf"
-    "tCommand\022\037\n\007raft_id\030\002 \001(\003B\016\310\336\037\000\342\336\037\006RaftI"
-    "D\022<\n\003cmd\030\003 \001(\0132).cockroach.proto.Interna"
-    "lRaftCommandUnionB\004\310\336\037\000\"D\n\022RaftMessageRe"
-    "quest\022!\n\010group_id\030\001 \001(\004B\017\310\336\037\000\342\336\037\007GroupID"
-    "\022\013\n\003msg\030\002 \001(\014\"\025\n\023RaftMessageResponse\"\236\001\n"
-    "\026InternalTimeSeriesData\022#\n\025start_timesta"
-    "mp_nanos\030\001 \001(\003B\004\310\336\037\000\022#\n\025sample_duration_"
-    "nanos\030\002 \001(\003B\004\310\336\037\000\022:\n\007samples\030\003 \003(\0132).coc"
-    "kroach.proto.InternalTimeSeriesSample\"\320\001"
-    "\n\030InternalTimeSeriesSample\022\024\n\006offset\030\001 \001"
-    "(\005B\004\310\336\037\000\022\027\n\tint_count\030\002 \001(\rB\004\310\336\037\000\022\017\n\007int"
-    "_sum\030\003 \001(\003\022\017\n\007int_max\030\004 \001(\003\022\017\n\007int_min\030\005"
-    " \001(\003\022\031\n\013float_count\030\006 \001(\rB\004\310\336\037\000\022\021\n\tfloat"
-    "_sum\030\007 \001(\002\022\021\n\tfloat_max\030\010 \001(\002\022\021\n\tfloat_m"
-    "in\030\t \001(\002\"=\n\022RaftTruncatedState\022\023\n\005index\030"
-    "\001 \001(\004B\004\310\336\037\000\022\022\n\004term\030\002 \001(\004B\004\310\336\037\000\"z\n\020RaftS"
-    "napshotData\022>\n\002KV\030\001 \003(\0132*.cockroach.prot"
-    "o.RaftSnapshotData.KeyValueB\006\342\336\037\002KV\032&\n\010K"
-    "eyValue\022\013\n\003key\030\001 \001(\014\022\r\n\005value\030\002 \001(\014*%\n\021I"
-    "nternalValueType\022\n\n\006_CR_TS\020\001\032\004\210\243\036\000B\023Z\005pr"
-    "oto\340\342\036\001\310\342\036\001\320\342\036\001", 4935);
+    ".InternalGCResponseH\000\022M\n\025internal_leader"
+    "_lease\030\020 \001(\0132,.cockroach.proto.InternalL"
+    "eaderLeaseResponseH\000:\004\310\240\037\001B\007\n\005value\"\242\t\n\030"
+    "InternalRaftCommandUnion\0224\n\010contains\030\001 \001"
+    "(\0132 .cockroach.proto.ContainsRequestH\000\022*"
+    "\n\003get\030\002 \001(\0132\033.cockroach.proto.GetRequest"
+    "H\000\022*\n\003put\030\003 \001(\0132\033.cockroach.proto.PutReq"
+    "uestH\000\022A\n\017conditional_put\030\004 \001(\0132&.cockro"
+    "ach.proto.ConditionalPutRequestH\000\0226\n\tinc"
+    "rement\030\005 \001(\0132!.cockroach.proto.Increment"
+    "RequestH\000\0220\n\006delete\030\006 \001(\0132\036.cockroach.pr"
+    "oto.DeleteRequestH\000\022;\n\014delete_range\030\007 \001("
+    "\0132#.cockroach.proto.DeleteRangeRequestH\000"
+    "\022,\n\004scan\030\010 \001(\0132\034.cockroach.proto.ScanReq"
+    "uestH\000\022A\n\017end_transaction\030\t \001(\0132&.cockro"
+    "ach.proto.EndTransactionRequestH\000\022.\n\005bat"
+    "ch\030\036 \001(\0132\035.cockroach.proto.BatchRequestH"
+    "\000\022L\n\025internal_range_lookup\030\037 \001(\0132+.cockr"
+    "oach.proto.InternalRangeLookupRequestH\000\022"
+    "N\n\026internal_heartbeat_txn\030  \001(\0132,.cockro"
+    "ach.proto.InternalHeartbeatTxnRequestH\000\022"
+    "D\n\021internal_push_txn\030! \001(\0132\'.cockroach.p"
+    "roto.InternalPushTxnRequestH\000\022P\n\027interna"
+    "l_resolve_intent\030\" \001(\0132-.cockroach.proto"
+    ".InternalResolveIntentRequestH\000\022H\n\027inter"
+    "nal_merge_response\030# \001(\0132%.cockroach.pro"
+    "to.InternalMergeRequestH\000\022L\n\025internal_tr"
+    "uncate_log\030$ \001(\0132+.cockroach.proto.Inter"
+    "nalTruncateLogRequestH\000\022I\n\013internal_gc\030%"
+    " \001(\0132\".cockroach.proto.InternalGCRequest"
+    "B\016\342\336\037\nInternalGCH\000\022E\n\016internal_lease\030& \001"
+    "(\0132+.cockroach.proto.InternalLeaderLease"
+    "RequestH\000:\004\310\240\037\001B\007\n\005value\"\242\001\n\023InternalRaf"
+    "tCommand\022\037\n\007raft_id\030\001 \001(\003B\016\310\336\037\000\342\336\037\006RaftI"
+    "D\022,\n\016origin_node_id\030\002 \001(\004B\024\310\336\037\000\342\336\037\014Origi"
+    "nNodeID\022<\n\003cmd\030\003 \001(\0132).cockroach.proto.I"
+    "nternalRaftCommandUnionB\004\310\336\037\000\"D\n\022RaftMes"
+    "sageRequest\022!\n\010group_id\030\001 \001(\004B\017\310\336\037\000\342\336\037\007G"
+    "roupID\022\013\n\003msg\030\002 \001(\014\"\025\n\023RaftMessageRespon"
+    "se\"\236\001\n\026InternalTimeSeriesData\022#\n\025start_t"
+    "imestamp_nanos\030\001 \001(\003B\004\310\336\037\000\022#\n\025sample_dur"
+    "ation_nanos\030\002 \001(\003B\004\310\336\037\000\022:\n\007samples\030\003 \003(\013"
+    "2).cockroach.proto.InternalTimeSeriesSam"
+    "ple\"\320\001\n\030InternalTimeSeriesSample\022\024\n\006offs"
+    "et\030\001 \001(\005B\004\310\336\037\000\022\027\n\tint_count\030\002 \001(\rB\004\310\336\037\000\022"
+    "\017\n\007int_sum\030\003 \001(\003\022\017\n\007int_max\030\004 \001(\003\022\017\n\007int"
+    "_min\030\005 \001(\003\022\031\n\013float_count\030\006 \001(\rB\004\310\336\037\000\022\021\n"
+    "\tfloat_sum\030\007 \001(\002\022\021\n\tfloat_max\030\010 \001(\002\022\021\n\tf"
+    "loat_min\030\t \001(\002\"=\n\022RaftTruncatedState\022\023\n\005"
+    "index\030\001 \001(\004B\004\310\336\037\000\022\022\n\004term\030\002 \001(\004B\004\310\336\037\000\"z\n"
+    "\020RaftSnapshotData\022>\n\002KV\030\001 \003(\0132*.cockroac"
+    "h.proto.RaftSnapshotData.KeyValueB\006\342\336\037\002K"
+    "V\032&\n\010KeyValue\022\013\n\003key\030\001 \001(\014\022\r\n\005value\030\002 \001("
+    "\014*%\n\021InternalValueType\022\n\n\006_CR_TS\020\001\032\004\210\243\036\000"
+    "B\023Z\005proto\340\342\036\001\310\342\036\001\320\342\036\001", 5061);
   ::google::protobuf::MessageFactory::InternalRegisterGeneratedFile(
     "cockroach/proto/internal.proto", &protobuf_RegisterTypes);
   InternalRangeLookupRequest::default_instance_ = new InternalRangeLookupRequest();
@@ -5307,6 +5313,7 @@ const int ReadWriteCmdResponse::kInternalResolveIntentFieldNumber;
 const int ReadWriteCmdResponse::kInternalMergeFieldNumber;
 const int ReadWriteCmdResponse::kInternalTruncateLogFieldNumber;
 const int ReadWriteCmdResponse::kInternalGcFieldNumber;
+const int ReadWriteCmdResponse::kInternalLeaderLeaseFieldNumber;
 #endif  // !_MSC_VER
 
 ReadWriteCmdResponse::ReadWriteCmdResponse()
@@ -5328,6 +5335,7 @@ void ReadWriteCmdResponse::InitAsDefaultInstance() {
   ReadWriteCmdResponse_default_oneof_instance_->internal_merge_ = const_cast< ::cockroach::proto::InternalMergeResponse*>(&::cockroach::proto::InternalMergeResponse::default_instance());
   ReadWriteCmdResponse_default_oneof_instance_->internal_truncate_log_ = const_cast< ::cockroach::proto::InternalTruncateLogResponse*>(&::cockroach::proto::InternalTruncateLogResponse::default_instance());
   ReadWriteCmdResponse_default_oneof_instance_->internal_gc_ = const_cast< ::cockroach::proto::InternalGCResponse*>(&::cockroach::proto::InternalGCResponse::default_instance());
+  ReadWriteCmdResponse_default_oneof_instance_->internal_leader_lease_ = const_cast< ::cockroach::proto::InternalLeaderLeaseResponse*>(&::cockroach::proto::InternalLeaderLeaseResponse::default_instance());
 }
 
 ReadWriteCmdResponse::ReadWriteCmdResponse(const ReadWriteCmdResponse& from)
@@ -5427,6 +5435,10 @@ void ReadWriteCmdResponse::clear_value() {
       delete value_.internal_gc_;
       break;
     }
+    case kInternalLeaderLease: {
+      delete value_.internal_leader_lease_;
+      break;
+    }
     case VALUE_NOT_SET: {
       break;
     }
@@ -5447,7 +5459,7 @@ bool ReadWriteCmdResponse::MergePartialFromCodedStream(
   ::google::protobuf::uint32 tag;
   // @@protoc_insertion_point(parse_start:cockroach.proto.ReadWriteCmdResponse)
   for (;;) {
-    ::std::pair< ::google::protobuf::uint32, bool> p = input->ReadTagWithCutoff(127);
+    ::std::pair< ::google::protobuf::uint32, bool> p = input->ReadTagWithCutoff(16383);
     tag = p.first;
     if (!p.second) goto handle_unusual;
     switch (::google::protobuf::internal::WireFormatLite::GetTagFieldNumber(tag)) {
@@ -5602,6 +5614,19 @@ bool ReadWriteCmdResponse::MergePartialFromCodedStream(
         } else {
           goto handle_unusual;
         }
+        if (input->ExpectTag(130)) goto parse_internal_leader_lease;
+        break;
+      }
+
+      // optional .cockroach.proto.InternalLeaderLeaseResponse internal_leader_lease = 16;
+      case 16: {
+        if (tag == 130) {
+         parse_internal_leader_lease:
+          DO_(::google::protobuf::internal::WireFormatLite::ReadMessageNoVirtual(
+               input, mutable_internal_leader_lease()));
+        } else {
+          goto handle_unusual;
+        }
         if (input->ExpectAtEnd()) goto success;
         break;
       }
@@ -5703,6 +5728,12 @@ void ReadWriteCmdResponse::SerializeWithCachedSizes(
       15, this->internal_gc(), output);
   }
 
+  // optional .cockroach.proto.InternalLeaderLeaseResponse internal_leader_lease = 16;
+  if (has_internal_leader_lease()) {
+    ::google::protobuf::internal::WireFormatLite::WriteMessageMaybeToArray(
+      16, this->internal_leader_lease(), output);
+  }
+
   if (!unknown_fields().empty()) {
     ::google::protobuf::internal::WireFormat::SerializeUnknownFields(
         unknown_fields(), output);
@@ -5795,6 +5826,13 @@ void ReadWriteCmdResponse::SerializeWithCachedSizes(
     target = ::google::protobuf::internal::WireFormatLite::
       WriteMessageNoVirtualToArray(
         15, this->internal_gc(), target);
+  }
+
+  // optional .cockroach.proto.InternalLeaderLeaseResponse internal_leader_lease = 16;
+  if (has_internal_leader_lease()) {
+    target = ::google::protobuf::internal::WireFormatLite::
+      WriteMessageNoVirtualToArray(
+        16, this->internal_leader_lease(), target);
   }
 
   if (!unknown_fields().empty()) {
@@ -5893,6 +5931,13 @@ int ReadWriteCmdResponse::ByteSize() const {
           this->internal_gc());
       break;
     }
+    // optional .cockroach.proto.InternalLeaderLeaseResponse internal_leader_lease = 16;
+    case kInternalLeaderLease: {
+      total_size += 2 +
+        ::google::protobuf::internal::WireFormatLite::MessageSizeNoVirtual(
+          this->internal_leader_lease());
+      break;
+    }
     case VALUE_NOT_SET: {
       break;
     }
@@ -5969,6 +6014,10 @@ void ReadWriteCmdResponse::MergeFrom(const ReadWriteCmdResponse& from) {
     }
     case kInternalGc: {
       mutable_internal_gc()->::cockroach::proto::InternalGCResponse::MergeFrom(from.internal_gc());
+      break;
+    }
+    case kInternalLeaderLease: {
+      mutable_internal_leader_lease()->::cockroach::proto::InternalLeaderLeaseResponse::MergeFrom(from.internal_leader_lease());
       break;
     }
     case VALUE_NOT_SET: {
@@ -6998,6 +7047,7 @@ void InternalRaftCommandUnion::Swap(InternalRaftCommandUnion* other) {
 
 #ifndef _MSC_VER
 const int InternalRaftCommand::kRaftIdFieldNumber;
+const int InternalRaftCommand::kOriginNodeIdFieldNumber;
 const int InternalRaftCommand::kCmdFieldNumber;
 #endif  // !_MSC_VER
 
@@ -7021,6 +7071,7 @@ InternalRaftCommand::InternalRaftCommand(const InternalRaftCommand& from)
 void InternalRaftCommand::SharedCtor() {
   _cached_size_ = 0;
   raft_id_ = GOOGLE_LONGLONG(0);
+  origin_node_id_ = GOOGLE_ULONGLONG(0);
   cmd_ = NULL;
   ::memset(_has_bits_, 0, sizeof(_has_bits_));
 }
@@ -7058,12 +7109,26 @@ InternalRaftCommand* InternalRaftCommand::New() const {
 }
 
 void InternalRaftCommand::Clear() {
-  if (_has_bits_[0 / 32] & 3) {
-    raft_id_ = GOOGLE_LONGLONG(0);
+#define OFFSET_OF_FIELD_(f) (reinterpret_cast<char*>(      \
+  &reinterpret_cast<InternalRaftCommand*>(16)->f) - \
+   reinterpret_cast<char*>(16))
+
+#define ZR_(first, last) do {                              \
+    size_t f = OFFSET_OF_FIELD_(first);                    \
+    size_t n = OFFSET_OF_FIELD_(last) - f + sizeof(last);  \
+    ::memset(&first, 0, n);                                \
+  } while (0)
+
+  if (_has_bits_[0 / 32] & 7) {
+    ZR_(raft_id_, origin_node_id_);
     if (has_cmd()) {
       if (cmd_ != NULL) cmd_->::cockroach::proto::InternalRaftCommandUnion::Clear();
     }
   }
+
+#undef OFFSET_OF_FIELD_
+#undef ZR_
+
   ::memset(_has_bits_, 0, sizeof(_has_bits_));
   mutable_unknown_fields()->Clear();
 }
@@ -7078,13 +7143,28 @@ bool InternalRaftCommand::MergePartialFromCodedStream(
     tag = p.first;
     if (!p.second) goto handle_unusual;
     switch (::google::protobuf::internal::WireFormatLite::GetTagFieldNumber(tag)) {
-      // optional int64 raft_id = 2;
-      case 2: {
-        if (tag == 16) {
+      // optional int64 raft_id = 1;
+      case 1: {
+        if (tag == 8) {
           DO_((::google::protobuf::internal::WireFormatLite::ReadPrimitive<
                    ::google::protobuf::int64, ::google::protobuf::internal::WireFormatLite::TYPE_INT64>(
                  input, &raft_id_)));
           set_has_raft_id();
+        } else {
+          goto handle_unusual;
+        }
+        if (input->ExpectTag(16)) goto parse_origin_node_id;
+        break;
+      }
+
+      // optional uint64 origin_node_id = 2;
+      case 2: {
+        if (tag == 16) {
+         parse_origin_node_id:
+          DO_((::google::protobuf::internal::WireFormatLite::ReadPrimitive<
+                   ::google::protobuf::uint64, ::google::protobuf::internal::WireFormatLite::TYPE_UINT64>(
+                 input, &origin_node_id_)));
+          set_has_origin_node_id();
         } else {
           goto handle_unusual;
         }
@@ -7130,9 +7210,14 @@ failure:
 void InternalRaftCommand::SerializeWithCachedSizes(
     ::google::protobuf::io::CodedOutputStream* output) const {
   // @@protoc_insertion_point(serialize_start:cockroach.proto.InternalRaftCommand)
-  // optional int64 raft_id = 2;
+  // optional int64 raft_id = 1;
   if (has_raft_id()) {
-    ::google::protobuf::internal::WireFormatLite::WriteInt64(2, this->raft_id(), output);
+    ::google::protobuf::internal::WireFormatLite::WriteInt64(1, this->raft_id(), output);
+  }
+
+  // optional uint64 origin_node_id = 2;
+  if (has_origin_node_id()) {
+    ::google::protobuf::internal::WireFormatLite::WriteUInt64(2, this->origin_node_id(), output);
   }
 
   // optional .cockroach.proto.InternalRaftCommandUnion cmd = 3;
@@ -7151,9 +7236,14 @@ void InternalRaftCommand::SerializeWithCachedSizes(
 ::google::protobuf::uint8* InternalRaftCommand::SerializeWithCachedSizesToArray(
     ::google::protobuf::uint8* target) const {
   // @@protoc_insertion_point(serialize_to_array_start:cockroach.proto.InternalRaftCommand)
-  // optional int64 raft_id = 2;
+  // optional int64 raft_id = 1;
   if (has_raft_id()) {
-    target = ::google::protobuf::internal::WireFormatLite::WriteInt64ToArray(2, this->raft_id(), target);
+    target = ::google::protobuf::internal::WireFormatLite::WriteInt64ToArray(1, this->raft_id(), target);
+  }
+
+  // optional uint64 origin_node_id = 2;
+  if (has_origin_node_id()) {
+    target = ::google::protobuf::internal::WireFormatLite::WriteUInt64ToArray(2, this->origin_node_id(), target);
   }
 
   // optional .cockroach.proto.InternalRaftCommandUnion cmd = 3;
@@ -7175,11 +7265,18 @@ int InternalRaftCommand::ByteSize() const {
   int total_size = 0;
 
   if (_has_bits_[0 / 32] & (0xffu << (0 % 32))) {
-    // optional int64 raft_id = 2;
+    // optional int64 raft_id = 1;
     if (has_raft_id()) {
       total_size += 1 +
         ::google::protobuf::internal::WireFormatLite::Int64Size(
           this->raft_id());
+    }
+
+    // optional uint64 origin_node_id = 2;
+    if (has_origin_node_id()) {
+      total_size += 1 +
+        ::google::protobuf::internal::WireFormatLite::UInt64Size(
+          this->origin_node_id());
     }
 
     // optional .cockroach.proto.InternalRaftCommandUnion cmd = 3;
@@ -7219,6 +7316,9 @@ void InternalRaftCommand::MergeFrom(const InternalRaftCommand& from) {
     if (from.has_raft_id()) {
       set_raft_id(from.raft_id());
     }
+    if (from.has_origin_node_id()) {
+      set_origin_node_id(from.origin_node_id());
+    }
     if (from.has_cmd()) {
       mutable_cmd()->::cockroach::proto::InternalRaftCommandUnion::MergeFrom(from.cmd());
     }
@@ -7246,6 +7346,7 @@ bool InternalRaftCommand::IsInitialized() const {
 void InternalRaftCommand::Swap(InternalRaftCommand* other) {
   if (other != this) {
     std::swap(raft_id_, other->raft_id_);
+    std::swap(origin_node_id_, other->origin_node_id_);
     std::swap(cmd_, other->cmd_);
     std::swap(_has_bits_[0], other->_has_bits_[0]);
     _unknown_fields_.Swap(&other->_unknown_fields_);

--- a/storage/engine/cockroach/proto/internal.pb.h
+++ b/storage/engine/cockroach/proto/internal.pb.h
@@ -1633,6 +1633,7 @@ class ReadWriteCmdResponse : public ::google::protobuf::Message {
     kInternalMerge = 13,
     kInternalTruncateLog = 14,
     kInternalGc = 15,
+    kInternalLeaderLease = 16,
     VALUE_NOT_SET = 0,
   };
 
@@ -1774,6 +1775,15 @@ class ReadWriteCmdResponse : public ::google::protobuf::Message {
   inline ::cockroach::proto::InternalGCResponse* release_internal_gc();
   inline void set_allocated_internal_gc(::cockroach::proto::InternalGCResponse* internal_gc);
 
+  // optional .cockroach.proto.InternalLeaderLeaseResponse internal_leader_lease = 16;
+  inline bool has_internal_leader_lease() const;
+  inline void clear_internal_leader_lease();
+  static const int kInternalLeaderLeaseFieldNumber = 16;
+  inline const ::cockroach::proto::InternalLeaderLeaseResponse& internal_leader_lease() const;
+  inline ::cockroach::proto::InternalLeaderLeaseResponse* mutable_internal_leader_lease();
+  inline ::cockroach::proto::InternalLeaderLeaseResponse* release_internal_leader_lease();
+  inline void set_allocated_internal_leader_lease(::cockroach::proto::InternalLeaderLeaseResponse* internal_leader_lease);
+
   inline ValueCase value_case() const;
   // @@protoc_insertion_point(class_scope:cockroach.proto.ReadWriteCmdResponse)
  private:
@@ -1789,6 +1799,7 @@ class ReadWriteCmdResponse : public ::google::protobuf::Message {
   inline void set_has_internal_merge();
   inline void set_has_internal_truncate_log();
   inline void set_has_internal_gc();
+  inline void set_has_internal_leader_lease();
 
   inline bool has_value();
   void clear_value();
@@ -1811,6 +1822,7 @@ class ReadWriteCmdResponse : public ::google::protobuf::Message {
     ::cockroach::proto::InternalMergeResponse* internal_merge_;
     ::cockroach::proto::InternalTruncateLogResponse* internal_truncate_log_;
     ::cockroach::proto::InternalGCResponse* internal_gc_;
+    ::cockroach::proto::InternalLeaderLeaseResponse* internal_leader_lease_;
   } value_;
   ::google::protobuf::uint32 _oneof_case_[1];
 
@@ -2174,12 +2186,19 @@ class InternalRaftCommand : public ::google::protobuf::Message {
 
   // accessors -------------------------------------------------------
 
-  // optional int64 raft_id = 2;
+  // optional int64 raft_id = 1;
   inline bool has_raft_id() const;
   inline void clear_raft_id();
-  static const int kRaftIdFieldNumber = 2;
+  static const int kRaftIdFieldNumber = 1;
   inline ::google::protobuf::int64 raft_id() const;
   inline void set_raft_id(::google::protobuf::int64 value);
+
+  // optional uint64 origin_node_id = 2;
+  inline bool has_origin_node_id() const;
+  inline void clear_origin_node_id();
+  static const int kOriginNodeIdFieldNumber = 2;
+  inline ::google::protobuf::uint64 origin_node_id() const;
+  inline void set_origin_node_id(::google::protobuf::uint64 value);
 
   // optional .cockroach.proto.InternalRaftCommandUnion cmd = 3;
   inline bool has_cmd() const;
@@ -2194,6 +2213,8 @@ class InternalRaftCommand : public ::google::protobuf::Message {
  private:
   inline void set_has_raft_id();
   inline void clear_has_raft_id();
+  inline void set_has_origin_node_id();
+  inline void clear_has_origin_node_id();
   inline void set_has_cmd();
   inline void clear_has_cmd();
 
@@ -2202,6 +2223,7 @@ class InternalRaftCommand : public ::google::protobuf::Message {
   ::google::protobuf::uint32 _has_bits_[1];
   mutable int _cached_size_;
   ::google::protobuf::int64 raft_id_;
+  ::google::protobuf::uint64 origin_node_id_;
   ::cockroach::proto::InternalRaftCommandUnion* cmd_;
   friend void  protobuf_AddDesc_cockroach_2fproto_2finternal_2eproto();
   friend void protobuf_AssignDesc_cockroach_2fproto_2finternal_2eproto();
@@ -4607,6 +4629,49 @@ inline void ReadWriteCmdResponse::set_allocated_internal_gc(::cockroach::proto::
   }
 }
 
+// optional .cockroach.proto.InternalLeaderLeaseResponse internal_leader_lease = 16;
+inline bool ReadWriteCmdResponse::has_internal_leader_lease() const {
+  return value_case() == kInternalLeaderLease;
+}
+inline void ReadWriteCmdResponse::set_has_internal_leader_lease() {
+  _oneof_case_[0] = kInternalLeaderLease;
+}
+inline void ReadWriteCmdResponse::clear_internal_leader_lease() {
+  if (has_internal_leader_lease()) {
+    delete value_.internal_leader_lease_;
+    clear_has_value();
+  }
+}
+inline const ::cockroach::proto::InternalLeaderLeaseResponse& ReadWriteCmdResponse::internal_leader_lease() const {
+  return has_internal_leader_lease() ? *value_.internal_leader_lease_
+                      : ::cockroach::proto::InternalLeaderLeaseResponse::default_instance();
+}
+inline ::cockroach::proto::InternalLeaderLeaseResponse* ReadWriteCmdResponse::mutable_internal_leader_lease() {
+  if (!has_internal_leader_lease()) {
+    clear_value();
+    set_has_internal_leader_lease();
+    value_.internal_leader_lease_ = new ::cockroach::proto::InternalLeaderLeaseResponse;
+  }
+  return value_.internal_leader_lease_;
+}
+inline ::cockroach::proto::InternalLeaderLeaseResponse* ReadWriteCmdResponse::release_internal_leader_lease() {
+  if (has_internal_leader_lease()) {
+    clear_has_value();
+    ::cockroach::proto::InternalLeaderLeaseResponse* temp = value_.internal_leader_lease_;
+    value_.internal_leader_lease_ = NULL;
+    return temp;
+  } else {
+    return NULL;
+  }
+}
+inline void ReadWriteCmdResponse::set_allocated_internal_leader_lease(::cockroach::proto::InternalLeaderLeaseResponse* internal_leader_lease) {
+  clear_value();
+  if (internal_leader_lease) {
+    set_has_internal_leader_lease();
+    value_.internal_leader_lease_ = internal_leader_lease;
+  }
+}
+
 inline bool ReadWriteCmdResponse::has_value() {
   return value_case() != VALUE_NOT_SET;
 }
@@ -5407,7 +5472,7 @@ inline InternalRaftCommandUnion::ValueCase InternalRaftCommandUnion::value_case(
 
 // InternalRaftCommand
 
-// optional int64 raft_id = 2;
+// optional int64 raft_id = 1;
 inline bool InternalRaftCommand::has_raft_id() const {
   return (_has_bits_[0] & 0x00000001u) != 0;
 }
@@ -5431,15 +5496,39 @@ inline void InternalRaftCommand::set_raft_id(::google::protobuf::int64 value) {
   // @@protoc_insertion_point(field_set:cockroach.proto.InternalRaftCommand.raft_id)
 }
 
-// optional .cockroach.proto.InternalRaftCommandUnion cmd = 3;
-inline bool InternalRaftCommand::has_cmd() const {
+// optional uint64 origin_node_id = 2;
+inline bool InternalRaftCommand::has_origin_node_id() const {
   return (_has_bits_[0] & 0x00000002u) != 0;
 }
-inline void InternalRaftCommand::set_has_cmd() {
+inline void InternalRaftCommand::set_has_origin_node_id() {
   _has_bits_[0] |= 0x00000002u;
 }
-inline void InternalRaftCommand::clear_has_cmd() {
+inline void InternalRaftCommand::clear_has_origin_node_id() {
   _has_bits_[0] &= ~0x00000002u;
+}
+inline void InternalRaftCommand::clear_origin_node_id() {
+  origin_node_id_ = GOOGLE_ULONGLONG(0);
+  clear_has_origin_node_id();
+}
+inline ::google::protobuf::uint64 InternalRaftCommand::origin_node_id() const {
+  // @@protoc_insertion_point(field_get:cockroach.proto.InternalRaftCommand.origin_node_id)
+  return origin_node_id_;
+}
+inline void InternalRaftCommand::set_origin_node_id(::google::protobuf::uint64 value) {
+  set_has_origin_node_id();
+  origin_node_id_ = value;
+  // @@protoc_insertion_point(field_set:cockroach.proto.InternalRaftCommand.origin_node_id)
+}
+
+// optional .cockroach.proto.InternalRaftCommandUnion cmd = 3;
+inline bool InternalRaftCommand::has_cmd() const {
+  return (_has_bits_[0] & 0x00000004u) != 0;
+}
+inline void InternalRaftCommand::set_has_cmd() {
+  _has_bits_[0] |= 0x00000004u;
+}
+inline void InternalRaftCommand::clear_has_cmd() {
+  _has_bits_[0] &= ~0x00000004u;
 }
 inline void InternalRaftCommand::clear_cmd() {
   if (cmd_ != NULL) cmd_->::cockroach::proto::InternalRaftCommandUnion::Clear();

--- a/storage/engine/keys.go
+++ b/storage/engine/keys.go
@@ -108,6 +108,11 @@ func RaftAppliedIndexKey(raftID int64) proto.Key {
 	return MakeRangeIDKey(raftID, KeyLocalRaftAppliedIndexSuffix, proto.Key{})
 }
 
+// RaftLeaderLeaseKey returns a system-local key for a raft leader lease.
+func RaftLeaderLeaseKey(raftID int64) proto.Key {
+	return MakeRangeIDKey(raftID, KeyLocalRaftLeaderLeaseSuffix, proto.Key{})
+}
+
 // RangeStatKey returns the key for accessing the named stat
 // for the specified Raft ID.
 func RangeStatKey(raftID int64, stat proto.Key) proto.Key {
@@ -369,14 +374,21 @@ var (
 	// NOTE: KeyLocalRangeIDPrefix must be kept in sync with the value
 	// in storage/engine/db.cc.
 	KeyLocalRangeIDPrefix = MakeKey(KeyLocalPrefix, proto.Key("i"))
-	// KeyLocalRaftLogSuffix is the suffix for the raft log.
-	KeyLocalRaftLogSuffix = proto.Key("rftl")
+	// KeyLocalResponseCacheSuffix is the suffix for keys storing
+	// command responses used to guarantee idempotency (see ResponseCache).
+	// NOTE: if this value changes, it must be updated in C++
+	// (storage/engine/db.cc).
+	KeyLocalResponseCacheSuffix = proto.Key("res-")
+	// KeyLocalRaftLeaderLeaseSuffix is the suffix for the raft leader lease.
+	KeyLocalRaftLeaderLeaseSuffix = proto.Key("rfll")
 	// KeyLocalRaftHardStateSuffix is the Suffix for the raft HardState.
 	KeyLocalRaftHardStateSuffix = proto.Key("rfth")
-	// KeyLocalRaftTruncatedStateSuffix is the suffix for the RaftTruncatedState.
-	KeyLocalRaftTruncatedStateSuffix = proto.Key("rftt")
 	// KeyLocalRaftAppliedIndexSuffix is the suffix for the raft applied index.
 	KeyLocalRaftAppliedIndexSuffix = proto.Key("rfta")
+	// KeyLocalRaftLogSuffix is the suffix for the raft log.
+	KeyLocalRaftLogSuffix = proto.Key("rftl")
+	// KeyLocalRaftTruncatedStateSuffix is the suffix for the RaftTruncatedState.
+	KeyLocalRaftTruncatedStateSuffix = proto.Key("rftt")
 	// KeyLocalRangeGCMetadataSuffix is the suffix for a range's GC metadata.
 	KeyLocalRangeGCMetadataSuffix = proto.Key("rgcm")
 	// KeyLocalRangeLastVerificationTimestampSuffix is the suffix for a range's
@@ -384,12 +396,6 @@ var (
 	KeyLocalRangeLastVerificationTimestampSuffix = proto.Key("rlvt")
 	// KeyLocalRangeStatSuffix is the suffix for range statistics.
 	KeyLocalRangeStatSuffix = proto.Key("rst-")
-	// KeyLocalResponseCacheSuffix is the suffix for keys storing
-	// command responses used to guarantee idempotency (see
-	// ResponseCache).
-	// NOTE: if this value changes, it must be updated in C++
-	// (storage/engine/db.cc).
-	KeyLocalResponseCacheSuffix = proto.Key("res-")
 
 	// KeyLocalRangeKeyPrefix is the prefix identifying per-range data
 	// indexed by range key (either start key, or some key in the

--- a/storage/engine/rocksdb.go
+++ b/storage/engine/rocksdb.go
@@ -84,7 +84,11 @@ func (r *RocksDB) Open() error {
 		return nil
 	}
 
-	log.Infof("opening rocksdb instance at %q", r.dir)
+	if len(r.dir) == 0 {
+		log.Infof("opening in-memory rocksdb instance")
+	} else {
+		log.Infof("opening rocksdb instance at %q", r.dir)
+	}
 	status := C.DBOpen(&r.rdb, goToCSlice([]byte(r.dir)),
 		C.DBOptions{
 			cache_size:      C.int64_t(r.cacheSize),

--- a/storage/feed.go
+++ b/storage/feed.go
@@ -25,9 +25,8 @@ import (
 // NewRangeEvent occurs when a new range is added to a store.  This event
 // includes the Range's RangeDescriptor and current MVCCStats.
 type NewRangeEvent struct {
-	Desc     *proto.RangeDescriptor
-	IsLeader bool
-	Stats    proto.MVCCStats
+	Desc  *proto.RangeDescriptor
+	Stats proto.MVCCStats
 }
 
 // UpdateRangeEvent occurs whenever a Range is modified. This structure includes
@@ -35,19 +34,17 @@ type NewRangeEvent struct {
 // MVCCStats containing the difference from the Range's previous stats. If the
 // update did not modify any statistics, this diff may be nil.
 type UpdateRangeEvent struct {
-	Desc     *proto.RangeDescriptor
-	IsLeader bool
-	Stats    proto.MVCCStats
-	Diff     proto.MVCCStats
+	Desc  *proto.RangeDescriptor
+	Stats proto.MVCCStats
+	Diff  proto.MVCCStats
 }
 
 // RemoveRangeEvent occurs whenever a Range is removed from a store. This
 // structure includes the Range's RangeDescriptor and the Range's previous
 // MVCCStats before it was removed.
 type RemoveRangeEvent struct {
-	Desc     *proto.RangeDescriptor
-	IsLeader bool
-	Stats    proto.MVCCStats
+	Desc  *proto.RangeDescriptor
+	Stats proto.MVCCStats
 }
 
 // SplitRangeEvent occurs whenever a range is split in two. This Event actually
@@ -161,41 +158,36 @@ func (sef StoreEventFeed) endScanRanges() {
 
 func makeNewRangeEvent(rng *Range) *NewRangeEvent {
 	return &NewRangeEvent{
-		Desc:     rng.Desc(),
-		IsLeader: rng.IsLeader(),
-		Stats:    rng.stats.GetMVCC(),
+		Desc:  rng.Desc(),
+		Stats: rng.stats.GetMVCC(),
 	}
 }
 
 func makeUpdateRangeEvent(rng *Range, diff *proto.MVCCStats) *UpdateRangeEvent {
 	return &UpdateRangeEvent{
-		Desc:     rng.Desc(),
-		IsLeader: rng.IsLeader(),
-		Stats:    rng.stats.GetMVCC(),
-		Diff:     *diff,
+		Desc:  rng.Desc(),
+		Stats: rng.stats.GetMVCC(),
+		Diff:  *diff,
 	}
 }
 
 func makeRemoveRangeEvent(rng *Range) *RemoveRangeEvent {
 	return &RemoveRangeEvent{
-		Desc:     rng.Desc(),
-		IsLeader: rng.IsLeader(),
-		Stats:    rng.stats.GetMVCC(),
+		Desc:  rng.Desc(),
+		Stats: rng.stats.GetMVCC(),
 	}
 }
 
 func makeSplitRangeEvent(rngOrig, rngNew *Range, diffOrig *proto.MVCCStats) *SplitRangeEvent {
 	return &SplitRangeEvent{
 		Original: UpdateRangeEvent{
-			Desc:     rngOrig.Desc(),
-			IsLeader: rngOrig.IsLeader(),
-			Stats:    rngOrig.stats.GetMVCC(),
-			Diff:     *diffOrig,
+			Desc:  rngOrig.Desc(),
+			Stats: rngOrig.stats.GetMVCC(),
+			Diff:  *diffOrig,
 		},
 		New: NewRangeEvent{
-			Desc:     rngNew.Desc(),
-			IsLeader: rngNew.IsLeader(),
-			Stats:    rngNew.stats.GetMVCC(),
+			Desc:  rngNew.Desc(),
+			Stats: rngNew.stats.GetMVCC(),
 		},
 	}
 }
@@ -203,15 +195,13 @@ func makeSplitRangeEvent(rngOrig, rngNew *Range, diffOrig *proto.MVCCStats) *Spl
 func makeMergeRangeEvent(rngMerged, rngRemoved *Range, diffMerged *proto.MVCCStats) *MergeRangeEvent {
 	return &MergeRangeEvent{
 		Merged: UpdateRangeEvent{
-			Desc:     rngMerged.Desc(),
-			IsLeader: rngMerged.IsLeader(),
-			Stats:    rngMerged.stats.GetMVCC(),
-			Diff:     *diffMerged,
+			Desc:  rngMerged.Desc(),
+			Stats: rngMerged.stats.GetMVCC(),
+			Diff:  *diffMerged,
 		},
 		Removed: RemoveRangeEvent{
-			Desc:     rngRemoved.Desc(),
-			IsLeader: rngRemoved.IsLeader(),
-			Stats:    rngRemoved.stats.GetMVCC(),
+			Desc:  rngRemoved.Desc(),
+			Stats: rngRemoved.stats.GetMVCC(),
 		},
 	}
 }

--- a/storage/feed_test.go
+++ b/storage/feed_test.go
@@ -131,7 +131,6 @@ func TestStoreEventFeed(t *testing.T) {
 					StartKey: proto.Key("a"),
 					EndKey:   proto.Key("b"),
 				},
-				IsLeader: true,
 				Stats: proto.MVCCStats{
 					LiveBytes: 400,
 					KeyBytes:  40,
@@ -150,7 +149,6 @@ func TestStoreEventFeed(t *testing.T) {
 					StartKey: proto.Key("a"),
 					EndKey:   proto.Key("b"),
 				},
-				IsLeader: true,
 				Stats: proto.MVCCStats{
 					LiveBytes: 400,
 					KeyBytes:  40,
@@ -173,7 +171,6 @@ func TestStoreEventFeed(t *testing.T) {
 					StartKey: proto.Key("b"),
 					EndKey:   proto.Key("c"),
 				},
-				IsLeader: true,
 				Stats: proto.MVCCStats{
 					LiveBytes: 200,
 					KeyBytes:  30,
@@ -193,7 +190,6 @@ func TestStoreEventFeed(t *testing.T) {
 						StartKey: proto.Key("a"),
 						EndKey:   proto.Key("b"),
 					},
-					IsLeader: true,
 					Stats: proto.MVCCStats{
 						LiveBytes: 400,
 						KeyBytes:  40,
@@ -210,7 +206,6 @@ func TestStoreEventFeed(t *testing.T) {
 						StartKey: proto.Key("b"),
 						EndKey:   proto.Key("c"),
 					},
-					IsLeader: true,
 					Stats: proto.MVCCStats{
 						LiveBytes: 200,
 						KeyBytes:  30,
@@ -231,7 +226,6 @@ func TestStoreEventFeed(t *testing.T) {
 						StartKey: proto.Key("a"),
 						EndKey:   proto.Key("b"),
 					},
-					IsLeader: true,
 					Stats: proto.MVCCStats{
 						LiveBytes: 400,
 						KeyBytes:  40,
@@ -248,7 +242,6 @@ func TestStoreEventFeed(t *testing.T) {
 						StartKey: proto.Key("b"),
 						EndKey:   proto.Key("c"),
 					},
-					IsLeader: true,
 					Stats: proto.MVCCStats{
 						LiveBytes: 200,
 						KeyBytes:  30,

--- a/storage/gc_queue.go
+++ b/storage/gc_queue.go
@@ -69,15 +69,15 @@ func newGCQueue() *gcQueue {
 	return gcq
 }
 
+func (gcq *gcQueue) needsLeaderLease() bool {
+	return true
+}
+
 // shouldQueue determines whether a range should be queued for garbage
 // collection, and if so, at what priority. Returns true for shouldQ
 // in the event that the cumulative ages of GC'able bytes or extant
 // intents exceed thresholds.
 func (gcq *gcQueue) shouldQueue(now proto.Timestamp, rng *Range) (shouldQ bool, priority float64) {
-	// Only queue for GC if this replica is leader.
-	if !rng.IsLeader() {
-		return
-	}
 	// Lookup GC policy for this range.
 	policy, err := gcq.lookupGCPolicy(rng)
 	if err != nil {
@@ -108,11 +108,6 @@ func (gcq *gcQueue) shouldQueue(now proto.Timestamp, rng *Range) (shouldQ bool, 
 // batched into InternalGC calls. Extant intents are resolved if
 // intents are older than intentAgeThreshold.
 func (gcq *gcQueue) process(now proto.Timestamp, rng *Range) error {
-	if !rng.IsLeader() {
-		log.Infof("not leader of range %s; skipping GC", rng)
-		return nil
-	}
-
 	snap := rng.rm.Engine().NewSnapshot()
 	iter := newRangeDataIterator(rng, snap)
 	defer iter.Close()

--- a/storage/gc_queue_test.go
+++ b/storage/gc_queue_test.go
@@ -177,7 +177,7 @@ func TestGCQueueProcess(t *testing.T) {
 		{key9, ts3, true, false},
 	}
 
-	for _, datum := range data {
+	for i, datum := range data {
 		if datum.del {
 			dArgs, dReply := deleteArgs(datum.key, tc.rng.Desc().RaftID, tc.store.StoreID())
 			dArgs.Timestamp = datum.ts
@@ -186,7 +186,7 @@ func TestGCQueueProcess(t *testing.T) {
 				dArgs.Txn.Timestamp = datum.ts
 			}
 			if err := tc.rng.AddCmd(dArgs, dReply, true); err != nil {
-				t.Fatal(err)
+				t.Fatalf("%d: could not delete data: %s", err)
 			}
 		} else {
 			pArgs, pReply := putArgs(datum.key, []byte("value"), tc.rng.Desc().RaftID, tc.store.StoreID())
@@ -196,7 +196,7 @@ func TestGCQueueProcess(t *testing.T) {
 				pArgs.Txn.Timestamp = datum.ts
 			}
 			if err := tc.rng.AddCmd(pArgs, pReply, true); err != nil {
-				t.Fatal(err)
+				t.Fatalf("%d: could not put data: %s", i, err)
 			}
 		}
 	}

--- a/storage/gc_queue_test.go
+++ b/storage/gc_queue_test.go
@@ -186,7 +186,7 @@ func TestGCQueueProcess(t *testing.T) {
 				dArgs.Txn.Timestamp = datum.ts
 			}
 			if err := tc.rng.AddCmd(dArgs, dReply, true); err != nil {
-				t.Fatalf("%d: could not delete data: %s", err)
+				t.Fatalf("%d: could not delete data: %s", i, err)
 			}
 		} else {
 			pArgs, pReply := putArgs(datum.key, []byte("value"), tc.rng.Desc().RaftID, tc.store.StoreID())

--- a/storage/queue_test.go
+++ b/storage/queue_test.go
@@ -36,6 +36,8 @@ type testQueueImpl struct {
 	duration      time.Duration
 }
 
+func (tq *testQueueImpl) needsLeaderLease() bool { return false }
+
 func (tq *testQueueImpl) shouldQueue(now proto.Timestamp, r *Range) (bool, float64) {
 	return tq.shouldQueueFn(now, r)
 }

--- a/storage/range.go
+++ b/storage/range.go
@@ -1533,6 +1533,8 @@ func (r *Range) InternalLeaderLease(batch engine.Engine, ms *proto.MVCCStats, ar
 				args.Lease.Start, args.Lease.Expiration, oldLease.Start, oldLease.Expiration))
 			return
 		}
+		// Note that the lease expiration can be shortened by the holder.
+		// This could be used to effect a faster lease handoff.
 	} else if args.Lease.Start.Less(oldLease.Expiration) {
 		reply.SetGoError(util.Errorf("lease %s - %s invalid; prior lease %s - %s",
 			args.Lease.Start, args.Lease.Expiration, oldLease.Start, oldLease.Expiration))

--- a/storage/range_test.go
+++ b/storage/range_test.go
@@ -271,11 +271,6 @@ func TestRangeReadConsistency(t *testing.T) {
 	tc.Start(t)
 	defer tc.Stop()
 
-	pArgs, pReply := putArgs([]byte("a"), []byte("value"), 1, tc.store.StoreID())
-	err := tc.rng.AddCmd(pArgs, pReply, true)
-	if err != nil {
-		t.Fatal(err)
-	}
 	gArgs, gReply := getArgs(proto.Key("a"), 1, tc.store.StoreID())
 	gArgs.Timestamp = tc.clock.Now()
 
@@ -303,7 +298,7 @@ func TestRangeReadConsistency(t *testing.T) {
 	})
 	gArgs.ReadConsistency = proto.CONSISTENT
 	gArgs.Txn = nil
-	err = tc.rng.AddCmd(gArgs, gReply, true)
+	err := tc.rng.AddCmd(gArgs, gReply, true)
 	if _, ok := err.(*proto.NotLeaderError); !ok {
 		t.Errorf("expected not leader error; got %s", err)
 	}

--- a/storage/range_test.go
+++ b/storage/range_test.go
@@ -82,12 +82,14 @@ func testRangeDescriptor() *proto.RangeDescriptor {
 type bootstrapMode int
 
 const (
-	// Use Store.BootstrapRange, which writes the range descriptor and other metadata.
-	// Most tests should use this mode because it more closely resembles the real world.
+	// Use Store.BootstrapRange, which writes the range descriptor and
+	// other metadata. Most tests should use this mode because it more
+	// closely resembles the real world.
 	bootstrapRangeWithMetadata bootstrapMode = iota
-	// Create a range with NewRange and Store.AddRange. The store's data will
-	// be persisted but metadata will not. This mode is provided for backwards compatiblity
-	// for tests that expect the store to initially be empty.
+	// Create a range with NewRange and Store.AddRange. The store's data
+	// will be persisted but metadata will not. This mode is provided
+	// for backwards compatibility for tests that expect the store to
+	// initially be empty.
 	bootstrapRangeOnly
 )
 
@@ -177,14 +179,6 @@ func (tc *testContext) Start(t *testing.T) {
 		}
 		tc.rangeID = tc.rng.Desc().RaftID
 	}
-
-	if !tc.dormantRaft {
-		// Make sure that the group is running.
-		// MultiRaft will automatically elect a leader if the group contains
-		// only one member.
-		tc.store.startGroup(1)
-		tc.rng.WaitForElection()
-	}
 }
 
 func (tc *testContext) Stop() {
@@ -260,12 +254,28 @@ func TestRangeContains(t *testing.T) {
 	}
 }
 
-func TestRangeCanService(t *testing.T) {
+func setLeaderLease(t *testing.T, r *Range, l *proto.Lease) {
+	req := &proto.InternalLeaderLeaseRequest{Lease: *l}
+	reply := &proto.InternalLeaderLeaseResponse{}
+	if err := r.AddCmd(req, reply, true); err != nil {
+		t.Errorf("failed to set lease: %s", err)
+	}
+}
+
+// TestRangeReadConsistency verifies behavior of the range under
+// different read consistencies. Note that this unittest plays
+// fast and loose with granting leader leases.
+func TestRangeReadConsistency(t *testing.T) {
 	defer leaktest.AfterTest(t)
 	tc := testContext{}
 	tc.Start(t)
 	defer tc.Stop()
 
+	pArgs, pReply := putArgs([]byte("a"), []byte("value"), 1, tc.store.StoreID())
+	err := tc.rng.AddCmd(pArgs, pReply, true)
+	if err != nil {
+		t.Fatal(err)
+	}
 	gArgs, gReply := getArgs(proto.Key("a"), 1, tc.store.StoreID())
 	gArgs.Timestamp = tc.clock.Now()
 
@@ -282,15 +292,226 @@ func TestRangeCanService(t *testing.T) {
 		t.Errorf("expected error on inconsistent read within a txn")
 	}
 
-	// TODO(spencer): verify non-leader inconsistent read works.
-
-	// Verify range checking.
-	splitTestRange(tc.store, proto.Key("a"), proto.Key("a"), t)
-	gArgs.Key = proto.Key("b")
+	// Lose the lease and verify CONSISTENT reads receive NotLeaderError
+	// and INCONSISTENT reads work as expected.
+	start := tc.rng.getLease().Expiration.Add(1, 0)
+	tc.manualClock.Set(start.WallTime)
+	setLeaderLease(t, tc.rng, &proto.Lease{
+		Start:      start,
+		Expiration: start.Add(10, 0),
+		RaftNodeID: uint64(MakeRaftNodeID(2, 2)), // a different node
+	})
+	gArgs.ReadConsistency = proto.CONSISTENT
 	gArgs.Txn = nil
+	err = tc.rng.AddCmd(gArgs, gReply, true)
+	if _, ok := err.(*proto.NotLeaderError); !ok {
+		t.Errorf("expected not leader error; got %s", err)
+	}
+
+	gArgs.ReadConsistency = proto.INCONSISTENT
+	if err := tc.rng.AddCmd(gArgs, gReply, true); err != nil {
+		t.Errorf("expected success reading with inconsistent: %s", err)
+	}
+}
+
+func TestRangeRangeBoundsChecking(t *testing.T) {
+	defer leaktest.AfterTest(t)
+	tc := testContext{}
+	tc.Start(t)
+	defer tc.Stop()
+
+	splitTestRange(tc.store, proto.Key("a"), proto.Key("a"), t)
+	gArgs, gReply := getArgs(proto.Key("b"), 1, tc.store.StoreID())
 	err := tc.rng.AddCmd(gArgs, gReply, true)
 	if _, ok := err.(*proto.RangeKeyMismatchError); !ok {
 		t.Errorf("expected range key mismatch error: %s", err)
+	}
+}
+
+func TestRangeHasLeaderLease(t *testing.T) {
+	defer leaktest.AfterTest(t)
+	tc := testContext{}
+	tc.Start(t)
+	defer tc.Stop()
+	tc.clock.SetMaxOffset(maxClockOffset)
+
+	if held, _ := tc.rng.HasLeaderLease(tc.clock.Now()); held {
+		t.Errorf("expected no lease on range start")
+	}
+	now := tc.clock.Now()
+	setLeaderLease(t, tc.rng, &proto.Lease{
+		Start:      now,
+		Expiration: now.Add(10, 0),
+		RaftNodeID: uint64(MakeRaftNodeID(2, 2)),
+	})
+	if held, expired := tc.rng.HasLeaderLease(tc.clock.Now()); held || expired {
+		t.Errorf("expected another replica to have leader lease")
+	}
+
+	// Advance clock past expiration and verify that another has
+	// leader lease will still be true up to the grace period.
+	tc.manualClock.Set(11) // time is 11ns
+	if held, expired := tc.rng.HasLeaderLease(tc.clock.Now()); held || expired {
+		t.Errorf("expected another replica to still have leader lease due to grace period")
+	}
+	tc.manualClock.Set(11 + int64(tc.clock.MaxOffset()))
+	if held, expired := tc.rng.HasLeaderLease(tc.clock.Now()); held || !expired {
+		t.Errorf("expected expiration of other replica's leader lease")
+	}
+}
+
+func TestRangeNotLeaderError(t *testing.T) {
+	defer leaktest.AfterTest(t)
+	tc := testContext{}
+	tc.Start(t)
+	defer tc.Stop()
+
+	now := tc.clock.Now()
+	setLeaderLease(t, tc.rng, &proto.Lease{
+		Start:      now,
+		Expiration: now.Add(10, 0),
+		RaftNodeID: uint64(MakeRaftNodeID(2, 2)),
+	})
+
+	header := proto.RequestHeader{
+		Key:       proto.Key("a"),
+		RaftID:    tc.rng.Desc().RaftID,
+		Replica:   proto.Replica{StoreID: tc.store.StoreID()},
+		Timestamp: now,
+	}
+	testCases := []struct {
+		args  proto.Request
+		reply proto.Response
+	}{
+		// Admin split covers admin commands.
+		{&proto.AdminSplitRequest{
+			RequestHeader: header,
+			SplitKey:      proto.Key("a"),
+		},
+			&proto.AdminSplitResponse{},
+		},
+		// Get covers read-only commands.
+		{&proto.GetRequest{
+			RequestHeader: header,
+		},
+			&proto.GetResponse{},
+		},
+		// Put covers read-write commands.
+		{&proto.PutRequest{
+			RequestHeader: header,
+			Value: proto.Value{
+				Bytes: []byte("value"),
+			},
+		},
+			&proto.PutResponse{},
+		},
+	}
+
+	for i, test := range testCases {
+		err := tc.rng.AddCmd(test.args, test.reply, true)
+		if _, ok := err.(*proto.NotLeaderError); !ok {
+			t.Errorf("%d: expected not leader error: %s", i, err)
+		}
+	}
+}
+
+// TestRangeGossipConfigsOnLease verifies that config info is gossiped
+// upon acquisition of the leader lease.
+func TestRangeGossipConfigsOnLease(t *testing.T) {
+	defer leaktest.AfterTest(t)
+	tc := testContext{}
+	tc.Start(t)
+	defer tc.Stop()
+
+	// Give lease to someone else to start.
+	now := tc.clock.Now()
+	setLeaderLease(t, tc.rng, &proto.Lease{
+		Start:      now,
+		Expiration: now.Add(10, 0),
+		RaftNodeID: uint64(MakeRaftNodeID(2, 2)),
+	})
+
+	// Add a permission for a new key prefix.
+	db1Perm := proto.PermConfig{
+		Read:  []string{"spencer", "foo", "bar", "baz"},
+		Write: []string{"spencer"},
+	}
+	key := engine.MakeKey(engine.KeyConfigPermissionPrefix, proto.Key("/db1"))
+	if err := engine.MVCCPutProto(tc.engine, nil, key, proto.MinTimestamp, nil, &db1Perm); err != nil {
+		t.Fatal(err)
+	}
+
+	verifyPerm := func() bool {
+		info, err := tc.gossip.GetInfo(gossip.KeyConfigPermission)
+		if err != nil {
+			t.Fatal(err)
+		}
+		configMap := info.(PrefixConfigMap)
+		expConfigs := []*PrefixConfig{
+			{engine.KeyMin, nil, &testDefaultPermConfig},
+			{proto.Key("/db1"), nil, &db1Perm},
+			{proto.Key("/db2"), engine.KeyMin, &testDefaultPermConfig},
+		}
+		return reflect.DeepEqual([]*PrefixConfig(configMap), expConfigs)
+	}
+
+	if verifyPerm() {
+		t.Errorf("not expecting gossip of new config until lease is acquired")
+	}
+
+	// Give lease to this range.
+	tc.manualClock.Set(11 + int64(tc.clock.MaxOffset())) // advance time
+	setLeaderLease(t, tc.rng, &proto.Lease{
+		Start:      now.Add(11, 0),
+		Expiration: now.Add(20, 0),
+		RaftNodeID: uint64(tc.store.RaftNodeID()),
+	})
+	if !verifyPerm() {
+		t.Errorf("expected gossip of new config")
+	}
+}
+
+// TestRangeTSCacheLowWaterOnLease verifies that the low water mark is
+// set on the timestamp cache when the node is granted the leader
+// lease after not holding it and it is not set when the node is
+// granted the leader lease when it was the last holder.
+func TestRangeTSCacheLowWaterOnLease(t *testing.T) {
+	defer leaktest.AfterTest(t)
+	tc := testContext{}
+	tc.Start(t)
+	defer tc.Stop()
+	tc.clock.SetMaxOffset(maxClockOffset)
+
+	now := proto.Timestamp{WallTime: maxClockOffset.Nanoseconds() + 10}
+	tc.manualClock.Set(now.WallTime)
+
+	testCases := []struct {
+		nodeID      multiraft.NodeID
+		start       proto.Timestamp
+		expiration  proto.Timestamp
+		expLowWater int64
+	}{
+		// Grant the lease fresh.
+		{tc.store.RaftNodeID(), now, now.Add(10, 0), maxClockOffset.Nanoseconds()},
+		// Renew the lease.
+		{tc.store.RaftNodeID(), now.Add(15, 0), now.Add(30, 0), maxClockOffset.Nanoseconds()},
+		// Lease is held by another.
+		{MakeRaftNodeID(2, 2), now.Add(35, 0), now.Add(50, 0), maxClockOffset.Nanoseconds()},
+		// Lease is regranted to this replica.
+		{tc.store.RaftNodeID(), now.Add(60, 0), now.Add(70, 0), now.Add(50, 0).WallTime + maxClockOffset.Nanoseconds()},
+	}
+
+	for i, test := range testCases {
+		setLeaderLease(t, tc.rng, &proto.Lease{
+			Start:      test.start,
+			Expiration: test.expiration,
+			RaftNodeID: uint64(test.nodeID),
+		})
+		// Verify expected low water mark.
+		rTS, wTS := tc.rng.tsCache.GetMax(proto.Key("a"), nil, proto.NoTxnMD5)
+		if rTS.WallTime != test.expLowWater || wTS.WallTime != test.expLowWater {
+			t.Errorf("%d: expected low water %d; got %d, %d", i, test.expLowWater, rTS.WallTime, wTS.WallTime)
+		}
 	}
 }
 
@@ -377,7 +598,7 @@ func TestRangeGossipConfigWithMultipleKeyPrefixes(t *testing.T) {
 	}
 	reply := &proto.PutResponse{}
 
-	if err := tc.rng.executeCmd(0, req, reply); err != nil {
+	if err := tc.rng.AddCmd(req, reply, true); err != nil {
 		t.Fatal(err)
 	}
 
@@ -419,7 +640,7 @@ func TestRangeGossipConfigUpdates(t *testing.T) {
 	}
 	reply := &proto.PutResponse{}
 
-	if err := tc.rng.executeCmd(0, req, reply); err != nil {
+	if err := tc.rng.AddCmd(req, reply, true); err != nil {
 		t.Fatal(err)
 	}
 
@@ -630,6 +851,44 @@ func verifyErrorMatches(err error, regexpStr string, t *testing.T) {
 		if matched, regexpErr := regexp.MatchString(regexpStr, err.Error()); !matched || regexpErr != nil {
 			t.Errorf("expected error to match %q (%s): %s", regexpStr, regexpErr, err.Error())
 		}
+	}
+}
+
+// TestAcquireLeaderLease verifies that the leader lease is acquired
+// for read and write methods.
+func TestAcquireLeaderLease(t *testing.T) {
+	defer leaktest.AfterTest(t)
+
+	gArgs, gReply := getArgs([]byte("a"), 1, 0)
+	pArgs, pReply := putArgs([]byte("b"), []byte("1"), 1, 0)
+
+	testCases := []struct {
+		args  proto.Request
+		reply proto.Response
+	}{
+		{gArgs, gReply},
+		{pArgs, pReply},
+	}
+	for i, test := range testCases {
+		tc := testContext{}
+		tc.Start(t)
+		tc.manualClock.Set(time.Second.Nanoseconds())
+
+		test.args.Header().Timestamp = tc.clock.Now()
+		if err := tc.rng.AddCmd(test.args, test.reply, true); err != nil {
+			t.Fatal(err)
+		}
+		lease := tc.rng.getLease()
+		if lease == nil {
+			t.Fatalf("%d: expected lease acquisition", i)
+		}
+		expStart := test.args.Header().Timestamp
+		expExpiration := expStart.Add(int64(defaultLeaderLeaseDuration), 0)
+		if !lease.Start.Equal(expStart) || !lease.Expiration.Equal(expExpiration) {
+			t.Errorf("%d: unexpected lease timing %d, %d; expected %s, %s",
+				i, lease.Start, lease.Expiration, expStart, expExpiration)
+		}
+		tc.Stop()
 	}
 }
 
@@ -1784,7 +2043,7 @@ func TestConditionFailedError(t *testing.T) {
 	key := []byte("k")
 	value := []byte("quack")
 	pArgs, pReply := putArgs(key, value, 1, tc.store.StoreID())
-	if err := tc.rng.executeCmd(0, pArgs, pReply); err != nil {
+	if err := tc.rng.AddCmd(pArgs, pReply, true); err != nil {
 		t.Fatal(err)
 	}
 	args := &proto.ConditionalPutRequest{
@@ -1802,7 +2061,7 @@ func TestConditionFailedError(t *testing.T) {
 		},
 	}
 	reply := &proto.ConditionalPutResponse{}
-	err := tc.rng.executeCmd(0, args, reply)
+	err := tc.rng.AddCmd(args, reply, true)
 	if cErr, ok := err.(*proto.ConditionFailedError); err == nil || !ok {
 		t.Fatalf("expected ConditionFailedError, got %T with content %+v",
 			err, err)

--- a/storage/response_cache.go
+++ b/storage/response_cache.go
@@ -19,7 +19,6 @@ package storage
 
 import (
 	"bytes"
-	"fmt"
 	"sync"
 
 	"github.com/cockroachdb/cockroach/proto"
@@ -50,9 +49,8 @@ func makeCmdIDKey(cmdID proto.ClientCmdID) cmdIDKey {
 //
 // A ResponseCache is safe for concurrent access.
 type ResponseCache struct {
-	raftID   int64
-	engine   engine.Engine
-	inflight map[cmdIDKey]*sync.Cond
+	raftID int64
+	engine engine.Engine
 	sync.Mutex
 }
 
@@ -62,21 +60,9 @@ type ResponseCache struct {
 // inflight map should be cleared.
 func NewResponseCache(raftID int64, engine engine.Engine) *ResponseCache {
 	return &ResponseCache{
-		raftID:   raftID,
-		engine:   engine,
-		inflight: map[cmdIDKey]*sync.Cond{},
+		raftID: raftID,
+		engine: engine,
 	}
-}
-
-// ClearInflight removes all pending commands from the inflight map,
-// signaling and clearing any inflight waiters.
-func (rc *ResponseCache) ClearInflight() {
-	rc.Lock()
-	defer rc.Unlock()
-	for _, cond := range rc.inflight {
-		cond.Broadcast()
-	}
-	rc.inflight = map[cmdIDKey]*sync.Cond{}
 }
 
 // ClearData removes all items stored in the persistent cache. It does not alter
@@ -99,38 +85,17 @@ func (rc *ResponseCache) GetResponse(cmdID proto.ClientCmdID, reply proto.Respon
 	if cmdID.IsEmpty() {
 		return false, nil
 	}
-	// If the command is inflight, wait for it to complete.
-	rc.Lock()
-	for {
-		if cond, ok := rc.inflight[makeCmdIDKey(cmdID)]; ok {
-			log.Infof("waiting on cmdID: %s", &cmdID)
-			cond.Wait()
-		} else {
-			break
-		}
-	}
-	// Adding inflight here is preemptive; we don't want to hold lock
-	// while fetching from the on-disk cache. The vast, vast majority of
-	// calls to GetResponse will be cache misses, so this saves us
-	// from acquiring the lock twice: once here and once below in the
-	// event we experience a cache miss.
-	rc.addInflightLocked(cmdID)
-	rc.Unlock()
 
 	// If the response is in the cache or we experienced an error, return.
 	rwResp := proto.ReadWriteCmdResponse{}
 	key := engine.ResponseCacheKey(rc.raftID, &cmdID)
-	if ok, err := engine.MVCCGetProto(rc.engine, key, proto.ZeroTimestamp,
-		true, nil, &rwResp); ok || err != nil {
-		rc.Lock() // Take lock after fetching response from cache.
-		defer rc.Unlock()
-		rc.removeInflightLocked(cmdID)
+	if ok, err := engine.MVCCGetProto(rc.engine, key, proto.ZeroTimestamp, true, nil, &rwResp); ok || err != nil {
 		if err == nil && rwResp.GetValue() != nil {
 			gogoproto.Merge(reply.(gogoproto.Message), rwResp.GetValue().(gogoproto.Message))
 		}
 		return ok, err
 	}
-	// There's no command result cached for this ID; but inflight was added above.
+	// There's no command result cached for this ID.
 	return false, nil
 }
 
@@ -204,10 +169,6 @@ func (rc *ResponseCache) CopyFrom(e engine.Engine, originRaftID int64) error {
 }
 
 // PutResponse writes a response to the cache for the specified cmdID.
-// The inflight entry corresponding to cmdID is removed from the
-// inflight map. Any requests waiting on the outcome of the inflight
-// command will be signaled to wakeup and read the command response
-// from the cache.
 func (rc *ResponseCache) PutResponse(cmdID proto.ClientCmdID, reply proto.Response) error {
 	// Do nothing if command ID is empty.
 	if cmdID.IsEmpty() {
@@ -219,17 +180,10 @@ func (rc *ResponseCache) PutResponse(cmdID proto.ClientCmdID, reply proto.Respon
 		key := engine.ResponseCacheKey(rc.raftID, &cmdID)
 		rwResp := &proto.ReadWriteCmdResponse{}
 		if !rwResp.SetValue(reply) {
-			log.Fatalf("attempt to add invalid item to response cache: %+v",
-				reply)
+			log.Fatalf("response %T not supported by response cache", reply)
 		}
 		err = engine.MVCCPutProto(rc.engine, nil, key, proto.ZeroTimestamp, nil, rwResp)
 	}
-
-	// Take lock after writing response to cache!
-	rc.Lock()
-	defer rc.Unlock()
-	// Even on error, we remove the entry from the inflight map.
-	rc.removeInflightLocked(cmdID)
 
 	return err
 }
@@ -244,29 +198,6 @@ func (rc *ResponseCache) shouldCacheResponse(reply proto.Response) bool {
 		return false
 	}
 	return true
-}
-
-// addInflightLocked adds the supplied ClientCmdID to the inflight
-// map. Any subsequent invocations of GetResponse for the same client
-// command will block on the inflight cond var until either the
-// response cache is cleared or this command is removed via
-// PutResponse().
-func (rc *ResponseCache) addInflightLocked(cmdID proto.ClientCmdID) {
-	if _, ok := rc.inflight[makeCmdIDKey(cmdID)]; ok {
-		panic(fmt.Sprintf("command %+v is already inflight; GetResponse() should have been "+
-			"invoked first", cmdID))
-	}
-	rc.inflight[makeCmdIDKey(cmdID)] = sync.NewCond(&rc.Mutex)
-}
-
-// removeInflightLocked removes an entry matching cmdID from the
-// inflight map and broadcasts a wakeup to all waiters.
-func (rc *ResponseCache) removeInflightLocked(cmdID proto.ClientCmdID) {
-	key := makeCmdIDKey(cmdID)
-	if cond, ok := rc.inflight[key]; ok {
-		cond.Broadcast()
-		delete(rc.inflight, key)
-	}
 }
 
 func (rc *ResponseCache) decodeResponseCacheKey(encKey proto.EncodedKey) (proto.ClientCmdID, error) {

--- a/storage/split_queue.go
+++ b/storage/split_queue.go
@@ -41,8 +41,6 @@ type splitQueue struct {
 	*baseQueue
 	db     *client.KV
 	gossip *gossip.Gossip
-	// Some tests in this package disable the split queue.
-	disabled bool
 }
 
 // newSplitQueue returns a new instance of splitQueue.
@@ -55,16 +53,15 @@ func newSplitQueue(db *client.KV, gossip *gossip.Gossip) *splitQueue {
 	return sq
 }
 
+func (sq *splitQueue) needsLeaderLease() bool {
+	return true
+}
+
 // shouldQueue determines whether a range should be queued for
 // splitting. This is true if the range is intersected by any
 // accounting or zone config prefix or if the range's size in
 // bytes exceeds the limit for the zone.
 func (sq *splitQueue) shouldQueue(now proto.Timestamp, rng *Range) (shouldQ bool, priority float64) {
-	// Only queue for Split if this replica is leader.
-	if !rng.IsLeader() || sq.disabled {
-		return
-	}
-
 	// Set priority to 1 in the event the range is split by acct or zone configs.
 	if len(computeSplitKeys(sq.gossip, rng)) > 0 {
 		priority = 1
@@ -87,10 +84,6 @@ func (sq *splitQueue) shouldQueue(now proto.Timestamp, rng *Range) (shouldQ bool
 
 // process synchronously invokes admin split for each proposed split key.
 func (sq *splitQueue) process(now proto.Timestamp, rng *Range) error {
-	if !rng.IsLeader() {
-		log.Infof("not leader of range %s; skipping split", rng)
-		return nil
-	}
 	// First handle case of splitting due to accounting and zone config maps.
 	splitKeys := computeSplitKeys(sq.gossip, rng)
 	if len(splitKeys) > 0 {

--- a/storage/verify_queue.go
+++ b/storage/verify_queue.go
@@ -51,6 +51,10 @@ func newVerifyQueue(stats storeStatsFn) *verifyQueue {
 	return vq
 }
 
+func (vq *verifyQueue) needsLeaderLease() bool {
+	return false
+}
+
 // shouldQueue determines whether a range should be queued for
 // verification scanning, and if so, at what priority. Returns true
 // for shouldQ in the event that it's been longer since the last scan

--- a/ts/db_test.go
+++ b/ts/db_test.go
@@ -61,9 +61,7 @@ func newTestModel(t *testing.T) *testModel {
 // Start constructs and starts the local test server and creates a
 // time series DB.
 func (tm *testModel) Start() {
-	if err := tm.LocalTestCluster.Start(); err != nil {
-		tm.t.Fatal(err)
-	}
+	tm.LocalTestCluster.Start(tm.t)
 	tm.DB = NewDB(tm.KV)
 }
 

--- a/util/hlc/hlc.go
+++ b/util/hlc/hlc.go
@@ -174,8 +174,6 @@ func (c *Clock) Now() (result proto.Timestamp) {
 // PhysicalNow returns the local wall time. It corresponds to the physicalClock
 // provided at instantiation. For a timestamp value, use Now() instead.
 func (c *Clock) PhysicalNow() int64 {
-	c.Lock()
-	defer c.Unlock()
 	wallTime := c.physicalClock()
 	return wallTime
 }

--- a/util/testing.go
+++ b/util/testing.go
@@ -130,7 +130,7 @@ func IsTrueWithin(trueFunc func() bool, duration time.Duration) error {
 // function is invoked immediately at first and then successively with
 // an exponential backoff starting at 1ns and ending at the specified
 // duration.
-func SucceedsWithin(t *testing.T, duration time.Duration, fn func() error) {
+func SucceedsWithin(t testing.TB, duration time.Duration, fn func() error) {
 	total := time.Duration(0)
 	var lastErr error
 	for wait := time.Duration(1); total < duration; wait *= 2 {


### PR DESCRIPTION
Added new Lease type to proto/data.proto. Leases contain an expiration
as a wall time in unix nanos as well as the node and store IDs of the
replica being granted the lease. Ranges keep track of the lease and can
now answer the question HasLeaderLease() for a range. Further, the last
set lease is used to construct proper NotLeaderError error returns.

On change in leader lease, only update timestamp cache by moving the low
water mark forward instead of clearing it completely. This change will also
need to rely on the last leader lease always being persisted.

Leases are raft-agnostic. They are a sequence of database time intervals
which are guaranteed not to overlap, for which a single replica in a raft
group has the leader lease. With the leader lease, a replica can submit
consistent read commands, write commands, and admin commands to raft, where
the command's timestamp is within the leader lease window. Note that this
is not the current system time, but the actual time of the command being
submitted (i.e. Request.Header.Timestamp).

Pre raft, when a command which requires the leader lease is received, the
lease holder is checked. If the lease is held by the replica and hasn't
expired (remember, according to the timestamp in the command's header),
the command can either be executed (consistent read and admin cases) or
submitted to raft (write case). If another replica currently holds the
lease and it hasn't expired (again, according to the timestamp in the
command's header), the a NotLeaderError is returned to the client, which
prompts a retry from the dist sender. If the lease currently isn't held,
the replica attempts to acquire it by submitting an InternalLeaderLease
command to raft. Because raft commands are executed by all replicas in
exact order, only one leader lease acquisition (the first after the prior
lease's expiration) will succeed.

Post raft, when a command is executed in Range.executeCmd, the lease is
verified.
