### PR TITLE
Fix txn commitment fail with TimestampRegression error

### DIFF
--- a/kv/txn_correctness_test.go
+++ b/kv/txn_correctness_test.go
@@ -777,3 +777,32 @@ func TestTxnDBWriteSkewAnomaly(t *testing.T) {
 	checkConcurrency("write skew", onlySerializable, []string{txn1, txn2}, verify, true, t)
 	checkConcurrency("write skew", onlySnapshot, []string{txn1, txn2}, verify, false, t)
 }
+
+// TestTxnTimestampRegression verifies that SI failed with TimestampRegression.
+// When both Txn's timestamp in system transaction table being pushed and Txn's
+// timestamp in Request being pushed, Txn's commitment will fail because of
+// TimestampRegression error.
+// Just check the following txn sequence:
+// ------ts1----ts2------ts3---ts4----ts5-----
+// txn1: I(A)                  I(B)    C
+// txn2:        R(A)
+// txn3:                R(B)
+// In this sequence, txn2 "R(A)" will push txn1's timestamp in system
+// transaction table to ts2. After txn3 "R(B)", timestamp_cache for key(B) ts3
+// will be stored, so txn1 "I(B)" will generate a response with pushed timestamp
+// as ts3.
+// When txn1 commit, the EndTransaction request will get a TimestampRegression
+// error.
+func TestTxntimestampRegression(t *testing.T) {
+	txn1 := "I(A) I(B) C"
+	txn2 := "R(A) C"
+	txn3 := "R(B) C"
+
+	verify := &verifier{
+		history: "R(A) R(B)",
+		checkFn: func(env map[string]int64) error {
+			return nil
+		},
+	}
+	checkConcurrency("TimestampRegression", onlySnapshot, []string{txn1, txn2, txn3}, verify, true, t)
+}

--- a/kv/txn_test.go
+++ b/kv/txn_test.go
@@ -439,11 +439,11 @@ func TestUncertaintyMaxTimestampForwarding(t *testing.T) {
 // commit. A bug in the EndTransaction implementation used to compare
 // the transaction's current timestamp instead of original timestamp.
 func TestTxnTimestampRegression(t *testing.T) {
-	db, _, _, _, _, transport, err := createTestDB()
+	db, _, _, _, _, stopper, err := createTestDB()
 	if err != nil {
 		t.Fatal(err)
 	}
-	defer transport.Close()
+	defer stopper.Stop()
 
 	keyA := proto.Key("a")
 	keyB := proto.Key("b")

--- a/storage/range.go
+++ b/storage/range.go
@@ -986,8 +986,8 @@ func (r *Range) EndTransaction(batch engine.Engine, ms *engine.MVCCStats, args *
 		} else if existTxn.Timestamp.Less(args.Txn.OrigTimestamp) {
 			// The transaction record can only ever be pushed forward, so it's an
 			// error if somehow the transaction record has an earlier timestamp
-			// than the transaction timestamp.
-			reply.SetGoError(proto.NewTransactionStatusError(existTxn, fmt.Sprintf("timestamp regression: %s", args.Txn.Timestamp)))
+			// than the original transaction timestamp.
+			reply.SetGoError(proto.NewTransactionStatusError(existTxn, fmt.Sprintf("timestamp regression: %s", args.Txn.OrigTimestamp)))
 			return
 		}
 		// Take max of requested epoch and existing epoch. The requester

--- a/storage/range.go
+++ b/storage/range.go
@@ -983,7 +983,7 @@ func (r *Range) EndTransaction(batch engine.Engine, ms *engine.MVCCStats, args *
 		} else if args.Txn.Epoch < existTxn.Epoch {
 			reply.SetGoError(proto.NewTransactionStatusError(existTxn, fmt.Sprintf("epoch regression: %d", args.Txn.Epoch)))
 			return
-		} else if existTxn.Timestamp.Less(args.Txn.Timestamp) {
+		} else if existTxn.Timestamp.Less(args.Txn.OrigTimestamp) {
 			// The transaction record can only ever be pushed forward, so it's an
 			// error if somehow the transaction record has an earlier timestamp
 			// than the transaction timestamp.


### PR DESCRIPTION
When both Txn's timestamp in system transaction table being pushed and Txn's timestamp in Request being pushed, Txn's commitment will fail because of TimestampRegression error.
