### PR TITLE
Rename: `RemoteOffset.{Error,Uncertainty}`

### DIFF
--- a/proto/heartbeat.go
+++ b/proto/heartbeat.go
@@ -26,17 +26,17 @@ import (
 
 // InfiniteOffset is the offset value used if we fail to detect a heartbeat.
 var InfiniteOffset = RemoteOffset{
-	Offset: math.MaxInt64,
-	Error:  0,
+	Offset:      math.MaxInt64,
+	Uncertainty: 0,
 }
 
 // Equal is a equality comparison between remote offsets.
 func (r RemoteOffset) Equal(o RemoteOffset) bool {
-	return r.Offset == o.Offset && r.Error == o.Error && r.MeasuredAt == o.MeasuredAt
+	return r.Offset == o.Offset && r.Uncertainty == o.Uncertainty && r.MeasuredAt == o.MeasuredAt
 }
 
 // String formats the RemoteOffset for human readability.
 func (r RemoteOffset) String() string {
 	t := time.Unix(r.MeasuredAt/1E9, 0).UTC()
-	return fmt.Sprintf("off=%.9fs, err=%.9fs, at=%s", float64(r.Offset)/1E9, float64(r.Error)/1E9, t)
+	return fmt.Sprintf("off=%.9fs, err=%.9fs, at=%s", float64(r.Offset)/1E9, float64(r.Uncertainty)/1E9, t)
 }

--- a/proto/heartbeat.pb.go
+++ b/proto/heartbeat.pb.go
@@ -14,17 +14,17 @@ var _ = proto1.Marshal
 var _ = math.Inf
 
 // RemoteOffset keeps track of this client's estimate of its offset from a
-// remote server. Error is the maximum error in the reading of this offset, so
-// that the real offset should be in the interval [Offset - Error, Offset
-// + Error]. If the last heartbeat timed out, Offset = InfiniteOffset.
-//
-// Offset and error are measured using the remote clock reading technique
-// described in http://se.inf.tu-dresden.de/pubs/papers/SRDS1994.pdf, page 6.
+// remote server. Uncertainty is the maximum error in the reading of this
+// offset, so that the real offset should be in the interval
+// [Offset - Uncertainty, Offset + Uncertainty]. If the last heartbeat timed
+// out, Offset = InfiniteOffset. Offset and Uncertainty are measured using the
+// remote clock reading technique described in
+// http://se.inf.tu-dresden.de/pubs/papers/SRDS1994.pdf, page 6.
 type RemoteOffset struct {
 	// The estimated offset from the remote server, in nanoseconds.
 	Offset int64 `protobuf:"varint,1,opt,name=offset" json:"offset"`
 	// The maximum error of the measured offset, in nanoseconds.
-	Error int64 `protobuf:"varint,2,opt,name=error" json:"error"`
+	Uncertainty int64 `protobuf:"varint,2,opt,name=uncertainty" json:"uncertainty"`
 	// Measurement time, in nanoseconds from unix epoch.
 	MeasuredAt       int64  `protobuf:"varint,3,opt,name=measured_at" json:"measured_at"`
 	XXX_unrecognized []byte `json:"-"`
@@ -40,9 +40,9 @@ func (m *RemoteOffset) GetOffset() int64 {
 	return 0
 }
 
-func (m *RemoteOffset) GetError() int64 {
+func (m *RemoteOffset) GetUncertainty() int64 {
 	if m != nil {
-		return m.Error
+		return m.Uncertainty
 	}
 	return 0
 }

--- a/proto/heartbeat.proto
+++ b/proto/heartbeat.proto
@@ -23,19 +23,19 @@ option go_package = "proto";
 import "gogoproto/gogo.proto";
 
 // RemoteOffset keeps track of this client's estimate of its offset from a
-// remote server. Error is the maximum error in the reading of this offset, so
-// that the real offset should be in the interval [Offset - Error, Offset
-// + Error]. If the last heartbeat timed out, Offset = InfiniteOffset.
-//
-// Offset and error are measured using the remote clock reading technique
-// described in http://se.inf.tu-dresden.de/pubs/papers/SRDS1994.pdf, page 6.
+// remote server. Uncertainty is the maximum error in the reading of this
+// offset, so that the real offset should be in the interval
+// [Offset - Uncertainty, Offset + Uncertainty]. If the last heartbeat timed
+// out, Offset = InfiniteOffset. Offset and Uncertainty are measured using the
+// remote clock reading technique described in
+// http://se.inf.tu-dresden.de/pubs/papers/SRDS1994.pdf, page 6.
 message RemoteOffset {
   option (gogoproto.goproto_stringer) = false;
 
   // The estimated offset from the remote server, in nanoseconds.
   optional int64 offset = 1 [(gogoproto.nullable) = false];
   // The maximum error of the measured offset, in nanoseconds.
-  optional int64 error = 2 [(gogoproto.nullable) = false];
+  optional int64 uncertainty = 2 [(gogoproto.nullable) = false];
   // Measurement time, in nanoseconds from unix epoch.
   optional int64 measured_at = 3 [(gogoproto.nullable) = false];
 }

--- a/proto/heartbeat_test.go
+++ b/proto/heartbeat_test.go
@@ -21,9 +21,9 @@ import "testing"
 
 func TestRemoteOffsetString(t *testing.T) {
 	ro := RemoteOffset{
-		Offset:     -501584461,
-		Error:      351698,
-		MeasuredAt: 1430348776127420269,
+		Offset:      -501584461,
+		Uncertainty: 351698,
+		MeasuredAt:  1430348776127420269,
 	}
 	expStr := "off=-0.501584461s, err=0.000351698s, at=2015-04-29 23:06:16 +0000 UTC"
 	if str := ro.String(); str != expStr {

--- a/rpc/client.go
+++ b/rpc/client.go
@@ -261,7 +261,7 @@ func (c *Client) heartbeat() error {
 				// http://se.inf.tu-dresden.de/pubs/papers/SRDS1994.pdf, page 6.
 				// However, we assume that drift and min message delay are 0, for
 				// now.
-				c.offset.Error = (receiveTime - sendTime) / 2
+				c.offset.Uncertainty = (receiveTime - sendTime) / 2
 				remoteTimeNow := response.ServerTime + (receiveTime-sendTime)/2
 				c.offset.Offset = remoteTimeNow - receiveTime
 			}

--- a/rpc/client_test.go
+++ b/rpc/client_test.go
@@ -127,7 +127,7 @@ func TestOffsetMeasurement(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	expectedOffset := proto.RemoteOffset{Offset: 5, Error: 5, MeasuredAt: 10}
+	expectedOffset := proto.RemoteOffset{Offset: 5, Uncertainty: 5, MeasuredAt: 10}
 	if o := c.RemoteOffset(); !o.Equal(expectedOffset) {
 		t.Errorf("expected offset %v, actual %v", expectedOffset, o)
 	}

--- a/rpc/clock_offset.go
+++ b/rpc/clock_offset.go
@@ -139,7 +139,7 @@ func (r *RemoteClockMonitor) UpdateOffset(addr string, offset proto.RemoteOffset
 		r.offsets[addr] = offset
 	} else if oldOffset.MeasuredAt >= r.lastMonitoredAt &&
 		!offset.Equal(proto.InfiniteOffset) &&
-		offset.Error < oldOffset.Error {
+		offset.Uncertainty < oldOffset.Uncertainty {
 		r.offsets[addr] = offset
 	}
 }
@@ -295,11 +295,11 @@ func (r *RemoteClockMonitor) buildEndpointList() endpointList {
 		}
 
 		lowpoint := endpoint{
-			offset:  o.Offset - o.Error - r.lClock.MaxOffset().Nanoseconds(),
+			offset:  o.Offset - o.Uncertainty - r.lClock.MaxOffset().Nanoseconds(),
 			endType: -1,
 		}
 		highpoint := endpoint{
-			offset:  o.Offset + o.Error + r.lClock.MaxOffset().Nanoseconds(),
+			offset:  o.Offset + o.Uncertainty + r.lClock.MaxOffset().Nanoseconds(),
 			endType: +1,
 		}
 		endpoints = append(endpoints, lowpoint, highpoint)

--- a/rpc/clock_offset_test.go
+++ b/rpc/clock_offset_test.go
@@ -41,9 +41,9 @@ func TestUpdateOffset(t *testing.T) {
 	// Case 2: The old offset for addr was measured before lastMonitoredAt.
 	monitor.lastMonitoredAt = 5
 	offset2 := proto.RemoteOffset{
-		Offset:     0,
-		Error:      20,
-		MeasuredAt: 6,
+		Offset:      0,
+		Uncertainty: 20,
+		MeasuredAt:  6,
 	}
 	monitor.UpdateOffset("addr", offset2)
 	if o := monitor.offsets["addr"]; !o.Equal(offset2) {
@@ -52,9 +52,9 @@ func TestUpdateOffset(t *testing.T) {
 
 	// Case 3: The new offset's error is smaller.
 	offset3 := proto.RemoteOffset{
-		Offset:     0,
-		Error:      10,
-		MeasuredAt: 8,
+		Offset:      0,
+		Uncertainty: 10,
+		MeasuredAt:  8,
 	}
 	monitor.UpdateOffset("addr", offset3)
 	if o := monitor.offsets["addr"]; !o.Equal(offset3) {
@@ -118,10 +118,10 @@ func TestEndpointListSort(t *testing.T) {
 func TestBuildEndpointList(t *testing.T) {
 	// Build the offsets we will turn into an endpoint list.
 	offsets := map[string]proto.RemoteOffset{
-		"0": {Offset: 0, Error: 10},
-		"1": {Offset: 1, Error: 10},
-		"2": {Offset: 2, Error: 10},
-		"3": {Offset: 3, Error: 10},
+		"0": {Offset: 0, Uncertainty: 10},
+		"1": {Offset: 1, Uncertainty: 10},
+		"2": {Offset: 2, Uncertainty: 10},
+		"3": {Offset: 3, Uncertainty: 10},
 	}
 	manual := hlc.NewManualClock(0)
 	clock := hlc.NewClock(manual.UnixNano)
@@ -162,10 +162,10 @@ func TestBuildEndpointList(t *testing.T) {
 // older offsets when we build an endpoint list.
 func TestBuildEndpointListRemoveStagnantClocks(t *testing.T) {
 	offsets := map[string]proto.RemoteOffset{
-		"0":         {Offset: 0, Error: 10, MeasuredAt: 11},
-		"stagnant0": {Offset: 1, Error: 10, MeasuredAt: 0},
-		"1":         {Offset: 2, Error: 10, MeasuredAt: 20},
-		"stagnant1": {Offset: 3, Error: 10, MeasuredAt: 9},
+		"0":         {Offset: 0, Uncertainty: 10, MeasuredAt: 11},
+		"stagnant0": {Offset: 1, Uncertainty: 10, MeasuredAt: 0},
+		"1":         {Offset: 2, Uncertainty: 10, MeasuredAt: 20},
+		"stagnant1": {Offset: 3, Uncertainty: 10, MeasuredAt: 9},
 	}
 
 	// The stagnant offsets older than 10ns ago will be removed.
@@ -196,10 +196,10 @@ func TestFindOffsetInterval(t *testing.T) {
 	// Build the offsets. We will return the interval that the maximum number
 	// of remote clocks overlap.
 	offsets := map[string]proto.RemoteOffset{
-		"0": {Offset: 20, Error: 10},
-		"1": {Offset: 58, Error: 20},
-		"2": {Offset: 71, Error: 25},
-		"3": {Offset: 91, Error: 31},
+		"0": {Offset: 20, Uncertainty: 10},
+		"1": {Offset: 58, Uncertainty: 20},
+		"2": {Offset: 71, Uncertainty: 25},
+		"3": {Offset: 91, Uncertainty: 31},
 	}
 
 	manual := hlc.NewManualClock(0)
@@ -219,10 +219,10 @@ func TestFindOffsetIntervalNoMajorityOverlap(t *testing.T) {
 	// Build the offsets. We will return the interval that the maximum number
 	// of remote clocks overlap.
 	offsets := map[string]proto.RemoteOffset{
-		"0": {Offset: 0, Error: 1},
-		"1": {Offset: 1, Error: 1},
-		"2": {Offset: 3, Error: 1},
-		"3": {Offset: 4, Error: 1},
+		"0": {Offset: 0, Uncertainty: 1},
+		"1": {Offset: 1, Uncertainty: 1},
+		"2": {Offset: 3, Uncertainty: 1},
+		"3": {Offset: 4, Uncertainty: 1},
 	}
 
 	manual := hlc.NewManualClock(0)
@@ -240,7 +240,7 @@ func TestFindOffsetIntervalNoMajorityOverlap(t *testing.T) {
 // interval for an infinite offset.
 func TestFindOffsetIntervalWithInfinites(t *testing.T) {
 	offsets := map[string]proto.RemoteOffset{
-		"0": {Offset: 0, Error: 1},
+		"0": {Offset: 0, Uncertainty: 1},
 		"1": proto.InfiniteOffset,
 		"2": proto.InfiniteOffset,
 		"3": proto.InfiniteOffset,
@@ -279,7 +279,7 @@ func TestFindOffsetIntervalNoRemotes(t *testing.T) {
 // of the single remote clock.
 func TestFindOffsetIntervalOneClock(t *testing.T) {
 	offsets := map[string]proto.RemoteOffset{
-		"0": {Offset: 0, Error: 10},
+		"0": {Offset: 0, Uncertainty: 10},
 	}
 
 	manual := hlc.NewManualClock(0)
@@ -308,14 +308,14 @@ func TestFindOffsetIntervalTwoClocks(t *testing.T) {
 	}
 
 	// Two intervals overlap.
-	offsets["0"] = proto.RemoteOffset{Offset: 0, Error: 10}
-	offsets["1"] = proto.RemoteOffset{Offset: 20, Error: 10}
+	offsets["0"] = proto.RemoteOffset{Offset: 0, Uncertainty: 10}
+	offsets["1"] = proto.RemoteOffset{Offset: 20, Uncertainty: 10}
 	expectedInterval := ClusterOffsetInterval{Lowerbound: 10, Upperbound: 10}
 	assertClusterOffset(remoteClocks, expectedInterval, t)
 
 	// Two intervals don't overlap.
-	offsets["0"] = proto.RemoteOffset{Offset: 0, Error: 10}
-	offsets["1"] = proto.RemoteOffset{Offset: 30, Error: 10}
+	offsets["0"] = proto.RemoteOffset{Offset: 0, Uncertainty: 10}
+	offsets["1"] = proto.RemoteOffset{Offset: 30, Uncertainty: 10}
 	assertMajorityIntervalError(remoteClocks, t)
 }
 
@@ -330,9 +330,9 @@ func TestFindOffsetWithLargeError(t *testing.T) {
 	clock.SetMaxOffset(maxOffset)
 	offsets := map[string]proto.RemoteOffset{}
 	// Offsets are bigger than maxOffset, but Errors are also bigger than Offset.
-	offsets["0"] = proto.RemoteOffset{Offset: 110, Error: 300}
-	offsets["1"] = proto.RemoteOffset{Offset: 120, Error: 300}
-	offsets["2"] = proto.RemoteOffset{Offset: 130, Error: 300}
+	offsets["0"] = proto.RemoteOffset{Offset: 110, Uncertainty: 300}
+	offsets["1"] = proto.RemoteOffset{Offset: 120, Uncertainty: 300}
+	offsets["2"] = proto.RemoteOffset{Offset: 130, Uncertainty: 300}
 
 	remoteClocks := &RemoteClockMonitor{
 		offsets: offsets,

--- a/rpc/heartbeat_test.go
+++ b/rpc/heartbeat_test.go
@@ -106,9 +106,9 @@ func TestUpdateOffsetOnHeartbeat(t *testing.T) {
 		clock:        sContext.localClock,
 		remoteClocks: sContext.RemoteClocks,
 		offset: proto.RemoteOffset{
-			Offset:     10,
-			Error:      5,
-			MeasuredAt: 20,
+			Offset:      10,
+			Uncertainty: 5,
+			MeasuredAt:  20,
 		},
 	}
 	go client.connect(nil, sContext)
@@ -118,7 +118,7 @@ func TestUpdateOffsetOnHeartbeat(t *testing.T) {
 	remoteAddr := client.Addr().String()
 	o := sContext.RemoteClocks.offsets[remoteAddr]
 	sContext.RemoteClocks.mu.Unlock()
-	expServerOffset := proto.RemoteOffset{Offset: -10, Error: 5, MeasuredAt: 20}
+	expServerOffset := proto.RemoteOffset{Offset: -10, Uncertainty: 5, MeasuredAt: 20}
 	if o.Equal(expServerOffset) {
 		t.Errorf("expected updated offset %v, instead %v", expServerOffset, o)
 	}

--- a/storage/engine/cockroach/proto/heartbeat.pb.cc
+++ b/storage/engine/cockroach/proto/heartbeat.pb.cc
@@ -43,7 +43,7 @@ void protobuf_AssignDesc_cockroach_2fproto_2fheartbeat_2eproto() {
   RemoteOffset_descriptor_ = file->message_type(0);
   static const int RemoteOffset_offsets_[3] = {
     GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(RemoteOffset, offset_),
-    GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(RemoteOffset, error_),
+    GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(RemoteOffset, uncertainty_),
     GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(RemoteOffset, measured_at_),
   };
   RemoteOffset_reflection_ =
@@ -130,14 +130,14 @@ void protobuf_AddDesc_cockroach_2fproto_2fheartbeat_2eproto() {
   ::gogoproto::protobuf_AddDesc_gogoproto_2fgogo_2eproto();
   ::google::protobuf::DescriptorPool::InternalAddGeneratedFile(
     "\n\037cockroach/proto/heartbeat.proto\022\017cockr"
-    "oach.proto\032\024gogoproto/gogo.proto\"Z\n\014Remo"
-    "teOffset\022\024\n\006offset\030\001 \001(\003B\004\310\336\037\000\022\023\n\005error\030"
-    "\002 \001(\003B\004\310\336\037\000\022\031\n\013measured_at\030\003 \001(\003B\004\310\336\037\000:\004"
-    "\230\240\037\000\"j\n\013PingRequest\022\022\n\004ping\030\001 \001(\tB\004\310\336\037\000\022"
-    "3\n\006offset\030\002 \001(\0132\035.cockroach.proto.Remote"
-    "OffsetB\004\310\336\037\000\022\022\n\004addr\030\003 \001(\tB\004\310\336\037\000\"=\n\014Ping"
-    "Response\022\022\n\004pong\030\001 \001(\tB\004\310\336\037\000\022\031\n\013server_t"
-    "ime\030\002 \001(\003B\004\310\336\037\000B\007Z\005proto", 344);
+    "oach.proto\032\024gogoproto/gogo.proto\"`\n\014Remo"
+    "teOffset\022\024\n\006offset\030\001 \001(\003B\004\310\336\037\000\022\031\n\013uncert"
+    "ainty\030\002 \001(\003B\004\310\336\037\000\022\031\n\013measured_at\030\003 \001(\003B\004"
+    "\310\336\037\000:\004\230\240\037\000\"j\n\013PingRequest\022\022\n\004ping\030\001 \001(\tB"
+    "\004\310\336\037\000\0223\n\006offset\030\002 \001(\0132\035.cockroach.proto."
+    "RemoteOffsetB\004\310\336\037\000\022\022\n\004addr\030\003 \001(\tB\004\310\336\037\000\"="
+    "\n\014PingResponse\022\022\n\004pong\030\001 \001(\tB\004\310\336\037\000\022\031\n\013se"
+    "rver_time\030\002 \001(\003B\004\310\336\037\000B\007Z\005proto", 350);
   ::google::protobuf::MessageFactory::InternalRegisterGeneratedFile(
     "cockroach/proto/heartbeat.proto", &protobuf_RegisterTypes);
   RemoteOffset::default_instance_ = new RemoteOffset();
@@ -160,7 +160,7 @@ struct StaticDescriptorInitializer_cockroach_2fproto_2fheartbeat_2eproto {
 
 #ifndef _MSC_VER
 const int RemoteOffset::kOffsetFieldNumber;
-const int RemoteOffset::kErrorFieldNumber;
+const int RemoteOffset::kUncertaintyFieldNumber;
 const int RemoteOffset::kMeasuredAtFieldNumber;
 #endif  // !_MSC_VER
 
@@ -183,7 +183,7 @@ RemoteOffset::RemoteOffset(const RemoteOffset& from)
 void RemoteOffset::SharedCtor() {
   _cached_size_ = 0;
   offset_ = GOOGLE_LONGLONG(0);
-  error_ = GOOGLE_LONGLONG(0);
+  uncertainty_ = GOOGLE_LONGLONG(0);
   measured_at_ = GOOGLE_LONGLONG(0);
   ::memset(_has_bits_, 0, sizeof(_has_bits_));
 }
@@ -259,18 +259,18 @@ bool RemoteOffset::MergePartialFromCodedStream(
         } else {
           goto handle_unusual;
         }
-        if (input->ExpectTag(16)) goto parse_error;
+        if (input->ExpectTag(16)) goto parse_uncertainty;
         break;
       }
 
-      // optional int64 error = 2;
+      // optional int64 uncertainty = 2;
       case 2: {
         if (tag == 16) {
-         parse_error:
+         parse_uncertainty:
           DO_((::google::protobuf::internal::WireFormatLite::ReadPrimitive<
                    ::google::protobuf::int64, ::google::protobuf::internal::WireFormatLite::TYPE_INT64>(
-                 input, &error_)));
-          set_has_error();
+                 input, &uncertainty_)));
+          set_has_uncertainty();
         } else {
           goto handle_unusual;
         }
@@ -323,9 +323,9 @@ void RemoteOffset::SerializeWithCachedSizes(
     ::google::protobuf::internal::WireFormatLite::WriteInt64(1, this->offset(), output);
   }
 
-  // optional int64 error = 2;
-  if (has_error()) {
-    ::google::protobuf::internal::WireFormatLite::WriteInt64(2, this->error(), output);
+  // optional int64 uncertainty = 2;
+  if (has_uncertainty()) {
+    ::google::protobuf::internal::WireFormatLite::WriteInt64(2, this->uncertainty(), output);
   }
 
   // optional int64 measured_at = 3;
@@ -348,9 +348,9 @@ void RemoteOffset::SerializeWithCachedSizes(
     target = ::google::protobuf::internal::WireFormatLite::WriteInt64ToArray(1, this->offset(), target);
   }
 
-  // optional int64 error = 2;
-  if (has_error()) {
-    target = ::google::protobuf::internal::WireFormatLite::WriteInt64ToArray(2, this->error(), target);
+  // optional int64 uncertainty = 2;
+  if (has_uncertainty()) {
+    target = ::google::protobuf::internal::WireFormatLite::WriteInt64ToArray(2, this->uncertainty(), target);
   }
 
   // optional int64 measured_at = 3;
@@ -377,11 +377,11 @@ int RemoteOffset::ByteSize() const {
           this->offset());
     }
 
-    // optional int64 error = 2;
-    if (has_error()) {
+    // optional int64 uncertainty = 2;
+    if (has_uncertainty()) {
       total_size += 1 +
         ::google::protobuf::internal::WireFormatLite::Int64Size(
-          this->error());
+          this->uncertainty());
     }
 
     // optional int64 measured_at = 3;
@@ -421,8 +421,8 @@ void RemoteOffset::MergeFrom(const RemoteOffset& from) {
     if (from.has_offset()) {
       set_offset(from.offset());
     }
-    if (from.has_error()) {
-      set_error(from.error());
+    if (from.has_uncertainty()) {
+      set_uncertainty(from.uncertainty());
     }
     if (from.has_measured_at()) {
       set_measured_at(from.measured_at());
@@ -451,7 +451,7 @@ bool RemoteOffset::IsInitialized() const {
 void RemoteOffset::Swap(RemoteOffset* other) {
   if (other != this) {
     std::swap(offset_, other->offset_);
-    std::swap(error_, other->error_);
+    std::swap(uncertainty_, other->uncertainty_);
     std::swap(measured_at_, other->measured_at_);
     std::swap(_has_bits_[0], other->_has_bits_[0]);
     _unknown_fields_.Swap(&other->_unknown_fields_);

--- a/storage/engine/cockroach/proto/heartbeat.pb.h
+++ b/storage/engine/cockroach/proto/heartbeat.pb.h
@@ -101,12 +101,12 @@ class RemoteOffset : public ::google::protobuf::Message {
   inline ::google::protobuf::int64 offset() const;
   inline void set_offset(::google::protobuf::int64 value);
 
-  // optional int64 error = 2;
-  inline bool has_error() const;
-  inline void clear_error();
-  static const int kErrorFieldNumber = 2;
-  inline ::google::protobuf::int64 error() const;
-  inline void set_error(::google::protobuf::int64 value);
+  // optional int64 uncertainty = 2;
+  inline bool has_uncertainty() const;
+  inline void clear_uncertainty();
+  static const int kUncertaintyFieldNumber = 2;
+  inline ::google::protobuf::int64 uncertainty() const;
+  inline void set_uncertainty(::google::protobuf::int64 value);
 
   // optional int64 measured_at = 3;
   inline bool has_measured_at() const;
@@ -119,8 +119,8 @@ class RemoteOffset : public ::google::protobuf::Message {
  private:
   inline void set_has_offset();
   inline void clear_has_offset();
-  inline void set_has_error();
-  inline void clear_has_error();
+  inline void set_has_uncertainty();
+  inline void clear_has_uncertainty();
   inline void set_has_measured_at();
   inline void clear_has_measured_at();
 
@@ -129,7 +129,7 @@ class RemoteOffset : public ::google::protobuf::Message {
   ::google::protobuf::uint32 _has_bits_[1];
   mutable int _cached_size_;
   ::google::protobuf::int64 offset_;
-  ::google::protobuf::int64 error_;
+  ::google::protobuf::int64 uncertainty_;
   ::google::protobuf::int64 measured_at_;
   friend void  protobuf_AddDesc_cockroach_2fproto_2fheartbeat_2eproto();
   friend void protobuf_AssignDesc_cockroach_2fproto_2fheartbeat_2eproto();
@@ -374,28 +374,28 @@ inline void RemoteOffset::set_offset(::google::protobuf::int64 value) {
   // @@protoc_insertion_point(field_set:cockroach.proto.RemoteOffset.offset)
 }
 
-// optional int64 error = 2;
-inline bool RemoteOffset::has_error() const {
+// optional int64 uncertainty = 2;
+inline bool RemoteOffset::has_uncertainty() const {
   return (_has_bits_[0] & 0x00000002u) != 0;
 }
-inline void RemoteOffset::set_has_error() {
+inline void RemoteOffset::set_has_uncertainty() {
   _has_bits_[0] |= 0x00000002u;
 }
-inline void RemoteOffset::clear_has_error() {
+inline void RemoteOffset::clear_has_uncertainty() {
   _has_bits_[0] &= ~0x00000002u;
 }
-inline void RemoteOffset::clear_error() {
-  error_ = GOOGLE_LONGLONG(0);
-  clear_has_error();
+inline void RemoteOffset::clear_uncertainty() {
+  uncertainty_ = GOOGLE_LONGLONG(0);
+  clear_has_uncertainty();
 }
-inline ::google::protobuf::int64 RemoteOffset::error() const {
-  // @@protoc_insertion_point(field_get:cockroach.proto.RemoteOffset.error)
-  return error_;
+inline ::google::protobuf::int64 RemoteOffset::uncertainty() const {
+  // @@protoc_insertion_point(field_get:cockroach.proto.RemoteOffset.uncertainty)
+  return uncertainty_;
 }
-inline void RemoteOffset::set_error(::google::protobuf::int64 value) {
-  set_has_error();
-  error_ = value;
-  // @@protoc_insertion_point(field_set:cockroach.proto.RemoteOffset.error)
+inline void RemoteOffset::set_uncertainty(::google::protobuf::int64 value) {
+  set_has_uncertainty();
+  uncertainty_ = value;
+  // @@protoc_insertion_point(field_set:cockroach.proto.RemoteOffset.uncertainty)
 }
 
 // optional int64 measured_at = 3;


### PR DESCRIPTION
I found `Error` to be a surprising name (because it's overloaded in Go).
