### PR TITLE
Adjust command groups to display help better.

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,8 +78,8 @@ Now we're in an environment that has everything set up, and we start by first in
 ```bash
 DIR=$(mktemp -d /tmp/dbXXX)
 # Initialize CA and server certificates. Default directory is --certs=certs
-./cockroach create-ca-cert
-./cockroach create-node-cert 127.0.0.1 localhost $(hostname)
+./cockroach cert create-ca
+./cockroach cert create-node 127.0.0.1 localhost $(hostname)
 # Initialize data directories.
 ./cockroach init --stores ssd=$DIR
 # Start the server.
@@ -171,9 +171,9 @@ Assuming you've built `cockroachdb/cockroach`, let's run a simple Cockroach node
 ```bash
 docker run -v /data -v /certs cockroachdb/cockroach init --stores ssd=/data
 docker run --volumes-from=$(docker ps -q -n 1) cockroachdb/cockroach \
-  create-ca-cert --certs /certs
+  cert create-ca --certs /certs
 docker run --volumes-from=$(docker ps -q -n 1) cockroachdb/cockroach \
-  create-node-cert --certs /certs 127.0.0.1 localhost roachnode
+  cert create-node --certs /certs 127.0.0.1 localhost roachnode
 docker run -p 8080:8080 -h roachnode --volumes-from=$(docker ps -q -n 1) \
   cockroachdb/cockroach start --certs /certs --stores ssd=/data --gossip self://
 ```

--- a/run/local-cluster.sh
+++ b/run/local-cluster.sh
@@ -105,8 +105,8 @@ for i in $(seq 1 $NODES); do
 done
 
 # Generate certs.
-docker run -v ${CERTS_DIR} --name=${CERTS_NAME} ${COCKROACH_IMAGE} create-ca-cert --certs=${CERTS_DIR} 2> /dev/null
-docker run --rm --volumes-from=${CERTS_NAME} ${COCKROACH_IMAGE} create-node-cert --certs=${CERTS_DIR} ${NODE_ADDRESSES} 2> /dev/null
+docker run -v ${CERTS_DIR} --name=${CERTS_NAME} ${COCKROACH_IMAGE} cert create-ca --certs=${CERTS_DIR} 2> /dev/null
+docker run --rm --volumes-from=${CERTS_NAME} ${COCKROACH_IMAGE} cert create-node --certs=${CERTS_DIR} ${NODE_ADDRESSES} 2> /dev/null
 
 # Start all nodes.
 for i in $(seq 1 $NODES); do

--- a/server/cli/accounting.go
+++ b/server/cli/accounting.go
@@ -146,7 +146,11 @@ var acctCmds = []*cobra.Command{
 }
 
 var acctCmd = &cobra.Command{
-	Use: "accounting",
+	Use:   "accounting",
+	Short: "get, set, list and remove accounting configuration",
+	Run: func(cmd *cobra.Command, args []string) {
+		cmd.Usage()
+	},
 }
 
 func init() {

--- a/server/cli/cert.go
+++ b/server/cli/cert.go
@@ -28,7 +28,7 @@ import (
 // A createCACert command generates a CA certificate and stores it
 // in the cert directory.
 var createCACertCmd = &cobra.Command{
-	Use:   "create-ca-cert [options]",
+	Use:   "create-ca [options]",
 	Short: "create CA cert and key",
 	Long: `
 Generates a new key pair, a new CA certificate and writes them to
@@ -51,8 +51,8 @@ func runCreateCACert(cmd *cobra.Command, args []string) {
 // A createNodeCert command generates a node certificate and stores it
 // in the cert directory.
 var createNodeCertCmd = &cobra.Command{
-	Use:   "create-node-cert [options] <host 1> <host 2> ... <host N>",
-	Short: "create node cert and key\n",
+	Use:   "create-node [options] <host 1> <host 2> ... <host N>",
+	Short: "create node cert and key",
 	Long: `
 Generates a new key pair, a new node certificate and writes them to
 individual files in the directory specified by --certs (required).
@@ -76,4 +76,16 @@ func runCreateNodeCert(cmd *cobra.Command, args []string) {
 var certCmds = []*cobra.Command{
 	createCACertCmd,
 	createNodeCertCmd,
+}
+
+var certCmd = &cobra.Command{
+	Use:   "cert",
+	Short: "create ca and node certs",
+	Run: func(cmd *cobra.Command, args []string) {
+		cmd.Usage()
+	},
+}
+
+func init() {
+	certCmd.AddCommand(certCmds...)
 }

--- a/server/cli/cli.go
+++ b/server/cli/cli.go
@@ -68,13 +68,17 @@ var cockroachCmd = &cobra.Command{
 }
 
 func init() {
-	cockroachCmd.AddCommand(nodeCmds...)
-	cockroachCmd.AddCommand(certCmds...)
 	cockroachCmd.AddCommand(
+		initCmd,
+		startCmd,
+		certCmd,
+		exterminateCmd,
+		quitCmd,
+
 		kvCmd,
-		rangeCmd,
 		acctCmd,
 		permCmd,
+		rangeCmd,
 		zoneCmd,
 
 		// Miscellaneous commands.
@@ -82,6 +86,40 @@ func init() {
 		listParamsCmd,
 		versionCmd,
 	)
+
+	// The default cobra usage and help templates have some
+	// ugliness. For example, the "Additional help topics:" section is
+	// shown unnecessarily and it doesn't place a newline before the
+	// "Flags:" section if there are no subcommands. We should really
+	// get these tweaks merged upstream.
+	cockroachCmd.SetUsageTemplate(`{{ $cmd := . }}Usage: {{if .Runnable}}
+  {{.UseLine}}{{if .HasFlags}} [flags]{{end}}{{end}}{{if .HasSubCommands}}
+  {{ .CommandPath}} [command]{{end}}{{if gt .Aliases 0}}
+
+Aliases:
+  {{.NameAndAliases}}
+{{end}}{{if .HasExample}}
+
+Examples:
+{{ .Example }}
+{{end}}{{ if .HasRunnableSubCommands}}
+
+Available Commands: {{range .Commands}}{{if and (.Runnable) (not .Deprecated)}}
+  {{rpad .Name .NamePadding }} {{.Short}}{{end}}{{end}}{{end}}
+{{ if .HasLocalFlags}}
+Flags:
+{{.LocalFlags.FlagUsages}}{{end}}{{ if .HasInheritedFlags}}
+Global Flags:
+{{.InheritedFlags.FlagUsages}}{{end}}{{if .HasHelpSubCommands}}
+Additional help topics:
+{{if .HasHelpSubCommands}}{{range .Commands}}{{if and (not .Runnable) (not .Deprecated)}} {{rpad .CommandPath .CommandPathPadding}} {{.Short}}{{end}}{{end}}{{end}}
+{{end}}{{ if .HasSubCommands }}
+Use "{{.Root.Name}} help [command]" for more information about a command.
+{{end}}`)
+	cockroachCmd.SetHelpTemplate(`{{with or .Long .Short }}{{. | trim}}
+
+{{end}}{{if or .Runnable .HasSubCommands}}{{.UsageString}}
+{{end}}`)
 }
 
 // Run ...

--- a/server/cli/kv.go
+++ b/server/cli/kv.go
@@ -53,7 +53,7 @@ var getCmd = &cobra.Command{
 	Use:   "get [options] <key>",
 	Short: "gets the value for a key",
 	Long: `
-Fetches and display the value for <key>.
+Fetches and displays the value for <key>.
 `,
 	Run: runGet,
 }
@@ -315,7 +315,11 @@ var kvCmds = []*cobra.Command{
 }
 
 var kvCmd = &cobra.Command{
-	Use: "kv",
+	Use:   "kv",
+	Short: "get, put, increment, delete and scan key/value pairs",
+	Run: func(cmd *cobra.Command, args []string) {
+		cmd.Usage()
+	},
 }
 
 func init() {

--- a/server/cli/permission.go
+++ b/server/cli/permission.go
@@ -160,7 +160,11 @@ var permCmds = []*cobra.Command{
 }
 
 var permCmd = &cobra.Command{
-	Use: "permission",
+	Use:   "permission",
+	Short: "get, set, list and remove permissions",
+	Run: func(cmd *cobra.Command, args []string) {
+		cmd.Usage()
+	},
 }
 
 func init() {

--- a/server/cli/range.go
+++ b/server/cli/range.go
@@ -164,7 +164,11 @@ var rangeCmds = []*cobra.Command{
 }
 
 var rangeCmd = &cobra.Command{
-	Use: "range",
+	Use:   "range",
+	Short: "list, split and merge ranges",
+	Run: func(cmd *cobra.Command, args []string) {
+		cmd.Usage()
+	},
 }
 
 func init() {

--- a/server/cli/zone.go
+++ b/server/cli/zone.go
@@ -154,7 +154,11 @@ var zoneCmds = []*cobra.Command{
 }
 
 var zoneCmd = &cobra.Command{
-	Use: "zone",
+	Use:   "zone",
+	Short: "get, set, list and remove zones\n",
+	Run: func(cmd *cobra.Command, args []string) {
+		cmd.Usage()
+	},
 }
 
 func init() {


### PR DESCRIPTION
The command groups (kv, range, permission, accounting, zone) are now
considered commands and display in the same section as the other
top-level commands.

Created a new "cert" group. No reason for "create-ca-cert" and
"create-node-cert" to be toplevel.
