### PR TITLE
New 'IsRangeOp' flag on methods and better enforcement of keys

### DIFF
--- a/client/db.go
+++ b/client/db.go
@@ -572,6 +572,7 @@ func (b *Batch) fillResults() error {
 			case *proto.InternalPushTxnResponse:
 			case *proto.InternalRangeLookupResponse:
 			case *proto.InternalResolveIntentResponse:
+			case *proto.InternalResolveIntentRangeResponse:
 				// Nothing to do for these methods as they do not generate any
 				// rows. For the proto.Internal* responses the caller will have hold of
 				// the response object itself.

--- a/kv/db_test.go
+++ b/kv/db_test.go
@@ -176,6 +176,7 @@ func TestKVDBInternalMethods(t *testing.T) {
 		{&proto.InternalHeartbeatTxnRequest{}, &proto.InternalHeartbeatTxnResponse{}},
 		{&proto.InternalPushTxnRequest{}, &proto.InternalPushTxnResponse{}},
 		{&proto.InternalResolveIntentRequest{}, &proto.InternalResolveIntentResponse{}},
+		{&proto.InternalResolveIntentRangeRequest{}, &proto.InternalResolveIntentRangeResponse{}},
 		{&proto.InternalMergeRequest{}, &proto.InternalMergeResponse{}},
 		{&proto.InternalTruncateLogRequest{}, &proto.InternalTruncateLogResponse{}},
 	}
@@ -183,6 +184,9 @@ func TestKVDBInternalMethods(t *testing.T) {
 	kvClient := createTestClient(t, s.ServingAddr())
 	for i, test := range testCases {
 		test.args.Header().Key = proto.Key("a")
+		if proto.IsRangeOp(test.args) {
+			test.args.Header().EndKey = test.args.Header().Key.Next()
+		}
 		err := kvClient.Run(client.Call{Args: test.args, Reply: test.reply})
 		if err == nil {
 			t.Errorf("%d: unexpected success calling %s", i, test.args.Method())

--- a/kv/dist_sender_test.go
+++ b/kv/dist_sender_test.go
@@ -542,6 +542,7 @@ func TestVerifyPermissions(t *testing.T) {
 		&proto.InternalPushTxnRequest{},
 		&proto.InternalRangeLookupRequest{},
 		&proto.InternalResolveIntentRequest{},
+		&proto.InternalResolveIntentRangeRequest{},
 		&proto.InternalMergeRequest{},
 		&proto.InternalTruncateLogRequest{},
 		&proto.InternalLeaderLeaseRequest{},

--- a/proto/internal.pb.go
+++ b/proto/internal.pb.go
@@ -340,6 +340,29 @@ func (m *InternalResolveIntentResponse) Reset()         { *m = InternalResolveIn
 func (m *InternalResolveIntentResponse) String() string { return proto1.CompactTextString(m) }
 func (*InternalResolveIntentResponse) ProtoMessage()    {}
 
+// An InternalResolveIntentRangeRequest is arguments to the
+// InternalResolveIntentRange() method. This clear write intents
+// for a range of keys to resolve intents created by range ops.
+type InternalResolveIntentRangeRequest struct {
+	RequestHeader    `protobuf:"bytes,1,opt,name=header,embedded=header" json:"header"`
+	XXX_unrecognized []byte `json:"-"`
+}
+
+func (m *InternalResolveIntentRangeRequest) Reset()         { *m = InternalResolveIntentRangeRequest{} }
+func (m *InternalResolveIntentRangeRequest) String() string { return proto1.CompactTextString(m) }
+func (*InternalResolveIntentRangeRequest) ProtoMessage()    {}
+
+// An InternalResolveIntentRangeResponse is the return value from the
+// InternalResolveIntent() method.
+type InternalResolveIntentRangeResponse struct {
+	ResponseHeader   `protobuf:"bytes,1,opt,name=header,embedded=header" json:"header"`
+	XXX_unrecognized []byte `json:"-"`
+}
+
+func (m *InternalResolveIntentRangeResponse) Reset()         { *m = InternalResolveIntentRangeResponse{} }
+func (m *InternalResolveIntentRangeResponse) String() string { return proto1.CompactTextString(m) }
+func (*InternalResolveIntentRangeResponse) ProtoMessage()    {}
+
 // An InternalMergeRequest contains arguments to the InternalMerge() method. It
 // specifies a key and a value which should be merged into the existing value at
 // that key.
@@ -437,18 +460,19 @@ func (*InternalLeaderLeaseResponse) ProtoMessage()    {}
 // An InternalRequestUnion contains exactly one of the optional requests.
 // Non-internal values added to RequestUnion must be added here.
 type InternalRequestUnion struct {
-	Contains              *ContainsRequest              `protobuf:"bytes,1,opt,name=contains" json:"contains,omitempty"`
-	Get                   *GetRequest                   `protobuf:"bytes,2,opt,name=get" json:"get,omitempty"`
-	Put                   *PutRequest                   `protobuf:"bytes,3,opt,name=put" json:"put,omitempty"`
-	ConditionalPut        *ConditionalPutRequest        `protobuf:"bytes,4,opt,name=conditional_put" json:"conditional_put,omitempty"`
-	Increment             *IncrementRequest             `protobuf:"bytes,5,opt,name=increment" json:"increment,omitempty"`
-	Delete                *DeleteRequest                `protobuf:"bytes,6,opt,name=delete" json:"delete,omitempty"`
-	DeleteRange           *DeleteRangeRequest           `protobuf:"bytes,7,opt,name=delete_range" json:"delete_range,omitempty"`
-	Scan                  *ScanRequest                  `protobuf:"bytes,8,opt,name=scan" json:"scan,omitempty"`
-	EndTransaction        *EndTransactionRequest        `protobuf:"bytes,9,opt,name=end_transaction" json:"end_transaction,omitempty"`
-	InternalPushTxn       *InternalPushTxnRequest       `protobuf:"bytes,30,opt,name=internal_push_txn" json:"internal_push_txn,omitempty"`
-	InternalResolveIntent *InternalResolveIntentRequest `protobuf:"bytes,31,opt,name=internal_resolve_intent" json:"internal_resolve_intent,omitempty"`
-	XXX_unrecognized      []byte                        `json:"-"`
+	Contains                   *ContainsRequest                   `protobuf:"bytes,1,opt,name=contains" json:"contains,omitempty"`
+	Get                        *GetRequest                        `protobuf:"bytes,2,opt,name=get" json:"get,omitempty"`
+	Put                        *PutRequest                        `protobuf:"bytes,3,opt,name=put" json:"put,omitempty"`
+	ConditionalPut             *ConditionalPutRequest             `protobuf:"bytes,4,opt,name=conditional_put" json:"conditional_put,omitempty"`
+	Increment                  *IncrementRequest                  `protobuf:"bytes,5,opt,name=increment" json:"increment,omitempty"`
+	Delete                     *DeleteRequest                     `protobuf:"bytes,6,opt,name=delete" json:"delete,omitempty"`
+	DeleteRange                *DeleteRangeRequest                `protobuf:"bytes,7,opt,name=delete_range" json:"delete_range,omitempty"`
+	Scan                       *ScanRequest                       `protobuf:"bytes,8,opt,name=scan" json:"scan,omitempty"`
+	EndTransaction             *EndTransactionRequest             `protobuf:"bytes,9,opt,name=end_transaction" json:"end_transaction,omitempty"`
+	InternalPushTxn            *InternalPushTxnRequest            `protobuf:"bytes,30,opt,name=internal_push_txn" json:"internal_push_txn,omitempty"`
+	InternalResolveIntent      *InternalResolveIntentRequest      `protobuf:"bytes,31,opt,name=internal_resolve_intent" json:"internal_resolve_intent,omitempty"`
+	InternalResolveIntentRange *InternalResolveIntentRangeRequest `protobuf:"bytes,32,opt,name=internal_resolve_intent_range" json:"internal_resolve_intent_range,omitempty"`
+	XXX_unrecognized           []byte                             `json:"-"`
 }
 
 func (m *InternalRequestUnion) Reset()         { *m = InternalRequestUnion{} }
@@ -532,21 +556,29 @@ func (m *InternalRequestUnion) GetInternalResolveIntent() *InternalResolveIntent
 	return nil
 }
 
+func (m *InternalRequestUnion) GetInternalResolveIntentRange() *InternalResolveIntentRangeRequest {
+	if m != nil {
+		return m.InternalResolveIntentRange
+	}
+	return nil
+}
+
 // An InternalResponseUnion contains exactly one of the optional responses.
 // Non-internal values added to ResponseUnion must be added here.
 type InternalResponseUnion struct {
-	Contains              *ContainsResponse              `protobuf:"bytes,1,opt,name=contains" json:"contains,omitempty"`
-	Get                   *GetResponse                   `protobuf:"bytes,2,opt,name=get" json:"get,omitempty"`
-	Put                   *PutResponse                   `protobuf:"bytes,3,opt,name=put" json:"put,omitempty"`
-	ConditionalPut        *ConditionalPutResponse        `protobuf:"bytes,4,opt,name=conditional_put" json:"conditional_put,omitempty"`
-	Increment             *IncrementResponse             `protobuf:"bytes,5,opt,name=increment" json:"increment,omitempty"`
-	Delete                *DeleteResponse                `protobuf:"bytes,6,opt,name=delete" json:"delete,omitempty"`
-	DeleteRange           *DeleteRangeResponse           `protobuf:"bytes,7,opt,name=delete_range" json:"delete_range,omitempty"`
-	Scan                  *ScanResponse                  `protobuf:"bytes,8,opt,name=scan" json:"scan,omitempty"`
-	EndTransaction        *EndTransactionResponse        `protobuf:"bytes,9,opt,name=end_transaction" json:"end_transaction,omitempty"`
-	InternalPushTxn       *InternalPushTxnResponse       `protobuf:"bytes,30,opt,name=internal_push_txn" json:"internal_push_txn,omitempty"`
-	InternalResolveIntent *InternalResolveIntentResponse `protobuf:"bytes,31,opt,name=internal_resolve_intent" json:"internal_resolve_intent,omitempty"`
-	XXX_unrecognized      []byte                         `json:"-"`
+	Contains                   *ContainsResponse                   `protobuf:"bytes,1,opt,name=contains" json:"contains,omitempty"`
+	Get                        *GetResponse                        `protobuf:"bytes,2,opt,name=get" json:"get,omitempty"`
+	Put                        *PutResponse                        `protobuf:"bytes,3,opt,name=put" json:"put,omitempty"`
+	ConditionalPut             *ConditionalPutResponse             `protobuf:"bytes,4,opt,name=conditional_put" json:"conditional_put,omitempty"`
+	Increment                  *IncrementResponse                  `protobuf:"bytes,5,opt,name=increment" json:"increment,omitempty"`
+	Delete                     *DeleteResponse                     `protobuf:"bytes,6,opt,name=delete" json:"delete,omitempty"`
+	DeleteRange                *DeleteRangeResponse                `protobuf:"bytes,7,opt,name=delete_range" json:"delete_range,omitempty"`
+	Scan                       *ScanResponse                       `protobuf:"bytes,8,opt,name=scan" json:"scan,omitempty"`
+	EndTransaction             *EndTransactionResponse             `protobuf:"bytes,9,opt,name=end_transaction" json:"end_transaction,omitempty"`
+	InternalPushTxn            *InternalPushTxnResponse            `protobuf:"bytes,30,opt,name=internal_push_txn" json:"internal_push_txn,omitempty"`
+	InternalResolveIntent      *InternalResolveIntentResponse      `protobuf:"bytes,31,opt,name=internal_resolve_intent" json:"internal_resolve_intent,omitempty"`
+	InternalResolveIntentRange *InternalResolveIntentRangeResponse `protobuf:"bytes,32,opt,name=internal_resolve_intent_range" json:"internal_resolve_intent_range,omitempty"`
+	XXX_unrecognized           []byte                              `json:"-"`
 }
 
 func (m *InternalResponseUnion) Reset()         { *m = InternalResponseUnion{} }
@@ -630,6 +662,13 @@ func (m *InternalResponseUnion) GetInternalResolveIntent() *InternalResolveInten
 	return nil
 }
 
+func (m *InternalResponseUnion) GetInternalResolveIntentRange() *InternalResolveIntentRangeResponse {
+	if m != nil {
+		return m.InternalResolveIntentRange
+	}
+	return nil
+}
+
 // An InternalBatchRequest contains a superset of commands from
 // BatchRequest and internal batchable commands.
 //
@@ -675,20 +714,21 @@ func (m *InternalBatchResponse) GetResponses() []InternalResponseUnion {
 // mutating commands. Note that any entry added here must be handled
 // in storage/engine/db.cc in GetResponseHeader().
 type ReadWriteCmdResponse struct {
-	Put                   *PutResponse                   `protobuf:"bytes,1,opt,name=put" json:"put,omitempty"`
-	ConditionalPut        *ConditionalPutResponse        `protobuf:"bytes,2,opt,name=conditional_put" json:"conditional_put,omitempty"`
-	Increment             *IncrementResponse             `protobuf:"bytes,3,opt,name=increment" json:"increment,omitempty"`
-	Delete                *DeleteResponse                `protobuf:"bytes,4,opt,name=delete" json:"delete,omitempty"`
-	DeleteRange           *DeleteRangeResponse           `protobuf:"bytes,5,opt,name=delete_range" json:"delete_range,omitempty"`
-	EndTransaction        *EndTransactionResponse        `protobuf:"bytes,6,opt,name=end_transaction" json:"end_transaction,omitempty"`
-	InternalHeartbeatTxn  *InternalHeartbeatTxnResponse  `protobuf:"bytes,10,opt,name=internal_heartbeat_txn" json:"internal_heartbeat_txn,omitempty"`
-	InternalPushTxn       *InternalPushTxnResponse       `protobuf:"bytes,11,opt,name=internal_push_txn" json:"internal_push_txn,omitempty"`
-	InternalResolveIntent *InternalResolveIntentResponse `protobuf:"bytes,12,opt,name=internal_resolve_intent" json:"internal_resolve_intent,omitempty"`
-	InternalMerge         *InternalMergeResponse         `protobuf:"bytes,13,opt,name=internal_merge" json:"internal_merge,omitempty"`
-	InternalTruncateLog   *InternalTruncateLogResponse   `protobuf:"bytes,14,opt,name=internal_truncate_log" json:"internal_truncate_log,omitempty"`
-	InternalGc            *InternalGCResponse            `protobuf:"bytes,15,opt,name=internal_gc" json:"internal_gc,omitempty"`
-	InternalLeaderLease   *InternalLeaderLeaseResponse   `protobuf:"bytes,16,opt,name=internal_leader_lease" json:"internal_leader_lease,omitempty"`
-	XXX_unrecognized      []byte                         `json:"-"`
+	Put                        *PutResponse                        `protobuf:"bytes,1,opt,name=put" json:"put,omitempty"`
+	ConditionalPut             *ConditionalPutResponse             `protobuf:"bytes,2,opt,name=conditional_put" json:"conditional_put,omitempty"`
+	Increment                  *IncrementResponse                  `protobuf:"bytes,3,opt,name=increment" json:"increment,omitempty"`
+	Delete                     *DeleteResponse                     `protobuf:"bytes,4,opt,name=delete" json:"delete,omitempty"`
+	DeleteRange                *DeleteRangeResponse                `protobuf:"bytes,5,opt,name=delete_range" json:"delete_range,omitempty"`
+	EndTransaction             *EndTransactionResponse             `protobuf:"bytes,6,opt,name=end_transaction" json:"end_transaction,omitempty"`
+	InternalHeartbeatTxn       *InternalHeartbeatTxnResponse       `protobuf:"bytes,10,opt,name=internal_heartbeat_txn" json:"internal_heartbeat_txn,omitempty"`
+	InternalPushTxn            *InternalPushTxnResponse            `protobuf:"bytes,11,opt,name=internal_push_txn" json:"internal_push_txn,omitempty"`
+	InternalResolveIntent      *InternalResolveIntentResponse      `protobuf:"bytes,12,opt,name=internal_resolve_intent" json:"internal_resolve_intent,omitempty"`
+	InternalResolveIntentRange *InternalResolveIntentRangeResponse `protobuf:"bytes,13,opt,name=internal_resolve_intent_range" json:"internal_resolve_intent_range,omitempty"`
+	InternalMerge              *InternalMergeResponse              `protobuf:"bytes,14,opt,name=internal_merge" json:"internal_merge,omitempty"`
+	InternalTruncateLog        *InternalTruncateLogResponse        `protobuf:"bytes,15,opt,name=internal_truncate_log" json:"internal_truncate_log,omitempty"`
+	InternalGc                 *InternalGCResponse                 `protobuf:"bytes,16,opt,name=internal_gc" json:"internal_gc,omitempty"`
+	InternalLeaderLease        *InternalLeaderLeaseResponse        `protobuf:"bytes,17,opt,name=internal_leader_lease" json:"internal_leader_lease,omitempty"`
+	XXX_unrecognized           []byte                              `json:"-"`
 }
 
 func (m *ReadWriteCmdResponse) Reset()         { *m = ReadWriteCmdResponse{} }
@@ -758,6 +798,13 @@ func (m *ReadWriteCmdResponse) GetInternalResolveIntent() *InternalResolveIntent
 	return nil
 }
 
+func (m *ReadWriteCmdResponse) GetInternalResolveIntentRange() *InternalResolveIntentRangeResponse {
+	if m != nil {
+		return m.InternalResolveIntentRange
+	}
+	return nil
+}
+
 func (m *ReadWriteCmdResponse) GetInternalMerge() *InternalMergeResponse {
 	if m != nil {
 		return m.InternalMerge
@@ -801,17 +848,18 @@ type InternalRaftCommandUnion struct {
 	EndTransaction *EndTransactionRequest `protobuf:"bytes,9,opt,name=end_transaction" json:"end_transaction,omitempty"`
 	// Other requests. Allow a gap in tag numbers so the previous list can
 	// be copy/pasted from RequestUnion.
-	Batch                 *BatchRequest                 `protobuf:"bytes,30,opt,name=batch" json:"batch,omitempty"`
-	InternalRangeLookup   *InternalRangeLookupRequest   `protobuf:"bytes,31,opt,name=internal_range_lookup" json:"internal_range_lookup,omitempty"`
-	InternalHeartbeatTxn  *InternalHeartbeatTxnRequest  `protobuf:"bytes,32,opt,name=internal_heartbeat_txn" json:"internal_heartbeat_txn,omitempty"`
-	InternalPushTxn       *InternalPushTxnRequest       `protobuf:"bytes,33,opt,name=internal_push_txn" json:"internal_push_txn,omitempty"`
-	InternalResolveIntent *InternalResolveIntentRequest `protobuf:"bytes,34,opt,name=internal_resolve_intent" json:"internal_resolve_intent,omitempty"`
-	InternalMergeResponse *InternalMergeRequest         `protobuf:"bytes,35,opt,name=internal_merge_response" json:"internal_merge_response,omitempty"`
-	InternalTruncateLog   *InternalTruncateLogRequest   `protobuf:"bytes,36,opt,name=internal_truncate_log" json:"internal_truncate_log,omitempty"`
-	InternalGC            *InternalGCRequest            `protobuf:"bytes,37,opt,name=internal_gc" json:"internal_gc,omitempty"`
-	InternalLease         *InternalLeaderLeaseRequest   `protobuf:"bytes,38,opt,name=internal_lease" json:"internal_lease,omitempty"`
-	InternalBatch         *InternalBatchRequest         `protobuf:"bytes,39,opt,name=internal_batch" json:"internal_batch,omitempty"`
-	XXX_unrecognized      []byte                        `json:"-"`
+	Batch                      *BatchRequest                      `protobuf:"bytes,30,opt,name=batch" json:"batch,omitempty"`
+	InternalRangeLookup        *InternalRangeLookupRequest        `protobuf:"bytes,31,opt,name=internal_range_lookup" json:"internal_range_lookup,omitempty"`
+	InternalHeartbeatTxn       *InternalHeartbeatTxnRequest       `protobuf:"bytes,32,opt,name=internal_heartbeat_txn" json:"internal_heartbeat_txn,omitempty"`
+	InternalPushTxn            *InternalPushTxnRequest            `protobuf:"bytes,33,opt,name=internal_push_txn" json:"internal_push_txn,omitempty"`
+	InternalResolveIntent      *InternalResolveIntentRequest      `protobuf:"bytes,34,opt,name=internal_resolve_intent" json:"internal_resolve_intent,omitempty"`
+	InternalResolveIntentRange *InternalResolveIntentRangeRequest `protobuf:"bytes,35,opt,name=internal_resolve_intent_range" json:"internal_resolve_intent_range,omitempty"`
+	InternalMergeResponse      *InternalMergeRequest              `protobuf:"bytes,36,opt,name=internal_merge_response" json:"internal_merge_response,omitempty"`
+	InternalTruncateLog        *InternalTruncateLogRequest        `protobuf:"bytes,37,opt,name=internal_truncate_log" json:"internal_truncate_log,omitempty"`
+	InternalGC                 *InternalGCRequest                 `protobuf:"bytes,38,opt,name=internal_gc" json:"internal_gc,omitempty"`
+	InternalLease              *InternalLeaderLeaseRequest        `protobuf:"bytes,39,opt,name=internal_lease" json:"internal_lease,omitempty"`
+	InternalBatch              *InternalBatchRequest              `protobuf:"bytes,40,opt,name=internal_batch" json:"internal_batch,omitempty"`
+	XXX_unrecognized           []byte                             `json:"-"`
 }
 
 func (m *InternalRaftCommandUnion) Reset()         { *m = InternalRaftCommandUnion{} }
@@ -912,6 +960,13 @@ func (m *InternalRaftCommandUnion) GetInternalPushTxn() *InternalPushTxnRequest 
 func (m *InternalRaftCommandUnion) GetInternalResolveIntent() *InternalResolveIntentRequest {
 	if m != nil {
 		return m.InternalResolveIntent
+	}
+	return nil
+}
+
+func (m *InternalRaftCommandUnion) GetInternalResolveIntentRange() *InternalResolveIntentRangeRequest {
+	if m != nil {
+		return m.InternalResolveIntentRange
 	}
 	return nil
 }
@@ -2170,6 +2225,138 @@ func (m *InternalResolveIntentResponse) Unmarshal(data []byte) error {
 	}
 	return nil
 }
+func (m *InternalResolveIntentRangeRequest) Unmarshal(data []byte) error {
+	l := len(data)
+	index := 0
+	for index < l {
+		var wire uint64
+		for shift := uint(0); ; shift += 7 {
+			if index >= l {
+				return io.ErrUnexpectedEOF
+			}
+			b := data[index]
+			index++
+			wire |= (uint64(b) & 0x7F) << shift
+			if b < 0x80 {
+				break
+			}
+		}
+		fieldNum := int32(wire >> 3)
+		wireType := int(wire & 0x7)
+		switch fieldNum {
+		case 1:
+			if wireType != 2 {
+				return fmt.Errorf("proto: wrong wireType = %d for field RequestHeader", wireType)
+			}
+			var msglen int
+			for shift := uint(0); ; shift += 7 {
+				if index >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := data[index]
+				index++
+				msglen |= (int(b) & 0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			postIndex := index + msglen
+			if postIndex > l {
+				return io.ErrUnexpectedEOF
+			}
+			if err := m.RequestHeader.Unmarshal(data[index:postIndex]); err != nil {
+				return err
+			}
+			index = postIndex
+		default:
+			var sizeOfWire int
+			for {
+				sizeOfWire++
+				wire >>= 7
+				if wire == 0 {
+					break
+				}
+			}
+			index -= sizeOfWire
+			skippy, err := github_com_gogo_protobuf_proto.Skip(data[index:])
+			if err != nil {
+				return err
+			}
+			if (index + skippy) > l {
+				return io.ErrUnexpectedEOF
+			}
+			m.XXX_unrecognized = append(m.XXX_unrecognized, data[index:index+skippy]...)
+			index += skippy
+		}
+	}
+	return nil
+}
+func (m *InternalResolveIntentRangeResponse) Unmarshal(data []byte) error {
+	l := len(data)
+	index := 0
+	for index < l {
+		var wire uint64
+		for shift := uint(0); ; shift += 7 {
+			if index >= l {
+				return io.ErrUnexpectedEOF
+			}
+			b := data[index]
+			index++
+			wire |= (uint64(b) & 0x7F) << shift
+			if b < 0x80 {
+				break
+			}
+		}
+		fieldNum := int32(wire >> 3)
+		wireType := int(wire & 0x7)
+		switch fieldNum {
+		case 1:
+			if wireType != 2 {
+				return fmt.Errorf("proto: wrong wireType = %d for field ResponseHeader", wireType)
+			}
+			var msglen int
+			for shift := uint(0); ; shift += 7 {
+				if index >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := data[index]
+				index++
+				msglen |= (int(b) & 0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			postIndex := index + msglen
+			if postIndex > l {
+				return io.ErrUnexpectedEOF
+			}
+			if err := m.ResponseHeader.Unmarshal(data[index:postIndex]); err != nil {
+				return err
+			}
+			index = postIndex
+		default:
+			var sizeOfWire int
+			for {
+				sizeOfWire++
+				wire >>= 7
+				if wire == 0 {
+					break
+				}
+			}
+			index -= sizeOfWire
+			skippy, err := github_com_gogo_protobuf_proto.Skip(data[index:])
+			if err != nil {
+				return err
+			}
+			if (index + skippy) > l {
+				return io.ErrUnexpectedEOF
+			}
+			m.XXX_unrecognized = append(m.XXX_unrecognized, data[index:index+skippy]...)
+			index += skippy
+		}
+	}
+	return nil
+}
 func (m *InternalMergeRequest) Unmarshal(data []byte) error {
 	l := len(data)
 	index := 0
@@ -2945,6 +3132,33 @@ func (m *InternalRequestUnion) Unmarshal(data []byte) error {
 				return err
 			}
 			index = postIndex
+		case 32:
+			if wireType != 2 {
+				return fmt.Errorf("proto: wrong wireType = %d for field InternalResolveIntentRange", wireType)
+			}
+			var msglen int
+			for shift := uint(0); ; shift += 7 {
+				if index >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := data[index]
+				index++
+				msglen |= (int(b) & 0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			postIndex := index + msglen
+			if postIndex > l {
+				return io.ErrUnexpectedEOF
+			}
+			if m.InternalResolveIntentRange == nil {
+				m.InternalResolveIntentRange = &InternalResolveIntentRangeRequest{}
+			}
+			if err := m.InternalResolveIntentRange.Unmarshal(data[index:postIndex]); err != nil {
+				return err
+			}
+			index = postIndex
 		default:
 			var sizeOfWire int
 			for {
@@ -3281,6 +3495,33 @@ func (m *InternalResponseUnion) Unmarshal(data []byte) error {
 				m.InternalResolveIntent = &InternalResolveIntentResponse{}
 			}
 			if err := m.InternalResolveIntent.Unmarshal(data[index:postIndex]); err != nil {
+				return err
+			}
+			index = postIndex
+		case 32:
+			if wireType != 2 {
+				return fmt.Errorf("proto: wrong wireType = %d for field InternalResolveIntentRange", wireType)
+			}
+			var msglen int
+			for shift := uint(0); ; shift += 7 {
+				if index >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := data[index]
+				index++
+				msglen |= (int(b) & 0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			postIndex := index + msglen
+			if postIndex > l {
+				return io.ErrUnexpectedEOF
+			}
+			if m.InternalResolveIntentRange == nil {
+				m.InternalResolveIntentRange = &InternalResolveIntentRangeResponse{}
+			}
+			if err := m.InternalResolveIntentRange.Unmarshal(data[index:postIndex]); err != nil {
 				return err
 			}
 			index = postIndex
@@ -3753,6 +3994,33 @@ func (m *ReadWriteCmdResponse) Unmarshal(data []byte) error {
 			index = postIndex
 		case 13:
 			if wireType != 2 {
+				return fmt.Errorf("proto: wrong wireType = %d for field InternalResolveIntentRange", wireType)
+			}
+			var msglen int
+			for shift := uint(0); ; shift += 7 {
+				if index >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := data[index]
+				index++
+				msglen |= (int(b) & 0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			postIndex := index + msglen
+			if postIndex > l {
+				return io.ErrUnexpectedEOF
+			}
+			if m.InternalResolveIntentRange == nil {
+				m.InternalResolveIntentRange = &InternalResolveIntentRangeResponse{}
+			}
+			if err := m.InternalResolveIntentRange.Unmarshal(data[index:postIndex]); err != nil {
+				return err
+			}
+			index = postIndex
+		case 14:
+			if wireType != 2 {
 				return fmt.Errorf("proto: wrong wireType = %d for field InternalMerge", wireType)
 			}
 			var msglen int
@@ -3778,7 +4046,7 @@ func (m *ReadWriteCmdResponse) Unmarshal(data []byte) error {
 				return err
 			}
 			index = postIndex
-		case 14:
+		case 15:
 			if wireType != 2 {
 				return fmt.Errorf("proto: wrong wireType = %d for field InternalTruncateLog", wireType)
 			}
@@ -3805,7 +4073,7 @@ func (m *ReadWriteCmdResponse) Unmarshal(data []byte) error {
 				return err
 			}
 			index = postIndex
-		case 15:
+		case 16:
 			if wireType != 2 {
 				return fmt.Errorf("proto: wrong wireType = %d for field InternalGc", wireType)
 			}
@@ -3832,7 +4100,7 @@ func (m *ReadWriteCmdResponse) Unmarshal(data []byte) error {
 				return err
 			}
 			index = postIndex
-		case 16:
+		case 17:
 			if wireType != 2 {
 				return fmt.Errorf("proto: wrong wireType = %d for field InternalLeaderLease", wireType)
 			}
@@ -4281,6 +4549,33 @@ func (m *InternalRaftCommandUnion) Unmarshal(data []byte) error {
 			index = postIndex
 		case 35:
 			if wireType != 2 {
+				return fmt.Errorf("proto: wrong wireType = %d for field InternalResolveIntentRange", wireType)
+			}
+			var msglen int
+			for shift := uint(0); ; shift += 7 {
+				if index >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := data[index]
+				index++
+				msglen |= (int(b) & 0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			postIndex := index + msglen
+			if postIndex > l {
+				return io.ErrUnexpectedEOF
+			}
+			if m.InternalResolveIntentRange == nil {
+				m.InternalResolveIntentRange = &InternalResolveIntentRangeRequest{}
+			}
+			if err := m.InternalResolveIntentRange.Unmarshal(data[index:postIndex]); err != nil {
+				return err
+			}
+			index = postIndex
+		case 36:
+			if wireType != 2 {
 				return fmt.Errorf("proto: wrong wireType = %d for field InternalMergeResponse", wireType)
 			}
 			var msglen int
@@ -4306,7 +4601,7 @@ func (m *InternalRaftCommandUnion) Unmarshal(data []byte) error {
 				return err
 			}
 			index = postIndex
-		case 36:
+		case 37:
 			if wireType != 2 {
 				return fmt.Errorf("proto: wrong wireType = %d for field InternalTruncateLog", wireType)
 			}
@@ -4333,7 +4628,7 @@ func (m *InternalRaftCommandUnion) Unmarshal(data []byte) error {
 				return err
 			}
 			index = postIndex
-		case 37:
+		case 38:
 			if wireType != 2 {
 				return fmt.Errorf("proto: wrong wireType = %d for field InternalGC", wireType)
 			}
@@ -4360,7 +4655,7 @@ func (m *InternalRaftCommandUnion) Unmarshal(data []byte) error {
 				return err
 			}
 			index = postIndex
-		case 38:
+		case 39:
 			if wireType != 2 {
 				return fmt.Errorf("proto: wrong wireType = %d for field InternalLease", wireType)
 			}
@@ -4387,7 +4682,7 @@ func (m *InternalRaftCommandUnion) Unmarshal(data []byte) error {
 				return err
 			}
 			index = postIndex
-		case 39:
+		case 40:
 			if wireType != 2 {
 				return fmt.Errorf("proto: wrong wireType = %d for field InternalBatch", wireType)
 			}
@@ -5140,6 +5435,9 @@ func (this *InternalRequestUnion) GetValue() interface{} {
 	if this.InternalResolveIntent != nil {
 		return this.InternalResolveIntent
 	}
+	if this.InternalResolveIntentRange != nil {
+		return this.InternalResolveIntentRange
+	}
 	return nil
 }
 
@@ -5167,6 +5465,8 @@ func (this *InternalRequestUnion) SetValue(value interface{}) bool {
 		this.InternalPushTxn = vt
 	case *InternalResolveIntentRequest:
 		this.InternalResolveIntent = vt
+	case *InternalResolveIntentRangeRequest:
+		this.InternalResolveIntentRange = vt
 	default:
 		return false
 	}
@@ -5206,6 +5506,9 @@ func (this *InternalResponseUnion) GetValue() interface{} {
 	if this.InternalResolveIntent != nil {
 		return this.InternalResolveIntent
 	}
+	if this.InternalResolveIntentRange != nil {
+		return this.InternalResolveIntentRange
+	}
 	return nil
 }
 
@@ -5233,6 +5536,8 @@ func (this *InternalResponseUnion) SetValue(value interface{}) bool {
 		this.InternalPushTxn = vt
 	case *InternalResolveIntentResponse:
 		this.InternalResolveIntent = vt
+	case *InternalResolveIntentRangeResponse:
+		this.InternalResolveIntentRange = vt
 	default:
 		return false
 	}
@@ -5265,6 +5570,9 @@ func (this *ReadWriteCmdResponse) GetValue() interface{} {
 	}
 	if this.InternalResolveIntent != nil {
 		return this.InternalResolveIntent
+	}
+	if this.InternalResolveIntentRange != nil {
+		return this.InternalResolveIntentRange
 	}
 	if this.InternalMerge != nil {
 		return this.InternalMerge
@@ -5301,6 +5609,8 @@ func (this *ReadWriteCmdResponse) SetValue(value interface{}) bool {
 		this.InternalPushTxn = vt
 	case *InternalResolveIntentResponse:
 		this.InternalResolveIntent = vt
+	case *InternalResolveIntentRangeResponse:
+		this.InternalResolveIntentRange = vt
 	case *InternalMergeResponse:
 		this.InternalMerge = vt
 	case *InternalTruncateLogResponse:
@@ -5357,6 +5667,9 @@ func (this *InternalRaftCommandUnion) GetValue() interface{} {
 	if this.InternalResolveIntent != nil {
 		return this.InternalResolveIntent
 	}
+	if this.InternalResolveIntentRange != nil {
+		return this.InternalResolveIntentRange
+	}
 	if this.InternalMergeResponse != nil {
 		return this.InternalMergeResponse
 	}
@@ -5405,6 +5718,8 @@ func (this *InternalRaftCommandUnion) SetValue(value interface{}) bool {
 		this.InternalPushTxn = vt
 	case *InternalResolveIntentRequest:
 		this.InternalResolveIntent = vt
+	case *InternalResolveIntentRangeRequest:
+		this.InternalResolveIntentRange = vt
 	case *InternalMergeRequest:
 		this.InternalMergeResponse = vt
 	case *InternalTruncateLogRequest:
@@ -5567,6 +5882,28 @@ func (m *InternalResolveIntentResponse) Size() (n int) {
 	return n
 }
 
+func (m *InternalResolveIntentRangeRequest) Size() (n int) {
+	var l int
+	_ = l
+	l = m.RequestHeader.Size()
+	n += 1 + l + sovInternal(uint64(l))
+	if m.XXX_unrecognized != nil {
+		n += len(m.XXX_unrecognized)
+	}
+	return n
+}
+
+func (m *InternalResolveIntentRangeResponse) Size() (n int) {
+	var l int
+	_ = l
+	l = m.ResponseHeader.Size()
+	n += 1 + l + sovInternal(uint64(l))
+	if m.XXX_unrecognized != nil {
+		n += len(m.XXX_unrecognized)
+	}
+	return n
+}
+
 func (m *InternalMergeRequest) Size() (n int) {
 	var l int
 	_ = l
@@ -5685,6 +6022,10 @@ func (m *InternalRequestUnion) Size() (n int) {
 		l = m.InternalResolveIntent.Size()
 		n += 2 + l + sovInternal(uint64(l))
 	}
+	if m.InternalResolveIntentRange != nil {
+		l = m.InternalResolveIntentRange.Size()
+		n += 2 + l + sovInternal(uint64(l))
+	}
 	if m.XXX_unrecognized != nil {
 		n += len(m.XXX_unrecognized)
 	}
@@ -5736,6 +6077,10 @@ func (m *InternalResponseUnion) Size() (n int) {
 	}
 	if m.InternalResolveIntent != nil {
 		l = m.InternalResolveIntent.Size()
+		n += 2 + l + sovInternal(uint64(l))
+	}
+	if m.InternalResolveIntentRange != nil {
+		l = m.InternalResolveIntentRange.Size()
 		n += 2 + l + sovInternal(uint64(l))
 	}
 	if m.XXX_unrecognized != nil {
@@ -5817,6 +6162,10 @@ func (m *ReadWriteCmdResponse) Size() (n int) {
 		l = m.InternalResolveIntent.Size()
 		n += 1 + l + sovInternal(uint64(l))
 	}
+	if m.InternalResolveIntentRange != nil {
+		l = m.InternalResolveIntentRange.Size()
+		n += 1 + l + sovInternal(uint64(l))
+	}
 	if m.InternalMerge != nil {
 		l = m.InternalMerge.Size()
 		n += 1 + l + sovInternal(uint64(l))
@@ -5827,7 +6176,7 @@ func (m *ReadWriteCmdResponse) Size() (n int) {
 	}
 	if m.InternalGc != nil {
 		l = m.InternalGc.Size()
-		n += 1 + l + sovInternal(uint64(l))
+		n += 2 + l + sovInternal(uint64(l))
 	}
 	if m.InternalLeaderLease != nil {
 		l = m.InternalLeaderLease.Size()
@@ -5896,6 +6245,10 @@ func (m *InternalRaftCommandUnion) Size() (n int) {
 	}
 	if m.InternalResolveIntent != nil {
 		l = m.InternalResolveIntent.Size()
+		n += 2 + l + sovInternal(uint64(l))
+	}
+	if m.InternalResolveIntentRange != nil {
+		l = m.InternalResolveIntentRange.Size()
 		n += 2 + l + sovInternal(uint64(l))
 	}
 	if m.InternalMergeResponse != nil {
@@ -6450,6 +6803,64 @@ func (m *InternalResolveIntentResponse) MarshalTo(data []byte) (n int, err error
 	return i, nil
 }
 
+func (m *InternalResolveIntentRangeRequest) Marshal() (data []byte, err error) {
+	size := m.Size()
+	data = make([]byte, size)
+	n, err := m.MarshalTo(data)
+	if err != nil {
+		return nil, err
+	}
+	return data[:n], nil
+}
+
+func (m *InternalResolveIntentRangeRequest) MarshalTo(data []byte) (n int, err error) {
+	var i int
+	_ = i
+	var l int
+	_ = l
+	data[i] = 0xa
+	i++
+	i = encodeVarintInternal(data, i, uint64(m.RequestHeader.Size()))
+	n16, err := m.RequestHeader.MarshalTo(data[i:])
+	if err != nil {
+		return 0, err
+	}
+	i += n16
+	if m.XXX_unrecognized != nil {
+		i += copy(data[i:], m.XXX_unrecognized)
+	}
+	return i, nil
+}
+
+func (m *InternalResolveIntentRangeResponse) Marshal() (data []byte, err error) {
+	size := m.Size()
+	data = make([]byte, size)
+	n, err := m.MarshalTo(data)
+	if err != nil {
+		return nil, err
+	}
+	return data[:n], nil
+}
+
+func (m *InternalResolveIntentRangeResponse) MarshalTo(data []byte) (n int, err error) {
+	var i int
+	_ = i
+	var l int
+	_ = l
+	data[i] = 0xa
+	i++
+	i = encodeVarintInternal(data, i, uint64(m.ResponseHeader.Size()))
+	n17, err := m.ResponseHeader.MarshalTo(data[i:])
+	if err != nil {
+		return 0, err
+	}
+	i += n17
+	if m.XXX_unrecognized != nil {
+		i += copy(data[i:], m.XXX_unrecognized)
+	}
+	return i, nil
+}
+
 func (m *InternalMergeRequest) Marshal() (data []byte, err error) {
 	size := m.Size()
 	data = make([]byte, size)
@@ -6468,19 +6879,19 @@ func (m *InternalMergeRequest) MarshalTo(data []byte) (n int, err error) {
 	data[i] = 0xa
 	i++
 	i = encodeVarintInternal(data, i, uint64(m.RequestHeader.Size()))
-	n16, err := m.RequestHeader.MarshalTo(data[i:])
+	n18, err := m.RequestHeader.MarshalTo(data[i:])
 	if err != nil {
 		return 0, err
 	}
-	i += n16
+	i += n18
 	data[i] = 0x12
 	i++
 	i = encodeVarintInternal(data, i, uint64(m.Value.Size()))
-	n17, err := m.Value.MarshalTo(data[i:])
+	n19, err := m.Value.MarshalTo(data[i:])
 	if err != nil {
 		return 0, err
 	}
-	i += n17
+	i += n19
 	if m.XXX_unrecognized != nil {
 		i += copy(data[i:], m.XXX_unrecognized)
 	}
@@ -6505,11 +6916,11 @@ func (m *InternalMergeResponse) MarshalTo(data []byte) (n int, err error) {
 	data[i] = 0xa
 	i++
 	i = encodeVarintInternal(data, i, uint64(m.ResponseHeader.Size()))
-	n18, err := m.ResponseHeader.MarshalTo(data[i:])
+	n20, err := m.ResponseHeader.MarshalTo(data[i:])
 	if err != nil {
 		return 0, err
 	}
-	i += n18
+	i += n20
 	if m.XXX_unrecognized != nil {
 		i += copy(data[i:], m.XXX_unrecognized)
 	}
@@ -6534,11 +6945,11 @@ func (m *InternalTruncateLogRequest) MarshalTo(data []byte) (n int, err error) {
 	data[i] = 0xa
 	i++
 	i = encodeVarintInternal(data, i, uint64(m.RequestHeader.Size()))
-	n19, err := m.RequestHeader.MarshalTo(data[i:])
+	n21, err := m.RequestHeader.MarshalTo(data[i:])
 	if err != nil {
 		return 0, err
 	}
-	i += n19
+	i += n21
 	data[i] = 0x10
 	i++
 	i = encodeVarintInternal(data, i, uint64(m.Index))
@@ -6566,11 +6977,11 @@ func (m *InternalTruncateLogResponse) MarshalTo(data []byte) (n int, err error) 
 	data[i] = 0xa
 	i++
 	i = encodeVarintInternal(data, i, uint64(m.ResponseHeader.Size()))
-	n20, err := m.ResponseHeader.MarshalTo(data[i:])
+	n22, err := m.ResponseHeader.MarshalTo(data[i:])
 	if err != nil {
 		return 0, err
 	}
-	i += n20
+	i += n22
 	if m.XXX_unrecognized != nil {
 		i += copy(data[i:], m.XXX_unrecognized)
 	}
@@ -6595,19 +7006,19 @@ func (m *InternalLeaderLeaseRequest) MarshalTo(data []byte) (n int, err error) {
 	data[i] = 0xa
 	i++
 	i = encodeVarintInternal(data, i, uint64(m.RequestHeader.Size()))
-	n21, err := m.RequestHeader.MarshalTo(data[i:])
+	n23, err := m.RequestHeader.MarshalTo(data[i:])
 	if err != nil {
 		return 0, err
 	}
-	i += n21
+	i += n23
 	data[i] = 0x12
 	i++
 	i = encodeVarintInternal(data, i, uint64(m.Lease.Size()))
-	n22, err := m.Lease.MarshalTo(data[i:])
+	n24, err := m.Lease.MarshalTo(data[i:])
 	if err != nil {
 		return 0, err
 	}
-	i += n22
+	i += n24
 	if m.XXX_unrecognized != nil {
 		i += copy(data[i:], m.XXX_unrecognized)
 	}
@@ -6632,11 +7043,11 @@ func (m *InternalLeaderLeaseResponse) MarshalTo(data []byte) (n int, err error) 
 	data[i] = 0xa
 	i++
 	i = encodeVarintInternal(data, i, uint64(m.ResponseHeader.Size()))
-	n23, err := m.ResponseHeader.MarshalTo(data[i:])
+	n25, err := m.ResponseHeader.MarshalTo(data[i:])
 	if err != nil {
 		return 0, err
 	}
-	i += n23
+	i += n25
 	if m.XXX_unrecognized != nil {
 		i += copy(data[i:], m.XXX_unrecognized)
 	}
@@ -6662,91 +7073,91 @@ func (m *InternalRequestUnion) MarshalTo(data []byte) (n int, err error) {
 		data[i] = 0xa
 		i++
 		i = encodeVarintInternal(data, i, uint64(m.Contains.Size()))
-		n24, err := m.Contains.MarshalTo(data[i:])
-		if err != nil {
-			return 0, err
-		}
-		i += n24
-	}
-	if m.Get != nil {
-		data[i] = 0x12
-		i++
-		i = encodeVarintInternal(data, i, uint64(m.Get.Size()))
-		n25, err := m.Get.MarshalTo(data[i:])
-		if err != nil {
-			return 0, err
-		}
-		i += n25
-	}
-	if m.Put != nil {
-		data[i] = 0x1a
-		i++
-		i = encodeVarintInternal(data, i, uint64(m.Put.Size()))
-		n26, err := m.Put.MarshalTo(data[i:])
+		n26, err := m.Contains.MarshalTo(data[i:])
 		if err != nil {
 			return 0, err
 		}
 		i += n26
 	}
-	if m.ConditionalPut != nil {
-		data[i] = 0x22
+	if m.Get != nil {
+		data[i] = 0x12
 		i++
-		i = encodeVarintInternal(data, i, uint64(m.ConditionalPut.Size()))
-		n27, err := m.ConditionalPut.MarshalTo(data[i:])
+		i = encodeVarintInternal(data, i, uint64(m.Get.Size()))
+		n27, err := m.Get.MarshalTo(data[i:])
 		if err != nil {
 			return 0, err
 		}
 		i += n27
 	}
-	if m.Increment != nil {
-		data[i] = 0x2a
+	if m.Put != nil {
+		data[i] = 0x1a
 		i++
-		i = encodeVarintInternal(data, i, uint64(m.Increment.Size()))
-		n28, err := m.Increment.MarshalTo(data[i:])
+		i = encodeVarintInternal(data, i, uint64(m.Put.Size()))
+		n28, err := m.Put.MarshalTo(data[i:])
 		if err != nil {
 			return 0, err
 		}
 		i += n28
 	}
-	if m.Delete != nil {
-		data[i] = 0x32
+	if m.ConditionalPut != nil {
+		data[i] = 0x22
 		i++
-		i = encodeVarintInternal(data, i, uint64(m.Delete.Size()))
-		n29, err := m.Delete.MarshalTo(data[i:])
+		i = encodeVarintInternal(data, i, uint64(m.ConditionalPut.Size()))
+		n29, err := m.ConditionalPut.MarshalTo(data[i:])
 		if err != nil {
 			return 0, err
 		}
 		i += n29
 	}
-	if m.DeleteRange != nil {
-		data[i] = 0x3a
+	if m.Increment != nil {
+		data[i] = 0x2a
 		i++
-		i = encodeVarintInternal(data, i, uint64(m.DeleteRange.Size()))
-		n30, err := m.DeleteRange.MarshalTo(data[i:])
+		i = encodeVarintInternal(data, i, uint64(m.Increment.Size()))
+		n30, err := m.Increment.MarshalTo(data[i:])
 		if err != nil {
 			return 0, err
 		}
 		i += n30
 	}
-	if m.Scan != nil {
-		data[i] = 0x42
+	if m.Delete != nil {
+		data[i] = 0x32
 		i++
-		i = encodeVarintInternal(data, i, uint64(m.Scan.Size()))
-		n31, err := m.Scan.MarshalTo(data[i:])
+		i = encodeVarintInternal(data, i, uint64(m.Delete.Size()))
+		n31, err := m.Delete.MarshalTo(data[i:])
 		if err != nil {
 			return 0, err
 		}
 		i += n31
 	}
-	if m.EndTransaction != nil {
-		data[i] = 0x4a
+	if m.DeleteRange != nil {
+		data[i] = 0x3a
 		i++
-		i = encodeVarintInternal(data, i, uint64(m.EndTransaction.Size()))
-		n32, err := m.EndTransaction.MarshalTo(data[i:])
+		i = encodeVarintInternal(data, i, uint64(m.DeleteRange.Size()))
+		n32, err := m.DeleteRange.MarshalTo(data[i:])
 		if err != nil {
 			return 0, err
 		}
 		i += n32
+	}
+	if m.Scan != nil {
+		data[i] = 0x42
+		i++
+		i = encodeVarintInternal(data, i, uint64(m.Scan.Size()))
+		n33, err := m.Scan.MarshalTo(data[i:])
+		if err != nil {
+			return 0, err
+		}
+		i += n33
+	}
+	if m.EndTransaction != nil {
+		data[i] = 0x4a
+		i++
+		i = encodeVarintInternal(data, i, uint64(m.EndTransaction.Size()))
+		n34, err := m.EndTransaction.MarshalTo(data[i:])
+		if err != nil {
+			return 0, err
+		}
+		i += n34
 	}
 	if m.InternalPushTxn != nil {
 		data[i] = 0xf2
@@ -6754,11 +7165,11 @@ func (m *InternalRequestUnion) MarshalTo(data []byte) (n int, err error) {
 		data[i] = 0x1
 		i++
 		i = encodeVarintInternal(data, i, uint64(m.InternalPushTxn.Size()))
-		n33, err := m.InternalPushTxn.MarshalTo(data[i:])
+		n35, err := m.InternalPushTxn.MarshalTo(data[i:])
 		if err != nil {
 			return 0, err
 		}
-		i += n33
+		i += n35
 	}
 	if m.InternalResolveIntent != nil {
 		data[i] = 0xfa
@@ -6766,11 +7177,23 @@ func (m *InternalRequestUnion) MarshalTo(data []byte) (n int, err error) {
 		data[i] = 0x1
 		i++
 		i = encodeVarintInternal(data, i, uint64(m.InternalResolveIntent.Size()))
-		n34, err := m.InternalResolveIntent.MarshalTo(data[i:])
+		n36, err := m.InternalResolveIntent.MarshalTo(data[i:])
 		if err != nil {
 			return 0, err
 		}
-		i += n34
+		i += n36
+	}
+	if m.InternalResolveIntentRange != nil {
+		data[i] = 0x82
+		i++
+		data[i] = 0x2
+		i++
+		i = encodeVarintInternal(data, i, uint64(m.InternalResolveIntentRange.Size()))
+		n37, err := m.InternalResolveIntentRange.MarshalTo(data[i:])
+		if err != nil {
+			return 0, err
+		}
+		i += n37
 	}
 	if m.XXX_unrecognized != nil {
 		i += copy(data[i:], m.XXX_unrecognized)
@@ -6797,91 +7220,91 @@ func (m *InternalResponseUnion) MarshalTo(data []byte) (n int, err error) {
 		data[i] = 0xa
 		i++
 		i = encodeVarintInternal(data, i, uint64(m.Contains.Size()))
-		n35, err := m.Contains.MarshalTo(data[i:])
-		if err != nil {
-			return 0, err
-		}
-		i += n35
-	}
-	if m.Get != nil {
-		data[i] = 0x12
-		i++
-		i = encodeVarintInternal(data, i, uint64(m.Get.Size()))
-		n36, err := m.Get.MarshalTo(data[i:])
-		if err != nil {
-			return 0, err
-		}
-		i += n36
-	}
-	if m.Put != nil {
-		data[i] = 0x1a
-		i++
-		i = encodeVarintInternal(data, i, uint64(m.Put.Size()))
-		n37, err := m.Put.MarshalTo(data[i:])
-		if err != nil {
-			return 0, err
-		}
-		i += n37
-	}
-	if m.ConditionalPut != nil {
-		data[i] = 0x22
-		i++
-		i = encodeVarintInternal(data, i, uint64(m.ConditionalPut.Size()))
-		n38, err := m.ConditionalPut.MarshalTo(data[i:])
+		n38, err := m.Contains.MarshalTo(data[i:])
 		if err != nil {
 			return 0, err
 		}
 		i += n38
 	}
-	if m.Increment != nil {
-		data[i] = 0x2a
+	if m.Get != nil {
+		data[i] = 0x12
 		i++
-		i = encodeVarintInternal(data, i, uint64(m.Increment.Size()))
-		n39, err := m.Increment.MarshalTo(data[i:])
+		i = encodeVarintInternal(data, i, uint64(m.Get.Size()))
+		n39, err := m.Get.MarshalTo(data[i:])
 		if err != nil {
 			return 0, err
 		}
 		i += n39
 	}
-	if m.Delete != nil {
-		data[i] = 0x32
+	if m.Put != nil {
+		data[i] = 0x1a
 		i++
-		i = encodeVarintInternal(data, i, uint64(m.Delete.Size()))
-		n40, err := m.Delete.MarshalTo(data[i:])
+		i = encodeVarintInternal(data, i, uint64(m.Put.Size()))
+		n40, err := m.Put.MarshalTo(data[i:])
 		if err != nil {
 			return 0, err
 		}
 		i += n40
 	}
-	if m.DeleteRange != nil {
-		data[i] = 0x3a
+	if m.ConditionalPut != nil {
+		data[i] = 0x22
 		i++
-		i = encodeVarintInternal(data, i, uint64(m.DeleteRange.Size()))
-		n41, err := m.DeleteRange.MarshalTo(data[i:])
+		i = encodeVarintInternal(data, i, uint64(m.ConditionalPut.Size()))
+		n41, err := m.ConditionalPut.MarshalTo(data[i:])
 		if err != nil {
 			return 0, err
 		}
 		i += n41
 	}
-	if m.Scan != nil {
-		data[i] = 0x42
+	if m.Increment != nil {
+		data[i] = 0x2a
 		i++
-		i = encodeVarintInternal(data, i, uint64(m.Scan.Size()))
-		n42, err := m.Scan.MarshalTo(data[i:])
+		i = encodeVarintInternal(data, i, uint64(m.Increment.Size()))
+		n42, err := m.Increment.MarshalTo(data[i:])
 		if err != nil {
 			return 0, err
 		}
 		i += n42
 	}
-	if m.EndTransaction != nil {
-		data[i] = 0x4a
+	if m.Delete != nil {
+		data[i] = 0x32
 		i++
-		i = encodeVarintInternal(data, i, uint64(m.EndTransaction.Size()))
-		n43, err := m.EndTransaction.MarshalTo(data[i:])
+		i = encodeVarintInternal(data, i, uint64(m.Delete.Size()))
+		n43, err := m.Delete.MarshalTo(data[i:])
 		if err != nil {
 			return 0, err
 		}
 		i += n43
+	}
+	if m.DeleteRange != nil {
+		data[i] = 0x3a
+		i++
+		i = encodeVarintInternal(data, i, uint64(m.DeleteRange.Size()))
+		n44, err := m.DeleteRange.MarshalTo(data[i:])
+		if err != nil {
+			return 0, err
+		}
+		i += n44
+	}
+	if m.Scan != nil {
+		data[i] = 0x42
+		i++
+		i = encodeVarintInternal(data, i, uint64(m.Scan.Size()))
+		n45, err := m.Scan.MarshalTo(data[i:])
+		if err != nil {
+			return 0, err
+		}
+		i += n45
+	}
+	if m.EndTransaction != nil {
+		data[i] = 0x4a
+		i++
+		i = encodeVarintInternal(data, i, uint64(m.EndTransaction.Size()))
+		n46, err := m.EndTransaction.MarshalTo(data[i:])
+		if err != nil {
+			return 0, err
+		}
+		i += n46
 	}
 	if m.InternalPushTxn != nil {
 		data[i] = 0xf2
@@ -6889,11 +7312,11 @@ func (m *InternalResponseUnion) MarshalTo(data []byte) (n int, err error) {
 		data[i] = 0x1
 		i++
 		i = encodeVarintInternal(data, i, uint64(m.InternalPushTxn.Size()))
-		n44, err := m.InternalPushTxn.MarshalTo(data[i:])
+		n47, err := m.InternalPushTxn.MarshalTo(data[i:])
 		if err != nil {
 			return 0, err
 		}
-		i += n44
+		i += n47
 	}
 	if m.InternalResolveIntent != nil {
 		data[i] = 0xfa
@@ -6901,11 +7324,23 @@ func (m *InternalResponseUnion) MarshalTo(data []byte) (n int, err error) {
 		data[i] = 0x1
 		i++
 		i = encodeVarintInternal(data, i, uint64(m.InternalResolveIntent.Size()))
-		n45, err := m.InternalResolveIntent.MarshalTo(data[i:])
+		n48, err := m.InternalResolveIntent.MarshalTo(data[i:])
 		if err != nil {
 			return 0, err
 		}
-		i += n45
+		i += n48
+	}
+	if m.InternalResolveIntentRange != nil {
+		data[i] = 0x82
+		i++
+		data[i] = 0x2
+		i++
+		i = encodeVarintInternal(data, i, uint64(m.InternalResolveIntentRange.Size()))
+		n49, err := m.InternalResolveIntentRange.MarshalTo(data[i:])
+		if err != nil {
+			return 0, err
+		}
+		i += n49
 	}
 	if m.XXX_unrecognized != nil {
 		i += copy(data[i:], m.XXX_unrecognized)
@@ -6931,11 +7366,11 @@ func (m *InternalBatchRequest) MarshalTo(data []byte) (n int, err error) {
 	data[i] = 0xa
 	i++
 	i = encodeVarintInternal(data, i, uint64(m.RequestHeader.Size()))
-	n46, err := m.RequestHeader.MarshalTo(data[i:])
+	n50, err := m.RequestHeader.MarshalTo(data[i:])
 	if err != nil {
 		return 0, err
 	}
-	i += n46
+	i += n50
 	if len(m.Requests) > 0 {
 		for _, msg := range m.Requests {
 			data[i] = 0x12
@@ -6972,11 +7407,11 @@ func (m *InternalBatchResponse) MarshalTo(data []byte) (n int, err error) {
 	data[i] = 0xa
 	i++
 	i = encodeVarintInternal(data, i, uint64(m.ResponseHeader.Size()))
-	n47, err := m.ResponseHeader.MarshalTo(data[i:])
+	n51, err := m.ResponseHeader.MarshalTo(data[i:])
 	if err != nil {
 		return 0, err
 	}
-	i += n47
+	i += n51
 	if len(m.Responses) > 0 {
 		for _, msg := range m.Responses {
 			data[i] = 0x12
@@ -7014,133 +7449,145 @@ func (m *ReadWriteCmdResponse) MarshalTo(data []byte) (n int, err error) {
 		data[i] = 0xa
 		i++
 		i = encodeVarintInternal(data, i, uint64(m.Put.Size()))
-		n48, err := m.Put.MarshalTo(data[i:])
-		if err != nil {
-			return 0, err
-		}
-		i += n48
-	}
-	if m.ConditionalPut != nil {
-		data[i] = 0x12
-		i++
-		i = encodeVarintInternal(data, i, uint64(m.ConditionalPut.Size()))
-		n49, err := m.ConditionalPut.MarshalTo(data[i:])
-		if err != nil {
-			return 0, err
-		}
-		i += n49
-	}
-	if m.Increment != nil {
-		data[i] = 0x1a
-		i++
-		i = encodeVarintInternal(data, i, uint64(m.Increment.Size()))
-		n50, err := m.Increment.MarshalTo(data[i:])
-		if err != nil {
-			return 0, err
-		}
-		i += n50
-	}
-	if m.Delete != nil {
-		data[i] = 0x22
-		i++
-		i = encodeVarintInternal(data, i, uint64(m.Delete.Size()))
-		n51, err := m.Delete.MarshalTo(data[i:])
-		if err != nil {
-			return 0, err
-		}
-		i += n51
-	}
-	if m.DeleteRange != nil {
-		data[i] = 0x2a
-		i++
-		i = encodeVarintInternal(data, i, uint64(m.DeleteRange.Size()))
-		n52, err := m.DeleteRange.MarshalTo(data[i:])
+		n52, err := m.Put.MarshalTo(data[i:])
 		if err != nil {
 			return 0, err
 		}
 		i += n52
 	}
-	if m.EndTransaction != nil {
-		data[i] = 0x32
+	if m.ConditionalPut != nil {
+		data[i] = 0x12
 		i++
-		i = encodeVarintInternal(data, i, uint64(m.EndTransaction.Size()))
-		n53, err := m.EndTransaction.MarshalTo(data[i:])
+		i = encodeVarintInternal(data, i, uint64(m.ConditionalPut.Size()))
+		n53, err := m.ConditionalPut.MarshalTo(data[i:])
 		if err != nil {
 			return 0, err
 		}
 		i += n53
 	}
-	if m.InternalHeartbeatTxn != nil {
-		data[i] = 0x52
+	if m.Increment != nil {
+		data[i] = 0x1a
 		i++
-		i = encodeVarintInternal(data, i, uint64(m.InternalHeartbeatTxn.Size()))
-		n54, err := m.InternalHeartbeatTxn.MarshalTo(data[i:])
+		i = encodeVarintInternal(data, i, uint64(m.Increment.Size()))
+		n54, err := m.Increment.MarshalTo(data[i:])
 		if err != nil {
 			return 0, err
 		}
 		i += n54
 	}
-	if m.InternalPushTxn != nil {
-		data[i] = 0x5a
+	if m.Delete != nil {
+		data[i] = 0x22
 		i++
-		i = encodeVarintInternal(data, i, uint64(m.InternalPushTxn.Size()))
-		n55, err := m.InternalPushTxn.MarshalTo(data[i:])
+		i = encodeVarintInternal(data, i, uint64(m.Delete.Size()))
+		n55, err := m.Delete.MarshalTo(data[i:])
 		if err != nil {
 			return 0, err
 		}
 		i += n55
 	}
-	if m.InternalResolveIntent != nil {
-		data[i] = 0x62
+	if m.DeleteRange != nil {
+		data[i] = 0x2a
 		i++
-		i = encodeVarintInternal(data, i, uint64(m.InternalResolveIntent.Size()))
-		n56, err := m.InternalResolveIntent.MarshalTo(data[i:])
+		i = encodeVarintInternal(data, i, uint64(m.DeleteRange.Size()))
+		n56, err := m.DeleteRange.MarshalTo(data[i:])
 		if err != nil {
 			return 0, err
 		}
 		i += n56
 	}
-	if m.InternalMerge != nil {
-		data[i] = 0x6a
+	if m.EndTransaction != nil {
+		data[i] = 0x32
 		i++
-		i = encodeVarintInternal(data, i, uint64(m.InternalMerge.Size()))
-		n57, err := m.InternalMerge.MarshalTo(data[i:])
+		i = encodeVarintInternal(data, i, uint64(m.EndTransaction.Size()))
+		n57, err := m.EndTransaction.MarshalTo(data[i:])
 		if err != nil {
 			return 0, err
 		}
 		i += n57
 	}
-	if m.InternalTruncateLog != nil {
-		data[i] = 0x72
+	if m.InternalHeartbeatTxn != nil {
+		data[i] = 0x52
 		i++
-		i = encodeVarintInternal(data, i, uint64(m.InternalTruncateLog.Size()))
-		n58, err := m.InternalTruncateLog.MarshalTo(data[i:])
+		i = encodeVarintInternal(data, i, uint64(m.InternalHeartbeatTxn.Size()))
+		n58, err := m.InternalHeartbeatTxn.MarshalTo(data[i:])
 		if err != nil {
 			return 0, err
 		}
 		i += n58
 	}
-	if m.InternalGc != nil {
-		data[i] = 0x7a
+	if m.InternalPushTxn != nil {
+		data[i] = 0x5a
 		i++
-		i = encodeVarintInternal(data, i, uint64(m.InternalGc.Size()))
-		n59, err := m.InternalGc.MarshalTo(data[i:])
+		i = encodeVarintInternal(data, i, uint64(m.InternalPushTxn.Size()))
+		n59, err := m.InternalPushTxn.MarshalTo(data[i:])
 		if err != nil {
 			return 0, err
 		}
 		i += n59
 	}
-	if m.InternalLeaderLease != nil {
-		data[i] = 0x82
+	if m.InternalResolveIntent != nil {
+		data[i] = 0x62
 		i++
-		data[i] = 0x1
-		i++
-		i = encodeVarintInternal(data, i, uint64(m.InternalLeaderLease.Size()))
-		n60, err := m.InternalLeaderLease.MarshalTo(data[i:])
+		i = encodeVarintInternal(data, i, uint64(m.InternalResolveIntent.Size()))
+		n60, err := m.InternalResolveIntent.MarshalTo(data[i:])
 		if err != nil {
 			return 0, err
 		}
 		i += n60
+	}
+	if m.InternalResolveIntentRange != nil {
+		data[i] = 0x6a
+		i++
+		i = encodeVarintInternal(data, i, uint64(m.InternalResolveIntentRange.Size()))
+		n61, err := m.InternalResolveIntentRange.MarshalTo(data[i:])
+		if err != nil {
+			return 0, err
+		}
+		i += n61
+	}
+	if m.InternalMerge != nil {
+		data[i] = 0x72
+		i++
+		i = encodeVarintInternal(data, i, uint64(m.InternalMerge.Size()))
+		n62, err := m.InternalMerge.MarshalTo(data[i:])
+		if err != nil {
+			return 0, err
+		}
+		i += n62
+	}
+	if m.InternalTruncateLog != nil {
+		data[i] = 0x7a
+		i++
+		i = encodeVarintInternal(data, i, uint64(m.InternalTruncateLog.Size()))
+		n63, err := m.InternalTruncateLog.MarshalTo(data[i:])
+		if err != nil {
+			return 0, err
+		}
+		i += n63
+	}
+	if m.InternalGc != nil {
+		data[i] = 0x82
+		i++
+		data[i] = 0x1
+		i++
+		i = encodeVarintInternal(data, i, uint64(m.InternalGc.Size()))
+		n64, err := m.InternalGc.MarshalTo(data[i:])
+		if err != nil {
+			return 0, err
+		}
+		i += n64
+	}
+	if m.InternalLeaderLease != nil {
+		data[i] = 0x8a
+		i++
+		data[i] = 0x1
+		i++
+		i = encodeVarintInternal(data, i, uint64(m.InternalLeaderLease.Size()))
+		n65, err := m.InternalLeaderLease.MarshalTo(data[i:])
+		if err != nil {
+			return 0, err
+		}
+		i += n65
 	}
 	if m.XXX_unrecognized != nil {
 		i += copy(data[i:], m.XXX_unrecognized)
@@ -7167,91 +7614,91 @@ func (m *InternalRaftCommandUnion) MarshalTo(data []byte) (n int, err error) {
 		data[i] = 0xa
 		i++
 		i = encodeVarintInternal(data, i, uint64(m.Contains.Size()))
-		n61, err := m.Contains.MarshalTo(data[i:])
-		if err != nil {
-			return 0, err
-		}
-		i += n61
-	}
-	if m.Get != nil {
-		data[i] = 0x12
-		i++
-		i = encodeVarintInternal(data, i, uint64(m.Get.Size()))
-		n62, err := m.Get.MarshalTo(data[i:])
-		if err != nil {
-			return 0, err
-		}
-		i += n62
-	}
-	if m.Put != nil {
-		data[i] = 0x1a
-		i++
-		i = encodeVarintInternal(data, i, uint64(m.Put.Size()))
-		n63, err := m.Put.MarshalTo(data[i:])
-		if err != nil {
-			return 0, err
-		}
-		i += n63
-	}
-	if m.ConditionalPut != nil {
-		data[i] = 0x22
-		i++
-		i = encodeVarintInternal(data, i, uint64(m.ConditionalPut.Size()))
-		n64, err := m.ConditionalPut.MarshalTo(data[i:])
-		if err != nil {
-			return 0, err
-		}
-		i += n64
-	}
-	if m.Increment != nil {
-		data[i] = 0x2a
-		i++
-		i = encodeVarintInternal(data, i, uint64(m.Increment.Size()))
-		n65, err := m.Increment.MarshalTo(data[i:])
-		if err != nil {
-			return 0, err
-		}
-		i += n65
-	}
-	if m.Delete != nil {
-		data[i] = 0x32
-		i++
-		i = encodeVarintInternal(data, i, uint64(m.Delete.Size()))
-		n66, err := m.Delete.MarshalTo(data[i:])
+		n66, err := m.Contains.MarshalTo(data[i:])
 		if err != nil {
 			return 0, err
 		}
 		i += n66
 	}
-	if m.DeleteRange != nil {
-		data[i] = 0x3a
+	if m.Get != nil {
+		data[i] = 0x12
 		i++
-		i = encodeVarintInternal(data, i, uint64(m.DeleteRange.Size()))
-		n67, err := m.DeleteRange.MarshalTo(data[i:])
+		i = encodeVarintInternal(data, i, uint64(m.Get.Size()))
+		n67, err := m.Get.MarshalTo(data[i:])
 		if err != nil {
 			return 0, err
 		}
 		i += n67
 	}
-	if m.Scan != nil {
-		data[i] = 0x42
+	if m.Put != nil {
+		data[i] = 0x1a
 		i++
-		i = encodeVarintInternal(data, i, uint64(m.Scan.Size()))
-		n68, err := m.Scan.MarshalTo(data[i:])
+		i = encodeVarintInternal(data, i, uint64(m.Put.Size()))
+		n68, err := m.Put.MarshalTo(data[i:])
 		if err != nil {
 			return 0, err
 		}
 		i += n68
 	}
-	if m.EndTransaction != nil {
-		data[i] = 0x4a
+	if m.ConditionalPut != nil {
+		data[i] = 0x22
 		i++
-		i = encodeVarintInternal(data, i, uint64(m.EndTransaction.Size()))
-		n69, err := m.EndTransaction.MarshalTo(data[i:])
+		i = encodeVarintInternal(data, i, uint64(m.ConditionalPut.Size()))
+		n69, err := m.ConditionalPut.MarshalTo(data[i:])
 		if err != nil {
 			return 0, err
 		}
 		i += n69
+	}
+	if m.Increment != nil {
+		data[i] = 0x2a
+		i++
+		i = encodeVarintInternal(data, i, uint64(m.Increment.Size()))
+		n70, err := m.Increment.MarshalTo(data[i:])
+		if err != nil {
+			return 0, err
+		}
+		i += n70
+	}
+	if m.Delete != nil {
+		data[i] = 0x32
+		i++
+		i = encodeVarintInternal(data, i, uint64(m.Delete.Size()))
+		n71, err := m.Delete.MarshalTo(data[i:])
+		if err != nil {
+			return 0, err
+		}
+		i += n71
+	}
+	if m.DeleteRange != nil {
+		data[i] = 0x3a
+		i++
+		i = encodeVarintInternal(data, i, uint64(m.DeleteRange.Size()))
+		n72, err := m.DeleteRange.MarshalTo(data[i:])
+		if err != nil {
+			return 0, err
+		}
+		i += n72
+	}
+	if m.Scan != nil {
+		data[i] = 0x42
+		i++
+		i = encodeVarintInternal(data, i, uint64(m.Scan.Size()))
+		n73, err := m.Scan.MarshalTo(data[i:])
+		if err != nil {
+			return 0, err
+		}
+		i += n73
+	}
+	if m.EndTransaction != nil {
+		data[i] = 0x4a
+		i++
+		i = encodeVarintInternal(data, i, uint64(m.EndTransaction.Size()))
+		n74, err := m.EndTransaction.MarshalTo(data[i:])
+		if err != nil {
+			return 0, err
+		}
+		i += n74
 	}
 	if m.Batch != nil {
 		data[i] = 0xf2
@@ -7259,11 +7706,11 @@ func (m *InternalRaftCommandUnion) MarshalTo(data []byte) (n int, err error) {
 		data[i] = 0x1
 		i++
 		i = encodeVarintInternal(data, i, uint64(m.Batch.Size()))
-		n70, err := m.Batch.MarshalTo(data[i:])
+		n75, err := m.Batch.MarshalTo(data[i:])
 		if err != nil {
 			return 0, err
 		}
-		i += n70
+		i += n75
 	}
 	if m.InternalRangeLookup != nil {
 		data[i] = 0xfa
@@ -7271,11 +7718,11 @@ func (m *InternalRaftCommandUnion) MarshalTo(data []byte) (n int, err error) {
 		data[i] = 0x1
 		i++
 		i = encodeVarintInternal(data, i, uint64(m.InternalRangeLookup.Size()))
-		n71, err := m.InternalRangeLookup.MarshalTo(data[i:])
+		n76, err := m.InternalRangeLookup.MarshalTo(data[i:])
 		if err != nil {
 			return 0, err
 		}
-		i += n71
+		i += n76
 	}
 	if m.InternalHeartbeatTxn != nil {
 		data[i] = 0x82
@@ -7283,11 +7730,11 @@ func (m *InternalRaftCommandUnion) MarshalTo(data []byte) (n int, err error) {
 		data[i] = 0x2
 		i++
 		i = encodeVarintInternal(data, i, uint64(m.InternalHeartbeatTxn.Size()))
-		n72, err := m.InternalHeartbeatTxn.MarshalTo(data[i:])
+		n77, err := m.InternalHeartbeatTxn.MarshalTo(data[i:])
 		if err != nil {
 			return 0, err
 		}
-		i += n72
+		i += n77
 	}
 	if m.InternalPushTxn != nil {
 		data[i] = 0x8a
@@ -7295,11 +7742,11 @@ func (m *InternalRaftCommandUnion) MarshalTo(data []byte) (n int, err error) {
 		data[i] = 0x2
 		i++
 		i = encodeVarintInternal(data, i, uint64(m.InternalPushTxn.Size()))
-		n73, err := m.InternalPushTxn.MarshalTo(data[i:])
+		n78, err := m.InternalPushTxn.MarshalTo(data[i:])
 		if err != nil {
 			return 0, err
 		}
-		i += n73
+		i += n78
 	}
 	if m.InternalResolveIntent != nil {
 		data[i] = 0x92
@@ -7307,71 +7754,83 @@ func (m *InternalRaftCommandUnion) MarshalTo(data []byte) (n int, err error) {
 		data[i] = 0x2
 		i++
 		i = encodeVarintInternal(data, i, uint64(m.InternalResolveIntent.Size()))
-		n74, err := m.InternalResolveIntent.MarshalTo(data[i:])
-		if err != nil {
-			return 0, err
-		}
-		i += n74
-	}
-	if m.InternalMergeResponse != nil {
-		data[i] = 0x9a
-		i++
-		data[i] = 0x2
-		i++
-		i = encodeVarintInternal(data, i, uint64(m.InternalMergeResponse.Size()))
-		n75, err := m.InternalMergeResponse.MarshalTo(data[i:])
-		if err != nil {
-			return 0, err
-		}
-		i += n75
-	}
-	if m.InternalTruncateLog != nil {
-		data[i] = 0xa2
-		i++
-		data[i] = 0x2
-		i++
-		i = encodeVarintInternal(data, i, uint64(m.InternalTruncateLog.Size()))
-		n76, err := m.InternalTruncateLog.MarshalTo(data[i:])
-		if err != nil {
-			return 0, err
-		}
-		i += n76
-	}
-	if m.InternalGC != nil {
-		data[i] = 0xaa
-		i++
-		data[i] = 0x2
-		i++
-		i = encodeVarintInternal(data, i, uint64(m.InternalGC.Size()))
-		n77, err := m.InternalGC.MarshalTo(data[i:])
-		if err != nil {
-			return 0, err
-		}
-		i += n77
-	}
-	if m.InternalLease != nil {
-		data[i] = 0xb2
-		i++
-		data[i] = 0x2
-		i++
-		i = encodeVarintInternal(data, i, uint64(m.InternalLease.Size()))
-		n78, err := m.InternalLease.MarshalTo(data[i:])
-		if err != nil {
-			return 0, err
-		}
-		i += n78
-	}
-	if m.InternalBatch != nil {
-		data[i] = 0xba
-		i++
-		data[i] = 0x2
-		i++
-		i = encodeVarintInternal(data, i, uint64(m.InternalBatch.Size()))
-		n79, err := m.InternalBatch.MarshalTo(data[i:])
+		n79, err := m.InternalResolveIntent.MarshalTo(data[i:])
 		if err != nil {
 			return 0, err
 		}
 		i += n79
+	}
+	if m.InternalResolveIntentRange != nil {
+		data[i] = 0x9a
+		i++
+		data[i] = 0x2
+		i++
+		i = encodeVarintInternal(data, i, uint64(m.InternalResolveIntentRange.Size()))
+		n80, err := m.InternalResolveIntentRange.MarshalTo(data[i:])
+		if err != nil {
+			return 0, err
+		}
+		i += n80
+	}
+	if m.InternalMergeResponse != nil {
+		data[i] = 0xa2
+		i++
+		data[i] = 0x2
+		i++
+		i = encodeVarintInternal(data, i, uint64(m.InternalMergeResponse.Size()))
+		n81, err := m.InternalMergeResponse.MarshalTo(data[i:])
+		if err != nil {
+			return 0, err
+		}
+		i += n81
+	}
+	if m.InternalTruncateLog != nil {
+		data[i] = 0xaa
+		i++
+		data[i] = 0x2
+		i++
+		i = encodeVarintInternal(data, i, uint64(m.InternalTruncateLog.Size()))
+		n82, err := m.InternalTruncateLog.MarshalTo(data[i:])
+		if err != nil {
+			return 0, err
+		}
+		i += n82
+	}
+	if m.InternalGC != nil {
+		data[i] = 0xb2
+		i++
+		data[i] = 0x2
+		i++
+		i = encodeVarintInternal(data, i, uint64(m.InternalGC.Size()))
+		n83, err := m.InternalGC.MarshalTo(data[i:])
+		if err != nil {
+			return 0, err
+		}
+		i += n83
+	}
+	if m.InternalLease != nil {
+		data[i] = 0xba
+		i++
+		data[i] = 0x2
+		i++
+		i = encodeVarintInternal(data, i, uint64(m.InternalLease.Size()))
+		n84, err := m.InternalLease.MarshalTo(data[i:])
+		if err != nil {
+			return 0, err
+		}
+		i += n84
+	}
+	if m.InternalBatch != nil {
+		data[i] = 0xc2
+		i++
+		data[i] = 0x2
+		i++
+		i = encodeVarintInternal(data, i, uint64(m.InternalBatch.Size()))
+		n85, err := m.InternalBatch.MarshalTo(data[i:])
+		if err != nil {
+			return 0, err
+		}
+		i += n85
 	}
 	if m.XXX_unrecognized != nil {
 		i += copy(data[i:], m.XXX_unrecognized)
@@ -7403,11 +7862,11 @@ func (m *InternalRaftCommand) MarshalTo(data []byte) (n int, err error) {
 	data[i] = 0x1a
 	i++
 	i = encodeVarintInternal(data, i, uint64(m.Cmd.Size()))
-	n80, err := m.Cmd.MarshalTo(data[i:])
+	n86, err := m.Cmd.MarshalTo(data[i:])
 	if err != nil {
 		return 0, err
 	}
-	i += n80
+	i += n86
 	if m.XXX_unrecognized != nil {
 		i += copy(data[i:], m.XXX_unrecognized)
 	}

--- a/proto/internal.proto
+++ b/proto/internal.proto
@@ -161,6 +161,19 @@ message InternalResolveIntentResponse {
   optional ResponseHeader header = 1 [(gogoproto.nullable) = false, (gogoproto.embed) = true];
 }
 
+// An InternalResolveIntentRangeRequest is arguments to the
+// InternalResolveIntentRange() method. This clear write intents
+// for a range of keys to resolve intents created by range ops.
+message InternalResolveIntentRangeRequest {
+  optional RequestHeader header = 1 [(gogoproto.nullable) = false, (gogoproto.embed) = true];
+}
+
+// An InternalResolveIntentRangeResponse is the return value from the
+// InternalResolveIntent() method.
+message InternalResolveIntentRangeResponse {
+  optional ResponseHeader header = 1 [(gogoproto.nullable) = false, (gogoproto.embed) = true];
+}
+
 // An InternalMergeRequest contains arguments to the InternalMerge() method. It
 // specifies a key and a value which should be merged into the existing value at
 // that key.
@@ -222,6 +235,7 @@ message InternalRequestUnion {
 
     InternalPushTxnRequest internal_push_txn = 30;
     InternalResolveIntentRequest internal_resolve_intent = 31;
+    InternalResolveIntentRangeRequest internal_resolve_intent_range = 32;
 }
 }
 
@@ -242,6 +256,7 @@ message InternalResponseUnion {
 
     InternalPushTxnResponse internal_push_txn = 30;
     InternalResolveIntentResponse internal_resolve_intent = 31;
+    InternalResolveIntentRangeResponse internal_resolve_intent_range = 32;
   }
 }
 
@@ -277,10 +292,11 @@ message ReadWriteCmdResponse {
     InternalHeartbeatTxnResponse internal_heartbeat_txn = 10;
     InternalPushTxnResponse internal_push_txn = 11;
     InternalResolveIntentResponse internal_resolve_intent = 12;
-    InternalMergeResponse internal_merge = 13;
-    InternalTruncateLogResponse internal_truncate_log = 14;
-    InternalGCResponse internal_gc = 15;
-    InternalLeaderLeaseResponse internal_leader_lease = 16;
+    InternalResolveIntentRangeResponse internal_resolve_intent_range = 13;
+    InternalMergeResponse internal_merge = 14;
+    InternalTruncateLogResponse internal_truncate_log = 15;
+    InternalGCResponse internal_gc = 16;
+    InternalLeaderLeaseResponse internal_leader_lease = 17;
   }
 }
 
@@ -307,11 +323,12 @@ message InternalRaftCommandUnion {
     InternalHeartbeatTxnRequest internal_heartbeat_txn = 32;
     InternalPushTxnRequest internal_push_txn = 33;
     InternalResolveIntentRequest internal_resolve_intent = 34;
-    InternalMergeRequest internal_merge_response = 35;
-    InternalTruncateLogRequest internal_truncate_log = 36;
-    InternalGCRequest internal_gc = 37 [(gogoproto.customname) = "InternalGC"];
-    InternalLeaderLeaseRequest internal_lease = 38;
-    InternalBatchRequest internal_batch = 39;
+    InternalResolveIntentRangeRequest internal_resolve_intent_range = 35;
+    InternalMergeRequest internal_merge_response = 36;
+    InternalTruncateLogRequest internal_truncate_log = 37;
+    InternalGCRequest internal_gc = 38 [(gogoproto.customname) = "InternalGC"];
+    InternalLeaderLeaseRequest internal_lease = 39;
+    InternalBatchRequest internal_batch = 40;
   }
 }
 

--- a/proto/method.go
+++ b/proto/method.go
@@ -89,9 +89,10 @@ const (
 	// an error code either indicating the pusher must retry or abort and
 	// restart the transaction.
 	InternalPushTxn
-	// InternalResolveIntent resolves existing write intents for a key or
-	// key range.
+	// InternalResolveIntent resolves existing write intents for a key.
 	InternalResolveIntent
+	// InternalResolveIntentRange resolves existing write intents for a key range.
+	InternalResolveIntentRange
 	// InternalMerge merges a given value into the specified key. Merge is a
 	// high-performance operation provided by underlying data storage for values
 	// which are accumulated over several writes. Because it is not
@@ -111,25 +112,26 @@ const (
 
 // AllMethods is a map from string to method enum.
 var AllMethods = map[string]Method{
-	Contains.String():              Contains,
-	Get.String():                   Get,
-	Put.String():                   Put,
-	ConditionalPut.String():        ConditionalPut,
-	Increment.String():             Increment,
-	Delete.String():                Delete,
-	DeleteRange.String():           DeleteRange,
-	Scan.String():                  Scan,
-	EndTransaction.String():        EndTransaction,
-	Batch.String():                 Batch,
-	AdminSplit.String():            AdminSplit,
-	AdminMerge.String():            AdminMerge,
-	InternalRangeLookup.String():   InternalRangeLookup,
-	InternalHeartbeatTxn.String():  InternalHeartbeatTxn,
-	InternalGC.String():            InternalGC,
-	InternalPushTxn.String():       InternalPushTxn,
-	InternalResolveIntent.String(): InternalResolveIntent,
-	InternalMerge.String():         InternalMerge,
-	InternalTruncateLog.String():   InternalTruncateLog,
-	InternalLeaderLease.String():   InternalLeaderLease,
-	InternalBatch.String():         InternalBatch,
+	Contains.String():                   Contains,
+	Get.String():                        Get,
+	Put.String():                        Put,
+	ConditionalPut.String():             ConditionalPut,
+	Increment.String():                  Increment,
+	Delete.String():                     Delete,
+	DeleteRange.String():                DeleteRange,
+	Scan.String():                       Scan,
+	EndTransaction.String():             EndTransaction,
+	Batch.String():                      Batch,
+	AdminSplit.String():                 AdminSplit,
+	AdminMerge.String():                 AdminMerge,
+	InternalRangeLookup.String():        InternalRangeLookup,
+	InternalHeartbeatTxn.String():       InternalHeartbeatTxn,
+	InternalGC.String():                 InternalGC,
+	InternalPushTxn.String():            InternalPushTxn,
+	InternalResolveIntent.String():      InternalResolveIntent,
+	InternalResolveIntentRange.String(): InternalResolveIntentRange,
+	InternalMerge.String():              InternalMerge,
+	InternalTruncateLog.String():        InternalTruncateLog,
+	InternalLeaderLease.String():        InternalLeaderLease,
+	InternalBatch.String():              InternalBatch,
 }

--- a/proto/method_string.go
+++ b/proto/method_string.go
@@ -4,9 +4,9 @@ package proto
 
 import "fmt"
 
-const _Method_name = "ContainsGetPutConditionalPutIncrementDeleteDeleteRangeScanEndTransactionReapQueueEnqueueUpdateEnqueueMessageBatchAdminSplitAdminMergeInternalRangeLookupInternalHeartbeatTxnInternalGCInternalPushTxnInternalResolveIntentInternalMergeInternalTruncateLogInternalLeaderLeaseInternalBatch"
+const _Method_name = "ContainsGetPutConditionalPutIncrementDeleteDeleteRangeScanEndTransactionReapQueueEnqueueUpdateEnqueueMessageBatchAdminSplitAdminMergeInternalRangeLookupInternalHeartbeatTxnInternalGCInternalPushTxnInternalResolveIntentInternalResolveIntentRangeInternalMergeInternalTruncateLogInternalLeaderLeaseInternalBatch"
 
-var _Method_index = [...]uint16{0, 8, 11, 14, 28, 37, 43, 54, 58, 72, 81, 94, 108, 113, 123, 133, 152, 172, 182, 197, 218, 231, 250, 269, 282}
+var _Method_index = [...]uint16{0, 8, 11, 14, 28, 37, 43, 54, 58, 72, 81, 94, 108, 113, 123, 133, 152, 172, 182, 197, 218, 244, 257, 276, 295, 308}
 
 func (i Method) String() string {
 	if i < 0 || i+1 >= Method(len(_Method_index)) {

--- a/server/node.go
+++ b/server/node.go
@@ -588,6 +588,11 @@ func (n *nodeServer) InternalResolveIntent(args *proto.InternalResolveIntentRequ
 	return n.executeCmd(args, reply)
 }
 
+// InternalResolveIntentRange .
+func (n *nodeServer) InternalResolveIntentRange(args *proto.InternalResolveIntentRangeRequest, reply *proto.InternalResolveIntentRangeResponse) error {
+	return n.executeCmd(args, reply)
+}
+
 // InternalMerge .
 func (n *nodeServer) InternalMerge(args *proto.InternalMergeRequest, reply *proto.InternalMergeResponse) error {
 	return n.executeCmd(args, reply)

--- a/storage/client_event_test.go
+++ b/storage/client_event_test.go
@@ -55,7 +55,7 @@ func (ser *storeEventReader) recordEvent(event interface{}) {
 		eventStr = fmt.Sprintf("AddRange rid=%d, live=%d",
 			event.Desc.RaftID, event.Stats.LiveBytes)
 	case *storage.UpdateRangeEvent:
-		if event.Method == proto.InternalResolveIntent {
+		if event.Method == proto.InternalResolveIntent || event.Method == proto.InternalResolveIntentRange {
 			// InternalResolveIntent is a best effort call that seems to make
 			// this test flaky. Ignore them.
 			break

--- a/storage/engine/cockroach/proto/internal.pb.cc
+++ b/storage/engine/cockroach/proto/internal.pb.cc
@@ -54,6 +54,12 @@ const ::google::protobuf::internal::GeneratedMessageReflection*
 const ::google::protobuf::Descriptor* InternalResolveIntentResponse_descriptor_ = NULL;
 const ::google::protobuf::internal::GeneratedMessageReflection*
   InternalResolveIntentResponse_reflection_ = NULL;
+const ::google::protobuf::Descriptor* InternalResolveIntentRangeRequest_descriptor_ = NULL;
+const ::google::protobuf::internal::GeneratedMessageReflection*
+  InternalResolveIntentRangeRequest_reflection_ = NULL;
+const ::google::protobuf::Descriptor* InternalResolveIntentRangeResponse_descriptor_ = NULL;
+const ::google::protobuf::internal::GeneratedMessageReflection*
+  InternalResolveIntentRangeResponse_reflection_ = NULL;
 const ::google::protobuf::Descriptor* InternalMergeRequest_descriptor_ = NULL;
 const ::google::protobuf::internal::GeneratedMessageReflection*
   InternalMergeRequest_reflection_ = NULL;
@@ -87,6 +93,7 @@ struct InternalRequestUnionOneofInstance {
   const ::cockroach::proto::EndTransactionRequest* end_transaction_;
   const ::cockroach::proto::InternalPushTxnRequest* internal_push_txn_;
   const ::cockroach::proto::InternalResolveIntentRequest* internal_resolve_intent_;
+  const ::cockroach::proto::InternalResolveIntentRangeRequest* internal_resolve_intent_range_;
 }* InternalRequestUnion_default_oneof_instance_ = NULL;
 const ::google::protobuf::Descriptor* InternalResponseUnion_descriptor_ = NULL;
 const ::google::protobuf::internal::GeneratedMessageReflection*
@@ -103,6 +110,7 @@ struct InternalResponseUnionOneofInstance {
   const ::cockroach::proto::EndTransactionResponse* end_transaction_;
   const ::cockroach::proto::InternalPushTxnResponse* internal_push_txn_;
   const ::cockroach::proto::InternalResolveIntentResponse* internal_resolve_intent_;
+  const ::cockroach::proto::InternalResolveIntentRangeResponse* internal_resolve_intent_range_;
 }* InternalResponseUnion_default_oneof_instance_ = NULL;
 const ::google::protobuf::Descriptor* InternalBatchRequest_descriptor_ = NULL;
 const ::google::protobuf::internal::GeneratedMessageReflection*
@@ -123,6 +131,7 @@ struct ReadWriteCmdResponseOneofInstance {
   const ::cockroach::proto::InternalHeartbeatTxnResponse* internal_heartbeat_txn_;
   const ::cockroach::proto::InternalPushTxnResponse* internal_push_txn_;
   const ::cockroach::proto::InternalResolveIntentResponse* internal_resolve_intent_;
+  const ::cockroach::proto::InternalResolveIntentRangeResponse* internal_resolve_intent_range_;
   const ::cockroach::proto::InternalMergeResponse* internal_merge_;
   const ::cockroach::proto::InternalTruncateLogResponse* internal_truncate_log_;
   const ::cockroach::proto::InternalGCResponse* internal_gc_;
@@ -146,6 +155,7 @@ struct InternalRaftCommandUnionOneofInstance {
   const ::cockroach::proto::InternalHeartbeatTxnRequest* internal_heartbeat_txn_;
   const ::cockroach::proto::InternalPushTxnRequest* internal_push_txn_;
   const ::cockroach::proto::InternalResolveIntentRequest* internal_resolve_intent_;
+  const ::cockroach::proto::InternalResolveIntentRangeRequest* internal_resolve_intent_range_;
   const ::cockroach::proto::InternalMergeRequest* internal_merge_response_;
   const ::cockroach::proto::InternalTruncateLogRequest* internal_truncate_log_;
   const ::cockroach::proto::InternalGCRequest* internal_gc_;
@@ -363,7 +373,37 @@ void protobuf_AssignDesc_cockroach_2fproto_2finternal_2eproto() {
       ::google::protobuf::DescriptorPool::generated_pool(),
       ::google::protobuf::MessageFactory::generated_factory(),
       sizeof(InternalResolveIntentResponse));
-  InternalMergeRequest_descriptor_ = file->message_type(10);
+  InternalResolveIntentRangeRequest_descriptor_ = file->message_type(10);
+  static const int InternalResolveIntentRangeRequest_offsets_[1] = {
+    GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(InternalResolveIntentRangeRequest, header_),
+  };
+  InternalResolveIntentRangeRequest_reflection_ =
+    new ::google::protobuf::internal::GeneratedMessageReflection(
+      InternalResolveIntentRangeRequest_descriptor_,
+      InternalResolveIntentRangeRequest::default_instance_,
+      InternalResolveIntentRangeRequest_offsets_,
+      GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(InternalResolveIntentRangeRequest, _has_bits_[0]),
+      GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(InternalResolveIntentRangeRequest, _unknown_fields_),
+      -1,
+      ::google::protobuf::DescriptorPool::generated_pool(),
+      ::google::protobuf::MessageFactory::generated_factory(),
+      sizeof(InternalResolveIntentRangeRequest));
+  InternalResolveIntentRangeResponse_descriptor_ = file->message_type(11);
+  static const int InternalResolveIntentRangeResponse_offsets_[1] = {
+    GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(InternalResolveIntentRangeResponse, header_),
+  };
+  InternalResolveIntentRangeResponse_reflection_ =
+    new ::google::protobuf::internal::GeneratedMessageReflection(
+      InternalResolveIntentRangeResponse_descriptor_,
+      InternalResolveIntentRangeResponse::default_instance_,
+      InternalResolveIntentRangeResponse_offsets_,
+      GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(InternalResolveIntentRangeResponse, _has_bits_[0]),
+      GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(InternalResolveIntentRangeResponse, _unknown_fields_),
+      -1,
+      ::google::protobuf::DescriptorPool::generated_pool(),
+      ::google::protobuf::MessageFactory::generated_factory(),
+      sizeof(InternalResolveIntentRangeResponse));
+  InternalMergeRequest_descriptor_ = file->message_type(12);
   static const int InternalMergeRequest_offsets_[2] = {
     GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(InternalMergeRequest, header_),
     GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(InternalMergeRequest, value_),
@@ -379,7 +419,7 @@ void protobuf_AssignDesc_cockroach_2fproto_2finternal_2eproto() {
       ::google::protobuf::DescriptorPool::generated_pool(),
       ::google::protobuf::MessageFactory::generated_factory(),
       sizeof(InternalMergeRequest));
-  InternalMergeResponse_descriptor_ = file->message_type(11);
+  InternalMergeResponse_descriptor_ = file->message_type(13);
   static const int InternalMergeResponse_offsets_[1] = {
     GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(InternalMergeResponse, header_),
   };
@@ -394,7 +434,7 @@ void protobuf_AssignDesc_cockroach_2fproto_2finternal_2eproto() {
       ::google::protobuf::DescriptorPool::generated_pool(),
       ::google::protobuf::MessageFactory::generated_factory(),
       sizeof(InternalMergeResponse));
-  InternalTruncateLogRequest_descriptor_ = file->message_type(12);
+  InternalTruncateLogRequest_descriptor_ = file->message_type(14);
   static const int InternalTruncateLogRequest_offsets_[2] = {
     GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(InternalTruncateLogRequest, header_),
     GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(InternalTruncateLogRequest, index_),
@@ -410,7 +450,7 @@ void protobuf_AssignDesc_cockroach_2fproto_2finternal_2eproto() {
       ::google::protobuf::DescriptorPool::generated_pool(),
       ::google::protobuf::MessageFactory::generated_factory(),
       sizeof(InternalTruncateLogRequest));
-  InternalTruncateLogResponse_descriptor_ = file->message_type(13);
+  InternalTruncateLogResponse_descriptor_ = file->message_type(15);
   static const int InternalTruncateLogResponse_offsets_[1] = {
     GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(InternalTruncateLogResponse, header_),
   };
@@ -425,7 +465,7 @@ void protobuf_AssignDesc_cockroach_2fproto_2finternal_2eproto() {
       ::google::protobuf::DescriptorPool::generated_pool(),
       ::google::protobuf::MessageFactory::generated_factory(),
       sizeof(InternalTruncateLogResponse));
-  InternalLeaderLeaseRequest_descriptor_ = file->message_type(14);
+  InternalLeaderLeaseRequest_descriptor_ = file->message_type(16);
   static const int InternalLeaderLeaseRequest_offsets_[2] = {
     GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(InternalLeaderLeaseRequest, header_),
     GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(InternalLeaderLeaseRequest, lease_),
@@ -441,7 +481,7 @@ void protobuf_AssignDesc_cockroach_2fproto_2finternal_2eproto() {
       ::google::protobuf::DescriptorPool::generated_pool(),
       ::google::protobuf::MessageFactory::generated_factory(),
       sizeof(InternalLeaderLeaseRequest));
-  InternalLeaderLeaseResponse_descriptor_ = file->message_type(15);
+  InternalLeaderLeaseResponse_descriptor_ = file->message_type(17);
   static const int InternalLeaderLeaseResponse_offsets_[1] = {
     GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(InternalLeaderLeaseResponse, header_),
   };
@@ -456,8 +496,8 @@ void protobuf_AssignDesc_cockroach_2fproto_2finternal_2eproto() {
       ::google::protobuf::DescriptorPool::generated_pool(),
       ::google::protobuf::MessageFactory::generated_factory(),
       sizeof(InternalLeaderLeaseResponse));
-  InternalRequestUnion_descriptor_ = file->message_type(16);
-  static const int InternalRequestUnion_offsets_[12] = {
+  InternalRequestUnion_descriptor_ = file->message_type(18);
+  static const int InternalRequestUnion_offsets_[13] = {
     PROTO2_GENERATED_DEFAULT_ONEOF_FIELD_OFFSET(InternalRequestUnion_default_oneof_instance_, contains_),
     PROTO2_GENERATED_DEFAULT_ONEOF_FIELD_OFFSET(InternalRequestUnion_default_oneof_instance_, get_),
     PROTO2_GENERATED_DEFAULT_ONEOF_FIELD_OFFSET(InternalRequestUnion_default_oneof_instance_, put_),
@@ -469,6 +509,7 @@ void protobuf_AssignDesc_cockroach_2fproto_2finternal_2eproto() {
     PROTO2_GENERATED_DEFAULT_ONEOF_FIELD_OFFSET(InternalRequestUnion_default_oneof_instance_, end_transaction_),
     PROTO2_GENERATED_DEFAULT_ONEOF_FIELD_OFFSET(InternalRequestUnion_default_oneof_instance_, internal_push_txn_),
     PROTO2_GENERATED_DEFAULT_ONEOF_FIELD_OFFSET(InternalRequestUnion_default_oneof_instance_, internal_resolve_intent_),
+    PROTO2_GENERATED_DEFAULT_ONEOF_FIELD_OFFSET(InternalRequestUnion_default_oneof_instance_, internal_resolve_intent_range_),
     GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(InternalRequestUnion, value_),
   };
   InternalRequestUnion_reflection_ =
@@ -484,8 +525,8 @@ void protobuf_AssignDesc_cockroach_2fproto_2finternal_2eproto() {
       ::google::protobuf::DescriptorPool::generated_pool(),
       ::google::protobuf::MessageFactory::generated_factory(),
       sizeof(InternalRequestUnion));
-  InternalResponseUnion_descriptor_ = file->message_type(17);
-  static const int InternalResponseUnion_offsets_[12] = {
+  InternalResponseUnion_descriptor_ = file->message_type(19);
+  static const int InternalResponseUnion_offsets_[13] = {
     PROTO2_GENERATED_DEFAULT_ONEOF_FIELD_OFFSET(InternalResponseUnion_default_oneof_instance_, contains_),
     PROTO2_GENERATED_DEFAULT_ONEOF_FIELD_OFFSET(InternalResponseUnion_default_oneof_instance_, get_),
     PROTO2_GENERATED_DEFAULT_ONEOF_FIELD_OFFSET(InternalResponseUnion_default_oneof_instance_, put_),
@@ -497,6 +538,7 @@ void protobuf_AssignDesc_cockroach_2fproto_2finternal_2eproto() {
     PROTO2_GENERATED_DEFAULT_ONEOF_FIELD_OFFSET(InternalResponseUnion_default_oneof_instance_, end_transaction_),
     PROTO2_GENERATED_DEFAULT_ONEOF_FIELD_OFFSET(InternalResponseUnion_default_oneof_instance_, internal_push_txn_),
     PROTO2_GENERATED_DEFAULT_ONEOF_FIELD_OFFSET(InternalResponseUnion_default_oneof_instance_, internal_resolve_intent_),
+    PROTO2_GENERATED_DEFAULT_ONEOF_FIELD_OFFSET(InternalResponseUnion_default_oneof_instance_, internal_resolve_intent_range_),
     GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(InternalResponseUnion, value_),
   };
   InternalResponseUnion_reflection_ =
@@ -512,7 +554,7 @@ void protobuf_AssignDesc_cockroach_2fproto_2finternal_2eproto() {
       ::google::protobuf::DescriptorPool::generated_pool(),
       ::google::protobuf::MessageFactory::generated_factory(),
       sizeof(InternalResponseUnion));
-  InternalBatchRequest_descriptor_ = file->message_type(18);
+  InternalBatchRequest_descriptor_ = file->message_type(20);
   static const int InternalBatchRequest_offsets_[2] = {
     GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(InternalBatchRequest, header_),
     GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(InternalBatchRequest, requests_),
@@ -528,7 +570,7 @@ void protobuf_AssignDesc_cockroach_2fproto_2finternal_2eproto() {
       ::google::protobuf::DescriptorPool::generated_pool(),
       ::google::protobuf::MessageFactory::generated_factory(),
       sizeof(InternalBatchRequest));
-  InternalBatchResponse_descriptor_ = file->message_type(19);
+  InternalBatchResponse_descriptor_ = file->message_type(21);
   static const int InternalBatchResponse_offsets_[2] = {
     GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(InternalBatchResponse, header_),
     GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(InternalBatchResponse, responses_),
@@ -544,8 +586,8 @@ void protobuf_AssignDesc_cockroach_2fproto_2finternal_2eproto() {
       ::google::protobuf::DescriptorPool::generated_pool(),
       ::google::protobuf::MessageFactory::generated_factory(),
       sizeof(InternalBatchResponse));
-  ReadWriteCmdResponse_descriptor_ = file->message_type(20);
-  static const int ReadWriteCmdResponse_offsets_[14] = {
+  ReadWriteCmdResponse_descriptor_ = file->message_type(22);
+  static const int ReadWriteCmdResponse_offsets_[15] = {
     PROTO2_GENERATED_DEFAULT_ONEOF_FIELD_OFFSET(ReadWriteCmdResponse_default_oneof_instance_, put_),
     PROTO2_GENERATED_DEFAULT_ONEOF_FIELD_OFFSET(ReadWriteCmdResponse_default_oneof_instance_, conditional_put_),
     PROTO2_GENERATED_DEFAULT_ONEOF_FIELD_OFFSET(ReadWriteCmdResponse_default_oneof_instance_, increment_),
@@ -555,6 +597,7 @@ void protobuf_AssignDesc_cockroach_2fproto_2finternal_2eproto() {
     PROTO2_GENERATED_DEFAULT_ONEOF_FIELD_OFFSET(ReadWriteCmdResponse_default_oneof_instance_, internal_heartbeat_txn_),
     PROTO2_GENERATED_DEFAULT_ONEOF_FIELD_OFFSET(ReadWriteCmdResponse_default_oneof_instance_, internal_push_txn_),
     PROTO2_GENERATED_DEFAULT_ONEOF_FIELD_OFFSET(ReadWriteCmdResponse_default_oneof_instance_, internal_resolve_intent_),
+    PROTO2_GENERATED_DEFAULT_ONEOF_FIELD_OFFSET(ReadWriteCmdResponse_default_oneof_instance_, internal_resolve_intent_range_),
     PROTO2_GENERATED_DEFAULT_ONEOF_FIELD_OFFSET(ReadWriteCmdResponse_default_oneof_instance_, internal_merge_),
     PROTO2_GENERATED_DEFAULT_ONEOF_FIELD_OFFSET(ReadWriteCmdResponse_default_oneof_instance_, internal_truncate_log_),
     PROTO2_GENERATED_DEFAULT_ONEOF_FIELD_OFFSET(ReadWriteCmdResponse_default_oneof_instance_, internal_gc_),
@@ -574,8 +617,8 @@ void protobuf_AssignDesc_cockroach_2fproto_2finternal_2eproto() {
       ::google::protobuf::DescriptorPool::generated_pool(),
       ::google::protobuf::MessageFactory::generated_factory(),
       sizeof(ReadWriteCmdResponse));
-  InternalRaftCommandUnion_descriptor_ = file->message_type(21);
-  static const int InternalRaftCommandUnion_offsets_[20] = {
+  InternalRaftCommandUnion_descriptor_ = file->message_type(23);
+  static const int InternalRaftCommandUnion_offsets_[21] = {
     PROTO2_GENERATED_DEFAULT_ONEOF_FIELD_OFFSET(InternalRaftCommandUnion_default_oneof_instance_, contains_),
     PROTO2_GENERATED_DEFAULT_ONEOF_FIELD_OFFSET(InternalRaftCommandUnion_default_oneof_instance_, get_),
     PROTO2_GENERATED_DEFAULT_ONEOF_FIELD_OFFSET(InternalRaftCommandUnion_default_oneof_instance_, put_),
@@ -590,6 +633,7 @@ void protobuf_AssignDesc_cockroach_2fproto_2finternal_2eproto() {
     PROTO2_GENERATED_DEFAULT_ONEOF_FIELD_OFFSET(InternalRaftCommandUnion_default_oneof_instance_, internal_heartbeat_txn_),
     PROTO2_GENERATED_DEFAULT_ONEOF_FIELD_OFFSET(InternalRaftCommandUnion_default_oneof_instance_, internal_push_txn_),
     PROTO2_GENERATED_DEFAULT_ONEOF_FIELD_OFFSET(InternalRaftCommandUnion_default_oneof_instance_, internal_resolve_intent_),
+    PROTO2_GENERATED_DEFAULT_ONEOF_FIELD_OFFSET(InternalRaftCommandUnion_default_oneof_instance_, internal_resolve_intent_range_),
     PROTO2_GENERATED_DEFAULT_ONEOF_FIELD_OFFSET(InternalRaftCommandUnion_default_oneof_instance_, internal_merge_response_),
     PROTO2_GENERATED_DEFAULT_ONEOF_FIELD_OFFSET(InternalRaftCommandUnion_default_oneof_instance_, internal_truncate_log_),
     PROTO2_GENERATED_DEFAULT_ONEOF_FIELD_OFFSET(InternalRaftCommandUnion_default_oneof_instance_, internal_gc_),
@@ -610,7 +654,7 @@ void protobuf_AssignDesc_cockroach_2fproto_2finternal_2eproto() {
       ::google::protobuf::DescriptorPool::generated_pool(),
       ::google::protobuf::MessageFactory::generated_factory(),
       sizeof(InternalRaftCommandUnion));
-  InternalRaftCommand_descriptor_ = file->message_type(22);
+  InternalRaftCommand_descriptor_ = file->message_type(24);
   static const int InternalRaftCommand_offsets_[3] = {
     GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(InternalRaftCommand, raft_id_),
     GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(InternalRaftCommand, origin_node_id_),
@@ -627,7 +671,7 @@ void protobuf_AssignDesc_cockroach_2fproto_2finternal_2eproto() {
       ::google::protobuf::DescriptorPool::generated_pool(),
       ::google::protobuf::MessageFactory::generated_factory(),
       sizeof(InternalRaftCommand));
-  RaftMessageRequest_descriptor_ = file->message_type(23);
+  RaftMessageRequest_descriptor_ = file->message_type(25);
   static const int RaftMessageRequest_offsets_[2] = {
     GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(RaftMessageRequest, group_id_),
     GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(RaftMessageRequest, msg_),
@@ -643,7 +687,7 @@ void protobuf_AssignDesc_cockroach_2fproto_2finternal_2eproto() {
       ::google::protobuf::DescriptorPool::generated_pool(),
       ::google::protobuf::MessageFactory::generated_factory(),
       sizeof(RaftMessageRequest));
-  RaftMessageResponse_descriptor_ = file->message_type(24);
+  RaftMessageResponse_descriptor_ = file->message_type(26);
   static const int RaftMessageResponse_offsets_[1] = {
   };
   RaftMessageResponse_reflection_ =
@@ -657,7 +701,7 @@ void protobuf_AssignDesc_cockroach_2fproto_2finternal_2eproto() {
       ::google::protobuf::DescriptorPool::generated_pool(),
       ::google::protobuf::MessageFactory::generated_factory(),
       sizeof(RaftMessageResponse));
-  InternalTimeSeriesData_descriptor_ = file->message_type(25);
+  InternalTimeSeriesData_descriptor_ = file->message_type(27);
   static const int InternalTimeSeriesData_offsets_[3] = {
     GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(InternalTimeSeriesData, start_timestamp_nanos_),
     GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(InternalTimeSeriesData, sample_duration_nanos_),
@@ -674,7 +718,7 @@ void protobuf_AssignDesc_cockroach_2fproto_2finternal_2eproto() {
       ::google::protobuf::DescriptorPool::generated_pool(),
       ::google::protobuf::MessageFactory::generated_factory(),
       sizeof(InternalTimeSeriesData));
-  InternalTimeSeriesSample_descriptor_ = file->message_type(26);
+  InternalTimeSeriesSample_descriptor_ = file->message_type(28);
   static const int InternalTimeSeriesSample_offsets_[5] = {
     GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(InternalTimeSeriesSample, offset_),
     GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(InternalTimeSeriesSample, count_),
@@ -693,7 +737,7 @@ void protobuf_AssignDesc_cockroach_2fproto_2finternal_2eproto() {
       ::google::protobuf::DescriptorPool::generated_pool(),
       ::google::protobuf::MessageFactory::generated_factory(),
       sizeof(InternalTimeSeriesSample));
-  RaftTruncatedState_descriptor_ = file->message_type(27);
+  RaftTruncatedState_descriptor_ = file->message_type(29);
   static const int RaftTruncatedState_offsets_[2] = {
     GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(RaftTruncatedState, index_),
     GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(RaftTruncatedState, term_),
@@ -709,7 +753,7 @@ void protobuf_AssignDesc_cockroach_2fproto_2finternal_2eproto() {
       ::google::protobuf::DescriptorPool::generated_pool(),
       ::google::protobuf::MessageFactory::generated_factory(),
       sizeof(RaftTruncatedState));
-  RaftSnapshotData_descriptor_ = file->message_type(28);
+  RaftSnapshotData_descriptor_ = file->message_type(30);
   static const int RaftSnapshotData_offsets_[1] = {
     GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(RaftSnapshotData, kv_),
   };
@@ -777,6 +821,10 @@ void protobuf_RegisterTypes(const ::std::string&) {
   ::google::protobuf::MessageFactory::InternalRegisterGeneratedMessage(
     InternalResolveIntentResponse_descriptor_, &InternalResolveIntentResponse::default_instance());
   ::google::protobuf::MessageFactory::InternalRegisterGeneratedMessage(
+    InternalResolveIntentRangeRequest_descriptor_, &InternalResolveIntentRangeRequest::default_instance());
+  ::google::protobuf::MessageFactory::InternalRegisterGeneratedMessage(
+    InternalResolveIntentRangeResponse_descriptor_, &InternalResolveIntentRangeResponse::default_instance());
+  ::google::protobuf::MessageFactory::InternalRegisterGeneratedMessage(
     InternalMergeRequest_descriptor_, &InternalMergeRequest::default_instance());
   ::google::protobuf::MessageFactory::InternalRegisterGeneratedMessage(
     InternalMergeResponse_descriptor_, &InternalMergeResponse::default_instance());
@@ -843,6 +891,10 @@ void protobuf_ShutdownFile_cockroach_2fproto_2finternal_2eproto() {
   delete InternalResolveIntentRequest_reflection_;
   delete InternalResolveIntentResponse::default_instance_;
   delete InternalResolveIntentResponse_reflection_;
+  delete InternalResolveIntentRangeRequest::default_instance_;
+  delete InternalResolveIntentRangeRequest_reflection_;
+  delete InternalResolveIntentRangeResponse::default_instance_;
+  delete InternalResolveIntentRangeResponse_reflection_;
   delete InternalMergeRequest::default_instance_;
   delete InternalMergeRequest_reflection_;
   delete InternalMergeResponse::default_instance_;
@@ -938,140 +990,154 @@ void protobuf_AddDesc_cockroach_2fproto_2finternal_2eproto() {
     "ader\030\001 \001(\0132\036.cockroach.proto.RequestHead"
     "erB\010\310\336\037\000\320\336\037\001\"Z\n\035InternalResolveIntentRes"
     "ponse\0229\n\006header\030\001 \001(\0132\037.cockroach.proto."
-    "ResponseHeaderB\010\310\336\037\000\320\336\037\001\"}\n\024InternalMerg"
-    "eRequest\0228\n\006header\030\001 \001(\0132\036.cockroach.pro"
-    "to.RequestHeaderB\010\310\336\037\000\320\336\037\001\022+\n\005value\030\002 \001("
-    "\0132\026.cockroach.proto.ValueB\004\310\336\037\000\"R\n\025Inter"
-    "nalMergeResponse\0229\n\006header\030\001 \001(\0132\037.cockr"
-    "oach.proto.ResponseHeaderB\010\310\336\037\000\320\336\037\001\"k\n\032I"
-    "nternalTruncateLogRequest\0228\n\006header\030\001 \001("
-    "\0132\036.cockroach.proto.RequestHeaderB\010\310\336\037\000\320"
-    "\336\037\001\022\023\n\005index\030\002 \001(\004B\004\310\336\037\000\"X\n\033InternalTrun"
-    "cateLogResponse\0229\n\006header\030\001 \001(\0132\037.cockro"
-    "ach.proto.ResponseHeaderB\010\310\336\037\000\320\336\037\001\"\203\001\n\032I"
-    "nternalLeaderLeaseRequest\0228\n\006header\030\001 \001("
-    "\0132\036.cockroach.proto.RequestHeaderB\010\310\336\037\000\320"
-    "\336\037\001\022+\n\005lease\030\002 \001(\0132\026.cockroach.proto.Lea"
-    "seB\004\310\336\037\000\"X\n\033InternalLeaderLeaseResponse\022"
-    "9\n\006header\030\001 \001(\0132\037.cockroach.proto.Respon"
-    "seHeaderB\010\310\336\037\000\320\336\037\001\"\246\005\n\024InternalRequestUn"
-    "ion\0224\n\010contains\030\001 \001(\0132 .cockroach.proto."
-    "ContainsRequestH\000\022*\n\003get\030\002 \001(\0132\033.cockroa"
-    "ch.proto.GetRequestH\000\022*\n\003put\030\003 \001(\0132\033.coc"
-    "kroach.proto.PutRequestH\000\022A\n\017conditional"
-    "_put\030\004 \001(\0132&.cockroach.proto.Conditional"
-    "PutRequestH\000\0226\n\tincrement\030\005 \001(\0132!.cockro"
-    "ach.proto.IncrementRequestH\000\0220\n\006delete\030\006"
-    " \001(\0132\036.cockroach.proto.DeleteRequestH\000\022;"
-    "\n\014delete_range\030\007 \001(\0132#.cockroach.proto.D"
-    "eleteRangeRequestH\000\022,\n\004scan\030\010 \001(\0132\034.cock"
-    "roach.proto.ScanRequestH\000\022A\n\017end_transac"
-    "tion\030\t \001(\0132&.cockroach.proto.EndTransact"
-    "ionRequestH\000\022D\n\021internal_push_txn\030\036 \001(\0132"
-    "\'.cockroach.proto.InternalPushTxnRequest"
-    "H\000\022P\n\027internal_resolve_intent\030\037 \001(\0132-.co"
-    "ckroach.proto.InternalResolveIntentReque"
-    "stH\000:\004\310\240\037\001B\007\n\005value\"\262\005\n\025InternalResponse"
-    "Union\0225\n\010contains\030\001 \001(\0132!.cockroach.prot"
-    "o.ContainsResponseH\000\022+\n\003get\030\002 \001(\0132\034.cock"
-    "roach.proto.GetResponseH\000\022+\n\003put\030\003 \001(\0132\034"
-    ".cockroach.proto.PutResponseH\000\022B\n\017condit"
-    "ional_put\030\004 \001(\0132\'.cockroach.proto.Condit"
-    "ionalPutResponseH\000\0227\n\tincrement\030\005 \001(\0132\"."
-    "cockroach.proto.IncrementResponseH\000\0221\n\006d"
-    "elete\030\006 \001(\0132\037.cockroach.proto.DeleteResp"
-    "onseH\000\022<\n\014delete_range\030\007 \001(\0132$.cockroach"
-    ".proto.DeleteRangeResponseH\000\022-\n\004scan\030\010 \001"
-    "(\0132\035.cockroach.proto.ScanResponseH\000\022B\n\017e"
-    "nd_transaction\030\t \001(\0132\'.cockroach.proto.E"
-    "ndTransactionResponseH\000\022E\n\021internal_push"
-    "_txn\030\036 \001(\0132(.cockroach.proto.InternalPus"
-    "hTxnResponseH\000\022Q\n\027internal_resolve_inten"
-    "t\030\037 \001(\0132..cockroach.proto.InternalResolv"
-    "eIntentResponseH\000:\004\310\240\037\001B\007\n\005value\"\217\001\n\024Int"
-    "ernalBatchRequest\0228\n\006header\030\001 \001(\0132\036.cock"
-    "roach.proto.RequestHeaderB\010\310\336\037\000\320\336\037\001\022=\n\010r"
-    "equests\030\002 \003(\0132%.cockroach.proto.Internal"
-    "RequestUnionB\004\310\336\037\000\"\223\001\n\025InternalBatchResp"
-    "onse\0229\n\006header\030\001 \001(\0132\037.cockroach.proto.R"
-    "esponseHeaderB\010\310\336\037\000\320\336\037\001\022\?\n\tresponses\030\002 \003"
-    "(\0132&.cockroach.proto.InternalResponseUni"
-    "onB\004\310\336\037\000\"\213\007\n\024ReadWriteCmdResponse\022+\n\003put"
-    "\030\001 \001(\0132\034.cockroach.proto.PutResponseH\000\022B"
-    "\n\017conditional_put\030\002 \001(\0132\'.cockroach.prot"
-    "o.ConditionalPutResponseH\000\0227\n\tincrement\030"
-    "\003 \001(\0132\".cockroach.proto.IncrementRespons"
-    "eH\000\0221\n\006delete\030\004 \001(\0132\037.cockroach.proto.De"
-    "leteResponseH\000\022<\n\014delete_range\030\005 \001(\0132$.c"
-    "ockroach.proto.DeleteRangeResponseH\000\022B\n\017"
-    "end_transaction\030\006 \001(\0132\'.cockroach.proto."
-    "EndTransactionResponseH\000\022O\n\026internal_hea"
-    "rtbeat_txn\030\n \001(\0132-.cockroach.proto.Inter"
-    "nalHeartbeatTxnResponseH\000\022E\n\021internal_pu"
-    "sh_txn\030\013 \001(\0132(.cockroach.proto.InternalP"
-    "ushTxnResponseH\000\022Q\n\027internal_resolve_int"
-    "ent\030\014 \001(\0132..cockroach.proto.InternalReso"
-    "lveIntentResponseH\000\022@\n\016internal_merge\030\r "
-    "\001(\0132&.cockroach.proto.InternalMergeRespo"
-    "nseH\000\022M\n\025internal_truncate_log\030\016 \001(\0132,.c"
-    "ockroach.proto.InternalTruncateLogRespon"
-    "seH\000\022:\n\013internal_gc\030\017 \001(\0132#.cockroach.pr"
-    "oto.InternalGCResponseH\000\022M\n\025internal_lea"
-    "der_lease\030\020 \001(\0132,.cockroach.proto.Intern"
-    "alLeaderLeaseResponseH\000:\004\310\240\037\001B\007\n\005value\"\343"
-    "\t\n\030InternalRaftCommandUnion\0224\n\010contains\030"
-    "\001 \001(\0132 .cockroach.proto.ContainsRequestH"
-    "\000\022*\n\003get\030\002 \001(\0132\033.cockroach.proto.GetRequ"
-    "estH\000\022*\n\003put\030\003 \001(\0132\033.cockroach.proto.Put"
-    "RequestH\000\022A\n\017conditional_put\030\004 \001(\0132&.coc"
-    "kroach.proto.ConditionalPutRequestH\000\0226\n\t"
-    "increment\030\005 \001(\0132!.cockroach.proto.Increm"
-    "entRequestH\000\0220\n\006delete\030\006 \001(\0132\036.cockroach"
-    ".proto.DeleteRequestH\000\022;\n\014delete_range\030\007"
-    " \001(\0132#.cockroach.proto.DeleteRangeReques"
-    "tH\000\022,\n\004scan\030\010 \001(\0132\034.cockroach.proto.Scan"
-    "RequestH\000\022A\n\017end_transaction\030\t \001(\0132&.coc"
-    "kroach.proto.EndTransactionRequestH\000\022.\n\005"
-    "batch\030\036 \001(\0132\035.cockroach.proto.BatchReque"
-    "stH\000\022L\n\025internal_range_lookup\030\037 \001(\0132+.co"
-    "ckroach.proto.InternalRangeLookupRequest"
-    "H\000\022N\n\026internal_heartbeat_txn\030  \001(\0132,.coc"
-    "kroach.proto.InternalHeartbeatTxnRequest"
-    "H\000\022D\n\021internal_push_txn\030! \001(\0132\'.cockroac"
-    "h.proto.InternalPushTxnRequestH\000\022P\n\027inte"
-    "rnal_resolve_intent\030\" \001(\0132-.cockroach.pr"
-    "oto.InternalResolveIntentRequestH\000\022H\n\027in"
-    "ternal_merge_response\030# \001(\0132%.cockroach."
-    "proto.InternalMergeRequestH\000\022L\n\025internal"
-    "_truncate_log\030$ \001(\0132+.cockroach.proto.In"
-    "ternalTruncateLogRequestH\000\022I\n\013internal_g"
-    "c\030% \001(\0132\".cockroach.proto.InternalGCRequ"
-    "estB\016\342\336\037\nInternalGCH\000\022E\n\016internal_lease\030"
-    "& \001(\0132+.cockroach.proto.InternalLeaderLe"
-    "aseRequestH\000\022\?\n\016internal_batch\030\' \001(\0132%.c"
-    "ockroach.proto.InternalBatchRequestH\000:\004\310"
-    "\240\037\001B\007\n\005value\"\242\001\n\023InternalRaftCommand\022\037\n\007"
-    "raft_id\030\001 \001(\003B\016\310\336\037\000\342\336\037\006RaftID\022,\n\016origin_"
-    "node_id\030\002 \001(\004B\024\310\336\037\000\342\336\037\014OriginNodeID\022<\n\003c"
-    "md\030\003 \001(\0132).cockroach.proto.InternalRaftC"
-    "ommandUnionB\004\310\336\037\000\"D\n\022RaftMessageRequest\022"
-    "!\n\010group_id\030\001 \001(\004B\017\310\336\037\000\342\336\037\007GroupID\022\013\n\003ms"
-    "g\030\002 \001(\014\"\025\n\023RaftMessageResponse\"\236\001\n\026Inter"
-    "nalTimeSeriesData\022#\n\025start_timestamp_nan"
-    "os\030\001 \001(\003B\004\310\336\037\000\022#\n\025sample_duration_nanos\030"
-    "\002 \001(\003B\004\310\336\037\000\022:\n\007samples\030\003 \003(\0132).cockroach"
-    ".proto.InternalTimeSeriesSample\"r\n\030Inter"
-    "nalTimeSeriesSample\022\024\n\006offset\030\001 \001(\005B\004\310\336\037"
-    "\000\022\023\n\005count\030\006 \001(\rB\004\310\336\037\000\022\021\n\003sum\030\007 \001(\001B\004\310\336\037"
-    "\000\022\013\n\003max\030\010 \001(\001\022\013\n\003min\030\t \001(\001\"=\n\022RaftTrunc"
-    "atedState\022\023\n\005index\030\001 \001(\004B\004\310\336\037\000\022\022\n\004term\030\002"
-    " \001(\004B\004\310\336\037\000\"z\n\020RaftSnapshotData\022>\n\002KV\030\001 \003"
-    "(\0132*.cockroach.proto.RaftSnapshotData.Ke"
-    "yValueB\006\342\336\037\002KV\032&\n\010KeyValue\022\013\n\003key\030\001 \001(\014\022"
-    "\r\n\005value\030\002 \001(\014*G\n\013PushTxnType\022\022\n\016PUSH_TI"
-    "MESTAMP\020\000\022\r\n\tABORT_TXN\020\001\022\017\n\013CLEANUP_TXN\020"
-    "\002\032\004\210\243\036\000*%\n\021InternalValueType\022\n\n\006_CR_TS\020\001"
-    "\032\004\210\243\036\000B\023Z\005proto\340\342\036\001\310\342\036\001\320\342\036\001", 6867);
+    "ResponseHeaderB\010\310\336\037\000\320\336\037\001\"]\n!InternalReso"
+    "lveIntentRangeRequest\0228\n\006header\030\001 \001(\0132\036."
+    "cockroach.proto.RequestHeaderB\010\310\336\037\000\320\336\037\001\""
+    "_\n\"InternalResolveIntentRangeResponse\0229\n"
+    "\006header\030\001 \001(\0132\037.cockroach.proto.Response"
+    "HeaderB\010\310\336\037\000\320\336\037\001\"}\n\024InternalMergeRequest"
+    "\0228\n\006header\030\001 \001(\0132\036.cockroach.proto.Reque"
+    "stHeaderB\010\310\336\037\000\320\336\037\001\022+\n\005value\030\002 \001(\0132\026.cock"
+    "roach.proto.ValueB\004\310\336\037\000\"R\n\025InternalMerge"
+    "Response\0229\n\006header\030\001 \001(\0132\037.cockroach.pro"
+    "to.ResponseHeaderB\010\310\336\037\000\320\336\037\001\"k\n\032InternalT"
+    "runcateLogRequest\0228\n\006header\030\001 \001(\0132\036.cock"
+    "roach.proto.RequestHeaderB\010\310\336\037\000\320\336\037\001\022\023\n\005i"
+    "ndex\030\002 \001(\004B\004\310\336\037\000\"X\n\033InternalTruncateLogR"
+    "esponse\0229\n\006header\030\001 \001(\0132\037.cockroach.prot"
+    "o.ResponseHeaderB\010\310\336\037\000\320\336\037\001\"\203\001\n\032InternalL"
+    "eaderLeaseRequest\0228\n\006header\030\001 \001(\0132\036.cock"
+    "roach.proto.RequestHeaderB\010\310\336\037\000\320\336\037\001\022+\n\005l"
+    "ease\030\002 \001(\0132\026.cockroach.proto.LeaseB\004\310\336\037\000"
+    "\"X\n\033InternalLeaderLeaseResponse\0229\n\006heade"
+    "r\030\001 \001(\0132\037.cockroach.proto.ResponseHeader"
+    "B\010\310\336\037\000\320\336\037\001\"\203\006\n\024InternalRequestUnion\0224\n\010c"
+    "ontains\030\001 \001(\0132 .cockroach.proto.Contains"
+    "RequestH\000\022*\n\003get\030\002 \001(\0132\033.cockroach.proto"
+    ".GetRequestH\000\022*\n\003put\030\003 \001(\0132\033.cockroach.p"
+    "roto.PutRequestH\000\022A\n\017conditional_put\030\004 \001"
+    "(\0132&.cockroach.proto.ConditionalPutReque"
+    "stH\000\0226\n\tincrement\030\005 \001(\0132!.cockroach.prot"
+    "o.IncrementRequestH\000\0220\n\006delete\030\006 \001(\0132\036.c"
+    "ockroach.proto.DeleteRequestH\000\022;\n\014delete"
+    "_range\030\007 \001(\0132#.cockroach.proto.DeleteRan"
+    "geRequestH\000\022,\n\004scan\030\010 \001(\0132\034.cockroach.pr"
+    "oto.ScanRequestH\000\022A\n\017end_transaction\030\t \001"
+    "(\0132&.cockroach.proto.EndTransactionReque"
+    "stH\000\022D\n\021internal_push_txn\030\036 \001(\0132\'.cockro"
+    "ach.proto.InternalPushTxnRequestH\000\022P\n\027in"
+    "ternal_resolve_intent\030\037 \001(\0132-.cockroach."
+    "proto.InternalResolveIntentRequestH\000\022[\n\035"
+    "internal_resolve_intent_range\030  \001(\01322.co"
+    "ckroach.proto.InternalResolveIntentRange"
+    "RequestH\000:\004\310\240\037\001B\007\n\005value\"\220\006\n\025InternalRes"
+    "ponseUnion\0225\n\010contains\030\001 \001(\0132!.cockroach"
+    ".proto.ContainsResponseH\000\022+\n\003get\030\002 \001(\0132\034"
+    ".cockroach.proto.GetResponseH\000\022+\n\003put\030\003 "
+    "\001(\0132\034.cockroach.proto.PutResponseH\000\022B\n\017c"
+    "onditional_put\030\004 \001(\0132\'.cockroach.proto.C"
+    "onditionalPutResponseH\000\0227\n\tincrement\030\005 \001"
+    "(\0132\".cockroach.proto.IncrementResponseH\000"
+    "\0221\n\006delete\030\006 \001(\0132\037.cockroach.proto.Delet"
+    "eResponseH\000\022<\n\014delete_range\030\007 \001(\0132$.cock"
+    "roach.proto.DeleteRangeResponseH\000\022-\n\004sca"
+    "n\030\010 \001(\0132\035.cockroach.proto.ScanResponseH\000"
+    "\022B\n\017end_transaction\030\t \001(\0132\'.cockroach.pr"
+    "oto.EndTransactionResponseH\000\022E\n\021internal"
+    "_push_txn\030\036 \001(\0132(.cockroach.proto.Intern"
+    "alPushTxnResponseH\000\022Q\n\027internal_resolve_"
+    "intent\030\037 \001(\0132..cockroach.proto.InternalR"
+    "esolveIntentResponseH\000\022\\\n\035internal_resol"
+    "ve_intent_range\030  \001(\01323.cockroach.proto."
+    "InternalResolveIntentRangeResponseH\000:\004\310\240"
+    "\037\001B\007\n\005value\"\217\001\n\024InternalBatchRequest\0228\n\006"
+    "header\030\001 \001(\0132\036.cockroach.proto.RequestHe"
+    "aderB\010\310\336\037\000\320\336\037\001\022=\n\010requests\030\002 \003(\0132%.cockr"
+    "oach.proto.InternalRequestUnionB\004\310\336\037\000\"\223\001"
+    "\n\025InternalBatchResponse\0229\n\006header\030\001 \001(\0132"
+    "\037.cockroach.proto.ResponseHeaderB\010\310\336\037\000\320\336"
+    "\037\001\022\?\n\tresponses\030\002 \003(\0132&.cockroach.proto."
+    "InternalResponseUnionB\004\310\336\037\000\"\351\007\n\024ReadWrit"
+    "eCmdResponse\022+\n\003put\030\001 \001(\0132\034.cockroach.pr"
+    "oto.PutResponseH\000\022B\n\017conditional_put\030\002 \001"
+    "(\0132\'.cockroach.proto.ConditionalPutRespo"
+    "nseH\000\0227\n\tincrement\030\003 \001(\0132\".cockroach.pro"
+    "to.IncrementResponseH\000\0221\n\006delete\030\004 \001(\0132\037"
+    ".cockroach.proto.DeleteResponseH\000\022<\n\014del"
+    "ete_range\030\005 \001(\0132$.cockroach.proto.Delete"
+    "RangeResponseH\000\022B\n\017end_transaction\030\006 \001(\013"
+    "2\'.cockroach.proto.EndTransactionRespons"
+    "eH\000\022O\n\026internal_heartbeat_txn\030\n \001(\0132-.co"
+    "ckroach.proto.InternalHeartbeatTxnRespon"
+    "seH\000\022E\n\021internal_push_txn\030\013 \001(\0132(.cockro"
+    "ach.proto.InternalPushTxnResponseH\000\022Q\n\027i"
+    "nternal_resolve_intent\030\014 \001(\0132..cockroach"
+    ".proto.InternalResolveIntentResponseH\000\022\\"
+    "\n\035internal_resolve_intent_range\030\r \001(\01323."
+    "cockroach.proto.InternalResolveIntentRan"
+    "geResponseH\000\022@\n\016internal_merge\030\016 \001(\0132&.c"
+    "ockroach.proto.InternalMergeResponseH\000\022M"
+    "\n\025internal_truncate_log\030\017 \001(\0132,.cockroac"
+    "h.proto.InternalTruncateLogResponseH\000\022:\n"
+    "\013internal_gc\030\020 \001(\0132#.cockroach.proto.Int"
+    "ernalGCResponseH\000\022M\n\025internal_leader_lea"
+    "se\030\021 \001(\0132,.cockroach.proto.InternalLeade"
+    "rLeaseResponseH\000:\004\310\240\037\001B\007\n\005value\"\300\n\n\030Inte"
+    "rnalRaftCommandUnion\0224\n\010contains\030\001 \001(\0132 "
+    ".cockroach.proto.ContainsRequestH\000\022*\n\003ge"
+    "t\030\002 \001(\0132\033.cockroach.proto.GetRequestH\000\022*"
+    "\n\003put\030\003 \001(\0132\033.cockroach.proto.PutRequest"
+    "H\000\022A\n\017conditional_put\030\004 \001(\0132&.cockroach."
+    "proto.ConditionalPutRequestH\000\0226\n\tincreme"
+    "nt\030\005 \001(\0132!.cockroach.proto.IncrementRequ"
+    "estH\000\0220\n\006delete\030\006 \001(\0132\036.cockroach.proto."
+    "DeleteRequestH\000\022;\n\014delete_range\030\007 \001(\0132#."
+    "cockroach.proto.DeleteRangeRequestH\000\022,\n\004"
+    "scan\030\010 \001(\0132\034.cockroach.proto.ScanRequest"
+    "H\000\022A\n\017end_transaction\030\t \001(\0132&.cockroach."
+    "proto.EndTransactionRequestH\000\022.\n\005batch\030\036"
+    " \001(\0132\035.cockroach.proto.BatchRequestH\000\022L\n"
+    "\025internal_range_lookup\030\037 \001(\0132+.cockroach"
+    ".proto.InternalRangeLookupRequestH\000\022N\n\026i"
+    "nternal_heartbeat_txn\030  \001(\0132,.cockroach."
+    "proto.InternalHeartbeatTxnRequestH\000\022D\n\021i"
+    "nternal_push_txn\030! \001(\0132\'.cockroach.proto"
+    ".InternalPushTxnRequestH\000\022P\n\027internal_re"
+    "solve_intent\030\" \001(\0132-.cockroach.proto.Int"
+    "ernalResolveIntentRequestH\000\022[\n\035internal_"
+    "resolve_intent_range\030# \001(\01322.cockroach.p"
+    "roto.InternalResolveIntentRangeRequestH\000"
+    "\022H\n\027internal_merge_response\030$ \001(\0132%.cock"
+    "roach.proto.InternalMergeRequestH\000\022L\n\025in"
+    "ternal_truncate_log\030% \001(\0132+.cockroach.pr"
+    "oto.InternalTruncateLogRequestH\000\022I\n\013inte"
+    "rnal_gc\030& \001(\0132\".cockroach.proto.Internal"
+    "GCRequestB\016\342\336\037\nInternalGCH\000\022E\n\016internal_"
+    "lease\030\' \001(\0132+.cockroach.proto.InternalLe"
+    "aderLeaseRequestH\000\022\?\n\016internal_batch\030( \001"
+    "(\0132%.cockroach.proto.InternalBatchReques"
+    "tH\000:\004\310\240\037\001B\007\n\005value\"\242\001\n\023InternalRaftComma"
+    "nd\022\037\n\007raft_id\030\001 \001(\003B\016\310\336\037\000\342\336\037\006RaftID\022,\n\016o"
+    "rigin_node_id\030\002 \001(\004B\024\310\336\037\000\342\336\037\014OriginNodeI"
+    "D\022<\n\003cmd\030\003 \001(\0132).cockroach.proto.Interna"
+    "lRaftCommandUnionB\004\310\336\037\000\"D\n\022RaftMessageRe"
+    "quest\022!\n\010group_id\030\001 \001(\004B\017\310\336\037\000\342\336\037\007GroupID"
+    "\022\013\n\003msg\030\002 \001(\014\"\025\n\023RaftMessageResponse\"\236\001\n"
+    "\026InternalTimeSeriesData\022#\n\025start_timesta"
+    "mp_nanos\030\001 \001(\003B\004\310\336\037\000\022#\n\025sample_duration_"
+    "nanos\030\002 \001(\003B\004\310\336\037\000\022:\n\007samples\030\003 \003(\0132).coc"
+    "kroach.proto.InternalTimeSeriesSample\"r\n"
+    "\030InternalTimeSeriesSample\022\024\n\006offset\030\001 \001("
+    "\005B\004\310\336\037\000\022\023\n\005count\030\006 \001(\rB\004\310\336\037\000\022\021\n\003sum\030\007 \001("
+    "\001B\004\310\336\037\000\022\013\n\003max\030\010 \001(\001\022\013\n\003min\030\t \001(\001\"=\n\022Raf"
+    "tTruncatedState\022\023\n\005index\030\001 \001(\004B\004\310\336\037\000\022\022\n\004"
+    "term\030\002 \001(\004B\004\310\336\037\000\"z\n\020RaftSnapshotData\022>\n\002"
+    "KV\030\001 \003(\0132*.cockroach.proto.RaftSnapshotD"
+    "ata.KeyValueB\006\342\336\037\002KV\032&\n\010KeyValue\022\013\n\003key\030"
+    "\001 \001(\014\022\r\n\005value\030\002 \001(\014*G\n\013PushTxnType\022\022\n\016P"
+    "USH_TIMESTAMP\020\000\022\r\n\tABORT_TXN\020\001\022\017\n\013CLEANU"
+    "P_TXN\020\002\032\004\210\243\036\000*%\n\021InternalValueType\022\n\n\006_C"
+    "R_TS\020\001\032\004\210\243\036\000B\023Z\005proto\340\342\036\001\310\342\036\001\320\342\036\001", 7433);
   ::google::protobuf::MessageFactory::InternalRegisterGeneratedFile(
     "cockroach/proto/internal.proto", &protobuf_RegisterTypes);
   InternalRangeLookupRequest::default_instance_ = new InternalRangeLookupRequest();
@@ -1085,6 +1151,8 @@ void protobuf_AddDesc_cockroach_2fproto_2finternal_2eproto() {
   InternalPushTxnResponse::default_instance_ = new InternalPushTxnResponse();
   InternalResolveIntentRequest::default_instance_ = new InternalResolveIntentRequest();
   InternalResolveIntentResponse::default_instance_ = new InternalResolveIntentResponse();
+  InternalResolveIntentRangeRequest::default_instance_ = new InternalResolveIntentRangeRequest();
+  InternalResolveIntentRangeResponse::default_instance_ = new InternalResolveIntentRangeResponse();
   InternalMergeRequest::default_instance_ = new InternalMergeRequest();
   InternalMergeResponse::default_instance_ = new InternalMergeResponse();
   InternalTruncateLogRequest::default_instance_ = new InternalTruncateLogRequest();
@@ -1120,6 +1188,8 @@ void protobuf_AddDesc_cockroach_2fproto_2finternal_2eproto() {
   InternalPushTxnResponse::default_instance_->InitAsDefaultInstance();
   InternalResolveIntentRequest::default_instance_->InitAsDefaultInstance();
   InternalResolveIntentResponse::default_instance_->InitAsDefaultInstance();
+  InternalResolveIntentRangeRequest::default_instance_->InitAsDefaultInstance();
+  InternalResolveIntentRangeResponse::default_instance_->InitAsDefaultInstance();
   InternalMergeRequest::default_instance_->InitAsDefaultInstance();
   InternalMergeResponse::default_instance_->InitAsDefaultInstance();
   InternalTruncateLogRequest::default_instance_->InitAsDefaultInstance();
@@ -4130,6 +4200,460 @@ void InternalResolveIntentResponse::Swap(InternalResolveIntentResponse* other) {
 // ===================================================================
 
 #ifndef _MSC_VER
+const int InternalResolveIntentRangeRequest::kHeaderFieldNumber;
+#endif  // !_MSC_VER
+
+InternalResolveIntentRangeRequest::InternalResolveIntentRangeRequest()
+  : ::google::protobuf::Message() {
+  SharedCtor();
+  // @@protoc_insertion_point(constructor:cockroach.proto.InternalResolveIntentRangeRequest)
+}
+
+void InternalResolveIntentRangeRequest::InitAsDefaultInstance() {
+  header_ = const_cast< ::cockroach::proto::RequestHeader*>(&::cockroach::proto::RequestHeader::default_instance());
+}
+
+InternalResolveIntentRangeRequest::InternalResolveIntentRangeRequest(const InternalResolveIntentRangeRequest& from)
+  : ::google::protobuf::Message() {
+  SharedCtor();
+  MergeFrom(from);
+  // @@protoc_insertion_point(copy_constructor:cockroach.proto.InternalResolveIntentRangeRequest)
+}
+
+void InternalResolveIntentRangeRequest::SharedCtor() {
+  _cached_size_ = 0;
+  header_ = NULL;
+  ::memset(_has_bits_, 0, sizeof(_has_bits_));
+}
+
+InternalResolveIntentRangeRequest::~InternalResolveIntentRangeRequest() {
+  // @@protoc_insertion_point(destructor:cockroach.proto.InternalResolveIntentRangeRequest)
+  SharedDtor();
+}
+
+void InternalResolveIntentRangeRequest::SharedDtor() {
+  if (this != default_instance_) {
+    delete header_;
+  }
+}
+
+void InternalResolveIntentRangeRequest::SetCachedSize(int size) const {
+  GOOGLE_SAFE_CONCURRENT_WRITES_BEGIN();
+  _cached_size_ = size;
+  GOOGLE_SAFE_CONCURRENT_WRITES_END();
+}
+const ::google::protobuf::Descriptor* InternalResolveIntentRangeRequest::descriptor() {
+  protobuf_AssignDescriptorsOnce();
+  return InternalResolveIntentRangeRequest_descriptor_;
+}
+
+const InternalResolveIntentRangeRequest& InternalResolveIntentRangeRequest::default_instance() {
+  if (default_instance_ == NULL) protobuf_AddDesc_cockroach_2fproto_2finternal_2eproto();
+  return *default_instance_;
+}
+
+InternalResolveIntentRangeRequest* InternalResolveIntentRangeRequest::default_instance_ = NULL;
+
+InternalResolveIntentRangeRequest* InternalResolveIntentRangeRequest::New() const {
+  return new InternalResolveIntentRangeRequest;
+}
+
+void InternalResolveIntentRangeRequest::Clear() {
+  if (has_header()) {
+    if (header_ != NULL) header_->::cockroach::proto::RequestHeader::Clear();
+  }
+  ::memset(_has_bits_, 0, sizeof(_has_bits_));
+  mutable_unknown_fields()->Clear();
+}
+
+bool InternalResolveIntentRangeRequest::MergePartialFromCodedStream(
+    ::google::protobuf::io::CodedInputStream* input) {
+#define DO_(EXPRESSION) if (!(EXPRESSION)) goto failure
+  ::google::protobuf::uint32 tag;
+  // @@protoc_insertion_point(parse_start:cockroach.proto.InternalResolveIntentRangeRequest)
+  for (;;) {
+    ::std::pair< ::google::protobuf::uint32, bool> p = input->ReadTagWithCutoff(127);
+    tag = p.first;
+    if (!p.second) goto handle_unusual;
+    switch (::google::protobuf::internal::WireFormatLite::GetTagFieldNumber(tag)) {
+      // optional .cockroach.proto.RequestHeader header = 1;
+      case 1: {
+        if (tag == 10) {
+          DO_(::google::protobuf::internal::WireFormatLite::ReadMessageNoVirtual(
+               input, mutable_header()));
+        } else {
+          goto handle_unusual;
+        }
+        if (input->ExpectAtEnd()) goto success;
+        break;
+      }
+
+      default: {
+      handle_unusual:
+        if (tag == 0 ||
+            ::google::protobuf::internal::WireFormatLite::GetTagWireType(tag) ==
+            ::google::protobuf::internal::WireFormatLite::WIRETYPE_END_GROUP) {
+          goto success;
+        }
+        DO_(::google::protobuf::internal::WireFormat::SkipField(
+              input, tag, mutable_unknown_fields()));
+        break;
+      }
+    }
+  }
+success:
+  // @@protoc_insertion_point(parse_success:cockroach.proto.InternalResolveIntentRangeRequest)
+  return true;
+failure:
+  // @@protoc_insertion_point(parse_failure:cockroach.proto.InternalResolveIntentRangeRequest)
+  return false;
+#undef DO_
+}
+
+void InternalResolveIntentRangeRequest::SerializeWithCachedSizes(
+    ::google::protobuf::io::CodedOutputStream* output) const {
+  // @@protoc_insertion_point(serialize_start:cockroach.proto.InternalResolveIntentRangeRequest)
+  // optional .cockroach.proto.RequestHeader header = 1;
+  if (has_header()) {
+    ::google::protobuf::internal::WireFormatLite::WriteMessageMaybeToArray(
+      1, this->header(), output);
+  }
+
+  if (!unknown_fields().empty()) {
+    ::google::protobuf::internal::WireFormat::SerializeUnknownFields(
+        unknown_fields(), output);
+  }
+  // @@protoc_insertion_point(serialize_end:cockroach.proto.InternalResolveIntentRangeRequest)
+}
+
+::google::protobuf::uint8* InternalResolveIntentRangeRequest::SerializeWithCachedSizesToArray(
+    ::google::protobuf::uint8* target) const {
+  // @@protoc_insertion_point(serialize_to_array_start:cockroach.proto.InternalResolveIntentRangeRequest)
+  // optional .cockroach.proto.RequestHeader header = 1;
+  if (has_header()) {
+    target = ::google::protobuf::internal::WireFormatLite::
+      WriteMessageNoVirtualToArray(
+        1, this->header(), target);
+  }
+
+  if (!unknown_fields().empty()) {
+    target = ::google::protobuf::internal::WireFormat::SerializeUnknownFieldsToArray(
+        unknown_fields(), target);
+  }
+  // @@protoc_insertion_point(serialize_to_array_end:cockroach.proto.InternalResolveIntentRangeRequest)
+  return target;
+}
+
+int InternalResolveIntentRangeRequest::ByteSize() const {
+  int total_size = 0;
+
+  if (_has_bits_[0 / 32] & (0xffu << (0 % 32))) {
+    // optional .cockroach.proto.RequestHeader header = 1;
+    if (has_header()) {
+      total_size += 1 +
+        ::google::protobuf::internal::WireFormatLite::MessageSizeNoVirtual(
+          this->header());
+    }
+
+  }
+  if (!unknown_fields().empty()) {
+    total_size +=
+      ::google::protobuf::internal::WireFormat::ComputeUnknownFieldsSize(
+        unknown_fields());
+  }
+  GOOGLE_SAFE_CONCURRENT_WRITES_BEGIN();
+  _cached_size_ = total_size;
+  GOOGLE_SAFE_CONCURRENT_WRITES_END();
+  return total_size;
+}
+
+void InternalResolveIntentRangeRequest::MergeFrom(const ::google::protobuf::Message& from) {
+  GOOGLE_CHECK_NE(&from, this);
+  const InternalResolveIntentRangeRequest* source =
+    ::google::protobuf::internal::dynamic_cast_if_available<const InternalResolveIntentRangeRequest*>(
+      &from);
+  if (source == NULL) {
+    ::google::protobuf::internal::ReflectionOps::Merge(from, this);
+  } else {
+    MergeFrom(*source);
+  }
+}
+
+void InternalResolveIntentRangeRequest::MergeFrom(const InternalResolveIntentRangeRequest& from) {
+  GOOGLE_CHECK_NE(&from, this);
+  if (from._has_bits_[0 / 32] & (0xffu << (0 % 32))) {
+    if (from.has_header()) {
+      mutable_header()->::cockroach::proto::RequestHeader::MergeFrom(from.header());
+    }
+  }
+  mutable_unknown_fields()->MergeFrom(from.unknown_fields());
+}
+
+void InternalResolveIntentRangeRequest::CopyFrom(const ::google::protobuf::Message& from) {
+  if (&from == this) return;
+  Clear();
+  MergeFrom(from);
+}
+
+void InternalResolveIntentRangeRequest::CopyFrom(const InternalResolveIntentRangeRequest& from) {
+  if (&from == this) return;
+  Clear();
+  MergeFrom(from);
+}
+
+bool InternalResolveIntentRangeRequest::IsInitialized() const {
+
+  return true;
+}
+
+void InternalResolveIntentRangeRequest::Swap(InternalResolveIntentRangeRequest* other) {
+  if (other != this) {
+    std::swap(header_, other->header_);
+    std::swap(_has_bits_[0], other->_has_bits_[0]);
+    _unknown_fields_.Swap(&other->_unknown_fields_);
+    std::swap(_cached_size_, other->_cached_size_);
+  }
+}
+
+::google::protobuf::Metadata InternalResolveIntentRangeRequest::GetMetadata() const {
+  protobuf_AssignDescriptorsOnce();
+  ::google::protobuf::Metadata metadata;
+  metadata.descriptor = InternalResolveIntentRangeRequest_descriptor_;
+  metadata.reflection = InternalResolveIntentRangeRequest_reflection_;
+  return metadata;
+}
+
+
+// ===================================================================
+
+#ifndef _MSC_VER
+const int InternalResolveIntentRangeResponse::kHeaderFieldNumber;
+#endif  // !_MSC_VER
+
+InternalResolveIntentRangeResponse::InternalResolveIntentRangeResponse()
+  : ::google::protobuf::Message() {
+  SharedCtor();
+  // @@protoc_insertion_point(constructor:cockroach.proto.InternalResolveIntentRangeResponse)
+}
+
+void InternalResolveIntentRangeResponse::InitAsDefaultInstance() {
+  header_ = const_cast< ::cockroach::proto::ResponseHeader*>(&::cockroach::proto::ResponseHeader::default_instance());
+}
+
+InternalResolveIntentRangeResponse::InternalResolveIntentRangeResponse(const InternalResolveIntentRangeResponse& from)
+  : ::google::protobuf::Message() {
+  SharedCtor();
+  MergeFrom(from);
+  // @@protoc_insertion_point(copy_constructor:cockroach.proto.InternalResolveIntentRangeResponse)
+}
+
+void InternalResolveIntentRangeResponse::SharedCtor() {
+  _cached_size_ = 0;
+  header_ = NULL;
+  ::memset(_has_bits_, 0, sizeof(_has_bits_));
+}
+
+InternalResolveIntentRangeResponse::~InternalResolveIntentRangeResponse() {
+  // @@protoc_insertion_point(destructor:cockroach.proto.InternalResolveIntentRangeResponse)
+  SharedDtor();
+}
+
+void InternalResolveIntentRangeResponse::SharedDtor() {
+  if (this != default_instance_) {
+    delete header_;
+  }
+}
+
+void InternalResolveIntentRangeResponse::SetCachedSize(int size) const {
+  GOOGLE_SAFE_CONCURRENT_WRITES_BEGIN();
+  _cached_size_ = size;
+  GOOGLE_SAFE_CONCURRENT_WRITES_END();
+}
+const ::google::protobuf::Descriptor* InternalResolveIntentRangeResponse::descriptor() {
+  protobuf_AssignDescriptorsOnce();
+  return InternalResolveIntentRangeResponse_descriptor_;
+}
+
+const InternalResolveIntentRangeResponse& InternalResolveIntentRangeResponse::default_instance() {
+  if (default_instance_ == NULL) protobuf_AddDesc_cockroach_2fproto_2finternal_2eproto();
+  return *default_instance_;
+}
+
+InternalResolveIntentRangeResponse* InternalResolveIntentRangeResponse::default_instance_ = NULL;
+
+InternalResolveIntentRangeResponse* InternalResolveIntentRangeResponse::New() const {
+  return new InternalResolveIntentRangeResponse;
+}
+
+void InternalResolveIntentRangeResponse::Clear() {
+  if (has_header()) {
+    if (header_ != NULL) header_->::cockroach::proto::ResponseHeader::Clear();
+  }
+  ::memset(_has_bits_, 0, sizeof(_has_bits_));
+  mutable_unknown_fields()->Clear();
+}
+
+bool InternalResolveIntentRangeResponse::MergePartialFromCodedStream(
+    ::google::protobuf::io::CodedInputStream* input) {
+#define DO_(EXPRESSION) if (!(EXPRESSION)) goto failure
+  ::google::protobuf::uint32 tag;
+  // @@protoc_insertion_point(parse_start:cockroach.proto.InternalResolveIntentRangeResponse)
+  for (;;) {
+    ::std::pair< ::google::protobuf::uint32, bool> p = input->ReadTagWithCutoff(127);
+    tag = p.first;
+    if (!p.second) goto handle_unusual;
+    switch (::google::protobuf::internal::WireFormatLite::GetTagFieldNumber(tag)) {
+      // optional .cockroach.proto.ResponseHeader header = 1;
+      case 1: {
+        if (tag == 10) {
+          DO_(::google::protobuf::internal::WireFormatLite::ReadMessageNoVirtual(
+               input, mutable_header()));
+        } else {
+          goto handle_unusual;
+        }
+        if (input->ExpectAtEnd()) goto success;
+        break;
+      }
+
+      default: {
+      handle_unusual:
+        if (tag == 0 ||
+            ::google::protobuf::internal::WireFormatLite::GetTagWireType(tag) ==
+            ::google::protobuf::internal::WireFormatLite::WIRETYPE_END_GROUP) {
+          goto success;
+        }
+        DO_(::google::protobuf::internal::WireFormat::SkipField(
+              input, tag, mutable_unknown_fields()));
+        break;
+      }
+    }
+  }
+success:
+  // @@protoc_insertion_point(parse_success:cockroach.proto.InternalResolveIntentRangeResponse)
+  return true;
+failure:
+  // @@protoc_insertion_point(parse_failure:cockroach.proto.InternalResolveIntentRangeResponse)
+  return false;
+#undef DO_
+}
+
+void InternalResolveIntentRangeResponse::SerializeWithCachedSizes(
+    ::google::protobuf::io::CodedOutputStream* output) const {
+  // @@protoc_insertion_point(serialize_start:cockroach.proto.InternalResolveIntentRangeResponse)
+  // optional .cockroach.proto.ResponseHeader header = 1;
+  if (has_header()) {
+    ::google::protobuf::internal::WireFormatLite::WriteMessageMaybeToArray(
+      1, this->header(), output);
+  }
+
+  if (!unknown_fields().empty()) {
+    ::google::protobuf::internal::WireFormat::SerializeUnknownFields(
+        unknown_fields(), output);
+  }
+  // @@protoc_insertion_point(serialize_end:cockroach.proto.InternalResolveIntentRangeResponse)
+}
+
+::google::protobuf::uint8* InternalResolveIntentRangeResponse::SerializeWithCachedSizesToArray(
+    ::google::protobuf::uint8* target) const {
+  // @@protoc_insertion_point(serialize_to_array_start:cockroach.proto.InternalResolveIntentRangeResponse)
+  // optional .cockroach.proto.ResponseHeader header = 1;
+  if (has_header()) {
+    target = ::google::protobuf::internal::WireFormatLite::
+      WriteMessageNoVirtualToArray(
+        1, this->header(), target);
+  }
+
+  if (!unknown_fields().empty()) {
+    target = ::google::protobuf::internal::WireFormat::SerializeUnknownFieldsToArray(
+        unknown_fields(), target);
+  }
+  // @@protoc_insertion_point(serialize_to_array_end:cockroach.proto.InternalResolveIntentRangeResponse)
+  return target;
+}
+
+int InternalResolveIntentRangeResponse::ByteSize() const {
+  int total_size = 0;
+
+  if (_has_bits_[0 / 32] & (0xffu << (0 % 32))) {
+    // optional .cockroach.proto.ResponseHeader header = 1;
+    if (has_header()) {
+      total_size += 1 +
+        ::google::protobuf::internal::WireFormatLite::MessageSizeNoVirtual(
+          this->header());
+    }
+
+  }
+  if (!unknown_fields().empty()) {
+    total_size +=
+      ::google::protobuf::internal::WireFormat::ComputeUnknownFieldsSize(
+        unknown_fields());
+  }
+  GOOGLE_SAFE_CONCURRENT_WRITES_BEGIN();
+  _cached_size_ = total_size;
+  GOOGLE_SAFE_CONCURRENT_WRITES_END();
+  return total_size;
+}
+
+void InternalResolveIntentRangeResponse::MergeFrom(const ::google::protobuf::Message& from) {
+  GOOGLE_CHECK_NE(&from, this);
+  const InternalResolveIntentRangeResponse* source =
+    ::google::protobuf::internal::dynamic_cast_if_available<const InternalResolveIntentRangeResponse*>(
+      &from);
+  if (source == NULL) {
+    ::google::protobuf::internal::ReflectionOps::Merge(from, this);
+  } else {
+    MergeFrom(*source);
+  }
+}
+
+void InternalResolveIntentRangeResponse::MergeFrom(const InternalResolveIntentRangeResponse& from) {
+  GOOGLE_CHECK_NE(&from, this);
+  if (from._has_bits_[0 / 32] & (0xffu << (0 % 32))) {
+    if (from.has_header()) {
+      mutable_header()->::cockroach::proto::ResponseHeader::MergeFrom(from.header());
+    }
+  }
+  mutable_unknown_fields()->MergeFrom(from.unknown_fields());
+}
+
+void InternalResolveIntentRangeResponse::CopyFrom(const ::google::protobuf::Message& from) {
+  if (&from == this) return;
+  Clear();
+  MergeFrom(from);
+}
+
+void InternalResolveIntentRangeResponse::CopyFrom(const InternalResolveIntentRangeResponse& from) {
+  if (&from == this) return;
+  Clear();
+  MergeFrom(from);
+}
+
+bool InternalResolveIntentRangeResponse::IsInitialized() const {
+
+  return true;
+}
+
+void InternalResolveIntentRangeResponse::Swap(InternalResolveIntentRangeResponse* other) {
+  if (other != this) {
+    std::swap(header_, other->header_);
+    std::swap(_has_bits_[0], other->_has_bits_[0]);
+    _unknown_fields_.Swap(&other->_unknown_fields_);
+    std::swap(_cached_size_, other->_cached_size_);
+  }
+}
+
+::google::protobuf::Metadata InternalResolveIntentRangeResponse::GetMetadata() const {
+  protobuf_AssignDescriptorsOnce();
+  ::google::protobuf::Metadata metadata;
+  metadata.descriptor = InternalResolveIntentRangeResponse_descriptor_;
+  metadata.reflection = InternalResolveIntentRangeResponse_reflection_;
+  return metadata;
+}
+
+
+// ===================================================================
+
+#ifndef _MSC_VER
 const int InternalMergeRequest::kHeaderFieldNumber;
 const int InternalMergeRequest::kValueFieldNumber;
 #endif  // !_MSC_VER
@@ -5636,6 +6160,7 @@ const int InternalRequestUnion::kScanFieldNumber;
 const int InternalRequestUnion::kEndTransactionFieldNumber;
 const int InternalRequestUnion::kInternalPushTxnFieldNumber;
 const int InternalRequestUnion::kInternalResolveIntentFieldNumber;
+const int InternalRequestUnion::kInternalResolveIntentRangeFieldNumber;
 #endif  // !_MSC_VER
 
 InternalRequestUnion::InternalRequestUnion()
@@ -5656,6 +6181,7 @@ void InternalRequestUnion::InitAsDefaultInstance() {
   InternalRequestUnion_default_oneof_instance_->end_transaction_ = const_cast< ::cockroach::proto::EndTransactionRequest*>(&::cockroach::proto::EndTransactionRequest::default_instance());
   InternalRequestUnion_default_oneof_instance_->internal_push_txn_ = const_cast< ::cockroach::proto::InternalPushTxnRequest*>(&::cockroach::proto::InternalPushTxnRequest::default_instance());
   InternalRequestUnion_default_oneof_instance_->internal_resolve_intent_ = const_cast< ::cockroach::proto::InternalResolveIntentRequest*>(&::cockroach::proto::InternalResolveIntentRequest::default_instance());
+  InternalRequestUnion_default_oneof_instance_->internal_resolve_intent_range_ = const_cast< ::cockroach::proto::InternalResolveIntentRangeRequest*>(&::cockroach::proto::InternalResolveIntentRangeRequest::default_instance());
 }
 
 InternalRequestUnion::InternalRequestUnion(const InternalRequestUnion& from)
@@ -5749,6 +6275,10 @@ void InternalRequestUnion::clear_value() {
     }
     case kInternalResolveIntent: {
       delete value_.internal_resolve_intent_;
+      break;
+    }
+    case kInternalResolveIntentRange: {
+      delete value_.internal_resolve_intent_range_;
       break;
     }
     case VALUE_NOT_SET: {
@@ -5913,6 +6443,19 @@ bool InternalRequestUnion::MergePartialFromCodedStream(
         } else {
           goto handle_unusual;
         }
+        if (input->ExpectTag(258)) goto parse_internal_resolve_intent_range;
+        break;
+      }
+
+      // optional .cockroach.proto.InternalResolveIntentRangeRequest internal_resolve_intent_range = 32;
+      case 32: {
+        if (tag == 258) {
+         parse_internal_resolve_intent_range:
+          DO_(::google::protobuf::internal::WireFormatLite::ReadMessageNoVirtual(
+               input, mutable_internal_resolve_intent_range()));
+        } else {
+          goto handle_unusual;
+        }
         if (input->ExpectAtEnd()) goto success;
         break;
       }
@@ -6008,6 +6551,12 @@ void InternalRequestUnion::SerializeWithCachedSizes(
       31, this->internal_resolve_intent(), output);
   }
 
+  // optional .cockroach.proto.InternalResolveIntentRangeRequest internal_resolve_intent_range = 32;
+  if (has_internal_resolve_intent_range()) {
+    ::google::protobuf::internal::WireFormatLite::WriteMessageMaybeToArray(
+      32, this->internal_resolve_intent_range(), output);
+  }
+
   if (!unknown_fields().empty()) {
     ::google::protobuf::internal::WireFormat::SerializeUnknownFields(
         unknown_fields(), output);
@@ -6093,6 +6642,13 @@ void InternalRequestUnion::SerializeWithCachedSizes(
     target = ::google::protobuf::internal::WireFormatLite::
       WriteMessageNoVirtualToArray(
         31, this->internal_resolve_intent(), target);
+  }
+
+  // optional .cockroach.proto.InternalResolveIntentRangeRequest internal_resolve_intent_range = 32;
+  if (has_internal_resolve_intent_range()) {
+    target = ::google::protobuf::internal::WireFormatLite::
+      WriteMessageNoVirtualToArray(
+        32, this->internal_resolve_intent_range(), target);
   }
 
   if (!unknown_fields().empty()) {
@@ -6184,6 +6740,13 @@ int InternalRequestUnion::ByteSize() const {
           this->internal_resolve_intent());
       break;
     }
+    // optional .cockroach.proto.InternalResolveIntentRangeRequest internal_resolve_intent_range = 32;
+    case kInternalResolveIntentRange: {
+      total_size += 2 +
+        ::google::protobuf::internal::WireFormatLite::MessageSizeNoVirtual(
+          this->internal_resolve_intent_range());
+      break;
+    }
     case VALUE_NOT_SET: {
       break;
     }
@@ -6258,6 +6821,10 @@ void InternalRequestUnion::MergeFrom(const InternalRequestUnion& from) {
       mutable_internal_resolve_intent()->::cockroach::proto::InternalResolveIntentRequest::MergeFrom(from.internal_resolve_intent());
       break;
     }
+    case kInternalResolveIntentRange: {
+      mutable_internal_resolve_intent_range()->::cockroach::proto::InternalResolveIntentRangeRequest::MergeFrom(from.internal_resolve_intent_range());
+      break;
+    }
     case VALUE_NOT_SET: {
       break;
     }
@@ -6315,6 +6882,7 @@ const int InternalResponseUnion::kScanFieldNumber;
 const int InternalResponseUnion::kEndTransactionFieldNumber;
 const int InternalResponseUnion::kInternalPushTxnFieldNumber;
 const int InternalResponseUnion::kInternalResolveIntentFieldNumber;
+const int InternalResponseUnion::kInternalResolveIntentRangeFieldNumber;
 #endif  // !_MSC_VER
 
 InternalResponseUnion::InternalResponseUnion()
@@ -6335,6 +6903,7 @@ void InternalResponseUnion::InitAsDefaultInstance() {
   InternalResponseUnion_default_oneof_instance_->end_transaction_ = const_cast< ::cockroach::proto::EndTransactionResponse*>(&::cockroach::proto::EndTransactionResponse::default_instance());
   InternalResponseUnion_default_oneof_instance_->internal_push_txn_ = const_cast< ::cockroach::proto::InternalPushTxnResponse*>(&::cockroach::proto::InternalPushTxnResponse::default_instance());
   InternalResponseUnion_default_oneof_instance_->internal_resolve_intent_ = const_cast< ::cockroach::proto::InternalResolveIntentResponse*>(&::cockroach::proto::InternalResolveIntentResponse::default_instance());
+  InternalResponseUnion_default_oneof_instance_->internal_resolve_intent_range_ = const_cast< ::cockroach::proto::InternalResolveIntentRangeResponse*>(&::cockroach::proto::InternalResolveIntentRangeResponse::default_instance());
 }
 
 InternalResponseUnion::InternalResponseUnion(const InternalResponseUnion& from)
@@ -6428,6 +6997,10 @@ void InternalResponseUnion::clear_value() {
     }
     case kInternalResolveIntent: {
       delete value_.internal_resolve_intent_;
+      break;
+    }
+    case kInternalResolveIntentRange: {
+      delete value_.internal_resolve_intent_range_;
       break;
     }
     case VALUE_NOT_SET: {
@@ -6592,6 +7165,19 @@ bool InternalResponseUnion::MergePartialFromCodedStream(
         } else {
           goto handle_unusual;
         }
+        if (input->ExpectTag(258)) goto parse_internal_resolve_intent_range;
+        break;
+      }
+
+      // optional .cockroach.proto.InternalResolveIntentRangeResponse internal_resolve_intent_range = 32;
+      case 32: {
+        if (tag == 258) {
+         parse_internal_resolve_intent_range:
+          DO_(::google::protobuf::internal::WireFormatLite::ReadMessageNoVirtual(
+               input, mutable_internal_resolve_intent_range()));
+        } else {
+          goto handle_unusual;
+        }
         if (input->ExpectAtEnd()) goto success;
         break;
       }
@@ -6687,6 +7273,12 @@ void InternalResponseUnion::SerializeWithCachedSizes(
       31, this->internal_resolve_intent(), output);
   }
 
+  // optional .cockroach.proto.InternalResolveIntentRangeResponse internal_resolve_intent_range = 32;
+  if (has_internal_resolve_intent_range()) {
+    ::google::protobuf::internal::WireFormatLite::WriteMessageMaybeToArray(
+      32, this->internal_resolve_intent_range(), output);
+  }
+
   if (!unknown_fields().empty()) {
     ::google::protobuf::internal::WireFormat::SerializeUnknownFields(
         unknown_fields(), output);
@@ -6772,6 +7364,13 @@ void InternalResponseUnion::SerializeWithCachedSizes(
     target = ::google::protobuf::internal::WireFormatLite::
       WriteMessageNoVirtualToArray(
         31, this->internal_resolve_intent(), target);
+  }
+
+  // optional .cockroach.proto.InternalResolveIntentRangeResponse internal_resolve_intent_range = 32;
+  if (has_internal_resolve_intent_range()) {
+    target = ::google::protobuf::internal::WireFormatLite::
+      WriteMessageNoVirtualToArray(
+        32, this->internal_resolve_intent_range(), target);
   }
 
   if (!unknown_fields().empty()) {
@@ -6863,6 +7462,13 @@ int InternalResponseUnion::ByteSize() const {
           this->internal_resolve_intent());
       break;
     }
+    // optional .cockroach.proto.InternalResolveIntentRangeResponse internal_resolve_intent_range = 32;
+    case kInternalResolveIntentRange: {
+      total_size += 2 +
+        ::google::protobuf::internal::WireFormatLite::MessageSizeNoVirtual(
+          this->internal_resolve_intent_range());
+      break;
+    }
     case VALUE_NOT_SET: {
       break;
     }
@@ -6935,6 +7541,10 @@ void InternalResponseUnion::MergeFrom(const InternalResponseUnion& from) {
     }
     case kInternalResolveIntent: {
       mutable_internal_resolve_intent()->::cockroach::proto::InternalResolveIntentResponse::MergeFrom(from.internal_resolve_intent());
+      break;
+    }
+    case kInternalResolveIntentRange: {
+      mutable_internal_resolve_intent_range()->::cockroach::proto::InternalResolveIntentRangeResponse::MergeFrom(from.internal_resolve_intent_range());
       break;
     }
     case VALUE_NOT_SET: {
@@ -7524,6 +8134,7 @@ const int ReadWriteCmdResponse::kEndTransactionFieldNumber;
 const int ReadWriteCmdResponse::kInternalHeartbeatTxnFieldNumber;
 const int ReadWriteCmdResponse::kInternalPushTxnFieldNumber;
 const int ReadWriteCmdResponse::kInternalResolveIntentFieldNumber;
+const int ReadWriteCmdResponse::kInternalResolveIntentRangeFieldNumber;
 const int ReadWriteCmdResponse::kInternalMergeFieldNumber;
 const int ReadWriteCmdResponse::kInternalTruncateLogFieldNumber;
 const int ReadWriteCmdResponse::kInternalGcFieldNumber;
@@ -7546,6 +8157,7 @@ void ReadWriteCmdResponse::InitAsDefaultInstance() {
   ReadWriteCmdResponse_default_oneof_instance_->internal_heartbeat_txn_ = const_cast< ::cockroach::proto::InternalHeartbeatTxnResponse*>(&::cockroach::proto::InternalHeartbeatTxnResponse::default_instance());
   ReadWriteCmdResponse_default_oneof_instance_->internal_push_txn_ = const_cast< ::cockroach::proto::InternalPushTxnResponse*>(&::cockroach::proto::InternalPushTxnResponse::default_instance());
   ReadWriteCmdResponse_default_oneof_instance_->internal_resolve_intent_ = const_cast< ::cockroach::proto::InternalResolveIntentResponse*>(&::cockroach::proto::InternalResolveIntentResponse::default_instance());
+  ReadWriteCmdResponse_default_oneof_instance_->internal_resolve_intent_range_ = const_cast< ::cockroach::proto::InternalResolveIntentRangeResponse*>(&::cockroach::proto::InternalResolveIntentRangeResponse::default_instance());
   ReadWriteCmdResponse_default_oneof_instance_->internal_merge_ = const_cast< ::cockroach::proto::InternalMergeResponse*>(&::cockroach::proto::InternalMergeResponse::default_instance());
   ReadWriteCmdResponse_default_oneof_instance_->internal_truncate_log_ = const_cast< ::cockroach::proto::InternalTruncateLogResponse*>(&::cockroach::proto::InternalTruncateLogResponse::default_instance());
   ReadWriteCmdResponse_default_oneof_instance_->internal_gc_ = const_cast< ::cockroach::proto::InternalGCResponse*>(&::cockroach::proto::InternalGCResponse::default_instance());
@@ -7635,6 +8247,10 @@ void ReadWriteCmdResponse::clear_value() {
     }
     case kInternalResolveIntent: {
       delete value_.internal_resolve_intent_;
+      break;
+    }
+    case kInternalResolveIntentRange: {
+      delete value_.internal_resolve_intent_range_;
       break;
     }
     case kInternalMerge: {
@@ -7789,52 +8405,65 @@ bool ReadWriteCmdResponse::MergePartialFromCodedStream(
         } else {
           goto handle_unusual;
         }
-        if (input->ExpectTag(106)) goto parse_internal_merge;
+        if (input->ExpectTag(106)) goto parse_internal_resolve_intent_range;
         break;
       }
 
-      // optional .cockroach.proto.InternalMergeResponse internal_merge = 13;
+      // optional .cockroach.proto.InternalResolveIntentRangeResponse internal_resolve_intent_range = 13;
       case 13: {
         if (tag == 106) {
+         parse_internal_resolve_intent_range:
+          DO_(::google::protobuf::internal::WireFormatLite::ReadMessageNoVirtual(
+               input, mutable_internal_resolve_intent_range()));
+        } else {
+          goto handle_unusual;
+        }
+        if (input->ExpectTag(114)) goto parse_internal_merge;
+        break;
+      }
+
+      // optional .cockroach.proto.InternalMergeResponse internal_merge = 14;
+      case 14: {
+        if (tag == 114) {
          parse_internal_merge:
           DO_(::google::protobuf::internal::WireFormatLite::ReadMessageNoVirtual(
                input, mutable_internal_merge()));
         } else {
           goto handle_unusual;
         }
-        if (input->ExpectTag(114)) goto parse_internal_truncate_log;
+        if (input->ExpectTag(122)) goto parse_internal_truncate_log;
         break;
       }
 
-      // optional .cockroach.proto.InternalTruncateLogResponse internal_truncate_log = 14;
-      case 14: {
-        if (tag == 114) {
+      // optional .cockroach.proto.InternalTruncateLogResponse internal_truncate_log = 15;
+      case 15: {
+        if (tag == 122) {
          parse_internal_truncate_log:
           DO_(::google::protobuf::internal::WireFormatLite::ReadMessageNoVirtual(
                input, mutable_internal_truncate_log()));
         } else {
           goto handle_unusual;
         }
-        if (input->ExpectTag(122)) goto parse_internal_gc;
+        if (input->ExpectTag(130)) goto parse_internal_gc;
         break;
       }
 
-      // optional .cockroach.proto.InternalGCResponse internal_gc = 15;
-      case 15: {
-        if (tag == 122) {
+      // optional .cockroach.proto.InternalGCResponse internal_gc = 16;
+      case 16: {
+        if (tag == 130) {
          parse_internal_gc:
           DO_(::google::protobuf::internal::WireFormatLite::ReadMessageNoVirtual(
                input, mutable_internal_gc()));
         } else {
           goto handle_unusual;
         }
-        if (input->ExpectTag(130)) goto parse_internal_leader_lease;
+        if (input->ExpectTag(138)) goto parse_internal_leader_lease;
         break;
       }
 
-      // optional .cockroach.proto.InternalLeaderLeaseResponse internal_leader_lease = 16;
-      case 16: {
-        if (tag == 130) {
+      // optional .cockroach.proto.InternalLeaderLeaseResponse internal_leader_lease = 17;
+      case 17: {
+        if (tag == 138) {
          parse_internal_leader_lease:
           DO_(::google::protobuf::internal::WireFormatLite::ReadMessageNoVirtual(
                input, mutable_internal_leader_lease()));
@@ -7924,28 +8553,34 @@ void ReadWriteCmdResponse::SerializeWithCachedSizes(
       12, this->internal_resolve_intent(), output);
   }
 
-  // optional .cockroach.proto.InternalMergeResponse internal_merge = 13;
+  // optional .cockroach.proto.InternalResolveIntentRangeResponse internal_resolve_intent_range = 13;
+  if (has_internal_resolve_intent_range()) {
+    ::google::protobuf::internal::WireFormatLite::WriteMessageMaybeToArray(
+      13, this->internal_resolve_intent_range(), output);
+  }
+
+  // optional .cockroach.proto.InternalMergeResponse internal_merge = 14;
   if (has_internal_merge()) {
     ::google::protobuf::internal::WireFormatLite::WriteMessageMaybeToArray(
-      13, this->internal_merge(), output);
+      14, this->internal_merge(), output);
   }
 
-  // optional .cockroach.proto.InternalTruncateLogResponse internal_truncate_log = 14;
+  // optional .cockroach.proto.InternalTruncateLogResponse internal_truncate_log = 15;
   if (has_internal_truncate_log()) {
     ::google::protobuf::internal::WireFormatLite::WriteMessageMaybeToArray(
-      14, this->internal_truncate_log(), output);
+      15, this->internal_truncate_log(), output);
   }
 
-  // optional .cockroach.proto.InternalGCResponse internal_gc = 15;
+  // optional .cockroach.proto.InternalGCResponse internal_gc = 16;
   if (has_internal_gc()) {
     ::google::protobuf::internal::WireFormatLite::WriteMessageMaybeToArray(
-      15, this->internal_gc(), output);
+      16, this->internal_gc(), output);
   }
 
-  // optional .cockroach.proto.InternalLeaderLeaseResponse internal_leader_lease = 16;
+  // optional .cockroach.proto.InternalLeaderLeaseResponse internal_leader_lease = 17;
   if (has_internal_leader_lease()) {
     ::google::protobuf::internal::WireFormatLite::WriteMessageMaybeToArray(
-      16, this->internal_leader_lease(), output);
+      17, this->internal_leader_lease(), output);
   }
 
   if (!unknown_fields().empty()) {
@@ -8021,32 +8656,39 @@ void ReadWriteCmdResponse::SerializeWithCachedSizes(
         12, this->internal_resolve_intent(), target);
   }
 
-  // optional .cockroach.proto.InternalMergeResponse internal_merge = 13;
+  // optional .cockroach.proto.InternalResolveIntentRangeResponse internal_resolve_intent_range = 13;
+  if (has_internal_resolve_intent_range()) {
+    target = ::google::protobuf::internal::WireFormatLite::
+      WriteMessageNoVirtualToArray(
+        13, this->internal_resolve_intent_range(), target);
+  }
+
+  // optional .cockroach.proto.InternalMergeResponse internal_merge = 14;
   if (has_internal_merge()) {
     target = ::google::protobuf::internal::WireFormatLite::
       WriteMessageNoVirtualToArray(
-        13, this->internal_merge(), target);
+        14, this->internal_merge(), target);
   }
 
-  // optional .cockroach.proto.InternalTruncateLogResponse internal_truncate_log = 14;
+  // optional .cockroach.proto.InternalTruncateLogResponse internal_truncate_log = 15;
   if (has_internal_truncate_log()) {
     target = ::google::protobuf::internal::WireFormatLite::
       WriteMessageNoVirtualToArray(
-        14, this->internal_truncate_log(), target);
+        15, this->internal_truncate_log(), target);
   }
 
-  // optional .cockroach.proto.InternalGCResponse internal_gc = 15;
+  // optional .cockroach.proto.InternalGCResponse internal_gc = 16;
   if (has_internal_gc()) {
     target = ::google::protobuf::internal::WireFormatLite::
       WriteMessageNoVirtualToArray(
-        15, this->internal_gc(), target);
+        16, this->internal_gc(), target);
   }
 
-  // optional .cockroach.proto.InternalLeaderLeaseResponse internal_leader_lease = 16;
+  // optional .cockroach.proto.InternalLeaderLeaseResponse internal_leader_lease = 17;
   if (has_internal_leader_lease()) {
     target = ::google::protobuf::internal::WireFormatLite::
       WriteMessageNoVirtualToArray(
-        16, this->internal_leader_lease(), target);
+        17, this->internal_leader_lease(), target);
   }
 
   if (!unknown_fields().empty()) {
@@ -8124,28 +8766,35 @@ int ReadWriteCmdResponse::ByteSize() const {
           this->internal_resolve_intent());
       break;
     }
-    // optional .cockroach.proto.InternalMergeResponse internal_merge = 13;
+    // optional .cockroach.proto.InternalResolveIntentRangeResponse internal_resolve_intent_range = 13;
+    case kInternalResolveIntentRange: {
+      total_size += 1 +
+        ::google::protobuf::internal::WireFormatLite::MessageSizeNoVirtual(
+          this->internal_resolve_intent_range());
+      break;
+    }
+    // optional .cockroach.proto.InternalMergeResponse internal_merge = 14;
     case kInternalMerge: {
       total_size += 1 +
         ::google::protobuf::internal::WireFormatLite::MessageSizeNoVirtual(
           this->internal_merge());
       break;
     }
-    // optional .cockroach.proto.InternalTruncateLogResponse internal_truncate_log = 14;
+    // optional .cockroach.proto.InternalTruncateLogResponse internal_truncate_log = 15;
     case kInternalTruncateLog: {
       total_size += 1 +
         ::google::protobuf::internal::WireFormatLite::MessageSizeNoVirtual(
           this->internal_truncate_log());
       break;
     }
-    // optional .cockroach.proto.InternalGCResponse internal_gc = 15;
+    // optional .cockroach.proto.InternalGCResponse internal_gc = 16;
     case kInternalGc: {
-      total_size += 1 +
+      total_size += 2 +
         ::google::protobuf::internal::WireFormatLite::MessageSizeNoVirtual(
           this->internal_gc());
       break;
     }
-    // optional .cockroach.proto.InternalLeaderLeaseResponse internal_leader_lease = 16;
+    // optional .cockroach.proto.InternalLeaderLeaseResponse internal_leader_lease = 17;
     case kInternalLeaderLease: {
       total_size += 2 +
         ::google::protobuf::internal::WireFormatLite::MessageSizeNoVirtual(
@@ -8216,6 +8865,10 @@ void ReadWriteCmdResponse::MergeFrom(const ReadWriteCmdResponse& from) {
     }
     case kInternalResolveIntent: {
       mutable_internal_resolve_intent()->::cockroach::proto::InternalResolveIntentResponse::MergeFrom(from.internal_resolve_intent());
+      break;
+    }
+    case kInternalResolveIntentRange: {
+      mutable_internal_resolve_intent_range()->::cockroach::proto::InternalResolveIntentRangeResponse::MergeFrom(from.internal_resolve_intent_range());
       break;
     }
     case kInternalMerge: {
@@ -8294,6 +8947,7 @@ const int InternalRaftCommandUnion::kInternalRangeLookupFieldNumber;
 const int InternalRaftCommandUnion::kInternalHeartbeatTxnFieldNumber;
 const int InternalRaftCommandUnion::kInternalPushTxnFieldNumber;
 const int InternalRaftCommandUnion::kInternalResolveIntentFieldNumber;
+const int InternalRaftCommandUnion::kInternalResolveIntentRangeFieldNumber;
 const int InternalRaftCommandUnion::kInternalMergeResponseFieldNumber;
 const int InternalRaftCommandUnion::kInternalTruncateLogFieldNumber;
 const int InternalRaftCommandUnion::kInternalGcFieldNumber;
@@ -8322,6 +8976,7 @@ void InternalRaftCommandUnion::InitAsDefaultInstance() {
   InternalRaftCommandUnion_default_oneof_instance_->internal_heartbeat_txn_ = const_cast< ::cockroach::proto::InternalHeartbeatTxnRequest*>(&::cockroach::proto::InternalHeartbeatTxnRequest::default_instance());
   InternalRaftCommandUnion_default_oneof_instance_->internal_push_txn_ = const_cast< ::cockroach::proto::InternalPushTxnRequest*>(&::cockroach::proto::InternalPushTxnRequest::default_instance());
   InternalRaftCommandUnion_default_oneof_instance_->internal_resolve_intent_ = const_cast< ::cockroach::proto::InternalResolveIntentRequest*>(&::cockroach::proto::InternalResolveIntentRequest::default_instance());
+  InternalRaftCommandUnion_default_oneof_instance_->internal_resolve_intent_range_ = const_cast< ::cockroach::proto::InternalResolveIntentRangeRequest*>(&::cockroach::proto::InternalResolveIntentRangeRequest::default_instance());
   InternalRaftCommandUnion_default_oneof_instance_->internal_merge_response_ = const_cast< ::cockroach::proto::InternalMergeRequest*>(&::cockroach::proto::InternalMergeRequest::default_instance());
   InternalRaftCommandUnion_default_oneof_instance_->internal_truncate_log_ = const_cast< ::cockroach::proto::InternalTruncateLogRequest*>(&::cockroach::proto::InternalTruncateLogRequest::default_instance());
   InternalRaftCommandUnion_default_oneof_instance_->internal_gc_ = const_cast< ::cockroach::proto::InternalGCRequest*>(&::cockroach::proto::InternalGCRequest::default_instance());
@@ -8432,6 +9087,10 @@ void InternalRaftCommandUnion::clear_value() {
     }
     case kInternalResolveIntent: {
       delete value_.internal_resolve_intent_;
+      break;
+    }
+    case kInternalResolveIntentRange: {
+      delete value_.internal_resolve_intent_range_;
       break;
     }
     case kInternalMergeResponse: {
@@ -8655,65 +9314,78 @@ bool InternalRaftCommandUnion::MergePartialFromCodedStream(
         } else {
           goto handle_unusual;
         }
-        if (input->ExpectTag(282)) goto parse_internal_merge_response;
+        if (input->ExpectTag(282)) goto parse_internal_resolve_intent_range;
         break;
       }
 
-      // optional .cockroach.proto.InternalMergeRequest internal_merge_response = 35;
+      // optional .cockroach.proto.InternalResolveIntentRangeRequest internal_resolve_intent_range = 35;
       case 35: {
         if (tag == 282) {
+         parse_internal_resolve_intent_range:
+          DO_(::google::protobuf::internal::WireFormatLite::ReadMessageNoVirtual(
+               input, mutable_internal_resolve_intent_range()));
+        } else {
+          goto handle_unusual;
+        }
+        if (input->ExpectTag(290)) goto parse_internal_merge_response;
+        break;
+      }
+
+      // optional .cockroach.proto.InternalMergeRequest internal_merge_response = 36;
+      case 36: {
+        if (tag == 290) {
          parse_internal_merge_response:
           DO_(::google::protobuf::internal::WireFormatLite::ReadMessageNoVirtual(
                input, mutable_internal_merge_response()));
         } else {
           goto handle_unusual;
         }
-        if (input->ExpectTag(290)) goto parse_internal_truncate_log;
+        if (input->ExpectTag(298)) goto parse_internal_truncate_log;
         break;
       }
 
-      // optional .cockroach.proto.InternalTruncateLogRequest internal_truncate_log = 36;
-      case 36: {
-        if (tag == 290) {
+      // optional .cockroach.proto.InternalTruncateLogRequest internal_truncate_log = 37;
+      case 37: {
+        if (tag == 298) {
          parse_internal_truncate_log:
           DO_(::google::protobuf::internal::WireFormatLite::ReadMessageNoVirtual(
                input, mutable_internal_truncate_log()));
         } else {
           goto handle_unusual;
         }
-        if (input->ExpectTag(298)) goto parse_internal_gc;
+        if (input->ExpectTag(306)) goto parse_internal_gc;
         break;
       }
 
-      // optional .cockroach.proto.InternalGCRequest internal_gc = 37;
-      case 37: {
-        if (tag == 298) {
+      // optional .cockroach.proto.InternalGCRequest internal_gc = 38;
+      case 38: {
+        if (tag == 306) {
          parse_internal_gc:
           DO_(::google::protobuf::internal::WireFormatLite::ReadMessageNoVirtual(
                input, mutable_internal_gc()));
         } else {
           goto handle_unusual;
         }
-        if (input->ExpectTag(306)) goto parse_internal_lease;
+        if (input->ExpectTag(314)) goto parse_internal_lease;
         break;
       }
 
-      // optional .cockroach.proto.InternalLeaderLeaseRequest internal_lease = 38;
-      case 38: {
-        if (tag == 306) {
+      // optional .cockroach.proto.InternalLeaderLeaseRequest internal_lease = 39;
+      case 39: {
+        if (tag == 314) {
          parse_internal_lease:
           DO_(::google::protobuf::internal::WireFormatLite::ReadMessageNoVirtual(
                input, mutable_internal_lease()));
         } else {
           goto handle_unusual;
         }
-        if (input->ExpectTag(314)) goto parse_internal_batch;
+        if (input->ExpectTag(322)) goto parse_internal_batch;
         break;
       }
 
-      // optional .cockroach.proto.InternalBatchRequest internal_batch = 39;
-      case 39: {
-        if (tag == 314) {
+      // optional .cockroach.proto.InternalBatchRequest internal_batch = 40;
+      case 40: {
+        if (tag == 322) {
          parse_internal_batch:
           DO_(::google::protobuf::internal::WireFormatLite::ReadMessageNoVirtual(
                input, mutable_internal_batch()));
@@ -8833,34 +9505,40 @@ void InternalRaftCommandUnion::SerializeWithCachedSizes(
       34, this->internal_resolve_intent(), output);
   }
 
-  // optional .cockroach.proto.InternalMergeRequest internal_merge_response = 35;
+  // optional .cockroach.proto.InternalResolveIntentRangeRequest internal_resolve_intent_range = 35;
+  if (has_internal_resolve_intent_range()) {
+    ::google::protobuf::internal::WireFormatLite::WriteMessageMaybeToArray(
+      35, this->internal_resolve_intent_range(), output);
+  }
+
+  // optional .cockroach.proto.InternalMergeRequest internal_merge_response = 36;
   if (has_internal_merge_response()) {
     ::google::protobuf::internal::WireFormatLite::WriteMessageMaybeToArray(
-      35, this->internal_merge_response(), output);
+      36, this->internal_merge_response(), output);
   }
 
-  // optional .cockroach.proto.InternalTruncateLogRequest internal_truncate_log = 36;
+  // optional .cockroach.proto.InternalTruncateLogRequest internal_truncate_log = 37;
   if (has_internal_truncate_log()) {
     ::google::protobuf::internal::WireFormatLite::WriteMessageMaybeToArray(
-      36, this->internal_truncate_log(), output);
+      37, this->internal_truncate_log(), output);
   }
 
-  // optional .cockroach.proto.InternalGCRequest internal_gc = 37;
+  // optional .cockroach.proto.InternalGCRequest internal_gc = 38;
   if (has_internal_gc()) {
     ::google::protobuf::internal::WireFormatLite::WriteMessageMaybeToArray(
-      37, this->internal_gc(), output);
+      38, this->internal_gc(), output);
   }
 
-  // optional .cockroach.proto.InternalLeaderLeaseRequest internal_lease = 38;
+  // optional .cockroach.proto.InternalLeaderLeaseRequest internal_lease = 39;
   if (has_internal_lease()) {
     ::google::protobuf::internal::WireFormatLite::WriteMessageMaybeToArray(
-      38, this->internal_lease(), output);
+      39, this->internal_lease(), output);
   }
 
-  // optional .cockroach.proto.InternalBatchRequest internal_batch = 39;
+  // optional .cockroach.proto.InternalBatchRequest internal_batch = 40;
   if (has_internal_batch()) {
     ::google::protobuf::internal::WireFormatLite::WriteMessageMaybeToArray(
-      39, this->internal_batch(), output);
+      40, this->internal_batch(), output);
   }
 
   if (!unknown_fields().empty()) {
@@ -8971,39 +9649,46 @@ void InternalRaftCommandUnion::SerializeWithCachedSizes(
         34, this->internal_resolve_intent(), target);
   }
 
-  // optional .cockroach.proto.InternalMergeRequest internal_merge_response = 35;
+  // optional .cockroach.proto.InternalResolveIntentRangeRequest internal_resolve_intent_range = 35;
+  if (has_internal_resolve_intent_range()) {
+    target = ::google::protobuf::internal::WireFormatLite::
+      WriteMessageNoVirtualToArray(
+        35, this->internal_resolve_intent_range(), target);
+  }
+
+  // optional .cockroach.proto.InternalMergeRequest internal_merge_response = 36;
   if (has_internal_merge_response()) {
     target = ::google::protobuf::internal::WireFormatLite::
       WriteMessageNoVirtualToArray(
-        35, this->internal_merge_response(), target);
+        36, this->internal_merge_response(), target);
   }
 
-  // optional .cockroach.proto.InternalTruncateLogRequest internal_truncate_log = 36;
+  // optional .cockroach.proto.InternalTruncateLogRequest internal_truncate_log = 37;
   if (has_internal_truncate_log()) {
     target = ::google::protobuf::internal::WireFormatLite::
       WriteMessageNoVirtualToArray(
-        36, this->internal_truncate_log(), target);
+        37, this->internal_truncate_log(), target);
   }
 
-  // optional .cockroach.proto.InternalGCRequest internal_gc = 37;
+  // optional .cockroach.proto.InternalGCRequest internal_gc = 38;
   if (has_internal_gc()) {
     target = ::google::protobuf::internal::WireFormatLite::
       WriteMessageNoVirtualToArray(
-        37, this->internal_gc(), target);
+        38, this->internal_gc(), target);
   }
 
-  // optional .cockroach.proto.InternalLeaderLeaseRequest internal_lease = 38;
+  // optional .cockroach.proto.InternalLeaderLeaseRequest internal_lease = 39;
   if (has_internal_lease()) {
     target = ::google::protobuf::internal::WireFormatLite::
       WriteMessageNoVirtualToArray(
-        38, this->internal_lease(), target);
+        39, this->internal_lease(), target);
   }
 
-  // optional .cockroach.proto.InternalBatchRequest internal_batch = 39;
+  // optional .cockroach.proto.InternalBatchRequest internal_batch = 40;
   if (has_internal_batch()) {
     target = ::google::protobuf::internal::WireFormatLite::
       WriteMessageNoVirtualToArray(
-        39, this->internal_batch(), target);
+        40, this->internal_batch(), target);
   }
 
   if (!unknown_fields().empty()) {
@@ -9116,35 +9801,42 @@ int InternalRaftCommandUnion::ByteSize() const {
           this->internal_resolve_intent());
       break;
     }
-    // optional .cockroach.proto.InternalMergeRequest internal_merge_response = 35;
+    // optional .cockroach.proto.InternalResolveIntentRangeRequest internal_resolve_intent_range = 35;
+    case kInternalResolveIntentRange: {
+      total_size += 2 +
+        ::google::protobuf::internal::WireFormatLite::MessageSizeNoVirtual(
+          this->internal_resolve_intent_range());
+      break;
+    }
+    // optional .cockroach.proto.InternalMergeRequest internal_merge_response = 36;
     case kInternalMergeResponse: {
       total_size += 2 +
         ::google::protobuf::internal::WireFormatLite::MessageSizeNoVirtual(
           this->internal_merge_response());
       break;
     }
-    // optional .cockroach.proto.InternalTruncateLogRequest internal_truncate_log = 36;
+    // optional .cockroach.proto.InternalTruncateLogRequest internal_truncate_log = 37;
     case kInternalTruncateLog: {
       total_size += 2 +
         ::google::protobuf::internal::WireFormatLite::MessageSizeNoVirtual(
           this->internal_truncate_log());
       break;
     }
-    // optional .cockroach.proto.InternalGCRequest internal_gc = 37;
+    // optional .cockroach.proto.InternalGCRequest internal_gc = 38;
     case kInternalGc: {
       total_size += 2 +
         ::google::protobuf::internal::WireFormatLite::MessageSizeNoVirtual(
           this->internal_gc());
       break;
     }
-    // optional .cockroach.proto.InternalLeaderLeaseRequest internal_lease = 38;
+    // optional .cockroach.proto.InternalLeaderLeaseRequest internal_lease = 39;
     case kInternalLease: {
       total_size += 2 +
         ::google::protobuf::internal::WireFormatLite::MessageSizeNoVirtual(
           this->internal_lease());
       break;
     }
-    // optional .cockroach.proto.InternalBatchRequest internal_batch = 39;
+    // optional .cockroach.proto.InternalBatchRequest internal_batch = 40;
     case kInternalBatch: {
       total_size += 2 +
         ::google::protobuf::internal::WireFormatLite::MessageSizeNoVirtual(
@@ -9235,6 +9927,10 @@ void InternalRaftCommandUnion::MergeFrom(const InternalRaftCommandUnion& from) {
     }
     case kInternalResolveIntent: {
       mutable_internal_resolve_intent()->::cockroach::proto::InternalResolveIntentRequest::MergeFrom(from.internal_resolve_intent());
+      break;
+    }
+    case kInternalResolveIntentRange: {
+      mutable_internal_resolve_intent_range()->::cockroach::proto::InternalResolveIntentRangeRequest::MergeFrom(from.internal_resolve_intent_range());
       break;
     }
     case kInternalMergeResponse: {

--- a/storage/engine/cockroach/proto/internal.pb.h
+++ b/storage/engine/cockroach/proto/internal.pb.h
@@ -50,6 +50,8 @@ class InternalPushTxnRequest;
 class InternalPushTxnResponse;
 class InternalResolveIntentRequest;
 class InternalResolveIntentResponse;
+class InternalResolveIntentRangeRequest;
+class InternalResolveIntentRangeResponse;
 class InternalMergeRequest;
 class InternalMergeResponse;
 class InternalTruncateLogRequest;
@@ -1121,6 +1123,168 @@ class InternalResolveIntentResponse : public ::google::protobuf::Message {
 };
 // -------------------------------------------------------------------
 
+class InternalResolveIntentRangeRequest : public ::google::protobuf::Message {
+ public:
+  InternalResolveIntentRangeRequest();
+  virtual ~InternalResolveIntentRangeRequest();
+
+  InternalResolveIntentRangeRequest(const InternalResolveIntentRangeRequest& from);
+
+  inline InternalResolveIntentRangeRequest& operator=(const InternalResolveIntentRangeRequest& from) {
+    CopyFrom(from);
+    return *this;
+  }
+
+  inline const ::google::protobuf::UnknownFieldSet& unknown_fields() const {
+    return _unknown_fields_;
+  }
+
+  inline ::google::protobuf::UnknownFieldSet* mutable_unknown_fields() {
+    return &_unknown_fields_;
+  }
+
+  static const ::google::protobuf::Descriptor* descriptor();
+  static const InternalResolveIntentRangeRequest& default_instance();
+
+  void Swap(InternalResolveIntentRangeRequest* other);
+
+  // implements Message ----------------------------------------------
+
+  InternalResolveIntentRangeRequest* New() const;
+  void CopyFrom(const ::google::protobuf::Message& from);
+  void MergeFrom(const ::google::protobuf::Message& from);
+  void CopyFrom(const InternalResolveIntentRangeRequest& from);
+  void MergeFrom(const InternalResolveIntentRangeRequest& from);
+  void Clear();
+  bool IsInitialized() const;
+
+  int ByteSize() const;
+  bool MergePartialFromCodedStream(
+      ::google::protobuf::io::CodedInputStream* input);
+  void SerializeWithCachedSizes(
+      ::google::protobuf::io::CodedOutputStream* output) const;
+  ::google::protobuf::uint8* SerializeWithCachedSizesToArray(::google::protobuf::uint8* output) const;
+  int GetCachedSize() const { return _cached_size_; }
+  private:
+  void SharedCtor();
+  void SharedDtor();
+  void SetCachedSize(int size) const;
+  public:
+  ::google::protobuf::Metadata GetMetadata() const;
+
+  // nested types ----------------------------------------------------
+
+  // accessors -------------------------------------------------------
+
+  // optional .cockroach.proto.RequestHeader header = 1;
+  inline bool has_header() const;
+  inline void clear_header();
+  static const int kHeaderFieldNumber = 1;
+  inline const ::cockroach::proto::RequestHeader& header() const;
+  inline ::cockroach::proto::RequestHeader* mutable_header();
+  inline ::cockroach::proto::RequestHeader* release_header();
+  inline void set_allocated_header(::cockroach::proto::RequestHeader* header);
+
+  // @@protoc_insertion_point(class_scope:cockroach.proto.InternalResolveIntentRangeRequest)
+ private:
+  inline void set_has_header();
+  inline void clear_has_header();
+
+  ::google::protobuf::UnknownFieldSet _unknown_fields_;
+
+  ::google::protobuf::uint32 _has_bits_[1];
+  mutable int _cached_size_;
+  ::cockroach::proto::RequestHeader* header_;
+  friend void  protobuf_AddDesc_cockroach_2fproto_2finternal_2eproto();
+  friend void protobuf_AssignDesc_cockroach_2fproto_2finternal_2eproto();
+  friend void protobuf_ShutdownFile_cockroach_2fproto_2finternal_2eproto();
+
+  void InitAsDefaultInstance();
+  static InternalResolveIntentRangeRequest* default_instance_;
+};
+// -------------------------------------------------------------------
+
+class InternalResolveIntentRangeResponse : public ::google::protobuf::Message {
+ public:
+  InternalResolveIntentRangeResponse();
+  virtual ~InternalResolveIntentRangeResponse();
+
+  InternalResolveIntentRangeResponse(const InternalResolveIntentRangeResponse& from);
+
+  inline InternalResolveIntentRangeResponse& operator=(const InternalResolveIntentRangeResponse& from) {
+    CopyFrom(from);
+    return *this;
+  }
+
+  inline const ::google::protobuf::UnknownFieldSet& unknown_fields() const {
+    return _unknown_fields_;
+  }
+
+  inline ::google::protobuf::UnknownFieldSet* mutable_unknown_fields() {
+    return &_unknown_fields_;
+  }
+
+  static const ::google::protobuf::Descriptor* descriptor();
+  static const InternalResolveIntentRangeResponse& default_instance();
+
+  void Swap(InternalResolveIntentRangeResponse* other);
+
+  // implements Message ----------------------------------------------
+
+  InternalResolveIntentRangeResponse* New() const;
+  void CopyFrom(const ::google::protobuf::Message& from);
+  void MergeFrom(const ::google::protobuf::Message& from);
+  void CopyFrom(const InternalResolveIntentRangeResponse& from);
+  void MergeFrom(const InternalResolveIntentRangeResponse& from);
+  void Clear();
+  bool IsInitialized() const;
+
+  int ByteSize() const;
+  bool MergePartialFromCodedStream(
+      ::google::protobuf::io::CodedInputStream* input);
+  void SerializeWithCachedSizes(
+      ::google::protobuf::io::CodedOutputStream* output) const;
+  ::google::protobuf::uint8* SerializeWithCachedSizesToArray(::google::protobuf::uint8* output) const;
+  int GetCachedSize() const { return _cached_size_; }
+  private:
+  void SharedCtor();
+  void SharedDtor();
+  void SetCachedSize(int size) const;
+  public:
+  ::google::protobuf::Metadata GetMetadata() const;
+
+  // nested types ----------------------------------------------------
+
+  // accessors -------------------------------------------------------
+
+  // optional .cockroach.proto.ResponseHeader header = 1;
+  inline bool has_header() const;
+  inline void clear_header();
+  static const int kHeaderFieldNumber = 1;
+  inline const ::cockroach::proto::ResponseHeader& header() const;
+  inline ::cockroach::proto::ResponseHeader* mutable_header();
+  inline ::cockroach::proto::ResponseHeader* release_header();
+  inline void set_allocated_header(::cockroach::proto::ResponseHeader* header);
+
+  // @@protoc_insertion_point(class_scope:cockroach.proto.InternalResolveIntentRangeResponse)
+ private:
+  inline void set_has_header();
+  inline void clear_has_header();
+
+  ::google::protobuf::UnknownFieldSet _unknown_fields_;
+
+  ::google::protobuf::uint32 _has_bits_[1];
+  mutable int _cached_size_;
+  ::cockroach::proto::ResponseHeader* header_;
+  friend void  protobuf_AddDesc_cockroach_2fproto_2finternal_2eproto();
+  friend void protobuf_AssignDesc_cockroach_2fproto_2finternal_2eproto();
+  friend void protobuf_ShutdownFile_cockroach_2fproto_2finternal_2eproto();
+
+  void InitAsDefaultInstance();
+  static InternalResolveIntentRangeResponse* default_instance_;
+};
+// -------------------------------------------------------------------
+
 class InternalMergeRequest : public ::google::protobuf::Message {
  public:
   InternalMergeRequest();
@@ -1676,6 +1840,7 @@ class InternalRequestUnion : public ::google::protobuf::Message {
     kEndTransaction = 9,
     kInternalPushTxn = 30,
     kInternalResolveIntent = 31,
+    kInternalResolveIntentRange = 32,
     VALUE_NOT_SET = 0,
   };
 
@@ -1808,6 +1973,15 @@ class InternalRequestUnion : public ::google::protobuf::Message {
   inline ::cockroach::proto::InternalResolveIntentRequest* release_internal_resolve_intent();
   inline void set_allocated_internal_resolve_intent(::cockroach::proto::InternalResolveIntentRequest* internal_resolve_intent);
 
+  // optional .cockroach.proto.InternalResolveIntentRangeRequest internal_resolve_intent_range = 32;
+  inline bool has_internal_resolve_intent_range() const;
+  inline void clear_internal_resolve_intent_range();
+  static const int kInternalResolveIntentRangeFieldNumber = 32;
+  inline const ::cockroach::proto::InternalResolveIntentRangeRequest& internal_resolve_intent_range() const;
+  inline ::cockroach::proto::InternalResolveIntentRangeRequest* mutable_internal_resolve_intent_range();
+  inline ::cockroach::proto::InternalResolveIntentRangeRequest* release_internal_resolve_intent_range();
+  inline void set_allocated_internal_resolve_intent_range(::cockroach::proto::InternalResolveIntentRangeRequest* internal_resolve_intent_range);
+
   inline ValueCase value_case() const;
   // @@protoc_insertion_point(class_scope:cockroach.proto.InternalRequestUnion)
  private:
@@ -1822,6 +1996,7 @@ class InternalRequestUnion : public ::google::protobuf::Message {
   inline void set_has_end_transaction();
   inline void set_has_internal_push_txn();
   inline void set_has_internal_resolve_intent();
+  inline void set_has_internal_resolve_intent_range();
 
   inline bool has_value();
   void clear_value();
@@ -1843,6 +2018,7 @@ class InternalRequestUnion : public ::google::protobuf::Message {
     ::cockroach::proto::EndTransactionRequest* end_transaction_;
     ::cockroach::proto::InternalPushTxnRequest* internal_push_txn_;
     ::cockroach::proto::InternalResolveIntentRequest* internal_resolve_intent_;
+    ::cockroach::proto::InternalResolveIntentRangeRequest* internal_resolve_intent_range_;
   } value_;
   ::google::protobuf::uint32 _oneof_case_[1];
 
@@ -1890,6 +2066,7 @@ class InternalResponseUnion : public ::google::protobuf::Message {
     kEndTransaction = 9,
     kInternalPushTxn = 30,
     kInternalResolveIntent = 31,
+    kInternalResolveIntentRange = 32,
     VALUE_NOT_SET = 0,
   };
 
@@ -2022,6 +2199,15 @@ class InternalResponseUnion : public ::google::protobuf::Message {
   inline ::cockroach::proto::InternalResolveIntentResponse* release_internal_resolve_intent();
   inline void set_allocated_internal_resolve_intent(::cockroach::proto::InternalResolveIntentResponse* internal_resolve_intent);
 
+  // optional .cockroach.proto.InternalResolveIntentRangeResponse internal_resolve_intent_range = 32;
+  inline bool has_internal_resolve_intent_range() const;
+  inline void clear_internal_resolve_intent_range();
+  static const int kInternalResolveIntentRangeFieldNumber = 32;
+  inline const ::cockroach::proto::InternalResolveIntentRangeResponse& internal_resolve_intent_range() const;
+  inline ::cockroach::proto::InternalResolveIntentRangeResponse* mutable_internal_resolve_intent_range();
+  inline ::cockroach::proto::InternalResolveIntentRangeResponse* release_internal_resolve_intent_range();
+  inline void set_allocated_internal_resolve_intent_range(::cockroach::proto::InternalResolveIntentRangeResponse* internal_resolve_intent_range);
+
   inline ValueCase value_case() const;
   // @@protoc_insertion_point(class_scope:cockroach.proto.InternalResponseUnion)
  private:
@@ -2036,6 +2222,7 @@ class InternalResponseUnion : public ::google::protobuf::Message {
   inline void set_has_end_transaction();
   inline void set_has_internal_push_txn();
   inline void set_has_internal_resolve_intent();
+  inline void set_has_internal_resolve_intent_range();
 
   inline bool has_value();
   void clear_value();
@@ -2057,6 +2244,7 @@ class InternalResponseUnion : public ::google::protobuf::Message {
     ::cockroach::proto::EndTransactionResponse* end_transaction_;
     ::cockroach::proto::InternalPushTxnResponse* internal_push_txn_;
     ::cockroach::proto::InternalResolveIntentResponse* internal_resolve_intent_;
+    ::cockroach::proto::InternalResolveIntentRangeResponse* internal_resolve_intent_range_;
   } value_;
   ::google::protobuf::uint32 _oneof_case_[1];
 
@@ -2290,10 +2478,11 @@ class ReadWriteCmdResponse : public ::google::protobuf::Message {
     kInternalHeartbeatTxn = 10,
     kInternalPushTxn = 11,
     kInternalResolveIntent = 12,
-    kInternalMerge = 13,
-    kInternalTruncateLog = 14,
-    kInternalGc = 15,
-    kInternalLeaderLease = 16,
+    kInternalResolveIntentRange = 13,
+    kInternalMerge = 14,
+    kInternalTruncateLog = 15,
+    kInternalGc = 16,
+    kInternalLeaderLease = 17,
     VALUE_NOT_SET = 0,
   };
 
@@ -2408,37 +2597,46 @@ class ReadWriteCmdResponse : public ::google::protobuf::Message {
   inline ::cockroach::proto::InternalResolveIntentResponse* release_internal_resolve_intent();
   inline void set_allocated_internal_resolve_intent(::cockroach::proto::InternalResolveIntentResponse* internal_resolve_intent);
 
-  // optional .cockroach.proto.InternalMergeResponse internal_merge = 13;
+  // optional .cockroach.proto.InternalResolveIntentRangeResponse internal_resolve_intent_range = 13;
+  inline bool has_internal_resolve_intent_range() const;
+  inline void clear_internal_resolve_intent_range();
+  static const int kInternalResolveIntentRangeFieldNumber = 13;
+  inline const ::cockroach::proto::InternalResolveIntentRangeResponse& internal_resolve_intent_range() const;
+  inline ::cockroach::proto::InternalResolveIntentRangeResponse* mutable_internal_resolve_intent_range();
+  inline ::cockroach::proto::InternalResolveIntentRangeResponse* release_internal_resolve_intent_range();
+  inline void set_allocated_internal_resolve_intent_range(::cockroach::proto::InternalResolveIntentRangeResponse* internal_resolve_intent_range);
+
+  // optional .cockroach.proto.InternalMergeResponse internal_merge = 14;
   inline bool has_internal_merge() const;
   inline void clear_internal_merge();
-  static const int kInternalMergeFieldNumber = 13;
+  static const int kInternalMergeFieldNumber = 14;
   inline const ::cockroach::proto::InternalMergeResponse& internal_merge() const;
   inline ::cockroach::proto::InternalMergeResponse* mutable_internal_merge();
   inline ::cockroach::proto::InternalMergeResponse* release_internal_merge();
   inline void set_allocated_internal_merge(::cockroach::proto::InternalMergeResponse* internal_merge);
 
-  // optional .cockroach.proto.InternalTruncateLogResponse internal_truncate_log = 14;
+  // optional .cockroach.proto.InternalTruncateLogResponse internal_truncate_log = 15;
   inline bool has_internal_truncate_log() const;
   inline void clear_internal_truncate_log();
-  static const int kInternalTruncateLogFieldNumber = 14;
+  static const int kInternalTruncateLogFieldNumber = 15;
   inline const ::cockroach::proto::InternalTruncateLogResponse& internal_truncate_log() const;
   inline ::cockroach::proto::InternalTruncateLogResponse* mutable_internal_truncate_log();
   inline ::cockroach::proto::InternalTruncateLogResponse* release_internal_truncate_log();
   inline void set_allocated_internal_truncate_log(::cockroach::proto::InternalTruncateLogResponse* internal_truncate_log);
 
-  // optional .cockroach.proto.InternalGCResponse internal_gc = 15;
+  // optional .cockroach.proto.InternalGCResponse internal_gc = 16;
   inline bool has_internal_gc() const;
   inline void clear_internal_gc();
-  static const int kInternalGcFieldNumber = 15;
+  static const int kInternalGcFieldNumber = 16;
   inline const ::cockroach::proto::InternalGCResponse& internal_gc() const;
   inline ::cockroach::proto::InternalGCResponse* mutable_internal_gc();
   inline ::cockroach::proto::InternalGCResponse* release_internal_gc();
   inline void set_allocated_internal_gc(::cockroach::proto::InternalGCResponse* internal_gc);
 
-  // optional .cockroach.proto.InternalLeaderLeaseResponse internal_leader_lease = 16;
+  // optional .cockroach.proto.InternalLeaderLeaseResponse internal_leader_lease = 17;
   inline bool has_internal_leader_lease() const;
   inline void clear_internal_leader_lease();
-  static const int kInternalLeaderLeaseFieldNumber = 16;
+  static const int kInternalLeaderLeaseFieldNumber = 17;
   inline const ::cockroach::proto::InternalLeaderLeaseResponse& internal_leader_lease() const;
   inline ::cockroach::proto::InternalLeaderLeaseResponse* mutable_internal_leader_lease();
   inline ::cockroach::proto::InternalLeaderLeaseResponse* release_internal_leader_lease();
@@ -2456,6 +2654,7 @@ class ReadWriteCmdResponse : public ::google::protobuf::Message {
   inline void set_has_internal_heartbeat_txn();
   inline void set_has_internal_push_txn();
   inline void set_has_internal_resolve_intent();
+  inline void set_has_internal_resolve_intent_range();
   inline void set_has_internal_merge();
   inline void set_has_internal_truncate_log();
   inline void set_has_internal_gc();
@@ -2479,6 +2678,7 @@ class ReadWriteCmdResponse : public ::google::protobuf::Message {
     ::cockroach::proto::InternalHeartbeatTxnResponse* internal_heartbeat_txn_;
     ::cockroach::proto::InternalPushTxnResponse* internal_push_txn_;
     ::cockroach::proto::InternalResolveIntentResponse* internal_resolve_intent_;
+    ::cockroach::proto::InternalResolveIntentRangeResponse* internal_resolve_intent_range_;
     ::cockroach::proto::InternalMergeResponse* internal_merge_;
     ::cockroach::proto::InternalTruncateLogResponse* internal_truncate_log_;
     ::cockroach::proto::InternalGCResponse* internal_gc_;
@@ -2533,11 +2733,12 @@ class InternalRaftCommandUnion : public ::google::protobuf::Message {
     kInternalHeartbeatTxn = 32,
     kInternalPushTxn = 33,
     kInternalResolveIntent = 34,
-    kInternalMergeResponse = 35,
-    kInternalTruncateLog = 36,
-    kInternalGc = 37,
-    kInternalLease = 38,
-    kInternalBatch = 39,
+    kInternalResolveIntentRange = 35,
+    kInternalMergeResponse = 36,
+    kInternalTruncateLog = 37,
+    kInternalGc = 38,
+    kInternalLease = 39,
+    kInternalBatch = 40,
     VALUE_NOT_SET = 0,
   };
 
@@ -2697,46 +2898,55 @@ class InternalRaftCommandUnion : public ::google::protobuf::Message {
   inline ::cockroach::proto::InternalResolveIntentRequest* release_internal_resolve_intent();
   inline void set_allocated_internal_resolve_intent(::cockroach::proto::InternalResolveIntentRequest* internal_resolve_intent);
 
-  // optional .cockroach.proto.InternalMergeRequest internal_merge_response = 35;
+  // optional .cockroach.proto.InternalResolveIntentRangeRequest internal_resolve_intent_range = 35;
+  inline bool has_internal_resolve_intent_range() const;
+  inline void clear_internal_resolve_intent_range();
+  static const int kInternalResolveIntentRangeFieldNumber = 35;
+  inline const ::cockroach::proto::InternalResolveIntentRangeRequest& internal_resolve_intent_range() const;
+  inline ::cockroach::proto::InternalResolveIntentRangeRequest* mutable_internal_resolve_intent_range();
+  inline ::cockroach::proto::InternalResolveIntentRangeRequest* release_internal_resolve_intent_range();
+  inline void set_allocated_internal_resolve_intent_range(::cockroach::proto::InternalResolveIntentRangeRequest* internal_resolve_intent_range);
+
+  // optional .cockroach.proto.InternalMergeRequest internal_merge_response = 36;
   inline bool has_internal_merge_response() const;
   inline void clear_internal_merge_response();
-  static const int kInternalMergeResponseFieldNumber = 35;
+  static const int kInternalMergeResponseFieldNumber = 36;
   inline const ::cockroach::proto::InternalMergeRequest& internal_merge_response() const;
   inline ::cockroach::proto::InternalMergeRequest* mutable_internal_merge_response();
   inline ::cockroach::proto::InternalMergeRequest* release_internal_merge_response();
   inline void set_allocated_internal_merge_response(::cockroach::proto::InternalMergeRequest* internal_merge_response);
 
-  // optional .cockroach.proto.InternalTruncateLogRequest internal_truncate_log = 36;
+  // optional .cockroach.proto.InternalTruncateLogRequest internal_truncate_log = 37;
   inline bool has_internal_truncate_log() const;
   inline void clear_internal_truncate_log();
-  static const int kInternalTruncateLogFieldNumber = 36;
+  static const int kInternalTruncateLogFieldNumber = 37;
   inline const ::cockroach::proto::InternalTruncateLogRequest& internal_truncate_log() const;
   inline ::cockroach::proto::InternalTruncateLogRequest* mutable_internal_truncate_log();
   inline ::cockroach::proto::InternalTruncateLogRequest* release_internal_truncate_log();
   inline void set_allocated_internal_truncate_log(::cockroach::proto::InternalTruncateLogRequest* internal_truncate_log);
 
-  // optional .cockroach.proto.InternalGCRequest internal_gc = 37;
+  // optional .cockroach.proto.InternalGCRequest internal_gc = 38;
   inline bool has_internal_gc() const;
   inline void clear_internal_gc();
-  static const int kInternalGcFieldNumber = 37;
+  static const int kInternalGcFieldNumber = 38;
   inline const ::cockroach::proto::InternalGCRequest& internal_gc() const;
   inline ::cockroach::proto::InternalGCRequest* mutable_internal_gc();
   inline ::cockroach::proto::InternalGCRequest* release_internal_gc();
   inline void set_allocated_internal_gc(::cockroach::proto::InternalGCRequest* internal_gc);
 
-  // optional .cockroach.proto.InternalLeaderLeaseRequest internal_lease = 38;
+  // optional .cockroach.proto.InternalLeaderLeaseRequest internal_lease = 39;
   inline bool has_internal_lease() const;
   inline void clear_internal_lease();
-  static const int kInternalLeaseFieldNumber = 38;
+  static const int kInternalLeaseFieldNumber = 39;
   inline const ::cockroach::proto::InternalLeaderLeaseRequest& internal_lease() const;
   inline ::cockroach::proto::InternalLeaderLeaseRequest* mutable_internal_lease();
   inline ::cockroach::proto::InternalLeaderLeaseRequest* release_internal_lease();
   inline void set_allocated_internal_lease(::cockroach::proto::InternalLeaderLeaseRequest* internal_lease);
 
-  // optional .cockroach.proto.InternalBatchRequest internal_batch = 39;
+  // optional .cockroach.proto.InternalBatchRequest internal_batch = 40;
   inline bool has_internal_batch() const;
   inline void clear_internal_batch();
-  static const int kInternalBatchFieldNumber = 39;
+  static const int kInternalBatchFieldNumber = 40;
   inline const ::cockroach::proto::InternalBatchRequest& internal_batch() const;
   inline ::cockroach::proto::InternalBatchRequest* mutable_internal_batch();
   inline ::cockroach::proto::InternalBatchRequest* release_internal_batch();
@@ -2759,6 +2969,7 @@ class InternalRaftCommandUnion : public ::google::protobuf::Message {
   inline void set_has_internal_heartbeat_txn();
   inline void set_has_internal_push_txn();
   inline void set_has_internal_resolve_intent();
+  inline void set_has_internal_resolve_intent_range();
   inline void set_has_internal_merge_response();
   inline void set_has_internal_truncate_log();
   inline void set_has_internal_gc();
@@ -2788,6 +2999,7 @@ class InternalRaftCommandUnion : public ::google::protobuf::Message {
     ::cockroach::proto::InternalHeartbeatTxnRequest* internal_heartbeat_txn_;
     ::cockroach::proto::InternalPushTxnRequest* internal_push_txn_;
     ::cockroach::proto::InternalResolveIntentRequest* internal_resolve_intent_;
+    ::cockroach::proto::InternalResolveIntentRangeRequest* internal_resolve_intent_range_;
     ::cockroach::proto::InternalMergeRequest* internal_merge_response_;
     ::cockroach::proto::InternalTruncateLogRequest* internal_truncate_log_;
     ::cockroach::proto::InternalGCRequest* internal_gc_;
@@ -4416,6 +4628,96 @@ inline void InternalResolveIntentResponse::set_allocated_header(::cockroach::pro
 
 // -------------------------------------------------------------------
 
+// InternalResolveIntentRangeRequest
+
+// optional .cockroach.proto.RequestHeader header = 1;
+inline bool InternalResolveIntentRangeRequest::has_header() const {
+  return (_has_bits_[0] & 0x00000001u) != 0;
+}
+inline void InternalResolveIntentRangeRequest::set_has_header() {
+  _has_bits_[0] |= 0x00000001u;
+}
+inline void InternalResolveIntentRangeRequest::clear_has_header() {
+  _has_bits_[0] &= ~0x00000001u;
+}
+inline void InternalResolveIntentRangeRequest::clear_header() {
+  if (header_ != NULL) header_->::cockroach::proto::RequestHeader::Clear();
+  clear_has_header();
+}
+inline const ::cockroach::proto::RequestHeader& InternalResolveIntentRangeRequest::header() const {
+  // @@protoc_insertion_point(field_get:cockroach.proto.InternalResolveIntentRangeRequest.header)
+  return header_ != NULL ? *header_ : *default_instance_->header_;
+}
+inline ::cockroach::proto::RequestHeader* InternalResolveIntentRangeRequest::mutable_header() {
+  set_has_header();
+  if (header_ == NULL) header_ = new ::cockroach::proto::RequestHeader;
+  // @@protoc_insertion_point(field_mutable:cockroach.proto.InternalResolveIntentRangeRequest.header)
+  return header_;
+}
+inline ::cockroach::proto::RequestHeader* InternalResolveIntentRangeRequest::release_header() {
+  clear_has_header();
+  ::cockroach::proto::RequestHeader* temp = header_;
+  header_ = NULL;
+  return temp;
+}
+inline void InternalResolveIntentRangeRequest::set_allocated_header(::cockroach::proto::RequestHeader* header) {
+  delete header_;
+  header_ = header;
+  if (header) {
+    set_has_header();
+  } else {
+    clear_has_header();
+  }
+  // @@protoc_insertion_point(field_set_allocated:cockroach.proto.InternalResolveIntentRangeRequest.header)
+}
+
+// -------------------------------------------------------------------
+
+// InternalResolveIntentRangeResponse
+
+// optional .cockroach.proto.ResponseHeader header = 1;
+inline bool InternalResolveIntentRangeResponse::has_header() const {
+  return (_has_bits_[0] & 0x00000001u) != 0;
+}
+inline void InternalResolveIntentRangeResponse::set_has_header() {
+  _has_bits_[0] |= 0x00000001u;
+}
+inline void InternalResolveIntentRangeResponse::clear_has_header() {
+  _has_bits_[0] &= ~0x00000001u;
+}
+inline void InternalResolveIntentRangeResponse::clear_header() {
+  if (header_ != NULL) header_->::cockroach::proto::ResponseHeader::Clear();
+  clear_has_header();
+}
+inline const ::cockroach::proto::ResponseHeader& InternalResolveIntentRangeResponse::header() const {
+  // @@protoc_insertion_point(field_get:cockroach.proto.InternalResolveIntentRangeResponse.header)
+  return header_ != NULL ? *header_ : *default_instance_->header_;
+}
+inline ::cockroach::proto::ResponseHeader* InternalResolveIntentRangeResponse::mutable_header() {
+  set_has_header();
+  if (header_ == NULL) header_ = new ::cockroach::proto::ResponseHeader;
+  // @@protoc_insertion_point(field_mutable:cockroach.proto.InternalResolveIntentRangeResponse.header)
+  return header_;
+}
+inline ::cockroach::proto::ResponseHeader* InternalResolveIntentRangeResponse::release_header() {
+  clear_has_header();
+  ::cockroach::proto::ResponseHeader* temp = header_;
+  header_ = NULL;
+  return temp;
+}
+inline void InternalResolveIntentRangeResponse::set_allocated_header(::cockroach::proto::ResponseHeader* header) {
+  delete header_;
+  header_ = header;
+  if (header) {
+    set_has_header();
+  } else {
+    clear_has_header();
+  }
+  // @@protoc_insertion_point(field_set_allocated:cockroach.proto.InternalResolveIntentRangeResponse.header)
+}
+
+// -------------------------------------------------------------------
+
 // InternalMergeRequest
 
 // optional .cockroach.proto.RequestHeader header = 1;
@@ -5267,6 +5569,49 @@ inline void InternalRequestUnion::set_allocated_internal_resolve_intent(::cockro
   }
 }
 
+// optional .cockroach.proto.InternalResolveIntentRangeRequest internal_resolve_intent_range = 32;
+inline bool InternalRequestUnion::has_internal_resolve_intent_range() const {
+  return value_case() == kInternalResolveIntentRange;
+}
+inline void InternalRequestUnion::set_has_internal_resolve_intent_range() {
+  _oneof_case_[0] = kInternalResolveIntentRange;
+}
+inline void InternalRequestUnion::clear_internal_resolve_intent_range() {
+  if (has_internal_resolve_intent_range()) {
+    delete value_.internal_resolve_intent_range_;
+    clear_has_value();
+  }
+}
+inline const ::cockroach::proto::InternalResolveIntentRangeRequest& InternalRequestUnion::internal_resolve_intent_range() const {
+  return has_internal_resolve_intent_range() ? *value_.internal_resolve_intent_range_
+                      : ::cockroach::proto::InternalResolveIntentRangeRequest::default_instance();
+}
+inline ::cockroach::proto::InternalResolveIntentRangeRequest* InternalRequestUnion::mutable_internal_resolve_intent_range() {
+  if (!has_internal_resolve_intent_range()) {
+    clear_value();
+    set_has_internal_resolve_intent_range();
+    value_.internal_resolve_intent_range_ = new ::cockroach::proto::InternalResolveIntentRangeRequest;
+  }
+  return value_.internal_resolve_intent_range_;
+}
+inline ::cockroach::proto::InternalResolveIntentRangeRequest* InternalRequestUnion::release_internal_resolve_intent_range() {
+  if (has_internal_resolve_intent_range()) {
+    clear_has_value();
+    ::cockroach::proto::InternalResolveIntentRangeRequest* temp = value_.internal_resolve_intent_range_;
+    value_.internal_resolve_intent_range_ = NULL;
+    return temp;
+  } else {
+    return NULL;
+  }
+}
+inline void InternalRequestUnion::set_allocated_internal_resolve_intent_range(::cockroach::proto::InternalResolveIntentRangeRequest* internal_resolve_intent_range) {
+  clear_value();
+  if (internal_resolve_intent_range) {
+    set_has_internal_resolve_intent_range();
+    value_.internal_resolve_intent_range_ = internal_resolve_intent_range;
+  }
+}
+
 inline bool InternalRequestUnion::has_value() {
   return value_case() != VALUE_NOT_SET;
 }
@@ -5750,6 +6095,49 @@ inline void InternalResponseUnion::set_allocated_internal_resolve_intent(::cockr
   if (internal_resolve_intent) {
     set_has_internal_resolve_intent();
     value_.internal_resolve_intent_ = internal_resolve_intent;
+  }
+}
+
+// optional .cockroach.proto.InternalResolveIntentRangeResponse internal_resolve_intent_range = 32;
+inline bool InternalResponseUnion::has_internal_resolve_intent_range() const {
+  return value_case() == kInternalResolveIntentRange;
+}
+inline void InternalResponseUnion::set_has_internal_resolve_intent_range() {
+  _oneof_case_[0] = kInternalResolveIntentRange;
+}
+inline void InternalResponseUnion::clear_internal_resolve_intent_range() {
+  if (has_internal_resolve_intent_range()) {
+    delete value_.internal_resolve_intent_range_;
+    clear_has_value();
+  }
+}
+inline const ::cockroach::proto::InternalResolveIntentRangeResponse& InternalResponseUnion::internal_resolve_intent_range() const {
+  return has_internal_resolve_intent_range() ? *value_.internal_resolve_intent_range_
+                      : ::cockroach::proto::InternalResolveIntentRangeResponse::default_instance();
+}
+inline ::cockroach::proto::InternalResolveIntentRangeResponse* InternalResponseUnion::mutable_internal_resolve_intent_range() {
+  if (!has_internal_resolve_intent_range()) {
+    clear_value();
+    set_has_internal_resolve_intent_range();
+    value_.internal_resolve_intent_range_ = new ::cockroach::proto::InternalResolveIntentRangeResponse;
+  }
+  return value_.internal_resolve_intent_range_;
+}
+inline ::cockroach::proto::InternalResolveIntentRangeResponse* InternalResponseUnion::release_internal_resolve_intent_range() {
+  if (has_internal_resolve_intent_range()) {
+    clear_has_value();
+    ::cockroach::proto::InternalResolveIntentRangeResponse* temp = value_.internal_resolve_intent_range_;
+    value_.internal_resolve_intent_range_ = NULL;
+    return temp;
+  } else {
+    return NULL;
+  }
+}
+inline void InternalResponseUnion::set_allocated_internal_resolve_intent_range(::cockroach::proto::InternalResolveIntentRangeResponse* internal_resolve_intent_range) {
+  clear_value();
+  if (internal_resolve_intent_range) {
+    set_has_internal_resolve_intent_range();
+    value_.internal_resolve_intent_range_ = internal_resolve_intent_range;
   }
 }
 
@@ -6303,7 +6691,50 @@ inline void ReadWriteCmdResponse::set_allocated_internal_resolve_intent(::cockro
   }
 }
 
-// optional .cockroach.proto.InternalMergeResponse internal_merge = 13;
+// optional .cockroach.proto.InternalResolveIntentRangeResponse internal_resolve_intent_range = 13;
+inline bool ReadWriteCmdResponse::has_internal_resolve_intent_range() const {
+  return value_case() == kInternalResolveIntentRange;
+}
+inline void ReadWriteCmdResponse::set_has_internal_resolve_intent_range() {
+  _oneof_case_[0] = kInternalResolveIntentRange;
+}
+inline void ReadWriteCmdResponse::clear_internal_resolve_intent_range() {
+  if (has_internal_resolve_intent_range()) {
+    delete value_.internal_resolve_intent_range_;
+    clear_has_value();
+  }
+}
+inline const ::cockroach::proto::InternalResolveIntentRangeResponse& ReadWriteCmdResponse::internal_resolve_intent_range() const {
+  return has_internal_resolve_intent_range() ? *value_.internal_resolve_intent_range_
+                      : ::cockroach::proto::InternalResolveIntentRangeResponse::default_instance();
+}
+inline ::cockroach::proto::InternalResolveIntentRangeResponse* ReadWriteCmdResponse::mutable_internal_resolve_intent_range() {
+  if (!has_internal_resolve_intent_range()) {
+    clear_value();
+    set_has_internal_resolve_intent_range();
+    value_.internal_resolve_intent_range_ = new ::cockroach::proto::InternalResolveIntentRangeResponse;
+  }
+  return value_.internal_resolve_intent_range_;
+}
+inline ::cockroach::proto::InternalResolveIntentRangeResponse* ReadWriteCmdResponse::release_internal_resolve_intent_range() {
+  if (has_internal_resolve_intent_range()) {
+    clear_has_value();
+    ::cockroach::proto::InternalResolveIntentRangeResponse* temp = value_.internal_resolve_intent_range_;
+    value_.internal_resolve_intent_range_ = NULL;
+    return temp;
+  } else {
+    return NULL;
+  }
+}
+inline void ReadWriteCmdResponse::set_allocated_internal_resolve_intent_range(::cockroach::proto::InternalResolveIntentRangeResponse* internal_resolve_intent_range) {
+  clear_value();
+  if (internal_resolve_intent_range) {
+    set_has_internal_resolve_intent_range();
+    value_.internal_resolve_intent_range_ = internal_resolve_intent_range;
+  }
+}
+
+// optional .cockroach.proto.InternalMergeResponse internal_merge = 14;
 inline bool ReadWriteCmdResponse::has_internal_merge() const {
   return value_case() == kInternalMerge;
 }
@@ -6346,7 +6777,7 @@ inline void ReadWriteCmdResponse::set_allocated_internal_merge(::cockroach::prot
   }
 }
 
-// optional .cockroach.proto.InternalTruncateLogResponse internal_truncate_log = 14;
+// optional .cockroach.proto.InternalTruncateLogResponse internal_truncate_log = 15;
 inline bool ReadWriteCmdResponse::has_internal_truncate_log() const {
   return value_case() == kInternalTruncateLog;
 }
@@ -6389,7 +6820,7 @@ inline void ReadWriteCmdResponse::set_allocated_internal_truncate_log(::cockroac
   }
 }
 
-// optional .cockroach.proto.InternalGCResponse internal_gc = 15;
+// optional .cockroach.proto.InternalGCResponse internal_gc = 16;
 inline bool ReadWriteCmdResponse::has_internal_gc() const {
   return value_case() == kInternalGc;
 }
@@ -6432,7 +6863,7 @@ inline void ReadWriteCmdResponse::set_allocated_internal_gc(::cockroach::proto::
   }
 }
 
-// optional .cockroach.proto.InternalLeaderLeaseResponse internal_leader_lease = 16;
+// optional .cockroach.proto.InternalLeaderLeaseResponse internal_leader_lease = 17;
 inline bool ReadWriteCmdResponse::has_internal_leader_lease() const {
   return value_case() == kInternalLeaderLease;
 }
@@ -7090,7 +7521,50 @@ inline void InternalRaftCommandUnion::set_allocated_internal_resolve_intent(::co
   }
 }
 
-// optional .cockroach.proto.InternalMergeRequest internal_merge_response = 35;
+// optional .cockroach.proto.InternalResolveIntentRangeRequest internal_resolve_intent_range = 35;
+inline bool InternalRaftCommandUnion::has_internal_resolve_intent_range() const {
+  return value_case() == kInternalResolveIntentRange;
+}
+inline void InternalRaftCommandUnion::set_has_internal_resolve_intent_range() {
+  _oneof_case_[0] = kInternalResolveIntentRange;
+}
+inline void InternalRaftCommandUnion::clear_internal_resolve_intent_range() {
+  if (has_internal_resolve_intent_range()) {
+    delete value_.internal_resolve_intent_range_;
+    clear_has_value();
+  }
+}
+inline const ::cockroach::proto::InternalResolveIntentRangeRequest& InternalRaftCommandUnion::internal_resolve_intent_range() const {
+  return has_internal_resolve_intent_range() ? *value_.internal_resolve_intent_range_
+                      : ::cockroach::proto::InternalResolveIntentRangeRequest::default_instance();
+}
+inline ::cockroach::proto::InternalResolveIntentRangeRequest* InternalRaftCommandUnion::mutable_internal_resolve_intent_range() {
+  if (!has_internal_resolve_intent_range()) {
+    clear_value();
+    set_has_internal_resolve_intent_range();
+    value_.internal_resolve_intent_range_ = new ::cockroach::proto::InternalResolveIntentRangeRequest;
+  }
+  return value_.internal_resolve_intent_range_;
+}
+inline ::cockroach::proto::InternalResolveIntentRangeRequest* InternalRaftCommandUnion::release_internal_resolve_intent_range() {
+  if (has_internal_resolve_intent_range()) {
+    clear_has_value();
+    ::cockroach::proto::InternalResolveIntentRangeRequest* temp = value_.internal_resolve_intent_range_;
+    value_.internal_resolve_intent_range_ = NULL;
+    return temp;
+  } else {
+    return NULL;
+  }
+}
+inline void InternalRaftCommandUnion::set_allocated_internal_resolve_intent_range(::cockroach::proto::InternalResolveIntentRangeRequest* internal_resolve_intent_range) {
+  clear_value();
+  if (internal_resolve_intent_range) {
+    set_has_internal_resolve_intent_range();
+    value_.internal_resolve_intent_range_ = internal_resolve_intent_range;
+  }
+}
+
+// optional .cockroach.proto.InternalMergeRequest internal_merge_response = 36;
 inline bool InternalRaftCommandUnion::has_internal_merge_response() const {
   return value_case() == kInternalMergeResponse;
 }
@@ -7133,7 +7607,7 @@ inline void InternalRaftCommandUnion::set_allocated_internal_merge_response(::co
   }
 }
 
-// optional .cockroach.proto.InternalTruncateLogRequest internal_truncate_log = 36;
+// optional .cockroach.proto.InternalTruncateLogRequest internal_truncate_log = 37;
 inline bool InternalRaftCommandUnion::has_internal_truncate_log() const {
   return value_case() == kInternalTruncateLog;
 }
@@ -7176,7 +7650,7 @@ inline void InternalRaftCommandUnion::set_allocated_internal_truncate_log(::cock
   }
 }
 
-// optional .cockroach.proto.InternalGCRequest internal_gc = 37;
+// optional .cockroach.proto.InternalGCRequest internal_gc = 38;
 inline bool InternalRaftCommandUnion::has_internal_gc() const {
   return value_case() == kInternalGc;
 }
@@ -7219,7 +7693,7 @@ inline void InternalRaftCommandUnion::set_allocated_internal_gc(::cockroach::pro
   }
 }
 
-// optional .cockroach.proto.InternalLeaderLeaseRequest internal_lease = 38;
+// optional .cockroach.proto.InternalLeaderLeaseRequest internal_lease = 39;
 inline bool InternalRaftCommandUnion::has_internal_lease() const {
   return value_case() == kInternalLease;
 }
@@ -7262,7 +7736,7 @@ inline void InternalRaftCommandUnion::set_allocated_internal_lease(::cockroach::
   }
 }
 
-// optional .cockroach.proto.InternalBatchRequest internal_batch = 39;
+// optional .cockroach.proto.InternalBatchRequest internal_batch = 40;
 inline bool InternalRaftCommandUnion::has_internal_batch() const {
   return value_case() == kInternalBatch;
 }

--- a/storage/range.go
+++ b/storage/range.go
@@ -124,15 +124,16 @@ var configDescriptors = [...]*configDescriptor{
 // tsCacheMethods specifies the set of methods which affect the
 // timestamp cache.
 var tsCacheMethods = [...]bool{
-	proto.Contains:              true,
-	proto.Get:                   true,
-	proto.Put:                   true,
-	proto.ConditionalPut:        true,
-	proto.Increment:             true,
-	proto.Scan:                  true,
-	proto.Delete:                true,
-	proto.DeleteRange:           true,
-	proto.InternalResolveIntent: true,
+	proto.Contains:                   true,
+	proto.Get:                        true,
+	proto.Put:                        true,
+	proto.ConditionalPut:             true,
+	proto.Increment:                  true,
+	proto.Scan:                       true,
+	proto.Delete:                     true,
+	proto.DeleteRange:                true,
+	proto.InternalResolveIntent:      true,
+	proto.InternalResolveIntentRange: true,
 }
 
 // usesTimestampCache returns true if the request affects or is

--- a/storage/store_test.go
+++ b/storage/store_test.go
@@ -24,6 +24,7 @@ import (
 	"fmt"
 	"math"
 	"sort"
+	"strings"
 	"testing"
 	"time"
 
@@ -456,7 +457,7 @@ func TestStoreVerifyKeys(t *testing.T) {
 	defer leaktest.AfterTest(t)
 	store, _, stopper := createTestStore(t)
 	defer stopper.Stop()
-	tooLongKey := engine.MakeKey(engine.KeyMax, []byte{0})
+	tooLongKey := proto.Key(strings.Repeat("x", engine.KeyMaxLength+1))
 
 	// Start with a too-long key on a get.
 	gArgs, gReply := getArgs(tooLongKey, 1, store.StoreID())
@@ -468,6 +469,11 @@ func TestStoreVerifyKeys(t *testing.T) {
 	if err := store.ExecuteCmd(context.Background(), client.Call{Args: gArgs, Reply: gReply}); err == nil {
 		t.Fatal("expected error for start key == KeyMax")
 	}
+	// Try a get with an end key specified (get requires only a start key and should fail).
+	gArgs.EndKey = engine.KeyMax
+	if err := store.ExecuteCmd(context.Background(), client.Call{Args: gArgs, Reply: gReply}); err == nil {
+		t.Fatal("expected error for end key specified on a non-range-based operation")
+	}
 	// Try a scan with too-long EndKey.
 	sArgs, sReply := scanArgs(engine.KeyMin, tooLongKey, 1, store.StoreID())
 	if err := store.ExecuteCmd(context.Background(), client.Call{Args: sArgs, Reply: sReply}); err == nil {
@@ -478,6 +484,12 @@ func TestStoreVerifyKeys(t *testing.T) {
 	sArgs.EndKey = []byte("a")
 	if err := store.ExecuteCmd(context.Background(), client.Call{Args: sArgs, Reply: sReply}); err == nil {
 		t.Fatal("expected error for end key < start")
+	}
+	// Try a scan with start key == end key.
+	sArgs.Key = []byte("a")
+	sArgs.EndKey = sArgs.Key
+	if err := store.ExecuteCmd(context.Background(), client.Call{Args: sArgs, Reply: sReply}); err == nil {
+		t.Fatal("expected error for start == end key")
 	}
 	// Try a put to meta2 key which would otherwise exceed maximum key
 	// length, but is accepted because of the meta prefix.


### PR DESCRIPTION
For ranged ops, the end key must be present and must be different
from the start key. For non-ranged ops, the end key must not be
specified.

Created a new InternalResolveIntentRange op to keep it separate from
the non-ranged version. Having them as the same op was getting
confusing and seemed to be inviting problems.
