### PR TITLE
Make store IDs global instead of per-node.

### DIFF
--- a/server/node.go
+++ b/server/node.go
@@ -20,7 +20,6 @@ package server
 import (
 	"container/list"
 	"net"
-	"strconv"
 	"time"
 
 	"github.com/cockroachdb/cockroach/client"
@@ -89,7 +88,7 @@ func allocateStoreIDs(nodeID proto.NodeID, inc int64, db *client.KV) (proto.Stor
 	if err := db.Run(client.Call{
 		Args: &proto.IncrementRequest{
 			RequestHeader: proto.RequestHeader{
-				Key:  engine.MakeKey(engine.KeyStoreIDGeneratorPrefix, []byte(strconv.Itoa(int(nodeID)))),
+				Key:  engine.KeyStoreIDGenerator,
 				User: storage.UserRoot,
 			},
 			Increment: inc,

--- a/server/node_test.go
+++ b/server/node_test.go
@@ -125,7 +125,7 @@ func TestBootstrapCluster(t *testing.T) {
 		proto.Key("\x00node-idgen"),
 		proto.Key("\x00perm"),
 		proto.Key("\x00range-tree-root"),
-		proto.Key("\x00store-idgen-1"),
+		proto.Key("\x00store-idgen"),
 		proto.Key("\x00zone"),
 	}
 	if !reflect.DeepEqual(keys, expectedKeys) {

--- a/storage/engine/keys.go
+++ b/storage/engine/keys.go
@@ -446,9 +446,8 @@ var (
 	KeyRaftIDGenerator = MakeKey(KeySystemPrefix, proto.Key("raft-idgen"))
 	// KeySchemaPrefix specifies key prefixes for schema definitions.
 	KeySchemaPrefix = MakeKey(KeySystemPrefix, proto.Key("schema"))
-	// KeyStoreIDGeneratorPrefix specifies key prefixes for sequence
-	// generators, one per node, for store IDs.
-	KeyStoreIDGeneratorPrefix = MakeKey(KeySystemPrefix, proto.Key("store-idgen-"))
+	// KeyStoreIDGenerator is the global store ID generator sequence.
+	KeyStoreIDGenerator = MakeKey(KeySystemPrefix, proto.Key("store-idgen"))
 	// KeyRangeTreeRoot specifies the root range in the range tree.
 	KeyRangeTreeRoot = MakeKey(KeySystemPrefix, proto.Key("range-tree-root"))
 


### PR DESCRIPTION
We rely on the global uniqueness of store IDs but this has not actually
been true.
