### PR TITLE
Remove time.Tickers from the timers' list by Stop'ing them.

### DIFF
--- a/kv/txn_coord_sender.go
+++ b/kv/txn_coord_sender.go
@@ -519,6 +519,7 @@ func (tc *TxnCoordSender) cleanupTxn(txn *proto.Transaction, resolved []proto.Ke
 func (tc *TxnCoordSender) heartbeat(txnMeta *txnMetadata) {
 	tc.stopper.RunWorker(func() {
 		ticker := time.NewTicker(tc.heartbeatInterval)
+		defer ticker.Stop()
 		request := &proto.InternalHeartbeatTxnRequest{
 			RequestHeader: proto.RequestHeader{
 				Key:  txnMeta.txn.Key,

--- a/multiraft/clock.go
+++ b/multiraft/clock.go
@@ -25,6 +25,9 @@ type Ticker interface {
 	// the channel has this type for compatibility with time.Ticker but other implementations
 	// may not return real times.
 	Chan() <-chan time.Time
+
+	// Close stops the ticker and releases its resources.
+	Close()
 }
 
 type realTicker struct {
@@ -37,6 +40,10 @@ func newTicker(interval time.Duration) Ticker {
 
 func (t *realTicker) Chan() <-chan time.Time {
 	return t.C
+}
+
+func (t *realTicker) Close() {
+	t.Ticker.Stop()
 }
 
 // manualTicker is a fake implementation of the Ticker interface.  With this ticker
@@ -57,3 +64,5 @@ func (m *manualTicker) Chan() <-chan time.Time {
 func (m *manualTicker) Tick() {
 	m.ch <- time.Time{}
 }
+
+func (m *manualTicker) Close() { /* do nothing */ }

--- a/multiraft/multiraft.go
+++ b/multiraft/multiraft.go
@@ -124,6 +124,7 @@ func NewMultiRaft(nodeID proto.RaftNodeID, config *Config, stopper *util.Stopper
 
 	if config.Ticker == nil {
 		config.Ticker = newTicker(config.TickInterval)
+		stopper.AddCloser(config.Ticker)
 	}
 
 	if config.EntryFormatter != nil {

--- a/server/node.go
+++ b/server/node.go
@@ -404,6 +404,7 @@ func (n *Node) connectGossip() {
 func (n *Node) startGossip(stopper *util.Stopper) {
 	stopper.RunWorker(func() {
 		ticker := time.NewTicker(gossipInterval)
+		defer ticker.Stop()
 		n.gossipCapacities() // one-off run before going to sleep
 		for {
 			select {

--- a/storage/store.go
+++ b/storage/store.go
@@ -538,6 +538,7 @@ func (s *Store) startGossip() error {
 		}
 		s.initComplete.Done()
 		ticker := time.NewTicker(clusterIDGossipInterval)
+		defer ticker.Stop()
 		for {
 			select {
 			case <-ticker.C:
@@ -557,6 +558,7 @@ func (s *Store) startGossip() error {
 		}
 		s.initComplete.Done()
 		ticker := time.NewTicker(configGossipInterval)
+		defer ticker.Stop()
 		for {
 			select {
 			case <-ticker.C:

--- a/ts/db.go
+++ b/ts/db.go
@@ -72,6 +72,7 @@ type poller struct {
 func (p *poller) start() {
 	p.stopper.RunWorker(func() {
 		ticker := time.NewTicker(p.frequency)
+		defer ticker.Stop()
 		for {
 			select {
 			case <-ticker.C:

--- a/util/log/clog.go
+++ b/util/log/clog.go
@@ -1027,7 +1027,8 @@ const flushInterval = 30 * time.Second
 
 // flushDaemon periodically flushes the log file buffers.
 func (l *loggingT) flushDaemon() {
-	for range time.NewTicker(flushInterval).C {
+	// doesn't need to be Stop()'d as the loop never escapes
+	for range time.Tick(flushInterval) {
 		l.lockAndFlushAll()
 	}
 }


### PR DESCRIPTION
If tickers are not stopped, the list of scheduled timers grows unbounded and leads to continuously increasing CPU usage.

`time.Ticker` is implemented by adding a timer to the runtime. This timer is appended to a heap and stays there until it is deleted (by a call to `ticker.Stop()`). See https://golang.org/src/runtime/time.go.

I've grep'd for all the usages of `time.Ticker` and I think I have them all.
