### PR TITLE
Skip `TestNoLinkTesting` when GOPATH is unset

### DIFF
--- a/server/cli/flags_test.go
+++ b/server/cli/flags_test.go
@@ -38,6 +38,10 @@ func TestStdFlagToPflag(t *testing.T) {
 }
 
 func TestNoLinkTesting(t *testing.T) {
+	if build.Default.GOPATH == "" {
+		t.Skip("GOPATH isn't set")
+	}
+
 	imports := make(map[string]struct{})
 
 	var addImports func(string)


### PR DESCRIPTION
Fixes #946.
