### PR TITLE
Add Node Event Feed

### DIFF
--- a/server/feed.go
+++ b/server/feed.go
@@ -1,0 +1,92 @@
+// Copyright 2015 The Cockroach Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+// implied. See the License for the specific language governing
+// permissions and limitations under the License. See the AUTHORS file
+// for names of contributors.
+//
+// Author: Matt Tracy (matt@cockroachlabs.com)
+
+package server
+
+import (
+	"github.com/cockroachdb/cockroach/proto"
+	"github.com/cockroachdb/cockroach/util"
+)
+
+// CallSuccessEvent is published when a call to a node completes without error.
+type CallSuccessEvent struct {
+	NodeID proto.NodeID
+	Method proto.Method
+}
+
+// CallErrorEvent is published when a call to a node returns an error.
+type CallErrorEvent struct {
+	NodeID proto.NodeID
+	Method proto.Method
+}
+
+// NodeEventFeed is a helper structure which publishes node-specific events to a
+// util.Feed. If the target feed is nil, event methods become no-ops.
+type NodeEventFeed struct {
+	id proto.NodeID
+	f  *util.Feed
+}
+
+// NewNodeEventFeed creates a new NodeEventFeed which publishes events for a
+// specific node to the supplied feed.
+func NewNodeEventFeed(id proto.NodeID, feed *util.Feed) NodeEventFeed {
+	return NodeEventFeed{
+		id: id,
+		f:  feed,
+	}
+}
+
+// callComplete is called by a node whenever it completes a request. This will
+// publish an appropriate event to the feed based on the results of the call.
+func (nef NodeEventFeed) callComplete(args proto.Request, reply proto.Response) {
+	if nef.f == nil {
+		return
+	}
+	if err := reply.Header().GoError(); err != nil {
+		nef.f.Publish(&CallErrorEvent{
+			NodeID: nef.id,
+			Method: args.Method(),
+		})
+	} else {
+		nef.f.Publish(&CallSuccessEvent{
+			NodeID: nef.id,
+			Method: args.Method(),
+		})
+	}
+}
+
+// NodeEventListener is an interface that can be implemented by objects which
+// listen for events published by nodes.
+type NodeEventListener interface {
+	OnCallComplete(event *CallSuccessEvent)
+	OnCallError(event *CallErrorEvent)
+}
+
+// ProcessNodeEvents reads node events from the supplied channel and passes them
+// to the correct methods of the supplied NodeEventListener. This method will
+// run until the Subscription's events channel is closed.
+func ProcessNodeEvents(l NodeEventListener, sub *util.Subscription) {
+	for event := range sub.Events() {
+		// TODO(tamird): https://github.com/barakmich/go-nyet/issues/7
+		switch specificEvent := event.(type) {
+		case *CallSuccessEvent:
+			l.OnCallComplete(specificEvent)
+		case *CallErrorEvent:
+			l.OnCallError(specificEvent)
+		}
+	}
+}

--- a/server/feed_test.go
+++ b/server/feed_test.go
@@ -1,0 +1,279 @@
+// Copyright 2015 The Cockroach Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+// implied. See the License for the specific language governing
+// permissions and limitations under the License. See the AUTHORS file
+// for names of contributors.
+//
+// Author: Matt Tracy (matt@cockroachlabs.com)
+
+package server
+
+import (
+	"fmt"
+	"reflect"
+	"testing"
+	"time"
+
+	"github.com/cockroachdb/cockroach/client"
+	"github.com/cockroachdb/cockroach/proto"
+	"github.com/cockroachdb/cockroach/storage"
+	"github.com/cockroachdb/cockroach/testutils"
+	"github.com/cockroachdb/cockroach/util"
+	"github.com/cockroachdb/cockroach/util/leaktest"
+)
+
+// simpleEventConsumer stores every event published to a feed.
+type simpleEventConsumer struct {
+	sub      *util.Subscription
+	received []interface{}
+}
+
+func newSimpleEventConsumer(feed *util.Feed) *simpleEventConsumer {
+	return &simpleEventConsumer{
+		sub: feed.Subscribe(),
+	}
+}
+
+func (sec *simpleEventConsumer) process() {
+	for e := range sec.sub.Events() {
+		sec.received = append(sec.received, e)
+	}
+}
+
+// startConsumerSet starts a NodeEventFeed and a number of associated
+// simple consumers.
+func startConsumerSet(count int) (*util.Stopper, *util.Feed, []*simpleEventConsumer) {
+	stopper := util.NewStopper()
+	feed := &util.Feed{}
+	consumers := make([]*simpleEventConsumer, count)
+	for i := range consumers {
+		consumers[i] = newSimpleEventConsumer(feed)
+		stopper.RunWorker(consumers[i].process)
+	}
+	return stopper, feed, consumers
+}
+
+// waitForStopper stops the supplied util.Stopper and waits up to five seconds
+// for it to complete.
+func waitForStopper(t testing.TB, stopper *util.Stopper) {
+	stopper.Stop()
+	select {
+	case <-stopper.IsStopped():
+	case <-time.After(5 * time.Second):
+		t.Fatalf("Stopper failed to stop after 5 seconds")
+	}
+}
+
+func TestNodeEventFeed(t *testing.T) {
+	defer leaktest.AfterTest(t)
+
+	// A testCase corresponds to a single Store event type. Each case contains a
+	// method which publishes a single event to the given storeEventPublisher,
+	// and an expected result interface which should match the produced
+	// event.
+	testCases := []struct {
+		name      string
+		publishTo func(NodeEventFeed)
+		expected  interface{}
+	}{
+		{
+			name: "Get",
+			publishTo: func(nef NodeEventFeed) {
+				call := client.Get(proto.Key("abc"))
+				nef.callComplete(call.Args, call.Reply)
+			},
+			expected: &CallSuccessEvent{
+				NodeID: proto.NodeID(1),
+				Method: proto.Get,
+			},
+		},
+		{
+			name: "Put",
+			publishTo: func(nef NodeEventFeed) {
+				call := client.Put(proto.Key("abc"), []byte("def"))
+				nef.callComplete(call.Args, call.Reply)
+			},
+			expected: &CallSuccessEvent{
+				NodeID: proto.NodeID(1),
+				Method: proto.Put,
+			},
+		},
+		{
+			name: "Get Error",
+			publishTo: func(nef NodeEventFeed) {
+				call := client.Get(proto.Key("abc"))
+				call.Reply.Header().SetGoError(util.Errorf("error"))
+				nef.callComplete(call.Args, call.Reply)
+			},
+			expected: &CallErrorEvent{
+				NodeID: proto.NodeID(1),
+				Method: proto.Get,
+			},
+		},
+	}
+
+	// Compile expected events into a single slice.
+	expectedEvents := make([]interface{}, len(testCases))
+	for i := range testCases {
+		expectedEvents[i] = testCases[i].expected
+	}
+
+	// assertEventsEqual verifies that the given set of events is equal to the
+	// expectedEvents.
+	verifyEventSlice := func(source string, events []interface{}) {
+		if a, e := len(events), len(expectedEvents); a != e {
+			t.Errorf("%s had wrong number of events %d, expected %d", source, a, e)
+			return
+		}
+
+		for i := range events {
+			if a, e := events[i], expectedEvents[i]; !reflect.DeepEqual(a, e) {
+				t.Errorf("%s had wrong event for case %s: got %v, expected %v", source, testCases[i].name, a, e)
+			}
+		}
+	}
+
+	// Run test cases directly through a feed.
+	stopper, feed, consumers := startConsumerSet(3)
+	nodefeed := NewNodeEventFeed(proto.NodeID(1), feed)
+	for _, tc := range testCases {
+		tc.publishTo(nodefeed)
+	}
+	feed.Close()
+	waitForStopper(t, stopper)
+	for i, c := range consumers {
+		verifyEventSlice(fmt.Sprintf("feed direct consumer %d", i), c.received)
+	}
+}
+
+// nodeEventReader reads the node-related events off of a feed subscription,
+// ignoring other events.
+type nodeEventReader struct {
+	perNodeFeeds map[proto.NodeID][]string
+}
+
+// recordEvent records an events received from the node itself. Each event is
+// recorded as a simple string value; this is less exhaustive than a full struct
+// comparison, but should be easier to correct if future changes slightly modify
+// these values. Events which do not pertain to a Node are ignored.
+func (ner *nodeEventReader) recordEvent(event interface{}) {
+	var nid proto.NodeID
+	eventStr := ""
+	switch event := event.(type) {
+	case *CallSuccessEvent:
+		if event.Method == proto.InternalResolveIntent {
+			// Ignore this best-effort method.
+			break
+		}
+		nid = event.NodeID
+		eventStr = event.Method.String()
+	case *CallErrorEvent:
+		nid = event.NodeID
+		eventStr = "failed " + event.Method.String()
+	}
+	if nid > 0 {
+		ner.perNodeFeeds[nid] = append(ner.perNodeFeeds[nid], eventStr)
+	}
+}
+
+func (ner *nodeEventReader) readEvents(sub *util.Subscription) {
+	ner.perNodeFeeds = make(map[proto.NodeID][]string)
+	for e := range sub.Events() {
+		ner.recordEvent(e)
+	}
+}
+
+// eventFeedString describes the event information that was recorded by
+// nodeEventReader. The formatting is appropriate to paste directly into test as
+// a new expected value.
+func (ner *nodeEventReader) eventFeedString() string {
+	var response string
+	for id, feed := range ner.perNodeFeeds {
+		response += fmt.Sprintf("proto.NodeID(%d): []string{\n", int64(id))
+		for _, evt := range feed {
+			response += fmt.Sprintf("\t\t\"%s\",\n", evt)
+		}
+		response += fmt.Sprintf("},\n")
+	}
+	return response
+}
+
+// TestServerNodeEventFeed verifies that a test server emits Node-specific
+// events.
+func TestServerNodeEventFeed(t *testing.T) {
+	s := StartTestServer(t)
+	defer s.Stop()
+
+	feed := s.node.ctx.EventFeed
+
+	// Start reading events from the feed before starting the stores.
+	readStopper := util.NewStopper()
+	ner := &nodeEventReader{}
+	sub := feed.Subscribe()
+	readStopper.RunWorker(func() {
+		ner.readEvents(sub)
+	})
+
+	sender, err := client.NewHTTPSender(s.ServingAddr(), testutils.NewTestBaseContext())
+	if err != nil {
+		t.Fatal(err)
+	}
+	kv := client.NewKV(nil, sender)
+	kv.User = storage.UserRoot
+
+	// Add some data in a transaction
+	err = kv.RunTransaction(nil, func(txn *client.Txn) error {
+		return txn.Run(
+			client.Put(proto.Key("a"), []byte("asdf")),
+			client.Put(proto.Key("c"), []byte("jkl;")),
+		)
+	})
+	if err != nil {
+		t.Fatalf("error putting data to db: %s", err.Error())
+	}
+
+	// Get some data, discarding the result.
+	err = kv.Run(
+		client.Get(proto.Key("a")),
+	)
+	if err != nil {
+		t.Fatalf("error putting data to db: %s", err.Error())
+	}
+
+	// Scan, which should fail.
+	err = kv.Run(
+		client.Scan(proto.Key("b"), proto.Key("a"), 0),
+	)
+	if err == nil {
+		t.Fatal("expected scan to fail.")
+	}
+
+	// Close feed and wait for reader to receive all events.
+	feed.Close()
+	readStopper.Stop()
+
+	expectedNodeEvents := map[proto.NodeID][]string{
+		proto.NodeID(1): {
+			"InternalRangeLookup",
+			"InternalRangeLookup",
+			"Put",
+			"Put",
+			"EndTransaction",
+			"Get",
+			"failed Scan",
+		},
+	}
+	if a, e := ner.perNodeFeeds, expectedNodeEvents; !reflect.DeepEqual(a, e) {
+		t.Errorf("node feed did not match expected value. Actual values have been printed to compare with above expectation.\n")
+		t.Logf("Event feed information:\n%s", ner.eventFeedString())
+	}
+}


### PR DESCRIPTION
Nodes will now publish node-specific events to the node's existing event feed -
previously, only the stores within a node would publish events.

The only events currently published contain basic information about incoming RPC
operations.
