### PR TITLE
Add availability and replication stats.

### DIFF
--- a/proto/status.pb.go
+++ b/proto/status.pb.go
@@ -20,13 +20,16 @@ var _ = math.Inf
 // StoreStatus contains the stats needed to calculate the current status of a
 // store.
 type StoreStatus struct {
-	Desc             StoreDescriptor `protobuf:"bytes,1,opt,name=desc" json:"desc"`
-	NodeID           NodeID          `protobuf:"varint,2,opt,name=node_id,customtype=NodeID" json:"node_id"`
-	RangeCount       int32           `protobuf:"varint,3,opt,name=range_count" json:"range_count"`
-	StartedAt        int64           `protobuf:"varint,4,opt,name=started_at" json:"started_at"`
-	UpdatedAt        int64           `protobuf:"varint,5,opt,name=updated_at" json:"updated_at"`
-	Stats            MVCCStats       `protobuf:"bytes,6,opt,name=stats" json:"stats"`
-	XXX_unrecognized []byte          `json:"-"`
+	Desc                 StoreDescriptor `protobuf:"bytes,1,opt,name=desc" json:"desc"`
+	NodeID               NodeID          `protobuf:"varint,2,opt,name=node_id,customtype=NodeID" json:"node_id"`
+	RangeCount           int32           `protobuf:"varint,3,opt,name=range_count" json:"range_count"`
+	StartedAt            int64           `protobuf:"varint,4,opt,name=started_at" json:"started_at"`
+	UpdatedAt            int64           `protobuf:"varint,5,opt,name=updated_at" json:"updated_at"`
+	Stats                MVCCStats       `protobuf:"bytes,6,opt,name=stats" json:"stats"`
+	LeaderRangeCount     int32           `protobuf:"varint,7,opt,name=leader_range_count" json:"leader_range_count"`
+	ReplicatedRangeCount int32           `protobuf:"varint,8,opt,name=replicated_range_count" json:"replicated_range_count"`
+	AvailableRangeCount  int32           `protobuf:"varint,9,opt,name=available_range_count" json:"available_range_count"`
+	XXX_unrecognized     []byte          `json:"-"`
 }
 
 func (m *StoreStatus) Reset()         { *m = StoreStatus{} }
@@ -68,16 +71,40 @@ func (m *StoreStatus) GetStats() MVCCStats {
 	return MVCCStats{}
 }
 
+func (m *StoreStatus) GetLeaderRangeCount() int32 {
+	if m != nil {
+		return m.LeaderRangeCount
+	}
+	return 0
+}
+
+func (m *StoreStatus) GetReplicatedRangeCount() int32 {
+	if m != nil {
+		return m.ReplicatedRangeCount
+	}
+	return 0
+}
+
+func (m *StoreStatus) GetAvailableRangeCount() int32 {
+	if m != nil {
+		return m.AvailableRangeCount
+	}
+	return 0
+}
+
 // NodeStatus contains the stats needed to calculate the current status of a
 // node.
 type NodeStatus struct {
-	Desc             NodeDescriptor `protobuf:"bytes,1,opt,name=desc" json:"desc"`
-	StoreIDs         []int32        `protobuf:"varint,2,rep,name=store_ids" json:"store_ids"`
-	RangeCount       int32          `protobuf:"varint,3,opt,name=range_count" json:"range_count"`
-	StartedAt        int64          `protobuf:"varint,4,opt,name=started_at" json:"started_at"`
-	UpdatedAt        int64          `protobuf:"varint,5,opt,name=updated_at" json:"updated_at"`
-	Stats            MVCCStats      `protobuf:"bytes,6,opt,name=stats" json:"stats"`
-	XXX_unrecognized []byte         `json:"-"`
+	Desc                 NodeDescriptor `protobuf:"bytes,1,opt,name=desc" json:"desc"`
+	StoreIDs             []int32        `protobuf:"varint,2,rep,name=store_ids" json:"store_ids"`
+	RangeCount           int32          `protobuf:"varint,3,opt,name=range_count" json:"range_count"`
+	StartedAt            int64          `protobuf:"varint,4,opt,name=started_at" json:"started_at"`
+	UpdatedAt            int64          `protobuf:"varint,5,opt,name=updated_at" json:"updated_at"`
+	Stats                MVCCStats      `protobuf:"bytes,6,opt,name=stats" json:"stats"`
+	LeaderRangeCount     int32          `protobuf:"varint,7,opt,name=leader_range_count" json:"leader_range_count"`
+	ReplicatedRangeCount int32          `protobuf:"varint,8,opt,name=replicated_range_count" json:"replicated_range_count"`
+	AvailableRangeCount  int32          `protobuf:"varint,9,opt,name=available_range_count" json:"available_range_count"`
+	XXX_unrecognized     []byte         `json:"-"`
 }
 
 func (m *NodeStatus) Reset()         { *m = NodeStatus{} }
@@ -124,6 +151,27 @@ func (m *NodeStatus) GetStats() MVCCStats {
 		return m.Stats
 	}
 	return MVCCStats{}
+}
+
+func (m *NodeStatus) GetLeaderRangeCount() int32 {
+	if m != nil {
+		return m.LeaderRangeCount
+	}
+	return 0
+}
+
+func (m *NodeStatus) GetReplicatedRangeCount() int32 {
+	if m != nil {
+		return m.ReplicatedRangeCount
+	}
+	return 0
+}
+
+func (m *NodeStatus) GetAvailableRangeCount() int32 {
+	if m != nil {
+		return m.AvailableRangeCount
+	}
+	return 0
 }
 
 func init() {
@@ -255,6 +303,51 @@ func (m *StoreStatus) Unmarshal(data []byte) error {
 				return err
 			}
 			index = postIndex
+		case 7:
+			if wireType != 0 {
+				return fmt.Errorf("proto: wrong wireType = %d for field LeaderRangeCount", wireType)
+			}
+			for shift := uint(0); ; shift += 7 {
+				if index >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := data[index]
+				index++
+				m.LeaderRangeCount |= (int32(b) & 0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+		case 8:
+			if wireType != 0 {
+				return fmt.Errorf("proto: wrong wireType = %d for field ReplicatedRangeCount", wireType)
+			}
+			for shift := uint(0); ; shift += 7 {
+				if index >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := data[index]
+				index++
+				m.ReplicatedRangeCount |= (int32(b) & 0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+		case 9:
+			if wireType != 0 {
+				return fmt.Errorf("proto: wrong wireType = %d for field AvailableRangeCount", wireType)
+			}
+			for shift := uint(0); ; shift += 7 {
+				if index >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := data[index]
+				index++
+				m.AvailableRangeCount |= (int32(b) & 0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
 		default:
 			var sizeOfWire int
 			for {
@@ -407,6 +500,51 @@ func (m *NodeStatus) Unmarshal(data []byte) error {
 				return err
 			}
 			index = postIndex
+		case 7:
+			if wireType != 0 {
+				return fmt.Errorf("proto: wrong wireType = %d for field LeaderRangeCount", wireType)
+			}
+			for shift := uint(0); ; shift += 7 {
+				if index >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := data[index]
+				index++
+				m.LeaderRangeCount |= (int32(b) & 0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+		case 8:
+			if wireType != 0 {
+				return fmt.Errorf("proto: wrong wireType = %d for field ReplicatedRangeCount", wireType)
+			}
+			for shift := uint(0); ; shift += 7 {
+				if index >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := data[index]
+				index++
+				m.ReplicatedRangeCount |= (int32(b) & 0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+		case 9:
+			if wireType != 0 {
+				return fmt.Errorf("proto: wrong wireType = %d for field AvailableRangeCount", wireType)
+			}
+			for shift := uint(0); ; shift += 7 {
+				if index >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := data[index]
+				index++
+				m.AvailableRangeCount |= (int32(b) & 0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
 		default:
 			var sizeOfWire int
 			for {
@@ -441,6 +579,9 @@ func (m *StoreStatus) Size() (n int) {
 	n += 1 + sovStatus(uint64(m.UpdatedAt))
 	l = m.Stats.Size()
 	n += 1 + l + sovStatus(uint64(l))
+	n += 1 + sovStatus(uint64(m.LeaderRangeCount))
+	n += 1 + sovStatus(uint64(m.ReplicatedRangeCount))
+	n += 1 + sovStatus(uint64(m.AvailableRangeCount))
 	if m.XXX_unrecognized != nil {
 		n += len(m.XXX_unrecognized)
 	}
@@ -462,6 +603,9 @@ func (m *NodeStatus) Size() (n int) {
 	n += 1 + sovStatus(uint64(m.UpdatedAt))
 	l = m.Stats.Size()
 	n += 1 + l + sovStatus(uint64(l))
+	n += 1 + sovStatus(uint64(m.LeaderRangeCount))
+	n += 1 + sovStatus(uint64(m.ReplicatedRangeCount))
+	n += 1 + sovStatus(uint64(m.AvailableRangeCount))
 	if m.XXX_unrecognized != nil {
 		n += len(m.XXX_unrecognized)
 	}
@@ -524,6 +668,15 @@ func (m *StoreStatus) MarshalTo(data []byte) (n int, err error) {
 		return 0, err
 	}
 	i += n2
+	data[i] = 0x38
+	i++
+	i = encodeVarintStatus(data, i, uint64(m.LeaderRangeCount))
+	data[i] = 0x40
+	i++
+	i = encodeVarintStatus(data, i, uint64(m.ReplicatedRangeCount))
+	data[i] = 0x48
+	i++
+	i = encodeVarintStatus(data, i, uint64(m.AvailableRangeCount))
 	if m.XXX_unrecognized != nil {
 		i += copy(data[i:], m.XXX_unrecognized)
 	}
@@ -577,6 +730,15 @@ func (m *NodeStatus) MarshalTo(data []byte) (n int, err error) {
 		return 0, err
 	}
 	i += n4
+	data[i] = 0x38
+	i++
+	i = encodeVarintStatus(data, i, uint64(m.LeaderRangeCount))
+	data[i] = 0x40
+	i++
+	i = encodeVarintStatus(data, i, uint64(m.ReplicatedRangeCount))
+	data[i] = 0x48
+	i++
+	i = encodeVarintStatus(data, i, uint64(m.AvailableRangeCount))
 	if m.XXX_unrecognized != nil {
 		i += copy(data[i:], m.XXX_unrecognized)
 	}

--- a/proto/status.proto
+++ b/proto/status.proto
@@ -29,16 +29,19 @@ option (gogoproto.unmarshaler_all) = true;
 
 // StoreStatus contains the stats needed to calculate the current status of a
 // store.
-message StoreStatus {  
+message StoreStatus {
   optional StoreDescriptor desc = 1 [(gogoproto.nullable) = false];
   optional int32 node_id = 2 [(gogoproto.nullable) = false, (gogoproto.customname) = "NodeID", (gogoproto.customtype) = "NodeID"];
   optional int32 range_count = 3 [(gogoproto.nullable) = false];
   optional int64 started_at = 4 [(gogoproto.nullable) = false];
   optional int64 updated_at = 5 [(gogoproto.nullable) = false];
   optional MVCCStats stats = 6 [(gogoproto.nullable) = false];
+  optional int32 leader_range_count = 7 [(gogoproto.nullable) = false];
+  optional int32 replicated_range_count = 8 [(gogoproto.nullable) = false];
+  optional int32 available_range_count = 9 [(gogoproto.nullable) = false];
 }
 
-// NodeStatus contains the stats needed to calculate the current status of a 
+// NodeStatus contains the stats needed to calculate the current status of a
 // node.
 message NodeStatus {
   optional NodeDescriptor desc = 1 [(gogoproto.nullable) = false];
@@ -47,5 +50,7 @@ message NodeStatus {
   optional int64 started_at = 4 [(gogoproto.nullable) = false];
   optional int64 updated_at = 5 [(gogoproto.nullable) = false];
   optional MVCCStats stats = 6 [(gogoproto.nullable) = false];
-
+  optional int32 leader_range_count = 7 [(gogoproto.nullable) = false];
+  optional int32 replicated_range_count = 8 [(gogoproto.nullable) = false];
+  optional int32 available_range_count = 9 [(gogoproto.nullable) = false];
 }

--- a/server/node_test.go
+++ b/server/node_test.go
@@ -265,7 +265,8 @@ func TestCorruptedClusterID(t *testing.T) {
 
 // compareNodeStatus ensures that the actual node status for the passed in
 // node is updated correctly. It checks that the Node Descriptor, StoreIDs,
-// RangeCount and StartedAt are exactly correct and that the bytes and counts
+// RangeCount, StartedAt, LeaderRangeCount, ReplicatedRangeCount and
+// AvailableRangeCount are exactly correct and that the bytes and counts
 // for Live, Key and Val are at least the expected value.  And that UpdatedAt
 // has increased.
 // The latest actual stats are returned.
@@ -295,6 +296,15 @@ func compareStoreStatus(t *testing.T, node *Node, expectedNodeStatus *proto.Node
 	}
 	if !reflect.DeepEqual(expectedNodeStatus.Desc, nodeStatus.Desc) {
 		t.Errorf("%v: Description does not match expected\nexpected: %+v\nactual: %v\n", testNumber, expectedNodeStatus, nodeStatus)
+	}
+	if expectedNodeStatus.LeaderRangeCount != nodeStatus.LeaderRangeCount {
+		t.Errorf("%v: LeaderRangeCount does not match expected\nexpected: %+v\nactual: %v\n", testNumber, expectedNodeStatus, nodeStatus)
+	}
+	if expectedNodeStatus.ReplicatedRangeCount != nodeStatus.ReplicatedRangeCount {
+		t.Errorf("%v: ReplicatedRangeCount does not match expected\nexpected: %+v\nactual: %v\n", testNumber, expectedNodeStatus, nodeStatus)
+	}
+	if expectedNodeStatus.AvailableRangeCount != nodeStatus.AvailableRangeCount {
+		t.Errorf("%v: AvailableRangeCount does not match expected\nexpected: %+v\nactual: %v\n", testNumber, expectedNodeStatus, nodeStatus)
 	}
 
 	// There values must >= to the older value.
@@ -360,12 +370,22 @@ func TestNodeStatus(t *testing.T) {
 		t.Fatal(err)
 	}
 
+	s.WaitForInit()
+	// Perform a read from the range to ensure that the raft election has
+	// completed.  We do not expect an response.
+	if err := ts.kv.Run(client.Get([]byte("a"))); err != nil {
+		t.Fatal(err)
+	}
+
 	expectedNodeStatus := &proto.NodeStatus{
-		RangeCount: 1,
-		StoreIDs:   []int32{1, 2, 3},
-		StartedAt:  0,
-		UpdatedAt:  0,
-		Desc:       ts.node.Descriptor,
+		RangeCount:           1,
+		StoreIDs:             []int32{1, 2, 3},
+		StartedAt:            0,
+		UpdatedAt:            0,
+		Desc:                 ts.node.Descriptor,
+		LeaderRangeCount:     1,
+		AvailableRangeCount:  1,
+		ReplicatedRangeCount: 0,
 		Stats: proto.MVCCStats{
 			LiveBytes: 1,
 			KeyBytes:  1,
@@ -392,11 +412,14 @@ func TestNodeStatus(t *testing.T) {
 	}
 
 	expectedNodeStatus = &proto.NodeStatus{
-		RangeCount: 1,
-		StoreIDs:   []int32{1, 2, 3},
-		StartedAt:  oldStats.StartedAt,
-		UpdatedAt:  oldStats.UpdatedAt,
-		Desc:       ts.node.Descriptor,
+		RangeCount:           1,
+		StoreIDs:             []int32{1, 2, 3},
+		StartedAt:            oldStats.StartedAt,
+		UpdatedAt:            oldStats.UpdatedAt,
+		Desc:                 ts.node.Descriptor,
+		LeaderRangeCount:     1,
+		AvailableRangeCount:  1,
+		ReplicatedRangeCount: 0,
 		Stats: proto.MVCCStats{
 			LiveBytes: 1,
 			KeyBytes:  1,
@@ -432,11 +455,14 @@ func TestNodeStatus(t *testing.T) {
 	}
 
 	expectedNodeStatus = &proto.NodeStatus{
-		RangeCount: 2,
-		StoreIDs:   []int32{1, 2, 3},
-		StartedAt:  oldStats.StartedAt,
-		UpdatedAt:  oldStats.UpdatedAt,
-		Desc:       ts.node.Descriptor,
+		RangeCount:           2,
+		StoreIDs:             []int32{1, 2, 3},
+		StartedAt:            oldStats.StartedAt,
+		UpdatedAt:            oldStats.UpdatedAt,
+		Desc:                 ts.node.Descriptor,
+		LeaderRangeCount:     2,
+		AvailableRangeCount:  2,
+		ReplicatedRangeCount: 0,
 		Stats: proto.MVCCStats{
 			LiveBytes: 1,
 			KeyBytes:  1,
@@ -461,11 +487,14 @@ func TestNodeStatus(t *testing.T) {
 	}
 
 	expectedNodeStatus = &proto.NodeStatus{
-		RangeCount: 2,
-		StoreIDs:   []int32{1, 2, 3},
-		StartedAt:  oldStats.StartedAt,
-		UpdatedAt:  oldStats.UpdatedAt,
-		Desc:       ts.node.Descriptor,
+		RangeCount:           2,
+		StoreIDs:             []int32{1, 2, 3},
+		StartedAt:            oldStats.StartedAt,
+		UpdatedAt:            oldStats.UpdatedAt,
+		Desc:                 ts.node.Descriptor,
+		LeaderRangeCount:     2,
+		AvailableRangeCount:  2,
+		ReplicatedRangeCount: 0,
 		Stats: proto.MVCCStats{
 			LiveBytes: 1,
 			KeyBytes:  1,

--- a/storage/engine/cockroach/proto/status.pb.cc
+++ b/storage/engine/cockroach/proto/status.pb.cc
@@ -38,13 +38,16 @@ void protobuf_AssignDesc_cockroach_2fproto_2fstatus_2eproto() {
       "cockroach/proto/status.proto");
   GOOGLE_CHECK(file != NULL);
   StoreStatus_descriptor_ = file->message_type(0);
-  static const int StoreStatus_offsets_[6] = {
+  static const int StoreStatus_offsets_[9] = {
     GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(StoreStatus, desc_),
     GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(StoreStatus, node_id_),
     GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(StoreStatus, range_count_),
     GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(StoreStatus, started_at_),
     GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(StoreStatus, updated_at_),
     GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(StoreStatus, stats_),
+    GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(StoreStatus, leader_range_count_),
+    GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(StoreStatus, replicated_range_count_),
+    GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(StoreStatus, available_range_count_),
   };
   StoreStatus_reflection_ =
     new ::google::protobuf::internal::GeneratedMessageReflection(
@@ -58,13 +61,16 @@ void protobuf_AssignDesc_cockroach_2fproto_2fstatus_2eproto() {
       ::google::protobuf::MessageFactory::generated_factory(),
       sizeof(StoreStatus));
   NodeStatus_descriptor_ = file->message_type(1);
-  static const int NodeStatus_offsets_[6] = {
+  static const int NodeStatus_offsets_[9] = {
     GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(NodeStatus, desc_),
     GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(NodeStatus, store_ids_),
     GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(NodeStatus, range_count_),
     GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(NodeStatus, started_at_),
     GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(NodeStatus, updated_at_),
     GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(NodeStatus, stats_),
+    GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(NodeStatus, leader_range_count_),
+    GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(NodeStatus, replicated_range_count_),
+    GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(NodeStatus, available_range_count_),
   };
   NodeStatus_reflection_ =
     new ::google::protobuf::internal::GeneratedMessageReflection(
@@ -117,19 +123,24 @@ void protobuf_AddDesc_cockroach_2fproto_2fstatus_2eproto() {
     "\n\034cockroach/proto/status.proto\022\017cockroac"
     "h.proto\032\032cockroach/proto/data.proto\032\034coc"
     "kroach/proto/config.proto\032\024gogoproto/gog"
-    "o.proto\"\356\001\n\013StoreStatus\0224\n\004desc\030\001 \001(\0132 ."
+    "o.proto\"\333\002\n\013StoreStatus\0224\n\004desc\030\001 \001(\0132 ."
     "cockroach.proto.StoreDescriptorB\004\310\336\037\000\022)\n"
     "\007node_id\030\002 \001(\005B\030\310\336\037\000\342\336\037\006NodeID\332\336\037\006NodeID"
     "\022\031\n\013range_count\030\003 \001(\005B\004\310\336\037\000\022\030\n\nstarted_a"
     "t\030\004 \001(\003B\004\310\336\037\000\022\030\n\nupdated_at\030\005 \001(\003B\004\310\336\037\000\022"
     "/\n\005stats\030\006 \001(\0132\032.cockroach.proto.MVCCSta"
-    "tsB\004\310\336\037\000\"\346\001\n\nNodeStatus\0223\n\004desc\030\001 \001(\0132\037."
-    "cockroach.proto.NodeDescriptorB\004\310\336\037\000\022#\n\t"
-    "store_ids\030\002 \003(\005B\020\310\336\037\000\342\336\037\010StoreIDs\022\031\n\013ran"
-    "ge_count\030\003 \001(\005B\004\310\336\037\000\022\030\n\nstarted_at\030\004 \001(\003"
-    "B\004\310\336\037\000\022\030\n\nupdated_at\030\005 \001(\003B\004\310\336\037\000\022/\n\005stat"
-    "s\030\006 \001(\0132\032.cockroach.proto.MVCCStatsB\004\310\336\037"
-    "\000B\023Z\005proto\340\342\036\001\310\342\036\001\320\342\036\001", 622);
+    "tsB\004\310\336\037\000\022 \n\022leader_range_count\030\007 \001(\005B\004\310\336"
+    "\037\000\022$\n\026replicated_range_count\030\010 \001(\005B\004\310\336\037\000"
+    "\022#\n\025available_range_count\030\t \001(\005B\004\310\336\037\000\"\323\002"
+    "\n\nNodeStatus\0223\n\004desc\030\001 \001(\0132\037.cockroach.p"
+    "roto.NodeDescriptorB\004\310\336\037\000\022#\n\tstore_ids\030\002"
+    " \003(\005B\020\310\336\037\000\342\336\037\010StoreIDs\022\031\n\013range_count\030\003 "
+    "\001(\005B\004\310\336\037\000\022\030\n\nstarted_at\030\004 \001(\003B\004\310\336\037\000\022\030\n\nu"
+    "pdated_at\030\005 \001(\003B\004\310\336\037\000\022/\n\005stats\030\006 \001(\0132\032.c"
+    "ockroach.proto.MVCCStatsB\004\310\336\037\000\022 \n\022leader"
+    "_range_count\030\007 \001(\005B\004\310\336\037\000\022$\n\026replicated_r"
+    "ange_count\030\010 \001(\005B\004\310\336\037\000\022#\n\025available_rang"
+    "e_count\030\t \001(\005B\004\310\336\037\000B\023Z\005proto\340\342\036\001\310\342\036\001\320\342\036\001", 840);
   ::google::protobuf::MessageFactory::InternalRegisterGeneratedFile(
     "cockroach/proto/status.proto", &protobuf_RegisterTypes);
   StoreStatus::default_instance_ = new StoreStatus();
@@ -155,6 +166,9 @@ const int StoreStatus::kRangeCountFieldNumber;
 const int StoreStatus::kStartedAtFieldNumber;
 const int StoreStatus::kUpdatedAtFieldNumber;
 const int StoreStatus::kStatsFieldNumber;
+const int StoreStatus::kLeaderRangeCountFieldNumber;
+const int StoreStatus::kReplicatedRangeCountFieldNumber;
+const int StoreStatus::kAvailableRangeCountFieldNumber;
 #endif  // !_MSC_VER
 
 StoreStatus::StoreStatus()
@@ -183,6 +197,9 @@ void StoreStatus::SharedCtor() {
   started_at_ = GOOGLE_LONGLONG(0);
   updated_at_ = GOOGLE_LONGLONG(0);
   stats_ = NULL;
+  leader_range_count_ = 0;
+  replicated_range_count_ = 0;
+  available_range_count_ = 0;
   ::memset(_has_bits_, 0, sizeof(_has_bits_));
 }
 
@@ -230,8 +247,9 @@ void StoreStatus::Clear() {
     ::memset(&first, 0, n);                                \
   } while (0)
 
-  if (_has_bits_[0 / 32] & 63) {
+  if (_has_bits_[0 / 32] & 255) {
     ZR_(node_id_, updated_at_);
+    ZR_(leader_range_count_, replicated_range_count_);
     if (has_desc()) {
       if (desc_ != NULL) desc_->::cockroach::proto::StoreDescriptor::Clear();
     }
@@ -239,6 +257,7 @@ void StoreStatus::Clear() {
       if (stats_ != NULL) stats_->::cockroach::proto::MVCCStats::Clear();
     }
   }
+  available_range_count_ = 0;
 
 #undef OFFSET_OF_FIELD_
 #undef ZR_
@@ -338,6 +357,51 @@ bool StoreStatus::MergePartialFromCodedStream(
         } else {
           goto handle_unusual;
         }
+        if (input->ExpectTag(56)) goto parse_leader_range_count;
+        break;
+      }
+
+      // optional int32 leader_range_count = 7;
+      case 7: {
+        if (tag == 56) {
+         parse_leader_range_count:
+          DO_((::google::protobuf::internal::WireFormatLite::ReadPrimitive<
+                   ::google::protobuf::int32, ::google::protobuf::internal::WireFormatLite::TYPE_INT32>(
+                 input, &leader_range_count_)));
+          set_has_leader_range_count();
+        } else {
+          goto handle_unusual;
+        }
+        if (input->ExpectTag(64)) goto parse_replicated_range_count;
+        break;
+      }
+
+      // optional int32 replicated_range_count = 8;
+      case 8: {
+        if (tag == 64) {
+         parse_replicated_range_count:
+          DO_((::google::protobuf::internal::WireFormatLite::ReadPrimitive<
+                   ::google::protobuf::int32, ::google::protobuf::internal::WireFormatLite::TYPE_INT32>(
+                 input, &replicated_range_count_)));
+          set_has_replicated_range_count();
+        } else {
+          goto handle_unusual;
+        }
+        if (input->ExpectTag(72)) goto parse_available_range_count;
+        break;
+      }
+
+      // optional int32 available_range_count = 9;
+      case 9: {
+        if (tag == 72) {
+         parse_available_range_count:
+          DO_((::google::protobuf::internal::WireFormatLite::ReadPrimitive<
+                   ::google::protobuf::int32, ::google::protobuf::internal::WireFormatLite::TYPE_INT32>(
+                 input, &available_range_count_)));
+          set_has_available_range_count();
+        } else {
+          goto handle_unusual;
+        }
         if (input->ExpectAtEnd()) goto success;
         break;
       }
@@ -399,6 +463,21 @@ void StoreStatus::SerializeWithCachedSizes(
       6, this->stats(), output);
   }
 
+  // optional int32 leader_range_count = 7;
+  if (has_leader_range_count()) {
+    ::google::protobuf::internal::WireFormatLite::WriteInt32(7, this->leader_range_count(), output);
+  }
+
+  // optional int32 replicated_range_count = 8;
+  if (has_replicated_range_count()) {
+    ::google::protobuf::internal::WireFormatLite::WriteInt32(8, this->replicated_range_count(), output);
+  }
+
+  // optional int32 available_range_count = 9;
+  if (has_available_range_count()) {
+    ::google::protobuf::internal::WireFormatLite::WriteInt32(9, this->available_range_count(), output);
+  }
+
   if (!unknown_fields().empty()) {
     ::google::protobuf::internal::WireFormat::SerializeUnknownFields(
         unknown_fields(), output);
@@ -441,6 +520,21 @@ void StoreStatus::SerializeWithCachedSizes(
     target = ::google::protobuf::internal::WireFormatLite::
       WriteMessageNoVirtualToArray(
         6, this->stats(), target);
+  }
+
+  // optional int32 leader_range_count = 7;
+  if (has_leader_range_count()) {
+    target = ::google::protobuf::internal::WireFormatLite::WriteInt32ToArray(7, this->leader_range_count(), target);
+  }
+
+  // optional int32 replicated_range_count = 8;
+  if (has_replicated_range_count()) {
+    target = ::google::protobuf::internal::WireFormatLite::WriteInt32ToArray(8, this->replicated_range_count(), target);
+  }
+
+  // optional int32 available_range_count = 9;
+  if (has_available_range_count()) {
+    target = ::google::protobuf::internal::WireFormatLite::WriteInt32ToArray(9, this->available_range_count(), target);
   }
 
   if (!unknown_fields().empty()) {
@@ -497,6 +591,29 @@ int StoreStatus::ByteSize() const {
           this->stats());
     }
 
+    // optional int32 leader_range_count = 7;
+    if (has_leader_range_count()) {
+      total_size += 1 +
+        ::google::protobuf::internal::WireFormatLite::Int32Size(
+          this->leader_range_count());
+    }
+
+    // optional int32 replicated_range_count = 8;
+    if (has_replicated_range_count()) {
+      total_size += 1 +
+        ::google::protobuf::internal::WireFormatLite::Int32Size(
+          this->replicated_range_count());
+    }
+
+  }
+  if (_has_bits_[8 / 32] & (0xffu << (8 % 32))) {
+    // optional int32 available_range_count = 9;
+    if (has_available_range_count()) {
+      total_size += 1 +
+        ::google::protobuf::internal::WireFormatLite::Int32Size(
+          this->available_range_count());
+    }
+
   }
   if (!unknown_fields().empty()) {
     total_size +=
@@ -542,6 +659,17 @@ void StoreStatus::MergeFrom(const StoreStatus& from) {
     if (from.has_stats()) {
       mutable_stats()->::cockroach::proto::MVCCStats::MergeFrom(from.stats());
     }
+    if (from.has_leader_range_count()) {
+      set_leader_range_count(from.leader_range_count());
+    }
+    if (from.has_replicated_range_count()) {
+      set_replicated_range_count(from.replicated_range_count());
+    }
+  }
+  if (from._has_bits_[8 / 32] & (0xffu << (8 % 32))) {
+    if (from.has_available_range_count()) {
+      set_available_range_count(from.available_range_count());
+    }
   }
   mutable_unknown_fields()->MergeFrom(from.unknown_fields());
 }
@@ -571,6 +699,9 @@ void StoreStatus::Swap(StoreStatus* other) {
     std::swap(started_at_, other->started_at_);
     std::swap(updated_at_, other->updated_at_);
     std::swap(stats_, other->stats_);
+    std::swap(leader_range_count_, other->leader_range_count_);
+    std::swap(replicated_range_count_, other->replicated_range_count_);
+    std::swap(available_range_count_, other->available_range_count_);
     std::swap(_has_bits_[0], other->_has_bits_[0]);
     _unknown_fields_.Swap(&other->_unknown_fields_);
     std::swap(_cached_size_, other->_cached_size_);
@@ -595,6 +726,9 @@ const int NodeStatus::kRangeCountFieldNumber;
 const int NodeStatus::kStartedAtFieldNumber;
 const int NodeStatus::kUpdatedAtFieldNumber;
 const int NodeStatus::kStatsFieldNumber;
+const int NodeStatus::kLeaderRangeCountFieldNumber;
+const int NodeStatus::kReplicatedRangeCountFieldNumber;
+const int NodeStatus::kAvailableRangeCountFieldNumber;
 #endif  // !_MSC_VER
 
 NodeStatus::NodeStatus()
@@ -622,6 +756,9 @@ void NodeStatus::SharedCtor() {
   started_at_ = GOOGLE_LONGLONG(0);
   updated_at_ = GOOGLE_LONGLONG(0);
   stats_ = NULL;
+  leader_range_count_ = 0;
+  replicated_range_count_ = 0;
+  available_range_count_ = 0;
   ::memset(_has_bits_, 0, sizeof(_has_bits_));
 }
 
@@ -669,16 +806,17 @@ void NodeStatus::Clear() {
     ::memset(&first, 0, n);                                \
   } while (0)
 
-  if (_has_bits_[0 / 32] & 61) {
-    ZR_(started_at_, updated_at_);
+  if (_has_bits_[0 / 32] & 253) {
+    ZR_(started_at_, leader_range_count_);
     if (has_desc()) {
       if (desc_ != NULL) desc_->::cockroach::proto::NodeDescriptor::Clear();
     }
-    range_count_ = 0;
     if (has_stats()) {
       if (stats_ != NULL) stats_->::cockroach::proto::MVCCStats::Clear();
     }
+    replicated_range_count_ = 0;
   }
+  available_range_count_ = 0;
 
 #undef OFFSET_OF_FIELD_
 #undef ZR_
@@ -783,6 +921,51 @@ bool NodeStatus::MergePartialFromCodedStream(
         } else {
           goto handle_unusual;
         }
+        if (input->ExpectTag(56)) goto parse_leader_range_count;
+        break;
+      }
+
+      // optional int32 leader_range_count = 7;
+      case 7: {
+        if (tag == 56) {
+         parse_leader_range_count:
+          DO_((::google::protobuf::internal::WireFormatLite::ReadPrimitive<
+                   ::google::protobuf::int32, ::google::protobuf::internal::WireFormatLite::TYPE_INT32>(
+                 input, &leader_range_count_)));
+          set_has_leader_range_count();
+        } else {
+          goto handle_unusual;
+        }
+        if (input->ExpectTag(64)) goto parse_replicated_range_count;
+        break;
+      }
+
+      // optional int32 replicated_range_count = 8;
+      case 8: {
+        if (tag == 64) {
+         parse_replicated_range_count:
+          DO_((::google::protobuf::internal::WireFormatLite::ReadPrimitive<
+                   ::google::protobuf::int32, ::google::protobuf::internal::WireFormatLite::TYPE_INT32>(
+                 input, &replicated_range_count_)));
+          set_has_replicated_range_count();
+        } else {
+          goto handle_unusual;
+        }
+        if (input->ExpectTag(72)) goto parse_available_range_count;
+        break;
+      }
+
+      // optional int32 available_range_count = 9;
+      case 9: {
+        if (tag == 72) {
+         parse_available_range_count:
+          DO_((::google::protobuf::internal::WireFormatLite::ReadPrimitive<
+                   ::google::protobuf::int32, ::google::protobuf::internal::WireFormatLite::TYPE_INT32>(
+                 input, &available_range_count_)));
+          set_has_available_range_count();
+        } else {
+          goto handle_unusual;
+        }
         if (input->ExpectAtEnd()) goto success;
         break;
       }
@@ -845,6 +1028,21 @@ void NodeStatus::SerializeWithCachedSizes(
       6, this->stats(), output);
   }
 
+  // optional int32 leader_range_count = 7;
+  if (has_leader_range_count()) {
+    ::google::protobuf::internal::WireFormatLite::WriteInt32(7, this->leader_range_count(), output);
+  }
+
+  // optional int32 replicated_range_count = 8;
+  if (has_replicated_range_count()) {
+    ::google::protobuf::internal::WireFormatLite::WriteInt32(8, this->replicated_range_count(), output);
+  }
+
+  // optional int32 available_range_count = 9;
+  if (has_available_range_count()) {
+    ::google::protobuf::internal::WireFormatLite::WriteInt32(9, this->available_range_count(), output);
+  }
+
   if (!unknown_fields().empty()) {
     ::google::protobuf::internal::WireFormat::SerializeUnknownFields(
         unknown_fields(), output);
@@ -888,6 +1086,21 @@ void NodeStatus::SerializeWithCachedSizes(
     target = ::google::protobuf::internal::WireFormatLite::
       WriteMessageNoVirtualToArray(
         6, this->stats(), target);
+  }
+
+  // optional int32 leader_range_count = 7;
+  if (has_leader_range_count()) {
+    target = ::google::protobuf::internal::WireFormatLite::WriteInt32ToArray(7, this->leader_range_count(), target);
+  }
+
+  // optional int32 replicated_range_count = 8;
+  if (has_replicated_range_count()) {
+    target = ::google::protobuf::internal::WireFormatLite::WriteInt32ToArray(8, this->replicated_range_count(), target);
+  }
+
+  // optional int32 available_range_count = 9;
+  if (has_available_range_count()) {
+    target = ::google::protobuf::internal::WireFormatLite::WriteInt32ToArray(9, this->available_range_count(), target);
   }
 
   if (!unknown_fields().empty()) {
@@ -935,6 +1148,29 @@ int NodeStatus::ByteSize() const {
       total_size += 1 +
         ::google::protobuf::internal::WireFormatLite::MessageSizeNoVirtual(
           this->stats());
+    }
+
+    // optional int32 leader_range_count = 7;
+    if (has_leader_range_count()) {
+      total_size += 1 +
+        ::google::protobuf::internal::WireFormatLite::Int32Size(
+          this->leader_range_count());
+    }
+
+    // optional int32 replicated_range_count = 8;
+    if (has_replicated_range_count()) {
+      total_size += 1 +
+        ::google::protobuf::internal::WireFormatLite::Int32Size(
+          this->replicated_range_count());
+    }
+
+  }
+  if (_has_bits_[8 / 32] & (0xffu << (8 % 32))) {
+    // optional int32 available_range_count = 9;
+    if (has_available_range_count()) {
+      total_size += 1 +
+        ::google::protobuf::internal::WireFormatLite::Int32Size(
+          this->available_range_count());
     }
 
   }
@@ -990,6 +1226,17 @@ void NodeStatus::MergeFrom(const NodeStatus& from) {
     if (from.has_stats()) {
       mutable_stats()->::cockroach::proto::MVCCStats::MergeFrom(from.stats());
     }
+    if (from.has_leader_range_count()) {
+      set_leader_range_count(from.leader_range_count());
+    }
+    if (from.has_replicated_range_count()) {
+      set_replicated_range_count(from.replicated_range_count());
+    }
+  }
+  if (from._has_bits_[8 / 32] & (0xffu << (8 % 32))) {
+    if (from.has_available_range_count()) {
+      set_available_range_count(from.available_range_count());
+    }
   }
   mutable_unknown_fields()->MergeFrom(from.unknown_fields());
 }
@@ -1019,6 +1266,9 @@ void NodeStatus::Swap(NodeStatus* other) {
     std::swap(started_at_, other->started_at_);
     std::swap(updated_at_, other->updated_at_);
     std::swap(stats_, other->stats_);
+    std::swap(leader_range_count_, other->leader_range_count_);
+    std::swap(replicated_range_count_, other->replicated_range_count_);
+    std::swap(available_range_count_, other->available_range_count_);
     std::swap(_has_bits_[0], other->_has_bits_[0]);
     _unknown_fields_.Swap(&other->_unknown_fields_);
     std::swap(_cached_size_, other->_cached_size_);

--- a/storage/engine/cockroach/proto/status.pb.h
+++ b/storage/engine/cockroach/proto/status.pb.h
@@ -141,6 +141,27 @@ class StoreStatus : public ::google::protobuf::Message {
   inline ::cockroach::proto::MVCCStats* release_stats();
   inline void set_allocated_stats(::cockroach::proto::MVCCStats* stats);
 
+  // optional int32 leader_range_count = 7;
+  inline bool has_leader_range_count() const;
+  inline void clear_leader_range_count();
+  static const int kLeaderRangeCountFieldNumber = 7;
+  inline ::google::protobuf::int32 leader_range_count() const;
+  inline void set_leader_range_count(::google::protobuf::int32 value);
+
+  // optional int32 replicated_range_count = 8;
+  inline bool has_replicated_range_count() const;
+  inline void clear_replicated_range_count();
+  static const int kReplicatedRangeCountFieldNumber = 8;
+  inline ::google::protobuf::int32 replicated_range_count() const;
+  inline void set_replicated_range_count(::google::protobuf::int32 value);
+
+  // optional int32 available_range_count = 9;
+  inline bool has_available_range_count() const;
+  inline void clear_available_range_count();
+  static const int kAvailableRangeCountFieldNumber = 9;
+  inline ::google::protobuf::int32 available_range_count() const;
+  inline void set_available_range_count(::google::protobuf::int32 value);
+
   // @@protoc_insertion_point(class_scope:cockroach.proto.StoreStatus)
  private:
   inline void set_has_desc();
@@ -155,6 +176,12 @@ class StoreStatus : public ::google::protobuf::Message {
   inline void clear_has_updated_at();
   inline void set_has_stats();
   inline void clear_has_stats();
+  inline void set_has_leader_range_count();
+  inline void clear_has_leader_range_count();
+  inline void set_has_replicated_range_count();
+  inline void clear_has_replicated_range_count();
+  inline void set_has_available_range_count();
+  inline void clear_has_available_range_count();
 
   ::google::protobuf::UnknownFieldSet _unknown_fields_;
 
@@ -166,6 +193,9 @@ class StoreStatus : public ::google::protobuf::Message {
   ::google::protobuf::int64 started_at_;
   ::google::protobuf::int64 updated_at_;
   ::cockroach::proto::MVCCStats* stats_;
+  ::google::protobuf::int32 leader_range_count_;
+  ::google::protobuf::int32 replicated_range_count_;
+  ::google::protobuf::int32 available_range_count_;
   friend void  protobuf_AddDesc_cockroach_2fproto_2fstatus_2eproto();
   friend void protobuf_AssignDesc_cockroach_2fproto_2fstatus_2eproto();
   friend void protobuf_ShutdownFile_cockroach_2fproto_2fstatus_2eproto();
@@ -279,6 +309,27 @@ class NodeStatus : public ::google::protobuf::Message {
   inline ::cockroach::proto::MVCCStats* release_stats();
   inline void set_allocated_stats(::cockroach::proto::MVCCStats* stats);
 
+  // optional int32 leader_range_count = 7;
+  inline bool has_leader_range_count() const;
+  inline void clear_leader_range_count();
+  static const int kLeaderRangeCountFieldNumber = 7;
+  inline ::google::protobuf::int32 leader_range_count() const;
+  inline void set_leader_range_count(::google::protobuf::int32 value);
+
+  // optional int32 replicated_range_count = 8;
+  inline bool has_replicated_range_count() const;
+  inline void clear_replicated_range_count();
+  static const int kReplicatedRangeCountFieldNumber = 8;
+  inline ::google::protobuf::int32 replicated_range_count() const;
+  inline void set_replicated_range_count(::google::protobuf::int32 value);
+
+  // optional int32 available_range_count = 9;
+  inline bool has_available_range_count() const;
+  inline void clear_available_range_count();
+  static const int kAvailableRangeCountFieldNumber = 9;
+  inline ::google::protobuf::int32 available_range_count() const;
+  inline void set_available_range_count(::google::protobuf::int32 value);
+
   // @@protoc_insertion_point(class_scope:cockroach.proto.NodeStatus)
  private:
   inline void set_has_desc();
@@ -291,6 +342,12 @@ class NodeStatus : public ::google::protobuf::Message {
   inline void clear_has_updated_at();
   inline void set_has_stats();
   inline void clear_has_stats();
+  inline void set_has_leader_range_count();
+  inline void clear_has_leader_range_count();
+  inline void set_has_replicated_range_count();
+  inline void clear_has_replicated_range_count();
+  inline void set_has_available_range_count();
+  inline void clear_has_available_range_count();
 
   ::google::protobuf::UnknownFieldSet _unknown_fields_;
 
@@ -300,8 +357,11 @@ class NodeStatus : public ::google::protobuf::Message {
   ::google::protobuf::RepeatedField< ::google::protobuf::int32 > store_ids_;
   ::google::protobuf::int64 started_at_;
   ::google::protobuf::int64 updated_at_;
-  ::cockroach::proto::MVCCStats* stats_;
   ::google::protobuf::int32 range_count_;
+  ::google::protobuf::int32 leader_range_count_;
+  ::cockroach::proto::MVCCStats* stats_;
+  ::google::protobuf::int32 replicated_range_count_;
+  ::google::protobuf::int32 available_range_count_;
   friend void  protobuf_AddDesc_cockroach_2fproto_2fstatus_2eproto();
   friend void protobuf_AssignDesc_cockroach_2fproto_2fstatus_2eproto();
   friend void protobuf_ShutdownFile_cockroach_2fproto_2fstatus_2eproto();
@@ -494,6 +554,78 @@ inline void StoreStatus::set_allocated_stats(::cockroach::proto::MVCCStats* stat
   // @@protoc_insertion_point(field_set_allocated:cockroach.proto.StoreStatus.stats)
 }
 
+// optional int32 leader_range_count = 7;
+inline bool StoreStatus::has_leader_range_count() const {
+  return (_has_bits_[0] & 0x00000040u) != 0;
+}
+inline void StoreStatus::set_has_leader_range_count() {
+  _has_bits_[0] |= 0x00000040u;
+}
+inline void StoreStatus::clear_has_leader_range_count() {
+  _has_bits_[0] &= ~0x00000040u;
+}
+inline void StoreStatus::clear_leader_range_count() {
+  leader_range_count_ = 0;
+  clear_has_leader_range_count();
+}
+inline ::google::protobuf::int32 StoreStatus::leader_range_count() const {
+  // @@protoc_insertion_point(field_get:cockroach.proto.StoreStatus.leader_range_count)
+  return leader_range_count_;
+}
+inline void StoreStatus::set_leader_range_count(::google::protobuf::int32 value) {
+  set_has_leader_range_count();
+  leader_range_count_ = value;
+  // @@protoc_insertion_point(field_set:cockroach.proto.StoreStatus.leader_range_count)
+}
+
+// optional int32 replicated_range_count = 8;
+inline bool StoreStatus::has_replicated_range_count() const {
+  return (_has_bits_[0] & 0x00000080u) != 0;
+}
+inline void StoreStatus::set_has_replicated_range_count() {
+  _has_bits_[0] |= 0x00000080u;
+}
+inline void StoreStatus::clear_has_replicated_range_count() {
+  _has_bits_[0] &= ~0x00000080u;
+}
+inline void StoreStatus::clear_replicated_range_count() {
+  replicated_range_count_ = 0;
+  clear_has_replicated_range_count();
+}
+inline ::google::protobuf::int32 StoreStatus::replicated_range_count() const {
+  // @@protoc_insertion_point(field_get:cockroach.proto.StoreStatus.replicated_range_count)
+  return replicated_range_count_;
+}
+inline void StoreStatus::set_replicated_range_count(::google::protobuf::int32 value) {
+  set_has_replicated_range_count();
+  replicated_range_count_ = value;
+  // @@protoc_insertion_point(field_set:cockroach.proto.StoreStatus.replicated_range_count)
+}
+
+// optional int32 available_range_count = 9;
+inline bool StoreStatus::has_available_range_count() const {
+  return (_has_bits_[0] & 0x00000100u) != 0;
+}
+inline void StoreStatus::set_has_available_range_count() {
+  _has_bits_[0] |= 0x00000100u;
+}
+inline void StoreStatus::clear_has_available_range_count() {
+  _has_bits_[0] &= ~0x00000100u;
+}
+inline void StoreStatus::clear_available_range_count() {
+  available_range_count_ = 0;
+  clear_has_available_range_count();
+}
+inline ::google::protobuf::int32 StoreStatus::available_range_count() const {
+  // @@protoc_insertion_point(field_get:cockroach.proto.StoreStatus.available_range_count)
+  return available_range_count_;
+}
+inline void StoreStatus::set_available_range_count(::google::protobuf::int32 value) {
+  set_has_available_range_count();
+  available_range_count_ = value;
+  // @@protoc_insertion_point(field_set:cockroach.proto.StoreStatus.available_range_count)
+}
+
 // -------------------------------------------------------------------
 
 // NodeStatus
@@ -680,6 +812,78 @@ inline void NodeStatus::set_allocated_stats(::cockroach::proto::MVCCStats* stats
     clear_has_stats();
   }
   // @@protoc_insertion_point(field_set_allocated:cockroach.proto.NodeStatus.stats)
+}
+
+// optional int32 leader_range_count = 7;
+inline bool NodeStatus::has_leader_range_count() const {
+  return (_has_bits_[0] & 0x00000040u) != 0;
+}
+inline void NodeStatus::set_has_leader_range_count() {
+  _has_bits_[0] |= 0x00000040u;
+}
+inline void NodeStatus::clear_has_leader_range_count() {
+  _has_bits_[0] &= ~0x00000040u;
+}
+inline void NodeStatus::clear_leader_range_count() {
+  leader_range_count_ = 0;
+  clear_has_leader_range_count();
+}
+inline ::google::protobuf::int32 NodeStatus::leader_range_count() const {
+  // @@protoc_insertion_point(field_get:cockroach.proto.NodeStatus.leader_range_count)
+  return leader_range_count_;
+}
+inline void NodeStatus::set_leader_range_count(::google::protobuf::int32 value) {
+  set_has_leader_range_count();
+  leader_range_count_ = value;
+  // @@protoc_insertion_point(field_set:cockroach.proto.NodeStatus.leader_range_count)
+}
+
+// optional int32 replicated_range_count = 8;
+inline bool NodeStatus::has_replicated_range_count() const {
+  return (_has_bits_[0] & 0x00000080u) != 0;
+}
+inline void NodeStatus::set_has_replicated_range_count() {
+  _has_bits_[0] |= 0x00000080u;
+}
+inline void NodeStatus::clear_has_replicated_range_count() {
+  _has_bits_[0] &= ~0x00000080u;
+}
+inline void NodeStatus::clear_replicated_range_count() {
+  replicated_range_count_ = 0;
+  clear_has_replicated_range_count();
+}
+inline ::google::protobuf::int32 NodeStatus::replicated_range_count() const {
+  // @@protoc_insertion_point(field_get:cockroach.proto.NodeStatus.replicated_range_count)
+  return replicated_range_count_;
+}
+inline void NodeStatus::set_replicated_range_count(::google::protobuf::int32 value) {
+  set_has_replicated_range_count();
+  replicated_range_count_ = value;
+  // @@protoc_insertion_point(field_set:cockroach.proto.NodeStatus.replicated_range_count)
+}
+
+// optional int32 available_range_count = 9;
+inline bool NodeStatus::has_available_range_count() const {
+  return (_has_bits_[0] & 0x00000100u) != 0;
+}
+inline void NodeStatus::set_has_available_range_count() {
+  _has_bits_[0] |= 0x00000100u;
+}
+inline void NodeStatus::clear_has_available_range_count() {
+  _has_bits_[0] &= ~0x00000100u;
+}
+inline void NodeStatus::clear_available_range_count() {
+  available_range_count_ = 0;
+  clear_has_available_range_count();
+}
+inline ::google::protobuf::int32 NodeStatus::available_range_count() const {
+  // @@protoc_insertion_point(field_get:cockroach.proto.NodeStatus.available_range_count)
+  return available_range_count_;
+}
+inline void NodeStatus::set_available_range_count(::google::protobuf::int32 value) {
+  set_has_available_range_count();
+  available_range_count_ = value;
+  // @@protoc_insertion_point(field_set:cockroach.proto.NodeStatus.available_range_count)
 }
 
 


### PR DESCRIPTION
This adds counts to the statuses for 
- number of leader ranges
- number of fully replicated ranges
- number of available ranges

There will be some refinement that is going to be needed, but this should get us an estimate at the store and node levels of the health of the system.
