### PR TITLE
Fix rpc retry

### DIFF
--- a/rpc/client.go
+++ b/rpc/client.go
@@ -129,9 +129,9 @@ func (c *Client) connect(opts *retry.Options, context *Context) {
 
 	err := retry.WithBackoff(retryOpts, func() (retry.Status, error) {
 		conn, err := tlsDialHTTP(c.addr.Network(), c.addr.String(), context.tlsConfig)
-		if err != nil {
-			log.Info(err)
-			return retry.Continue, nil
+		if err != nil { //could be many error: bad host; bad certificate
+			log.Error(err)
+			return retry.Break, nil
 		}
 
 		c.mu.Lock()


### PR DESCRIPTION
The retry would never end if return retry.Continue.
It can be reproduced by following errors:
bad host
bad certificate
