### PR TITLE
Do not wait indefinitely when a client is not ready

### DIFF
--- a/rpc/send.go
+++ b/rpc/send.go
@@ -20,6 +20,7 @@ package rpc
 import (
 	"fmt"
 	"io"
+	"math"
 	"math/rand"
 	"net"
 	"net/rpc"
@@ -208,7 +209,19 @@ func Send(opts Options, method string, addrs []net.Addr, getArgs func(addr net.A
 // client is ready. On success, the reply is sent on the channel;
 // otherwise an error is sent.
 func sendOne(client *Client, timeout time.Duration, method string, args, reply interface{}, c chan interface{}) {
-	<-client.Ready
+	if timeout == 0 {
+		// Wait forever.
+		timeout = math.MaxInt64
+	}
+	select {
+	case <-client.Ready:
+	case <-client.Closed:
+		c <- rpcError{fmt.Sprintf("rpc to %s failed as client connection was closed", method)}
+		return
+	case <-time.After(timeout):
+		c <- rpcError{fmt.Sprintf("rpc to %s: client not ready after %s", method, timeout)}
+		return
+	}
 	call := client.Go(method, args, reply, nil)
 	select {
 	case <-call.Done:


### PR DESCRIPTION
A client does not become ready until initial heartbeat succeeds. In such a case, `Send()` shouldn't wait forever. It should return an RPC error or try another client.
