### PR TITLE
Fix off-by-one error in encoding.DecodeBytes.

### DIFF
--- a/util/encoding/encoding.go
+++ b/util/encoding/encoding.go
@@ -421,7 +421,7 @@ func DecodeBytes(b []byte) ([]byte, []byte) {
 		if i == -1 {
 			panic("did not find terminator")
 		}
-		if i+1 > len(b) {
+		if i+1 >= len(b) {
 			panic("malformed escape")
 		}
 


### PR DESCRIPTION
The tests check for panic, and it still panics, but it's panicing on the slice
index instead of the "malformed escape" check.
