### PR TITLE
Change admin split command to only take the split key

### DIFF
--- a/client/db.go
+++ b/client/db.go
@@ -296,14 +296,12 @@ func (db *DB) AdminMerge(key interface{}) error {
 	return err
 }
 
-// AdminSplit splits the range containing key. If splitKey is non-nil it
-// specifies the key to split the range at, otherwise an appropriate key is
-// chosen automatically.
+// AdminSplit splits the range at splitkey.
 //
 // key can be either a byte slice, a string, a fmt.Stringer or an
 // encoding.BinaryMarshaler.
-func (db *DB) AdminSplit(key, splitKey interface{}) error {
-	_, err := runOne(db, (&Batch{}).adminSplit(key, splitKey))
+func (db *DB) AdminSplit(splitKey interface{}) error {
+	_, err := runOne(db, (&Batch{}).adminSplit(splitKey))
 	return err
 }
 
@@ -820,8 +818,8 @@ func (b *Batch) adminMerge(key interface{}) *Batch {
 
 // adminSplit is only exported on DB. It is here for symmetry with the
 // other operations.
-func (b *Batch) adminSplit(key, splitKey interface{}) *Batch {
-	k, err := marshalKey(key)
+func (b *Batch) adminSplit(splitKey interface{}) *Batch {
+	k, err := marshalKey(splitKey)
 	if err != nil {
 		b.initResult(0, 0, err)
 		return b
@@ -831,14 +829,7 @@ func (b *Batch) adminSplit(key, splitKey interface{}) *Batch {
 			Key: proto.Key(k),
 		},
 	}
-	if splitKey != nil {
-		ak, err := marshalKey(splitKey)
-		if err != nil {
-			b.initResult(0, 0, err)
-			return b
-		}
-		req.SplitKey = proto.Key(ak)
-	}
+	req.SplitKey = proto.Key(k)
 	resp := &proto.AdminSplitResponse{}
 	b.calls = append(b.calls, Call{Args: req, Reply: resp})
 	b.initResult(1, 0, nil)

--- a/kv/split_test.go
+++ b/kv/split_test.go
@@ -116,7 +116,7 @@ func TestRangeSplitsWithConcurrentTxns(t *testing.T) {
 			<-txnChannel
 		}
 		log.Infof("starting split at key %q...", splitKey)
-		if err := s.DB.AdminSplit(splitKey, splitKey); err != nil {
+		if err := s.DB.AdminSplit(splitKey); err != nil {
 			t.Fatal(err)
 		}
 		log.Infof("split at key %q complete", splitKey)
@@ -198,14 +198,14 @@ func TestRangeSplitsWithSameKeyTwice(t *testing.T) {
 
 	splitKey := proto.Key("aa")
 	log.Infof("starting split at key %q...", splitKey)
-	if err := s.DB.AdminSplit("a", splitKey); err != nil {
+	if err := s.DB.AdminSplit(splitKey); err != nil {
 		t.Fatal(err)
 	}
 	log.Infof("split at key %q first time complete", splitKey)
 	ch := make(chan error)
 	go func() {
 		// should return error other than infinite loop
-		ch <- s.DB.AdminSplit("a", splitKey)
+		ch <- s.DB.AdminSplit(splitKey)
 	}()
 
 	select {

--- a/server/cli/cli_test.go
+++ b/server/cli/cli_test.go
@@ -167,7 +167,7 @@ func ExampleSplitMergeRanges() {
 
 	c.Run("kv put a 1 b 2 c 3 d 4")
 	c.Run("kv scan")
-	c.Run("range split c c")
+	c.Run("range split c")
 	c.Run("range ls")
 	c.Run("kv scan")
 	c.Run("range merge b")
@@ -182,7 +182,7 @@ func ExampleSplitMergeRanges() {
 	// "b"	"2"
 	// "c"	"3"
 	// "d"	"4"
-	// range split c c
+	// range split c
 	// range ls
 	// ""-"c" [1]
 	// 	0: node-id=1 store-id=1

--- a/server/cli/range.go
+++ b/server/cli/range.go
@@ -81,7 +81,7 @@ var splitRangeCmd = &cobra.Command{
 	Use:   "split [options] <key>",
 	Short: "splits a range",
 	Long: `
-Splits the range containing at <key>.
+Splits the range containing <key> at <key>.
 `,
 	Run: runSplitRange,
 }

--- a/server/cli/range.go
+++ b/server/cli/range.go
@@ -78,33 +78,26 @@ func runLsRanges(cmd *cobra.Command, args []string) {
 
 // A splitRangeCmd command splits a range.
 var splitRangeCmd = &cobra.Command{
-	Use:   "split [options] <key> [<split-key>]",
+	Use:   "split [options] <key>",
 	Short: "splits a range",
 	Long: `
-Splits the range containing <key>. If <split-key> is not specified a
-key to split the range approximately in half will be automatically
-chosen.
+Splits the range containing at <key>.
 `,
 	Run: runSplitRange,
 }
 
 func runSplitRange(cmd *cobra.Command, args []string) {
-	if len(args) == 0 || len(args) > 2 {
+	if len(args) != 1 {
 		cmd.Usage()
 		return
 	}
 
 	key := proto.Key(args[0])
-	var splitKey proto.Key
-	if len(args) >= 2 {
-		splitKey = proto.Key(args[1])
-	}
-
 	kvDB := makeDBClient()
 	if kvDB == nil {
 		return
 	}
-	if err := kvDB.AdminSplit(key, splitKey); err != nil {
+	if err := kvDB.AdminSplit(key); err != nil {
 		fmt.Fprintf(os.Stderr, "split failed: %s\n", err)
 		osExit(1)
 	}

--- a/server/server_test.go
+++ b/server/server_test.go
@@ -307,7 +307,7 @@ func TestMultiRangeScanDeleteRange(t *testing.T) {
 	ds := kv.NewDistSender(&kv.DistSenderContext{Clock: s.Clock()}, s.Gossip())
 	tds := kv.NewTxnCoordSender(ds, s.Clock(), testContext.Linearizable, s.stopper)
 
-	if err := s.node.ctx.DB.AdminSplit("m", "m"); err != nil {
+	if err := s.node.ctx.DB.AdminSplit("m"); err != nil {
 		t.Fatal(err)
 	}
 	writes := []proto.Key{proto.Key("a"), proto.Key("z")}
@@ -409,7 +409,7 @@ func TestMultiRangeScanWithMaxResults(t *testing.T) {
 		tds := kv.NewTxnCoordSender(ds, s.Clock(), testContext.Linearizable, s.stopper)
 
 		for _, sk := range tc.splitKeys {
-			if err := s.node.ctx.DB.AdminSplit(sk, sk); err != nil {
+			if err := s.node.ctx.DB.AdminSplit(sk); err != nil {
 				t.Fatal(err)
 			}
 		}

--- a/storage/client_event_test.go
+++ b/storage/client_event_test.go
@@ -167,12 +167,12 @@ func TestMultiStoreEventFeed(t *testing.T) {
 	}
 
 	// AdminSplit in between the two ranges.
-	if err := mtc.db.AdminSplit("b", "b"); err != nil {
+	if err := mtc.db.AdminSplit("b"); err != nil {
 		t.Fatalf("error splitting initial: %s", err)
 	}
 
 	// AdminSplit an empty range at the end of the second range.
-	if err := mtc.db.AdminSplit("z", "z"); err != nil {
+	if err := mtc.db.AdminSplit("z"); err != nil {
 		t.Fatalf("error splitting second range: %s", err)
 	}
 

--- a/storage/client_range_tree_test.go
+++ b/storage/client_range_tree_test.go
@@ -120,7 +120,7 @@ func treesEqual(db *client.DB, expected testRangeTree) error {
 
 // splitRange splits whichever range contains the key on that key.
 func splitRange(db *client.DB, key proto.Key) error {
-	return db.AdminSplit(key, key)
+	return db.AdminSplit(key)
 }
 
 // TestSetupRangeTree ensures that SetupRangeTree correctly setups up the range

--- a/storage/split_queue.go
+++ b/storage/split_queue.go
@@ -89,7 +89,7 @@ func (sq *splitQueue) process(now proto.Timestamp, rng *Range) error {
 	if len(splitKeys) > 0 {
 		log.Infof("splitting %s at keys %v", rng, splitKeys)
 		for _, splitKey := range splitKeys {
-			if err := sq.db.AdminSplit(splitKey, splitKey); err != nil {
+			if err := sq.db.AdminSplit(splitKey); err != nil {
 				return util.Errorf("unable to split %s at key %q: %s", rng, splitKey, err)
 			}
 		}


### PR DESCRIPTION
The "key" arg was only really needed to find the range. Beyond that, people manually splitting ranges will usually have a specific split key in mind and won't want automatic split determination.
