### PR TITLE
Fix bug in clientCodec.WriteRequest and serverCodec.WriteResponse.

### DIFF
--- a/rpc/codec/message.pb/arith.pb.go
+++ b/rpc/codec/message.pb/arith.pb.go
@@ -18,7 +18,7 @@ package message
 import proto "github.com/gogo/protobuf/proto"
 import math "math"
 
-// discarding unused import gogoproto "code.google.com/p/gogoprotobuf/gogoproto/gogo.pb"
+// discarding unused import gogoproto "github.com/gogo/protobuf/gogoproto/gogo.pb"
 
 // Reference imports to suppress errors if they are not otherwise used.
 var _ = proto.Marshal

--- a/rpc/codec/message.pb/echo.pb.go
+++ b/rpc/codec/message.pb/echo.pb.go
@@ -7,7 +7,11 @@ package message
 import proto "github.com/gogo/protobuf/proto"
 import math "math"
 
-// discarding unused import gogoproto "code.google.com/p/gogoprotobuf/gogoproto/gogo.pb"
+// discarding unused import gogoproto "github.com/gogo/protobuf/gogoproto/gogo.pb"
+
+import io "io"
+import fmt "fmt"
+import github_com_gogo_protobuf_proto "github.com/gogo/protobuf/proto"
 
 // Reference imports to suppress errors if they are not otherwise used.
 var _ = proto.Marshal
@@ -46,4 +50,244 @@ func (m *EchoResponse) GetMsg() string {
 }
 
 func init() {
+}
+func (m *EchoRequest) Unmarshal(data []byte) error {
+	l := len(data)
+	index := 0
+	for index < l {
+		var wire uint64
+		for shift := uint(0); ; shift += 7 {
+			if index >= l {
+				return io.ErrUnexpectedEOF
+			}
+			b := data[index]
+			index++
+			wire |= (uint64(b) & 0x7F) << shift
+			if b < 0x80 {
+				break
+			}
+		}
+		fieldNum := int32(wire >> 3)
+		wireType := int(wire & 0x7)
+		switch fieldNum {
+		case 1:
+			if wireType != 2 {
+				return fmt.Errorf("proto: wrong wireType = %d for field Msg", wireType)
+			}
+			var stringLen uint64
+			for shift := uint(0); ; shift += 7 {
+				if index >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := data[index]
+				index++
+				stringLen |= (uint64(b) & 0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			postIndex := index + int(stringLen)
+			if postIndex > l {
+				return io.ErrUnexpectedEOF
+			}
+			m.Msg = string(data[index:postIndex])
+			index = postIndex
+		default:
+			var sizeOfWire int
+			for {
+				sizeOfWire++
+				wire >>= 7
+				if wire == 0 {
+					break
+				}
+			}
+			index -= sizeOfWire
+			skippy, err := github_com_gogo_protobuf_proto.Skip(data[index:])
+			if err != nil {
+				return err
+			}
+			if (index + skippy) > l {
+				return io.ErrUnexpectedEOF
+			}
+			m.XXX_unrecognized = append(m.XXX_unrecognized, data[index:index+skippy]...)
+			index += skippy
+		}
+	}
+	return nil
+}
+func (m *EchoResponse) Unmarshal(data []byte) error {
+	l := len(data)
+	index := 0
+	for index < l {
+		var wire uint64
+		for shift := uint(0); ; shift += 7 {
+			if index >= l {
+				return io.ErrUnexpectedEOF
+			}
+			b := data[index]
+			index++
+			wire |= (uint64(b) & 0x7F) << shift
+			if b < 0x80 {
+				break
+			}
+		}
+		fieldNum := int32(wire >> 3)
+		wireType := int(wire & 0x7)
+		switch fieldNum {
+		case 1:
+			if wireType != 2 {
+				return fmt.Errorf("proto: wrong wireType = %d for field Msg", wireType)
+			}
+			var stringLen uint64
+			for shift := uint(0); ; shift += 7 {
+				if index >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := data[index]
+				index++
+				stringLen |= (uint64(b) & 0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			postIndex := index + int(stringLen)
+			if postIndex > l {
+				return io.ErrUnexpectedEOF
+			}
+			m.Msg = string(data[index:postIndex])
+			index = postIndex
+		default:
+			var sizeOfWire int
+			for {
+				sizeOfWire++
+				wire >>= 7
+				if wire == 0 {
+					break
+				}
+			}
+			index -= sizeOfWire
+			skippy, err := github_com_gogo_protobuf_proto.Skip(data[index:])
+			if err != nil {
+				return err
+			}
+			if (index + skippy) > l {
+				return io.ErrUnexpectedEOF
+			}
+			m.XXX_unrecognized = append(m.XXX_unrecognized, data[index:index+skippy]...)
+			index += skippy
+		}
+	}
+	return nil
+}
+func (m *EchoRequest) Size() (n int) {
+	var l int
+	_ = l
+	l = len(m.Msg)
+	n += 1 + l + sovEcho(uint64(l))
+	if m.XXX_unrecognized != nil {
+		n += len(m.XXX_unrecognized)
+	}
+	return n
+}
+
+func (m *EchoResponse) Size() (n int) {
+	var l int
+	_ = l
+	l = len(m.Msg)
+	n += 1 + l + sovEcho(uint64(l))
+	if m.XXX_unrecognized != nil {
+		n += len(m.XXX_unrecognized)
+	}
+	return n
+}
+
+func sovEcho(x uint64) (n int) {
+	for {
+		n++
+		x >>= 7
+		if x == 0 {
+			break
+		}
+	}
+	return n
+}
+func sozEcho(x uint64) (n int) {
+	return sovEcho(uint64((x << 1) ^ uint64((int64(x) >> 63))))
+}
+func (m *EchoRequest) Marshal() (data []byte, err error) {
+	size := m.Size()
+	data = make([]byte, size)
+	n, err := m.MarshalTo(data)
+	if err != nil {
+		return nil, err
+	}
+	return data[:n], nil
+}
+
+func (m *EchoRequest) MarshalTo(data []byte) (n int, err error) {
+	var i int
+	_ = i
+	var l int
+	_ = l
+	data[i] = 0xa
+	i++
+	i = encodeVarintEcho(data, i, uint64(len(m.Msg)))
+	i += copy(data[i:], m.Msg)
+	if m.XXX_unrecognized != nil {
+		i += copy(data[i:], m.XXX_unrecognized)
+	}
+	return i, nil
+}
+
+func (m *EchoResponse) Marshal() (data []byte, err error) {
+	size := m.Size()
+	data = make([]byte, size)
+	n, err := m.MarshalTo(data)
+	if err != nil {
+		return nil, err
+	}
+	return data[:n], nil
+}
+
+func (m *EchoResponse) MarshalTo(data []byte) (n int, err error) {
+	var i int
+	_ = i
+	var l int
+	_ = l
+	data[i] = 0xa
+	i++
+	i = encodeVarintEcho(data, i, uint64(len(m.Msg)))
+	i += copy(data[i:], m.Msg)
+	if m.XXX_unrecognized != nil {
+		i += copy(data[i:], m.XXX_unrecognized)
+	}
+	return i, nil
+}
+
+func encodeFixed64Echo(data []byte, offset int, v uint64) int {
+	data[offset] = uint8(v)
+	data[offset+1] = uint8(v >> 8)
+	data[offset+2] = uint8(v >> 16)
+	data[offset+3] = uint8(v >> 24)
+	data[offset+4] = uint8(v >> 32)
+	data[offset+5] = uint8(v >> 40)
+	data[offset+6] = uint8(v >> 48)
+	data[offset+7] = uint8(v >> 56)
+	return offset + 8
+}
+func encodeFixed32Echo(data []byte, offset int, v uint32) int {
+	data[offset] = uint8(v)
+	data[offset+1] = uint8(v >> 8)
+	data[offset+2] = uint8(v >> 16)
+	data[offset+3] = uint8(v >> 24)
+	return offset + 4
+}
+func encodeVarintEcho(data []byte, offset int, v uint64) int {
+	for v >= 1<<7 {
+		data[offset] = uint8(v&0x7f | 0x80)
+		v >>= 7
+		offset++
+	}
+	data[offset] = uint8(v)
+	return offset + 1
 }

--- a/rpc/codec/message.pb/echo.proto
+++ b/rpc/codec/message.pb/echo.proto
@@ -6,6 +6,10 @@ package message;
 
 import "github.com/gogo/protobuf/gogoproto/gogo.proto";
 
+option (gogoproto.sizer_all) = true;
+option (gogoproto.marshaler_all) = true;
+option (gogoproto.unmarshaler_all) = true;
+
 message EchoRequest {
 	optional string msg = 1 [(gogoproto.nullable) = false];
 }

--- a/rpc/codec/wire.go
+++ b/rpc/codec/wire.go
@@ -5,18 +5,40 @@
 package codec
 
 import (
-	"fmt"
-	"hash/crc32"
+	"bufio"
 	"io"
+	"sync"
 
-	"code.google.com/p/snappy-go/snappy"
 	wire "github.com/cockroachdb/cockroach/rpc/codec/wire.pb"
 	"github.com/gogo/protobuf/proto"
 )
 
+type reqHeaderBuf struct {
+	header wire.RequestHeader
+	data   [256]byte
+}
+
+type respHeaderBuf struct {
+	header wire.ResponseHeader
+	data   [256]byte
+}
+
+var (
+	reqHeaderPool = sync.Pool{
+		New: func() interface{} {
+			return &reqHeaderBuf{}
+		},
+	}
+	respHeaderPool = sync.Pool{
+		New: func() interface{} {
+			return &respHeaderBuf{}
+		},
+	}
+)
+
 func writeRequest(w io.Writer, id uint64, method string, request proto.Message) error {
 	// marshal request
-	pbRequest := []byte{}
+	pbRequest := []byte(nil)
 	if request != nil {
 		var err error
 		pbRequest, err = proto.Marshal(request)
@@ -25,191 +47,115 @@ func writeRequest(w io.Writer, id uint64, method string, request proto.Message) 
 		}
 	}
 
-	// compress serialized proto data
-	compressedPbRequest, err := snappy.Encode(nil, pbRequest)
-	if err != nil {
-		return err
-	}
+	// TODO(pmattis): Snappy compression using go-snappy benchmarks as a
+	// loss. We've got the C++ snappy library linked in to the
+	// library. Should benchmark whether it is significantly faster than
+	// the go version.
 
 	// generate header
-	header := &wire.RequestHeader{
-		Id:                         id,
-		Method:                     method,
-		RawRequestLen:              uint32(len(pbRequest)),
-		SnappyCompressedRequestLen: uint32(len(compressedPbRequest)),
-		Checksum:                   crc32.ChecksumIEEE(compressedPbRequest),
+	buf := reqHeaderPool.Get().(*reqHeaderBuf)
+	header := &buf.header
+	*header = wire.RequestHeader{
+		Id:     id,
+		Method: method,
+	}
+
+	size := header.Size()
+	var pbHeader []byte
+	if size <= len(buf.data) {
+		pbHeader = buf.data[:size]
+	} else {
+		pbHeader = make([]byte, size)
 	}
 
 	// check header size
-	pbHeader, err := proto.Marshal(header)
-	if err != err {
+	_, err := header.MarshalTo(pbHeader)
+	if err != nil {
+		reqHeaderPool.Put(buf)
 		return err
-	}
-	if uint32(len(pbHeader)) > wire.Default_Const_MaxHeaderLen {
-		return fmt.Errorf("protorpc.writeRequest: header larger than max_header_len: %d.", len(pbHeader))
 	}
 
 	// send header (more)
-	if err := sendFrame(w, pbHeader); err != nil {
+	err = sendFrame(w, pbHeader)
+	reqHeaderPool.Put(buf)
+	if err != nil {
 		return err
 	}
 
 	// send body (end)
-	if err := sendFrame(w, compressedPbRequest); err != nil {
+	if err := sendFrame(w, pbRequest); err != nil {
 		return err
 	}
 
 	return nil
 }
 
-func readRequestHeader(r io.Reader, header *wire.RequestHeader) (err error) {
-	// recv header (more)
-	pbHeader, err := recvFrame(r)
-	if err != nil {
-		return err
-	}
-
-	// Unmarshal Header
-	err = proto.Unmarshal(pbHeader, header)
-	if err != nil {
-		return err
-	}
-
-	return nil
+func readRequestHeader(r *bufio.Reader, header *wire.RequestHeader) error {
+	return recvProto(r, header)
 }
 
-func readRequestBody(r io.Reader, header *wire.RequestHeader, request proto.Message) error {
-	// recv body (end)
-	compressedPbRequest, err := recvFrame(r)
-	if err != nil {
-		return err
-	}
-
-	// checksum
-	if crc32.ChecksumIEEE(compressedPbRequest) != header.GetChecksum() {
-		return fmt.Errorf("protorpc.readRequestBody: unexpected checksum.")
-	}
-
-	// decode the compressed data
-	pbRequest, err := snappy.Decode(nil, compressedPbRequest)
-	if err != nil {
-		return err
-	}
-	// check wire header: rawMsgLen
-	if uint32(len(pbRequest)) != header.GetRawRequestLen() {
-		return fmt.Errorf("protorpc.readRequestBody: Unexcpeted header.RawRequestLen.")
-	}
-
-	// Unmarshal to proto message
-	if request != nil {
-		err = proto.Unmarshal(pbRequest, request)
-		if err != nil {
-			return err
-		}
-	}
-
-	return nil
+func readRequestBody(r *bufio.Reader, request proto.Message) error {
+	return recvProto(r, request)
 }
 
-func writeResponse(w io.Writer, id uint64, serr string, response proto.Message) (err error) {
+func writeResponse(w io.Writer, id uint64, serr string, response proto.Message) error {
 	// clean response if error
 	if serr != "" {
 		response = nil
 	}
 
 	// marshal response
-	pbResponse := []byte{}
+	pbResponse := []byte(nil)
 	if response != nil {
+		var err error
 		pbResponse, err = proto.Marshal(response)
 		if err != nil {
 			return err
 		}
 	}
 
-	// compress serialized proto data
-	compressedPbResponse, err := snappy.Encode(nil, pbResponse)
-	if err != nil {
-		return err
+	// generate header
+	buf := respHeaderPool.Get().(*respHeaderBuf)
+	header := &buf.header
+	*header = wire.ResponseHeader{
+		Id:    id,
+		Error: serr,
 	}
 
-	// generate header
-	header := &wire.ResponseHeader{
-		Id:                          id,
-		Error:                       serr,
-		RawResponseLen:              uint32(len(pbResponse)),
-		SnappyCompressedResponseLen: uint32(len(compressedPbResponse)),
-		Checksum:                    crc32.ChecksumIEEE(compressedPbResponse),
+	size := header.Size()
+	var pbHeader []byte
+	if size <= len(buf.data) {
+		pbHeader = buf.data[:size]
+	} else {
+		pbHeader = make([]byte, size)
 	}
 
 	// check header size
-	pbHeader, err := proto.Marshal(header)
-	if err != err {
-		return
-	}
-	if uint32(len(pbHeader)) > wire.Default_Const_MaxHeaderLen {
-		return fmt.Errorf("protorpc.writeResponse: header larger than max_header_len: %d.",
-			len(pbHeader),
-		)
+	_, err := header.MarshalTo(pbHeader)
+	if err != nil {
+		respHeaderPool.Put(buf)
+		return err
 	}
 
 	// send header (more)
-	if err = sendFrame(w, pbHeader); err != nil {
-		return
+	err = sendFrame(w, pbHeader)
+	respHeaderPool.Put(buf)
+	if err != nil {
+		return err
 	}
 
 	// send body (end)
-	if err = sendFrame(w, compressedPbResponse); err != nil {
-		return
-	}
-
-	return nil
-}
-
-func readResponseHeader(r io.Reader, header *wire.ResponseHeader) error {
-	// recv header (more)
-	pbHeader, err := recvFrame(r)
-	if err != nil {
-		return err
-	}
-
-	// Marshal Header
-	err = proto.Unmarshal(pbHeader, header)
-	if err != nil {
+	if err = sendFrame(w, pbResponse); err != nil {
 		return err
 	}
 
 	return nil
 }
 
-func readResponseBody(r io.Reader, header *wire.ResponseHeader, response proto.Message) error {
-	// recv body (end)
-	compressedPbResponse, err := recvFrame(r)
-	if err != nil {
-		return err
-	}
+func readResponseHeader(r *bufio.Reader, header *wire.ResponseHeader) error {
+	return recvProto(r, header)
+}
 
-	// checksum
-	if crc32.ChecksumIEEE(compressedPbResponse) != header.GetChecksum() {
-		return fmt.Errorf("protorpc.readResponseBody: unexpected checksum.")
-	}
-
-	// decode the compressed data
-	pbResponse, err := snappy.Decode(nil, compressedPbResponse)
-	if err != nil {
-		return err
-	}
-	// check wire header: rawMsgLen
-	if uint32(len(pbResponse)) != header.GetRawResponseLen() {
-		return fmt.Errorf("protorpc.readResponseBody: Unexcpeted header.RawResponseLen.")
-	}
-
-	// Unmarshal to proto message
-	if response != nil {
-		err = proto.Unmarshal(pbResponse, response)
-		if err != nil {
-			return err
-		}
-	}
-
-	return nil
+func readResponseBody(r *bufio.Reader, response proto.Message) error {
+	return recvProto(r, response)
 }

--- a/rpc/codec/wire.pb/wire.pb.go
+++ b/rpc/codec/wire.pb/wire.pb.go
@@ -3,78 +3,56 @@
 // DO NOT EDIT!
 
 /*
-Package google_protobuf_rpc_wire is a generated protocol buffer package.
+	Package wire is a generated protocol buffer package.
 
-	protorpc wire format wrapper
+		protorpc wire format wrapper
 
-	0. Frame Format
-	len : uvarint64
-	data: byte[len]
+		0. Frame Format
+		len : uvarint64
+		data: byte[len]
 
-	1. Client Send Request
-	Send RequestHeader: sendFrame(conn, hdr, len(hdr))
-	Send Request: sendFrame(conn, body, hdr.snappy_compressed_request_len)
+		1. Client Send Request
+		Send RequestHeader: sendFrame(conn, hdr, len(hdr))
+		Send Request: sendFrame(conn, body, len(body))
 
-	2. Server Recv Request
-	Recv RequestHeader: recvFrame(conn, hdr, max_hdr_len, 0)
-	Recv Request: recvFrame(conn, body, hdr.snappy_compressed_request_len, 0)
+		2. Server Recv Request
+		Recv RequestHeader: recvFrame(conn, hdr, max_hdr_len, 0)
+		Recv Request: recvFrame(conn, body)
 
-	3. Server Send Response
-	Send ResponseHeader: sendFrame(conn, hdr, len(hdr))
-	Send Response: sendFrame(conn, body, hdr.snappy_compressed_response_len)
+		3. Server Send Response
+		Send ResponseHeader: sendFrame(conn, hdr, len(hdr))
+		Send Response: sendFrame(conn, body, len(body))
 
-	4. Client Recv Response
-	Recv ResponseHeader: recvFrame(conn, hdr, max_hdr_len, 0)
-	Recv Response: recvFrame(conn, body, hdr.snappy_compressed_response_len, 0)
+		4. Client Recv Response
+		Recv ResponseHeader: recvFrame(conn, hdr, max_hdr_len, 0)
+		Recv Response: recvFrame(conn, body)
 
-	5. Header Size
-	len(RequestHeader)  < Const.max_header_len.default
-	len(ResponseHeader) < Const.max_header_len.default
+	It is generated from these files:
+		wire.proto
 
-It is generated from these files:
-	wire.proto
-
-It has these top-level messages:
-	Const
-	RequestHeader
-	ResponseHeader
+	It has these top-level messages:
+		RequestHeader
+		ResponseHeader
 */
-package google_protobuf_rpc_wire
+package wire
 
 import proto "github.com/gogo/protobuf/proto"
 import math "math"
 
-// discarding unused import gogoproto "code.google.com/p/gogoprotobuf/gogoproto/gogo.pb"
+// discarding unused import gogoproto "github.com/gogo/protobuf/gogoproto/gogo.pb"
+
+import io "io"
+import fmt "fmt"
+import github_com_gogo_protobuf_proto "github.com/gogo/protobuf/proto"
 
 // Reference imports to suppress errors if they are not otherwise used.
 var _ = proto.Marshal
 var _ = math.Inf
 
-type Const struct {
-	MaxHeaderLen     *uint32 `protobuf:"varint,1,opt,name=max_header_len,def=1024" json:"max_header_len,omitempty"`
-	XXX_unrecognized []byte  `json:"-"`
-}
-
-func (m *Const) Reset()         { *m = Const{} }
-func (m *Const) String() string { return proto.CompactTextString(m) }
-func (*Const) ProtoMessage()    {}
-
-const Default_Const_MaxHeaderLen uint32 = 1024
-
-func (m *Const) GetMaxHeaderLen() uint32 {
-	if m != nil && m.MaxHeaderLen != nil {
-		return *m.MaxHeaderLen
-	}
-	return Default_Const_MaxHeaderLen
-}
-
 type RequestHeader struct {
-	Id                         uint64 `protobuf:"varint,1,opt,name=id" json:"id"`
-	Method                     string `protobuf:"bytes,2,opt,name=method" json:"method"`
-	RawRequestLen              uint32 `protobuf:"varint,3,opt,name=raw_request_len" json:"raw_request_len"`
-	SnappyCompressedRequestLen uint32 `protobuf:"varint,4,opt,name=snappy_compressed_request_len" json:"snappy_compressed_request_len"`
-	Checksum                   uint32 `protobuf:"varint,5,opt,name=checksum" json:"checksum"`
-	XXX_unrecognized           []byte `json:"-"`
+	Id               uint64 `protobuf:"varint,1,opt,name=id" json:"id"`
+	Method           string `protobuf:"bytes,2,opt,name=method" json:"method"`
+	XXX_unrecognized []byte `json:"-"`
 }
 
 func (m *RequestHeader) Reset()         { *m = RequestHeader{} }
@@ -95,34 +73,10 @@ func (m *RequestHeader) GetMethod() string {
 	return ""
 }
 
-func (m *RequestHeader) GetRawRequestLen() uint32 {
-	if m != nil {
-		return m.RawRequestLen
-	}
-	return 0
-}
-
-func (m *RequestHeader) GetSnappyCompressedRequestLen() uint32 {
-	if m != nil {
-		return m.SnappyCompressedRequestLen
-	}
-	return 0
-}
-
-func (m *RequestHeader) GetChecksum() uint32 {
-	if m != nil {
-		return m.Checksum
-	}
-	return 0
-}
-
 type ResponseHeader struct {
-	Id                          uint64 `protobuf:"varint,1,opt,name=id" json:"id"`
-	Error                       string `protobuf:"bytes,2,opt,name=error" json:"error"`
-	RawResponseLen              uint32 `protobuf:"varint,3,opt,name=raw_response_len" json:"raw_response_len"`
-	SnappyCompressedResponseLen uint32 `protobuf:"varint,4,opt,name=snappy_compressed_response_len" json:"snappy_compressed_response_len"`
-	Checksum                    uint32 `protobuf:"varint,5,opt,name=checksum" json:"checksum"`
-	XXX_unrecognized            []byte `json:"-"`
+	Id               uint64 `protobuf:"varint,1,opt,name=id" json:"id"`
+	Error            string `protobuf:"bytes,2,opt,name=error" json:"error"`
+	XXX_unrecognized []byte `json:"-"`
 }
 
 func (m *ResponseHeader) Reset()         { *m = ResponseHeader{} }
@@ -143,26 +97,283 @@ func (m *ResponseHeader) GetError() string {
 	return ""
 }
 
-func (m *ResponseHeader) GetRawResponseLen() uint32 {
-	if m != nil {
-		return m.RawResponseLen
-	}
-	return 0
-}
-
-func (m *ResponseHeader) GetSnappyCompressedResponseLen() uint32 {
-	if m != nil {
-		return m.SnappyCompressedResponseLen
-	}
-	return 0
-}
-
-func (m *ResponseHeader) GetChecksum() uint32 {
-	if m != nil {
-		return m.Checksum
-	}
-	return 0
-}
-
 func init() {
+}
+func (m *RequestHeader) Unmarshal(data []byte) error {
+	l := len(data)
+	index := 0
+	for index < l {
+		var wire uint64
+		for shift := uint(0); ; shift += 7 {
+			if index >= l {
+				return io.ErrUnexpectedEOF
+			}
+			b := data[index]
+			index++
+			wire |= (uint64(b) & 0x7F) << shift
+			if b < 0x80 {
+				break
+			}
+		}
+		fieldNum := int32(wire >> 3)
+		wireType := int(wire & 0x7)
+		switch fieldNum {
+		case 1:
+			if wireType != 0 {
+				return fmt.Errorf("proto: wrong wireType = %d for field Id", wireType)
+			}
+			for shift := uint(0); ; shift += 7 {
+				if index >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := data[index]
+				index++
+				m.Id |= (uint64(b) & 0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+		case 2:
+			if wireType != 2 {
+				return fmt.Errorf("proto: wrong wireType = %d for field Method", wireType)
+			}
+			var stringLen uint64
+			for shift := uint(0); ; shift += 7 {
+				if index >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := data[index]
+				index++
+				stringLen |= (uint64(b) & 0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			postIndex := index + int(stringLen)
+			if postIndex > l {
+				return io.ErrUnexpectedEOF
+			}
+			m.Method = string(data[index:postIndex])
+			index = postIndex
+		default:
+			var sizeOfWire int
+			for {
+				sizeOfWire++
+				wire >>= 7
+				if wire == 0 {
+					break
+				}
+			}
+			index -= sizeOfWire
+			skippy, err := github_com_gogo_protobuf_proto.Skip(data[index:])
+			if err != nil {
+				return err
+			}
+			if (index + skippy) > l {
+				return io.ErrUnexpectedEOF
+			}
+			m.XXX_unrecognized = append(m.XXX_unrecognized, data[index:index+skippy]...)
+			index += skippy
+		}
+	}
+	return nil
+}
+func (m *ResponseHeader) Unmarshal(data []byte) error {
+	l := len(data)
+	index := 0
+	for index < l {
+		var wire uint64
+		for shift := uint(0); ; shift += 7 {
+			if index >= l {
+				return io.ErrUnexpectedEOF
+			}
+			b := data[index]
+			index++
+			wire |= (uint64(b) & 0x7F) << shift
+			if b < 0x80 {
+				break
+			}
+		}
+		fieldNum := int32(wire >> 3)
+		wireType := int(wire & 0x7)
+		switch fieldNum {
+		case 1:
+			if wireType != 0 {
+				return fmt.Errorf("proto: wrong wireType = %d for field Id", wireType)
+			}
+			for shift := uint(0); ; shift += 7 {
+				if index >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := data[index]
+				index++
+				m.Id |= (uint64(b) & 0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+		case 2:
+			if wireType != 2 {
+				return fmt.Errorf("proto: wrong wireType = %d for field Error", wireType)
+			}
+			var stringLen uint64
+			for shift := uint(0); ; shift += 7 {
+				if index >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := data[index]
+				index++
+				stringLen |= (uint64(b) & 0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			postIndex := index + int(stringLen)
+			if postIndex > l {
+				return io.ErrUnexpectedEOF
+			}
+			m.Error = string(data[index:postIndex])
+			index = postIndex
+		default:
+			var sizeOfWire int
+			for {
+				sizeOfWire++
+				wire >>= 7
+				if wire == 0 {
+					break
+				}
+			}
+			index -= sizeOfWire
+			skippy, err := github_com_gogo_protobuf_proto.Skip(data[index:])
+			if err != nil {
+				return err
+			}
+			if (index + skippy) > l {
+				return io.ErrUnexpectedEOF
+			}
+			m.XXX_unrecognized = append(m.XXX_unrecognized, data[index:index+skippy]...)
+			index += skippy
+		}
+	}
+	return nil
+}
+func (m *RequestHeader) Size() (n int) {
+	var l int
+	_ = l
+	n += 1 + sovWire(uint64(m.Id))
+	l = len(m.Method)
+	n += 1 + l + sovWire(uint64(l))
+	if m.XXX_unrecognized != nil {
+		n += len(m.XXX_unrecognized)
+	}
+	return n
+}
+
+func (m *ResponseHeader) Size() (n int) {
+	var l int
+	_ = l
+	n += 1 + sovWire(uint64(m.Id))
+	l = len(m.Error)
+	n += 1 + l + sovWire(uint64(l))
+	if m.XXX_unrecognized != nil {
+		n += len(m.XXX_unrecognized)
+	}
+	return n
+}
+
+func sovWire(x uint64) (n int) {
+	for {
+		n++
+		x >>= 7
+		if x == 0 {
+			break
+		}
+	}
+	return n
+}
+func sozWire(x uint64) (n int) {
+	return sovWire(uint64((x << 1) ^ uint64((int64(x) >> 63))))
+}
+func (m *RequestHeader) Marshal() (data []byte, err error) {
+	size := m.Size()
+	data = make([]byte, size)
+	n, err := m.MarshalTo(data)
+	if err != nil {
+		return nil, err
+	}
+	return data[:n], nil
+}
+
+func (m *RequestHeader) MarshalTo(data []byte) (n int, err error) {
+	var i int
+	_ = i
+	var l int
+	_ = l
+	data[i] = 0x8
+	i++
+	i = encodeVarintWire(data, i, uint64(m.Id))
+	data[i] = 0x12
+	i++
+	i = encodeVarintWire(data, i, uint64(len(m.Method)))
+	i += copy(data[i:], m.Method)
+	if m.XXX_unrecognized != nil {
+		i += copy(data[i:], m.XXX_unrecognized)
+	}
+	return i, nil
+}
+
+func (m *ResponseHeader) Marshal() (data []byte, err error) {
+	size := m.Size()
+	data = make([]byte, size)
+	n, err := m.MarshalTo(data)
+	if err != nil {
+		return nil, err
+	}
+	return data[:n], nil
+}
+
+func (m *ResponseHeader) MarshalTo(data []byte) (n int, err error) {
+	var i int
+	_ = i
+	var l int
+	_ = l
+	data[i] = 0x8
+	i++
+	i = encodeVarintWire(data, i, uint64(m.Id))
+	data[i] = 0x12
+	i++
+	i = encodeVarintWire(data, i, uint64(len(m.Error)))
+	i += copy(data[i:], m.Error)
+	if m.XXX_unrecognized != nil {
+		i += copy(data[i:], m.XXX_unrecognized)
+	}
+	return i, nil
+}
+
+func encodeFixed64Wire(data []byte, offset int, v uint64) int {
+	data[offset] = uint8(v)
+	data[offset+1] = uint8(v >> 8)
+	data[offset+2] = uint8(v >> 16)
+	data[offset+3] = uint8(v >> 24)
+	data[offset+4] = uint8(v >> 32)
+	data[offset+5] = uint8(v >> 40)
+	data[offset+6] = uint8(v >> 48)
+	data[offset+7] = uint8(v >> 56)
+	return offset + 8
+}
+func encodeFixed32Wire(data []byte, offset int, v uint32) int {
+	data[offset] = uint8(v)
+	data[offset+1] = uint8(v >> 8)
+	data[offset+2] = uint8(v >> 16)
+	data[offset+3] = uint8(v >> 24)
+	return offset + 4
+}
+func encodeVarintWire(data []byte, offset int, v uint64) int {
+	for v >= 1<<7 {
+		data[offset] = uint8(v&0x7f | 0x80)
+		v >>= 7
+		offset++
+	}
+	data[offset] = uint8(v)
+	return offset + 1
 }

--- a/rpc/codec/wire.pb/wire.proto
+++ b/rpc/codec/wire.pb/wire.proto
@@ -10,45 +10,33 @@
 //
 //	1. Client Send Request
 //	Send RequestHeader: sendFrame(conn, hdr, len(hdr))
-//	Send Request: sendFrame(conn, body, hdr.snappy_compressed_request_len)
+//	Send Request: sendFrame(conn, body, len(body))
 //
 //	2. Server Recv Request
 //	Recv RequestHeader: recvFrame(conn, hdr, max_hdr_len, 0)
-//	Recv Request: recvFrame(conn, body, hdr.snappy_compressed_request_len, 0)
+//	Recv Request: recvFrame(conn, body)
 //
 //	3. Server Send Response
 //	Send ResponseHeader: sendFrame(conn, hdr, len(hdr))
-//	Send Response: sendFrame(conn, body, hdr.snappy_compressed_response_len)
+//	Send Response: sendFrame(conn, body, len(body))
 //
 //	4. Client Recv Response
 //	Recv ResponseHeader: recvFrame(conn, hdr, max_hdr_len, 0)
-//	Recv Response: recvFrame(conn, body, hdr.snappy_compressed_response_len, 0)
-//
-//	5. Header Size
-//	len(RequestHeader)  < Const.max_header_len.default
-//	len(ResponseHeader) < Const.max_header_len.default
+//	Recv Response: recvFrame(conn, body)
 package wire;
 
 import "github.com/gogo/protobuf/gogoproto/gogo.proto";
 
-message Const {
-  optional uint32 max_header_len = 1 [default = 1024];
-}
+option (gogoproto.sizer_all) = true;
+option (gogoproto.marshaler_all) = true;
+option (gogoproto.unmarshaler_all) = true;
 
 message RequestHeader {
 	optional uint64 id = 1 [(gogoproto.nullable) = false];
 	optional string method = 2 [(gogoproto.nullable) = false];
-
-	optional uint32 raw_request_len = 3 [(gogoproto.nullable) = false];
-	optional uint32 snappy_compressed_request_len = 4 [(gogoproto.nullable) = false];
-	optional uint32 checksum = 5 [(gogoproto.nullable) = false];
 }
 
 message ResponseHeader {
 	optional uint64 id = 1 [(gogoproto.nullable) = false];
 	optional string error = 2 [(gogoproto.nullable) = false];
-
-	optional uint32 raw_response_len = 3 [(gogoproto.nullable) = false];
-	optional uint32 snappy_compressed_response_len = 4 [(gogoproto.nullable) = false];
-	optional uint32 checksum = 5 [(gogoproto.nullable) = false];
 }


### PR DESCRIPTION
WriteRequest and WriteResponse need to be safe for concurrent use. Both
were writing out the header and body of a request to the underlying conn
without proper locking which would allow interleaving of the data.

Discovered this as part of some network optimization work which is also
present in this change. Wrap bufio readers and writers around the
connection. Use the optimized marshalers and unmarshalers for the
request and response headers. Remove snappy compression which benchmarks
as a pure loss (presumably due to the Go implementation). Removed
checksumming of the body which isn't present in the other Go rpc codecs
and doesn't seem worthwhile given we have end-to-end checksums of user
data along with the TCP checksums. Reduced allocations in various
network code paths.

benchmark              old ns/op     new ns/op     delta
BenchmarkEchoGoRPC     45062         43120         -4.31%
BenchmarkEchoRPC       101950        38029         -62.70%

benchmark              old MB/s     new MB/s     speedup
BenchmarkEchoGoRPC     22.72        23.75        1.05x
BenchmarkEchoRPC       10.04        26.93        2.68x
