### PR TITLE
Fix the logic used to push timestamps forward based on the timestamp cache

### DIFF
--- a/proto/data.go
+++ b/proto/data.go
@@ -274,6 +274,22 @@ func (t Timestamp) Add(wallTime int64, logical int32) Timestamp {
 	}
 }
 
+// Next returns the timestamp with the next later timestamp.
+func (t *Timestamp) Next() Timestamp {
+	if t.Logical == math.MaxInt32 {
+		if t.WallTime == math.MaxInt32 {
+			panic("cannot take the next value to a max timestamp")
+		}
+		return Timestamp{
+			WallTime: t.WallTime + 1,
+		}
+	}
+	return Timestamp{
+		WallTime: t.WallTime,
+		Logical:  t.Logical + 1,
+	}
+}
+
 // Prev returns the next earliest timestamp.
 func (t *Timestamp) Prev() Timestamp {
 	if t.Logical > 0 {

--- a/proto/data_test.go
+++ b/proto/data_test.go
@@ -206,6 +206,21 @@ func TestEqual(t *testing.T) {
 	}
 }
 
+func TestTimestampNext(t *testing.T) {
+	testCases := []struct {
+		ts, expNext Timestamp
+	}{
+		{makeTS(1, 2), makeTS(1, 3)},
+		{makeTS(1, math.MaxInt32-1), makeTS(1, math.MaxInt32)},
+		{makeTS(1, math.MaxInt32), makeTS(2, 0)},
+	}
+	for i, c := range testCases {
+		if next := c.ts.Next(); !next.Equal(c.expNext) {
+			t.Errorf("%d: expected %s; got %s", i, c.expNext, next)
+		}
+	}
+}
+
 func TestTimestampPrev(t *testing.T) {
 	testCases := []struct {
 		ts, expPrev Timestamp

--- a/proto/errors.go
+++ b/proto/errors.go
@@ -155,7 +155,7 @@ func (e *WriteIntentError) Error() string {
 
 // Error formats error.
 func (e *WriteTooOldError) Error() string {
-	return fmt.Sprintf("write too old: timestamp %s < %s", e.Timestamp, e.ExistingTimestamp)
+	return fmt.Sprintf("write too old: timestamp %s <= %s", e.Timestamp, e.ExistingTimestamp)
 }
 
 // Error formats error.

--- a/storage/range.go
+++ b/storage/range.go
@@ -160,7 +160,7 @@ type RangeManager interface {
 	// Range manipulation methods.
 	AddRange(rng *Range) error
 	LookupRange(start, end proto.Key) *Range
-	MergeRange(subsumingRng *Range, updatedEndKey proto.Key, subsumedRaftID int64) error
+	MergeRange(subsumingRng *Range, updatedEndKey proto.Key, subsumedRaftID int64) (*Range, error)
 	NewRangeDescriptor(start, end proto.Key, replicas []proto.Replica) (*proto.RangeDescriptor, error)
 	NewSnapshot() engine.Engine
 	ProposeRaftCommand(cmdIDKey, proto.InternalRaftCommand) <-chan error
@@ -541,25 +541,24 @@ func (r *Range) addReadWriteCmd(method string, args proto.Request, reply proto.R
 		rTS, wTS := r.tsCache.GetMax(header.Key, header.EndKey, txnMD5)
 		r.Unlock()
 
-		// If there's a newer write timestamp and we're in a txn, set a
-		// write too old error in reply. We still go ahead and try the
-		// write; afterall, the cause of the higher timestamp may be an
-		// intent we can push.
-		if !wTS.Less(header.Timestamp) && header.Txn != nil {
-			err := &proto.WriteTooOldError{Timestamp: header.Timestamp, ExistingTimestamp: wTS}
-			reply.Header().SetGoError(err)
-		} else if !wTS.Less(header.Timestamp) || !rTS.Less(header.Timestamp) {
-			// Otherwise, make sure we advance the request's timestamp.
-			ts := wTS
-			if ts.Less(rTS) {
-				ts = rTS
+		// Always push the timestamp forward if there's been a read which
+		// occurred after our txn timestamp.
+		if !rTS.Less(header.Timestamp) {
+			header.Timestamp = rTS.Next()
+		}
+		// If there's a newer write timestamp...
+		if !wTS.Less(header.Timestamp) {
+			// If we're in a txn, set a write too old error in reply. We
+			// still go ahead and try the write because we want to avoid
+			// restarting the transaction in the event that there isn't an
+			// intent or the intent can be pushed by us.
+			if header.Txn != nil {
+				err := &proto.WriteTooOldError{Timestamp: header.Timestamp, ExistingTimestamp: wTS}
+				reply.Header().SetGoError(err)
+			} else {
+				// Otherwise, make sure we advance the request's timestamp.
+				header.Timestamp = wTS.Next()
 			}
-			if log.V(1) {
-				log.Infof("Overriding existing timestamp %s with %s", header.Timestamp, ts)
-			}
-			ts.Logical++ // increment logical component by one to differentiate.
-			// Update the request timestamp.
-			header.Timestamp = ts
 		}
 	}
 
@@ -1539,6 +1538,11 @@ func (r *Range) splitTrigger(batch engine.Engine, split *proto.SplitTrigger) err
 	}
 	newRng.stats.SetMVCCStats(batch, ms)
 
+	// Copy the timestamp cache into the new range.
+	r.Lock()
+	r.tsCache.MergeInto(newRng.tsCache, true)
+	r.Unlock()
+
 	return r.rm.SplitRange(r, newRng)
 }
 
@@ -1573,7 +1577,14 @@ func (r *Range) mergeTrigger(batch engine.Engine, merge *proto.MergeTrigger) err
 	}
 	r.stats.SetMVCCStats(batch, ms)
 
-	return r.rm.MergeRange(r, merge.UpdatedDesc.EndKey, merge.SubsumedRaftID)
+	subsumedRng, err := r.rm.MergeRange(r, merge.UpdatedDesc.EndKey, merge.SubsumedRaftID)
+	if err == nil {
+		// Merge the timestamp caches from both ranges.
+		r.Lock()
+		subsumedRng.tsCache.MergeInto(r.tsCache, false)
+		r.Unlock()
+	}
+	return err
 }
 
 func (r *Range) changeReplicasTrigger(change *proto.ChangeReplicasTrigger) error {

--- a/storage/range.go
+++ b/storage/range.go
@@ -1540,7 +1540,7 @@ func (r *Range) splitTrigger(batch engine.Engine, split *proto.SplitTrigger) err
 
 	// Copy the timestamp cache into the new range.
 	r.Lock()
-	r.tsCache.MergeInto(newRng.tsCache, true)
+	r.tsCache.MergeInto(newRng.tsCache, true /* clear */)
 	r.Unlock()
 
 	return r.rm.SplitRange(r, newRng)
@@ -1581,7 +1581,7 @@ func (r *Range) mergeTrigger(batch engine.Engine, merge *proto.MergeTrigger) err
 	if err == nil {
 		// Merge the timestamp caches from both ranges.
 		r.Lock()
-		subsumedRng.tsCache.MergeInto(r.tsCache, false)
+		subsumedRng.tsCache.MergeInto(r.tsCache, false /* clear */)
 		r.Unlock()
 	}
 	return err

--- a/storage/timestamp_cache.go
+++ b/storage/timestamp_cache.go
@@ -146,6 +146,27 @@ func (tc *TimestampCache) GetMax(start, end proto.Key, txnMD5 [md5.Size]byte) (p
 	return maxR, maxW
 }
 
+// MergeInto merges all entries from this timestamp cache into the
+// dest timestamp cache. The copy parameter, if true, copies the
+// values of lowWater and latest.
+func (tc *TimestampCache) MergeInto(dest *TimestampCache, copy bool) {
+	if copy {
+		dest.cache.Clear()
+		dest.lowWater = tc.lowWater
+		dest.latest = tc.latest
+	} else {
+		if dest.lowWater.Less(tc.lowWater) {
+			dest.lowWater = tc.lowWater
+		}
+		if dest.latest.Less(tc.latest) {
+			tc.latest = dest.latest
+		}
+	}
+	tc.cache.Do(func(k, v interface{}) {
+		dest.cache.Add(k, v)
+	})
+}
+
 // shouldEvict returns true if the cache entry's timestamp is no
 // longer within the minCacheWindow.
 func (tc *TimestampCache) shouldEvict(size int, key, value interface{}) bool {

--- a/storage/timestamp_cache.go
+++ b/storage/timestamp_cache.go
@@ -147,10 +147,11 @@ func (tc *TimestampCache) GetMax(start, end proto.Key, txnMD5 [md5.Size]byte) (p
 }
 
 // MergeInto merges all entries from this timestamp cache into the
-// dest timestamp cache. The copy parameter, if true, copies the
-// values of lowWater and latest.
-func (tc *TimestampCache) MergeInto(dest *TimestampCache, copy bool) {
-	if copy {
+// dest timestamp cache. The clear parameter, if true, copies the
+// values of lowWater and latest and clears the destination cache
+// before merging in the source.
+func (tc *TimestampCache) MergeInto(dest *TimestampCache, clear bool) {
+	if clear {
 		dest.cache.Clear()
 		dest.lowWater = tc.lowWater
 		dest.latest = tc.latest

--- a/storage/timestamp_cache_test.go
+++ b/storage/timestamp_cache_test.go
@@ -132,8 +132,8 @@ func TestTimestampCacheMergeInto(t *testing.T) {
 	clock := hlc.NewClock(manual.UnixNano)
 
 	testCases := []struct {
-		useCopy bool
-		expLen  int
+		useClear bool
+		expLen   int
 	}{
 		{true, 3},
 		{false, 5},
@@ -157,7 +157,7 @@ func TestTimestampCacheMergeInto(t *testing.T) {
 		cTS := clock.Now()
 		tc1.Add(proto.Key("c"), nil, cTS, proto.NoTxnMD5, true)
 
-		tc1.MergeInto(tc2, test.useCopy)
+		tc1.MergeInto(tc2, test.useClear)
 
 		if tc2.cache.Len() != test.expLen {
 			t.Errorf("expected merged length of %d; got %d", test.expLen, tc2.cache.Len())
@@ -172,7 +172,7 @@ func TestTimestampCacheMergeInto(t *testing.T) {
 		if rTS, _ := tc2.GetMax(proto.Key("b"), nil, proto.NoTxnMD5); !rTS.Equal(beTS) {
 			t.Error("expected \"b\" to have beTS timestamp")
 		}
-		if test.useCopy {
+		if test.useClear {
 			if rTS, _ := tc2.GetMax(proto.Key("aa"), nil, proto.NoTxnMD5); !rTS.Equal(adTS) {
 				t.Error("expected \"aa\" to have adTS timestamp")
 			}


### PR DESCRIPTION
In particular:
- Always push the timestamp forward if the timestamp cache indicates a
  read happened at same time or more recently.
- Next, if there's a write which happened at same time or more recently,
  and we're part of a txn, then set writeTooOldError, but instead of pushing
  the timestamp, we instead try to push the intent if possible.
  - Else, if we're not part of a txn, just set timestamp forward as there's
    no cost.

Also, on splits and merges, we now preserve the timestamp cache. For splits,
we simply copy the cache. For merges, we merge the caches. This preserves
the state of the original range(s) and prevents unnecessary txn restarts.

Added two test cases provided by @es-chow 
Fixes #676.
