### PR TITLE
Add a range to rangesByKey after a Raft snapshot is applied

### DIFF
--- a/storage/feed_test.go
+++ b/storage/feed_test.go
@@ -94,7 +94,9 @@ func TestStoreEventFeed(t *testing.T) {
 			},
 		},
 	}
-	rng1.SetDesc(desc1)
+	if err := rng1.SetDesc(desc1); err != nil {
+		t.Fatal(err)
+	}
 	rng2 := &Range{
 		stats: &rangeStats{
 			raftID: desc2.RaftID,
@@ -105,7 +107,9 @@ func TestStoreEventFeed(t *testing.T) {
 			},
 		},
 	}
-	rng2.SetDesc(desc2)
+	if err := rng2.SetDesc(desc2); err != nil {
+		t.Fatal(err)
+	}
 	diffStats := &proto.MVCCStats{
 		IntentBytes: 30,
 		IntentAge:   20,

--- a/storage/queue_test.go
+++ b/storage/queue_test.go
@@ -97,9 +97,13 @@ func TestQueuePriorityQueue(t *testing.T) {
 func TestBaseQueueAddUpdateAndRemove(t *testing.T) {
 	defer leaktest.AfterTest(t)
 	r1 := &Range{}
-	r1.SetDesc(&proto.RangeDescriptor{RaftID: 1})
+	if err := r1.SetDesc(&proto.RangeDescriptor{RaftID: 1}); err != nil {
+		t.Fatal(err)
+	}
 	r2 := &Range{}
-	r2.SetDesc(&proto.RangeDescriptor{RaftID: 2})
+	if err := r2.SetDesc(&proto.RangeDescriptor{RaftID: 2}); err != nil {
+		t.Fatal(err)
+	}
 	shouldAddMap := map[*Range]bool{
 		r1: true,
 		r2: true,
@@ -179,9 +183,13 @@ func TestBaseQueueAddUpdateAndRemove(t *testing.T) {
 func TestBaseQueueProcess(t *testing.T) {
 	defer leaktest.AfterTest(t)
 	r1 := &Range{}
-	r1.SetDesc(&proto.RangeDescriptor{RaftID: 1})
+	if err := r1.SetDesc(&proto.RangeDescriptor{RaftID: 1}); err != nil {
+		t.Fatal(err)
+	}
 	r2 := &Range{}
-	r2.SetDesc(&proto.RangeDescriptor{RaftID: 2})
+	if err := r2.SetDesc(&proto.RangeDescriptor{RaftID: 2}); err != nil {
+		t.Fatal(err)
+	}
 	testQueue := &testQueueImpl{
 		shouldQueueFn: func(now proto.Timestamp, r *Range) (shouldQueue bool, priority float64) {
 			shouldQueue = true
@@ -222,7 +230,9 @@ func TestBaseQueueProcess(t *testing.T) {
 func TestBaseQueueAddRemove(t *testing.T) {
 	defer leaktest.AfterTest(t)
 	r := &Range{}
-	r.SetDesc(&proto.RangeDescriptor{RaftID: 1})
+	if err := r.SetDesc(&proto.RangeDescriptor{RaftID: 1}); err != nil {
+		t.Fatal(err)
+	}
 	testQueue := &testQueueImpl{
 		shouldQueueFn: func(now proto.Timestamp, r *Range) (shouldQueue bool, priority float64) {
 			shouldQueue = true

--- a/storage/range_command.go
+++ b/storage/range_command.go
@@ -1078,8 +1078,7 @@ func (r *Range) mergeTrigger(batch engine.Engine, merge *proto.MergeTrigger) err
 func (r *Range) changeReplicasTrigger(change *proto.ChangeReplicasTrigger) error {
 	copy := *r.Desc()
 	copy.Replicas = change.UpdatedReplicas
-	r.SetDesc(&copy)
-	return nil
+	return r.SetDesc(&copy)
 }
 
 // ChangeReplicas adds or removes a replica of a range. The change is performed

--- a/storage/range_data_iter_test.go
+++ b/storage/range_data_iter_test.go
@@ -109,7 +109,9 @@ func TestRangeDataIteratorEmptyRange(t *testing.T) {
 	// nasty little hack, but since it's test code, meh.
 	newDesc := *tc.rng.Desc()
 	newDesc.StartKey = proto.Key("a")
-	tc.rng.SetDesc(&newDesc)
+	if err := tc.rng.SetDesc(&newDesc); err != nil {
+		t.Fatal(err)
+	}
 
 	iter := newRangeDataIterator(tc.rng.Desc(), tc.rng.rm.Engine())
 	defer iter.Close()
@@ -144,7 +146,9 @@ func disabledTestRangeDataIterator(t *testing.T) {
 	newDesc := *tc.rng.Desc()
 	newDesc.StartKey = proto.Key("b")
 	newDesc.EndKey = proto.Key("c")
-	tc.rng.SetDesc(&newDesc)
+	if err := tc.rng.SetDesc(&newDesc); err != nil {
+		t.Fatal(err)
+	}
 
 	// Create two more ranges, one before the test range and one after.
 	preRng := createRange(tc.store, 2, proto.KeyMin, proto.Key("b"))

--- a/storage/range_raftstorage.go
+++ b/storage/range_raftstorage.go
@@ -406,7 +406,9 @@ func (r *Range) ApplySnapshot(snap raftpb.Snapshot) error {
 	atomic.StoreUint64(&r.appliedIndex, snap.Metadata.Index)
 
 	// Atomically update the descriptor and lease.
-	r.SetDesc(&desc)
+	if err := r.SetDesc(&desc); err != nil {
+		return err
+	}
 	atomic.StorePointer(&r.lease, unsafe.Pointer(lease))
 	return nil
 }

--- a/storage/split_queue_test.go
+++ b/storage/split_queue_test.go
@@ -93,7 +93,9 @@ func TestSplitQueueShouldQueue(t *testing.T) {
 		copy := *tc.rng.Desc()
 		copy.StartKey = test.start
 		copy.EndKey = test.end
-		tc.rng.SetDesc(&copy)
+		if err := tc.rng.SetDesc(&copy); err != nil {
+			t.Fatal(err)
+		}
 		shouldQ, priority := splitQ.shouldQueue(proto.ZeroTimestamp, tc.rng)
 		if shouldQ != test.shouldQ {
 			t.Errorf("%d: should queue expected %t; got %t", i, test.shouldQ, shouldQ)

--- a/storage/store_test.go
+++ b/storage/store_test.go
@@ -256,7 +256,9 @@ func TestRangeSliceSort(t *testing.T) {
 	var rs RangeSlice
 	for i := 4; i >= 0; i-- {
 		r := &Range{}
-		r.SetDesc(&proto.RangeDescriptor{StartKey: proto.Key(fmt.Sprintf("foo%d", i))})
+		if err := r.SetDesc(&proto.RangeDescriptor{StartKey: proto.Key(fmt.Sprintf("foo%d", i))}); err != nil {
+			t.Fatal(err)
+		}
 		rs = append(rs, r)
 	}
 


### PR DESCRIPTION
This fixes #1054. Didn't come up with a good way to test this. Any suggestion appreciated.
