### PR TITLE
pass a context from node all the way down

### DIFF
--- a/client/client_test.go
+++ b/client/client_test.go
@@ -30,6 +30,8 @@ import (
 	"testing"
 	"time"
 
+	"golang.org/x/net/context"
+
 	"github.com/cockroachdb/cockroach/client"
 	"github.com/cockroachdb/cockroach/proto"
 	"github.com/cockroachdb/cockroach/server"
@@ -60,8 +62,8 @@ func (ss *notifyingSender) wait() {
 	ss.waiter = nil
 }
 
-func (ss *notifyingSender) Send(call client.Call) {
-	ss.wrapped.Send(call)
+func (ss *notifyingSender) Send(ctx context.Context, call client.Call) {
+	ss.wrapped.Send(ctx, call)
 	if ss.waiter != nil {
 		ss.waiter.Done()
 	}

--- a/client/http_sender.go
+++ b/client/http_sender.go
@@ -27,6 +27,8 @@ import (
 	"net/url"
 	"time"
 
+	"golang.org/x/net/context"
+
 	"github.com/cockroachdb/c-snappy"
 	"github.com/cockroachdb/cockroach/base"
 	"github.com/cockroachdb/cockroach/util"
@@ -99,7 +101,7 @@ func NewHTTPSender(server string, ctx *base.Context) (*HTTPSender, error) {
 // and been executed successfully. We retry here to eventually get
 // through with the same client command ID and be given the cached
 // response.
-func (s *HTTPSender) Send(call Call) {
+func (s *HTTPSender) Send(_ context.Context, call Call) {
 	retryOpts := HTTPRetryOptions
 	retryOpts.Tag = fmt.Sprintf("%s %s", s.context.RequestScheme(), call.Method())
 

--- a/client/http_sender_test.go
+++ b/client/http_sender_test.go
@@ -80,7 +80,7 @@ func TestHTTPSenderSend(t *testing.T) {
 		t.Fatal(err)
 	}
 	reply := &proto.PutResponse{}
-	sender.Send(context.TODO(), Call{Args: testPutReq, Reply: reply})
+	sender.Send(context.Background(), Call{Args: testPutReq, Reply: reply})
 	if reply.GoError() != nil {
 		t.Errorf("expected success; got %s", reply.GoError())
 	}
@@ -135,7 +135,7 @@ func TestHTTPSenderRetryResponseCodes(t *testing.T) {
 			t.Fatal(err)
 		}
 		reply := &proto.PutResponse{}
-		sender.Send(context.TODO(), Call{Args: testPutReq, Reply: reply})
+		sender.Send(context.Background(), Call{Args: testPutReq, Reply: reply})
 		if test.retry {
 			if count != 2 {
 				t.Errorf("%d: expected retry", i)
@@ -196,7 +196,7 @@ func TestHTTPSenderRetryHTTPSendError(t *testing.T) {
 			t.Fatal(err)
 		}
 		reply := &proto.PutResponse{}
-		sender.Send(context.TODO(), Call{Args: testPutReq, Reply: reply})
+		sender.Send(context.Background(), Call{Args: testPutReq, Reply: reply})
 		if reply.GoError() != nil {
 			t.Errorf("%d: expected success; got %s", i, reply.GoError())
 		}

--- a/client/http_sender_test.go
+++ b/client/http_sender_test.go
@@ -25,6 +25,8 @@ import (
 	"testing"
 	"time"
 
+	"golang.org/x/net/context"
+
 	"github.com/cockroachdb/cockroach/proto"
 	"github.com/cockroachdb/cockroach/testutils"
 	"github.com/cockroachdb/cockroach/util"
@@ -78,7 +80,7 @@ func TestHTTPSenderSend(t *testing.T) {
 		t.Fatal(err)
 	}
 	reply := &proto.PutResponse{}
-	sender.Send(Call{Args: testPutReq, Reply: reply})
+	sender.Send(context.TODO(), Call{Args: testPutReq, Reply: reply})
 	if reply.GoError() != nil {
 		t.Errorf("expected success; got %s", reply.GoError())
 	}
@@ -133,7 +135,7 @@ func TestHTTPSenderRetryResponseCodes(t *testing.T) {
 			t.Fatal(err)
 		}
 		reply := &proto.PutResponse{}
-		sender.Send(Call{Args: testPutReq, Reply: reply})
+		sender.Send(context.TODO(), Call{Args: testPutReq, Reply: reply})
 		if test.retry {
 			if count != 2 {
 				t.Errorf("%d: expected retry", i)
@@ -194,7 +196,7 @@ func TestHTTPSenderRetryHTTPSendError(t *testing.T) {
 			t.Fatal(err)
 		}
 		reply := &proto.PutResponse{}
-		sender.Send(Call{Args: testPutReq, Reply: reply})
+		sender.Send(context.TODO(), Call{Args: testPutReq, Reply: reply})
 		if reply.GoError() != nil {
 			t.Errorf("%d: expected success; got %s", i, reply.GoError())
 		}

--- a/client/kv.go
+++ b/client/kv.go
@@ -22,6 +22,7 @@ import (
 	"github.com/cockroachdb/cockroach/util"
 	"github.com/cockroachdb/cockroach/util/log"
 	gogoproto "github.com/gogo/protobuf/proto"
+	"golang.org/x/net/context"
 )
 
 // TransactionOptions are parameters for use with KV.RunTransaction.
@@ -104,7 +105,7 @@ func (kv *KV) Run(calls ...Call) (err error) {
 			c.Args.Header().UserPriority = gogoproto.Int32(kv.UserPriority)
 		}
 		c.resetClientCmdID(kv.clock)
-		kv.Sender.Send(c)
+		kv.Sender.Send(context.TODO(), c)
 		err = c.Reply.Header().GoError()
 		if err != nil {
 			log.Infof("failed %s: %s", c.Method(), err)

--- a/client/rpc_sender.go
+++ b/client/rpc_sender.go
@@ -22,6 +22,8 @@ import (
 	"net"
 	"net/url"
 
+	"golang.org/x/net/context"
+
 	"github.com/cockroachdb/cockroach/base"
 	"github.com/cockroachdb/cockroach/rpc"
 	"github.com/cockroachdb/cockroach/util"
@@ -76,7 +78,7 @@ func NewRPCSender(server string, context *base.Context) (*RPCSender, error) {
 // and been executed successfully. We retry here to eventually get
 // through with the same client command ID and be given the cached
 // response.
-func (s *RPCSender) Send(call Call) {
+func (s *RPCSender) Send(_ context.Context, call Call) {
 	retryOpts := HTTPRetryOptions
 	retryOpts.Tag = fmt.Sprintf("rpc %s", call.Method())
 

--- a/client/sender.go
+++ b/client/sender.go
@@ -23,6 +23,8 @@ import (
 	"net/url"
 	"sync"
 
+	"golang.org/x/net/context"
+
 	"github.com/cockroachdb/cockroach/base"
 )
 
@@ -31,15 +33,17 @@ import (
 type KVSender interface {
 	// Send invokes the Call.Method with Call.Args and sets the result
 	// in Call.Reply.
-	Send(Call)
+	Send(context.Context, Call)
 }
 
 // KVSenderFunc is an adapter to allow the use of ordinary functions
 // as KVSenders.
 type KVSenderFunc func(Call)
 
+var _ KVSender = KVSenderFunc(func(Call) {})
+
 // Send calls f(c).
-func (f KVSenderFunc) Send(c Call) {
+func (f KVSenderFunc) Send(_ context.Context, c Call) {
 	f(c)
 }
 

--- a/client/sender.go
+++ b/client/sender.go
@@ -38,13 +38,11 @@ type KVSender interface {
 
 // KVSenderFunc is an adapter to allow the use of ordinary functions
 // as KVSenders.
-type KVSenderFunc func(Call)
-
-var _ KVSender = KVSenderFunc(func(Call) {})
+type KVSenderFunc func(context.Context, Call)
 
 // Send calls f(c).
-func (f KVSenderFunc) Send(_ context.Context, c Call) {
-	f(c)
+func (f KVSenderFunc) Send(ctx context.Context, c Call) {
+	f(ctx, c)
 }
 
 type newSenderFunc func(u *url.URL, ctx *base.Context) (KVSender, error)

--- a/client/txn.go
+++ b/client/txn.go
@@ -21,16 +21,17 @@ import (
 	"github.com/cockroachdb/cockroach/proto"
 	"github.com/cockroachdb/cockroach/util"
 	"github.com/cockroachdb/cockroach/util/log"
+	"golang.org/x/net/context"
 )
 
 type txnSender struct {
 	*Txn
 }
 
-func (ts *txnSender) Send(call Call) {
+func (ts *txnSender) Send(ctx context.Context, call Call) {
 	// Send call through wrapped sender.
 	call.Args.Header().Txn = &ts.txn
-	ts.wrapped.Send(call)
+	ts.wrapped.Send(ctx, call)
 	ts.txn.Update(call.Reply.Header().Txn)
 
 	if err, ok := call.Reply.Header().GoError().(*proto.TransactionAbortedError); ok {

--- a/client/txn_test.go
+++ b/client/txn_test.go
@@ -40,7 +40,7 @@ func makeTS(walltime int64, logical int32) proto.Timestamp {
 }
 
 func newTestSender(handler func(Call)) KVSenderFunc {
-	return func(call Call) {
+	return func(_ context.Context, call Call) {
 		header := call.Args.Header()
 		header.UserPriority = gogoproto.Int32(-1)
 		if header.Txn != nil && len(header.Txn.ID) == 0 {

--- a/client/txn_test.go
+++ b/client/txn_test.go
@@ -88,7 +88,7 @@ func TestTxnRequestTxnTimestamp(t *testing.T) {
 	txn := newTxn(kv, nil)
 
 	for testIdx = range testCases {
-		txn.kv.Sender.Send(context.TODO(), Call{Args: testPutReq, Reply: &proto.PutResponse{}})
+		txn.kv.Sender.Send(context.Background(), Call{Args: testPutReq, Reply: &proto.PutResponse{}})
 	}
 }
 
@@ -100,7 +100,7 @@ func TestTxnResetTxnOnAbort(t *testing.T) {
 	}))
 	txn := newTxn(kv, nil)
 
-	txn.kv.Sender.Send(context.TODO(), Call{Args: testPutReq, Reply: &proto.PutResponse{}})
+	txn.kv.Sender.Send(context.Background(), Call{Args: testPutReq, Reply: &proto.PutResponse{}})
 
 	if len(txn.txn.ID) != 0 {
 		t.Errorf("expected txn to be cleared")

--- a/client/txn_test.go
+++ b/client/txn_test.go
@@ -20,6 +20,8 @@ package client
 import (
 	"testing"
 
+	"golang.org/x/net/context"
+
 	"github.com/cockroachdb/cockroach/proto"
 	"github.com/cockroachdb/cockroach/util"
 	gogoproto "github.com/gogo/protobuf/proto"
@@ -86,7 +88,7 @@ func TestTxnRequestTxnTimestamp(t *testing.T) {
 	txn := newTxn(kv, nil)
 
 	for testIdx = range testCases {
-		txn.kv.Sender.Send(Call{Args: testPutReq, Reply: &proto.PutResponse{}})
+		txn.kv.Sender.Send(context.TODO(), Call{Args: testPutReq, Reply: &proto.PutResponse{}})
 	}
 }
 
@@ -98,7 +100,7 @@ func TestTxnResetTxnOnAbort(t *testing.T) {
 	}))
 	txn := newTxn(kv, nil)
 
-	txn.kv.Sender.Send(Call{Args: testPutReq, Reply: &proto.PutResponse{}})
+	txn.kv.Sender.Send(context.TODO(), Call{Args: testPutReq, Reply: &proto.PutResponse{}})
 
 	if len(txn.txn.ID) != 0 {
 		t.Errorf("expected txn to be cleared")

--- a/kv/db.go
+++ b/kv/db.go
@@ -22,6 +22,8 @@ import (
 	"net/http"
 	"strings"
 
+	"golang.org/x/net/context"
+
 	"github.com/cockroachdb/cockroach/client"
 	"github.com/cockroachdb/cockroach/proto"
 	"github.com/cockroachdb/cockroach/rpc"
@@ -136,7 +138,7 @@ func (s *DBServer) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	}
 
 	// Create a call and invoke through sender.
-	s.sender.Send(client.Call{Args: args, Reply: reply})
+	s.sender.Send(context.TODO(), client.Call{Args: args, Reply: reply})
 
 	// Marshal the response.
 	body, contentType, err := util.MarshalResponse(r, reply, allowedEncodings)
@@ -159,7 +161,7 @@ type rpcDBServer DBServer
 
 // executeCmd creates a client.Call struct and sends if via our local sender.
 func (s *rpcDBServer) executeCmd(args proto.Request, reply proto.Response) error {
-	s.sender.Send(client.Call{Args: args, Reply: reply})
+	s.sender.Send(context.TODO(), client.Call{Args: args, Reply: reply})
 	return nil
 }
 

--- a/kv/dist_sender.go
+++ b/kv/dist_sender.go
@@ -22,6 +22,8 @@ import (
 	"net"
 	"time"
 
+	"golang.org/x/net/context"
+
 	"github.com/cockroachdb/cockroach/client"
 	"github.com/cockroachdb/cockroach/gossip"
 	"github.com/cockroachdb/cockroach/proto"
@@ -113,6 +115,8 @@ type DistSender struct {
 	rpcSend         rpcSendFn
 	rpcRetryOptions util.RetryOptions
 }
+
+var _ client.KVSender = &DistSender{}
 
 // rpcSendFn is the function type used to dispatch RPC calls.
 type rpcSendFn func(rpc.Options, string, []net.Addr,
@@ -483,7 +487,7 @@ func (ds *DistSender) sendRPC(desc *proto.RangeDescriptor,
 //
 // This may temporarily adjust the request headers, so the client.Call
 // must not be used concurrently until Send has returned.
-func (ds *DistSender) Send(call client.Call) {
+func (ds *DistSender) Send(_ context.Context, call client.Call) {
 
 	// TODO: Refactor this method into more manageable pieces.
 	// Verify permissions.

--- a/kv/dist_sender_server_test.go
+++ b/kv/dist_sender_server_test.go
@@ -157,7 +157,7 @@ func TestMultiRangeScanInconsistent(t *testing.T) {
 	sa := call.Args.(*proto.ScanRequest)
 	sa.ReadConsistency = proto.INCONSISTENT
 	sa.User = storage.UserRoot
-	ds.Send(context.TODO(), call)
+	ds.Send(context.Background(), call)
 	if err := sr.GoError(); err != nil {
 		t.Fatal(err)
 	}

--- a/kv/dist_sender_server_test.go
+++ b/kv/dist_sender_server_test.go
@@ -21,6 +21,8 @@ import (
 	"testing"
 	"time"
 
+	"golang.org/x/net/context"
+
 	"github.com/cockroachdb/cockroach/client"
 	"github.com/cockroachdb/cockroach/kv"
 	"github.com/cockroachdb/cockroach/proto"
@@ -155,7 +157,7 @@ func TestMultiRangeScanInconsistent(t *testing.T) {
 	sa := call.Args.(*proto.ScanRequest)
 	sa.ReadConsistency = proto.INCONSISTENT
 	sa.User = storage.UserRoot
-	ds.Send(call)
+	ds.Send(context.TODO(), call)
 	if err := sr.GoError(); err != nil {
 		t.Fatal(err)
 	}

--- a/kv/dist_sender_test.go
+++ b/kv/dist_sender_test.go
@@ -300,7 +300,7 @@ func TestRetryOnNotLeaderError(t *testing.T) {
 	ds := NewDistSender(ctx, g)
 	call := client.Put(proto.Key("a"), []byte("value"))
 	reply := call.Reply.(*proto.PutResponse)
-	ds.Send(context.TODO(), call)
+	ds.Send(context.Background(), call)
 	if err := reply.GoError(); err != nil {
 		t.Errorf("put encountered error: %s", err)
 	}
@@ -345,7 +345,7 @@ func TestRangeLookupOnPushTxnIgnoresIntents(t *testing.T) {
 			},
 			Reply: &proto.InternalPushTxnResponse{},
 		}
-		ds.Send(context.TODO(), call)
+		ds.Send(context.Background(), call)
 	}
 }
 
@@ -395,7 +395,7 @@ func TestRetryOnWrongReplicaError(t *testing.T) {
 	ds := NewDistSender(ctx, g)
 	call := client.Scan(proto.Key("a"), proto.Key("d"), 0)
 	sr := call.Reply.(*proto.ScanResponse)
-	ds.Send(context.TODO(), call)
+	ds.Send(context.Background(), call)
 	if err := sr.GoError(); err != nil {
 		t.Errorf("scan encountered error: %s", err)
 	}

--- a/kv/dist_sender_test.go
+++ b/kv/dist_sender_test.go
@@ -26,6 +26,8 @@ import (
 	"testing"
 	"time"
 
+	"golang.org/x/net/context"
+
 	"github.com/cockroachdb/cockroach/client"
 	"github.com/cockroachdb/cockroach/gossip"
 	"github.com/cockroachdb/cockroach/gossip/simulation"
@@ -298,7 +300,7 @@ func TestRetryOnNotLeaderError(t *testing.T) {
 	ds := NewDistSender(ctx, g)
 	call := client.Put(proto.Key("a"), []byte("value"))
 	reply := call.Reply.(*proto.PutResponse)
-	ds.Send(call)
+	ds.Send(context.TODO(), call)
 	if err := reply.GoError(); err != nil {
 		t.Errorf("put encountered error: %s", err)
 	}
@@ -343,7 +345,7 @@ func TestRangeLookupOnPushTxnIgnoresIntents(t *testing.T) {
 			},
 			Reply: &proto.InternalPushTxnResponse{},
 		}
-		ds.Send(call)
+		ds.Send(context.TODO(), call)
 	}
 }
 
@@ -393,7 +395,7 @@ func TestRetryOnWrongReplicaError(t *testing.T) {
 	ds := NewDistSender(ctx, g)
 	call := client.Scan(proto.Key("a"), proto.Key("d"), 0)
 	sr := call.Reply.(*proto.ScanResponse)
-	ds.Send(call)
+	ds.Send(context.TODO(), call)
 	if err := sr.GoError(); err != nil {
 		t.Errorf("scan encountered error: %s", err)
 	}

--- a/kv/local_sender.go
+++ b/kv/local_sender.go
@@ -31,7 +31,6 @@ import (
 
 // A LocalSender provides methods to access a collection of local stores.
 type LocalSender struct {
-	context.Context
 	mu       sync.RWMutex                     // Protects storeMap and addrs
 	storeMap map[proto.StoreID]*storage.Store // Map from StoreID to Store
 }
@@ -42,7 +41,6 @@ var _ client.KVSender = &LocalSender{}
 // a collection of stores.
 func NewLocalSender() *LocalSender {
 	return &LocalSender{
-		Context:  context.Background(),
 		storeMap: map[proto.StoreID]*storage.Store{},
 	}
 }
@@ -120,7 +118,7 @@ func (ls *LocalSender) GetStoreIDs() []proto.StoreID {
 // up from the store map if specified by header.Replica; otherwise,
 // the command is being executed locally, and the replica is
 // determined via lookup through each store's LookupRange method.
-func (ls *LocalSender) Send(_ context.Context, call client.Call) {
+func (ls *LocalSender) Send(ctx context.Context, call client.Call) {
 	var err error
 	var store *storage.Store
 
@@ -149,7 +147,7 @@ func (ls *LocalSender) Send(_ context.Context, call client.Call) {
 			// MaxTimestamp = Timestamp corresponds to no clock uncertainty.
 			header.Txn.MaxTimestamp = header.Txn.Timestamp
 		}
-		err = store.ExecuteCmd(ls.Context, call)
+		err = store.ExecuteCmd(ctx, call)
 	}
 	if err != nil {
 		call.Reply.Header().SetGoError(err)

--- a/kv/local_sender.go
+++ b/kv/local_sender.go
@@ -36,6 +36,8 @@ type LocalSender struct {
 	storeMap map[proto.StoreID]*storage.Store // Map from StoreID to Store
 }
 
+var _ client.KVSender = &LocalSender{}
+
 // NewLocalSender returns a local-only sender which directly accesses
 // a collection of stores.
 func NewLocalSender() *LocalSender {
@@ -118,7 +120,7 @@ func (ls *LocalSender) GetStoreIDs() []proto.StoreID {
 // up from the store map if specified by header.Replica; otherwise,
 // the command is being executed locally, and the replica is
 // determined via lookup through each store's LookupRange method.
-func (ls *LocalSender) Send(call client.Call) {
+func (ls *LocalSender) Send(_ context.Context, call client.Call) {
 	var err error
 	var store *storage.Store
 

--- a/kv/local_test_cluster.go
+++ b/kv/local_test_cluster.go
@@ -122,12 +122,12 @@ func (ltc *LocalTestCluster) Start(t util.Tester) {
 	ltc.KV.User = storage.UserRoot
 	transport := multiraft.NewLocalRPCTransport()
 	ltc.Stopper.AddCloser(transport)
-	sCtx := storage.TestStoreContext
-	sCtx.Clock = ltc.Clock
-	sCtx.DB = ltc.KV
-	sCtx.Gossip = ltc.Gossip
-	sCtx.Transport = transport
-	ltc.Store = storage.NewStore(sCtx, ltc.Eng, &proto.NodeDescriptor{NodeID: 1})
+	ctx := storage.TestStoreContext
+	ctx.Clock = ltc.Clock
+	ctx.DB = ltc.KV
+	ctx.Gossip = ltc.Gossip
+	ctx.Transport = transport
+	ltc.Store = storage.NewStore(ctx, ltc.Eng, &proto.NodeDescriptor{NodeID: 1})
 	if err := ltc.Store.Bootstrap(proto.StoreIdent{NodeID: 1, StoreID: 1}, ltc.Stopper); err != nil {
 		t.Fatalf("unable to start local test cluster: %s", err)
 	}

--- a/kv/txn_coord_sender_test.go
+++ b/kv/txn_coord_sender_test.go
@@ -122,7 +122,7 @@ func TestTxnCoordSenderBeginTransaction(t *testing.T) {
 
 	reply := &proto.PutResponse{}
 	key := proto.Key("key")
-	s.KV.Sender.Send(context.TODO(), client.Call{
+	s.KV.Sender.Send(context.Background(), client.Call{
 		Args: &proto.PutRequest{
 			RequestHeader: proto.RequestHeader{
 				Key:          key,
@@ -160,7 +160,7 @@ func TestTxnCoordSenderBeginTransactionMinPriority(t *testing.T) {
 	defer s.Stop()
 
 	reply := &proto.PutResponse{}
-	s.KV.Sender.Send(context.TODO(), client.Call{
+	s.KV.Sender.Send(context.Background(), client.Call{
 		Args: &proto.PutRequest{
 			RequestHeader: proto.RequestHeader{
 				Key:          proto.Key("key"),
@@ -342,7 +342,7 @@ func TestTxnCoordSenderEndTxn(t *testing.T) {
 		t.Fatal(pReply.GoError())
 	}
 	etReply := &proto.EndTransactionResponse{}
-	s.KV.Sender.Send(context.TODO(), client.Call{
+	s.KV.Sender.Send(context.Background(), client.Call{
 		Args: &proto.EndTransactionRequest{
 			RequestHeader: proto.RequestHeader{
 				Key:       txn.Key,
@@ -520,7 +520,7 @@ func TestTxnCoordSenderTxnUpdatedOnError(t *testing.T) {
 			call.Reply.Header().SetGoError(test.err)
 		}), clock, false, stopper)
 		reply := &proto.PutResponse{}
-		ts.Send(context.TODO(), client.Call{Args: testPutReq, Reply: reply})
+		ts.Send(context.Background(), client.Call{Args: testPutReq, Reply: reply})
 
 		if reflect.TypeOf(test.err) != reflect.TypeOf(reply.GoError()) {
 			t.Fatalf("%d: expected %T; got %T", i, test.err, reply.GoError())

--- a/server/node.go
+++ b/server/node.go
@@ -496,7 +496,7 @@ func (n *Node) waitForScanCompletion() int64 {
 
 // executeCmd creates a client.Call struct and sends if via our local sender.
 func (n *nodeServer) executeCmd(args proto.Request, reply proto.Response) error {
-	n.lSender.Send(client.Call{Args: args, Reply: reply})
+	n.lSender.Send(context.TODO(), client.Call{Args: args, Reply: reply})
 	return nil
 }
 

--- a/server/node_test.go
+++ b/server/node_test.go
@@ -37,7 +37,6 @@ import (
 	"github.com/cockroachdb/cockroach/util"
 	"github.com/cockroachdb/cockroach/util/hlc"
 	gogoproto "github.com/gogo/protobuf/proto"
-	"golang.org/x/net/context"
 )
 
 // createTestNode creates an rpc server using the specified address,
@@ -53,7 +52,6 @@ func createTestNode(addr net.Addr, engines []engine.Engine, gossipBS net.Addr, t
 		t.Fatal(err)
 	}
 	ctx := storage.StoreContext{}
-	ctx.Context = context.Background()
 
 	stopper := util.NewStopper()
 	ctx.Clock = hlc.NewClock(hlc.UnixNano)

--- a/server/server.go
+++ b/server/server.go
@@ -41,7 +41,6 @@ import (
 	"github.com/cockroachdb/cockroach/util/hlc"
 	"github.com/cockroachdb/cockroach/util/log"
 	assetfs "github.com/elazarl/go-bindata-assetfs"
-	"golang.org/x/net/context"
 )
 
 var (
@@ -131,7 +130,6 @@ func NewServer(ctx *Context, stopper *util.Stopper) (*Server, error) {
 		DB:           s.kv,
 		Gossip:       s.gossip,
 		Transport:    s.raftTransport,
-		Context:      context.Background(),
 		ScanInterval: s.ctx.ScanInterval,
 		EventFeed:    &util.Feed{},
 	}

--- a/server/server_test.go
+++ b/server/server_test.go
@@ -328,7 +328,7 @@ func TestMultiRangeScanDeleteRange(t *testing.T) {
 	}
 	get.Args.Header().User = storage.UserRoot
 	get.Args.Header().EndKey = writes[len(writes)-1]
-	tds.Send(context.TODO(), get)
+	tds.Send(context.Background(), get)
 	if err := get.Reply.Header().GoError(); err == nil {
 		t.Errorf("able to call Get with a key range: %v", get)
 	}
@@ -336,7 +336,7 @@ func TestMultiRangeScanDeleteRange(t *testing.T) {
 	for i, k := range writes {
 		call = client.Put(k, k)
 		call.Args.Header().User = storage.UserRoot
-		tds.Send(context.TODO(), call)
+		tds.Send(context.Background(), call)
 		if err := call.Reply.Header().GoError(); err != nil {
 			t.Fatal(err)
 		}
@@ -345,7 +345,7 @@ func TestMultiRangeScanDeleteRange(t *testing.T) {
 		// so make sure we see their values in our Scan.
 		scan.Args.Header().Timestamp = call.Reply.Header().Timestamp
 		scan.Args.Header().User = storage.UserRoot
-		tds.Send(context.TODO(), scan)
+		tds.Send(context.Background(), scan)
 		if err := scan.Reply.Header().GoError(); err != nil {
 			t.Fatal(err)
 		}
@@ -368,7 +368,7 @@ func TestMultiRangeScanDeleteRange(t *testing.T) {
 		},
 		Reply: &proto.DeleteRangeResponse{},
 	}
-	tds.Send(context.TODO(), del)
+	tds.Send(context.Background(), del)
 	if err := del.Reply.Header().GoError(); err != nil {
 		t.Fatal(err)
 	}
@@ -384,7 +384,7 @@ func TestMultiRangeScanDeleteRange(t *testing.T) {
 	scan.Args.Header().Timestamp = del.Reply.Header().Timestamp
 	scan.Args.Header().User = storage.UserRoot
 	scan.Args.Header().Txn = &proto.Transaction{Name: "MyTxn"}
-	tds.Send(context.TODO(), scan)
+	tds.Send(context.Background(), scan)
 	if err := scan.Reply.Header().GoError(); err != nil {
 		t.Fatal(err)
 	}
@@ -432,7 +432,7 @@ func TestMultiRangeScanWithMaxResults(t *testing.T) {
 		for _, k := range tc.keys {
 			call = client.Put(k, k)
 			call.Args.Header().User = storage.UserRoot
-			tds.Send(context.TODO(), call)
+			tds.Send(context.Background(), call)
 			if err := call.Reply.Header().GoError(); err != nil {
 				t.Fatal(err)
 			}
@@ -446,7 +446,7 @@ func TestMultiRangeScanWithMaxResults(t *testing.T) {
 					int64(maxResults))
 				scan.Args.Header().Timestamp = call.Reply.Header().Timestamp
 				scan.Args.Header().User = storage.UserRoot
-				tds.Send(context.TODO(), scan)
+				tds.Send(context.Background(), scan)
 				if err := scan.Reply.Header().GoError(); err != nil {
 					t.Fatal(err)
 				}

--- a/server/server_test.go
+++ b/server/server_test.go
@@ -26,6 +26,8 @@ import (
 	"strings"
 	"testing"
 
+	"golang.org/x/net/context"
+
 	"github.com/cockroachdb/c-snappy"
 	"github.com/cockroachdb/cockroach/client"
 	"github.com/cockroachdb/cockroach/kv"
@@ -326,7 +328,7 @@ func TestMultiRangeScanDeleteRange(t *testing.T) {
 	}
 	get.Args.Header().User = storage.UserRoot
 	get.Args.Header().EndKey = writes[len(writes)-1]
-	tds.Send(get)
+	tds.Send(context.TODO(), get)
 	if err := get.Reply.Header().GoError(); err == nil {
 		t.Errorf("able to call Get with a key range: %v", get)
 	}
@@ -334,7 +336,7 @@ func TestMultiRangeScanDeleteRange(t *testing.T) {
 	for i, k := range writes {
 		call = client.Put(k, k)
 		call.Args.Header().User = storage.UserRoot
-		tds.Send(call)
+		tds.Send(context.TODO(), call)
 		if err := call.Reply.Header().GoError(); err != nil {
 			t.Fatal(err)
 		}
@@ -343,7 +345,7 @@ func TestMultiRangeScanDeleteRange(t *testing.T) {
 		// so make sure we see their values in our Scan.
 		scan.Args.Header().Timestamp = call.Reply.Header().Timestamp
 		scan.Args.Header().User = storage.UserRoot
-		tds.Send(scan)
+		tds.Send(context.TODO(), scan)
 		if err := scan.Reply.Header().GoError(); err != nil {
 			t.Fatal(err)
 		}
@@ -366,7 +368,7 @@ func TestMultiRangeScanDeleteRange(t *testing.T) {
 		},
 		Reply: &proto.DeleteRangeResponse{},
 	}
-	tds.Send(del)
+	tds.Send(context.TODO(), del)
 	if err := del.Reply.Header().GoError(); err != nil {
 		t.Fatal(err)
 	}
@@ -382,7 +384,7 @@ func TestMultiRangeScanDeleteRange(t *testing.T) {
 	scan.Args.Header().Timestamp = del.Reply.Header().Timestamp
 	scan.Args.Header().User = storage.UserRoot
 	scan.Args.Header().Txn = &proto.Transaction{Name: "MyTxn"}
-	tds.Send(scan)
+	tds.Send(context.TODO(), scan)
 	if err := scan.Reply.Header().GoError(); err != nil {
 		t.Fatal(err)
 	}
@@ -430,7 +432,7 @@ func TestMultiRangeScanWithMaxResults(t *testing.T) {
 		for _, k := range tc.keys {
 			call = client.Put(k, k)
 			call.Args.Header().User = storage.UserRoot
-			tds.Send(call)
+			tds.Send(context.TODO(), call)
 			if err := call.Reply.Header().GoError(); err != nil {
 				t.Fatal(err)
 			}
@@ -444,7 +446,7 @@ func TestMultiRangeScanWithMaxResults(t *testing.T) {
 					int64(maxResults))
 				scan.Args.Header().Timestamp = call.Reply.Header().Timestamp
 				scan.Args.Header().User = storage.UserRoot
-				tds.Send(scan)
+				tds.Send(context.TODO(), scan)
 				if err := scan.Reply.Header().GoError(); err != nil {
 					t.Fatal(err)
 				}

--- a/sql/parser/parse_test.go
+++ b/sql/parser/parse_test.go
@@ -2,16 +2,13 @@ package parser
 
 import (
 	"bufio"
+	"flag"
 	"fmt"
 	"io"
 	"os"
 	"path/filepath"
 	"strings"
 	"testing"
-
-	// This is a bit silly. Require log in order for -logstderr to be
-	// defined which is set for all tests by the toplevel Makefile.
-	_ "github.com/cockroachdb/cockroach/util/log"
 )
 
 type testCase struct {
@@ -19,6 +16,10 @@ type testCase struct {
 	lineno int
 	input  string
 	output string
+}
+
+func init() {
+	_ = flag.Bool("logtostderr", false, "provided only since it's passed to our tests")
 }
 
 func iterateFiles(t *testing.T, pattern string) (ch chan testCase) {

--- a/sql/parser/parse_test.go
+++ b/sql/parser/parse_test.go
@@ -2,13 +2,16 @@ package parser
 
 import (
 	"bufio"
-	"flag"
 	"fmt"
 	"io"
 	"os"
 	"path/filepath"
 	"strings"
 	"testing"
+
+	// This is a bit silly. Require log in order for -logstderr to be
+	// defined which is set for all tests by the toplevel Makefile.
+	_ "github.com/cockroachdb/cockroach/util/log"
 )
 
 type testCase struct {
@@ -16,10 +19,6 @@ type testCase struct {
 	lineno int
 	input  string
 	output string
-}
-
-func init() {
-	_ = flag.Bool("logtostderr", false, "provided only since it's passed to our tests")
 }
 
 func iterateFiles(t *testing.T, pattern string) (ch chan testCase) {

--- a/storage/client_merge_test.go
+++ b/storage/client_merge_test.go
@@ -23,6 +23,8 @@ import (
 	"strings"
 	"testing"
 
+	"golang.org/x/net/context"
+
 	"github.com/cockroachdb/cockroach/client"
 	"github.com/cockroachdb/cockroach/proto"
 	"github.com/cockroachdb/cockroach/storage"
@@ -45,7 +47,7 @@ func adminMergeArgs(key []byte, raftID int64, storeID proto.StoreID) (*proto.Adm
 
 func createSplitRanges(store *storage.Store) (*proto.RangeDescriptor, *proto.RangeDescriptor, error) {
 	args, reply := adminSplitArgs(engine.KeyMin, []byte("b"), 1, store.StoreID())
-	if err := store.ExecuteCmd(client.Call{Args: args, Reply: reply}); err != nil {
+	if err := store.ExecuteCmd(context.Background(), client.Call{Args: args, Reply: reply}); err != nil {
 		return nil, nil, err
 	}
 
@@ -73,7 +75,7 @@ func TestStoreRangeMergeTwoEmptyRanges(t *testing.T) {
 
 	// Merge the b range back into the a range.
 	args, reply := adminMergeArgs(engine.KeyMin, 1, store.StoreID())
-	err = store.ExecuteCmd(client.Call{Args: args, Reply: reply})
+	err = store.ExecuteCmd(context.Background(), client.Call{Args: args, Reply: reply})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -103,29 +105,29 @@ func TestStoreRangeMergeWithData(t *testing.T) {
 
 	// Write some values left and right of the proposed split key.
 	pArgs, pReply := putArgs([]byte("aaa"), content, aDesc.RaftID, store.StoreID())
-	if err := store.ExecuteCmd(client.Call{Args: pArgs, Reply: pReply}); err != nil {
+	if err := store.ExecuteCmd(context.Background(), client.Call{Args: pArgs, Reply: pReply}); err != nil {
 		t.Fatal(err)
 	}
 	pArgs, pReply = putArgs([]byte("ccc"), content, bDesc.RaftID, store.StoreID())
-	if err := store.ExecuteCmd(client.Call{Args: pArgs, Reply: pReply}); err != nil {
+	if err := store.ExecuteCmd(context.Background(), client.Call{Args: pArgs, Reply: pReply}); err != nil {
 		t.Fatal(err)
 	}
 
 	// Confirm the values are there.
 	gArgs, gReply := getArgs([]byte("aaa"), aDesc.RaftID, store.StoreID())
-	if err := store.ExecuteCmd(client.Call{Args: gArgs, Reply: gReply}); err != nil ||
+	if err := store.ExecuteCmd(context.Background(), client.Call{Args: gArgs, Reply: gReply}); err != nil ||
 		!bytes.Equal(gReply.Value.Bytes, content) {
 		t.Fatal(err)
 	}
 	gArgs, gReply = getArgs([]byte("ccc"), bDesc.RaftID, store.StoreID())
-	if err := store.ExecuteCmd(client.Call{Args: gArgs, Reply: gReply}); err != nil ||
+	if err := store.ExecuteCmd(context.Background(), client.Call{Args: gArgs, Reply: gReply}); err != nil ||
 		!bytes.Equal(gReply.Value.Bytes, content) {
 		t.Fatal(err)
 	}
 
 	// Merge the b range back into the a range.
 	args, reply := adminMergeArgs(engine.KeyMin, 1, store.StoreID())
-	if err := store.ExecuteCmd(client.Call{Args: args, Reply: reply}); err != nil {
+	if err := store.ExecuteCmd(context.Background(), client.Call{Args: args, Reply: reply}); err != nil {
 		t.Fatal(err)
 	}
 
@@ -152,33 +154,33 @@ func TestStoreRangeMergeWithData(t *testing.T) {
 
 	// Try to get values from after the merge.
 	gArgs, gReply = getArgs([]byte("aaa"), rangeA.Desc().RaftID, store.StoreID())
-	if err := store.ExecuteCmd(client.Call{Args: gArgs, Reply: gReply}); err != nil ||
+	if err := store.ExecuteCmd(context.Background(), client.Call{Args: gArgs, Reply: gReply}); err != nil ||
 		!bytes.Equal(gReply.Value.Bytes, content) {
 		t.Fatal(err)
 	}
 	gArgs, gReply = getArgs([]byte("ccc"), rangeB.Desc().RaftID, store.StoreID())
-	if err := store.ExecuteCmd(client.Call{Args: gArgs, Reply: gReply}); err != nil ||
+	if err := store.ExecuteCmd(context.Background(), client.Call{Args: gArgs, Reply: gReply}); err != nil ||
 		!bytes.Equal(gReply.Value.Bytes, content) {
 		t.Fatal(err)
 	}
 
 	// Put new values after the merge on both sides.
 	pArgs, pReply = putArgs([]byte("aaaa"), content, rangeA.Desc().RaftID, store.StoreID())
-	if err = store.ExecuteCmd(client.Call{Args: pArgs, Reply: pReply}); err != nil {
+	if err = store.ExecuteCmd(context.Background(), client.Call{Args: pArgs, Reply: pReply}); err != nil {
 		t.Fatal(err)
 	}
 	pArgs, pReply = putArgs([]byte("cccc"), content, rangeB.Desc().RaftID, store.StoreID())
-	if err = store.ExecuteCmd(client.Call{Args: pArgs, Reply: pReply}); err != nil {
+	if err = store.ExecuteCmd(context.Background(), client.Call{Args: pArgs, Reply: pReply}); err != nil {
 		t.Fatal(err)
 	}
 
 	// Try to get the newly placed values.
 	gArgs, gReply = getArgs([]byte("aaaa"), rangeA.Desc().RaftID, store.StoreID())
-	if err := store.ExecuteCmd(client.Call{Args: gArgs, Reply: gReply}); err != nil || !bytes.Equal(gReply.Value.Bytes, content) {
+	if err := store.ExecuteCmd(context.Background(), client.Call{Args: gArgs, Reply: gReply}); err != nil || !bytes.Equal(gReply.Value.Bytes, content) {
 		t.Fatal(err)
 	}
 	gArgs, gReply = getArgs([]byte("cccc"), rangeA.Desc().RaftID, store.StoreID())
-	if err := store.ExecuteCmd(client.Call{Args: gArgs, Reply: gReply}); err != nil ||
+	if err := store.ExecuteCmd(context.Background(), client.Call{Args: gArgs, Reply: gReply}); err != nil ||
 		!bytes.Equal(gReply.Value.Bytes, content) {
 		t.Fatal(err)
 	}
@@ -192,7 +194,7 @@ func TestStoreRangeMergeLastRange(t *testing.T) {
 
 	// Merge last range.
 	args, reply := adminMergeArgs(engine.KeyMin, 1, store.StoreID())
-	if err := store.ExecuteCmd(client.Call{Args: args, Reply: reply}); err != nil {
+	if err := store.ExecuteCmd(context.Background(), client.Call{Args: args, Reply: reply}); err != nil {
 		t.Fatalf("merge of last range should be a noop: %s", err)
 	}
 }
@@ -206,11 +208,11 @@ func TestStoreRangeMergeNonConsecutive(t *testing.T) {
 
 	// Split into 3 ranges
 	argsSplit, replySplit := adminSplitArgs(engine.KeyMin, []byte("d"), 1, store.StoreID())
-	if err := store.ExecuteCmd(client.Call{Args: argsSplit, Reply: replySplit}); err != nil {
+	if err := store.ExecuteCmd(context.Background(), client.Call{Args: argsSplit, Reply: replySplit}); err != nil {
 		t.Fatalf("Can't split range %s", err)
 	}
 	argsSplit, replySplit = adminSplitArgs(engine.KeyMin, []byte("b"), 1, store.StoreID())
-	if err := store.ExecuteCmd(client.Call{Args: argsSplit, Reply: replySplit}); err != nil {
+	if err := store.ExecuteCmd(context.Background(), client.Call{Args: argsSplit, Reply: replySplit}); err != nil {
 		t.Fatalf("Can't split range %s", err)
 	}
 

--- a/storage/client_raft_test.go
+++ b/storage/client_raft_test.go
@@ -23,6 +23,8 @@ import (
 	"testing"
 	"time"
 
+	"golang.org/x/net/context"
+
 	"github.com/cockroachdb/cockroach/client"
 	"github.com/cockroachdb/cockroach/proto"
 	"github.com/cockroachdb/cockroach/storage"
@@ -49,7 +51,7 @@ func TestStoreRecoverFromEngine(t *testing.T) {
 
 	get := func(store *storage.Store, raftID int64, key proto.Key) int64 {
 		args, resp := getArgs(key, raftID, store.StoreID())
-		err := store.ExecuteCmd(client.Call{Args: args, Reply: resp})
+		err := store.ExecuteCmd(context.Background(), client.Call{Args: args, Reply: resp})
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -72,7 +74,7 @@ func TestStoreRecoverFromEngine(t *testing.T) {
 
 		increment := func(raftID int64, key proto.Key, value int64) (*proto.IncrementResponse, error) {
 			args, resp := incrementArgs(key, value, raftID, store.StoreID())
-			err := store.ExecuteCmd(client.Call{Args: args, Reply: resp})
+			err := store.ExecuteCmd(context.Background(), client.Call{Args: args, Reply: resp})
 			return resp, err
 		}
 
@@ -83,7 +85,7 @@ func TestStoreRecoverFromEngine(t *testing.T) {
 			t.Fatal(err)
 		}
 		splitArgs, splitResp := adminSplitArgs(engine.KeyMin, splitKey, raftID, store.StoreID())
-		if err := store.ExecuteCmd(client.Call{Args: splitArgs, Reply: splitResp}); err != nil {
+		if err := store.ExecuteCmd(context.Background(), client.Call{Args: splitArgs, Reply: splitResp}); err != nil {
 			t.Fatal(err)
 		}
 		raftID2 = store.LookupRange(key2, nil).Desc().RaftID
@@ -108,11 +110,11 @@ func TestStoreRecoverFromEngine(t *testing.T) {
 	// Raft processing is initialized lazily; issue a no-op write request on each key to
 	// ensure that is has been started.
 	incArgs, incReply := incrementArgs(key1, 0, raftID, store.StoreID())
-	if err := store.ExecuteCmd(client.Call{Args: incArgs, Reply: incReply}); err != nil {
+	if err := store.ExecuteCmd(context.Background(), client.Call{Args: incArgs, Reply: incReply}); err != nil {
 		t.Fatal(err)
 	}
 	incArgs, incReply = incrementArgs(key2, 0, raftID2, store.StoreID())
-	if err := store.ExecuteCmd(client.Call{Args: incArgs, Reply: incReply}); err != nil {
+	if err := store.ExecuteCmd(context.Background(), client.Call{Args: incArgs, Reply: incReply}); err != nil {
 		t.Fatal(err)
 	}
 
@@ -145,14 +147,14 @@ func TestStoreRecoverWithErrors(t *testing.T) {
 
 		// Write a bytes value so the increment will fail.
 		putArgs, putReply := putArgs(proto.Key("a"), []byte("asdf"), 1, store.StoreID())
-		if err := store.ExecuteCmd(client.Call{Args: putArgs, Reply: putReply}); err != nil {
+		if err := store.ExecuteCmd(context.Background(), client.Call{Args: putArgs, Reply: putReply}); err != nil {
 			t.Fatal(err)
 		}
 
 		// Try and fail to increment the key. It is important for this test that the
 		// failure be the last thing in the raft log when the store is stopped.
 		incArgs, incReply := incrementArgs(proto.Key("a"), 42, 1, store.StoreID())
-		if err := store.ExecuteCmd(client.Call{Args: incArgs, Reply: incReply}); err == nil {
+		if err := store.ExecuteCmd(context.Background(), client.Call{Args: incArgs, Reply: incReply}); err == nil {
 			t.Fatal("did not get expected error")
 		}
 	}()
@@ -167,7 +169,7 @@ func TestStoreRecoverWithErrors(t *testing.T) {
 
 	// Issue a no-op write to lazily initialize raft on the range.
 	incArgs, incReply := incrementArgs(proto.Key("b"), 0, 1, store.StoreID())
-	if err := store.ExecuteCmd(client.Call{Args: incArgs, Reply: incReply}); err != nil {
+	if err := store.ExecuteCmd(context.Background(), client.Call{Args: incArgs, Reply: incReply}); err != nil {
 		t.Fatal(err)
 	}
 
@@ -187,7 +189,7 @@ func TestReplicateRange(t *testing.T) {
 
 	// Issue a command on the first node before replicating.
 	incArgs, incResp := incrementArgs([]byte("a"), 5, 1, mtc.stores[0].StoreID())
-	if err := mtc.stores[0].ExecuteCmd(client.Call{Args: incArgs, Reply: incResp}); err != nil {
+	if err := mtc.stores[0].ExecuteCmd(context.Background(), client.Call{Args: incArgs, Reply: incResp}); err != nil {
 		t.Fatal(err)
 	}
 
@@ -231,7 +233,7 @@ func TestReplicateRange(t *testing.T) {
 	util.SucceedsWithin(t, 1*time.Second, func() error {
 		getArgs, getResp := getArgs([]byte("a"), 1, mtc.stores[1].StoreID())
 		getArgs.ReadConsistency = proto.INCONSISTENT
-		if err := mtc.stores[1].ExecuteCmd(client.Call{Args: getArgs, Reply: getResp}); err != nil {
+		if err := mtc.stores[1].ExecuteCmd(context.Background(), client.Call{Args: getArgs, Reply: getResp}); err != nil {
 			return util.Errorf("failed to read data")
 		}
 		if getResp.Value.GetInteger() != 5 {
@@ -257,7 +259,7 @@ func TestRestoreReplicas(t *testing.T) {
 	// Perform an increment before replication to ensure that commands are not
 	// repeated on restarts.
 	incArgs, incResp := incrementArgs([]byte("a"), 23, 1, mtc.stores[0].StoreID())
-	if err := mtc.stores[0].ExecuteCmd(client.Call{Args: incArgs, Reply: incResp}); err != nil {
+	if err := mtc.stores[0].ExecuteCmd(context.Background(), client.Call{Args: incArgs, Reply: incResp}); err != nil {
 		t.Fatal(err)
 	}
 
@@ -285,25 +287,25 @@ func TestRestoreReplicas(t *testing.T) {
 	// Send a command on each store. The original store (the leader still)
 	// will succeed.
 	incArgs, incResp = incrementArgs([]byte("a"), 5, 1, mtc.stores[0].StoreID())
-	if err := mtc.stores[0].ExecuteCmd(client.Call{Args: incArgs, Reply: incResp}); err != nil {
+	if err := mtc.stores[0].ExecuteCmd(context.Background(), client.Call{Args: incArgs, Reply: incResp}); err != nil {
 		t.Fatal(err)
 	}
 	// The follower will return a not leader error, indicating the command
 	// should be forwarded to the leader.
 	incArgs, incResp = incrementArgs([]byte("a"), 11, 1, mtc.stores[1].StoreID())
-	err = mtc.stores[1].ExecuteCmd(client.Call{Args: incArgs, Reply: incResp})
+	err = mtc.stores[1].ExecuteCmd(context.Background(), client.Call{Args: incArgs, Reply: incResp})
 	if _, ok := err.(*proto.NotLeaderError); !ok {
 		t.Fatalf("expected not leader error; got %s", err)
 	}
 	incArgs.Replica.StoreID = mtc.stores[0].StoreID()
-	if err := mtc.stores[0].ExecuteCmd(client.Call{Args: incArgs, Reply: incResp}); err != nil {
+	if err := mtc.stores[0].ExecuteCmd(context.Background(), client.Call{Args: incArgs, Reply: incResp}); err != nil {
 		t.Fatal(err)
 	}
 
 	if err := util.IsTrueWithin(func() bool {
 		getArgs, getResp := getArgs([]byte("a"), 1, mtc.stores[1].StoreID())
 		getArgs.ReadConsistency = proto.INCONSISTENT
-		if err := mtc.stores[1].ExecuteCmd(client.Call{Args: getArgs, Reply: getResp}); err != nil {
+		if err := mtc.stores[1].ExecuteCmd(context.Background(), client.Call{Args: getArgs, Reply: getResp}); err != nil {
 			return false
 		}
 		return getResp.Value.GetInteger() == 39
@@ -413,7 +415,7 @@ func TestReplicateAfterTruncation(t *testing.T) {
 
 	// Issue a command on the first node before replicating.
 	incArgs, incResp := incrementArgs([]byte("a"), 5, 1, mtc.stores[0].StoreID())
-	if err := mtc.stores[0].ExecuteCmd(client.Call{Args: incArgs, Reply: incResp}); err != nil {
+	if err := mtc.stores[0].ExecuteCmd(context.Background(), client.Call{Args: incArgs, Reply: incResp}); err != nil {
 		t.Fatal(err)
 	}
 
@@ -426,13 +428,13 @@ func TestReplicateAfterTruncation(t *testing.T) {
 	// Truncate the log at index+1 (log entries < N are removed, so this includes
 	// the increment).
 	truncArgs, truncResp := internalTruncateLogArgs(index+1, 1, mtc.stores[0].StoreID())
-	if err := mtc.stores[0].ExecuteCmd(client.Call{Args: truncArgs, Reply: truncResp}); err != nil {
+	if err := mtc.stores[0].ExecuteCmd(context.Background(), client.Call{Args: truncArgs, Reply: truncResp}); err != nil {
 		t.Fatal(err)
 	}
 
 	// Issue a second command post-truncation.
 	incArgs, incResp = incrementArgs([]byte("a"), 11, 1, mtc.stores[0].StoreID())
-	if err := mtc.stores[0].ExecuteCmd(client.Call{Args: incArgs, Reply: incResp}); err != nil {
+	if err := mtc.stores[0].ExecuteCmd(context.Background(), client.Call{Args: incArgs, Reply: incResp}); err != nil {
 		t.Fatal(err)
 	}
 	mvcc := rng.GetMVCCStats()
@@ -451,7 +453,7 @@ func TestReplicateAfterTruncation(t *testing.T) {
 	if err := util.IsTrueWithin(func() bool {
 		getArgs, getResp := getArgs([]byte("a"), 1, mtc.stores[1].StoreID())
 		getArgs.ReadConsistency = proto.INCONSISTENT
-		if err := mtc.stores[1].ExecuteCmd(client.Call{Args: getArgs, Reply: getResp}); err != nil {
+		if err := mtc.stores[1].ExecuteCmd(context.Background(), client.Call{Args: getArgs, Reply: getResp}); err != nil {
 			return false
 		}
 		if log.V(1) {
@@ -473,14 +475,14 @@ func TestReplicateAfterTruncation(t *testing.T) {
 	// Send a third command to verify that the log states are synced up so the
 	// new node can accept new commands.
 	incArgs, incResp = incrementArgs([]byte("a"), 23, 1, mtc.stores[0].StoreID())
-	if err := mtc.stores[0].ExecuteCmd(client.Call{Args: incArgs, Reply: incResp}); err != nil {
+	if err := mtc.stores[0].ExecuteCmd(context.Background(), client.Call{Args: incArgs, Reply: incResp}); err != nil {
 		t.Fatal(err)
 	}
 
 	if err := util.IsTrueWithin(func() bool {
 		getArgs, getResp := getArgs([]byte("a"), 1, mtc.stores[1].StoreID())
 		getArgs.ReadConsistency = proto.INCONSISTENT
-		if err := mtc.stores[1].ExecuteCmd(client.Call{Args: getArgs, Reply: getResp}); err != nil {
+		if err := mtc.stores[1].ExecuteCmd(context.Background(), client.Call{Args: getArgs, Reply: getResp}); err != nil {
 			return false
 		}
 		log.Infof("read value %d", getResp.Value.GetInteger())
@@ -532,7 +534,7 @@ func TestProgressWithDownNode(t *testing.T) {
 	mtc.replicateRange(raftID, 0, 1, 2)
 
 	incArgs, incResp := incrementArgs([]byte("a"), 5, raftID, mtc.stores[0].StoreID())
-	if err := mtc.stores[0].ExecuteCmd(client.Call{Args: incArgs, Reply: incResp}); err != nil {
+	if err := mtc.stores[0].ExecuteCmd(context.Background(), client.Call{Args: incArgs, Reply: incResp}); err != nil {
 		t.Fatal(err)
 	}
 
@@ -558,7 +560,7 @@ func TestProgressWithDownNode(t *testing.T) {
 	// Stop one of the replicas and issue a new increment.
 	mtc.stopStore(1)
 	incArgs, incResp = incrementArgs([]byte("a"), 11, raftID, mtc.stores[0].StoreID())
-	if err := mtc.stores[0].ExecuteCmd(client.Call{Args: incArgs, Reply: incResp}); err != nil {
+	if err := mtc.stores[0].ExecuteCmd(context.Background(), client.Call{Args: incArgs, Reply: incResp}); err != nil {
 		t.Fatal(err)
 	}
 
@@ -584,7 +586,7 @@ func TestReplicateAddAndRemove(t *testing.T) {
 		mtc.replicateRange(raftID, 0, 3, 1)
 
 		incArgs, incResp := incrementArgs([]byte("a"), 5, raftID, mtc.stores[0].StoreID())
-		if err := mtc.stores[0].ExecuteCmd(client.Call{Args: incArgs, Reply: incResp}); err != nil {
+		if err := mtc.stores[0].ExecuteCmd(context.Background(), client.Call{Args: incArgs, Reply: incResp}); err != nil {
 			t.Fatal(err)
 		}
 
@@ -621,7 +623,7 @@ func TestReplicateAddAndRemove(t *testing.T) {
 
 		// Ensure that the rest of the group can make progress.
 		incArgs, incResp = incrementArgs([]byte("a"), 11, raftID, mtc.stores[0].StoreID())
-		if err := mtc.stores[0].ExecuteCmd(client.Call{Args: incArgs, Reply: incResp}); err != nil {
+		if err := mtc.stores[0].ExecuteCmd(context.Background(), client.Call{Args: incArgs, Reply: incResp}); err != nil {
 			t.Fatal(err)
 		}
 		verify([]int64{16, 5, 16, 16})
@@ -632,7 +634,7 @@ func TestReplicateAddAndRemove(t *testing.T) {
 		// Node 1 never sees the increment that was added while it was
 		// down. Perform another increment on the live nodes to verify.
 		incArgs, incResp = incrementArgs([]byte("a"), 23, raftID, mtc.stores[0].StoreID())
-		if err := mtc.stores[0].ExecuteCmd(client.Call{Args: incArgs, Reply: incResp}); err != nil {
+		if err := mtc.stores[0].ExecuteCmd(context.Background(), client.Call{Args: incArgs, Reply: incResp}); err != nil {
 			t.Fatal(err)
 		}
 		verify([]int64{39, 5, 39, 39})

--- a/storage/client_status_test.go
+++ b/storage/client_status_test.go
@@ -22,6 +22,8 @@ import (
 	"testing"
 	"time"
 
+	"golang.org/x/net/context"
+
 	"github.com/cockroachdb/cockroach/client"
 	"github.com/cockroachdb/cockroach/proto"
 	"github.com/cockroachdb/cockroach/storage"
@@ -40,7 +42,7 @@ import (
 func compareStoreStatus(t *testing.T, store *storage.Store, expectedStoreStatus *proto.StoreStatus, testNumber int) *proto.StoreStatus {
 	storeStatusKey := engine.StoreStatusKey(int32(store.Ident.StoreID))
 	gArgs, gReply := getArgs(storeStatusKey, 1, store.Ident.StoreID)
-	if err := store.ExecuteCmd(client.Call{Args: gArgs, Reply: gReply}); err != nil {
+	if err := store.ExecuteCmd(context.Background(), client.Call{Args: gArgs, Reply: gReply}); err != nil {
 		t.Fatalf("%v: failure getting store status: %s", testNumber, err)
 	}
 	if gReply.Value == nil {
@@ -130,11 +132,11 @@ func TestStoreStatus(t *testing.T) {
 	// Write some values left and right of the proposed split key.
 	rng := store.LookupRange([]byte("a"), nil)
 	pArgs, pReply := putArgs([]byte("a"), content, rng.Desc().RaftID, store.StoreID())
-	if err := store.ExecuteCmd(client.Call{Args: pArgs, Reply: pReply}); err != nil {
+	if err := store.ExecuteCmd(context.Background(), client.Call{Args: pArgs, Reply: pReply}); err != nil {
 		t.Fatal(err)
 	}
 	pArgs, pReply = putArgs([]byte("c"), content, rng.Desc().RaftID, store.StoreID())
-	if err := store.ExecuteCmd(client.Call{Args: pArgs, Reply: pReply}); err != nil {
+	if err := store.ExecuteCmd(context.Background(), client.Call{Args: pArgs, Reply: pReply}); err != nil {
 		t.Fatal(err)
 	}
 
@@ -157,7 +159,7 @@ func TestStoreStatus(t *testing.T) {
 
 	// Split the range.
 	args, reply := adminSplitArgs(engine.KeyMin, splitKey, rng.Desc().RaftID, store.StoreID())
-	if err := store.ExecuteCmd(client.Call{Args: args, Reply: reply}); err != nil {
+	if err := store.ExecuteCmd(context.Background(), client.Call{Args: args, Reply: reply}); err != nil {
 		t.Fatal(err)
 	}
 
@@ -181,12 +183,12 @@ func TestStoreStatus(t *testing.T) {
 	// Write some values left and right of the split key.
 	rng = store.LookupRange([]byte("aa"), nil)
 	pArgs, pReply = putArgs([]byte("aa"), content, rng.Desc().RaftID, store.StoreID())
-	if err := store.ExecuteCmd(client.Call{Args: pArgs, Reply: pReply}); err != nil {
+	if err := store.ExecuteCmd(context.Background(), client.Call{Args: pArgs, Reply: pReply}); err != nil {
 		t.Fatal(err)
 	}
 	rng2 := store.LookupRange([]byte("cc"), nil)
 	pArgs, pReply = putArgs([]byte("cc"), content, rng2.Desc().RaftID, store.StoreID())
-	if err := store.ExecuteCmd(client.Call{Args: pArgs, Reply: pReply}); err != nil {
+	if err := store.ExecuteCmd(context.Background(), client.Call{Args: pArgs, Reply: pReply}); err != nil {
 		t.Fatal(err)
 	}
 

--- a/storage/gc_queue.go
+++ b/storage/gc_queue.go
@@ -216,7 +216,7 @@ func (gcq *gcQueue) process(now proto.Timestamp, rng *Range) error {
 
 	// Send GC request through range.
 	gcArgs.GCMeta = *gcMeta
-	if err := rng.AddCmd(client.Call{Args: gcArgs, Reply: &proto.InternalGCResponse{}}, true); err != nil {
+	if err := rng.AddCmd(rng.context(), client.Call{Args: gcArgs, Reply: &proto.InternalGCResponse{}}, true); err != nil {
 		return err
 	}
 
@@ -275,7 +275,7 @@ func (gcq *gcQueue) resolveIntent(rng *Range, key proto.Key, meta *proto.MVCCMet
 			Txn:       pushReply.PusheeTxn,
 		},
 	}
-	if err := rng.AddCmd(client.Call{Args: resolveArgs, Reply: &proto.InternalResolveIntentResponse{}}, true); err != nil {
+	if err := rng.AddCmd(rng.context(), client.Call{Args: resolveArgs, Reply: &proto.InternalResolveIntentResponse{}}, true); err != nil {
 		log.Warningf("resolve of key %q failed: %s", key, err)
 		updateOldestIntent(meta.Timestamp.WallTime)
 	}

--- a/storage/gc_queue_test.go
+++ b/storage/gc_queue_test.go
@@ -187,7 +187,7 @@ func TestGCQueueProcess(t *testing.T) {
 				dArgs.Txn = newTransaction("test", datum.key, 1, proto.SERIALIZABLE, tc.clock)
 				dArgs.Txn.Timestamp = datum.ts
 			}
-			if err := tc.rng.AddCmd(client.Call{Args: dArgs, Reply: dReply}, true); err != nil {
+			if err := tc.rng.AddCmd(tc.rng.context(), client.Call{Args: dArgs, Reply: dReply}, true); err != nil {
 				t.Fatalf("%d: could not delete data: %s", i, err)
 			}
 		} else {
@@ -197,7 +197,7 @@ func TestGCQueueProcess(t *testing.T) {
 				pArgs.Txn = newTransaction("test", datum.key, 1, proto.SERIALIZABLE, tc.clock)
 				pArgs.Txn.Timestamp = datum.ts
 			}
-			if err := tc.rng.AddCmd(client.Call{Args: pArgs, Reply: pReply}, true); err != nil {
+			if err := tc.rng.AddCmd(tc.rng.context(), client.Call{Args: pArgs, Reply: pReply}, true); err != nil {
 				t.Fatalf("%d: could not put data: %s", i, err)
 			}
 		}

--- a/storage/split_queue.go
+++ b/storage/split_queue.go
@@ -101,7 +101,7 @@ func (sq *splitQueue) process(now proto.Timestamp, rng *Range) error {
 		return err
 	}
 	if float64(rng.stats.GetSize())/float64(zone.RangeMaxBytes) > 1 {
-		if err = rng.AddCmd(
+		if err = rng.AddCmd(rng.context(),
 			client.Call{
 				Args: &proto.AdminSplitRequest{
 					RequestHeader: proto.RequestHeader{Key: rng.Desc().StartKey},

--- a/storage/store_test.go
+++ b/storage/store_test.go
@@ -80,7 +80,7 @@ type responseAdder interface {
 // supporting tests in this package. Transactions are not supported.
 // Since kv/ depends on storage/, we can't get access to a
 // txn_coord_sender from here.
-func (db *testSender) Send(call client.Call) {
+func (db *testSender) Send(_ context.Context, call client.Call) {
 	reqs := []requestUnion{}
 	switch t := call.Args.(type) {
 	case *proto.BatchRequest:

--- a/util/log/field.go
+++ b/util/log/field.go
@@ -31,6 +31,6 @@ const (
 	Client          // TODO: client on whose behalf we're acting
 	Err             // a wrapped error message, if applicable
 	Detail          // information intended for human eyes only
-	Key             // a proto.Key related to this event.
+	Key             // a proto.Key related to an event.
 	maxField        // internal field bounding the range of allocated fields
 )


### PR DESCRIPTION
Node/LocalSender now embeds a context which is passed down along with
client requests and threaded through the relevant code paths.
This sets the stage for populating the context as it makes it way down
with requests and moving to the `Infoc`-style logging functions throughout.

What we currently don't get are client ips, etc. But that's only a matter of
getting that information from the RPC framework or adding it in the messages
somehow.
