### PR TITLE
use a StoreContext struct for NewStore and NewNode

### DIFF
--- a/GLOCKFILE
+++ b/GLOCKFILE
@@ -24,5 +24,6 @@ github.com/jteeuwen/go-bindata 7362d4b6b2ce6a7d3c28b523a6e40629f4d81116
 github.com/kisielk/errcheck eb516cb958915b69ad14384890b4d37bd910c9f3
 github.com/kisielk/gotool d678387370a2eb9b5b0a33218bc8c9d8de15b6be
 github.com/robfig/glock 78c45da050a4d993d12ad07e8ddb10a4891ac701
+golang.org/x/net 169f42267807fe93f4a4b0150583e410aefafe4e
 golang.org/x/tools 4744be3abc70249546ce31c32fa9b5a5e96b5ad1
 gopkg.in/yaml.v1 9f9df34309c04878acc86042b16630b0f696e1de

--- a/build/devbase/godeps.sh
+++ b/build/devbase/godeps.sh
@@ -38,12 +38,14 @@ github.com/biogo/store/llrb
 github.com/cockroachdb/c-protobuf
 github.com/cockroachdb/c-rocksdb
 github.com/cockroachdb/c-snappy
-github.com/jteeuwen/go-bindata/go-bindata
+github.com/coreos/etcd/Godeps/_workspace/src/github.com/gogo/protobuf/proto
+github.com/coreos/etcd/Godeps/_workspace/src/golang.org/x/net/context
 github.com/coreos/etcd/raft
 github.com/coreos/etcd/raft/raftpb
 github.com/elazarl/go-bindata-assetfs
 github.com/gogo/protobuf/proto
 github.com/golang/glog
+golang.org/x/net/context
 gopkg.in/yaml.v1
 "
 

--- a/build/devbase/godeps.sh
+++ b/build/devbase/godeps.sh
@@ -39,8 +39,6 @@ github.com/cockroachdb/c-protobuf
 github.com/cockroachdb/c-rocksdb
 github.com/cockroachdb/c-snappy
 github.com/jteeuwen/go-bindata/go-bindata
-github.com/coreos/etcd/Godeps/_workspace/src/github.com/gogo/protobuf/proto
-github.com/coreos/etcd/Godeps/_workspace/src/golang.org/x/net/context
 github.com/coreos/etcd/raft
 github.com/coreos/etcd/raft/raftpb
 github.com/elazarl/go-bindata-assetfs

--- a/kv/local_sender_test.go
+++ b/kv/local_sender_test.go
@@ -20,13 +20,10 @@ package kv
 import (
 	"errors"
 	"testing"
-	"time"
 
 	"github.com/cockroachdb/cockroach/client"
-	"github.com/cockroachdb/cockroach/gossip"
 	"github.com/cockroachdb/cockroach/multiraft"
 	"github.com/cockroachdb/cockroach/proto"
-	"github.com/cockroachdb/cockroach/rpc"
 	"github.com/cockroachdb/cockroach/storage"
 	"github.com/cockroachdb/cockroach/storage/engine"
 	"github.com/cockroachdb/cockroach/util"
@@ -131,8 +128,6 @@ func TestLocalSenderLookupReplica(t *testing.T) {
 	manualClock := hlc.NewManualClock(0)
 	ctx.Clock = hlc.NewClock(manualClock.UnixNano)
 	ctx.Context = context.Background()
-	// Dummy Gossip.
-	ctx.Gossip = gossip.New(&rpc.Context{}, 10*time.Hour, nil)
 	eng := engine.NewInMem(proto.Attributes{}, 1<<20)
 	ls := NewLocalSender()
 	stopper := util.NewStopper()

--- a/kv/local_sender_test.go
+++ b/kv/local_sender_test.go
@@ -123,16 +123,17 @@ func splitTestRange(store *storage.Store, key, splitKey proto.Key, t *testing.T)
 }
 
 func TestLocalSenderLookupReplica(t *testing.T) {
+	ctx := storage.TestStoreContext
 	manualClock := hlc.NewManualClock(0)
-	clock := hlc.NewClock(manualClock.UnixNano)
+	ctx.Clock = hlc.NewClock(manualClock.UnixNano)
 	eng := engine.NewInMem(proto.Attributes{}, 1<<20)
 	ls := NewLocalSender()
 	stopper := util.NewStopper()
 	defer stopper.Stop()
-	db := client.NewKV(nil, NewTxnCoordSender(ls, clock, false, stopper))
-	transport := multiraft.NewLocalRPCTransport()
-	defer transport.Close()
-	store := storage.NewStore(clock, eng, db, nil, transport, storage.TestStoreConfig)
+	ctx.DB = client.NewKV(nil, NewTxnCoordSender(ls, ctx.Clock, false, stopper))
+	ctx.Transport = multiraft.NewLocalRPCTransport()
+	defer ctx.Transport.Close()
+	store := storage.NewStore(ctx, eng)
 	if err := store.Bootstrap(proto.StoreIdent{NodeID: 1, StoreID: 1}, stopper); err != nil {
 		t.Fatal(err)
 	}
@@ -163,9 +164,9 @@ func TestLocalSenderLookupReplica(t *testing.T) {
 	}
 	for i, rng := range ranges {
 		e[i] = engine.NewInMem(proto.Attributes{}, 1<<20)
-		transport := multiraft.NewLocalRPCTransport()
-		defer transport.Close()
-		s[i] = storage.NewStore(clock, e[i], db, nil, transport, storage.TestStoreConfig)
+		ctx.Transport = multiraft.NewLocalRPCTransport()
+		defer ctx.Transport.Close()
+		s[i] = storage.NewStore(ctx, e[i])
 		s[i].Ident.StoreID = rng.storeID
 		if err := s[i].Bootstrap(proto.StoreIdent{NodeID: 1, StoreID: rng.storeID}, stopper); err != nil {
 			t.Fatal(err)

--- a/kv/local_sender_test.go
+++ b/kv/local_sender_test.go
@@ -20,10 +20,13 @@ package kv
 import (
 	"errors"
 	"testing"
+	"time"
 
 	"github.com/cockroachdb/cockroach/client"
+	"github.com/cockroachdb/cockroach/gossip"
 	"github.com/cockroachdb/cockroach/multiraft"
 	"github.com/cockroachdb/cockroach/proto"
+	"github.com/cockroachdb/cockroach/rpc"
 	"github.com/cockroachdb/cockroach/storage"
 	"github.com/cockroachdb/cockroach/storage/engine"
 	"github.com/cockroachdb/cockroach/util"
@@ -126,6 +129,8 @@ func TestLocalSenderLookupReplica(t *testing.T) {
 	ctx := storage.TestStoreContext
 	manualClock := hlc.NewManualClock(0)
 	ctx.Clock = hlc.NewClock(manualClock.UnixNano)
+	// Dummy Gossip.
+	ctx.Gossip = gossip.New(&rpc.Context{}, 10*time.Hour, nil)
 	eng := engine.NewInMem(proto.Attributes{}, 1<<20)
 	ls := NewLocalSender()
 	stopper := util.NewStopper()

--- a/kv/local_sender_test.go
+++ b/kv/local_sender_test.go
@@ -31,6 +31,7 @@ import (
 	"github.com/cockroachdb/cockroach/storage/engine"
 	"github.com/cockroachdb/cockroach/util"
 	"github.com/cockroachdb/cockroach/util/hlc"
+	"golang.org/x/net/context"
 )
 
 func TestLocalSenderAddStore(t *testing.T) {
@@ -129,6 +130,7 @@ func TestLocalSenderLookupReplica(t *testing.T) {
 	ctx := storage.TestStoreContext
 	manualClock := hlc.NewManualClock(0)
 	ctx.Clock = hlc.NewClock(manualClock.UnixNano)
+	ctx.Context = context.Background()
 	// Dummy Gossip.
 	ctx.Gossip = gossip.New(&rpc.Context{}, 10*time.Hour, nil)
 	eng := engine.NewInMem(proto.Attributes{}, 1<<20)

--- a/kv/txn_correctness_test.go
+++ b/kv/txn_correctness_test.go
@@ -50,7 +50,7 @@ func setCorrectnessRetryOptions(lSender *retryableLocalSender) {
 	}
 
 	lSender.VisitStores(func(s *storage.Store) error {
-		s.RetryOpts = client.DefaultTxnRetryOptions
+		s.SetRangeRetryOptions(client.DefaultTxnRetryOptions)
 		return nil
 	})
 }

--- a/multiraft/heartbeat_test.go
+++ b/multiraft/heartbeat_test.go
@@ -31,10 +31,6 @@ import (
 // until either the given conditional returns true, the channel is closed or a
 // read on the channel times out.
 func processEventsUntil(ch <-chan *interceptMessage, stopper *util.Stopper, f func(*RaftMessageRequest) bool) {
-	if stopper == nil {
-		// Just to avoid listening on a nil channel below.
-		stopper = util.NewStopper()
-	}
 	for {
 		select {
 		case e, ok := <-ch:

--- a/multiraft/multiraft.go
+++ b/multiraft/multiraft.go
@@ -26,9 +26,9 @@ import (
 	"github.com/cockroachdb/cockroach/proto"
 	"github.com/cockroachdb/cockroach/util"
 	"github.com/cockroachdb/cockroach/util/log"
-	"github.com/coreos/etcd/Godeps/_workspace/src/golang.org/x/net/context"
 	"github.com/coreos/etcd/raft"
 	"github.com/coreos/etcd/raft/raftpb"
+	"golang.org/x/net/context"
 
 	gogoproto "github.com/gogo/protobuf/proto"
 )

--- a/multiraft/multiraft_test.go
+++ b/multiraft/multiraft_test.go
@@ -26,9 +26,9 @@ import (
 	"github.com/cockroachdb/cockroach/util"
 	"github.com/cockroachdb/cockroach/util/leaktest"
 	"github.com/cockroachdb/cockroach/util/log"
-	"github.com/coreos/etcd/Godeps/_workspace/src/golang.org/x/net/context"
 	"github.com/coreos/etcd/raft"
 	"github.com/coreos/etcd/raft/raftpb"
+	"golang.org/x/net/context"
 )
 
 var testRand, _ = util.NewPseudoRand()

--- a/server/cli/flags.go
+++ b/server/cli/flags.go
@@ -78,6 +78,11 @@ func initFlags(ctx *server.Context) {
 
 	flag.Int64Var(&ctx.CacheSize, "cache-size", ctx.CacheSize, "total size in bytes for "+
 		"caches, shared evenly if there are multiple storage devices.")
+
+	flag.DurationVar(&ctx.ScanInterval, "scan-interval", ctx.ScanInterval, "specify "+
+		"--scan_interval to adjust the target for the duration of a single scan "+
+		"through a store's ranges. The scan is slowed as necessary to approximately"+
+		"achieve this duration.")
 }
 
 func init() {

--- a/server/context.go
+++ b/server/context.go
@@ -38,6 +38,7 @@ const (
 	defaultMaxOffset      = 250 * time.Millisecond
 	defaultGossipInterval = 2 * time.Second
 	defaultCacheSize      = 1 << 30 // GB
+	defaultScanInterval   = 10 * time.Minute
 )
 
 // Context holds parameters needed to setup a server.
@@ -99,6 +100,10 @@ type Context struct {
 	// GossipBootstrapResolvers is a list of gossip resolvers used
 	// to find bootstrap nodes for connecting to the gossip network.
 	GossipBootstrapResolvers []gossip.Resolver
+
+	// ScanInterval determines a duration during which each range should be
+	// visited approximately once by the range scanner.
+	ScanInterval time.Duration
 }
 
 // NewContext returns a Context with default values.
@@ -108,6 +113,7 @@ func NewContext() *Context {
 		MaxOffset:      defaultMaxOffset,
 		GossipInterval: defaultGossipInterval,
 		CacheSize:      defaultCacheSize,
+		ScanInterval:   defaultScanInterval,
 	}
 }
 

--- a/server/node.go
+++ b/server/node.go
@@ -114,6 +114,7 @@ func BootstrapCluster(clusterID string, eng engine.Engine, stopper *util.Stopper
 	ctx.Context = context.Background()
 	// Dummy gossip, not actually used.
 	ctx.Gossip = gossip.New(&rpc.Context{}, 10*time.Hour, nil)
+	ctx.ScanInterval = 10 * time.Minute
 	ctx.Clock = hlc.NewClock(hlc.UnixNano)
 	// Create a KV DB with a local sender.
 	lSender := kv.NewLocalSender()

--- a/server/node.go
+++ b/server/node.go
@@ -54,13 +54,10 @@ const (
 // IDs for bootstrapping the node itself or new stores as they're added
 // on subsequent instantiations.
 type Node struct {
-	ClusterID     string                // UUID for Cockroach cluster
-	Descriptor    gossip.NodeDescriptor // Node ID, network/physical topology
-	storeConfig   storage.StoreConfig   // Store/Raft configuration.
-	gossip        *gossip.Gossip        // Nodes gossip cluster ID, node ID -> host:port
-	db            *client.KV            // KV DB client; used to access global id generators
-	raftTransport multiraft.Transport
-	lSender       *kv.LocalSender // Local KV sender for access to node-local stores
+	ClusterID  string                // UUID for Cockroach cluster
+	Descriptor gossip.NodeDescriptor // Node ID, network/physical topology
+	ctx        storage.StoreContext
+	lSender    *kv.LocalSender // Local KV sender for access to node-local stores
 }
 
 // allocateNodeID increments the node id generator key to allocate
@@ -112,13 +109,16 @@ func BootstrapCluster(clusterID string, eng engine.Engine, stopper *util.Stopper
 		NodeID:    1,
 		StoreID:   1,
 	}
-	clock := hlc.NewClock(hlc.UnixNano)
+	ctx := storage.StoreContext{}
+	ctx.Clock = hlc.NewClock(hlc.UnixNano)
 	// Create a KV DB with a local sender.
 	lSender := kv.NewLocalSender()
-	localDB := client.NewKV(nil, kv.NewTxnCoordSender(lSender, clock, false, stopper))
+	localDB := client.NewKV(nil, kv.NewTxnCoordSender(lSender, ctx.Clock, false, stopper))
+	ctx.DB = localDB
+	ctx.Transport = multiraft.NewLocalRPCTransport()
 	// The bootstrapping store will not connect to other nodes so its StoreConfig
 	// doesn't really matter.
-	s := storage.NewStore(clock, eng, localDB, nil, multiraft.NewLocalRPCTransport(), storage.StoreConfig{})
+	s := storage.NewStore(ctx, eng)
 
 	// Verify the store isn't already part of a cluster.
 	if len(s.Ident.ClusterID) > 0 {
@@ -154,14 +154,10 @@ func BootstrapCluster(clusterID string, eng engine.Engine, stopper *util.Stopper
 }
 
 // NewNode returns a new instance of Node.
-func NewNode(db *client.KV, gossip *gossip.Gossip, storeConfig storage.StoreConfig,
-	raftTransport multiraft.Transport) *Node {
+func NewNode(ctx storage.StoreContext) *Node {
 	return &Node{
-		storeConfig:   storeConfig,
-		gossip:        gossip,
-		db:            db,
-		raftTransport: raftTransport,
-		lSender:       kv.NewLocalSender(),
+		ctx:     ctx,
+		lSender: kv.NewLocalSender(),
 	}
 }
 
@@ -192,7 +188,7 @@ func (n *Node) initNodeID(id proto.NodeID) {
 	}
 	var err error
 	if id == 0 {
-		id, err = allocateNodeID(n.db)
+		id, err = allocateNodeID(n.ctx.DB)
 		if err != nil {
 			log.Fatal(err)
 		}
@@ -204,7 +200,7 @@ func (n *Node) initNodeID(id proto.NodeID) {
 	}
 	// Gossip the node descriptor to make this node addressable by node ID.
 	n.Descriptor.NodeID = id
-	if err = n.gossip.SetNodeDescriptor(&n.Descriptor); err != nil {
+	if err = n.ctx.Gossip.SetNodeDescriptor(&n.Descriptor); err != nil {
 		log.Fatalf("couldn't gossip descriptor for node %d: %s", n.Descriptor.NodeID, err)
 	}
 }
@@ -212,8 +208,11 @@ func (n *Node) initNodeID(id proto.NodeID) {
 // start starts the node by registering the storage instance for the
 // RPC service "Node" and initializing stores for each specified
 // engine. Launches periodic store gossiping in a goroutine.
+// TODO(tschottdorf) avoid passing the clock unless there is a good reason.
 func (n *Node) start(rpcServer *rpc.Server, clock *hlc.Clock,
 	engines []engine.Engine, attrs proto.Attributes, stopper *util.Stopper) error {
+	// TODO(tschottdorf)
+	n.ctx.Clock = clock
 	n.initDescriptor(rpcServer.Addr(), attrs)
 	if err := rpcServer.RegisterName("Node", n); err != nil {
 		log.Fatalf("unable to register node service with RPC server: %s", err)
@@ -242,7 +241,7 @@ func (n *Node) initStores(clock *hlc.Clock, engines []engine.Engine, stopper *ut
 	}
 	for _, e := range engines {
 		// TODO(bdarnell): make StoreConfig configurable.
-		s := storage.NewStore(clock, e, n.db, n.gossip, n.raftTransport, n.storeConfig)
+		s := storage.NewStore(n.ctx, e)
 		// Initialize each store in turn, handling un-bootstrapped errors by
 		// adding the store to the bootstraps list.
 		if err := s.Start(stopper); err != nil {
@@ -317,7 +316,7 @@ func (n *Node) bootstrapStores(bootstraps *list.List, stopper *util.Stopper) {
 	// Bootstrap all waiting stores by allocating a new store id for
 	// each and invoking store.Bootstrap() to persist.
 	inc := int64(bootstraps.Len())
-	firstID, err := allocateStoreIDs(n.Descriptor.NodeID, inc, n.db)
+	firstID, err := allocateStoreIDs(n.Descriptor.NodeID, inc, n.ctx.DB)
 	if err != nil {
 		log.Fatal(err)
 	}
@@ -348,9 +347,9 @@ func (n *Node) connectGossip() {
 	log.Infof("connecting to gossip network to verify cluster ID...")
 	// No timeout or stop condition is needed here. Log statements should be
 	// sufficient for diagnosing this type of condition.
-	<-n.gossip.Connected
+	<-n.ctx.Gossip.Connected
 
-	val, err := n.gossip.GetInfo(gossip.KeyClusterID)
+	val, err := n.ctx.Gossip.GetInfo(gossip.KeyClusterID)
 	if err != nil || val == nil {
 		log.Fatalf("unable to ascertain cluster ID from gossip network: %s", err)
 	}

--- a/server/node.go
+++ b/server/node.go
@@ -34,6 +34,7 @@ import (
 	"github.com/cockroachdb/cockroach/util"
 	"github.com/cockroachdb/cockroach/util/hlc"
 	"github.com/cockroachdb/cockroach/util/log"
+	"golang.org/x/net/context"
 )
 
 const (
@@ -110,6 +111,7 @@ func BootstrapCluster(clusterID string, eng engine.Engine, stopper *util.Stopper
 		StoreID:   1,
 	}
 	ctx := storage.StoreContext{}
+	ctx.Context = context.Background()
 	// Dummy gossip, not actually used.
 	ctx.Gossip = gossip.New(&rpc.Context{}, 10*time.Hour, nil)
 	ctx.Clock = hlc.NewClock(hlc.UnixNano)

--- a/server/node.go
+++ b/server/node.go
@@ -112,8 +112,6 @@ func BootstrapCluster(clusterID string, eng engine.Engine, stopper *util.Stopper
 	}
 	ctx := storage.StoreContext{}
 	ctx.Context = context.Background()
-	// Dummy gossip, not actually used.
-	ctx.Gossip = gossip.New(&rpc.Context{}, 10*time.Hour, nil)
 	ctx.ScanInterval = 10 * time.Minute
 	ctx.Clock = hlc.NewClock(hlc.UnixNano)
 	// Create a KV DB with a local sender.

--- a/server/node_test.go
+++ b/server/node_test.go
@@ -48,10 +48,11 @@ func createTestNode(addr net.Addr, engines []engine.Engine, gossipBS net.Addr, t
 	if err != nil {
 		t.Fatal(err)
 	}
+	ctx := storage.StoreContext{}
 
 	stopper := util.NewStopper()
-	clock := hlc.NewClock(hlc.UnixNano)
-	rpcContext := rpc.NewContext(clock, tlsConfig, stopper)
+	ctx.Clock = hlc.NewClock(hlc.UnixNano)
+	rpcContext := rpc.NewContext(ctx.Clock, tlsConfig, stopper)
 	rpcServer := rpc.NewServer(addr, rpcContext)
 	if err := rpcServer.Start(); err != nil {
 		t.Fatal(err)
@@ -65,10 +66,13 @@ func createTestNode(addr net.Addr, engines []engine.Engine, gossipBS net.Addr, t
 		g.SetResolvers([]gossip.Resolver{gossip.NewResolverFromAddress(gossipBS)})
 		g.Start(rpcServer, stopper)
 	}
-	db := client.NewKV(nil, kv.NewDistSender(&kv.DistSenderContext{Clock: clock}, g))
+	ctx.Gossip = g
+	ctx.DB = client.NewKV(nil,
+		kv.NewDistSender(&kv.DistSenderContext{Clock: ctx.Clock}, g))
 	// TODO(bdarnell): arrange to have the transport closed.
-	node := NewNode(db, g, storage.TestStoreConfig, multiraft.NewLocalRPCTransport())
-	return rpcServer, clock, node, stopper
+	ctx.Transport = multiraft.NewLocalRPCTransport()
+	node := NewNode(ctx)
+	return rpcServer, ctx.Clock, node, stopper
 }
 
 // createAndStartTestNode creates a new test node and starts it. The server and node are returned.
@@ -208,12 +212,12 @@ func TestNodeJoin(t *testing.T) {
 	node1Key := gossip.MakeNodeIDKey(node1.Descriptor.NodeID)
 	node2Key := gossip.MakeNodeIDKey(node2.Descriptor.NodeID)
 	if err := util.IsTrueWithin(func() bool {
-		if val, err := node1.gossip.GetInfo(node2Key); err != nil {
+		if val, err := node1.ctx.Gossip.GetInfo(node2Key); err != nil {
 			return false
 		} else if addr2 := val.(*gossip.NodeDescriptor).Address.String(); addr2 != server2.Addr().String() {
 			t.Errorf("addr2 gossip %s doesn't match addr2 address %s", addr2, server2.Addr().String())
 		}
-		if val, err := node2.gossip.GetInfo(node1Key); err != nil {
+		if val, err := node2.ctx.Gossip.GetInfo(node1Key); err != nil {
 			return false
 		} else if addr1 := val.(*gossip.NodeDescriptor).Address.String(); addr1 != server1.Addr().String() {
 			t.Errorf("addr1 gossip %s doesn't match addr1 address %s", addr1, server1.Addr().String())

--- a/server/node_test.go
+++ b/server/node_test.go
@@ -78,8 +78,8 @@ func createTestNode(addr net.Addr, engines []engine.Engine, gossipBS net.Addr, t
 // createAndStartTestNode creates a new test node and starts it. The server and node are returned.
 func createAndStartTestNode(addr net.Addr, engines []engine.Engine, gossipBS net.Addr, t *testing.T) (
 	*rpc.Server, *Node, *util.Stopper) {
-	rpcServer, clock, node, stopper := createTestNode(addr, engines, gossipBS, t)
-	if err := node.start(rpcServer, clock, engines, proto.Attributes{}, stopper); err != nil {
+	rpcServer, _, node, stopper := createTestNode(addr, engines, gossipBS, t)
+	if err := node.start(rpcServer, engines, proto.Attributes{}, stopper); err != nil {
 		t.Fatal(err)
 	}
 	return rpcServer, node, stopper
@@ -250,8 +250,8 @@ func TestCorruptedClusterID(t *testing.T) {
 	}
 
 	engines := []engine.Engine{e}
-	server, clock, node, stopper := createTestNode(util.CreateTestAddr("tcp"), engines, nil, t)
-	if err := node.start(server, clock, engines, proto.Attributes{}, stopper); err == nil {
+	server, _, node, stopper := createTestNode(util.CreateTestAddr("tcp"), engines, nil, t)
+	if err := node.start(server, engines, proto.Attributes{}, stopper); err == nil {
 		t.Errorf("unexpected success")
 	}
 	stopper.Stop()

--- a/server/node_test.go
+++ b/server/node_test.go
@@ -36,6 +36,7 @@ import (
 	"github.com/cockroachdb/cockroach/storage/engine"
 	"github.com/cockroachdb/cockroach/util"
 	"github.com/cockroachdb/cockroach/util/hlc"
+	"golang.org/x/net/context"
 )
 
 // createTestNode creates an rpc server using the specified address,
@@ -49,6 +50,7 @@ func createTestNode(addr net.Addr, engines []engine.Engine, gossipBS net.Addr, t
 		t.Fatal(err)
 	}
 	ctx := storage.StoreContext{}
+	ctx.Context = context.Background()
 
 	stopper := util.NewStopper()
 	ctx.Clock = hlc.NewClock(hlc.UnixNano)

--- a/server/node_test.go
+++ b/server/node_test.go
@@ -55,6 +55,7 @@ func createTestNode(addr net.Addr, engines []engine.Engine, gossipBS net.Addr, t
 	stopper := util.NewStopper()
 	ctx.Clock = hlc.NewClock(hlc.UnixNano)
 	rpcContext := rpc.NewContext(ctx.Clock, tlsConfig, stopper)
+	ctx.ScanInterval = 10 * time.Hour
 	rpcServer := rpc.NewServer(addr, rpcContext)
 	if err := rpcServer.Start(); err != nil {
 		t.Fatal(err)

--- a/server/server.go
+++ b/server/server.go
@@ -40,6 +40,7 @@ import (
 	"github.com/cockroachdb/cockroach/util/hlc"
 	"github.com/cockroachdb/cockroach/util/log"
 	assetfs "github.com/elazarl/go-bindata-assetfs"
+	"golang.org/x/net/context"
 )
 
 var (
@@ -124,6 +125,7 @@ func NewServer(ctx *Context, stopper *util.Stopper) (*Server, error) {
 		DB:        s.kv,
 		Gossip:    s.gossip,
 		Transport: s.raftTransport,
+		Context:   context.Background(),
 	}
 	s.node = NewNode(nCtx)
 	s.admin = newAdminServer(s.kv, s.stopper)

--- a/server/server.go
+++ b/server/server.go
@@ -119,7 +119,13 @@ func NewServer(ctx *Context, stopper *util.Stopper) (*Server, error) {
 	s.kvDB = kv.NewDBServer(sender)
 	s.kvREST = kv.NewRESTServer(s.kv)
 	// TODO(bdarnell): make StoreConfig configurable.
-	s.node = NewNode(s.kv, s.gossip, storage.StoreConfig{}, s.raftTransport)
+	nCtx := storage.StoreContext{
+		Clock:     s.clock,
+		DB:        s.kv,
+		Gossip:    s.gossip,
+		Transport: s.raftTransport,
+	}
+	s.node = NewNode(nCtx)
 	s.admin = newAdminServer(s.kv, s.stopper)
 	s.status = newStatusServer(s.kv, s.gossip)
 	s.structuredDB = structured.NewDB(s.kv)

--- a/server/server.go
+++ b/server/server.go
@@ -152,7 +152,7 @@ func (s *Server) Start(selfBootstrap bool) error {
 	}
 	s.gossip.Start(s.rpc, s.stopper)
 
-	if err := s.node.start(s.rpc, s.clock, s.ctx.Engines, s.ctx.NodeAttributes, s.stopper); err != nil {
+	if err := s.node.start(s.rpc, s.ctx.Engines, s.ctx.NodeAttributes, s.stopper); err != nil {
 		return err
 	}
 

--- a/server/server.go
+++ b/server/server.go
@@ -121,11 +121,12 @@ func NewServer(ctx *Context, stopper *util.Stopper) (*Server, error) {
 	s.kvREST = kv.NewRESTServer(s.kv)
 	// TODO(bdarnell): make StoreConfig configurable.
 	nCtx := storage.StoreContext{
-		Clock:     s.clock,
-		DB:        s.kv,
-		Gossip:    s.gossip,
-		Transport: s.raftTransport,
-		Context:   context.Background(),
+		Clock:        s.clock,
+		DB:           s.kv,
+		Gossip:       s.gossip,
+		Transport:    s.raftTransport,
+		Context:      context.Background(),
+		ScanInterval: s.ctx.ScanInterval,
 	}
 	s.node = NewNode(nCtx)
 	s.admin = newAdminServer(s.kv, s.stopper)

--- a/server/server_test.go
+++ b/server/server_test.go
@@ -275,7 +275,7 @@ func TestMultiRangeScanDeleteRange(t *testing.T) {
 	ds := kv.NewDistSender(&kv.DistSenderContext{Clock: s.Clock()}, s.Gossip())
 	tds := kv.NewTxnCoordSender(ds, s.Clock(), testContext.Linearizable, s.stopper)
 
-	if err := s.node.db.Run(client.Call{
+	if err := s.node.ctx.DB.Run(client.Call{
 		Args: &proto.AdminSplitRequest{
 			RequestHeader: proto.RequestHeader{
 				Key: proto.Key("m"),
@@ -384,7 +384,7 @@ func TestMultiRangeScanWithMaxResults(t *testing.T) {
 		tds := kv.NewTxnCoordSender(ds, s.Clock(), testContext.Linearizable, s.stopper)
 
 		for _, sk := range tc.splitKeys {
-			if err := s.node.db.Run(client.Call{
+			if err := s.node.ctx.DB.Run(client.Call{
 				Args: &proto.AdminSplitRequest{
 					RequestHeader: proto.RequestHeader{
 						Key: sk,

--- a/server/testserver.go
+++ b/server/testserver.go
@@ -126,7 +126,7 @@ func (ts *TestServer) Stop() {
 // SetRangeRetryOptions sets the retry options for stores in TestServer.
 func (ts *TestServer) SetRangeRetryOptions(ro util.RetryOptions) {
 	ts.node.lSender.VisitStores(func(s *storage.Store) error {
-		s.RetryOpts = ro
+		s.SetRangeRetryOptions(ro)
 		return nil
 	})
 }

--- a/storage/id_alloc_test.go
+++ b/storage/id_alloc_test.go
@@ -38,7 +38,8 @@ func TestIDAllocator(t *testing.T) {
 	store, _, stopper := createTestStore(t)
 	defer stopper.Stop()
 	allocd := make(chan int, 100)
-	idAlloc, err := NewIDAllocator(engine.KeyRaftIDGenerator, store.db, 2, 10, stopper)
+	idAlloc, err := NewIDAllocator(engine.KeyRaftIDGenerator, store.ctx.DB,
+		2, 10, stopper)
 	if err != nil {
 		t.Errorf("failed to create IDAllocator: %v", err)
 	}
@@ -82,14 +83,14 @@ func TestIDAllocatorNegativeValue(t *testing.T) {
 	defer stopper.Stop()
 
 	// Increment our key to a negative value.
-	newValue, err := engine.MVCCIncrement(store.Engine(), nil, engine.KeyRaftIDGenerator, store.clock.Now(), nil, -1024)
+	newValue, err := engine.MVCCIncrement(store.Engine(), nil, engine.KeyRaftIDGenerator, store.ctx.Clock.Now(), nil, -1024)
 	if err != nil {
 		t.Fatal(err)
 	}
 	if newValue != -1024 {
 		t.Errorf("expected new value to be -1024; got %d", newValue)
 	}
-	idAlloc, err := NewIDAllocator(engine.KeyRaftIDGenerator, store.db, 2, 10, stopper)
+	idAlloc, err := NewIDAllocator(engine.KeyRaftIDGenerator, store.ctx.DB, 2, 10, stopper)
 	if err != nil {
 		t.Errorf("failed to create IDAllocator: %v", err)
 	}
@@ -126,7 +127,8 @@ func TestAllocateErrorAndRecovery(t *testing.T) {
 	allocd := make(chan int, 10)
 
 	// Firstly create a valid IDAllocator to get some ID.
-	idAlloc, err := NewIDAllocator(engine.KeyRaftIDGenerator, store.db, 2, 10, stopper)
+	idAlloc, err := NewIDAllocator(engine.KeyRaftIDGenerator, store.ctx.DB,
+		2, 10, stopper)
 	if err != nil {
 		t.Errorf("failed to create IDAllocator: %v", err)
 	}

--- a/storage/range_test.go
+++ b/storage/range_test.go
@@ -138,8 +138,6 @@ func (tc *testContext) Start(t *testing.T) {
 		ctx.Clock = tc.clock
 		ctx.Gossip = tc.gossip
 		ctx.Transport = tc.transport
-		// Dummy DB.
-		ctx.DB = &client.KV{}
 		tc.store = NewStore(ctx, tc.engine)
 		if err := tc.store.Bootstrap(proto.StoreIdent{NodeID: 1, StoreID: 1}, tc.stopper); err != nil {
 			t.Fatal(err)
@@ -239,10 +237,6 @@ func TestRangeContains(t *testing.T) {
 	defer transport.Close()
 	ctx := TestStoreContext
 	ctx.Clock = clock
-	// Dummy Gossip.
-	ctx.Gossip = gossip.New(&rpc.Context{}, 10*time.Hour, nil)
-	// Dummy KV.
-	ctx.DB = &client.KV{}
 	ctx.Transport = multiraft.NewLocalRPCTransport()
 	store := NewStore(ctx, e)
 	r, err := NewRange(desc, store)

--- a/storage/range_test.go
+++ b/storage/range_test.go
@@ -138,6 +138,8 @@ func (tc *testContext) Start(t *testing.T) {
 		ctx.Clock = tc.clock
 		ctx.Gossip = tc.gossip
 		ctx.Transport = tc.transport
+		// Dummy DB.
+		ctx.DB = &client.KV{}
 		tc.store = NewStore(ctx, tc.engine)
 		if err := tc.store.Bootstrap(proto.StoreIdent{NodeID: 1, StoreID: 1}, tc.stopper); err != nil {
 			t.Fatal(err)
@@ -237,6 +239,10 @@ func TestRangeContains(t *testing.T) {
 	defer transport.Close()
 	ctx := TestStoreContext
 	ctx.Clock = clock
+	// Dummy Gossip.
+	ctx.Gossip = gossip.New(&rpc.Context{}, 10*time.Hour, nil)
+	// Dummy KV.
+	ctx.DB = &client.KV{}
 	ctx.Transport = multiraft.NewLocalRPCTransport()
 	store := NewStore(ctx, e)
 	r, err := NewRange(desc, store)

--- a/storage/store.go
+++ b/storage/store.go
@@ -306,7 +306,7 @@ func (sc *StoreContext) Valid() bool {
 	return sc.Clock != nil && sc.DB != nil && sc.Gossip != nil &&
 		sc.Context != nil && sc.Transport != nil &&
 		sc.RaftTickInterval != 0 && sc.RaftHeartbeatIntervalTicks > 0 &&
-		sc.RaftElectionTimeoutTicks > 0
+		sc.RaftElectionTimeoutTicks > 0 && sc.ScanInterval > 0
 }
 
 // setDefaults initializes unset fields in StoreConfig to values
@@ -321,11 +321,6 @@ func (sc *StoreContext) setDefaults() {
 	}
 	if sc.RaftElectionTimeoutTicks == 0 {
 		sc.RaftElectionTimeoutTicks = defaultRaftElectionTimeoutTicks
-	}
-	// A ScanInterval of 0 is not great in tests, especially in those
-	// that do not have a proper Gossip instance.
-	if sc.ScanInterval == 0 {
-		sc.ScanInterval = 10 * time.Minute
 	}
 }
 

--- a/storage/store.go
+++ b/storage/store.go
@@ -19,7 +19,6 @@ package storage
 
 import (
 	"bytes"
-	"flag"
 	"fmt"
 	"sort"
 	"sync"
@@ -37,6 +36,7 @@ import (
 	"github.com/cockroachdb/cockroach/util/log"
 	"github.com/coreos/etcd/raft/raftpb"
 	gogoproto "github.com/gogo/protobuf/proto"
+	"golang.org/x/net/context"
 )
 
 const (
@@ -47,9 +47,11 @@ const (
 	GCResponseCacheExpiration = 1 * time.Hour
 	// raftIDAllocCount is the number of Raft IDs to allocate per allocation.
 	raftIDAllocCount = 10
-	// defaultScanInterval is the default value for the scan interval
+	// defaultScanInterval is the default value for the scan interval.
 	// command line flag.
-	defaultScanInterval = 10 * time.Minute
+	defaultRaftTickInterval         = 10 * time.Millisecond
+	defaultHeartbeatIntervalTicks   = 3
+	defaultRaftElectionTimeoutTicks = 15
 	// ttlCapacityGossip is time-to-live for capacity-related info.
 	ttlCapacityGossip = 2 * time.Minute
 )
@@ -64,10 +66,14 @@ var (
 		MaxAttempts: 0, // retry indefinitely
 	}
 
-	scanInterval = flag.Duration("scan_interval", defaultScanInterval, "specify "+
-		"--scan_interval to adjust the target for the duration of a single scan "+
-		"through a store's ranges. The scan is slowed as necessary to approximately"+
-		"achieve this duration.")
+	// TestStoreContext has some fields initialized with values relevant
+	// in tests.
+	TestStoreContext = StoreContext{
+		RaftTickInterval:           100 * time.Millisecond,
+		RaftHeartbeatIntervalTicks: 1,
+		RaftElectionTimeoutTicks:   2,
+		ScanInterval:               10 * time.Minute,
+	}
 )
 
 var (
@@ -235,65 +241,21 @@ func (si *storeRangeIterator) Reset() {
 	si.index = 0
 }
 
-// StoreConfig contains various parameters of a Store.
-type StoreConfig struct {
-	// RaftTickInterval is the resolution of the Raft timer; other raft timeouts
-	// are defined in terms of multiples of this value.
-	RaftTickInterval time.Duration
-
-	// RaftHeartbeatIntervalTicks is the number of ticks that pass between heartbeats.
-	RaftHeartbeatIntervalTicks int
-
-	// RaftElectionTimeoutTicks is the number of ticks that must pass before a follower
-	// considers a leader to have failed and calls a new election. Should be significantly
-	// higher than RaftHeartbeatIntervalTicks. The raft paper recommends a value of 150ms
-	// for local networks.
-	RaftElectionTimeoutTicks int
-}
-
-// setDefaults initializes unset fields in StoreConfig to values
-// suitable for use on a local network.
-func (c *StoreConfig) setDefaults() {
-	if c.RaftTickInterval == 0 {
-		c.RaftTickInterval = 10 * time.Millisecond
-	}
-	if c.RaftHeartbeatIntervalTicks == 0 {
-		c.RaftHeartbeatIntervalTicks = 3
-	}
-	if c.RaftElectionTimeoutTicks == 0 {
-		c.RaftElectionTimeoutTicks = 15
-	}
-}
-
-// TestStoreConfig is a StoreConfig for use in tests.
-// It uses a high default timeout since most test scenarios elect a leader
-// automatically upon creating the group.
-var TestStoreConfig = StoreConfig{
-	RaftTickInterval:           100 * time.Millisecond,
-	RaftHeartbeatIntervalTicks: 1,
-	RaftElectionTimeoutTicks:   2,
-}
-
 // A Store maintains a map of ranges by start key. A Store corresponds
 // to one physical device.
 type Store struct {
 	*StoreFinder
-	StoreConfig
 
 	Ident          proto.StoreIdent
-	RetryOpts      util.RetryOptions
-	clock          *hlc.Clock
-	engine         engine.Engine       // The underlying key-value store
-	db             *client.KV          // Cockroach KV DB
-	allocator      *allocator          // Makes allocation decisions
-	gossip         *gossip.Gossip      // Configs and store capacities
-	transport      multiraft.Transport // Log replication traffic
-	raftIDAlloc    *IDAllocator        // Raft ID allocator
-	gcQueue        *gcQueue            // Garbage collection queue
-	splitQueue     *splitQueue         // Range splitting queue
-	verifyQueue    *verifyQueue        // Checksum verification queue
-	replicateQueue *replicateQueue     // Replication queue
-	scanner        *rangeScanner       // Range scanner
+	ctx            StoreContext
+	engine         engine.Engine   // The underlying key-value store
+	allocator      *allocator      // Makes allocation decisions
+	raftIDAlloc    *IDAllocator    // Raft ID allocator
+	gcQueue        *gcQueue        // Garbage collection queue
+	splitQueue     *splitQueue     // Range splitting queue
+	verifyQueue    *verifyQueue    // Checksum verification queue
+	replicateQueue *replicateQueue // Replication queue
+	scanner        *rangeScanner   // Range scanner
 	multiraft      *multiraft.MultiRaft
 	started        int32
 	stopper        *util.Stopper
@@ -306,35 +268,129 @@ type Store struct {
 
 var _ multiraft.Storage = &Store{}
 
+// A StoreContext encompasses the auxiliary objects and configuration
+// required to create a store.
+// All fields holding a pointer or an interface are required to create
+// a store; the rest will have sane defaults set.
+type StoreContext struct {
+	Clock     *hlc.Clock
+	DB        *client.KV
+	Gossip    *gossip.Gossip
+	Transport multiraft.Transport
+	Context   context.Context
+
+	// RangeRetryOptions are the retry options for ranges.
+	// TODO(tschottdorf) improve comment once I figure out what this is.
+	RangeRetryOptions util.RetryOptions
+
+	// RaftTickInterval is the resolution of the Raft timer; other raft timeouts
+	// are defined in terms of multiples of this value.
+	RaftTickInterval time.Duration
+
+	// RaftHeartbeatIntervalTicks is the number of ticks that pass between heartbeats.
+	RaftHeartbeatIntervalTicks int
+
+	// RaftElectionTimeoutTicks is the number of ticks that must pass before a follower
+	// considers a leader to have failed and calls a new election. Should be significantly
+	// higher than RaftHeartbeatIntervalTicks. The raft paper recommends a value of 150ms
+	// for local networks.
+	RaftElectionTimeoutTicks int
+
+	// ScanInterval is the default value for the scan interval
+	ScanInterval time.Duration
+}
+
+// Valid returns true if the StoreContext appears correctly populated.
+func (sc *StoreContext) Valid() bool {
+	// Gossip is allowed to be nil for testing purposes.
+	// KV as well.
+	// TODO(tschottdorf) change the above two things in those tests.
+	return sc.Clock != nil &&
+		sc.Transport != nil && sc.RaftTickInterval != 0 &&
+		sc.RaftHeartbeatIntervalTicks > 0 && sc.RaftElectionTimeoutTicks > 0
+
+}
+
+// setDefaults initializes unset fields in StoreConfig to values
+// suitable for use on a local network.
+// TODO(tschottdorf) see if this ought to be configurable via flags.
+func (sc *StoreContext) setDefaults() {
+	if sc.RaftTickInterval == 0 {
+		sc.RaftTickInterval = defaultRaftTickInterval
+	}
+	if sc.RaftHeartbeatIntervalTicks == 0 {
+		sc.RaftHeartbeatIntervalTicks = defaultHeartbeatIntervalTicks
+	}
+	if sc.RaftElectionTimeoutTicks == 0 {
+		sc.RaftElectionTimeoutTicks = defaultRaftElectionTimeoutTicks
+	}
+	// If the scanner runs in tests, we explode because often Gossip
+	// is nil.
+	// TODO(tschottdorf) update all tests so that they have a basic Gossip
+	// instance.
+	if sc.ScanInterval == 0 {
+		sc.ScanInterval = 10 * time.Minute
+	}
+
+}
+
 // NewStore returns a new instance of a store.
-func NewStore(clock *hlc.Clock, eng engine.Engine, db *client.KV, gossip *gossip.Gossip,
-	transport multiraft.Transport, config StoreConfig) *Store {
-	config.setDefaults()
-	sf := newStoreFinder(gossip)
+func NewStore(ctx StoreContext, eng engine.Engine) *Store {
+	// TODO(tschottdorf) find better place to set these defaults.
+	ctx.setDefaults()
+	sf := newStoreFinder(ctx.Gossip)
 	s := &Store{
+		// Make a copy - makes it easier for tests to reuse the Context.
+		ctx:         ctx,
 		StoreFinder: sf,
-		StoreConfig: config,
-		RetryOpts:   defaultRangeRetryOptions,
-		clock:       clock,
 		engine:      eng,
-		db:          db,
 		allocator:   newAllocator(sf.findStores),
-		gossip:      gossip,
-		transport:   transport,
 		ranges:      map[int64]*Range{},
 		status:      &proto.StoreStatus{},
 	}
 
 	// Add range scanner and configure with queues.
-	s.scanner = newRangeScanner(defaultScanInterval, newStoreRangeIterator(s), s.updateStoreStatus)
+	s.scanner = newRangeScanner(ctx.ScanInterval, newStoreRangeIterator(s), s.
+		updateStoreStatus)
 	s.gcQueue = newGCQueue()
-	s.splitQueue = newSplitQueue(db, gossip)
+	s.splitQueue = newSplitQueue(s.ctx.DB, s.ctx.Gossip)
 	s.verifyQueue = newVerifyQueue(s.scanner.Stats)
-	s.replicateQueue = newReplicateQueue(gossip, s.allocator, clock)
+	s.replicateQueue = newReplicateQueue(s.ctx.Gossip, s.allocator, s.ctx.Clock)
 	s.scanner.AddQueues(s.gcQueue, s.splitQueue, s.verifyQueue, s.replicateQueue)
 
 	return s
+
 }
+
+// NewStore returns a new instance of a store.
+//func NewStore(clock *hlc.Clock, eng engine.Engine, db *client.KV, gossip *gossip.Gossip,
+//	transport multiraft.Transport, config StoreConfig) *Store {
+//	config.setDefaults()
+//	sf := newStoreFinder(gossip)
+//	s := &Store{
+//		StoreFinder: sf,
+//		StoreConfig: config,
+//		RetryOpts:   defaultRangeRetryOptions,
+//		clock:       clock,
+//		engine:      eng,
+//		db:          db,
+//		allocator:   newAllocator(sf.findStores),
+//		gossip:      gossip,
+//		transport:   transport,
+//		ranges:      map[int64]*Range{},
+//		status:      &proto.StoreStatus{},
+//	}
+//
+//	// Add range scanner and configure with queues.
+//	s.scanner = newRangeScanner(defaultScanInterval, newStoreRangeIterator(s))
+//	s.gcQueue = newGCQueue()
+//	s.splitQueue = newSplitQueue(db, gossip)
+//	s.verifyQueue = newVerifyQueue(s.scanner.Stats)
+//	s.replicateQueue = newReplicateQueue(gossip, s.allocator, clock)
+//	s.scanner.AddQueues(s.gcQueue, s.splitQueue, s.verifyQueue, s.replicateQueue)
+//
+//	return s
+//}
 
 // String formats a store for debug output.
 func (s *Store) String() string {
@@ -348,6 +404,12 @@ func (s *Store) IsStarted() bool {
 
 // Start the engine, set the GC and read the StoreIdent.
 func (s *Store) Start(stopper *util.Stopper) error {
+	// Validity check only here since some tests have a weird order of setting
+	// this up.
+	if !s.ctx.Valid() {
+		panic(fmt.Sprintf("invalid store configuration: %+v", &s.ctx))
+	}
+
 	s.stopper = stopper
 
 	if s.Ident.NodeID == 0 {
@@ -369,7 +431,7 @@ func (s *Store) Start(stopper *util.Stopper) error {
 	}
 
 	// Create ID allocators.
-	idAlloc, err := NewIDAllocator(engine.KeyRaftIDGenerator, s.db, 2 /* min ID */, raftIDAllocCount, s.stopper)
+	idAlloc, err := NewIDAllocator(engine.KeyRaftIDGenerator, s.ctx.DB, 2 /* min ID */, raftIDAllocCount, s.stopper)
 	if err != nil {
 		return err
 	}
@@ -378,7 +440,7 @@ func (s *Store) Start(stopper *util.Stopper) error {
 	// GCTimeouts method is called each time an engine compaction is
 	// underway. It sets minimum timeouts for transaction records and
 	// response cache entries.
-	now := s.clock.Now()
+	now := s.ctx.Clock.Now()
 	minTxnTS := int64(0) // disable GC of transactions until we know minimum write intent age
 	minRCacheTS := now.WallTime - GCResponseCacheExpiration.Nanoseconds()
 	s.engine.SetGCTimeouts(minTxnTS, minRCacheTS)
@@ -388,12 +450,12 @@ func (s *Store) Start(stopper *util.Stopper) error {
 	end := engine.RangeDescriptorKey(engine.KeyMax)
 
 	if s.multiraft, err = multiraft.NewMultiRaft(s.RaftNodeID(), &multiraft.Config{
-		Transport:              s.transport,
+		Transport:              s.ctx.Transport,
 		Storage:                s,
 		StateMachine:           s,
-		TickInterval:           s.RaftTickInterval,
-		ElectionTimeoutTicks:   s.RaftElectionTimeoutTicks,
-		HeartbeatIntervalTicks: s.RaftHeartbeatIntervalTicks,
+		TickInterval:           s.ctx.RaftTickInterval,
+		ElectionTimeoutTicks:   s.ctx.RaftElectionTimeoutTicks,
+		HeartbeatIntervalTicks: s.ctx.RaftHeartbeatIntervalTicks,
 		EntryFormatter:         raftEntryFormatter,
 	}); err != nil {
 		return err
@@ -443,17 +505,17 @@ func (s *Store) Start(stopper *util.Stopper) error {
 	s.processRaft()
 
 	// Start the scanner.
-	s.scanner.Start(s.clock, s.stopper)
+	s.scanner.Start(s.ctx.Clock, s.stopper)
 
 	// Register callbacks for any changes to accounting and zone
 	// configurations; we split ranges along prefix boundaries.
 	// Gossip is only ever nil for unittests.
-	if s.gossip != nil {
-		s.gossip.RegisterCallback(gossip.KeyConfigAccounting, s.configGossipUpdate)
-		s.gossip.RegisterCallback(gossip.KeyConfigZone, s.configGossipUpdate)
+	if s.ctx.Gossip != nil {
+		s.ctx.Gossip.RegisterCallback(gossip.KeyConfigAccounting, s.configGossipUpdate)
+		s.ctx.Gossip.RegisterCallback(gossip.KeyConfigZone, s.configGossipUpdate)
 		// Callback triggers on capacity gossip from all stores.
 		capacityRegex := gossip.MakePrefixPattern(gossip.KeyMaxAvailCapacityPrefix)
-		s.gossip.RegisterCallback(capacityRegex, s.capacityGossipUpdate)
+		s.ctx.Gossip.RegisterCallback(capacityRegex, s.capacityGossipUpdate)
 	}
 
 	// Set the started flag (for unittests).
@@ -473,7 +535,7 @@ func (s *Store) configGossipUpdate(key string, contentsChanged bool) {
 	if !contentsChanged {
 		return // Skip update if it's just a newer timestamp or fewer hops to info
 	}
-	info, err := s.gossip.GetInfo(key)
+	info, err := s.ctx.Gossip.GetInfo(key)
 	if err != nil {
 		log.Errorf("unable to fetch %s config from gossip: %s", key, err)
 		return
@@ -501,7 +563,7 @@ func (s *Store) GossipCapacity(n *gossip.NodeDescriptor) {
 	// Unique gossip key per store.
 	keyMaxCapacity := gossip.MakeMaxAvailCapacityKey(storeDesc.Node.NodeID, storeDesc.StoreID)
 	// Gossip store descriptor.
-	s.gossip.AddInfo(keyMaxCapacity, *storeDesc, ttlCapacityGossip)
+	s.ctx.Gossip.AddInfo(keyMaxCapacity, *storeDesc, ttlCapacityGossip)
 }
 
 // maybeSplitRangesByConfigs determines ranges which should be
@@ -520,7 +582,7 @@ func (s *Store) maybeSplitRangesByConfigs(configMap PrefixConfigMap) {
 		if n >= len(s.rangesByKey) || !s.rangesByKey[n].Desc().ContainsKey(config.Prefix) || !s.rangesByKey[n].IsLeader() {
 			continue
 		}
-		s.splitQueue.MaybeAdd(s.rangesByKey[n], s.clock.Now())
+		s.splitQueue.MaybeAdd(s.rangesByKey[n], s.ctx.Clock.Now())
 	}
 }
 
@@ -531,7 +593,7 @@ func (s *Store) ForceReplicationScan() {
 	defer s.mu.Unlock()
 
 	for _, r := range s.ranges {
-		s.replicateQueue.MaybeAdd(r, s.clock.Now())
+		s.replicateQueue.MaybeAdd(r, s.ctx.Clock.Now())
 	}
 }
 
@@ -640,7 +702,7 @@ func (s *Store) BootstrapRange() error {
 	}
 	batch := s.engine.NewBatch()
 	ms := &engine.MVCCStats{}
-	now := s.clock.Now()
+	now := s.ctx.Clock.Now()
 
 	// Range descriptor.
 	if err := engine.MVCCPutProto(batch, ms, engine.RangeDescriptorKey(desc.StartKey), now, nil, desc); err != nil {
@@ -723,19 +785,19 @@ func (s *Store) RaftNodeID() multiraft.NodeID {
 }
 
 // Clock accessor.
-func (s *Store) Clock() *hlc.Clock { return s.clock }
+func (s *Store) Clock() *hlc.Clock { return s.ctx.Clock }
 
 // Engine accessor.
 func (s *Store) Engine() engine.Engine { return s.engine }
 
 // DB accessor.
-func (s *Store) DB() *client.KV { return s.db }
+func (s *Store) DB() *client.KV { return s.ctx.DB }
 
 // Allocator accessor.
 func (s *Store) Allocator() *allocator { return s.allocator }
 
 // Gossip accessor.
-func (s *Store) Gossip() *gossip.Gossip { return s.gossip }
+func (s *Store) Gossip() *gossip.Gossip { return s.ctx.Gossip }
 
 // SplitQueue accessor.
 func (s *Store) SplitQueue() *splitQueue { return s.splitQueue }
@@ -916,13 +978,13 @@ func (s *Store) ExecuteCmd(args proto.Request, reply proto.Response) error {
 	}
 	if header.Timestamp.Equal(proto.ZeroTimestamp) {
 		// Update the incoming timestamp if unset.
-		header.Timestamp = s.clock.Now()
+		header.Timestamp = s.ctx.Clock.Now()
 	} else {
 		// Otherwise, update our clock with the incoming request. This
 		// advances the local node's clock to a high water mark from
 		// amongst all nodes with which it has interacted. The update is
 		// bounded by the max clock drift.
-		_, err := s.clock.Update(header.Timestamp)
+		_, err := s.ctx.Clock.Update(header.Timestamp)
 		if err != nil {
 			reply.Header().SetGoError(err)
 			return err
@@ -931,7 +993,7 @@ func (s *Store) ExecuteCmd(args proto.Request, reply proto.Response) error {
 
 	// Backoff and retry loop for handling errors.
 	method := args.Method()
-	retryOpts := s.RetryOpts
+	retryOpts := s.ctx.RangeRetryOptions
 	retryOpts.Tag = fmt.Sprintf("store: %s", method)
 	err := util.RetryWithBackoff(retryOpts, func() (util.RetryStatus, error) {
 		// Add the command to the range for execution; exit retry loop on success.
@@ -1016,7 +1078,7 @@ func (s *Store) maybeResolveWriteIntentError(rng *Range, method string, args pro
 		Abort:     proto.IsReadWrite(method), // abort if cmd is read/write
 	}
 	pushReply := &proto.InternalPushTxnResponse{}
-	s.db.Run(client.Call{Args: pushArgs, Reply: pushReply})
+	s.ctx.DB.Run(client.Call{Args: pushArgs, Reply: pushReply})
 	if pushErr := pushReply.GoError(); pushErr != nil {
 		log.V(1).Infof("push %q failed: %s", pushArgs.Header().Key, pushErr)
 
@@ -1259,12 +1321,17 @@ func raftEntryFormatter(data []byte) string {
 
 // updateStoreStatus updates the store's status proto.
 func (s *Store) updateStoreStatus() {
-	now := s.clock.Now().WallTime
+	now := s.ctx.Clock.Now().WallTime
 	s.status.UpdatedAt = now
 	s.status.RangeCount = int32(len(s.ranges))
 	key := engine.StoreStatusKey(int32(s.Ident.StoreID))
 	s.status.Stats = proto.MVCCStats(s.scanner.Stats().MVCC)
-	if err := s.db.Run(client.PutProtoCall(key, s.status)); err != nil {
+	if err := s.ctx.DB.Run(client.PutProtoCall(key, s.status)); err != nil {
 		util.Error(err)
 	}
+}
+
+// SetRangeRetryOptions sets the retry options used for this store.
+func (s *Store) SetRangeRetryOptions(ro util.RetryOptions) {
+	s.ctx.RangeRetryOptions = ro
 }

--- a/storage/store.go
+++ b/storage/store.go
@@ -302,9 +302,10 @@ type StoreContext struct {
 }
 
 // Valid returns true if the StoreContext is populated correctly.
+// We don't check for Gossip and DB since some of our tests pass
+// that as nil.
 func (sc *StoreContext) Valid() bool {
-	return sc.Clock != nil && sc.DB != nil && sc.Gossip != nil &&
-		sc.Context != nil && sc.Transport != nil &&
+	return sc.Clock != nil && sc.Context != nil && sc.Transport != nil &&
 		sc.RaftTickInterval != 0 && sc.RaftHeartbeatIntervalTicks > 0 &&
 		sc.RaftElectionTimeoutTicks > 0 && sc.ScanInterval > 0
 }
@@ -355,36 +356,6 @@ func NewStore(ctx StoreContext, eng engine.Engine) *Store {
 	return s
 
 }
-
-// NewStore returns a new instance of a store.
-//func NewStore(clock *hlc.Clock, eng engine.Engine, db *client.KV, gossip *gossip.Gossip,
-//	transport multiraft.Transport, config StoreConfig) *Store {
-//	config.setDefaults()
-//	sf := newStoreFinder(gossip)
-//	s := &Store{
-//		StoreFinder: sf,
-//		StoreConfig: config,
-//		RetryOpts:   defaultRangeRetryOptions,
-//		clock:       clock,
-//		engine:      eng,
-//		db:          db,
-//		allocator:   newAllocator(sf.findStores),
-//		gossip:      gossip,
-//		transport:   transport,
-//		ranges:      map[int64]*Range{},
-//		status:      &proto.StoreStatus{},
-//	}
-//
-//	// Add range scanner and configure with queues.
-//	s.scanner = newRangeScanner(defaultScanInterval, newStoreRangeIterator(s))
-//	s.gcQueue = newGCQueue()
-//	s.splitQueue = newSplitQueue(db, gossip)
-//	s.verifyQueue = newVerifyQueue(s.scanner.Stats)
-//	s.replicateQueue = newReplicateQueue(gossip, s.allocator, clock)
-//	s.scanner.AddQueues(s.gcQueue, s.splitQueue, s.verifyQueue, s.replicateQueue)
-//
-//	return s
-//}
 
 // String formats a store for debug output.
 func (s *Store) String() string {

--- a/storage/store.go
+++ b/storage/store.go
@@ -73,6 +73,7 @@ var (
 		RaftHeartbeatIntervalTicks: 1,
 		RaftElectionTimeoutTicks:   2,
 		ScanInterval:               10 * time.Minute,
+		Context:                    context.Background(),
 	}
 )
 
@@ -271,7 +272,7 @@ var _ multiraft.Storage = &Store{}
 // A StoreContext encompasses the auxiliary objects and configuration
 // required to create a store.
 // All fields holding a pointer or an interface are required to create
-// a store; the rest will have sane defaults set.
+// a store; the rest will have sane defaults set if omitted.
 type StoreContext struct {
 	Clock     *hlc.Clock
 	DB        *client.KV
@@ -303,8 +304,9 @@ type StoreContext struct {
 // Valid returns true if the StoreContext is populated correctly.
 func (sc *StoreContext) Valid() bool {
 	return sc.Clock != nil && sc.DB != nil && sc.Gossip != nil &&
-		sc.Transport != nil && sc.RaftTickInterval != 0 &&
-		sc.RaftHeartbeatIntervalTicks > 0 && sc.RaftElectionTimeoutTicks > 0
+		sc.Context != nil && sc.Transport != nil &&
+		sc.RaftTickInterval != 0 && sc.RaftHeartbeatIntervalTicks > 0 &&
+		sc.RaftElectionTimeoutTicks > 0
 }
 
 // setDefaults initializes unset fields in StoreConfig to values

--- a/storage/store_test.go
+++ b/storage/store_test.go
@@ -99,6 +99,8 @@ func createTestStore(t *testing.T) (*Store, *hlc.ManualClock, *util.Stopper) {
 	ctx.Clock = hlc.NewClock(manual.UnixNano)
 	eng := engine.NewInMem(proto.Attributes{}, 10<<20)
 	ctx.Transport = multiraft.NewLocalRPCTransport()
+	// Dummy, replaced momentarily.
+	ctx.DB = &client.KV{}
 	// TODO(bdarnell): arrange to have the transport closed.
 	store := NewStore(ctx, eng)
 	if err := store.Bootstrap(proto.StoreIdent{NodeID: 1, StoreID: 1}, stopper); err != nil {
@@ -120,6 +122,10 @@ func TestStoreInitAndBootstrap(t *testing.T) {
 	ctx := TestStoreContext
 	manual := hlc.NewManualClock(0)
 	ctx.Clock = hlc.NewClock(manual.UnixNano)
+	// Dummy Gossip.
+	ctx.Gossip = gossip.New(&rpc.Context{}, 10*time.Hour, nil)
+	// Dummy KV.
+	ctx.DB = &client.KV{}
 	eng := engine.NewInMem(proto.Attributes{}, 1<<20)
 	ctx.Transport = multiraft.NewLocalRPCTransport()
 	stopper := util.NewStopper()
@@ -172,6 +178,10 @@ func TestBootstrapOfNonEmptyStore(t *testing.T) {
 	manual := hlc.NewManualClock(0)
 	ctx.Clock = hlc.NewClock(manual.UnixNano)
 	ctx.Transport = multiraft.NewLocalRPCTransport()
+	// Dummy Gossip.
+	ctx.Gossip = gossip.New(&rpc.Context{}, 10*time.Hour, nil)
+	// Dummy KV.
+	ctx.DB = &client.KV{}
 	stopper := util.NewStopper()
 	stopper.AddCloser(ctx.Transport)
 	defer stopper.Stop()

--- a/storage/store_test.go
+++ b/storage/store_test.go
@@ -99,8 +99,6 @@ func createTestStore(t *testing.T) (*Store, *hlc.ManualClock, *util.Stopper) {
 	ctx.Clock = hlc.NewClock(manual.UnixNano)
 	eng := engine.NewInMem(proto.Attributes{}, 10<<20)
 	ctx.Transport = multiraft.NewLocalRPCTransport()
-	// Dummy, replaced momentarily.
-	ctx.DB = &client.KV{}
 	// TODO(bdarnell): arrange to have the transport closed.
 	store := NewStore(ctx, eng)
 	if err := store.Bootstrap(proto.StoreIdent{NodeID: 1, StoreID: 1}, stopper); err != nil {
@@ -122,10 +120,6 @@ func TestStoreInitAndBootstrap(t *testing.T) {
 	ctx := TestStoreContext
 	manual := hlc.NewManualClock(0)
 	ctx.Clock = hlc.NewClock(manual.UnixNano)
-	// Dummy Gossip.
-	ctx.Gossip = gossip.New(&rpc.Context{}, 10*time.Hour, nil)
-	// Dummy KV.
-	ctx.DB = &client.KV{}
 	eng := engine.NewInMem(proto.Attributes{}, 1<<20)
 	ctx.Transport = multiraft.NewLocalRPCTransport()
 	stopper := util.NewStopper()
@@ -178,10 +172,6 @@ func TestBootstrapOfNonEmptyStore(t *testing.T) {
 	manual := hlc.NewManualClock(0)
 	ctx.Clock = hlc.NewClock(manual.UnixNano)
 	ctx.Transport = multiraft.NewLocalRPCTransport()
-	// Dummy Gossip.
-	ctx.Gossip = gossip.New(&rpc.Context{}, 10*time.Hour, nil)
-	// Dummy KV.
-	ctx.DB = &client.KV{}
 	stopper := util.NewStopper()
 	stopper.AddCloser(ctx.Transport)
 	defer stopper.Stop()


### PR DESCRIPTION
I considered a separate struct for NewNode but really it takes about the same things it needs for creating a store later on and likely always will.
Could pack those in a NodeContext and extend the StoreContext from that, but all that would add are a few extra methods for copying contents around.
Content-wise this PR is a no-op; pure refactoring.
