### PR TITLE
Time Series Queries

### DIFF
--- a/proto/data.pb.go
+++ b/proto/data.pb.go
@@ -803,6 +803,45 @@ func (m *TimeSeriesData) GetDatapoints() []*TimeSeriesDatapoint {
 	return nil
 }
 
+// TimeSeriesQueryResult is the response to a query over time series data. It
+// is similar to the TimeSeriesData message, but contains a list of sources
+// instead of a single source.
+type TimeSeriesQueryResult struct {
+	// A string which uniquely identifies the variable from which this data was
+	// measured.
+	Name string `protobuf:"bytes,1,opt,name=name" json:"name"`
+	// A list of sources from which the data was aggregated.
+	Sources []string `protobuf:"bytes,2,rep,name=sources" json:"sources"`
+	// Datapoints describing the queried data.
+	Datapoints       []*TimeSeriesDatapoint `protobuf:"bytes,3,rep,name=datapoints" json:"datapoints,omitempty"`
+	XXX_unrecognized []byte                 `json:"-"`
+}
+
+func (m *TimeSeriesQueryResult) Reset()         { *m = TimeSeriesQueryResult{} }
+func (m *TimeSeriesQueryResult) String() string { return proto1.CompactTextString(m) }
+func (*TimeSeriesQueryResult) ProtoMessage()    {}
+
+func (m *TimeSeriesQueryResult) GetName() string {
+	if m != nil {
+		return m.Name
+	}
+	return ""
+}
+
+func (m *TimeSeriesQueryResult) GetSources() []string {
+	if m != nil {
+		return m.Sources
+	}
+	return nil
+}
+
+func (m *TimeSeriesQueryResult) GetDatapoints() []*TimeSeriesDatapoint {
+	if m != nil {
+		return m.Datapoints
+	}
+	return nil
+}
+
 // MVCCStats tracks byte and instance counts for:
 //  - Live key/values (i.e. what a scan at current time will reveal;
 //    note that this includes intent keys and values, but not keys and
@@ -2839,6 +2878,117 @@ func (m *TimeSeriesData) Unmarshal(data []byte) error {
 	}
 	return nil
 }
+func (m *TimeSeriesQueryResult) Unmarshal(data []byte) error {
+	l := len(data)
+	index := 0
+	for index < l {
+		var wire uint64
+		for shift := uint(0); ; shift += 7 {
+			if index >= l {
+				return io.ErrUnexpectedEOF
+			}
+			b := data[index]
+			index++
+			wire |= (uint64(b) & 0x7F) << shift
+			if b < 0x80 {
+				break
+			}
+		}
+		fieldNum := int32(wire >> 3)
+		wireType := int(wire & 0x7)
+		switch fieldNum {
+		case 1:
+			if wireType != 2 {
+				return fmt.Errorf("proto: wrong wireType = %d for field Name", wireType)
+			}
+			var stringLen uint64
+			for shift := uint(0); ; shift += 7 {
+				if index >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := data[index]
+				index++
+				stringLen |= (uint64(b) & 0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			postIndex := index + int(stringLen)
+			if postIndex > l {
+				return io.ErrUnexpectedEOF
+			}
+			m.Name = string(data[index:postIndex])
+			index = postIndex
+		case 2:
+			if wireType != 2 {
+				return fmt.Errorf("proto: wrong wireType = %d for field Sources", wireType)
+			}
+			var stringLen uint64
+			for shift := uint(0); ; shift += 7 {
+				if index >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := data[index]
+				index++
+				stringLen |= (uint64(b) & 0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			postIndex := index + int(stringLen)
+			if postIndex > l {
+				return io.ErrUnexpectedEOF
+			}
+			m.Sources = append(m.Sources, string(data[index:postIndex]))
+			index = postIndex
+		case 3:
+			if wireType != 2 {
+				return fmt.Errorf("proto: wrong wireType = %d for field Datapoints", wireType)
+			}
+			var msglen int
+			for shift := uint(0); ; shift += 7 {
+				if index >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := data[index]
+				index++
+				msglen |= (int(b) & 0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			postIndex := index + msglen
+			if postIndex > l {
+				return io.ErrUnexpectedEOF
+			}
+			m.Datapoints = append(m.Datapoints, &TimeSeriesDatapoint{})
+			if err := m.Datapoints[len(m.Datapoints)-1].Unmarshal(data[index:postIndex]); err != nil {
+				return err
+			}
+			index = postIndex
+		default:
+			var sizeOfWire int
+			for {
+				sizeOfWire++
+				wire >>= 7
+				if wire == 0 {
+					break
+				}
+			}
+			index -= sizeOfWire
+			skippy, err := github_com_gogo_protobuf_proto.Skip(data[index:])
+			if err != nil {
+				return err
+			}
+			if (index + skippy) > l {
+				return io.ErrUnexpectedEOF
+			}
+			m.XXX_unrecognized = append(m.XXX_unrecognized, data[index:index+skippy]...)
+			index += skippy
+		}
+	}
+	return nil
+}
 func (m *MVCCStats) Unmarshal(data []byte) error {
 	l := len(data)
 	index := 0
@@ -3325,6 +3475,29 @@ func (m *TimeSeriesData) Size() (n int) {
 	n += 1 + l + sovData(uint64(l))
 	l = len(m.Source)
 	n += 1 + l + sovData(uint64(l))
+	if len(m.Datapoints) > 0 {
+		for _, e := range m.Datapoints {
+			l = e.Size()
+			n += 1 + l + sovData(uint64(l))
+		}
+	}
+	if m.XXX_unrecognized != nil {
+		n += len(m.XXX_unrecognized)
+	}
+	return n
+}
+
+func (m *TimeSeriesQueryResult) Size() (n int) {
+	var l int
+	_ = l
+	l = len(m.Name)
+	n += 1 + l + sovData(uint64(l))
+	if len(m.Sources) > 0 {
+		for _, s := range m.Sources {
+			l = len(s)
+			n += 1 + l + sovData(uint64(l))
+		}
+	}
 	if len(m.Datapoints) > 0 {
 		for _, e := range m.Datapoints {
 			l = e.Size()
@@ -4080,6 +4253,58 @@ func (m *TimeSeriesData) MarshalTo(data []byte) (n int, err error) {
 	i++
 	i = encodeVarintData(data, i, uint64(len(m.Source)))
 	i += copy(data[i:], m.Source)
+	if len(m.Datapoints) > 0 {
+		for _, msg := range m.Datapoints {
+			data[i] = 0x1a
+			i++
+			i = encodeVarintData(data, i, uint64(msg.Size()))
+			n, err := msg.MarshalTo(data[i:])
+			if err != nil {
+				return 0, err
+			}
+			i += n
+		}
+	}
+	if m.XXX_unrecognized != nil {
+		i += copy(data[i:], m.XXX_unrecognized)
+	}
+	return i, nil
+}
+
+func (m *TimeSeriesQueryResult) Marshal() (data []byte, err error) {
+	size := m.Size()
+	data = make([]byte, size)
+	n, err := m.MarshalTo(data)
+	if err != nil {
+		return nil, err
+	}
+	return data[:n], nil
+}
+
+func (m *TimeSeriesQueryResult) MarshalTo(data []byte) (n int, err error) {
+	var i int
+	_ = i
+	var l int
+	_ = l
+	data[i] = 0xa
+	i++
+	i = encodeVarintData(data, i, uint64(len(m.Name)))
+	i += copy(data[i:], m.Name)
+	if len(m.Sources) > 0 {
+		for _, s := range m.Sources {
+			data[i] = 0x12
+			i++
+			l = len(s)
+			for l >= 1<<7 {
+				data[i] = uint8(uint64(l)&0x7f | 0x80)
+				l >>= 7
+				i++
+			}
+			data[i] = uint8(l)
+			i++
+			i += copy(data[i:], s)
+		}
+	}
 	if len(m.Datapoints) > 0 {
 		for _, msg := range m.Datapoints {
 			data[i] = 0x1a

--- a/proto/data.proto
+++ b/proto/data.proto
@@ -316,6 +316,19 @@ message TimeSeriesData {
   repeated TimeSeriesDatapoint datapoints = 3;
 }
 
+// TimeSeriesQueryResult is the response to a query over time series data. It
+// is similar to the TimeSeriesData message, but contains a list of sources
+// instead of a single source.
+message TimeSeriesQueryResult {
+  // A string which uniquely identifies the variable from which this data was
+  // measured.
+  optional string name = 1 [(gogoproto.nullable) = false];
+  // A list of sources from which the data was aggregated. 
+  repeated string sources = 2 [(gogoproto.nullable) = false];
+  // Datapoints describing the queried data. 
+  repeated TimeSeriesDatapoint datapoints = 3;
+}
+
 // MVCCStats tracks byte and instance counts for:
 //  - Live key/values (i.e. what a scan at current time will reveal;
 //    note that this includes intent keys and values, but not keys and

--- a/proto/internal.go
+++ b/proto/internal.go
@@ -75,3 +75,27 @@ func (br *InternalBatchResponse) Add(reply Response) {
 	}
 	br.Responses = append(br.Responses, union)
 }
+
+// Average returns the average value for this sample.
+func (samp *InternalTimeSeriesSample) Average() float64 {
+	if samp.Count == 0 {
+		return 0
+	}
+	return samp.Sum / float64(samp.Count)
+}
+
+// Maximum returns the maximum value encountered by this sample.
+func (samp *InternalTimeSeriesSample) Maximum() float64 {
+	if samp.Count < 2 {
+		return samp.Sum
+	}
+	return samp.GetMax()
+}
+
+// Minimum returns the minimum value encountered by this sample.
+func (samp *InternalTimeSeriesSample) Minimum() float64 {
+	if samp.Count < 2 {
+		return samp.Sum
+	}
+	return samp.GetMin()
+}

--- a/storage/engine/cockroach/proto/data.pb.cc
+++ b/storage/engine/cockroach/proto/data.pb.cc
@@ -72,6 +72,9 @@ const ::google::protobuf::internal::GeneratedMessageReflection*
 const ::google::protobuf::Descriptor* TimeSeriesData_descriptor_ = NULL;
 const ::google::protobuf::internal::GeneratedMessageReflection*
   TimeSeriesData_reflection_ = NULL;
+const ::google::protobuf::Descriptor* TimeSeriesQueryResult_descriptor_ = NULL;
+const ::google::protobuf::internal::GeneratedMessageReflection*
+  TimeSeriesQueryResult_reflection_ = NULL;
 const ::google::protobuf::Descriptor* MVCCStats_descriptor_ = NULL;
 const ::google::protobuf::internal::GeneratedMessageReflection*
   MVCCStats_reflection_ = NULL;
@@ -383,7 +386,24 @@ void protobuf_AssignDesc_cockroach_2fproto_2fdata_2eproto() {
       ::google::protobuf::DescriptorPool::generated_pool(),
       ::google::protobuf::MessageFactory::generated_factory(),
       sizeof(TimeSeriesData));
-  MVCCStats_descriptor_ = file->message_type(17);
+  TimeSeriesQueryResult_descriptor_ = file->message_type(17);
+  static const int TimeSeriesQueryResult_offsets_[3] = {
+    GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(TimeSeriesQueryResult, name_),
+    GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(TimeSeriesQueryResult, sources_),
+    GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(TimeSeriesQueryResult, datapoints_),
+  };
+  TimeSeriesQueryResult_reflection_ =
+    new ::google::protobuf::internal::GeneratedMessageReflection(
+      TimeSeriesQueryResult_descriptor_,
+      TimeSeriesQueryResult::default_instance_,
+      TimeSeriesQueryResult_offsets_,
+      GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(TimeSeriesQueryResult, _has_bits_[0]),
+      GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(TimeSeriesQueryResult, _unknown_fields_),
+      -1,
+      ::google::protobuf::DescriptorPool::generated_pool(),
+      ::google::protobuf::MessageFactory::generated_factory(),
+      sizeof(TimeSeriesQueryResult));
+  MVCCStats_descriptor_ = file->message_type(18);
   static const int MVCCStats_offsets_[11] = {
     GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(MVCCStats, live_bytes_),
     GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(MVCCStats, key_bytes_),
@@ -458,6 +478,8 @@ void protobuf_RegisterTypes(const ::std::string&) {
   ::google::protobuf::MessageFactory::InternalRegisterGeneratedMessage(
     TimeSeriesData_descriptor_, &TimeSeriesData::default_instance());
   ::google::protobuf::MessageFactory::InternalRegisterGeneratedMessage(
+    TimeSeriesQueryResult_descriptor_, &TimeSeriesQueryResult::default_instance());
+  ::google::protobuf::MessageFactory::InternalRegisterGeneratedMessage(
     MVCCStats_descriptor_, &MVCCStats::default_instance());
 }
 
@@ -498,6 +520,8 @@ void protobuf_ShutdownFile_cockroach_2fproto_2fdata_2eproto() {
   delete TimeSeriesDatapoint_reflection_;
   delete TimeSeriesData::default_instance_;
   delete TimeSeriesData_reflection_;
+  delete TimeSeriesQueryResult::default_instance_;
+  delete TimeSeriesQueryResult_reflection_;
   delete MVCCStats::default_instance_;
   delete MVCCStats_reflection_;
 }
@@ -576,20 +600,23 @@ void protobuf_AddDesc_cockroach_2fproto_2fdata_2eproto() {
     "\000\"t\n\016TimeSeriesData\022\022\n\004name\030\001 \001(\tB\004\310\336\037\000\022"
     "\024\n\006source\030\002 \001(\tB\004\310\336\037\000\0228\n\ndatapoints\030\003 \003("
     "\0132$.cockroach.proto.TimeSeriesDatapoint\""
-    "\300\002\n\tMVCCStats\022\030\n\nlive_bytes\030\001 \001(\003B\004\310\336\037\000\022"
-    "\027\n\tkey_bytes\030\002 \001(\003B\004\310\336\037\000\022\027\n\tval_bytes\030\003 "
-    "\001(\003B\004\310\336\037\000\022\032\n\014intent_bytes\030\004 \001(\003B\004\310\336\037\000\022\030\n"
-    "\nlive_count\030\005 \001(\003B\004\310\336\037\000\022\027\n\tkey_count\030\006 \001"
-    "(\003B\004\310\336\037\000\022\027\n\tval_count\030\007 \001(\003B\004\310\336\037\000\022\032\n\014int"
-    "ent_count\030\010 \001(\003B\004\310\336\037\000\022\030\n\nintent_age\030\t \001("
-    "\003B\004\310\336\037\000\022(\n\014gc_bytes_age\030\n \001(\003B\022\310\336\037\000\342\336\037\nG"
-    "CBytesAge\022\037\n\021last_update_nanos\030\013 \001(\003B\004\310\336"
-    "\037\000*>\n\021ReplicaChangeType\022\017\n\013ADD_REPLICA\020\000"
-    "\022\022\n\016REMOVE_REPLICA\020\001\032\004\210\243\036\000*5\n\rIsolationT"
-    "ype\022\020\n\014SERIALIZABLE\020\000\022\014\n\010SNAPSHOT\020\001\032\004\210\243\036"
-    "\000*B\n\021TransactionStatus\022\013\n\007PENDING\020\000\022\r\n\tC"
-    "OMMITTED\020\001\022\013\n\007ABORTED\020\002\032\004\210\243\036\000B\023Z\005proto\340\342"
-    "\036\001\310\342\036\001\320\342\036\001", 3130);
+    "|\n\025TimeSeriesQueryResult\022\022\n\004name\030\001 \001(\tB\004"
+    "\310\336\037\000\022\025\n\007sources\030\002 \003(\tB\004\310\336\037\000\0228\n\ndatapoint"
+    "s\030\003 \003(\0132$.cockroach.proto.TimeSeriesData"
+    "point\"\300\002\n\tMVCCStats\022\030\n\nlive_bytes\030\001 \001(\003B"
+    "\004\310\336\037\000\022\027\n\tkey_bytes\030\002 \001(\003B\004\310\336\037\000\022\027\n\tval_by"
+    "tes\030\003 \001(\003B\004\310\336\037\000\022\032\n\014intent_bytes\030\004 \001(\003B\004\310"
+    "\336\037\000\022\030\n\nlive_count\030\005 \001(\003B\004\310\336\037\000\022\027\n\tkey_cou"
+    "nt\030\006 \001(\003B\004\310\336\037\000\022\027\n\tval_count\030\007 \001(\003B\004\310\336\037\000\022"
+    "\032\n\014intent_count\030\010 \001(\003B\004\310\336\037\000\022\030\n\nintent_ag"
+    "e\030\t \001(\003B\004\310\336\037\000\022(\n\014gc_bytes_age\030\n \001(\003B\022\310\336\037"
+    "\000\342\336\037\nGCBytesAge\022\037\n\021last_update_nanos\030\013 \001"
+    "(\003B\004\310\336\037\000*>\n\021ReplicaChangeType\022\017\n\013ADD_REP"
+    "LICA\020\000\022\022\n\016REMOVE_REPLICA\020\001\032\004\210\243\036\000*5\n\rIsol"
+    "ationType\022\020\n\014SERIALIZABLE\020\000\022\014\n\010SNAPSHOT\020"
+    "\001\032\004\210\243\036\000*B\n\021TransactionStatus\022\013\n\007PENDING\020"
+    "\000\022\r\n\tCOMMITTED\020\001\022\013\n\007ABORTED\020\002\032\004\210\243\036\000B\023Z\005p"
+    "roto\340\342\036\001\310\342\036\001\320\342\036\001", 3256);
   ::google::protobuf::MessageFactory::InternalRegisterGeneratedFile(
     "cockroach/proto/data.proto", &protobuf_RegisterTypes);
   Timestamp::default_instance_ = new Timestamp();
@@ -609,6 +636,7 @@ void protobuf_AddDesc_cockroach_2fproto_2fdata_2eproto() {
   GCMetadata::default_instance_ = new GCMetadata();
   TimeSeriesDatapoint::default_instance_ = new TimeSeriesDatapoint();
   TimeSeriesData::default_instance_ = new TimeSeriesData();
+  TimeSeriesQueryResult::default_instance_ = new TimeSeriesQueryResult();
   MVCCStats::default_instance_ = new MVCCStats();
   Timestamp::default_instance_->InitAsDefaultInstance();
   Value::default_instance_->InitAsDefaultInstance();
@@ -627,6 +655,7 @@ void protobuf_AddDesc_cockroach_2fproto_2fdata_2eproto() {
   GCMetadata::default_instance_->InitAsDefaultInstance();
   TimeSeriesDatapoint::default_instance_->InitAsDefaultInstance();
   TimeSeriesData::default_instance_->InitAsDefaultInstance();
+  TimeSeriesQueryResult::default_instance_->InitAsDefaultInstance();
   MVCCStats::default_instance_->InitAsDefaultInstance();
   ::google::protobuf::internal::OnShutdown(&protobuf_ShutdownFile_cockroach_2fproto_2fdata_2eproto);
 }
@@ -6410,6 +6439,338 @@ void TimeSeriesData::Swap(TimeSeriesData* other) {
   ::google::protobuf::Metadata metadata;
   metadata.descriptor = TimeSeriesData_descriptor_;
   metadata.reflection = TimeSeriesData_reflection_;
+  return metadata;
+}
+
+
+// ===================================================================
+
+#ifndef _MSC_VER
+const int TimeSeriesQueryResult::kNameFieldNumber;
+const int TimeSeriesQueryResult::kSourcesFieldNumber;
+const int TimeSeriesQueryResult::kDatapointsFieldNumber;
+#endif  // !_MSC_VER
+
+TimeSeriesQueryResult::TimeSeriesQueryResult()
+  : ::google::protobuf::Message() {
+  SharedCtor();
+  // @@protoc_insertion_point(constructor:cockroach.proto.TimeSeriesQueryResult)
+}
+
+void TimeSeriesQueryResult::InitAsDefaultInstance() {
+}
+
+TimeSeriesQueryResult::TimeSeriesQueryResult(const TimeSeriesQueryResult& from)
+  : ::google::protobuf::Message() {
+  SharedCtor();
+  MergeFrom(from);
+  // @@protoc_insertion_point(copy_constructor:cockroach.proto.TimeSeriesQueryResult)
+}
+
+void TimeSeriesQueryResult::SharedCtor() {
+  ::google::protobuf::internal::GetEmptyString();
+  _cached_size_ = 0;
+  name_ = const_cast< ::std::string*>(&::google::protobuf::internal::GetEmptyStringAlreadyInited());
+  ::memset(_has_bits_, 0, sizeof(_has_bits_));
+}
+
+TimeSeriesQueryResult::~TimeSeriesQueryResult() {
+  // @@protoc_insertion_point(destructor:cockroach.proto.TimeSeriesQueryResult)
+  SharedDtor();
+}
+
+void TimeSeriesQueryResult::SharedDtor() {
+  if (name_ != &::google::protobuf::internal::GetEmptyStringAlreadyInited()) {
+    delete name_;
+  }
+  if (this != default_instance_) {
+  }
+}
+
+void TimeSeriesQueryResult::SetCachedSize(int size) const {
+  GOOGLE_SAFE_CONCURRENT_WRITES_BEGIN();
+  _cached_size_ = size;
+  GOOGLE_SAFE_CONCURRENT_WRITES_END();
+}
+const ::google::protobuf::Descriptor* TimeSeriesQueryResult::descriptor() {
+  protobuf_AssignDescriptorsOnce();
+  return TimeSeriesQueryResult_descriptor_;
+}
+
+const TimeSeriesQueryResult& TimeSeriesQueryResult::default_instance() {
+  if (default_instance_ == NULL) protobuf_AddDesc_cockroach_2fproto_2fdata_2eproto();
+  return *default_instance_;
+}
+
+TimeSeriesQueryResult* TimeSeriesQueryResult::default_instance_ = NULL;
+
+TimeSeriesQueryResult* TimeSeriesQueryResult::New() const {
+  return new TimeSeriesQueryResult;
+}
+
+void TimeSeriesQueryResult::Clear() {
+  if (has_name()) {
+    if (name_ != &::google::protobuf::internal::GetEmptyStringAlreadyInited()) {
+      name_->clear();
+    }
+  }
+  sources_.Clear();
+  datapoints_.Clear();
+  ::memset(_has_bits_, 0, sizeof(_has_bits_));
+  mutable_unknown_fields()->Clear();
+}
+
+bool TimeSeriesQueryResult::MergePartialFromCodedStream(
+    ::google::protobuf::io::CodedInputStream* input) {
+#define DO_(EXPRESSION) if (!(EXPRESSION)) goto failure
+  ::google::protobuf::uint32 tag;
+  // @@protoc_insertion_point(parse_start:cockroach.proto.TimeSeriesQueryResult)
+  for (;;) {
+    ::std::pair< ::google::protobuf::uint32, bool> p = input->ReadTagWithCutoff(127);
+    tag = p.first;
+    if (!p.second) goto handle_unusual;
+    switch (::google::protobuf::internal::WireFormatLite::GetTagFieldNumber(tag)) {
+      // optional string name = 1;
+      case 1: {
+        if (tag == 10) {
+          DO_(::google::protobuf::internal::WireFormatLite::ReadString(
+                input, this->mutable_name()));
+          ::google::protobuf::internal::WireFormat::VerifyUTF8StringNamedField(
+            this->name().data(), this->name().length(),
+            ::google::protobuf::internal::WireFormat::PARSE,
+            "name");
+        } else {
+          goto handle_unusual;
+        }
+        if (input->ExpectTag(18)) goto parse_sources;
+        break;
+      }
+
+      // repeated string sources = 2;
+      case 2: {
+        if (tag == 18) {
+         parse_sources:
+          DO_(::google::protobuf::internal::WireFormatLite::ReadString(
+                input, this->add_sources()));
+          ::google::protobuf::internal::WireFormat::VerifyUTF8StringNamedField(
+            this->sources(this->sources_size() - 1).data(),
+            this->sources(this->sources_size() - 1).length(),
+            ::google::protobuf::internal::WireFormat::PARSE,
+            "sources");
+        } else {
+          goto handle_unusual;
+        }
+        if (input->ExpectTag(18)) goto parse_sources;
+        if (input->ExpectTag(26)) goto parse_datapoints;
+        break;
+      }
+
+      // repeated .cockroach.proto.TimeSeriesDatapoint datapoints = 3;
+      case 3: {
+        if (tag == 26) {
+         parse_datapoints:
+          DO_(::google::protobuf::internal::WireFormatLite::ReadMessageNoVirtual(
+                input, add_datapoints()));
+        } else {
+          goto handle_unusual;
+        }
+        if (input->ExpectTag(26)) goto parse_datapoints;
+        if (input->ExpectAtEnd()) goto success;
+        break;
+      }
+
+      default: {
+      handle_unusual:
+        if (tag == 0 ||
+            ::google::protobuf::internal::WireFormatLite::GetTagWireType(tag) ==
+            ::google::protobuf::internal::WireFormatLite::WIRETYPE_END_GROUP) {
+          goto success;
+        }
+        DO_(::google::protobuf::internal::WireFormat::SkipField(
+              input, tag, mutable_unknown_fields()));
+        break;
+      }
+    }
+  }
+success:
+  // @@protoc_insertion_point(parse_success:cockroach.proto.TimeSeriesQueryResult)
+  return true;
+failure:
+  // @@protoc_insertion_point(parse_failure:cockroach.proto.TimeSeriesQueryResult)
+  return false;
+#undef DO_
+}
+
+void TimeSeriesQueryResult::SerializeWithCachedSizes(
+    ::google::protobuf::io::CodedOutputStream* output) const {
+  // @@protoc_insertion_point(serialize_start:cockroach.proto.TimeSeriesQueryResult)
+  // optional string name = 1;
+  if (has_name()) {
+    ::google::protobuf::internal::WireFormat::VerifyUTF8StringNamedField(
+      this->name().data(), this->name().length(),
+      ::google::protobuf::internal::WireFormat::SERIALIZE,
+      "name");
+    ::google::protobuf::internal::WireFormatLite::WriteStringMaybeAliased(
+      1, this->name(), output);
+  }
+
+  // repeated string sources = 2;
+  for (int i = 0; i < this->sources_size(); i++) {
+  ::google::protobuf::internal::WireFormat::VerifyUTF8StringNamedField(
+    this->sources(i).data(), this->sources(i).length(),
+    ::google::protobuf::internal::WireFormat::SERIALIZE,
+    "sources");
+    ::google::protobuf::internal::WireFormatLite::WriteString(
+      2, this->sources(i), output);
+  }
+
+  // repeated .cockroach.proto.TimeSeriesDatapoint datapoints = 3;
+  for (int i = 0; i < this->datapoints_size(); i++) {
+    ::google::protobuf::internal::WireFormatLite::WriteMessageMaybeToArray(
+      3, this->datapoints(i), output);
+  }
+
+  if (!unknown_fields().empty()) {
+    ::google::protobuf::internal::WireFormat::SerializeUnknownFields(
+        unknown_fields(), output);
+  }
+  // @@protoc_insertion_point(serialize_end:cockroach.proto.TimeSeriesQueryResult)
+}
+
+::google::protobuf::uint8* TimeSeriesQueryResult::SerializeWithCachedSizesToArray(
+    ::google::protobuf::uint8* target) const {
+  // @@protoc_insertion_point(serialize_to_array_start:cockroach.proto.TimeSeriesQueryResult)
+  // optional string name = 1;
+  if (has_name()) {
+    ::google::protobuf::internal::WireFormat::VerifyUTF8StringNamedField(
+      this->name().data(), this->name().length(),
+      ::google::protobuf::internal::WireFormat::SERIALIZE,
+      "name");
+    target =
+      ::google::protobuf::internal::WireFormatLite::WriteStringToArray(
+        1, this->name(), target);
+  }
+
+  // repeated string sources = 2;
+  for (int i = 0; i < this->sources_size(); i++) {
+    ::google::protobuf::internal::WireFormat::VerifyUTF8StringNamedField(
+      this->sources(i).data(), this->sources(i).length(),
+      ::google::protobuf::internal::WireFormat::SERIALIZE,
+      "sources");
+    target = ::google::protobuf::internal::WireFormatLite::
+      WriteStringToArray(2, this->sources(i), target);
+  }
+
+  // repeated .cockroach.proto.TimeSeriesDatapoint datapoints = 3;
+  for (int i = 0; i < this->datapoints_size(); i++) {
+    target = ::google::protobuf::internal::WireFormatLite::
+      WriteMessageNoVirtualToArray(
+        3, this->datapoints(i), target);
+  }
+
+  if (!unknown_fields().empty()) {
+    target = ::google::protobuf::internal::WireFormat::SerializeUnknownFieldsToArray(
+        unknown_fields(), target);
+  }
+  // @@protoc_insertion_point(serialize_to_array_end:cockroach.proto.TimeSeriesQueryResult)
+  return target;
+}
+
+int TimeSeriesQueryResult::ByteSize() const {
+  int total_size = 0;
+
+  if (_has_bits_[0 / 32] & (0xffu << (0 % 32))) {
+    // optional string name = 1;
+    if (has_name()) {
+      total_size += 1 +
+        ::google::protobuf::internal::WireFormatLite::StringSize(
+          this->name());
+    }
+
+  }
+  // repeated string sources = 2;
+  total_size += 1 * this->sources_size();
+  for (int i = 0; i < this->sources_size(); i++) {
+    total_size += ::google::protobuf::internal::WireFormatLite::StringSize(
+      this->sources(i));
+  }
+
+  // repeated .cockroach.proto.TimeSeriesDatapoint datapoints = 3;
+  total_size += 1 * this->datapoints_size();
+  for (int i = 0; i < this->datapoints_size(); i++) {
+    total_size +=
+      ::google::protobuf::internal::WireFormatLite::MessageSizeNoVirtual(
+        this->datapoints(i));
+  }
+
+  if (!unknown_fields().empty()) {
+    total_size +=
+      ::google::protobuf::internal::WireFormat::ComputeUnknownFieldsSize(
+        unknown_fields());
+  }
+  GOOGLE_SAFE_CONCURRENT_WRITES_BEGIN();
+  _cached_size_ = total_size;
+  GOOGLE_SAFE_CONCURRENT_WRITES_END();
+  return total_size;
+}
+
+void TimeSeriesQueryResult::MergeFrom(const ::google::protobuf::Message& from) {
+  GOOGLE_CHECK_NE(&from, this);
+  const TimeSeriesQueryResult* source =
+    ::google::protobuf::internal::dynamic_cast_if_available<const TimeSeriesQueryResult*>(
+      &from);
+  if (source == NULL) {
+    ::google::protobuf::internal::ReflectionOps::Merge(from, this);
+  } else {
+    MergeFrom(*source);
+  }
+}
+
+void TimeSeriesQueryResult::MergeFrom(const TimeSeriesQueryResult& from) {
+  GOOGLE_CHECK_NE(&from, this);
+  sources_.MergeFrom(from.sources_);
+  datapoints_.MergeFrom(from.datapoints_);
+  if (from._has_bits_[0 / 32] & (0xffu << (0 % 32))) {
+    if (from.has_name()) {
+      set_name(from.name());
+    }
+  }
+  mutable_unknown_fields()->MergeFrom(from.unknown_fields());
+}
+
+void TimeSeriesQueryResult::CopyFrom(const ::google::protobuf::Message& from) {
+  if (&from == this) return;
+  Clear();
+  MergeFrom(from);
+}
+
+void TimeSeriesQueryResult::CopyFrom(const TimeSeriesQueryResult& from) {
+  if (&from == this) return;
+  Clear();
+  MergeFrom(from);
+}
+
+bool TimeSeriesQueryResult::IsInitialized() const {
+
+  return true;
+}
+
+void TimeSeriesQueryResult::Swap(TimeSeriesQueryResult* other) {
+  if (other != this) {
+    std::swap(name_, other->name_);
+    sources_.Swap(&other->sources_);
+    datapoints_.Swap(&other->datapoints_);
+    std::swap(_has_bits_[0], other->_has_bits_[0]);
+    _unknown_fields_.Swap(&other->_unknown_fields_);
+    std::swap(_cached_size_, other->_cached_size_);
+  }
+}
+
+::google::protobuf::Metadata TimeSeriesQueryResult::GetMetadata() const {
+  protobuf_AssignDescriptorsOnce();
+  ::google::protobuf::Metadata metadata;
+  metadata.descriptor = TimeSeriesQueryResult_descriptor_;
+  metadata.reflection = TimeSeriesQueryResult_reflection_;
   return metadata;
 }
 

--- a/storage/engine/cockroach/proto/data.pb.h
+++ b/storage/engine/cockroach/proto/data.pb.h
@@ -54,6 +54,7 @@ class MVCCMetadata;
 class GCMetadata;
 class TimeSeriesDatapoint;
 class TimeSeriesData;
+class TimeSeriesQueryResult;
 class MVCCStats;
 
 enum ReplicaChangeType {
@@ -1966,6 +1967,120 @@ class TimeSeriesData : public ::google::protobuf::Message {
 
   void InitAsDefaultInstance();
   static TimeSeriesData* default_instance_;
+};
+// -------------------------------------------------------------------
+
+class TimeSeriesQueryResult : public ::google::protobuf::Message {
+ public:
+  TimeSeriesQueryResult();
+  virtual ~TimeSeriesQueryResult();
+
+  TimeSeriesQueryResult(const TimeSeriesQueryResult& from);
+
+  inline TimeSeriesQueryResult& operator=(const TimeSeriesQueryResult& from) {
+    CopyFrom(from);
+    return *this;
+  }
+
+  inline const ::google::protobuf::UnknownFieldSet& unknown_fields() const {
+    return _unknown_fields_;
+  }
+
+  inline ::google::protobuf::UnknownFieldSet* mutable_unknown_fields() {
+    return &_unknown_fields_;
+  }
+
+  static const ::google::protobuf::Descriptor* descriptor();
+  static const TimeSeriesQueryResult& default_instance();
+
+  void Swap(TimeSeriesQueryResult* other);
+
+  // implements Message ----------------------------------------------
+
+  TimeSeriesQueryResult* New() const;
+  void CopyFrom(const ::google::protobuf::Message& from);
+  void MergeFrom(const ::google::protobuf::Message& from);
+  void CopyFrom(const TimeSeriesQueryResult& from);
+  void MergeFrom(const TimeSeriesQueryResult& from);
+  void Clear();
+  bool IsInitialized() const;
+
+  int ByteSize() const;
+  bool MergePartialFromCodedStream(
+      ::google::protobuf::io::CodedInputStream* input);
+  void SerializeWithCachedSizes(
+      ::google::protobuf::io::CodedOutputStream* output) const;
+  ::google::protobuf::uint8* SerializeWithCachedSizesToArray(::google::protobuf::uint8* output) const;
+  int GetCachedSize() const { return _cached_size_; }
+  private:
+  void SharedCtor();
+  void SharedDtor();
+  void SetCachedSize(int size) const;
+  public:
+  ::google::protobuf::Metadata GetMetadata() const;
+
+  // nested types ----------------------------------------------------
+
+  // accessors -------------------------------------------------------
+
+  // optional string name = 1;
+  inline bool has_name() const;
+  inline void clear_name();
+  static const int kNameFieldNumber = 1;
+  inline const ::std::string& name() const;
+  inline void set_name(const ::std::string& value);
+  inline void set_name(const char* value);
+  inline void set_name(const char* value, size_t size);
+  inline ::std::string* mutable_name();
+  inline ::std::string* release_name();
+  inline void set_allocated_name(::std::string* name);
+
+  // repeated string sources = 2;
+  inline int sources_size() const;
+  inline void clear_sources();
+  static const int kSourcesFieldNumber = 2;
+  inline const ::std::string& sources(int index) const;
+  inline ::std::string* mutable_sources(int index);
+  inline void set_sources(int index, const ::std::string& value);
+  inline void set_sources(int index, const char* value);
+  inline void set_sources(int index, const char* value, size_t size);
+  inline ::std::string* add_sources();
+  inline void add_sources(const ::std::string& value);
+  inline void add_sources(const char* value);
+  inline void add_sources(const char* value, size_t size);
+  inline const ::google::protobuf::RepeatedPtrField< ::std::string>& sources() const;
+  inline ::google::protobuf::RepeatedPtrField< ::std::string>* mutable_sources();
+
+  // repeated .cockroach.proto.TimeSeriesDatapoint datapoints = 3;
+  inline int datapoints_size() const;
+  inline void clear_datapoints();
+  static const int kDatapointsFieldNumber = 3;
+  inline const ::cockroach::proto::TimeSeriesDatapoint& datapoints(int index) const;
+  inline ::cockroach::proto::TimeSeriesDatapoint* mutable_datapoints(int index);
+  inline ::cockroach::proto::TimeSeriesDatapoint* add_datapoints();
+  inline const ::google::protobuf::RepeatedPtrField< ::cockroach::proto::TimeSeriesDatapoint >&
+      datapoints() const;
+  inline ::google::protobuf::RepeatedPtrField< ::cockroach::proto::TimeSeriesDatapoint >*
+      mutable_datapoints();
+
+  // @@protoc_insertion_point(class_scope:cockroach.proto.TimeSeriesQueryResult)
+ private:
+  inline void set_has_name();
+  inline void clear_has_name();
+
+  ::google::protobuf::UnknownFieldSet _unknown_fields_;
+
+  ::google::protobuf::uint32 _has_bits_[1];
+  mutable int _cached_size_;
+  ::std::string* name_;
+  ::google::protobuf::RepeatedPtrField< ::std::string> sources_;
+  ::google::protobuf::RepeatedPtrField< ::cockroach::proto::TimeSeriesDatapoint > datapoints_;
+  friend void  protobuf_AddDesc_cockroach_2fproto_2fdata_2eproto();
+  friend void protobuf_AssignDesc_cockroach_2fproto_2fdata_2eproto();
+  friend void protobuf_ShutdownFile_cockroach_2fproto_2fdata_2eproto();
+
+  void InitAsDefaultInstance();
+  static TimeSeriesQueryResult* default_instance_;
 };
 // -------------------------------------------------------------------
 
@@ -4528,6 +4643,170 @@ TimeSeriesData::datapoints() const {
 inline ::google::protobuf::RepeatedPtrField< ::cockroach::proto::TimeSeriesDatapoint >*
 TimeSeriesData::mutable_datapoints() {
   // @@protoc_insertion_point(field_mutable_list:cockroach.proto.TimeSeriesData.datapoints)
+  return &datapoints_;
+}
+
+// -------------------------------------------------------------------
+
+// TimeSeriesQueryResult
+
+// optional string name = 1;
+inline bool TimeSeriesQueryResult::has_name() const {
+  return (_has_bits_[0] & 0x00000001u) != 0;
+}
+inline void TimeSeriesQueryResult::set_has_name() {
+  _has_bits_[0] |= 0x00000001u;
+}
+inline void TimeSeriesQueryResult::clear_has_name() {
+  _has_bits_[0] &= ~0x00000001u;
+}
+inline void TimeSeriesQueryResult::clear_name() {
+  if (name_ != &::google::protobuf::internal::GetEmptyStringAlreadyInited()) {
+    name_->clear();
+  }
+  clear_has_name();
+}
+inline const ::std::string& TimeSeriesQueryResult::name() const {
+  // @@protoc_insertion_point(field_get:cockroach.proto.TimeSeriesQueryResult.name)
+  return *name_;
+}
+inline void TimeSeriesQueryResult::set_name(const ::std::string& value) {
+  set_has_name();
+  if (name_ == &::google::protobuf::internal::GetEmptyStringAlreadyInited()) {
+    name_ = new ::std::string;
+  }
+  name_->assign(value);
+  // @@protoc_insertion_point(field_set:cockroach.proto.TimeSeriesQueryResult.name)
+}
+inline void TimeSeriesQueryResult::set_name(const char* value) {
+  set_has_name();
+  if (name_ == &::google::protobuf::internal::GetEmptyStringAlreadyInited()) {
+    name_ = new ::std::string;
+  }
+  name_->assign(value);
+  // @@protoc_insertion_point(field_set_char:cockroach.proto.TimeSeriesQueryResult.name)
+}
+inline void TimeSeriesQueryResult::set_name(const char* value, size_t size) {
+  set_has_name();
+  if (name_ == &::google::protobuf::internal::GetEmptyStringAlreadyInited()) {
+    name_ = new ::std::string;
+  }
+  name_->assign(reinterpret_cast<const char*>(value), size);
+  // @@protoc_insertion_point(field_set_pointer:cockroach.proto.TimeSeriesQueryResult.name)
+}
+inline ::std::string* TimeSeriesQueryResult::mutable_name() {
+  set_has_name();
+  if (name_ == &::google::protobuf::internal::GetEmptyStringAlreadyInited()) {
+    name_ = new ::std::string;
+  }
+  // @@protoc_insertion_point(field_mutable:cockroach.proto.TimeSeriesQueryResult.name)
+  return name_;
+}
+inline ::std::string* TimeSeriesQueryResult::release_name() {
+  clear_has_name();
+  if (name_ == &::google::protobuf::internal::GetEmptyStringAlreadyInited()) {
+    return NULL;
+  } else {
+    ::std::string* temp = name_;
+    name_ = const_cast< ::std::string*>(&::google::protobuf::internal::GetEmptyStringAlreadyInited());
+    return temp;
+  }
+}
+inline void TimeSeriesQueryResult::set_allocated_name(::std::string* name) {
+  if (name_ != &::google::protobuf::internal::GetEmptyStringAlreadyInited()) {
+    delete name_;
+  }
+  if (name) {
+    set_has_name();
+    name_ = name;
+  } else {
+    clear_has_name();
+    name_ = const_cast< ::std::string*>(&::google::protobuf::internal::GetEmptyStringAlreadyInited());
+  }
+  // @@protoc_insertion_point(field_set_allocated:cockroach.proto.TimeSeriesQueryResult.name)
+}
+
+// repeated string sources = 2;
+inline int TimeSeriesQueryResult::sources_size() const {
+  return sources_.size();
+}
+inline void TimeSeriesQueryResult::clear_sources() {
+  sources_.Clear();
+}
+inline const ::std::string& TimeSeriesQueryResult::sources(int index) const {
+  // @@protoc_insertion_point(field_get:cockroach.proto.TimeSeriesQueryResult.sources)
+  return sources_.Get(index);
+}
+inline ::std::string* TimeSeriesQueryResult::mutable_sources(int index) {
+  // @@protoc_insertion_point(field_mutable:cockroach.proto.TimeSeriesQueryResult.sources)
+  return sources_.Mutable(index);
+}
+inline void TimeSeriesQueryResult::set_sources(int index, const ::std::string& value) {
+  // @@protoc_insertion_point(field_set:cockroach.proto.TimeSeriesQueryResult.sources)
+  sources_.Mutable(index)->assign(value);
+}
+inline void TimeSeriesQueryResult::set_sources(int index, const char* value) {
+  sources_.Mutable(index)->assign(value);
+  // @@protoc_insertion_point(field_set_char:cockroach.proto.TimeSeriesQueryResult.sources)
+}
+inline void TimeSeriesQueryResult::set_sources(int index, const char* value, size_t size) {
+  sources_.Mutable(index)->assign(
+    reinterpret_cast<const char*>(value), size);
+  // @@protoc_insertion_point(field_set_pointer:cockroach.proto.TimeSeriesQueryResult.sources)
+}
+inline ::std::string* TimeSeriesQueryResult::add_sources() {
+  return sources_.Add();
+}
+inline void TimeSeriesQueryResult::add_sources(const ::std::string& value) {
+  sources_.Add()->assign(value);
+  // @@protoc_insertion_point(field_add:cockroach.proto.TimeSeriesQueryResult.sources)
+}
+inline void TimeSeriesQueryResult::add_sources(const char* value) {
+  sources_.Add()->assign(value);
+  // @@protoc_insertion_point(field_add_char:cockroach.proto.TimeSeriesQueryResult.sources)
+}
+inline void TimeSeriesQueryResult::add_sources(const char* value, size_t size) {
+  sources_.Add()->assign(reinterpret_cast<const char*>(value), size);
+  // @@protoc_insertion_point(field_add_pointer:cockroach.proto.TimeSeriesQueryResult.sources)
+}
+inline const ::google::protobuf::RepeatedPtrField< ::std::string>&
+TimeSeriesQueryResult::sources() const {
+  // @@protoc_insertion_point(field_list:cockroach.proto.TimeSeriesQueryResult.sources)
+  return sources_;
+}
+inline ::google::protobuf::RepeatedPtrField< ::std::string>*
+TimeSeriesQueryResult::mutable_sources() {
+  // @@protoc_insertion_point(field_mutable_list:cockroach.proto.TimeSeriesQueryResult.sources)
+  return &sources_;
+}
+
+// repeated .cockroach.proto.TimeSeriesDatapoint datapoints = 3;
+inline int TimeSeriesQueryResult::datapoints_size() const {
+  return datapoints_.size();
+}
+inline void TimeSeriesQueryResult::clear_datapoints() {
+  datapoints_.Clear();
+}
+inline const ::cockroach::proto::TimeSeriesDatapoint& TimeSeriesQueryResult::datapoints(int index) const {
+  // @@protoc_insertion_point(field_get:cockroach.proto.TimeSeriesQueryResult.datapoints)
+  return datapoints_.Get(index);
+}
+inline ::cockroach::proto::TimeSeriesDatapoint* TimeSeriesQueryResult::mutable_datapoints(int index) {
+  // @@protoc_insertion_point(field_mutable:cockroach.proto.TimeSeriesQueryResult.datapoints)
+  return datapoints_.Mutable(index);
+}
+inline ::cockroach::proto::TimeSeriesDatapoint* TimeSeriesQueryResult::add_datapoints() {
+  // @@protoc_insertion_point(field_add:cockroach.proto.TimeSeriesQueryResult.datapoints)
+  return datapoints_.Add();
+}
+inline const ::google::protobuf::RepeatedPtrField< ::cockroach::proto::TimeSeriesDatapoint >&
+TimeSeriesQueryResult::datapoints() const {
+  // @@protoc_insertion_point(field_list:cockroach.proto.TimeSeriesQueryResult.datapoints)
+  return datapoints_;
+}
+inline ::google::protobuf::RepeatedPtrField< ::cockroach::proto::TimeSeriesDatapoint >*
+TimeSeriesQueryResult::mutable_datapoints() {
+  // @@protoc_insertion_point(field_mutable_list:cockroach.proto.TimeSeriesQueryResult.datapoints)
   return &datapoints_;
 }
 

--- a/ts/db.go
+++ b/ts/db.go
@@ -13,7 +13,7 @@
 // permissions and limitations under the License. See the AUTHORS file
 // for names of contributors.
 //
-// Author: Matt Tracy (matt.r.tracy@gmail.com)
+// Author: Matt Tracy (matt@cockroachlabs.com)
 
 package ts
 

--- a/ts/query.go
+++ b/ts/query.go
@@ -1,0 +1,438 @@
+// Copyright 2015 The Cockroach Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+// implied. See the License for the specific language governing
+// permissions and limitations under the License. See the AUTHORS file
+// for names of contributors.
+//
+// Author: Matt Tracy (matt@cockroachlabs.com)
+
+package ts
+
+import (
+	"container/heap"
+	"sort"
+
+	"github.com/cockroachdb/cockroach/client"
+	"github.com/cockroachdb/cockroach/proto"
+	"github.com/cockroachdb/cockroach/util"
+)
+
+// calibratedData is used to calibrate an InternalTimeSeriesData object for
+// use in a dataSpan.  This is accomplished by computing a constant offset
+// adjustment which adjusts each Sample offset to be relative to the start time
+// of the dataSpan, rather than the start time of the InternalTimeSeriesData.
+type calibratedData struct {
+	*proto.InternalTimeSeriesData
+	offsetAdjustment int32
+}
+
+// offsetAt returns the calibrated offset for the Sample at the supplied index
+// in the InternalTimeSeriesData's Samples collection.
+func (rdc *calibratedData) offsetAt(idx int) int32 {
+	return rdc.Samples[idx].Offset + rdc.offsetAdjustment
+}
+
+// dataSpan is used to construct  monolithic view of a single time series over
+// an arbitrary time span. The actual data in a span may be stored in multiple
+// instances of InternalTimeSeriesData.
+type dataSpan struct {
+	startNanos  int64
+	sampleNanos int64
+	datas       []calibratedData
+}
+
+// timestampForOffset returns an appropriate timestamp for the given offset
+// within a dataSpan. Because each offset represents a duration of time and not
+// an exact time, the returned timestamp will fall exactly in the middle of the
+// time slot represented by the offset.
+func (ds *dataSpan) timestampForOffset(offset int32) int64 {
+	return ds.startNanos + (int64(offset) * ds.sampleNanos) + (ds.sampleNanos / 2)
+}
+
+// addData adds an InternalTimeSeriesData object into this dataSpan, normalizing
+// it to a calibratedData object in the process.
+func (ds *dataSpan) addData(data *proto.InternalTimeSeriesData) error {
+	if data.SampleDurationNanos != ds.sampleNanos {
+		return util.Errorf("data added to dataSpan with mismatched sample duration period")
+	}
+
+	// Reject data if there are no samples.
+	if len(data.Samples) == 0 {
+		return nil
+	}
+
+	// Calculate an offset adjustment which normalizes the supplied data into
+	// the dataSpan's time period.
+	adjustment := (data.StartTimestampNanos - ds.startNanos) / ds.sampleNanos
+	rd := calibratedData{
+		InternalTimeSeriesData: data,
+		offsetAdjustment:       int32(adjustment),
+	}
+
+	// If all samples in the supplied data set are before calibrated offset 0,
+	// do not include it.
+	if rd.offsetAt(len(data.Samples)-1) < 0 {
+		return nil
+	}
+
+	// If the supplied data does not occur after all previously added data,
+	// return an error.
+	if len(ds.datas) > 0 {
+		last := ds.datas[len(ds.datas)-1]
+		if rd.offsetAt(0) <= last.offsetAt(len(last.Samples)-1) {
+			return util.Error("data must be added to dataSpan in chronological order")
+		}
+	}
+
+	ds.datas = append(ds.datas, rd)
+	return nil
+}
+
+// dataSpanIterator is used to iterate through the samples in a dataSpan.
+// Samples are spread across multiple InternalTimeSeriesData objects; this
+// iterator thus maintains a two-level index to point to a unique sample.
+type dataSpanIterator struct {
+	*dataSpan
+	offset    int32 // The calibrated offset of the current sample within the dataSpan
+	dataIdx   int   // Index of InternalTimeSeriesData which contains current Sample
+	sampleIdx int   // Index of current Sample within InternalTimeSeriesData
+	valid     bool  // True if this iterator points to a valid Sample
+}
+
+// sample returns the InternalTimeSeriesSample value currently pointed to by
+// this iterator.
+func (dsi *dataSpanIterator) sample() *proto.InternalTimeSeriesSample {
+	if !dsi.valid {
+		return nil
+	}
+	return dsi.datas[dsi.dataIdx].Samples[dsi.sampleIdx]
+}
+
+// advance moves the iterator to point to the next Sample.
+func (dsi *dataSpanIterator) advance() {
+	if !dsi.valid {
+		return
+	}
+	data := dsi.datas[dsi.dataIdx]
+	switch {
+	case dsi.sampleIdx+1 < len(data.Samples):
+		dsi.sampleIdx++
+	case dsi.dataIdx+1 < len(dsi.datas):
+		dsi.dataIdx++
+		data = dsi.datas[dsi.dataIdx]
+		dsi.sampleIdx = 0
+	default:
+		dsi.valid = false
+	}
+	dsi.offset = data.offsetAt(dsi.sampleIdx)
+}
+
+// interpolatingIterator is used to iterate over offsets within a dataSpan. The
+// iterator can provide sample values for any offset, even if there is no actual
+// sample in the dataSpan at that offset.
+//
+// Values for missing offsets are computed using linear interpolation from the
+// nearest real samples preceding and following the missing offset.
+type interpolatingIterator struct {
+	offset   int32            // Current offset within dataSpan
+	nextReal dataSpanIterator // Next sample with an offset >= iterator's offset
+	prevReal dataSpanIterator // Prev sample with offset < iterator's offset
+}
+
+// advanceTo advances the iterator to the supplied offset.
+func (ii *interpolatingIterator) advanceTo(offset int32) {
+	ii.offset = offset
+	// Advance real iterators until nextReal has offset >= the interpolated
+	// offset.
+	for ii.nextReal.valid && ii.nextReal.offset < ii.offset {
+		ii.prevReal = ii.nextReal
+		ii.nextReal.advance()
+	}
+}
+
+// isValid returns true if this interpolatingIterator still points to valid data.
+func (ii *interpolatingIterator) isValid() bool {
+	return ii.nextReal.valid
+}
+
+// avg returns the average value at the current offset for this iterator.
+func (ii *interpolatingIterator) avg() float64 {
+	if !ii.isValid() {
+		return 0
+	}
+	if ii.nextReal.offset == ii.offset {
+		return ii.nextReal.sample().Average()
+	}
+	// Cannot interpolate if previous value is invalid.
+	if !ii.prevReal.valid {
+		return 0
+	}
+
+	// Linear interpolation of value at the current offset.
+	off := float64(ii.offset)
+	nextAvg := ii.nextReal.sample().Average()
+	nextOff := float64(ii.nextReal.offset)
+	prevAvg := ii.prevReal.sample().Average()
+	prevOff := float64(ii.prevReal.offset)
+	return prevAvg + (nextAvg-prevAvg)*(off-prevOff)/(nextOff-prevOff)
+}
+
+// newIterator returns an interpolating iterator for the given dataSpan. The
+// iterator is initialized to offset 0.
+func (ds *dataSpan) newIterator() interpolatingIterator {
+	if len(ds.datas) == 0 {
+		return interpolatingIterator{}
+	}
+
+	// The first data index necessarily contains the positive offset closest to
+	// 0. Use a binary search to find the lowest positive offset (or the zero
+	// offset).
+	data := ds.datas[0]
+	innerIdx := sort.Search(len(data.Samples), func(i int) bool {
+		return data.offsetAt(i) >= 0
+	})
+
+	iterator := interpolatingIterator{
+		offset: 0,
+		nextReal: dataSpanIterator{
+			dataSpan:  ds,
+			dataIdx:   0,
+			sampleIdx: innerIdx,
+			offset:    data.offsetAt(innerIdx),
+			valid:     true,
+		},
+	}
+
+	// If innerIdx > 0, then we can compute a "previous" iterator as well; this
+	// will let us interpolate a 0 value if it is not actually present in the
+	// data.
+	if innerIdx > 0 {
+		iterator.prevReal = dataSpanIterator{
+			dataSpan:  ds,
+			dataIdx:   0,
+			sampleIdx: innerIdx - 1,
+			offset:    data.offsetAt(innerIdx - 1),
+			valid:     true,
+		}
+	}
+
+	return iterator
+}
+
+// A unionIterator jointly advances multiple interpolatingIterators, visiting
+// precisely those offsets for which at least one of the underlying
+// interpolating iterators has a real (that is, non-interpolated) value.
+//
+// All valid iterators in the set will have the same offset at all times. During
+// advancement, the next offset is chosen by finding the individual iterator
+// with the lowest value of nextReal.offset; in other words, the iteratorSet
+// will visit each possible offset in sequence, skipping offsets for which *no*
+// iterators have real data.  If even a single iterator has real data at an
+// offset, that offset will eventually be visited.
+//
+// In order to faciliate finding the lowest value of nextReal.offset, the set is
+// organized as a min heap using Go's heap package.
+type unionIterator []interpolatingIterator
+
+// Len returns the length of the iteratorSet; needed by heap.Interface.
+func (is unionIterator) Len() int {
+	return len(is)
+}
+
+// Swap swaps the values at the two given indices; needed by heap.Interface.
+func (is unionIterator) Swap(i, j int) {
+	is[i], is[j] = is[j], is[i]
+}
+
+// Less determines if the iterator at the first supplied index in the
+// iteratorSet is "Less" than the iterator at the second index; need by
+// heap.Interface.
+//
+// An iterator is less than another if its nextReal iterator points to an
+// earlier offset.
+func (is unionIterator) Less(i, j int) bool {
+	thisNext, otherNext := is[i].nextReal, is[j].nextReal
+	if !(thisNext.valid || otherNext.valid) {
+		return false
+	}
+	if !thisNext.valid {
+		return false
+	}
+	if !otherNext.valid {
+		return true
+	}
+	return thisNext.offset < otherNext.offset
+}
+
+// Push pushes an element into the iteratorSet heap; needed by heap.Interface
+func (is *unionIterator) Push(x interface{}) {
+	// Push and Pop use pointer receivers because they modify the slice's length,
+	// not just its contents.
+	*is = append(*is, x.(interpolatingIterator))
+}
+
+// Pop removes the minimum element from the iteratorSet heap; needed by
+// heap.Interface.
+func (is *unionIterator) Pop() interface{} {
+	old := *is
+	n := len(old)
+	x := old[n-1]
+	*is = old[0 : n-1]
+	return x
+}
+
+// isValid returns true if at least one iterator in the set is still valid. This
+// method only works if init() has already been called on the set.
+func (is unionIterator) isValid() bool {
+	return len(is) > 0 && is[0].isValid()
+}
+
+// init initializes the iteratorSet. This method moves all iterators to the
+// first offset for which *any* iterator in the set has real data.
+func (is unionIterator) init() {
+	heap.Init(&is)
+	if !is.isValid() {
+		return
+	}
+	if is[0].nextReal.offset > 0 {
+		is.advance()
+	}
+}
+
+// advance advances each iterator in the set to the next value for which *any*
+// interpolatingIterator has a real value.
+func (is unionIterator) advance() {
+	if !is.isValid() {
+		return
+	}
+
+	// All iterators in the set currently point to the same offset. Advancement
+	// begins by pre-advancing any iterators that have a real value for the
+	// current offset.
+	current := is[0].offset
+	for is[0].offset == current {
+		is[0].advanceTo(current + 1)
+		heap.Fix(&is, 0)
+	}
+
+	// It is possible that all iterators are now invalid.
+	if !is.isValid() {
+		return
+	}
+
+	// The iterator in position zero now has the lowest value for
+	// nextReal.offset - advance all iterators to that offset.
+	min := is[0].nextReal.offset
+	for i := range is {
+		is[i].advanceTo(min)
+	}
+	heap.Init(&is)
+}
+
+// timestamp returns a timestamp for the current offset of the iterators in this
+// set. Offsets are converted into timestamps before returning them as part of a
+// query result.
+func (is unionIterator) timestamp() int64 {
+	if !is.isValid() {
+		return 0
+	}
+	return is[0].nextReal.timestampForOffset(is[0].offset)
+}
+
+// sumAvg returns the sum of the averages of all iterators in the set. This is
+// the value returned for each datapoint in a query result.
+func (is unionIterator) sumAvg() float64 {
+	var sum float64
+	for i := range is {
+		sum += is[i].avg()
+	}
+	return sum
+}
+
+// Query returns data for the named time series during the supplied time span.
+// Data is returned as a series of consecutive data points.
+//
+// Data is queried only at the Resolution supplied: if data for the named time
+// series is not stored at the given resolution, an empty result will be
+// returned.
+//
+// All data stored on the server is downsampled to some degree; the data points
+// returned represent the average value within a sample period. Each datapoint's
+// timestamp falls in the middle of the sample period it represents.
+//
+// If data for a time series was collected from multiple sources, datapoints
+// will represent the sum across all sources at the same sample period. The
+// response will contain a list of all sources which were summed to produce the
+// result.
+func (db *DB) Query(name string, r Resolution, startNanos, endNanos int64) (
+	*proto.TimeSeriesQueryResult, error) {
+	// Normalize startNanos and endNanos the nearest SampleDuration boundary.
+	startNanos -= startNanos % r.SampleDuration()
+
+	// Based on the supplied timestamps and resolution, construct start and end
+	// keys for a scan that will return every key with data relevant to the
+	// query.
+	startKey := MakeDataKey(name, "" /* source */, r, startNanos)
+	endKey := MakeDataKey(name, "" /* source */, r, endNanos).PrefixEnd()
+	scan := client.Scan(startKey, endKey, 0)
+	if err := db.kv.Run(scan); err != nil {
+		return nil, err
+	}
+	scanResponse := scan.Reply.(*proto.ScanResponse)
+
+	// Construct a new dataSpan for each distinct source encountered in the
+	// query. Each dataspan will contain all data queried from the same source.
+	sourceSpans := make(map[string]*dataSpan)
+	for _, row := range scanResponse.Rows {
+		_, source, _, _ := DecodeDataKey(row.Key)
+		data, err := proto.InternalTimeSeriesDataFromValue(&row.Value)
+		if err != nil {
+			return nil, err
+		}
+
+		if _, ok := sourceSpans[source]; !ok {
+			sourceSpans[source] = &dataSpan{
+				startNanos:  startNanos,
+				sampleNanos: data.SampleDurationNanos,
+				datas:       make([]calibratedData, 0, 1),
+			}
+		}
+		if err := sourceSpans[source].addData(data); err != nil {
+			return nil, err
+		}
+	}
+
+	response := &proto.TimeSeriesQueryResult{
+		Name:    name,
+		Sources: make([]string, 0, len(sourceSpans)),
+	}
+
+	// Create an interpolatingIterator for each dataSpan.
+	iters := make(unionIterator, 0, len(sourceSpans))
+	for name, span := range sourceSpans {
+		response.Sources = append(response.Sources, name)
+		iters = append(iters, span.newIterator())
+	}
+
+	// Iterate through all values in the iteratorSet, adding a datapoint to
+	// the response for each value.
+	iters.init()
+	for iters.isValid() {
+		response.Datapoints = append(response.Datapoints, &proto.TimeSeriesDatapoint{
+			TimestampNanos: iters.timestamp(),
+			Value:          iters.sumAvg(),
+		})
+		iters.advance()
+	}
+
+	return response, nil
+}

--- a/ts/query_test.go
+++ b/ts/query_test.go
@@ -1,0 +1,296 @@
+// Copyright 2015 The Cockroach Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+// implied. See the License for the specific language governing
+// permissions and limitations under the License. See the AUTHORS file
+// for names of contributors.
+//
+// Author: Matt Tracy (matt@cockroachlabs.com)
+
+package ts
+
+import (
+	"reflect"
+	"sort"
+	"testing"
+
+	"github.com/cockroachdb/cockroach/proto"
+)
+
+var (
+	testSeries1 = []*proto.InternalTimeSeriesData{
+		{
+			StartTimestampNanos: 0,
+			SampleDurationNanos: 10,
+			Samples: []*proto.InternalTimeSeriesSample{
+				{
+					Offset: 0,
+					Count:  1,
+					Sum:    1,
+				},
+				{
+					Offset: 5,
+					Count:  1,
+					Sum:    5,
+				},
+				{
+					Offset: 7,
+					Count:  1,
+					Sum:    10,
+				},
+			},
+		},
+		{
+			StartTimestampNanos: 80,
+			SampleDurationNanos: 10,
+			Samples: []*proto.InternalTimeSeriesSample{
+				{
+					Offset: 1,
+					Count:  3,
+					Sum:    60,
+				},
+				{
+					Offset: 6,
+					Count:  2,
+					Sum:    80,
+				},
+			},
+		},
+	}
+	testSeries2 = []*proto.InternalTimeSeriesData{
+		{
+			StartTimestampNanos: 30,
+			SampleDurationNanos: 10,
+			Samples: []*proto.InternalTimeSeriesSample{
+				{
+					Offset: 0,
+					Count:  1,
+					Sum:    1,
+				},
+				{
+					Offset: 3,
+					Count:  5,
+					Sum:    50,
+				},
+				{
+					Offset: 4,
+					Count:  1,
+					Sum:    25,
+				},
+				{
+					Offset: 6,
+					Count:  3,
+					Sum:    60,
+				},
+				{
+					Offset: 15,
+					Count:  2,
+					Sum:    112,
+				},
+			},
+		},
+	}
+)
+
+// TestInterpolation verifies the interpolated average values of a single interpolatingIterator.
+func TestAvgInterpolation(t *testing.T) {
+	dataSpan := &dataSpan{
+		startNanos:  30,
+		sampleNanos: 10,
+	}
+	for _, data := range testSeries1 {
+		if err := dataSpan.addData(data); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	expected := []float64{3.4, 4.2, 5, 7.5, 10, 15, 20, 24, 28, 32, 36, 40, 0}
+	actual := make([]float64, 0, len(expected))
+	iter := dataSpan.newIterator()
+	for i := 0; i < len(expected); i++ {
+		iter.advanceTo(int32(i))
+		actual = append(actual, iter.avg())
+	}
+
+	if !reflect.DeepEqual(actual, expected) {
+		t.Fatalf("interpolated values: %v, expected values: %v", actual, expected)
+	}
+}
+
+// TestSumAvgInterpolation verifies the behavior of an iteratorSet, which
+// advances multiple interpolatingIterators together.
+func TestSumAvgInterpolation(t *testing.T) {
+	dataSpan1 := &dataSpan{
+		startNanos:  30,
+		sampleNanos: 10,
+	}
+	dataSpan2 := &dataSpan{
+		startNanos:  30,
+		sampleNanos: 10,
+	}
+	for _, data := range testSeries1 {
+		if err := dataSpan1.addData(data); err != nil {
+			t.Fatal(err)
+		}
+	}
+	for _, data := range testSeries2 {
+		if err := dataSpan2.addData(data); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	expected := []float64{4.4, 12, 17.5, 35, 40, 80, 56}
+	actual := make([]float64, 0, len(expected))
+	offsets := make([]int32, 0, len(expected))
+	iters := unionIterator{
+		dataSpan1.newIterator(),
+		dataSpan2.newIterator(),
+	}
+	iters.init()
+	for iters.isValid() {
+		actual = append(actual, iters.sumAvg())
+		offsets = append(offsets, iters[0].offset)
+		iters.advance()
+	}
+	if !reflect.DeepEqual(actual, expected) {
+		t.Fatalf("summed values: %v, expected values: %v", actual, expected)
+	}
+}
+
+// assertQuery generates a query result from the local test model and compares
+// it against the query returned from the server.
+func (tm *testModel) assertQuery(name string, r Resolution, start, end int64,
+	expectedDatapoints int, expectedSources int) {
+	// Query the actual server.
+	actual, err := tm.DB.Query(name, r, start, end)
+	if err != nil {
+		tm.t.Fatal(err)
+	}
+	if a, e := len(actual.Datapoints), expectedDatapoints; a != e {
+		tm.t.Fatalf("query expected %d datapoints, got %d", e, a)
+	}
+	if a, e := len(actual.Sources), expectedSources; a != e {
+		tm.t.Fatalf("query expected %d sources, got %d", e, a)
+	}
+
+	// Construct an expected result for comparison.
+	expected := proto.TimeSeriesQueryResult{
+		Name:    name,
+		Sources: make([]string, 0, 0),
+	}
+	dataSpans := make(map[string]*dataSpan)
+
+	// Iterate over all possible sources which may have data for this query.
+	for sourceName := range tm.seenSources {
+		// Iterate over all possible key times at which query data may be present.
+		for time := start - (start % r.KeyDuration()); time < end; time += r.KeyDuration() {
+			// Construct a key for this source/time and retrieve it from model.
+			key := MakeDataKey(name, sourceName, r, time)
+			value := tm.modelData[string(key)]
+			if value == nil {
+				continue
+			}
+
+			// Add data from the key to the correct dataSpan.
+			data, err := proto.InternalTimeSeriesDataFromValue(value)
+			if err != nil {
+				tm.t.Fatal(err)
+			}
+			ds, ok := dataSpans[sourceName]
+			if !ok {
+				ds = &dataSpan{
+					startNanos:  start - (start % r.SampleDuration()),
+					sampleNanos: r.SampleDuration(),
+				}
+				dataSpans[sourceName] = ds
+				expected.Sources = append(expected.Sources, sourceName)
+			}
+			if err := ds.addData(data); err != nil {
+				tm.t.Fatal(err)
+			}
+		}
+	}
+
+	// Iterate over data in all dataSpans and construct expected datapoints.
+	var iters unionIterator
+	for _, ds := range dataSpans {
+		iters = append(iters, ds.newIterator())
+	}
+	iters.init()
+	for iters.isValid() {
+		expected.Datapoints = append(expected.Datapoints, &proto.TimeSeriesDatapoint{
+			TimestampNanos: iters.timestamp(),
+			Value:          iters.sumAvg(),
+		})
+		iters.advance()
+	}
+
+	sort.Strings(expected.Sources)
+	sort.Strings(actual.Sources)
+	if !reflect.DeepEqual(actual, &expected) {
+		tm.t.Fatalf("actual time series: %v, expected: %v", actual, &expected)
+	}
+}
+
+// TestQuery validates that query results match the expectation of the test
+// model.
+func TestQuery(t *testing.T) {
+	tm := newTestModel(t)
+	tm.Start()
+	defer tm.Stop()
+
+	tm.storeTimeSeriesData(resolution1ns, []proto.TimeSeriesData{
+		{
+			Name: "test.metric",
+			Datapoints: []*proto.TimeSeriesDatapoint{
+				datapoint(1, 100),
+				datapoint(5, 200),
+				datapoint(15, 300),
+				datapoint(16, 400),
+				datapoint(17, 500),
+				datapoint(22, 600),
+				datapoint(52, 900),
+			},
+		},
+	})
+	tm.assertKeyCount(4)
+	tm.assertModelCorrect()
+	tm.assertQuery("test.metric", resolution1ns, 0, 60, 7, 1)
+
+	// Verify across multiple sources
+	tm.storeTimeSeriesData(resolution1ns, []proto.TimeSeriesData{
+		{
+			Name:   "test.multimetric",
+			Source: "source1",
+			Datapoints: []*proto.TimeSeriesDatapoint{
+				datapoint(1, 100),
+				datapoint(15, 300),
+				datapoint(17, 500),
+				datapoint(52, 900),
+			},
+		},
+		{
+			Name:   "test.multimetric",
+			Source: "source2",
+			Datapoints: []*proto.TimeSeriesDatapoint{
+				datapoint(5, 100),
+				datapoint(16, 300),
+				datapoint(22, 500),
+				datapoint(82, 900),
+			},
+		},
+	})
+
+	tm.assertKeyCount(11)
+	tm.assertModelCorrect()
+	tm.assertQuery("test.multimetric", resolution1ns, 0, 90, 8, 2)
+	tm.assertQuery("nodata", resolution1ns, 0, 90, 0, 0)
+}

--- a/ts/resolution.go
+++ b/ts/resolution.go
@@ -31,6 +31,9 @@ type Resolution int64
 const (
 	// Resolution10s stores data with a sample resolution of 10 seconds.
 	Resolution10s Resolution = 1
+	// resolution1ns stores data with a sample resolution of 1 nanosecond. Used
+	// only for testing.
+	resolution1ns Resolution = 999
 )
 
 // sampleDurationByResolution is a map used to retrieve the sample duration
@@ -38,6 +41,7 @@ const (
 // nanoseconds.
 var sampleDurationByResolution = map[Resolution]int64{
 	Resolution10s: int64(time.Second * 10),
+	resolution1ns: 1, // 1ns resolution only for tests.
 }
 
 // keyDurationByResolution is a map used to retrieve the key duration
@@ -46,6 +50,7 @@ var sampleDurationByResolution = map[Resolution]int64{
 // in nanoseconds.
 var keyDurationByResolution = map[Resolution]int64{
 	Resolution10s: int64(time.Hour),
+	resolution1ns: 10, // 1ns resolution only for tests.
 }
 
 // SampleDuration returns the sample duration corresponding to this resolution


### PR DESCRIPTION
Add the Query method to the Time Series DB objects, allowing data for a metric
to be queryied across an arbitrary timespan.

Data for a single metric may come from multiple sources; data from each source
is stored at a separate key. The query system returns the sum of datapoints from
all sources. This includes situations where data is "misaligned" due to clock
skew and data is thus missing from certain sources at certain sample offsets;
the query accounts for this by interpolating values for the missing samples.
