### PR TITLE
Miscellaneous cleanup of the client implementation.

### DIFF
--- a/client/client_test.go
+++ b/client/client_test.go
@@ -85,11 +85,8 @@ func createTestNotifyClient(addr string, priority int) (*client.DB, *notifyingSe
 	if err != nil {
 		log.Fatal(err)
 	}
-	// TODO(peter): This is currently the only use of
-	// InternalSender/InternalSetSender. Remove once db.Sender is exposed.
-	origSender := db.InternalSender()
-	sender := &notifyingSender{wrapped: origSender}
-	db.InternalSetSender(sender)
+	sender := &notifyingSender{wrapped: db.Sender}
+	db.Sender = sender
 	return db, sender
 }
 

--- a/client/db_test.go
+++ b/client/db_test.go
@@ -305,8 +305,6 @@ func TestCommonMethods(t *testing.T) {
 		key{batchType, "InternalAddCall"}:   {},
 		key{dbType, "AdminMerge"}:           {},
 		key{dbType, "AdminSplit"}:           {},
-		key{dbType, "InternalSender"}:       {},
-		key{dbType, "InternalSetSender"}:    {},
 		key{dbType, "Run"}:                  {},
 		key{dbType, "Tx"}:                   {},
 		key{txType, "Commit"}:               {},

--- a/client/txn.go
+++ b/client/txn.go
@@ -39,6 +39,8 @@ var (
 	}
 )
 
+// txnSender implements the Sender interface and is used to hide the Send
+// method from the txn interface.
 type txnSender struct {
 	*txn
 }
@@ -71,25 +73,21 @@ type txn struct {
 	wrapped      Sender
 	txn          proto.Transaction
 	txnSender    txnSender
-	prepared     []Call
 	haveTxnWrite bool // True if there were transactional writes
 	haveEndTxn   bool // True if there was an explicit EndTransaction
 }
 
-func newTxn(kv *kv) *txn {
-	t := &txn{
-		kv:      *kv,
-		wrapped: kv.Sender,
-	}
+func (t *txn) init(kv *kv) {
+	t.kv = *kv
+	t.wrapped = kv.Sender
 	t.txnSender.txn = t
 	t.kv.Sender = &t.txnSender
-	return t
 }
 
 func (t *txn) exec(retryable func(txn *txn) error) error {
 	// Run retryable in a retry loop until we encounter a success or
 	// error condition this loop isn't capable of handling.
-	retryOpts := t.kv.TxnRetryOptions
+	retryOpts := t.kv.txnRetryOptions
 	retryOpts.Tag = t.txn.Name
 	err := retry.WithBackoff(retryOpts, func() (retry.Status, error) {
 		t.haveTxnWrite, t.haveEndTxn = false, false // always reset before [re]starting txn
@@ -102,11 +100,8 @@ func (t *txn) exec(retryable func(txn *txn) error) error {
 				// timestamps in order to commit.
 				etArgs := &proto.EndTransactionRequest{Commit: true}
 				etReply := &proto.EndTransactionResponse{}
-				// Prepare and flush for end txn in order to execute entire txn in
-				// a single round trip if possible.
-				t.Prepare(Call{Args: etArgs, Reply: etReply})
+				err = t.send(Call{Args: etArgs, Reply: etReply})
 			}
-			err = t.Flush()
 		}
 		if restartErr, ok := err.(proto.TransactionRestartError); ok {
 			if restartErr.CanRestartTransaction() == proto.TransactionRestart_IMMEDIATE {
@@ -119,7 +114,7 @@ func (t *txn) exec(retryable func(txn *txn) error) error {
 		return retry.Break, err
 	})
 	if err != nil && t.haveTxnWrite {
-		if replyErr := t.Run(Call{
+		if replyErr := t.send(Call{
 			Args:  &proto.EndTransactionRequest{Commit: false},
 			Reply: &proto.EndTransactionResponse{},
 		}); replyErr != nil {
@@ -130,58 +125,14 @@ func (t *txn) exec(retryable func(txn *txn) error) error {
 	return err
 }
 
-// Run runs the specified calls synchronously in a single batch and
+// send runs the specified calls synchronously in a single batch and
 // returns any errors.
-func (t *txn) Run(calls ...Call) error {
+func (t *txn) send(calls ...Call) error {
 	if len(calls) == 0 {
 		return nil
 	}
-	if len(t.prepared) > 0 || len(calls) > 1 {
-		t.Prepare(calls...)
-		return t.Flush()
-	}
 	t.updateState(calls)
-	return t.kv.Run(calls...)
-}
-
-// Prepare accepts a KV API call, specified by arguments and a reply
-// struct. The call will be buffered locally until the first call to
-// Flush(), at which time it will be sent for execution as part of a
-// batch call. Using Prepare/Flush parallelizes queries and updates
-// and should be used where possible for efficiency.
-//
-// For clients using an HTTP sender, Prepare/Flush allows multiple
-// commands to be sent over the same connection. Prepare/Flush can
-// dramatically improve efficiency by compressing multiple writes into
-// a single atomic update in the event that the writes are to keys
-// within a single range.
-//
-// TODO(pmattis): Can Prepare/Flush be replaced with a Batch struct?
-// Doing so could potentially make the Txn interface more symmetric
-// with the KV interface, but potentially removes the optimization to
-// send the EndTransaction in the same batch as the final set of
-// prepared calls.
-func (t *txn) Prepare(calls ...Call) {
-	t.updateState(calls)
-	for _, c := range calls {
-		c.resetClientCmdID()
-	}
-	t.prepared = append(t.prepared, calls...)
-}
-
-// Flush sends all previously prepared calls, buffered by invocations
-// of Prepare(). The calls are organized into a single batch command
-// and sent together. Flush returns nil if all prepared calls are
-// executed successfully. Otherwise, Flush returns the first error,
-// where calls are executed in the order in which they were prepared.
-// After Flush returns, all prepared reply structs will be valid.
-func (t *txn) Flush() error {
-	calls := t.prepared
-	t.prepared = nil
-	if len(calls) == 0 {
-		return nil
-	}
-	return t.kv.Run(calls...)
+	return t.kv.send(calls...)
 }
 
 func (t *txn) updateState(calls []Call) {


### PR DESCRIPTION
Removed txn.{Prepare,Flush} as they were no longer being used outside of
the client package.

Embedded kv directly in DB which allowed DB.Sender to be exposed
removing the need for DB.{InternalSender,InternalSetSender}.

Converted kv_test.go from using client.kv to client.DB.

Still todo: merge the txn and Tx structs and the kv and DB structs.

See #997.
