### PR TITLE
fix batch Txn handling

### DIFF
--- a/kv/range_cache.go
+++ b/kv/range_cache.go
@@ -109,11 +109,11 @@ func (rmc *rangeDescriptorCache) String() string {
 func (rmc *rangeDescriptorCache) LookupRangeDescriptor(key proto.Key,
 	options lookupOptions) (*proto.RangeDescriptor, error) {
 	_, r := rmc.getCachedRangeDescriptor(key)
-	if log.V(1) {
-		log.Infof("lookup range descriptor: key=%s desc=%+v\n%s", key, r, rmc)
-	}
 	if r != nil {
 		return r, nil
+	}
+	if log.V(1) {
+		log.Infof("lookup range descriptor: key=%s desc=%+v\n%s", key, r, rmc)
 	}
 
 	rs, err := rmc.db.getRangeDescriptor(key, options)

--- a/kv/txn_coord_sender.go
+++ b/kv/txn_coord_sender.go
@@ -408,7 +408,11 @@ func (tc *TxnCoordSender) sendBatch(batchArgs *proto.InternalBatchRequest, batch
 		if args.Header().UserPriority == nil {
 			args.Header().UserPriority = batchArgs.UserPriority
 		}
-		args.Header().Txn = batchArgs.Txn
+		// Only update the individual calls' Txn from the batch if there isn't
+		// one already.
+		if args.Header().Txn == nil {
+			args.Header().Txn = batchArgs.Txn
+		}
 
 		// Create a reply from the method type and add to batch response.
 		if i >= len(batchReply.Responses) {


### PR DESCRIPTION
previously, the individual calls in a BatchRequest were
always updated from the Batch. Now we make sure that we
only do that for calls which are not transactional already.

This caused lethal behaviour in store.go when trying to
resolve write intents, which would wind up always pushing
outside of a Txn (which rarely succeeds).

work towards making the bank example run smoothly. It's not
enough due to the busy retry loop in Store upon WriteIntentErrors
but at least now if you exit the client, after 10 seconds it would
theoretically wind down due to abandoned transactions which
are always pushable (except it doesn't yet due to another bug
addressed next).

related to #877 
