### PR TITLE
Fork snappy-go.

### DIFF
--- a/GLOCKFILE
+++ b/GLOCKFILE
@@ -8,13 +8,12 @@ cmd github.com/robfig/glock
 cmd golang.org/x/tools/cmd/goimports
 cmd golang.org/x/tools/cmd/stringer
 bitbucket.org/tebeka/go2xunit 77968f802fb3
-code.google.com/p/snappy-go 8850bd446ad6
 github.com/agtorre/gocolorize f42b554bf7f006936130c9bb4f971afd2d87f671
 github.com/biogo/store cb1ae010c5c75b7ce4f5c5d0ef92defcafdfdce4
 github.com/cockroachdb/c-lz4 6e71f140a365017bbe0904710007f8725fd3f809
 github.com/cockroachdb/c-protobuf 9e8dac59ca2a3fc82cd0665ad32b1a36f3df40b8
 github.com/cockroachdb/c-rocksdb e120ce0fb32f86b94188928743270ea11ff016b3
-github.com/cockroachdb/c-snappy af73b00e85e6f0e3c1fcc51f73f1d036df1e99ff
+github.com/cockroachdb/c-snappy 0975dbfba5147722a2cad2229f34aad2ee85c2b4
 github.com/coreos/etcd e5f2f401450b56947e231336f9e8350059428036
 github.com/elazarl/go-bindata-assetfs bea323321994103859d60197d229f1a94699dde3
 github.com/gogo/protobuf bc946d07d1016848dfd2507f90f0859c9471681e

--- a/build/devbase/godeps.sh
+++ b/build/devbase/godeps.sh
@@ -30,7 +30,6 @@ ${GOPATH}/bin/glock sync github.com/cockroachdb/cockroach
 # (and adding /... to repo paths will match packages that have been
 # downloaded but whose dependencies have not).
 pkgs="
-code.google.com/p/snappy-go/snappy
 github.com/biogo/store/interval
 github.com/biogo/store/llrb
 github.com/cockroachdb/c-lz4

--- a/client/http_sender.go
+++ b/client/http_sender.go
@@ -26,8 +26,7 @@ import (
 	"net/http"
 	"time"
 
-	"code.google.com/p/snappy-go/snappy"
-
+	"github.com/cockroachdb/c-snappy"
 	"github.com/cockroachdb/cockroach/base"
 	"github.com/cockroachdb/cockroach/util"
 	"github.com/cockroachdb/cockroach/util/log"

--- a/server/server.go
+++ b/server/server.go
@@ -26,8 +26,7 @@ import (
 	"strings"
 	"sync"
 
-	"code.google.com/p/snappy-go/snappy"
-
+	"github.com/cockroachdb/c-snappy"
 	"github.com/cockroachdb/cockroach/client"
 	"github.com/cockroachdb/cockroach/gossip"
 	"github.com/cockroachdb/cockroach/kv"

--- a/server/server_test.go
+++ b/server/server_test.go
@@ -26,8 +26,7 @@ import (
 	"strings"
 	"testing"
 
-	"code.google.com/p/snappy-go/snappy"
-
+	"github.com/cockroachdb/c-snappy"
 	"github.com/cockroachdb/cockroach/client"
 	"github.com/cockroachdb/cockroach/kv"
 	"github.com/cockroachdb/cockroach/proto"


### PR DESCRIPTION
Use C++ snappy instead of Go snappy for encoding/decoding.
