### PR TITLE
Map "flag" package flags into the "pflag" package.

### DIFF
--- a/server/cli/cli.go
+++ b/server/cli/cli.go
@@ -18,7 +18,6 @@
 package cli
 
 import (
-	"flag"
 	"fmt"
 	"os"
 	"strings"
@@ -28,21 +27,6 @@ import (
 
 	"github.com/spf13/cobra"
 )
-
-var listParamsCmd = &cobra.Command{
-	Use:   "listparams",
-	Short: "list all available parameters and their default values",
-	Long: `
-List all available parameters and their default values.
-Note that parameter parsing stops after the first non-
-option after the command name. Hence, the options need
-to precede any additional arguments,
-
-  cockroach <command> [options] [arguments].`,
-	Run: func(cmd *cobra.Command, args []string) {
-		flag.CommandLine.PrintDefaults()
-	},
-}
 
 var versionCmd = &cobra.Command{
 	Use:   "version",
@@ -83,7 +67,6 @@ func init() {
 
 		// Miscellaneous commands.
 		// TODO(pmattis): stats
-		listParamsCmd,
 		versionCmd,
 	)
 

--- a/server/cli/cli_test.go
+++ b/server/cli/cli_test.go
@@ -142,3 +142,24 @@ func ExampleSplitMergeRanges() {
 	// quit
 	// node drained and shutdown: ok
 }
+
+func ExampleGlogFlags() {
+	c := newCLITest()
+
+	c.Run("kv --alsologtostderr=false scan")
+	c.Run("kv --log_backtrace_at=foo.go:1 scan")
+	c.Run("kv --log_dir='' scan")
+	c.Run("kv --logtostderr scan")
+	c.Run("kv --stderrthreshold=2 scan")
+	c.Run("kv --v=0 scan")
+	c.Run("kv --vmodule=foo=1 scan")
+
+	// Output:
+	// kv --alsologtostderr=false scan
+	// kv --log_backtrace_at=foo.go:1 scan
+	// kv --log_dir='' scan
+	// kv --logtostderr scan
+	// kv --stderrthreshold=2 scan
+	// kv --v=0 scan
+	// kv --vmodule=foo=1 scan
+}

--- a/server/cli/flags_test.go
+++ b/server/cli/flags_test.go
@@ -1,0 +1,36 @@
+// Copyright 2015 The Cockroach Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+// implied. See the License for the specific language governing
+// permissions and limitations under the License. See the AUTHORS file
+// for names of contributors.
+//
+// Author: Peter Mattis (peter.mattis@gmail.com)
+
+package cli
+
+import (
+	"flag"
+	"strings"
+	"testing"
+)
+
+func TestStdFlagToPflag(t *testing.T) {
+	cf := cockroachCmd.PersistentFlags()
+	flag.VisitAll(func(f *flag.Flag) {
+		if strings.HasPrefix(f.Name, "test.") {
+			return
+		}
+		if pf := cf.Lookup(f.Name); pf == nil {
+			t.Errorf("unable to find \"%s\"", f.Name)
+		}
+	})
+}


### PR DESCRIPTION
Remove the "listparams" command. It is no longer useful now that the
help message displays the flags for a particular command.

Fixes #931.
