### PR TITLE
Increase timeout for testrace on slow CI machines

### DIFF
--- a/kv/dist_sender_server_test.go
+++ b/kv/dist_sender_server_test.go
@@ -215,7 +215,7 @@ func TestSplitByMeta2KeyMax(t *testing.T) {
 
 	select {
 	case <-ch:
-	case <-time.After(500 * time.Millisecond):
+	case <-time.After(5 * time.Second):
 		t.Error("range split on Meta2KeyMax timed out")
 	}
 }


### PR DESCRIPTION
Fixes #1263.
