### PR TITLE
Control retries via explicit method calls

### DIFF
--- a/GLOCKFILE
+++ b/GLOCKFILE
@@ -12,6 +12,7 @@ bitbucket.org/tebeka/go2xunit 77968f802fb3
 github.com/agtorre/gocolorize f42b554bf7f006936130c9bb4f971afd2d87f671
 github.com/barakmich/go-nyet fba7607fa3f727680833b0c44f35b448dbe5c5a8
 github.com/biogo/store e1f74b3c58befe661feed7fa4cf52436de753128
+github.com/cenkalti/backoff 6c45d6bc1e78d94431dff8fc28a99f20bafa355a
 github.com/cockroachdb/c-lz4 6e71f140a365017bbe0904710007f8725fd3f809
 github.com/cockroachdb/c-protobuf 0f9ab7b988ca7474cf76b9a961ab03c0552abcb3
 github.com/cockroachdb/c-rocksdb e120ce0fb32f86b94188928743270ea11ff016b3

--- a/build/devbase/godeps.sh
+++ b/build/devbase/godeps.sh
@@ -32,6 +32,7 @@ ${GOPATH}/bin/glock sync github.com/cockroachdb/cockroach
 pkgs="
 github.com/biogo/store/interval
 github.com/biogo/store/llrb
+github.com/cenkalti/backoff
 github.com/cockroachdb/c-lz4
 github.com/cockroachdb/c-protobuf
 github.com/cockroachdb/c-rocksdb
@@ -40,11 +41,14 @@ github.com/coreos/etcd/Godeps/_workspace/src/github.com/gogo/protobuf/proto
 github.com/coreos/etcd/Godeps/_workspace/src/golang.org/x/net/context
 github.com/coreos/etcd/raft
 github.com/coreos/etcd/raft/raftpb
+github.com/docker/docker/pkg/units
 github.com/elazarl/go-bindata-assetfs
 github.com/gogo/protobuf/proto
 github.com/google/btree
 github.com/inconshreveable/mousetrap
 github.com/julienschmidt/httprouter
+github.com/montanaflynn/stats
+github.com/samalba/dockerclient
 github.com/spf13/cobra
 github.com/spf13/pflag
 golang.org/x/net/context

--- a/client/http_sender_test.go
+++ b/client/http_sender_test.go
@@ -108,7 +108,7 @@ func TestHTTPSenderSend(t *testing.T) {
 // on some HTTP response codes but not on others.
 func TestHTTPSenderRetryResponseCodes(t *testing.T) {
 	retryOptions := defaultRetryOptions
-	retryOptions.Backoff = 1 * time.Millisecond
+	retryOptions.BackOff.InitialInterval = 1 * time.Millisecond
 
 	testCases := []struct {
 		code  int
@@ -175,7 +175,7 @@ func TestHTTPSenderRetryResponseCodes(t *testing.T) {
 // on all errors sending HTTP requests.
 func TestHTTPSenderRetryHTTPSendError(t *testing.T) {
 	retryOptions := defaultRetryOptions
-	retryOptions.Backoff = 1 * time.Millisecond
+	retryOptions.BackOff.InitialInterval = 1 * time.Millisecond
 
 	testCases := []func(*httptest.Server, http.ResponseWriter){
 		// Send back an unparseable response but a success code on first try.

--- a/client/sender.go
+++ b/client/sender.go
@@ -26,6 +26,7 @@ import (
 
 	"golang.org/x/net/context"
 
+	"github.com/cenkalti/backoff"
 	"github.com/cockroachdb/cockroach/base"
 	"github.com/cockroachdb/cockroach/util/retry"
 )
@@ -33,11 +34,13 @@ import (
 // defaultRetryOptions sets the retry options for handling retryable errors and
 // connection I/O errors.
 var defaultRetryOptions = retry.Options{
-	Backoff:     50 * time.Millisecond,
-	MaxBackoff:  5 * time.Second,
-	Constant:    2,
-	MaxAttempts: 0, // retry indefinitely
-	UseV1Info:   true,
+	BackOff: backoff.ExponentialBackOff{
+		Clock:           backoff.SystemClock,
+		InitialInterval: 50 * time.Millisecond,
+		MaxInterval:     5 * time.Second,
+		Multiplier:      2,
+	},
+	UseV1Info: true,
 }
 
 // Sender is an interface for sending a request to a Key-Value

--- a/client/txn.go
+++ b/client/txn.go
@@ -23,6 +23,7 @@ import (
 	"runtime"
 	"time"
 
+	"github.com/cenkalti/backoff"
 	"github.com/cockroachdb/cockroach/proto"
 	"github.com/cockroachdb/cockroach/util/log"
 	"github.com/cockroachdb/cockroach/util/retry"
@@ -35,11 +36,13 @@ var (
 	// for transactions.
 	// This is exported for testing purposes only.
 	DefaultTxnRetryOptions = retry.Options{
-		Backoff:     50 * time.Millisecond,
-		MaxBackoff:  5 * time.Second,
-		Constant:    2,
-		MaxAttempts: 0, // retry indefinitely
-		UseV1Info:   true,
+		BackOff: backoff.ExponentialBackOff{
+			Clock:           backoff.SystemClock,
+			InitialInterval: 50 * time.Millisecond,
+			MaxInterval:     5 * time.Second,
+			Multiplier:      2,
+		},
+		UseV1Info: true,
 	}
 )
 
@@ -268,7 +271,7 @@ func (txn *Txn) exec(retryable func(txn *Txn) error) error {
 	// error condition this loop isn't capable of handling.
 	retryOpts := txn.db.txnRetryOptions
 	retryOpts.Tag = txn.txn.Name
-	err := retry.WithBackoff(retryOpts, func() (retry.Status, error) {
+	err := retry.WithBackoff(retryOpts, func(r *retry.Retry) error {
 		txn.haveTxnWrite, txn.haveEndTxn = false, false // always reset before [re]starting txn
 		err := retryable(txn)
 		if err == nil {
@@ -282,15 +285,19 @@ func (txn *Txn) exec(retryable func(txn *Txn) error) error {
 				err = txn.send(Call{Args: etArgs, Reply: etReply})
 			}
 		}
+		if err == nil {
+			return nil
+		}
 		if restartErr, ok := err.(proto.TransactionRestartError); ok {
 			if restartErr.CanRestartTransaction() == proto.TransactionRestart_IMMEDIATE {
-				return retry.Reset, err
+				r.Reset()
+				return err
 			} else if restartErr.CanRestartTransaction() == proto.TransactionRestart_BACKOFF {
-				return retry.Continue, err
+				return err
 			}
-			// By default, fall through and return Break.
 		}
-		return retry.Break, err
+		r.Stop()
+		return err
 	})
 	if err != nil && txn.haveTxnWrite {
 		if replyErr := txn.send(Call{

--- a/client/txn_test.go
+++ b/client/txn_test.go
@@ -263,7 +263,7 @@ func TestRunTransactionRetryOnErrors(t *testing.T) {
 				}
 			}
 		}))
-		db.txnRetryOptions.Backoff = 1 * time.Millisecond
+		db.txnRetryOptions.BackOff.InitialInterval = 1 * time.Millisecond
 		err := db.Txn(func(txn *Txn) error {
 			return txn.Put("a", "b")
 		})

--- a/kv/range_cache_test.go
+++ b/kv/range_cache_test.go
@@ -56,7 +56,7 @@ func (db *testDescriptorDB) getDescriptor(key proto.Key) []proto.RangeDescriptor
 			break
 		}
 		response = append(response, *(v.(testDescriptorNode).RangeDescriptor))
-		// Break to keep from skidding off the end of the available ranges.
+		// break to keep from skidding off the end of the available ranges.
 		if response[i].EndKey.Equal(proto.KeyMax) {
 			break
 		}

--- a/kv/split_test.go
+++ b/kv/split_test.go
@@ -24,6 +24,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/cenkalti/backoff"
 	"github.com/cockroachdb/cockroach/client"
 	"github.com/cockroachdb/cockroach/keys"
 	"github.com/cockroachdb/cockroach/proto"
@@ -36,9 +37,12 @@ import (
 // setTestRetryOptions sets client retry options for speedier testing.
 func setTestRetryOptions() {
 	client.DefaultTxnRetryOptions = retry.Options{
-		Backoff:    1 * time.Millisecond,
-		MaxBackoff: 10 * time.Millisecond,
-		Constant:   2,
+		BackOff: backoff.ExponentialBackOff{
+			Clock:           backoff.SystemClock,
+			InitialInterval: 1 * time.Millisecond,
+			MaxInterval:     10 * time.Millisecond,
+			Multiplier:      2,
+		},
 	}
 }
 

--- a/kv/txn_correctness_test.go
+++ b/kv/txn_correctness_test.go
@@ -28,6 +28,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/cenkalti/backoff"
 	"github.com/cockroachdb/cockroach/client"
 	"github.com/cockroachdb/cockroach/proto"
 	"github.com/cockroachdb/cockroach/storage"
@@ -42,9 +43,12 @@ import (
 // return retry error.
 func setCorrectnessRetryOptions(lSender *retryableLocalSender) {
 	client.DefaultTxnRetryOptions = retry.Options{
-		Backoff:     1 * time.Millisecond,
-		MaxBackoff:  5 * time.Millisecond,
-		Constant:    2,
+		BackOff: backoff.ExponentialBackOff{
+			Clock:           backoff.SystemClock,
+			InitialInterval: 1 * time.Millisecond,
+			MaxInterval:     5 * time.Millisecond,
+			Multiplier:      2,
+		},
 		MaxAttempts: 3,
 		UseV1Info:   true,
 	}

--- a/kv/txn_test.go
+++ b/kv/txn_test.go
@@ -213,12 +213,12 @@ func TestTxnDBUncertainty(t *testing.T) {
 	// Make sure that we notice immediately if any kind of backing off is
 	// happening. Restore the previous options after this test is done to avoid
 	// interfering with other tests.
-	defaultRetryOptions := client.DefaultTxnRetryOptions
+	defaultRetryOptions := client.DefaultTxnRetryOptions.BackOff
 	defer func() {
-		client.DefaultTxnRetryOptions = defaultRetryOptions
+		client.DefaultTxnRetryOptions.BackOff = defaultRetryOptions
 	}()
-	client.DefaultTxnRetryOptions.Backoff = 100 * time.Second
-	client.DefaultTxnRetryOptions.MaxBackoff = 100 * time.Second
+	client.DefaultTxnRetryOptions.BackOff.InitialInterval = 100 * time.Second
+	client.DefaultTxnRetryOptions.BackOff.MaxInterval = 100 * time.Second
 
 	// < 5ns means no uncertainty & no restarts.
 	verifyUncertainty(1, 3*time.Nanosecond, t)

--- a/server/node_test.go
+++ b/server/node_test.go
@@ -500,10 +500,10 @@ func (ts testSender) Send(ctx context.Context, c client.Call) {
 }
 
 func setAllocRetryBackoff(backoff time.Duration) func() {
-	savedBackoff := allocRetryOptions.Backoff
-	allocRetryOptions.Backoff = backoff
+	savedBackoff := allocRetryOptions.BackOff.InitialInterval
+	allocRetryOptions.BackOff.InitialInterval = backoff
 	return func() {
-		allocRetryOptions.Backoff = savedBackoff
+		allocRetryOptions.BackOff.InitialInterval = savedBackoff
 	}
 }
 

--- a/storage/store.go
+++ b/storage/store.go
@@ -24,6 +24,7 @@ import (
 	"sync/atomic"
 	"time"
 
+	"github.com/cenkalti/backoff"
 	"github.com/cockroachdb/cockroach/client"
 	"github.com/cockroachdb/cockroach/gossip"
 	"github.com/cockroachdb/cockroach/keys"
@@ -61,11 +62,13 @@ var (
 	// defaultRangeRetryOptions are default retry options for retrying commands
 	// sent to the store's ranges, for WriteTooOld and WriteIntent errors.
 	defaultRangeRetryOptions = retry.Options{
-		Backoff:     50 * time.Millisecond,
-		MaxBackoff:  5 * time.Second,
-		Constant:    2,
-		MaxAttempts: 0, // retry indefinitely
-		UseV1Info:   true,
+		BackOff: backoff.ExponentialBackOff{
+			Clock:           backoff.SystemClock,
+			InitialInterval: 50 * time.Millisecond,
+			MaxInterval:     5 * time.Second,
+			Multiplier:      2,
+		},
+		UseV1Info: true,
 	}
 
 	// TestStoreContext has some fields initialized with values relevant
@@ -1220,7 +1223,7 @@ func (s *Store) ExecuteCmd(ctx context.Context, call client.Call) error {
 	// Backoff and retry loop for handling errors.
 	retryOpts := *s.ctx.RangeRetryOptions
 	retryOpts.Tag = fmt.Sprintf("store: %s", args.Method())
-	err := retry.WithBackoff(retryOpts, func() (retry.Status, error) {
+	err := retry.WithBackoff(retryOpts, func(r *retry.Retry) error {
 		// Add the command to the range for execution; exit retry loop on success.
 		reply.Reset()
 
@@ -1228,11 +1231,12 @@ func (s *Store) ExecuteCmd(ctx context.Context, call client.Call) error {
 		rng, err := s.GetRange(header.RaftID)
 		if err != nil {
 			reply.Header().SetGoError(err)
-			return retry.Break, err
+			r.Stop()
+			return err
 		}
 
 		if err = rng.AddCmd(ctx, client.Call{Args: args, Reply: reply}, true); err == nil {
-			return retry.Break, err
+			return nil
 		}
 
 		// Maybe resolve a potential write intent error. We do this here
@@ -1249,7 +1253,7 @@ func (s *Store) ExecuteCmd(ctx context.Context, call client.Call) error {
 					s.stopper.FinishTask()
 				}()
 				reply.Header().Error = nil
-				return retry.Break, nil
+				return nil
 			}
 			pushType := proto.PUSH_TIMESTAMP
 			if proto.IsWrite(args) {
@@ -1264,12 +1268,14 @@ func (s *Store) ExecuteCmd(ctx context.Context, call client.Call) error {
 			// Update request timestamp and retry immediately.
 			header.Timestamp = t.ExistingTimestamp
 			header.Timestamp.Logical++
-			return retry.Reset, err
+			r.Reset()
+			return err
 		case *proto.WriteIntentError:
 			// If write intent error is resolved, exit retry/backoff loop to
 			// immediately retry.
 			if t.Resolved {
-				return retry.Reset, err
+				r.Reset()
+				return err
 			}
 
 			// Otherwise, update timestamp on read/write and backoff / retry.
@@ -1278,9 +1284,10 @@ func (s *Store) ExecuteCmd(ctx context.Context, call client.Call) error {
 					header.Timestamp = intent.Txn.Timestamp.Next()
 				}
 			}
-			return retry.Continue, err
+			return err
 		}
-		return retry.Break, err
+		r.Stop()
+		return err
 	})
 
 	// By default, retries are indefinite. However, some unittests set a

--- a/storage/store_test.go
+++ b/storage/store_test.go
@@ -29,6 +29,7 @@ import (
 
 	"golang.org/x/net/context"
 
+	"github.com/cenkalti/backoff"
 	"github.com/cockroachdb/cockroach/client"
 	"github.com/cockroachdb/cockroach/gossip"
 	"github.com/cockroachdb/cockroach/keys"
@@ -58,9 +59,12 @@ var testBaseContext = testutils.NewTestBaseContext()
 // loops.
 func setTestRetryOptions(s *Store) {
 	s.SetRangeRetryOptions(retry.Options{
-		Backoff:     1 * time.Millisecond,
-		MaxBackoff:  2 * time.Millisecond,
-		Constant:    2,
+		BackOff: backoff.ExponentialBackOff{
+			Clock:           backoff.SystemClock,
+			InitialInterval: 1 * time.Millisecond,
+			MaxInterval:     2 * time.Millisecond,
+			Multiplier:      2,
+		},
 		MaxAttempts: 2,
 	})
 }


### PR DESCRIPTION
Uses github.com/cenkalti/backoff.

Presented as an alternative to #1363. @petermattis I opted not to do the full rewrite yet because of the logging currently provided by `retry.WithBackoff`.
