### PR TITLE
async intent resolution only once per store retry loop

### DIFF
--- a/kv/dist_sender.go
+++ b/kv/dist_sender.go
@@ -523,7 +523,7 @@ func (ds *DistSender) Send(_ context.Context, call client.Call) {
 
 	// If this is an InternalPushTxn, set ignoreIntents option as
 	// necessary. This prevents a potential infinite loop; see the
-	// comments in proto.InternalLookupRangeRequest.
+	// comments in proto.InternalRangeLookupRequest.
 	options := lookupOptions{}
 	if pushArgs, ok := args.(*proto.InternalPushTxnRequest); ok {
 		options.ignoreIntents = pushArgs.RangeLookup

--- a/proto/internal.pb.go
+++ b/proto/internal.pb.go
@@ -266,7 +266,7 @@ type InternalPushTxnRequest struct {
 	PushType PushTxnType `protobuf:"varint,4,opt,name=push_type,enum=cockroach.proto.PushTxnType" json:"push_type"`
 	// Range lookup indicates whether we're pushing a txn because of an
 	// intent encountered while servicing an internal range lookup
-	// request. See notes in InternalLookupRangeRequest.
+	// request. See notes in InternalRangeLookupRequest.
 	RangeLookup      bool   `protobuf:"varint,5,opt,name=range_lookup" json:"range_lookup"`
 	XXX_unrecognized []byte `json:"-"`
 }

--- a/proto/internal.proto
+++ b/proto/internal.proto
@@ -135,7 +135,7 @@ message InternalPushTxnRequest {
   optional PushTxnType push_type = 4 [(gogoproto.nullable) = false];
   // Range lookup indicates whether we're pushing a txn because of an
   // intent encountered while servicing an internal range lookup
-  // request. See notes in InternalLookupRangeRequest.
+  // request. See notes in InternalRangeLookupRequest.
   optional bool range_lookup = 5 [(gogoproto.nullable) = false];
 }
 

--- a/storage/store.go
+++ b/storage/store.go
@@ -936,9 +936,9 @@ func (s *Store) SplitRange(origRng, newRng *Range) error {
 	}
 	// Replace the end key of the original range with the start key of
 	// the new range.
-	copy := *origRng.Desc()
-	copy.EndKey = append([]byte(nil), newRng.Desc().StartKey...)
-	if err := origRng.SetDesc(&copy); err != nil {
+	copyDesc := *origRng.Desc()
+	copyDesc.EndKey = append([]byte(nil), newRng.Desc().StartKey...)
+	if err := origRng.SetDesc(&copyDesc); err != nil {
 		return err
 	}
 	s.mu.Lock()
@@ -1060,8 +1060,8 @@ func (s *Store) RemoveRange(rng *Range) error {
 }
 
 // ProcessRangeDescriptorUpdate is called whenever a range's
-// descriptor is updated. Currently, it adds a range to the rangesByS
-// slice if it has not yet been added.
+// descriptor is updated. Currently, it makes the range available
+// for lookups by key idempotently.
 func (s *Store) ProcessRangeDescriptorUpdate(rng *Range) error {
 	s.mu.Lock()
 	defer s.mu.Unlock()
@@ -1473,7 +1473,7 @@ func raftEntryFormatter(data []byte) string {
 }
 
 // GetStatus fetches the latest store status from the stored value on the cluster.
-// Returns nil if the scanner has not yet run.  The scanner runs once every
+// Returns nil if the scanner has not yet run. The scanner runs once every
 // ctx.ScanInterval.
 func (s *Store) GetStatus() (*proto.StoreStatus, error) {
 	if s.scanner.Count() == 0 {


### PR DESCRIPTION
since we see those fire in rapid succession (if an intent remains open
and unpushable for a while, there may be a lot of retries), this change
saves us from firing a potentially unbounded number of goroutines per request.
