### PR TITLE
Normalize name of client.DB variable to "db".

### DIFF
--- a/acceptance/multiuser_test.go
+++ b/acceptance/multiuser_test.go
@@ -63,7 +63,7 @@ func TestMultiuser(t *testing.T) {
 	// Write some data. The value is just the key.
 	writes := []struct {
 		key     string
-		client  *client.DB
+		db      *client.DB
 		success bool
 	}{
 		{"some-file", rootClient, true}, {"some-file", fooClient, false}, {"some-file", otherClient, false},
@@ -73,7 +73,7 @@ func TestMultiuser(t *testing.T) {
 	}
 
 	for i, w := range writes {
-		err := w.client.Put(w.key, w.key)
+		err := w.db.Put(w.key, w.key)
 		if (err == nil) != w.success {
 			t.Errorf("test case #%d: %+v, got err=%v", i, w, err)
 		}
@@ -82,7 +82,7 @@ func TestMultiuser(t *testing.T) {
 	// Read the previously-written files. They all succeeded at least once.
 	reads := []struct {
 		key     string
-		client  *client.DB
+		db      *client.DB
 		success bool
 	}{
 		{"some-file", rootClient, true}, {"some-file", fooClient, false}, {"some-file", otherClient, false},
@@ -92,7 +92,7 @@ func TestMultiuser(t *testing.T) {
 	}
 
 	for i, r := range reads {
-		_, err := r.client.Get(r.key)
+		_, err := r.db.Get(r.key)
 		if (err == nil) != r.success {
 			t.Errorf("test case #%d: %+v, got err=%v", i, r, err)
 		}

--- a/acceptance/put_test.go
+++ b/acceptance/put_test.go
@@ -37,8 +37,8 @@ func TestPut(t *testing.T) {
 	l.Start()
 	defer l.Stop()
 
-	c := makeDBClient(t, l, 0)
-	setDefaultRangeMaxBytes(t, c, *rangeMaxBytes)
+	db := makeDBClient(t, l, 0)
+	setDefaultRangeMaxBytes(t, db, *rangeMaxBytes)
 	checkRangeReplication(t, l, 20*time.Second)
 
 	errs := make(chan error, *numNodes)
@@ -53,7 +53,7 @@ func TestPut(t *testing.T) {
 			for time.Now().Before(deadline) {
 				k := atomic.AddInt64(&count, 1)
 				v := value[:r.Intn(len(value))]
-				if err := c.Put(fmt.Sprintf("%08d", k), v); err != nil {
+				if err := db.Put(fmt.Sprintf("%08d", k), v); err != nil {
 					errs <- err
 					return
 				}

--- a/acceptance/replication_test.go
+++ b/acceptance/replication_test.go
@@ -32,9 +32,9 @@ import (
 	"github.com/cockroachdb/cockroach/util/log"
 )
 
-func countRangeReplicas(client *client.DB) (int, error) {
+func countRangeReplicas(db *client.DB) (int, error) {
 	desc := &proto.RangeDescriptor{}
-	if err := client.GetProto(keys.RangeDescriptorKey(proto.KeyMin), desc); err != nil {
+	if err := db.GetProto(keys.RangeDescriptorKey(proto.KeyMin), desc); err != nil {
 		return 0, err
 	}
 	return len(desc.Replicas), nil

--- a/acceptance/single_key_test.go
+++ b/acceptance/single_key_test.go
@@ -62,8 +62,8 @@ func TestSingleKey(t *testing.T) {
 
 	// Initialize the value for our test key to zero.
 	const key = "test-key"
-	c := makeDBClient(t, l, 0)
-	if err := c.Put(key, testVal(0)); err != nil {
+	db := makeDBClient(t, l, 0)
+	if err := db.Put(key, testVal(0)); err != nil {
 		t.Fatal(err)
 	}
 
@@ -81,12 +81,12 @@ func TestSingleKey(t *testing.T) {
 	// key. Each worker is configured to talk to a different node in the
 	// cluster.
 	for i := 0; i < *numNodes; i++ {
-		c := makeDBClient(t, l, i)
+		db := makeDBClient(t, l, i)
 		go func() {
 			var r result
 			for time.Now().Before(deadline) {
 				start := time.Now()
-				err := c.Txn(func(txn *client.Txn) error {
+				err := db.Txn(func(txn *client.Txn) error {
 					r, err := txn.Get(key)
 					if err != nil {
 						return err
@@ -133,7 +133,7 @@ func TestSingleKey(t *testing.T) {
 	}
 
 	// Verify the resulting value stored at the key is what we expect.
-	r, err := c.Get(key)
+	r, err := db.Get(key)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/acceptance/util.go
+++ b/acceptance/util.go
@@ -39,35 +39,35 @@ func makeDBClientForUser(t *testing.T, cluster *localcluster.Cluster, user strin
 	// We need to run with "InsecureSkipVerify" (set when Certs="" inside the http sender).
 	// This is due to the fact that we're running outside docker, so we cannot use a fixed hostname
 	// to reach the cluster. This in turn means that we do not have a verified server name in the certs.
-	c, err := client.Open("https://" + user + "@" +
+	db, err := client.Open("https://" + user + "@" +
 		cluster.Nodes[node].Addr("").String() +
 		"?certs=" + cluster.CertsDir)
 
 	if err != nil {
 		t.Fatal(err)
 	}
-	return c
+	return db
 }
 
 // setDefaultRangeMaxBytes sets the range-max-bytes value for the default zone.
-func setDefaultRangeMaxBytes(t *testing.T, c *client.DB, maxBytes int64) {
+func setDefaultRangeMaxBytes(t *testing.T, db *client.DB, maxBytes int64) {
 	zone := &proto.ZoneConfig{}
-	if err := c.GetProto(keys.ConfigZonePrefix, zone); err != nil {
+	if err := db.GetProto(keys.ConfigZonePrefix, zone); err != nil {
 		t.Fatal(err)
 	}
 	if zone.RangeMaxBytes == maxBytes {
 		return
 	}
 	zone.RangeMaxBytes = maxBytes
-	if err := c.Put(keys.ConfigZonePrefix, zone); err != nil {
+	if err := db.Put(keys.ConfigZonePrefix, zone); err != nil {
 		t.Fatal(err)
 	}
 }
 
 // getPermConfig fetches the permissions config for 'prefix'.
-func getPermConfig(client *client.DB, prefix string) (*proto.PermConfig, error) {
+func getPermConfig(db *client.DB, prefix string) (*proto.PermConfig, error) {
 	config := &proto.PermConfig{}
-	if err := client.GetProto(keys.MakeKey(keys.ConfigPermissionPrefix, proto.Key(prefix)), config); err != nil {
+	if err := db.GetProto(keys.MakeKey(keys.ConfigPermissionPrefix, proto.Key(prefix)), config); err != nil {
 		return nil, err
 	}
 
@@ -75,6 +75,6 @@ func getPermConfig(client *client.DB, prefix string) (*proto.PermConfig, error) 
 }
 
 // putPermConfig writes the permissions config for 'prefix'.
-func putPermConfig(client *client.DB, prefix string, config *proto.PermConfig) error {
-	return client.Put(keys.MakeKey(keys.ConfigPermissionPrefix, proto.Key(prefix)), config)
+func putPermConfig(db *client.DB, prefix string, config *proto.PermConfig) error {
+	return db.Put(keys.MakeKey(keys.ConfigPermissionPrefix, proto.Key(prefix)), config)
 }


### PR DESCRIPTION
This makes the acceptance package consistent with the rest of the code
base.
