### PR TITLE
Move client.Batch to its own file.

### DIFF
--- a/acceptance/single_key_test.go
+++ b/acceptance/single_key_test.go
@@ -95,7 +95,9 @@ func TestSingleKey(t *testing.T) {
 					if err := v.UnmarshalBinary(r.ValueBytes()); err != nil {
 						return err
 					}
-					return txn.Commit(client.B().Put(key, v+1))
+					b := &client.Batch{}
+					b.Put(key, v+1)
+					return txn.Commit(b)
 				})
 				if err != nil {
 					resultCh <- result{err: err}

--- a/acceptance/single_key_test.go
+++ b/acceptance/single_key_test.go
@@ -95,7 +95,7 @@ func TestSingleKey(t *testing.T) {
 					if err := v.UnmarshalBinary(r.ValueBytes()); err != nil {
 						return err
 					}
-					return txn.Commit(txn.B.Put(key, v+1))
+					return txn.Commit(client.B().Put(key, v+1))
 				})
 				if err != nil {
 					resultCh <- result{err: err}

--- a/client/batch.go
+++ b/client/batch.go
@@ -1,0 +1,399 @@
+// Copyright 2015 The Cockroach Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+// implied. See the License for the specific language governing
+// permissions and limitations under the License. See the AUTHORS file
+// for names of contributors.
+//
+// Author: Peter Mattis (peter@cockroachlabs.com)
+
+package client
+
+import (
+	"fmt"
+
+	"github.com/cockroachdb/cockroach/proto"
+	gogoproto "github.com/gogo/protobuf/proto"
+)
+
+// Batch provides for the parallel execution of a number of database
+// operations. Operations are added to the Batch and then the Batch is executed
+// via either DB.Run, Txn.Run or Txn.Commit.
+//
+// TODO(pmattis): Allow a timestamp to be specified which is applied to all
+// operations within the batch.
+type Batch struct {
+	// Results contains an entry for each operation added to the batch. The order
+	// of the results matches the order the operations were added to the
+	// batch. For example:
+	//
+	//   b := client.B().Put("a", "1").Put("b", "2")
+	//   _ = db.Run(b)
+	//   // string(b.Results[0].Rows[0].Key) == "a"
+	//   // string(b.Results[1].Rows[0].Key) == "b"
+	Results    []Result
+	calls      []Call
+	resultsBuf [8]Result
+	rowsBuf    [8]KeyValue
+	rowsIdx    int
+}
+
+// B creates a new empty batch:
+//
+//   err := db.Run(client.B().Put("a", "1").Put("b", "2"))
+func B() *Batch {
+	return &Batch{}
+}
+
+func (b *Batch) prepare() error {
+	for _, r := range b.Results {
+		if err := r.Err; err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func (b *Batch) initResult(calls, numRows int, err error) {
+	r := Result{calls: calls, Err: err}
+	if numRows > 0 {
+		if b.rowsIdx+numRows <= len(b.rowsBuf) {
+			r.Rows = b.rowsBuf[b.rowsIdx : b.rowsIdx+numRows]
+			b.rowsIdx += numRows
+		} else {
+			r.Rows = make([]KeyValue, numRows)
+		}
+	}
+	if b.Results == nil {
+		b.Results = b.resultsBuf[0:0]
+	}
+	b.Results = append(b.Results, r)
+}
+
+func (b *Batch) fillResults() error {
+	offset := 0
+	for i := range b.Results {
+		result := &b.Results[i]
+
+		for k := 0; k < result.calls; k++ {
+			call := b.calls[offset+k]
+
+			if result.Err == nil {
+				result.Err = call.Reply.Header().GoError()
+			}
+
+			switch t := call.Reply.(type) {
+			case *proto.GetResponse:
+				row := &result.Rows[k]
+				row.Key = []byte(call.Args.(*proto.GetRequest).Key)
+				if result.Err == nil {
+					row.setValue(t.Value)
+				}
+			case *proto.PutResponse:
+				req := call.Args.(*proto.PutRequest)
+				row := &result.Rows[k]
+				row.Key = []byte(req.Key)
+				if result.Err == nil {
+					row.setValue(&req.Value)
+					row.setTimestamp(t.Timestamp)
+				}
+			case *proto.ConditionalPutResponse:
+				req := call.Args.(*proto.ConditionalPutRequest)
+				row := &result.Rows[k]
+				row.Key = []byte(req.Key)
+				if result.Err == nil {
+					row.setValue(&req.Value)
+					row.setTimestamp(t.Timestamp)
+				}
+			case *proto.IncrementResponse:
+				row := &result.Rows[k]
+				row.Key = []byte(call.Args.(*proto.IncrementRequest).Key)
+				if result.Err == nil {
+					// TODO(pmattis): Should IncrementResponse contain a
+					// proto.Value so that the timestamp can be returned?
+					row.Value = &t.NewValue
+				}
+			case *proto.ScanResponse:
+				result.Rows = make([]KeyValue, len(t.Rows))
+				for j, kv := range t.Rows {
+					row := &result.Rows[j]
+					row.Key = kv.Key
+					row.setValue(&kv.Value)
+				}
+			case *proto.DeleteResponse:
+				row := &result.Rows[k]
+				row.Key = []byte(call.Args.(*proto.DeleteRequest).Key)
+
+			case *proto.AdminMergeResponse:
+			case *proto.AdminSplitResponse:
+			case *proto.DeleteRangeResponse:
+			case *proto.EndTransactionResponse:
+			case *proto.InternalBatchResponse:
+			case *proto.InternalGCResponse:
+			case *proto.InternalMergeResponse:
+			case *proto.InternalPushTxnResponse:
+			case *proto.InternalRangeLookupResponse:
+			case *proto.InternalResolveIntentResponse:
+			case *proto.InternalResolveIntentRangeResponse:
+				// Nothing to do for these methods as they do not generate any
+				// rows. For the proto.Internal* responses the caller will have hold of
+				// the response object itself.
+
+			default:
+				if result.Err == nil {
+					result.Err = fmt.Errorf("unsupported reply: %T", call.Reply)
+				}
+			}
+		}
+		offset += result.calls
+	}
+
+	for i := range b.Results {
+		result := &b.Results[i]
+		if result.Err != nil {
+			return result.Err
+		}
+	}
+	return nil
+}
+
+// InternalAddCall adds the specified call to the batch. It is intended for
+// internal use only.
+func (b *Batch) InternalAddCall(call Call) {
+	numRows := 0
+	switch call.Args.(type) {
+	case *proto.GetRequest,
+		*proto.PutRequest,
+		*proto.ConditionalPutRequest,
+		*proto.IncrementRequest,
+		*proto.DeleteRequest:
+		numRows = 1
+	}
+	b.calls = append(b.calls, call)
+	b.initResult(1 /* calls */, numRows, nil)
+}
+
+// Get retrieves the value for a key. A new result will be appended to the
+// batch which will contain a single row.
+//
+//   r, err := db.Get("a")
+//   // string(r.Rows[0].Key) == "a"
+//
+// key can be either a byte slice, a string, a fmt.Stringer or an
+// encoding.BinaryMarshaler.
+func (b *Batch) Get(key interface{}) *Batch {
+	k, err := marshalKey(key)
+	if err != nil {
+		b.initResult(0, 1, err)
+		return b
+	}
+	b.calls = append(b.calls, Get(proto.Key(k)))
+	b.initResult(1, 1, nil)
+	return b
+}
+
+// GetProto retrieves the value for a key and decodes the result as a proto
+// message. A new result will be appended to the batch which will contain a
+// single row. Note that the proto will not be decoded until after the batch is
+// executed using DB.Run or Txn.Run.
+//
+// key can be either a byte slice, a string, a fmt.Stringer or an
+// encoding.BinaryMarshaler.
+func (b *Batch) GetProto(key interface{}, msg gogoproto.Message) *Batch {
+	k, err := marshalKey(key)
+	if err != nil {
+		b.initResult(0, 1, err)
+		return b
+	}
+	b.calls = append(b.calls, GetProto(proto.Key(k), msg))
+	b.initResult(1, 1, nil)
+	return b
+}
+
+// Put sets the value for a key.
+//
+// A new result will be appended to the batch which will contain a single row
+// and Result.Err will indicate success or failure.
+//
+// key can be either a byte slice, a string, a fmt.Stringer or an
+// encoding.BinaryMarshaler. value can be any key type or a proto.Message.
+func (b *Batch) Put(key, value interface{}) *Batch {
+	k, err := marshalKey(key)
+	if err != nil {
+		b.initResult(0, 1, err)
+		return b
+	}
+	v, err := marshalValue(value)
+	if err != nil {
+		b.initResult(0, 1, err)
+		return b
+	}
+	b.calls = append(b.calls, Put(proto.Key(k), v))
+	b.initResult(1, 1, nil)
+	return b
+}
+
+// CPut conditionally sets the value for a key if the existing value is equal
+// to expValue. To conditionally set a value only if there is no existing entry
+// pass nil for expValue.
+//
+// A new result will be appended to the batch which will contain a single row
+// and Result.Err will indicate success or failure.
+//
+// key can be either a byte slice, a string, a fmt.Stringer or an
+// encoding.BinaryMarshaler. value can be any key type or a proto.Message.
+func (b *Batch) CPut(key, value, expValue interface{}) *Batch {
+	k, err := marshalKey(key)
+	if err != nil {
+		b.initResult(0, 1, err)
+		return b
+	}
+	v, err := marshalValue(value)
+	if err != nil {
+		b.initResult(0, 1, err)
+		return b
+	}
+	ev, err := marshalValue(expValue)
+	if err != nil {
+		b.initResult(0, 1, err)
+		return b
+	}
+	b.calls = append(b.calls, ConditionalPut(proto.Key(k), v, ev))
+	b.initResult(1, 1, nil)
+	return b
+}
+
+// Inc increments the integer value at key. If the key does not exist it will
+// be created with an initial value of 0 which will then be incremented. If the
+// key exists but was set using Put or CPut an error will be returned.
+//
+// A new result will be appended to the batch which will contain a single row
+// and Result.Err will indicate success or failure.
+//
+// key can be either a byte slice, a string, a fmt.Stringer or an
+// encoding.BinaryMarshaler.
+func (b *Batch) Inc(key interface{}, value int64) *Batch {
+	k, err := marshalKey(key)
+	if err != nil {
+		b.initResult(0, 1, err)
+		return b
+	}
+	b.calls = append(b.calls, Increment(proto.Key(k), value))
+	b.initResult(1, 1, nil)
+	return b
+}
+
+// Scan retrieves the rows between begin (inclusive) and end (exclusive).
+//
+// A new result will be appended to the batch which will contain up to maxRows
+// rows and Result.Err will indicate success or failure.
+//
+// key can be either a byte slice, a string, a fmt.Stringer or an
+// encoding.BinaryMarshaler.
+func (b *Batch) Scan(s, e interface{}, maxRows int64) *Batch {
+	begin, err := marshalKey(s)
+	if err != nil {
+		b.initResult(0, 0, err)
+		return b
+	}
+	end, err := marshalKey(e)
+	if err != nil {
+		b.initResult(0, 0, err)
+		return b
+	}
+	b.calls = append(b.calls, Scan(proto.Key(begin), proto.Key(end), maxRows))
+	b.initResult(1, 0, nil)
+	return b
+}
+
+// Del deletes one or more keys.
+//
+// A new result will be appended to the batch and each key will have a
+// corresponding row in the returned Result.
+//
+// key can be either a byte slice, a string, a fmt.Stringer or an
+// encoding.BinaryMarshaler.
+func (b *Batch) Del(keys ...interface{}) *Batch {
+	var calls []Call
+	for _, key := range keys {
+		k, err := marshalKey(key)
+		if err != nil {
+			b.initResult(0, len(keys), err)
+			return b
+		}
+		calls = append(calls, Delete(proto.Key(k)))
+	}
+	b.calls = append(b.calls, calls...)
+	b.initResult(len(calls), len(calls), nil)
+	return b
+}
+
+// DelRange deletes the rows between begin (inclusive) and end (exclusive).
+//
+// A new result will be appended to the batch which will contain 0 rows and
+// Result.Err will indicate success or failure.
+//
+// key can be either a byte slice, a string, a fmt.Stringer or an
+// encoding.BinaryMarshaler.
+func (b *Batch) DelRange(s, e interface{}) *Batch {
+	begin, err := marshalKey(s)
+	if err != nil {
+		b.initResult(0, 0, err)
+		return b
+	}
+	end, err := marshalKey(e)
+	if err != nil {
+		b.initResult(0, 0, err)
+		return b
+	}
+	b.calls = append(b.calls, DeleteRange(proto.Key(begin), proto.Key(end)))
+	b.initResult(1, 0, nil)
+	return b
+}
+
+// adminMerge is only exported on DB. It is here for symmetry with the
+// other operations.
+func (b *Batch) adminMerge(key interface{}) *Batch {
+	k, err := marshalKey(key)
+	if err != nil {
+		b.initResult(0, 0, err)
+		return b
+	}
+	req := &proto.AdminMergeRequest{
+		RequestHeader: proto.RequestHeader{
+			Key: proto.Key(k),
+		},
+	}
+	resp := &proto.AdminMergeResponse{}
+	b.calls = append(b.calls, Call{Args: req, Reply: resp})
+	b.initResult(1, 0, nil)
+	return b
+}
+
+// adminSplit is only exported on DB. It is here for symmetry with the
+// other operations.
+func (b *Batch) adminSplit(splitKey interface{}) *Batch {
+	k, err := marshalKey(splitKey)
+	if err != nil {
+		b.initResult(0, 0, err)
+		return b
+	}
+	req := &proto.AdminSplitRequest{
+		RequestHeader: proto.RequestHeader{
+			Key: proto.Key(k),
+		},
+	}
+	req.SplitKey = proto.Key(k)
+	resp := &proto.AdminSplitResponse{}
+	b.calls = append(b.calls, Call{Args: req, Reply: resp})
+	b.initResult(1, 0, nil)
+	return b
+}

--- a/client/db.go
+++ b/client/db.go
@@ -135,12 +135,6 @@ func (r Result) String() string {
 // DB is a database handle to a single cockroach cluster. A DB is safe for
 // concurrent use by multiple goroutines.
 type DB struct {
-	// B is a helper to make creating a new batch and performing an
-	// operation on it easer:
-	//
-	//   err := db.Run(db.B.Put("a", "1").Put("b", "2"))
-	B batcher
-
 	Sender Sender
 
 	// user is the default user to set on API calls. If User is set to
@@ -238,7 +232,7 @@ func Open(addr string, opts ...Option) (*DB, error) {
 // key can be either a byte slice, a string, a fmt.Stringer or an
 // encoding.BinaryMarshaler.
 func (db *DB) Get(key interface{}) (KeyValue, error) {
-	return runOneRow(db, db.B.Get(key))
+	return runOneRow(db, B().Get(key))
 }
 
 // GetProto retrieves the value for a key and decodes the result as a proto
@@ -259,7 +253,7 @@ func (db *DB) GetProto(key interface{}, msg gogoproto.Message) error {
 // key can be either a byte slice, a string, a fmt.Stringer or an
 // encoding.BinaryMarshaler. value can be any key type or a proto.Message.
 func (db *DB) Put(key, value interface{}) error {
-	_, err := runOneResult(db, db.B.Put(key, value))
+	_, err := runOneResult(db, B().Put(key, value))
 	return err
 }
 
@@ -270,7 +264,7 @@ func (db *DB) Put(key, value interface{}) error {
 // key can be either a byte slice, a string, a fmt.Stringer or an
 // encoding.BinaryMarshaler. value can be any key type or a proto.Message.
 func (db *DB) CPut(key, value, expValue interface{}) error {
-	_, err := runOneResult(db, db.B.CPut(key, value, expValue))
+	_, err := runOneResult(db, B().CPut(key, value, expValue))
 	return err
 }
 
@@ -281,7 +275,7 @@ func (db *DB) CPut(key, value, expValue interface{}) error {
 // key can be either a byte slice, a string, a fmt.Stringer or an
 // encoding.BinaryMarshaler.
 func (db *DB) Inc(key interface{}, value int64) (KeyValue, error) {
-	return runOneRow(db, db.B.Inc(key, value))
+	return runOneRow(db, B().Inc(key, value))
 }
 
 // Scan retrieves the rows between begin (inclusive) and end (exclusive).
@@ -291,7 +285,7 @@ func (db *DB) Inc(key interface{}, value int64) (KeyValue, error) {
 // key can be either a byte slice, a string, a fmt.Stringer or an
 // encoding.BinaryMarshaler.
 func (db *DB) Scan(begin, end interface{}, maxRows int64) ([]KeyValue, error) {
-	r, err := runOneResult(db, db.B.Scan(begin, end, maxRows))
+	r, err := runOneResult(db, B().Scan(begin, end, maxRows))
 	return r.Rows, err
 }
 
@@ -300,7 +294,7 @@ func (db *DB) Scan(begin, end interface{}, maxRows int64) ([]KeyValue, error) {
 // key can be either a byte slice, a string, a fmt.Stringer or an
 // encoding.BinaryMarshaler.
 func (db *DB) Del(keys ...interface{}) error {
-	_, err := runOneResult(db, db.B.Del(keys...))
+	_, err := runOneResult(db, B().Del(keys...))
 	return err
 }
 
@@ -311,7 +305,7 @@ func (db *DB) Del(keys ...interface{}) error {
 // key can be either a byte slice, a string, a fmt.Stringer or an
 // encoding.BinaryMarshaler.
 func (db *DB) DelRange(begin, end interface{}) error {
-	_, err := runOneResult(db, db.B.DelRange(begin, end))
+	_, err := runOneResult(db, B().DelRange(begin, end))
 	return err
 }
 
@@ -323,7 +317,7 @@ func (db *DB) DelRange(begin, end interface{}) error {
 // key can be either a byte slice, a string, a fmt.Stringer or an
 // encoding.BinaryMarshaler.
 func (db *DB) AdminMerge(key interface{}) error {
-	_, err := runOneResult(db, (&Batch{}).adminMerge(key))
+	_, err := runOneResult(db, B().adminMerge(key))
 	return err
 }
 
@@ -332,7 +326,7 @@ func (db *DB) AdminMerge(key interface{}) error {
 // key can be either a byte slice, a string, a fmt.Stringer or an
 // encoding.BinaryMarshaler.
 func (db *DB) AdminSplit(splitKey interface{}) error {
-	_, err := runOneResult(db, (&Batch{}).adminSplit(splitKey))
+	_, err := runOneResult(db, B().adminSplit(splitKey))
 	return err
 }
 
@@ -435,407 +429,6 @@ func (db *DB) send(calls ...Call) (err error) {
 		}
 	}
 	return
-}
-
-// Batch provides for the parallel execution of a number of database
-// operations. Operations are added to the Batch and then the Batch is executed
-// via either DB.Run, Txn.Run or Txn.Commit.
-//
-// TODO(pmattis): Allow a timestamp to be specified which is applied to all
-// operations within the batch.
-type Batch struct {
-	// Results contains an entry for each operation added to the batch. The order
-	// of the results matches the order the operations were added to the
-	// batch. For example:
-	//
-	//   b := client.B.Put("a", "1").Put("b", "2")
-	//   _ = db.Run(b)
-	//   // string(b.Results[0].Rows[0].Key) == "a"
-	//   // string(b.Results[1].Rows[0].Key) == "b"
-	Results    []Result
-	calls      []Call
-	resultsBuf [8]Result
-	rowsBuf    [8]KeyValue
-	rowsIdx    int
-}
-
-func (b *Batch) prepare() error {
-	for _, r := range b.Results {
-		if err := r.Err; err != nil {
-			return err
-		}
-	}
-	return nil
-}
-
-func (b *Batch) initResult(calls, numRows int, err error) {
-	r := Result{calls: calls, Err: err}
-	if numRows > 0 {
-		if b.rowsIdx+numRows <= len(b.rowsBuf) {
-			r.Rows = b.rowsBuf[b.rowsIdx : b.rowsIdx+numRows]
-			b.rowsIdx += numRows
-		} else {
-			r.Rows = make([]KeyValue, numRows)
-		}
-	}
-	if b.Results == nil {
-		b.Results = b.resultsBuf[0:0]
-	}
-	b.Results = append(b.Results, r)
-}
-
-func (b *Batch) fillResults() error {
-	offset := 0
-	for i := range b.Results {
-		result := &b.Results[i]
-
-		for k := 0; k < result.calls; k++ {
-			call := b.calls[offset+k]
-
-			if result.Err == nil {
-				result.Err = call.Reply.Header().GoError()
-			}
-
-			switch t := call.Reply.(type) {
-			case *proto.GetResponse:
-				row := &result.Rows[k]
-				row.Key = []byte(call.Args.(*proto.GetRequest).Key)
-				if result.Err == nil {
-					row.setValue(t.Value)
-				}
-			case *proto.PutResponse:
-				req := call.Args.(*proto.PutRequest)
-				row := &result.Rows[k]
-				row.Key = []byte(req.Key)
-				if result.Err == nil {
-					row.setValue(&req.Value)
-					row.setTimestamp(t.Timestamp)
-				}
-			case *proto.ConditionalPutResponse:
-				req := call.Args.(*proto.ConditionalPutRequest)
-				row := &result.Rows[k]
-				row.Key = []byte(req.Key)
-				if result.Err == nil {
-					row.setValue(&req.Value)
-					row.setTimestamp(t.Timestamp)
-				}
-			case *proto.IncrementResponse:
-				row := &result.Rows[k]
-				row.Key = []byte(call.Args.(*proto.IncrementRequest).Key)
-				if result.Err == nil {
-					// TODO(pmattis): Should IncrementResponse contain a
-					// proto.Value so that the timestamp can be returned?
-					row.Value = &t.NewValue
-				}
-			case *proto.ScanResponse:
-				result.Rows = make([]KeyValue, len(t.Rows))
-				for j, kv := range t.Rows {
-					row := &result.Rows[j]
-					row.Key = kv.Key
-					row.setValue(&kv.Value)
-				}
-			case *proto.DeleteResponse:
-				row := &result.Rows[k]
-				row.Key = []byte(call.Args.(*proto.DeleteRequest).Key)
-
-			case *proto.AdminMergeResponse:
-			case *proto.AdminSplitResponse:
-			case *proto.DeleteRangeResponse:
-			case *proto.EndTransactionResponse:
-			case *proto.InternalBatchResponse:
-			case *proto.InternalGCResponse:
-			case *proto.InternalMergeResponse:
-			case *proto.InternalPushTxnResponse:
-			case *proto.InternalRangeLookupResponse:
-			case *proto.InternalResolveIntentResponse:
-			case *proto.InternalResolveIntentRangeResponse:
-				// Nothing to do for these methods as they do not generate any
-				// rows. For the proto.Internal* responses the caller will have hold of
-				// the response object itself.
-
-			default:
-				if result.Err == nil {
-					result.Err = fmt.Errorf("unsupported reply: %T", call.Reply)
-				}
-			}
-		}
-		offset += result.calls
-	}
-
-	for i := range b.Results {
-		result := &b.Results[i]
-		if result.Err != nil {
-			return result.Err
-		}
-	}
-	return nil
-}
-
-// InternalAddCall adds the specified call to the batch. It is intended for
-// internal use only.
-func (b *Batch) InternalAddCall(call Call) {
-	numRows := 0
-	switch call.Args.(type) {
-	case *proto.GetRequest,
-		*proto.PutRequest,
-		*proto.ConditionalPutRequest,
-		*proto.IncrementRequest,
-		*proto.DeleteRequest:
-		numRows = 1
-	}
-	b.calls = append(b.calls, call)
-	b.initResult(1 /* calls */, numRows, nil)
-}
-
-// Get retrieves the value for a key. A new result will be appended to the
-// batch which will contain a single row.
-//
-//   r, err := db.Get("a")
-//   // string(r.Rows[0].Key) == "a"
-//
-// key can be either a byte slice, a string, a fmt.Stringer or an
-// encoding.BinaryMarshaler.
-func (b *Batch) Get(key interface{}) *Batch {
-	k, err := marshalKey(key)
-	if err != nil {
-		b.initResult(0, 1, err)
-		return b
-	}
-	b.calls = append(b.calls, Get(proto.Key(k)))
-	b.initResult(1, 1, nil)
-	return b
-}
-
-// GetProto retrieves the value for a key and decodes the result as a proto
-// message. A new result will be appended to the batch which will contain a
-// single row. Note that the proto will not be decoded until after the batch is
-// executed using DB.Run or Txn.Run.
-//
-// key can be either a byte slice, a string, a fmt.Stringer or an
-// encoding.BinaryMarshaler.
-func (b *Batch) GetProto(key interface{}, msg gogoproto.Message) *Batch {
-	k, err := marshalKey(key)
-	if err != nil {
-		b.initResult(0, 1, err)
-		return b
-	}
-	b.calls = append(b.calls, GetProto(proto.Key(k), msg))
-	b.initResult(1, 1, nil)
-	return b
-}
-
-// Put sets the value for a key.
-//
-// A new result will be appended to the batch which will contain a single row
-// and Result.Err will indicate success or failure.
-//
-// key can be either a byte slice, a string, a fmt.Stringer or an
-// encoding.BinaryMarshaler. value can be any key type or a proto.Message.
-func (b *Batch) Put(key, value interface{}) *Batch {
-	k, err := marshalKey(key)
-	if err != nil {
-		b.initResult(0, 1, err)
-		return b
-	}
-	v, err := marshalValue(value)
-	if err != nil {
-		b.initResult(0, 1, err)
-		return b
-	}
-	b.calls = append(b.calls, Put(proto.Key(k), v))
-	b.initResult(1, 1, nil)
-	return b
-}
-
-// CPut conditionally sets the value for a key if the existing value is equal
-// to expValue. To conditionally set a value only if there is no existing entry
-// pass nil for expValue.
-//
-// A new result will be appended to the batch which will contain a single row
-// and Result.Err will indicate success or failure.
-//
-// key can be either a byte slice, a string, a fmt.Stringer or an
-// encoding.BinaryMarshaler. value can be any key type or a proto.Message.
-func (b *Batch) CPut(key, value, expValue interface{}) *Batch {
-	k, err := marshalKey(key)
-	if err != nil {
-		b.initResult(0, 1, err)
-		return b
-	}
-	v, err := marshalValue(value)
-	if err != nil {
-		b.initResult(0, 1, err)
-		return b
-	}
-	ev, err := marshalValue(expValue)
-	if err != nil {
-		b.initResult(0, 1, err)
-		return b
-	}
-	b.calls = append(b.calls, ConditionalPut(proto.Key(k), v, ev))
-	b.initResult(1, 1, nil)
-	return b
-}
-
-// Inc increments the integer value at key. If the key does not exist it will
-// be created with an initial value of 0 which will then be incremented. If the
-// key exists but was set using Put or CPut an error will be returned.
-//
-// A new result will be appended to the batch which will contain a single row
-// and Result.Err will indicate success or failure.
-//
-// key can be either a byte slice, a string, a fmt.Stringer or an
-// encoding.BinaryMarshaler.
-func (b *Batch) Inc(key interface{}, value int64) *Batch {
-	k, err := marshalKey(key)
-	if err != nil {
-		b.initResult(0, 1, err)
-		return b
-	}
-	b.calls = append(b.calls, Increment(proto.Key(k), value))
-	b.initResult(1, 1, nil)
-	return b
-}
-
-// Scan retrieves the rows between begin (inclusive) and end (exclusive).
-//
-// A new result will be appended to the batch which will contain up to maxRows
-// rows and Result.Err will indicate success or failure.
-//
-// key can be either a byte slice, a string, a fmt.Stringer or an
-// encoding.BinaryMarshaler.
-func (b *Batch) Scan(s, e interface{}, maxRows int64) *Batch {
-	begin, err := marshalKey(s)
-	if err != nil {
-		b.initResult(0, 0, err)
-		return b
-	}
-	end, err := marshalKey(e)
-	if err != nil {
-		b.initResult(0, 0, err)
-		return b
-	}
-	b.calls = append(b.calls, Scan(proto.Key(begin), proto.Key(end), maxRows))
-	b.initResult(1, 0, nil)
-	return b
-}
-
-// Del deletes one or more keys.
-//
-// A new result will be appended to the batch and each key will have a
-// corresponding row in the returned Result.
-//
-// key can be either a byte slice, a string, a fmt.Stringer or an
-// encoding.BinaryMarshaler.
-func (b *Batch) Del(keys ...interface{}) *Batch {
-	var calls []Call
-	for _, key := range keys {
-		k, err := marshalKey(key)
-		if err != nil {
-			b.initResult(0, len(keys), err)
-			return b
-		}
-		calls = append(calls, Delete(proto.Key(k)))
-	}
-	b.calls = append(b.calls, calls...)
-	b.initResult(len(calls), len(calls), nil)
-	return b
-}
-
-// DelRange deletes the rows between begin (inclusive) and end (exclusive).
-//
-// A new result will be appended to the batch which will contain 0 rows and
-// Result.Err will indicate success or failure.
-//
-// key can be either a byte slice, a string, a fmt.Stringer or an
-// encoding.BinaryMarshaler.
-func (b *Batch) DelRange(s, e interface{}) *Batch {
-	begin, err := marshalKey(s)
-	if err != nil {
-		b.initResult(0, 0, err)
-		return b
-	}
-	end, err := marshalKey(e)
-	if err != nil {
-		b.initResult(0, 0, err)
-		return b
-	}
-	b.calls = append(b.calls, DeleteRange(proto.Key(begin), proto.Key(end)))
-	b.initResult(1, 0, nil)
-	return b
-}
-
-// adminMerge is only exported on DB. It is here for symmetry with the
-// other operations.
-func (b *Batch) adminMerge(key interface{}) *Batch {
-	k, err := marshalKey(key)
-	if err != nil {
-		b.initResult(0, 0, err)
-		return b
-	}
-	req := &proto.AdminMergeRequest{
-		RequestHeader: proto.RequestHeader{
-			Key: proto.Key(k),
-		},
-	}
-	resp := &proto.AdminMergeResponse{}
-	b.calls = append(b.calls, Call{Args: req, Reply: resp})
-	b.initResult(1, 0, nil)
-	return b
-}
-
-// adminSplit is only exported on DB. It is here for symmetry with the
-// other operations.
-func (b *Batch) adminSplit(splitKey interface{}) *Batch {
-	k, err := marshalKey(splitKey)
-	if err != nil {
-		b.initResult(0, 0, err)
-		return b
-	}
-	req := &proto.AdminSplitRequest{
-		RequestHeader: proto.RequestHeader{
-			Key: proto.Key(k),
-		},
-	}
-	req.SplitKey = proto.Key(k)
-	resp := &proto.AdminSplitResponse{}
-	b.calls = append(b.calls, Call{Args: req, Reply: resp})
-	b.initResult(1, 0, nil)
-	return b
-}
-
-type batcher struct{}
-
-func (b batcher) Get(key interface{}) *Batch {
-	return (&Batch{}).Get(key)
-}
-
-func (b batcher) GetProto(key interface{}, msg gogoproto.Message) *Batch {
-	return (&Batch{}).GetProto(key, msg)
-}
-
-func (b batcher) Put(key, value interface{}) *Batch {
-	return (&Batch{}).Put(key, value)
-}
-
-func (b batcher) CPut(key, value, expValue interface{}) *Batch {
-	return (&Batch{}).CPut(key, value, expValue)
-}
-
-func (b batcher) Inc(key interface{}, value int64) *Batch {
-	return (&Batch{}).Inc(key, value)
-}
-
-func (b batcher) Scan(begin, end interface{}, maxRows int64) *Batch {
-	return (&Batch{}).Scan(begin, end, maxRows)
-}
-
-func (b batcher) Del(keys ...interface{}) *Batch {
-	return (&Batch{}).Del(keys...)
-}
-
-func (b batcher) DelRange(begin, end interface{}) *Batch {
-	return (&Batch{}).DelRange(begin, end)
 }
 
 func marshalKey(k interface{}) ([]byte, error) {

--- a/client/db.go
+++ b/client/db.go
@@ -232,7 +232,9 @@ func Open(addr string, opts ...Option) (*DB, error) {
 // key can be either a byte slice, a string, a fmt.Stringer or an
 // encoding.BinaryMarshaler.
 func (db *DB) Get(key interface{}) (KeyValue, error) {
-	return runOneRow(db, B().Get(key))
+	b := &Batch{}
+	b.Get(key)
+	return runOneRow(db, b)
 }
 
 // GetProto retrieves the value for a key and decodes the result as a proto
@@ -253,7 +255,9 @@ func (db *DB) GetProto(key interface{}, msg gogoproto.Message) error {
 // key can be either a byte slice, a string, a fmt.Stringer or an
 // encoding.BinaryMarshaler. value can be any key type or a proto.Message.
 func (db *DB) Put(key, value interface{}) error {
-	_, err := runOneResult(db, B().Put(key, value))
+	b := &Batch{}
+	b.Put(key, value)
+	_, err := runOneResult(db, b)
 	return err
 }
 
@@ -264,7 +268,9 @@ func (db *DB) Put(key, value interface{}) error {
 // key can be either a byte slice, a string, a fmt.Stringer or an
 // encoding.BinaryMarshaler. value can be any key type or a proto.Message.
 func (db *DB) CPut(key, value, expValue interface{}) error {
-	_, err := runOneResult(db, B().CPut(key, value, expValue))
+	b := &Batch{}
+	b.CPut(key, value, expValue)
+	_, err := runOneResult(db, b)
 	return err
 }
 
@@ -275,7 +281,9 @@ func (db *DB) CPut(key, value, expValue interface{}) error {
 // key can be either a byte slice, a string, a fmt.Stringer or an
 // encoding.BinaryMarshaler.
 func (db *DB) Inc(key interface{}, value int64) (KeyValue, error) {
-	return runOneRow(db, B().Inc(key, value))
+	b := &Batch{}
+	b.Inc(key, value)
+	return runOneRow(db, b)
 }
 
 // Scan retrieves the rows between begin (inclusive) and end (exclusive).
@@ -285,7 +293,9 @@ func (db *DB) Inc(key interface{}, value int64) (KeyValue, error) {
 // key can be either a byte slice, a string, a fmt.Stringer or an
 // encoding.BinaryMarshaler.
 func (db *DB) Scan(begin, end interface{}, maxRows int64) ([]KeyValue, error) {
-	r, err := runOneResult(db, B().Scan(begin, end, maxRows))
+	b := &Batch{}
+	b.Scan(begin, end, maxRows)
+	r, err := runOneResult(db, b)
 	return r.Rows, err
 }
 
@@ -294,7 +304,9 @@ func (db *DB) Scan(begin, end interface{}, maxRows int64) ([]KeyValue, error) {
 // key can be either a byte slice, a string, a fmt.Stringer or an
 // encoding.BinaryMarshaler.
 func (db *DB) Del(keys ...interface{}) error {
-	_, err := runOneResult(db, B().Del(keys...))
+	b := &Batch{}
+	b.Del(keys...)
+	_, err := runOneResult(db, b)
 	return err
 }
 
@@ -305,7 +317,9 @@ func (db *DB) Del(keys ...interface{}) error {
 // key can be either a byte slice, a string, a fmt.Stringer or an
 // encoding.BinaryMarshaler.
 func (db *DB) DelRange(begin, end interface{}) error {
-	_, err := runOneResult(db, B().DelRange(begin, end))
+	b := &Batch{}
+	b.DelRange(begin, end)
+	_, err := runOneResult(db, b)
 	return err
 }
 
@@ -317,7 +331,9 @@ func (db *DB) DelRange(begin, end interface{}) error {
 // key can be either a byte slice, a string, a fmt.Stringer or an
 // encoding.BinaryMarshaler.
 func (db *DB) AdminMerge(key interface{}) error {
-	_, err := runOneResult(db, B().adminMerge(key))
+	b := &Batch{}
+	b.adminMerge(key)
+	_, err := runOneResult(db, b)
 	return err
 }
 
@@ -326,7 +342,9 @@ func (db *DB) AdminMerge(key interface{}) error {
 // key can be either a byte slice, a string, a fmt.Stringer or an
 // encoding.BinaryMarshaler.
 func (db *DB) AdminSplit(splitKey interface{}) error {
-	_, err := runOneResult(db, B().adminSplit(splitKey))
+	b := &Batch{}
+	b.adminSplit(splitKey)
+	_, err := runOneResult(db, b)
 	return err
 }
 

--- a/client/db_test.go
+++ b/client/db_test.go
@@ -140,7 +140,9 @@ func ExampleBatch() {
 	s, db := setup()
 	defer s.Stop()
 
-	b := client.B().Get("aa").Put("bb", "2")
+	b := &client.Batch{}
+	b.Get("aa")
+	b.Put("bb", "2")
 	if err := db.Run(b); err != nil {
 		panic(err)
 	}
@@ -159,7 +161,10 @@ func ExampleDB_Scan() {
 	s, db := setup()
 	defer s.Stop()
 
-	b := client.B().Put("aa", "1").Put("ab", "2").Put("bb", "3")
+	b := &client.Batch{}
+	b.Put("aa", "1")
+	b.Put("ab", "2")
+	b.Put("bb", "3")
 	if err := db.Run(b); err != nil {
 		panic(err)
 	}
@@ -180,7 +185,11 @@ func ExampleDB_Del() {
 	s, db := setup()
 	defer s.Stop()
 
-	if err := db.Run(client.B().Put("aa", "1").Put("ab", "2").Put("ac", "3")); err != nil {
+	b := &client.Batch{}
+	b.Put("aa", "1")
+	b.Put("ab", "2")
+	b.Put("ac", "3")
+	if err := db.Run(b); err != nil {
 		panic(err)
 	}
 	if err := db.Del("ab"); err != nil {
@@ -204,13 +213,18 @@ func ExampleTx_Commit() {
 	defer s.Stop()
 
 	err := db.Txn(func(txn *client.Txn) error {
-		return txn.Commit(client.B().Put("aa", "1").Put("ab", "2"))
+		b := &client.Batch{}
+		b.Put("aa", "1")
+		b.Put("ab", "2")
+		return txn.Commit(b)
 	})
 	if err != nil {
 		panic(err)
 	}
 
-	b := client.B().Get("aa").Get("ab")
+	b := &client.Batch{}
+	b.Get("aa")
+	b.Get("ab")
 	if err := db.Run(b); err != nil {
 		panic(err)
 	}

--- a/client/db_test.go
+++ b/client/db_test.go
@@ -140,7 +140,7 @@ func ExampleBatch() {
 	s, db := setup()
 	defer s.Stop()
 
-	b := db.B.Get("aa").Put("bb", "2")
+	b := client.B().Get("aa").Put("bb", "2")
 	if err := db.Run(b); err != nil {
 		panic(err)
 	}
@@ -159,7 +159,7 @@ func ExampleDB_Scan() {
 	s, db := setup()
 	defer s.Stop()
 
-	b := db.B.Put("aa", "1").Put("ab", "2").Put("bb", "3")
+	b := client.B().Put("aa", "1").Put("ab", "2").Put("bb", "3")
 	if err := db.Run(b); err != nil {
 		panic(err)
 	}
@@ -180,7 +180,7 @@ func ExampleDB_Del() {
 	s, db := setup()
 	defer s.Stop()
 
-	if err := db.Run(db.B.Put("aa", "1").Put("ab", "2").Put("ac", "3")); err != nil {
+	if err := db.Run(client.B().Put("aa", "1").Put("ab", "2").Put("ac", "3")); err != nil {
 		panic(err)
 	}
 	if err := db.Del("ab"); err != nil {
@@ -204,13 +204,13 @@ func ExampleTx_Commit() {
 	defer s.Stop()
 
 	err := db.Txn(func(txn *client.Txn) error {
-		return txn.Commit(txn.B.Put("aa", "1").Put("ab", "2"))
+		return txn.Commit(client.B().Put("aa", "1").Put("ab", "2"))
 	})
 	if err != nil {
 		panic(err)
 	}
 
-	b := db.B.Get("aa").Get("ab")
+	b := client.B().Get("aa").Get("ab")
 	if err := db.Run(b); err != nil {
 		panic(err)
 	}
@@ -292,10 +292,9 @@ func TestDebugName(t *testing.T) {
 
 func TestCommonMethods(t *testing.T) {
 	batchType := reflect.TypeOf(&client.Batch{})
-	batcherType := reflect.TypeOf(client.DB{}.B)
 	dbType := reflect.TypeOf(&client.DB{})
 	txnType := reflect.TypeOf(&client.Txn{})
-	types := []reflect.Type{batchType, batcherType, dbType, txnType}
+	types := []reflect.Type{batchType, dbType, txnType}
 
 	type key struct {
 		typ    reflect.Type

--- a/client/txn.go
+++ b/client/txn.go
@@ -66,13 +66,6 @@ func (ts *txnSender) Send(ctx context.Context, call Call) {
 // Txn is an in-progress distributed database transaction. A Txn is not safe for
 // concurrent use by multiple goroutines.
 type Txn struct {
-	// B is a helper to make creating a new batch and performing an
-	// operation on it easer:
-	//
-	//   err := db.Txn(func(txn *Txn) error {
-	//     return txn.Commit(txn.B.Put("a", "1").Put("b", "2"))
-	//   })
-	B            batcher
 	db           DB
 	wrapped      Sender
 	txn          proto.Transaction
@@ -142,7 +135,7 @@ func (txn *Txn) InternalSetPriority(priority int32) {
 // key can be either a byte slice, a string, a fmt.Stringer or an
 // encoding.BinaryMarshaler.
 func (txn *Txn) Get(key interface{}) (KeyValue, error) {
-	return runOneRow(txn, txn.B.Get(key))
+	return runOneRow(txn, B().Get(key))
 }
 
 // GetProto retrieves the value for a key and decodes the result as a proto
@@ -163,7 +156,7 @@ func (txn *Txn) GetProto(key interface{}, msg gogoproto.Message) error {
 // key can be either a byte slice, a string, a fmt.Stringer or an
 // encoding.BinaryMarshaler. value can be any key type or a proto.Message.
 func (txn *Txn) Put(key, value interface{}) error {
-	_, err := runOneResult(txn, txn.B.Put(key, value))
+	_, err := runOneResult(txn, B().Put(key, value))
 	return err
 }
 
@@ -174,7 +167,7 @@ func (txn *Txn) Put(key, value interface{}) error {
 // key can be either a byte slice, a string, a fmt.Stringer or an
 // encoding.BinaryMarshaler. value can be any key type or a proto.Message.
 func (txn *Txn) CPut(key, value, expValue interface{}) error {
-	_, err := runOneResult(txn, txn.B.CPut(key, value, expValue))
+	_, err := runOneResult(txn, B().CPut(key, value, expValue))
 	return err
 }
 
@@ -188,7 +181,7 @@ func (txn *Txn) CPut(key, value, expValue interface{}) error {
 // key can be either a byte slice, a string, a fmt.Stringer or an
 // encoding.BinaryMarshaler.
 func (txn *Txn) Inc(key interface{}, value int64) (KeyValue, error) {
-	return runOneRow(txn, txn.B.Inc(key, value))
+	return runOneRow(txn, B().Inc(key, value))
 }
 
 // Scan retrieves the rows between begin (inclusive) and end (exclusive).
@@ -198,7 +191,7 @@ func (txn *Txn) Inc(key interface{}, value int64) (KeyValue, error) {
 // key can be either a byte slice, a string, a fmt.Stringer or an
 // encoding.BinaryMarshaler.
 func (txn *Txn) Scan(begin, end interface{}, maxRows int64) ([]KeyValue, error) {
-	r, err := runOneResult(txn, txn.B.Scan(begin, end, maxRows))
+	r, err := runOneResult(txn, B().Scan(begin, end, maxRows))
 	return r.Rows, err
 }
 
@@ -207,7 +200,7 @@ func (txn *Txn) Scan(begin, end interface{}, maxRows int64) ([]KeyValue, error) 
 // key can be either a byte slice, a string, a fmt.Stringer or an
 // encoding.BinaryMarshaler.
 func (txn *Txn) Del(keys ...interface{}) error {
-	_, err := runOneResult(txn, txn.B.Del(keys...))
+	_, err := runOneResult(txn, B().Del(keys...))
 	return err
 }
 
@@ -219,7 +212,7 @@ func (txn *Txn) Del(keys ...interface{}) error {
 // key can be either a byte slice, a string, a fmt.Stringer or an
 // encoding.BinaryMarshaler.
 func (txn *Txn) DelRange(begin, end interface{}) error {
-	_, err := runOneResult(txn, txn.B.DelRange(begin, end))
+	_, err := runOneResult(txn, B().DelRange(begin, end))
 	return err
 }
 

--- a/client/txn.go
+++ b/client/txn.go
@@ -135,7 +135,9 @@ func (txn *Txn) InternalSetPriority(priority int32) {
 // key can be either a byte slice, a string, a fmt.Stringer or an
 // encoding.BinaryMarshaler.
 func (txn *Txn) Get(key interface{}) (KeyValue, error) {
-	return runOneRow(txn, B().Get(key))
+	b := &Batch{}
+	b.Get(key)
+	return runOneRow(txn, b)
 }
 
 // GetProto retrieves the value for a key and decodes the result as a proto
@@ -156,7 +158,9 @@ func (txn *Txn) GetProto(key interface{}, msg gogoproto.Message) error {
 // key can be either a byte slice, a string, a fmt.Stringer or an
 // encoding.BinaryMarshaler. value can be any key type or a proto.Message.
 func (txn *Txn) Put(key, value interface{}) error {
-	_, err := runOneResult(txn, B().Put(key, value))
+	b := &Batch{}
+	b.Put(key, value)
+	_, err := runOneResult(txn, b)
 	return err
 }
 
@@ -167,7 +171,9 @@ func (txn *Txn) Put(key, value interface{}) error {
 // key can be either a byte slice, a string, a fmt.Stringer or an
 // encoding.BinaryMarshaler. value can be any key type or a proto.Message.
 func (txn *Txn) CPut(key, value, expValue interface{}) error {
-	_, err := runOneResult(txn, B().CPut(key, value, expValue))
+	b := &Batch{}
+	b.CPut(key, value, expValue)
+	_, err := runOneResult(txn, b)
 	return err
 }
 
@@ -181,7 +187,9 @@ func (txn *Txn) CPut(key, value, expValue interface{}) error {
 // key can be either a byte slice, a string, a fmt.Stringer or an
 // encoding.BinaryMarshaler.
 func (txn *Txn) Inc(key interface{}, value int64) (KeyValue, error) {
-	return runOneRow(txn, B().Inc(key, value))
+	b := &Batch{}
+	b.Inc(key, value)
+	return runOneRow(txn, b)
 }
 
 // Scan retrieves the rows between begin (inclusive) and end (exclusive).
@@ -191,7 +199,9 @@ func (txn *Txn) Inc(key interface{}, value int64) (KeyValue, error) {
 // key can be either a byte slice, a string, a fmt.Stringer or an
 // encoding.BinaryMarshaler.
 func (txn *Txn) Scan(begin, end interface{}, maxRows int64) ([]KeyValue, error) {
-	r, err := runOneResult(txn, B().Scan(begin, end, maxRows))
+	b := &Batch{}
+	b.Scan(begin, end, maxRows)
+	r, err := runOneResult(txn, b)
 	return r.Rows, err
 }
 
@@ -200,7 +210,9 @@ func (txn *Txn) Scan(begin, end interface{}, maxRows int64) ([]KeyValue, error) 
 // key can be either a byte slice, a string, a fmt.Stringer or an
 // encoding.BinaryMarshaler.
 func (txn *Txn) Del(keys ...interface{}) error {
-	_, err := runOneResult(txn, B().Del(keys...))
+	b := &Batch{}
+	b.Del(keys...)
+	_, err := runOneResult(txn, b)
 	return err
 }
 
@@ -212,7 +224,9 @@ func (txn *Txn) Del(keys ...interface{}) error {
 // key can be either a byte slice, a string, a fmt.Stringer or an
 // encoding.BinaryMarshaler.
 func (txn *Txn) DelRange(begin, end interface{}) error {
-	_, err := runOneResult(txn, B().DelRange(begin, end))
+	b := &Batch{}
+	b.DelRange(begin, end)
+	_, err := runOneResult(txn, b)
 	return err
 }
 

--- a/examples/bank/bank.go
+++ b/examples/bank/bank.go
@@ -114,7 +114,8 @@ func (bank *Bank) continuouslyTransferMoney(cash int64) {
 		// transferMoney transfers exchangeAmount between the two accounts
 		transferMoney := func(runner client.Runner) error {
 			batchRead := &client.Batch{}
-			batchRead.Get(from).Get(to)
+			batchRead.Get(from)
+			batchRead.Get(to)
 			if err := runner.Run(batchRead); err != nil {
 				return err
 			}
@@ -143,7 +144,8 @@ func (bank *Bank) continuouslyTransferMoney(cash int64) {
 			} else if toValue, err := toAccount.encode(); err != nil {
 				return err
 			} else {
-				batchWrite.Put(from, fromValue).Put(to, toValue)
+				batchWrite.Put(from, fromValue)
+				batchWrite.Put(to, toValue)
 			}
 			return runner.Run(batchWrite)
 		}

--- a/kv/txn_test.go
+++ b/kv/txn_test.go
@@ -108,7 +108,7 @@ func BenchmarkTxnWrites(b *testing.B) {
 	for i := 0; i < b.N; i++ {
 		s.Manual.Increment(1)
 		if tErr := s.DB.Txn(func(txn *client.Txn) error {
-			return txn.Commit(txn.B.Put(key, fmt.Sprintf("value-%d", i)))
+			return txn.Commit(client.B().Put(key, fmt.Sprintf("value-%d", i)))
 		}); tErr != nil {
 			b.Fatal(tErr)
 		}

--- a/kv/txn_test.go
+++ b/kv/txn_test.go
@@ -108,7 +108,9 @@ func BenchmarkTxnWrites(b *testing.B) {
 	for i := 0; i < b.N; i++ {
 		s.Manual.Increment(1)
 		if tErr := s.DB.Txn(func(txn *client.Txn) error {
-			return txn.Commit(client.B().Put(key, fmt.Sprintf("value-%d", i)))
+			b := &client.Batch{}
+			b.Put(key, fmt.Sprintf("value-%d", i))
+			return txn.Commit(b)
 		}); tErr != nil {
 			b.Fatal(tErr)
 		}

--- a/server/status/feed_test.go
+++ b/server/status/feed_test.go
@@ -231,7 +231,10 @@ func TestServerNodeEventFeed(t *testing.T) {
 
 	// Add some data in a transaction
 	err = db.Txn(func(txn *client.Txn) error {
-		return txn.Commit(client.B().Put("a", "asdf").Put("c", "jkl;"))
+		b := &client.Batch{}
+		b.Put("a", "asdf")
+		b.Put("c", "jkl;")
+		return txn.Commit(b)
 	})
 	if err != nil {
 		t.Fatalf("error putting data to db: %s", err)

--- a/server/status/feed_test.go
+++ b/server/status/feed_test.go
@@ -231,7 +231,7 @@ func TestServerNodeEventFeed(t *testing.T) {
 
 	// Add some data in a transaction
 	err = db.Txn(func(txn *client.Txn) error {
-		return txn.Commit(txn.B.Put("a", "asdf").Put("c", "jkl;"))
+		return txn.Commit(client.B().Put("a", "asdf").Put("c", "jkl;"))
 	})
 	if err != nil {
 		t.Fatalf("error putting data to db: %s", err)

--- a/storage/client_event_test.go
+++ b/storage/client_event_test.go
@@ -182,7 +182,7 @@ func TestMultiStoreEventFeed(t *testing.T) {
 
 	// Add some data in a transaction
 	err := mtc.db.Txn(func(txn *client.Txn) error {
-		b := txn.B.Put("a", "asdf")
+		b := client.B().Put("a", "asdf")
 		b.Put("c", "jkl;")
 		return txn.Commit(b)
 	})

--- a/storage/client_event_test.go
+++ b/storage/client_event_test.go
@@ -182,7 +182,8 @@ func TestMultiStoreEventFeed(t *testing.T) {
 
 	// Add some data in a transaction
 	err := mtc.db.Txn(func(txn *client.Txn) error {
-		b := client.B().Put("a", "asdf")
+		b := &client.Batch{}
+		b.Put("a", "asdf")
 		b.Put("c", "jkl;")
 		return txn.Commit(b)
 	})


### PR DESCRIPTION
Replaced client.batcher with client.B() which plays nicer with godoc and
removes any confusion as to whether the Batch created is specific to a
DB or Txn.

Fixes #1254.
