### PR TITLE
Add ts Package, Time Series Key Encoding

### DIFF
--- a/proto/data.pb.go
+++ b/proto/data.pb.go
@@ -788,15 +788,18 @@ func (m *TimeSeriesDatapoint) GetFloatValue() float32 {
 }
 
 // TimeSeriesData is a set of observations of a single variable value at
-// multiple points in time. This message contains a string which uniquely
-// identifies the source variable, and a repeated set of TimeSeriesDatapoint
-// messages representing distinct measurements of that variable.
+// multiple points in time. This message contains a name and a source which, in
+// combination, uniquely identify the series being measured. The message also
+// contains a repeated set of TimeSeriesDatapoint messages representing distinct
+// measurements of the variable.
 type TimeSeriesData struct {
 	// A string which uniquely identifies the variable from which this data was
 	// measured.
 	Name string `protobuf:"bytes,1,opt,name=name" json:"name"`
+	// A string which identifies the unique source from which the variable was measured.
+	Source string `protobuf:"bytes,2,opt,name=source" json:"source"`
 	// Datapoints representing one or more measurements taken from the variable.
-	Datapoints       []*TimeSeriesDatapoint `protobuf:"bytes,2,rep,name=datapoints" json:"datapoints,omitempty"`
+	Datapoints       []*TimeSeriesDatapoint `protobuf:"bytes,3,rep,name=datapoints" json:"datapoints,omitempty"`
 	XXX_unrecognized []byte                 `json:"-"`
 }
 
@@ -807,6 +810,13 @@ func (*TimeSeriesData) ProtoMessage()    {}
 func (m *TimeSeriesData) GetName() string {
 	if m != nil {
 		return m.Name
+	}
+	return ""
+}
+
+func (m *TimeSeriesData) GetSource() string {
+	if m != nil {
+		return m.Source
 	}
 	return ""
 }
@@ -2687,6 +2697,28 @@ func (m *TimeSeriesData) Unmarshal(data []byte) error {
 			index = postIndex
 		case 2:
 			if wireType != 2 {
+				return fmt.Errorf("proto: wrong wireType = %d for field Source", wireType)
+			}
+			var stringLen uint64
+			for shift := uint(0); ; shift += 7 {
+				if index >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := data[index]
+				index++
+				stringLen |= (uint64(b) & 0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			postIndex := index + int(stringLen)
+			if postIndex > l {
+				return io.ErrUnexpectedEOF
+			}
+			m.Source = string(data[index:postIndex])
+			index = postIndex
+		case 3:
+			if wireType != 2 {
 				return fmt.Errorf("proto: wrong wireType = %d for field Datapoints", wireType)
 			}
 			var msglen int
@@ -3011,6 +3043,8 @@ func (m *TimeSeriesData) Size() (n int) {
 	var l int
 	_ = l
 	l = len(m.Name)
+	n += 1 + l + sovData(uint64(l))
+	l = len(m.Source)
 	n += 1 + l + sovData(uint64(l))
 	if len(m.Datapoints) > 0 {
 		for _, e := range m.Datapoints {
@@ -3743,9 +3777,13 @@ func (m *TimeSeriesData) MarshalTo(data []byte) (n int, err error) {
 	i++
 	i = encodeVarintData(data, i, uint64(len(m.Name)))
 	i += copy(data[i:], m.Name)
+	data[i] = 0x12
+	i++
+	i = encodeVarintData(data, i, uint64(len(m.Source)))
+	i += copy(data[i:], m.Source)
 	if len(m.Datapoints) > 0 {
 		for _, msg := range m.Datapoints {
-			data[i] = 0x12
+			data[i] = 0x1a
 			i++
 			i = encodeVarintData(data, i, uint64(msg.Size()))
 			n, err := msg.MarshalTo(data[i:])

--- a/proto/data.proto
+++ b/proto/data.proto
@@ -311,13 +311,16 @@ message TimeSeriesDatapoint {
 }
 
 // TimeSeriesData is a set of observations of a single variable value at
-// multiple points in time. This message contains a string which uniquely
-// identifies the source variable, and a repeated set of TimeSeriesDatapoint
-// messages representing distinct measurements of that variable.
+// multiple points in time. This message contains a name and a source which, in
+// combination, uniquely identify the series being measured. The message also
+// contains a repeated set of TimeSeriesDatapoint messages representing distinct
+// measurements of the variable.
 message TimeSeriesData {
   // A string which uniquely identifies the variable from which this data was
   // measured.
   optional string name = 1 [(gogoproto.nullable) = false];
+  // A string which identifies the unique source from which the variable was measured.
+  optional string source = 2 [(gogoproto.nullable) = false];
   // Datapoints representing one or more measurements taken from the variable.
-  repeated TimeSeriesDatapoint datapoints = 2;
+  repeated TimeSeriesDatapoint datapoints = 3;
 }

--- a/storage/engine/cockroach/proto/data.pb.cc
+++ b/storage/engine/cockroach/proto/data.pb.cc
@@ -366,8 +366,9 @@ void protobuf_AssignDesc_cockroach_2fproto_2fdata_2eproto() {
       ::google::protobuf::MessageFactory::generated_factory(),
       sizeof(TimeSeriesDatapoint));
   TimeSeriesData_descriptor_ = file->message_type(16);
-  static const int TimeSeriesData_offsets_[2] = {
+  static const int TimeSeriesData_offsets_[3] = {
     GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(TimeSeriesData, name_),
+    GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(TimeSeriesData, source_),
     GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(TimeSeriesData, datapoints_),
   };
   TimeSeriesData_reflection_ =
@@ -541,15 +542,15 @@ void protobuf_AddDesc_cockroach_2fproto_2fdata_2eproto() {
     "nanos\030\001 \001(\003B\004\310\336\037\000\022\033\n\023oldest_intent_nanos"
     "\030\002 \001(\003\"\\\n\023TimeSeriesDatapoint\022\035\n\017timesta"
     "mp_nanos\030\001 \001(\003B\004\310\336\037\000\022\021\n\tint_value\030\002 \001(\003\022"
-    "\023\n\013float_value\030\003 \001(\002\"^\n\016TimeSeriesData\022\022"
-    "\n\004name\030\001 \001(\tB\004\310\336\037\000\0228\n\ndatapoints\030\002 \003(\0132$"
-    ".cockroach.proto.TimeSeriesDatapoint*>\n\021"
-    "ReplicaChangeType\022\017\n\013ADD_REPLICA\020\000\022\022\n\016RE"
-    "MOVE_REPLICA\020\001\032\004\210\243\036\000*5\n\rIsolationType\022\020\n"
-    "\014SERIALIZABLE\020\000\022\014\n\010SNAPSHOT\020\001\032\004\210\243\036\000*B\n\021T"
-    "ransactionStatus\022\013\n\007PENDING\020\000\022\r\n\tCOMMITT"
-    "ED\020\001\022\013\n\007ABORTED\020\002\032\004\210\243\036\000B\023Z\005proto\340\342\036\001\310\342\036\001"
-    "\320\342\036\001", 2764);
+    "\023\n\013float_value\030\003 \001(\002\"t\n\016TimeSeriesData\022\022"
+    "\n\004name\030\001 \001(\tB\004\310\336\037\000\022\024\n\006source\030\002 \001(\tB\004\310\336\037\000"
+    "\0228\n\ndatapoints\030\003 \003(\0132$.cockroach.proto.T"
+    "imeSeriesDatapoint*>\n\021ReplicaChangeType\022"
+    "\017\n\013ADD_REPLICA\020\000\022\022\n\016REMOVE_REPLICA\020\001\032\004\210\243"
+    "\036\000*5\n\rIsolationType\022\020\n\014SERIALIZABLE\020\000\022\014\n"
+    "\010SNAPSHOT\020\001\032\004\210\243\036\000*B\n\021TransactionStatus\022\013"
+    "\n\007PENDING\020\000\022\r\n\tCOMMITTED\020\001\022\013\n\007ABORTED\020\002\032"
+    "\004\210\243\036\000B\023Z\005proto\340\342\036\001\310\342\036\001\320\342\036\001", 2786);
   ::google::protobuf::MessageFactory::InternalRegisterGeneratedFile(
     "cockroach/proto/data.proto", &protobuf_RegisterTypes);
   Timestamp::default_instance_ = new Timestamp();
@@ -6109,6 +6110,7 @@ void TimeSeriesDatapoint::Swap(TimeSeriesDatapoint* other) {
 
 #ifndef _MSC_VER
 const int TimeSeriesData::kNameFieldNumber;
+const int TimeSeriesData::kSourceFieldNumber;
 const int TimeSeriesData::kDatapointsFieldNumber;
 #endif  // !_MSC_VER
 
@@ -6132,6 +6134,7 @@ void TimeSeriesData::SharedCtor() {
   ::google::protobuf::internal::GetEmptyString();
   _cached_size_ = 0;
   name_ = const_cast< ::std::string*>(&::google::protobuf::internal::GetEmptyStringAlreadyInited());
+  source_ = const_cast< ::std::string*>(&::google::protobuf::internal::GetEmptyStringAlreadyInited());
   ::memset(_has_bits_, 0, sizeof(_has_bits_));
 }
 
@@ -6143,6 +6146,9 @@ TimeSeriesData::~TimeSeriesData() {
 void TimeSeriesData::SharedDtor() {
   if (name_ != &::google::protobuf::internal::GetEmptyStringAlreadyInited()) {
     delete name_;
+  }
+  if (source_ != &::google::protobuf::internal::GetEmptyStringAlreadyInited()) {
+    delete source_;
   }
   if (this != default_instance_) {
   }
@@ -6170,9 +6176,16 @@ TimeSeriesData* TimeSeriesData::New() const {
 }
 
 void TimeSeriesData::Clear() {
-  if (has_name()) {
-    if (name_ != &::google::protobuf::internal::GetEmptyStringAlreadyInited()) {
-      name_->clear();
+  if (_has_bits_[0 / 32] & 3) {
+    if (has_name()) {
+      if (name_ != &::google::protobuf::internal::GetEmptyStringAlreadyInited()) {
+        name_->clear();
+      }
+    }
+    if (has_source()) {
+      if (source_ != &::google::protobuf::internal::GetEmptyStringAlreadyInited()) {
+        source_->clear();
+      }
     }
   }
   datapoints_.Clear();
@@ -6202,20 +6215,37 @@ bool TimeSeriesData::MergePartialFromCodedStream(
         } else {
           goto handle_unusual;
         }
-        if (input->ExpectTag(18)) goto parse_datapoints;
+        if (input->ExpectTag(18)) goto parse_source;
         break;
       }
 
-      // repeated .cockroach.proto.TimeSeriesDatapoint datapoints = 2;
+      // optional string source = 2;
       case 2: {
         if (tag == 18) {
+         parse_source:
+          DO_(::google::protobuf::internal::WireFormatLite::ReadString(
+                input, this->mutable_source()));
+          ::google::protobuf::internal::WireFormat::VerifyUTF8StringNamedField(
+            this->source().data(), this->source().length(),
+            ::google::protobuf::internal::WireFormat::PARSE,
+            "source");
+        } else {
+          goto handle_unusual;
+        }
+        if (input->ExpectTag(26)) goto parse_datapoints;
+        break;
+      }
+
+      // repeated .cockroach.proto.TimeSeriesDatapoint datapoints = 3;
+      case 3: {
+        if (tag == 26) {
          parse_datapoints:
           DO_(::google::protobuf::internal::WireFormatLite::ReadMessageNoVirtual(
                 input, add_datapoints()));
         } else {
           goto handle_unusual;
         }
-        if (input->ExpectTag(18)) goto parse_datapoints;
+        if (input->ExpectTag(26)) goto parse_datapoints;
         if (input->ExpectAtEnd()) goto success;
         break;
       }
@@ -6255,10 +6285,20 @@ void TimeSeriesData::SerializeWithCachedSizes(
       1, this->name(), output);
   }
 
-  // repeated .cockroach.proto.TimeSeriesDatapoint datapoints = 2;
+  // optional string source = 2;
+  if (has_source()) {
+    ::google::protobuf::internal::WireFormat::VerifyUTF8StringNamedField(
+      this->source().data(), this->source().length(),
+      ::google::protobuf::internal::WireFormat::SERIALIZE,
+      "source");
+    ::google::protobuf::internal::WireFormatLite::WriteStringMaybeAliased(
+      2, this->source(), output);
+  }
+
+  // repeated .cockroach.proto.TimeSeriesDatapoint datapoints = 3;
   for (int i = 0; i < this->datapoints_size(); i++) {
     ::google::protobuf::internal::WireFormatLite::WriteMessageMaybeToArray(
-      2, this->datapoints(i), output);
+      3, this->datapoints(i), output);
   }
 
   if (!unknown_fields().empty()) {
@@ -6282,11 +6322,22 @@ void TimeSeriesData::SerializeWithCachedSizes(
         1, this->name(), target);
   }
 
-  // repeated .cockroach.proto.TimeSeriesDatapoint datapoints = 2;
+  // optional string source = 2;
+  if (has_source()) {
+    ::google::protobuf::internal::WireFormat::VerifyUTF8StringNamedField(
+      this->source().data(), this->source().length(),
+      ::google::protobuf::internal::WireFormat::SERIALIZE,
+      "source");
+    target =
+      ::google::protobuf::internal::WireFormatLite::WriteStringToArray(
+        2, this->source(), target);
+  }
+
+  // repeated .cockroach.proto.TimeSeriesDatapoint datapoints = 3;
   for (int i = 0; i < this->datapoints_size(); i++) {
     target = ::google::protobuf::internal::WireFormatLite::
       WriteMessageNoVirtualToArray(
-        2, this->datapoints(i), target);
+        3, this->datapoints(i), target);
   }
 
   if (!unknown_fields().empty()) {
@@ -6308,8 +6359,15 @@ int TimeSeriesData::ByteSize() const {
           this->name());
     }
 
+    // optional string source = 2;
+    if (has_source()) {
+      total_size += 1 +
+        ::google::protobuf::internal::WireFormatLite::StringSize(
+          this->source());
+    }
+
   }
-  // repeated .cockroach.proto.TimeSeriesDatapoint datapoints = 2;
+  // repeated .cockroach.proto.TimeSeriesDatapoint datapoints = 3;
   total_size += 1 * this->datapoints_size();
   for (int i = 0; i < this->datapoints_size(); i++) {
     total_size +=
@@ -6347,6 +6405,9 @@ void TimeSeriesData::MergeFrom(const TimeSeriesData& from) {
     if (from.has_name()) {
       set_name(from.name());
     }
+    if (from.has_source()) {
+      set_source(from.source());
+    }
   }
   mutable_unknown_fields()->MergeFrom(from.unknown_fields());
 }
@@ -6371,6 +6432,7 @@ bool TimeSeriesData::IsInitialized() const {
 void TimeSeriesData::Swap(TimeSeriesData* other) {
   if (other != this) {
     std::swap(name_, other->name_);
+    std::swap(source_, other->source_);
     datapoints_.Swap(&other->datapoints_);
     std::swap(_has_bits_[0], other->_has_bits_[0]);
     _unknown_fields_.Swap(&other->_unknown_fields_);

--- a/storage/engine/cockroach/proto/data.pb.h
+++ b/storage/engine/cockroach/proto/data.pb.h
@@ -1937,10 +1937,22 @@ class TimeSeriesData : public ::google::protobuf::Message {
   inline ::std::string* release_name();
   inline void set_allocated_name(::std::string* name);
 
-  // repeated .cockroach.proto.TimeSeriesDatapoint datapoints = 2;
+  // optional string source = 2;
+  inline bool has_source() const;
+  inline void clear_source();
+  static const int kSourceFieldNumber = 2;
+  inline const ::std::string& source() const;
+  inline void set_source(const ::std::string& value);
+  inline void set_source(const char* value);
+  inline void set_source(const char* value, size_t size);
+  inline ::std::string* mutable_source();
+  inline ::std::string* release_source();
+  inline void set_allocated_source(::std::string* source);
+
+  // repeated .cockroach.proto.TimeSeriesDatapoint datapoints = 3;
   inline int datapoints_size() const;
   inline void clear_datapoints();
-  static const int kDatapointsFieldNumber = 2;
+  static const int kDatapointsFieldNumber = 3;
   inline const ::cockroach::proto::TimeSeriesDatapoint& datapoints(int index) const;
   inline ::cockroach::proto::TimeSeriesDatapoint* mutable_datapoints(int index);
   inline ::cockroach::proto::TimeSeriesDatapoint* add_datapoints();
@@ -1953,12 +1965,15 @@ class TimeSeriesData : public ::google::protobuf::Message {
  private:
   inline void set_has_name();
   inline void clear_has_name();
+  inline void set_has_source();
+  inline void clear_has_source();
 
   ::google::protobuf::UnknownFieldSet _unknown_fields_;
 
   ::google::protobuf::uint32 _has_bits_[1];
   mutable int _cached_size_;
   ::std::string* name_;
+  ::std::string* source_;
   ::google::protobuf::RepeatedPtrField< ::cockroach::proto::TimeSeriesDatapoint > datapoints_;
   friend void  protobuf_AddDesc_cockroach_2fproto_2fdata_2eproto();
   friend void protobuf_AssignDesc_cockroach_2fproto_2fdata_2eproto();
@@ -4260,7 +4275,83 @@ inline void TimeSeriesData::set_allocated_name(::std::string* name) {
   // @@protoc_insertion_point(field_set_allocated:cockroach.proto.TimeSeriesData.name)
 }
 
-// repeated .cockroach.proto.TimeSeriesDatapoint datapoints = 2;
+// optional string source = 2;
+inline bool TimeSeriesData::has_source() const {
+  return (_has_bits_[0] & 0x00000002u) != 0;
+}
+inline void TimeSeriesData::set_has_source() {
+  _has_bits_[0] |= 0x00000002u;
+}
+inline void TimeSeriesData::clear_has_source() {
+  _has_bits_[0] &= ~0x00000002u;
+}
+inline void TimeSeriesData::clear_source() {
+  if (source_ != &::google::protobuf::internal::GetEmptyStringAlreadyInited()) {
+    source_->clear();
+  }
+  clear_has_source();
+}
+inline const ::std::string& TimeSeriesData::source() const {
+  // @@protoc_insertion_point(field_get:cockroach.proto.TimeSeriesData.source)
+  return *source_;
+}
+inline void TimeSeriesData::set_source(const ::std::string& value) {
+  set_has_source();
+  if (source_ == &::google::protobuf::internal::GetEmptyStringAlreadyInited()) {
+    source_ = new ::std::string;
+  }
+  source_->assign(value);
+  // @@protoc_insertion_point(field_set:cockroach.proto.TimeSeriesData.source)
+}
+inline void TimeSeriesData::set_source(const char* value) {
+  set_has_source();
+  if (source_ == &::google::protobuf::internal::GetEmptyStringAlreadyInited()) {
+    source_ = new ::std::string;
+  }
+  source_->assign(value);
+  // @@protoc_insertion_point(field_set_char:cockroach.proto.TimeSeriesData.source)
+}
+inline void TimeSeriesData::set_source(const char* value, size_t size) {
+  set_has_source();
+  if (source_ == &::google::protobuf::internal::GetEmptyStringAlreadyInited()) {
+    source_ = new ::std::string;
+  }
+  source_->assign(reinterpret_cast<const char*>(value), size);
+  // @@protoc_insertion_point(field_set_pointer:cockroach.proto.TimeSeriesData.source)
+}
+inline ::std::string* TimeSeriesData::mutable_source() {
+  set_has_source();
+  if (source_ == &::google::protobuf::internal::GetEmptyStringAlreadyInited()) {
+    source_ = new ::std::string;
+  }
+  // @@protoc_insertion_point(field_mutable:cockroach.proto.TimeSeriesData.source)
+  return source_;
+}
+inline ::std::string* TimeSeriesData::release_source() {
+  clear_has_source();
+  if (source_ == &::google::protobuf::internal::GetEmptyStringAlreadyInited()) {
+    return NULL;
+  } else {
+    ::std::string* temp = source_;
+    source_ = const_cast< ::std::string*>(&::google::protobuf::internal::GetEmptyStringAlreadyInited());
+    return temp;
+  }
+}
+inline void TimeSeriesData::set_allocated_source(::std::string* source) {
+  if (source_ != &::google::protobuf::internal::GetEmptyStringAlreadyInited()) {
+    delete source_;
+  }
+  if (source) {
+    set_has_source();
+    source_ = source;
+  } else {
+    clear_has_source();
+    source_ = const_cast< ::std::string*>(&::google::protobuf::internal::GetEmptyStringAlreadyInited());
+  }
+  // @@protoc_insertion_point(field_set_allocated:cockroach.proto.TimeSeriesData.source)
+}
+
+// repeated .cockroach.proto.TimeSeriesDatapoint datapoints = 3;
 inline int TimeSeriesData::datapoints_size() const {
   return datapoints_.size();
 }

--- a/ts/doc.go
+++ b/ts/doc.go
@@ -1,0 +1,139 @@
+// Copyright 2015 The Cockroach Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+// implied. See the License for the specific language governing
+// permissions and limitations under the License. See the AUTHORS file
+// for names of contributors.
+//
+// Author: Matt Tracy (matt.r.tracy@gmail.com)
+
+/*
+Package ts provides a high-level time series API on top of an underlying
+Cockroach datastore. Cockroach itself provides a single monolithic, sorted
+key-value map. The ts package collects time series data, consisting of
+timestamped data points, and efficiently stores it in the key-value store.
+
+Storing time series data is a unique challenge for databases. Time series data
+is typically generated at an extremely high volume, and is queried by providing
+a range of time of arbitrary size, which can lead to an enormous amount of data
+being scanned for a query. Many specialized time series databases exist to meet
+these challenges.
+
+Cockroach organizes time series data by series name and timestamp; when querying
+a given series over a time range, all data in that range is thus stored
+contiguously. However, Cockroach transforms the data in a few important ways in
+order to effectively query a large amount of data.
+
+Downsampling
+
+The amount of data produced by time series sampling can be staggering; the naive
+solution, storing every incoming data point with perfect fidelity in a unique
+key, would commmand a tremendous amount of computing resources.
+
+However, in most cases a perfect fidelity is not necessary or desired; the exact
+time a sample was taken is unimportant, with the overall trend of the data over
+time being far more important to analysis than the individual samples.
+
+With this in mind, Cockroach downsamples data before storing it; the original
+timestamp for each data point in a series is not recorded. Cockroach instead
+divides time into contiguous slots of uniform length (e.g. 10 seconds); if
+multiple data points for a series fall in the same slot, they are aggregated
+together.  Aggregated data for a slot records the count, sum, min and max of
+data points that were found in that slot. A single slot is referred to as a
+"sample", and the length of the slot is known as the "sample duration".
+
+Cockroach also uses its own key space efficiently by storing data for
+multiple samples in a single key. This is done by again dividing time into
+contiguous slots, but with a longer duration; this is known as the "key
+duration". For example, Cockroach samples much of its internal data at a
+resolution of 10 seconds, but stores it with a "key duration" of 1 hour, meaning
+that all samples that fall in the same hour are stored at the same key. This
+strategy helps reduce the number of keys scanned during a query.
+
+Finally, Cockroach can record the same series at multiple sample durations, in a
+process commonly known as "rollup".  For example, a single series may be
+recorded with a sample size of 10 seconds, but also record the same data with a
+sample size of 1 hour. The 1 hour data will have much less information, but can
+be queried much faster; this is very useful when querying a series over a very
+long period of time (e.g. an entire month or year).
+
+A specific sample duration in Cockroach is known as a Resolution. Cockroach
+supports a fixed set of Resolutions; each Resolution has a fixed sample duration
+and a key duration. For example, the resolution "Resolution10s" has a sample
+duration of 10 seconds and a key duration of 1 hour.
+
+Source Keys
+
+Another dimension of time series queries is the aggregation of multiple series;
+for example, you may want to query the same data point across multiple machines
+on a cluster.
+
+While Cockroach will support this, in some cases queries are almost *always* an
+aggregate of multiple source series; for example, we often want to query storage
+data for a Cockroach accounting prefix, but data is always collected from
+multiple stores; the information on a specific range is rarely relevant, as they
+can arbitrarily split and rebalance over time.
+
+Unforunately, data from multiple sources cannot be safely aggregated in the same
+way as multiple data points from the same series can be downsampled; each series
+must be stored separately. However, Cockroach *can* optimize for this situation
+by altering the keyspace; Cockroach can store data from multiple sources
+contiguously in the key space, ensuring that the multiple series can be queried
+together more efficiently.
+
+This is done by creating a "source key", an optional identifier that is separate
+from the series name itself. Source keys are appended to the key as a suffix,
+after the series name and timestamp; this means that data that is from the same
+series and time period, but is from different sources, will be stored adjacently
+in the key space.  Data from all sources in a series can thus be queried in a
+single scan.
+
+Example
+
+A hypothetical example from Cockroach: we want to record the size of all data
+stored in the cluster with a key prefix of "ExampleApplication". This will let
+us track data usage for a single application in a shared cluster.
+
+The series name is: Cockroach.disksize.ExampleApplication
+
+Data points for this series are automatically collected from any store that
+contains keys with a prefix of "ExampleApplication". When data points are
+written, they are recorded with a store key of: [store id]
+
+There are 3 stores which contain data: 3, 9 and 10.  These are arbitrary and may
+change over time, and are not often interested in the behavior of a specific
+store in this context.
+
+Data is recorded for January 1st, 2016 between 10:05 pm and 11:05 pm. The data
+is recorded at a 10 second resolution.
+
+The data is recorded into keys structurally similar to the following:
+
+	tsd.cockroach.disksize.ExampleApplication.10s.403234.3
+	tsd.cockroach.disksize.ExampleApplication.10s.403234.9
+	tsd.cockroach.disksize.ExampleApplication.10s.403234.10
+	tsd.cockroach.disksize.ExampleApplication.10s.403235.3
+	tsd.cockroach.disksize.ExampleApplication.10s.403235.9
+	tsd.cockroach.disksize.ExampleApplication.10s.403235.10
+
+Data for each source is stored in two keys: one for the 10 pm hour, and one
+for the 11pm hour. Each key contains the tsd prefix, the series name, the
+resolution (10s), a timestamp representing the hour, and finally the series key. The
+keys will appear in the data store in the order shown above.
+
+(Note that the keys will NOT be exactly as pictured above; they will be encoded
+in a way that is more efficient, but is not readily human readable.)
+
+TODO(mrtracy):
+The ts package is a work in progress, and will initially only service queries
+for Cockroach's own internally generated time series data.
+*/
+package ts

--- a/ts/keys.go
+++ b/ts/keys.go
@@ -1,0 +1,108 @@
+// Copyright 2014 The Cockroach Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+// implied. See the License for the specific language governing
+// permissions and limitations under the License. See the AUTHORS file
+// for names of contributors.
+//
+// Author: Matt Tracy (matt.r.tracy@gmail.com)
+
+package ts
+
+import (
+	"bytes"
+	"fmt"
+
+	"github.com/cockroachdb/cockroach/proto"
+	"github.com/cockroachdb/cockroach/storage/engine"
+	"github.com/cockroachdb/cockroach/util/encoding"
+)
+
+// Time series keys are carefully constructed to usefully sort the data in the
+// key-value store for the purpose of queries. Time series data is queryied by
+// providing a series name and a timespan; we therefore expose the series name
+// and the collection time prominently on the key.
+//
+// The precise formula for a time series key is:
+//
+//   [system key prefix]tsd[series name][resolution][time slot][source key]
+//
+// The series name is an arbitrary string identifying the series, although the
+// ts system may enforce naming rules at a higher level. This string is binary
+// encoded in the key.
+//
+// The source key is a possibly empty string which identifies the source from
+// which the series data was gathered. Data for a series may be gathered from
+// multiple sources, which are stored separately but are sorted adjacently for
+// efficient access.
+//
+// The resolution refers to the sample duration at which data is stored.
+// Cockroach supports a fixed set of named resolutions, which are stored in the
+// Resolution enumeration. This value is encoded as a VarInt in the key.
+//
+// Cockroach divides all data for a series into contiguous "time slots" of
+// uniform length based on the "key duration" of the Resolution. For each
+// series/source pair, there will be one key per slot. Slot 0 begins at unix
+// epoch; the slot for a specific timestamp is found by truncating the
+// timestamp to an exact multiple of the key duration, and then dividing it by
+// the key duration:
+//
+// 		slot := (timestamp / keyDuration) // integer division
+var (
+	// keyDataPrefix is the key prefix for time series data keys.
+	keyDataPrefix = proto.MakeKey(engine.KeySystemPrefix, proto.Key("tsd"))
+)
+
+// MakeDataKey creates a time series data key for the given series name, source,
+// Resolution and timestamp. The timestamp is expressed in nanoseconds since the
+// epoch; it will be truncated to an exact multiple of the supplied
+// Resolution's KeyDuration.
+func MakeDataKey(name string, source string, r Resolution, timestamp int64) proto.Key {
+	// Normalize timestamp into a timeslot before recording.
+	timeslot := timestamp / r.KeyDuration()
+
+	k := append(proto.Key(nil), keyDataPrefix...)
+	k = encoding.EncodeBytes(k, []byte(name))
+	k = encoding.EncodeVarint(k, int64(r))
+	k = encoding.EncodeVarint(k, timeslot)
+	k = append(k, source...)
+	return k
+}
+
+// DecodeDataKey decodes a time series key into its components.
+func DecodeDataKey(key proto.Key) (string, string, Resolution, int64) {
+	var (
+		name          []byte
+		source        []byte
+		resolutionInt int64
+		timeslot      int64
+		remainder     = key
+	)
+
+	// Detect and remove prefix.
+	if !bytes.HasPrefix(remainder, keyDataPrefix) {
+		panic(fmt.Sprintf("malformed time series data key %v: improper prefix", key))
+	}
+	remainder = remainder[len(keyDataPrefix):]
+
+	// Decode series name.
+	remainder, name = encoding.DecodeBytes(remainder)
+	// Decode resolution.
+	remainder, resolutionInt = encoding.DecodeVarint(remainder)
+	resolution := Resolution(resolutionInt)
+	// Decode timestamp.
+	remainder, timeslot = encoding.DecodeVarint(remainder)
+	timestamp := timeslot * resolution.KeyDuration()
+	// The remaining bytes are the source.
+	source = remainder
+
+	return string(name), string(source), resolution, timestamp
+}

--- a/ts/keys_test.go
+++ b/ts/keys_test.go
@@ -1,0 +1,77 @@
+// Copyright 2014 The Cockroach Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+// implied. See the License for the specific language governing
+// permissions and limitations under the License. See the AUTHORS file
+// for names of contributors.
+//
+// Author: Matt Tracy (matt.r.tracy@gmail.com)
+
+package ts
+
+import (
+	"bytes"
+	"reflect"
+	"testing"
+)
+
+func TestDataKeys(t *testing.T) {
+	testCases := []struct {
+		name        string
+		source      string
+		timestamp   int64
+		resolution  Resolution
+		expectedLen int
+	}{
+		{
+			"test.metric",
+			"testsource",
+			0,
+			Resolution10s,
+			30,
+		},
+		{
+			"test.no.source",
+			"",
+			1429114700000000000,
+			Resolution10s,
+			26,
+		},
+		{
+			"",
+			"",
+			-1429114700000000000,
+			Resolution10s,
+			12,
+		},
+	}
+
+	for i, tc := range testCases {
+		encoded := MakeDataKey(tc.name, tc.source, tc.resolution, tc.timestamp)
+		if !bytes.HasPrefix(encoded, keyDataPrefix) {
+			t.Errorf("case %d, encoded key %v did not have time series data prefix", i, encoded)
+		}
+		if a, e := len(encoded), tc.expectedLen; a != e {
+			t.Errorf("case %d, encoded length %d did not match expected %d", i, a, e)
+		}
+
+		// Normalize timestamp of test case; we expect MakeDataKey to
+		// automatically truncate it to an exact multiple of the Resolution's
+		// KeyDuration
+		tc.timestamp = (tc.timestamp / tc.resolution.KeyDuration()) * tc.resolution.KeyDuration()
+
+		d := tc
+		d.name, d.source, d.resolution, d.timestamp = DecodeDataKey(encoded)
+		if !reflect.DeepEqual(d, tc) {
+			t.Errorf("case %d, decoded values %v did not match expected %v", i, d, tc)
+		}
+	}
+}

--- a/ts/resolution.go
+++ b/ts/resolution.go
@@ -1,0 +1,70 @@
+// Copyright 2014 The Cockroach Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+// implied. See the License for the specific language governing
+// permissions and limitations under the License. See the AUTHORS file
+// for names of contributors.
+//
+// Author: Matt Tracy (matt.r.tracy@gmail.com)
+
+package ts
+
+import (
+	"fmt"
+	"time"
+)
+
+// Resolution is used to enumerate the different resolution values supported by
+// Cockroach.
+type Resolution int64
+
+// Resolution enumeration values are directly serialized and persisted into
+// system keys; these values must never be altered or reordered.
+const (
+	// Resolution10s stores data with a sample resolution of 10 seconds.
+	Resolution10s Resolution = 1
+)
+
+// sampleDurationByResolution is a map used to retrieve the sample duration
+// corresponding to a Resolution value. Sample durations are expressed in
+// nanoseconds.
+var sampleDurationByResolution = map[Resolution]int64{
+	Resolution10s: int64(time.Second * 10),
+}
+
+// keyDurationByResolution is a map used to retrieve the key duration
+// corresponding to a Resolution value; the key duration determines how many
+// samples are stored at a single Cockroach key. Sample durations are expressed
+// in nanoseconds.
+var keyDurationByResolution = map[Resolution]int64{
+	Resolution10s: int64(time.Hour),
+}
+
+// SampleDuration returns the sample duration corresponding to this resolution
+// value, expressed in nanoseconds.
+func (r Resolution) SampleDuration() int64 {
+	duration, ok := sampleDurationByResolution[r]
+	if !ok {
+		panic(fmt.Sprintf("no sample duration found for resolution value %v", r))
+	}
+	return duration
+}
+
+// KeyDuration returns the sample duration corresponding to this resolution
+// value, expressed in nanoseconds. The key duration determines how many samples
+// are stored at a single Cockroach key.
+func (r Resolution) KeyDuration() int64 {
+	duration, ok := keyDurationByResolution[r]
+	if !ok {
+		panic(fmt.Sprintf("no key duration found for resolution value %v", r))
+	}
+	return duration
+}


### PR DESCRIPTION
This commit creates the /ts package for handling time series data.

Included in the initial commit is the encoding and decoding logic for time
series data keys. This logic constructs cockroach keys based on the metric name
and timestamp for datapoints; this should providing a usefully ordered
distribution of time series data.
