### PR TITLE
Added per-sender retry options.

### DIFF
--- a/client/db.go
+++ b/client/db.go
@@ -155,6 +155,8 @@ func SenderOpt(sender Sender) Option {
 	}
 }
 
+// TODO(pmattis): Allow setting the sender/txn retry options.
+
 // Open creates a new database handle to the cockroach cluster specified by
 // addr. The cluster is identified by a URL with the format:
 //

--- a/client/http_sender_test.go
+++ b/client/http_sender_test.go
@@ -75,7 +75,7 @@ func TestHTTPSenderSend(t *testing.T) {
 	}))
 	defer server.Close()
 
-	sender, err := newHTTPSender(addr, testutils.NewTestBaseContext())
+	sender, err := newHTTPSender(addr, testutils.NewTestBaseContext(), defaultRetryOptions)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -92,7 +92,8 @@ func TestHTTPSenderSend(t *testing.T) {
 // TestHTTPSenderRetryResponseCodes verifies that send is retried
 // on some HTTP response codes but not on others.
 func TestHTTPSenderRetryResponseCodes(t *testing.T) {
-	httpRetryOptions.Backoff = 1 * time.Millisecond
+	retryOptions := defaultRetryOptions
+	retryOptions.Backoff = 1 * time.Millisecond
 
 	testCases := []struct {
 		code  int
@@ -130,7 +131,7 @@ func TestHTTPSenderRetryResponseCodes(t *testing.T) {
 			w.Write(body)
 		}))
 
-		sender, err := newHTTPSender(addr, testutils.NewTestBaseContext())
+		sender, err := newHTTPSender(addr, testutils.NewTestBaseContext(), retryOptions)
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -158,7 +159,8 @@ func TestHTTPSenderRetryResponseCodes(t *testing.T) {
 // TestHTTPSenderRetryHTTPSendError verifies that send is retried
 // on all errors sending HTTP requests.
 func TestHTTPSenderRetryHTTPSendError(t *testing.T) {
-	httpRetryOptions.Backoff = 1 * time.Millisecond
+	retryOptions := defaultRetryOptions
+	retryOptions.Backoff = 1 * time.Millisecond
 
 	testCases := []func(*httptest.Server, http.ResponseWriter){
 		// Send back an unparseable response but a success code on first try.
@@ -191,7 +193,7 @@ func TestHTTPSenderRetryHTTPSendError(t *testing.T) {
 		}))
 
 		s = server
-		sender, err := newHTTPSender(addr, testutils.NewTestBaseContext())
+		sender, err := newHTTPSender(addr, testutils.NewTestBaseContext(), retryOptions)
 		if err != nil {
 			t.Fatal(err)
 		}


### PR DESCRIPTION
The default retry options are now passed to the sender creation function
which allowed for the de-duplication of client.httpRetryOptions and
client/rpc.retryOptions.
