### PR TITLE
Use lazily-initialized http client in context.

### DIFF
--- a/client/client_test.go
+++ b/client/client_test.go
@@ -95,7 +95,7 @@ func TestKVClientRetryNonTxn(t *testing.T) {
 		Constant:    2,
 		MaxAttempts: 2,
 	})
-	kvClient := createTestNotifyClient(s.Addr)
+	kvClient := createTestNotifyClient(s.ServingAddr())
 	kvClient.User = storage.UserRoot
 
 	testCases := []struct {
@@ -210,7 +210,7 @@ func TestKVClientRetryNonTxn(t *testing.T) {
 func TestKVClientRunTransaction(t *testing.T) {
 	s := server.StartTestServer()
 	defer s.Stop()
-	kvClient := createTestNotifyClient(s.Addr)
+	kvClient := createTestNotifyClient(s.ServingAddr())
 	kvClient.TxnRetryOptions.Backoff = 1 * time.Millisecond
 	kvClient.User = storage.UserRoot
 
@@ -276,7 +276,7 @@ func TestKVClientRunTransaction(t *testing.T) {
 func TestKVClientGetAndPutProto(t *testing.T) {
 	s := server.StartTestServer()
 	defer s.Stop()
-	kvClient := createTestNotifyClient(s.Addr)
+	kvClient := createTestNotifyClient(s.ServingAddr())
 	kvClient.User = storage.UserRoot
 
 	zoneConfig := &proto.ZoneConfig{
@@ -315,7 +315,7 @@ func TestKVClientGetAndPutProto(t *testing.T) {
 func TestKVClientGetAndPut(t *testing.T) {
 	s := server.StartTestServer()
 	defer s.Stop()
-	kvClient := createTestNotifyClient(s.Addr)
+	kvClient := createTestNotifyClient(s.ServingAddr())
 	kvClient.User = storage.UserRoot
 
 	key := proto.Key("key")
@@ -345,7 +345,7 @@ func TestKVClientGetAndPut(t *testing.T) {
 func TestKVClientEmptyValues(t *testing.T) {
 	s := server.StartTestServer()
 	defer s.Stop()
-	kvClient := createTestNotifyClient(s.Addr)
+	kvClient := createTestNotifyClient(s.ServingAddr())
 	kvClient.User = storage.UserRoot
 
 	kvClient.Run(client.PutCall(proto.Key("a"), []byte{}))
@@ -380,7 +380,7 @@ func TestKVClientEmptyValues(t *testing.T) {
 func TestKVClientBatch(t *testing.T) {
 	s := server.StartTestServer()
 	defer s.Stop()
-	kvClient := createTestNotifyClient(s.Addr)
+	kvClient := createTestNotifyClient(s.ServingAddr())
 	kvClient.User = storage.UserRoot
 
 	keys := []proto.Key{}
@@ -441,11 +441,8 @@ func ExampleKV_Run1() {
 	serv := server.StartTestServer()
 	defer serv.Stop()
 
-	// Replace with actual host:port address string (ex "localhost:8080") for server cluster.
-	serverAddress := serv.Addr
-
 	// Key Value Client initialization.
-	sender, err := client.NewHTTPSender(serverAddress, "")
+	sender, err := client.NewHTTPSender(serv.ServingAddr(), "")
 	if err != nil {
 		log.Fatal(err)
 	}
@@ -487,11 +484,8 @@ func ExampleKV_RunMultiple() {
 	serv := server.StartTestServer()
 	defer serv.Stop()
 
-	// Replace with actual host:port address string (ex "localhost:8080") for server cluster.
-	serverAddress := serv.Addr
-
 	// Key Value Client initialization.
-	sender, err := client.NewHTTPSender(serverAddress, "")
+	sender, err := client.NewHTTPSender(serv.ServingAddr(), "")
 	if err != nil {
 		log.Fatal(err)
 	}
@@ -557,11 +551,8 @@ func ExampleKV_RunTransaction() {
 	serv := server.StartTestServer()
 	defer serv.Stop()
 
-	// Replace with actual host:port address string (ex "localhost:8080") for server cluster.
-	serverAddress := serv.Addr
-
 	// Key Value Client initialization.
-	sender, err := client.NewHTTPSender(serverAddress, "")
+	sender, err := client.NewHTTPSender(serv.ServingAddr(), "")
 	if err != nil {
 		log.Fatal(err)
 	}
@@ -706,7 +697,7 @@ func concurrentIncrements(kvClient *client.KV, t *testing.T) {
 func TestConcurrentIncrements(t *testing.T) {
 	s := server.StartTestServer()
 	defer s.Stop()
-	kvClient := createTestNotifyClient(s.Addr)
+	kvClient := createTestNotifyClient(s.ServingAddr())
 	kvClient.User = storage.UserRoot
 
 	// Convenience loop: Crank up this number for testing this
@@ -736,7 +727,7 @@ func setupClientBenchData(numVersions, numKeys int, b *testing.B) (*server.TestS
 		b.Fatalf("Could not start server: %v", err)
 	}
 
-	kv := createTestNotifyClient(s.Addr)
+	kv := createTestNotifyClient(s.ServingAddr())
 	kv.User = storage.UserRoot
 
 	if exists {

--- a/client/http_sender.go
+++ b/client/http_sender.go
@@ -68,10 +68,10 @@ var HTTPRetryOptions = util.RetryOptions{
 func NewHTTPClient(certsDir string) (*http.Client, error) {
 	var tlsConfig *tls.Config
 	if certsDir == "" {
-		log.Infof("no certificates directory specified: using insecure TLS")
+		log.V(1).Infof("no certificates directory specified: using insecure TLS")
 		tlsConfig = rpc.LoadInsecureClientTLSConfig().Config()
 	} else {
-		log.Infof("setting up TLS from certificates directory: %s", certsDir)
+		log.V(1).Infof("setting up TLS from certificates directory: %s", certsDir)
 		cfg, err := rpc.LoadClientTLSConfigFromDir(certsDir)
 		if err != nil {
 			return nil, util.Errorf("error setting up client TLS config: %s", err)

--- a/kv/dist_sender_server_test.go
+++ b/kv/dist_sender_server_test.go
@@ -45,7 +45,7 @@ func TestRangeLookupWithOpenTransaction(t *testing.T) {
 		t.Fatal(err)
 	}
 	defer s.Stop()
-	db := createTestClient(s.Addr)
+	db := createTestClient(s.ServingAddr())
 	db.User = storage.UserRoot
 
 	// Create an intent on the meta1 record by writing directly to the
@@ -89,7 +89,7 @@ func setupMultipleRanges(t *testing.T) (*server.TestServer, *client.KV) {
 	if err := s.Start(); err != nil {
 		t.Fatal(err)
 	}
-	db := createTestClient(s.Addr)
+	db := createTestClient(s.ServingAddr())
 	db.User = storage.UserRoot
 
 	// Split the keyspace at "b".

--- a/security/certs_test.go
+++ b/security/certs_test.go
@@ -92,8 +92,10 @@ func TestUseCerts(t *testing.T) {
 		t.Fatalf("Expected success, got %v", err)
 	}
 
-	// Start a test server with the just-generated certs.
-	s := &server.TestServer{CertDir: certsDir, Addr: "127.0.0.1:0"}
+	// Start a test server and override certs.
+	testCtx := server.NewTestContext()
+	testCtx.Certs = certsDir
+	s := &server.TestServer{Ctx: testCtx}
 	if err := s.Start(); err != nil {
 		t.Fatal(err)
 	}
@@ -101,7 +103,7 @@ func TestUseCerts(t *testing.T) {
 
 	// Try a client without certs and without InsecureSkipVerify.
 	httpClient := &http.Client{Transport: &http.Transport{TLSClientConfig: nil}}
-	req, err := http.NewRequest("GET", "https://"+s.Addr+"/_admin/health", nil)
+	req, err := http.NewRequest("GET", "https://"+s.ServingAddr()+"/_admin/health", nil)
 	if err != nil {
 		t.Fatalf("could not create request: %v", err)
 	}
@@ -116,7 +118,7 @@ func TestUseCerts(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Expected success, got %v", err)
 	}
-	req, err = http.NewRequest("GET", "https://"+s.Addr+"/_admin/health", nil)
+	req, err = http.NewRequest("GET", "https://"+s.ServingAddr()+"/_admin/health", nil)
 	if err != nil {
 		t.Fatalf("could not create request: %v", err)
 	}

--- a/server/admin_client.go
+++ b/server/admin_client.go
@@ -22,14 +22,13 @@ import (
 	"io/ioutil"
 	"net/http"
 
-	"github.com/cockroachdb/cockroach/client"
 	"github.com/cockroachdb/cockroach/util"
 )
 
 // sendAdminRequest send an HTTP request and processes the response for
 // its body or error message if a non-200 response code.
 func sendAdminRequest(ctx *Context, req *http.Request) ([]byte, error) {
-	client, err := client.NewHTTPClient(ctx.Certs)
+	client, err := ctx.GetHTTPClient()
 	if err != nil {
 		return nil, util.Errorf("failed to initialized http client: %s", err)
 	}

--- a/server/cli/cli_test.go
+++ b/server/cli/cli_test.go
@@ -48,7 +48,7 @@ func (c cliTest) Run(line string) {
 
 	var args []string
 	args = append(args, a[0])
-	args = append(args, fmt.Sprintf("-addr=%s", c.Addr))
+	args = append(args, fmt.Sprintf("-addr=%s", c.ServingAddr()))
 	// Always load server certs. Not sure if this path is a good assumption though.
 	args = append(args, fmt.Sprintf("-certs=%s",
 		path.Join(os.Getenv("GOPATH"), "src/github.com/cockroachdb/cockroach/resource/test_certs")))

--- a/server/context.go
+++ b/server/context.go
@@ -108,10 +108,10 @@ type Context struct {
 	// visited approximately once by the range scanner.
 	ScanInterval time.Duration
 
-	// HTTPClient is a lazily-initialized http client.
+	// httpClient is a lazily-initialized http client.
 	// It should be accessed through Context.GetHTTPClient() which will
 	// initialize if needed.
-	HTTPClient *http.Client
+	httpClient *http.Client
 }
 
 // NewContext returns a Context with default values.
@@ -217,10 +217,10 @@ func (ctx *Context) parseGossipBootstrapResolvers() ([]gossip.Resolver, error) {
 // In the worst case, we'll be creating more than one.
 func (ctx *Context) GetHTTPClient() (*http.Client, error) {
 	var err error
-	if ctx.HTTPClient == nil {
-		ctx.HTTPClient, err = client.NewHTTPClient(ctx.Certs)
+	if ctx.httpClient == nil {
+		ctx.httpClient, err = client.NewHTTPClient(ctx.Certs)
 	}
-	return ctx.HTTPClient, err
+	return ctx.httpClient, err
 }
 
 // parseAttributes parses a colon-separated list of strings,

--- a/server/server_test.go
+++ b/server/server_test.go
@@ -162,7 +162,7 @@ func TestSelfBootstrap(t *testing.T) {
 func TestHealth(t *testing.T) {
 	s := StartTestServer()
 	defer s.Stop()
-	url := "https://" + s.Addr + healthPath
+	url := "https://" + s.ServingAddr() + healthPath
 	resp, err := client.CreateTestHTTPClient().Get(url)
 	if err != nil {
 		t.Fatalf("error requesting health at %s: %s", url, err)
@@ -219,7 +219,7 @@ func TestAcceptEncoding(t *testing.T) {
 		},
 	}
 	for _, d := range testData {
-		req, err := http.NewRequest("GET", "https://"+s.Addr+healthPath, nil)
+		req, err := http.NewRequest("GET", "https://"+s.ServingAddr()+healthPath, nil)
 		if err != nil {
 			t.Fatalf("could not create request: %s", err)
 		}

--- a/server/status_test.go
+++ b/server/status_test.go
@@ -99,7 +99,7 @@ func TestStatusJson(t *testing.T) {
 	for _, spec := range testCases {
 		contentTypes := []string{"application/json", "application/x-protobuf", "text/yaml"}
 		for _, contentType := range contentTypes {
-			req, err := http.NewRequest("GET", "https://"+s.Addr+spec.keyPrefix, nil)
+			req, err := http.NewRequest("GET", "https://"+s.ServingAddr()+spec.keyPrefix, nil)
 			if err != nil {
 				t.Fatal(err)
 			}
@@ -166,7 +166,7 @@ func TestStatusGossipJson(t *testing.T) {
 
 	contentTypes := []string{"application/json", "application/x-protobuf", "text/yaml"}
 	for _, contentType := range contentTypes {
-		req, err := http.NewRequest("GET", "https://"+s.Addr+statusGossipKeyPrefix, nil)
+		req, err := http.NewRequest("GET", "https://"+s.ServingAddr()+statusGossipKeyPrefix, nil)
 		if err != nil {
 			t.Fatal(err)
 		}


### PR DESCRIPTION
Also use a test context in TestServer and rework address lookup.
Next step is to switch all tests to use a test context to allow http client reuse.
