### PR TITLE
enforce batch header fields

### DIFF
--- a/kv/txn_coord_sender_test.go
+++ b/kv/txn_coord_sender_test.go
@@ -560,3 +560,50 @@ func TestTxnCoordSenderTxnUpdatedOnError(t *testing.T) {
 		}
 	}
 }
+
+// TestTxnCoordSenderBatchTransaction tests that it is not possible to send
+// one-off transactional calls within a batch (the batch must contain the
+// transaction for all contained calls instead).
+func TestTxnCoordSenderBatchTransaction(t *testing.T) {
+	stopper := util.NewStopper()
+	defer stopper.Stop()
+	clock := hlc.NewClock(hlc.UnixNano)
+	var called bool
+	ts := NewTxnCoordSender(newTestSender(func(call client.Call) {
+		called = true
+		return
+	}), clock, false, stopper)
+
+	testCases := []struct{ batch, arg, ok bool }{
+		{false, false, true},
+		{true, false, true},
+		{true, true, false},
+		{false, true, false},
+	}
+
+	txn1 := &proto.Transaction{ID: []byte("txn1")}
+	txn2 := &proto.Transaction{ID: []byte("txn2")}
+
+	for i, tc := range testCases {
+		bArgs := &proto.InternalBatchRequest{}
+		bReply := &proto.InternalBatchResponse{}
+
+		pushArgs := &proto.InternalPushTxnRequest{}
+		if tc.arg {
+			pushArgs.RequestHeader = proto.RequestHeader{
+				Txn: txn1,
+			}
+		}
+		bArgs.Add(pushArgs)
+		if tc.batch {
+			bArgs.Txn = txn2
+		}
+		called = false
+		ts.Send(context.Background(), client.Call{Args: bArgs, Reply: bReply})
+		if !tc.ok && bReply.GoError() == nil {
+			t.Fatalf("%d: expected error", i)
+		} else if tc.ok != called {
+			t.Fatalf("%d: wanted call: %t, got call: %t", i, tc.ok, called)
+		}
+	}
+}

--- a/proto/api.pb.go
+++ b/proto/api.pb.go
@@ -809,7 +809,9 @@ func (m *ResponseUnion) GetEndTransaction() *EndTransactionResponse {
 // range-locality), as a single update.
 //
 // The RequestHeader should contain the Key of the first request
-// in the batch.
+// in the batch. It also contains the transaction itself; individual
+// calls must not have transactions specified. The same applies to
+// the User and UserPriority fields.
 type BatchRequest struct {
 	RequestHeader    `protobuf:"bytes,1,opt,name=header,embedded=header" json:"header"`
 	Requests         []RequestUnion `protobuf:"bytes,2,rep,name=requests" json:"requests"`

--- a/proto/api.proto
+++ b/proto/api.proto
@@ -319,7 +319,9 @@ message ResponseUnion {
 // range-locality), as a single update.
 //
 // The RequestHeader should contain the Key of the first request
-// in the batch.
+// in the batch. It also contains the transaction itself; individual
+// calls must not have transactions specified. The same applies to
+// the User and UserPriority fields.
 message BatchRequest {
   optional RequestHeader header = 1 [(gogoproto.nullable) = false, (gogoproto.embed) = true];
   repeated RequestUnion requests = 2 [(gogoproto.nullable) = false];

--- a/proto/data.go
+++ b/proto/data.go
@@ -417,7 +417,7 @@ func (t *Transaction) Equal(s *Transaction) bool {
 	if (t == nil && s != nil) || (t != nil && s == nil) {
 		return false
 	}
-	return bytes.Equal(t.ID, s.ID)
+	return TxnIDEqual(t.ID, s.ID)
 }
 
 // MakePriority generates a random priority value, biased by the

--- a/proto/data.go
+++ b/proto/data.go
@@ -408,6 +408,18 @@ func NewTransaction(name string, baseKey Key, userPriority int32,
 	}
 }
 
+// Equal tests two transactions for equality. They are equal if they are
+// either simultaneously nil or their IDs match.
+func (t *Transaction) Equal(s *Transaction) bool {
+	if t == nil && s == nil {
+		return true
+	}
+	if (t == nil && s != nil) || (t != nil && s == nil) {
+		return false
+	}
+	return bytes.Equal(t.ID, s.ID)
+}
+
 // MakePriority generates a random priority value, biased by the
 // specified userPriority. If userPriority=100, the resulting
 // priority is 100x more likely to be probabilistically greater

--- a/proto/data_test.go
+++ b/proto/data_test.go
@@ -349,6 +349,22 @@ func TestValueChecksumWithInteger(t *testing.T) {
 	}
 }
 
+func TestTxnEqual(t *testing.T) {
+	tc := []struct {
+		txn1, txn2 *Transaction
+		eq         bool
+	}{
+		{nil, nil, true},
+		{&Transaction{}, nil, false},
+		{&Transaction{ID: []byte("A")}, &Transaction{ID: []byte("B")}, false},
+	}
+	for i, c := range tc {
+		if c.txn1.Equal(c.txn2) != c.txn2.Equal(c.txn1) || c.txn1.Equal(c.txn2) != c.eq {
+			t.Errorf("%d: wanted %t", i, c.eq)
+		}
+	}
+}
+
 func TestTxnIDEqual(t *testing.T) {
 	txn1, txn2 := util.NewUUID4(), util.NewUUID4()
 	txn1Copy := append([]byte(nil), txn1...)

--- a/storage/store.go
+++ b/storage/store.go
@@ -1232,16 +1232,28 @@ func (s *Store) resolveWriteIntentError(ctx context.Context, wiErr *proto.WriteI
 	}
 
 	// Attempt to push the transaction(s) which created the conflicting intent(s).
-	bArgs := &proto.InternalBatchRequest{}
+	bArgs := &proto.InternalBatchRequest{
+		RequestHeader: proto.RequestHeader{
+			Txn:          args.Header().Txn,
+			User:         args.Header().User,
+			UserPriority: args.Header().UserPriority,
+		},
+	}
 	bReply := &proto.InternalBatchResponse{}
 	for _, intent := range wiErr.Intents {
 		pushArgs := &proto.InternalPushTxnRequest{
 			RequestHeader: proto.RequestHeader{
-				Timestamp:    args.Header().Timestamp,
-				Key:          intent.Txn.Key,
+				Timestamp: args.Header().Timestamp,
+				Key:       intent.Txn.Key,
+				// TODO(tschottdorf):
+				// The following fields should not be supplied here, but store
+				// tests (for example TestStoreResolveWriteIntent) which do not
+				// go through TxnCoordSender rely on them being specified on
+				// the individual calls (and TxnCoordSender is in charge of
+				// filling them in here later).
+				Txn:          args.Header().Txn,
 				User:         args.Header().User,
 				UserPriority: args.Header().UserPriority,
-				Txn:          args.Header().Txn,
 			},
 			PusheeTxn:   intent.Txn,
 			PushType:    pushType,


### PR DESCRIPTION
- User, UserPrio and Txn cause errors when sent through the TxnCoordSender
  in an individual call which is part of a Batch with non-identical header
- Had to leave them in the individual calls in store.resolveWriteIntent because of
  tests in store_test.go which omit the TxnCoordSender; added a TODO there.
  Batch handling and/or those tests need some additional cleanup beyond this PR.
