### PR TITLE
Convert Resource Compilation to Makefile

### DIFF
--- a/resource/Makefile
+++ b/resource/Makefile
@@ -1,0 +1,41 @@
+# Copyright 2015 The Cockroach Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+# implied. See the License for the specific language governing
+# permissions and limitations under the License. See the AUTHORS file
+# for names of contributors.
+#
+# Author: Matt Tracy (matt@cockroachlabs.com)
+
+GOBINDATA_PACKAGE := resource
+
+GOBINDATA_TARGET := ./embedded.go
+
+GOBINDATA_SOURCE := ui/...
+
+GOBINDATA_FLAGS := -mode 0644 -modtime 1400000000
+
+.PHONY: all
+all: gobindata 
+
+.PHONY: js
+js:
+	tsc -p ui/ts/
+
+.PHONY: gobindata
+gobindata: js
+	go-bindata $(GOBINDATA_FLAGS) -pkg $(GOBINDATA_PACKAGE) -o $(GOBINDATA_TARGET) $(GOBINDATA_SOURCE)
+	gofmt -s -w $(GOBINDATA_TARGET)
+	goimports -w $(GOBINDATA_TARGET)
+
+.PHONY: debug
+debug: GOBINDATA_FLAGS += -debug
+debug: gobindata

--- a/resource/README.md
+++ b/resource/README.md
@@ -1,0 +1,40 @@
+# Binary Resources
+
+This directory contains binary resources needed by cockroach in various
+capacities, includes images and documentation for display on our github page.
+
+## Embedded UI
+
+The /ui directory contains the client-side code for cockroach's web admin
+console. These files are embedded into the cockroach binary via the
+[go-bindata](https://github.com/jteeuwen/go-bindata) package, which is used to
+generate the `embedded.go` file in this directory.
+
+#### Modification
+If any modifications are made to the contents of the /ui directory, run `make`
+in this directory to generate a new `embedded.go`, which should _then be
+committed along with the original files_. The generated file is committed
+because making our web admin resource requires [additional non-go
+dependencies](####dependencies)
+
+#### Development
+While actively developing the user interface, use `make debug` in order to run
+go-bindata in debug mode.  This will instruct go-bindata to proxy your local
+files (rather than using embedded versions) so you'll be able to edit them live
+without recompiling or restarting the server.  
+
+Note that only those files that were present the last time you ran `make debug`
+will be proxied; if you add a new file, you must run recompile and restart the
+server after running `make debug`.
+
+Before committing, be sure to run `make` to generate a non-debug version of
+`embedded.go`. This is enforced by our build system, but forgetting to do this
+will result in wasted time waiting for the build.
+
+#### Dependencies
+Our admin UI is written in Typescript, so compiling it depends on having the
+typescript compiler locally.
+
+1. Install [nodejs](https://nodejs.org/)
+2. Install [typescript](http://www.typescriptlang.org/). This can be done via
+   the command line using npm: `npm install -g typescript`

--- a/resource/resource.go
+++ b/resource/resource.go
@@ -13,26 +13,10 @@
 // permissions and limitations under the License. See the AUTHORS file
 // for names of contributors.
 //
-// Author: Tobias Schottdorf (tobias.schottdorf@gmail.com)
+// Author: Matt Tracy (matt@cockroachlabs.com)
 
 // Package resource embeds into the Cockroach certain data such as web html
 // and stylesheets.
 package resource
 
-//go:generate tsc -p ui/ts/
-
-// If you add or change any files to the ui folder, you'll need to generate and
-// make build for the new and/or updated files to appear.
-//
-// If you're planning on doing any development of the ui, add a -debug flag
-// before the -pkg flag in the go:generate command below. This flag will
-// instruct go-bindata to just proxy your local files so you'll be able to edit
-// them live.  However, it will only proxy those files that were present the
-// last time you ran go generate.
-// Be sure to remove this flag and go generate before creating a PR. Also, make
-// sure you clear the page cache when debugging or you might not see the
-// changes.
-//go:generate go-bindata -pkg resource -mode 0644 -modtime 1400000000 -o ./embedded.go ./ui/...
-
-//go:generate gofmt -s -w embedded.go
-//go:generate goimports -w embedded.go
+//go:generate make


### PR DESCRIPTION
This commit converts compilation of the admin UI to a makefile, where go
generate was previously used. This means that go generate will no longer have a
dependency on node or typescript; however, the makefile inside of the resources
directory will have that dependency.

This also simplifies the 'debug' situation for development - rather than having
to constantly add the `-debug` flag into the resource.go file, you now just
`make debug`.
