### PR TITLE
For discussion: Introduce client.Callable interface.

### DIFF
--- a/client/call.go
+++ b/client/call.go
@@ -76,6 +76,14 @@ func (c GetCall) Call() Call {
 	}
 }
 
+// ValueBytes returns the byte value of the reply, or nil if no result was found.
+func (c GetCall) ValueBytes() []byte {
+	if c.Reply.Value == nil {
+		return nil
+	}
+	return c.Reply.Value.Bytes
+}
+
 // Get returns a Call object initialized to get the value at key.
 func Get(key proto.Key) GetCall {
 	return GetCall{

--- a/client/call.go
+++ b/client/call.go
@@ -25,6 +25,11 @@ import (
 	gogoproto "github.com/gogo/protobuf/proto"
 )
 
+// A Callable can be converted into a Call.
+type Callable interface {
+	Call() Call
+}
+
 // A Call is a pending database API call.
 type Call struct {
 	Args  proto.Request  // The argument to the command
@@ -36,7 +41,7 @@ type Call struct {
 // resetClientCmdID sets the client command ID if the call is for a
 // read-write method. The client command ID provides idempotency
 // protection in conjunction with the server.
-func (c *Call) resetClientCmdID(clock Clock) {
+func (c Call) resetClientCmdID(clock Clock) {
 	c.Args.Header().CmdID = proto.ClientCmdID{
 		WallTime: clock.Now(),
 		Random:   rand.Int63(),
@@ -44,13 +49,36 @@ func (c *Call) resetClientCmdID(clock Clock) {
 }
 
 // Method returns the method of the database command for the call.
-func (c *Call) Method() proto.Method {
+func (c Call) Method() proto.Method {
 	return c.Args.Method()
 }
 
-// Get returns a Call object initialized to get the value at key.
-func Get(key proto.Key) Call {
+// Call implements Callable
+func (c Call) Call() Call {
+	return c
+}
+
+// GetCall is a type-safe Callable for Get operations.
+type GetCall struct {
+	Args  *proto.GetRequest
+	Reply *proto.GetResponse
+	Post  func() error
+}
+
+var _ Callable = GetCall{}
+
+// Call implements Callable.
+func (c GetCall) Call() Call {
 	return Call{
+		Args:  c.Args,
+		Reply: c.Reply,
+		Post:  c.Post,
+	}
+}
+
+// Get returns a Call object initialized to get the value at key.
+func Get(key proto.Key) GetCall {
+	return GetCall{
 		Args: &proto.GetRequest{
 			RequestHeader: proto.RequestHeader{
 				Key: key,
@@ -62,10 +90,10 @@ func Get(key proto.Key) Call {
 
 // GetProto returns a Call object initialized to get the value at key
 // and then to decode it as a protobuf message.
-func GetProto(key proto.Key, msg gogoproto.Message) Call {
+func GetProto(key proto.Key, msg gogoproto.Message) GetCall {
 	c := Get(key)
 	c.Post = func() error {
-		reply := c.Reply.(*proto.GetResponse)
+		reply := c.Reply
 		if reply.Value == nil {
 			return util.Errorf("%s: no value present", key)
 		}

--- a/client/call_test.go
+++ b/client/call_test.go
@@ -1,0 +1,133 @@
+// Copyright 2015 The Cockroach Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+// implied. See the License for the specific language governing
+// permissions and limitations under the License. See the AUTHORS file
+// for names of contributors.
+//
+// Author: Ben Darnell
+
+package client_test
+
+import (
+	"fmt"
+	"log"
+
+	"github.com/cockroachdb/cockroach/client"
+	"github.com/cockroachdb/cockroach/proto"
+	"github.com/cockroachdb/cockroach/server"
+	"github.com/cockroachdb/cockroach/testutils"
+)
+
+func setupCall() (*server.TestServer, *client.KV) {
+	s := server.StartTestServer(nil)
+	sender, err := client.NewHTTPSender(s.ServingAddr(), testutils.NewTestBaseContext())
+	if err != nil {
+		log.Fatal(err)
+	}
+	kvClient := client.NewKV(nil, sender)
+	kvClient.User = "root"
+	return s, kvClient
+}
+
+func ExampleCall_Get() {
+	s, db := setupCall()
+	defer s.Stop()
+
+	get := client.Get(proto.Key("aa"))
+	if err := db.Run(get); err != nil {
+		panic(err)
+	}
+	fmt.Printf("aa=%s\n", get.ValueBytes())
+
+	// Output:
+	// aa=
+}
+
+func ExampleCall_Put() {
+	s, db := setupCall()
+	defer s.Stop()
+
+	if err := db.Run(client.Put(proto.Key("aa"), []byte("1"))); err != nil {
+		panic(err)
+	}
+	get := client.Get(proto.Key("aa"))
+	if err := db.Run(get); err != nil {
+		panic(err)
+	}
+	fmt.Printf("aa=%s\n", get.ValueBytes())
+
+	// Output:
+	// aa=
+}
+
+func ExampleCall_CPut() {
+	s, db := setupCall()
+	defer s.Stop()
+
+	if err := db.Run(client.Put(proto.Key("aa"), []byte("1"))); err != nil {
+		panic(err)
+	}
+	if err := db.Run(client.ConditionalPut(proto.Key("aa"), []byte("2"), []byte("1"))); err != nil {
+		panic(err)
+	}
+}
+
+func ExampleCall_Batch() {
+	s, db := setupCall()
+	defer s.Stop()
+
+	calls := []client.Callable{client.Get(proto.Key("aa")), client.Put(proto.Key("bb"), []byte("2"))}
+	if err := db.Run(calls...); err != nil {
+		panic(err)
+	}
+	for _, call := range calls {
+		if get, ok := call.(client.GetCall); ok {
+			fmt.Printf("%s=%s\n", get.Args.Key, get.ValueBytes())
+		}
+	}
+
+	// Output:
+	// aa=
+}
+
+func ExampleCall_Batch2() {
+	s, db := setupCall()
+	defer s.Stop()
+
+	get := client.Get(proto.Key("aa"))
+	put := client.Put(proto.Key("aa"), []byte("2"))
+	if err := db.Run(get, put); err != nil {
+		panic(err)
+	}
+
+	fmt.Printf("aa=%s\n", get.ValueBytes())
+
+	// Output:
+	// aa=
+}
+
+func ExampleCall_Scan() {
+	s, db := setupCall()
+	defer s.Stop()
+
+	if err := db.Run(
+		client.Put(proto.Key("aa"), []byte("1")),
+		client.Put(proto.Key("ab"), []byte("2")),
+		client.Put(proto.Key("bb"), []byte("3"))); err != nil {
+		panic(err)
+	}
+	scan := client.Scan(proto.Key("a"), proto.Key("b"), 100)
+	if err := db.Run(scan); err != nil {
+		panic(err)
+	}
+
+}

--- a/client/db.go
+++ b/client/db.go
@@ -481,7 +481,7 @@ type Batch struct {
 	//   // string(b.Results[0].Rows[0].Key) == "a"
 	//   // string(b.Results[1].Rows[0].Key) == "b"
 	Results    []Result
-	calls      []Call
+	calls      []Callable
 	resultsBuf [8]Result
 	rowsBuf    [8]KeyValue
 	rowsIdx    int
@@ -518,7 +518,7 @@ func (b *Batch) fillResults() error {
 		result := &b.Results[i]
 
 		for k := 0; k < result.calls; k++ {
-			call := b.calls[offset+k]
+			call := b.calls[offset+k].Call()
 
 			if result.Err == nil {
 				result.Err = call.Reply.Header().GoError()
@@ -623,7 +623,7 @@ func (b *Batch) InternalAddCall(call Call) {
 // key can be either a byte slice, a string, a fmt.Stringer or an
 // encoding.BinaryMarshaler.
 func (b *Batch) Get(keys ...interface{}) *Batch {
-	var calls []Call
+	var calls []Callable
 	for _, key := range keys {
 		k, err := marshalKey(key)
 		if err != nil {
@@ -741,7 +741,7 @@ func (b *Batch) Scan(s, e interface{}, maxRows int64) *Batch {
 // key can be either a byte slice, a string, a fmt.Stringer or an
 // encoding.BinaryMarshaler.
 func (b *Batch) Del(keys ...interface{}) *Batch {
-	var calls []Call
+	var calls []Callable
 	for _, key := range keys {
 		k, err := marshalKey(key)
 		if err != nil {

--- a/kv/db_test.go
+++ b/kv/db_test.go
@@ -316,7 +316,7 @@ func TestKVDBTransaction(t *testing.T) {
 
 		// Attempt to read outside of txn.
 		call := client.Get(key)
-		gr := call.Reply.(*proto.GetResponse)
+		gr := call.Reply
 		if err := kvClient.Run(call); err != nil {
 			t.Fatal(err)
 		}
@@ -326,7 +326,7 @@ func TestKVDBTransaction(t *testing.T) {
 
 		// Read within the transaction.
 		call = client.Get(key)
-		gr = call.Reply.(*proto.GetResponse)
+		gr = call.Reply
 		if err := txn.Run(call); err != nil {
 			t.Fatal(err)
 		}
@@ -341,7 +341,7 @@ func TestKVDBTransaction(t *testing.T) {
 
 	// Verify the value is now visible after commit.
 	call := client.Get(key)
-	gr := call.Reply.(*proto.GetResponse)
+	gr := call.Reply
 	if err = kvClient.Run(call); err != nil {
 		t.Errorf("expected success reading value; got %s", err)
 	}

--- a/kv/txn_correctness_test.go
+++ b/kv/txn_correctness_test.go
@@ -58,7 +58,7 @@ func setCorrectnessRetryOptions(lSender *retryableLocalSender) {
 }
 
 type runner interface {
-	Run(calls ...client.Call) error
+	Run(calls ...client.Callable) error
 }
 
 // The following structs and methods provide a mechanism for verifying
@@ -146,7 +146,7 @@ func (c *cmd) String() string {
 // readCmd reads a value from the db and stores it in the env.
 func readCmd(c *cmd, db runner, t *testing.T) error {
 	call := client.Get(c.getKey())
-	r := call.Reply.(*proto.GetResponse)
+	r := call.Reply
 	if err := db.Run(call); err != nil {
 		return err
 	}

--- a/server/status.go
+++ b/server/status.go
@@ -293,7 +293,7 @@ func (s *statusServer) handleNodeStatus(w http.ResponseWriter, r *http.Request, 
 
 	nodeStatus := &proto.NodeStatus{}
 	call := client.GetProto(key, nodeStatus)
-	resp := call.Reply.(*proto.GetResponse)
+	resp := call.Reply
 	if err := s.db.Run(call); err != nil {
 		log.Error(err)
 		w.WriteHeader(http.StatusInternalServerError)
@@ -366,7 +366,7 @@ func (s *statusServer) handleStoreStatus(w http.ResponseWriter, r *http.Request,
 
 	storeStatus := &proto.StoreStatus{}
 	call := client.GetProto(key, storeStatus)
-	resp := call.Reply.(*proto.GetResponse)
+	resp := call.Reply
 	if err := s.db.Run(call); err != nil {
 		log.Error(err)
 		w.WriteHeader(http.StatusInternalServerError)

--- a/server/status_test.go
+++ b/server/status_test.go
@@ -454,10 +454,7 @@ func TestMetricsRecording(t *testing.T) {
 		if err := tsrv.kv.Run(call); err != nil {
 			return err
 		}
-		resp, ok := call.Reply.(*proto.GetResponse)
-		if !ok {
-			return util.Error("response was not a GetResponse")
-		}
+		resp := call.Reply
 		if resp.Value == nil {
 			return util.Errorf("key %s had nil value", key)
 		}

--- a/storage/addressing.go
+++ b/storage/addressing.go
@@ -26,21 +26,21 @@ import (
 	"github.com/cockroachdb/cockroach/util"
 )
 
-type metaAction func([]client.Call, proto.Key, *proto.RangeDescriptor) []client.Call
+type metaAction func([]client.Callable, proto.Key, *proto.RangeDescriptor) []client.Callable
 
-func putMeta(calls []client.Call, key proto.Key, desc *proto.RangeDescriptor) []client.Call {
+func putMeta(calls []client.Callable, key proto.Key, desc *proto.RangeDescriptor) []client.Callable {
 	return append(calls, client.PutProto(key, desc))
 }
 
-func delMeta(calls []client.Call, key proto.Key, desc *proto.RangeDescriptor) []client.Call {
+func delMeta(calls []client.Callable, key proto.Key, desc *proto.RangeDescriptor) []client.Callable {
 	return append(calls, client.Delete(key))
 }
 
 // splitRangeAddressing creates (or overwrites if necessary) the meta1
 // and meta2 range addressing records for the left and right ranges
 // caused by a split.
-func splitRangeAddressing(left, right *proto.RangeDescriptor) ([]client.Call, error) {
-	var calls []client.Call
+func splitRangeAddressing(left, right *proto.RangeDescriptor) ([]client.Callable, error) {
+	var calls []client.Callable
 	var err error
 	if calls, err = rangeAddressing(calls, left, putMeta); err != nil {
 		return nil, err
@@ -55,8 +55,8 @@ func splitRangeAddressing(left, right *proto.RangeDescriptor) ([]client.Call, er
 // addressing records caused by merging and updates the records for
 // the new merged range. Left is the range descriptor for the "left"
 // range before merging and merged describes the left to right merge.
-func mergeRangeAddressing(left, merged *proto.RangeDescriptor) ([]client.Call, error) {
-	var calls []client.Call
+func mergeRangeAddressing(left, merged *proto.RangeDescriptor) ([]client.Callable, error) {
+	var calls []client.Callable
 	var err error
 	if calls, err = rangeAddressing(calls, left, delMeta); err != nil {
 		return nil, err
@@ -70,8 +70,8 @@ func mergeRangeAddressing(left, merged *proto.RangeDescriptor) ([]client.Call, e
 // updateRangeAddressing overwrites the meta1 and meta2 range addressing
 // records for the descriptor. Returns a slice of calls necessary to
 // update the records on the KV database.
-func updateRangeAddressing(desc *proto.RangeDescriptor) ([]client.Call, error) {
-	return rangeAddressing([]client.Call{}, desc, putMeta)
+func updateRangeAddressing(desc *proto.RangeDescriptor) ([]client.Callable, error) {
+	return rangeAddressing([]client.Callable{}, desc, putMeta)
 }
 
 // rangeAddressing updates or deletes the range addressing metadata
@@ -88,8 +88,8 @@ func updateRangeAddressing(desc *proto.RangeDescriptor) ([]client.Call, error) {
 //     - meta2(desc.EndKey)
 //     3a. If desc.StartKey is KeyMin or meta2:
 //         - meta1(KeyMax)
-func rangeAddressing(calls []client.Call, desc *proto.RangeDescriptor,
-	action metaAction) ([]client.Call, error) {
+func rangeAddressing(calls []client.Callable, desc *proto.RangeDescriptor,
+	action metaAction) ([]client.Callable, error) {
 	// 1. handle illegal case of start or end key being meta1.
 	if bytes.HasPrefix(desc.EndKey, engine.KeyMeta1Prefix) ||
 		bytes.HasPrefix(desc.StartKey, engine.KeyMeta1Prefix) {

--- a/storage/addressing_test.go
+++ b/storage/addressing_test.go
@@ -114,7 +114,7 @@ func TestUpdateRangeAddressing(t *testing.T) {
 	for i, test := range testCases {
 		left := &proto.RangeDescriptor{RaftID: int64(i * 2), StartKey: test.leftStart, EndKey: test.leftEnd}
 		right := &proto.RangeDescriptor{RaftID: int64(i*2 + 1), StartKey: test.rightStart, EndKey: test.rightEnd}
-		var calls []client.Call
+		var calls []client.Callable
 		if test.split {
 			var err error
 			if calls, err = splitRangeAddressing(left, right); err != nil {

--- a/storage/client_split_test.go
+++ b/storage/client_split_test.go
@@ -422,7 +422,7 @@ func TestStoreRangeSplitOnConfigs(t *testing.T) {
 	zoneConfig := &proto.ZoneConfig{}
 
 	// Write zone configs for db3 & db4.
-	var calls []client.Call
+	var calls []client.Callable
 	for _, k := range []string{"db4", "db3"} {
 		call := client.PutProto(
 			engine.MakeKey(engine.KeyConfigZonePrefix, proto.Key(k)),

--- a/structured/db.go
+++ b/structured/db.go
@@ -86,7 +86,7 @@ func (db *structuredDB) GetSchema(key string) (*Schema, error) {
 	if err := db.kvDB.Run(call); err != nil {
 		return nil, err
 	}
-	reply := call.Reply.(*proto.GetResponse)
+	reply := call.Reply
 	if reply.Value == nil {
 		// No value present.
 		return nil, nil


### PR DESCRIPTION
This lets us use separate types for each operation (I've implemented one
for Get in this change), giving us type-safe accessors and a place to
potentially add helper methods.

This helps eliminate type assertions in application code, although it
is intrusive in the case of batch operations. I think this could be
alleviated with a new Calls type instead of a raw slice, but is
it worth it given the new higher-level client interface? (One reason
I'm interested in enhancing the Call-based interface is that I want to
use Calls in storage-level tests, where we can't always use the full
client)
