### PR TITLE
Update etcd version.

### DIFF
--- a/GLOCKFILE
+++ b/GLOCKFILE
@@ -16,7 +16,7 @@ github.com/cockroachdb/c-lz4 6e71f140a365017bbe0904710007f8725fd3f809
 github.com/cockroachdb/c-protobuf 9e8dac59ca2a3fc82cd0665ad32b1a36f3df40b8
 github.com/cockroachdb/c-rocksdb e120ce0fb32f86b94188928743270ea11ff016b3
 github.com/cockroachdb/c-snappy 618733f9e5bab8463b9049117a335a7a1bfc9fd5
-github.com/coreos/etcd 42783c1faa17d5463528be35f1bc320516d5258c
+github.com/coreos/etcd 0ad6d7e3babb7667b24ca15ef8d54cfc870eff51
 github.com/elazarl/go-bindata-assetfs bea323321994103859d60197d229f1a94699dde3
 github.com/gogo/protobuf e888c342b46b97d9bf828e98ac755d227b57d6e8
 github.com/golang/lint dea130113ab8ebacb52dbce09c9a4c92951afdca

--- a/multiraft/multiraft.go
+++ b/multiraft/multiraft.go
@@ -364,7 +364,7 @@ func (m *MultiRaft) ChangeGroupMembership(groupID uint64, commandID string,
 }
 
 // Status returns the current status of the given group.
-func (m *MultiRaft) Status(groupID uint64) raft.Status {
+func (m *MultiRaft) Status(groupID uint64) *raft.Status {
 	return m.multiNode.Status(groupID)
 }
 

--- a/storage/store.go
+++ b/storage/store.go
@@ -762,7 +762,7 @@ func (s *Store) LookupRange(start, end proto.Key) *Range {
 }
 
 // RaftStatus returns the current raft status of the given range.
-func (s *Store) RaftStatus(raftID int64) raft.Status {
+func (s *Store) RaftStatus(raftID int64) *raft.Status {
 	return s.multiraft.Status(uint64(raftID))
 }
 


### PR DESCRIPTION
The key change is that MultiNode.Status no longer panics when you ask
for a group that doesn't exist.
