### PR TITLE
range split on same splitKey should not cause infinite retry loop

### DIFF
--- a/storage/client_split_test.go
+++ b/storage/client_split_test.go
@@ -130,7 +130,7 @@ func TestStoreRangeSplitConcurrent(t *testing.T) {
 			args, reply := adminSplitArgs(proto.KeyMin, []byte("a"), 1, store.StoreID())
 			err := store.ExecuteCmd(context.Background(), client.Call{Args: args, Reply: reply})
 			if err != nil {
-				if matched, regexpErr := regexp.MatchString(".*outside of bounds of range", err.Error()); !matched || regexpErr != nil {
+				if matched, regexpErr := regexp.MatchString("range has already been split by key", err.Error()); !matched || regexpErr != nil {
 					t.Errorf("error %s didn't match regex %v", err, regexpErr)
 				} else {
 					atomic.AddInt32(&failureCount, 1)

--- a/storage/client_split_test.go
+++ b/storage/client_split_test.go
@@ -130,7 +130,7 @@ func TestStoreRangeSplitConcurrent(t *testing.T) {
 			args, reply := adminSplitArgs(proto.KeyMin, []byte("a"), 1, store.StoreID())
 			err := store.ExecuteCmd(context.Background(), client.Call{Args: args, Reply: reply})
 			if err != nil {
-				if matched, regexpErr := regexp.MatchString("range has already been split by key", err.Error()); !matched || regexpErr != nil {
+				if matched, regexpErr := regexp.MatchString("range is already split at key", err.Error()); !matched || regexpErr != nil {
 					t.Errorf("error %s didn't match regex %v", err, regexpErr)
 				} else {
 					atomic.AddInt32(&failureCount, 1)

--- a/storage/range_command.go
+++ b/storage/range_command.go
@@ -802,7 +802,13 @@ func (r *Range) AdminSplit(args *proto.AdminSplitRequest, reply *proto.AdminSpli
 			return
 		}
 	}
-
+	// First verify this condition so that it will not return
+	// proto.NewRangeKeyMismatchError if splitKey equals to desc.EndKey,
+	// otherwise it will cause infinite retry loop.
+	if splitKey.Equal(desc.StartKey) || splitKey.Equal(desc.EndKey) {
+		reply.SetGoError(util.Errorf("range has already been split by key %s", splitKey))
+		return
+	}
 	// Verify some properties of split key.
 	if !r.ContainsKey(splitKey) {
 		reply.SetGoError(proto.NewRangeKeyMismatchError(splitKey, splitKey, desc))
@@ -810,10 +816,6 @@ func (r *Range) AdminSplit(args *proto.AdminSplitRequest, reply *proto.AdminSpli
 	}
 	if !engine.IsValidSplitKey(splitKey) {
 		reply.SetGoError(util.Errorf("cannot split range at key %s", splitKey))
-		return
-	}
-	if splitKey.Equal(desc.StartKey) || splitKey.Equal(desc.EndKey) {
-		reply.SetGoError(util.Errorf("range has already been split by key %s", splitKey))
 		return
 	}
 

--- a/storage/range_command.go
+++ b/storage/range_command.go
@@ -806,7 +806,7 @@ func (r *Range) AdminSplit(args *proto.AdminSplitRequest, reply *proto.AdminSpli
 	// proto.NewRangeKeyMismatchError if splitKey equals to desc.EndKey,
 	// otherwise it will cause infinite retry loop.
 	if splitKey.Equal(desc.StartKey) || splitKey.Equal(desc.EndKey) {
-		reply.SetGoError(util.Errorf("range has already been split by key %s", splitKey))
+		reply.SetGoError(util.Errorf("range is already split at key %s", splitKey))
 		return
 	}
 	// Verify some properties of split key.


### PR DESCRIPTION
if splitKey equals to desc.EndKey should be checked first, otherwise it will return proto.NewRangeKeyMismatchError, and cause retry in infinite retry loop.
