### PR TITLE
Add support for LZ4 compression.

### DIFF
--- a/GLOCKFILE
+++ b/GLOCKFILE
@@ -13,8 +13,9 @@ code.google.com/p/go-uuid 35bc42037350
 code.google.com/p/snappy-go 8850bd446ad6
 github.com/agtorre/gocolorize f42b554bf7f006936130c9bb4f971afd2d87f671
 github.com/biogo/store cb1ae010c5c75b7ce4f5c5d0ef92defcafdfdce4
+github.com/cockroachdb/c-lz4 6e71f140a365017bbe0904710007f8725fd3f809
 github.com/cockroachdb/c-protobuf 9e8dac59ca2a3fc82cd0665ad32b1a36f3df40b8
-github.com/cockroachdb/c-rocksdb e34a11209d37a442e4e69158e1712e8834f87259
+github.com/cockroachdb/c-rocksdb e120ce0fb32f86b94188928743270ea11ff016b3
 github.com/cockroachdb/c-snappy af73b00e85e6f0e3c1fcc51f73f1d036df1e99ff
 github.com/coreos/etcd e5f2f401450b56947e231336f9e8350059428036
 github.com/elazarl/go-bindata-assetfs bea323321994103859d60197d229f1a94699dde3

--- a/rpc/codec/lz4.go
+++ b/rpc/codec/lz4.go
@@ -1,0 +1,106 @@
+// Copyright 2015 The Cockroach Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+// implied. See the License for the specific language governing
+// permissions and limitations under the License. See the AUTHORS file
+// for names of contributors.
+//
+// Author: Peter Mattis (peter.mattis@gmail.com)
+
+package codec
+
+import (
+	"unsafe"
+
+	// Link against the lz4 library. This is explicit because this Go
+	// library does not export any Go symbols.
+	_ "github.com/cockroachdb/c-lz4"
+	"github.com/gogo/protobuf/proto"
+)
+
+// #cgo CPPFLAGS: -I ../../../c-lz4/internal/lib
+// #cgo darwin LDFLAGS: -Wl,-undefined -Wl,dynamic_lookup
+// #cgo !darwin LDFLAGS: -Wl,-unresolved-symbols=ignore-all
+//
+// #include <stdlib.h>
+// #include <lz4.h>
+//
+// int lz4_encode(const char* input,
+//                int inputLength,
+//                void** compressed) {
+//   int compressBound = LZ4_compressBound(inputLength);
+//   *compressed = malloc(compressBound);
+//   int outputLength = LZ4_compress_limitedOutput(
+//       input, *compressed, inputLength, compressBound);
+//   if (outputLength == 0 || outputLength == inputLength) {
+//     free(*compressed);
+//   }
+//   return outputLength;
+// }
+//
+// int lz4_decode(const char* compressed,
+//                int compressed_length,
+//                void** uncompressed,
+//                int uncompressed_length) {
+//   *uncompressed = malloc(uncompressed_length);
+//   int outputLength = LZ4_decompress_safe(
+//       compressed, *uncompressed, compressed_length, uncompressed_length);
+//   if (outputLength < 0) {
+//     free(*uncompressed);
+//   }
+//   return outputLength;
+// }
+import "C"
+
+// lz4Encode compresses the byte array src and sends the compressed
+// data to w.
+func lz4Encode(src []byte, w func([]byte) error) error {
+	if len(src) == 0 {
+		return w(nil)
+	}
+
+	var dst unsafe.Pointer
+	dLen := C.lz4_encode((*C.char)(unsafe.Pointer(&src[0])), C.int(len(src)), &dst)
+	if dLen == 0 || int(dLen) == len(src) {
+		// The input was not compressed or compressed to exactly the same
+		// length as the source. Either way we treat the input as not
+		// compressible. See lz4Decode() for the decode-side handling.
+		return w(src)
+	}
+
+	err := w(unsafeSlice(dst, C.size_t(dLen)))
+	C.free(dst)
+	return err
+}
+
+// lz4Decode uncompresses the byte array src and unmarshals the
+// uncompressed data into m.
+func lz4Decode(src []byte, uncompressedSize uint32, m proto.Message) error {
+	if len(src) == 0 || len(src) == int(uncompressedSize) {
+		// len(src) == int(uncompressedSize) indicates the data was not
+		// compressible.
+		return proto.Unmarshal(src, m)
+	}
+
+	var dst unsafe.Pointer
+	dLen := C.lz4_decode((*C.char)(unsafe.Pointer(&src[0])),
+		C.int(len(src)), &dst, C.int(uncompressedSize))
+	if uint32(dLen) != uncompressedSize {
+		return errInvalidInput
+	}
+
+	// We call through directly to proto.Unmarshal so that we don't have
+	// to allocate a slice for "dst" or have some awkward interface
+	// where the caller has to deallocate "dst".
+	err := proto.Unmarshal(unsafeSlice(dst, C.size_t(dLen)), m)
+	C.free(dst)
+	return err
+}

--- a/rpc/codec/snappy.go
+++ b/rpc/codec/snappy.go
@@ -90,7 +90,7 @@ var (
 // data to w.
 func snappyEncode(src []byte, w func([]byte) error) error {
 	if len(src) == 0 {
-		return w([]byte(nil))
+		return w(nil)
 	}
 
 	var dLen C.size_t
@@ -109,9 +109,9 @@ func snappyEncode(src []byte, w func([]byte) error) error {
 
 // snappyDecode uncompresses the byte array src and unmarshals the
 // uncompressed data into m.
-func snappyDecode(src []byte, m proto.Message) error {
+func snappyDecode(src []byte, uncompressedSize uint32, m proto.Message) error {
 	if len(src) == 0 {
-		return proto.Unmarshal([]byte(nil), m)
+		return proto.Unmarshal(nil, m)
 	}
 
 	var dLen C.size_t

--- a/rpc/codec/wire.pb/wire.proto
+++ b/rpc/codec/wire.pb/wire.proto
@@ -51,6 +51,7 @@ option (gogoproto.unmarshaler_all) = true;
 enum CompressionType {
   NONE = 0;
   SNAPPY = 1;
+  LZ4 = 2;
 }
 
 message RequestHeader {
@@ -58,6 +59,7 @@ message RequestHeader {
   optional string method = 2;
   optional int32 method_id = 3 [(gogoproto.nullable) = false];
   optional CompressionType compression = 4 [(gogoproto.nullable) = false];
+  optional uint32 uncompressed_size = 5 [(gogoproto.nullable) = false];
 }
 
 message ResponseHeader {
@@ -65,4 +67,5 @@ message ResponseHeader {
   optional string method = 2;
   optional string error = 3 [(gogoproto.nullable) = false];
   optional CompressionType compression = 4 [(gogoproto.nullable) = false];
+  optional uint32 uncompressed_size = 5 [(gogoproto.nullable) = false];
 }

--- a/storage/engine/cgo_flags.go
+++ b/storage/engine/cgo_flags.go
@@ -4,6 +4,7 @@ import (
 	// Link against the protobuf and rocksdb libaries. This is
 	// explicitly because these Go libraries do not export any Go
 	// symbols.
+	_ "github.com/cockroachdb/c-lz4"
 	_ "github.com/cockroachdb/c-protobuf"
 	_ "github.com/cockroachdb/c-rocksdb"
 	_ "github.com/cockroachdb/c-snappy"


### PR DESCRIPTION
LZ4 benchmarks faster than Snappy in the RPC system, but slower than
Snappy for our client scan benchmark. Here are the RPC benchmarks (old
== snappy, new == LZ4).

benchmark                    old ns/op     new ns/op     delta
BenchmarkEchoProtoRPC1K      42229         42754         +1.24%
BenchmarkEchoProtoRPC64K     140167        120343        -14.14%

benchmark                    old MB/s     new MB/s     speedup
BenchmarkEchoProtoRPC1K      48.50        47.90        0.99x
BenchmarkEchoProtoRPC64K     935.11       1089.15      1.16x
