### PR TITLE
Add file logging to acceptance tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,16 @@
 .#*
 *.test
 
+# Log Files
+*.ERROR
+*.ERROR.*
+*.INFO
+*.INFO.*
+*.WARNING
+*.WARNING.*
+*.FATAL
+*.FATAL.*
+
 # Folders
 _obj
 _test

--- a/util/log/flags.go
+++ b/util/log/flags.go
@@ -29,5 +29,5 @@ func init() {
 	// pf.Var(&logging.stderrThreshold, "log-threshold", "logs at or above this threshold go to stderr")
 	flag.Var(&logging.vmodule, "vmodule", "comma-separated list of file=N settings for file-filtered logging")
 	flag.Var(&logging.traceLocation, "log-backtrace-at", "when logging hits line file:N, emit a stack trace")
-	logDir = flag.String("log-dir", "", "if non-empty, write log files in this directory") // in clog_file.go
+	flag.StringVar(logDir, "log-dir", "", "if non-empty, write log files in this directory") // in util/log/file.go
 }


### PR DESCRIPTION
With this change, you can specify a local directory to keep the logs from the acceptance test.
- Also fix a small issue with the logDir flag.
- Also make sure the log files get ignored by git.
