### PR TITLE
Simplify Feed System

### DIFF
--- a/util/feed.go
+++ b/util/feed.go
@@ -17,85 +17,17 @@
 
 package util
 
-import "sync"
+import (
+	"sync"
 
-// A feedEntry represents a single entry in a feed. A feed entry usually an
-// event published to the feed, but may also be a management action used by the
-// feed itself to manage subscribers.
-//
-// Each feedEntry structure is a node in a "linked channel", which is analogous
-// to a linked list but using channels instead of pointers. Each feedEntry
-// contains a channel which can be used to get the next feedEntry in the
-// sequence.
-//
-// The "linked channel" is designed to be traversed by multiple consumers
-// simultaneously, with each consumer visiting each entry once. This is
-// accomplished with the following algorithm:
-//
-// 1. Each consumer attempts to read the next feedEntry from the "next" channel
-// of the last feedEntry.
-// 2. When the next entry is placed into the channel, one consumer will actually
-// obtain it.
-// 3. The obtaining consumer copies the values from the feedEntry, and
-// immediately places it back into the channel from which it was obtained. This
-// will allow another waiting consumer to obtain it.
-// 4. The obtaining consumer returns to step 1, but now reads from the
-// "next" channel of the feedEntry it had just obtained.
-//
-// Code example:
-//
-//		func traverseLinkedChannel(next chan *feedEntry) {
-//			for {
-//				nextEntry := <-next
-//				// Copy values from nextEntry
-//				last := next
-//				next = nextEntry.next
-//				last <- nextEntry
-//			}
-//		}
-//
-// The "next" channel of each feedEntry is given a buffer size of one. Since
-// that channel will only ever contain one feedEntry, the act of placing an
-// entry back into the channel can never block, meaning that consumers cannot
-// block each other as long as they behave correctly.
-//
-// The above implementation is sufficient for a linked channel: each consumer
-// will read each entry in the feed, after which the garbage collector would
-// clean up any entries which have been read by all subscribers.
-//
-// However, in order to improve memory performance each feedEntry maintains a
-// reference counter to determine when it can be safely returned to a shared
-// pool.
-type feedEntry struct {
-	entryType entryType
-	value     interface{}
-	next      chan *feedEntry
-
-	// consumerCount is the number of subscribers still waiting to receive this
-	// entry. This is a reference counter used to determine when entries can be
-	// released to the entry pool; however, an entry is not released when its
-	// own consumerCount is zero, but rather when the consumerCount of the
-	// *next* entry in the linked channel is zero. When the next entry has zero
-	// remaining consumers, that signifies that no more consumers are listening
-	// on the next channel of this entry, and thus it can be released.
-	consumerCount int
-}
-
-type entryType int
-
-const (
-	valueEntry entryType = iota
-	unsubEntry
-	closedEntry
+	"github.com/cockroachdb/cockroach/util/log"
 )
 
-var feedEntryPool = sync.Pool{
-	New: func() interface{} {
-		return &feedEntry{
-			next: make(chan *feedEntry, 1),
-		}
-	},
-}
+// subscriptionChannelSize is the buffer size of the Events channel for each
+// subscriber. This value is fairly large for a channel, and is used to ensure
+// that writing to a subscriber channel will not block under normal
+// circumstances.
+const subscriptionChannelSize = 2048
 
 // A Subscription is used to receive events from a specific Feed. A Subscription
 // should only be instantiated via a call to a Feed's Subscribe() method. Once
@@ -105,30 +37,26 @@ var feedEntryPool = sync.Pool{
 // An example of a typical usage of a Subscription:
 //
 //		subscriber := feed.Subscribe()
-//		for {
-//			select {
-//			case event, ok := <-subscriber.Events:
-//				// Process event...
-//			}
+//		for event := range subscriber.Events() {
+//			// Process event...
 //		}
 //
 // A Subscription cannot block other Subscriptions to the same feed, and each
-// Subscription will receive all events published by the Feed. A user of a
+// Subscription will receive all events published by the Feed. The user of a
 // Subscription should not modify Events received over the channel.
 //
-// A Subscription can be closed via the Unsubscribe() method.
-//
-// If the Feed is stopped, the Events channel will be closed after reading all
-// remaining events that were published to the Feed before it was stopped.
+// A Subscription can be closed via the Unsubscribe() method, which will result
+// in the Events channel being closed. The Events channel will also be closed if
+// the Feed itself is closed.
 type Subscription struct {
-	Events <-chan interface{}
-	closer chan<- struct{}
+	feed   *Feed
+	events chan interface{}
 }
 
-// Unsubscribe immediately stops the given Subscriber. After this method is
-// called, the Events channel will be closed.
-func (s *Subscription) Unsubscribe() {
-	close(s.closer)
+// Events returns a recieve only channel for reading events from this
+// Subscriber.
+func (s *Subscription) Events() <-chan interface{} {
+	return s.events
 }
 
 // A Feed is used to publish a stream of events to a set of Subscribers.  Events
@@ -140,109 +68,45 @@ func (s *Subscription) Unsubscribe() {
 // blocked by Subscriber activities and will always return quickly.  Subscribers
 // receive events by reading from their Events channel.
 //
-// The Feed will continue running until its associated Stopper is closed.
+// A Feed can be initialized by simply instantiating an empty feed object:
 //
-// The Feed's non-blocking properties are achieved with a linked channel instead
-// of buffered channels, and thus there is no limit (other than available
-// memory) to how many unread events the Feed can maintain. This is desirable
-// for Feeds which may publish data in quick bursts.
+//		feed := &Feed{}
+//		subscriber := feed.Subscribe()
+//		feed.Publish(someEvent())
 //
 // The Feed does not keep historical events; individual Subscribers will only
-// receive events published after they subscribe.
+// receive events published after they Subscribe. Events can be published to a
+// Feed until its Close() method is called.
+//
+// The non-blocking property of the feed is achieved by giving each Subscriber's
+// Events channel a very large buffer. If a Subscriber does not read from its
+// channel, then its buffer will fill; if a call to Publish() attempts to write
+// to a full Subscriber channel, it will panic.
 type Feed struct {
-	events  chan interface{}
-	stopper *Stopper
-
-	// subscriberCount counts the total number of subscribers that have
-	// ever been started. activeCount counts the number of subscribers still
-	// active (i.e. that have not been unsubscribed).
-	subscriberCount int
-	activeCount     int
-
-	// these channels are used for synchronizing different subscription
-	// lifecycle tasks.
-	subscribe   chan *publisher
-	unsubscribe chan *publisher
-	closed      chan struct{}
-}
-
-// StartFeed instatiates and starts a new Feed. The Feed can immediately accept
-// Subscribers and publish events.
-func StartFeed(stopper *Stopper) *Feed {
-	f := &Feed{
-		events:      make(chan interface{}),
-		stopper:     stopper,
-		subscribe:   make(chan *publisher),
-		unsubscribe: make(chan *publisher),
-		closed:      make(chan struct{}),
-	}
-	stopper.RunWorker(func() {
-		// head is the most recent entry added to the feed. This is also the
-		// current head of the linked channel of entries. The first entry
-		// will never be consumed by any subscribers, but initial
-		// subscribers may listen on its "next" channel.
-		head := feedEntryPool.Get().(*feedEntry)
-		// addEntry is used to correctly add a new entry to the linked channel.
-		addEntry := func(et entryType, value interface{}) {
-			entry := feedEntryPool.Get().(*feedEntry)
-			entry.entryType = et
-			entry.consumerCount = f.activeCount
-			switch et {
-			case valueEntry:
-				entry.value = value
-			case unsubEntry:
-				entry.value = value.(int)
-			}
-			head.next <- entry
-			head = entry
-		}
-		for {
-			select {
-			case pub := <-f.subscribe:
-				// A new Subscription is requested, and we have received the
-				// publisher associated with it. Give the publisher the channel
-				// for the next entry and start it's process() goroutine.
-				f.subscriberCount++
-				f.activeCount++
-				pub.id = f.subscriberCount
-				pub.current = head
-				stopper.RunWorker(pub.process)
-			case pub := <-f.unsubscribe:
-				// A Subscription has unsubscribed; ackowledge this with an
-				// "unsubscribed" entry and decrease the number of activeSubs
-				// for future entries.
-				addEntry(unsubEntry, pub.id)
-				f.activeCount--
-			case event := <-f.events:
-				// A new event has been published to the feed, which will
-				// eventually be read by all active subscribers.
-				if f.activeCount == 0 {
-					break
-				}
-				addEntry(valueEntry, event)
-			case <-stopper.ShouldStop():
-				// The stopper has been activated and the feed should cease.
-				if f.activeCount != 0 {
-					// Add a 'closed' entry to the linked channel, which will
-					// cause consuming publishers to stop.
-					addEntry(closedEntry, nil)
-				}
-				close(f.closed)
-				return
-			}
-		}
-	})
-	return f
+	sync.Mutex
+	closed      bool
+	subscribers []*Subscription
 }
 
 // Publish publishes a event into the Feed, which will eventually be received by
-// all Subscribers to the feed. Publishing to a closed feed will panic.
+// all Subscribers to the feed. Events published to a closed feed, or to a feed
+// with no Subscribers, will be ignored.
 func (f *Feed) Publish(event interface{}) {
-	select {
-	case f.events <- event:
-		// Event was successfully published.
-	case <-f.closed:
-		panic("attempt to publish value to a closed Feed")
+	f.Lock()
+	defer f.Unlock()
+	if f.closed || len(f.subscribers) == 0 {
+		return
+	}
+
+	for _, sub := range f.subscribers {
+		select {
+		case sub.events <- event:
+			// Subscription successfully sent.
+		default:
+			// Subscription buffer was exceeded; this is a panic situation.
+			log.Fatalf("event subscriber had full buffer, %d entries unread.",
+				subscriptionChannelSize)
+		}
 	}
 }
 
@@ -251,122 +115,51 @@ func (f *Feed) Publish(event interface{}) {
 //
 // Events are read from the Subscription's Events channel. Subscribers cannot
 // block each other from receiving events, but should still attempt to consume
-// events in a timely fashion; the Feed will not release the memory for an
-// individual event until every Subscriber has seen it.
-//
-// Attempting to subscribe to a closed Feed will panic.
+// events in a timely fashion; if a Subscriber's (very large) Events channel
+// fills up, a panic may result.
 func (f *Feed) Subscribe() *Subscription {
-	// events and closer are used to manage the interaction between a
-	// Subscription and its backing publisher.
-	events := make(chan interface{})
-	closer := make(chan struct{})
 	sub := &Subscription{
-		Events: events,
-		closer: closer,
-	}
-	p := &publisher{
-		events: events,
-		closer: closer,
 		feed:   f,
+		events: make(chan interface{}, subscriptionChannelSize),
 	}
-	select {
-	case f.subscribe <- p:
-		// Subscription was successfully logged.
-	case <-f.closed:
-		panic("attempt to publish value to a closed Feed")
+
+	f.Lock()
+	defer f.Unlock()
+	if !f.closed {
+		f.subscribers = append(f.subscribers, sub)
+	} else {
+		close(sub.events)
 	}
 	return sub
 }
 
-// A publisher reads values from a Feed and passes them to a Subscriber; each
-// Subscriber is backed by a publisher. The publisher correctly reads from the
-// linked channel provided by the Feed, ensuring that other publishers cannot be
-// blocked.
-type publisher struct {
-	id      int
-	current *feedEntry
-	events  chan<- interface{}
-	closer  <-chan struct{}
-	feed    *Feed
+// Close closes the given Feed. All existing Subscribers will be closed
+// immediately when the Feed is closed. After closure, any new Subscribers will
+// be closed immediately and attempts to Publish will be ignored.
+func (f *Feed) Close() {
+	f.Lock()
+	defer f.Unlock()
+	if !f.closed {
+		f.closed = true
+		for _, sub := range f.subscribers {
+			close(sub.events)
+		}
+		f.subscribers = nil
+	}
 }
 
-// process is a method which reads the linked channel provided by a Feed,
-// passing relevant events to a Subscription. It is
-// intended to be run as a goroutine.
-func (p *publisher) process() {
-	// If the Subscriber has unsubscribed, the publisher must still
-	// read events from the Feed until the unsubscription event has
-	// been acknowledged by the Feed: this ensures that each
-	// feedEntry reaches its consumerCount count and is returned to
-	// the pool. This is the 'draining' phase, during which the publisher
-	// reads events but no longer sends them to the subscriber.
-	draining := false
-	// readEntry is called on every entry read from the next channel of the
-	// current entry. This method properly maintains the consumerCount
-	// reference counter on feedEntries.
-	readEntry := func(entry *feedEntry) {
-		entry.consumerCount--
-		if entry.consumerCount > 0 {
-			// The next entry still has remaining consumers, so place it
-			// back on the 'next' channel of the current entry. Buffer size
-			// is 1, so this will not block.
-			p.current.next <- entry
-		} else {
-			// The next entry has no remaining consumers, and thus nothing
-			// is listening on the 'next' channel of the current entry.
-			// Release the current entry to the entry pool.
-			feedEntryPool.Put(p.current)
-		}
-		p.current = entry
-	}
-	for !draining {
-		select {
-		case entry := <-p.current.next:
-			readEntry(entry)
-			switch p.current.entryType {
-			case valueEntry:
-				select {
-				case p.events <- p.current.value:
-					// Event successfully sent.
-				case <-p.closer:
-					// Prevent blocking if the subscriber has stopped
-					// reading events in order to close.
-				}
-			case closedEntry:
-				// The Feed has been closed.
-				close(p.events)
-				return
+// Unsubscribe stops the Subscriber. This will close the Subscriber's Events
+// channel; however, there may still be unprocessed Events remaining in the
+// channel.
+func (s *Subscription) Unsubscribe() {
+	s.feed.Lock()
+	defer s.feed.Unlock()
+	if !s.feed.closed {
+		for i, sub := range s.feed.subscribers {
+			if s == sub {
+				s.feed.subscribers = append(s.feed.subscribers[:i], s.feed.subscribers[i+1:]...)
+				break
 			}
-		case <-p.closer:
-			// The Subscriber wants to initiate a closure. Inform the Feed of
-			// the unsubscription, close the channel to the Subscription and
-			// begin draining.
-			select {
-			case p.feed.unsubscribe <- p:
-				// Successfully unsubscribed.
-			case <-p.feed.closed:
-				// Feed closed first - this might happen due to a race a
-				// shutdown scenario. The publisher will simply run until the
-				// inevitable 'closed' entry stops this publisher.
-			}
-			draining = true
-		}
-	}
-	for {
-		entry := <-p.current.next
-		readEntry(entry)
-		switch p.current.entryType {
-		case unsubEntry:
-			if p.current.value.(int) == p.id {
-				// The feed has acknowledged that this subscriber has
-				// unsubscriber. The publisher can safely stop.
-				close(p.events)
-				return
-			}
-		case closedEntry:
-			// The Feed has been closed.
-			close(p.events)
-			return
 		}
 	}
 }

--- a/util/feed_example_test.go
+++ b/util/feed_example_test.go
@@ -23,14 +23,14 @@ import (
 
 func ExampleFeed() {
 	stopper := NewStopper()
-	feed := StartFeed(stopper)
+	feed := Feed{}
 
 	output := make([][]string, 5)
 	for i := 0; i < len(output); i++ {
 		sub := feed.Subscribe()
 		index := i
 		stopper.RunWorker(func() {
-			for event := range sub.Events {
+			for event := range sub.Events() {
 				// events must be cast from interface{}
 				output[index] = append(output[index], event.(string))
 			}
@@ -40,6 +40,7 @@ func ExampleFeed() {
 	feed.Publish("Event 1")
 	feed.Publish("Event 2")
 	feed.Publish("Event 3")
+	feed.Close()
 	stopper.Stop()
 
 	<-stopper.IsStopped()


### PR DESCRIPTION
While investigating the addition of feeds to the Store system, two requirements
came under scrutiny:
1. We must be able to subscribe to a feed before it 'starts'.
2. It is NOT necessary for StoreEventFeed to maintain commitable batches.

The second requirement was repaired by removing StoreEventFeed's newBatch method
and associated structures, a significant simplification.

The first requirement was solved by converting feeds to a simpler "Big Channel"
model, where each Subscriber maintains a very large buffer for its channel of
events. This is a dramatic simplification; Feeds no longer need to be started,
and no additional goroutines are created to service them.

While it's possible that this new setup could panic if a Subscriber
doesn't read its channel, this kind of performance should not be a concern at
the frequency we are intending to publish events.
