### PR TITLE
retry on {Node,Store}ID allocation

### DIFF
--- a/server/node.go
+++ b/server/node.go
@@ -38,6 +38,7 @@ import (
 	"github.com/cockroachdb/cockroach/util"
 	"github.com/cockroachdb/cockroach/util/hlc"
 	"github.com/cockroachdb/cockroach/util/log"
+	"github.com/cockroachdb/cockroach/util/retry"
 )
 
 const (
@@ -51,6 +52,14 @@ const (
 	runtimeStatsInterval = 15 * time.Second
 	mb                   = 1 << 20
 )
+
+var allocRetryOptions = retry.Options{
+	Tag:        "ID allocation",
+	Backoff:    time.Second,
+	MaxBackoff: 30 * time.Second,
+	Constant:   2,
+	UseV1Info:  true,
+}
 
 // A Node manages a map of stores (by store ID) for which it serves
 // traffic. A node is the top-level data structure. There is one node
@@ -80,24 +89,44 @@ type Node struct {
 type nodeServer Node
 
 // allocateNodeID increments the node id generator key to allocate
-// a new, unique node id.
+// a new, unique node id. It will retry indefinitely on retryable
+// errors.
 func allocateNodeID(db *client.DB) (proto.NodeID, error) {
-	r, err := db.Inc(keys.NodeIDGenerator, 1)
-	if err != nil {
-		return 0, util.Errorf("unable to allocate node ID: %s", err)
-	}
-	return proto.NodeID(r.ValueInt()), nil
+	var id proto.NodeID
+	err := retry.WithBackoff(allocRetryOptions, func() (retry.Status, error) {
+		r, err := db.Inc(keys.NodeIDGenerator, 1)
+		if err != nil {
+			status := retry.Break
+			if _, ok := err.(util.Retryable); ok {
+				status = retry.Continue
+			}
+			return status, util.Errorf("unable to allocate node ID: %s", err)
+		}
+		id = proto.NodeID(r.ValueInt())
+		return retry.Break, nil
+	})
+	return id, err
 }
 
 // allocateStoreIDs increments the store id generator key for the
 // specified node to allocate "inc" new, unique store ids. The
-// first ID in a contiguous range is returned on success.
+// first ID in a contiguous range is returned on success. The call
+// will retry indefinitely on retryable errors.
 func allocateStoreIDs(nodeID proto.NodeID, inc int64, db *client.DB) (proto.StoreID, error) {
-	r, err := db.Inc(keys.StoreIDGenerator, inc)
-	if err != nil {
-		return 0, util.Errorf("unable to allocate %d store IDs for node %d: %s", inc, nodeID, err)
-	}
-	return proto.StoreID(r.ValueInt() - inc + 1), nil
+	var id proto.StoreID
+	err := retry.WithBackoff(allocRetryOptions, func() (retry.Status, error) {
+		r, err := db.Inc(keys.StoreIDGenerator, inc)
+		if err != nil {
+			status := retry.Break
+			if _, ok := err.(util.Retryable); ok {
+				status = retry.Continue
+			}
+			return status, util.Errorf("unable to allocate %d store IDs for node %d: %s", inc, nodeID, err)
+		}
+		id = proto.StoreID(r.ValueInt() - inc + 1)
+		return retry.Break, nil
+	})
+	return id, err
 }
 
 // BootstrapCluster bootstraps a multiple stores using the provided engines and

--- a/server/node_test.go
+++ b/server/node_test.go
@@ -25,6 +25,8 @@ import (
 	"testing"
 	"time"
 
+	"golang.org/x/net/context"
+
 	"github.com/cockroachdb/cockroach/client"
 	"github.com/cockroachdb/cockroach/gossip"
 	"github.com/cockroachdb/cockroach/gossip/resolver"
@@ -494,4 +496,42 @@ func TestNodeStatus(t *testing.T) {
 	ts.node.waitForScanCompletion()
 	ts.node.waitForScanCompletion()
 	compareStoreStatus(t, ts.node, expectedNodeStatus, 3)
+}
+
+type testSender func(context.Context, client.Call)
+
+func (ts testSender) Send(ctx context.Context, c client.Call) {
+	ts(ctx, c)
+}
+
+func setAllocRetryBackoff(backoff time.Duration) func() {
+	savedBackoff := allocRetryOptions.Backoff
+	allocRetryOptions.Backoff = backoff
+	return func() {
+		allocRetryOptions.Backoff = savedBackoff
+	}
+}
+
+func TestIDAllocationRetry(t *testing.T) {
+	defer setAllocRetryBackoff(0)()
+	i := 98
+	sender := func(_ context.Context, c client.Call) {
+		if i%2 == 0 {
+			c.Reply.Header().Error = &proto.Error{Retryable: true}
+		}
+		c.Reply.(*proto.IncrementResponse).NewValue = int64(i)
+		i++
+	}
+	db, err := client.Open("//root@", client.SenderOpt(testSender(sender)))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if n, err := allocateNodeID(db); n != 99 || err != nil {
+		t.Fatalf("wanted NodeID 99, got %d (err=%s)", n, err)
+	}
+
+	if n, err := allocateStoreIDs(1, 1, db); n != 101 || err != nil {
+		t.Fatalf("wanted NodeID 101, got %d (err=%s)", n, err)
+	}
+
 }


### PR DESCRIPTION
The calls to generate Node and Store IDs should be retried when they fail.

Otherwise, Fatals like this can happen:

> node connected via gossip and verified as part of cluster "..."
> unable to allocate node ID: the descriptor for the first range is not available via gossip
