### PR TITLE
Tighten an error check in RemoveRange

### DIFF
--- a/storage/store.go
+++ b/storage/store.go
@@ -900,7 +900,7 @@ func (s *Store) RemoveRange(rng *Range) error {
 	n := sort.Search(len(s.rangesByKey), func(i int) bool {
 		return bytes.Compare(rng.Desc().StartKey, s.rangesByKey[i].Desc().EndKey) < 0
 	})
-	if n >= len(s.rangesByKey) {
+	if n >= len(s.rangesByKey) || rng.Desc().RaftID != s.rangesByKey[n].Desc().RaftID {
 		return util.Errorf("couldn't find range in rangesByKey slice")
 	}
 	s.rangesByKey = append(s.rangesByKey[:n], s.rangesByKey[n+1:]...)

--- a/storage/store_test.go
+++ b/storage/store_test.go
@@ -250,6 +250,10 @@ func TestStoreAddRemoveRanges(t *testing.T) {
 	if _, ok := err.(*rangeAlreadyExists); !ok {
 		t.Fatalf("expected rangeAlreadyExists error; got %s", err)
 	}
+	// Try to remove range 1 again.
+	if err := store.RemoveRange(rng1); err == nil {
+		t.Fatal("expected error re-removing same range")
+	}
 	// Try to add a range with previously-used (but now removed) ID.
 	rng2Dup := createRange(store, 1, proto.Key("a"), proto.Key("b"))
 	if err := store.AddRange(rng2Dup); err != nil {


### PR DESCRIPTION
Make the method return an error if a range found by `sort.Search()` does not have the same Raft ID. This happens when `Search()` returns a range next to a given range.
