### PR TITLE
multiraft.GroupDeletedError->proto.RangeNotFoundError

### DIFF
--- a/storage/range.go
+++ b/storage/range.go
@@ -677,7 +677,7 @@ func (r *Range) addWriteCmd(args proto.Request, reply proto.Response, wait bool)
 		if err = <-errChan; err == nil {
 			// Next if the command was committed, wait for the range to apply it.
 			err = <-pendingCmd.done
-		} else if _, ok := err.(multiraft.GroupDeletedError); ok {
+		} else if err == multiraft.ErrGroupDeleted {
 			// This error needs to be converted appropriately so that
 			// clients will retry.
 			err = proto.NewRangeNotFoundError(r.Desc().RaftID)

--- a/storage/range.go
+++ b/storage/range.go
@@ -677,6 +677,10 @@ func (r *Range) addWriteCmd(args proto.Request, reply proto.Response, wait bool)
 		if err = <-errChan; err == nil {
 			// Next if the command was committed, wait for the range to apply it.
 			err = <-pendingCmd.done
+		} else if _, ok := err.(multiraft.GroupDeletedError); ok {
+			// This error needs to be converted appropriately so that
+			// clients will retry.
+			err = proto.NewRangeNotFoundError(r.Desc().RaftID)
 		}
 		// As for reads, update timestamp cache with the timestamp
 		// of this write on success. This ensures a strictly higher


### PR DESCRIPTION
following @bdarnell's comment in #907. I didn't introduce a new proto error type since RangeNotFoundError seems appropriate.

When a Raft group gets deleted while a command is underway, MultiRaft now returns a multiraft.GroupDeletedError, which will be changed to a proto.RangeNotFoundError in `r.addWriteCommand`.

This error should be fairly rare in practice, but we've seen it a bunch of times during testing. It doesn't seem worthwhile adding it to other code paths which execute Raft commands because those don't act on behalf of their clients but mostly on the range level.
