### PR TITLE
ignore docker push failures; barf on data races

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -54,6 +54,10 @@ test:
       else
         echo "Not posting an issue."
       fi
+      # Fail the test if there's anything in the excerpt. This will usually
+      # be a data race warning (which does not generally fail `make testrace`
+      # for some reason).
+      test -s "${CIRCLE_ARTIFACTS}/excerpt.txt"
 
 
 deployment:

--- a/circle.yml
+++ b/circle.yml
@@ -69,8 +69,11 @@ deployment:
             make COCKROACH_IMAGE="cockroachdb/cockroach" acceptance && \
             docker tag cockroachdb/cockroach:latest cockroachdb/cockroach:${VERSION} && \
             docker tag cockroachdb/cockroach-dev:latest cockroachdb/cockroach-dev:${VERSION} && \
-            docker push cockroachdb/cockroach:latest && \
-            docker push cockroachdb/cockroach:${VERSION} && \
-            docker push cockroachdb/cockroach-dev:latest && \
-            docker push cockroachdb/cockroach-dev:${VERSION}
+            # Pushing to the registry just fails sometimes, so for the time
+            # being just make this a best-effort action.
+            (docker push cockroachdb/cockroach:latest; \
+            docker push cockroachdb/cockroach:${VERSION}; \
+            docker push cockroachdb/cockroach-dev:latest; \
+            docker push cockroachdb/cockroach-dev:${VERSION}; \
+            true)
           fi

--- a/kv/txn_coord_sender.go
+++ b/kv/txn_coord_sender.go
@@ -536,7 +536,7 @@ func (tc *TxnCoordSender) heartbeat(txn *proto.Transaction, closer chan struct{}
 			// write intents accordingly.
 			if reply.GoError() != nil {
 				log.Warningf("heartbeat to %q:%q failed: %s", txn.Key, txn.ID, reply.GoError())
-			} else if reply.Txn.Status != proto.PENDING {
+			} else if reply.Txn != nil && reply.Txn.Status != proto.PENDING {
 				tc.cleanupTxn(reply.Txn, nil)
 				return
 			}


### PR DESCRIPTION
a docker push failing has been a source of red builds recently, so better to turn this off just for now. Can always make this a more elaborate retry loop later.

added logic to generally fail a test if anything ends up in `excerpt.log` (major player here: data races we never get to see except on `cockroach/master` because they don't fail the race test, whyever that happens).
