### PR TITLE
Return an error if a client.DB is created without a sender.

### DIFF
--- a/client/db.go
+++ b/client/db.go
@@ -226,6 +226,10 @@ func Open(addr string, opts ...Option) (*DB, error) {
 	for _, opt := range opts {
 		opt(db)
 	}
+
+	if db.Sender == nil {
+		return nil, fmt.Errorf("\"%s\" no sender specified", addr)
+	}
 	return db, nil
 }
 

--- a/client/db_test.go
+++ b/client/db_test.go
@@ -264,6 +264,7 @@ func TestOpenArgs(t *testing.T) {
 		{"https://root@" + s.ServingAddr() + "?certs=test_certs", false},
 		{"https://" + s.ServingAddr() + "?certs=test_certs", false},
 		{"https://" + s.ServingAddr() + "?certs=foo", true},
+		{s.ServingAddr(), true},
 	}
 
 	for _, test := range testCases {


### PR DESCRIPTION
Fixes #1321.
