### PR TITLE
Add Time Series Rate Aggregator

### DIFF
--- a/proto/timeseries.pb.go
+++ b/proto/timeseries.pb.go
@@ -13,6 +13,50 @@ import math "math"
 var _ = proto1.Marshal
 var _ = math.Inf
 
+// TimeSeriesQueryAggregator describes a set of aggregation functions which are
+// applied to data points before returning them as part of a query.
+//
+// Cockroach does not store data points at full fidelity, instead "downsampling"
+// data points into fixed-length sample periods. The value returned for each
+// sample period is equivalent to applying the supplied aggregator function to
+// the original data points that fell within the sample period.
+type TimeSeriesQueryAggregator int32
+
+const (
+	// AVG returns the average value of points within the sample period.
+	TimeSeriesQueryAggregator_AVG TimeSeriesQueryAggregator = 1
+	// AVG_RATE returns the rate of change of the average over the sample period's
+	// duration.  This is computed via linear regression with the previous sample
+	// period's average value.
+	TimeSeriesQueryAggregator_AVG_RATE TimeSeriesQueryAggregator = 2
+)
+
+var TimeSeriesQueryAggregator_name = map[int32]string{
+	1: "AVG",
+	2: "AVG_RATE",
+}
+var TimeSeriesQueryAggregator_value = map[string]int32{
+	"AVG":      1,
+	"AVG_RATE": 2,
+}
+
+func (x TimeSeriesQueryAggregator) Enum() *TimeSeriesQueryAggregator {
+	p := new(TimeSeriesQueryAggregator)
+	*p = x
+	return p
+}
+func (x TimeSeriesQueryAggregator) String() string {
+	return proto1.EnumName(TimeSeriesQueryAggregator_name, int32(x))
+}
+func (x *TimeSeriesQueryAggregator) UnmarshalJSON(data []byte) error {
+	value, err := proto1.UnmarshalJSONEnum(TimeSeriesQueryAggregator_value, data, "TimeSeriesQueryAggregator")
+	if err != nil {
+		return err
+	}
+	*x = TimeSeriesQueryAggregator(value)
+	return nil
+}
+
 // TimeSeriesDatapoint is a single point of time series data; a value associated
 // with a timestamp.
 type TimeSeriesDatapoint struct {
@@ -126,19 +170,30 @@ func (m *TimeSeriesQueryRequest) GetQueries() []TimeSeriesQueryRequest_Query {
 // this request.
 type TimeSeriesQueryRequest_Query struct {
 	// The name of the time series to query.
-	Name             string `protobuf:"bytes,1,opt,name=name" json:"name"`
-	XXX_unrecognized []byte `json:"-"`
+	Name string `protobuf:"bytes,1,opt,name=name" json:"name"`
+	// The aggregation function to apply to points in the result.
+	Aggregator       *TimeSeriesQueryAggregator `protobuf:"varint,2,opt,name=aggregator,enum=cockroach.proto.TimeSeriesQueryAggregator,def=1" json:"aggregator,omitempty"`
+	XXX_unrecognized []byte                     `json:"-"`
 }
 
 func (m *TimeSeriesQueryRequest_Query) Reset()         { *m = TimeSeriesQueryRequest_Query{} }
 func (m *TimeSeriesQueryRequest_Query) String() string { return proto1.CompactTextString(m) }
 func (*TimeSeriesQueryRequest_Query) ProtoMessage()    {}
 
+const Default_TimeSeriesQueryRequest_Query_Aggregator TimeSeriesQueryAggregator = TimeSeriesQueryAggregator_AVG
+
 func (m *TimeSeriesQueryRequest_Query) GetName() string {
 	if m != nil {
 		return m.Name
 	}
 	return ""
+}
+
+func (m *TimeSeriesQueryRequest_Query) GetAggregator() TimeSeriesQueryAggregator {
+	if m != nil && m.Aggregator != nil {
+		return *m.Aggregator
+	}
+	return Default_TimeSeriesQueryRequest_Query_Aggregator
 }
 
 // TimeSeriesQueryResponse is the standard response for time series queries
@@ -169,14 +224,18 @@ type TimeSeriesQueryResponse_Result struct {
 	Name string `protobuf:"bytes,1,opt,name=name" json:"name"`
 	// A list of sources from which the data was aggregated.
 	Sources []string `protobuf:"bytes,2,rep,name=sources" json:"sources"`
+	// The aggregation function applied to points in the result.
+	Aggregator *TimeSeriesQueryAggregator `protobuf:"varint,3,opt,name=aggregator,enum=cockroach.proto.TimeSeriesQueryAggregator,def=1" json:"aggregator,omitempty"`
 	// Datapoints describing the queried data.
-	Datapoints       []*TimeSeriesDatapoint `protobuf:"bytes,3,rep,name=datapoints" json:"datapoints,omitempty"`
+	Datapoints       []*TimeSeriesDatapoint `protobuf:"bytes,4,rep,name=datapoints" json:"datapoints,omitempty"`
 	XXX_unrecognized []byte                 `json:"-"`
 }
 
 func (m *TimeSeriesQueryResponse_Result) Reset()         { *m = TimeSeriesQueryResponse_Result{} }
 func (m *TimeSeriesQueryResponse_Result) String() string { return proto1.CompactTextString(m) }
 func (*TimeSeriesQueryResponse_Result) ProtoMessage()    {}
+
+const Default_TimeSeriesQueryResponse_Result_Aggregator TimeSeriesQueryAggregator = TimeSeriesQueryAggregator_AVG
 
 func (m *TimeSeriesQueryResponse_Result) GetName() string {
 	if m != nil {
@@ -192,6 +251,13 @@ func (m *TimeSeriesQueryResponse_Result) GetSources() []string {
 	return nil
 }
 
+func (m *TimeSeriesQueryResponse_Result) GetAggregator() TimeSeriesQueryAggregator {
+	if m != nil && m.Aggregator != nil {
+		return *m.Aggregator
+	}
+	return Default_TimeSeriesQueryResponse_Result_Aggregator
+}
+
 func (m *TimeSeriesQueryResponse_Result) GetDatapoints() []*TimeSeriesDatapoint {
 	if m != nil {
 		return m.Datapoints
@@ -200,4 +266,5 @@ func (m *TimeSeriesQueryResponse_Result) GetDatapoints() []*TimeSeriesDatapoint 
 }
 
 func init() {
+	proto1.RegisterEnum("cockroach.proto.TimeSeriesQueryAggregator", TimeSeriesQueryAggregator_name, TimeSeriesQueryAggregator_value)
 }

--- a/proto/timeseries.proto
+++ b/proto/timeseries.proto
@@ -46,6 +46,22 @@ message TimeSeriesData {
   repeated TimeSeriesDatapoint datapoints = 3;
 }
 
+// TimeSeriesQueryAggregator describes a set of aggregation functions which are
+// applied to data points before returning them as part of a query. 
+//
+// Cockroach does not store data points at full fidelity, instead "downsampling"
+// data points into fixed-length sample periods. The value returned for each
+// sample period is equivalent to applying the supplied aggregator function to
+// the original data points that fell within the sample period.
+enum TimeSeriesQueryAggregator {
+  // AVG returns the average value of points within the sample period.
+  AVG = 1;
+  // AVG_RATE returns the rate of change of the average over the sample period's
+  // duration.  This is computed via linear regression with the previous sample
+  // period's average value.
+  AVG_RATE = 2;
+}
+
 // TimeSeriesQueryRequest is the standard incoming time series query request
 // accepted from cockroach clients.
 message TimeSeriesQueryRequest {
@@ -61,6 +77,8 @@ message TimeSeriesQueryRequest {
     message Query {
         // The name of the time series to query.
         optional string name = 1 [(gogoproto.nullable) = false];
+        // The aggregation function to apply to points in the result.
+        optional TimeSeriesQueryAggregator aggregator = 2 [default = AVG];
     }
 
     // A set of Queries for this request. A request must have at least one
@@ -78,8 +96,10 @@ message TimeSeriesQueryResponse {
         optional string name = 1 [(gogoproto.nullable) = false];
         // A list of sources from which the data was aggregated.
         repeated string sources = 2 [(gogoproto.nullable) = false];
+        // The aggregation function applied to points in the result.
+        optional TimeSeriesQueryAggregator aggregator = 3 [default = AVG];
         // Datapoints describing the queried data.
-        repeated TimeSeriesDatapoint datapoints = 3;
+        repeated TimeSeriesDatapoint datapoints = 4;
     }
 
     // A set of Results; there will be one result for each Query in the matching

--- a/storage/engine/cockroach/proto/timeseries.pb.cc
+++ b/storage/engine/cockroach/proto/timeseries.pb.cc
@@ -39,6 +39,7 @@ const ::google::protobuf::internal::GeneratedMessageReflection*
 const ::google::protobuf::Descriptor* TimeSeriesQueryResponse_Result_descriptor_ = NULL;
 const ::google::protobuf::internal::GeneratedMessageReflection*
   TimeSeriesQueryResponse_Result_reflection_ = NULL;
+const ::google::protobuf::EnumDescriptor* TimeSeriesQueryAggregator_descriptor_ = NULL;
 
 }  // namespace
 
@@ -100,8 +101,9 @@ void protobuf_AssignDesc_cockroach_2fproto_2ftimeseries_2eproto() {
       ::google::protobuf::MessageFactory::generated_factory(),
       sizeof(TimeSeriesQueryRequest));
   TimeSeriesQueryRequest_Query_descriptor_ = TimeSeriesQueryRequest_descriptor_->nested_type(0);
-  static const int TimeSeriesQueryRequest_Query_offsets_[1] = {
+  static const int TimeSeriesQueryRequest_Query_offsets_[2] = {
     GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(TimeSeriesQueryRequest_Query, name_),
+    GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(TimeSeriesQueryRequest_Query, aggregator_),
   };
   TimeSeriesQueryRequest_Query_reflection_ =
     new ::google::protobuf::internal::GeneratedMessageReflection(
@@ -130,9 +132,10 @@ void protobuf_AssignDesc_cockroach_2fproto_2ftimeseries_2eproto() {
       ::google::protobuf::MessageFactory::generated_factory(),
       sizeof(TimeSeriesQueryResponse));
   TimeSeriesQueryResponse_Result_descriptor_ = TimeSeriesQueryResponse_descriptor_->nested_type(0);
-  static const int TimeSeriesQueryResponse_Result_offsets_[3] = {
+  static const int TimeSeriesQueryResponse_Result_offsets_[4] = {
     GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(TimeSeriesQueryResponse_Result, name_),
     GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(TimeSeriesQueryResponse_Result, sources_),
+    GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(TimeSeriesQueryResponse_Result, aggregator_),
     GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(TimeSeriesQueryResponse_Result, datapoints_),
   };
   TimeSeriesQueryResponse_Result_reflection_ =
@@ -146,6 +149,7 @@ void protobuf_AssignDesc_cockroach_2fproto_2ftimeseries_2eproto() {
       ::google::protobuf::DescriptorPool::generated_pool(),
       ::google::protobuf::MessageFactory::generated_factory(),
       sizeof(TimeSeriesQueryResponse_Result));
+  TimeSeriesQueryAggregator_descriptor_ = file->enum_type(0);
 }
 
 namespace {
@@ -203,17 +207,22 @@ void protobuf_AddDesc_cockroach_2fproto_2ftimeseries_2eproto() {
     "\003B\004\310\336\037\000\022\023\n\005value\030\002 \001(\001B\004\310\336\037\000\"t\n\016TimeSeri"
     "esData\022\022\n\004name\030\001 \001(\tB\004\310\336\037\000\022\024\n\006source\030\002 \001"
     "(\tB\004\310\336\037\000\0228\n\ndatapoints\030\003 \003(\0132$.cockroach"
-    ".proto.TimeSeriesDatapoint\"\257\001\n\026TimeSerie"
+    ".proto.TimeSeriesDatapoint\"\364\001\n\026TimeSerie"
     "sQueryRequest\022\031\n\013start_nanos\030\001 \001(\003B\004\310\336\037\000"
     "\022\027\n\tend_nanos\030\002 \001(\003B\004\310\336\037\000\022D\n\007queries\030\003 \003"
     "(\0132-.cockroach.proto.TimeSeriesQueryRequ"
-    "est.QueryB\004\310\336\037\000\032\033\n\005Query\022\022\n\004name\030\001 \001(\tB\004"
-    "\310\336\037\000\"\312\001\n\027TimeSeriesQueryResponse\022@\n\007resu"
-    "lts\030\001 \003(\0132/.cockroach.proto.TimeSeriesQu"
-    "eryResponse.Result\032m\n\006Result\022\022\n\004name\030\001 \001"
-    "(\tB\004\310\336\037\000\022\025\n\007sources\030\002 \003(\tB\004\310\336\037\000\0228\n\ndatap"
-    "oints\030\003 \003(\0132$.cockroach.proto.TimeSeries"
-    "DatapointB\007Z\005proto", 658);
+    "est.QueryB\004\310\336\037\000\032`\n\005Query\022\022\n\004name\030\001 \001(\tB\004"
+    "\310\336\037\000\022C\n\naggregator\030\002 \001(\0162*.cockroach.pro"
+    "to.TimeSeriesQueryAggregator:\003AVG\"\220\002\n\027Ti"
+    "meSeriesQueryResponse\022@\n\007results\030\001 \003(\0132/"
+    ".cockroach.proto.TimeSeriesQueryResponse"
+    ".Result\032\262\001\n\006Result\022\022\n\004name\030\001 \001(\tB\004\310\336\037\000\022\025"
+    "\n\007sources\030\002 \003(\tB\004\310\336\037\000\022C\n\naggregator\030\003 \001("
+    "\0162*.cockroach.proto.TimeSeriesQueryAggre"
+    "gator:\003AVG\0228\n\ndatapoints\030\004 \003(\0132$.cockroa"
+    "ch.proto.TimeSeriesDatapoint*2\n\031TimeSeri"
+    "esQueryAggregator\022\007\n\003AVG\020\001\022\014\n\010AVG_RATE\020\002"
+    "B\007Z\005proto", 849);
   ::google::protobuf::MessageFactory::InternalRegisterGeneratedFile(
     "cockroach/proto/timeseries.proto", &protobuf_RegisterTypes);
   TimeSeriesDatapoint::default_instance_ = new TimeSeriesDatapoint();
@@ -237,6 +246,20 @@ struct StaticDescriptorInitializer_cockroach_2fproto_2ftimeseries_2eproto {
     protobuf_AddDesc_cockroach_2fproto_2ftimeseries_2eproto();
   }
 } static_descriptor_initializer_cockroach_2fproto_2ftimeseries_2eproto_;
+const ::google::protobuf::EnumDescriptor* TimeSeriesQueryAggregator_descriptor() {
+  protobuf_AssignDescriptorsOnce();
+  return TimeSeriesQueryAggregator_descriptor_;
+}
+bool TimeSeriesQueryAggregator_IsValid(int value) {
+  switch(value) {
+    case 1:
+    case 2:
+      return true;
+    default:
+      return false;
+  }
+}
+
 
 // ===================================================================
 
@@ -857,6 +880,7 @@ void TimeSeriesData::Swap(TimeSeriesData* other) {
 
 #ifndef _MSC_VER
 const int TimeSeriesQueryRequest_Query::kNameFieldNumber;
+const int TimeSeriesQueryRequest_Query::kAggregatorFieldNumber;
 #endif  // !_MSC_VER
 
 TimeSeriesQueryRequest_Query::TimeSeriesQueryRequest_Query()
@@ -879,6 +903,7 @@ void TimeSeriesQueryRequest_Query::SharedCtor() {
   ::google::protobuf::internal::GetEmptyString();
   _cached_size_ = 0;
   name_ = const_cast< ::std::string*>(&::google::protobuf::internal::GetEmptyStringAlreadyInited());
+  aggregator_ = 1;
   ::memset(_has_bits_, 0, sizeof(_has_bits_));
 }
 
@@ -917,10 +942,13 @@ TimeSeriesQueryRequest_Query* TimeSeriesQueryRequest_Query::New() const {
 }
 
 void TimeSeriesQueryRequest_Query::Clear() {
-  if (has_name()) {
-    if (name_ != &::google::protobuf::internal::GetEmptyStringAlreadyInited()) {
-      name_->clear();
+  if (_has_bits_[0 / 32] & 3) {
+    if (has_name()) {
+      if (name_ != &::google::protobuf::internal::GetEmptyStringAlreadyInited()) {
+        name_->clear();
+      }
     }
+    aggregator_ = 1;
   }
   ::memset(_has_bits_, 0, sizeof(_has_bits_));
   mutable_unknown_fields()->Clear();
@@ -945,6 +973,26 @@ bool TimeSeriesQueryRequest_Query::MergePartialFromCodedStream(
             this->name().data(), this->name().length(),
             ::google::protobuf::internal::WireFormat::PARSE,
             "name");
+        } else {
+          goto handle_unusual;
+        }
+        if (input->ExpectTag(16)) goto parse_aggregator;
+        break;
+      }
+
+      // optional .cockroach.proto.TimeSeriesQueryAggregator aggregator = 2 [default = AVG];
+      case 2: {
+        if (tag == 16) {
+         parse_aggregator:
+          int value;
+          DO_((::google::protobuf::internal::WireFormatLite::ReadPrimitive<
+                   int, ::google::protobuf::internal::WireFormatLite::TYPE_ENUM>(
+                 input, &value)));
+          if (::cockroach::proto::TimeSeriesQueryAggregator_IsValid(value)) {
+            set_aggregator(static_cast< ::cockroach::proto::TimeSeriesQueryAggregator >(value));
+          } else {
+            mutable_unknown_fields()->AddVarint(2, value);
+          }
         } else {
           goto handle_unusual;
         }
@@ -987,6 +1035,12 @@ void TimeSeriesQueryRequest_Query::SerializeWithCachedSizes(
       1, this->name(), output);
   }
 
+  // optional .cockroach.proto.TimeSeriesQueryAggregator aggregator = 2 [default = AVG];
+  if (has_aggregator()) {
+    ::google::protobuf::internal::WireFormatLite::WriteEnum(
+      2, this->aggregator(), output);
+  }
+
   if (!unknown_fields().empty()) {
     ::google::protobuf::internal::WireFormat::SerializeUnknownFields(
         unknown_fields(), output);
@@ -1008,6 +1062,12 @@ void TimeSeriesQueryRequest_Query::SerializeWithCachedSizes(
         1, this->name(), target);
   }
 
+  // optional .cockroach.proto.TimeSeriesQueryAggregator aggregator = 2 [default = AVG];
+  if (has_aggregator()) {
+    target = ::google::protobuf::internal::WireFormatLite::WriteEnumToArray(
+      2, this->aggregator(), target);
+  }
+
   if (!unknown_fields().empty()) {
     target = ::google::protobuf::internal::WireFormat::SerializeUnknownFieldsToArray(
         unknown_fields(), target);
@@ -1025,6 +1085,12 @@ int TimeSeriesQueryRequest_Query::ByteSize() const {
       total_size += 1 +
         ::google::protobuf::internal::WireFormatLite::StringSize(
           this->name());
+    }
+
+    // optional .cockroach.proto.TimeSeriesQueryAggregator aggregator = 2 [default = AVG];
+    if (has_aggregator()) {
+      total_size += 1 +
+        ::google::protobuf::internal::WireFormatLite::EnumSize(this->aggregator());
     }
 
   }
@@ -1057,6 +1123,9 @@ void TimeSeriesQueryRequest_Query::MergeFrom(const TimeSeriesQueryRequest_Query&
     if (from.has_name()) {
       set_name(from.name());
     }
+    if (from.has_aggregator()) {
+      set_aggregator(from.aggregator());
+    }
   }
   mutable_unknown_fields()->MergeFrom(from.unknown_fields());
 }
@@ -1081,6 +1150,7 @@ bool TimeSeriesQueryRequest_Query::IsInitialized() const {
 void TimeSeriesQueryRequest_Query::Swap(TimeSeriesQueryRequest_Query* other) {
   if (other != this) {
     std::swap(name_, other->name_);
+    std::swap(aggregator_, other->aggregator_);
     std::swap(_has_bits_[0], other->_has_bits_[0]);
     _unknown_fields_.Swap(&other->_unknown_fields_);
     std::swap(_cached_size_, other->_cached_size_);
@@ -1414,6 +1484,7 @@ void TimeSeriesQueryRequest::Swap(TimeSeriesQueryRequest* other) {
 #ifndef _MSC_VER
 const int TimeSeriesQueryResponse_Result::kNameFieldNumber;
 const int TimeSeriesQueryResponse_Result::kSourcesFieldNumber;
+const int TimeSeriesQueryResponse_Result::kAggregatorFieldNumber;
 const int TimeSeriesQueryResponse_Result::kDatapointsFieldNumber;
 #endif  // !_MSC_VER
 
@@ -1437,6 +1508,7 @@ void TimeSeriesQueryResponse_Result::SharedCtor() {
   ::google::protobuf::internal::GetEmptyString();
   _cached_size_ = 0;
   name_ = const_cast< ::std::string*>(&::google::protobuf::internal::GetEmptyStringAlreadyInited());
+  aggregator_ = 1;
   ::memset(_has_bits_, 0, sizeof(_has_bits_));
 }
 
@@ -1475,10 +1547,13 @@ TimeSeriesQueryResponse_Result* TimeSeriesQueryResponse_Result::New() const {
 }
 
 void TimeSeriesQueryResponse_Result::Clear() {
-  if (has_name()) {
-    if (name_ != &::google::protobuf::internal::GetEmptyStringAlreadyInited()) {
-      name_->clear();
+  if (_has_bits_[0 / 32] & 5) {
+    if (has_name()) {
+      if (name_ != &::google::protobuf::internal::GetEmptyStringAlreadyInited()) {
+        name_->clear();
+      }
     }
+    aggregator_ = 1;
   }
   sources_.Clear();
   datapoints_.Clear();
@@ -1527,20 +1602,40 @@ bool TimeSeriesQueryResponse_Result::MergePartialFromCodedStream(
           goto handle_unusual;
         }
         if (input->ExpectTag(18)) goto parse_sources;
-        if (input->ExpectTag(26)) goto parse_datapoints;
+        if (input->ExpectTag(24)) goto parse_aggregator;
         break;
       }
 
-      // repeated .cockroach.proto.TimeSeriesDatapoint datapoints = 3;
+      // optional .cockroach.proto.TimeSeriesQueryAggregator aggregator = 3 [default = AVG];
       case 3: {
-        if (tag == 26) {
+        if (tag == 24) {
+         parse_aggregator:
+          int value;
+          DO_((::google::protobuf::internal::WireFormatLite::ReadPrimitive<
+                   int, ::google::protobuf::internal::WireFormatLite::TYPE_ENUM>(
+                 input, &value)));
+          if (::cockroach::proto::TimeSeriesQueryAggregator_IsValid(value)) {
+            set_aggregator(static_cast< ::cockroach::proto::TimeSeriesQueryAggregator >(value));
+          } else {
+            mutable_unknown_fields()->AddVarint(3, value);
+          }
+        } else {
+          goto handle_unusual;
+        }
+        if (input->ExpectTag(34)) goto parse_datapoints;
+        break;
+      }
+
+      // repeated .cockroach.proto.TimeSeriesDatapoint datapoints = 4;
+      case 4: {
+        if (tag == 34) {
          parse_datapoints:
           DO_(::google::protobuf::internal::WireFormatLite::ReadMessageNoVirtual(
                 input, add_datapoints()));
         } else {
           goto handle_unusual;
         }
-        if (input->ExpectTag(26)) goto parse_datapoints;
+        if (input->ExpectTag(34)) goto parse_datapoints;
         if (input->ExpectAtEnd()) goto success;
         break;
       }
@@ -1590,10 +1685,16 @@ void TimeSeriesQueryResponse_Result::SerializeWithCachedSizes(
       2, this->sources(i), output);
   }
 
-  // repeated .cockroach.proto.TimeSeriesDatapoint datapoints = 3;
+  // optional .cockroach.proto.TimeSeriesQueryAggregator aggregator = 3 [default = AVG];
+  if (has_aggregator()) {
+    ::google::protobuf::internal::WireFormatLite::WriteEnum(
+      3, this->aggregator(), output);
+  }
+
+  // repeated .cockroach.proto.TimeSeriesDatapoint datapoints = 4;
   for (int i = 0; i < this->datapoints_size(); i++) {
     ::google::protobuf::internal::WireFormatLite::WriteMessageMaybeToArray(
-      3, this->datapoints(i), output);
+      4, this->datapoints(i), output);
   }
 
   if (!unknown_fields().empty()) {
@@ -1627,11 +1728,17 @@ void TimeSeriesQueryResponse_Result::SerializeWithCachedSizes(
       WriteStringToArray(2, this->sources(i), target);
   }
 
-  // repeated .cockroach.proto.TimeSeriesDatapoint datapoints = 3;
+  // optional .cockroach.proto.TimeSeriesQueryAggregator aggregator = 3 [default = AVG];
+  if (has_aggregator()) {
+    target = ::google::protobuf::internal::WireFormatLite::WriteEnumToArray(
+      3, this->aggregator(), target);
+  }
+
+  // repeated .cockroach.proto.TimeSeriesDatapoint datapoints = 4;
   for (int i = 0; i < this->datapoints_size(); i++) {
     target = ::google::protobuf::internal::WireFormatLite::
       WriteMessageNoVirtualToArray(
-        3, this->datapoints(i), target);
+        4, this->datapoints(i), target);
   }
 
   if (!unknown_fields().empty()) {
@@ -1653,6 +1760,12 @@ int TimeSeriesQueryResponse_Result::ByteSize() const {
           this->name());
     }
 
+    // optional .cockroach.proto.TimeSeriesQueryAggregator aggregator = 3 [default = AVG];
+    if (has_aggregator()) {
+      total_size += 1 +
+        ::google::protobuf::internal::WireFormatLite::EnumSize(this->aggregator());
+    }
+
   }
   // repeated string sources = 2;
   total_size += 1 * this->sources_size();
@@ -1661,7 +1774,7 @@ int TimeSeriesQueryResponse_Result::ByteSize() const {
       this->sources(i));
   }
 
-  // repeated .cockroach.proto.TimeSeriesDatapoint datapoints = 3;
+  // repeated .cockroach.proto.TimeSeriesDatapoint datapoints = 4;
   total_size += 1 * this->datapoints_size();
   for (int i = 0; i < this->datapoints_size(); i++) {
     total_size +=
@@ -1700,6 +1813,9 @@ void TimeSeriesQueryResponse_Result::MergeFrom(const TimeSeriesQueryResponse_Res
     if (from.has_name()) {
       set_name(from.name());
     }
+    if (from.has_aggregator()) {
+      set_aggregator(from.aggregator());
+    }
   }
   mutable_unknown_fields()->MergeFrom(from.unknown_fields());
 }
@@ -1725,6 +1841,7 @@ void TimeSeriesQueryResponse_Result::Swap(TimeSeriesQueryResponse_Result* other)
   if (other != this) {
     std::swap(name_, other->name_);
     sources_.Swap(&other->sources_);
+    std::swap(aggregator_, other->aggregator_);
     datapoints_.Swap(&other->datapoints_);
     std::swap(_has_bits_[0], other->_has_bits_[0]);
     _unknown_fields_.Swap(&other->_unknown_fields_);

--- a/storage/engine/cockroach/proto/timeseries.pb.h
+++ b/storage/engine/cockroach/proto/timeseries.pb.h
@@ -23,6 +23,7 @@
 #include <google/protobuf/message.h>
 #include <google/protobuf/repeated_field.h>
 #include <google/protobuf/extension_set.h>
+#include <google/protobuf/generated_enum_reflection.h>
 #include <google/protobuf/unknown_field_set.h>
 #include "gogoproto/gogo.pb.h"
 // @@protoc_insertion_point(includes)
@@ -42,6 +43,25 @@ class TimeSeriesQueryRequest_Query;
 class TimeSeriesQueryResponse;
 class TimeSeriesQueryResponse_Result;
 
+enum TimeSeriesQueryAggregator {
+  AVG = 1,
+  AVG_RATE = 2
+};
+bool TimeSeriesQueryAggregator_IsValid(int value);
+const TimeSeriesQueryAggregator TimeSeriesQueryAggregator_MIN = AVG;
+const TimeSeriesQueryAggregator TimeSeriesQueryAggregator_MAX = AVG_RATE;
+const int TimeSeriesQueryAggregator_ARRAYSIZE = TimeSeriesQueryAggregator_MAX + 1;
+
+const ::google::protobuf::EnumDescriptor* TimeSeriesQueryAggregator_descriptor();
+inline const ::std::string& TimeSeriesQueryAggregator_Name(TimeSeriesQueryAggregator value) {
+  return ::google::protobuf::internal::NameOfEnum(
+    TimeSeriesQueryAggregator_descriptor(), value);
+}
+inline bool TimeSeriesQueryAggregator_Parse(
+    const ::std::string& name, TimeSeriesQueryAggregator* value) {
+  return ::google::protobuf::internal::ParseNamedEnum<TimeSeriesQueryAggregator>(
+    TimeSeriesQueryAggregator_descriptor(), name, value);
+}
 // ===================================================================
 
 class TimeSeriesDatapoint : public ::google::protobuf::Message {
@@ -310,16 +330,26 @@ class TimeSeriesQueryRequest_Query : public ::google::protobuf::Message {
   inline ::std::string* release_name();
   inline void set_allocated_name(::std::string* name);
 
+  // optional .cockroach.proto.TimeSeriesQueryAggregator aggregator = 2 [default = AVG];
+  inline bool has_aggregator() const;
+  inline void clear_aggregator();
+  static const int kAggregatorFieldNumber = 2;
+  inline ::cockroach::proto::TimeSeriesQueryAggregator aggregator() const;
+  inline void set_aggregator(::cockroach::proto::TimeSeriesQueryAggregator value);
+
   // @@protoc_insertion_point(class_scope:cockroach.proto.TimeSeriesQueryRequest.Query)
  private:
   inline void set_has_name();
   inline void clear_has_name();
+  inline void set_has_aggregator();
+  inline void clear_has_aggregator();
 
   ::google::protobuf::UnknownFieldSet _unknown_fields_;
 
   ::google::protobuf::uint32 _has_bits_[1];
   mutable int _cached_size_;
   ::std::string* name_;
+  int aggregator_;
   friend void  protobuf_AddDesc_cockroach_2fproto_2ftimeseries_2eproto();
   friend void protobuf_AssignDesc_cockroach_2fproto_2ftimeseries_2eproto();
   friend void protobuf_ShutdownFile_cockroach_2fproto_2ftimeseries_2eproto();
@@ -514,10 +544,17 @@ class TimeSeriesQueryResponse_Result : public ::google::protobuf::Message {
   inline const ::google::protobuf::RepeatedPtrField< ::std::string>& sources() const;
   inline ::google::protobuf::RepeatedPtrField< ::std::string>* mutable_sources();
 
-  // repeated .cockroach.proto.TimeSeriesDatapoint datapoints = 3;
+  // optional .cockroach.proto.TimeSeriesQueryAggregator aggregator = 3 [default = AVG];
+  inline bool has_aggregator() const;
+  inline void clear_aggregator();
+  static const int kAggregatorFieldNumber = 3;
+  inline ::cockroach::proto::TimeSeriesQueryAggregator aggregator() const;
+  inline void set_aggregator(::cockroach::proto::TimeSeriesQueryAggregator value);
+
+  // repeated .cockroach.proto.TimeSeriesDatapoint datapoints = 4;
   inline int datapoints_size() const;
   inline void clear_datapoints();
-  static const int kDatapointsFieldNumber = 3;
+  static const int kDatapointsFieldNumber = 4;
   inline const ::cockroach::proto::TimeSeriesDatapoint& datapoints(int index) const;
   inline ::cockroach::proto::TimeSeriesDatapoint* mutable_datapoints(int index);
   inline ::cockroach::proto::TimeSeriesDatapoint* add_datapoints();
@@ -530,6 +567,8 @@ class TimeSeriesQueryResponse_Result : public ::google::protobuf::Message {
  private:
   inline void set_has_name();
   inline void clear_has_name();
+  inline void set_has_aggregator();
+  inline void clear_has_aggregator();
 
   ::google::protobuf::UnknownFieldSet _unknown_fields_;
 
@@ -538,6 +577,7 @@ class TimeSeriesQueryResponse_Result : public ::google::protobuf::Message {
   ::std::string* name_;
   ::google::protobuf::RepeatedPtrField< ::std::string> sources_;
   ::google::protobuf::RepeatedPtrField< ::cockroach::proto::TimeSeriesDatapoint > datapoints_;
+  int aggregator_;
   friend void  protobuf_AddDesc_cockroach_2fproto_2ftimeseries_2eproto();
   friend void protobuf_AssignDesc_cockroach_2fproto_2ftimeseries_2eproto();
   friend void protobuf_ShutdownFile_cockroach_2fproto_2ftimeseries_2eproto();
@@ -950,6 +990,31 @@ inline void TimeSeriesQueryRequest_Query::set_allocated_name(::std::string* name
   // @@protoc_insertion_point(field_set_allocated:cockroach.proto.TimeSeriesQueryRequest.Query.name)
 }
 
+// optional .cockroach.proto.TimeSeriesQueryAggregator aggregator = 2 [default = AVG];
+inline bool TimeSeriesQueryRequest_Query::has_aggregator() const {
+  return (_has_bits_[0] & 0x00000002u) != 0;
+}
+inline void TimeSeriesQueryRequest_Query::set_has_aggregator() {
+  _has_bits_[0] |= 0x00000002u;
+}
+inline void TimeSeriesQueryRequest_Query::clear_has_aggregator() {
+  _has_bits_[0] &= ~0x00000002u;
+}
+inline void TimeSeriesQueryRequest_Query::clear_aggregator() {
+  aggregator_ = 1;
+  clear_has_aggregator();
+}
+inline ::cockroach::proto::TimeSeriesQueryAggregator TimeSeriesQueryRequest_Query::aggregator() const {
+  // @@protoc_insertion_point(field_get:cockroach.proto.TimeSeriesQueryRequest.Query.aggregator)
+  return static_cast< ::cockroach::proto::TimeSeriesQueryAggregator >(aggregator_);
+}
+inline void TimeSeriesQueryRequest_Query::set_aggregator(::cockroach::proto::TimeSeriesQueryAggregator value) {
+  assert(::cockroach::proto::TimeSeriesQueryAggregator_IsValid(value));
+  set_has_aggregator();
+  aggregator_ = value;
+  // @@protoc_insertion_point(field_set:cockroach.proto.TimeSeriesQueryRequest.Query.aggregator)
+}
+
 // -------------------------------------------------------------------
 
 // TimeSeriesQueryRequest
@@ -1166,7 +1231,32 @@ TimeSeriesQueryResponse_Result::mutable_sources() {
   return &sources_;
 }
 
-// repeated .cockroach.proto.TimeSeriesDatapoint datapoints = 3;
+// optional .cockroach.proto.TimeSeriesQueryAggregator aggregator = 3 [default = AVG];
+inline bool TimeSeriesQueryResponse_Result::has_aggregator() const {
+  return (_has_bits_[0] & 0x00000004u) != 0;
+}
+inline void TimeSeriesQueryResponse_Result::set_has_aggregator() {
+  _has_bits_[0] |= 0x00000004u;
+}
+inline void TimeSeriesQueryResponse_Result::clear_has_aggregator() {
+  _has_bits_[0] &= ~0x00000004u;
+}
+inline void TimeSeriesQueryResponse_Result::clear_aggregator() {
+  aggregator_ = 1;
+  clear_has_aggregator();
+}
+inline ::cockroach::proto::TimeSeriesQueryAggregator TimeSeriesQueryResponse_Result::aggregator() const {
+  // @@protoc_insertion_point(field_get:cockroach.proto.TimeSeriesQueryResponse.Result.aggregator)
+  return static_cast< ::cockroach::proto::TimeSeriesQueryAggregator >(aggregator_);
+}
+inline void TimeSeriesQueryResponse_Result::set_aggregator(::cockroach::proto::TimeSeriesQueryAggregator value) {
+  assert(::cockroach::proto::TimeSeriesQueryAggregator_IsValid(value));
+  set_has_aggregator();
+  aggregator_ = value;
+  // @@protoc_insertion_point(field_set:cockroach.proto.TimeSeriesQueryResponse.Result.aggregator)
+}
+
+// repeated .cockroach.proto.TimeSeriesDatapoint datapoints = 4;
 inline int TimeSeriesQueryResponse_Result::datapoints_size() const {
   return datapoints_.size();
 }
@@ -1240,6 +1330,11 @@ TimeSeriesQueryResponse::mutable_results() {
 namespace google {
 namespace protobuf {
 
+template <> struct is_proto_enum< ::cockroach::proto::TimeSeriesQueryAggregator> : ::google::protobuf::internal::true_type {};
+template <>
+inline const EnumDescriptor* GetEnumDescriptor< ::cockroach::proto::TimeSeriesQueryAggregator>() {
+  return ::cockroach::proto::TimeSeriesQueryAggregator_descriptor();
+}
 
 }  // namespace google
 }  // namespace protobuf

--- a/ts/server.go
+++ b/ts/server.go
@@ -84,7 +84,7 @@ func (s *Server) handleQuery(w http.ResponseWriter, r *http.Request, _ httproute
 		Results: make([]*proto.TimeSeriesQueryResponse_Result, 0, len(request.Queries)),
 	}
 	for _, q := range request.Queries {
-		datapoints, sources, err := s.db.Query(q.Name, Resolution10s, request.StartNanos, request.EndNanos)
+		datapoints, sources, err := s.db.Query(q, Resolution10s, request.StartNanos, request.EndNanos)
 		if err != nil {
 			http.Error(w, err.Error(), http.StatusInternalServerError)
 			return
@@ -93,6 +93,7 @@ func (s *Server) handleQuery(w http.ResponseWriter, r *http.Request, _ httproute
 			Name:       q.Name,
 			Sources:    sources,
 			Datapoints: datapoints,
+			Aggregator: q.Aggregator,
 		})
 	}
 


### PR DESCRIPTION
Introduces the concept of an Aggregator function to time series queries. Time
series now have a choice of two aggregation functions, Average and Rate.

Average captures the previous behavior, where queries return the average value
of each sample period. Rate returns the rate of change for the series at each
sample period; the rate denominator is the length of the sample period
(currently 10 seconds for all metrics).

More work needs to be done to expose the sample period length in queries,
especially in the case of Rate; this should be considered a partially complete
work, which is desired to support upcoming product demos.
