### PR TITLE
Unexport HTTPSender and NewHTTPSender.

### DIFF
--- a/client/doc.go
+++ b/client/doc.go
@@ -29,7 +29,7 @@ The simplest way to use the client is through the Run method. Run
 synchronously invokes the call and fills in the the reply and returns
 an error. The example below shows a get and a put.
 
-  kv := client.NewKV(nil, client.NewHTTPSender("localhost:8080", httpClient))
+  kv := client.NewKV(nil, client.newHTTPSender("localhost:8080", httpClient))
 
   getCall := client.Get(proto.Key("a"))
   getResp := getCall.Reply.(*proto.GetResponse)
@@ -49,7 +49,7 @@ used to guarantee atomicity. A simple example of using the API which
 does two scans in parallel and then sends a sequence of puts in
 parallel:
 
-  kv := client.NewKV(nil, client.NewHTTPSender("localhost:8080", httpClient))
+  kv := client.NewKV(nil, client.newHTTPSender("localhost:8080", httpClient))
 
   acScan := client.Scan(proto.Key("a"), proto.Key("c\x00"), 1000)
   xzScan := client.Scan(proto.Key("x"), proto.Key("z\x00"), 1000)
@@ -88,7 +88,7 @@ given necessary transactional details, and conflicts are handled with
 backoff/retry loops and transaction restarts as necessary. An example
 of using transactions with parallel writes:
 
-  kv := client.NewKV(nil, client.NewHTTPSender("localhost:8080", httpClient))
+  kv := client.NewKV(nil, client.newHTTPSender("localhost:8080", httpClient))
 
   opts := &client.TransactionOptions{Name: "test", Isolation: proto.SERIALIZABLE}
   err := kv.RunTransaction(opts, func(txn *client.Txn) error {

--- a/client/http_sender_test.go
+++ b/client/http_sender_test.go
@@ -75,7 +75,7 @@ func TestHTTPSenderSend(t *testing.T) {
 	}))
 	defer server.Close()
 
-	sender, err := NewHTTPSender(addr, testutils.NewTestBaseContext())
+	sender, err := newHTTPSender(addr, testutils.NewTestBaseContext())
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -130,7 +130,7 @@ func TestHTTPSenderRetryResponseCodes(t *testing.T) {
 			w.Write(body)
 		}))
 
-		sender, err := NewHTTPSender(addr, testutils.NewTestBaseContext())
+		sender, err := newHTTPSender(addr, testutils.NewTestBaseContext())
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -191,7 +191,7 @@ func TestHTTPSenderRetryHTTPSendError(t *testing.T) {
 		}))
 
 		s = server
-		sender, err := NewHTTPSender(addr, testutils.NewTestBaseContext())
+		sender, err := newHTTPSender(addr, testutils.NewTestBaseContext())
 		if err != nil {
 			t.Fatal(err)
 		}

--- a/kv/db_test.go
+++ b/kv/db_test.go
@@ -26,21 +26,18 @@ import (
 	"github.com/cockroachdb/cockroach/client"
 	"github.com/cockroachdb/cockroach/kv"
 	"github.com/cockroachdb/cockroach/proto"
-	"github.com/cockroachdb/cockroach/storage"
-	"github.com/cockroachdb/cockroach/testutils"
+	"github.com/cockroachdb/cockroach/security"
 	"github.com/cockroachdb/cockroach/util"
 	gogoproto "github.com/gogo/protobuf/proto"
 	yaml "gopkg.in/yaml.v1"
 )
 
 func createTestClient(t *testing.T, addr string) *client.KV {
-	httpSender, err := client.NewHTTPSender(addr, testutils.NewTestBaseContext())
+	db, err := client.Open("https://root@" + addr + "?certs=" + security.EmbeddedCertsDir)
 	if err != nil {
 		t.Fatal(err)
 	}
-	context := client.NewContext()
-	context.User = storage.UserRoot
-	return client.NewKV(context, httpSender)
+	return db.InternalKV()
 }
 
 // TestKVDBCoverage verifies that all methods may be invoked on the


### PR DESCRIPTION
Yes, the client package docs are quite out of date.

See #997.
