### PR TITLE
Use V(1) for client logging.

### DIFF
--- a/client/context.go
+++ b/client/context.go
@@ -43,6 +43,7 @@ var (
 		MaxBackoff:  5 * time.Second,
 		Constant:    2,
 		MaxAttempts: 0, // retry indefinitely
+		UseV1Info:   true,
 	}
 	DefaultClock = systemClock{}
 )

--- a/client/http_sender.go
+++ b/client/http_sender.go
@@ -68,6 +68,7 @@ var HTTPRetryOptions = retry.Options{
 	MaxBackoff:  5 * time.Second,
 	Constant:    2,
 	MaxAttempts: 0, // retry indefinitely
+	UseV1Info:   true,
 }
 
 // HTTPSender is an implementation of KVSender which exposes the

--- a/client/kv.go
+++ b/client/kv.go
@@ -109,7 +109,9 @@ func (kv *KV) Run(calls ...Call) (err error) {
 		kv.Sender.Send(context.TODO(), c)
 		err = c.Reply.Header().GoError()
 		if err != nil {
-			log.Infof("failed %s: %s", c.Method(), err)
+			if log.V(1) {
+				log.Infof("failed %s: %s", c.Method(), err)
+			}
 		} else if c.Post != nil {
 			err = c.Post()
 		}


### PR DESCRIPTION
This avoids a ton of verbosity when there are transaction retries.
