### PR TITLE
Test killing/restarting individual nodes

### DIFF
--- a/acceptance/gossip_peerings_test.go
+++ b/acceptance/gossip_peerings_test.go
@@ -104,9 +104,4 @@ func TestGossipPeerings(t *testing.T) {
 	defer l.Stop()
 
 	checkGossipPeerings(t, l, 20)
-
-	select {
-	case <-stopper:
-	case <-done:
-	}
 }

--- a/acceptance/gossip_peerings_test.go
+++ b/acceptance/gossip_peerings_test.go
@@ -104,4 +104,9 @@ func TestGossipPeerings(t *testing.T) {
 	defer l.Stop()
 
 	checkGossipPeerings(t, l, 20)
+
+	select {
+	case <-stopper:
+	case <-done:
+	}
 }

--- a/acceptance/localcluster/docker.go
+++ b/acceptance/localcluster/docker.go
@@ -218,6 +218,16 @@ func (c *Container) Unpause() error {
 	return c.client.UnpauseContainer(c.Id)
 }
 
+// Restart restarts a running container.
+// Container will be killed after 'timeout' seconds if it fails to stop.
+func (c *Container) Restart(timeoutSeconds int) error {
+	if err := c.client.RestartContainer(c.Id, timeoutSeconds); err != nil {
+		return err
+	}
+	// We need to refresh the container metadata. Ports change on restart.
+	return c.Inspect()
+}
+
 // Wait waits for a running container to exit.
 func (c *Container) Wait() error {
 	// TODO(pmattis): dockerclient does not support the "wait" method

--- a/acceptance/localcluster/localcluster.go
+++ b/acceptance/localcluster/localcluster.go
@@ -106,7 +106,7 @@ type Cluster struct {
 	vols           *Container
 	Nodes          []*Container
 	Events         chan Event
-	certsDir       string
+	CertsDir       string
 	monitorStopper chan struct{}
 }
 

--- a/acceptance/localcluster/localcluster.go
+++ b/acceptance/localcluster/localcluster.go
@@ -217,12 +217,12 @@ func (l *Cluster) createVolumes() {
 		panic(err)
 	}
 
-	l.certsDir, err = ioutil.TempDir(os.TempDir(), "localcluster.")
+	l.CertsDir, err = ioutil.TempDir(os.TempDir(), "localcluster.")
 	if err != nil {
 		panic(err)
 	}
 
-	binds := []string{l.certsDir + ":/certs"}
+	binds := []string{l.CertsDir + ":/certs"}
 	if *cockroachImage == builderImage {
 		path, err := filepath.Abs(*cockroachBinary)
 		if err != nil {
@@ -395,9 +395,9 @@ func (l *Cluster) Stop() {
 		maybePanic(l.vols.Kill())
 		l.vols = nil
 	}
-	if l.certsDir != "" {
-		_ = os.RemoveAll(l.certsDir)
-		l.certsDir = ""
+	if l.CertsDir != "" {
+		_ = os.RemoveAll(l.CertsDir)
+		l.CertsDir = ""
 	}
 	for i, n := range l.Nodes {
 		if n != nil {

--- a/acceptance/replication_test.go
+++ b/acceptance/replication_test.go
@@ -1,0 +1,127 @@
+// Copyright 2015 The Cockroach Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+// implied. See the License for the specific language governing
+// permissions and limitations under the License. See the AUTHORS file
+// for names of contributors.
+//
+// Author: Marc Berhault (marc@cockroachlabs.com)
+
+// +build acceptance
+
+package acceptance
+
+import (
+	"fmt"
+	"os"
+	"testing"
+	"time"
+
+	"github.com/cockroachdb/cockroach/acceptance/localcluster"
+	"github.com/cockroachdb/cockroach/client"
+	"github.com/cockroachdb/cockroach/proto"
+	"github.com/cockroachdb/cockroach/storage/engine"
+	"github.com/cockroachdb/cockroach/util"
+	"github.com/cockroachdb/cockroach/util/log"
+)
+
+// makeDBClient creates a DB client for node 'i'.
+// It uses the cluster certs dir.
+func makeDBClient(cluster *localcluster.Cluster, node int) (*client.DB, error) {
+	// We always run these tests with certs.
+	db, err := client.Open("https://root@" +
+		cluster.Nodes[node].Addr("").String() +
+		"?certs=" + cluster.CertsDir)
+	if err != nil {
+		return nil, util.Errorf("failed to initialize DB client: %s", err)
+	}
+	return db, nil
+}
+
+func countRangeReplicas(client *client.DB) (int, error) {
+	r, err := client.Scan(engine.KeyMeta2Prefix, engine.KeyMeta2Prefix.PrefixEnd(), 10)
+	if err != nil {
+		return 0, err
+	}
+
+	for _, row := range r.Rows {
+		desc := &proto.RangeDescriptor{}
+		if err := row.ValueProto(desc); err != nil {
+			return 0, err
+		}
+		return len(desc.Replicas), nil
+		fmt.Printf("%s-%s [%d]\n", desc.StartKey, desc.EndKey, desc.RaftID)
+		return len(desc.Replicas), nil
+		for i, replica := range desc.Replicas {
+			fmt.Printf("\t%d: node-id=%d store-id=%d attrs=%v\n",
+				i, replica.NodeID, replica.StoreID, replica.Attrs.Attrs)
+		}
+	}
+	return 0, util.Errorf("Problem!")
+}
+
+func checkRangeReplication(t *testing.T, cluster *localcluster.Cluster, attempts int, done chan error) {
+	go func() {
+		// Always talk to node 0..
+		client, err := makeDBClient(cluster, 0)
+		if err != nil {
+			done <- err
+			return
+		}
+
+		wantedReplicas := 3
+		if len(cluster.Nodes) < 3 {
+			wantedReplicas = len(cluster.Nodes)
+		}
+
+		log.Infof("waiting for first range to have %d replicas", wantedReplicas)
+
+		for i := 0; i < attempts; i++ {
+			found, err := countRangeReplicas(client)
+			if err != nil {
+				done <- err
+				return
+			}
+
+			fmt.Fprintf(os.Stderr, "%d ", found)
+			if found == wantedReplicas {
+				fmt.Printf("... correct number of replicas found\n")
+				done <- nil
+				return
+			}
+			time.Sleep(1 * time.Second)
+		}
+
+		fmt.Fprintf(os.Stderr, "\n")
+		done <- util.Error("failed to replicate first range")
+	}()
+}
+
+func TestRangeReplication(t *testing.T) {
+	cluster := localcluster.Create(*numNodes, stopper)
+	if !cluster.Start() {
+		return
+	}
+	defer cluster.Stop()
+
+	done := make(chan error)
+	checkRangeReplication(t, cluster, 20, done)
+
+	var err error
+	select {
+	case <-stopper:
+		return
+	case err = <-done:
+		if err != nil {
+			t.Fatal(err)
+		}
+	}
+}


### PR DESCRIPTION
Once we have a gossip network established, make sure that killing any node keeps everyone connected.
Specifically try node 0 (gossip address) and a random other one.

We can't stop and restart a given container, so kill the existing one and create a new one in its place.
