### PR TITLE
Replace kv/rest's router with a httprouter.

### DIFF
--- a/GLOCKFILE
+++ b/GLOCKFILE
@@ -21,6 +21,7 @@ github.com/golang/glog 44145f04b68cf362d9c4df2182967c2275eaefed
 github.com/golang/lint 39d15d55e9777df34cdffde4f406ab27fd2e60c0
 github.com/inconshreveable/mousetrap 76626ae9c91c4f2a10f34cad8ce83ea42c93bb75
 github.com/jteeuwen/go-bindata 7362d4b6b2ce6a7d3c28b523a6e40629f4d81116
+github.com/julienschmidt/httprouter 8c199fb6259ffc1af525cc3ad52ee60ba8359669
 github.com/kisielk/errcheck eb516cb958915b69ad14384890b4d37bd910c9f3
 github.com/kisielk/gotool d678387370a2eb9b5b0a33218bc8c9d8de15b6be
 github.com/robfig/glock 78c45da050a4d993d12ad07e8ddb10a4891ac701

--- a/build/devbase/godeps.sh
+++ b/build/devbase/godeps.sh
@@ -44,6 +44,7 @@ github.com/elazarl/go-bindata-assetfs
 github.com/gogo/protobuf/proto
 github.com/golang/glog
 github.com/inconshreveable/mousetrap
+github.com/julienschmidt/httprouter
 github.com/spf13/cobra
 github.com/spf13/pflag
 golang.org/x/net/context

--- a/kv/rest_test.go
+++ b/kv/rest_test.go
@@ -98,6 +98,9 @@ func TestMethods(t *testing.T) {
 		// Test that empty keys are not acceptable, but empty values are.
 		{methodGet, "", nil, http.StatusBadRequest, nil},
 		{methodPost, "", nil, http.StatusBadRequest, nil},
+		{methodPut, "", nil, http.StatusBadRequest, nil},
+		{methodDelete, "", nil, http.StatusBadRequest, nil},
+		{methodHead, "", nil, http.StatusBadRequest, nil},
 		{methodPut, testKey, nil, http.StatusOK, nil},
 		{methodHead, testKey, nil, http.StatusOK, nil},
 		{methodGet, testKey, nil, http.StatusOK, nil},
@@ -440,7 +443,7 @@ func TestKeysAndBodyArePreserved(t *testing.T) {
 	s := startServer(t)
 	defer s.Stop()
 
-	encKey := "%00some%2Fkey%20that%20encodes%E4%B8%96%E7%95%8C"
+	encKey := "%00some-key%20that%20encodes%E4%B8%96%E7%95%8C"
 	encBody := "%00some%2FBODY%20that%20encodes"
 	url := testContext.RequestScheme() + "://" + s.ServingAddr() + EntryPrefix + encKey
 	postURL(testContext, url, strings.NewReader(encBody), t)
@@ -453,7 +456,7 @@ func TestKeysAndBodyArePreserved(t *testing.T) {
 		t.Fatalf("expected body to be %q; got %q", encBody, string(pr.Value.Bytes))
 	}
 	// Lookup results direclty from the underlying engine.
-	key := proto.Key("\x00some/key that encodes世界")
+	key := proto.Key("\x00some-key that encodes世界")
 	val, err := engine.MVCCGet(s.Engines[0], key, s.Clock().Now(), false, nil)
 	if err != nil {
 		t.Errorf("unable to fetch value for key %s: %s", key, err)


### PR DESCRIPTION
https://github.com/julienschmidt/httprouter

This new router is faster, smaller and allows for parsing of parameters using a pattern in the path as opposed to having to parse it ourselves.  

I plan to clean up other instances as well.
