### PR TITLE
dispatch Raft messages in goroutine

### DIFF
--- a/rpc/client.go
+++ b/rpc/client.go
@@ -139,9 +139,10 @@ func (c *Client) connect(opts *util.RetryOptions, context *Context) {
 		c.mu.Unlock()
 
 		// Ensure at least one heartbeat succeeds before exiting the
-		// retry loop.
+		// retry loop. If it fails, don't retry: The node is probably
+		// dead.
 		if err = c.heartbeat(); err != nil {
-			return util.RetryContinue, err
+			return util.RetryBreak, err
 		}
 
 		// Signal client is ready by closing Ready channel.

--- a/rpc/client.go
+++ b/rpc/client.go
@@ -124,7 +124,7 @@ func (c *Client) connect(opts *util.RetryOptions, context *Context) {
 		retryOpts = *opts
 	}
 	retryOpts.Tag = fmt.Sprintf("client %s connection", c.addr)
-	retryOpts.Stopper = context.stopper
+	retryOpts.Stopper = context.Stopper
 
 	err := util.RetryWithBackoff(retryOpts, func() (util.RetryStatus, error) {
 		conn, err := tlsDialHTTP(c.addr.Network(), c.addr.String(), context.tlsConfig)

--- a/rpc/rpc.go
+++ b/rpc/rpc.go
@@ -11,7 +11,7 @@ import (
 type Context struct {
 	localClock   *hlc.Clock
 	tlsConfig    *tls.Config
-	stopper      *util.Stopper
+	Stopper      *util.Stopper
 	RemoteClocks *RemoteClockMonitor
 	DisableCache bool // Disable client cache when calling NewClient()
 }
@@ -21,7 +21,7 @@ func NewContext(clock *hlc.Clock, config *tls.Config, stopper *util.Stopper) *Co
 	return &Context{
 		localClock:   clock,
 		tlsConfig:    config,
-		stopper:      stopper,
+		Stopper:      stopper,
 		RemoteClocks: newRemoteClockMonitor(clock),
 	}
 }
@@ -32,7 +32,7 @@ func (c *Context) Copy() *Context {
 	return &Context{
 		localClock:   c.localClock,
 		tlsConfig:    c.tlsConfig,
-		stopper:      c.stopper,
+		Stopper:      c.Stopper,
 		RemoteClocks: newRemoteClockMonitor(c.localClock),
 		DisableCache: c.DisableCache,
 	}

--- a/server/raft_transport_test.go
+++ b/server/raft_transport_test.go
@@ -39,11 +39,20 @@ func (s ChannelServer) RaftMessage(req *multiraft.RaftMessageRequest,
 }
 
 func TestSendAndReceive(t *testing.T) {
+	defer func(t time.Duration) {
+		raftMessageTimeout = t
+	}(raftMessageTimeout)
+	// Practically disable the Raft message timeout for this test.
+	// CircleCI + Race testing is not a happy marriage for channel-based
+	// consumers.
+	raftMessageTimeout = time.Minute
 	tlsConfig, err := testContext.GetServerTLSConfig()
 	if err != nil {
 		t.Fatal(err)
 	}
-	rpcContext := rpc.NewContext(hlc.NewClock(hlc.UnixNano), tlsConfig, nil)
+	stopper := util.NewStopper()
+	defer stopper.Stop()
+	rpcContext := rpc.NewContext(hlc.NewClock(hlc.UnixNano), tlsConfig, stopper)
 	g := gossip.New(rpcContext, gossip.TestInterval, gossip.TestBootstrap)
 
 	// Create several servers, each of which has two stores (A multiraft node ID addresses
@@ -129,7 +138,7 @@ func TestSendAndReceive(t *testing.T) {
 					t.Errorf("invalid message received on channel %d (expected from %d): %+v",
 						nodeIDs[to], nodeIDs[from], req)
 				}
-			case <-time.After(time.Second):
+			case <-time.After(5 * time.Second):
 				t.Fatal("timed out waiting for message")
 			}
 		}

--- a/server/raft_transport_test.go
+++ b/server/raft_transport_test.go
@@ -39,13 +39,6 @@ func (s ChannelServer) RaftMessage(req *multiraft.RaftMessageRequest,
 }
 
 func TestSendAndReceive(t *testing.T) {
-	defer func(t time.Duration) {
-		raftMessageTimeout = t
-	}(raftMessageTimeout)
-	// Practically disable the Raft message timeout for this test.
-	// CircleCI + Race testing is not a happy marriage for channel-based
-	// consumers.
-	raftMessageTimeout = time.Minute
 	tlsConfig, err := testContext.GetServerTLSConfig()
 	if err != nil {
 		t.Fatal(err)


### PR DESCRIPTION
Prior to this change, Transport.Send() would wait for the RPC client to be
ready, which can block for arbitrary amounts of time, on top of there not
being a timeout after which the call was discarded (potentially forever).

fixes #1073
