### PR TITLE
Tiny fixes to comments in range.go and queue.go

### DIFF
--- a/storage/queue.go
+++ b/storage/queue.go
@@ -185,7 +185,7 @@ func (bq *baseQueue) MaybeRemove(rng *Range) {
 	}
 }
 
-// process processes the entries in the queue until the provided
+// processLoop processes the entries in the queue until the provided
 // stopper signals exit.
 //
 // TODO(spencer): current load should factor into range processing timer.

--- a/storage/range.go
+++ b/storage/range.go
@@ -466,8 +466,6 @@ func (r *Range) GetMVCCStats() proto.MVCCStats {
 }
 
 // ContainsKey returns whether this range contains the specified key.
-// Read-lock the mutex to protect access to Desc, which might be changed
-// concurrently via range split.
 func (r *Range) ContainsKey(key proto.Key) bool {
 	return r.Desc().ContainsKey(engine.KeyAddress(key))
 }


### PR DESCRIPTION
- s/process/processLoop/
- Remove the comment on mutex from ContainsKey()
