### PR TITLE
Add a post-rewrite glock hook.

### DIFF
--- a/githooks/post-rewrite
+++ b/githooks/post-rewrite
@@ -1,0 +1,12 @@
+#!/bin/bash
+set -e
+
+# $1 is either "rebase" or "amend"; only "rebase" can introduce new changes.
+if [[ $1 != rebase ]]; then
+   exit 0
+fi
+
+LOG=$(git log -U0 --oneline -p HEAD@{1}..HEAD GLOCKFILE)
+[ -z "$LOG" ] && echo "glock: no changes to apply" && exit 0
+echo "glock: applying updates..."
+glock apply <<< "$LOG"


### PR DESCRIPTION
This should address the problem Spencer had yesterday involving
inconsistent versions of C dependencies; assuming it works I'll
send a PR upstream to add this to glock itself.
