### PR TITLE
Record Node Event Time Series

### DIFF
--- a/server/node.go
+++ b/server/node.go
@@ -62,7 +62,7 @@ type Node struct {
 	Descriptor proto.NodeDescriptor // Node ID, network/physical topology
 	ctx        storage.StoreContext // Context to use and pass to stores
 	lSender    *kv.LocalSender      // Local KV sender for access to node-local stores
-	feed       NodeEventFeed        // Feed publisher for local events
+	feed       status.NodeEventFeed // Feed publisher for local events
 	status     *status.NodeStatusMonitor
 	startedAt  int64
 	// ScanCount is the number of times through the store scanning loop locked
@@ -244,7 +244,7 @@ func (n *Node) start(rpcServer *rpc.Server, engines []engine.Engine,
 	}
 
 	// Initialize publisher for Node Events.
-	n.feed = NewNodeEventFeed(n.Descriptor.NodeID, n.ctx.EventFeed)
+	n.feed = status.NewNodeEventFeed(n.Descriptor.NodeID, n.ctx.EventFeed)
 
 	n.startedAt = n.ctx.Clock.Now().WallTime
 	n.startStoresScanner(stopper)
@@ -511,7 +511,7 @@ func (n *nodeServer) executeCmd(args proto.Request, reply proto.Response) error 
 	// TODO(tschottdorf) get a hold on the client's ip and add it to the
 	// context before dispatching.
 	n.lSender.Send((*Node)(n).context(), client.Call{Args: args, Reply: reply})
-	n.feed.callComplete(args, reply)
+	n.feed.CallComplete(args, reply)
 	return nil
 }
 

--- a/server/status/feed.go
+++ b/server/status/feed.go
@@ -15,7 +15,7 @@
 //
 // Author: Matt Tracy (matt@cockroachlabs.com)
 
-package server
+package status
 
 import (
 	"github.com/cockroachdb/cockroach/proto"
@@ -50,9 +50,9 @@ func NewNodeEventFeed(id proto.NodeID, feed *util.Feed) NodeEventFeed {
 	}
 }
 
-// callComplete is called by a node whenever it completes a request. This will
+// CallComplete is called by a node whenever it completes a request. This will
 // publish an appropriate event to the feed based on the results of the call.
-func (nef NodeEventFeed) callComplete(args proto.Request, reply proto.Response) {
+func (nef NodeEventFeed) CallComplete(args proto.Request, reply proto.Response) {
 	if nef.f == nil {
 		return
 	}
@@ -72,7 +72,7 @@ func (nef NodeEventFeed) callComplete(args proto.Request, reply proto.Response) 
 // NodeEventListener is an interface that can be implemented by objects which
 // listen for events published by nodes.
 type NodeEventListener interface {
-	OnCallComplete(event *CallSuccessEvent)
+	OnCallSuccess(event *CallSuccessEvent)
 	OnCallError(event *CallErrorEvent)
 }
 
@@ -84,7 +84,7 @@ func ProcessNodeEvents(l NodeEventListener, sub *util.Subscription) {
 		// TODO(tamird): https://github.com/barakmich/go-nyet/issues/7
 		switch specificEvent := event.(type) {
 		case *CallSuccessEvent:
-			l.OnCallComplete(specificEvent)
+			l.OnCallSuccess(specificEvent)
 		case *CallErrorEvent:
 			l.OnCallError(specificEvent)
 		}

--- a/server/status/main_test.go
+++ b/server/status/main_test.go
@@ -1,0 +1,27 @@
+// Copyright 2015 The Cockroach Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+// implied. See the License for the specific language governing
+// permissions and limitations under the License. See the AUTHORS file
+// for names of contributors.
+//
+// Author: Tobias Schottdorf (tobias.schottdorf@gmail.com)
+
+package status_test
+
+import (
+	"github.com/cockroachdb/cockroach/security"
+	"github.com/cockroachdb/cockroach/security/securitytest"
+)
+
+func init() {
+	security.SetReadFileFn(securitytest.Asset)
+}

--- a/server/testserver.go
+++ b/server/testserver.go
@@ -109,6 +109,14 @@ func (ts *TestServer) TsDB() *ts.DB {
 	return nil
 }
 
+// EventFeed returns the event feed that the server uses to publish events.
+func (ts *TestServer) EventFeed() *util.Feed {
+	if ts != nil {
+		return ts.node.ctx.EventFeed
+	}
+	return nil
+}
+
 // Start starts the TestServer by bootstrapping an in-memory store
 // (defaults to maximum of 100M). The server is started, launching the
 // node RPC server and all HTTP endpoints. Use the value of


### PR DESCRIPTION
Begin recording time series data based on the Node's "CallSuccess" and
"CallError" events. Currently only records the total number of calls and errors,
without recording per-event time series.

This commit also moves "feed" and "feed_test" into the status package to avoid
an import cycle.
