### PR TITLE
fix up coalesced heartbeats

### DIFF
--- a/multiraft/transport.go
+++ b/multiraft/transport.go
@@ -42,8 +42,8 @@ type Transport interface {
 	// Stop undoes a previous Listen.
 	Stop(id NodeID)
 
-	// Send a message to the given node.
-	Send(id NodeID, req *RaftMessageRequest) error
+	// Send a message to the node specified in the request's To field.
+	Send(req *RaftMessageRequest) error
 
 	// Close all associated connections.
 	Close()
@@ -179,8 +179,8 @@ func (lt *localRPCTransport) getClient(id NodeID) (*rpc.Client, error) {
 	return client, err
 }
 
-func (lt *localRPCTransport) Send(id NodeID, req *RaftMessageRequest) error {
-	client, err := lt.getClient(id)
+func (lt *localRPCTransport) Send(req *RaftMessageRequest) error {
+	client, err := lt.getClient(NodeID(req.Message.To))
 	if err != nil {
 		return err
 	}

--- a/multiraft/transport_test.go
+++ b/multiraft/transport_test.go
@@ -92,7 +92,7 @@ func (lt *localInterceptableTransport) Stop(id NodeID) {
 	lt.mu.Unlock()
 }
 
-func (lt *localInterceptableTransport) Send(id NodeID, req *RaftMessageRequest) error {
+func (lt *localInterceptableTransport) Send(req *RaftMessageRequest) error {
 	select {
 	case lt.messages <- req:
 	case <-lt.stopper.ShouldStop():

--- a/server/raft_transport.go
+++ b/server/raft_transport.go
@@ -102,8 +102,8 @@ func (t *rpcTransport) Stop(id multiraft.NodeID) {
 	delete(t.servers, id)
 }
 
-// Send a message to the specified Node id.
-func (t *rpcTransport) Send(id multiraft.NodeID, req *multiraft.RaftMessageRequest) error {
+// Send a message to the recipient specified in the request.
+func (t *rpcTransport) Send(req *multiraft.RaftMessageRequest) error {
 	// Convert internal to proto formats.
 	protoReq := &proto.RaftMessageRequest{GroupID: req.GroupID}
 	var err error
@@ -111,7 +111,7 @@ func (t *rpcTransport) Send(id multiraft.NodeID, req *multiraft.RaftMessageReque
 		return err
 	}
 
-	nodeID, _ := storage.DecodeRaftNodeID(id)
+	nodeID, _ := storage.DecodeRaftNodeID(multiraft.NodeID(req.Message.To))
 	addr, err := t.gossip.GetNodeIDAddress(nodeID)
 	if err != nil {
 		return err

--- a/server/raft_transport_test.go
+++ b/server/raft_transport_test.go
@@ -113,7 +113,7 @@ func TestSendAndReceive(t *testing.T) {
 				},
 			}
 
-			if err := transports[from].Send(multiraft.NodeID(nodeIDs[to]), req); err != nil {
+			if err := transports[from].Send(req); err != nil {
 				t.Errorf("Unable to send message from %d to %d: %s", nodeIDs[from], nodeIDs[to], err)
 			}
 		}


### PR DESCRIPTION
- use multiraft.sendMessage, which will set up the transport if the recipient
  is new.
- missing To: in one of the heartbeat messages wreaked havoc

these two points were the main culprit in #1003. when starting a fresh cluster,
after 10minutes the replication queue would kick in and begin replicating the
first range two one of the two other nodes. misaddressed heartbeats would then
quickly fill the log and prevent the replication from going through.

this fixes #1003.
