### PR TITLE
Add embedded: prefix to --certs and use in tests

### DIFF
--- a/rpc/heartbeat_test.go
+++ b/rpc/heartbeat_test.go
@@ -21,7 +21,6 @@ import (
 	"testing"
 
 	"github.com/cockroachdb/cockroach/proto"
-	"github.com/cockroachdb/cockroach/security"
 	"github.com/cockroachdb/cockroach/util"
 	"github.com/cockroachdb/cockroach/util/hlc"
 )
@@ -83,13 +82,9 @@ func TestManualHeartbeat(t *testing.T) {
 }
 
 func TestUpdateOffsetOnHeartbeat(t *testing.T) {
-	tlsConfig, err := security.LoadTestTLSConfig()
-	if err != nil {
-		t.Fatal(err)
-	}
+	sContext := NewTestContext(t)
 	serverAddr := util.CreateTestAddr("tcp")
 	// Start heartbeat.
-	sContext := NewContext(hlc.NewClock(hlc.UnixNano), tlsConfig, nil)
 	s := NewServer(serverAddr, sContext)
 	if err := s.Start(); err != nil {
 		t.Fatal(err)

--- a/rpc/send_test.go
+++ b/rpc/send_test.go
@@ -23,9 +23,7 @@ import (
 	"time"
 
 	"github.com/cockroachdb/cockroach/proto"
-	"github.com/cockroachdb/cockroach/security"
 	"github.com/cockroachdb/cockroach/util"
-	"github.com/cockroachdb/cockroach/util/hlc"
 )
 
 func TestInvalidAddrLength(t *testing.T) {
@@ -43,7 +41,7 @@ func TestInvalidAddrLength(t *testing.T) {
 // TestSendToOneClient verifies that Send correctly sends a request
 // to one server using the heartbeat RPC.
 func TestSendToOneClient(t *testing.T) {
-	rpcContext := createNewTestRPCContext(t)
+	rpcContext := NewTestContext(t)
 	s := createAndStartNewServer(rpcContext, t)
 	defer s.Close()
 
@@ -65,7 +63,7 @@ func TestSendToOneClient(t *testing.T) {
 // TestSendToMultipleClients verifies that Send correctly sends
 // multiple requests to multiple server using the heartbeat RPC.
 func TestSendToMultipleClients(t *testing.T) {
-	rpcContext := createNewTestRPCContext(t)
+	rpcContext := NewTestContext(t)
 	numServers := 4
 	var addrs []net.Addr
 	for i := 0; i < numServers; i++ {
@@ -94,7 +92,7 @@ func TestSendToMultipleClients(t *testing.T) {
 // TestRetryableError verifies that Send returns a retryable error
 // when it hits an RPC error.
 func TestRetryableError(t *testing.T) {
-	rpcContext := createNewTestRPCContext(t)
+	rpcContext := NewTestContext(t)
 	s := createAndStartNewServer(rpcContext, t)
 
 	// Wait until the server becomes ready and shut down the server.
@@ -127,7 +125,7 @@ func TestRetryableError(t *testing.T) {
 // TestUnretryableError verifies that Send returns an unretryable
 // error when it hits a critical error.
 func TestUnretryableError(t *testing.T) {
-	rpcContext := createNewTestRPCContext(t)
+	rpcContext := NewTestContext(t)
 	s := createAndStartNewServer(rpcContext, t)
 
 	opts := Options{
@@ -160,7 +158,7 @@ func TestUnretryableError(t *testing.T) {
 // TestClientNotReady verifies that Send gets an RPC error when a client
 // does not become ready.
 func TestClientNotReady(t *testing.T) {
-	rpcContext := createNewTestRPCContext(t)
+	rpcContext := NewTestContext(t)
 
 	opts := Options{
 		N:               1,
@@ -199,7 +197,7 @@ func TestClientNotReady(t *testing.T) {
 // TestComplexScenarios verifies various complex success/failure scenarios by
 // mocking sendOne.
 func TestComplexScenarios(t *testing.T) {
-	rpcContext := createNewTestRPCContext(t)
+	rpcContext := NewTestContext(t)
 
 	testCases := []struct {
 		numServers               int
@@ -300,15 +298,6 @@ func TestComplexScenarios(t *testing.T) {
 			t.Errorf("%d: Unexpected error: %v", i, retryErr)
 		}
 	}
-}
-
-// createNewTestRPCContext creates an RPCContext used for test.
-func createNewTestRPCContext(t *testing.T) *Context {
-	tlsConfig, err := security.LoadTestTLSConfig()
-	if err != nil {
-		t.Fatal(err)
-	}
-	return NewContext(hlc.NewClock(hlc.UnixNano), tlsConfig, nil)
 }
 
 // createAndStartNewServer creates and starts a new server with a test address.

--- a/rpc/testing.go
+++ b/rpc/testing.go
@@ -1,0 +1,36 @@
+// Copyright 2015 The Cockroach Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+// implied. See the License for the specific language governing
+// permissions and limitations under the License. See the AUTHORS file
+// for names of contributors.
+//
+// Author: marc@cockroachlabs.com
+
+package rpc
+
+import (
+	"testing"
+
+	"github.com/cockroachdb/cockroach/security"
+	"github.com/cockroachdb/cockroach/util/hlc"
+)
+
+// NewTestContext returns a rpc.Context for testing.
+func NewTestContext(t *testing.T) *Context {
+	tlsConfig, err := security.LoadTLSConfigFromDir(security.EmbeddedPrefix + "test_certs")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	clock := hlc.NewClock(hlc.UnixNano)
+	return NewContext(clock, tlsConfig, nil)
+}

--- a/run/local-cluster.sh
+++ b/run/local-cluster.sh
@@ -105,8 +105,8 @@ for i in $(seq 1 $NODES); do
 done
 
 # Generate certs.
-docker run -d -v ${CERTS_DIR} --name=${CERTS_NAME} ${COCKROACH_IMAGE} create-ca-cert --certs=${CERTS_DIR} 2> /dev/null
-docker run --rm --volumes-from=${CERTS_NAME} ${COCKROACH_IMAGE} create-node-cert --certs=${CERTS_DIR} ${NODE_ADDRESSES} 2> /dev/null
+docker run -d -v ${CERTS_DIR} --name=${CERTS_NAME} ${COCKROACH_IMAGE} create-ca-cert -certs=${CERTS_DIR} 2> /dev/null
+docker run --rm --volumes-from=${CERTS_NAME} ${COCKROACH_IMAGE} create-node-cert -certs=${CERTS_DIR} ${NODE_ADDRESSES} 2> /dev/null
 
 # Start all nodes.
 for i in $(seq 1 $NODES); do

--- a/security/certs.go
+++ b/security/certs.go
@@ -86,7 +86,7 @@ func writeCertificateAndKey(certsDir string, prefix string,
 // to generate CA cert and key.
 func RunCreateCACert(certsDir string) error {
 	if certsDir == "" {
-		return util.Errorf("no certs directory specified, use --certs")
+		return util.Errorf("no certs directory specified, use -certs")
 	}
 
 	// Make the directory first.
@@ -109,7 +109,7 @@ func RunCreateCACert(certsDir string) error {
 // to generate node cert and key.
 func RunCreateNodeCert(certsDir string, hosts []string) error {
 	if certsDir == "" {
-		return util.Errorf("no certs directory specified, use --certs")
+		return util.Errorf("no certs directory specified, use -certs")
 	}
 	if len(hosts) == 0 {
 		return util.Errorf("no hosts specified. Need at least one")

--- a/security/tls.go
+++ b/security/tls.go
@@ -33,7 +33,7 @@ import (
 )
 
 const (
-	// EmbeddedPrefix is the prefix to the --certs arg that indicates embedded certs.
+	// EmbeddedPrefix is the prefix to the -certs arg that indicates embedded certs.
 	EmbeddedPrefix = "embedded="
 )
 

--- a/security/tls.go
+++ b/security/tls.go
@@ -33,6 +33,7 @@ import (
 )
 
 const (
+	// EmbeddedPrefix is the prefix to the --certs arg that indicates embedded certs.
 	EmbeddedPrefix = "embedded:"
 )
 

--- a/security/tls.go
+++ b/security/tls.go
@@ -34,7 +34,7 @@ import (
 
 const (
 	// EmbeddedPrefix is the prefix to the --certs arg that indicates embedded certs.
-	EmbeddedPrefix = "embedded:"
+	EmbeddedPrefix = "embedded="
 )
 
 // TLSConfig contains the TLS settings for a Cockroach node. Currently it's
@@ -60,7 +60,7 @@ func (c *TLSConfig) Config() *tls.Config {
 // - ca.crt   -- the certificate of the cluster CA
 // - node.crt -- the certificate of this node; should be signed by the CA
 // - node.key -- the private key of this node
-// If the path is prefixed with "embedded:", load the embedded certs.
+// If the path is prefixed with "embedded=", load the embedded certs.
 func LoadTLSConfigFromDir(certDir string) (*TLSConfig, error) {
 	if strings.HasPrefix(certDir, EmbeddedPrefix) {
 		return LoadTestTLSConfig(certDir[len(EmbeddedPrefix):])
@@ -81,7 +81,7 @@ func LoadTLSConfigFromDir(certDir string) (*TLSConfig, error) {
 }
 
 // LoadTestTLSConfig loads the embedded certs. This is only called from
-// LoadTLSConfigFromDir when the certdir path starts with "embedded:".
+// LoadTLSConfigFromDir when the certdir path starts with "embedded=".
 func LoadTestTLSConfig(certDir string) (*TLSConfig, error) {
 	certPEM, err := securitytest.Asset(path.Join(certDir, "node.crt"))
 	if err != nil {
@@ -158,7 +158,7 @@ func LoadClientTLSConfigFromDir(certDir string) (*TLSConfig, error) {
 }
 
 // LoadTestClientTLSConfig loads the embedded certs. This is only called from
-// LoadClientTLSConfigFromDir when the certdir path starts with "embedded:".
+// LoadClientTLSConfigFromDir when the certdir path starts with "embedded=".
 func LoadTestClientTLSConfig(certDir string) (*TLSConfig, error) {
 	caPEM, err := securitytest.Asset(path.Join(certDir, "ca.crt"))
 	if err != nil {

--- a/security/tls_test.go
+++ b/security/tls_test.go
@@ -23,7 +23,7 @@ import (
 )
 
 func TestLoadTLSConfig(t *testing.T) {
-	wrapperConfig, err := LoadTestTLSConfig()
+	wrapperConfig, err := LoadTLSConfigFromDir(EmbeddedPrefix + "test_certs")
 	if err != nil {
 		t.Fatalf("Failed to load TLS config: %v", err)
 	}

--- a/server/cli/cert.go
+++ b/server/cli/cert.go
@@ -33,7 +33,7 @@ var createCACertCmd = &commander.Command{
 	Short:     "create CA cert and key",
 	Long: `
 Generates a new key pair, a new CA certificate and writes them to
-individual files in the directory specified by --certs (required).
+individual files in the directory specified by -certs (required).
 `,
 	Run:  runCreateCACert,
 	Flag: *flag.CommandLine,
@@ -57,7 +57,7 @@ var createNodeCertCmd = &commander.Command{
 	Short:     "create node cert and key\n",
 	Long: `
 Generates a new key pair, a new node certificate and writes them to
-individual files in the directory specified by --certs (required).
+individual files in the directory specified by -certs (required).
 The certs directory should contain a CA cert and key.
 At least one host should be passed in (either IP address of dns name).
 `,

--- a/server/cli/cli_test.go
+++ b/server/cli/cli_test.go
@@ -21,9 +21,9 @@ import (
 	"fmt"
 	"log"
 	"os"
-	"path"
 	"strings"
 
+	"github.com/cockroachdb/cockroach/security"
 	"github.com/cockroachdb/cockroach/server"
 )
 
@@ -50,8 +50,7 @@ func (c cliTest) Run(line string) {
 	args = append(args, a[0])
 	args = append(args, fmt.Sprintf("-addr=%s", c.ServingAddr()))
 	// Always load server certs. Not sure if this path is a good assumption though.
-	args = append(args, fmt.Sprintf("-certs=%s",
-		path.Join(os.Getenv("GOPATH"), "src/github.com/cockroachdb/cockroach/resource/test_certs")))
+	args = append(args, fmt.Sprintf("-certs=%s", security.EmbeddedPrefix+"test_certs"))
 	args = append(args, a[1:]...)
 
 	fmt.Printf("%s\n", line)

--- a/server/node_test.go
+++ b/server/node_test.go
@@ -46,7 +46,7 @@ import (
 // not nil, the gossip bootstrap address is set to gossipBS.
 func createTestNode(addr net.Addr, engines []engine.Engine, gossipBS net.Addr, t *testing.T) (
 	*rpc.Server, *hlc.Clock, *Node, *util.Stopper) {
-	tlsConfig, err := security.LoadTestTLSConfig()
+	tlsConfig, err := security.LoadTLSConfigFromDir(security.EmbeddedPrefix + "test_certs")
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/server/server_test.go
+++ b/server/server_test.go
@@ -23,8 +23,6 @@ import (
 	"io"
 	"io/ioutil"
 	"net/http"
-	"os"
-	"path"
 	"strings"
 	"testing"
 
@@ -42,7 +40,7 @@ import (
 
 func newTestContext() *Context {
 	newContext := NewContext()
-	newContext.Certs = path.Join(os.Getenv("GOPATH"), "src/github.com/cockroachdb/cockroach/resource/test_certs")
+	newContext.Certs = security.EmbeddedPrefix + "test_certs"
 	return newContext
 }
 

--- a/server/testserver.go
+++ b/server/testserver.go
@@ -18,12 +18,11 @@
 package server
 
 import (
-	"os"
-	"path"
 	"testing"
 
 	"github.com/cockroachdb/cockroach/gossip"
 	"github.com/cockroachdb/cockroach/proto"
+	"github.com/cockroachdb/cockroach/security"
 	"github.com/cockroachdb/cockroach/storage"
 	"github.com/cockroachdb/cockroach/storage/engine"
 	"github.com/cockroachdb/cockroach/util"
@@ -56,7 +55,8 @@ func NewTestContext() *Context {
 	// uncertainty intervals.
 	ctx.MaxOffset = 0
 
-	ctx.Certs = path.Join(os.Getenv("GOPATH"), "src/github.com/cockroachdb/cockroach/resource/test_certs")
+	// Load certs from embedded files.
+	ctx.Certs = security.EmbeddedPrefix + "test_certs"
 	// Addr defaults to localhost with port set at time of call to
 	// Start() to an available port.
 	// Call TestServer.ServingAddr() for the full address (including bound port).


### PR DESCRIPTION
Add a small rpc.NewTestContext for testing.
Still a few tests that initialize tls configs, this will be combined later.
