### PR TITLE
Unbuffer multiraft's input channels.

### DIFF
--- a/multiraft/multiraft_test.go
+++ b/multiraft/multiraft_test.go
@@ -71,7 +71,7 @@ func newTestCluster(transport Transport, size int, stopper *util.Stopper, t *tes
 			TickInterval:           time.Hour, // not in use
 			Strict:                 true,
 		}
-		mr, err := NewMultiRaft(proto.RaftNodeID(i+1), config)
+		mr, err := NewMultiRaft(proto.RaftNodeID(i+1), config, stopper)
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -83,14 +83,14 @@ func newTestCluster(transport Transport, size int, stopper *util.Stopper, t *tes
 		cluster.events = append(cluster.events, demux)
 		cluster.storages = append(cluster.storages, storage)
 	}
-	cluster.start(stopper)
+	cluster.start()
 	return cluster
 }
 
-func (c *testCluster) start(stopper *util.Stopper) {
+func (c *testCluster) start() {
 	// Let all the states listen before starting any.
 	for _, node := range c.nodes {
-		node.start(stopper)
+		node.start()
 	}
 }
 

--- a/storage/store.go
+++ b/storage/store.go
@@ -395,7 +395,7 @@ func (s *Store) Start(stopper *util.Stopper) error {
 		ElectionTimeoutTicks:   s.ctx.RaftElectionTimeoutTicks,
 		HeartbeatIntervalTicks: s.ctx.RaftHeartbeatIntervalTicks,
 		EntryFormatter:         raftEntryFormatter,
-	}); err != nil {
+	}, s.stopper); err != nil {
 		return err
 	}
 
@@ -443,7 +443,7 @@ func (s *Store) Start(stopper *util.Stopper) error {
 	sort.Sort(s.rangesByKey)
 
 	// Start Raft processing goroutines.
-	if err = s.multiraft.Start(s.stopper); err != nil {
+	if err = s.multiraft.Start(); err != nil {
 		return err
 	}
 	s.processRaft()


### PR DESCRIPTION
Buffering at this level makes it difficult to guarantee sequencing of
different operations from the outside.

This also fixes a potential bug in re-proposals: if the pending queue
ever exceeded the size of proposalChan's buffer, we would deadlock
trying to write to proposalChan. We now avoid this problem by calling
state.propose directly instead of sending everything back through the
channel.
