### PR TITLE
Update request timestamp after beginning cmd & update node clock post-Raft

### DIFF
--- a/storage/client_event_test.go
+++ b/storage/client_event_test.go
@@ -129,8 +129,8 @@ func TestMultiStoreEventFeed(t *testing.T) {
 	// Add some data in a transaction
 	err := mtc.db.RunTransaction(nil, func(txn *client.Txn) error {
 		return txn.Run(
-			client.PutCall(proto.Key("a"), []byte("asdf")),
-			client.PutCall(proto.Key("c"), []byte("jkl;")),
+			client.Put(proto.Key("a"), []byte("asdf")),
+			client.Put(proto.Key("c"), []byte("jkl;")),
 		)
 	})
 	if err != nil {
@@ -187,7 +187,7 @@ func TestMultiStoreEventFeed(t *testing.T) {
 	// Add an additional put through the system and wait for all
 	// replicas to receive it.
 	err = mtc.db.Run(
-		client.IncrementCall(proto.Key("aa"), 5),
+		client.Increment(proto.Key("aa"), 5),
 	)
 	if err != nil {
 		t.Fatalf("error putting data to db: %s", err.Error())

--- a/storage/range.go
+++ b/storage/range.go
@@ -314,8 +314,7 @@ func (r *Range) requestLeaderLease(timestamp proto.Timestamp) error {
 		},
 	}
 	// Send lease request directly to raft in order to skip unnecessary
-	// checks entanglements with normal request machinery, (e.g. the
-	// command queue).
+	// checks from normal request machinery, (e.g. the command queue).
 	errChan, pendingCmd := r.proposeRaftCommand(args, &proto.InternalLeaderLeaseResponse{})
 	var err error
 	if err = <-errChan; err == nil {

--- a/storage/store.go
+++ b/storage/store.go
@@ -948,11 +948,8 @@ func (s *Store) ExecuteCmd(args proto.Request, reply proto.Response) error {
 		reply.Header().SetGoError(err)
 		return err
 	}
-	if header.Timestamp.Equal(proto.ZeroTimestamp) {
-		// Update the incoming timestamp if unset.
-		header.Timestamp = s.ctx.Clock.Now()
-	} else {
-		// Otherwise, update our clock with the incoming request. This
+	if !header.Timestamp.Equal(proto.ZeroTimestamp) {
+		// Update our clock with the incoming request timestamp. This
 		// advances the local node's clock to a high water mark from
 		// amongst all nodes with which it has interacted. The update is
 		// bounded by the max clock drift.

--- a/storage/store_test.go
+++ b/storage/store_test.go
@@ -1027,8 +1027,8 @@ func TestStoreReadInconsistent(t *testing.T) {
 	gArgs.ReadConsistency = proto.INCONSISTENT
 	if err := store.ExecuteCmd(gArgs, gReply); err != nil {
 		t.Errorf("expected read to succeed: %s", err)
-	} else if !bytes.Equal(gReply.Value.Bytes, []byte("value1")) {
-		t.Errorf("expected value %q, got %q", []byte("value1"), gReply.Value.Bytes)
+	} else if gReply.Value == nil || !bytes.Equal(gReply.Value.Bytes, []byte("value1")) {
+		t.Errorf("expected value %q, got %+v", []byte("value1"), gReply.Value)
 	}
 	gArgs.Key = keyB
 	if err := store.ExecuteCmd(gArgs, gReply); err != nil {


### PR DESCRIPTION
This ensures that ops executed on replica with leader lease with zero
timestamps get the latest timestamp despite any leader lease changeover.
It also guarantees that all nodes with replicas for a range will update
their clocks to at least the last executed raft command.

Fixed a bug in client transaction execution by eliminating confusion between
having an end transaction as part of the transaction and having a txn'al
write. They were being conflated before, which made it impossible to tell
whether to abort on txn failure.
