### PR TITLE
Add --range-max-bytes flag to control range size in tests.

### DIFF
--- a/acceptance/main_test.go
+++ b/acceptance/main_test.go
@@ -29,6 +29,7 @@ import (
 
 var duration = flag.Duration("d", 5*time.Second, "duration to run the test")
 var numNodes = flag.Int("num", 3, "the number of nodes to start (if not otherwise specified by a test)")
+var rangeMaxBytes = flag.Int64("range-max-bytes", 64<<20, "the maximum size of a range")
 var stopper = make(chan struct{})
 
 func TestMain(m *testing.M) {

--- a/acceptance/put_test.go
+++ b/acceptance/put_test.go
@@ -37,12 +37,9 @@ func TestPut(t *testing.T) {
 	l.Start()
 	defer l.Stop()
 
+	c := makeDBClient(t, l, 0)
+	setDefaultRangeMaxBytes(t, c, *rangeMaxBytes)
 	checkRangeReplication(t, l, 20*time.Second)
-
-	c, err := makeDBClient(l, 0)
-	if err != nil {
-		t.Fatal(err)
-	}
 
 	r, _ := util.NewPseudoRand()
 	value := util.RandBytes(r, 8192)

--- a/acceptance/replication_test.go
+++ b/acceptance/replication_test.go
@@ -48,10 +48,7 @@ func countRangeReplicas(client *client.DB) (int, error) {
 
 func checkRangeReplication(t *testing.T, cluster *localcluster.Cluster, d time.Duration) {
 	// Always talk to node 0.
-	client, err := makeDBClient(cluster, 0)
-	if err != nil {
-		t.Fatal(err)
-	}
+	client := makeDBClient(t, cluster, 0)
 
 	wantedReplicas := 3
 	if len(cluster.Nodes) < 3 {

--- a/acceptance/single_key_test.go
+++ b/acceptance/single_key_test.go
@@ -62,10 +62,7 @@ func TestSingleKey(t *testing.T) {
 
 	// Initialize the value for our test key to zero.
 	const key = "test-key"
-	c, err := makeDBClient(l, 0)
-	if err != nil {
-		t.Fatal(err)
-	}
+	c := makeDBClient(t, l, 0)
 	if _, err := c.Put(key, testVal(0)); err != nil {
 		t.Fatal(err)
 	}
@@ -84,12 +81,8 @@ func TestSingleKey(t *testing.T) {
 	// key. Each worker is configured to talk to a different node in the
 	// cluster.
 	for i := 0; i < *numNodes; i++ {
-		go func(i int) {
-			c, err := makeDBClient(l, i)
-			if err != nil {
-				resultCh <- result{err: err}
-				return
-			}
+		c := makeDBClient(t, l, i)
+		go func() {
 			var r result
 			for time.Now().Before(deadline) {
 				start := time.Now()
@@ -116,7 +109,7 @@ func TestSingleKey(t *testing.T) {
 				}
 			}
 			resultCh <- r
-		}(i)
+		}()
 	}
 
 	// Verify that none of the workers encountered an error.


### PR DESCRIPTION
Changed makeDBClient to take a testing.T instead of returning an error.
