### PR TITLE
Miscellaneous changes.

### DIFF
--- a/client/client_test.go
+++ b/client/client_test.go
@@ -730,7 +730,7 @@ func setupClientBenchData(numVersions, numKeys int, b *testing.B) (*server.TestS
 		b.Fatalf("Could not start server: %v", err)
 	}
 
-	kv := createTestNotifyClient(s.ServingAddr())
+	kv := client.NewKV(nil, client.CreateTestHTTPSender(s.ServingAddr()))
 	kv.User = storage.UserRoot
 
 	if exists {

--- a/kv/txn_coord_sender.go
+++ b/kv/txn_coord_sender.go
@@ -296,7 +296,7 @@ func (tc *TxnCoordSender) sendOne(call client.Call) {
 		tc.cleanupTxn(&t.Txn, nil)
 	case *proto.OpRequiresTxnError:
 		// Run a one-off transaction with that single command.
-		log.Infof("%s: auto-wrapping in txn and re-executing", call.Method())
+		log.V(1).Infof("%s: auto-wrapping in txn and re-executing", call.Method())
 		txnOpts := &client.TransactionOptions{
 			Name: "auto-wrap",
 		}


### PR DESCRIPTION
Don't use a notifying client in the scan benchmark. Place a verbose log
message about "auto-wrapping in txn" under V(1).
