### PR TITLE
Set request scheme based on -certs value.

### DIFF
--- a/base/context.go
+++ b/base/context.go
@@ -137,6 +137,9 @@ func (ctx *Context) GetHTTPClient() (*http.Client, error) {
 		return ctx.httpClient, nil
 	}
 
+	if !ctx.SSLWanted() {
+		log.Warning("SSL disabled, this is strongly discouraged. See the -certs flag")
+	}
 	tlsConfig, err := ctx.GetClientTLSConfig()
 	if err != nil {
 		return nil, err

--- a/client/client_test.go
+++ b/client/client_test.go
@@ -79,12 +79,11 @@ func newNotifyingSender(wrapped client.KVSender) *notifyingSender {
 // an HTTP sender to the server at addr.
 // It contains a waitgroup to allow waiting.
 func createTestNotifyClient(addr string) *client.KV {
-	httpClient, err := testutils.NewTestHTTPClient()
+	sender, err := client.NewHTTPSender(addr, testutils.NewTestBaseContext())
 	if err != nil {
 		log.Fatal(err)
 	}
-	sender := newNotifyingSender(client.NewHTTPSender(addr, httpClient))
-	return client.NewKV(nil, sender)
+	return client.NewKV(nil, newNotifyingSender(sender))
 }
 
 // TestKVClientRetryNonTxn verifies that non-transactional client will
@@ -447,13 +446,11 @@ func ExampleKV_Run1() {
 	serv := server.StartTestServer(nil)
 	defer serv.Stop()
 
-	httpClient, err := testutils.NewTestHTTPClient()
+	// Key Value Client initialization.
+	sender, err := client.NewHTTPSender(serv.ServingAddr(), testutils.NewTestBaseContext())
 	if err != nil {
 		log.Fatal(err)
 	}
-
-	// Key Value Client initialization.
-	sender := client.NewHTTPSender(serv.ServingAddr(), httpClient)
 	kvClient := client.NewKV(nil, sender)
 	kvClient.User = storage.UserRoot
 
@@ -492,13 +489,11 @@ func ExampleKV_RunMultiple() {
 	serv := server.StartTestServer(nil)
 	defer serv.Stop()
 
-	httpClient, err := testutils.NewTestHTTPClient()
+	// Key Value Client initialization.
+	sender, err := client.NewHTTPSender(serv.ServingAddr(), testutils.NewTestBaseContext())
 	if err != nil {
 		log.Fatal(err)
 	}
-
-	// Key Value Client initialization.
-	sender := client.NewHTTPSender(serv.ServingAddr(), httpClient)
 	kvClient := client.NewKV(nil, sender)
 	kvClient.User = storage.UserRoot
 
@@ -561,13 +556,11 @@ func ExampleKV_RunTransaction() {
 	serv := server.StartTestServer(nil)
 	defer serv.Stop()
 
-	httpClient, err := testutils.NewTestHTTPClient()
+	// Key Value Client initialization.
+	sender, err := client.NewHTTPSender(serv.ServingAddr(), testutils.NewTestBaseContext())
 	if err != nil {
 		log.Fatal(err)
 	}
-
-	// Key Value Client initialization.
-	sender := client.NewHTTPSender(serv.ServingAddr(), httpClient)
 	kvClient := client.NewKV(nil, sender)
 	kvClient.User = storage.UserRoot
 

--- a/client/http_sender_test.go
+++ b/client/http_sender_test.go
@@ -73,11 +73,10 @@ func TestHTTPSenderSend(t *testing.T) {
 	}))
 	defer server.Close()
 
-	httpClient, err := testutils.NewTestHTTPClient()
+	sender, err := NewHTTPSender(addr, testutils.NewTestBaseContext())
 	if err != nil {
 		t.Fatal(err)
 	}
-	sender := NewHTTPSender(addr, httpClient)
 	reply := &proto.PutResponse{}
 	sender.Send(Call{Args: testPutReq, Reply: reply})
 	if reply.GoError() != nil {
@@ -110,10 +109,6 @@ func TestHTTPSenderRetryResponseCodes(t *testing.T) {
 		{http.StatusInternalServerError, false},
 		{http.StatusNotImplemented, false},
 	}
-	httpClient, err := testutils.NewTestHTTPClient()
-	if err != nil {
-		t.Fatal(err)
-	}
 	for i, test := range testCases {
 		count := 0
 		server, addr := startTestHTTPServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -133,7 +128,10 @@ func TestHTTPSenderRetryResponseCodes(t *testing.T) {
 			w.Write(body)
 		}))
 
-		sender := NewHTTPSender(addr, httpClient)
+		sender, err := NewHTTPSender(addr, testutils.NewTestBaseContext())
+		if err != nil {
+			t.Fatal(err)
+		}
 		reply := &proto.PutResponse{}
 		sender.Send(Call{Args: testPutReq, Reply: reply})
 		if test.retry {
@@ -171,10 +169,6 @@ func TestHTTPSenderRetryHTTPSendError(t *testing.T) {
 		},
 	}
 
-	httpClient, err := testutils.NewTestHTTPClient()
-	if err != nil {
-		t.Fatal(err)
-	}
 	for i, testFunc := range testCases {
 		count := 0
 		var s *httptest.Server
@@ -195,7 +189,10 @@ func TestHTTPSenderRetryHTTPSendError(t *testing.T) {
 		}))
 
 		s = server
-		sender := NewHTTPSender(addr, httpClient)
+		sender, err := NewHTTPSender(addr, testutils.NewTestBaseContext())
+		if err != nil {
+			t.Fatal(err)
+		}
 		reply := &proto.PutResponse{}
 		sender.Send(Call{Args: testPutReq, Reply: reply})
 		if reply.GoError() != nil {

--- a/client/rpc_sender.go
+++ b/client/rpc_sender.go
@@ -41,6 +41,7 @@ type RPCSender struct {
 }
 
 // NewRPCSender returns a new instance of RPCSender.
+// TODO(marc): initialize using a base.Context.
 func NewRPCSender(server string, certsDir string) (*RPCSender, error) {
 	addr, err := net.ResolveTCPAddr("tcp", server)
 	if err != nil {
@@ -49,7 +50,7 @@ func NewRPCSender(server string, certsDir string) (*RPCSender, error) {
 
 	var tlsConfig *tls.Config
 	if certsDir == "" {
-		log.V(1).Infof("no certificates directory specified: using insecure TLS")
+		log.Warning("SSL disabled, this is strongly discouraged. See the -certs flag")
 		tlsConfig = security.LoadInsecureClientTLSConfig()
 	} else {
 		log.V(1).Infof("setting up TLS from certificates directory: %s", certsDir)

--- a/kv/db_test.go
+++ b/kv/db_test.go
@@ -264,7 +264,8 @@ func TestKVDBContentType(t *testing.T) {
 			t.Fatalf("%d: %s", i, err)
 		}
 		// Send a Put request but with non-canonical capitalization.
-		httpReq, err := http.NewRequest("POST", "https://"+addr+kv.DBPrefix+"Put", bytes.NewReader(body))
+		httpReq, err := http.NewRequest("POST", testContext.RequestScheme()+"://"+addr+kv.DBPrefix+"Put",
+			bytes.NewReader(body))
 		if err != nil {
 			t.Fatalf("%d: %s", i, err)
 		}
@@ -272,7 +273,7 @@ func TestKVDBContentType(t *testing.T) {
 		if test.accept != "" {
 			httpReq.Header.Add(util.AcceptHeader, test.accept)
 		}
-		resp, err := httpDoReq(httpReq)
+		resp, err := httpDoReq(testContext, httpReq)
 		if err != nil {
 			t.Fatalf("%d: %s", i, err)
 		}

--- a/kv/db_test.go
+++ b/kv/db_test.go
@@ -33,11 +33,11 @@ import (
 )
 
 func createTestClient(t *testing.T, addr string) *client.KV {
-	httpClient, err := testutils.NewTestHTTPClient()
+	httpSender, err := client.NewHTTPSender(addr, testutils.NewTestBaseContext())
 	if err != nil {
 		t.Fatal(err)
 	}
-	return client.NewKV(nil, client.NewHTTPSender(addr, httpClient))
+	return client.NewKV(nil, httpSender)
 }
 
 // TestKVDBCoverage verifies that all methods may be invoked on the

--- a/server/accounting_test.go
+++ b/server/accounting_test.go
@@ -187,6 +187,7 @@ func ExampleAcctContentTypes() {
 		{"application/json", "text/yaml"},
 		{"text/yaml", "text/yaml"},
 	}
+
 	for i, test := range testCases {
 		key := fmt.Sprintf("/test%d", i)
 
@@ -200,13 +201,15 @@ func ExampleAcctContentTypes() {
 				fmt.Println(err)
 			}
 		}
-		req, err := http.NewRequest("POST", fmt.Sprintf("%s://%s%s%s", adminScheme, testContext.Addr, acctPathPrefix, key), bytes.NewReader(body))
+		req, err := http.NewRequest("POST", fmt.Sprintf("%s://%s%s%s", testContext.RequestScheme(), testContext.Addr,
+			acctPathPrefix, key), bytes.NewReader(body))
 		req.Header.Add("Content-Type", test.contentType)
 		if _, err = sendAdminRequest(testContext, req); err != nil {
 			fmt.Println(err)
 		}
 
-		req, err = http.NewRequest("GET", fmt.Sprintf("%s://%s%s%s", adminScheme, testContext.Addr, acctPathPrefix, key), nil)
+		req, err = http.NewRequest("GET", fmt.Sprintf("%s://%s%s%s", testContext.RequestScheme(), testContext.Addr,
+			acctPathPrefix, key), nil)
 		req.Header.Add("Accept", test.accept)
 		if body, err = sendAdminRequest(testContext, req); err != nil {
 			fmt.Println(err)

--- a/server/admin.go
+++ b/server/admin.go
@@ -38,8 +38,6 @@ import (
 const (
 	maxGetResults = 0 // TODO(spencer): maybe we need paged query support
 
-	// adminScheme is the scheme for connecting to the admin endpoint.
-	adminScheme = "https"
 	// adminEndpoint is the prefix for RESTful endpoints used to
 	// provide an administrative interface to the cockroach cluster.
 	adminEndpoint = "/_admin/"

--- a/server/admin_client.go
+++ b/server/admin_client.go
@@ -49,7 +49,7 @@ func sendAdminRequest(ctx *Context, req *http.Request) ([]byte, error) {
 
 // SendQuit requests the admin quit path to drain and shutdown the server.
 func SendQuit(ctx *Context) error {
-	req, err := http.NewRequest("GET", fmt.Sprintf("%s://%s%s", adminScheme, ctx.Addr, quitPath), nil)
+	req, err := http.NewRequest("GET", fmt.Sprintf("%s://%s%s", ctx.RequestScheme(), ctx.Addr, quitPath), nil)
 	if err != nil {
 		return util.Errorf("unable to create request to admin REST endpoint: %s", err)
 	}

--- a/server/cli/kv.go
+++ b/server/cli/kv.go
@@ -39,11 +39,10 @@ var osExit = os.Exit
 var osStderr = os.Stderr
 
 func makeKVClient() (*client.KV, error) {
-	httpClient, err := Context.GetHTTPClient()
+	httpSender, err := client.NewHTTPSender(util.EnsureHost(Context.Addr), &Context.Context)
 	if err != nil {
 		return nil, err
 	}
-	httpSender := client.NewHTTPSender(util.EnsureHost(Context.Addr), httpClient)
 	kv := client.NewKV(nil, httpSender)
 	// TODO(pmattis): Initialize this to something more reasonable
 	kv.User = "root"

--- a/server/config.go
+++ b/server/config.go
@@ -53,7 +53,7 @@ func getFriendlyNameFromPrefix(prefix string) string {
 // runGetConfig invokes the REST API with GET action and key prefix as path.
 func runGetConfig(ctx *Context, prefix, keyPrefix string) {
 	friendlyName := getFriendlyNameFromPrefix(prefix)
-	req, err := http.NewRequest("GET", fmt.Sprintf("%s://%s%s/%s", adminScheme, ctx.Addr, prefix, keyPrefix), nil)
+	req, err := http.NewRequest("GET", fmt.Sprintf("%s://%s%s/%s", ctx.RequestScheme(), ctx.Addr, prefix, keyPrefix), nil)
 	if err != nil {
 		log.Errorf("unable to create request to admin REST endpoint: %s", err)
 		return
@@ -89,7 +89,7 @@ func RunGetZone(ctx *Context, keyPrefix string) {
 // displayed.
 func runLsConfigs(ctx *Context, prefix, pattern string) {
 	friendlyName := getFriendlyNameFromPrefix(prefix)
-	req, err := http.NewRequest("GET", fmt.Sprintf("%s://%s%s", adminScheme, ctx.Addr, prefix), nil)
+	req, err := http.NewRequest("GET", fmt.Sprintf("%s://%s%s", ctx.RequestScheme(), ctx.Addr, prefix), nil)
 	if err != nil {
 		log.Errorf("unable to create request to admin REST endpoint: %s", err)
 		return
@@ -144,7 +144,8 @@ func RunLsZone(ctx *Context, pattern string) {
 // The type of config that is removed is based on the passed in prefix.
 func runRmConfig(ctx *Context, prefix, keyPrefix string) {
 	friendlyName := getFriendlyNameFromPrefix(prefix)
-	req, err := http.NewRequest("DELETE", fmt.Sprintf("%s://%s%s/%s", adminScheme, ctx.Addr, prefix, keyPrefix), nil)
+	req, err := http.NewRequest("DELETE", fmt.Sprintf("%s://%s%s/%s", ctx.RequestScheme(), ctx.Addr, prefix, keyPrefix),
+		nil)
 	if err != nil {
 		log.Errorf("unable to create request to admin REST endpoint: %s", err)
 		return
@@ -185,7 +186,8 @@ func runSetConfig(ctx *Context, prefix, keyPrefix, configFileName string) {
 		return
 	}
 	// Send to admin REST API.
-	req, err := http.NewRequest("POST", fmt.Sprintf("%s://%s%s/%s", adminScheme, ctx.Addr, prefix, keyPrefix), bytes.NewReader(body))
+	req, err := http.NewRequest("POST", fmt.Sprintf("%s://%s%s/%s", ctx.RequestScheme(), ctx.Addr, prefix, keyPrefix),
+		bytes.NewReader(body))
 	if err != nil {
 		log.Errorf("unable to create request to admin REST endpoint: %s", err)
 		return

--- a/server/permission_test.go
+++ b/server/permission_test.go
@@ -224,13 +224,15 @@ func ExamplePermContentTypes() {
 				fmt.Println(err)
 			}
 		}
-		req, err := http.NewRequest("POST", fmt.Sprintf("%s://%s%s%s", adminScheme, testContext.Addr, permPathPrefix, key), bytes.NewReader(body))
+		req, err := http.NewRequest("POST", fmt.Sprintf("%s://%s%s%s", testContext.RequestScheme(), testContext.Addr,
+			permPathPrefix, key), bytes.NewReader(body))
 		req.Header.Add("Content-Type", test.contentType)
 		if _, err = sendAdminRequest(testContext, req); err != nil {
 			fmt.Println(err)
 		}
 
-		req, err = http.NewRequest("GET", fmt.Sprintf("%s://%s%s%s", adminScheme, testContext.Addr, permPathPrefix, key), nil)
+		req, err = http.NewRequest("GET", fmt.Sprintf("%s://%s%s%s", testContext.RequestScheme(), testContext.Addr,
+			permPathPrefix, key), nil)
 		req.Header.Add("Accept", test.accept)
 		if body, err = sendAdminRequest(testContext, req); err != nil {
 			fmt.Println(err)
@@ -291,7 +293,8 @@ func TestPermEmptyKey(t *testing.T) {
 	}
 	keys := []string{"key0", "key1"}
 	for _, key := range keys {
-		req, err := http.NewRequest("POST", fmt.Sprintf("%s://%s%s/%s", adminScheme, testContext.Addr, permPathPrefix, key), bytes.NewReader(body))
+		req, err := http.NewRequest("POST", fmt.Sprintf("%s://%s%s/%s", testContext.RequestScheme(), testContext.Addr,
+			permPathPrefix, key), bytes.NewReader(body))
 		req.Header.Set("Content-Type", "application/json")
 		if _, err = sendAdminRequest(testContext, req); err != nil {
 			t.Fatal(err)
@@ -318,7 +321,8 @@ func TestPermEmptyKey(t *testing.T) {
 	}
 
 	for i, test := range testCases {
-		req, err := http.NewRequest("GET", fmt.Sprintf("%s://%s%s", adminScheme, testContext.Addr, permPathPrefix), nil)
+		req, err := http.NewRequest("GET", fmt.Sprintf("%s://%s%s", testContext.RequestScheme(), testContext.Addr,
+			permPathPrefix), nil)
 		req.Header.Set("Accept", test.accept)
 		body, err = sendAdminRequest(testContext, req)
 		if err != nil {

--- a/server/server.go
+++ b/server/server.go
@@ -158,7 +158,7 @@ func (s *Server) Start(selfBootstrap bool) error {
 		return err
 	}
 
-	log.Infof("starting https server at %s", s.rpc.Addr())
+	log.Infof("starting %s server at %s", s.ctx.RequestScheme(), s.rpc.Addr())
 	// TODO(spencer): go1.5 is supposed to allow shutdown of running http server.
 	s.initHTTP()
 	s.rpc.Serve(s)

--- a/server/server.go
+++ b/server/server.go
@@ -82,6 +82,9 @@ func NewServer(ctx *Context, stopper *util.Stopper) (*Server, error) {
 		return nil, util.Errorf("unable to resolve RPC address %q: %v", addr, err)
 	}
 
+	if !ctx.SSLWanted() {
+		log.Warning("SSL disabled, this is strongly discouraged. See the -certs flag")
+	}
 	tlsConfig, err := ctx.GetServerTLSConfig()
 	if err != nil {
 		return nil, err

--- a/server/server_test.go
+++ b/server/server_test.go
@@ -153,7 +153,7 @@ func TestSelfBootstrap(t *testing.T) {
 func TestHealth(t *testing.T) {
 	s := StartTestServer(t)
 	defer s.Stop()
-	url := "https://" + s.ServingAddr() + healthPath
+	url := testContext.RequestScheme() + "://" + s.ServingAddr() + healthPath
 	httpClient, err := testContext.GetHTTPClient()
 	if err != nil {
 		t.Fatal(err)
@@ -268,7 +268,7 @@ func TestAcceptEncoding(t *testing.T) {
 		},
 	}
 	for _, d := range testData {
-		req, err := http.NewRequest("GET", "https://"+s.ServingAddr()+healthPath, nil)
+		req, err := http.NewRequest("GET", testContext.RequestScheme()+"://"+s.ServingAddr()+healthPath, nil)
 		if err != nil {
 			t.Fatalf("could not create request: %s", err)
 		}

--- a/server/status_test.go
+++ b/server/status_test.go
@@ -30,7 +30,6 @@ import (
 	"github.com/cockroachdb/cockroach/proto"
 	"github.com/cockroachdb/cockroach/storage"
 	"github.com/cockroachdb/cockroach/storage/engine"
-	"github.com/cockroachdb/cockroach/testutils"
 	"github.com/cockroachdb/cockroach/util"
 	"github.com/cockroachdb/cockroach/util/log"
 )
@@ -96,14 +95,14 @@ func TestStatusJson(t *testing.T) {
 }`})
 	}
 
-	httpClient, err := testutils.NewTestHTTPClient()
+	httpClient, err := testContext.GetHTTPClient()
 	if err != nil {
 		t.Fatal(err)
 	}
 	for _, spec := range testCases {
 		contentTypes := []string{"application/json", "application/x-protobuf", "text/yaml"}
 		for _, contentType := range contentTypes {
-			req, err := http.NewRequest("GET", "https://"+s.ServingAddr()+spec.keyPrefix, nil)
+			req, err := http.NewRequest("GET", testContext.RequestScheme()+"://"+s.ServingAddr()+spec.keyPrefix, nil)
 			if err != nil {
 				t.Fatal(err)
 			}
@@ -168,13 +167,13 @@ func TestStatusGossipJson(t *testing.T) {
 		} `json:"infos"`
 	}
 
-	httpClient, err := testutils.NewTestHTTPClient()
+	httpClient, err := testContext.GetHTTPClient()
 	if err != nil {
 		t.Fatal(err)
 	}
 	contentTypes := []string{"application/json", "application/x-protobuf", "text/yaml"}
 	for _, contentType := range contentTypes {
-		req, err := http.NewRequest("GET", "https://"+s.ServingAddr()+statusGossipKeyPrefix, nil)
+		req, err := http.NewRequest("GET", testContext.RequestScheme()+"://"+s.ServingAddr()+statusGossipKeyPrefix, nil)
 		if err != nil {
 			t.Fatal(err)
 		}

--- a/server/testserver.go
+++ b/server/testserver.go
@@ -40,7 +40,7 @@ func StartTestServer(t *testing.T) *TestServer {
 			log.Fatalf("Could not start server: %v", err)
 		}
 	}
-	log.Infof("Test server listening on https: %s", s.ServingAddr())
+	log.Infof("Test server listening on %s: %s", s.Ctx.RequestScheme(), s.ServingAddr())
 	return s
 }
 

--- a/server/zone_test.go
+++ b/server/zone_test.go
@@ -227,13 +227,15 @@ func ExampleZoneContentTypes() {
 				fmt.Println(err)
 			}
 		}
-		req, err := http.NewRequest("POST", fmt.Sprintf("%s://%s%s%s", adminScheme, testContext.Addr, zonePathPrefix, key), bytes.NewReader(body))
+		req, err := http.NewRequest("POST", fmt.Sprintf("%s://%s%s%s", testContext.RequestScheme(), testContext.Addr,
+			zonePathPrefix, key), bytes.NewReader(body))
 		req.Header.Add("Content-Type", test.contentType)
 		if _, err = sendAdminRequest(testContext, req); err != nil {
 			fmt.Println(err)
 		}
 
-		req, err = http.NewRequest("GET", fmt.Sprintf("%s://%s%s%s", adminScheme, testContext.Addr, zonePathPrefix, key), nil)
+		req, err = http.NewRequest("GET", fmt.Sprintf("%s://%s%s%s", testContext.RequestScheme(), testContext.Addr,
+			zonePathPrefix, key), nil)
 		req.Header.Add("Accept", test.accept)
 		if body, err = sendAdminRequest(testContext, req); err != nil {
 			fmt.Println(err)

--- a/structured/rest_test.go
+++ b/structured/rest_test.go
@@ -101,7 +101,7 @@ func TestGetPutDeleteSchema(t *testing.T) {
 		{methodDelete, "/schema/foo", nil, http.StatusOK, nil},
 		{methodGet, "/schema/foo", nil, http.StatusNotFound, nil},
 	}
-	testContext := testutils.NewTestBaseContest()
+	testContext := testutils.NewTestBaseContext()
 	httpClient, err := testContext.GetHTTPClient()
 	if err != nil {
 		t.Fatal(err)

--- a/structured/rest_test.go
+++ b/structured/rest_test.go
@@ -101,12 +101,13 @@ func TestGetPutDeleteSchema(t *testing.T) {
 		{methodDelete, "/schema/foo", nil, http.StatusOK, nil},
 		{methodGet, "/schema/foo", nil, http.StatusNotFound, nil},
 	}
-	httpClient, err := testutils.NewTestHTTPClient()
+	testContext := testutils.NewTestBaseContest()
+	httpClient, err := testContext.GetHTTPClient()
 	if err != nil {
 		t.Fatal(err)
 	}
 	for _, tc := range testCases {
-		addr := "https://" + serverAddr + tc.path
+		addr := testContext.RequestScheme() + "://" + serverAddr + tc.path
 		req, err := http.NewRequest(tc.method, addr, tc.body)
 		if err != nil {
 			t.Fatalf("[%s] %s: error creating request: %v", tc.method, tc.path, err)


### PR DESCRIPTION
This allows easy switch to plain http.
There are still a bunch of tests that hard-code "https" which is fine with the default -certs value.
I'll probably switch those to properly use the context as well.
