### PR TITLE
Tweak TestStoreRangeIterator and avoid creating overlapping ranges

### DIFF
--- a/storage/store_test.go
+++ b/storage/store_test.go
@@ -374,9 +374,9 @@ func TestStoreRangeIterator(t *testing.T) {
 	if ec := iter.EstimatedCount(); ec != 9 {
 		t.Errorf("expected 9 remaining; got %d", ec)
 	}
-	// Insert range as second range.
-	rng := createRange(store, 11, proto.Key("a000"), proto.Key("a001"))
-	if err := store.AddRange(rng); err != nil {
+	// Split the first range to insert a new range as second range.
+	rng := createRange(store, 11, proto.Key("a000"), proto.Key("a01"))
+	if err = store.SplitRange(store.LookupRange(proto.Key("a00"), nil), rng); err != nil {
 		t.Fatal(err)
 	}
 	// Estimated count will still be 9, as it's cached, but next() will refresh.


### PR DESCRIPTION
The test used to create range `["a00", "a01")` and `["a000", "a001")`. This commit changes the test to split `["a00", "a01")` to `["a00", "a000")` and `["a000", "a01")`.

This fix was needed for me to pass the test with btree ranges, but I'm not sure this change is right.. `TestStoreAddRemoveRanges` has a test case for duplicated ranges, but I wasn't sure whether such range overlapping can happen in real (and if so, how it should be handled). If we need to support duplicated/overlapping ranges, I need to think more on how to use btree.
