### PR TITLE
Call rangeScanner.RemoveRange from Store.RemoveRange

### DIFF
--- a/storage/store.go
+++ b/storage/store.go
@@ -1018,6 +1018,9 @@ func (s *Store) RemoveRange(rng *Range) error {
 		return util.Errorf("couldn't find range in rangesByKey slice")
 	}
 	s.rangesByKey = append(s.rangesByKey[:n], s.rangesByKey[n+1:]...)
+
+	s.scanner.RemoveRange(rng)
+
 	return nil
 }
 

--- a/storage/store_test.go
+++ b/storage/store_test.go
@@ -1327,3 +1327,46 @@ func TestRaftNodeID(t *testing.T) {
 		}()
 	}
 }
+
+// fakeRangeQueue implements the rangeQueue interface and
+// records which range is passed to MaybeRemove.
+type fakeRangeQueue struct {
+	maybeRemovedRngs chan *Range
+}
+
+func (fq *fakeRangeQueue) Start(clock *hlc.Clock, stopper *util.Stopper) {
+	// Do nothing
+}
+
+func (fq *fakeRangeQueue) MaybeAdd(rng *Range, t proto.Timestamp) {
+	// Do nothing
+}
+
+func (fq *fakeRangeQueue) MaybeRemove(rng *Range) {
+	fq.maybeRemovedRngs <- rng
+}
+
+// TestMaybeRemove tests that MaybeRemove is called when a range is removed.
+func TestMaybeRemove(t *testing.T) {
+	defer leaktest.AfterTest(t)
+	store, _, stopper := createTestStore(t)
+	defer stopper.Stop()
+
+	fq := &fakeRangeQueue{
+		maybeRemovedRngs: make(chan *Range),
+	}
+	store.scanner.AddQueues(fq)
+
+	rng, err := store.GetRange(1)
+	if err != nil {
+		t.Error(err)
+	}
+	if err := store.RemoveRange(rng); err != nil {
+		t.Error(err)
+	}
+	// MaybeRemove is called.
+	removedRng := <-fq.maybeRemovedRngs
+	if removedRng != rng {
+		t.Errorf("Unexpected removed range %v", removedRng)
+	}
+}


### PR DESCRIPTION
The comment in `rangeScanner` says "This method should be called by the Store when a range is removed (e.g. rebalanced or merged)."
