### PR TITLE
Add -insecure flag (default false). Turns off SSL entirely.

### DIFF
--- a/base/context_test.go
+++ b/base/context_test.go
@@ -1,0 +1,112 @@
+// Copyright 2015 The Cockroach Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+// implied. See the License for the specific language governing
+// permissions and limitations under the License. See the AUTHORS file
+// for names of contributors.
+//
+// Author: Marc Berhault (marc@cockroachlabs.com)
+
+package base_test
+
+import (
+	"testing"
+
+	"github.com/cockroachdb/cockroach/base"
+	"github.com/cockroachdb/cockroach/security"
+)
+
+func TestClientSSLSettings(t *testing.T) {
+	certsDir := security.EmbeddedCertsDir
+
+	testCases := []struct {
+		// args
+		insecure bool
+		certs    string
+		// output
+		sslWanted     bool
+		requestScheme string
+		configSuccess bool
+		nilConfig     bool
+		noCAs         bool
+	}{
+		{true, "foobar", false, "http", true, true, false},
+		{false, "", true, "https", true, false, true},
+		{false, certsDir, true, "https", true, false, false},
+		{false, "/dev/null", true, "https", false, false, false},
+	}
+
+	for tcNum, tc := range testCases {
+		ctx := &base.Context{Insecure: tc.insecure, Certs: tc.certs}
+		if ctx.SSLWanted() != tc.sslWanted {
+			t.Fatalf("#%d: expected SSLWanted=%t, got: %t", tcNum, tc.sslWanted, ctx.SSLWanted())
+		}
+		if ctx.RequestScheme() != tc.requestScheme {
+			t.Fatalf("#%d: expected RequestScheme=%s, got: %s", tcNum, tc.requestScheme, ctx.RequestScheme())
+		}
+		tlsConfig, err := ctx.GetClientTLSConfig()
+		if (err == nil) != tc.configSuccess {
+			t.Fatalf("#%d: expected GetClientTLSConfig success=%t, got err=%v", tcNum, tc.configSuccess, err)
+		}
+		if err != nil {
+			continue
+		}
+		if (tlsConfig == nil) != tc.nilConfig {
+			t.Fatalf("#%d: expected nil config=%t, got: %+v", tcNum, tc.nilConfig, tlsConfig)
+		}
+		if tlsConfig == nil {
+			continue
+		}
+		if (tlsConfig.RootCAs == nil) != tc.noCAs {
+			t.Fatalf("#%d: expected nil RootCAs: %t, got: %+v", tcNum, tc.noCAs, tlsConfig.RootCAs)
+		}
+	}
+}
+
+func TestServerSSLSettings(t *testing.T) {
+	certsDir := security.EmbeddedCertsDir
+
+	testCases := []struct {
+		// args
+		insecure bool
+		certs    string
+		// output
+		sslWanted     bool
+		requestScheme string
+		configSuccess bool
+		nilConfig     bool
+	}{
+		{true, "foobar", false, "http", true, true},
+		{false, "", true, "https", false, false},
+		{false, certsDir, true, "https", true, false},
+		{false, "/dev/null", true, "https", false, false},
+	}
+
+	for tcNum, tc := range testCases {
+		ctx := &base.Context{Insecure: tc.insecure, Certs: tc.certs}
+		if ctx.SSLWanted() != tc.sslWanted {
+			t.Fatalf("#%d: expected SSLWanted=%t, got: %t", tcNum, tc.sslWanted, ctx.SSLWanted())
+		}
+		if ctx.RequestScheme() != tc.requestScheme {
+			t.Fatalf("#%d: expected RequestScheme=%s, got: %s", tcNum, tc.requestScheme, ctx.RequestScheme())
+		}
+		tlsConfig, err := ctx.GetServerTLSConfig()
+		if (err == nil) != tc.configSuccess {
+			t.Fatalf("#%d: expected GetServerTLSConfig success=%t, got err=%v", tcNum, tc.configSuccess, err)
+		}
+		if err != nil {
+			continue
+		}
+		if (tlsConfig == nil) != tc.nilConfig {
+			t.Fatalf("#%d: expected nil config=%t, got: %+v", tcNum, tc.nilConfig, tlsConfig)
+		}
+	}
+}

--- a/base/context_test.go
+++ b/base/context_test.go
@@ -32,23 +32,19 @@ func TestClientSSLSettings(t *testing.T) {
 		insecure bool
 		certs    string
 		// output
-		sslWanted     bool
 		requestScheme string
 		configSuccess bool
 		nilConfig     bool
 		noCAs         bool
 	}{
-		{true, "foobar", false, "http", true, true, false},
-		{false, "", true, "https", true, false, true},
-		{false, certsDir, true, "https", true, false, false},
-		{false, "/dev/null", true, "https", false, false, false},
+		{true, "foobar", "http", true, true, false},
+		{false, "", "https", true, false, true},
+		{false, certsDir, "https", true, false, false},
+		{false, "/dev/null", "https", false, false, false},
 	}
 
 	for tcNum, tc := range testCases {
 		ctx := &base.Context{Insecure: tc.insecure, Certs: tc.certs}
-		if ctx.SSLWanted() != tc.sslWanted {
-			t.Fatalf("#%d: expected SSLWanted=%t, got: %t", tcNum, tc.sslWanted, ctx.SSLWanted())
-		}
 		if ctx.RequestScheme() != tc.requestScheme {
 			t.Fatalf("#%d: expected RequestScheme=%s, got: %s", tcNum, tc.requestScheme, ctx.RequestScheme())
 		}
@@ -79,22 +75,18 @@ func TestServerSSLSettings(t *testing.T) {
 		insecure bool
 		certs    string
 		// output
-		sslWanted     bool
 		requestScheme string
 		configSuccess bool
 		nilConfig     bool
 	}{
-		{true, "foobar", false, "http", true, true},
-		{false, "", true, "https", false, false},
-		{false, certsDir, true, "https", true, false},
-		{false, "/dev/null", true, "https", false, false},
+		{true, "foobar", "http", true, true},
+		{false, "", "https", false, false},
+		{false, certsDir, "https", true, false},
+		{false, "/dev/null", "https", false, false},
 	}
 
 	for tcNum, tc := range testCases {
 		ctx := &base.Context{Insecure: tc.insecure, Certs: tc.certs}
-		if ctx.SSLWanted() != tc.sslWanted {
-			t.Fatalf("#%d: expected SSLWanted=%t, got: %t", tcNum, tc.sslWanted, ctx.SSLWanted())
-		}
 		if ctx.RequestScheme() != tc.requestScheme {
 			t.Fatalf("#%d: expected RequestScheme=%s, got: %s", tcNum, tc.requestScheme, ctx.RequestScheme())
 		}

--- a/base/main_test.go
+++ b/base/main_test.go
@@ -1,0 +1,27 @@
+// Copyright 2015 The Cockroach Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+// implied. See the License for the specific language governing
+// permissions and limitations under the License. See the AUTHORS file
+// for names of contributors.
+//
+// Author: Tobias Schottdorf (tobias.schottdorf@gmail.com)
+
+package base
+
+import (
+	"github.com/cockroachdb/cockroach/security"
+	"github.com/cockroachdb/cockroach/security/securitytest"
+)
+
+func init() {
+	security.SetReadFileFn(securitytest.Asset)
+}

--- a/client/rpc_sender.go
+++ b/client/rpc_sender.go
@@ -18,12 +18,11 @@
 package client
 
 import (
-	"crypto/tls"
 	"fmt"
 	"net"
 
+	"github.com/cockroachdb/cockroach/base"
 	"github.com/cockroachdb/cockroach/rpc"
-	"github.com/cockroachdb/cockroach/security"
 	"github.com/cockroachdb/cockroach/util"
 	"github.com/cockroachdb/cockroach/util/hlc"
 	"github.com/cockroachdb/cockroach/util/log"
@@ -41,46 +40,22 @@ type RPCSender struct {
 }
 
 // NewRPCSender returns a new instance of RPCSender.
-// TODO(marc): initialize using a base.Context.
-func NewRPCSender(server string, certsDir string) (*RPCSender, error) {
+func NewRPCSender(server string, context *base.Context) (*RPCSender, error) {
 	addr, err := net.ResolveTCPAddr("tcp", server)
 	if err != nil {
 		return nil, err
 	}
 
-	var tlsConfig *tls.Config
-	if certsDir == "" {
+	if context.Insecure {
 		log.Warning("SSL disabled, this is strongly discouraged. See the -certs flag")
-		tlsConfig = security.LoadInsecureClientTLSConfig()
-	} else {
-		log.V(1).Infof("setting up TLS from certificates directory: %s", certsDir)
-		var err error
-		tlsConfig, err = security.LoadClientTLSConfigFromDir(certsDir)
-		if err != nil {
-			return nil, util.Errorf("error setting up client TLS config: %s", err)
-		}
 	}
-
+	tlsConfig, err := context.GetClientTLSConfig()
+	if err != nil {
+		return nil, err
+	}
 	ctx := rpc.NewContext(hlc.NewClock(hlc.UnixNano), tlsConfig, nil)
 	client := rpc.NewClient(addr, &HTTPRetryOptions, ctx)
 	return &RPCSender{client: client}, nil
-}
-
-// NewTestRPCSender initializes a new RPCSender using an insecure TLS
-// config.
-func NewTestRPCSender(server string, sslEnabled bool) *RPCSender {
-	addr, err := net.ResolveTCPAddr("tcp", server)
-	if err != nil {
-		return nil
-	}
-
-	var tlsConfig *tls.Config
-	if sslEnabled {
-		tlsConfig = security.LoadInsecureClientTLSConfig()
-	}
-	ctx := rpc.NewContext(hlc.NewClock(hlc.UnixNano), tlsConfig, nil)
-	client := rpc.NewClient(addr, &HTTPRetryOptions, ctx)
-	return &RPCSender{client: client}
 }
 
 // Send sends call to Cockroach via an HTTP post. HTTP response codes

--- a/client/rpc_sender.go
+++ b/client/rpc_sender.go
@@ -47,7 +47,7 @@ func NewRPCSender(server string, context *base.Context) (*RPCSender, error) {
 	}
 
 	if context.Insecure {
-		log.Warning("SSL disabled, this is strongly discouraged. See the -certs flag")
+		log.Warning("running in insecure mode, this is strongly discouraged. See -insecure and -certs.")
 	}
 	tlsConfig, err := context.GetClientTLSConfig()
 	if err != nil {

--- a/server/cli/flags.go
+++ b/server/cli/flags.go
@@ -34,7 +34,8 @@ func initFlags(ctx *server.Context) {
 	flag.BoolVar(&ctx.Insecure, "insecure", ctx.Insecure, "run over plain HTTP. WARNING: "+
 		"this is strongly discouraged.")
 
-	flag.StringVar(&ctx.Certs, "certs", ctx.Certs, "directory containing RSA key and x509 certs.")
+	flag.StringVar(&ctx.Certs, "certs", ctx.Certs, "directory containing RSA key and x509 certs. "+
+		"This flag is required if -insecure=false.")
 
 	flag.StringVar(&ctx.Stores, "stores", ctx.Stores, "specify a comma-separated list of stores, "+
 		"specified by a colon-separated list of device attributes followed by '=' and "+

--- a/server/cli/flags.go
+++ b/server/cli/flags.go
@@ -31,6 +31,9 @@ func initFlags(ctx *server.Context) {
 	flag.StringVar(&ctx.Addr, "addr", ctx.Addr, "when run as the server the host:port to bind for "+
 		"HTTP/RPC traffic; when run as the client the address for connection to the cockroach cluster.")
 
+	flag.BoolVar(&ctx.Insecure, "insecure", ctx.Insecure, "run over plain HTTP. WARNING: "+
+		"this is strongly discouraged.")
+
 	flag.StringVar(&ctx.Certs, "certs", ctx.Certs, "directory containing RSA key and x509 certs.")
 
 	flag.StringVar(&ctx.Stores, "stores", ctx.Stores, "specify a comma-separated list of stores, "+

--- a/server/server.go
+++ b/server/server.go
@@ -82,8 +82,8 @@ func NewServer(ctx *Context, stopper *util.Stopper) (*Server, error) {
 		return nil, util.Errorf("unable to resolve RPC address %q: %v", addr, err)
 	}
 
-	if !ctx.SSLWanted() {
-		log.Warning("SSL disabled, this is strongly discouraged. See the -certs flag")
+	if ctx.Insecure {
+		log.Warning("running in insecure mode, this is strongly discouraged. See -insecure and -certs.")
 	}
 	tlsConfig, err := ctx.GetServerTLSConfig()
 	if err != nil {

--- a/server/server_test.go
+++ b/server/server_test.go
@@ -179,7 +179,7 @@ func TestPlainHTTPServer(t *testing.T) {
 	// Create a custom context. The default one has a default -certs value.
 	ctx := NewContext()
 	ctx.Addr = "127.0.0.1:0"
-	ctx.Certs = ""
+	ctx.Insecure = true
 	// TestServer.Start does not override the context if set.
 	s := &TestServer{Ctx: ctx}
 	if err := s.Start(); err != nil {


### PR DESCRIPTION
This replaces the use of -certs="".
If the server has insecure=false and -certs="": error out.
If the client has insecure=false and -certs="": return a permissive config (with InsecureSkipVerify). This will change once we have client certs.
