### PR TITLE
Return a channel from MultiRaft.{Create,Remove}Group.

### DIFF
--- a/multiraft/multiraft_test.go
+++ b/multiraft/multiraft_test.go
@@ -123,7 +123,7 @@ func (c *testCluster) createGroup(groupID uint64, firstNode, numReplicas int) {
 		}
 
 		node := c.nodes[firstNode+i]
-		err := node.CreateGroup(groupID)
+		err := <-node.CreateGroup(groupID)
 		if err != nil {
 			c.t.Fatal(err)
 		}
@@ -397,7 +397,7 @@ func TestRapidMembershipChange(t *testing.T) {
 			cmdID := fmt.Sprintf(cmdIDFormat, seq)
 		retry:
 			for {
-				if err := cluster.nodes[0].CreateGroup(groupID); err != nil {
+				if err := <-cluster.nodes[0].CreateGroup(groupID); err != nil {
 					t.Fatal(err)
 				}
 				if log.V(1) {
@@ -416,7 +416,7 @@ func TestRapidMembershipChange(t *testing.T) {
 					return
 				}
 			}
-			if err := cluster.nodes[0].RemoveGroup(groupID); err != nil {
+			if err := <-cluster.nodes[0].RemoveGroup(groupID); err != nil {
 				t.Fatal(err)
 			}
 		}

--- a/storage/store.go
+++ b/storage/store.go
@@ -1003,7 +1003,7 @@ func (s *Store) addRangeInternal(rng *Range, resort bool) error {
 func (s *Store) RemoveRange(rng *Range) error {
 	// RemoveGroup needs to access the storage, which in turn needs the
 	// lock. Some care is needed to avoid deadlocks.
-	if err := s.multiraft.RemoveGroup(uint64(rng.Desc().RaftID)); err != nil {
+	if err := <-s.multiraft.RemoveGroup(uint64(rng.Desc().RaftID)); err != nil {
 		return err
 	}
 	s.mu.Lock()
@@ -1248,7 +1248,7 @@ func (s *Store) ProposeRaftCommand(idKey cmdIDKey, cmd proto.InternalRaftCommand
 		panic("proposed a nil command")
 	}
 	// Lazily create group. TODO(bdarnell): make this non-lazy
-	err := s.multiraft.CreateGroup(uint64(cmd.RaftID))
+	err := <-s.multiraft.CreateGroup(uint64(cmd.RaftID))
 	if err != nil {
 		ch := make(chan error, 1)
 		ch <- err


### PR DESCRIPTION
This creates an opportunity for locking to fix a race in
ProposeRaftCommand.
