### PR TITLE
Rename RawAddr to UnresolvedAddr and move Resolver to Util.

### DIFF
--- a/gossip/client.go
+++ b/gossip/client.go
@@ -41,7 +41,7 @@ const (
 func init() {
 	gob.Register(&net.TCPAddr{})
 	gob.Register(&net.UnixAddr{})
-	gob.Register(&util.RawAddr{})
+	gob.Register(&util.UnresolvedAddr{})
 }
 
 // client is a client-side RPC connection to a gossip peer node.

--- a/gossip/gossip.go
+++ b/gossip/gossip.go
@@ -95,7 +95,7 @@ const (
 
 var (
 	// TestBootstrap is the default gossip bootstrap used for running tests.
-	TestBootstrap = []Resolver{}
+	TestBootstrap = []util.Resolver{}
 )
 
 func init() {
@@ -121,12 +121,12 @@ type Gossip struct {
 	// resolvers is a list of resolvers used to determine
 	// bootstrap hosts for connecting to the gossip network.
 	resolverIdx int
-	resolvers   []Resolver
+	resolvers   []util.Resolver
 	triedAll    bool // True when all resolvers have been tried once
 }
 
 // New creates an instance of a gossip node.
-func New(rpcContext *rpc.Context, gossipInterval time.Duration, resolvers []Resolver) *Gossip {
+func New(rpcContext *rpc.Context, gossipInterval time.Duration, resolvers []util.Resolver) *Gossip {
 	g := &Gossip{
 		Connected:     make(chan struct{}),
 		RPCContext:    rpcContext,
@@ -172,7 +172,7 @@ func (g *Gossip) SetNodeDescriptor(desc *proto.NodeDescriptor) error {
 
 // SetResolvers initializes the set of gossip resolvers used to
 // find nodes to bootstrap the gossip network.
-func (g *Gossip) SetResolvers(resolvers []Resolver) {
+func (g *Gossip) SetResolvers(resolvers []util.Resolver) {
 	g.mu.Lock()
 	defer g.mu.Unlock()
 	g.resolverIdx = 0
@@ -195,7 +195,7 @@ func (g *Gossip) getNodeIDAddressLocked(nodeID proto.NodeID) (net.Addr, error) {
 	nodeIDKey := MakeNodeIDKey(nodeID)
 	if i := g.is.getInfo(nodeIDKey); i != nil {
 		if nd, ok := i.Val.(*proto.NodeDescriptor); ok {
-			return util.MakeRawAddr(nd.Address.Network, nd.Address.Address), nil
+			return util.MakeUnresolvedAddr(nd.Address.Network, nd.Address.Address), nil
 		}
 		return nil, util.Errorf("error in node descriptor gossip: %+v", i.Val)
 	}

--- a/gossip/gossip_test.go
+++ b/gossip/gossip_test.go
@@ -24,6 +24,7 @@ import (
 
 	"github.com/cockroachdb/cockroach/rpc"
 	"github.com/cockroachdb/cockroach/security"
+	"github.com/cockroachdb/cockroach/util"
 	"github.com/cockroachdb/cockroach/util/hlc"
 )
 
@@ -148,9 +149,9 @@ func TestGossipGetNextBootstrapAddress(t *testing.T) {
 		"lb=127.0.0.1:9005",
 	}
 
-	resolvers := []Resolver{}
+	resolvers := []util.Resolver{}
 	for _, rs := range resolverSpecs {
-		resolver, err := NewResolver(rs)
+		resolver, err := util.NewResolver(rs)
 		if err == nil {
 			resolvers = append(resolvers, resolver)
 		}

--- a/gossip/simulation/network.go
+++ b/gossip/simulation/network.go
@@ -80,9 +80,9 @@ func NewNetwork(nodeCount int, networkType string,
 
 	for i, leftNode := range nodes {
 		// Build new resolvers for each instance or we'll get data races.
-		var resolvers []gossip.Resolver
+		var resolvers []util.Resolver
 		for _, rightNode := range nodes[:numResolvers] {
-			resolvers = append(resolvers, gossip.NewResolverFromAddress(rightNode.Server.Addr()))
+			resolvers = append(resolvers, util.NewResolverFromAddress(rightNode.Server.Addr()))
 		}
 
 		gossipNode := gossip.New(rpcContext, gossipInterval, resolvers)

--- a/kv/dist_sender_test.go
+++ b/kv/dist_sender_test.go
@@ -50,7 +50,7 @@ var testRangeDescriptor = proto.RangeDescriptor{
 	},
 }
 
-var testAddress = util.MakeRawAddr("tcp", "node1:8080")
+var testAddress = util.MakeUnresolvedAddr("tcp", "node1:8080")
 
 func makeTestGossip(t *testing.T) *gossip.Gossip {
 	n := simulation.NewNetwork(1, "unix", gossip.TestInterval)
@@ -220,7 +220,7 @@ func TestSendRPCOrder(t *testing.T) {
 			Replicas: nil,
 		}
 		for i := int32(1); i <= 5; i++ {
-			addr := util.MakeRawAddr("tcp", fmt.Sprintf("node%d", i))
+			addr := util.MakeUnresolvedAddr("tcp", fmt.Sprintf("node%d", i))
 			addrToNode[addr.String()] = i
 			nd := &proto.NodeDescriptor{
 				NodeID: proto.NodeID(i),

--- a/rpc/server.go
+++ b/rpc/server.go
@@ -176,7 +176,7 @@ func updatedAddr(oldAddr, newAddr net.Addr) (net.Addr, error) {
 			log.Warningf("asked for port %s, got %s", oldPort, newPort)
 		}
 
-		return util.MakeRawAddr("tcp", net.JoinHostPort(host, newPort)), nil
+		return util.MakeUnresolvedAddr("tcp", net.JoinHostPort(host, newPort)), nil
 
 	case "unix":
 		if oldAddr.String() != newAddr.String() {

--- a/rpc/server_test.go
+++ b/rpc/server_test.go
@@ -24,9 +24,9 @@ import (
 )
 
 func checkUpdateMatches(t *testing.T, network, oldAddrString, newAddrString, expAddrString string) {
-	oldAddr := util.MakeRawAddr(network, oldAddrString)
-	newAddr := util.MakeRawAddr(network, newAddrString)
-	expAddr := util.MakeRawAddr(network, expAddrString)
+	oldAddr := util.MakeUnresolvedAddr(network, oldAddrString)
+	newAddr := util.MakeUnresolvedAddr(network, newAddrString)
+	expAddr := util.MakeUnresolvedAddr(network, expAddrString)
 
 	retAddr, err := updatedAddr(oldAddr, newAddr)
 	if err != nil {
@@ -39,8 +39,8 @@ func checkUpdateMatches(t *testing.T, network, oldAddrString, newAddrString, exp
 }
 
 func checkUpdateFails(t *testing.T, network, oldAddrString, newAddrString string) {
-	oldAddr := util.MakeRawAddr(network, oldAddrString)
-	newAddr := util.MakeRawAddr(network, newAddrString)
+	oldAddr := util.MakeUnresolvedAddr(network, oldAddrString)
+	newAddr := util.MakeUnresolvedAddr(network, newAddrString)
 
 	retAddr, err := updatedAddr(oldAddr, newAddr)
 	if err == nil {

--- a/server/context.go
+++ b/server/context.go
@@ -26,7 +26,6 @@ import (
 	"time"
 
 	"github.com/cockroachdb/cockroach/base"
-	"github.com/cockroachdb/cockroach/gossip"
 	"github.com/cockroachdb/cockroach/proto"
 	"github.com/cockroachdb/cockroach/storage/engine"
 	"github.com/cockroachdb/cockroach/util"
@@ -105,7 +104,7 @@ type Context struct {
 
 	// GossipBootstrapResolvers is a list of gossip resolvers used
 	// to find bootstrap nodes for connecting to the gossip network.
-	GossipBootstrapResolvers []gossip.Resolver
+	GossipBootstrapResolvers []util.Resolver
 
 	// ScanInterval determines a duration during which each range should be
 	// visited approximately once by the range scanner.
@@ -197,8 +196,8 @@ func (ctx *Context) initEngine(attrsStr, path string) (engine.Engine, error) {
 
 // parseGossipBootstrapResolvers parses a comma-separated list of
 // gossip bootstrap resolvers.
-func (ctx *Context) parseGossipBootstrapResolvers() ([]gossip.Resolver, error) {
-	var bootstrapResolvers []gossip.Resolver
+func (ctx *Context) parseGossipBootstrapResolvers() ([]util.Resolver, error) {
+	var bootstrapResolvers []util.Resolver
 	addresses := strings.Split(ctx.GossipBootstrap, ",")
 	for _, address := range addresses {
 		if len(address) == 0 {
@@ -211,7 +210,7 @@ func (ctx *Context) parseGossipBootstrapResolvers() ([]gossip.Resolver, error) {
 		if strings.HasPrefix(address, "self://") {
 			address = util.EnsureHost(ctx.Addr)
 		}
-		resolver, err := gossip.NewResolver(address)
+		resolver, err := util.NewResolver(address)
 		if err != nil {
 			return nil, err
 		}

--- a/server/context_test.go
+++ b/server/context_test.go
@@ -21,7 +21,7 @@ import (
 	"reflect"
 	"testing"
 
-	"github.com/cockroachdb/cockroach/gossip"
+	"github.com/cockroachdb/cockroach/util"
 )
 
 func TestParseNodeAttributes(t *testing.T) {
@@ -47,15 +47,15 @@ func TestParseGossipBootstrapAddrs(t *testing.T) {
 	if err := ctx.Init("start"); err != nil {
 		t.Fatalf("Failed to initialize the context: %v", err)
 	}
-	r1, err := gossip.NewResolver("tcp=localhost:12345")
+	r1, err := util.NewResolver("tcp=localhost:12345")
 	if err != nil {
 		t.Fatal(err)
 	}
-	r2, err := gossip.NewResolver("tcp=localhost:23456")
+	r2, err := util.NewResolver("tcp=localhost:23456")
 	if err != nil {
 		t.Fatal(err)
 	}
-	expected := []gossip.Resolver{r1, r2}
+	expected := []util.Resolver{r1, r2}
 	if !reflect.DeepEqual(ctx.GossipBootstrapResolvers, expected) {
 		t.Fatalf("Unexpected bootstrap addresses: %v, expected: %v", ctx.GossipBootstrapResolvers, expected)
 	}

--- a/server/node_test.go
+++ b/server/node_test.go
@@ -69,7 +69,7 @@ func createTestNode(addr net.Addr, engines []engine.Engine, gossipBS net.Addr, t
 		if gossipBS == addr {
 			gossipBS = rpcServer.Addr()
 		}
-		g.SetResolvers([]gossip.Resolver{gossip.NewResolverFromAddress(gossipBS)})
+		g.SetResolvers([]util.Resolver{util.NewResolverFromAddress(gossipBS)})
 		g.Start(rpcServer, stopper)
 	}
 	ctx.Gossip = g

--- a/server/server.go
+++ b/server/server.go
@@ -103,7 +103,7 @@ func NewServer(ctx *Context, stopper *util.Stopper) (*Server, error) {
 	rpcContext := rpc.NewContext(s.clock, tlsConfig, stopper)
 	go rpcContext.RemoteClocks.MonitorRemoteOffsets()
 
-	s.rpc = rpc.NewServer(util.MakeRawAddr("tcp", addr), rpcContext)
+	s.rpc = rpc.NewServer(util.MakeUnresolvedAddr("tcp", addr), rpcContext)
 	s.stopper.AddCloser(s.rpc)
 	s.gossip = gossip.New(rpcContext, s.ctx.GossipInterval, s.ctx.GossipBootstrapResolvers)
 
@@ -156,11 +156,11 @@ func (s *Server) Start(selfBootstrap bool) error {
 
 	// Handle self-bootstrapping case for a single node.
 	if selfBootstrap {
-		selfResolver, err := gossip.NewResolver(s.rpc.Addr().String())
+		selfResolver, err := util.NewResolver(s.rpc.Addr().String())
 		if err != nil {
 			return err
 		}
-		s.gossip.SetResolvers([]gossip.Resolver{selfResolver})
+		s.gossip.SetResolvers([]util.Resolver{selfResolver})
 	}
 	s.gossip.Start(s.rpc, s.stopper)
 

--- a/util/resolver.go
+++ b/util/resolver.go
@@ -15,13 +15,12 @@
 //
 // Author: Marc Berhault (marc@cockroachlabs.com)
 
-package gossip
+package util
 
 import (
 	"net"
 	"strings"
 
-	"github.com/cockroachdb/cockroach/util"
 	"github.com/cockroachdb/cockroach/util/log"
 )
 
@@ -68,9 +67,9 @@ func (sr *socketResolver) GetAddress() (net.Addr, error) {
 			// "tcp" resolvers point to a single host. "lb" have an unknown of number of backends.
 			sr.exhausted = true
 		}
-		return util.MakeRawAddr("tcp", sr.addr), nil
+		return MakeUnresolvedAddr("tcp", sr.addr), nil
 	}
-	return nil, util.Errorf("unknown address type: %q", sr.typ)
+	return nil, Errorf("unknown address type: %q", sr.typ)
 }
 
 // IsExhausted returns whether the resolver can yield further
@@ -101,23 +100,23 @@ func NewResolver(spec string) (Resolver, error) {
 		typ = strings.TrimSpace(parts[0])
 		addr = strings.TrimSpace(parts[1])
 	} else {
-		return nil, util.Errorf("unable to parse gossip resolver spec: %q", spec)
+		return nil, Errorf("unable to parse gossip resolver spec: %q", spec)
 	}
 
 	// We should not have an empty address at this point.
 	if len(addr) == 0 {
-		return nil, util.Errorf("invalid address value in gossip resolver spec: %q", spec)
+		return nil, Errorf("invalid address value in gossip resolver spec: %q", spec)
 	}
 
 	// Validate the type.
 	if _, ok := validTypes[typ]; !ok {
-		return nil, util.Errorf("unknown address type in gossip resolver spec: %q, "+
+		return nil, Errorf("unknown address type in gossip resolver spec: %q, "+
 			"valid types are %s", spec, validTypes)
 	}
 
 	// If we're on tcp or lb make sure we fill in the host when not specified (eg: ":8080")
 	if typ == "tcp" || typ == "lb" {
-		addr = util.EnsureHost(addr)
+		addr = EnsureHost(addr)
 	}
 
 	return &socketResolver{typ: typ, addr: addr}, nil

--- a/util/resolver_test.go
+++ b/util/resolver_test.go
@@ -15,12 +15,10 @@
 //
 // Author: Marc Berhault (marc@cockroachlabs.com)
 
-package gossip
+package util
 
 import (
 	"testing"
-
-	"github.com/cockroachdb/cockroach/util"
 )
 
 func TestParseResolverSpec(t *testing.T) {
@@ -32,7 +30,7 @@ func TestParseResolverSpec(t *testing.T) {
 	}{
 		// Ports are not checked at parsing time. They are at GetAddress time though.
 		{"127.0.0.1:8080", true, "tcp", "127.0.0.1:8080"},
-		{":8080", true, "tcp", util.EnsureHost(":8080")},
+		{":8080", true, "tcp", EnsureHost(":8080")},
 		{"127.0.0.1", true, "tcp", "127.0.0.1"},
 		{"tcp=127.0.0.1", true, "tcp", "127.0.0.1"},
 		{"lb=127.0.0.1", true, "lb", "127.0.0.1"},

--- a/util/unresolved_addr.go
+++ b/util/unresolved_addr.go
@@ -15,19 +15,32 @@
 //
 // Author: jqmp (jaqueramaphan@gmail.com)
 
+// TODO(jqmp): Needs testing.
+
 package util
 
-import "testing"
+// UnresolvedAddr is an unresolved version of net.Addr.
+type UnresolvedAddr struct {
+	// These fields are only exported so that gob can see them.
+	NetworkField string
+	StringField  string
+}
 
-func TestRawAddr(t *testing.T) {
-	network := "tcp"
-	str := "host:1234"
-	addr := MakeRawAddr(network, str)
+// MakeUnresolvedAddr creates a new UnresolvedAddr from a network
+// and raw address string.
+func MakeUnresolvedAddr(network string, str string) UnresolvedAddr {
+	return UnresolvedAddr{
+		NetworkField: network,
+		StringField:  str,
+	}
+}
 
-	if addr.Network() != network {
-		t.Errorf("Expected addr.Network() to be %s; got %s", network, addr.Network())
-	}
-	if addr.String() != str {
-		t.Errorf("Expected addr.String() to be %s; got %s", str, addr.String())
-	}
+// Network returns the address's network name.
+func (a UnresolvedAddr) Network() string {
+	return a.NetworkField
+}
+
+// String returns the address's string form.
+func (a UnresolvedAddr) String() string {
+	return a.StringField
 }

--- a/util/unresolved_addr_test.go
+++ b/util/unresolved_addr_test.go
@@ -15,28 +15,19 @@
 //
 // Author: jqmp (jaqueramaphan@gmail.com)
 
-// TODO(jqmp): Needs testing.
-
 package util
 
-// RawAddr is a super-simple implementation of net.Addr.
-type RawAddr struct {
-	// These fields are only exported so that gob can see them.
-	NetworkField string
-	StringField  string
-}
+import "testing"
 
-// MakeRawAddr creates a new RawAddr from a network and raw address string.
-func MakeRawAddr(network string, str string) RawAddr {
-	return RawAddr{NetworkField: network, StringField: str}
-}
+func TestUnresolvedAddr(t *testing.T) {
+	network := "tcp"
+	str := "host:1234"
+	addr := MakeUnresolvedAddr(network, str)
 
-// Network returns the address's network name.
-func (a RawAddr) Network() string {
-	return a.NetworkField
-}
-
-// String returns the address's string form.
-func (a RawAddr) String() string {
-	return a.StringField
+	if addr.Network() != network {
+		t.Errorf("Expected addr.Network() to be %s; got %s", network, addr.Network())
+	}
+	if addr.String() != str {
+		t.Errorf("Expected addr.String() to be %s; got %s", str, addr.String())
+	}
 }


### PR DESCRIPTION
1) RawAddr was a poorly chosen name, and unresolvedAddr seems like a better choice as it explains what it is.  If you can think of a better one, let me know.
2) Secondly, moved Resolver into utils.  There's no need for it to be stuck in the gossip package as it should be useful outside of it.

I want to actually combine the two at some point, but I'll save that for another PR.
