### PR TITLE
Remove retry loop in local sender.

### DIFF
--- a/kv/txn_correctness_test.go
+++ b/kv/txn_correctness_test.go
@@ -40,7 +40,7 @@ import (
 // limit on number of attempts so we don't get stuck behind indefinite
 // backoff/retry loops. If MaxAttempts is reached, transaction will
 // return retry error.
-func setCorrectnessRetryOptions(lSender *LocalSender) {
+func setCorrectnessRetryOptions(lSender *retryableLocalSender) {
 	client.DefaultTxnRetryOptions = util.RetryOptions{
 		Backoff:     1 * time.Millisecond,
 		MaxBackoff:  5 * time.Millisecond,

--- a/storage/store.go
+++ b/storage/store.go
@@ -929,6 +929,7 @@ func (s *Store) ExecuteCmd(method string, args proto.Request, reply proto.Respon
 	// If the request has a zero timestamp, initialize to this node's clock.
 	header := args.Header()
 	if err := verifyKeys(header.Key, header.EndKey); err != nil {
+		reply.Header().SetGoError(err)
 		return err
 	}
 	if header.Timestamp.Equal(proto.ZeroTimestamp) {
@@ -941,6 +942,7 @@ func (s *Store) ExecuteCmd(method string, args proto.Request, reply proto.Respon
 		// bounded by the max clock drift.
 		_, err := s.clock.Update(header.Timestamp)
 		if err != nil {
+			reply.Header().SetGoError(err)
 			return err
 		}
 	}
@@ -997,6 +999,7 @@ func (s *Store) ExecuteCmd(method string, args proto.Request, reply proto.Respon
 	if _, ok := err.(*util.RetryMaxAttemptsError); ok && header.Txn != nil {
 		reply.Header().SetGoError(proto.NewTransactionRetryError(header.Txn))
 	}
+
 	return reply.Header().GoError()
 }
 


### PR DESCRIPTION
The retry loop was causing successes on range splits which in turn was
preventing the remote distributed sender from invalidating its range
addressing cache.

Fixes #679
