### PR TITLE
Always generate certs in acceptance tests

### DIFF
--- a/acceptance/localcluster/localcluster.go
+++ b/acceptance/localcluster/localcluster.go
@@ -23,10 +23,8 @@ import (
 	"fmt"
 	"io"
 	"io/ioutil"
-	"net"
 	"os"
 	"path/filepath"
-	"runtime"
 	"strings"
 	"sync"
 
@@ -316,12 +314,7 @@ func (l *Cluster) createNodeCerts() {
 	}
 	args := []string{"cert", "--certs=/certs", "create-node", "--key-size=512"}
 	args = append(args, nodes...)
-	if host := os.Getenv("DOCKER_HOST"); host != "" {
-		args = append(args, host)
-	}
-	if runtime.GOOS == "linux" {
-		args = append(args, net.IPv4zero.String())
-	}
+	args = append(args, dockerIP().String())
 	c := l.createRoach(-1, args...)
 	defer c.mustRemove()
 	maybePanic(c.Start(nil, nil, l.vols))

--- a/acceptance/util.go
+++ b/acceptance/util.go
@@ -41,7 +41,7 @@ func makeDBClientForUser(t *testing.T, cluster *localcluster.Cluster, user strin
 	// to reach the cluster. This in turn means that we do not have a verified server name in the certs.
 	c, err := client.Open("https://" + user + "@" +
 		cluster.Nodes[node].Addr("").String() +
-		"?certs=")
+		"?certs=" + cluster.CertsDir)
 
 	if err != nil {
 		t.Fatal(err)


### PR DESCRIPTION
Now that we're using key-size=512, it's much much faster.
Add DOCKER_HOST and 0.0.0.0 to server certs if appropriate.
