### PR TITLE
Attach flags (read-perm, write-perm, is-transactional) to proto.Request.

### DIFF
--- a/client/kv.go
+++ b/client/kv.go
@@ -119,7 +119,7 @@ func (kv *KV) Run(calls ...Call) (err error) {
 		kv.sender.Send(c)
 		err = c.Reply.Header().GoError()
 		if err != nil {
-			log.Infof("failed %s: %s", c.Method, err)
+			log.Infof("failed %s: %s", c.Method(), err)
 		}
 		return
 	}

--- a/kv/txn_coord_sender.go
+++ b/kv/txn_coord_sender.go
@@ -242,7 +242,7 @@ func (tc *TxnCoordSender) sendOne(call client.Call) {
 		// Set the timestamp to the original timestamp for read-only
 		// commands and to the transaction timestamp for read/write
 		// commands.
-		if proto.IsReadOnly(call.Method()) {
+		if proto.IsReadOnly(call.Args) {
 			header.Timestamp = header.Txn.OrigTimestamp
 		} else {
 			header.Timestamp = header.Txn.Timestamp
@@ -270,7 +270,7 @@ func (tc *TxnCoordSender) sendOne(call client.Call) {
 	// If successful, we're in a transaction, and the command leaves
 	// transactional intents, add the key or key range to the intents map.
 	// If the transaction metadata doesn't yet exist, create it.
-	if call.Reply.Header().GoError() == nil && header.Txn != nil && proto.IsTransactional(call.Method()) {
+	if call.Reply.Header().GoError() == nil && header.Txn != nil && proto.IsTransactional(call.Args) {
 		tc.Lock()
 		var ok bool
 		var txnMeta *txnMetadata

--- a/storage/client_raft_test.go
+++ b/storage/client_raft_test.go
@@ -129,8 +129,8 @@ func TestStoreRecoverWithErrors(t *testing.T) {
 
 	numIncrements := 0
 
-	storage.TestingCommandFilter = func(method string, args proto.Request, reply proto.Response) bool {
-		if method == proto.Increment && args.Header().Key.Equal(proto.Key("a")) {
+	storage.TestingCommandFilter = func(args proto.Request, reply proto.Response) bool {
+		if args.Method() == proto.Increment && args.Header().Key.Equal(proto.Key("a")) {
 			numIncrements++
 		}
 		return false
@@ -320,8 +320,8 @@ func TestFailedReplicaChange(t *testing.T) {
 	defer func() {
 		storage.TestingCommandFilter = nil
 	}()
-	storage.TestingCommandFilter = func(method string, args proto.Request, reply proto.Response) bool {
-		if method == proto.EndTransaction && args.(*proto.EndTransactionRequest).Commit == true {
+	storage.TestingCommandFilter = func(args proto.Request, reply proto.Response) bool {
+		if args.Method() == proto.EndTransaction && args.(*proto.EndTransactionRequest).Commit == true {
 			reply.Header().SetGoError(util.Errorf("boom"))
 			return true
 		}

--- a/storage/range_test.go
+++ b/storage/range_test.go
@@ -375,7 +375,7 @@ func TestRangeGossipConfigWithMultipleKeyPrefixes(t *testing.T) {
 	}
 	reply := &proto.PutResponse{}
 
-	if err := tc.rng.executeCmd(0, proto.Put, req, reply); err != nil {
+	if err := tc.rng.executeCmd(0, req, reply); err != nil {
 		t.Fatal(err)
 	}
 
@@ -417,7 +417,7 @@ func TestRangeGossipConfigUpdates(t *testing.T) {
 	}
 	reply := &proto.PutResponse{}
 
-	if err := tc.rng.executeCmd(0, proto.Put, req, reply); err != nil {
+	if err := tc.rng.executeCmd(0, req, reply); err != nil {
 		t.Fatal(err)
 	}
 
@@ -685,7 +685,7 @@ func TestRangeCommandQueue(t *testing.T) {
 
 	// Intercept commands with matching command IDs and block them.
 	blockingDone := make(chan struct{}, 1)
-	TestingCommandFilter = func(method string, args proto.Request, reply proto.Response) bool {
+	TestingCommandFilter = func(args proto.Request, reply proto.Response) bool {
 		if args.Header().User == "Foo" {
 			<-blockingDone
 		}
@@ -787,7 +787,7 @@ func TestRangeCommandQueueInconsistent(t *testing.T) {
 
 	key := proto.Key("key1")
 	blockingDone := make(chan struct{})
-	TestingCommandFilter = func(method string, args proto.Request, reply proto.Response) bool {
+	TestingCommandFilter = func(args proto.Request, reply proto.Response) bool {
 		if args.Header().CmdID.Random == 1 {
 			<-blockingDone
 		}
@@ -1782,7 +1782,7 @@ func TestConditionFailedError(t *testing.T) {
 	key := []byte("k")
 	value := []byte("quack")
 	pArgs, pReply := putArgs(key, value, 1, tc.store.StoreID())
-	if err := tc.rng.executeCmd(0, proto.Put, pArgs, pReply); err != nil {
+	if err := tc.rng.executeCmd(0, pArgs, pReply); err != nil {
 		t.Fatal(err)
 	}
 	args := &proto.ConditionalPutRequest{
@@ -1800,7 +1800,7 @@ func TestConditionFailedError(t *testing.T) {
 		},
 	}
 	reply := &proto.ConditionalPutResponse{}
-	err := tc.rng.executeCmd(0, proto.ConditionalPut, args, reply)
+	err := tc.rng.executeCmd(0, args, reply)
 	if cErr, ok := err.(*proto.ConditionFailedError); err == nil || !ok {
 		t.Fatalf("expected ConditionFailedError, got %T with content %+v",
 			err, err)


### PR DESCRIPTION
Rather than using maps keyed by method, request flags are now hung off
the request itself.

Remove "method string" parameter from more methods.
