### PR TITLE
Move "set -u" to after the test for the "init" command.

### DIFF
--- a/build/builder.sh
+++ b/build/builder.sh
@@ -4,7 +4,7 @@ set -eu
 
 image="cockroachdb/builder"
 
-if [ "$1" = "init" ]; then
+if [ "${1:-}" = "init" ]; then
     docker build --tag="${image}" - <<EOF
 FROM golang:1.4.2
 


### PR DESCRIPTION
The "-u" option was preventing running build/builder.sh without
arguments which is a nice way to drop into a shell within the builder
image.
