### PR TITLE
`go-commander` -> `cobra`

### DIFF
--- a/GLOCKFILE
+++ b/GLOCKFILE
@@ -8,7 +8,6 @@ cmd github.com/robfig/glock
 cmd golang.org/x/tools/cmd/goimports
 cmd golang.org/x/tools/cmd/stringer
 bitbucket.org/tebeka/go2xunit 77968f802fb3
-code.google.com/p/go-commander df033a4b379cd723ef7408b881c1e092cd943831
 code.google.com/p/snappy-go 8850bd446ad6
 github.com/agtorre/gocolorize f42b554bf7f006936130c9bb4f971afd2d87f671
 github.com/biogo/store cb1ae010c5c75b7ce4f5c5d0ef92defcafdfdce4
@@ -21,10 +20,13 @@ github.com/elazarl/go-bindata-assetfs bea323321994103859d60197d229f1a94699dde3
 github.com/gogo/protobuf bc946d07d1016848dfd2507f90f0859c9471681e
 github.com/golang/glog 44145f04b68cf362d9c4df2182967c2275eaefed
 github.com/golang/lint 39d15d55e9777df34cdffde4f406ab27fd2e60c0
+github.com/inconshreveable/mousetrap 76626ae9c91c4f2a10f34cad8ce83ea42c93bb75
 github.com/jteeuwen/go-bindata 7362d4b6b2ce6a7d3c28b523a6e40629f4d81116
 github.com/kisielk/errcheck eb516cb958915b69ad14384890b4d37bd910c9f3
 github.com/kisielk/gotool d678387370a2eb9b5b0a33218bc8c9d8de15b6be
 github.com/robfig/glock 78c45da050a4d993d12ad07e8ddb10a4891ac701
+github.com/spf13/cobra bba56042cf767e329430e7c7f68c3f9f640b4b8b
+github.com/spf13/pflag 8730624c6c03fa1c5b8ae471cb5e4d735784d32a
 golang.org/x/net 169f42267807fe93f4a4b0150583e410aefafe4e
 golang.org/x/tools 4744be3abc70249546ce31c32fa9b5a5e96b5ad1
 gopkg.in/yaml.v1 9f9df34309c04878acc86042b16630b0f696e1de

--- a/Makefile
+++ b/Makefile
@@ -22,7 +22,7 @@ GO ?= go
 # Allow setting of go build flags from the command line.
 GOFLAGS :=
 # Set to 1 to use static linking for all builds (including tests).
-STATIC := $(STATIC)
+STATIC :=
 # The cockroach image to be used for starting Docker containers
 # during acceptance tests. Usually cockroachdb/cockroach{,-dev}
 # depending on the context.

--- a/README.md
+++ b/README.md
@@ -77,13 +77,13 @@ Now we're in an environment that has everything set up, and we start by first in
 
 ```bash
 DIR=$(mktemp -d /tmp/dbXXX)
-# Initialize CA and server certificates. Default directory is -certs=certs
+# Initialize CA and server certificates. Default directory is --certs=certs
 ./cockroach create-ca-cert
 ./cockroach create-node-cert 127.0.0.1 localhost $(hostname)
 # Initialize data directories.
-./cockroach init -stores ssd=$DIR
+./cockroach init --stores ssd=$DIR
 # Start the server.
-./cockroach start -stores ssd="$DIR" -gossip self:// &
+./cockroach start --stores ssd="$DIR" --gossip self:// &
 ```
 This initializes and starts a single-node cluster in the background.
 
@@ -169,13 +169,13 @@ Once you've built your image, you may want to run the tests:
 Assuming you've built `cockroachdb/cockroach`, let's run a simple Cockroach node:
 
 ```bash
-docker run -v /data -v /certs cockroachdb/cockroach init -stores ssd=/data
+docker run -v /data -v /certs cockroachdb/cockroach init --stores ssd=/data
 docker run --volumes-from=$(docker ps -q -n 1) cockroachdb/cockroach \
-  create-ca-cert -certs /certs
+  create-ca-cert --certs /certs
 docker run --volumes-from=$(docker ps -q -n 1) cockroachdb/cockroach \
-  create-node-cert -certs /certs 127.0.0.1 localhost roachnode
+  create-node-cert --certs /certs 127.0.0.1 localhost roachnode
 docker run -p 8080:8080 -h roachnode --volumes-from=$(docker ps -q -n 1) \
-  cockroachdb/cockroach start -certs /certs -stores ssd=/data -gossip self://
+  cockroachdb/cockroach start --certs /certs --stores ssd=/data --gossip self://
 ```
 
 Run `docker run cockroachdb/cockroach help` to get an overview over the available commands and settings, and see [Running Cockroach](#running-cockroach) for first steps on interacting with your new node.

--- a/base/context.go
+++ b/base/context.go
@@ -125,7 +125,7 @@ func (ctx *Context) GetServerTLSConfig() (*tls.Config, error) {
 	}
 
 	if ctx.Certs == "" {
-		return nil, util.Errorf("-insecure=false, but -certs is empty. We need a certs directory")
+		return nil, util.Errorf("--insecure=false, but --certs is empty. We need a certs directory")
 	}
 
 	log.V(1).Infof("setting up TLS from certificates directory: %s", ctx.Certs)
@@ -149,7 +149,7 @@ func (ctx *Context) GetHTTPClient() (*http.Client, error) {
 	}
 
 	if ctx.Insecure {
-		log.Warning("running in insecure mode, this is strongly discouraged. See -insecure and -certs.")
+		log.Warning("running in insecure mode, this is strongly discouraged. See --insecure and --certs.")
 	}
 	tlsConfig, err := ctx.GetClientTLSConfig()
 	if err != nil {

--- a/build/devbase/godeps.sh
+++ b/build/devbase/godeps.sh
@@ -30,7 +30,6 @@ ${GOPATH}/bin/glock sync github.com/cockroachdb/cockroach
 # (and adding /... to repo paths will match packages that have been
 # downloaded but whose dependencies have not).
 pkgs="
-code.google.com/p/go-commander
 code.google.com/p/snappy-go/snappy
 github.com/biogo/store/interval
 github.com/biogo/store/llrb
@@ -45,6 +44,9 @@ github.com/coreos/etcd/raft/raftpb
 github.com/elazarl/go-bindata-assetfs
 github.com/gogo/protobuf/proto
 github.com/golang/glog
+github.com/inconshreveable/mousetrap
+github.com/spf13/cobra
+github.com/spf13/pflag
 golang.org/x/net/context
 gopkg.in/yaml.v1
 "

--- a/client/rpc_sender.go
+++ b/client/rpc_sender.go
@@ -47,7 +47,7 @@ func NewRPCSender(server string, context *base.Context) (*RPCSender, error) {
 	}
 
 	if context.Insecure {
-		log.Warning("running in insecure mode, this is strongly discouraged. See -insecure and -certs.")
+		log.Warning("running in insecure mode, this is strongly discouraged. See --insecure and --certs.")
 	}
 	tlsConfig, err := context.GetClientTLSConfig()
 	if err != nil {

--- a/gossip/gossip.go
+++ b/gossip/gossip.go
@@ -302,7 +302,7 @@ func (g *Gossip) Outgoing() []proto.NodeID {
 
 // Start launches the gossip instance, which commences joining the
 // gossip network using the supplied rpc server and the gossip
-// bootstrap addresses specified via command-line flag: -gossip.
+// bootstrap addresses specified via command-line flag: --gossip.
 //
 // This method starts bootstrap loop, gossip server, and client
 // management in separate goroutines and returns.

--- a/kv/txn_coord_sender.go
+++ b/kv/txn_coord_sender.go
@@ -329,7 +329,7 @@ func (tc *TxnCoordSender) sendOne(call client.Call) {
 		var resolved []proto.Key
 		if _, ok := call.Args.(*proto.EndTransactionRequest); ok {
 			txn = call.Reply.Header().Txn
-			// If the -linearizable flag is set, we want to make sure that
+			// If the --linearizable flag is set, we want to make sure that
 			// all the clocks in the system are past the commit timestamp
 			// of the transaction. This is guaranteed if either
 			// - the commit timestamp is MaxOffset behind startNS

--- a/run/local-cluster.sh
+++ b/run/local-cluster.sh
@@ -105,8 +105,8 @@ for i in $(seq 1 $NODES); do
 done
 
 # Generate certs.
-docker run -v ${CERTS_DIR} --name=${CERTS_NAME} ${COCKROACH_IMAGE} create-ca-cert -certs=${CERTS_DIR} 2> /dev/null
-docker run --rm --volumes-from=${CERTS_NAME} ${COCKROACH_IMAGE} create-node-cert -certs=${CERTS_DIR} ${NODE_ADDRESSES} 2> /dev/null
+docker run -v ${CERTS_DIR} --name=${CERTS_NAME} ${COCKROACH_IMAGE} create-ca-cert --certs=${CERTS_DIR} 2> /dev/null
+docker run --rm --volumes-from=${CERTS_NAME} ${COCKROACH_IMAGE} create-node-cert --certs=${CERTS_DIR} ${NODE_ADDRESSES} 2> /dev/null
 
 # Start all nodes.
 for i in $(seq 1 $NODES); do
@@ -114,7 +114,7 @@ for i in $(seq 1 $NODES); do
   VOL="/data$i"
 
   # Command args specify two data directories per instance to simulate two physical devices.
-  START_ARGS="-gossip=${HOSTS[1]}:$PORT -stores=ssd=$VOL -addr=${HOSTS[$i]}:$PORT -certs=${CERTS_DIR}"
+  START_ARGS="--gossip=${HOSTS[1]}:$PORT --stores=ssd=$VOL --addr=${HOSTS[$i]}:$PORT --certs=${CERTS_DIR}"
   # Log (almost) everything.
   #START_ARGS="${START_ARGS} -v 7"
   # Node-specific arguments for node container.
@@ -122,7 +122,7 @@ for i in $(seq 1 $NODES); do
 
   # If this is the first node, initialize the cluster first.
   if [[ $i == 1 ]]; then
-      docker run -v $VOL --volumes-from=${CERTS_NAME} --name=cockroach-init $COCKROACH_IMAGE init -certs=${CERTS_DIR} -stores=ssd=$VOL 2> /dev/null
+      docker run -v $VOL --volumes-from=${CERTS_NAME} --name=cockroach-init $COCKROACH_IMAGE init --certs=${CERTS_DIR} --stores=ssd=$VOL 2> /dev/null
       NODE_ARGS="${NODE_ARGS} --volumes-from=cockroach-init"
   fi
 

--- a/security/certs.go
+++ b/security/certs.go
@@ -86,7 +86,7 @@ func writeCertificateAndKey(certsDir string, prefix string,
 // to generate CA cert and key.
 func RunCreateCACert(certsDir string) error {
 	if certsDir == "" {
-		return util.Errorf("no certs directory specified, use -certs")
+		return util.Errorf("no certs directory specified, use --certs")
 	}
 
 	// Make the directory first.
@@ -109,7 +109,7 @@ func RunCreateCACert(certsDir string) error {
 // to generate node cert and key.
 func RunCreateNodeCert(certsDir string, hosts []string) error {
 	if certsDir == "" {
-		return util.Errorf("no certs directory specified, use -certs")
+		return util.Errorf("no certs directory specified, use --certs")
 	}
 	if len(hosts) == 0 {
 		return util.Errorf("no hosts specified. Need at least one")

--- a/server/cli/accounting.go
+++ b/server/cli/accounting.go
@@ -18,10 +18,9 @@
 package cli
 
 import (
-	"flag"
-
-	"code.google.com/p/go-commander"
 	"github.com/cockroachdb/cockroach/server"
+
+	"github.com/spf13/cobra"
 )
 
 // TODO:(bram) change this api to not require a file, just set (no file),
@@ -29,20 +28,19 @@ import (
 
 // A getAcctCmd command displays the acct config for the specified
 // prefix.
-var getAcctCmd = &commander.Command{
-	UsageLine: "get-acct [options] <key-prefix>",
-	Short:     "fetches and displays an accounting config",
+var getAcctCmd = &cobra.Command{
+	Use:   "get-acct [options] <key-prefix>",
+	Short: "fetches and displays an accounting config",
 	Long: `
 Fetches and displays the accounting configuration for <key-prefix>. The key
 prefix should be escaped via URL query escaping if it contains
 non-ascii bytes or spaces.
 `,
-	Run:  runGetAcct,
-	Flag: *flag.CommandLine,
+	Run: runGetAcct,
 }
 
 // runGetAcct invokes the REST API with GET action and key prefix as path.
-func runGetAcct(cmd *commander.Command, args []string) {
+func runGetAcct(cmd *cobra.Command, args []string) {
 	if len(args) != 1 {
 		cmd.Usage()
 		return
@@ -51,24 +49,23 @@ func runGetAcct(cmd *commander.Command, args []string) {
 }
 
 // A lsAcctsCmd command displays a list of acct configs by prefix.
-var lsAcctsCmd = &commander.Command{
-	UsageLine: "ls-accts [options] [key-regexp]",
-	Short:     "list all accounting configs by key prefix",
+var lsAcctsCmd = &cobra.Command{
+	Use:   "ls-accts [options] [key-regexp]",
+	Short: "list all accounting configs by key prefix",
 	Long: `
 List accounting configs. If a regular expression is given, the results of
 the listing are filtered by key prefixes matching the regexp. The key
 prefix should be escaped via URL query escaping if it contains
 non-ascii bytes or spaces.
 `,
-	Run:  runLsAccts,
-	Flag: *flag.CommandLine,
+	Run: runLsAccts,
 }
 
 // runLsAccts invokes the REST API with GET action and no path, which
 // fetches a list of all acct configuration prefixes. The optional
 // regexp is applied to the complete list and matching prefixes
 // displayed.
-func runLsAccts(cmd *commander.Command, args []string) {
+func runLsAccts(cmd *cobra.Command, args []string) {
 	if len(args) > 1 {
 		cmd.Usage()
 		return
@@ -82,9 +79,9 @@ func runLsAccts(cmd *commander.Command, args []string) {
 }
 
 // A rmAcctCmd command removes an acct config by prefix.
-var rmAcctCmd = &commander.Command{
-	UsageLine: "rm-acct [options] <key-prefix>",
-	Short:     "remove an accounting config by key prefix",
+var rmAcctCmd = &cobra.Command{
+	Use:   "rm-acct [options] <key-prefix>",
+	Short: "remove an accounting config by key prefix",
 	Long: `
 Remove an existing accounting config by key prefix. No action is taken if no
 accounting configuration exists for the specified key prefix. Note that this
@@ -92,13 +89,12 @@ command can affect only a single accounting config with an exactly matching
 prefix. The key prefix should be escaped via URL query escaping if it
 contains non-ascii bytes or spaces.
 `,
-	Run:  runRmAcct,
-	Flag: *flag.CommandLine,
+	Run: runRmAcct,
 }
 
 // runRmAcct invokes the REST API with DELETE action and key prefix as
 // path.
-func runRmAcct(cmd *commander.Command, args []string) {
+func runRmAcct(cmd *cobra.Command, args []string) {
 	if len(args) != 1 {
 		cmd.Usage()
 		return
@@ -108,9 +104,9 @@ func runRmAcct(cmd *commander.Command, args []string) {
 
 // A setAcctCmd command creates a new or updates an existing acct
 // config.
-var setAcctCmd = &commander.Command{
-	UsageLine: "set-acct [options] <key-prefix> <acct-config-file>",
-	Short:     "create or update an accounting config for key prefix\n",
+var setAcctCmd = &cobra.Command{
+	Use:   "set-acct [options] <key-prefix> <acct-config-file>",
+	Short: "create or update an accounting config for key prefix\n",
 	Long: `
 Create or update a accounting config for the specified key prefix (first
 argument: <key-prefix>) to the contents of the specified file
@@ -126,14 +122,13 @@ For example:
 
   cluster_id: test
 `,
-	Run:  runSetAcct,
-	Flag: *flag.CommandLine,
+	Run: runSetAcct,
 }
 
 // runSetAcct invokes the REST API with POST action and key prefix as
 // path. The specified configuration file is read from disk and sent
 // as the POST body.
-func runSetAcct(cmd *commander.Command, args []string) {
+func runSetAcct(cmd *cobra.Command, args []string) {
 	if len(args) != 2 {
 		cmd.Usage()
 		return

--- a/server/cli/accounting.go
+++ b/server/cli/accounting.go
@@ -20,7 +20,7 @@ package cli
 import (
 	"flag"
 
-	commander "code.google.com/p/go-commander"
+	"code.google.com/p/go-commander"
 	"github.com/cockroachdb/cockroach/server"
 )
 

--- a/server/cli/cert.go
+++ b/server/cli/cert.go
@@ -18,30 +18,28 @@
 package cli
 
 import (
-	"flag"
 	"fmt"
 
 	"github.com/cockroachdb/cockroach/security"
 
-	"code.google.com/p/go-commander"
+	"github.com/spf13/cobra"
 )
 
 // A createCACert command generates a CA certificate and stores it
 // in the cert directory.
-var createCACertCmd = &commander.Command{
-	UsageLine: "create-ca-cert [options]",
-	Short:     "create CA cert and key",
+var createCACertCmd = &cobra.Command{
+	Use:   "create-ca-cert [options]",
+	Short: "create CA cert and key",
 	Long: `
 Generates a new key pair, a new CA certificate and writes them to
-individual files in the directory specified by -certs (required).
+individual files in the directory specified by --certs (required).
 `,
-	Run:  runCreateCACert,
-	Flag: *flag.CommandLine,
+	Run: runCreateCACert,
 }
 
 // runCreateCACert generates key pair and CA certificate and writes them
 // to their corresponding files.
-func runCreateCACert(cmd *commander.Command, args []string) {
+func runCreateCACert(cmd *cobra.Command, args []string) {
 	err := security.RunCreateCACert(Context.Certs)
 	if err != nil {
 		fmt.Fprintf(osStderr, "failed to generate CA certificate: %s\n", err)
@@ -52,22 +50,21 @@ func runCreateCACert(cmd *commander.Command, args []string) {
 
 // A createNodeCert command generates a node certificate and stores it
 // in the cert directory.
-var createNodeCertCmd = &commander.Command{
-	UsageLine: "create-node-cert [options] <host 1> <host 2> ... <host N>",
-	Short:     "create node cert and key\n",
+var createNodeCertCmd = &cobra.Command{
+	Use:   "create-node-cert [options] <host 1> <host 2> ... <host N>",
+	Short: "create node cert and key\n",
 	Long: `
 Generates a new key pair, a new node certificate and writes them to
-individual files in the directory specified by -certs (required).
+individual files in the directory specified by --certs (required).
 The certs directory should contain a CA cert and key.
 At least one host should be passed in (either IP address of dns name).
 `,
-	Run:  runCreateNodeCert,
-	Flag: *flag.CommandLine,
+	Run: runCreateNodeCert,
 }
 
 // runCreateNodeCert generates key pair and CA certificate and writes them
 // to their corresponding files.
-func runCreateNodeCert(cmd *commander.Command, args []string) {
+func runCreateNodeCert(cmd *cobra.Command, args []string) {
 	err := security.RunCreateNodeCert(Context.Certs, args)
 	if err != nil {
 		fmt.Fprintf(osStderr, "failed to generate node certificate: %s\n", err)

--- a/server/cli/cli.go
+++ b/server/cli/cli.go
@@ -26,12 +26,12 @@ import (
 
 	"github.com/cockroachdb/cockroach/util"
 
-	"code.google.com/p/go-commander"
+	"github.com/spf13/cobra"
 )
 
-var listParamsCmd = &commander.Command{
-	UsageLine: "listparams",
-	Short:     "list all available parameters and their default values",
+var listParamsCmd = &cobra.Command{
+	Use:   "listparams",
+	Short: "list all available parameters and their default values",
 	Long: `
 List all available parameters and their default values.
 Note that parameter parsing stops after the first non-
@@ -39,18 +39,18 @@ option after the command name. Hence, the options need
 to precede any additional arguments,
 
   cockroach <command> [options] [arguments].`,
-	Run: func(cmd *commander.Command, args []string) {
+	Run: func(cmd *cobra.Command, args []string) {
 		flag.CommandLine.PrintDefaults()
 	},
 }
 
-var versionCmd = &commander.Command{
-	UsageLine: "version",
-	Short:     "output version information",
+var versionCmd = &cobra.Command{
+	Use:   "version",
+	Short: "output version information",
 	Long: `
 Output build version information.
 `,
-	Run: func(cmd *commander.Command, args []string) {
+	Run: func(cmd *cobra.Command, args []string) {
 		info := util.GetBuildInfo()
 		w := &tabwriter.Writer{}
 		w.Init(os.Stdout, 2, 1, 2, ' ', 0)
@@ -63,57 +63,63 @@ Output build version information.
 	},
 }
 
-var allCmds = &commander.Commander{
-	Name: "cockroach",
-	Commands: []*commander.Command{
-		// Node commands.
-		initCmd,
-		startCmd,
-		exterminateCmd,
-		quitCmd,
+var allCmds = []*cobra.Command{
+	// Node commands.
+	initCmd,
+	startCmd,
+	exterminateCmd,
+	quitCmd,
 
-		// Certificate commands.
-		createCACertCmd,
-		createNodeCertCmd,
+	// Certificate commands.
+	createCACertCmd,
+	createNodeCertCmd,
 
-		// Key/value commands.
-		getCmd,
-		putCmd,
-		incCmd,
-		delCmd,
-		scanCmd,
+	// Key/value commands.
+	getCmd,
+	putCmd,
+	incCmd,
+	delCmd,
+	scanCmd,
 
-		// Range commands.
-		lsRangesCmd,
-		splitRangeCmd,
-		mergeRangeCmd,
+	// Range commands.
+	lsRangesCmd,
+	splitRangeCmd,
+	mergeRangeCmd,
 
-		// Accounting commands.
-		getAcctCmd,
-		lsAcctsCmd,
-		rmAcctCmd,
-		setAcctCmd,
+	// Accounting commands.
+	getAcctCmd,
+	lsAcctsCmd,
+	rmAcctCmd,
+	setAcctCmd,
 
-		// Permission commands.
-		getPermsCmd,
-		lsPermsCmd,
-		rmPermsCmd,
-		setPermsCmd,
+	// Permission commands.
+	getPermsCmd,
+	lsPermsCmd,
+	rmPermsCmd,
+	setPermsCmd,
 
-		// Zone commands.
-		getZoneCmd,
-		lsZonesCmd,
-		rmZoneCmd,
-		setZoneCmd,
+	// Zone commands.
+	getZoneCmd,
+	lsZonesCmd,
+	rmZoneCmd,
+	setZoneCmd,
 
-		// Miscellaneous commands.
-		// TODO(pmattis): stats
-		listParamsCmd,
-		versionCmd,
-	},
+	// Miscellaneous commands.
+	// TODO(pmattis): stats
+	listParamsCmd,
+	versionCmd,
+}
+
+var cockroachCmd = cobra.Command{
+	Use: "cockroach",
+}
+
+func init() {
+	cockroachCmd.AddCommand(allCmds...)
 }
 
 // Run ...
 func Run(args []string) error {
-	return allCmds.Run(args)
+	cockroachCmd.SetArgs(args)
+	return cockroachCmd.Execute()
 }

--- a/server/cli/cli.go
+++ b/server/cli/cli.go
@@ -26,7 +26,7 @@ import (
 
 	"github.com/cockroachdb/cockroach/util"
 
-	commander "code.google.com/p/go-commander"
+	"code.google.com/p/go-commander"
 )
 
 var listParamsCmd = &commander.Command{

--- a/server/cli/cli_test.go
+++ b/server/cli/cli_test.go
@@ -48,9 +48,9 @@ func (c cliTest) Run(line string) {
 
 	var args []string
 	args = append(args, a[0])
-	args = append(args, fmt.Sprintf("-addr=%s", c.ServingAddr()))
+	args = append(args, fmt.Sprintf("--addr=%s", c.ServingAddr()))
 	// Always load test certs.
-	args = append(args, fmt.Sprintf("-certs=%s", security.EmbeddedCertsDir))
+	args = append(args, fmt.Sprintf("--certs=%s", security.EmbeddedCertsDir))
 	args = append(args, a[1:]...)
 
 	fmt.Printf("%s\n", line)

--- a/server/cli/flags.go
+++ b/server/cli/flags.go
@@ -18,9 +18,9 @@
 package cli
 
 import (
-	"flag"
-
 	"github.com/cockroachdb/cockroach/server"
+
+	"github.com/spf13/pflag"
 )
 
 // initFlags sets the server.Context values to flag values.
@@ -28,16 +28,16 @@ import (
 // settable here.
 func initFlags(ctx *server.Context) {
 	// Server flags.
-	flag.StringVar(&ctx.Addr, "addr", ctx.Addr, "when run as the server the host:port to bind for "+
+	pflag.StringVar(&ctx.Addr, "addr", ctx.Addr, "when run as the server the host:port to bind for "+
 		"HTTP/RPC traffic; when run as the client the address for connection to the cockroach cluster.")
 
-	flag.BoolVar(&ctx.Insecure, "insecure", ctx.Insecure, "run over plain HTTP. WARNING: "+
+	pflag.BoolVar(&ctx.Insecure, "insecure", ctx.Insecure, "run over plain HTTP. WARNING: "+
 		"this is strongly discouraged.")
 
-	flag.StringVar(&ctx.Certs, "certs", ctx.Certs, "directory containing RSA key and x509 certs. "+
-		"This flag is required if -insecure=false.")
+	pflag.StringVar(&ctx.Certs, "certs", ctx.Certs, "directory containing RSA key and x509 certs. "+
+		"This flag is required if --insecure=false.")
 
-	flag.StringVar(&ctx.Stores, "stores", ctx.Stores, "specify a comma-separated list of stores, "+
+	pflag.StringVar(&ctx.Stores, "stores", ctx.Stores, "specify a comma-separated list of stores, "+
 		"specified by a colon-separated list of device attributes followed by '=' and "+
 		"either a filepath for a persistent store or an integer size in bytes for an "+
 		"in-memory store. Device attributes typically include whether the store is "+
@@ -45,7 +45,7 @@ func initFlags(ctx *server.Context) {
 		"attributes might also include speeds and other specs (7200rpm, 200kiops, etc.). "+
 		"For example, -store=hdd:7200rpm=/mnt/hda1,ssd=/mnt/ssd01,ssd=/mnt/ssd02,mem=1073741824.")
 
-	flag.StringVar(&ctx.Attrs, "attrs", ctx.Attrs, "specify an ordered, colon-separated list of node "+
+	pflag.StringVar(&ctx.Attrs, "attrs", ctx.Attrs, "specify an ordered, colon-separated list of node "+
 		"attributes. Attributes are arbitrary strings specifying topography or "+
 		"machine capabilities. Topography might include datacenter designation "+
 		"(e.g. \"us-west-1a\", \"us-west-1b\", \"us-east-1c\"). Machine capabilities "+
@@ -54,36 +54,36 @@ func initFlags(ctx *server.Context) {
 		"The relative geographic proximity of two nodes is inferred from the "+
 		"common prefix of the attributes list, so topographic attributes should be "+
 		"specified first and in the same order for all nodes. "+
-		"For example: -attrs=us-west-1b,gpu.")
+		"For example: --attrs=us-west-1b,gpu.")
 
-	flag.DurationVar(&ctx.MaxOffset, "max-offset", ctx.MaxOffset, "specify "+
+	pflag.DurationVar(&ctx.MaxOffset, "max-offset", ctx.MaxOffset, "specify "+
 		"the maximum clock offset for the cluster. Clock offset is measured on all "+
 		"node-to-node links and if any node notices it has clock offset in excess "+
-		"of -max-offset, it will commit suicide. Setting this value too high may "+
+		"of --max-offset, it will commit suicide. Setting this value too high may "+
 		"decrease transaction performance in the presence of contention.")
 
 	// Gossip flags.
-	flag.StringVar(&ctx.GossipBootstrap, "gossip", ctx.GossipBootstrap, "specify a "+
+	pflag.StringVar(&ctx.GossipBootstrap, "gossip", ctx.GossipBootstrap, "specify a "+
 		"comma-separated list of gossip addresses or resolvers for gossip bootstrap. "+
 		"Each item in the list has an optional type: [type=]<address>. "+
 		"Unspecified type means ip address or dns. Type can also be a load balancer (\"lb\"), "+
 		"a unix socket (\"unix\") or, for single-node systems, \"self\".")
 
-	flag.DurationVar(&ctx.GossipInterval, "gossip-interval", ctx.GossipInterval,
+	pflag.DurationVar(&ctx.GossipInterval, "gossip-interval", ctx.GossipInterval,
 		"approximate interval (time.Duration) for gossiping new information to peers.")
 
 	// KV flags.
 
-	flag.BoolVar(&ctx.Linearizable, "linearizable", ctx.Linearizable, "enables linearizable behaviour "+
+	pflag.BoolVar(&ctx.Linearizable, "linearizable", ctx.Linearizable, "enables linearizable behaviour "+
 		"of operations on this node by making sure that no commit timestamp is reported "+
 		"back to the client until all other node clocks have necessarily passed it.")
 
 	// Engine flags.
 
-	flag.Int64Var(&ctx.CacheSize, "cache-size", ctx.CacheSize, "total size in bytes for "+
+	pflag.Int64Var(&ctx.CacheSize, "cache-size", ctx.CacheSize, "total size in bytes for "+
 		"caches, shared evenly if there are multiple storage devices.")
 
-	flag.DurationVar(&ctx.ScanInterval, "scan-interval", ctx.ScanInterval, "specify "+
+	pflag.DurationVar(&ctx.ScanInterval, "scan-interval", ctx.ScanInterval, "specify "+
 		"--scan_interval to adjust the target for the duration of a single scan "+
 		"through a store's ranges. The scan is slowed as necessary to approximately"+
 		"achieve this duration.")

--- a/server/cli/kv.go
+++ b/server/cli/kv.go
@@ -32,7 +32,7 @@ import (
 	"github.com/cockroachdb/cockroach/storage/engine"
 	"github.com/cockroachdb/cockroach/util"
 
-	commander "code.google.com/p/go-commander"
+	"code.google.com/p/go-commander"
 )
 
 var osExit = os.Exit

--- a/server/cli/kv.go
+++ b/server/cli/kv.go
@@ -21,7 +21,6 @@ package cli
 
 import (
 	"bytes"
-	"flag"
 	"fmt"
 	"os"
 	"strconv"
@@ -32,7 +31,7 @@ import (
 	"github.com/cockroachdb/cockroach/storage/engine"
 	"github.com/cockroachdb/cockroach/util"
 
-	"code.google.com/p/go-commander"
+	"github.com/spf13/cobra"
 )
 
 var osExit = os.Exit
@@ -50,17 +49,16 @@ func makeKVClient() (*client.KV, error) {
 }
 
 // A getCmd command gets the value for the specified key.
-var getCmd = &commander.Command{
-	UsageLine: "get [options] <key>",
-	Short:     "gets the value for a key",
+var getCmd = &cobra.Command{
+	Use:   "get [options] <key>",
+	Short: "gets the value for a key",
 	Long: `
 Fetches and display the value for <key>.
 `,
-	Run:  runGet,
-	Flag: *flag.CommandLine,
+	Run: runGet,
 }
 
-func runGet(cmd *commander.Command, args []string) {
+func runGet(cmd *cobra.Command, args []string) {
 	if len(args) != 1 {
 		cmd.Usage()
 		return
@@ -92,19 +90,18 @@ func runGet(cmd *commander.Command, args []string) {
 }
 
 // A putCmd command sets the value for one or more keys.
-var putCmd = &commander.Command{
-	UsageLine: "put [options] <key> <value> [<key2> <value2>...]",
-	Short:     "sets the value for a key",
+var putCmd = &cobra.Command{
+	Use:   "put [options] <key> <value> [<key2> <value2>...]",
+	Short: "sets the value for a key",
 	Long: `
 Sets the value for one or more keys. Keys and values must be provided
 in pairs on the command line. All of the key/value pairs are set within
 a transaction.
 `,
-	Run:  runPut,
-	Flag: *flag.CommandLine,
+	Run: runPut,
 }
 
-func runPut(cmd *commander.Command, args []string) {
+func runPut(cmd *cobra.Command, args []string) {
 	if len(args) == 0 || len(args)%2 == 1 {
 		cmd.Usage()
 		return
@@ -145,18 +142,17 @@ func runPut(cmd *commander.Command, args []string) {
 }
 
 // A incCmd command increments the value for one or more keys.
-var incCmd = &commander.Command{
-	UsageLine: "inc [options] <key> [<amount>]",
-	Short:     "increments the value for a key",
+var incCmd = &cobra.Command{
+	Use:   "inc [options] <key> [<amount>]",
+	Short: "increments the value for a key",
 	Long: `
 Increments the value for a key. The increment amount defaults to 1 if
 not specified. Displays the incremented value upon success.
 `,
-	Run:  runInc,
-	Flag: *flag.CommandLine,
+	Run: runInc,
 }
 
-func runInc(cmd *commander.Command, args []string) {
+func runInc(cmd *cobra.Command, args []string) {
 	if len(args) > 2 {
 		cmd.Usage()
 		return
@@ -196,17 +192,16 @@ func runInc(cmd *commander.Command, args []string) {
 }
 
 // A delCmd command sets the value for one or more keys.
-var delCmd = &commander.Command{
-	UsageLine: "del [options] <key> [<key2>...]",
-	Short:     "deletes the value for a key",
+var delCmd = &cobra.Command{
+	Use:   "del [options] <key> [<key2>...]",
+	Short: "deletes the value for a key",
 	Long: `
 Deletes the value for one or more keys.
 `,
-	Run:  runDel,
-	Flag: *flag.CommandLine,
+	Run: runDel,
 }
 
-func runDel(cmd *commander.Command, args []string) {
+func runDel(cmd *cobra.Command, args []string) {
 	if len(args) == 0 {
 		cmd.Usage()
 		return
@@ -244,9 +239,9 @@ func runDel(cmd *commander.Command, args []string) {
 
 // A scanCmd command fetches the key/value pairs for a specified
 // range.
-var scanCmd = &commander.Command{
-	UsageLine: "scan [options] [<start-key> [<end-key>]]",
-	Short:     "scans a range of keys\n",
+var scanCmd = &cobra.Command{
+	Use:   "scan [options] [<start-key> [<end-key>]]",
+	Short: "scans a range of keys\n",
 	Long: `
 Fetches and display the key/value pairs for a range. If no <start-key>
 is specified then all (non-system) key/value pairs are retrieved. If no
@@ -255,11 +250,10 @@ are retrieved.
 
 Caveat: Currently only retrieves up to 1000 keys.
 `,
-	Run:  runScan,
-	Flag: *flag.CommandLine,
+	Run: runScan,
 }
 
-func runScan(cmd *commander.Command, args []string) {
+func runScan(cmd *cobra.Command, args []string) {
 	if len(args) > 2 {
 		cmd.Usage()
 		return

--- a/server/cli/permission.go
+++ b/server/cli/permission.go
@@ -20,7 +20,7 @@ package cli
 import (
 	"flag"
 
-	commander "code.google.com/p/go-commander"
+	"code.google.com/p/go-commander"
 	"github.com/cockroachdb/cockroach/server"
 )
 

--- a/server/cli/permission.go
+++ b/server/cli/permission.go
@@ -18,28 +18,26 @@
 package cli
 
 import (
-	"flag"
-
-	"code.google.com/p/go-commander"
 	"github.com/cockroachdb/cockroach/server"
+
+	"github.com/spf13/cobra"
 )
 
 // A getPermsCmd command displays the perm config for the specified
 // prefix.
-var getPermsCmd = &commander.Command{
-	UsageLine: "get-perms [options] <key-prefix>",
-	Short:     "fetches and displays the permission config",
+var getPermsCmd = &cobra.Command{
+	Use:   "get-perms [options] <key-prefix>",
+	Short: "fetches and displays the permission config",
 	Long: `
 Fetches and displays the permission configuration for <key-prefix>. The key
 prefix should be escaped via URL query escaping if it contains
 non-ascii bytes or spaces.
 `,
-	Run:  runGetPerms,
-	Flag: *flag.CommandLine,
+	Run: runGetPerms,
 }
 
 // runGetPerms invokes the REST API with GET action and key prefix as path.
-func runGetPerms(cmd *commander.Command, args []string) {
+func runGetPerms(cmd *cobra.Command, args []string) {
 	if len(args) != 1 {
 		cmd.Usage()
 		return
@@ -48,24 +46,23 @@ func runGetPerms(cmd *commander.Command, args []string) {
 }
 
 // A lsPermsCmd command displays a list of perm configs by prefix.
-var lsPermsCmd = &commander.Command{
-	UsageLine: "ls-perms [options] [key-regexp]",
-	Short:     "list all permisison configs by key prefix",
+var lsPermsCmd = &cobra.Command{
+	Use:   "ls-perms [options] [key-regexp]",
+	Short: "list all permisison configs by key prefix",
 	Long: `
 List permission configs. If a regular expression is given, the results of
 the listing are filtered by key prefixes matching the regexp. The key
 prefix should be escaped via URL query escaping if it contains
 non-ascii bytes or spaces.
 `,
-	Run:  runLsPerms,
-	Flag: *flag.CommandLine,
+	Run: runLsPerms,
 }
 
 // runLsPerms invokes the REST API with GET action and no path, which
 // fetches a list of all perm configuration prefixes. The optional
 // regexp is applied to the complete list and matching prefixes
 // displayed.
-func runLsPerms(cmd *commander.Command, args []string) {
+func runLsPerms(cmd *cobra.Command, args []string) {
 	if len(args) > 1 {
 		cmd.Usage()
 		return
@@ -79,9 +76,9 @@ func runLsPerms(cmd *commander.Command, args []string) {
 }
 
 // A rmPermsCmd command removes a perm config by prefix.
-var rmPermsCmd = &commander.Command{
-	UsageLine: "rm-perms [options] <key-prefix>",
-	Short:     "remove a permission config by key prefix",
+var rmPermsCmd = &cobra.Command{
+	Use:   "rm-perms [options] <key-prefix>",
+	Short: "remove a permission config by key prefix",
 	Long: `
 Remove an existing permission config by key prefix. No action is taken if no
 permission configuration exists for the specified key prefix. Note that this
@@ -89,13 +86,12 @@ command can affect only a single perm config with an exactly matching
 prefix. The key prefix should be escaped via URL query escaping if it
 contains non-ascii bytes or spaces.
 `,
-	Run:  runRmPerms,
-	Flag: *flag.CommandLine,
+	Run: runRmPerms,
 }
 
 // runRmPerms invokes the REST API with DELETE action and key prefix as
 // path.
-func runRmPerms(cmd *commander.Command, args []string) {
+func runRmPerms(cmd *cobra.Command, args []string) {
 	if len(args) != 1 {
 		cmd.Usage()
 		return
@@ -105,9 +101,9 @@ func runRmPerms(cmd *commander.Command, args []string) {
 
 // A setPermsCmd command creates a new or updates an existing perm
 // config.
-var setPermsCmd = &commander.Command{
-	UsageLine: "set-perm [options] <key-prefix> <perm-config-file>",
-	Short:     "create or update permission config for key prefix\n",
+var setPermsCmd = &cobra.Command{
+	Use:   "set-perm [options] <key-prefix> <perm-config-file>",
+	Short: "create or update permission config for key prefix\n",
 	Long: `
 Create or update a perm config for the specified key prefix (first
 argument: <key-prefix>) to the contents of the specified file
@@ -138,14 +134,13 @@ For example:
 Setting permission configs will guarantee that users will have permissions for
 this key prefix and all sub prefixes of the one that is set
 `,
-	Run:  runSetPerms,
-	Flag: *flag.CommandLine,
+	Run: runSetPerms,
 }
 
 // runSetPerm invokes the REST API with POST action and key prefix as
 // path. The specified configuration file is read from disk and sent
 // as the POST body.
-func runSetPerms(cmd *commander.Command, args []string) {
+func runSetPerms(cmd *cobra.Command, args []string) {
 	if len(args) != 2 {
 		cmd.Usage()
 		return

--- a/server/cli/range.go
+++ b/server/cli/range.go
@@ -22,7 +22,7 @@ import (
 	"fmt"
 	"os"
 
-	commander "code.google.com/p/go-commander"
+	"code.google.com/p/go-commander"
 	"github.com/cockroachdb/cockroach/client"
 	"github.com/cockroachdb/cockroach/proto"
 	"github.com/cockroachdb/cockroach/storage/engine"

--- a/server/cli/range.go
+++ b/server/cli/range.go
@@ -18,31 +18,30 @@
 package cli
 
 import (
-	"flag"
 	"fmt"
 	"os"
 
-	"code.google.com/p/go-commander"
 	"github.com/cockroachdb/cockroach/client"
 	"github.com/cockroachdb/cockroach/proto"
 	"github.com/cockroachdb/cockroach/storage/engine"
+
 	gogoproto "github.com/gogo/protobuf/proto"
+	"github.com/spf13/cobra"
 )
 
 // A lsRangesCmd command lists the ranges in a cluster.
-var lsRangesCmd = &commander.Command{
-	UsageLine: "ls-ranges [options] [<start-key>]",
-	Short:     "lists the ranges",
+var lsRangesCmd = &cobra.Command{
+	Use:   "ls-ranges [options] [<start-key>]",
+	Short: "lists the ranges",
 	Long: `
 Lists the ranges in a cluster.
 
 Caveat: Currently only lists up to 1000 rangges.
 `,
-	Run:  runLsRanges,
-	Flag: *flag.CommandLine,
+	Run: runLsRanges,
 }
 
-func runLsRanges(cmd *commander.Command, args []string) {
+func runLsRanges(cmd *cobra.Command, args []string) {
 	if len(args) > 1 {
 		cmd.Usage()
 		return
@@ -82,19 +81,18 @@ func runLsRanges(cmd *commander.Command, args []string) {
 }
 
 // A splitRangeCmd command splits a range.
-var splitRangeCmd = &commander.Command{
-	UsageLine: "split-range [options] <key> [<split-key>]",
-	Short:     "splits a range",
+var splitRangeCmd = &cobra.Command{
+	Use:   "split-range [options] <key> [<split-key>]",
+	Short: "splits a range",
 	Long: `
 Splits the range containing <key>. If <split-key> is not specified a
 key to split the range approximately in half will be automatically
 chosen.
 `,
-	Run:  runSplitRange,
-	Flag: *flag.CommandLine,
+	Run: runSplitRange,
 }
 
-func runSplitRange(cmd *commander.Command, args []string) {
+func runSplitRange(cmd *cobra.Command, args []string) {
 	if len(args) == 0 || len(args) > 2 {
 		cmd.Usage()
 		return
@@ -126,17 +124,16 @@ func runSplitRange(cmd *commander.Command, args []string) {
 }
 
 // A mergeRangeCmd command merges a range.
-var mergeRangeCmd = &commander.Command{
-	UsageLine: "merge-range [options] <key>",
-	Short:     "merges a range\n",
+var mergeRangeCmd = &cobra.Command{
+	Use:   "merge-range [options] <key>",
+	Short: "merges a range\n",
 	Long: `
 Merges the range containing <key> with the immediate successor range.
 `,
-	Run:  runMergeRange,
-	Flag: *flag.CommandLine,
+	Run: runMergeRange,
 }
 
-func runMergeRange(cmd *commander.Command, args []string) {
+func runMergeRange(cmd *cobra.Command, args []string) {
 	if len(args) != 1 {
 		cmd.Usage()
 		return

--- a/server/cli/start.go
+++ b/server/cli/start.go
@@ -25,7 +25,7 @@ import (
 	"syscall"
 	"time"
 
-	commander "code.google.com/p/go-commander"
+	"code.google.com/p/go-commander"
 	"github.com/cockroachdb/cockroach/kv"
 	"github.com/cockroachdb/cockroach/server"
 	"github.com/cockroachdb/cockroach/storage/engine"

--- a/server/cli/zone.go
+++ b/server/cli/zone.go
@@ -19,28 +19,26 @@
 package cli
 
 import (
-	"flag"
-
-	"code.google.com/p/go-commander"
 	"github.com/cockroachdb/cockroach/server"
+
+	"github.com/spf13/cobra"
 )
 
 // A getZoneCmd command displays the zone config for the specified
 // prefix.
-var getZoneCmd = &commander.Command{
-	UsageLine: "get-zone [options] <key-prefix>",
-	Short:     "fetches and displays the zone config",
+var getZoneCmd = &cobra.Command{
+	Use:   "get-zone [options] <key-prefix>",
+	Short: "fetches and displays the zone config",
 	Long: `
 Fetches and displays the zone configuration for <key-prefix>. The key
 prefix should be escaped via URL query escaping if it contains
 non-ascii bytes or spaces.
 `,
-	Run:  runGetZone,
-	Flag: *flag.CommandLine,
+	Run: runGetZone,
 }
 
 // runGetZone invokes the REST API with GET action and key prefix as path.
-func runGetZone(cmd *commander.Command, args []string) {
+func runGetZone(cmd *cobra.Command, args []string) {
 	if len(args) != 1 {
 		cmd.Usage()
 		return
@@ -49,24 +47,23 @@ func runGetZone(cmd *commander.Command, args []string) {
 }
 
 // A lsZonesCmd command displays a list of zone configs by prefix.
-var lsZonesCmd = &commander.Command{
-	UsageLine: "ls-zones [options] [key-regexp]",
-	Short:     "list all zone configs by key prefix",
+var lsZonesCmd = &cobra.Command{
+	Use:   "ls-zones [options] [key-regexp]",
+	Short: "list all zone configs by key prefix",
 	Long: `
 List zone configs. If a regular expression is given, the results of
 the listing are filtered by key prefixes matching the regexp. The key
 prefix should be escaped via URL query escaping if it contains
 non-ascii bytes or spaces.
 `,
-	Run:  runLsZones,
-	Flag: *flag.CommandLine,
+	Run: runLsZones,
 }
 
 // runLsZones invokes the REST API with GET action and no path, which
 // fetches a list of all zone configuration prefixes. The optional
 // regexp is applied to the complete list and matching prefixes
 // displayed.
-func runLsZones(cmd *commander.Command, args []string) {
+func runLsZones(cmd *cobra.Command, args []string) {
 	if len(args) > 1 {
 		cmd.Usage()
 		return
@@ -79,9 +76,9 @@ func runLsZones(cmd *commander.Command, args []string) {
 }
 
 // A rmZoneCmd command removes a zone config by prefix.
-var rmZoneCmd = &commander.Command{
-	UsageLine: "rm-zone [options] <key-prefix>",
-	Short:     "remove a zone config by key prefix",
+var rmZoneCmd = &cobra.Command{
+	Use:   "rm-zone [options] <key-prefix>",
+	Short: "remove a zone config by key prefix",
 	Long: `
 Remove an existing zone config by key prefix. No action is taken if no
 zone configuration exists for the specified key prefix. Note that this
@@ -89,13 +86,12 @@ command can affect only a single zone config with an exactly matching
 prefix. The key prefix should be escaped via URL query escaping if it
 contains non-ascii bytes or spaces.
 `,
-	Run:  runRmZone,
-	Flag: *flag.CommandLine,
+	Run: runRmZone,
 }
 
 // runRmZone invokes the REST API with DELETE action and key prefix as
 // path.
-func runRmZone(cmd *commander.Command, args []string) {
+func runRmZone(cmd *cobra.Command, args []string) {
 	if len(args) != 1 {
 		cmd.Usage()
 		return
@@ -105,9 +101,9 @@ func runRmZone(cmd *commander.Command, args []string) {
 
 // A setZoneCmd command creates a new or updates an existing zone
 // config.
-var setZoneCmd = &commander.Command{
-	UsageLine: "set-zone [options] <key-prefix> <zone-config-file>",
-	Short:     "create or update zone config for key prefix\n",
+var setZoneCmd = &cobra.Command{
+	Use:   "set-zone [options] <key-prefix> <zone-config-file>",
+	Short: "create or update zone config for key prefix\n",
 	Long: `
 Create or update a zone config for the specified key prefix (first
 argument: <key-prefix>) to the contents of the specified file
@@ -136,14 +132,13 @@ Setting zone configs will guarantee that key ranges will be split
 such that no key range straddles two zone config specifications.
 This feature can be taken advantage of to pre-split ranges.
 `,
-	Run:  runSetZone,
-	Flag: *flag.CommandLine,
+	Run: runSetZone,
 }
 
 // runSetZone invokes the REST API with POST action and key prefix as
 // path. The specified configuration file is read from disk and sent
 // as the POST body.
-func runSetZone(cmd *commander.Command, args []string) {
+func runSetZone(cmd *cobra.Command, args []string) {
 	if len(args) != 2 {
 		cmd.Usage()
 		return

--- a/server/cli/zone.go
+++ b/server/cli/zone.go
@@ -21,7 +21,7 @@ package cli
 import (
 	"flag"
 
-	commander "code.google.com/p/go-commander"
+	"code.google.com/p/go-commander"
 	"github.com/cockroachdb/cockroach/server"
 )
 

--- a/server/context.go
+++ b/server/context.go
@@ -138,7 +138,7 @@ func (ctx *Context) Init(command string) error {
 		storeSpecs := storesRE.FindAllStringSubmatch(ctx.Stores, -1)
 		if storeSpecs == nil || len(storeSpecs) == 0 {
 			return fmt.Errorf("invalid or empty engines specification %q, "+
-				"did you specify -stores?", ctx.Stores)
+				"did you specify --stores?", ctx.Stores)
 		}
 
 		ctx.Engines = nil
@@ -167,7 +167,7 @@ func (ctx *Context) Init(command string) error {
 			return err
 		}
 		if len(resolvers) == 0 {
-			return errors.New("no gossip addresses found, did you specify -gossip?")
+			return errors.New("no gossip addresses found, did you specify --gossip?")
 		}
 		ctx.GossipBootstrapResolvers = resolvers
 	}
@@ -202,8 +202,8 @@ func (ctx *Context) parseGossipBootstrapResolvers() ([]gossip.Resolver, error) {
 		}
 		// Special case self:// to pick a nice address that resolves
 		// uniquely for use in Gossip. This avoids having to specify
-		// the port for single-node clusters twice (once in -addr,
-		// once in -gossip).
+		// the port for single-node clusters twice (once in --addr,
+		// once in --gossip).
 		if strings.HasPrefix(address, "self://") {
 			address = util.EnsureHost(ctx.Addr)
 		}

--- a/server/server.go
+++ b/server/server.go
@@ -83,7 +83,7 @@ func NewServer(ctx *Context, stopper *util.Stopper) (*Server, error) {
 	}
 
 	if ctx.Insecure {
-		log.Warning("running in insecure mode, this is strongly discouraged. See -insecure and -certs.")
+		log.Warning("running in insecure mode, this is strongly discouraged. See --insecure and --certs.")
 	}
 	tlsConfig, err := ctx.GetServerTLSConfig()
 	if err != nil {

--- a/server/server_test.go
+++ b/server/server_test.go
@@ -176,7 +176,7 @@ func TestHealth(t *testing.T) {
 // TestPlainHTTPServer verifies that we can serve plain http and talk to it.
 // This is controlled by -cert=""
 func TestPlainHTTPServer(t *testing.T) {
-	// Create a custom context. The default one has a default -certs value.
+	// Create a custom context. The default one has a default --certs value.
 	ctx := NewContext()
 	ctx.Addr = "127.0.0.1:0"
 	ctx.Insecure = true


### PR DESCRIPTION
cobra uses `pflags` over `flags`, and `pflags` strictly treats
single-dash flags as shorthands, so all invocations including flags
have grown a leading dash.

Fixes #867.

Moar info: https://github.com/ogier/pflag#command-line-flag-syntax
