### PR TITLE
Explicitly bind to localhost in new server test.

### DIFF
--- a/server/server_test.go
+++ b/server/server_test.go
@@ -178,6 +178,7 @@ func TestHealth(t *testing.T) {
 func TestPlainHTTPServer(t *testing.T) {
 	// Create a custom context. The default one has a default -certs value.
 	ctx := NewContext()
+	ctx.Addr = "127.0.0.1:0"
 	ctx.Certs = ""
 	// TestServer.Start does not override the context if set.
 	s := &TestServer{Ctx: ctx}


### PR DESCRIPTION
This silences a firewall warning on the mac.
