### PR TITLE
Move key, gossip key and key prefix definitions to proto.

### DIFF
--- a/acceptance/localcluster/localcluster.go
+++ b/acceptance/localcluster/localcluster.go
@@ -192,7 +192,7 @@ func (l *Cluster) runDockerSpy() {
 	maybePanic(c.Inspect())
 	c.Name = "docker-spy"
 	l.dns = c
-	log.Infof("started %s: %s\n", c.Name, c.NetworkSettings.IPAddress)
+	log.Infof("started %s: %s", c.Name, c.NetworkSettings.IPAddress)
 }
 
 // create the volumes container that keeps all of the volumes used by

--- a/acceptance/replication_test.go
+++ b/acceptance/replication_test.go
@@ -43,7 +43,7 @@ func makeDBClient(cluster *localcluster.Cluster, node int) (*client.DB, error) {
 }
 
 func countRangeReplicas(client *client.DB) (int, error) {
-	r, err := client.Scan(keys.KeyMeta2Prefix, keys.KeyMeta2Prefix.PrefixEnd(), 10)
+	r, err := client.Scan(keys.Meta2Prefix, keys.Meta2Prefix.PrefixEnd(), 10)
 	if err != nil {
 		return 0, err
 	}

--- a/acceptance/replication_test.go
+++ b/acceptance/replication_test.go
@@ -27,8 +27,8 @@ import (
 
 	"github.com/cockroachdb/cockroach/acceptance/localcluster"
 	"github.com/cockroachdb/cockroach/client"
+	"github.com/cockroachdb/cockroach/keys"
 	"github.com/cockroachdb/cockroach/proto"
-	"github.com/cockroachdb/cockroach/storage/engine"
 	"github.com/cockroachdb/cockroach/util"
 	"github.com/cockroachdb/cockroach/util/log"
 )
@@ -43,7 +43,7 @@ func makeDBClient(cluster *localcluster.Cluster, node int) (*client.DB, error) {
 }
 
 func countRangeReplicas(client *client.DB) (int, error) {
-	r, err := client.Scan(engine.KeyMeta2Prefix, engine.KeyMeta2Prefix.PrefixEnd(), 10)
+	r, err := client.Scan(keys.KeyMeta2Prefix, keys.KeyMeta2Prefix.PrefixEnd(), 10)
 	if err != nil {
 		return 0, err
 	}

--- a/gossip/keys.go
+++ b/gossip/keys.go
@@ -33,11 +33,10 @@ const separator = ":"
 // Constants for gossip keys.
 const (
 	// KeyClusterID is the unique UUID for this Cockroach cluster.
-	// The value is a string UUID for the cluster.
-	// The cluster ID is gossiped by all nodes that contain a replica
-	// of the first range, and it serves as a check for basic gossip
-	// connectivity. The Gossip.Connected channel is closed when we see
-	// this key.
+	// The value is a string UUID for the cluster.  The cluster ID is
+	// gossiped by all nodes that contain a replica of the first range,
+	// and it serves as a check for basic gossip connectivity. The
+	// Gossip.Connected channel is closed when we see this key.
 	KeyClusterID = "cluster-id"
 
 	// KeyConfigAccounting is the accounting configuration map.
@@ -49,13 +48,14 @@ const (
 	// KeyConfigZone is the zone configuration map.
 	KeyConfigZone = "zones"
 
-	// KeyCapacityPrefix is the key prefix for gossiping available store
-	// capacity. The suffix is composed of: <node ID>-<store ID>.  The
-	// value is a storage.StoreDescriptor struct.
+	// KeyCapacityPrefix is the key prefix for gossiping available
+	// store capacity. The suffix is composed of: <node ID>-<store ID>.
+	// The value is a storage.StoreDescriptor struct.
 	KeyCapacityPrefix = "capacity"
 
-	// KeyNodeCount is the count of gossip nodes in the network. The
-	// value is an int64 containing the count of nodes in the cluster.
+	// KeyNodeCount is the count of gossip nodes in the
+	// network. The value is an int64 containing the count of nodes in
+	// the cluster.
 	// TODO(spencer): should remove this and instead just count the
 	//   number of node ids being gossiped.
 	KeyNodeCount = "node-count"
@@ -66,10 +66,10 @@ const (
 	// string address of the node. E.g. node:1 => 127.0.0.1:24001
 	KeyNodeIDPrefix = "node"
 
-	// KeySentinel is a key for gossip which must not expire or else the
-	// node considers itself partitioned and will retry with bootstrap hosts.
-	// The sentinel is gossiped by the node that holds the leader lease for the
-	// first range.
+	// KeySentinel is a key for gossip which must not expire or
+	// else the node considers itself partitioned and will retry with
+	// bootstrap hosts.  The sentinel is gossiped by the node that holds
+	// the leader lease for the first range.
 	KeySentinel = "sentinel"
 
 	// KeyFirstRangeDescriptor is the descriptor for the "first"

--- a/keys/constants.go
+++ b/keys/constants.go
@@ -21,7 +21,7 @@ import "github.com/cockroachdb/cockroach/proto"
 
 // Constants for system-reserved keys in the KV map.
 var (
-	// KeyLocalPrefix is the prefix for keys which hold data local to a
+	// LocalPrefix is the prefix for keys which hold data local to a
 	// RocksDB instance, such as store and range-specific metadata which
 	// must not pollute the user key space, but must be collocate with
 	// the store and/or ranges which they refer to. Storing this
@@ -32,7 +32,7 @@ var (
 	// node pointers, and message queues.
 	//
 	// The local key prefix has been deliberately chosen to sort before
-	// the KeySystemPrefix, because these local keys are not addressable
+	// the SystemPrefix, because these local keys are not addressable
 	// via the meta range addressing indexes.
 	//
 	// Some local data are not replicated, such as the store's 'ident'
@@ -42,125 +42,124 @@ var (
 	// stored as MVCC values and are addressable as part of distributed
 	// transactions, such as range metadata, range-spanning binary tree
 	// node pointers, and message queues.
-	KeyLocalPrefix = proto.Key("\x00\x00\x00")
+	LocalPrefix = proto.Key("\x00\x00\x00")
 
-	// KeyLocalSuffixLength specifies the length in bytes of all local
+	// LocalSuffixLength specifies the length in bytes of all local
 	// key suffixes.
-	KeyLocalSuffixLength = 4
+	LocalSuffixLength = 4
 
 	// There are three types of local key data enumerated below:
 	// store-local, range-local by ID, and range-local by key.
 
-	// KeyLocalStorePrefix is the prefix identifying per-store data.
-	KeyLocalStorePrefix = MakeKey(KeyLocalPrefix, proto.Key("s"))
-	// KeyLocalStoreIdentSuffix stores an immutable identifier for this
+	// LocalStorePrefix is the prefix identifying per-store data.
+	LocalStorePrefix = MakeKey(LocalPrefix, proto.Key("s"))
+	// LocalStoreIdentSuffix stores an immutable identifier for this
 	// store, created when the store is first bootstrapped.
-	KeyLocalStoreIdentSuffix = proto.Key("iden")
+	LocalStoreIdentSuffix = proto.Key("iden")
 
-	// KeyLocalRangeIDPrefix is the prefix identifying per-range data
+	// LocalRangeIDPrefix is the prefix identifying per-range data
 	// indexed by Raft ID. The Raft ID is appended to this prefix,
 	// encoded using EncodeUvarint. The specific sort of per-range
 	// metadata is identified by one of the suffixes listed below, along
 	// with potentially additional encoded key info, such as a command
 	// ID in the case of response cache entry.
 	//
-	// NOTE: KeyLocalRangeIDPrefix must be kept in sync with the value
+	// NOTE: LocalRangeIDPrefix must be kept in sync with the value
 	// in storage/engine/db.cc.
-	KeyLocalRangeIDPrefix = MakeKey(KeyLocalPrefix, proto.Key("i"))
-	// KeyLocalResponseCacheSuffix is the suffix for keys storing
+	LocalRangeIDPrefix = MakeKey(LocalPrefix, proto.Key("i"))
+	// LocalResponseCacheSuffix is the suffix for keys storing
 	// command responses used to guarantee idempotency (see ResponseCache).
 	// NOTE: if this value changes, it must be updated in C++
 	// (storage/engine/db.cc).
-	KeyLocalResponseCacheSuffix = proto.Key("res-")
-	// KeyLocalRaftLeaderLeaseSuffix is the suffix for the raft leader lease.
-	KeyLocalRaftLeaderLeaseSuffix = proto.Key("rfll")
-	// KeyLocalRaftHardStateSuffix is the Suffix for the raft HardState.
-	KeyLocalRaftHardStateSuffix = proto.Key("rfth")
-	// KeyLocalRaftAppliedIndexSuffix is the suffix for the raft applied index.
-	KeyLocalRaftAppliedIndexSuffix = proto.Key("rfta")
-	// KeyLocalRaftLogSuffix is the suffix for the raft log.
-	KeyLocalRaftLogSuffix = proto.Key("rftl")
-	// KeyLocalRaftTruncatedStateSuffix is the suffix for the RaftTruncatedState.
-	KeyLocalRaftTruncatedStateSuffix = proto.Key("rftt")
-	// KeyLocalRaftLastIndexSuffix is the suffix for raft's last index.
-	KeyLocalRaftLastIndexSuffix = proto.Key("rfti")
-	// KeyLocalRangeGCMetadataSuffix is the suffix for a range's GC metadata.
-	KeyLocalRangeGCMetadataSuffix = proto.Key("rgcm")
-	// KeyLocalRangeLastVerificationTimestampSuffix is the suffix for a range's
+	LocalResponseCacheSuffix = proto.Key("res-")
+	// LocalRaftLeaderLeaseSuffix is the suffix for the raft leader lease.
+	LocalRaftLeaderLeaseSuffix = proto.Key("rfll")
+	// LocalRaftHardStateSuffix is the Suffix for the raft HardState.
+	LocalRaftHardStateSuffix = proto.Key("rfth")
+	// LocalRaftAppliedIndexSuffix is the suffix for the raft applied index.
+	LocalRaftAppliedIndexSuffix = proto.Key("rfta")
+	// LocalRaftLogSuffix is the suffix for the raft log.
+	LocalRaftLogSuffix = proto.Key("rftl")
+	// LocalRaftTruncatedStateSuffix is the suffix for the RaftTruncatedState.
+	LocalRaftTruncatedStateSuffix = proto.Key("rftt")
+	// LocalRaftLastIndexSuffix is the suffix for raft's last index.
+	LocalRaftLastIndexSuffix = proto.Key("rfti")
+	// LocalRangeGCMetadataSuffix is the suffix for a range's GC metadata.
+	LocalRangeGCMetadataSuffix = proto.Key("rgcm")
+	// LocalRangeLastVerificationTimestampSuffix is the suffix for a range's
 	// last verification timestamp (for checking integrity of on-disk data).
-	KeyLocalRangeLastVerificationTimestampSuffix = proto.Key("rlvt")
-	// KeyLocalRangeStatsSuffix is the suffix for range statistics.
-	KeyLocalRangeStatsSuffix = proto.Key("stat")
+	LocalRangeLastVerificationTimestampSuffix = proto.Key("rlvt")
+	// LocalRangeStatsSuffix is the suffix for range statistics.
+	LocalRangeStatsSuffix = proto.Key("stat")
 
-	// KeyLocalRangeKeyPrefix is the prefix identifying per-range data
-	// indexed by range key (either start key, or some key in the
-	// range). The key is appended to this prefix, encoded using
-	// EncodeBytes. The specific sort of per-range metadata is
-	// identified by one of the suffixes listed below, along with
-	// potentially additional encoded key info, such as the txn ID in
-	// the case of a transaction record.
+	// LocalRangePrefix is the prefix identifying per-range data indexed
+	// by range key (either start key, or some key in the range). The
+	// key is appended to this prefix, encoded using EncodeBytes. The
+	// specific sort of per-range metadata is identified by one of the
+	// suffixes listed below, along with potentially additional encoded
+	// key info, such as the txn ID in the case of a transaction record.
 	//
-	// NOTE: KeyLocalRangeKeyPrefix must be kept in sync with the value
-	// in storage/engine/db.cc.
-	KeyLocalRangeKeyPrefix = MakeKey(KeyLocalPrefix, proto.Key("k"))
-	// KeyLocalRangeDescriptorSuffix is the suffix for keys storing
+	// NOTE: LocalRangePrefix must be kept in sync with the value in
+	// storage/engine/db.cc.
+	LocalRangePrefix = MakeKey(LocalPrefix, proto.Key("k"))
+	// LocalRangeDescriptorSuffix is the suffix for keys storing
 	// range descriptors. The value is a struct of type RangeDescriptor.
-	KeyLocalRangeDescriptorSuffix = proto.Key("rdsc")
-	// KeyLocalRangeTreeNodeSuffix is the suffix for keys storing
+	LocalRangeDescriptorSuffix = proto.Key("rdsc")
+	// LocalRangeTreeNodeSuffix is the suffix for keys storing
 	// range tree nodes.  The value is a struct of type RangeTreeNode.
-	KeyLocalRangeTreeNodeSuffix = proto.Key("rtn-")
-	// KeyLocalTransactionSuffix specifies the key suffix for
+	LocalRangeTreeNodeSuffix = proto.Key("rtn-")
+	// LocalTransactionSuffix specifies the key suffix for
 	// transaction records. The additional detail is the transaction id.
 	// NOTE: if this value changes, it must be updated in C++
 	// (storage/engine/db.cc).
-	KeyLocalTransactionSuffix = proto.Key("txn-")
+	LocalTransactionSuffix = proto.Key("txn-")
 
-	// KeyLocalMax is the end of the local key range.
-	KeyLocalMax = KeyLocalPrefix.PrefixEnd()
+	// LocalMax is the end of the local key range.
+	LocalMax = LocalPrefix.PrefixEnd()
 
-	// KeySystemPrefix indicates the beginning of the key range for
+	// SystemPrefix indicates the beginning of the key range for
 	// global, system data which are replicated across the cluster.
-	KeySystemPrefix = proto.Key("\x00")
-	KeySystemMax    = proto.Key("\x01")
+	SystemPrefix = proto.Key("\x00")
+	SystemMax    = proto.Key("\x01")
 
-	// KeyMetaPrefix is the prefix for range metadata keys. Notice that
+	// MetaPrefix is the prefix for range metadata keys. Notice that
 	// an extra null character in the prefix causes all range addressing
 	// records to sort before any system tables which they might describe.
-	KeyMetaPrefix = MakeKey(KeySystemPrefix, proto.Key("\x00meta"))
-	// KeyMeta1Prefix is the first level of key addressing. The value is a
+	MetaPrefix = MakeKey(SystemPrefix, proto.Key("\x00meta"))
+	// Meta1Prefix is the first level of key addressing. The value is a
 	// RangeDescriptor struct.
-	KeyMeta1Prefix = MakeKey(KeyMetaPrefix, proto.Key("1"))
-	// KeyMeta2Prefix is the second level of key addressing. The value is a
+	Meta1Prefix = MakeKey(MetaPrefix, proto.Key("1"))
+	// Meta2Prefix is the second level of key addressing. The value is a
 	// RangeDescriptor struct.
-	KeyMeta2Prefix = MakeKey(KeyMetaPrefix, proto.Key("2"))
+	Meta2Prefix = MakeKey(MetaPrefix, proto.Key("2"))
 
-	// KeyMetaMax is the end of the range of addressing keys.
-	KeyMetaMax = MakeKey(KeySystemPrefix, proto.Key("\x01"))
+	// MetaMax is the end of the range of addressing keys.
+	MetaMax = MakeKey(SystemPrefix, proto.Key("\x01"))
 
-	// KeyConfigAccountingPrefix specifies the key prefix for accounting
+	// ConfigAccountingPrefix specifies the key prefix for accounting
 	// configurations. The suffix is the affected key prefix.
-	KeyConfigAccountingPrefix = MakeKey(KeySystemPrefix, proto.Key("acct"))
-	// KeyConfigPermissionPrefix specifies the key prefix for accounting
+	ConfigAccountingPrefix = MakeKey(SystemPrefix, proto.Key("acct"))
+	// ConfigPermissionPrefix specifies the key prefix for accounting
 	// configurations. The suffix is the affected key prefix.
-	KeyConfigPermissionPrefix = MakeKey(KeySystemPrefix, proto.Key("perm"))
-	// KeyConfigZonePrefix specifies the key prefix for zone
+	ConfigPermissionPrefix = MakeKey(SystemPrefix, proto.Key("perm"))
+	// ConfigZonePrefix specifies the key prefix for zone
 	// configurations. The suffix is the affected key prefix.
-	KeyConfigZonePrefix = MakeKey(KeySystemPrefix, proto.Key("zone"))
-	// KeyNodeIDGenerator is the global node ID generator sequence.
-	KeyNodeIDGenerator = MakeKey(KeySystemPrefix, proto.Key("node-idgen"))
-	// KeyRaftIDGenerator is the global Raft consensus group ID generator sequence.
-	KeyRaftIDGenerator = MakeKey(KeySystemPrefix, proto.Key("raft-idgen"))
-	// KeySchemaPrefix specifies key prefixes for schema definitions.
-	KeySchemaPrefix = MakeKey(KeySystemPrefix, proto.Key("schema"))
-	// KeyStoreIDGenerator is the global store ID generator sequence.
-	KeyStoreIDGenerator = MakeKey(KeySystemPrefix, proto.Key("store-idgen"))
-	// KeyRangeTreeRoot specifies the root range in the range tree.
-	KeyRangeTreeRoot = MakeKey(KeySystemPrefix, proto.Key("range-tree-root"))
+	ConfigZonePrefix = MakeKey(SystemPrefix, proto.Key("zone"))
+	// NodeIDGenerator is the global node ID generator sequence.
+	NodeIDGenerator = MakeKey(SystemPrefix, proto.Key("node-idgen"))
+	// RaftIDGenerator is the global Raft consensus group ID generator sequence.
+	RaftIDGenerator = MakeKey(SystemPrefix, proto.Key("raft-idgen"))
+	// SchemaPrefix specifies key prefixes for schema definitions.
+	SchemaPrefix = MakeKey(SystemPrefix, proto.Key("schema"))
+	// StoreIDGenerator is the global store ID generator sequence.
+	StoreIDGenerator = MakeKey(SystemPrefix, proto.Key("store-idgen"))
+	// RangeTreeRoot specifies the root range in the range tree.
+	RangeTreeRoot = MakeKey(SystemPrefix, proto.Key("range-tree-root"))
 
-	// KeyStatusPrefix specifies the key prefix to store all status details.
-	KeyStatusPrefix = MakeKey(KeySystemPrefix, proto.Key("status-"))
-	// KeyStatusStorePrefix stores all status info for stores.
-	KeyStatusStorePrefix = MakeKey(KeyStatusPrefix, proto.Key("store-"))
-	// KeyStatusNodePrefix stores all status info for nodes.
-	KeyStatusNodePrefix = MakeKey(KeyStatusPrefix, proto.Key("node-"))
+	// StatusPrefix specifies the key prefix to store all status details.
+	StatusPrefix = MakeKey(SystemPrefix, proto.Key("status-"))
+	// StatusStorePrefix stores all status info for stores.
+	StatusStorePrefix = MakeKey(StatusPrefix, proto.Key("store-"))
+	// StatusNodePrefix stores all status info for nodes.
+	StatusNodePrefix = MakeKey(StatusPrefix, proto.Key("node-"))
 )

--- a/keys/constants.go
+++ b/keys/constants.go
@@ -1,0 +1,166 @@
+// Copyright 2015 The Cockroach Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+// implied. See the License for the specific language governing
+// permissions and limitations under the License. See the AUTHORS file
+// for names of contributors.
+//
+// Author: Peter Mattis (peter.mattis@gmail.com)
+
+package keys
+
+import "github.com/cockroachdb/cockroach/proto"
+
+// Constants for system-reserved keys in the KV map.
+var (
+	// KeyLocalPrefix is the prefix for keys which hold data local to a
+	// RocksDB instance, such as store and range-specific metadata which
+	// must not pollute the user key space, but must be collocate with
+	// the store and/or ranges which they refer to. Storing this
+	// information in the normal system keyspace would place the data on
+	// an arbitrary set of stores, with no guarantee of collocation.
+	// Local data includes store metadata, range metadata, response
+	// cache values, transaction records, range-spanning binary tree
+	// node pointers, and message queues.
+	//
+	// The local key prefix has been deliberately chosen to sort before
+	// the KeySystemPrefix, because these local keys are not addressable
+	// via the meta range addressing indexes.
+	//
+	// Some local data are not replicated, such as the store's 'ident'
+	// record. Most local data are replicated, such as response cache
+	// entries and transaction rows, but are not addressable as normal
+	// MVCC values as part of transactions. Finally, some local data are
+	// stored as MVCC values and are addressable as part of distributed
+	// transactions, such as range metadata, range-spanning binary tree
+	// node pointers, and message queues.
+	KeyLocalPrefix = proto.Key("\x00\x00\x00")
+
+	// KeyLocalSuffixLength specifies the length in bytes of all local
+	// key suffixes.
+	KeyLocalSuffixLength = 4
+
+	// There are three types of local key data enumerated below:
+	// store-local, range-local by ID, and range-local by key.
+
+	// KeyLocalStorePrefix is the prefix identifying per-store data.
+	KeyLocalStorePrefix = MakeKey(KeyLocalPrefix, proto.Key("s"))
+	// KeyLocalStoreIdentSuffix stores an immutable identifier for this
+	// store, created when the store is first bootstrapped.
+	KeyLocalStoreIdentSuffix = proto.Key("iden")
+
+	// KeyLocalRangeIDPrefix is the prefix identifying per-range data
+	// indexed by Raft ID. The Raft ID is appended to this prefix,
+	// encoded using EncodeUvarint. The specific sort of per-range
+	// metadata is identified by one of the suffixes listed below, along
+	// with potentially additional encoded key info, such as a command
+	// ID in the case of response cache entry.
+	//
+	// NOTE: KeyLocalRangeIDPrefix must be kept in sync with the value
+	// in storage/engine/db.cc.
+	KeyLocalRangeIDPrefix = MakeKey(KeyLocalPrefix, proto.Key("i"))
+	// KeyLocalResponseCacheSuffix is the suffix for keys storing
+	// command responses used to guarantee idempotency (see ResponseCache).
+	// NOTE: if this value changes, it must be updated in C++
+	// (storage/engine/db.cc).
+	KeyLocalResponseCacheSuffix = proto.Key("res-")
+	// KeyLocalRaftLeaderLeaseSuffix is the suffix for the raft leader lease.
+	KeyLocalRaftLeaderLeaseSuffix = proto.Key("rfll")
+	// KeyLocalRaftHardStateSuffix is the Suffix for the raft HardState.
+	KeyLocalRaftHardStateSuffix = proto.Key("rfth")
+	// KeyLocalRaftAppliedIndexSuffix is the suffix for the raft applied index.
+	KeyLocalRaftAppliedIndexSuffix = proto.Key("rfta")
+	// KeyLocalRaftLogSuffix is the suffix for the raft log.
+	KeyLocalRaftLogSuffix = proto.Key("rftl")
+	// KeyLocalRaftTruncatedStateSuffix is the suffix for the RaftTruncatedState.
+	KeyLocalRaftTruncatedStateSuffix = proto.Key("rftt")
+	// KeyLocalRaftLastIndexSuffix is the suffix for raft's last index.
+	KeyLocalRaftLastIndexSuffix = proto.Key("rfti")
+	// KeyLocalRangeGCMetadataSuffix is the suffix for a range's GC metadata.
+	KeyLocalRangeGCMetadataSuffix = proto.Key("rgcm")
+	// KeyLocalRangeLastVerificationTimestampSuffix is the suffix for a range's
+	// last verification timestamp (for checking integrity of on-disk data).
+	KeyLocalRangeLastVerificationTimestampSuffix = proto.Key("rlvt")
+	// KeyLocalRangeStatsSuffix is the suffix for range statistics.
+	KeyLocalRangeStatsSuffix = proto.Key("stat")
+
+	// KeyLocalRangeKeyPrefix is the prefix identifying per-range data
+	// indexed by range key (either start key, or some key in the
+	// range). The key is appended to this prefix, encoded using
+	// EncodeBytes. The specific sort of per-range metadata is
+	// identified by one of the suffixes listed below, along with
+	// potentially additional encoded key info, such as the txn ID in
+	// the case of a transaction record.
+	//
+	// NOTE: KeyLocalRangeKeyPrefix must be kept in sync with the value
+	// in storage/engine/db.cc.
+	KeyLocalRangeKeyPrefix = MakeKey(KeyLocalPrefix, proto.Key("k"))
+	// KeyLocalRangeDescriptorSuffix is the suffix for keys storing
+	// range descriptors. The value is a struct of type RangeDescriptor.
+	KeyLocalRangeDescriptorSuffix = proto.Key("rdsc")
+	// KeyLocalRangeTreeNodeSuffix is the suffix for keys storing
+	// range tree nodes.  The value is a struct of type RangeTreeNode.
+	KeyLocalRangeTreeNodeSuffix = proto.Key("rtn-")
+	// KeyLocalTransactionSuffix specifies the key suffix for
+	// transaction records. The additional detail is the transaction id.
+	// NOTE: if this value changes, it must be updated in C++
+	// (storage/engine/db.cc).
+	KeyLocalTransactionSuffix = proto.Key("txn-")
+
+	// KeyLocalMax is the end of the local key range.
+	KeyLocalMax = KeyLocalPrefix.PrefixEnd()
+
+	// KeySystemPrefix indicates the beginning of the key range for
+	// global, system data which are replicated across the cluster.
+	KeySystemPrefix = proto.Key("\x00")
+	KeySystemMax    = proto.Key("\x01")
+
+	// KeyMetaPrefix is the prefix for range metadata keys. Notice that
+	// an extra null character in the prefix causes all range addressing
+	// records to sort before any system tables which they might describe.
+	KeyMetaPrefix = MakeKey(KeySystemPrefix, proto.Key("\x00meta"))
+	// KeyMeta1Prefix is the first level of key addressing. The value is a
+	// RangeDescriptor struct.
+	KeyMeta1Prefix = MakeKey(KeyMetaPrefix, proto.Key("1"))
+	// KeyMeta2Prefix is the second level of key addressing. The value is a
+	// RangeDescriptor struct.
+	KeyMeta2Prefix = MakeKey(KeyMetaPrefix, proto.Key("2"))
+
+	// KeyMetaMax is the end of the range of addressing keys.
+	KeyMetaMax = MakeKey(KeySystemPrefix, proto.Key("\x01"))
+
+	// KeyConfigAccountingPrefix specifies the key prefix for accounting
+	// configurations. The suffix is the affected key prefix.
+	KeyConfigAccountingPrefix = MakeKey(KeySystemPrefix, proto.Key("acct"))
+	// KeyConfigPermissionPrefix specifies the key prefix for accounting
+	// configurations. The suffix is the affected key prefix.
+	KeyConfigPermissionPrefix = MakeKey(KeySystemPrefix, proto.Key("perm"))
+	// KeyConfigZonePrefix specifies the key prefix for zone
+	// configurations. The suffix is the affected key prefix.
+	KeyConfigZonePrefix = MakeKey(KeySystemPrefix, proto.Key("zone"))
+	// KeyNodeIDGenerator is the global node ID generator sequence.
+	KeyNodeIDGenerator = MakeKey(KeySystemPrefix, proto.Key("node-idgen"))
+	// KeyRaftIDGenerator is the global Raft consensus group ID generator sequence.
+	KeyRaftIDGenerator = MakeKey(KeySystemPrefix, proto.Key("raft-idgen"))
+	// KeySchemaPrefix specifies key prefixes for schema definitions.
+	KeySchemaPrefix = MakeKey(KeySystemPrefix, proto.Key("schema"))
+	// KeyStoreIDGenerator is the global store ID generator sequence.
+	KeyStoreIDGenerator = MakeKey(KeySystemPrefix, proto.Key("store-idgen"))
+	// KeyRangeTreeRoot specifies the root range in the range tree.
+	KeyRangeTreeRoot = MakeKey(KeySystemPrefix, proto.Key("range-tree-root"))
+
+	// KeyStatusPrefix specifies the key prefix to store all status details.
+	KeyStatusPrefix = MakeKey(KeySystemPrefix, proto.Key("status-"))
+	// KeyStatusStorePrefix stores all status info for stores.
+	KeyStatusStorePrefix = MakeKey(KeyStatusPrefix, proto.Key("store-"))
+	// KeyStatusNodePrefix stores all status info for nodes.
+	KeyStatusNodePrefix = MakeKey(KeyStatusPrefix, proto.Key("node-"))
+)

--- a/keys/errors.go
+++ b/keys/errors.go
@@ -15,7 +15,7 @@
 //
 // Author: Matt Tracy (matt.r.tracy@gmail.com)
 
-package engine
+package keys
 
 import (
 	"encoding/gob"

--- a/keys/keys.go
+++ b/keys/keys.go
@@ -36,90 +36,88 @@ func MakeKey(keys ...proto.Key) proto.Key {
 // MakeStoreKey creates a store-local key based on the metadata key
 // suffix, and optional detail.
 func MakeStoreKey(suffix, detail proto.Key) proto.Key {
-	return MakeKey(KeyLocalStorePrefix, suffix, detail)
+	return MakeKey(LocalStorePrefix, suffix, detail)
 }
 
 // StoreIdentKey returns a store-local key for the store metadata.
 func StoreIdentKey() proto.Key {
-	return MakeStoreKey(KeyLocalStoreIdentSuffix, proto.Key{})
+	return MakeStoreKey(LocalStoreIdentSuffix, proto.Key{})
 }
 
 // StoreStatusKey returns the key for accessing the store status for the
 // specified store ID.
 func StoreStatusKey(storeID int32) proto.Key {
-	return MakeKey(KeyStatusStorePrefix,
-		encoding.EncodeUvarint(nil, uint64(storeID)))
+	return MakeKey(StatusStorePrefix, encoding.EncodeUvarint(nil, uint64(storeID)))
 }
 
 // NodeStatusKey returns the key for accessing the node status for the
 // specified node ID.
 func NodeStatusKey(nodeID int32) proto.Key {
-	return MakeKey(KeyStatusNodePrefix,
-		encoding.EncodeUvarint(nil, uint64(nodeID)))
+	return MakeKey(StatusNodePrefix, encoding.EncodeUvarint(nil, uint64(nodeID)))
 }
 
 // MakeRangeIDKey creates a range-local key based on the range's
 // Raft ID, metadata key suffix, and optional detail (e.g. the
 // encoded command ID for a response cache entry, etc.).
 func MakeRangeIDKey(raftID int64, suffix, detail proto.Key) proto.Key {
-	if len(suffix) != KeyLocalSuffixLength {
-		panic(fmt.Sprintf("suffix len(%q) != %d", suffix, KeyLocalSuffixLength))
+	if len(suffix) != LocalSuffixLength {
+		panic(fmt.Sprintf("suffix len(%q) != %d", suffix, LocalSuffixLength))
 	}
-	return MakeKey(KeyLocalRangeIDPrefix,
+	return MakeKey(LocalRangeIDPrefix,
 		encoding.EncodeUvarint(nil, uint64(raftID)), suffix, detail)
 }
 
 // RaftLogKey returns a system-local key for a Raft log entry.
 func RaftLogKey(raftID int64, logIndex uint64) proto.Key {
-	return MakeRangeIDKey(raftID, KeyLocalRaftLogSuffix,
+	return MakeRangeIDKey(raftID, LocalRaftLogSuffix,
 		encoding.EncodeUint64(nil, logIndex))
 }
 
 // RaftLogPrefix returns the system-local prefix shared by all entries in a Raft log.
 func RaftLogPrefix(raftID int64) proto.Key {
-	return MakeRangeIDKey(raftID, KeyLocalRaftLogSuffix, proto.Key{})
+	return MakeRangeIDKey(raftID, LocalRaftLogSuffix, proto.Key{})
 }
 
 // RaftHardStateKey returns a system-local key for a Raft HardState.
 func RaftHardStateKey(raftID int64) proto.Key {
-	return MakeRangeIDKey(raftID, KeyLocalRaftHardStateSuffix, proto.Key{})
+	return MakeRangeIDKey(raftID, LocalRaftHardStateSuffix, proto.Key{})
 }
 
 // DecodeRaftStateKey extracts the Raft ID from a RaftStateKey.
 func DecodeRaftStateKey(key proto.Key) int64 {
-	if !bytes.HasPrefix(key, KeyLocalRangeIDPrefix) {
-		panic(fmt.Sprintf("key %q does not have %q prefix", key, KeyLocalRangeIDPrefix))
+	if !bytes.HasPrefix(key, LocalRangeIDPrefix) {
+		panic(fmt.Sprintf("key %q does not have %q prefix", key, LocalRangeIDPrefix))
 	}
 	// Cut the prefix and the Raft ID.
-	b := key[len(KeyLocalRangeIDPrefix):]
+	b := key[len(LocalRangeIDPrefix):]
 	_, raftID := encoding.DecodeUvarint(b)
 	return int64(raftID)
 }
 
 // RaftTruncatedStateKey returns a system-local key for a RaftTruncatedState.
 func RaftTruncatedStateKey(raftID int64) proto.Key {
-	return MakeRangeIDKey(raftID, KeyLocalRaftTruncatedStateSuffix, proto.Key{})
+	return MakeRangeIDKey(raftID, LocalRaftTruncatedStateSuffix, proto.Key{})
 }
 
 // RaftAppliedIndexKey returns a system-local key for a raft applied index.
 func RaftAppliedIndexKey(raftID int64) proto.Key {
-	return MakeRangeIDKey(raftID, KeyLocalRaftAppliedIndexSuffix, proto.Key{})
+	return MakeRangeIDKey(raftID, LocalRaftAppliedIndexSuffix, proto.Key{})
 }
 
 // RaftLeaderLeaseKey returns a system-local key for a raft leader lease.
 func RaftLeaderLeaseKey(raftID int64) proto.Key {
-	return MakeRangeIDKey(raftID, KeyLocalRaftLeaderLeaseSuffix, proto.Key{})
+	return MakeRangeIDKey(raftID, LocalRaftLeaderLeaseSuffix, proto.Key{})
 }
 
 // RaftLastIndexKey returns a system-local key for a raft last index.
 func RaftLastIndexKey(raftID int64) proto.Key {
-	return MakeRangeIDKey(raftID, KeyLocalRaftLastIndexSuffix, proto.Key{})
+	return MakeRangeIDKey(raftID, LocalRaftLastIndexSuffix, proto.Key{})
 }
 
 // RangeStatsKey returns the key for accessing the MVCCStats struct
 // for the specified Raft ID.
 func RangeStatsKey(raftID int64) proto.Key {
-	return MakeRangeIDKey(raftID, KeyLocalRangeStatsSuffix, nil)
+	return MakeRangeIDKey(raftID, LocalRangeStatsSuffix, nil)
 }
 
 // ResponseCacheKey returns a range-local key by Raft ID for a
@@ -132,71 +130,69 @@ func ResponseCacheKey(raftID int64, cmdID *proto.ClientCmdID) proto.Key {
 		detail = encoding.EncodeUvarint(nil, uint64(cmdID.WallTime))
 		detail = encoding.EncodeUint64(detail, uint64(cmdID.Random))
 	}
-	return MakeRangeIDKey(raftID, KeyLocalResponseCacheSuffix, detail)
+	return MakeRangeIDKey(raftID, LocalResponseCacheSuffix, detail)
 }
 
 // MakeRangeKey creates a range-local key based on the range
 // start key, metadata key suffix, and optional detail (e.g. the
 // transaction ID for a txn record, etc.).
 func MakeRangeKey(key, suffix, detail proto.Key) proto.Key {
-	if len(suffix) != KeyLocalSuffixLength {
-		panic(fmt.Sprintf("suffix len(%q) != %d", suffix, KeyLocalSuffixLength))
+	if len(suffix) != LocalSuffixLength {
+		panic(fmt.Sprintf("suffix len(%q) != %d", suffix, LocalSuffixLength))
 	}
-	return MakeKey(KeyLocalRangeKeyPrefix,
+	return MakeKey(LocalRangePrefix,
 		encoding.EncodeBytes(nil, key), suffix, detail)
 }
 
 // DecodeRangeKey decodes the range key into range start key,
 // suffix and optional detail (may be nil).
 func DecodeRangeKey(key proto.Key) (startKey, suffix, detail proto.Key) {
-	if !bytes.HasPrefix(key, KeyLocalRangeKeyPrefix) {
+	if !bytes.HasPrefix(key, LocalRangePrefix) {
 		panic(fmt.Sprintf("key %q does not have %q prefix",
-			key, KeyLocalRangeKeyPrefix))
+			key, LocalRangePrefix))
 	}
 	// Cut the prefix and the Raft ID.
-	b := key[len(KeyLocalRangeKeyPrefix):]
+	b := key[len(LocalRangePrefix):]
 	b, startKey = encoding.DecodeBytes(b, nil)
-	if len(b) < KeyLocalSuffixLength {
+	if len(b) < LocalSuffixLength {
 		panic(fmt.Sprintf("key %q does not have suffix of length %d",
-			key, KeyLocalSuffixLength))
+			key, LocalSuffixLength))
 	}
 	// Cut the response cache suffix.
-	suffix = b[:KeyLocalSuffixLength]
-	detail = b[KeyLocalSuffixLength:]
+	suffix = b[:LocalSuffixLength]
+	detail = b[LocalSuffixLength:]
 	return
 }
 
 // RangeGCMetadataKey returns a range-local key for range garbage
 // collection metadata.
 func RangeGCMetadataKey(raftID int64) proto.Key {
-	return MakeRangeIDKey(raftID,
-		KeyLocalRangeGCMetadataSuffix, proto.Key{})
+	return MakeRangeIDKey(raftID, LocalRangeGCMetadataSuffix, proto.Key{})
 }
 
 // RangeLastVerificationTimestampKey returns a range-local key for
 // the range's last verification timestamp.
 func RangeLastVerificationTimestampKey(raftID int64) proto.Key {
-	return MakeRangeIDKey(raftID,
-		KeyLocalRangeLastVerificationTimestampSuffix, proto.Key{})
+	return MakeRangeIDKey(raftID, LocalRangeLastVerificationTimestampSuffix, proto.Key{})
 }
 
 // RangeTreeNodeKey returns a range-local key for the the range's
 // node in the range tree.
 func RangeTreeNodeKey(key proto.Key) proto.Key {
-	return MakeRangeKey(key, KeyLocalRangeTreeNodeSuffix, proto.Key{})
+	return MakeRangeKey(key, LocalRangeTreeNodeSuffix, proto.Key{})
 }
 
 // RangeDescriptorKey returns a range-local key for the descriptor
 // for the range with specified key.
 func RangeDescriptorKey(key proto.Key) proto.Key {
-	return MakeRangeKey(key, KeyLocalRangeDescriptorSuffix, proto.Key{})
+	return MakeRangeKey(key, LocalRangeDescriptorSuffix, proto.Key{})
 }
 
 // TransactionKey returns a transaction key based on the provided
 // transaction key and ID. The base key is encoded in order to
 // guarantee that all transaction records for a range sort together.
 func TransactionKey(key proto.Key, id []byte) proto.Key {
-	return MakeRangeKey(key, KeyLocalTransactionSuffix, proto.Key(id))
+	return MakeRangeKey(key, LocalTransactionSuffix, proto.Key(id))
 }
 
 // KeyAddress returns the address for the key, used to lookup the
@@ -218,16 +214,16 @@ func KeyAddress(k proto.Key) proto.Key {
 		return nil
 	}
 
-	if !bytes.HasPrefix(k, KeyLocalPrefix) {
+	if !bytes.HasPrefix(k, LocalPrefix) {
 		return k
 	}
-	if bytes.HasPrefix(k, KeyLocalRangeKeyPrefix) {
-		k = k[len(KeyLocalRangeKeyPrefix):]
+	if bytes.HasPrefix(k, LocalRangePrefix) {
+		k = k[len(LocalRangePrefix):]
 		_, k = encoding.DecodeBytes(k, nil)
 		return k
 	}
 	log.Fatalf("local key %q malformed; should contain prefix %q",
-		k, KeyLocalRangeKeyPrefix)
+		k, LocalRangePrefix)
 	return nil
 }
 
@@ -240,11 +236,11 @@ func RangeMetaKey(key proto.Key) proto.Key {
 		return proto.KeyMin
 	}
 	addr := KeyAddress(key)
-	if !bytes.HasPrefix(addr, KeyMetaPrefix) {
-		return MakeKey(KeyMeta2Prefix, addr)
+	if !bytes.HasPrefix(addr, MetaPrefix) {
+		return MakeKey(Meta2Prefix, addr)
 	}
-	if bytes.HasPrefix(addr, KeyMeta2Prefix) {
-		return MakeKey(KeyMeta1Prefix, addr[len(KeyMeta2Prefix):])
+	if bytes.HasPrefix(addr, Meta2Prefix) {
+		return MakeKey(Meta1Prefix, addr[len(Meta2Prefix):])
 	}
 
 	return proto.KeyMin
@@ -259,19 +255,19 @@ func ValidateRangeMetaKey(key proto.Key) error {
 	if len(key) == 0 {
 		return nil
 	}
-	// Key must be at least as long as KeyMeta1Prefix.
-	if len(key) < len(KeyMeta1Prefix) {
+	// Key must be at least as long as Meta1Prefix.
+	if len(key) < len(Meta1Prefix) {
 		return NewInvalidRangeMetaKeyError("too short", key)
 	}
 
-	prefix, body := key[:len(KeyMeta1Prefix)], key[len(KeyMeta1Prefix):]
+	prefix, body := key[:len(Meta1Prefix)], key[len(Meta1Prefix):]
 
-	// The prefix must be equal to KeyMeta1Prefix or KeyMeta2Prefix
-	if !bytes.HasPrefix(key, KeyMetaPrefix) {
+	// The prefix must be equal to Meta1Prefix or Meta2Prefix
+	if !bytes.HasPrefix(key, MetaPrefix) {
 		return NewInvalidRangeMetaKeyError(
-			fmt.Sprintf("does not have %q prefix", KeyMetaPrefix), key)
+			fmt.Sprintf("does not have %q prefix", MetaPrefix), key)
 	}
-	if lvl := string(prefix[len(KeyMetaPrefix)]); lvl != "1" && lvl != "2" {
+	if lvl := string(prefix[len(MetaPrefix)]); lvl != "1" && lvl != "2" {
 		return NewInvalidRangeMetaKeyError("meta level is not 1 or 2", key)
 	}
 	// Body of the key must sort <= KeyMax. KeyMax might be the body in
@@ -289,9 +285,9 @@ func ValidateRangeMetaKey(key proto.Key) error {
 func DecodeRangeMetaKey(key proto.Key) (proto.Key, proto.Key) {
 	if len(key) == 0 {
 		// Special case KeyMin: find the first entry in meta1.
-		return KeyMeta1Prefix, KeyMeta1Prefix.PrefixEnd()
+		return Meta1Prefix, Meta1Prefix.PrefixEnd()
 	}
 	// Otherwise find the first entry greater than the given key in the same meta prefix.
-	metaPrefix := proto.Key(key[:len(KeyMeta1Prefix)])
+	metaPrefix := proto.Key(key[:len(Meta1Prefix)])
 	return key.Next(), metaPrefix.PrefixEnd()
 }

--- a/keys/keys_test.go
+++ b/keys/keys_test.go
@@ -35,7 +35,7 @@ func TestKeySorting(t *testing.T) {
 		proto.Key("\x01").Less(proto.Key("\x01\x00"))) {
 		t.Fatalf("something is seriously wrong with this machine")
 	}
-	if !KeyLocalPrefix.Less(KeyMetaPrefix) {
+	if !LocalPrefix.Less(MetaPrefix) {
 		t.Fatalf("local key spilling into replicable ranges")
 	}
 	if !bytes.Equal(proto.Key(""), proto.Key(nil)) || !bytes.Equal(proto.Key(""), proto.Key(nil)) {
@@ -59,7 +59,7 @@ func TestKeyAddress(t *testing.T) {
 	}{
 		{proto.Key{}, proto.KeyMin},
 		{proto.Key("123"), proto.Key("123")},
-		{MakeKey(KeyConfigAccountingPrefix, proto.Key("foo")), proto.Key("\x00acctfoo")},
+		{MakeKey(ConfigAccountingPrefix, proto.Key("foo")), proto.Key("\x00acctfoo")},
 		{RangeDescriptorKey(proto.Key("foo")), proto.Key("foo")},
 		{TransactionKey(proto.Key("baz"), proto.Key(util.NewUUID4())), proto.Key("baz")},
 		{TransactionKey(proto.KeyMax, proto.Key(util.NewUUID4())), proto.KeyMax},
@@ -83,7 +83,7 @@ func TestRangeMetaKey(t *testing.T) {
 			expKey: proto.KeyMin,
 		},
 		{
-			key:    MakeKey(KeyConfigAccountingPrefix, proto.Key("foo")),
+			key:    MakeKey(ConfigAccountingPrefix, proto.Key("foo")),
 			expKey: proto.Key("\x00\x00meta2\x00acctfoo"),
 		},
 		{
@@ -127,11 +127,11 @@ func TestValidateRangeMetaKey(t *testing.T) {
 	}{
 		{proto.KeyMin, false},
 		{proto.Key("\x00"), true},
-		{KeyMeta1Prefix[:len(KeyMeta1Prefix)-1], true},
-		{KeyMeta1Prefix, false},
-		{proto.MakeKey(KeyMeta1Prefix, proto.KeyMax), false},
-		{proto.MakeKey(KeyMeta2Prefix, proto.KeyMax), false},
-		{proto.MakeKey(KeyMeta2Prefix, proto.KeyMax.Next()), true},
+		{Meta1Prefix[:len(Meta1Prefix)-1], true},
+		{Meta1Prefix, false},
+		{proto.MakeKey(Meta1Prefix, proto.KeyMax), false},
+		{proto.MakeKey(Meta2Prefix, proto.KeyMax), false},
+		{proto.MakeKey(Meta2Prefix, proto.KeyMax.Next()), true},
 	}
 	for i, test := range testCases {
 		err := ValidateRangeMetaKey(test.key)

--- a/keys/keys_test.go
+++ b/keys/keys_test.go
@@ -15,7 +15,7 @@
 //
 // Author: Tobias Schottdorf (tobias.schottdorf@gmail.com)
 
-package engine
+package keys
 
 import (
 	"bytes"
@@ -57,12 +57,12 @@ func TestKeyAddress(t *testing.T) {
 	testCases := []struct {
 		key, expAddress proto.Key
 	}{
-		{proto.Key{}, KeyMin},
+		{proto.Key{}, proto.KeyMin},
 		{proto.Key("123"), proto.Key("123")},
 		{MakeKey(KeyConfigAccountingPrefix, proto.Key("foo")), proto.Key("\x00acctfoo")},
 		{RangeDescriptorKey(proto.Key("foo")), proto.Key("foo")},
 		{TransactionKey(proto.Key("baz"), proto.Key(util.NewUUID4())), proto.Key("baz")},
-		{TransactionKey(KeyMax, proto.Key(util.NewUUID4())), KeyMax},
+		{TransactionKey(proto.KeyMax, proto.Key(util.NewUUID4())), proto.KeyMax},
 		{nil, nil},
 	}
 	for i, test := range testCases {
@@ -80,7 +80,7 @@ func TestRangeMetaKey(t *testing.T) {
 	}{
 		{
 			key:    proto.Key{},
-			expKey: KeyMin,
+			expKey: proto.KeyMin,
 		},
 		{
 			key:    MakeKey(KeyConfigAccountingPrefix, proto.Key("foo")),
@@ -92,7 +92,7 @@ func TestRangeMetaKey(t *testing.T) {
 		},
 		{
 			key:    proto.Key("\x00\x00meta1\x00acctfoo"),
-			expKey: KeyMin,
+			expKey: proto.KeyMin,
 		},
 		{
 			key:    proto.Key("foo"),
@@ -108,7 +108,7 @@ func TestRangeMetaKey(t *testing.T) {
 		},
 		{
 			key:    proto.Key("\x00\x00meta1foo"),
-			expKey: KeyMin,
+			expKey: proto.KeyMin,
 		},
 	}
 	for i, test := range testCases {

--- a/kv/dist_sender.go
+++ b/kv/dist_sender.go
@@ -27,10 +27,10 @@ import (
 
 	"github.com/cockroachdb/cockroach/client"
 	"github.com/cockroachdb/cockroach/gossip"
+	"github.com/cockroachdb/cockroach/keys"
 	"github.com/cockroachdb/cockroach/proto"
 	"github.com/cockroachdb/cockroach/rpc"
 	"github.com/cockroachdb/cockroach/storage"
-	"github.com/cockroachdb/cockroach/storage/engine"
 	"github.com/cockroachdb/cockroach/util"
 	"github.com/cockroachdb/cockroach/util/hlc"
 	"github.com/cockroachdb/cockroach/util/log"
@@ -317,7 +317,7 @@ func (ds *DistSender) getRangeDescriptor(key proto.Key, options lookupOptions) (
 	var (
 		// metadataKey is sent to InternalRangeLookup to find the
 		// RangeDescriptor which contains key.
-		metadataKey = engine.RangeMetaKey(key)
+		metadataKey = keys.RangeMetaKey(key)
 		// desc is the RangeDescriptor for the range which contains
 		// metadataKey.
 		desc *proto.RangeDescriptor
@@ -333,7 +333,7 @@ func (ds *DistSender) getRangeDescriptor(key proto.Key, options lookupOptions) (
 		}
 		return []proto.RangeDescriptor{*rd}, nil
 	}
-	if bytes.HasPrefix(metadataKey, engine.KeyMeta1Prefix) {
+	if bytes.HasPrefix(metadataKey, keys.KeyMeta1Prefix) {
 		// In this case, desc is the cluster's first range.
 		if desc, err = ds.getFirstRangeDescriptor(); err != nil {
 			return nil, err

--- a/kv/dist_sender.go
+++ b/kv/dist_sender.go
@@ -333,7 +333,7 @@ func (ds *DistSender) getRangeDescriptor(key proto.Key, options lookupOptions) (
 		}
 		return []proto.RangeDescriptor{*rd}, nil
 	}
-	if bytes.HasPrefix(metadataKey, keys.KeyMeta1Prefix) {
+	if bytes.HasPrefix(metadataKey, keys.Meta1Prefix) {
 		// In this case, desc is the cluster's first range.
 		if desc, err = ds.getFirstRangeDescriptor(); err != nil {
 			return nil, err

--- a/kv/dist_sender_server_test.go
+++ b/kv/dist_sender_server_test.go
@@ -24,6 +24,7 @@ import (
 	"golang.org/x/net/context"
 
 	"github.com/cockroachdb/cockroach/client"
+	"github.com/cockroachdb/cockroach/keys"
 	"github.com/cockroachdb/cockroach/kv"
 	"github.com/cockroachdb/cockroach/proto"
 	"github.com/cockroachdb/cockroach/server"
@@ -49,7 +50,7 @@ func TestRangeLookupWithOpenTransaction(t *testing.T) {
 
 	// Create an intent on the meta1 record by writing directly to the
 	// engine.
-	key := engine.MakeKey(engine.KeyMeta1Prefix, engine.KeyMax)
+	key := keys.MakeKey(keys.KeyMeta1Prefix, proto.KeyMax)
 	now := s.Clock().Now()
 	txn := proto.NewTransaction("txn", proto.Key("foobar"), 0, proto.SERIALIZABLE, now, 0)
 	if err := engine.MVCCPutProto(s.Engines[0], nil, key, now, txn, &proto.RangeDescriptor{}); err != nil {

--- a/kv/dist_sender_server_test.go
+++ b/kv/dist_sender_server_test.go
@@ -50,7 +50,7 @@ func TestRangeLookupWithOpenTransaction(t *testing.T) {
 
 	// Create an intent on the meta1 record by writing directly to the
 	// engine.
-	key := keys.MakeKey(keys.KeyMeta1Prefix, proto.KeyMax)
+	key := keys.MakeKey(keys.Meta1Prefix, proto.KeyMax)
 	now := s.Clock().Now()
 	txn := proto.NewTransaction("txn", proto.Key("foobar"), 0, proto.SERIALIZABLE, now, 0)
 	if err := engine.MVCCPutProto(s.Engines[0], nil, key, now, txn, &proto.RangeDescriptor{}); err != nil {

--- a/kv/dist_sender_test.go
+++ b/kv/dist_sender_test.go
@@ -427,14 +427,14 @@ func TestRetryOnWrongReplicaError(t *testing.T) {
 		if method == "Node.InternalRangeLookup" {
 			// If the non-broken descriptor has already been returned, that's
 			// an error.
-			if !descStale && bytes.HasPrefix(header.Key, keys.KeyMeta2Prefix) {
+			if !descStale && bytes.HasPrefix(header.Key, keys.Meta2Prefix) {
 				t.Errorf("unexpected extra lookup for non-stale replica descriptor at %s",
 					header.Key)
 			}
 
 			r := getReply().(*proto.InternalRangeLookupResponse)
 			// The fresh descriptor is about to be returned.
-			if bytes.HasPrefix(header.Key, keys.KeyMeta2Prefix) &&
+			if bytes.HasPrefix(header.Key, keys.Meta2Prefix) &&
 				newRangeDescriptor.StartKey.Equal(newEndKey) {
 				descStale = false
 			}

--- a/kv/dist_sender_test.go
+++ b/kv/dist_sender_test.go
@@ -31,10 +31,10 @@ import (
 	"github.com/cockroachdb/cockroach/client"
 	"github.com/cockroachdb/cockroach/gossip"
 	"github.com/cockroachdb/cockroach/gossip/simulation"
+	"github.com/cockroachdb/cockroach/keys"
 	"github.com/cockroachdb/cockroach/proto"
 	"github.com/cockroachdb/cockroach/rpc"
 	"github.com/cockroachdb/cockroach/storage"
-	"github.com/cockroachdb/cockroach/storage/engine"
 	"github.com/cockroachdb/cockroach/util"
 	gogoproto "github.com/gogo/protobuf/proto"
 )
@@ -63,7 +63,7 @@ func makeTestGossip(t *testing.T) *gossip.Gossip {
 	}
 
 	configMap, err := storage.NewPrefixConfigMap([]*storage.PrefixConfig{
-		{engine.KeyMin, nil, permConfig},
+		{proto.KeyMin, nil, permConfig},
 	})
 	if err != nil {
 		t.Fatalf("failed to make prefix config map, err: %s", err.Error())
@@ -427,14 +427,14 @@ func TestRetryOnWrongReplicaError(t *testing.T) {
 		if method == "Node.InternalRangeLookup" {
 			// If the non-broken descriptor has already been returned, that's
 			// an error.
-			if !descStale && bytes.HasPrefix(header.Key, engine.KeyMeta2Prefix) {
+			if !descStale && bytes.HasPrefix(header.Key, keys.KeyMeta2Prefix) {
 				t.Errorf("unexpected extra lookup for non-stale replica descriptor at %s",
 					header.Key)
 			}
 
 			r := getReply().(*proto.InternalRangeLookupResponse)
 			// The fresh descriptor is about to be returned.
-			if bytes.HasPrefix(header.Key, engine.KeyMeta2Prefix) &&
+			if bytes.HasPrefix(header.Key, keys.KeyMeta2Prefix) &&
 				newRangeDescriptor.StartKey.Equal(newEndKey) {
 				descStale = false
 			}
@@ -513,7 +513,7 @@ func TestVerifyPermissions(t *testing.T) {
 		Read:  []string{"read2", "readAll", "rw2", "rwAll"},
 		Write: []string{"write2", "writeAll", "rw2", "rwAll"}}
 	configs := []*storage.PrefixConfig{
-		{engine.KeyMin, nil, config1},
+		{proto.KeyMin, nil, config1},
 		{proto.Key("a"), nil, config2},
 	}
 	configMap, err := storage.NewPrefixConfigMap(configs)
@@ -573,33 +573,33 @@ func TestVerifyPermissions(t *testing.T) {
 		hasPermission    bool
 	}{
 		// Test permissions within a single range
-		{readOnlyRequests, "read1", engine.KeyMin, engine.KeyMin, true},
-		{readOnlyRequests, "rw1", engine.KeyMin, engine.KeyMin, true},
-		{readOnlyRequests, "write1", engine.KeyMin, engine.KeyMin, false},
-		{readOnlyRequests, "random", engine.KeyMin, engine.KeyMin, false},
-		{readWriteRequests, "rw1", engine.KeyMin, engine.KeyMin, true},
-		{readWriteRequests, "read1", engine.KeyMin, engine.KeyMin, false},
-		{readWriteRequests, "write1", engine.KeyMin, engine.KeyMin, false},
-		{writeOnlyRequests, "write1", engine.KeyMin, engine.KeyMin, true},
-		{writeOnlyRequests, "rw1", engine.KeyMin, engine.KeyMin, true},
-		{writeOnlyRequests, "read1", engine.KeyMin, engine.KeyMin, false},
-		{writeOnlyRequests, "random", engine.KeyMin, engine.KeyMin, false},
+		{readOnlyRequests, "read1", proto.KeyMin, proto.KeyMin, true},
+		{readOnlyRequests, "rw1", proto.KeyMin, proto.KeyMin, true},
+		{readOnlyRequests, "write1", proto.KeyMin, proto.KeyMin, false},
+		{readOnlyRequests, "random", proto.KeyMin, proto.KeyMin, false},
+		{readWriteRequests, "rw1", proto.KeyMin, proto.KeyMin, true},
+		{readWriteRequests, "read1", proto.KeyMin, proto.KeyMin, false},
+		{readWriteRequests, "write1", proto.KeyMin, proto.KeyMin, false},
+		{writeOnlyRequests, "write1", proto.KeyMin, proto.KeyMin, true},
+		{writeOnlyRequests, "rw1", proto.KeyMin, proto.KeyMin, true},
+		{writeOnlyRequests, "read1", proto.KeyMin, proto.KeyMin, false},
+		{writeOnlyRequests, "random", proto.KeyMin, proto.KeyMin, false},
 		// Test permissions hierarchically.
 		{readOnlyRequests, "read1", proto.Key("a"), proto.Key("a1"), true},
 		{readWriteRequests, "rw1", proto.Key("a"), proto.Key("a1"), true},
 		{writeOnlyRequests, "write1", proto.Key("a"), proto.Key("a1"), true},
 		// Test permissions across both ranges.
-		{readOnlyRequests, "readAll", engine.KeyMin, proto.Key("b"), true},
-		{readOnlyRequests, "read1", engine.KeyMin, proto.Key("b"), true},
-		{readOnlyRequests, "read2", engine.KeyMin, proto.Key("b"), false},
-		{readOnlyRequests, "random", engine.KeyMin, proto.Key("b"), false},
-		{readWriteRequests, "rwAll", engine.KeyMin, proto.Key("b"), true},
-		{readWriteRequests, "rw1", engine.KeyMin, proto.Key("b"), true},
-		{readWriteRequests, "random", engine.KeyMin, proto.Key("b"), false},
-		{writeOnlyRequests, "writeAll", engine.KeyMin, proto.Key("b"), true},
-		{writeOnlyRequests, "write1", engine.KeyMin, proto.Key("b"), true},
-		{writeOnlyRequests, "write2", engine.KeyMin, proto.Key("b"), false},
-		{writeOnlyRequests, "random", engine.KeyMin, proto.Key("b"), false},
+		{readOnlyRequests, "readAll", proto.KeyMin, proto.Key("b"), true},
+		{readOnlyRequests, "read1", proto.KeyMin, proto.Key("b"), true},
+		{readOnlyRequests, "read2", proto.KeyMin, proto.Key("b"), false},
+		{readOnlyRequests, "random", proto.KeyMin, proto.Key("b"), false},
+		{readWriteRequests, "rwAll", proto.KeyMin, proto.Key("b"), true},
+		{readWriteRequests, "rw1", proto.KeyMin, proto.Key("b"), true},
+		{readWriteRequests, "random", proto.KeyMin, proto.Key("b"), false},
+		{writeOnlyRequests, "writeAll", proto.KeyMin, proto.Key("b"), true},
+		{writeOnlyRequests, "write1", proto.KeyMin, proto.Key("b"), true},
+		{writeOnlyRequests, "write2", proto.KeyMin, proto.Key("b"), false},
+		{writeOnlyRequests, "random", proto.KeyMin, proto.Key("b"), false},
 		// Test permissions within and around the boundaries of a range,
 		// representatively using rw methods.
 		{readWriteRequests, "rw2", proto.Key("a"), proto.Key("b"), true},

--- a/kv/range_cache_test.go
+++ b/kv/range_cache_test.go
@@ -74,7 +74,7 @@ func (db *testDescriptorDB) getRangeDescriptor(key proto.Key,
 
 	// Recursively call into cache as the real DB would, terminating recursion
 	// when a meta1key is encountered.
-	if len(metadataKey) > 0 && !bytes.HasPrefix(metadataKey, keys.KeyMeta1Prefix) {
+	if len(metadataKey) > 0 && !bytes.HasPrefix(metadataKey, keys.Meta1Prefix) {
 		_, err = db.cache.LookupRangeDescriptor(metadataKey, options)
 	}
 	return db.getDescriptor(key), err
@@ -107,13 +107,13 @@ func newTestDescriptorDB() *testDescriptorDB {
 	db := &testDescriptorDB{}
 	db.data.Insert(testDescriptorNode{
 		&proto.RangeDescriptor{
-			StartKey: keys.MakeKey(keys.KeyMeta2Prefix, proto.KeyMin),
-			EndKey:   keys.MakeKey(keys.KeyMeta2Prefix, proto.KeyMax),
+			StartKey: keys.MakeKey(keys.Meta2Prefix, proto.KeyMin),
+			EndKey:   keys.MakeKey(keys.Meta2Prefix, proto.KeyMax),
 		},
 	})
 	db.data.Insert(testDescriptorNode{
 		&proto.RangeDescriptor{
-			StartKey: keys.KeyMetaMax,
+			StartKey: keys.MetaMax,
 			EndKey:   proto.KeyMax,
 		},
 	})

--- a/kv/range_cache_test.go
+++ b/kv/range_cache_test.go
@@ -22,8 +22,8 @@ import (
 	"testing"
 
 	"github.com/biogo/store/llrb"
+	"github.com/cockroachdb/cockroach/keys"
 	"github.com/cockroachdb/cockroach/proto"
-	"github.com/cockroachdb/cockroach/storage/engine"
 	"github.com/cockroachdb/cockroach/util/log"
 )
 
@@ -68,13 +68,13 @@ func (db *testDescriptorDB) getDescriptor(key proto.Key) []proto.RangeDescriptor
 func (db *testDescriptorDB) getRangeDescriptor(key proto.Key,
 	options lookupOptions) ([]proto.RangeDescriptor, error) {
 	db.hitCount++
-	metadataKey := engine.RangeMetaKey(key)
+	metadataKey := keys.RangeMetaKey(key)
 
 	var err error
 
 	// Recursively call into cache as the real DB would, terminating recursion
 	// when a meta1key is encountered.
-	if len(metadataKey) > 0 && !bytes.HasPrefix(metadataKey, engine.KeyMeta1Prefix) {
+	if len(metadataKey) > 0 && !bytes.HasPrefix(metadataKey, keys.KeyMeta1Prefix) {
 		_, err = db.cache.LookupRangeDescriptor(metadataKey, options)
 	}
 	return db.getDescriptor(key), err
@@ -107,14 +107,14 @@ func newTestDescriptorDB() *testDescriptorDB {
 	db := &testDescriptorDB{}
 	db.data.Insert(testDescriptorNode{
 		&proto.RangeDescriptor{
-			StartKey: engine.MakeKey(engine.KeyMeta2Prefix, engine.KeyMin),
-			EndKey:   engine.MakeKey(engine.KeyMeta2Prefix, engine.KeyMax),
+			StartKey: keys.MakeKey(keys.KeyMeta2Prefix, proto.KeyMin),
+			EndKey:   keys.MakeKey(keys.KeyMeta2Prefix, proto.KeyMax),
 		},
 	})
 	db.data.Insert(testDescriptorNode{
 		&proto.RangeDescriptor{
-			StartKey: engine.KeyMetaMax,
-			EndKey:   engine.KeyMax,
+			StartKey: keys.KeyMetaMax,
+			EndKey:   proto.KeyMax,
 		},
 	})
 	return db
@@ -132,7 +132,7 @@ func doLookup(t *testing.T, rc *rangeDescriptorCache, key string) {
 	if err != nil {
 		t.Fatalf("Unexpected error from LookupRangeDescriptor: %s", err.Error())
 	}
-	if !r.ContainsKey(engine.KeyAddress(proto.Key(key))) {
+	if !r.ContainsKey(keys.KeyAddress(proto.Key(key))) {
 		t.Fatalf("Returned range did not contain key: %s-%s, %s", r.StartKey, r.EndKey, key)
 	}
 	log.Infof("doLookup: %s %+v", key, r)
@@ -147,7 +147,7 @@ func TestRangeCache(t *testing.T) {
 	for i, char := range "abcdefghijklmnopqrstuvwx" {
 		db.splitRange(t, proto.Key(string(char)))
 		if i > 0 && i%6 == 0 {
-			db.splitRange(t, engine.RangeMetaKey(proto.Key(string(char))))
+			db.splitRange(t, keys.RangeMetaKey(proto.Key(string(char))))
 		}
 	}
 

--- a/kv/rest_test.go
+++ b/kv/rest_test.go
@@ -417,7 +417,7 @@ func TestSystemKeys(t *testing.T) {
 	}
 
 	// Manipulate the meta1 key.
-	metaKey := keys.MakeKey(keys.KeyMeta1Prefix, proto.KeyMax)
+	metaKey := keys.MakeKey(keys.Meta1Prefix, proto.KeyMax)
 	encMeta1Key := url.QueryEscape(string(metaKey))
 	url := testContext.RequestScheme() + "://" + s.ServingAddr() + EntryPrefix + encMeta1Key
 	resp := getURL(testContext, url, t)

--- a/kv/rest_test.go
+++ b/kv/rest_test.go
@@ -35,6 +35,7 @@ import (
 	"testing"
 
 	"github.com/cockroachdb/cockroach/base"
+	"github.com/cockroachdb/cockroach/keys"
 	. "github.com/cockroachdb/cockroach/kv"
 	"github.com/cockroachdb/cockroach/proto"
 	"github.com/cockroachdb/cockroach/server"
@@ -401,8 +402,8 @@ func TestSystemKeys(t *testing.T) {
 	// Compute expected system key.
 	desc := &proto.RangeDescriptor{
 		RaftID:   1,
-		StartKey: engine.KeyMin,
-		EndKey:   engine.KeyMax,
+		StartKey: proto.KeyMin,
+		EndKey:   proto.KeyMax,
 		Replicas: []proto.Replica{
 			{
 				NodeID:  1,
@@ -416,7 +417,7 @@ func TestSystemKeys(t *testing.T) {
 	}
 
 	// Manipulate the meta1 key.
-	metaKey := engine.MakeKey(engine.KeyMeta1Prefix, engine.KeyMax)
+	metaKey := keys.MakeKey(keys.KeyMeta1Prefix, proto.KeyMax)
 	encMeta1Key := url.QueryEscape(string(metaKey))
 	url := testContext.RequestScheme() + "://" + s.ServingAddr() + EntryPrefix + encMeta1Key
 	resp := getURL(testContext, url, t)

--- a/kv/split_test.go
+++ b/kv/split_test.go
@@ -26,6 +26,7 @@ import (
 	"time"
 
 	"github.com/cockroachdb/cockroach/client"
+	"github.com/cockroachdb/cockroach/keys"
 	"github.com/cockroachdb/cockroach/proto"
 	"github.com/cockroachdb/cockroach/storage/engine"
 	"github.com/cockroachdb/cockroach/util"
@@ -149,7 +150,7 @@ func TestRangeSplitsWithWritePressure(t *testing.T) {
 		RangeMinBytes: 1 << 8,
 		RangeMaxBytes: 1 << 18,
 	}
-	call := client.PutProto(engine.MakeKey(engine.KeyConfigZonePrefix, engine.KeyMin), zoneConfig)
+	call := client.PutProto(keys.MakeKey(keys.KeyConfigZonePrefix, proto.KeyMin), zoneConfig)
 	if err := s.KV.Run(call); err != nil {
 		t.Fatal(err)
 	}
@@ -163,7 +164,7 @@ func TestRangeSplitsWithWritePressure(t *testing.T) {
 	// Check that we split 5 times in allotted time.
 	if err := util.IsTrueWithin(func() bool {
 		// Scan the txn records.
-		call := client.Scan(engine.KeyMeta2Prefix, engine.KeyMetaMax, 0)
+		call := client.Scan(keys.KeyMeta2Prefix, keys.KeyMetaMax, 0)
 		resp := call.Reply.(*proto.ScanResponse)
 		if err := s.KV.Run(call); err != nil {
 			t.Fatalf("failed to scan meta2 keys: %s", err)
@@ -183,7 +184,7 @@ func TestRangeSplitsWithWritePressure(t *testing.T) {
 	// for timing of finishing the test writer and a possibly-ongoing
 	// asynchronous split.
 	if err := util.IsTrueWithin(func() bool {
-		if _, err := engine.MVCCScan(s.Eng, engine.KeyLocalMax, engine.KeyMax, 0, proto.MaxTimestamp, true, nil); err != nil {
+		if _, err := engine.MVCCScan(s.Eng, keys.KeyLocalMax, proto.KeyMax, 0, proto.MaxTimestamp, true, nil); err != nil {
 			log.Infof("mvcc scan should be clean: %s", err)
 			return false
 		}

--- a/kv/split_test.go
+++ b/kv/split_test.go
@@ -150,7 +150,7 @@ func TestRangeSplitsWithWritePressure(t *testing.T) {
 		RangeMinBytes: 1 << 8,
 		RangeMaxBytes: 1 << 18,
 	}
-	call := client.PutProto(keys.MakeKey(keys.KeyConfigZonePrefix, proto.KeyMin), zoneConfig)
+	call := client.PutProto(keys.MakeKey(keys.ConfigZonePrefix, proto.KeyMin), zoneConfig)
 	if err := s.KV.Run(call); err != nil {
 		t.Fatal(err)
 	}
@@ -164,7 +164,7 @@ func TestRangeSplitsWithWritePressure(t *testing.T) {
 	// Check that we split 5 times in allotted time.
 	if err := util.IsTrueWithin(func() bool {
 		// Scan the txn records.
-		call := client.Scan(keys.KeyMeta2Prefix, keys.KeyMetaMax, 0)
+		call := client.Scan(keys.Meta2Prefix, keys.MetaMax, 0)
 		resp := call.Reply.(*proto.ScanResponse)
 		if err := s.KV.Run(call); err != nil {
 			t.Fatalf("failed to scan meta2 keys: %s", err)
@@ -184,7 +184,7 @@ func TestRangeSplitsWithWritePressure(t *testing.T) {
 	// for timing of finishing the test writer and a possibly-ongoing
 	// asynchronous split.
 	if err := util.IsTrueWithin(func() bool {
-		if _, err := engine.MVCCScan(s.Eng, keys.KeyLocalMax, proto.KeyMax, 0, proto.MaxTimestamp, true, nil); err != nil {
+		if _, err := engine.MVCCScan(s.Eng, keys.LocalMax, proto.KeyMax, 0, proto.MaxTimestamp, true, nil); err != nil {
 			log.Infof("mvcc scan should be clean: %s", err)
 			return false
 		}

--- a/kv/txn_test.go
+++ b/kv/txn_test.go
@@ -28,6 +28,7 @@ import (
 	"time"
 
 	"github.com/cockroachdb/cockroach/client"
+	"github.com/cockroachdb/cockroach/keys"
 	"github.com/cockroachdb/cockroach/proto"
 	"github.com/cockroachdb/cockroach/storage"
 	"github.com/cockroachdb/cockroach/storage/engine"
@@ -607,7 +608,7 @@ func TestTxnRepeatGetWithRangeSplit(t *testing.T) {
 		// Check that we split 1 times in allotted time.
 		if err := util.IsTrueWithin(func() bool {
 			// Scan the txn records.
-			call := client.Scan(engine.KeyMeta2Prefix, engine.KeyMetaMax, 0)
+			call := client.Scan(keys.KeyMeta2Prefix, keys.KeyMetaMax, 0)
 			resp := call.Reply.(*proto.ScanResponse)
 			if err := s.KV.Run(call); err != nil {
 				t.Fatalf("failed to scan meta2 keys: %s", err)

--- a/kv/txn_test.go
+++ b/kv/txn_test.go
@@ -608,7 +608,7 @@ func TestTxnRepeatGetWithRangeSplit(t *testing.T) {
 		// Check that we split 1 times in allotted time.
 		if err := util.IsTrueWithin(func() bool {
 			// Scan the txn records.
-			call := client.Scan(keys.KeyMeta2Prefix, keys.KeyMetaMax, 0)
+			call := client.Scan(keys.Meta2Prefix, keys.MetaMax, 0)
 			resp := call.Reply.(*proto.ScanResponse)
 			if err := s.KV.Run(call); err != nil {
 				t.Fatalf("failed to scan meta2 keys: %s", err)

--- a/server/accounting.go
+++ b/server/accounting.go
@@ -21,8 +21,8 @@ import (
 	"net/http"
 
 	"github.com/cockroachdb/cockroach/client"
+	"github.com/cockroachdb/cockroach/keys"
 	"github.com/cockroachdb/cockroach/proto"
-	"github.com/cockroachdb/cockroach/storage/engine"
 )
 
 // An acctHandler implements the adminHandler interface.
@@ -35,7 +35,7 @@ type acctHandler struct {
 // The accounting config is stored gob-encoded. The specified body must
 // validly parse into an acctConfig struct.
 func (ah *acctHandler) Put(path string, body []byte, r *http.Request) error {
-	return putConfig(ah.db, engine.KeyConfigAccountingPrefix, &proto.AcctConfig{},
+	return putConfig(ah.db, keys.KeyConfigAccountingPrefix, &proto.AcctConfig{},
 		path, body, r, nil)
 }
 
@@ -48,10 +48,10 @@ func (ah *acctHandler) Put(path string, body []byte, r *http.Request) error {
 // The body result contains JSON-formatted output for a listing of keys
 // and JSON-formatted output for retrieval of an accounting config.
 func (ah *acctHandler) Get(path string, r *http.Request) (body []byte, contentType string, err error) {
-	return getConfig(ah.db, engine.KeyConfigAccountingPrefix, &proto.AcctConfig{}, path, r)
+	return getConfig(ah.db, keys.KeyConfigAccountingPrefix, &proto.AcctConfig{}, path, r)
 }
 
 // Delete removes the accouting config specified by key.
 func (ah *acctHandler) Delete(path string, r *http.Request) error {
-	return deleteConfig(ah.db, engine.KeyConfigAccountingPrefix, path, r)
+	return deleteConfig(ah.db, keys.KeyConfigAccountingPrefix, path, r)
 }

--- a/server/accounting.go
+++ b/server/accounting.go
@@ -35,7 +35,7 @@ type acctHandler struct {
 // The accounting config is stored gob-encoded. The specified body must
 // validly parse into an acctConfig struct.
 func (ah *acctHandler) Put(path string, body []byte, r *http.Request) error {
-	return putConfig(ah.db, keys.KeyConfigAccountingPrefix, &proto.AcctConfig{},
+	return putConfig(ah.db, keys.ConfigAccountingPrefix, &proto.AcctConfig{},
 		path, body, r, nil)
 }
 
@@ -48,10 +48,10 @@ func (ah *acctHandler) Put(path string, body []byte, r *http.Request) error {
 // The body result contains JSON-formatted output for a listing of keys
 // and JSON-formatted output for retrieval of an accounting config.
 func (ah *acctHandler) Get(path string, r *http.Request) (body []byte, contentType string, err error) {
-	return getConfig(ah.db, keys.KeyConfigAccountingPrefix, &proto.AcctConfig{}, path, r)
+	return getConfig(ah.db, keys.ConfigAccountingPrefix, &proto.AcctConfig{}, path, r)
 }
 
 // Delete removes the accouting config specified by key.
 func (ah *acctHandler) Delete(path string, r *http.Request) error {
-	return deleteConfig(ah.db, keys.KeyConfigAccountingPrefix, path, r)
+	return deleteConfig(ah.db, keys.ConfigAccountingPrefix, path, r)
 }

--- a/server/accounting_test.go
+++ b/server/accounting_test.go
@@ -26,7 +26,6 @@ import (
 	"os"
 
 	"github.com/cockroachdb/cockroach/proto"
-	"github.com/cockroachdb/cockroach/storage/engine"
 	"github.com/cockroachdb/cockroach/util"
 	yaml "gopkg.in/yaml.v1"
 )
@@ -46,7 +45,7 @@ func ExampleSetAndGetAccts() {
 		prefix proto.Key
 		yaml   string
 	}{
-		{engine.KeyMin, testAcctConfig},
+		{proto.KeyMin, testAcctConfig},
 		{proto.Key("db1"), testAcctConfig},
 		{proto.Key("db 2"), testAcctConfig},
 		{proto.Key("\xfe"), testAcctConfig},
@@ -86,7 +85,7 @@ func ExampleLsAccts() {
 	defer util.CleanupDir(testConfigFn)
 
 	keys := []proto.Key{
-		engine.KeyMin,
+		proto.KeyMin,
 		proto.Key("db1"),
 		proto.Key("db2"),
 		proto.Key("db3"),
@@ -145,7 +144,7 @@ func ExampleRmAccts() {
 	defer util.CleanupDir(testConfigFn)
 
 	keys := []proto.Key{
-		engine.KeyMin,
+		proto.KeyMin,
 		proto.Key("db1"),
 	}
 

--- a/server/cli/kv.go
+++ b/server/cli/kv.go
@@ -247,7 +247,7 @@ func runScan(cmd *cobra.Command, args []string) {
 		startKey = proto.Key(unquoteArg(args[0], false))
 	} else {
 		// Start with the first key after the system key range.
-		startKey = keys.KeySystemMax
+		startKey = keys.SystemMax
 	}
 	if len(args) >= 2 {
 		endKey = proto.Key(unquoteArg(args[1], false))

--- a/server/cli/kv.go
+++ b/server/cli/kv.go
@@ -27,8 +27,8 @@ import (
 	"strings"
 
 	"github.com/cockroachdb/cockroach/client"
+	"github.com/cockroachdb/cockroach/keys"
 	"github.com/cockroachdb/cockroach/proto"
-	"github.com/cockroachdb/cockroach/storage/engine"
 	"github.com/cockroachdb/cockroach/util"
 
 	"github.com/spf13/cobra"
@@ -247,7 +247,7 @@ func runScan(cmd *cobra.Command, args []string) {
 		startKey = proto.Key(unquoteArg(args[0], false))
 	} else {
 		// Start with the first key after the system key range.
-		startKey = engine.KeySystemMax
+		startKey = keys.KeySystemMax
 	}
 	if len(args) >= 2 {
 		endKey = proto.Key(unquoteArg(args[1], false))

--- a/server/cli/range.go
+++ b/server/cli/range.go
@@ -48,14 +48,14 @@ func runLsRanges(cmd *cobra.Command, args []string) {
 	if len(args) >= 1 {
 		startKey = keys.RangeMetaKey(proto.Key(args[0]))
 	} else {
-		startKey = keys.KeyMeta2Prefix
+		startKey = keys.Meta2Prefix
 	}
 
 	kvDB := makeDBClient()
 	if kvDB == nil {
 		return
 	}
-	r, err := kvDB.Scan(startKey, keys.KeyMeta2Prefix.PrefixEnd(), 1000)
+	r, err := kvDB.Scan(startKey, keys.Meta2Prefix.PrefixEnd(), 1000)
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "scan failed: %s\n", err)
 		osExit(1)

--- a/server/cli/range.go
+++ b/server/cli/range.go
@@ -21,8 +21,8 @@ import (
 	"fmt"
 	"os"
 
+	"github.com/cockroachdb/cockroach/keys"
 	"github.com/cockroachdb/cockroach/proto"
-	"github.com/cockroachdb/cockroach/storage/engine"
 
 	"github.com/spf13/cobra"
 )
@@ -46,16 +46,16 @@ func runLsRanges(cmd *cobra.Command, args []string) {
 	}
 	var startKey proto.Key
 	if len(args) >= 1 {
-		startKey = engine.RangeMetaKey(proto.Key(args[0]))
+		startKey = keys.RangeMetaKey(proto.Key(args[0]))
 	} else {
-		startKey = engine.KeyMeta2Prefix
+		startKey = keys.KeyMeta2Prefix
 	}
 
 	kvDB := makeDBClient()
 	if kvDB == nil {
 		return
 	}
-	r, err := kvDB.Scan(startKey, engine.KeyMeta2Prefix.PrefixEnd(), 1000)
+	r, err := kvDB.Scan(startKey, keys.KeyMeta2Prefix.PrefixEnd(), 1000)
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "scan failed: %s\n", err)
 		osExit(1)

--- a/server/config.go
+++ b/server/config.go
@@ -28,9 +28,9 @@ import (
 	"regexp"
 
 	"github.com/cockroachdb/cockroach/client"
+	"github.com/cockroachdb/cockroach/keys"
 	"github.com/cockroachdb/cockroach/proto"
 	"github.com/cockroachdb/cockroach/storage"
-	"github.com/cockroachdb/cockroach/storage/engine"
 	"github.com/cockroachdb/cockroach/util"
 	"github.com/cockroachdb/cockroach/util/log"
 	gogoproto "github.com/gogo/protobuf/proto"
@@ -238,7 +238,7 @@ func putConfig(db *client.KV, configPrefix proto.Key, config gogoproto.Message,
 			return err
 		}
 	}
-	key := engine.MakeKey(configPrefix, proto.Key(path[1:]))
+	key := keys.MakeKey(configPrefix, proto.Key(path[1:]))
 	if err := db.Run(client.PutProto(key, config)); err != nil {
 		return err
 	}
@@ -281,7 +281,7 @@ func getConfig(db *client.KV, configPrefix proto.Key, config gogoproto.Message,
 		// Encode the response.
 		body, contentType, err = util.MarshalResponse(r, prefixes, util.AllEncodings)
 	} else {
-		configkey := engine.MakeKey(configPrefix, proto.Key(path[1:]))
+		configkey := keys.MakeKey(configPrefix, proto.Key(path[1:]))
 		if err = db.Run(client.GetProto(configkey, config)); err != nil {
 			return
 		}
@@ -299,7 +299,7 @@ func deleteConfig(db *client.KV, configPrefix proto.Key, path string, r *http.Re
 	if path == "/" {
 		return util.Errorf("the default configuration cannot be deleted")
 	}
-	configKey := engine.MakeKey(configPrefix, proto.Key(path[1:]))
+	configKey := keys.MakeKey(configPrefix, proto.Key(path[1:]))
 	return db.Run(client.Call{
 		Args: &proto.DeleteRequest{
 			RequestHeader: proto.RequestHeader{

--- a/server/node.go
+++ b/server/node.go
@@ -27,6 +27,7 @@ import (
 
 	"github.com/cockroachdb/cockroach/client"
 	"github.com/cockroachdb/cockroach/gossip"
+	"github.com/cockroachdb/cockroach/keys"
 	"github.com/cockroachdb/cockroach/kv"
 	"github.com/cockroachdb/cockroach/multiraft"
 	"github.com/cockroachdb/cockroach/proto"
@@ -76,7 +77,7 @@ type nodeServer Node
 // allocateNodeID increments the node id generator key to allocate
 // a new, unique node id.
 func allocateNodeID(db *client.DB) (proto.NodeID, error) {
-	r, err := db.Inc(engine.KeyNodeIDGenerator, 1)
+	r, err := db.Inc(keys.KeyNodeIDGenerator, 1)
 	if err != nil {
 		return 0, util.Errorf("unable to allocate node ID: %s", err)
 	}
@@ -87,7 +88,7 @@ func allocateNodeID(db *client.DB) (proto.NodeID, error) {
 // specified node to allocate "inc" new, unique store ids. The
 // first ID in a contiguous range is returned on success.
 func allocateStoreIDs(nodeID proto.NodeID, inc int64, db *client.DB) (proto.StoreID, error) {
-	r, err := db.Inc(engine.KeyStoreIDGenerator, inc)
+	r, err := db.Inc(keys.KeyStoreIDGenerator, inc)
 	if err != nil {
 		return 0, util.Errorf("unable to allocate %d store IDs for node %d: %s", inc, nodeID, err)
 	}
@@ -464,7 +465,7 @@ func (n *Node) startStoresScanner(stopper *util.Stopper) {
 					ReplicatedRangeCount: replicatedRangeCount,
 					AvailableRangeCount:  availableRangeCount,
 				}
-				key := engine.NodeStatusKey(int32(n.Descriptor.NodeID))
+				key := keys.NodeStatusKey(int32(n.Descriptor.NodeID))
 				if err := n.ctx.DB.Run(client.PutProto(key, status)); err != nil {
 					log.Error(err)
 				}

--- a/server/node.go
+++ b/server/node.go
@@ -77,7 +77,7 @@ type nodeServer Node
 // allocateNodeID increments the node id generator key to allocate
 // a new, unique node id.
 func allocateNodeID(db *client.DB) (proto.NodeID, error) {
-	r, err := db.Inc(keys.KeyNodeIDGenerator, 1)
+	r, err := db.Inc(keys.NodeIDGenerator, 1)
 	if err != nil {
 		return 0, util.Errorf("unable to allocate node ID: %s", err)
 	}
@@ -88,7 +88,7 @@ func allocateNodeID(db *client.DB) (proto.NodeID, error) {
 // specified node to allocate "inc" new, unique store ids. The
 // first ID in a contiguous range is returned on success.
 func allocateStoreIDs(nodeID proto.NodeID, inc int64, db *client.DB) (proto.StoreID, error) {
-	r, err := db.Inc(keys.KeyStoreIDGenerator, inc)
+	r, err := db.Inc(keys.StoreIDGenerator, inc)
 	if err != nil {
 		return 0, util.Errorf("unable to allocate %d store IDs for node %d: %s", inc, nodeID, err)
 	}

--- a/server/node_test.go
+++ b/server/node_test.go
@@ -29,6 +29,7 @@ import (
 	"github.com/cockroachdb/cockroach/client"
 	"github.com/cockroachdb/cockroach/gossip"
 	"github.com/cockroachdb/cockroach/gossip/resolver"
+	"github.com/cockroachdb/cockroach/keys"
 	"github.com/cockroachdb/cockroach/kv"
 	"github.com/cockroachdb/cockroach/multiraft"
 	"github.com/cockroachdb/cockroach/proto"
@@ -116,8 +117,8 @@ func TestBootstrapCluster(t *testing.T) {
 	if err := localDB.Run(client.Call{
 		Args: &proto.ScanRequest{
 			RequestHeader: proto.RequestHeader{
-				Key:    engine.KeyLocalPrefix.PrefixEnd(), // skip local keys
-				EndKey: engine.KeyMax,
+				Key:    keys.KeyLocalPrefix.PrefixEnd(), // skip local keys
+				EndKey: proto.KeyMax,
 				User:   storage.UserRoot,
 			},
 			MaxResults: math.MaxInt64,
@@ -130,8 +131,8 @@ func TestBootstrapCluster(t *testing.T) {
 		keys = append(keys, kv.Key)
 	}
 	var expectedKeys = []proto.Key{
-		engine.MakeKey(proto.Key("\x00\x00meta1"), engine.KeyMax),
-		engine.MakeKey(proto.Key("\x00\x00meta2"), engine.KeyMax),
+		proto.MakeKey(proto.Key("\x00\x00meta1"), proto.KeyMax),
+		proto.MakeKey(proto.Key("\x00\x00meta2"), proto.KeyMax),
 		proto.Key("\x00acct"),
 		proto.Key("\x00node-idgen"),
 		proto.Key("\x00perm"),
@@ -251,7 +252,7 @@ func TestCorruptedClusterID(t *testing.T) {
 		NodeID:    1,
 		StoreID:   1,
 	}
-	if err = engine.MVCCPutProto(e, nil, engine.StoreIdentKey(), proto.ZeroTimestamp, nil, &sIdent); err != nil {
+	if err = engine.MVCCPutProto(e, nil, keys.StoreIdentKey(), proto.ZeroTimestamp, nil, &sIdent); err != nil {
 		t.Fatal(err)
 	}
 
@@ -270,7 +271,7 @@ func TestCorruptedClusterID(t *testing.T) {
 // And that UpdatedAt has increased.
 // The latest actual stats are returned.
 func compareStoreStatus(t *testing.T, node *Node, expectedNodeStatus *proto.NodeStatus, testNumber int) *proto.NodeStatus {
-	nodeStatusKey := engine.NodeStatusKey(int32(node.Descriptor.NodeID))
+	nodeStatusKey := keys.NodeStatusKey(int32(node.Descriptor.NodeID))
 	request := &proto.GetRequest{
 		RequestHeader: proto.RequestHeader{
 			Key: nodeStatusKey,
@@ -432,7 +433,7 @@ func TestNodeStatus(t *testing.T) {
 	rng := s.LookupRange(splitKey, nil)
 	args := &proto.AdminSplitRequest{
 		RequestHeader: proto.RequestHeader{
-			Key:     engine.KeyMin,
+			Key:     proto.KeyMin,
 			RaftID:  rng.Desc().RaftID,
 			Replica: proto.Replica{StoreID: s.Ident.StoreID},
 		},

--- a/server/node_test.go
+++ b/server/node_test.go
@@ -117,7 +117,7 @@ func TestBootstrapCluster(t *testing.T) {
 	if err := localDB.Run(client.Call{
 		Args: &proto.ScanRequest{
 			RequestHeader: proto.RequestHeader{
-				Key:    keys.KeyLocalPrefix.PrefixEnd(), // skip local keys
+				Key:    keys.LocalPrefix.PrefixEnd(), // skip local keys
 				EndKey: proto.KeyMax,
 				User:   storage.UserRoot,
 			},

--- a/server/permission.go
+++ b/server/permission.go
@@ -21,8 +21,8 @@ import (
 	"net/http"
 
 	"github.com/cockroachdb/cockroach/client"
+	"github.com/cockroachdb/cockroach/keys"
 	"github.com/cockroachdb/cockroach/proto"
-	"github.com/cockroachdb/cockroach/storage/engine"
 )
 
 // A permHandler implements the adminHandler interface.
@@ -35,7 +35,7 @@ type permHandler struct {
 // stored gob-encoded. The specified body must validly parse into a
 // perm config struct.
 func (ph *permHandler) Put(path string, body []byte, r *http.Request) error {
-	return putConfig(ph.db, engine.KeyConfigPermissionPrefix, &proto.PermConfig{},
+	return putConfig(ph.db, keys.KeyConfigPermissionPrefix, &proto.PermConfig{},
 		path, body, r, nil)
 }
 
@@ -48,10 +48,10 @@ func (ph *permHandler) Put(path string, body []byte, r *http.Request) error {
 // JSON-formatted output for a listing of keys and JSON-formatted
 // output for retrieval of a perm config.
 func (ph *permHandler) Get(path string, r *http.Request) ([]byte, string, error) {
-	return getConfig(ph.db, engine.KeyConfigPermissionPrefix, &proto.PermConfig{}, path, r)
+	return getConfig(ph.db, keys.KeyConfigPermissionPrefix, &proto.PermConfig{}, path, r)
 }
 
 // Delete removes the perm config specified by key.
 func (ph *permHandler) Delete(path string, r *http.Request) error {
-	return deleteConfig(ph.db, engine.KeyConfigPermissionPrefix, path, r)
+	return deleteConfig(ph.db, keys.KeyConfigPermissionPrefix, path, r)
 }

--- a/server/permission.go
+++ b/server/permission.go
@@ -35,7 +35,7 @@ type permHandler struct {
 // stored gob-encoded. The specified body must validly parse into a
 // perm config struct.
 func (ph *permHandler) Put(path string, body []byte, r *http.Request) error {
-	return putConfig(ph.db, keys.KeyConfigPermissionPrefix, &proto.PermConfig{},
+	return putConfig(ph.db, keys.ConfigPermissionPrefix, &proto.PermConfig{},
 		path, body, r, nil)
 }
 
@@ -48,10 +48,10 @@ func (ph *permHandler) Put(path string, body []byte, r *http.Request) error {
 // JSON-formatted output for a listing of keys and JSON-formatted
 // output for retrieval of a perm config.
 func (ph *permHandler) Get(path string, r *http.Request) ([]byte, string, error) {
-	return getConfig(ph.db, keys.KeyConfigPermissionPrefix, &proto.PermConfig{}, path, r)
+	return getConfig(ph.db, keys.ConfigPermissionPrefix, &proto.PermConfig{}, path, r)
 }
 
 // Delete removes the perm config specified by key.
 func (ph *permHandler) Delete(path string, r *http.Request) error {
-	return deleteConfig(ph.db, keys.KeyConfigPermissionPrefix, path, r)
+	return deleteConfig(ph.db, keys.ConfigPermissionPrefix, path, r)
 }

--- a/server/permission_test.go
+++ b/server/permission_test.go
@@ -27,7 +27,6 @@ import (
 	"testing"
 
 	"github.com/cockroachdb/cockroach/proto"
-	"github.com/cockroachdb/cockroach/storage/engine"
 	"github.com/cockroachdb/cockroach/util"
 	yaml "gopkg.in/yaml.v1"
 )
@@ -50,7 +49,7 @@ func ExampleSetAndGetPerms() {
 		prefix proto.Key
 		yaml   string
 	}{
-		{engine.KeyMin, testPermConfig},
+		{proto.KeyMin, testPermConfig},
 		{proto.Key("db1"), testPermConfig},
 		{proto.Key("db 2"), testPermConfig},
 		{proto.Key("\xfe"), testPermConfig},
@@ -110,7 +109,7 @@ func ExampleLsPerms() {
 	defer util.CleanupDir(testConfigFn)
 
 	keys := []proto.Key{
-		engine.KeyMin,
+		proto.KeyMin,
 		proto.Key("db1"),
 		proto.Key("db2"),
 		proto.Key("db3"),
@@ -169,7 +168,7 @@ func ExampleRmPerms() {
 	defer util.CleanupDir(testConfigFn)
 
 	keys := []proto.Key{
-		engine.KeyMin,
+		proto.KeyMin,
 		proto.Key("db1"),
 	}
 

--- a/server/status.go
+++ b/server/status.go
@@ -244,7 +244,7 @@ func (s *statusServer) handleLocalStacks(w http.ResponseWriter, r *http.Request,
 
 // handleNodesStatus handles GET requests for all node statuses.
 func (s *statusServer) handleNodesStatus(w http.ResponseWriter, r *http.Request, _ httprouter.Params) {
-	startKey := keys.KeyStatusNodePrefix
+	startKey := keys.StatusNodePrefix
 	endKey := startKey.PrefixEnd()
 
 	call := client.Scan(startKey, endKey, 0)
@@ -317,7 +317,7 @@ func (s *statusServer) handleNodeStatus(w http.ResponseWriter, r *http.Request, 
 
 // handleStoresStatus handles GET requests for all store statuses.
 func (s *statusServer) handleStoresStatus(w http.ResponseWriter, r *http.Request, _ httprouter.Params) {
-	startKey := keys.KeyStatusStorePrefix
+	startKey := keys.StatusStorePrefix
 	endKey := startKey.PrefixEnd()
 
 	call := client.Scan(startKey, endKey, 0)

--- a/server/status.go
+++ b/server/status.go
@@ -25,9 +25,9 @@ import (
 
 	"github.com/cockroachdb/cockroach/client"
 	"github.com/cockroachdb/cockroach/gossip"
+	"github.com/cockroachdb/cockroach/keys"
 	"github.com/cockroachdb/cockroach/proto"
 	"github.com/cockroachdb/cockroach/server/status"
-	"github.com/cockroachdb/cockroach/storage/engine"
 	"github.com/cockroachdb/cockroach/util"
 	"github.com/cockroachdb/cockroach/util/log"
 	gogoproto "github.com/gogo/protobuf/proto"
@@ -244,7 +244,7 @@ func (s *statusServer) handleLocalStacks(w http.ResponseWriter, r *http.Request,
 
 // handleNodesStatus handles GET requests for all node statuses.
 func (s *statusServer) handleNodesStatus(w http.ResponseWriter, r *http.Request, _ httprouter.Params) {
-	startKey := engine.KeyStatusNodePrefix
+	startKey := keys.KeyStatusNodePrefix
 	endKey := startKey.PrefixEnd()
 
 	call := client.Scan(startKey, endKey, 0)
@@ -289,7 +289,7 @@ func (s *statusServer) handleNodeStatus(w http.ResponseWriter, r *http.Request, 
 		w.WriteHeader(http.StatusInternalServerError)
 		return
 	}
-	key := engine.NodeStatusKey(int32(id))
+	key := keys.NodeStatusKey(int32(id))
 
 	nodeStatus := &proto.NodeStatus{}
 	call := client.GetProto(key, nodeStatus)
@@ -317,7 +317,7 @@ func (s *statusServer) handleNodeStatus(w http.ResponseWriter, r *http.Request, 
 
 // handleStoresStatus handles GET requests for all store statuses.
 func (s *statusServer) handleStoresStatus(w http.ResponseWriter, r *http.Request, _ httprouter.Params) {
-	startKey := engine.KeyStatusStorePrefix
+	startKey := keys.KeyStatusStorePrefix
 	endKey := startKey.PrefixEnd()
 
 	call := client.Scan(startKey, endKey, 0)
@@ -362,7 +362,7 @@ func (s *statusServer) handleStoreStatus(w http.ResponseWriter, r *http.Request,
 		w.WriteHeader(http.StatusInternalServerError)
 		return
 	}
-	key := engine.StoreStatusKey(int32(id))
+	key := keys.StoreStatusKey(int32(id))
 
 	storeStatus := &proto.StoreStatus{}
 	call := client.GetProto(key, storeStatus)

--- a/server/zone.go
+++ b/server/zone.go
@@ -21,8 +21,8 @@ import (
 	"net/http"
 
 	"github.com/cockroachdb/cockroach/client"
+	"github.com/cockroachdb/cockroach/keys"
 	"github.com/cockroachdb/cockroach/proto"
-	"github.com/cockroachdb/cockroach/storage/engine"
 	"github.com/cockroachdb/cockroach/util"
 	gogoproto "github.com/gogo/protobuf/proto"
 )
@@ -58,7 +58,7 @@ func validateZoneConfig(config gogoproto.Message) error {
 // "body". The specified body must validly parse into a zone config
 // struct.
 func (zh *zoneHandler) Put(path string, body []byte, r *http.Request) error {
-	return putConfig(zh.db, engine.KeyConfigZonePrefix, &proto.ZoneConfig{},
+	return putConfig(zh.db, keys.KeyConfigZonePrefix, &proto.ZoneConfig{},
 		path, body, r, validateZoneConfig)
 }
 
@@ -71,10 +71,10 @@ func (zh *zoneHandler) Put(path string, body []byte, r *http.Request) error {
 // JSON-formatted output for a listing of keys and JSON-formatted
 // output for retrieval of a zone config.
 func (zh *zoneHandler) Get(path string, r *http.Request) (body []byte, contentType string, err error) {
-	return getConfig(zh.db, engine.KeyConfigZonePrefix, &proto.ZoneConfig{}, path, r)
+	return getConfig(zh.db, keys.KeyConfigZonePrefix, &proto.ZoneConfig{}, path, r)
 }
 
 // Delete removes the zone config specified by key.
 func (zh *zoneHandler) Delete(path string, r *http.Request) error {
-	return deleteConfig(zh.db, engine.KeyConfigZonePrefix, path, r)
+	return deleteConfig(zh.db, keys.KeyConfigZonePrefix, path, r)
 }

--- a/server/zone.go
+++ b/server/zone.go
@@ -58,7 +58,7 @@ func validateZoneConfig(config gogoproto.Message) error {
 // "body". The specified body must validly parse into a zone config
 // struct.
 func (zh *zoneHandler) Put(path string, body []byte, r *http.Request) error {
-	return putConfig(zh.db, keys.KeyConfigZonePrefix, &proto.ZoneConfig{},
+	return putConfig(zh.db, keys.ConfigZonePrefix, &proto.ZoneConfig{},
 		path, body, r, validateZoneConfig)
 }
 
@@ -71,10 +71,10 @@ func (zh *zoneHandler) Put(path string, body []byte, r *http.Request) error {
 // JSON-formatted output for a listing of keys and JSON-formatted
 // output for retrieval of a zone config.
 func (zh *zoneHandler) Get(path string, r *http.Request) (body []byte, contentType string, err error) {
-	return getConfig(zh.db, keys.KeyConfigZonePrefix, &proto.ZoneConfig{}, path, r)
+	return getConfig(zh.db, keys.ConfigZonePrefix, &proto.ZoneConfig{}, path, r)
 }
 
 // Delete removes the zone config specified by key.
 func (zh *zoneHandler) Delete(path string, r *http.Request) error {
-	return deleteConfig(zh.db, keys.KeyConfigZonePrefix, path, r)
+	return deleteConfig(zh.db, keys.ConfigZonePrefix, path, r)
 }

--- a/server/zone_test.go
+++ b/server/zone_test.go
@@ -26,7 +26,6 @@ import (
 	"os"
 
 	"github.com/cockroachdb/cockroach/proto"
-	"github.com/cockroachdb/cockroach/storage/engine"
 	"github.com/cockroachdb/cockroach/util"
 	yaml "gopkg.in/yaml.v1"
 )
@@ -53,7 +52,7 @@ func ExampleSetAndGetZone() {
 		prefix proto.Key
 		yaml   string
 	}{
-		{engine.KeyMin, testZoneConfig},
+		{proto.KeyMin, testZoneConfig},
 		{proto.Key("db1"), testZoneConfig},
 		{proto.Key("db 2"), testZoneConfig},
 		{proto.Key("\xfe"), testZoneConfig},
@@ -113,7 +112,7 @@ func ExampleLsZones() {
 	defer util.CleanupDir(testConfigFn)
 
 	keys := []proto.Key{
-		engine.KeyMin,
+		proto.KeyMin,
 		proto.Key("db1"),
 		proto.Key("db2"),
 		proto.Key("db3"),
@@ -172,7 +171,7 @@ func ExampleRmZones() {
 	defer util.CleanupDir(testConfigFn)
 
 	keys := []proto.Key{
-		engine.KeyMin,
+		proto.KeyMin,
 		proto.Key("db1"),
 	}
 

--- a/storage/addressing.go
+++ b/storage/addressing.go
@@ -91,24 +91,24 @@ func updateRangeAddressing(desc *proto.RangeDescriptor) ([]client.Call, error) {
 func rangeAddressing(calls []client.Call, desc *proto.RangeDescriptor,
 	action metaAction) ([]client.Call, error) {
 	// 1. handle illegal case of start or end key being meta1.
-	if bytes.HasPrefix(desc.EndKey, keys.KeyMeta1Prefix) ||
-		bytes.HasPrefix(desc.StartKey, keys.KeyMeta1Prefix) {
+	if bytes.HasPrefix(desc.EndKey, keys.Meta1Prefix) ||
+		bytes.HasPrefix(desc.StartKey, keys.Meta1Prefix) {
 		return nil, util.Errorf("meta1 addressing records cannot be split: %+v", desc)
 	}
 	// 2. the case of the range ending with a meta2 prefix. This means
 	// the range is full of meta2. We must update the relevant meta1
 	// entry pointing to the end of this range.
-	if bytes.HasPrefix(desc.EndKey, keys.KeyMeta2Prefix) {
+	if bytes.HasPrefix(desc.EndKey, keys.Meta2Prefix) {
 		calls = action(calls, keys.RangeMetaKey(desc.EndKey), desc)
 	} else {
 		// 3. the range ends with a normal user key, so we must update the
 		// relevant meta2 entry pointing to the end of this range.
-		calls = action(calls, keys.MakeKey(keys.KeyMeta2Prefix, desc.EndKey), desc)
+		calls = action(calls, keys.MakeKey(keys.Meta2Prefix, desc.EndKey), desc)
 		// 3a. the range starts with KeyMin or a meta2 addressing record,
 		// update the meta1 entry for KeyMax.
 		if bytes.Equal(desc.StartKey, proto.KeyMin) ||
-			bytes.HasPrefix(desc.StartKey, keys.KeyMeta2Prefix) {
-			calls = action(calls, keys.MakeKey(keys.KeyMeta1Prefix, proto.KeyMax), desc)
+			bytes.HasPrefix(desc.StartKey, keys.Meta2Prefix) {
+			calls = action(calls, keys.MakeKey(keys.Meta1Prefix, proto.KeyMax), desc)
 		}
 	}
 	return calls, nil

--- a/storage/addressing_test.go
+++ b/storage/addressing_test.go
@@ -44,11 +44,11 @@ func (ms metaSlice) Swap(i, j int)      { ms[i], ms[j] = ms[j], ms[i] }
 func (ms metaSlice) Less(i, j int) bool { return ms[i].key.Less(ms[j].key) }
 
 func meta1Key(key proto.Key) proto.Key {
-	return keys.MakeKey(keys.KeyMeta1Prefix, key)
+	return keys.MakeKey(keys.Meta1Prefix, key)
 }
 
 func meta2Key(key proto.Key) proto.Key {
-	return keys.MakeKey(keys.KeyMeta2Prefix, key)
+	return keys.MakeKey(keys.Meta2Prefix, key)
 }
 
 // TestUpdateRangeAddressing verifies range addressing records are
@@ -131,7 +131,7 @@ func TestUpdateRangeAddressing(t *testing.T) {
 			t.Fatal(err)
 		}
 		// Scan meta keys directly from engine.
-		kvs, err := engine.MVCCScan(store.Engine(), keys.KeyMetaPrefix, keys.KeyMetaMax, 0, proto.MaxTimestamp, true, nil)
+		kvs, err := engine.MVCCScan(store.Engine(), keys.MetaPrefix, keys.MetaMax, 0, proto.MaxTimestamp, true, nil)
 		if err != nil {
 			t.Fatal(err)
 		}

--- a/storage/addressing_test.go
+++ b/storage/addressing_test.go
@@ -24,6 +24,7 @@ import (
 	"testing"
 
 	"github.com/cockroachdb/cockroach/client"
+	"github.com/cockroachdb/cockroach/keys"
 	"github.com/cockroachdb/cockroach/proto"
 	"github.com/cockroachdb/cockroach/storage/engine"
 	"github.com/cockroachdb/cockroach/util/leaktest"
@@ -43,11 +44,11 @@ func (ms metaSlice) Swap(i, j int)      { ms[i], ms[j] = ms[j], ms[i] }
 func (ms metaSlice) Less(i, j int) bool { return ms[i].key.Less(ms[j].key) }
 
 func meta1Key(key proto.Key) proto.Key {
-	return engine.MakeKey(engine.KeyMeta1Prefix, key)
+	return keys.MakeKey(keys.KeyMeta1Prefix, key)
 }
 
 func meta2Key(key proto.Key) proto.Key {
-	return engine.MakeKey(engine.KeyMeta2Prefix, key)
+	return keys.MakeKey(keys.KeyMeta2Prefix, key)
 }
 
 // TestUpdateRangeAddressing verifies range addressing records are
@@ -67,47 +68,47 @@ func TestUpdateRangeAddressing(t *testing.T) {
 		leftExpNew, rightExpNew []proto.Key
 	}{
 		// Start out with whole range.
-		{false, engine.KeyMin, engine.KeyMax, engine.KeyMin, engine.KeyMax,
-			[]proto.Key{}, []proto.Key{meta1Key(engine.KeyMax), meta2Key(engine.KeyMax)}},
+		{false, proto.KeyMin, proto.KeyMax, proto.KeyMin, proto.KeyMax,
+			[]proto.Key{}, []proto.Key{meta1Key(proto.KeyMax), meta2Key(proto.KeyMax)}},
 		// Split KeyMin-KeyMax at key "a".
-		{true, engine.KeyMin, proto.Key("a"), proto.Key("a"), engine.KeyMax,
-			[]proto.Key{meta1Key(engine.KeyMax), meta2Key(proto.Key("a"))}, []proto.Key{meta2Key(engine.KeyMax)}},
+		{true, proto.KeyMin, proto.Key("a"), proto.Key("a"), proto.KeyMax,
+			[]proto.Key{meta1Key(proto.KeyMax), meta2Key(proto.Key("a"))}, []proto.Key{meta2Key(proto.KeyMax)}},
 		// Split "a"-KeyMax at key "z".
-		{true, proto.Key("a"), proto.Key("z"), proto.Key("z"), engine.KeyMax,
-			[]proto.Key{meta2Key(proto.Key("z"))}, []proto.Key{meta2Key(engine.KeyMax)}},
+		{true, proto.Key("a"), proto.Key("z"), proto.Key("z"), proto.KeyMax,
+			[]proto.Key{meta2Key(proto.Key("z"))}, []proto.Key{meta2Key(proto.KeyMax)}},
 		// Split "a"-"z" at key "m".
 		{true, proto.Key("a"), proto.Key("m"), proto.Key("m"), proto.Key("z"),
 			[]proto.Key{meta2Key(proto.Key("m"))}, []proto.Key{meta2Key(proto.Key("z"))}},
 		// Split KeyMin-"a" at meta2(m).
-		{true, engine.KeyMin, engine.RangeMetaKey(proto.Key("m")), engine.RangeMetaKey(proto.Key("m")), proto.Key("a"),
-			[]proto.Key{meta1Key(proto.Key("m"))}, []proto.Key{meta1Key(engine.KeyMax), meta2Key(proto.Key("a"))}},
+		{true, proto.KeyMin, keys.RangeMetaKey(proto.Key("m")), keys.RangeMetaKey(proto.Key("m")), proto.Key("a"),
+			[]proto.Key{meta1Key(proto.Key("m"))}, []proto.Key{meta1Key(proto.KeyMax), meta2Key(proto.Key("a"))}},
 		// Split meta2(m)-"a" at meta2(z).
-		{true, engine.RangeMetaKey(proto.Key("m")), engine.RangeMetaKey(proto.Key("z")), engine.RangeMetaKey(proto.Key("z")), proto.Key("a"),
-			[]proto.Key{meta1Key(proto.Key("z"))}, []proto.Key{meta1Key(engine.KeyMax), meta2Key(proto.Key("a"))}},
+		{true, keys.RangeMetaKey(proto.Key("m")), keys.RangeMetaKey(proto.Key("z")), keys.RangeMetaKey(proto.Key("z")), proto.Key("a"),
+			[]proto.Key{meta1Key(proto.Key("z"))}, []proto.Key{meta1Key(proto.KeyMax), meta2Key(proto.Key("a"))}},
 		// Split meta2(m)-meta2(z) at meta2(r).
-		{true, engine.RangeMetaKey(proto.Key("m")), engine.RangeMetaKey(proto.Key("r")), engine.RangeMetaKey(proto.Key("r")), engine.RangeMetaKey(proto.Key("z")),
+		{true, keys.RangeMetaKey(proto.Key("m")), keys.RangeMetaKey(proto.Key("r")), keys.RangeMetaKey(proto.Key("r")), keys.RangeMetaKey(proto.Key("z")),
 			[]proto.Key{meta1Key(proto.Key("r"))}, []proto.Key{meta1Key(proto.Key("z"))}},
 
 		// Now, merge all of our splits backwards...
 
 		// Merge meta2(m)-meta2(z).
-		{false, engine.RangeMetaKey(proto.Key("m")), engine.RangeMetaKey(proto.Key("r")), engine.RangeMetaKey(proto.Key("m")), engine.RangeMetaKey(proto.Key("z")),
+		{false, keys.RangeMetaKey(proto.Key("m")), keys.RangeMetaKey(proto.Key("r")), keys.RangeMetaKey(proto.Key("m")), keys.RangeMetaKey(proto.Key("z")),
 			[]proto.Key{meta1Key(proto.Key("r"))}, []proto.Key{meta1Key(proto.Key("z"))}},
 		// Merge meta2(m)-"a".
-		{false, engine.RangeMetaKey(proto.Key("m")), engine.RangeMetaKey(proto.Key("z")), engine.RangeMetaKey(proto.Key("m")), proto.Key("a"),
-			[]proto.Key{meta1Key(proto.Key("z"))}, []proto.Key{meta1Key(engine.KeyMax), meta2Key(proto.Key("a"))}},
+		{false, keys.RangeMetaKey(proto.Key("m")), keys.RangeMetaKey(proto.Key("z")), keys.RangeMetaKey(proto.Key("m")), proto.Key("a"),
+			[]proto.Key{meta1Key(proto.Key("z"))}, []proto.Key{meta1Key(proto.KeyMax), meta2Key(proto.Key("a"))}},
 		// Merge KeyMin-"a".
-		{false, engine.KeyMin, engine.RangeMetaKey(proto.Key("m")), engine.KeyMin, proto.Key("a"),
-			[]proto.Key{meta1Key(proto.Key("m"))}, []proto.Key{meta1Key(engine.KeyMax), meta2Key(proto.Key("a"))}},
+		{false, proto.KeyMin, keys.RangeMetaKey(proto.Key("m")), proto.KeyMin, proto.Key("a"),
+			[]proto.Key{meta1Key(proto.Key("m"))}, []proto.Key{meta1Key(proto.KeyMax), meta2Key(proto.Key("a"))}},
 		// Merge "a"-"z".
 		{false, proto.Key("a"), proto.Key("m"), proto.Key("a"), proto.Key("z"),
 			[]proto.Key{meta2Key(proto.Key("m"))}, []proto.Key{meta2Key(proto.Key("z"))}},
 		// Merge "a"-KeyMax.
-		{false, proto.Key("a"), proto.Key("z"), proto.Key("a"), engine.KeyMax,
-			[]proto.Key{meta2Key(proto.Key("z"))}, []proto.Key{meta2Key(engine.KeyMax)}},
+		{false, proto.Key("a"), proto.Key("z"), proto.Key("a"), proto.KeyMax,
+			[]proto.Key{meta2Key(proto.Key("z"))}, []proto.Key{meta2Key(proto.KeyMax)}},
 		// Merge KeyMin-KeyMax.
-		{false, engine.KeyMin, proto.Key("a"), engine.KeyMin, engine.KeyMax,
-			[]proto.Key{meta2Key(proto.Key("a"))}, []proto.Key{meta1Key(engine.KeyMax), meta2Key(engine.KeyMax)}},
+		{false, proto.KeyMin, proto.Key("a"), proto.KeyMin, proto.KeyMax,
+			[]proto.Key{meta2Key(proto.Key("a"))}, []proto.Key{meta1Key(proto.KeyMax), meta2Key(proto.KeyMax)}},
 	}
 	expMetas := metaSlice{}
 
@@ -130,7 +131,7 @@ func TestUpdateRangeAddressing(t *testing.T) {
 			t.Fatal(err)
 		}
 		// Scan meta keys directly from engine.
-		kvs, err := engine.MVCCScan(store.Engine(), engine.KeyMetaPrefix, engine.KeyMetaMax, 0, proto.MaxTimestamp, true, nil)
+		kvs, err := engine.MVCCScan(store.Engine(), keys.KeyMetaPrefix, keys.KeyMetaMax, 0, proto.MaxTimestamp, true, nil)
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -204,8 +205,8 @@ func TestUpdateRangeAddressing(t *testing.T) {
 // of meta1 records.
 func TestUpdateRangeAddressingSplitMeta1(t *testing.T) {
 	defer leaktest.AfterTest(t)
-	left := &proto.RangeDescriptor{StartKey: engine.KeyMin, EndKey: meta1Key(proto.Key("a"))}
-	right := &proto.RangeDescriptor{StartKey: meta1Key(proto.Key("a")), EndKey: engine.KeyMax}
+	left := &proto.RangeDescriptor{StartKey: proto.KeyMin, EndKey: meta1Key(proto.Key("a"))}
+	right := &proto.RangeDescriptor{StartKey: meta1Key(proto.Key("a")), EndKey: proto.KeyMax}
 	if _, err := splitRangeAddressing(left, right); err == nil {
 		t.Error("expected failure trying to update addressing records for meta1 split")
 	}

--- a/storage/client_merge_test.go
+++ b/storage/client_merge_test.go
@@ -235,7 +235,7 @@ func TestStoreRangeMergeNonConsecutive(t *testing.T) {
 	// resolve intents.  If intents are left unresolved then the
 	// asynchronous resolution may happen after the call to RemoveRange
 	// below, reviving the range and breaking the test.
-	if err := store.DB().Run(client.Scan(keys.KeyLocalMax, keys.KeySystemMax, 1000)); err != nil {
+	if err := store.DB().Run(client.Scan(keys.LocalMax, keys.SystemMax, 1000)); err != nil {
 		t.Fatal(err)
 	}
 

--- a/storage/client_range_tree_test.go
+++ b/storage/client_range_tree_test.go
@@ -25,8 +25,8 @@ import (
 
 	"github.com/biogo/store/llrb"
 	"github.com/cockroachdb/cockroach/client"
+	"github.com/cockroachdb/cockroach/keys"
 	"github.com/cockroachdb/cockroach/proto"
-	"github.com/cockroachdb/cockroach/storage/engine"
 	"github.com/cockroachdb/cockroach/util"
 	"github.com/cockroachdb/cockroach/util/leaktest"
 )
@@ -84,7 +84,7 @@ func treeNodesEqual(db *client.KV, expected testRangeTree, key proto.Key) error 
 		return util.Errorf("Expected does not contain a node for %s", key)
 	}
 	actualNode := &proto.RangeTreeNode{}
-	if err := db.Run(client.GetProto(engine.RangeTreeNodeKey(key), actualNode)); err != nil {
+	if err := db.Run(client.GetProto(keys.RangeTreeNodeKey(key), actualNode)); err != nil {
 		return err
 	}
 	if err := nodesEqual(key, expectedNode, *actualNode); err != nil {
@@ -108,7 +108,7 @@ func treeNodesEqual(db *client.KV, expected testRangeTree, key proto.Key) error 
 func treesEqual(db *client.KV, expected testRangeTree) error {
 	// Compare the tree roots.
 	actualTree := &proto.RangeTree{}
-	if err := db.Run(client.GetProto(engine.KeyRangeTreeRoot, actualTree)); err != nil {
+	if err := db.Run(client.GetProto(keys.KeyRangeTreeRoot, actualTree)); err != nil {
 		return err
 	}
 	if !reflect.DeepEqual(&expected.Tree, actualTree) {
@@ -139,12 +139,12 @@ func TestSetupRangeTree(t *testing.T) {
 
 	// Check to make sure the range tree is stored correctly.
 	tree := proto.RangeTree{
-		RootKey: engine.KeyMin,
+		RootKey: proto.KeyMin,
 	}
 	nodes := map[string]proto.RangeTreeNode{
-		string(engine.KeyMin): {
-			Key:       engine.KeyMin,
-			ParentKey: engine.KeyMin,
+		string(proto.KeyMin): {
+			Key:       proto.KeyMin,
+			ParentKey: proto.KeyMin,
 			Black:     true,
 		},
 	}
@@ -178,13 +178,13 @@ func TestInsertRight(t *testing.T) {
 	nodes := map[string]proto.RangeTreeNode{
 		string(keyA): {
 			Key:       keyA,
-			ParentKey: engine.KeyMin,
+			ParentKey: proto.KeyMin,
 			Black:     true,
-			LeftKey:   &engine.KeyMin,
+			LeftKey:   &proto.KeyMin,
 		},
-		string(engine.KeyMin): {
-			Key:       engine.KeyMin,
-			ParentKey: engine.KeyMin,
+		string(proto.KeyMin): {
+			Key:       proto.KeyMin,
+			ParentKey: proto.KeyMin,
 			Black:     false,
 		},
 	}
@@ -206,19 +206,19 @@ func TestInsertRight(t *testing.T) {
 	nodes = map[string]proto.RangeTreeNode{
 		string(keyA): {
 			Key:       keyA,
-			ParentKey: engine.KeyMin,
+			ParentKey: proto.KeyMin,
 			Black:     true,
-			LeftKey:   &engine.KeyMin,
+			LeftKey:   &proto.KeyMin,
 			RightKey:  &keyB,
 		},
-		string(engine.KeyMin): {
-			Key:       engine.KeyMin,
-			ParentKey: engine.KeyMin,
+		string(proto.KeyMin): {
+			Key:       proto.KeyMin,
+			ParentKey: proto.KeyMin,
 			Black:     true,
 		},
 		string(keyB): {
 			Key:       keyB,
-			ParentKey: engine.KeyMin,
+			ParentKey: proto.KeyMin,
 			Black:     true,
 		},
 	}
@@ -240,25 +240,25 @@ func TestInsertRight(t *testing.T) {
 	nodes = map[string]proto.RangeTreeNode{
 		string(keyA): {
 			Key:       keyA,
-			ParentKey: engine.KeyMin,
+			ParentKey: proto.KeyMin,
 			Black:     true,
-			LeftKey:   &engine.KeyMin,
+			LeftKey:   &proto.KeyMin,
 			RightKey:  &keyC,
 		},
-		string(engine.KeyMin): {
-			Key:       engine.KeyMin,
-			ParentKey: engine.KeyMin,
+		string(proto.KeyMin): {
+			Key:       proto.KeyMin,
+			ParentKey: proto.KeyMin,
 			Black:     true,
 		},
 		string(keyC): {
 			Key:       keyC,
-			ParentKey: engine.KeyMin,
+			ParentKey: proto.KeyMin,
 			Black:     true,
 			LeftKey:   &keyB,
 		},
 		string(keyB): {
 			Key:       keyB,
-			ParentKey: engine.KeyMin,
+			ParentKey: proto.KeyMin,
 			Black:     false,
 		},
 	}
@@ -280,31 +280,31 @@ func TestInsertRight(t *testing.T) {
 	nodes = map[string]proto.RangeTreeNode{
 		string(keyC): {
 			Key:       keyC,
-			ParentKey: engine.KeyMin,
+			ParentKey: proto.KeyMin,
 			Black:     true,
 			LeftKey:   &keyA,
 			RightKey:  &keyD,
 		},
 		string(keyA): {
 			Key:       keyA,
-			ParentKey: engine.KeyMin,
+			ParentKey: proto.KeyMin,
 			Black:     false,
-			LeftKey:   &engine.KeyMin,
+			LeftKey:   &proto.KeyMin,
 			RightKey:  &keyB,
 		},
-		string(engine.KeyMin): {
-			Key:       engine.KeyMin,
-			ParentKey: engine.KeyMin,
+		string(proto.KeyMin): {
+			Key:       proto.KeyMin,
+			ParentKey: proto.KeyMin,
 			Black:     true,
 		},
 		string(keyB): {
 			Key:       keyB,
-			ParentKey: engine.KeyMin,
+			ParentKey: proto.KeyMin,
 			Black:     true,
 		},
 		string(keyD): {
 			Key:       keyD,
-			ParentKey: engine.KeyMin,
+			ParentKey: proto.KeyMin,
 			Black:     true,
 		},
 	}
@@ -326,37 +326,37 @@ func TestInsertRight(t *testing.T) {
 	nodes = map[string]proto.RangeTreeNode{
 		string(keyC): {
 			Key:       keyC,
-			ParentKey: engine.KeyMin,
+			ParentKey: proto.KeyMin,
 			Black:     true,
 			LeftKey:   &keyA,
 			RightKey:  &keyE,
 		},
 		string(keyA): {
 			Key:       keyA,
-			ParentKey: engine.KeyMin,
+			ParentKey: proto.KeyMin,
 			Black:     false,
-			LeftKey:   &engine.KeyMin,
+			LeftKey:   &proto.KeyMin,
 			RightKey:  &keyB,
 		},
-		string(engine.KeyMin): {
-			Key:       engine.KeyMin,
-			ParentKey: engine.KeyMin,
+		string(proto.KeyMin): {
+			Key:       proto.KeyMin,
+			ParentKey: proto.KeyMin,
 			Black:     true,
 		},
 		string(keyB): {
 			Key:       keyB,
-			ParentKey: engine.KeyMin,
+			ParentKey: proto.KeyMin,
 			Black:     true,
 		},
 		string(keyE): {
 			Key:       keyE,
-			ParentKey: engine.KeyMin,
+			ParentKey: proto.KeyMin,
 			Black:     true,
 			LeftKey:   &keyD,
 		},
 		string(keyD): {
 			Key:       keyD,
-			ParentKey: engine.KeyMin,
+			ParentKey: proto.KeyMin,
 			Black:     false,
 		},
 	}
@@ -393,13 +393,13 @@ func TestInsertLeft(t *testing.T) {
 	nodes := map[string]proto.RangeTreeNode{
 		string(keyE): {
 			Key:       keyE,
-			ParentKey: engine.KeyMin,
+			ParentKey: proto.KeyMin,
 			Black:     true,
-			LeftKey:   &engine.KeyMin,
+			LeftKey:   &proto.KeyMin,
 		},
-		string(engine.KeyMin): {
-			Key:       engine.KeyMin,
-			ParentKey: engine.KeyMin,
+		string(proto.KeyMin): {
+			Key:       proto.KeyMin,
+			ParentKey: proto.KeyMin,
 			Black:     false,
 		},
 	}
@@ -421,19 +421,19 @@ func TestInsertLeft(t *testing.T) {
 	nodes = map[string]proto.RangeTreeNode{
 		string(keyD): {
 			Key:       keyD,
-			ParentKey: engine.KeyMin,
+			ParentKey: proto.KeyMin,
 			Black:     true,
-			LeftKey:   &engine.KeyMin,
+			LeftKey:   &proto.KeyMin,
 			RightKey:  &keyE,
 		},
-		string(engine.KeyMin): {
-			Key:       engine.KeyMin,
-			ParentKey: engine.KeyMin,
+		string(proto.KeyMin): {
+			Key:       proto.KeyMin,
+			ParentKey: proto.KeyMin,
 			Black:     true,
 		},
 		string(keyE): {
 			Key:       keyE,
-			ParentKey: engine.KeyMin,
+			ParentKey: proto.KeyMin,
 			Black:     true,
 		},
 	}
@@ -455,26 +455,26 @@ func TestInsertLeft(t *testing.T) {
 	nodes = map[string]proto.RangeTreeNode{
 		string(keyD): {
 			Key:       keyD,
-			ParentKey: engine.KeyMin,
+			ParentKey: proto.KeyMin,
 			Black:     true,
 			LeftKey:   &keyC,
 			RightKey:  &keyE,
 		},
 		string(keyC): {
 			Key:       keyC,
-			ParentKey: engine.KeyMin,
+			ParentKey: proto.KeyMin,
 			Black:     true,
-			LeftKey:   &engine.KeyMin,
+			LeftKey:   &proto.KeyMin,
 		},
-		string(engine.KeyMin): {
-			Key:       engine.KeyMin,
-			ParentKey: engine.KeyMin,
+		string(proto.KeyMin): {
+			Key:       proto.KeyMin,
+			ParentKey: proto.KeyMin,
 			Black:     false,
 		},
 
 		string(keyE): {
 			Key:       keyE,
-			ParentKey: engine.KeyMin,
+			ParentKey: proto.KeyMin,
 			Black:     true,
 		},
 	}
@@ -496,31 +496,31 @@ func TestInsertLeft(t *testing.T) {
 	nodes = map[string]proto.RangeTreeNode{
 		string(keyD): {
 			Key:       keyD,
-			ParentKey: engine.KeyMin,
+			ParentKey: proto.KeyMin,
 			Black:     true,
 			LeftKey:   &keyB,
 			RightKey:  &keyE,
 		},
 		string(keyB): {
 			Key:       keyB,
-			ParentKey: engine.KeyMin,
+			ParentKey: proto.KeyMin,
 			Black:     false,
-			LeftKey:   &engine.KeyMin,
+			LeftKey:   &proto.KeyMin,
 			RightKey:  &keyC,
 		},
-		string(engine.KeyMin): {
-			Key:       engine.KeyMin,
-			ParentKey: engine.KeyMin,
+		string(proto.KeyMin): {
+			Key:       proto.KeyMin,
+			ParentKey: proto.KeyMin,
 			Black:     true,
 		},
 		string(keyC): {
 			Key:       keyC,
-			ParentKey: engine.KeyMin,
+			ParentKey: proto.KeyMin,
 			Black:     true,
 		},
 		string(keyE): {
 			Key:       keyE,
-			ParentKey: engine.KeyMin,
+			ParentKey: proto.KeyMin,
 			Black:     true,
 		},
 	}
@@ -542,37 +542,37 @@ func TestInsertLeft(t *testing.T) {
 	nodes = map[string]proto.RangeTreeNode{
 		string(keyD): {
 			Key:       keyD,
-			ParentKey: engine.KeyMin,
+			ParentKey: proto.KeyMin,
 			Black:     true,
 			LeftKey:   &keyB,
 			RightKey:  &keyE,
 		},
 		string(keyB): {
 			Key:       keyB,
-			ParentKey: engine.KeyMin,
+			ParentKey: proto.KeyMin,
 			Black:     false,
 			LeftKey:   &keyA,
 			RightKey:  &keyC,
 		},
 		string(keyA): {
 			Key:       keyA,
-			ParentKey: engine.KeyMin,
+			ParentKey: proto.KeyMin,
 			Black:     true,
-			LeftKey:   &engine.KeyMin,
+			LeftKey:   &proto.KeyMin,
 		},
-		string(engine.KeyMin): {
-			Key:       engine.KeyMin,
-			ParentKey: engine.KeyMin,
+		string(proto.KeyMin): {
+			Key:       proto.KeyMin,
+			ParentKey: proto.KeyMin,
 			Black:     false,
 		},
 		string(keyC): {
 			Key:       keyC,
-			ParentKey: engine.KeyMin,
+			ParentKey: proto.KeyMin,
 			Black:     true,
 		},
 		string(keyE): {
 			Key:       keyE,
-			ParentKey: engine.KeyMin,
+			ParentKey: proto.KeyMin,
 			Black:     true,
 		},
 	}
@@ -599,13 +599,13 @@ func (k Key) Compare(b llrb.Comparable) int {
 func compareBiogoNode(db *client.KV, biogoNode *llrb.Node, key *proto.Key) error {
 	// Retrieve the node form the range tree.
 	rtNode := &proto.RangeTreeNode{}
-	if err := db.Run(client.GetProto(engine.RangeTreeNodeKey(*key), rtNode)); err != nil {
+	if err := db.Run(client.GetProto(keys.RangeTreeNodeKey(*key), rtNode)); err != nil {
 		return err
 	}
 
 	bNode := &proto.RangeTreeNode{
 		Key:       proto.Key(biogoNode.Elem.(Key)),
-		ParentKey: engine.KeyMin,
+		ParentKey: proto.KeyMin,
 		Black:     bool(biogoNode.Color),
 	}
 	if biogoNode.Left != nil {
@@ -636,7 +636,7 @@ func compareBiogoNode(db *client.KV, biogoNode *llrb.Node, key *proto.Key) error
 // contain the same values in the same order.
 func compareBiogoTree(db *client.KV, biogoTree *llrb.Tree) error {
 	rt := &proto.RangeTree{}
-	if err := db.Run(client.GetProto(engine.KeyRangeTreeRoot, rt)); err != nil {
+	if err := db.Run(client.GetProto(keys.KeyRangeTreeRoot, rt)); err != nil {
 		return err
 	}
 	return compareBiogoNode(db, biogoTree.Root, &rt.RootKey)
@@ -655,7 +655,7 @@ func TestRandomSplits(t *testing.T) {
 	t.Logf("using pseudo random number generator with seed %d", seed)
 
 	tree := &llrb.Tree{}
-	tree.Insert(Key(engine.KeyMin))
+	tree.Insert(Key(proto.KeyMin))
 
 	// Test an unsplit tree.
 	if err := compareBiogoTree(db, tree); err != nil {

--- a/storage/client_range_tree_test.go
+++ b/storage/client_range_tree_test.go
@@ -108,7 +108,7 @@ func treeNodesEqual(db *client.KV, expected testRangeTree, key proto.Key) error 
 func treesEqual(db *client.KV, expected testRangeTree) error {
 	// Compare the tree roots.
 	actualTree := &proto.RangeTree{}
-	if err := db.Run(client.GetProto(keys.KeyRangeTreeRoot, actualTree)); err != nil {
+	if err := db.Run(client.GetProto(keys.RangeTreeRoot, actualTree)); err != nil {
 		return err
 	}
 	if !reflect.DeepEqual(&expected.Tree, actualTree) {
@@ -636,7 +636,7 @@ func compareBiogoNode(db *client.KV, biogoNode *llrb.Node, key *proto.Key) error
 // contain the same values in the same order.
 func compareBiogoTree(db *client.KV, biogoTree *llrb.Tree) error {
 	rt := &proto.RangeTree{}
-	if err := db.Run(client.GetProto(keys.KeyRangeTreeRoot, rt)); err != nil {
+	if err := db.Run(client.GetProto(keys.RangeTreeRoot, rt)); err != nil {
 		return err
 	}
 	return compareBiogoNode(db, biogoTree.Root, &rt.RootKey)

--- a/storage/client_split_test.go
+++ b/storage/client_split_test.go
@@ -73,12 +73,12 @@ func TestStoreRangeSplitAtIllegalKeys(t *testing.T) {
 	defer stopper.Stop()
 
 	for _, key := range []proto.Key{
-		keys.KeyMeta1Prefix,
-		keys.MakeKey(keys.KeyMeta1Prefix, []byte("a")),
-		keys.MakeKey(keys.KeyMeta1Prefix, proto.KeyMax),
-		keys.MakeKey(keys.KeyConfigAccountingPrefix, []byte("a")),
-		keys.MakeKey(keys.KeyConfigPermissionPrefix, []byte("a")),
-		keys.MakeKey(keys.KeyConfigZonePrefix, []byte("a")),
+		keys.Meta1Prefix,
+		keys.MakeKey(keys.Meta1Prefix, []byte("a")),
+		keys.MakeKey(keys.Meta1Prefix, proto.KeyMax),
+		keys.MakeKey(keys.ConfigAccountingPrefix, []byte("a")),
+		keys.MakeKey(keys.ConfigPermissionPrefix, []byte("a")),
+		keys.MakeKey(keys.ConfigZonePrefix, []byte("a")),
 	} {
 		args, reply := adminSplitArgs(proto.KeyMin, key, 1, store.StoreID())
 		err := store.ExecuteCmd(context.Background(), client.Call{Args: args, Reply: reply})
@@ -390,7 +390,7 @@ func TestStoreZoneUpdateAndRangeSplit(t *testing.T) {
 		RangeMinBytes: 1 << 8,
 		RangeMaxBytes: maxBytes,
 	}
-	call := client.PutProto(keys.MakeKey(keys.KeyConfigZonePrefix, proto.KeyMin), zoneConfig)
+	call := client.PutProto(keys.MakeKey(keys.ConfigZonePrefix, proto.KeyMin), zoneConfig)
 	if err := store.DB().Run(call); err != nil {
 		t.Fatal(err)
 	}
@@ -426,14 +426,14 @@ func TestStoreRangeSplitOnConfigs(t *testing.T) {
 	var calls []client.Call
 	for _, k := range []string{"db4", "db3"} {
 		call := client.PutProto(
-			keys.MakeKey(keys.KeyConfigZonePrefix, proto.Key(k)),
+			keys.MakeKey(keys.ConfigZonePrefix, proto.Key(k)),
 			zoneConfig)
 		calls = append(calls, call)
 	}
 	// Write accounting configs for db1 & db2.
 	for _, k := range []string{"db2", "db1"} {
 		call := client.PutProto(
-			keys.MakeKey(keys.KeyConfigAccountingPrefix, proto.Key(k)),
+			keys.MakeKey(keys.ConfigAccountingPrefix, proto.Key(k)),
 			acctConfig)
 		calls = append(calls, call)
 	}
@@ -452,7 +452,7 @@ func TestStoreRangeSplitOnConfigs(t *testing.T) {
 		keys.MakeKey(proto.Key("\x00\x00meta2"), proto.KeyMax),
 	}
 	if err := util.IsTrueWithin(func() bool {
-		call := client.Scan(keys.KeyMeta2Prefix, keys.KeyMetaMax, 0)
+		call := client.Scan(keys.Meta2Prefix, keys.MetaMax, 0)
 		resp := call.Reply.(*proto.ScanResponse)
 		if err := store.DB().Run(call); err != nil {
 			t.Fatalf("failed to scan meta2 keys: %s", err)

--- a/storage/client_split_test.go
+++ b/storage/client_split_test.go
@@ -30,6 +30,7 @@ import (
 	"golang.org/x/net/context"
 
 	"github.com/cockroachdb/cockroach/client"
+	"github.com/cockroachdb/cockroach/keys"
 	"github.com/cockroachdb/cockroach/proto"
 	"github.com/cockroachdb/cockroach/storage"
 	"github.com/cockroachdb/cockroach/storage/engine"
@@ -72,14 +73,14 @@ func TestStoreRangeSplitAtIllegalKeys(t *testing.T) {
 	defer stopper.Stop()
 
 	for _, key := range []proto.Key{
-		engine.KeyMeta1Prefix,
-		engine.MakeKey(engine.KeyMeta1Prefix, []byte("a")),
-		engine.MakeKey(engine.KeyMeta1Prefix, engine.KeyMax),
-		engine.MakeKey(engine.KeyConfigAccountingPrefix, []byte("a")),
-		engine.MakeKey(engine.KeyConfigPermissionPrefix, []byte("a")),
-		engine.MakeKey(engine.KeyConfigZonePrefix, []byte("a")),
+		keys.KeyMeta1Prefix,
+		keys.MakeKey(keys.KeyMeta1Prefix, []byte("a")),
+		keys.MakeKey(keys.KeyMeta1Prefix, proto.KeyMax),
+		keys.MakeKey(keys.KeyConfigAccountingPrefix, []byte("a")),
+		keys.MakeKey(keys.KeyConfigPermissionPrefix, []byte("a")),
+		keys.MakeKey(keys.KeyConfigZonePrefix, []byte("a")),
 	} {
-		args, reply := adminSplitArgs(engine.KeyMin, key, 1, store.StoreID())
+		args, reply := adminSplitArgs(proto.KeyMin, key, 1, store.StoreID())
 		err := store.ExecuteCmd(context.Background(), client.Call{Args: args, Reply: reply})
 		if err == nil {
 			t.Fatalf("%q: split succeeded unexpectedly", key)
@@ -97,7 +98,7 @@ func TestStoreRangeSplitAtRangeBounds(t *testing.T) {
 	store, stopper := createTestStore(t)
 	defer stopper.Stop()
 
-	args, reply := adminSplitArgs(engine.KeyMin, []byte("a"), 1, store.StoreID())
+	args, reply := adminSplitArgs(proto.KeyMin, []byte("a"), 1, store.StoreID())
 	if err := store.ExecuteCmd(context.Background(), client.Call{Args: args, Reply: reply}); err != nil {
 		t.Fatal(err)
 	}
@@ -106,7 +107,7 @@ func TestStoreRangeSplitAtRangeBounds(t *testing.T) {
 		t.Fatalf("split succeeded unexpectedly")
 	}
 	// Now try to split at start of new range.
-	args, reply = adminSplitArgs(engine.KeyMin, []byte("a"), 2, store.StoreID())
+	args, reply = adminSplitArgs(proto.KeyMin, []byte("a"), 2, store.StoreID())
 	if err := store.ExecuteCmd(context.Background(), client.Call{Args: args, Reply: reply}); err == nil {
 		t.Fatalf("split succeeded unexpectedly")
 	}
@@ -126,7 +127,7 @@ func TestStoreRangeSplitConcurrent(t *testing.T) {
 	failureCount := int32(0)
 	for i := int32(0); i < concurrentCount; i++ {
 		go func() {
-			args, reply := adminSplitArgs(engine.KeyMin, []byte("a"), 1, store.StoreID())
+			args, reply := adminSplitArgs(proto.KeyMin, []byte("a"), 1, store.StoreID())
 			err := store.ExecuteCmd(context.Background(), client.Call{Args: args, Reply: reply})
 			if err != nil {
 				if matched, regexpErr := regexp.MatchString(".*outside of bounds of range", err.Error()); !matched || regexpErr != nil {
@@ -187,24 +188,24 @@ func TestStoreRangeSplit(t *testing.T) {
 	keyBytes, valBytes := ms.KeyBytes, ms.ValBytes
 
 	// Split the range.
-	args, reply := adminSplitArgs(engine.KeyMin, splitKey, 1, store.StoreID())
+	args, reply := adminSplitArgs(proto.KeyMin, splitKey, 1, store.StoreID())
 	if err := store.ExecuteCmd(context.Background(), client.Call{Args: args, Reply: reply}); err != nil {
 		t.Fatal(err)
 	}
 
 	// Verify no intents remains on range descriptor keys.
-	for _, key := range []proto.Key{engine.RangeDescriptorKey(engine.KeyMin), engine.RangeDescriptorKey(splitKey)} {
+	for _, key := range []proto.Key{keys.RangeDescriptorKey(proto.KeyMin), keys.RangeDescriptorKey(splitKey)} {
 		if _, err := engine.MVCCGet(store.Engine(), key, store.Clock().Now(), true, nil); err != nil {
 			t.Fatal(err)
 		}
 	}
 
-	rng := store.LookupRange(engine.KeyMin, nil)
+	rng := store.LookupRange(proto.KeyMin, nil)
 	newRng := store.LookupRange([]byte("m"), nil)
 	if !bytes.Equal(newRng.Desc().StartKey, splitKey) || !bytes.Equal(splitKey, rng.Desc().EndKey) {
 		t.Errorf("ranges mismatched, wanted %q=%q=%q", newRng.Desc().StartKey, splitKey, rng.Desc().EndKey)
 	}
-	if !bytes.Equal(newRng.Desc().EndKey, engine.KeyMax) || !bytes.Equal(rng.Desc().StartKey, engine.KeyMin) {
+	if !bytes.Equal(newRng.Desc().EndKey, proto.KeyMax) || !bytes.Equal(rng.Desc().StartKey, proto.KeyMin) {
 		t.Errorf("new ranges do not cover KeyMin-KeyMax, but only %q-%q", rng.Desc().StartKey, newRng.Desc().EndKey)
 	}
 
@@ -278,7 +279,7 @@ func TestStoreRangeSplitStats(t *testing.T) {
 	defer stopper.Stop()
 
 	// Split the range at the first user key.
-	args, reply := adminSplitArgs(engine.KeyMin, proto.Key("\x01"), 1, store.StoreID())
+	args, reply := adminSplitArgs(proto.KeyMin, proto.Key("\x01"), 1, store.StoreID())
 	if err := store.ExecuteCmd(context.Background(), client.Call{Args: args, Reply: reply}); err != nil {
 		t.Fatal(err)
 	}
@@ -373,7 +374,7 @@ func TestStoreZoneUpdateAndRangeSplit(t *testing.T) {
 	defer stopper.Stop()
 
 	maxBytes := int64(1 << 16)
-	rng := store.LookupRange(engine.KeyMin, nil)
+	rng := store.LookupRange(proto.KeyMin, nil)
 	fillRange(store, rng.Desc().RaftID, proto.Key("test"), maxBytes, t)
 
 	// Rewrite zone config with range max bytes set to 64K.
@@ -389,7 +390,7 @@ func TestStoreZoneUpdateAndRangeSplit(t *testing.T) {
 		RangeMinBytes: 1 << 8,
 		RangeMaxBytes: maxBytes,
 	}
-	call := client.PutProto(engine.MakeKey(engine.KeyConfigZonePrefix, engine.KeyMin), zoneConfig)
+	call := client.PutProto(keys.MakeKey(keys.KeyConfigZonePrefix, proto.KeyMin), zoneConfig)
 	if err := store.DB().Run(call); err != nil {
 		t.Fatal(err)
 	}
@@ -425,14 +426,14 @@ func TestStoreRangeSplitOnConfigs(t *testing.T) {
 	var calls []client.Call
 	for _, k := range []string{"db4", "db3"} {
 		call := client.PutProto(
-			engine.MakeKey(engine.KeyConfigZonePrefix, proto.Key(k)),
+			keys.MakeKey(keys.KeyConfigZonePrefix, proto.Key(k)),
 			zoneConfig)
 		calls = append(calls, call)
 	}
 	// Write accounting configs for db1 & db2.
 	for _, k := range []string{"db2", "db1"} {
 		call := client.PutProto(
-			engine.MakeKey(engine.KeyConfigAccountingPrefix, proto.Key(k)),
+			keys.MakeKey(keys.KeyConfigAccountingPrefix, proto.Key(k)),
 			acctConfig)
 		calls = append(calls, call)
 	}
@@ -448,10 +449,10 @@ func TestStoreRangeSplitOnConfigs(t *testing.T) {
 		proto.Key("\x00\x00meta2db3"),
 		proto.Key("\x00\x00meta2db4"),
 		proto.Key("\x00\x00meta2db5"),
-		engine.MakeKey(proto.Key("\x00\x00meta2"), engine.KeyMax),
+		keys.MakeKey(proto.Key("\x00\x00meta2"), proto.KeyMax),
 	}
 	if err := util.IsTrueWithin(func() bool {
-		call := client.Scan(engine.KeyMeta2Prefix, engine.KeyMetaMax, 0)
+		call := client.Scan(keys.KeyMeta2Prefix, keys.KeyMetaMax, 0)
 		resp := call.Reply.(*proto.ScanResponse)
 		if err := store.DB().Run(call); err != nil {
 			t.Fatalf("failed to scan meta2 keys: %s", err)

--- a/storage/client_status_test.go
+++ b/storage/client_status_test.go
@@ -25,6 +25,7 @@ import (
 	"golang.org/x/net/context"
 
 	"github.com/cockroachdb/cockroach/client"
+	"github.com/cockroachdb/cockroach/keys"
 	"github.com/cockroachdb/cockroach/proto"
 	"github.com/cockroachdb/cockroach/storage"
 	"github.com/cockroachdb/cockroach/storage/engine"
@@ -40,7 +41,7 @@ import (
 // at least the expected value.
 // The latest actual stats are returned.
 func compareStoreStatus(t *testing.T, store *storage.Store, expectedStoreStatus *proto.StoreStatus, testNumber int) *proto.StoreStatus {
-	storeStatusKey := engine.StoreStatusKey(int32(store.Ident.StoreID))
+	storeStatusKey := keys.StoreStatusKey(int32(store.Ident.StoreID))
 	gArgs, gReply := getArgs(storeStatusKey, 1, store.Ident.StoreID)
 	if err := store.ExecuteCmd(context.Background(), client.Call{Args: gArgs, Reply: gReply}); err != nil {
 		t.Fatalf("%v: failure getting store status: %s", testNumber, err)
@@ -175,7 +176,7 @@ func TestStoreStatus(t *testing.T) {
 	oldstats = compareStoreStatus(t, store, expectedStoreStatus, 1)
 
 	// Split the range.
-	args, reply := adminSplitArgs(engine.KeyMin, splitKey, rng.Desc().RaftID, store.StoreID())
+	args, reply := adminSplitArgs(proto.KeyMin, splitKey, rng.Desc().RaftID, store.StoreID())
 	if err := store.ExecuteCmd(context.Background(), client.Call{Args: args, Reply: reply}); err != nil {
 		t.Fatal(err)
 	}

--- a/storage/engine/batch_test.go
+++ b/storage/engine/batch_test.go
@@ -61,7 +61,7 @@ func TestBatchBasics(t *testing.T) {
 		{Key: proto.EncodedKey("b"), Value: []byte("value")},
 		{Key: proto.EncodedKey("c"), Value: appender("foo")},
 	}
-	kvs, err := Scan(e, proto.EncodedKey(KeyMin), proto.EncodedKey(KeyMax), 0)
+	kvs, err := Scan(e, proto.EncodedKey(proto.KeyMin), proto.EncodedKey(proto.KeyMax), 0)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -75,7 +75,7 @@ func TestBatchBasics(t *testing.T) {
 		{Key: proto.EncodedKey("c"), Value: appender("foobar")},
 	}
 	// Scan values from batch directly.
-	kvs, err = Scan(b, proto.EncodedKey(KeyMin), proto.EncodedKey(KeyMax), 0)
+	kvs, err = Scan(b, proto.EncodedKey(proto.KeyMin), proto.EncodedKey(proto.KeyMax), 0)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -87,7 +87,7 @@ func TestBatchBasics(t *testing.T) {
 	if err := b.Commit(); err != nil {
 		t.Fatal(err)
 	}
-	kvs, err = Scan(e, proto.EncodedKey(KeyMin), proto.EncodedKey(KeyMax), 0)
+	kvs, err = Scan(e, proto.EncodedKey(proto.KeyMin), proto.EncodedKey(proto.KeyMax), 0)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -358,7 +358,7 @@ func TestBatchScanWithDelete(t *testing.T) {
 	if err := b.Clear(proto.EncodedKey("a")); err != nil {
 		t.Fatal(err)
 	}
-	kvs, err := Scan(b, proto.EncodedKey(KeyMin), proto.EncodedKey(KeyMax), 0)
+	kvs, err := Scan(b, proto.EncodedKey(proto.KeyMin), proto.EncodedKey(proto.KeyMax), 0)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -390,7 +390,7 @@ func TestBatchScanMaxWithDeleted(t *testing.T) {
 		t.Fatal(err)
 	}
 	// A scan with max=1 should scan "b".
-	kvs, err := Scan(b, proto.EncodedKey(KeyMin), proto.EncodedKey(KeyMax), 1)
+	kvs, err := Scan(b, proto.EncodedKey(proto.KeyMin), proto.EncodedKey(proto.KeyMax), 1)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/storage/engine/db.cc
+++ b/storage/engine/db.cc
@@ -68,10 +68,10 @@ namespace {
 
 // NOTE: these constants must be kept in sync with the values in
 // storage/engine/keys.go. Both kKeyLocalRangeIDPrefix and
-// kKeyLocalRangeKeyPrefix are the mvcc-encoded prefixes.
+// kKeyLocalRangePrefix are the mvcc-encoded prefixes.
 const int kKeyLocalRangePrefixSize = 4;
 const rocksdb::Slice kKeyLocalRangeIDPrefix("\x00\xff\x00\xff\x00\xffi", 7);
-const rocksdb::Slice kKeyLocalRangeKeyPrefix("\x00\xff\x00\xff\x00\xffk", 7);
+const rocksdb::Slice kKeyLocalRangePrefix("\x00\xff\x00\xff\x00\xffk", 7);
 const rocksdb::Slice kKeyLocalResponseCacheSuffix("res-", 4);
 const rocksdb::Slice kKeyLocalTransactionSuffix("\x00\x01txn-", 6);
 
@@ -216,7 +216,7 @@ class DBCompactionFilter : public rocksdb::CompactionFilter {
   bool IsTransactionRecord(rocksdb::Slice key) const {
     // The transaction key format is:
     //   <prefix>[key]<suffix>[remainder].
-    if (!key.starts_with(kKeyLocalRangeKeyPrefix)) {
+    if (!key.starts_with(kKeyLocalRangePrefix)) {
       return false;
     }
 

--- a/storage/engine/engine_test.go
+++ b/storage/engine/engine_test.go
@@ -428,7 +428,7 @@ func TestEngineScan1(t *testing.T) {
 		// a special case in engine.scan, that's why we test it here.
 		startKeys := []proto.EncodedKey{proto.EncodedKey("cat"), proto.EncodedKey("")}
 		for _, startKey := range startKeys {
-			keyvals, err := Scan(engine, startKey, proto.EncodedKey(KeyMax), 0)
+			keyvals, err := Scan(engine, startKey, proto.EncodedKey(proto.KeyMax), 0)
 			if err != nil {
 				t.Fatalf("could not run scan: %v", err)
 			}
@@ -510,25 +510,25 @@ func TestEngineScan2(t *testing.T) {
 			proto.EncodedKey("aaa"),
 			proto.EncodedKey("ab"),
 			proto.EncodedKey("abc"),
-			proto.EncodedKey(KeyMax),
+			proto.EncodedKey(proto.KeyMax),
 		}
 
 		insertKeys(keys, engine, t)
 
 		// Scan all keys (non-inclusive of final key).
-		verifyScan(proto.EncodedKey(KeyMin), proto.EncodedKey(KeyMax), 10, keys[0:5], engine, t)
-		verifyScan(proto.EncodedKey("a"), proto.EncodedKey(KeyMax), 10, keys[0:5], engine, t)
+		verifyScan(proto.EncodedKey(proto.KeyMin), proto.EncodedKey(proto.KeyMax), 10, keys[0:5], engine, t)
+		verifyScan(proto.EncodedKey("a"), proto.EncodedKey(proto.KeyMax), 10, keys[0:5], engine, t)
 
 		// Scan sub range.
 		verifyScan(proto.EncodedKey("aab"), proto.EncodedKey("abcc"), 10, keys[3:5], engine, t)
 		verifyScan(proto.EncodedKey("aa0"), proto.EncodedKey("abcc"), 10, keys[2:5], engine, t)
 
 		// Scan with max values.
-		verifyScan(proto.EncodedKey(KeyMin), proto.EncodedKey(KeyMax), 3, keys[0:3], engine, t)
-		verifyScan(proto.EncodedKey("a0"), proto.EncodedKey(KeyMax), 3, keys[1:4], engine, t)
+		verifyScan(proto.EncodedKey(proto.KeyMin), proto.EncodedKey(proto.KeyMax), 3, keys[0:3], engine, t)
+		verifyScan(proto.EncodedKey("a0"), proto.EncodedKey(proto.KeyMax), 3, keys[1:4], engine, t)
 
 		// Scan with max value 0 gets all values.
-		verifyScan(proto.EncodedKey(KeyMin), proto.EncodedKey(KeyMax), 0, keys[0:5], engine, t)
+		verifyScan(proto.EncodedKey(proto.KeyMin), proto.EncodedKey(proto.KeyMax), 0, keys[0:5], engine, t)
 	}, t)
 }
 
@@ -541,13 +541,13 @@ func TestEngineDeleteRange(t *testing.T) {
 			proto.EncodedKey("aaa"),
 			proto.EncodedKey("ab"),
 			proto.EncodedKey("abc"),
-			proto.EncodedKey(KeyMax),
+			proto.EncodedKey(proto.KeyMax),
 		}
 
 		insertKeys(keys, engine, t)
 
 		// Scan all keys (non-inclusive of final key).
-		verifyScan(proto.EncodedKey(KeyMin), proto.EncodedKey(KeyMax), 10, keys[0:5], engine, t)
+		verifyScan(proto.EncodedKey(proto.KeyMin), proto.EncodedKey(proto.KeyMax), 10, keys[0:5], engine, t)
 
 		// Delete a range of keys
 		numDeleted, err := ClearRange(engine, proto.EncodedKey("aa"), proto.EncodedKey("abc"))
@@ -559,7 +559,7 @@ func TestEngineDeleteRange(t *testing.T) {
 			t.Errorf("Expected to delete 3 entries; was %v", numDeleted)
 		}
 		// Verify what's left
-		verifyScan(proto.EncodedKey(KeyMin), proto.EncodedKey(KeyMax), 10,
+		verifyScan(proto.EncodedKey(proto.KeyMin), proto.EncodedKey(proto.KeyMax), 10,
 			[]proto.EncodedKey{proto.EncodedKey("a"), proto.EncodedKey("abc")}, engine, t)
 	}, t)
 }
@@ -599,8 +599,8 @@ func TestSnapshot(t *testing.T) {
 				valSnapshot, val1)
 		}
 
-		keyvals, _ := Scan(engine, key, proto.EncodedKey(KeyMax), 0)
-		keyvalsSnapshot, error := Scan(snap, key, proto.EncodedKey(KeyMax), 0)
+		keyvals, _ := Scan(engine, key, proto.EncodedKey(proto.KeyMax), 0)
+		keyvalsSnapshot, error := Scan(snap, key, proto.EncodedKey(proto.KeyMax), 0)
 		if error != nil {
 			t.Fatalf("error : %s", error)
 		}
@@ -656,8 +656,8 @@ func TestSnapshotMethods(t *testing.T) {
 		}
 
 		// Verify Scan.
-		keyvals, _ := Scan(engine, proto.EncodedKey(KeyMin), proto.EncodedKey(KeyMax), 0)
-		keyvalsSnapshot, err := Scan(snap, proto.EncodedKey(KeyMin), proto.EncodedKey(KeyMax), 0)
+		keyvals, _ := Scan(engine, proto.EncodedKey(proto.KeyMin), proto.EncodedKey(proto.KeyMax), 0)
+		keyvalsSnapshot, err := Scan(snap, proto.EncodedKey(proto.KeyMin), proto.EncodedKey(proto.KeyMax), 0)
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -668,7 +668,7 @@ func TestSnapshotMethods(t *testing.T) {
 
 		// Verify Iterate.
 		index := 0
-		if err := snap.Iterate(proto.EncodedKey(KeyMin), proto.EncodedKey(KeyMax), func(kv proto.RawKeyValue) (bool, error) {
+		if err := snap.Iterate(proto.EncodedKey(proto.KeyMin), proto.EncodedKey(proto.KeyMax), func(kv proto.RawKeyValue) (bool, error) {
 			if !bytes.Equal(kv.Key, keys[index]) || !bytes.Equal(kv.Value, vals[index]) {
 				t.Errorf("%d: key/value not equal between expected and snapshot: %s/%s, %s/%s",
 					index, keys[index], vals[index], kv.Key, kv.Value)
@@ -705,11 +705,11 @@ func TestSnapshotMethods(t *testing.T) {
 		}
 
 		// Verify ApproximateSize.
-		approx, err := engine.ApproximateSize(proto.EncodedKey(KeyMin), proto.EncodedKey(KeyMax))
+		approx, err := engine.ApproximateSize(proto.EncodedKey(proto.KeyMin), proto.EncodedKey(proto.KeyMax))
 		if err != nil {
 			t.Fatal(err)
 		}
-		approxSnapshot, err := snap.ApproximateSize(proto.EncodedKey(KeyMin), proto.EncodedKey(KeyMax))
+		approxSnapshot, err := snap.ApproximateSize(proto.EncodedKey(proto.KeyMin), proto.EncodedKey(proto.KeyMax))
 		if err != nil {
 			t.Fatal(err)
 		}

--- a/storage/engine/mvcc.go
+++ b/storage/engine/mvcc.go
@@ -49,7 +49,7 @@ var (
 // the specified key should be tracked at all, and if so, whether the
 // key is system-local.
 func updateStatsForKey(ms *proto.MVCCStats, key proto.Key) (bool, bool) {
-	return ms != nil, key.Less(keys.KeyLocalMax)
+	return ms != nil, key.Less(keys.LocalMax)
 }
 
 // updateStatsForInline updates stat counters for an inline value.
@@ -1234,19 +1234,19 @@ var illegalSplitKeyRanges = []struct {
 }{
 	{
 		start: MVCCEncodeKey(proto.KeyMin),
-		end:   MVCCEncodeKey(keys.KeyMeta2Prefix),
+		end:   MVCCEncodeKey(keys.Meta2Prefix),
 	},
 	{
-		start: MVCCEncodeKey(keys.KeyConfigAccountingPrefix),
-		end:   MVCCEncodeKey(keys.KeyConfigAccountingPrefix.PrefixEnd()),
+		start: MVCCEncodeKey(keys.ConfigAccountingPrefix),
+		end:   MVCCEncodeKey(keys.ConfigAccountingPrefix.PrefixEnd()),
 	},
 	{
-		start: MVCCEncodeKey(keys.KeyConfigPermissionPrefix),
-		end:   MVCCEncodeKey(keys.KeyConfigPermissionPrefix.PrefixEnd()),
+		start: MVCCEncodeKey(keys.ConfigPermissionPrefix),
+		end:   MVCCEncodeKey(keys.ConfigPermissionPrefix.PrefixEnd()),
 	},
 	{
-		start: MVCCEncodeKey(keys.KeyConfigZonePrefix),
-		end:   MVCCEncodeKey(keys.KeyConfigZonePrefix.PrefixEnd()),
+		start: MVCCEncodeKey(keys.ConfigZonePrefix),
+		end:   MVCCEncodeKey(keys.ConfigZonePrefix.PrefixEnd()),
 	},
 }
 
@@ -1269,8 +1269,8 @@ func isValidEncodedSplitKey(key proto.EncodedKey) bool {
 // The split key will never be chosen from the key ranges listed in
 // illegalSplitKeyRanges.
 func MVCCFindSplitKey(engine Engine, raftID int64, key, endKey proto.Key) (proto.Key, error) {
-	if key.Less(keys.KeyLocalMax) {
-		key = keys.KeyLocalMax
+	if key.Less(keys.LocalMax) {
+		key = keys.LocalMax
 	}
 	encStartKey := MVCCEncodeKey(key)
 	encEndKey := MVCCEncodeKey(endKey)

--- a/storage/engine/mvcc.go
+++ b/storage/engine/mvcc.go
@@ -24,6 +24,7 @@ import (
 	"math"
 	"sync"
 
+	"github.com/cockroachdb/cockroach/keys"
 	"github.com/cockroachdb/cockroach/proto"
 	"github.com/cockroachdb/cockroach/util"
 	"github.com/cockroachdb/cockroach/util/encoding"
@@ -38,11 +39,17 @@ const (
 	mvccVersionTimestampSize int64 = 12
 )
 
+var (
+	// MVCCKeyMax is a maximum mvcc-encoded key value which sorts after
+	// all other keys.
+	MVCCKeyMax = MVCCEncodeKey(proto.KeyMax)
+)
+
 // updateStatsForKey returns whether or not the bytes and counts for
 // the specified key should be tracked at all, and if so, whether the
 // key is system-local.
 func updateStatsForKey(ms *proto.MVCCStats, key proto.Key) (bool, bool) {
-	return ms != nil, key.Less(KeyLocalMax)
+	return ms != nil, key.Less(keys.KeyLocalMax)
 }
 
 // updateStatsForInline updates stat counters for an inline value.
@@ -294,13 +301,13 @@ func MVCCComputeGCBytesAge(bytes, ageSeconds int64) int64 {
 // MVCCGetRangeStats reads stat counters for the specified range and
 // sets the values in the supplied MVCCStats struct.
 func MVCCGetRangeStats(engine Engine, raftID int64, ms *proto.MVCCStats) error {
-	_, err := MVCCGetProto(engine, RangeStatsKey(raftID), proto.ZeroTimestamp, true, nil, ms)
+	_, err := MVCCGetProto(engine, keys.RangeStatsKey(raftID), proto.ZeroTimestamp, true, nil, ms)
 	return err
 }
 
 // MVCCSetRangeStats sets stat counters for specified range.
 func MVCCSetRangeStats(engine Engine, raftID int64, ms *proto.MVCCStats) error {
-	return MVCCPutProto(engine, nil, RangeStatsKey(raftID), proto.ZeroTimestamp, nil, ms)
+	return MVCCPutProto(engine, nil, keys.RangeStatsKey(raftID), proto.ZeroTimestamp, nil, ms)
 }
 
 // MVCCGetProto fetches the value at the specified key and unmarshals
@@ -1226,20 +1233,20 @@ var illegalSplitKeyRanges = []struct {
 	start, end proto.EncodedKey
 }{
 	{
-		start: MVCCEncodeKey(KeyMin),
-		end:   MVCCEncodeKey(KeyMeta2Prefix),
+		start: MVCCEncodeKey(proto.KeyMin),
+		end:   MVCCEncodeKey(keys.KeyMeta2Prefix),
 	},
 	{
-		start: MVCCEncodeKey(KeyConfigAccountingPrefix),
-		end:   MVCCEncodeKey(KeyConfigAccountingPrefix.PrefixEnd()),
+		start: MVCCEncodeKey(keys.KeyConfigAccountingPrefix),
+		end:   MVCCEncodeKey(keys.KeyConfigAccountingPrefix.PrefixEnd()),
 	},
 	{
-		start: MVCCEncodeKey(KeyConfigPermissionPrefix),
-		end:   MVCCEncodeKey(KeyConfigPermissionPrefix.PrefixEnd()),
+		start: MVCCEncodeKey(keys.KeyConfigPermissionPrefix),
+		end:   MVCCEncodeKey(keys.KeyConfigPermissionPrefix.PrefixEnd()),
 	},
 	{
-		start: MVCCEncodeKey(KeyConfigZonePrefix),
-		end:   MVCCEncodeKey(KeyConfigZonePrefix.PrefixEnd()),
+		start: MVCCEncodeKey(keys.KeyConfigZonePrefix),
+		end:   MVCCEncodeKey(keys.KeyConfigZonePrefix.PrefixEnd()),
 	},
 }
 
@@ -1262,8 +1269,8 @@ func isValidEncodedSplitKey(key proto.EncodedKey) bool {
 // The split key will never be chosen from the key ranges listed in
 // illegalSplitKeyRanges.
 func MVCCFindSplitKey(engine Engine, raftID int64, key, endKey proto.Key) (proto.Key, error) {
-	if key.Less(KeyLocalMax) {
-		key = KeyLocalMax
+	if key.Less(keys.KeyLocalMax) {
+		key = keys.KeyLocalMax
 	}
 	encStartKey := MVCCEncodeKey(key)
 	encEndKey := MVCCEncodeKey(endKey)

--- a/storage/gc_queue_test.go
+++ b/storage/gc_queue_test.go
@@ -24,6 +24,7 @@ import (
 
 	"github.com/cockroachdb/cockroach/client"
 	"github.com/cockroachdb/cockroach/gossip"
+	"github.com/cockroachdb/cockroach/keys"
 	"github.com/cockroachdb/cockroach/proto"
 	"github.com/cockroachdb/cockroach/storage/engine"
 	"github.com/cockroachdb/cockroach/util/leaktest"
@@ -49,7 +50,7 @@ func TestGCQueueShouldQueue(t *testing.T) {
 	defer tc.Stop()
 
 	// Put an empty GC metadata; all that's read from it is last scan nanos.
-	key := engine.RangeGCMetadataKey(tc.rng.Desc().RaftID)
+	key := keys.RangeGCMetadataKey(tc.rng.Desc().RaftID)
 	if err := engine.MVCCPutProto(tc.rng.rm.Engine(), nil, key, proto.ZeroTimestamp, nil, &proto.GCMetadata{}); err != nil {
 		t.Fatal(err)
 	}
@@ -230,7 +231,7 @@ func TestGCQueueProcess(t *testing.T) {
 		{key8, ts2},
 	}
 	// Read data directly from engine to avoid intent errors from MVCC.
-	kvs, err := engine.Scan(tc.store.Engine(), engine.MVCCEncodeKey(key1), engine.MVCCEncodeKey(engine.KeyMax), 0)
+	kvs, err := engine.Scan(tc.store.Engine(), engine.MVCCEncodeKey(key1), engine.MVCCEncodeKey(proto.KeyMax), 0)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -310,7 +311,7 @@ func TestGCQueueLookupGCPolicy(t *testing.T) {
 		// hierarchical parent's GC policy; in this case, zoneConfig1.
 	}
 	configs := []*PrefixConfig{
-		{engine.KeyMin, nil, &zoneConfig1},
+		{proto.KeyMin, nil, &zoneConfig1},
 		{proto.Key("/db1"), nil, &zoneConfig2},
 	}
 	pcc, err := NewPrefixConfigMap(configs)

--- a/storage/id_alloc_test.go
+++ b/storage/id_alloc_test.go
@@ -41,7 +41,7 @@ func TestIDAllocator(t *testing.T) {
 	store, _, stopper := createTestStore(t)
 	defer stopper.Stop()
 	allocd := make(chan int, 100)
-	idAlloc, err := NewIDAllocator(keys.KeyRaftIDGenerator, store.ctx.DB,
+	idAlloc, err := NewIDAllocator(keys.RaftIDGenerator, store.ctx.DB,
 		2, 10, stopper)
 	if err != nil {
 		t.Errorf("failed to create IDAllocator: %v", err)
@@ -90,14 +90,14 @@ func TestIDAllocatorNegativeValue(t *testing.T) {
 	defer stopper.Stop()
 
 	// Increment our key to a negative value.
-	newValue, err := engine.MVCCIncrement(store.Engine(), nil, keys.KeyRaftIDGenerator, store.ctx.Clock.Now(), nil, -1024)
+	newValue, err := engine.MVCCIncrement(store.Engine(), nil, keys.RaftIDGenerator, store.ctx.Clock.Now(), nil, -1024)
 	if err != nil {
 		t.Fatal(err)
 	}
 	if newValue != -1024 {
 		t.Errorf("expected new value to be -1024; got %d", newValue)
 	}
-	idAlloc, err := NewIDAllocator(keys.KeyRaftIDGenerator, store.ctx.DB, 2, 10, stopper)
+	idAlloc, err := NewIDAllocator(keys.RaftIDGenerator, store.ctx.DB, 2, 10, stopper)
 	if err != nil {
 		t.Errorf("failed to create IDAllocator: %v", err)
 	}
@@ -137,7 +137,7 @@ func TestAllocateErrorAndRecovery(t *testing.T) {
 	allocd := make(chan int, 10)
 
 	// Firstly create a valid IDAllocator to get some ID.
-	idAlloc, err := NewIDAllocator(keys.KeyRaftIDGenerator, store.ctx.DB, 2, 10, stopper)
+	idAlloc, err := NewIDAllocator(keys.RaftIDGenerator, store.ctx.DB, 2, 10, stopper)
 	if err != nil {
 		t.Errorf("failed to create IDAllocator: %v", err)
 	}
@@ -183,7 +183,7 @@ func TestAllocateErrorAndRecovery(t *testing.T) {
 	}
 
 	// Make the IDAllocator valid again.
-	idAlloc.idKey.Store(keys.KeyRaftIDGenerator)
+	idAlloc.idKey.Store(keys.RaftIDGenerator)
 	// Check if the blocked allocations return expected ID.
 	ids := make([]int, 10)
 	for i := 0; i < 10; i++ {
@@ -211,7 +211,7 @@ func TestAllocateErrorAndRecovery(t *testing.T) {
 func TestAllocateWithStopper(t *testing.T) {
 	defer leaktest.AfterTest(t)
 	store, _, stopper := createTestStore(t)
-	idAlloc, err := NewIDAllocator(keys.KeyRaftIDGenerator, store.ctx.DB, 2, 10, stopper)
+	idAlloc, err := NewIDAllocator(keys.RaftIDGenerator, store.ctx.DB, 2, 10, stopper)
 	if err != nil {
 		log.Fatal(err)
 	}

--- a/storage/id_alloc_test.go
+++ b/storage/id_alloc_test.go
@@ -24,6 +24,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/cockroachdb/cockroach/keys"
 	"github.com/cockroachdb/cockroach/proto"
 	"github.com/cockroachdb/cockroach/storage/engine"
 	"github.com/cockroachdb/cockroach/util/leaktest"
@@ -40,7 +41,7 @@ func TestIDAllocator(t *testing.T) {
 	store, _, stopper := createTestStore(t)
 	defer stopper.Stop()
 	allocd := make(chan int, 100)
-	idAlloc, err := NewIDAllocator(engine.KeyRaftIDGenerator, store.ctx.DB,
+	idAlloc, err := NewIDAllocator(keys.KeyRaftIDGenerator, store.ctx.DB,
 		2, 10, stopper)
 	if err != nil {
 		t.Errorf("failed to create IDAllocator: %v", err)
@@ -89,14 +90,14 @@ func TestIDAllocatorNegativeValue(t *testing.T) {
 	defer stopper.Stop()
 
 	// Increment our key to a negative value.
-	newValue, err := engine.MVCCIncrement(store.Engine(), nil, engine.KeyRaftIDGenerator, store.ctx.Clock.Now(), nil, -1024)
+	newValue, err := engine.MVCCIncrement(store.Engine(), nil, keys.KeyRaftIDGenerator, store.ctx.Clock.Now(), nil, -1024)
 	if err != nil {
 		t.Fatal(err)
 	}
 	if newValue != -1024 {
 		t.Errorf("expected new value to be -1024; got %d", newValue)
 	}
-	idAlloc, err := NewIDAllocator(engine.KeyRaftIDGenerator, store.ctx.DB, 2, 10, stopper)
+	idAlloc, err := NewIDAllocator(keys.KeyRaftIDGenerator, store.ctx.DB, 2, 10, stopper)
 	if err != nil {
 		t.Errorf("failed to create IDAllocator: %v", err)
 	}
@@ -136,7 +137,7 @@ func TestAllocateErrorAndRecovery(t *testing.T) {
 	allocd := make(chan int, 10)
 
 	// Firstly create a valid IDAllocator to get some ID.
-	idAlloc, err := NewIDAllocator(engine.KeyRaftIDGenerator, store.ctx.DB, 2, 10, stopper)
+	idAlloc, err := NewIDAllocator(keys.KeyRaftIDGenerator, store.ctx.DB, 2, 10, stopper)
 	if err != nil {
 		t.Errorf("failed to create IDAllocator: %v", err)
 	}
@@ -182,7 +183,7 @@ func TestAllocateErrorAndRecovery(t *testing.T) {
 	}
 
 	// Make the IDAllocator valid again.
-	idAlloc.idKey.Store(engine.KeyRaftIDGenerator)
+	idAlloc.idKey.Store(keys.KeyRaftIDGenerator)
 	// Check if the blocked allocations return expected ID.
 	ids := make([]int, 10)
 	for i := 0; i < 10; i++ {
@@ -210,7 +211,7 @@ func TestAllocateErrorAndRecovery(t *testing.T) {
 func TestAllocateWithStopper(t *testing.T) {
 	defer leaktest.AfterTest(t)
 	store, _, stopper := createTestStore(t)
-	idAlloc, err := NewIDAllocator(engine.KeyRaftIDGenerator, store.ctx.DB, 2, 10, stopper)
+	idAlloc, err := NewIDAllocator(keys.KeyRaftIDGenerator, store.ctx.DB, 2, 10, stopper)
 	if err != nil {
 		log.Fatal(err)
 	}

--- a/storage/prefix.go
+++ b/storage/prefix.go
@@ -24,7 +24,6 @@ import (
 	"sort"
 
 	"github.com/cockroachdb/cockroach/proto"
-	"github.com/cockroachdb/cockroach/storage/engine"
 	"github.com/cockroachdb/cockroach/util"
 )
 
@@ -111,7 +110,7 @@ func NewPrefixConfigMap(configs []*PrefixConfig) (PrefixConfigMap, error) {
 	p := PrefixConfigMap(configs)
 	sort.Sort(p)
 
-	if len(p) == 0 || !p[0].Prefix.Equal(engine.KeyMin) {
+	if len(p) == 0 || !p[0].Prefix.Equal(proto.KeyMin) {
 		return nil, util.Errorf("no default prefix specified")
 	}
 

--- a/storage/range.go
+++ b/storage/range.go
@@ -117,9 +117,9 @@ type configDescriptor struct {
 // configDescriptors is an array containing the accounting, permissions
 // and zone configuration descriptors.
 var configDescriptors = [...]*configDescriptor{
-	{keys.KeyConfigAccountingPrefix, gossip.KeyConfigAccounting, proto.AcctConfig{}},
-	{keys.KeyConfigPermissionPrefix, gossip.KeyConfigPermission, proto.PermConfig{}},
-	{keys.KeyConfigZonePrefix, gossip.KeyConfigZone, proto.ZoneConfig{}},
+	{keys.ConfigAccountingPrefix, gossip.KeyConfigAccounting, proto.AcctConfig{}},
+	{keys.ConfigPermissionPrefix, gossip.KeyConfigPermission, proto.PermConfig{}},
+	{keys.ConfigZonePrefix, gossip.KeyConfigZone, proto.ZoneConfig{}},
 }
 
 // tsCacheMethods specifies the set of methods which affect the
@@ -868,7 +868,7 @@ func (r *Range) applyRaftCommand(index uint64, originNodeID proto.RaftNodeID, ar
 		// Maybe update gossip configs on a put.
 		switch args.(type) {
 		case *proto.PutRequest, *proto.DeleteRequest, *proto.DeleteRangeRequest:
-			if header.Key.Less(keys.KeySystemMax) {
+			if header.Key.Less(keys.SystemMax) {
 				// We hold the lock already.
 				r.maybeGossipConfigsLocked(func(configPrefix proto.Key) bool {
 					return bytes.HasPrefix(header.Key, configPrefix)

--- a/storage/range.go
+++ b/storage/range.go
@@ -34,6 +34,7 @@ import (
 
 	"github.com/cockroachdb/cockroach/client"
 	"github.com/cockroachdb/cockroach/gossip"
+	"github.com/cockroachdb/cockroach/keys"
 	"github.com/cockroachdb/cockroach/multiraft"
 	"github.com/cockroachdb/cockroach/proto"
 	"github.com/cockroachdb/cockroach/storage/engine"
@@ -116,9 +117,9 @@ type configDescriptor struct {
 // configDescriptors is an array containing the accounting, permissions
 // and zone configuration descriptors.
 var configDescriptors = [...]*configDescriptor{
-	{engine.KeyConfigAccountingPrefix, gossip.KeyConfigAccounting, proto.AcctConfig{}},
-	{engine.KeyConfigPermissionPrefix, gossip.KeyConfigPermission, proto.PermConfig{}},
-	{engine.KeyConfigZonePrefix, gossip.KeyConfigZone, proto.ZoneConfig{}},
+	{keys.KeyConfigAccountingPrefix, gossip.KeyConfigAccounting, proto.AcctConfig{}},
+	{keys.KeyConfigPermissionPrefix, gossip.KeyConfigPermission, proto.PermConfig{}},
+	{keys.KeyConfigZonePrefix, gossip.KeyConfigZone, proto.ZoneConfig{}},
 }
 
 // tsCacheMethods specifies the set of methods which affect the
@@ -287,12 +288,12 @@ func (r *Range) SetMaxBytes(maxBytes int64) {
 
 // IsFirstRange returns true if this is the first range.
 func (r *Range) IsFirstRange() bool {
-	return bytes.Equal(r.Desc().StartKey, engine.KeyMin)
+	return bytes.Equal(r.Desc().StartKey, proto.KeyMin)
 }
 
 func loadLeaderLease(eng engine.Engine, raftID int64) (*proto.Lease, error) {
 	lease := &proto.Lease{}
-	if _, err := engine.MVCCGetProto(eng, engine.RaftLeaderLeaseKey(raftID), proto.ZeroTimestamp, true, nil, lease); err != nil {
+	if _, err := engine.MVCCGetProto(eng, keys.RaftLeaderLeaseKey(raftID), proto.ZeroTimestamp, true, nil, lease); err != nil {
 		return nil, err
 	}
 	return lease, nil
@@ -454,18 +455,18 @@ func (r *Range) GetMVCCStats() proto.MVCCStats {
 
 // ContainsKey returns whether this range contains the specified key.
 func (r *Range) ContainsKey(key proto.Key) bool {
-	return r.Desc().ContainsKey(engine.KeyAddress(key))
+	return r.Desc().ContainsKey(keys.KeyAddress(key))
 }
 
 // ContainsKeyRange returns whether this range contains the specified
 // key range from start to end.
 func (r *Range) ContainsKeyRange(start, end proto.Key) bool {
-	return r.Desc().ContainsKeyRange(engine.KeyAddress(start), engine.KeyAddress(end))
+	return r.Desc().ContainsKeyRange(keys.KeyAddress(start), keys.KeyAddress(end))
 }
 
 // GetGCMetadata reads the latest GC metadata for this range.
 func (r *Range) GetGCMetadata() (*proto.GCMetadata, error) {
-	key := engine.RangeGCMetadataKey(r.Desc().RaftID)
+	key := keys.RangeGCMetadataKey(r.Desc().RaftID)
 	gcMeta := &proto.GCMetadata{}
 	_, err := engine.MVCCGetProto(r.rm.Engine(), key, proto.ZeroTimestamp, true, nil, gcMeta)
 	if err != nil {
@@ -477,7 +478,7 @@ func (r *Range) GetGCMetadata() (*proto.GCMetadata, error) {
 // GetLastVerificationTimestamp reads the timestamp at which the range's
 // data was last verified.
 func (r *Range) GetLastVerificationTimestamp() (proto.Timestamp, error) {
-	key := engine.RangeLastVerificationTimestampKey(r.Desc().RaftID)
+	key := keys.RangeLastVerificationTimestampKey(r.Desc().RaftID)
 	timestamp := proto.Timestamp{}
 	_, err := engine.MVCCGetProto(r.rm.Engine(), key, proto.ZeroTimestamp, true, nil, &timestamp)
 	if err != nil {
@@ -489,7 +490,7 @@ func (r *Range) GetLastVerificationTimestamp() (proto.Timestamp, error) {
 // SetLastVerificationTimestamp writes the timestamp at which the range's
 // data was last verified.
 func (r *Range) SetLastVerificationTimestamp(timestamp proto.Timestamp) error {
-	key := engine.RangeLastVerificationTimestampKey(r.Desc().RaftID)
+	key := keys.RangeLastVerificationTimestampKey(r.Desc().RaftID)
 	return engine.MVCCPutProto(r.rm.Engine(), nil, key, proto.ZeroTimestamp, nil, &timestamp)
 }
 
@@ -867,7 +868,7 @@ func (r *Range) applyRaftCommand(index uint64, originNodeID proto.RaftNodeID, ar
 		// Maybe update gossip configs on a put.
 		switch args.(type) {
 		case *proto.PutRequest, *proto.DeleteRequest, *proto.DeleteRangeRequest:
-			if header.Key.Less(engine.KeySystemMax) {
+			if header.Key.Less(keys.KeySystemMax) {
 				// We hold the lock already.
 				r.maybeGossipConfigsLocked(func(configPrefix proto.Key) bool {
 					return bytes.HasPrefix(header.Key, configPrefix)

--- a/storage/range_data_iter.go
+++ b/storage/range_data_iter.go
@@ -18,6 +18,7 @@
 package storage
 
 import (
+	"github.com/cockroachdb/cockroach/keys"
 	"github.com/cockroachdb/cockroach/proto"
 	"github.com/cockroachdb/cockroach/storage/engine"
 	"github.com/cockroachdb/cockroach/util/encoding"
@@ -47,18 +48,18 @@ func newRangeDataIterator(d *proto.RangeDescriptor, e engine.Engine) *rangeDataI
 	// space. We need the original StartKey to find the range metadata, but the
 	// actual data starts at KeyLocalMax.
 	dataStartKey := d.StartKey
-	if d.StartKey.Equal(engine.KeyMin) {
-		dataStartKey = engine.KeyLocalMax
+	if d.StartKey.Equal(proto.KeyMin) {
+		dataStartKey = keys.KeyLocalMax
 	}
 	ri := &rangeDataIterator{
 		ranges: []keyRange{
 			{
-				start: engine.MVCCEncodeKey(engine.MakeKey(engine.KeyLocalRangeIDPrefix, encoding.EncodeUvarint(nil, uint64(d.RaftID)))),
-				end:   engine.MVCCEncodeKey(engine.MakeKey(engine.KeyLocalRangeIDPrefix, encoding.EncodeUvarint(nil, uint64(d.RaftID+1)))),
+				start: engine.MVCCEncodeKey(keys.MakeKey(keys.KeyLocalRangeIDPrefix, encoding.EncodeUvarint(nil, uint64(d.RaftID)))),
+				end:   engine.MVCCEncodeKey(keys.MakeKey(keys.KeyLocalRangeIDPrefix, encoding.EncodeUvarint(nil, uint64(d.RaftID+1)))),
 			},
 			{
-				start: engine.MVCCEncodeKey(engine.MakeKey(engine.KeyLocalRangeKeyPrefix, encoding.EncodeBytes(nil, d.StartKey))),
-				end:   engine.MVCCEncodeKey(engine.MakeKey(engine.KeyLocalRangeKeyPrefix, encoding.EncodeBytes(nil, d.EndKey))),
+				start: engine.MVCCEncodeKey(keys.MakeKey(keys.KeyLocalRangeKeyPrefix, encoding.EncodeBytes(nil, d.StartKey))),
+				end:   engine.MVCCEncodeKey(keys.MakeKey(keys.KeyLocalRangeKeyPrefix, encoding.EncodeBytes(nil, d.EndKey))),
 			},
 			{
 				start: engine.MVCCEncodeKey(dataStartKey),

--- a/storage/range_data_iter.go
+++ b/storage/range_data_iter.go
@@ -46,20 +46,20 @@ type rangeDataIterator struct {
 func newRangeDataIterator(d *proto.RangeDescriptor, e engine.Engine) *rangeDataIterator {
 	// The first range in the keyspace starts at KeyMin, which includes the node-local
 	// space. We need the original StartKey to find the range metadata, but the
-	// actual data starts at KeyLocalMax.
+	// actual data starts at LocalMax.
 	dataStartKey := d.StartKey
 	if d.StartKey.Equal(proto.KeyMin) {
-		dataStartKey = keys.KeyLocalMax
+		dataStartKey = keys.LocalMax
 	}
 	ri := &rangeDataIterator{
 		ranges: []keyRange{
 			{
-				start: engine.MVCCEncodeKey(keys.MakeKey(keys.KeyLocalRangeIDPrefix, encoding.EncodeUvarint(nil, uint64(d.RaftID)))),
-				end:   engine.MVCCEncodeKey(keys.MakeKey(keys.KeyLocalRangeIDPrefix, encoding.EncodeUvarint(nil, uint64(d.RaftID+1)))),
+				start: engine.MVCCEncodeKey(keys.MakeKey(keys.LocalRangeIDPrefix, encoding.EncodeUvarint(nil, uint64(d.RaftID)))),
+				end:   engine.MVCCEncodeKey(keys.MakeKey(keys.LocalRangeIDPrefix, encoding.EncodeUvarint(nil, uint64(d.RaftID+1)))),
 			},
 			{
-				start: engine.MVCCEncodeKey(keys.MakeKey(keys.KeyLocalRangeKeyPrefix, encoding.EncodeBytes(nil, d.StartKey))),
-				end:   engine.MVCCEncodeKey(keys.MakeKey(keys.KeyLocalRangeKeyPrefix, encoding.EncodeBytes(nil, d.EndKey))),
+				start: engine.MVCCEncodeKey(keys.MakeKey(keys.LocalRangePrefix, encoding.EncodeBytes(nil, d.StartKey))),
+				end:   engine.MVCCEncodeKey(keys.MakeKey(keys.LocalRangePrefix, encoding.EncodeBytes(nil, d.EndKey))),
 			},
 			{
 				start: engine.MVCCEncodeKey(dataStartKey),

--- a/storage/range_data_iter_test.go
+++ b/storage/range_data_iter_test.go
@@ -210,10 +210,10 @@ func disabledTestRangeDataIterator(t *testing.T) {
 		i = 0
 		for ; iter.Valid(); iter.Next() {
 			k1, ts1, _ := engine.MVCCDecodeKey(iter.Key())
-			if bytes.HasPrefix(k1, keys.KeyConfigAccountingPrefix) ||
-				bytes.HasPrefix(k1, keys.KeyConfigPermissionPrefix) ||
-				bytes.HasPrefix(k1, keys.KeyConfigZonePrefix) ||
-				bytes.HasPrefix(k1, keys.KeyStatusPrefix) {
+			if bytes.HasPrefix(k1, keys.ConfigAccountingPrefix) ||
+				bytes.HasPrefix(k1, keys.ConfigPermissionPrefix) ||
+				bytes.HasPrefix(k1, keys.ConfigZonePrefix) ||
+				bytes.HasPrefix(k1, keys.StatusPrefix) {
 				// Some data is written into the system prefix by Store.BootstrapRange,
 				// but it is not in our expected key list so skip it.
 				// TODO(bdarnell): validate this data instead of skipping it.

--- a/storage/range_gc_queue.go
+++ b/storage/range_gc_queue.go
@@ -21,8 +21,8 @@ import (
 	"time"
 
 	"github.com/cockroachdb/cockroach/client"
+	"github.com/cockroachdb/cockroach/keys"
 	"github.com/cockroachdb/cockroach/proto"
-	"github.com/cockroachdb/cockroach/storage/engine"
 	"github.com/cockroachdb/cockroach/util"
 	"github.com/cockroachdb/cockroach/util/log"
 )
@@ -85,7 +85,7 @@ func (q *rangeGCQueue) process(now proto.Timestamp, rng *Range) error {
 	err := q.db.Run(client.Call{
 		Args: &proto.InternalRangeLookupRequest{
 			RequestHeader: proto.RequestHeader{
-				Key: engine.RangeMetaKey(rng.Desc().StartKey),
+				Key: keys.RangeMetaKey(rng.Desc().StartKey),
 			},
 			MaxRanges: 1,
 		},

--- a/storage/range_test.go
+++ b/storage/range_test.go
@@ -202,13 +202,13 @@ func (tc *testContext) Stop() {
 
 // initConfigs creates default configuration entries.
 func initConfigs(e engine.Engine, t testing.TB) {
-	if err := engine.MVCCPutProto(e, nil, keys.KeyConfigAccountingPrefix, proto.MinTimestamp, nil, &testDefaultAcctConfig); err != nil {
+	if err := engine.MVCCPutProto(e, nil, keys.ConfigAccountingPrefix, proto.MinTimestamp, nil, &testDefaultAcctConfig); err != nil {
 		t.Fatal(err)
 	}
-	if err := engine.MVCCPutProto(e, nil, keys.KeyConfigPermissionPrefix, proto.MinTimestamp, nil, &testDefaultPermConfig); err != nil {
+	if err := engine.MVCCPutProto(e, nil, keys.ConfigPermissionPrefix, proto.MinTimestamp, nil, &testDefaultPermConfig); err != nil {
 		t.Fatal(err)
 	}
-	if err := engine.MVCCPutProto(e, nil, keys.KeyConfigZonePrefix, proto.MinTimestamp, nil, &testDefaultZoneConfig); err != nil {
+	if err := engine.MVCCPutProto(e, nil, keys.ConfigZonePrefix, proto.MinTimestamp, nil, &testDefaultZoneConfig); err != nil {
 		t.Fatal(err)
 	}
 }
@@ -461,7 +461,7 @@ func TestRangeGossipConfigsOnLease(t *testing.T) {
 		Read:  []string{"spencer", "foo", "bar", "baz"},
 		Write: []string{"spencer"},
 	}
-	key := keys.MakeKey(keys.KeyConfigPermissionPrefix, proto.Key("/db1"))
+	key := keys.MakeKey(keys.ConfigPermissionPrefix, proto.Key("/db1"))
 	if err := engine.MVCCPutProto(tc.engine, nil, key, proto.MinTimestamp, nil, &db1Perm); err != nil {
 		t.Fatal(err)
 	}
@@ -621,7 +621,7 @@ func TestRangeGossipConfigWithMultipleKeyPrefixes(t *testing.T) {
 		Read:  []string{"spencer", "foo", "bar", "baz"},
 		Write: []string{"spencer"},
 	}
-	key := keys.MakeKey(keys.KeyConfigPermissionPrefix, proto.Key("/db1"))
+	key := keys.MakeKey(keys.ConfigPermissionPrefix, proto.Key("/db1"))
 	data, err := gogoproto.Marshal(db1Perm)
 	if err != nil {
 		t.Fatal(err)
@@ -664,7 +664,7 @@ func TestRangeGossipConfigUpdates(t *testing.T) {
 		Read:  []string{"spencer"},
 		Write: []string{"spencer"},
 	}
-	key := keys.MakeKey(keys.KeyConfigPermissionPrefix, proto.Key("/db1"))
+	key := keys.MakeKey(keys.ConfigPermissionPrefix, proto.Key("/db1"))
 	data, err := gogoproto.Marshal(db1Perm)
 	if err != nil {
 		t.Fatal(err)

--- a/storage/range_tree.go
+++ b/storage/range_tree.go
@@ -54,7 +54,7 @@ func SetupRangeTree(batch engine.Engine, ms *proto.MVCCStats, timestamp proto.Ti
 		Key:   startKey,
 		Black: true,
 	}
-	if err := engine.MVCCPutProto(batch, ms, keys.KeyRangeTreeRoot, timestamp, nil, tree); err != nil {
+	if err := engine.MVCCPutProto(batch, ms, keys.RangeTreeRoot, timestamp, nil, tree); err != nil {
 		return err
 	}
 	if err := engine.MVCCPutProto(batch, ms, keys.RangeTreeNodeKey(startKey), timestamp, nil, node); err != nil {
@@ -66,7 +66,7 @@ func SetupRangeTree(batch engine.Engine, ms *proto.MVCCStats, timestamp proto.Ti
 // flush writes all dirty nodes and the tree to the transaction.
 func (tc *treeContext) flush() error {
 	if tc.dirty {
-		tc.txn.Prepare(client.PutProto(keys.KeyRangeTreeRoot, tc.tree))
+		tc.txn.Prepare(client.PutProto(keys.RangeTreeRoot, tc.tree))
 	}
 	for _, cachedNode := range tc.nodes {
 		if cachedNode.dirty {
@@ -80,7 +80,7 @@ func (tc *treeContext) flush() error {
 // GetRangeTree fetches the RangeTree proto and sets up the range tree context.
 func getRangeTree(txn *client.Txn) (*treeContext, error) {
 	tree := &proto.RangeTree{}
-	if err := txn.Run(client.GetProto(keys.KeyRangeTreeRoot, tree)); err != nil {
+	if err := txn.Run(client.GetProto(keys.RangeTreeRoot, tree)); err != nil {
 		return nil, err
 	}
 	return &treeContext{

--- a/storage/range_tree_test.go
+++ b/storage/range_tree_test.go
@@ -22,7 +22,6 @@ import (
 	"testing"
 
 	"github.com/cockroachdb/cockroach/proto"
-	"github.com/cockroachdb/cockroach/storage/engine"
 	"github.com/cockroachdb/cockroach/util/leaktest"
 )
 
@@ -91,7 +90,7 @@ func TestFlip(t *testing.T) {
 	for i, test := range testCases {
 		node := &proto.RangeTreeNode{
 			Key:       keyNode,
-			ParentKey: engine.KeyMin,
+			ParentKey: proto.KeyMin,
 			Black:     test.nodeBlack,
 			LeftKey:   &keyLeft,
 			RightKey:  &keyRight,
@@ -180,28 +179,28 @@ func TestRotateRight(t *testing.T) {
 		{
 			node: &proto.RangeTreeNode{
 				Key:       keyNode,
-				ParentKey: engine.KeyMin,
+				ParentKey: proto.KeyMin,
 				Black:     true,
 				LeftKey:   &keyLeft,
 				RightKey:  &keyRight,
 			},
 			left: &proto.RangeTreeNode{
 				Key:       keyLeft,
-				ParentKey: engine.KeyMin,
+				ParentKey: proto.KeyMin,
 				Black:     false,
 				LeftKey:   &keyLeftLeft,
 				RightKey:  &keyLeftRight,
 			},
 			expectedNode: &proto.RangeTreeNode{
 				Key:       keyLeft,
-				ParentKey: engine.KeyMin,
+				ParentKey: proto.KeyMin,
 				Black:     true,
 				LeftKey:   &keyLeftLeft,
 				RightKey:  &keyNode,
 			},
 			expectedLeft: &proto.RangeTreeNode{
 				Key:       keyNode,
-				ParentKey: engine.KeyMin,
+				ParentKey: proto.KeyMin,
 				Black:     false,
 				LeftKey:   &keyLeftRight,
 				RightKey:  &keyRight,
@@ -212,28 +211,28 @@ func TestRotateRight(t *testing.T) {
 		{
 			node: &proto.RangeTreeNode{
 				Key:       keyNode,
-				ParentKey: engine.KeyMin,
+				ParentKey: proto.KeyMin,
 				Black:     false,
 				LeftKey:   &keyLeft,
 				RightKey:  &keyRight,
 			},
 			left: &proto.RangeTreeNode{
 				Key:       keyLeft,
-				ParentKey: engine.KeyMin,
+				ParentKey: proto.KeyMin,
 				Black:     false,
 				LeftKey:   &keyLeftLeft,
 				RightKey:  &keyLeftRight,
 			},
 			expectedNode: &proto.RangeTreeNode{
 				Key:       keyLeft,
-				ParentKey: engine.KeyMin,
+				ParentKey: proto.KeyMin,
 				Black:     false,
 				LeftKey:   &keyLeftLeft,
 				RightKey:  &keyNode,
 			},
 			expectedLeft: &proto.RangeTreeNode{
 				Key:       keyNode,
-				ParentKey: engine.KeyMin,
+				ParentKey: proto.KeyMin,
 				Black:     false,
 				LeftKey:   &keyLeftRight,
 				RightKey:  &keyRight,
@@ -244,14 +243,14 @@ func TestRotateRight(t *testing.T) {
 		{
 			node: &proto.RangeTreeNode{
 				Key:       keyNode,
-				ParentKey: engine.KeyMin,
+				ParentKey: proto.KeyMin,
 				Black:     false,
 				LeftKey:   &keyLeft,
 				RightKey:  &keyRight,
 			},
 			left: &proto.RangeTreeNode{
 				Key:       keyLeft,
-				ParentKey: engine.KeyMin,
+				ParentKey: proto.KeyMin,
 				Black:     true,
 				LeftKey:   &keyLeftLeft,
 				RightKey:  &keyLeftRight,
@@ -262,24 +261,24 @@ func TestRotateRight(t *testing.T) {
 		{
 			node: &proto.RangeTreeNode{
 				Key:       keyNode,
-				ParentKey: engine.KeyMin,
+				ParentKey: proto.KeyMin,
 				Black:     true,
 				LeftKey:   &keyLeft,
 			},
 			left: &proto.RangeTreeNode{
 				Key:       keyLeft,
-				ParentKey: engine.KeyMin,
+				ParentKey: proto.KeyMin,
 				Black:     false,
 			},
 			expectedNode: &proto.RangeTreeNode{
 				Key:       keyLeft,
-				ParentKey: engine.KeyMin,
+				ParentKey: proto.KeyMin,
 				Black:     true,
 				RightKey:  &keyNode,
 			},
 			expectedLeft: &proto.RangeTreeNode{
 				Key:       keyNode,
-				ParentKey: engine.KeyMin,
+				ParentKey: proto.KeyMin,
 				Black:     false,
 			},
 			expectedErr: false,
@@ -355,28 +354,28 @@ func TestRotateLeft(t *testing.T) {
 		{
 			node: &proto.RangeTreeNode{
 				Key:       keyNode,
-				ParentKey: engine.KeyMin,
+				ParentKey: proto.KeyMin,
 				Black:     true,
 				LeftKey:   &keyLeft,
 				RightKey:  &keyRight,
 			},
 			right: &proto.RangeTreeNode{
 				Key:       keyRight,
-				ParentKey: engine.KeyMin,
+				ParentKey: proto.KeyMin,
 				Black:     false,
 				LeftKey:   &keyRightLeft,
 				RightKey:  &keyRightRight,
 			},
 			expectedNode: &proto.RangeTreeNode{
 				Key:       keyRight,
-				ParentKey: engine.KeyMin,
+				ParentKey: proto.KeyMin,
 				Black:     true,
 				LeftKey:   &keyNode,
 				RightKey:  &keyRightRight,
 			},
 			expectedRight: &proto.RangeTreeNode{
 				Key:       keyNode,
-				ParentKey: engine.KeyMin,
+				ParentKey: proto.KeyMin,
 				Black:     false,
 				LeftKey:   &keyLeft,
 				RightKey:  &keyRightLeft,
@@ -387,28 +386,28 @@ func TestRotateLeft(t *testing.T) {
 		{
 			node: &proto.RangeTreeNode{
 				Key:       keyNode,
-				ParentKey: engine.KeyMin,
+				ParentKey: proto.KeyMin,
 				Black:     false,
 				LeftKey:   &keyLeft,
 				RightKey:  &keyRight,
 			},
 			right: &proto.RangeTreeNode{
 				Key:       keyRight,
-				ParentKey: engine.KeyMin,
+				ParentKey: proto.KeyMin,
 				Black:     false,
 				LeftKey:   &keyRightLeft,
 				RightKey:  &keyRightRight,
 			},
 			expectedNode: &proto.RangeTreeNode{
 				Key:       keyRight,
-				ParentKey: engine.KeyMin,
+				ParentKey: proto.KeyMin,
 				Black:     false,
 				LeftKey:   &keyNode,
 				RightKey:  &keyRightRight,
 			},
 			expectedRight: &proto.RangeTreeNode{
 				Key:       keyNode,
-				ParentKey: engine.KeyMin,
+				ParentKey: proto.KeyMin,
 				Black:     false,
 				LeftKey:   &keyLeft,
 				RightKey:  &keyRightLeft,
@@ -419,14 +418,14 @@ func TestRotateLeft(t *testing.T) {
 		{
 			node: &proto.RangeTreeNode{
 				Key:       keyNode,
-				ParentKey: engine.KeyMin,
+				ParentKey: proto.KeyMin,
 				Black:     true,
 				LeftKey:   &keyLeft,
 				RightKey:  &keyRight,
 			},
 			right: &proto.RangeTreeNode{
 				Key:       keyRight,
-				ParentKey: engine.KeyMin,
+				ParentKey: proto.KeyMin,
 				Black:     true,
 				LeftKey:   &keyRightLeft,
 				RightKey:  &keyRightRight,
@@ -437,24 +436,24 @@ func TestRotateLeft(t *testing.T) {
 		{
 			node: &proto.RangeTreeNode{
 				Key:       keyNode,
-				ParentKey: engine.KeyMin,
+				ParentKey: proto.KeyMin,
 				Black:     true,
 				RightKey:  &keyRight,
 			},
 			right: &proto.RangeTreeNode{
 				Key:       keyRight,
-				ParentKey: engine.KeyMin,
+				ParentKey: proto.KeyMin,
 				Black:     false,
 			},
 			expectedNode: &proto.RangeTreeNode{
 				Key:       keyRight,
-				ParentKey: engine.KeyMin,
+				ParentKey: proto.KeyMin,
 				Black:     true,
 				LeftKey:   &keyNode,
 			},
 			expectedRight: &proto.RangeTreeNode{
 				Key:       keyNode,
-				ParentKey: engine.KeyMin,
+				ParentKey: proto.KeyMin,
 				Black:     false,
 			},
 			expectedErr: false,

--- a/storage/response_cache.go
+++ b/storage/response_cache.go
@@ -207,18 +207,18 @@ func (rc *ResponseCache) decodeResponseCacheKey(encKey proto.EncodedKey) (proto.
 	if isValue {
 		return ret, util.Errorf("key %s is not a raw MVCC value", encKey)
 	}
-	if !bytes.HasPrefix(key, keys.KeyLocalRangeIDPrefix) {
-		return ret, util.Errorf("key %s does not have %s prefix", key, keys.KeyLocalRangeIDPrefix)
+	if !bytes.HasPrefix(key, keys.LocalRangeIDPrefix) {
+		return ret, util.Errorf("key %s does not have %s prefix", key, keys.LocalRangeIDPrefix)
 	}
 	// Cut the prefix and the Raft ID.
-	b := key[len(keys.KeyLocalRangeIDPrefix):]
+	b := key[len(keys.LocalRangeIDPrefix):]
 	b, _ = encoding.DecodeUvarint(b)
-	if !bytes.HasPrefix(b, keys.KeyLocalResponseCacheSuffix) {
+	if !bytes.HasPrefix(b, keys.LocalResponseCacheSuffix) {
 		return ret, util.Errorf("key %s does not contain the response cache suffix %s",
-			key, keys.KeyLocalResponseCacheSuffix)
+			key, keys.LocalResponseCacheSuffix)
 	}
 	// Cut the response cache suffix.
-	b = b[len(keys.KeyLocalResponseCacheSuffix):]
+	b = b[len(keys.LocalResponseCacheSuffix):]
 	// Now, decode the command ID.
 	b, wt := encoding.DecodeUvarint(b)
 	b, rd := encoding.DecodeUint64(b)

--- a/storage/response_cache.go
+++ b/storage/response_cache.go
@@ -21,6 +21,7 @@ import (
 	"bytes"
 	"sync"
 
+	"github.com/cockroachdb/cockroach/keys"
 	"github.com/cockroachdb/cockroach/proto"
 	"github.com/cockroachdb/cockroach/storage/engine"
 	"github.com/cockroachdb/cockroach/util"
@@ -68,7 +69,7 @@ func NewResponseCache(raftID int64, engine engine.Engine) *ResponseCache {
 // ClearData removes all items stored in the persistent cache. It does not alter
 // the inflight map.
 func (rc *ResponseCache) ClearData() error {
-	p := engine.ResponseCacheKey(rc.raftID, nil) // prefix for all response cache entries with this raft ID
+	p := keys.ResponseCacheKey(rc.raftID, nil) // prefix for all response cache entries with this raft ID
 	end := p.PrefixEnd()
 	_, err := engine.ClearRange(rc.engine, engine.MVCCEncodeKey(p), engine.MVCCEncodeKey(end))
 	return err
@@ -88,7 +89,7 @@ func (rc *ResponseCache) GetResponse(cmdID proto.ClientCmdID, reply proto.Respon
 
 	// If the response is in the cache or we experienced an error, return.
 	rwResp := proto.ReadWriteCmdResponse{}
-	key := engine.ResponseCacheKey(rc.raftID, &cmdID)
+	key := keys.ResponseCacheKey(rc.raftID, &cmdID)
 	if ok, err := engine.MVCCGetProto(rc.engine, key, proto.ZeroTimestamp, true, nil, &rwResp); ok || err != nil {
 		if err == nil && rwResp.GetValue() != nil {
 			gogoproto.Merge(reply.(gogoproto.Message), rwResp.GetValue().(gogoproto.Message))
@@ -108,7 +109,7 @@ func (rc *ResponseCache) CopyInto(e engine.Engine, destRaftID int64) error {
 	rc.Lock()
 	defer rc.Unlock()
 
-	prefix := engine.ResponseCacheKey(rc.raftID, nil) // response cache prefix
+	prefix := keys.ResponseCacheKey(rc.raftID, nil) // response cache prefix
 	start := engine.MVCCEncodeKey(prefix)
 	end := engine.MVCCEncodeKey(prefix.PrefixEnd())
 
@@ -120,7 +121,7 @@ func (rc *ResponseCache) CopyInto(e engine.Engine, destRaftID int64) error {
 			return false, util.Errorf("could not decode a response cache key %s: %s",
 				proto.Key(kv.Key), err)
 		}
-		key := engine.ResponseCacheKey(destRaftID, &cmdID)
+		key := keys.ResponseCacheKey(destRaftID, &cmdID)
 		encKey := engine.MVCCEncodeKey(key)
 		// Decode the value, update the checksum and re-encode.
 		meta := &proto.MVCCMetadata{}
@@ -141,7 +142,7 @@ func (rc *ResponseCache) CopyInto(e engine.Engine, destRaftID int64) error {
 // error. The copy is done directly using the engine instead of interpreting
 // values through MVCC for efficiency.
 func (rc *ResponseCache) CopyFrom(e engine.Engine, originRaftID int64) error {
-	prefix := engine.ResponseCacheKey(originRaftID, nil) // response cache prefix
+	prefix := keys.ResponseCacheKey(originRaftID, nil) // response cache prefix
 	start := engine.MVCCEncodeKey(prefix)
 	end := engine.MVCCEncodeKey(prefix.PrefixEnd())
 
@@ -153,7 +154,7 @@ func (rc *ResponseCache) CopyFrom(e engine.Engine, originRaftID int64) error {
 			return false, util.Errorf("could not decode a response cache key %s: %s",
 				proto.Key(kv.Key), err)
 		}
-		key := engine.ResponseCacheKey(rc.raftID, &cmdID)
+		key := keys.ResponseCacheKey(rc.raftID, &cmdID)
 		encKey := engine.MVCCEncodeKey(key)
 		// Decode the value, update the checksum and re-encode.
 		meta := &proto.MVCCMetadata{}
@@ -177,7 +178,7 @@ func (rc *ResponseCache) PutResponse(cmdID proto.ClientCmdID, reply proto.Respon
 	// Write the response value to the engine.
 	var err error
 	if rc.shouldCacheResponse(reply) {
-		key := engine.ResponseCacheKey(rc.raftID, &cmdID)
+		key := keys.ResponseCacheKey(rc.raftID, &cmdID)
 		rwResp := &proto.ReadWriteCmdResponse{}
 		if !rwResp.SetValue(reply) {
 			log.Fatalf("response %T not supported by response cache", reply)
@@ -206,18 +207,18 @@ func (rc *ResponseCache) decodeResponseCacheKey(encKey proto.EncodedKey) (proto.
 	if isValue {
 		return ret, util.Errorf("key %s is not a raw MVCC value", encKey)
 	}
-	if !bytes.HasPrefix(key, engine.KeyLocalRangeIDPrefix) {
-		return ret, util.Errorf("key %s does not have %s prefix", key, engine.KeyLocalRangeIDPrefix)
+	if !bytes.HasPrefix(key, keys.KeyLocalRangeIDPrefix) {
+		return ret, util.Errorf("key %s does not have %s prefix", key, keys.KeyLocalRangeIDPrefix)
 	}
 	// Cut the prefix and the Raft ID.
-	b := key[len(engine.KeyLocalRangeIDPrefix):]
+	b := key[len(keys.KeyLocalRangeIDPrefix):]
 	b, _ = encoding.DecodeUvarint(b)
-	if !bytes.HasPrefix(b, engine.KeyLocalResponseCacheSuffix) {
+	if !bytes.HasPrefix(b, keys.KeyLocalResponseCacheSuffix) {
 		return ret, util.Errorf("key %s does not contain the response cache suffix %s",
-			key, engine.KeyLocalResponseCacheSuffix)
+			key, keys.KeyLocalResponseCacheSuffix)
 	}
 	// Cut the response cache suffix.
-	b = b[len(engine.KeyLocalResponseCacheSuffix):]
+	b = b[len(keys.KeyLocalResponseCacheSuffix):]
 	// Now, decode the command ID.
 	b, wt := encoding.DecodeUvarint(b)
 	b, rd := encoding.DecodeUint64(b)

--- a/storage/split_queue_test.go
+++ b/storage/split_queue_test.go
@@ -24,7 +24,6 @@ import (
 
 	"github.com/cockroachdb/cockroach/gossip"
 	"github.com/cockroachdb/cockroach/proto"
-	"github.com/cockroachdb/cockroach/storage/engine"
 	"github.com/cockroachdb/cockroach/util/leaktest"
 )
 
@@ -39,7 +38,7 @@ func TestSplitQueueShouldQueue(t *testing.T) {
 
 	// Set accounting and zone configs.
 	acctMap, err := NewPrefixConfigMap([]*PrefixConfig{
-		{engine.KeyMin, nil, 1},
+		{proto.KeyMin, nil, 1},
 		{proto.Key("/dbA"), nil, 2},
 	})
 	if err != nil {
@@ -50,7 +49,7 @@ func TestSplitQueueShouldQueue(t *testing.T) {
 	}
 
 	zoneMap, err := NewPrefixConfigMap([]*PrefixConfig{
-		{engine.KeyMin, nil, &proto.ZoneConfig{RangeMaxBytes: 64 << 20}},
+		{proto.KeyMin, nil, &proto.ZoneConfig{RangeMaxBytes: 64 << 20}},
 		{proto.Key("/dbB"), nil, &proto.ZoneConfig{RangeMaxBytes: 64 << 20}},
 	})
 	if err != nil {

--- a/storage/store_test.go
+++ b/storage/store_test.go
@@ -495,7 +495,7 @@ func TestStoreVerifyKeys(t *testing.T) {
 	}
 	// Try a put to meta2 key which would otherwise exceed maximum key
 	// length, but is accepted because of the meta prefix.
-	meta2KeyMax := keys.MakeKey(keys.KeyMeta2Prefix, proto.KeyMax)
+	meta2KeyMax := keys.MakeKey(keys.Meta2Prefix, proto.KeyMax)
 	pArgs, pReply := putArgs(meta2KeyMax, []byte("value"), 1, store.StoreID())
 	if err := store.ExecuteCmd(context.Background(), client.Call{Args: pArgs, Reply: pReply}); err != nil {
 		t.Fatalf("unexpected error on put to meta2 value: %s", err)
@@ -733,7 +733,7 @@ func TestStoreSetRangesMaxBytes(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	key := keys.MakeKey(keys.KeyConfigZonePrefix, proto.Key("a"))
+	key := keys.MakeKey(keys.ConfigZonePrefix, proto.Key("a"))
 	pArgs, pReply := putArgs(key, data, 1, store.StoreID())
 	pArgs.Timestamp = store.ctx.Clock.Now()
 	if err := store.ExecuteCmd(context.Background(), client.Call{Args: pArgs, Reply: pReply}); err != nil {

--- a/storage/verify_queue_test.go
+++ b/storage/verify_queue_test.go
@@ -21,6 +21,7 @@ import (
 	"math"
 	"testing"
 
+	"github.com/cockroachdb/cockroach/keys"
 	"github.com/cockroachdb/cockroach/proto"
 	"github.com/cockroachdb/cockroach/storage/engine"
 	"github.com/cockroachdb/cockroach/util/leaktest"
@@ -36,7 +37,7 @@ func TestVerifyQueueShouldQueue(t *testing.T) {
 	defer tc.Stop()
 
 	// Put empty verification timestamp
-	key := engine.RangeLastVerificationTimestampKey(tc.rng.Desc().RaftID)
+	key := keys.RangeLastVerificationTimestampKey(tc.rng.Desc().RaftID)
 	if err := engine.MVCCPutProto(tc.rng.rm.Engine(), nil, key, proto.ZeroTimestamp, nil, &proto.Timestamp{}); err != nil {
 		t.Fatal(err)
 	}

--- a/structured/db.go
+++ b/structured/db.go
@@ -23,8 +23,8 @@ import (
 	"encoding/gob"
 
 	"github.com/cockroachdb/cockroach/client"
+	"github.com/cockroachdb/cockroach/keys"
 	"github.com/cockroachdb/cockroach/proto"
-	"github.com/cockroachdb/cockroach/storage/engine"
 	"github.com/cockroachdb/cockroach/util"
 )
 
@@ -55,7 +55,7 @@ func (db *structuredDB) PutSchema(s *Schema) error {
 	if err := s.Validate(); err != nil {
 		return err
 	}
-	k := engine.MakeKey(engine.KeySchemaPrefix, proto.Key(s.Key))
+	k := keys.MakeKey(keys.KeySchemaPrefix, proto.Key(s.Key))
 	// TODO(pmattis): This is an inappropriate use of gob. Replace with
 	// something else.
 	var buf bytes.Buffer
@@ -70,7 +70,7 @@ func (db *structuredDB) DeleteSchema(s *Schema) error {
 	return db.kvDB.Run(client.Call{
 		Args: &proto.DeleteRequest{
 			RequestHeader: proto.RequestHeader{
-				Key: engine.MakeKey(engine.KeySchemaPrefix, proto.Key(s.Key)),
+				Key: keys.MakeKey(keys.KeySchemaPrefix, proto.Key(s.Key)),
 			},
 		},
 		Reply: &proto.DeleteResponse{}})
@@ -81,7 +81,7 @@ func (db *structuredDB) DeleteSchema(s *Schema) error {
 // with the given key cannot be found.
 func (db *structuredDB) GetSchema(key string) (*Schema, error) {
 	s := &Schema{}
-	k := engine.MakeKey(engine.KeySchemaPrefix, proto.Key(key))
+	k := keys.MakeKey(keys.KeySchemaPrefix, proto.Key(key))
 	call := client.Get(k)
 	if err := db.kvDB.Run(call); err != nil {
 		return nil, err

--- a/structured/db.go
+++ b/structured/db.go
@@ -55,7 +55,7 @@ func (db *structuredDB) PutSchema(s *Schema) error {
 	if err := s.Validate(); err != nil {
 		return err
 	}
-	k := keys.MakeKey(keys.KeySchemaPrefix, proto.Key(s.Key))
+	k := keys.MakeKey(keys.SchemaPrefix, proto.Key(s.Key))
 	// TODO(pmattis): This is an inappropriate use of gob. Replace with
 	// something else.
 	var buf bytes.Buffer
@@ -70,7 +70,7 @@ func (db *structuredDB) DeleteSchema(s *Schema) error {
 	return db.kvDB.Run(client.Call{
 		Args: &proto.DeleteRequest{
 			RequestHeader: proto.RequestHeader{
-				Key: keys.MakeKey(keys.KeySchemaPrefix, proto.Key(s.Key)),
+				Key: keys.MakeKey(keys.SchemaPrefix, proto.Key(s.Key)),
 			},
 		},
 		Reply: &proto.DeleteResponse{}})
@@ -81,7 +81,7 @@ func (db *structuredDB) DeleteSchema(s *Schema) error {
 // with the given key cannot be found.
 func (db *structuredDB) GetSchema(key string) (*Schema, error) {
 	s := &Schema{}
-	k := keys.MakeKey(keys.KeySchemaPrefix, proto.Key(key))
+	k := keys.MakeKey(keys.SchemaPrefix, proto.Key(key))
 	call := client.Get(k)
 	if err := db.kvDB.Run(call); err != nil {
 		return nil, err

--- a/ts/keys.go
+++ b/ts/keys.go
@@ -21,8 +21,8 @@ import (
 	"bytes"
 	"fmt"
 
+	"github.com/cockroachdb/cockroach/keys"
 	"github.com/cockroachdb/cockroach/proto"
-	"github.com/cockroachdb/cockroach/storage/engine"
 	"github.com/cockroachdb/cockroach/util/encoding"
 )
 
@@ -58,7 +58,7 @@ import (
 // 		slot := (timestamp / keyDuration) // integer division
 var (
 	// keyDataPrefix is the key prefix for time series data keys.
-	keyDataPrefix = proto.MakeKey(engine.KeySystemPrefix, proto.Key("tsd"))
+	keyDataPrefix = proto.MakeKey(keys.KeySystemPrefix, proto.Key("tsd"))
 )
 
 // MakeDataKey creates a time series data key for the given series name, source,

--- a/ts/keys.go
+++ b/ts/keys.go
@@ -58,7 +58,7 @@ import (
 // 		slot := (timestamp / keyDuration) // integer division
 var (
 	// keyDataPrefix is the key prefix for time series data keys.
-	keyDataPrefix = proto.MakeKey(keys.KeySystemPrefix, proto.Key("tsd"))
+	keyDataPrefix = proto.MakeKey(keys.SystemPrefix, proto.Key("tsd"))
 )
 
 // MakeDataKey creates a time series data key for the given series name, source,


### PR DESCRIPTION
This removes a large number (19) of dependencies on gossip and
storage/engine. Proto is a more appropriate base package for these
definitions.
