### PR TITLE
refactor & log statistics from txn coordinator

### DIFF
--- a/GLOCKFILE
+++ b/GLOCKFILE
@@ -26,6 +26,7 @@ github.com/jteeuwen/go-bindata 83a44d533bf65a1d05c51314ec58d6ee72ec2ddb
 github.com/julienschmidt/httprouter 8c199fb6259ffc1af525cc3ad52ee60ba8359669
 github.com/kisielk/errcheck a48456c583c0111c8310fc59335f6496b8eb85f1
 github.com/kisielk/gotool d678387370a2eb9b5b0a33218bc8c9d8de15b6be
+github.com/montanaflynn/stats a284fdcb4087fd56fbafa546cdf350c0e2c4a99f
 github.com/robfig/glock e0f25993e42f3aff6494cf397815841a3491d890
 github.com/samalba/dockerclient 142d8fe0150952d52867ac222e3a02eb17916f01
 github.com/spf13/cobra 8f5946caaeeff40a98d67f60c25e89c3525038a3

--- a/proto/data.go
+++ b/proto/data.go
@@ -532,6 +532,11 @@ func (t Transaction) String() string {
 		util.UUID(t.ID).Short(), t.Key, floatPri, t.Isolation, t.Status, t.Epoch, t.Timestamp, t.OrigTimestamp, t.MaxTimestamp)
 }
 
+// Short returns the short form of the Transaction's UUID.
+func (t Transaction) Short() string {
+	return util.UUID(t.ID).Short()
+}
+
 // IsInline returns true if the value is inlined in the metadata.
 func (mvcc *MVCCMetadata) IsInline() bool {
 	return mvcc.Value != nil

--- a/util/duration.go
+++ b/util/duration.go
@@ -1,0 +1,31 @@
+// Copyright 2014 The Cockroach Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+// implied. See the License for the specific language governing
+// permissions and limitations under the License. See the AUTHORS file
+// for names of contributors.
+//
+// Author: Tobias Schottdorf
+
+package util
+
+import "time"
+
+// TruncateDuration returns a new duration obtained from the first argument
+// by discarding the portions at finer resolution than that given by the
+// second argument.
+// Example: TruncateDuration(time.Second+1, time.Second) == time.Second.
+func TruncateDuration(d time.Duration, r time.Duration) time.Duration {
+	if r == 0 {
+		panic("zero passed as resolution")
+	}
+	return d - (d % r)
+}

--- a/util/duration_test.go
+++ b/util/duration_test.go
@@ -1,0 +1,43 @@
+// Copyright 2014 The Cockroach Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+// implied. See the License for the specific language governing
+// permissions and limitations under the License. See the AUTHORS file
+// for names of contributors.
+//
+// Author: Tobias Schottdorf
+
+package util
+
+import (
+	"testing"
+	"time"
+)
+
+func TestTruncateDuration(t *testing.T) {
+	testCases := []struct {
+		d, r time.Duration
+		s    string
+	}{
+		{0, 1, "0"},
+		{0, 1, "0"},
+		{time.Second, 1, "1s"},
+		{time.Second, 2 * time.Second, "0"},
+		{time.Second + 1, time.Second, "1s"},
+		{11 * time.Nanosecond, 10 * time.Nanosecond, "10ns"},
+		{time.Hour + time.Nanosecond + 3*time.Millisecond + time.Second, time.Millisecond, "1h0m1.003s"},
+	}
+	for i, tc := range testCases {
+		if s := TruncateDuration(tc.d, tc.r).String(); s != tc.s {
+			t.Errorf("%d: (%s,%s) should give %s, but got %s", i, tc.d, tc.r, tc.s, s)
+		}
+	}
+}


### PR DESCRIPTION
the refactoring is mostly for transparency and to make sure that the transaction record stored in the txnMetadata is updated appropriately, as this is relevant for the stats.

> txn coordinator: 157.60 txn/sec, 92.13/7.87/0.00 %cmmt/abrt/abnd, 16ms/178ms/5.002s avg/σ/max duration, 0.3/0.7/5.0 avg/σ/max restarts (788 samples)
