### PR TITLE
Move check for future timestamps from HLC.Update to Store.ExecuteCmd

### DIFF
--- a/kv/txn_test.go
+++ b/kv/txn_test.go
@@ -139,9 +139,7 @@ func verifyUncertainty(concurrency int, maxOffset time.Duration, t *testing.T) {
 		value := []byte(fmt.Sprintf("value-%d", i))
 		// Values will be written with 5ns spacing.
 		futureTS := s.Clock.Now().Add(5, 0)
-		if _, err := s.Clock.Update(futureTS); err != nil {
-			t.Fatal(err)
-		}
+		s.Clock.Update(futureTS)
 		// Expected number of versions skipped.
 		skipCount := int(maxOffset) / 5
 		if i+skipCount >= concurrency {
@@ -169,9 +167,7 @@ func verifyUncertainty(concurrency int, maxOffset time.Duration, t *testing.T) {
 			// hasn't changed (i=0). The logical component will change
 			// internally in a way we can't track, but we want to be just
 			// ahead.if
-			if _, err := txnClock.Update(futureTS.Add(0, 999)); err != nil {
-				t.Fatal(err)
-			}
+			txnClock.Update(futureTS.Add(0, 999))
 			// The written values are spaced out in intervals of 5ns, so
 			// setting <5ns here should make do without any restarts while
 			// higher values require roughly offset/5 restarts.

--- a/kv/txn_test.go
+++ b/kv/txn_test.go
@@ -166,7 +166,7 @@ func verifyUncertainty(concurrency int, maxOffset time.Duration, t *testing.T) {
 			// Make sure to incorporate the logical component if the wall time
 			// hasn't changed (i=0). The logical component will change
 			// internally in a way we can't track, but we want to be just
-			// ahead.if
+			// ahead.
 			txnClock.Update(futureTS.Add(0, 999))
 			// The written values are spaced out in intervals of 5ns, so
 			// setting <5ns here should make do without any restarts while

--- a/storage/client_raft_test.go
+++ b/storage/client_raft_test.go
@@ -673,7 +673,7 @@ func TestRaftHeartbeats(t *testing.T) {
 	}
 
 	// Wait for several ticks to elapse.
-	time.Sleep(5 * mtc.makeContext().RaftTickInterval)
+	time.Sleep(5 * mtc.makeContext(0).RaftTickInterval)
 	status = mtc.stores[0].RaftStatus(1)
 	if status.SoftState.RaftState != raft.StateLeader {
 		t.Errorf("expected node 0 to be leader after sleeping but was %s", status.SoftState.RaftState)

--- a/storage/client_range_test.go
+++ b/storage/client_range_test.go
@@ -1,0 +1,151 @@
+// Copyright 2015 The Cockroach Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+// implied. See the License for the specific language governing
+// permissions and limitations under the License. See the AUTHORS file
+// for names of contributors.
+//
+// Author: Ben Darnell
+
+package storage_test
+
+import (
+	"reflect"
+	"testing"
+	"time"
+
+	"golang.org/x/net/context"
+
+	"github.com/cockroachdb/cockroach/client"
+	"github.com/cockroachdb/cockroach/proto"
+	"github.com/cockroachdb/cockroach/storage/engine"
+	"github.com/cockroachdb/cockroach/util"
+	"github.com/cockroachdb/cockroach/util/hlc"
+	"github.com/cockroachdb/cockroach/util/leaktest"
+)
+
+// TestRangeCommandClockUpdate verifies that followers update their
+// clocks when executing a command, even if the leader's clock is far
+// in the future.
+func TestRangeCommandClockUpdate(t *testing.T) {
+	defer leaktest.AfterTest(t)
+
+	const numNodes = 3
+	var manuals []*hlc.ManualClock
+	var clocks []*hlc.Clock
+	for i := 0; i < numNodes; i++ {
+		manuals = append(manuals, hlc.NewManualClock(1))
+		clocks = append(clocks, hlc.NewClock(manuals[i].UnixNano))
+		clocks[i].SetMaxOffset(100 * time.Millisecond)
+	}
+	mtc := multiTestContext{
+		clocks: clocks,
+	}
+	mtc.Start(t, numNodes)
+	defer mtc.Stop()
+	mtc.replicateRange(1, 0, 1, 2)
+
+	// Advance the leader's clock ahead of the followers (by more than
+	// MaxOffset but less than the leader lease) and execute a command.
+	manuals[0].Increment(int64(500 * time.Millisecond))
+	incArgs, incResp := incrementArgs([]byte("a"), 5, 1, mtc.stores[0].StoreID())
+	incArgs.Timestamp = clocks[0].Now()
+	if err := mtc.stores[0].ExecuteCmd(context.Background(), client.Call{Args: incArgs, Reply: incResp}); err != nil {
+		t.Fatal(err)
+	}
+
+	// Wait for that command to execute on all the followers.
+	util.SucceedsWithin(t, 50*time.Millisecond, func() error {
+		values := []int64{}
+		for _, eng := range mtc.engines {
+			val, err := engine.MVCCGet(eng, proto.Key("a"), clocks[0].Now(), true, nil)
+			if err != nil {
+				return err
+			}
+			values = append(values, val.GetInteger())
+		}
+		if !reflect.DeepEqual(values, []int64{5, 5, 5}) {
+			return util.Errorf("expected (5, 5, 5), got %v", values)
+		}
+		return nil
+	})
+
+	// Verify that all the followers have accepted the clock update from
+	// node 0 even though it comes from outside the usual max offset.
+	now := clocks[0].Now()
+	for i, clock := range clocks {
+		// Only compare the WallTimes: it's normal for clock 0 to be a few logical ticks ahead.
+		if clock.Now().WallTime < now.WallTime {
+			t.Errorf("clock %d is behind clock 0: %s vs %s", i, clock.Now(), now)
+		}
+	}
+}
+
+// TestRejectFutureCommand verifies that leaders reject commands that
+// would cause a large time jump.
+func TestRejectFutureCommand(t *testing.T) {
+	defer leaktest.AfterTest(t)
+
+	const maxOffset = 100 * time.Millisecond
+	manual := hlc.NewManualClock(0)
+	clock := hlc.NewClock(manual.UnixNano)
+	clock.SetMaxOffset(maxOffset)
+	mtc := multiTestContext{
+		clock: clock,
+	}
+	mtc.Start(t, 1)
+	defer mtc.Stop()
+
+	// First do a write. The first write will advance the clock by MaxOffset
+	// because of the read cache's low water mark.
+	getArgs, getResp := putArgs([]byte("b"), []byte("b"), 1, mtc.stores[0].StoreID())
+	if err := mtc.stores[0].ExecuteCmd(context.Background(), client.Call{Args: getArgs, Reply: getResp}); err != nil {
+		t.Fatal(err)
+	}
+	if now := clock.Now(); now.WallTime != int64(maxOffset) {
+		t.Fatalf("expected clock to advance to 100ms; got %s", now)
+	}
+	// The logical clock has advanced past the physical clock; increment
+	// the "physical" clock to catch up.
+	manual.Increment(int64(maxOffset))
+
+	// Commands with a future timestamp that is within the MaxOffset
+	// bound will be accepted and will cause the clock to advance.
+	for i := int64(0); i < 3; i++ {
+		incArgs, incResp := incrementArgs([]byte("a"), 5, 1, mtc.stores[0].StoreID())
+		incArgs.Timestamp.WallTime = (130 + i*30) * int64(time.Millisecond)
+		if err := mtc.stores[0].ExecuteCmd(context.Background(), client.Call{Args: incArgs, Reply: incResp}); err != nil {
+			t.Fatal(err)
+		}
+	}
+	if now := clock.Now(); now.WallTime != int64(190*time.Millisecond) {
+		t.Fatalf("expected clock to advance to 190ms; got %s", now)
+	}
+
+	// Once the accumulated offset reaches MaxOffset, commands will be rejected.
+	incArgs, incResp := incrementArgs([]byte("a"), 11, 1, mtc.stores[0].StoreID())
+	incArgs.Timestamp.WallTime = int64(220 * time.Millisecond)
+	if err := mtc.stores[0].ExecuteCmd(context.Background(), client.Call{Args: incArgs, Reply: incResp}); err == nil {
+		t.Fatalf("expected clock offset error but got nil")
+	}
+
+	// The clock remained at 90ms and the final command was not executed.
+	if now := clock.Now(); now.WallTime != int64(190*time.Millisecond) {
+		t.Errorf("expected clock to advance to 190ms; got %s", now)
+	}
+	val, err := engine.MVCCGet(mtc.engines[0], proto.Key("a"), clock.Now(), true, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if val.GetInteger() != 15 {
+		t.Errorf("expected 15, got %v", val.GetInteger())
+	}
+}

--- a/storage/range_command.go
+++ b/storage/range_command.go
@@ -98,10 +98,7 @@ func (r *Range) executeCmd(batch engine.Engine, ms *proto.MVCCStats, args proto.
 	// high water mark for all ops serviced, so that received ops
 	// without a timestamp specified are guaranteed one higher than any
 	// op already executed for overlapping keys.
-	_, err := r.rm.Clock().Update(header.Timestamp)
-	if err != nil {
-		log.Errorf("executed a command with excessive future clock offset: %s", err)
-	}
+	r.rm.Clock().Update(header.Timestamp)
 
 	// Propagate the request timestamp (which may have changed).
 	reply.Header().Timestamp = header.Timestamp

--- a/storage/store.go
+++ b/storage/store.go
@@ -1198,13 +1198,8 @@ func (s *Store) ExecuteCmd(ctx context.Context, call client.Call) error {
 		}
 		// Update our clock with the incoming request timestamp. This
 		// advances the local node's clock to a high water mark from
-		// amongst all nodes with which it has interacted. The update is
-		// bounded by the max clock drift.
-		_, err := s.ctx.Clock.Update(header.Timestamp)
-		if err != nil {
-			reply.Header().SetGoError(err)
-			return err
-		}
+		// amongst all nodes with which it has interacted.
+		s.ctx.Clock.Update(header.Timestamp)
 	}
 
 	// Backoff and retry loop for handling errors.

--- a/storage/store.go
+++ b/storage/store.go
@@ -1184,7 +1184,7 @@ func (s *Store) ExecuteCmd(ctx context.Context, call client.Call) error {
 	}
 	if !header.Timestamp.Equal(proto.ZeroTimestamp) {
 		if s.Clock().MaxOffset() > 0 {
-			// Once a command is submitted to raft, all replica's logical
+			// Once a command is submitted to raft, all replicas' logical
 			// clocks will be ratcheted forward to match. If the command
 			// appears to come from a node with a bad clock, reject it now
 			// before we reach that point.

--- a/storage/store_test.go
+++ b/storage/store_test.go
@@ -571,7 +571,7 @@ func TestStoreExecuteCmdWithZeroTime(t *testing.T) {
 
 // TestStoreExecuteCmdWithClockOffset verifies that if the request
 // specifies a timestamp further into the future than the node's
-// maximum allowed clock offset, the cmd fails with an error.
+// maximum allowed clock offset, the cmd still succeeds.
 func TestStoreExecuteCmdWithClockOffset(t *testing.T) {
 	defer leaktest.AfterTest(t)
 	store, mc, stopper := createTestStore(t)

--- a/util/hlc/hlc.go
+++ b/util/hlc/hlc.go
@@ -193,12 +193,9 @@ func (c *Clock) PhysicalTime() time.Time {
 // in which case the state of the clock will not have been
 // altered.
 // To timestamp events of local origin, use Now instead.
-func (c *Clock) Update(rt proto.Timestamp) (result proto.Timestamp, err error) {
+func (c *Clock) Update(rt proto.Timestamp) proto.Timestamp {
 	c.Lock()
 	defer c.Unlock()
-	defer func() {
-		result = c.timestamp()
-	}()
 	physicalClock := c.physicalClock()
 
 	if physicalClock > c.state.WallTime && physicalClock > rt.WallTime {
@@ -206,7 +203,7 @@ func (c *Clock) Update(rt proto.Timestamp) (result proto.Timestamp, err error) {
 		// as the new wall time and the logical clock is reset.
 		c.state.WallTime = physicalClock
 		c.state.Logical = 0
-		return
+		return c.timestamp()
 	}
 
 	// In the remaining cases, our physical clock plays no role
@@ -235,7 +232,5 @@ func (c *Clock) Update(rt proto.Timestamp) (result proto.Timestamp, err error) {
 		}
 		c.state.Logical++
 	}
-	// The variable result will be updated via defer just
-	// before the object is unlocked.
-	return
+	return c.timestamp()
 }

--- a/util/hlc/hlc.go
+++ b/util/hlc/hlc.go
@@ -152,12 +152,9 @@ func (c *Clock) timestamp() proto.Timestamp {
 // of the distributed network. This is the counterpart
 // of Update, which is passed a timestamp received from
 // another member of the distributed network.
-func (c *Clock) Now() (result proto.Timestamp) {
+func (c *Clock) Now() proto.Timestamp {
 	c.Lock()
 	defer c.Unlock()
-	defer func() {
-		result = c.timestamp()
-	}()
 
 	physicalClock := c.physicalClock()
 	if c.state.WallTime >= physicalClock {
@@ -168,7 +165,7 @@ func (c *Clock) Now() (result proto.Timestamp) {
 		c.state.WallTime = physicalClock
 		c.state.Logical = 0
 	}
-	return
+	return c.timestamp()
 }
 
 // PhysicalNow returns the local wall time. It corresponds to the physicalClock

--- a/util/hlc/hlc.go
+++ b/util/hlc/hlc.go
@@ -27,7 +27,7 @@ import (
 	"time"
 
 	"github.com/cockroachdb/cockroach/proto"
-	"github.com/cockroachdb/cockroach/util"
+	"github.com/cockroachdb/cockroach/util/log"
 )
 
 // TODO(Tobias): Figure out if it would make sense to save some
@@ -216,9 +216,8 @@ func (c *Clock) Update(rt proto.Timestamp) (result proto.Timestamp, err error) {
 		if c.maxOffset.Nanoseconds() > 0 &&
 			rt.WallTime-physicalClock > c.maxOffset.Nanoseconds() {
 			// The remote wall time is too far ahead to be trustworthy.
-			err = util.Errorf("Remote wall time offsets from local physical clock: %d (%dns ahead)",
+			log.Errorf("Remote wall time offsets from local physical clock: %d (%dns ahead)",
 				rt.WallTime, rt.WallTime-physicalClock)
-			return
 		}
 		// The remote clock is ahead of ours, and we update
 		// our own logical clock with theirs.

--- a/util/hlc/hlc_test.go
+++ b/util/hlc/hlc_test.go
@@ -133,7 +133,6 @@ func TestClock(t *testing.T) {
 	}
 
 	var current proto.Timestamp
-	var err error
 	for i, step := range expectedHistory {
 		m.Set(step.wallClock)
 		switch step.event {
@@ -143,9 +142,9 @@ func TestClock(t *testing.T) {
 			fallthrough
 		default:
 			previous := c.Timestamp()
-			current, err = c.Update(*step.input)
-			if current.Equal(previous) && err == nil {
-				t.Errorf("%d: clock not updated even though no error occurred", i)
+			current = c.Update(*step.input)
+			if current.Equal(previous) {
+				t.Errorf("%d: clock not updated", i)
 			}
 		}
 		if !current.Equal(step.expected) {

--- a/util/hlc/hlc_test.go
+++ b/util/hlc/hlc_test.go
@@ -125,9 +125,6 @@ func TestClock(t *testing.T) {
 		{7, SEND, nil, proto.Timestamp{WallTime: 10, Logical: 7}},
 		// Wall clocks coincide, but the local logical clock wins.
 		{8, RECV, &proto.Timestamp{WallTime: 10, Logical: 4}, proto.Timestamp{WallTime: 10, Logical: 8}},
-		// The next message comes from a faulty clock and should
-		// be discarded.
-		{9, RECV, &proto.Timestamp{WallTime: 1100, Logical: 888}, proto.Timestamp{WallTime: 10, Logical: 8}},
 		// Wall clocks coincide, but the remote logical clock wins.
 		{10, RECV, &proto.Timestamp{WallTime: 10, Logical: 99}, proto.Timestamp{WallTime: 10, Logical: 100}},
 		// The physical clock has caught up and takes over.
@@ -156,35 +153,6 @@ func TestClock(t *testing.T) {
 		}
 	}
 	c.Now()
-}
-
-// TestSetMaxOffset ensures that checking received timestamps
-// for excessive offsets works correctly.
-func TestSetMaxOffset(t *testing.T) {
-	m := NewManualClock(123456789)
-	skewedTime := int64(123456789 + 51)
-	c := NewClock(m.UnixNano)
-	if c.MaxOffset() != 0 {
-		t.Fatalf("unexpected offset setting")
-	}
-	c.SetMaxOffset(50)
-	if c.MaxOffset() != 50 {
-		t.Fatalf("unexpected offset setting")
-	}
-	c.Now()
-	if c.Timestamp().WallTime != m.UnixNano() {
-		t.Fatalf("unexpected clock value")
-	}
-	_, err := c.Update(proto.Timestamp{WallTime: skewedTime})
-	if err == nil {
-		t.Fatalf("clock offset not recognized")
-	}
-	// Disable offset checking.
-	c.SetMaxOffset(0)
-	_, err = c.Update(proto.Timestamp{WallTime: skewedTime})
-	if err != nil || c.Timestamp().WallTime != skewedTime {
-		t.Fatalf("failed to disable offset checking")
-	}
 }
 
 // ExampleManualClock shows how a manual clock can be


### PR DESCRIPTION
HLC.Update is called post-raft, which means it must not vary based on
the node's current clock.

See #1242.
