### PR TITLE
Adjust the client error API.

### DIFF
--- a/client/db_test.go
+++ b/client/db_test.go
@@ -38,9 +38,9 @@ func ExampleDB_Get() {
 	s, db := setup()
 	defer s.Stop()
 
-	result := db.Get("aa")
-	if result.Err != nil {
-		panic(result.Err)
+	result, err := db.Get("aa")
+	if err != nil {
+		panic(err)
 	}
 	fmt.Printf("aa=%s\n", result.Rows[0].ValueBytes())
 
@@ -52,13 +52,12 @@ func ExampleDB_Put() {
 	s, db := setup()
 	defer s.Stop()
 
-	result := db.Put("aa", "1")
-	if result.Err != nil {
-		panic(result.Err)
+	if _, err := db.Put("aa", "1"); err != nil {
+		panic(err)
 	}
-	result = db.Get("aa")
-	if result.Err != nil {
-		panic(result.Err)
+	result, err := db.Get("aa")
+	if err != nil {
+		panic(err)
 	}
 	fmt.Printf("aa=%s\n", result.Rows[0].ValueBytes())
 
@@ -70,46 +69,41 @@ func ExampleDB_CPut() {
 	s, db := setup()
 	defer s.Stop()
 
-	result := db.Put("aa", "1")
-	if result.Err != nil {
-		panic(result.Err)
+	if _, err := db.Put("aa", "1"); err != nil {
+		panic(err)
 	}
-	result = db.CPut("aa", "2", "1")
-	if result.Err != nil {
-		panic(result.Err)
+	if _, err := db.CPut("aa", "2", "1"); err != nil {
+		panic(err)
 	}
-	result = db.Get("aa")
-	if result.Err != nil {
-		panic(result.Err)
+	result, err := db.Get("aa")
+	if err != nil {
+		panic(err)
 	}
 	fmt.Printf("aa=%s\n", result.Rows[0].ValueBytes())
 
-	result = db.CPut("aa", "3", "1")
-	if result.Err == nil {
+	if _, err = db.CPut("aa", "3", "1"); err == nil {
 		panic("expected error from conditional put")
 	}
-	result = db.Get("aa")
-	if result.Err != nil {
-		panic(result.Err)
+	result, err = db.Get("aa")
+	if err != nil {
+		panic(err)
 	}
 	fmt.Printf("aa=%s\n", result.Rows[0].ValueBytes())
 
-	result = db.CPut("bb", "4", "1")
-	if result.Err == nil {
+	if _, err = db.CPut("bb", "4", "1"); err == nil {
 		panic("expected error from conditional put")
 	}
-	result = db.Get("bb")
-	if result.Err != nil {
-		panic(result.Err)
+	result, err = db.Get("bb")
+	if err != nil {
+		panic(err)
 	}
 	fmt.Printf("bb=%s\n", result.Rows[0].ValueBytes())
-	result = db.CPut("bb", "4", nil)
-	if result.Err != nil {
-		panic(result.Err)
+	if _, err = db.CPut("bb", "4", nil); err != nil {
+		panic(err)
 	}
-	result = db.Get("bb")
-	if result.Err != nil {
-		panic(result.Err)
+	result, err = db.Get("bb")
+	if err != nil {
+		panic(err)
 	}
 	fmt.Printf("bb=%s\n", result.Rows[0].ValueBytes())
 
@@ -124,13 +118,12 @@ func ExampleDB_Inc() {
 	s, db := setup()
 	defer s.Stop()
 
-	result := db.Inc("aa", 100)
-	if result.Err != nil {
-		panic(result.Err)
+	if _, err := db.Inc("aa", 100); err != nil {
+		panic(err)
 	}
-	result = db.Get("aa")
-	if result.Err != nil {
-		panic(result.Err)
+	result, err := db.Get("aa")
+	if err != nil {
+		panic(err)
 	}
 	fmt.Printf("aa=%d\n", result.Rows[0].ValueInt())
 
@@ -143,8 +136,7 @@ func ExampleBatch() {
 	defer s.Stop()
 
 	b := db.B.Get("aa").Put("bb", "2")
-	err := db.Run(b)
-	if err != nil {
+	if err := db.Run(b); err != nil {
 		panic(err)
 	}
 	for _, result := range b.Results {
@@ -163,13 +155,12 @@ func ExampleDB_Scan() {
 	defer s.Stop()
 
 	b := db.B.Put("aa", "1").Put("ab", "2").Put("bb", "3")
-	err := db.Run(b)
-	if err != nil {
+	if err := db.Run(b); err != nil {
 		panic(err)
 	}
-	result := db.Scan("a", "b", 100)
-	if result.Err != nil {
-		panic(result.Err)
+	result, err := db.Scan("a", "b", 100)
+	if err != nil {
+		panic(err)
 	}
 	for i, row := range result.Rows {
 		fmt.Printf("%d: %s=%s\n", i, row.Key, row.ValueBytes())
@@ -184,17 +175,15 @@ func ExampleDB_Del() {
 	s, db := setup()
 	defer s.Stop()
 
-	err := db.Run(db.B.Put("aa", "1").Put("ab", "2").Put("ac", "3"))
-	if err != nil {
+	if err := db.Run(db.B.Put("aa", "1").Put("ab", "2").Put("ac", "3")); err != nil {
 		panic(err)
 	}
-	result := db.Del("ab")
-	if result.Err != nil {
-		panic(result.Err)
+	if _, err := db.Del("ab"); err != nil {
+		panic(err)
 	}
-	result = db.Scan("a", "b", 100)
-	if result.Err != nil {
-		panic(result.Err)
+	result, err := db.Scan("a", "b", 100)
+	if err != nil {
+		panic(err)
 	}
 	for i, row := range result.Rows {
 		fmt.Printf("%d: %s=%s\n", i, row.Key, row.ValueBytes())
@@ -216,9 +205,9 @@ func ExampleTx_Commit() {
 		panic(err)
 	}
 
-	result := db.Get("aa", "ab")
-	if result.Err != nil {
-		panic(result.Err)
+	result, err := db.Get("aa", "ab")
+	if err != nil {
+		panic(err)
 	}
 	for i, row := range result.Rows {
 		fmt.Printf("%d: %s=%s\n", i, row.Key, row.ValueBytes())

--- a/server/cli/kv.go
+++ b/server/cli/kv.go
@@ -69,9 +69,9 @@ func runGet(cmd *cobra.Command, args []string) {
 		return
 	}
 	key := proto.Key(args[0])
-	r := kvDB.Get(key)
-	if r.Err != nil {
-		fmt.Fprintf(osStderr, "get failed: %s\n", r.Err)
+	r, err := kvDB.Get(key)
+	if err != nil {
+		fmt.Fprintf(osStderr, "get failed: %s\n", err)
 		osExit(1)
 		return
 	}
@@ -173,8 +173,8 @@ func runInc(cmd *cobra.Command, args []string) {
 	}
 
 	key := args[0]
-	if r := kvDB.Inc(key, int64(amount)); r.Err != nil {
-		fmt.Fprintf(osStderr, "increment failed: %s\n", r.Err)
+	if r, err := kvDB.Inc(key, int64(amount)); err != nil {
+		fmt.Fprintf(osStderr, "increment failed: %s\n", err)
 		osExit(1)
 	} else {
 		fmt.Printf("%d\n", r.Rows[0].ValueInt())
@@ -268,9 +268,9 @@ func runScan(cmd *cobra.Command, args []string) {
 		return
 	}
 	// TODO(pmattis): Add a flag for the number of results to scan.
-	r := kvDB.Scan(startKey, endKey, 1000)
-	if r.Err != nil {
-		fmt.Fprintf(osStderr, "scan failed: %s\n", r.Err)
+	r, err := kvDB.Scan(startKey, endKey, 1000)
+	if err != nil {
+		fmt.Fprintf(osStderr, "scan failed: %s\n", err)
 		osExit(1)
 		return
 	}

--- a/server/cli/range.go
+++ b/server/cli/range.go
@@ -55,9 +55,9 @@ func runLsRanges(cmd *cobra.Command, args []string) {
 	if kvDB == nil {
 		return
 	}
-	r := kvDB.Scan(startKey, engine.KeyMeta2Prefix.PrefixEnd(), 1000)
-	if r.Err != nil {
-		fmt.Fprintf(os.Stderr, "scan failed: %s\n", r.Err)
+	r, err := kvDB.Scan(startKey, engine.KeyMeta2Prefix.PrefixEnd(), 1000)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "scan failed: %s\n", err)
 		osExit(1)
 		return
 	}
@@ -104,8 +104,8 @@ func runSplitRange(cmd *cobra.Command, args []string) {
 	if kvDB == nil {
 		return
 	}
-	if r := kvDB.AdminSplit(key, splitKey); r.Err != nil {
-		fmt.Fprintf(os.Stderr, "split failed: %s\n", r.Err)
+	if _, err := kvDB.AdminSplit(key, splitKey); err != nil {
+		fmt.Fprintf(os.Stderr, "split failed: %s\n", err)
 		osExit(1)
 	}
 }
@@ -130,8 +130,8 @@ func runMergeRange(cmd *cobra.Command, args []string) {
 	if kvDB == nil {
 		return
 	}
-	if r := kvDB.AdminMerge(args[0]); r.Err != nil {
-		fmt.Fprintf(os.Stderr, "merge failed: %s\n", r.Err)
+	if _, err := kvDB.AdminMerge(args[0]); err != nil {
+		fmt.Fprintf(os.Stderr, "merge failed: %s\n", err)
 		osExit(1)
 	}
 }

--- a/server/node.go
+++ b/server/node.go
@@ -75,9 +75,9 @@ type nodeServer Node
 // allocateNodeID increments the node id generator key to allocate
 // a new, unique node id.
 func allocateNodeID(db *client.DB) (proto.NodeID, error) {
-	r := db.Inc(engine.KeyNodeIDGenerator, 1)
-	if r.Err != nil {
-		return 0, util.Errorf("unable to allocate node ID: %s", r.Err)
+	r, err := db.Inc(engine.KeyNodeIDGenerator, 1)
+	if err != nil {
+		return 0, util.Errorf("unable to allocate node ID: %s", err)
 	}
 	return proto.NodeID(r.Rows[0].ValueInt()), nil
 }
@@ -86,9 +86,9 @@ func allocateNodeID(db *client.DB) (proto.NodeID, error) {
 // specified node to allocate "inc" new, unique store ids. The
 // first ID in a contiguous range is returned on success.
 func allocateStoreIDs(nodeID proto.NodeID, inc int64, db *client.DB) (proto.StoreID, error) {
-	r := db.Inc(engine.KeyStoreIDGenerator, inc)
-	if r.Err != nil {
-		return 0, util.Errorf("unable to allocate %d store IDs for node %d: %s", inc, nodeID, r.Err)
+	r, err := db.Inc(engine.KeyStoreIDGenerator, inc)
+	if err != nil {
+		return 0, util.Errorf("unable to allocate %d store IDs for node %d: %s", inc, nodeID, err)
 	}
 	return proto.StoreID(r.Rows[0].ValueInt() - inc + 1), nil
 }

--- a/storage/id_alloc.go
+++ b/storage/id_alloc.go
@@ -107,10 +107,10 @@ func (ia *IDAllocator) allocateBlock(incr int64) {
 	retryOpts := IDAllocationRetryOpts
 	err := util.RetryWithBackoff(retryOpts, func() (util.RetryStatus, error) {
 		idKey := ia.idKey.Load().(proto.Key)
-		r := ia.db.Inc(idKey, incr)
-		if r.Err != nil {
-			log.Warningf("unable to allocate %d ids from %s: %s", incr, idKey, r.Err)
-			return util.RetryContinue, r.Err
+		r, err := ia.db.Inc(idKey, incr)
+		if err != nil {
+			log.Warningf("unable to allocate %d ids from %s: %s", incr, idKey, err)
+			return util.RetryContinue, err
 		}
 		newValue = r.Rows[0].ValueInt()
 		return util.RetryBreak, nil

--- a/storage/split_queue.go
+++ b/storage/split_queue.go
@@ -89,8 +89,8 @@ func (sq *splitQueue) process(now proto.Timestamp, rng *Range) error {
 	if len(splitKeys) > 0 {
 		log.Infof("splitting range %q-%q at keys %v", rng.Desc().StartKey, rng.Desc().EndKey, splitKeys)
 		for _, splitKey := range splitKeys {
-			if r := sq.db.AdminSplit(splitKey, splitKey); r.Err != nil {
-				return util.Errorf("unable to split at key %q: %s", splitKey, r.Err)
+			if _, err := sq.db.AdminSplit(splitKey, splitKey); err != nil {
+				return util.Errorf("unable to split at key %q: %s", splitKey, err)
 			}
 		}
 		return nil

--- a/storage/store.go
+++ b/storage/store.go
@@ -1408,9 +1408,9 @@ func (s *Store) GetStatus() (*proto.StoreStatus, error) {
 		return nil, nil
 	}
 	key := engine.StoreStatusKey(int32(s.Ident.StoreID))
-	r := s.kvDB.Get(key)
-	if r.Err != nil {
-		return nil, r.Err
+	r, err := s.kvDB.Get(key)
+	if err != nil {
+		return nil, err
 	}
 	status := &proto.StoreStatus{}
 	if err := r.Rows[0].ValueProto(status); err != nil {
@@ -1445,8 +1445,8 @@ func (s *Store) updateStoreStatus() {
 		Stats:      proto.MVCCStats(scannerStats.MVCC),
 	}
 	key := engine.StoreStatusKey(int32(s.Ident.StoreID))
-	if r := s.kvDB.Put(key, status); r.Err != nil {
-		log.Error(r.Err)
+	if _, err := s.kvDB.Put(key, status); err != nil {
+		log.Error(err)
 	}
 }
 


### PR DESCRIPTION
The various DB and Tx methods now return (Result, error). Running a
batch returns the error of the first result in the batch containing an
error. Result no longer implements the error interface. These changes
make it harder to ignore errors.
