### PR TITLE
Update the node status immediately at startup.

### DIFF
--- a/server/feed_test.go
+++ b/server/feed_test.go
@@ -265,6 +265,9 @@ func TestServerNodeEventFeed(t *testing.T) {
 		proto.NodeID(1): {
 			"InternalRangeLookup",
 			"InternalRangeLookup",
+			"InternalRangeLookup",
+			"InternalRangeLookup",
+			"Put",
 			"Put",
 			"Put",
 			"EndTransaction",

--- a/server/node.go
+++ b/server/node.go
@@ -426,9 +426,12 @@ func (n *Node) gossipCapacities() {
 // ctx.ScanInterval and store the status in the db.
 func (n *Node) startStoresScanner(stopper *util.Stopper) {
 	stopper.RunWorker(func() {
-		for {
+		// TODO(bram): The number of stores is small. The node status should be
+		// updated whenever a store status is updated.
+		for interval := time.Duration(0); true; interval = n.ctx.ScanInterval {
+			// for interval := n.ctx.ScanInterval; true; interval = n.ctx.ScanInterval {
 			select {
-			case <-time.After(n.ctx.ScanInterval):
+			case <-time.After(interval):
 				if !stopper.StartTask() {
 					continue
 				}


### PR DESCRIPTION
This ensures that a node status exists for a newly started node.
