### PR TITLE
Bootstrap address resolvers.

### DIFF
--- a/gossip/resolver.go
+++ b/gossip/resolver.go
@@ -1,0 +1,111 @@
+// Copyright 2015 The Cockroach Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+// implied. See the License for the specific language governing
+// permissions and limitations under the License. See the AUTHORS file
+// for names of contributors.
+//
+// Author: Marc Berhault (marc@cockroachlabs.com)
+
+package gossip
+
+import (
+	"net"
+	"strings"
+
+	"github.com/cockroachdb/cockroach/util"
+	"github.com/cockroachdb/cockroach/util/log"
+)
+
+// Resolver represents the different types of node resolvers.
+// Based on the ResolverType, it will return the same
+// address multiple times (eg: "lb") or not (eg: "tcp").
+type Resolver struct {
+	ResolverType string
+	Address      string
+	// indicates whether we should try this resolver again.
+	IsExhausted bool
+}
+
+// GetAddress returns a net.Addr.
+func (r *Resolver) GetAddress() (net.Addr, error) {
+	switch r.ResolverType {
+	case "unix":
+		addr, err := net.ResolveUnixAddr("unix", r.Address)
+		if err != nil {
+			return nil, err
+		}
+		r.IsExhausted = true
+		return addr, nil
+	case "tcp", "lb":
+		_, err := net.ResolveTCPAddr("tcp", r.Address)
+		if err != nil {
+			return nil, err
+		}
+		if r.ResolverType == "tcp" {
+			// "tcp" resolvers point to a single host. "lb" have an unknown of number of backends.
+			r.IsExhausted = true
+		}
+		return util.MakeRawAddr("tcp", r.Address), nil
+	}
+	return nil, util.Errorf("unknown address type: %q", r.ResolverType)
+}
+
+// NewResolver takes a resolver specification and returns a new resolver.
+// A specification is of the form: [<network type>=]<address>
+// Network type can be one of:
+// - tcp: plain hostname of ip address
+// - lb: load balancer host name or ip: points to an unknown number of backends
+// - unix: unix sockets
+// If "network type" is not specified, "tcp" is assumed.
+func NewResolver(spec string) (*Resolver, error) {
+	parts := strings.Split(spec, "=")
+	var resolverType, address string
+	if len(parts) == 1 {
+		// No type specified: assume "tcp".
+		resolverType = "tcp"
+		address = strings.TrimSpace(parts[0])
+	} else if len(parts) == 2 {
+		resolverType = strings.TrimSpace(parts[0])
+		address = strings.TrimSpace(parts[1])
+	} else {
+		return nil, util.Errorf("unable to parse gossip resolver spec: %q", spec)
+	}
+
+	// We should not have an empty address at this point.
+	if len(address) == 0 {
+		return nil, util.Errorf("invalid address value in gossip resolver spec: %q", spec)
+	}
+
+	// Validate the type.
+	if resolverType != "tcp" && resolverType != "lb" && resolverType != "unix" {
+		return nil, util.Errorf("unknown address type in gossip resolver spec: %q, "+
+			"valid types are 'tcp', 'lb', 'unix'", spec)
+	}
+
+	// If we're on tcp or lb make sure we fill in the host when not specified (eg: ":8080")
+	if resolverType == "tcp" || resolverType == "lb" {
+		address = util.EnsureHost(address)
+	}
+
+	return &Resolver{resolverType, address, false}, nil
+}
+
+// NewResolverFromAddress take a net.Addr and contructs a resolver.
+func NewResolverFromAddress(addr net.Addr) *Resolver {
+	switch addr.Network() {
+	case "tcp", "unix":
+		return &Resolver{addr.Network(), addr.String(), false}
+	default:
+		log.Fatalf("unknown address network %q for %v", addr.Network(), addr)
+		return nil
+	}
+}

--- a/gossip/resolver_test.go
+++ b/gossip/resolver_test.go
@@ -1,0 +1,103 @@
+// Copyright 2015 The Cockroach Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+// implied. See the License for the specific language governing
+// permissions and limitations under the License. See the AUTHORS file
+// for names of contributors.
+//
+// Author: Marc Berhault (marc@cockroachlabs.com)
+
+package gossip
+
+import (
+	"os"
+	"testing"
+)
+
+func TestParseResolverSpec(t *testing.T) {
+	myHost, err := os.Hostname()
+	if err != nil {
+		myHost = "127.0.0.1"
+	}
+	testCases := []struct {
+		input           string
+		success         bool
+		resolverType    string
+		resolverAddress string
+	}{
+		// Ports are not checked at parsing time. They are at GetAddress time though.
+		{"127.0.0.1:8080", true, "tcp", "127.0.0.1:8080"},
+		{":8080", true, "tcp", myHost + ":8080"},
+		{"127.0.0.1", true, "tcp", "127.0.0.1"},
+		{"tcp=127.0.0.1", true, "tcp", "127.0.0.1"},
+		{"lb=127.0.0.1", true, "lb", "127.0.0.1"},
+		{"unix=/tmp/unix-socket12345", true, "unix", "/tmp/unix-socket12345"},
+		{"", false, "", ""},
+		{"foo=127.0.0.1", false, "", ""},
+		{"lb=", false, "", ""},
+	}
+
+	for tcNum, tc := range testCases {
+		resolver, err := NewResolver(tc.input)
+		if (err == nil) != tc.success {
+			t.Errorf("#%d: expected success=%t, got err=%v", tcNum, tc.success, err)
+		}
+		if err != nil {
+			continue
+		}
+		if resolver.ResolverType != tc.resolverType {
+			t.Errorf("#%d: expected resolverType=%s, got %+v", tcNum, tc.resolverType, resolver)
+		}
+		if resolver.Address != tc.resolverAddress {
+			t.Errorf("#%d: expected resolverAddress=%s, got %+v", tcNum, tc.resolverAddress, resolver)
+		}
+	}
+}
+
+func TestGetAddress(t *testing.T) {
+	testCases := []struct {
+		resolverType    string
+		resolverAddress string
+		success         bool
+		oneShot         bool
+		addressType     string
+		addressValue    string
+	}{
+		{"tcp", "127.0.0.1:8080", true, true, "tcp", "127.0.0.1:8080"},
+		{"tcp", "127.0.0.1", false, false, "", ""},
+		{"tcp", "localhost:80", true, true, "tcp", "localhost:80"},
+		// We should test unresolvable dns too, but this would be fragile.
+		{"lb", "localhost:80", true, false, "tcp", "localhost:80"},
+		{"lb", "127.0.0.1:80", true, false, "tcp", "127.0.0.1:80"},
+		{"lb", "127.0.0.1", false, false, "", ""},
+		{"unix", "/tmp/foo", true, true, "unix", "/tmp/foo"},
+	}
+
+	for tcNum, tc := range testCases {
+		resolver := &Resolver{tc.resolverType, tc.resolverAddress, false}
+		address, err := resolver.GetAddress()
+		if (err == nil) != tc.success {
+			t.Errorf("#%d: expected success=%t, got err=%v", tcNum, tc.success, err)
+		}
+		if err != nil {
+			continue
+		}
+		if resolver.IsExhausted != tc.oneShot {
+			t.Errorf("#%d: expected exhausted resolver=%t, but is: %+v", tcNum, tc.oneShot, resolver)
+		}
+		if address.Network() != tc.addressType {
+			t.Errorf("#%d: expected address type=%s, got %+v", tcNum, tc.addressType, address)
+		}
+		if address.String() != tc.addressValue {
+			t.Errorf("#%d: expected address value=%s, got %+v", tcNum, tc.addressValue, address)
+		}
+	}
+}

--- a/gossip/simulation/network.go
+++ b/gossip/simulation/network.go
@@ -71,11 +71,12 @@ func NewNetwork(nodeCount int, networkType string,
 		}
 		addrs[i] = servers[i].Addr()
 	}
-	var bootstrap []net.Addr
-	if nodeCount < 3 {
-		bootstrap = addrs
-	} else {
-		bootstrap = addrs[:3]
+	var bootstrap []*gossip.Resolver
+	for i, addr := range addrs {
+		if i >= 3 {
+			break
+		}
+		bootstrap = append(bootstrap, gossip.NewResolverFromAddress(addr))
 	}
 
 	stopper := util.NewStopper()

--- a/gossip/simulation/network.go
+++ b/gossip/simulation/network.go
@@ -71,17 +71,18 @@ func NewNetwork(nodeCount int, networkType string,
 		}
 		addrs[i] = servers[i].Addr()
 	}
-	var bootstrap []*gossip.Resolver
-	for i, addr := range addrs {
-		if i >= 3 {
-			break
-		}
-		bootstrap = append(bootstrap, gossip.NewResolverFromAddress(addr))
-	}
-
 	stopper := util.NewStopper()
 	nodes := make([]*Node, nodeCount)
 	for i := 0; i < nodeCount; i++ {
+		// Build new resolvers for each instance or we'll get data races.
+		var bootstrap []*gossip.Resolver
+		for i, addr := range addrs {
+			if i >= 3 {
+				break
+			}
+			bootstrap = append(bootstrap, gossip.NewResolverFromAddress(addr))
+		}
+
 		node := gossip.New(rpcContext, gossipInterval, bootstrap)
 		node.SetNodeID(proto.NodeID(i))
 		node.Start(servers[i], stopper)

--- a/server/cli/flags.go
+++ b/server/cli/flags.go
@@ -59,9 +59,11 @@ func initFlags(ctx *server.Context) {
 		"decrease transaction performance in the presence of contention.")
 
 	// Gossip flags.
-
-	flag.StringVar(&ctx.GossipBootstrap, "gossip", ctx.GossipBootstrap,
-		"addresses (comma-separated host:port pairs) of node addresses for gossip bootstrap.")
+	flag.StringVar(&ctx.GossipBootstrap, "gossip", ctx.GossipBootstrap, "specify a "+
+		"comma-separated list of gossip addresses or resolvers for gossip bootstrap. "+
+		"Each item in the list has an optional type: [type=]<address>. "+
+		"Unspecified type means ip address or dns. Type can also be a load balancer (\"lb\"), "+
+		"or a unix socket (\"unix\")")
 
 	flag.DurationVar(&ctx.GossipInterval, "gossip-interval", ctx.GossipInterval,
 		"approximate interval (time.Duration) for gossiping new information to peers.")

--- a/server/context_test.go
+++ b/server/context_test.go
@@ -18,11 +18,10 @@
 package server
 
 import (
-	"net"
 	"reflect"
 	"testing"
 
-	"github.com/cockroachdb/cockroach/util"
+	"github.com/cockroachdb/cockroach/gossip"
 )
 
 func TestParseNodeAttributes(t *testing.T) {
@@ -47,11 +46,11 @@ func TestParseGossipBootstrapAddrs(t *testing.T) {
 	if err := ctx.Init(); err != nil {
 		t.Fatalf("Failed to initialize the context: %v", err)
 	}
-	expected := []net.Addr{
-		util.MakeRawAddr("tcp", "localhost:12345"),
-		util.MakeRawAddr("tcp", "localhost:23456"),
+	expected := []*gossip.Resolver{
+		{"tcp", "localhost:12345", false},
+		{"tcp", "localhost:23456", false},
 	}
-	if !reflect.DeepEqual(ctx.GossipBootstrapAddrs, expected) {
-		t.Fatalf("Unexpected bootstrap addresses: %v", ctx.GossipBootstrapAddrs)
+	if !reflect.DeepEqual(ctx.GossipBootstrapResolvers, expected) {
+		t.Fatalf("Unexpected bootstrap addresses: %v, expected: %v", ctx.GossipBootstrapResolvers, expected)
 	}
 }

--- a/server/node_test.go
+++ b/server/node_test.go
@@ -56,13 +56,13 @@ func createTestNode(addr net.Addr, engines []engine.Engine, gossipBS net.Addr, t
 	if err := rpcServer.Start(); err != nil {
 		t.Fatal(err)
 	}
-	g := gossip.New(rpcContext, testContext.GossipInterval, testContext.GossipBootstrapAddrs)
+	g := gossip.New(rpcContext, testContext.GossipInterval, testContext.GossipBootstrapResolvers)
 	if gossipBS != nil {
 		// Handle possibility of a :0 port specification.
 		if gossipBS == addr {
 			gossipBS = rpcServer.Addr()
 		}
-		g.SetBootstrap([]net.Addr{gossipBS})
+		g.SetResolvers([]*gossip.Resolver{gossip.NewResolverFromAddress(gossipBS)})
 		g.Start(rpcServer, stopper)
 	}
 	db := client.NewKV(nil, kv.NewDistSender(&kv.DistSenderContext{Clock: clock}, g))


### PR DESCRIPTION
The --gossip flag now takes a comma-separated list of:
[type=]address
type can be one of "lb", "tcp", "unix".
If type is not specified, "tcp" is assumed.

The only difference is that the bootstrap initialization will keep
thinking there are unused addresses when "lb" is specified since there
may be an unknown number of backends.

This is needed to allow us to specify a AWS load balancer to --gossip.
Since unconnected nodes may be resolved first, we want it to keep trying.

Unix sockets can be specified on the command line as well, but this is
mostly because we use them in tests.
