### PR TITLE
Check command key range against Range extents before adding to Raft.

### DIFF
--- a/proto/config.go
+++ b/proto/config.go
@@ -20,7 +20,6 @@ package proto
 
 import (
 	"bytes"
-	"fmt"
 	"sort"
 	"strconv"
 	"strings"
@@ -116,10 +115,10 @@ func (r *RangeDescriptor) ContainsKey(key []byte) bool {
 // key range from start to end.
 func (r *RangeDescriptor) ContainsKeyRange(start, end []byte) bool {
 	if len(end) == 0 {
-		end = append(append([]byte(nil), start...), byte(0))
+		return r.ContainsKey(start)
 	}
 	if bytes.Compare(end, start) < 0 {
-		panic(fmt.Sprintf("start key is larger than end key %q > %q", string(start), string(end)))
+		return false
 	}
 	return bytes.Compare(start, r.StartKey) >= 0 && bytes.Compare(r.EndKey, end) >= 0
 }

--- a/proto/config_test.go
+++ b/proto/config_test.go
@@ -114,6 +114,7 @@ func TestRangeDescriptorContains(t *testing.T) {
 		{[]byte("b"), []byte("bb"), false},
 		{[]byte("0"), []byte("bb"), false},
 		{[]byte("aa"), []byte("bb"), false},
+		{[]byte("b"), []byte("a"), false},
 	}
 	for _, test := range testData {
 		if bytes.Compare(test.start, test.end) == 0 {

--- a/storage/range_test.go
+++ b/storage/range_test.go
@@ -263,6 +263,15 @@ func TestRangeCanService(t *testing.T) {
 	}
 
 	// TODO(spencer): verify non-leader inconsistent read works.
+
+	// Verify range checking.
+	splitTestRange(tc.store, proto.Key("a"), proto.Key("a"), t)
+	gArgs.Key = proto.Key("b")
+	gArgs.Txn = nil
+	err := tc.rng.AddCmd(proto.Get, gArgs, gReply, true)
+	if _, ok := err.(*proto.RangeKeyMismatchError); !ok {
+		t.Errorf("expected range key mistmatch error: %s", err)
+	}
 }
 
 // TestRangeGossipFirstRange verifies that the first range gossips its


### PR DESCRIPTION
Also made the comparison hugely more efficient for RangeDescriptor.
ContainsKeyRange for the common case of end=nil.

Fixes #680
