### PR TITLE
Use `self=` instead of `self://` as the magic gossip single-node config.

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,7 +83,7 @@ DIR=$(mktemp -d /tmp/dbXXX)
 # Initialize data directories.
 ./cockroach init --stores=ssd=$DIR
 # Start the server.
-./cockroach start --stores=ssd="$DIR" --gossip=self:// &
+./cockroach start --stores=ssd="$DIR" --gossip=self= &
 ```
 This initializes and starts a single-node cluster in the background.
 
@@ -175,7 +175,7 @@ docker run --volumes-from=$(docker ps -q -n 1) cockroachdb/cockroach \
 docker run --volumes-from=$(docker ps -q -n 1) cockroachdb/cockroach \
   cert create-node --certs=/certs 127.0.0.1 localhost roachnode
 docker run -p 8080:8080 -h roachnode --volumes-from=$(docker ps -q -n 1) \
-  cockroachdb/cockroach start --certs=/certs --stores=ssd=/data --gossip=self://
+  cockroachdb/cockroach start --certs=/certs --stores=ssd=/data --gossip=self=
 ```
 
 Run `docker run cockroachdb/cockroach help` to get an overview over the available commands and settings, and see [Running Cockroach](#running-cockroach) for first steps on interacting with your new node.

--- a/server/context.go
+++ b/server/context.go
@@ -204,11 +204,11 @@ func (ctx *Context) parseGossipBootstrapResolvers() ([]resolver.Resolver, error)
 		if len(address) == 0 {
 			continue
 		}
-		// Special case self:// to pick a nice address that resolves
+		// Special case self= to pick a nice address that resolves
 		// uniquely for use in Gossip. This avoids having to specify
 		// the port for single-node clusters twice (once in --addr,
 		// once in --gossip).
-		if strings.HasPrefix(address, "self://") {
+		if strings.HasPrefix(address, "self=") {
 			address = util.EnsureHost(ctx.Addr)
 		}
 		resolver, err := resolver.NewResolver(&ctx.Context, address)

--- a/server/context_test.go
+++ b/server/context_test.go
@@ -28,7 +28,7 @@ func TestParseNodeAttributes(t *testing.T) {
 	ctx := NewContext()
 	ctx.Attrs = "attr1=val1::attr2=val2"
 	ctx.Stores = "mem=1"
-	ctx.GossipBootstrap = "self://"
+	ctx.GossipBootstrap = "self="
 	if err := ctx.Init("start"); err != nil {
 		t.Fatalf("Failed to initialize the context: %v", err)
 	}

--- a/server/server_test.go
+++ b/server/server_test.go
@@ -83,7 +83,7 @@ func TestInitEngine(t *testing.T) {
 	}
 	for _, spec := range testCases {
 		ctx := NewContext()
-		ctx.Stores, ctx.GossipBootstrap = spec.key, "self://"
+		ctx.Stores, ctx.GossipBootstrap = spec.key, "self="
 		err := ctx.Init("start")
 		engines := ctx.Engines
 		if err == nil {
@@ -115,7 +115,7 @@ func TestInitEngines(t *testing.T) {
 
 	ctx := NewContext()
 	ctx.Stores = fmt.Sprintf("mem=1000,mem:ddr3=1000,ssd=%s,hdd:7200rpm=%s", tmp[0], tmp[1])
-	ctx.GossipBootstrap = "self://"
+	ctx.GossipBootstrap = "self="
 	expEngines := []struct {
 		attrs proto.Attributes
 		isMem bool


### PR DESCRIPTION
The gossip flag takes values like `tcp=192.168.1.1:8080`, not urls,
so use the same style.
