### PR TITLE
Prettified flag usage strings.

### DIFF
--- a/run/local-cluster.sh
+++ b/run/local-cluster.sh
@@ -122,7 +122,7 @@ for i in $(seq 1 $NODES); do
 
   # If this is the first node, initialize the cluster first.
   if [[ $i == 1 ]]; then
-      docker run -v $VOL --volumes-from=${CERTS_NAME} --name=cockroach-init $COCKROACH_IMAGE init --certs=${CERTS_DIR} --stores=ssd=$VOL 2> /dev/null
+      docker run -v $VOL --volumes-from=${CERTS_NAME} --name=cockroach-init $COCKROACH_IMAGE init --stores=ssd=$VOL 2> /dev/null
       NODE_ARGS="${NODE_ARGS} --volumes-from=cockroach-init"
   fi
 

--- a/server/cli/cli.go
+++ b/server/cli/cli.go
@@ -84,8 +84,7 @@ Aliases:
 {{end}}{{if .HasExample}}
 
 Examples:
-{{ .Example }}
-{{end}}{{ if .HasRunnableSubCommands}}
+{{ .Example }}{{end}}{{ if .HasRunnableSubCommands}}
 
 Available Commands: {{range .Commands}}{{if and (.Runnable) (not .Deprecated)}}
   {{rpad .Name .NamePadding }} {{.Short}}{{end}}{{end}}{{end}}

--- a/server/cli/cli_test.go
+++ b/server/cli/cli_test.go
@@ -147,8 +147,8 @@ func ExampleGlogFlags() {
 	c := newCLITest()
 
 	c.Run("kv --alsologtostderr=false scan")
-	c.Run("kv --log_backtrace_at=foo.go:1 scan")
-	c.Run("kv --log_dir='' scan")
+	c.Run("kv --log-backtrace-at=foo.go:1 scan")
+	c.Run("kv --log-dir='' scan")
 	c.Run("kv --logtostderr scan")
 	c.Run("kv --stderrthreshold=2 scan")
 	c.Run("kv --v=0 scan")
@@ -156,8 +156,8 @@ func ExampleGlogFlags() {
 
 	// Output:
 	// kv --alsologtostderr=false scan
-	// kv --log_backtrace_at=foo.go:1 scan
-	// kv --log_dir='' scan
+	// kv --log-backtrace-at=foo.go:1 scan
+	// kv --log-dir='' scan
 	// kv --logtostderr scan
 	// kv --stderrthreshold=2 scan
 	// kv --v=0 scan

--- a/server/cli/flags_test.go
+++ b/server/cli/flags_test.go
@@ -29,8 +29,9 @@ func TestStdFlagToPflag(t *testing.T) {
 		if strings.HasPrefix(f.Name, "test.") {
 			return
 		}
-		if pf := cf.Lookup(f.Name); pf == nil {
-			t.Errorf("unable to find \"%s\"", f.Name)
+		n := normalizeStdFlagName(f.Name)
+		if pf := cf.Lookup(n); pf == nil {
+			t.Errorf("unable to find \"%s\"", n)
 		}
 	})
 }

--- a/server/cli/start.go
+++ b/server/cli/start.go
@@ -39,18 +39,16 @@ var Context = server.NewContext()
 
 // An initCmd command initializes a new Cockroach cluster.
 var initCmd = &cobra.Command{
-	Use:   "init --stores=(ssd=<data-dir>,hdd:7200rpm=<data-dir>|mem=<capacity-in-bytes>)[,...]",
+	Use:   "init --stores=...",
 	Short: "init new Cockroach cluster and start server",
 	Long: `
-Initialize a new Cockroach cluster using the --stores command line flag to
-specify one or more storage locations. The first of these storage locations is
-used to bootstrap the first replica of the first range. If any of the storage
-locations are already part of a pre-existing cluster, the bootstrap will fail.
-
-For example:
-	cockroach init --stores=ssd=/mnt/ssd1,ssd=/mnt/ssd2
+Initialize a new Cockroach cluster using the --stores flag to specify one or
+more storage locations. The first of these storage locations is used to
+bootstrap the first replica of the first range. If any of the storage locations
+are already part of a pre-existing cluster, the bootstrap will fail.
 `,
-	Run: runInit,
+	Example: `  cockroach init --stores=ssd=/mnt/ssd1,ssd=/mnt/ssd2`,
+	Run:     runInit,
 }
 
 // runInit initializes the engine based on the first
@@ -77,35 +75,30 @@ func runInit(cmd *cobra.Command, args []string) {
 
 // A startCmd command starts nodes by joining the gossip network.
 var startCmd = &cobra.Command{
-	Use: "start --gossip=host1:port1[,host2:port2...] " +
-		"--certs=<cert-dir> " +
-		"--stores=(ssd=<data-dir>,hdd:7200rpm=<data-dir>|mem=<capacity-in-bytes>)[,...]",
-	Short: "start node by joining the gossip network",
+	Use:   "start",
+	Short: "start a node by joining the gossip network",
 	Long: `
-Start Cockroach node by joining the gossip network and exporting key
-ranges stored on physical device(s). The gossip network is joined by
-contacting one or more well-known hosts specified by the --gossip
-flag. Every node should be run with the same list of bootstrap hosts
-to guarantee a connected network. An alternate approach is to use a
-single host for --gossip and round-robin DNS.
+Start a Cockroach node by joining the gossip network and exporting key ranges
+stored on physical device(s). The gossip network is joined by contacting one or
+more well-known hosts specified by the --gossip flag. Every node should be run
+with the same list of bootstrap hosts to guarantee a connected network. An
+alternate approach is to use a single host for --gossip and round-robin DNS.
 
-Each node exports data from one or more physical devices. These
-devices are specified via the --stores flag. This is a comma-separated
-list of paths to storage directories or for in-memory stores, the
-number of bytes. Although the paths should be specified to correspond
-uniquely to physical devices, this requirement isn't strictly
-enforced.
-
-For example:
-
-  cockroach start --gossip=host1:port1,host2:port2 --stores=ssd=/mnt/ssd1,ssd=/mnt/ssd2
+Each node exports data from one or more physical devices. These devices are
+specified via the --stores flag. This is a comma-separated list of paths to
+storage directories or for in-memory stores, the number of bytes. Although the
+paths should be specified to correspond uniquely to physical devices, this
+requirement isn't strictly enforced. See the --stores flag help description for
+additional details.
 
 A node exports an HTTP API with the following endpoints:
 
   Health check:           /healthz
   Key-value REST:         ` + kv.RESTPrefix + `
-  Structured Schema REST: ` + structured.StructuredKeyPrefix,
-	Run: runStart,
+  Structured Schema REST: ` + structured.StructuredKeyPrefix + `
+`,
+	Example: `  cockroach start --certs=<dir> --gossip=host1:port1[,...] --stores=ssd=/mnt/ssd1,...`,
+	Run:     runStart,
 }
 
 // runStart starts the cockroach node using --stores as the list of
@@ -175,7 +168,6 @@ var exterminateCmd = &cobra.Command{
 	Use:   "exterminate",
 	Short: "destroy all data held by the node",
 	Long: `
-
 First shuts down the system and then destroys all data held by the
 node, cycling through each store specified by the --stores flag.
 `,


### PR DESCRIPTION
Ensured that flags were only added to commands that need them.

Fixes #936.
