### PR TITLE
A tiny fix: finish a retry with err when the error is not recoverable

### DIFF
--- a/storage/store.go
+++ b/storage/store.go
@@ -989,7 +989,7 @@ func (s *Store) ExecuteCmd(args proto.Request, reply proto.Response) error {
 			}
 			return util.RetryContinue, nil
 		}
-		return util.RetryBreak, nil
+		return util.RetryBreak, err
 	})
 
 	// By default, retries are indefinite. However, some unittests set a


### PR DESCRIPTION
I think this doesn't matter, but follows other cases where we finish retry with err=nil.
