### PR TITLE
publish range stats correctly

### DIFF
--- a/server/status/monitor_test.go
+++ b/server/status/monitor_test.go
@@ -77,12 +77,19 @@ func TestNodeStatusMonitor(t *testing.T) {
 				Stats:   stats,
 				Delta:   stats,
 			},
-			&storage.AddRangeEvent{
+			&storage.RegisterRangeEvent{
+				StoreID: id,
+				Desc:    desc2,
+				Stats:   stats,
+				Scan:    false, // should lead to this being ignored
+			},
+			&storage.RegisterRangeEvent{
 				StoreID: id,
 				Desc:    desc1,
 				Stats:   stats,
+				Scan:    true, // not ignored
 			},
-			&storage.UpdateRangeEvent{ // Update during scan after add, should be picked up.
+			&storage.UpdateRangeEvent{ // Update during scan after register, should be picked up
 				StoreID: id,
 				Desc:    desc1,
 				Stats:   stats,
@@ -90,6 +97,12 @@ func TestNodeStatusMonitor(t *testing.T) {
 			},
 			&storage.EndScanRangesEvent{ // End Scan.
 				StoreID: id,
+			},
+			&storage.RegisterRangeEvent{
+				StoreID: id,
+				Desc:    desc2,
+				Stats:   stats,
+				Scan:    true, // ignored, not in ScanRanges mode
 			},
 			&storage.UpdateRangeEvent{
 				StoreID: id,
@@ -111,10 +124,11 @@ func TestNodeStatusMonitor(t *testing.T) {
 					Stats:   stats,
 					Delta:   stats,
 				},
-				New: storage.AddRangeEvent{
+				New: storage.RegisterRangeEvent{
 					StoreID: id,
 					Desc:    desc2,
 					Stats:   stats,
+					Scan:    false,
 				},
 			},
 			&storage.UpdateRangeEvent{

--- a/server/status/recorder_test.go
+++ b/server/status/recorder_test.go
@@ -85,20 +85,23 @@ func TestNodeStatusRecorder(t *testing.T) {
 	monitor.OnBeginScanRanges(&storage.BeginScanRangesEvent{
 		StoreID: proto.StoreID(2),
 	})
-	monitor.OnAddRange(&storage.AddRangeEvent{
+	monitor.OnRegisterRange(&storage.RegisterRangeEvent{
 		StoreID: proto.StoreID(1),
 		Desc:    desc1,
 		Stats:   stats,
+		Scan:    true,
 	})
-	monitor.OnAddRange(&storage.AddRangeEvent{
+	monitor.OnRegisterRange(&storage.RegisterRangeEvent{
 		StoreID: proto.StoreID(1),
 		Desc:    desc2,
 		Stats:   stats,
+		Scan:    true,
 	})
-	monitor.OnAddRange(&storage.AddRangeEvent{
+	monitor.OnRegisterRange(&storage.RegisterRangeEvent{
 		StoreID: proto.StoreID(2),
 		Desc:    desc1,
 		Stats:   stats,
+		Scan:    true,
 	})
 	monitor.OnEndScanRanges(&storage.EndScanRangesEvent{
 		StoreID: proto.StoreID(1),

--- a/storage/feed_test.go
+++ b/storage/feed_test.go
@@ -127,9 +127,9 @@ func TestStoreEventFeed(t *testing.T) {
 		{
 			"NewRange",
 			func(feed StoreEventFeed) {
-				feed.addRange(rng1)
+				feed.registerRange(rng1, false /* scan */)
 			},
-			&AddRangeEvent{
+			&RegisterRangeEvent{
 				StoreID: proto.StoreID(1),
 				Desc: &proto.RangeDescriptor{
 					RaftID:   1,
@@ -210,7 +210,7 @@ func TestStoreEventFeed(t *testing.T) {
 						ValBytes:  -170,
 					},
 				},
-				New: AddRangeEvent{
+				New: RegisterRangeEvent{
 					Desc: &proto.RangeDescriptor{
 						RaftID:   2,
 						StartKey: proto.Key("b"),

--- a/storage/store.go
+++ b/storage/store.go
@@ -456,7 +456,7 @@ func (s *Store) Start(stopper *util.Stopper) error {
 		if err != nil {
 			return false, err
 		}
-		s.feed.addRange(rng)
+		s.feed.registerRange(rng, true /* scan */)
 		// Note that we do not create raft groups at this time; they will be created
 		// on-demand the first time they are needed. This helps reduce the amount of
 		// election-related traffic in a cold start.
@@ -1007,7 +1007,7 @@ func (s *Store) AddRangeTest(rng *Range) error {
 	if err != nil {
 		return err
 	}
-	s.feed.addRange(rng)
+	s.feed.registerRange(rng, false /* scan */)
 	return nil
 }
 
@@ -1084,6 +1084,7 @@ func (s *Store) processRangeDescriptorUpdate(rng *Range) error {
 		return nil
 	}
 	delete(s.uninitRanges, rng.Desc().RaftID)
+	s.feed.registerRange(rng, false /* scan */)
 
 	s.rangesByKey = append(s.rangesByKey, rng)
 	sort.Sort(s.rangesByKey)


### PR DESCRIPTION
- renamed AddRangeEvent to RegisterRangeEvent
- new flag Scan: true for events dispatched by the store
  to initialize a new consumer, false otherwise
- consumer ignores such events when they do not match
  the expected Scan flag
- updated tests
- dispatch a RegisterRange(scan=false) event when moving a
  range from uninitialized to initialized (as occurs when
  replicating a range to a new store)

fixes #1189
