### PR TITLE
Properly copy the replicas from the range descriptor.

### DIFF
--- a/kv/dist_sender.go
+++ b/kv/dist_sender.go
@@ -386,8 +386,7 @@ func (ds *DistSender) sendRPC(desc *proto.RangeDescriptor,
 	}
 
 	// Copy and rearrange the replicas suitably, then return the desired order.
-	replicas := proto.ReplicaSlice(append(make([]proto.Replica,
-		len(desc.Replicas)), desc.Replicas...))
+	replicas := proto.ReplicaSlice(append([]proto.Replica(nil), desc.Replicas...))
 	// Rearrange the replicas so that those replicas with long common
 	// prefix of attributes end up first. If there's no prefix, this is a
 	// no-op.


### PR DESCRIPTION
The previous code was prefixing the copied range descriptors with
num-replicas "zero" replicas. The lookup of the replica address in the
gossip info for NodeID 0 was actually showing up in benchmarks. The
below numbers were gathered using RPCSender, but a similar speedup
occurs for the HTTPSender.

benchmark                           old ns/op     new ns/op     delta
BenchmarkClientScan1Version1Row     359020        340027        -5.29%

benchmark                           old MB/s     new MB/s     speedup
BenchmarkClientScan1Version1Row     2.85         3.01         1.06x
