### PR TITLE
Add client/client_bench_* to .dockerignore.

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -5,5 +5,6 @@ cockroach
 */*.test
 */*/*.test
 */*/*/*.test
+client/client_bench_*
 storage/engine/mvcc_scan_*
 build/deploy/build


### PR DESCRIPTION
This speeds up docker-related actions after running the client benchmarks.
