### PR TITLE
log tweak for failed pushes

### DIFF
--- a/storage/range_command.go
+++ b/storage/range_command.go
@@ -602,10 +602,11 @@ func (r *Range) InternalPushTxn(batch engine.Engine, ms *proto.MVCCStats, args *
 	}
 
 	if !pusherWins {
+		err := proto.NewTransactionPushError(args.Txn, reply.PusheeTxn)
 		if log.V(1) {
-			log.Infof("failed to push intent %s vs %s using priority=%d", reply.PusheeTxn, args.Txn, priority)
+			log.Info(err)
 		}
-		reply.SetGoError(proto.NewTransactionPushError(args.Txn, reply.PusheeTxn))
+		reply.SetGoError(err)
 		return
 	}
 


### PR DESCRIPTION
err.Error() is already pretty much the perfect
error message, especially since you usually see
it echoed from the DistSender, which prints the
same thing, so it helps if they look alike.
