### PR TITLE
Add a maxIdleTime parameter to rangeScanner.

### DIFF
--- a/server/cli/flags.go
+++ b/server/cli/flags.go
@@ -105,6 +105,10 @@ var flagUsage = map[string]string{
         ranges. The scan is slowed as necessary to approximately achieve this
         duration.
 `,
+	"scan-max-idle-time": `
+        Adjusts the max idle time of the scanner. This speeds up the scanner on small
+        clusters to be more responsive.
+`,
 	"stores": `
         A comma-separated list of stores, specified by a colon-separated list
         of device attributes followed by '=' and either a filepath for a
@@ -162,6 +166,8 @@ func initFlags(ctx *server.Context) {
 		// Engine flags.
 		f.Int64Var(&ctx.CacheSize, "cache-size", ctx.CacheSize, flagUsage["cache-size"])
 		f.DurationVar(&ctx.ScanInterval, "scan-interval", ctx.ScanInterval, flagUsage["scan-interval"])
+		f.DurationVar(&ctx.ScanMaxIdleTime, "scan-max-idle-time", ctx.ScanMaxIdleTime,
+			flagUsage["scan-max-idle-time"])
 
 		startCmd.MarkFlagRequired("gossip")
 		startCmd.MarkFlagRequired("stores")

--- a/server/context.go
+++ b/server/context.go
@@ -40,6 +40,7 @@ const (
 	defaultGossipInterval   = 2 * time.Second
 	defaultCacheSize        = 1 << 30 // GB
 	defaultScanInterval     = 10 * time.Minute
+	defaultScanMaxIdleTime  = 5 * time.Second
 	defaultMetricsFrequency = 10 * time.Second
 )
 
@@ -111,6 +112,11 @@ type Context struct {
 	// visited approximately once by the range scanner.
 	ScanInterval time.Duration
 
+	// ScanMaxIdleTime is the maximum time the scanner will be idle between ranges.
+	// If enabled (> 0), the scanner may complete in less than ScanInterval for small
+	// stores.
+	ScanMaxIdleTime time.Duration
+
 	// MetricsFrequency determines the frequency at which the server should
 	// record internal metrics.
 	MetricsFrequency time.Duration
@@ -124,6 +130,7 @@ func NewContext() *Context {
 		GossipInterval:   defaultGossipInterval,
 		CacheSize:        defaultCacheSize,
 		ScanInterval:     defaultScanInterval,
+		ScanMaxIdleTime:  defaultScanMaxIdleTime,
 		MetricsFrequency: defaultMetricsFrequency,
 	}
 	// Initializes base context defaults.

--- a/server/server.go
+++ b/server/server.go
@@ -128,12 +128,13 @@ func NewServer(ctx *Context, stopper *util.Stopper) (*Server, error) {
 	s.kvREST = kv.NewRESTServer(s.kv)
 	// TODO(bdarnell): make StoreConfig configurable.
 	nCtx := storage.StoreContext{
-		Clock:        s.clock,
-		DB:           s.kv,
-		Gossip:       s.gossip,
-		Transport:    s.raftTransport,
-		ScanInterval: s.ctx.ScanInterval,
-		EventFeed:    &util.Feed{},
+		Clock:           s.clock,
+		DB:              s.kv,
+		Gossip:          s.gossip,
+		Transport:       s.raftTransport,
+		ScanInterval:    s.ctx.ScanInterval,
+		ScanMaxIdleTime: s.ctx.ScanMaxIdleTime,
+		EventFeed:       &util.Feed{},
 	}
 	s.node = NewNode(nCtx)
 	s.admin = newAdminServer(s.kv, s.stopper)

--- a/storage/scanner_test.go
+++ b/storage/scanner_test.go
@@ -189,7 +189,7 @@ func TestScannerAddToQueues(t *testing.T) {
 	// We don't want to actually consume entries from the queues during this test.
 	q1.setDisabled(true)
 	q2.setDisabled(true)
-	s := newRangeScanner(1*time.Millisecond, iter, nil)
+	s := newRangeScanner(1*time.Millisecond, 0, iter, nil)
 	s.AddQueues(q1, q2)
 	mc := hlc.NewManualClock(0)
 	clock := hlc.NewClock(mc.UnixNano)
@@ -233,7 +233,7 @@ func TestScannerTiming(t *testing.T) {
 	for i, duration := range durations {
 		iter := newTestIterator(count)
 		q := &testQueue{}
-		s := newRangeScanner(duration, iter, nil)
+		s := newRangeScanner(duration, 0, iter, nil)
 		s.AddQueues(q)
 		mc := hlc.NewManualClock(0)
 		clock := hlc.NewClock(mc.UnixNano)
@@ -271,16 +271,16 @@ func TestScannerPaceInterval(t *testing.T) {
 	for _, duration := range durations {
 		startTime := time.Now()
 		iter := newTestIterator(count)
-		s := newRangeScanner(duration, iter, nil)
+		s := newRangeScanner(duration, 0, iter, nil)
 		interval := s.paceInterval(startTime, startTime)
 		logErrorWhenNotCloseTo(duration/count, interval)
 		// The iterator is empty
 		iter = newTestIterator(0)
-		s = newRangeScanner(duration, iter, nil)
+		s = newRangeScanner(duration, 0, iter, nil)
 		interval = s.paceInterval(startTime, startTime)
 		logErrorWhenNotCloseTo(duration, interval)
 		iter = newTestIterator(count)
-		s = newRangeScanner(duration, iter, nil)
+		s = newRangeScanner(duration, 0, iter, nil)
 		// Move the present to duration time into the future
 		interval = s.paceInterval(startTime, startTime.Add(duration))
 		logErrorWhenNotCloseTo(0, interval)
@@ -292,7 +292,7 @@ func TestScannerEmptyIterator(t *testing.T) {
 	defer leaktest.AfterTest(t)
 	iter := newTestIterator(0)
 	q := &testQueue{}
-	s := newRangeScanner(1*time.Millisecond, iter, nil)
+	s := newRangeScanner(1*time.Millisecond, 0, iter, nil)
 	s.AddQueues(q)
 	mc := hlc.NewManualClock(0)
 	clock := hlc.NewClock(mc.UnixNano)
@@ -313,7 +313,7 @@ func TestScannerStats(t *testing.T) {
 	q := &testQueue{}
 	stopper := util.NewStopper()
 	defer stopper.Stop()
-	s := newRangeScanner(1*time.Millisecond, iter, nil)
+	s := newRangeScanner(1*time.Millisecond, 0, iter, nil)
 	s.AddQueues(q)
 	mc := hlc.NewManualClock(0)
 	clock := hlc.NewClock(mc.UnixNano)

--- a/storage/store.go
+++ b/storage/store.go
@@ -263,6 +263,11 @@ type StoreContext struct {
 	// ScanInterval is the default value for the scan interval
 	ScanInterval time.Duration
 
+	// ScanMaxIdleTime is the maximum time the scanner will be idle between ranges.
+	// If enabled (> 0), the scanner may complete in less than ScanInterval for small
+	// stores.
+	ScanMaxIdleTime time.Duration
+
 	// EventFeed is a feed to which this store will publish events.
 	EventFeed *util.Feed
 }
@@ -311,7 +316,8 @@ func NewStore(ctx StoreContext, eng engine.Engine, nodeDesc *proto.NodeDescripto
 	}
 
 	// Add range scanner and configure with queues.
-	s.scanner = newRangeScanner(ctx.ScanInterval, newStoreRangeIterator(s), s.updateStoreStatus)
+	s.scanner = newRangeScanner(ctx.ScanInterval, ctx.ScanMaxIdleTime, newStoreRangeIterator(s),
+		s.updateStoreStatus)
 	s.gcQueue = newGCQueue()
 	s._splitQueue = newSplitQueue(s.ctx.DB, s.ctx.Gossip)
 	s.verifyQueue = newVerifyQueue(s.scanner.Stats)


### PR DESCRIPTION
This is a quick fix for #1058 to make the scanner more responsive in
small clusters.
