### PR TITLE
add LastEvicted to MVCCMetadata

### DIFF
--- a/proto/data.proto
+++ b/proto/data.proto
@@ -284,6 +284,9 @@ message MVCCMetadata {
   // is only a single MVCC metadata row with value inlined, and with
   // empty timestamp, key_bytes, and val_bytes.
   optional Value value = 6;
+  // The timestamp of the most recent evicted version of the key.
+  optional Timestamp last_evicted = 7 [(gogoproto.nullable) = false];
+
 }
 
 // GCMetadata holds information about the last complete key/value

--- a/proto/errors.pb.go
+++ b/proto/errors.pb.go
@@ -300,6 +300,25 @@ func (m *WriteTooOldError) GetExistingTimestamp() Timestamp {
 	return Timestamp{}
 }
 
+// A ReadTooOldError indicates that a read was issued for a version
+// of a key which has already been garbage collected.
+// The read should be retried with a higher timestamp.
+type ReadTooOldError struct {
+	Timestamp        Timestamp `protobuf:"bytes,1,opt,name=timestamp" json:"timestamp"`
+	XXX_unrecognized []byte    `json:"-"`
+}
+
+func (m *ReadTooOldError) Reset()         { *m = ReadTooOldError{} }
+func (m *ReadTooOldError) String() string { return proto1.CompactTextString(m) }
+func (*ReadTooOldError) ProtoMessage()    {}
+
+func (m *ReadTooOldError) GetTimestamp() Timestamp {
+	if m != nil {
+		return m.Timestamp
+	}
+	return Timestamp{}
+}
+
 // An OpRequiresTxnError indicates that a command required to be
 // carried out in a transactional context but was not.
 // For example, a Scan which spans ranges requires a transaction.
@@ -1329,6 +1348,72 @@ func (m *WriteTooOldError) Unmarshal(data []byte) error {
 	}
 	return nil
 }
+func (m *ReadTooOldError) Unmarshal(data []byte) error {
+	l := len(data)
+	index := 0
+	for index < l {
+		var wire uint64
+		for shift := uint(0); ; shift += 7 {
+			if index >= l {
+				return io.ErrUnexpectedEOF
+			}
+			b := data[index]
+			index++
+			wire |= (uint64(b) & 0x7F) << shift
+			if b < 0x80 {
+				break
+			}
+		}
+		fieldNum := int32(wire >> 3)
+		wireType := int(wire & 0x7)
+		switch fieldNum {
+		case 1:
+			if wireType != 2 {
+				return fmt.Errorf("proto: wrong wireType = %d for field Timestamp", wireType)
+			}
+			var msglen int
+			for shift := uint(0); ; shift += 7 {
+				if index >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := data[index]
+				index++
+				msglen |= (int(b) & 0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			postIndex := index + msglen
+			if postIndex > l {
+				return io.ErrUnexpectedEOF
+			}
+			if err := m.Timestamp.Unmarshal(data[index:postIndex]); err != nil {
+				return err
+			}
+			index = postIndex
+		default:
+			var sizeOfWire int
+			for {
+				sizeOfWire++
+				wire >>= 7
+				if wire == 0 {
+					break
+				}
+			}
+			index -= sizeOfWire
+			skippy, err := github_com_gogo_protobuf_proto.Skip(data[index:])
+			if err != nil {
+				return err
+			}
+			if (index + skippy) > l {
+				return io.ErrUnexpectedEOF
+			}
+			m.XXX_unrecognized = append(m.XXX_unrecognized, data[index:index+skippy]...)
+			index += skippy
+		}
+	}
+	return nil
+}
 func (m *OpRequiresTxnError) Unmarshal(data []byte) error {
 	l := len(data)
 	index := 0
@@ -2127,6 +2212,17 @@ func (m *WriteTooOldError) Size() (n int) {
 	return n
 }
 
+func (m *ReadTooOldError) Size() (n int) {
+	var l int
+	_ = l
+	l = m.Timestamp.Size()
+	n += 1 + l + sovErrors(uint64(l))
+	if m.XXX_unrecognized != nil {
+		n += len(m.XXX_unrecognized)
+	}
+	return n
+}
+
 func (m *OpRequiresTxnError) Size() (n int) {
 	var l int
 	_ = l
@@ -2585,6 +2681,35 @@ func (m *WriteTooOldError) MarshalTo(data []byte) (n int, err error) {
 	return i, nil
 }
 
+func (m *ReadTooOldError) Marshal() (data []byte, err error) {
+	size := m.Size()
+	data = make([]byte, size)
+	n, err := m.MarshalTo(data)
+	if err != nil {
+		return nil, err
+	}
+	return data[:n], nil
+}
+
+func (m *ReadTooOldError) MarshalTo(data []byte) (n int, err error) {
+	var i int
+	_ = i
+	var l int
+	_ = l
+	data[i] = 0xa
+	i++
+	i = encodeVarintErrors(data, i, uint64(m.Timestamp.Size()))
+	n16, err := m.Timestamp.MarshalTo(data[i:])
+	if err != nil {
+		return 0, err
+	}
+	i += n16
+	if m.XXX_unrecognized != nil {
+		i += copy(data[i:], m.XXX_unrecognized)
+	}
+	return i, nil
+}
+
 func (m *OpRequiresTxnError) Marshal() (data []byte, err error) {
 	size := m.Size()
 	data = make([]byte, size)
@@ -2625,11 +2750,11 @@ func (m *ConditionFailedError) MarshalTo(data []byte) (n int, err error) {
 		data[i] = 0xa
 		i++
 		i = encodeVarintErrors(data, i, uint64(m.ActualValue.Size()))
-		n16, err := m.ActualValue.MarshalTo(data[i:])
+		n17, err := m.ActualValue.MarshalTo(data[i:])
 		if err != nil {
 			return 0, err
 		}
-		i += n16
+		i += n17
 	}
 	if m.XXX_unrecognized != nil {
 		i += copy(data[i:], m.XXX_unrecognized)
@@ -2656,121 +2781,121 @@ func (m *ErrorDetail) MarshalTo(data []byte) (n int, err error) {
 		data[i] = 0xa
 		i++
 		i = encodeVarintErrors(data, i, uint64(m.NotLeader.Size()))
-		n17, err := m.NotLeader.MarshalTo(data[i:])
-		if err != nil {
-			return 0, err
-		}
-		i += n17
-	}
-	if m.RangeNotFound != nil {
-		data[i] = 0x12
-		i++
-		i = encodeVarintErrors(data, i, uint64(m.RangeNotFound.Size()))
-		n18, err := m.RangeNotFound.MarshalTo(data[i:])
+		n18, err := m.NotLeader.MarshalTo(data[i:])
 		if err != nil {
 			return 0, err
 		}
 		i += n18
 	}
-	if m.RangeKeyMismatch != nil {
-		data[i] = 0x1a
+	if m.RangeNotFound != nil {
+		data[i] = 0x12
 		i++
-		i = encodeVarintErrors(data, i, uint64(m.RangeKeyMismatch.Size()))
-		n19, err := m.RangeKeyMismatch.MarshalTo(data[i:])
+		i = encodeVarintErrors(data, i, uint64(m.RangeNotFound.Size()))
+		n19, err := m.RangeNotFound.MarshalTo(data[i:])
 		if err != nil {
 			return 0, err
 		}
 		i += n19
 	}
-	if m.ReadWithinUncertaintyInterval != nil {
-		data[i] = 0x22
+	if m.RangeKeyMismatch != nil {
+		data[i] = 0x1a
 		i++
-		i = encodeVarintErrors(data, i, uint64(m.ReadWithinUncertaintyInterval.Size()))
-		n20, err := m.ReadWithinUncertaintyInterval.MarshalTo(data[i:])
+		i = encodeVarintErrors(data, i, uint64(m.RangeKeyMismatch.Size()))
+		n20, err := m.RangeKeyMismatch.MarshalTo(data[i:])
 		if err != nil {
 			return 0, err
 		}
 		i += n20
 	}
-	if m.TransactionAborted != nil {
-		data[i] = 0x2a
+	if m.ReadWithinUncertaintyInterval != nil {
+		data[i] = 0x22
 		i++
-		i = encodeVarintErrors(data, i, uint64(m.TransactionAborted.Size()))
-		n21, err := m.TransactionAborted.MarshalTo(data[i:])
+		i = encodeVarintErrors(data, i, uint64(m.ReadWithinUncertaintyInterval.Size()))
+		n21, err := m.ReadWithinUncertaintyInterval.MarshalTo(data[i:])
 		if err != nil {
 			return 0, err
 		}
 		i += n21
 	}
-	if m.TransactionPush != nil {
-		data[i] = 0x32
+	if m.TransactionAborted != nil {
+		data[i] = 0x2a
 		i++
-		i = encodeVarintErrors(data, i, uint64(m.TransactionPush.Size()))
-		n22, err := m.TransactionPush.MarshalTo(data[i:])
+		i = encodeVarintErrors(data, i, uint64(m.TransactionAborted.Size()))
+		n22, err := m.TransactionAborted.MarshalTo(data[i:])
 		if err != nil {
 			return 0, err
 		}
 		i += n22
 	}
-	if m.TransactionRetry != nil {
-		data[i] = 0x3a
+	if m.TransactionPush != nil {
+		data[i] = 0x32
 		i++
-		i = encodeVarintErrors(data, i, uint64(m.TransactionRetry.Size()))
-		n23, err := m.TransactionRetry.MarshalTo(data[i:])
+		i = encodeVarintErrors(data, i, uint64(m.TransactionPush.Size()))
+		n23, err := m.TransactionPush.MarshalTo(data[i:])
 		if err != nil {
 			return 0, err
 		}
 		i += n23
 	}
-	if m.TransactionStatus != nil {
-		data[i] = 0x42
+	if m.TransactionRetry != nil {
+		data[i] = 0x3a
 		i++
-		i = encodeVarintErrors(data, i, uint64(m.TransactionStatus.Size()))
-		n24, err := m.TransactionStatus.MarshalTo(data[i:])
+		i = encodeVarintErrors(data, i, uint64(m.TransactionRetry.Size()))
+		n24, err := m.TransactionRetry.MarshalTo(data[i:])
 		if err != nil {
 			return 0, err
 		}
 		i += n24
 	}
-	if m.WriteIntent != nil {
-		data[i] = 0x4a
+	if m.TransactionStatus != nil {
+		data[i] = 0x42
 		i++
-		i = encodeVarintErrors(data, i, uint64(m.WriteIntent.Size()))
-		n25, err := m.WriteIntent.MarshalTo(data[i:])
+		i = encodeVarintErrors(data, i, uint64(m.TransactionStatus.Size()))
+		n25, err := m.TransactionStatus.MarshalTo(data[i:])
 		if err != nil {
 			return 0, err
 		}
 		i += n25
 	}
-	if m.WriteTooOld != nil {
-		data[i] = 0x52
+	if m.WriteIntent != nil {
+		data[i] = 0x4a
 		i++
-		i = encodeVarintErrors(data, i, uint64(m.WriteTooOld.Size()))
-		n26, err := m.WriteTooOld.MarshalTo(data[i:])
+		i = encodeVarintErrors(data, i, uint64(m.WriteIntent.Size()))
+		n26, err := m.WriteIntent.MarshalTo(data[i:])
 		if err != nil {
 			return 0, err
 		}
 		i += n26
 	}
-	if m.OpRequiresTxn != nil {
-		data[i] = 0x5a
+	if m.WriteTooOld != nil {
+		data[i] = 0x52
 		i++
-		i = encodeVarintErrors(data, i, uint64(m.OpRequiresTxn.Size()))
-		n27, err := m.OpRequiresTxn.MarshalTo(data[i:])
+		i = encodeVarintErrors(data, i, uint64(m.WriteTooOld.Size()))
+		n27, err := m.WriteTooOld.MarshalTo(data[i:])
 		if err != nil {
 			return 0, err
 		}
 		i += n27
 	}
-	if m.ConditionFailed != nil {
-		data[i] = 0x62
+	if m.OpRequiresTxn != nil {
+		data[i] = 0x5a
 		i++
-		i = encodeVarintErrors(data, i, uint64(m.ConditionFailed.Size()))
-		n28, err := m.ConditionFailed.MarshalTo(data[i:])
+		i = encodeVarintErrors(data, i, uint64(m.OpRequiresTxn.Size()))
+		n28, err := m.OpRequiresTxn.MarshalTo(data[i:])
 		if err != nil {
 			return 0, err
 		}
 		i += n28
+	}
+	if m.ConditionFailed != nil {
+		data[i] = 0x62
+		i++
+		i = encodeVarintErrors(data, i, uint64(m.ConditionFailed.Size()))
+		n29, err := m.ConditionFailed.MarshalTo(data[i:])
+		if err != nil {
+			return 0, err
+		}
+		i += n29
 	}
 	if m.XXX_unrecognized != nil {
 		i += copy(data[i:], m.XXX_unrecognized)
@@ -2812,11 +2937,11 @@ func (m *Error) MarshalTo(data []byte) (n int, err error) {
 		data[i] = 0x1a
 		i++
 		i = encodeVarintErrors(data, i, uint64(m.Detail.Size()))
-		n29, err := m.Detail.MarshalTo(data[i:])
+		n30, err := m.Detail.MarshalTo(data[i:])
 		if err != nil {
 			return 0, err
 		}
-		i += n29
+		i += n30
 	}
 	if m.XXX_unrecognized != nil {
 		i += copy(data[i:], m.XXX_unrecognized)

--- a/proto/errors.proto
+++ b/proto/errors.proto
@@ -111,6 +111,13 @@ message WriteTooOldError {
   optional Timestamp existing_timestamp = 2 [(gogoproto.nullable) = false];
 }
 
+// A ReadTooOldError indicates that a read was issued for a version
+// of a key which has already been garbage collected.
+// The read should be retried with a higher timestamp.
+message ReadTooOldError {
+  optional Timestamp timestamp = 1 [(gogoproto.nullable) = false];
+}
+
 // An OpRequiresTxnError indicates that a command required to be
 // carried out in a transactional context but was not.
 // For example, a Scan which spans ranges requires a transaction.

--- a/storage/engine/cockroach/proto/data.pb.cc
+++ b/storage/engine/cockroach/proto/data.pb.cc
@@ -316,13 +316,14 @@ void protobuf_AssignDesc_cockroach_2fproto_2fdata_2eproto() {
       ::google::protobuf::MessageFactory::generated_factory(),
       sizeof(Lease));
   MVCCMetadata_descriptor_ = file->message_type(13);
-  static const int MVCCMetadata_offsets_[6] = {
+  static const int MVCCMetadata_offsets_[7] = {
     GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(MVCCMetadata, txn_),
     GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(MVCCMetadata, timestamp_),
     GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(MVCCMetadata, deleted_),
     GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(MVCCMetadata, key_bytes_),
     GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(MVCCMetadata, val_bytes_),
     GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(MVCCMetadata, value_),
+    GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(MVCCMetadata, last_evicted_),
   };
   MVCCMetadata_reflection_ =
     new ::google::protobuf::internal::GeneratedMessageReflection(
@@ -564,33 +565,35 @@ void protobuf_AddDesc_cockroach_2fproto_2fdata_2eproto() {
     "proto.NodeListB\004\310\336\037\000:\004\230\240\037\000\"w\n\005Lease\022\030\n\ne"
     "xpiration\030\001 \001(\003B\004\310\336\037\000\022\026\n\010duration\030\002 \001(\003B"
     "\004\310\336\037\000\022\022\n\004term\030\003 \001(\004B\004\310\336\037\000\022(\n\014raft_node_i"
-    "d\030\004 \001(\004B\022\310\336\037\000\342\336\037\nRaftNodeID\"\336\001\n\014MVCCMeta"
+    "d\030\004 \001(\004B\022\310\336\037\000\342\336\037\nRaftNodeID\"\226\002\n\014MVCCMeta"
     "data\022)\n\003txn\030\001 \001(\0132\034.cockroach.proto.Tran"
     "saction\0223\n\ttimestamp\030\002 \001(\0132\032.cockroach.p"
     "roto.TimestampB\004\310\336\037\000\022\025\n\007deleted\030\003 \001(\010B\004\310"
     "\336\037\000\022\027\n\tkey_bytes\030\004 \001(\003B\004\310\336\037\000\022\027\n\tval_byte"
     "s\030\005 \001(\003B\004\310\336\037\000\022%\n\005value\030\006 \001(\0132\026.cockroach"
-    ".proto.Value\"H\n\nGCMetadata\022\035\n\017last_scan_"
-    "nanos\030\001 \001(\003B\004\310\336\037\000\022\033\n\023oldest_intent_nanos"
-    "\030\002 \001(\003\"\\\n\023TimeSeriesDatapoint\022\035\n\017timesta"
-    "mp_nanos\030\001 \001(\003B\004\310\336\037\000\022\021\n\tint_value\030\002 \001(\003\022"
-    "\023\n\013float_value\030\003 \001(\002\"t\n\016TimeSeriesData\022\022"
-    "\n\004name\030\001 \001(\tB\004\310\336\037\000\022\024\n\006source\030\002 \001(\tB\004\310\336\037\000"
-    "\0228\n\ndatapoints\030\003 \003(\0132$.cockroach.proto.T"
-    "imeSeriesDatapoint\"\300\002\n\tMVCCStats\022\030\n\nlive"
-    "_bytes\030\001 \001(\003B\004\310\336\037\000\022\027\n\tkey_bytes\030\002 \001(\003B\004\310"
-    "\336\037\000\022\027\n\tval_bytes\030\003 \001(\003B\004\310\336\037\000\022\032\n\014intent_b"
-    "ytes\030\004 \001(\003B\004\310\336\037\000\022\030\n\nlive_count\030\005 \001(\003B\004\310\336"
-    "\037\000\022\027\n\tkey_count\030\006 \001(\003B\004\310\336\037\000\022\027\n\tval_count"
-    "\030\007 \001(\003B\004\310\336\037\000\022\032\n\014intent_count\030\010 \001(\003B\004\310\336\037\000"
-    "\022\030\n\nintent_age\030\t \001(\003B\004\310\336\037\000\022(\n\014gc_bytes_a"
-    "ge\030\n \001(\003B\022\310\336\037\000\342\336\037\nGCBytesAge\022\037\n\021last_upd"
-    "ate_nanos\030\013 \001(\003B\004\310\336\037\000*>\n\021ReplicaChangeTy"
-    "pe\022\017\n\013ADD_REPLICA\020\000\022\022\n\016REMOVE_REPLICA\020\001\032"
-    "\004\210\243\036\000*5\n\rIsolationType\022\020\n\014SERIALIZABLE\020\000"
-    "\022\014\n\010SNAPSHOT\020\001\032\004\210\243\036\000*B\n\021TransactionStatu"
-    "s\022\013\n\007PENDING\020\000\022\r\n\tCOMMITTED\020\001\022\013\n\007ABORTED"
-    "\020\002\032\004\210\243\036\000B\023Z\005proto\340\342\036\001\310\342\036\001\320\342\036\001", 3109);
+    ".proto.Value\0226\n\014last_evicted\030\007 \001(\0132\032.coc"
+    "kroach.proto.TimestampB\004\310\336\037\000\"H\n\nGCMetada"
+    "ta\022\035\n\017last_scan_nanos\030\001 \001(\003B\004\310\336\037\000\022\033\n\023old"
+    "est_intent_nanos\030\002 \001(\003\"\\\n\023TimeSeriesData"
+    "point\022\035\n\017timestamp_nanos\030\001 \001(\003B\004\310\336\037\000\022\021\n\t"
+    "int_value\030\002 \001(\003\022\023\n\013float_value\030\003 \001(\002\"t\n\016"
+    "TimeSeriesData\022\022\n\004name\030\001 \001(\tB\004\310\336\037\000\022\024\n\006so"
+    "urce\030\002 \001(\tB\004\310\336\037\000\0228\n\ndatapoints\030\003 \003(\0132$.c"
+    "ockroach.proto.TimeSeriesDatapoint\"\300\002\n\tM"
+    "VCCStats\022\030\n\nlive_bytes\030\001 \001(\003B\004\310\336\037\000\022\027\n\tke"
+    "y_bytes\030\002 \001(\003B\004\310\336\037\000\022\027\n\tval_bytes\030\003 \001(\003B\004"
+    "\310\336\037\000\022\032\n\014intent_bytes\030\004 \001(\003B\004\310\336\037\000\022\030\n\nlive"
+    "_count\030\005 \001(\003B\004\310\336\037\000\022\027\n\tkey_count\030\006 \001(\003B\004\310"
+    "\336\037\000\022\027\n\tval_count\030\007 \001(\003B\004\310\336\037\000\022\032\n\014intent_c"
+    "ount\030\010 \001(\003B\004\310\336\037\000\022\030\n\nintent_age\030\t \001(\003B\004\310\336"
+    "\037\000\022(\n\014gc_bytes_age\030\n \001(\003B\022\310\336\037\000\342\336\037\nGCByte"
+    "sAge\022\037\n\021last_update_nanos\030\013 \001(\003B\004\310\336\037\000*>\n"
+    "\021ReplicaChangeType\022\017\n\013ADD_REPLICA\020\000\022\022\n\016R"
+    "EMOVE_REPLICA\020\001\032\004\210\243\036\000*5\n\rIsolationType\022\020"
+    "\n\014SERIALIZABLE\020\000\022\014\n\010SNAPSHOT\020\001\032\004\210\243\036\000*B\n\021"
+    "TransactionStatus\022\013\n\007PENDING\020\000\022\r\n\tCOMMIT"
+    "TED\020\001\022\013\n\007ABORTED\020\002\032\004\210\243\036\000B\023Z\005proto\340\342\036\001\310\342\036"
+    "\001\320\342\036\001", 3165);
   ::google::protobuf::MessageFactory::InternalRegisterGeneratedFile(
     "cockroach/proto/data.proto", &protobuf_RegisterTypes);
   Timestamp::default_instance_ = new Timestamp();
@@ -5128,6 +5131,7 @@ const int MVCCMetadata::kDeletedFieldNumber;
 const int MVCCMetadata::kKeyBytesFieldNumber;
 const int MVCCMetadata::kValBytesFieldNumber;
 const int MVCCMetadata::kValueFieldNumber;
+const int MVCCMetadata::kLastEvictedFieldNumber;
 #endif  // !_MSC_VER
 
 MVCCMetadata::MVCCMetadata()
@@ -5140,6 +5144,7 @@ void MVCCMetadata::InitAsDefaultInstance() {
   txn_ = const_cast< ::cockroach::proto::Transaction*>(&::cockroach::proto::Transaction::default_instance());
   timestamp_ = const_cast< ::cockroach::proto::Timestamp*>(&::cockroach::proto::Timestamp::default_instance());
   value_ = const_cast< ::cockroach::proto::Value*>(&::cockroach::proto::Value::default_instance());
+  last_evicted_ = const_cast< ::cockroach::proto::Timestamp*>(&::cockroach::proto::Timestamp::default_instance());
 }
 
 MVCCMetadata::MVCCMetadata(const MVCCMetadata& from)
@@ -5157,6 +5162,7 @@ void MVCCMetadata::SharedCtor() {
   key_bytes_ = GOOGLE_LONGLONG(0);
   val_bytes_ = GOOGLE_LONGLONG(0);
   value_ = NULL;
+  last_evicted_ = NULL;
   ::memset(_has_bits_, 0, sizeof(_has_bits_));
 }
 
@@ -5170,6 +5176,7 @@ void MVCCMetadata::SharedDtor() {
     delete txn_;
     delete timestamp_;
     delete value_;
+    delete last_evicted_;
   }
 }
 
@@ -5205,7 +5212,7 @@ void MVCCMetadata::Clear() {
     ::memset(&first, 0, n);                                \
   } while (0)
 
-  if (_has_bits_[0 / 32] & 63) {
+  if (_has_bits_[0 / 32] & 127) {
     ZR_(key_bytes_, val_bytes_);
     if (has_txn()) {
       if (txn_ != NULL) txn_->::cockroach::proto::Transaction::Clear();
@@ -5216,6 +5223,9 @@ void MVCCMetadata::Clear() {
     deleted_ = false;
     if (has_value()) {
       if (value_ != NULL) value_->::cockroach::proto::Value::Clear();
+    }
+    if (has_last_evicted()) {
+      if (last_evicted_ != NULL) last_evicted_->::cockroach::proto::Timestamp::Clear();
     }
   }
 
@@ -5315,6 +5325,19 @@ bool MVCCMetadata::MergePartialFromCodedStream(
         } else {
           goto handle_unusual;
         }
+        if (input->ExpectTag(58)) goto parse_last_evicted;
+        break;
+      }
+
+      // optional .cockroach.proto.Timestamp last_evicted = 7;
+      case 7: {
+        if (tag == 58) {
+         parse_last_evicted:
+          DO_(::google::protobuf::internal::WireFormatLite::ReadMessageNoVirtual(
+               input, mutable_last_evicted()));
+        } else {
+          goto handle_unusual;
+        }
         if (input->ExpectAtEnd()) goto success;
         break;
       }
@@ -5377,6 +5400,12 @@ void MVCCMetadata::SerializeWithCachedSizes(
       6, this->value(), output);
   }
 
+  // optional .cockroach.proto.Timestamp last_evicted = 7;
+  if (has_last_evicted()) {
+    ::google::protobuf::internal::WireFormatLite::WriteMessageMaybeToArray(
+      7, this->last_evicted(), output);
+  }
+
   if (!unknown_fields().empty()) {
     ::google::protobuf::internal::WireFormat::SerializeUnknownFields(
         unknown_fields(), output);
@@ -5421,6 +5450,13 @@ void MVCCMetadata::SerializeWithCachedSizes(
     target = ::google::protobuf::internal::WireFormatLite::
       WriteMessageNoVirtualToArray(
         6, this->value(), target);
+  }
+
+  // optional .cockroach.proto.Timestamp last_evicted = 7;
+  if (has_last_evicted()) {
+    target = ::google::protobuf::internal::WireFormatLite::
+      WriteMessageNoVirtualToArray(
+        7, this->last_evicted(), target);
   }
 
   if (!unknown_fields().empty()) {
@@ -5475,6 +5511,13 @@ int MVCCMetadata::ByteSize() const {
           this->value());
     }
 
+    // optional .cockroach.proto.Timestamp last_evicted = 7;
+    if (has_last_evicted()) {
+      total_size += 1 +
+        ::google::protobuf::internal::WireFormatLite::MessageSizeNoVirtual(
+          this->last_evicted());
+    }
+
   }
   if (!unknown_fields().empty()) {
     total_size +=
@@ -5520,6 +5563,9 @@ void MVCCMetadata::MergeFrom(const MVCCMetadata& from) {
     if (from.has_value()) {
       mutable_value()->::cockroach::proto::Value::MergeFrom(from.value());
     }
+    if (from.has_last_evicted()) {
+      mutable_last_evicted()->::cockroach::proto::Timestamp::MergeFrom(from.last_evicted());
+    }
   }
   mutable_unknown_fields()->MergeFrom(from.unknown_fields());
 }
@@ -5549,6 +5595,7 @@ void MVCCMetadata::Swap(MVCCMetadata* other) {
     std::swap(key_bytes_, other->key_bytes_);
     std::swap(val_bytes_, other->val_bytes_);
     std::swap(value_, other->value_);
+    std::swap(last_evicted_, other->last_evicted_);
     std::swap(_has_bits_[0], other->_has_bits_[0]);
     _unknown_fields_.Swap(&other->_unknown_fields_);
     std::swap(_cached_size_, other->_cached_size_);

--- a/storage/engine/cockroach/proto/data.pb.h
+++ b/storage/engine/cockroach/proto/data.pb.h
@@ -1651,6 +1651,15 @@ class MVCCMetadata : public ::google::protobuf::Message {
   inline ::cockroach::proto::Value* release_value();
   inline void set_allocated_value(::cockroach::proto::Value* value);
 
+  // optional .cockroach.proto.Timestamp last_evicted = 7;
+  inline bool has_last_evicted() const;
+  inline void clear_last_evicted();
+  static const int kLastEvictedFieldNumber = 7;
+  inline const ::cockroach::proto::Timestamp& last_evicted() const;
+  inline ::cockroach::proto::Timestamp* mutable_last_evicted();
+  inline ::cockroach::proto::Timestamp* release_last_evicted();
+  inline void set_allocated_last_evicted(::cockroach::proto::Timestamp* last_evicted);
+
   // @@protoc_insertion_point(class_scope:cockroach.proto.MVCCMetadata)
  private:
   inline void set_has_txn();
@@ -1665,6 +1674,8 @@ class MVCCMetadata : public ::google::protobuf::Message {
   inline void clear_has_val_bytes();
   inline void set_has_value();
   inline void clear_has_value();
+  inline void set_has_last_evicted();
+  inline void clear_has_last_evicted();
 
   ::google::protobuf::UnknownFieldSet _unknown_fields_;
 
@@ -1675,6 +1686,7 @@ class MVCCMetadata : public ::google::protobuf::Message {
   ::google::protobuf::int64 key_bytes_;
   ::google::protobuf::int64 val_bytes_;
   ::cockroach::proto::Value* value_;
+  ::cockroach::proto::Timestamp* last_evicted_;
   bool deleted_;
   friend void  protobuf_AddDesc_cockroach_2fproto_2fdata_2eproto();
   friend void protobuf_AssignDesc_cockroach_2fproto_2fdata_2eproto();
@@ -4245,6 +4257,47 @@ inline void MVCCMetadata::set_allocated_value(::cockroach::proto::Value* value) 
     clear_has_value();
   }
   // @@protoc_insertion_point(field_set_allocated:cockroach.proto.MVCCMetadata.value)
+}
+
+// optional .cockroach.proto.Timestamp last_evicted = 7;
+inline bool MVCCMetadata::has_last_evicted() const {
+  return (_has_bits_[0] & 0x00000040u) != 0;
+}
+inline void MVCCMetadata::set_has_last_evicted() {
+  _has_bits_[0] |= 0x00000040u;
+}
+inline void MVCCMetadata::clear_has_last_evicted() {
+  _has_bits_[0] &= ~0x00000040u;
+}
+inline void MVCCMetadata::clear_last_evicted() {
+  if (last_evicted_ != NULL) last_evicted_->::cockroach::proto::Timestamp::Clear();
+  clear_has_last_evicted();
+}
+inline const ::cockroach::proto::Timestamp& MVCCMetadata::last_evicted() const {
+  // @@protoc_insertion_point(field_get:cockroach.proto.MVCCMetadata.last_evicted)
+  return last_evicted_ != NULL ? *last_evicted_ : *default_instance_->last_evicted_;
+}
+inline ::cockroach::proto::Timestamp* MVCCMetadata::mutable_last_evicted() {
+  set_has_last_evicted();
+  if (last_evicted_ == NULL) last_evicted_ = new ::cockroach::proto::Timestamp;
+  // @@protoc_insertion_point(field_mutable:cockroach.proto.MVCCMetadata.last_evicted)
+  return last_evicted_;
+}
+inline ::cockroach::proto::Timestamp* MVCCMetadata::release_last_evicted() {
+  clear_has_last_evicted();
+  ::cockroach::proto::Timestamp* temp = last_evicted_;
+  last_evicted_ = NULL;
+  return temp;
+}
+inline void MVCCMetadata::set_allocated_last_evicted(::cockroach::proto::Timestamp* last_evicted) {
+  delete last_evicted_;
+  last_evicted_ = last_evicted;
+  if (last_evicted) {
+    set_has_last_evicted();
+  } else {
+    clear_has_last_evicted();
+  }
+  // @@protoc_insertion_point(field_set_allocated:cockroach.proto.MVCCMetadata.last_evicted)
 }
 
 // -------------------------------------------------------------------

--- a/storage/engine/cockroach/proto/errors.pb.cc
+++ b/storage/engine/cockroach/proto/errors.pb.cc
@@ -51,6 +51,9 @@ const ::google::protobuf::internal::GeneratedMessageReflection*
 const ::google::protobuf::Descriptor* WriteTooOldError_descriptor_ = NULL;
 const ::google::protobuf::internal::GeneratedMessageReflection*
   WriteTooOldError_reflection_ = NULL;
+const ::google::protobuf::Descriptor* ReadTooOldError_descriptor_ = NULL;
+const ::google::protobuf::internal::GeneratedMessageReflection*
+  ReadTooOldError_reflection_ = NULL;
 const ::google::protobuf::Descriptor* OpRequiresTxnError_descriptor_ = NULL;
 const ::google::protobuf::internal::GeneratedMessageReflection*
   OpRequiresTxnError_reflection_ = NULL;
@@ -246,7 +249,22 @@ void protobuf_AssignDesc_cockroach_2fproto_2ferrors_2eproto() {
       ::google::protobuf::DescriptorPool::generated_pool(),
       ::google::protobuf::MessageFactory::generated_factory(),
       sizeof(WriteTooOldError));
-  OpRequiresTxnError_descriptor_ = file->message_type(10);
+  ReadTooOldError_descriptor_ = file->message_type(10);
+  static const int ReadTooOldError_offsets_[1] = {
+    GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(ReadTooOldError, timestamp_),
+  };
+  ReadTooOldError_reflection_ =
+    new ::google::protobuf::internal::GeneratedMessageReflection(
+      ReadTooOldError_descriptor_,
+      ReadTooOldError::default_instance_,
+      ReadTooOldError_offsets_,
+      GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(ReadTooOldError, _has_bits_[0]),
+      GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(ReadTooOldError, _unknown_fields_),
+      -1,
+      ::google::protobuf::DescriptorPool::generated_pool(),
+      ::google::protobuf::MessageFactory::generated_factory(),
+      sizeof(ReadTooOldError));
+  OpRequiresTxnError_descriptor_ = file->message_type(11);
   static const int OpRequiresTxnError_offsets_[1] = {
   };
   OpRequiresTxnError_reflection_ =
@@ -260,7 +278,7 @@ void protobuf_AssignDesc_cockroach_2fproto_2ferrors_2eproto() {
       ::google::protobuf::DescriptorPool::generated_pool(),
       ::google::protobuf::MessageFactory::generated_factory(),
       sizeof(OpRequiresTxnError));
-  ConditionFailedError_descriptor_ = file->message_type(11);
+  ConditionFailedError_descriptor_ = file->message_type(12);
   static const int ConditionFailedError_offsets_[1] = {
     GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(ConditionFailedError, actual_value_),
   };
@@ -275,7 +293,7 @@ void protobuf_AssignDesc_cockroach_2fproto_2ferrors_2eproto() {
       ::google::protobuf::DescriptorPool::generated_pool(),
       ::google::protobuf::MessageFactory::generated_factory(),
       sizeof(ConditionFailedError));
-  ErrorDetail_descriptor_ = file->message_type(12);
+  ErrorDetail_descriptor_ = file->message_type(13);
   static const int ErrorDetail_offsets_[13] = {
     PROTO2_GENERATED_DEFAULT_ONEOF_FIELD_OFFSET(ErrorDetail_default_oneof_instance_, not_leader_),
     PROTO2_GENERATED_DEFAULT_ONEOF_FIELD_OFFSET(ErrorDetail_default_oneof_instance_, range_not_found_),
@@ -304,7 +322,7 @@ void protobuf_AssignDesc_cockroach_2fproto_2ferrors_2eproto() {
       ::google::protobuf::DescriptorPool::generated_pool(),
       ::google::protobuf::MessageFactory::generated_factory(),
       sizeof(ErrorDetail));
-  Error_descriptor_ = file->message_type(13);
+  Error_descriptor_ = file->message_type(14);
   static const int Error_offsets_[4] = {
     GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(Error, message_),
     GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(Error, retryable_),
@@ -356,6 +374,8 @@ void protobuf_RegisterTypes(const ::std::string&) {
   ::google::protobuf::MessageFactory::InternalRegisterGeneratedMessage(
     WriteTooOldError_descriptor_, &WriteTooOldError::default_instance());
   ::google::protobuf::MessageFactory::InternalRegisterGeneratedMessage(
+    ReadTooOldError_descriptor_, &ReadTooOldError::default_instance());
+  ::google::protobuf::MessageFactory::InternalRegisterGeneratedMessage(
     OpRequiresTxnError_descriptor_, &OpRequiresTxnError::default_instance());
   ::google::protobuf::MessageFactory::InternalRegisterGeneratedMessage(
     ConditionFailedError_descriptor_, &ConditionFailedError::default_instance());
@@ -388,6 +408,8 @@ void protobuf_ShutdownFile_cockroach_2fproto_2ferrors_2eproto() {
   delete WriteIntentError_reflection_;
   delete WriteTooOldError::default_instance_;
   delete WriteTooOldError_reflection_;
+  delete ReadTooOldError::default_instance_;
+  delete ReadTooOldError_reflection_;
   delete OpRequiresTxnError::default_instance_;
   delete OpRequiresTxnError_reflection_;
   delete ConditionFailedError::default_instance_;
@@ -438,37 +460,39 @@ void protobuf_AddDesc_cockroach_2fproto_2ferrors_2eproto() {
     "\000\"\205\001\n\020WriteTooOldError\0223\n\ttimestamp\030\001 \001("
     "\0132\032.cockroach.proto.TimestampB\004\310\336\037\000\022<\n\022e"
     "xisting_timestamp\030\002 \001(\0132\032.cockroach.prot"
-    "o.TimestampB\004\310\336\037\000\"\024\n\022OpRequiresTxnError\""
-    "D\n\024ConditionFailedError\022,\n\014actual_value\030"
-    "\001 \001(\0132\026.cockroach.proto.Value\"\314\006\n\013ErrorD"
-    "etail\0225\n\nnot_leader\030\001 \001(\0132\037.cockroach.pr"
-    "oto.NotLeaderErrorH\000\022>\n\017range_not_found\030"
-    "\002 \001(\0132#.cockroach.proto.RangeNotFoundErr"
-    "orH\000\022D\n\022range_key_mismatch\030\003 \001(\0132&.cockr"
-    "oach.proto.RangeKeyMismatchErrorH\000\022_\n re"
-    "ad_within_uncertainty_interval\030\004 \001(\01323.c"
-    "ockroach.proto.ReadWithinUncertaintyInte"
-    "rvalErrorH\000\022G\n\023transaction_aborted\030\005 \001(\013"
-    "2(.cockroach.proto.TransactionAbortedErr"
-    "orH\000\022A\n\020transaction_push\030\006 \001(\0132%.cockroa"
-    "ch.proto.TransactionPushErrorH\000\022C\n\021trans"
-    "action_retry\030\007 \001(\0132&.cockroach.proto.Tra"
-    "nsactionRetryErrorH\000\022E\n\022transaction_stat"
-    "us\030\010 \001(\0132\'.cockroach.proto.TransactionSt"
-    "atusErrorH\000\0229\n\014write_intent\030\t \001(\0132!.cock"
-    "roach.proto.WriteIntentErrorH\000\022:\n\rwrite_"
-    "too_old\030\n \001(\0132!.cockroach.proto.WriteToo"
-    "OldErrorH\000\022>\n\017op_requires_txn\030\013 \001(\0132#.co"
-    "ckroach.proto.OpRequiresTxnErrorH\000\022A\n\020co"
-    "ndition_failed\030\014 \001(\0132%.cockroach.proto.C"
-    "onditionFailedErrorH\000:\004\310\240\037\001B\007\n\005value\"\255\001\n"
-    "\005Error\022\025\n\007message\030\001 \001(\tB\004\310\336\037\000\022\027\n\tretryab"
-    "le\030\002 \001(\010B\004\310\336\037\000\022F\n\023transaction_restart\030\004 "
-    "\001(\0162#.cockroach.proto.TransactionRestart"
-    "B\004\310\336\037\000\022,\n\006detail\030\003 \001(\0132\034.cockroach.proto"
-    ".ErrorDetail*;\n\022TransactionRestart\022\t\n\005AB"
-    "ORT\020\000\022\013\n\007BACKOFF\020\001\022\r\n\tIMMEDIATE\020\002B\023Z\005pro"
-    "to\340\342\036\001\310\342\036\001\320\342\036\001", 2374);
+    "o.TimestampB\004\310\336\037\000\"F\n\017ReadTooOldError\0223\n\t"
+    "timestamp\030\001 \001(\0132\032.cockroach.proto.Timest"
+    "ampB\004\310\336\037\000\"\024\n\022OpRequiresTxnError\"D\n\024Condi"
+    "tionFailedError\022,\n\014actual_value\030\001 \001(\0132\026."
+    "cockroach.proto.Value\"\314\006\n\013ErrorDetail\0225\n"
+    "\nnot_leader\030\001 \001(\0132\037.cockroach.proto.NotL"
+    "eaderErrorH\000\022>\n\017range_not_found\030\002 \001(\0132#."
+    "cockroach.proto.RangeNotFoundErrorH\000\022D\n\022"
+    "range_key_mismatch\030\003 \001(\0132&.cockroach.pro"
+    "to.RangeKeyMismatchErrorH\000\022_\n read_withi"
+    "n_uncertainty_interval\030\004 \001(\01323.cockroach"
+    ".proto.ReadWithinUncertaintyIntervalErro"
+    "rH\000\022G\n\023transaction_aborted\030\005 \001(\0132(.cockr"
+    "oach.proto.TransactionAbortedErrorH\000\022A\n\020"
+    "transaction_push\030\006 \001(\0132%.cockroach.proto"
+    ".TransactionPushErrorH\000\022C\n\021transaction_r"
+    "etry\030\007 \001(\0132&.cockroach.proto.Transaction"
+    "RetryErrorH\000\022E\n\022transaction_status\030\010 \001(\013"
+    "2\'.cockroach.proto.TransactionStatusErro"
+    "rH\000\0229\n\014write_intent\030\t \001(\0132!.cockroach.pr"
+    "oto.WriteIntentErrorH\000\022:\n\rwrite_too_old\030"
+    "\n \001(\0132!.cockroach.proto.WriteTooOldError"
+    "H\000\022>\n\017op_requires_txn\030\013 \001(\0132#.cockroach."
+    "proto.OpRequiresTxnErrorH\000\022A\n\020condition_"
+    "failed\030\014 \001(\0132%.cockroach.proto.Condition"
+    "FailedErrorH\000:\004\310\240\037\001B\007\n\005value\"\255\001\n\005Error\022\025"
+    "\n\007message\030\001 \001(\tB\004\310\336\037\000\022\027\n\tretryable\030\002 \001(\010"
+    "B\004\310\336\037\000\022F\n\023transaction_restart\030\004 \001(\0162#.co"
+    "ckroach.proto.TransactionRestartB\004\310\336\037\000\022,"
+    "\n\006detail\030\003 \001(\0132\034.cockroach.proto.ErrorDe"
+    "tail*;\n\022TransactionRestart\022\t\n\005ABORT\020\000\022\013\n"
+    "\007BACKOFF\020\001\022\r\n\tIMMEDIATE\020\002B\023Z\005proto\340\342\036\001\310\342"
+    "\036\001\320\342\036\001", 2446);
   ::google::protobuf::MessageFactory::InternalRegisterGeneratedFile(
     "cockroach/proto/errors.proto", &protobuf_RegisterTypes);
   NotLeaderError::default_instance_ = new NotLeaderError();
@@ -481,6 +505,7 @@ void protobuf_AddDesc_cockroach_2fproto_2ferrors_2eproto() {
   TransactionStatusError::default_instance_ = new TransactionStatusError();
   WriteIntentError::default_instance_ = new WriteIntentError();
   WriteTooOldError::default_instance_ = new WriteTooOldError();
+  ReadTooOldError::default_instance_ = new ReadTooOldError();
   OpRequiresTxnError::default_instance_ = new OpRequiresTxnError();
   ConditionFailedError::default_instance_ = new ConditionFailedError();
   ErrorDetail::default_instance_ = new ErrorDetail();
@@ -496,6 +521,7 @@ void protobuf_AddDesc_cockroach_2fproto_2ferrors_2eproto() {
   TransactionStatusError::default_instance_->InitAsDefaultInstance();
   WriteIntentError::default_instance_->InitAsDefaultInstance();
   WriteTooOldError::default_instance_->InitAsDefaultInstance();
+  ReadTooOldError::default_instance_->InitAsDefaultInstance();
   OpRequiresTxnError::default_instance_->InitAsDefaultInstance();
   ConditionFailedError::default_instance_->InitAsDefaultInstance();
   ErrorDetail::default_instance_->InitAsDefaultInstance();
@@ -3170,6 +3196,233 @@ void WriteTooOldError::Swap(WriteTooOldError* other) {
   ::google::protobuf::Metadata metadata;
   metadata.descriptor = WriteTooOldError_descriptor_;
   metadata.reflection = WriteTooOldError_reflection_;
+  return metadata;
+}
+
+
+// ===================================================================
+
+#ifndef _MSC_VER
+const int ReadTooOldError::kTimestampFieldNumber;
+#endif  // !_MSC_VER
+
+ReadTooOldError::ReadTooOldError()
+  : ::google::protobuf::Message() {
+  SharedCtor();
+  // @@protoc_insertion_point(constructor:cockroach.proto.ReadTooOldError)
+}
+
+void ReadTooOldError::InitAsDefaultInstance() {
+  timestamp_ = const_cast< ::cockroach::proto::Timestamp*>(&::cockroach::proto::Timestamp::default_instance());
+}
+
+ReadTooOldError::ReadTooOldError(const ReadTooOldError& from)
+  : ::google::protobuf::Message() {
+  SharedCtor();
+  MergeFrom(from);
+  // @@protoc_insertion_point(copy_constructor:cockroach.proto.ReadTooOldError)
+}
+
+void ReadTooOldError::SharedCtor() {
+  _cached_size_ = 0;
+  timestamp_ = NULL;
+  ::memset(_has_bits_, 0, sizeof(_has_bits_));
+}
+
+ReadTooOldError::~ReadTooOldError() {
+  // @@protoc_insertion_point(destructor:cockroach.proto.ReadTooOldError)
+  SharedDtor();
+}
+
+void ReadTooOldError::SharedDtor() {
+  if (this != default_instance_) {
+    delete timestamp_;
+  }
+}
+
+void ReadTooOldError::SetCachedSize(int size) const {
+  GOOGLE_SAFE_CONCURRENT_WRITES_BEGIN();
+  _cached_size_ = size;
+  GOOGLE_SAFE_CONCURRENT_WRITES_END();
+}
+const ::google::protobuf::Descriptor* ReadTooOldError::descriptor() {
+  protobuf_AssignDescriptorsOnce();
+  return ReadTooOldError_descriptor_;
+}
+
+const ReadTooOldError& ReadTooOldError::default_instance() {
+  if (default_instance_ == NULL) protobuf_AddDesc_cockroach_2fproto_2ferrors_2eproto();
+  return *default_instance_;
+}
+
+ReadTooOldError* ReadTooOldError::default_instance_ = NULL;
+
+ReadTooOldError* ReadTooOldError::New() const {
+  return new ReadTooOldError;
+}
+
+void ReadTooOldError::Clear() {
+  if (has_timestamp()) {
+    if (timestamp_ != NULL) timestamp_->::cockroach::proto::Timestamp::Clear();
+  }
+  ::memset(_has_bits_, 0, sizeof(_has_bits_));
+  mutable_unknown_fields()->Clear();
+}
+
+bool ReadTooOldError::MergePartialFromCodedStream(
+    ::google::protobuf::io::CodedInputStream* input) {
+#define DO_(EXPRESSION) if (!(EXPRESSION)) goto failure
+  ::google::protobuf::uint32 tag;
+  // @@protoc_insertion_point(parse_start:cockroach.proto.ReadTooOldError)
+  for (;;) {
+    ::std::pair< ::google::protobuf::uint32, bool> p = input->ReadTagWithCutoff(127);
+    tag = p.first;
+    if (!p.second) goto handle_unusual;
+    switch (::google::protobuf::internal::WireFormatLite::GetTagFieldNumber(tag)) {
+      // optional .cockroach.proto.Timestamp timestamp = 1;
+      case 1: {
+        if (tag == 10) {
+          DO_(::google::protobuf::internal::WireFormatLite::ReadMessageNoVirtual(
+               input, mutable_timestamp()));
+        } else {
+          goto handle_unusual;
+        }
+        if (input->ExpectAtEnd()) goto success;
+        break;
+      }
+
+      default: {
+      handle_unusual:
+        if (tag == 0 ||
+            ::google::protobuf::internal::WireFormatLite::GetTagWireType(tag) ==
+            ::google::protobuf::internal::WireFormatLite::WIRETYPE_END_GROUP) {
+          goto success;
+        }
+        DO_(::google::protobuf::internal::WireFormat::SkipField(
+              input, tag, mutable_unknown_fields()));
+        break;
+      }
+    }
+  }
+success:
+  // @@protoc_insertion_point(parse_success:cockroach.proto.ReadTooOldError)
+  return true;
+failure:
+  // @@protoc_insertion_point(parse_failure:cockroach.proto.ReadTooOldError)
+  return false;
+#undef DO_
+}
+
+void ReadTooOldError::SerializeWithCachedSizes(
+    ::google::protobuf::io::CodedOutputStream* output) const {
+  // @@protoc_insertion_point(serialize_start:cockroach.proto.ReadTooOldError)
+  // optional .cockroach.proto.Timestamp timestamp = 1;
+  if (has_timestamp()) {
+    ::google::protobuf::internal::WireFormatLite::WriteMessageMaybeToArray(
+      1, this->timestamp(), output);
+  }
+
+  if (!unknown_fields().empty()) {
+    ::google::protobuf::internal::WireFormat::SerializeUnknownFields(
+        unknown_fields(), output);
+  }
+  // @@protoc_insertion_point(serialize_end:cockroach.proto.ReadTooOldError)
+}
+
+::google::protobuf::uint8* ReadTooOldError::SerializeWithCachedSizesToArray(
+    ::google::protobuf::uint8* target) const {
+  // @@protoc_insertion_point(serialize_to_array_start:cockroach.proto.ReadTooOldError)
+  // optional .cockroach.proto.Timestamp timestamp = 1;
+  if (has_timestamp()) {
+    target = ::google::protobuf::internal::WireFormatLite::
+      WriteMessageNoVirtualToArray(
+        1, this->timestamp(), target);
+  }
+
+  if (!unknown_fields().empty()) {
+    target = ::google::protobuf::internal::WireFormat::SerializeUnknownFieldsToArray(
+        unknown_fields(), target);
+  }
+  // @@protoc_insertion_point(serialize_to_array_end:cockroach.proto.ReadTooOldError)
+  return target;
+}
+
+int ReadTooOldError::ByteSize() const {
+  int total_size = 0;
+
+  if (_has_bits_[0 / 32] & (0xffu << (0 % 32))) {
+    // optional .cockroach.proto.Timestamp timestamp = 1;
+    if (has_timestamp()) {
+      total_size += 1 +
+        ::google::protobuf::internal::WireFormatLite::MessageSizeNoVirtual(
+          this->timestamp());
+    }
+
+  }
+  if (!unknown_fields().empty()) {
+    total_size +=
+      ::google::protobuf::internal::WireFormat::ComputeUnknownFieldsSize(
+        unknown_fields());
+  }
+  GOOGLE_SAFE_CONCURRENT_WRITES_BEGIN();
+  _cached_size_ = total_size;
+  GOOGLE_SAFE_CONCURRENT_WRITES_END();
+  return total_size;
+}
+
+void ReadTooOldError::MergeFrom(const ::google::protobuf::Message& from) {
+  GOOGLE_CHECK_NE(&from, this);
+  const ReadTooOldError* source =
+    ::google::protobuf::internal::dynamic_cast_if_available<const ReadTooOldError*>(
+      &from);
+  if (source == NULL) {
+    ::google::protobuf::internal::ReflectionOps::Merge(from, this);
+  } else {
+    MergeFrom(*source);
+  }
+}
+
+void ReadTooOldError::MergeFrom(const ReadTooOldError& from) {
+  GOOGLE_CHECK_NE(&from, this);
+  if (from._has_bits_[0 / 32] & (0xffu << (0 % 32))) {
+    if (from.has_timestamp()) {
+      mutable_timestamp()->::cockroach::proto::Timestamp::MergeFrom(from.timestamp());
+    }
+  }
+  mutable_unknown_fields()->MergeFrom(from.unknown_fields());
+}
+
+void ReadTooOldError::CopyFrom(const ::google::protobuf::Message& from) {
+  if (&from == this) return;
+  Clear();
+  MergeFrom(from);
+}
+
+void ReadTooOldError::CopyFrom(const ReadTooOldError& from) {
+  if (&from == this) return;
+  Clear();
+  MergeFrom(from);
+}
+
+bool ReadTooOldError::IsInitialized() const {
+
+  return true;
+}
+
+void ReadTooOldError::Swap(ReadTooOldError* other) {
+  if (other != this) {
+    std::swap(timestamp_, other->timestamp_);
+    std::swap(_has_bits_[0], other->_has_bits_[0]);
+    _unknown_fields_.Swap(&other->_unknown_fields_);
+    std::swap(_cached_size_, other->_cached_size_);
+  }
+}
+
+::google::protobuf::Metadata ReadTooOldError::GetMetadata() const {
+  protobuf_AssignDescriptorsOnce();
+  ::google::protobuf::Metadata metadata;
+  metadata.descriptor = ReadTooOldError_descriptor_;
+  metadata.reflection = ReadTooOldError_reflection_;
   return metadata;
 }
 

--- a/storage/engine/cockroach/proto/errors.pb.h
+++ b/storage/engine/cockroach/proto/errors.pb.h
@@ -48,6 +48,7 @@ class TransactionRetryError;
 class TransactionStatusError;
 class WriteIntentError;
 class WriteTooOldError;
+class ReadTooOldError;
 class OpRequiresTxnError;
 class ConditionFailedError;
 class ErrorDetail;
@@ -986,6 +987,87 @@ class WriteTooOldError : public ::google::protobuf::Message {
 
   void InitAsDefaultInstance();
   static WriteTooOldError* default_instance_;
+};
+// -------------------------------------------------------------------
+
+class ReadTooOldError : public ::google::protobuf::Message {
+ public:
+  ReadTooOldError();
+  virtual ~ReadTooOldError();
+
+  ReadTooOldError(const ReadTooOldError& from);
+
+  inline ReadTooOldError& operator=(const ReadTooOldError& from) {
+    CopyFrom(from);
+    return *this;
+  }
+
+  inline const ::google::protobuf::UnknownFieldSet& unknown_fields() const {
+    return _unknown_fields_;
+  }
+
+  inline ::google::protobuf::UnknownFieldSet* mutable_unknown_fields() {
+    return &_unknown_fields_;
+  }
+
+  static const ::google::protobuf::Descriptor* descriptor();
+  static const ReadTooOldError& default_instance();
+
+  void Swap(ReadTooOldError* other);
+
+  // implements Message ----------------------------------------------
+
+  ReadTooOldError* New() const;
+  void CopyFrom(const ::google::protobuf::Message& from);
+  void MergeFrom(const ::google::protobuf::Message& from);
+  void CopyFrom(const ReadTooOldError& from);
+  void MergeFrom(const ReadTooOldError& from);
+  void Clear();
+  bool IsInitialized() const;
+
+  int ByteSize() const;
+  bool MergePartialFromCodedStream(
+      ::google::protobuf::io::CodedInputStream* input);
+  void SerializeWithCachedSizes(
+      ::google::protobuf::io::CodedOutputStream* output) const;
+  ::google::protobuf::uint8* SerializeWithCachedSizesToArray(::google::protobuf::uint8* output) const;
+  int GetCachedSize() const { return _cached_size_; }
+  private:
+  void SharedCtor();
+  void SharedDtor();
+  void SetCachedSize(int size) const;
+  public:
+  ::google::protobuf::Metadata GetMetadata() const;
+
+  // nested types ----------------------------------------------------
+
+  // accessors -------------------------------------------------------
+
+  // optional .cockroach.proto.Timestamp timestamp = 1;
+  inline bool has_timestamp() const;
+  inline void clear_timestamp();
+  static const int kTimestampFieldNumber = 1;
+  inline const ::cockroach::proto::Timestamp& timestamp() const;
+  inline ::cockroach::proto::Timestamp* mutable_timestamp();
+  inline ::cockroach::proto::Timestamp* release_timestamp();
+  inline void set_allocated_timestamp(::cockroach::proto::Timestamp* timestamp);
+
+  // @@protoc_insertion_point(class_scope:cockroach.proto.ReadTooOldError)
+ private:
+  inline void set_has_timestamp();
+  inline void clear_has_timestamp();
+
+  ::google::protobuf::UnknownFieldSet _unknown_fields_;
+
+  ::google::protobuf::uint32 _has_bits_[1];
+  mutable int _cached_size_;
+  ::cockroach::proto::Timestamp* timestamp_;
+  friend void  protobuf_AddDesc_cockroach_2fproto_2ferrors_2eproto();
+  friend void protobuf_AssignDesc_cockroach_2fproto_2ferrors_2eproto();
+  friend void protobuf_ShutdownFile_cockroach_2fproto_2ferrors_2eproto();
+
+  void InitAsDefaultInstance();
+  static ReadTooOldError* default_instance_;
 };
 // -------------------------------------------------------------------
 
@@ -2364,6 +2446,51 @@ inline void WriteTooOldError::set_allocated_existing_timestamp(::cockroach::prot
     clear_has_existing_timestamp();
   }
   // @@protoc_insertion_point(field_set_allocated:cockroach.proto.WriteTooOldError.existing_timestamp)
+}
+
+// -------------------------------------------------------------------
+
+// ReadTooOldError
+
+// optional .cockroach.proto.Timestamp timestamp = 1;
+inline bool ReadTooOldError::has_timestamp() const {
+  return (_has_bits_[0] & 0x00000001u) != 0;
+}
+inline void ReadTooOldError::set_has_timestamp() {
+  _has_bits_[0] |= 0x00000001u;
+}
+inline void ReadTooOldError::clear_has_timestamp() {
+  _has_bits_[0] &= ~0x00000001u;
+}
+inline void ReadTooOldError::clear_timestamp() {
+  if (timestamp_ != NULL) timestamp_->::cockroach::proto::Timestamp::Clear();
+  clear_has_timestamp();
+}
+inline const ::cockroach::proto::Timestamp& ReadTooOldError::timestamp() const {
+  // @@protoc_insertion_point(field_get:cockroach.proto.ReadTooOldError.timestamp)
+  return timestamp_ != NULL ? *timestamp_ : *default_instance_->timestamp_;
+}
+inline ::cockroach::proto::Timestamp* ReadTooOldError::mutable_timestamp() {
+  set_has_timestamp();
+  if (timestamp_ == NULL) timestamp_ = new ::cockroach::proto::Timestamp;
+  // @@protoc_insertion_point(field_mutable:cockroach.proto.ReadTooOldError.timestamp)
+  return timestamp_;
+}
+inline ::cockroach::proto::Timestamp* ReadTooOldError::release_timestamp() {
+  clear_has_timestamp();
+  ::cockroach::proto::Timestamp* temp = timestamp_;
+  timestamp_ = NULL;
+  return temp;
+}
+inline void ReadTooOldError::set_allocated_timestamp(::cockroach::proto::Timestamp* timestamp) {
+  delete timestamp_;
+  timestamp_ = timestamp;
+  if (timestamp) {
+    set_has_timestamp();
+  } else {
+    clear_has_timestamp();
+  }
+  // @@protoc_insertion_point(field_set_allocated:cockroach.proto.ReadTooOldError.timestamp)
 }
 
 // -------------------------------------------------------------------

--- a/storage/engine/mvcc.go
+++ b/storage/engine/mvcc.go
@@ -1178,7 +1178,6 @@ func MVCCResolveWriteIntentRange(engine Engine, ms *proto.MVCCStats, key, endKey
 // key, clearing all values with timestamps <= to expiration.
 func MVCCGarbageCollect(engine Engine, ms *proto.MVCCStats, keys []proto.InternalGCRequest_GCKey, timestamp proto.Timestamp) error {
 	iter := engine.NewIterator()
-
 	// Iterate through specified GC keys.
 	for _, gcKey := range keys {
 		encKey := MVCCEncodeKey(gcKey.Key)
@@ -1188,6 +1187,9 @@ func MVCCGarbageCollect(engine Engine, ms *proto.MVCCStats, keys []proto.Interna
 		}
 		// First, check whether all values of the key are being deleted.
 		meta := &proto.MVCCMetadata{}
+		metaKey := iter.Key()
+		origMetaKeySize := int64(len(metaKey))
+		origMetaValSize := int64(len(iter.Value()))
 		if err := gogoproto.Unmarshal(iter.Value(), meta); err != nil {
 			return util.Errorf("unable to marshal mvcc meta: %s", err)
 		}
@@ -1201,6 +1203,7 @@ func MVCCGarbageCollect(engine Engine, ms *proto.MVCCStats, keys []proto.Interna
 			ageSeconds := timestamp.WallTime/1E9 - meta.Timestamp.WallTime/1E9
 			updateStatsOnGC(ms, gcKey.Key, int64(len(iter.Key())), int64(len(iter.Value())), meta, ageSeconds)
 			engine.Clear(iter.Key())
+			metaKey = nil // mark as deleted for later use.
 		}
 
 		// Now, iterate through all values, GC'ing ones which have expired.
@@ -1213,9 +1216,24 @@ func MVCCGarbageCollect(engine Engine, ms *proto.MVCCStats, keys []proto.Interna
 			}
 			if !gcKey.Timestamp.Less(ts) {
 				ageSeconds := timestamp.WallTime/1E9 - ts.WallTime/1E9
-				updateStatsOnGC(ms, gcKey.Key, mvccVersionTimestampSize, int64(len(iter.Value())), nil, ageSeconds)
+				updateStatsOnGC(ms, gcKey.Key, mvccVersionTimestampSize,
+					int64(len(iter.Value())), nil, ageSeconds)
 				engine.Clear(iter.Key())
+				meta.LastEvicted.Forward(ts)
 			}
+		}
+
+		// If we didn't just GC the meta key, and the meta key is not
+		// deleted, update the stats.
+		// TODO(tschottdorf): is this the right kind of update?
+		if metaKey != nil && !meta.Deleted {
+			metaKeyBytes, metaValBytes, err := PutProto(engine, metaKey, meta)
+			if err != nil {
+				return util.Errorf("error updating meta key: %s", err)
+			}
+			decMetaKey, _, _ := MVCCDecodeKey(metaKey)
+			updateStatsForInline(ms, decMetaKey, origMetaKeySize,
+				origMetaValSize, metaKeyBytes, metaValBytes)
 		}
 	}
 

--- a/storage/range_test.go
+++ b/storage/range_test.go
@@ -1612,7 +1612,7 @@ func TestRangeStatsComputation(t *testing.T) {
 	if err := tc.rng.AddCmd(pArgs, pReply, true); err != nil {
 		t.Fatal(err)
 	}
-	expMS := proto.MVCCStats{LiveBytes: 39, KeyBytes: 15, ValBytes: 24, IntentBytes: 0, LiveCount: 1, KeyCount: 1, ValCount: 1, IntentCount: 0}
+	expMS := proto.MVCCStats{LiveBytes: 45, KeyBytes: 15, ValBytes: 30, IntentBytes: 0, LiveCount: 1, KeyCount: 1, ValCount: 1, IntentCount: 0}
 	verifyRangeStats(tc.engine, tc.rng.Desc().RaftID, expMS, t)
 
 	// Put a 2nd value transactionally.
@@ -1622,7 +1622,7 @@ func TestRangeStatsComputation(t *testing.T) {
 	if err := tc.rng.AddCmd(pArgs, pReply, true); err != nil {
 		t.Fatal(err)
 	}
-	expMS = proto.MVCCStats{LiveBytes: 118, KeyBytes: 30, ValBytes: 88, IntentBytes: 24, LiveCount: 2, KeyCount: 2, ValCount: 2, IntentCount: 1}
+	expMS = proto.MVCCStats{LiveBytes: 130, KeyBytes: 30, ValBytes: 100, IntentBytes: 24, LiveCount: 2, KeyCount: 2, ValCount: 2, IntentCount: 1}
 	verifyRangeStats(tc.engine, tc.rng.Desc().RaftID, expMS, t)
 
 	// Resolve the 2nd value.
@@ -1640,7 +1640,7 @@ func TestRangeStatsComputation(t *testing.T) {
 	if err := tc.rng.AddCmd(rArgs, rReply, true); err != nil {
 		t.Fatal(err)
 	}
-	expMS = proto.MVCCStats{LiveBytes: 78, KeyBytes: 30, ValBytes: 48, IntentBytes: 0, LiveCount: 2, KeyCount: 2, ValCount: 2, IntentCount: 0}
+	expMS = proto.MVCCStats{LiveBytes: 90, KeyBytes: 30, ValBytes: 60, IntentBytes: 0, LiveCount: 2, KeyCount: 2, ValCount: 2, IntentCount: 0}
 	verifyRangeStats(tc.engine, tc.rng.Desc().RaftID, expMS, t)
 
 	// Delete the 1st value.
@@ -1649,7 +1649,7 @@ func TestRangeStatsComputation(t *testing.T) {
 	if err := tc.rng.AddCmd(dArgs, dReply, true); err != nil {
 		t.Fatal(err)
 	}
-	expMS = proto.MVCCStats{LiveBytes: 39, KeyBytes: 42, ValBytes: 50, IntentBytes: 0, LiveCount: 1, KeyCount: 2, ValCount: 3, IntentCount: 0}
+	expMS = proto.MVCCStats{LiveBytes: 45, KeyBytes: 42, ValBytes: 62, IntentBytes: 0, LiveCount: 1, KeyCount: 2, ValCount: 3, IntentCount: 0}
 	verifyRangeStats(tc.engine, tc.rng.Desc().RaftID, expMS, t)
 }
 


### PR DESCRIPTION
in preparation to clearing #731, this change adds a
LastEvicted timestamp to MVCCMetadata which is updated
appropriately in MVCCGarbageCollect.
