### PR TITLE
Merge RPC and HTTP ports.

### DIFF
--- a/client/client_test.go
+++ b/client/client_test.go
@@ -49,7 +49,7 @@ func StartTestServer(t *testing.T) *server.TestServer {
 	if err := s.Start(); err != nil {
 		t.Fatalf("Could not start server: %v", err)
 	}
-	log.Infof("Test server listening on http: %s", s.HTTPAddr)
+	log.Infof("Test server listening on http: %s", s.Addr)
 	return s
 }
 
@@ -108,7 +108,7 @@ func TestKVClientRetryNonTxn(t *testing.T) {
 		Constant:    2,
 		MaxAttempts: 2,
 	})
-	kvClient := createTestClient(s.HTTPAddr)
+	kvClient := createTestClient(s.Addr)
 	kvClient.User = storage.UserRoot
 
 	testCases := []struct {
@@ -218,7 +218,7 @@ func TestKVClientRetryNonTxn(t *testing.T) {
 func TestKVClientRunTransaction(t *testing.T) {
 	s := StartTestServer(t)
 	defer s.Stop()
-	kvClient := createTestClient(s.HTTPAddr)
+	kvClient := createTestClient(s.Addr)
 	kvClient.TxnRetryOptions.Backoff = 1 * time.Millisecond
 	kvClient.User = storage.UserRoot
 
@@ -279,7 +279,7 @@ func TestKVClientRunTransaction(t *testing.T) {
 func TestKVClientGetAndPutProto(t *testing.T) {
 	s := StartTestServer(t)
 	defer s.Stop()
-	kvClient := createTestClient(s.HTTPAddr)
+	kvClient := createTestClient(s.Addr)
 	kvClient.User = storage.UserRoot
 
 	zoneConfig := &proto.ZoneConfig{
@@ -314,7 +314,7 @@ func TestKVClientGetAndPutProto(t *testing.T) {
 func TestKVClientGetAndPutGob(t *testing.T) {
 	s := StartTestServer(t)
 	defer s.Stop()
-	kvClient := createTestClient(s.HTTPAddr)
+	kvClient := createTestClient(s.Addr)
 	kvClient.User = storage.UserRoot
 
 	obj := map[string]map[int]int{
@@ -354,7 +354,7 @@ func TestKVClientGetAndPutGob(t *testing.T) {
 func TestKVClientEmptyValues(t *testing.T) {
 	s := StartTestServer(t)
 	defer s.Stop()
-	kvClient := createTestClient(s.HTTPAddr)
+	kvClient := createTestClient(s.Addr)
 	kvClient.User = storage.UserRoot
 
 	kvClient.Call(proto.Put, proto.PutArgs(proto.Key("a"), []byte{}), &proto.PutResponse{})
@@ -383,7 +383,7 @@ func TestKVClientEmptyValues(t *testing.T) {
 func TestKVClientPrepareAndFlush(t *testing.T) {
 	s := StartTestServer(t)
 	defer s.Stop()
-	kvClient := createTestClient(s.HTTPAddr)
+	kvClient := createTestClient(s.Addr)
 	kvClient.User = storage.UserRoot
 
 	replies := []*proto.IncrementResponse{}
@@ -445,7 +445,7 @@ func ExampleKV_Call() {
 	defer serv.Stop()
 
 	// Replace with actual host:port address string (ex "localhost:8080") for server cluster.
-	serverAddress := serv.HTTPAddr
+	serverAddress := serv.Addr
 
 	// Key Value Client initialization.
 	sender := client.NewHTTPSender(serverAddress, &http.Transport{
@@ -490,7 +490,7 @@ func ExampleKV_Prepare() {
 	defer serv.Stop()
 
 	// Replace with actual host:port address string (ex "localhost:8080") for server cluster.
-	serverAddress := serv.HTTPAddr
+	serverAddress := serv.Addr
 
 	// Key Value Client initialization.
 	sender := client.NewHTTPSender(serverAddress, &http.Transport{
@@ -560,7 +560,7 @@ func ExampleKV_RunTransaction() {
 	defer serv.Stop()
 
 	// Replace with actual host:port address string (ex "localhost:8080") for server cluster.
-	serverAddress := serv.HTTPAddr
+	serverAddress := serv.Addr
 
 	// Key Value Client initialization.
 	sender := client.NewHTTPSender(serverAddress, &http.Transport{
@@ -705,7 +705,7 @@ func concurrentIncrements(kvClient *client.KV, t *testing.T) {
 func TestConcurrentIncrements(t *testing.T) {
 	s := StartTestServer(t)
 	defer s.Stop()
-	kvClient := createTestClient(s.HTTPAddr)
+	kvClient := createTestClient(s.Addr)
 	kvClient.User = storage.UserRoot
 
 	// Convenience loop: Crank up this number for testing this
@@ -736,7 +736,7 @@ func setupClientBenchData(numVersions, numKeys int, b *testing.B) (*server.TestS
 		b.Fatalf("Could not start server: %v", err)
 	}
 
-	kv := createTestClient(s.HTTPAddr)
+	kv := createTestClient(s.Addr)
 	kv.User = storage.UserRoot
 
 	if exists {

--- a/client/client_test.go
+++ b/client/client_test.go
@@ -49,7 +49,7 @@ func StartTestServer(t *testing.T) *server.TestServer {
 	if err := s.Start(); err != nil {
 		t.Fatalf("Could not start server: %v", err)
 	}
-	log.Infof("Test server listening on http: %s, rpc: %s", s.HTTPAddr, s.RPCAddr)
+	log.Infof("Test server listening on http: %s", s.HTTPAddr)
 	return s
 }
 

--- a/kv/dist_sender_server_test.go
+++ b/kv/dist_sender_server_test.go
@@ -47,7 +47,7 @@ func TestRangeLookupWithOpenTransaction(t *testing.T) {
 		t.Fatal(err)
 	}
 	defer s.Stop()
-	sender := client.NewHTTPSender(s.HTTPAddr, &http.Transport{
+	sender := client.NewHTTPSender(s.Addr, &http.Transport{
 		TLSClientConfig: rpc.LoadInsecureTLSConfig().Config(),
 	})
 	db := client.NewKV(nil, sender)
@@ -94,7 +94,7 @@ func setupMultipleRanges(t *testing.T) (*server.TestServer, *client.KV) {
 	if err := s.Start(); err != nil {
 		t.Fatal(err)
 	}
-	sender := client.NewHTTPSender(s.HTTPAddr, &http.Transport{
+	sender := client.NewHTTPSender(s.Addr, &http.Transport{
 		TLSClientConfig: rpc.LoadInsecureTLSConfig().Config(),
 	})
 	db := client.NewKV(nil, sender)

--- a/rpc/client.go
+++ b/rpc/client.go
@@ -120,7 +120,7 @@ func (c *Client) connect(opts *util.RetryOptions, context *Context) {
 	retryOpts.Tag = fmt.Sprintf("client %s connection", c.addr)
 
 	err := util.RetryWithBackoff(retryOpts, func() (util.RetryStatus, error) {
-		conn, err := tlsDial(c.addr.Network(), c.addr.String(), context.tlsConfig)
+		conn, err := tlsDialHTTP(c.addr.Network(), c.addr.String(), context.tlsConfig)
 		if err != nil {
 			log.Info(err)
 			return util.RetryContinue, nil

--- a/run/local-cluster.sh
+++ b/run/local-cluster.sh
@@ -91,8 +91,7 @@ DNS_CID=$(docker run -d -v "$DNS_DIR:/dnsmasq.hosts" --name=$DNSMASQ_NAME $DNSMA
 DNS_IP=$(docker inspect --format '{{ .NetworkSettings.IPAddress }}' $DNS_CID)
 echo "* ${DNSMASQ_NAME}"
 
-# Local rpc and http ports.
-RPC_PORT=9000
+# Local http ports.
 HTTP_PORT=8080
 
 # Start all nodes.
@@ -105,7 +104,7 @@ for i in $(seq 1 $NODES); do
     CMD="init"
   fi
   # Command args specify two data directories per instance to simulate two physical devices.
-  CMD_ARGS="-gossip=${HOSTS[1]}:$RPC_PORT -stores=hdd=/tmp/disk1,hdd=/tmp/disk2 -rpc=${HOSTS[$i]}:$RPC_PORT -http=${HOSTS[$i]}:$HTTP_PORT"
+  CMD_ARGS="-gossip=${HOSTS[1]}:$HTTP_PORT -stores=hdd=/tmp/disk1,hdd=/tmp/disk2 -http=${HOSTS[$i]}:$HTTP_PORT"
   # Log (almost) everything.
   CMD_ARGS="${CMD_ARGS} -v 7"
 

--- a/run/local-cluster.sh
+++ b/run/local-cluster.sh
@@ -91,8 +91,8 @@ DNS_CID=$(docker run -d -v "$DNS_DIR:/dnsmasq.hosts" --name=$DNSMASQ_NAME $DNSMA
 DNS_IP=$(docker inspect --format '{{ .NetworkSettings.IPAddress }}' $DNS_CID)
 echo "* ${DNSMASQ_NAME}"
 
-# Local http ports.
-HTTP_PORT=8080
+# Local ports.
+PORT=8080
 
 # Start all nodes.
 for i in $(seq 1 $NODES); do
@@ -104,7 +104,7 @@ for i in $(seq 1 $NODES); do
     CMD="init"
   fi
   # Command args specify two data directories per instance to simulate two physical devices.
-  CMD_ARGS="-gossip=${HOSTS[1]}:$HTTP_PORT -stores=hdd=/tmp/disk1,hdd=/tmp/disk2 -http=${HOSTS[$i]}:$HTTP_PORT"
+  CMD_ARGS="-gossip=${HOSTS[1]}:$PORT -stores=hdd=/tmp/disk1,hdd=/tmp/disk2 -addr=${HOSTS[$i]}:$PORT"
   # Log (almost) everything.
   CMD_ARGS="${CMD_ARGS} -v 7"
 
@@ -114,7 +114,7 @@ for i in $(seq 1 $NODES); do
   # Start Cockroach docker container and corral HTTP port and docker
   # IP address for container-local DNS.
   CIDS[$i]=$(docker run $STD_ARGS $NODE_ARGS $COCKROACH_IMAGE $CMD $CMD_ARGS)
-  HTTP_PORTS[$i]=$(echo $(docker port ${CIDS[$i]} 8080) | sed 's/.*://')
+  PORTS[$i]=$(echo $(docker port ${CIDS[$i]} 8080) | sed 's/.*://')
   IP=$(docker inspect --format '{{ .NetworkSettings.IPAddress }}' ${CIDS[$i]})
   IP_HOST[$i]="$IP ${HOSTS[$i]}"
   echo "* ${HOSTS[$i]}"
@@ -136,7 +136,7 @@ if [[ $DOCKERHOST != "127.0.0.1" ]]; then
 fi
 
 # Fetch the local status contents from node 1 and verify build information is present.
-LOCAL_URL="$DOCKERHOST:${HTTP_PORTS[1]}/_status/local/"
+LOCAL_URL="$DOCKERHOST:${PORTS[1]}/_status/local/"
 LOCAL=$(curl --noproxy '*' -s $LOCAL_URL)
 if [[ -z $LOCAL ]]; then
   echo "Failed to fetch status from node 1"
@@ -161,7 +161,7 @@ for ATTEMPT in $(seq 1 $MAX_WAIT); do
   FOUND=0
   for i in $(seq 1 $NODES); do
     FOUND_NAMES=""
-    GOSSIP_URL="$DOCKERHOST:${HTTP_PORTS[$i]}/_status/gossip"
+    GOSSIP_URL="$DOCKERHOST:${PORTS[$i]}/_status/gossip"
     GOSSIP=$(curl --noproxy '*' -s $GOSSIP_URL)
     for j in $(seq 1 $((2*NODES))); do
       if [[ ! -z $(echo $GOSSIP | grep "node:$j") ]]; then

--- a/server/cli/cli_test.go
+++ b/server/cli/cli_test.go
@@ -47,7 +47,7 @@ func (c cliTest) Run(line string) {
 
 	var args []string
 	args = append(args, a[0])
-	args = append(args, fmt.Sprintf("-addr=%s", c.HTTPAddr))
+	args = append(args, fmt.Sprintf("-addr=%s", c.Addr))
 	args = append(args, a[1:]...)
 
 	fmt.Printf("%s\n", line)

--- a/server/cli/flags.go
+++ b/server/cli/flags.go
@@ -28,7 +28,8 @@ import (
 // settable here.
 func initFlags(ctx *server.Context) {
 	// Server flags.
-	flag.StringVar(&ctx.HTTP, "http", ctx.HTTP, "host:port to bind for HTTP traffic; 0 to pick unused port")
+	flag.StringVar(&ctx.Addr, "addr", ctx.Addr, "when run as the server the host:port to bind for "+
+		"HTTP/RPC traffic; when run as the client the address for connection to the cockroach cluster")
 
 	flag.StringVar(&ctx.Certs, "certs", ctx.Certs, "directory containing RSA key and x509 certs")
 
@@ -55,8 +56,6 @@ func initFlags(ctx *server.Context) {
 
 	flag.BoolVar(&ctx.BootstrapOnly, "bootstrap_only", ctx.BootstrapOnly, "specify --bootstrap_only "+
 		"to avoid starting the server after bootstrapping with the init command.")
-
-	flag.StringVar(&ctx.Addr, "addr", ctx.Addr, "address for connection to cockroach cluster")
 
 	// Gossip flags.
 

--- a/server/cli/flags.go
+++ b/server/cli/flags.go
@@ -28,7 +28,6 @@ import (
 // settable here.
 func initFlags(ctx *server.Context) {
 	// Server flags.
-	flag.StringVar(&ctx.RPC, "rpc", ctx.RPC, "host:port to bind for RPC traffic; 0 to pick unused port")
 	flag.StringVar(&ctx.HTTP, "http", ctx.HTTP, "host:port to bind for HTTP traffic; 0 to pick unused port")
 
 	flag.StringVar(&ctx.Certs, "certs", ctx.Certs, "directory containing RSA key and x509 certs")

--- a/server/context.go
+++ b/server/context.go
@@ -33,7 +33,6 @@ import (
 
 // Context defaults.
 const (
-	defaultRPC            = ":0"
 	defaultHTTP           = ":8080"
 	defaultAddr           = "127.0.0.1:8080"
 	defaultMaxOffset      = 250 * time.Millisecond
@@ -45,9 +44,6 @@ const (
 // Calling "server/cli".InitFlags(ctx *Context) will initialize Context using
 // command flags. Keep in sync with "server/cli/flags.go".
 type Context struct {
-	// RPC is the "host:port" to bind for RPC traffic.
-	RPC string
-
 	// HTTP is the "host:port to bind for HTTP traffic.
 	HTTP string
 
@@ -114,7 +110,6 @@ type Context struct {
 // NewContext returns a Context with default values.
 func NewContext() *Context {
 	return &Context{
-		RPC:  defaultRPC,
 		HTTP: defaultHTTP,
 		Addr: defaultAddr,
 

--- a/server/context.go
+++ b/server/context.go
@@ -33,8 +33,7 @@ import (
 
 // Context defaults.
 const (
-	defaultHTTP           = ":8080"
-	defaultAddr           = "127.0.0.1:8080"
+	defaultAddr           = ":8080"
 	defaultMaxOffset      = 250 * time.Millisecond
 	defaultGossipInterval = 2 * time.Second
 	defaultCacheSize      = 1 << 30 // GB
@@ -44,10 +43,7 @@ const (
 // Calling "server/cli".InitFlags(ctx *Context) will initialize Context using
 // command flags. Keep in sync with "server/cli/flags.go".
 type Context struct {
-	// HTTP is the "host:port to bind for HTTP traffic.
-	HTTP string
-
-	// Addr is the address for connection to cockroach cluster.
+	// Addr is the host:port to bind for HTTP/RPC traffic.
 	Addr string
 
 	// Certs specifies a directory containing RSA key and x509 certs.
@@ -110,7 +106,6 @@ type Context struct {
 // NewContext returns a Context with default values.
 func NewContext() *Context {
 	return &Context{
-		HTTP: defaultHTTP,
 		Addr: defaultAddr,
 
 		MaxOffset: defaultMaxOffset,

--- a/server/server_test.go
+++ b/server/server_test.go
@@ -44,7 +44,7 @@ func startTestServer(t *testing.T) *TestServer {
 	if err := s.Start(); err != nil {
 		t.Fatalf("Could not start server: %v", err)
 	}
-	log.Infof("Test server listening on http: %s, rpc: %s", s.HTTPAddr, s.RPCAddr)
+	log.Infof("Test server listening on http: %s", s.HTTPAddr)
 	return s
 }
 

--- a/server/server_test.go
+++ b/server/server_test.go
@@ -44,7 +44,7 @@ func startTestServer(t *testing.T) *TestServer {
 	if err := s.Start(); err != nil {
 		t.Fatalf("Could not start server: %v", err)
 	}
-	log.Infof("Test server listening on http: %s", s.HTTPAddr)
+	log.Infof("Test server listening on http: %s", s.Addr)
 	return s
 }
 
@@ -181,7 +181,7 @@ func TestSelfBootstrap(t *testing.T) {
 func TestHealth(t *testing.T) {
 	s := startTestServer(t)
 	defer s.Stop()
-	url := "http://" + s.HTTPAddr + healthPath
+	url := "http://" + s.Addr + healthPath
 	resp, err := http.Get(url)
 	if err != nil {
 		t.Fatalf("error requesting health at %s: %s", url, err)
@@ -209,7 +209,7 @@ func TestGzip(t *testing.T) {
 			DisableCompression: true,
 		},
 	}
-	req, err := http.NewRequest("GET", "http://"+s.HTTPAddr+healthPath, nil)
+	req, err := http.NewRequest("GET", "http://"+s.Addr+healthPath, nil)
 	if err != nil {
 		t.Fatalf("could not create request: %s", err)
 	}

--- a/server/testserver.go
+++ b/server/testserver.go
@@ -30,7 +30,6 @@ import (
 
 const (
 	defaultHTTPAddr = "127.0.0.1:0"
-	defaultRPCAddr  = "127.0.0.1:0"
 )
 
 // A TestServer encapsulates an in-memory instantiation of a cockroach
@@ -51,10 +50,10 @@ type TestServer struct {
 	// This is mostly irrelevant except when testing reads within
 	// uncertainty intervals.
 	MaxOffset time.Duration
-	// HTTPAddr and RPCAddr default to localhost with port set
-	// at time of call to Start() to an available port.
-	HTTPAddr, RPCAddr string
-	SkipBootstrap     bool
+	// HTTPAddr defaults to localhost with port set at time of call to
+	// Start() to an available port.
+	HTTPAddr      string
+	SkipBootstrap bool
 	// server is the embedded Cockroach server struct.
 	*Server
 	// Engine underlying the test server.
@@ -85,15 +84,11 @@ func (ts *TestServer) Clock() *hlc.Clock {
 func (ts *TestServer) Start() error {
 	// We update these with the actual port once the servers
 	// have been launched for the purpose of this test.
-	if ts.RPCAddr == "" {
-		ts.RPCAddr = defaultRPCAddr
-	}
 	if ts.HTTPAddr == "" {
 		ts.HTTPAddr = defaultHTTPAddr
 	}
 
 	ctx := NewContext()
-	ctx.RPC = ts.RPCAddr
 	ctx.HTTP = ts.HTTPAddr
 	ctx.Addr = ts.HTTPAddr
 	ctx.Certs = ts.CertDir
@@ -123,8 +118,7 @@ func (ts *TestServer) Start() error {
 	}
 	// Update the configuration variables to reflect the actual
 	// ports bound.
-	ts.HTTPAddr = (*ts.httpListener).Addr().String()
-	ts.RPCAddr = ts.rpc.Addr().String()
+	ts.HTTPAddr = ts.rpc.Addr().String()
 
 	return nil
 }

--- a/server/testserver.go
+++ b/server/testserver.go
@@ -28,10 +28,6 @@ import (
 	"github.com/cockroachdb/cockroach/util/hlc"
 )
 
-const (
-	defaultHTTPAddr = "127.0.0.1:0"
-)
-
 // A TestServer encapsulates an in-memory instantiation of a cockroach
 // node with a single store. Example usage of a TestServer follows:
 //
@@ -50,9 +46,9 @@ type TestServer struct {
 	// This is mostly irrelevant except when testing reads within
 	// uncertainty intervals.
 	MaxOffset time.Duration
-	// HTTPAddr defaults to localhost with port set at time of call to
+	// Addr defaults to localhost with port set at time of call to
 	// Start() to an available port.
-	HTTPAddr      string
+	Addr          string
 	SkipBootstrap bool
 	// server is the embedded Cockroach server struct.
 	*Server
@@ -79,18 +75,17 @@ func (ts *TestServer) Clock() *hlc.Clock {
 // Start starts the TestServer by bootstrapping an in-memory store
 // (defaults to maximum of 100M). The server is started, launching the
 // node RPC server and all HTTP endpoints. Use the value of
-// TestServer.HTTPAddr after Start() for client connections. Use Stop()
+// TestServer.Addr after Start() for client connections. Use Stop()
 // to shutdown the server after the test completes.
 func (ts *TestServer) Start() error {
 	// We update these with the actual port once the servers
 	// have been launched for the purpose of this test.
-	if ts.HTTPAddr == "" {
-		ts.HTTPAddr = defaultHTTPAddr
+	if ts.Addr == "" {
+		ts.Addr = "127.0.0.1:0"
 	}
 
 	ctx := NewContext()
-	ctx.HTTP = ts.HTTPAddr
-	ctx.Addr = ts.HTTPAddr
+	ctx.Addr = ts.Addr
 	ctx.Certs = ts.CertDir
 	ctx.MaxOffset = ts.MaxOffset
 
@@ -118,7 +113,7 @@ func (ts *TestServer) Start() error {
 	}
 	// Update the configuration variables to reflect the actual
 	// ports bound.
-	ts.HTTPAddr = ts.rpc.Addr().String()
+	ts.Addr = ts.rpc.Addr().String()
 
 	return nil
 }


### PR DESCRIPTION
rpc.Server now performs HTTP serving similar to the way net/rpc can use
HTTP to set up the connection before hijacking it. This allows the RPC
and HTTP ports to be combined.
