### PR TITLE
Added framework for acceptance tests.

### DIFF
--- a/GLOCKFILE
+++ b/GLOCKFILE
@@ -17,6 +17,7 @@ github.com/cockroachdb/c-protobuf 9e8dac59ca2a3fc82cd0665ad32b1a36f3df40b8
 github.com/cockroachdb/c-rocksdb e120ce0fb32f86b94188928743270ea11ff016b3
 github.com/cockroachdb/c-snappy 618733f9e5bab8463b9049117a335a7a1bfc9fd5
 github.com/coreos/etcd 0ad6d7e3babb7667b24ca15ef8d54cfc870eff51
+github.com/docker/docker f5850e8e30b9420d26bd12136d8bbb6669d1e2bb
 github.com/elazarl/go-bindata-assetfs bea323321994103859d60197d229f1a94699dde3
 github.com/gogo/protobuf e888c342b46b97d9bf828e98ac755d227b57d6e8
 github.com/golang/lint dea130113ab8ebacb52dbce09c9a4c92951afdca
@@ -26,6 +27,7 @@ github.com/julienschmidt/httprouter 8c199fb6259ffc1af525cc3ad52ee60ba8359669
 github.com/kisielk/errcheck a48456c583c0111c8310fc59335f6496b8eb85f1
 github.com/kisielk/gotool d678387370a2eb9b5b0a33218bc8c9d8de15b6be
 github.com/robfig/glock e0f25993e42f3aff6494cf397815841a3491d890
+github.com/samalba/dockerclient 979115d9e4d847c0e936d539c0584e25c226162e
 github.com/spf13/cobra c11766b405b388c6bbafaa1c8b3ad2eaf471b7b6
 github.com/spf13/pflag 0ed81a961505a7dfaab5490049a7a324743e6f03
 golang.org/x/net e0403b4e005737430c05a57aac078479844f919c

--- a/acceptance/gossip_peerings_test.go
+++ b/acceptance/gossip_peerings_test.go
@@ -1,0 +1,107 @@
+// Copyright 2015 The Cockroach Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+// implied. See the License for the specific language governing
+// permissions and limitations under the License. See the AUTHORS file
+// for names of contributors.
+//
+// Author: Peter Mattis (peter.mattis@gmail.com)
+
+// +build acceptance
+
+package acceptance
+
+import (
+	"crypto/tls"
+	"encoding/json"
+	"fmt"
+	"io/ioutil"
+	"net/http"
+	"os"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/cockroachdb/cockroach/acceptance/localcluster"
+	"github.com/cockroachdb/cockroach/util/log"
+)
+
+func checkGossipNodes(client *http.Client, node *localcluster.Container) int {
+	resp, err := client.Get(fmt.Sprintf("https://%s/_status/gossip", node.Addr("")))
+	if err != nil {
+		return 0
+	}
+	defer resp.Body.Close()
+	b, err := ioutil.ReadAll(resp.Body)
+	if err != nil {
+		return 0
+	}
+	var m map[string]interface{}
+	if err := json.Unmarshal(b, &m); err != nil {
+		return 0
+	}
+	count := 0
+	infos := m["infos"].(map[string]interface{})
+	for k := range infos {
+		if strings.HasPrefix(k, "node:") {
+			count++
+		}
+	}
+	return count
+}
+
+func checkGossipPeerings(t *testing.T, l *localcluster.Cluster, attempts int, done chan struct{}) {
+	go func() {
+		defer close(done)
+
+		client := &http.Client{
+			Transport: &http.Transport{
+				TLSClientConfig: &tls.Config{
+					InsecureSkipVerify: true,
+				},
+			}}
+
+		log.Infof("waiting for complete gossip network of %d peerings",
+			len(l.Nodes)*len(l.Nodes))
+
+		for i := 0; i < attempts; i++ {
+			time.Sleep(1 * time.Second)
+			found := 0
+			for j := 0; j < len(l.Nodes); j++ {
+				found += checkGossipNodes(client, l.Nodes[j])
+			}
+			fmt.Fprintf(os.Stderr, "%d ", found)
+			if found == len(l.Nodes)*len(l.Nodes) {
+				fmt.Printf("... all nodes verified in the cluster\n")
+				return
+			}
+		}
+
+		fmt.Fprintf(os.Stderr, "\n")
+		t.Errorf("failed to verify all nodes in cluster\n")
+	}()
+}
+
+func TestGossipPeerings(t *testing.T) {
+	cluster := localcluster.Create(*numNodes, stopper)
+	if !cluster.Start() {
+		return
+	}
+	defer cluster.Stop()
+
+	done := make(chan struct{})
+	checkGossipPeerings(t, cluster, 20, done)
+
+	select {
+	case <-stopper:
+	case <-done:
+	}
+}

--- a/acceptance/localcluster/docker.go
+++ b/acceptance/localcluster/docker.go
@@ -1,0 +1,295 @@
+// Copyright 2015 The Cockroach Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+// implied. See the License for the specific language governing
+// permissions and limitations under the License. See the AUTHORS file
+// for names of contributors.
+//
+// Author: Peter Mattis (peter.mattis@gmail.com)
+
+package localcluster
+
+import (
+	"bufio"
+	"bytes"
+	"crypto/tls"
+	"crypto/x509"
+	"encoding/json"
+	"fmt"
+	"io"
+	"io/ioutil"
+	"net"
+	"net/http"
+	"net/url"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"regexp"
+	"runtime"
+	"strconv"
+
+	"github.com/cockroachdb/cockroach/util/log"
+	"github.com/samalba/dockerclient"
+)
+
+func getTLSConfig() *tls.Config {
+	certPath := os.Getenv("DOCKER_CERT_PATH")
+
+	clientCert, err := tls.LoadX509KeyPair(
+		filepath.Join(certPath, "cert.pem"),
+		filepath.Join(certPath, "key.pem"),
+	)
+	if err != nil {
+		panic(err)
+	}
+
+	rootCAs := x509.NewCertPool()
+	caCert, err := ioutil.ReadFile(filepath.Join(certPath, "ca.pem"))
+	if err != nil {
+		panic(err)
+	}
+	rootCAs.AppendCertsFromPEM(caCert)
+
+	return &tls.Config{
+		Certificates: []tls.Certificate{clientCert},
+		RootCAs:      rootCAs,
+	}
+}
+
+// newDockerClient constructs a new docker client using the best available
+// method. On darwin (Mac OS X), first look for the DOCKER_HOST env
+// variable. If not found, run "boot2docker shellinit" and add the exported
+// variables to the environment. If DOCKER_HOST is set, initialize the client
+// using DOCKER_TLS_VERIFY and DOCKER_CERT_PATH. If DOCKER_HOST is not set,
+// look for the unix domain socket in /run/docker.sock and
+// /var/run/docker.sock.
+func newDockerClient() dockerclient.Client {
+	if runtime.GOOS == "darwin" && os.Getenv("DOCKER_HOST") == "" {
+		output, err := exec.Command("boot2docker", "shellinit").Output()
+		if err != nil {
+			log.Fatal(err)
+		}
+		exportRE := regexp.MustCompile(`export (\w+)=([^\n]+)`)
+		for s := bufio.NewScanner(bytes.NewReader(output)); s.Scan(); {
+			export := exportRE.FindStringSubmatch(s.Text())
+			if len(export) != 3 {
+				continue
+			}
+			if err := os.Setenv(export[1], export[2]); err != nil {
+				log.Fatal(err)
+			}
+		}
+	}
+
+	host := os.Getenv("DOCKER_HOST")
+	if host != "" {
+		if os.Getenv("DOCKER_TLS_VERIFY") == "" {
+			c, err := dockerclient.NewDockerClient(host, nil)
+			if err != nil {
+				log.Fatal(err)
+			}
+			return c
+		}
+		c, err := dockerclient.NewDockerClient(host, getTLSConfig())
+		if err != nil {
+			log.Fatal(err)
+		}
+		return c
+	}
+
+	for _, l := range []string{"/run/docker.sock", "/var/run/docker.sock"} {
+		if _, err := os.Stat(l); err != nil {
+			continue
+		}
+		c, err := dockerclient.NewDockerClient("unix://"+l, nil)
+		if err != nil {
+			return nil
+		}
+		return c
+	}
+	log.Fatal("docker not configured")
+	return nil
+}
+
+// Retrieve the IP address of docker itself.
+func dockerIP() net.IP {
+	host := os.Getenv("DOCKER_HOST")
+	if host != "" {
+		u, err := url.Parse(host)
+		if err != nil {
+			panic(err)
+		}
+		h, _, err := net.SplitHostPort(u.Host)
+		if err != nil {
+			panic(err)
+		}
+		return net.ParseIP(h)
+	}
+	if runtime.GOOS == "linux" {
+		return net.IPv4zero
+	}
+	panic(fmt.Errorf("unable to determine docker ip address"))
+}
+
+// Container provides the programmatic interface for a single docker
+// container.
+type Container struct {
+	dockerclient.ContainerInfo
+	client dockerclient.Client
+}
+
+// createContainer creates a new container using the specified options. Per the
+// docker API, the created container is not running and must be started
+// explicitly.
+func createContainer(client dockerclient.Client, config dockerclient.ContainerConfig) (*Container, error) {
+	id, err := client.CreateContainer(&config, "")
+	if err != nil {
+		return nil, err
+	}
+	return &Container{
+		ContainerInfo: dockerclient.ContainerInfo{Id: id},
+		client:        client}, nil
+}
+
+func maybePanic(err error) {
+	if err != nil {
+		panic(err)
+	}
+}
+
+// Remove removes the container from docker. It is an error to remove a running
+// container.
+func (c *Container) Remove() error {
+	return c.client.RemoveContainer(c.Id, false, true)
+}
+
+func (c *Container) mustRemove() {
+	maybePanic(c.Remove())
+}
+
+// Kill stops a running container and removes it.
+func (c *Container) Kill() error {
+	// Paused containers cannot be killed. Attempt to unpause it first
+	// (which might fail) before killing.
+	_ = c.Unpause()
+	err := c.client.KillContainer(c.Id, "9")
+	if err != nil {
+		return err
+	}
+	return c.Remove()
+}
+
+func (c *Container) mustKill() {
+	maybePanic(c.Kill())
+}
+
+// Start starts a non-running container.
+//
+// TODO(pmattis): Generalize the setting of parameters here.
+func (c *Container) Start(binds []string, dns, vols *Container) error {
+	config := &dockerclient.HostConfig{
+		Binds:           binds,
+		PublishAllPorts: true,
+	}
+	if dns != nil {
+		config.Dns = append(config.Dns, dns.NetworkSettings.IPAddress)
+	}
+	if vols != nil {
+		config.VolumesFrom = append(config.VolumesFrom, vols.Id)
+	}
+	return c.client.StartContainer(c.Id, config)
+}
+
+// Pause pauses a running container.
+func (c *Container) Pause() error {
+	return c.client.PauseContainer(c.Id)
+}
+
+// Unpause resumes a paused container.
+func (c *Container) Unpause() error {
+	return c.client.UnpauseContainer(c.Id)
+}
+
+// Wait waits for a running container to exit.
+func (c *Container) Wait() error {
+	// TODO(pmattis): dockerclient does not support the "wait" method
+	// (yet), so perform the http call ourselves. Remove once "wait"
+	// support is added to dockerclient.
+	dc := c.client.(*dockerclient.DockerClient)
+	resp, err := dc.HTTPClient.Post(
+		fmt.Sprintf("%s/containers/%s/wait", dc.URL, c.Id), "application/json", nil)
+	if err != nil {
+		return err
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode == http.StatusNotFound {
+		return fmt.Errorf("no such container: %s", c.Id)
+	}
+	body, err := ioutil.ReadAll(resp.Body)
+	if err != nil {
+		return err
+	}
+	var r struct{ StatusCode int }
+	err = json.Unmarshal(body, &r)
+	if err != nil {
+		return err
+	}
+	if r.StatusCode != 0 {
+		_ = c.Logs()
+		return fmt.Errorf("non-zero exit code: %d", r.StatusCode)
+	}
+	return nil
+}
+
+// Logs outputs the containers logs to stdout/stderr.
+func (c *Container) Logs() error {
+	r, err := c.client.ContainerLogs(c.Id, &dockerclient.LogOptions{
+		Stdout: true,
+		Stderr: true,
+	})
+	if err != nil {
+		return err
+	}
+	defer r.Close()
+	_, err = io.Copy(os.Stdout, r)
+	return err
+}
+
+// Inspect retrieves detailed info about a container.
+func (c *Container) Inspect() error {
+	out, err := c.client.InspectContainer(c.Id)
+	if err != nil {
+		return err
+	}
+	c.ContainerInfo = *out
+	return nil
+}
+
+// Addr returns the address to connect to the specified port.
+func (c *Container) Addr(name string) *net.TCPAddr {
+	if name == "" {
+		// No port specified, pick a random one (random because iteration
+		// over maps is randomized).
+		for port := range c.NetworkSettings.Ports {
+			name = port
+			break
+		}
+	}
+	bindings, ok := c.NetworkSettings.Ports[name]
+	if !ok || len(bindings) == 0 {
+		return nil
+	}
+	port, _ := strconv.Atoi(bindings[0].HostPort)
+	return &net.TCPAddr{
+		IP:   dockerIP(),
+		Port: port,
+	}
+}

--- a/acceptance/localcluster/localcluster.go
+++ b/acceptance/localcluster/localcluster.go
@@ -1,0 +1,324 @@
+// Copyright 2015 The Cockroach Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+// implied. See the License for the specific language governing
+// permissions and limitations under the License. See the AUTHORS file
+// for names of contributors.
+//
+// Author: Peter Mattis (peter.mattis@gmail.com)
+
+package localcluster
+
+import (
+	"encoding/json"
+	"flag"
+	"fmt"
+	"io/ioutil"
+	"os"
+	"path/filepath"
+
+	"github.com/cockroachdb/cockroach/util/log"
+	"github.com/samalba/dockerclient"
+)
+
+const (
+	builderImage   = "cockroachdb/builder"
+	dockerspyImage = "cockroachdb/docker-spy"
+	domain         = "local"
+)
+
+var cockroachImage = flag.String("i", builderImage, "the docker image to run")
+var cockroachBinary = flag.String("b", defaultBinary(), "the binary to run (if image == "+builderImage+")")
+var cockroachEntry = flag.String("e", "", "the entry point for the image")
+
+func prettyJSON(v interface{}) string {
+	pretty, err := json.MarshalIndent(v, "", "  ")
+	if err != nil {
+		panic(err)
+	}
+	return string(pretty)
+}
+
+func defaultBinary() string {
+	gopath := filepath.SplitList(os.Getenv("GOPATH"))
+	if len(gopath) == 0 {
+		return ""
+	}
+	return gopath[0] + "/bin/linux_amd64/cockroach"
+}
+
+func exists(path string) bool {
+	if _, err := os.Stat(path); os.IsNotExist(err) {
+		return false
+	}
+	return true
+}
+
+// Cluster manages a local cockroach cluster running on docker. The cluster is
+// composed of a "dns" container which automatically registers dns entries for
+// the cockroach nodes, a "volumes" container which manages the persistent
+// volumes used for certs and node data and N cockroach nodes.
+type Cluster struct {
+	client   dockerclient.Client
+	dns      *Container
+	vols     *Container
+	Nodes    []*Container
+	certsDir string
+	stopper  chan struct{}
+}
+
+// Create creates a new local cockroach cluster. The stopper is used to
+// gracefully shutdown the channel (e.g. when a signal arrives). The cluster
+// must be started before being used.
+func Create(numNodes int, stopper chan struct{}) *Cluster {
+	if *cockroachImage == builderImage && !exists(*cockroachBinary) {
+		log.Fatalf("\"%s\": does not exist", *cockroachBinary)
+	}
+
+	return &Cluster{
+		client:  newDockerClient(),
+		Nodes:   make([]*Container, numNodes),
+		stopper: stopper,
+	}
+}
+
+func (l *Cluster) stopOnPanic() {
+	if r := recover(); r != nil {
+		l.Stop()
+		if r != l {
+			panic(r)
+		}
+	}
+}
+
+func (l *Cluster) panicOnStop() {
+	if l.stopper == nil {
+		panic(l)
+	}
+
+	select {
+	case <-l.stopper:
+		l.stopper = nil
+		panic(l)
+	default:
+	}
+}
+
+func (l *Cluster) runDockerSpy() {
+	l.panicOnStop()
+
+	create := func() (*Container, error) {
+		return createContainer(l.client, dockerclient.ContainerConfig{
+			Image: dockerspyImage,
+			Cmd:   []string{"--dns-domain=" + domain},
+		})
+	}
+	c, err := create()
+	if err == dockerclient.ErrNotFound {
+		log.Infof("pulling %s", dockerspyImage)
+		err = l.client.PullImage(dockerspyImage, nil)
+		if err == nil {
+			c, err = create()
+		}
+	}
+	if err != nil {
+		panic(err)
+	}
+	maybePanic(c.Start([]string{"/var/run/docker.sock:/var/run/docker.sock"}, nil, nil))
+	maybePanic(c.Inspect())
+	c.Name = "docker-spy"
+	l.dns = c
+	log.Infof("started %s: %s\n", c.Name, c.NetworkSettings.IPAddress)
+}
+
+// create the volumes container that keeps all of the volumes used by the
+// cluster.
+func (l *Cluster) createVolumes() {
+	l.panicOnStop()
+
+	vols := map[string]struct{}{}
+	for i := range l.Nodes {
+		vols[l.data(i)] = struct{}{}
+	}
+	create := func() (*Container, error) {
+		return createContainer(l.client, dockerclient.ContainerConfig{
+			Image:   *cockroachImage,
+			Volumes: vols,
+		})
+	}
+	c, err := create()
+	if err == dockerclient.ErrNotFound && *cockroachImage == builderImage {
+		log.Infof("pulling %s", *cockroachImage)
+		err = l.client.PullImage(*cockroachImage, nil)
+		if err == nil {
+			c, err = create()
+		}
+	}
+	if err != nil {
+		panic(err)
+	}
+
+	l.certsDir, err = ioutil.TempDir(os.TempDir(), "localcluster.")
+	if err != nil {
+		panic(err)
+	}
+
+	binds := []string{l.certsDir + ":/certs"}
+	if *cockroachImage == builderImage {
+		path, err := filepath.Abs(*cockroachBinary)
+		if err != nil {
+			panic(err)
+		}
+		binds = append(binds, path+":/"+filepath.Base(*cockroachBinary))
+	}
+	maybePanic(c.Start(binds, nil, nil))
+	c.Name = "volumes"
+	log.Infof("created volumes")
+	l.vols = c
+}
+
+func (l *Cluster) createRoach(i int, cmd ...string) *Container {
+	l.panicOnStop()
+
+	var hostname string
+	if i >= 0 {
+		hostname = fmt.Sprintf("roach%d", i)
+	}
+	var entrypoint []string
+	if *cockroachImage == builderImage {
+		entrypoint = append(entrypoint, "/"+filepath.Base(*cockroachBinary))
+	} else if *cockroachEntry != "" {
+		entrypoint = append(entrypoint, *cockroachEntry)
+	}
+	c, err := createContainer(l.client, dockerclient.ContainerConfig{
+		Hostname:     hostname,
+		Domainname:   domain,
+		Image:        *cockroachImage,
+		ExposedPorts: map[string]struct{}{"8080/tcp": {}},
+		Entrypoint:   entrypoint,
+		Cmd:          cmd,
+	})
+	if err != nil {
+		panic(err)
+	}
+	return c
+}
+
+func (l *Cluster) createCACert() {
+	log.Infof("creating ca")
+	c := l.createRoach(-1, "cert", "--certs=/certs", "create-ca")
+	defer c.mustRemove()
+	maybePanic(c.Start(nil, nil, l.vols))
+	maybePanic(c.Wait())
+}
+
+func (l *Cluster) createNodeCerts() {
+	log.Infof("creating node certs: ./certs")
+	var nodes []string
+	for i := range l.Nodes {
+		nodes = append(nodes, l.node(i))
+	}
+	args := []string{"cert", "--certs=/certs", "create-node"}
+	args = append(args, nodes...)
+	c := l.createRoach(-1, args...)
+	defer c.mustRemove()
+	maybePanic(c.Start(nil, nil, l.vols))
+	maybePanic(c.Wait())
+}
+
+func (l *Cluster) initCluster() {
+	log.Infof("initializing cluster")
+	c := l.createRoach(-1, "init", "--stores=ssd="+l.data(0))
+	defer c.mustRemove()
+	maybePanic(c.Start(nil, nil, l.vols))
+	maybePanic(c.Wait())
+}
+
+func (l *Cluster) startNode(i int) *Container {
+	cmd := []string{
+		"start",
+		"--stores=ssd=" + l.data(i),
+		"--certs=/certs",
+		"--addr=" + l.node(i) + ":8080",
+		"--gossip=" + l.node(0) + ":8080",
+	}
+	c := l.createRoach(i, cmd...)
+	maybePanic(c.Start(nil, l.dns, l.vols))
+	maybePanic(c.Inspect())
+	c.Name = l.node(i)
+	log.Infof("started %s: %s", c.Name, c.Addr(""))
+	return c
+}
+
+// Start starts the cluster. Returns false if the cluster did not start
+// properly.
+func (l *Cluster) Start() bool {
+	defer l.stopOnPanic()
+
+	l.runDockerSpy()
+	l.createVolumes()
+	l.createCACert()
+	l.createNodeCerts()
+	l.initCluster()
+
+	for i := range l.Nodes {
+		l.Nodes[i] = l.startNode(i)
+	}
+
+	// TODO(pmattis):
+	// ch, err := l.client.MonitorEvents(nil, nil)
+	// if err != nil {
+	// 	panic(err)
+	// }
+	// go func() {
+	// 	for {
+	// 		e := <-ch
+	// 		if e.Error != nil {
+	// 			log.Println(e.Error)
+	// 			break
+	// 		}
+	// 		log.Println(e.Event)
+	// 	}
+	// }()
+
+	// Mildy tricky: we return false on failure by recovering from a panic.
+	return true
+}
+
+// Stop stops the clusters. It is safe to stop the cluster multiple times.
+func (l *Cluster) Stop() {
+	if l.dns != nil {
+		maybePanic(l.dns.Kill())
+		l.dns = nil
+	}
+	if l.vols != nil {
+		maybePanic(l.vols.Kill())
+		l.vols = nil
+	}
+	if l.certsDir != "" {
+		_ = os.RemoveAll(l.certsDir)
+		l.certsDir = ""
+	}
+	for i, n := range l.Nodes {
+		if n != nil {
+			maybePanic(n.Kill())
+			l.Nodes[i] = nil
+		}
+	}
+}
+
+func (l *Cluster) node(i int) string {
+	return fmt.Sprintf("roach%d.%s", i, domain)
+}
+
+func (l *Cluster) data(i int) string {
+	return fmt.Sprintf("/data%d", i)
+}

--- a/acceptance/main_test.go
+++ b/acceptance/main_test.go
@@ -1,0 +1,40 @@
+// Copyright 2015 The Cockroach Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+// implied. See the License for the specific language governing
+// permissions and limitations under the License. See the AUTHORS file
+// for names of contributors.
+//
+// Author: Peter Mattis (peter.mattis@gmail.com)
+
+// +build acceptance
+
+package acceptance
+
+import (
+	"flag"
+	"os"
+	"os/signal"
+	"testing"
+)
+
+var numNodes = flag.Int("n", 3, "the number of nodes to start (if not otherwise specified by a test)")
+var stopper = make(chan struct{})
+
+func TestMain(m *testing.M) {
+	go func() {
+		sig := make(chan os.Signal, 1)
+		signal.Notify(sig, os.Interrupt)
+		<-sig
+		close(stopper)
+	}()
+	os.Exit(m.Run())
+}

--- a/acceptance/run.sh
+++ b/acceptance/run.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+
+cd $(dirname $0)/..
+build/builder.sh make install
+go test -v -tags acceptance ./acceptance

--- a/build/builder.sh
+++ b/build/builder.sh
@@ -1,0 +1,60 @@
+#!/bin/bash
+
+set -e
+
+image="cockroachdb/builder"
+
+if [ "$1" = "init" ]; then
+    docker build --tag="${image}" - <<EOF
+FROM golang:1.4.2
+
+RUN apt-get update -y && \
+ apt-get dist-upgrade -y && \
+ apt-get install --no-install-recommends --auto-remove -y git build-essential file npm nodejs && \
+ apt-get clean autoclean && \
+ apt-get autoremove -y && \
+ rm -rf /tmp/* /var/lib/{apt,dpkg,cache,log} && \
+ npm -g install typescript && \
+ ln -s /usr/bin/nodejs /usr/bin/node && \
+ apt-get remove --auto-remove -y npm
+RUN go get golang.org/x/tools/cmd/vet
+
+CMD ["/bin/bash"]
+EOF
+    exit 0
+fi
+
+gopath0="${GOPATH%%:*}"
+dockerVers=$(docker version | grep 'Server version:' | awk '{print $NF}')
+rm=""
+
+case "${dockerVers}" in
+    0.*|1.[012345]*)
+    # Removing volume containers fails on older versions of docker with
+    # the error:
+    #
+    #   Failed to destroy btrfs snapshot: operation not permitted
+    ;;
+    *)
+	rm="--rm"
+	;;
+esac
+
+tty=""
+if test -t 0; then
+    tty="--tty"
+fi
+
+# Run our build container with a set of volumes mounted that will
+# allow the container to store persistent build data on the host
+# computer.
+docker run -i ${tty} ${rm} \
+       --volume="${gopath0}/src:/go/src" \
+       --volume="${PWD}:/go/src/github.com/cockroachdb/cockroach" \
+       --volume="${gopath0}/pkg:/go/pkg" \
+       --volume="${gopath0}/pkg/linux_amd64_netgo:/usr/src/go/pkg/linux_amd64_netgo" \
+       --volume="${gopath0}/pkg/linux_amd64_race:/usr/src/go/pkg/linux_amd64_race" \
+       --volume="${gopath0}/bin/linux_amd64:/go/bin" \
+       --workdir="/go/src/github.com/cockroachdb/cockroach" \
+       --env="CACHE=/go/pkg/cache" \
+       "${image}" "$@"


### PR DESCRIPTION
The acceptance/localcluster package contains tools for starting up a
local cockroach cluster using docker. The acceptance package contains a
small framework for registering and running acceptance tests.

Ported the existing "gossip-peerings" acceptance test from
run/local-cluster.sh to the new acceptance framework.

Added a new build/builder.sh script which uses the cockroachdb/builder
image and various volume mappings to build linux binaries from the local
source tree.

Added an "install" target to the Makefile which is similar to "build"
but uses "go install" instead. The benefit of "install" target is that
it will not rebuild the output if the sources have not changed.
