### PR TITLE
break down DistSender.Send

### DIFF
--- a/kv/dist_sender_test.go
+++ b/kv/dist_sender_test.go
@@ -116,6 +116,9 @@ func TestSendRPCOrder(t *testing.T) {
 			}
 			var actualAddrs []int32
 			for i, a := range addrs {
+				if len(expAddrs) <= i {
+					return util.Errorf("got unexpected address: %s", a)
+				}
 				if expAddrs[i] == 0 {
 					actualAddrs = append(actualAddrs, 0)
 				} else {
@@ -130,10 +133,11 @@ func TestSendRPCOrder(t *testing.T) {
 	}
 
 	testCases := []struct {
-		args   proto.Request
-		attrs  []string
-		fn     func(rpc.Options, []net.Addr) error
-		leader int32 // 0 for not caching a leader.
+		args       proto.Request
+		attrs      []string
+		order      rpc.OrderingPolicy
+		expReplica []int32
+		leader     int32 // 0 for not caching a leader.
 		// Naming is somewhat off, as eventually consistent reads usually
 		// do not have to go to the leader when a node has a read lease.
 		// Would really want CONSENSUS here, but that is not implemented.
@@ -143,9 +147,10 @@ func TestSendRPCOrder(t *testing.T) {
 	}{
 		// Inconsistent Scan without matching attributes.
 		{
-			args:  &proto.ScanRequest{},
-			attrs: []string{},
-			fn:    makeVerifier(rpc.OrderRandom, []int32{1, 2, 3, 4, 5}),
+			args:       &proto.ScanRequest{},
+			attrs:      []string{},
+			order:      rpc.OrderRandom,
+			expReplica: []int32{1, 2, 3, 4, 5},
 		},
 		// Inconsistent Scan with matching attributes.
 		// Should move the two nodes matching the attributes to the front and
@@ -153,8 +158,9 @@ func TestSendRPCOrder(t *testing.T) {
 		{
 			args:  &proto.ScanRequest{},
 			attrs: nodeAttrs[5],
+			order: rpc.OrderStable,
 			// Compare only the first two resulting addresses.
-			fn: makeVerifier(rpc.OrderStable, []int32{5, 4, 0, 0, 0}),
+			expReplica: []int32{5, 4, 0, 0, 0},
 		},
 
 		// Scan without matching attributes that requires but does not find
@@ -162,15 +168,17 @@ func TestSendRPCOrder(t *testing.T) {
 		{
 			args:       &proto.ScanRequest{},
 			attrs:      []string{},
-			fn:         makeVerifier(rpc.OrderRandom, []int32{1, 2, 3, 4, 5}),
+			order:      rpc.OrderRandom,
+			expReplica: []int32{1, 2, 3, 4, 5},
 			consistent: true,
 		},
 		// Put without matching attributes that requires but does not find leader.
 		// Should go random and not change anything.
 		{
-			args:  &proto.PutRequest{},
-			attrs: []string{"nomatch"},
-			fn:    makeVerifier(rpc.OrderRandom, []int32{1, 2, 3, 4, 5}),
+			args:       &proto.PutRequest{},
+			attrs:      []string{"nomatch"},
+			order:      rpc.OrderRandom,
+			expReplica: []int32{1, 2, 3, 4, 5},
 		},
 		// Put with matching attributes but no leader.
 		// Should move the two nodes matching the attributes to the front and
@@ -179,19 +187,35 @@ func TestSendRPCOrder(t *testing.T) {
 			args:  &proto.PutRequest{},
 			attrs: append(nodeAttrs[5], "irrelevant"),
 			// Compare only the first two resulting addresses.
-			fn: makeVerifier(rpc.OrderStable, []int32{5, 4, 0, 0, 0}),
+			order:      rpc.OrderStable,
+			expReplica: []int32{5, 4, 0, 0, 0},
 		},
-
 		// Put with matching attributes that finds the leader (node 3).
 		// Should address the leader and the two nodes matching the attributes
 		// (the last and second to last) in that order.
 		{
 			args:  &proto.PutRequest{},
 			attrs: append(nodeAttrs[5], "irrelevant"),
-			// Compare only the first three resulting addresses.
-			fn:     makeVerifier(rpc.OrderStable, []int32{2, 5, 4, 0, 0}),
-			leader: 2,
+			// Compare only the first resulting addresses as we have a leader
+			// and that means we're only trying to send there.
+			order:      rpc.OrderStable,
+			expReplica: []int32{2, 5, 4, 0, 0},
+			leader:     2,
 		},
+		// Inconsistent Get without matching attributes but leader (node 3). Should just
+		// go random as the leader does not matter.
+		{
+			args:       &proto.GetRequest{},
+			attrs:      []string{},
+			order:      rpc.OrderRandom,
+			expReplica: []int32{1, 2, 3, 4, 5},
+			leader:     2,
+		},
+	}
+
+	descriptor := proto.RangeDescriptor{
+		RaftID:   raftID,
+		Replicas: nil,
 	}
 
 	// Stub to be changed in each test case.
@@ -208,18 +232,16 @@ func TestSendRPCOrder(t *testing.T) {
 
 	ctx := &DistSenderContext{
 		rpcSend: testFn,
+		rangeDescriptorDB: mockRangeDescriptorDB(func(proto.Key, lookupOptions) ([]proto.RangeDescriptor, error) {
+			return []proto.RangeDescriptor{descriptor}, nil
+		}),
 	}
 
 	ds := NewDistSender(ctx, g)
 
 	for n, tc := range testCases {
-		verifyCall = tc.fn
-		// We don't need to do all of it for each test case, but we need the
-		// replica slice so might as well do it all.
-		descriptor := proto.RangeDescriptor{
-			RaftID:   raftID,
-			Replicas: nil,
-		}
+		verifyCall = makeVerifier(tc.order, tc.expReplica)
+		descriptor.Replicas = nil // could do this once above, but more convenient here
 		for i := int32(1); i <= 5; i++ {
 			addr := util.MakeUnresolvedAddr("tcp", fmt.Sprintf("node%d", i))
 			addrToNode[addr.String()] = i
@@ -236,7 +258,6 @@ func TestSendRPCOrder(t *testing.T) {
 			if err := g.AddInfo(gossip.MakeNodeIDKey(proto.NodeID(i)), nd, time.Hour); err != nil {
 				t.Fatal(err)
 			}
-
 			descriptor.Replicas = append(descriptor.Replicas, proto.Replica{
 				NodeID:  proto.NodeID(i),
 				StoreID: proto.StoreID(i),
@@ -268,8 +289,9 @@ func TestSendRPCOrder(t *testing.T) {
 		}
 		// Kill the cached NodeDescriptor, enforcing a lookup from Gossip.
 		ds.nodeDescriptor = nil
-		replicas := newReplicaSlice(ds.gossip, &descriptor)
-		if err := ds.sendRPC(descriptor.RaftID, replicas, args, args.CreateReply()); err != nil {
+		call := client.Call{Args: args, Reply: args.CreateReply()}
+		ds.Send(context.Background(), call)
+		if err := call.Reply.Header().GoError(); err != nil {
 			t.Errorf("%d: %s", n, err)
 		}
 	}
@@ -295,7 +317,7 @@ func TestRetryOnNotLeaderError(t *testing.T) {
 		if first {
 			reply := getReply()
 			reply.(proto.Response).Header().SetGoError(
-				&proto.NotLeaderError{Leader: &leader})
+				&proto.NotLeaderError{Leader: &leader, Replica: &proto.Replica{}})
 			first = false
 			return []interface{}{reply}, nil
 		}
@@ -318,13 +340,9 @@ func TestRetryOnNotLeaderError(t *testing.T) {
 	if first {
 		t.Errorf("The command did not retry")
 	}
-	if cur := ds.leaderCache.Lookup(1); !reflect.DeepEqual(cur, &leader) {
+	if cur := ds.leaderCache.Lookup(1); cur.StoreID != leader.StoreID {
 		t.Errorf("leader cache was not updated: expected %v, got %v",
 			&leader, cur)
-	}
-	ds.updateLeaderCache(1, leader)
-	if ds.leaderCache.Lookup(1) != nil {
-		t.Errorf("update with same replica did not evict the cache")
 	}
 }
 
@@ -701,4 +719,21 @@ func TestSendRPCRetry(t *testing.T) {
 	if l := len(sr.Rows); l != 1 {
 		t.Fatalf("expected 1 row; got %d", l)
 	}
+}
+
+// TestGetNodeDescriptor checks that the Node descriptor automatically gets
+// looked up from Gossip.
+func TestGetNodeDescriptor(t *testing.T) {
+	g := makeTestGossip(t)
+	ds := NewDistSender(&DistSenderContext{}, g)
+	if err := g.SetNodeDescriptor(&proto.NodeDescriptor{NodeID: 5}); err != nil {
+		t.Fatal(err)
+	}
+	util.SucceedsWithin(t, time.Second, func() error {
+		desc := ds.getNodeDescriptor()
+		if desc != nil && desc.NodeID == 5 {
+			return nil
+		}
+		return util.Errorf("wanted NodeID 5, got %v", desc)
+	})
 }

--- a/kv/leader_cache.go
+++ b/kv/leader_cache.go
@@ -47,14 +47,14 @@ func newLeaderCache(size int) *leaderCache {
 
 // Lookup consults the cache for the replica cached as the leader of
 // the given Raft consensus group.
-func (lc *leaderCache) Lookup(group proto.RaftID) *proto.Replica {
+func (lc *leaderCache) Lookup(group proto.RaftID) proto.Replica {
 	lc.mu.Lock()
 	defer lc.mu.Unlock()
 	v, ok := lc.cache.Get(group)
-	if !ok {
-		return nil
+	if !ok || v == nil {
+		return proto.Replica{}
 	}
-	return v.(*proto.Replica)
+	return *(v.(*proto.Replica))
 }
 
 // Update invalidates the cached leader for the given Raft group.

--- a/kv/range_cache.go
+++ b/kv/range_cache.go
@@ -175,7 +175,7 @@ func (rmc *rangeDescriptorCache) EvictCachedRangeDescriptor(descKey proto.Key, s
 			log.Infof("evict cached descriptor: key=%s desc=%s\n%s", descKey, cachedDesc, rmc.stringLocked())
 		}
 		if log.V(1) {
-			log.Infof("evict cached descriptor: key=%s desc=%s\n%s", descKey, cachedDesc)
+			log.Infof("evict cached descriptor: key=%s desc=%s", descKey, cachedDesc)
 		}
 		rmc.rangeCache.Del(rngKey)
 

--- a/proto/api.pb.go
+++ b/proto/api.pb.go
@@ -162,7 +162,10 @@ type RequestHeader struct {
 	// The key for request. If the request operates on a range, this
 	// represents the starting key for the range.
 	Key Key `protobuf:"bytes,3,opt,name=key,customtype=Key" json:"key"`
-	// End key is empty if request spans only a single key.
+	// The end key is empty if the request spans only a single key. Otherwise,
+	// it must order strictly after Key. In such a case, the header indicates
+	// that the operation takes place on the key range from Key to EndKey,
+	// including Key and excluding EndKey.
 	EndKey Key `protobuf:"bytes,4,opt,name=end_key,customtype=Key" json:"end_key"`
 	// User is the originating user. Used to lookup priority when
 	// scheduling queued operations at target node.

--- a/proto/api.proto
+++ b/proto/api.proto
@@ -79,7 +79,10 @@ message RequestHeader {
   // The key for request. If the request operates on a range, this
   // represents the starting key for the range.
   optional bytes key = 3 [(gogoproto.nullable) = false, (gogoproto.customtype) = "Key"];
-  // End key is empty if request spans only a single key.
+  // The end key is empty if the request spans only a single key. Otherwise,
+  // it must order strictly after Key. In such a case, the header indicates
+  // that the operation takes place on the key range from Key to EndKey,
+  // including Key and excluding EndKey.
   optional bytes end_key = 4 [(gogoproto.nullable) = false, (gogoproto.customtype) = "Key"];
   // User is the originating user. Used to lookup priority when
   // scheduling queued operations at target node.

--- a/server/server_test.go
+++ b/server/server_test.go
@@ -403,7 +403,7 @@ func TestMultiRangeScanWithMaxResults(t *testing.T) {
 				proto.Key("r"), proto.Key("w"), proto.Key("y")}},
 	}
 
-	for _, tc := range testCases {
+	for i, tc := range testCases {
 		s := StartTestServer(t)
 		ds := kv.NewDistSender(&kv.DistSenderContext{Clock: s.Clock()}, s.Gossip())
 		tds := kv.NewTxnCoordSender(ds, s.Clock(), testContext.Linearizable, s.stopper)
@@ -438,9 +438,9 @@ func TestMultiRangeScanWithMaxResults(t *testing.T) {
 				}
 				rows := scan.Reply.(*proto.ScanResponse).Rows
 				if start+maxResults <= len(tc.keys) && len(rows) != maxResults {
-					t.Fatalf("expected %d rows, but got %d", maxResults, len(rows))
+					t.Fatalf("%d: start=%s: expected %d rows, but got %d", i, tc.keys[start], maxResults, len(rows))
 				} else if start+maxResults == len(tc.keys)+1 && len(rows) != maxResults-1 {
-					t.Fatalf("expected %d rows, but got %d", maxResults-1, len(rows))
+					t.Fatalf("%d: expected %d rows, but got %d", i, maxResults-1, len(rows))
 				}
 			}
 		}

--- a/util/error.go
+++ b/util/error.go
@@ -65,3 +65,14 @@ func ErrorSkipFrames(skip int, a ...interface{}) error {
 	}
 	return fmt.Errorf("%s", fmt.Sprint(a...))
 }
+
+// FirstError returns the first of its arguments which is not nil (or nil if
+// they all are).
+func FirstError(errs ...error) error {
+	for _, err := range errs {
+		if err != nil {
+			return err
+		}
+	}
+	return nil
+}


### PR DESCRIPTION
- remove the mechanism for removing a cached leader upon
  caching the same leader twice in a row: silly idea, obviously
  concurrent request going to the wrong leader will return
  almost simultaneously and expire the freshly updated cache.
- the leaderCache now only deals with proto.Replica{}, not pointers.
- pretty complete refactoring of DistSender.Send to get more manageable
  pieces and less error handling spagetthi.
- atomic updates in ds.getNodeDescriptors
