### PR TITLE
Renamed client *Call methods by dropping the "Call" suffix.

### DIFF
--- a/client/call.go
+++ b/client/call.go
@@ -46,8 +46,8 @@ func (c *Call) Method() proto.Method {
 	return c.Args.Method()
 }
 
-// GetCall returns a Call object initialized to get the value at key.
-func GetCall(key proto.Key) Call {
+// Get returns a Call object initialized to get the value at key.
+func Get(key proto.Key) Call {
 	return Call{
 		Args: &proto.GetRequest{
 			RequestHeader: proto.RequestHeader{
@@ -58,9 +58,9 @@ func GetCall(key proto.Key) Call {
 	}
 }
 
-// IncrementCall returns a Call object initialized to increment the
+// Increment returns a Call object initialized to increment the
 // value at key by increment.
-func IncrementCall(key proto.Key, increment int64) Call {
+func Increment(key proto.Key, increment int64) Call {
 	return Call{
 		Args: &proto.IncrementRequest{
 			RequestHeader: proto.RequestHeader{
@@ -72,9 +72,9 @@ func IncrementCall(key proto.Key, increment int64) Call {
 	}
 }
 
-// PutCall returns a Call object initialized to put value
+// Put returns a Call object initialized to put value
 // as a byte slice at key.
-func PutCall(key proto.Key, valueBytes []byte) Call {
+func Put(key proto.Key, valueBytes []byte) Call {
 	value := proto.Value{Bytes: valueBytes}
 	value.InitChecksum(key)
 	return Call{
@@ -88,9 +88,9 @@ func PutCall(key proto.Key, valueBytes []byte) Call {
 	}
 }
 
-// PutProtoCall returns a Call object initialized to put the proto
+// PutProto returns a Call object initialized to put the proto
 // message as a byte slice at key.
-func PutProtoCall(key proto.Key, msg gogoproto.Message) Call {
+func PutProto(key proto.Key, msg gogoproto.Message) Call {
 	data, err := gogoproto.Marshal(msg)
 	if err != nil {
 		return Call{Err: err}
@@ -108,9 +108,9 @@ func PutProtoCall(key proto.Key, msg gogoproto.Message) Call {
 	}
 }
 
-// DeleteCall returns a Call object initialized to delete the value at
+// Delete returns a Call object initialized to delete the value at
 // key.
-func DeleteCall(key proto.Key) Call {
+func Delete(key proto.Key) Call {
 	return Call{
 		Args: &proto.DeleteRequest{
 			RequestHeader: proto.RequestHeader{
@@ -121,9 +121,9 @@ func DeleteCall(key proto.Key) Call {
 	}
 }
 
-// DeleteRangeCall returns a Call object initialized to delete the
+// DeleteRange returns a Call object initialized to delete the
 // values in the given key range (excluding the endpoint).
-func DeleteRangeCall(startKey, endKey proto.Key) Call {
+func DeleteRange(startKey, endKey proto.Key) Call {
 	return Call{
 		Args: &proto.DeleteRangeRequest{
 			RequestHeader: proto.RequestHeader{
@@ -135,9 +135,9 @@ func DeleteRangeCall(startKey, endKey proto.Key) Call {
 	}
 }
 
-// ScanCall returns a Call object initialized to scan from start to
+// Scan returns a Call object initialized to scan from start to
 // end keys with max results.
-func ScanCall(key, endKey proto.Key, maxResults int64) Call {
+func Scan(key, endKey proto.Key, maxResults int64) Call {
 	return Call{
 		Args: &proto.ScanRequest{
 			RequestHeader: proto.RequestHeader{

--- a/client/kv.go
+++ b/client/kv.go
@@ -97,7 +97,7 @@ func (kv *KV) Run(calls ...Call) (err error) {
 
 	// First check if any call contains an error. This allows the
 	// generation of a Call to create an error that is reported
-	// here. See PutProtoCall for an example.
+	// here. See PutProto for an example.
 	for _, call := range calls {
 		if call.Err != nil {
 			return call.Err

--- a/client/kv_test.go
+++ b/client/kv_test.go
@@ -135,7 +135,7 @@ func TestKVCommitReadOnlyTransaction(t *testing.T) {
 		calls = append(calls, call.Method())
 	}))
 	if err := client.RunTransaction(nil, func(txn *Txn) error {
-		txn.Run(GetCall(proto.Key("a")))
+		txn.Run(Get(proto.Key("a")))
 		return nil
 	}); err != nil {
 		t.Errorf("unexpected error on commit: %s", err)
@@ -157,7 +157,7 @@ func TestKVCommitMutatingTransaction(t *testing.T) {
 		}
 	}))
 	if err := client.RunTransaction(nil, func(txn *Txn) error {
-		txn.Run(PutCall(proto.Key("a"), nil))
+		txn.Run(Put(proto.Key("a"), nil))
 		return nil
 	}); err != nil {
 		t.Errorf("unexpected error on commit: %s", err)
@@ -200,7 +200,7 @@ func TestKVAbortReadOnlyTransaction(t *testing.T) {
 		}
 	}))
 	err := client.RunTransaction(nil, func(txn *Txn) error {
-		txn.Run(GetCall(proto.Key("a")))
+		txn.Run(Get(proto.Key("a")))
 		return errors.New("foo")
 	})
 	if err == nil {
@@ -219,7 +219,7 @@ func TestKVAbortMutatingTransaction(t *testing.T) {
 		}
 	}))
 	err := client.RunTransaction(nil, func(txn *Txn) error {
-		txn.Run(PutCall(proto.Key("a"), nil))
+		txn.Run(Put(proto.Key("a"), nil))
 		return errors.New("foo")
 	})
 	if err == nil {

--- a/kv/db_test.go
+++ b/kv/db_test.go
@@ -310,12 +310,12 @@ func TestKVDBTransaction(t *testing.T) {
 		Isolation: proto.SNAPSHOT,
 	}
 	err := kvClient.RunTransaction(txnOpts, func(txn *client.Txn) error {
-		if err := txn.Run(client.PutCall(key, value)); err != nil {
+		if err := txn.Run(client.Put(key, value)); err != nil {
 			t.Fatal(err)
 		}
 
 		// Attempt to read outside of txn.
-		call := client.GetCall(key)
+		call := client.Get(key)
 		gr := call.Reply.(*proto.GetResponse)
 		if err := kvClient.Run(call); err != nil {
 			t.Fatal(err)
@@ -325,7 +325,7 @@ func TestKVDBTransaction(t *testing.T) {
 		}
 
 		// Read within the transaction.
-		call = client.GetCall(key)
+		call = client.Get(key)
 		gr = call.Reply.(*proto.GetResponse)
 		if err := txn.Run(call); err != nil {
 			t.Fatal(err)
@@ -340,7 +340,7 @@ func TestKVDBTransaction(t *testing.T) {
 	}
 
 	// Verify the value is now visible after commit.
-	call := client.GetCall(key)
+	call := client.Get(key)
 	gr := call.Reply.(*proto.GetResponse)
 	if err = kvClient.Run(call); err != nil {
 		t.Errorf("expected success reading value; got %s", err)

--- a/kv/dist_sender_server_test.go
+++ b/kv/dist_sender_server_test.go
@@ -63,7 +63,7 @@ func TestRangeLookupWithOpenTransaction(t *testing.T) {
 	// lookup, etc, ad nauseam.
 	success := make(chan struct{})
 	go func() {
-		if err := db.Run(client.GetCall(proto.Key("a"))); err != nil {
+		if err := db.Run(client.Get(proto.Key("a"))); err != nil {
 			t.Fatal(err)
 		}
 		close(success)
@@ -109,12 +109,12 @@ func TestMultiRangeScan(t *testing.T) {
 
 	// Write keys "a" and "b".
 	for _, key := range []proto.Key{proto.Key("a"), proto.Key("b")} {
-		if err := db.Run(client.PutCall(key, []byte("value"))); err != nil {
+		if err := db.Run(client.Put(key, []byte("value"))); err != nil {
 			t.Fatal(err)
 		}
 	}
 
-	call := client.ScanCall(proto.Key("a"), proto.Key("c"), 0)
+	call := client.Scan(proto.Key("a"), proto.Key("c"), 0)
 	sr := call.Reply.(*proto.ScanResponse)
 	if err := db.Run(call); err != nil {
 		t.Fatalf("unexpected error on scan: %s", err)
@@ -135,7 +135,7 @@ func TestMultiRangeScanInconsistent(t *testing.T) {
 	keys := []proto.Key{proto.Key("a"), proto.Key("b")}
 	ts := []proto.Timestamp{}
 	for _, key := range keys {
-		call := client.PutCall(key, []byte("value"))
+		call := client.Put(key, []byte("value"))
 		pr := call.Reply.(*proto.PutResponse)
 		if err := db.Run(call); err != nil {
 			t.Fatal(err)
@@ -150,7 +150,7 @@ func TestMultiRangeScanInconsistent(t *testing.T) {
 	manual := hlc.NewManualClock(ts[1].WallTime - 1)
 	clock := hlc.NewClock(manual.UnixNano)
 	ds := kv.NewDistSender(&kv.DistSenderContext{Clock: clock}, s.Gossip())
-	call := client.ScanCall(proto.Key("a"), proto.Key("c"), 0)
+	call := client.Scan(proto.Key("a"), proto.Key("c"), 0)
 	sr := call.Reply.(*proto.ScanResponse)
 	sa := call.Args.(*proto.ScanRequest)
 	sa.ReadConsistency = proto.INCONSISTENT

--- a/kv/dist_sender_test.go
+++ b/kv/dist_sender_test.go
@@ -234,7 +234,7 @@ func TestSendRPCOrder(t *testing.T) {
 
 		// Always create the parameters for Scan, only the Header() is used
 		// anyways so it doesn't matter.
-		call := client.ScanCall(proto.Key("b"), proto.Key("y"), 0)
+		call := client.Scan(proto.Key("b"), proto.Key("y"), 0)
 		args := tc.args
 		args.Header().RaftID = raftID // Not used in this test, but why not.
 		if !tc.consistent {
@@ -280,7 +280,7 @@ func TestRetryOnNotLeaderError(t *testing.T) {
 		}),
 	}
 	ds := NewDistSender(ctx, g)
-	call := client.PutCall(proto.Key("a"), []byte("value"))
+	call := client.Put(proto.Key("a"), []byte("value"))
 	reply := call.Reply.(*proto.PutResponse)
 	ds.Send(call)
 	if err := reply.GoError(); err != nil {
@@ -343,7 +343,7 @@ func TestRetryOnWrongReplicaError(t *testing.T) {
 		rpcSend: testFn,
 	}
 	ds := NewDistSender(ctx, g)
-	call := client.ScanCall(proto.Key("a"), proto.Key("d"), 0)
+	call := client.Scan(proto.Key("a"), proto.Key("d"), 0)
 	sr := call.Reply.(*proto.ScanResponse)
 	ds.Send(call)
 	if err := sr.GoError(); err != nil {

--- a/kv/split_test.go
+++ b/kv/split_test.go
@@ -68,7 +68,7 @@ func startTestWriter(db *client.KV, i int64, valBytes int32, wg *sync.WaitGroup,
 				for j := 0; j <= int(src.Int31n(10)); j++ {
 					key := util.RandBytes(src, 10)
 					val := util.RandBytes(src, int(src.Int31n(valBytes)))
-					if err := txn.Run(client.PutCall(key, val)); err != nil {
+					if err := txn.Run(client.Put(key, val)); err != nil {
 						log.Infof("experienced an error in routine %d: %s", i, err)
 						return err
 					}
@@ -148,7 +148,7 @@ func TestRangeSplitsWithWritePressure(t *testing.T) {
 		RangeMinBytes: 1 << 8,
 		RangeMaxBytes: 1 << 18,
 	}
-	call := client.PutProtoCall(engine.MakeKey(engine.KeyConfigZonePrefix, engine.KeyMin), zoneConfig)
+	call := client.PutProto(engine.MakeKey(engine.KeyConfigZonePrefix, engine.KeyMin), zoneConfig)
 	if err := s.KV.Run(call); err != nil {
 		t.Fatal(err)
 	}
@@ -162,7 +162,7 @@ func TestRangeSplitsWithWritePressure(t *testing.T) {
 	// Check that we split 5 times in allotted time.
 	if err := util.IsTrueWithin(func() bool {
 		// Scan the txn records.
-		call := client.ScanCall(engine.KeyMeta2Prefix, engine.KeyMetaMax, 0)
+		call := client.Scan(engine.KeyMeta2Prefix, engine.KeyMetaMax, 0)
 		resp := call.Reply.(*proto.ScanResponse)
 		if err := s.KV.Run(call); err != nil {
 			t.Fatalf("failed to scan meta2 keys: %s", err)

--- a/kv/txn_correctness_test.go
+++ b/kv/txn_correctness_test.go
@@ -141,7 +141,7 @@ func (c *cmd) String() string {
 
 // readCmd reads a value from the db and stores it in the env.
 func readCmd(c *cmd, db runner, t *testing.T) error {
-	call := client.GetCall(c.getKey())
+	call := client.Get(c.getKey())
 	r := call.Reply.(*proto.GetResponse)
 	if err := db.Run(call); err != nil {
 		return err
@@ -155,12 +155,12 @@ func readCmd(c *cmd, db runner, t *testing.T) error {
 
 // deleteRngCmd deletes the range of values from the db from [key, endKey).
 func deleteRngCmd(c *cmd, db runner, t *testing.T) error {
-	return db.Run(client.DeleteRangeCall(c.getKey(), c.getEndKey()))
+	return db.Run(client.DeleteRange(c.getKey(), c.getEndKey()))
 }
 
 // scanCmd reads the values from the db from [key, endKey).
 func scanCmd(c *cmd, db runner, t *testing.T) error {
-	call := client.ScanCall(c.getKey(), c.getEndKey(), 0)
+	call := client.Scan(c.getKey(), c.getEndKey(), 0)
 	r := call.Reply.(*proto.ScanResponse)
 	if err := db.Run(call); err != nil {
 		return err
@@ -179,7 +179,7 @@ func scanCmd(c *cmd, db runner, t *testing.T) error {
 // incCmd adds one to the value of c.key in the env and writes
 // it to the db. If c.key isn't in the db, writes 1.
 func incCmd(c *cmd, db runner, t *testing.T) error {
-	call := client.IncrementCall(c.getKey(), 1)
+	call := client.Increment(c.getKey(), 1)
 	r := call.Reply.(*proto.IncrementResponse)
 	if err := db.Run(call); err != nil {
 		return err

--- a/kv/txn_test.go
+++ b/kv/txn_test.go
@@ -654,7 +654,7 @@ func TestTxnRestartedSerializableTimestampRegression(t *testing.T) {
 	go func() {
 		err := s.KV.RunTransaction(txnAOpts, func(txn *client.Txn) error {
 			// Put transactional value.
-			if err := txn.Run(client.PutCall(keyA, []byte("value1"))); err != nil {
+			if err := txn.Run(client.Put(keyA, []byte("value1"))); err != nil {
 				return err
 			}
 			// Notify txnB to push txnA on get(a).
@@ -662,7 +662,7 @@ func TestTxnRestartedSerializableTimestampRegression(t *testing.T) {
 			// Wait for txnB notify us to commit.
 			<-ch
 			// Do a write to keyB, which will forward txn timestamp.
-			if err := txn.Run(client.PutCall(keyB, []byte("value2"))); err != nil {
+			if err := txn.Run(client.Put(keyB, []byte("value2"))); err != nil {
 				return err
 			}
 			// Now commit...
@@ -678,11 +678,11 @@ func TestTxnRestartedSerializableTimestampRegression(t *testing.T) {
 	// Wait until txnA finishes put(a).
 	<-ch
 	// Attempt to get keyA, which will push txnA.
-	if err := s.KV.Run(client.GetCall(keyA)); err != nil {
+	if err := s.KV.Run(client.Get(keyA)); err != nil {
 		t.Fatal(err)
 	}
 	// Do a read at keyB to cause txnA to forward timestamp.
-	if err := s.KV.Run(client.GetCall(keyB)); err != nil {
+	if err := s.KV.Run(client.Get(keyB)); err != nil {
 		t.Fatal(err)
 	}
 	// Notify txnA to commit.

--- a/server/cli/kv.go
+++ b/server/cli/kv.go
@@ -72,7 +72,7 @@ func runGet(cmd *commander.Command, args []string) {
 		return
 	}
 	key := proto.Key(args[0])
-	call := client.GetCall(key)
+	call := client.Get(key)
 	resp := call.Reply.(*proto.GetResponse)
 	if err := kv.Run(call); err != nil {
 		fmt.Fprintf(osStderr, "get failed: %s\n", err)
@@ -133,7 +133,7 @@ func runPut(cmd *commander.Command, args []string) {
 		for i := 0; i < len(args); i += 2 {
 			key := proto.Key(args[i])
 			value := []byte(args[i+1])
-			txn.Prepare(client.PutCall(key, value))
+			txn.Prepare(client.Put(key, value))
 		}
 		return nil
 	})
@@ -185,7 +185,7 @@ func runInc(cmd *commander.Command, args []string) {
 	}
 
 	key := proto.Key(args[0])
-	call := client.IncrementCall(key, int64(amount))
+	call := client.Increment(key, int64(amount))
 	resp := call.Reply.(*proto.IncrementResponse)
 	if err := kv.Run(call); err != nil {
 		fmt.Fprintf(osStderr, "increment failed: %s\n", err)
@@ -231,7 +231,7 @@ func runDel(cmd *commander.Command, args []string) {
 	err = kv.RunTransaction(opts, func(txn *client.Txn) error {
 		for i := 0; i < len(args); i++ {
 			key := proto.Key(args[i])
-			txn.Prepare(client.DeleteCall(key))
+			txn.Prepare(client.Delete(key))
 		}
 		return nil
 	})
@@ -289,7 +289,7 @@ func runScan(cmd *commander.Command, args []string) {
 		return
 	}
 	// TODO(pmattis): Add a flag for the number of results to scan.
-	call := client.ScanCall(startKey, endKey, 1000)
+	call := client.Scan(startKey, endKey, 1000)
 	resp := call.Reply.(*proto.ScanResponse)
 	if err := kv.Run(call); err != nil {
 		fmt.Fprintf(osStderr, "scan failed: %s\n", err)

--- a/server/cli/range.go
+++ b/server/cli/range.go
@@ -60,7 +60,7 @@ func runLsRanges(cmd *commander.Command, args []string) {
 		osExit(1)
 		return
 	}
-	call := client.ScanCall(startKey, engine.KeyMeta2Prefix.PrefixEnd(), 1000)
+	call := client.Scan(startKey, engine.KeyMeta2Prefix.PrefixEnd(), 1000)
 	resp := call.Reply.(*proto.ScanResponse)
 	if err := kv.Run(call); err != nil {
 		fmt.Fprintf(os.Stderr, "scan failed: %s\n", err)

--- a/server/config.go
+++ b/server/config.go
@@ -236,7 +236,7 @@ func putConfig(db *client.KV, configPrefix proto.Key, config gogoproto.Message,
 		}
 	}
 	key := engine.MakeKey(configPrefix, proto.Key(path[1:]))
-	if err := db.Run(client.PutProtoCall(key, config)); err != nil {
+	if err := db.Run(client.PutProto(key, config)); err != nil {
 		return err
 	}
 	return nil
@@ -279,7 +279,7 @@ func getConfig(db *client.KV, configPrefix proto.Key, config gogoproto.Message,
 		body, contentType, err = util.MarshalResponse(r, prefixes, util.AllEncodings)
 	} else {
 		configkey := engine.MakeKey(configPrefix, proto.Key(path[1:]))
-		call := client.GetCall(configkey)
+		call := client.Get(configkey)
 		if err = db.Run(call); err != nil {
 			return
 		}

--- a/server/node.go
+++ b/server/node.go
@@ -445,7 +445,7 @@ func (n *Node) startStoresScanner(stopper *util.Stopper) {
 					Stats:      *stats,
 				}
 				key := engine.NodeStatusKey(int32(n.Descriptor.NodeID))
-				if err := n.ctx.DB.Run(client.PutProtoCall(key, status)); err != nil {
+				if err := n.ctx.DB.Run(client.PutProto(key, status)); err != nil {
 					log.Error(err)
 				}
 				// Increment iteration count.

--- a/server/node_test.go
+++ b/server/node_test.go
@@ -348,10 +348,10 @@ func TestNodeStatus(t *testing.T) {
 	oldStats := compareStoreStatus(t, ts.node, expectedNodeStatus, 0)
 
 	// Write some values left and right of the proposed split key.
-	if err := ts.kv.Run(client.PutCall([]byte("a"), content)); err != nil {
+	if err := ts.kv.Run(client.Put([]byte("a"), content)); err != nil {
 		t.Fatal(err)
 	}
-	if err := ts.kv.Run(client.PutCall([]byte("c"), content)); err != nil {
+	if err := ts.kv.Run(client.Put([]byte("c"), content)); err != nil {
 		t.Fatal(err)
 	}
 
@@ -403,10 +403,10 @@ func TestNodeStatus(t *testing.T) {
 	oldStats = compareStoreStatus(t, ts.node, expectedNodeStatus, 2)
 
 	// Write some values left and right of the proposed split key.
-	if err := ts.kv.Run(client.PutCall([]byte("aa"), content)); err != nil {
+	if err := ts.kv.Run(client.Put([]byte("aa"), content)); err != nil {
 		t.Fatal(err)
 	}
-	if err := ts.kv.Run(client.PutCall([]byte("cc"), content)); err != nil {
+	if err := ts.kv.Run(client.Put([]byte("cc"), content)); err != nil {
 		t.Fatal(err)
 	}
 

--- a/server/server_test.go
+++ b/server/server_test.go
@@ -331,13 +331,13 @@ func TestMultiRangeScanDeleteRange(t *testing.T) {
 	}
 	var call client.Call
 	for i, k := range writes {
-		call = client.PutCall(k, k)
+		call = client.Put(k, k)
 		call.Args.Header().User = storage.UserRoot
 		tds.Send(call)
 		if err := call.Reply.Header().GoError(); err != nil {
 			t.Fatal(err)
 		}
-		scan := client.ScanCall(writes[0], writes[len(writes)-1].Next(), 0)
+		scan := client.Scan(writes[0], writes[len(writes)-1].Next(), 0)
 		// The Put ts may have been pushed by tsCache,
 		// so make sure we see their values in our Scan.
 		scan.Args.Header().Timestamp = call.Reply.Header().Timestamp
@@ -377,7 +377,7 @@ func TestMultiRangeScanDeleteRange(t *testing.T) {
 			len(writes), n)
 	}
 
-	scan := client.ScanCall(writes[0], writes[len(writes)-1].Next(), 0)
+	scan := client.Scan(writes[0], writes[len(writes)-1].Next(), 0)
 	scan.Args.Header().Timestamp = del.Reply.Header().Timestamp
 	scan.Args.Header().User = storage.UserRoot
 	scan.Args.Header().Txn = &proto.Transaction{Name: "MyTxn"}
@@ -427,7 +427,7 @@ func TestMultiRangeScanWithMaxResults(t *testing.T) {
 
 		var call client.Call
 		for _, k := range tc.keys {
-			call = client.PutCall(k, k)
+			call = client.Put(k, k)
 			call.Args.Header().User = storage.UserRoot
 			tds.Send(call)
 			if err := call.Reply.Header().GoError(); err != nil {
@@ -439,7 +439,7 @@ func TestMultiRangeScanWithMaxResults(t *testing.T) {
 		for start := 0; start < len(tc.keys); start++ {
 			// Try every possible maxResults, from 1 to beyond the size of key array.
 			for maxResults := 1; maxResults <= len(tc.keys)-start+1; maxResults++ {
-				scan := client.ScanCall(tc.keys[start], tc.keys[len(tc.keys)-1].Next(),
+				scan := client.Scan(tc.keys[start], tc.keys[len(tc.keys)-1].Next(),
 					int64(maxResults))
 				scan.Args.Header().Timestamp = call.Reply.Header().Timestamp
 				scan.Args.Header().User = storage.UserRoot

--- a/storage/client_range_tree_test.go
+++ b/storage/client_range_tree_test.go
@@ -77,7 +77,7 @@ func nodesEqual(key proto.Key, expected, actual proto.RangeTreeNode) error {
 }
 
 func getProto(kv *client.KV, key proto.Key, msg gogoproto.Message) error {
-	call := client.GetCall(key)
+	call := client.Get(key)
 	if err := kv.Run(call); err != nil {
 		return err
 	}

--- a/storage/client_split_test.go
+++ b/storage/client_split_test.go
@@ -392,7 +392,7 @@ func TestStoreZoneUpdateAndRangeSplit(t *testing.T) {
 		RangeMinBytes: 1 << 8,
 		RangeMaxBytes: maxBytes,
 	}
-	call := client.PutProtoCall(engine.MakeKey(engine.KeyConfigZonePrefix, engine.KeyMin), zoneConfig)
+	call := client.PutProto(engine.MakeKey(engine.KeyConfigZonePrefix, engine.KeyMin), zoneConfig)
 	if err := store.DB().Run(call); err != nil {
 		t.Fatal(err)
 	}
@@ -427,14 +427,14 @@ func TestStoreRangeSplitOnConfigs(t *testing.T) {
 	// Write zone configs for db3 & db4.
 	var calls []client.Call
 	for _, k := range []string{"db4", "db3"} {
-		call := client.PutProtoCall(
+		call := client.PutProto(
 			engine.MakeKey(engine.KeyConfigZonePrefix, proto.Key(k)),
 			zoneConfig)
 		calls = append(calls, call)
 	}
 	// Write accounting configs for db1 & db2.
 	for _, k := range []string{"db2", "db1"} {
-		call := client.PutProtoCall(
+		call := client.PutProto(
 			engine.MakeKey(engine.KeyConfigAccountingPrefix, proto.Key(k)),
 			acctConfig)
 		calls = append(calls, call)
@@ -454,7 +454,7 @@ func TestStoreRangeSplitOnConfigs(t *testing.T) {
 		engine.MakeKey(proto.Key("\x00\x00meta2"), engine.KeyMax),
 	}
 	if err := util.IsTrueWithin(func() bool {
-		call := client.ScanCall(engine.KeyMeta2Prefix, engine.KeyMetaMax, 0)
+		call := client.Scan(engine.KeyMeta2Prefix, engine.KeyMetaMax, 0)
 		resp := call.Reply.(*proto.ScanResponse)
 		if err := store.DB().Run(call); err != nil {
 			t.Fatalf("failed to scan meta2 keys: %s", err)

--- a/storage/db.go
+++ b/storage/db.go
@@ -29,11 +29,11 @@ import (
 type metaAction func([]client.Call, proto.Key, *proto.RangeDescriptor) []client.Call
 
 func putMeta(calls []client.Call, key proto.Key, desc *proto.RangeDescriptor) []client.Call {
-	return append(calls, client.PutProtoCall(key, desc))
+	return append(calls, client.PutProto(key, desc))
 }
 
 func delMeta(calls []client.Call, key proto.Key, desc *proto.RangeDescriptor) []client.Call {
-	return append(calls, client.DeleteCall(key))
+	return append(calls, client.Delete(key))
 }
 
 // SplitRangeAddressing creates (or overwrites if necessary) the meta1

--- a/storage/id_alloc.go
+++ b/storage/id_alloc.go
@@ -104,7 +104,7 @@ func (ia *IDAllocator) allocateBlock(incr int64) {
 			return util.RetryBreak, util.Errorf("id allocator exiting as stopper is draining")
 		}
 		idKey := ia.idKey.Load().(proto.Key)
-		call := client.IncrementCall(idKey, incr)
+		call := client.Increment(idKey, incr)
 		ir = call.Reply.(*proto.IncrementResponse)
 		if err := ia.db.Run(call); err != nil {
 			log.Warningf("unable to allocate %d ids from %s: %s", incr, ia.idKey, err)

--- a/storage/range.go
+++ b/storage/range.go
@@ -1863,7 +1863,7 @@ func (r *Range) AdminMerge(args *proto.AdminMergeRequest, reply *proto.AdminMerg
 		// Remove the range descriptor for the deleted range.
 		// TODO(bdarnell): need a conditional delete?
 		desc2Key := engine.RangeDescriptorKey(subsumedDesc.StartKey)
-		txn.Prepare(client.DeleteCall(desc2Key))
+		txn.Prepare(client.Delete(desc2Key))
 
 		calls, err := MergeRangeAddressing(desc, &updatedDesc)
 		if err != nil {

--- a/storage/range_tree.go
+++ b/storage/range_tree.go
@@ -66,11 +66,11 @@ func SetupRangeTree(batch engine.Engine, ms *proto.MVCCStats, timestamp proto.Ti
 // flush writes all dirty nodes and the tree to the transaction.
 func (tc *treeContext) flush() error {
 	if tc.dirty {
-		tc.txn.Prepare(client.PutProtoCall(engine.KeyRangeTreeRoot, tc.tree))
+		tc.txn.Prepare(client.PutProto(engine.KeyRangeTreeRoot, tc.tree))
 	}
 	for _, cachedNode := range tc.nodes {
 		if cachedNode.dirty {
-			call := client.PutProtoCall(engine.RangeTreeNodeKey(cachedNode.node.Key), cachedNode.node)
+			call := client.PutProto(engine.RangeTreeNodeKey(cachedNode.node.Key), cachedNode.node)
 			tc.txn.Prepare(call)
 		}
 	}
@@ -78,7 +78,7 @@ func (tc *treeContext) flush() error {
 }
 
 func getProto(txn *client.Txn, key proto.Key, msg gogoproto.Message) error {
-	call := client.GetCall(key)
+	call := client.Get(key)
 	if err := txn.Run(call); err != nil {
 		return err
 	}

--- a/storage/store.go
+++ b/storage/store.go
@@ -1226,7 +1226,7 @@ func (s *Store) GetStatus() (*proto.StoreStatus, error) {
 		return nil, nil
 	}
 	key := engine.StoreStatusKey(int32(s.Ident.StoreID))
-	call := client.GetCall(key)
+	call := client.Get(key)
 	reply := call.Reply.(*proto.GetResponse)
 	if err := s.ctx.DB.Run(call); err != nil {
 		return nil, err
@@ -1261,7 +1261,7 @@ func (s *Store) updateStoreStatus() {
 		Stats:      proto.MVCCStats(scannerStats.MVCC),
 	}
 	key := engine.StoreStatusKey(int32(s.Ident.StoreID))
-	if err := s.ctx.DB.Run(client.PutProtoCall(key, status)); err != nil {
+	if err := s.ctx.DB.Run(client.PutProto(key, status)); err != nil {
 		log.Error(err)
 	}
 }

--- a/structured/db.go
+++ b/structured/db.go
@@ -62,7 +62,7 @@ func (db *structuredDB) PutSchema(s *Schema) error {
 	if err := gob.NewEncoder(&buf).Encode(s); err != nil {
 		return err
 	}
-	return db.kvDB.Run(client.PutCall(k, buf.Bytes()))
+	return db.kvDB.Run(client.Put(k, buf.Bytes()))
 }
 
 // DeleteSchema removes s from the kv store.
@@ -82,7 +82,7 @@ func (db *structuredDB) DeleteSchema(s *Schema) error {
 func (db *structuredDB) GetSchema(key string) (*Schema, error) {
 	s := &Schema{}
 	k := engine.MakeKey(engine.KeySchemaPrefix, proto.Key(key))
-	call := client.GetCall(k)
+	call := client.Get(k)
 	if err := db.kvDB.Run(call); err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
This looks especially nice in code like:

```
    return txn.Run(
        client.Put(proto.Key("a"), []byte("asdf")),
        client.Put(proto.Key("c"), []byte("jkl;")),
    )
```

The Call suffix is just repetitive and not particularly useful.
