### PR TITLE
Run checkGossipPeerings inline instead of in a separate goroutine.

### DIFF
--- a/acceptance/main_test.go
+++ b/acceptance/main_test.go
@@ -34,7 +34,13 @@ func TestMain(m *testing.M) {
 		sig := make(chan os.Signal, 1)
 		signal.Notify(sig, os.Interrupt)
 		<-sig
-		close(stopper)
+		select {
+		case <-stopper:
+		default:
+			// There is a very tiny race here: the cluster might be closing
+			// the stopper simultaneously.
+			close(stopper)
+		}
 	}()
 	os.Exit(m.Run())
 }


### PR DESCRIPTION
Added support for a Cluster.Events channel which provides access to
cockroach node events.
