### PR TITLE
Convert various uses of client.KV to client.DB.

### DIFF
--- a/client/kv.go
+++ b/client/kv.go
@@ -88,6 +88,14 @@ func NewKV(ctx *Context, sender KVSender) *KV {
 	}
 }
 
+// NewDB returns a new database handle using KV for the underlying
+// communication.
+//
+// TODO(pmattis): Remove once we plumb usage of DB everywhere.
+func (kv *KV) NewDB() *DB {
+	return &DB{kv: kv}
+}
+
 // Run runs the specified calls synchronously in a single batch and
 // returns any errors.
 func (kv *KV) Run(calls ...Call) (err error) {

--- a/server/node_test.go
+++ b/server/node_test.go
@@ -75,6 +75,7 @@ func createTestNode(addr net.Addr, engines []engine.Engine, gossipBS net.Addr, t
 	ctx.Gossip = g
 	ctx.DB = client.NewKV(nil,
 		kv.NewDistSender(&kv.DistSenderContext{Clock: ctx.Clock}, g))
+	ctx.DB.User = storage.UserRoot
 	// TODO(bdarnell): arrange to have the transport closed.
 	ctx.Transport = multiraft.NewLocalRPCTransport()
 	ctx.EventFeed = &util.Feed{}


### PR DESCRIPTION
First step in moving the codebase from using client.KV to
client.DB. Added client.Batch.InternalAddCall to handle sending requests
which are not supported in the client.DB interface. Added a temporary
client.KV.NewDB method to create a client.DB from a client.KV.
