### PR TITLE
Tailor the return types of the various client.DB operations.

### DIFF
--- a/acceptance/multiuser_test.go
+++ b/acceptance/multiuser_test.go
@@ -73,7 +73,7 @@ func TestMultiuser(t *testing.T) {
 	}
 
 	for i, w := range writes {
-		_, err := w.client.Put(w.key, w.key)
+		err := w.client.Put(w.key, w.key)
 		if (err == nil) != w.success {
 			t.Errorf("test case #%d: %+v, got err=%v", i, w, err)
 		}

--- a/acceptance/multiuser_test.go
+++ b/acceptance/multiuser_test.go
@@ -92,7 +92,7 @@ func TestMultiuser(t *testing.T) {
 	}
 
 	for i, r := range reads {
-		_, err := r.client.Get(r.key, r.key)
+		_, err := r.client.Get(r.key)
 		if (err == nil) != r.success {
 			t.Errorf("test case #%d: %+v, got err=%v", i, r, err)
 		}

--- a/acceptance/put_test.go
+++ b/acceptance/put_test.go
@@ -53,7 +53,7 @@ func TestPut(t *testing.T) {
 			for time.Now().Before(deadline) {
 				k := atomic.AddInt64(&count, 1)
 				v := value[:r.Intn(len(value))]
-				if _, err := c.Put(fmt.Sprintf("%08d", k), v); err != nil {
+				if err := c.Put(fmt.Sprintf("%08d", k), v); err != nil {
 					errs <- err
 					return
 				}

--- a/acceptance/single_key_test.go
+++ b/acceptance/single_key_test.go
@@ -92,7 +92,7 @@ func TestSingleKey(t *testing.T) {
 						return err
 					}
 					var v testVal
-					if err := v.UnmarshalBinary(r.Rows[0].ValueBytes()); err != nil {
+					if err := v.UnmarshalBinary(r.ValueBytes()); err != nil {
 						return err
 					}
 					return tx.Commit(tx.B.Put(key, v+1))
@@ -136,7 +136,7 @@ func TestSingleKey(t *testing.T) {
 		t.Fatal(err)
 	}
 	var v testVal
-	if err := v.UnmarshalBinary(r.Rows[0].ValueBytes()); err != nil {
+	if err := v.UnmarshalBinary(r.ValueBytes()); err != nil {
 		t.Fatal(err)
 	}
 	if expected != int64(v) {

--- a/acceptance/single_key_test.go
+++ b/acceptance/single_key_test.go
@@ -63,7 +63,7 @@ func TestSingleKey(t *testing.T) {
 	// Initialize the value for our test key to zero.
 	const key = "test-key"
 	c := makeDBClient(t, l, 0)
-	if _, err := c.Put(key, testVal(0)); err != nil {
+	if err := c.Put(key, testVal(0)); err != nil {
 		t.Fatal(err)
 	}
 

--- a/acceptance/util.go
+++ b/acceptance/util.go
@@ -56,7 +56,7 @@ func setDefaultRangeMaxBytes(t *testing.T, c *client.DB, maxBytes int64) {
 		return
 	}
 	zone.RangeMaxBytes = maxBytes
-	if _, err := c.Put(keys.ConfigZonePrefix, zone); err != nil {
+	if err := c.Put(keys.ConfigZonePrefix, zone); err != nil {
 		t.Fatal(err)
 	}
 }
@@ -73,6 +73,5 @@ func getPermConfig(client *client.DB, prefix string) (*proto.PermConfig, error) 
 
 // putPermConfig writes the permissions config for 'prefix'.
 func putPermConfig(client *client.DB, prefix string, config *proto.PermConfig) error {
-	_, err := client.Put(keys.MakeKey(keys.ConfigPermissionPrefix, proto.Key(prefix)), config)
-	return err
+	return client.Put(keys.MakeKey(keys.ConfigPermissionPrefix, proto.Key(prefix)), config)
 }

--- a/client/db.go
+++ b/client/db.go
@@ -253,12 +253,13 @@ func (db *DB) GetProto(key interface{}, msg gogoproto.Message) error {
 	return r.ValueProto(msg)
 }
 
-// Put sets the value for a key, returning the set key/value or an error.
+// Put sets the value for a key.
 //
 // key can be either a byte slice, a string, a fmt.Stringer or an
 // encoding.BinaryMarshaler. value can be any key type or a proto.Message.
-func (db *DB) Put(key, value interface{}) (KeyValue, error) {
-	return runOneRow(db, db.B.Put(key, value))
+func (db *DB) Put(key, value interface{}) error {
+	_, err := runOneResult(db, db.B.Put(key, value))
+	return err
 }
 
 // CPut conditionally sets the value for a key if the existing value is equal
@@ -267,8 +268,9 @@ func (db *DB) Put(key, value interface{}) (KeyValue, error) {
 //
 // key can be either a byte slice, a string, a fmt.Stringer or an
 // encoding.BinaryMarshaler. value can be any key type or a proto.Message.
-func (db *DB) CPut(key, value, expValue interface{}) (KeyValue, error) {
-	return runOneRow(db, db.B.CPut(key, value, expValue))
+func (db *DB) CPut(key, value, expValue interface{}) error {
+	_, err := runOneResult(db, db.B.CPut(key, value, expValue))
+	return err
 }
 
 // Inc increments the integer value at key. If the key does not exist it will
@@ -294,13 +296,11 @@ func (db *DB) Scan(begin, end interface{}, maxRows int64) ([]KeyValue, error) {
 
 // Del deletes one or more keys.
 //
-// Each key will have a corresponding entry in the returned []KeyValue.
-//
 // key can be either a byte slice, a string, a fmt.Stringer or an
 // encoding.BinaryMarshaler.
-func (db *DB) Del(keys ...interface{}) ([]KeyValue, error) {
-	r, err := runOneResult(db, db.B.Del(keys...))
-	return r.Rows, err
+func (db *DB) Del(keys ...interface{}) error {
+	_, err := runOneResult(db, db.B.Del(keys...))
+	return err
 }
 
 // DelRange deletes the rows between begin (inclusive) and end (exclusive).
@@ -432,25 +432,24 @@ func (tx *Tx) Get(key interface{}) (KeyValue, error) {
 	return runOneRow(tx, tx.B.Get(key))
 }
 
-// Put sets the value for a key, returning the set key/value or an error.
+// Put sets the value for a key
 //
 // key can be either a byte slice, a string, a fmt.Stringer or an
 // encoding.BinaryMarshaler. value can be any key type or a proto.Message.
-func (tx *Tx) Put(key, value interface{}) (KeyValue, error) {
-	return runOneRow(tx, tx.B.Put(key, value))
+func (tx *Tx) Put(key, value interface{}) error {
+	_, err := runOneResult(tx, tx.B.Put(key, value))
+	return err
 }
 
 // CPut conditionally sets the value for a key if the existing value is equal
 // to expValue. To conditionally set a value only if there is no existing entry
 // pass nil for expValue.
 //
-// The returned Result will contain a single row and Result.Err will indicate
-// success or failure.
-//
 // key can be either a byte slice, a string, a fmt.Stringer or an
 // encoding.BinaryMarshaler. value can be any key type or a proto.Message.
-func (tx *Tx) CPut(key, value, expValue interface{}) (KeyValue, error) {
-	return runOneRow(tx, tx.B.CPut(key, value, expValue))
+func (tx *Tx) CPut(key, value, expValue interface{}) error {
+	_, err := runOneResult(tx, tx.B.CPut(key, value, expValue))
+	return err
 }
 
 // Inc increments the integer value at key. If the key does not exist it will
@@ -479,13 +478,11 @@ func (tx *Tx) Scan(begin, end interface{}, maxRows int64) ([]KeyValue, error) {
 
 // Del deletes one or more keys.
 //
-// Each key will have a corresponding entry in the returned []KeyValue.
-//
 // key can be either a byte slice, a string, a fmt.Stringer or an
 // encoding.BinaryMarshaler.
-func (tx *Tx) Del(keys ...interface{}) ([]KeyValue, error) {
-	r, err := runOneResult(tx, tx.B.Del(keys...))
-	return r.Rows, err
+func (tx *Tx) Del(keys ...interface{}) error {
+	_, err := runOneResult(tx, tx.B.Del(keys...))
+	return err
 }
 
 // DelRange deletes the rows between begin (inclusive) and end (exclusive).

--- a/client/db.go
+++ b/client/db.go
@@ -228,22 +228,20 @@ func (db *DB) InternalKV() *KV {
 	return &db.kv
 }
 
-// Get retrieves one or more keys. Each requested key will have a corresponding
-// row in the returned Result.
+// Get retrieves the value for a key, returning the retrieved key/value or an
+// error.
 //
-//   r, err := db.Get("a", "b", "c")
-//   // string(r.Rows[0].Key) == "a"
-//   // string(r.Rows[1].Key) == "b"
-//   // string(r.Rows[2].Key) == "c"
+//   r, err := db.Get("a")
+//   // string(r.Key) == "a"
 //
 // key can be either a byte slice, a string, a fmt.Stringer or an
 // encoding.BinaryMarshaler.
-func (db *DB) Get(keys ...interface{}) (Result, error) {
-	return runOne(db, db.B.Get(keys...))
+func (db *DB) Get(key interface{}) (KeyValue, error) {
+	return runOneRow(db, db.B.Get(key))
 }
 
-// GetProto retrieves a single key/value and decodes the resulting value as a
-// proto message.
+// GetProto retrieves the value for a key and decodes the result as a proto
+// message.
 //
 // key can be either a byte slice, a string, a fmt.Stringer or an
 // encoding.BinaryMarshaler.
@@ -252,78 +250,68 @@ func (db *DB) GetProto(key interface{}, msg gogoproto.Message) error {
 	if err != nil {
 		return err
 	}
-	return r.Rows[0].ValueProto(msg)
+	return r.ValueProto(msg)
 }
 
-// Put sets the value for a key.
-//
-// The returned Result will contain a single row and Result.Err will indicate
-// success or failure.
+// Put sets the value for a key, returning the set key/value or an error.
 //
 // key can be either a byte slice, a string, a fmt.Stringer or an
 // encoding.BinaryMarshaler. value can be any key type or a proto.Message.
-func (db *DB) Put(key, value interface{}) (Result, error) {
-	return runOne(db, db.B.Put(key, value))
+func (db *DB) Put(key, value interface{}) (KeyValue, error) {
+	return runOneRow(db, db.B.Put(key, value))
 }
 
 // CPut conditionally sets the value for a key if the existing value is equal
 // to expValue. To conditionally set a value only if there is no existing entry
 // pass nil for expValue.
 //
-// The returned Result will contain a single row and Result.Err will indicate
-// success or failure.
-//
 // key can be either a byte slice, a string, a fmt.Stringer or an
 // encoding.BinaryMarshaler. value can be any key type or a proto.Message.
-func (db *DB) CPut(key, value, expValue interface{}) (Result, error) {
-	return runOne(db, db.B.CPut(key, value, expValue))
+func (db *DB) CPut(key, value, expValue interface{}) (KeyValue, error) {
+	return runOneRow(db, db.B.CPut(key, value, expValue))
 }
 
 // Inc increments the integer value at key. If the key does not exist it will
 // be created with an initial value of 0 which will then be incremented. If the
 // key exists but was set using Put or CPut an error will be returned.
 //
-// The returned Result will contain a single row and Result.Err will indicate
-// success or failure.
-//
 // key can be either a byte slice, a string, a fmt.Stringer or an
 // encoding.BinaryMarshaler.
-func (db *DB) Inc(key interface{}, value int64) (Result, error) {
-	return runOne(db, db.B.Inc(key, value))
+func (db *DB) Inc(key interface{}, value int64) (KeyValue, error) {
+	return runOneRow(db, db.B.Inc(key, value))
 }
 
 // Scan retrieves the rows between begin (inclusive) and end (exclusive).
 //
-// The returned Result will contain up to maxRows rows and Result.Err will
-// indicate success or failure.
+// The returned []KeyValue will contain up to maxRows elements.
 //
 // key can be either a byte slice, a string, a fmt.Stringer or an
 // encoding.BinaryMarshaler.
-func (db *DB) Scan(begin, end interface{}, maxRows int64) (Result, error) {
-	return runOne(db, db.B.Scan(begin, end, maxRows))
+func (db *DB) Scan(begin, end interface{}, maxRows int64) ([]KeyValue, error) {
+	r, err := runOneResult(db, db.B.Scan(begin, end, maxRows))
+	return r.Rows, err
 }
 
 // Del deletes one or more keys.
 //
-// Each key will have a corresponding row in the returned Result.
+// Each key will have a corresponding entry in the returned []KeyValue.
 //
 // key can be either a byte slice, a string, a fmt.Stringer or an
 // encoding.BinaryMarshaler.
-func (db *DB) Del(keys ...interface{}) (Result, error) {
-	return runOne(db, db.B.Del(keys...))
+func (db *DB) Del(keys ...interface{}) ([]KeyValue, error) {
+	r, err := runOneResult(db, db.B.Del(keys...))
+	return r.Rows, err
 }
 
 // DelRange deletes the rows between begin (inclusive) and end (exclusive).
-//
-// The returned Result will contain 0 rows and Result.Err will indicate success
-// or failure.
 //
 // TODO(pmattis): Perhaps the result should return which rows were deleted.
 //
 // key can be either a byte slice, a string, a fmt.Stringer or an
 // encoding.BinaryMarshaler.
-func (db *DB) DelRange(begin, end interface{}) (Result, error) {
-	return runOne(db, db.B.DelRange(begin, end))
+func (db *DB) DelRange(begin, end interface{}) error {
+	_, err := runOneResult(db, db.B.DelRange(begin, end))
+	return err
 }
 
 // AdminMerge merges the range containing key and the subsequent
@@ -334,7 +322,7 @@ func (db *DB) DelRange(begin, end interface{}) (Result, error) {
 // key can be either a byte slice, a string, a fmt.Stringer or an
 // encoding.BinaryMarshaler.
 func (db *DB) AdminMerge(key interface{}) error {
-	_, err := runOne(db, (&Batch{}).adminMerge(key))
+	_, err := runOneResult(db, (&Batch{}).adminMerge(key))
 	return err
 }
 
@@ -343,7 +331,7 @@ func (db *DB) AdminMerge(key interface{}) error {
 // key can be either a byte slice, a string, a fmt.Stringer or an
 // encoding.BinaryMarshaler.
 func (db *DB) AdminSplit(splitKey interface{}) error {
-	_, err := runOne(db, (&Batch{}).adminSplit(splitKey))
+	_, err := runOneResult(db, (&Batch{}).adminSplit(splitKey))
 	return err
 }
 
@@ -432,29 +420,24 @@ func (tx *Tx) SetSnapshotIsolation() {
 	tx.txn.txn.Isolation = proto.SNAPSHOT
 }
 
-// Get retrieves one or more keys. Each requested key will have a corresponding
-// row in the returned Result.
+// Get retrieves the value for a key, returning the retrieved key/value or an
+// error.
 //
-//   r, err := db.Get("a", "b", "c")
-//   // string(r.Rows[0].Key) == "a"
-//   // string(r.Rows[1].Key) == "b"
-//   // string(r.Rows[2].Key) == "c"
+//   r, err := db.Get("a")
+//   // string(r.Key) == "a"
 //
 // key can be either a byte slice, a string, a fmt.Stringer or an
 // encoding.BinaryMarshaler.
-func (tx *Tx) Get(keys ...interface{}) (Result, error) {
-	return runOne(tx, tx.B.Get(keys...))
+func (tx *Tx) Get(key interface{}) (KeyValue, error) {
+	return runOneRow(tx, tx.B.Get(key))
 }
 
-// Put sets the value for a key.
-//
-// The returned Result will contain a single row and Result.Err will indicate
-// success or failure.
+// Put sets the value for a key, returning the set key/value or an error.
 //
 // key can be either a byte slice, a string, a fmt.Stringer or an
 // encoding.BinaryMarshaler. value can be any key type or a proto.Message.
-func (tx *Tx) Put(key, value interface{}) (Result, error) {
-	return runOne(tx, tx.B.Put(key, value))
+func (tx *Tx) Put(key, value interface{}) (KeyValue, error) {
+	return runOneRow(tx, tx.B.Put(key, value))
 }
 
 // CPut conditionally sets the value for a key if the existing value is equal
@@ -466,8 +449,8 @@ func (tx *Tx) Put(key, value interface{}) (Result, error) {
 //
 // key can be either a byte slice, a string, a fmt.Stringer or an
 // encoding.BinaryMarshaler. value can be any key type or a proto.Message.
-func (tx *Tx) CPut(key, value, expValue interface{}) (Result, error) {
-	return runOne(tx, tx.B.CPut(key, value, expValue))
+func (tx *Tx) CPut(key, value, expValue interface{}) (KeyValue, error) {
+	return runOneRow(tx, tx.B.CPut(key, value, expValue))
 }
 
 // Inc increments the integer value at key. If the key does not exist it will
@@ -479,29 +462,30 @@ func (tx *Tx) CPut(key, value, expValue interface{}) (Result, error) {
 //
 // key can be either a byte slice, a string, a fmt.Stringer or an
 // encoding.BinaryMarshaler.
-func (tx *Tx) Inc(key interface{}, value int64) (Result, error) {
-	return runOne(tx, tx.B.Inc(key, value))
+func (tx *Tx) Inc(key interface{}, value int64) (KeyValue, error) {
+	return runOneRow(tx, tx.B.Inc(key, value))
 }
 
 // Scan retrieves the rows between begin (inclusive) and end (exclusive).
 //
-// The returned Result will contain up to maxRows rows and Result.Err will
-// indicate success or failure.
+// The returned []KeyValue will contain up to maxRows elements.
 //
 // key can be either a byte slice, a string, a fmt.Stringer or an
 // encoding.BinaryMarshaler.
-func (tx *Tx) Scan(begin, end interface{}, maxRows int64) (Result, error) {
-	return runOne(tx, tx.B.Scan(begin, end, maxRows))
+func (tx *Tx) Scan(begin, end interface{}, maxRows int64) ([]KeyValue, error) {
+	r, err := runOneResult(tx, tx.B.Scan(begin, end, maxRows))
+	return r.Rows, err
 }
 
 // Del deletes one or more keys.
 //
-// Each key will have a corresponding row in the returned Result.
+// Each key will have a corresponding entry in the returned []KeyValue.
 //
 // key can be either a byte slice, a string, a fmt.Stringer or an
 // encoding.BinaryMarshaler.
-func (tx *Tx) Del(keys ...interface{}) (Result, error) {
-	return runOne(tx, tx.B.Del(keys...))
+func (tx *Tx) Del(keys ...interface{}) ([]KeyValue, error) {
+	r, err := runOneResult(tx, tx.B.Del(keys...))
+	return r.Rows, err
 }
 
 // DelRange deletes the rows between begin (inclusive) and end (exclusive).
@@ -511,8 +495,9 @@ func (tx *Tx) Del(keys ...interface{}) (Result, error) {
 //
 // key can be either a byte slice, a string, a fmt.Stringer or an
 // encoding.BinaryMarshaler.
-func (tx *Tx) DelRange(begin, end interface{}) (Result, error) {
-	return runOne(tx, tx.B.DelRange(begin, end))
+func (tx *Tx) DelRange(begin, end interface{}) error {
+	_, err := runOneResult(tx, tx.B.DelRange(begin, end))
+	return err
 }
 
 // Run executes the operations queued up within a batch. Before executing any
@@ -696,28 +681,22 @@ func (b *Batch) InternalAddCall(call Call) {
 	b.initResult(1 /* calls */, 0 /* numRows */, nil)
 }
 
-// Get retrieves one or more keys. A new result will be appended to the batch
-// and each requested key will have a corresponding row in the Result.
+// Get retrieves the value for a key. A new result will be appended to the
+// batch which will contain a single row.
 //
-//   r, err := db.Get("a", "b", "c")
+//   r, err := db.Get("a")
 //   // string(r.Rows[0].Key) == "a"
-//   // string(r.Rows[1].Key) == "b"
-//   // string(r.Rows[2].Key) == "c"
 //
 // key can be either a byte slice, a string, a fmt.Stringer or an
 // encoding.BinaryMarshaler.
-func (b *Batch) Get(keys ...interface{}) *Batch {
-	var calls []Call
-	for _, key := range keys {
-		k, err := marshalKey(key)
-		if err != nil {
-			b.initResult(0, len(keys), err)
-			break
-		}
-		calls = append(calls, Get(proto.Key(k)))
+func (b *Batch) Get(key interface{}) *Batch {
+	k, err := marshalKey(key)
+	if err != nil {
+		b.initResult(0, 1, err)
+		return b
 	}
-	b.calls = append(b.calls, calls...)
-	b.initResult(len(calls), len(calls), nil)
+	b.calls = append(b.calls, Get(proto.Key(k)))
+	b.initResult(1, 1, nil)
 	return b
 }
 
@@ -903,8 +882,8 @@ func (b *Batch) adminSplit(splitKey interface{}) *Batch {
 
 type batcher struct{}
 
-func (b batcher) Get(keys ...interface{}) *Batch {
-	return (&Batch{}).Get(keys...)
+func (b batcher) Get(key interface{}) *Batch {
+	return (&Batch{}).Get(key)
 }
 
 func (b batcher) Put(key, value interface{}) *Batch {
@@ -972,10 +951,18 @@ type Runner interface {
 	Run(b *Batch) error
 }
 
-func runOne(r Runner, b *Batch) (Result, error) {
+func runOneResult(r Runner, b *Batch) (Result, error) {
 	if err := r.Run(b); err != nil {
 		return Result{Err: err}, err
 	}
 	res := b.Results[0]
 	return res, res.Err
+}
+
+func runOneRow(r Runner, b *Batch) (KeyValue, error) {
+	if err := r.Run(b); err != nil {
+		return KeyValue{}, err
+	}
+	res := b.Results[0]
+	return res.Rows[0], res.Err
 }

--- a/client/db_test.go
+++ b/client/db_test.go
@@ -56,7 +56,7 @@ func ExampleDB_Put() {
 	s, db := setup()
 	defer s.Stop()
 
-	if _, err := db.Put("aa", "1"); err != nil {
+	if err := db.Put("aa", "1"); err != nil {
 		panic(err)
 	}
 	result, err := db.Get("aa")
@@ -73,10 +73,10 @@ func ExampleDB_CPut() {
 	s, db := setup()
 	defer s.Stop()
 
-	if _, err := db.Put("aa", "1"); err != nil {
+	if err := db.Put("aa", "1"); err != nil {
 		panic(err)
 	}
-	if _, err := db.CPut("aa", "2", "1"); err != nil {
+	if err := db.CPut("aa", "2", "1"); err != nil {
 		panic(err)
 	}
 	result, err := db.Get("aa")
@@ -85,7 +85,7 @@ func ExampleDB_CPut() {
 	}
 	fmt.Printf("aa=%s\n", result.ValueBytes())
 
-	if _, err = db.CPut("aa", "3", "1"); err == nil {
+	if err = db.CPut("aa", "3", "1"); err == nil {
 		panic("expected error from conditional put")
 	}
 	result, err = db.Get("aa")
@@ -94,7 +94,7 @@ func ExampleDB_CPut() {
 	}
 	fmt.Printf("aa=%s\n", result.ValueBytes())
 
-	if _, err = db.CPut("bb", "4", "1"); err == nil {
+	if err = db.CPut("bb", "4", "1"); err == nil {
 		panic("expected error from conditional put")
 	}
 	result, err = db.Get("bb")
@@ -102,7 +102,7 @@ func ExampleDB_CPut() {
 		panic(err)
 	}
 	fmt.Printf("bb=%s\n", result.ValueBytes())
-	if _, err = db.CPut("bb", "4", nil); err != nil {
+	if err = db.CPut("bb", "4", nil); err != nil {
 		panic(err)
 	}
 	result, err = db.Get("bb")
@@ -182,7 +182,7 @@ func ExampleDB_Del() {
 	if err := db.Run(db.B.Put("aa", "1").Put("ab", "2").Put("ac", "3")); err != nil {
 		panic(err)
 	}
-	if _, err := db.Del("ab"); err != nil {
+	if err := db.Del("ab"); err != nil {
 		panic(err)
 	}
 	rows, err := db.Scan("a", "b", 100)
@@ -239,7 +239,7 @@ func ExampleDB_Insecure() {
 		log.Fatal(err)
 	}
 
-	if _, err := db.Put("aa", "1"); err != nil {
+	if err := db.Put("aa", "1"); err != nil {
 		panic(err)
 	}
 	result, err := db.Get("aa")

--- a/client/db_test.go
+++ b/client/db_test.go
@@ -46,7 +46,7 @@ func ExampleDB_Get() {
 	if err != nil {
 		panic(err)
 	}
-	fmt.Printf("aa=%s\n", result.Rows[0].ValueBytes())
+	fmt.Printf("aa=%s\n", result.ValueBytes())
 
 	// Output:
 	// aa=
@@ -63,7 +63,7 @@ func ExampleDB_Put() {
 	if err != nil {
 		panic(err)
 	}
-	fmt.Printf("aa=%s\n", result.Rows[0].ValueBytes())
+	fmt.Printf("aa=%s\n", result.ValueBytes())
 
 	// Output:
 	// aa=1
@@ -83,7 +83,7 @@ func ExampleDB_CPut() {
 	if err != nil {
 		panic(err)
 	}
-	fmt.Printf("aa=%s\n", result.Rows[0].ValueBytes())
+	fmt.Printf("aa=%s\n", result.ValueBytes())
 
 	if _, err = db.CPut("aa", "3", "1"); err == nil {
 		panic("expected error from conditional put")
@@ -92,7 +92,7 @@ func ExampleDB_CPut() {
 	if err != nil {
 		panic(err)
 	}
-	fmt.Printf("aa=%s\n", result.Rows[0].ValueBytes())
+	fmt.Printf("aa=%s\n", result.ValueBytes())
 
 	if _, err = db.CPut("bb", "4", "1"); err == nil {
 		panic("expected error from conditional put")
@@ -101,7 +101,7 @@ func ExampleDB_CPut() {
 	if err != nil {
 		panic(err)
 	}
-	fmt.Printf("bb=%s\n", result.Rows[0].ValueBytes())
+	fmt.Printf("bb=%s\n", result.ValueBytes())
 	if _, err = db.CPut("bb", "4", nil); err != nil {
 		panic(err)
 	}
@@ -109,7 +109,7 @@ func ExampleDB_CPut() {
 	if err != nil {
 		panic(err)
 	}
-	fmt.Printf("bb=%s\n", result.Rows[0].ValueBytes())
+	fmt.Printf("bb=%s\n", result.ValueBytes())
 
 	// Output:
 	// aa=2
@@ -129,7 +129,7 @@ func ExampleDB_Inc() {
 	if err != nil {
 		panic(err)
 	}
-	fmt.Printf("aa=%d\n", result.Rows[0].ValueInt())
+	fmt.Printf("aa=%d\n", result.ValueInt())
 
 	// Output:
 	// aa=100
@@ -162,11 +162,11 @@ func ExampleDB_Scan() {
 	if err := db.Run(b); err != nil {
 		panic(err)
 	}
-	result, err := db.Scan("a", "b", 100)
+	rows, err := db.Scan("a", "b", 100)
 	if err != nil {
 		panic(err)
 	}
-	for i, row := range result.Rows {
+	for i, row := range rows {
 		fmt.Printf("%d: %s=%s\n", i, row.Key, row.ValueBytes())
 	}
 
@@ -185,11 +185,11 @@ func ExampleDB_Del() {
 	if _, err := db.Del("ab"); err != nil {
 		panic(err)
 	}
-	result, err := db.Scan("a", "b", 100)
+	rows, err := db.Scan("a", "b", 100)
 	if err != nil {
 		panic(err)
 	}
-	for i, row := range result.Rows {
+	for i, row := range rows {
 		fmt.Printf("%d: %s=%s\n", i, row.Key, row.ValueBytes())
 	}
 
@@ -209,17 +209,19 @@ func ExampleTx_Commit() {
 		panic(err)
 	}
 
-	result, err := db.Get("aa", "ab")
-	if err != nil {
+	b := db.B.Get("aa").Get("ab")
+	if err := db.Run(b); err != nil {
 		panic(err)
 	}
-	for i, row := range result.Rows {
-		fmt.Printf("%d: %s=%s\n", i, row.Key, row.ValueBytes())
+	for i, result := range b.Results {
+		for j, row := range result.Rows {
+			fmt.Printf("%d/%d: %s=%s\n", i, j, row.Key, row.ValueBytes())
+		}
 	}
 
 	// Output:
-	// 0: aa=1
-	// 1: ab=2
+	// 0/0: aa=1
+	// 1/0: ab=2
 }
 
 func ExampleDB_Insecure() {
@@ -244,7 +246,7 @@ func ExampleDB_Insecure() {
 	if err != nil {
 		panic(err)
 	}
-	fmt.Printf("aa=%s\n", result.Rows[0].ValueBytes())
+	fmt.Printf("aa=%s\n", result.ValueBytes())
 
 	// Output:
 	// aa=1

--- a/kv/split_test.go
+++ b/kv/split_test.go
@@ -161,11 +161,11 @@ func TestRangeSplitsWithWritePressure(t *testing.T) {
 	// Check that we split 5 times in allotted time.
 	if err := util.IsTrueWithin(func() bool {
 		// Scan the txn records.
-		sr, err := s.DB.Scan(keys.Meta2Prefix, keys.MetaMax, 0)
+		rows, err := s.DB.Scan(keys.Meta2Prefix, keys.MetaMax, 0)
 		if err != nil {
 			t.Fatalf("failed to scan meta2 keys: %s", err)
 		}
-		return len(sr.Rows) >= 5
+		return len(rows) >= 5
 	}, 6*time.Second); err != nil {
 		t.Errorf("failed to split 5 times: %s", err)
 	}

--- a/kv/split_test.go
+++ b/kv/split_test.go
@@ -148,7 +148,7 @@ func TestRangeSplitsWithWritePressure(t *testing.T) {
 		RangeMinBytes: 1 << 8,
 		RangeMaxBytes: 1 << 18,
 	}
-	if _, err := s.DB.Put(keys.MakeKey(keys.ConfigZonePrefix, proto.KeyMin), zoneConfig); err != nil {
+	if err := s.DB.Put(keys.MakeKey(keys.ConfigZonePrefix, proto.KeyMin), zoneConfig); err != nil {
 		t.Fatal(err)
 	}
 

--- a/server/cli/kv.go
+++ b/server/cli/kv.go
@@ -91,15 +91,15 @@ func runGet(cmd *cobra.Command, args []string) {
 		osExit(1)
 		return
 	}
-	if !r.Rows[0].Exists() {
+	if !r.Exists() {
 		fmt.Fprintf(osStderr, "%s not found\n", key)
 		osExit(1)
 		return
 	}
-	if i, ok := r.Rows[0].Value.(*int64); ok {
+	if i, ok := r.Value.(*int64); ok {
 		fmt.Printf("%d\n", *i)
 	} else {
-		fmt.Printf("%s\n", r.Rows[0].Value)
+		fmt.Printf("%s\n", r.Value)
 	}
 }
 
@@ -177,7 +177,7 @@ func runInc(cmd *cobra.Command, args []string) {
 		fmt.Fprintf(osStderr, "increment failed: %s\n", err)
 		osExit(1)
 	} else {
-		fmt.Printf("%d\n", r.Rows[0].ValueInt())
+		fmt.Printf("%d\n", r.ValueInt())
 	}
 }
 
@@ -260,13 +260,13 @@ func runScan(cmd *cobra.Command, args []string) {
 		return
 	}
 	// TODO(pmattis): Add a flag for the number of results to scan.
-	r, err := kvDB.Scan(startKey, endKey, 1000)
+	rows, err := kvDB.Scan(startKey, endKey, 1000)
 	if err != nil {
 		fmt.Fprintf(osStderr, "scan failed: %s\n", err)
 		osExit(1)
 		return
 	}
-	for _, row := range r.Rows {
+	for _, row := range rows {
 		if bytes.HasPrefix(row.Key, []byte{0}) {
 			// TODO(pmattis): Pretty-print system keys.
 			fmt.Printf("%s\n", row.Key)

--- a/server/cli/range.go
+++ b/server/cli/range.go
@@ -55,14 +55,14 @@ func runLsRanges(cmd *cobra.Command, args []string) {
 	if kvDB == nil {
 		return
 	}
-	r, err := kvDB.Scan(startKey, keys.Meta2Prefix.PrefixEnd(), 1000)
+	rows, err := kvDB.Scan(startKey, keys.Meta2Prefix.PrefixEnd(), 1000)
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "scan failed: %s\n", err)
 		osExit(1)
 		return
 	}
 
-	for _, row := range r.Rows {
+	for _, row := range rows {
 		desc := &proto.RangeDescriptor{}
 		if err := row.ValueProto(desc); err != nil {
 			fmt.Fprintf(os.Stderr, "%s: unable to unmarshal range descriptor\n", row.Key)

--- a/server/config.go
+++ b/server/config.go
@@ -254,15 +254,15 @@ func getConfig(db *client.DB, configPrefix proto.Key, config gogoproto.Message,
 	path string, r *http.Request) (body []byte, contentType string, err error) {
 	// Scan all configs if the key is empty.
 	if len(path) == 0 {
-		var sr client.Result
-		if sr, err = db.Scan(configPrefix, configPrefix.PrefixEnd(), maxGetResults); err != nil {
+		var rows []client.KeyValue
+		if rows, err = db.Scan(configPrefix, configPrefix.PrefixEnd(), maxGetResults); err != nil {
 			return
 		}
-		if len(sr.Rows) == maxGetResults {
+		if len(rows) == maxGetResults {
 			log.Warningf("retrieved maximum number of results (%d); some may be missing", maxGetResults)
 		}
 		var prefixes []string
-		for _, row := range sr.Rows {
+		for _, row := range rows {
 			trimmed := bytes.TrimPrefix(row.Key, configPrefix)
 			prefixes = append(prefixes, url.QueryEscape(string(trimmed)))
 		}

--- a/server/config.go
+++ b/server/config.go
@@ -238,8 +238,7 @@ func putConfig(db *client.DB, configPrefix proto.Key, config gogoproto.Message,
 		}
 	}
 	key := keys.MakeKey(configPrefix, proto.Key(path[1:]))
-	_, err := db.Put(key, config)
-	return err
+	return db.Put(key, config)
 }
 
 // getConfig retrieves the configuration for the specified key. If the
@@ -288,6 +287,5 @@ func deleteConfig(db *client.DB, configPrefix proto.Key, path string, r *http.Re
 		return util.Errorf("the default configuration cannot be deleted")
 	}
 	configKey := keys.MakeKey(configPrefix, proto.Key(path[1:]))
-	_, err := db.Del(configKey)
-	return err
+	return db.Del(configKey)
 }

--- a/server/node.go
+++ b/server/node.go
@@ -88,7 +88,7 @@ func allocateNodeID(db *client.DB) (proto.NodeID, error) {
 	if err != nil {
 		return 0, util.Errorf("unable to allocate node ID: %s", err)
 	}
-	return proto.NodeID(r.Rows[0].ValueInt()), nil
+	return proto.NodeID(r.ValueInt()), nil
 }
 
 // allocateStoreIDs increments the store id generator key for the
@@ -99,7 +99,7 @@ func allocateStoreIDs(nodeID proto.NodeID, inc int64, db *client.DB) (proto.Stor
 	if err != nil {
 		return 0, util.Errorf("unable to allocate %d store IDs for node %d: %s", inc, nodeID, err)
 	}
-	return proto.StoreID(r.Rows[0].ValueInt() - inc + 1), nil
+	return proto.StoreID(r.ValueInt() - inc + 1), nil
 }
 
 // BootstrapCluster bootstraps a multiple stores using the provided engines and

--- a/server/node.go
+++ b/server/node.go
@@ -493,7 +493,7 @@ func (n *Node) startStoresScanner(stopper *util.Stopper) {
 					AvailableRangeCount:  availableRangeCount,
 				}
 				key := keys.NodeStatusKey(int32(n.Descriptor.NodeID))
-				if _, err := n.ctx.DB.Put(key, status); err != nil {
+				if err := n.ctx.DB.Put(key, status); err != nil {
 					log.Error(err)
 				}
 				// Increment iteration count.

--- a/server/node_test.go
+++ b/server/node_test.go
@@ -113,12 +113,12 @@ func TestBootstrapCluster(t *testing.T) {
 	defer stopper.Stop()
 
 	// Scan the complete contents of the local database.
-	sr, err := localDB.Scan(keys.LocalPrefix.PrefixEnd(), proto.KeyMax, 0)
+	rows, err := localDB.Scan(keys.LocalPrefix.PrefixEnd(), proto.KeyMax, 0)
 	if err != nil {
 		t.Fatal(err)
 	}
 	var keys []proto.Key
-	for _, kv := range sr.Rows {
+	for _, kv := range rows {
 		keys = append(keys, kv.Key)
 	}
 	var expectedKeys = []proto.Key{

--- a/server/node_test.go
+++ b/server/node_test.go
@@ -389,10 +389,10 @@ func TestNodeStatus(t *testing.T) {
 	oldStats := compareStoreStatus(t, ts.node, expectedNodeStatus, 0)
 
 	// Write some values left and right of the proposed split key.
-	if _, err := ts.db.Put("a", content); err != nil {
+	if err := ts.db.Put("a", content); err != nil {
 		t.Fatal(err)
 	}
-	if _, err := ts.db.Put("c", content); err != nil {
+	if err := ts.db.Put("c", content); err != nil {
 		t.Fatal(err)
 	}
 
@@ -464,10 +464,10 @@ func TestNodeStatus(t *testing.T) {
 	oldStats = compareStoreStatus(t, ts.node, expectedNodeStatus, 2)
 
 	// Write some values left and right of the proposed split key.
-	if _, err := ts.db.Put("aa", content); err != nil {
+	if err := ts.db.Put("aa", content); err != nil {
 		t.Fatal(err)
 	}
-	if _, err := ts.db.Put("cc", content); err != nil {
+	if err := ts.db.Put("cc", content); err != nil {
 		t.Fatal(err)
 	}
 

--- a/server/status.go
+++ b/server/status.go
@@ -246,7 +246,7 @@ func (s *statusServer) handleNodesStatus(w http.ResponseWriter, r *http.Request,
 	startKey := keys.StatusNodePrefix
 	endKey := startKey.PrefixEnd()
 
-	sr, err := s.db.Scan(startKey, endKey, 0)
+	rows, err := s.db.Scan(startKey, endKey, 0)
 	if err != nil {
 		log.Error(err)
 		w.WriteHeader(http.StatusInternalServerError)
@@ -254,7 +254,7 @@ func (s *statusServer) handleNodesStatus(w http.ResponseWriter, r *http.Request,
 	}
 
 	nodeStatuses := []proto.NodeStatus{}
-	for _, row := range sr.Rows {
+	for _, row := range rows {
 		nodeStatus := &proto.NodeStatus{}
 		if err := row.ValueProto(nodeStatus); err != nil {
 			log.Error(err)
@@ -306,7 +306,7 @@ func (s *statusServer) handleStoresStatus(w http.ResponseWriter, r *http.Request
 	startKey := keys.StatusStorePrefix
 	endKey := startKey.PrefixEnd()
 
-	sr, err := s.db.Scan(startKey, endKey, 0)
+	rows, err := s.db.Scan(startKey, endKey, 0)
 	if err != nil {
 		log.Error(err)
 		w.WriteHeader(http.StatusInternalServerError)
@@ -314,7 +314,7 @@ func (s *statusServer) handleStoresStatus(w http.ResponseWriter, r *http.Request
 	}
 
 	storeStatuses := []proto.StoreStatus{}
-	for _, row := range sr.Rows {
+	for _, row := range rows {
 		storeStatus := &proto.StoreStatus{}
 		if err := row.ValueProto(storeStatus); err != nil {
 			log.Error(err)

--- a/server/status_test.go
+++ b/server/status_test.go
@@ -452,13 +452,13 @@ func TestMetricsRecording(t *testing.T) {
 		gr, err := tsrv.db.Get(key)
 		if err != nil {
 			return err
-		} else if !gr.Rows[0].Exists() {
+		} else if !gr.Exists() {
 			return util.Errorf("key %s had nil value", key)
 		}
 
 		// The value should be an internal time series.
 		data := &proto.InternalTimeSeriesData{}
-		if err := gr.Rows[0].ValueProto(data); err != nil {
+		if err := gr.ValueProto(data); err != nil {
 			return err
 		}
 		return nil

--- a/storage/client_split_test.go
+++ b/storage/client_split_test.go
@@ -391,7 +391,7 @@ func TestStoreZoneUpdateAndRangeSplit(t *testing.T) {
 		RangeMaxBytes: maxBytes,
 	}
 	key := keys.MakeKey(keys.ConfigZonePrefix, proto.KeyMin)
-	if _, err := store.DB().Put(key, zoneConfig); err != nil {
+	if err := store.DB().Put(key, zoneConfig); err != nil {
 		t.Fatal(err)
 	}
 

--- a/storage/client_split_test.go
+++ b/storage/client_split_test.go
@@ -446,12 +446,12 @@ func TestStoreRangeSplitOnConfigs(t *testing.T) {
 		keys.MakeKey(proto.Key("\x00\x00meta2"), proto.KeyMax),
 	}
 	if err := util.IsTrueWithin(func() bool {
-		sr, err := store.DB().Scan(keys.Meta2Prefix, keys.MetaMax, 0)
+		rows, err := store.DB().Scan(keys.Meta2Prefix, keys.MetaMax, 0)
 		if err != nil {
 			t.Fatalf("failed to scan meta2 keys: %s", err)
 		}
 		var keys []proto.Key
-		for _, r := range sr.Rows {
+		for _, r := range rows {
 			keys = append(keys, r.Key)
 		}
 		return reflect.DeepEqual(keys, expKeys)

--- a/storage/id_alloc.go
+++ b/storage/id_alloc.go
@@ -113,7 +113,7 @@ func (ia *idAllocator) allocateBlock(incr int64) {
 			log.Warningf("unable to allocate %d ids from %s: %s", incr, idKey, err)
 			return retry.Continue, err
 		}
-		newValue = r.Rows[0].ValueInt()
+		newValue = r.ValueInt()
 		return retry.Break, nil
 	})
 	if err != nil {

--- a/storage/store.go
+++ b/storage/store.go
@@ -1579,7 +1579,7 @@ func (s *Store) updateStoreStatus() {
 		AvailableRangeCount:  availableRangeCount,
 	}
 	key := keys.StoreStatusKey(int32(s.Ident.StoreID))
-	if _, err := s.db.Put(key, status); err != nil {
+	if err := s.db.Put(key, status); err != nil {
 		log.Error(err)
 	}
 }

--- a/structured/db.go
+++ b/structured/db.go
@@ -80,14 +80,14 @@ func (db *structuredDB) GetSchema(key string) (*Schema, error) {
 	if err != nil {
 		return nil, err
 	}
-	if !gr.Rows[0].Exists() {
+	if !gr.Exists() {
 		// No value present.
 		return nil, nil
 	}
 	// TODO(pmattis): This is an inappropriate use of gob. Replace with
 	// something else.
 	s := &Schema{}
-	if err := gob.NewDecoder(bytes.NewBuffer(gr.Rows[0].ValueBytes())).Decode(s); err != nil {
+	if err := gob.NewDecoder(bytes.NewBuffer(gr.ValueBytes())).Decode(s); err != nil {
 		return nil, err
 	}
 	return s, nil

--- a/structured/db.go
+++ b/structured/db.go
@@ -61,14 +61,12 @@ func (db *structuredDB) PutSchema(s *Schema) error {
 	if err := gob.NewEncoder(&buf).Encode(s); err != nil {
 		return err
 	}
-	_, err := db.kvDB.Put(k, buf.Bytes())
-	return err
+	return db.kvDB.Put(k, buf.Bytes())
 }
 
 // DeleteSchema removes s from the kv store.
 func (db *structuredDB) DeleteSchema(s *Schema) error {
-	_, err := db.kvDB.Del(keys.MakeKey(keys.SchemaPrefix, proto.Key(s.Key)))
-	return err
+	return db.kvDB.Del(keys.MakeKey(keys.SchemaPrefix, proto.Key(s.Key)))
 }
 
 // GetSchema returns the Schema with the given key, or nil if

--- a/ts/query.go
+++ b/ts/query.go
@@ -405,7 +405,7 @@ func (db *DB) Query(query proto.TimeSeriesQueryRequest_Query, r Resolution,
 	// query.
 	startKey := MakeDataKey(query.Name, "" /* source */, r, startNanos)
 	endKey := MakeDataKey(query.Name, "" /* source */, r, endNanos).PrefixEnd()
-	sr, err := db.db.Scan(startKey, endKey, 0)
+	rows, err := db.db.Scan(startKey, endKey, 0)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -413,7 +413,7 @@ func (db *DB) Query(query proto.TimeSeriesQueryRequest_Query, r Resolution,
 	// Construct a new dataSpan for each distinct source encountered in the
 	// query. Each dataspan will contain all data queried from the same source.
 	sourceSpans := make(map[string]*dataSpan)
-	for _, row := range sr.Rows {
+	for _, row := range rows {
 		data := &proto.InternalTimeSeriesData{}
 		if err := row.ValueProto(data); err != nil {
 			return nil, nil, err


### PR DESCRIPTION
Single key operations now return a KeyValue instead of a
Result. Multi-key operations return a []KeyValue instead of a Result
because Result.Err is already checked for and returned in the error
return value.

Note: I decided to try this after having getting some more exposure to
client.DB. It removes the irritation of frequently having to access
Rows[0] at the expense of removing the uniformity of the return value
from the client.DB operations.
