### PR TITLE
Rename client.KVSender to client.Sender.

### DIFF
--- a/client/client_test.go
+++ b/client/client_test.go
@@ -51,7 +51,7 @@ import (
 // being sent.
 type notifyingSender struct {
 	waiter  *sync.WaitGroup
-	wrapped client.KVSender
+	wrapped client.Sender
 }
 
 func (ss *notifyingSender) reset(waiter *sync.WaitGroup) {
@@ -73,7 +73,7 @@ func (ss *notifyingSender) Send(ctx context.Context, call client.Call) {
 
 func (ss *notifyingSender) Close() {}
 
-func newNotifyingSender(wrapped client.KVSender) *notifyingSender {
+func newNotifyingSender(wrapped client.Sender) *notifyingSender {
 	return &notifyingSender{
 		wrapped: wrapped,
 	}

--- a/client/http_sender.go
+++ b/client/http_sender.go
@@ -47,7 +47,7 @@ const (
 )
 
 func init() {
-	f := func(u *url.URL, ctx *base.Context) (KVSender, error) {
+	f := func(u *url.URL, ctx *base.Context) (Sender, error) {
 		ctx.Insecure = (u.Scheme != "https")
 		return NewHTTPSender(u.Host, ctx)
 	}
@@ -71,7 +71,7 @@ var HTTPRetryOptions = retry.Options{
 	UseV1Info:   true,
 }
 
-// HTTPSender is an implementation of KVSender which exposes the
+// HTTPSender is an implementation of Sender which exposes the
 // Key-Value database provided by a Cockroach cluster by connecting
 // via HTTP to a Cockroach node. Overly-busy nodes will redirect
 // this client to other nodes.

--- a/client/kv.go
+++ b/client/kv.go
@@ -50,7 +50,7 @@ type KV struct {
 	// ignored.
 	UserPriority    int32
 	TxnRetryOptions retry.Options
-	Sender          KVSender
+	Sender          Sender
 	clock           Clock
 }
 
@@ -60,7 +60,7 @@ type KV struct {
 // formulate client command IDs, which provide idempotency on API
 // calls and defaults to the system clock.
 // implementation.
-func NewKV(ctx *Context, sender KVSender) *KV {
+func NewKV(ctx *Context, sender Sender) *KV {
 	if ctx == nil {
 		ctx = NewContext()
 	}

--- a/client/rpc/rpc_sender.go
+++ b/client/rpc/rpc_sender.go
@@ -33,7 +33,7 @@ import (
 )
 
 func init() {
-	f := func(u *url.URL, ctx *base.Context) (client.KVSender, error) {
+	f := func(u *url.URL, ctx *base.Context) (client.Sender, error) {
 		ctx.Insecure = (u.Scheme != "rpcs")
 		return NewSender(u.Host, ctx)
 	}
@@ -41,7 +41,7 @@ func init() {
 	client.RegisterSender("rpcs", f)
 }
 
-// Sender is an implementation of KVSender which exposes the
+// Sender is an implementation of Sender which exposes the
 // Key-Value database provided by a Cockroach cluster by connecting
 // via RPC to a Cockroach node. Overly-busy nodes will redirect this
 // client to other nodes.

--- a/client/sender.go
+++ b/client/sender.go
@@ -28,25 +28,25 @@ import (
 	"github.com/cockroachdb/cockroach/base"
 )
 
-// KVSender is an interface for sending a request to a Key-Value
+// Sender is an interface for sending a request to a Key-Value
 // database backend.
-type KVSender interface {
+type Sender interface {
 	// Send invokes the Call.Method with Call.Args and sets the result
 	// in Call.Reply.
 	Send(context.Context, Call)
 }
 
-// KVSenderFunc is an adapter to allow the use of ordinary functions
-// as KVSenders.
-type KVSenderFunc func(context.Context, Call)
+// SenderFunc is an adapter to allow the use of ordinary functions
+// as Senders.
+type SenderFunc func(context.Context, Call)
 
 // Send calls f(c).
-func (f KVSenderFunc) Send(ctx context.Context, c Call) {
+func (f SenderFunc) Send(ctx context.Context, c Call) {
 	f(ctx, c)
 }
 
 // NewSenderFunc creates a new sender for the registered scheme.
-type NewSenderFunc func(u *url.URL, ctx *base.Context) (KVSender, error)
+type NewSenderFunc func(u *url.URL, ctx *base.Context) (Sender, error)
 
 var sendersMu sync.Mutex
 var senders = map[string]NewSenderFunc{}
@@ -65,7 +65,7 @@ func RegisterSender(scheme string, f NewSenderFunc) {
 	senders[scheme] = f
 }
 
-func newSender(u *url.URL, ctx *base.Context) (KVSender, error) {
+func newSender(u *url.URL, ctx *base.Context) (Sender, error) {
 	sendersMu.Lock()
 	defer sendersMu.Unlock()
 	f := senders[u.Scheme]

--- a/client/txn.go
+++ b/client/txn.go
@@ -53,7 +53,7 @@ func (ts *txnSender) Send(ctx context.Context, call Call) {
 // A Txn instance is not thread safe.
 type Txn struct {
 	kv           KV
-	wrapped      KVSender
+	wrapped      Sender
 	txn          proto.Transaction
 	txnSender    txnSender
 	prepared     []Call

--- a/client/txn_test.go
+++ b/client/txn_test.go
@@ -39,7 +39,7 @@ func makeTS(walltime int64, logical int32) proto.Timestamp {
 	}
 }
 
-func newTestSender(handler func(Call)) KVSenderFunc {
+func newTestSender(handler func(Call)) SenderFunc {
 	return func(_ context.Context, call Call) {
 		header := call.Args.Header()
 		header.UserPriority = gogoproto.Int32(-1)

--- a/kv/db.go
+++ b/kv/db.go
@@ -90,11 +90,11 @@ func createArgsAndReply(method string) (proto.Request, proto.Response) {
 // A DBServer provides an HTTP server endpoint serving the key-value API.
 // It accepts either JSON or serialized protobuf content types.
 type DBServer struct {
-	sender client.KVSender
+	sender client.Sender
 }
 
 // NewDBServer allocates and returns a new DBServer.
-func NewDBServer(sender client.KVSender) *DBServer {
+func NewDBServer(sender client.Sender) *DBServer {
 	return &DBServer{sender: sender}
 }
 

--- a/kv/dist_sender.go
+++ b/kv/dist_sender.go
@@ -119,7 +119,7 @@ type DistSender struct {
 	rpcRetryOptions retry.Options
 }
 
-var _ client.KVSender = &DistSender{}
+var _ client.Sender = &DistSender{}
 
 // rpcSendFn is the function type used to dispatch RPC calls.
 type rpcSendFn func(rpc.Options, string, []net.Addr,
@@ -146,7 +146,7 @@ type DistSenderContext struct {
 	rangeDescriptorDB rangeDescriptorDB
 }
 
-// NewDistSender returns a client.KVSender instance which connects to the
+// NewDistSender returns a client.Sender instance which connects to the
 // Cockroach cluster via the supplied gossip instance. Supplying a
 // DistSenderContext or the fields within is optional. For omitted values, sane
 // defaults will be used.
@@ -480,7 +480,7 @@ func (ds *DistSender) sendRPC(raftID int64, replicas replicaSlice,
 	return err
 }
 
-// Send implements the client.KVSender interface. It verifies
+// Send implements the client.Sender interface. It verifies
 // permissions and looks up the appropriate range based on the
 // supplied key and sends the RPC according to the specified options.
 //

--- a/kv/local_sender.go
+++ b/kv/local_sender.go
@@ -35,7 +35,7 @@ type LocalSender struct {
 	storeMap map[proto.StoreID]*storage.Store // Map from StoreID to Store
 }
 
-var _ client.KVSender = &LocalSender{}
+var _ client.Sender = &LocalSender{}
 
 // NewLocalSender returns a local-only sender which directly accesses
 // a collection of stores.
@@ -114,7 +114,7 @@ func (ls *LocalSender) GetStoreIDs() []proto.StoreID {
 	return storeIDs
 }
 
-// Send implements the client.KVSender interface. The store is looked
+// Send implements the client.Sender interface. The store is looked
 // up from the store map if specified by header.Replica; otherwise,
 // the command is being executed locally, and the replica is
 // determined via lookup through each store's LookupRange method.

--- a/kv/txn_coord_sender_test.go
+++ b/kv/txn_coord_sender_test.go
@@ -468,7 +468,7 @@ type testSender struct {
 	handler func(call client.Call)
 }
 
-var _ client.KVSender = &testSender{}
+var _ client.Sender = &testSender{}
 
 func newTestSender(handler func(client.Call)) *testSender {
 	return &testSender{

--- a/storage/store_test.go
+++ b/storage/store_test.go
@@ -64,7 +64,7 @@ func setTestRetryOptions(s *Store) {
 	})
 }
 
-// testSender is an implementation of the client.KVSender interface
+// testSender is an implementation of the client.Sender interface
 // which passes all requests through to a single store.
 type testSender struct {
 	store *Store


### PR DESCRIPTION
The sender abstraction is not KV specific.
