### PR TITLE
When start=end, ContainsKeyRange should return true if the keys fall …

### DIFF
--- a/kv/dist_sender_server_test.go
+++ b/kv/dist_sender_server_test.go
@@ -168,3 +168,26 @@ func TestMultiRangeScanInconsistent(t *testing.T) {
 		t.Errorf("expected key %q; got %q", keys[0], key)
 	}
 }
+
+// TestStartEqualsEndKeyScan verifies that specifying start==end on scan
+// returns an empty set.
+func TestStartEqualsEndKeyScan(t *testing.T) {
+	s := startServer(t)
+	db := createTestClient(t, s.ServingAddr())
+	db.User = storage.UserRoot
+	defer s.Stop()
+
+	// Write key "a".
+	if err := db.Run(client.Put(proto.Key("a"), []byte("value"))); err != nil {
+		t.Fatal(err)
+	}
+
+	call := client.Scan(proto.Key("a"), proto.Key("a"), 0)
+	sr := call.Reply.(*proto.ScanResponse)
+	if err := db.Run(call); err != nil {
+		t.Fatalf("unexpected error on scan: %s", err)
+	}
+	if l := len(sr.Rows); l != 0 {
+		t.Errorf("expected no rows; got %d", l)
+	}
+}

--- a/proto/config.go
+++ b/proto/config.go
@@ -145,8 +145,10 @@ func (r *RangeDescriptor) ContainsKeyRange(start, end []byte) bool {
 	if len(end) == 0 {
 		return r.ContainsKey(start)
 	}
-	if bytes.Compare(end, start) <= 0 {
+	if comp := bytes.Compare(end, start); comp < 0 {
 		return false
+	} else if comp == 0 {
+		return r.ContainsKey(start)
 	}
 	return bytes.Compare(start, r.StartKey) >= 0 && bytes.Compare(r.EndKey, end) >= 0
 }

--- a/proto/config_test.go
+++ b/proto/config_test.go
@@ -116,18 +116,14 @@ func TestRangeDescriptorContains(t *testing.T) {
 		{[]byte("aa"), []byte("bb"), false},
 		{[]byte("b"), []byte("a"), false},
 	}
-	for _, test := range testData {
+	for i, test := range testData {
 		if bytes.Compare(test.start, test.end) == 0 {
 			if desc.ContainsKey(test.start) != test.contains {
-				t.Errorf("expected key %q within range", test.start)
+				t.Errorf("%d: expected key %q within range", i, test.start)
 			}
-			if desc.ContainsKeyRange(test.start, test.end) {
-				t.Errorf("expected false for single key range %q", test.start)
-			}
-		} else {
-			if desc.ContainsKeyRange(test.start, test.end) != test.contains {
-				t.Errorf("expected key range %q-%q within range", test.start, test.end)
-			}
+		}
+		if desc.ContainsKeyRange(test.start, test.end) != test.contains {
+			t.Errorf("%d: expected key %q within range", i, test.start)
 		}
 	}
 }


### PR DESCRIPTION
…within the range.

Added a unittest for scan where start key == end key.

Fixes #1069
