### PR TITLE
provide and use compiled in test certs (only) in tests

### DIFF
--- a/client/main_test.go
+++ b/client/main_test.go
@@ -13,24 +13,15 @@
 // permissions and limitations under the License. See the AUTHORS file
 // for names of contributors.
 //
-// Author: marc@cockroachlabs.com
+// Author: Tobias Schottdorf (tobias.schottdorf@gmail.com)
 
-package rpc
+package client
 
 import (
-	"testing"
-
 	"github.com/cockroachdb/cockroach/security"
-	"github.com/cockroachdb/cockroach/util/hlc"
+	"github.com/cockroachdb/cockroach/security/securitytest"
 )
 
-// NewTestContext returns a rpc.Context for testing.
-func NewTestContext(t *testing.T) *Context {
-	tlsConfig, err := security.LoadTLSConfigFromDir("test_certs")
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	clock := hlc.NewClock(hlc.UnixNano)
-	return NewContext(clock, tlsConfig, nil)
+func init() {
+	security.SetReadFileFn(securitytest.Asset)
 }

--- a/kv/main_test.go
+++ b/kv/main_test.go
@@ -13,24 +13,15 @@
 // permissions and limitations under the License. See the AUTHORS file
 // for names of contributors.
 //
-// Author: marc@cockroachlabs.com
+// Author: Tobias Schottdorf (tobias.schottdorf@gmail.com)
 
-package rpc
+package kv
 
 import (
-	"testing"
-
 	"github.com/cockroachdb/cockroach/security"
-	"github.com/cockroachdb/cockroach/util/hlc"
+	"github.com/cockroachdb/cockroach/security/securitytest"
 )
 
-// NewTestContext returns a rpc.Context for testing.
-func NewTestContext(t *testing.T) *Context {
-	tlsConfig, err := security.LoadTLSConfigFromDir("test_certs")
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	clock := hlc.NewClock(hlc.UnixNano)
-	return NewContext(clock, tlsConfig, nil)
+func init() {
+	security.SetReadFileFn(securitytest.Asset)
 }

--- a/rpc/main_test.go
+++ b/rpc/main_test.go
@@ -13,24 +13,15 @@
 // permissions and limitations under the License. See the AUTHORS file
 // for names of contributors.
 //
-// Author: marc@cockroachlabs.com
+// Author: Tobias Schottdorf (tobias.schottdorf@gmail.com)
 
 package rpc
 
 import (
-	"testing"
-
 	"github.com/cockroachdb/cockroach/security"
-	"github.com/cockroachdb/cockroach/util/hlc"
+	"github.com/cockroachdb/cockroach/security/securitytest"
 )
 
-// NewTestContext returns a rpc.Context for testing.
-func NewTestContext(t *testing.T) *Context {
-	tlsConfig, err := security.LoadTLSConfigFromDir("test_certs")
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	clock := hlc.NewClock(hlc.UnixNano)
-	return NewContext(clock, tlsConfig, nil)
+func init() {
+	security.SetReadFileFn(securitytest.Asset)
 }

--- a/security/certs_test.go
+++ b/security/certs_test.go
@@ -29,6 +29,10 @@ import (
 
 // This is just the mechanics of certs generation.
 func TestGenerateCerts(t *testing.T) {
+	// Do not mock cert access for this test.
+	security.ResetReadFileFn()
+	defer security.ResetTest()
+
 	certsDir := util.CreateTempDir(t, "certs_test")
 	defer util.CleanupDir(certsDir)
 
@@ -63,6 +67,9 @@ func TestGenerateCerts(t *testing.T) {
 // This is a fairly high-level test of CA and node certificates.
 // We construct SSL server and clients and use the generated certs.
 func TestUseCerts(t *testing.T) {
+	// Do not mock cert access for this test.
+	security.ResetReadFileFn()
+	defer security.ResetTest()
 	certsDir := util.CreateTempDir(t, "certs_test")
 	defer util.CleanupDir(certsDir)
 

--- a/security/main_test.go
+++ b/security/main_test.go
@@ -13,24 +13,18 @@
 // permissions and limitations under the License. See the AUTHORS file
 // for names of contributors.
 //
-// Author: marc@cockroachlabs.com
+// Author: Tobias Schottdorf (tobias.schottdorf@gmail.com)
 
-package rpc
+package security
 
-import (
-	"testing"
+import "github.com/cockroachdb/cockroach/security/securitytest"
 
-	"github.com/cockroachdb/cockroach/security"
-	"github.com/cockroachdb/cockroach/util/hlc"
-)
+func init() {
+	ResetTest()
+}
 
-// NewTestContext returns a rpc.Context for testing.
-func NewTestContext(t *testing.T) *Context {
-	tlsConfig, err := security.LoadTLSConfigFromDir("test_certs")
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	clock := hlc.NewClock(hlc.UnixNano)
-	return NewContext(clock, tlsConfig, nil)
+// ResetTest sets up the test environment. In particular, it embeds the
+// test_certs folder and makes the tls package load from there.
+func ResetTest() {
+	SetReadFileFn(securitytest.Asset)
 }

--- a/security/tls_test.go
+++ b/security/tls_test.go
@@ -23,7 +23,7 @@ import (
 )
 
 func TestLoadTLSConfig(t *testing.T) {
-	wrapperConfig, err := LoadTLSConfigFromDir(EmbeddedPrefix + "test_certs")
+	wrapperConfig, err := LoadTLSConfigFromDir("test_certs")
 	if err != nil {
 		t.Fatalf("Failed to load TLS config: %v", err)
 	}

--- a/server/cli/cli_test.go
+++ b/server/cli/cli_test.go
@@ -23,7 +23,6 @@ import (
 	"os"
 	"strings"
 
-	"github.com/cockroachdb/cockroach/security"
 	"github.com/cockroachdb/cockroach/server"
 )
 
@@ -49,8 +48,8 @@ func (c cliTest) Run(line string) {
 	var args []string
 	args = append(args, a[0])
 	args = append(args, fmt.Sprintf("-addr=%s", c.ServingAddr()))
-	// Always load server certs. Not sure if this path is a good assumption though.
-	args = append(args, fmt.Sprintf("-certs=%s", security.EmbeddedPrefix+"test_certs"))
+	// Always load test certs.
+	args = append(args, fmt.Sprintf("-certs=%s", "test_certs"))
 	args = append(args, a[1:]...)
 
 	fmt.Printf("%s\n", line)

--- a/server/cli/main_test.go
+++ b/server/cli/main_test.go
@@ -13,24 +13,15 @@
 // permissions and limitations under the License. See the AUTHORS file
 // for names of contributors.
 //
-// Author: marc@cockroachlabs.com
+// Author: Tobias Schottdorf (tobias.schottdorf@gmail.com)
 
-package rpc
+package cli
 
 import (
-	"testing"
-
 	"github.com/cockroachdb/cockroach/security"
-	"github.com/cockroachdb/cockroach/util/hlc"
+	"github.com/cockroachdb/cockroach/security/securitytest"
 )
 
-// NewTestContext returns a rpc.Context for testing.
-func NewTestContext(t *testing.T) *Context {
-	tlsConfig, err := security.LoadTLSConfigFromDir("test_certs")
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	clock := hlc.NewClock(hlc.UnixNano)
-	return NewContext(clock, tlsConfig, nil)
+func init() {
+	security.SetReadFileFn(securitytest.Asset)
 }

--- a/server/main_test.go
+++ b/server/main_test.go
@@ -13,24 +13,15 @@
 // permissions and limitations under the License. See the AUTHORS file
 // for names of contributors.
 //
-// Author: marc@cockroachlabs.com
+// Author: Tobias Schottdorf (tobias.schottdorf@gmail.com)
 
-package rpc
+package server
 
 import (
-	"testing"
-
 	"github.com/cockroachdb/cockroach/security"
-	"github.com/cockroachdb/cockroach/util/hlc"
+	"github.com/cockroachdb/cockroach/security/securitytest"
 )
 
-// NewTestContext returns a rpc.Context for testing.
-func NewTestContext(t *testing.T) *Context {
-	tlsConfig, err := security.LoadTLSConfigFromDir("test_certs")
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	clock := hlc.NewClock(hlc.UnixNano)
-	return NewContext(clock, tlsConfig, nil)
+func init() {
+	security.SetReadFileFn(securitytest.Asset)
 }

--- a/server/node_test.go
+++ b/server/node_test.go
@@ -46,7 +46,10 @@ import (
 // not nil, the gossip bootstrap address is set to gossipBS.
 func createTestNode(addr net.Addr, engines []engine.Engine, gossipBS net.Addr, t *testing.T) (
 	*rpc.Server, *hlc.Clock, *Node, *util.Stopper) {
-	tlsConfig, err := security.LoadTLSConfigFromDir(security.EmbeddedPrefix + "test_certs")
+	// Load the TLS config from our test certs. They're embedded in the
+	// test binary and calls to the file system have been mocked out,
+	// see main_test.go.
+	tlsConfig, err := security.LoadTLSConfigFromDir("test_certs")
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/server/server_test.go
+++ b/server/server_test.go
@@ -40,7 +40,8 @@ import (
 
 func newTestContext() *Context {
 	newContext := NewContext()
-	newContext.Certs = security.EmbeddedPrefix + "test_certs"
+	// The certs are compiled in, see main_test.go.
+	newContext.Certs = "test_certs"
 	return newContext
 }
 

--- a/server/testserver.go
+++ b/server/testserver.go
@@ -22,7 +22,6 @@ import (
 
 	"github.com/cockroachdb/cockroach/gossip"
 	"github.com/cockroachdb/cockroach/proto"
-	"github.com/cockroachdb/cockroach/security"
 	"github.com/cockroachdb/cockroach/storage"
 	"github.com/cockroachdb/cockroach/storage/engine"
 	"github.com/cockroachdb/cockroach/util"
@@ -55,8 +54,12 @@ func NewTestContext() *Context {
 	// uncertainty intervals.
 	ctx.MaxOffset = 0
 
-	// Load certs from embedded files.
-	ctx.Certs = security.EmbeddedPrefix + "test_certs"
+	// Load test certs. In addition, the tests requiring certs
+	// need to call security.SetReadFileFn(securitytest.Asset)
+	// in their init to mock out the file system calls for calls to AssetFS,
+	// which has the test certs compiled in. Typically this is done
+	// once per package, in main_test.go.
+	ctx.Certs = "test_certs"
 	// Addr defaults to localhost with port set at time of call to
 	// Start() to an available port.
 	// Call TestServer.ServingAddr() for the full address (including bound port).

--- a/storage/main_test.go
+++ b/storage/main_test.go
@@ -20,10 +20,16 @@ package storage
 import (
 	"testing"
 
+	"github.com/cockroachdb/cockroach/security"
+	"github.com/cockroachdb/cockroach/security/securitytest"
 	"github.com/cockroachdb/cockroach/util/leaktest"
 )
 
 //go:generate ../util/leaktest/add-leaktest.sh *_test.go
+
+func init() {
+	security.SetReadFileFn(securitytest.Asset)
+}
 
 func TestMain(m *testing.M) {
 	leaktest.TestMainWithLeakCheck(m)


### PR DESCRIPTION
this allows tests to run without external dependencies while avoiding compiled-in testdata in the main build.
