### PR TITLE
support for logging in JSON format (file+stderr)

### DIFF
--- a/util/log/flags.go
+++ b/util/log/flags.go
@@ -23,6 +23,7 @@ import "flag"
 func init() {
 	flag.BoolVar(&logging.toStderr, "logtostderr", true, "log to standard error instead of files")
 	flag.BoolVar(&logging.alsoToStderr, "alsologtostderr", false, "log to standard error as well as files")
+	flag.BoolVar(&logging.json, "logjson", false, "log in JSON format")
 	flag.StringVar(&logging.color, "color", "auto", "colorize standard error output according to severity")
 	flag.Var(&logging.verbosity, "verbosity", "log level for V logs")
 	// TODO(tschottdorf): decide if we need this.


### PR DESCRIPTION
spending the recent days debugging and sifting through logs, I've become
convinced that staring at our human-readable log output for that purpose is
ineffective. This change makes it easy to just log JSON to stderr (+files, but
I don't care about that) and pipe that into https://github.com/tschottdorf/cockroach-elk:

```
(cd ~/cockroach-elk; docker-compose up -d)
./cockroach start --logjson [...] 2>&1 | netcat localhost 5000
./cockroach start --logjson [...] 2>&1 | tee log.log | netcat localhost 5000
(cd ~/cockroach-elk; docker-compose stop)
```

We should be able to string this up with acceptance tests so that what they
do can be inspected more easily.

The logging-related command line flags are obviously pretty jumbled up right
now and will eventually need a do-over. I have no preferences, I just want
to be able to log JSON to stderr and logs.

Getting a good grip on the arguments contained in the proto message is
unfortunately awkward: Each message contains an optional field `json` which
may hold a JSON serialization of the argument (i.e. a RangeDescriptor), but
serializing the protobuf to JSON means that you'll have JSON which contains
a JSON string containing JSON. Ideally, the JSON serialization should special-
case that field, but I didn't want to go down that road since it means dealing
with gogoproto.customtype and reimplementing a bunch of things.
Even if we did that, with Elasticsearch we would still have the issue that it
tries to index those fields, but since the schema changes from arg to arg, it
will barf. Instead I've special-cased that field in cockroach-elk for now, so
that it will only base64-decode the serialized JSON arg to make it legible,
and keep it as string. Convincing Elasticsearch to not index the args JSON
is awkward since it means altering the mapper of the index, but those are auto-
generated by logstash every day. We can make all of this whole again but it's
not too important now. Eventually Cockroach will need to output the JSON right away.
