### PR TITLE
Add client.DB.InternalKV().

### DIFF
--- a/client/db.go
+++ b/client/db.go
@@ -181,6 +181,11 @@ func Open(addr string) (*DB, error) {
 	return &DB{kv: kv}, nil
 }
 
+// InternalKV returns the internal KV. It is intended for internal use only.
+func (db *DB) InternalKV() *KV {
+	return db.kv
+}
+
 // Get retrieves one or more keys. Each requested key will have a corresponding
 // row in the returned Result.
 //
@@ -286,8 +291,9 @@ func (db *DB) DelRange(begin, end interface{}) (Result, error) {
 //
 // key can be either a byte slice, a string, a fmt.Stringer or an
 // encoding.BinaryMarshaler.
-func (db *DB) AdminMerge(key interface{}) (Result, error) {
-	return runOne(db, (&Batch{}).adminMerge(key))
+func (db *DB) AdminMerge(key interface{}) error {
+	_, err := runOne(db, (&Batch{}).adminMerge(key))
+	return err
 }
 
 // AdminSplit splits the range containing key. If splitKey is non-nil it
@@ -296,8 +302,9 @@ func (db *DB) AdminMerge(key interface{}) (Result, error) {
 //
 // key can be either a byte slice, a string, a fmt.Stringer or an
 // encoding.BinaryMarshaler.
-func (db *DB) AdminSplit(key, splitKey interface{}) (Result, error) {
-	return runOne(db, (&Batch{}).adminSplit(key, splitKey))
+func (db *DB) AdminSplit(key, splitKey interface{}) error {
+	_, err := runOne(db, (&Batch{}).adminSplit(key, splitKey))
+	return err
 }
 
 // Run executes the operations queued up within a batch. Before executing any

--- a/kv/rest.go
+++ b/kv/rest.go
@@ -69,11 +69,11 @@ const (
 // an underlying key-value store.
 type RESTServer struct {
 	router *httprouter.Router
-	db     *client.KV // Key-value database client
+	db     *client.DB // Key-value database client
 }
 
 // NewRESTServer allocates and returns a new server.
-func NewRESTServer(db *client.KV) *RESTServer {
+func NewRESTServer(db *client.DB) *RESTServer {
 	server := &RESTServer{
 		router: httprouter.New(),
 		db:     db,
@@ -171,14 +171,14 @@ func (s *RESTServer) handleRangeAction(w http.ResponseWriter, r *http.Request, _
 			scanReq.MaxResults = limit
 		}
 		results = &proto.ScanResponse{}
-		err = s.db.Run(client.Call{Args: scanReq, Reply: results})
+		err = s.db.InternalKV().Run(client.Call{Args: scanReq, Reply: results})
 	} else if r.Method == methodDelete {
 		deleteReq := &proto.DeleteRangeRequest{RequestHeader: reqHeader}
 		if limit > 0 {
 			deleteReq.MaxEntriesToDelete = limit
 		}
 		results = &proto.DeleteRangeResponse{}
-		err = s.db.Run(client.Call{Args: deleteReq, Reply: results})
+		err = s.db.InternalKV().Run(client.Call{Args: deleteReq, Reply: results})
 	}
 	if err != nil {
 		http.Error(w, err.Error(), http.StatusInternalServerError)
@@ -208,7 +208,7 @@ func (s *RESTServer) handleCounterAction(w http.ResponseWriter, r *http.Request,
 	}
 
 	ir := &proto.IncrementResponse{}
-	if err := s.db.Run(client.Call{
+	if err := s.db.InternalKV().Run(client.Call{
 		Args: &proto.IncrementRequest{
 			RequestHeader: proto.RequestHeader{
 				Key:  key,
@@ -233,7 +233,7 @@ func (s *RESTServer) handlePutAction(w http.ResponseWriter, r *http.Request, ps 
 	}
 	defer r.Body.Close()
 	pr := &proto.PutResponse{}
-	if err := s.db.Run(client.Call{
+	if err := s.db.InternalKV().Run(client.Call{
 		Args: &proto.PutRequest{
 			RequestHeader: proto.RequestHeader{
 				Key:  key,
@@ -252,7 +252,7 @@ func (s *RESTServer) handlePutAction(w http.ResponseWriter, r *http.Request, ps 
 func (s *RESTServer) handleGetAction(w http.ResponseWriter, r *http.Request, ps httprouter.Params) {
 	key := proto.Key(ps.ByName("key"))
 	gr := &proto.GetResponse{}
-	if err := s.db.Run(client.Call{
+	if err := s.db.InternalKV().Run(client.Call{
 		Args: &proto.GetRequest{
 			RequestHeader: proto.RequestHeader{
 				Key:  key,
@@ -274,7 +274,7 @@ func (s *RESTServer) handleGetAction(w http.ResponseWriter, r *http.Request, ps 
 func (s *RESTServer) handleHeadAction(w http.ResponseWriter, r *http.Request, ps httprouter.Params) {
 	key := proto.Key(ps.ByName("key"))
 	cr := &proto.ContainsResponse{}
-	if err := s.db.Run(client.Call{
+	if err := s.db.InternalKV().Run(client.Call{
 		Args: &proto.ContainsRequest{
 			RequestHeader: proto.RequestHeader{
 				Key:  key,
@@ -295,7 +295,7 @@ func (s *RESTServer) handleHeadAction(w http.ResponseWriter, r *http.Request, ps
 func (s *RESTServer) handleDeleteAction(w http.ResponseWriter, r *http.Request, ps httprouter.Params) {
 	key := proto.Key(ps.ByName("key"))
 	dr := &proto.DeleteResponse{}
-	if err := s.db.Run(client.Call{
+	if err := s.db.InternalKV().Run(client.Call{
 		Args: &proto.DeleteRequest{
 			RequestHeader: proto.RequestHeader{
 				Key:  key,

--- a/kv/txn_correctness_test.go
+++ b/kv/txn_correctness_test.go
@@ -622,7 +622,7 @@ func checkConcurrency(name string, isolations []proto.IsolationType, txns []stri
 	s := createTestDB(t)
 	defer s.Stop()
 	setCorrectnessRetryOptions(s.lSender)
-	verifier.run(isolations, s.KV, t)
+	verifier.run(isolations, s.DB.InternalKV(), t)
 }
 
 // The following tests for concurrency anomalies include documentation

--- a/server/admin_test.go
+++ b/server/admin_test.go
@@ -39,11 +39,11 @@ import (
 // Cockroach KV client address is set to the address of the test server.
 func startAdminServer() (string, *util.Stopper) {
 	stopper := util.NewStopper()
-	kv, err := BootstrapCluster("cluster-1", []engine.Engine{engine.NewInMem(proto.Attributes{}, 1<<20)}, stopper)
+	db, err := BootstrapCluster("cluster-1", []engine.Engine{engine.NewInMem(proto.Attributes{}, 1<<20)}, stopper)
 	if err != nil {
 		log.Fatal(err)
 	}
-	admin := newAdminServer(kv.NewDB(), stopper)
+	admin := newAdminServer(db, stopper)
 	mux := http.NewServeMux()
 	admin.registerHandlers(mux)
 	httpServer := httptest.NewTLSServer(mux)

--- a/server/cli/range.go
+++ b/server/cli/range.go
@@ -104,7 +104,7 @@ func runSplitRange(cmd *cobra.Command, args []string) {
 	if kvDB == nil {
 		return
 	}
-	if _, err := kvDB.AdminSplit(key, splitKey); err != nil {
+	if err := kvDB.AdminSplit(key, splitKey); err != nil {
 		fmt.Fprintf(os.Stderr, "split failed: %s\n", err)
 		osExit(1)
 	}
@@ -130,7 +130,7 @@ func runMergeRange(cmd *cobra.Command, args []string) {
 	if kvDB == nil {
 		return
 	}
-	if _, err := kvDB.AdminMerge(args[0]); err != nil {
+	if err := kvDB.AdminMerge(args[0]); err != nil {
 		fmt.Fprintf(os.Stderr, "merge failed: %s\n", err)
 		osExit(1)
 	}

--- a/server/server_test.go
+++ b/server/server_test.go
@@ -307,14 +307,7 @@ func TestMultiRangeScanDeleteRange(t *testing.T) {
 	ds := kv.NewDistSender(&kv.DistSenderContext{Clock: s.Clock()}, s.Gossip())
 	tds := kv.NewTxnCoordSender(ds, s.Clock(), testContext.Linearizable, s.stopper)
 
-	if err := s.node.ctx.DB.Run(client.Call{
-		Args: &proto.AdminSplitRequest{
-			RequestHeader: proto.RequestHeader{
-				Key: proto.Key("m"),
-			},
-			SplitKey: proto.Key("m"),
-		},
-		Reply: &proto.AdminSplitResponse{}}); err != nil {
+	if err := s.node.ctx.DB.AdminSplit("m", "m"); err != nil {
 		t.Fatal(err)
 	}
 	writes := []proto.Key{proto.Key("a"), proto.Key("z")}
@@ -416,14 +409,7 @@ func TestMultiRangeScanWithMaxResults(t *testing.T) {
 		tds := kv.NewTxnCoordSender(ds, s.Clock(), testContext.Linearizable, s.stopper)
 
 		for _, sk := range tc.splitKeys {
-			if err := s.node.ctx.DB.Run(client.Call{
-				Args: &proto.AdminSplitRequest{
-					RequestHeader: proto.RequestHeader{
-						Key: sk,
-					},
-					SplitKey: sk,
-				},
-				Reply: &proto.AdminSplitResponse{}}); err != nil {
+			if err := s.node.ctx.DB.AdminSplit(sk, sk); err != nil {
 				t.Fatal(err)
 			}
 		}

--- a/server/status/feed_test.go
+++ b/server/status/feed_test.go
@@ -25,10 +25,9 @@ import (
 
 	"github.com/cockroachdb/cockroach/client"
 	"github.com/cockroachdb/cockroach/proto"
+	"github.com/cockroachdb/cockroach/security"
 	"github.com/cockroachdb/cockroach/server"
 	"github.com/cockroachdb/cockroach/server/status"
-	"github.com/cockroachdb/cockroach/storage"
-	"github.com/cockroachdb/cockroach/testutils"
 	"github.com/cockroachdb/cockroach/util"
 	"github.com/cockroachdb/cockroach/util/leaktest"
 )
@@ -225,12 +224,11 @@ func TestServerNodeEventFeed(t *testing.T) {
 		ner.readEvents(sub)
 	})
 
-	sender, err := client.NewHTTPSender(s.ServingAddr(), testutils.NewTestBaseContext())
+	db, err := client.Open("https://root@" + s.ServingAddr() + "?certs=" + security.EmbeddedCertsDir)
 	if err != nil {
 		t.Fatal(err)
 	}
-	kv := client.NewKV(nil, sender)
-	kv.User = storage.UserRoot
+	kv := db.InternalKV()
 
 	// Add some data in a transaction
 	err = kv.RunTransaction(nil, func(txn *client.Txn) error {

--- a/storage/addressing_test.go
+++ b/storage/addressing_test.go
@@ -127,7 +127,7 @@ func TestUpdateRangeAddressing(t *testing.T) {
 				t.Fatal(err)
 			}
 		}
-		if err := store.DB().Run(calls...); err != nil {
+		if err := store.DB().InternalKV().Run(calls...); err != nil {
 			t.Fatal(err)
 		}
 		// Scan meta keys directly from engine.

--- a/storage/client_merge_test.go
+++ b/storage/client_merge_test.go
@@ -235,7 +235,8 @@ func TestStoreRangeMergeNonConsecutive(t *testing.T) {
 	// resolve intents.  If intents are left unresolved then the
 	// asynchronous resolution may happen after the call to RemoveRange
 	// below, reviving the range and breaking the test.
-	if err := store.DB().Run(client.Scan(keys.LocalMax, keys.SystemMax, 1000)); err != nil {
+	kv := store.DB().InternalKV()
+	if err := kv.Run(client.Scan(keys.LocalMax, keys.SystemMax, 1000)); err != nil {
 		t.Fatal(err)
 	}
 

--- a/storage/client_range_tree_test.go
+++ b/storage/client_range_tree_test.go
@@ -120,8 +120,7 @@ func treesEqual(db *client.DB, expected testRangeTree) error {
 
 // splitRange splits whichever range contains the key on that key.
 func splitRange(db *client.DB, key proto.Key) error {
-	_, err := db.AdminSplit(key, key)
-	return err
+	return db.AdminSplit(key, key)
 }
 
 // TestSetupRangeTree ensures that SetupRangeTree correctly setups up the range
@@ -146,8 +145,7 @@ func TestSetupRangeTree(t *testing.T) {
 		Tree:  tree,
 		Nodes: nodes,
 	}
-	db := store.DB().NewDB()
-	if err := treesEqual(db, expectedTree); err != nil {
+	if err := treesEqual(store.DB(), expectedTree); err != nil {
 		t.Fatal(err)
 	}
 }
@@ -158,7 +156,7 @@ func TestInsertRight(t *testing.T) {
 	defer leaktest.AfterTest(t)
 	store, stopper := createTestStore(t)
 	defer stopper.Stop()
-	db := store.DB().NewDB()
+	db := store.DB()
 
 	keyA := proto.Key("a")
 	keyB := proto.Key("b")
@@ -373,7 +371,7 @@ func TestInsertLeft(t *testing.T) {
 	defer leaktest.AfterTest(t)
 	store, stopper := createTestStore(t)
 	defer stopper.Stop()
-	db := store.DB().NewDB()
+	db := store.DB()
 
 	keyE := proto.Key("e")
 	keyD := proto.Key("d")
@@ -645,7 +643,7 @@ func TestRandomSplits(t *testing.T) {
 	defer leaktest.AfterTest(t)
 	store, stopper := createTestStore(t)
 	defer stopper.Stop()
-	db := store.DB().NewDB()
+	db := store.DB()
 	rng, seed := util.NewPseudoRand()
 	t.Logf("using pseudo random number generator with seed %d", seed)
 

--- a/storage/gc_queue.go
+++ b/storage/gc_queue.go
@@ -272,7 +272,8 @@ func (gcq *gcQueue) resolveIntent(rng *Range, key proto.Key, meta *proto.MVCCMet
 		PushType:  proto.ABORT_TXN,
 	}
 	pushReply := &proto.InternalPushTxnResponse{}
-	if err := rng.rm.DB().Run(client.Call{Args: pushArgs, Reply: pushReply}); err != nil {
+	kv := rng.rm.DB().InternalKV()
+	if err := kv.Run(client.Call{Args: pushArgs, Reply: pushReply}); err != nil {
 		log.Warningf("push of txn %s failed: %s", meta.Txn, err)
 		updateOldestIntent(meta.Timestamp.WallTime)
 		return

--- a/storage/id_alloc_test.go
+++ b/storage/id_alloc_test.go
@@ -41,8 +41,7 @@ func TestIDAllocator(t *testing.T) {
 	store, _, stopper := createTestStore(t)
 	defer stopper.Stop()
 	allocd := make(chan int, 100)
-	idAlloc, err := newIDAllocator(keys.RaftIDGenerator, store.ctx.DB.NewDB(),
-		2, 10, stopper)
+	idAlloc, err := newIDAllocator(keys.RaftIDGenerator, store.ctx.DB, 2, 10, stopper)
 	if err != nil {
 		t.Errorf("failed to create idAllocator: %v", err)
 	}
@@ -97,7 +96,7 @@ func TestIDAllocatorNegativeValue(t *testing.T) {
 	if newValue != -1024 {
 		t.Errorf("expected new value to be -1024; got %d", newValue)
 	}
-	idAlloc, err := newIDAllocator(keys.RaftIDGenerator, store.ctx.DB.NewDB(), 2, 10, stopper)
+	idAlloc, err := newIDAllocator(keys.RaftIDGenerator, store.ctx.DB, 2, 10, stopper)
 	if err != nil {
 		t.Errorf("failed to create IDAllocator: %v", err)
 	}
@@ -137,7 +136,7 @@ func TestAllocateErrorAndRecovery(t *testing.T) {
 	allocd := make(chan int, 10)
 
 	// Firstly create a valid IDAllocator to get some ID.
-	idAlloc, err := newIDAllocator(keys.RaftIDGenerator, store.ctx.DB.NewDB(), 2, 10, stopper)
+	idAlloc, err := newIDAllocator(keys.RaftIDGenerator, store.ctx.DB, 2, 10, stopper)
 	if err != nil {
 		t.Errorf("failed to create IDAllocator: %v", err)
 	}
@@ -211,7 +210,7 @@ func TestAllocateErrorAndRecovery(t *testing.T) {
 func TestAllocateWithStopper(t *testing.T) {
 	defer leaktest.AfterTest(t)
 	store, _, stopper := createTestStore(t)
-	idAlloc, err := newIDAllocator(keys.RaftIDGenerator, store.ctx.DB.NewDB(), 2, 10, stopper)
+	idAlloc, err := newIDAllocator(keys.RaftIDGenerator, store.ctx.DB, 2, 10, stopper)
 	if err != nil {
 		log.Fatal(err)
 	}

--- a/storage/range.go
+++ b/storage/range.go
@@ -164,7 +164,7 @@ type rangeManager interface {
 	RaftNodeID() proto.RaftNodeID
 	Clock() *hlc.Clock
 	Engine() engine.Engine
-	DB() *client.KV
+	DB() *client.DB
 	allocator() *allocator
 	Gossip() *gossip.Gossip
 	splitQueue() *splitQueue

--- a/storage/range_command.go
+++ b/storage/range_command.go
@@ -835,7 +835,8 @@ func (r *Range) AdminSplit(args *proto.AdminSplitRequest, reply *proto.AdminSpli
 	txnOpts := &client.TransactionOptions{
 		Name: fmt.Sprintf("split range %d at %s", desc.RaftID, splitKey),
 	}
-	if err = r.rm.DB().RunTransaction(txnOpts, func(txn *client.Txn) error {
+	kv := r.rm.DB().InternalKV()
+	if err = kv.RunTransaction(txnOpts, func(txn *client.Txn) error {
 		// Create range descriptor for second half of split.
 		// Note that this put must go first in order to locate the
 		// transaction record on the correct range.
@@ -1004,7 +1005,8 @@ func (r *Range) AdminMerge(args *proto.AdminMergeRequest, reply *proto.AdminMerg
 	txnOpts := &client.TransactionOptions{
 		Name: fmt.Sprintf("merge range %d into %d", subsumedDesc.RaftID, desc.RaftID),
 	}
-	if err := r.rm.DB().RunTransaction(txnOpts, func(txn *client.Txn) error {
+	kv := r.rm.DB().InternalKV()
+	if err := kv.RunTransaction(txnOpts, func(txn *client.Txn) error {
 		// Update the range descriptor for the receiving range.
 		desc1Key := keys.RangeDescriptorKey(updatedDesc.StartKey)
 		txn.Prepare(updateRangeDescriptorCall(desc1Key, desc, &updatedDesc))
@@ -1136,7 +1138,8 @@ func (r *Range) ChangeReplicas(changeType proto.ReplicaChangeType, replica proto
 	txnOpts := &client.TransactionOptions{
 		Name: fmt.Sprintf("change replicas of %d", desc.RaftID),
 	}
-	err := r.rm.DB().RunTransaction(txnOpts, func(txn *client.Txn) error {
+	kv := r.rm.DB().InternalKV()
+	err := kv.RunTransaction(txnOpts, func(txn *client.Txn) error {
 		// Important: the range descriptor must be the first thing touched in the transaction
 		// so the transaction record is co-located with the range being modified.
 		descKey := keys.RangeDescriptorKey(updatedDesc.StartKey)

--- a/storage/range_test.go
+++ b/storage/range_test.go
@@ -149,7 +149,7 @@ func (tc *testContext) Start(t testing.TB) {
 		// circular dependency between the test sender and the store. The actual
 		// store will be passed to the sender after it is created and bootstrapped.
 		sender := &testSender{}
-		ctx.DB = client.NewKV(nil, sender)
+		ctx.DB = client.NewKV(nil, sender).NewDB()
 		tc.store = NewStore(ctx, tc.engine, &proto.NodeDescriptor{NodeID: 1})
 		if err := tc.store.Bootstrap(proto.StoreIdent{
 			ClusterID: "test",

--- a/storage/split_queue.go
+++ b/storage/split_queue.go
@@ -89,7 +89,7 @@ func (sq *splitQueue) process(now proto.Timestamp, rng *Range) error {
 	if len(splitKeys) > 0 {
 		log.Infof("splitting %s at keys %v", rng, splitKeys)
 		for _, splitKey := range splitKeys {
-			if _, err := sq.db.AdminSplit(splitKey, splitKey); err != nil {
+			if err := sq.db.AdminSplit(splitKey, splitKey); err != nil {
 				return util.Errorf("unable to split %s at key %q: %s", rng, splitKey, err)
 			}
 		}

--- a/storage/store_test.go
+++ b/storage/store_test.go
@@ -157,7 +157,7 @@ func createTestStoreWithoutStart(t *testing.T) (*Store, *hlc.ManualClock, *util.
 	ctx.Transport = multiraft.NewLocalRPCTransport()
 	stopper.AddCloser(ctx.Transport)
 	sender := &testSender{}
-	ctx.DB = client.NewKV(nil, sender)
+	ctx.DB = client.NewKV(nil, sender).NewDB()
 	store := NewStore(ctx, eng, &proto.NodeDescriptor{NodeID: 1})
 	sender.store = store
 	if err := store.Bootstrap(proto.StoreIdent{NodeID: 1, StoreID: 1}, stopper); err != nil {

--- a/structured/db_test.go
+++ b/structured/db_test.go
@@ -35,11 +35,11 @@ func TestPutGetDeleteSchema(t *testing.T) {
 	stopper := util.NewStopper()
 	defer stopper.Stop()
 	e := engine.NewInMem(proto.Attributes{}, 1<<20)
-	localKV, err := server.BootstrapCluster("test-cluster", []engine.Engine{e}, stopper)
+	localDB, err := server.BootstrapCluster("test-cluster", []engine.Engine{e}, stopper)
 	if err != nil {
 		t.Fatalf("unable to boostrap cluster: %v", err)
 	}
-	db := structured.NewDB(localKV.NewDB())
+	db := structured.NewDB(localDB)
 	if err := db.PutSchema(s); err != nil {
 		t.Fatalf("could not register schema: %v", err)
 	}

--- a/ts/db_test.go
+++ b/ts/db_test.go
@@ -66,7 +66,7 @@ func newTestModel(t *testing.T) *testModel {
 // time series DB.
 func (tm *testModel) Start() {
 	tm.LocalTestCluster.Start(tm.t)
-	tm.DB = NewDB(tm.KV.NewDB())
+	tm.DB = NewDB(tm.LocalTestCluster.DB)
 }
 
 // getActualData returns the actual value of all time series keys in the


### PR DESCRIPTION
Convert many structures from internally holding a client.KV to holding a
client.DB. This gives client.DB primacy in much of the code base.
