### PR TITLE
Collect and Record Node Metrics

### DIFF
--- a/server/cli/flags.go
+++ b/server/cli/flags.go
@@ -43,7 +43,7 @@ func initFlags(ctx *server.Context) {
 		"in-memory store. Device attributes typically include whether the store is "+
 		"flash (ssd), spinny disk (hdd), fusion-io (fio), in-memory (mem); device "+
 		"attributes might also include speeds and other specs (7200rpm, 200kiops, etc.). "+
-		"For example, -store=hdd:7200rpm=/mnt/hda1,ssd=/mnt/ssd01,ssd=/mnt/ssd02,mem=1073741824.")
+		"For example, --stores=hdd:7200rpm=/mnt/hda1,ssd=/mnt/ssd01,ssd=/mnt/ssd02,mem=1073741824.")
 
 	pflag.StringVar(&ctx.Attrs, "attrs", ctx.Attrs, "specify an ordered, colon-separated list of node "+
 		"attributes. Attributes are arbitrary strings specifying topography or "+
@@ -61,6 +61,10 @@ func initFlags(ctx *server.Context) {
 		"node-to-node links and if any node notices it has clock offset in excess "+
 		"of --max-offset, it will commit suicide. Setting this value too high may "+
 		"decrease transaction performance in the presence of contention.")
+
+	pflag.DurationVar(&ctx.MetricsFrequency, "metrics-frequency", ctx.MetricsFrequency, "specify "+
+		"--metrics-frequency to adjust the frequency at which the server records "+
+		"its own internal metrics.")
 
 	// Gossip flags.
 	pflag.StringVar(&ctx.GossipBootstrap, "gossip", ctx.GossipBootstrap, "specify a "+
@@ -84,7 +88,7 @@ func initFlags(ctx *server.Context) {
 		"caches, shared evenly if there are multiple storage devices.")
 
 	pflag.DurationVar(&ctx.ScanInterval, "scan-interval", ctx.ScanInterval, "specify "+
-		"--scan_interval to adjust the target for the duration of a single scan "+
+		"--scan-interval to adjust the target for the duration of a single scan "+
 		"through a store's ranges. The scan is slowed as necessary to approximately"+
 		"achieve this duration.")
 }

--- a/server/context.go
+++ b/server/context.go
@@ -35,13 +35,12 @@ import (
 
 // Context defaults.
 const (
-	defaultAddr           = ":8080"
-	defaultMaxOffset      = 250 * time.Millisecond
-	defaultGossipInterval = 2 * time.Second
-	defaultCacheSize      = 1 << 30 // GB
-	// defaultScanInterval is the default value for the scan interval.
-	// command line flag.
-	defaultScanInterval = 10 * time.Minute
+	defaultAddr             = ":8080"
+	defaultMaxOffset        = 250 * time.Millisecond
+	defaultGossipInterval   = 2 * time.Second
+	defaultCacheSize        = 1 << 30 // GB
+	defaultScanInterval     = 10 * time.Minute
+	defaultMetricsFrequency = 10 * time.Second
 )
 
 // Context holds parameters needed to setup a server.
@@ -111,16 +110,21 @@ type Context struct {
 	// ScanInterval determines a duration during which each range should be
 	// visited approximately once by the range scanner.
 	ScanInterval time.Duration
+
+	// MetricsFrequency determines the frequency at which the server should
+	// record internal metrics.
+	MetricsFrequency time.Duration
 }
 
 // NewContext returns a Context with default values.
 func NewContext() *Context {
 	ctx := &Context{
-		Addr:           defaultAddr,
-		MaxOffset:      defaultMaxOffset,
-		GossipInterval: defaultGossipInterval,
-		CacheSize:      defaultCacheSize,
-		ScanInterval:   defaultScanInterval,
+		Addr:             defaultAddr,
+		MaxOffset:        defaultMaxOffset,
+		GossipInterval:   defaultGossipInterval,
+		CacheSize:        defaultCacheSize,
+		ScanInterval:     defaultScanInterval,
+		MetricsFrequency: defaultMetricsFrequency,
 	}
 	// Initializes base context defaults.
 	ctx.InitDefaults()

--- a/server/node_test.go
+++ b/server/node_test.go
@@ -77,6 +77,7 @@ func createTestNode(addr net.Addr, engines []engine.Engine, gossipBS net.Addr, t
 		kv.NewDistSender(&kv.DistSenderContext{Clock: ctx.Clock}, g))
 	// TODO(bdarnell): arrange to have the transport closed.
 	ctx.Transport = multiraft.NewLocalRPCTransport()
+	ctx.EventFeed = &util.Feed{}
 	node := NewNode(ctx)
 	return rpcServer, ctx.Clock, node, stopper
 }

--- a/server/status/monitor.go
+++ b/server/status/monitor.go
@@ -88,11 +88,12 @@ func (nsm *NodeStatusMonitor) VisitStoreMonitors(visitor func(*StoreStatusMonito
 	}
 }
 
-// StartMonitorFeed begins processing events published to the supplied
-// Subscription. This method will continue running until the Subscription's
-// events feed is closed.
-func (nsm *NodeStatusMonitor) StartMonitorFeed(sub *util.Subscription) {
-	storage.ProcessStoreEvents(nsm, sub)
+// StartMonitorFeed starts a goroutine which processes events published to the
+// supplied Subscription. The goroutine will continue running until the
+// Subscription's Events feed is closed.
+func (nsm *NodeStatusMonitor) StartMonitorFeed(feed *util.Feed) {
+	sub := feed.Subscribe()
+	go storage.ProcessStoreEvents(nsm, sub)
 }
 
 // OnAddRange receives AddRangeEvents retrieved from an storage event

--- a/server/status/monitor_test.go
+++ b/server/status/monitor_test.go
@@ -57,7 +57,7 @@ func TestNodeStatusMonitor(t *testing.T) {
 	monitor := NewNodeStatusMonitor()
 	sub := feed.Subscribe()
 	monitorStopper.RunWorker(func() {
-		monitor.StartMonitorFeed(sub)
+		storage.ProcessStoreEvents(monitor, sub)
 	})
 
 	for i := 0; i < 3; i++ {

--- a/server/status/recorder.go
+++ b/server/status/recorder.go
@@ -26,7 +26,18 @@ import (
 )
 
 const (
-	storeTimeSeriesNameFmt = "cr.store.%d.%s"
+	// storeTimeSeriesNameFmt is the current format for cockroach's
+	// store-specific time series keys. Each key has a prefix of "cr.store",
+	// followed by the name of the specific stat, followed by the StoreID.
+	//
+	// For example, the livebytes stats for Store with ID 1 would be stored with
+	// key:
+	//		cr.store.livebytes.1
+	//
+	// This format has been chosen to put the StoreID as the suffix of keys, in
+	// anticipation of an initially simple query system where only key suffixes
+	// can be wildcarded.
+	storeTimeSeriesNameFmt = "cr.store.%s.%d"
 )
 
 // NodeStatusRecorder is used to periodically persist the status of a node as a
@@ -80,7 +91,7 @@ type storeStatusRecorder struct {
 // proto.TimeSeriesData object.
 func (ssr *storeStatusRecorder) recordInt(name string, data int64) proto.TimeSeriesData {
 	return proto.TimeSeriesData{
-		Name: fmt.Sprintf(storeTimeSeriesNameFmt, ssr.ID, name),
+		Name: fmt.Sprintf(storeTimeSeriesNameFmt, name, ssr.ID),
 		Datapoints: []*proto.TimeSeriesDatapoint{
 			intDatapoint(ssr.timestampNanos, data),
 		},

--- a/server/status/recorder_test.go
+++ b/server/status/recorder_test.go
@@ -113,7 +113,7 @@ func TestNodeStatusRecorder(t *testing.T) {
 
 	generateStoreData := func(storeId int, name string, time, val int64) proto.TimeSeriesData {
 		return proto.TimeSeriesData{
-			Name: fmt.Sprintf(storeTimeSeriesNameFmt, proto.StoreID(storeId), name),
+			Name: fmt.Sprintf(storeTimeSeriesNameFmt, name, proto.StoreID(storeId)),
 			Datapoints: []*proto.TimeSeriesDatapoint{
 				intDatapoint(time, val),
 			},


### PR DESCRIPTION
Cockroach Node now has a NodeStatusMonitor which monitors metrics based on
StoreEventFeeds.

Cockroach server now configures a ts.DB instance, and uses it to periodically
record data from the node's NodeStatusMonitor.
