### PR TITLE
Allow the full 32-bit range of store IDs in raft node IDs.

### DIFF
--- a/storage/store.go
+++ b/storage/store.go
@@ -125,8 +125,6 @@ func verifyKeys(start, end proto.Key) error {
 }
 
 // MakeRaftNodeID packs a NodeID and StoreID into a single uint64 for use in raft.
-// Both values are int32s, but we only allocate 8 bits for StoreID so we have
-// the option of expanding proto.NodeID and being more "wasteful" of node IDs.
 func MakeRaftNodeID(n proto.NodeID, s proto.StoreID) multiraft.NodeID {
 	if n < 0 || s <= 0 {
 		// Zeroes are likely the result of incomplete initialization.
@@ -134,15 +132,12 @@ func MakeRaftNodeID(n proto.NodeID, s proto.StoreID) multiraft.NodeID {
 		// production but many tests use it.
 		panic("NodeID must be >= 0 and StoreID must be > 0")
 	}
-	if s > 0xff {
-		panic("StoreID must be <= 0xff")
-	}
-	return multiraft.NodeID(n)<<8 | multiraft.NodeID(s)
+	return multiraft.NodeID(n)<<32 | multiraft.NodeID(s)
 }
 
 // DecodeRaftNodeID converts a multiraft NodeID into its component NodeID and StoreID.
 func DecodeRaftNodeID(n multiraft.NodeID) (proto.NodeID, proto.StoreID) {
-	return proto.NodeID(n >> 8), proto.StoreID(n & 0xff)
+	return proto.NodeID(n >> 32), proto.StoreID(n & 0xffffffff)
 }
 
 type rangeAlreadyExists struct {

--- a/storage/store_test.go
+++ b/storage/store_test.go
@@ -1049,9 +1049,9 @@ func TestRaftNodeID(t *testing.T) {
 		expected multiraft.NodeID
 	}{
 		{0, 1, 1},
-		{1, 1, 257},
-		{2, 3, 515},
-		{math.MaxInt32, 0xff, 549755813887},
+		{1, 1, 0x100000001},
+		{2, 3, 0x200000003},
+		{math.MaxInt32, math.MaxInt32, 0x7fffffff7fffffff},
 	}
 	for _, c := range cases {
 		x := MakeRaftNodeID(c.nodeID, c.storeID)
@@ -1071,7 +1071,6 @@ func TestRaftNodeID(t *testing.T) {
 		storeID proto.StoreID
 	}{
 		{1, 0},
-		{1, 0x100},
 		{1, -1},
 		{-1, 1},
 	}


### PR DESCRIPTION
Closes #603.
