### PR TITLE
Add Feed structure to Util package

### DIFF
--- a/util/feed.go
+++ b/util/feed.go
@@ -1,0 +1,372 @@
+// Copyright 2015 The Cockroach Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+// implied. See the License for the specific language governing
+// permissions and limitations under the License. See the AUTHORS file
+// for names of contributors.
+//
+// Author: Matt Tracy (matt@cockroachlabs.com)
+
+package util
+
+import "sync"
+
+// A feedEntry represents a single entry in a feed. A feed entry usually an
+// event published to the feed, but may also be a management action used by the
+// feed itself to manage subscribers.
+//
+// Each feedEntry structure is a node in a "linked channel", which is analogous
+// to a linked list but using channels instead of pointers. Each feedEntry
+// contains a channel which can be used to get the next feedEntry in the
+// sequence.
+//
+// The "linked channel" is designed to be traversed by multiple consumers
+// simultaneously, with each consumer visiting each entry once. This is
+// accomplished with the following algorithm:
+//
+// 1. Each consumer attempts to read the next feedEntry from the "next" channel
+// of the last feedEntry.
+// 2. When the next entry is placed into the channel, one consumer will actually
+// obtain it.
+// 3. The obtaining consumer copies the values from the feedEntry, and
+// immediately places it back into the channel from which it was obtained. This
+// will allow another waiting consumer to obtain it.
+// 4. The obtaining consumer returns to step 1, but now reads from the
+// "next" channel of the feedEntry it had just obtained.
+//
+// Code example:
+//
+//		func traverseLinkedChannel(next chan *feedEntry) {
+//			for {
+//				nextEntry := <-next
+//				// Copy values from nextEntry
+//				last := next
+//				next = nextEntry.next
+//				last <- nextEntry
+//			}
+//		}
+//
+// The "next" channel of each feedEntry is given a buffer size of one. Since
+// that channel will only ever contain one feedEntry, the act of placing an
+// entry back into the channel can never block, meaning that consumers cannot
+// block each other as long as they behave correctly.
+//
+// The above implementation is sufficient for a linked channel: each consumer
+// will read each entry in the feed, after which the garbage collector would
+// clean up any entries which have been read by all subscribers.
+//
+// However, in order to improve memory performance each feedEntry maintains a
+// reference counter to determine when it can be safely returned to a shared
+// pool.
+type feedEntry struct {
+	entryType entryType
+	value     interface{}
+	next      chan *feedEntry
+
+	// consumerCount is the number of subscribers still waiting to receive this
+	// entry. This is a reference counter used to determine when entries can be
+	// released to the entry pool; however, an entry is not released when its
+	// own consumerCount is zero, but rather when the consumerCount of the
+	// *next* entry in the linked channel is zero. When the next entry has zero
+	// remaining consumers, that signifies that no more consumers are listening
+	// on the next channel of this entry, and thus it can be released.
+	consumerCount int
+}
+
+type entryType int
+
+const (
+	valueEntry entryType = iota
+	unsubEntry
+	closedEntry
+)
+
+var feedEntryPool = sync.Pool{
+	New: func() interface{} {
+		return &feedEntry{
+			next: make(chan *feedEntry, 1),
+		}
+	},
+}
+
+// A Subscription is used to receive events from a specific Feed. A Subscription
+// should only be instantiated via a call to a Feed's Subscribe() method. Once
+// created, events can be read directly from the Events channel provided by this
+// structure.
+//
+// An example of a typical usage of a Subscription:
+//
+//		subscriber := feed.Subscribe()
+//		for {
+//			select {
+//			case event, ok := <-subscriber.Events:
+//				// Process event...
+//			}
+//		}
+//
+// A Subscription cannot block other Subscriptions to the same feed, and each
+// Subscription will receive all events published by the Feed. A user of a
+// Subscription should not modify Events received over the channel.
+//
+// A Subscription can be closed via the Unsubscribe() method.
+//
+// If the Feed is stopped, the Events channel will be closed after reading all
+// remaining events that were published to the Feed before it was stopped.
+type Subscription struct {
+	Events <-chan interface{}
+	closer chan<- struct{}
+}
+
+// Unsubscribe immediately stops the given Subscriber. After this method is
+// called, the Events channel will be closed.
+func (s *Subscription) Unsubscribe() {
+	close(s.closer)
+}
+
+// A Feed is used to publish a stream of events to a set of Subscribers.  Events
+// are values of arbitrary type, and are received and published as an empty
+// interface.  Each Subscriber will receive, in order, each entry published to
+// the Feed.
+//
+// Entries are published by via the Publish method of the Feed; this cannot be
+// blocked by Subscriber activities and will always return quickly.  Subscribers
+// receive events by reading from their Events channel.
+//
+// The Feed will continue running until its associated Stopper is closed.
+//
+// The Feed's non-blocking properties are achieved with a linked channel instead
+// of buffered channels, and thus there is no limit (other than available
+// memory) to how many unread events the Feed can maintain. This is desirable
+// for Feeds which may publish data in quick bursts.
+//
+// The Feed does not keep historical events; individual Subscribers will only
+// receive events published after they subscribe.
+type Feed struct {
+	events  chan interface{}
+	stopper *Stopper
+
+	// subscriberCount counts the total number of subscribers that have
+	// ever been started. activeCount counts the number of subscribers still
+	// active (i.e. that have not been unsubscribed).
+	subscriberCount int
+	activeCount     int
+
+	// these channels are used for synchronizing different subscription
+	// lifecycle tasks.
+	subscribe   chan *publisher
+	unsubscribe chan *publisher
+	closed      chan struct{}
+}
+
+// StartFeed instatiates and starts a new Feed. The Feed can immediately accept
+// Subscribers and publish events.
+func StartFeed(stopper *Stopper) *Feed {
+	f := &Feed{
+		events:      make(chan interface{}),
+		stopper:     stopper,
+		subscribe:   make(chan *publisher),
+		unsubscribe: make(chan *publisher),
+		closed:      make(chan struct{}),
+	}
+	stopper.RunWorker(func() {
+		// head is the most recent entry added to the feed. This is also the
+		// current head of the linked channel of entries. The first entry
+		// will never be consumed by any subscribers, but initial
+		// subscribers may listen on its "next" channel.
+		head := feedEntryPool.Get().(*feedEntry)
+		// addEntry is used to correctly add a new entry to the linked channel.
+		addEntry := func(et entryType, value interface{}) {
+			entry := feedEntryPool.Get().(*feedEntry)
+			entry.entryType = et
+			entry.consumerCount = f.activeCount
+			switch et {
+			case valueEntry:
+				entry.value = value
+			case unsubEntry:
+				entry.value = value.(int)
+			}
+			head.next <- entry
+			head = entry
+		}
+		for {
+			select {
+			case pub := <-f.subscribe:
+				// A new Subscription is requested, and we have received the
+				// publisher associated with it. Give the publisher the channel
+				// for the next entry and start it's process() goroutine.
+				f.subscriberCount++
+				f.activeCount++
+				pub.id = f.subscriberCount
+				pub.current = head
+				stopper.RunWorker(pub.process)
+			case pub := <-f.unsubscribe:
+				// A Subscription has unsubscribed; ackowledge this with an
+				// "unsubscribed" entry and decrease the number of activeSubs
+				// for future entries.
+				addEntry(unsubEntry, pub.id)
+				f.activeCount--
+			case event := <-f.events:
+				// A new event has been published to the feed, which will
+				// eventually be read by all active subscribers.
+				if f.activeCount == 0 {
+					break
+				}
+				addEntry(valueEntry, event)
+			case <-stopper.ShouldStop():
+				// The stopper has been activated and the feed should cease.
+				if f.activeCount != 0 {
+					// Add a 'closed' entry to the linked channel, which will
+					// cause consuming publishers to stop.
+					addEntry(closedEntry, nil)
+				}
+				close(f.closed)
+				return
+			}
+		}
+	})
+	return f
+}
+
+// Publish publishes a event into the Feed, which will eventually be received by
+// all Subscribers to the feed. Publishing to a closed feed will panic.
+func (f *Feed) Publish(event interface{}) {
+	select {
+	case f.events <- event:
+		// Event was successfully published.
+	case <-f.closed:
+		panic("attempt to publish value to a closed Feed")
+	}
+}
+
+// Subscribe returns a Subscription object which can immediately recieve events
+// which were published to this feed. An event is an arbitrary interface.
+//
+// Events are read from the Subscription's Events channel. Subscribers cannot
+// block each other from receiving events, but should still attempt to consume
+// events in a timely fashion; the Feed will not release the memory for an
+// individual event until every Subscriber has seen it.
+//
+// Attempting to subscribe to a closed Feed will panic.
+func (f *Feed) Subscribe() *Subscription {
+	// events and closer are used to manage the interaction between a
+	// Subscription and its backing publisher.
+	events := make(chan interface{})
+	closer := make(chan struct{})
+	sub := &Subscription{
+		Events: events,
+		closer: closer,
+	}
+	p := &publisher{
+		events: events,
+		closer: closer,
+		feed:   f,
+	}
+	select {
+	case f.subscribe <- p:
+		// Subscription was successfully logged.
+	case <-f.closed:
+		panic("attempt to publish value to a closed Feed")
+	}
+	return sub
+}
+
+// A publisher reads values from a Feed and passes them to a Subscriber; each
+// Subscriber is backed by a publisher. The publisher correctly reads from the
+// linked channel provided by the Feed, ensuring that other publishers cannot be
+// blocked.
+type publisher struct {
+	id      int
+	current *feedEntry
+	events  chan<- interface{}
+	closer  <-chan struct{}
+	feed    *Feed
+}
+
+// process is a method which reads the linked channel provided by a Feed,
+// passing relevant events to a Subscription. It is
+// intended to be run as a goroutine.
+func (p *publisher) process() {
+	// If the Subscriber has unsubscribed, the publisher must still
+	// read events from the Feed until the unsubscription event has
+	// been acknowledged by the Feed: this ensures that each
+	// feedEntry reaches its consumerCount count and is returned to
+	// the pool. This is the 'draining' phase, during which the publisher
+	// reads events but no longer sends them to the subscriber.
+	draining := false
+	// readEntry is called on every entry read from the next channel of the
+	// current entry. This method properly maintains the consumerCount
+	// reference counter on feedEntries.
+	readEntry := func(entry *feedEntry) {
+		entry.consumerCount--
+		if entry.consumerCount > 0 {
+			// The next entry still has remaining consumers, so place it
+			// back on the 'next' channel of the current entry. Buffer size
+			// is 1, so this will not block.
+			p.current.next <- entry
+		} else {
+			// The next entry has no remaining consumers, and thus nothing
+			// is listening on the 'next' channel of the current entry.
+			// Release the current entry to the entry pool.
+			feedEntryPool.Put(p.current)
+		}
+		p.current = entry
+	}
+	for !draining {
+		select {
+		case entry := <-p.current.next:
+			readEntry(entry)
+			switch p.current.entryType {
+			case valueEntry:
+				select {
+				case p.events <- p.current.value:
+					// Event successfully sent.
+				case <-p.closer:
+					// Prevent blocking if the subscriber has stopped
+					// reading events in order to close.
+				}
+			case closedEntry:
+				// The Feed has been closed.
+				close(p.events)
+				return
+			}
+		case <-p.closer:
+			// The Subscriber wants to initiate a closure. Inform the Feed of
+			// the unsubscription, close the channel to the Subscription and
+			// begin draining.
+			select {
+			case p.feed.unsubscribe <- p:
+				// Successfully unsubscribed.
+			case <-p.feed.closed:
+				// Feed closed first - this might happen due to a race a
+				// shutdown scenario. The publisher will simply run until the
+				// inevitable 'closed' entry stops this publisher.
+			}
+			draining = true
+		}
+	}
+	for {
+		entry := <-p.current.next
+		readEntry(entry)
+		switch p.current.entryType {
+		case unsubEntry:
+			if p.current.value.(int) == p.id {
+				// The feed has acknowledged that this subscriber has
+				// unsubscriber. The publisher can safely stop.
+				close(p.events)
+				return
+			}
+		case closedEntry:
+			// The Feed has been closed.
+			close(p.events)
+			return
+		}
+	}
+}

--- a/util/feed_example_test.go
+++ b/util/feed_example_test.go
@@ -1,0 +1,55 @@
+// Copyright 2015 The Cockroach Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+// implied. See the License for the specific language governing
+// permissions and limitations under the License. See the AUTHORS file
+// for names of contributors.
+//
+// Author: Matt Tracy (matt@cockroachlabs.com)
+
+package util
+
+import (
+	"fmt"
+)
+
+func ExampleFeed() {
+	stopper := NewStopper()
+	feed := StartFeed(stopper)
+
+	output := make([][]string, 5)
+	for i := 0; i < len(output); i++ {
+		sub := feed.Subscribe()
+		index := i
+		stopper.RunWorker(func() {
+			for event := range sub.Events {
+				// events must be cast from interface{}
+				output[index] = append(output[index], event.(string))
+			}
+		})
+	}
+
+	feed.Publish("Event 1")
+	feed.Publish("Event 2")
+	feed.Publish("Event 3")
+	stopper.Stop()
+
+	<-stopper.IsStopped()
+	for i, out := range output {
+		fmt.Printf("subscriber %d got output %v\n", i+1, out)
+	}
+	//Output:
+	//subscriber 1 got output [Event 1 Event 2 Event 3]
+	//subscriber 2 got output [Event 1 Event 2 Event 3]
+	//subscriber 3 got output [Event 1 Event 2 Event 3]
+	//subscriber 4 got output [Event 1 Event 2 Event 3]
+	//subscriber 5 got output [Event 1 Event 2 Event 3]
+}

--- a/util/feed_test.go
+++ b/util/feed_test.go
@@ -1,0 +1,199 @@
+// Copyright 2015 The Cockroach Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+// implied. See the License for the specific language governing
+// permissions and limitations under the License. See the AUTHORS file
+// for names of contributors.
+//
+// Author: Matt Tracy (matt@cockroachlabs.com)
+
+package util
+
+import (
+	"reflect"
+	"testing"
+	"time"
+)
+
+type testSubscriber struct {
+	sub      *Subscription
+	received []interface{}
+	done     chan struct{}
+}
+
+func (ts *testSubscriber) readAll() {
+	for e := range ts.sub.Events {
+		ts.received = append(ts.received, e)
+	}
+	close(ts.done)
+}
+
+func (ts *testSubscriber) readN(n int) {
+	for e := range ts.sub.Events {
+		ts.received = append(ts.received, e)
+		if len(ts.received) == n {
+			break
+		}
+	}
+	close(ts.done)
+}
+
+func newSubscriber(feed *Feed) *testSubscriber {
+	return &testSubscriber{
+		sub:  feed.Subscribe(),
+		done: make(chan struct{}),
+	}
+}
+
+// TestFeed exercises the most basic behavior of a Feed, with a constant set of
+// Subscribers.
+func TestFeed(t *testing.T) {
+	var (
+		numSubs  = 10
+		events   = []interface{}{1, 1, 2, 3, 5, 8, 13, 21, 34}
+		testSubs = make([]*testSubscriber, 0, numSubs)
+		stopper  = NewStopper()
+	)
+
+	feed := StartFeed(stopper)
+
+	// Add a number of subscribers.
+	for i := 0; i < numSubs; i++ {
+		ts := newSubscriber(feed)
+		testSubs = append(testSubs, ts)
+		stopper.RunWorker(ts.readAll)
+	}
+	// Publish every event to the Feed in order.
+	for _, e := range events {
+		feed.Publish(e)
+	}
+	stopper.Stop()
+
+	// Wait for stopper to finish, meaning all publishers have ceased.
+	select {
+	case <-stopper.IsStopped():
+	case <-time.After(5 * time.Second):
+		t.Fatalf("stopper failed to complete after 5 seconds.")
+	}
+
+	// Verify that all results are received by all Subscribers in order.
+	for i, ts := range testSubs {
+		if a, e := ts.received, events; !reflect.DeepEqual(a, e) {
+			t.Errorf("subscriber %d received incorrect events: %v", i, a)
+		}
+	}
+}
+
+// TestFeedUnsubscription tests that Subscriptions are able to Unsubscribe.
+func TestFeedUnsubscription(t *testing.T) {
+	var (
+		events   = []interface{}{1, 1, 2, 3, 5, 8, 13, 21, 34}
+		testSubs = make([]*testSubscriber, len(events))
+		stopper  = NewStopper()
+	)
+
+	feed := StartFeed(stopper)
+
+	// The strategy is to Publish every event twice. In the first pass, a
+	// subscriber is added before each event is published. In the second pass, a
+	// Subscriber is unsubscribed before each publish. The result should be that
+	// every Subscriber gets every value, but their individual 'received' arrays
+	// will be a rotation of the original events array.
+	for i, e := range events {
+		ts := newSubscriber(feed)
+		testSubs[i] = ts
+		stopper.RunWorker(func() {
+			ts.readN(len(events))
+		})
+		feed.Publish(e)
+	}
+	for i, e := range events {
+		select {
+		case <-testSubs[i].done:
+		case <-time.After(5 * time.Second):
+			t.Logf("subscriber %d failed to complete in 5 seconds", i)
+		}
+		testSubs[i].sub.Unsubscribe()
+		feed.Publish(e)
+	}
+	stopper.Stop()
+
+	// Wait for stopper to finish, meaning all publishers have ceased.
+	select {
+	case <-stopper.IsStopped():
+	case <-time.After(5 * time.Second):
+		t.Fatalf("stopper failed to complete after 5 seconds.")
+	}
+
+	// Verify that all results are received by all Subscribers. Each subscriber
+	// will have received the results in a unique but predictable order.
+	for i, ts := range testSubs {
+		expected := make([]interface{}, 0, len(ts.received))
+		expected = append(expected, events[i:]...)
+		expected = append(expected, events[:i]...)
+		if a, e := ts.received, expected; !reflect.DeepEqual(a, e) {
+			t.Errorf("subscriber %d received incorrect events %v, expected %v", i, a, e)
+		}
+	}
+}
+
+// TestMultipleFeed verifies that feeds are separate from each other. This is
+// important to verify because of the shared pool of feedEntry objects used in
+// their implementation.
+func TestMultipleFeed(t *testing.T) {
+	var (
+		numSubs      = 10
+		intEvents    = []interface{}{1, 1, 2, 3, 5, 8, 13, 21, 34}
+		stringEvents = []interface{}{"one", "two", "three", "four", "five", "six", "seven", "eight", "nine"}
+		intSubs      = make([]*testSubscriber, 0, numSubs)
+		stringSubs   = make([]*testSubscriber, 0, numSubs)
+		stopper      = NewStopper()
+	)
+
+	intFeed := StartFeed(stopper)
+	stringFeed := StartFeed(stopper)
+
+	for i := 0; i < numSubs; i++ {
+		// int subscriber
+		ts := newSubscriber(intFeed)
+		intSubs = append(intSubs, ts)
+		stopper.RunWorker(ts.readAll)
+
+		// string subscriber
+		ts = newSubscriber(stringFeed)
+		stringSubs = append(stringSubs, ts)
+		stopper.RunWorker(ts.readAll)
+	}
+
+	for i := 0; i < len(intEvents); i++ {
+		intFeed.Publish(intEvents[i])
+		stringFeed.Publish(stringEvents[i])
+	}
+	stopper.Stop()
+
+	// Wait for stopper to finish, meaning all publishers have ceased.
+	select {
+	case <-stopper.IsStopped():
+	case <-time.After(5 * time.Second):
+		t.Fatalf("stopper failed to complete after 5 seconds.")
+	}
+
+	for i, ts := range intSubs {
+		if a, e := ts.received, intEvents; !reflect.DeepEqual(a, e) {
+			t.Errorf("int subscriber %d received incorrect events %v, expected %v", i, a, e)
+		}
+	}
+	for i, ts := range stringSubs {
+		if a, e := ts.received, stringEvents; !reflect.DeepEqual(a, e) {
+			t.Errorf("int subscriber %d received incorrect events %v, expected %v", i, a, e)
+		}
+	}
+}


### PR DESCRIPTION
Create the Feed structure, a utility structure used for publishing a stream of
events to subscribers. Feed events are arbitrary Go objects, passed as
interface{}.

Feed has two important properties:
- It is highly non-blocking. Publishing cannot be blocked by slow
  subscribers and is effectively constant time. Subscribers cannot be blocked from
  reading by other slow subscribers.
- There is no limit (other than available memory) to how many unread events can
  be stored in the Feed. This is very desirable for processes which might publish
  events in quick bursts.

The above properties are realized by implementing the feed as a "linked
channel", rather than using buffered channels.
