### PR TITLE
avoid redundant descriptor cache expiration

### DIFF
--- a/kv/dist_sender.go
+++ b/kv/dist_sender.go
@@ -583,7 +583,7 @@ func (ds *DistSender) Send(_ context.Context, call client.Call) {
 			// It amounts to the same situations though.
 			if rpcErr != nil {
 				ds.updateLeaderCache(proto.RaftID(desc.RaftID), proto.Replica{})
-				ds.rangeCache.EvictCachedRangeDescriptor(args.Header().Key, nil)
+				ds.rangeCache.EvictCachedRangeDescriptor(args.Header().Key, desc)
 			}
 
 			if err != nil {

--- a/kv/dist_sender.go
+++ b/kv/dist_sender.go
@@ -583,7 +583,7 @@ func (ds *DistSender) Send(_ context.Context, call client.Call) {
 			// It amounts to the same situations though.
 			if rpcErr != nil {
 				ds.updateLeaderCache(proto.RaftID(desc.RaftID), proto.Replica{})
-				ds.rangeCache.EvictCachedRangeDescriptor(args.Header().Key)
+				ds.rangeCache.EvictCachedRangeDescriptor(args.Header().Key, nil)
 			}
 
 			if err != nil {
@@ -595,7 +595,7 @@ func (ds *DistSender) Send(_ context.Context, call client.Call) {
 				switch err.(type) {
 				case *proto.RangeNotFoundError, *proto.RangeKeyMismatchError:
 					// Range descriptor might be out of date - evict it.
-					ds.rangeCache.EvictCachedRangeDescriptor(args.Header().Key)
+					ds.rangeCache.EvictCachedRangeDescriptor(args.Header().Key, desc)
 					// On addressing errors, don't backoff; retry immediately.
 					return retry.Reset, nil
 				case *proto.NotLeaderError:

--- a/kv/range_cache_test.go
+++ b/kv/range_cache_test.go
@@ -144,6 +144,11 @@ func doLookup(t *testing.T, rc *rangeDescriptorCache, key string) *proto.RangeDe
 // store for the cache, and measures how often that backing store is
 // accessed when looking up metadata keys through the cache.
 func TestRangeCache(t *testing.T) {
+	expKeyMin := keys.RangeMetaKey(keys.RangeMetaKey(keys.RangeMetaKey(proto.Key("test"))))
+	if !bytes.Equal(expKeyMin, proto.KeyMin) {
+		t.Fatalf("RangeCache relies on RangeMetaKey returning KeyMin after two levels, but got %s", expKeyMin)
+	}
+
 	db := newTestDescriptorDB()
 	for i, char := range "abcdefghijklmnopqrstuvwx" {
 		db.splitRange(t, proto.Key(string(char)))

--- a/kv/range_cache_test.go
+++ b/kv/range_cache_test.go
@@ -127,7 +127,7 @@ func (db *testDescriptorDB) assertHitCount(t *testing.T, expected int) {
 	db.hitCount = 0
 }
 
-func doLookup(t *testing.T, rc *rangeDescriptorCache, key string) {
+func doLookup(t *testing.T, rc *rangeDescriptorCache, key string) *proto.RangeDescriptor {
 	r, err := rc.LookupRangeDescriptor(proto.Key(key), lookupOptions{})
 	if err != nil {
 		t.Fatalf("Unexpected error from LookupRangeDescriptor: %s", err.Error())
@@ -136,6 +136,7 @@ func doLookup(t *testing.T, rc *rangeDescriptorCache, key string) {
 		t.Fatalf("Returned range did not contain key: %s-%s, %s", r.StartKey, r.EndKey, key)
 	}
 	log.Infof("doLookup: %s %+v", key, r)
+	return r
 }
 
 // TestRangeCache is a simple test which verifies that metadata ranges
@@ -185,7 +186,7 @@ func TestRangeCache(t *testing.T) {
 	db.assertHitCount(t, 0)
 
 	// Evict clears one level 1 and one level 2 cache
-	db.cache.EvictCachedRangeDescriptor(proto.Key("da"))
+	db.cache.EvictCachedRangeDescriptor(proto.Key("da"), nil)
 	doLookup(t, db.cache, "fa")
 	db.assertHitCount(t, 0)
 	doLookup(t, db.cache, "da")
@@ -195,4 +196,16 @@ func TestRangeCache(t *testing.T) {
 	// without a cache miss.
 	doLookup(t, db.cache, "a")
 	db.assertHitCount(t, 0)
+
+	// Attempt to compare-and-evict with a descriptor that is not equal to the
+	// cached one; it should not alter the cache.
+	db.cache.EvictCachedRangeDescriptor(proto.Key("cz"), &proto.RangeDescriptor{})
+	doLookup(t, db.cache, "cz")
+	db.assertHitCount(t, 0)
+	// Now evict with the actual descriptor. The cache should clear the
+	// descriptor and the cached meta key.
+	db.cache.EvictCachedRangeDescriptor(proto.Key("cz"), doLookup(t, db.cache, "cz"))
+	doLookup(t, db.cache, "cz")
+	db.assertHitCount(t, 2)
+
 }


### PR DESCRIPTION
especially during a range split, multiple clients may receive retriable
errors indicating that their commands were sent to the wrong range.
the reaction to this is to evict the cached range descriptor, which
prompts an expensive query on the next retry.
however, it makes no sense to evict a range descriptor which is not
equal to the one taken out of the cache earlier. hence in this change
we optionally allow passing in the seen range descriptor when evicting,
which the cache uses to pass on the eviction if it believes that that
seen descriptor has been evicted previously anyways.
