### PR TITLE
Remove proto.Value.Integer.

### DIFF
--- a/client/batch.go
+++ b/client/batch.go
@@ -115,9 +115,10 @@ func (b *Batch) fillResults() error {
 				row := &result.Rows[k]
 				row.Key = []byte(call.Args.(*proto.IncrementRequest).Key)
 				if result.Err == nil {
-					// TODO(pmattis): Should IncrementResponse contain a
-					// proto.Value so that the timestamp can be returned?
+					// TODO(pmattis): This is odd. KeyValue.Value is otherwise always a
+					// []byte except for setting it to a *int64 here.
 					row.Value = &t.NewValue
+					row.setTimestamp(t.Timestamp)
 				}
 			case *proto.ScanResponse:
 				result.Rows = make([]KeyValue, len(t.Rows))

--- a/client/call.go
+++ b/client/call.go
@@ -70,9 +70,6 @@ func GetProto(key proto.Key, msg gogoproto.Message) Call {
 		if reply.Value == nil {
 			return util.Errorf("%s: no value present", key)
 		}
-		if reply.Value.Integer != nil {
-			return util.Errorf("%s: unexpected integer value: %+v", key, reply.Value)
-		}
 		return gogoproto.Unmarshal(reply.Value.Bytes, msg)
 	}
 	return c

--- a/proto/api.pb.go
+++ b/proto/api.pb.go
@@ -328,8 +328,8 @@ func (m *GetResponse) GetValue() *Value {
 }
 
 // A PutRequest is arguments to the Put() method. Note that to write
-// an empty value, the value parameter is still specified, but both
-// Bytes and Integer are set to nil.
+// an empty value, the value parameter is still specified, but Bytes
+// is set to nil.
 type PutRequest struct {
 	RequestHeader    `protobuf:"bytes,1,opt,name=header,embedded=header" json:"header"`
 	Value            Value  `protobuf:"bytes,2,opt,name=value" json:"value"`

--- a/proto/api.proto
+++ b/proto/api.proto
@@ -148,8 +148,8 @@ message GetResponse {
 }
 
 // A PutRequest is arguments to the Put() method. Note that to write
-// an empty value, the value parameter is still specified, but both
-// Bytes and Integer are set to nil.
+// an empty value, the value parameter is still specified, but Bytes
+// is set to nil.
 message PutRequest {
   optional RequestHeader header = 1 [(gogoproto.nullable) = false, (gogoproto.embed) = true];
   optional Value value = 2 [(gogoproto.nullable) = false];

--- a/proto/data.go
+++ b/proto/data.go
@@ -321,11 +321,22 @@ func (v *Value) Verify(key []byte) error {
 				cksum, Key(key), v)
 		}
 	}
-	if v.Bytes != nil && v.Integer != nil {
-		return util.Errorf("both the value byte slice and integer fields are set for key %s: [% x]",
-			Key(key), v)
-	}
 	return nil
+}
+
+// SetInteger encodes the specified int64 value into the bytes field of the
+// receiver.
+func (v *Value) SetInteger(i int64) {
+	v.Bytes = encoding.EncodeUint64(nil, uint64(i))
+}
+
+// GetInteger decodes an int64 value from the bytes field of the receiver.
+func (v *Value) GetInteger() int64 {
+	if v == nil || v.Bytes == nil {
+		return 0
+	}
+	_, u := encoding.DecodeUint64(v.Bytes)
+	return int64(u)
 }
 
 // computeChecksum computes a checksum based on the provided key and
@@ -336,8 +347,6 @@ func (v *Value) computeChecksum(key []byte) uint32 {
 	c := encoding.NewCRC32Checksum(key)
 	if v.Bytes != nil {
 		c.Write(v.Bytes)
-	} else if v.Integer != nil {
-		c.Write(encoding.EncodeUint64(nil, uint64(v.GetInteger())))
 	}
 	sum := c.Sum32()
 	encoding.ReleaseCRC32Checksum(c)

--- a/proto/data.pb.go
+++ b/proto/data.pb.go
@@ -174,9 +174,6 @@ func (m *Timestamp) GetLogical() int32 {
 type Value struct {
 	// Bytes is the byte slice value.
 	Bytes []byte `protobuf:"bytes,1,opt,name=bytes" json:"bytes,omitempty"`
-	// Integer is an integer value type. Only Integer values may exist at a key
-	// when making the Increment API call.
-	Integer *int64 `protobuf:"varint,2,opt,name=integer" json:"integer,omitempty"`
 	// Checksum is a CRC-32-IEEE checksum of the key + value, in that order.
 	// If this is an integer value, then the value is interpreted as an 8
 	// byte, big-endian encoded value. This value is set by the client on
@@ -202,13 +199,6 @@ func (m *Value) GetBytes() []byte {
 		return m.Bytes
 	}
 	return nil
-}
-
-func (m *Value) GetInteger() int64 {
-	if m != nil && m.Integer != nil {
-		return *m.Integer
-	}
-	return 0
 }
 
 func (m *Value) GetChecksum() uint32 {
@@ -959,23 +949,6 @@ func (m *Value) Unmarshal(data []byte) error {
 			}
 			m.Bytes = append([]byte{}, data[index:postIndex]...)
 			index = postIndex
-		case 2:
-			if wireType != 0 {
-				return fmt.Errorf("proto: wrong wireType = %d for field Integer", wireType)
-			}
-			var v int64
-			for shift := uint(0); ; shift += 7 {
-				if index >= l {
-					return io.ErrUnexpectedEOF
-				}
-				b := data[index]
-				index++
-				v |= (int64(b) & 0x7F) << shift
-				if b < 0x80 {
-					break
-				}
-			}
-			m.Integer = &v
 		case 3:
 			if wireType != 5 {
 				return fmt.Errorf("proto: wrong wireType = %d for field Checksum", wireType)
@@ -2845,9 +2818,6 @@ func (m *Value) Size() (n int) {
 		l = len(m.Bytes)
 		n += 1 + l + sovData(uint64(l))
 	}
-	if m.Integer != nil {
-		n += 1 + sovData(uint64(*m.Integer))
-	}
 	if m.Checksum != nil {
 		n += 5
 	}
@@ -3176,11 +3146,6 @@ func (m *Value) MarshalTo(data []byte) (n int, err error) {
 		i++
 		i = encodeVarintData(data, i, uint64(len(m.Bytes)))
 		i += copy(data[i:], m.Bytes)
-	}
-	if m.Integer != nil {
-		data[i] = 0x10
-		i++
-		i = encodeVarintData(data, i, uint64(*m.Integer))
 	}
 	if m.Checksum != nil {
 		data[i] = 0x1d

--- a/proto/data.proto
+++ b/proto/data.proto
@@ -46,13 +46,8 @@ message Timestamp {
 // basic types: a "bag o' bytes" generic byte slice and an incrementable
 // int64, for use with the Increment API call.
 message Value {
-  oneof value {
-    // Bytes is the byte slice value.
-    bytes bytes = 1;
-    // Integer is an integer value type. Only Integer values may exist at a key
-    // when making the Increment API call.
-    int64 integer = 2;
-  }
+  // Bytes is the byte slice value.
+  optional bytes bytes = 1;
   // Checksum is a CRC-32-IEEE checksum of the key + value, in that order.
   // If this is an integer value, then the value is interpreted as an 8
   // byte, big-endian encoded value. This value is set by the client on

--- a/server/cli/cli_test.go
+++ b/server/cli/cli_test.go
@@ -89,7 +89,7 @@ func ExampleBasic() {
 	// kv get a
 	// "a" not found
 	// kv get b
-	// 2
+	// "2"
 	// kv inc c 1
 	// 1
 	// kv inc c 10
@@ -98,7 +98,7 @@ func ExampleBasic() {
 	// 111
 	// kv scan
 	// "b"	"2"
-	// "c"	111
+	// "c"	"\x00\x00\x00\x00\x00\x00\x00o"
 	// kv inc c b
 	// invalid increment: b: strconv.ParseInt: parsing "b": invalid syntax
 	// quit
@@ -130,12 +130,12 @@ func ExampleQuoted() {
 	// "a\x02"	"日本語"
 	// "a\x03"	"日本語"
 	// kv get a\x00
-	// 日本語
+	// "日本語"
 	// kv del a\x00
 	// kv inc 1\x01
 	// 1
 	// kv get 1\x01
-	// 1
+	// "\x00\x00\x00\x00\x00\x00\x00\x01"
 	// quit
 	// node drained and shutdown: ok
 }

--- a/server/cli/kv.go
+++ b/server/cli/kv.go
@@ -96,11 +96,7 @@ func runGet(cmd *cobra.Command, args []string) {
 		osExit(1)
 		return
 	}
-	if i, ok := r.Value.(*int64); ok {
-		fmt.Printf("%d\n", *i)
-	} else {
-		fmt.Printf("%s\n", r.Value)
-	}
+	fmt.Printf("%q\n", r.Value)
 }
 
 // A putCmd command sets the value for one or more keys.
@@ -274,11 +270,7 @@ func runScan(cmd *cobra.Command, args []string) {
 		}
 
 		key := proto.Key(row.Key)
-		if i, ok := row.Value.(*int64); ok {
-			fmt.Printf("%s\t%d\n", key, *i)
-		} else {
-			fmt.Printf("%s\t%q\n", key, row.Value)
-		}
+		fmt.Printf("%s\t%q\n", key, row.Value)
 	}
 }
 

--- a/storage/client_raft_test.go
+++ b/storage/client_raft_test.go
@@ -240,8 +240,8 @@ func TestReplicateRange(t *testing.T) {
 		if err := mtc.stores[1].ExecuteCmd(context.Background(), client.Call{Args: getArgs, Reply: getResp}); err != nil {
 			return util.Errorf("failed to read data")
 		}
-		if getResp.Value.GetInteger() != 5 {
-			return util.Errorf("failed to read correct data: %d", getResp.Value.GetInteger())
+		if v := getResp.Value.GetInteger(); v != 5 {
+			return util.Errorf("failed to read correct data: %d", v)
 		}
 		return nil
 	})

--- a/storage/client_range_test.go
+++ b/storage/client_range_test.go
@@ -147,7 +147,7 @@ func TestRejectFutureCommand(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if val.GetInteger() != 15 {
-		t.Errorf("expected 15, got %v", val.GetInteger())
+	if v := val.GetInteger(); v != 15 {
+		t.Errorf("expected 15, got %v", v)
 	}
 }

--- a/storage/engine/cockroach/proto/data.pb.cc
+++ b/storage/engine/cockroach/proto/data.pb.cc
@@ -27,10 +27,6 @@ const ::google::protobuf::internal::GeneratedMessageReflection*
 const ::google::protobuf::Descriptor* Value_descriptor_ = NULL;
 const ::google::protobuf::internal::GeneratedMessageReflection*
   Value_reflection_ = NULL;
-struct ValueOneofInstance {
-  ::google::protobuf::internal::ArenaStringPtr bytes_;
-  ::google::protobuf::int64 integer_;
-}* Value_default_oneof_instance_ = NULL;
 const ::google::protobuf::Descriptor* MVCCValue_descriptor_ = NULL;
 const ::google::protobuf::internal::GeneratedMessageReflection*
   MVCCValue_reflection_ = NULL;
@@ -103,13 +99,11 @@ void protobuf_AssignDesc_cockroach_2fproto_2fdata_2eproto() {
       GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(Timestamp, _internal_metadata_),
       -1);
   Value_descriptor_ = file->message_type(1);
-  static const int Value_offsets_[6] = {
-    PROTO2_GENERATED_DEFAULT_ONEOF_FIELD_OFFSET(Value_default_oneof_instance_, bytes_),
-    PROTO2_GENERATED_DEFAULT_ONEOF_FIELD_OFFSET(Value_default_oneof_instance_, integer_),
+  static const int Value_offsets_[4] = {
+    GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(Value, bytes_),
     GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(Value, checksum_),
     GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(Value, timestamp_),
     GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(Value, tag_),
-    GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(Value, value_),
   };
   Value_reflection_ =
     ::google::protobuf::internal::GeneratedMessageReflection::NewGeneratedMessageReflection(
@@ -119,8 +113,6 @@ void protobuf_AssignDesc_cockroach_2fproto_2fdata_2eproto() {
       GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(Value, _has_bits_[0]),
       -1,
       -1,
-      Value_default_oneof_instance_,
-      GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(Value, _oneof_case_[0]),
       sizeof(Value),
       GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(Value, _internal_metadata_),
       -1);
@@ -433,7 +425,6 @@ void protobuf_ShutdownFile_cockroach_2fproto_2fdata_2eproto() {
   delete Timestamp::default_instance_;
   delete Timestamp_reflection_;
   delete Value::default_instance_;
-  delete Value_default_oneof_instance_;
   delete Value_reflection_;
   delete MVCCValue::default_instance_;
   delete MVCCValue_reflection_;
@@ -478,83 +469,81 @@ void protobuf_AddDesc_cockroach_2fproto_2fdata_2eproto() {
     "proto\032\034cockroach/proto/config.proto\032\024gog"
     "oproto/gogo.proto\"A\n\tTimestamp\022\027\n\twall_t"
     "ime\030\001 \001(\003B\004\310\336\037\000\022\025\n\007logical\030\002 \001(\005B\004\310\336\037\000:\004"
-    "\230\240\037\000\"\202\001\n\005Value\022\017\n\005bytes\030\001 \001(\014H\000\022\021\n\007integ"
-    "er\030\002 \001(\003H\000\022\020\n\010checksum\030\003 \001(\007\022-\n\ttimestam"
-    "p\030\004 \001(\0132\032.cockroach.proto.Timestamp\022\013\n\003t"
-    "ag\030\005 \001(\tB\007\n\005value\"I\n\tMVCCValue\022\025\n\007delete"
-    "d\030\001 \001(\010B\004\310\336\037\000\022%\n\005value\030\002 \001(\0132\026.cockroach"
-    ".proto.Value\"M\n\010KeyValue\022\024\n\003key\030\001 \001(\014B\007\372"
-    "\336\037\003Key\022+\n\005value\030\002 \001(\0132\026.cockroach.proto."
-    "ValueB\004\310\336\037\000\"9\n\013RawKeyValue\022\033\n\003key\030\001 \001(\014B"
-    "\016\372\336\037\nEncodedKey\022\r\n\005value\030\002 \001(\014\"\214\001\n\nStore"
-    "Ident\022%\n\ncluster_id\030\001 \001(\tB\021\310\336\037\000\342\336\037\tClust"
-    "erID\022)\n\007node_id\030\002 \001(\005B\030\310\336\037\000\342\336\037\006NodeID\372\336\037"
-    "\006NodeID\022,\n\010store_id\030\003 \001(\005B\032\310\336\037\000\342\336\037\007Store"
-    "ID\372\336\037\007StoreID\"\206\001\n\014SplitTrigger\022<\n\014update"
-    "d_desc\030\001 \001(\0132 .cockroach.proto.RangeDesc"
-    "riptorB\004\310\336\037\000\0228\n\010new_desc\030\002 \001(\0132 .cockroa"
-    "ch.proto.RangeDescriptorB\004\310\336\037\000\"\210\001\n\014Merge"
-    "Trigger\022<\n\014updated_desc\030\001 \001(\0132 .cockroac"
-    "h.proto.RangeDescriptorB\004\310\336\037\000\022:\n\020subsume"
-    "d_raft_id\030\002 \001(\003B \310\336\037\000\342\336\037\016SubsumedRaftID\372"
-    "\336\037\006RaftID\"\351\001\n\025ChangeReplicasTrigger\022)\n\007n"
-    "ode_id\030\001 \001(\005B\030\310\336\037\000\342\336\037\006NodeID\372\336\037\006NodeID\022,"
-    "\n\010store_id\030\002 \001(\005B\032\310\336\037\000\342\336\037\007StoreID\372\336\037\007Sto"
-    "reID\022=\n\013change_type\030\003 \001(\0162\".cockroach.pr"
-    "oto.ReplicaChangeTypeB\004\310\336\037\000\0228\n\020updated_r"
-    "eplicas\030\004 \003(\0132\030.cockroach.proto.ReplicaB"
-    "\004\310\336\037\000\"\346\001\n\025InternalCommitTrigger\0224\n\rsplit"
-    "_trigger\030\001 \001(\0132\035.cockroach.proto.SplitTr"
-    "igger\0224\n\rmerge_trigger\030\002 \001(\0132\035.cockroach"
-    ".proto.MergeTrigger\022G\n\027change_replicas_t"
-    "rigger\030\003 \001(\0132&.cockroach.proto.ChangeRep"
-    "licasTrigger\022\030\n\007intents\030\004 \003(\014B\007\372\336\037\003Key\"\035"
-    "\n\010NodeList\022\021\n\005nodes\030\001 \003(\005B\002\020\001\"\205\004\n\013Transa"
-    "ction\022\022\n\004name\030\001 \001(\tB\004\310\336\037\000\022\024\n\003key\030\002 \001(\014B\007"
-    "\372\336\037\003Key\022\022\n\002id\030\003 \001(\014B\006\342\336\037\002ID\022\026\n\010priority\030"
-    "\004 \001(\005B\004\310\336\037\000\0227\n\tisolation\030\005 \001(\0162\036.cockroa"
-    "ch.proto.IsolationTypeB\004\310\336\037\000\0228\n\006status\030\006"
-    " \001(\0162\".cockroach.proto.TransactionStatus"
-    "B\004\310\336\037\000\022\023\n\005epoch\030\007 \001(\005B\004\310\336\037\000\0222\n\016last_hear"
-    "tbeat\030\010 \001(\0132\032.cockroach.proto.Timestamp\022"
-    "3\n\ttimestamp\030\t \001(\0132\032.cockroach.proto.Tim"
-    "estampB\004\310\336\037\000\0228\n\016orig_timestamp\030\n \001(\0132\032.c"
-    "ockroach.proto.TimestampB\004\310\336\037\000\0227\n\rmax_ti"
-    "mestamp\030\013 \001(\0132\032.cockroach.proto.Timestam"
-    "pB\004\310\336\037\000\0226\n\rcertain_nodes\030\014 \001(\0132\031.cockroa"
-    "ch.proto.NodeListB\004\310\336\037\000:\004\230\240\037\000\"\254\001\n\005Lease\022"
-    "/\n\005start\030\001 \001(\0132\032.cockroach.proto.Timesta"
-    "mpB\004\310\336\037\000\0224\n\nexpiration\030\002 \001(\0132\032.cockroach"
-    ".proto.TimestampB\004\310\336\037\000\0226\n\014raft_node_id\030\003"
-    " \001(\004B \310\336\037\000\342\336\037\nRaftNodeID\372\336\037\nRaftNodeID:\004"
-    "\230\240\037\000\"\336\001\n\014MVCCMetadata\022)\n\003txn\030\001 \001(\0132\034.coc"
-    "kroach.proto.Transaction\0223\n\ttimestamp\030\002 "
-    "\001(\0132\032.cockroach.proto.TimestampB\004\310\336\037\000\022\025\n"
-    "\007deleted\030\003 \001(\010B\004\310\336\037\000\022\027\n\tkey_bytes\030\004 \001(\003B"
-    "\004\310\336\037\000\022\027\n\tval_bytes\030\005 \001(\003B\004\310\336\037\000\022%\n\005value\030"
-    "\006 \001(\0132\026.cockroach.proto.Value\"H\n\nGCMetad"
-    "ata\022\035\n\017last_scan_nanos\030\001 \001(\003B\004\310\336\037\000\022\033\n\023ol"
-    "dest_intent_nanos\030\002 \001(\003\"\362\002\n\tMVCCStats\022\030\n"
-    "\nlive_bytes\030\001 \001(\003B\004\310\336\037\000\022\027\n\tkey_bytes\030\002 \001"
-    "(\003B\004\310\336\037\000\022\027\n\tval_bytes\030\003 \001(\003B\004\310\336\037\000\022\032\n\014int"
-    "ent_bytes\030\004 \001(\003B\004\310\336\037\000\022\030\n\nlive_count\030\005 \001("
-    "\003B\004\310\336\037\000\022\027\n\tkey_count\030\006 \001(\003B\004\310\336\037\000\022\027\n\tval_"
-    "count\030\007 \001(\003B\004\310\336\037\000\022\032\n\014intent_count\030\010 \001(\003B"
-    "\004\310\336\037\000\022\030\n\nintent_age\030\t \001(\003B\004\310\336\037\000\022(\n\014gc_by"
-    "tes_age\030\n \001(\003B\022\310\336\037\000\342\336\037\nGCBytesAge\022\027\n\tsys"
-    "_bytes\030\014 \001(\003B\004\310\336\037\000\022\027\n\tsys_count\030\r \001(\003B\004\310"
-    "\336\037\000\022\037\n\021last_update_nanos\030\036 \001(\003B\004\310\336\037\000*>\n\021"
-    "ReplicaChangeType\022\017\n\013ADD_REPLICA\020\000\022\022\n\016RE"
-    "MOVE_REPLICA\020\001\032\004\210\243\036\000*5\n\rIsolationType\022\020\n"
-    "\014SERIALIZABLE\020\000\022\014\n\010SNAPSHOT\020\001\032\004\210\243\036\000*B\n\021T"
-    "ransactionStatus\022\013\n\007PENDING\020\000\022\r\n\tCOMMITT"
-    "ED\020\001\022\013\n\007ABORTED\020\002\032\004\210\243\036\000B\023Z\005proto\340\342\036\001\310\342\036\001"
-    "\320\342\036\001", 3004);
+    "\230\240\037\000\"d\n\005Value\022\r\n\005bytes\030\001 \001(\014\022\020\n\010checksum"
+    "\030\003 \001(\007\022-\n\ttimestamp\030\004 \001(\0132\032.cockroach.pr"
+    "oto.Timestamp\022\013\n\003tag\030\005 \001(\t\"I\n\tMVCCValue\022"
+    "\025\n\007deleted\030\001 \001(\010B\004\310\336\037\000\022%\n\005value\030\002 \001(\0132\026."
+    "cockroach.proto.Value\"M\n\010KeyValue\022\024\n\003key"
+    "\030\001 \001(\014B\007\372\336\037\003Key\022+\n\005value\030\002 \001(\0132\026.cockroa"
+    "ch.proto.ValueB\004\310\336\037\000\"9\n\013RawKeyValue\022\033\n\003k"
+    "ey\030\001 \001(\014B\016\372\336\037\nEncodedKey\022\r\n\005value\030\002 \001(\014\""
+    "\214\001\n\nStoreIdent\022%\n\ncluster_id\030\001 \001(\tB\021\310\336\037\000"
+    "\342\336\037\tClusterID\022)\n\007node_id\030\002 \001(\005B\030\310\336\037\000\342\336\037\006"
+    "NodeID\372\336\037\006NodeID\022,\n\010store_id\030\003 \001(\005B\032\310\336\037\000"
+    "\342\336\037\007StoreID\372\336\037\007StoreID\"\206\001\n\014SplitTrigger\022"
+    "<\n\014updated_desc\030\001 \001(\0132 .cockroach.proto."
+    "RangeDescriptorB\004\310\336\037\000\0228\n\010new_desc\030\002 \001(\0132"
+    " .cockroach.proto.RangeDescriptorB\004\310\336\037\000\""
+    "\210\001\n\014MergeTrigger\022<\n\014updated_desc\030\001 \001(\0132 "
+    ".cockroach.proto.RangeDescriptorB\004\310\336\037\000\022:"
+    "\n\020subsumed_raft_id\030\002 \001(\003B \310\336\037\000\342\336\037\016Subsum"
+    "edRaftID\372\336\037\006RaftID\"\351\001\n\025ChangeReplicasTri"
+    "gger\022)\n\007node_id\030\001 \001(\005B\030\310\336\037\000\342\336\037\006NodeID\372\336\037"
+    "\006NodeID\022,\n\010store_id\030\002 \001(\005B\032\310\336\037\000\342\336\037\007Store"
+    "ID\372\336\037\007StoreID\022=\n\013change_type\030\003 \001(\0162\".coc"
+    "kroach.proto.ReplicaChangeTypeB\004\310\336\037\000\0228\n\020"
+    "updated_replicas\030\004 \003(\0132\030.cockroach.proto"
+    ".ReplicaB\004\310\336\037\000\"\346\001\n\025InternalCommitTrigger"
+    "\0224\n\rsplit_trigger\030\001 \001(\0132\035.cockroach.prot"
+    "o.SplitTrigger\0224\n\rmerge_trigger\030\002 \001(\0132\035."
+    "cockroach.proto.MergeTrigger\022G\n\027change_r"
+    "eplicas_trigger\030\003 \001(\0132&.cockroach.proto."
+    "ChangeReplicasTrigger\022\030\n\007intents\030\004 \003(\014B\007"
+    "\372\336\037\003Key\"\035\n\010NodeList\022\021\n\005nodes\030\001 \003(\005B\002\020\001\"\205"
+    "\004\n\013Transaction\022\022\n\004name\030\001 \001(\tB\004\310\336\037\000\022\024\n\003ke"
+    "y\030\002 \001(\014B\007\372\336\037\003Key\022\022\n\002id\030\003 \001(\014B\006\342\336\037\002ID\022\026\n\010"
+    "priority\030\004 \001(\005B\004\310\336\037\000\0227\n\tisolation\030\005 \001(\0162"
+    "\036.cockroach.proto.IsolationTypeB\004\310\336\037\000\0228\n"
+    "\006status\030\006 \001(\0162\".cockroach.proto.Transact"
+    "ionStatusB\004\310\336\037\000\022\023\n\005epoch\030\007 \001(\005B\004\310\336\037\000\0222\n\016"
+    "last_heartbeat\030\010 \001(\0132\032.cockroach.proto.T"
+    "imestamp\0223\n\ttimestamp\030\t \001(\0132\032.cockroach."
+    "proto.TimestampB\004\310\336\037\000\0228\n\016orig_timestamp\030"
+    "\n \001(\0132\032.cockroach.proto.TimestampB\004\310\336\037\000\022"
+    "7\n\rmax_timestamp\030\013 \001(\0132\032.cockroach.proto"
+    ".TimestampB\004\310\336\037\000\0226\n\rcertain_nodes\030\014 \001(\0132"
+    "\031.cockroach.proto.NodeListB\004\310\336\037\000:\004\230\240\037\000\"\254"
+    "\001\n\005Lease\022/\n\005start\030\001 \001(\0132\032.cockroach.prot"
+    "o.TimestampB\004\310\336\037\000\0224\n\nexpiration\030\002 \001(\0132\032."
+    "cockroach.proto.TimestampB\004\310\336\037\000\0226\n\014raft_"
+    "node_id\030\003 \001(\004B \310\336\037\000\342\336\037\nRaftNodeID\372\336\037\nRaf"
+    "tNodeID:\004\230\240\037\000\"\336\001\n\014MVCCMetadata\022)\n\003txn\030\001 "
+    "\001(\0132\034.cockroach.proto.Transaction\0223\n\ttim"
+    "estamp\030\002 \001(\0132\032.cockroach.proto.Timestamp"
+    "B\004\310\336\037\000\022\025\n\007deleted\030\003 \001(\010B\004\310\336\037\000\022\027\n\tkey_byt"
+    "es\030\004 \001(\003B\004\310\336\037\000\022\027\n\tval_bytes\030\005 \001(\003B\004\310\336\037\000\022"
+    "%\n\005value\030\006 \001(\0132\026.cockroach.proto.Value\"H"
+    "\n\nGCMetadata\022\035\n\017last_scan_nanos\030\001 \001(\003B\004\310"
+    "\336\037\000\022\033\n\023oldest_intent_nanos\030\002 \001(\003\"\362\002\n\tMVC"
+    "CStats\022\030\n\nlive_bytes\030\001 \001(\003B\004\310\336\037\000\022\027\n\tkey_"
+    "bytes\030\002 \001(\003B\004\310\336\037\000\022\027\n\tval_bytes\030\003 \001(\003B\004\310\336"
+    "\037\000\022\032\n\014intent_bytes\030\004 \001(\003B\004\310\336\037\000\022\030\n\nlive_c"
+    "ount\030\005 \001(\003B\004\310\336\037\000\022\027\n\tkey_count\030\006 \001(\003B\004\310\336\037"
+    "\000\022\027\n\tval_count\030\007 \001(\003B\004\310\336\037\000\022\032\n\014intent_cou"
+    "nt\030\010 \001(\003B\004\310\336\037\000\022\030\n\nintent_age\030\t \001(\003B\004\310\336\037\000"
+    "\022(\n\014gc_bytes_age\030\n \001(\003B\022\310\336\037\000\342\336\037\nGCBytesA"
+    "ge\022\027\n\tsys_bytes\030\014 \001(\003B\004\310\336\037\000\022\027\n\tsys_count"
+    "\030\r \001(\003B\004\310\336\037\000\022\037\n\021last_update_nanos\030\036 \001(\003B"
+    "\004\310\336\037\000*>\n\021ReplicaChangeType\022\017\n\013ADD_REPLIC"
+    "A\020\000\022\022\n\016REMOVE_REPLICA\020\001\032\004\210\243\036\000*5\n\rIsolati"
+    "onType\022\020\n\014SERIALIZABLE\020\000\022\014\n\010SNAPSHOT\020\001\032\004"
+    "\210\243\036\000*B\n\021TransactionStatus\022\013\n\007PENDING\020\000\022\r"
+    "\n\tCOMMITTED\020\001\022\013\n\007ABORTED\020\002\032\004\210\243\036\000B\023Z\005prot"
+    "o\340\342\036\001\310\342\036\001\320\342\036\001", 2973);
   ::google::protobuf::MessageFactory::InternalRegisterGeneratedFile(
     "cockroach/proto/data.proto", &protobuf_RegisterTypes);
   Timestamp::default_instance_ = new Timestamp();
   Value::default_instance_ = new Value();
-  Value_default_oneof_instance_ = new ValueOneofInstance();
   MVCCValue::default_instance_ = new MVCCValue();
   KeyValue::default_instance_ = new KeyValue();
   RawKeyValue::default_instance_ = new RawKeyValue();
@@ -987,7 +976,6 @@ void Timestamp::clear_logical() {
 
 #ifndef _MSC_VER
 const int Value::kBytesFieldNumber;
-const int Value::kIntegerFieldNumber;
 const int Value::kChecksumFieldNumber;
 const int Value::kTimestampFieldNumber;
 const int Value::kTagFieldNumber;
@@ -1000,8 +988,6 @@ Value::Value()
 }
 
 void Value::InitAsDefaultInstance() {
-  Value_default_oneof_instance_->bytes_.UnsafeSetDefault(&::google::protobuf::internal::GetEmptyStringAlreadyInited());
-  Value_default_oneof_instance_->integer_ = GOOGLE_LONGLONG(0);
   timestamp_ = const_cast< ::cockroach::proto::Timestamp*>(&::cockroach::proto::Timestamp::default_instance());
 }
 
@@ -1016,11 +1002,11 @@ Value::Value(const Value& from)
 void Value::SharedCtor() {
   ::google::protobuf::internal::GetEmptyString();
   _cached_size_ = 0;
+  bytes_.UnsafeSetDefault(&::google::protobuf::internal::GetEmptyStringAlreadyInited());
   checksum_ = 0u;
   timestamp_ = NULL;
   tag_.UnsafeSetDefault(&::google::protobuf::internal::GetEmptyStringAlreadyInited());
   ::memset(_has_bits_, 0, sizeof(_has_bits_));
-  clear_has_value();
 }
 
 Value::~Value() {
@@ -1029,10 +1015,8 @@ Value::~Value() {
 }
 
 void Value::SharedDtor() {
+  bytes_.DestroyNoArena(&::google::protobuf::internal::GetEmptyStringAlreadyInited());
   tag_.DestroyNoArena(&::google::protobuf::internal::GetEmptyStringAlreadyInited());
-  if (has_value()) {
-    clear_value();
-  }
   if (this != default_instance_) {
     delete timestamp_;
   }
@@ -1063,26 +1047,11 @@ Value* Value::New(::google::protobuf::Arena* arena) const {
   return n;
 }
 
-void Value::clear_value() {
-  switch(value_case()) {
-    case kBytes: {
-      value_.bytes_.DestroyNoArena(&::google::protobuf::internal::GetEmptyStringAlreadyInited());
-      break;
-    }
-    case kInteger: {
-      // No need to clear
-      break;
-    }
-    case VALUE_NOT_SET: {
-      break;
-    }
-  }
-  _oneof_case_[0] = VALUE_NOT_SET;
-}
-
-
 void Value::Clear() {
-  if (_has_bits_[0 / 32] & 28u) {
+  if (_has_bits_[0 / 32] & 15u) {
+    if (has_bytes()) {
+      bytes_.ClearToEmptyNoArena(&::google::protobuf::internal::GetEmptyStringAlreadyInited());
+    }
     checksum_ = 0u;
     if (has_timestamp()) {
       if (timestamp_ != NULL) timestamp_->::cockroach::proto::Timestamp::Clear();
@@ -1091,7 +1060,6 @@ void Value::Clear() {
       tag_.ClearToEmptyNoArena(&::google::protobuf::internal::GetEmptyStringAlreadyInited());
     }
   }
-  clear_value();
   ::memset(_has_bits_, 0, sizeof(_has_bits_));
   if (_internal_metadata_.have_unknown_fields()) {
     mutable_unknown_fields()->Clear();
@@ -1113,22 +1081,6 @@ bool Value::MergePartialFromCodedStream(
         if (tag == 10) {
           DO_(::google::protobuf::internal::WireFormatLite::ReadBytes(
                 input, this->mutable_bytes()));
-        } else {
-          goto handle_unusual;
-        }
-        if (input->ExpectTag(16)) goto parse_integer;
-        break;
-      }
-
-      // optional int64 integer = 2;
-      case 2: {
-        if (tag == 16) {
-         parse_integer:
-          clear_value();
-          DO_((::google::protobuf::internal::WireFormatLite::ReadPrimitive<
-                   ::google::protobuf::int64, ::google::protobuf::internal::WireFormatLite::TYPE_INT64>(
-                 input, &value_.integer_)));
-          set_has_integer();
         } else {
           goto handle_unusual;
         }
@@ -1212,11 +1164,6 @@ void Value::SerializeWithCachedSizes(
       1, this->bytes(), output);
   }
 
-  // optional int64 integer = 2;
-  if (has_integer()) {
-    ::google::protobuf::internal::WireFormatLite::WriteInt64(2, this->integer(), output);
-  }
-
   // optional fixed32 checksum = 3;
   if (has_checksum()) {
     ::google::protobuf::internal::WireFormatLite::WriteFixed32(3, this->checksum(), output);
@@ -1255,11 +1202,6 @@ void Value::SerializeWithCachedSizes(
         1, this->bytes(), target);
   }
 
-  // optional int64 integer = 2;
-  if (has_integer()) {
-    target = ::google::protobuf::internal::WireFormatLite::WriteInt64ToArray(2, this->integer(), target);
-  }
-
   // optional fixed32 checksum = 3;
   if (has_checksum()) {
     target = ::google::protobuf::internal::WireFormatLite::WriteFixed32ToArray(3, this->checksum(), target);
@@ -1294,7 +1236,14 @@ void Value::SerializeWithCachedSizes(
 int Value::ByteSize() const {
   int total_size = 0;
 
-  if (_has_bits_[2 / 32] & 28) {
+  if (_has_bits_[0 / 32] & 15) {
+    // optional bytes bytes = 1;
+    if (has_bytes()) {
+      total_size += 1 +
+        ::google::protobuf::internal::WireFormatLite::BytesSize(
+          this->bytes());
+    }
+
     // optional fixed32 checksum = 3;
     if (has_checksum()) {
       total_size += 1 + 4;
@@ -1314,25 +1263,6 @@ int Value::ByteSize() const {
           this->tag());
     }
 
-  }
-  switch (value_case()) {
-    // optional bytes bytes = 1;
-    case kBytes: {
-      total_size += 1 +
-        ::google::protobuf::internal::WireFormatLite::BytesSize(
-          this->bytes());
-      break;
-    }
-    // optional int64 integer = 2;
-    case kInteger: {
-      total_size += 1 +
-        ::google::protobuf::internal::WireFormatLite::Int64Size(
-          this->integer());
-      break;
-    }
-    case VALUE_NOT_SET: {
-      break;
-    }
   }
   if (_internal_metadata_.have_unknown_fields()) {
     total_size +=
@@ -1359,20 +1289,11 @@ void Value::MergeFrom(const ::google::protobuf::Message& from) {
 
 void Value::MergeFrom(const Value& from) {
   if (GOOGLE_PREDICT_FALSE(&from == this)) MergeFromFail(__LINE__);
-  switch (from.value_case()) {
-    case kBytes: {
-      set_bytes(from.bytes());
-      break;
+  if (from._has_bits_[0 / 32] & (0xffu << (0 % 32))) {
+    if (from.has_bytes()) {
+      set_has_bytes();
+      bytes_.AssignWithDefault(&::google::protobuf::internal::GetEmptyStringAlreadyInited(), from.bytes_);
     }
-    case kInteger: {
-      set_integer(from.integer());
-      break;
-    }
-    case VALUE_NOT_SET: {
-      break;
-    }
-  }
-  if (from._has_bits_[2 / 32] & (0xffu << (2 % 32))) {
     if (from.has_checksum()) {
       set_checksum(from.checksum());
     }
@@ -1411,11 +1332,10 @@ void Value::Swap(Value* other) {
   InternalSwap(other);
 }
 void Value::InternalSwap(Value* other) {
+  bytes_.Swap(&other->bytes_);
   std::swap(checksum_, other->checksum_);
   std::swap(timestamp_, other->timestamp_);
   tag_.Swap(&other->tag_);
-  std::swap(value_, other->value_);
-  std::swap(_oneof_case_[0], other->_oneof_case_[0]);
   std::swap(_has_bits_[0], other->_has_bits_[0]);
   _internal_metadata_.Swap(&other->_internal_metadata_);
   std::swap(_cached_size_, other->_cached_size_);
@@ -1434,122 +1354,66 @@ void Value::InternalSwap(Value* other) {
 
 // optional bytes bytes = 1;
 bool Value::has_bytes() const {
-  return value_case() == kBytes;
+  return (_has_bits_[0] & 0x00000001u) != 0;
 }
 void Value::set_has_bytes() {
-  _oneof_case_[0] = kBytes;
+  _has_bits_[0] |= 0x00000001u;
+}
+void Value::clear_has_bytes() {
+  _has_bits_[0] &= ~0x00000001u;
 }
 void Value::clear_bytes() {
-  if (has_bytes()) {
-    value_.bytes_.DestroyNoArena(&::google::protobuf::internal::GetEmptyStringAlreadyInited());
-    clear_has_value();
-  }
+  bytes_.ClearToEmptyNoArena(&::google::protobuf::internal::GetEmptyStringAlreadyInited());
+  clear_has_bytes();
 }
  const ::std::string& Value::bytes() const {
   // @@protoc_insertion_point(field_get:cockroach.proto.Value.bytes)
-  if (has_bytes()) {
-    return value_.bytes_.GetNoArena(&::google::protobuf::internal::GetEmptyStringAlreadyInited());
-  }
-  return *&::google::protobuf::internal::GetEmptyStringAlreadyInited();
+  return bytes_.GetNoArena(&::google::protobuf::internal::GetEmptyStringAlreadyInited());
 }
  void Value::set_bytes(const ::std::string& value) {
-  // @@protoc_insertion_point(field_set:cockroach.proto.Value.bytes)
-  if (!has_bytes()) {
-    clear_value();
-    set_has_bytes();
-    value_.bytes_.UnsafeSetDefault(&::google::protobuf::internal::GetEmptyStringAlreadyInited());
-  }
-  value_.bytes_.SetNoArena(&::google::protobuf::internal::GetEmptyStringAlreadyInited(), value);
+  set_has_bytes();
+  bytes_.SetNoArena(&::google::protobuf::internal::GetEmptyStringAlreadyInited(), value);
   // @@protoc_insertion_point(field_set:cockroach.proto.Value.bytes)
 }
  void Value::set_bytes(const char* value) {
-  if (!has_bytes()) {
-    clear_value();
-    set_has_bytes();
-    value_.bytes_.UnsafeSetDefault(&::google::protobuf::internal::GetEmptyStringAlreadyInited());
-  }
-  value_.bytes_.SetNoArena(&::google::protobuf::internal::GetEmptyStringAlreadyInited(),
-      ::std::string(value));
+  set_has_bytes();
+  bytes_.SetNoArena(&::google::protobuf::internal::GetEmptyStringAlreadyInited(), ::std::string(value));
   // @@protoc_insertion_point(field_set_char:cockroach.proto.Value.bytes)
 }
  void Value::set_bytes(const void* value, size_t size) {
-  if (!has_bytes()) {
-    clear_value();
-    set_has_bytes();
-    value_.bytes_.UnsafeSetDefault(&::google::protobuf::internal::GetEmptyStringAlreadyInited());
-  }
-  value_.bytes_.SetNoArena(&::google::protobuf::internal::GetEmptyStringAlreadyInited(), ::std::string(
-      reinterpret_cast<const char*>(value), size));
+  set_has_bytes();
+  bytes_.SetNoArena(&::google::protobuf::internal::GetEmptyStringAlreadyInited(),
+      ::std::string(reinterpret_cast<const char*>(value), size));
   // @@protoc_insertion_point(field_set_pointer:cockroach.proto.Value.bytes)
 }
  ::std::string* Value::mutable_bytes() {
-  if (!has_bytes()) {
-    clear_value();
-    set_has_bytes();
-    value_.bytes_.UnsafeSetDefault(&::google::protobuf::internal::GetEmptyStringAlreadyInited());
-  }
+  set_has_bytes();
   // @@protoc_insertion_point(field_mutable:cockroach.proto.Value.bytes)
-  return value_.bytes_.MutableNoArena(&::google::protobuf::internal::GetEmptyStringAlreadyInited());
+  return bytes_.MutableNoArena(&::google::protobuf::internal::GetEmptyStringAlreadyInited());
 }
  ::std::string* Value::release_bytes() {
-  if (has_bytes()) {
-    clear_has_value();
-    return value_.bytes_.ReleaseNoArena(&::google::protobuf::internal::GetEmptyStringAlreadyInited());
-  } else {
-    return NULL;
-  }
+  clear_has_bytes();
+  return bytes_.ReleaseNoArena(&::google::protobuf::internal::GetEmptyStringAlreadyInited());
 }
  void Value::set_allocated_bytes(::std::string* bytes) {
-  if (!has_bytes()) {
-    value_.bytes_.UnsafeSetDefault(&::google::protobuf::internal::GetEmptyStringAlreadyInited());
-  }
-  clear_value();
   if (bytes != NULL) {
     set_has_bytes();
-    value_.bytes_.SetAllocatedNoArena(&::google::protobuf::internal::GetEmptyStringAlreadyInited(),
-        bytes);
+  } else {
+    clear_has_bytes();
   }
+  bytes_.SetAllocatedNoArena(&::google::protobuf::internal::GetEmptyStringAlreadyInited(), bytes);
   // @@protoc_insertion_point(field_set_allocated:cockroach.proto.Value.bytes)
-}
-
-// optional int64 integer = 2;
-bool Value::has_integer() const {
-  return value_case() == kInteger;
-}
-void Value::set_has_integer() {
-  _oneof_case_[0] = kInteger;
-}
-void Value::clear_integer() {
-  if (has_integer()) {
-    value_.integer_ = GOOGLE_LONGLONG(0);
-    clear_has_value();
-  }
-}
- ::google::protobuf::int64 Value::integer() const {
-  // @@protoc_insertion_point(field_get:cockroach.proto.Value.integer)
-  if (has_integer()) {
-    return value_.integer_;
-  }
-  return GOOGLE_LONGLONG(0);
-}
- void Value::set_integer(::google::protobuf::int64 value) {
-  if (!has_integer()) {
-    clear_value();
-    set_has_integer();
-  }
-  value_.integer_ = value;
-  // @@protoc_insertion_point(field_set:cockroach.proto.Value.integer)
 }
 
 // optional fixed32 checksum = 3;
 bool Value::has_checksum() const {
-  return (_has_bits_[0] & 0x00000004u) != 0;
+  return (_has_bits_[0] & 0x00000002u) != 0;
 }
 void Value::set_has_checksum() {
-  _has_bits_[0] |= 0x00000004u;
+  _has_bits_[0] |= 0x00000002u;
 }
 void Value::clear_has_checksum() {
-  _has_bits_[0] &= ~0x00000004u;
+  _has_bits_[0] &= ~0x00000002u;
 }
 void Value::clear_checksum() {
   checksum_ = 0u;
@@ -1567,13 +1431,13 @@ void Value::clear_checksum() {
 
 // optional .cockroach.proto.Timestamp timestamp = 4;
 bool Value::has_timestamp() const {
-  return (_has_bits_[0] & 0x00000008u) != 0;
+  return (_has_bits_[0] & 0x00000004u) != 0;
 }
 void Value::set_has_timestamp() {
-  _has_bits_[0] |= 0x00000008u;
+  _has_bits_[0] |= 0x00000004u;
 }
 void Value::clear_has_timestamp() {
-  _has_bits_[0] &= ~0x00000008u;
+  _has_bits_[0] &= ~0x00000004u;
 }
 void Value::clear_timestamp() {
   if (timestamp_ != NULL) timestamp_->::cockroach::proto::Timestamp::Clear();
@@ -1610,13 +1474,13 @@ void Value::clear_timestamp() {
 
 // optional string tag = 5;
 bool Value::has_tag() const {
-  return (_has_bits_[0] & 0x00000010u) != 0;
+  return (_has_bits_[0] & 0x00000008u) != 0;
 }
 void Value::set_has_tag() {
-  _has_bits_[0] |= 0x00000010u;
+  _has_bits_[0] |= 0x00000008u;
 }
 void Value::clear_has_tag() {
-  _has_bits_[0] &= ~0x00000010u;
+  _has_bits_[0] &= ~0x00000008u;
 }
 void Value::clear_tag() {
   tag_.ClearToEmptyNoArena(&::google::protobuf::internal::GetEmptyStringAlreadyInited());
@@ -1661,15 +1525,6 @@ void Value::clear_tag() {
   // @@protoc_insertion_point(field_set_allocated:cockroach.proto.Value.tag)
 }
 
-bool Value::has_value() const {
-  return value_case() != VALUE_NOT_SET;
-}
-void Value::clear_has_value() {
-  _oneof_case_[0] = VALUE_NOT_SET;
-}
-Value::ValueCase Value::value_case() const {
-  return Value::ValueCase(_oneof_case_[0]);
-}
 #endif  // PROTOBUF_INLINE_NOT_IN_HEADERS
 
 // ===================================================================

--- a/storage/engine/cockroach/proto/data.pb.h
+++ b/storage/engine/cockroach/proto/data.pb.h
@@ -239,12 +239,6 @@ class Value : public ::google::protobuf::Message {
   static const ::google::protobuf::Descriptor* descriptor();
   static const Value& default_instance();
 
-  enum ValueCase {
-    kBytes = 1,
-    kInteger = 2,
-    VALUE_NOT_SET = 0,
-  };
-
   void Swap(Value* other);
 
   // implements Message ----------------------------------------------
@@ -298,13 +292,6 @@ class Value : public ::google::protobuf::Message {
   ::std::string* release_bytes();
   void set_allocated_bytes(::std::string* bytes);
 
-  // optional int64 integer = 2;
-  bool has_integer() const;
-  void clear_integer();
-  static const int kIntegerFieldNumber = 2;
-  ::google::protobuf::int64 integer() const;
-  void set_integer(::google::protobuf::int64 value);
-
   // optional fixed32 checksum = 3;
   bool has_checksum() const;
   void clear_checksum();
@@ -333,11 +320,10 @@ class Value : public ::google::protobuf::Message {
   ::std::string* release_tag();
   void set_allocated_tag(::std::string* tag);
 
-  ValueCase value_case() const;
   // @@protoc_insertion_point(class_scope:cockroach.proto.Value)
  private:
   inline void set_has_bytes();
-  inline void set_has_integer();
+  inline void clear_has_bytes();
   inline void set_has_checksum();
   inline void clear_has_checksum();
   inline void set_has_timestamp();
@@ -345,23 +331,13 @@ class Value : public ::google::protobuf::Message {
   inline void set_has_tag();
   inline void clear_has_tag();
 
-  inline bool has_value() const;
-  void clear_value();
-  inline void clear_has_value();
-
   ::google::protobuf::internal::InternalMetadataWithArena _internal_metadata_;
   ::google::protobuf::uint32 _has_bits_[1];
   mutable int _cached_size_;
+  ::google::protobuf::internal::ArenaStringPtr bytes_;
   ::cockroach::proto::Timestamp* timestamp_;
   ::google::protobuf::internal::ArenaStringPtr tag_;
   ::google::protobuf::uint32 checksum_;
-  union ValueUnion {
-    ValueUnion() {}
-    ::google::protobuf::internal::ArenaStringPtr bytes_;
-    ::google::protobuf::int64 integer_;
-  } value_;
-  ::google::protobuf::uint32 _oneof_case_[1];
-
   friend void  protobuf_AddDesc_cockroach_2fproto_2fdata_2eproto();
   friend void protobuf_AssignDesc_cockroach_2fproto_2fdata_2eproto();
   friend void protobuf_ShutdownFile_cockroach_2fproto_2fdata_2eproto();
@@ -2202,122 +2178,66 @@ inline void Timestamp::set_logical(::google::protobuf::int32 value) {
 
 // optional bytes bytes = 1;
 inline bool Value::has_bytes() const {
-  return value_case() == kBytes;
+  return (_has_bits_[0] & 0x00000001u) != 0;
 }
 inline void Value::set_has_bytes() {
-  _oneof_case_[0] = kBytes;
+  _has_bits_[0] |= 0x00000001u;
+}
+inline void Value::clear_has_bytes() {
+  _has_bits_[0] &= ~0x00000001u;
 }
 inline void Value::clear_bytes() {
-  if (has_bytes()) {
-    value_.bytes_.DestroyNoArena(&::google::protobuf::internal::GetEmptyStringAlreadyInited());
-    clear_has_value();
-  }
+  bytes_.ClearToEmptyNoArena(&::google::protobuf::internal::GetEmptyStringAlreadyInited());
+  clear_has_bytes();
 }
 inline const ::std::string& Value::bytes() const {
   // @@protoc_insertion_point(field_get:cockroach.proto.Value.bytes)
-  if (has_bytes()) {
-    return value_.bytes_.GetNoArena(&::google::protobuf::internal::GetEmptyStringAlreadyInited());
-  }
-  return *&::google::protobuf::internal::GetEmptyStringAlreadyInited();
+  return bytes_.GetNoArena(&::google::protobuf::internal::GetEmptyStringAlreadyInited());
 }
 inline void Value::set_bytes(const ::std::string& value) {
-  // @@protoc_insertion_point(field_set:cockroach.proto.Value.bytes)
-  if (!has_bytes()) {
-    clear_value();
-    set_has_bytes();
-    value_.bytes_.UnsafeSetDefault(&::google::protobuf::internal::GetEmptyStringAlreadyInited());
-  }
-  value_.bytes_.SetNoArena(&::google::protobuf::internal::GetEmptyStringAlreadyInited(), value);
+  set_has_bytes();
+  bytes_.SetNoArena(&::google::protobuf::internal::GetEmptyStringAlreadyInited(), value);
   // @@protoc_insertion_point(field_set:cockroach.proto.Value.bytes)
 }
 inline void Value::set_bytes(const char* value) {
-  if (!has_bytes()) {
-    clear_value();
-    set_has_bytes();
-    value_.bytes_.UnsafeSetDefault(&::google::protobuf::internal::GetEmptyStringAlreadyInited());
-  }
-  value_.bytes_.SetNoArena(&::google::protobuf::internal::GetEmptyStringAlreadyInited(),
-      ::std::string(value));
+  set_has_bytes();
+  bytes_.SetNoArena(&::google::protobuf::internal::GetEmptyStringAlreadyInited(), ::std::string(value));
   // @@protoc_insertion_point(field_set_char:cockroach.proto.Value.bytes)
 }
 inline void Value::set_bytes(const void* value, size_t size) {
-  if (!has_bytes()) {
-    clear_value();
-    set_has_bytes();
-    value_.bytes_.UnsafeSetDefault(&::google::protobuf::internal::GetEmptyStringAlreadyInited());
-  }
-  value_.bytes_.SetNoArena(&::google::protobuf::internal::GetEmptyStringAlreadyInited(), ::std::string(
-      reinterpret_cast<const char*>(value), size));
+  set_has_bytes();
+  bytes_.SetNoArena(&::google::protobuf::internal::GetEmptyStringAlreadyInited(),
+      ::std::string(reinterpret_cast<const char*>(value), size));
   // @@protoc_insertion_point(field_set_pointer:cockroach.proto.Value.bytes)
 }
 inline ::std::string* Value::mutable_bytes() {
-  if (!has_bytes()) {
-    clear_value();
-    set_has_bytes();
-    value_.bytes_.UnsafeSetDefault(&::google::protobuf::internal::GetEmptyStringAlreadyInited());
-  }
+  set_has_bytes();
   // @@protoc_insertion_point(field_mutable:cockroach.proto.Value.bytes)
-  return value_.bytes_.MutableNoArena(&::google::protobuf::internal::GetEmptyStringAlreadyInited());
+  return bytes_.MutableNoArena(&::google::protobuf::internal::GetEmptyStringAlreadyInited());
 }
 inline ::std::string* Value::release_bytes() {
-  if (has_bytes()) {
-    clear_has_value();
-    return value_.bytes_.ReleaseNoArena(&::google::protobuf::internal::GetEmptyStringAlreadyInited());
-  } else {
-    return NULL;
-  }
+  clear_has_bytes();
+  return bytes_.ReleaseNoArena(&::google::protobuf::internal::GetEmptyStringAlreadyInited());
 }
 inline void Value::set_allocated_bytes(::std::string* bytes) {
-  if (!has_bytes()) {
-    value_.bytes_.UnsafeSetDefault(&::google::protobuf::internal::GetEmptyStringAlreadyInited());
-  }
-  clear_value();
   if (bytes != NULL) {
     set_has_bytes();
-    value_.bytes_.SetAllocatedNoArena(&::google::protobuf::internal::GetEmptyStringAlreadyInited(),
-        bytes);
+  } else {
+    clear_has_bytes();
   }
+  bytes_.SetAllocatedNoArena(&::google::protobuf::internal::GetEmptyStringAlreadyInited(), bytes);
   // @@protoc_insertion_point(field_set_allocated:cockroach.proto.Value.bytes)
-}
-
-// optional int64 integer = 2;
-inline bool Value::has_integer() const {
-  return value_case() == kInteger;
-}
-inline void Value::set_has_integer() {
-  _oneof_case_[0] = kInteger;
-}
-inline void Value::clear_integer() {
-  if (has_integer()) {
-    value_.integer_ = GOOGLE_LONGLONG(0);
-    clear_has_value();
-  }
-}
-inline ::google::protobuf::int64 Value::integer() const {
-  // @@protoc_insertion_point(field_get:cockroach.proto.Value.integer)
-  if (has_integer()) {
-    return value_.integer_;
-  }
-  return GOOGLE_LONGLONG(0);
-}
-inline void Value::set_integer(::google::protobuf::int64 value) {
-  if (!has_integer()) {
-    clear_value();
-    set_has_integer();
-  }
-  value_.integer_ = value;
-  // @@protoc_insertion_point(field_set:cockroach.proto.Value.integer)
 }
 
 // optional fixed32 checksum = 3;
 inline bool Value::has_checksum() const {
-  return (_has_bits_[0] & 0x00000004u) != 0;
+  return (_has_bits_[0] & 0x00000002u) != 0;
 }
 inline void Value::set_has_checksum() {
-  _has_bits_[0] |= 0x00000004u;
+  _has_bits_[0] |= 0x00000002u;
 }
 inline void Value::clear_has_checksum() {
-  _has_bits_[0] &= ~0x00000004u;
+  _has_bits_[0] &= ~0x00000002u;
 }
 inline void Value::clear_checksum() {
   checksum_ = 0u;
@@ -2335,13 +2255,13 @@ inline void Value::set_checksum(::google::protobuf::uint32 value) {
 
 // optional .cockroach.proto.Timestamp timestamp = 4;
 inline bool Value::has_timestamp() const {
-  return (_has_bits_[0] & 0x00000008u) != 0;
+  return (_has_bits_[0] & 0x00000004u) != 0;
 }
 inline void Value::set_has_timestamp() {
-  _has_bits_[0] |= 0x00000008u;
+  _has_bits_[0] |= 0x00000004u;
 }
 inline void Value::clear_has_timestamp() {
-  _has_bits_[0] &= ~0x00000008u;
+  _has_bits_[0] &= ~0x00000004u;
 }
 inline void Value::clear_timestamp() {
   if (timestamp_ != NULL) timestamp_->::cockroach::proto::Timestamp::Clear();
@@ -2378,13 +2298,13 @@ inline void Value::set_allocated_timestamp(::cockroach::proto::Timestamp* timest
 
 // optional string tag = 5;
 inline bool Value::has_tag() const {
-  return (_has_bits_[0] & 0x00000010u) != 0;
+  return (_has_bits_[0] & 0x00000008u) != 0;
 }
 inline void Value::set_has_tag() {
-  _has_bits_[0] |= 0x00000010u;
+  _has_bits_[0] |= 0x00000008u;
 }
 inline void Value::clear_has_tag() {
-  _has_bits_[0] &= ~0x00000010u;
+  _has_bits_[0] &= ~0x00000008u;
 }
 inline void Value::clear_tag() {
   tag_.ClearToEmptyNoArena(&::google::protobuf::internal::GetEmptyStringAlreadyInited());
@@ -2429,15 +2349,6 @@ inline void Value::set_allocated_tag(::std::string* tag) {
   // @@protoc_insertion_point(field_set_allocated:cockroach.proto.Value.tag)
 }
 
-inline bool Value::has_value() const {
-  return value_case() != VALUE_NOT_SET;
-}
-inline void Value::clear_has_value() {
-  _oneof_case_[0] = VALUE_NOT_SET;
-}
-inline Value::ValueCase Value::value_case() const {
-  return Value::ValueCase(_oneof_case_[0]);
-}
 // -------------------------------------------------------------------
 
 // MVCCValue

--- a/storage/engine/db.cc
+++ b/storage/engine/db.cc
@@ -548,18 +548,6 @@ bool MergeValues(cockroach::proto::Value *left, const cockroach::proto::Value &r
             *left->mutable_bytes() += right.bytes();
         }
         return true;
-    } else if (left->has_integer()) {
-        if (!right.has_integer()) {
-            rocksdb::Warn(logger,
-                    "inconsistent value types for merge (left = integer, right = ?)");
-            return false;
-        }
-        if (WillOverflow(left->integer(), right.integer())) {
-            rocksdb::Warn(logger, "merge would result in integer overflow.");
-            return false;
-        }
-        left->set_integer(left->integer() + right.integer());
-        return true;
     } else {
         *left = right;
         if (full_merge && IsTimeSeriesData(left)) {

--- a/storage/engine/mvcc_test.go
+++ b/storage/engine/mvcc_test.go
@@ -150,18 +150,6 @@ func TestMVCCGetNotExist(t *testing.T) {
 	}
 }
 
-func TestMVCCPutWithBadValue(t *testing.T) {
-	defer leaktest.AfterTest(t)
-	engine := createTestEngine()
-	defer engine.Close()
-
-	badValue := proto.Value{Bytes: []byte("a"), Integer: gogoproto.Int64(1)}
-	err := MVCCPut(engine, nil, testKey1, makeTS(0, 1), badValue, nil)
-	if err == nil {
-		t.Fatal("expected an error putting a value with both byte slice and integer components")
-	}
-}
-
 func TestMVCCPutWithTxn(t *testing.T) {
 	defer leaktest.AfterTest(t)
 	engine := createTestEngine()

--- a/storage/engine/rocksdb_test.go
+++ b/storage/engine/rocksdb_test.go
@@ -468,20 +468,11 @@ func runMVCCMerge(value *proto.Value, numKeys int, b *testing.B) {
 			continue
 		}
 		if testing.Verbose() {
-			if val.Integer != nil {
-				fmt.Printf("%q: %d\n", key, val.GetInteger())
-			} else {
-				fmt.Printf("%q: [%d]byte\n", key, len(val.Bytes))
-			}
+			fmt.Printf("%q: [%d]byte\n", key, len(val.Bytes))
 		}
 	}
 
 	b.StopTimer()
-}
-
-// BenchmarkMVCCMergeInteger computes performance of merging integers.
-func BenchmarkMVCCMergeInteger(b *testing.B) {
-	runMVCCMerge(&proto.Value{Integer: gogoproto.Int64(1)}, 1024, b)
 }
 
 // BenchmarkMVCCMergeTimeSeries computes performance of merging time series data.

--- a/storage/store.go
+++ b/storage/store.go
@@ -912,7 +912,8 @@ func (s *Store) BootstrapRange() error {
 
 	// We reserve the first 1000 descriptor IDs.
 	key = keys.DescIDGenerator
-	value := proto.Value{Integer: gogoproto.Int64(proto.MaxReservedDescID + 1)}
+	value := proto.Value{}
+	value.SetInteger(proto.MaxReservedDescID + 1)
 	value.InitChecksum(key)
 	if err := engine.MVCCPut(batch, nil, key, now, value, nil); err != nil {
 		return err


### PR DESCRIPTION
Integer values are now encoded into proto.Value.Bytes and any 0 or 8
byte value can be intepreted as an int64. Some of the printing niceness
disappeared from the cockroach cli, but that will hopefully return once
we move to the table-based API where we know the types of columns.
