### PR TITLE
Do not block Store.Start while waiting for the first gossip.

### DIFF
--- a/storage/client_test.go
+++ b/storage/client_test.go
@@ -220,6 +220,7 @@ func (m *multiTestContext) addStore(t *testing.T) {
 	if err := store.Start(stopper); err != nil {
 		t.Fatal(err)
 	}
+	store.WaitForInit()
 	m.stores = append(m.stores, store)
 	if len(m.senders) == idx {
 		m.senders = append(m.senders, kv.NewLocalSender())

--- a/storage/range_test.go
+++ b/storage/range_test.go
@@ -163,6 +163,7 @@ func (tc *testContext) Start(t testing.TB) {
 		if err := tc.store.Start(tc.stopper); err != nil {
 			t.Fatal(err)
 		}
+		tc.store.WaitForInit()
 	}
 
 	initConfigs(tc.engine, t)

--- a/storage/store_test.go
+++ b/storage/store_test.go
@@ -158,6 +158,7 @@ func createTestStore(t *testing.T) (*Store, *hlc.ManualClock, *util.Stopper) {
 	if err := store.Start(stopper); err != nil {
 		t.Fatal(err)
 	}
+	store.WaitForInit()
 	return store, manual, stopper
 }
 


### PR DESCRIPTION
In tests related to removed replicas, the first gossip run will block
while attempting to acquire the lease until the range GC queue can
determine that the range has been removed.
