### PR TITLE
Migrate part of the storage package from client.KV to client.DB.

### DIFF
--- a/client/db.go
+++ b/client/db.go
@@ -184,7 +184,7 @@ func Open(addr string) (*DB, error) {
 // Get retrieves one or more keys. Each requested key will have a corresponding
 // row in the returned Result.
 //
-//   r := db.Get("a", "b", "c")
+//   r, err := db.Get("a", "b", "c")
 //   // string(r.Rows[0].Key) == "a"
 //   // string(r.Rows[1].Key) == "b"
 //   // string(r.Rows[2].Key) == "c"
@@ -193,6 +193,19 @@ func Open(addr string) (*DB, error) {
 // encoding.BinaryMarshaler.
 func (db *DB) Get(keys ...interface{}) (Result, error) {
 	return runOne(db, db.B.Get(keys...))
+}
+
+// GetProto retrieves a single key/value and decodes the resulting value as a
+// proto message.
+//
+// key can be either a byte slice, a string, a fmt.Stringer or an
+// encoding.BinaryMarshaler.
+func (db *DB) GetProto(key interface{}, msg gogoproto.Message) error {
+	r, err := db.Get(key)
+	if err != nil {
+		return err
+	}
+	return r.Rows[0].ValueProto(msg)
 }
 
 // Put sets the value for a key.
@@ -352,7 +365,7 @@ func (tx *Tx) SetSnapshotIsolation() {
 // Get retrieves one or more keys. Each requested key will have a corresponding
 // row in the returned Result.
 //
-//   r := db.Get("a", "b", "c")
+//   r, err := db.Get("a", "b", "c")
 //   // string(r.Rows[0].Key) == "a"
 //   // string(r.Rows[1].Key) == "b"
 //   // string(r.Rows[2].Key) == "c"
@@ -616,7 +629,7 @@ func (b *Batch) InternalAddCall(call Call) {
 // Get retrieves one or more keys. A new result will be appended to the batch
 // and each requested key will have a corresponding row in the Result.
 //
-//   r := db.Get("a", "b", "c")
+//   r, err := db.Get("a", "b", "c")
 //   // string(r.Rows[0].Key) == "a"
 //   // string(r.Rows[1].Key) == "b"
 //   // string(r.Rows[2].Key) == "c"

--- a/storage/id_alloc_test.go
+++ b/storage/id_alloc_test.go
@@ -41,10 +41,10 @@ func TestIDAllocator(t *testing.T) {
 	store, _, stopper := createTestStore(t)
 	defer stopper.Stop()
 	allocd := make(chan int, 100)
-	idAlloc, err := NewIDAllocator(keys.RaftIDGenerator, store.ctx.DB,
+	idAlloc, err := newIDAllocator(keys.RaftIDGenerator, store.ctx.DB.NewDB(),
 		2, 10, stopper)
 	if err != nil {
-		t.Errorf("failed to create IDAllocator: %v", err)
+		t.Errorf("failed to create idAllocator: %v", err)
 	}
 
 	for i := 0; i < 10; i++ {
@@ -97,7 +97,7 @@ func TestIDAllocatorNegativeValue(t *testing.T) {
 	if newValue != -1024 {
 		t.Errorf("expected new value to be -1024; got %d", newValue)
 	}
-	idAlloc, err := NewIDAllocator(keys.RaftIDGenerator, store.ctx.DB, 2, 10, stopper)
+	idAlloc, err := newIDAllocator(keys.RaftIDGenerator, store.ctx.DB.NewDB(), 2, 10, stopper)
 	if err != nil {
 		t.Errorf("failed to create IDAllocator: %v", err)
 	}
@@ -110,7 +110,7 @@ func TestIDAllocatorNegativeValue(t *testing.T) {
 	}
 }
 
-// TestNewIDAllocatorInvalidArgs checks validation logic of NewIDAllocator.
+// TestNewIDAllocatorInvalidArgs checks validation logic of newIDAllocator.
 func TestNewIDAllocatorInvalidArgs(t *testing.T) {
 	defer leaktest.AfterTest(t)
 	args := [][]int64{
@@ -118,7 +118,7 @@ func TestNewIDAllocatorInvalidArgs(t *testing.T) {
 		{2, 0},  // blockSize < 1
 	}
 	for i := range args {
-		if _, err := NewIDAllocator(nil, nil, args[i][0], args[i][1], nil); err == nil {
+		if _, err := newIDAllocator(nil, nil, args[i][0], args[i][1], nil); err == nil {
 			t.Errorf("expect to have error return, but got nil")
 		}
 	}
@@ -137,7 +137,7 @@ func TestAllocateErrorAndRecovery(t *testing.T) {
 	allocd := make(chan int, 10)
 
 	// Firstly create a valid IDAllocator to get some ID.
-	idAlloc, err := NewIDAllocator(keys.RaftIDGenerator, store.ctx.DB, 2, 10, stopper)
+	idAlloc, err := newIDAllocator(keys.RaftIDGenerator, store.ctx.DB.NewDB(), 2, 10, stopper)
 	if err != nil {
 		t.Errorf("failed to create IDAllocator: %v", err)
 	}
@@ -211,7 +211,7 @@ func TestAllocateErrorAndRecovery(t *testing.T) {
 func TestAllocateWithStopper(t *testing.T) {
 	defer leaktest.AfterTest(t)
 	store, _, stopper := createTestStore(t)
-	idAlloc, err := NewIDAllocator(keys.RaftIDGenerator, store.ctx.DB, 2, 10, stopper)
+	idAlloc, err := newIDAllocator(keys.RaftIDGenerator, store.ctx.DB.NewDB(), 2, 10, stopper)
 	if err != nil {
 		log.Fatal(err)
 	}

--- a/storage/split_queue.go
+++ b/storage/split_queue.go
@@ -44,9 +44,9 @@ type splitQueue struct {
 }
 
 // newSplitQueue returns a new instance of splitQueue.
-func newSplitQueue(db *client.KV, gossip *gossip.Gossip) *splitQueue {
+func newSplitQueue(db *client.DB, gossip *gossip.Gossip) *splitQueue {
 	sq := &splitQueue{
-		db:     db.NewDB(),
+		db:     db,
 		gossip: gossip,
 	}
 	sq.baseQueue = newBaseQueue("split", sq, splitQueueMaxSize)

--- a/storage/store_test.go
+++ b/storage/store_test.go
@@ -156,11 +156,13 @@ func createTestStoreWithoutStart(t *testing.T) (*Store, *hlc.ManualClock, *util.
 	eng := engine.NewInMem(proto.Attributes{}, 10<<20)
 	ctx.Transport = multiraft.NewLocalRPCTransport()
 	stopper.AddCloser(ctx.Transport)
+	sender := &testSender{}
+	ctx.DB = client.NewKV(nil, sender)
 	store := NewStore(ctx, eng, &proto.NodeDescriptor{NodeID: 1})
+	sender.store = store
 	if err := store.Bootstrap(proto.StoreIdent{NodeID: 1, StoreID: 1}, stopper); err != nil {
 		t.Fatal(err)
 	}
-	store.ctx.DB = client.NewKV(nil, &testSender{store: store})
 	if err := store.BootstrapRange(); err != nil {
 		t.Fatal(err)
 	}


### PR DESCRIPTION
Added client.DB.GetProto() helper method to address a common pattern.
