### PR TITLE
Meta2KeyMax should not be valid range split key

### DIFF
--- a/keys/constants.go
+++ b/keys/constants.go
@@ -135,6 +135,9 @@ var (
 	// Meta1KeyMax is the end of the range of the first level of key addressing.
 	// The value is a RangeDescriptor struct.
 	Meta1KeyMax = MakeKey(Meta1Prefix, proto.KeyMax)
+	// Meta2KeyMax is the end of the range of the second level of key addressing.
+	// The value is a RangeDescriptor struct.
+	Meta2KeyMax = MakeKey(Meta2Prefix, proto.KeyMax)
 
 	// MetaMax is the end of the range of addressing keys.
 	MetaMax = MakeKey(SystemPrefix, proto.Key("\x01"))

--- a/kv/dist_sender_server_test.go
+++ b/kv/dist_sender_server_test.go
@@ -188,3 +188,34 @@ func TestStartEqualsEndKeyScan(t *testing.T) {
 		t.Fatalf("expected error on scan with startkey == endkey")
 	}
 }
+
+// TestSplitByMeta2KeyMax check range splitting at key Meta2KeyMax should
+// failed as Meta2KeyMax is not an invalid split key.
+func TestSplitByMeta2KeyMax(t *testing.T) {
+	s := startServer(t)
+	db := createTestClient(t, s.ServingAddr())
+	db.User = storage.UserRoot
+	defer s.Stop()
+
+	ch := make(chan struct{})
+	go func() {
+		if err := db.Run(client.Call{
+			Args: &proto.AdminSplitRequest{
+				RequestHeader: proto.RequestHeader{
+					Key: proto.KeyMin,
+				},
+				SplitKey: keys.Meta2KeyMax,
+			},
+			Reply: &proto.AdminSplitResponse{},
+		}); err == nil {
+			t.Fatalf("range split on Meta2KeyMax should fail")
+		}
+		close(ch)
+	}()
+
+	select {
+	case <-ch:
+	case <-time.After(100 * time.Millisecond):
+		t.Error("range split on Meta2KeyMax timed out")
+	}
+}

--- a/kv/dist_sender_server_test.go
+++ b/kv/dist_sender_server_test.go
@@ -190,7 +190,7 @@ func TestStartEqualsEndKeyScan(t *testing.T) {
 }
 
 // TestSplitByMeta2KeyMax check range splitting at key Meta2KeyMax should
-// failed as Meta2KeyMax is not an invalid split key.
+// fail as Meta2KeyMax is not a valid split key.
 func TestSplitByMeta2KeyMax(t *testing.T) {
 	s := startServer(t)
 	db := createTestClient(t, s.ServingAddr())
@@ -215,7 +215,7 @@ func TestSplitByMeta2KeyMax(t *testing.T) {
 
 	select {
 	case <-ch:
-	case <-time.After(100 * time.Millisecond):
+	case <-time.After(500 * time.Millisecond):
 		t.Error("range split on Meta2KeyMax timed out")
 	}
 }

--- a/storage/engine/mvcc.go
+++ b/storage/engine/mvcc.go
@@ -1223,7 +1223,12 @@ func MVCCGarbageCollect(engine Engine, ms *proto.MVCCStats, keys []proto.Interna
 //   - \x00acct < SplitKey < \x00accu
 //   - \x00perm < SplitKey < \x00pern
 //   - \x00zone < SplitKey < \x00zonf
+// And split key equal to Meta2KeyMax (\x00\x00meta2\xff\xff) is
+// considered invalid.
 func IsValidSplitKey(key proto.Key) bool {
+	if key.Equal(keys.Meta2KeyMax) {
+		return false
+	}
 	return isValidEncodedSplitKey(MVCCEncodeKey(key))
 }
 

--- a/storage/engine/mvcc_test.go
+++ b/storage/engine/mvcc_test.go
@@ -1478,6 +1478,7 @@ func TestValidSplitKeys(t *testing.T) {
 		{proto.Key("\x00\x00meta2"), true},
 		{proto.Key("\x00\x00meta2\x00"), true},
 		{proto.Key("\x00\x00meta2\xff"), true},
+		{proto.Key("\x00\x00meta2\xff\xff"), false},
 		{proto.Key("\x00\x00meta3"), true},
 		{proto.Key("\x00\x01"), true},
 		{proto.Key("\x00accs\xff"), true},


### PR DESCRIPTION
when try to make range split at key Meta2KeyMax (\x00\x00meta2\xff\xff), the call to AdminSplit will succeed, but the server will fall into a infinite loop:

``` log
W0601 22:56:18.657173    5953 dist_sender.go:588] failed to invoke InternalResolveIntent: key range "\x00\x00\x00k\x00\xff\x00\xffmeta2\xff\xff\x00\x01rtn-"-"" outside of boun\
ds of range ""-"\x00\x00meta2\xff\xff"
I0601 22:56:18.657203    5953 retry.go:95] routing InternalResolveIntent rpc failed; retrying immediately
W0601 22:56:18.657240    5953 dist_sender.go:588] failed to invoke InternalResolveIntent: key range "\x00\x00meta2\xff\xff"-"" outside of bounds of range ""-"\x00\x00meta2\xff\
\xff"
I0601 22:56:18.657260    5953 retry.go:95] routing InternalResolveIntent rpc failed; retrying immediately
W0601 22:56:18.657280    5953 dist_sender.go:588] failed to invoke InternalResolveIntent: key range "\x00range-tree-root"-"" outside of bounds of range ""-"\x00\x00meta2\xff\x\
ff"
I0601 22:56:18.657287    5953 retry.go:95] routing InternalResolveIntent rpc failed; retrying immediately
```

The reason for this is Meta1KeyMax (\x00\x00meta1\xff\xff) server as dual purpose:
1. boundary check of Meta1 addressing range (\x00~\x00\x00meta1\xff\xff)
2. metadata key for key Meta2KeyMax (\x00\x00meta2\xff\xff),
so when a split happens at Meta2KeyMax, initial range will be split into 2 ranges:
1. range1 (0x00~Meta2KeyMax)
2. range2 [Meta2KeyMax~KeyMax)
but Meta1KeyMax will fall into a dilemma: 
1. As boundary key for Meta1 addressing range, it's value should be range1
2. but as a metadata key for Meta2KeyMax, it's value should be range2.
In current implementation after splitRangeAddressing function, the value stored is range1, so the InternalResolveIntent(Key:Meta2KeyMax) request will be route to range1, but this key is outside of bounds of range1. so the InternalResolveIntent will retry infinitely but no reason to be succeed.
So the solution may be not allowed Meta2KeyMax be a split key.
Two issues for this fix are not resolved:
1. The test case added cannot finish if the change is not made as the server is falling in infinite loop, please help on make it out.
2. make testrace also fail, but I cannot make out the reason, so please help.
