### PR TITLE
do not daemonize cert generation in acceptance test

### DIFF
--- a/run/local-cluster.sh
+++ b/run/local-cluster.sh
@@ -105,7 +105,7 @@ for i in $(seq 1 $NODES); do
 done
 
 # Generate certs.
-docker run -d -v ${CERTS_DIR} --name=${CERTS_NAME} ${COCKROACH_IMAGE} create-ca-cert -certs=${CERTS_DIR} 2> /dev/null
+docker run -v ${CERTS_DIR} --name=${CERTS_NAME} ${COCKROACH_IMAGE} create-ca-cert -certs=${CERTS_DIR} 2> /dev/null
 docker run --rm --volumes-from=${CERTS_NAME} ${COCKROACH_IMAGE} create-node-cert -certs=${CERTS_DIR} ${NODE_ADDRESSES} 2> /dev/null
 
 # Start all nodes.


### PR DESCRIPTION
since we want that to be finished when the script continues.
this caused the failed build [1776](https://circleci.com/gh/cockroachdb/cockroach/1776).
