### PR TITLE
Split gossip.Key{ClusterID,Sentinel}.

### DIFF
--- a/acceptance/cert_gen_test.go
+++ b/acceptance/cert_gen_test.go
@@ -34,5 +34,5 @@ func TestCertGen(t *testing.T) {
 
 	// Check the gossip peerings which will indicate whether the nodes
 	// can talk to each other with the generated certs.
-	checkGossipPeerings(t, l, 20*time.Second)
+	checkGossip(t, l, 20*time.Second, hasPeers(len(l.Nodes)))
 }

--- a/acceptance/localcluster/docker.go
+++ b/acceptance/localcluster/docker.go
@@ -229,6 +229,11 @@ func (c *Container) Restart(timeoutSeconds int) error {
 	return c.Inspect()
 }
 
+// Stop a running container.
+func (c *Container) Stop(timeoutSeconds int) error {
+	return c.client.StopContainer(c.Id, timeoutSeconds)
+}
+
 // Wait waits for a running container to exit.
 func (c *Container) Wait() error {
 	// TODO(pmattis): dockerclient does not support the "wait" method

--- a/acceptance/run.sh
+++ b/acceptance/run.sh
@@ -3,4 +3,4 @@
 cd $(dirname $0)/..
 build/builder.sh make install
 set -x
-go test -v -tags acceptance ./acceptance ${GOFLAGS} -run "${TESTS:-.*}" -timeout ${TESTTIMEOUT:-1m} ${TESTFLAGS}
+go test -v -tags acceptance ./acceptance ${GOFLAGS} -run "${TESTS:-.*}" -timeout ${TESTTIMEOUT:-5m} ${TESTFLAGS}

--- a/gossip/gossip.go
+++ b/gossip/gossip.go
@@ -535,13 +535,13 @@ func (g *Gossip) maybeWarnAboutInit(stopper *util.Stopper) {
 }
 
 // checkHasConnected checks whether this gossip instance is connected
-// to enough of the gossip network that it has received the sentinel
+// to enough of the gossip network that it has received the cluster ID
 // gossip info. Once connected, the "Connected" channel is closed to
 // signal to any waiters that the gossip instance is ready.
 func (g *Gossip) checkHasConnected() {
-	// Check if we have the sentinel gossip (cluster ID) to start.
+	// Check if we have the cluster ID gossip to start.
 	// If so, then mark ourselves as trivially connected to the gossip network.
-	if !g.hasConnected && g.is.getInfo(KeySentinel) != nil {
+	if !g.hasConnected && g.is.getInfo(KeyClusterID) != nil {
 		g.hasConnected = true
 		close(g.Connected)
 	}

--- a/gossip/keys.go
+++ b/gossip/keys.go
@@ -34,6 +34,10 @@ const separator = ":"
 const (
 	// KeyClusterID is the unique UUID for this Cockroach cluster.
 	// The value is a string UUID for the cluster.
+	// The cluster ID is gossiped by all nodes that contain a replica
+	// of the first range, and it serves as a check for basic gossip
+	// connectivity. The Gossip.Connected channel is closed when we see
+	// this key.
 	KeyClusterID = "cluster-id"
 
 	// KeyConfigAccounting is the accounting configuration map.
@@ -64,7 +68,9 @@ const (
 
 	// KeySentinel is a key for gossip which must not expire or else the
 	// node considers itself partitioned and will retry with bootstrap hosts.
-	KeySentinel = KeyClusterID
+	// The sentinel is gossiped by the node that holds the leader lease for the
+	// first range.
+	KeySentinel = "sentinel"
 
 	// KeyFirstRangeDescriptor is the descriptor for the "first"
 	// range. The "first" range contains the meta1 key range, the first

--- a/server/raft_transport.go
+++ b/server/raft_transport.go
@@ -137,6 +137,7 @@ func (t *rpcTransport) processQueue(raftNodeID proto.RaftNodeID) {
 	addr, err := t.gossip.GetNodeIDAddress(nodeID)
 	if err != nil {
 		log.Errorf("could not get address for node %d: %s", nodeID, err)
+		return
 	}
 	client := rpc.NewClient(addr, nil, t.rpcContext)
 	select {

--- a/storage/range_test.go
+++ b/storage/range_test.go
@@ -568,7 +568,7 @@ func TestRangeGossipFirstRange(t *testing.T) {
 	tc := testContext{}
 	tc.Start(t)
 	defer tc.Stop()
-	for _, key := range []string{gossip.KeyClusterID, gossip.KeyFirstRangeDescriptor} {
+	for _, key := range []string{gossip.KeyClusterID, gossip.KeyFirstRangeDescriptor, gossip.KeySentinel} {
 		info, err := tc.gossip.GetInfo(key)
 		if err != nil {
 			t.Errorf("missing first range gossip of key %s", key)
@@ -579,6 +579,9 @@ func TestRangeGossipFirstRange(t *testing.T) {
 		}
 		if key == gossip.KeyClusterID && info.(string) == "" {
 			t.Errorf("expected non-empty gossiped cluster ID, got %+v", info)
+		}
+		if key == gossip.KeySentinel && info.(string) == "" {
+			t.Errorf("expected non-empty gossiped sentinel, got %+v", info)
 		}
 	}
 }

--- a/util/testing.go
+++ b/util/testing.go
@@ -126,7 +126,7 @@ func IsTrueWithin(trueFunc func() bool, duration time.Duration) error {
 		time.Sleep(wait)
 		total += wait
 	}
-	return fmt.Errorf("condition failed to evaluate true within %s", duration)
+	return ErrorfSkipFrames(1, "condition failed to evaluate true within %s", duration)
 }
 
 // SucceedsWithin fails the test (with t.Fatal) unless the supplied
@@ -147,5 +147,5 @@ func SucceedsWithin(t Tester, duration time.Duration, fn func() error) {
 		}
 		time.Sleep(wait)
 	}
-	t.Fatalf("condition failed to evaluate within %s: %s", duration, lastErr)
+	t.Fatal(ErrorfSkipFrames(1, "condition failed to evaluate within %s: %s", duration, lastErr))
 }


### PR DESCRIPTION
KeyClusterID is now gossiped by any node with a replica of the first
range, instead of just the lease holder. Gossip is considered
"connected" as soon as the cluster ID is seen, which allows the node to
complete the startup process and acquire the lease.

KeySentinel continues to be gossiped only by the first range lease
holder, and is used to detect partitions in the gossip network.

Slightly generalize the gossip acceptance tests and increase the
timeout. Fix an error-handling bug in server/raft_transport.go.
Improve error messages from util.SucceedsWithin.

Fixes #1056.
