### PR TITLE
Publish UpdateStoreEvent after Write commands

### DIFF
--- a/storage/feed.go
+++ b/storage/feed.go
@@ -38,6 +38,7 @@ type UpdateRangeEvent struct {
 	StoreID proto.StoreID
 	Desc    *proto.RangeDescriptor
 	Stats   proto.MVCCStats
+	Method  proto.Method
 	Diff    proto.MVCCStats
 }
 
@@ -118,11 +119,11 @@ func (sef StoreEventFeed) addRange(rng *Range) {
 
 // updateRange publishes an UpdateRangeEvent to this feed which describes a change
 // to the supplied Range.
-func (sef StoreEventFeed) updateRange(rng *Range, diff *proto.MVCCStats) {
+func (sef StoreEventFeed) updateRange(rng *Range, method proto.Method, diff *proto.MVCCStats) {
 	if sef.f == nil {
 		return
 	}
-	sef.f.Publish(makeUpdateRangeEvent(sef.id, rng, diff))
+	sef.f.Publish(makeUpdateRangeEvent(sef.id, rng, method, diff))
 }
 
 // removeRange publishes a RemoveRangeEvent to this feed which describes the
@@ -184,11 +185,12 @@ func makeAddRangeEvent(id proto.StoreID, rng *Range) *AddRangeEvent {
 	}
 }
 
-func makeUpdateRangeEvent(id proto.StoreID, rng *Range, diff *proto.MVCCStats) *UpdateRangeEvent {
+func makeUpdateRangeEvent(id proto.StoreID, rng *Range, method proto.Method, diff *proto.MVCCStats) *UpdateRangeEvent {
 	return &UpdateRangeEvent{
 		StoreID: id,
 		Desc:    rng.Desc(),
 		Stats:   rng.stats.GetMVCC(),
+		Method:  method,
 		Diff:    *diff,
 	}
 }

--- a/storage/feed_test.go
+++ b/storage/feed_test.go
@@ -142,7 +142,7 @@ func TestStoreEventFeed(t *testing.T) {
 		{
 			"UpdateRange",
 			func(feed StoreEventFeed) {
-				feed.updateRange(rng1, diffStats)
+				feed.updateRange(rng1, proto.Put, diffStats)
 			},
 			&UpdateRangeEvent{
 				StoreID: proto.StoreID(1),
@@ -156,6 +156,7 @@ func TestStoreEventFeed(t *testing.T) {
 					KeyBytes:  40,
 					ValBytes:  360,
 				},
+				Method: proto.Put,
 				Diff: proto.MVCCStats{
 					IntentBytes: 30,
 					IntentAge:   20,

--- a/storage/range.go
+++ b/storage/range.go
@@ -154,6 +154,7 @@ type RangeManager interface {
 	Gossip() *gossip.Gossip
 	SplitQueue() *splitQueue
 	Stopper() *util.Stopper
+	EventFeed() StoreEventFeed
 
 	// Range manipulation methods.
 	AddRange(rng *Range) error
@@ -802,6 +803,8 @@ func (r *Range) applyRaftCommand(index uint64, originNodeID multiraft.NodeID, ar
 			} else {
 				// After successful commit, update cached stats values.
 				r.stats.Update(ms)
+				// Publish update to event feed.
+				r.rm.EventFeed().updateRange(r, args.Method(), &ms)
 				// If the commit succeeded, potentially add range to split queue.
 				r.maybeSplit()
 				// Maybe update gossip configs on a put.


### PR DESCRIPTION
Ranges now publish an UpdateStoreEvent to their Store's event feed whenever a
write command completes. This event includes the command type that was executed
and the difference in stats that resulted from executing the command.

Included is a set of benchmarks which demonstrate that the generation of Update
events currently has a negligible impact on the performance of write commands.
This is accomplished by benchmarking write command with and without an event
feed.
