### PR TITLE
Publish Store events to Feed

### DIFF
--- a/storage/client_event_test.go
+++ b/storage/client_event_test.go
@@ -1,0 +1,245 @@
+// Copyright 2015 The Cockroach Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+// implied. See the License for the specific language governing
+// permissions and limitations under the License. See the AUTHORS file
+// for names of contributors.
+//
+// Author: Matt Tracy (matt@cockroachlabs.com)
+
+package storage_test
+
+import (
+	"fmt"
+	"reflect"
+	"testing"
+	"time"
+
+	"github.com/cockroachdb/cockroach/client"
+	"github.com/cockroachdb/cockroach/proto"
+	"github.com/cockroachdb/cockroach/storage"
+	"github.com/cockroachdb/cockroach/storage/engine"
+	"github.com/cockroachdb/cockroach/util"
+	"github.com/cockroachdb/cockroach/util/leaktest"
+)
+
+type storeEventReader struct {
+	perStoreFeeds map[proto.StoreID][]string
+}
+
+// recordEvent records the events received for all stores. Each event is
+// recorded as a simple string value; this is less exhaustive than a full struct
+// comparison, but should be easier to correct if future changes slightly modify
+// these values.
+func (ser *storeEventReader) recordEvent(event interface{}) {
+	var sid proto.StoreID
+	eventStr := ""
+	switch event := event.(type) {
+	case *storage.StartStoreEvent:
+		sid = event.StoreID
+		eventStr = "StartStore"
+	case *storage.AddRangeEvent:
+		sid = event.StoreID
+		eventStr = fmt.Sprintf("AddRange rid=%d, live=%d",
+			event.Desc.RaftID, event.Stats.LiveBytes)
+	case *storage.UpdateRangeEvent:
+		sid = event.StoreID
+		eventStr = fmt.Sprintf("UpdateRange rid=%d, live=%d",
+			event.Desc.RaftID, event.Diff.LiveBytes)
+	case *storage.RemoveRangeEvent:
+		sid = event.StoreID
+		eventStr = fmt.Sprintf("RemoveRange rid=%d, live=%d",
+			event.Desc.RaftID, event.Stats.LiveBytes)
+	case *storage.SplitRangeEvent:
+		sid = event.StoreID
+		eventStr = fmt.Sprintf("SplitRange origId=%d, newId=%d, origLive=%d, newLive=%d",
+			event.Original.Desc.RaftID, event.New.Desc.RaftID,
+			event.Original.Stats.LiveBytes, event.New.Stats.LiveBytes)
+	case *storage.MergeRangeEvent:
+		sid = event.StoreID
+		eventStr = fmt.Sprintf("MergeRange rid=%d, subId=%d, live=%d, subLive=%d",
+			event.Merged.Desc.RaftID, event.Removed.Desc.RaftID,
+			event.Merged.Stats.LiveBytes, event.Removed.Stats.LiveBytes)
+	case *storage.BeginScanRangesEvent:
+		sid = event.StoreID
+		eventStr = "BeginScanRanges"
+	case *storage.EndScanRangesEvent:
+		sid = event.StoreID
+		eventStr = "EndScanRanges"
+	}
+	if sid > 0 {
+		ser.perStoreFeeds[sid] = append(ser.perStoreFeeds[sid], eventStr)
+	}
+}
+
+func (ser *storeEventReader) readEvents(sub *util.Subscription) {
+	ser.perStoreFeeds = make(map[proto.StoreID][]string)
+	for e := range sub.Events() {
+		ser.recordEvent(e)
+	}
+}
+
+// printValues is used to assist the debugging of tests which use
+// storeEventReader.
+func (ser *storeEventReader) printValues(t testing.TB) {
+	for id, feed := range ser.perStoreFeeds {
+		fmt.Printf("proto.StoreID(%d): []string{\n", int64(id))
+		for _, evt := range feed {
+			fmt.Printf("\t\t\"%s\",\n", evt)
+		}
+		fmt.Printf("},\n")
+	}
+}
+
+// TestMultiStoreEventFeed verifies that events on multiple stores are properly
+// recieved by a single event reader.
+func TestMultiStoreEventFeed(t *testing.T) {
+	defer leaktest.AfterTest(t)
+
+	// Create a multiTestContext which publishes all store events to the given
+	// feed.
+	ser := &storeEventReader{}
+	feed := &util.Feed{}
+	mtc := &multiTestContext{
+		feed: feed,
+	}
+
+	// Start reading events from the feed before starting the stores.
+	readStopper := util.NewStopper()
+	sub := feed.Subscribe()
+	readStopper.RunWorker(func() {
+		ser.readEvents(sub)
+	})
+
+	mtc.Start(t, 3)
+	defer mtc.Stop()
+
+	// Replicate the default range.
+	raftID := int64(1)
+	mtc.replicateRange(raftID, 0, 1, 2)
+
+	// Add some data in a transaction
+	err := mtc.db.RunTransaction(nil, func(txn *client.Txn) error {
+		return txn.Run(
+			client.PutCall(proto.Key("a"), []byte("asdf")),
+			client.PutCall(proto.Key("c"), []byte("jkl;")),
+		)
+	})
+	if err != nil {
+		t.Fatalf("error putting data to db: %s", err.Error())
+	}
+
+	// AdminSplit in between the two ranges.
+	err = mtc.db.Run(
+		client.Call{
+			Args: &proto.AdminSplitRequest{
+				RequestHeader: proto.RequestHeader{
+					Key: proto.Key("b"),
+				},
+				SplitKey: proto.Key("b"),
+			},
+			Reply: &proto.AdminSplitResponse{},
+		},
+	)
+	if err != nil {
+		t.Fatalf("error splitting initial: %s", err.Error())
+	}
+
+	// AdminSplit an empty range at the end of the second range.
+	err = mtc.db.Run(
+		client.Call{
+			Args: &proto.AdminSplitRequest{
+				RequestHeader: proto.RequestHeader{
+					Key: proto.Key("z"),
+				},
+				SplitKey: proto.Key("z"),
+			},
+			Reply: &proto.AdminSplitResponse{},
+		},
+	)
+	if err != nil {
+		t.Fatalf("error splitting second range: %s", err.Error())
+	}
+
+	// AdminMerge the empty range back into the second range.
+	err = mtc.db.Run(
+		client.Call{
+			Args: &proto.AdminMergeRequest{
+				RequestHeader: proto.RequestHeader{
+					Key: proto.Key("c"),
+				},
+			},
+			Reply: &proto.AdminMergeResponse{},
+		},
+	)
+	if err != nil {
+		t.Fatalf("error merging final range: %s", err.Error())
+	}
+
+	// Add an additional put through the system and wait for all
+	// replicas to receive it.
+	err = mtc.db.Run(
+		client.IncrementCall(proto.Key("aa"), 5),
+	)
+	if err != nil {
+		t.Fatalf("error putting data to db: %s", err.Error())
+	}
+	util.SucceedsWithin(t, time.Second, func() error {
+		for _, eng := range mtc.engines {
+			val, err := engine.MVCCGet(eng, proto.Key("aa"), mtc.clock.Now(), true, nil)
+			if err != nil {
+				return err
+			}
+			if a, e := val.GetInteger(), int64(5); a != e {
+				return util.Errorf("expected aa = %d, got %d", e, a)
+			}
+		}
+		return nil
+	})
+
+	// Close feed and wait for reader to receive all events.
+	feed.Close()
+	readStopper.Stop()
+	<-readStopper.IsStopped()
+
+	// Compare events to expected values.
+	expected := map[proto.StoreID][]string{
+		proto.StoreID(1): []string{
+			"StartStore",
+			"BeginScanRanges",
+			"AddRange rid=1, live=348",
+			"EndScanRanges",
+			"SplitRange origId=1, newId=2, origLive=938, newLive=42",
+			"SplitRange origId=2, newId=3, origLive=42, newLive=0",
+			"MergeRange rid=2, subId=3, live=42, subLive=0",
+		},
+		proto.StoreID(2): []string{
+			"StartStore",
+			"BeginScanRanges",
+			"EndScanRanges",
+			"SplitRange origId=1, newId=2, origLive=938, newLive=42",
+			"SplitRange origId=2, newId=3, origLive=42, newLive=0",
+			"MergeRange rid=2, subId=3, live=42, subLive=0",
+		},
+		proto.StoreID(3): []string{
+			"StartStore",
+			"BeginScanRanges",
+			"EndScanRanges",
+			"SplitRange origId=1, newId=2, origLive=938, newLive=42",
+			"SplitRange origId=2, newId=3, origLive=42, newLive=0",
+			"MergeRange rid=2, subId=3, live=42, subLive=0",
+		},
+	}
+	if a, e := ser.perStoreFeeds, expected; !reflect.DeepEqual(a, e) {
+		t.Errorf("event feed did not meet expected value: printing actual values to compare with above expectation:\n")
+		ser.printValues(t)
+	}
+}

--- a/storage/client_test.go
+++ b/storage/client_test.go
@@ -103,6 +103,7 @@ type multiTestContext struct {
 	gossip      *gossip.Gossip
 	transport   multiraft.Transport
 	db          *client.KV
+	feed        *util.Feed
 	engines     []engine.Engine
 	senders     []*kv.LocalSender
 	stores      []*storage.Store
@@ -180,6 +181,7 @@ func (m *multiTestContext) makeContext() storage.StoreContext {
 	ctx.DB = m.db
 	ctx.Gossip = m.gossip
 	ctx.Transport = m.transport
+	ctx.EventFeed = m.feed
 	return ctx
 }
 

--- a/storage/feed.go
+++ b/storage/feed.go
@@ -22,186 +22,215 @@ import (
 	"github.com/cockroachdb/cockroach/util"
 )
 
-// NewRangeEvent occurs when a new range is added to a store.  This event
+// AddRangeEvent occurs when a new range is added to a store.  This event
 // includes the Range's RangeDescriptor and current MVCCStats.
-type NewRangeEvent struct {
-	Desc  *proto.RangeDescriptor
-	Stats proto.MVCCStats
+type AddRangeEvent struct {
+	StoreID proto.StoreID
+	Desc    *proto.RangeDescriptor
+	Stats   proto.MVCCStats
 }
 
 // UpdateRangeEvent occurs whenever a Range is modified. This structure includes
-// the same information as NewRangeEvent, but also includes a second set of
+// the same information as AddRangeEvent, but also includes a second set of
 // MVCCStats containing the difference from the Range's previous stats. If the
 // update did not modify any statistics, this diff may be nil.
 type UpdateRangeEvent struct {
-	Desc  *proto.RangeDescriptor
-	Stats proto.MVCCStats
-	Diff  proto.MVCCStats
+	StoreID proto.StoreID
+	Desc    *proto.RangeDescriptor
+	Stats   proto.MVCCStats
+	Diff    proto.MVCCStats
 }
 
 // RemoveRangeEvent occurs whenever a Range is removed from a store. This
 // structure includes the Range's RangeDescriptor and the Range's previous
 // MVCCStats before it was removed.
 type RemoveRangeEvent struct {
-	Desc  *proto.RangeDescriptor
-	Stats proto.MVCCStats
+	StoreID proto.StoreID
+	Desc    *proto.RangeDescriptor
+	Stats   proto.MVCCStats
 }
 
 // SplitRangeEvent occurs whenever a range is split in two. This Event actually
 // contains two other events: an UpdateRangeEvent for the Range which
-// originally existed, and a NewRangeEvent for the range that was created via
+// originally existed, and a AddRangeEvent for the range that was created via
 // the split.
 type SplitRangeEvent struct {
+	StoreID  proto.StoreID
 	Original UpdateRangeEvent
-	New      NewRangeEvent
+	New      AddRangeEvent
 }
 
 // MergeRangeEvent occurs whenever a range is merged into another. This Event
 // contains two component events: an UpdateRangeEvent for the range which
 // subsumed the other, and a RemoveRangeEvent for the range that was subsumed.
 type MergeRangeEvent struct {
+	StoreID proto.StoreID
 	Merged  UpdateRangeEvent
 	Removed RemoveRangeEvent
 }
 
+// StartStoreEvent occurs whenever a store is initially started.
+type StartStoreEvent struct {
+	StoreID proto.StoreID
+}
+
 // BeginScanRangesEvent occurs when the store is about to scan over all ranges.
 // During such a scan, each existing range will be published to the feed as a
-// NewRangeEvent. This is used because downstream consumers may be tracking
+// AddRangeEvent. This is used because downstream consumers may be tracking
 // statistics via the Diffs in UpdateRangeEvent; this event informs subscribers
 // to clear currently cached values.
-type BeginScanRangesEvent struct{}
+type BeginScanRangesEvent struct {
+	StoreID proto.StoreID
+}
 
 // EndScanRangesEvent occurs when the store has finished scanning all ranges.
 // Every BeginScanRangeEvent will eventually be followed by an
 // EndScanRangeEvent.
-type EndScanRangesEvent struct{}
-
-// StoreEventFeed is a feed of events that occur on a Store. Most of these
-// events are specific to a single range within the store.
-type StoreEventFeed struct {
-	f *util.Feed
+type EndScanRangesEvent struct {
+	StoreID proto.StoreID
 }
 
-// NewStoreEventFeed creates a new StoreEventFeed. Events can immediately be
-// published and Subscribers can immediately subscribe to the feed.
-func NewStoreEventFeed() StoreEventFeed {
+// StoreEventFeed is a helper structure which publishes store-specific events to
+// a util.Feed. The target feed may be shared by multiple StoreEventFeeds. If
+// the target feed is nil, event methods become no-ops.
+type StoreEventFeed struct {
+	id proto.StoreID
+	f  *util.Feed
+}
+
+// NewStoreEventFeed creates a new StoreEventFeed which publishes events for a
+// specific store to the supplied feed.
+func NewStoreEventFeed(id proto.StoreID, feed *util.Feed) StoreEventFeed {
 	return StoreEventFeed{
-		f: &util.Feed{},
+		id: id,
+		f:  feed,
 	}
 }
 
-// Subscribe returns a util.Subscription which receives events from this
-// StoreEventFeed.
-//
-// Events are received from the feed as an empty interface and must be cast to
-// one of the event types in this package. This is best accomplished with a type
-// switch:
-//
-// 		sub := storeFeed.Subscribe()
-//		for event := range sub.Events {
-//			switch event := event.(type) {
-//			case NewRangeEvent:
-//				// Process NewRangeEvent...
-//		    case UpdateRangeEvent:
-//				// Process UpdateRangeEvent...
-//			// ... other interesting types
-//			}
-//		}
-func (sef StoreEventFeed) Subscribe() *util.Subscription {
-	return sef.f.Subscribe()
-}
-
-// closeFeed closes the underlying events feed.
-func (sef StoreEventFeed) closeFeed() {
-	sef.f.Close()
-}
-
-// newRange publishes a NewRangeEvent to this feed which describes the addition
+// addRange publishes a AddRangeEvent to this feed which describes the addition
 // of the supplied Range.
-func (sef StoreEventFeed) newRange(rng *Range) {
-	sef.f.Publish(makeNewRangeEvent(rng))
+func (sef StoreEventFeed) addRange(rng *Range) {
+	if sef.f == nil {
+		return
+	}
+	sef.f.Publish(makeAddRangeEvent(sef.id, rng))
 }
 
-// uewRange publishes an UpdateRangeEvent to this feed which describes a change
+// updateRange publishes an UpdateRangeEvent to this feed which describes a change
 // to the supplied Range.
 func (sef StoreEventFeed) updateRange(rng *Range, diff *proto.MVCCStats) {
-	sef.f.Publish(makeUpdateRangeEvent(rng, diff))
+	if sef.f == nil {
+		return
+	}
+	sef.f.Publish(makeUpdateRangeEvent(sef.id, rng, diff))
 }
 
 // removeRange publishes a RemoveRangeEvent to this feed which describes the
 // removal of the supplied Range.
 func (sef StoreEventFeed) removeRange(rng *Range) {
-	sef.f.Publish(makeRemoveRangeEvent(rng))
+	if sef.f == nil {
+		return
+	}
+	sef.f.Publish(makeRemoveRangeEvent(sef.id, rng))
 }
 
 // splitRange publishes a SplitRangeEvent to this feed which describes a split
 // involving the supplied Ranges.
-func (sef StoreEventFeed) splitRange(rngOrig, rngNew *Range, diffOrig *proto.MVCCStats) {
-	sef.f.Publish(makeSplitRangeEvent(rngOrig, rngNew, diffOrig))
+func (sef StoreEventFeed) splitRange(rngOrig, rngNew *Range) {
+	if sef.f == nil {
+		return
+	}
+	sef.f.Publish(makeSplitRangeEvent(sef.id, rngOrig, rngNew))
 }
 
 // mergeRange publishes a MergeRangeEvent to this feed which describes a merger
 // of the supplied Ranges.
-func (sef StoreEventFeed) mergeRange(rngMerged, rngRemoved *Range, diffMerged *proto.MVCCStats) {
-	sef.f.Publish(makeMergeRangeEvent(rngMerged, rngRemoved, diffMerged))
+func (sef StoreEventFeed) mergeRange(rngMerged, rngRemoved *Range) {
+	if sef.f == nil {
+		return
+	}
+	sef.f.Publish(makeMergeRangeEvent(sef.id, rngMerged, rngRemoved))
+}
+
+// startStore publishes a StartStoreEvent to this feed.
+func (sef StoreEventFeed) startStore() {
+	if sef.f == nil {
+		return
+	}
+	sef.f.Publish(&StartStoreEvent{sef.id})
 }
 
 // beginScanRanges publishes a BeginScanRangesEvent to this feed.
 func (sef StoreEventFeed) beginScanRanges() {
-	sef.f.Publish(&BeginScanRangesEvent{})
+	if sef.f == nil {
+		return
+	}
+	sef.f.Publish(&BeginScanRangesEvent{sef.id})
 }
 
 // endScanRanges publishes an EndScanRangesEvent to this feed.
 func (sef StoreEventFeed) endScanRanges() {
-	sef.f.Publish(&EndScanRangesEvent{})
+	if sef.f == nil {
+		return
+	}
+	sef.f.Publish(&EndScanRangesEvent{sef.id})
 }
 
-func makeNewRangeEvent(rng *Range) *NewRangeEvent {
-	return &NewRangeEvent{
-		Desc:  rng.Desc(),
-		Stats: rng.stats.GetMVCC(),
+func makeAddRangeEvent(id proto.StoreID, rng *Range) *AddRangeEvent {
+	return &AddRangeEvent{
+		StoreID: id,
+		Desc:    rng.Desc(),
+		Stats:   rng.stats.GetMVCC(),
 	}
 }
 
-func makeUpdateRangeEvent(rng *Range, diff *proto.MVCCStats) *UpdateRangeEvent {
+func makeUpdateRangeEvent(id proto.StoreID, rng *Range, diff *proto.MVCCStats) *UpdateRangeEvent {
 	return &UpdateRangeEvent{
-		Desc:  rng.Desc(),
-		Stats: rng.stats.GetMVCC(),
-		Diff:  *diff,
+		StoreID: id,
+		Desc:    rng.Desc(),
+		Stats:   rng.stats.GetMVCC(),
+		Diff:    *diff,
 	}
 }
 
-func makeRemoveRangeEvent(rng *Range) *RemoveRangeEvent {
+func makeRemoveRangeEvent(id proto.StoreID, rng *Range) *RemoveRangeEvent {
 	return &RemoveRangeEvent{
-		Desc:  rng.Desc(),
-		Stats: rng.stats.GetMVCC(),
+		StoreID: id,
+		Desc:    rng.Desc(),
+		Stats:   rng.stats.GetMVCC(),
 	}
 }
 
-func makeSplitRangeEvent(rngOrig, rngNew *Range, diffOrig *proto.MVCCStats) *SplitRangeEvent {
-	return &SplitRangeEvent{
+func makeSplitRangeEvent(id proto.StoreID, rngOrig, rngNew *Range) *SplitRangeEvent {
+	sre := &SplitRangeEvent{
+		StoreID: id,
 		Original: UpdateRangeEvent{
 			Desc:  rngOrig.Desc(),
 			Stats: rngOrig.stats.GetMVCC(),
-			Diff:  *diffOrig,
 		},
-		New: NewRangeEvent{
+		New: AddRangeEvent{
 			Desc:  rngNew.Desc(),
 			Stats: rngNew.stats.GetMVCC(),
 		},
 	}
+	// Size difference of original range is the additive inverse of stats for
+	// the new range.
+	sre.Original.Diff = sre.Original.Diff.Difference(&sre.New.Stats)
+	return sre
 }
 
-func makeMergeRangeEvent(rngMerged, rngRemoved *Range, diffMerged *proto.MVCCStats) *MergeRangeEvent {
-	return &MergeRangeEvent{
+func makeMergeRangeEvent(id proto.StoreID, rngMerged, rngRemoved *Range) *MergeRangeEvent {
+	mre := &MergeRangeEvent{
+		StoreID: id,
 		Merged: UpdateRangeEvent{
 			Desc:  rngMerged.Desc(),
 			Stats: rngMerged.stats.GetMVCC(),
-			Diff:  *diffMerged,
 		},
 		Removed: RemoveRangeEvent{
 			Desc:  rngRemoved.Desc(),
 			Stats: rngRemoved.stats.GetMVCC(),
 		},
 	}
+	mre.Merged.Diff = mre.Removed.Stats
+	return mre
 }


### PR DESCRIPTION
Stores now publish intersting events to a feed. The feed is passed to NewStore
as part of the StoreContext; if no feed is passed one is generated, although it
is not currently available for subscribers.

This commit also augments MultiTestContext to optionally pass a feed to the
Stores it creates. This is used in the new test `TestMultiStoreEventFeed`, which
passes a feed to multiple stores and verifies that the correct events are
published to the feed.

Finally, this commit renames "NewStoreEvent" to "AddStoreEvent".
