### PR TITLE
Update Store Stats and convert MVCCStats into a proto.

### DIFF
--- a/proto/data.pb.go
+++ b/proto/data.pb.go
@@ -828,6 +828,111 @@ func (m *TimeSeriesData) GetDatapoints() []*TimeSeriesDatapoint {
 	return nil
 }
 
+// MVCCStats tracks byte and instance counts for:
+//  - Live key/values (i.e. what a scan at current time will reveal;
+//    note that this includes intent keys and values, but not keys and
+//    values with most recent value deleted)
+//  - Key bytes (includes all keys, even those with most recent value deleted)
+//  - Value bytes (includes all versions)
+//  - Key count (count of all keys, including keys with deleted tombstones)
+//  - Value count (all versions, including deleted tombstones)
+//  - Intents (provisional values written during txns)
+type MVCCStats struct {
+	LiveBytes        int64  `protobuf:"varint,1,opt,name=live_bytes" json:"live_bytes"`
+	KeyBytes         int64  `protobuf:"varint,2,opt,name=key_bytes" json:"key_bytes"`
+	ValBytes         int64  `protobuf:"varint,3,opt,name=val_bytes" json:"val_bytes"`
+	IntentBytes      int64  `protobuf:"varint,4,opt,name=intent_bytes" json:"intent_bytes"`
+	LiveCount        int64  `protobuf:"varint,5,opt,name=live_count" json:"live_count"`
+	KeyCount         int64  `protobuf:"varint,6,opt,name=key_count" json:"key_count"`
+	ValCount         int64  `protobuf:"varint,7,opt,name=val_count" json:"val_count"`
+	IntentCount      int64  `protobuf:"varint,8,opt,name=intent_count" json:"intent_count"`
+	IntentAge        int64  `protobuf:"varint,9,opt,name=intent_age" json:"intent_age"`
+	GCBytesAge       int64  `protobuf:"varint,10,opt,name=gc_bytes_age" json:"gc_bytes_age"`
+	LastUpdateNanos  int64  `protobuf:"varint,11,opt,name=last_update_nanos" json:"last_update_nanos"`
+	XXX_unrecognized []byte `json:"-"`
+}
+
+func (m *MVCCStats) Reset()         { *m = MVCCStats{} }
+func (m *MVCCStats) String() string { return proto1.CompactTextString(m) }
+func (*MVCCStats) ProtoMessage()    {}
+
+func (m *MVCCStats) GetLiveBytes() int64 {
+	if m != nil {
+		return m.LiveBytes
+	}
+	return 0
+}
+
+func (m *MVCCStats) GetKeyBytes() int64 {
+	if m != nil {
+		return m.KeyBytes
+	}
+	return 0
+}
+
+func (m *MVCCStats) GetValBytes() int64 {
+	if m != nil {
+		return m.ValBytes
+	}
+	return 0
+}
+
+func (m *MVCCStats) GetIntentBytes() int64 {
+	if m != nil {
+		return m.IntentBytes
+	}
+	return 0
+}
+
+func (m *MVCCStats) GetLiveCount() int64 {
+	if m != nil {
+		return m.LiveCount
+	}
+	return 0
+}
+
+func (m *MVCCStats) GetKeyCount() int64 {
+	if m != nil {
+		return m.KeyCount
+	}
+	return 0
+}
+
+func (m *MVCCStats) GetValCount() int64 {
+	if m != nil {
+		return m.ValCount
+	}
+	return 0
+}
+
+func (m *MVCCStats) GetIntentCount() int64 {
+	if m != nil {
+		return m.IntentCount
+	}
+	return 0
+}
+
+func (m *MVCCStats) GetIntentAge() int64 {
+	if m != nil {
+		return m.IntentAge
+	}
+	return 0
+}
+
+func (m *MVCCStats) GetGCBytesAge() int64 {
+	if m != nil {
+		return m.GCBytesAge
+	}
+	return 0
+}
+
+func (m *MVCCStats) GetLastUpdateNanos() int64 {
+	if m != nil {
+		return m.LastUpdateNanos
+	}
+	return 0
+}
+
 func init() {
 	proto1.RegisterEnum("cockroach.proto.ReplicaChangeType", ReplicaChangeType_name, ReplicaChangeType_value)
 	proto1.RegisterEnum("cockroach.proto.IsolationType", IsolationType_name, IsolationType_value)
@@ -2763,6 +2868,213 @@ func (m *TimeSeriesData) Unmarshal(data []byte) error {
 	}
 	return nil
 }
+func (m *MVCCStats) Unmarshal(data []byte) error {
+	l := len(data)
+	index := 0
+	for index < l {
+		var wire uint64
+		for shift := uint(0); ; shift += 7 {
+			if index >= l {
+				return io.ErrUnexpectedEOF
+			}
+			b := data[index]
+			index++
+			wire |= (uint64(b) & 0x7F) << shift
+			if b < 0x80 {
+				break
+			}
+		}
+		fieldNum := int32(wire >> 3)
+		wireType := int(wire & 0x7)
+		switch fieldNum {
+		case 1:
+			if wireType != 0 {
+				return fmt.Errorf("proto: wrong wireType = %d for field LiveBytes", wireType)
+			}
+			for shift := uint(0); ; shift += 7 {
+				if index >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := data[index]
+				index++
+				m.LiveBytes |= (int64(b) & 0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+		case 2:
+			if wireType != 0 {
+				return fmt.Errorf("proto: wrong wireType = %d for field KeyBytes", wireType)
+			}
+			for shift := uint(0); ; shift += 7 {
+				if index >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := data[index]
+				index++
+				m.KeyBytes |= (int64(b) & 0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+		case 3:
+			if wireType != 0 {
+				return fmt.Errorf("proto: wrong wireType = %d for field ValBytes", wireType)
+			}
+			for shift := uint(0); ; shift += 7 {
+				if index >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := data[index]
+				index++
+				m.ValBytes |= (int64(b) & 0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+		case 4:
+			if wireType != 0 {
+				return fmt.Errorf("proto: wrong wireType = %d for field IntentBytes", wireType)
+			}
+			for shift := uint(0); ; shift += 7 {
+				if index >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := data[index]
+				index++
+				m.IntentBytes |= (int64(b) & 0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+		case 5:
+			if wireType != 0 {
+				return fmt.Errorf("proto: wrong wireType = %d for field LiveCount", wireType)
+			}
+			for shift := uint(0); ; shift += 7 {
+				if index >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := data[index]
+				index++
+				m.LiveCount |= (int64(b) & 0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+		case 6:
+			if wireType != 0 {
+				return fmt.Errorf("proto: wrong wireType = %d for field KeyCount", wireType)
+			}
+			for shift := uint(0); ; shift += 7 {
+				if index >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := data[index]
+				index++
+				m.KeyCount |= (int64(b) & 0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+		case 7:
+			if wireType != 0 {
+				return fmt.Errorf("proto: wrong wireType = %d for field ValCount", wireType)
+			}
+			for shift := uint(0); ; shift += 7 {
+				if index >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := data[index]
+				index++
+				m.ValCount |= (int64(b) & 0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+		case 8:
+			if wireType != 0 {
+				return fmt.Errorf("proto: wrong wireType = %d for field IntentCount", wireType)
+			}
+			for shift := uint(0); ; shift += 7 {
+				if index >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := data[index]
+				index++
+				m.IntentCount |= (int64(b) & 0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+		case 9:
+			if wireType != 0 {
+				return fmt.Errorf("proto: wrong wireType = %d for field IntentAge", wireType)
+			}
+			for shift := uint(0); ; shift += 7 {
+				if index >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := data[index]
+				index++
+				m.IntentAge |= (int64(b) & 0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+		case 10:
+			if wireType != 0 {
+				return fmt.Errorf("proto: wrong wireType = %d for field GCBytesAge", wireType)
+			}
+			for shift := uint(0); ; shift += 7 {
+				if index >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := data[index]
+				index++
+				m.GCBytesAge |= (int64(b) & 0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+		case 11:
+			if wireType != 0 {
+				return fmt.Errorf("proto: wrong wireType = %d for field LastUpdateNanos", wireType)
+			}
+			for shift := uint(0); ; shift += 7 {
+				if index >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := data[index]
+				index++
+				m.LastUpdateNanos |= (int64(b) & 0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+		default:
+			var sizeOfWire int
+			for {
+				sizeOfWire++
+				wire >>= 7
+				if wire == 0 {
+					break
+				}
+			}
+			index -= sizeOfWire
+			skippy, err := github_com_gogo_protobuf_proto.Skip(data[index:])
+			if err != nil {
+				return err
+			}
+			if (index + skippy) > l {
+				return io.ErrUnexpectedEOF
+			}
+			m.XXX_unrecognized = append(m.XXX_unrecognized, data[index:index+skippy]...)
+			index += skippy
+		}
+	}
+	return nil
+}
 func (m *Timestamp) Size() (n int) {
 	var l int
 	_ = l
@@ -3052,6 +3364,26 @@ func (m *TimeSeriesData) Size() (n int) {
 			n += 1 + l + sovData(uint64(l))
 		}
 	}
+	if m.XXX_unrecognized != nil {
+		n += len(m.XXX_unrecognized)
+	}
+	return n
+}
+
+func (m *MVCCStats) Size() (n int) {
+	var l int
+	_ = l
+	n += 1 + sovData(uint64(m.LiveBytes))
+	n += 1 + sovData(uint64(m.KeyBytes))
+	n += 1 + sovData(uint64(m.ValBytes))
+	n += 1 + sovData(uint64(m.IntentBytes))
+	n += 1 + sovData(uint64(m.LiveCount))
+	n += 1 + sovData(uint64(m.KeyCount))
+	n += 1 + sovData(uint64(m.ValCount))
+	n += 1 + sovData(uint64(m.IntentCount))
+	n += 1 + sovData(uint64(m.IntentAge))
+	n += 1 + sovData(uint64(m.GCBytesAge))
+	n += 1 + sovData(uint64(m.LastUpdateNanos))
 	if m.XXX_unrecognized != nil {
 		n += len(m.XXX_unrecognized)
 	}
@@ -3793,6 +4125,60 @@ func (m *TimeSeriesData) MarshalTo(data []byte) (n int, err error) {
 			i += n
 		}
 	}
+	if m.XXX_unrecognized != nil {
+		i += copy(data[i:], m.XXX_unrecognized)
+	}
+	return i, nil
+}
+
+func (m *MVCCStats) Marshal() (data []byte, err error) {
+	size := m.Size()
+	data = make([]byte, size)
+	n, err := m.MarshalTo(data)
+	if err != nil {
+		return nil, err
+	}
+	return data[:n], nil
+}
+
+func (m *MVCCStats) MarshalTo(data []byte) (n int, err error) {
+	var i int
+	_ = i
+	var l int
+	_ = l
+	data[i] = 0x8
+	i++
+	i = encodeVarintData(data, i, uint64(m.LiveBytes))
+	data[i] = 0x10
+	i++
+	i = encodeVarintData(data, i, uint64(m.KeyBytes))
+	data[i] = 0x18
+	i++
+	i = encodeVarintData(data, i, uint64(m.ValBytes))
+	data[i] = 0x20
+	i++
+	i = encodeVarintData(data, i, uint64(m.IntentBytes))
+	data[i] = 0x28
+	i++
+	i = encodeVarintData(data, i, uint64(m.LiveCount))
+	data[i] = 0x30
+	i++
+	i = encodeVarintData(data, i, uint64(m.KeyCount))
+	data[i] = 0x38
+	i++
+	i = encodeVarintData(data, i, uint64(m.ValCount))
+	data[i] = 0x40
+	i++
+	i = encodeVarintData(data, i, uint64(m.IntentCount))
+	data[i] = 0x48
+	i++
+	i = encodeVarintData(data, i, uint64(m.IntentAge))
+	data[i] = 0x50
+	i++
+	i = encodeVarintData(data, i, uint64(m.GCBytesAge))
+	data[i] = 0x58
+	i++
+	i = encodeVarintData(data, i, uint64(m.LastUpdateNanos))
 	if m.XXX_unrecognized != nil {
 		i += copy(data[i:], m.XXX_unrecognized)
 	}

--- a/proto/data.proto
+++ b/proto/data.proto
@@ -324,3 +324,26 @@ message TimeSeriesData {
   // Datapoints representing one or more measurements taken from the variable.
   repeated TimeSeriesDatapoint datapoints = 3;
 }
+
+// MVCCStats tracks byte and instance counts for:
+//  - Live key/values (i.e. what a scan at current time will reveal;
+//    note that this includes intent keys and values, but not keys and
+//    values with most recent value deleted)
+//  - Key bytes (includes all keys, even those with most recent value deleted)
+//  - Value bytes (includes all versions)
+//  - Key count (count of all keys, including keys with deleted tombstones)
+//  - Value count (all versions, including deleted tombstones)
+//  - Intents (provisional values written during txns)
+message MVCCStats {
+  optional int64 live_bytes = 1 [(gogoproto.nullable) = false];
+  optional int64 key_bytes = 2 [(gogoproto.nullable) = false];
+  optional int64 val_bytes = 3 [(gogoproto.nullable) = false];
+  optional int64 intent_bytes = 4 [(gogoproto.nullable) = false];
+  optional int64 live_count = 5 [(gogoproto.nullable) = false];
+  optional int64 key_count = 6 [(gogoproto.nullable) = false];
+  optional int64 val_count = 7 [(gogoproto.nullable) = false];
+  optional int64 intent_count = 8 [(gogoproto.nullable) = false];
+  optional int64 intent_age = 9 [(gogoproto.nullable) = false];
+  optional int64 gc_bytes_age = 10 [(gogoproto.nullable) = false, (gogoproto.customname) = "GCBytesAge" ];
+  optional int64 last_update_nanos = 11 [(gogoproto.nullable) = false];
+}

--- a/proto/status.proto
+++ b/proto/status.proto
@@ -19,6 +19,7 @@ syntax = "proto2";
 package cockroach.proto;
 option go_package = "proto";
 
+import "cockroach/proto/data.proto";
 import "gogoproto/gogo.proto";
 
 option (gogoproto.sizer_all) = true;
@@ -27,25 +28,14 @@ option (gogoproto.unmarshaler_all) = true;
 
 // StoreStatus contains the stats needed to calculate the current status of a
 // store.
-// TODO(bram): add significantly more statistics.
 message StoreStatus {  
-  // The storeID for this store.
   optional int32 store_id = 1 [(gogoproto.nullable) = false, (gogoproto.customname) = "StoreID", (gogoproto.customtype) = "StoreID"];
-  // The node id associated with this store.
   optional int32 node_id = 2 [(gogoproto.nullable) = false, (gogoproto.customname) = "NodeID", (gogoproto.customtype) = "NodeID"];
-  // A list of the raft_ids (ranges) available through this store.
-  repeated int64 raft_ids = 3 [(gogoproto.nullable) = false, (gogoproto.customname) = "RaftIDs"];
-
-  // Time based statistics.
-  // The last time this was updated, note that this is not the time it was 
-  // written to the DB, but when this measurement was taken.
-  optional int64 updated_at = 4 [(gogoproto.nullable) = false];
-  // The last time this node was started.
-  optional int64 started_at = 5 [(gogoproto.nullable) = false];
-
-  // Size based statistics.
-  // The number of bytes currently being used by this store.
-  optional int64 used_bytes = 6 [(gogoproto.nullable) = false];
-  // The maximum number of bytes available.
-  optional int64 max_bytes = 7 [(gogoproto.nullable) = false];
+  optional int32 range_count = 3 [(gogoproto.nullable) = false];
+  // The last time this store was started.
+  optional int64 started_at = 4 [(gogoproto.nullable) = false];
+  // The last time this status was updated.
+  optional int64 updated_at = 5 [(gogoproto.nullable) = false];
+  // All current aggregated stats are contained in MVCCStats.
+  optional MVCCStats stats = 6 [(gogoproto.nullable) = false];
 }

--- a/server/node_test.go
+++ b/server/node_test.go
@@ -125,7 +125,6 @@ func TestBootstrapCluster(t *testing.T) {
 		proto.Key("\x00node-idgen"),
 		proto.Key("\x00perm"),
 		proto.Key("\x00range-tree-root"),
-		proto.Key("\x00status-store-1"),
 		proto.Key("\x00store-idgen-1"),
 		proto.Key("\x00zone"),
 	}

--- a/storage/engine/cockroach/proto/data.pb.cc
+++ b/storage/engine/cockroach/proto/data.pb.cc
@@ -72,6 +72,9 @@ const ::google::protobuf::internal::GeneratedMessageReflection*
 const ::google::protobuf::Descriptor* TimeSeriesData_descriptor_ = NULL;
 const ::google::protobuf::internal::GeneratedMessageReflection*
   TimeSeriesData_reflection_ = NULL;
+const ::google::protobuf::Descriptor* MVCCStats_descriptor_ = NULL;
+const ::google::protobuf::internal::GeneratedMessageReflection*
+  MVCCStats_reflection_ = NULL;
 const ::google::protobuf::EnumDescriptor* ReplicaChangeType_descriptor_ = NULL;
 const ::google::protobuf::EnumDescriptor* IsolationType_descriptor_ = NULL;
 const ::google::protobuf::EnumDescriptor* TransactionStatus_descriptor_ = NULL;
@@ -382,6 +385,31 @@ void protobuf_AssignDesc_cockroach_2fproto_2fdata_2eproto() {
       ::google::protobuf::DescriptorPool::generated_pool(),
       ::google::protobuf::MessageFactory::generated_factory(),
       sizeof(TimeSeriesData));
+  MVCCStats_descriptor_ = file->message_type(17);
+  static const int MVCCStats_offsets_[11] = {
+    GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(MVCCStats, live_bytes_),
+    GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(MVCCStats, key_bytes_),
+    GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(MVCCStats, val_bytes_),
+    GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(MVCCStats, intent_bytes_),
+    GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(MVCCStats, live_count_),
+    GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(MVCCStats, key_count_),
+    GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(MVCCStats, val_count_),
+    GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(MVCCStats, intent_count_),
+    GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(MVCCStats, intent_age_),
+    GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(MVCCStats, gc_bytes_age_),
+    GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(MVCCStats, last_update_nanos_),
+  };
+  MVCCStats_reflection_ =
+    new ::google::protobuf::internal::GeneratedMessageReflection(
+      MVCCStats_descriptor_,
+      MVCCStats::default_instance_,
+      MVCCStats_offsets_,
+      GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(MVCCStats, _has_bits_[0]),
+      GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(MVCCStats, _unknown_fields_),
+      -1,
+      ::google::protobuf::DescriptorPool::generated_pool(),
+      ::google::protobuf::MessageFactory::generated_factory(),
+      sizeof(MVCCStats));
   ReplicaChangeType_descriptor_ = file->enum_type(0);
   IsolationType_descriptor_ = file->enum_type(1);
   TransactionStatus_descriptor_ = file->enum_type(2);
@@ -431,6 +459,8 @@ void protobuf_RegisterTypes(const ::std::string&) {
     TimeSeriesDatapoint_descriptor_, &TimeSeriesDatapoint::default_instance());
   ::google::protobuf::MessageFactory::InternalRegisterGeneratedMessage(
     TimeSeriesData_descriptor_, &TimeSeriesData::default_instance());
+  ::google::protobuf::MessageFactory::InternalRegisterGeneratedMessage(
+    MVCCStats_descriptor_, &MVCCStats::default_instance());
 }
 
 }  // namespace
@@ -470,6 +500,8 @@ void protobuf_ShutdownFile_cockroach_2fproto_2fdata_2eproto() {
   delete TimeSeriesDatapoint_reflection_;
   delete TimeSeriesData::default_instance_;
   delete TimeSeriesData_reflection_;
+  delete MVCCStats::default_instance_;
+  delete MVCCStats_reflection_;
 }
 
 void protobuf_AddDesc_cockroach_2fproto_2fdata_2eproto() {
@@ -545,12 +577,20 @@ void protobuf_AddDesc_cockroach_2fproto_2fdata_2eproto() {
     "\023\n\013float_value\030\003 \001(\002\"t\n\016TimeSeriesData\022\022"
     "\n\004name\030\001 \001(\tB\004\310\336\037\000\022\024\n\006source\030\002 \001(\tB\004\310\336\037\000"
     "\0228\n\ndatapoints\030\003 \003(\0132$.cockroach.proto.T"
-    "imeSeriesDatapoint*>\n\021ReplicaChangeType\022"
-    "\017\n\013ADD_REPLICA\020\000\022\022\n\016REMOVE_REPLICA\020\001\032\004\210\243"
-    "\036\000*5\n\rIsolationType\022\020\n\014SERIALIZABLE\020\000\022\014\n"
-    "\010SNAPSHOT\020\001\032\004\210\243\036\000*B\n\021TransactionStatus\022\013"
-    "\n\007PENDING\020\000\022\r\n\tCOMMITTED\020\001\022\013\n\007ABORTED\020\002\032"
-    "\004\210\243\036\000B\023Z\005proto\340\342\036\001\310\342\036\001\320\342\036\001", 2786);
+    "imeSeriesDatapoint\"\300\002\n\tMVCCStats\022\030\n\nlive"
+    "_bytes\030\001 \001(\003B\004\310\336\037\000\022\027\n\tkey_bytes\030\002 \001(\003B\004\310"
+    "\336\037\000\022\027\n\tval_bytes\030\003 \001(\003B\004\310\336\037\000\022\032\n\014intent_b"
+    "ytes\030\004 \001(\003B\004\310\336\037\000\022\030\n\nlive_count\030\005 \001(\003B\004\310\336"
+    "\037\000\022\027\n\tkey_count\030\006 \001(\003B\004\310\336\037\000\022\027\n\tval_count"
+    "\030\007 \001(\003B\004\310\336\037\000\022\032\n\014intent_count\030\010 \001(\003B\004\310\336\037\000"
+    "\022\030\n\nintent_age\030\t \001(\003B\004\310\336\037\000\022(\n\014gc_bytes_a"
+    "ge\030\n \001(\003B\022\310\336\037\000\342\336\037\nGCBytesAge\022\037\n\021last_upd"
+    "ate_nanos\030\013 \001(\003B\004\310\336\037\000*>\n\021ReplicaChangeTy"
+    "pe\022\017\n\013ADD_REPLICA\020\000\022\022\n\016REMOVE_REPLICA\020\001\032"
+    "\004\210\243\036\000*5\n\rIsolationType\022\020\n\014SERIALIZABLE\020\000"
+    "\022\014\n\010SNAPSHOT\020\001\032\004\210\243\036\000*B\n\021TransactionStatu"
+    "s\022\013\n\007PENDING\020\000\022\r\n\tCOMMITTED\020\001\022\013\n\007ABORTED"
+    "\020\002\032\004\210\243\036\000B\023Z\005proto\340\342\036\001\310\342\036\001\320\342\036\001", 3109);
   ::google::protobuf::MessageFactory::InternalRegisterGeneratedFile(
     "cockroach/proto/data.proto", &protobuf_RegisterTypes);
   Timestamp::default_instance_ = new Timestamp();
@@ -570,6 +610,7 @@ void protobuf_AddDesc_cockroach_2fproto_2fdata_2eproto() {
   GCMetadata::default_instance_ = new GCMetadata();
   TimeSeriesDatapoint::default_instance_ = new TimeSeriesDatapoint();
   TimeSeriesData::default_instance_ = new TimeSeriesData();
+  MVCCStats::default_instance_ = new MVCCStats();
   Timestamp::default_instance_->InitAsDefaultInstance();
   Value::default_instance_->InitAsDefaultInstance();
   MVCCValue::default_instance_->InitAsDefaultInstance();
@@ -587,6 +628,7 @@ void protobuf_AddDesc_cockroach_2fproto_2fdata_2eproto() {
   GCMetadata::default_instance_->InitAsDefaultInstance();
   TimeSeriesDatapoint::default_instance_->InitAsDefaultInstance();
   TimeSeriesData::default_instance_->InitAsDefaultInstance();
+  MVCCStats::default_instance_->InitAsDefaultInstance();
   ::google::protobuf::internal::OnShutdown(&protobuf_ShutdownFile_cockroach_2fproto_2fdata_2eproto);
 }
 
@@ -6445,6 +6487,629 @@ void TimeSeriesData::Swap(TimeSeriesData* other) {
   ::google::protobuf::Metadata metadata;
   metadata.descriptor = TimeSeriesData_descriptor_;
   metadata.reflection = TimeSeriesData_reflection_;
+  return metadata;
+}
+
+
+// ===================================================================
+
+#ifndef _MSC_VER
+const int MVCCStats::kLiveBytesFieldNumber;
+const int MVCCStats::kKeyBytesFieldNumber;
+const int MVCCStats::kValBytesFieldNumber;
+const int MVCCStats::kIntentBytesFieldNumber;
+const int MVCCStats::kLiveCountFieldNumber;
+const int MVCCStats::kKeyCountFieldNumber;
+const int MVCCStats::kValCountFieldNumber;
+const int MVCCStats::kIntentCountFieldNumber;
+const int MVCCStats::kIntentAgeFieldNumber;
+const int MVCCStats::kGcBytesAgeFieldNumber;
+const int MVCCStats::kLastUpdateNanosFieldNumber;
+#endif  // !_MSC_VER
+
+MVCCStats::MVCCStats()
+  : ::google::protobuf::Message() {
+  SharedCtor();
+  // @@protoc_insertion_point(constructor:cockroach.proto.MVCCStats)
+}
+
+void MVCCStats::InitAsDefaultInstance() {
+}
+
+MVCCStats::MVCCStats(const MVCCStats& from)
+  : ::google::protobuf::Message() {
+  SharedCtor();
+  MergeFrom(from);
+  // @@protoc_insertion_point(copy_constructor:cockroach.proto.MVCCStats)
+}
+
+void MVCCStats::SharedCtor() {
+  _cached_size_ = 0;
+  live_bytes_ = GOOGLE_LONGLONG(0);
+  key_bytes_ = GOOGLE_LONGLONG(0);
+  val_bytes_ = GOOGLE_LONGLONG(0);
+  intent_bytes_ = GOOGLE_LONGLONG(0);
+  live_count_ = GOOGLE_LONGLONG(0);
+  key_count_ = GOOGLE_LONGLONG(0);
+  val_count_ = GOOGLE_LONGLONG(0);
+  intent_count_ = GOOGLE_LONGLONG(0);
+  intent_age_ = GOOGLE_LONGLONG(0);
+  gc_bytes_age_ = GOOGLE_LONGLONG(0);
+  last_update_nanos_ = GOOGLE_LONGLONG(0);
+  ::memset(_has_bits_, 0, sizeof(_has_bits_));
+}
+
+MVCCStats::~MVCCStats() {
+  // @@protoc_insertion_point(destructor:cockroach.proto.MVCCStats)
+  SharedDtor();
+}
+
+void MVCCStats::SharedDtor() {
+  if (this != default_instance_) {
+  }
+}
+
+void MVCCStats::SetCachedSize(int size) const {
+  GOOGLE_SAFE_CONCURRENT_WRITES_BEGIN();
+  _cached_size_ = size;
+  GOOGLE_SAFE_CONCURRENT_WRITES_END();
+}
+const ::google::protobuf::Descriptor* MVCCStats::descriptor() {
+  protobuf_AssignDescriptorsOnce();
+  return MVCCStats_descriptor_;
+}
+
+const MVCCStats& MVCCStats::default_instance() {
+  if (default_instance_ == NULL) protobuf_AddDesc_cockroach_2fproto_2fdata_2eproto();
+  return *default_instance_;
+}
+
+MVCCStats* MVCCStats::default_instance_ = NULL;
+
+MVCCStats* MVCCStats::New() const {
+  return new MVCCStats;
+}
+
+void MVCCStats::Clear() {
+#define OFFSET_OF_FIELD_(f) (reinterpret_cast<char*>(      \
+  &reinterpret_cast<MVCCStats*>(16)->f) - \
+   reinterpret_cast<char*>(16))
+
+#define ZR_(first, last) do {                              \
+    size_t f = OFFSET_OF_FIELD_(first);                    \
+    size_t n = OFFSET_OF_FIELD_(last) - f + sizeof(last);  \
+    ::memset(&first, 0, n);                                \
+  } while (0)
+
+  if (_has_bits_[0 / 32] & 255) {
+    ZR_(live_bytes_, intent_count_);
+  }
+  ZR_(intent_age_, last_update_nanos_);
+
+#undef OFFSET_OF_FIELD_
+#undef ZR_
+
+  ::memset(_has_bits_, 0, sizeof(_has_bits_));
+  mutable_unknown_fields()->Clear();
+}
+
+bool MVCCStats::MergePartialFromCodedStream(
+    ::google::protobuf::io::CodedInputStream* input) {
+#define DO_(EXPRESSION) if (!(EXPRESSION)) goto failure
+  ::google::protobuf::uint32 tag;
+  // @@protoc_insertion_point(parse_start:cockroach.proto.MVCCStats)
+  for (;;) {
+    ::std::pair< ::google::protobuf::uint32, bool> p = input->ReadTagWithCutoff(127);
+    tag = p.first;
+    if (!p.second) goto handle_unusual;
+    switch (::google::protobuf::internal::WireFormatLite::GetTagFieldNumber(tag)) {
+      // optional int64 live_bytes = 1;
+      case 1: {
+        if (tag == 8) {
+          DO_((::google::protobuf::internal::WireFormatLite::ReadPrimitive<
+                   ::google::protobuf::int64, ::google::protobuf::internal::WireFormatLite::TYPE_INT64>(
+                 input, &live_bytes_)));
+          set_has_live_bytes();
+        } else {
+          goto handle_unusual;
+        }
+        if (input->ExpectTag(16)) goto parse_key_bytes;
+        break;
+      }
+
+      // optional int64 key_bytes = 2;
+      case 2: {
+        if (tag == 16) {
+         parse_key_bytes:
+          DO_((::google::protobuf::internal::WireFormatLite::ReadPrimitive<
+                   ::google::protobuf::int64, ::google::protobuf::internal::WireFormatLite::TYPE_INT64>(
+                 input, &key_bytes_)));
+          set_has_key_bytes();
+        } else {
+          goto handle_unusual;
+        }
+        if (input->ExpectTag(24)) goto parse_val_bytes;
+        break;
+      }
+
+      // optional int64 val_bytes = 3;
+      case 3: {
+        if (tag == 24) {
+         parse_val_bytes:
+          DO_((::google::protobuf::internal::WireFormatLite::ReadPrimitive<
+                   ::google::protobuf::int64, ::google::protobuf::internal::WireFormatLite::TYPE_INT64>(
+                 input, &val_bytes_)));
+          set_has_val_bytes();
+        } else {
+          goto handle_unusual;
+        }
+        if (input->ExpectTag(32)) goto parse_intent_bytes;
+        break;
+      }
+
+      // optional int64 intent_bytes = 4;
+      case 4: {
+        if (tag == 32) {
+         parse_intent_bytes:
+          DO_((::google::protobuf::internal::WireFormatLite::ReadPrimitive<
+                   ::google::protobuf::int64, ::google::protobuf::internal::WireFormatLite::TYPE_INT64>(
+                 input, &intent_bytes_)));
+          set_has_intent_bytes();
+        } else {
+          goto handle_unusual;
+        }
+        if (input->ExpectTag(40)) goto parse_live_count;
+        break;
+      }
+
+      // optional int64 live_count = 5;
+      case 5: {
+        if (tag == 40) {
+         parse_live_count:
+          DO_((::google::protobuf::internal::WireFormatLite::ReadPrimitive<
+                   ::google::protobuf::int64, ::google::protobuf::internal::WireFormatLite::TYPE_INT64>(
+                 input, &live_count_)));
+          set_has_live_count();
+        } else {
+          goto handle_unusual;
+        }
+        if (input->ExpectTag(48)) goto parse_key_count;
+        break;
+      }
+
+      // optional int64 key_count = 6;
+      case 6: {
+        if (tag == 48) {
+         parse_key_count:
+          DO_((::google::protobuf::internal::WireFormatLite::ReadPrimitive<
+                   ::google::protobuf::int64, ::google::protobuf::internal::WireFormatLite::TYPE_INT64>(
+                 input, &key_count_)));
+          set_has_key_count();
+        } else {
+          goto handle_unusual;
+        }
+        if (input->ExpectTag(56)) goto parse_val_count;
+        break;
+      }
+
+      // optional int64 val_count = 7;
+      case 7: {
+        if (tag == 56) {
+         parse_val_count:
+          DO_((::google::protobuf::internal::WireFormatLite::ReadPrimitive<
+                   ::google::protobuf::int64, ::google::protobuf::internal::WireFormatLite::TYPE_INT64>(
+                 input, &val_count_)));
+          set_has_val_count();
+        } else {
+          goto handle_unusual;
+        }
+        if (input->ExpectTag(64)) goto parse_intent_count;
+        break;
+      }
+
+      // optional int64 intent_count = 8;
+      case 8: {
+        if (tag == 64) {
+         parse_intent_count:
+          DO_((::google::protobuf::internal::WireFormatLite::ReadPrimitive<
+                   ::google::protobuf::int64, ::google::protobuf::internal::WireFormatLite::TYPE_INT64>(
+                 input, &intent_count_)));
+          set_has_intent_count();
+        } else {
+          goto handle_unusual;
+        }
+        if (input->ExpectTag(72)) goto parse_intent_age;
+        break;
+      }
+
+      // optional int64 intent_age = 9;
+      case 9: {
+        if (tag == 72) {
+         parse_intent_age:
+          DO_((::google::protobuf::internal::WireFormatLite::ReadPrimitive<
+                   ::google::protobuf::int64, ::google::protobuf::internal::WireFormatLite::TYPE_INT64>(
+                 input, &intent_age_)));
+          set_has_intent_age();
+        } else {
+          goto handle_unusual;
+        }
+        if (input->ExpectTag(80)) goto parse_gc_bytes_age;
+        break;
+      }
+
+      // optional int64 gc_bytes_age = 10;
+      case 10: {
+        if (tag == 80) {
+         parse_gc_bytes_age:
+          DO_((::google::protobuf::internal::WireFormatLite::ReadPrimitive<
+                   ::google::protobuf::int64, ::google::protobuf::internal::WireFormatLite::TYPE_INT64>(
+                 input, &gc_bytes_age_)));
+          set_has_gc_bytes_age();
+        } else {
+          goto handle_unusual;
+        }
+        if (input->ExpectTag(88)) goto parse_last_update_nanos;
+        break;
+      }
+
+      // optional int64 last_update_nanos = 11;
+      case 11: {
+        if (tag == 88) {
+         parse_last_update_nanos:
+          DO_((::google::protobuf::internal::WireFormatLite::ReadPrimitive<
+                   ::google::protobuf::int64, ::google::protobuf::internal::WireFormatLite::TYPE_INT64>(
+                 input, &last_update_nanos_)));
+          set_has_last_update_nanos();
+        } else {
+          goto handle_unusual;
+        }
+        if (input->ExpectAtEnd()) goto success;
+        break;
+      }
+
+      default: {
+      handle_unusual:
+        if (tag == 0 ||
+            ::google::protobuf::internal::WireFormatLite::GetTagWireType(tag) ==
+            ::google::protobuf::internal::WireFormatLite::WIRETYPE_END_GROUP) {
+          goto success;
+        }
+        DO_(::google::protobuf::internal::WireFormat::SkipField(
+              input, tag, mutable_unknown_fields()));
+        break;
+      }
+    }
+  }
+success:
+  // @@protoc_insertion_point(parse_success:cockroach.proto.MVCCStats)
+  return true;
+failure:
+  // @@protoc_insertion_point(parse_failure:cockroach.proto.MVCCStats)
+  return false;
+#undef DO_
+}
+
+void MVCCStats::SerializeWithCachedSizes(
+    ::google::protobuf::io::CodedOutputStream* output) const {
+  // @@protoc_insertion_point(serialize_start:cockroach.proto.MVCCStats)
+  // optional int64 live_bytes = 1;
+  if (has_live_bytes()) {
+    ::google::protobuf::internal::WireFormatLite::WriteInt64(1, this->live_bytes(), output);
+  }
+
+  // optional int64 key_bytes = 2;
+  if (has_key_bytes()) {
+    ::google::protobuf::internal::WireFormatLite::WriteInt64(2, this->key_bytes(), output);
+  }
+
+  // optional int64 val_bytes = 3;
+  if (has_val_bytes()) {
+    ::google::protobuf::internal::WireFormatLite::WriteInt64(3, this->val_bytes(), output);
+  }
+
+  // optional int64 intent_bytes = 4;
+  if (has_intent_bytes()) {
+    ::google::protobuf::internal::WireFormatLite::WriteInt64(4, this->intent_bytes(), output);
+  }
+
+  // optional int64 live_count = 5;
+  if (has_live_count()) {
+    ::google::protobuf::internal::WireFormatLite::WriteInt64(5, this->live_count(), output);
+  }
+
+  // optional int64 key_count = 6;
+  if (has_key_count()) {
+    ::google::protobuf::internal::WireFormatLite::WriteInt64(6, this->key_count(), output);
+  }
+
+  // optional int64 val_count = 7;
+  if (has_val_count()) {
+    ::google::protobuf::internal::WireFormatLite::WriteInt64(7, this->val_count(), output);
+  }
+
+  // optional int64 intent_count = 8;
+  if (has_intent_count()) {
+    ::google::protobuf::internal::WireFormatLite::WriteInt64(8, this->intent_count(), output);
+  }
+
+  // optional int64 intent_age = 9;
+  if (has_intent_age()) {
+    ::google::protobuf::internal::WireFormatLite::WriteInt64(9, this->intent_age(), output);
+  }
+
+  // optional int64 gc_bytes_age = 10;
+  if (has_gc_bytes_age()) {
+    ::google::protobuf::internal::WireFormatLite::WriteInt64(10, this->gc_bytes_age(), output);
+  }
+
+  // optional int64 last_update_nanos = 11;
+  if (has_last_update_nanos()) {
+    ::google::protobuf::internal::WireFormatLite::WriteInt64(11, this->last_update_nanos(), output);
+  }
+
+  if (!unknown_fields().empty()) {
+    ::google::protobuf::internal::WireFormat::SerializeUnknownFields(
+        unknown_fields(), output);
+  }
+  // @@protoc_insertion_point(serialize_end:cockroach.proto.MVCCStats)
+}
+
+::google::protobuf::uint8* MVCCStats::SerializeWithCachedSizesToArray(
+    ::google::protobuf::uint8* target) const {
+  // @@protoc_insertion_point(serialize_to_array_start:cockroach.proto.MVCCStats)
+  // optional int64 live_bytes = 1;
+  if (has_live_bytes()) {
+    target = ::google::protobuf::internal::WireFormatLite::WriteInt64ToArray(1, this->live_bytes(), target);
+  }
+
+  // optional int64 key_bytes = 2;
+  if (has_key_bytes()) {
+    target = ::google::protobuf::internal::WireFormatLite::WriteInt64ToArray(2, this->key_bytes(), target);
+  }
+
+  // optional int64 val_bytes = 3;
+  if (has_val_bytes()) {
+    target = ::google::protobuf::internal::WireFormatLite::WriteInt64ToArray(3, this->val_bytes(), target);
+  }
+
+  // optional int64 intent_bytes = 4;
+  if (has_intent_bytes()) {
+    target = ::google::protobuf::internal::WireFormatLite::WriteInt64ToArray(4, this->intent_bytes(), target);
+  }
+
+  // optional int64 live_count = 5;
+  if (has_live_count()) {
+    target = ::google::protobuf::internal::WireFormatLite::WriteInt64ToArray(5, this->live_count(), target);
+  }
+
+  // optional int64 key_count = 6;
+  if (has_key_count()) {
+    target = ::google::protobuf::internal::WireFormatLite::WriteInt64ToArray(6, this->key_count(), target);
+  }
+
+  // optional int64 val_count = 7;
+  if (has_val_count()) {
+    target = ::google::protobuf::internal::WireFormatLite::WriteInt64ToArray(7, this->val_count(), target);
+  }
+
+  // optional int64 intent_count = 8;
+  if (has_intent_count()) {
+    target = ::google::protobuf::internal::WireFormatLite::WriteInt64ToArray(8, this->intent_count(), target);
+  }
+
+  // optional int64 intent_age = 9;
+  if (has_intent_age()) {
+    target = ::google::protobuf::internal::WireFormatLite::WriteInt64ToArray(9, this->intent_age(), target);
+  }
+
+  // optional int64 gc_bytes_age = 10;
+  if (has_gc_bytes_age()) {
+    target = ::google::protobuf::internal::WireFormatLite::WriteInt64ToArray(10, this->gc_bytes_age(), target);
+  }
+
+  // optional int64 last_update_nanos = 11;
+  if (has_last_update_nanos()) {
+    target = ::google::protobuf::internal::WireFormatLite::WriteInt64ToArray(11, this->last_update_nanos(), target);
+  }
+
+  if (!unknown_fields().empty()) {
+    target = ::google::protobuf::internal::WireFormat::SerializeUnknownFieldsToArray(
+        unknown_fields(), target);
+  }
+  // @@protoc_insertion_point(serialize_to_array_end:cockroach.proto.MVCCStats)
+  return target;
+}
+
+int MVCCStats::ByteSize() const {
+  int total_size = 0;
+
+  if (_has_bits_[0 / 32] & (0xffu << (0 % 32))) {
+    // optional int64 live_bytes = 1;
+    if (has_live_bytes()) {
+      total_size += 1 +
+        ::google::protobuf::internal::WireFormatLite::Int64Size(
+          this->live_bytes());
+    }
+
+    // optional int64 key_bytes = 2;
+    if (has_key_bytes()) {
+      total_size += 1 +
+        ::google::protobuf::internal::WireFormatLite::Int64Size(
+          this->key_bytes());
+    }
+
+    // optional int64 val_bytes = 3;
+    if (has_val_bytes()) {
+      total_size += 1 +
+        ::google::protobuf::internal::WireFormatLite::Int64Size(
+          this->val_bytes());
+    }
+
+    // optional int64 intent_bytes = 4;
+    if (has_intent_bytes()) {
+      total_size += 1 +
+        ::google::protobuf::internal::WireFormatLite::Int64Size(
+          this->intent_bytes());
+    }
+
+    // optional int64 live_count = 5;
+    if (has_live_count()) {
+      total_size += 1 +
+        ::google::protobuf::internal::WireFormatLite::Int64Size(
+          this->live_count());
+    }
+
+    // optional int64 key_count = 6;
+    if (has_key_count()) {
+      total_size += 1 +
+        ::google::protobuf::internal::WireFormatLite::Int64Size(
+          this->key_count());
+    }
+
+    // optional int64 val_count = 7;
+    if (has_val_count()) {
+      total_size += 1 +
+        ::google::protobuf::internal::WireFormatLite::Int64Size(
+          this->val_count());
+    }
+
+    // optional int64 intent_count = 8;
+    if (has_intent_count()) {
+      total_size += 1 +
+        ::google::protobuf::internal::WireFormatLite::Int64Size(
+          this->intent_count());
+    }
+
+  }
+  if (_has_bits_[8 / 32] & (0xffu << (8 % 32))) {
+    // optional int64 intent_age = 9;
+    if (has_intent_age()) {
+      total_size += 1 +
+        ::google::protobuf::internal::WireFormatLite::Int64Size(
+          this->intent_age());
+    }
+
+    // optional int64 gc_bytes_age = 10;
+    if (has_gc_bytes_age()) {
+      total_size += 1 +
+        ::google::protobuf::internal::WireFormatLite::Int64Size(
+          this->gc_bytes_age());
+    }
+
+    // optional int64 last_update_nanos = 11;
+    if (has_last_update_nanos()) {
+      total_size += 1 +
+        ::google::protobuf::internal::WireFormatLite::Int64Size(
+          this->last_update_nanos());
+    }
+
+  }
+  if (!unknown_fields().empty()) {
+    total_size +=
+      ::google::protobuf::internal::WireFormat::ComputeUnknownFieldsSize(
+        unknown_fields());
+  }
+  GOOGLE_SAFE_CONCURRENT_WRITES_BEGIN();
+  _cached_size_ = total_size;
+  GOOGLE_SAFE_CONCURRENT_WRITES_END();
+  return total_size;
+}
+
+void MVCCStats::MergeFrom(const ::google::protobuf::Message& from) {
+  GOOGLE_CHECK_NE(&from, this);
+  const MVCCStats* source =
+    ::google::protobuf::internal::dynamic_cast_if_available<const MVCCStats*>(
+      &from);
+  if (source == NULL) {
+    ::google::protobuf::internal::ReflectionOps::Merge(from, this);
+  } else {
+    MergeFrom(*source);
+  }
+}
+
+void MVCCStats::MergeFrom(const MVCCStats& from) {
+  GOOGLE_CHECK_NE(&from, this);
+  if (from._has_bits_[0 / 32] & (0xffu << (0 % 32))) {
+    if (from.has_live_bytes()) {
+      set_live_bytes(from.live_bytes());
+    }
+    if (from.has_key_bytes()) {
+      set_key_bytes(from.key_bytes());
+    }
+    if (from.has_val_bytes()) {
+      set_val_bytes(from.val_bytes());
+    }
+    if (from.has_intent_bytes()) {
+      set_intent_bytes(from.intent_bytes());
+    }
+    if (from.has_live_count()) {
+      set_live_count(from.live_count());
+    }
+    if (from.has_key_count()) {
+      set_key_count(from.key_count());
+    }
+    if (from.has_val_count()) {
+      set_val_count(from.val_count());
+    }
+    if (from.has_intent_count()) {
+      set_intent_count(from.intent_count());
+    }
+  }
+  if (from._has_bits_[8 / 32] & (0xffu << (8 % 32))) {
+    if (from.has_intent_age()) {
+      set_intent_age(from.intent_age());
+    }
+    if (from.has_gc_bytes_age()) {
+      set_gc_bytes_age(from.gc_bytes_age());
+    }
+    if (from.has_last_update_nanos()) {
+      set_last_update_nanos(from.last_update_nanos());
+    }
+  }
+  mutable_unknown_fields()->MergeFrom(from.unknown_fields());
+}
+
+void MVCCStats::CopyFrom(const ::google::protobuf::Message& from) {
+  if (&from == this) return;
+  Clear();
+  MergeFrom(from);
+}
+
+void MVCCStats::CopyFrom(const MVCCStats& from) {
+  if (&from == this) return;
+  Clear();
+  MergeFrom(from);
+}
+
+bool MVCCStats::IsInitialized() const {
+
+  return true;
+}
+
+void MVCCStats::Swap(MVCCStats* other) {
+  if (other != this) {
+    std::swap(live_bytes_, other->live_bytes_);
+    std::swap(key_bytes_, other->key_bytes_);
+    std::swap(val_bytes_, other->val_bytes_);
+    std::swap(intent_bytes_, other->intent_bytes_);
+    std::swap(live_count_, other->live_count_);
+    std::swap(key_count_, other->key_count_);
+    std::swap(val_count_, other->val_count_);
+    std::swap(intent_count_, other->intent_count_);
+    std::swap(intent_age_, other->intent_age_);
+    std::swap(gc_bytes_age_, other->gc_bytes_age_);
+    std::swap(last_update_nanos_, other->last_update_nanos_);
+    std::swap(_has_bits_[0], other->_has_bits_[0]);
+    _unknown_fields_.Swap(&other->_unknown_fields_);
+    std::swap(_cached_size_, other->_cached_size_);
+  }
+}
+
+::google::protobuf::Metadata MVCCStats::GetMetadata() const {
+  protobuf_AssignDescriptorsOnce();
+  ::google::protobuf::Metadata metadata;
+  metadata.descriptor = MVCCStats_descriptor_;
+  metadata.reflection = MVCCStats_reflection_;
   return metadata;
 }
 

--- a/storage/engine/cockroach/proto/data.pb.h
+++ b/storage/engine/cockroach/proto/data.pb.h
@@ -54,6 +54,7 @@ class MVCCMetadata;
 class GCMetadata;
 class TimeSeriesDatapoint;
 class TimeSeriesData;
+class MVCCStats;
 
 enum ReplicaChangeType {
   ADD_REPLICA = 0,
@@ -1981,6 +1982,185 @@ class TimeSeriesData : public ::google::protobuf::Message {
 
   void InitAsDefaultInstance();
   static TimeSeriesData* default_instance_;
+};
+// -------------------------------------------------------------------
+
+class MVCCStats : public ::google::protobuf::Message {
+ public:
+  MVCCStats();
+  virtual ~MVCCStats();
+
+  MVCCStats(const MVCCStats& from);
+
+  inline MVCCStats& operator=(const MVCCStats& from) {
+    CopyFrom(from);
+    return *this;
+  }
+
+  inline const ::google::protobuf::UnknownFieldSet& unknown_fields() const {
+    return _unknown_fields_;
+  }
+
+  inline ::google::protobuf::UnknownFieldSet* mutable_unknown_fields() {
+    return &_unknown_fields_;
+  }
+
+  static const ::google::protobuf::Descriptor* descriptor();
+  static const MVCCStats& default_instance();
+
+  void Swap(MVCCStats* other);
+
+  // implements Message ----------------------------------------------
+
+  MVCCStats* New() const;
+  void CopyFrom(const ::google::protobuf::Message& from);
+  void MergeFrom(const ::google::protobuf::Message& from);
+  void CopyFrom(const MVCCStats& from);
+  void MergeFrom(const MVCCStats& from);
+  void Clear();
+  bool IsInitialized() const;
+
+  int ByteSize() const;
+  bool MergePartialFromCodedStream(
+      ::google::protobuf::io::CodedInputStream* input);
+  void SerializeWithCachedSizes(
+      ::google::protobuf::io::CodedOutputStream* output) const;
+  ::google::protobuf::uint8* SerializeWithCachedSizesToArray(::google::protobuf::uint8* output) const;
+  int GetCachedSize() const { return _cached_size_; }
+  private:
+  void SharedCtor();
+  void SharedDtor();
+  void SetCachedSize(int size) const;
+  public:
+  ::google::protobuf::Metadata GetMetadata() const;
+
+  // nested types ----------------------------------------------------
+
+  // accessors -------------------------------------------------------
+
+  // optional int64 live_bytes = 1;
+  inline bool has_live_bytes() const;
+  inline void clear_live_bytes();
+  static const int kLiveBytesFieldNumber = 1;
+  inline ::google::protobuf::int64 live_bytes() const;
+  inline void set_live_bytes(::google::protobuf::int64 value);
+
+  // optional int64 key_bytes = 2;
+  inline bool has_key_bytes() const;
+  inline void clear_key_bytes();
+  static const int kKeyBytesFieldNumber = 2;
+  inline ::google::protobuf::int64 key_bytes() const;
+  inline void set_key_bytes(::google::protobuf::int64 value);
+
+  // optional int64 val_bytes = 3;
+  inline bool has_val_bytes() const;
+  inline void clear_val_bytes();
+  static const int kValBytesFieldNumber = 3;
+  inline ::google::protobuf::int64 val_bytes() const;
+  inline void set_val_bytes(::google::protobuf::int64 value);
+
+  // optional int64 intent_bytes = 4;
+  inline bool has_intent_bytes() const;
+  inline void clear_intent_bytes();
+  static const int kIntentBytesFieldNumber = 4;
+  inline ::google::protobuf::int64 intent_bytes() const;
+  inline void set_intent_bytes(::google::protobuf::int64 value);
+
+  // optional int64 live_count = 5;
+  inline bool has_live_count() const;
+  inline void clear_live_count();
+  static const int kLiveCountFieldNumber = 5;
+  inline ::google::protobuf::int64 live_count() const;
+  inline void set_live_count(::google::protobuf::int64 value);
+
+  // optional int64 key_count = 6;
+  inline bool has_key_count() const;
+  inline void clear_key_count();
+  static const int kKeyCountFieldNumber = 6;
+  inline ::google::protobuf::int64 key_count() const;
+  inline void set_key_count(::google::protobuf::int64 value);
+
+  // optional int64 val_count = 7;
+  inline bool has_val_count() const;
+  inline void clear_val_count();
+  static const int kValCountFieldNumber = 7;
+  inline ::google::protobuf::int64 val_count() const;
+  inline void set_val_count(::google::protobuf::int64 value);
+
+  // optional int64 intent_count = 8;
+  inline bool has_intent_count() const;
+  inline void clear_intent_count();
+  static const int kIntentCountFieldNumber = 8;
+  inline ::google::protobuf::int64 intent_count() const;
+  inline void set_intent_count(::google::protobuf::int64 value);
+
+  // optional int64 intent_age = 9;
+  inline bool has_intent_age() const;
+  inline void clear_intent_age();
+  static const int kIntentAgeFieldNumber = 9;
+  inline ::google::protobuf::int64 intent_age() const;
+  inline void set_intent_age(::google::protobuf::int64 value);
+
+  // optional int64 gc_bytes_age = 10;
+  inline bool has_gc_bytes_age() const;
+  inline void clear_gc_bytes_age();
+  static const int kGcBytesAgeFieldNumber = 10;
+  inline ::google::protobuf::int64 gc_bytes_age() const;
+  inline void set_gc_bytes_age(::google::protobuf::int64 value);
+
+  // optional int64 last_update_nanos = 11;
+  inline bool has_last_update_nanos() const;
+  inline void clear_last_update_nanos();
+  static const int kLastUpdateNanosFieldNumber = 11;
+  inline ::google::protobuf::int64 last_update_nanos() const;
+  inline void set_last_update_nanos(::google::protobuf::int64 value);
+
+  // @@protoc_insertion_point(class_scope:cockroach.proto.MVCCStats)
+ private:
+  inline void set_has_live_bytes();
+  inline void clear_has_live_bytes();
+  inline void set_has_key_bytes();
+  inline void clear_has_key_bytes();
+  inline void set_has_val_bytes();
+  inline void clear_has_val_bytes();
+  inline void set_has_intent_bytes();
+  inline void clear_has_intent_bytes();
+  inline void set_has_live_count();
+  inline void clear_has_live_count();
+  inline void set_has_key_count();
+  inline void clear_has_key_count();
+  inline void set_has_val_count();
+  inline void clear_has_val_count();
+  inline void set_has_intent_count();
+  inline void clear_has_intent_count();
+  inline void set_has_intent_age();
+  inline void clear_has_intent_age();
+  inline void set_has_gc_bytes_age();
+  inline void clear_has_gc_bytes_age();
+  inline void set_has_last_update_nanos();
+  inline void clear_has_last_update_nanos();
+
+  ::google::protobuf::UnknownFieldSet _unknown_fields_;
+
+  ::google::protobuf::uint32 _has_bits_[1];
+  mutable int _cached_size_;
+  ::google::protobuf::int64 live_bytes_;
+  ::google::protobuf::int64 key_bytes_;
+  ::google::protobuf::int64 val_bytes_;
+  ::google::protobuf::int64 intent_bytes_;
+  ::google::protobuf::int64 live_count_;
+  ::google::protobuf::int64 key_count_;
+  ::google::protobuf::int64 val_count_;
+  ::google::protobuf::int64 intent_count_;
+  ::google::protobuf::int64 intent_age_;
+  ::google::protobuf::int64 gc_bytes_age_;
+  ::google::protobuf::int64 last_update_nanos_;
+  friend void  protobuf_AddDesc_cockroach_2fproto_2fdata_2eproto();
+  friend void protobuf_AssignDesc_cockroach_2fproto_2fdata_2eproto();
+  friend void protobuf_ShutdownFile_cockroach_2fproto_2fdata_2eproto();
+
+  void InitAsDefaultInstance();
+  static MVCCStats* default_instance_;
 };
 // ===================================================================
 
@@ -4379,6 +4559,274 @@ inline ::google::protobuf::RepeatedPtrField< ::cockroach::proto::TimeSeriesDatap
 TimeSeriesData::mutable_datapoints() {
   // @@protoc_insertion_point(field_mutable_list:cockroach.proto.TimeSeriesData.datapoints)
   return &datapoints_;
+}
+
+// -------------------------------------------------------------------
+
+// MVCCStats
+
+// optional int64 live_bytes = 1;
+inline bool MVCCStats::has_live_bytes() const {
+  return (_has_bits_[0] & 0x00000001u) != 0;
+}
+inline void MVCCStats::set_has_live_bytes() {
+  _has_bits_[0] |= 0x00000001u;
+}
+inline void MVCCStats::clear_has_live_bytes() {
+  _has_bits_[0] &= ~0x00000001u;
+}
+inline void MVCCStats::clear_live_bytes() {
+  live_bytes_ = GOOGLE_LONGLONG(0);
+  clear_has_live_bytes();
+}
+inline ::google::protobuf::int64 MVCCStats::live_bytes() const {
+  // @@protoc_insertion_point(field_get:cockroach.proto.MVCCStats.live_bytes)
+  return live_bytes_;
+}
+inline void MVCCStats::set_live_bytes(::google::protobuf::int64 value) {
+  set_has_live_bytes();
+  live_bytes_ = value;
+  // @@protoc_insertion_point(field_set:cockroach.proto.MVCCStats.live_bytes)
+}
+
+// optional int64 key_bytes = 2;
+inline bool MVCCStats::has_key_bytes() const {
+  return (_has_bits_[0] & 0x00000002u) != 0;
+}
+inline void MVCCStats::set_has_key_bytes() {
+  _has_bits_[0] |= 0x00000002u;
+}
+inline void MVCCStats::clear_has_key_bytes() {
+  _has_bits_[0] &= ~0x00000002u;
+}
+inline void MVCCStats::clear_key_bytes() {
+  key_bytes_ = GOOGLE_LONGLONG(0);
+  clear_has_key_bytes();
+}
+inline ::google::protobuf::int64 MVCCStats::key_bytes() const {
+  // @@protoc_insertion_point(field_get:cockroach.proto.MVCCStats.key_bytes)
+  return key_bytes_;
+}
+inline void MVCCStats::set_key_bytes(::google::protobuf::int64 value) {
+  set_has_key_bytes();
+  key_bytes_ = value;
+  // @@protoc_insertion_point(field_set:cockroach.proto.MVCCStats.key_bytes)
+}
+
+// optional int64 val_bytes = 3;
+inline bool MVCCStats::has_val_bytes() const {
+  return (_has_bits_[0] & 0x00000004u) != 0;
+}
+inline void MVCCStats::set_has_val_bytes() {
+  _has_bits_[0] |= 0x00000004u;
+}
+inline void MVCCStats::clear_has_val_bytes() {
+  _has_bits_[0] &= ~0x00000004u;
+}
+inline void MVCCStats::clear_val_bytes() {
+  val_bytes_ = GOOGLE_LONGLONG(0);
+  clear_has_val_bytes();
+}
+inline ::google::protobuf::int64 MVCCStats::val_bytes() const {
+  // @@protoc_insertion_point(field_get:cockroach.proto.MVCCStats.val_bytes)
+  return val_bytes_;
+}
+inline void MVCCStats::set_val_bytes(::google::protobuf::int64 value) {
+  set_has_val_bytes();
+  val_bytes_ = value;
+  // @@protoc_insertion_point(field_set:cockroach.proto.MVCCStats.val_bytes)
+}
+
+// optional int64 intent_bytes = 4;
+inline bool MVCCStats::has_intent_bytes() const {
+  return (_has_bits_[0] & 0x00000008u) != 0;
+}
+inline void MVCCStats::set_has_intent_bytes() {
+  _has_bits_[0] |= 0x00000008u;
+}
+inline void MVCCStats::clear_has_intent_bytes() {
+  _has_bits_[0] &= ~0x00000008u;
+}
+inline void MVCCStats::clear_intent_bytes() {
+  intent_bytes_ = GOOGLE_LONGLONG(0);
+  clear_has_intent_bytes();
+}
+inline ::google::protobuf::int64 MVCCStats::intent_bytes() const {
+  // @@protoc_insertion_point(field_get:cockroach.proto.MVCCStats.intent_bytes)
+  return intent_bytes_;
+}
+inline void MVCCStats::set_intent_bytes(::google::protobuf::int64 value) {
+  set_has_intent_bytes();
+  intent_bytes_ = value;
+  // @@protoc_insertion_point(field_set:cockroach.proto.MVCCStats.intent_bytes)
+}
+
+// optional int64 live_count = 5;
+inline bool MVCCStats::has_live_count() const {
+  return (_has_bits_[0] & 0x00000010u) != 0;
+}
+inline void MVCCStats::set_has_live_count() {
+  _has_bits_[0] |= 0x00000010u;
+}
+inline void MVCCStats::clear_has_live_count() {
+  _has_bits_[0] &= ~0x00000010u;
+}
+inline void MVCCStats::clear_live_count() {
+  live_count_ = GOOGLE_LONGLONG(0);
+  clear_has_live_count();
+}
+inline ::google::protobuf::int64 MVCCStats::live_count() const {
+  // @@protoc_insertion_point(field_get:cockroach.proto.MVCCStats.live_count)
+  return live_count_;
+}
+inline void MVCCStats::set_live_count(::google::protobuf::int64 value) {
+  set_has_live_count();
+  live_count_ = value;
+  // @@protoc_insertion_point(field_set:cockroach.proto.MVCCStats.live_count)
+}
+
+// optional int64 key_count = 6;
+inline bool MVCCStats::has_key_count() const {
+  return (_has_bits_[0] & 0x00000020u) != 0;
+}
+inline void MVCCStats::set_has_key_count() {
+  _has_bits_[0] |= 0x00000020u;
+}
+inline void MVCCStats::clear_has_key_count() {
+  _has_bits_[0] &= ~0x00000020u;
+}
+inline void MVCCStats::clear_key_count() {
+  key_count_ = GOOGLE_LONGLONG(0);
+  clear_has_key_count();
+}
+inline ::google::protobuf::int64 MVCCStats::key_count() const {
+  // @@protoc_insertion_point(field_get:cockroach.proto.MVCCStats.key_count)
+  return key_count_;
+}
+inline void MVCCStats::set_key_count(::google::protobuf::int64 value) {
+  set_has_key_count();
+  key_count_ = value;
+  // @@protoc_insertion_point(field_set:cockroach.proto.MVCCStats.key_count)
+}
+
+// optional int64 val_count = 7;
+inline bool MVCCStats::has_val_count() const {
+  return (_has_bits_[0] & 0x00000040u) != 0;
+}
+inline void MVCCStats::set_has_val_count() {
+  _has_bits_[0] |= 0x00000040u;
+}
+inline void MVCCStats::clear_has_val_count() {
+  _has_bits_[0] &= ~0x00000040u;
+}
+inline void MVCCStats::clear_val_count() {
+  val_count_ = GOOGLE_LONGLONG(0);
+  clear_has_val_count();
+}
+inline ::google::protobuf::int64 MVCCStats::val_count() const {
+  // @@protoc_insertion_point(field_get:cockroach.proto.MVCCStats.val_count)
+  return val_count_;
+}
+inline void MVCCStats::set_val_count(::google::protobuf::int64 value) {
+  set_has_val_count();
+  val_count_ = value;
+  // @@protoc_insertion_point(field_set:cockroach.proto.MVCCStats.val_count)
+}
+
+// optional int64 intent_count = 8;
+inline bool MVCCStats::has_intent_count() const {
+  return (_has_bits_[0] & 0x00000080u) != 0;
+}
+inline void MVCCStats::set_has_intent_count() {
+  _has_bits_[0] |= 0x00000080u;
+}
+inline void MVCCStats::clear_has_intent_count() {
+  _has_bits_[0] &= ~0x00000080u;
+}
+inline void MVCCStats::clear_intent_count() {
+  intent_count_ = GOOGLE_LONGLONG(0);
+  clear_has_intent_count();
+}
+inline ::google::protobuf::int64 MVCCStats::intent_count() const {
+  // @@protoc_insertion_point(field_get:cockroach.proto.MVCCStats.intent_count)
+  return intent_count_;
+}
+inline void MVCCStats::set_intent_count(::google::protobuf::int64 value) {
+  set_has_intent_count();
+  intent_count_ = value;
+  // @@protoc_insertion_point(field_set:cockroach.proto.MVCCStats.intent_count)
+}
+
+// optional int64 intent_age = 9;
+inline bool MVCCStats::has_intent_age() const {
+  return (_has_bits_[0] & 0x00000100u) != 0;
+}
+inline void MVCCStats::set_has_intent_age() {
+  _has_bits_[0] |= 0x00000100u;
+}
+inline void MVCCStats::clear_has_intent_age() {
+  _has_bits_[0] &= ~0x00000100u;
+}
+inline void MVCCStats::clear_intent_age() {
+  intent_age_ = GOOGLE_LONGLONG(0);
+  clear_has_intent_age();
+}
+inline ::google::protobuf::int64 MVCCStats::intent_age() const {
+  // @@protoc_insertion_point(field_get:cockroach.proto.MVCCStats.intent_age)
+  return intent_age_;
+}
+inline void MVCCStats::set_intent_age(::google::protobuf::int64 value) {
+  set_has_intent_age();
+  intent_age_ = value;
+  // @@protoc_insertion_point(field_set:cockroach.proto.MVCCStats.intent_age)
+}
+
+// optional int64 gc_bytes_age = 10;
+inline bool MVCCStats::has_gc_bytes_age() const {
+  return (_has_bits_[0] & 0x00000200u) != 0;
+}
+inline void MVCCStats::set_has_gc_bytes_age() {
+  _has_bits_[0] |= 0x00000200u;
+}
+inline void MVCCStats::clear_has_gc_bytes_age() {
+  _has_bits_[0] &= ~0x00000200u;
+}
+inline void MVCCStats::clear_gc_bytes_age() {
+  gc_bytes_age_ = GOOGLE_LONGLONG(0);
+  clear_has_gc_bytes_age();
+}
+inline ::google::protobuf::int64 MVCCStats::gc_bytes_age() const {
+  // @@protoc_insertion_point(field_get:cockroach.proto.MVCCStats.gc_bytes_age)
+  return gc_bytes_age_;
+}
+inline void MVCCStats::set_gc_bytes_age(::google::protobuf::int64 value) {
+  set_has_gc_bytes_age();
+  gc_bytes_age_ = value;
+  // @@protoc_insertion_point(field_set:cockroach.proto.MVCCStats.gc_bytes_age)
+}
+
+// optional int64 last_update_nanos = 11;
+inline bool MVCCStats::has_last_update_nanos() const {
+  return (_has_bits_[0] & 0x00000400u) != 0;
+}
+inline void MVCCStats::set_has_last_update_nanos() {
+  _has_bits_[0] |= 0x00000400u;
+}
+inline void MVCCStats::clear_has_last_update_nanos() {
+  _has_bits_[0] &= ~0x00000400u;
+}
+inline void MVCCStats::clear_last_update_nanos() {
+  last_update_nanos_ = GOOGLE_LONGLONG(0);
+  clear_has_last_update_nanos();
+}
+inline ::google::protobuf::int64 MVCCStats::last_update_nanos() const {
+  // @@protoc_insertion_point(field_get:cockroach.proto.MVCCStats.last_update_nanos)
+  return last_update_nanos_;
+}
+inline void MVCCStats::set_last_update_nanos(::google::protobuf::int64 value) {
+  set_has_last_update_nanos();
+  last_update_nanos_ = value;
+  // @@protoc_insertion_point(field_set:cockroach.proto.MVCCStats.last_update_nanos)
 }
 
 

--- a/storage/engine/cockroach/proto/status.pb.cc
+++ b/storage/engine/cockroach/proto/status.pb.cc
@@ -35,14 +35,13 @@ void protobuf_AssignDesc_cockroach_2fproto_2fstatus_2eproto() {
       "cockroach/proto/status.proto");
   GOOGLE_CHECK(file != NULL);
   StoreStatus_descriptor_ = file->message_type(0);
-  static const int StoreStatus_offsets_[7] = {
+  static const int StoreStatus_offsets_[6] = {
     GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(StoreStatus, store_id_),
     GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(StoreStatus, node_id_),
-    GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(StoreStatus, raft_ids_),
-    GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(StoreStatus, updated_at_),
+    GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(StoreStatus, range_count_),
     GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(StoreStatus, started_at_),
-    GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(StoreStatus, used_bytes_),
-    GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(StoreStatus, max_bytes_),
+    GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(StoreStatus, updated_at_),
+    GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(StoreStatus, stats_),
   };
   StoreStatus_reflection_ =
     new ::google::protobuf::internal::GeneratedMessageReflection(
@@ -84,17 +83,18 @@ void protobuf_AddDesc_cockroach_2fproto_2fstatus_2eproto() {
   already_here = true;
   GOOGLE_PROTOBUF_VERIFY_VERSION;
 
+  ::cockroach::proto::protobuf_AddDesc_cockroach_2fproto_2fdata_2eproto();
   ::gogoproto::protobuf_AddDesc_gogoproto_2fgogo_2eproto();
   ::google::protobuf::DescriptorPool::InternalAddGeneratedFile(
     "\n\034cockroach/proto/status.proto\022\017cockroac"
-    "h.proto\032\024gogoproto/gogo.proto\"\360\001\n\013StoreS"
-    "tatus\022,\n\010store_id\030\001 \001(\005B\032\310\336\037\000\342\336\037\007StoreID"
-    "\332\336\037\007StoreID\022)\n\007node_id\030\002 \001(\005B\030\310\336\037\000\342\336\037\006No"
-    "deID\332\336\037\006NodeID\022!\n\010raft_ids\030\003 \003(\003B\017\310\336\037\000\342\336"
-    "\037\007RaftIDs\022\030\n\nupdated_at\030\004 \001(\003B\004\310\336\037\000\022\030\n\ns"
-    "tarted_at\030\005 \001(\003B\004\310\336\037\000\022\030\n\nused_bytes\030\006 \001("
-    "\003B\004\310\336\037\000\022\027\n\tmax_bytes\030\007 \001(\003B\004\310\336\037\000B\023Z\005prot"
-    "o\340\342\036\001\310\342\036\001\320\342\036\001", 333);
+    "h.proto\032\032cockroach/proto/data.proto\032\024gog"
+    "oproto/gogo.proto\"\346\001\n\013StoreStatus\022,\n\010sto"
+    "re_id\030\001 \001(\005B\032\310\336\037\000\342\336\037\007StoreID\332\336\037\007StoreID\022"
+    ")\n\007node_id\030\002 \001(\005B\030\310\336\037\000\342\336\037\006NodeID\332\336\037\006Node"
+    "ID\022\031\n\013range_count\030\003 \001(\005B\004\310\336\037\000\022\030\n\nstarted"
+    "_at\030\004 \001(\003B\004\310\336\037\000\022\030\n\nupdated_at\030\005 \001(\003B\004\310\336\037"
+    "\000\022/\n\005stats\030\006 \001(\0132\032.cockroach.proto.MVCCS"
+    "tatsB\004\310\336\037\000B\023Z\005proto\340\342\036\001\310\342\036\001\320\342\036\001", 351);
   ::google::protobuf::MessageFactory::InternalRegisterGeneratedFile(
     "cockroach/proto/status.proto", &protobuf_RegisterTypes);
   StoreStatus::default_instance_ = new StoreStatus();
@@ -114,11 +114,10 @@ struct StaticDescriptorInitializer_cockroach_2fproto_2fstatus_2eproto {
 #ifndef _MSC_VER
 const int StoreStatus::kStoreIdFieldNumber;
 const int StoreStatus::kNodeIdFieldNumber;
-const int StoreStatus::kRaftIdsFieldNumber;
-const int StoreStatus::kUpdatedAtFieldNumber;
+const int StoreStatus::kRangeCountFieldNumber;
 const int StoreStatus::kStartedAtFieldNumber;
-const int StoreStatus::kUsedBytesFieldNumber;
-const int StoreStatus::kMaxBytesFieldNumber;
+const int StoreStatus::kUpdatedAtFieldNumber;
+const int StoreStatus::kStatsFieldNumber;
 #endif  // !_MSC_VER
 
 StoreStatus::StoreStatus()
@@ -128,6 +127,7 @@ StoreStatus::StoreStatus()
 }
 
 void StoreStatus::InitAsDefaultInstance() {
+  stats_ = const_cast< ::cockroach::proto::MVCCStats*>(&::cockroach::proto::MVCCStats::default_instance());
 }
 
 StoreStatus::StoreStatus(const StoreStatus& from)
@@ -141,10 +141,10 @@ void StoreStatus::SharedCtor() {
   _cached_size_ = 0;
   store_id_ = 0;
   node_id_ = 0;
-  updated_at_ = GOOGLE_LONGLONG(0);
+  range_count_ = 0;
   started_at_ = GOOGLE_LONGLONG(0);
-  used_bytes_ = GOOGLE_LONGLONG(0);
-  max_bytes_ = GOOGLE_LONGLONG(0);
+  updated_at_ = GOOGLE_LONGLONG(0);
+  stats_ = NULL;
   ::memset(_has_bits_, 0, sizeof(_has_bits_));
 }
 
@@ -155,6 +155,7 @@ StoreStatus::~StoreStatus() {
 
 void StoreStatus::SharedDtor() {
   if (this != default_instance_) {
+    delete stats_;
   }
 }
 
@@ -190,15 +191,17 @@ void StoreStatus::Clear() {
     ::memset(&first, 0, n);                                \
   } while (0)
 
-  if (_has_bits_[0 / 32] & 123) {
-    ZR_(store_id_, node_id_);
-    ZR_(updated_at_, max_bytes_);
+  if (_has_bits_[0 / 32] & 63) {
+    ZR_(store_id_, updated_at_);
+    range_count_ = 0;
+    if (has_stats()) {
+      if (stats_ != NULL) stats_->::cockroach::proto::MVCCStats::Clear();
+    }
   }
 
 #undef OFFSET_OF_FIELD_
 #undef ZR_
 
-  raft_ids_.Clear();
   ::memset(_has_bits_, 0, sizeof(_has_bits_));
   mutable_unknown_fields()->Clear();
 }
@@ -238,47 +241,28 @@ bool StoreStatus::MergePartialFromCodedStream(
         } else {
           goto handle_unusual;
         }
-        if (input->ExpectTag(24)) goto parse_raft_ids;
+        if (input->ExpectTag(24)) goto parse_range_count;
         break;
       }
 
-      // repeated int64 raft_ids = 3;
+      // optional int32 range_count = 3;
       case 3: {
         if (tag == 24) {
-         parse_raft_ids:
-          DO_((::google::protobuf::internal::WireFormatLite::ReadRepeatedPrimitive<
-                   ::google::protobuf::int64, ::google::protobuf::internal::WireFormatLite::TYPE_INT64>(
-                 1, 24, input, this->mutable_raft_ids())));
-        } else if (tag == 26) {
-          DO_((::google::protobuf::internal::WireFormatLite::ReadPackedPrimitiveNoInline<
-                   ::google::protobuf::int64, ::google::protobuf::internal::WireFormatLite::TYPE_INT64>(
-                 input, this->mutable_raft_ids())));
+         parse_range_count:
+          DO_((::google::protobuf::internal::WireFormatLite::ReadPrimitive<
+                   ::google::protobuf::int32, ::google::protobuf::internal::WireFormatLite::TYPE_INT32>(
+                 input, &range_count_)));
+          set_has_range_count();
         } else {
           goto handle_unusual;
         }
-        if (input->ExpectTag(24)) goto parse_raft_ids;
-        if (input->ExpectTag(32)) goto parse_updated_at;
+        if (input->ExpectTag(32)) goto parse_started_at;
         break;
       }
 
-      // optional int64 updated_at = 4;
+      // optional int64 started_at = 4;
       case 4: {
         if (tag == 32) {
-         parse_updated_at:
-          DO_((::google::protobuf::internal::WireFormatLite::ReadPrimitive<
-                   ::google::protobuf::int64, ::google::protobuf::internal::WireFormatLite::TYPE_INT64>(
-                 input, &updated_at_)));
-          set_has_updated_at();
-        } else {
-          goto handle_unusual;
-        }
-        if (input->ExpectTag(40)) goto parse_started_at;
-        break;
-      }
-
-      // optional int64 started_at = 5;
-      case 5: {
-        if (tag == 40) {
          parse_started_at:
           DO_((::google::protobuf::internal::WireFormatLite::ReadPrimitive<
                    ::google::protobuf::int64, ::google::protobuf::internal::WireFormatLite::TYPE_INT64>(
@@ -287,33 +271,31 @@ bool StoreStatus::MergePartialFromCodedStream(
         } else {
           goto handle_unusual;
         }
-        if (input->ExpectTag(48)) goto parse_used_bytes;
+        if (input->ExpectTag(40)) goto parse_updated_at;
         break;
       }
 
-      // optional int64 used_bytes = 6;
-      case 6: {
-        if (tag == 48) {
-         parse_used_bytes:
+      // optional int64 updated_at = 5;
+      case 5: {
+        if (tag == 40) {
+         parse_updated_at:
           DO_((::google::protobuf::internal::WireFormatLite::ReadPrimitive<
                    ::google::protobuf::int64, ::google::protobuf::internal::WireFormatLite::TYPE_INT64>(
-                 input, &used_bytes_)));
-          set_has_used_bytes();
+                 input, &updated_at_)));
+          set_has_updated_at();
         } else {
           goto handle_unusual;
         }
-        if (input->ExpectTag(56)) goto parse_max_bytes;
+        if (input->ExpectTag(50)) goto parse_stats;
         break;
       }
 
-      // optional int64 max_bytes = 7;
-      case 7: {
-        if (tag == 56) {
-         parse_max_bytes:
-          DO_((::google::protobuf::internal::WireFormatLite::ReadPrimitive<
-                   ::google::protobuf::int64, ::google::protobuf::internal::WireFormatLite::TYPE_INT64>(
-                 input, &max_bytes_)));
-          set_has_max_bytes();
+      // optional .cockroach.proto.MVCCStats stats = 6;
+      case 6: {
+        if (tag == 50) {
+         parse_stats:
+          DO_(::google::protobuf::internal::WireFormatLite::ReadMessageNoVirtual(
+               input, mutable_stats()));
         } else {
           goto handle_unusual;
         }
@@ -356,30 +338,25 @@ void StoreStatus::SerializeWithCachedSizes(
     ::google::protobuf::internal::WireFormatLite::WriteInt32(2, this->node_id(), output);
   }
 
-  // repeated int64 raft_ids = 3;
-  for (int i = 0; i < this->raft_ids_size(); i++) {
-    ::google::protobuf::internal::WireFormatLite::WriteInt64(
-      3, this->raft_ids(i), output);
+  // optional int32 range_count = 3;
+  if (has_range_count()) {
+    ::google::protobuf::internal::WireFormatLite::WriteInt32(3, this->range_count(), output);
   }
 
-  // optional int64 updated_at = 4;
-  if (has_updated_at()) {
-    ::google::protobuf::internal::WireFormatLite::WriteInt64(4, this->updated_at(), output);
-  }
-
-  // optional int64 started_at = 5;
+  // optional int64 started_at = 4;
   if (has_started_at()) {
-    ::google::protobuf::internal::WireFormatLite::WriteInt64(5, this->started_at(), output);
+    ::google::protobuf::internal::WireFormatLite::WriteInt64(4, this->started_at(), output);
   }
 
-  // optional int64 used_bytes = 6;
-  if (has_used_bytes()) {
-    ::google::protobuf::internal::WireFormatLite::WriteInt64(6, this->used_bytes(), output);
+  // optional int64 updated_at = 5;
+  if (has_updated_at()) {
+    ::google::protobuf::internal::WireFormatLite::WriteInt64(5, this->updated_at(), output);
   }
 
-  // optional int64 max_bytes = 7;
-  if (has_max_bytes()) {
-    ::google::protobuf::internal::WireFormatLite::WriteInt64(7, this->max_bytes(), output);
+  // optional .cockroach.proto.MVCCStats stats = 6;
+  if (has_stats()) {
+    ::google::protobuf::internal::WireFormatLite::WriteMessageMaybeToArray(
+      6, this->stats(), output);
   }
 
   if (!unknown_fields().empty()) {
@@ -402,30 +379,26 @@ void StoreStatus::SerializeWithCachedSizes(
     target = ::google::protobuf::internal::WireFormatLite::WriteInt32ToArray(2, this->node_id(), target);
   }
 
-  // repeated int64 raft_ids = 3;
-  for (int i = 0; i < this->raft_ids_size(); i++) {
-    target = ::google::protobuf::internal::WireFormatLite::
-      WriteInt64ToArray(3, this->raft_ids(i), target);
+  // optional int32 range_count = 3;
+  if (has_range_count()) {
+    target = ::google::protobuf::internal::WireFormatLite::WriteInt32ToArray(3, this->range_count(), target);
   }
 
-  // optional int64 updated_at = 4;
-  if (has_updated_at()) {
-    target = ::google::protobuf::internal::WireFormatLite::WriteInt64ToArray(4, this->updated_at(), target);
-  }
-
-  // optional int64 started_at = 5;
+  // optional int64 started_at = 4;
   if (has_started_at()) {
-    target = ::google::protobuf::internal::WireFormatLite::WriteInt64ToArray(5, this->started_at(), target);
+    target = ::google::protobuf::internal::WireFormatLite::WriteInt64ToArray(4, this->started_at(), target);
   }
 
-  // optional int64 used_bytes = 6;
-  if (has_used_bytes()) {
-    target = ::google::protobuf::internal::WireFormatLite::WriteInt64ToArray(6, this->used_bytes(), target);
+  // optional int64 updated_at = 5;
+  if (has_updated_at()) {
+    target = ::google::protobuf::internal::WireFormatLite::WriteInt64ToArray(5, this->updated_at(), target);
   }
 
-  // optional int64 max_bytes = 7;
-  if (has_max_bytes()) {
-    target = ::google::protobuf::internal::WireFormatLite::WriteInt64ToArray(7, this->max_bytes(), target);
+  // optional .cockroach.proto.MVCCStats stats = 6;
+  if (has_stats()) {
+    target = ::google::protobuf::internal::WireFormatLite::
+      WriteMessageNoVirtualToArray(
+        6, this->stats(), target);
   }
 
   if (!unknown_fields().empty()) {
@@ -454,45 +427,35 @@ int StoreStatus::ByteSize() const {
           this->node_id());
     }
 
-    // optional int64 updated_at = 4;
-    if (has_updated_at()) {
+    // optional int32 range_count = 3;
+    if (has_range_count()) {
       total_size += 1 +
-        ::google::protobuf::internal::WireFormatLite::Int64Size(
-          this->updated_at());
+        ::google::protobuf::internal::WireFormatLite::Int32Size(
+          this->range_count());
     }
 
-    // optional int64 started_at = 5;
+    // optional int64 started_at = 4;
     if (has_started_at()) {
       total_size += 1 +
         ::google::protobuf::internal::WireFormatLite::Int64Size(
           this->started_at());
     }
 
-    // optional int64 used_bytes = 6;
-    if (has_used_bytes()) {
+    // optional int64 updated_at = 5;
+    if (has_updated_at()) {
       total_size += 1 +
         ::google::protobuf::internal::WireFormatLite::Int64Size(
-          this->used_bytes());
+          this->updated_at());
     }
 
-    // optional int64 max_bytes = 7;
-    if (has_max_bytes()) {
+    // optional .cockroach.proto.MVCCStats stats = 6;
+    if (has_stats()) {
       total_size += 1 +
-        ::google::protobuf::internal::WireFormatLite::Int64Size(
-          this->max_bytes());
+        ::google::protobuf::internal::WireFormatLite::MessageSizeNoVirtual(
+          this->stats());
     }
 
   }
-  // repeated int64 raft_ids = 3;
-  {
-    int data_size = 0;
-    for (int i = 0; i < this->raft_ids_size(); i++) {
-      data_size += ::google::protobuf::internal::WireFormatLite::
-        Int64Size(this->raft_ids(i));
-    }
-    total_size += 1 * this->raft_ids_size() + data_size;
-  }
-
   if (!unknown_fields().empty()) {
     total_size +=
       ::google::protobuf::internal::WireFormat::ComputeUnknownFieldsSize(
@@ -518,7 +481,6 @@ void StoreStatus::MergeFrom(const ::google::protobuf::Message& from) {
 
 void StoreStatus::MergeFrom(const StoreStatus& from) {
   GOOGLE_CHECK_NE(&from, this);
-  raft_ids_.MergeFrom(from.raft_ids_);
   if (from._has_bits_[0 / 32] & (0xffu << (0 % 32))) {
     if (from.has_store_id()) {
       set_store_id(from.store_id());
@@ -526,17 +488,17 @@ void StoreStatus::MergeFrom(const StoreStatus& from) {
     if (from.has_node_id()) {
       set_node_id(from.node_id());
     }
-    if (from.has_updated_at()) {
-      set_updated_at(from.updated_at());
+    if (from.has_range_count()) {
+      set_range_count(from.range_count());
     }
     if (from.has_started_at()) {
       set_started_at(from.started_at());
     }
-    if (from.has_used_bytes()) {
-      set_used_bytes(from.used_bytes());
+    if (from.has_updated_at()) {
+      set_updated_at(from.updated_at());
     }
-    if (from.has_max_bytes()) {
-      set_max_bytes(from.max_bytes());
+    if (from.has_stats()) {
+      mutable_stats()->::cockroach::proto::MVCCStats::MergeFrom(from.stats());
     }
   }
   mutable_unknown_fields()->MergeFrom(from.unknown_fields());
@@ -563,11 +525,10 @@ void StoreStatus::Swap(StoreStatus* other) {
   if (other != this) {
     std::swap(store_id_, other->store_id_);
     std::swap(node_id_, other->node_id_);
-    raft_ids_.Swap(&other->raft_ids_);
-    std::swap(updated_at_, other->updated_at_);
+    std::swap(range_count_, other->range_count_);
     std::swap(started_at_, other->started_at_);
-    std::swap(used_bytes_, other->used_bytes_);
-    std::swap(max_bytes_, other->max_bytes_);
+    std::swap(updated_at_, other->updated_at_);
+    std::swap(stats_, other->stats_);
     std::swap(_has_bits_[0], other->_has_bits_[0]);
     _unknown_fields_.Swap(&other->_unknown_fields_);
     std::swap(_cached_size_, other->_cached_size_);

--- a/storage/engine/cockroach/proto/status.pb.h
+++ b/storage/engine/cockroach/proto/status.pb.h
@@ -24,6 +24,7 @@
 #include <google/protobuf/repeated_field.h>
 #include <google/protobuf/extension_set.h>
 #include <google/protobuf/unknown_field_set.h>
+#include "cockroach/proto/data.pb.h"
 #include "gogoproto/gogo.pb.h"
 // @@protoc_insertion_point(includes)
 
@@ -106,45 +107,35 @@ class StoreStatus : public ::google::protobuf::Message {
   inline ::google::protobuf::int32 node_id() const;
   inline void set_node_id(::google::protobuf::int32 value);
 
-  // repeated int64 raft_ids = 3;
-  inline int raft_ids_size() const;
-  inline void clear_raft_ids();
-  static const int kRaftIdsFieldNumber = 3;
-  inline ::google::protobuf::int64 raft_ids(int index) const;
-  inline void set_raft_ids(int index, ::google::protobuf::int64 value);
-  inline void add_raft_ids(::google::protobuf::int64 value);
-  inline const ::google::protobuf::RepeatedField< ::google::protobuf::int64 >&
-      raft_ids() const;
-  inline ::google::protobuf::RepeatedField< ::google::protobuf::int64 >*
-      mutable_raft_ids();
+  // optional int32 range_count = 3;
+  inline bool has_range_count() const;
+  inline void clear_range_count();
+  static const int kRangeCountFieldNumber = 3;
+  inline ::google::protobuf::int32 range_count() const;
+  inline void set_range_count(::google::protobuf::int32 value);
 
-  // optional int64 updated_at = 4;
-  inline bool has_updated_at() const;
-  inline void clear_updated_at();
-  static const int kUpdatedAtFieldNumber = 4;
-  inline ::google::protobuf::int64 updated_at() const;
-  inline void set_updated_at(::google::protobuf::int64 value);
-
-  // optional int64 started_at = 5;
+  // optional int64 started_at = 4;
   inline bool has_started_at() const;
   inline void clear_started_at();
-  static const int kStartedAtFieldNumber = 5;
+  static const int kStartedAtFieldNumber = 4;
   inline ::google::protobuf::int64 started_at() const;
   inline void set_started_at(::google::protobuf::int64 value);
 
-  // optional int64 used_bytes = 6;
-  inline bool has_used_bytes() const;
-  inline void clear_used_bytes();
-  static const int kUsedBytesFieldNumber = 6;
-  inline ::google::protobuf::int64 used_bytes() const;
-  inline void set_used_bytes(::google::protobuf::int64 value);
+  // optional int64 updated_at = 5;
+  inline bool has_updated_at() const;
+  inline void clear_updated_at();
+  static const int kUpdatedAtFieldNumber = 5;
+  inline ::google::protobuf::int64 updated_at() const;
+  inline void set_updated_at(::google::protobuf::int64 value);
 
-  // optional int64 max_bytes = 7;
-  inline bool has_max_bytes() const;
-  inline void clear_max_bytes();
-  static const int kMaxBytesFieldNumber = 7;
-  inline ::google::protobuf::int64 max_bytes() const;
-  inline void set_max_bytes(::google::protobuf::int64 value);
+  // optional .cockroach.proto.MVCCStats stats = 6;
+  inline bool has_stats() const;
+  inline void clear_stats();
+  static const int kStatsFieldNumber = 6;
+  inline const ::cockroach::proto::MVCCStats& stats() const;
+  inline ::cockroach::proto::MVCCStats* mutable_stats();
+  inline ::cockroach::proto::MVCCStats* release_stats();
+  inline void set_allocated_stats(::cockroach::proto::MVCCStats* stats);
 
   // @@protoc_insertion_point(class_scope:cockroach.proto.StoreStatus)
  private:
@@ -152,14 +143,14 @@ class StoreStatus : public ::google::protobuf::Message {
   inline void clear_has_store_id();
   inline void set_has_node_id();
   inline void clear_has_node_id();
-  inline void set_has_updated_at();
-  inline void clear_has_updated_at();
+  inline void set_has_range_count();
+  inline void clear_has_range_count();
   inline void set_has_started_at();
   inline void clear_has_started_at();
-  inline void set_has_used_bytes();
-  inline void clear_has_used_bytes();
-  inline void set_has_max_bytes();
-  inline void clear_has_max_bytes();
+  inline void set_has_updated_at();
+  inline void clear_has_updated_at();
+  inline void set_has_stats();
+  inline void clear_has_stats();
 
   ::google::protobuf::UnknownFieldSet _unknown_fields_;
 
@@ -167,11 +158,10 @@ class StoreStatus : public ::google::protobuf::Message {
   mutable int _cached_size_;
   ::google::protobuf::int32 store_id_;
   ::google::protobuf::int32 node_id_;
-  ::google::protobuf::RepeatedField< ::google::protobuf::int64 > raft_ids_;
-  ::google::protobuf::int64 updated_at_;
   ::google::protobuf::int64 started_at_;
-  ::google::protobuf::int64 used_bytes_;
-  ::google::protobuf::int64 max_bytes_;
+  ::google::protobuf::int64 updated_at_;
+  ::cockroach::proto::MVCCStats* stats_;
+  ::google::protobuf::int32 range_count_;
   friend void  protobuf_AddDesc_cockroach_2fproto_2fstatus_2eproto();
   friend void protobuf_AssignDesc_cockroach_2fproto_2fstatus_2eproto();
   friend void protobuf_ShutdownFile_cockroach_2fproto_2fstatus_2eproto();
@@ -234,69 +224,39 @@ inline void StoreStatus::set_node_id(::google::protobuf::int32 value) {
   // @@protoc_insertion_point(field_set:cockroach.proto.StoreStatus.node_id)
 }
 
-// repeated int64 raft_ids = 3;
-inline int StoreStatus::raft_ids_size() const {
-  return raft_ids_.size();
+// optional int32 range_count = 3;
+inline bool StoreStatus::has_range_count() const {
+  return (_has_bits_[0] & 0x00000004u) != 0;
 }
-inline void StoreStatus::clear_raft_ids() {
-  raft_ids_.Clear();
+inline void StoreStatus::set_has_range_count() {
+  _has_bits_[0] |= 0x00000004u;
 }
-inline ::google::protobuf::int64 StoreStatus::raft_ids(int index) const {
-  // @@protoc_insertion_point(field_get:cockroach.proto.StoreStatus.raft_ids)
-  return raft_ids_.Get(index);
+inline void StoreStatus::clear_has_range_count() {
+  _has_bits_[0] &= ~0x00000004u;
 }
-inline void StoreStatus::set_raft_ids(int index, ::google::protobuf::int64 value) {
-  raft_ids_.Set(index, value);
-  // @@protoc_insertion_point(field_set:cockroach.proto.StoreStatus.raft_ids)
+inline void StoreStatus::clear_range_count() {
+  range_count_ = 0;
+  clear_has_range_count();
 }
-inline void StoreStatus::add_raft_ids(::google::protobuf::int64 value) {
-  raft_ids_.Add(value);
-  // @@protoc_insertion_point(field_add:cockroach.proto.StoreStatus.raft_ids)
+inline ::google::protobuf::int32 StoreStatus::range_count() const {
+  // @@protoc_insertion_point(field_get:cockroach.proto.StoreStatus.range_count)
+  return range_count_;
 }
-inline const ::google::protobuf::RepeatedField< ::google::protobuf::int64 >&
-StoreStatus::raft_ids() const {
-  // @@protoc_insertion_point(field_list:cockroach.proto.StoreStatus.raft_ids)
-  return raft_ids_;
-}
-inline ::google::protobuf::RepeatedField< ::google::protobuf::int64 >*
-StoreStatus::mutable_raft_ids() {
-  // @@protoc_insertion_point(field_mutable_list:cockroach.proto.StoreStatus.raft_ids)
-  return &raft_ids_;
+inline void StoreStatus::set_range_count(::google::protobuf::int32 value) {
+  set_has_range_count();
+  range_count_ = value;
+  // @@protoc_insertion_point(field_set:cockroach.proto.StoreStatus.range_count)
 }
 
-// optional int64 updated_at = 4;
-inline bool StoreStatus::has_updated_at() const {
+// optional int64 started_at = 4;
+inline bool StoreStatus::has_started_at() const {
   return (_has_bits_[0] & 0x00000008u) != 0;
 }
-inline void StoreStatus::set_has_updated_at() {
+inline void StoreStatus::set_has_started_at() {
   _has_bits_[0] |= 0x00000008u;
 }
-inline void StoreStatus::clear_has_updated_at() {
-  _has_bits_[0] &= ~0x00000008u;
-}
-inline void StoreStatus::clear_updated_at() {
-  updated_at_ = GOOGLE_LONGLONG(0);
-  clear_has_updated_at();
-}
-inline ::google::protobuf::int64 StoreStatus::updated_at() const {
-  // @@protoc_insertion_point(field_get:cockroach.proto.StoreStatus.updated_at)
-  return updated_at_;
-}
-inline void StoreStatus::set_updated_at(::google::protobuf::int64 value) {
-  set_has_updated_at();
-  updated_at_ = value;
-  // @@protoc_insertion_point(field_set:cockroach.proto.StoreStatus.updated_at)
-}
-
-// optional int64 started_at = 5;
-inline bool StoreStatus::has_started_at() const {
-  return (_has_bits_[0] & 0x00000010u) != 0;
-}
-inline void StoreStatus::set_has_started_at() {
-  _has_bits_[0] |= 0x00000010u;
-}
 inline void StoreStatus::clear_has_started_at() {
-  _has_bits_[0] &= ~0x00000010u;
+  _has_bits_[0] &= ~0x00000008u;
 }
 inline void StoreStatus::clear_started_at() {
   started_at_ = GOOGLE_LONGLONG(0);
@@ -312,52 +272,69 @@ inline void StoreStatus::set_started_at(::google::protobuf::int64 value) {
   // @@protoc_insertion_point(field_set:cockroach.proto.StoreStatus.started_at)
 }
 
-// optional int64 used_bytes = 6;
-inline bool StoreStatus::has_used_bytes() const {
-  return (_has_bits_[0] & 0x00000020u) != 0;
+// optional int64 updated_at = 5;
+inline bool StoreStatus::has_updated_at() const {
+  return (_has_bits_[0] & 0x00000010u) != 0;
 }
-inline void StoreStatus::set_has_used_bytes() {
-  _has_bits_[0] |= 0x00000020u;
+inline void StoreStatus::set_has_updated_at() {
+  _has_bits_[0] |= 0x00000010u;
 }
-inline void StoreStatus::clear_has_used_bytes() {
-  _has_bits_[0] &= ~0x00000020u;
+inline void StoreStatus::clear_has_updated_at() {
+  _has_bits_[0] &= ~0x00000010u;
 }
-inline void StoreStatus::clear_used_bytes() {
-  used_bytes_ = GOOGLE_LONGLONG(0);
-  clear_has_used_bytes();
+inline void StoreStatus::clear_updated_at() {
+  updated_at_ = GOOGLE_LONGLONG(0);
+  clear_has_updated_at();
 }
-inline ::google::protobuf::int64 StoreStatus::used_bytes() const {
-  // @@protoc_insertion_point(field_get:cockroach.proto.StoreStatus.used_bytes)
-  return used_bytes_;
+inline ::google::protobuf::int64 StoreStatus::updated_at() const {
+  // @@protoc_insertion_point(field_get:cockroach.proto.StoreStatus.updated_at)
+  return updated_at_;
 }
-inline void StoreStatus::set_used_bytes(::google::protobuf::int64 value) {
-  set_has_used_bytes();
-  used_bytes_ = value;
-  // @@protoc_insertion_point(field_set:cockroach.proto.StoreStatus.used_bytes)
+inline void StoreStatus::set_updated_at(::google::protobuf::int64 value) {
+  set_has_updated_at();
+  updated_at_ = value;
+  // @@protoc_insertion_point(field_set:cockroach.proto.StoreStatus.updated_at)
 }
 
-// optional int64 max_bytes = 7;
-inline bool StoreStatus::has_max_bytes() const {
-  return (_has_bits_[0] & 0x00000040u) != 0;
+// optional .cockroach.proto.MVCCStats stats = 6;
+inline bool StoreStatus::has_stats() const {
+  return (_has_bits_[0] & 0x00000020u) != 0;
 }
-inline void StoreStatus::set_has_max_bytes() {
-  _has_bits_[0] |= 0x00000040u;
+inline void StoreStatus::set_has_stats() {
+  _has_bits_[0] |= 0x00000020u;
 }
-inline void StoreStatus::clear_has_max_bytes() {
-  _has_bits_[0] &= ~0x00000040u;
+inline void StoreStatus::clear_has_stats() {
+  _has_bits_[0] &= ~0x00000020u;
 }
-inline void StoreStatus::clear_max_bytes() {
-  max_bytes_ = GOOGLE_LONGLONG(0);
-  clear_has_max_bytes();
+inline void StoreStatus::clear_stats() {
+  if (stats_ != NULL) stats_->::cockroach::proto::MVCCStats::Clear();
+  clear_has_stats();
 }
-inline ::google::protobuf::int64 StoreStatus::max_bytes() const {
-  // @@protoc_insertion_point(field_get:cockroach.proto.StoreStatus.max_bytes)
-  return max_bytes_;
+inline const ::cockroach::proto::MVCCStats& StoreStatus::stats() const {
+  // @@protoc_insertion_point(field_get:cockroach.proto.StoreStatus.stats)
+  return stats_ != NULL ? *stats_ : *default_instance_->stats_;
 }
-inline void StoreStatus::set_max_bytes(::google::protobuf::int64 value) {
-  set_has_max_bytes();
-  max_bytes_ = value;
-  // @@protoc_insertion_point(field_set:cockroach.proto.StoreStatus.max_bytes)
+inline ::cockroach::proto::MVCCStats* StoreStatus::mutable_stats() {
+  set_has_stats();
+  if (stats_ == NULL) stats_ = new ::cockroach::proto::MVCCStats;
+  // @@protoc_insertion_point(field_mutable:cockroach.proto.StoreStatus.stats)
+  return stats_;
+}
+inline ::cockroach::proto::MVCCStats* StoreStatus::release_stats() {
+  clear_has_stats();
+  ::cockroach::proto::MVCCStats* temp = stats_;
+  stats_ = NULL;
+  return temp;
+}
+inline void StoreStatus::set_allocated_stats(::cockroach::proto::MVCCStats* stats) {
+  delete stats_;
+  stats_ = stats;
+  if (stats) {
+    set_has_stats();
+  } else {
+    clear_has_stats();
+  }
+  // @@protoc_insertion_point(field_set_allocated:cockroach.proto.StoreStatus.stats)
 }
 
 

--- a/storage/engine/mvcc.go
+++ b/storage/engine/mvcc.go
@@ -47,11 +47,7 @@ const (
 //  - Key count (count of all keys, including keys with deleted tombstones)
 //  - Value count (all versions, including deleted tombstones)
 //  - Intents (provisional values written during txns)
-type MVCCStats struct {
-	LiveBytes, KeyBytes, ValBytes, IntentBytes int64
-	LiveCount, KeyCount, ValCount, IntentCount int64
-	IntentAge, GCBytesAge, LastUpdateNanos     int64
-}
+type MVCCStats proto.MVCCStats
 
 // MergeStats merges accumulated stats to stat counters for specified range.
 func (ms *MVCCStats) MergeStats(engine Engine, raftID int64) {

--- a/storage/scanner_test.go
+++ b/storage/scanner_test.go
@@ -190,7 +190,7 @@ func TestScannerAddToQueues(t *testing.T) {
 	// We don't want to actually consume entries from the queues during this test.
 	q1.setDisabled(true)
 	q2.setDisabled(true)
-	s := newRangeScanner(1*time.Millisecond, iter)
+	s := newRangeScanner(1*time.Millisecond, iter, nil)
 	s.AddQueues(q1, q2)
 	mc := hlc.NewManualClock(0)
 	clock := hlc.NewClock(mc.UnixNano)
@@ -234,7 +234,7 @@ func TestScannerTiming(t *testing.T) {
 	for i, duration := range durations {
 		iter := newTestIterator(count)
 		q := &testQueue{}
-		s := newRangeScanner(duration, iter)
+		s := newRangeScanner(duration, iter, nil)
 		s.AddQueues(q)
 		mc := hlc.NewManualClock(0)
 		clock := hlc.NewClock(mc.UnixNano)
@@ -257,7 +257,7 @@ func TestScannerEmptyIterator(t *testing.T) {
 	defer leaktest.AfterTest(t)
 	iter := newTestIterator(0)
 	q := &testQueue{}
-	s := newRangeScanner(1*time.Millisecond, iter)
+	s := newRangeScanner(1*time.Millisecond, iter, nil)
 	s.AddQueues(q)
 	mc := hlc.NewManualClock(0)
 	clock := hlc.NewClock(mc.UnixNano)
@@ -278,7 +278,7 @@ func TestScannerStats(t *testing.T) {
 	q := &testQueue{}
 	stopper := util.NewStopper()
 	defer stopper.Stop()
-	s := newRangeScanner(1*time.Millisecond, iter)
+	s := newRangeScanner(1*time.Millisecond, iter, nil)
 	s.AddQueues(q)
 	mc := hlc.NewManualClock(0)
 	clock := hlc.NewClock(mc.UnixNano)

--- a/storage/store_test.go
+++ b/storage/store_test.go
@@ -23,7 +23,6 @@ import (
 	"bytes"
 	"fmt"
 	"math"
-	"reflect"
 	"sort"
 	"testing"
 	"time"
@@ -153,32 +152,6 @@ func TestStoreInitAndBootstrap(t *testing.T) {
 	// 1st range should be available.
 	if _, err := store.GetRange(1); err != nil {
 		t.Errorf("failure fetching 1st range: %s", err)
-	}
-
-	// Make sure the store status exists and is correct.
-	expectedStoreStatus := &proto.StoreStatus{
-		StoreID:   1,
-		NodeID:    1,
-		RaftIDs:   []int64{1},
-		UpdatedAt: 0,
-		StartedAt: 0,
-		UsedBytes: 0,
-		MaxBytes:  0,
-	}
-	storeStatusKey := engine.StoreStatusKey(int32(store.Ident.StoreID))
-	gArgs, gReply := getArgs(storeStatusKey, 1, store.StoreID())
-	if err := store.ExecuteCmd(proto.Get, gArgs, gReply); err != nil {
-		t.Fatalf("failure getting store status: %s", err)
-	}
-	if gReply.Value == nil {
-		t.Errorf("could not find store status at: %s", storeStatusKey)
-	}
-	storeStatus := &proto.StoreStatus{}
-	if err := gogoproto.Unmarshal(gReply.Value.GetBytes(), storeStatus); err != nil {
-		t.Errorf("could not unmarshal store status: %+v", gReply)
-	}
-	if !reflect.DeepEqual(storeStatus, expectedStoreStatus) {
-		t.Errorf("actual store status is not as expected\nexpected: %+v\nactual: %v\n", expectedStoreStatus, storeStatus)
 	}
 }
 


### PR DESCRIPTION
- Convert MVCCStats into a proto
- Replace the collection of stats in the StoreStatus proto with these correct stats
- Update the status when adding/removing a range
- Add updating of the status when the scanner finished a full scan

Needs a bit more unit/acceptance testing, which I'm going to be adding shortly.
