### PR TITLE
regularly output some runtime stats

### DIFF
--- a/server/node.go
+++ b/server/node.go
@@ -557,7 +557,7 @@ func (n *Node) startRuntimeStats(stopper *util.Stopper) {
 				sPerc := float64(newStime-sTime) / dur
 				uTime = newUtime
 				sTime = newStime
-				log.Infof("runtime stats: %d goroutines, %.2fmb/%.2fmb/%.2fmb active/heap/total, %.2fcgo/sec, %.2f/%.2f (u/s)perc",
+				log.Infof("runtime stats: %d goroutines, %.2fmb/%.2fmb/%.2fmb active/heap/total, %.2fcgo/sec, %.2f/%.2f %%(u/s)time",
 					runtime.NumGoroutine(), activeMB, activeHeapMB, totalMB, cgoRate, uPerc, sPerc)
 				cgoCall += newCGOCall
 			}

--- a/util/log/structured.go
+++ b/util/log/structured.go
@@ -83,7 +83,6 @@ func setLogEntry(ctx context.Context, format string, args []interface{}, entry *
 
 // parseFormatWithArgs parses the format string, matching each
 // format specifier with an argument from the args array.
-// TODO(spencerkimball): support '%%' for a literal percent sign.
 func parseFormatWithArgs(format string, args []interface{}) (string, []proto.LogEntry_Arg) {
 	// Process format string.
 	var logArgs []proto.LogEntry_Arg
@@ -98,13 +97,22 @@ func parseFormatWithArgs(format string, args []interface{}) (string, []proto.Log
 		if i > lasti {
 			buf = append(buf, format[lasti:i]...)
 		}
+
 		if i >= end {
 			break
 		}
+
 		start := i
 
 		// Process one verb.
 		i++
+		// Make sure '%%' prints as a literal percent sign.
+		if format[i] == '%' {
+			buf = append(buf, '%', '%')
+			i++
+			continue
+		}
+
 	F:
 		for ; i < end; i++ {
 			switch format[i] {

--- a/util/log/structured.go
+++ b/util/log/structured.go
@@ -83,6 +83,7 @@ func setLogEntry(ctx context.Context, format string, args []interface{}, entry *
 
 // parseFormatWithArgs parses the format string, matching each
 // format specifier with an argument from the args array.
+// TODO(spencerkimball): support '%%' for a literal percent sign.
 func parseFormatWithArgs(format string, args []interface{}) (string, []proto.LogEntry_Arg) {
 	// Process format string.
 	var logArgs []proto.LogEntry_Arg

--- a/util/log/structured.go
+++ b/util/log/structured.go
@@ -106,12 +106,6 @@ func parseFormatWithArgs(format string, args []interface{}) (string, []proto.Log
 
 		// Process one verb.
 		i++
-		// Make sure '%%' prints as a literal percent sign.
-		if format[i] == '%' {
-			buf = append(buf, '%', '%')
-			i++
-			continue
-		}
 
 	F:
 		for ; i < end; i++ {
@@ -141,9 +135,9 @@ func parseFormatWithArgs(format string, args []interface{}) (string, []proto.Log
 		}
 		c, w := utf8.DecodeRuneInString(format[i:])
 		i += w
-		// Add percent directly to format buf.
+		// Escape and add percent directly to format buf.
 		if c == '%' {
-			buf = append(buf, '%')
+			buf = append(buf, '%', '%')
 			continue
 		}
 		buf = append(buf, "%s"...)


### PR DESCRIPTION
> I0601 18:53:20.283745   29093 node.go:544] runtime stats: 42 goroutines, 26.27mb active, 706.16mb total, 14719 cgo/second
