### PR TITLE
A small fix: Make the scan interval configurable for BootstrapCluster

### DIFF
--- a/kv/rest_test.go
+++ b/kv/rest_test.go
@@ -53,7 +53,7 @@ func startServer(t *testing.T) (string, *client.KV, *util.Stopper) {
 	// Initialize engine, store, and localDB.
 	e := engine.NewInMem(proto.Attributes{}, 1<<20)
 	stopper := util.NewStopper()
-	db, err := server.BootstrapCluster("test-cluster", e, stopper)
+	db, err := server.BootstrapCluster("test-cluster", e, server.NewContext(), stopper)
 	if err != nil {
 		t.Fatalf("could not bootstrap test cluster: %s", err)
 	}

--- a/server/admin_test.go
+++ b/server/admin_test.go
@@ -39,7 +39,7 @@ import (
 // Cockroach KV client address is set to the address of the test server.
 func startAdminServer() (string, *util.Stopper) {
 	stopper := util.NewStopper()
-	db, err := BootstrapCluster("cluster-1", engine.NewInMem(proto.Attributes{}, 1<<20), stopper)
+	db, err := BootstrapCluster("cluster-1", engine.NewInMem(proto.Attributes{}, 1<<20), testContext, stopper)
 	if err != nil {
 		log.Fatal(err)
 	}

--- a/server/cli/start.go
+++ b/server/cli/start.go
@@ -70,11 +70,17 @@ func runInit(cmd *commander.Command, args []string) {
 		return
 	}
 
+	err := Context.Init()
+	if err != nil {
+		log.Errorf("failed to initialize context: %s", err)
+		return
+	}
+
 	// Generate a new UUID for cluster ID and bootstrap the cluster.
 	clusterID := uuid.New()
 	e := engine.NewRocksDB(proto.Attributes{}, args[0], 1<<20)
 	stopper := util.NewStopper()
-	if _, err := server.BootstrapCluster(clusterID, e, stopper); err != nil {
+	if _, err := server.BootstrapCluster(clusterID, e, Context, stopper); err != nil {
 		log.Errorf("unable to bootstrap cluster: %s", err)
 		return
 	}

--- a/server/node_test.go
+++ b/server/node_test.go
@@ -103,7 +103,7 @@ func formatKeys(keys []proto.Key) string {
 func TestBootstrapCluster(t *testing.T) {
 	stopper := util.NewStopper()
 	e := engine.NewInMem(proto.Attributes{}, 1<<20)
-	localDB, err := BootstrapCluster("cluster-1", e, stopper)
+	localDB, err := BootstrapCluster("cluster-1", e, testContext, stopper)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -150,7 +150,7 @@ func TestBootstrapCluster(t *testing.T) {
 func TestBootstrapNewStore(t *testing.T) {
 	stopper := util.NewStopper()
 	e := engine.NewInMem(proto.Attributes{}, 1<<20)
-	_, err := BootstrapCluster("cluster-1", e, stopper)
+	_, err := BootstrapCluster("cluster-1", e, testContext, stopper)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -189,7 +189,7 @@ func TestBootstrapNewStore(t *testing.T) {
 func TestNodeJoin(t *testing.T) {
 	stopper := util.NewStopper()
 	e := engine.NewInMem(proto.Attributes{}, 1<<20)
-	_, err := BootstrapCluster("cluster-1", e, stopper)
+	_, err := BootstrapCluster("cluster-1", e, testContext, stopper)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -238,7 +238,7 @@ func TestNodeJoin(t *testing.T) {
 func TestCorruptedClusterID(t *testing.T) {
 	stopper := util.NewStopper()
 	e := engine.NewInMem(proto.Attributes{}, 1<<20)
-	_, err := BootstrapCluster("cluster-1", e, stopper)
+	_, err := BootstrapCluster("cluster-1", e, testContext, stopper)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/server/status_test.go
+++ b/server/status_test.go
@@ -41,7 +41,7 @@ import (
 // Cockroach KV client address is set to the address of the test server.
 func startStatusServer() (*httptest.Server, *util.Stopper) {
 	stopper := util.NewStopper()
-	db, err := BootstrapCluster("cluster-1", engine.NewInMem(proto.Attributes{}, 1<<20), stopper)
+	db, err := BootstrapCluster("cluster-1", engine.NewInMem(proto.Attributes{}, 1<<20), testContext, stopper)
 	if err != nil {
 		log.Fatal(err)
 	}

--- a/server/testserver.go
+++ b/server/testserver.go
@@ -126,7 +126,7 @@ func (ts *TestServer) Start() error {
 	ts.Ctx.Engines = []engine.Engine{ts.Engine}
 	if !ts.SkipBootstrap {
 		stopper := util.NewStopper()
-		_, err := BootstrapCluster("cluster-1", ts.Engine, stopper)
+		_, err := BootstrapCluster("cluster-1", ts.Engine, ts.Ctx, stopper)
 		if err != nil {
 			return util.Errorf("could not bootstrap cluster: %s", err)
 		}

--- a/structured/db_test.go
+++ b/structured/db_test.go
@@ -35,7 +35,7 @@ func TestPutGetDeleteSchema(t *testing.T) {
 	stopper := util.NewStopper()
 	defer stopper.Stop()
 	e := engine.NewInMem(proto.Attributes{}, 1<<20)
-	localDB, err := server.BootstrapCluster("test-cluster", e, stopper)
+	localDB, err := server.BootstrapCluster("test-cluster", e, server.NewTestContext(), stopper)
 	if err != nil {
 		t.Fatalf("unable to boostrap cluster: %v", err)
 	}


### PR DESCRIPTION
Change `runInit()` to pass a `Context` to `BootstrapCluster()`.
