### PR TITLE
Move util/cache.go into its own package.

### DIFF
--- a/kv/leader_cache.go
+++ b/kv/leader_cache.go
@@ -21,14 +21,14 @@ import (
 	"sync"
 
 	"github.com/cockroachdb/cockroach/proto"
-	"github.com/cockroachdb/cockroach/util"
+	"github.com/cockroachdb/cockroach/util/cache"
 )
 
 // A leaderCache is a cache used to keep track of the leader
 // replica of Raft consensus groups.
 type leaderCache struct {
 	mu    sync.RWMutex
-	cache *util.UnorderedCache
+	cache *cache.UnorderedCache
 }
 
 // newLeaderCache creates a new leaderCache of the given size.
@@ -36,8 +36,8 @@ type leaderCache struct {
 // are cheap.
 func newLeaderCache(size int) *leaderCache {
 	return &leaderCache{
-		cache: util.NewUnorderedCache(util.CacheConfig{
-			Policy: util.CacheLRU,
+		cache: cache.NewUnorderedCache(cache.Config{
+			Policy: cache.CacheLRU,
 			ShouldEvict: func(s int, key, value interface{}) bool {
 				return s > size
 			},

--- a/kv/range_cache.go
+++ b/kv/range_cache.go
@@ -25,7 +25,7 @@ import (
 	"github.com/biogo/store/llrb"
 	"github.com/cockroachdb/cockroach/proto"
 	"github.com/cockroachdb/cockroach/storage/engine"
-	"github.com/cockroachdb/cockroach/util"
+	"github.com/cockroachdb/cockroach/util/cache"
 	"github.com/cockroachdb/cockroach/util/log"
 )
 
@@ -63,7 +63,7 @@ type rangeDescriptorCache struct {
 	// rangeCache caches replica metadata for key ranges. The cache is
 	// filled while servicing read and write requests to the key value
 	// store.
-	rangeCache *util.OrderedCache
+	rangeCache *cache.OrderedCache
 	// rangeCacheMu protects rangeCache for concurrent access
 	rangeCacheMu sync.RWMutex
 }
@@ -74,8 +74,8 @@ type rangeDescriptorCache struct {
 func newRangeDescriptorCache(db rangeDescriptorDB, size int) *rangeDescriptorCache {
 	return &rangeDescriptorCache{
 		db: db,
-		rangeCache: util.NewOrderedCache(util.CacheConfig{
-			Policy: util.CacheLRU,
+		rangeCache: cache.NewOrderedCache(cache.Config{
+			Policy: cache.CacheLRU,
 			ShouldEvict: func(n int, k, v interface{}) bool {
 				return n > size
 			},

--- a/kv/txn_coord_sender.go
+++ b/kv/txn_coord_sender.go
@@ -27,6 +27,7 @@ import (
 	"github.com/cockroachdb/cockroach/storage"
 	"github.com/cockroachdb/cockroach/storage/engine"
 	"github.com/cockroachdb/cockroach/util"
+	"github.com/cockroachdb/cockroach/util/cache"
 	"github.com/cockroachdb/cockroach/util/hlc"
 	"github.com/cockroachdb/cockroach/util/log"
 	gogoproto "github.com/gogo/protobuf/proto"
@@ -58,7 +59,7 @@ type txnMetadata struct {
 	// keys stores key ranges affected by this transaction through this
 	// coordinator. By keeping this record, the coordinator will be able
 	// to update the write intent when the transaction is committed.
-	keys *util.IntervalCache
+	keys *cache.IntervalCache
 
 	// lastUpdateTS is the latest time when the client sent transaction
 	// operations to this coordinator.
@@ -296,7 +297,7 @@ func (tc *TxnCoordSender) sendOne(call client.Call) {
 		if txnMeta, ok = tc.txns[string(header.Txn.ID)]; !ok {
 			txnMeta = &txnMetadata{
 				txn:             *header.Txn,
-				keys:            util.NewIntervalCache(util.CacheConfig{Policy: util.CacheNone}),
+				keys:            cache.NewIntervalCache(cache.Config{Policy: cache.CacheNone}),
 				lastUpdateTS:    tc.clock.Now(),
 				timeoutDuration: tc.clientTimeout,
 			}

--- a/storage/command_queue.go
+++ b/storage/command_queue.go
@@ -21,7 +21,7 @@ import (
 	"sync"
 
 	"github.com/cockroachdb/cockroach/proto"
-	"github.com/cockroachdb/cockroach/util"
+	"github.com/cockroachdb/cockroach/util/cache"
 )
 
 // A CommandQueue maintains an interval tree of keys or key ranges for
@@ -48,7 +48,7 @@ import (
 //
 // CommandQueue is not thread safe.
 type CommandQueue struct {
-	cache *util.IntervalCache
+	cache *cache.IntervalCache
 }
 
 type cmd struct {
@@ -59,7 +59,7 @@ type cmd struct {
 // NewCommandQueue returns a new command queue.
 func NewCommandQueue() *CommandQueue {
 	cq := &CommandQueue{
-		cache: util.NewIntervalCache(util.CacheConfig{Policy: util.CacheNone}),
+		cache: cache.NewIntervalCache(cache.Config{Policy: cache.CacheNone}),
 	}
 	cq.cache.OnEvicted = cq.onEvicted
 	return cq

--- a/storage/timestamp_cache.go
+++ b/storage/timestamp_cache.go
@@ -21,7 +21,7 @@ import (
 	"time"
 
 	"github.com/cockroachdb/cockroach/proto"
-	"github.com/cockroachdb/cockroach/util"
+	"github.com/cockroachdb/cockroach/util/cache"
 	"github.com/cockroachdb/cockroach/util/hlc"
 )
 
@@ -45,7 +45,7 @@ const (
 // with monotonic increases. The low water mark is initialized to
 // the current system time plus the maximum clock offset.
 type TimestampCache struct {
-	cache            *util.IntervalCache
+	cache            *cache.IntervalCache
 	lowWater, latest proto.Timestamp
 }
 
@@ -60,10 +60,10 @@ type cacheEntry struct {
 // hybrid clock.
 func NewTimestampCache(clock *hlc.Clock) *TimestampCache {
 	tc := &TimestampCache{
-		cache: util.NewIntervalCache(util.CacheConfig{Policy: util.CacheFIFO}),
+		cache: cache.NewIntervalCache(cache.Config{Policy: cache.CacheFIFO}),
 	}
 	tc.Clear(clock)
-	tc.cache.CacheConfig.ShouldEvict = tc.shouldEvict
+	tc.cache.Config.ShouldEvict = tc.shouldEvict
 	return tc
 }
 

--- a/util/cache/cache.go
+++ b/util/cache/cache.go
@@ -17,7 +17,7 @@
 //
 // Author: Spencer Kimball (spencer.kimball@gmail.com)
 
-package util
+package cache
 
 import (
 	"container/list"
@@ -39,9 +39,9 @@ const (
 	CacheNone                       // No evictions; don't maintain ordering list
 )
 
-// A CacheConfig specifies the eviction policy, eviction
+// A Config specifies the eviction policy, eviction
 // trigger callback, and eviction listener callback.
-type CacheConfig struct {
+type Config struct {
 	// Policy is one of the consts listed for EvictionPolicy.
 	Policy EvictionPolicy
 
@@ -120,15 +120,15 @@ type cacheStore interface {
 // baseCache contains the config, cacheStore interface, and the linked
 // list for eviction order.
 type baseCache struct {
-	CacheConfig
+	Config
 	store cacheStore
 	ll    *list.List
 }
 
-func newBaseCache(config CacheConfig) *baseCache {
+func newBaseCache(config Config) *baseCache {
 	return &baseCache{
-		CacheConfig: config,
-		ll:          list.New(),
+		Config: config,
+		ll:     list.New(),
 	}
 }
 
@@ -225,7 +225,7 @@ type UnorderedCache struct {
 }
 
 // NewUnorderedCache creates a new UnorderedCache backed by a hash map.
-func NewUnorderedCache(config CacheConfig) *UnorderedCache {
+func NewUnorderedCache(config Config) *UnorderedCache {
 	mc := &UnorderedCache{
 		baseCache: newBaseCache(config),
 		hmap:      make(map[interface{}]interface{}),
@@ -271,7 +271,7 @@ type OrderedCache struct {
 // NewOrderedCache creates a new Cache backed by a left-leaning red
 // black binary tree which supports binary searches via the Ceil() and
 // Floor() methods. See NewUnorderedCache() for details on parameters.
-func NewOrderedCache(config CacheConfig) *OrderedCache {
+func NewOrderedCache(config Config) *OrderedCache {
 	oc := &OrderedCache{
 		baseCache: newBaseCache(config),
 	}
@@ -381,7 +381,7 @@ func (ik *IntervalKey) Contains(lk *IntervalKey) bool {
 
 // NewIntervalCache creates a new Cache backed by an interval tree.
 // See NewCache() for details on parameters.
-func NewIntervalCache(config CacheConfig) *IntervalCache {
+func NewIntervalCache(config Config) *IntervalCache {
 	ic := &IntervalCache{
 		baseCache: newBaseCache(config),
 		tree:      &interval.Tree{},


### PR DESCRIPTION
This file depends on biogo/store/llrb, which is inappropriate for a util
package that is used everywhere (including client
applications). However, this change does not sever the dependency
because it is still used from the proto package.

See #942.
