### PR TITLE
when client fails, do not return nil

### DIFF
--- a/rpc/client.go
+++ b/rpc/client.go
@@ -131,8 +131,7 @@ func (c *Client) connect(opts *retry.Options, context *Context) {
 		conn, err := tlsDialHTTP(c.addr.Network(), c.addr.String(), context.tlsConfig)
 		// Could be many errors: bad host; bad certificate ...
 		if err != nil {
-			log.Error(err)
-			return retry.Break, nil
+			return retry.Break, err
 		}
 
 		c.mu.Lock()


### PR DESCRIPTION
we need to keep an eye out, multiple PRs have recently
attempted to swallow errors by improperly exiting the
retry loop. This one caused a hard-to-debug error.
