### PR TITLE
Rename client.Tx to client.Txn.

### DIFF
--- a/acceptance/single_key_test.go
+++ b/acceptance/single_key_test.go
@@ -86,8 +86,8 @@ func TestSingleKey(t *testing.T) {
 			var r result
 			for time.Now().Before(deadline) {
 				start := time.Now()
-				err := c.Tx(func(tx *client.Tx) error {
-					r, err := tx.Get(key)
+				err := c.Txn(func(txn *client.Txn) error {
+					r, err := txn.Get(key)
 					if err != nil {
 						return err
 					}
@@ -95,7 +95,7 @@ func TestSingleKey(t *testing.T) {
 					if err := v.UnmarshalBinary(r.ValueBytes()); err != nil {
 						return err
 					}
-					return tx.Commit(tx.B.Put(key, v+1))
+					return txn.Commit(txn.B.Put(key, v+1))
 				})
 				if err != nil {
 					resultCh <- result{err: err}

--- a/client/db_test.go
+++ b/client/db_test.go
@@ -203,8 +203,8 @@ func ExampleTx_Commit() {
 	s, db := setup()
 	defer s.Stop()
 
-	err := db.Tx(func(tx *client.Tx) error {
-		return tx.Commit(tx.B.Put("aa", "1").Put("ab", "2"))
+	err := db.Txn(func(txn *client.Txn) error {
+		return txn.Commit(txn.B.Put("aa", "1").Put("ab", "2"))
 	})
 	if err != nil {
 		panic(err)
@@ -282,9 +282,9 @@ func TestDebugName(t *testing.T) {
 
 	_, file, _, _ := runtime.Caller(0)
 	base := filepath.Base(file)
-	_ = db.Tx(func(tx *client.Tx) error {
-		if !strings.HasPrefix(tx.DebugName(), base+":") {
-			t.Fatalf("expected \"%s\" to have the prefix \"%s:\"", tx.DebugName(), base)
+	_ = db.Txn(func(txn *client.Txn) error {
+		if !strings.HasPrefix(txn.DebugName(), base+":") {
+			t.Fatalf("expected \"%s\" to have the prefix \"%s:\"", txn.DebugName(), base)
 		}
 		return nil
 	})
@@ -294,25 +294,25 @@ func TestCommonMethods(t *testing.T) {
 	batchType := reflect.TypeOf(&client.Batch{})
 	batcherType := reflect.TypeOf(client.DB{}.B)
 	dbType := reflect.TypeOf(&client.DB{})
-	txType := reflect.TypeOf(&client.Tx{})
-	types := []reflect.Type{batchType, batcherType, dbType, txType}
+	txnType := reflect.TypeOf(&client.Txn{})
+	types := []reflect.Type{batchType, batcherType, dbType, txnType}
 
 	type key struct {
 		typ    reflect.Type
 		method string
 	}
 	blacklist := map[key]struct{}{
-		key{batchType, "InternalAddCall"}:   {},
-		key{dbType, "AdminMerge"}:           {},
-		key{dbType, "AdminSplit"}:           {},
-		key{dbType, "Run"}:                  {},
-		key{dbType, "Tx"}:                   {},
-		key{txType, "Commit"}:               {},
-		key{txType, "DebugName"}:            {},
-		key{txType, "InternalSetPriority"}:  {},
-		key{txType, "Run"}:                  {},
-		key{txType, "SetDebugName"}:         {},
-		key{txType, "SetSnapshotIsolation"}: {},
+		key{batchType, "InternalAddCall"}:    {},
+		key{dbType, "AdminMerge"}:            {},
+		key{dbType, "AdminSplit"}:            {},
+		key{dbType, "Run"}:                   {},
+		key{dbType, "Txn"}:                   {},
+		key{txnType, "Commit"}:               {},
+		key{txnType, "DebugName"}:            {},
+		key{txnType, "InternalSetPriority"}:  {},
+		key{txnType, "Run"}:                  {},
+		key{txnType, "SetDebugName"}:         {},
+		key{txnType, "SetSnapshotIsolation"}: {},
 	}
 
 	for b := range blacklist {

--- a/kv/split_test.go
+++ b/kv/split_test.go
@@ -58,7 +58,7 @@ func startTestWriter(db *client.DB, i int64, valBytes int32, wg *sync.WaitGroup,
 			return
 		default:
 			first := true
-			err := db.Tx(func(tx *client.Tx) error {
+			err := db.Txn(func(txn *client.Txn) error {
 				if first && txnChannel != nil {
 					txnChannel <- struct{}{}
 				} else if !first && retries != nil {
@@ -68,7 +68,7 @@ func startTestWriter(db *client.DB, i int64, valBytes int32, wg *sync.WaitGroup,
 				for j := 0; j <= int(src.Int31n(10)); j++ {
 					key := util.RandBytes(src, 10)
 					val := util.RandBytes(src, int(src.Int31n(valBytes)))
-					if err := tx.Put(key, val); err != nil {
+					if err := txn.Put(key, val); err != nil {
 						log.Infof("experienced an error in routine %d: %s", i, err)
 						return err
 					}

--- a/kv/txn_coord_sender.go
+++ b/kv/txn_coord_sender.go
@@ -452,11 +452,11 @@ func (tc *TxnCoordSender) sendOne(call client.Call) {
 			return
 		}
 		call.Reply.Reset()
-		if err := tmpDB.Tx(func(tx *client.Tx) error {
-			tx.SetDebugName("auto-wrap")
+		if err := tmpDB.Txn(func(txn *client.Txn) error {
+			txn.SetDebugName("auto-wrap")
 			b := &client.Batch{}
 			b.InternalAddCall(call)
-			return tx.Commit(b)
+			return txn.Commit(b)
 		}); err != nil {
 			log.Warning(err)
 		}

--- a/server/status/feed_test.go
+++ b/server/status/feed_test.go
@@ -230,8 +230,8 @@ func TestServerNodeEventFeed(t *testing.T) {
 	}
 
 	// Add some data in a transaction
-	err = db.Tx(func(tx *client.Tx) error {
-		return tx.Commit(tx.B.Put("a", "asdf").Put("c", "jkl;"))
+	err = db.Txn(func(txn *client.Txn) error {
+		return txn.Commit(txn.B.Put("a", "asdf").Put("c", "jkl;"))
 	})
 	if err != nil {
 		t.Fatalf("error putting data to db: %s", err)

--- a/storage/client_event_test.go
+++ b/storage/client_event_test.go
@@ -181,10 +181,10 @@ func TestMultiStoreEventFeed(t *testing.T) {
 	mtc.replicateRange(raftID, 0, 1, 2)
 
 	// Add some data in a transaction
-	err := mtc.db.Tx(func(tx *client.Tx) error {
-		b := tx.B.Put("a", "asdf")
+	err := mtc.db.Txn(func(txn *client.Txn) error {
+		b := txn.B.Put("a", "asdf")
 		b.Put("c", "jkl;")
-		return tx.Commit(b)
+		return txn.Commit(b)
 	})
 	if err != nil {
 		t.Fatalf("error putting data to db: %s", err)

--- a/storage/range_tree_test.go
+++ b/storage/range_tree_test.go
@@ -30,7 +30,7 @@ func createTreeContext(rootKey *proto.Key, nodes []*proto.RangeTreeNode) *treeCo
 		RootKey: *rootKey,
 	}
 	tc := &treeContext{
-		tx:    nil,
+		txn:   nil,
 		tree:  root,
 		dirty: false,
 		nodes: map[string]cachedNode{},


### PR DESCRIPTION
Mostly done using gorename with a few hand edits to comments.

Simplify txnSender slightly by making it a type alias for Txn.

Fixes #997.
