### PR TITLE
fix #1011

### DIFF
--- a/storage/range_command.go
+++ b/storage/range_command.go
@@ -760,7 +760,7 @@ func (r *Range) InternalLeaderLease(batch engine.Engine, ms *proto.MVCCStats, ar
 	}
 
 	// Gossip configs in the event this range contains config info.
-	r.maybeGossipConfigs(func(configPrefix proto.Key) bool {
+	r.maybeGossipConfigsLocked(func(configPrefix proto.Key) bool {
 		return r.ContainsKey(configPrefix)
 	})
 }


### PR DESCRIPTION
we need to hold the lock during maybeGossipConfigs
to protect the configHashes.
since we also call gossip from the store, better to have
the main entry point take the lock, and do the actual
work in another method that presupposes the lock.

fixes #1011
