### PR TITLE
Migrate client/client_test.go from client.KV to client.DB.

### DIFF
--- a/client/db.go
+++ b/client/db.go
@@ -230,6 +230,21 @@ func (db *DB) InternalKV() *KV {
 	return &db.kv
 }
 
+// InternalSender returns the internal sender. It is intended for internal use
+// only.
+//
+// TODO(peter): This is temporary. Once client.KV goes away we can put
+// KV.Sender directly in DB.
+func (db *DB) InternalSender() Sender {
+	return db.kv.Sender
+}
+
+// InternalSetSender sets the internal set field. It is intended for internal
+// use only.
+func (db *DB) InternalSetSender(sender Sender) {
+	db.kv.Sender = sender
+}
+
 // Get retrieves the value for a key, returning the retrieved key/value or an
 // error.
 //

--- a/client/db_test.go
+++ b/client/db_test.go
@@ -306,6 +306,8 @@ func TestCommonMethods(t *testing.T) {
 		key{dbType, "AdminMerge"}:           {},
 		key{dbType, "AdminSplit"}:           {},
 		key{dbType, "InternalKV"}:           {},
+		key{dbType, "InternalSender"}:       {},
+		key{dbType, "InternalSetSender"}:    {},
 		key{dbType, "Run"}:                  {},
 		key{dbType, "Tx"}:                   {},
 		key{txType, "Commit"}:               {},


### PR DESCRIPTION
Removed various ExampleKV_\* examples that duplicated examples in
client/db_test.go.
