### PR TITLE
Unexport client.HTTPRetryOptions.

### DIFF
--- a/client/http_sender.go
+++ b/client/http_sender.go
@@ -61,9 +61,9 @@ type httpSendError struct {
 	error
 }
 
-// HTTPRetryOptions sets the retry options for handling retryable
+// httpRetryOptions sets the retry options for handling retryable
 // HTTP errors and connection I/O errors.
-var HTTPRetryOptions = retry.Options{
+var httpRetryOptions = retry.Options{
 	Backoff:     50 * time.Millisecond,
 	MaxBackoff:  5 * time.Second,
 	Constant:    2,
@@ -104,7 +104,7 @@ func newHTTPSender(server string, ctx *base.Context) (*httpSender, error) {
 // through with the same client command ID and be given the cached
 // response.
 func (s *httpSender) Send(_ context.Context, call Call) {
-	retryOpts := HTTPRetryOptions
+	retryOpts := httpRetryOptions
 	retryOpts.Tag = fmt.Sprintf("%s %s", s.context.RequestScheme(), call.Method())
 
 	if err := retry.WithBackoff(retryOpts, func() (retry.Status, error) {

--- a/client/http_sender_test.go
+++ b/client/http_sender_test.go
@@ -92,7 +92,7 @@ func TestHTTPSenderSend(t *testing.T) {
 // TestHTTPSenderRetryResponseCodes verifies that send is retried
 // on some HTTP response codes but not on others.
 func TestHTTPSenderRetryResponseCodes(t *testing.T) {
-	HTTPRetryOptions.Backoff = 1 * time.Millisecond
+	httpRetryOptions.Backoff = 1 * time.Millisecond
 
 	testCases := []struct {
 		code  int
@@ -158,7 +158,7 @@ func TestHTTPSenderRetryResponseCodes(t *testing.T) {
 // TestHTTPSenderRetryHTTPSendError verifies that send is retried
 // on all errors sending HTTP requests.
 func TestHTTPSenderRetryHTTPSendError(t *testing.T) {
-	HTTPRetryOptions.Backoff = 1 * time.Millisecond
+	httpRetryOptions.Backoff = 1 * time.Millisecond
 
 	testCases := []func(*httptest.Server, http.ResponseWriter){
 		// Send back an unparseable response but a success code on first try.


### PR DESCRIPTION
Fix an inaccurate copy&pasted comment.
