### PR TITLE
Remove mvcc diagnostics and fix non-determinism in TestMultiStoreEventFe...

### DIFF
--- a/storage/client_event_test.go
+++ b/storage/client_event_test.go
@@ -73,15 +73,14 @@ func (ser *storeEventReader) recordEvent(event interface{}) {
 			event.Desc.RaftID, event.Stats.LiveBytes)
 	case *storage.SplitRangeEvent:
 		sid = event.StoreID
-		eventStr = fmt.Sprintf("SplitRange origId=%d, newId=%d, origLive=%d, newLive=%d, origVal=%d, newVal=%d",
+		eventStr = fmt.Sprintf("SplitRange origId=%d, newId=%d, origKey=%d, newKey=%d",
 			event.Original.Desc.RaftID, event.New.Desc.RaftID,
-			event.Original.Stats.LiveBytes, event.New.Stats.LiveBytes,
-			event.Original.Stats.ValBytes, event.New.Stats.ValBytes)
+			event.Original.Stats.KeyBytes, event.New.Stats.KeyBytes)
 	case *storage.MergeRangeEvent:
 		sid = event.StoreID
-		eventStr = fmt.Sprintf("MergeRange rid=%d, subId=%d, live=%d, subLive=%d",
+		eventStr = fmt.Sprintf("MergeRange rid=%d, subId=%d, key=%d, subKey=%d",
 			event.Merged.Desc.RaftID, event.Removed.Desc.RaftID,
-			event.Merged.Stats.LiveBytes, event.Removed.Stats.LiveBytes)
+			event.Merged.Stats.KeyBytes, event.Removed.Stats.KeyBytes)
 	case *storage.BeginScanRangesEvent:
 		sid = event.StoreID
 		eventStr = "BeginScanRanges"
@@ -132,8 +131,6 @@ func (ser *storeEventReader) updateCountString() string {
 // recieved by a single event reader.
 func TestMultiStoreEventFeed(t *testing.T) {
 	defer leaktest.AfterTest(t)
-	engine.EnableMVCCComputeStatsDiagnostics(true)
-	defer engine.EnableMVCCComputeStatsDiagnostics(false)
 
 	// Create a multiTestContext which publishes all store events to the given
 	// feed.
@@ -249,25 +246,25 @@ func TestMultiStoreEventFeed(t *testing.T) {
 			"BeginScanRanges",
 			"AddRange rid=1, live=348",
 			"EndScanRanges",
-			"SplitRange origId=1, newId=2, origLive=858, newLive=42, origVal=719, newVal=27",
-			"SplitRange origId=2, newId=3, origLive=42, newLive=0, origVal=27, newVal=0",
-			"MergeRange rid=2, subId=3, live=42, subLive=0",
+			"SplitRange origId=1, newId=2, origKey=242, newKey=15",
+			"SplitRange origId=2, newId=3, origKey=15, newKey=0",
+			"MergeRange rid=2, subId=3, key=15, subKey=0",
 		},
 		proto.StoreID(2): []string{
 			"StartStore",
 			"BeginScanRanges",
 			"EndScanRanges",
-			"SplitRange origId=1, newId=2, origLive=858, newLive=42, origVal=719, newVal=27",
-			"SplitRange origId=2, newId=3, origLive=42, newLive=0, origVal=27, newVal=0",
-			"MergeRange rid=2, subId=3, live=42, subLive=0",
+			"SplitRange origId=1, newId=2, origKey=242, newKey=15",
+			"SplitRange origId=2, newId=3, origKey=15, newKey=0",
+			"MergeRange rid=2, subId=3, key=15, subKey=0",
 		},
 		proto.StoreID(3): []string{
 			"StartStore",
 			"BeginScanRanges",
 			"EndScanRanges",
-			"SplitRange origId=1, newId=2, origLive=858, newLive=42, origVal=719, newVal=27",
-			"SplitRange origId=2, newId=3, origLive=42, newLive=0, origVal=27, newVal=0",
-			"MergeRange rid=2, subId=3, live=42, subLive=0",
+			"SplitRange origId=1, newId=2, origKey=242, newKey=15",
+			"SplitRange origId=2, newId=3, origKey=15, newKey=0",
+			"MergeRange rid=2, subId=3, key=15, subKey=0",
 		},
 	}
 	if a, e := ser.perStoreFeeds, expected; !reflect.DeepEqual(a, e) {

--- a/storage/engine/mvcc.go
+++ b/storage/engine/mvcc.go
@@ -23,7 +23,6 @@ import (
 	"fmt"
 	"math"
 	"sync"
-	"sync/atomic"
 
 	"github.com/cockroachdb/cockroach/proto"
 	"github.com/cockroachdb/cockroach/util"
@@ -1355,22 +1354,6 @@ func MVCCFindSplitKey(engine Engine, raftID int64, key, endKey proto.Key) (proto
 	return humanKey, nil
 }
 
-var statsDiagnosticsEnabled int32
-
-func areStatsDiagnosticsEnabled() bool {
-	return atomic.LoadInt32(&statsDiagnosticsEnabled) == 1
-}
-
-// EnableMVCCComputeStatsDiagnostics turns stats diagnostics on or off.
-func EnableMVCCComputeStatsDiagnostics(enabled bool) {
-	oldValue := int32(0)
-	newValue := int32(1)
-	if !enabled {
-		oldValue, newValue = newValue, oldValue
-	}
-	atomic.CompareAndSwapInt32(&statsDiagnosticsEnabled, oldValue, newValue)
-}
-
 // MVCCComputeStats scans the underlying engine from start to end keys
 // and computes stats counters based on the values. This method is
 // used after a range is split to recompute stats for each
@@ -1389,10 +1372,9 @@ func MVCCComputeStats(engine Engine, key, endKey proto.Key, nowNanos int64) (pro
 	ms := proto.MVCCStats{LastUpdateNanos: nowNanos}
 	first := false
 	meta := &proto.MVCCMetadata{}
-	diag := areStatsDiagnosticsEnabled()
 
 	err := engine.Iterate(encStartKey, encEndKey, func(kv proto.RawKeyValue) (bool, error) {
-		key, ts, isValue := MVCCDecodeKey(kv.Key)
+		_, ts, isValue := MVCCDecodeKey(kv.Key)
 		if !isValue {
 			totalBytes := int64(len(kv.Value)) + int64(len(kv.Key))
 			first = true
@@ -1411,10 +1393,6 @@ func MVCCComputeStats(engine Engine, key, endKey proto.Key, nowNanos int64) (pro
 			ms.KeyCount++
 			if meta.IsInline() {
 				ms.ValCount++
-			}
-			if diag {
-				log.Infof("diag: %s meta  k=%d v=%d", key, len(kv.Key), len(kv.Value))
-				log.Infof("meta: %+v, encoded=%q", meta, kv.Value)
 			}
 		} else {
 			totalBytes := int64(len(kv.Value)) + mvccVersionTimestampSize
@@ -1444,9 +1422,6 @@ func MVCCComputeStats(engine Engine, key, endKey proto.Key, nowNanos int64) (pro
 			ms.KeyBytes += mvccVersionTimestampSize
 			ms.ValBytes += int64(len(kv.Value))
 			ms.ValCount++
-			if diag {
-				log.Infof("diag: %s value k=%d v=%d @%s", key, mvccVersionTimestampSize, len(kv.Value), ts)
-			}
 		}
 		return false, nil
 	})


### PR DESCRIPTION
...ed.

The problem was that intents on the meta keys had randomized priorities,
which encoded to different lengths, causing a mismatch in expected value
bytes counts depending on the random priority chosen.

Fixes #891
