### PR TITLE
Remove client.Clock interface.

### DIFF
--- a/client/call.go
+++ b/client/call.go
@@ -19,6 +19,7 @@ package client
 
 import (
 	"math/rand"
+	"time"
 
 	"github.com/cockroachdb/cockroach/proto"
 	"github.com/cockroachdb/cockroach/util"
@@ -36,9 +37,9 @@ type Call struct {
 // resetClientCmdID sets the client command ID if the call is for a
 // read-write method. The client command ID provides idempotency
 // protection in conjunction with the server.
-func (c *Call) resetClientCmdID(clock Clock) {
+func (c *Call) resetClientCmdID() {
 	c.Args.Header().CmdID = proto.ClientCmdID{
-		WallTime: clock.Now(),
+		WallTime: time.Now().UnixNano(),
 		Random:   rand.Int63(),
 	}
 }

--- a/client/db.go
+++ b/client/db.go
@@ -32,15 +32,6 @@ import (
 	gogoproto "github.com/gogo/protobuf/proto"
 )
 
-// A systemClock is an implementation of the Clock interface that
-// returns the node's wall time.
-type systemClock struct{}
-
-// Now implements the Clock interface, returning the node's wall time.
-func (systemClock) Now() int64 {
-	return time.Now().UnixNano()
-}
-
 // KeyValue represents a single key/value pair and corresponding timestamp.
 type KeyValue struct {
 	Key       []byte
@@ -209,7 +200,6 @@ func Open(addr string, opts ...Option) (*DB, error) {
 	db.kv.Sender = sender
 	db.kv.User = u.User.Username()
 	db.kv.TxnRetryOptions = DefaultTxnRetryOptions
-	db.kv.clock = systemClock{}
 
 	if priority := q["priority"]; len(priority) > 0 {
 		p, err := strconv.Atoi(priority[0])

--- a/client/txn.go
+++ b/client/txn.go
@@ -177,7 +177,7 @@ func (t *Txn) Run(calls ...Call) error {
 func (t *Txn) Prepare(calls ...Call) {
 	t.updateState(calls)
 	for _, c := range calls {
-		c.resetClientCmdID(t.kv.clock)
+		c.resetClientCmdID()
 	}
 	t.prepared = append(t.prepared, calls...)
 }


### PR DESCRIPTION
The client.Clock interface was only being used to set the
Header.CmdID.WallTime field in requests, but only a single
implementation existed which used time.Now().UnixNano().
