### PR TITLE
fix #1010

### DIFF
--- a/storage/client_raft_test.go
+++ b/storage/client_raft_test.go
@@ -572,7 +572,6 @@ func TestProgressWithDownNode(t *testing.T) {
 
 func TestReplicateAddAndRemove(t *testing.T) {
 	defer leaktest.AfterTest(t)
-	t.Skip("currently disabled due to data race, see #1010")
 
 	// Run the test twice, once adding the replacement before removing
 	// the downed node, and once removing the downed node first.

--- a/storage/feed_test.go
+++ b/storage/feed_test.go
@@ -71,7 +71,6 @@ func waitForStopper(t testing.TB, stopper *util.Stopper) {
 
 func TestStoreEventFeed(t *testing.T) {
 	defer leaktest.AfterTest(t)
-	t.Skip("currently disabled; see #1010")
 
 	// Construct a set of fake ranges to synthesize events correctly. They do
 	// not need to be added to a Store.


### PR DESCRIPTION
the issue was that coalesced heartbeats addressed their messages
to a dummy group. however, the information that a node was unreachable
 was still passed down to multinode, which in turn caused a message to
be sent to raft raft (addressed to the dummy group) in those tests
which stop a multinode as part of their tasks.
raft does not like receiving messages for groups it has no knowledge
of, so this caused a panic.

it's kind of scary that all of this time we've basically never had
working coalesced heartbeats despite the tests before today.
also, running test clusters must have had their leadership flipflop
all the time without us noticing. we need to bump up the logging for
coalesced heartbeat timeouts; those things should be visible.
