### PR TITLE
disallow the log.V(i).Infof syntax

### DIFF
--- a/base/context.go
+++ b/base/context.go
@@ -94,14 +94,18 @@ func (ctx *Context) GetClientTLSConfig() (*tls.Config, error) {
 	}
 
 	if ctx.Certs != "" {
-		log.V(1).Infof("setting up TLS from certificates directory: %s", ctx.Certs)
+		if log.V(1) {
+			log.Infof("setting up TLS from certificates directory: %s", ctx.Certs)
+		}
 		cfg, err := security.LoadClientTLSConfigFromDir(ctx.Certs)
 		if err != nil {
 			return nil, util.Errorf("error setting up client TLS config: %s", err)
 		}
 		ctx.clientTLSConfig = cfg
 	} else {
-		log.V(1).Infof("no certificates directory specified: using insecure TLS")
+		if log.V(1) {
+			log.Infof("no certificates directory specified: using insecure TLS")
+		}
 		ctx.clientTLSConfig = security.LoadInsecureClientTLSConfig()
 	}
 
@@ -128,7 +132,9 @@ func (ctx *Context) GetServerTLSConfig() (*tls.Config, error) {
 		return nil, util.Errorf("--insecure=false, but --certs is empty. We need a certs directory")
 	}
 
-	log.V(1).Infof("setting up TLS from certificates directory: %s", ctx.Certs)
+	if log.V(1) {
+		log.Infof("setting up TLS from certificates directory: %s", ctx.Certs)
+	}
 	cfg, err := security.LoadTLSConfigFromDir(ctx.Certs)
 	if err != nil {
 		return nil, util.Errorf("error setting up server TLS config: %s", err)

--- a/gossip/client.go
+++ b/gossip/client.go
@@ -158,7 +158,9 @@ func (c *client) gossip(g *Gossip, stopper *util.Stopper) error {
 			if err := gob.NewDecoder(bytes.NewBuffer(reply.Delta)).Decode(delta); err != nil {
 				return util.Errorf("infostore could not be decoded: %s", err)
 			}
-			log.V(1).Infof("received gossip reply delta from %s: %s", c.addr, delta)
+			if log.V(1) {
+				log.Infof("received gossip reply delta from %s: %s", c.addr, delta)
+			}
 			g.mu.Lock()
 			c.peerID = delta.NodeID
 			g.outgoing.addNode(c.peerID)

--- a/gossip/server.go
+++ b/gossip/server.go
@@ -104,7 +104,9 @@ func (s *server) Gossip(args *proto.GossipRequest, reply *proto.GossipResponse) 
 		if err := gob.NewDecoder(bytes.NewBuffer(args.Delta)).Decode(delta); err != nil {
 			return util.Errorf("infostore could not be decoded: %s", err)
 		}
-		log.V(1).Infof("received delta infostore from client %s: %s", addr, delta)
+		if log.V(1) {
+			log.Infof("received delta infostore from client %s: %s", addr, delta)
+		}
 		s.is.combine(delta)
 	}
 	// If requested max sequence is not -1, wait for gossip interval to expire.

--- a/kv/dist_sender.go
+++ b/kv/dist_sender.go
@@ -419,7 +419,9 @@ func (ds *DistSender) sendRPC(desc *proto.RangeDescriptor,
 	for i := range replicas {
 		addr, err := ds.gossip.GetNodeIDAddress(replicas[i].NodeID)
 		if err != nil {
-			log.V(1).Infof("node %d address is not gossiped: %v", replicas[i].NodeID, err)
+			if log.V(1) {
+				log.Infof("node %d address is not gossiped: %v", replicas[i].NodeID, err)
+			}
 			continue
 		}
 		addrs = append(addrs, addr)
@@ -631,13 +633,17 @@ func (ds *DistSender) updateLeaderCache(rid proto.RaftID, leader proto.Replica) 
 	oldLeader := ds.leaderCache.Lookup(rid)
 	ds.leaderCache.Update(rid, proto.Replica{})
 	if oldLeader != nil {
-		log.V(1).Infof("raft %d: evicted cached leader %d", rid, oldLeader.StoreID)
+		if log.V(1) {
+			log.Infof("raft %d: evicted cached leader %d", rid, oldLeader.StoreID)
+		}
 	}
 	if leader.StoreID == 0 {
 		return
 	}
 	if oldLeader == nil || leader.StoreID != oldLeader.StoreID {
-		log.V(1).Infof("raft %d: new cached leader %d", rid, leader.StoreID)
+		if log.V(1) {
+			log.Infof("raft %d: new cached leader %d", rid, leader.StoreID)
+		}
 		ds.leaderCache.Update(rid, leader)
 	}
 }

--- a/kv/range_cache.go
+++ b/kv/range_cache.go
@@ -109,7 +109,9 @@ func (rmc *rangeDescriptorCache) String() string {
 func (rmc *rangeDescriptorCache) LookupRangeDescriptor(key proto.Key,
 	options lookupOptions) (*proto.RangeDescriptor, error) {
 	_, r := rmc.getCachedRangeDescriptor(key)
-	log.V(1).Infof("lookup range descriptor: key=%s desc=%+v\n%s", key, r, rmc)
+	if log.V(1) {
+		log.Infof("lookup range descriptor: key=%s desc=%+v\n%s", key, r, rmc)
+	}
 	if r != nil {
 		return r, nil
 	}
@@ -145,7 +147,9 @@ func (rmc *rangeDescriptorCache) EvictCachedRangeDescriptor(key proto.Key) {
 			rmc.rangeCacheMu.Lock()
 			rmc.rangeCache.Del(k)
 			rmc.rangeCacheMu.Unlock()
-			log.V(1).Infof("evict cached descriptor: key=%s desc=%+v\n%s", key, rd, rmc)
+			if log.V(1) {
+				log.Infof("evict cached descriptor: key=%s desc=%+v\n%s", key, rd, rmc)
+			}
 		}
 		// Retrieve the metadata range key for the next level of metadata, and
 		// evict that key as well. This loop ends after the meta1 range, which

--- a/kv/txn_correctness_test.go
+++ b/kv/txn_correctness_test.go
@@ -97,7 +97,9 @@ func (c *cmd) execute(db runner, t *testing.T) (string, error) {
 	if c.prev != nil {
 		<-c.prev
 	}
-	log.V(1).Infof("executing %s", c)
+	if log.V(1) {
+		log.Infof("executing %s", c)
+	}
 	err := c.fn(c, db, t)
 	if c.ch != nil {
 		c.ch <- struct{}{}
@@ -504,7 +506,9 @@ func (hv *historyVerifier) run(isolations []proto.IsolationType, db *client.KV, 
 func (hv *historyVerifier) runHistory(historyIdx int, priorities []int32,
 	isolations []proto.IsolationType, cmds []*cmd, db *client.KV, t *testing.T) error {
 	plannedStr := historyString(cmds)
-	log.V(1).Infof("attempting iso=%v pri=%v history=%s", isolations, priorities, plannedStr)
+	if log.V(1) {
+		log.Infof("attempting iso=%v pri=%v history=%s", isolations, priorities, plannedStr)
+	}
 
 	hv.actual = []string{}
 	hv.wg.Add(len(priorities))
@@ -546,7 +550,9 @@ func (hv *historyVerifier) runHistory(historyIdx int, priorities []int32,
 
 	err := hv.verify.checkFn(verifyEnv)
 	if err == nil {
-		log.V(1).Infof("PASSED: iso=%v, pri=%v, history=%q", isolations, priorities, actualStr)
+		if log.V(1) {
+			log.Infof("PASSED: iso=%v, pri=%v, history=%q", isolations, priorities, actualStr)
+		}
 	}
 	if hv.expSuccess && err != nil {
 		verifyStr := strings.Join(verifyStrs, " ")
@@ -579,7 +585,9 @@ func (hv *historyVerifier) runTxn(txnIdx int, priority int32,
 				c.done()
 			}
 		}
-		log.V(1).Infof("%s, retry=%d", txnName, retry)
+		if log.V(1) {
+			log.Infof("%s, retry=%d", txnName, retry)
+		}
 		for i := range cmds {
 			cmds[i].env = env
 			if err := hv.runCmd(txn, txnIdx, retry, i, cmds, t); err != nil {

--- a/main.go
+++ b/main.go
@@ -53,7 +53,9 @@ func main() {
 	numCPU := runtime.NumCPU()
 	runtime.GOMAXPROCS(numCPU)
 	rand.Seed(util.NewPseudoSeed())
-	log.V(1).Infof("running using %d processor cores", numCPU)
+	if log.V(1) {
+		log.Infof("running using %d processor cores", numCPU)
+	}
 
 	if len(os.Args) == 1 {
 		os.Args = append(os.Args, "help")

--- a/multiraft/storage.go
+++ b/multiraft/storage.go
@@ -148,13 +148,17 @@ func (w *writeTask) start(stopper *util.Stopper) {
 				return
 			case request = <-w.in:
 			}
-			log.V(6).Infof("writeTask got request %#v", *request)
+			if log.V(6) {
+				log.Infof("writeTask got request %#v", *request)
+			}
 			response := &writeResponse{make(map[uint64]*groupWriteResponse)}
 
 			for groupID, groupReq := range request.groups {
 				group := w.storage.GroupStorage(groupID)
 				if group == nil {
-					log.V(4).Infof("dropping write to group %v", groupID)
+					if log.V(4) {
+						log.Infof("dropping write to group %v", groupID)
+					}
 					continue
 				}
 				groupResp := &groupWriteResponse{raftpb.HardState{}, -1, -1, groupReq.entries}

--- a/rpc/client.go
+++ b/rpc/client.go
@@ -244,7 +244,9 @@ func (c *Client) heartbeat() error {
 	select {
 	case <-call.Done:
 		receiveTime := c.clock.PhysicalNow()
-		log.V(1).Infof("client %s heartbeat: %v", c.Addr(), call.Error)
+		if log.V(1) {
+			log.Infof("client %s heartbeat: %v", c.Addr(), call.Error)
+		}
 		c.mu.Lock()
 		c.healthy = true
 		c.offset.MeasuredAt = receiveTime

--- a/rpc/clock_offset.go
+++ b/rpc/clock_offset.go
@@ -144,7 +144,9 @@ func (r *RemoteClockMonitor) UpdateOffset(addr string, offset proto.RemoteOffset
 // MaxOffset, then this method will trigger a fatal error, causing the node to
 // suicide.
 func (r *RemoteClockMonitor) MonitorRemoteOffsets() {
-	log.V(1).Infof("monitoring cluster offset")
+	if log.V(1) {
+		log.Infof("monitoring cluster offset")
+	}
 	for {
 		time.Sleep(monitorInterval)
 		offsetInterval, err := r.findOffsetInterval()
@@ -168,7 +170,9 @@ func (r *RemoteClockMonitor) MonitorRemoteOffsets() {
 					"indicates that the true offset is greater than %d",
 					r.offsets, offsetInterval, r.lClock.MaxOffset())
 			}
-			log.V(1).Infof("healthy cluster offset: %v", offsetInterval)
+			if log.V(1) {
+				log.Infof("healthy cluster offset: %v", offsetInterval)
+			}
 		}
 		r.mu.Lock()
 		r.lastMonitoredAt = r.lClock.PhysicalNow()
@@ -209,8 +213,10 @@ func (r *RemoteClockMonitor) findOffsetInterval() (ClusterOffsetInterval, error)
 	endpoints := r.buildEndpointList()
 	sort.Sort(endpoints)
 	numClocks := len(endpoints) / 2
-	log.V(1).Infof("finding offset interval for monitorInterval: %d, numOffsets %d",
-		monitorInterval, numClocks)
+	if log.V(1) {
+		log.Infof("finding offset interval for monitorInterval: %d, numOffsets %d",
+			monitorInterval, numClocks)
+	}
 	if numClocks == 0 {
 		return ClusterOffsetInterval{
 			Lowerbound: 0,

--- a/rpc/send.go
+++ b/rpc/send.go
@@ -162,7 +162,9 @@ func Send(opts Options, method string, addrs []net.Addr, getArgs func(addr net.A
 				continue
 			}
 			reply := getReply()
-			log.V(1).Infof("%s: sending request to %s: %+v", method, clients[index].Addr(), args)
+			if log.V(1) {
+				log.Infof("%s: sending request to %s: %+v", method, clients[index].Addr(), args)
+			}
 			go sendOneFn(clients[index], opts.Timeout, method, args, reply, helperChan)
 		}
 		// Wait for completions.
@@ -190,7 +192,9 @@ func Send(opts Options, method string, addrs []net.Addr, getArgs func(addr net.A
 				}
 			default:
 				successes++
-				log.V(1).Infof("%s: successful reply: %+v", method, t)
+				if log.V(1) {
+					log.Infof("%s: successful reply: %+v", method, t)
+				}
 				replies = append(replies, t)
 				if successes == opts.N {
 					return replies, nil

--- a/server/node.go
+++ b/server/node.go
@@ -463,7 +463,9 @@ func (n *Node) startStoresScanner(stopper *util.Stopper) {
 				n.scanCount++
 				n.completedScan.Broadcast()
 				n.completedScan.L.Unlock()
-				log.V(6).Infof("store scan iteration completed")
+				if log.V(6) {
+					log.Infof("store scan iteration completed")
+				}
 				stopper.FinishTask()
 			case <-stopper.ShouldStop():
 				// Exit the loop.

--- a/storage/addressing_test.go
+++ b/storage/addressing_test.go
@@ -167,14 +167,19 @@ func TestUpdateRangeAddressing(t *testing.T) {
 		sort.Sort(expMetas)
 
 		if test.split {
-			log.V(1).Infof("test case %d: split %q-%q at %q", i, left.StartKey, right.EndKey, left.EndKey)
+			if log.V(1) {
+				log.Infof("test case %d: split %q-%q at %q", i, left.StartKey, right.EndKey, left.EndKey)
+			}
 		} else {
-			log.V(1).Infof("test case %d: merge %q-%q + %q-%q", i, left.StartKey, left.EndKey, left.EndKey, right.EndKey)
+			if log.V(1) {
+				log.Infof("test case %d: merge %q-%q + %q-%q", i, left.StartKey, left.EndKey, left.EndKey, right.EndKey)
+			}
 		}
 		for _, meta := range metas {
-			log.V(1).Infof("%q", meta.key)
+			if log.V(1) {
+				log.Infof("%q", meta.key)
+			}
 		}
-		log.V(1).Infof("")
 
 		if !reflect.DeepEqual(expMetas, metas) {
 			t.Errorf("expected metas don't match")

--- a/storage/client_raft_test.go
+++ b/storage/client_raft_test.go
@@ -453,7 +453,9 @@ func TestReplicateAfterTruncation(t *testing.T) {
 		if err := mtc.stores[1].ExecuteCmd(getArgs, getResp); err != nil {
 			return false
 		}
-		log.V(1).Infof("read value %d", getResp.Value.GetInteger())
+		if log.V(1) {
+			log.Infof("read value %d", getResp.Value.GetInteger())
+		}
 		return getResp.Value.GetInteger() == 16
 	}, 1*time.Second); err != nil {
 		t.Fatal(err)

--- a/storage/engine/mvcc_test.go
+++ b/storage/engine/mvcc_test.go
@@ -1929,17 +1929,23 @@ func TestMVCCStatsWithRandomRuns(t *testing.T) {
 		isDelete := rng.Int31n(4) == 0
 		if i > 0 && isDelete {
 			idx := rng.Int31n(i)
-			log.V(1).Infof("*** DELETE index %d", idx)
+			if log.V(1) {
+				log.Infof("*** DELETE index %d", idx)
+			}
 			if err := MVCCDelete(engine, ms, keys[idx], makeTS(int64(i+1)*1E9, 0), txn); err != nil {
 				// Abort any write intent on an earlier, unresolved txn.
 				if wiErr, ok := err.(*proto.WriteIntentError); ok {
 					wiErr.Intents[0].Txn.Status = proto.ABORTED
-					log.V(1).Infof("*** ABORT index %d", idx)
+					if log.V(1) {
+						log.Infof("*** ABORT index %d", idx)
+					}
 					if err := MVCCResolveWriteIntent(engine, ms, keys[idx], makeTS(int64(i+1)*1E9, 0), &wiErr.Intents[0].Txn); err != nil {
 						t.Fatal(err)
 					}
 					// Now, re-delete.
-					log.V(1).Infof("*** RE-DELETE index %d", idx)
+					if log.V(1) {
+						log.Infof("*** RE-DELETE index %d", idx)
+					}
 					if err := MVCCDelete(engine, ms, keys[idx], makeTS(int64(i+1)*1E9, 0), txn); err != nil {
 						t.Fatal(err)
 					}
@@ -1949,7 +1955,9 @@ func TestMVCCStatsWithRandomRuns(t *testing.T) {
 			}
 		} else {
 			rngVal := proto.Value{Bytes: util.RandBytes(rng, int(rng.Int31n(128)))}
-			log.V(1).Infof("*** PUT index %d; TXN=%t", i, txn != nil)
+			if log.V(1) {
+				log.Infof("*** PUT index %d; TXN=%t", i, txn != nil)
+			}
 			if err := MVCCPut(engine, ms, key, makeTS(int64(i+1)*1E9, 0), rngVal, txn); err != nil {
 				t.Fatal(err)
 			}
@@ -1959,7 +1967,9 @@ func TestMVCCStatsWithRandomRuns(t *testing.T) {
 			if rng.Int31n(10) == 0 { // abort txn with 10% prob
 				txn.Status = proto.ABORTED
 			}
-			log.V(1).Infof("*** RESOLVE index %d; COMMIT=%t", i, txn.Status == proto.COMMITTED)
+			if log.V(1) {
+				log.Infof("*** RESOLVE index %d; COMMIT=%t", i, txn.Status == proto.COMMITTED)
+			}
 			if err := MVCCResolveWriteIntent(engine, ms, key, makeTS(int64(i+1)*1E9, 0), txn); err != nil {
 				t.Fatal(err)
 			}
@@ -2033,7 +2043,9 @@ func TestMVCCGarbageCollect(t *testing.T) {
 	}
 	for i, kv := range kvsn {
 		key, ts, _ := MVCCDecodeKey(kv.Key)
-		log.V(1).Infof("%d: %q, ts=%s", i, key, ts)
+		if log.V(1) {
+			log.Infof("%d: %q, ts=%s", i, key, ts)
+		}
 	}
 
 	keys := []proto.InternalGCRequest_GCKey{

--- a/storage/gc_queue.go
+++ b/storage/gc_queue.go
@@ -311,7 +311,9 @@ func (gcq *gcQueue) lookupGCPolicy(rng *Range) (proto.GCPolicy, error) {
 			gc = zone.GC
 			return true, nil
 		}
-		log.V(1).Infof("skipping zone config %+v, because no GC policy is set", zone)
+		if log.V(1) {
+			log.Infof("skipping zone config %+v, because no GC policy is set", zone)
+		}
 		return false, nil
 	}); err != nil {
 		return proto.GCPolicy{}, err

--- a/storage/gc_queue_test.go
+++ b/storage/gc_queue_test.go
@@ -235,9 +235,13 @@ func TestGCQueueProcess(t *testing.T) {
 	}
 	for i, kv := range kvs {
 		if key, ts, isValue := engine.MVCCDecodeKey(kv.Key); isValue {
-			log.V(1).Infof("%d: %q, ts=%s", i, key, ts)
+			if log.V(1) {
+				log.Infof("%d: %q, ts=%s", i, key, ts)
+			}
 		} else {
-			log.V(1).Infof("%d: %q meta", i, key)
+			if log.V(1) {
+				log.Infof("%d: %q meta", i, key)
+			}
 		}
 	}
 	if len(kvs) != len(expKVs) {
@@ -252,9 +256,13 @@ func TestGCQueueProcess(t *testing.T) {
 			t.Errorf("%d: expected ts=%s; got %s", i, expKVs[i].ts, ts)
 		}
 		if isValue {
-			log.V(1).Infof("%d: %q, ts=%s", i, key, ts)
+			if log.V(1) {
+				log.Infof("%d: %q, ts=%s", i, key, ts)
+			}
 		} else {
-			log.V(1).Infof("%d: %q meta", i, key)
+			if log.V(1) {
+				log.Infof("%d: %q meta", i, key)
+			}
 		}
 	}
 

--- a/storage/range.go
+++ b/storage/range.go
@@ -790,7 +790,9 @@ func (r *Range) applyRaftCommand(index uint64, originNodeID multiraft.NodeID, ar
 	// Check the response cache to ensure idempotency.
 	if proto.IsWrite(args) {
 		if ok, err := r.respCache.GetResponse(header.CmdID, reply); ok && err == nil {
-			log.V(1).Infof("found response cache entry for %+v", args.Header().CmdID)
+			if log.V(1) {
+				log.Infof("found response cache entry for %+v", args.Header().CmdID)
+			}
 			return reply.Header().GoError()
 		} else if ok && err != nil {
 			newErr := util.Errorf("unable to read result for %+v from the response cache: %s", args, err)

--- a/storage/replicate_queue.go
+++ b/storage/replicate_queue.go
@@ -81,7 +81,9 @@ func (rq *replicateQueue) needsReplication(zone proto.ZoneConfig, rng *Range) (b
 	need := len(zone.ReplicaAttrs)
 	have := len(rng.Desc().Replicas)
 	if need > have {
-		log.V(1).Infof("%s needs %d nodes; has %d", rng, need, have)
+		if log.V(1) {
+			log.Infof("%s needs %d nodes; has %d", rng, need, have)
+		}
 		return true, float64(need - have)
 	}
 

--- a/storage/scanner.go
+++ b/storage/scanner.go
@@ -172,7 +172,9 @@ func (rs *rangeScanner) scanLoop(clock *hlc.Clock, stopper *util.Stopper) {
 
 		for {
 			waitInterval := rs.paceInterval(start, time.Now())
-			log.V(6).Infof("Wait time interval set to %s", waitInterval)
+			if log.V(6) {
+				log.Infof("Wait time interval set to %s", waitInterval)
+			}
 			select {
 			case <-time.After(waitInterval):
 				if !stopper.StartTask() {
@@ -202,7 +204,9 @@ func (rs *rangeScanner) scanLoop(clock *hlc.Clock, stopper *util.Stopper) {
 					rs.count++
 					rs.completedScan.Broadcast()
 					rs.completedScan.L.Unlock()
-					log.V(6).Infof("reset range scan iteration")
+					if log.V(6) {
+						log.Infof("reset range scan iteration")
+					}
 				}
 				stopper.FinishTask()
 
@@ -211,7 +215,9 @@ func (rs *rangeScanner) scanLoop(clock *hlc.Clock, stopper *util.Stopper) {
 				for _, q := range rs.queues {
 					q.MaybeRemove(rng)
 				}
-				log.V(6).Infof("removed range %s", rng)
+				if log.V(6) {
+					log.Infof("removed range %s", rng)
+				}
 
 			case <-stopper.ShouldStop():
 				// Exit the loop.

--- a/storage/store.go
+++ b/storage/store.go
@@ -1127,7 +1127,9 @@ func (s *Store) ExecuteCmd(args proto.Request, reply proto.Response) error {
 // false so that the client backs off before reissuing the command.
 func (s *Store) resolveWriteIntentError(wiErr *proto.WriteIntentError, rng *Range, args proto.Request,
 	pushType proto.PushTxnType, wait bool) error {
-	log.V(1).Infof("resolving write intent on %s %q: %s", args.Method(), args.Header().Key, wiErr)
+	if log.V(1) {
+		log.Infof("resolving write intent on %s %q: %s", args.Method(), args.Header().Key, wiErr)
+	}
 
 	// Attempt to push the transaction(s) which created the conflicting intent(s).
 	bArgs := &proto.InternalBatchRequest{}
@@ -1149,7 +1151,9 @@ func (s *Store) resolveWriteIntentError(wiErr *proto.WriteIntentError, rng *Rang
 	}
 	// Run all pushes in parallel.
 	if pushErr := s.ctx.DB.Run(client.Call{Args: bArgs, Reply: bReply}); pushErr != nil {
-		log.V(1).Infof("pushes for %+v failed: %s", wiErr.Intents, pushErr)
+		if log.V(1) {
+			log.Infof("pushes for %+v failed: %s", wiErr.Intents, pushErr)
+		}
 
 		// For write/write conflicts within a transaction, propagate the
 		// push failure, not the original write intent error. The push

--- a/util/log/log.go
+++ b/util/log/log.go
@@ -99,4 +99,9 @@ var Fatalln = glog.Fatalln
 var FatalDepth = glog.FatalDepth
 
 // V wraps glog.V. See that documentation for details.
-var V = glog.V
+// glog has a custom type alias for bool and implements logging functions on
+// it; we don't want to have that here since the calls would go straight to
+// the glog package and not to whatever functions we define here.
+func V(level glog.Level) bool {
+	return bool(glog.V(level))
+}


### PR DESCRIPTION
if you use it, you'll call Infof directly from the glog package,
and not from our local log package. That hasn't been an issue
so far, but it will be soon so this puts an end to it.

We might have an API like that again later, but let's keep it
simple for now.
