### PR TITLE
wait for store gossip at node start

### DIFF
--- a/examples/bank/bank.go
+++ b/examples/bank/bank.go
@@ -169,7 +169,7 @@ func (bank *Bank) continuousMoneyTransfer() {
 			if txn != nil {
 				txn.Prepare(client.Put(from, fromPut), client.Put(to, toPut))
 			} else {
-				bank.kvClient.Run(client.Put(from, fromPut), client.Put(to, toPut))
+				return bank.kvClient.Run(client.Put(from, fromPut), client.Put(to, toPut))
 			}
 			return nil
 		}

--- a/util/stopper.go
+++ b/util/stopper.go
@@ -133,8 +133,9 @@ func (s *Stopper) Stop() {
 	close(s.stopped)
 }
 
-// ShouldStop returns a channel which will be closed when Stop() has
-// been invoked. SetStopped() should be called to confirm.
+// ShouldStop returns a channel which will be closed when Stop() has been
+// invoked and outstanding tasks have drained. SetStopped() should be called
+// to confirm.
 func (s *Stopper) ShouldStop() <-chan struct{} {
 	if s == nil {
 		// A nil stopper will never signal ShouldStop, but will also never panic.


### PR DESCRIPTION
otherwise, things that check gossip keys may log some errors when starting a node. shouldn't actually cause harm, but it's good to avoid.
