### PR TITLE
up some timeouts for recent (presumed) test flukes

### DIFF
--- a/kv/dist_sender_server_test.go
+++ b/kv/dist_sender_server_test.go
@@ -75,7 +75,7 @@ func TestRangeLookupWithOpenTransaction(t *testing.T) {
 	select {
 	case <-success:
 		// Hurrah!
-	case <-time.After(1 * time.Second):
+	case <-time.After(5 * time.Second):
 		t.Errorf("get request did not succeed in face of range metadata intent")
 	}
 }

--- a/kv/local_test_cluster.go
+++ b/kv/local_test_cluster.go
@@ -31,7 +31,6 @@ import (
 	"github.com/cockroachdb/cockroach/storage/engine"
 	"github.com/cockroachdb/cockroach/util"
 	"github.com/cockroachdb/cockroach/util/hlc"
-	"github.com/cockroachdb/cockroach/util/log"
 	gogoproto "github.com/gogo/protobuf/proto"
 )
 
@@ -83,7 +82,8 @@ func (rls *retryableLocalSender) Send(call client.Call) {
 		return util.RetryBreak, nil
 	})
 	if err != nil {
-		log.Fatalf("local sender did not succeed on two attempts: %s", err)
+		panic(fmt.Sprintf("local sender did not succeed on two attempts: %s",
+			err))
 	}
 }
 

--- a/rpc/send_test.go
+++ b/rpc/send_test.go
@@ -132,7 +132,7 @@ func TestUnretryableError(t *testing.T) {
 		N:               1,
 		Ordering:        OrderStable,
 		SendNextTimeout: 1 * time.Second,
-		Timeout:         1 * time.Second,
+		Timeout:         5 * time.Second,
 	}
 	getArgs := func(addr net.Addr) interface{} {
 		return &proto.PingRequest{}


### PR DESCRIPTION
closes #747, closes #774
closes #770 (well, not really, but at least the next time there'll be a stack trace)
