### PR TITLE
Test gossip with flapping nodes

### DIFF
--- a/acceptance/gossip_peerings_test.go
+++ b/acceptance/gossip_peerings_test.go
@@ -86,7 +86,7 @@ func TestGossipPeerings(t *testing.T) {
 	checkGossipPeerings(t, l, 20*time.Second)
 
 	// Restart the first node.
-	log.Infof("Restarting node 0")
+	log.Infof("restarting node 0")
 	if err := l.Nodes[0].Restart(5); err != nil {
 		t.Fatal(err)
 	}
@@ -95,7 +95,7 @@ func TestGossipPeerings(t *testing.T) {
 	// Restart another node.
 	rand.Seed(util.NewPseudoSeed())
 	pickedNode := rand.Intn(len(l.Nodes)-1) + 1
-	log.Infof("Restarting node %d", pickedNode)
+	log.Infof("restarting node %d", pickedNode)
 	if err := l.Nodes[pickedNode].Restart(5); err != nil {
 		t.Fatal(err)
 	}

--- a/acceptance/gossip_peerings_test.go
+++ b/acceptance/gossip_peerings_test.go
@@ -21,6 +21,7 @@ package acceptance
 
 import (
 	"fmt"
+	"math/rand"
 	"os"
 	"strings"
 	"testing"
@@ -82,5 +83,21 @@ func TestGossipPeerings(t *testing.T) {
 	l.Start()
 	defer l.Stop()
 
+	checkGossipPeerings(t, l, 20*time.Second)
+
+	// Restart the first node.
+	log.Infof("Restarting node 0")
+	if err := l.Nodes[0].Restart(5); err != nil {
+		t.Fatal(err)
+	}
+	checkGossipPeerings(t, l, 20*time.Second)
+
+	// Restart another node.
+	rand.Seed(util.NewPseudoSeed())
+	pickedNode := rand.Intn(len(l.Nodes)-1) + 1
+	log.Infof("Restarting node %d", pickedNode)
+	if err := l.Nodes[pickedNode].Restart(5); err != nil {
+		t.Fatal(err)
+	}
 	checkGossipPeerings(t, l, 20*time.Second)
 }

--- a/acceptance/localcluster/docker.go
+++ b/acceptance/localcluster/docker.go
@@ -309,7 +309,7 @@ func (c *Container) Addr(name string) *net.TCPAddr {
 // and unmarshals the result as JSON.
 func (c *Container) GetJSON(port, path string, v interface{}) error {
 	client := &http.Client{
-		Timeout: time.Second,
+		Timeout: 200 * time.Millisecond,
 		Transport: &http.Transport{
 			TLSClientConfig: &tls.Config{
 				InsecureSkipVerify: true,

--- a/acceptance/localcluster/docker.go
+++ b/acceptance/localcluster/docker.go
@@ -35,6 +35,7 @@ import (
 	"regexp"
 	"runtime"
 	"strconv"
+	"time"
 
 	"github.com/cockroachdb/cockroach/util/log"
 	"github.com/samalba/dockerclient"
@@ -308,6 +309,7 @@ func (c *Container) Addr(name string) *net.TCPAddr {
 // and unmarshals the result as JSON.
 func (c *Container) GetJSON(port, path string, v interface{}) error {
 	client := &http.Client{
+		Timeout: time.Second,
 		Transport: &http.Transport{
 			TLSClientConfig: &tls.Config{
 				InsecureSkipVerify: true,

--- a/acceptance/localcluster/localcluster.go
+++ b/acceptance/localcluster/localcluster.go
@@ -24,6 +24,7 @@ import (
 	"io/ioutil"
 	"os"
 	"path/filepath"
+	"strings"
 	"sync"
 
 	"github.com/cockroachdb/cockroach/util/log"
@@ -304,12 +305,17 @@ func (l *Cluster) initCluster() {
 }
 
 func (l *Cluster) startNode(i int) *Container {
+	gossipNodes := []string{}
+	for i := range l.Nodes {
+		gossipNodes = append(gossipNodes, node(i)+":8080")
+	}
+
 	cmd := []string{
 		"start",
 		"--stores=ssd=" + data(i),
 		"--certs=/certs",
 		"--addr=" + node(i) + ":8080",
-		"--gossip=" + node(0) + ":8080",
+		"--gossip=" + strings.Join(gossipNodes, ","),
 	}
 	c := l.createRoach(i, cmd...)
 	maybePanic(c.Start(nil, l.dns, l.vols))

--- a/util/testing.go
+++ b/util/testing.go
@@ -137,15 +137,17 @@ func IsTrueWithin(trueFunc func() bool, duration time.Duration) error {
 // an exponential backoff starting at 1ns and ending at the specified
 // duration.
 func SucceedsWithin(t Tester, duration time.Duration, fn func() error) {
-	total := time.Duration(0)
+	deadline := time.Now().Add(duration)
 	var lastErr error
-	for wait := time.Duration(1); total < duration; wait *= 2 {
+	for wait := time.Duration(1); time.Now().Before(deadline); wait *= 2 {
 		lastErr = fn()
 		if lastErr == nil {
 			return
 		}
+		if wait > time.Second {
+			wait = time.Second
+		}
 		time.Sleep(wait)
-		total += wait
 	}
 	t.Fatalf("condition failed to evaluate within %s: %s", duration, lastErr)
 }


### PR DESCRIPTION
Small changes to make this work:
- pass all nodes as gossip addresses. If the first range gets replicated before bringing down node0, it will never be able to rejoin since it'll just be talking to itself. This is closer to real-world deployment anyway.
- set 1s timeout on HTTPClient. When the test was flaky (before passing all nodes to gossip), we would just sit there holding up the test.

Rather unrelated: change replication_test to use util.SucceedsWithin
