### PR TITLE
Fix a tiny spelling mistake in proto/errors.proto

### DIFF
--- a/proto/errors.pb.go
+++ b/proto/errors.pb.go
@@ -437,7 +437,7 @@ func (m *ErrorDetail) GetConditionFailed() *ConditionFailedError {
 	return nil
 }
 
-// Error is a generic represesentation including a string message
+// Error is a generic representation including a string message
 // and information about retryability.
 type Error struct {
 	// Message is a human-readable error message.

--- a/proto/errors.proto
+++ b/proto/errors.proto
@@ -161,7 +161,7 @@ enum TransactionRestart {
   IMMEDIATE = 2;
 }
 
-// Error is a generic represesentation including a string message
+// Error is a generic representation including a string message
 // and information about retryability.
 message Error {
   // Message is a human-readable error message.


### PR DESCRIPTION
s/represesentation/representation/
