### PR TITLE
send only to leader; adjust leader caching

### DIFF
--- a/kv/dist_sender.go
+++ b/kv/dist_sender.go
@@ -562,12 +562,6 @@ func (ds *DistSender) Send(_ context.Context, call client.Call) {
 				}
 
 				rpcErr = ds.sendRPC(desc.RaftID, replicas, order, args, reply)
-				err = rpcErr
-			}
-
-			// If the RPC went through fine, an error (if any) is in the reply.
-			if err == nil {
-				err = reply.Header().GoError()
 			}
 
 			// For an RPC error to occur, we've must've been unable to contact
@@ -587,6 +581,8 @@ func (ds *DistSender) Send(_ context.Context, call client.Call) {
 					ds.rangeCache.EvictCachedRangeDescriptor(args.Header().Key, desc)
 				}
 			}
+
+			err = util.FirstError(err, rpcErr, reply.Header().GoError())
 
 			if err != nil {
 				if log.V(1) {

--- a/kv/dist_sender.go
+++ b/kv/dist_sender.go
@@ -287,7 +287,7 @@ func (ds *DistSender) internalRangeLookup(key proto.Key, options lookupOptions,
 	}
 	reply := &proto.InternalRangeLookupResponse{}
 	replicas := newReplicaSlice(ds.gossip, desc)
-	if err := ds.sendRPC(desc.RaftID, replicas, args, reply); err != nil {
+	if err := ds.sendRPC(desc.RaftID, replicas, rpc.OrderRandom, args, reply); err != nil {
 		return nil, err
 	}
 	if reply.Error != nil {
@@ -396,26 +396,10 @@ func (ds *DistSender) getNodeDescriptor() *proto.NodeDescriptor {
 // server must succeed. Returns an RPC error if the request could not be sent.
 // Note that the reply may contain a higher level error and must be checked in
 // addition to the RPC error.
-func (ds *DistSender) sendRPC(raftID int64, replicas replicaSlice,
+func (ds *DistSender) sendRPC(raftID int64, replicas replicaSlice, order rpc.OrderingPolicy,
 	args proto.Request, reply proto.Response) error {
 	if len(replicas) == 0 {
 		return util.Errorf("%s: replicas set is empty", args.Method())
-	}
-
-	// Rearrange the replicas so that those replicas with long common
-	// prefix of attributes end up first. If there's no prefix, this is a
-	// no-op.
-	order := ds.optimizeReplicaOrder(replicas)
-
-	// If this request needs to go to a leader and we know who that is, move
-	// it to the front and send requests in order.
-	if !(proto.IsRead(args) && args.Header().ReadConsistency == proto.INCONSISTENT) {
-		if leader := ds.leaderCache.Lookup(proto.RaftID(raftID)); leader != nil {
-			if i := replicas.FindReplica(leader.StoreID); i >= 0 {
-				replicas.MoveToFront(i)
-				order = rpc.OrderStable
-			}
-		}
 	}
 
 	// Build a slice of replica addresses (if gossiped).
@@ -527,6 +511,10 @@ func (ds *DistSender) Send(_ context.Context, call client.Call) {
 			reply.Header().Reset()
 			descNext = nil
 			desc, err := ds.rangeCache.LookupRangeDescriptor(args.Header().Key, options)
+			var leader proto.Replica
+			if err == nil {
+				leader = ds.leaderCache.Lookup(proto.RaftID(desc.RaftID))
+			}
 
 			// If the request accesses keys beyond the end of this range,
 			// get the descriptor of the adjacent range to address next.
@@ -555,7 +543,25 @@ func (ds *DistSender) Send(_ context.Context, call client.Call) {
 			var replicas replicaSlice
 			if err == nil {
 				replicas = newReplicaSlice(ds.gossip, desc)
-				rpcErr = ds.sendRPC(desc.RaftID, replicas, args, reply)
+
+				// Rearrange the replicas so that those replicas with long common
+				// prefix of attributes end up first. If there's no prefix, this is a
+				// no-op.
+				order := ds.optimizeReplicaOrder(replicas)
+
+				// If this request needs to go to a leader and we know who that is, move
+				// it to the front and make it our single replica to send to.
+				// This allows us to special-case this when an RPC error comes back.
+				if !(proto.IsRead(args) && args.Header().ReadConsistency == proto.INCONSISTENT) &&
+					leader.StoreID > 0 {
+					if i := replicas.FindReplica(leader.StoreID); i >= 0 {
+						replicas.MoveToFront(i)
+						replicas = replicas[:1]
+						order = rpc.OrderStable
+					}
+				}
+
+				rpcErr = ds.sendRPC(desc.RaftID, replicas, order, args, reply)
 				err = rpcErr
 			}
 
@@ -565,20 +571,21 @@ func (ds *DistSender) Send(_ context.Context, call client.Call) {
 			}
 
 			// For an RPC error to occur, we've must've been unable to contact
-			// any replicas. In this case, likely all nodes are down; this
-			// should really only happen if either the replica set is dead or
+			// any replicas. In this case, either
+			// - we sent only to a leader or
+			// - all nodes are down.
+			// The second case only happens if either the replica set is dead or
 			// we have an old descriptor which does not have a list of current
 			// nodes; we hope it's the latter.
-			// TODO(tschottdorf): individual rpc calls always return an
-			// rpcError, which is always retriable. Thus, rpc.Send will always
-			// return retriable errors if everything is unreachable. That seems
-			// awkward; rpcError should probably not be retriable (rpc.Send
-			// will still succeed if it manages to talk to *anyone*), and
-			// then we can clear the cache here only for retriable errors.
-			// It amounts to the same situations though.
+			// In the first case, we update the leader cache only.
 			if rpcErr != nil {
-				ds.updateLeaderCache(proto.RaftID(desc.RaftID), proto.Replica{})
-				ds.rangeCache.EvictCachedRangeDescriptor(args.Header().Key, desc)
+				if len(replicas) == 1 && replicas[0].StoreID == leader.StoreID {
+					log.Warningf("RPC error to leader %d; expiring cache", leader.StoreID)
+					ds.updateLeaderCache(proto.RaftID(desc.RaftID), proto.Replica{})
+				} else {
+					log.Warningf("RPC error; expiring cached descriptor")
+					ds.rangeCache.EvictCachedRangeDescriptor(args.Header().Key, desc)
+				}
 			}
 
 			if err != nil {
@@ -589,22 +596,25 @@ func (ds *DistSender) Send(_ context.Context, call client.Call) {
 				// If retryable, allow retry. For range not found or range
 				// key mismatch errors, we don't backoff on the retry,
 				// but reset the backoff loop so we can retry immediately.
-				switch err.(type) {
+				switch tErr := err.(type) {
 				case *proto.RangeNotFoundError, *proto.RangeKeyMismatchError:
 					// Range descriptor might be out of date - evict it.
 					ds.rangeCache.EvictCachedRangeDescriptor(args.Header().Key, desc)
 					// On addressing errors, don't backoff; retry immediately.
 					return retry.Reset, nil
 				case *proto.NotLeaderError:
-					leader := err.(*proto.NotLeaderError).GetLeader()
-					if leader != nil {
-						// First, verify that leader is a known replica; if not,
-						// we've got a stale replica; evict cache and store leader.
-						if i := replicas.FindReplica(leader.StoreID); i == -1 {
+					newLeader := tErr.GetLeader()
+					// Verify that leader is a known replica; if not,
+					// we've got a stale replica; evict cache.
+					// Next, cache the new leader.
+					if newLeader != nil {
+						if i := replicas.FindReplica(newLeader.StoreID); i == -1 {
 							ds.rangeCache.EvictCachedRangeDescriptor(args.Header().Key, desc)
 						}
-						ds.updateLeaderCache(proto.RaftID(desc.RaftID), *leader)
+					} else {
+						newLeader = &proto.Replica{}
 					}
+					ds.updateLeaderCache(proto.RaftID(desc.RaftID), *newLeader)
 					return retry.Reset, nil
 				default:
 					if retryErr, ok := err.(util.Retryable); ok && retryErr.CanRetry() {
@@ -665,24 +675,11 @@ func (ds *DistSender) Send(_ context.Context, call client.Call) {
 
 // updateLeaderCache updates the cached leader for the given Raft group,
 // evicting any previous value in the process.
-// The new leader is cached only if it isn't equal to the newly evicted value.
 func (ds *DistSender) updateLeaderCache(rid proto.RaftID, leader proto.Replica) {
-	// Slight overhead here since we want to make sure that when the new
-	// proposed leader equals the old, we only evict so that the next call
-	// picks a random replica, avoiding getting stuck in a loop.
 	oldLeader := ds.leaderCache.Lookup(rid)
-	ds.leaderCache.Update(rid, proto.Replica{})
-	if oldLeader != nil {
+	if leader.StoreID != oldLeader.StoreID {
 		if log.V(1) {
-			log.Infof("raft %d: evicted cached leader %d", rid, oldLeader.StoreID)
-		}
-	}
-	if leader.StoreID == 0 {
-		return
-	}
-	if oldLeader == nil || leader.StoreID != oldLeader.StoreID {
-		if log.V(1) {
-			log.Infof("raft %d: new cached leader %d", rid, leader.StoreID)
+			log.Infof("raft %d: new cached leader store %d (old: %d)", rid, leader.StoreID, oldLeader.StoreID)
 		}
 		ds.leaderCache.Update(rid, leader)
 	}

--- a/kv/dist_sender_test.go
+++ b/kv/dist_sender_test.go
@@ -730,3 +730,20 @@ func TestSendRPCRetry(t *testing.T) {
 		t.Fatalf("expected 1 row; got %d", l)
 	}
 }
+
+// TestGetNodeDescriptor checks that the Node descriptor automatically gets
+// looked up from Gossip.
+func TestGetNodeDescriptor(t *testing.T) {
+	g := makeTestGossip(t)
+	ds := NewDistSender(&DistSenderContext{}, g)
+	if err := g.SetNodeDescriptor(&proto.NodeDescriptor{NodeID: 5}); err != nil {
+		t.Fatal(err)
+	}
+	util.SucceedsWithin(t, time.Second, func() error {
+		desc := ds.getNodeDescriptor()
+		if desc != nil && desc.NodeID == 5 {
+			return nil
+		}
+		return util.Errorf("wanted NodeID 5, got %v", desc)
+	})
+}

--- a/kv/leader_cache.go
+++ b/kv/leader_cache.go
@@ -47,14 +47,14 @@ func newLeaderCache(size int) *leaderCache {
 
 // Lookup consults the cache for the replica cached as the leader of
 // the given Raft consensus group.
-func (lc *leaderCache) Lookup(group proto.RaftID) *proto.Replica {
+func (lc *leaderCache) Lookup(group proto.RaftID) proto.Replica {
 	lc.mu.Lock()
 	defer lc.mu.Unlock()
 	v, ok := lc.cache.Get(group)
-	if !ok {
-		return nil
+	if !ok || v == nil {
+		return proto.Replica{}
 	}
-	return v.(*proto.Replica)
+	return *(v.(*proto.Replica))
 }
 
 // Update invalidates the cached leader for the given Raft group.

--- a/kv/range_cache.go
+++ b/kv/range_cache.go
@@ -175,7 +175,7 @@ func (rmc *rangeDescriptorCache) EvictCachedRangeDescriptor(descKey proto.Key, s
 			log.Infof("evict cached descriptor: key=%s desc=%s\n%s", descKey, cachedDesc, rmc.stringLocked())
 		}
 		if log.V(1) {
-			log.Infof("evict cached descriptor: key=%s desc=%s\n%s", descKey, cachedDesc)
+			log.Infof("evict cached descriptor: key=%s desc=%s", descKey, cachedDesc)
 		}
 		rmc.rangeCache.Del(rngKey)
 

--- a/util/error.go
+++ b/util/error.go
@@ -65,3 +65,14 @@ func ErrorSkipFrames(skip int, a ...interface{}) error {
 	}
 	return fmt.Errorf("%s", fmt.Sprint(a...))
 }
+
+// FirstError returns the first of its arguments which is not nil (or nil if
+// they all are).
+func FirstError(errs ...error) error {
+	for _, err := range errs {
+		if err != nil {
+			return err
+		}
+	}
+	return nil
+}


### PR DESCRIPTION
change inspired by actual events testing with the bank example under impossibly high contention under which requests time out all the time.
- remove the mechanism for removing a cached leader upon
  caching the same leader twice in a row: silly idea, obviously
  concurrent request going to the wrong leader will return
  almost simultaneously and expire the freshly updated cache.
- send RPCs only to the leader if the request HAS to go to it.
  the upshot of this is that if an RPC error comes back, we know
  fairly certainly that the leader is dead, and we expire it only then.
- moved the replica optimization from ds.sendRPC to ds.Send (necessary
  for this change) and reworked/upgraded associated tests.
