### PR TITLE
Update multiraft's group/node mapping when receiving a snapshot.

### DIFF
--- a/storage/client_test.go
+++ b/storage/client_test.go
@@ -89,17 +89,18 @@ func createTestStoreWithEngine(t *testing.T, eng engine.Engine, clock *hlc.Clock
 }
 
 type multiTestContext struct {
-	t           *testing.T
-	manualClock *hlc.ManualClock
-	clock       *hlc.Clock
-	gossip      *gossip.Gossip
-	transport   multiraft.Transport
-	db          *client.KV
-	feed        *util.Feed
-	engines     []engine.Engine
-	senders     []*kv.LocalSender
-	stores      []*storage.Store
-	idents      []proto.StoreIdent
+	t            *testing.T
+	storeContext *storage.StoreContext
+	manualClock  *hlc.ManualClock
+	clock        *hlc.Clock
+	gossip       *gossip.Gossip
+	transport    multiraft.Transport
+	db           *client.KV
+	feed         *util.Feed
+	engines      []engine.Engine
+	senders      []*kv.LocalSender
+	stores       []*storage.Store
+	idents       []proto.StoreIdent
 	// We use multiple stoppers so we can restart different parts of the
 	// test individually. clientStopper is for 'db', transportStopper is
 	// for 'transport', and the 'stoppers' slice corresponds to the
@@ -168,7 +169,12 @@ func (m *multiTestContext) Stop() {
 }
 
 func (m *multiTestContext) makeContext() storage.StoreContext {
-	ctx := storage.TestStoreContext
+	var ctx storage.StoreContext
+	if m.storeContext != nil {
+		ctx = *m.storeContext
+	} else {
+		ctx = storage.TestStoreContext
+	}
 	ctx.Clock = m.clock
 	ctx.DB = m.db
 	ctx.Gossip = m.gossip

--- a/storage/store.go
+++ b/storage/store.go
@@ -34,6 +34,7 @@ import (
 	"github.com/cockroachdb/cockroach/util/encoding"
 	"github.com/cockroachdb/cockroach/util/hlc"
 	"github.com/cockroachdb/cockroach/util/log"
+	"github.com/coreos/etcd/raft"
 	"github.com/coreos/etcd/raft/raftpb"
 	gogoproto "github.com/gogo/protobuf/proto"
 	"golang.org/x/net/context"
@@ -759,6 +760,11 @@ func (s *Store) LookupRange(start, end proto.Key) *Range {
 		return nil
 	}
 	return s.rangesByKey[n]
+}
+
+// RaftStatus returns the current raft status of the given range.
+func (s *Store) RaftStatus(raftID int64) raft.Status {
+	return s.multiraft.Status(uint64(raftID))
 }
 
 // BootstrapRange creates the first range in the cluster and manually


### PR DESCRIPTION
Expose the raft.MultiNode.Status method through MultiRaft and Store.

Add a basic test for coalesced heartbeats. Unfortunately this doesn't
actually detect the snapshot bug fixed in this change (I've seen
problems related to this but haven't been able to reproduce them in a
test).
