### PR TITLE
Vivek/banktransfer

### DIFF
--- a/examples/bank/bank.go
+++ b/examples/bank/bank.go
@@ -36,7 +36,7 @@ import (
 	"github.com/cockroachdb/cockroach/util/log"
 )
 
-var useTransaction = flag.Bool("use_transaction", true, "Turn off to disable transaction.")
+var useTransaction = flag.Bool("use-transaction", true, "Turn off to disable transaction.")
 
 // Makes an id string from an id int.
 func makeAccountID(id int) []byte {
@@ -67,96 +67,19 @@ func readInt64(call client.Call) (int64, error) {
 	return 0, nil
 }
 
-// moveMoneyTransaction() moves an amount between two accounts in a transaction
-// if the amount is available in the from account. Returns true on success.
-func (bank *Bank) moveMoneyTransaction(from, to []byte, amount int64) bool {
-	// Early exit when from == to
-	if bytes.Compare(from, to) == 0 {
-		return true
-	}
-	txnOpts := &client.TransactionOptions{Name: fmt.Sprintf("Transferring %s-%s-%d", from, to, amount)}
-	err := bank.kvClient.RunTransaction(txnOpts, func(txn *client.Txn) error {
-		fromGet := client.Get(proto.Key(from))
-		toGet := client.Get(proto.Key(to))
-		if err := txn.Run(fromGet, toGet); err != nil {
-			return err
-		}
-		// Read from value.
-		fromValue, err := readInt64(fromGet)
-		if err != nil {
-			return err
-		}
-		// Ensure there is enough cash.
-		if fromValue < amount {
-			return nil
-		}
-		// Read to value.
-		toValue, errRead := readInt64(toGet)
-		if errRead != nil {
-			return errRead
-		}
-		// Update both accounts.
-		txn.Prepare(client.Put(proto.Key(from), []byte(fmt.Sprintf("%d", fromValue-amount))),
-			client.Put(proto.Key(to), []byte(fmt.Sprintf("%d", toValue+amount))))
-		return nil
-	})
-	if err != nil {
-		log.Fatal(err)
-	}
-	atomic.AddInt32(&bank.numTransfers, 1)
-	return true
-}
-
-// moveMoneyWithoutTransaction() moves an amount between two accounts without the
-// use of a transaction, if the amount is available in the from account.
-// Returns true on success.
-func (bank *Bank) moveMoney(from, to []byte, amount int64) bool {
-	// Early exit when from == to
-	if bytes.Compare(from, to) == 0 {
-		return true
-	}
-	fromGet := client.Get(proto.Key(from))
-	toGet := client.Get(proto.Key(to))
-	if err := bank.kvClient.Run(fromGet, toGet); err != nil {
-		log.Fatal(err)
-		return false
-	}
-	// Read from value.
-	fromValue, err := readInt64(fromGet)
-	if err != nil {
-		log.Fatal(err)
-		return false
-	}
-	// Ensure there is enough cash.
-	if fromValue < amount {
-		return false
-	}
-	// Read to value.
-	toValue, errRead := readInt64(toGet)
-	if errRead != nil {
-		log.Fatal(errRead)
-		return false
-	}
-	// Update both accounts.
-	bank.kvClient.Run(client.Put(proto.Key(from), []byte(fmt.Sprintf("%d", fromValue-amount))),
-		client.Put(proto.Key(to), []byte(fmt.Sprintf("%d", toValue+amount))))
-	atomic.AddInt32(&bank.numTransfers, 1)
-	return true
-}
-
 // Read the balances in all the accounts and return them.
 func (bank *Bank) readAllAccountsWithScan() []int64 {
 	balances := make([]int64, bank.numAccounts)
 	txnOpts := &client.TransactionOptions{Name: "Reading all balances"}
 	err := bank.kvClient.RunTransaction(txnOpts, func(txn *client.Txn) error {
-		call := client.Scan(proto.Key(makeAccountID(0)), proto.Key(makeAccountID(bank.numAccounts)), int64(bank.numAccounts))
+		call := client.Scan(makeAccountID(0), makeAccountID(bank.numAccounts), int64(bank.numAccounts))
 		if err := txn.Run(call); err != nil {
 			log.Fatal(err)
 		}
 		// Copy responses into balances.
 		scan := call.Reply.(*proto.ScanResponse)
 		if len(scan.Rows) != bank.numAccounts {
-			log.Fatal(fmt.Errorf("Could only read %d of %d rows of the database.\n", len(scan.Rows), bank.numAccounts))
+			log.Fatalf("Could only read %d of %d rows of the database.\n", len(scan.Rows), bank.numAccounts)
 		}
 		for i := 0; i < bank.numAccounts; i++ {
 			value, err := strconv.ParseInt(string(scan.Rows[i].Value.Bytes), 10, 64)
@@ -180,7 +103,7 @@ func (bank *Bank) readAllAccounts() []int64 {
 	txnOpts := &client.TransactionOptions{Name: "Reading all balances"}
 	err := bank.kvClient.RunTransaction(txnOpts, func(txn *client.Txn) error {
 		for i := 0; i < bank.numAccounts; i++ {
-			calls[i] = client.Get(proto.Key(makeAccountID(i)))
+			calls[i] = client.Get(makeAccountID(i))
 		}
 		if err := txn.Run(calls...); err != nil {
 			log.Fatal(err)
@@ -207,12 +130,58 @@ func (bank *Bank) continuousMoneyTransfer() {
 	for {
 		from := makeAccountID(rand.Intn(bank.numAccounts))
 		to := makeAccountID(rand.Intn(bank.numAccounts))
-		exchange := rand.Int63n(100)
-		if *useTransaction {
-			bank.moveMoneyTransaction(from, to, exchange)
-		} else {
-			bank.moveMoney(from, to, exchange)
+		// Continue when from == to
+		if bytes.Equal(from, to) {
+			continue
 		}
+		exchangeAmount := rand.Int63n(100)
+		// transferMoney transfers exchangeAmount between the two accounts
+		// using transaction txn if its non nil
+		transferMoney := func(txn *client.Txn) error {
+			fromGet := client.Get(from)
+			toGet := client.Get(to)
+			if txn != nil {
+				if err := txn.Run(fromGet, toGet); err != nil {
+					return err
+				}
+			} else {
+				if err := bank.kvClient.Run(fromGet, toGet); err != nil {
+					return err
+				}
+			}
+			// Read from value.
+			fromValue, err := readInt64(fromGet)
+			if err != nil {
+				return err
+			}
+			// Ensure there is enough cash.
+			if fromValue < exchangeAmount {
+				return nil
+			}
+			// Read to value.
+			toValue, errRead := readInt64(toGet)
+			if errRead != nil {
+				return errRead
+			}
+			// Update both accounts.
+			fromPut := []byte(fmt.Sprintf("%d", fromValue-exchangeAmount))
+			toPut := []byte(fmt.Sprintf("%d", toValue+exchangeAmount))
+			if txn != nil {
+				txn.Prepare(client.Put(from, fromPut), client.Put(to, toPut))
+			} else {
+				bank.kvClient.Run(client.Put(from, fromPut), client.Put(to, toPut))
+			}
+			return nil
+		}
+		if *useTransaction {
+			txnOpts := &client.TransactionOptions{Name: fmt.Sprintf("Transferring %s-%s-%d", from, to, exchangeAmount)}
+			if err := bank.kvClient.RunTransaction(txnOpts, transferMoney); err != nil {
+				log.Fatal(err)
+			}
+		} else if err := transferMoney(nil); err != nil {
+			log.Fatal(err)
+		}
+		atomic.AddInt32(&bank.numTransfers, 1)
 	}
 }
 
@@ -220,7 +189,7 @@ func (bank *Bank) continuousMoneyTransfer() {
 func (bank *Bank) initBankAccounts(cash int64) {
 	calls := make([]client.Call, bank.numAccounts)
 	for i := 0; i < bank.numAccounts; i++ {
-		calls[i] = client.Put(proto.Key(makeAccountID(i)), []byte(fmt.Sprintf("%d", cash)))
+		calls[i] = client.Put(makeAccountID(i), []byte(fmt.Sprintf("%d", cash)))
 	}
 	if err := bank.kvClient.Run(calls...); err != nil {
 		log.Fatal(err)


### PR DESCRIPTION
@petermattis I've added in a flag to disable the use of a transaction in the account transfers.

I also tried to change the readAllAccounts implementation to use a Scan() but it surprisingly didn't work. Doesn't the Scan() read the database at a timestamp?
