### PR TITLE
more context.Context on receiver path

### DIFF
--- a/kv/local_sender.go
+++ b/kv/local_sender.go
@@ -27,6 +27,7 @@ import (
 	"github.com/cockroachdb/cockroach/proto"
 	"github.com/cockroachdb/cockroach/storage"
 	"github.com/cockroachdb/cockroach/util"
+	"github.com/cockroachdb/cockroach/util/log"
 )
 
 // A LocalSender provides methods to access a collection of local stores.
@@ -134,6 +135,11 @@ func (ls *LocalSender) Send(ctx context.Context, call client.Call) {
 			header.Replica = *repl
 		}
 	}
+	ctx = log.Add(ctx,
+		log.Method, call.Method(),
+		log.Key, header.Key,
+		log.RaftID, header.RaftID)
+
 	if err == nil {
 		store, err = ls.GetStore(header.Replica.StoreID)
 	}

--- a/server/node.go
+++ b/server/node.go
@@ -206,8 +206,7 @@ func NewNode(ctx storage.StoreContext) *Node {
 	}
 }
 
-// context returns a context encapsulating the NodeID and ClusterID (or the
-// respective zero values, until that information is known).
+// context returns a context encapsulating the NodeID.
 func (n *Node) context() context.Context {
 	return log.Add(context.Background(), log.NodeID, n.Descriptor.NodeID)
 }
@@ -287,7 +286,7 @@ func (n *Node) start(rpcServer *rpc.Server, engines []engine.Engine,
 	n.startedAt = n.ctx.Clock.Now().WallTime
 	n.startStoresScanner(stopper)
 	n.startGossip(stopper)
-	log.Infof("Started node with %v engine(s) and attributes %v", engines, attrs.Attrs)
+	log.Infoc(n.context(), "Started node with %v engine(s) and attributes %v", engines, attrs.Attrs)
 	return nil
 }
 
@@ -554,8 +553,8 @@ func (n *Node) waitForScanCompletion() int64 {
 
 // executeCmd creates a client.Call struct and sends it via our local sender.
 func (n *nodeServer) executeCmd(args proto.Request, reply proto.Response) error {
-	// TODO(tschottdorf) get a hold on the client's ip and add it to the
-	// context before dispatching.
+	// TODO(tschottdorf) get a hold of the client's ID, add it to the
+	// context before dispatching, and create an ID for tracing the request.
 	n.lSender.Send((*Node)(n).context(), client.Call{Args: args, Reply: reply})
 	n.feed.CallComplete(args, reply)
 	return nil

--- a/storage/range_test.go
+++ b/storage/range_test.go
@@ -274,10 +274,10 @@ func TestRangeContains(t *testing.T) {
 func setLeaderLease(t *testing.T, r *Range, l *proto.Lease) {
 	args := &proto.InternalLeaderLeaseRequest{Lease: *l}
 	reply := &proto.InternalLeaderLeaseResponse{}
-	errChan, pendingCmd := r.proposeRaftCommand(args, reply)
+	errChan, pendingCmd := r.proposeRaftCommand(r.context(), args, reply)
 	var err error
 	if err = <-errChan; err == nil {
-		// Next if the command was commited, wait for the range to apply it.
+		// Next if the command was committed, wait for the range to apply it.
 		err = <-pendingCmd.done
 	}
 	if err != nil {


### PR DESCRIPTION
> Node -> LocalSender -> Store -> Range [ -> Raft -> ] -> Range

is the chain along which the context.Context is now passed,
which gives us pretty good coverage of a client request once
it has been received at a Node (which is the opposite end
from the DistSender).
The context is not passed into Raft, but the replica which
proposed the command keeps track of it and will have it available
when it executes the command; the remaining replicas will
run it with their default range-level context.

Replaced all log calls in store and range with their contextualized
counterparts.
