### PR TITLE
Disable alsoToStderr flag

### DIFF
--- a/util/log/log.go
+++ b/util/log/log.go
@@ -40,7 +40,7 @@ func FatalOnPanic() {
 func EnableLogFileOutput(dir string) {
 	*logDir = dir
 	logging.toStderr = false
-	logging.alsoToStderr = true
+	logging.alsoToStderr = false
 }
 
 // DisableLogFileOutput turns off logging. For unittesting only.


### PR DESCRIPTION
I think we shouldn't write logs to stderr when users want to write logs to  a directory.
Any thoughts ?
