### PR TITLE
Make ContainsKeyRange return false when start is equal to end

### DIFF
--- a/kv/txn_test.go
+++ b/kv/txn_test.go
@@ -380,7 +380,7 @@ func TestUncertaintyMaxTimestampForwarding(t *testing.T) {
 		i++
 		// The first command serves to start a Txn, fixing the timestamps.
 		// There will be a restart, but this is idempotent.
-		call := client.Scan(proto.Key("t"), proto.Key("t"), 0)
+		call := client.Scan(proto.Key("t"), proto.Key("t").Next(), 0)
 		if err = txn.Run(call); err != nil {
 			t.Fatal(err)
 		}

--- a/proto/config.go
+++ b/proto/config.go
@@ -112,12 +112,12 @@ func (r *RangeDescriptor) ContainsKey(key []byte) bool {
 }
 
 // ContainsKeyRange returns whether this RangeDescriptor contains the specified
-// key range from start to end.
+// key range from start (inclusive) to end (exclusive).
 func (r *RangeDescriptor) ContainsKeyRange(start, end []byte) bool {
 	if len(end) == 0 {
 		return r.ContainsKey(start)
 	}
-	if bytes.Compare(end, start) < 0 {
+	if bytes.Compare(end, start) <= 0 {
 		return false
 	}
 	return bytes.Compare(start, r.StartKey) >= 0 && bytes.Compare(r.EndKey, end) >= 0

--- a/proto/config_test.go
+++ b/proto/config_test.go
@@ -121,6 +121,9 @@ func TestRangeDescriptorContains(t *testing.T) {
 			if desc.ContainsKey(test.start) != test.contains {
 				t.Errorf("expected key %q within range", test.start)
 			}
+			if desc.ContainsKeyRange(test.start, test.end) {
+				t.Errorf("expected false for single key range %q", test.start)
+			}
 		} else {
 			if desc.ContainsKeyRange(test.start, test.end) != test.contains {
 				t.Errorf("expected key range %q-%q within range", test.start, test.end)

--- a/storage/client_test.go
+++ b/storage/client_test.go
@@ -287,7 +287,7 @@ func (m *multiTestContext) replicateRange(raftID int64, sourceStoreIndex int, de
 		for _, dest := range dests {
 			// Use LookupRange(keys) instead of GetRange(raftID) to ensure that the
 			// snaphost has been transferred and the descriptor initialized.
-			if m.stores[dest].LookupRange(rng.Desc().StartKey, rng.Desc().StartKey) == nil {
+			if m.stores[dest].LookupRange(rng.Desc().StartKey, nil) == nil {
 				return util.Errorf("range not found on store %d", dest)
 			}
 		}

--- a/storage/engine/keys.go
+++ b/storage/engine/keys.go
@@ -209,6 +209,10 @@ func TransactionKey(key proto.Key, id []byte) proto.Key {
 // local keys incorporating the Raft ID are not (e.g. response cache
 // entries, and range stats).
 func KeyAddress(k proto.Key) proto.Key {
+	if k == nil {
+		return nil
+	}
+
 	if !bytes.HasPrefix(k, KeyLocalPrefix) {
 		return k
 	}

--- a/storage/engine/keys_test.go
+++ b/storage/engine/keys_test.go
@@ -63,6 +63,7 @@ func TestKeyAddress(t *testing.T) {
 		{RangeDescriptorKey(proto.Key("foo")), proto.Key("foo")},
 		{TransactionKey(proto.Key("baz"), proto.Key(util.NewUUID4())), proto.Key("baz")},
 		{TransactionKey(KeyMax, proto.Key(util.NewUUID4())), KeyMax},
+		{nil, nil},
 	}
 	for i, test := range testCases {
 		result := KeyAddress(test.key)

--- a/storage/range_command.go
+++ b/storage/range_command.go
@@ -961,7 +961,7 @@ func (r *Range) AdminMerge(args *proto.AdminMergeRequest, reply *proto.AdminMerg
 		// Noop.
 		return
 	}
-	subsumedRng := r.rm.LookupRange(desc.EndKey, desc.EndKey)
+	subsumedRng := r.rm.LookupRange(desc.EndKey, nil)
 	if subsumedRng == nil {
 		reply.SetGoError(util.Errorf("ranges not collocated; migration of ranges in anticipation of merge not yet implemented"))
 		return

--- a/storage/store.go
+++ b/storage/store.go
@@ -536,7 +536,7 @@ func (s *Store) startGossip() error {
 // range and if so, reminds it to gossip the first range descriptor and
 // sentinel gossip.
 func (s *Store) maybeGossipFirstRange() error {
-	rng := s.LookupRange(engine.KeyMin, engine.KeyMin.Next())
+	rng := s.LookupRange(engine.KeyMin, nil)
 	if rng != nil {
 		log.Infof("gossiping first range on store %d, range %d",
 			s.StoreID(), rng.Desc().RaftID)
@@ -555,7 +555,7 @@ func (s *Store) maybeGossipFirstRange() error {
 // periodically.
 func (s *Store) maybeGossipConfigs() error {
 	for _, cd := range configDescriptors {
-		rng := s.LookupRange(cd.keyPrefix, cd.keyPrefix.Next())
+		rng := s.LookupRange(cd.keyPrefix, nil)
 		if rng == nil {
 			// This store has no range with this configuration.
 			continue
@@ -714,7 +714,7 @@ func (s *Store) GetRange(raftID int64) (*Range, error) {
 // "rangesByKey" RangeSlice. Returns nil if no range is found for
 // specified key range. Note that the specified keys are transformed
 // using Key.Address() to ensure we lookup ranges correctly for local
-// keys.
+// keys. When end is nill, a range that contains start is looked up.
 func (s *Store) LookupRange(start, end proto.Key) *Range {
 	s.mu.RLock()
 	defer s.mu.RUnlock()

--- a/storage/store_test.go
+++ b/storage/store_test.go
@@ -322,6 +322,8 @@ func TestStoreAddRemoveRanges(t *testing.T) {
 		{proto.Key("x60\xff\xff"), proto.Key("a\x00"), nil},
 		{proto.Key("d"), proto.Key("d"), nil},
 		{proto.Key("c\xff\xff"), proto.Key("d\x00"), nil},
+		{proto.Key("a"), nil, rng2},
+		{proto.Key("d"), nil, nil},
 	}
 
 	for i, test := range testCases {
@@ -387,7 +389,7 @@ func TestStoreRangeIterator(t *testing.T) {
 
 	// Now, remove the next range in the iteration but verify iteration
 	// continues as expected.
-	rng = store.LookupRange(proto.Key("a01"), proto.Key("a01"))
+	rng = store.LookupRange(proto.Key("a01"), nil)
 	if rng.Desc().RaftID != 2 {
 		t.Errorf("expected fetch of raftID=2; got %d", rng.Desc().RaftID)
 	}
@@ -563,7 +565,7 @@ func TestStoreExecuteCmdBadRange(t *testing.T) {
 // See #702
 // TODO(bdarnell): convert tests that use this function to use AdminSplit instead.
 func splitTestRange(store *Store, key, splitKey proto.Key, t *testing.T) *Range {
-	rng := store.LookupRange(key, key)
+	rng := store.LookupRange(key, nil)
 	if rng == nil {
 		t.Fatalf("couldn't lookup range for key %q", key)
 	}
@@ -634,7 +636,7 @@ func TestStoreRangesByKey(t *testing.T) {
 	store, _, stopper := createTestStore(t)
 	defer stopper.Stop()
 
-	r0 := store.LookupRange(engine.KeyMin, engine.KeyMin)
+	r0 := store.LookupRange(engine.KeyMin, nil)
 	r1 := splitTestRange(store, engine.KeyMin, proto.Key("A"), t)
 	r2 := splitTestRange(store, proto.Key("A"), proto.Key("C"), t)
 	r3 := splitTestRange(store, proto.Key("C"), proto.Key("X"), t)
@@ -681,7 +683,7 @@ func TestStoreSetRangesMaxBytes(t *testing.T) {
 		rng         *Range
 		expMaxBytes int64
 	}{
-		{store.LookupRange(engine.KeyMin, engine.KeyMin), 64 << 20},
+		{store.LookupRange(engine.KeyMin, nil), 64 << 20},
 		{splitTestRange(store, engine.KeyMin, proto.Key("a"), t), 1 << 20},
 		{splitTestRange(store, proto.Key("a"), proto.Key("aa"), t), 1 << 20},
 		{splitTestRange(store, proto.Key("aa"), proto.Key("b"), t), 64 << 20},


### PR DESCRIPTION
`ContainsKeyRange` used to return true when a range has `["a", "b")` and `start == end == "b"`. It seems this is not an expected behavior since end key is exclusive.

This commit also fixes `AdminMerge` and test code to pass `(key, nil)` to look up a range with a single key.
