### PR TITLE
raft rapid group recreation test & fix

### DIFF
--- a/multiraft/multiraft_test.go
+++ b/multiraft/multiraft_test.go
@@ -428,8 +428,4 @@ func TestRapidMembershipChange(t *testing.T) {
 
 	}
 	close(teardown)
-
-	// TODO(tschottdorf): get the stray RaftMessage calls under control.
-	// Maybe they should be ignored by leaktest?
-	time.Sleep(20 * time.Millisecond)
 }


### PR DESCRIPTION
this simulates a rare error surfaced by #906 (and apparently others).
the test has a handful of concurrent actors add, commit to
(with retries) and remove a group.

currently this sometimes panics Raft:

E0506 13:09:45.552958   78550 log.go:188] applied(304) is out of range [prevApplied(10), committed(303)]
panic: applied(304) is out of range [prevApplied(10), committed(303)]

and other times (especially with a high number of writers) there are
deadlock issues.

i will continue to investigate these phenomena and hopefully attach
a fix to this PR prior to considering a merge.
