### PR TITLE
Add our own simple UUID version, based on go-uuid.

### DIFF
--- a/GLOCKFILE
+++ b/GLOCKFILE
@@ -9,7 +9,6 @@ cmd golang.org/x/tools/cmd/goimports
 cmd golang.org/x/tools/cmd/stringer
 bitbucket.org/tebeka/go2xunit 77968f802fb3
 code.google.com/p/go-commander df033a4b379cd723ef7408b881c1e092cd943831
-code.google.com/p/go-uuid 35bc42037350
 code.google.com/p/snappy-go 8850bd446ad6
 github.com/agtorre/gocolorize f42b554bf7f006936130c9bb4f971afd2d87f671
 github.com/biogo/store cb1ae010c5c75b7ce4f5c5d0ef92defcafdfdce4

--- a/build/devbase/godeps.sh
+++ b/build/devbase/godeps.sh
@@ -20,7 +20,7 @@ if ! test -e ${GOPATH}/bin/glock ; then
     # itself, so no -u here)
     go get github.com/robfig/glock
 fi
-    
+
 ${GOPATH}/bin/glock sync github.com/cockroachdb/cockroach
 
 # NOTE: Use "make listdeps" to update this list. We can't just use "go
@@ -31,10 +31,10 @@ ${GOPATH}/bin/glock sync github.com/cockroachdb/cockroach
 # downloaded but whose dependencies have not).
 pkgs="
 code.google.com/p/go-commander
-code.google.com/p/go-uuid/uuid
 code.google.com/p/snappy-go/snappy
 github.com/biogo/store/interval
 github.com/biogo/store/llrb
+github.com/cockroachdb/c-lz4
 github.com/cockroachdb/c-protobuf
 github.com/cockroachdb/c-rocksdb
 github.com/cockroachdb/c-snappy

--- a/client/txn_test.go
+++ b/client/txn_test.go
@@ -20,14 +20,14 @@ package client
 import (
 	"testing"
 
-	"code.google.com/p/go-uuid/uuid"
 	"github.com/cockroachdb/cockroach/proto"
+	"github.com/cockroachdb/cockroach/util"
 	gogoproto "github.com/gogo/protobuf/proto"
 )
 
 var (
 	txnKey = proto.Key("test-txn")
-	txnID  = []byte(uuid.New())
+	txnID  = []byte(util.NewUUID4())
 )
 
 func makeTS(walltime int64, logical int32) proto.Timestamp {

--- a/proto/data_test.go
+++ b/proto/data_test.go
@@ -25,7 +25,7 @@ import (
 	"testing"
 	"time"
 
-	"code.google.com/p/go-uuid/uuid"
+	"github.com/cockroachdb/cockroach/util"
 	gogoproto "github.com/gogo/protobuf/proto"
 )
 
@@ -350,7 +350,7 @@ func TestValueChecksumWithInteger(t *testing.T) {
 }
 
 func TestTxnIDEqual(t *testing.T) {
-	txn1, txn2 := uuid.NewRandom(), uuid.NewRandom()
+	txn1, txn2 := util.NewUUID4(), util.NewUUID4()
 	txn1Copy := append([]byte(nil), txn1...)
 
 	testCases := []struct {

--- a/server/cli/start.go
+++ b/server/cli/start.go
@@ -26,7 +26,6 @@ import (
 	"time"
 
 	commander "code.google.com/p/go-commander"
-	"code.google.com/p/go-uuid/uuid"
 	"github.com/cockroachdb/cockroach/kv"
 	"github.com/cockroachdb/cockroach/server"
 	"github.com/cockroachdb/cockroach/storage/engine"
@@ -43,9 +42,9 @@ var initCmd = &commander.Command{
 	UsageLine: "init -stores=(ssd=<data-dir>,hdd:7200rpm=<data-dir>|mem=<capacity-in-bytes>)[,...]",
 	Short:     "init new Cockroach cluster and start server",
 	Long: `
-Initialize a new Cockroach cluster using the -stores command line flag to 
-specify one or more storage locations. The first of these storage locations is 
-used to bootstrap the first replica of the first range. If any of the storage 
+Initialize a new Cockroach cluster using the -stores command line flag to
+specify one or more storage locations. The first of these storage locations is
+used to bootstrap the first replica of the first range. If any of the storage
 locations are already part of a pre-existing cluster, the bootstrap will fail.
 
 For example:
@@ -66,7 +65,7 @@ func runInit(cmd *commander.Command, args []string) {
 	}
 
 	// Generate a new UUID for cluster ID and bootstrap the cluster.
-	clusterID := uuid.New()
+	clusterID := util.NewUUID4().String()
 	stopper := util.NewStopper()
 	if _, err := server.BootstrapCluster(clusterID, Context.Engines, stopper); err != nil {
 		log.Errorf("unable to bootstrap cluster: %s", err)

--- a/storage/engine/keys.go
+++ b/storage/engine/keys.go
@@ -137,7 +137,7 @@ func ResponseCacheKey(raftID int64, cmdID *proto.ClientCmdID) proto.Key {
 
 // MakeRangeKey creates a range-local key based on the range
 // start key, metadata key suffix, and optional detail (e.g. the
-// transaction UUID for a txn record, etc.).
+// transaction ID for a txn record, etc.).
 func MakeRangeKey(key, suffix, detail proto.Key) proto.Key {
 	if len(suffix) != KeyLocalSuffixLength {
 		panic(fmt.Sprintf("suffix len(%q) != %d", suffix, KeyLocalSuffixLength))
@@ -408,7 +408,7 @@ var (
 	// range). The key is appended to this prefix, encoded using
 	// EncodeBytes. The specific sort of per-range metadata is
 	// identified by one of the suffixes listed below, along with
-	// potentially additional encoded key info, such as the txn UUID in
+	// potentially additional encoded key info, such as the txn ID in
 	// the case of a transaction record.
 	//
 	// NOTE: KeyLocalRangeKeyPrefix must be kept in sync with the value

--- a/storage/engine/keys_test.go
+++ b/storage/engine/keys_test.go
@@ -21,8 +21,8 @@ import (
 	"bytes"
 	"testing"
 
-	"code.google.com/p/go-uuid/uuid"
 	"github.com/cockroachdb/cockroach/proto"
+	"github.com/cockroachdb/cockroach/util"
 	"github.com/cockroachdb/cockroach/util/leaktest"
 )
 
@@ -61,8 +61,8 @@ func TestKeyAddress(t *testing.T) {
 		{proto.Key("123"), proto.Key("123")},
 		{MakeKey(KeyConfigAccountingPrefix, proto.Key("foo")), proto.Key("\x00acctfoo")},
 		{RangeDescriptorKey(proto.Key("foo")), proto.Key("foo")},
-		{TransactionKey(proto.Key("baz"), proto.Key(uuid.New())), proto.Key("baz")},
-		{TransactionKey(KeyMax, proto.Key(uuid.New())), KeyMax},
+		{TransactionKey(proto.Key("baz"), proto.Key(util.NewUUID4())), proto.Key("baz")},
+		{TransactionKey(KeyMax, proto.Key(util.NewUUID4())), KeyMax},
 	}
 	for i, test := range testCases {
 		result := KeyAddress(test.key)

--- a/storage/engine/rocksdb_test.go
+++ b/storage/engine/rocksdb_test.go
@@ -26,7 +26,6 @@ import (
 	"testing"
 	"time"
 
-	"code.google.com/p/go-uuid/uuid"
 	"github.com/cockroachdb/cockroach/proto"
 	"github.com/cockroachdb/cockroach/util"
 	"github.com/cockroachdb/cockroach/util/encoding"
@@ -95,11 +94,11 @@ func TestRocksDBCompaction(t *testing.T) {
 			Value: proto.Value{Bytes: encodePutResponse(makeTS(3, 0), t)},
 		},
 		{
-			Key:   TransactionKey(proto.Key("a"), proto.Key(uuid.New())),
+			Key:   TransactionKey(proto.Key("a"), proto.Key(util.NewUUID4())),
 			Value: proto.Value{Bytes: encodeTransaction(makeTS(1, 0), t)},
 		},
 		{
-			Key:   TransactionKey(proto.Key("b"), proto.Key(uuid.New())),
+			Key:   TransactionKey(proto.Key("b"), proto.Key(util.NewUUID4())),
 			Value: proto.Value{Bytes: encodeTransaction(makeTS(2, 0), t)},
 		},
 	}

--- a/storage/range_test.go
+++ b/storage/range_test.go
@@ -28,7 +28,6 @@ import (
 	"testing"
 	"time"
 
-	"code.google.com/p/go-uuid/uuid"
 	"github.com/cockroachdb/cockroach/client"
 	"github.com/cockroachdb/cockroach/gossip"
 	"github.com/cockroachdb/cockroach/multiraft"
@@ -1894,7 +1893,7 @@ func TestRangeStatsComputation(t *testing.T) {
 	// Put a 2nd value transactionally.
 	pArgs, pReply = putArgs([]byte("b"), []byte("value2"), 1, tc.store.StoreID())
 	pArgs.Timestamp = tc.clock.Now()
-	pArgs.Txn = &proto.Transaction{ID: uuid.NewRandom(), Timestamp: pArgs.Timestamp}
+	pArgs.Txn = &proto.Transaction{ID: util.NewUUID4(), Timestamp: pArgs.Timestamp}
 	if err := tc.rng.AddCmd(pArgs, pReply, true); err != nil {
 		t.Fatal(err)
 	}

--- a/storage/store_test.go
+++ b/storage/store_test.go
@@ -27,7 +27,6 @@ import (
 	"testing"
 	"time"
 
-	"code.google.com/p/go-uuid/uuid"
 	"github.com/cockroachdb/cockroach/client"
 	"github.com/cockroachdb/cockroach/gossip"
 	"github.com/cockroachdb/cockroach/multiraft"
@@ -476,7 +475,7 @@ func TestStoreVerifyKeys(t *testing.T) {
 	// Try a put to txn record for a meta2 key (note that this doesn't
 	// actually happen in practice, as txn records are not put directly,
 	// but are instead manipulated only through txn methods).
-	pArgs, pReply = putArgs(engine.TransactionKey(meta2KeyMax, []byte(uuid.New())),
+	pArgs, pReply = putArgs(engine.TransactionKey(meta2KeyMax, []byte(util.NewUUID4())),
 		[]byte("value"), 1, store.StoreID())
 	if err := store.ExecuteCmd(pArgs, pReply); err != nil {
 		t.Fatalf("unexpected error on put to txn meta2 value: %s", err)

--- a/storage/timestamp_cache_test.go
+++ b/storage/timestamp_cache_test.go
@@ -21,8 +21,8 @@ import (
 	"testing"
 	"time"
 
-	"code.google.com/p/go-uuid/uuid"
 	"github.com/cockroachdb/cockroach/proto"
+	"github.com/cockroachdb/cockroach/util"
 	"github.com/cockroachdb/cockroach/util/hlc"
 	"github.com/cockroachdb/cockroach/util/leaktest"
 )
@@ -322,8 +322,8 @@ func TestTimestampCacheReplacements(t *testing.T) {
 	clock := hlc.NewClock(manual.UnixNano)
 	tc := NewTimestampCache(clock)
 
-	txn1ID := uuid.NewRandom()
-	txn2ID := uuid.NewRandom()
+	txn1ID := util.NewUUID4()
+	txn2ID := util.NewUUID4()
 
 	ts1 := clock.Now()
 	tc.Add(proto.Key("a"), nil, ts1, nil, true)
@@ -375,8 +375,8 @@ func TestTimestampCacheWithTxnID(t *testing.T) {
 	tc := NewTimestampCache(clock)
 
 	// Add two successive txn entries.
-	txn1ID := uuid.NewRandom()
-	txn2ID := uuid.NewRandom()
+	txn1ID := util.NewUUID4()
+	txn2ID := util.NewUUID4()
 	ts1 := clock.Now()
 	tc.Add(proto.Key("a"), proto.Key("c"), ts1, txn1ID, true)
 	ts2 := clock.Now()
@@ -410,8 +410,8 @@ func TestTimestampCacheReadVsWrite(t *testing.T) {
 	tc.Add(proto.Key("a"), proto.Key("b"), ts1, nil, true)
 
 	// Add two successive txn entries; one read-only and one read-write.
-	txn1ID := uuid.NewRandom()
-	txn2ID := uuid.NewRandom()
+	txn1ID := util.NewUUID4()
+	txn2ID := util.NewUUID4()
 	ts2 := clock.Now()
 	tc.Add(proto.Key("a"), nil, ts2, txn1ID, true)
 	ts3 := clock.Now()

--- a/util/uuid.go
+++ b/util/uuid.go
@@ -49,7 +49,7 @@ func NewUUID4() UUID {
 }
 
 // String formats as hex xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx,
-// or "" if t is invalid.
+// or "" if u is invalid.
 func (u UUID) String() string {
 	if u == nil || len(u) != UUIDSize {
 		return ""

--- a/util/uuid.go
+++ b/util/uuid.go
@@ -1,0 +1,59 @@
+// Copyright 2015 The Cockroach Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+// implied. See the License for the specific language governing
+// permissions and limitations under the License. See the AUTHORS file
+// for names of contributors.
+//
+// Author: Spencer Kimball (spencer.kimball@gmail.com)
+//
+// Based on code from http://code.google.com/p/go-uuid/uuid
+
+package util
+
+import (
+	"crypto/rand"
+	"fmt"
+	"io"
+)
+
+const (
+	// UUIDSize is the size in bytes of a UUID.
+	UUIDSize = 16
+)
+
+// UUID is a 16 byte UUID.
+type UUID []byte
+
+// NewUUID4 returns a new UUID (Version 4) using 16 random bytes or panics.
+//
+// The uniqueness depends on the strength of crypto/rand. Version 4
+// UUIDs have 122 random bits.
+func NewUUID4() UUID {
+	uuid := make([]byte, UUIDSize)
+	if _, err := io.ReadFull(rand.Reader, uuid); err != nil {
+		panic(err.Error()) // rand should never fail
+	}
+	// UUID (Version 4) compliance.
+	uuid[6] = (uuid[6] & 0x0f) | 0x40 // Version 4
+	uuid[8] = (uuid[8] & 0x3f) | 0x80 // Variant is 10
+	return uuid
+}
+
+// String formats as hex xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx,
+// or "" if t is invalid.
+func (u UUID) String() string {
+	if u == nil || len(u) != UUIDSize {
+		return ""
+	}
+	b := []byte(u)
+	return fmt.Sprintf("%08x-%04x-%04x-%04x-%012x", b[:4], b[4:6], b[6:8], b[8:10], b[10:])
+}

--- a/util/uuid_test.go
+++ b/util/uuid_test.go
@@ -1,0 +1,39 @@
+// Copyright 2015 The Cockroach Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+// implied. See the License for the specific language governing
+// permissions and limitations under the License. See the AUTHORS file
+// for names of contributors.
+//
+// Author: Spencer Kimball (spencer.kimball@gmail.com)
+
+package util
+
+import (
+	"bytes"
+	"testing"
+)
+
+func TestUUID(t *testing.T) {
+	uuid1 := NewUUID4()
+	uuid2 := NewUUID4()
+	if bytes.Equal(uuid1, uuid2) {
+		t.Errorf("consecutive uuids equal %s", uuid1)
+	}
+}
+
+func TestUUIDString(t *testing.T) {
+	uuid := UUID([]byte("ת\x0f^\xe4-Fؽ\xf7\x16\xe4\xf9\xbe^\xbe"))
+	expStr := "d7aa0f5e-e42d-46d8-bdf7-16e4f9be5ebe"
+	if str := uuid.String(); str != expStr {
+		t.Errorf("expected txn %s; got %s", expStr, str)
+	}
+}


### PR DESCRIPTION
go-uuid seems to be going away, so this PR pulls out the part we were
using, namely the Version 4 UUID generation and string formatter.

Closes #887
