### PR TITLE
Time Series now store Float64 exclusively

### DIFF
--- a/proto/data.go
+++ b/proto/data.go
@@ -590,14 +590,6 @@ func (ts TimeSeriesData) ToInternal(keyDuration int64, sampleDuration int64) (
 	resultByKeyTime := map[int64]*InternalTimeSeriesData{}
 
 	for _, dp := range ts.Datapoints {
-		// Validate the datapoint.
-		if dp.IntValue == nil && dp.FloatValue == nil {
-			return nil, util.Errorf("datapoint %v has no value.", dp)
-		}
-		if dp.IntValue != nil && dp.FloatValue != nil {
-			return nil, util.Errorf("datapoint %v has both integer and float data.", dp)
-		}
-
 		// Determine which InternalTimeSeriesData this datapoint belongs to,
 		// creating if it has not already been created for a previous sample.
 		keyTime := (dp.TimestampNanos / keyDuration) * keyDuration
@@ -614,13 +606,10 @@ func (ts TimeSeriesData) ToInternal(keyDuration int64, sampleDuration int64) (
 		// Create a new sample for this datapoint and place it into the
 		// InternalTimeSeriesData.
 		sampleOffset := int32((dp.TimestampNanos - keyTime) / sampleDuration)
-		sample := &InternalTimeSeriesSample{Offset: sampleOffset}
-		if dp.IntValue != nil {
-			sample.IntCount = 1
-			sample.IntSum = dp.IntValue
-		} else {
-			sample.FloatCount = 1
-			sample.FloatSum = dp.FloatValue
+		sample := &InternalTimeSeriesSample{
+			Offset: sampleOffset,
+			Count:  1,
+			Sum:    dp.Value,
 		}
 		itsd.Samples = append(itsd.Samples, sample)
 	}

--- a/proto/data.pb.go
+++ b/proto/data.pb.go
@@ -739,13 +739,9 @@ type TimeSeriesDatapoint struct {
 	// The timestamp when this datapoint is located, expressed in nanoseconds
 	// since the unix epoch.
 	TimestampNanos int64 `protobuf:"varint,1,opt,name=timestamp_nanos" json:"timestamp_nanos"`
-	// An integer representation of the value of this datapoint. If this field
-	// is set, then 'float_value' must not be set.
-	IntValue *int64 `protobuf:"varint,2,opt,name=int_value" json:"int_value,omitempty"`
-	// A floating point representation of the value of this datapoint. If this
-	// field is set, then 'int_value' must not be set.
-	FloatValue       *float32 `protobuf:"fixed32,3,opt,name=float_value" json:"float_value,omitempty"`
-	XXX_unrecognized []byte   `json:"-"`
+	// A floating point representation of the value of this datapoint.
+	Value            float64 `protobuf:"fixed64,2,opt,name=value" json:"value"`
+	XXX_unrecognized []byte  `json:"-"`
 }
 
 func (m *TimeSeriesDatapoint) Reset()         { *m = TimeSeriesDatapoint{} }
@@ -759,16 +755,9 @@ func (m *TimeSeriesDatapoint) GetTimestampNanos() int64 {
 	return 0
 }
 
-func (m *TimeSeriesDatapoint) GetIntValue() int64 {
-	if m != nil && m.IntValue != nil {
-		return *m.IntValue
-	}
-	return 0
-}
-
-func (m *TimeSeriesDatapoint) GetFloatValue() float32 {
-	if m != nil && m.FloatValue != nil {
-		return *m.FloatValue
+func (m *TimeSeriesDatapoint) GetValue() float64 {
+	if m != nil {
+		return m.Value
 	}
 	return 0
 }
@@ -2693,38 +2682,24 @@ func (m *TimeSeriesDatapoint) Unmarshal(data []byte) error {
 				}
 			}
 		case 2:
-			if wireType != 0 {
-				return fmt.Errorf("proto: wrong wireType = %d for field IntValue", wireType)
+			if wireType != 1 {
+				return fmt.Errorf("proto: wrong wireType = %d for field Value", wireType)
 			}
-			var v int64
-			for shift := uint(0); ; shift += 7 {
-				if index >= l {
-					return io.ErrUnexpectedEOF
-				}
-				b := data[index]
-				index++
-				v |= (int64(b) & 0x7F) << shift
-				if b < 0x80 {
-					break
-				}
-			}
-			m.IntValue = &v
-		case 3:
-			if wireType != 5 {
-				return fmt.Errorf("proto: wrong wireType = %d for field FloatValue", wireType)
-			}
-			var v uint32
-			i := index + 4
+			var v uint64
+			i := index + 8
 			if i > l {
 				return io.ErrUnexpectedEOF
 			}
 			index = i
-			v = uint32(data[i-4])
-			v |= uint32(data[i-3]) << 8
-			v |= uint32(data[i-2]) << 16
-			v |= uint32(data[i-1]) << 24
-			v2 := math.Float32frombits(v)
-			m.FloatValue = &v2
+			v = uint64(data[i-8])
+			v |= uint64(data[i-7]) << 8
+			v |= uint64(data[i-6]) << 16
+			v |= uint64(data[i-5]) << 24
+			v |= uint64(data[i-4]) << 32
+			v |= uint64(data[i-3]) << 40
+			v |= uint64(data[i-2]) << 48
+			v |= uint64(data[i-1]) << 56
+			m.Value = math.Float64frombits(v)
 		default:
 			var sizeOfWire int
 			for {
@@ -3329,12 +3304,7 @@ func (m *TimeSeriesDatapoint) Size() (n int) {
 	var l int
 	_ = l
 	n += 1 + sovData(uint64(m.TimestampNanos))
-	if m.IntValue != nil {
-		n += 1 + sovData(uint64(*m.IntValue))
-	}
-	if m.FloatValue != nil {
-		n += 5
-	}
+	n += 9
 	if m.XXX_unrecognized != nil {
 		n += len(m.XXX_unrecognized)
 	}
@@ -4071,16 +4041,9 @@ func (m *TimeSeriesDatapoint) MarshalTo(data []byte) (n int, err error) {
 	data[i] = 0x8
 	i++
 	i = encodeVarintData(data, i, uint64(m.TimestampNanos))
-	if m.IntValue != nil {
-		data[i] = 0x10
-		i++
-		i = encodeVarintData(data, i, uint64(*m.IntValue))
-	}
-	if m.FloatValue != nil {
-		data[i] = 0x1d
-		i++
-		i = encodeFixed32Data(data, i, uint32(math.Float32bits(*m.FloatValue)))
-	}
+	data[i] = 0x11
+	i++
+	i = encodeFixed64Data(data, i, uint64(math.Float64bits(m.Value)))
 	if m.XXX_unrecognized != nil {
 		i += copy(data[i:], m.XXX_unrecognized)
 	}

--- a/proto/data.proto
+++ b/proto/data.proto
@@ -297,12 +297,8 @@ message TimeSeriesDatapoint {
   // The timestamp when this datapoint is located, expressed in nanoseconds
   // since the unix epoch.
   optional int64 timestamp_nanos = 1 [(gogoproto.nullable) = false];
-  // An integer representation of the value of this datapoint. If this field
-  // is set, then 'float_value' must not be set.
-  optional int64 int_value = 2;
-  // A floating point representation of the value of this datapoint. If this
-  // field is set, then 'int_value' must not be set.
-  optional float float_value = 3;
+  // A floating point representation of the value of this datapoint.
+  optional double value = 2 [(gogoproto.nullable) = false];
 }
 
 // TimeSeriesData is a set of observations of a single variable value at

--- a/proto/data_test.go
+++ b/proto/data_test.go
@@ -425,17 +425,10 @@ func ts(name string, dps ...*TimeSeriesDatapoint) *TimeSeriesData {
 	}
 }
 
-func tsdpi(ts time.Duration, val int64) *TimeSeriesDatapoint {
+func tsdp(ts time.Duration, val float64) *TimeSeriesDatapoint {
 	return &TimeSeriesDatapoint{
 		TimestampNanos: int64(ts),
-		IntValue:       gogoproto.Int64(val),
-	}
-}
-
-func tsdpf(ts time.Duration, val float32) *TimeSeriesDatapoint {
-	return &TimeSeriesDatapoint{
-		TimestampNanos: int64(ts),
-		FloatValue:     gogoproto.Float32(val),
+		Value:          val,
 	}
 }
 
@@ -464,102 +457,16 @@ func TestToInternal(t *testing.T) {
 			nil,
 		},
 		{
-			time.Hour.Nanoseconds(),
-			time.Second.Nanoseconds(),
-			true,
-			ts("error.series",
-				tsdpi((time.Hour*50)+(time.Second*5), 1),
-				&TimeSeriesDatapoint{},
-			),
-			nil,
-		},
-		{
-			time.Hour.Nanoseconds(),
-			time.Second.Nanoseconds(),
-			true,
-			ts("error.series",
-				tsdpi((time.Hour*50)+(time.Second*5), 1),
-				&TimeSeriesDatapoint{
-					IntValue:   gogoproto.Int64(5),
-					FloatValue: gogoproto.Float32(5.0),
-				},
-			),
-			nil,
-		},
-		{
-			time.Hour.Nanoseconds(),
-			time.Second.Nanoseconds(),
-			false,
-			ts("test.series",
-				tsdpi((time.Hour*50)+(time.Second*5), 1),
-				tsdpi((time.Hour*51)+(time.Second*3), 2),
-				tsdpi((time.Hour*50)+(time.Second*10), 3),
-				tsdpi((time.Hour*53), 4),
-				tsdpi((time.Hour*50)+(time.Second*5)+1, 5),
-				tsdpi((time.Hour*53)+(time.Second*15), 0),
-			),
-			[]*InternalTimeSeriesData{
-				{
-					StartTimestampNanos: int64(time.Hour * 50),
-					SampleDurationNanos: int64(time.Second),
-					Samples: []*InternalTimeSeriesSample{
-						{
-							Offset:   5,
-							IntCount: 1,
-							IntSum:   gogoproto.Int64(1),
-						},
-						{
-							Offset:   10,
-							IntCount: 1,
-							IntSum:   gogoproto.Int64(3),
-						},
-						{
-							Offset:   5,
-							IntCount: 1,
-							IntSum:   gogoproto.Int64(5),
-						},
-					},
-				},
-				{
-					StartTimestampNanos: int64(time.Hour * 51),
-					SampleDurationNanos: int64(time.Second),
-					Samples: []*InternalTimeSeriesSample{
-						{
-							Offset:   3,
-							IntCount: 1,
-							IntSum:   gogoproto.Int64(2),
-						},
-					},
-				},
-				{
-					StartTimestampNanos: int64(time.Hour * 53),
-					SampleDurationNanos: int64(time.Second),
-					Samples: []*InternalTimeSeriesSample{
-						{
-							Offset:   0,
-							IntCount: 1,
-							IntSum:   gogoproto.Int64(4),
-						},
-						{
-							Offset:   15,
-							IntCount: 1,
-							IntSum:   gogoproto.Int64(0),
-						},
-					},
-				},
-			},
-		},
-		{
 			(time.Hour * 24).Nanoseconds(),
 			(time.Minute * 20).Nanoseconds(),
 			false,
 			ts("test.series",
-				tsdpf((time.Hour*5)+(time.Minute*5), 1.0),
-				tsdpf((time.Hour*24)+(time.Minute*39), 2.0),
-				tsdpf((time.Hour*10)+(time.Minute*10), 3.0),
-				tsdpf((time.Hour*48), 4.0),
-				tsdpf((time.Hour*15)+(time.Minute*22)+1, 5.0),
-				tsdpf((time.Hour*52)+(time.Minute*15), 0.0),
+				tsdp((time.Hour*5)+(time.Minute*5), 1.0),
+				tsdp((time.Hour*24)+(time.Minute*39), 2.0),
+				tsdp((time.Hour*10)+(time.Minute*10), 3.0),
+				tsdp((time.Hour*48), 4.0),
+				tsdp((time.Hour*15)+(time.Minute*22)+1, 5.0),
+				tsdp((time.Hour*52)+(time.Minute*15), 0.0),
 			),
 			[]*InternalTimeSeriesData{
 				{
@@ -567,19 +474,19 @@ func TestToInternal(t *testing.T) {
 					SampleDurationNanos: int64(time.Minute * 20),
 					Samples: []*InternalTimeSeriesSample{
 						{
-							Offset:     15,
-							FloatCount: 1,
-							FloatSum:   gogoproto.Float32(1.0),
+							Offset: 15,
+							Count:  1,
+							Sum:    1.0,
 						},
 						{
-							Offset:     30,
-							FloatCount: 1,
-							FloatSum:   gogoproto.Float32(3.0),
+							Offset: 30,
+							Count:  1,
+							Sum:    3.0,
 						},
 						{
-							Offset:     46,
-							FloatCount: 1,
-							FloatSum:   gogoproto.Float32(5.0),
+							Offset: 46,
+							Count:  1,
+							Sum:    5.0,
 						},
 					},
 				},
@@ -588,9 +495,9 @@ func TestToInternal(t *testing.T) {
 					SampleDurationNanos: int64(time.Minute * 20),
 					Samples: []*InternalTimeSeriesSample{
 						{
-							Offset:     1,
-							FloatCount: 1,
-							FloatSum:   gogoproto.Float32(2.0),
+							Offset: 1,
+							Count:  1,
+							Sum:    2.0,
 						},
 					},
 				},
@@ -599,14 +506,14 @@ func TestToInternal(t *testing.T) {
 					SampleDurationNanos: int64(time.Minute * 20),
 					Samples: []*InternalTimeSeriesSample{
 						{
-							Offset:     0,
-							FloatCount: 1,
-							FloatSum:   gogoproto.Float32(4.0),
+							Offset: 0,
+							Count:  1,
+							Sum:    4.0,
 						},
 						{
-							Offset:     12,
-							FloatCount: 1,
-							FloatSum:   gogoproto.Float32(0.0),
+							Offset: 12,
+							Count:  1,
+							Sum:    0.0,
 						},
 					},
 				},

--- a/proto/internal.pb.go
+++ b/proto/internal.pb.go
@@ -1101,36 +1101,20 @@ func (m *InternalTimeSeriesData) GetSamples() []*InternalTimeSeriesSample {
 //
 // If the count of measurements is 1, then max and min fields may be omitted
 // and assumed equal to the sum field.
-//
-// The variable being measured may be either an integer or a floating point;
-// therefore, there are two fields each for "sum", "max" and "min" to hold
-// either an integer or floating point number. In practice, only one set of
-// these fields should be present for any individual sample; however, int and
-// float values are recorded in parallel, allowing clients to write both floats
-// and integers to the same value. These are recorded separately to retain
-// precision, but are easily combined by higher-level logic at query time.
 type InternalTimeSeriesSample struct {
 	// Temporal offset from the "start_timestamp" of the InternalTimeSeriesData
 	// collection this data point is part in. The units of this value are
 	// determined by the value of the "sample_duration_milliseconds" field of
 	// the TimeSeriesData collection.
 	Offset int32 `protobuf:"varint,1,opt,name=offset" json:"offset"`
-	// Count of integer measurements taken within this sample.
-	IntCount uint32 `protobuf:"varint,2,opt,name=int_count" json:"int_count"`
-	// Sum of all integer measurements.
-	IntSum *int64 `protobuf:"varint,3,opt,name=int_sum" json:"int_sum,omitempty"`
-	// Maximum encountered integer measurement in this sample.
-	IntMax *int64 `protobuf:"varint,4,opt,name=int_max" json:"int_max,omitempty"`
-	// Minimum encountered integer measurement in this sample.
-	IntMin *int64 `protobuf:"varint,5,opt,name=int_min" json:"int_min,omitempty"`
-	// Count of floating point measurements taken within this sample.
-	FloatCount uint32 `protobuf:"varint,6,opt,name=float_count" json:"float_count"`
-	// Sum of all floating point measurements.
-	FloatSum *float32 `protobuf:"fixed32,7,opt,name=float_sum" json:"float_sum,omitempty"`
-	// Maximum encountered floating point measurement in this sample.
-	FloatMax *float32 `protobuf:"fixed32,8,opt,name=float_max" json:"float_max,omitempty"`
-	// Minimum encountered floating point measurement in this sample.
-	FloatMin         *float32 `protobuf:"fixed32,9,opt,name=float_min" json:"float_min,omitempty"`
+	// Count of measurements taken within this sample.
+	Count uint32 `protobuf:"varint,6,opt,name=count" json:"count"`
+	// Sum of all measurements.
+	Sum float64 `protobuf:"fixed64,7,opt,name=sum" json:"sum"`
+	// Maximum encountered measurement in this sample.
+	Max *float64 `protobuf:"fixed64,8,opt,name=max" json:"max,omitempty"`
+	// Minimum encountered measurement in this sample.
+	Min              *float64 `protobuf:"fixed64,9,opt,name=min" json:"min,omitempty"`
 	XXX_unrecognized []byte   `json:"-"`
 }
 
@@ -1145,58 +1129,30 @@ func (m *InternalTimeSeriesSample) GetOffset() int32 {
 	return 0
 }
 
-func (m *InternalTimeSeriesSample) GetIntCount() uint32 {
+func (m *InternalTimeSeriesSample) GetCount() uint32 {
 	if m != nil {
-		return m.IntCount
+		return m.Count
 	}
 	return 0
 }
 
-func (m *InternalTimeSeriesSample) GetIntSum() int64 {
-	if m != nil && m.IntSum != nil {
-		return *m.IntSum
-	}
-	return 0
-}
-
-func (m *InternalTimeSeriesSample) GetIntMax() int64 {
-	if m != nil && m.IntMax != nil {
-		return *m.IntMax
-	}
-	return 0
-}
-
-func (m *InternalTimeSeriesSample) GetIntMin() int64 {
-	if m != nil && m.IntMin != nil {
-		return *m.IntMin
-	}
-	return 0
-}
-
-func (m *InternalTimeSeriesSample) GetFloatCount() uint32 {
+func (m *InternalTimeSeriesSample) GetSum() float64 {
 	if m != nil {
-		return m.FloatCount
+		return m.Sum
 	}
 	return 0
 }
 
-func (m *InternalTimeSeriesSample) GetFloatSum() float32 {
-	if m != nil && m.FloatSum != nil {
-		return *m.FloatSum
+func (m *InternalTimeSeriesSample) GetMax() float64 {
+	if m != nil && m.Max != nil {
+		return *m.Max
 	}
 	return 0
 }
 
-func (m *InternalTimeSeriesSample) GetFloatMax() float32 {
-	if m != nil && m.FloatMax != nil {
-		return *m.FloatMax
-	}
-	return 0
-}
-
-func (m *InternalTimeSeriesSample) GetFloatMin() float32 {
-	if m != nil && m.FloatMin != nil {
-		return *m.FloatMin
+func (m *InternalTimeSeriesSample) GetMin() float64 {
+	if m != nil && m.Min != nil {
+		return *m.Min
 	}
 	return 0
 }
@@ -4819,75 +4775,9 @@ func (m *InternalTimeSeriesSample) Unmarshal(data []byte) error {
 					break
 				}
 			}
-		case 2:
-			if wireType != 0 {
-				return fmt.Errorf("proto: wrong wireType = %d for field IntCount", wireType)
-			}
-			for shift := uint(0); ; shift += 7 {
-				if index >= l {
-					return io.ErrUnexpectedEOF
-				}
-				b := data[index]
-				index++
-				m.IntCount |= (uint32(b) & 0x7F) << shift
-				if b < 0x80 {
-					break
-				}
-			}
-		case 3:
-			if wireType != 0 {
-				return fmt.Errorf("proto: wrong wireType = %d for field IntSum", wireType)
-			}
-			var v int64
-			for shift := uint(0); ; shift += 7 {
-				if index >= l {
-					return io.ErrUnexpectedEOF
-				}
-				b := data[index]
-				index++
-				v |= (int64(b) & 0x7F) << shift
-				if b < 0x80 {
-					break
-				}
-			}
-			m.IntSum = &v
-		case 4:
-			if wireType != 0 {
-				return fmt.Errorf("proto: wrong wireType = %d for field IntMax", wireType)
-			}
-			var v int64
-			for shift := uint(0); ; shift += 7 {
-				if index >= l {
-					return io.ErrUnexpectedEOF
-				}
-				b := data[index]
-				index++
-				v |= (int64(b) & 0x7F) << shift
-				if b < 0x80 {
-					break
-				}
-			}
-			m.IntMax = &v
-		case 5:
-			if wireType != 0 {
-				return fmt.Errorf("proto: wrong wireType = %d for field IntMin", wireType)
-			}
-			var v int64
-			for shift := uint(0); ; shift += 7 {
-				if index >= l {
-					return io.ErrUnexpectedEOF
-				}
-				b := data[index]
-				index++
-				v |= (int64(b) & 0x7F) << shift
-				if b < 0x80 {
-					break
-				}
-			}
-			m.IntMin = &v
 		case 6:
 			if wireType != 0 {
-				return fmt.Errorf("proto: wrong wireType = %d for field FloatCount", wireType)
+				return fmt.Errorf("proto: wrong wireType = %d for field Count", wireType)
 			}
 			for shift := uint(0); ; shift += 7 {
 				if index >= l {
@@ -4895,59 +4785,70 @@ func (m *InternalTimeSeriesSample) Unmarshal(data []byte) error {
 				}
 				b := data[index]
 				index++
-				m.FloatCount |= (uint32(b) & 0x7F) << shift
+				m.Count |= (uint32(b) & 0x7F) << shift
 				if b < 0x80 {
 					break
 				}
 			}
 		case 7:
-			if wireType != 5 {
-				return fmt.Errorf("proto: wrong wireType = %d for field FloatSum", wireType)
+			if wireType != 1 {
+				return fmt.Errorf("proto: wrong wireType = %d for field Sum", wireType)
 			}
-			var v uint32
-			i := index + 4
+			var v uint64
+			i := index + 8
 			if i > l {
 				return io.ErrUnexpectedEOF
 			}
 			index = i
-			v = uint32(data[i-4])
-			v |= uint32(data[i-3]) << 8
-			v |= uint32(data[i-2]) << 16
-			v |= uint32(data[i-1]) << 24
-			v2 := math.Float32frombits(v)
-			m.FloatSum = &v2
+			v = uint64(data[i-8])
+			v |= uint64(data[i-7]) << 8
+			v |= uint64(data[i-6]) << 16
+			v |= uint64(data[i-5]) << 24
+			v |= uint64(data[i-4]) << 32
+			v |= uint64(data[i-3]) << 40
+			v |= uint64(data[i-2]) << 48
+			v |= uint64(data[i-1]) << 56
+			m.Sum = math.Float64frombits(v)
 		case 8:
-			if wireType != 5 {
-				return fmt.Errorf("proto: wrong wireType = %d for field FloatMax", wireType)
+			if wireType != 1 {
+				return fmt.Errorf("proto: wrong wireType = %d for field Max", wireType)
 			}
-			var v uint32
-			i := index + 4
+			var v uint64
+			i := index + 8
 			if i > l {
 				return io.ErrUnexpectedEOF
 			}
 			index = i
-			v = uint32(data[i-4])
-			v |= uint32(data[i-3]) << 8
-			v |= uint32(data[i-2]) << 16
-			v |= uint32(data[i-1]) << 24
-			v2 := math.Float32frombits(v)
-			m.FloatMax = &v2
+			v = uint64(data[i-8])
+			v |= uint64(data[i-7]) << 8
+			v |= uint64(data[i-6]) << 16
+			v |= uint64(data[i-5]) << 24
+			v |= uint64(data[i-4]) << 32
+			v |= uint64(data[i-3]) << 40
+			v |= uint64(data[i-2]) << 48
+			v |= uint64(data[i-1]) << 56
+			v2 := math.Float64frombits(v)
+			m.Max = &v2
 		case 9:
-			if wireType != 5 {
-				return fmt.Errorf("proto: wrong wireType = %d for field FloatMin", wireType)
+			if wireType != 1 {
+				return fmt.Errorf("proto: wrong wireType = %d for field Min", wireType)
 			}
-			var v uint32
-			i := index + 4
+			var v uint64
+			i := index + 8
 			if i > l {
 				return io.ErrUnexpectedEOF
 			}
 			index = i
-			v = uint32(data[i-4])
-			v |= uint32(data[i-3]) << 8
-			v |= uint32(data[i-2]) << 16
-			v |= uint32(data[i-1]) << 24
-			v2 := math.Float32frombits(v)
-			m.FloatMin = &v2
+			v = uint64(data[i-8])
+			v |= uint64(data[i-7]) << 8
+			v |= uint64(data[i-6]) << 16
+			v |= uint64(data[i-5]) << 24
+			v |= uint64(data[i-4]) << 32
+			v |= uint64(data[i-3]) << 40
+			v |= uint64(data[i-2]) << 48
+			v |= uint64(data[i-1]) << 56
+			v2 := math.Float64frombits(v)
+			m.Min = &v2
 		default:
 			var sizeOfWire int
 			for {
@@ -6069,25 +5970,13 @@ func (m *InternalTimeSeriesSample) Size() (n int) {
 	var l int
 	_ = l
 	n += 1 + sovInternal(uint64(m.Offset))
-	n += 1 + sovInternal(uint64(m.IntCount))
-	if m.IntSum != nil {
-		n += 1 + sovInternal(uint64(*m.IntSum))
+	n += 1 + sovInternal(uint64(m.Count))
+	n += 9
+	if m.Max != nil {
+		n += 9
 	}
-	if m.IntMax != nil {
-		n += 1 + sovInternal(uint64(*m.IntMax))
-	}
-	if m.IntMin != nil {
-		n += 1 + sovInternal(uint64(*m.IntMin))
-	}
-	n += 1 + sovInternal(uint64(m.FloatCount))
-	if m.FloatSum != nil {
-		n += 5
-	}
-	if m.FloatMax != nil {
-		n += 5
-	}
-	if m.FloatMin != nil {
-		n += 5
+	if m.Min != nil {
+		n += 9
 	}
 	if m.XXX_unrecognized != nil {
 		n += len(m.XXX_unrecognized)
@@ -7622,41 +7511,21 @@ func (m *InternalTimeSeriesSample) MarshalTo(data []byte) (n int, err error) {
 	data[i] = 0x8
 	i++
 	i = encodeVarintInternal(data, i, uint64(m.Offset))
-	data[i] = 0x10
-	i++
-	i = encodeVarintInternal(data, i, uint64(m.IntCount))
-	if m.IntSum != nil {
-		data[i] = 0x18
-		i++
-		i = encodeVarintInternal(data, i, uint64(*m.IntSum))
-	}
-	if m.IntMax != nil {
-		data[i] = 0x20
-		i++
-		i = encodeVarintInternal(data, i, uint64(*m.IntMax))
-	}
-	if m.IntMin != nil {
-		data[i] = 0x28
-		i++
-		i = encodeVarintInternal(data, i, uint64(*m.IntMin))
-	}
 	data[i] = 0x30
 	i++
-	i = encodeVarintInternal(data, i, uint64(m.FloatCount))
-	if m.FloatSum != nil {
-		data[i] = 0x3d
+	i = encodeVarintInternal(data, i, uint64(m.Count))
+	data[i] = 0x39
+	i++
+	i = encodeFixed64Internal(data, i, uint64(math.Float64bits(m.Sum)))
+	if m.Max != nil {
+		data[i] = 0x41
 		i++
-		i = encodeFixed32Internal(data, i, uint32(math.Float32bits(*m.FloatSum)))
+		i = encodeFixed64Internal(data, i, uint64(math.Float64bits(*m.Max)))
 	}
-	if m.FloatMax != nil {
-		data[i] = 0x45
+	if m.Min != nil {
+		data[i] = 0x49
 		i++
-		i = encodeFixed32Internal(data, i, uint32(math.Float32bits(*m.FloatMax)))
-	}
-	if m.FloatMin != nil {
-		data[i] = 0x4d
-		i++
-		i = encodeFixed32Internal(data, i, uint32(math.Float32bits(*m.FloatMin)))
+		i = encodeFixed64Internal(data, i, uint64(math.Float64bits(*m.Min)))
 	}
 	if m.XXX_unrecognized != nil {
 		i += copy(data[i:], m.XXX_unrecognized)

--- a/proto/internal.proto
+++ b/proto/internal.proto
@@ -401,14 +401,6 @@ message InternalTimeSeriesData {
 //
 // If the count of measurements is 1, then max and min fields may be omitted
 // and assumed equal to the sum field.
-//
-// The variable being measured may be either an integer or a floating point;
-// therefore, there are two fields each for "sum", "max" and "min" to hold
-// either an integer or floating point number. In practice, only one set of
-// these fields should be present for any individual sample; however, int and
-// float values are recorded in parallel, allowing clients to write both floats
-// and integers to the same value. These are recorded separately to retain
-// precision, but are easily combined by higher-level logic at query time.
 message InternalTimeSeriesSample {
   // Temporal offset from the "start_timestamp" of the InternalTimeSeriesData
   // collection this data point is part in. The units of this value are
@@ -416,23 +408,14 @@ message InternalTimeSeriesSample {
   // the TimeSeriesData collection.
   optional int32 offset = 1 [(gogoproto.nullable) = false];
 
-  // Count of integer measurements taken within this sample.
-  optional uint32 int_count = 2 [(gogoproto.nullable) = false];
-  // Sum of all integer measurements.
-  optional int64 int_sum = 3;
-  // Maximum encountered integer measurement in this sample.
-  optional int64 int_max = 4;
-  // Minimum encountered integer measurement in this sample.
-  optional int64 int_min = 5;
-
-  // Count of floating point measurements taken within this sample.
-  optional uint32 float_count = 6 [(gogoproto.nullable) = false];
-  // Sum of all floating point measurements.
-  optional float float_sum = 7;
-  // Maximum encountered floating point measurement in this sample.
-  optional float float_max = 8;
-  // Minimum encountered floating point measurement in this sample.
-  optional float float_min = 9;
+  // Count of measurements taken within this sample.
+  optional uint32 count = 6 [(gogoproto.nullable) = false];
+  // Sum of all measurements.
+  optional double sum = 7 [(gogoproto.nullable) = false];
+  // Maximum encountered measurement in this sample.
+  optional double max = 8;
+  // Minimum encountered measurement in this sample.
+  optional double min = 9;
 }
 
 // RaftTruncatedState contains metadata about the truncated portion of the raft log.

--- a/proto/internal_test.go
+++ b/proto/internal_test.go
@@ -30,19 +30,19 @@ func TestTimeSeriesToValue(t *testing.T) {
 		SampleDurationNanos: 1000000000,
 		Samples: []*InternalTimeSeriesSample{
 			{
-				Offset:   1,
-				IntCount: 1,
-				IntSum:   gogoproto.Int64(1),
+				Offset: 1,
+				Count:  1,
+				Sum:    64,
 			},
 			{
-				Offset:   2,
-				IntCount: 1,
-				IntSum:   gogoproto.Int64(2),
+				Offset: 2,
+				Count:  1,
+				Sum:    2,
 			},
 			{
-				Offset:   3,
-				IntCount: 1,
-				IntSum:   gogoproto.Int64(3),
+				Offset: 3,
+				Count:  1,
+				Sum:    3,
 			},
 		},
 	}

--- a/server/status/recorder.go
+++ b/server/status/recorder.go
@@ -22,7 +22,6 @@ import (
 
 	"github.com/cockroachdb/cockroach/proto"
 	"github.com/cockroachdb/cockroach/util/hlc"
-	gogoproto "github.com/gogo/protobuf/proto"
 )
 
 const (
@@ -87,21 +86,16 @@ type storeStatusRecorder struct {
 	timestampNanos int64
 }
 
-// recordInt records a single int value from the StoreStatusMonitor as a
+// recordInt records a single int64 value from the StoreStatusMonitor as a
 // proto.TimeSeriesData object.
 func (ssr *storeStatusRecorder) recordInt(name string, data int64) proto.TimeSeriesData {
 	return proto.TimeSeriesData{
 		Name: fmt.Sprintf(storeTimeSeriesNameFmt, name, ssr.ID),
 		Datapoints: []*proto.TimeSeriesDatapoint{
-			intDatapoint(ssr.timestampNanos, data),
+			{
+				TimestampNanos: ssr.timestampNanos,
+				Value:          float64(data),
+			},
 		},
-	}
-}
-
-// intDatapoint quickly generates an integer-valued datapoint.
-func intDatapoint(timestamp, val int64) *proto.TimeSeriesDatapoint {
-	return &proto.TimeSeriesDatapoint{
-		TimestampNanos: timestamp,
-		IntValue:       gogoproto.Int64(val),
 	}
 }

--- a/server/status/recorder_test.go
+++ b/server/status/recorder_test.go
@@ -115,7 +115,10 @@ func TestNodeStatusRecorder(t *testing.T) {
 		return proto.TimeSeriesData{
 			Name: fmt.Sprintf(storeTimeSeriesNameFmt, name, proto.StoreID(storeId)),
 			Datapoints: []*proto.TimeSeriesDatapoint{
-				intDatapoint(time, val),
+				{
+					TimestampNanos: time,
+					Value:          float64(val),
+				},
 			},
 		}
 	}

--- a/storage/engine/cockroach/proto/data.pb.cc
+++ b/storage/engine/cockroach/proto/data.pb.cc
@@ -351,10 +351,9 @@ void protobuf_AssignDesc_cockroach_2fproto_2fdata_2eproto() {
       ::google::protobuf::MessageFactory::generated_factory(),
       sizeof(GCMetadata));
   TimeSeriesDatapoint_descriptor_ = file->message_type(15);
-  static const int TimeSeriesDatapoint_offsets_[3] = {
+  static const int TimeSeriesDatapoint_offsets_[2] = {
     GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(TimeSeriesDatapoint, timestamp_nanos_),
-    GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(TimeSeriesDatapoint, int_value_),
-    GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(TimeSeriesDatapoint, float_value_),
+    GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(TimeSeriesDatapoint, value_),
   };
   TimeSeriesDatapoint_reflection_ =
     new ::google::protobuf::internal::GeneratedMessageReflection(
@@ -572,25 +571,25 @@ void protobuf_AddDesc_cockroach_2fproto_2fdata_2eproto() {
     "s\030\005 \001(\003B\004\310\336\037\000\022%\n\005value\030\006 \001(\0132\026.cockroach"
     ".proto.Value\"H\n\nGCMetadata\022\035\n\017last_scan_"
     "nanos\030\001 \001(\003B\004\310\336\037\000\022\033\n\023oldest_intent_nanos"
-    "\030\002 \001(\003\"\\\n\023TimeSeriesDatapoint\022\035\n\017timesta"
-    "mp_nanos\030\001 \001(\003B\004\310\336\037\000\022\021\n\tint_value\030\002 \001(\003\022"
-    "\023\n\013float_value\030\003 \001(\002\"t\n\016TimeSeriesData\022\022"
-    "\n\004name\030\001 \001(\tB\004\310\336\037\000\022\024\n\006source\030\002 \001(\tB\004\310\336\037\000"
-    "\0228\n\ndatapoints\030\003 \003(\0132$.cockroach.proto.T"
-    "imeSeriesDatapoint\"\300\002\n\tMVCCStats\022\030\n\nlive"
-    "_bytes\030\001 \001(\003B\004\310\336\037\000\022\027\n\tkey_bytes\030\002 \001(\003B\004\310"
-    "\336\037\000\022\027\n\tval_bytes\030\003 \001(\003B\004\310\336\037\000\022\032\n\014intent_b"
-    "ytes\030\004 \001(\003B\004\310\336\037\000\022\030\n\nlive_count\030\005 \001(\003B\004\310\336"
-    "\037\000\022\027\n\tkey_count\030\006 \001(\003B\004\310\336\037\000\022\027\n\tval_count"
-    "\030\007 \001(\003B\004\310\336\037\000\022\032\n\014intent_count\030\010 \001(\003B\004\310\336\037\000"
-    "\022\030\n\nintent_age\030\t \001(\003B\004\310\336\037\000\022(\n\014gc_bytes_a"
-    "ge\030\n \001(\003B\022\310\336\037\000\342\336\037\nGCBytesAge\022\037\n\021last_upd"
-    "ate_nanos\030\013 \001(\003B\004\310\336\037\000*>\n\021ReplicaChangeTy"
-    "pe\022\017\n\013ADD_REPLICA\020\000\022\022\n\016REMOVE_REPLICA\020\001\032"
-    "\004\210\243\036\000*5\n\rIsolationType\022\020\n\014SERIALIZABLE\020\000"
-    "\022\014\n\010SNAPSHOT\020\001\032\004\210\243\036\000*B\n\021TransactionStatu"
-    "s\022\013\n\007PENDING\020\000\022\r\n\tCOMMITTED\020\001\022\013\n\007ABORTED"
-    "\020\002\032\004\210\243\036\000B\023Z\005proto\340\342\036\001\310\342\036\001\320\342\036\001", 3149);
+    "\030\002 \001(\003\"I\n\023TimeSeriesDatapoint\022\035\n\017timesta"
+    "mp_nanos\030\001 \001(\003B\004\310\336\037\000\022\023\n\005value\030\002 \001(\001B\004\310\336\037"
+    "\000\"t\n\016TimeSeriesData\022\022\n\004name\030\001 \001(\tB\004\310\336\037\000\022"
+    "\024\n\006source\030\002 \001(\tB\004\310\336\037\000\0228\n\ndatapoints\030\003 \003("
+    "\0132$.cockroach.proto.TimeSeriesDatapoint\""
+    "\300\002\n\tMVCCStats\022\030\n\nlive_bytes\030\001 \001(\003B\004\310\336\037\000\022"
+    "\027\n\tkey_bytes\030\002 \001(\003B\004\310\336\037\000\022\027\n\tval_bytes\030\003 "
+    "\001(\003B\004\310\336\037\000\022\032\n\014intent_bytes\030\004 \001(\003B\004\310\336\037\000\022\030\n"
+    "\nlive_count\030\005 \001(\003B\004\310\336\037\000\022\027\n\tkey_count\030\006 \001"
+    "(\003B\004\310\336\037\000\022\027\n\tval_count\030\007 \001(\003B\004\310\336\037\000\022\032\n\014int"
+    "ent_count\030\010 \001(\003B\004\310\336\037\000\022\030\n\nintent_age\030\t \001("
+    "\003B\004\310\336\037\000\022(\n\014gc_bytes_age\030\n \001(\003B\022\310\336\037\000\342\336\037\nG"
+    "CBytesAge\022\037\n\021last_update_nanos\030\013 \001(\003B\004\310\336"
+    "\037\000*>\n\021ReplicaChangeType\022\017\n\013ADD_REPLICA\020\000"
+    "\022\022\n\016REMOVE_REPLICA\020\001\032\004\210\243\036\000*5\n\rIsolationT"
+    "ype\022\020\n\014SERIALIZABLE\020\000\022\014\n\010SNAPSHOT\020\001\032\004\210\243\036"
+    "\000*B\n\021TransactionStatus\022\013\n\007PENDING\020\000\022\r\n\tC"
+    "OMMITTED\020\001\022\013\n\007ABORTED\020\002\032\004\210\243\036\000B\023Z\005proto\340\342"
+    "\036\001\310\342\036\001\320\342\036\001", 3130);
   ::google::protobuf::MessageFactory::InternalRegisterGeneratedFile(
     "cockroach/proto/data.proto", &protobuf_RegisterTypes);
   Timestamp::default_instance_ = new Timestamp();
@@ -5804,8 +5803,7 @@ void GCMetadata::Swap(GCMetadata* other) {
 
 #ifndef _MSC_VER
 const int TimeSeriesDatapoint::kTimestampNanosFieldNumber;
-const int TimeSeriesDatapoint::kIntValueFieldNumber;
-const int TimeSeriesDatapoint::kFloatValueFieldNumber;
+const int TimeSeriesDatapoint::kValueFieldNumber;
 #endif  // !_MSC_VER
 
 TimeSeriesDatapoint::TimeSeriesDatapoint()
@@ -5827,8 +5825,7 @@ TimeSeriesDatapoint::TimeSeriesDatapoint(const TimeSeriesDatapoint& from)
 void TimeSeriesDatapoint::SharedCtor() {
   _cached_size_ = 0;
   timestamp_nanos_ = GOOGLE_LONGLONG(0);
-  int_value_ = GOOGLE_LONGLONG(0);
-  float_value_ = 0;
+  value_ = 0;
   ::memset(_has_bits_, 0, sizeof(_has_bits_));
 }
 
@@ -5874,7 +5871,7 @@ void TimeSeriesDatapoint::Clear() {
     ::memset(&first, 0, n);                                \
   } while (0)
 
-  ZR_(timestamp_nanos_, float_value_);
+  ZR_(timestamp_nanos_, value_);
 
 #undef OFFSET_OF_FIELD_
 #undef ZR_
@@ -5903,33 +5900,18 @@ bool TimeSeriesDatapoint::MergePartialFromCodedStream(
         } else {
           goto handle_unusual;
         }
-        if (input->ExpectTag(16)) goto parse_int_value;
+        if (input->ExpectTag(17)) goto parse_value;
         break;
       }
 
-      // optional int64 int_value = 2;
+      // optional double value = 2;
       case 2: {
-        if (tag == 16) {
-         parse_int_value:
+        if (tag == 17) {
+         parse_value:
           DO_((::google::protobuf::internal::WireFormatLite::ReadPrimitive<
-                   ::google::protobuf::int64, ::google::protobuf::internal::WireFormatLite::TYPE_INT64>(
-                 input, &int_value_)));
-          set_has_int_value();
-        } else {
-          goto handle_unusual;
-        }
-        if (input->ExpectTag(29)) goto parse_float_value;
-        break;
-      }
-
-      // optional float float_value = 3;
-      case 3: {
-        if (tag == 29) {
-         parse_float_value:
-          DO_((::google::protobuf::internal::WireFormatLite::ReadPrimitive<
-                   float, ::google::protobuf::internal::WireFormatLite::TYPE_FLOAT>(
-                 input, &float_value_)));
-          set_has_float_value();
+                   double, ::google::protobuf::internal::WireFormatLite::TYPE_DOUBLE>(
+                 input, &value_)));
+          set_has_value();
         } else {
           goto handle_unusual;
         }
@@ -5967,14 +5949,9 @@ void TimeSeriesDatapoint::SerializeWithCachedSizes(
     ::google::protobuf::internal::WireFormatLite::WriteInt64(1, this->timestamp_nanos(), output);
   }
 
-  // optional int64 int_value = 2;
-  if (has_int_value()) {
-    ::google::protobuf::internal::WireFormatLite::WriteInt64(2, this->int_value(), output);
-  }
-
-  // optional float float_value = 3;
-  if (has_float_value()) {
-    ::google::protobuf::internal::WireFormatLite::WriteFloat(3, this->float_value(), output);
+  // optional double value = 2;
+  if (has_value()) {
+    ::google::protobuf::internal::WireFormatLite::WriteDouble(2, this->value(), output);
   }
 
   if (!unknown_fields().empty()) {
@@ -5992,14 +5969,9 @@ void TimeSeriesDatapoint::SerializeWithCachedSizes(
     target = ::google::protobuf::internal::WireFormatLite::WriteInt64ToArray(1, this->timestamp_nanos(), target);
   }
 
-  // optional int64 int_value = 2;
-  if (has_int_value()) {
-    target = ::google::protobuf::internal::WireFormatLite::WriteInt64ToArray(2, this->int_value(), target);
-  }
-
-  // optional float float_value = 3;
-  if (has_float_value()) {
-    target = ::google::protobuf::internal::WireFormatLite::WriteFloatToArray(3, this->float_value(), target);
+  // optional double value = 2;
+  if (has_value()) {
+    target = ::google::protobuf::internal::WireFormatLite::WriteDoubleToArray(2, this->value(), target);
   }
 
   if (!unknown_fields().empty()) {
@@ -6021,16 +5993,9 @@ int TimeSeriesDatapoint::ByteSize() const {
           this->timestamp_nanos());
     }
 
-    // optional int64 int_value = 2;
-    if (has_int_value()) {
-      total_size += 1 +
-        ::google::protobuf::internal::WireFormatLite::Int64Size(
-          this->int_value());
-    }
-
-    // optional float float_value = 3;
-    if (has_float_value()) {
-      total_size += 1 + 4;
+    // optional double value = 2;
+    if (has_value()) {
+      total_size += 1 + 8;
     }
 
   }
@@ -6063,11 +6028,8 @@ void TimeSeriesDatapoint::MergeFrom(const TimeSeriesDatapoint& from) {
     if (from.has_timestamp_nanos()) {
       set_timestamp_nanos(from.timestamp_nanos());
     }
-    if (from.has_int_value()) {
-      set_int_value(from.int_value());
-    }
-    if (from.has_float_value()) {
-      set_float_value(from.float_value());
+    if (from.has_value()) {
+      set_value(from.value());
     }
   }
   mutable_unknown_fields()->MergeFrom(from.unknown_fields());
@@ -6093,8 +6055,7 @@ bool TimeSeriesDatapoint::IsInitialized() const {
 void TimeSeriesDatapoint::Swap(TimeSeriesDatapoint* other) {
   if (other != this) {
     std::swap(timestamp_nanos_, other->timestamp_nanos_);
-    std::swap(int_value_, other->int_value_);
-    std::swap(float_value_, other->float_value_);
+    std::swap(value_, other->value_);
     std::swap(_has_bits_[0], other->_has_bits_[0]);
     _unknown_fields_.Swap(&other->_unknown_fields_);
     std::swap(_cached_size_, other->_cached_size_);

--- a/storage/engine/cockroach/proto/data.pb.h
+++ b/storage/engine/cockroach/proto/data.pb.h
@@ -1828,36 +1828,26 @@ class TimeSeriesDatapoint : public ::google::protobuf::Message {
   inline ::google::protobuf::int64 timestamp_nanos() const;
   inline void set_timestamp_nanos(::google::protobuf::int64 value);
 
-  // optional int64 int_value = 2;
-  inline bool has_int_value() const;
-  inline void clear_int_value();
-  static const int kIntValueFieldNumber = 2;
-  inline ::google::protobuf::int64 int_value() const;
-  inline void set_int_value(::google::protobuf::int64 value);
-
-  // optional float float_value = 3;
-  inline bool has_float_value() const;
-  inline void clear_float_value();
-  static const int kFloatValueFieldNumber = 3;
-  inline float float_value() const;
-  inline void set_float_value(float value);
+  // optional double value = 2;
+  inline bool has_value() const;
+  inline void clear_value();
+  static const int kValueFieldNumber = 2;
+  inline double value() const;
+  inline void set_value(double value);
 
   // @@protoc_insertion_point(class_scope:cockroach.proto.TimeSeriesDatapoint)
  private:
   inline void set_has_timestamp_nanos();
   inline void clear_has_timestamp_nanos();
-  inline void set_has_int_value();
-  inline void clear_has_int_value();
-  inline void set_has_float_value();
-  inline void clear_has_float_value();
+  inline void set_has_value();
+  inline void clear_has_value();
 
   ::google::protobuf::UnknownFieldSet _unknown_fields_;
 
   ::google::protobuf::uint32 _has_bits_[1];
   mutable int _cached_size_;
   ::google::protobuf::int64 timestamp_nanos_;
-  ::google::protobuf::int64 int_value_;
-  float float_value_;
+  double value_;
   friend void  protobuf_AddDesc_cockroach_2fproto_2fdata_2eproto();
   friend void protobuf_AssignDesc_cockroach_2fproto_2fdata_2eproto();
   friend void protobuf_ShutdownFile_cockroach_2fproto_2fdata_2eproto();
@@ -4331,52 +4321,28 @@ inline void TimeSeriesDatapoint::set_timestamp_nanos(::google::protobuf::int64 v
   // @@protoc_insertion_point(field_set:cockroach.proto.TimeSeriesDatapoint.timestamp_nanos)
 }
 
-// optional int64 int_value = 2;
-inline bool TimeSeriesDatapoint::has_int_value() const {
+// optional double value = 2;
+inline bool TimeSeriesDatapoint::has_value() const {
   return (_has_bits_[0] & 0x00000002u) != 0;
 }
-inline void TimeSeriesDatapoint::set_has_int_value() {
+inline void TimeSeriesDatapoint::set_has_value() {
   _has_bits_[0] |= 0x00000002u;
 }
-inline void TimeSeriesDatapoint::clear_has_int_value() {
+inline void TimeSeriesDatapoint::clear_has_value() {
   _has_bits_[0] &= ~0x00000002u;
 }
-inline void TimeSeriesDatapoint::clear_int_value() {
-  int_value_ = GOOGLE_LONGLONG(0);
-  clear_has_int_value();
+inline void TimeSeriesDatapoint::clear_value() {
+  value_ = 0;
+  clear_has_value();
 }
-inline ::google::protobuf::int64 TimeSeriesDatapoint::int_value() const {
-  // @@protoc_insertion_point(field_get:cockroach.proto.TimeSeriesDatapoint.int_value)
-  return int_value_;
+inline double TimeSeriesDatapoint::value() const {
+  // @@protoc_insertion_point(field_get:cockroach.proto.TimeSeriesDatapoint.value)
+  return value_;
 }
-inline void TimeSeriesDatapoint::set_int_value(::google::protobuf::int64 value) {
-  set_has_int_value();
-  int_value_ = value;
-  // @@protoc_insertion_point(field_set:cockroach.proto.TimeSeriesDatapoint.int_value)
-}
-
-// optional float float_value = 3;
-inline bool TimeSeriesDatapoint::has_float_value() const {
-  return (_has_bits_[0] & 0x00000004u) != 0;
-}
-inline void TimeSeriesDatapoint::set_has_float_value() {
-  _has_bits_[0] |= 0x00000004u;
-}
-inline void TimeSeriesDatapoint::clear_has_float_value() {
-  _has_bits_[0] &= ~0x00000004u;
-}
-inline void TimeSeriesDatapoint::clear_float_value() {
-  float_value_ = 0;
-  clear_has_float_value();
-}
-inline float TimeSeriesDatapoint::float_value() const {
-  // @@protoc_insertion_point(field_get:cockroach.proto.TimeSeriesDatapoint.float_value)
-  return float_value_;
-}
-inline void TimeSeriesDatapoint::set_float_value(float value) {
-  set_has_float_value();
-  float_value_ = value;
-  // @@protoc_insertion_point(field_set:cockroach.proto.TimeSeriesDatapoint.float_value)
+inline void TimeSeriesDatapoint::set_value(double value) {
+  set_has_value();
+  value_ = value;
+  // @@protoc_insertion_point(field_set:cockroach.proto.TimeSeriesDatapoint.value)
 }
 
 // -------------------------------------------------------------------

--- a/storage/engine/cockroach/proto/internal.pb.cc
+++ b/storage/engine/cockroach/proto/internal.pb.cc
@@ -675,16 +675,12 @@ void protobuf_AssignDesc_cockroach_2fproto_2finternal_2eproto() {
       ::google::protobuf::MessageFactory::generated_factory(),
       sizeof(InternalTimeSeriesData));
   InternalTimeSeriesSample_descriptor_ = file->message_type(26);
-  static const int InternalTimeSeriesSample_offsets_[9] = {
+  static const int InternalTimeSeriesSample_offsets_[5] = {
     GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(InternalTimeSeriesSample, offset_),
-    GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(InternalTimeSeriesSample, int_count_),
-    GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(InternalTimeSeriesSample, int_sum_),
-    GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(InternalTimeSeriesSample, int_max_),
-    GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(InternalTimeSeriesSample, int_min_),
-    GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(InternalTimeSeriesSample, float_count_),
-    GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(InternalTimeSeriesSample, float_sum_),
-    GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(InternalTimeSeriesSample, float_max_),
-    GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(InternalTimeSeriesSample, float_min_),
+    GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(InternalTimeSeriesSample, count_),
+    GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(InternalTimeSeriesSample, sum_),
+    GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(InternalTimeSeriesSample, max_),
+    GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(InternalTimeSeriesSample, min_),
   };
   InternalTimeSeriesSample_reflection_ =
     new ::google::protobuf::internal::GeneratedMessageReflection(
@@ -1064,21 +1060,18 @@ void protobuf_AddDesc_cockroach_2fproto_2finternal_2eproto() {
     "nalTimeSeriesData\022#\n\025start_timestamp_nan"
     "os\030\001 \001(\003B\004\310\336\037\000\022#\n\025sample_duration_nanos\030"
     "\002 \001(\003B\004\310\336\037\000\022:\n\007samples\030\003 \003(\0132).cockroach"
-    ".proto.InternalTimeSeriesSample\"\320\001\n\030Inte"
-    "rnalTimeSeriesSample\022\024\n\006offset\030\001 \001(\005B\004\310\336"
-    "\037\000\022\027\n\tint_count\030\002 \001(\rB\004\310\336\037\000\022\017\n\007int_sum\030\003"
-    " \001(\003\022\017\n\007int_max\030\004 \001(\003\022\017\n\007int_min\030\005 \001(\003\022\031"
-    "\n\013float_count\030\006 \001(\rB\004\310\336\037\000\022\021\n\tfloat_sum\030\007"
-    " \001(\002\022\021\n\tfloat_max\030\010 \001(\002\022\021\n\tfloat_min\030\t \001"
-    "(\002\"=\n\022RaftTruncatedState\022\023\n\005index\030\001 \001(\004B"
-    "\004\310\336\037\000\022\022\n\004term\030\002 \001(\004B\004\310\336\037\000\"z\n\020RaftSnapsho"
-    "tData\022>\n\002KV\030\001 \003(\0132*.cockroach.proto.Raft"
-    "SnapshotData.KeyValueB\006\342\336\037\002KV\032&\n\010KeyValu"
-    "e\022\013\n\003key\030\001 \001(\014\022\r\n\005value\030\002 \001(\014*G\n\013PushTxn"
-    "Type\022\022\n\016PUSH_TIMESTAMP\020\000\022\r\n\tABORT_TXN\020\001\022"
-    "\017\n\013CLEANUP_TXN\020\002\032\004\210\243\036\000*%\n\021InternalValueT"
-    "ype\022\n\n\006_CR_TS\020\001\032\004\210\243\036\000B\023Z\005proto\340\342\036\001\310\342\036\001\320\342"
-    "\036\001", 6962);
+    ".proto.InternalTimeSeriesSample\"r\n\030Inter"
+    "nalTimeSeriesSample\022\024\n\006offset\030\001 \001(\005B\004\310\336\037"
+    "\000\022\023\n\005count\030\006 \001(\rB\004\310\336\037\000\022\021\n\003sum\030\007 \001(\001B\004\310\336\037"
+    "\000\022\013\n\003max\030\010 \001(\001\022\013\n\003min\030\t \001(\001\"=\n\022RaftTrunc"
+    "atedState\022\023\n\005index\030\001 \001(\004B\004\310\336\037\000\022\022\n\004term\030\002"
+    " \001(\004B\004\310\336\037\000\"z\n\020RaftSnapshotData\022>\n\002KV\030\001 \003"
+    "(\0132*.cockroach.proto.RaftSnapshotData.Ke"
+    "yValueB\006\342\336\037\002KV\032&\n\010KeyValue\022\013\n\003key\030\001 \001(\014\022"
+    "\r\n\005value\030\002 \001(\014*G\n\013PushTxnType\022\022\n\016PUSH_TI"
+    "MESTAMP\020\000\022\r\n\tABORT_TXN\020\001\022\017\n\013CLEANUP_TXN\020"
+    "\002\032\004\210\243\036\000*%\n\021InternalValueType\022\n\n\006_CR_TS\020\001"
+    "\032\004\210\243\036\000B\023Z\005proto\340\342\036\001\310\342\036\001\320\342\036\001", 6867);
   ::google::protobuf::MessageFactory::InternalRegisterGeneratedFile(
     "cockroach/proto/internal.proto", &protobuf_RegisterTypes);
   InternalRangeLookupRequest::default_instance_ = new InternalRangeLookupRequest();
@@ -10390,14 +10383,10 @@ void InternalTimeSeriesData::Swap(InternalTimeSeriesData* other) {
 
 #ifndef _MSC_VER
 const int InternalTimeSeriesSample::kOffsetFieldNumber;
-const int InternalTimeSeriesSample::kIntCountFieldNumber;
-const int InternalTimeSeriesSample::kIntSumFieldNumber;
-const int InternalTimeSeriesSample::kIntMaxFieldNumber;
-const int InternalTimeSeriesSample::kIntMinFieldNumber;
-const int InternalTimeSeriesSample::kFloatCountFieldNumber;
-const int InternalTimeSeriesSample::kFloatSumFieldNumber;
-const int InternalTimeSeriesSample::kFloatMaxFieldNumber;
-const int InternalTimeSeriesSample::kFloatMinFieldNumber;
+const int InternalTimeSeriesSample::kCountFieldNumber;
+const int InternalTimeSeriesSample::kSumFieldNumber;
+const int InternalTimeSeriesSample::kMaxFieldNumber;
+const int InternalTimeSeriesSample::kMinFieldNumber;
 #endif  // !_MSC_VER
 
 InternalTimeSeriesSample::InternalTimeSeriesSample()
@@ -10419,14 +10408,10 @@ InternalTimeSeriesSample::InternalTimeSeriesSample(const InternalTimeSeriesSampl
 void InternalTimeSeriesSample::SharedCtor() {
   _cached_size_ = 0;
   offset_ = 0;
-  int_count_ = 0u;
-  int_sum_ = GOOGLE_LONGLONG(0);
-  int_max_ = GOOGLE_LONGLONG(0);
-  int_min_ = GOOGLE_LONGLONG(0);
-  float_count_ = 0u;
-  float_sum_ = 0;
-  float_max_ = 0;
-  float_min_ = 0;
+  count_ = 0u;
+  sum_ = 0;
+  max_ = 0;
+  min_ = 0;
   ::memset(_has_bits_, 0, sizeof(_has_bits_));
 }
 
@@ -10472,10 +10457,9 @@ void InternalTimeSeriesSample::Clear() {
     ::memset(&first, 0, n);                                \
   } while (0)
 
-  if (_has_bits_[0 / 32] & 255) {
-    ZR_(offset_, float_max_);
+  if (_has_bits_[0 / 32] & 31) {
+    ZR_(offset_, min_);
   }
-  float_min_ = 0;
 
 #undef OFFSET_OF_FIELD_
 #undef ZR_
@@ -10504,123 +10488,63 @@ bool InternalTimeSeriesSample::MergePartialFromCodedStream(
         } else {
           goto handle_unusual;
         }
-        if (input->ExpectTag(16)) goto parse_int_count;
+        if (input->ExpectTag(48)) goto parse_count;
         break;
       }
 
-      // optional uint32 int_count = 2;
-      case 2: {
-        if (tag == 16) {
-         parse_int_count:
-          DO_((::google::protobuf::internal::WireFormatLite::ReadPrimitive<
-                   ::google::protobuf::uint32, ::google::protobuf::internal::WireFormatLite::TYPE_UINT32>(
-                 input, &int_count_)));
-          set_has_int_count();
-        } else {
-          goto handle_unusual;
-        }
-        if (input->ExpectTag(24)) goto parse_int_sum;
-        break;
-      }
-
-      // optional int64 int_sum = 3;
-      case 3: {
-        if (tag == 24) {
-         parse_int_sum:
-          DO_((::google::protobuf::internal::WireFormatLite::ReadPrimitive<
-                   ::google::protobuf::int64, ::google::protobuf::internal::WireFormatLite::TYPE_INT64>(
-                 input, &int_sum_)));
-          set_has_int_sum();
-        } else {
-          goto handle_unusual;
-        }
-        if (input->ExpectTag(32)) goto parse_int_max;
-        break;
-      }
-
-      // optional int64 int_max = 4;
-      case 4: {
-        if (tag == 32) {
-         parse_int_max:
-          DO_((::google::protobuf::internal::WireFormatLite::ReadPrimitive<
-                   ::google::protobuf::int64, ::google::protobuf::internal::WireFormatLite::TYPE_INT64>(
-                 input, &int_max_)));
-          set_has_int_max();
-        } else {
-          goto handle_unusual;
-        }
-        if (input->ExpectTag(40)) goto parse_int_min;
-        break;
-      }
-
-      // optional int64 int_min = 5;
-      case 5: {
-        if (tag == 40) {
-         parse_int_min:
-          DO_((::google::protobuf::internal::WireFormatLite::ReadPrimitive<
-                   ::google::protobuf::int64, ::google::protobuf::internal::WireFormatLite::TYPE_INT64>(
-                 input, &int_min_)));
-          set_has_int_min();
-        } else {
-          goto handle_unusual;
-        }
-        if (input->ExpectTag(48)) goto parse_float_count;
-        break;
-      }
-
-      // optional uint32 float_count = 6;
+      // optional uint32 count = 6;
       case 6: {
         if (tag == 48) {
-         parse_float_count:
+         parse_count:
           DO_((::google::protobuf::internal::WireFormatLite::ReadPrimitive<
                    ::google::protobuf::uint32, ::google::protobuf::internal::WireFormatLite::TYPE_UINT32>(
-                 input, &float_count_)));
-          set_has_float_count();
+                 input, &count_)));
+          set_has_count();
         } else {
           goto handle_unusual;
         }
-        if (input->ExpectTag(61)) goto parse_float_sum;
+        if (input->ExpectTag(57)) goto parse_sum;
         break;
       }
 
-      // optional float float_sum = 7;
+      // optional double sum = 7;
       case 7: {
-        if (tag == 61) {
-         parse_float_sum:
+        if (tag == 57) {
+         parse_sum:
           DO_((::google::protobuf::internal::WireFormatLite::ReadPrimitive<
-                   float, ::google::protobuf::internal::WireFormatLite::TYPE_FLOAT>(
-                 input, &float_sum_)));
-          set_has_float_sum();
+                   double, ::google::protobuf::internal::WireFormatLite::TYPE_DOUBLE>(
+                 input, &sum_)));
+          set_has_sum();
         } else {
           goto handle_unusual;
         }
-        if (input->ExpectTag(69)) goto parse_float_max;
+        if (input->ExpectTag(65)) goto parse_max;
         break;
       }
 
-      // optional float float_max = 8;
+      // optional double max = 8;
       case 8: {
-        if (tag == 69) {
-         parse_float_max:
+        if (tag == 65) {
+         parse_max:
           DO_((::google::protobuf::internal::WireFormatLite::ReadPrimitive<
-                   float, ::google::protobuf::internal::WireFormatLite::TYPE_FLOAT>(
-                 input, &float_max_)));
-          set_has_float_max();
+                   double, ::google::protobuf::internal::WireFormatLite::TYPE_DOUBLE>(
+                 input, &max_)));
+          set_has_max();
         } else {
           goto handle_unusual;
         }
-        if (input->ExpectTag(77)) goto parse_float_min;
+        if (input->ExpectTag(73)) goto parse_min;
         break;
       }
 
-      // optional float float_min = 9;
+      // optional double min = 9;
       case 9: {
-        if (tag == 77) {
-         parse_float_min:
+        if (tag == 73) {
+         parse_min:
           DO_((::google::protobuf::internal::WireFormatLite::ReadPrimitive<
-                   float, ::google::protobuf::internal::WireFormatLite::TYPE_FLOAT>(
-                 input, &float_min_)));
-          set_has_float_min();
+                   double, ::google::protobuf::internal::WireFormatLite::TYPE_DOUBLE>(
+                 input, &min_)));
+          set_has_min();
         } else {
           goto handle_unusual;
         }
@@ -10658,44 +10582,24 @@ void InternalTimeSeriesSample::SerializeWithCachedSizes(
     ::google::protobuf::internal::WireFormatLite::WriteInt32(1, this->offset(), output);
   }
 
-  // optional uint32 int_count = 2;
-  if (has_int_count()) {
-    ::google::protobuf::internal::WireFormatLite::WriteUInt32(2, this->int_count(), output);
+  // optional uint32 count = 6;
+  if (has_count()) {
+    ::google::protobuf::internal::WireFormatLite::WriteUInt32(6, this->count(), output);
   }
 
-  // optional int64 int_sum = 3;
-  if (has_int_sum()) {
-    ::google::protobuf::internal::WireFormatLite::WriteInt64(3, this->int_sum(), output);
+  // optional double sum = 7;
+  if (has_sum()) {
+    ::google::protobuf::internal::WireFormatLite::WriteDouble(7, this->sum(), output);
   }
 
-  // optional int64 int_max = 4;
-  if (has_int_max()) {
-    ::google::protobuf::internal::WireFormatLite::WriteInt64(4, this->int_max(), output);
+  // optional double max = 8;
+  if (has_max()) {
+    ::google::protobuf::internal::WireFormatLite::WriteDouble(8, this->max(), output);
   }
 
-  // optional int64 int_min = 5;
-  if (has_int_min()) {
-    ::google::protobuf::internal::WireFormatLite::WriteInt64(5, this->int_min(), output);
-  }
-
-  // optional uint32 float_count = 6;
-  if (has_float_count()) {
-    ::google::protobuf::internal::WireFormatLite::WriteUInt32(6, this->float_count(), output);
-  }
-
-  // optional float float_sum = 7;
-  if (has_float_sum()) {
-    ::google::protobuf::internal::WireFormatLite::WriteFloat(7, this->float_sum(), output);
-  }
-
-  // optional float float_max = 8;
-  if (has_float_max()) {
-    ::google::protobuf::internal::WireFormatLite::WriteFloat(8, this->float_max(), output);
-  }
-
-  // optional float float_min = 9;
-  if (has_float_min()) {
-    ::google::protobuf::internal::WireFormatLite::WriteFloat(9, this->float_min(), output);
+  // optional double min = 9;
+  if (has_min()) {
+    ::google::protobuf::internal::WireFormatLite::WriteDouble(9, this->min(), output);
   }
 
   if (!unknown_fields().empty()) {
@@ -10713,44 +10617,24 @@ void InternalTimeSeriesSample::SerializeWithCachedSizes(
     target = ::google::protobuf::internal::WireFormatLite::WriteInt32ToArray(1, this->offset(), target);
   }
 
-  // optional uint32 int_count = 2;
-  if (has_int_count()) {
-    target = ::google::protobuf::internal::WireFormatLite::WriteUInt32ToArray(2, this->int_count(), target);
+  // optional uint32 count = 6;
+  if (has_count()) {
+    target = ::google::protobuf::internal::WireFormatLite::WriteUInt32ToArray(6, this->count(), target);
   }
 
-  // optional int64 int_sum = 3;
-  if (has_int_sum()) {
-    target = ::google::protobuf::internal::WireFormatLite::WriteInt64ToArray(3, this->int_sum(), target);
+  // optional double sum = 7;
+  if (has_sum()) {
+    target = ::google::protobuf::internal::WireFormatLite::WriteDoubleToArray(7, this->sum(), target);
   }
 
-  // optional int64 int_max = 4;
-  if (has_int_max()) {
-    target = ::google::protobuf::internal::WireFormatLite::WriteInt64ToArray(4, this->int_max(), target);
+  // optional double max = 8;
+  if (has_max()) {
+    target = ::google::protobuf::internal::WireFormatLite::WriteDoubleToArray(8, this->max(), target);
   }
 
-  // optional int64 int_min = 5;
-  if (has_int_min()) {
-    target = ::google::protobuf::internal::WireFormatLite::WriteInt64ToArray(5, this->int_min(), target);
-  }
-
-  // optional uint32 float_count = 6;
-  if (has_float_count()) {
-    target = ::google::protobuf::internal::WireFormatLite::WriteUInt32ToArray(6, this->float_count(), target);
-  }
-
-  // optional float float_sum = 7;
-  if (has_float_sum()) {
-    target = ::google::protobuf::internal::WireFormatLite::WriteFloatToArray(7, this->float_sum(), target);
-  }
-
-  // optional float float_max = 8;
-  if (has_float_max()) {
-    target = ::google::protobuf::internal::WireFormatLite::WriteFloatToArray(8, this->float_max(), target);
-  }
-
-  // optional float float_min = 9;
-  if (has_float_min()) {
-    target = ::google::protobuf::internal::WireFormatLite::WriteFloatToArray(9, this->float_min(), target);
+  // optional double min = 9;
+  if (has_min()) {
+    target = ::google::protobuf::internal::WireFormatLite::WriteDoubleToArray(9, this->min(), target);
   }
 
   if (!unknown_fields().empty()) {
@@ -10772,56 +10656,26 @@ int InternalTimeSeriesSample::ByteSize() const {
           this->offset());
     }
 
-    // optional uint32 int_count = 2;
-    if (has_int_count()) {
+    // optional uint32 count = 6;
+    if (has_count()) {
       total_size += 1 +
         ::google::protobuf::internal::WireFormatLite::UInt32Size(
-          this->int_count());
+          this->count());
     }
 
-    // optional int64 int_sum = 3;
-    if (has_int_sum()) {
-      total_size += 1 +
-        ::google::protobuf::internal::WireFormatLite::Int64Size(
-          this->int_sum());
+    // optional double sum = 7;
+    if (has_sum()) {
+      total_size += 1 + 8;
     }
 
-    // optional int64 int_max = 4;
-    if (has_int_max()) {
-      total_size += 1 +
-        ::google::protobuf::internal::WireFormatLite::Int64Size(
-          this->int_max());
+    // optional double max = 8;
+    if (has_max()) {
+      total_size += 1 + 8;
     }
 
-    // optional int64 int_min = 5;
-    if (has_int_min()) {
-      total_size += 1 +
-        ::google::protobuf::internal::WireFormatLite::Int64Size(
-          this->int_min());
-    }
-
-    // optional uint32 float_count = 6;
-    if (has_float_count()) {
-      total_size += 1 +
-        ::google::protobuf::internal::WireFormatLite::UInt32Size(
-          this->float_count());
-    }
-
-    // optional float float_sum = 7;
-    if (has_float_sum()) {
-      total_size += 1 + 4;
-    }
-
-    // optional float float_max = 8;
-    if (has_float_max()) {
-      total_size += 1 + 4;
-    }
-
-  }
-  if (_has_bits_[8 / 32] & (0xffu << (8 % 32))) {
-    // optional float float_min = 9;
-    if (has_float_min()) {
-      total_size += 1 + 4;
+    // optional double min = 9;
+    if (has_min()) {
+      total_size += 1 + 8;
     }
 
   }
@@ -10854,31 +10708,17 @@ void InternalTimeSeriesSample::MergeFrom(const InternalTimeSeriesSample& from) {
     if (from.has_offset()) {
       set_offset(from.offset());
     }
-    if (from.has_int_count()) {
-      set_int_count(from.int_count());
+    if (from.has_count()) {
+      set_count(from.count());
     }
-    if (from.has_int_sum()) {
-      set_int_sum(from.int_sum());
+    if (from.has_sum()) {
+      set_sum(from.sum());
     }
-    if (from.has_int_max()) {
-      set_int_max(from.int_max());
+    if (from.has_max()) {
+      set_max(from.max());
     }
-    if (from.has_int_min()) {
-      set_int_min(from.int_min());
-    }
-    if (from.has_float_count()) {
-      set_float_count(from.float_count());
-    }
-    if (from.has_float_sum()) {
-      set_float_sum(from.float_sum());
-    }
-    if (from.has_float_max()) {
-      set_float_max(from.float_max());
-    }
-  }
-  if (from._has_bits_[8 / 32] & (0xffu << (8 % 32))) {
-    if (from.has_float_min()) {
-      set_float_min(from.float_min());
+    if (from.has_min()) {
+      set_min(from.min());
     }
   }
   mutable_unknown_fields()->MergeFrom(from.unknown_fields());
@@ -10904,14 +10744,10 @@ bool InternalTimeSeriesSample::IsInitialized() const {
 void InternalTimeSeriesSample::Swap(InternalTimeSeriesSample* other) {
   if (other != this) {
     std::swap(offset_, other->offset_);
-    std::swap(int_count_, other->int_count_);
-    std::swap(int_sum_, other->int_sum_);
-    std::swap(int_max_, other->int_max_);
-    std::swap(int_min_, other->int_min_);
-    std::swap(float_count_, other->float_count_);
-    std::swap(float_sum_, other->float_sum_);
-    std::swap(float_max_, other->float_max_);
-    std::swap(float_min_, other->float_min_);
+    std::swap(count_, other->count_);
+    std::swap(sum_, other->sum_);
+    std::swap(max_, other->max_);
+    std::swap(min_, other->min_);
     std::swap(_has_bits_[0], other->_has_bits_[0]);
     _unknown_fields_.Swap(&other->_unknown_fields_);
     std::swap(_cached_size_, other->_cached_size_);

--- a/storage/engine/cockroach/proto/internal.pb.h
+++ b/storage/engine/cockroach/proto/internal.pb.h
@@ -3231,96 +3231,56 @@ class InternalTimeSeriesSample : public ::google::protobuf::Message {
   inline ::google::protobuf::int32 offset() const;
   inline void set_offset(::google::protobuf::int32 value);
 
-  // optional uint32 int_count = 2;
-  inline bool has_int_count() const;
-  inline void clear_int_count();
-  static const int kIntCountFieldNumber = 2;
-  inline ::google::protobuf::uint32 int_count() const;
-  inline void set_int_count(::google::protobuf::uint32 value);
+  // optional uint32 count = 6;
+  inline bool has_count() const;
+  inline void clear_count();
+  static const int kCountFieldNumber = 6;
+  inline ::google::protobuf::uint32 count() const;
+  inline void set_count(::google::protobuf::uint32 value);
 
-  // optional int64 int_sum = 3;
-  inline bool has_int_sum() const;
-  inline void clear_int_sum();
-  static const int kIntSumFieldNumber = 3;
-  inline ::google::protobuf::int64 int_sum() const;
-  inline void set_int_sum(::google::protobuf::int64 value);
+  // optional double sum = 7;
+  inline bool has_sum() const;
+  inline void clear_sum();
+  static const int kSumFieldNumber = 7;
+  inline double sum() const;
+  inline void set_sum(double value);
 
-  // optional int64 int_max = 4;
-  inline bool has_int_max() const;
-  inline void clear_int_max();
-  static const int kIntMaxFieldNumber = 4;
-  inline ::google::protobuf::int64 int_max() const;
-  inline void set_int_max(::google::protobuf::int64 value);
+  // optional double max = 8;
+  inline bool has_max() const;
+  inline void clear_max();
+  static const int kMaxFieldNumber = 8;
+  inline double max() const;
+  inline void set_max(double value);
 
-  // optional int64 int_min = 5;
-  inline bool has_int_min() const;
-  inline void clear_int_min();
-  static const int kIntMinFieldNumber = 5;
-  inline ::google::protobuf::int64 int_min() const;
-  inline void set_int_min(::google::protobuf::int64 value);
-
-  // optional uint32 float_count = 6;
-  inline bool has_float_count() const;
-  inline void clear_float_count();
-  static const int kFloatCountFieldNumber = 6;
-  inline ::google::protobuf::uint32 float_count() const;
-  inline void set_float_count(::google::protobuf::uint32 value);
-
-  // optional float float_sum = 7;
-  inline bool has_float_sum() const;
-  inline void clear_float_sum();
-  static const int kFloatSumFieldNumber = 7;
-  inline float float_sum() const;
-  inline void set_float_sum(float value);
-
-  // optional float float_max = 8;
-  inline bool has_float_max() const;
-  inline void clear_float_max();
-  static const int kFloatMaxFieldNumber = 8;
-  inline float float_max() const;
-  inline void set_float_max(float value);
-
-  // optional float float_min = 9;
-  inline bool has_float_min() const;
-  inline void clear_float_min();
-  static const int kFloatMinFieldNumber = 9;
-  inline float float_min() const;
-  inline void set_float_min(float value);
+  // optional double min = 9;
+  inline bool has_min() const;
+  inline void clear_min();
+  static const int kMinFieldNumber = 9;
+  inline double min() const;
+  inline void set_min(double value);
 
   // @@protoc_insertion_point(class_scope:cockroach.proto.InternalTimeSeriesSample)
  private:
   inline void set_has_offset();
   inline void clear_has_offset();
-  inline void set_has_int_count();
-  inline void clear_has_int_count();
-  inline void set_has_int_sum();
-  inline void clear_has_int_sum();
-  inline void set_has_int_max();
-  inline void clear_has_int_max();
-  inline void set_has_int_min();
-  inline void clear_has_int_min();
-  inline void set_has_float_count();
-  inline void clear_has_float_count();
-  inline void set_has_float_sum();
-  inline void clear_has_float_sum();
-  inline void set_has_float_max();
-  inline void clear_has_float_max();
-  inline void set_has_float_min();
-  inline void clear_has_float_min();
+  inline void set_has_count();
+  inline void clear_has_count();
+  inline void set_has_sum();
+  inline void clear_has_sum();
+  inline void set_has_max();
+  inline void clear_has_max();
+  inline void set_has_min();
+  inline void clear_has_min();
 
   ::google::protobuf::UnknownFieldSet _unknown_fields_;
 
   ::google::protobuf::uint32 _has_bits_[1];
   mutable int _cached_size_;
   ::google::protobuf::int32 offset_;
-  ::google::protobuf::uint32 int_count_;
-  ::google::protobuf::int64 int_sum_;
-  ::google::protobuf::int64 int_max_;
-  ::google::protobuf::int64 int_min_;
-  ::google::protobuf::uint32 float_count_;
-  float float_sum_;
-  float float_max_;
-  float float_min_;
+  ::google::protobuf::uint32 count_;
+  double sum_;
+  double max_;
+  double min_;
   friend void  protobuf_AddDesc_cockroach_2fproto_2finternal_2eproto();
   friend void protobuf_AssignDesc_cockroach_2fproto_2finternal_2eproto();
   friend void protobuf_ShutdownFile_cockroach_2fproto_2finternal_2eproto();
@@ -7665,196 +7625,100 @@ inline void InternalTimeSeriesSample::set_offset(::google::protobuf::int32 value
   // @@protoc_insertion_point(field_set:cockroach.proto.InternalTimeSeriesSample.offset)
 }
 
-// optional uint32 int_count = 2;
-inline bool InternalTimeSeriesSample::has_int_count() const {
+// optional uint32 count = 6;
+inline bool InternalTimeSeriesSample::has_count() const {
   return (_has_bits_[0] & 0x00000002u) != 0;
 }
-inline void InternalTimeSeriesSample::set_has_int_count() {
+inline void InternalTimeSeriesSample::set_has_count() {
   _has_bits_[0] |= 0x00000002u;
 }
-inline void InternalTimeSeriesSample::clear_has_int_count() {
+inline void InternalTimeSeriesSample::clear_has_count() {
   _has_bits_[0] &= ~0x00000002u;
 }
-inline void InternalTimeSeriesSample::clear_int_count() {
-  int_count_ = 0u;
-  clear_has_int_count();
+inline void InternalTimeSeriesSample::clear_count() {
+  count_ = 0u;
+  clear_has_count();
 }
-inline ::google::protobuf::uint32 InternalTimeSeriesSample::int_count() const {
-  // @@protoc_insertion_point(field_get:cockroach.proto.InternalTimeSeriesSample.int_count)
-  return int_count_;
+inline ::google::protobuf::uint32 InternalTimeSeriesSample::count() const {
+  // @@protoc_insertion_point(field_get:cockroach.proto.InternalTimeSeriesSample.count)
+  return count_;
 }
-inline void InternalTimeSeriesSample::set_int_count(::google::protobuf::uint32 value) {
-  set_has_int_count();
-  int_count_ = value;
-  // @@protoc_insertion_point(field_set:cockroach.proto.InternalTimeSeriesSample.int_count)
+inline void InternalTimeSeriesSample::set_count(::google::protobuf::uint32 value) {
+  set_has_count();
+  count_ = value;
+  // @@protoc_insertion_point(field_set:cockroach.proto.InternalTimeSeriesSample.count)
 }
 
-// optional int64 int_sum = 3;
-inline bool InternalTimeSeriesSample::has_int_sum() const {
+// optional double sum = 7;
+inline bool InternalTimeSeriesSample::has_sum() const {
   return (_has_bits_[0] & 0x00000004u) != 0;
 }
-inline void InternalTimeSeriesSample::set_has_int_sum() {
+inline void InternalTimeSeriesSample::set_has_sum() {
   _has_bits_[0] |= 0x00000004u;
 }
-inline void InternalTimeSeriesSample::clear_has_int_sum() {
+inline void InternalTimeSeriesSample::clear_has_sum() {
   _has_bits_[0] &= ~0x00000004u;
 }
-inline void InternalTimeSeriesSample::clear_int_sum() {
-  int_sum_ = GOOGLE_LONGLONG(0);
-  clear_has_int_sum();
+inline void InternalTimeSeriesSample::clear_sum() {
+  sum_ = 0;
+  clear_has_sum();
 }
-inline ::google::protobuf::int64 InternalTimeSeriesSample::int_sum() const {
-  // @@protoc_insertion_point(field_get:cockroach.proto.InternalTimeSeriesSample.int_sum)
-  return int_sum_;
+inline double InternalTimeSeriesSample::sum() const {
+  // @@protoc_insertion_point(field_get:cockroach.proto.InternalTimeSeriesSample.sum)
+  return sum_;
 }
-inline void InternalTimeSeriesSample::set_int_sum(::google::protobuf::int64 value) {
-  set_has_int_sum();
-  int_sum_ = value;
-  // @@protoc_insertion_point(field_set:cockroach.proto.InternalTimeSeriesSample.int_sum)
+inline void InternalTimeSeriesSample::set_sum(double value) {
+  set_has_sum();
+  sum_ = value;
+  // @@protoc_insertion_point(field_set:cockroach.proto.InternalTimeSeriesSample.sum)
 }
 
-// optional int64 int_max = 4;
-inline bool InternalTimeSeriesSample::has_int_max() const {
+// optional double max = 8;
+inline bool InternalTimeSeriesSample::has_max() const {
   return (_has_bits_[0] & 0x00000008u) != 0;
 }
-inline void InternalTimeSeriesSample::set_has_int_max() {
+inline void InternalTimeSeriesSample::set_has_max() {
   _has_bits_[0] |= 0x00000008u;
 }
-inline void InternalTimeSeriesSample::clear_has_int_max() {
+inline void InternalTimeSeriesSample::clear_has_max() {
   _has_bits_[0] &= ~0x00000008u;
 }
-inline void InternalTimeSeriesSample::clear_int_max() {
-  int_max_ = GOOGLE_LONGLONG(0);
-  clear_has_int_max();
+inline void InternalTimeSeriesSample::clear_max() {
+  max_ = 0;
+  clear_has_max();
 }
-inline ::google::protobuf::int64 InternalTimeSeriesSample::int_max() const {
-  // @@protoc_insertion_point(field_get:cockroach.proto.InternalTimeSeriesSample.int_max)
-  return int_max_;
+inline double InternalTimeSeriesSample::max() const {
+  // @@protoc_insertion_point(field_get:cockroach.proto.InternalTimeSeriesSample.max)
+  return max_;
 }
-inline void InternalTimeSeriesSample::set_int_max(::google::protobuf::int64 value) {
-  set_has_int_max();
-  int_max_ = value;
-  // @@protoc_insertion_point(field_set:cockroach.proto.InternalTimeSeriesSample.int_max)
+inline void InternalTimeSeriesSample::set_max(double value) {
+  set_has_max();
+  max_ = value;
+  // @@protoc_insertion_point(field_set:cockroach.proto.InternalTimeSeriesSample.max)
 }
 
-// optional int64 int_min = 5;
-inline bool InternalTimeSeriesSample::has_int_min() const {
+// optional double min = 9;
+inline bool InternalTimeSeriesSample::has_min() const {
   return (_has_bits_[0] & 0x00000010u) != 0;
 }
-inline void InternalTimeSeriesSample::set_has_int_min() {
+inline void InternalTimeSeriesSample::set_has_min() {
   _has_bits_[0] |= 0x00000010u;
 }
-inline void InternalTimeSeriesSample::clear_has_int_min() {
+inline void InternalTimeSeriesSample::clear_has_min() {
   _has_bits_[0] &= ~0x00000010u;
 }
-inline void InternalTimeSeriesSample::clear_int_min() {
-  int_min_ = GOOGLE_LONGLONG(0);
-  clear_has_int_min();
+inline void InternalTimeSeriesSample::clear_min() {
+  min_ = 0;
+  clear_has_min();
 }
-inline ::google::protobuf::int64 InternalTimeSeriesSample::int_min() const {
-  // @@protoc_insertion_point(field_get:cockroach.proto.InternalTimeSeriesSample.int_min)
-  return int_min_;
+inline double InternalTimeSeriesSample::min() const {
+  // @@protoc_insertion_point(field_get:cockroach.proto.InternalTimeSeriesSample.min)
+  return min_;
 }
-inline void InternalTimeSeriesSample::set_int_min(::google::protobuf::int64 value) {
-  set_has_int_min();
-  int_min_ = value;
-  // @@protoc_insertion_point(field_set:cockroach.proto.InternalTimeSeriesSample.int_min)
-}
-
-// optional uint32 float_count = 6;
-inline bool InternalTimeSeriesSample::has_float_count() const {
-  return (_has_bits_[0] & 0x00000020u) != 0;
-}
-inline void InternalTimeSeriesSample::set_has_float_count() {
-  _has_bits_[0] |= 0x00000020u;
-}
-inline void InternalTimeSeriesSample::clear_has_float_count() {
-  _has_bits_[0] &= ~0x00000020u;
-}
-inline void InternalTimeSeriesSample::clear_float_count() {
-  float_count_ = 0u;
-  clear_has_float_count();
-}
-inline ::google::protobuf::uint32 InternalTimeSeriesSample::float_count() const {
-  // @@protoc_insertion_point(field_get:cockroach.proto.InternalTimeSeriesSample.float_count)
-  return float_count_;
-}
-inline void InternalTimeSeriesSample::set_float_count(::google::protobuf::uint32 value) {
-  set_has_float_count();
-  float_count_ = value;
-  // @@protoc_insertion_point(field_set:cockroach.proto.InternalTimeSeriesSample.float_count)
-}
-
-// optional float float_sum = 7;
-inline bool InternalTimeSeriesSample::has_float_sum() const {
-  return (_has_bits_[0] & 0x00000040u) != 0;
-}
-inline void InternalTimeSeriesSample::set_has_float_sum() {
-  _has_bits_[0] |= 0x00000040u;
-}
-inline void InternalTimeSeriesSample::clear_has_float_sum() {
-  _has_bits_[0] &= ~0x00000040u;
-}
-inline void InternalTimeSeriesSample::clear_float_sum() {
-  float_sum_ = 0;
-  clear_has_float_sum();
-}
-inline float InternalTimeSeriesSample::float_sum() const {
-  // @@protoc_insertion_point(field_get:cockroach.proto.InternalTimeSeriesSample.float_sum)
-  return float_sum_;
-}
-inline void InternalTimeSeriesSample::set_float_sum(float value) {
-  set_has_float_sum();
-  float_sum_ = value;
-  // @@protoc_insertion_point(field_set:cockroach.proto.InternalTimeSeriesSample.float_sum)
-}
-
-// optional float float_max = 8;
-inline bool InternalTimeSeriesSample::has_float_max() const {
-  return (_has_bits_[0] & 0x00000080u) != 0;
-}
-inline void InternalTimeSeriesSample::set_has_float_max() {
-  _has_bits_[0] |= 0x00000080u;
-}
-inline void InternalTimeSeriesSample::clear_has_float_max() {
-  _has_bits_[0] &= ~0x00000080u;
-}
-inline void InternalTimeSeriesSample::clear_float_max() {
-  float_max_ = 0;
-  clear_has_float_max();
-}
-inline float InternalTimeSeriesSample::float_max() const {
-  // @@protoc_insertion_point(field_get:cockroach.proto.InternalTimeSeriesSample.float_max)
-  return float_max_;
-}
-inline void InternalTimeSeriesSample::set_float_max(float value) {
-  set_has_float_max();
-  float_max_ = value;
-  // @@protoc_insertion_point(field_set:cockroach.proto.InternalTimeSeriesSample.float_max)
-}
-
-// optional float float_min = 9;
-inline bool InternalTimeSeriesSample::has_float_min() const {
-  return (_has_bits_[0] & 0x00000100u) != 0;
-}
-inline void InternalTimeSeriesSample::set_has_float_min() {
-  _has_bits_[0] |= 0x00000100u;
-}
-inline void InternalTimeSeriesSample::clear_has_float_min() {
-  _has_bits_[0] &= ~0x00000100u;
-}
-inline void InternalTimeSeriesSample::clear_float_min() {
-  float_min_ = 0;
-  clear_has_float_min();
-}
-inline float InternalTimeSeriesSample::float_min() const {
-  // @@protoc_insertion_point(field_get:cockroach.proto.InternalTimeSeriesSample.float_min)
-  return float_min_;
-}
-inline void InternalTimeSeriesSample::set_float_min(float value) {
-  set_has_float_min();
-  float_min_ = value;
-  // @@protoc_insertion_point(field_set:cockroach.proto.InternalTimeSeriesSample.float_min)
+inline void InternalTimeSeriesSample::set_min(double value) {
+  set_has_min();
+  min_ = value;
+  // @@protoc_insertion_point(field_set:cockroach.proto.InternalTimeSeriesSample.min)
 }
 
 // -------------------------------------------------------------------

--- a/storage/engine/db.cc
+++ b/storage/engine/db.cc
@@ -355,28 +355,16 @@ bool IsTimeSeriesData(const cockroach::proto::Value *val) {
         && val->tag() == cockroach::proto::InternalValueType_Name(cockroach::proto::_CR_TS);
 }
 
-long GetIntMax(const cockroach::proto::InternalTimeSeriesSample *sample) {
-    if (sample->has_int_max()) return sample->int_max();
-    if (sample->has_int_sum()) return sample->int_sum();
-    return std::numeric_limits<long>::min();
+double GetMax(const cockroach::proto::InternalTimeSeriesSample *sample) {
+    if (sample->has_max()) return sample->max();
+    if (sample->has_sum()) return sample->sum();
+    return std::numeric_limits<double>::min();
 }
 
-long GetIntMin(const cockroach::proto::InternalTimeSeriesSample *sample) {
-    if (sample->has_int_min()) return sample->int_min();
-    if (sample->has_int_sum()) return sample->int_sum();
-    return std::numeric_limits<long>::max();
-}
-
-float GetFloatMax(const cockroach::proto::InternalTimeSeriesSample *sample) {
-    if (sample->has_float_max()) return sample->float_max();
-    if (sample->has_float_sum()) return sample->float_sum();
-    return std::numeric_limits<float>::min();
-}
-
-float GetFloatMin(const cockroach::proto::InternalTimeSeriesSample *sample) {
-    if (sample->has_float_min()) return sample->float_min();
-    if (sample->has_float_sum()) return sample->float_sum();
-    return std::numeric_limits<float>::max();
+double GetMin(const cockroach::proto::InternalTimeSeriesSample *sample) {
+    if (sample->has_min()) return sample->min();
+    if (sample->has_sum()) return sample->sum();
+    return std::numeric_limits<double>::max();
 }
 
 // AccumulateTimeSeriesSamples accumulates the individual values of two
@@ -385,27 +373,16 @@ float GetFloatMin(const cockroach::proto::InternalTimeSeriesSample *sample) {
 void AccumulateTimeSeriesSamples(cockroach::proto::InternalTimeSeriesSample* dest,
         const cockroach::proto::InternalTimeSeriesSample &src) {
     // Accumulate integer values
-    int total_int_count = dest->int_count() + src.int_count();
-    if (total_int_count > 1) {
+    int total_count = dest->count() + src.count();
+    if (total_count > 1) {
         // Keep explicit max and min values.
-        dest->set_int_max(std::max(GetIntMax(dest), GetIntMax(&src)));
-        dest->set_int_min(std::min(GetIntMin(dest), GetIntMin(&src)));
+        dest->set_max(std::max(GetMax(dest), GetMax(&src)));
+        dest->set_min(std::min(GetMin(dest), GetMin(&src)));
     }
-    if (total_int_count > 0) {
-        dest->set_int_sum(dest->int_sum() + src.int_sum());
+    if (total_count > 0) {
+        dest->set_sum(dest->sum() + src.sum());
     }
-    dest->set_int_count(total_int_count);
-
-    int total_float_count = dest->float_count() + src.float_count();
-    if (total_float_count > 1) {
-        // Keep explicit max and min values.
-        dest->set_float_max(std::max(GetFloatMax(dest), GetFloatMax(&src)));
-        dest->set_float_min(std::min(GetFloatMin(dest), GetFloatMin(&src)));
-    }
-    if (total_float_count > 0) {
-        dest->set_float_sum(dest->float_sum() + src.float_sum());
-    }
-    dest->set_float_count(total_float_count);
+    dest->set_count(total_count);
 }
 
 // MergeTimeSeriesValues attempts to merge two Values which contain

--- a/storage/engine/engine_test.go
+++ b/storage/engine/engine_test.go
@@ -325,22 +325,22 @@ func TestEngineMerge(t *testing.T) {
 			{
 				proto.EncodedKey("timeseriesmerged"),
 				[][]byte{
-					timeSeriesInt(testtime, 1000, []tsIntSample{
+					timeSeries(testtime, 1000, []tsSample{
 						{1, 1, 5, 5, 5},
 					}...),
-					timeSeriesInt(testtime, 1000, []tsIntSample{
+					timeSeries(testtime, 1000, []tsSample{
 						{2, 1, 5, 5, 5},
 						{1, 2, 10, 7, 3},
 					}...),
-					timeSeriesInt(testtime, 1000, []tsIntSample{
+					timeSeries(testtime, 1000, []tsSample{
 						{10, 1, 5, 5, 5},
 					}...),
-					timeSeriesInt(testtime, 1000, []tsIntSample{
+					timeSeries(testtime, 1000, []tsSample{
 						{5, 1, 5, 5, 5},
 						{3, 1, 5, 5, 5},
 					}...),
 				},
-				timeSeriesInt(testtime, 1000, []tsIntSample{
+				timeSeries(testtime, 1000, []tsSample{
 					{1, 3, 15, 7, 3},
 					{2, 1, 5, 5, 5},
 					{3, 1, 5, 5, 5},

--- a/storage/engine/rocksdb_test.go
+++ b/storage/engine/rocksdb_test.go
@@ -488,7 +488,7 @@ func BenchmarkMVCCMergeTimeSeries(b *testing.B) {
 		StartTimestampNanos: 0,
 		SampleDurationNanos: 1000,
 		Samples: []*proto.InternalTimeSeriesSample{
-			{Offset: 0, IntCount: 1, IntSum: gogoproto.Int64(5)},
+			{Offset: 0, Count: 1, Sum: 5.0},
 		},
 	}
 	value, err := ts.ToValue()

--- a/ts/db_test.go
+++ b/ts/db_test.go
@@ -223,19 +223,11 @@ func (mds *modelDataSource) GetTimeSeriesData() []proto.TimeSeriesData {
 	return data
 }
 
-// intDatapoint quickly generates an integer-valued datapoint.
-func intDatapoint(timestamp int64, val int64) *proto.TimeSeriesDatapoint {
+// datapoint quickly generates a time series datapoint.
+func datapoint(timestamp int64, val float64) *proto.TimeSeriesDatapoint {
 	return &proto.TimeSeriesDatapoint{
 		TimestampNanos: timestamp,
-		IntValue:       gogoproto.Int64(val),
-	}
-}
-
-// floatDatapoint quickly generates an integer-valued datapoint.
-func floatDatapoint(timestamp int64, val float32) *proto.TimeSeriesDatapoint {
-	return &proto.TimeSeriesDatapoint{
-		TimestampNanos: timestamp,
-		FloatValue:     gogoproto.Float32(val),
+		Value:          val,
 	}
 }
 
@@ -251,7 +243,7 @@ func TestStoreTimeSeries(t *testing.T) {
 		{
 			Name: "test.metric",
 			Datapoints: []*proto.TimeSeriesDatapoint{
-				intDatapoint(-446061360000000000, 100),
+				datapoint(-446061360000000000, 100),
 			},
 		},
 	})
@@ -265,9 +257,9 @@ func TestStoreTimeSeries(t *testing.T) {
 			Name:   "test.metric.float",
 			Source: "cpu01",
 			Datapoints: []*proto.TimeSeriesDatapoint{
-				floatDatapoint(1428713843000000000, 100.0),
-				floatDatapoint(1428713843000000001, 50.2),
-				floatDatapoint(1428713843000000002, 90.9),
+				datapoint(1428713843000000000, 100.0),
+				datapoint(1428713843000000001, 50.2),
+				datapoint(1428713843000000002, 90.9),
 			},
 		},
 	})
@@ -276,9 +268,9 @@ func TestStoreTimeSeries(t *testing.T) {
 			Name:   "test.metric.float",
 			Source: "cpu02",
 			Datapoints: []*proto.TimeSeriesDatapoint{
-				floatDatapoint(1428713843000000000, 900.8),
-				floatDatapoint(1428713843000000001, 30.12),
-				floatDatapoint(1428713843000000002, 72.324),
+				datapoint(1428713843000000000, 900.8),
+				datapoint(1428713843000000001, 30.12),
+				datapoint(1428713843000000002, 72.324),
 			},
 		},
 	})
@@ -291,9 +283,9 @@ func TestStoreTimeSeries(t *testing.T) {
 		{
 			Name: "test.metric",
 			Datapoints: []*proto.TimeSeriesDatapoint{
-				intDatapoint(-446061360000000001, 200),
-				intDatapoint(450000000000000000, 1),
-				intDatapoint(460000000000000000, 777),
+				datapoint(-446061360000000001, 200),
+				datapoint(450000000000000000, 1),
+				datapoint(460000000000000000, 777),
 			},
 		},
 	})
@@ -317,18 +309,18 @@ func TestPollSource(t *testing.T) {
 					Name:   "test.metric.float",
 					Source: "cpu01",
 					Datapoints: []*proto.TimeSeriesDatapoint{
-						floatDatapoint(1428713843000000000, 100.0),
-						floatDatapoint(1428713843000000001, 50.2),
-						floatDatapoint(1428713843000000002, 90.9),
+						datapoint(1428713843000000000, 100.0),
+						datapoint(1428713843000000001, 50.2),
+						datapoint(1428713843000000002, 90.9),
 					},
 				},
 				{
 					Name:   "test.metric.float",
 					Source: "cpu02",
 					Datapoints: []*proto.TimeSeriesDatapoint{
-						floatDatapoint(1428713843000000000, 900.8),
-						floatDatapoint(1428713843000000001, 30.12),
-						floatDatapoint(1428713843000000002, 72.324),
+						datapoint(1428713843000000000, 900.8),
+						datapoint(1428713843000000001, 30.12),
+						datapoint(1428713843000000002, 72.324),
 					},
 				},
 			},
@@ -336,7 +328,7 @@ func TestPollSource(t *testing.T) {
 				{
 					Name: "test.metric",
 					Datapoints: []*proto.TimeSeriesDatapoint{
-						intDatapoint(-446061360000000000, 100),
+						datapoint(-446061360000000000, 100),
 					},
 				},
 			},


### PR DESCRIPTION
When Time Series storage was originally developed, we allowed time series data
to be expressed as either Integer or Float values.

However, while building the Query portion of the /ts package and revisiting this
two-type design, I now believe that there is insufficient reason to store
integer data. This commit removes the integer pathways, which is a significant
simplification.

This commmit also increases the size of floats stored; double-precision floats
are now used for all time series values.
