### PR TITLE
Fix check for uninitialized variable in init-docker.

### DIFF
--- a/build/init-docker.sh
+++ b/build/init-docker.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-if [ "${DOCKER_HOST+x}" = "x" -a "$(uname)" = "Darwin" ]; then
+if [ "${DOCKER_HOST+x}" != "x" -a "$(uname)" = "Darwin" ]; then
     if ! type -P "boot2docker" >& /dev/null; then
 	echo "boot2docker not found!"
 	exit 1


### PR DESCRIPTION
This was changed from "x${DOCKER_HOST}" to "${DOCKER_HOST+x}" to be
agnostic about the sourcing script's `-u` setting, but the sense of the
comparison needs to be reversed.
