### PR TITLE
Register high-level prefixes for /_admin/ and /debug/.

### DIFF
--- a/server/admin_test.go
+++ b/server/admin_test.go
@@ -45,7 +45,8 @@ func startAdminServer() (string, *util.Stopper) {
 	}
 	admin := newAdminServer(db, stopper)
 	mux := http.NewServeMux()
-	admin.registerHandlers(mux)
+	mux.Handle(adminEndpoint, admin)
+	mux.Handle(debugEndpoint, admin)
 	httpServer := httptest.NewUnstartedServer(mux)
 	tlsConfig, err := testContext.GetServerTLSConfig()
 	if err != nil {

--- a/server/server.go
+++ b/server/server.go
@@ -191,10 +191,9 @@ func (s *Server) initHTTP() {
 	s.mux.Handle("/", http.FileServer(
 		&assetfs.AssetFS{Asset: resource.Asset, AssetDir: resource.AssetDir, Prefix: "./ui/"}))
 
-	// Admin handlers.
-	s.admin.registerHandlers(s.mux)
-
-	// Status endpoints:
+	// The admin server handles both /debug/ and /_admin/
+	s.mux.Handle(adminEndpoint, s.admin)
+	s.mux.Handle(debugEndpoint, s.admin)
 	s.mux.Handle(statusKeyPrefix, s.status)
 
 	s.mux.Handle(kv.RESTPrefix, s.kvREST)


### PR DESCRIPTION
This puts all http handlers in one place, which will make it easier to add authentication handlers in the middle.
