### PR TITLE
Add client benchmarks for all combinations of SSL on/off and RPC/http

### DIFF
--- a/client/rpc_sender.go
+++ b/client/rpc_sender.go
@@ -68,13 +68,16 @@ func NewRPCSender(server string, certsDir string) (*RPCSender, error) {
 
 // NewTestRPCSender initializes a new RPCSender using an insecure TLS
 // config.
-func NewTestRPCSender(server string) *RPCSender {
+func NewTestRPCSender(server string, sslEnabled bool) *RPCSender {
 	addr, err := net.ResolveTCPAddr("tcp", server)
 	if err != nil {
 		return nil
 	}
 
-	tlsConfig := security.LoadInsecureClientTLSConfig()
+	var tlsConfig *tls.Config
+	if sslEnabled {
+		tlsConfig = security.LoadInsecureClientTLSConfig()
+	}
 	ctx := rpc.NewContext(hlc.NewClock(hlc.UnixNano), tlsConfig, nil)
 	client := rpc.NewClient(addr, &HTTPRetryOptions, ctx)
 	return &RPCSender{client: client}


### PR DESCRIPTION
Sample run:

```
BenchmarkRPCSSLClientScan1Version1Row           2000        672636 ns/op       1.52 MB/s
BenchmarkRPCSSLClientScan1Version10Rows          500       2196239 ns/op       4.66 MB/s
BenchmarkRPCSSLClientScan1Version100Rows         100      12313846 ns/op       8.32 MB/s
BenchmarkRPCSSLClientScan1Version1000Rows         20      86299799 ns/op      11.87 MB/s
BenchmarkHTTPSSLClientScan1Version1Row          1000       1055764 ns/op       0.97 MB/s
BenchmarkHTTPSSLClientScan1Version10Rows         500       2484454 ns/op       4.12 MB/s
BenchmarkHTTPSSLClientScan1Version100Rows        100      14972338 ns/op       6.84 MB/s
BenchmarkHTTPSSLClientScan1Version1000Rows        20      97406602 ns/op      10.51 MB/s
BenchmarkRPCNoSSLClientScan1Version1Row         5000        525065 ns/op       1.95 MB/s
BenchmarkRPCNoSSLClientScan1Version10Rows       2000       1132722 ns/op       9.04 MB/s
BenchmarkRPCNoSSLClientScan1Version100Rows       300       5454395 ns/op      18.77 MB/s
BenchmarkRPCNoSSLClientScan1Version1000Rows       30      36060814 ns/op      28.40 MB/s
BenchmarkHTTPNoSSLClientScan1Version1Row        2000        861589 ns/op       1.19 MB/s
BenchmarkHTTPNoSSLClientScan1Version10Rows      1000       1608671 ns/op       6.37 MB/s
BenchmarkHTTPNoSSLClientScan1Version100Rows      200       8239798 ns/op      12.43 MB/s
BenchmarkHTTPNoSSLClientScan1Version1000Rows      20      54811774 ns/op      18.68 MB/s
```
