### PR TITLE
Make sure the store scanner doesn't take an interval of 0

### DIFF
--- a/server/node.go
+++ b/server/node.go
@@ -432,7 +432,7 @@ func (n *Node) startStoresScanner(stopper *util.Stopper) {
 	stopper.RunWorker(func() {
 		// Pick the smalled of the two intervals.
 		var minScanInterval time.Duration
-		if n.ctx.ScanInterval <= n.ctx.ScanMaxIdleTime {
+		if n.ctx.ScanInterval <= n.ctx.ScanMaxIdleTime || n.ctx.ScanMaxIdleTime == 0 {
 			minScanInterval = n.ctx.ScanInterval
 		} else {
 			minScanInterval = n.ctx.ScanMaxIdleTime


### PR DESCRIPTION
maxIdleTime can be set to 0, this just ensure that if it is, we don't set the interval to it and default to the scanInterval instead.
