### PR TITLE
Add http-lb resolver

### DIFF
--- a/gossip/gossip.go
+++ b/gossip/gossip.go
@@ -63,7 +63,7 @@ import (
 	"sync"
 	"time"
 
-	"github.com/cockroachdb/cockroach/base"
+	"github.com/cockroachdb/cockroach/gossip/resolver"
 	"github.com/cockroachdb/cockroach/proto"
 	"github.com/cockroachdb/cockroach/rpc"
 	"github.com/cockroachdb/cockroach/util"
@@ -96,7 +96,7 @@ const (
 
 var (
 	// TestBootstrap is the default gossip bootstrap used for running tests.
-	TestBootstrap = []base.Resolver{}
+	TestBootstrap = []resolver.Resolver{}
 )
 
 func init() {
@@ -122,12 +122,12 @@ type Gossip struct {
 	// resolvers is a list of resolvers used to determine
 	// bootstrap hosts for connecting to the gossip network.
 	resolverIdx int
-	resolvers   []base.Resolver
+	resolvers   []resolver.Resolver
 	triedAll    bool // True when all resolvers have been tried once
 }
 
 // New creates an instance of a gossip node.
-func New(rpcContext *rpc.Context, gossipInterval time.Duration, resolvers []base.Resolver) *Gossip {
+func New(rpcContext *rpc.Context, gossipInterval time.Duration, resolvers []resolver.Resolver) *Gossip {
 	g := &Gossip{
 		Connected:     make(chan struct{}),
 		RPCContext:    rpcContext,
@@ -173,7 +173,7 @@ func (g *Gossip) SetNodeDescriptor(desc *proto.NodeDescriptor) error {
 
 // SetResolvers initializes the set of gossip resolvers used to
 // find nodes to bootstrap the gossip network.
-func (g *Gossip) SetResolvers(resolvers []base.Resolver) {
+func (g *Gossip) SetResolvers(resolvers []resolver.Resolver) {
 	g.mu.Lock()
 	defer g.mu.Unlock()
 	g.resolverIdx = 0

--- a/gossip/gossip.go
+++ b/gossip/gossip.go
@@ -63,6 +63,7 @@ import (
 	"sync"
 	"time"
 
+	"github.com/cockroachdb/cockroach/base"
 	"github.com/cockroachdb/cockroach/proto"
 	"github.com/cockroachdb/cockroach/rpc"
 	"github.com/cockroachdb/cockroach/util"
@@ -95,7 +96,7 @@ const (
 
 var (
 	// TestBootstrap is the default gossip bootstrap used for running tests.
-	TestBootstrap = []util.Resolver{}
+	TestBootstrap = []base.Resolver{}
 )
 
 func init() {
@@ -121,12 +122,12 @@ type Gossip struct {
 	// resolvers is a list of resolvers used to determine
 	// bootstrap hosts for connecting to the gossip network.
 	resolverIdx int
-	resolvers   []util.Resolver
+	resolvers   []base.Resolver
 	triedAll    bool // True when all resolvers have been tried once
 }
 
 // New creates an instance of a gossip node.
-func New(rpcContext *rpc.Context, gossipInterval time.Duration, resolvers []util.Resolver) *Gossip {
+func New(rpcContext *rpc.Context, gossipInterval time.Duration, resolvers []base.Resolver) *Gossip {
 	g := &Gossip{
 		Connected:     make(chan struct{}),
 		RPCContext:    rpcContext,
@@ -172,7 +173,7 @@ func (g *Gossip) SetNodeDescriptor(desc *proto.NodeDescriptor) error {
 
 // SetResolvers initializes the set of gossip resolvers used to
 // find nodes to bootstrap the gossip network.
-func (g *Gossip) SetResolvers(resolvers []util.Resolver) {
+func (g *Gossip) SetResolvers(resolvers []base.Resolver) {
 	g.mu.Lock()
 	defer g.mu.Unlock()
 	g.resolverIdx = 0

--- a/gossip/gossip_test.go
+++ b/gossip/gossip_test.go
@@ -22,9 +22,10 @@ import (
 	"testing"
 	"time"
 
+	"github.com/cockroachdb/cockroach/base"
+	"github.com/cockroachdb/cockroach/gossip/resolver"
 	"github.com/cockroachdb/cockroach/rpc"
 	"github.com/cockroachdb/cockroach/security"
-	"github.com/cockroachdb/cockroach/util"
 	"github.com/cockroachdb/cockroach/util/hlc"
 )
 
@@ -149,9 +150,9 @@ func TestGossipGetNextBootstrapAddress(t *testing.T) {
 		"lb=127.0.0.1:9005",
 	}
 
-	resolvers := []util.Resolver{}
+	resolvers := []base.Resolver{}
 	for _, rs := range resolverSpecs {
-		resolver, err := util.NewResolver(rs)
+		resolver, err := resolver.NewResolver(&base.Context{}, rs)
 		if err == nil {
 			resolvers = append(resolvers, resolver)
 		}

--- a/gossip/gossip_test.go
+++ b/gossip/gossip_test.go
@@ -150,7 +150,7 @@ func TestGossipGetNextBootstrapAddress(t *testing.T) {
 		"lb=127.0.0.1:9005",
 	}
 
-	resolvers := []base.Resolver{}
+	resolvers := []resolver.Resolver{}
 	for _, rs := range resolverSpecs {
 		resolver, err := resolver.NewResolver(&base.Context{}, rs)
 		if err == nil {

--- a/gossip/resolver/node_lookup.go
+++ b/gossip/resolver/node_lookup.go
@@ -1,0 +1,128 @@
+// Copyright 2015 The Cockroach Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+// implied. See the License for the specific language governing
+// permissions and limitations under the License. See the AUTHORS file
+// for names of contributors.
+//
+// Author: Marc Berhault (marc@cockroachlabs.com)
+
+package resolver
+
+import (
+	"encoding/json"
+	"fmt"
+	"io/ioutil"
+	"net"
+	"net/http"
+	"time"
+
+	"github.com/cockroachdb/cockroach/base"
+	"github.com/cockroachdb/cockroach/proto"
+	"github.com/cockroachdb/cockroach/util"
+	"github.com/cockroachdb/cockroach/util/log"
+)
+
+const lookupTimeout = time.Second * 3
+
+// nodeLookupResolver implements Resolver.
+// It queries http(s)://<address>/_status/nodes and extracts the first node's address.
+// This is useful for http load balancers which will not forward RPC.
+// It is never exhausted.
+type nodeLookupResolver struct {
+	context   *base.Context
+	typ       string
+	addr      string
+	exhausted bool
+	// We need our own client so that we may specify timeouts.
+	httpClient *http.Client
+}
+
+// Type returns the resolver type.
+func (nl *nodeLookupResolver) Type() string { return nl.typ }
+
+// Addr returns the resolver address.
+func (nl *nodeLookupResolver) Addr() string { return nl.addr }
+
+// GetAddress returns a net.Addr or error.
+// Upon errors, we set exhausted=true, then flip it back when called again.
+func (nl *nodeLookupResolver) GetAddress() (net.Addr, error) {
+	if nl.exhausted {
+		nl.exhausted = false
+		return nil, util.Errorf("skipping temporarily-exhausted resolved")
+	}
+
+	if nl.httpClient == nil {
+		tlsConfig, err := nl.context.GetClientTLSConfig()
+		if err != nil {
+			return nil, err
+		}
+		nl.httpClient = &http.Client{
+			Transport: &http.Transport{TLSClientConfig: tlsConfig},
+			Timeout:   lookupTimeout,
+		}
+	}
+
+	nl.exhausted = true
+	// TODO(marc): put common URIs in base and reuse everywhere.
+	url := fmt.Sprintf("%s://%s/_status/nodes", nl.context.RequestScheme(), nl.addr)
+	req, err := http.NewRequest("GET", url, nil)
+	if err != nil {
+		return nil, err
+	}
+	log.Infof("querying %s for gossip nodes", url)
+	resp, err := nl.httpClient.Do(req)
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close()
+
+	contents, err := ioutil.ReadAll(resp.Body)
+	if err != nil {
+		return nil, err
+	}
+
+	var nodes []*proto.NodeStatus
+	err = json.Unmarshal(contents, &nodes)
+	if err != nil {
+		return nil, err
+	}
+
+	for _, node := range nodes {
+		if node == nil {
+			continue
+		}
+		addr, err := resolveAddress(node.Desc.Address.Network, node.Desc.Address.Address)
+		if err != nil {
+			continue
+		}
+		nl.exhausted = false
+		log.Infof("found gossip node: %+v", addr)
+		return addr, nil
+	}
+
+	return nil, util.Errorf("no nodes addresses found in %s", contents)
+}
+
+func resolveAddress(network, address string) (net.Addr, error) {
+	if network == "tcp" {
+		_, err := net.ResolveTCPAddr("tcp", address)
+		if err != nil {
+			return nil, err
+		}
+		return util.MakeUnresolvedAddr("tcp", address), nil
+	}
+	return nil, util.Errorf("unknown address type: %q", network)
+}
+
+// IsExhausted returns whether the resolver can yield further
+// addresses.
+func (nl *nodeLookupResolver) IsExhausted() bool { return nl.exhausted }

--- a/gossip/resolver/node_lookup.go
+++ b/gossip/resolver/node_lookup.go
@@ -54,9 +54,16 @@ func (nl *nodeLookupResolver) Addr() string { return nl.addr }
 // GetAddress returns a net.Addr or error.
 // Upon errors, we set exhausted=true, then flip it back when called again.
 func (nl *nodeLookupResolver) GetAddress() (net.Addr, error) {
+	// TODO(marc): this is a bit of a hack to allow the server to start.
+	// In single-node setups, this resolver will never return anything since
+	// the status handlers are not serving yet. Instead, we specify multiple
+	// gossip addresses (--gossip=localhost,http-lb=lb). We need this one to
+	// be exhausted from time to time so that we have a chance to hit the fixed address.
+	// Remove once the status pages are served before we've established a connection to
+	// the gossip network.
 	if nl.exhausted {
 		nl.exhausted = false
-		return nil, util.Errorf("skipping temporarily-exhausted resolved")
+		return nil, util.Errorf("skipping temporarily-exhausted resolver")
 	}
 
 	if nl.httpClient == nil {

--- a/gossip/resolver/resolver.go
+++ b/gossip/resolver/resolver.go
@@ -48,7 +48,7 @@ var validTypes = map[string]struct{}{
 // - tcp: plain hostname of ip address
 // - lb: load balancer host name or ip: points to an unknown number of backends
 // - unix: unix sockets
-// - http-lb: http load balancer: queries http(s)://<lb>/_status/nodes for node addresses
+// - http-lb: http load balancer: queries http(s)://<lb>/_status/local for node addresses
 // If "network type" is not specified, "tcp" is assumed.
 func NewResolver(context *base.Context, spec string) (Resolver, error) {
 	parts := strings.Split(spec, "=")

--- a/gossip/resolver/socket.go
+++ b/gossip/resolver/socket.go
@@ -1,0 +1,67 @@
+// Copyright 2015 The Cockroach Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+// implied. See the License for the specific language governing
+// permissions and limitations under the License. See the AUTHORS file
+// for names of contributors.
+//
+// Author: Marc Berhault (marc@cockroachlabs.com)
+
+package resolver
+
+import (
+	"net"
+
+	"github.com/cockroachdb/cockroach/util"
+)
+
+// socketResolver represents the different types of socket-based
+// address resolvers. Based on the Type, it may return the same
+// address multiple times (eg: "lb") or not (eg: "tcp").
+type socketResolver struct {
+	typ       string
+	addr      string
+	exhausted bool // Can we try this resolver again?
+}
+
+// Type returns the resolver type.
+func (sr *socketResolver) Type() string { return sr.typ }
+
+// Addr returns the resolver address.
+func (sr *socketResolver) Addr() string { return sr.addr }
+
+// GetAddress returns a net.Addr or error.
+func (sr *socketResolver) GetAddress() (net.Addr, error) {
+	switch sr.typ {
+	case "unix":
+		addr, err := net.ResolveUnixAddr("unix", sr.addr)
+		if err != nil {
+			return nil, err
+		}
+		sr.exhausted = true
+		return addr, nil
+	case "tcp", "lb":
+		_, err := net.ResolveTCPAddr("tcp", sr.addr)
+		if err != nil {
+			return nil, err
+		}
+		if sr.typ == "tcp" {
+			// "tcp" resolvers point to a single host. "lb" have an unknown of number of backends.
+			sr.exhausted = true
+		}
+		return util.MakeUnresolvedAddr("tcp", sr.addr), nil
+	}
+	return nil, util.Errorf("unknown address type: %q", sr.typ)
+}
+
+// IsExhausted returns whether the resolver can yield further
+// addresses.
+func (sr *socketResolver) IsExhausted() bool { return sr.exhausted }

--- a/gossip/simulation/network.go
+++ b/gossip/simulation/network.go
@@ -20,7 +20,9 @@ package simulation
 import (
 	"time"
 
+	"github.com/cockroachdb/cockroach/base"
 	"github.com/cockroachdb/cockroach/gossip"
+	"github.com/cockroachdb/cockroach/gossip/resolver"
 	"github.com/cockroachdb/cockroach/proto"
 	"github.com/cockroachdb/cockroach/rpc"
 	"github.com/cockroachdb/cockroach/security"
@@ -80,9 +82,9 @@ func NewNetwork(nodeCount int, networkType string,
 
 	for i, leftNode := range nodes {
 		// Build new resolvers for each instance or we'll get data races.
-		var resolvers []util.Resolver
+		var resolvers []base.Resolver
 		for _, rightNode := range nodes[:numResolvers] {
-			resolvers = append(resolvers, util.NewResolverFromAddress(rightNode.Server.Addr()))
+			resolvers = append(resolvers, resolver.NewResolverFromAddress(rightNode.Server.Addr()))
 		}
 
 		gossipNode := gossip.New(rpcContext, gossipInterval, resolvers)

--- a/gossip/simulation/network.go
+++ b/gossip/simulation/network.go
@@ -20,7 +20,6 @@ package simulation
 import (
 	"time"
 
-	"github.com/cockroachdb/cockroach/base"
 	"github.com/cockroachdb/cockroach/gossip"
 	"github.com/cockroachdb/cockroach/gossip/resolver"
 	"github.com/cockroachdb/cockroach/proto"
@@ -82,7 +81,7 @@ func NewNetwork(nodeCount int, networkType string,
 
 	for i, leftNode := range nodes {
 		// Build new resolvers for each instance or we'll get data races.
-		var resolvers []base.Resolver
+		var resolvers []resolver.Resolver
 		for _, rightNode := range nodes[:numResolvers] {
 			resolvers = append(resolvers, resolver.NewResolverFromAddress(rightNode.Server.Addr()))
 		}

--- a/server/cli/flags.go
+++ b/server/cli/flags.go
@@ -77,7 +77,7 @@ var flagUsage = map[string]string{
           or "self" for single-node systems.
         - unix: unix socket
         - lb: RPC load balancer fowarding to an arbitrary node
-        - http-lb: HTTP load balancer: we query http(s)://<address>/_status/nodes
+        - http-lb: HTTP load balancer: we query http(s)://<address>/_status/local
 `,
 	"gossip-interval": `
         Approximate interval (time.Duration) for gossiping new information to peers.

--- a/server/cli/flags.go
+++ b/server/cli/flags.go
@@ -71,9 +71,13 @@ var flagUsage = map[string]string{
 	"gossip": `
         A comma-separated list of gossip addresses or resolvers for gossip
         bootstrap. Each item in the list has an optional type:
-        [type=]<address>. An unspecified type means ip address or dns. Type can
-        also be a load balancer ("lb"), a unix socket ("unix") or, for
-        single-node systems, "self".
+        [type=]<address>. An unspecified type means ip address or dns.
+        Type is one of:
+        - tcp: (default if type is omitted): plain ip address or hostname,
+          or "self" for single-node systems.
+        - unix: unix socket
+        - lb: RPC load balancer fowarding to an arbitrary node
+        - http-lb: HTTP load balancer: we query http(s)://<address>/_status/nodes
 `,
 	"gossip-interval": `
         Approximate interval (time.Duration) for gossiping new information to peers.

--- a/server/context.go
+++ b/server/context.go
@@ -105,7 +105,7 @@ type Context struct {
 
 	// GossipBootstrapResolvers is a list of gossip resolvers used
 	// to find bootstrap nodes for connecting to the gossip network.
-	GossipBootstrapResolvers []base.Resolver
+	GossipBootstrapResolvers []resolver.Resolver
 
 	// ScanInterval determines a duration during which each range should be
 	// visited approximately once by the range scanner.
@@ -197,8 +197,8 @@ func (ctx *Context) initEngine(attrsStr, path string) (engine.Engine, error) {
 
 // parseGossipBootstrapResolvers parses a comma-separated list of
 // gossip bootstrap resolvers.
-func (ctx *Context) parseGossipBootstrapResolvers() ([]base.Resolver, error) {
-	var bootstrapResolvers []base.Resolver
+func (ctx *Context) parseGossipBootstrapResolvers() ([]resolver.Resolver, error) {
+	var bootstrapResolvers []resolver.Resolver
 	addresses := strings.Split(ctx.GossipBootstrap, ",")
 	for _, address := range addresses {
 		if len(address) == 0 {

--- a/server/context.go
+++ b/server/context.go
@@ -26,6 +26,7 @@ import (
 	"time"
 
 	"github.com/cockroachdb/cockroach/base"
+	"github.com/cockroachdb/cockroach/gossip/resolver"
 	"github.com/cockroachdb/cockroach/proto"
 	"github.com/cockroachdb/cockroach/storage/engine"
 	"github.com/cockroachdb/cockroach/util"
@@ -104,7 +105,7 @@ type Context struct {
 
 	// GossipBootstrapResolvers is a list of gossip resolvers used
 	// to find bootstrap nodes for connecting to the gossip network.
-	GossipBootstrapResolvers []util.Resolver
+	GossipBootstrapResolvers []base.Resolver
 
 	// ScanInterval determines a duration during which each range should be
 	// visited approximately once by the range scanner.
@@ -196,8 +197,8 @@ func (ctx *Context) initEngine(attrsStr, path string) (engine.Engine, error) {
 
 // parseGossipBootstrapResolvers parses a comma-separated list of
 // gossip bootstrap resolvers.
-func (ctx *Context) parseGossipBootstrapResolvers() ([]util.Resolver, error) {
-	var bootstrapResolvers []util.Resolver
+func (ctx *Context) parseGossipBootstrapResolvers() ([]base.Resolver, error) {
+	var bootstrapResolvers []base.Resolver
 	addresses := strings.Split(ctx.GossipBootstrap, ",")
 	for _, address := range addresses {
 		if len(address) == 0 {
@@ -210,7 +211,7 @@ func (ctx *Context) parseGossipBootstrapResolvers() ([]util.Resolver, error) {
 		if strings.HasPrefix(address, "self://") {
 			address = util.EnsureHost(ctx.Addr)
 		}
-		resolver, err := util.NewResolver(address)
+		resolver, err := resolver.NewResolver(&ctx.Context, address)
 		if err != nil {
 			return nil, err
 		}

--- a/server/context_test.go
+++ b/server/context_test.go
@@ -21,7 +21,6 @@ import (
 	"reflect"
 	"testing"
 
-	"github.com/cockroachdb/cockroach/base"
 	"github.com/cockroachdb/cockroach/gossip/resolver"
 )
 
@@ -56,7 +55,7 @@ func TestParseGossipBootstrapAddrs(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	expected := []base.Resolver{r1, r2}
+	expected := []resolver.Resolver{r1, r2}
 	if !reflect.DeepEqual(ctx.GossipBootstrapResolvers, expected) {
 		t.Fatalf("Unexpected bootstrap addresses: %v, expected: %v", ctx.GossipBootstrapResolvers, expected)
 	}

--- a/server/context_test.go
+++ b/server/context_test.go
@@ -21,7 +21,8 @@ import (
 	"reflect"
 	"testing"
 
-	"github.com/cockroachdb/cockroach/util"
+	"github.com/cockroachdb/cockroach/base"
+	"github.com/cockroachdb/cockroach/gossip/resolver"
 )
 
 func TestParseNodeAttributes(t *testing.T) {
@@ -47,15 +48,15 @@ func TestParseGossipBootstrapAddrs(t *testing.T) {
 	if err := ctx.Init("start"); err != nil {
 		t.Fatalf("Failed to initialize the context: %v", err)
 	}
-	r1, err := util.NewResolver("tcp=localhost:12345")
+	r1, err := resolver.NewResolver(&ctx.Context, "tcp=localhost:12345")
 	if err != nil {
 		t.Fatal(err)
 	}
-	r2, err := util.NewResolver("tcp=localhost:23456")
+	r2, err := resolver.NewResolver(&ctx.Context, "tcp=localhost:23456")
 	if err != nil {
 		t.Fatal(err)
 	}
-	expected := []util.Resolver{r1, r2}
+	expected := []base.Resolver{r1, r2}
 	if !reflect.DeepEqual(ctx.GossipBootstrapResolvers, expected) {
 		t.Fatalf("Unexpected bootstrap addresses: %v, expected: %v", ctx.GossipBootstrapResolvers, expected)
 	}

--- a/server/node_test.go
+++ b/server/node_test.go
@@ -26,7 +26,6 @@ import (
 	"testing"
 	"time"
 
-	"github.com/cockroachdb/cockroach/base"
 	"github.com/cockroachdb/cockroach/client"
 	"github.com/cockroachdb/cockroach/gossip"
 	"github.com/cockroachdb/cockroach/gossip/resolver"
@@ -71,7 +70,7 @@ func createTestNode(addr net.Addr, engines []engine.Engine, gossipBS net.Addr, t
 		if gossipBS == addr {
 			gossipBS = rpcServer.Addr()
 		}
-		g.SetResolvers([]base.Resolver{resolver.NewResolverFromAddress(gossipBS)})
+		g.SetResolvers([]resolver.Resolver{resolver.NewResolverFromAddress(gossipBS)})
 		g.Start(rpcServer, stopper)
 	}
 	ctx.Gossip = g

--- a/server/node_test.go
+++ b/server/node_test.go
@@ -26,8 +26,10 @@ import (
 	"testing"
 	"time"
 
+	"github.com/cockroachdb/cockroach/base"
 	"github.com/cockroachdb/cockroach/client"
 	"github.com/cockroachdb/cockroach/gossip"
+	"github.com/cockroachdb/cockroach/gossip/resolver"
 	"github.com/cockroachdb/cockroach/kv"
 	"github.com/cockroachdb/cockroach/multiraft"
 	"github.com/cockroachdb/cockroach/proto"
@@ -69,7 +71,7 @@ func createTestNode(addr net.Addr, engines []engine.Engine, gossipBS net.Addr, t
 		if gossipBS == addr {
 			gossipBS = rpcServer.Addr()
 		}
-		g.SetResolvers([]util.Resolver{util.NewResolverFromAddress(gossipBS)})
+		g.SetResolvers([]base.Resolver{resolver.NewResolverFromAddress(gossipBS)})
 		g.Start(rpcServer, stopper)
 	}
 	ctx.Gossip = g

--- a/server/server.go
+++ b/server/server.go
@@ -27,8 +27,10 @@ import (
 	"sync"
 
 	"github.com/cockroachdb/c-snappy"
+	"github.com/cockroachdb/cockroach/base"
 	"github.com/cockroachdb/cockroach/client"
 	"github.com/cockroachdb/cockroach/gossip"
+	"github.com/cockroachdb/cockroach/gossip/resolver"
 	"github.com/cockroachdb/cockroach/kv"
 	"github.com/cockroachdb/cockroach/multiraft"
 	"github.com/cockroachdb/cockroach/resource"
@@ -156,11 +158,11 @@ func (s *Server) Start(selfBootstrap bool) error {
 
 	// Handle self-bootstrapping case for a single node.
 	if selfBootstrap {
-		selfResolver, err := util.NewResolver(s.rpc.Addr().String())
+		selfResolver, err := resolver.NewResolver(&s.ctx.Context, s.rpc.Addr().String())
 		if err != nil {
 			return err
 		}
-		s.gossip.SetResolvers([]util.Resolver{selfResolver})
+		s.gossip.SetResolvers([]base.Resolver{selfResolver})
 	}
 	s.gossip.Start(s.rpc, s.stopper)
 

--- a/server/server.go
+++ b/server/server.go
@@ -27,7 +27,6 @@ import (
 	"sync"
 
 	"github.com/cockroachdb/c-snappy"
-	"github.com/cockroachdb/cockroach/base"
 	"github.com/cockroachdb/cockroach/client"
 	"github.com/cockroachdb/cockroach/gossip"
 	"github.com/cockroachdb/cockroach/gossip/resolver"
@@ -162,7 +161,7 @@ func (s *Server) Start(selfBootstrap bool) error {
 		if err != nil {
 			return err
 		}
-		s.gossip.SetResolvers([]base.Resolver{selfResolver})
+		s.gossip.SetResolvers([]resolver.Resolver{selfResolver})
 	}
 	s.gossip.Start(s.rpc, s.stopper)
 


### PR DESCRIPTION
To be used with http-only load balancers.
We get http(s)://<load-balancer>/_status_nodes and extract the first node address to use as the gossip address.

There's some oddness I want to refactor before getting this in. Mainly, in single-node (or first node) setups, we will be talking to ourselves. We need to make sure the http server is up while this resolver fails. This is where the separate http client and exhausted logic comes in.

Moved resolver to base/ to avoid base<->util import cycle.
