### PR TITLE
Create NodeStatusMonitor

### DIFF
--- a/proto/data.go
+++ b/proto/data.go
@@ -646,25 +646,15 @@ func (ts TimeSeriesData) ToInternal(keyDuration int64, sampleDuration int64) (
 	return result, nil
 }
 
-// Difference returns the difference between two MVCCStats structures.
-func (ms *MVCCStats) Difference(oms *MVCCStats) MVCCStats {
-	return MVCCStats{
-		LiveBytes:       ms.LiveBytes - oms.LiveBytes,
-		KeyBytes:        ms.KeyBytes - oms.KeyBytes,
-		ValBytes:        ms.ValBytes - oms.ValBytes,
-		IntentBytes:     ms.IntentBytes - oms.IntentBytes,
-		LiveCount:       ms.LiveCount - oms.LiveCount,
-		KeyCount:        ms.KeyCount - oms.KeyCount,
-		ValCount:        ms.ValCount - oms.ValCount,
-		IntentCount:     ms.IntentCount - oms.IntentCount,
-		IntentAge:       ms.IntentAge - oms.IntentAge,
-		GCBytesAge:      ms.GCBytesAge - oms.GCBytesAge,
-		LastUpdateNanos: ms.LastUpdateNanos - oms.LastUpdateNanos,
-	}
+// Delta returns the difference between two MVCCStats structures.
+func (ms *MVCCStats) Delta(oms *MVCCStats) MVCCStats {
+	result := *ms
+	result.Subtract(oms)
+	return result
 }
 
 // Accumulate adds values from oms to ms.
-func (ms *MVCCStats) Accumulate(oms MVCCStats) {
+func (ms *MVCCStats) Accumulate(oms *MVCCStats) {
 	ms.LiveBytes += oms.LiveBytes
 	ms.KeyBytes += oms.KeyBytes
 	ms.ValBytes += oms.ValBytes
@@ -676,4 +666,19 @@ func (ms *MVCCStats) Accumulate(oms MVCCStats) {
 	ms.IntentAge += oms.IntentAge
 	ms.GCBytesAge += oms.GCBytesAge
 	ms.LastUpdateNanos += oms.LastUpdateNanos
+}
+
+// Subtract subtracts the values of oms from ms.
+func (ms *MVCCStats) Subtract(oms *MVCCStats) {
+	ms.LiveBytes -= oms.LiveBytes
+	ms.KeyBytes -= oms.KeyBytes
+	ms.ValBytes -= oms.ValBytes
+	ms.IntentBytes -= oms.IntentBytes
+	ms.LiveCount -= oms.LiveCount
+	ms.KeyCount -= oms.KeyCount
+	ms.ValCount -= oms.ValCount
+	ms.IntentCount -= oms.IntentCount
+	ms.IntentAge -= oms.IntentAge
+	ms.GCBytesAge -= oms.GCBytesAge
+	ms.LastUpdateNanos -= oms.LastUpdateNanos
 }

--- a/server/node.go
+++ b/server/node.go
@@ -439,7 +439,7 @@ func (n *Node) startStoresScanner(stopper *util.Stopper) {
 					}
 					accessedStoreIDs = append(accessedStoreIDs, int32(store.Ident.StoreID))
 					rangeCount += int(storeStatus.RangeCount)
-					stats.Accumulate(storeStatus.Stats)
+					stats.Accumulate(&storeStatus.Stats)
 					return nil
 				})
 

--- a/server/status/monitor.go
+++ b/server/status/monitor.go
@@ -1,0 +1,191 @@
+// Copyright 2015 The Cockroach Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+// implied. See the License for the specific language governing
+// permissions and limitations under the License. See the AUTHORS file
+// for names of contributors.
+//
+// Author: Matt Tracy (matt.r.tracy@gmail.com)
+
+package status
+
+import (
+	"github.com/cockroachdb/cockroach/proto"
+	"github.com/cockroachdb/cockroach/storage"
+	"github.com/cockroachdb/cockroach/util"
+)
+
+// StoreStatusMonitor monitors the status of a single store on the server.
+// Status information is collected from event feeds provided by lower level
+// components.
+type StoreStatusMonitor struct {
+	rangeDataAccumulator
+}
+
+// NodeStatusMonitor monitors the status of a server node. Status information
+// is collected from event feeds provided by lower level components.
+//
+// This structure contains collections of other StatusMonitor types which monitor
+// interesting subsets of data on the node. NodeStatusMonitor is responsible
+// for passing event feed data to these subset structures for accumulation.
+type NodeStatusMonitor struct {
+	stores map[proto.StoreID]*StoreStatusMonitor
+}
+
+// NewNodeStatusMonitor initializes a new NodeStatusMonitor instance.
+func NewNodeStatusMonitor() *NodeStatusMonitor {
+	return &NodeStatusMonitor{
+		stores: make(map[proto.StoreID]*StoreStatusMonitor),
+	}
+}
+
+// getStore is a helper method which retrieves the StoreStatusMonitor for the
+// given StoreID, creating it if it does not already exist.
+func (nsm *NodeStatusMonitor) getStore(id proto.StoreID) *StoreStatusMonitor {
+	if s, ok := nsm.stores[id]; ok {
+		return s
+	}
+	s := &StoreStatusMonitor{}
+	nsm.stores[id] = s
+	return s
+}
+
+// StartMonitorFeed begins processing events published to the supplied
+// Subscription. This method will continue running until the Subscription's
+// events feed is closed.
+func (nsm *NodeStatusMonitor) StartMonitorFeed(sub *util.Subscription) {
+	storage.ProcessStoreEvents(nsm, sub)
+}
+
+// OnAddRange receives AddRangeEvents retrieved from an storage event
+// subscription. This method is part of the implementation of
+// store.StoreEventListener.
+func (nsm *NodeStatusMonitor) OnAddRange(event *storage.AddRangeEvent) {
+	nsm.getStore(event.StoreID).addRange(event)
+}
+
+// OnUpdateRange receives UpdateRangeEvents retrieved from an storage event
+// subscription. This method is part of the implementation of
+// store.StoreEventListener.
+func (nsm *NodeStatusMonitor) OnUpdateRange(event *storage.UpdateRangeEvent) {
+	nsm.getStore(event.StoreID).updateRange(event)
+}
+
+// OnRemoveRange receives RemoveRangeEvents retrieved from an storage event
+// subscription. This method is part of the implementation of
+// store.StoreEventListener.
+func (nsm *NodeStatusMonitor) OnRemoveRange(event *storage.RemoveRangeEvent) {
+	nsm.getStore(event.StoreID).removeRange(event)
+}
+
+// OnSplitRange receives SplitRangeEvents retrieved from an storage event
+// subscription. This method is part of the implementation of
+// store.StoreEventListener.
+func (nsm *NodeStatusMonitor) OnSplitRange(event *storage.SplitRangeEvent) {
+	nsm.getStore(event.StoreID).splitRange(event)
+}
+
+// OnMergeRange receives MergeRangeEvents retrieved from an storage event
+// subscription. This method is part of the implementation of
+// store.StoreEventListener.
+func (nsm *NodeStatusMonitor) OnMergeRange(event *storage.MergeRangeEvent) {
+	nsm.getStore(event.StoreID).mergeRange(event)
+}
+
+// OnStartStore receives StartStoreEvents retrieved from an storage event
+// subscription. This method is part of the implementation of
+// store.StoreEventListener.
+func (nsm *NodeStatusMonitor) OnStartStore(event *storage.StartStoreEvent) {
+	nsm.getStore(event.StoreID)
+}
+
+// OnBeginScanRanges receives BeginScanRangesEvents retrieved from an storage
+// event subscription. This method is part of the implementation of
+// store.StoreEventListener.
+func (nsm *NodeStatusMonitor) OnBeginScanRanges(event *storage.BeginScanRangesEvent) {
+	nsm.getStore(event.StoreID).beginScanRanges(event)
+}
+
+// OnEndScanRanges receives EndScanRangesEvents retrieved from an storage event
+// subscription. This method is part of the implementation of
+// store.StoreEventListener.
+func (nsm *NodeStatusMonitor) OnEndScanRanges(event *storage.EndScanRangesEvent) {
+	nsm.getStore(event.StoreID).endScanRanges(event)
+}
+
+// rangeDataAccumulator maintains a set of accumulated stats for a set of
+// ranges, computed from an incoming stream of storage events. Stats will be
+// changed by any events sent to this type; higher level components are
+// responsible for selecting the specific ranges accumulated by a
+// rangeDataAccumulator instance.
+type rangeDataAccumulator struct {
+	stats      proto.MVCCStats
+	rangeCount int64
+	// 'scanning' is a special mode used to initialize a rangeDataAccumulator.
+	// During typical operation stats are monitored using per-operation deltas;
+	// however, when a rangeDataAccumulator is initialized it must first read
+	// the total value of all stats at the time when it is created.
+	//
+	// The scanning mode is used to facilitate this: the underlying store will
+	// initiate a scan with "beginScanRanges", and then send an AddRangeEvent
+	// for each range in the store.
+	//
+	// During a scan it is not possible for ranges to be added, removed, split
+	// or merged; however, it is possible for UpdateRangeEvents to occur during
+	// a scan. The seenScan collection is used to properly handle
+	// UpdateRangeEvents in this case.
+	isScanning bool
+	seenScan   map[int64]struct{}
+}
+
+func (rda *rangeDataAccumulator) addRange(event *storage.AddRangeEvent) {
+	if rda.isScanning {
+		rda.seenScan[event.Desc.RaftID] = struct{}{}
+		rda.rangeCount++
+		rda.stats.Accumulate(&event.Stats)
+	}
+}
+
+func (rda *rangeDataAccumulator) updateRange(event *storage.UpdateRangeEvent) {
+	if rda.isScanning {
+		// Skip if we are in an active scan and have not yet accumulated the
+		// data for this range.
+		if _, seen := rda.seenScan[event.Desc.RaftID]; !seen {
+			return
+		}
+	}
+	rda.stats.Accumulate(&event.Delta)
+}
+
+func (rda *rangeDataAccumulator) removeRange(event *storage.RemoveRangeEvent) {
+	rda.stats.Subtract(&event.Stats)
+	rda.rangeCount--
+}
+
+func (rda *rangeDataAccumulator) splitRange(event *storage.SplitRangeEvent) {
+	rda.rangeCount++
+}
+
+func (rda *rangeDataAccumulator) mergeRange(event *storage.MergeRangeEvent) {
+	rda.rangeCount--
+}
+
+func (rda *rangeDataAccumulator) beginScanRanges(event *storage.BeginScanRangesEvent) {
+	rda.isScanning = true
+	rda.stats = proto.MVCCStats{}
+	rda.rangeCount = 0
+	rda.seenScan = make(map[int64]struct{})
+}
+
+func (rda *rangeDataAccumulator) endScanRanges(event *storage.EndScanRangesEvent) {
+	rda.isScanning = false
+	rda.seenScan = nil
+}

--- a/server/status/monitor_test.go
+++ b/server/status/monitor_test.go
@@ -1,0 +1,167 @@
+// Copyright 2015 The Cockroach Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+// implied. See the License for the specific language governing
+// permissions and limitations under the License. See the AUTHORS file
+// for names of contributors.
+//
+// Author: Matt Tracy (matt.r.tracy@gmail.com)
+
+package status
+
+import (
+	"reflect"
+	"testing"
+
+	"github.com/cockroachdb/cockroach/proto"
+	"github.com/cockroachdb/cockroach/storage"
+	"github.com/cockroachdb/cockroach/util"
+)
+
+func TestNodeStatusMonitor(t *testing.T) {
+	desc1 := &proto.RangeDescriptor{
+		RaftID:   1,
+		StartKey: proto.Key("a"),
+		EndKey:   proto.Key("b"),
+	}
+	desc2 := &proto.RangeDescriptor{
+		RaftID:   2,
+		StartKey: proto.Key("b"),
+		EndKey:   proto.Key("c"),
+	}
+	stats := proto.MVCCStats{
+		LiveBytes:       1,
+		KeyBytes:        2,
+		ValBytes:        2,
+		IntentBytes:     1,
+		LiveCount:       1,
+		KeyCount:        1,
+		ValCount:        1,
+		IntentCount:     1,
+		IntentAge:       1,
+		GCBytesAge:      1,
+		LastUpdateNanos: 1 * 1E9,
+	}
+
+	monitorStopper := util.NewStopper()
+	storeStopper := util.NewStopper()
+	feed := &util.Feed{}
+	monitor := NewNodeStatusMonitor()
+	sub := feed.Subscribe()
+	monitorStopper.RunWorker(func() {
+		monitor.StartMonitorFeed(sub)
+	})
+
+	for i := 0; i < 3; i++ {
+		id := proto.StoreID(i + 1)
+		eventList := []interface{}{
+			&storage.StartStoreEvent{
+				StoreID: id,
+			},
+			&storage.BeginScanRangesEvent{ // Begin scan phase.
+				StoreID: id,
+			},
+			&storage.UpdateRangeEvent{ // Update during scan, expect it to be ignored.
+				StoreID: id,
+				Desc:    desc1,
+				Stats:   stats,
+				Delta:   stats,
+			},
+			&storage.AddRangeEvent{
+				StoreID: id,
+				Desc:    desc1,
+				Stats:   stats,
+			},
+			&storage.UpdateRangeEvent{ // Update during scan after add, should be picked up.
+				StoreID: id,
+				Desc:    desc1,
+				Stats:   stats,
+				Delta:   stats,
+			},
+			&storage.EndScanRangesEvent{ // End Scan.
+				StoreID: id,
+			},
+			&storage.UpdateRangeEvent{
+				StoreID: id,
+				Desc:    desc1,
+				Stats:   stats,
+				Delta:   stats,
+			},
+			&storage.UpdateRangeEvent{
+				StoreID: id,
+				Desc:    desc1,
+				Stats:   stats,
+				Delta:   stats,
+			},
+			&storage.SplitRangeEvent{
+				StoreID: id,
+				Original: storage.UpdateRangeEvent{
+					StoreID: id,
+					Desc:    desc1,
+					Stats:   stats,
+					Delta:   stats,
+				},
+				New: storage.AddRangeEvent{
+					StoreID: id,
+					Desc:    desc2,
+					Stats:   stats,
+				},
+			},
+			&storage.UpdateRangeEvent{
+				StoreID: id,
+				Desc:    desc2,
+				Stats:   stats,
+				Delta:   stats,
+			},
+			&storage.UpdateRangeEvent{
+				StoreID: id,
+				Desc:    desc2,
+				Stats:   stats,
+				Delta:   stats,
+			},
+		}
+		storeStopper.RunWorker(func() {
+			for _, event := range eventList {
+				feed.Publish(event)
+			}
+		})
+	}
+
+	storeStopper.Stop()
+	feed.Close()
+	monitorStopper.Stop()
+
+	expectedStats := proto.MVCCStats{
+		LiveBytes:       6,
+		KeyBytes:        12,
+		ValBytes:        12,
+		IntentBytes:     6,
+		LiveCount:       6,
+		KeyCount:        6,
+		ValCount:        6,
+		IntentCount:     6,
+		IntentAge:       6,
+		GCBytesAge:      6,
+		LastUpdateNanos: 6 * 1E9,
+	}
+
+	if a, e := len(monitor.stores), 3; a != e {
+		t.Fatalf("unexpected number of stores recorded by monitor; expected %d, got %d", e, a)
+	}
+	for id, store := range monitor.stores {
+		if a, e := store.stats, expectedStats; !reflect.DeepEqual(a, e) {
+			t.Errorf("monitored stats for store %d did not match expectation: %v != %v", id, a, e)
+		}
+		if a, e := store.rangeCount, int64(2); a != e {
+			t.Errorf("monitored range count for store %d did not match expectation: %d != %d", id, a, e)
+		}
+	}
+}

--- a/storage/client_event_test.go
+++ b/storage/client_event_test.go
@@ -63,7 +63,7 @@ func (ser *storeEventReader) recordEvent(event interface{}) {
 		if ser.recordUpdateDetail {
 			sid = event.StoreID
 			eventStr = fmt.Sprintf("UpdateRange rid=%d, method=%s, livediff=%d",
-				event.Desc.RaftID, event.Method.String(), event.Diff.LiveBytes)
+				event.Desc.RaftID, event.Method.String(), event.Delta.LiveBytes)
 		} else {
 			ser.perStoreUpdateCount[event.StoreID]++
 		}

--- a/storage/feed_test.go
+++ b/storage/feed_test.go
@@ -157,7 +157,7 @@ func TestStoreEventFeed(t *testing.T) {
 					ValBytes:  360,
 				},
 				Method: proto.Put,
-				Diff: proto.MVCCStats{
+				Delta: proto.MVCCStats{
 					IntentBytes: 30,
 					IntentAge:   20,
 				},
@@ -200,7 +200,7 @@ func TestStoreEventFeed(t *testing.T) {
 						KeyBytes:  40,
 						ValBytes:  360,
 					},
-					Diff: proto.MVCCStats{
+					Delta: proto.MVCCStats{
 						LiveBytes: -200,
 						KeyBytes:  -30,
 						ValBytes:  -170,
@@ -238,7 +238,7 @@ func TestStoreEventFeed(t *testing.T) {
 						KeyBytes:  40,
 						ValBytes:  360,
 					},
-					Diff: proto.MVCCStats{
+					Delta: proto.MVCCStats{
 						LiveBytes: 200,
 						KeyBytes:  30,
 						ValBytes:  170,

--- a/storage/range.go
+++ b/storage/range.go
@@ -813,11 +813,11 @@ func (r *Range) applyRaftCommand(index uint64, originNodeID multiraft.NodeID, ar
 			log.Fatalf("failed to commit batch from Raft command execution: %s", err)
 		}
 		committed = true
+		// Publish update to event feed.
+		r.rm.EventFeed().updateRange(r, args.Method(), &ms)
 		// After successful commit, update cached stats and appliedIndex value.
 		atomic.StoreUint64(&r.appliedIndex, index)
 		r.stats.Update(ms)
-		// Publish update to event feed.
-		r.rm.EventFeed().updateRange(r, args.Method(), &ms)
 		// If the commit succeeded, potentially add range to split queue.
 		r.maybeAddToSplitQueue()
 		// Maybe update gossip configs on a put.

--- a/storage/scanner.go
+++ b/storage/scanner.go
@@ -185,7 +185,8 @@ func (rs *rangeScanner) scanLoop(clock *hlc.Clock, stopper *util.Stopper) {
 						q.MaybeAdd(rng, clock.Now())
 					}
 					stats.RangeCount++
-					stats.MVCC.Accumulate(rng.stats.GetMVCC())
+					ms := rng.stats.GetMVCC()
+					stats.MVCC.Accumulate(&ms)
 				} else {
 					// Otherwise, we're done with the iteration. Reset iteration and start time.
 					rs.iter.Reset()

--- a/storage/stats.go
+++ b/storage/stats.go
@@ -95,7 +95,7 @@ func (rs *rangeStats) SetMVCCStats(e engine.Engine, ms proto.MVCCStats) {
 func (rs *rangeStats) Update(ms proto.MVCCStats) {
 	rs.Lock()
 	defer rs.Unlock()
-	rs.MVCCStats.Accumulate(ms)
+	rs.MVCCStats.Accumulate(&ms)
 }
 
 // GetAvgIntentAge returns the average age of outstanding intents,


### PR DESCRIPTION
Create the NodeStatusMonitor type, a high-level package that accumulates
statistics by monitoring event feeds from stores. This structure is not yet
being instantiated by the server.

Also includes some refactoring of the storage feed system which resolves some
concerns encountered while developing NodeStatusMonitor.
