### PR TITLE
Use base.Context in rpc.Context

### DIFF
--- a/client/rpc/rpc_sender.go
+++ b/client/rpc/rpc_sender.go
@@ -63,11 +63,7 @@ func newSender(server string, context *base.Context, retryOpts retry.Options) (*
 	if context.Insecure {
 		log.Warning("running in insecure mode, this is strongly discouraged. See --insecure and --certs.")
 	}
-	tlsConfig, err := context.GetClientTLSConfig()
-	if err != nil {
-		return nil, err
-	}
-	ctx := roachrpc.NewContext(hlc.NewClock(hlc.UnixNano), tlsConfig, nil)
+	ctx := roachrpc.NewContext(context, hlc.NewClock(hlc.UnixNano), nil)
 	client := roachrpc.NewClient(addr, &retryOpts, ctx)
 	return &Sender{
 		client:    client,

--- a/gossip/gossip_test.go
+++ b/gossip/gossip_test.go
@@ -25,13 +25,15 @@ import (
 	"github.com/cockroachdb/cockroach/base"
 	"github.com/cockroachdb/cockroach/gossip/resolver"
 	"github.com/cockroachdb/cockroach/rpc"
-	"github.com/cockroachdb/cockroach/security"
+	"github.com/cockroachdb/cockroach/testutils"
 	"github.com/cockroachdb/cockroach/util/hlc"
 )
 
+var testBaseContext = testutils.NewTestBaseContext()
+
 // TestGossipInfoStore verifies operation of gossip instance infostore.
 func TestGossipInfoStore(t *testing.T) {
-	rpcContext := rpc.NewContext(hlc.NewClock(hlc.UnixNano), security.LoadInsecureTLSConfig(), nil)
+	rpcContext := rpc.NewContext(testBaseContext, hlc.NewClock(hlc.UnixNano), nil)
 	g := New(rpcContext, TestInterval, TestBootstrap)
 	if err := g.AddInfo("i", int64(1), time.Hour); err != nil {
 		t.Fatal(err)
@@ -65,7 +67,7 @@ func TestGossipInfoStore(t *testing.T) {
 // TestGossipGroupsInfoStore verifies gossiping of groups via the
 // gossip instance infostore.
 func TestGossipGroupsInfoStore(t *testing.T) {
-	rpcContext := rpc.NewContext(hlc.NewClock(hlc.UnixNano), security.LoadInsecureTLSConfig(), nil)
+	rpcContext := rpc.NewContext(testBaseContext, hlc.NewClock(hlc.UnixNano), nil)
 	g := New(rpcContext, TestInterval, TestBootstrap)
 
 	// For int64.

--- a/gossip/main_test.go
+++ b/gossip/main_test.go
@@ -15,24 +15,12 @@
 //
 // Author: Tobias Schottdorf (tobias.schottdorf@gmail.com)
 
-package rpc
+package gossip_test
 
 import (
-	"testing"
-
 	"github.com/cockroachdb/cockroach/security"
 	"github.com/cockroachdb/cockroach/security/securitytest"
-	"github.com/cockroachdb/cockroach/testutils"
-	"github.com/cockroachdb/cockroach/util/hlc"
 )
-
-var testBaseContext = testutils.NewTestBaseContext()
-
-// NewTestContext returns a rpc.Context for testing.
-func NewTestContext(t *testing.T) *Context {
-	clock := hlc.NewClock(hlc.UnixNano)
-	return NewContext(testBaseContext, clock, nil)
-}
 
 func init() {
 	security.SetReadFileFn(securitytest.Asset)

--- a/gossip/simulation/network.go
+++ b/gossip/simulation/network.go
@@ -20,11 +20,11 @@ package simulation
 import (
 	"time"
 
+	"github.com/cockroachdb/cockroach/base"
 	"github.com/cockroachdb/cockroach/gossip"
 	"github.com/cockroachdb/cockroach/gossip/resolver"
 	"github.com/cockroachdb/cockroach/proto"
 	"github.com/cockroachdb/cockroach/rpc"
-	"github.com/cockroachdb/cockroach/security"
 	"github.com/cockroachdb/cockroach/util"
 	"github.com/cockroachdb/cockroach/util/hlc"
 	"github.com/cockroachdb/cockroach/util/log"
@@ -54,10 +54,8 @@ type Network struct {
 // up being at the various nodes (e.g. DefaultTestGossipInterval).
 func NewNetwork(nodeCount int, networkType string,
 	gossipInterval time.Duration) *Network {
-
-	tlsConfig := security.LoadInsecureTLSConfig()
 	clock := hlc.NewClock(hlc.UnixNano)
-	rpcContext := rpc.NewContext(clock, tlsConfig, nil)
+	rpcContext := rpc.NewContext(&base.Context{Insecure: true}, clock, nil)
 
 	log.Infof("simulating gossip network with %d nodes", nodeCount)
 

--- a/kv/local_test_cluster.go
+++ b/kv/local_test_cluster.go
@@ -27,9 +27,9 @@ import (
 	"github.com/cockroachdb/cockroach/multiraft"
 	"github.com/cockroachdb/cockroach/proto"
 	"github.com/cockroachdb/cockroach/rpc"
-	"github.com/cockroachdb/cockroach/security"
 	"github.com/cockroachdb/cockroach/storage"
 	"github.com/cockroachdb/cockroach/storage/engine"
+	"github.com/cockroachdb/cockroach/testutils"
 	"github.com/cockroachdb/cockroach/util"
 	"github.com/cockroachdb/cockroach/util/hlc"
 	"github.com/cockroachdb/cockroach/util/retry"
@@ -117,7 +117,7 @@ func (ltc *LocalTestCluster) Start(t util.Tester) {
 	ltc.Manual = hlc.NewManualClock(0)
 	ltc.Clock = hlc.NewClock(ltc.Manual.UnixNano)
 	ltc.Stopper = util.NewStopper()
-	rpcContext := rpc.NewContext(ltc.Clock, security.LoadInsecureTLSConfig(), ltc.Stopper)
+	rpcContext := rpc.NewContext(testutils.NewTestBaseContext(), ltc.Clock, ltc.Stopper)
 	ltc.Gossip = gossip.New(rpcContext, gossip.TestInterval, gossip.TestBootstrap)
 	ltc.Eng = engine.NewInMem(proto.Attributes{}, 50<<20)
 	ltc.lSender = newRetryableLocalSender(NewLocalSender())

--- a/rpc/client_test.go
+++ b/rpc/client_test.go
@@ -117,7 +117,7 @@ func TestOffsetMeasurement(t *testing.T) {
 	// Create a client that is 10 nanoseconds behind the server.
 	advancing := AdvancingClock{time: 0, advancementInterval: 10}
 	clientClock := hlc.NewClock(advancing.UnixNano)
-	context := NewContext(clientClock, s.context.tlsConfig, nil)
+	context := NewContext(testBaseContext, clientClock, nil)
 	c := NewClient(s.Addr(), nil, context)
 	<-c.Ready
 
@@ -163,7 +163,7 @@ func TestDelayedOffsetMeasurement(t *testing.T) {
 		advancementInterval: maximumClockReadingDelay.Nanoseconds() + 1,
 	}
 	clientClock := hlc.NewClock(advancing.UnixNano)
-	context := NewContext(clientClock, s.context.tlsConfig, nil)
+	context := NewContext(testBaseContext, clientClock, nil)
 	c := NewClient(s.Addr(), nil, context)
 	<-c.Ready
 
@@ -205,7 +205,7 @@ func TestFailedOffestMeasurement(t *testing.T) {
 	// Create a client that never receives a heartbeat after the first.
 	clientManual := hlc.NewManualClock(0)
 	clientClock := hlc.NewClock(clientManual.UnixNano)
-	context := NewContext(clientClock, s.context.tlsConfig, nil)
+	context := NewContext(testBaseContext, clientClock, nil)
 	c := NewClient(s.Addr(), nil, context)
 	heartbeat.ready <- struct{}{} // Allow one heartbeat for initialization.
 	<-c.Ready

--- a/rpc/rpc.go
+++ b/rpc/rpc.go
@@ -1,37 +1,39 @@
 package rpc
 
 import (
-	"crypto/tls"
-
+	"github.com/cockroachdb/cockroach/base"
 	"github.com/cockroachdb/cockroach/util"
 	"github.com/cockroachdb/cockroach/util/hlc"
 )
 
 // Context contains the fields required by the rpc framework.
 type Context struct {
+	// Embed the base context.
+	base.Context
+
 	localClock   *hlc.Clock
-	tlsConfig    *tls.Config
 	Stopper      *util.Stopper
 	RemoteClocks *RemoteClockMonitor
 	DisableCache bool // Disable client cache when calling NewClient()
 }
 
 // NewContext creates an rpc Context with the supplied values.
-func NewContext(clock *hlc.Clock, config *tls.Config, stopper *util.Stopper) *Context {
-	return &Context{
+func NewContext(context *base.Context, clock *hlc.Clock, stopper *util.Stopper) *Context {
+	ctx := &Context{
+		Context:      *context,
 		localClock:   clock,
-		tlsConfig:    config,
 		Stopper:      stopper,
 		RemoteClocks: newRemoteClockMonitor(clock),
 	}
+	return ctx
 }
 
 // Copy creates a copy of the rpc Context config values, but with a
 // new remote clock monitor.
 func (c *Context) Copy() *Context {
 	return &Context{
+		Context:      c.Context,
 		localClock:   c.localClock,
-		tlsConfig:    c.tlsConfig,
 		Stopper:      c.Stopper,
 		RemoteClocks: newRemoteClockMonitor(c.localClock),
 		DisableCache: c.DisableCache,

--- a/rpc/server.go
+++ b/rpc/server.go
@@ -111,7 +111,11 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 func (s *Server) Listen() error {
 	s.mu.Lock()
 	defer s.mu.Unlock()
-	ln, err := tlsListen(s.addr.Network(), s.addr.String(), s.context.tlsConfig)
+	tlsConfig, err := s.context.GetServerTLSConfig()
+	if err != nil {
+		return err
+	}
+	ln, err := tlsListen(s.addr.Network(), s.addr.String(), tlsConfig)
 	if err != nil {
 		return err
 	}

--- a/server/node_test.go
+++ b/server/node_test.go
@@ -48,17 +48,12 @@ import (
 // not nil, the gossip bootstrap address is set to gossipBS.
 func createTestNode(addr net.Addr, engines []engine.Engine, gossipBS net.Addr, t *testing.T) (
 	*rpc.Server, *hlc.Clock, *Node, *util.Stopper) {
-	// Load the TLS config from our test certs. They're embedded in the
-	// test binary and calls to the file system have been mocked out.
-	tlsConfig, err := testContext.GetServerTLSConfig()
-	if err != nil {
-		t.Fatal(err)
-	}
+	var err error
 	ctx := storage.StoreContext{}
 
 	stopper := util.NewStopper()
 	ctx.Clock = hlc.NewClock(hlc.UnixNano)
-	rpcContext := rpc.NewContext(ctx.Clock, tlsConfig, stopper)
+	rpcContext := rpc.NewContext(testBaseContext, ctx.Clock, stopper)
 	ctx.ScanInterval = 10 * time.Hour
 	rpcServer := rpc.NewServer(addr, rpcContext)
 	if err := rpcServer.Start(); err != nil {

--- a/server/raft_transport_test.go
+++ b/server/raft_transport_test.go
@@ -39,13 +39,9 @@ func (s ChannelServer) RaftMessage(req *multiraft.RaftMessageRequest,
 }
 
 func TestSendAndReceive(t *testing.T) {
-	tlsConfig, err := testContext.GetServerTLSConfig()
-	if err != nil {
-		t.Fatal(err)
-	}
 	stopper := util.NewStopper()
 	defer stopper.Stop()
-	rpcContext := rpc.NewContext(hlc.NewClock(hlc.UnixNano), tlsConfig, stopper)
+	rpcContext := rpc.NewContext(testBaseContext, hlc.NewClock(hlc.UnixNano), stopper)
 	g := gossip.New(rpcContext, gossip.TestInterval, gossip.TestBootstrap)
 
 	// Create several servers, each of which has two stores (A multiraft node ID addresses

--- a/server/server.go
+++ b/server/server.go
@@ -86,8 +86,8 @@ func NewServer(ctx *Context, stopper *util.Stopper) (*Server, error) {
 	if ctx.Insecure {
 		log.Warning("running in insecure mode, this is strongly discouraged. See --insecure and --certs.")
 	}
-	tlsConfig, err := ctx.GetServerTLSConfig()
-	if err != nil {
+	// Try loading the TLS config before anything else.
+	if _, err := ctx.GetServerTLSConfig(); err != nil {
 		return nil, err
 	}
 
@@ -99,7 +99,7 @@ func NewServer(ctx *Context, stopper *util.Stopper) (*Server, error) {
 	}
 	s.clock.SetMaxOffset(ctx.MaxOffset)
 
-	rpcContext := rpc.NewContext(s.clock, tlsConfig, stopper)
+	rpcContext := rpc.NewContext(&ctx.Context, s.clock, stopper)
 	go rpcContext.RemoteClocks.MonitorRemoteOffsets()
 
 	s.rpc = rpc.NewServer(util.MakeUnresolvedAddr("tcp", addr), rpcContext)

--- a/server/server_test.go
+++ b/server/server_test.go
@@ -34,11 +34,13 @@ import (
 	"github.com/cockroachdb/cockroach/proto"
 	"github.com/cockroachdb/cockroach/storage"
 	"github.com/cockroachdb/cockroach/storage/engine"
+	"github.com/cockroachdb/cockroach/testutils"
 	"github.com/cockroachdb/cockroach/util"
 	"github.com/cockroachdb/cockroach/util/log"
 )
 
 var testContext = NewTestContext()
+var testBaseContext = testutils.NewTestBaseContext()
 
 // createTestConfigFile creates a temporary file and writes the
 // testConfig yaml data to it. The caller is responsible for

--- a/storage/client_test.go
+++ b/storage/client_test.go
@@ -35,12 +35,14 @@ import (
 	"github.com/cockroachdb/cockroach/multiraft"
 	"github.com/cockroachdb/cockroach/proto"
 	"github.com/cockroachdb/cockroach/rpc"
-	"github.com/cockroachdb/cockroach/security"
 	"github.com/cockroachdb/cockroach/storage"
 	"github.com/cockroachdb/cockroach/storage/engine"
+	"github.com/cockroachdb/cockroach/testutils"
 	"github.com/cockroachdb/cockroach/util"
 	"github.com/cockroachdb/cockroach/util/hlc"
 )
+
+var testBaseContext = testutils.NewTestBaseContext()
 
 // createTestStore creates a test store using an in-memory
 // engine. The caller is responsible for closing the store on exit.
@@ -56,7 +58,7 @@ func createTestStore(t *testing.T) (*storage.Store, *util.Stopper) {
 func createTestStoreWithEngine(t *testing.T, eng engine.Engine, clock *hlc.Clock,
 	bootstrap bool, context *storage.StoreContext) (*storage.Store, *util.Stopper) {
 	stopper := util.NewStopper()
-	rpcContext := rpc.NewContext(hlc.NewClock(hlc.UnixNano), security.LoadInsecureTLSConfig(), stopper)
+	rpcContext := rpc.NewContext(testBaseContext, hlc.NewClock(hlc.UnixNano), stopper)
 	if context == nil {
 		// make a copy
 		ctx := storage.TestStoreContext
@@ -129,7 +131,7 @@ func (m *multiTestContext) Start(t *testing.T, numStores int) {
 		m.clock = hlc.NewClock(m.manualClock.UnixNano)
 	}
 	if m.gossip == nil {
-		rpcContext := rpc.NewContext(m.clock, security.LoadInsecureTLSConfig(), nil)
+		rpcContext := rpc.NewContext(testBaseContext, m.clock, nil)
 		m.gossip = gossip.New(rpcContext, gossip.TestInterval, gossip.TestBootstrap)
 	}
 	if m.transport == nil {

--- a/storage/range_test.go
+++ b/storage/range_test.go
@@ -37,7 +37,6 @@ import (
 	"github.com/cockroachdb/cockroach/multiraft/storagetest"
 	"github.com/cockroachdb/cockroach/proto"
 	"github.com/cockroachdb/cockroach/rpc"
-	"github.com/cockroachdb/cockroach/security"
 	"github.com/cockroachdb/cockroach/storage/engine"
 	"github.com/cockroachdb/cockroach/util"
 	"github.com/cockroachdb/cockroach/util/hlc"
@@ -119,7 +118,7 @@ func (tc *testContext) Start(t testing.TB) {
 		tc.stopper = util.NewStopper()
 	}
 	if tc.gossip == nil {
-		rpcContext := rpc.NewContext(hlc.NewClock(hlc.UnixNano), security.LoadInsecureTLSConfig(), tc.stopper)
+		rpcContext := rpc.NewContext(testBaseContext, hlc.NewClock(hlc.UnixNano), tc.stopper)
 		tc.gossip = gossip.New(rpcContext, gossip.TestInterval, gossip.TestBootstrap)
 	}
 	if tc.manualClock == nil {

--- a/storage/store_test.go
+++ b/storage/store_test.go
@@ -36,8 +36,8 @@ import (
 	"github.com/cockroachdb/cockroach/multiraft"
 	"github.com/cockroachdb/cockroach/proto"
 	"github.com/cockroachdb/cockroach/rpc"
-	"github.com/cockroachdb/cockroach/security"
 	"github.com/cockroachdb/cockroach/storage/engine"
+	"github.com/cockroachdb/cockroach/testutils"
 	"github.com/cockroachdb/cockroach/util"
 	"github.com/cockroachdb/cockroach/util/hlc"
 	"github.com/cockroachdb/cockroach/util/leaktest"
@@ -51,6 +51,8 @@ var testIdent = proto.StoreIdent{
 	NodeID:    1,
 	StoreID:   1,
 }
+
+var testBaseContext = testutils.NewTestBaseContext()
 
 // setTestRetryOptions sets aggressive retries with a limit on number
 // of attempts so we don't get stuck behind indefinite backoff/retry
@@ -148,7 +150,7 @@ func (db *testSender) sendOne(call client.Call) {
 // responsible for stopping the stopper upon completion.
 func createTestStoreWithoutStart(t *testing.T) (*Store, *hlc.ManualClock, *util.Stopper) {
 	stopper := util.NewStopper()
-	rpcContext := rpc.NewContext(hlc.NewClock(hlc.UnixNano), security.LoadInsecureTLSConfig(), stopper)
+	rpcContext := rpc.NewContext(testBaseContext, hlc.NewClock(hlc.UnixNano), stopper)
 	ctx := TestStoreContext
 	ctx.Gossip = gossip.New(rpcContext, gossip.TestInterval, gossip.TestBootstrap)
 	manual := hlc.NewManualClock(0)


### PR DESCRIPTION
Same pattern as server.Context.
TLSConfig is now always grabbed from context rather than passed around separately.
