### PR TITLE
Remove an erroneous stopper.StartTask() in multiraft.

### DIFF
--- a/multiraft/multiraft.go
+++ b/multiraft/multiraft.go
@@ -770,7 +770,6 @@ func (s *state) handleWriteResponse(response *writeResponse, readyGroups map[uin
 				if len(cc.Context) > 0 {
 					commandID, payload = decodeCommand(cc.Context)
 				}
-				s.stopper.StartTask()
 				s.sendEvent(&EventMembershipChangeCommitted{
 					GroupID:    groupID,
 					CommandID:  commandID,
@@ -809,7 +808,6 @@ func (s *state) handleWriteResponse(response *writeResponse, readyGroups map[uin
 							for _, prop := range g.pending {
 								s.proposalChan <- prop
 							}
-							s.stopper.FinishTask()
 						}
 					},
 				})


### PR DESCRIPTION
It is incorrect to call StartTask without looking at its result, and
this call should not be necessary since the goroutine that proposed the
conf change should have an active task.
