### PR TITLE
fix #1301

### DIFF
--- a/server/status/feed.go
+++ b/server/status/feed.go
@@ -56,7 +56,8 @@ func (nef NodeEventFeed) CallComplete(args proto.Request, reply proto.Response) 
 	if nef.f == nil {
 		return
 	}
-	if err := reply.Header().GoError(); err != nil {
+	if err := reply.Header().Error; err != nil &&
+		err.CanRestartTransaction() == proto.TransactionRestart_ABORT {
 		nef.f.Publish(&CallErrorEvent{
 			NodeID: nef.id,
 			Method: args.Method(),


### PR DESCRIPTION
don't count transaction restarts as errors for the node feed.
