### PR TITLE
range's RaftID should be used to find RangeDesc if range is not initialized

### DIFF
--- a/proto/internal.proto
+++ b/proto/internal.proto
@@ -456,5 +456,7 @@ message RaftSnapshotData {
     optional bytes key = 1;
     optional bytes value = 2;
   }
-  repeated KeyValue KV = 1 [(gogoproto.customname) = "KV"];
+  // The latest RangeDescriptor
+  optional RangeDescriptor range_descriptor = 1 [(gogoproto.nullable) = false];
+  repeated KeyValue KV = 2 [(gogoproto.customname) = "KV"];
 }

--- a/storage/engine/cockroach/proto/internal.pb.cc
+++ b/storage/engine/cockroach/proto/internal.pb.cc
@@ -749,7 +749,8 @@ void protobuf_AssignDesc_cockroach_2fproto_2finternal_2eproto() {
       GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(RaftTruncatedState, _internal_metadata_),
       -1);
   RaftSnapshotData_descriptor_ = file->message_type(30);
-  static const int RaftSnapshotData_offsets_[1] = {
+  static const int RaftSnapshotData_offsets_[2] = {
+    GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(RaftSnapshotData, range_descriptor_),
     GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(RaftSnapshotData, kv_),
   };
   RaftSnapshotData_reflection_ =
@@ -1124,13 +1125,15 @@ void protobuf_AddDesc_cockroach_2fproto_2finternal_2eproto() {
     "\000\022\023\n\005count\030\006 \001(\rB\004\310\336\037\000\022\021\n\003sum\030\007 \001(\001B\004\310\336\037"
     "\000\022\013\n\003max\030\010 \001(\001\022\013\n\003min\030\t \001(\001\"=\n\022RaftTrunc"
     "atedState\022\023\n\005index\030\001 \001(\004B\004\310\336\037\000\022\022\n\004term\030\002"
-    " \001(\004B\004\310\336\037\000\"z\n\020RaftSnapshotData\022>\n\002KV\030\001 \003"
-    "(\0132*.cockroach.proto.RaftSnapshotData.Ke"
-    "yValueB\006\342\336\037\002KV\032&\n\010KeyValue\022\013\n\003key\030\001 \001(\014\022"
-    "\r\n\005value\030\002 \001(\014*G\n\013PushTxnType\022\022\n\016PUSH_TI"
-    "MESTAMP\020\000\022\r\n\tABORT_TXN\020\001\022\017\n\013CLEANUP_TXN\020"
-    "\002\032\004\210\243\036\000*%\n\021InternalValueType\022\n\n\006_CR_TS\020\001"
-    "\032\004\210\243\036\000B\023Z\005proto\340\342\036\001\310\342\036\001\320\342\036\001", 7347);
+    " \001(\004B\004\310\336\037\000\"\274\001\n\020RaftSnapshotData\022@\n\020range"
+    "_descriptor\030\001 \001(\0132 .cockroach.proto.Rang"
+    "eDescriptorB\004\310\336\037\000\022>\n\002KV\030\002 \003(\0132*.cockroac"
+    "h.proto.RaftSnapshotData.KeyValueB\006\342\336\037\002K"
+    "V\032&\n\010KeyValue\022\013\n\003key\030\001 \001(\014\022\r\n\005value\030\002 \001("
+    "\014*G\n\013PushTxnType\022\022\n\016PUSH_TIMESTAMP\020\000\022\r\n\t"
+    "ABORT_TXN\020\001\022\017\n\013CLEANUP_TXN\020\002\032\004\210\243\036\000*%\n\021In"
+    "ternalValueType\022\n\n\006_CR_TS\020\001\032\004\210\243\036\000B\023Z\005pro"
+    "to\340\342\036\001\310\342\036\001\320\342\036\001", 7414);
   ::google::protobuf::MessageFactory::InternalRegisterGeneratedFile(
     "cockroach/proto/internal.proto", &protobuf_RegisterTypes);
   InternalRangeLookupRequest::default_instance_ = new InternalRangeLookupRequest();
@@ -16810,6 +16813,7 @@ void RaftSnapshotData_KeyValue::InternalSwap(RaftSnapshotData_KeyValue* other) {
 // -------------------------------------------------------------------
 
 #ifndef _MSC_VER
+const int RaftSnapshotData::kRangeDescriptorFieldNumber;
 const int RaftSnapshotData::kKVFieldNumber;
 #endif  // !_MSC_VER
 
@@ -16820,6 +16824,7 @@ RaftSnapshotData::RaftSnapshotData()
 }
 
 void RaftSnapshotData::InitAsDefaultInstance() {
+  range_descriptor_ = const_cast< ::cockroach::proto::RangeDescriptor*>(&::cockroach::proto::RangeDescriptor::default_instance());
 }
 
 RaftSnapshotData::RaftSnapshotData(const RaftSnapshotData& from)
@@ -16832,6 +16837,7 @@ RaftSnapshotData::RaftSnapshotData(const RaftSnapshotData& from)
 
 void RaftSnapshotData::SharedCtor() {
   _cached_size_ = 0;
+  range_descriptor_ = NULL;
   ::memset(_has_bits_, 0, sizeof(_has_bits_));
 }
 
@@ -16842,6 +16848,7 @@ RaftSnapshotData::~RaftSnapshotData() {
 
 void RaftSnapshotData::SharedDtor() {
   if (this != default_instance_) {
+    delete range_descriptor_;
   }
 }
 
@@ -16871,6 +16878,9 @@ RaftSnapshotData* RaftSnapshotData::New(::google::protobuf::Arena* arena) const 
 }
 
 void RaftSnapshotData::Clear() {
+  if (has_range_descriptor()) {
+    if (range_descriptor_ != NULL) range_descriptor_->::cockroach::proto::RangeDescriptor::Clear();
+  }
   kv_.Clear();
   ::memset(_has_bits_, 0, sizeof(_has_bits_));
   if (_internal_metadata_.have_unknown_fields()) {
@@ -16888,9 +16898,22 @@ bool RaftSnapshotData::MergePartialFromCodedStream(
     tag = p.first;
     if (!p.second) goto handle_unusual;
     switch (::google::protobuf::internal::WireFormatLite::GetTagFieldNumber(tag)) {
-      // repeated .cockroach.proto.RaftSnapshotData.KeyValue KV = 1;
+      // optional .cockroach.proto.RangeDescriptor range_descriptor = 1;
       case 1: {
         if (tag == 10) {
+          DO_(::google::protobuf::internal::WireFormatLite::ReadMessageNoVirtual(
+               input, mutable_range_descriptor()));
+        } else {
+          goto handle_unusual;
+        }
+        if (input->ExpectTag(18)) goto parse_KV;
+        break;
+      }
+
+      // repeated .cockroach.proto.RaftSnapshotData.KeyValue KV = 2;
+      case 2: {
+        if (tag == 18) {
+         parse_KV:
           DO_(input->IncrementRecursionDepth());
          parse_loop_KV:
           DO_(::google::protobuf::internal::WireFormatLite::ReadMessageNoVirtualNoRecursionDepth(
@@ -16898,7 +16921,7 @@ bool RaftSnapshotData::MergePartialFromCodedStream(
         } else {
           goto handle_unusual;
         }
-        if (input->ExpectTag(10)) goto parse_loop_KV;
+        if (input->ExpectTag(18)) goto parse_loop_KV;
         input->UnsafeDecrementRecursionDepth();
         if (input->ExpectAtEnd()) goto success;
         break;
@@ -16929,10 +16952,16 @@ failure:
 void RaftSnapshotData::SerializeWithCachedSizes(
     ::google::protobuf::io::CodedOutputStream* output) const {
   // @@protoc_insertion_point(serialize_start:cockroach.proto.RaftSnapshotData)
-  // repeated .cockroach.proto.RaftSnapshotData.KeyValue KV = 1;
+  // optional .cockroach.proto.RangeDescriptor range_descriptor = 1;
+  if (has_range_descriptor()) {
+    ::google::protobuf::internal::WireFormatLite::WriteMessageMaybeToArray(
+      1, *this->range_descriptor_, output);
+  }
+
+  // repeated .cockroach.proto.RaftSnapshotData.KeyValue KV = 2;
   for (unsigned int i = 0, n = this->kv_size(); i < n; i++) {
     ::google::protobuf::internal::WireFormatLite::WriteMessageMaybeToArray(
-      1, this->kv(i), output);
+      2, this->kv(i), output);
   }
 
   if (_internal_metadata_.have_unknown_fields()) {
@@ -16945,11 +16974,18 @@ void RaftSnapshotData::SerializeWithCachedSizes(
 ::google::protobuf::uint8* RaftSnapshotData::SerializeWithCachedSizesToArray(
     ::google::protobuf::uint8* target) const {
   // @@protoc_insertion_point(serialize_to_array_start:cockroach.proto.RaftSnapshotData)
-  // repeated .cockroach.proto.RaftSnapshotData.KeyValue KV = 1;
+  // optional .cockroach.proto.RangeDescriptor range_descriptor = 1;
+  if (has_range_descriptor()) {
+    target = ::google::protobuf::internal::WireFormatLite::
+      WriteMessageNoVirtualToArray(
+        1, *this->range_descriptor_, target);
+  }
+
+  // repeated .cockroach.proto.RaftSnapshotData.KeyValue KV = 2;
   for (unsigned int i = 0, n = this->kv_size(); i < n; i++) {
     target = ::google::protobuf::internal::WireFormatLite::
       WriteMessageNoVirtualToArray(
-        1, this->kv(i), target);
+        2, this->kv(i), target);
   }
 
   if (_internal_metadata_.have_unknown_fields()) {
@@ -16963,7 +16999,14 @@ void RaftSnapshotData::SerializeWithCachedSizes(
 int RaftSnapshotData::ByteSize() const {
   int total_size = 0;
 
-  // repeated .cockroach.proto.RaftSnapshotData.KeyValue KV = 1;
+  // optional .cockroach.proto.RangeDescriptor range_descriptor = 1;
+  if (has_range_descriptor()) {
+    total_size += 1 +
+      ::google::protobuf::internal::WireFormatLite::MessageSizeNoVirtual(
+        *this->range_descriptor_);
+  }
+
+  // repeated .cockroach.proto.RaftSnapshotData.KeyValue KV = 2;
   total_size += 1 * this->kv_size();
   for (int i = 0; i < this->kv_size(); i++) {
     total_size +=
@@ -16997,6 +17040,11 @@ void RaftSnapshotData::MergeFrom(const ::google::protobuf::Message& from) {
 void RaftSnapshotData::MergeFrom(const RaftSnapshotData& from) {
   if (GOOGLE_PREDICT_FALSE(&from == this)) MergeFromFail(__LINE__);
   kv_.MergeFrom(from.kv_);
+  if (from._has_bits_[0 / 32] & (0xffu << (0 % 32))) {
+    if (from.has_range_descriptor()) {
+      mutable_range_descriptor()->::cockroach::proto::RangeDescriptor::MergeFrom(from.range_descriptor());
+    }
+  }
   if (from._internal_metadata_.have_unknown_fields()) {
     mutable_unknown_fields()->MergeFrom(from.unknown_fields());
   }
@@ -17024,6 +17072,7 @@ void RaftSnapshotData::Swap(RaftSnapshotData* other) {
   InternalSwap(other);
 }
 void RaftSnapshotData::InternalSwap(RaftSnapshotData* other) {
+  std::swap(range_descriptor_, other->range_descriptor_);
   kv_.UnsafeArenaSwap(&other->kv_);
   std::swap(_has_bits_[0], other->_has_bits_[0]);
   _internal_metadata_.Swap(&other->_internal_metadata_);
@@ -17151,7 +17200,50 @@ void RaftSnapshotData_KeyValue::clear_value() {
 
 // RaftSnapshotData
 
-// repeated .cockroach.proto.RaftSnapshotData.KeyValue KV = 1;
+// optional .cockroach.proto.RangeDescriptor range_descriptor = 1;
+bool RaftSnapshotData::has_range_descriptor() const {
+  return (_has_bits_[0] & 0x00000001u) != 0;
+}
+void RaftSnapshotData::set_has_range_descriptor() {
+  _has_bits_[0] |= 0x00000001u;
+}
+void RaftSnapshotData::clear_has_range_descriptor() {
+  _has_bits_[0] &= ~0x00000001u;
+}
+void RaftSnapshotData::clear_range_descriptor() {
+  if (range_descriptor_ != NULL) range_descriptor_->::cockroach::proto::RangeDescriptor::Clear();
+  clear_has_range_descriptor();
+}
+ const ::cockroach::proto::RangeDescriptor& RaftSnapshotData::range_descriptor() const {
+  // @@protoc_insertion_point(field_get:cockroach.proto.RaftSnapshotData.range_descriptor)
+  return range_descriptor_ != NULL ? *range_descriptor_ : *default_instance_->range_descriptor_;
+}
+ ::cockroach::proto::RangeDescriptor* RaftSnapshotData::mutable_range_descriptor() {
+  set_has_range_descriptor();
+  if (range_descriptor_ == NULL) {
+    range_descriptor_ = new ::cockroach::proto::RangeDescriptor;
+  }
+  // @@protoc_insertion_point(field_mutable:cockroach.proto.RaftSnapshotData.range_descriptor)
+  return range_descriptor_;
+}
+ ::cockroach::proto::RangeDescriptor* RaftSnapshotData::release_range_descriptor() {
+  clear_has_range_descriptor();
+  ::cockroach::proto::RangeDescriptor* temp = range_descriptor_;
+  range_descriptor_ = NULL;
+  return temp;
+}
+ void RaftSnapshotData::set_allocated_range_descriptor(::cockroach::proto::RangeDescriptor* range_descriptor) {
+  delete range_descriptor_;
+  range_descriptor_ = range_descriptor;
+  if (range_descriptor) {
+    set_has_range_descriptor();
+  } else {
+    clear_has_range_descriptor();
+  }
+  // @@protoc_insertion_point(field_set_allocated:cockroach.proto.RaftSnapshotData.range_descriptor)
+}
+
+// repeated .cockroach.proto.RaftSnapshotData.KeyValue KV = 2;
 int RaftSnapshotData::kv_size() const {
   return kv_.size();
 }

--- a/storage/engine/cockroach/proto/internal.pb.h
+++ b/storage/engine/cockroach/proto/internal.pb.h
@@ -4059,10 +4059,19 @@ class RaftSnapshotData : public ::google::protobuf::Message {
 
   // accessors -------------------------------------------------------
 
-  // repeated .cockroach.proto.RaftSnapshotData.KeyValue KV = 1;
+  // optional .cockroach.proto.RangeDescriptor range_descriptor = 1;
+  bool has_range_descriptor() const;
+  void clear_range_descriptor();
+  static const int kRangeDescriptorFieldNumber = 1;
+  const ::cockroach::proto::RangeDescriptor& range_descriptor() const;
+  ::cockroach::proto::RangeDescriptor* mutable_range_descriptor();
+  ::cockroach::proto::RangeDescriptor* release_range_descriptor();
+  void set_allocated_range_descriptor(::cockroach::proto::RangeDescriptor* range_descriptor);
+
+  // repeated .cockroach.proto.RaftSnapshotData.KeyValue KV = 2;
   int kv_size() const;
   void clear_kv();
-  static const int kKVFieldNumber = 1;
+  static const int kKVFieldNumber = 2;
   const ::cockroach::proto::RaftSnapshotData_KeyValue& kv(int index) const;
   ::cockroach::proto::RaftSnapshotData_KeyValue* mutable_kv(int index);
   ::cockroach::proto::RaftSnapshotData_KeyValue* add_kv();
@@ -4073,10 +4082,13 @@ class RaftSnapshotData : public ::google::protobuf::Message {
 
   // @@protoc_insertion_point(class_scope:cockroach.proto.RaftSnapshotData)
  private:
+  inline void set_has_range_descriptor();
+  inline void clear_has_range_descriptor();
 
   ::google::protobuf::internal::InternalMetadataWithArena _internal_metadata_;
   ::google::protobuf::uint32 _has_bits_[1];
   mutable int _cached_size_;
+  ::cockroach::proto::RangeDescriptor* range_descriptor_;
   ::google::protobuf::RepeatedPtrField< ::cockroach::proto::RaftSnapshotData_KeyValue > kv_;
   friend void  protobuf_AddDesc_cockroach_2fproto_2finternal_2eproto();
   friend void protobuf_AssignDesc_cockroach_2fproto_2finternal_2eproto();
@@ -8762,7 +8774,50 @@ inline void RaftSnapshotData_KeyValue::set_allocated_value(::std::string* value)
 
 // RaftSnapshotData
 
-// repeated .cockroach.proto.RaftSnapshotData.KeyValue KV = 1;
+// optional .cockroach.proto.RangeDescriptor range_descriptor = 1;
+inline bool RaftSnapshotData::has_range_descriptor() const {
+  return (_has_bits_[0] & 0x00000001u) != 0;
+}
+inline void RaftSnapshotData::set_has_range_descriptor() {
+  _has_bits_[0] |= 0x00000001u;
+}
+inline void RaftSnapshotData::clear_has_range_descriptor() {
+  _has_bits_[0] &= ~0x00000001u;
+}
+inline void RaftSnapshotData::clear_range_descriptor() {
+  if (range_descriptor_ != NULL) range_descriptor_->::cockroach::proto::RangeDescriptor::Clear();
+  clear_has_range_descriptor();
+}
+inline const ::cockroach::proto::RangeDescriptor& RaftSnapshotData::range_descriptor() const {
+  // @@protoc_insertion_point(field_get:cockroach.proto.RaftSnapshotData.range_descriptor)
+  return range_descriptor_ != NULL ? *range_descriptor_ : *default_instance_->range_descriptor_;
+}
+inline ::cockroach::proto::RangeDescriptor* RaftSnapshotData::mutable_range_descriptor() {
+  set_has_range_descriptor();
+  if (range_descriptor_ == NULL) {
+    range_descriptor_ = new ::cockroach::proto::RangeDescriptor;
+  }
+  // @@protoc_insertion_point(field_mutable:cockroach.proto.RaftSnapshotData.range_descriptor)
+  return range_descriptor_;
+}
+inline ::cockroach::proto::RangeDescriptor* RaftSnapshotData::release_range_descriptor() {
+  clear_has_range_descriptor();
+  ::cockroach::proto::RangeDescriptor* temp = range_descriptor_;
+  range_descriptor_ = NULL;
+  return temp;
+}
+inline void RaftSnapshotData::set_allocated_range_descriptor(::cockroach::proto::RangeDescriptor* range_descriptor) {
+  delete range_descriptor_;
+  range_descriptor_ = range_descriptor;
+  if (range_descriptor) {
+    set_has_range_descriptor();
+  } else {
+    clear_has_range_descriptor();
+  }
+  // @@protoc_insertion_point(field_set_allocated:cockroach.proto.RaftSnapshotData.range_descriptor)
+}
+
+// repeated .cockroach.proto.RaftSnapshotData.KeyValue KV = 2;
 inline int RaftSnapshotData::kv_size() const {
   return kv_.size();
 }


### PR DESCRIPTION
In My setup, when run the following shell script, a panic log got catched in 2.log or 3.log.

``` shell
./cockroach start --addr=":8080" --gossip=":8080" --stores=hdd=$HOME/roach-data/1 --verbosity=1 > 1.log 2>&1 &
sleep 5
./cockroach range split a
./cockroach start --addr=":8081" --gossip=":8080" --stores=hdd=$HOME/roach-data/2 --verbosity=1 > 2.log 2>&1&
./cockroach start --addr=":8082" --gossip=":8080" --stores=hdd=$HOME/roach-data/3 --verbosity=1 > 3.log 2>&1 &
```

panic log is:

``` log
I0609 22:15:59.186143    6892 multiraft.go:514] node 200000002: got message for unknown group 2; creating it                                                                    
I0609 22:15:59.186380    6892 raft.go:390] 200000002 became follower at term 0                                                                                                  
I0609 22:15:59.186485    6892 raft.go:207] newRaft 200000002 [peers: [], term: 0, commit: 0, applied: 0, lastindex: 0, lastterm: 0]                                             
I0609 22:15:59.186494    6892 raft.go:390] 200000002 became follower at term 1                                                                                                  
I0609 22:15:59.187435    6892 raft.go:479] 200000002 [term: 1] received a MsgApp message with higher term from 100000001 [term: 6]                                              
I0609 22:15:59.187450    6892 raft.go:390] 200000002 became follower at term 6                                                                                                  
I0609 22:15:59.188349    6892 raft.go:698] 200000002 [commit: 0, lastindex: 0, lastterm: 0] starts to restore snapshot [index: 17, term: 6]                                     
I0609 22:15:59.188366    6892 log.go:250] log [committed=0, applied=0, unstable.offset=1, len(unstable.Entries)=0] starts to restore snapshot [index: 17, term: 6]              
I0609 22:15:59.188383    6892 raft.go:710] 200000002 restored progress of 100000001 [next = 18, match = 0, state = ProgressStateProbe, waiting = false, pendingSnapshot = 0]    
I0609 22:15:59.188392    6892 raft.go:710] 200000002 restored progress of 200000002 [next = 18, match = 17, state = ProgressStateProbe, waiting = false, pendingSnapshot = 0]   
I0609 22:15:59.188398    6892 raft.go:675] 200000002 [commit: 0] restored snapshot [index: 17, term: 6]                                                                         
panic: store.go:1079: attempted to process uninitialized range range=0 ["" - "")                                                                                                

goroutine 53 [running]:                                                                                                                                                         
github.com/cockroachdb/cockroach/multiraft.func·008()                                                                                                                           
        /gopath/src/github.com/cockroachdb/cockroach/multiraft/storage.go:176 +0x7e9                                                                                
github.com/cockroachdb/cockroach/util.func·001()                                                                                                                                
        /gopath/src/github.com/cockroachdb/cockroach/util/stopper.go:75 +0x51                                                                                       
created by github.com/cockroachdb/cockroach/util.(*Stopper).RunWorker                                                                                                           
        /gopath/src/github.com/cockroachdb/cockroach/util/stopper.go:76 +0xe3                                                                                       
```

The reason for the panic is that raft group 2 is creating before raft group 1 in second or third cockroach node, but the StartKey/EndKey is not initialized for raft group 2, so it will cause panic in ApplySnapshot.
When creating of a range other than raftID 1 is triggered by multiraft, the StartKey and EndKey of that range is invalid, so the following code snippet in ApplySnapshot method in range_raftstorage.go is no op or it will find the RangeDesc with RaftID 1 which StartKey is KeyMin, either case is not valid.

``` go
        if _, err := engine.MVCCGetProto(batch, keys.RangeDescriptorKey(r.Desc().StartKey),
                r.rm.Clock().Now(), false, nil, &desc); err != nil {
                return err
        } 
```

This shell script is made intentionally, but in reality when a New Replica being add to a raft group, the same will happen. 
