### PR TITLE
Add client.Tx.SetTimestamp.

### DIFF
--- a/client/db.go
+++ b/client/db.go
@@ -74,10 +74,8 @@ func (kv *KeyValue) setValue(v *proto.Value) {
 	} else if v.Integer != nil {
 		kv.Value = v.Integer
 	}
-	if ts := v.Timestamp; ts != nil {
-		sec := ts.WallTime / 1e9
-		nsec := ts.WallTime % 1e9
-		kv.Timestamp = time.Unix(sec, nsec)
+	if v.Timestamp != nil {
+		kv.Timestamp = v.Timestamp.GoTime()
 	}
 }
 
@@ -418,6 +416,14 @@ func (tx *Tx) SetSnapshotIsolation() {
 	// operations run on it. Needs to tie into the Txn reset in case of
 	// retries.
 	tx.txn.txn.Isolation = proto.SNAPSHOT
+}
+
+// InternalSetPriority sets the transaction priority. It is intended for
+// internal (testing) use only.
+func (tx *Tx) InternalSetPriority(priority int32) {
+	// The negative user priority translates into a positive (and known) priority
+	// for the transaction.
+	tx.txn.kv.UserPriority = -priority
 }
 
 // Get retrieves the value for a key, returning the retrieved key/value or an

--- a/proto/data.go
+++ b/proto/data.go
@@ -319,6 +319,13 @@ func (t *Timestamp) Backward(s Timestamp) {
 	}
 }
 
+// GoTime converts the timestamp to a time.Time.
+func (t *Timestamp) GoTime() time.Time {
+	sec := t.WallTime / 1e9
+	nsec := t.WallTime % 1e9
+	return time.Unix(sec, nsec)
+}
+
 // InitChecksum initializes a checksum based on the provided key and
 // the contents of the value. If the value contains a byte slice, the
 // checksum includes it directly; if the value contains an integer,


### PR DESCRIPTION
Added the ability to set the timestamp for read/write operations within
a transaction.

Migrate some more usages of client.KV to client.DB.

See #997.
