### PR TITLE
Require client certs on some endpoint.

### DIFF
--- a/rpc/server.go
+++ b/rpc/server.go
@@ -27,7 +27,6 @@ import (
 	"sync"
 
 	"github.com/cockroachdb/cockroach/rpc/codec"
-	"github.com/cockroachdb/cockroach/security"
 	"github.com/cockroachdb/cockroach/util"
 	"github.com/cockroachdb/cockroach/util/log"
 )
@@ -80,7 +79,6 @@ var connected = "200 Connected to Go RPC"
 
 // ServeHTTP implements an http.Handler that answers RPC requests.
 func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
-	security.LogRequestCertificates(r)
 	if r.URL.Path != rpc.DefaultRPCPath {
 		if s.handler != nil {
 			s.handler.ServeHTTP(w, r)
@@ -89,6 +87,9 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		http.NotFound(w, r)
 		return
 	}
+	// TODO(marc): figure out the right way to do authentication,
+	// and how to pass verified credentials.
+
 	// Note: this code was adapted from net/rpc.Server.ServeHTTP.
 	if r.Method != "CONNECT" {
 		w.Header().Set("Content-Type", "text/plain; charset=utf-8")

--- a/server/authentication_test.go
+++ b/server/authentication_test.go
@@ -1,0 +1,125 @@
+// Copyright 2015 The Cockroach Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+// implied. See the License for the specific language governing
+// permissions and limitations under the License. See the AUTHORS file
+// for names of contributors.
+//
+// Author: Marc Berhault (marc@cockroachlabs.com)
+
+package server
+
+import (
+	"fmt"
+	"net/http"
+	"testing"
+
+	"github.com/cockroachdb/cockroach/kv"
+	"github.com/cockroachdb/cockroach/testutils"
+	"github.com/cockroachdb/cockroach/ts"
+)
+
+func doHTTPReq(t *testing.T, client *http.Client, method, url string) (*http.Response, error) {
+	req, err := http.NewRequest(method, url, nil)
+	if err != nil {
+		t.Fatalf("%s %s: error building request: %s", method, url, err)
+	}
+
+	return client.Do(req)
+}
+
+// Verify client certificate enforcement.
+func TestSSLEnforcement(t *testing.T) {
+	s := StartTestServer(t)
+	defer s.Stop()
+	testCases := []struct {
+		method, key   string
+		certsStatus   int // Status code for https with client certs.
+		noCertsStatus int // Status code for https without client certs.
+	}{
+		// /ui/: basic file server: no auth.
+		{"GET", "/index.html", http.StatusOK, http.StatusOK},
+
+		// /_admin/: server.adminServer: no auth.
+		{"GET", healthPath, http.StatusOK, http.StatusOK},
+
+		// /debug/: server.adminServer: no auth.
+		{"GET", debugEndpoint + "vars", http.StatusOK, http.StatusOK},
+
+		// /_status/: server.statusServer: no auth.
+		{"GET", statusKeyPrefix, http.StatusOK, http.StatusOK},
+
+		// /kv/rest/: kv.RESTServer. Key cannot be empty. Response is NotFound since the key does not exist.
+		{"GET", kv.EntryPrefix + "foo", http.StatusNotFound, http.StatusUnauthorized},
+
+		// /kv/db/: kv.DBServer. These are proto reqs, but we can at least get past auth.
+		{"GET", kv.DBPrefix + "Get", http.StatusBadRequest, http.StatusUnauthorized},
+
+		// /ts/: ts.Server.
+		{"GET", ts.URLPrefix, http.StatusNotFound, http.StatusUnauthorized},
+	}
+
+	// HTTPS with client certs.
+	certsContext := testutils.NewTestBaseContext()
+	client, err := certsContext.GetHTTPClient()
+	if err != nil {
+		t.Fatalf("error initializing http client: %s", err)
+	}
+	for tcNum, tc := range testCases {
+		resp, err := doHTTPReq(t, client, tc.method,
+			fmt.Sprintf("%s://%s%s", certsContext.RequestScheme(), s.ServingAddr(), tc.key))
+		if err != nil {
+			t.Fatalf("[%d]: error issuing request: %s", tcNum, err)
+		}
+
+		defer resp.Body.Close()
+		if resp.StatusCode != tc.certsStatus {
+			t.Errorf("[%d]: expected status code %d, got %d", tcNum, tc.certsStatus, resp.StatusCode)
+		}
+	}
+
+	// HTTPS without client certs.
+	noCertsContext := testutils.NewTestBaseContext()
+	noCertsContext.Certs = ""
+	client, err = noCertsContext.GetHTTPClient()
+	if err != nil {
+		t.Fatalf("error initializing http client: %s", err)
+	}
+	for tcNum, tc := range testCases {
+		resp, err := doHTTPReq(t, client, tc.method,
+			fmt.Sprintf("%s://%s%s", noCertsContext.RequestScheme(), s.ServingAddr(), tc.key))
+		if err != nil {
+			t.Fatalf("[%d]: error issuing request: %s", tcNum, err)
+		}
+
+		defer resp.Body.Close()
+		if resp.StatusCode != tc.noCertsStatus {
+			t.Errorf("[%d]: expected status code %d, got %d", tcNum, tc.noCertsStatus, resp.StatusCode)
+		}
+	}
+
+	// Plain http.
+	insecureContext := testutils.NewTestBaseContext()
+	insecureContext.Insecure = true
+	client, err = insecureContext.GetHTTPClient()
+	if err != nil {
+		t.Fatalf("error initializing http client: %s", err)
+	}
+	for tcNum, tc := range testCases {
+		resp, err := doHTTPReq(t, client, tc.method,
+			fmt.Sprintf("%s://%s%s", insecureContext.RequestScheme(), s.ServingAddr(), tc.key))
+		// We're talking http to a https server. We don't even make it to a response.
+		if err == nil {
+			defer resp.Body.Close()
+			t.Errorf("[%d]: unexpected success", tcNum)
+		}
+	}
+}

--- a/server/cli/start.go
+++ b/server/cli/start.go
@@ -24,10 +24,8 @@ import (
 	"syscall"
 	"time"
 
-	"github.com/cockroachdb/cockroach/kv"
 	"github.com/cockroachdb/cockroach/server"
 	"github.com/cockroachdb/cockroach/storage/engine"
-	"github.com/cockroachdb/cockroach/structured"
 	"github.com/cockroachdb/cockroach/util"
 	"github.com/cockroachdb/cockroach/util/log"
 
@@ -89,14 +87,7 @@ specified via the --stores flag. This is a comma-separated list of paths to
 storage directories or for in-memory stores, the number of bytes. Although the
 paths should be specified to correspond uniquely to physical devices, this
 requirement isn't strictly enforced. See the --stores flag help description for
-additional details.
-
-A node exports an HTTP API with the following endpoints:
-
-  Health check:           /healthz
-  Key-value REST:         ` + kv.RESTPrefix + `
-  Structured Schema REST: ` + structured.StructuredKeyPrefix + `
-`,
+additional details.`,
 	Example: `  cockroach start --certs=<dir> --gossip=host1:port1[,...] --stores=ssd=/mnt/ssd1,...`,
 	Run:     runStart,
 }


### PR DESCRIPTION
- only when --insecure=false
- basic test per prefix (granularity used for authentication setting)
- remove structured/ from server/server.go (and comment in cli)
