### PR TITLE
EnsureHost for all command, so --addr=":8080" format can be used for all command

### DIFF
--- a/server/cli/cli.go
+++ b/server/cli/cli.go
@@ -52,6 +52,9 @@ Output build version information.
 
 var cockroachCmd = &cobra.Command{
 	Use: "cockroach",
+	PersistentPreRun: func(cmd *cobra.Command, args []string) {
+		Context.Addr = util.EnsureHost(Context.Addr)
+	},
 }
 
 func init() {

--- a/server/cli/kv.go
+++ b/server/cli/kv.go
@@ -29,7 +29,6 @@ import (
 	"github.com/cockroachdb/cockroach/client"
 	"github.com/cockroachdb/cockroach/keys"
 	"github.com/cockroachdb/cockroach/proto"
-	"github.com/cockroachdb/cockroach/util"
 
 	"github.com/spf13/cobra"
 )
@@ -41,7 +40,7 @@ func makeDBClient() *client.DB {
 	// TODO(pmattis): Initialize the user to something more
 	// reasonable. Perhaps Context.Addr should be considered a URL.
 	db, err := client.Open(Context.RequestScheme() +
-		"://root@" + util.EnsureHost(Context.Addr) +
+		"://root@" + Context.Addr +
 		"?certs=" + Context.Certs)
 	if err != nil {
 		fmt.Fprintf(osStderr, "failed to initialize KV client: %s", err)

--- a/server/context.go
+++ b/server/context.go
@@ -216,7 +216,7 @@ func (ctx *Context) parseGossipBootstrapResolvers() ([]resolver.Resolver, error)
 		// the port for single-node clusters twice (once in --addr,
 		// once in --gossip).
 		if strings.HasPrefix(address, "self=") {
-			address = util.EnsureHost(ctx.Addr)
+			address = ctx.Addr
 		}
 		resolver, err := resolver.NewResolver(&ctx.Context, address)
 		if err != nil {


### PR DESCRIPTION
Currently, ./cockroach quit --addr=":8080" is not work, so make change to make it work and make all command look like consistent.
