### PR TITLE
Bump RocksDB pointer to 3.10.1.

### DIFF
--- a/GLOCKFILE
+++ b/GLOCKFILE
@@ -14,7 +14,7 @@ code.google.com/p/snappy-go 8850bd446ad6
 github.com/agtorre/gocolorize f42b554bf7f006936130c9bb4f971afd2d87f671
 github.com/biogo/store cb1ae010c5c75b7ce4f5c5d0ef92defcafdfdce4
 github.com/cockroachdb/c-protobuf 9e8dac59ca2a3fc82cd0665ad32b1a36f3df40b8
-github.com/cockroachdb/c-rocksdb 72de025ca13dd4ab2dce63e8e19c6a59b8388ffd
+github.com/cockroachdb/c-rocksdb e34a11209d37a442e4e69158e1712e8834f87259
 github.com/cockroachdb/c-snappy af73b00e85e6f0e3c1fcc51f73f1d036df1e99ff
 github.com/coreos/etcd e5f2f401450b56947e231336f9e8350059428036
 github.com/elazarl/go-bindata-assetfs bea323321994103859d60197d229f1a94699dde3

--- a/storage/engine/rocksdb_test.go
+++ b/storage/engine/rocksdb_test.go
@@ -79,12 +79,7 @@ func TestRocksDBCompaction(t *testing.T) {
 		t.Fatalf("could not create new in-memory rocksdb db instance: %v", err)
 	}
 	rocksdb.SetGCTimeouts(1, 2)
-	defer func(t *testing.T) {
-		rocksdb.Close()
-		if err := rocksdb.Destroy(); err != nil {
-			t.Errorf("could not delete in-memory rocksdb db: %v", err)
-		}
-	}(t)
+	defer rocksdb.Close()
 
 	cmdID := &proto.ClientCmdID{WallTime: 1, Random: 1}
 


### PR DESCRIPTION
RocksDB now complains about destroying an in-mem instance.
