### PR TITLE
Convert StoreDescriptor to Proto.

### DIFF
--- a/kv/local_sender_test.go
+++ b/kv/local_sender_test.go
@@ -121,7 +121,7 @@ func TestLocalSenderLookupReplica(t *testing.T) {
 		e[i] = engine.NewInMem(proto.Attributes{}, 1<<20)
 		ctx.Transport = multiraft.NewLocalRPCTransport()
 		defer ctx.Transport.Close()
-		s[i] = storage.NewStore(ctx, e[i])
+		s[i] = storage.NewStore(ctx, e[i], &proto.NodeDescriptor{NodeID: 1})
 		s[i].Ident.StoreID = rng.storeID
 
 		desc := &proto.RangeDescriptor{

--- a/kv/local_test_cluster.go
+++ b/kv/local_test_cluster.go
@@ -129,7 +129,7 @@ func (ltc *LocalTestCluster) Start(t testing.TB) {
 	sCtx.DB = ltc.KV
 	sCtx.Gossip = ltc.Gossip
 	sCtx.Transport = transport
-	ltc.Store = storage.NewStore(sCtx, ltc.Eng)
+	ltc.Store = storage.NewStore(sCtx, ltc.Eng, &proto.NodeDescriptor{NodeID: 1})
 	if err := ltc.Store.Bootstrap(proto.StoreIdent{NodeID: 1, StoreID: 1}, ltc.Stopper); err != nil {
 		t.Fatalf("unable to start local test cluster: %s", err)
 	}

--- a/proto/config.go
+++ b/proto/config.go
@@ -209,3 +209,25 @@ func (rs ReplicaSlice) MoveToFront(i int) {
 	copy(rs[1:i+1], rs[0:i])
 	rs[0] = front
 }
+
+// PercentAvail computes the percentage of disk space that is available.
+func (sc StoreCapacity) PercentAvail() float64 {
+	if sc.Capacity == 0 {
+		return 0
+	}
+	return float64(sc.Available) / float64(sc.Capacity)
+}
+
+// Less compares two StoreDescriptors based on percentage of disk available.
+func (s StoreDescriptor) Less(b util.Ordered) bool {
+	return s.Capacity.PercentAvail() < b.(StoreDescriptor).Capacity.PercentAvail()
+}
+
+// CombinedAttrs returns the full list of attributes for the store, including
+// both the node and store attributes.
+func (s StoreDescriptor) CombinedAttrs() *Attributes {
+	var a []string
+	a = append(a, s.Node.Attrs.Attrs...)
+	a = append(a, s.Attrs.Attrs...)
+	return &Attributes{Attrs: a}
+}

--- a/proto/config.pb.go
+++ b/proto/config.pb.go
@@ -270,6 +270,31 @@ func (m *Addr) GetAddress() string {
 	return ""
 }
 
+// StoreCapacity contains capacity information for a storage device.
+type StoreCapacity struct {
+	Capacity         int64  `protobuf:"varint,1,opt" json:"Capacity"`
+	Available        int64  `protobuf:"varint,2,opt" json:"Available"`
+	XXX_unrecognized []byte `json:"-"`
+}
+
+func (m *StoreCapacity) Reset()         { *m = StoreCapacity{} }
+func (m *StoreCapacity) String() string { return proto1.CompactTextString(m) }
+func (*StoreCapacity) ProtoMessage()    {}
+
+func (m *StoreCapacity) GetCapacity() int64 {
+	if m != nil {
+		return m.Capacity
+	}
+	return 0
+}
+
+func (m *StoreCapacity) GetAvailable() int64 {
+	if m != nil {
+		return m.Available
+	}
+	return 0
+}
+
 // NodeDescriptor holds details on node physical/network topology.
 type NodeDescriptor struct {
 	NodeID           NodeID     `protobuf:"varint,1,opt,name=node_id,customtype=NodeID" json:"node_id"`
@@ -294,6 +319,41 @@ func (m *NodeDescriptor) GetAttrs() Attributes {
 		return m.Attrs
 	}
 	return Attributes{}
+}
+
+// StoreDescriptor holds store information including store attributes, node
+// descriptor and store capacity.
+type StoreDescriptor struct {
+	StoreID          StoreID        `protobuf:"varint,1,opt,name=store_id,customtype=StoreID" json:"store_id"`
+	Attrs            Attributes     `protobuf:"bytes,2,opt,name=attrs" json:"attrs"`
+	Node             NodeDescriptor `protobuf:"bytes,3,opt,name=node" json:"node"`
+	Capacity         StoreCapacity  `protobuf:"bytes,4,opt,name=capacity" json:"capacity"`
+	XXX_unrecognized []byte         `json:"-"`
+}
+
+func (m *StoreDescriptor) Reset()         { *m = StoreDescriptor{} }
+func (m *StoreDescriptor) String() string { return proto1.CompactTextString(m) }
+func (*StoreDescriptor) ProtoMessage()    {}
+
+func (m *StoreDescriptor) GetAttrs() Attributes {
+	if m != nil {
+		return m.Attrs
+	}
+	return Attributes{}
+}
+
+func (m *StoreDescriptor) GetNode() NodeDescriptor {
+	if m != nil {
+		return m.Node
+	}
+	return NodeDescriptor{}
+}
+
+func (m *StoreDescriptor) GetCapacity() StoreCapacity {
+	if m != nil {
+		return m.Capacity
+	}
+	return StoreCapacity{}
 }
 
 func init() {
@@ -1224,6 +1284,78 @@ func (m *Addr) Unmarshal(data []byte) error {
 	}
 	return nil
 }
+func (m *StoreCapacity) Unmarshal(data []byte) error {
+	l := len(data)
+	index := 0
+	for index < l {
+		var wire uint64
+		for shift := uint(0); ; shift += 7 {
+			if index >= l {
+				return io.ErrUnexpectedEOF
+			}
+			b := data[index]
+			index++
+			wire |= (uint64(b) & 0x7F) << shift
+			if b < 0x80 {
+				break
+			}
+		}
+		fieldNum := int32(wire >> 3)
+		wireType := int(wire & 0x7)
+		switch fieldNum {
+		case 1:
+			if wireType != 0 {
+				return fmt.Errorf("proto: wrong wireType = %d for field Capacity", wireType)
+			}
+			for shift := uint(0); ; shift += 7 {
+				if index >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := data[index]
+				index++
+				m.Capacity |= (int64(b) & 0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+		case 2:
+			if wireType != 0 {
+				return fmt.Errorf("proto: wrong wireType = %d for field Available", wireType)
+			}
+			for shift := uint(0); ; shift += 7 {
+				if index >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := data[index]
+				index++
+				m.Available |= (int64(b) & 0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+		default:
+			var sizeOfWire int
+			for {
+				sizeOfWire++
+				wire >>= 7
+				if wire == 0 {
+					break
+				}
+			}
+			index -= sizeOfWire
+			skippy, err := github_com_gogo_protobuf_proto.Skip(data[index:])
+			if err != nil {
+				return err
+			}
+			if (index + skippy) > l {
+				return io.ErrUnexpectedEOF
+			}
+			m.XXX_unrecognized = append(m.XXX_unrecognized, data[index:index+skippy]...)
+			index += skippy
+		}
+	}
+	return nil
+}
 func (m *NodeDescriptor) Unmarshal(data []byte) error {
 	l := len(data)
 	index := 0
@@ -1303,6 +1435,135 @@ func (m *NodeDescriptor) Unmarshal(data []byte) error {
 				return io.ErrUnexpectedEOF
 			}
 			if err := m.Attrs.Unmarshal(data[index:postIndex]); err != nil {
+				return err
+			}
+			index = postIndex
+		default:
+			var sizeOfWire int
+			for {
+				sizeOfWire++
+				wire >>= 7
+				if wire == 0 {
+					break
+				}
+			}
+			index -= sizeOfWire
+			skippy, err := github_com_gogo_protobuf_proto.Skip(data[index:])
+			if err != nil {
+				return err
+			}
+			if (index + skippy) > l {
+				return io.ErrUnexpectedEOF
+			}
+			m.XXX_unrecognized = append(m.XXX_unrecognized, data[index:index+skippy]...)
+			index += skippy
+		}
+	}
+	return nil
+}
+func (m *StoreDescriptor) Unmarshal(data []byte) error {
+	l := len(data)
+	index := 0
+	for index < l {
+		var wire uint64
+		for shift := uint(0); ; shift += 7 {
+			if index >= l {
+				return io.ErrUnexpectedEOF
+			}
+			b := data[index]
+			index++
+			wire |= (uint64(b) & 0x7F) << shift
+			if b < 0x80 {
+				break
+			}
+		}
+		fieldNum := int32(wire >> 3)
+		wireType := int(wire & 0x7)
+		switch fieldNum {
+		case 1:
+			if wireType != 0 {
+				return fmt.Errorf("proto: wrong wireType = %d for field StoreID", wireType)
+			}
+			for shift := uint(0); ; shift += 7 {
+				if index >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := data[index]
+				index++
+				m.StoreID |= (StoreID(b) & 0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+		case 2:
+			if wireType != 2 {
+				return fmt.Errorf("proto: wrong wireType = %d for field Attrs", wireType)
+			}
+			var msglen int
+			for shift := uint(0); ; shift += 7 {
+				if index >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := data[index]
+				index++
+				msglen |= (int(b) & 0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			postIndex := index + msglen
+			if postIndex > l {
+				return io.ErrUnexpectedEOF
+			}
+			if err := m.Attrs.Unmarshal(data[index:postIndex]); err != nil {
+				return err
+			}
+			index = postIndex
+		case 3:
+			if wireType != 2 {
+				return fmt.Errorf("proto: wrong wireType = %d for field Node", wireType)
+			}
+			var msglen int
+			for shift := uint(0); ; shift += 7 {
+				if index >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := data[index]
+				index++
+				msglen |= (int(b) & 0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			postIndex := index + msglen
+			if postIndex > l {
+				return io.ErrUnexpectedEOF
+			}
+			if err := m.Node.Unmarshal(data[index:postIndex]); err != nil {
+				return err
+			}
+			index = postIndex
+		case 4:
+			if wireType != 2 {
+				return fmt.Errorf("proto: wrong wireType = %d for field Capacity", wireType)
+			}
+			var msglen int
+			for shift := uint(0); ; shift += 7 {
+				if index >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := data[index]
+				index++
+				msglen |= (int(b) & 0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			postIndex := index + msglen
+			if postIndex > l {
+				return io.ErrUnexpectedEOF
+			}
+			if err := m.Capacity.Unmarshal(data[index:postIndex]); err != nil {
 				return err
 			}
 			index = postIndex
@@ -1486,6 +1747,17 @@ func (m *Addr) Size() (n int) {
 	return n
 }
 
+func (m *StoreCapacity) Size() (n int) {
+	var l int
+	_ = l
+	n += 1 + sovConfig(uint64(m.Capacity))
+	n += 1 + sovConfig(uint64(m.Available))
+	if m.XXX_unrecognized != nil {
+		n += len(m.XXX_unrecognized)
+	}
+	return n
+}
+
 func (m *NodeDescriptor) Size() (n int) {
 	var l int
 	_ = l
@@ -1493,6 +1765,22 @@ func (m *NodeDescriptor) Size() (n int) {
 	l = m.Address.Size()
 	n += 1 + l + sovConfig(uint64(l))
 	l = m.Attrs.Size()
+	n += 1 + l + sovConfig(uint64(l))
+	if m.XXX_unrecognized != nil {
+		n += len(m.XXX_unrecognized)
+	}
+	return n
+}
+
+func (m *StoreDescriptor) Size() (n int) {
+	var l int
+	_ = l
+	n += 1 + sovConfig(uint64(m.StoreID))
+	l = m.Attrs.Size()
+	n += 1 + l + sovConfig(uint64(l))
+	l = m.Node.Size()
+	n += 1 + l + sovConfig(uint64(l))
+	l = m.Capacity.Size()
 	n += 1 + l + sovConfig(uint64(l))
 	if m.XXX_unrecognized != nil {
 		n += len(m.XXX_unrecognized)
@@ -1908,6 +2196,33 @@ func (m *Addr) MarshalTo(data []byte) (n int, err error) {
 	return i, nil
 }
 
+func (m *StoreCapacity) Marshal() (data []byte, err error) {
+	size := m.Size()
+	data = make([]byte, size)
+	n, err := m.MarshalTo(data)
+	if err != nil {
+		return nil, err
+	}
+	return data[:n], nil
+}
+
+func (m *StoreCapacity) MarshalTo(data []byte) (n int, err error) {
+	var i int
+	_ = i
+	var l int
+	_ = l
+	data[i] = 0x8
+	i++
+	i = encodeVarintConfig(data, i, uint64(m.Capacity))
+	data[i] = 0x10
+	i++
+	i = encodeVarintConfig(data, i, uint64(m.Available))
+	if m.XXX_unrecognized != nil {
+		i += copy(data[i:], m.XXX_unrecognized)
+	}
+	return i, nil
+}
+
 func (m *NodeDescriptor) Marshal() (data []byte, err error) {
 	size := m.Size()
 	data = make([]byte, size)
@@ -1942,6 +2257,54 @@ func (m *NodeDescriptor) MarshalTo(data []byte) (n int, err error) {
 		return 0, err
 	}
 	i += n11
+	if m.XXX_unrecognized != nil {
+		i += copy(data[i:], m.XXX_unrecognized)
+	}
+	return i, nil
+}
+
+func (m *StoreDescriptor) Marshal() (data []byte, err error) {
+	size := m.Size()
+	data = make([]byte, size)
+	n, err := m.MarshalTo(data)
+	if err != nil {
+		return nil, err
+	}
+	return data[:n], nil
+}
+
+func (m *StoreDescriptor) MarshalTo(data []byte) (n int, err error) {
+	var i int
+	_ = i
+	var l int
+	_ = l
+	data[i] = 0x8
+	i++
+	i = encodeVarintConfig(data, i, uint64(m.StoreID))
+	data[i] = 0x12
+	i++
+	i = encodeVarintConfig(data, i, uint64(m.Attrs.Size()))
+	n12, err := m.Attrs.MarshalTo(data[i:])
+	if err != nil {
+		return 0, err
+	}
+	i += n12
+	data[i] = 0x1a
+	i++
+	i = encodeVarintConfig(data, i, uint64(m.Node.Size()))
+	n13, err := m.Node.MarshalTo(data[i:])
+	if err != nil {
+		return 0, err
+	}
+	i += n13
+	data[i] = 0x22
+	i++
+	i = encodeVarintConfig(data, i, uint64(m.Capacity.Size()))
+	n14, err := m.Capacity.MarshalTo(data[i:])
+	if err != nil {
+		return 0, err
+	}
+	i += n14
 	if m.XXX_unrecognized != nil {
 		i += copy(data[i:], m.XXX_unrecognized)
 	}

--- a/proto/config.proto
+++ b/proto/config.proto
@@ -128,6 +128,12 @@ message Addr {
   optional string address = 2 [(gogoproto.nullable) = false];
 }
 
+// StoreCapacity contains capacity information for a storage device.
+message StoreCapacity {
+  optional int64 Capacity = 1 [(gogoproto.nullable) = false];
+  optional int64 Available = 2 [(gogoproto.nullable) = false];
+}
+
 // NodeDescriptor holds details on node physical/network topology.
 message NodeDescriptor {
   optional int32 node_id = 1 [(gogoproto.nullable) = false, (gogoproto.customname) = "NodeID", (gogoproto.customtype) = "NodeID"];
@@ -135,5 +141,11 @@ message NodeDescriptor {
   optional Attributes attrs = 3 [(gogoproto.nullable) = false];
 }
 
-
-
+// StoreDescriptor holds store information including store attributes, node 
+// descriptor and store capacity.
+message StoreDescriptor {
+  optional int32 store_id = 1 [(gogoproto.nullable) = false, (gogoproto.customname) = "StoreID", (gogoproto.customtype) = "StoreID"];
+  optional Attributes attrs = 2 [(gogoproto.nullable) = false];
+  optional NodeDescriptor node = 3 [(gogoproto.nullable) = false];
+  optional StoreCapacity capacity = 4 [(gogoproto.nullable) = false];
+}

--- a/proto/status.pb.go
+++ b/proto/status.pb.go
@@ -20,18 +20,25 @@ var _ = math.Inf
 // StoreStatus contains the stats needed to calculate the current status of a
 // store.
 type StoreStatus struct {
-	StoreID          StoreID   `protobuf:"varint,1,opt,name=store_id,customtype=StoreID" json:"store_id"`
-	NodeID           NodeID    `protobuf:"varint,2,opt,name=node_id,customtype=NodeID" json:"node_id"`
-	RangeCount       int32     `protobuf:"varint,3,opt,name=range_count" json:"range_count"`
-	StartedAt        int64     `protobuf:"varint,4,opt,name=started_at" json:"started_at"`
-	UpdatedAt        int64     `protobuf:"varint,5,opt,name=updated_at" json:"updated_at"`
-	Stats            MVCCStats `protobuf:"bytes,6,opt,name=stats" json:"stats"`
-	XXX_unrecognized []byte    `json:"-"`
+	Desc             StoreDescriptor `protobuf:"bytes,1,opt,name=desc" json:"desc"`
+	NodeID           NodeID          `protobuf:"varint,2,opt,name=node_id,customtype=NodeID" json:"node_id"`
+	RangeCount       int32           `protobuf:"varint,3,opt,name=range_count" json:"range_count"`
+	StartedAt        int64           `protobuf:"varint,4,opt,name=started_at" json:"started_at"`
+	UpdatedAt        int64           `protobuf:"varint,5,opt,name=updated_at" json:"updated_at"`
+	Stats            MVCCStats       `protobuf:"bytes,6,opt,name=stats" json:"stats"`
+	XXX_unrecognized []byte          `json:"-"`
 }
 
 func (m *StoreStatus) Reset()         { *m = StoreStatus{} }
 func (m *StoreStatus) String() string { return proto1.CompactTextString(m) }
 func (*StoreStatus) ProtoMessage()    {}
+
+func (m *StoreStatus) GetDesc() StoreDescriptor {
+	if m != nil {
+		return m.Desc
+	}
+	return StoreDescriptor{}
+}
 
 func (m *StoreStatus) GetRangeCount() int32 {
 	if m != nil {
@@ -141,20 +148,29 @@ func (m *StoreStatus) Unmarshal(data []byte) error {
 		wireType := int(wire & 0x7)
 		switch fieldNum {
 		case 1:
-			if wireType != 0 {
-				return fmt.Errorf("proto: wrong wireType = %d for field StoreID", wireType)
+			if wireType != 2 {
+				return fmt.Errorf("proto: wrong wireType = %d for field Desc", wireType)
 			}
+			var msglen int
 			for shift := uint(0); ; shift += 7 {
 				if index >= l {
 					return io.ErrUnexpectedEOF
 				}
 				b := data[index]
 				index++
-				m.StoreID |= (StoreID(b) & 0x7F) << shift
+				msglen |= (int(b) & 0x7F) << shift
 				if b < 0x80 {
 					break
 				}
 			}
+			postIndex := index + msglen
+			if postIndex > l {
+				return io.ErrUnexpectedEOF
+			}
+			if err := m.Desc.Unmarshal(data[index:postIndex]); err != nil {
+				return err
+			}
+			index = postIndex
 		case 2:
 			if wireType != 0 {
 				return fmt.Errorf("proto: wrong wireType = %d for field NodeID", wireType)
@@ -417,7 +433,8 @@ func (m *NodeStatus) Unmarshal(data []byte) error {
 func (m *StoreStatus) Size() (n int) {
 	var l int
 	_ = l
-	n += 1 + sovStatus(uint64(m.StoreID))
+	l = m.Desc.Size()
+	n += 1 + l + sovStatus(uint64(l))
 	n += 1 + sovStatus(uint64(m.NodeID))
 	n += 1 + sovStatus(uint64(m.RangeCount))
 	n += 1 + sovStatus(uint64(m.StartedAt))
@@ -479,9 +496,14 @@ func (m *StoreStatus) MarshalTo(data []byte) (n int, err error) {
 	_ = i
 	var l int
 	_ = l
-	data[i] = 0x8
+	data[i] = 0xa
 	i++
-	i = encodeVarintStatus(data, i, uint64(m.StoreID))
+	i = encodeVarintStatus(data, i, uint64(m.Desc.Size()))
+	n1, err := m.Desc.MarshalTo(data[i:])
+	if err != nil {
+		return 0, err
+	}
+	i += n1
 	data[i] = 0x10
 	i++
 	i = encodeVarintStatus(data, i, uint64(m.NodeID))
@@ -497,11 +519,11 @@ func (m *StoreStatus) MarshalTo(data []byte) (n int, err error) {
 	data[i] = 0x32
 	i++
 	i = encodeVarintStatus(data, i, uint64(m.Stats.Size()))
-	n1, err := m.Stats.MarshalTo(data[i:])
+	n2, err := m.Stats.MarshalTo(data[i:])
 	if err != nil {
 		return 0, err
 	}
-	i += n1
+	i += n2
 	if m.XXX_unrecognized != nil {
 		i += copy(data[i:], m.XXX_unrecognized)
 	}
@@ -526,11 +548,11 @@ func (m *NodeStatus) MarshalTo(data []byte) (n int, err error) {
 	data[i] = 0xa
 	i++
 	i = encodeVarintStatus(data, i, uint64(m.Desc.Size()))
-	n2, err := m.Desc.MarshalTo(data[i:])
+	n3, err := m.Desc.MarshalTo(data[i:])
 	if err != nil {
 		return 0, err
 	}
-	i += n2
+	i += n3
 	if len(m.StoreIDs) > 0 {
 		for _, num := range m.StoreIDs {
 			data[i] = 0x10
@@ -550,11 +572,11 @@ func (m *NodeStatus) MarshalTo(data []byte) (n int, err error) {
 	data[i] = 0x32
 	i++
 	i = encodeVarintStatus(data, i, uint64(m.Stats.Size()))
-	n3, err := m.Stats.MarshalTo(data[i:])
+	n4, err := m.Stats.MarshalTo(data[i:])
 	if err != nil {
 		return 0, err
 	}
-	i += n3
+	i += n4
 	if m.XXX_unrecognized != nil {
 		i += copy(data[i:], m.XXX_unrecognized)
 	}

--- a/proto/status.proto
+++ b/proto/status.proto
@@ -30,7 +30,7 @@ option (gogoproto.unmarshaler_all) = true;
 // StoreStatus contains the stats needed to calculate the current status of a
 // store.
 message StoreStatus {  
-  optional int32 store_id = 1 [(gogoproto.nullable) = false, (gogoproto.customname) = "StoreID", (gogoproto.customtype) = "StoreID"];
+  optional StoreDescriptor desc = 1 [(gogoproto.nullable) = false];
   optional int32 node_id = 2 [(gogoproto.nullable) = false, (gogoproto.customname) = "NodeID", (gogoproto.customtype) = "NodeID"];
   optional int32 range_count = 3 [(gogoproto.nullable) = false];
   optional int64 started_at = 4 [(gogoproto.nullable) = false];

--- a/server/node.go
+++ b/server/node.go
@@ -130,9 +130,9 @@ func BootstrapCluster(clusterID string, engines []engine.Engine, stopper *util.S
 			StoreID:   proto.StoreID(i + 1),
 		}
 
-		// The bootstrapping store will not connect to other nodes so its StoreConfig
-		// doesn't really matter.
-		s := storage.NewStore(ctx, eng)
+		// The bootstrapping store will not connect to other nodes so its
+		// StoreConfig doesn't really matter.
+		s := storage.NewStore(ctx, eng, &proto.NodeDescriptor{NodeID: 1})
 
 		// Verify the store isn't already part of a cluster.
 		if len(s.Ident.ClusterID) > 0 {
@@ -154,6 +154,7 @@ func BootstrapCluster(clusterID string, engines []engine.Engine, stopper *util.S
 		if err := s.Start(stopper); err != nil {
 			return nil, err
 		}
+
 		lSender.AddStore(s)
 
 		// Initialize node and store ids.  Only initialize the node once.
@@ -262,7 +263,7 @@ func (n *Node) initStores(engines []engine.Engine, stopper *util.Stopper) error 
 		return util.Error("no engines")
 	}
 	for _, e := range engines {
-		s := storage.NewStore(n.ctx, e)
+		s := storage.NewStore(n.ctx, e, &n.Descriptor)
 		// Initialize each store in turn, handling un-bootstrapped errors by
 		// adding the store to the bootstraps list.
 		if err := s.Start(stopper); err != nil {
@@ -408,7 +409,7 @@ func (n *Node) startGossip(stopper *util.Stopper) {
 // gossip network.
 func (n *Node) gossipCapacities() {
 	n.lSender.VisitStores(func(s *storage.Store) error {
-		s.GossipCapacity(&n.Descriptor)
+		s.GossipCapacity()
 		return nil
 	})
 }

--- a/storage/allocator.go
+++ b/storage/allocator.go
@@ -50,7 +50,7 @@ func newAllocator(f FindStoreFunc) *allocator {
 // available stores matching attributes for missing replicas and picks
 // using randomly weighted selection based on available capacities.
 func (a *allocator) allocate(required proto.Attributes, existingReplicas []proto.Replica) (
-	*StoreDescriptor, error) {
+	*proto.StoreDescriptor, error) {
 	// Get a set of current nodes -- we never want to allocate on an existing node.
 	usedNodes := make(map[proto.NodeID]struct{})
 	for _, replica := range existingReplicas {
@@ -63,7 +63,7 @@ func (a *allocator) allocate(required proto.Attributes, existingReplicas []proto
 	}
 
 	// Randomly pick a node weighted by capacity.
-	var candidates []*StoreDescriptor
+	var candidates []*proto.StoreDescriptor
 	var capacityTotal float64
 	for _, s := range stores {
 		if _, ok := usedNodes[s.Node.NodeID]; !ok {

--- a/storage/allocator_test.go
+++ b/storage/allocator_test.go
@@ -22,7 +22,6 @@ import (
 	"testing"
 
 	"github.com/cockroachdb/cockroach/proto"
-	"github.com/cockroachdb/cockroach/storage/engine"
 	"github.com/cockroachdb/cockroach/util/leaktest"
 )
 
@@ -49,8 +48,8 @@ var multiDCConfig = proto.ZoneConfig{
 
 // filterStores returns just the store descriptors in the supplied
 // stores slice which contain all the specified attributes.
-func filterStores(a proto.Attributes, stores []*StoreDescriptor) ([]*StoreDescriptor, error) {
-	var filtered []*StoreDescriptor
+func filterStores(a proto.Attributes, stores []*proto.StoreDescriptor) ([]*proto.StoreDescriptor, error) {
+	var filtered []*proto.StoreDescriptor
 	for _, s := range stores {
 		sAttrs := s.CombinedAttrs()
 		if a.IsSubset(*sAttrs) {
@@ -60,8 +59,8 @@ func filterStores(a proto.Attributes, stores []*StoreDescriptor) ([]*StoreDescri
 	return filtered, nil
 }
 
-var singleStore = func(a proto.Attributes) ([]*StoreDescriptor, error) {
-	return filterStores(a, []*StoreDescriptor{
+var singleStore = func(a proto.Attributes) ([]*proto.StoreDescriptor, error) {
+	return filterStores(a, []*proto.StoreDescriptor{
 		{
 			StoreID: 1,
 			Attrs:   proto.Attributes{Attrs: []string{"ssd"}},
@@ -69,7 +68,7 @@ var singleStore = func(a proto.Attributes) ([]*StoreDescriptor, error) {
 				NodeID: 1,
 				Attrs:  proto.Attributes{Attrs: []string{"a"}},
 			},
-			Capacity: engine.StoreCapacity{
+			Capacity: proto.StoreCapacity{
 				Capacity:  100,
 				Available: 100,
 			},
@@ -77,8 +76,8 @@ var singleStore = func(a proto.Attributes) ([]*StoreDescriptor, error) {
 	})
 }
 
-var sameDCStores = func(a proto.Attributes) ([]*StoreDescriptor, error) {
-	return filterStores(a, []*StoreDescriptor{
+var sameDCStores = func(a proto.Attributes) ([]*proto.StoreDescriptor, error) {
+	return filterStores(a, []*proto.StoreDescriptor{
 		{
 			StoreID: 1,
 			Attrs:   proto.Attributes{Attrs: []string{"ssd"}},
@@ -86,7 +85,7 @@ var sameDCStores = func(a proto.Attributes) ([]*StoreDescriptor, error) {
 				NodeID: 1,
 				Attrs:  proto.Attributes{Attrs: []string{"a"}},
 			},
-			Capacity: engine.StoreCapacity{
+			Capacity: proto.StoreCapacity{
 				Capacity:  100,
 				Available: 100,
 			},
@@ -98,7 +97,7 @@ var sameDCStores = func(a proto.Attributes) ([]*StoreDescriptor, error) {
 				NodeID: 2,
 				Attrs:  proto.Attributes{Attrs: []string{"a"}},
 			},
-			Capacity: engine.StoreCapacity{
+			Capacity: proto.StoreCapacity{
 				Capacity:  100,
 				Available: 100,
 			},
@@ -110,7 +109,7 @@ var sameDCStores = func(a proto.Attributes) ([]*StoreDescriptor, error) {
 				NodeID: 2,
 				Attrs:  proto.Attributes{Attrs: []string{"a"}},
 			},
-			Capacity: engine.StoreCapacity{
+			Capacity: proto.StoreCapacity{
 				Capacity:  100,
 				Available: 100,
 			},
@@ -122,7 +121,7 @@ var sameDCStores = func(a proto.Attributes) ([]*StoreDescriptor, error) {
 				NodeID: 3,
 				Attrs:  proto.Attributes{Attrs: []string{"a"}},
 			},
-			Capacity: engine.StoreCapacity{
+			Capacity: proto.StoreCapacity{
 				Capacity:  100,
 				Available: 100,
 			},
@@ -134,7 +133,7 @@ var sameDCStores = func(a proto.Attributes) ([]*StoreDescriptor, error) {
 				NodeID: 4,
 				Attrs:  proto.Attributes{Attrs: []string{"a"}},
 			},
-			Capacity: engine.StoreCapacity{
+			Capacity: proto.StoreCapacity{
 				Capacity:  100,
 				Available: 100,
 			},
@@ -142,8 +141,8 @@ var sameDCStores = func(a proto.Attributes) ([]*StoreDescriptor, error) {
 	})
 }
 
-var multiDCStores = func(a proto.Attributes) ([]*StoreDescriptor, error) {
-	return filterStores(a, []*StoreDescriptor{
+var multiDCStores = func(a proto.Attributes) ([]*proto.StoreDescriptor, error) {
+	return filterStores(a, []*proto.StoreDescriptor{
 		{
 			StoreID: 1,
 			Attrs:   proto.Attributes{Attrs: []string{"ssd"}},
@@ -151,7 +150,7 @@ var multiDCStores = func(a proto.Attributes) ([]*StoreDescriptor, error) {
 				NodeID: 1,
 				Attrs:  proto.Attributes{Attrs: []string{"a"}},
 			},
-			Capacity: engine.StoreCapacity{
+			Capacity: proto.StoreCapacity{
 				Capacity:  100,
 				Available: 100,
 			},
@@ -163,7 +162,7 @@ var multiDCStores = func(a proto.Attributes) ([]*StoreDescriptor, error) {
 				NodeID: 2,
 				Attrs:  proto.Attributes{Attrs: []string{"b"}},
 			},
-			Capacity: engine.StoreCapacity{
+			Capacity: proto.StoreCapacity{
 				Capacity:  100,
 				Available: 100,
 			},
@@ -171,8 +170,8 @@ var multiDCStores = func(a proto.Attributes) ([]*StoreDescriptor, error) {
 	})
 }
 
-var noStores = func(a proto.Attributes) ([]*StoreDescriptor, error) {
-	return filterStores(a, []*StoreDescriptor{})
+var noStores = func(a proto.Attributes) ([]*proto.StoreDescriptor, error) {
+	return filterStores(a, []*proto.StoreDescriptor{})
 }
 
 func TestSimpleRetrieval(t *testing.T) {

--- a/storage/client_raft_test.go
+++ b/storage/client_raft_test.go
@@ -479,7 +479,7 @@ func TestStoreRangeReplicate(t *testing.T) {
 
 	// Initialize the gossip network.
 	for _, s := range mtc.stores {
-		s.GossipCapacity(&proto.NodeDescriptor{NodeID: s.Ident.NodeID})
+		s.GossipCapacity()
 	}
 	mtc.stores[0].WaitForNodes(3)
 

--- a/storage/client_test.go
+++ b/storage/client_test.go
@@ -78,7 +78,7 @@ func createTestStoreWithEngine(t *testing.T, eng engine.Engine, clock *hlc.Clock
 	ctx.DB.User = storage.UserRoot
 	ctx.Transport = multiraft.NewLocalRPCTransport()
 	// TODO(bdarnell): arrange to have the transport closed.
-	store := storage.NewStore(*ctx, eng)
+	store := storage.NewStore(*ctx, eng, &proto.NodeDescriptor{NodeID: 1})
 	if bootstrap {
 		if err := store.Bootstrap(proto.StoreIdent{NodeID: 1, StoreID: 1}, stopper); err != nil {
 			t.Fatal(err)
@@ -206,7 +206,7 @@ func (m *multiTestContext) addStore(t *testing.T) {
 
 	stopper := util.NewStopper()
 	ctx := m.makeContext()
-	store := storage.NewStore(ctx, eng)
+	store := storage.NewStore(ctx, eng, &proto.NodeDescriptor{NodeID: proto.NodeID(idx + 1)})
 	if needBootstrap {
 		err := store.Bootstrap(proto.StoreIdent{
 			NodeID:  proto.NodeID(idx + 1),
@@ -251,7 +251,7 @@ func (m *multiTestContext) restartStore(i int) {
 	m.stoppers[i] = util.NewStopper()
 
 	ctx := m.makeContext()
-	m.stores[i] = storage.NewStore(ctx, m.engines[i])
+	m.stores[i] = storage.NewStore(ctx, m.engines[i], &proto.NodeDescriptor{NodeID: proto.NodeID(i + 1)})
 	if err := m.stores[i].Start(m.stoppers[i]); err != nil {
 		m.t.Fatal(err)
 	}

--- a/storage/engine/cockroach/proto/config.pb.cc
+++ b/storage/engine/cockroach/proto/config.pb.cc
@@ -51,9 +51,15 @@ const ::google::protobuf::internal::GeneratedMessageReflection*
 const ::google::protobuf::Descriptor* Addr_descriptor_ = NULL;
 const ::google::protobuf::internal::GeneratedMessageReflection*
   Addr_reflection_ = NULL;
+const ::google::protobuf::Descriptor* StoreCapacity_descriptor_ = NULL;
+const ::google::protobuf::internal::GeneratedMessageReflection*
+  StoreCapacity_reflection_ = NULL;
 const ::google::protobuf::Descriptor* NodeDescriptor_descriptor_ = NULL;
 const ::google::protobuf::internal::GeneratedMessageReflection*
   NodeDescriptor_reflection_ = NULL;
+const ::google::protobuf::Descriptor* StoreDescriptor_descriptor_ = NULL;
+const ::google::protobuf::internal::GeneratedMessageReflection*
+  StoreDescriptor_reflection_ = NULL;
 
 }  // namespace
 
@@ -228,7 +234,23 @@ void protobuf_AssignDesc_cockroach_2fproto_2fconfig_2eproto() {
       ::google::protobuf::DescriptorPool::generated_pool(),
       ::google::protobuf::MessageFactory::generated_factory(),
       sizeof(Addr));
-  NodeDescriptor_descriptor_ = file->message_type(10);
+  StoreCapacity_descriptor_ = file->message_type(10);
+  static const int StoreCapacity_offsets_[2] = {
+    GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(StoreCapacity, capacity_),
+    GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(StoreCapacity, available_),
+  };
+  StoreCapacity_reflection_ =
+    new ::google::protobuf::internal::GeneratedMessageReflection(
+      StoreCapacity_descriptor_,
+      StoreCapacity::default_instance_,
+      StoreCapacity_offsets_,
+      GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(StoreCapacity, _has_bits_[0]),
+      GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(StoreCapacity, _unknown_fields_),
+      -1,
+      ::google::protobuf::DescriptorPool::generated_pool(),
+      ::google::protobuf::MessageFactory::generated_factory(),
+      sizeof(StoreCapacity));
+  NodeDescriptor_descriptor_ = file->message_type(11);
   static const int NodeDescriptor_offsets_[3] = {
     GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(NodeDescriptor, node_id_),
     GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(NodeDescriptor, address_),
@@ -245,6 +267,24 @@ void protobuf_AssignDesc_cockroach_2fproto_2fconfig_2eproto() {
       ::google::protobuf::DescriptorPool::generated_pool(),
       ::google::protobuf::MessageFactory::generated_factory(),
       sizeof(NodeDescriptor));
+  StoreDescriptor_descriptor_ = file->message_type(12);
+  static const int StoreDescriptor_offsets_[4] = {
+    GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(StoreDescriptor, store_id_),
+    GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(StoreDescriptor, attrs_),
+    GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(StoreDescriptor, node_),
+    GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(StoreDescriptor, capacity_),
+  };
+  StoreDescriptor_reflection_ =
+    new ::google::protobuf::internal::GeneratedMessageReflection(
+      StoreDescriptor_descriptor_,
+      StoreDescriptor::default_instance_,
+      StoreDescriptor_offsets_,
+      GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(StoreDescriptor, _has_bits_[0]),
+      GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(StoreDescriptor, _unknown_fields_),
+      -1,
+      ::google::protobuf::DescriptorPool::generated_pool(),
+      ::google::protobuf::MessageFactory::generated_factory(),
+      sizeof(StoreDescriptor));
 }
 
 namespace {
@@ -278,7 +318,11 @@ void protobuf_RegisterTypes(const ::std::string&) {
   ::google::protobuf::MessageFactory::InternalRegisterGeneratedMessage(
     Addr_descriptor_, &Addr::default_instance());
   ::google::protobuf::MessageFactory::InternalRegisterGeneratedMessage(
+    StoreCapacity_descriptor_, &StoreCapacity::default_instance());
+  ::google::protobuf::MessageFactory::InternalRegisterGeneratedMessage(
     NodeDescriptor_descriptor_, &NodeDescriptor::default_instance());
+  ::google::protobuf::MessageFactory::InternalRegisterGeneratedMessage(
+    StoreDescriptor_descriptor_, &StoreDescriptor::default_instance());
 }
 
 }  // namespace
@@ -304,8 +348,12 @@ void protobuf_ShutdownFile_cockroach_2fproto_2fconfig_2eproto() {
   delete RangeTreeNode_reflection_;
   delete Addr::default_instance_;
   delete Addr_reflection_;
+  delete StoreCapacity::default_instance_;
+  delete StoreCapacity_reflection_;
   delete NodeDescriptor::default_instance_;
   delete NodeDescriptor_reflection_;
+  delete StoreDescriptor::default_instance_;
+  delete StoreDescriptor_reflection_;
 }
 
 void protobuf_AddDesc_cockroach_2fproto_2fconfig_2eproto() {
@@ -346,12 +394,19 @@ void protobuf_AddDesc_cockroach_2fproto_2fconfig_2eproto() {
     "B\004\310\336\037\000\022\037\n\nparent_key\030\003 \001(\014B\013\310\336\037\000\332\336\037\003Key\022"
     "\031\n\010left_key\030\004 \001(\014B\007\332\336\037\003Key\022\032\n\tright_key\030"
     "\005 \001(\014B\007\332\336\037\003Key\"4\n\004Addr\022\025\n\007network\030\001 \001(\tB"
-    "\004\310\336\037\000\022\025\n\007address\030\002 \001(\tB\004\310\336\037\000\"\233\001\n\016NodeDes"
-    "criptor\022)\n\007node_id\030\001 \001(\005B\030\310\336\037\000\342\336\037\006NodeID"
-    "\332\336\037\006NodeID\022,\n\007address\030\002 \001(\0132\025.cockroach."
-    "proto.AddrB\004\310\336\037\000\0220\n\005attrs\030\003 \001(\0132\033.cockro"
-    "ach.proto.AttributesB\004\310\336\037\000B\023Z\005proto\340\342\036\001\310"
-    "\342\036\001\320\342\036\001", 1407);
+    "\004\310\336\037\000\022\025\n\007address\030\002 \001(\tB\004\310\336\037\000\"@\n\rStoreCap"
+    "acity\022\026\n\010Capacity\030\001 \001(\003B\004\310\336\037\000\022\027\n\tAvailab"
+    "le\030\002 \001(\003B\004\310\336\037\000\"\233\001\n\016NodeDescriptor\022)\n\007nod"
+    "e_id\030\001 \001(\005B\030\310\336\037\000\342\336\037\006NodeID\332\336\037\006NodeID\022,\n\007"
+    "address\030\002 \001(\0132\025.cockroach.proto.AddrB\004\310\336"
+    "\037\000\0220\n\005attrs\030\003 \001(\0132\033.cockroach.proto.Attr"
+    "ibutesB\004\310\336\037\000\"\336\001\n\017StoreDescriptor\022,\n\010stor"
+    "e_id\030\001 \001(\005B\032\310\336\037\000\342\336\037\007StoreID\332\336\037\007StoreID\0220"
+    "\n\005attrs\030\002 \001(\0132\033.cockroach.proto.Attribut"
+    "esB\004\310\336\037\000\0223\n\004node\030\003 \001(\0132\037.cockroach.proto"
+    ".NodeDescriptorB\004\310\336\037\000\0226\n\010capacity\030\004 \001(\0132"
+    "\036.cockroach.proto.StoreCapacityB\004\310\336\037\000B\023Z"
+    "\005proto\340\342\036\001\310\342\036\001\320\342\036\001", 1698);
   ::google::protobuf::MessageFactory::InternalRegisterGeneratedFile(
     "cockroach/proto/config.proto", &protobuf_RegisterTypes);
   Attributes::default_instance_ = new Attributes();
@@ -364,7 +419,9 @@ void protobuf_AddDesc_cockroach_2fproto_2fconfig_2eproto() {
   RangeTree::default_instance_ = new RangeTree();
   RangeTreeNode::default_instance_ = new RangeTreeNode();
   Addr::default_instance_ = new Addr();
+  StoreCapacity::default_instance_ = new StoreCapacity();
   NodeDescriptor::default_instance_ = new NodeDescriptor();
+  StoreDescriptor::default_instance_ = new StoreDescriptor();
   Attributes::default_instance_->InitAsDefaultInstance();
   Replica::default_instance_->InitAsDefaultInstance();
   RangeDescriptor::default_instance_->InitAsDefaultInstance();
@@ -375,7 +432,9 @@ void protobuf_AddDesc_cockroach_2fproto_2fconfig_2eproto() {
   RangeTree::default_instance_->InitAsDefaultInstance();
   RangeTreeNode::default_instance_->InitAsDefaultInstance();
   Addr::default_instance_->InitAsDefaultInstance();
+  StoreCapacity::default_instance_->InitAsDefaultInstance();
   NodeDescriptor::default_instance_->InitAsDefaultInstance();
+  StoreDescriptor::default_instance_->InitAsDefaultInstance();
   ::google::protobuf::internal::OnShutdown(&protobuf_ShutdownFile_cockroach_2fproto_2fconfig_2eproto);
 }
 
@@ -3350,6 +3409,280 @@ void Addr::Swap(Addr* other) {
 // ===================================================================
 
 #ifndef _MSC_VER
+const int StoreCapacity::kCapacityFieldNumber;
+const int StoreCapacity::kAvailableFieldNumber;
+#endif  // !_MSC_VER
+
+StoreCapacity::StoreCapacity()
+  : ::google::protobuf::Message() {
+  SharedCtor();
+  // @@protoc_insertion_point(constructor:cockroach.proto.StoreCapacity)
+}
+
+void StoreCapacity::InitAsDefaultInstance() {
+}
+
+StoreCapacity::StoreCapacity(const StoreCapacity& from)
+  : ::google::protobuf::Message() {
+  SharedCtor();
+  MergeFrom(from);
+  // @@protoc_insertion_point(copy_constructor:cockroach.proto.StoreCapacity)
+}
+
+void StoreCapacity::SharedCtor() {
+  _cached_size_ = 0;
+  capacity_ = GOOGLE_LONGLONG(0);
+  available_ = GOOGLE_LONGLONG(0);
+  ::memset(_has_bits_, 0, sizeof(_has_bits_));
+}
+
+StoreCapacity::~StoreCapacity() {
+  // @@protoc_insertion_point(destructor:cockroach.proto.StoreCapacity)
+  SharedDtor();
+}
+
+void StoreCapacity::SharedDtor() {
+  if (this != default_instance_) {
+  }
+}
+
+void StoreCapacity::SetCachedSize(int size) const {
+  GOOGLE_SAFE_CONCURRENT_WRITES_BEGIN();
+  _cached_size_ = size;
+  GOOGLE_SAFE_CONCURRENT_WRITES_END();
+}
+const ::google::protobuf::Descriptor* StoreCapacity::descriptor() {
+  protobuf_AssignDescriptorsOnce();
+  return StoreCapacity_descriptor_;
+}
+
+const StoreCapacity& StoreCapacity::default_instance() {
+  if (default_instance_ == NULL) protobuf_AddDesc_cockroach_2fproto_2fconfig_2eproto();
+  return *default_instance_;
+}
+
+StoreCapacity* StoreCapacity::default_instance_ = NULL;
+
+StoreCapacity* StoreCapacity::New() const {
+  return new StoreCapacity;
+}
+
+void StoreCapacity::Clear() {
+#define OFFSET_OF_FIELD_(f) (reinterpret_cast<char*>(      \
+  &reinterpret_cast<StoreCapacity*>(16)->f) - \
+   reinterpret_cast<char*>(16))
+
+#define ZR_(first, last) do {                              \
+    size_t f = OFFSET_OF_FIELD_(first);                    \
+    size_t n = OFFSET_OF_FIELD_(last) - f + sizeof(last);  \
+    ::memset(&first, 0, n);                                \
+  } while (0)
+
+  ZR_(capacity_, available_);
+
+#undef OFFSET_OF_FIELD_
+#undef ZR_
+
+  ::memset(_has_bits_, 0, sizeof(_has_bits_));
+  mutable_unknown_fields()->Clear();
+}
+
+bool StoreCapacity::MergePartialFromCodedStream(
+    ::google::protobuf::io::CodedInputStream* input) {
+#define DO_(EXPRESSION) if (!(EXPRESSION)) goto failure
+  ::google::protobuf::uint32 tag;
+  // @@protoc_insertion_point(parse_start:cockroach.proto.StoreCapacity)
+  for (;;) {
+    ::std::pair< ::google::protobuf::uint32, bool> p = input->ReadTagWithCutoff(127);
+    tag = p.first;
+    if (!p.second) goto handle_unusual;
+    switch (::google::protobuf::internal::WireFormatLite::GetTagFieldNumber(tag)) {
+      // optional int64 Capacity = 1;
+      case 1: {
+        if (tag == 8) {
+          DO_((::google::protobuf::internal::WireFormatLite::ReadPrimitive<
+                   ::google::protobuf::int64, ::google::protobuf::internal::WireFormatLite::TYPE_INT64>(
+                 input, &capacity_)));
+          set_has_capacity();
+        } else {
+          goto handle_unusual;
+        }
+        if (input->ExpectTag(16)) goto parse_Available;
+        break;
+      }
+
+      // optional int64 Available = 2;
+      case 2: {
+        if (tag == 16) {
+         parse_Available:
+          DO_((::google::protobuf::internal::WireFormatLite::ReadPrimitive<
+                   ::google::protobuf::int64, ::google::protobuf::internal::WireFormatLite::TYPE_INT64>(
+                 input, &available_)));
+          set_has_available();
+        } else {
+          goto handle_unusual;
+        }
+        if (input->ExpectAtEnd()) goto success;
+        break;
+      }
+
+      default: {
+      handle_unusual:
+        if (tag == 0 ||
+            ::google::protobuf::internal::WireFormatLite::GetTagWireType(tag) ==
+            ::google::protobuf::internal::WireFormatLite::WIRETYPE_END_GROUP) {
+          goto success;
+        }
+        DO_(::google::protobuf::internal::WireFormat::SkipField(
+              input, tag, mutable_unknown_fields()));
+        break;
+      }
+    }
+  }
+success:
+  // @@protoc_insertion_point(parse_success:cockroach.proto.StoreCapacity)
+  return true;
+failure:
+  // @@protoc_insertion_point(parse_failure:cockroach.proto.StoreCapacity)
+  return false;
+#undef DO_
+}
+
+void StoreCapacity::SerializeWithCachedSizes(
+    ::google::protobuf::io::CodedOutputStream* output) const {
+  // @@protoc_insertion_point(serialize_start:cockroach.proto.StoreCapacity)
+  // optional int64 Capacity = 1;
+  if (has_capacity()) {
+    ::google::protobuf::internal::WireFormatLite::WriteInt64(1, this->capacity(), output);
+  }
+
+  // optional int64 Available = 2;
+  if (has_available()) {
+    ::google::protobuf::internal::WireFormatLite::WriteInt64(2, this->available(), output);
+  }
+
+  if (!unknown_fields().empty()) {
+    ::google::protobuf::internal::WireFormat::SerializeUnknownFields(
+        unknown_fields(), output);
+  }
+  // @@protoc_insertion_point(serialize_end:cockroach.proto.StoreCapacity)
+}
+
+::google::protobuf::uint8* StoreCapacity::SerializeWithCachedSizesToArray(
+    ::google::protobuf::uint8* target) const {
+  // @@protoc_insertion_point(serialize_to_array_start:cockroach.proto.StoreCapacity)
+  // optional int64 Capacity = 1;
+  if (has_capacity()) {
+    target = ::google::protobuf::internal::WireFormatLite::WriteInt64ToArray(1, this->capacity(), target);
+  }
+
+  // optional int64 Available = 2;
+  if (has_available()) {
+    target = ::google::protobuf::internal::WireFormatLite::WriteInt64ToArray(2, this->available(), target);
+  }
+
+  if (!unknown_fields().empty()) {
+    target = ::google::protobuf::internal::WireFormat::SerializeUnknownFieldsToArray(
+        unknown_fields(), target);
+  }
+  // @@protoc_insertion_point(serialize_to_array_end:cockroach.proto.StoreCapacity)
+  return target;
+}
+
+int StoreCapacity::ByteSize() const {
+  int total_size = 0;
+
+  if (_has_bits_[0 / 32] & (0xffu << (0 % 32))) {
+    // optional int64 Capacity = 1;
+    if (has_capacity()) {
+      total_size += 1 +
+        ::google::protobuf::internal::WireFormatLite::Int64Size(
+          this->capacity());
+    }
+
+    // optional int64 Available = 2;
+    if (has_available()) {
+      total_size += 1 +
+        ::google::protobuf::internal::WireFormatLite::Int64Size(
+          this->available());
+    }
+
+  }
+  if (!unknown_fields().empty()) {
+    total_size +=
+      ::google::protobuf::internal::WireFormat::ComputeUnknownFieldsSize(
+        unknown_fields());
+  }
+  GOOGLE_SAFE_CONCURRENT_WRITES_BEGIN();
+  _cached_size_ = total_size;
+  GOOGLE_SAFE_CONCURRENT_WRITES_END();
+  return total_size;
+}
+
+void StoreCapacity::MergeFrom(const ::google::protobuf::Message& from) {
+  GOOGLE_CHECK_NE(&from, this);
+  const StoreCapacity* source =
+    ::google::protobuf::internal::dynamic_cast_if_available<const StoreCapacity*>(
+      &from);
+  if (source == NULL) {
+    ::google::protobuf::internal::ReflectionOps::Merge(from, this);
+  } else {
+    MergeFrom(*source);
+  }
+}
+
+void StoreCapacity::MergeFrom(const StoreCapacity& from) {
+  GOOGLE_CHECK_NE(&from, this);
+  if (from._has_bits_[0 / 32] & (0xffu << (0 % 32))) {
+    if (from.has_capacity()) {
+      set_capacity(from.capacity());
+    }
+    if (from.has_available()) {
+      set_available(from.available());
+    }
+  }
+  mutable_unknown_fields()->MergeFrom(from.unknown_fields());
+}
+
+void StoreCapacity::CopyFrom(const ::google::protobuf::Message& from) {
+  if (&from == this) return;
+  Clear();
+  MergeFrom(from);
+}
+
+void StoreCapacity::CopyFrom(const StoreCapacity& from) {
+  if (&from == this) return;
+  Clear();
+  MergeFrom(from);
+}
+
+bool StoreCapacity::IsInitialized() const {
+
+  return true;
+}
+
+void StoreCapacity::Swap(StoreCapacity* other) {
+  if (other != this) {
+    std::swap(capacity_, other->capacity_);
+    std::swap(available_, other->available_);
+    std::swap(_has_bits_[0], other->_has_bits_[0]);
+    _unknown_fields_.Swap(&other->_unknown_fields_);
+    std::swap(_cached_size_, other->_cached_size_);
+  }
+}
+
+::google::protobuf::Metadata StoreCapacity::GetMetadata() const {
+  protobuf_AssignDescriptorsOnce();
+  ::google::protobuf::Metadata metadata;
+  metadata.descriptor = StoreCapacity_descriptor_;
+  metadata.reflection = StoreCapacity_reflection_;
+  return metadata;
+}
+
+
+// ===================================================================
+
+#ifndef _MSC_VER
 const int NodeDescriptor::kNodeIdFieldNumber;
 const int NodeDescriptor::kAddressFieldNumber;
 const int NodeDescriptor::kAttrsFieldNumber;
@@ -3655,6 +3988,362 @@ void NodeDescriptor::Swap(NodeDescriptor* other) {
   ::google::protobuf::Metadata metadata;
   metadata.descriptor = NodeDescriptor_descriptor_;
   metadata.reflection = NodeDescriptor_reflection_;
+  return metadata;
+}
+
+
+// ===================================================================
+
+#ifndef _MSC_VER
+const int StoreDescriptor::kStoreIdFieldNumber;
+const int StoreDescriptor::kAttrsFieldNumber;
+const int StoreDescriptor::kNodeFieldNumber;
+const int StoreDescriptor::kCapacityFieldNumber;
+#endif  // !_MSC_VER
+
+StoreDescriptor::StoreDescriptor()
+  : ::google::protobuf::Message() {
+  SharedCtor();
+  // @@protoc_insertion_point(constructor:cockroach.proto.StoreDescriptor)
+}
+
+void StoreDescriptor::InitAsDefaultInstance() {
+  attrs_ = const_cast< ::cockroach::proto::Attributes*>(&::cockroach::proto::Attributes::default_instance());
+  node_ = const_cast< ::cockroach::proto::NodeDescriptor*>(&::cockroach::proto::NodeDescriptor::default_instance());
+  capacity_ = const_cast< ::cockroach::proto::StoreCapacity*>(&::cockroach::proto::StoreCapacity::default_instance());
+}
+
+StoreDescriptor::StoreDescriptor(const StoreDescriptor& from)
+  : ::google::protobuf::Message() {
+  SharedCtor();
+  MergeFrom(from);
+  // @@protoc_insertion_point(copy_constructor:cockroach.proto.StoreDescriptor)
+}
+
+void StoreDescriptor::SharedCtor() {
+  _cached_size_ = 0;
+  store_id_ = 0;
+  attrs_ = NULL;
+  node_ = NULL;
+  capacity_ = NULL;
+  ::memset(_has_bits_, 0, sizeof(_has_bits_));
+}
+
+StoreDescriptor::~StoreDescriptor() {
+  // @@protoc_insertion_point(destructor:cockroach.proto.StoreDescriptor)
+  SharedDtor();
+}
+
+void StoreDescriptor::SharedDtor() {
+  if (this != default_instance_) {
+    delete attrs_;
+    delete node_;
+    delete capacity_;
+  }
+}
+
+void StoreDescriptor::SetCachedSize(int size) const {
+  GOOGLE_SAFE_CONCURRENT_WRITES_BEGIN();
+  _cached_size_ = size;
+  GOOGLE_SAFE_CONCURRENT_WRITES_END();
+}
+const ::google::protobuf::Descriptor* StoreDescriptor::descriptor() {
+  protobuf_AssignDescriptorsOnce();
+  return StoreDescriptor_descriptor_;
+}
+
+const StoreDescriptor& StoreDescriptor::default_instance() {
+  if (default_instance_ == NULL) protobuf_AddDesc_cockroach_2fproto_2fconfig_2eproto();
+  return *default_instance_;
+}
+
+StoreDescriptor* StoreDescriptor::default_instance_ = NULL;
+
+StoreDescriptor* StoreDescriptor::New() const {
+  return new StoreDescriptor;
+}
+
+void StoreDescriptor::Clear() {
+  if (_has_bits_[0 / 32] & 15) {
+    store_id_ = 0;
+    if (has_attrs()) {
+      if (attrs_ != NULL) attrs_->::cockroach::proto::Attributes::Clear();
+    }
+    if (has_node()) {
+      if (node_ != NULL) node_->::cockroach::proto::NodeDescriptor::Clear();
+    }
+    if (has_capacity()) {
+      if (capacity_ != NULL) capacity_->::cockroach::proto::StoreCapacity::Clear();
+    }
+  }
+  ::memset(_has_bits_, 0, sizeof(_has_bits_));
+  mutable_unknown_fields()->Clear();
+}
+
+bool StoreDescriptor::MergePartialFromCodedStream(
+    ::google::protobuf::io::CodedInputStream* input) {
+#define DO_(EXPRESSION) if (!(EXPRESSION)) goto failure
+  ::google::protobuf::uint32 tag;
+  // @@protoc_insertion_point(parse_start:cockroach.proto.StoreDescriptor)
+  for (;;) {
+    ::std::pair< ::google::protobuf::uint32, bool> p = input->ReadTagWithCutoff(127);
+    tag = p.first;
+    if (!p.second) goto handle_unusual;
+    switch (::google::protobuf::internal::WireFormatLite::GetTagFieldNumber(tag)) {
+      // optional int32 store_id = 1;
+      case 1: {
+        if (tag == 8) {
+          DO_((::google::protobuf::internal::WireFormatLite::ReadPrimitive<
+                   ::google::protobuf::int32, ::google::protobuf::internal::WireFormatLite::TYPE_INT32>(
+                 input, &store_id_)));
+          set_has_store_id();
+        } else {
+          goto handle_unusual;
+        }
+        if (input->ExpectTag(18)) goto parse_attrs;
+        break;
+      }
+
+      // optional .cockroach.proto.Attributes attrs = 2;
+      case 2: {
+        if (tag == 18) {
+         parse_attrs:
+          DO_(::google::protobuf::internal::WireFormatLite::ReadMessageNoVirtual(
+               input, mutable_attrs()));
+        } else {
+          goto handle_unusual;
+        }
+        if (input->ExpectTag(26)) goto parse_node;
+        break;
+      }
+
+      // optional .cockroach.proto.NodeDescriptor node = 3;
+      case 3: {
+        if (tag == 26) {
+         parse_node:
+          DO_(::google::protobuf::internal::WireFormatLite::ReadMessageNoVirtual(
+               input, mutable_node()));
+        } else {
+          goto handle_unusual;
+        }
+        if (input->ExpectTag(34)) goto parse_capacity;
+        break;
+      }
+
+      // optional .cockroach.proto.StoreCapacity capacity = 4;
+      case 4: {
+        if (tag == 34) {
+         parse_capacity:
+          DO_(::google::protobuf::internal::WireFormatLite::ReadMessageNoVirtual(
+               input, mutable_capacity()));
+        } else {
+          goto handle_unusual;
+        }
+        if (input->ExpectAtEnd()) goto success;
+        break;
+      }
+
+      default: {
+      handle_unusual:
+        if (tag == 0 ||
+            ::google::protobuf::internal::WireFormatLite::GetTagWireType(tag) ==
+            ::google::protobuf::internal::WireFormatLite::WIRETYPE_END_GROUP) {
+          goto success;
+        }
+        DO_(::google::protobuf::internal::WireFormat::SkipField(
+              input, tag, mutable_unknown_fields()));
+        break;
+      }
+    }
+  }
+success:
+  // @@protoc_insertion_point(parse_success:cockroach.proto.StoreDescriptor)
+  return true;
+failure:
+  // @@protoc_insertion_point(parse_failure:cockroach.proto.StoreDescriptor)
+  return false;
+#undef DO_
+}
+
+void StoreDescriptor::SerializeWithCachedSizes(
+    ::google::protobuf::io::CodedOutputStream* output) const {
+  // @@protoc_insertion_point(serialize_start:cockroach.proto.StoreDescriptor)
+  // optional int32 store_id = 1;
+  if (has_store_id()) {
+    ::google::protobuf::internal::WireFormatLite::WriteInt32(1, this->store_id(), output);
+  }
+
+  // optional .cockroach.proto.Attributes attrs = 2;
+  if (has_attrs()) {
+    ::google::protobuf::internal::WireFormatLite::WriteMessageMaybeToArray(
+      2, this->attrs(), output);
+  }
+
+  // optional .cockroach.proto.NodeDescriptor node = 3;
+  if (has_node()) {
+    ::google::protobuf::internal::WireFormatLite::WriteMessageMaybeToArray(
+      3, this->node(), output);
+  }
+
+  // optional .cockroach.proto.StoreCapacity capacity = 4;
+  if (has_capacity()) {
+    ::google::protobuf::internal::WireFormatLite::WriteMessageMaybeToArray(
+      4, this->capacity(), output);
+  }
+
+  if (!unknown_fields().empty()) {
+    ::google::protobuf::internal::WireFormat::SerializeUnknownFields(
+        unknown_fields(), output);
+  }
+  // @@protoc_insertion_point(serialize_end:cockroach.proto.StoreDescriptor)
+}
+
+::google::protobuf::uint8* StoreDescriptor::SerializeWithCachedSizesToArray(
+    ::google::protobuf::uint8* target) const {
+  // @@protoc_insertion_point(serialize_to_array_start:cockroach.proto.StoreDescriptor)
+  // optional int32 store_id = 1;
+  if (has_store_id()) {
+    target = ::google::protobuf::internal::WireFormatLite::WriteInt32ToArray(1, this->store_id(), target);
+  }
+
+  // optional .cockroach.proto.Attributes attrs = 2;
+  if (has_attrs()) {
+    target = ::google::protobuf::internal::WireFormatLite::
+      WriteMessageNoVirtualToArray(
+        2, this->attrs(), target);
+  }
+
+  // optional .cockroach.proto.NodeDescriptor node = 3;
+  if (has_node()) {
+    target = ::google::protobuf::internal::WireFormatLite::
+      WriteMessageNoVirtualToArray(
+        3, this->node(), target);
+  }
+
+  // optional .cockroach.proto.StoreCapacity capacity = 4;
+  if (has_capacity()) {
+    target = ::google::protobuf::internal::WireFormatLite::
+      WriteMessageNoVirtualToArray(
+        4, this->capacity(), target);
+  }
+
+  if (!unknown_fields().empty()) {
+    target = ::google::protobuf::internal::WireFormat::SerializeUnknownFieldsToArray(
+        unknown_fields(), target);
+  }
+  // @@protoc_insertion_point(serialize_to_array_end:cockroach.proto.StoreDescriptor)
+  return target;
+}
+
+int StoreDescriptor::ByteSize() const {
+  int total_size = 0;
+
+  if (_has_bits_[0 / 32] & (0xffu << (0 % 32))) {
+    // optional int32 store_id = 1;
+    if (has_store_id()) {
+      total_size += 1 +
+        ::google::protobuf::internal::WireFormatLite::Int32Size(
+          this->store_id());
+    }
+
+    // optional .cockroach.proto.Attributes attrs = 2;
+    if (has_attrs()) {
+      total_size += 1 +
+        ::google::protobuf::internal::WireFormatLite::MessageSizeNoVirtual(
+          this->attrs());
+    }
+
+    // optional .cockroach.proto.NodeDescriptor node = 3;
+    if (has_node()) {
+      total_size += 1 +
+        ::google::protobuf::internal::WireFormatLite::MessageSizeNoVirtual(
+          this->node());
+    }
+
+    // optional .cockroach.proto.StoreCapacity capacity = 4;
+    if (has_capacity()) {
+      total_size += 1 +
+        ::google::protobuf::internal::WireFormatLite::MessageSizeNoVirtual(
+          this->capacity());
+    }
+
+  }
+  if (!unknown_fields().empty()) {
+    total_size +=
+      ::google::protobuf::internal::WireFormat::ComputeUnknownFieldsSize(
+        unknown_fields());
+  }
+  GOOGLE_SAFE_CONCURRENT_WRITES_BEGIN();
+  _cached_size_ = total_size;
+  GOOGLE_SAFE_CONCURRENT_WRITES_END();
+  return total_size;
+}
+
+void StoreDescriptor::MergeFrom(const ::google::protobuf::Message& from) {
+  GOOGLE_CHECK_NE(&from, this);
+  const StoreDescriptor* source =
+    ::google::protobuf::internal::dynamic_cast_if_available<const StoreDescriptor*>(
+      &from);
+  if (source == NULL) {
+    ::google::protobuf::internal::ReflectionOps::Merge(from, this);
+  } else {
+    MergeFrom(*source);
+  }
+}
+
+void StoreDescriptor::MergeFrom(const StoreDescriptor& from) {
+  GOOGLE_CHECK_NE(&from, this);
+  if (from._has_bits_[0 / 32] & (0xffu << (0 % 32))) {
+    if (from.has_store_id()) {
+      set_store_id(from.store_id());
+    }
+    if (from.has_attrs()) {
+      mutable_attrs()->::cockroach::proto::Attributes::MergeFrom(from.attrs());
+    }
+    if (from.has_node()) {
+      mutable_node()->::cockroach::proto::NodeDescriptor::MergeFrom(from.node());
+    }
+    if (from.has_capacity()) {
+      mutable_capacity()->::cockroach::proto::StoreCapacity::MergeFrom(from.capacity());
+    }
+  }
+  mutable_unknown_fields()->MergeFrom(from.unknown_fields());
+}
+
+void StoreDescriptor::CopyFrom(const ::google::protobuf::Message& from) {
+  if (&from == this) return;
+  Clear();
+  MergeFrom(from);
+}
+
+void StoreDescriptor::CopyFrom(const StoreDescriptor& from) {
+  if (&from == this) return;
+  Clear();
+  MergeFrom(from);
+}
+
+bool StoreDescriptor::IsInitialized() const {
+
+  return true;
+}
+
+void StoreDescriptor::Swap(StoreDescriptor* other) {
+  if (other != this) {
+    std::swap(store_id_, other->store_id_);
+    std::swap(attrs_, other->attrs_);
+    std::swap(node_, other->node_);
+    std::swap(capacity_, other->capacity_);
+    std::swap(_has_bits_[0], other->_has_bits_[0]);
+    _unknown_fields_.Swap(&other->_unknown_fields_);
+    std::swap(_cached_size_, other->_cached_size_);
+  }
+}
+
+::google::protobuf::Metadata StoreDescriptor::GetMetadata() const {
+  protobuf_AssignDescriptorsOnce();
+  ::google::protobuf::Metadata metadata;
+  metadata.descriptor = StoreDescriptor_descriptor_;
+  metadata.reflection = StoreDescriptor_reflection_;
   return metadata;
 }
 

--- a/storage/engine/cockroach/proto/config.pb.h
+++ b/storage/engine/cockroach/proto/config.pb.h
@@ -45,7 +45,9 @@ class ZoneConfig;
 class RangeTree;
 class RangeTreeNode;
 class Addr;
+class StoreCapacity;
 class NodeDescriptor;
+class StoreDescriptor;
 
 // ===================================================================
 
@@ -1060,6 +1062,95 @@ class Addr : public ::google::protobuf::Message {
 };
 // -------------------------------------------------------------------
 
+class StoreCapacity : public ::google::protobuf::Message {
+ public:
+  StoreCapacity();
+  virtual ~StoreCapacity();
+
+  StoreCapacity(const StoreCapacity& from);
+
+  inline StoreCapacity& operator=(const StoreCapacity& from) {
+    CopyFrom(from);
+    return *this;
+  }
+
+  inline const ::google::protobuf::UnknownFieldSet& unknown_fields() const {
+    return _unknown_fields_;
+  }
+
+  inline ::google::protobuf::UnknownFieldSet* mutable_unknown_fields() {
+    return &_unknown_fields_;
+  }
+
+  static const ::google::protobuf::Descriptor* descriptor();
+  static const StoreCapacity& default_instance();
+
+  void Swap(StoreCapacity* other);
+
+  // implements Message ----------------------------------------------
+
+  StoreCapacity* New() const;
+  void CopyFrom(const ::google::protobuf::Message& from);
+  void MergeFrom(const ::google::protobuf::Message& from);
+  void CopyFrom(const StoreCapacity& from);
+  void MergeFrom(const StoreCapacity& from);
+  void Clear();
+  bool IsInitialized() const;
+
+  int ByteSize() const;
+  bool MergePartialFromCodedStream(
+      ::google::protobuf::io::CodedInputStream* input);
+  void SerializeWithCachedSizes(
+      ::google::protobuf::io::CodedOutputStream* output) const;
+  ::google::protobuf::uint8* SerializeWithCachedSizesToArray(::google::protobuf::uint8* output) const;
+  int GetCachedSize() const { return _cached_size_; }
+  private:
+  void SharedCtor();
+  void SharedDtor();
+  void SetCachedSize(int size) const;
+  public:
+  ::google::protobuf::Metadata GetMetadata() const;
+
+  // nested types ----------------------------------------------------
+
+  // accessors -------------------------------------------------------
+
+  // optional int64 Capacity = 1;
+  inline bool has_capacity() const;
+  inline void clear_capacity();
+  static const int kCapacityFieldNumber = 1;
+  inline ::google::protobuf::int64 capacity() const;
+  inline void set_capacity(::google::protobuf::int64 value);
+
+  // optional int64 Available = 2;
+  inline bool has_available() const;
+  inline void clear_available();
+  static const int kAvailableFieldNumber = 2;
+  inline ::google::protobuf::int64 available() const;
+  inline void set_available(::google::protobuf::int64 value);
+
+  // @@protoc_insertion_point(class_scope:cockroach.proto.StoreCapacity)
+ private:
+  inline void set_has_capacity();
+  inline void clear_has_capacity();
+  inline void set_has_available();
+  inline void clear_has_available();
+
+  ::google::protobuf::UnknownFieldSet _unknown_fields_;
+
+  ::google::protobuf::uint32 _has_bits_[1];
+  mutable int _cached_size_;
+  ::google::protobuf::int64 capacity_;
+  ::google::protobuf::int64 available_;
+  friend void  protobuf_AddDesc_cockroach_2fproto_2fconfig_2eproto();
+  friend void protobuf_AssignDesc_cockroach_2fproto_2fconfig_2eproto();
+  friend void protobuf_ShutdownFile_cockroach_2fproto_2fconfig_2eproto();
+
+  void InitAsDefaultInstance();
+  static StoreCapacity* default_instance_;
+};
+// -------------------------------------------------------------------
+
 class NodeDescriptor : public ::google::protobuf::Message {
  public:
   NodeDescriptor();
@@ -1160,6 +1251,121 @@ class NodeDescriptor : public ::google::protobuf::Message {
 
   void InitAsDefaultInstance();
   static NodeDescriptor* default_instance_;
+};
+// -------------------------------------------------------------------
+
+class StoreDescriptor : public ::google::protobuf::Message {
+ public:
+  StoreDescriptor();
+  virtual ~StoreDescriptor();
+
+  StoreDescriptor(const StoreDescriptor& from);
+
+  inline StoreDescriptor& operator=(const StoreDescriptor& from) {
+    CopyFrom(from);
+    return *this;
+  }
+
+  inline const ::google::protobuf::UnknownFieldSet& unknown_fields() const {
+    return _unknown_fields_;
+  }
+
+  inline ::google::protobuf::UnknownFieldSet* mutable_unknown_fields() {
+    return &_unknown_fields_;
+  }
+
+  static const ::google::protobuf::Descriptor* descriptor();
+  static const StoreDescriptor& default_instance();
+
+  void Swap(StoreDescriptor* other);
+
+  // implements Message ----------------------------------------------
+
+  StoreDescriptor* New() const;
+  void CopyFrom(const ::google::protobuf::Message& from);
+  void MergeFrom(const ::google::protobuf::Message& from);
+  void CopyFrom(const StoreDescriptor& from);
+  void MergeFrom(const StoreDescriptor& from);
+  void Clear();
+  bool IsInitialized() const;
+
+  int ByteSize() const;
+  bool MergePartialFromCodedStream(
+      ::google::protobuf::io::CodedInputStream* input);
+  void SerializeWithCachedSizes(
+      ::google::protobuf::io::CodedOutputStream* output) const;
+  ::google::protobuf::uint8* SerializeWithCachedSizesToArray(::google::protobuf::uint8* output) const;
+  int GetCachedSize() const { return _cached_size_; }
+  private:
+  void SharedCtor();
+  void SharedDtor();
+  void SetCachedSize(int size) const;
+  public:
+  ::google::protobuf::Metadata GetMetadata() const;
+
+  // nested types ----------------------------------------------------
+
+  // accessors -------------------------------------------------------
+
+  // optional int32 store_id = 1;
+  inline bool has_store_id() const;
+  inline void clear_store_id();
+  static const int kStoreIdFieldNumber = 1;
+  inline ::google::protobuf::int32 store_id() const;
+  inline void set_store_id(::google::protobuf::int32 value);
+
+  // optional .cockroach.proto.Attributes attrs = 2;
+  inline bool has_attrs() const;
+  inline void clear_attrs();
+  static const int kAttrsFieldNumber = 2;
+  inline const ::cockroach::proto::Attributes& attrs() const;
+  inline ::cockroach::proto::Attributes* mutable_attrs();
+  inline ::cockroach::proto::Attributes* release_attrs();
+  inline void set_allocated_attrs(::cockroach::proto::Attributes* attrs);
+
+  // optional .cockroach.proto.NodeDescriptor node = 3;
+  inline bool has_node() const;
+  inline void clear_node();
+  static const int kNodeFieldNumber = 3;
+  inline const ::cockroach::proto::NodeDescriptor& node() const;
+  inline ::cockroach::proto::NodeDescriptor* mutable_node();
+  inline ::cockroach::proto::NodeDescriptor* release_node();
+  inline void set_allocated_node(::cockroach::proto::NodeDescriptor* node);
+
+  // optional .cockroach.proto.StoreCapacity capacity = 4;
+  inline bool has_capacity() const;
+  inline void clear_capacity();
+  static const int kCapacityFieldNumber = 4;
+  inline const ::cockroach::proto::StoreCapacity& capacity() const;
+  inline ::cockroach::proto::StoreCapacity* mutable_capacity();
+  inline ::cockroach::proto::StoreCapacity* release_capacity();
+  inline void set_allocated_capacity(::cockroach::proto::StoreCapacity* capacity);
+
+  // @@protoc_insertion_point(class_scope:cockroach.proto.StoreDescriptor)
+ private:
+  inline void set_has_store_id();
+  inline void clear_has_store_id();
+  inline void set_has_attrs();
+  inline void clear_has_attrs();
+  inline void set_has_node();
+  inline void clear_has_node();
+  inline void set_has_capacity();
+  inline void clear_has_capacity();
+
+  ::google::protobuf::UnknownFieldSet _unknown_fields_;
+
+  ::google::protobuf::uint32 _has_bits_[1];
+  mutable int _cached_size_;
+  ::cockroach::proto::Attributes* attrs_;
+  ::cockroach::proto::NodeDescriptor* node_;
+  ::cockroach::proto::StoreCapacity* capacity_;
+  ::google::protobuf::int32 store_id_;
+  friend void  protobuf_AddDesc_cockroach_2fproto_2fconfig_2eproto();
+  friend void protobuf_AssignDesc_cockroach_2fproto_2fconfig_2eproto();
+  friend void protobuf_ShutdownFile_cockroach_2fproto_2fconfig_2eproto();
+
+  void InitAsDefaultInstance();
+  static StoreDescriptor* default_instance_;
 };
 // ===================================================================
 
@@ -2438,6 +2644,58 @@ inline void Addr::set_allocated_address(::std::string* address) {
 
 // -------------------------------------------------------------------
 
+// StoreCapacity
+
+// optional int64 Capacity = 1;
+inline bool StoreCapacity::has_capacity() const {
+  return (_has_bits_[0] & 0x00000001u) != 0;
+}
+inline void StoreCapacity::set_has_capacity() {
+  _has_bits_[0] |= 0x00000001u;
+}
+inline void StoreCapacity::clear_has_capacity() {
+  _has_bits_[0] &= ~0x00000001u;
+}
+inline void StoreCapacity::clear_capacity() {
+  capacity_ = GOOGLE_LONGLONG(0);
+  clear_has_capacity();
+}
+inline ::google::protobuf::int64 StoreCapacity::capacity() const {
+  // @@protoc_insertion_point(field_get:cockroach.proto.StoreCapacity.Capacity)
+  return capacity_;
+}
+inline void StoreCapacity::set_capacity(::google::protobuf::int64 value) {
+  set_has_capacity();
+  capacity_ = value;
+  // @@protoc_insertion_point(field_set:cockroach.proto.StoreCapacity.Capacity)
+}
+
+// optional int64 Available = 2;
+inline bool StoreCapacity::has_available() const {
+  return (_has_bits_[0] & 0x00000002u) != 0;
+}
+inline void StoreCapacity::set_has_available() {
+  _has_bits_[0] |= 0x00000002u;
+}
+inline void StoreCapacity::clear_has_available() {
+  _has_bits_[0] &= ~0x00000002u;
+}
+inline void StoreCapacity::clear_available() {
+  available_ = GOOGLE_LONGLONG(0);
+  clear_has_available();
+}
+inline ::google::protobuf::int64 StoreCapacity::available() const {
+  // @@protoc_insertion_point(field_get:cockroach.proto.StoreCapacity.Available)
+  return available_;
+}
+inline void StoreCapacity::set_available(::google::protobuf::int64 value) {
+  set_has_available();
+  available_ = value;
+  // @@protoc_insertion_point(field_set:cockroach.proto.StoreCapacity.Available)
+}
+
+// -------------------------------------------------------------------
+
 // NodeDescriptor
 
 // optional int32 node_id = 1;
@@ -2544,6 +2802,157 @@ inline void NodeDescriptor::set_allocated_attrs(::cockroach::proto::Attributes* 
     clear_has_attrs();
   }
   // @@protoc_insertion_point(field_set_allocated:cockroach.proto.NodeDescriptor.attrs)
+}
+
+// -------------------------------------------------------------------
+
+// StoreDescriptor
+
+// optional int32 store_id = 1;
+inline bool StoreDescriptor::has_store_id() const {
+  return (_has_bits_[0] & 0x00000001u) != 0;
+}
+inline void StoreDescriptor::set_has_store_id() {
+  _has_bits_[0] |= 0x00000001u;
+}
+inline void StoreDescriptor::clear_has_store_id() {
+  _has_bits_[0] &= ~0x00000001u;
+}
+inline void StoreDescriptor::clear_store_id() {
+  store_id_ = 0;
+  clear_has_store_id();
+}
+inline ::google::protobuf::int32 StoreDescriptor::store_id() const {
+  // @@protoc_insertion_point(field_get:cockroach.proto.StoreDescriptor.store_id)
+  return store_id_;
+}
+inline void StoreDescriptor::set_store_id(::google::protobuf::int32 value) {
+  set_has_store_id();
+  store_id_ = value;
+  // @@protoc_insertion_point(field_set:cockroach.proto.StoreDescriptor.store_id)
+}
+
+// optional .cockroach.proto.Attributes attrs = 2;
+inline bool StoreDescriptor::has_attrs() const {
+  return (_has_bits_[0] & 0x00000002u) != 0;
+}
+inline void StoreDescriptor::set_has_attrs() {
+  _has_bits_[0] |= 0x00000002u;
+}
+inline void StoreDescriptor::clear_has_attrs() {
+  _has_bits_[0] &= ~0x00000002u;
+}
+inline void StoreDescriptor::clear_attrs() {
+  if (attrs_ != NULL) attrs_->::cockroach::proto::Attributes::Clear();
+  clear_has_attrs();
+}
+inline const ::cockroach::proto::Attributes& StoreDescriptor::attrs() const {
+  // @@protoc_insertion_point(field_get:cockroach.proto.StoreDescriptor.attrs)
+  return attrs_ != NULL ? *attrs_ : *default_instance_->attrs_;
+}
+inline ::cockroach::proto::Attributes* StoreDescriptor::mutable_attrs() {
+  set_has_attrs();
+  if (attrs_ == NULL) attrs_ = new ::cockroach::proto::Attributes;
+  // @@protoc_insertion_point(field_mutable:cockroach.proto.StoreDescriptor.attrs)
+  return attrs_;
+}
+inline ::cockroach::proto::Attributes* StoreDescriptor::release_attrs() {
+  clear_has_attrs();
+  ::cockroach::proto::Attributes* temp = attrs_;
+  attrs_ = NULL;
+  return temp;
+}
+inline void StoreDescriptor::set_allocated_attrs(::cockroach::proto::Attributes* attrs) {
+  delete attrs_;
+  attrs_ = attrs;
+  if (attrs) {
+    set_has_attrs();
+  } else {
+    clear_has_attrs();
+  }
+  // @@protoc_insertion_point(field_set_allocated:cockroach.proto.StoreDescriptor.attrs)
+}
+
+// optional .cockroach.proto.NodeDescriptor node = 3;
+inline bool StoreDescriptor::has_node() const {
+  return (_has_bits_[0] & 0x00000004u) != 0;
+}
+inline void StoreDescriptor::set_has_node() {
+  _has_bits_[0] |= 0x00000004u;
+}
+inline void StoreDescriptor::clear_has_node() {
+  _has_bits_[0] &= ~0x00000004u;
+}
+inline void StoreDescriptor::clear_node() {
+  if (node_ != NULL) node_->::cockroach::proto::NodeDescriptor::Clear();
+  clear_has_node();
+}
+inline const ::cockroach::proto::NodeDescriptor& StoreDescriptor::node() const {
+  // @@protoc_insertion_point(field_get:cockroach.proto.StoreDescriptor.node)
+  return node_ != NULL ? *node_ : *default_instance_->node_;
+}
+inline ::cockroach::proto::NodeDescriptor* StoreDescriptor::mutable_node() {
+  set_has_node();
+  if (node_ == NULL) node_ = new ::cockroach::proto::NodeDescriptor;
+  // @@protoc_insertion_point(field_mutable:cockroach.proto.StoreDescriptor.node)
+  return node_;
+}
+inline ::cockroach::proto::NodeDescriptor* StoreDescriptor::release_node() {
+  clear_has_node();
+  ::cockroach::proto::NodeDescriptor* temp = node_;
+  node_ = NULL;
+  return temp;
+}
+inline void StoreDescriptor::set_allocated_node(::cockroach::proto::NodeDescriptor* node) {
+  delete node_;
+  node_ = node;
+  if (node) {
+    set_has_node();
+  } else {
+    clear_has_node();
+  }
+  // @@protoc_insertion_point(field_set_allocated:cockroach.proto.StoreDescriptor.node)
+}
+
+// optional .cockroach.proto.StoreCapacity capacity = 4;
+inline bool StoreDescriptor::has_capacity() const {
+  return (_has_bits_[0] & 0x00000008u) != 0;
+}
+inline void StoreDescriptor::set_has_capacity() {
+  _has_bits_[0] |= 0x00000008u;
+}
+inline void StoreDescriptor::clear_has_capacity() {
+  _has_bits_[0] &= ~0x00000008u;
+}
+inline void StoreDescriptor::clear_capacity() {
+  if (capacity_ != NULL) capacity_->::cockroach::proto::StoreCapacity::Clear();
+  clear_has_capacity();
+}
+inline const ::cockroach::proto::StoreCapacity& StoreDescriptor::capacity() const {
+  // @@protoc_insertion_point(field_get:cockroach.proto.StoreDescriptor.capacity)
+  return capacity_ != NULL ? *capacity_ : *default_instance_->capacity_;
+}
+inline ::cockroach::proto::StoreCapacity* StoreDescriptor::mutable_capacity() {
+  set_has_capacity();
+  if (capacity_ == NULL) capacity_ = new ::cockroach::proto::StoreCapacity;
+  // @@protoc_insertion_point(field_mutable:cockroach.proto.StoreDescriptor.capacity)
+  return capacity_;
+}
+inline ::cockroach::proto::StoreCapacity* StoreDescriptor::release_capacity() {
+  clear_has_capacity();
+  ::cockroach::proto::StoreCapacity* temp = capacity_;
+  capacity_ = NULL;
+  return temp;
+}
+inline void StoreDescriptor::set_allocated_capacity(::cockroach::proto::StoreCapacity* capacity) {
+  delete capacity_;
+  capacity_ = capacity;
+  if (capacity) {
+    set_has_capacity();
+  } else {
+    clear_has_capacity();
+  }
+  // @@protoc_insertion_point(field_set_allocated:cockroach.proto.StoreDescriptor.capacity)
 }
 
 

--- a/storage/engine/cockroach/proto/status.pb.cc
+++ b/storage/engine/cockroach/proto/status.pb.cc
@@ -39,7 +39,7 @@ void protobuf_AssignDesc_cockroach_2fproto_2fstatus_2eproto() {
   GOOGLE_CHECK(file != NULL);
   StoreStatus_descriptor_ = file->message_type(0);
   static const int StoreStatus_offsets_[6] = {
-    GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(StoreStatus, store_id_),
+    GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(StoreStatus, desc_),
     GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(StoreStatus, node_id_),
     GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(StoreStatus, range_count_),
     GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(StoreStatus, started_at_),
@@ -117,19 +117,19 @@ void protobuf_AddDesc_cockroach_2fproto_2fstatus_2eproto() {
     "\n\034cockroach/proto/status.proto\022\017cockroac"
     "h.proto\032\032cockroach/proto/data.proto\032\034coc"
     "kroach/proto/config.proto\032\024gogoproto/gog"
-    "o.proto\"\346\001\n\013StoreStatus\022,\n\010store_id\030\001 \001("
-    "\005B\032\310\336\037\000\342\336\037\007StoreID\332\336\037\007StoreID\022)\n\007node_id"
-    "\030\002 \001(\005B\030\310\336\037\000\342\336\037\006NodeID\332\336\037\006NodeID\022\031\n\013rang"
-    "e_count\030\003 \001(\005B\004\310\336\037\000\022\030\n\nstarted_at\030\004 \001(\003B"
-    "\004\310\336\037\000\022\030\n\nupdated_at\030\005 \001(\003B\004\310\336\037\000\022/\n\005stats"
-    "\030\006 \001(\0132\032.cockroach.proto.MVCCStatsB\004\310\336\037\000"
-    "\"\346\001\n\nNodeStatus\0223\n\004desc\030\001 \001(\0132\037.cockroac"
-    "h.proto.NodeDescriptorB\004\310\336\037\000\022#\n\tstore_id"
-    "s\030\002 \003(\005B\020\310\336\037\000\342\336\037\010StoreIDs\022\031\n\013range_count"
-    "\030\003 \001(\005B\004\310\336\037\000\022\030\n\nstarted_at\030\004 \001(\003B\004\310\336\037\000\022\030"
-    "\n\nupdated_at\030\005 \001(\003B\004\310\336\037\000\022/\n\005stats\030\006 \001(\0132"
-    "\032.cockroach.proto.MVCCStatsB\004\310\336\037\000B\023Z\005pro"
-    "to\340\342\036\001\310\342\036\001\320\342\036\001", 614);
+    "o.proto\"\356\001\n\013StoreStatus\0224\n\004desc\030\001 \001(\0132 ."
+    "cockroach.proto.StoreDescriptorB\004\310\336\037\000\022)\n"
+    "\007node_id\030\002 \001(\005B\030\310\336\037\000\342\336\037\006NodeID\332\336\037\006NodeID"
+    "\022\031\n\013range_count\030\003 \001(\005B\004\310\336\037\000\022\030\n\nstarted_a"
+    "t\030\004 \001(\003B\004\310\336\037\000\022\030\n\nupdated_at\030\005 \001(\003B\004\310\336\037\000\022"
+    "/\n\005stats\030\006 \001(\0132\032.cockroach.proto.MVCCSta"
+    "tsB\004\310\336\037\000\"\346\001\n\nNodeStatus\0223\n\004desc\030\001 \001(\0132\037."
+    "cockroach.proto.NodeDescriptorB\004\310\336\037\000\022#\n\t"
+    "store_ids\030\002 \003(\005B\020\310\336\037\000\342\336\037\010StoreIDs\022\031\n\013ran"
+    "ge_count\030\003 \001(\005B\004\310\336\037\000\022\030\n\nstarted_at\030\004 \001(\003"
+    "B\004\310\336\037\000\022\030\n\nupdated_at\030\005 \001(\003B\004\310\336\037\000\022/\n\005stat"
+    "s\030\006 \001(\0132\032.cockroach.proto.MVCCStatsB\004\310\336\037"
+    "\000B\023Z\005proto\340\342\036\001\310\342\036\001\320\342\036\001", 622);
   ::google::protobuf::MessageFactory::InternalRegisterGeneratedFile(
     "cockroach/proto/status.proto", &protobuf_RegisterTypes);
   StoreStatus::default_instance_ = new StoreStatus();
@@ -149,7 +149,7 @@ struct StaticDescriptorInitializer_cockroach_2fproto_2fstatus_2eproto {
 // ===================================================================
 
 #ifndef _MSC_VER
-const int StoreStatus::kStoreIdFieldNumber;
+const int StoreStatus::kDescFieldNumber;
 const int StoreStatus::kNodeIdFieldNumber;
 const int StoreStatus::kRangeCountFieldNumber;
 const int StoreStatus::kStartedAtFieldNumber;
@@ -164,6 +164,7 @@ StoreStatus::StoreStatus()
 }
 
 void StoreStatus::InitAsDefaultInstance() {
+  desc_ = const_cast< ::cockroach::proto::StoreDescriptor*>(&::cockroach::proto::StoreDescriptor::default_instance());
   stats_ = const_cast< ::cockroach::proto::MVCCStats*>(&::cockroach::proto::MVCCStats::default_instance());
 }
 
@@ -176,7 +177,7 @@ StoreStatus::StoreStatus(const StoreStatus& from)
 
 void StoreStatus::SharedCtor() {
   _cached_size_ = 0;
-  store_id_ = 0;
+  desc_ = NULL;
   node_id_ = 0;
   range_count_ = 0;
   started_at_ = GOOGLE_LONGLONG(0);
@@ -192,6 +193,7 @@ StoreStatus::~StoreStatus() {
 
 void StoreStatus::SharedDtor() {
   if (this != default_instance_) {
+    delete desc_;
     delete stats_;
   }
 }
@@ -229,8 +231,10 @@ void StoreStatus::Clear() {
   } while (0)
 
   if (_has_bits_[0 / 32] & 63) {
-    ZR_(store_id_, updated_at_);
-    range_count_ = 0;
+    ZR_(node_id_, updated_at_);
+    if (has_desc()) {
+      if (desc_ != NULL) desc_->::cockroach::proto::StoreDescriptor::Clear();
+    }
     if (has_stats()) {
       if (stats_ != NULL) stats_->::cockroach::proto::MVCCStats::Clear();
     }
@@ -253,13 +257,11 @@ bool StoreStatus::MergePartialFromCodedStream(
     tag = p.first;
     if (!p.second) goto handle_unusual;
     switch (::google::protobuf::internal::WireFormatLite::GetTagFieldNumber(tag)) {
-      // optional int32 store_id = 1;
+      // optional .cockroach.proto.StoreDescriptor desc = 1;
       case 1: {
-        if (tag == 8) {
-          DO_((::google::protobuf::internal::WireFormatLite::ReadPrimitive<
-                   ::google::protobuf::int32, ::google::protobuf::internal::WireFormatLite::TYPE_INT32>(
-                 input, &store_id_)));
-          set_has_store_id();
+        if (tag == 10) {
+          DO_(::google::protobuf::internal::WireFormatLite::ReadMessageNoVirtual(
+               input, mutable_desc()));
         } else {
           goto handle_unusual;
         }
@@ -365,9 +367,10 @@ failure:
 void StoreStatus::SerializeWithCachedSizes(
     ::google::protobuf::io::CodedOutputStream* output) const {
   // @@protoc_insertion_point(serialize_start:cockroach.proto.StoreStatus)
-  // optional int32 store_id = 1;
-  if (has_store_id()) {
-    ::google::protobuf::internal::WireFormatLite::WriteInt32(1, this->store_id(), output);
+  // optional .cockroach.proto.StoreDescriptor desc = 1;
+  if (has_desc()) {
+    ::google::protobuf::internal::WireFormatLite::WriteMessageMaybeToArray(
+      1, this->desc(), output);
   }
 
   // optional int32 node_id = 2;
@@ -406,9 +409,11 @@ void StoreStatus::SerializeWithCachedSizes(
 ::google::protobuf::uint8* StoreStatus::SerializeWithCachedSizesToArray(
     ::google::protobuf::uint8* target) const {
   // @@protoc_insertion_point(serialize_to_array_start:cockroach.proto.StoreStatus)
-  // optional int32 store_id = 1;
-  if (has_store_id()) {
-    target = ::google::protobuf::internal::WireFormatLite::WriteInt32ToArray(1, this->store_id(), target);
+  // optional .cockroach.proto.StoreDescriptor desc = 1;
+  if (has_desc()) {
+    target = ::google::protobuf::internal::WireFormatLite::
+      WriteMessageNoVirtualToArray(
+        1, this->desc(), target);
   }
 
   // optional int32 node_id = 2;
@@ -450,11 +455,11 @@ int StoreStatus::ByteSize() const {
   int total_size = 0;
 
   if (_has_bits_[0 / 32] & (0xffu << (0 % 32))) {
-    // optional int32 store_id = 1;
-    if (has_store_id()) {
+    // optional .cockroach.proto.StoreDescriptor desc = 1;
+    if (has_desc()) {
       total_size += 1 +
-        ::google::protobuf::internal::WireFormatLite::Int32Size(
-          this->store_id());
+        ::google::protobuf::internal::WireFormatLite::MessageSizeNoVirtual(
+          this->desc());
     }
 
     // optional int32 node_id = 2;
@@ -519,8 +524,8 @@ void StoreStatus::MergeFrom(const ::google::protobuf::Message& from) {
 void StoreStatus::MergeFrom(const StoreStatus& from) {
   GOOGLE_CHECK_NE(&from, this);
   if (from._has_bits_[0 / 32] & (0xffu << (0 % 32))) {
-    if (from.has_store_id()) {
-      set_store_id(from.store_id());
+    if (from.has_desc()) {
+      mutable_desc()->::cockroach::proto::StoreDescriptor::MergeFrom(from.desc());
     }
     if (from.has_node_id()) {
       set_node_id(from.node_id());
@@ -560,7 +565,7 @@ bool StoreStatus::IsInitialized() const {
 
 void StoreStatus::Swap(StoreStatus* other) {
   if (other != this) {
-    std::swap(store_id_, other->store_id_);
+    std::swap(desc_, other->desc_);
     std::swap(node_id_, other->node_id_);
     std::swap(range_count_, other->range_count_);
     std::swap(started_at_, other->started_at_);

--- a/storage/engine/cockroach/proto/status.pb.h
+++ b/storage/engine/cockroach/proto/status.pb.h
@@ -95,12 +95,14 @@ class StoreStatus : public ::google::protobuf::Message {
 
   // accessors -------------------------------------------------------
 
-  // optional int32 store_id = 1;
-  inline bool has_store_id() const;
-  inline void clear_store_id();
-  static const int kStoreIdFieldNumber = 1;
-  inline ::google::protobuf::int32 store_id() const;
-  inline void set_store_id(::google::protobuf::int32 value);
+  // optional .cockroach.proto.StoreDescriptor desc = 1;
+  inline bool has_desc() const;
+  inline void clear_desc();
+  static const int kDescFieldNumber = 1;
+  inline const ::cockroach::proto::StoreDescriptor& desc() const;
+  inline ::cockroach::proto::StoreDescriptor* mutable_desc();
+  inline ::cockroach::proto::StoreDescriptor* release_desc();
+  inline void set_allocated_desc(::cockroach::proto::StoreDescriptor* desc);
 
   // optional int32 node_id = 2;
   inline bool has_node_id() const;
@@ -141,8 +143,8 @@ class StoreStatus : public ::google::protobuf::Message {
 
   // @@protoc_insertion_point(class_scope:cockroach.proto.StoreStatus)
  private:
-  inline void set_has_store_id();
-  inline void clear_has_store_id();
+  inline void set_has_desc();
+  inline void clear_has_desc();
   inline void set_has_node_id();
   inline void clear_has_node_id();
   inline void set_has_range_count();
@@ -158,12 +160,12 @@ class StoreStatus : public ::google::protobuf::Message {
 
   ::google::protobuf::uint32 _has_bits_[1];
   mutable int _cached_size_;
-  ::google::protobuf::int32 store_id_;
+  ::cockroach::proto::StoreDescriptor* desc_;
   ::google::protobuf::int32 node_id_;
+  ::google::protobuf::int32 range_count_;
   ::google::protobuf::int64 started_at_;
   ::google::protobuf::int64 updated_at_;
   ::cockroach::proto::MVCCStats* stats_;
-  ::google::protobuf::int32 range_count_;
   friend void  protobuf_AddDesc_cockroach_2fproto_2fstatus_2eproto();
   friend void protobuf_AssignDesc_cockroach_2fproto_2fstatus_2eproto();
   friend void protobuf_ShutdownFile_cockroach_2fproto_2fstatus_2eproto();
@@ -314,28 +316,45 @@ class NodeStatus : public ::google::protobuf::Message {
 
 // StoreStatus
 
-// optional int32 store_id = 1;
-inline bool StoreStatus::has_store_id() const {
+// optional .cockroach.proto.StoreDescriptor desc = 1;
+inline bool StoreStatus::has_desc() const {
   return (_has_bits_[0] & 0x00000001u) != 0;
 }
-inline void StoreStatus::set_has_store_id() {
+inline void StoreStatus::set_has_desc() {
   _has_bits_[0] |= 0x00000001u;
 }
-inline void StoreStatus::clear_has_store_id() {
+inline void StoreStatus::clear_has_desc() {
   _has_bits_[0] &= ~0x00000001u;
 }
-inline void StoreStatus::clear_store_id() {
-  store_id_ = 0;
-  clear_has_store_id();
+inline void StoreStatus::clear_desc() {
+  if (desc_ != NULL) desc_->::cockroach::proto::StoreDescriptor::Clear();
+  clear_has_desc();
 }
-inline ::google::protobuf::int32 StoreStatus::store_id() const {
-  // @@protoc_insertion_point(field_get:cockroach.proto.StoreStatus.store_id)
-  return store_id_;
+inline const ::cockroach::proto::StoreDescriptor& StoreStatus::desc() const {
+  // @@protoc_insertion_point(field_get:cockroach.proto.StoreStatus.desc)
+  return desc_ != NULL ? *desc_ : *default_instance_->desc_;
 }
-inline void StoreStatus::set_store_id(::google::protobuf::int32 value) {
-  set_has_store_id();
-  store_id_ = value;
-  // @@protoc_insertion_point(field_set:cockroach.proto.StoreStatus.store_id)
+inline ::cockroach::proto::StoreDescriptor* StoreStatus::mutable_desc() {
+  set_has_desc();
+  if (desc_ == NULL) desc_ = new ::cockroach::proto::StoreDescriptor;
+  // @@protoc_insertion_point(field_mutable:cockroach.proto.StoreStatus.desc)
+  return desc_;
+}
+inline ::cockroach::proto::StoreDescriptor* StoreStatus::release_desc() {
+  clear_has_desc();
+  ::cockroach::proto::StoreDescriptor* temp = desc_;
+  desc_ = NULL;
+  return temp;
+}
+inline void StoreStatus::set_allocated_desc(::cockroach::proto::StoreDescriptor* desc) {
+  delete desc_;
+  desc_ = desc;
+  if (desc) {
+    set_has_desc();
+  } else {
+    clear_has_desc();
+  }
+  // @@protoc_insertion_point(field_set_allocated:cockroach.proto.StoreStatus.desc)
 }
 
 // optional int32 node_id = 2;

--- a/storage/engine/engine.go
+++ b/storage/engine/engine.go
@@ -28,17 +28,6 @@ import (
 	gogoproto "github.com/gogo/protobuf/proto"
 )
 
-// StoreCapacity contains capacity information for a storage device.
-type StoreCapacity struct {
-	Capacity  int64
-	Available int64
-}
-
-// PercentAvail computes the percentage of disk space that is available.
-func (sc StoreCapacity) PercentAvail() float64 {
-	return float64(sc.Available) / float64(sc.Capacity)
-}
-
 // Iterator is an interface for iterating over key/value pairs in an
 // engine. Iterator implementation are thread safe unless otherwise
 // noted.
@@ -110,7 +99,7 @@ type Engine interface {
 	// The logic for merges is written in db.cc in order to be compatible with RocksDB.
 	Merge(key proto.EncodedKey, value []byte) error
 	// Capacity returns capacity details for the engine's available storage.
-	Capacity() (StoreCapacity, error)
+	Capacity() (proto.StoreCapacity, error)
 	// SetGCTimeouts sets a function which yields timeout values for GC
 	// compaction of transaction and response cache entries. The return
 	// values are in unix nanoseconds for the minimum transaction row

--- a/storage/engine/rocksdb.go
+++ b/storage/engine/rocksdb.go
@@ -249,11 +249,10 @@ func (r *RocksDB) iterateInternal(start, end proto.EncodedKey, f func(proto.RawK
 	return it.Error()
 }
 
-// Capacity queries the underlying file system for disk capacity
-// information.
-func (r *RocksDB) Capacity() (StoreCapacity, error) {
+// Capacity queries the underlying file system for disk capacity information.
+func (r *RocksDB) Capacity() (proto.StoreCapacity, error) {
 	var fs syscall.Statfs_t
-	var capacity StoreCapacity
+	var capacity proto.StoreCapacity
 	dir := r.dir
 	if dir == "" {
 		dir = "/tmp"
@@ -467,7 +466,7 @@ func (r *rocksDBSnapshot) Merge(key proto.EncodedKey, value []byte) error {
 }
 
 // Capacity returns capacity details for the engine's available storage.
-func (r *rocksDBSnapshot) Capacity() (StoreCapacity, error) {
+func (r *rocksDBSnapshot) Capacity() (proto.StoreCapacity, error) {
 	return r.parent.Capacity()
 }
 
@@ -620,7 +619,7 @@ func (r *rocksDBBatch) Clear(key proto.EncodedKey) error {
 	return nil
 }
 
-func (r *rocksDBBatch) Capacity() (StoreCapacity, error) {
+func (r *rocksDBBatch) Capacity() (proto.StoreCapacity, error) {
 	return r.parent.Capacity()
 }
 

--- a/storage/range.go
+++ b/storage/range.go
@@ -45,7 +45,7 @@ import (
 
 // init pre-registers RangeDescriptor, PrefixConfigMap types and Transaction.
 func init() {
-	gob.Register(StoreDescriptor{})
+	gob.Register(proto.StoreDescriptor{})
 	gob.Register(PrefixConfigMap{})
 	gob.Register(&proto.AcctConfig{})
 	gob.Register(&proto.PermConfig{})

--- a/storage/range_test.go
+++ b/storage/range_test.go
@@ -147,7 +147,7 @@ func (tc *testContext) Start(t testing.TB) {
 		ctx.Gossip = tc.gossip
 		ctx.Transport = tc.transport
 		ctx.EventFeed = tc.feed
-		tc.store = NewStore(ctx, tc.engine)
+		tc.store = NewStore(ctx, tc.engine, &proto.NodeDescriptor{NodeID: 1})
 		if err := tc.store.Bootstrap(proto.StoreIdent{NodeID: 1, StoreID: 1}, tc.stopper); err != nil {
 			t.Fatal(err)
 		}
@@ -239,7 +239,7 @@ func TestRangeContains(t *testing.T) {
 	ctx := TestStoreContext
 	ctx.Clock = clock
 	ctx.Transport = multiraft.NewLocalRPCTransport()
-	store := NewStore(ctx, e)
+	store := NewStore(ctx, e, &proto.NodeDescriptor{NodeID: 1})
 	r, err := NewRange(desc, store)
 	if err != nil {
 		t.Fatal(err)

--- a/storage/store_finder.go
+++ b/storage/store_finder.go
@@ -27,7 +27,7 @@ import (
 
 // FindStoreFunc finds the disks in a datacenter that have the requested
 // attributes.
-type FindStoreFunc func(proto.Attributes) ([]*StoreDescriptor, error)
+type FindStoreFunc func(proto.Attributes) ([]*proto.StoreDescriptor, error)
 
 type stringSet map[string]struct{}
 
@@ -81,10 +81,10 @@ func (sf *StoreFinder) WaitForNodes(n int) {
 // TODO(embark, spencer): consider using a reverse index map from Attr->stores,
 // for efficiency.  Ensure that entries in this map still have an opportunity
 // to be garbage collected.
-func (sf *StoreFinder) findStores(required proto.Attributes) ([]*StoreDescriptor, error) {
+func (sf *StoreFinder) findStores(required proto.Attributes) ([]*proto.StoreDescriptor, error) {
 	sf.finderMu.Lock()
 	defer sf.finderMu.Unlock()
-	var stores []*StoreDescriptor
+	var stores []*proto.StoreDescriptor
 	for key := range sf.capacityKeys {
 		storeDesc, err := storeDescFromGossip(key, sf.gossip)
 		if err != nil {
@@ -101,13 +101,13 @@ func (sf *StoreFinder) findStores(required proto.Attributes) ([]*StoreDescriptor
 // storeDescFromGossip retrieves a StoreDescriptor from the specified capacity
 // gossip key. Returns an error if the gossip doesn't exist or is not
 // a StoreDescriptor.
-func storeDescFromGossip(key string, g *gossip.Gossip) (*StoreDescriptor, error) {
+func storeDescFromGossip(key string, g *gossip.Gossip) (*proto.StoreDescriptor, error) {
 	info, err := g.GetInfo(key)
 
 	if err != nil {
 		return nil, err
 	}
-	storeDesc, ok := info.(StoreDescriptor)
+	storeDesc, ok := info.(proto.StoreDescriptor)
 	if !ok {
 		return nil, fmt.Errorf("gossiped info is not a StoreDescriptor: %+v", info)
 	}

--- a/storage/store_finder_test.go
+++ b/storage/store_finder_test.go
@@ -56,16 +56,16 @@ func TestStoreFinder(t *testing.T) {
 		t.Errorf("expected no stores, instead %+v", stores)
 	}
 
-	matchingStore := StoreDescriptor{
+	matchingStore := proto.StoreDescriptor{
 		Attrs: proto.Attributes{Attrs: required},
 	}
-	supersetStore := StoreDescriptor{
+	supersetStore := proto.StoreDescriptor{
 		Attrs: proto.Attributes{Attrs: append(required, "db")},
 	}
-	unmatchingStore := StoreDescriptor{
+	unmatchingStore := proto.StoreDescriptor{
 		Attrs: proto.Attributes{Attrs: []string{"ssd", "otherdc"}},
 	}
-	emptyStore := StoreDescriptor{Attrs: proto.Attributes{}}
+	emptyStore := proto.StoreDescriptor{Attrs: proto.Attributes{}}
 
 	// Explicitly add keys rather than registering a gossip callback to avoid
 	// waiting for the goroutine callback to finish.

--- a/storage/store_test.go
+++ b/storage/store_test.go
@@ -102,7 +102,7 @@ func createTestStore(t *testing.T) (*Store, *hlc.ManualClock, *util.Stopper) {
 	eng := engine.NewInMem(proto.Attributes{}, 10<<20)
 	ctx.Transport = multiraft.NewLocalRPCTransport()
 	stopper.AddCloser(ctx.Transport)
-	store := NewStore(ctx, eng)
+	store := NewStore(ctx, eng, &proto.NodeDescriptor{NodeID: 1})
 	if err := store.Bootstrap(proto.StoreIdent{NodeID: 1, StoreID: 1}, stopper); err != nil {
 		t.Fatal(err)
 	}
@@ -127,7 +127,7 @@ func TestStoreInitAndBootstrap(t *testing.T) {
 	stopper := util.NewStopper()
 	stopper.AddCloser(ctx.Transport)
 	defer stopper.Stop()
-	store := NewStore(ctx, eng)
+	store := NewStore(ctx, eng, &proto.NodeDescriptor{NodeID: 1})
 
 	// Can't start as haven't bootstrapped.
 	if err := store.Start(stopper); err == nil {
@@ -150,7 +150,7 @@ func TestStoreInitAndBootstrap(t *testing.T) {
 	}
 
 	// Now, attempt to initialize a store with a now-bootstrapped range.
-	store = NewStore(ctx, eng)
+	store = NewStore(ctx, eng, &proto.NodeDescriptor{NodeID: 1})
 	if err := store.Start(stopper); err != nil {
 		t.Errorf("failure initializing bootstrapped store: %s", err)
 	}
@@ -177,7 +177,7 @@ func TestBootstrapOfNonEmptyStore(t *testing.T) {
 	stopper := util.NewStopper()
 	stopper.AddCloser(ctx.Transport)
 	defer stopper.Stop()
-	store := NewStore(ctx, eng)
+	store := NewStore(ctx, eng, &proto.NodeDescriptor{NodeID: 1})
 
 	// Can't init as haven't bootstrapped.
 	if err := store.Start(stopper); err == nil {


### PR DESCRIPTION
- Convert StoreDescriptor to a Proto
- Convert StoreCapacity to a Proto
- Add StoreDescriptor to StoreStatus proto
- Pass NodeDescriptor to newStore 
- Remove the need to pass a NodeDescriptor when calling store.Descriptor() and store.GossipCapacity()
- Adjust the store status tests accordingly.
