### PR TITLE
Add check to encoding.DecodeUvarint for length > 8.

### DIFF
--- a/util/encoding/encoding.go
+++ b/util/encoding/encoding.go
@@ -329,12 +329,13 @@ func DecodeUvarint(b []byte) ([]byte, uint64) {
 		panic("insufficient bytes to decode var uint64 int value")
 	}
 	length := int(b[0]) - 8
+	b = b[1:] // skip length byte
 	if length < 0 {
 		panic(fmt.Sprintf("unable to decode negative value into uint64: %d", length))
-	}
-	b = b[1:] // skip length byte
-	if len(b) < length {
-		panic(fmt.Sprintf("insufficient bytes to decode var uint64 int value: %s", b))
+	} else if length > 8 {
+		panic(fmt.Sprintf("invalid uvarint length of %d", length))
+	} else if len(b) < length {
+		panic(fmt.Sprintf("insufficient bytes to decode var uint64 int value: %v", b))
 	}
 	var v uint64
 	// It is faster to range over the elements in a slice than to index

--- a/util/encoding/encoding.go
+++ b/util/encoding/encoding.go
@@ -330,9 +330,7 @@ func DecodeUvarint(b []byte) ([]byte, uint64) {
 	}
 	length := int(b[0]) - 8
 	b = b[1:] // skip length byte
-	if length < 0 {
-		panic(fmt.Sprintf("unable to decode negative value into uint64: %d", length))
-	} else if length > 8 {
+	if length < 0 || length > 8 {
 		panic(fmt.Sprintf("invalid uvarint length of %d", length))
 	} else if len(b) < length {
 		panic(fmt.Sprintf("insufficient bytes to decode var uint64 int value: %v", b))

--- a/util/encoding/encoding_test.go
+++ b/util/encoding/encoding_test.go
@@ -344,6 +344,24 @@ func TestEncodeDecodeUvarint(t *testing.T) {
 	testCustomEncodeUint64(testCases, EncodeUvarint, t)
 }
 
+// TestDecodeInvalidUvarint tests that invalid uvarint encodings panic.
+func TestDecodeInvalidUvarint(t *testing.T) {
+	testCases := [][]byte{
+		// length of 9 bytes should cause an error.
+		{0x11, 0x01, 0x01, 0x01, 0x01, 0x01, 0x01, 0x01, 0x01, 0x01},
+	}
+	for _, c := range testCases {
+		func() {
+			defer func() {
+				if r := recover(); r == nil {
+					t.Error("expected panic")
+				}
+			}()
+			DecodeUvarint(c)
+		}()
+	}
+}
+
 func TestEncodeDecodeUvarintDecreasing(t *testing.T) {
 	testBasicEncodeDecodeUint64(EncodeUvarintDecreasing, DecodeUvarintDecreasing, true, t)
 	testCases := []testCaseUint64{


### PR DESCRIPTION
This was not checked for so potentially a uvarint with malformed length could
cause the decoder to eat the next uvarint in the buffer.

I also changed one of the format specifier characters to %v. It was %s before which was causing it to print binary.
