### PR TITLE
New format-based {Encode,Decode}Key.

### DIFF
--- a/storage/engine/keys.go
+++ b/storage/engine/keys.go
@@ -153,7 +153,7 @@ func DecodeRangeKey(key proto.Key) (startKey, suffix, detail proto.Key) {
 	}
 	// Cut the prefix and the Raft ID.
 	b := key[len(KeyLocalRangeKeyPrefix):]
-	b, startKey = encoding.DecodeBytes(b)
+	b, startKey = encoding.DecodeBytes(b, nil)
 	if len(b) < KeyLocalSuffixLength {
 		panic(fmt.Sprintf("key %q does not have suffix of length %d", key, KeyLocalSuffixLength))
 	}
@@ -214,7 +214,7 @@ func KeyAddress(k proto.Key) proto.Key {
 	}
 	if bytes.HasPrefix(k, KeyLocalRangeKeyPrefix) {
 		k = k[len(KeyLocalRangeKeyPrefix):]
-		_, k = encoding.DecodeBytes(k)
+		_, k = encoding.DecodeBytes(k, nil)
 		return k
 	}
 	log.Fatalf("local key %q malformed; should contain prefix %q", k, KeyLocalRangeKeyPrefix)

--- a/storage/engine/mvcc.go
+++ b/storage/engine/mvcc.go
@@ -1514,7 +1514,7 @@ func mvccEncodeTimestamp(key proto.EncodedKey, timestamp proto.Timestamp) proto.
 // The decoded key, timestamp and true are returned to indicate the
 // key is for an MVCC versioned value.
 func MVCCDecodeKey(encodedKey proto.EncodedKey) (proto.Key, proto.Timestamp, bool) {
-	tsBytes, key := encoding.DecodeBytes(encodedKey)
+	tsBytes, key := encoding.DecodeBytes(encodedKey, nil)
 	if len(tsBytes) == 0 {
 		return key, proto.Timestamp{}, false
 	} else if len(tsBytes) != 12 {

--- a/storage/store.go
+++ b/storage/store.go
@@ -95,7 +95,7 @@ func verifyKeyLength(key proto.Key) error {
 	maxLength := engine.KeyMaxLength
 	if bytes.HasPrefix(key, engine.KeyLocalRangeKeyPrefix) {
 		key = key[len(engine.KeyLocalRangeKeyPrefix):]
-		_, key = encoding.DecodeBytes(key)
+		_, key = encoding.DecodeBytes(key, nil)
 	}
 	if bytes.HasPrefix(key, engine.KeyMetaPrefix) {
 		key = key[len(engine.KeyMeta1Prefix):]

--- a/ts/keys.go
+++ b/ts/keys.go
@@ -94,7 +94,7 @@ func DecodeDataKey(key proto.Key) (string, string, Resolution, int64) {
 	remainder = remainder[len(keyDataPrefix):]
 
 	// Decode series name.
-	remainder, name = encoding.DecodeBytes(remainder)
+	remainder, name = encoding.DecodeBytes(remainder, nil)
 	// Decode resolution.
 	remainder, resolutionInt = encoding.DecodeVarint(remainder)
 	resolution := Resolution(resolutionInt)

--- a/util/encoding/complement_fast.go
+++ b/util/encoding/complement_fast.go
@@ -1,0 +1,41 @@
+// Copyright 2015 The Cockroach Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+// implied. See the License for the specific language governing
+// permissions and limitations under the License. See the AUTHORS file
+// for names of contributors.
+//
+// Author: Peter Mattis (peter.mattis@gmail.com)
+
+// +build 386 amd64
+
+package encoding
+
+import "unsafe"
+
+// The idea for the fast ones complement is borrowed from fastXORBytes
+// in the crypto standard library.
+const wordSize = int(unsafe.Sizeof(uintptr(0)))
+
+func onesComplement(b []byte) {
+	n := len(b)
+	w := n / wordSize
+	if w > 0 {
+		bw := *(*[]uintptr)(unsafe.Pointer(&b))
+		for i := 0; i < w; i++ {
+			bw[i] = ^bw[i]
+		}
+	}
+
+	for i := w * wordSize; i < n; i++ {
+		b[i] = ^b[i]
+	}
+}

--- a/util/encoding/complement_safe.go
+++ b/util/encoding/complement_safe.go
@@ -1,0 +1,26 @@
+// Copyright 2015 The Cockroach Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+// implied. See the License for the specific language governing
+// permissions and limitations under the License. See the AUTHORS file
+// for names of contributors.
+//
+// Author: Peter Mattis (peter.mattis@gmail.com)
+
+// +build !386,!amd64
+
+package encoding
+
+func onesComplement(b []byte) {
+	for i := range b {
+		b[i] = ^b[i]
+	}
+}


### PR DESCRIPTION
Added {Encode,Decode}BytesDecreasing. Added fast version of
onesComplement based on the fastXORBytes in the crypto standard
library. Changed DecodeBytes to take a result parameter to allow the
caller to avoid allocations (passing nil is fine).
