### PR TITLE
Make the range GC queue check unleased duration

### DIFF
--- a/storage/client_raft_test.go
+++ b/storage/client_raft_test.go
@@ -646,8 +646,9 @@ func TestReplicateAddAndRemove(t *testing.T) {
 		// the downed node removes the data from this range after coming
 		// back up.
 
-		// Wait out the leader lease to make the range GC'able.
-		mtc.manualClock.Increment(int64(storage.DefaultLeaderLeaseDuration) + 1)
+		// Wait out the leader lease and the unleased duration to make the range GC'able.
+		mtc.manualClock.Increment(int64(storage.DefaultLeaderLeaseDuration) +
+			int64(storage.RangeGCQueueUnleasedDuration) + 1)
 		mtc.stores[1].ForceRangeGCScan(t)
 
 		// The removed store no longer has any of the data from the range.


### PR DESCRIPTION
This commit changes `shouldQueue` to return true when a range's lease has been expired for enough time period (default 1 hour). This will prevent unnecessary GC check that will be likely to fail.

Discussed in https://github.com/cockroachdb/cockroach/pull/1240.
