### PR TITLE
Retrieve log entries from the status server.

### DIFF
--- a/util/log/clog.go
+++ b/util/log/clog.go
@@ -45,66 +45,73 @@ import (
 // the flag.Value interface. The -stderrthreshold flag is of type Severity and
 // should be modified only through the flag.Value interface. The values match
 // the corresponding constants in C++.
-type severity int32 // sync/atomic int32
+type Severity int32 // sync/atomic int32
 
 // These constants identify the log levels in order of increasing Severity.
 // A message written to a high-Severity log file is also written to each
 // lower-Severity log file.
 const (
-	infoLog severity = iota
-	warningLog
-	errorLog
-	fatalLog
-	numSeverity = 4
+	InfoLog Severity = iota
+	WarningLog
+	ErrorLog
+	FatalLog
+	NumSeverity = 4
 )
 
 const severityChar = "IWEF"
 
-// SeverityName provides a mapping from Severity level to a string.
+// severityName provides a mapping from Severity level to a string.
 var severityName = []string{
-	infoLog:    "INFO",
-	warningLog: "WARNING",
-	errorLog:   "ERROR",
-	fatalLog:   "FATAL",
+	InfoLog:    "INFO",
+	WarningLog: "WARNING",
+	ErrorLog:   "ERROR",
+	FatalLog:   "FATAL",
 }
 
 // get returns the value of the Severity.
-func (s *severity) get() severity {
-	return severity(atomic.LoadInt32((*int32)(s)))
+func (s *Severity) get() Severity {
+	return Severity(atomic.LoadInt32((*int32)(s)))
 }
 
 // set sets the value of the Severity.
-func (s *severity) set(val severity) {
+func (s *Severity) set(val Severity) {
 	atomic.StoreInt32((*int32)(s), int32(val))
 }
 
 // String is part of the flag.Value interface.
-func (s *severity) String() string {
+func (s *Severity) String() string {
 	return strconv.FormatInt(int64(*s), 10)
 }
 
 // Set is part of the flag.Value interface.
-func (s *severity) Set(value string) error {
-	var threshold severity
+func (s *Severity) Set(value string) error {
+	var threshold Severity
 	// Is it a known name?
-	if v, ok := severityByName(value); ok {
+	if v, ok := SeverityByName(value); ok {
 		threshold = v
 	} else {
 		v, err := strconv.Atoi(value)
 		if err != nil {
 			return err
 		}
-		threshold = severity(v)
+		threshold = Severity(v)
 	}
 	logging.stderrThreshold.set(threshold)
 	return nil
 }
 
-func severityByName(s string) (severity, bool) {
+// Name returns the string representation of the severity (i.e. ERROR, INFO).
+func (s *Severity) Name() string {
+	return severityName[s.get()]
+}
+
+// SeverityByName attempts to parse the passed in string into a severity. (i.e.
+// ERROR, INFO). If it succeeds, the returned bool is set to true.
+func SeverityByName(s string) (Severity, bool) {
 	s = strings.ToUpper(s)
 	for i, name := range severityName {
 		if name == s {
-			return severity(i), true
+			return Severity(i), true
 		}
 	}
 	return 0, false
@@ -158,10 +165,10 @@ var Stats struct {
 	Info, Warning, Error outputStats
 }
 
-var severityStats = [numSeverity]*outputStats{
-	infoLog:    &Stats.Info,
-	warningLog: &Stats.Warning,
-	errorLog:   &Stats.Error,
+var severityStats = [NumSeverity]*outputStats{
+	InfoLog:    &Stats.Info,
+	WarningLog: &Stats.Warning,
+	ErrorLog:   &Stats.Error,
 }
 
 // Level is exported because it appears in the arguments to V and is
@@ -454,13 +461,13 @@ type flushSyncWriter interface {
 // 	file             The file name
 // 	line             The line number
 // 	msg              The user-supplied message
-func formatHeader(s severity, now time.Time, threadID int32, file string, line int32, colors *colorProfile) *buffer {
+func formatHeader(s Severity, now time.Time, threadID int32, file string, line int32, colors *colorProfile) *buffer {
 	buf := logging.getBuffer()
 	if line < 0 {
 		line = 0 // not a real line number, but acceptable to someDigits
 	}
-	if s > fatalLog {
-		s = infoLog // for safety.
+	if s > FatalLog {
+		s = InfoLog // for safety.
 	}
 
 	tmp := buf.tmp[:len(buf.tmp)]
@@ -468,11 +475,11 @@ func formatHeader(s severity, now time.Time, threadID int32, file string, line i
 	if colors != nil {
 		var prefix []byte
 		switch s {
-		case infoLog:
+		case InfoLog:
 			prefix = colors.infoPrefix
-		case warningLog:
+		case WarningLog:
 			prefix = colors.warnPrefix
-		case errorLog, fatalLog:
+		case ErrorLog, FatalLog:
 			prefix = colors.errorPrefix
 		}
 		n += copy(tmp, prefix)
@@ -566,7 +573,7 @@ func (buf *buffer) someDigits(i, d int) int {
 }
 
 func formatLogEntry(entry *proto.LogEntry, colors *colorProfile) []byte {
-	buf := formatHeader(severity(entry.Severity), time.Unix(entry.Time/1E9, entry.Time%1E9), entry.ThreadID, entry.File, entry.Line, colors)
+	buf := formatHeader(Severity(entry.Severity), time.Unix(entry.Time/1E9, entry.Time%1E9), entry.ThreadID, entry.File, entry.Line, colors)
 	var args []interface{}
 	for _, arg := range entry.Args {
 		args = append(args, arg.Str)
@@ -586,7 +593,7 @@ func formatLogEntry(entry *proto.LogEntry, colors *colorProfile) []byte {
 
 func init() {
 	// Default stderrThreshold is so high that nothing gets through.
-	logging.stderrThreshold = numSeverity
+	logging.stderrThreshold = NumSeverity
 	if tmpStr := ""; true {
 		logDir = &tmpStr
 	}
@@ -614,7 +621,7 @@ type loggingT struct {
 	colorProfile    *colorProfile // Set via call to getTermColorProfile
 
 	// Level flag. Handled atomically.
-	stderrThreshold severity // The -stderrthreshold flag.
+	stderrThreshold Severity // The -stderrthreshold flag.
 
 	// freeList is a list of byte buffers, maintained under freeListMu.
 	freeList *buffer
@@ -627,7 +634,7 @@ type loggingT struct {
 	// used to synchronize logging.
 	mu sync.Mutex
 	// file holds writer for each of the log types.
-	file [numSeverity]flushSyncWriter
+	file [NumSeverity]flushSyncWriter
 	// pcs is used in V to avoid an allocation when computing the caller's PC.
 	pcs [1]uintptr
 	// vmap is a cache of the V Level for each V() call site, identified by PC.
@@ -726,7 +733,7 @@ func (l *loggingT) Caller(depth int) (file string, line int) {
 	return
 }
 
-func (l *loggingT) print(s severity, args ...interface{}) {
+func (l *loggingT) print(s Severity, args ...interface{}) {
 	file, line := l.Caller(1)
 	entry := proto.LogEntry{}
 	setLogEntry(nil, "", args, &entry)
@@ -736,7 +743,7 @@ func (l *loggingT) print(s severity, args ...interface{}) {
 // outputLogEntry marshals a log entry proto into bytes, and writes
 // the data to the log files. If a trace location is set, stack traces
 // are added to the entry before marshaling.
-func (l *loggingT) outputLogEntry(s severity, file string, line int, alsoToStderr bool, entry *proto.LogEntry) {
+func (l *loggingT) outputLogEntry(s Severity, file string, line int, alsoToStderr bool, entry *proto.LogEntry) {
 	l.mu.Lock()
 
 	// Set additional details in log entry.
@@ -747,7 +754,7 @@ func (l *loggingT) outputLogEntry(s severity, file string, line int, alsoToStder
 	entry.File = file
 	entry.Line = int32(line)
 	// On fatal log, set all stacks.
-	if s == fatalLog {
+	if s == FatalLog {
 		entry.Stacks = stacks(true)
 		logExitFunc = func(error) {} // If we get a write error, we'll still exit.
 	} else if l.traceLocation.isSet() {
@@ -772,17 +779,17 @@ func (l *loggingT) outputLogEntry(s severity, file string, line int, alsoToStder
 		data := encodeLogEntry(entry)
 
 		switch s {
-		case fatalLog:
-			l.file[fatalLog].Write(data)
+		case FatalLog:
+			l.file[FatalLog].Write(data)
 			fallthrough
-		case errorLog:
-			l.file[errorLog].Write(data)
+		case ErrorLog:
+			l.file[ErrorLog].Write(data)
 			fallthrough
-		case warningLog:
-			l.file[warningLog].Write(data)
+		case WarningLog:
+			l.file[WarningLog].Write(data)
 			fallthrough
-		case infoLog:
-			l.file[infoLog].Write(data)
+		case InfoLog:
+			l.file[InfoLog].Write(data)
 		}
 
 		if stats := severityStats[s]; stats != nil {
@@ -792,7 +799,7 @@ func (l *loggingT) outputLogEntry(s severity, file string, line int, alsoToStder
 	}
 	l.mu.Unlock()
 	// Flush and exit on fatal logging.
-	if s == fatalLog {
+	if s == FatalLog {
 		// If we got here via Exit rather than Fatal, print no stacks.
 		timeoutFlush(10 * time.Second)
 		if atomic.LoadUint32(&fatalNoStacks) > 0 {
@@ -914,7 +921,7 @@ type syncBuffer struct {
 	logger *loggingT
 	*bufio.Writer
 	file   *os.File
-	sev    severity
+	sev    Severity
 	nbytes uint64 // The number of bytes written to this file
 }
 
@@ -947,7 +954,7 @@ func (sb *syncBuffer) rotateFile(now time.Time) error {
 		}
 	}
 	var err error
-	sb.file, _, err = create(severityName[sb.sev], now)
+	sb.file, _, err = create(sb.sev, now)
 	sb.nbytes = 0
 	if err != nil {
 		return err
@@ -984,11 +991,11 @@ const bufferSize = 256 * 1024
 
 // createFiles creates all the log files for severity from sev down to InfoLog.
 // l.mu is held.
-func (l *loggingT) createFiles(sev severity) error {
+func (l *loggingT) createFiles(sev Severity) error {
 	now := time.Now()
 	// Files are created in decreasing severity order, so as soon as we find one
 	// has already been created, we can stop.
-	for s := sev; s >= infoLog && l.file[s] == nil; s-- {
+	for s := sev; s >= InfoLog && l.file[s] == nil; s-- {
 		sb := &syncBuffer{
 			logger: l,
 			sev:    s,
@@ -1022,7 +1029,7 @@ func (l *loggingT) lockAndFlushAll() {
 // l.mu is held.
 func (l *loggingT) flushAll() {
 	// Flush from fatal down, in case there's trouble flushing.
-	for s := fatalLog; s >= infoLog; s-- {
+	for s := FatalLog; s >= InfoLog; s-- {
 		file := l.file[s]
 		if file != nil {
 			_ = file.Flush() // ignore error
@@ -1039,7 +1046,7 @@ func (l *loggingT) flushAll() {
 // Valid names are "INFO", "WARNING", "ERROR", and "FATAL".  If the name is not
 // recognized, CopyStandardLogTo panics.
 func CopyStandardLogTo(name string) {
-	sev, ok := severityByName(name)
+	sev, ok := SeverityByName(name)
 	if !ok {
 		panic(fmt.Sprintf("log.CopyStandardLogTo(%q): unrecognized Severity name", name))
 	}
@@ -1051,7 +1058,7 @@ func CopyStandardLogTo(name string) {
 
 // logBridge provides the Write method that enables CopyStandardLogTo to connect
 // Go's standard logs to the logs provided by this package.
-type logBridge severity
+type logBridge Severity
 
 // Write parses the standard logging line and passes its components to the
 // logger for Severity(lb).
@@ -1078,7 +1085,7 @@ func (lb logBridge) Write(b []byte) (n int, err error) {
 	entry := &proto.LogEntry{
 		Format: text,
 	}
-	logging.outputLogEntry(severity(lb), file, line, true, entry)
+	logging.outputLogEntry(Severity(lb), file, line, true, entry)
 	return len(b), nil
 }
 

--- a/util/log/clog_test.go
+++ b/util/log/clog_test.go
@@ -58,7 +58,7 @@ func (f *flushBuffer) Sync() error {
 }
 
 // swap sets the log writers and returns the old array.
-func (l *loggingT) swap(writers [numSeverity]flushSyncWriter) (old [numSeverity]flushSyncWriter) {
+func (l *loggingT) swap(writers [NumSeverity]flushSyncWriter) (old [NumSeverity]flushSyncWriter) {
 	l.mu.Lock()
 	defer l.mu.Unlock()
 	old = l.file
@@ -69,12 +69,12 @@ func (l *loggingT) swap(writers [numSeverity]flushSyncWriter) (old [numSeverity]
 }
 
 // newBuffers sets the log writers to all new byte buffers and returns the old array.
-func (l *loggingT) newBuffers() [numSeverity]flushSyncWriter {
-	return l.swap([numSeverity]flushSyncWriter{new(flushBuffer), new(flushBuffer), new(flushBuffer), new(flushBuffer)})
+func (l *loggingT) newBuffers() [NumSeverity]flushSyncWriter {
+	return l.swap([NumSeverity]flushSyncWriter{new(flushBuffer), new(flushBuffer), new(flushBuffer), new(flushBuffer)})
 }
 
 // contents returns the specified log value as a string.
-func contents(s severity) string {
+func contents(s Severity) string {
 	buffer := bytes.NewBuffer(logging.file[s].(*flushBuffer).Buffer.Bytes())
 	hr := NewTermEntryReader(buffer)
 	bytes, err := ioutil.ReadAll(hr)
@@ -85,7 +85,7 @@ func contents(s severity) string {
 }
 
 // jsonContents returns the specified log JSON-encoded.
-func jsonContents(s severity) []byte {
+func jsonContents(s Severity) []byte {
 	buffer := bytes.NewBuffer(logging.file[s].(*flushBuffer).Buffer.Bytes())
 	hr := NewJSONEntryReader(buffer)
 	bytes, err := ioutil.ReadAll(hr)
@@ -96,7 +96,7 @@ func jsonContents(s severity) []byte {
 }
 
 // contains reports whether the string is contained in the log.
-func contains(s severity, str string, t *testing.T) bool {
+func contains(s Severity, str string, t *testing.T) bool {
 	c := contents(s)
 	return strings.Contains(c, str)
 }
@@ -113,10 +113,10 @@ func TestInfo(t *testing.T) {
 	setFlags()
 	defer logging.swap(logging.newBuffers())
 	Info("test")
-	if !contains(infoLog, "I", t) {
-		t.Errorf("Info has wrong character: %q", contents(infoLog))
+	if !contains(InfoLog, "I", t) {
+		t.Errorf("Info has wrong character: %q", contents(InfoLog))
 	}
-	if !contains(infoLog, "test", t) {
+	if !contains(InfoLog, "test", t) {
 		t.Error("Info failed")
 	}
 }
@@ -141,10 +141,10 @@ func TestStandardLog(t *testing.T) {
 	setFlags()
 	defer logging.swap(logging.newBuffers())
 	stdLog.Print("test")
-	if !contains(infoLog, "I", t) {
-		t.Errorf("Info has wrong character: %q", contents(infoLog))
+	if !contains(InfoLog, "I", t) {
+		t.Errorf("Info has wrong character: %q", contents(InfoLog))
 	}
-	if !contains(infoLog, "test", t) {
+	if !contains(InfoLog, "test", t) {
 		t.Error("Info failed")
 	}
 }
@@ -154,7 +154,7 @@ func TestJSONLogFormat(t *testing.T) {
 	setFlags()
 	defer logging.swap(logging.newBuffers())
 	stdLog.Print("test")
-	json := jsonContents(infoLog)
+	json := jsonContents(InfoLog)
 	expPat := `{
   "severity": 0,
   "time": [\d]+,
@@ -178,17 +178,17 @@ func TestError(t *testing.T) {
 	setFlags()
 	defer logging.swap(logging.newBuffers())
 	Error("test")
-	if !contains(errorLog, "E", t) {
-		t.Errorf("Error has wrong character: %q", contents(errorLog))
+	if !contains(ErrorLog, "E", t) {
+		t.Errorf("Error has wrong character: %q", contents(ErrorLog))
 	}
-	if !contains(errorLog, "test", t) {
+	if !contains(ErrorLog, "test", t) {
 		t.Error("Error failed")
 	}
-	str := contents(errorLog)
-	if !contains(warningLog, str, t) {
+	str := contents(ErrorLog)
+	if !contains(WarningLog, str, t) {
 		t.Error("Warning failed")
 	}
-	if !contains(infoLog, str, t) {
+	if !contains(InfoLog, str, t) {
 		t.Error("Info failed")
 	}
 }
@@ -200,14 +200,14 @@ func TestWarning(t *testing.T) {
 	setFlags()
 	defer logging.swap(logging.newBuffers())
 	Warning("test")
-	if !contains(warningLog, "W", t) {
-		t.Errorf("Warning has wrong character: %q", contents(warningLog))
+	if !contains(WarningLog, "W", t) {
+		t.Errorf("Warning has wrong character: %q", contents(WarningLog))
 	}
-	if !contains(warningLog, "test", t) {
+	if !contains(WarningLog, "test", t) {
 		t.Error("Warning failed")
 	}
-	str := contents(warningLog)
-	if !contains(infoLog, str, t) {
+	str := contents(WarningLog)
+	if !contains(InfoLog, str, t) {
 		t.Error("Info failed")
 	}
 }
@@ -219,12 +219,12 @@ func TestV(t *testing.T) {
 	_ = logging.verbosity.Set("2")
 	defer func() { _ = logging.verbosity.Set("0") }()
 	if v(2) {
-		logging.print(infoLog, "test")
+		logging.print(InfoLog, "test")
 	}
-	if !contains(infoLog, "I", t) {
-		t.Errorf("Info has wrong character: %q", contents(infoLog))
+	if !contains(InfoLog, "I", t) {
+		t.Errorf("Info has wrong character: %q", contents(InfoLog))
 	}
-	if !contains(infoLog, "test", t) {
+	if !contains(InfoLog, "test", t) {
 		t.Error("Info failed")
 	}
 }
@@ -245,12 +245,12 @@ func TestVmoduleOn(t *testing.T) {
 		t.Error("V enabled for 3")
 	}
 	if v(2) {
-		logging.print(infoLog, "test")
+		logging.print(InfoLog, "test")
 	}
-	if !contains(infoLog, "I", t) {
-		t.Errorf("Info has wrong character: %q", contents(infoLog))
+	if !contains(InfoLog, "I", t) {
+		t.Errorf("Info has wrong character: %q", contents(InfoLog))
 	}
-	if !contains(infoLog, "test", t) {
+	if !contains(InfoLog, "test", t) {
 		t.Error("Info failed")
 	}
 }
@@ -267,9 +267,9 @@ func TestVmoduleOff(t *testing.T) {
 		}
 	}
 	if v(2) {
-		logging.print(infoLog, "test")
+		logging.print(InfoLog, "test")
 	}
-	if contents(infoLog) != "" {
+	if contents(InfoLog) != "" {
 		t.Error("V logged incorrectly")
 	}
 }
@@ -318,12 +318,12 @@ func TestListLogFiles(t *testing.T) {
 	Warning("x") // Be sure we have a file.
 	var info, warn *syncBuffer
 	var ok bool
-	info, ok = logging.file[infoLog].(*syncBuffer)
+	info, ok = logging.file[InfoLog].(*syncBuffer)
 	if !ok {
 		t.Fatal("info wasn't created")
 	}
 	infoName := path.Base(info.file.Name())
-	warn, ok = logging.file[warningLog].(*syncBuffer)
+	warn, ok = logging.file[WarningLog].(*syncBuffer)
 	if !ok {
 		t.Fatal("warning wasn't created")
 	}
@@ -334,6 +334,7 @@ func TestListLogFiles(t *testing.T) {
 	}
 	var foundInfo, foundWarn bool
 	for _, r := range results {
+		fmt.Printf("Results: Name:%v\n", r.Name)
 		if r.Name == infoName {
 			foundInfo = true
 		}
@@ -350,7 +351,7 @@ func TestGetLogReader(t *testing.T) {
 	setFlags()
 	*logDir = os.TempDir()
 	Warning("x")
-	warn, ok := logging.file[warningLog].(*syncBuffer)
+	warn, ok := logging.file[WarningLog].(*syncBuffer)
 	if !ok {
 		t.Fatal("warning wasn't created")
 	}
@@ -400,7 +401,7 @@ func TestRollover(t *testing.T) {
 	MaxSize = 512
 
 	Info("x") // Be sure we have a file.
-	info, ok := logging.file[infoLog].(*syncBuffer)
+	info, ok := logging.file[InfoLog].(*syncBuffer)
 	if !ok {
 		t.Fatal("info wasn't created")
 	}
@@ -460,7 +461,7 @@ func TestLogBacktraceAt(t *testing.T) {
 			t.Fatal(err)
 		}
 	}
-	numAppearances := strings.Count(contents(infoLog), infoLine)
+	numAppearances := strings.Count(contents(InfoLog), infoLine)
 	if numAppearances < 2 {
 		// Need 2 appearances, one in the log header and one in the trace:
 		//   log_test.go:281: I0511 16:36:06.952398 02238 log_test.go:280] we want a stack trace here
@@ -469,7 +470,7 @@ func TestLogBacktraceAt(t *testing.T) {
 		//   ...
 		// We could be more precise but that would require knowing the details
 		// of the traceback format, which may not be dependable.
-		t.Fatal("got no trace back; log is ", contents(infoLog))
+		t.Fatal("got no trace back; log is ", contents(InfoLog))
 	}
 }
 
@@ -518,7 +519,7 @@ func TestFatalStacktraceStderr(t *testing.T) {
 	defer logging.swap(logging.newBuffers())
 
 	Fatalf("cinap")
-	cont := contents(fatalLog)
+	cont := contents(FatalLog)
 	msg := ""
 	if !strings.Contains(cont, "] cinap") {
 		msg = "panic output does not contain cinap"
@@ -529,14 +530,14 @@ func TestFatalStacktraceStderr(t *testing.T) {
 	}
 
 	if msg != "" {
-		t.Fatalf("%s: %s", msg, contents(fatalLog))
+		t.Fatalf("%s: %s", msg, contents(FatalLog))
 	}
 
 }
 
 func BenchmarkHeader(b *testing.B) {
 	for i := 0; i < b.N; i++ {
-		buf := formatHeader(infoLog, time.Now(), 1, "file.go", 100, nil)
+		buf := formatHeader(InfoLog, time.Now(), 1, "file.go", 100, nil)
 		logging.putBuffer(buf)
 	}
 }

--- a/util/log/file_test.go
+++ b/util/log/file_test.go
@@ -1,0 +1,109 @@
+// Go support for leveled logs, analogous to https://code.google.com/p/google-clog/
+//
+// Copyright 2013 Google Inc. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Author: Bram Gruneir (bram@cockroachlabs.com)
+
+package log
+
+import (
+	"testing"
+	"time"
+)
+
+// TestLogFilenameParsing ensures that logName and parseLogFilename work as
+// advertised.
+func TestLogFilenameParsing(t *testing.T) {
+	testCases := []struct {
+		Severity Severity
+		Time     time.Time
+	}{
+		{InfoLog, time.Now()},
+		{WarningLog, time.Now().AddDate(-10, 0, 0)},
+		{ErrorLog, time.Now().AddDate(0, 0, -1)},
+	}
+
+	for i, testCase := range testCases {
+		filename, _ := logName(testCase.Severity, testCase.Time)
+		details, err := parseLogFilename(filename)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if details.Severity != testCase.Severity {
+			t.Errorf("%d: Severities do not match, expected:%s - actual:%s", i, testCase.Severity.Name(), details.Severity.Name())
+		}
+		if details.Time.Format(time.RFC3339) != testCase.Time.Format(time.RFC3339) {
+			t.Errorf("%d: Times do not match, expected:%v - actual:%v", i, testCase.Time.Format(time.RFC3339), details.Time.Format(time.RFC3339))
+		}
+	}
+}
+
+// TestSelectFiles checks that selectFiles correctly filters and orders
+// filesInfos.
+func TestSelectFiles(t *testing.T) {
+	testFiles := []FileInfo{}
+	year2000 := time.Date(2000, time.January, 1, 1, 0, 0, 0, time.UTC)
+	year2050 := time.Date(2050, time.January, 1, 1, 0, 0, 0, time.UTC)
+	year2200 := time.Date(2200, time.January, 1, 1, 0, 0, 0, time.UTC)
+	for i := 0; i < 100; i++ {
+		sev := Severity(i % 3)
+		fileTime := year2000.AddDate(i, 0, 0)
+		name, _ := logName(sev, fileTime)
+		testfile := FileInfo{
+			Name: name,
+			Details: FileDetails{
+				Severity: sev,
+				Time:     fileTime,
+			},
+		}
+		testFiles = append(testFiles, testfile)
+	}
+
+	testCases := []struct {
+		Severity      Severity
+		EndTimestamp  int64
+		ExpectedCount int
+	}{
+		{InfoLog, year2200.UnixNano(), 34},
+		{WarningLog, year2200.UnixNano(), 33},
+		{ErrorLog, year2200.UnixNano(), 33},
+		{InfoLog, year2050.UnixNano(), 17},
+		{WarningLog, year2050.UnixNano(), 17},
+		{ErrorLog, year2050.UnixNano(), 17},
+		{InfoLog, year2000.UnixNano(), 1},
+		{WarningLog, year2000.UnixNano(), 0},
+		{ErrorLog, year2000.UnixNano(), 0},
+	}
+
+	for i, testCase := range testCases {
+		actualFiles := selectFiles(testFiles, testCase.Severity, testCase.EndTimestamp)
+		previousTimestamp := year2200.UnixNano()
+		if len(actualFiles) != testCase.ExpectedCount {
+			t.Fatalf("%d: expected %d files, actual %d", i, testCase.ExpectedCount, len(actualFiles))
+		}
+		for _, file := range actualFiles {
+			if file.Details.Time.UnixNano() > previousTimestamp {
+				t.Fatalf("%d: returned files are not in the correct order", i)
+			}
+			if file.Details.Severity != testCase.Severity {
+				t.Fatalf("%d: did not filter by severity", i)
+			}
+			if file.Details.Time.UnixNano() > testCase.EndTimestamp {
+				t.Fatalf("%d: did not filter by endTime", i)
+			}
+			previousTimestamp = file.Details.Time.UnixNano()
+		}
+	}
+}

--- a/util/log/log.go
+++ b/util/log/log.go
@@ -53,7 +53,7 @@ func DisableLogFileOutput() {
 // logDepth uses the PrintWith to format the output string and
 // formulate the context information into the machine-readable
 // dictionary for separate binary-log output.
-func logDepth(ctx context.Context, depth int, sev severity, format string, args []interface{}) {
+func logDepth(ctx context.Context, depth int, sev Severity, format string, args []interface{}) {
 	// TODO(tschottdorf): logging hooks should have their entry point here.
 	AddStructured(ctx, sev, depth+1, format, args)
 }
@@ -63,25 +63,25 @@ func logDepth(ctx context.Context, depth int, sev severity, format string, args 
 // given message and any additional pairs specified as consecutive elements in
 // kvs.
 func Infoc(ctx context.Context, format string, args ...interface{}) {
-	logDepth(ctx, 1, infoLog, format, args)
+	logDepth(ctx, 1, InfoLog, format, args)
 }
 
 // Info logs to the INFO log.
 // Arguments are handled in the manner of fmt.Print; a newline is appended.
 func Info(args ...interface{}) {
-	logDepth(nil, 1, infoLog, "", args)
+	logDepth(nil, 1, InfoLog, "", args)
 }
 
 // Infof logs to the INFO log. Don't use it; use Info or Infoc instead.
 // Arguments are handled in the manner of fmt.Printf; a newline is appended if missing.
 func Infof(format string, args ...interface{}) {
-	logDepth(nil, 1, infoLog, format, args)
+	logDepth(nil, 1, InfoLog, format, args)
 }
 
 // InfoDepth logs to the INFO log, offsetting the caller's stack frame by
 // 'depth'.
 func InfoDepth(depth int, args ...interface{}) {
-	logDepth(nil, depth+1, infoLog, "", args)
+	logDepth(nil, depth+1, InfoLog, "", args)
 }
 
 // Warningc logs to the WARNING and INFO logs. It extracts values from the
@@ -89,53 +89,53 @@ func InfoDepth(depth int, args ...interface{}) {
 // with the given message and any additional pairs specified as consecutive
 // elements in kvs.
 func Warningc(ctx context.Context, format string, args ...interface{}) {
-	logDepth(ctx, 1, warningLog, format, args)
+	logDepth(ctx, 1, WarningLog, format, args)
 }
 
 // Warning logs to the WARNING and INFO logs.
 // Warningf logs to the WARNING and INFO logs. Don't use it; use Warning or
 // Arguments are handled in the manner of fmt.Print; a newline is appended.
 func Warning(args ...interface{}) {
-	logDepth(nil, 1, warningLog, "", args)
+	logDepth(nil, 1, WarningLog, "", args)
 }
 
 // Warningf logs to the WARNING and INFO logs. Don't use it; use Warning or
 // Warningc instead. Arguments are handled in the manner of fmt.Printf; a
 // newline is appended if missing.
 func Warningf(format string, args ...interface{}) {
-	logDepth(nil, 1, warningLog, format, args)
+	logDepth(nil, 1, WarningLog, format, args)
 }
 
 // WarningDepth logs to the WARNING and INFO logs, offsetting the caller's
 // stack frame by 'depth'.
 func WarningDepth(depth int, args ...interface{}) {
-	logDepth(nil, depth+1, warningLog, "", args)
+	logDepth(nil, depth+1, WarningLog, "", args)
 }
 
 // Errorc logs to the ERROR, WARNING, and INFO logs. It extracts values from
 // Field keys specified in this package and logs them along with the given
 // message and any additional pairs specified as consecutive elements in kvs.
 func Errorc(ctx context.Context, format string, args ...interface{}) {
-	logDepth(ctx, 1, errorLog, format, args)
+	logDepth(ctx, 1, ErrorLog, format, args)
 }
 
 // Error logs to the ERROR, WARNING, and INFO logs.
 // Arguments are handled in the manner of fmt.Print; a newline is appended.
 func Error(args ...interface{}) {
-	logDepth(nil, 1, errorLog, "", args)
+	logDepth(nil, 1, ErrorLog, "", args)
 }
 
 // Errorf logs to the ERROR, WARNING, and INFO logs. Don't use it; use Error
 // Info or Errorc instead. Arguments are handled in the manner of fmt.Printf;
 // a newline is appended if missing.
 func Errorf(format string, args ...interface{}) {
-	logDepth(nil, 1, errorLog, format, args)
+	logDepth(nil, 1, ErrorLog, format, args)
 }
 
 // ErrorDepth logs to the ERROR, WARNING, and INFO logs, offsetting the
 // caller's stack frame by 'depth'.
 func ErrorDepth(depth int, args ...interface{}) {
-	logDepth(nil, depth+1, errorLog, "", args)
+	logDepth(nil, depth+1, ErrorLog, "", args)
 }
 
 // Fatalc logs to the INFO, WARNING, ERROR, and FATAL logs, including a stack
@@ -144,28 +144,28 @@ func ErrorDepth(depth int, args ...interface{}) {
 // them along with the given message and any additional pairs specified as
 // consecutive elements in kvs.
 func Fatalc(ctx context.Context, format string, args ...interface{}) {
-	logDepth(ctx, 1, fatalLog, format, args)
+	logDepth(ctx, 1, FatalLog, format, args)
 }
 
 // Fatal logs to the INFO, WARNING, ERROR, and FATAL logs,
 // including a stack trace of all running goroutines, then calls os.Exit(255).
 // Arguments are handled in the manner of fmt.Print; a newline is appended.
 func Fatal(args ...interface{}) {
-	logDepth(nil, 1, fatalLog, "", args)
+	logDepth(nil, 1, FatalLog, "", args)
 }
 
 // Fatalf logs to the INFO, WARNING, ERROR, and FATAL logs,
 // including a stack trace of all running goroutines, then calls os.Exit(255).
 // Arguments are handled in the manner of fmt.Printf; a newline is appended.
 func Fatalf(format string, args ...interface{}) {
-	logDepth(nil, 1, fatalLog, format, args)
+	logDepth(nil, 1, FatalLog, format, args)
 }
 
 // FatalDepth logs to the INFO, WARNING, ERROR, and FATAL logs,
 // including a stack trace of all running goroutines, then calls os.Exit(255),
 // offsetting the caller's stack frame by 'depth'.
 func FatalDepth(depth int, args ...interface{}) {
-	logDepth(nil, depth+1, fatalLog, "", args)
+	logDepth(nil, depth+1, FatalLog, "", args)
 }
 
 // V returns true if the logging verbosity is set to the specified level or

--- a/util/log/structured.go
+++ b/util/log/structured.go
@@ -31,7 +31,7 @@ import (
 
 // AddStructured creates a structured log entry to be written to the
 // specified facility of the logger.
-func AddStructured(ctx context.Context, s severity, depth int, format string, args []interface{}) {
+func AddStructured(ctx context.Context, s Severity, depth int, format string, args []interface{}) {
 	file, line := Caller(depth + 1)
 	entry := &proto.LogEntry{}
 	setLogEntry(ctx, format, args, entry)


### PR DESCRIPTION
This enables the status server to retrieve log entires directly from the log files.

To get a list of logs, just go to: 
  **_status/local/log/**
or if you like to choose your logging level 
  **_status/local/log/WARNING**
or if you want to choose your start and end time
  **_status/local/log/ERROR?starttime=1433884484989655088&endtime=1433884484989655088**

But don't forget to turn on file logging using the flags:
--log-dir=/tmp/logs --alsologtostderr=true --logtostderr=false
