### PR TITLE
Increase the wait time to address flakiness of TestStoreRangeManySplits

### DIFF
--- a/storage/client_split_test.go
+++ b/storage/client_split_test.go
@@ -579,7 +579,7 @@ func TestStoreRangeManySplits(t *testing.T) {
 			keys = append(keys, r.Key)
 		}
 		return reflect.DeepEqual(keys, expKeys)
-	}, 1*time.Second); err != nil {
+	}, 5*time.Second); err != nil {
 		t.Errorf("expected splits not found: %s", err)
 	}
 }


### PR DESCRIPTION
This test was added to reproduce a deadlock issue with the split queue, and I think it's less useful now.

Fix #1369 and #1375.
