### PR TITLE
Added keys for the namespace and table metadata

### DIFF
--- a/keys/constants.go
+++ b/keys/constants.go
@@ -157,6 +157,10 @@ var (
 	RaftIDGenerator = MakeKey(SystemPrefix, proto.Key("raft-idgen"))
 	// SchemaPrefix specifies key prefixes for schema definitions.
 	SchemaPrefix = MakeKey(SystemPrefix, proto.Key("schema"))
+	// NamespaceMetadataPrefix is the key prefix for all namespace metadata.
+	NamespaceMetadataPrefix = MakeKey(SystemPrefix, proto.Key("ns-"))
+	// TableMetadataPrefix is the key prefix for all table metadata.
+	TableMetadataPrefix = MakeKey(SystemPrefix, proto.Key("tbl-"))
 	// StoreIDGenerator is the global store ID generator sequence.
 	StoreIDGenerator = MakeKey(SystemPrefix, proto.Key("store-idgen"))
 	// RangeTreeRoot specifies the root range in the range tree.

--- a/keys/keys.go
+++ b/keys/keys.go
@@ -57,13 +57,13 @@ func NodeStatusKey(nodeID int32) proto.Key {
 }
 
 // NamespaceMetadataKey returns the key for the namespace.
-func NamespaceMetadataKey(namespace string) proto.Key {
+func MakeNamespaceMetadataKey(namespace string) proto.Key {
 	return MakeKey(NamespaceMetadataPrefix, proto.Key(namespace))
 }
 
 // TableMetadataKey returns the key for the table in namespaceID.
-func TableMetadataKey(namespaceID uint32, tableName string) proto.Key {
-	return MakeKey(TableMetadataPrefix, encoding.EncodeUvarint(nil, uint64(namespaceID)), proto.Key("-"), proto.Key(tableName))
+func MakeTableMetadataKey(namespaceID uint32, tableName string) proto.Key {
+	return MakeKey(TableMetadataPrefix, encoding.EncodeUvarint(nil, uint64(namespaceID)), proto.Key(tableName))
 }
 
 // MakeRangeIDKey creates a range-local key based on the range's

--- a/keys/keys.go
+++ b/keys/keys.go
@@ -56,6 +56,16 @@ func NodeStatusKey(nodeID int32) proto.Key {
 	return MakeKey(StatusNodePrefix, encoding.EncodeUvarint(nil, uint64(nodeID)))
 }
 
+// NamespaceMetadataKey returns the key for the namespace.
+func NamespaceMetadataKey(namespace string) proto.Key {
+	return MakeKey(NamespaceMetadataPrefix, proto.Key(namespace))
+}
+
+// TableMetadataKey returns the key for the table in namespaceID.
+func TableMetadataKey(namespaceID uint32, tableName string) proto.Key {
+	return MakeKey(TableMetadataPrefix, encoding.EncodeUvarint(nil, uint64(namespaceID)), proto.Key("-"), proto.Key(tableName))
+}
+
 // MakeRangeIDKey creates a range-local key based on the range's
 // Raft ID, metadata key suffix, and optional detail (e.g. the
 // encoded command ID for a response cache entry, etc.).

--- a/keys/keys.go
+++ b/keys/keys.go
@@ -56,12 +56,12 @@ func NodeStatusKey(nodeID int32) proto.Key {
 	return MakeKey(StatusNodePrefix, encoding.EncodeUvarint(nil, uint64(nodeID)))
 }
 
-// NamespaceMetadataKey returns the key for the namespace.
+// MakeNamespaceMetadataKey returns the key for the namespace.
 func MakeNamespaceMetadataKey(namespace string) proto.Key {
 	return MakeKey(NamespaceMetadataPrefix, proto.Key(namespace))
 }
 
-// TableMetadataKey returns the key for the table in namespaceID.
+// MakeTableMetadataKey returns the key for the table in namespaceID.
 func MakeTableMetadataKey(namespaceID uint32, tableName string) proto.Key {
 	return MakeKey(TableMetadataPrefix, encoding.EncodeUvarint(nil, uint64(namespaceID)), proto.Key(tableName))
 }

--- a/keys/keys_test.go
+++ b/keys/keys_test.go
@@ -63,8 +63,8 @@ func TestKeyAddress(t *testing.T) {
 		{RangeDescriptorKey(proto.Key("foo")), proto.Key("foo")},
 		{TransactionKey(proto.Key("baz"), proto.Key(util.NewUUID4())), proto.Key("baz")},
 		{TransactionKey(proto.KeyMax, proto.Key(util.NewUUID4())), proto.KeyMax},
-		{NamespaceMetadataKey("foo"), proto.Key("\x00ns-foo")},
-		{TableMetadataKey(123, "bar"), proto.Key("\x00tbl-\t{-bar")},
+		{MakeNamespaceMetadataKey("foo"), proto.Key("\x00ns-foo")},
+		{MakeTableMetadataKey(123, "bar"), proto.Key("\x00tbl-\t{bar")},
 		{nil, nil},
 	}
 	for i, test := range testCases {

--- a/keys/keys_test.go
+++ b/keys/keys_test.go
@@ -63,6 +63,8 @@ func TestKeyAddress(t *testing.T) {
 		{RangeDescriptorKey(proto.Key("foo")), proto.Key("foo")},
 		{TransactionKey(proto.Key("baz"), proto.Key(util.NewUUID4())), proto.Key("baz")},
 		{TransactionKey(proto.KeyMax, proto.Key(util.NewUUID4())), proto.KeyMax},
+		{NamespaceMetadataKey("foo"), proto.Key("\x00ns-foo")},
+		{TableMetadataKey(123, "bar"), proto.Key("\x00tbl-\t{-bar")},
 		{nil, nil},
 	}
 	for i, test := range testCases {


### PR DESCRIPTION
I don't see a strong reason to encode the namespace id in the table metadata key.
