### PR TITLE
Only send the service method once per connection instead of on every RPC.

### DIFF
--- a/rpc/codec/wire.pb/wire.proto
+++ b/rpc/codec/wire.pb/wire.proto
@@ -37,14 +37,15 @@ enum CompressionType {
 }
 
 message RequestHeader {
-	optional uint64 id = 1 [(gogoproto.nullable) = false];
-	optional string method = 2 [(gogoproto.nullable) = false];
-	optional CompressionType compression = 3 [(gogoproto.nullable) = false];
+  optional uint64 id = 1 [(gogoproto.nullable) = false];
+  optional string method = 2;
+  optional int32 method_id = 3 [(gogoproto.nullable) = false];
+  optional CompressionType compression = 4 [(gogoproto.nullable) = false];
 }
 
 message ResponseHeader {
-	optional uint64 id = 1 [(gogoproto.nullable) = false];
-	optional string method = 2 [(gogoproto.nullable) = false];
-	optional string error = 3 [(gogoproto.nullable) = false];
-	optional CompressionType compression = 4 [(gogoproto.nullable) = false];
+  optional uint64 id = 1 [(gogoproto.nullable) = false];
+  optional string method = 2;
+  optional string error = 3 [(gogoproto.nullable) = false];
+  optional CompressionType compression = 4 [(gogoproto.nullable) = false];
 }


### PR DESCRIPTION
This removes an allocation per RPC in the steady state.

benchmark                    old ns/op     new ns/op     delta
BenchmarkEchoProtoRPC1K      41518         40297         -2.94%
BenchmarkEchoProtoRPC64K     142158        141040        -0.79%

benchmark                    old MB/s     new MB/s     speedup
BenchmarkEchoProtoRPC1K      49.33        50.82        1.03x
BenchmarkEchoProtoRPC64K     922.01       929.32       1.01x
