### PR TITLE
address @spencerkimball's feedback

### DIFF
--- a/gossip/resolver.go
+++ b/gossip/resolver.go
@@ -91,11 +91,6 @@ func NewResolver(spec string) (*Resolver, error) {
 			"valid types are 'tcp', 'lb', 'unix'", spec)
 	}
 
-	// If we're on tcp or lb make sure we fill in the host when not specified (eg: ":8080")
-	if resolverType == "tcp" || resolverType == "lb" {
-		address = util.EnsureHost(address)
-	}
-
 	return &Resolver{resolverType, address, false}, nil
 }
 

--- a/gossip/resolver_test.go
+++ b/gossip/resolver_test.go
@@ -17,16 +17,9 @@
 
 package gossip
 
-import (
-	"os"
-	"testing"
-)
+import "testing"
 
 func TestParseResolverSpec(t *testing.T) {
-	myHost, err := os.Hostname()
-	if err != nil {
-		myHost = "127.0.0.1"
-	}
 	testCases := []struct {
 		input           string
 		success         bool
@@ -35,7 +28,7 @@ func TestParseResolverSpec(t *testing.T) {
 	}{
 		// Ports are not checked at parsing time. They are at GetAddress time though.
 		{"127.0.0.1:8080", true, "tcp", "127.0.0.1:8080"},
-		{":8080", true, "tcp", myHost + ":8080"},
+		{":8080", true, "tcp", ":8080"},
 		{"127.0.0.1", true, "tcp", "127.0.0.1"},
 		{"tcp=127.0.0.1", true, "tcp", "127.0.0.1"},
 		{"lb=127.0.0.1", true, "lb", "127.0.0.1"},

--- a/server/context.go
+++ b/server/context.go
@@ -121,7 +121,7 @@ func (ctx *Context) Init() error {
 	storeSpecs := storesRE.FindAllStringSubmatch(ctx.Stores, -1)
 	if storeSpecs == nil || len(storeSpecs) == 0 {
 		return fmt.Errorf("invalid or empty engines specification %q, "+
-			"did you pass -stores?", ctx.Stores)
+			"did you specify -stores?", ctx.Stores)
 	}
 
 	ctx.Engines = nil
@@ -141,12 +141,12 @@ func (ctx *Context) Init() error {
 
 	ctx.NodeAttributes = parseAttributes(ctx.Attrs)
 
-	resolvers, err := ctx.parseGossipBootstrapAddrs()
+	resolvers, err := ctx.parseGossipBootstrapResolvers()
 	if err != nil {
 		return err
 	}
 	if len(resolvers) == 0 {
-		return errors.New("no resolvers specified for gossip network, did you pass -gossip?")
+		return errors.New("no gossip addresses found, did you specify -gossip?")
 	}
 	ctx.GossipBootstrapResolvers = resolvers
 
@@ -170,12 +170,11 @@ func (ctx *Context) initEngine(attrsStr, path string) (engine.Engine, error) {
 	return engine.NewRocksDB(attrs, path, ctx.CacheSize), nil
 }
 
-// parseGossipBootstrapAddrs parses a comma-separated list of
-// gossip bootstrap addresses or resolvers.
-func (ctx *Context) parseGossipBootstrapAddrs() ([]*gossip.Resolver, error) {
+// parseGossipBootstrapResolvers parses a comma-separated list of
+// gossip bootstrap resolvers.
+func (ctx *Context) parseGossipBootstrapResolvers() ([]*gossip.Resolver, error) {
 	var bootstrapResolvers []*gossip.Resolver
-	gossipBootstrap := ctx.GossipBootstrap
-	addresses := strings.Split(gossipBootstrap, ",")
+	addresses := strings.Split(ctx.GossipBootstrap, ",")
 	for _, address := range addresses {
 		if len(address) == 0 {
 			continue

--- a/util/host.go
+++ b/util/host.go
@@ -18,8 +18,8 @@
 package util
 
 import (
+	"net"
 	"os"
-	"strings"
 )
 
 // EnsureHost takes a host:port pair, where the host portion is optional.
@@ -27,12 +27,13 @@ import (
 // the output will contain a host portion equal to the hostname (or
 // "127.0.0.1" as a fallback).
 func EnsureHost(addr string) string {
-	if !strings.HasPrefix(addr, ":") {
+	host, port, err := net.SplitHostPort(addr)
+	if host != "" || err != nil {
 		return addr
 	}
-	host, err := os.Hostname()
+	host, err = os.Hostname()
 	if err != nil {
 		host = "127.0.0.1"
 	}
-	return host + addr
+	return net.JoinHostPort(host, port)
 }


### PR DESCRIPTION
most notably, make sure that the rpc server always returns an address that we
hope other clients can use to connect to us. of course, this means that the
hostname must be resolvable by those clients.
i'm assuming that we'll have to revisit the issue of having to know the
server's identity to pass to the outside world again when dealing with TLS,
and maybe we'll then decide that listening on all interfaces isn't even worth
it. in any case, for now it should work as advertised above.
