### PR TITLE
Bind to localhost instead of 0.0.0.0 in tests.

### DIFF
--- a/security/certs_test.go
+++ b/security/certs_test.go
@@ -96,7 +96,7 @@ func TestUseCerts(t *testing.T) {
 	// We use a real context since we want generated certs.
 	testCtx := server.NewContext()
 	testCtx.Certs = certsDir
-	testCtx.Addr = ":0"
+	testCtx.Addr = "127.0.0.1:0"
 	s := &server.TestServer{Ctx: testCtx}
 	if err := s.Start(); err != nil {
 		t.Fatal(err)


### PR DESCRIPTION
This silences a firewall warning on macs.
