### PR TITLE
Machinery to resolve write intents during the course of inconsistent rea...

### DIFF
--- a/kv/dist_sender.go
+++ b/kv/dist_sender.go
@@ -503,7 +503,9 @@ func (ds *DistSender) Send(call client.Call) {
 		args.Header().Timestamp = ds.clock.Now()
 	}
 
-	// If this is an InternalPushTxn, set ignoreIntents option as necessary.
+	// If this is an InternalPushTxn, set ignoreIntents option as
+	// necessary. This prevents a potential infinite loop; see the
+	// comments in proto.InternalLookupRangeRequest.
 	options := lookupOptions{}
 	if pushArgs, ok := args.(*proto.InternalPushTxnRequest); ok {
 		options.ignoreIntents = pushArgs.RangeLookup

--- a/kv/dist_sender_test.go
+++ b/kv/dist_sender_test.go
@@ -254,10 +254,10 @@ func TestSendRPCOrder(t *testing.T) {
 	}
 }
 
-type mockRangeDescriptorDB func(proto.Key) ([]proto.RangeDescriptor, error)
+type mockRangeDescriptorDB func(proto.Key, lookupOptions) ([]proto.RangeDescriptor, error)
 
-func (mdb mockRangeDescriptorDB) getRangeDescriptor(k proto.Key) ([]proto.RangeDescriptor, error) {
-	return mdb(k)
+func (mdb mockRangeDescriptorDB) getRangeDescriptor(k proto.Key, lo lookupOptions) ([]proto.RangeDescriptor, error) {
+	return mdb(k, lo)
 }
 
 // TestRetryOnNotLeaderError verifies that the DistSender correctly updates the
@@ -281,7 +281,7 @@ func TestRetryOnNotLeaderError(t *testing.T) {
 
 	ctx := &DistSenderContext{
 		rpcSend: testFn,
-		rangeDescriptorDB: mockRangeDescriptorDB(func(_ proto.Key) ([]proto.RangeDescriptor, error) {
+		rangeDescriptorDB: mockRangeDescriptorDB(func(_ proto.Key, _ lookupOptions) ([]proto.RangeDescriptor, error) {
 			return []proto.RangeDescriptor{testRangeDescriptor}, nil
 		}),
 	}
@@ -303,6 +303,36 @@ func TestRetryOnNotLeaderError(t *testing.T) {
 	if ds.leaderCache.Lookup(1) != nil {
 		t.Errorf("update with same replica did not evict the cache")
 	}
+}
+
+// TestRangeLookupOnPushTxnIgnoresIntents verifies that if a push txn
+// request has range lookup set, the range lookup requests will have
+// ignore intents set.
+func TestRangeLookupOnPushTxnIgnoresIntents(t *testing.T) {
+	g := makeTestGossip(t)
+
+	var testFn rpcSendFn = func(_ rpc.Options, method string, addrs []net.Addr, getArgs func(addr net.Addr) interface{}, getReply func() interface{}, _ *rpc.Context) ([]interface{}, error) {
+		return nil, nil
+	}
+
+	ctx := &DistSenderContext{
+		rpcSend: testFn,
+		rangeDescriptorDB: mockRangeDescriptorDB(func(_ proto.Key, opts lookupOptions) ([]proto.RangeDescriptor, error) {
+			if !opts.ignoreIntents {
+				t.Fatal("expected ignore intents to be true")
+			}
+			return []proto.RangeDescriptor{testRangeDescriptor}, nil
+		}),
+	}
+	ds := NewDistSender(ctx, g)
+	call := client.Call{
+		Args: &proto.InternalPushTxnRequest{
+			RequestHeader: proto.RequestHeader{Key: proto.Key("a")},
+			RangeLookup:   true,
+		},
+		Reply: &proto.InternalPushTxnResponse{},
+	}
+	ds.Send(call)
 }
 
 // TestRetryOnWrongReplicaError sets up a DistSender on a minimal gossip

--- a/kv/range_cache.go
+++ b/kv/range_cache.go
@@ -50,7 +50,7 @@ type rangeDescriptorDB interface {
 	// RangeDescriptors are returned with the intent of pre-caching
 	// subsequent ranges which are likely to be requested soon by the
 	// current workload.
-	getRangeDescriptor(proto.Key) ([]proto.RangeDescriptor, error)
+	getRangeDescriptor(proto.Key, lookupOptions) ([]proto.RangeDescriptor, error)
 }
 
 // rangeDescriptorCache is used to retrieve range descriptors for
@@ -106,14 +106,15 @@ func (rmc *rangeDescriptorCache) String() string {
 //
 // This method returns the RangeDescriptor for the range containing
 // the key's data, or an error if any occurred.
-func (rmc *rangeDescriptorCache) LookupRangeDescriptor(key proto.Key) (*proto.RangeDescriptor, error) {
+func (rmc *rangeDescriptorCache) LookupRangeDescriptor(key proto.Key,
+	options lookupOptions) (*proto.RangeDescriptor, error) {
 	_, r := rmc.getCachedRangeDescriptor(key)
 	log.V(1).Infof("lookup range descriptor: key=%s desc=%+v\n%s", key, r, rmc)
 	if r != nil {
 		return r, nil
 	}
 
-	rs, err := rmc.db.getRangeDescriptor(key)
+	rs, err := rmc.db.getRangeDescriptor(key, options)
 	if err != nil {
 		return nil, err
 	}

--- a/kv/range_cache_test.go
+++ b/kv/range_cache_test.go
@@ -65,14 +65,15 @@ func (db *testDescriptorDB) getDescriptor(key proto.Key) []proto.RangeDescriptor
 	return response
 }
 
-func (db *testDescriptorDB) getRangeDescriptor(key proto.Key) ([]proto.RangeDescriptor, error) {
+func (db *testDescriptorDB) getRangeDescriptor(key proto.Key,
+	options lookupOptions) ([]proto.RangeDescriptor, error) {
 	db.hitCount++
 	metadataKey := engine.RangeMetaKey(key)
 
 	// Recursively call into cache as the real DB would, terminating recursion
 	// when a meta1key is encountered.
 	if len(metadataKey) > 0 && !bytes.HasPrefix(metadataKey, engine.KeyMeta1Prefix) {
-		db.cache.LookupRangeDescriptor(metadataKey)
+		db.cache.LookupRangeDescriptor(metadataKey, options)
 	}
 	return db.getDescriptor(key), nil
 }
@@ -125,7 +126,7 @@ func (db *testDescriptorDB) assertHitCount(t *testing.T, expected int) {
 }
 
 func doLookup(t *testing.T, rc *rangeDescriptorCache, key string) {
-	r, err := rc.LookupRangeDescriptor(proto.Key(key))
+	r, err := rc.LookupRangeDescriptor(proto.Key(key), lookupOptions{})
 	if err != nil {
 		t.Fatalf("Unexpected error from LookupRangeDescriptor: %s", err.Error())
 	}

--- a/kv/txn_coord_sender_test.go
+++ b/kv/txn_coord_sender_test.go
@@ -382,7 +382,7 @@ func TestTxnCoordSenderCleanupOnAborted(t *testing.T) {
 			Txn: txn2,
 		},
 		PusheeTxn: *txn,
-		Abort:     true,
+		PushType:  proto.ABORT_TXN,
 	}
 	if err := s.KV.Run(client.Call{
 		Args:  pushArgs,

--- a/proto/data.go
+++ b/proto/data.go
@@ -263,7 +263,7 @@ func (t Timestamp) Equal(s Timestamp) bool {
 }
 
 func (t Timestamp) String() string {
-	return fmt.Sprintf("%d.%09d,%d", t.WallTime/1E9, t.WallTime%1E9, t.Logical)
+	return fmt.Sprintf("%.09f,%d", float64(t.WallTime)/1E9, t.Logical)
 }
 
 // Add returns a timestamp with the WallTime and Logical components increased.

--- a/proto/errors.go
+++ b/proto/errors.go
@@ -150,7 +150,7 @@ func (e *TransactionStatusError) Error() string {
 
 // Error formats error.
 func (e *WriteIntentError) Error() string {
-	return fmt.Sprintf("conflicting write intent at key %s from transaction %s: resolved? %t", e.Key, e.Txn, e.Resolved)
+	return fmt.Sprintf("conflicting write intents %+v: resolved? %t", e.Intents, e.Resolved)
 }
 
 // Error formats error.

--- a/proto/errors.pb.go
+++ b/proto/errors.pb.go
@@ -249,29 +249,29 @@ func (m *TransactionStatusError) GetMsg() string {
 	return ""
 }
 
-// A WriteIntentError indicates that a write intent belonging to
-// another transaction was encountered leading to a read/write or
-// write/write conflict. The Key at which the intent was encountered
-// is set, as is the Txn record for the intent's transaction.
-// Resolved is set if the intent was successfully resolved, meaning
-// the client may retry the operation immediately. If Resolved is
-// false, the client should back off and retry.
+// A WriteIntentError indicates that one or more write intent
+// belonging to another transaction were encountered leading to a
+// read/write or write/write conflict. The keys at which the intent
+// was encountered are set, as are the txn records for the intents'
+// transactions. Resolved is set if the intent was successfully
+// resolved, meaning the client may retry the operation
+// immediately. If Resolved is false, the client should back off and
+// retry.
 type WriteIntentError struct {
-	Key              Key         `protobuf:"bytes,1,opt,name=key,customtype=Key" json:"key"`
-	Txn              Transaction `protobuf:"bytes,2,opt,name=txn" json:"txn"`
-	Resolved         bool        `protobuf:"varint,3,opt,name=resolved" json:"resolved"`
-	XXX_unrecognized []byte      `json:"-"`
+	Intents          []WriteIntentError_Intent `protobuf:"bytes,1,rep,name=intents" json:"intents"`
+	Resolved         bool                      `protobuf:"varint,2,opt,name=resolved" json:"resolved"`
+	XXX_unrecognized []byte                    `json:"-"`
 }
 
 func (m *WriteIntentError) Reset()         { *m = WriteIntentError{} }
 func (m *WriteIntentError) String() string { return proto1.CompactTextString(m) }
 func (*WriteIntentError) ProtoMessage()    {}
 
-func (m *WriteIntentError) GetTxn() Transaction {
+func (m *WriteIntentError) GetIntents() []WriteIntentError_Intent {
 	if m != nil {
-		return m.Txn
+		return m.Intents
 	}
-	return Transaction{}
+	return nil
 }
 
 func (m *WriteIntentError) GetResolved() bool {
@@ -279,6 +279,23 @@ func (m *WriteIntentError) GetResolved() bool {
 		return m.Resolved
 	}
 	return false
+}
+
+type WriteIntentError_Intent struct {
+	Key              Key         `protobuf:"bytes,1,opt,name=key,customtype=Key" json:"key"`
+	Txn              Transaction `protobuf:"bytes,2,opt,name=txn" json:"txn"`
+	XXX_unrecognized []byte      `json:"-"`
+}
+
+func (m *WriteIntentError_Intent) Reset()         { *m = WriteIntentError_Intent{} }
+func (m *WriteIntentError_Intent) String() string { return proto1.CompactTextString(m) }
+func (*WriteIntentError_Intent) ProtoMessage()    {}
+
+func (m *WriteIntentError_Intent) GetTxn() Transaction {
+	if m != nil {
+		return m.Txn
+	}
+	return Transaction{}
 }
 
 // A WriteTooOldError indicates that a write encountered a versioned
@@ -1191,6 +1208,88 @@ func (m *WriteIntentError) Unmarshal(data []byte) error {
 		switch fieldNum {
 		case 1:
 			if wireType != 2 {
+				return fmt.Errorf("proto: wrong wireType = %d for field Intents", wireType)
+			}
+			var msglen int
+			for shift := uint(0); ; shift += 7 {
+				if index >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := data[index]
+				index++
+				msglen |= (int(b) & 0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			postIndex := index + msglen
+			if postIndex > l {
+				return io.ErrUnexpectedEOF
+			}
+			m.Intents = append(m.Intents, WriteIntentError_Intent{})
+			m.Intents[len(m.Intents)-1].Unmarshal(data[index:postIndex])
+			index = postIndex
+		case 2:
+			if wireType != 0 {
+				return fmt.Errorf("proto: wrong wireType = %d for field Resolved", wireType)
+			}
+			var v int
+			for shift := uint(0); ; shift += 7 {
+				if index >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := data[index]
+				index++
+				v |= (int(b) & 0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			m.Resolved = bool(v != 0)
+		default:
+			var sizeOfWire int
+			for {
+				sizeOfWire++
+				wire >>= 7
+				if wire == 0 {
+					break
+				}
+			}
+			index -= sizeOfWire
+			skippy, err := github_com_gogo_protobuf_proto.Skip(data[index:])
+			if err != nil {
+				return err
+			}
+			if (index + skippy) > l {
+				return io.ErrUnexpectedEOF
+			}
+			m.XXX_unrecognized = append(m.XXX_unrecognized, data[index:index+skippy]...)
+			index += skippy
+		}
+	}
+	return nil
+}
+func (m *WriteIntentError_Intent) Unmarshal(data []byte) error {
+	l := len(data)
+	index := 0
+	for index < l {
+		var wire uint64
+		for shift := uint(0); ; shift += 7 {
+			if index >= l {
+				return io.ErrUnexpectedEOF
+			}
+			b := data[index]
+			index++
+			wire |= (uint64(b) & 0x7F) << shift
+			if b < 0x80 {
+				break
+			}
+		}
+		fieldNum := int32(wire >> 3)
+		wireType := int(wire & 0x7)
+		switch fieldNum {
+		case 1:
+			if wireType != 2 {
 				return fmt.Errorf("proto: wrong wireType = %d for field Key", wireType)
 			}
 			var byteLen int
@@ -1237,23 +1336,6 @@ func (m *WriteIntentError) Unmarshal(data []byte) error {
 				return err
 			}
 			index = postIndex
-		case 3:
-			if wireType != 0 {
-				return fmt.Errorf("proto: wrong wireType = %d for field Resolved", wireType)
-			}
-			var v int
-			for shift := uint(0); ; shift += 7 {
-				if index >= l {
-					return io.ErrUnexpectedEOF
-				}
-				b := data[index]
-				index++
-				v |= (int(b) & 0x7F) << shift
-				if b < 0x80 {
-					break
-				}
-			}
-			m.Resolved = bool(v != 0)
 		default:
 			var sizeOfWire int
 			for {
@@ -2147,11 +2229,26 @@ func (m *TransactionStatusError) Size() (n int) {
 func (m *WriteIntentError) Size() (n int) {
 	var l int
 	_ = l
+	if len(m.Intents) > 0 {
+		for _, e := range m.Intents {
+			l = e.Size()
+			n += 1 + l + sovErrors(uint64(l))
+		}
+	}
+	n += 2
+	if m.XXX_unrecognized != nil {
+		n += len(m.XXX_unrecognized)
+	}
+	return n
+}
+
+func (m *WriteIntentError_Intent) Size() (n int) {
+	var l int
+	_ = l
 	l = m.Key.Size()
 	n += 1 + l + sovErrors(uint64(l))
 	l = m.Txn.Size()
 	n += 1 + l + sovErrors(uint64(l))
-	n += 2
 	if m.XXX_unrecognized != nil {
 		n += len(m.XXX_unrecognized)
 	}
@@ -2574,6 +2671,47 @@ func (m *WriteIntentError) MarshalTo(data []byte) (n int, err error) {
 	_ = i
 	var l int
 	_ = l
+	if len(m.Intents) > 0 {
+		for _, msg := range m.Intents {
+			data[i] = 0xa
+			i++
+			i = encodeVarintErrors(data, i, uint64(msg.Size()))
+			n, err := msg.MarshalTo(data[i:])
+			if err != nil {
+				return 0, err
+			}
+			i += n
+		}
+	}
+	data[i] = 0x10
+	i++
+	if m.Resolved {
+		data[i] = 1
+	} else {
+		data[i] = 0
+	}
+	i++
+	if m.XXX_unrecognized != nil {
+		i += copy(data[i:], m.XXX_unrecognized)
+	}
+	return i, nil
+}
+
+func (m *WriteIntentError_Intent) Marshal() (data []byte, err error) {
+	size := m.Size()
+	data = make([]byte, size)
+	n, err := m.MarshalTo(data)
+	if err != nil {
+		return nil, err
+	}
+	return data[:n], nil
+}
+
+func (m *WriteIntentError_Intent) MarshalTo(data []byte) (n int, err error) {
+	var i int
+	_ = i
+	var l int
+	_ = l
 	data[i] = 0xa
 	i++
 	i = encodeVarintErrors(data, i, uint64(m.Key.Size()))
@@ -2590,14 +2728,6 @@ func (m *WriteIntentError) MarshalTo(data []byte) (n int, err error) {
 		return 0, err
 	}
 	i += n14
-	data[i] = 0x18
-	i++
-	if m.Resolved {
-		data[i] = 1
-	} else {
-		data[i] = 0
-	}
-	i++
 	if m.XXX_unrecognized != nil {
 		i += copy(data[i:], m.XXX_unrecognized)
 	}

--- a/proto/errors.proto
+++ b/proto/errors.proto
@@ -91,17 +91,21 @@ message TransactionStatusError {
   optional string msg = 2 [(gogoproto.nullable) = false];
 }
 
-// A WriteIntentError indicates that a write intent belonging to
-// another transaction was encountered leading to a read/write or
-// write/write conflict. The Key at which the intent was encountered
-// is set, as is the Txn record for the intent's transaction.
-// Resolved is set if the intent was successfully resolved, meaning
-// the client may retry the operation immediately. If Resolved is
-// false, the client should back off and retry.
+// A WriteIntentError indicates that one or more write intent
+// belonging to another transaction were encountered leading to a
+// read/write or write/write conflict. The keys at which the intent
+// was encountered are set, as are the txn records for the intents'
+// transactions. Resolved is set if the intent was successfully
+// resolved, meaning the client may retry the operation
+// immediately. If Resolved is false, the client should back off and
+// retry.
 message WriteIntentError {
-  optional bytes key = 1 [(gogoproto.nullable) = false, (gogoproto.customtype) = "Key"];
-  optional Transaction txn = 2 [(gogoproto.nullable) = false];
-  optional bool resolved = 3 [(gogoproto.nullable) = false];
+  message Intent {
+    optional bytes key = 1 [(gogoproto.nullable) = false, (gogoproto.customtype) = "Key"];
+    optional Transaction txn = 2 [(gogoproto.nullable) = false];
+  }
+  repeated Intent intents = 1 [(gogoproto.nullable) = false];
+  optional bool resolved = 2 [(gogoproto.nullable) = false];
 }
 
 // A WriteTooOldError indicates that a write encountered a versioned

--- a/proto/internal.pb.go
+++ b/proto/internal.pb.go
@@ -61,8 +61,14 @@ func (x *InternalValueType) UnmarshalJSON(data []byte) error {
 // additional consecutive addressable ranges. Specify max_ranges > 1
 // to pre-fill the range descriptor cache.
 type InternalRangeLookupRequest struct {
-	RequestHeader    `protobuf:"bytes,1,opt,name=header,embedded=header" json:"header"`
-	MaxRanges        int32  `protobuf:"varint,2,opt,name=max_ranges" json:"max_ranges"`
+	RequestHeader `protobuf:"bytes,1,opt,name=header,embedded=header" json:"header"`
+	MaxRanges     int32 `protobuf:"varint,2,opt,name=max_ranges" json:"max_ranges"`
+	// Ignore intents indicates whether or not intents encountered
+	// while looking up the range info should be resolved. This should
+	// be false in general, except for the case where the lookup is
+	// already in service of pushing intents on meta records. Attempting
+	// to resolve intents in this case would lead to infinite recursion.
+	IgnoreIntents    bool   `protobuf:"varint,3,opt,name=ignore_intents" json:"ignore_intents"`
 	XXX_unrecognized []byte `json:"-"`
 }
 
@@ -75,6 +81,13 @@ func (m *InternalRangeLookupRequest) GetMaxRanges() int32 {
 		return m.MaxRanges
 	}
 	return 0
+}
+
+func (m *InternalRangeLookupRequest) GetIgnoreIntents() bool {
+	if m != nil {
+		return m.IgnoreIntents
+	}
+	return false
 }
 
 // An InternalRangeLookupResponse is the return value from the
@@ -203,7 +216,11 @@ type InternalPushTxnRequest struct {
 	// This is done in the event of a writer conflicting with PusheeTxn.
 	// Readers set this to false and instead attempt to move PusheeTxn's
 	// commit timestamp forward.
-	Abort            bool   `protobuf:"varint,3,opt" json:"Abort"`
+	Abort bool `protobuf:"varint,3,opt" json:"Abort"`
+	// Range lookup indicates whether we're pushing a txn because of an
+	// intent encountered while servicing an internal range lookup
+	// request. See notes in InternalLookupRangeRequest.
+	RangeLookup      bool   `protobuf:"varint,4,opt,name=range_lookup" json:"range_lookup"`
 	XXX_unrecognized []byte `json:"-"`
 }
 
@@ -221,6 +238,13 @@ func (m *InternalPushTxnRequest) GetPusheeTxn() Transaction {
 func (m *InternalPushTxnRequest) GetAbort() bool {
 	if m != nil {
 		return m.Abort
+	}
+	return false
+}
+
+func (m *InternalPushTxnRequest) GetRangeLookup() bool {
+	if m != nil {
+		return m.RangeLookup
 	}
 	return false
 }
@@ -1266,6 +1290,23 @@ func (m *InternalRangeLookupRequest) Unmarshal(data []byte) error {
 					break
 				}
 			}
+		case 3:
+			if wireType != 0 {
+				return fmt.Errorf("proto: wrong wireType = %d for field IgnoreIntents", wireType)
+			}
+			var v int
+			for shift := uint(0); ; shift += 7 {
+				if index >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := data[index]
+				index++
+				v |= (int(b) & 0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			m.IgnoreIntents = bool(v != 0)
 		default:
 			var sizeOfWire int
 			for {
@@ -1863,6 +1904,23 @@ func (m *InternalPushTxnRequest) Unmarshal(data []byte) error {
 				}
 			}
 			m.Abort = bool(v != 0)
+		case 4:
+			if wireType != 0 {
+				return fmt.Errorf("proto: wrong wireType = %d for field RangeLookup", wireType)
+			}
+			var v int
+			for shift := uint(0); ; shift += 7 {
+				if index >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := data[index]
+				index++
+				v |= (int(b) & 0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			m.RangeLookup = bool(v != 0)
 		default:
 			var sizeOfWire int
 			for {
@@ -5414,6 +5472,7 @@ func (m *InternalRangeLookupRequest) Size() (n int) {
 	l = m.RequestHeader.Size()
 	n += 1 + l + sovInternal(uint64(l))
 	n += 1 + sovInternal(uint64(m.MaxRanges))
+	n += 2
 	if m.XXX_unrecognized != nil {
 		n += len(m.XXX_unrecognized)
 	}
@@ -5509,6 +5568,7 @@ func (m *InternalPushTxnRequest) Size() (n int) {
 	n += 1 + l + sovInternal(uint64(l))
 	l = m.PusheeTxn.Size()
 	n += 1 + l + sovInternal(uint64(l))
+	n += 2
 	n += 2
 	if m.XXX_unrecognized != nil {
 		n += len(m.XXX_unrecognized)
@@ -6075,6 +6135,14 @@ func (m *InternalRangeLookupRequest) MarshalTo(data []byte) (n int, err error) {
 	data[i] = 0x10
 	i++
 	i = encodeVarintInternal(data, i, uint64(m.MaxRanges))
+	data[i] = 0x18
+	i++
+	if m.IgnoreIntents {
+		data[i] = 1
+	} else {
+		data[i] = 0
+	}
+	i++
 	if m.XXX_unrecognized != nil {
 		i += copy(data[i:], m.XXX_unrecognized)
 	}
@@ -6329,6 +6397,14 @@ func (m *InternalPushTxnRequest) MarshalTo(data []byte) (n int, err error) {
 	data[i] = 0x18
 	i++
 	if m.Abort {
+		data[i] = 1
+	} else {
+		data[i] = 0
+	}
+	i++
+	data[i] = 0x20
+	i++
+	if m.RangeLookup {
 		data[i] = 1
 	} else {
 		data[i] = 0

--- a/proto/internal.pb.go
+++ b/proto/internal.pb.go
@@ -26,19 +26,19 @@ const (
 	PUSH_TIMESTAMP PushTxnType = 0
 	// Abort the transaction if possible to accommodate a concurrent writer.
 	ABORT_TXN PushTxnType = 1
-	// Confirm that the transaction has either been committed or aborted.
-	CONFIRM_NOT_PENDING PushTxnType = 2
+	// Cleanup the transaction if already committed/aborted, or if too old.
+	CLEANUP_TXN PushTxnType = 2
 )
 
 var PushTxnType_name = map[int32]string{
 	0: "PUSH_TIMESTAMP",
 	1: "ABORT_TXN",
-	2: "CONFIRM_NOT_PENDING",
+	2: "CLEANUP_TXN",
 }
 var PushTxnType_value = map[string]int32{
-	"PUSH_TIMESTAMP":      0,
-	"ABORT_TXN":           1,
-	"CONFIRM_NOT_PENDING": 2,
+	"PUSH_TIMESTAMP": 0,
+	"ABORT_TXN":      1,
+	"CLEANUP_TXN":    2,
 }
 
 func (x PushTxnType) Enum() *PushTxnType {
@@ -257,7 +257,7 @@ type InternalPushTxnRequest struct {
 	// timestamp forward. Writers set this to ABORT_TXN to request that
 	// the PushTxn be aborted if possible. This is done in the event of
 	// a writer conflicting with PusheeTxn. Inconsistent readers set
-	// this to CONFIRM_NOT_PENDING to determine whether dangling intents
+	// this to CLEANUP_TXN to determine whether dangling intents
 	// may be resolved.
 	PushType PushTxnType `protobuf:"varint,3,opt,name=push_type,enum=cockroach.proto.PushTxnType" json:"push_type"`
 	// Range lookup indicates whether we're pushing a txn because of an

--- a/proto/internal.proto
+++ b/proto/internal.proto
@@ -93,6 +93,18 @@ message InternalGCResponse {
   optional ResponseHeader header = 1 [(gogoproto.nullable) = false, (gogoproto.embed) = true];
 }
 
+// TxnPushType determines what action to take when pushing a
+// transaction.
+enum PushTxnType {
+  option (gogoproto.goproto_enum_prefix) = false;
+  // Push the timestamp forward if possible to accommodate a concurrent reader.
+  PUSH_TIMESTAMP = 0;
+  // Abort the transaction if possible to accommodate a concurrent writer.
+  ABORT_TXN = 1;
+  // Confirm that the transaction has either been committed or aborted.
+  CONFIRM_NOT_PENDING = 2;
+}
+
 // An InternalPushTxnRequest is arguments to the InternalPushTxn()
 // method. It's sent by readers or writers which have encountered an
 // "intent" laid down by another transaction. The goal is to resolve
@@ -104,16 +116,18 @@ message InternalGCResponse {
 // been committed or aborted already. Otherwise, the existing txn can
 // either be aborted (for write/write conflicts), or its commit
 // timestamp can be moved forward (for read/write conflicts). The
-// course of action is determined by the owning txn's status and also
-// by comparing priorities.
+// course of action is determined by the specified push type, and by
+// the owning txn's status and priority.
 message InternalPushTxnRequest {
   optional RequestHeader header = 1 [(gogoproto.nullable) = false, (gogoproto.embed) = true];
   optional Transaction pushee_txn = 2 [(gogoproto.nullable) = false];
-  // Set to true to request that the PushTxn be aborted if possible.
-  // This is done in the event of a writer conflicting with PusheeTxn.
-  // Readers set this to false and instead attempt to move PusheeTxn's
-  // commit timestamp forward.
-  optional bool Abort = 3 [(gogoproto.nullable) = false];
+  // Readers set this to PUSH_TIMESTAMP to move PusheeTxn's commit
+  // timestamp forward. Writers set this to ABORT_TXN to request that
+  // the PushTxn be aborted if possible. This is done in the event of
+  // a writer conflicting with PusheeTxn. Inconsistent readers set
+  // this to CONFIRM_NOT_PENDING to determine whether dangling intents
+  // may be resolved.
+  optional PushTxnType push_type = 3 [(gogoproto.nullable) = false];
   // Range lookup indicates whether we're pushing a txn because of an
   // intent encountered while servicing an internal range lookup
   // request. See notes in InternalLookupRangeRequest.

--- a/proto/internal.proto
+++ b/proto/internal.proto
@@ -37,6 +37,12 @@ option (gogoproto.unmarshaler_all) = true;
 message InternalRangeLookupRequest {
   optional RequestHeader header = 1 [(gogoproto.nullable) = false, (gogoproto.embed) = true];
   optional int32 max_ranges = 2 [(gogoproto.nullable) = false];
+  // Ignore intents indicates whether or not intents encountered
+  // while looking up the range info should be resolved. This should
+  // be false in general, except for the case where the lookup is
+  // already in service of pushing intents on meta records. Attempting
+  // to resolve intents in this case would lead to infinite recursion.
+  optional bool ignore_intents = 3 [(gogoproto.nullable) = false];
 }
 
 // An InternalRangeLookupResponse is the return value from the
@@ -108,6 +114,10 @@ message InternalPushTxnRequest {
   // Readers set this to false and instead attempt to move PusheeTxn's
   // commit timestamp forward.
   optional bool Abort = 3 [(gogoproto.nullable) = false];
+  // Range lookup indicates whether we're pushing a txn because of an
+  // intent encountered while servicing an internal range lookup
+  // request. See notes in InternalLookupRangeRequest.
+  optional bool range_lookup = 4 [(gogoproto.nullable) = false];
 }
 
 // An InternalPushTxnResponse is the return value from the

--- a/proto/internal.proto
+++ b/proto/internal.proto
@@ -101,8 +101,8 @@ enum PushTxnType {
   PUSH_TIMESTAMP = 0;
   // Abort the transaction if possible to accommodate a concurrent writer.
   ABORT_TXN = 1;
-  // Confirm that the transaction has either been committed or aborted.
-  CONFIRM_NOT_PENDING = 2;
+  // Cleanup the transaction if already committed/aborted, or if too old.
+  CLEANUP_TXN = 2;
 }
 
 // An InternalPushTxnRequest is arguments to the InternalPushTxn()
@@ -125,7 +125,7 @@ message InternalPushTxnRequest {
   // timestamp forward. Writers set this to ABORT_TXN to request that
   // the PushTxn be aborted if possible. This is done in the event of
   // a writer conflicting with PusheeTxn. Inconsistent readers set
-  // this to CONFIRM_NOT_PENDING to determine whether dangling intents
+  // this to CLEANUP_TXN to determine whether dangling intents
   // may be resolved.
   optional PushTxnType push_type = 3 [(gogoproto.nullable) = false];
   // Range lookup indicates whether we're pushing a txn because of an

--- a/storage/client_event_test.go
+++ b/storage/client_event_test.go
@@ -73,9 +73,10 @@ func (ser *storeEventReader) recordEvent(event interface{}) {
 			event.Desc.RaftID, event.Stats.LiveBytes)
 	case *storage.SplitRangeEvent:
 		sid = event.StoreID
-		eventStr = fmt.Sprintf("SplitRange origId=%d, newId=%d, origLive=%d, newLive=%d",
+		eventStr = fmt.Sprintf("SplitRange origId=%d, newId=%d, origLive=%d, newLive=%d, origVal=%d, newVal=%d",
 			event.Original.Desc.RaftID, event.New.Desc.RaftID,
-			event.Original.Stats.LiveBytes, event.New.Stats.LiveBytes)
+			event.Original.Stats.LiveBytes, event.New.Stats.LiveBytes,
+			event.Original.Stats.ValBytes, event.New.Stats.ValBytes)
 	case *storage.MergeRangeEvent:
 		sid = event.StoreID
 		eventStr = fmt.Sprintf("MergeRange rid=%d, subId=%d, live=%d, subLive=%d",
@@ -246,24 +247,24 @@ func TestMultiStoreEventFeed(t *testing.T) {
 			"BeginScanRanges",
 			"AddRange rid=1, live=348",
 			"EndScanRanges",
-			"SplitRange origId=1, newId=2, origLive=938, newLive=42",
-			"SplitRange origId=2, newId=3, origLive=42, newLive=0",
+			"SplitRange origId=1, newId=2, origLive=938, newLive=42, origVal=799, newVal=27",
+			"SplitRange origId=2, newId=3, origLive=42, newLive=0, origVal=27, newVal=0",
 			"MergeRange rid=2, subId=3, live=42, subLive=0",
 		},
 		proto.StoreID(2): []string{
 			"StartStore",
 			"BeginScanRanges",
 			"EndScanRanges",
-			"SplitRange origId=1, newId=2, origLive=938, newLive=42",
-			"SplitRange origId=2, newId=3, origLive=42, newLive=0",
+			"SplitRange origId=1, newId=2, origLive=938, newLive=42, origVal=799, newVal=27",
+			"SplitRange origId=2, newId=3, origLive=42, newLive=0, origVal=27, newVal=0",
 			"MergeRange rid=2, subId=3, live=42, subLive=0",
 		},
 		proto.StoreID(3): []string{
 			"StartStore",
 			"BeginScanRanges",
 			"EndScanRanges",
-			"SplitRange origId=1, newId=2, origLive=938, newLive=42",
-			"SplitRange origId=2, newId=3, origLive=42, newLive=0",
+			"SplitRange origId=1, newId=2, origLive=938, newLive=42, origVal=799, newVal=27",
+			"SplitRange origId=2, newId=3, origLive=42, newLive=0, origVal=27, newVal=0",
 			"MergeRange rid=2, subId=3, live=42, subLive=0",
 		},
 	}

--- a/storage/engine/cockroach/proto/errors.pb.cc
+++ b/storage/engine/cockroach/proto/errors.pb.cc
@@ -48,6 +48,9 @@ const ::google::protobuf::internal::GeneratedMessageReflection*
 const ::google::protobuf::Descriptor* WriteIntentError_descriptor_ = NULL;
 const ::google::protobuf::internal::GeneratedMessageReflection*
   WriteIntentError_reflection_ = NULL;
+const ::google::protobuf::Descriptor* WriteIntentError_Intent_descriptor_ = NULL;
+const ::google::protobuf::internal::GeneratedMessageReflection*
+  WriteIntentError_Intent_reflection_ = NULL;
 const ::google::protobuf::Descriptor* WriteTooOldError_descriptor_ = NULL;
 const ::google::protobuf::internal::GeneratedMessageReflection*
   WriteTooOldError_reflection_ = NULL;
@@ -215,9 +218,8 @@ void protobuf_AssignDesc_cockroach_2fproto_2ferrors_2eproto() {
       ::google::protobuf::MessageFactory::generated_factory(),
       sizeof(TransactionStatusError));
   WriteIntentError_descriptor_ = file->message_type(8);
-  static const int WriteIntentError_offsets_[3] = {
-    GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(WriteIntentError, key_),
-    GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(WriteIntentError, txn_),
+  static const int WriteIntentError_offsets_[2] = {
+    GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(WriteIntentError, intents_),
     GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(WriteIntentError, resolved_),
   };
   WriteIntentError_reflection_ =
@@ -231,6 +233,22 @@ void protobuf_AssignDesc_cockroach_2fproto_2ferrors_2eproto() {
       ::google::protobuf::DescriptorPool::generated_pool(),
       ::google::protobuf::MessageFactory::generated_factory(),
       sizeof(WriteIntentError));
+  WriteIntentError_Intent_descriptor_ = WriteIntentError_descriptor_->nested_type(0);
+  static const int WriteIntentError_Intent_offsets_[2] = {
+    GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(WriteIntentError_Intent, key_),
+    GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(WriteIntentError_Intent, txn_),
+  };
+  WriteIntentError_Intent_reflection_ =
+    new ::google::protobuf::internal::GeneratedMessageReflection(
+      WriteIntentError_Intent_descriptor_,
+      WriteIntentError_Intent::default_instance_,
+      WriteIntentError_Intent_offsets_,
+      GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(WriteIntentError_Intent, _has_bits_[0]),
+      GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(WriteIntentError_Intent, _unknown_fields_),
+      -1,
+      ::google::protobuf::DescriptorPool::generated_pool(),
+      ::google::protobuf::MessageFactory::generated_factory(),
+      sizeof(WriteIntentError_Intent));
   WriteTooOldError_descriptor_ = file->message_type(9);
   static const int WriteTooOldError_offsets_[2] = {
     GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(WriteTooOldError, timestamp_),
@@ -355,6 +373,8 @@ void protobuf_RegisterTypes(const ::std::string&) {
   ::google::protobuf::MessageFactory::InternalRegisterGeneratedMessage(
     WriteIntentError_descriptor_, &WriteIntentError::default_instance());
   ::google::protobuf::MessageFactory::InternalRegisterGeneratedMessage(
+    WriteIntentError_Intent_descriptor_, &WriteIntentError_Intent::default_instance());
+  ::google::protobuf::MessageFactory::InternalRegisterGeneratedMessage(
     WriteTooOldError_descriptor_, &WriteTooOldError::default_instance());
   ::google::protobuf::MessageFactory::InternalRegisterGeneratedMessage(
     OpRequiresTxnError_descriptor_, &OpRequiresTxnError::default_instance());
@@ -387,6 +407,8 @@ void protobuf_ShutdownFile_cockroach_2fproto_2ferrors_2eproto() {
   delete TransactionStatusError_reflection_;
   delete WriteIntentError::default_instance_;
   delete WriteIntentError_reflection_;
+  delete WriteIntentError_Intent::default_instance_;
+  delete WriteIntentError_Intent_reflection_;
   delete WriteTooOldError::default_instance_;
   delete WriteTooOldError_reflection_;
   delete OpRequiresTxnError::default_instance_;
@@ -434,43 +456,45 @@ void protobuf_AddDesc_cockroach_2fproto_2ferrors_2eproto() {
     "h.proto.TransactionB\004\310\336\037\000\"\\\n\026Transaction"
     "StatusError\022/\n\003txn\030\001 \001(\0132\034.cockroach.pro"
     "to.TransactionB\004\310\336\037\000\022\021\n\003msg\030\002 \001(\tB\004\310\336\037\000\""
-    "u\n\020WriteIntentError\022\030\n\003key\030\001 \001(\014B\013\310\336\037\000\332\336"
-    "\037\003Key\022/\n\003txn\030\002 \001(\0132\034.cockroach.proto.Tra"
-    "nsactionB\004\310\336\037\000\022\026\n\010resolved\030\003 \001(\010B\004\310\336\037\000\"\205"
-    "\001\n\020WriteTooOldError\0223\n\ttimestamp\030\001 \001(\0132\032"
-    ".cockroach.proto.TimestampB\004\310\336\037\000\022<\n\022exis"
-    "ting_timestamp\030\002 \001(\0132\032.cockroach.proto.T"
-    "imestampB\004\310\336\037\000\"\024\n\022OpRequiresTxnError\"D\n\024"
-    "ConditionFailedError\022,\n\014actual_value\030\001 \001"
-    "(\0132\026.cockroach.proto.Value\"\314\006\n\013ErrorDeta"
-    "il\0225\n\nnot_leader\030\001 \001(\0132\037.cockroach.proto"
-    ".NotLeaderErrorH\000\022>\n\017range_not_found\030\002 \001"
-    "(\0132#.cockroach.proto.RangeNotFoundErrorH"
-    "\000\022D\n\022range_key_mismatch\030\003 \001(\0132&.cockroac"
-    "h.proto.RangeKeyMismatchErrorH\000\022_\n read_"
-    "within_uncertainty_interval\030\004 \001(\01323.cock"
-    "roach.proto.ReadWithinUncertaintyInterva"
-    "lErrorH\000\022G\n\023transaction_aborted\030\005 \001(\0132(."
-    "cockroach.proto.TransactionAbortedErrorH"
-    "\000\022A\n\020transaction_push\030\006 \001(\0132%.cockroach."
-    "proto.TransactionPushErrorH\000\022C\n\021transact"
-    "ion_retry\030\007 \001(\0132&.cockroach.proto.Transa"
-    "ctionRetryErrorH\000\022E\n\022transaction_status\030"
-    "\010 \001(\0132\'.cockroach.proto.TransactionStatu"
-    "sErrorH\000\0229\n\014write_intent\030\t \001(\0132!.cockroa"
-    "ch.proto.WriteIntentErrorH\000\022:\n\rwrite_too"
-    "_old\030\n \001(\0132!.cockroach.proto.WriteTooOld"
-    "ErrorH\000\022>\n\017op_requires_txn\030\013 \001(\0132#.cockr"
-    "oach.proto.OpRequiresTxnErrorH\000\022A\n\020condi"
-    "tion_failed\030\014 \001(\0132%.cockroach.proto.Cond"
-    "itionFailedErrorH\000:\004\310\240\037\001B\007\n\005value\"\255\001\n\005Er"
-    "ror\022\025\n\007message\030\001 \001(\tB\004\310\336\037\000\022\027\n\tretryable\030"
-    "\002 \001(\010B\004\310\336\037\000\022F\n\023transaction_restart\030\004 \001(\016"
-    "2#.cockroach.proto.TransactionRestartB\004\310"
-    "\336\037\000\022,\n\006detail\030\003 \001(\0132\034.cockroach.proto.Er"
-    "rorDetail*;\n\022TransactionRestart\022\t\n\005ABORT"
-    "\020\000\022\013\n\007BACKOFF\020\001\022\r\n\tIMMEDIATE\020\002B\023Z\005proto\340"
-    "\342\036\001\310\342\036\001\320\342\036\001", 2411);
+    "\300\001\n\020WriteIntentError\022\?\n\007intents\030\001 \003(\0132(."
+    "cockroach.proto.WriteIntentError.IntentB"
+    "\004\310\336\037\000\022\026\n\010resolved\030\002 \001(\010B\004\310\336\037\000\032S\n\006Intent\022"
+    "\030\n\003key\030\001 \001(\014B\013\310\336\037\000\332\336\037\003Key\022/\n\003txn\030\002 \001(\0132\034"
+    ".cockroach.proto.TransactionB\004\310\336\037\000\"\205\001\n\020W"
+    "riteTooOldError\0223\n\ttimestamp\030\001 \001(\0132\032.coc"
+    "kroach.proto.TimestampB\004\310\336\037\000\022<\n\022existing"
+    "_timestamp\030\002 \001(\0132\032.cockroach.proto.Times"
+    "tampB\004\310\336\037\000\"\024\n\022OpRequiresTxnError\"D\n\024Cond"
+    "itionFailedError\022,\n\014actual_value\030\001 \001(\0132\026"
+    ".cockroach.proto.Value\"\314\006\n\013ErrorDetail\0225"
+    "\n\nnot_leader\030\001 \001(\0132\037.cockroach.proto.Not"
+    "LeaderErrorH\000\022>\n\017range_not_found\030\002 \001(\0132#"
+    ".cockroach.proto.RangeNotFoundErrorH\000\022D\n"
+    "\022range_key_mismatch\030\003 \001(\0132&.cockroach.pr"
+    "oto.RangeKeyMismatchErrorH\000\022_\n read_with"
+    "in_uncertainty_interval\030\004 \001(\01323.cockroac"
+    "h.proto.ReadWithinUncertaintyIntervalErr"
+    "orH\000\022G\n\023transaction_aborted\030\005 \001(\0132(.cock"
+    "roach.proto.TransactionAbortedErrorH\000\022A\n"
+    "\020transaction_push\030\006 \001(\0132%.cockroach.prot"
+    "o.TransactionPushErrorH\000\022C\n\021transaction_"
+    "retry\030\007 \001(\0132&.cockroach.proto.Transactio"
+    "nRetryErrorH\000\022E\n\022transaction_status\030\010 \001("
+    "\0132\'.cockroach.proto.TransactionStatusErr"
+    "orH\000\0229\n\014write_intent\030\t \001(\0132!.cockroach.p"
+    "roto.WriteIntentErrorH\000\022:\n\rwrite_too_old"
+    "\030\n \001(\0132!.cockroach.proto.WriteTooOldErro"
+    "rH\000\022>\n\017op_requires_txn\030\013 \001(\0132#.cockroach"
+    ".proto.OpRequiresTxnErrorH\000\022A\n\020condition"
+    "_failed\030\014 \001(\0132%.cockroach.proto.Conditio"
+    "nFailedErrorH\000:\004\310\240\037\001B\007\n\005value\"\255\001\n\005Error\022"
+    "\025\n\007message\030\001 \001(\tB\004\310\336\037\000\022\027\n\tretryable\030\002 \001("
+    "\010B\004\310\336\037\000\022F\n\023transaction_restart\030\004 \001(\0162#.c"
+    "ockroach.proto.TransactionRestartB\004\310\336\037\000\022"
+    ",\n\006detail\030\003 \001(\0132\034.cockroach.proto.ErrorD"
+    "etail*;\n\022TransactionRestart\022\t\n\005ABORT\020\000\022\013"
+    "\n\007BACKOFF\020\001\022\r\n\tIMMEDIATE\020\002B\023Z\005proto\340\342\036\001\310"
+    "\342\036\001\320\342\036\001", 2487);
   ::google::protobuf::MessageFactory::InternalRegisterGeneratedFile(
     "cockroach/proto/errors.proto", &protobuf_RegisterTypes);
   NotLeaderError::default_instance_ = new NotLeaderError();
@@ -482,6 +506,7 @@ void protobuf_AddDesc_cockroach_2fproto_2ferrors_2eproto() {
   TransactionRetryError::default_instance_ = new TransactionRetryError();
   TransactionStatusError::default_instance_ = new TransactionStatusError();
   WriteIntentError::default_instance_ = new WriteIntentError();
+  WriteIntentError_Intent::default_instance_ = new WriteIntentError_Intent();
   WriteTooOldError::default_instance_ = new WriteTooOldError();
   OpRequiresTxnError::default_instance_ = new OpRequiresTxnError();
   ConditionFailedError::default_instance_ = new ConditionFailedError();
@@ -497,6 +522,7 @@ void protobuf_AddDesc_cockroach_2fproto_2ferrors_2eproto() {
   TransactionRetryError::default_instance_->InitAsDefaultInstance();
   TransactionStatusError::default_instance_->InitAsDefaultInstance();
   WriteIntentError::default_instance_->InitAsDefaultInstance();
+  WriteIntentError_Intent::default_instance_->InitAsDefaultInstance();
   WriteTooOldError::default_instance_->InitAsDefaultInstance();
   OpRequiresTxnError::default_instance_->InitAsDefaultInstance();
   ConditionFailedError::default_instance_->InitAsDefaultInstance();
@@ -2638,43 +2664,41 @@ void TransactionStatusError::Swap(TransactionStatusError* other) {
 // ===================================================================
 
 #ifndef _MSC_VER
-const int WriteIntentError::kKeyFieldNumber;
-const int WriteIntentError::kTxnFieldNumber;
-const int WriteIntentError::kResolvedFieldNumber;
+const int WriteIntentError_Intent::kKeyFieldNumber;
+const int WriteIntentError_Intent::kTxnFieldNumber;
 #endif  // !_MSC_VER
 
-WriteIntentError::WriteIntentError()
+WriteIntentError_Intent::WriteIntentError_Intent()
   : ::google::protobuf::Message() {
   SharedCtor();
-  // @@protoc_insertion_point(constructor:cockroach.proto.WriteIntentError)
+  // @@protoc_insertion_point(constructor:cockroach.proto.WriteIntentError.Intent)
 }
 
-void WriteIntentError::InitAsDefaultInstance() {
+void WriteIntentError_Intent::InitAsDefaultInstance() {
   txn_ = const_cast< ::cockroach::proto::Transaction*>(&::cockroach::proto::Transaction::default_instance());
 }
 
-WriteIntentError::WriteIntentError(const WriteIntentError& from)
+WriteIntentError_Intent::WriteIntentError_Intent(const WriteIntentError_Intent& from)
   : ::google::protobuf::Message() {
   SharedCtor();
   MergeFrom(from);
-  // @@protoc_insertion_point(copy_constructor:cockroach.proto.WriteIntentError)
+  // @@protoc_insertion_point(copy_constructor:cockroach.proto.WriteIntentError.Intent)
 }
 
-void WriteIntentError::SharedCtor() {
+void WriteIntentError_Intent::SharedCtor() {
   ::google::protobuf::internal::GetEmptyString();
   _cached_size_ = 0;
   key_ = const_cast< ::std::string*>(&::google::protobuf::internal::GetEmptyStringAlreadyInited());
   txn_ = NULL;
-  resolved_ = false;
   ::memset(_has_bits_, 0, sizeof(_has_bits_));
 }
 
-WriteIntentError::~WriteIntentError() {
-  // @@protoc_insertion_point(destructor:cockroach.proto.WriteIntentError)
+WriteIntentError_Intent::~WriteIntentError_Intent() {
+  // @@protoc_insertion_point(destructor:cockroach.proto.WriteIntentError.Intent)
   SharedDtor();
 }
 
-void WriteIntentError::SharedDtor() {
+void WriteIntentError_Intent::SharedDtor() {
   if (key_ != &::google::protobuf::internal::GetEmptyStringAlreadyInited()) {
     delete key_;
   }
@@ -2683,29 +2707,29 @@ void WriteIntentError::SharedDtor() {
   }
 }
 
-void WriteIntentError::SetCachedSize(int size) const {
+void WriteIntentError_Intent::SetCachedSize(int size) const {
   GOOGLE_SAFE_CONCURRENT_WRITES_BEGIN();
   _cached_size_ = size;
   GOOGLE_SAFE_CONCURRENT_WRITES_END();
 }
-const ::google::protobuf::Descriptor* WriteIntentError::descriptor() {
+const ::google::protobuf::Descriptor* WriteIntentError_Intent::descriptor() {
   protobuf_AssignDescriptorsOnce();
-  return WriteIntentError_descriptor_;
+  return WriteIntentError_Intent_descriptor_;
 }
 
-const WriteIntentError& WriteIntentError::default_instance() {
+const WriteIntentError_Intent& WriteIntentError_Intent::default_instance() {
   if (default_instance_ == NULL) protobuf_AddDesc_cockroach_2fproto_2ferrors_2eproto();
   return *default_instance_;
 }
 
-WriteIntentError* WriteIntentError::default_instance_ = NULL;
+WriteIntentError_Intent* WriteIntentError_Intent::default_instance_ = NULL;
 
-WriteIntentError* WriteIntentError::New() const {
-  return new WriteIntentError;
+WriteIntentError_Intent* WriteIntentError_Intent::New() const {
+  return new WriteIntentError_Intent;
 }
 
-void WriteIntentError::Clear() {
-  if (_has_bits_[0 / 32] & 7) {
+void WriteIntentError_Intent::Clear() {
+  if (_has_bits_[0 / 32] & 3) {
     if (has_key()) {
       if (key_ != &::google::protobuf::internal::GetEmptyStringAlreadyInited()) {
         key_->clear();
@@ -2714,17 +2738,16 @@ void WriteIntentError::Clear() {
     if (has_txn()) {
       if (txn_ != NULL) txn_->::cockroach::proto::Transaction::Clear();
     }
-    resolved_ = false;
   }
   ::memset(_has_bits_, 0, sizeof(_has_bits_));
   mutable_unknown_fields()->Clear();
 }
 
-bool WriteIntentError::MergePartialFromCodedStream(
+bool WriteIntentError_Intent::MergePartialFromCodedStream(
     ::google::protobuf::io::CodedInputStream* input) {
 #define DO_(EXPRESSION) if (!(EXPRESSION)) goto failure
   ::google::protobuf::uint32 tag;
-  // @@protoc_insertion_point(parse_start:cockroach.proto.WriteIntentError)
+  // @@protoc_insertion_point(parse_start:cockroach.proto.WriteIntentError.Intent)
   for (;;) {
     ::std::pair< ::google::protobuf::uint32, bool> p = input->ReadTagWithCutoff(127);
     tag = p.first;
@@ -2751,13 +2774,264 @@ bool WriteIntentError::MergePartialFromCodedStream(
         } else {
           goto handle_unusual;
         }
-        if (input->ExpectTag(24)) goto parse_resolved;
+        if (input->ExpectAtEnd()) goto success;
         break;
       }
 
-      // optional bool resolved = 3;
-      case 3: {
-        if (tag == 24) {
+      default: {
+      handle_unusual:
+        if (tag == 0 ||
+            ::google::protobuf::internal::WireFormatLite::GetTagWireType(tag) ==
+            ::google::protobuf::internal::WireFormatLite::WIRETYPE_END_GROUP) {
+          goto success;
+        }
+        DO_(::google::protobuf::internal::WireFormat::SkipField(
+              input, tag, mutable_unknown_fields()));
+        break;
+      }
+    }
+  }
+success:
+  // @@protoc_insertion_point(parse_success:cockroach.proto.WriteIntentError.Intent)
+  return true;
+failure:
+  // @@protoc_insertion_point(parse_failure:cockroach.proto.WriteIntentError.Intent)
+  return false;
+#undef DO_
+}
+
+void WriteIntentError_Intent::SerializeWithCachedSizes(
+    ::google::protobuf::io::CodedOutputStream* output) const {
+  // @@protoc_insertion_point(serialize_start:cockroach.proto.WriteIntentError.Intent)
+  // optional bytes key = 1;
+  if (has_key()) {
+    ::google::protobuf::internal::WireFormatLite::WriteBytesMaybeAliased(
+      1, this->key(), output);
+  }
+
+  // optional .cockroach.proto.Transaction txn = 2;
+  if (has_txn()) {
+    ::google::protobuf::internal::WireFormatLite::WriteMessageMaybeToArray(
+      2, this->txn(), output);
+  }
+
+  if (!unknown_fields().empty()) {
+    ::google::protobuf::internal::WireFormat::SerializeUnknownFields(
+        unknown_fields(), output);
+  }
+  // @@protoc_insertion_point(serialize_end:cockroach.proto.WriteIntentError.Intent)
+}
+
+::google::protobuf::uint8* WriteIntentError_Intent::SerializeWithCachedSizesToArray(
+    ::google::protobuf::uint8* target) const {
+  // @@protoc_insertion_point(serialize_to_array_start:cockroach.proto.WriteIntentError.Intent)
+  // optional bytes key = 1;
+  if (has_key()) {
+    target =
+      ::google::protobuf::internal::WireFormatLite::WriteBytesToArray(
+        1, this->key(), target);
+  }
+
+  // optional .cockroach.proto.Transaction txn = 2;
+  if (has_txn()) {
+    target = ::google::protobuf::internal::WireFormatLite::
+      WriteMessageNoVirtualToArray(
+        2, this->txn(), target);
+  }
+
+  if (!unknown_fields().empty()) {
+    target = ::google::protobuf::internal::WireFormat::SerializeUnknownFieldsToArray(
+        unknown_fields(), target);
+  }
+  // @@protoc_insertion_point(serialize_to_array_end:cockroach.proto.WriteIntentError.Intent)
+  return target;
+}
+
+int WriteIntentError_Intent::ByteSize() const {
+  int total_size = 0;
+
+  if (_has_bits_[0 / 32] & (0xffu << (0 % 32))) {
+    // optional bytes key = 1;
+    if (has_key()) {
+      total_size += 1 +
+        ::google::protobuf::internal::WireFormatLite::BytesSize(
+          this->key());
+    }
+
+    // optional .cockroach.proto.Transaction txn = 2;
+    if (has_txn()) {
+      total_size += 1 +
+        ::google::protobuf::internal::WireFormatLite::MessageSizeNoVirtual(
+          this->txn());
+    }
+
+  }
+  if (!unknown_fields().empty()) {
+    total_size +=
+      ::google::protobuf::internal::WireFormat::ComputeUnknownFieldsSize(
+        unknown_fields());
+  }
+  GOOGLE_SAFE_CONCURRENT_WRITES_BEGIN();
+  _cached_size_ = total_size;
+  GOOGLE_SAFE_CONCURRENT_WRITES_END();
+  return total_size;
+}
+
+void WriteIntentError_Intent::MergeFrom(const ::google::protobuf::Message& from) {
+  GOOGLE_CHECK_NE(&from, this);
+  const WriteIntentError_Intent* source =
+    ::google::protobuf::internal::dynamic_cast_if_available<const WriteIntentError_Intent*>(
+      &from);
+  if (source == NULL) {
+    ::google::protobuf::internal::ReflectionOps::Merge(from, this);
+  } else {
+    MergeFrom(*source);
+  }
+}
+
+void WriteIntentError_Intent::MergeFrom(const WriteIntentError_Intent& from) {
+  GOOGLE_CHECK_NE(&from, this);
+  if (from._has_bits_[0 / 32] & (0xffu << (0 % 32))) {
+    if (from.has_key()) {
+      set_key(from.key());
+    }
+    if (from.has_txn()) {
+      mutable_txn()->::cockroach::proto::Transaction::MergeFrom(from.txn());
+    }
+  }
+  mutable_unknown_fields()->MergeFrom(from.unknown_fields());
+}
+
+void WriteIntentError_Intent::CopyFrom(const ::google::protobuf::Message& from) {
+  if (&from == this) return;
+  Clear();
+  MergeFrom(from);
+}
+
+void WriteIntentError_Intent::CopyFrom(const WriteIntentError_Intent& from) {
+  if (&from == this) return;
+  Clear();
+  MergeFrom(from);
+}
+
+bool WriteIntentError_Intent::IsInitialized() const {
+
+  return true;
+}
+
+void WriteIntentError_Intent::Swap(WriteIntentError_Intent* other) {
+  if (other != this) {
+    std::swap(key_, other->key_);
+    std::swap(txn_, other->txn_);
+    std::swap(_has_bits_[0], other->_has_bits_[0]);
+    _unknown_fields_.Swap(&other->_unknown_fields_);
+    std::swap(_cached_size_, other->_cached_size_);
+  }
+}
+
+::google::protobuf::Metadata WriteIntentError_Intent::GetMetadata() const {
+  protobuf_AssignDescriptorsOnce();
+  ::google::protobuf::Metadata metadata;
+  metadata.descriptor = WriteIntentError_Intent_descriptor_;
+  metadata.reflection = WriteIntentError_Intent_reflection_;
+  return metadata;
+}
+
+
+// -------------------------------------------------------------------
+
+#ifndef _MSC_VER
+const int WriteIntentError::kIntentsFieldNumber;
+const int WriteIntentError::kResolvedFieldNumber;
+#endif  // !_MSC_VER
+
+WriteIntentError::WriteIntentError()
+  : ::google::protobuf::Message() {
+  SharedCtor();
+  // @@protoc_insertion_point(constructor:cockroach.proto.WriteIntentError)
+}
+
+void WriteIntentError::InitAsDefaultInstance() {
+}
+
+WriteIntentError::WriteIntentError(const WriteIntentError& from)
+  : ::google::protobuf::Message() {
+  SharedCtor();
+  MergeFrom(from);
+  // @@protoc_insertion_point(copy_constructor:cockroach.proto.WriteIntentError)
+}
+
+void WriteIntentError::SharedCtor() {
+  _cached_size_ = 0;
+  resolved_ = false;
+  ::memset(_has_bits_, 0, sizeof(_has_bits_));
+}
+
+WriteIntentError::~WriteIntentError() {
+  // @@protoc_insertion_point(destructor:cockroach.proto.WriteIntentError)
+  SharedDtor();
+}
+
+void WriteIntentError::SharedDtor() {
+  if (this != default_instance_) {
+  }
+}
+
+void WriteIntentError::SetCachedSize(int size) const {
+  GOOGLE_SAFE_CONCURRENT_WRITES_BEGIN();
+  _cached_size_ = size;
+  GOOGLE_SAFE_CONCURRENT_WRITES_END();
+}
+const ::google::protobuf::Descriptor* WriteIntentError::descriptor() {
+  protobuf_AssignDescriptorsOnce();
+  return WriteIntentError_descriptor_;
+}
+
+const WriteIntentError& WriteIntentError::default_instance() {
+  if (default_instance_ == NULL) protobuf_AddDesc_cockroach_2fproto_2ferrors_2eproto();
+  return *default_instance_;
+}
+
+WriteIntentError* WriteIntentError::default_instance_ = NULL;
+
+WriteIntentError* WriteIntentError::New() const {
+  return new WriteIntentError;
+}
+
+void WriteIntentError::Clear() {
+  resolved_ = false;
+  intents_.Clear();
+  ::memset(_has_bits_, 0, sizeof(_has_bits_));
+  mutable_unknown_fields()->Clear();
+}
+
+bool WriteIntentError::MergePartialFromCodedStream(
+    ::google::protobuf::io::CodedInputStream* input) {
+#define DO_(EXPRESSION) if (!(EXPRESSION)) goto failure
+  ::google::protobuf::uint32 tag;
+  // @@protoc_insertion_point(parse_start:cockroach.proto.WriteIntentError)
+  for (;;) {
+    ::std::pair< ::google::protobuf::uint32, bool> p = input->ReadTagWithCutoff(127);
+    tag = p.first;
+    if (!p.second) goto handle_unusual;
+    switch (::google::protobuf::internal::WireFormatLite::GetTagFieldNumber(tag)) {
+      // repeated .cockroach.proto.WriteIntentError.Intent intents = 1;
+      case 1: {
+        if (tag == 10) {
+         parse_intents:
+          DO_(::google::protobuf::internal::WireFormatLite::ReadMessageNoVirtual(
+                input, add_intents()));
+        } else {
+          goto handle_unusual;
+        }
+        if (input->ExpectTag(10)) goto parse_intents;
+        if (input->ExpectTag(16)) goto parse_resolved;
+        break;
+      }
+
+      // optional bool resolved = 2;
+      case 2: {
+        if (tag == 16) {
          parse_resolved:
           DO_((::google::protobuf::internal::WireFormatLite::ReadPrimitive<
                    bool, ::google::protobuf::internal::WireFormatLite::TYPE_BOOL>(
@@ -2795,21 +3069,15 @@ failure:
 void WriteIntentError::SerializeWithCachedSizes(
     ::google::protobuf::io::CodedOutputStream* output) const {
   // @@protoc_insertion_point(serialize_start:cockroach.proto.WriteIntentError)
-  // optional bytes key = 1;
-  if (has_key()) {
-    ::google::protobuf::internal::WireFormatLite::WriteBytesMaybeAliased(
-      1, this->key(), output);
-  }
-
-  // optional .cockroach.proto.Transaction txn = 2;
-  if (has_txn()) {
+  // repeated .cockroach.proto.WriteIntentError.Intent intents = 1;
+  for (int i = 0; i < this->intents_size(); i++) {
     ::google::protobuf::internal::WireFormatLite::WriteMessageMaybeToArray(
-      2, this->txn(), output);
+      1, this->intents(i), output);
   }
 
-  // optional bool resolved = 3;
+  // optional bool resolved = 2;
   if (has_resolved()) {
-    ::google::protobuf::internal::WireFormatLite::WriteBool(3, this->resolved(), output);
+    ::google::protobuf::internal::WireFormatLite::WriteBool(2, this->resolved(), output);
   }
 
   if (!unknown_fields().empty()) {
@@ -2822,23 +3090,16 @@ void WriteIntentError::SerializeWithCachedSizes(
 ::google::protobuf::uint8* WriteIntentError::SerializeWithCachedSizesToArray(
     ::google::protobuf::uint8* target) const {
   // @@protoc_insertion_point(serialize_to_array_start:cockroach.proto.WriteIntentError)
-  // optional bytes key = 1;
-  if (has_key()) {
-    target =
-      ::google::protobuf::internal::WireFormatLite::WriteBytesToArray(
-        1, this->key(), target);
-  }
-
-  // optional .cockroach.proto.Transaction txn = 2;
-  if (has_txn()) {
+  // repeated .cockroach.proto.WriteIntentError.Intent intents = 1;
+  for (int i = 0; i < this->intents_size(); i++) {
     target = ::google::protobuf::internal::WireFormatLite::
       WriteMessageNoVirtualToArray(
-        2, this->txn(), target);
+        1, this->intents(i), target);
   }
 
-  // optional bool resolved = 3;
+  // optional bool resolved = 2;
   if (has_resolved()) {
-    target = ::google::protobuf::internal::WireFormatLite::WriteBoolToArray(3, this->resolved(), target);
+    target = ::google::protobuf::internal::WireFormatLite::WriteBoolToArray(2, this->resolved(), target);
   }
 
   if (!unknown_fields().empty()) {
@@ -2852,27 +3113,21 @@ void WriteIntentError::SerializeWithCachedSizes(
 int WriteIntentError::ByteSize() const {
   int total_size = 0;
 
-  if (_has_bits_[0 / 32] & (0xffu << (0 % 32))) {
-    // optional bytes key = 1;
-    if (has_key()) {
-      total_size += 1 +
-        ::google::protobuf::internal::WireFormatLite::BytesSize(
-          this->key());
-    }
-
-    // optional .cockroach.proto.Transaction txn = 2;
-    if (has_txn()) {
-      total_size += 1 +
-        ::google::protobuf::internal::WireFormatLite::MessageSizeNoVirtual(
-          this->txn());
-    }
-
-    // optional bool resolved = 3;
+  if (_has_bits_[1 / 32] & (0xffu << (1 % 32))) {
+    // optional bool resolved = 2;
     if (has_resolved()) {
       total_size += 1 + 1;
     }
 
   }
+  // repeated .cockroach.proto.WriteIntentError.Intent intents = 1;
+  total_size += 1 * this->intents_size();
+  for (int i = 0; i < this->intents_size(); i++) {
+    total_size +=
+      ::google::protobuf::internal::WireFormatLite::MessageSizeNoVirtual(
+        this->intents(i));
+  }
+
   if (!unknown_fields().empty()) {
     total_size +=
       ::google::protobuf::internal::WireFormat::ComputeUnknownFieldsSize(
@@ -2898,13 +3153,8 @@ void WriteIntentError::MergeFrom(const ::google::protobuf::Message& from) {
 
 void WriteIntentError::MergeFrom(const WriteIntentError& from) {
   GOOGLE_CHECK_NE(&from, this);
-  if (from._has_bits_[0 / 32] & (0xffu << (0 % 32))) {
-    if (from.has_key()) {
-      set_key(from.key());
-    }
-    if (from.has_txn()) {
-      mutable_txn()->::cockroach::proto::Transaction::MergeFrom(from.txn());
-    }
+  intents_.MergeFrom(from.intents_);
+  if (from._has_bits_[1 / 32] & (0xffu << (1 % 32))) {
     if (from.has_resolved()) {
       set_resolved(from.resolved());
     }
@@ -2931,8 +3181,7 @@ bool WriteIntentError::IsInitialized() const {
 
 void WriteIntentError::Swap(WriteIntentError* other) {
   if (other != this) {
-    std::swap(key_, other->key_);
-    std::swap(txn_, other->txn_);
+    intents_.Swap(&other->intents_);
     std::swap(resolved_, other->resolved_);
     std::swap(_has_bits_[0], other->_has_bits_[0]);
     _unknown_fields_.Swap(&other->_unknown_fields_);

--- a/storage/engine/cockroach/proto/errors.pb.h
+++ b/storage/engine/cockroach/proto/errors.pb.h
@@ -47,6 +47,7 @@ class TransactionPushError;
 class TransactionRetryError;
 class TransactionStatusError;
 class WriteIntentError;
+class WriteIntentError_Intent;
 class WriteTooOldError;
 class OpRequiresTxnError;
 class ConditionFailedError;
@@ -802,6 +803,102 @@ class TransactionStatusError : public ::google::protobuf::Message {
 };
 // -------------------------------------------------------------------
 
+class WriteIntentError_Intent : public ::google::protobuf::Message {
+ public:
+  WriteIntentError_Intent();
+  virtual ~WriteIntentError_Intent();
+
+  WriteIntentError_Intent(const WriteIntentError_Intent& from);
+
+  inline WriteIntentError_Intent& operator=(const WriteIntentError_Intent& from) {
+    CopyFrom(from);
+    return *this;
+  }
+
+  inline const ::google::protobuf::UnknownFieldSet& unknown_fields() const {
+    return _unknown_fields_;
+  }
+
+  inline ::google::protobuf::UnknownFieldSet* mutable_unknown_fields() {
+    return &_unknown_fields_;
+  }
+
+  static const ::google::protobuf::Descriptor* descriptor();
+  static const WriteIntentError_Intent& default_instance();
+
+  void Swap(WriteIntentError_Intent* other);
+
+  // implements Message ----------------------------------------------
+
+  WriteIntentError_Intent* New() const;
+  void CopyFrom(const ::google::protobuf::Message& from);
+  void MergeFrom(const ::google::protobuf::Message& from);
+  void CopyFrom(const WriteIntentError_Intent& from);
+  void MergeFrom(const WriteIntentError_Intent& from);
+  void Clear();
+  bool IsInitialized() const;
+
+  int ByteSize() const;
+  bool MergePartialFromCodedStream(
+      ::google::protobuf::io::CodedInputStream* input);
+  void SerializeWithCachedSizes(
+      ::google::protobuf::io::CodedOutputStream* output) const;
+  ::google::protobuf::uint8* SerializeWithCachedSizesToArray(::google::protobuf::uint8* output) const;
+  int GetCachedSize() const { return _cached_size_; }
+  private:
+  void SharedCtor();
+  void SharedDtor();
+  void SetCachedSize(int size) const;
+  public:
+  ::google::protobuf::Metadata GetMetadata() const;
+
+  // nested types ----------------------------------------------------
+
+  // accessors -------------------------------------------------------
+
+  // optional bytes key = 1;
+  inline bool has_key() const;
+  inline void clear_key();
+  static const int kKeyFieldNumber = 1;
+  inline const ::std::string& key() const;
+  inline void set_key(const ::std::string& value);
+  inline void set_key(const char* value);
+  inline void set_key(const void* value, size_t size);
+  inline ::std::string* mutable_key();
+  inline ::std::string* release_key();
+  inline void set_allocated_key(::std::string* key);
+
+  // optional .cockroach.proto.Transaction txn = 2;
+  inline bool has_txn() const;
+  inline void clear_txn();
+  static const int kTxnFieldNumber = 2;
+  inline const ::cockroach::proto::Transaction& txn() const;
+  inline ::cockroach::proto::Transaction* mutable_txn();
+  inline ::cockroach::proto::Transaction* release_txn();
+  inline void set_allocated_txn(::cockroach::proto::Transaction* txn);
+
+  // @@protoc_insertion_point(class_scope:cockroach.proto.WriteIntentError.Intent)
+ private:
+  inline void set_has_key();
+  inline void clear_has_key();
+  inline void set_has_txn();
+  inline void clear_has_txn();
+
+  ::google::protobuf::UnknownFieldSet _unknown_fields_;
+
+  ::google::protobuf::uint32 _has_bits_[1];
+  mutable int _cached_size_;
+  ::std::string* key_;
+  ::cockroach::proto::Transaction* txn_;
+  friend void  protobuf_AddDesc_cockroach_2fproto_2ferrors_2eproto();
+  friend void protobuf_AssignDesc_cockroach_2fproto_2ferrors_2eproto();
+  friend void protobuf_ShutdownFile_cockroach_2fproto_2ferrors_2eproto();
+
+  void InitAsDefaultInstance();
+  static WriteIntentError_Intent* default_instance_;
+};
+// -------------------------------------------------------------------
+
 class WriteIntentError : public ::google::protobuf::Message {
  public:
   WriteIntentError();
@@ -853,42 +950,31 @@ class WriteIntentError : public ::google::protobuf::Message {
 
   // nested types ----------------------------------------------------
 
+  typedef WriteIntentError_Intent Intent;
+
   // accessors -------------------------------------------------------
 
-  // optional bytes key = 1;
-  inline bool has_key() const;
-  inline void clear_key();
-  static const int kKeyFieldNumber = 1;
-  inline const ::std::string& key() const;
-  inline void set_key(const ::std::string& value);
-  inline void set_key(const char* value);
-  inline void set_key(const void* value, size_t size);
-  inline ::std::string* mutable_key();
-  inline ::std::string* release_key();
-  inline void set_allocated_key(::std::string* key);
+  // repeated .cockroach.proto.WriteIntentError.Intent intents = 1;
+  inline int intents_size() const;
+  inline void clear_intents();
+  static const int kIntentsFieldNumber = 1;
+  inline const ::cockroach::proto::WriteIntentError_Intent& intents(int index) const;
+  inline ::cockroach::proto::WriteIntentError_Intent* mutable_intents(int index);
+  inline ::cockroach::proto::WriteIntentError_Intent* add_intents();
+  inline const ::google::protobuf::RepeatedPtrField< ::cockroach::proto::WriteIntentError_Intent >&
+      intents() const;
+  inline ::google::protobuf::RepeatedPtrField< ::cockroach::proto::WriteIntentError_Intent >*
+      mutable_intents();
 
-  // optional .cockroach.proto.Transaction txn = 2;
-  inline bool has_txn() const;
-  inline void clear_txn();
-  static const int kTxnFieldNumber = 2;
-  inline const ::cockroach::proto::Transaction& txn() const;
-  inline ::cockroach::proto::Transaction* mutable_txn();
-  inline ::cockroach::proto::Transaction* release_txn();
-  inline void set_allocated_txn(::cockroach::proto::Transaction* txn);
-
-  // optional bool resolved = 3;
+  // optional bool resolved = 2;
   inline bool has_resolved() const;
   inline void clear_resolved();
-  static const int kResolvedFieldNumber = 3;
+  static const int kResolvedFieldNumber = 2;
   inline bool resolved() const;
   inline void set_resolved(bool value);
 
   // @@protoc_insertion_point(class_scope:cockroach.proto.WriteIntentError)
  private:
-  inline void set_has_key();
-  inline void clear_has_key();
-  inline void set_has_txn();
-  inline void clear_has_txn();
   inline void set_has_resolved();
   inline void clear_has_resolved();
 
@@ -896,8 +982,7 @@ class WriteIntentError : public ::google::protobuf::Message {
 
   ::google::protobuf::uint32 _has_bits_[1];
   mutable int _cached_size_;
-  ::std::string* key_;
-  ::cockroach::proto::Transaction* txn_;
+  ::google::protobuf::RepeatedPtrField< ::cockroach::proto::WriteIntentError_Intent > intents_;
   bool resolved_;
   friend void  protobuf_AddDesc_cockroach_2fproto_2ferrors_2eproto();
   friend void protobuf_AssignDesc_cockroach_2fproto_2ferrors_2eproto();
@@ -2190,61 +2275,61 @@ inline void TransactionStatusError::set_allocated_msg(::std::string* msg) {
 
 // -------------------------------------------------------------------
 
-// WriteIntentError
+// WriteIntentError_Intent
 
 // optional bytes key = 1;
-inline bool WriteIntentError::has_key() const {
+inline bool WriteIntentError_Intent::has_key() const {
   return (_has_bits_[0] & 0x00000001u) != 0;
 }
-inline void WriteIntentError::set_has_key() {
+inline void WriteIntentError_Intent::set_has_key() {
   _has_bits_[0] |= 0x00000001u;
 }
-inline void WriteIntentError::clear_has_key() {
+inline void WriteIntentError_Intent::clear_has_key() {
   _has_bits_[0] &= ~0x00000001u;
 }
-inline void WriteIntentError::clear_key() {
+inline void WriteIntentError_Intent::clear_key() {
   if (key_ != &::google::protobuf::internal::GetEmptyStringAlreadyInited()) {
     key_->clear();
   }
   clear_has_key();
 }
-inline const ::std::string& WriteIntentError::key() const {
-  // @@protoc_insertion_point(field_get:cockroach.proto.WriteIntentError.key)
+inline const ::std::string& WriteIntentError_Intent::key() const {
+  // @@protoc_insertion_point(field_get:cockroach.proto.WriteIntentError.Intent.key)
   return *key_;
 }
-inline void WriteIntentError::set_key(const ::std::string& value) {
+inline void WriteIntentError_Intent::set_key(const ::std::string& value) {
   set_has_key();
   if (key_ == &::google::protobuf::internal::GetEmptyStringAlreadyInited()) {
     key_ = new ::std::string;
   }
   key_->assign(value);
-  // @@protoc_insertion_point(field_set:cockroach.proto.WriteIntentError.key)
+  // @@protoc_insertion_point(field_set:cockroach.proto.WriteIntentError.Intent.key)
 }
-inline void WriteIntentError::set_key(const char* value) {
+inline void WriteIntentError_Intent::set_key(const char* value) {
   set_has_key();
   if (key_ == &::google::protobuf::internal::GetEmptyStringAlreadyInited()) {
     key_ = new ::std::string;
   }
   key_->assign(value);
-  // @@protoc_insertion_point(field_set_char:cockroach.proto.WriteIntentError.key)
+  // @@protoc_insertion_point(field_set_char:cockroach.proto.WriteIntentError.Intent.key)
 }
-inline void WriteIntentError::set_key(const void* value, size_t size) {
+inline void WriteIntentError_Intent::set_key(const void* value, size_t size) {
   set_has_key();
   if (key_ == &::google::protobuf::internal::GetEmptyStringAlreadyInited()) {
     key_ = new ::std::string;
   }
   key_->assign(reinterpret_cast<const char*>(value), size);
-  // @@protoc_insertion_point(field_set_pointer:cockroach.proto.WriteIntentError.key)
+  // @@protoc_insertion_point(field_set_pointer:cockroach.proto.WriteIntentError.Intent.key)
 }
-inline ::std::string* WriteIntentError::mutable_key() {
+inline ::std::string* WriteIntentError_Intent::mutable_key() {
   set_has_key();
   if (key_ == &::google::protobuf::internal::GetEmptyStringAlreadyInited()) {
     key_ = new ::std::string;
   }
-  // @@protoc_insertion_point(field_mutable:cockroach.proto.WriteIntentError.key)
+  // @@protoc_insertion_point(field_mutable:cockroach.proto.WriteIntentError.Intent.key)
   return key_;
 }
-inline ::std::string* WriteIntentError::release_key() {
+inline ::std::string* WriteIntentError_Intent::release_key() {
   clear_has_key();
   if (key_ == &::google::protobuf::internal::GetEmptyStringAlreadyInited()) {
     return NULL;
@@ -2254,7 +2339,7 @@ inline ::std::string* WriteIntentError::release_key() {
     return temp;
   }
 }
-inline void WriteIntentError::set_allocated_key(::std::string* key) {
+inline void WriteIntentError_Intent::set_allocated_key(::std::string* key) {
   if (key_ != &::google::protobuf::internal::GetEmptyStringAlreadyInited()) {
     delete key_;
   }
@@ -2265,40 +2350,40 @@ inline void WriteIntentError::set_allocated_key(::std::string* key) {
     clear_has_key();
     key_ = const_cast< ::std::string*>(&::google::protobuf::internal::GetEmptyStringAlreadyInited());
   }
-  // @@protoc_insertion_point(field_set_allocated:cockroach.proto.WriteIntentError.key)
+  // @@protoc_insertion_point(field_set_allocated:cockroach.proto.WriteIntentError.Intent.key)
 }
 
 // optional .cockroach.proto.Transaction txn = 2;
-inline bool WriteIntentError::has_txn() const {
+inline bool WriteIntentError_Intent::has_txn() const {
   return (_has_bits_[0] & 0x00000002u) != 0;
 }
-inline void WriteIntentError::set_has_txn() {
+inline void WriteIntentError_Intent::set_has_txn() {
   _has_bits_[0] |= 0x00000002u;
 }
-inline void WriteIntentError::clear_has_txn() {
+inline void WriteIntentError_Intent::clear_has_txn() {
   _has_bits_[0] &= ~0x00000002u;
 }
-inline void WriteIntentError::clear_txn() {
+inline void WriteIntentError_Intent::clear_txn() {
   if (txn_ != NULL) txn_->::cockroach::proto::Transaction::Clear();
   clear_has_txn();
 }
-inline const ::cockroach::proto::Transaction& WriteIntentError::txn() const {
-  // @@protoc_insertion_point(field_get:cockroach.proto.WriteIntentError.txn)
+inline const ::cockroach::proto::Transaction& WriteIntentError_Intent::txn() const {
+  // @@protoc_insertion_point(field_get:cockroach.proto.WriteIntentError.Intent.txn)
   return txn_ != NULL ? *txn_ : *default_instance_->txn_;
 }
-inline ::cockroach::proto::Transaction* WriteIntentError::mutable_txn() {
+inline ::cockroach::proto::Transaction* WriteIntentError_Intent::mutable_txn() {
   set_has_txn();
   if (txn_ == NULL) txn_ = new ::cockroach::proto::Transaction;
-  // @@protoc_insertion_point(field_mutable:cockroach.proto.WriteIntentError.txn)
+  // @@protoc_insertion_point(field_mutable:cockroach.proto.WriteIntentError.Intent.txn)
   return txn_;
 }
-inline ::cockroach::proto::Transaction* WriteIntentError::release_txn() {
+inline ::cockroach::proto::Transaction* WriteIntentError_Intent::release_txn() {
   clear_has_txn();
   ::cockroach::proto::Transaction* temp = txn_;
   txn_ = NULL;
   return temp;
 }
-inline void WriteIntentError::set_allocated_txn(::cockroach::proto::Transaction* txn) {
+inline void WriteIntentError_Intent::set_allocated_txn(::cockroach::proto::Transaction* txn) {
   delete txn_;
   txn_ = txn;
   if (txn) {
@@ -2306,18 +2391,52 @@ inline void WriteIntentError::set_allocated_txn(::cockroach::proto::Transaction*
   } else {
     clear_has_txn();
   }
-  // @@protoc_insertion_point(field_set_allocated:cockroach.proto.WriteIntentError.txn)
+  // @@protoc_insertion_point(field_set_allocated:cockroach.proto.WriteIntentError.Intent.txn)
 }
 
-// optional bool resolved = 3;
+// -------------------------------------------------------------------
+
+// WriteIntentError
+
+// repeated .cockroach.proto.WriteIntentError.Intent intents = 1;
+inline int WriteIntentError::intents_size() const {
+  return intents_.size();
+}
+inline void WriteIntentError::clear_intents() {
+  intents_.Clear();
+}
+inline const ::cockroach::proto::WriteIntentError_Intent& WriteIntentError::intents(int index) const {
+  // @@protoc_insertion_point(field_get:cockroach.proto.WriteIntentError.intents)
+  return intents_.Get(index);
+}
+inline ::cockroach::proto::WriteIntentError_Intent* WriteIntentError::mutable_intents(int index) {
+  // @@protoc_insertion_point(field_mutable:cockroach.proto.WriteIntentError.intents)
+  return intents_.Mutable(index);
+}
+inline ::cockroach::proto::WriteIntentError_Intent* WriteIntentError::add_intents() {
+  // @@protoc_insertion_point(field_add:cockroach.proto.WriteIntentError.intents)
+  return intents_.Add();
+}
+inline const ::google::protobuf::RepeatedPtrField< ::cockroach::proto::WriteIntentError_Intent >&
+WriteIntentError::intents() const {
+  // @@protoc_insertion_point(field_list:cockroach.proto.WriteIntentError.intents)
+  return intents_;
+}
+inline ::google::protobuf::RepeatedPtrField< ::cockroach::proto::WriteIntentError_Intent >*
+WriteIntentError::mutable_intents() {
+  // @@protoc_insertion_point(field_mutable_list:cockroach.proto.WriteIntentError.intents)
+  return &intents_;
+}
+
+// optional bool resolved = 2;
 inline bool WriteIntentError::has_resolved() const {
-  return (_has_bits_[0] & 0x00000004u) != 0;
+  return (_has_bits_[0] & 0x00000002u) != 0;
 }
 inline void WriteIntentError::set_has_resolved() {
-  _has_bits_[0] |= 0x00000004u;
+  _has_bits_[0] |= 0x00000002u;
 }
 inline void WriteIntentError::clear_has_resolved() {
-  _has_bits_[0] &= ~0x00000004u;
+  _has_bits_[0] &= ~0x00000002u;
 }
 inline void WriteIntentError::clear_resolved() {
   resolved_ = false;

--- a/storage/engine/cockroach/proto/internal.pb.cc
+++ b/storage/engine/cockroach/proto/internal.pb.cc
@@ -188,9 +188,10 @@ void protobuf_AssignDesc_cockroach_2fproto_2finternal_2eproto() {
       "cockroach/proto/internal.proto");
   GOOGLE_CHECK(file != NULL);
   InternalRangeLookupRequest_descriptor_ = file->message_type(0);
-  static const int InternalRangeLookupRequest_offsets_[2] = {
+  static const int InternalRangeLookupRequest_offsets_[3] = {
     GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(InternalRangeLookupRequest, header_),
     GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(InternalRangeLookupRequest, max_ranges_),
+    GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(InternalRangeLookupRequest, ignore_intents_),
   };
   InternalRangeLookupRequest_reflection_ =
     new ::google::protobuf::internal::GeneratedMessageReflection(
@@ -298,10 +299,11 @@ void protobuf_AssignDesc_cockroach_2fproto_2finternal_2eproto() {
       ::google::protobuf::MessageFactory::generated_factory(),
       sizeof(InternalGCResponse));
   InternalPushTxnRequest_descriptor_ = file->message_type(6);
-  static const int InternalPushTxnRequest_offsets_[3] = {
+  static const int InternalPushTxnRequest_offsets_[4] = {
     GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(InternalPushTxnRequest, header_),
     GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(InternalPushTxnRequest, pushee_txn_),
     GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(InternalPushTxnRequest, abort_),
+    GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(InternalPushTxnRequest, range_lookup_),
   };
   InternalPushTxnRequest_reflection_ =
     new ::google::protobuf::internal::GeneratedMessageReflection(
@@ -903,173 +905,175 @@ void protobuf_AddDesc_cockroach_2fproto_2finternal_2eproto() {
     "\n\036cockroach/proto/internal.proto\022\017cockro"
     "ach.proto\032\031cockroach/proto/api.proto\032\034co"
     "ckroach/proto/config.proto\032\032cockroach/pr"
-    "oto/data.proto\032\024gogoproto/gogo.proto\"p\n\032"
-    "InternalRangeLookupRequest\0228\n\006header\030\001 \001"
-    "(\0132\036.cockroach.proto.RequestHeaderB\010\310\336\037\000"
-    "\320\336\037\001\022\030\n\nmax_ranges\030\002 \001(\005B\004\310\336\037\000\"\220\001\n\033Inter"
-    "nalRangeLookupResponse\0229\n\006header\030\001 \001(\0132\037"
+    "oto/data.proto\032\024gogoproto/gogo.proto\"\216\001\n"
+    "\032InternalRangeLookupRequest\0228\n\006header\030\001 "
+    "\001(\0132\036.cockroach.proto.RequestHeaderB\010\310\336\037"
+    "\000\320\336\037\001\022\030\n\nmax_ranges\030\002 \001(\005B\004\310\336\037\000\022\034\n\016ignor"
+    "e_intents\030\003 \001(\010B\004\310\336\037\000\"\220\001\n\033InternalRangeL"
+    "ookupResponse\0229\n\006header\030\001 \001(\0132\037.cockroac"
+    "h.proto.ResponseHeaderB\010\310\336\037\000\320\336\037\001\0226\n\006rang"
+    "es\030\002 \003(\0132 .cockroach.proto.RangeDescript"
+    "orB\004\310\336\037\000\"W\n\033InternalHeartbeatTxnRequest\022"
+    "8\n\006header\030\001 \001(\0132\036.cockroach.proto.Reques"
+    "tHeaderB\010\310\336\037\000\320\336\037\001\"Y\n\034InternalHeartbeatTx"
+    "nResponse\0229\n\006header\030\001 \001(\0132\037.cockroach.pr"
+    "oto.ResponseHeaderB\010\310\336\037\000\320\336\037\001\"\241\002\n\021Interna"
+    "lGCRequest\0228\n\006header\030\001 \001(\0132\036.cockroach.p"
+    "roto.RequestHeaderB\010\310\336\037\000\320\336\037\001\022<\n\007gc_meta\030"
+    "\002 \001(\0132\033.cockroach.proto.GCMetadataB\016\310\336\037\000"
+    "\342\336\037\006GCMeta\022<\n\004keys\030\003 \003(\0132(.cockroach.pro"
+    "to.InternalGCRequest.GCKeyB\004\310\336\037\000\032V\n\005GCKe"
+    "y\022\030\n\003key\030\001 \001(\014B\013\310\336\037\000\332\336\037\003Key\0223\n\ttimestamp"
+    "\030\002 \001(\0132\032.cockroach.proto.TimestampB\004\310\336\037\000"
+    "\"O\n\022InternalGCResponse\0229\n\006header\030\001 \001(\0132\037"
     ".cockroach.proto.ResponseHeaderB\010\310\336\037\000\320\336\037"
-    "\001\0226\n\006ranges\030\002 \003(\0132 .cockroach.proto.Rang"
-    "eDescriptorB\004\310\336\037\000\"W\n\033InternalHeartbeatTx"
-    "nRequest\0228\n\006header\030\001 \001(\0132\036.cockroach.pro"
-    "to.RequestHeaderB\010\310\336\037\000\320\336\037\001\"Y\n\034InternalHe"
-    "artbeatTxnResponse\0229\n\006header\030\001 \001(\0132\037.coc"
-    "kroach.proto.ResponseHeaderB\010\310\336\037\000\320\336\037\001\"\241\002"
-    "\n\021InternalGCRequest\0228\n\006header\030\001 \001(\0132\036.co"
-    "ckroach.proto.RequestHeaderB\010\310\336\037\000\320\336\037\001\022<\n"
-    "\007gc_meta\030\002 \001(\0132\033.cockroach.proto.GCMetad"
-    "ataB\016\310\336\037\000\342\336\037\006GCMeta\022<\n\004keys\030\003 \003(\0132(.cock"
-    "roach.proto.InternalGCRequest.GCKeyB\004\310\336\037"
-    "\000\032V\n\005GCKey\022\030\n\003key\030\001 \001(\014B\013\310\336\037\000\332\336\037\003Key\0223\n\t"
-    "timestamp\030\002 \001(\0132\032.cockroach.proto.Timest"
-    "ampB\004\310\336\037\000\"O\n\022InternalGCResponse\0229\n\006heade"
-    "r\030\001 \001(\0132\037.cockroach.proto.ResponseHeader"
-    "B\010\310\336\037\000\320\336\037\001\"\237\001\n\026InternalPushTxnRequest\0228\n"
-    "\006header\030\001 \001(\0132\036.cockroach.proto.RequestH"
-    "eaderB\010\310\336\037\000\320\336\037\001\0226\n\npushee_txn\030\002 \001(\0132\034.co"
-    "ckroach.proto.TransactionB\004\310\336\037\000\022\023\n\005Abort"
-    "\030\003 \001(\010B\004\310\336\037\000\"\206\001\n\027InternalPushTxnResponse"
-    "\0229\n\006header\030\001 \001(\0132\037.cockroach.proto.Respo"
-    "nseHeaderB\010\310\336\037\000\320\336\037\001\0220\n\npushee_txn\030\002 \001(\0132"
-    "\034.cockroach.proto.Transaction\"X\n\034Interna"
-    "lResolveIntentRequest\0228\n\006header\030\001 \001(\0132\036."
-    "cockroach.proto.RequestHeaderB\010\310\336\037\000\320\336\037\001\""
-    "Z\n\035InternalResolveIntentResponse\0229\n\006head"
-    "er\030\001 \001(\0132\037.cockroach.proto.ResponseHeade"
-    "rB\010\310\336\037\000\320\336\037\001\"}\n\024InternalMergeRequest\0228\n\006h"
-    "eader\030\001 \001(\0132\036.cockroach.proto.RequestHea"
-    "derB\010\310\336\037\000\320\336\037\001\022+\n\005value\030\002 \001(\0132\026.cockroach"
-    ".proto.ValueB\004\310\336\037\000\"R\n\025InternalMergeRespo"
-    "nse\0229\n\006header\030\001 \001(\0132\037.cockroach.proto.Re"
-    "sponseHeaderB\010\310\336\037\000\320\336\037\001\"k\n\032InternalTrunca"
-    "teLogRequest\0228\n\006header\030\001 \001(\0132\036.cockroach"
-    ".proto.RequestHeaderB\010\310\336\037\000\320\336\037\001\022\023\n\005index\030"
-    "\002 \001(\004B\004\310\336\037\000\"X\n\033InternalTruncateLogRespon"
-    "se\0229\n\006header\030\001 \001(\0132\037.cockroach.proto.Res"
-    "ponseHeaderB\010\310\336\037\000\320\336\037\001\"\203\001\n\032InternalLeader"
-    "LeaseRequest\0228\n\006header\030\001 \001(\0132\036.cockroach"
-    ".proto.RequestHeaderB\010\310\336\037\000\320\336\037\001\022+\n\005lease\030"
-    "\002 \001(\0132\026.cockroach.proto.LeaseB\004\310\336\037\000\"X\n\033I"
-    "nternalLeaderLeaseResponse\0229\n\006header\030\001 \001"
-    "(\0132\037.cockroach.proto.ResponseHeaderB\010\310\336\037"
-    "\000\320\336\037\001\"\246\005\n\024InternalRequestUnion\0224\n\010contai"
-    "ns\030\001 \001(\0132 .cockroach.proto.ContainsReque"
-    "stH\000\022*\n\003get\030\002 \001(\0132\033.cockroach.proto.GetR"
-    "equestH\000\022*\n\003put\030\003 \001(\0132\033.cockroach.proto."
-    "PutRequestH\000\022A\n\017conditional_put\030\004 \001(\0132&."
-    "cockroach.proto.ConditionalPutRequestH\000\022"
-    "6\n\tincrement\030\005 \001(\0132!.cockroach.proto.Inc"
-    "rementRequestH\000\0220\n\006delete\030\006 \001(\0132\036.cockro"
-    "ach.proto.DeleteRequestH\000\022;\n\014delete_rang"
-    "e\030\007 \001(\0132#.cockroach.proto.DeleteRangeReq"
-    "uestH\000\022,\n\004scan\030\010 \001(\0132\034.cockroach.proto.S"
-    "canRequestH\000\022A\n\017end_transaction\030\t \001(\0132&."
-    "cockroach.proto.EndTransactionRequestH\000\022"
-    "D\n\021internal_push_txn\030\036 \001(\0132\'.cockroach.p"
-    "roto.InternalPushTxnRequestH\000\022P\n\027interna"
-    "l_resolve_intent\030\037 \001(\0132-.cockroach.proto"
-    ".InternalResolveIntentRequestH\000:\004\310\240\037\001B\007\n"
-    "\005value\"\262\005\n\025InternalResponseUnion\0225\n\010cont"
-    "ains\030\001 \001(\0132!.cockroach.proto.ContainsRes"
-    "ponseH\000\022+\n\003get\030\002 \001(\0132\034.cockroach.proto.G"
-    "etResponseH\000\022+\n\003put\030\003 \001(\0132\034.cockroach.pr"
-    "oto.PutResponseH\000\022B\n\017conditional_put\030\004 \001"
-    "(\0132\'.cockroach.proto.ConditionalPutRespo"
-    "nseH\000\0227\n\tincrement\030\005 \001(\0132\".cockroach.pro"
-    "to.IncrementResponseH\000\0221\n\006delete\030\006 \001(\0132\037"
-    ".cockroach.proto.DeleteResponseH\000\022<\n\014del"
-    "ete_range\030\007 \001(\0132$.cockroach.proto.Delete"
-    "RangeResponseH\000\022-\n\004scan\030\010 \001(\0132\035.cockroac"
-    "h.proto.ScanResponseH\000\022B\n\017end_transactio"
-    "n\030\t \001(\0132\'.cockroach.proto.EndTransaction"
-    "ResponseH\000\022E\n\021internal_push_txn\030\036 \001(\0132(."
-    "cockroach.proto.InternalPushTxnResponseH"
-    "\000\022Q\n\027internal_resolve_intent\030\037 \001(\0132..coc"
-    "kroach.proto.InternalResolveIntentRespon"
-    "seH\000:\004\310\240\037\001B\007\n\005value\"\217\001\n\024InternalBatchReq"
-    "uest\0228\n\006header\030\001 \001(\0132\036.cockroach.proto.R"
-    "equestHeaderB\010\310\336\037\000\320\336\037\001\022=\n\010requests\030\002 \003(\013"
-    "2%.cockroach.proto.InternalRequestUnionB"
-    "\004\310\336\037\000\"\223\001\n\025InternalBatchResponse\0229\n\006heade"
-    "r\030\001 \001(\0132\037.cockroach.proto.ResponseHeader"
-    "B\010\310\336\037\000\320\336\037\001\022\?\n\tresponses\030\002 \003(\0132&.cockroac"
-    "h.proto.InternalResponseUnionB\004\310\336\037\000\"\213\007\n\024"
-    "ReadWriteCmdResponse\022+\n\003put\030\001 \001(\0132\034.cock"
-    "roach.proto.PutResponseH\000\022B\n\017conditional"
-    "_put\030\002 \001(\0132\'.cockroach.proto.Conditional"
-    "PutResponseH\000\0227\n\tincrement\030\003 \001(\0132\".cockr"
-    "oach.proto.IncrementResponseH\000\0221\n\006delete"
-    "\030\004 \001(\0132\037.cockroach.proto.DeleteResponseH"
-    "\000\022<\n\014delete_range\030\005 \001(\0132$.cockroach.prot"
-    "o.DeleteRangeResponseH\000\022B\n\017end_transacti"
-    "on\030\006 \001(\0132\'.cockroach.proto.EndTransactio"
-    "nResponseH\000\022O\n\026internal_heartbeat_txn\030\n "
-    "\001(\0132-.cockroach.proto.InternalHeartbeatT"
-    "xnResponseH\000\022E\n\021internal_push_txn\030\013 \001(\0132"
-    "(.cockroach.proto.InternalPushTxnRespons"
-    "eH\000\022Q\n\027internal_resolve_intent\030\014 \001(\0132..c"
-    "ockroach.proto.InternalResolveIntentResp"
-    "onseH\000\022@\n\016internal_merge\030\r \001(\0132&.cockroa"
-    "ch.proto.InternalMergeResponseH\000\022M\n\025inte"
-    "rnal_truncate_log\030\016 \001(\0132,.cockroach.prot"
-    "o.InternalTruncateLogResponseH\000\022:\n\013inter"
-    "nal_gc\030\017 \001(\0132#.cockroach.proto.InternalG"
-    "CResponseH\000\022M\n\025internal_leader_lease\030\020 \001"
-    "(\0132,.cockroach.proto.InternalLeaderLease"
-    "ResponseH\000:\004\310\240\037\001B\007\n\005value\"\343\t\n\030InternalRa"
-    "ftCommandUnion\0224\n\010contains\030\001 \001(\0132 .cockr"
-    "oach.proto.ContainsRequestH\000\022*\n\003get\030\002 \001("
-    "\0132\033.cockroach.proto.GetRequestH\000\022*\n\003put\030"
-    "\003 \001(\0132\033.cockroach.proto.PutRequestH\000\022A\n\017"
-    "conditional_put\030\004 \001(\0132&.cockroach.proto."
-    "ConditionalPutRequestH\000\0226\n\tincrement\030\005 \001"
-    "(\0132!.cockroach.proto.IncrementRequestH\000\022"
-    "0\n\006delete\030\006 \001(\0132\036.cockroach.proto.Delete"
-    "RequestH\000\022;\n\014delete_range\030\007 \001(\0132#.cockro"
-    "ach.proto.DeleteRangeRequestH\000\022,\n\004scan\030\010"
-    " \001(\0132\034.cockroach.proto.ScanRequestH\000\022A\n\017"
-    "end_transaction\030\t \001(\0132&.cockroach.proto."
-    "EndTransactionRequestH\000\022.\n\005batch\030\036 \001(\0132\035"
-    ".cockroach.proto.BatchRequestH\000\022L\n\025inter"
-    "nal_range_lookup\030\037 \001(\0132+.cockroach.proto"
-    ".InternalRangeLookupRequestH\000\022N\n\026interna"
-    "l_heartbeat_txn\030  \001(\0132,.cockroach.proto."
-    "InternalHeartbeatTxnRequestH\000\022D\n\021interna"
-    "l_push_txn\030! \001(\0132\'.cockroach.proto.Inter"
-    "nalPushTxnRequestH\000\022P\n\027internal_resolve_"
-    "intent\030\" \001(\0132-.cockroach.proto.InternalR"
-    "esolveIntentRequestH\000\022H\n\027internal_merge_"
-    "response\030# \001(\0132%.cockroach.proto.Interna"
-    "lMergeRequestH\000\022L\n\025internal_truncate_log"
-    "\030$ \001(\0132+.cockroach.proto.InternalTruncat"
-    "eLogRequestH\000\022I\n\013internal_gc\030% \001(\0132\".coc"
-    "kroach.proto.InternalGCRequestB\016\342\336\037\nInte"
-    "rnalGCH\000\022E\n\016internal_lease\030& \001(\0132+.cockr"
-    "oach.proto.InternalLeaderLeaseRequestH\000\022"
-    "\?\n\016internal_batch\030\' \001(\0132%.cockroach.prot"
-    "o.InternalBatchRequestH\000:\004\310\240\037\001B\007\n\005value\""
-    "\242\001\n\023InternalRaftCommand\022\037\n\007raft_id\030\001 \001(\003"
-    "B\016\310\336\037\000\342\336\037\006RaftID\022,\n\016origin_node_id\030\002 \001(\004"
-    "B\024\310\336\037\000\342\336\037\014OriginNodeID\022<\n\003cmd\030\003 \001(\0132).co"
-    "ckroach.proto.InternalRaftCommandUnionB\004"
-    "\310\336\037\000\"D\n\022RaftMessageRequest\022!\n\010group_id\030\001"
-    " \001(\004B\017\310\336\037\000\342\336\037\007GroupID\022\013\n\003msg\030\002 \001(\014\"\025\n\023Ra"
-    "ftMessageResponse\"\236\001\n\026InternalTimeSeries"
-    "Data\022#\n\025start_timestamp_nanos\030\001 \001(\003B\004\310\336\037"
-    "\000\022#\n\025sample_duration_nanos\030\002 \001(\003B\004\310\336\037\000\022:"
-    "\n\007samples\030\003 \003(\0132).cockroach.proto.Intern"
-    "alTimeSeriesSample\"\320\001\n\030InternalTimeSerie"
-    "sSample\022\024\n\006offset\030\001 \001(\005B\004\310\336\037\000\022\027\n\tint_cou"
-    "nt\030\002 \001(\rB\004\310\336\037\000\022\017\n\007int_sum\030\003 \001(\003\022\017\n\007int_m"
-    "ax\030\004 \001(\003\022\017\n\007int_min\030\005 \001(\003\022\031\n\013float_count"
-    "\030\006 \001(\rB\004\310\336\037\000\022\021\n\tfloat_sum\030\007 \001(\002\022\021\n\tfloat"
-    "_max\030\010 \001(\002\022\021\n\tfloat_min\030\t \001(\002\"=\n\022RaftTru"
-    "ncatedState\022\023\n\005index\030\001 \001(\004B\004\310\336\037\000\022\022\n\004term"
-    "\030\002 \001(\004B\004\310\336\037\000\"z\n\020RaftSnapshotData\022>\n\002KV\030\001"
-    " \003(\0132*.cockroach.proto.RaftSnapshotData."
-    "KeyValueB\006\342\336\037\002KV\032&\n\010KeyValue\022\013\n\003key\030\001 \001("
-    "\014\022\r\n\005value\030\002 \001(\014*%\n\021InternalValueType\022\n\n"
-    "\006_CR_TS\020\001\032\004\210\243\036\000B\023Z\005proto\340\342\036\001\310\342\036\001\320\342\036\001", 6796);
+    "\001\"\273\001\n\026InternalPushTxnRequest\0228\n\006header\030\001"
+    " \001(\0132\036.cockroach.proto.RequestHeaderB\010\310\336"
+    "\037\000\320\336\037\001\0226\n\npushee_txn\030\002 \001(\0132\034.cockroach.p"
+    "roto.TransactionB\004\310\336\037\000\022\023\n\005Abort\030\003 \001(\010B\004\310"
+    "\336\037\000\022\032\n\014range_lookup\030\004 \001(\010B\004\310\336\037\000\"\206\001\n\027Inte"
+    "rnalPushTxnResponse\0229\n\006header\030\001 \001(\0132\037.co"
+    "ckroach.proto.ResponseHeaderB\010\310\336\037\000\320\336\037\001\0220"
+    "\n\npushee_txn\030\002 \001(\0132\034.cockroach.proto.Tra"
+    "nsaction\"X\n\034InternalResolveIntentRequest"
+    "\0228\n\006header\030\001 \001(\0132\036.cockroach.proto.Reque"
+    "stHeaderB\010\310\336\037\000\320\336\037\001\"Z\n\035InternalResolveInt"
+    "entResponse\0229\n\006header\030\001 \001(\0132\037.cockroach."
+    "proto.ResponseHeaderB\010\310\336\037\000\320\336\037\001\"}\n\024Intern"
+    "alMergeRequest\0228\n\006header\030\001 \001(\0132\036.cockroa"
+    "ch.proto.RequestHeaderB\010\310\336\037\000\320\336\037\001\022+\n\005valu"
+    "e\030\002 \001(\0132\026.cockroach.proto.ValueB\004\310\336\037\000\"R\n"
+    "\025InternalMergeResponse\0229\n\006header\030\001 \001(\0132\037"
+    ".cockroach.proto.ResponseHeaderB\010\310\336\037\000\320\336\037"
+    "\001\"k\n\032InternalTruncateLogRequest\0228\n\006heade"
+    "r\030\001 \001(\0132\036.cockroach.proto.RequestHeaderB"
+    "\010\310\336\037\000\320\336\037\001\022\023\n\005index\030\002 \001(\004B\004\310\336\037\000\"X\n\033Intern"
+    "alTruncateLogResponse\0229\n\006header\030\001 \001(\0132\037."
+    "cockroach.proto.ResponseHeaderB\010\310\336\037\000\320\336\037\001"
+    "\"\203\001\n\032InternalLeaderLeaseRequest\0228\n\006heade"
+    "r\030\001 \001(\0132\036.cockroach.proto.RequestHeaderB"
+    "\010\310\336\037\000\320\336\037\001\022+\n\005lease\030\002 \001(\0132\026.cockroach.pro"
+    "to.LeaseB\004\310\336\037\000\"X\n\033InternalLeaderLeaseRes"
+    "ponse\0229\n\006header\030\001 \001(\0132\037.cockroach.proto."
+    "ResponseHeaderB\010\310\336\037\000\320\336\037\001\"\246\005\n\024InternalReq"
+    "uestUnion\0224\n\010contains\030\001 \001(\0132 .cockroach."
+    "proto.ContainsRequestH\000\022*\n\003get\030\002 \001(\0132\033.c"
+    "ockroach.proto.GetRequestH\000\022*\n\003put\030\003 \001(\013"
+    "2\033.cockroach.proto.PutRequestH\000\022A\n\017condi"
+    "tional_put\030\004 \001(\0132&.cockroach.proto.Condi"
+    "tionalPutRequestH\000\0226\n\tincrement\030\005 \001(\0132!."
+    "cockroach.proto.IncrementRequestH\000\0220\n\006de"
+    "lete\030\006 \001(\0132\036.cockroach.proto.DeleteReque"
+    "stH\000\022;\n\014delete_range\030\007 \001(\0132#.cockroach.p"
+    "roto.DeleteRangeRequestH\000\022,\n\004scan\030\010 \001(\0132"
+    "\034.cockroach.proto.ScanRequestH\000\022A\n\017end_t"
+    "ransaction\030\t \001(\0132&.cockroach.proto.EndTr"
+    "ansactionRequestH\000\022D\n\021internal_push_txn\030"
+    "\036 \001(\0132\'.cockroach.proto.InternalPushTxnR"
+    "equestH\000\022P\n\027internal_resolve_intent\030\037 \001("
+    "\0132-.cockroach.proto.InternalResolveInten"
+    "tRequestH\000:\004\310\240\037\001B\007\n\005value\"\262\005\n\025InternalRe"
+    "sponseUnion\0225\n\010contains\030\001 \001(\0132!.cockroac"
+    "h.proto.ContainsResponseH\000\022+\n\003get\030\002 \001(\0132"
+    "\034.cockroach.proto.GetResponseH\000\022+\n\003put\030\003"
+    " \001(\0132\034.cockroach.proto.PutResponseH\000\022B\n\017"
+    "conditional_put\030\004 \001(\0132\'.cockroach.proto."
+    "ConditionalPutResponseH\000\0227\n\tincrement\030\005 "
+    "\001(\0132\".cockroach.proto.IncrementResponseH"
+    "\000\0221\n\006delete\030\006 \001(\0132\037.cockroach.proto.Dele"
+    "teResponseH\000\022<\n\014delete_range\030\007 \001(\0132$.coc"
+    "kroach.proto.DeleteRangeResponseH\000\022-\n\004sc"
+    "an\030\010 \001(\0132\035.cockroach.proto.ScanResponseH"
+    "\000\022B\n\017end_transaction\030\t \001(\0132\'.cockroach.p"
+    "roto.EndTransactionResponseH\000\022E\n\021interna"
+    "l_push_txn\030\036 \001(\0132(.cockroach.proto.Inter"
+    "nalPushTxnResponseH\000\022Q\n\027internal_resolve"
+    "_intent\030\037 \001(\0132..cockroach.proto.Internal"
+    "ResolveIntentResponseH\000:\004\310\240\037\001B\007\n\005value\"\217"
+    "\001\n\024InternalBatchRequest\0228\n\006header\030\001 \001(\0132"
+    "\036.cockroach.proto.RequestHeaderB\010\310\336\037\000\320\336\037"
+    "\001\022=\n\010requests\030\002 \003(\0132%.cockroach.proto.In"
+    "ternalRequestUnionB\004\310\336\037\000\"\223\001\n\025InternalBat"
+    "chResponse\0229\n\006header\030\001 \001(\0132\037.cockroach.p"
+    "roto.ResponseHeaderB\010\310\336\037\000\320\336\037\001\022\?\n\trespons"
+    "es\030\002 \003(\0132&.cockroach.proto.InternalRespo"
+    "nseUnionB\004\310\336\037\000\"\213\007\n\024ReadWriteCmdResponse\022"
+    "+\n\003put\030\001 \001(\0132\034.cockroach.proto.PutRespon"
+    "seH\000\022B\n\017conditional_put\030\002 \001(\0132\'.cockroac"
+    "h.proto.ConditionalPutResponseH\000\0227\n\tincr"
+    "ement\030\003 \001(\0132\".cockroach.proto.IncrementR"
+    "esponseH\000\0221\n\006delete\030\004 \001(\0132\037.cockroach.pr"
+    "oto.DeleteResponseH\000\022<\n\014delete_range\030\005 \001"
+    "(\0132$.cockroach.proto.DeleteRangeResponse"
+    "H\000\022B\n\017end_transaction\030\006 \001(\0132\'.cockroach."
+    "proto.EndTransactionResponseH\000\022O\n\026intern"
+    "al_heartbeat_txn\030\n \001(\0132-.cockroach.proto"
+    ".InternalHeartbeatTxnResponseH\000\022E\n\021inter"
+    "nal_push_txn\030\013 \001(\0132(.cockroach.proto.Int"
+    "ernalPushTxnResponseH\000\022Q\n\027internal_resol"
+    "ve_intent\030\014 \001(\0132..cockroach.proto.Intern"
+    "alResolveIntentResponseH\000\022@\n\016internal_me"
+    "rge\030\r \001(\0132&.cockroach.proto.InternalMerg"
+    "eResponseH\000\022M\n\025internal_truncate_log\030\016 \001"
+    "(\0132,.cockroach.proto.InternalTruncateLog"
+    "ResponseH\000\022:\n\013internal_gc\030\017 \001(\0132#.cockro"
+    "ach.proto.InternalGCResponseH\000\022M\n\025intern"
+    "al_leader_lease\030\020 \001(\0132,.cockroach.proto."
+    "InternalLeaderLeaseResponseH\000:\004\310\240\037\001B\007\n\005v"
+    "alue\"\343\t\n\030InternalRaftCommandUnion\0224\n\010con"
+    "tains\030\001 \001(\0132 .cockroach.proto.ContainsRe"
+    "questH\000\022*\n\003get\030\002 \001(\0132\033.cockroach.proto.G"
+    "etRequestH\000\022*\n\003put\030\003 \001(\0132\033.cockroach.pro"
+    "to.PutRequestH\000\022A\n\017conditional_put\030\004 \001(\013"
+    "2&.cockroach.proto.ConditionalPutRequest"
+    "H\000\0226\n\tincrement\030\005 \001(\0132!.cockroach.proto."
+    "IncrementRequestH\000\0220\n\006delete\030\006 \001(\0132\036.coc"
+    "kroach.proto.DeleteRequestH\000\022;\n\014delete_r"
+    "ange\030\007 \001(\0132#.cockroach.proto.DeleteRange"
+    "RequestH\000\022,\n\004scan\030\010 \001(\0132\034.cockroach.prot"
+    "o.ScanRequestH\000\022A\n\017end_transaction\030\t \001(\013"
+    "2&.cockroach.proto.EndTransactionRequest"
+    "H\000\022.\n\005batch\030\036 \001(\0132\035.cockroach.proto.Batc"
+    "hRequestH\000\022L\n\025internal_range_lookup\030\037 \001("
+    "\0132+.cockroach.proto.InternalRangeLookupR"
+    "equestH\000\022N\n\026internal_heartbeat_txn\030  \001(\013"
+    "2,.cockroach.proto.InternalHeartbeatTxnR"
+    "equestH\000\022D\n\021internal_push_txn\030! \001(\0132\'.co"
+    "ckroach.proto.InternalPushTxnRequestH\000\022P"
+    "\n\027internal_resolve_intent\030\" \001(\0132-.cockro"
+    "ach.proto.InternalResolveIntentRequestH\000"
+    "\022H\n\027internal_merge_response\030# \001(\0132%.cock"
+    "roach.proto.InternalMergeRequestH\000\022L\n\025in"
+    "ternal_truncate_log\030$ \001(\0132+.cockroach.pr"
+    "oto.InternalTruncateLogRequestH\000\022I\n\013inte"
+    "rnal_gc\030% \001(\0132\".cockroach.proto.Internal"
+    "GCRequestB\016\342\336\037\nInternalGCH\000\022E\n\016internal_"
+    "lease\030& \001(\0132+.cockroach.proto.InternalLe"
+    "aderLeaseRequestH\000\022\?\n\016internal_batch\030\' \001"
+    "(\0132%.cockroach.proto.InternalBatchReques"
+    "tH\000:\004\310\240\037\001B\007\n\005value\"\242\001\n\023InternalRaftComma"
+    "nd\022\037\n\007raft_id\030\001 \001(\003B\016\310\336\037\000\342\336\037\006RaftID\022,\n\016o"
+    "rigin_node_id\030\002 \001(\004B\024\310\336\037\000\342\336\037\014OriginNodeI"
+    "D\022<\n\003cmd\030\003 \001(\0132).cockroach.proto.Interna"
+    "lRaftCommandUnionB\004\310\336\037\000\"D\n\022RaftMessageRe"
+    "quest\022!\n\010group_id\030\001 \001(\004B\017\310\336\037\000\342\336\037\007GroupID"
+    "\022\013\n\003msg\030\002 \001(\014\"\025\n\023RaftMessageResponse\"\236\001\n"
+    "\026InternalTimeSeriesData\022#\n\025start_timesta"
+    "mp_nanos\030\001 \001(\003B\004\310\336\037\000\022#\n\025sample_duration_"
+    "nanos\030\002 \001(\003B\004\310\336\037\000\022:\n\007samples\030\003 \003(\0132).coc"
+    "kroach.proto.InternalTimeSeriesSample\"\320\001"
+    "\n\030InternalTimeSeriesSample\022\024\n\006offset\030\001 \001"
+    "(\005B\004\310\336\037\000\022\027\n\tint_count\030\002 \001(\rB\004\310\336\037\000\022\017\n\007int"
+    "_sum\030\003 \001(\003\022\017\n\007int_max\030\004 \001(\003\022\017\n\007int_min\030\005"
+    " \001(\003\022\031\n\013float_count\030\006 \001(\rB\004\310\336\037\000\022\021\n\tfloat"
+    "_sum\030\007 \001(\002\022\021\n\tfloat_max\030\010 \001(\002\022\021\n\tfloat_m"
+    "in\030\t \001(\002\"=\n\022RaftTruncatedState\022\023\n\005index\030"
+    "\001 \001(\004B\004\310\336\037\000\022\022\n\004term\030\002 \001(\004B\004\310\336\037\000\"z\n\020RaftS"
+    "napshotData\022>\n\002KV\030\001 \003(\0132*.cockroach.prot"
+    "o.RaftSnapshotData.KeyValueB\006\342\336\037\002KV\032&\n\010K"
+    "eyValue\022\013\n\003key\030\001 \001(\014\022\r\n\005value\030\002 \001(\014*%\n\021I"
+    "nternalValueType\022\n\n\006_CR_TS\020\001\032\004\210\243\036\000B\023Z\005pr"
+    "oto\340\342\036\001\310\342\036\001\320\342\036\001", 6855);
   ::google::protobuf::MessageFactory::InternalRegisterGeneratedFile(
     "cockroach/proto/internal.proto", &protobuf_RegisterTypes);
   InternalRangeLookupRequest::default_instance_ = new InternalRangeLookupRequest();
@@ -1166,6 +1170,7 @@ bool InternalValueType_IsValid(int value) {
 #ifndef _MSC_VER
 const int InternalRangeLookupRequest::kHeaderFieldNumber;
 const int InternalRangeLookupRequest::kMaxRangesFieldNumber;
+const int InternalRangeLookupRequest::kIgnoreIntentsFieldNumber;
 #endif  // !_MSC_VER
 
 InternalRangeLookupRequest::InternalRangeLookupRequest()
@@ -1189,6 +1194,7 @@ void InternalRangeLookupRequest::SharedCtor() {
   _cached_size_ = 0;
   header_ = NULL;
   max_ranges_ = 0;
+  ignore_intents_ = false;
   ::memset(_has_bits_, 0, sizeof(_has_bits_));
 }
 
@@ -1225,12 +1231,26 @@ InternalRangeLookupRequest* InternalRangeLookupRequest::New() const {
 }
 
 void InternalRangeLookupRequest::Clear() {
-  if (_has_bits_[0 / 32] & 3) {
+#define OFFSET_OF_FIELD_(f) (reinterpret_cast<char*>(      \
+  &reinterpret_cast<InternalRangeLookupRequest*>(16)->f) - \
+   reinterpret_cast<char*>(16))
+
+#define ZR_(first, last) do {                              \
+    size_t f = OFFSET_OF_FIELD_(first);                    \
+    size_t n = OFFSET_OF_FIELD_(last) - f + sizeof(last);  \
+    ::memset(&first, 0, n);                                \
+  } while (0)
+
+  if (_has_bits_[0 / 32] & 7) {
+    ZR_(max_ranges_, ignore_intents_);
     if (has_header()) {
       if (header_ != NULL) header_->::cockroach::proto::RequestHeader::Clear();
     }
-    max_ranges_ = 0;
   }
+
+#undef OFFSET_OF_FIELD_
+#undef ZR_
+
   ::memset(_has_bits_, 0, sizeof(_has_bits_));
   mutable_unknown_fields()->Clear();
 }
@@ -1265,6 +1285,21 @@ bool InternalRangeLookupRequest::MergePartialFromCodedStream(
                    ::google::protobuf::int32, ::google::protobuf::internal::WireFormatLite::TYPE_INT32>(
                  input, &max_ranges_)));
           set_has_max_ranges();
+        } else {
+          goto handle_unusual;
+        }
+        if (input->ExpectTag(24)) goto parse_ignore_intents;
+        break;
+      }
+
+      // optional bool ignore_intents = 3;
+      case 3: {
+        if (tag == 24) {
+         parse_ignore_intents:
+          DO_((::google::protobuf::internal::WireFormatLite::ReadPrimitive<
+                   bool, ::google::protobuf::internal::WireFormatLite::TYPE_BOOL>(
+                 input, &ignore_intents_)));
+          set_has_ignore_intents();
         } else {
           goto handle_unusual;
         }
@@ -1308,6 +1343,11 @@ void InternalRangeLookupRequest::SerializeWithCachedSizes(
     ::google::protobuf::internal::WireFormatLite::WriteInt32(2, this->max_ranges(), output);
   }
 
+  // optional bool ignore_intents = 3;
+  if (has_ignore_intents()) {
+    ::google::protobuf::internal::WireFormatLite::WriteBool(3, this->ignore_intents(), output);
+  }
+
   if (!unknown_fields().empty()) {
     ::google::protobuf::internal::WireFormat::SerializeUnknownFields(
         unknown_fields(), output);
@@ -1328,6 +1368,11 @@ void InternalRangeLookupRequest::SerializeWithCachedSizes(
   // optional int32 max_ranges = 2;
   if (has_max_ranges()) {
     target = ::google::protobuf::internal::WireFormatLite::WriteInt32ToArray(2, this->max_ranges(), target);
+  }
+
+  // optional bool ignore_intents = 3;
+  if (has_ignore_intents()) {
+    target = ::google::protobuf::internal::WireFormatLite::WriteBoolToArray(3, this->ignore_intents(), target);
   }
 
   if (!unknown_fields().empty()) {
@@ -1354,6 +1399,11 @@ int InternalRangeLookupRequest::ByteSize() const {
       total_size += 1 +
         ::google::protobuf::internal::WireFormatLite::Int32Size(
           this->max_ranges());
+    }
+
+    // optional bool ignore_intents = 3;
+    if (has_ignore_intents()) {
+      total_size += 1 + 1;
     }
 
   }
@@ -1389,6 +1439,9 @@ void InternalRangeLookupRequest::MergeFrom(const InternalRangeLookupRequest& fro
     if (from.has_max_ranges()) {
       set_max_ranges(from.max_ranges());
     }
+    if (from.has_ignore_intents()) {
+      set_ignore_intents(from.ignore_intents());
+    }
   }
   mutable_unknown_fields()->MergeFrom(from.unknown_fields());
 }
@@ -1414,6 +1467,7 @@ void InternalRangeLookupRequest::Swap(InternalRangeLookupRequest* other) {
   if (other != this) {
     std::swap(header_, other->header_);
     std::swap(max_ranges_, other->max_ranges_);
+    std::swap(ignore_intents_, other->ignore_intents_);
     std::swap(_has_bits_[0], other->_has_bits_[0]);
     _unknown_fields_.Swap(&other->_unknown_fields_);
     std::swap(_cached_size_, other->_cached_size_);
@@ -2971,6 +3025,7 @@ void InternalGCResponse::Swap(InternalGCResponse* other) {
 const int InternalPushTxnRequest::kHeaderFieldNumber;
 const int InternalPushTxnRequest::kPusheeTxnFieldNumber;
 const int InternalPushTxnRequest::kAbortFieldNumber;
+const int InternalPushTxnRequest::kRangeLookupFieldNumber;
 #endif  // !_MSC_VER
 
 InternalPushTxnRequest::InternalPushTxnRequest()
@@ -2996,6 +3051,7 @@ void InternalPushTxnRequest::SharedCtor() {
   header_ = NULL;
   pushee_txn_ = NULL;
   abort_ = false;
+  range_lookup_ = false;
   ::memset(_has_bits_, 0, sizeof(_has_bits_));
 }
 
@@ -3033,15 +3089,29 @@ InternalPushTxnRequest* InternalPushTxnRequest::New() const {
 }
 
 void InternalPushTxnRequest::Clear() {
-  if (_has_bits_[0 / 32] & 7) {
+#define OFFSET_OF_FIELD_(f) (reinterpret_cast<char*>(      \
+  &reinterpret_cast<InternalPushTxnRequest*>(16)->f) - \
+   reinterpret_cast<char*>(16))
+
+#define ZR_(first, last) do {                              \
+    size_t f = OFFSET_OF_FIELD_(first);                    \
+    size_t n = OFFSET_OF_FIELD_(last) - f + sizeof(last);  \
+    ::memset(&first, 0, n);                                \
+  } while (0)
+
+  if (_has_bits_[0 / 32] & 15) {
+    ZR_(abort_, range_lookup_);
     if (has_header()) {
       if (header_ != NULL) header_->::cockroach::proto::RequestHeader::Clear();
     }
     if (has_pushee_txn()) {
       if (pushee_txn_ != NULL) pushee_txn_->::cockroach::proto::Transaction::Clear();
     }
-    abort_ = false;
   }
+
+#undef OFFSET_OF_FIELD_
+#undef ZR_
+
   ::memset(_has_bits_, 0, sizeof(_has_bits_));
   mutable_unknown_fields()->Clear();
 }
@@ -3092,6 +3162,21 @@ bool InternalPushTxnRequest::MergePartialFromCodedStream(
         } else {
           goto handle_unusual;
         }
+        if (input->ExpectTag(32)) goto parse_range_lookup;
+        break;
+      }
+
+      // optional bool range_lookup = 4;
+      case 4: {
+        if (tag == 32) {
+         parse_range_lookup:
+          DO_((::google::protobuf::internal::WireFormatLite::ReadPrimitive<
+                   bool, ::google::protobuf::internal::WireFormatLite::TYPE_BOOL>(
+                 input, &range_lookup_)));
+          set_has_range_lookup();
+        } else {
+          goto handle_unusual;
+        }
         if (input->ExpectAtEnd()) goto success;
         break;
       }
@@ -3138,6 +3223,11 @@ void InternalPushTxnRequest::SerializeWithCachedSizes(
     ::google::protobuf::internal::WireFormatLite::WriteBool(3, this->abort(), output);
   }
 
+  // optional bool range_lookup = 4;
+  if (has_range_lookup()) {
+    ::google::protobuf::internal::WireFormatLite::WriteBool(4, this->range_lookup(), output);
+  }
+
   if (!unknown_fields().empty()) {
     ::google::protobuf::internal::WireFormat::SerializeUnknownFields(
         unknown_fields(), output);
@@ -3165,6 +3255,11 @@ void InternalPushTxnRequest::SerializeWithCachedSizes(
   // optional bool Abort = 3;
   if (has_abort()) {
     target = ::google::protobuf::internal::WireFormatLite::WriteBoolToArray(3, this->abort(), target);
+  }
+
+  // optional bool range_lookup = 4;
+  if (has_range_lookup()) {
+    target = ::google::protobuf::internal::WireFormatLite::WriteBoolToArray(4, this->range_lookup(), target);
   }
 
   if (!unknown_fields().empty()) {
@@ -3195,6 +3290,11 @@ int InternalPushTxnRequest::ByteSize() const {
 
     // optional bool Abort = 3;
     if (has_abort()) {
+      total_size += 1 + 1;
+    }
+
+    // optional bool range_lookup = 4;
+    if (has_range_lookup()) {
       total_size += 1 + 1;
     }
 
@@ -3234,6 +3334,9 @@ void InternalPushTxnRequest::MergeFrom(const InternalPushTxnRequest& from) {
     if (from.has_abort()) {
       set_abort(from.abort());
     }
+    if (from.has_range_lookup()) {
+      set_range_lookup(from.range_lookup());
+    }
   }
   mutable_unknown_fields()->MergeFrom(from.unknown_fields());
 }
@@ -3260,6 +3363,7 @@ void InternalPushTxnRequest::Swap(InternalPushTxnRequest* other) {
     std::swap(header_, other->header_);
     std::swap(pushee_txn_, other->pushee_txn_);
     std::swap(abort_, other->abort_);
+    std::swap(range_lookup_, other->range_lookup_);
     std::swap(_has_bits_[0], other->_has_bits_[0]);
     _unknown_fields_.Swap(&other->_unknown_fields_);
     std::swap(_cached_size_, other->_cached_size_);

--- a/storage/engine/cockroach/proto/internal.pb.cc
+++ b/storage/engine/cockroach/proto/internal.pb.cc
@@ -1074,11 +1074,11 @@ void protobuf_AddDesc_cockroach_2fproto_2finternal_2eproto() {
     "\004\310\336\037\000\022\022\n\004term\030\002 \001(\004B\004\310\336\037\000\"z\n\020RaftSnapsho"
     "tData\022>\n\002KV\030\001 \003(\0132*.cockroach.proto.Raft"
     "SnapshotData.KeyValueB\006\342\336\037\002KV\032&\n\010KeyValu"
-    "e\022\013\n\003key\030\001 \001(\014\022\r\n\005value\030\002 \001(\014*O\n\013PushTxn"
+    "e\022\013\n\003key\030\001 \001(\014\022\r\n\005value\030\002 \001(\014*G\n\013PushTxn"
     "Type\022\022\n\016PUSH_TIMESTAMP\020\000\022\r\n\tABORT_TXN\020\001\022"
-    "\027\n\023CONFIRM_NOT_PENDING\020\002\032\004\210\243\036\000*%\n\021Intern"
-    "alValueType\022\n\n\006_CR_TS\020\001\032\004\210\243\036\000B\023Z\005proto\340\342"
-    "\036\001\310\342\036\001\320\342\036\001", 6970);
+    "\017\n\013CLEANUP_TXN\020\002\032\004\210\243\036\000*%\n\021InternalValueT"
+    "ype\022\n\n\006_CR_TS\020\001\032\004\210\243\036\000B\023Z\005proto\340\342\036\001\310\342\036\001\320\342"
+    "\036\001", 6962);
   ::google::protobuf::MessageFactory::InternalRegisterGeneratedFile(
     "cockroach/proto/internal.proto", &protobuf_RegisterTypes);
   InternalRangeLookupRequest::default_instance_ = new InternalRangeLookupRequest();

--- a/storage/engine/cockroach/proto/internal.pb.cc
+++ b/storage/engine/cockroach/proto/internal.pb.cc
@@ -176,6 +176,7 @@ const ::google::protobuf::internal::GeneratedMessageReflection*
 const ::google::protobuf::Descriptor* RaftSnapshotData_KeyValue_descriptor_ = NULL;
 const ::google::protobuf::internal::GeneratedMessageReflection*
   RaftSnapshotData_KeyValue_reflection_ = NULL;
+const ::google::protobuf::EnumDescriptor* PushTxnType_descriptor_ = NULL;
 const ::google::protobuf::EnumDescriptor* InternalValueType_descriptor_ = NULL;
 
 }  // namespace
@@ -302,7 +303,7 @@ void protobuf_AssignDesc_cockroach_2fproto_2finternal_2eproto() {
   static const int InternalPushTxnRequest_offsets_[4] = {
     GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(InternalPushTxnRequest, header_),
     GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(InternalPushTxnRequest, pushee_txn_),
-    GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(InternalPushTxnRequest, abort_),
+    GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(InternalPushTxnRequest, push_type_),
     GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(InternalPushTxnRequest, range_lookup_),
   };
   InternalPushTxnRequest_reflection_ =
@@ -743,7 +744,8 @@ void protobuf_AssignDesc_cockroach_2fproto_2finternal_2eproto() {
       ::google::protobuf::DescriptorPool::generated_pool(),
       ::google::protobuf::MessageFactory::generated_factory(),
       sizeof(RaftSnapshotData_KeyValue));
-  InternalValueType_descriptor_ = file->enum_type(0);
+  PushTxnType_descriptor_ = file->enum_type(0);
+  InternalValueType_descriptor_ = file->enum_type(1);
 }
 
 namespace {
@@ -927,153 +929,156 @@ void protobuf_AddDesc_cockroach_2fproto_2finternal_2eproto() {
     "\030\002 \001(\0132\032.cockroach.proto.TimestampB\004\310\336\037\000"
     "\"O\n\022InternalGCResponse\0229\n\006header\030\001 \001(\0132\037"
     ".cockroach.proto.ResponseHeaderB\010\310\336\037\000\320\336\037"
-    "\001\"\273\001\n\026InternalPushTxnRequest\0228\n\006header\030\001"
+    "\001\"\335\001\n\026InternalPushTxnRequest\0228\n\006header\030\001"
     " \001(\0132\036.cockroach.proto.RequestHeaderB\010\310\336"
     "\037\000\320\336\037\001\0226\n\npushee_txn\030\002 \001(\0132\034.cockroach.p"
-    "roto.TransactionB\004\310\336\037\000\022\023\n\005Abort\030\003 \001(\010B\004\310"
-    "\336\037\000\022\032\n\014range_lookup\030\004 \001(\010B\004\310\336\037\000\"\206\001\n\027Inte"
-    "rnalPushTxnResponse\0229\n\006header\030\001 \001(\0132\037.co"
-    "ckroach.proto.ResponseHeaderB\010\310\336\037\000\320\336\037\001\0220"
-    "\n\npushee_txn\030\002 \001(\0132\034.cockroach.proto.Tra"
-    "nsaction\"X\n\034InternalResolveIntentRequest"
-    "\0228\n\006header\030\001 \001(\0132\036.cockroach.proto.Reque"
-    "stHeaderB\010\310\336\037\000\320\336\037\001\"Z\n\035InternalResolveInt"
-    "entResponse\0229\n\006header\030\001 \001(\0132\037.cockroach."
-    "proto.ResponseHeaderB\010\310\336\037\000\320\336\037\001\"}\n\024Intern"
-    "alMergeRequest\0228\n\006header\030\001 \001(\0132\036.cockroa"
-    "ch.proto.RequestHeaderB\010\310\336\037\000\320\336\037\001\022+\n\005valu"
-    "e\030\002 \001(\0132\026.cockroach.proto.ValueB\004\310\336\037\000\"R\n"
-    "\025InternalMergeResponse\0229\n\006header\030\001 \001(\0132\037"
-    ".cockroach.proto.ResponseHeaderB\010\310\336\037\000\320\336\037"
-    "\001\"k\n\032InternalTruncateLogRequest\0228\n\006heade"
-    "r\030\001 \001(\0132\036.cockroach.proto.RequestHeaderB"
-    "\010\310\336\037\000\320\336\037\001\022\023\n\005index\030\002 \001(\004B\004\310\336\037\000\"X\n\033Intern"
-    "alTruncateLogResponse\0229\n\006header\030\001 \001(\0132\037."
-    "cockroach.proto.ResponseHeaderB\010\310\336\037\000\320\336\037\001"
-    "\"\203\001\n\032InternalLeaderLeaseRequest\0228\n\006heade"
-    "r\030\001 \001(\0132\036.cockroach.proto.RequestHeaderB"
-    "\010\310\336\037\000\320\336\037\001\022+\n\005lease\030\002 \001(\0132\026.cockroach.pro"
-    "to.LeaseB\004\310\336\037\000\"X\n\033InternalLeaderLeaseRes"
+    "roto.TransactionB\004\310\336\037\000\0225\n\tpush_type\030\003 \001("
+    "\0162\034.cockroach.proto.PushTxnTypeB\004\310\336\037\000\022\032\n"
+    "\014range_lookup\030\004 \001(\010B\004\310\336\037\000\"\206\001\n\027InternalPu"
+    "shTxnResponse\0229\n\006header\030\001 \001(\0132\037.cockroac"
+    "h.proto.ResponseHeaderB\010\310\336\037\000\320\336\037\001\0220\n\npush"
+    "ee_txn\030\002 \001(\0132\034.cockroach.proto.Transacti"
+    "on\"X\n\034InternalResolveIntentRequest\0228\n\006he"
+    "ader\030\001 \001(\0132\036.cockroach.proto.RequestHead"
+    "erB\010\310\336\037\000\320\336\037\001\"Z\n\035InternalResolveIntentRes"
     "ponse\0229\n\006header\030\001 \001(\0132\037.cockroach.proto."
-    "ResponseHeaderB\010\310\336\037\000\320\336\037\001\"\246\005\n\024InternalReq"
-    "uestUnion\0224\n\010contains\030\001 \001(\0132 .cockroach."
-    "proto.ContainsRequestH\000\022*\n\003get\030\002 \001(\0132\033.c"
-    "ockroach.proto.GetRequestH\000\022*\n\003put\030\003 \001(\013"
-    "2\033.cockroach.proto.PutRequestH\000\022A\n\017condi"
-    "tional_put\030\004 \001(\0132&.cockroach.proto.Condi"
-    "tionalPutRequestH\000\0226\n\tincrement\030\005 \001(\0132!."
-    "cockroach.proto.IncrementRequestH\000\0220\n\006de"
-    "lete\030\006 \001(\0132\036.cockroach.proto.DeleteReque"
-    "stH\000\022;\n\014delete_range\030\007 \001(\0132#.cockroach.p"
-    "roto.DeleteRangeRequestH\000\022,\n\004scan\030\010 \001(\0132"
-    "\034.cockroach.proto.ScanRequestH\000\022A\n\017end_t"
-    "ransaction\030\t \001(\0132&.cockroach.proto.EndTr"
-    "ansactionRequestH\000\022D\n\021internal_push_txn\030"
-    "\036 \001(\0132\'.cockroach.proto.InternalPushTxnR"
-    "equestH\000\022P\n\027internal_resolve_intent\030\037 \001("
-    "\0132-.cockroach.proto.InternalResolveInten"
-    "tRequestH\000:\004\310\240\037\001B\007\n\005value\"\262\005\n\025InternalRe"
-    "sponseUnion\0225\n\010contains\030\001 \001(\0132!.cockroac"
-    "h.proto.ContainsResponseH\000\022+\n\003get\030\002 \001(\0132"
-    "\034.cockroach.proto.GetResponseH\000\022+\n\003put\030\003"
-    " \001(\0132\034.cockroach.proto.PutResponseH\000\022B\n\017"
-    "conditional_put\030\004 \001(\0132\'.cockroach.proto."
-    "ConditionalPutResponseH\000\0227\n\tincrement\030\005 "
-    "\001(\0132\".cockroach.proto.IncrementResponseH"
-    "\000\0221\n\006delete\030\006 \001(\0132\037.cockroach.proto.Dele"
-    "teResponseH\000\022<\n\014delete_range\030\007 \001(\0132$.coc"
-    "kroach.proto.DeleteRangeResponseH\000\022-\n\004sc"
-    "an\030\010 \001(\0132\035.cockroach.proto.ScanResponseH"
-    "\000\022B\n\017end_transaction\030\t \001(\0132\'.cockroach.p"
-    "roto.EndTransactionResponseH\000\022E\n\021interna"
-    "l_push_txn\030\036 \001(\0132(.cockroach.proto.Inter"
-    "nalPushTxnResponseH\000\022Q\n\027internal_resolve"
-    "_intent\030\037 \001(\0132..cockroach.proto.Internal"
-    "ResolveIntentResponseH\000:\004\310\240\037\001B\007\n\005value\"\217"
-    "\001\n\024InternalBatchRequest\0228\n\006header\030\001 \001(\0132"
-    "\036.cockroach.proto.RequestHeaderB\010\310\336\037\000\320\336\037"
-    "\001\022=\n\010requests\030\002 \003(\0132%.cockroach.proto.In"
-    "ternalRequestUnionB\004\310\336\037\000\"\223\001\n\025InternalBat"
-    "chResponse\0229\n\006header\030\001 \001(\0132\037.cockroach.p"
-    "roto.ResponseHeaderB\010\310\336\037\000\320\336\037\001\022\?\n\trespons"
-    "es\030\002 \003(\0132&.cockroach.proto.InternalRespo"
-    "nseUnionB\004\310\336\037\000\"\213\007\n\024ReadWriteCmdResponse\022"
-    "+\n\003put\030\001 \001(\0132\034.cockroach.proto.PutRespon"
-    "seH\000\022B\n\017conditional_put\030\002 \001(\0132\'.cockroac"
-    "h.proto.ConditionalPutResponseH\000\0227\n\tincr"
-    "ement\030\003 \001(\0132\".cockroach.proto.IncrementR"
-    "esponseH\000\0221\n\006delete\030\004 \001(\0132\037.cockroach.pr"
-    "oto.DeleteResponseH\000\022<\n\014delete_range\030\005 \001"
-    "(\0132$.cockroach.proto.DeleteRangeResponse"
-    "H\000\022B\n\017end_transaction\030\006 \001(\0132\'.cockroach."
-    "proto.EndTransactionResponseH\000\022O\n\026intern"
-    "al_heartbeat_txn\030\n \001(\0132-.cockroach.proto"
-    ".InternalHeartbeatTxnResponseH\000\022E\n\021inter"
-    "nal_push_txn\030\013 \001(\0132(.cockroach.proto.Int"
-    "ernalPushTxnResponseH\000\022Q\n\027internal_resol"
-    "ve_intent\030\014 \001(\0132..cockroach.proto.Intern"
-    "alResolveIntentResponseH\000\022@\n\016internal_me"
-    "rge\030\r \001(\0132&.cockroach.proto.InternalMerg"
-    "eResponseH\000\022M\n\025internal_truncate_log\030\016 \001"
-    "(\0132,.cockroach.proto.InternalTruncateLog"
-    "ResponseH\000\022:\n\013internal_gc\030\017 \001(\0132#.cockro"
-    "ach.proto.InternalGCResponseH\000\022M\n\025intern"
-    "al_leader_lease\030\020 \001(\0132,.cockroach.proto."
-    "InternalLeaderLeaseResponseH\000:\004\310\240\037\001B\007\n\005v"
-    "alue\"\343\t\n\030InternalRaftCommandUnion\0224\n\010con"
-    "tains\030\001 \001(\0132 .cockroach.proto.ContainsRe"
-    "questH\000\022*\n\003get\030\002 \001(\0132\033.cockroach.proto.G"
-    "etRequestH\000\022*\n\003put\030\003 \001(\0132\033.cockroach.pro"
-    "to.PutRequestH\000\022A\n\017conditional_put\030\004 \001(\013"
-    "2&.cockroach.proto.ConditionalPutRequest"
-    "H\000\0226\n\tincrement\030\005 \001(\0132!.cockroach.proto."
-    "IncrementRequestH\000\0220\n\006delete\030\006 \001(\0132\036.coc"
-    "kroach.proto.DeleteRequestH\000\022;\n\014delete_r"
-    "ange\030\007 \001(\0132#.cockroach.proto.DeleteRange"
-    "RequestH\000\022,\n\004scan\030\010 \001(\0132\034.cockroach.prot"
-    "o.ScanRequestH\000\022A\n\017end_transaction\030\t \001(\013"
-    "2&.cockroach.proto.EndTransactionRequest"
-    "H\000\022.\n\005batch\030\036 \001(\0132\035.cockroach.proto.Batc"
-    "hRequestH\000\022L\n\025internal_range_lookup\030\037 \001("
-    "\0132+.cockroach.proto.InternalRangeLookupR"
-    "equestH\000\022N\n\026internal_heartbeat_txn\030  \001(\013"
-    "2,.cockroach.proto.InternalHeartbeatTxnR"
-    "equestH\000\022D\n\021internal_push_txn\030! \001(\0132\'.co"
-    "ckroach.proto.InternalPushTxnRequestH\000\022P"
-    "\n\027internal_resolve_intent\030\" \001(\0132-.cockro"
-    "ach.proto.InternalResolveIntentRequestH\000"
-    "\022H\n\027internal_merge_response\030# \001(\0132%.cock"
-    "roach.proto.InternalMergeRequestH\000\022L\n\025in"
-    "ternal_truncate_log\030$ \001(\0132+.cockroach.pr"
-    "oto.InternalTruncateLogRequestH\000\022I\n\013inte"
-    "rnal_gc\030% \001(\0132\".cockroach.proto.Internal"
-    "GCRequestB\016\342\336\037\nInternalGCH\000\022E\n\016internal_"
-    "lease\030& \001(\0132+.cockroach.proto.InternalLe"
-    "aderLeaseRequestH\000\022\?\n\016internal_batch\030\' \001"
-    "(\0132%.cockroach.proto.InternalBatchReques"
-    "tH\000:\004\310\240\037\001B\007\n\005value\"\242\001\n\023InternalRaftComma"
-    "nd\022\037\n\007raft_id\030\001 \001(\003B\016\310\336\037\000\342\336\037\006RaftID\022,\n\016o"
-    "rigin_node_id\030\002 \001(\004B\024\310\336\037\000\342\336\037\014OriginNodeI"
-    "D\022<\n\003cmd\030\003 \001(\0132).cockroach.proto.Interna"
-    "lRaftCommandUnionB\004\310\336\037\000\"D\n\022RaftMessageRe"
-    "quest\022!\n\010group_id\030\001 \001(\004B\017\310\336\037\000\342\336\037\007GroupID"
-    "\022\013\n\003msg\030\002 \001(\014\"\025\n\023RaftMessageResponse\"\236\001\n"
-    "\026InternalTimeSeriesData\022#\n\025start_timesta"
-    "mp_nanos\030\001 \001(\003B\004\310\336\037\000\022#\n\025sample_duration_"
-    "nanos\030\002 \001(\003B\004\310\336\037\000\022:\n\007samples\030\003 \003(\0132).coc"
-    "kroach.proto.InternalTimeSeriesSample\"\320\001"
-    "\n\030InternalTimeSeriesSample\022\024\n\006offset\030\001 \001"
-    "(\005B\004\310\336\037\000\022\027\n\tint_count\030\002 \001(\rB\004\310\336\037\000\022\017\n\007int"
-    "_sum\030\003 \001(\003\022\017\n\007int_max\030\004 \001(\003\022\017\n\007int_min\030\005"
-    " \001(\003\022\031\n\013float_count\030\006 \001(\rB\004\310\336\037\000\022\021\n\tfloat"
-    "_sum\030\007 \001(\002\022\021\n\tfloat_max\030\010 \001(\002\022\021\n\tfloat_m"
-    "in\030\t \001(\002\"=\n\022RaftTruncatedState\022\023\n\005index\030"
-    "\001 \001(\004B\004\310\336\037\000\022\022\n\004term\030\002 \001(\004B\004\310\336\037\000\"z\n\020RaftS"
-    "napshotData\022>\n\002KV\030\001 \003(\0132*.cockroach.prot"
-    "o.RaftSnapshotData.KeyValueB\006\342\336\037\002KV\032&\n\010K"
-    "eyValue\022\013\n\003key\030\001 \001(\014\022\r\n\005value\030\002 \001(\014*%\n\021I"
-    "nternalValueType\022\n\n\006_CR_TS\020\001\032\004\210\243\036\000B\023Z\005pr"
-    "oto\340\342\036\001\310\342\036\001\320\342\036\001", 6855);
+    "ResponseHeaderB\010\310\336\037\000\320\336\037\001\"}\n\024InternalMerg"
+    "eRequest\0228\n\006header\030\001 \001(\0132\036.cockroach.pro"
+    "to.RequestHeaderB\010\310\336\037\000\320\336\037\001\022+\n\005value\030\002 \001("
+    "\0132\026.cockroach.proto.ValueB\004\310\336\037\000\"R\n\025Inter"
+    "nalMergeResponse\0229\n\006header\030\001 \001(\0132\037.cockr"
+    "oach.proto.ResponseHeaderB\010\310\336\037\000\320\336\037\001\"k\n\032I"
+    "nternalTruncateLogRequest\0228\n\006header\030\001 \001("
+    "\0132\036.cockroach.proto.RequestHeaderB\010\310\336\037\000\320"
+    "\336\037\001\022\023\n\005index\030\002 \001(\004B\004\310\336\037\000\"X\n\033InternalTrun"
+    "cateLogResponse\0229\n\006header\030\001 \001(\0132\037.cockro"
+    "ach.proto.ResponseHeaderB\010\310\336\037\000\320\336\037\001\"\203\001\n\032I"
+    "nternalLeaderLeaseRequest\0228\n\006header\030\001 \001("
+    "\0132\036.cockroach.proto.RequestHeaderB\010\310\336\037\000\320"
+    "\336\037\001\022+\n\005lease\030\002 \001(\0132\026.cockroach.proto.Lea"
+    "seB\004\310\336\037\000\"X\n\033InternalLeaderLeaseResponse\022"
+    "9\n\006header\030\001 \001(\0132\037.cockroach.proto.Respon"
+    "seHeaderB\010\310\336\037\000\320\336\037\001\"\246\005\n\024InternalRequestUn"
+    "ion\0224\n\010contains\030\001 \001(\0132 .cockroach.proto."
+    "ContainsRequestH\000\022*\n\003get\030\002 \001(\0132\033.cockroa"
+    "ch.proto.GetRequestH\000\022*\n\003put\030\003 \001(\0132\033.coc"
+    "kroach.proto.PutRequestH\000\022A\n\017conditional"
+    "_put\030\004 \001(\0132&.cockroach.proto.Conditional"
+    "PutRequestH\000\0226\n\tincrement\030\005 \001(\0132!.cockro"
+    "ach.proto.IncrementRequestH\000\0220\n\006delete\030\006"
+    " \001(\0132\036.cockroach.proto.DeleteRequestH\000\022;"
+    "\n\014delete_range\030\007 \001(\0132#.cockroach.proto.D"
+    "eleteRangeRequestH\000\022,\n\004scan\030\010 \001(\0132\034.cock"
+    "roach.proto.ScanRequestH\000\022A\n\017end_transac"
+    "tion\030\t \001(\0132&.cockroach.proto.EndTransact"
+    "ionRequestH\000\022D\n\021internal_push_txn\030\036 \001(\0132"
+    "\'.cockroach.proto.InternalPushTxnRequest"
+    "H\000\022P\n\027internal_resolve_intent\030\037 \001(\0132-.co"
+    "ckroach.proto.InternalResolveIntentReque"
+    "stH\000:\004\310\240\037\001B\007\n\005value\"\262\005\n\025InternalResponse"
+    "Union\0225\n\010contains\030\001 \001(\0132!.cockroach.prot"
+    "o.ContainsResponseH\000\022+\n\003get\030\002 \001(\0132\034.cock"
+    "roach.proto.GetResponseH\000\022+\n\003put\030\003 \001(\0132\034"
+    ".cockroach.proto.PutResponseH\000\022B\n\017condit"
+    "ional_put\030\004 \001(\0132\'.cockroach.proto.Condit"
+    "ionalPutResponseH\000\0227\n\tincrement\030\005 \001(\0132\"."
+    "cockroach.proto.IncrementResponseH\000\0221\n\006d"
+    "elete\030\006 \001(\0132\037.cockroach.proto.DeleteResp"
+    "onseH\000\022<\n\014delete_range\030\007 \001(\0132$.cockroach"
+    ".proto.DeleteRangeResponseH\000\022-\n\004scan\030\010 \001"
+    "(\0132\035.cockroach.proto.ScanResponseH\000\022B\n\017e"
+    "nd_transaction\030\t \001(\0132\'.cockroach.proto.E"
+    "ndTransactionResponseH\000\022E\n\021internal_push"
+    "_txn\030\036 \001(\0132(.cockroach.proto.InternalPus"
+    "hTxnResponseH\000\022Q\n\027internal_resolve_inten"
+    "t\030\037 \001(\0132..cockroach.proto.InternalResolv"
+    "eIntentResponseH\000:\004\310\240\037\001B\007\n\005value\"\217\001\n\024Int"
+    "ernalBatchRequest\0228\n\006header\030\001 \001(\0132\036.cock"
+    "roach.proto.RequestHeaderB\010\310\336\037\000\320\336\037\001\022=\n\010r"
+    "equests\030\002 \003(\0132%.cockroach.proto.Internal"
+    "RequestUnionB\004\310\336\037\000\"\223\001\n\025InternalBatchResp"
+    "onse\0229\n\006header\030\001 \001(\0132\037.cockroach.proto.R"
+    "esponseHeaderB\010\310\336\037\000\320\336\037\001\022\?\n\tresponses\030\002 \003"
+    "(\0132&.cockroach.proto.InternalResponseUni"
+    "onB\004\310\336\037\000\"\213\007\n\024ReadWriteCmdResponse\022+\n\003put"
+    "\030\001 \001(\0132\034.cockroach.proto.PutResponseH\000\022B"
+    "\n\017conditional_put\030\002 \001(\0132\'.cockroach.prot"
+    "o.ConditionalPutResponseH\000\0227\n\tincrement\030"
+    "\003 \001(\0132\".cockroach.proto.IncrementRespons"
+    "eH\000\0221\n\006delete\030\004 \001(\0132\037.cockroach.proto.De"
+    "leteResponseH\000\022<\n\014delete_range\030\005 \001(\0132$.c"
+    "ockroach.proto.DeleteRangeResponseH\000\022B\n\017"
+    "end_transaction\030\006 \001(\0132\'.cockroach.proto."
+    "EndTransactionResponseH\000\022O\n\026internal_hea"
+    "rtbeat_txn\030\n \001(\0132-.cockroach.proto.Inter"
+    "nalHeartbeatTxnResponseH\000\022E\n\021internal_pu"
+    "sh_txn\030\013 \001(\0132(.cockroach.proto.InternalP"
+    "ushTxnResponseH\000\022Q\n\027internal_resolve_int"
+    "ent\030\014 \001(\0132..cockroach.proto.InternalReso"
+    "lveIntentResponseH\000\022@\n\016internal_merge\030\r "
+    "\001(\0132&.cockroach.proto.InternalMergeRespo"
+    "nseH\000\022M\n\025internal_truncate_log\030\016 \001(\0132,.c"
+    "ockroach.proto.InternalTruncateLogRespon"
+    "seH\000\022:\n\013internal_gc\030\017 \001(\0132#.cockroach.pr"
+    "oto.InternalGCResponseH\000\022M\n\025internal_lea"
+    "der_lease\030\020 \001(\0132,.cockroach.proto.Intern"
+    "alLeaderLeaseResponseH\000:\004\310\240\037\001B\007\n\005value\"\343"
+    "\t\n\030InternalRaftCommandUnion\0224\n\010contains\030"
+    "\001 \001(\0132 .cockroach.proto.ContainsRequestH"
+    "\000\022*\n\003get\030\002 \001(\0132\033.cockroach.proto.GetRequ"
+    "estH\000\022*\n\003put\030\003 \001(\0132\033.cockroach.proto.Put"
+    "RequestH\000\022A\n\017conditional_put\030\004 \001(\0132&.coc"
+    "kroach.proto.ConditionalPutRequestH\000\0226\n\t"
+    "increment\030\005 \001(\0132!.cockroach.proto.Increm"
+    "entRequestH\000\0220\n\006delete\030\006 \001(\0132\036.cockroach"
+    ".proto.DeleteRequestH\000\022;\n\014delete_range\030\007"
+    " \001(\0132#.cockroach.proto.DeleteRangeReques"
+    "tH\000\022,\n\004scan\030\010 \001(\0132\034.cockroach.proto.Scan"
+    "RequestH\000\022A\n\017end_transaction\030\t \001(\0132&.coc"
+    "kroach.proto.EndTransactionRequestH\000\022.\n\005"
+    "batch\030\036 \001(\0132\035.cockroach.proto.BatchReque"
+    "stH\000\022L\n\025internal_range_lookup\030\037 \001(\0132+.co"
+    "ckroach.proto.InternalRangeLookupRequest"
+    "H\000\022N\n\026internal_heartbeat_txn\030  \001(\0132,.coc"
+    "kroach.proto.InternalHeartbeatTxnRequest"
+    "H\000\022D\n\021internal_push_txn\030! \001(\0132\'.cockroac"
+    "h.proto.InternalPushTxnRequestH\000\022P\n\027inte"
+    "rnal_resolve_intent\030\" \001(\0132-.cockroach.pr"
+    "oto.InternalResolveIntentRequestH\000\022H\n\027in"
+    "ternal_merge_response\030# \001(\0132%.cockroach."
+    "proto.InternalMergeRequestH\000\022L\n\025internal"
+    "_truncate_log\030$ \001(\0132+.cockroach.proto.In"
+    "ternalTruncateLogRequestH\000\022I\n\013internal_g"
+    "c\030% \001(\0132\".cockroach.proto.InternalGCRequ"
+    "estB\016\342\336\037\nInternalGCH\000\022E\n\016internal_lease\030"
+    "& \001(\0132+.cockroach.proto.InternalLeaderLe"
+    "aseRequestH\000\022\?\n\016internal_batch\030\' \001(\0132%.c"
+    "ockroach.proto.InternalBatchRequestH\000:\004\310"
+    "\240\037\001B\007\n\005value\"\242\001\n\023InternalRaftCommand\022\037\n\007"
+    "raft_id\030\001 \001(\003B\016\310\336\037\000\342\336\037\006RaftID\022,\n\016origin_"
+    "node_id\030\002 \001(\004B\024\310\336\037\000\342\336\037\014OriginNodeID\022<\n\003c"
+    "md\030\003 \001(\0132).cockroach.proto.InternalRaftC"
+    "ommandUnionB\004\310\336\037\000\"D\n\022RaftMessageRequest\022"
+    "!\n\010group_id\030\001 \001(\004B\017\310\336\037\000\342\336\037\007GroupID\022\013\n\003ms"
+    "g\030\002 \001(\014\"\025\n\023RaftMessageResponse\"\236\001\n\026Inter"
+    "nalTimeSeriesData\022#\n\025start_timestamp_nan"
+    "os\030\001 \001(\003B\004\310\336\037\000\022#\n\025sample_duration_nanos\030"
+    "\002 \001(\003B\004\310\336\037\000\022:\n\007samples\030\003 \003(\0132).cockroach"
+    ".proto.InternalTimeSeriesSample\"\320\001\n\030Inte"
+    "rnalTimeSeriesSample\022\024\n\006offset\030\001 \001(\005B\004\310\336"
+    "\037\000\022\027\n\tint_count\030\002 \001(\rB\004\310\336\037\000\022\017\n\007int_sum\030\003"
+    " \001(\003\022\017\n\007int_max\030\004 \001(\003\022\017\n\007int_min\030\005 \001(\003\022\031"
+    "\n\013float_count\030\006 \001(\rB\004\310\336\037\000\022\021\n\tfloat_sum\030\007"
+    " \001(\002\022\021\n\tfloat_max\030\010 \001(\002\022\021\n\tfloat_min\030\t \001"
+    "(\002\"=\n\022RaftTruncatedState\022\023\n\005index\030\001 \001(\004B"
+    "\004\310\336\037\000\022\022\n\004term\030\002 \001(\004B\004\310\336\037\000\"z\n\020RaftSnapsho"
+    "tData\022>\n\002KV\030\001 \003(\0132*.cockroach.proto.Raft"
+    "SnapshotData.KeyValueB\006\342\336\037\002KV\032&\n\010KeyValu"
+    "e\022\013\n\003key\030\001 \001(\014\022\r\n\005value\030\002 \001(\014*O\n\013PushTxn"
+    "Type\022\022\n\016PUSH_TIMESTAMP\020\000\022\r\n\tABORT_TXN\020\001\022"
+    "\027\n\023CONFIRM_NOT_PENDING\020\002\032\004\210\243\036\000*%\n\021Intern"
+    "alValueType\022\n\n\006_CR_TS\020\001\032\004\210\243\036\000B\023Z\005proto\340\342"
+    "\036\001\310\342\036\001\320\342\036\001", 6970);
   ::google::protobuf::MessageFactory::InternalRegisterGeneratedFile(
     "cockroach/proto/internal.proto", &protobuf_RegisterTypes);
   InternalRangeLookupRequest::default_instance_ = new InternalRangeLookupRequest();
@@ -1151,6 +1156,21 @@ struct StaticDescriptorInitializer_cockroach_2fproto_2finternal_2eproto {
     protobuf_AddDesc_cockroach_2fproto_2finternal_2eproto();
   }
 } static_descriptor_initializer_cockroach_2fproto_2finternal_2eproto_;
+const ::google::protobuf::EnumDescriptor* PushTxnType_descriptor() {
+  protobuf_AssignDescriptorsOnce();
+  return PushTxnType_descriptor_;
+}
+bool PushTxnType_IsValid(int value) {
+  switch(value) {
+    case 0:
+    case 1:
+    case 2:
+      return true;
+    default:
+      return false;
+  }
+}
+
 const ::google::protobuf::EnumDescriptor* InternalValueType_descriptor() {
   protobuf_AssignDescriptorsOnce();
   return InternalValueType_descriptor_;
@@ -3024,7 +3044,7 @@ void InternalGCResponse::Swap(InternalGCResponse* other) {
 #ifndef _MSC_VER
 const int InternalPushTxnRequest::kHeaderFieldNumber;
 const int InternalPushTxnRequest::kPusheeTxnFieldNumber;
-const int InternalPushTxnRequest::kAbortFieldNumber;
+const int InternalPushTxnRequest::kPushTypeFieldNumber;
 const int InternalPushTxnRequest::kRangeLookupFieldNumber;
 #endif  // !_MSC_VER
 
@@ -3050,7 +3070,7 @@ void InternalPushTxnRequest::SharedCtor() {
   _cached_size_ = 0;
   header_ = NULL;
   pushee_txn_ = NULL;
-  abort_ = false;
+  push_type_ = 0;
   range_lookup_ = false;
   ::memset(_has_bits_, 0, sizeof(_has_bits_));
 }
@@ -3100,7 +3120,7 @@ void InternalPushTxnRequest::Clear() {
   } while (0)
 
   if (_has_bits_[0 / 32] & 15) {
-    ZR_(abort_, range_lookup_);
+    ZR_(push_type_, range_lookup_);
     if (has_header()) {
       if (header_ != NULL) header_->::cockroach::proto::RequestHeader::Clear();
     }
@@ -3147,18 +3167,23 @@ bool InternalPushTxnRequest::MergePartialFromCodedStream(
         } else {
           goto handle_unusual;
         }
-        if (input->ExpectTag(24)) goto parse_Abort;
+        if (input->ExpectTag(24)) goto parse_push_type;
         break;
       }
 
-      // optional bool Abort = 3;
+      // optional .cockroach.proto.PushTxnType push_type = 3;
       case 3: {
         if (tag == 24) {
-         parse_Abort:
+         parse_push_type:
+          int value;
           DO_((::google::protobuf::internal::WireFormatLite::ReadPrimitive<
-                   bool, ::google::protobuf::internal::WireFormatLite::TYPE_BOOL>(
-                 input, &abort_)));
-          set_has_abort();
+                   int, ::google::protobuf::internal::WireFormatLite::TYPE_ENUM>(
+                 input, &value)));
+          if (::cockroach::proto::PushTxnType_IsValid(value)) {
+            set_push_type(static_cast< ::cockroach::proto::PushTxnType >(value));
+          } else {
+            mutable_unknown_fields()->AddVarint(3, value);
+          }
         } else {
           goto handle_unusual;
         }
@@ -3218,9 +3243,10 @@ void InternalPushTxnRequest::SerializeWithCachedSizes(
       2, this->pushee_txn(), output);
   }
 
-  // optional bool Abort = 3;
-  if (has_abort()) {
-    ::google::protobuf::internal::WireFormatLite::WriteBool(3, this->abort(), output);
+  // optional .cockroach.proto.PushTxnType push_type = 3;
+  if (has_push_type()) {
+    ::google::protobuf::internal::WireFormatLite::WriteEnum(
+      3, this->push_type(), output);
   }
 
   // optional bool range_lookup = 4;
@@ -3252,9 +3278,10 @@ void InternalPushTxnRequest::SerializeWithCachedSizes(
         2, this->pushee_txn(), target);
   }
 
-  // optional bool Abort = 3;
-  if (has_abort()) {
-    target = ::google::protobuf::internal::WireFormatLite::WriteBoolToArray(3, this->abort(), target);
+  // optional .cockroach.proto.PushTxnType push_type = 3;
+  if (has_push_type()) {
+    target = ::google::protobuf::internal::WireFormatLite::WriteEnumToArray(
+      3, this->push_type(), target);
   }
 
   // optional bool range_lookup = 4;
@@ -3288,9 +3315,10 @@ int InternalPushTxnRequest::ByteSize() const {
           this->pushee_txn());
     }
 
-    // optional bool Abort = 3;
-    if (has_abort()) {
-      total_size += 1 + 1;
+    // optional .cockroach.proto.PushTxnType push_type = 3;
+    if (has_push_type()) {
+      total_size += 1 +
+        ::google::protobuf::internal::WireFormatLite::EnumSize(this->push_type());
     }
 
     // optional bool range_lookup = 4;
@@ -3331,8 +3359,8 @@ void InternalPushTxnRequest::MergeFrom(const InternalPushTxnRequest& from) {
     if (from.has_pushee_txn()) {
       mutable_pushee_txn()->::cockroach::proto::Transaction::MergeFrom(from.pushee_txn());
     }
-    if (from.has_abort()) {
-      set_abort(from.abort());
+    if (from.has_push_type()) {
+      set_push_type(from.push_type());
     }
     if (from.has_range_lookup()) {
       set_range_lookup(from.range_lookup());
@@ -3362,7 +3390,7 @@ void InternalPushTxnRequest::Swap(InternalPushTxnRequest* other) {
   if (other != this) {
     std::swap(header_, other->header_);
     std::swap(pushee_txn_, other->pushee_txn_);
-    std::swap(abort_, other->abort_);
+    std::swap(push_type_, other->push_type_);
     std::swap(range_lookup_, other->range_lookup_);
     std::swap(_has_bits_[0], other->_has_bits_[0]);
     _unknown_fields_.Swap(&other->_unknown_fields_);

--- a/storage/engine/cockroach/proto/internal.pb.h
+++ b/storage/engine/cockroach/proto/internal.pb.h
@@ -71,6 +71,26 @@ class RaftTruncatedState;
 class RaftSnapshotData;
 class RaftSnapshotData_KeyValue;
 
+enum PushTxnType {
+  PUSH_TIMESTAMP = 0,
+  ABORT_TXN = 1,
+  CONFIRM_NOT_PENDING = 2
+};
+bool PushTxnType_IsValid(int value);
+const PushTxnType PushTxnType_MIN = PUSH_TIMESTAMP;
+const PushTxnType PushTxnType_MAX = CONFIRM_NOT_PENDING;
+const int PushTxnType_ARRAYSIZE = PushTxnType_MAX + 1;
+
+const ::google::protobuf::EnumDescriptor* PushTxnType_descriptor();
+inline const ::std::string& PushTxnType_Name(PushTxnType value) {
+  return ::google::protobuf::internal::NameOfEnum(
+    PushTxnType_descriptor(), value);
+}
+inline bool PushTxnType_Parse(
+    const ::std::string& name, PushTxnType* value) {
+  return ::google::protobuf::internal::ParseNamedEnum<PushTxnType>(
+    PushTxnType_descriptor(), name, value);
+}
 enum InternalValueType {
   _CR_TS = 1
 };
@@ -804,12 +824,12 @@ class InternalPushTxnRequest : public ::google::protobuf::Message {
   inline ::cockroach::proto::Transaction* release_pushee_txn();
   inline void set_allocated_pushee_txn(::cockroach::proto::Transaction* pushee_txn);
 
-  // optional bool Abort = 3;
-  inline bool has_abort() const;
-  inline void clear_abort();
-  static const int kAbortFieldNumber = 3;
-  inline bool abort() const;
-  inline void set_abort(bool value);
+  // optional .cockroach.proto.PushTxnType push_type = 3;
+  inline bool has_push_type() const;
+  inline void clear_push_type();
+  static const int kPushTypeFieldNumber = 3;
+  inline ::cockroach::proto::PushTxnType push_type() const;
+  inline void set_push_type(::cockroach::proto::PushTxnType value);
 
   // optional bool range_lookup = 4;
   inline bool has_range_lookup() const;
@@ -824,8 +844,8 @@ class InternalPushTxnRequest : public ::google::protobuf::Message {
   inline void clear_has_header();
   inline void set_has_pushee_txn();
   inline void clear_has_pushee_txn();
-  inline void set_has_abort();
-  inline void clear_has_abort();
+  inline void set_has_push_type();
+  inline void clear_has_push_type();
   inline void set_has_range_lookup();
   inline void clear_has_range_lookup();
 
@@ -835,7 +855,7 @@ class InternalPushTxnRequest : public ::google::protobuf::Message {
   mutable int _cached_size_;
   ::cockroach::proto::RequestHeader* header_;
   ::cockroach::proto::Transaction* pushee_txn_;
-  bool abort_;
+  int push_type_;
   bool range_lookup_;
   friend void  protobuf_AddDesc_cockroach_2fproto_2finternal_2eproto();
   friend void protobuf_AssignDesc_cockroach_2fproto_2finternal_2eproto();
@@ -4209,28 +4229,29 @@ inline void InternalPushTxnRequest::set_allocated_pushee_txn(::cockroach::proto:
   // @@protoc_insertion_point(field_set_allocated:cockroach.proto.InternalPushTxnRequest.pushee_txn)
 }
 
-// optional bool Abort = 3;
-inline bool InternalPushTxnRequest::has_abort() const {
+// optional .cockroach.proto.PushTxnType push_type = 3;
+inline bool InternalPushTxnRequest::has_push_type() const {
   return (_has_bits_[0] & 0x00000004u) != 0;
 }
-inline void InternalPushTxnRequest::set_has_abort() {
+inline void InternalPushTxnRequest::set_has_push_type() {
   _has_bits_[0] |= 0x00000004u;
 }
-inline void InternalPushTxnRequest::clear_has_abort() {
+inline void InternalPushTxnRequest::clear_has_push_type() {
   _has_bits_[0] &= ~0x00000004u;
 }
-inline void InternalPushTxnRequest::clear_abort() {
-  abort_ = false;
-  clear_has_abort();
+inline void InternalPushTxnRequest::clear_push_type() {
+  push_type_ = 0;
+  clear_has_push_type();
 }
-inline bool InternalPushTxnRequest::abort() const {
-  // @@protoc_insertion_point(field_get:cockroach.proto.InternalPushTxnRequest.Abort)
-  return abort_;
+inline ::cockroach::proto::PushTxnType InternalPushTxnRequest::push_type() const {
+  // @@protoc_insertion_point(field_get:cockroach.proto.InternalPushTxnRequest.push_type)
+  return static_cast< ::cockroach::proto::PushTxnType >(push_type_);
 }
-inline void InternalPushTxnRequest::set_abort(bool value) {
-  set_has_abort();
-  abort_ = value;
-  // @@protoc_insertion_point(field_set:cockroach.proto.InternalPushTxnRequest.Abort)
+inline void InternalPushTxnRequest::set_push_type(::cockroach::proto::PushTxnType value) {
+  assert(::cockroach::proto::PushTxnType_IsValid(value));
+  set_has_push_type();
+  push_type_ = value;
+  // @@protoc_insertion_point(field_set:cockroach.proto.InternalPushTxnRequest.push_type)
 }
 
 // optional bool range_lookup = 4;
@@ -8088,6 +8109,11 @@ RaftSnapshotData::mutable_kv() {
 namespace google {
 namespace protobuf {
 
+template <> struct is_proto_enum< ::cockroach::proto::PushTxnType> : ::google::protobuf::internal::true_type {};
+template <>
+inline const EnumDescriptor* GetEnumDescriptor< ::cockroach::proto::PushTxnType>() {
+  return ::cockroach::proto::PushTxnType_descriptor();
+}
 template <> struct is_proto_enum< ::cockroach::proto::InternalValueType> : ::google::protobuf::internal::true_type {};
 template <>
 inline const EnumDescriptor* GetEnumDescriptor< ::cockroach::proto::InternalValueType>() {

--- a/storage/engine/cockroach/proto/internal.pb.h
+++ b/storage/engine/cockroach/proto/internal.pb.h
@@ -74,11 +74,11 @@ class RaftSnapshotData_KeyValue;
 enum PushTxnType {
   PUSH_TIMESTAMP = 0,
   ABORT_TXN = 1,
-  CONFIRM_NOT_PENDING = 2
+  CLEANUP_TXN = 2
 };
 bool PushTxnType_IsValid(int value);
 const PushTxnType PushTxnType_MIN = PUSH_TIMESTAMP;
-const PushTxnType PushTxnType_MAX = CONFIRM_NOT_PENDING;
+const PushTxnType PushTxnType_MAX = CLEANUP_TXN;
 const int PushTxnType_ARRAYSIZE = PushTxnType_MAX + 1;
 
 const ::google::protobuf::EnumDescriptor* PushTxnType_descriptor();

--- a/storage/engine/cockroach/proto/internal.pb.h
+++ b/storage/engine/cockroach/proto/internal.pb.h
@@ -160,12 +160,21 @@ class InternalRangeLookupRequest : public ::google::protobuf::Message {
   inline ::google::protobuf::int32 max_ranges() const;
   inline void set_max_ranges(::google::protobuf::int32 value);
 
+  // optional bool ignore_intents = 3;
+  inline bool has_ignore_intents() const;
+  inline void clear_ignore_intents();
+  static const int kIgnoreIntentsFieldNumber = 3;
+  inline bool ignore_intents() const;
+  inline void set_ignore_intents(bool value);
+
   // @@protoc_insertion_point(class_scope:cockroach.proto.InternalRangeLookupRequest)
  private:
   inline void set_has_header();
   inline void clear_has_header();
   inline void set_has_max_ranges();
   inline void clear_has_max_ranges();
+  inline void set_has_ignore_intents();
+  inline void clear_has_ignore_intents();
 
   ::google::protobuf::UnknownFieldSet _unknown_fields_;
 
@@ -173,6 +182,7 @@ class InternalRangeLookupRequest : public ::google::protobuf::Message {
   mutable int _cached_size_;
   ::cockroach::proto::RequestHeader* header_;
   ::google::protobuf::int32 max_ranges_;
+  bool ignore_intents_;
   friend void  protobuf_AddDesc_cockroach_2fproto_2finternal_2eproto();
   friend void protobuf_AssignDesc_cockroach_2fproto_2finternal_2eproto();
   friend void protobuf_ShutdownFile_cockroach_2fproto_2finternal_2eproto();
@@ -801,6 +811,13 @@ class InternalPushTxnRequest : public ::google::protobuf::Message {
   inline bool abort() const;
   inline void set_abort(bool value);
 
+  // optional bool range_lookup = 4;
+  inline bool has_range_lookup() const;
+  inline void clear_range_lookup();
+  static const int kRangeLookupFieldNumber = 4;
+  inline bool range_lookup() const;
+  inline void set_range_lookup(bool value);
+
   // @@protoc_insertion_point(class_scope:cockroach.proto.InternalPushTxnRequest)
  private:
   inline void set_has_header();
@@ -809,6 +826,8 @@ class InternalPushTxnRequest : public ::google::protobuf::Message {
   inline void clear_has_pushee_txn();
   inline void set_has_abort();
   inline void clear_has_abort();
+  inline void set_has_range_lookup();
+  inline void clear_has_range_lookup();
 
   ::google::protobuf::UnknownFieldSet _unknown_fields_;
 
@@ -817,6 +836,7 @@ class InternalPushTxnRequest : public ::google::protobuf::Message {
   ::cockroach::proto::RequestHeader* header_;
   ::cockroach::proto::Transaction* pushee_txn_;
   bool abort_;
+  bool range_lookup_;
   friend void  protobuf_AddDesc_cockroach_2fproto_2finternal_2eproto();
   friend void protobuf_AssignDesc_cockroach_2fproto_2finternal_2eproto();
   friend void protobuf_ShutdownFile_cockroach_2fproto_2finternal_2eproto();
@@ -3632,6 +3652,30 @@ inline void InternalRangeLookupRequest::set_max_ranges(::google::protobuf::int32
   // @@protoc_insertion_point(field_set:cockroach.proto.InternalRangeLookupRequest.max_ranges)
 }
 
+// optional bool ignore_intents = 3;
+inline bool InternalRangeLookupRequest::has_ignore_intents() const {
+  return (_has_bits_[0] & 0x00000004u) != 0;
+}
+inline void InternalRangeLookupRequest::set_has_ignore_intents() {
+  _has_bits_[0] |= 0x00000004u;
+}
+inline void InternalRangeLookupRequest::clear_has_ignore_intents() {
+  _has_bits_[0] &= ~0x00000004u;
+}
+inline void InternalRangeLookupRequest::clear_ignore_intents() {
+  ignore_intents_ = false;
+  clear_has_ignore_intents();
+}
+inline bool InternalRangeLookupRequest::ignore_intents() const {
+  // @@protoc_insertion_point(field_get:cockroach.proto.InternalRangeLookupRequest.ignore_intents)
+  return ignore_intents_;
+}
+inline void InternalRangeLookupRequest::set_ignore_intents(bool value) {
+  set_has_ignore_intents();
+  ignore_intents_ = value;
+  // @@protoc_insertion_point(field_set:cockroach.proto.InternalRangeLookupRequest.ignore_intents)
+}
+
 // -------------------------------------------------------------------
 
 // InternalRangeLookupResponse
@@ -4187,6 +4231,30 @@ inline void InternalPushTxnRequest::set_abort(bool value) {
   set_has_abort();
   abort_ = value;
   // @@protoc_insertion_point(field_set:cockroach.proto.InternalPushTxnRequest.Abort)
+}
+
+// optional bool range_lookup = 4;
+inline bool InternalPushTxnRequest::has_range_lookup() const {
+  return (_has_bits_[0] & 0x00000008u) != 0;
+}
+inline void InternalPushTxnRequest::set_has_range_lookup() {
+  _has_bits_[0] |= 0x00000008u;
+}
+inline void InternalPushTxnRequest::clear_has_range_lookup() {
+  _has_bits_[0] &= ~0x00000008u;
+}
+inline void InternalPushTxnRequest::clear_range_lookup() {
+  range_lookup_ = false;
+  clear_has_range_lookup();
+}
+inline bool InternalPushTxnRequest::range_lookup() const {
+  // @@protoc_insertion_point(field_get:cockroach.proto.InternalPushTxnRequest.range_lookup)
+  return range_lookup_;
+}
+inline void InternalPushTxnRequest::set_range_lookup(bool value) {
+  set_has_range_lookup();
+  range_lookup_ = value;
+  // @@protoc_insertion_point(field_set:cockroach.proto.InternalPushTxnRequest.range_lookup)
 }
 
 // -------------------------------------------------------------------

--- a/storage/engine/mvcc.go
+++ b/storage/engine/mvcc.go
@@ -1088,7 +1088,7 @@ func MVCCResolveWriteIntent(engine Engine, ms *proto.MVCCStats, key proto.Key, t
 		return nil
 	}
 
-	// This method shouldn't be called with this instance, but there's
+	// This method shouldn't be called in this instance, but there's
 	// nothing to do if the epochs match and the state is still PENDING.
 	if txn.Status == proto.PENDING && meta.Txn.Epoch == txn.Epoch {
 		return nil

--- a/storage/engine/rocksdb.go
+++ b/storage/engine/rocksdb.go
@@ -109,7 +109,11 @@ func (r *RocksDB) Close() {
 	if atomic.AddInt32(&r.refcount, -1) > 0 {
 		return
 	}
-	log.Infof("closing rocksdb instance at %q", r.dir)
+	if len(r.dir) == 0 {
+		log.Infof("closing in-memory rocksdb instance")
+	} else {
+		log.Infof("closing rocksdb instance at %q", r.dir)
+	}
 	if r.rdb != nil {
 		C.DBClose(r.rdb)
 		r.rdb = nil

--- a/storage/gc_queue.go
+++ b/storage/gc_queue.go
@@ -257,7 +257,7 @@ func (gcq *gcQueue) resolveIntent(rng *Range, key proto.Key, meta *proto.MVCCMet
 			Txn:          nil,
 		},
 		PusheeTxn: *meta.Txn,
-		Abort:     true,
+		PushType:  proto.ABORT_TXN,
 	}
 	pushReply := &proto.InternalPushTxnResponse{}
 	if err := rng.rm.DB().Run(client.Call{Args: pushArgs, Reply: pushReply}); err != nil {

--- a/storage/store.go
+++ b/storage/store.go
@@ -993,7 +993,9 @@ func (s *Store) ExecuteCmd(args proto.Request, reply proto.Response) error {
 		// because this is the code path with the requesting client
 		// waiting. We don't want every replica to attempt to resolve the
 		// intent independently, so we can't do it in Range.executeCmd.
-		err = s.maybeResolveWriteIntentError(rng, args, reply)
+		if wiErr, ok := err.(*proto.WriteIntentError); ok {
+			err = s.resolveWriteIntentError(wiErr, rng, args, reply)
+		}
 
 		switch t := err.(type) {
 		case *proto.WriteTooOldError:
@@ -1005,12 +1007,25 @@ func (s *Store) ExecuteCmd(args proto.Request, reply proto.Response) error {
 			// If write intent error is resolved, exit retry/backoff loop to
 			// immediately retry.
 			if t.Resolved {
+				// If read was inconsistent & we resolved, change to consistent
+				// to allow outstanding resolves to finish before reading.
+				if header.ReadConsistency == proto.INCONSISTENT {
+					header.ReadConsistency = proto.CONSISTENT
+				}
 				return util.RetryReset, nil
+			} else if header.ReadConsistency == proto.INCONSISTENT {
+				// If read was inconsistent, don't retry, clear the error and
+				// return the inconsistent results.
+				reply.Header().Error = nil
+				return util.RetryBreak, nil
 			}
+
 			// Otherwise, update timestamp on read/write and backoff / retry.
-			if proto.IsWrite(args) && header.Timestamp.Less(t.Txn.Timestamp) {
-				header.Timestamp = t.Txn.Timestamp
-				header.Timestamp.Logical++
+			for _, intent := range t.Intents {
+				if proto.IsWrite(args) && header.Timestamp.Less(intent.Txn.Timestamp) {
+					header.Timestamp = intent.Txn.Timestamp
+					header.Timestamp.Logical++
+				}
 			}
 			return util.RetryContinue, nil
 		}
@@ -1027,39 +1042,38 @@ func (s *Store) ExecuteCmd(args proto.Request, reply proto.Response) error {
 	return reply.Header().GoError()
 }
 
-// maybeResolveWriteIntentError checks the reply's error. If the error
-// is a writeIntentError, it tries to push the conflicting
-// transaction: either move its timestamp forward on a read/write
-// conflict, or abort it on a write/write conflict. If the push
-// succeeds, we immediately issue a resolve intent command and set the
-// error's Resolved flag to true so the client retries the command
+// resolveWriteIntentError tries to push the conflicting transaction:
+// either move its timestamp forward on a read/write conflict, or
+// abort it on a write/write conflict. If the push succeeds, we
+// immediately issue a resolve intent command and set the error's
+// Resolved flag to true so the client retries the command
 // immediately. If the push fails, we set the error's Resolved flag to
 // false so that the client backs off before reissuing the command.
-func (s *Store) maybeResolveWriteIntentError(rng *Range, args proto.Request, reply proto.Response) error {
-	err := reply.Header().GoError()
-	wiErr, ok := err.(*proto.WriteIntentError)
-	if !ok {
-		return err
-	}
-
+func (s *Store) resolveWriteIntentError(wiErr *proto.WriteIntentError,
+	rng *Range, args proto.Request, reply proto.Response) error {
 	log.V(1).Infof("resolving write intent on %s %q: %s", args.Method(), args.Header().Key, wiErr)
 
-	// Attempt to push the transaction which created the conflicting intent.
-	pushArgs := &proto.InternalPushTxnRequest{
-		RequestHeader: proto.RequestHeader{
-			Timestamp:    args.Header().Timestamp,
-			Key:          wiErr.Txn.Key,
-			User:         args.Header().User,
-			UserPriority: args.Header().UserPriority,
-			Txn:          args.Header().Txn,
-		},
-		PusheeTxn: wiErr.Txn,
-		Abort:     proto.IsWrite(args), // abort if cmd is write
+	// Attempt to push the transaction(s) which created the conflicting intent(s).
+	bArgs := &proto.InternalBatchRequest{}
+	bReply := &proto.InternalBatchResponse{}
+	for _, intent := range wiErr.Intents {
+		pushArgs := &proto.InternalPushTxnRequest{
+			RequestHeader: proto.RequestHeader{
+				Timestamp:    args.Header().Timestamp,
+				Key:          intent.Txn.Key,
+				User:         args.Header().User,
+				UserPriority: args.Header().UserPriority,
+				Txn:          args.Header().Txn,
+			},
+			PusheeTxn:   intent.Txn,
+			Abort:       proto.IsWrite(args), // abort if cmd is write
+			RangeLookup: args.Method() == proto.InternalRangeLookup,
+		}
+		bArgs.Add(pushArgs)
 	}
-	pushReply := &proto.InternalPushTxnResponse{}
-	s.ctx.DB.Run(client.Call{Args: pushArgs, Reply: pushReply})
-	if pushErr := pushReply.GoError(); pushErr != nil {
-		log.V(1).Infof("push %q failed: %s", pushArgs.Header().Key, pushErr)
+	// Run all pushes in parallel.
+	if pushErr := s.ctx.DB.Run(client.Call{Args: bArgs, Reply: bReply}); pushErr != nil {
+		log.V(1).Infof("pushes for %+v failed: %s", wiErr.Intents, pushErr)
 
 		// For write/write conflicts within a transaction, propagate the
 		// push failure, not the original write intent error. The push
@@ -1072,26 +1086,29 @@ func (s *Store) maybeResolveWriteIntentError(rng *Range, args proto.Request, rep
 		// For read/write conflicts, return the write intent error which
 		// engages backoff/retry (with !Resolved). We don't need to
 		// restart the txn, only resend the read with a backoff.
-		return err
+		return wiErr
 	}
 	wiErr.Resolved = true // success!
 
-	// We pushed the transaction successfully, so resolve the intent.
-	resolveArgs := &proto.InternalResolveIntentRequest{
-		RequestHeader: proto.RequestHeader{
-			// Use the pushee's timestamp, which might be lower than the
-			// pusher's request timestamp. No need to push the intent higher
-			// than the pushee's txn!
-			Timestamp: pushReply.PusheeTxn.Timestamp,
-			Key:       wiErr.Key,
-			User:      UserRoot,
-			Txn:       pushReply.PusheeTxn,
-		},
-	}
-	resolveReply := &proto.InternalResolveIntentResponse{}
-	// Add resolve command with wait=false to add to Raft but not wait for completion.
-	if resolveErr := rng.AddCmd(resolveArgs, resolveReply, false); resolveErr != nil {
-		log.Warningf("resolve of key %q failed: %s", wiErr.Key, resolveErr)
+	// We pushed the transaction(s) successfully, so resolve the intent(s).
+	for i, intent := range wiErr.Intents {
+		pushReply := bReply.Responses[i].GetValue().(*proto.InternalPushTxnResponse)
+		resolveArgs := &proto.InternalResolveIntentRequest{
+			RequestHeader: proto.RequestHeader{
+				// Use the pushee's timestamp, which might be lower than the
+				// pusher's request timestamp. No need to push the intent higher
+				// than the pushee's txn!
+				Timestamp: pushReply.PusheeTxn.Timestamp,
+				Key:       intent.Key,
+				User:      UserRoot,
+				Txn:       pushReply.PusheeTxn,
+			},
+		}
+		resolveReply := &proto.InternalResolveIntentResponse{}
+		// Add resolve command with wait=false to add to Raft but not wait for completion.
+		if resolveErr := rng.AddCmd(resolveArgs, resolveReply, false); resolveErr != nil {
+			return resolveErr
+		}
 	}
 
 	return wiErr

--- a/storage/store.go
+++ b/storage/store.go
@@ -1005,7 +1005,7 @@ func (s *Store) ExecuteCmd(args proto.Request, reply proto.Response) error {
 				reply.Header().Error = nil
 				return util.RetryBreak, nil
 			}
-			var pushType proto.PushTxnType
+			pushType := proto.PUSH_TIMESTAMP
 			if proto.IsWrite(args) {
 				pushType = proto.ABORT_TXN
 			}

--- a/storage/store_test.go
+++ b/storage/store_test.go
@@ -1144,8 +1144,8 @@ func TestStoreReadInconsistent(t *testing.T) {
 func TestStoreScanIntents(t *testing.T) {
 	defer leaktest.AfterTest(t)
 	store, _, stopper := createTestStore(t)
-	defer stopper.Stop()
 	defer func() { TestingCommandFilter = nil }()
+	defer stopper.Stop()
 
 	testCases := []struct {
 		consistent bool


### PR DESCRIPTION
...ds.

Previously, inconsistent reads would simply ignore write intents. This is
not correct for two reasons. The biggest is that we do range lookups
with inconsistent reads. If a dangling intent is left on a meta record,
this means that we'd never have a way to get to the up-to-date meta
record, which might contain the latest information about a split, merge
or replica change. The second, smaller reason is that keys which are
only read inconsistently (say for performance) would have to wait for
a GC event in order to be resolved, which could be a long time.

This change does two things:
- Changes MVCC to continue a scan in the face of write intent errors
  and batch up all of them into a list of intents, to be resolved in
  parallel. Inconsistent reads continue, as before, in spite of intents,
  but now return a write intent error containing all intents encountered.
- At the store level, we now formulate an internal batch command to
  do this efficiently.

There's a big caveat which is documented in the code related to infinte
loops caused by intents encountered on range meta records. The basic
gist is that the intent is encountered on range lookup, which then
causes the store to push the txn, which causes the distributed sender
to lookup the txn. Since the txn record is always located on the range
which the meta record with the intent points to, this would in turn
cause another write intent error, and the cycle would repeat. The
solution to this is hairy and makes me nervous, but I couldn't find
any less obnoxious way.

TODO: a unittest which does the following:
- Split a range
- Ignore intent resolves for meta records
- Send a get to the second half of the range; this would normally
  cause the infinite attempts to resolve.
