### PR TITLE
Eliminate "init" command in favor of "start" only with -bootstrap flag(s...

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,10 +60,10 @@ root@82cb657cdc42:/cockroach#
 Now we're in an environment that has everything set up, and we start by firing up a node:
 
 ```bash
-$ ./cockroach init -stores ssd="$(mktemp -d /tmp/dbXXX)" &> node.log &
+$ ./cockroach start -bootstrap -stores ssd="$(mktemp -d /tmp/dbXXX)" &> node.log &
 [...]
 ```
-This bootstraps and starts a single-node cluster in the background, with logs sent to `node.log`.
+This bootstraps (-bootstrap flags) and starts a single-node cluster in the background, with logs sent to `node.log`.
 
 ##### Built-in client
 
@@ -144,7 +144,7 @@ Once you've built your image, you may want to run the tests:
 Assuming you've built `cockroachdb/cockroach`, let's run a simple Cockroach node in the background:
 
 ```bash
-$ docker run -p 8080:8080 -d cockroachdb/cockroach init \
+$ docker run -p 8080:8080 -d cockroachdb/cockroach start -bootstrap \
     -stores ssd="$(mktemp -d /tmp/dbXXX)"
 ```
 

--- a/README.md
+++ b/README.md
@@ -57,13 +57,15 @@ $ docker run -t -i -p 8080:8080 cockroachdb/cockroach shell
 root@82cb657cdc42:/cockroach#
 ```
 
-Now we're in an environment that has everything set up, and we start by firing up a node:
+Now we're in an environment that has everything set up, and we start by first initializing the cluster and then firing up a node:
 
 ```bash
-$ ./cockroach start -bootstrap -stores ssd="$(mktemp -d /tmp/dbXXX)" &> node.log &
+$ DIR=$(mktemp -d /tmp/dbXXX)
+$ ./cockroach init $DIR"
+$ ./cockroach start -stores ssd="$DIR" &> node.log &
 [...]
 ```
-This bootstraps (-bootstrap flags) and starts a single-node cluster in the background, with logs sent to `node.log`.
+This initializes and starts a single-node cluster in the background, with logs sent to `node.log`.
 
 ##### Built-in client
 
@@ -144,8 +146,8 @@ Once you've built your image, you may want to run the tests:
 Assuming you've built `cockroachdb/cockroach`, let's run a simple Cockroach node in the background:
 
 ```bash
-$ docker run -p 8080:8080 -d cockroachdb/cockroach start -bootstrap \
-    -stores ssd="$(mktemp -d /tmp/dbXXX)"
+$ docker run -p 8080:8080 -d -v /cr-data cockroachdb/cockroach init /cr-data
+$ docker run -p 8080:8080 -d -v /cr-data cockroachdb/cockroach start -bootstrap -stores ssd=/cr-data
 ```
 
 Run `docker run cockroachdb/cockroach help` to get an overview over the available commands and settings, and see [Running Cockroach](#running-cockroach) for first steps on interacting with your new node.

--- a/README.md
+++ b/README.md
@@ -146,8 +146,8 @@ Once you've built your image, you may want to run the tests:
 Assuming you've built `cockroachdb/cockroach`, let's run a simple Cockroach node in the background:
 
 ```bash
-$ docker run -p 8080:8080 -d -v /cr-data cockroachdb/cockroach init /cr-data
-$ docker run -p 8080:8080 -d -v /cr-data cockroachdb/cockroach start -bootstrap -stores ssd=/cr-data
+$ docker run -p 8080:8080 -v /data cockroachdb/cockroach init /data
+$ docker run -p 8080:8080 -d --volumes-from=$(docker ps -q -n 1) cockroachdb/cockroach start -stores ssd=/data
 ```
 
 Run `docker run cockroachdb/cockroach help` to get an overview over the available commands and settings, and see [Running Cockroach](#running-cockroach) for first steps on interacting with your new node.

--- a/run/local-cluster.sh
+++ b/run/local-cluster.sh
@@ -98,14 +98,12 @@ PORT=8080
 # Start all nodes.
 for i in $(seq 1 $NODES); do
   HOSTS[$i]="$COCKROACH_NAME$i.local"
-
-  CMD="start"
   VOL="/data$i"
 
   # Command args specify two data directories per instance to simulate two physical devices.
-  CMD_ARGS="-gossip=${HOSTS[1]}:$PORT -stores=ssd=$VOL -addr=${HOSTS[$i]}:$PORT"
+  START_ARGS="-gossip=${HOSTS[1]}:$PORT -stores=ssd=$VOL -addr=${HOSTS[$i]}:$PORT"
   # Log (almost) everything.
-  #CMD_ARGS="${CMD_ARGS} -v 7"
+  #START_ARGS="${START_ARGS} -v 7"
   # Node-specific arguments for node container.
   NODE_ARGS="--hostname=${HOSTS[$i]} --name=${HOSTS[$i]} --dns=$DNS_IP"
 
@@ -119,7 +117,7 @@ for i in $(seq 1 $NODES); do
 
   # Start Cockroach docker container and corral HTTP port and docker
   # IP address for container-local DNS.
-  CIDS[$i]=$(docker run $STD_ARGS $NODE_ARGS $COCKROACH_IMAGE $CMD $CMD_ARGS)
+  CIDS[$i]=$(docker run $STD_ARGS $NODE_ARGS $COCKROACH_IMAGE start $START_ARGS)
   PORTS[$i]=$(echo $(docker port ${CIDS[$i]} 8080) | sed 's/.*://')
   IP=$(docker inspect --format '{{ .NetworkSettings.IPAddress }}' ${CIDS[$i]})
   IP_HOST[$i]="$IP ${HOSTS[$i]}"

--- a/run/local-cluster.sh
+++ b/run/local-cluster.sh
@@ -100,13 +100,13 @@ for i in $(seq 1 $NODES); do
 
   # If this is the first node, command is init; otherwise start.
   CMD="start"
-  if [[ $i == 1 ]]; then
-      CMD="init"
-  fi
   # Command args specify two data directories per instance to simulate two physical devices.
-  CMD_ARGS="-gossip=${HOSTS[1]}:$PORT -stores=hdd=/tmp/disk1,hdd=/tmp/disk2 -addr=${HOSTS[$i]}:$PORT -init_and_start"
+  CMD_ARGS="-gossip=${HOSTS[1]}:$PORT -stores=hdd=/tmp/disk1,hdd=/tmp/disk2 -addr=${HOSTS[$i]}:$PORT"
   # Log (almost) everything.
   CMD_ARGS="${CMD_ARGS} -v 7"
+  if [[ $i == 1 ]]; then
+      CMD_ARGS="${CMD_ARGS} -bootstrap"
+  fi
 
   # Node-specific arguments for node container.
   NODE_ARGS="--hostname=${HOSTS[$i]} --name=${HOSTS[$i]} --dns=$DNS_IP"

--- a/server/admin_client.go
+++ b/server/admin_client.go
@@ -54,7 +54,7 @@ func SendQuit(ctx *Context) error {
 		return util.Errorf("admin REST request failed: %s", err)
 	}
 
-	fmt.Printf("node drain and shutdown: %s\n", string(b))
+	fmt.Printf("node drained and shutdown: %s", string(b))
 
 	return nil
 }

--- a/server/admin_client.go
+++ b/server/admin_client.go
@@ -1,0 +1,60 @@
+// Copyright 2015 The Cockroach Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+// implied. See the License for the specific language governing
+// permissions and limitations under the License. See the AUTHORS file
+// for names of contributors.
+//
+// Author: Spencer Kimball (spencer.kimball@gmail.com)
+
+package server
+
+import (
+	"fmt"
+	"io/ioutil"
+	"net/http"
+
+	"github.com/cockroachdb/cockroach/util"
+)
+
+// sendAdminRequest send an HTTP request and processes the response for
+// its body or error message if a non-200 response code.
+func sendAdminRequest(req *http.Request) ([]byte, error) {
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		return nil, util.Errorf("admin REST request failed: %s", err)
+	}
+	defer resp.Body.Close()
+	b, err := ioutil.ReadAll(resp.Body)
+	if err != nil {
+		return nil, util.Errorf("unable to read admin REST response: %s", err)
+	}
+	if resp.StatusCode != 200 {
+		return nil, util.Errorf("%s: %s", resp.Status, string(b))
+	}
+	return b, nil
+}
+
+// SendQuit requests the admin quit path to drain and shutdown the server.
+func SendQuit(ctx *Context) error {
+	req, err := http.NewRequest("GET", fmt.Sprintf("%s://%s%s", adminScheme, ctx.Addr, quitPath), nil)
+	if err != nil {
+		return util.Errorf("unable to create request to admin REST endpoint: %s", err)
+	}
+	b, err := sendAdminRequest(req)
+	if err != nil {
+		return util.Errorf("admin REST request failed: %s", err)
+	}
+
+	fmt.Printf("node drain and shutdown: %s\n", string(b))
+
+	return nil
+}

--- a/server/cli/cli.go
+++ b/server/cli/cli.go
@@ -67,7 +67,9 @@ var allCmds = &commander.Commander{
 	Name: "cockroach",
 	Commands: []*commander.Command{
 		// Node commands.
+		initCmd,
 		startCmd,
+		exterminateCmd,
 		quitCmd,
 
 		// Key/value commands.

--- a/server/cli/cli.go
+++ b/server/cli/cli.go
@@ -66,8 +66,7 @@ Output build version information.
 var allCmds = &commander.Commander{
 	Name: "cockroach",
 	Commands: []*commander.Command{
-		// Initialization commands.
-		initCmd,
+		// Node commands.
 		startCmd,
 		quitCmd,
 

--- a/server/cli/cli_test.go
+++ b/server/cli/cli_test.go
@@ -93,7 +93,7 @@ func ExampleBasic() {
 	// inc c b
 	// invalid increment: b: strconv.ParseInt: parsing "b": invalid syntax
 	// quit
-	// node drain and shutdown: ok
+	// node drained and shutdown: ok
 }
 
 func ExampleSplitMergeRanges() {
@@ -137,5 +137,5 @@ func ExampleSplitMergeRanges() {
 	// "c"	3
 	// "d"	4
 	// quit
-	// node drain and shutdown: ok
+	// node drained and shutdown: ok
 }

--- a/server/cli/flags.go
+++ b/server/cli/flags.go
@@ -58,14 +58,6 @@ func initFlags(ctx *server.Context) {
 		"of -max-offset, it will commit suicide. Setting this value too high may "+
 		"decrease transaction performance in the presence of contention.")
 
-	flag.BoolVar(&ctx.Bootstrap, "bootstrap", ctx.Bootstrap, "specify "+
-		"to first bootstrap the cluster using the first store specified. This is a "+
-		"one-time operation which chooses a unique cluster ID. After bootstrapping, "+
-		"a node may never be restarted with this flag. See -bootstrap-only also.")
-
-	flag.BoolVar(&ctx.BootstrapOnly, "bootstrap-only", ctx.BootstrapOnly, "specify "+
-		"to bootstrap the cluster and exit. See -bootstrap for additional details.")
-
 	// Gossip flags.
 
 	flag.StringVar(&ctx.GossipBootstrap, "gossip", ctx.GossipBootstrap,

--- a/server/cli/flags.go
+++ b/server/cli/flags.go
@@ -29,9 +29,9 @@ import (
 func initFlags(ctx *server.Context) {
 	// Server flags.
 	flag.StringVar(&ctx.Addr, "addr", ctx.Addr, "when run as the server the host:port to bind for "+
-		"HTTP/RPC traffic; when run as the client the address for connection to the cockroach cluster")
+		"HTTP/RPC traffic; when run as the client the address for connection to the cockroach cluster.")
 
-	flag.StringVar(&ctx.Certs, "certs", ctx.Certs, "directory containing RSA key and x509 certs")
+	flag.StringVar(&ctx.Certs, "certs", ctx.Certs, "directory containing RSA key and x509 certs.")
 
 	flag.StringVar(&ctx.Stores, "stores", ctx.Stores, "specify a comma-separated list of stores, "+
 		"specified by a colon-separated list of device attributes followed by '=' and "+
@@ -39,7 +39,7 @@ func initFlags(ctx *server.Context) {
 		"in-memory store. Device attributes typically include whether the store is "+
 		"flash (ssd), spinny disk (hdd), fusion-io (fio), in-memory (mem); device "+
 		"attributes might also include speeds and other specs (7200rpm, 200kiops, etc.). "+
-		"For example, -store=hdd:7200rpm=/mnt/hda1,ssd=/mnt/ssd01,ssd=/mnt/ssd02,mem=1073741824")
+		"For example, -store=hdd:7200rpm=/mnt/hda1,ssd=/mnt/ssd01,ssd=/mnt/ssd02,mem=1073741824.")
 
 	flag.StringVar(&ctx.Attrs, "attrs", ctx.Attrs, "specify an ordered, colon-separated list of node "+
 		"attributes. Attributes are arbitrary strings specifying topography or "+
@@ -52,22 +52,27 @@ func initFlags(ctx *server.Context) {
 		"specified first and in the same order for all nodes. "+
 		"For example: -attrs=us-west-1b,gpu.")
 
-	flag.DurationVar(&ctx.MaxOffset, "max_offset", ctx.MaxOffset, "specify "+
+	flag.DurationVar(&ctx.MaxOffset, "max-offset", ctx.MaxOffset, "specify "+
 		"the maximum clock offset for the cluster. Clock offset is measured on all "+
 		"node-to-node links and if any node notices it has clock offset in excess "+
-		"of -max_offset, it will commit suicide. Setting this value too high may "+
+		"of -max-offset, it will commit suicide. Setting this value too high may "+
 		"decrease transaction performance in the presence of contention.")
 
-	flag.BoolVar(&ctx.InitAndStart, "init_and_start", ctx.InitAndStart, "specify "+
-		"to start the server after bootstrapping with the init command.")
+	flag.BoolVar(&ctx.Bootstrap, "bootstrap", ctx.Bootstrap, "specify "+
+		"to first bootstrap the cluster using the first store specified. This is a "+
+		"one-time operation which chooses a unique cluster ID. After bootstrapping, "+
+		"a node may never be restarted with this flag. See -bootstrap-only also.")
+
+	flag.BoolVar(&ctx.BootstrapOnly, "bootstrap-only", ctx.BootstrapOnly, "specify "+
+		"to bootstrap the cluster and exit. See -bootstrap for additional details.")
 
 	// Gossip flags.
 
 	flag.StringVar(&ctx.GossipBootstrap, "gossip", ctx.GossipBootstrap,
-		"addresses (comma-separated host:port pairs) of node addresses for gossip bootstrap")
+		"addresses (comma-separated host:port pairs) of node addresses for gossip bootstrap.")
 
-	flag.DurationVar(&ctx.GossipInterval, "gossip_interval", ctx.GossipInterval,
-		"approximate interval (time.Duration) for gossiping new information to peers")
+	flag.DurationVar(&ctx.GossipInterval, "gossip-interval", ctx.GossipInterval,
+		"approximate interval (time.Duration) for gossiping new information to peers.")
 
 	// KV flags.
 
@@ -77,8 +82,8 @@ func initFlags(ctx *server.Context) {
 
 	// Engine flags.
 
-	flag.Int64Var(&ctx.CacheSize, "cache_size", ctx.CacheSize, "total size in bytes for "+
-		"caches, shared evenly if there are multiple storage devices")
+	flag.Int64Var(&ctx.CacheSize, "cache-size", ctx.CacheSize, "total size in bytes for "+
+		"caches, shared evenly if there are multiple storage devices.")
 }
 
 func init() {

--- a/server/config.go
+++ b/server/config.go
@@ -36,24 +36,6 @@ import (
 	gogoproto "github.com/gogo/protobuf/proto"
 )
 
-// sendAdminRequest send an HTTP request and processes the response for
-// its body or error message if a non-200 response code.
-func sendAdminRequest(req *http.Request) ([]byte, error) {
-	resp, err := http.DefaultClient.Do(req)
-	if err != nil {
-		return nil, util.Errorf("admin REST request failed: %s", err)
-	}
-	defer resp.Body.Close()
-	b, err := ioutil.ReadAll(resp.Body)
-	if err != nil {
-		return nil, util.Errorf("unable to read admin REST response: %s", err)
-	}
-	if resp.StatusCode != 200 {
-		return nil, util.Errorf("%s: %s", resp.Status, string(b))
-	}
-	return b, nil
-}
-
 // Gets a friendly name for output based on the passed in config prefix.
 func getFriendlyNameFromPrefix(prefix string) string {
 	switch prefix {
@@ -327,20 +309,4 @@ func deleteConfig(db *client.KV, configPrefix proto.Key, path string, r *http.Re
 			User: storage.UserRoot,
 		},
 	}, &proto.DeleteResponse{})
-}
-
-// RunQuit fetches the admin quitquitquit path to drain and shutdown
-// the server.
-func RunQuit(ctx *Context) {
-	req, err := http.NewRequest("GET", fmt.Sprintf("%s://%s%s", adminScheme, ctx.Addr, quitPath), nil)
-	if err != nil {
-		log.Errorf("unable to create request to admin REST endpoint: %s", err)
-		return
-	}
-	b, err := sendAdminRequest(req)
-	if err != nil {
-		log.Errorf("admin REST request failed: %s", err)
-		return
-	}
-	fmt.Fprintf(os.Stdout, "node drain and shutdown: %s", string(b))
 }

--- a/server/context.go
+++ b/server/context.go
@@ -70,15 +70,6 @@ type Context struct {
 	// Maximum clock offset for the cluster.
 	MaxOffset time.Duration
 
-	// Bootstrap first bootstraps the cluster using the first store
-	// specified.  This option cannot be specified twice when starting a
-	// node.
-	Bootstrap bool
-
-	// BootstrapOnly bootstraps the cluster using the first store
-	// specified and exits.
-	BootstrapOnly bool
-
 	// GossipBootstrap is a comma-separated list of node addresses that
 	// act as bootstrap hosts for connecting to the gossip network.
 	GossipBootstrap string
@@ -139,7 +130,7 @@ func (ctx *Context) Init() error {
 		// list of attributes and the path.
 		engine, err := ctx.initEngine(store[1], store[2])
 		if err != nil {
-			return util.Errorf("unable to init engine for store %q: %v", store[0], err)
+			return util.Errorf("unable to init engine for store %q: %s", store[0], err)
 		}
 		ctx.Engines = append(ctx.Engines, engine)
 	}

--- a/server/context.go
+++ b/server/context.go
@@ -70,8 +70,14 @@ type Context struct {
 	// Maximum clock offset for the cluster.
 	MaxOffset time.Duration
 
-	// InitAndStart starts the server after bootstrap & initialization.
-	InitAndStart bool
+	// Bootstrap first bootstraps the cluster using the first store
+	// specified.  This option cannot be specified twice when starting a
+	// node.
+	Bootstrap bool
+
+	// BootstrapOnly bootstraps the cluster using the first store
+	// specified and exits.
+	BootstrapOnly bool
 
 	// GossipBootstrap is a comma-separated list of node addresses that
 	// act as bootstrap hosts for connecting to the gossip network.
@@ -106,15 +112,11 @@ type Context struct {
 // NewContext returns a Context with default values.
 func NewContext() *Context {
 	return &Context{
-		Addr: defaultAddr,
-
-		MaxOffset: defaultMaxOffset,
-
-		GossipInterval: defaultGossipInterval,
-
+		Addr:            defaultAddr,
+		MaxOffset:       defaultMaxOffset,
+		GossipInterval:  defaultGossipInterval,
 		GossipBootstrap: defaultGossipBootstrap,
-
-		CacheSize: defaultCacheSize,
+		CacheSize:       defaultCacheSize,
 	}
 }
 

--- a/server/node.go
+++ b/server/node.go
@@ -250,6 +250,7 @@ func (n *Node) initStores(clock *hlc.Clock, engines []engine.Engine, stopper *ut
 		// adding the store to the bootstraps list.
 		if err := s.Start(stopper); err != nil {
 			if _, ok := err.(*storage.NotBootstrappedError); ok {
+				log.Infof("store %s not bootstrapped", s)
 				bootstraps.PushBack(s)
 				continue
 			}

--- a/storage/store.go
+++ b/storage/store.go
@@ -581,9 +581,17 @@ func (s *Store) Bootstrap(ident proto.StoreIdent, stopper *util.Stopper) error {
 	s.Ident = ident
 	kvs, err := engine.Scan(s.engine, proto.EncodedKey(engine.KeyMin), proto.EncodedKey(engine.KeyMax), 1)
 	if err != nil {
-		return util.Errorf("unable to scan engine to verify empty: %s", err)
+		return util.Errorf("store %s: unable to access: %s", s.engine, err)
 	} else if len(kvs) > 0 {
-		return util.Errorf("non-empty engine %s (first key: %q)", s.engine, kvs[0].Key)
+		// See if this is an already-bootrapped store.
+		ok, err := engine.MVCCGetProto(s.engine, engine.StoreIdentKey(), proto.ZeroTimestamp, true, nil, &s.Ident)
+		if err != nil {
+			return util.Errorf("store %s is non-empty but cluster ID could not be determined: %s", s.engine, err)
+		}
+		if ok {
+			return util.Errorf("store %s already belongs to cockroach cluster %s", s.engine, s.Ident.ClusterID)
+		}
+		return util.Errorf("store %s is not-empty and has invalid contents (first key: %q)", s.engine, kvs[0].Key)
 	}
 	err = engine.MVCCPutProto(s.engine, nil, engine.StoreIdentKey(), proto.ZeroTimestamp, nil, &s.Ident)
 	return err

--- a/storage/store.go
+++ b/storage/store.go
@@ -583,7 +583,7 @@ func (s *Store) Bootstrap(ident proto.StoreIdent, stopper *util.Stopper) error {
 	if err != nil {
 		return util.Errorf("store %s: unable to access: %s", s.engine, err)
 	} else if len(kvs) > 0 {
-		// See if this is an already-bootrapped store.
+		// See if this is an already-bootstrapped store.
 		ok, err := engine.MVCCGetProto(s.engine, engine.StoreIdentKey(), proto.ZeroTimestamp, true, nil, &s.Ident)
 		if err != nil {
 			return util.Errorf("store %s is non-empty but cluster ID could not be determined: %s", s.engine, err)


### PR DESCRIPTION
...).

Removed -init_and_start and added -bootstrap and -bootstrap-only flags.
Also cleaned up error logging in Store.Bootstrap to make more sense.

Changed multi-word flags to using hyphens instead of underscores.

Updated docs and local-cluster.sh script.

Fixes #662
