### PR TITLE
as an interim to eliminate the heartbeat response of each raft group to stabilize the leadership

### DIFF
--- a/multiraft/multiraft.go
+++ b/multiraft/multiraft.go
@@ -232,7 +232,7 @@ func (s *state) fanoutHeartbeat(req *RaftMessageRequest) {
 		}
 		cnt++
 	}
-	if cnt != 0 {
+	if cnt > 0 {
 		s.sendMessage(noGroup,
 			raftpb.Message{
 				From: uint64(s.nodeID),
@@ -1047,13 +1047,13 @@ func (s *state) handleWriteResponse(response *writeResponse, readyGroups map[uin
 		for _, msg := range ready.Messages {
 			switch msg.Type {
 			case raftpb.MsgHeartbeat:
-				if log.V(7) {
+				if log.V(8) {
 					log.Infof("node %v dropped individual heartbeat to node %v",
 						s.nodeID, msg.To)
 				}
 				continue
 			case raftpb.MsgHeartbeatResp:
-				if log.V(7) {
+				if log.V(8) {
 					log.Infof("node %v dropped individual heartbeat response to node %v",
 						s.nodeID, msg.To)
 				}


### PR DESCRIPTION
  In current implementation, follower will fanout heartbeat request to each raft group and each raft group will respond heartbeat response to leader, then leader will fanout each heartbeat response to each group. 

  Assuming there are 30 raft groups in a 3 nodes cluster with one store on each node, and each node will host the leadership of 1/3 of total raft groups which are 10 raft groups. 

  One Node NodeA send 1 heartbeat request to NodeB and NodeC, NodeB and NodeC each will respond with 10 heartbeat responses, so NodeA will receive 20 heartbeat response, then NodeA will fanout these heartbeat response to 10 groups, it will generate 20*10=200 message. It will make the leader busy in processing those redundant message so it may not have time to send the coalesced heartbeat, and the follower may issue a new vote to make the leadership change.

  One interim mitigation is eliminate the heartbeat response of each raft group, but only one heartbeat response will be send back for each node. so the heartbeat response which leader will process will be 2*10 = 20.
  Please comments.
