### PR TITLE
attempt at fixing #893

### DIFF
--- a/storage/client_merge_test.go
+++ b/storage/client_merge_test.go
@@ -198,10 +198,8 @@ func TestStoreRangeMergeLastRange(t *testing.T) {
 
 // TestStoreRangeMergeNonConsecutive attempts to merge two ranges
 // that are not on same store.
-// TODO(tschottdorf): debug the test failures on CircleCI, see #893.
 func TestStoreRangeMergeNonConsecutive(t *testing.T) {
 	defer leaktest.AfterTest(t)
-	t.Skip("TODO(tschottdorf): debug and re-enable, see #893")
 	store, stopper := createTestStore(t)
 	defer stopper.Stop()
 


### PR DESCRIPTION
when a group gets deleted, everyone still waiting for a command to commit will
have their proposals aborted.
closes #893

there are still issues with this test (or multiraft/raft, depending on how you
see it), but this should fix the overwhelming majority of test failures in
TestStoreRangeMergeNonConsecutive.

see #906 for a very rare, open bug caused by this test.
