### PR TITLE
Small fix for multi-store bootstrap

### DIFF
--- a/server/node.go
+++ b/server/node.go
@@ -306,7 +306,12 @@ func (n *Node) bootstrapStores(bootstraps *list.List) {
 	}
 	for e := bootstraps.Front(); e != nil; e = e.Next() {
 		s := e.Value.(*storage.Store)
-		s.Bootstrap(sIdent)
+		if err := s.Bootstrap(sIdent); err != nil {
+			log.Fatal(err)
+		}
+		if err := s.Start(); err != nil {
+			log.Fatal(err)
+		}
 		n.lSender.AddStore(s)
 		sIdent.StoreID++
 		log.Infof("bootstrapped store %s", s)

--- a/storage/store.go
+++ b/storage/store.go
@@ -319,6 +319,8 @@ type Store struct {
 	mu          sync.RWMutex     // Protects variables below...
 	ranges      map[int64]*Range // Map of ranges by Raft ID
 	rangesByKey RangeSlice       // Sorted slice of ranges by StartKey
+
+	Started bool // Flag to indicate if the store is started completely
 }
 
 var _ multiraft.Storage = &Store{}
@@ -367,6 +369,7 @@ func (s *Store) Stop() {
 	}
 	s.stopper.Stop()
 	s.engine.Stop()
+	s.Started = false
 }
 
 // String formats a store for debug output.
@@ -486,6 +489,7 @@ func (s *Store) Start() error {
 		s.gossip.RegisterCallback(capacityRegex, s.capacityGossipUpdate)
 	}
 
+	s.Started = true
 	return nil
 }
 


### PR DESCRIPTION
When initializing node with multiple stores, Node.initStores() will call Start() for every stores, but only the bootstrapped store can be started (the first store in single node context), and the unbootstrapped stores will be put to the background bootstrap list,  then the following Node.bootstrapStores() will bootstrap the stores in the list.
Now the problem is Node.bootstrapStores() only bootstraps the stores, but does not start them, so the multiraft field in the store is not initialized also, maybe we need to call Start() for the store after it is bootstrapped, to make it start completely. 
