### PR TITLE
Remove Replica.Attrs.

### DIFF
--- a/kv/replica_slice.go
+++ b/kv/replica_slice.go
@@ -1,0 +1,123 @@
+// Copyright 2015 The Cockroach Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+// implied. See the License for the specific language governing
+// permissions and limitations under the License. See the AUTHORS file
+// for names of contributors.
+//
+// Author: Tobias Schottdorf (tobias.schottdorf@gmail.com)
+// Author: Peter Mattis (peter@cockroachlabs.com)
+
+package kv
+
+import (
+	"github.com/cockroachdb/cockroach/gossip"
+	"github.com/cockroachdb/cockroach/proto"
+	"github.com/cockroachdb/cockroach/util/log"
+)
+
+// replicaInfo extends the Replica structure with the associated node
+// descriptor.
+type replicaInfo struct {
+	proto.Replica
+	NodeDesc proto.NodeDescriptor
+}
+
+func (i *replicaInfo) attrs() []string {
+	return i.NodeDesc.GetAttrs().Attrs
+}
+
+// A replicaSlice is a slice of Replicas.
+type replicaSlice []replicaInfo
+
+// newReplicaSlice creates a replicaSlice from the replicas listed in the range
+// descriptor and using gossip to lookup node descriptors. Replicas on nodes
+// that are not gossipped are omitted from the result.
+func newReplicaSlice(gossip *gossip.Gossip, desc *proto.RangeDescriptor) replicaSlice {
+	replicas := make(replicaSlice, 0, len(desc.Replicas))
+	for _, r := range desc.Replicas {
+		nd, err := gossip.GetNodeDescriptor(r.NodeID)
+		if err != nil {
+			if log.V(1) {
+				log.Infof("node %d is not gossiped: %v", r.NodeID, err)
+			}
+			continue
+		}
+		replicas = append(replicas, replicaInfo{
+			Replica:  r,
+			NodeDesc: nd,
+		})
+	}
+	return replicas
+}
+
+// Swap interchanges the replicas stored at the given indices.
+func (rs replicaSlice) Swap(i, j int) {
+	rs[i], rs[j] = rs[j], rs[i]
+}
+
+// FindReplica returns the replica which matches the specified store
+// ID. If no replica matches, (-1, nil) is returned.
+func (rs replicaSlice) FindReplica(storeID proto.StoreID) (int, *proto.Replica) {
+	for i := range rs {
+		if rs[i].StoreID == storeID {
+			return i, &rs[i].Replica
+		}
+	}
+	return -1, nil
+}
+
+// SortByCommonAttributePrefix rearranges the replicaSlice by comparing the
+// attributes to the given reference attributes. The basis for the comparison
+// is that of the common prefix of replica attributes (i.e. the number of equal
+// attributes, starting at the first), with a longer prefix sorting first. The
+// number of attributes successfully matched to at least one replica is
+// returned (hence, if the return value equals the length of the replicaSlice,
+// at least one replica matched all attributes).
+//
+// TODO(peter): need to randomize the replica order within each bucket.
+func (rs replicaSlice) SortByCommonAttributePrefix(attrs []string) int {
+	if len(rs) < 2 {
+		return 0
+	}
+	topIndex := len(rs) - 1
+	for bucket := 0; bucket < len(attrs); bucket++ {
+		firstNotOrdered := 0
+		for i := 0; i <= topIndex; i++ {
+			if bucket < len(rs[i].attrs()) && rs[i].attrs()[bucket] == attrs[bucket] {
+				// Move replica which matches this attribute to an earlier
+				// place in the array, just behind the last matching replica.
+				// This packs all matching replicas together.
+				rs.Swap(firstNotOrdered, i)
+				firstNotOrdered++
+			}
+		}
+		if firstNotOrdered == 0 {
+			return bucket
+		}
+		topIndex = firstNotOrdered - 1
+	}
+	return len(attrs)
+}
+
+// MoveToFront moves the replica at the given index to the front
+// of the slice, keeping the order of the remaining elements stable.
+// The function will panic when invoked with an invalid index.
+func (rs replicaSlice) MoveToFront(i int) {
+	l := len(rs) - 1
+	if i > l {
+		panic("out of bound index")
+	}
+	front := rs[i]
+	// Move the first i-1 elements to the right
+	copy(rs[1:i+1], rs[0:i])
+	rs[0] = front
+}

--- a/kv/replica_slice_test.go
+++ b/kv/replica_slice_test.go
@@ -1,0 +1,109 @@
+// Copyright 2015 The Cockroach Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+// implied. See the License for the specific language governing
+// permissions and limitations under the License. See the AUTHORS file
+// for names of contributors.
+//
+// Author: Tobias Schottdorf (tobias.schottdorf@gmail.com)
+
+package kv
+
+import (
+	"reflect"
+	"testing"
+
+	"github.com/cockroachdb/cockroach/proto"
+)
+
+func verifyOrdering(attrs []string, replicas replicaSlice, prefixLen int) bool {
+	prevMatchIndex := len(attrs)
+	for i, replica := range replicas {
+		matchIndex := -1
+
+		for j, attr := range attrs {
+			if j >= len(replica.attrs()) || replica.attrs()[j] != attr {
+				break
+			}
+			matchIndex = j
+		}
+		if matchIndex != -1 && matchIndex > prevMatchIndex {
+			return false
+		}
+		if i == 0 && matchIndex+1 != prefixLen {
+			return false
+		}
+		prevMatchIndex = matchIndex
+	}
+	return true
+}
+
+func TestReplicaSetSortByCommonAttributePrefix(t *testing.T) {
+	replicaAttrs := [][]string{
+		{"us-west-1a", "gpu"},
+		{"us-east-1a", "pdu1", "gpu"},
+		{"us-east-1a", "pdu1", "fio"},
+		{"breaker", "us-east-1a", "pdu1", "fio"},
+		{""},
+		{"us-west-1a", "pdu1", "fio"},
+		{"us-west-1a", "pdu1", "fio", "aux"},
+	}
+	attrs := [][]string{
+		{"us-carl"},
+		{"us-west-1a", "pdu1", "fio"},
+		{"us-west-1a"},
+		{"", "pdu1", "fio"},
+	}
+
+	for i, attr := range attrs {
+		rs := replicaSlice{}
+		for _, c := range replicaAttrs {
+			rs = append(rs, replicaInfo{
+				NodeDesc: proto.NodeDescriptor{
+					Attrs: proto.Attributes{Attrs: c},
+				},
+			})
+		}
+		prefixLen := rs.SortByCommonAttributePrefix(attr)
+		if !verifyOrdering(attr, rs, prefixLen) {
+			t.Errorf("%d: attributes not ordered by %s or prefix length %d incorrect:\n%v", i, attr, prefixLen, rs)
+		}
+	}
+}
+
+func getStores(rs replicaSlice) (r []proto.StoreID) {
+	for i := range rs {
+		r = append(r, rs[i].StoreID)
+	}
+	return
+}
+
+func TestReplicaSetMoveToFront(t *testing.T) {
+	rs := replicaSlice(nil)
+	for i := 0; i < 5; i++ {
+		rs = append(rs, replicaInfo{Replica: proto.Replica{StoreID: proto.StoreID(i + 1)}})
+	}
+	rs.MoveToFront(0)
+	exp := []proto.StoreID{1, 2, 3, 4, 5}
+	if stores := getStores(rs); !reflect.DeepEqual(stores, exp) {
+		t.Errorf("expected order %s, got %s", exp, stores)
+	}
+	rs.MoveToFront(2)
+	exp = []proto.StoreID{3, 1, 2, 4, 5}
+	if stores := getStores(rs); !reflect.DeepEqual(stores, exp) {
+		t.Errorf("expected order %s, got %s", exp, stores)
+	}
+	rs.MoveToFront(4)
+	exp = []proto.StoreID{5, 3, 1, 2, 4}
+	if stores := getStores(rs); !reflect.DeepEqual(stores, exp) {
+		t.Errorf("expected order %s, got %s", exp, stores)
+	}
+}

--- a/proto/config.pb.go
+++ b/proto/config.pb.go
@@ -40,23 +40,14 @@ func (m *Attributes) GetAttrs() []string {
 // device) and associated attributes. Replicas are stored in Range
 // lookup records (meta1, meta2).
 type Replica struct {
-	NodeID  NodeID  `protobuf:"varint,1,opt,name=node_id,customtype=NodeID" json:"node_id"`
-	StoreID StoreID `protobuf:"varint,2,opt,name=store_id,customtype=StoreID" json:"store_id"`
-	// Combination of node & store attributes.
-	Attrs            Attributes `protobuf:"bytes,3,opt,name=attrs" json:"attrs"`
-	XXX_unrecognized []byte     `json:"-"`
+	NodeID           NodeID  `protobuf:"varint,1,opt,name=node_id,customtype=NodeID" json:"node_id"`
+	StoreID          StoreID `protobuf:"varint,2,opt,name=store_id,customtype=StoreID" json:"store_id"`
+	XXX_unrecognized []byte  `json:"-"`
 }
 
 func (m *Replica) Reset()         { *m = Replica{} }
 func (m *Replica) String() string { return proto1.CompactTextString(m) }
 func (*Replica) ProtoMessage()    {}
-
-func (m *Replica) GetAttrs() Attributes {
-	if m != nil {
-		return m.Attrs
-	}
-	return Attributes{}
-}
 
 // RangeDescriptor is the value stored in a range metadata key.
 // A range is described using an inclusive start key, a non-inclusive end key,
@@ -480,30 +471,6 @@ func (m *Replica) Unmarshal(data []byte) error {
 					break
 				}
 			}
-		case 3:
-			if wireType != 2 {
-				return fmt.Errorf("proto: wrong wireType = %d for field Attrs", wireType)
-			}
-			var msglen int
-			for shift := uint(0); ; shift += 7 {
-				if index >= l {
-					return io.ErrUnexpectedEOF
-				}
-				b := data[index]
-				index++
-				msglen |= (int(b) & 0x7F) << shift
-				if b < 0x80 {
-					break
-				}
-			}
-			postIndex := index + msglen
-			if postIndex > l {
-				return io.ErrUnexpectedEOF
-			}
-			if err := m.Attrs.Unmarshal(data[index:postIndex]); err != nil {
-				return err
-			}
-			index = postIndex
 		default:
 			var sizeOfWire int
 			for {
@@ -1652,8 +1619,6 @@ func (m *Replica) Size() (n int) {
 	_ = l
 	n += 1 + sovConfig(uint64(m.NodeID))
 	n += 1 + sovConfig(uint64(m.StoreID))
-	l = m.Attrs.Size()
-	n += 1 + l + sovConfig(uint64(l))
 	if m.XXX_unrecognized != nil {
 		n += len(m.XXX_unrecognized)
 	}
@@ -1901,14 +1866,6 @@ func (m *Replica) MarshalTo(data []byte) (n int, err error) {
 	data[i] = 0x10
 	i++
 	i = encodeVarintConfig(data, i, uint64(m.StoreID))
-	data[i] = 0x1a
-	i++
-	i = encodeVarintConfig(data, i, uint64(m.Attrs.Size()))
-	n1, err := m.Attrs.MarshalTo(data[i:])
-	if err != nil {
-		return 0, err
-	}
-	i += n1
 	if m.XXX_unrecognized != nil {
 		i += copy(data[i:], m.XXX_unrecognized)
 	}
@@ -1936,19 +1893,19 @@ func (m *RangeDescriptor) MarshalTo(data []byte) (n int, err error) {
 	data[i] = 0x12
 	i++
 	i = encodeVarintConfig(data, i, uint64(m.StartKey.Size()))
-	n2, err := m.StartKey.MarshalTo(data[i:])
+	n1, err := m.StartKey.MarshalTo(data[i:])
+	if err != nil {
+		return 0, err
+	}
+	i += n1
+	data[i] = 0x1a
+	i++
+	i = encodeVarintConfig(data, i, uint64(m.EndKey.Size()))
+	n2, err := m.EndKey.MarshalTo(data[i:])
 	if err != nil {
 		return 0, err
 	}
 	i += n2
-	data[i] = 0x1a
-	i++
-	i = encodeVarintConfig(data, i, uint64(m.EndKey.Size()))
-	n3, err := m.EndKey.MarshalTo(data[i:])
-	if err != nil {
-		return 0, err
-	}
-	i += n3
 	if len(m.Replicas) > 0 {
 		for _, msg := range m.Replicas {
 			data[i] = 0x22
@@ -2104,11 +2061,11 @@ func (m *ZoneConfig) MarshalTo(data []byte) (n int, err error) {
 		data[i] = 0x22
 		i++
 		i = encodeVarintConfig(data, i, uint64(m.GC.Size()))
-		n4, err := m.GC.MarshalTo(data[i:])
+		n3, err := m.GC.MarshalTo(data[i:])
 		if err != nil {
 			return 0, err
 		}
-		i += n4
+		i += n3
 	}
 	if m.XXX_unrecognized != nil {
 		i += copy(data[i:], m.XXX_unrecognized)
@@ -2134,11 +2091,11 @@ func (m *RangeTree) MarshalTo(data []byte) (n int, err error) {
 	data[i] = 0xa
 	i++
 	i = encodeVarintConfig(data, i, uint64(m.RootKey.Size()))
-	n5, err := m.RootKey.MarshalTo(data[i:])
+	n4, err := m.RootKey.MarshalTo(data[i:])
 	if err != nil {
 		return 0, err
 	}
-	i += n5
+	i += n4
 	if m.XXX_unrecognized != nil {
 		i += copy(data[i:], m.XXX_unrecognized)
 	}
@@ -2163,11 +2120,11 @@ func (m *RangeTreeNode) MarshalTo(data []byte) (n int, err error) {
 	data[i] = 0xa
 	i++
 	i = encodeVarintConfig(data, i, uint64(m.Key.Size()))
-	n6, err := m.Key.MarshalTo(data[i:])
+	n5, err := m.Key.MarshalTo(data[i:])
 	if err != nil {
 		return 0, err
 	}
-	i += n6
+	i += n5
 	data[i] = 0x10
 	i++
 	if m.Black {
@@ -2179,30 +2136,30 @@ func (m *RangeTreeNode) MarshalTo(data []byte) (n int, err error) {
 	data[i] = 0x1a
 	i++
 	i = encodeVarintConfig(data, i, uint64(m.ParentKey.Size()))
-	n7, err := m.ParentKey.MarshalTo(data[i:])
+	n6, err := m.ParentKey.MarshalTo(data[i:])
 	if err != nil {
 		return 0, err
 	}
-	i += n7
+	i += n6
 	if m.LeftKey != nil {
 		data[i] = 0x22
 		i++
 		i = encodeVarintConfig(data, i, uint64(m.LeftKey.Size()))
-		n8, err := m.LeftKey.MarshalTo(data[i:])
+		n7, err := m.LeftKey.MarshalTo(data[i:])
 		if err != nil {
 			return 0, err
 		}
-		i += n8
+		i += n7
 	}
 	if m.RightKey != nil {
 		data[i] = 0x2a
 		i++
 		i = encodeVarintConfig(data, i, uint64(m.RightKey.Size()))
-		n9, err := m.RightKey.MarshalTo(data[i:])
+		n8, err := m.RightKey.MarshalTo(data[i:])
 		if err != nil {
 			return 0, err
 		}
-		i += n9
+		i += n8
 	}
 	if m.XXX_unrecognized != nil {
 		i += copy(data[i:], m.XXX_unrecognized)
@@ -2290,19 +2247,19 @@ func (m *NodeDescriptor) MarshalTo(data []byte) (n int, err error) {
 	data[i] = 0x12
 	i++
 	i = encodeVarintConfig(data, i, uint64(m.Address.Size()))
-	n10, err := m.Address.MarshalTo(data[i:])
+	n9, err := m.Address.MarshalTo(data[i:])
+	if err != nil {
+		return 0, err
+	}
+	i += n9
+	data[i] = 0x1a
+	i++
+	i = encodeVarintConfig(data, i, uint64(m.Attrs.Size()))
+	n10, err := m.Attrs.MarshalTo(data[i:])
 	if err != nil {
 		return 0, err
 	}
 	i += n10
-	data[i] = 0x1a
-	i++
-	i = encodeVarintConfig(data, i, uint64(m.Attrs.Size()))
-	n11, err := m.Attrs.MarshalTo(data[i:])
-	if err != nil {
-		return 0, err
-	}
-	i += n11
 	if m.XXX_unrecognized != nil {
 		i += copy(data[i:], m.XXX_unrecognized)
 	}
@@ -2330,27 +2287,27 @@ func (m *StoreDescriptor) MarshalTo(data []byte) (n int, err error) {
 	data[i] = 0x12
 	i++
 	i = encodeVarintConfig(data, i, uint64(m.Attrs.Size()))
-	n12, err := m.Attrs.MarshalTo(data[i:])
+	n11, err := m.Attrs.MarshalTo(data[i:])
+	if err != nil {
+		return 0, err
+	}
+	i += n11
+	data[i] = 0x1a
+	i++
+	i = encodeVarintConfig(data, i, uint64(m.Node.Size()))
+	n12, err := m.Node.MarshalTo(data[i:])
 	if err != nil {
 		return 0, err
 	}
 	i += n12
-	data[i] = 0x1a
+	data[i] = 0x22
 	i++
-	i = encodeVarintConfig(data, i, uint64(m.Node.Size()))
-	n13, err := m.Node.MarshalTo(data[i:])
+	i = encodeVarintConfig(data, i, uint64(m.Capacity.Size()))
+	n13, err := m.Capacity.MarshalTo(data[i:])
 	if err != nil {
 		return 0, err
 	}
 	i += n13
-	data[i] = 0x22
-	i++
-	i = encodeVarintConfig(data, i, uint64(m.Capacity.Size()))
-	n14, err := m.Capacity.MarshalTo(data[i:])
-	if err != nil {
-		return 0, err
-	}
-	i += n14
 	if m.XXX_unrecognized != nil {
 		i += copy(data[i:], m.XXX_unrecognized)
 	}

--- a/proto/config.proto
+++ b/proto/config.proto
@@ -41,8 +41,6 @@ message Replica {
       (gogoproto.customname) = "NodeID", (gogoproto.customtype) = "NodeID"];
   optional int32 store_id = 2 [(gogoproto.nullable) = false,
       (gogoproto.customname) = "StoreID", (gogoproto.customtype) = "StoreID"];
-  // Combination of node & store attributes.
-  optional Attributes attrs = 3 [(gogoproto.nullable) = false];
 }
 
 // RangeDescriptor is the value stored in a range metadata key.

--- a/proto/config_test.go
+++ b/proto/config_test.go
@@ -19,7 +19,6 @@ package proto
 
 import (
 	"bytes"
-	"reflect"
 	"testing"
 )
 
@@ -148,86 +147,5 @@ func TestPermConfig(t *testing.T) {
 	}
 	if p.CanWrite("bar") {
 		t.Errorf("unexpected read access for user \"bar\"")
-	}
-}
-
-func verifyOrdering(attrs []string, replicas ReplicaSlice, prefixLen int) bool {
-	prevMatchIndex := len(attrs)
-	for i, replica := range replicas {
-		matchIndex := -1
-
-		for j, attr := range attrs {
-			if j >= len(replica.Attrs.Attrs) || replica.Attrs.Attrs[j] != attr {
-				break
-			}
-			matchIndex = j
-		}
-		if matchIndex != -1 && matchIndex > prevMatchIndex {
-			return false
-		}
-		if i == 0 && matchIndex+1 != prefixLen {
-			return false
-		}
-		prevMatchIndex = matchIndex
-	}
-	return true
-}
-
-func TestReplicaSetSortByCommonAttributePrefix(t *testing.T) {
-	replicaAttrs := [][]string{
-		{"us-west-1a", "gpu"},
-		{"us-east-1a", "pdu1", "gpu"},
-		{"us-east-1a", "pdu1", "fio"},
-		{"breaker", "us-east-1a", "pdu1", "fio"},
-		{""},
-		{"us-west-1a", "pdu1", "fio"},
-		{"us-west-1a", "pdu1", "fio", "aux"},
-	}
-	attrs := [][]string{
-		{"us-carl"},
-		{"us-west-1a", "pdu1", "fio"},
-		{"us-west-1a"},
-		{"", "pdu1", "fio"},
-	}
-
-	for i, attr := range attrs {
-		rs := ReplicaSlice{}
-		for _, c := range replicaAttrs {
-			rs = append(rs, Replica{Attrs: Attributes{Attrs: c}})
-		}
-		prefixLen := rs.SortByCommonAttributePrefix(attr)
-		if !verifyOrdering(attr, rs, prefixLen) {
-			t.Errorf("%d: attributes not ordered by %s or prefix length %d incorrect:\n%v", i, attr, prefixLen, rs)
-		}
-	}
-
-}
-
-func getStores(rs ReplicaSlice) (r []StoreID) {
-	for i := range rs {
-		r = append(r, rs[i].StoreID)
-	}
-	return
-}
-
-func TestReplicaSetMoveToFront(t *testing.T) {
-	rs := ReplicaSlice(nil)
-	for i := 0; i < 5; i++ {
-		rs = append(rs, Replica{StoreID: StoreID(i + 1)})
-	}
-	rs.MoveToFront(0)
-	exp := []StoreID{1, 2, 3, 4, 5}
-	if stores := getStores(rs); !reflect.DeepEqual(stores, exp) {
-		t.Errorf("expected order %s, got %s", exp, stores)
-	}
-	rs.MoveToFront(2)
-	exp = []StoreID{3, 1, 2, 4, 5}
-	if stores := getStores(rs); !reflect.DeepEqual(stores, exp) {
-		t.Errorf("expected order %s, got %s", exp, stores)
-	}
-	rs.MoveToFront(4)
-	exp = []StoreID{5, 3, 1, 2, 4}
-	if stores := getStores(rs); !reflect.DeepEqual(stores, exp) {
-		t.Errorf("expected order %s, got %s", exp, stores)
 	}
 }

--- a/server/cli/cli_test.go
+++ b/server/cli/cli_test.go
@@ -185,9 +185,9 @@ func ExampleSplitMergeRanges() {
 	// range split c c
 	// range ls
 	// ""-"c" [1]
-	// 	0: node-id=1 store-id=1 attrs=[]
+	// 	0: node-id=1 store-id=1
 	// "c"-"\xff\xff" [2]
-	// 	0: node-id=1 store-id=1 attrs=[]
+	// 	0: node-id=1 store-id=1
 	// kv scan
 	// "a"	"1"
 	// "b"	"2"
@@ -196,7 +196,7 @@ func ExampleSplitMergeRanges() {
 	// range merge b
 	// range ls
 	// ""-"\xff\xff" [1]
-	// 	0: node-id=1 store-id=1 attrs=[]
+	// 	0: node-id=1 store-id=1
 	// kv scan
 	// "a"	"1"
 	// "b"	"2"

--- a/server/cli/range.go
+++ b/server/cli/range.go
@@ -70,8 +70,8 @@ func runLsRanges(cmd *cobra.Command, args []string) {
 		}
 		fmt.Printf("%s-%s [%d]\n", desc.StartKey, desc.EndKey, desc.RaftID)
 		for i, replica := range desc.Replicas {
-			fmt.Printf("\t%d: node-id=%d store-id=%d attrs=%v\n",
-				i, replica.NodeID, replica.StoreID, replica.Attrs.Attrs)
+			fmt.Printf("\t%d: node-id=%d store-id=%d\n",
+				i, replica.NodeID, replica.StoreID)
 		}
 	}
 }

--- a/storage/allocator_test.go
+++ b/storage/allocator_test.go
@@ -219,7 +219,6 @@ func TestAllocatorThreeDisksSameDC(t *testing.T) {
 		{
 			NodeID:  result1.Node.NodeID,
 			StoreID: result1.StoreID,
-			Attrs:   multiDisksConfig.ReplicaAttrs[0],
 		},
 	}
 	result2, err := s.allocator().AllocateTarget(multiDisksConfig.ReplicaAttrs[1], exReplicas, false)
@@ -262,7 +261,6 @@ func TestAllocatorTwoDatacenters(t *testing.T) {
 		{
 			NodeID:  result2.Node.NodeID,
 			StoreID: result2.StoreID,
-			Attrs:   multiDCConfig.ReplicaAttrs[1],
 		},
 	}, false)
 	if err == nil {
@@ -279,7 +277,6 @@ func TestAllocatorExistingReplica(t *testing.T) {
 		{
 			NodeID:  2,
 			StoreID: 2,
-			Attrs:   multiDisksConfig.ReplicaAttrs[0],
 		},
 	}, false)
 	if err != nil {

--- a/storage/client_event_test.go
+++ b/storage/client_event_test.go
@@ -244,7 +244,7 @@ func TestMultiStoreEventFeed(t *testing.T) {
 		proto.StoreID(1): {
 			"StartStore",
 			"BeginScanRanges",
-			"AddRange rid=1, live=348",
+			"AddRange rid=1, live=344",
 			"EndScanRanges",
 			"SplitRange origId=1, newId=2, origKey=290, newKey=15",
 			"SplitRange origId=2, newId=3, origKey=15, newKey=0",

--- a/storage/client_raft_test.go
+++ b/storage/client_raft_test.go
@@ -206,7 +206,6 @@ func TestReplicateRange(t *testing.T) {
 		proto.Replica{
 			NodeID:  mtc.stores[1].Ident.NodeID,
 			StoreID: mtc.stores[1].Ident.StoreID,
-			Attrs:   proto.Attributes{},
 		}); err != nil {
 		t.Fatal(err)
 	}
@@ -271,7 +270,6 @@ func TestRestoreReplicas(t *testing.T) {
 		proto.Replica{
 			NodeID:  mtc.stores[1].Ident.NodeID,
 			StoreID: mtc.stores[1].Ident.StoreID,
-			Attrs:   proto.Attributes{},
 		}); err != nil {
 		t.Fatal(err)
 	}
@@ -361,7 +359,6 @@ func TestFailedReplicaChange(t *testing.T) {
 		proto.Replica{
 			NodeID:  mtc.stores[1].Ident.NodeID,
 			StoreID: mtc.stores[1].Ident.StoreID,
-			Attrs:   proto.Attributes{},
 		})
 	if err == nil || !strings.Contains(err.Error(), "boom") {
 		t.Fatalf("did not get expected error: %s", err)
@@ -381,7 +378,6 @@ func TestFailedReplicaChange(t *testing.T) {
 		proto.Replica{
 			NodeID:  mtc.stores[1].Ident.NodeID,
 			StoreID: mtc.stores[1].Ident.StoreID,
-			Attrs:   proto.Attributes{},
 		})
 	if err != nil {
 		t.Fatal(err)
@@ -448,7 +444,6 @@ func TestReplicateAfterTruncation(t *testing.T) {
 		proto.Replica{
 			NodeID:  mtc.stores[1].Ident.NodeID,
 			StoreID: mtc.stores[1].Ident.StoreID,
-			Attrs:   proto.Attributes{},
 		}); err != nil {
 		t.Fatal(err)
 	}

--- a/storage/engine/cockroach/proto/config.pb.cc
+++ b/storage/engine/cockroach/proto/config.pb.cc
@@ -86,10 +86,9 @@ void protobuf_AssignDesc_cockroach_2fproto_2fconfig_2eproto() {
       ::google::protobuf::MessageFactory::generated_factory(),
       sizeof(Attributes));
   Replica_descriptor_ = file->message_type(1);
-  static const int Replica_offsets_[3] = {
+  static const int Replica_offsets_[2] = {
     GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(Replica, node_id_),
     GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(Replica, store_id_),
-    GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(Replica, attrs_),
   };
   Replica_reflection_ =
     new ::google::protobuf::internal::GeneratedMessageReflection(
@@ -368,47 +367,45 @@ void protobuf_AddDesc_cockroach_2fproto_2fconfig_2eproto() {
     "\n\034cockroach/proto/config.proto\022\017cockroac"
     "h.proto\032\024gogoproto/gogo.proto\"6\n\nAttribu"
     "tes\022(\n\005attrs\030\001 \003(\tB\031\310\336\037\000\362\336\037\021yaml:\"attrs,"
-    "flow\"\"\224\001\n\007Replica\022)\n\007node_id\030\001 \001(\005B\030\310\336\037\000"
-    "\342\336\037\006NodeID\332\336\037\006NodeID\022,\n\010store_id\030\002 \001(\005B\032"
-    "\310\336\037\000\342\336\037\007StoreID\332\336\037\007StoreID\0220\n\005attrs\030\003 \001("
-    "\0132\033.cockroach.proto.AttributesB\004\310\336\037\000\"\242\001\n"
-    "\017RangeDescriptor\022\037\n\007raft_id\030\001 \001(\003B\016\310\336\037\000\342"
-    "\336\037\006RaftID\022\036\n\tstart_key\030\002 \001(\014B\013\310\336\037\000\332\336\037\003Ke"
-    "y\022\034\n\007end_key\030\003 \001(\014B\013\310\336\037\000\332\336\037\003Key\0220\n\010repli"
-    "cas\030\004 \003(\0132\030.cockroach.proto.ReplicaB\004\310\336\037"
-    "\000\"3\n\010GCPolicy\022\'\n\013ttl_seconds\030\001 \001(\005B\022\310\336\037\000"
-    "\342\336\037\nTTLSeconds\"E\n\nAcctConfig\0227\n\ncluster_"
-    "id\030\001 \001(\tB#\310\336\037\000\362\336\037\033yaml:\"cluster_id,omite"
-    "mpty\"\"h\n\nPermConfig\022+\n\004read\030\001 \003(\tB\035\310\336\037\000\362"
-    "\336\037\025yaml:\"read,omitempty\"\022-\n\005write\030\002 \003(\tB"
-    "\036\310\336\037\000\362\336\037\026yaml:\"write,omitempty\"\"\257\002\n\nZone"
-    "Config\022U\n\rreplica_attrs\030\001 \003(\0132\033.cockroac"
-    "h.proto.AttributesB!\310\336\037\000\362\336\037\031yaml:\"replic"
-    "as,omitempty\"\022A\n\017range_min_bytes\030\002 \001(\003B("
-    "\310\336\037\000\362\336\037 yaml:\"range_min_bytes,omitempty\""
-    "\022A\n\017range_max_bytes\030\003 \001(\003B(\310\336\037\000\362\336\037 yaml:"
-    "\"range_max_bytes,omitempty\"\022D\n\002gc\030\004 \001(\0132"
-    "\031.cockroach.proto.GCPolicyB\035\342\336\037\002GC\362\336\037\023ya"
-    "ml:\"gc,omitempty\"\"*\n\tRangeTree\022\035\n\010root_k"
-    "ey\030\001 \001(\014B\013\310\336\037\000\332\336\037\003Key\"\226\001\n\rRangeTreeNode\022"
-    "\030\n\003key\030\001 \001(\014B\013\310\336\037\000\332\336\037\003Key\022\023\n\005black\030\002 \001(\010"
-    "B\004\310\336\037\000\022\037\n\nparent_key\030\003 \001(\014B\013\310\336\037\000\332\336\037\003Key\022"
-    "\031\n\010left_key\030\004 \001(\014B\007\332\336\037\003Key\022\032\n\tright_key\030"
-    "\005 \001(\014B\007\332\336\037\003Key\"4\n\004Addr\022\025\n\007network\030\001 \001(\tB"
-    "\004\310\336\037\000\022\025\n\007address\030\002 \001(\tB\004\310\336\037\000\"Z\n\rStoreCap"
-    "acity\022\026\n\010Capacity\030\001 \001(\003B\004\310\336\037\000\022\027\n\tAvailab"
-    "le\030\002 \001(\003B\004\310\336\037\000\022\030\n\nRangeCount\030\003 \001(\005B\004\310\336\037\000"
-    "\"\233\001\n\016NodeDescriptor\022)\n\007node_id\030\001 \001(\005B\030\310\336"
-    "\037\000\342\336\037\006NodeID\332\336\037\006NodeID\022,\n\007address\030\002 \001(\0132"
-    "\025.cockroach.proto.AddrB\004\310\336\037\000\0220\n\005attrs\030\003 "
-    "\001(\0132\033.cockroach.proto.AttributesB\004\310\336\037\000\"\336"
-    "\001\n\017StoreDescriptor\022,\n\010store_id\030\001 \001(\005B\032\310\336"
-    "\037\000\342\336\037\007StoreID\332\336\037\007StoreID\0220\n\005attrs\030\002 \001(\0132"
-    "\033.cockroach.proto.AttributesB\004\310\336\037\000\0223\n\004no"
-    "de\030\003 \001(\0132\037.cockroach.proto.NodeDescripto"
-    "rB\004\310\336\037\000\0226\n\010capacity\030\004 \001(\0132\036.cockroach.pr"
-    "oto.StoreCapacityB\004\310\336\037\000B\023Z\005proto\340\342\036\001\310\342\036\001"
-    "\320\342\036\001", 1724);
+    "flow\"\"b\n\007Replica\022)\n\007node_id\030\001 \001(\005B\030\310\336\037\000\342"
+    "\336\037\006NodeID\332\336\037\006NodeID\022,\n\010store_id\030\002 \001(\005B\032\310"
+    "\336\037\000\342\336\037\007StoreID\332\336\037\007StoreID\"\242\001\n\017RangeDescr"
+    "iptor\022\037\n\007raft_id\030\001 \001(\003B\016\310\336\037\000\342\336\037\006RaftID\022\036"
+    "\n\tstart_key\030\002 \001(\014B\013\310\336\037\000\332\336\037\003Key\022\034\n\007end_ke"
+    "y\030\003 \001(\014B\013\310\336\037\000\332\336\037\003Key\0220\n\010replicas\030\004 \003(\0132\030"
+    ".cockroach.proto.ReplicaB\004\310\336\037\000\"3\n\010GCPoli"
+    "cy\022\'\n\013ttl_seconds\030\001 \001(\005B\022\310\336\037\000\342\336\037\nTTLSeco"
+    "nds\"E\n\nAcctConfig\0227\n\ncluster_id\030\001 \001(\tB#\310"
+    "\336\037\000\362\336\037\033yaml:\"cluster_id,omitempty\"\"h\n\nPe"
+    "rmConfig\022+\n\004read\030\001 \003(\tB\035\310\336\037\000\362\336\037\025yaml:\"re"
+    "ad,omitempty\"\022-\n\005write\030\002 \003(\tB\036\310\336\037\000\362\336\037\026ya"
+    "ml:\"write,omitempty\"\"\257\002\n\nZoneConfig\022U\n\rr"
+    "eplica_attrs\030\001 \003(\0132\033.cockroach.proto.Att"
+    "ributesB!\310\336\037\000\362\336\037\031yaml:\"replicas,omitempt"
+    "y\"\022A\n\017range_min_bytes\030\002 \001(\003B(\310\336\037\000\362\336\037 yam"
+    "l:\"range_min_bytes,omitempty\"\022A\n\017range_m"
+    "ax_bytes\030\003 \001(\003B(\310\336\037\000\362\336\037 yaml:\"range_max_"
+    "bytes,omitempty\"\022D\n\002gc\030\004 \001(\0132\031.cockroach"
+    ".proto.GCPolicyB\035\342\336\037\002GC\362\336\037\023yaml:\"gc,omit"
+    "empty\"\"*\n\tRangeTree\022\035\n\010root_key\030\001 \001(\014B\013\310"
+    "\336\037\000\332\336\037\003Key\"\226\001\n\rRangeTreeNode\022\030\n\003key\030\001 \001("
+    "\014B\013\310\336\037\000\332\336\037\003Key\022\023\n\005black\030\002 \001(\010B\004\310\336\037\000\022\037\n\np"
+    "arent_key\030\003 \001(\014B\013\310\336\037\000\332\336\037\003Key\022\031\n\010left_key"
+    "\030\004 \001(\014B\007\332\336\037\003Key\022\032\n\tright_key\030\005 \001(\014B\007\332\336\037\003"
+    "Key\"4\n\004Addr\022\025\n\007network\030\001 \001(\tB\004\310\336\037\000\022\025\n\007ad"
+    "dress\030\002 \001(\tB\004\310\336\037\000\"Z\n\rStoreCapacity\022\026\n\010Ca"
+    "pacity\030\001 \001(\003B\004\310\336\037\000\022\027\n\tAvailable\030\002 \001(\003B\004\310"
+    "\336\037\000\022\030\n\nRangeCount\030\003 \001(\005B\004\310\336\037\000\"\233\001\n\016NodeDe"
+    "scriptor\022)\n\007node_id\030\001 \001(\005B\030\310\336\037\000\342\336\037\006NodeI"
+    "D\332\336\037\006NodeID\022,\n\007address\030\002 \001(\0132\025.cockroach"
+    ".proto.AddrB\004\310\336\037\000\0220\n\005attrs\030\003 \001(\0132\033.cockr"
+    "oach.proto.AttributesB\004\310\336\037\000\"\336\001\n\017StoreDes"
+    "criptor\022,\n\010store_id\030\001 \001(\005B\032\310\336\037\000\342\336\037\007Store"
+    "ID\332\336\037\007StoreID\0220\n\005attrs\030\002 \001(\0132\033.cockroach"
+    ".proto.AttributesB\004\310\336\037\000\0223\n\004node\030\003 \001(\0132\037."
+    "cockroach.proto.NodeDescriptorB\004\310\336\037\000\0226\n\010"
+    "capacity\030\004 \001(\0132\036.cockroach.proto.StoreCa"
+    "pacityB\004\310\336\037\000B\023Z\005proto\340\342\036\001\310\342\036\001\320\342\036\001", 1673);
   ::google::protobuf::MessageFactory::InternalRegisterGeneratedFile(
     "cockroach/proto/config.proto", &protobuf_RegisterTypes);
   Attributes::default_instance_ = new Attributes();
@@ -683,7 +680,6 @@ void Attributes::Swap(Attributes* other) {
 #ifndef _MSC_VER
 const int Replica::kNodeIdFieldNumber;
 const int Replica::kStoreIdFieldNumber;
-const int Replica::kAttrsFieldNumber;
 #endif  // !_MSC_VER
 
 Replica::Replica()
@@ -693,7 +689,6 @@ Replica::Replica()
 }
 
 void Replica::InitAsDefaultInstance() {
-  attrs_ = const_cast< ::cockroach::proto::Attributes*>(&::cockroach::proto::Attributes::default_instance());
 }
 
 Replica::Replica(const Replica& from)
@@ -707,7 +702,6 @@ void Replica::SharedCtor() {
   _cached_size_ = 0;
   node_id_ = 0;
   store_id_ = 0;
-  attrs_ = NULL;
   ::memset(_has_bits_, 0, sizeof(_has_bits_));
 }
 
@@ -718,7 +712,6 @@ Replica::~Replica() {
 
 void Replica::SharedDtor() {
   if (this != default_instance_) {
-    delete attrs_;
   }
 }
 
@@ -754,12 +747,7 @@ void Replica::Clear() {
     ::memset(&first, 0, n);                                \
   } while (0)
 
-  if (_has_bits_[0 / 32] & 7) {
-    ZR_(node_id_, store_id_);
-    if (has_attrs()) {
-      if (attrs_ != NULL) attrs_->::cockroach::proto::Attributes::Clear();
-    }
-  }
+  ZR_(node_id_, store_id_);
 
 #undef OFFSET_OF_FIELD_
 #undef ZR_
@@ -803,19 +791,6 @@ bool Replica::MergePartialFromCodedStream(
         } else {
           goto handle_unusual;
         }
-        if (input->ExpectTag(26)) goto parse_attrs;
-        break;
-      }
-
-      // optional .cockroach.proto.Attributes attrs = 3;
-      case 3: {
-        if (tag == 26) {
-         parse_attrs:
-          DO_(::google::protobuf::internal::WireFormatLite::ReadMessageNoVirtual(
-               input, mutable_attrs()));
-        } else {
-          goto handle_unusual;
-        }
         if (input->ExpectAtEnd()) goto success;
         break;
       }
@@ -855,12 +830,6 @@ void Replica::SerializeWithCachedSizes(
     ::google::protobuf::internal::WireFormatLite::WriteInt32(2, this->store_id(), output);
   }
 
-  // optional .cockroach.proto.Attributes attrs = 3;
-  if (has_attrs()) {
-    ::google::protobuf::internal::WireFormatLite::WriteMessageMaybeToArray(
-      3, this->attrs(), output);
-  }
-
   if (!unknown_fields().empty()) {
     ::google::protobuf::internal::WireFormat::SerializeUnknownFields(
         unknown_fields(), output);
@@ -879,13 +848,6 @@ void Replica::SerializeWithCachedSizes(
   // optional int32 store_id = 2;
   if (has_store_id()) {
     target = ::google::protobuf::internal::WireFormatLite::WriteInt32ToArray(2, this->store_id(), target);
-  }
-
-  // optional .cockroach.proto.Attributes attrs = 3;
-  if (has_attrs()) {
-    target = ::google::protobuf::internal::WireFormatLite::
-      WriteMessageNoVirtualToArray(
-        3, this->attrs(), target);
   }
 
   if (!unknown_fields().empty()) {
@@ -912,13 +874,6 @@ int Replica::ByteSize() const {
       total_size += 1 +
         ::google::protobuf::internal::WireFormatLite::Int32Size(
           this->store_id());
-    }
-
-    // optional .cockroach.proto.Attributes attrs = 3;
-    if (has_attrs()) {
-      total_size += 1 +
-        ::google::protobuf::internal::WireFormatLite::MessageSizeNoVirtual(
-          this->attrs());
     }
 
   }
@@ -954,9 +909,6 @@ void Replica::MergeFrom(const Replica& from) {
     if (from.has_store_id()) {
       set_store_id(from.store_id());
     }
-    if (from.has_attrs()) {
-      mutable_attrs()->::cockroach::proto::Attributes::MergeFrom(from.attrs());
-    }
   }
   mutable_unknown_fields()->MergeFrom(from.unknown_fields());
 }
@@ -982,7 +934,6 @@ void Replica::Swap(Replica* other) {
   if (other != this) {
     std::swap(node_id_, other->node_id_);
     std::swap(store_id_, other->store_id_);
-    std::swap(attrs_, other->attrs_);
     std::swap(_has_bits_[0], other->_has_bits_[0]);
     _unknown_fields_.Swap(&other->_unknown_fields_);
     std::swap(_cached_size_, other->_cached_size_);

--- a/storage/engine/cockroach/proto/config.pb.h
+++ b/storage/engine/cockroach/proto/config.pb.h
@@ -204,23 +204,12 @@ class Replica : public ::google::protobuf::Message {
   inline ::google::protobuf::int32 store_id() const;
   inline void set_store_id(::google::protobuf::int32 value);
 
-  // optional .cockroach.proto.Attributes attrs = 3;
-  inline bool has_attrs() const;
-  inline void clear_attrs();
-  static const int kAttrsFieldNumber = 3;
-  inline const ::cockroach::proto::Attributes& attrs() const;
-  inline ::cockroach::proto::Attributes* mutable_attrs();
-  inline ::cockroach::proto::Attributes* release_attrs();
-  inline void set_allocated_attrs(::cockroach::proto::Attributes* attrs);
-
   // @@protoc_insertion_point(class_scope:cockroach.proto.Replica)
  private:
   inline void set_has_node_id();
   inline void clear_has_node_id();
   inline void set_has_store_id();
   inline void clear_has_store_id();
-  inline void set_has_attrs();
-  inline void clear_has_attrs();
 
   ::google::protobuf::UnknownFieldSet _unknown_fields_;
 
@@ -228,7 +217,6 @@ class Replica : public ::google::protobuf::Message {
   mutable int _cached_size_;
   ::google::protobuf::int32 node_id_;
   ::google::protobuf::int32 store_id_;
-  ::cockroach::proto::Attributes* attrs_;
   friend void  protobuf_AddDesc_cockroach_2fproto_2fconfig_2eproto();
   friend void protobuf_AssignDesc_cockroach_2fproto_2fconfig_2eproto();
   friend void protobuf_ShutdownFile_cockroach_2fproto_2fconfig_2eproto();
@@ -1488,47 +1476,6 @@ inline void Replica::set_store_id(::google::protobuf::int32 value) {
   set_has_store_id();
   store_id_ = value;
   // @@protoc_insertion_point(field_set:cockroach.proto.Replica.store_id)
-}
-
-// optional .cockroach.proto.Attributes attrs = 3;
-inline bool Replica::has_attrs() const {
-  return (_has_bits_[0] & 0x00000004u) != 0;
-}
-inline void Replica::set_has_attrs() {
-  _has_bits_[0] |= 0x00000004u;
-}
-inline void Replica::clear_has_attrs() {
-  _has_bits_[0] &= ~0x00000004u;
-}
-inline void Replica::clear_attrs() {
-  if (attrs_ != NULL) attrs_->::cockroach::proto::Attributes::Clear();
-  clear_has_attrs();
-}
-inline const ::cockroach::proto::Attributes& Replica::attrs() const {
-  // @@protoc_insertion_point(field_get:cockroach.proto.Replica.attrs)
-  return attrs_ != NULL ? *attrs_ : *default_instance_->attrs_;
-}
-inline ::cockroach::proto::Attributes* Replica::mutable_attrs() {
-  set_has_attrs();
-  if (attrs_ == NULL) attrs_ = new ::cockroach::proto::Attributes;
-  // @@protoc_insertion_point(field_mutable:cockroach.proto.Replica.attrs)
-  return attrs_;
-}
-inline ::cockroach::proto::Attributes* Replica::release_attrs() {
-  clear_has_attrs();
-  ::cockroach::proto::Attributes* temp = attrs_;
-  attrs_ = NULL;
-  return temp;
-}
-inline void Replica::set_allocated_attrs(::cockroach::proto::Attributes* attrs) {
-  delete attrs_;
-  attrs_ = attrs;
-  if (attrs) {
-    set_has_attrs();
-  } else {
-    clear_has_attrs();
-  }
-  // @@protoc_insertion_point(field_set_allocated:cockroach.proto.Replica.attrs)
 }
 
 // -------------------------------------------------------------------

--- a/storage/range_test.go
+++ b/storage/range_test.go
@@ -74,7 +74,6 @@ func testRangeDescriptor() *proto.RangeDescriptor {
 			{
 				NodeID:  1,
 				StoreID: 1,
-				Attrs:   proto.Attributes{Attrs: []string{"dc1", "mem"}},
 			},
 		},
 	}

--- a/storage/replicate_queue.go
+++ b/storage/replicate_queue.go
@@ -111,7 +111,6 @@ func (rq *replicateQueue) process(now proto.Timestamp, rng *Range) error {
 	replica := proto.Replica{
 		NodeID:  newReplica.Node.NodeID,
 		StoreID: newReplica.StoreID,
-		Attrs:   newReplica.Attrs,
 	}
 	if err = rng.ChangeReplicas(proto.ADD_REPLICA, replica); err != nil {
 		return err

--- a/storage/store.go
+++ b/storage/store.go
@@ -802,7 +802,6 @@ func (s *Store) BootstrapRange() error {
 			{
 				NodeID:  1,
 				StoreID: 1,
-				Attrs:   s.Attrs(),
 			},
 		},
 	}

--- a/storage/store_test.go
+++ b/storage/store_test.go
@@ -23,7 +23,6 @@ import (
 	"bytes"
 	"fmt"
 	"math"
-	"reflect"
 	"sort"
 	"strings"
 	"testing"
@@ -187,8 +186,7 @@ func TestStoreInitAndBootstrap(t *testing.T) {
 	ctx := TestStoreContext
 	manual := hlc.NewManualClock(0)
 	ctx.Clock = hlc.NewClock(manual.UnixNano)
-	expectedAttrs := []string{"test"}
-	eng := engine.NewInMem(proto.Attributes{Attrs: expectedAttrs}, 1<<20)
+	eng := engine.NewInMem(proto.Attributes{}, 1<<20)
 	ctx.Transport = multiraft.NewLocalRPCTransport()
 	stopper := util.NewStopper()
 	stopper.AddCloser(ctx.Transport)
@@ -221,13 +219,8 @@ func TestStoreInitAndBootstrap(t *testing.T) {
 		t.Errorf("failure initializing bootstrapped store: %s", err)
 	}
 	// 1st range should be available.
-	if rng, err := store.GetRange(1); err != nil {
+	if _, err := store.GetRange(1); err != nil {
 		t.Errorf("failure fetching 1st range: %s", err)
-	} else {
-		attrs := rng.Desc().Replicas[0].GetAttrs().Attrs
-		if !reflect.DeepEqual(expectedAttrs, attrs) {
-			t.Errorf("expected %v, but found %v", expectedAttrs, attrs)
-		}
 	}
 }
 


### PR DESCRIPTION
Move proto.ReplicaSlice to kv.replicaSlice. Instead of a []proto.Replica
this is now a []replicaInfo. When constructing a replicaSlice we lookup
the node descriptor in gossip. This replaces the existing lookup of the
node address in gossip and ends up being an equivalent amount of work.

Fixes #1208.
