### PR TITLE
Introduce util.SucceedsWithin, a replacement for IsTrueWithin.

### DIFF
--- a/util/testing_test.go
+++ b/util/testing_test.go
@@ -76,3 +76,18 @@ func TestTrueWithin(t *testing.T) {
 		t.Errorf("unexpected error on method which returns true after 5 invocations: %v", err)
 	}
 }
+
+func TestSucceedsWithin(t *testing.T) {
+	// Try a method which always succeeds.
+	SucceedsWithin(t, 1*time.Millisecond, func() error { return nil })
+
+	// Try a method which suceeds on 5th invocation.
+	count := 0
+	SucceedsWithin(t, 1*time.Millisecond, func() error {
+		count++
+		if count >= 5 {
+			return nil
+		}
+		return Errorf("not yet")
+	})
+}


### PR DESCRIPTION
Since this is a test-only function, it now takes the testing.T
and calls t.Fatalf directly, saving some syntactically-awkward
boilerplate at each call site. Returning an error instead of a bool
also allows us to produce better error messages in case of failure.
Finally, I swapped the order of the arguments because I think it
is aesthetically nicer for the inline function to be the last
argument.
