### PR TITLE
enforce only one copy of replica

### DIFF
--- a/storage/client_test.go
+++ b/storage/client_test.go
@@ -96,34 +96,15 @@ func createTestStoreWithEngine(t *testing.T, eng engine.Engine, clock *hlc.Clock
 	return store, stopper
 }
 
-type multiLocalSender struct {
-	senders map[int]*kv.LocalSender
-}
-
-func (mls *multiLocalSender) get(index int) *kv.LocalSender {
-	if _, ok := mls.senders[index]; !ok {
-		mls.set(index, kv.NewLocalSender())
-	}
-	return mls.senders[index]
-}
-
-func (mls *multiLocalSender) set(index int, s *kv.LocalSender) {
-	if mls.senders == nil {
-		mls.senders = make(map[int]*kv.LocalSender)
-	}
-	mls.senders[index] = s
-}
-
 type multiTestContext struct {
 	t           *testing.T
 	manualClock *hlc.ManualClock
 	clock       *hlc.Clock
 	gossip      *gossip.Gossip
-	sender      *kv.LocalSender
-	multisender *multiLocalSender
 	transport   multiraft.Transport
 	db          *client.KV
 	engines     []engine.Engine
+	senders     []*kv.LocalSender
 	stores      []*storage.Store
 	idents      []proto.StoreIdent
 	// We use multiple stoppers so we can restart different parts of the
@@ -159,18 +140,15 @@ func (m *multiTestContext) Start(t *testing.T, numStores int) {
 		m.transport = multiraft.NewLocalRPCTransport()
 	}
 
-	if m.sender == nil {
-		m.sender = kv.NewLocalSender()
-	}
-
-	m.multisender = &multiLocalSender{}
-	m.multisender.set(0, m.sender)
-
 	if m.clientStopper == nil {
 		m.clientStopper = util.NewStopper()
 	}
+
+	// Always create the first sender.
+	m.senders = append(m.senders, kv.NewLocalSender())
+
 	if m.db == nil {
-		txnSender := kv.NewTxnCoordSender(m.multisender.get(0), m.clock, false, m.clientStopper)
+		txnSender := kv.NewTxnCoordSender(m.senders[0], m.clock, false, m.clientStopper)
 		m.db = client.NewKV(nil, txnSender)
 		m.db.User = storage.UserRoot
 	}
@@ -247,7 +225,10 @@ func (m *multiTestContext) addStore(t *testing.T) {
 		t.Fatal(err)
 	}
 	m.stores = append(m.stores, store)
-	m.multisender.get(idx).AddStore(store)
+	if len(m.senders) == idx {
+		m.senders = append(m.senders, kv.NewLocalSender())
+	}
+	m.senders[idx].AddStore(store)
 	// Save the store identities for later so we can use them in
 	// replication operations even while the store is stopped.
 	m.idents = append(m.idents, store.Ident)
@@ -257,7 +238,7 @@ func (m *multiTestContext) addStore(t *testing.T) {
 // StopStore stops a store but leaves the engine intact.
 // All stopped stores must be restarted before multiTestContext.Stop is called.
 func (m *multiTestContext) stopStore(i int) {
-	m.multisender.get(i).RemoveStore(m.stores[i])
+	m.senders[i].RemoveStore(m.stores[i])
 	m.stoppers[i].Stop()
 	m.stoppers[i] = nil
 	m.stores[i] = nil
@@ -272,7 +253,8 @@ func (m *multiTestContext) restartStore(i int) {
 	if err := m.stores[i].Start(m.stoppers[i]); err != nil {
 		m.t.Fatal(err)
 	}
-	m.multisender.get(i).AddStore(m.stores[i])
+	// The sender is assumed to still exist.
+	m.senders[i].AddStore(m.stores[i])
 }
 
 // restart stops and restarts all stores but leaves the engines intact,

--- a/storage/client_test.go
+++ b/storage/client_test.go
@@ -96,12 +96,31 @@ func createTestStoreWithEngine(t *testing.T, eng engine.Engine, clock *hlc.Clock
 	return store, stopper
 }
 
+type multiLocalSender struct {
+	senders map[int]*kv.LocalSender
+}
+
+func (mls *multiLocalSender) get(index int) *kv.LocalSender {
+	if _, ok := mls.senders[index]; !ok {
+		mls.set(index, kv.NewLocalSender())
+	}
+	return mls.senders[index]
+}
+
+func (mls *multiLocalSender) set(index int, s *kv.LocalSender) {
+	if mls.senders == nil {
+		mls.senders = make(map[int]*kv.LocalSender)
+	}
+	mls.senders[index] = s
+}
+
 type multiTestContext struct {
 	t           *testing.T
 	manualClock *hlc.ManualClock
 	clock       *hlc.Clock
 	gossip      *gossip.Gossip
 	sender      *kv.LocalSender
+	multisender *multiLocalSender
 	transport   multiraft.Transport
 	db          *client.KV
 	engines     []engine.Engine
@@ -139,14 +158,19 @@ func (m *multiTestContext) Start(t *testing.T, numStores int) {
 	if m.transport == nil {
 		m.transport = multiraft.NewLocalRPCTransport()
 	}
+
 	if m.sender == nil {
 		m.sender = kv.NewLocalSender()
 	}
+
+	m.multisender = &multiLocalSender{}
+	m.multisender.set(0, m.sender)
+
 	if m.clientStopper == nil {
 		m.clientStopper = util.NewStopper()
 	}
 	if m.db == nil {
-		txnSender := kv.NewTxnCoordSender(m.sender, m.clock, false, m.clientStopper)
+		txnSender := kv.NewTxnCoordSender(m.multisender.get(0), m.clock, false, m.clientStopper)
 		m.db = client.NewKV(nil, txnSender)
 		m.db.User = storage.UserRoot
 	}
@@ -223,7 +247,7 @@ func (m *multiTestContext) addStore(t *testing.T) {
 		t.Fatal(err)
 	}
 	m.stores = append(m.stores, store)
-	m.sender.AddStore(store)
+	m.multisender.get(idx).AddStore(store)
 	// Save the store identities for later so we can use them in
 	// replication operations even while the store is stopped.
 	m.idents = append(m.idents, store.Ident)
@@ -233,7 +257,7 @@ func (m *multiTestContext) addStore(t *testing.T) {
 // StopStore stops a store but leaves the engine intact.
 // All stopped stores must be restarted before multiTestContext.Stop is called.
 func (m *multiTestContext) stopStore(i int) {
-	m.sender.RemoveStore(m.stores[i])
+	m.multisender.get(i).RemoveStore(m.stores[i])
 	m.stoppers[i].Stop()
 	m.stoppers[i] = nil
 	m.stores[i] = nil
@@ -248,7 +272,7 @@ func (m *multiTestContext) restartStore(i int) {
 	if err := m.stores[i].Start(m.stoppers[i]); err != nil {
 		m.t.Fatal(err)
 	}
-	m.sender.AddStore(m.stores[i])
+	m.multisender.get(i).AddStore(m.stores[i])
 }
 
 // restart stops and restarts all stores but leaves the engines intact,

--- a/storage/range.go
+++ b/storage/range.go
@@ -2160,20 +2160,27 @@ func (r *Range) ChangeReplicas(changeType proto.ReplicaChangeType, replica proto
 	desc := r.Desc()
 	updatedDesc := *desc
 	updatedDesc.Replicas = append([]proto.Replica{}, desc.Replicas...)
-	found := -1
+	found := -1       // tracks NodeID && StoreID
+	nodeUsed := false // tracks NodeID only
 	for i, existingRep := range desc.Replicas {
-		if existingRep.NodeID == replica.NodeID && existingRep.StoreID == replica.StoreID {
+		nodeUsed = nodeUsed || existingRep.NodeID == replica.NodeID
+		if existingRep.NodeID == replica.NodeID &&
+			existingRep.StoreID == replica.StoreID {
 			found = i
 			break
 		}
 	}
 	if changeType == proto.ADD_REPLICA {
-		if found != -1 {
+		// If the replica exists on the remote node, no matter in which store,
+		// abort the replica add.
+		if nodeUsed {
 			return util.Errorf("adding replica %v which is already present in range %d",
 				replica, desc.RaftID)
 		}
 		updatedDesc.Replicas = append(updatedDesc.Replicas, replica)
 	} else if changeType == proto.REMOVE_REPLICA {
+		// If that exact node-store combination does not have the replica,
+		// abort the removal.
 		if found == -1 {
 			return util.Errorf("removing replica %v which is not present in range %d",
 				replica, desc.RaftID)


### PR DESCRIPTION
- LocalSender will error out if it has a range in two stores
  (with a lot of stores, maybe we want to optimize a little
  bit the fact that now it is doing a linear search for each
  request, but that is an isolated improvement we can do when
  ever we need it)
- ChangeReplicas will also error out when asked to put a replica
  on the same node with one already present.
- the allocator seems node-aware already, so that part looked ok.
- introduced a multiLocalSender for the multiTestContext, which
  adds any additional stores to isolated local senders. This
  avoids three test failures in storage/client_raft_test related
  to replication and is cleaner anyways, since the new stores
  are made believe to belong to different nodes.
