### PR TITLE
Support environment variables in acceptance/run.sh.

### DIFF
--- a/acceptance/run.sh
+++ b/acceptance/run.sh
@@ -2,4 +2,5 @@
 
 cd $(dirname $0)/..
 build/builder.sh make install
-go test -v -tags acceptance ./acceptance
+set -x
+go test -v -tags acceptance ./acceptance ${GOFLAGS} -run "${TESTS:-.*}" -timeout ${TESTTIMEOUT:-1m} ${TESTFLAGS}


### PR DESCRIPTION
The variables are consistent with those used by `make test` and can
be used to select a subset of tests to run.
