### PR TITLE
Revamp CircleCI builds.

### DIFF
--- a/acceptance/localcluster/docker.go
+++ b/acceptance/localcluster/docker.go
@@ -146,7 +146,7 @@ func maybePanic(err error) {
 // Remove removes the container from docker. It is an error to remove a running
 // container.
 func (c *Container) Remove() error {
-	if os.Getenv("CIRCLE_ARTIFACTS") != "" {
+	if os.Getenv("CIRCLECI") == "true" {
 		// HACK: Removal of docker containers fails on circleci with the error:
 		// "Driver btrfs failed to remove root filesystem". So if we're running on
 		// circleci, just leave the containers around.

--- a/acceptance/localcluster/docker.go
+++ b/acceptance/localcluster/docker.go
@@ -146,6 +146,12 @@ func maybePanic(err error) {
 // Remove removes the container from docker. It is an error to remove a running
 // container.
 func (c *Container) Remove() error {
+	if os.Getenv("CIRCLE_ARTIFACTS") != "" {
+		// HACK: Removal of docker containers fails on circleci with the error:
+		// "Driver btrfs failed to remove root filesystem". So if we're running on
+		// circleci, just leave the containers around.
+		return nil
+	}
 	return c.client.RemoveContainer(c.ID, false, true)
 }
 

--- a/build/builder.sh
+++ b/build/builder.sh
@@ -36,7 +36,7 @@ fi
 
 gopath0="${GOPATH%%:*}"
 
-if [ "${CIRCLE_ARTIFACTS:-}" != "" ]; then
+if [ "${CIRCLECI:-}" = "true" ]; then
     # HACK: Removal of docker containers fails on circleci with the
     # error: "Driver btrfs failed to remove root filesystem". So if
     # we're running on circleci, just leave the containers around.

--- a/build/circle-deps.sh
+++ b/build/circle-deps.sh
@@ -21,6 +21,10 @@ fi
 
 gopath0="${GOPATH%%:*}"
 cachedir="${gopath0}/pkg/cache"
+
+# The tag for the cockroachdb/builder image. If the image is changed
+# (for example, adding "npm"), a new image should be pushed using
+# "build/builder.sh push" and the new tag value placed here.
 tag="20150719-133944"
 
 mkdir -p "${cachedir}"
@@ -42,8 +46,8 @@ if ! docker images | grep -q "${tag}"; then
     fi
 fi
 
-HOME= go get -d -u github.com/cockroachdb/build-cache
-HOME= go get -u github.com/robfig/glock
+HOME="" go get -d -u github.com/cockroachdb/build-cache
+HOME="" go get -u github.com/robfig/glock
 grep -v '^cmd' GLOCKFILE | glock sync -n
 
 # Pretend we're already bootstrapped, so that `make` doesn't go

--- a/build/circle-deps.sh
+++ b/build/circle-deps.sh
@@ -1,0 +1,61 @@
+#!/bin/bash
+
+set -ex
+
+if [ "$1" = "docker" ]; then
+    cmds=$(grep '^cmd' GLOCKFILE | grep -v glock | awk '{print $2}')
+
+    # Restore previously cached build artifacts.
+    time go install github.com/cockroachdb/build-cache
+    time build-cache restore . .:race,test ${cmds}
+    # Build everything needed by circle-test.sh.
+    time go test -race -v -i ./...
+    time go install -v ${cmds}
+    time make install
+    time (cd acceptance; go test -v -c -tags acceptance)
+    # Cache the current build artifacts for future builds.
+    time build-cache save . .:race,test ${cmds}
+
+    exit 0
+fi
+
+gopath0="${GOPATH%%:*}"
+cachedir="${gopath0}/pkg/cache"
+tag="20150719-133944"
+
+mkdir -p "${cachedir}"
+du -sh "${cachedir}"
+ls -lh "${cachedir}"
+
+if ! docker images | grep -q "${tag}"; then
+    # If there's a base image cached, load it. A click on CircleCI's "Clear
+    # Cache" will make sure we start with a clean slate.
+    rm -f "$(ls ${cachedir}/builder*.tar 2>/dev/null | grep -v ${tag})"
+    builder="${cachedir}/builder.${tag}.tar"
+    if [[ ! -e "${builder}" ]]; then
+	time docker pull "cockroachdb/builder:${tag}"
+	docker tag -f "cockroachdb/builder:${tag}" "cockroachdb/builder:latest"
+	time docker save "cockroachdb/builder:${tag}" > "${builder}"
+    else
+	time docker load -i "${builder}"
+	docker tag -f "cockroachdb/builder:${tag}" "cockroachdb/builder:latest"
+    fi
+fi
+
+HOME= go get -d -u github.com/cockroachdb/build-cache
+HOME= go get -u github.com/robfig/glock
+grep -v '^cmd' GLOCKFILE | glock sync -n
+
+# Pretend we're already bootstrapped, so that `make` doesn't go
+# through the bootstrap process which would glock sync and run
+# build/devbase/deps.sh (unnecessarily).
+touch .bootstrap
+
+# Recursively invoke this script inside the builder docker container,
+# passing "docker" as the first argument.
+$(dirname $0)/builder.sh $0 docker
+
+# Clear the cache of any files that haven't been modified in more than 3 days.
+find "${cachedir}" -mmin +4320 -ls -delete
+du -sh "${cachedir}"
+ls -lh "${cachedir}"

--- a/build/circle-local.sh
+++ b/build/circle-local.sh
@@ -1,4 +1,6 @@
 #!/bin/bash
 
+set -e
+
 $(dirname $0)/circle-deps.sh
 $(dirname $0)/circle-test.sh

--- a/build/circle-local.sh
+++ b/build/circle-local.sh
@@ -1,0 +1,4 @@
+#!/bin/bash
+
+$(dirname $0)/circle-deps.sh
+$(dirname $0)/circle-test.sh

--- a/build/circle-test.sh
+++ b/build/circle-test.sh
@@ -1,0 +1,66 @@
+#!/bin/bash
+
+set -e
+
+outdir="${TMPDIR}"
+if [ "${CIRCLE_ARTIFACTS}" != "" ]; then
+    outdir="${CIRCLE_ARTIFACTS}"
+fi
+
+builder=$(dirname $0)/builder.sh
+
+# 1. Run "make check" to verify coding guidelines.
+time ${builder} make GITHOOKS= check | tee "${outdir}/check.log"; test ${PIPESTATUS[0]} -eq 0
+
+# 2. Verify that "go generate" was run.
+time ${builder} /bin/bash -c "(go generate ./... && git ls-files --modified --deleted --others --exclude-standard | diff /dev/null -) || (git add -A && git diff -u HEAD && false)" | tee "${outdir}/generate.log"; test ${PIPESTATUS[0]} -eq 0
+
+# 3. Run "make testrace".
+match='^panic|^[Gg]oroutine \d+|(read|write) by.*goroutine|DATA RACE'
+time ${builder} make GITHOOKS= testrace \
+     RACETIMEOUT=5m TESTFLAGS='-v --verbosity=1 --vmodule=monitor=2' | \
+    tee "${outdir}/testrace.log" | \
+    grep -E "^\--- (PASS|FAIL)|^(FAIL|ok)|${match}"
+
+# 3a. Translate the log output to xml to integrate with CircleCI
+# better.
+if [ "${CIRCLE_TEST_REPORTS}" != "" ]; then
+    if [ -f "${outdir}/testrace.log" ]; then
+        mkdir -p "${CIRCLE_TEST_REPORTS}/race"
+	${builder} go2xunit < "${outdir}/testrace.log" \
+	       > "${CIRCLE_TEST_REPORTS}/race/testrace.xml"
+    fi
+fi
+
+# 3b. Generate the slow test output.
+find "${outdir}" -name 'test*.log' -type f -exec \
+     grep -F ': Test' {} ';' | \
+     sed -E 's/(--- PASS: |\(|\))//g' | \
+     awk '{ print $2, $1 }' | sort -rn | head -n 10 \
+     > "${outdir}/slow.txt"
+
+# 3c. Generate the excerpt output and fail if it is non-empty.
+find "${outdir}" -name 'test*.log' -type f -exec \
+     grep -B 5 -A 10 -E "^\-{0,3} *FAIL|${match}" {} ';' > "${outdir}/excerpt.txt"
+if [ -s "${outdir}/excerpt.txt" ]; then
+    echo "FAIL: excerpt.txt is not empty"
+
+    if [ "${CIRCLE_BRANCH}" = "master" ] && [ -n "${GITHUB_API_TOKEN}" ]; then
+        curl -X POST -H "Authorization: token ${GITHUB_API_TOKEN}" \
+             "https://api.github.com/repos/${CIRCLE_PROJECT_USERNAME}/${CIRCLE_PROJECT_REPONAME}/issues" \
+             -d "{ \"title\": \"Test failure in CI build ${CIRCLE_BUILD_NUM}\", \"body\": \"The following test appears to have failed:\n\n[#${CIRCLE_BUILD_NUM}](https://circleci.com/gh/${CIRCLE_PROJECT_USERNAME}/${CIRCLE_PROJECT_REPONAME}/${CIRCLE_BUILD_NUM}):\n\n\`\`\`\n$(python -c 'import json,sys; print json.dumps(sys.stdin.read()).strip("\"")' < ${outdir}/excerpt.txt)\n\`\`\`\nPlease assign, take a look and update the issue accordingly.\", \"labels\": [\"test-failure\"] }" > /dev/null
+        echo "Found test/race failures in test logs, see excerpt.log and the newly created issue on our issue tracker"
+    fi
+
+    exit 1
+fi
+
+# 4. Run the acceptance tests (only on Linux). We can run the
+# acceptance tests on the Mac's, but circle-deps.sh only built the
+# acceptance tests for Linux.
+if [ "$(uname)" = "Linux" ]; then
+    cd $(dirname $0)/../acceptance
+    time ./acceptance.test -test.v -test.timeout -5m
+else
+    echo "skipping acceptance tests on $(uname): use 'make acceptance' instead"
+fi

--- a/build/circle-test.sh
+++ b/build/circle-test.sh
@@ -46,7 +46,9 @@ find "${outdir}" -name 'test*.log' -type f -exec \
 find "${outdir}" -name 'test*.log' -type f -exec \
      grep -B 5 -A 10 -E "^\-{0,3} *FAIL|${match}" {} ';' > "${outdir}/excerpt.txt"
 if [ -s "${outdir}/excerpt.txt" ]; then
-    echo "FAIL: excerpt.txt is not empty"
+    echo "FAIL: excerpt.txt is not empty (${outdir}/excerpt.txt)"
+    echo
+    head -100 "${outdir}/excerpt.txt"
 
     if [ "${CIRCLE_BRANCH}" = "master" ] && [ -n "${GITHUB_API_TOKEN}" ]; then
         curl -X POST -H "Authorization: token ${GITHUB_API_TOKEN}" \

--- a/build/push-docker-deploy.sh
+++ b/build/push-docker-deploy.sh
@@ -10,12 +10,9 @@ run/local-cluster.sh start
 run/local-cluster.sh stop
 
 docker tag cockroachdb/cockroach:latest cockroachdb/cockroach:${VERSION}
-docker tag cockroachdb/cockroach-dev:latest cockroachdb/cockroach-dev:${VERSION}
 
-for type in {,-dev}; do
-  for version in {latest, ${VERSION}}; do
-    # Pushing to the registry just fails sometimes, so for the time
-    # being just make this a best-effort action.
-    docker push cockroachdb/cockroach${type}:${version} || true
-  done
+for version in {latest, ${VERSION}}; do
+  # Pushing to the registry just fails sometimes, so for the time
+  # being just make this a best-effort action.
+  docker push cockroachdb/cockroach:${version} || true
 done

--- a/circle.yml
+++ b/circle.yml
@@ -6,69 +6,14 @@ checkout:
   post:
     - git fetch --unshallow || true
     - git fetch --tags
-    # Nasty hack: Because we get a freshly restored repo, timestamps do not
-    # correspond any more to when the file was last changed. To rectify this,
-    # first set everything to a timestamp in the past and then update the
-    # timestamp for all git-tracked files based on their last committed change.
-    - find . -exec touch -t 201401010000 {} \;
-    - for x in $(git ls-tree --full-tree --name-only -r HEAD); do touch -t $(date -d "$(git log -1 --format=%ci "${x}")" +%y%m%d%H%M.%S) "${x}"; done
 
 dependencies:
-  cache_directories:
-    - "~/docker"
   override:
-    # If there's a base image cached, load it. A click on CircleCI's "Clear
-    # Cache" will make sure we start with a clean slate.
-    - mkdir -p ~/docker
-    - if [[ -e ~/docker/base.tar ]]; then docker load -i ~/docker/base.tar; fi
-    # Pretend we're already bootstrapped, so that `make` doesn't try to get us
-    # started which is impossible without a working Go env.
-    - touch .bootstrap && make '.git/hooks/*'
-    - ./build/build-docker-dev.sh
-    - docker save "cockroachdb/cockroach-devbase" > ~/docker/base.tar
-    - if [[ ! -e ~/docker/dnsmasq.tar ]]; then docker pull "cockroachdb/dnsmasq" && docker save "cockroachdb/dnsmasq" > ~/docker/dnsmasq.tar; else docker load -i ~/docker/dnsmasq.tar; fi
-    # Print the history so that we can investigate potential steps which fatten
-    # the image needlessly.
-    - docker history "cockroachdb/cockroach-dev"
+    - build/circle-deps.sh
 
 test:
   override:
-    # Check whether the committer forgot to run `go generate`.
-    # Either `go generate` does not change any files or it does, in which case we print the diff and fail.
-    - docker run cockroachdb/cockroach-dev shell make check | tee "${CIRCLE_ARTIFACTS}/check.log"; test ${PIPESTATUS[0]} -eq 0
-    - docker run cockroachdb/cockroach-dev shell "(go generate ./... && git ls-files --modified --deleted --others --exclude-standard | diff /dev/null -) || (git add -A && git diff -u HEAD && false)" | tee "${CIRCLE_ARTIFACTS}/generate.log"; test ${PIPESTATUS[0]} -eq 0
-    - docker run "cockroachdb/cockroach-dev" test TESTFLAGS='-v --verbosity=1 --vmodule=monitor=2' > "${CIRCLE_ARTIFACTS}/test.log"
-    - docker run "cockroachdb/cockroach-dev" testrace TESTFLAGS='-v --verbosity=1 --vmodule=monitor=2' > "${CIRCLE_ARTIFACTS}/testrace.log"
-    # TODO(pmattis): Use "make acceptance" again once we're using cockroachdb/builder on circleci
-    - run/local-cluster.sh stop && run/local-cluster.sh start && run/local-cluster.sh stop
-  post:
-    # Write the container's log output to artifacts.
-    - i=0; for cid in $(docker ps -aq); do i=$((i+1)); docker logs $cid &> "${CIRCLE_ARTIFACTS}/${i}_$(docker inspect -f '{{ .Config.Hostname }}' ${cid})_${cid}.log"; done
-    - mkdir -p ${CIRCLE_TEST_REPORTS}/{go,race}
-    - "[ -f ${CIRCLE_ARTIFACTS}/test.log ] && docker run -i cockroachdb/cockroach-dev shell /go/bin/go2xunit < ${CIRCLE_ARTIFACTS}/test.log > ${CIRCLE_TEST_REPORTS}/go/test.xml"
-    - "[ -f ${CIRCLE_ARTIFACTS}/testrace.log ] && docker run -i cockroachdb/cockroach-dev shell /go/bin/go2xunit < ${CIRCLE_ARTIFACTS}/testrace.log > ${CIRCLE_TEST_REPORTS}/race/testrace.xml"
-    - |
-      find "${CIRCLE_ARTIFACTS}" -name 'test*.log' -type f -exec \
-        grep -F ': Test' {} ';' | sed -E 's/(--- PASS: |\(|\))//g' | awk '{ print $2, $1 }' | sort -rn | head -n 10 \
-        >> "${CIRCLE_ARTIFACTS}"/slow.txt
-    - |
-      find "${CIRCLE_ARTIFACTS}" -name 'test*.log' -type f -exec \
-        grep -B 5 -A 10 -E '^\-{0,3} *FAIL|^panic|^[Gg]oroutine \d+|(read|write) by.*goroutine|DATA RACE' {} ';' \
-        >> "${CIRCLE_ARTIFACTS}"/excerpt.txt
-    - |
-      if [ "${CIRCLE_BRANCH}" = "master" ] && [ -n "${GITHUB_API_TOKEN}" ] && [ -s "${CIRCLE_ARTIFACTS}/excerpt.txt" ]; then
-        curl -X POST -H "Authorization: token ${GITHUB_API_TOKEN}" \
-          "https://api.github.com/repos/${CIRCLE_PROJECT_USERNAME}/${CIRCLE_PROJECT_REPONAME}/issues" \
-          -d "{ \"title\": \"Test failure in CI build ${CIRCLE_BUILD_NUM}\", \"body\": \"The following test appears to have failed:\n\n[#${CIRCLE_BUILD_NUM}](https://circleci.com/gh/${CIRCLE_PROJECT_USERNAME}/${CIRCLE_PROJECT_REPONAME}/${CIRCLE_BUILD_NUM}):\n\n\`\`\`\n$(python -c 'import json,sys; print json.dumps(sys.stdin.read()).strip("\"")' < ${CIRCLE_ARTIFACTS}/excerpt.txt)\n\`\`\`\nPlease assign, take a look and update the issue accordingly.\", \"labels\": [\"test-failure\"] }" > /dev/null
-        echo "Found test/race failures in test logs, see excerpt.log and the newly created issue on our issue tracker"
-      else
-        echo "Not posting an issue."
-      fi
-      # Fail the test if there's anything in the excerpt. This will usually
-      # be a data race warning (which does not generally fail `make testrace`
-      # for some reason).
-      test ! -s "${CIRCLE_ARTIFACTS}/excerpt.txt"
-
+    - build/circle-test.sh
 
 deployment:
   docker:
@@ -79,5 +24,5 @@ deployment:
           export VERSION=$(git describe || git rev-parse --short HEAD)
           echo "Deploying ${VERSION}..."
           if [ -n "$DOCKER_EMAIL" ]; then
-            ./build/push-docker-deploy.sh
+            build/push-docker-deploy.sh
           fi


### PR DESCRIPTION
Move almost all of circle.yml into build/circle-*.sh. These scripts can
be run locally with build/circle-local.sh performing nearly identical
work to what takes place on CircleCI.

This work isn't quite complete as I haven't done anything with
deployment or "make acceptance" yet, but it is worth a look and
comments.
