### PR TITLE
Support KeyMin in InternalRangeLookup.

### DIFF
--- a/storage/engine/keys.go
+++ b/storage/engine/keys.go
@@ -275,6 +275,18 @@ func ValidateRangeMetaKey(key proto.Key) error {
 	return nil
 }
 
+// DecodeRangeMetaKey returns the bounds within which the desired meta
+// record can be found. The given key must be a valid RangeMetaKey.
+func DecodeRangeMetaKey(key proto.Key) (proto.Key, proto.Key) {
+	if len(key) == 0 {
+		// Special case KeyMin: find the first entry in meta1.
+		return KeyMeta1Prefix, KeyMeta1Prefix.PrefixEnd()
+	}
+	// Otherwise find the first entry greater than the given key in the same meta prefix.
+	metaPrefix := proto.Key(key[:len(KeyMeta1Prefix)])
+	return key.Next(), metaPrefix.PrefixEnd()
+}
+
 // Constants for stat key construction.
 var (
 	// StatLiveBytes counts how many bytes are "live", including bytes

--- a/storage/range_command.go
+++ b/storage/range_command.go
@@ -351,18 +351,8 @@ func (r *Range) InternalRangeLookup(batch engine.Engine, args *proto.InternalRan
 	// We want to search for the metadata key just greater than args.Key. Scan
 	// for both the requested key and the keys immediately afterwards, up to
 	// MaxRanges.
-	var metaPrefix proto.Key
-	var startKey proto.Key
-	if len(args.Key) > 0 {
-		// ValidateRangeMetaKey ensures that key is either empty or starts with a meta prefix.
-		metaPrefix = proto.Key(args.Key[:len(engine.KeyMeta1Prefix)])
-		startKey = proto.Key(args.Key).Next()
-	} else {
-		// If args.Key is empty, we want the first entry in meta1.
-		metaPrefix = engine.KeyMeta1Prefix
-		startKey = engine.KeyMeta1Prefix
-	}
-	kvs, err := engine.MVCCScan(batch, startKey, metaPrefix.PrefixEnd(), rangeCount, args.Timestamp, false, args.Txn)
+	startKey, endKey := engine.DecodeRangeMetaKey(args.Key)
+	kvs, err := engine.MVCCScan(batch, startKey, endKey, rangeCount, args.Timestamp, false, args.Txn)
 	if err != nil {
 		if wiErr, ok := err.(*proto.WriteIntentError); ok && args.IgnoreIntents {
 			// NOTE (subtle): in general, we want to try to clean up dangling


### PR DESCRIPTION
This is not something we currently do (we use gossip instead for the
first range), but it is needed to support consistent range lookups.
