### PR TITLE
Fix handling of "infinite" clock offsets.

### DIFF
--- a/proto/heartbeat.go
+++ b/proto/heartbeat.go
@@ -20,15 +20,8 @@ package proto
 
 import (
 	"fmt"
-	"math"
 	"time"
 )
-
-// InfiniteOffset is the offset value used if we fail to detect a heartbeat.
-var InfiniteOffset = RemoteOffset{
-	Offset:      math.MaxInt64,
-	Uncertainty: 0,
-}
 
 // Equal is a equality comparison between remote offsets.
 func (r RemoteOffset) Equal(o RemoteOffset) bool {

--- a/proto/heartbeat.pb.go
+++ b/proto/heartbeat.pb.go
@@ -17,9 +17,10 @@ var _ = math.Inf
 // remote server. Uncertainty is the maximum error in the reading of this
 // offset, so that the real offset should be in the interval
 // [Offset - Uncertainty, Offset + Uncertainty]. If the last heartbeat timed
-// out, Offset = InfiniteOffset. Offset and Uncertainty are measured using the
-// remote clock reading technique described in
-// http://se.inf.tu-dresden.de/pubs/papers/SRDS1994.pdf, page 6.
+// out, Offset = 0.
+//
+// Offset and Uncertainty are measured using the remote clock reading technique
+// described in http://se.inf.tu-dresden.de/pubs/papers/SRDS1994.pdf, page 6.
 type RemoteOffset struct {
 	// The estimated offset from the remote server, in nanoseconds.
 	Offset int64 `protobuf:"varint,1,opt,name=offset" json:"offset"`

--- a/proto/heartbeat.proto
+++ b/proto/heartbeat.proto
@@ -26,9 +26,10 @@ import "gogoproto/gogo.proto";
 // remote server. Uncertainty is the maximum error in the reading of this
 // offset, so that the real offset should be in the interval
 // [Offset - Uncertainty, Offset + Uncertainty]. If the last heartbeat timed
-// out, Offset = InfiniteOffset. Offset and Uncertainty are measured using the
-// remote clock reading technique described in
-// http://se.inf.tu-dresden.de/pubs/papers/SRDS1994.pdf, page 6.
+// out, Offset = 0.
+//
+// Offset and Uncertainty are measured using the remote clock reading technique
+// described in http://se.inf.tu-dresden.de/pubs/papers/SRDS1994.pdf, page 6.
 message RemoteOffset {
   option (gogoproto.goproto_stringer) = false;
 

--- a/rpc/client.go
+++ b/rpc/client.go
@@ -265,18 +265,19 @@ func (c *Client) heartbeat() error {
 				remoteTimeNow := response.ServerTime + (receiveTime-sendTime)/2
 				c.offset.Offset = remoteTimeNow - receiveTime
 			}
+			offset := c.offset
 			c.mu.Unlock()
-			c.remoteClocks.UpdateOffset(c.addr.String(), c.offset)
+			c.remoteClocks.UpdateOffset(c.addr.String(), offset)
 		}
 		return call.Error
 	case <-time.After(heartbeatInterval * 2):
-		// Allowed twice gossip interval.
+		// Allowed twice heartbeat interval.
 		c.mu.Lock()
 		c.healthy = false
 		c.offset = proto.InfiniteOffset
-		c.offset.MeasuredAt = c.clock.PhysicalNow()
+		offset := c.offset
 		c.mu.Unlock()
-		c.remoteClocks.UpdateOffset(c.addr.String(), c.offset)
+		c.remoteClocks.UpdateOffset(c.addr.String(), offset)
 		log.Warningf("client %s unhealthy after %s", c.Addr(), heartbeatInterval)
 	case <-c.Closed:
 		return util.Errorf("client is closed")

--- a/rpc/client.go
+++ b/rpc/client.go
@@ -252,32 +252,32 @@ func (c *Client) heartbeat() error {
 			// successful response from the server.
 			c.mu.Lock()
 			c.healthy = true
-			c.offset.MeasuredAt = receiveTime
 			if receiveTime-sendTime > maximumClockReadingDelay.Nanoseconds() {
-				c.offset = proto.InfiniteOffset
+				c.offset.Reset()
 			} else {
 				// Offset and error are measured using the remote clock reading
 				// technique described in
 				// http://se.inf.tu-dresden.de/pubs/papers/SRDS1994.pdf, page 6.
 				// However, we assume that drift and min message delay are 0, for
 				// now.
+				c.offset.MeasuredAt = receiveTime
 				c.offset.Uncertainty = (receiveTime - sendTime) / 2
 				remoteTimeNow := response.ServerTime + (receiveTime-sendTime)/2
 				c.offset.Offset = remoteTimeNow - receiveTime
 			}
 			offset := c.offset
 			c.mu.Unlock()
-			c.remoteClocks.UpdateOffset(c.addr.String(), offset)
+			if offset.MeasuredAt != 0 {
+				c.remoteClocks.UpdateOffset(c.addr.String(), offset)
+			}
 		}
 		return call.Error
 	case <-time.After(heartbeatInterval * 2):
 		// Allowed twice heartbeat interval.
 		c.mu.Lock()
 		c.healthy = false
-		c.offset = proto.InfiniteOffset
-		offset := c.offset
+		c.offset.Reset()
 		c.mu.Unlock()
-		c.remoteClocks.UpdateOffset(c.addr.String(), offset)
 		log.Warningf("client %s unhealthy after %s", c.Addr(), heartbeatInterval)
 	case <-c.Closed:
 		return util.Errorf("client is closed")

--- a/rpc/client_test.go
+++ b/rpc/client_test.go
@@ -140,9 +140,9 @@ func TestOffsetMeasurement(t *testing.T) {
 	context.RemoteClocks.mu.Unlock()
 }
 
-// TestDelayedOffsetMeasurement tests that the client will record an
-// InfiniteOffset if the heartbeat reply exceeds the maximumClockReadingDelay,
-// but not the heartbeat timeout.
+// TestDelayedOffsetMeasurement tests that the client will record a
+// zero offset if the heartbeat reply exceeds the
+// maximumClockReadingDelay, but not the heartbeat timeout.
 func TestDelayedOffsetMeasurement(t *testing.T) {
 	serverManual := hlc.NewManualClock(10)
 	serverClock := hlc.NewClock(serverManual.UnixNano)
@@ -173,11 +173,11 @@ func TestDelayedOffsetMeasurement(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	// Since the reply took too long, we should have an InfiniteOffset, even
+	// Since the reply took too long, we should have a zero offset, even
 	// though the client is still healthy because it received a heartbeat
 	// reply.
-	if o := c.RemoteOffset(); !o.Equal(proto.InfiniteOffset) {
-		t.Errorf("expected offset %v, actual %v", proto.InfiniteOffset, o)
+	if o := c.RemoteOffset(); !o.Equal(proto.RemoteOffset{}) {
+		t.Errorf("expected offset %v, actual %v", proto.RemoteOffset{}, o)
 	}
 
 	// Ensure the general offsets map was updated properly too.
@@ -217,9 +217,9 @@ func TestFailedOffestMeasurement(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if !c.RemoteOffset().Equal(proto.InfiniteOffset) {
+	if !c.RemoteOffset().Equal(proto.RemoteOffset{}) {
 		t.Errorf("expected offset %v, actual %v",
-			proto.InfiniteOffset, c.RemoteOffset())
+			proto.RemoteOffset{}, c.RemoteOffset())
 	}
 }
 

--- a/rpc/client_test.go
+++ b/rpc/client_test.go
@@ -182,8 +182,8 @@ func TestDelayedOffsetMeasurement(t *testing.T) {
 
 	// Ensure the general offsets map was updated properly too.
 	context.RemoteClocks.mu.Lock()
-	if o := context.RemoteClocks.offsets[c.addr.String()]; !o.Equal(proto.InfiniteOffset) {
-		t.Errorf("expected offset %v, actual %v", proto.InfiniteOffset, o)
+	if o, ok := context.RemoteClocks.offsets[c.addr.String()]; ok {
+		t.Errorf("expected offset to not exist, but found %v", o)
 	}
 	context.RemoteClocks.mu.Unlock()
 }

--- a/rpc/clock_offset.go
+++ b/rpc/clock_offset.go
@@ -112,8 +112,7 @@ func newRemoteClockMonitor(clock *hlc.Clock) *RemoteClockMonitor {
 // 1. There is no prior offset for that address.
 // 2. The old offset for addr was measured before r.lastMonitoredAt. We never
 // use values during monitoring that are older than r.lastMonitoredAt.
-// 3. The new offset's error is smaller than the old offset's error. Note:
-// InfiniteOffsets implicitly have the largest error.
+// 3. The new offset's error is smaller than the old offset's error.
 //
 // The third case allows the monitor to use the most precise clock reading of
 // the remote addr during the next findOffsetInterval() invocation. We may
@@ -125,9 +124,6 @@ func newRemoteClockMonitor(clock *hlc.Clock) *RemoteClockMonitor {
 // information.
 func (r *RemoteClockMonitor) UpdateOffset(addr string, offset proto.RemoteOffset) {
 	if r == nil {
-		return
-	}
-	if offset.Equal(proto.InfiniteOffset) {
 		return
 	}
 

--- a/rpc/clock_offset_test.go
+++ b/rpc/clock_offset_test.go
@@ -67,17 +67,17 @@ func TestUpdateOffset(t *testing.T) {
 		t.Errorf("expected offset %v, instead %v", offset3, o)
 	}
 
-	// InfiniteOffset, shouldn't update because it has larger error.
+	// InfiniteOffset, shouldn't update...ever.
 	monitor.UpdateOffset("addr", proto.InfiniteOffset)
 	if o := monitor.offsets["addr"]; !o.Equal(offset3) {
 		t.Errorf("expected offset %v, instead %v", offset3, o)
 	}
 
-	// LastMonitoredAt moved up, so InfiniteOffset can be added now.
+	// LastMonitoredAt moved up, InfiniteOffset should still not update.
 	monitor.lastMonitoredAt = 10
 	monitor.UpdateOffset("addr", proto.InfiniteOffset)
-	if o := monitor.offsets["addr"]; !o.Equal(proto.InfiniteOffset) {
-		t.Errorf("expected offset %v, instead %v", proto.InfiniteOffset, o)
+	if o := monitor.offsets["addr"]; !o.Equal(offset3) {
+		t.Errorf("expected offset %v, instead %v", offset3, o)
 	}
 }
 


### PR DESCRIPTION
Infinite clock offsets are generated when a heartbeat times out (6s) or
takes too long to finish (greater than 1.5s). Previously, such offsets
were treated as valid values as part of the cluster offset interval
calculation, but doing so meant that a sufficient number of slow nodes
in a cluster (or a sufficiently slow network) would guarantee an
unhealthy clock offset interval to be calculated.

Now we never add "infinite" offsets to the clock offset monitor map. The
monitor is more pessimistic and will only suicide if the set of
good (non-infinite) clock offsets it has computes a cluster offset
interval that is larger than the max offset interval. If a node cannot
talk to any other nodes then no its cluster offset interval will be
considered healthy.
