### PR TITLE
Do not process a range from rangeGCQueue when it has not yet been initialized

### DIFF
--- a/storage/range_gc_queue.go
+++ b/storage/range_gc_queue.go
@@ -100,6 +100,11 @@ func (q *rangeGCQueue) process(now proto.Timestamp, rng *Range) error {
 	}
 	desc := reply.Ranges[0]
 
+	if !rng.isInitialized() {
+		// Do not process since the range might not have any replica.
+		return nil
+	}
+
 	currentMember := false
 	me := rng.GetReplica()
 	for _, rep := range desc.Replicas {


### PR DESCRIPTION
This might happen only in tests, but the following test caused a panic if the range GC queue tries to process the bootstrap range while `replicateRange()` is called.

```
func TestRangeGCQueue(t *testing.T) {
     defer leaktest.AfterTest(t)
     mtc := &multiTestContext{}
     mtc.Start(t, 3)
     defer mtc.Stop()
     raftID := int64(1)
     mtc.replicateRange(raftID, 0, 1, 2)
}
```

The panic message is following:

```
L="FATAL" T="5/16 01:24:02.783" F="range.go:442" Msg="own replica missing in range at store 3"
```

Here is what happened (I think):

1) `replicateRange()` calls `ChangeReplicas()`, which starts a txn to update the range descriptor.
2) Store 3 receives a Raft message from an unknown Raft group (ID 1).
3) Store 3 creates a new range with Raft ID 1 via `GroupStorage()`. The method does not populate a replica list.
4) Before the txn is committed and the range's replica list is updated, the range GC queue tries to process the range.
5) `GetReplica()` causes a panic since no replica is found.

Alternative solutions:
- Make `GroupStorage()` somehow populate a replica list.
- Disable the scanner in `multiTestContext`.
