### PR TITLE
fix bug in fanouting heartbeat response cause leader change to follower

### DIFF
--- a/multiraft/multiraft.go
+++ b/multiraft/multiraft.go
@@ -255,6 +255,10 @@ func (s *state) fanoutHeartbeatResponse(req *RaftMessageRequest) {
 			s.nodeID, fromID)
 		return
 	}
+	// Term in HeartbeatResponse is no meaning in fanouting. Otherwise it
+	// will cause Leader change to Follower if another group's term is
+	// greater than this.
+	req.Message.Term = 0
 	cnt := 0
 	for groupID := range originNode.groupIDs {
 		// If we don't think that the local node is leader, don't propagate.

--- a/multiraft/multiraft.go
+++ b/multiraft/multiraft.go
@@ -247,8 +247,7 @@ func (s *state) fanoutHeartbeat(req *RaftMessageRequest) {
 
 // fanoutHeartbeatResponse sends the given heartbeat response to all groups
 // which overlap with the sender's groups and consider themselves leader.
-func (s *state) fanoutHeartbeatResponse(req *RaftMessageRequest) {
-	fromID := proto.RaftNodeID(req.Message.From)
+func (s *state) fanoutHeartbeatResponse(fromID proto.RaftNodeID) {
 	originNode, ok := s.nodes[fromID]
 	if !ok {
 		log.Warningf("node %v: not fanning out heartbeat response from unknown node %v",
@@ -258,21 +257,25 @@ func (s *state) fanoutHeartbeatResponse(req *RaftMessageRequest) {
 	// Term in HeartbeatResponse is no meaning in fanouting. Otherwise it
 	// will cause Leader change to Follower if another group's term is
 	// greater than this.
-	req.Message.Term = 0
+	req := raftpb.Message{
+		From: uint64(fromID),
+		To:   uint64(s.nodeID),
+		Type: raftpb.MsgHeartbeatResp,
+	}
+
 	cnt := 0
 	for groupID := range originNode.groupIDs {
 		// If we don't think that the local node is leader, don't propagate.
 		if s.groups[groupID].leader != s.nodeID || fromID == s.nodeID {
 			if log.V(8) {
-				log.Infof("node %v: not fanning out heartbeat response to %v, msg is from %d and leader is %d",
-					s.nodeID, req.Message.To, fromID, s.groups[groupID].leader)
+				log.Infof("node %v: not fanning out heartbeat response to %v, leader is %v",
+					s.nodeID, fromID, s.groups[groupID].leader)
 			}
 			continue
 		}
-		if err := s.multiNode.Step(context.Background(), groupID, req.Message); err != nil {
+		if err := s.multiNode.Step(context.Background(), groupID, req); err != nil {
 			if log.V(4) {
-				log.Infof("node %v: coalesced heartbeat response step to group %v failed for message %s", s.nodeID, groupID,
-					raft.DescribeMessage(req.Message, s.EntryFormatter))
+				log.Infof("node %v: coalesced heartbeat response step to group %v failed", s.nodeID, groupID)
 			}
 		}
 		cnt++
@@ -491,7 +494,7 @@ func (s *state) start() {
 				case raftpb.MsgHeartbeat:
 					s.fanoutHeartbeat(req)
 				case raftpb.MsgHeartbeatResp:
-					s.fanoutHeartbeatResponse(req)
+					s.fanoutHeartbeatResponse(proto.RaftNodeID(req.Message.From))
 				default:
 					// We only want to lazily create the group if it's not heartbeat-related;
 					// our heartbeats are coalesced and contain a dummy GroupID.


### PR DESCRIPTION
Assume a cluster with 3 nodes(Node1,2,3) and 2 multiraft groups(Group1,2), both group have leader in Node1, but Group1 was in term 6, Group2 was term 8. When Node1 send Heartbeat request to Node2 and Node3, Group2 will respond with HeartbeatResponse with Term8. After Node1 receive this Heartbeat Response, it will fanout this response to Group1 and Group2. Group2 will process this normally. But Group1 will change Node1's leader state to follower in raft process (etcd/raft.go). So there will be no leader for Group1 for a long time as the coalesced heartbeat will let Node2 and Node3 think Node1 is leader and let Node1 think Node2 or Node3 is leader.

``` go
 func (r *raft) Step(m pb.Message) error {                                                                                                                                       
        if m.Type == pb.MsgHup {                                                                                                                                                
                raftLogger.Infof("raft: %x is starting a new election at term %d", r.id, r.Term)                                                                                
                r.campaign()                                                                                                                                                    
                r.Commit = r.raftLog.committed                                                                                                                                  
                return nil                                                                                                                                                      
        }                                                                                                                                                                       

        switch {                                                                                                                                                                
        case m.Term == 0:                                                                                                                                                       
                // local message                                                                                                                                                
        case m.Term > r.Term:                                                                                                                                                   
                lead := m.From                                                                                                                                                  
                if m.Type == pb.MsgVote {                                                                                                                                       
                        lead = None                                                                                                                                             
                }                                                                                                                                                               
                raftLogger.Infof("raft: %x [term: %d] received a %s message with higher term from %x [term: %d]",                                                               
                        r.id, r.Term, m.Type, m.From, m.Term)                                                                                                                   
                r.becomeFollower(m.Term, lead)  
```

There are several ways to solve this issue:
1. Before a Node fanout response, it change the term in Heartbeat response to 0, so raft will ignore the term.
2. a Node will not fanout Heartbeat response, as each group in the receive node will send the Heartbeat response back, so it's not required to fanout Heartbeat response.
3. To limit the Heartbeat response between 2 nodes, Heartbeat response can be handled like Heartbeat request: A. when a node receive a Heartbeat request, it will respond a Heartbeat response, then fanout the Heartbeat request to each group. B. Heartbeat response from each raft group will be discard in handleWriteResponse(multiraft.go). 

This fix is choice 1. Please help check.
