### PR TITLE
Changed proto.PutCall to take a proto.Value instead of a []byte.

### DIFF
--- a/client/batch.go
+++ b/client/batch.go
@@ -233,7 +233,7 @@ func (b *Batch) Put(key, value interface{}) {
 		b.initResult(0, 1, err)
 		return
 	}
-	b.calls = append(b.calls, proto.PutCall(proto.Key(k), v))
+	b.calls = append(b.calls, proto.PutCall(proto.Key(k), proto.Value{Bytes: v}))
 	b.initResult(1, 1, nil)
 }
 

--- a/client/table.go
+++ b/client/table.go
@@ -611,16 +611,7 @@ func (b *Batch) PutStruct(obj interface{}, columns ...string) {
 			return
 		}
 
-		v.InitChecksum(key)
-		calls = append(calls, proto.Call{
-			Args: &proto.PutRequest{
-				RequestHeader: proto.RequestHeader{
-					Key: key,
-				},
-				Value: v,
-			},
-			Reply: &proto.PutResponse{},
-		})
+		calls = append(calls, proto.PutCall(key, v))
 	}
 
 	b.calls = append(b.calls, calls...)

--- a/kv/dist_sender_test.go
+++ b/kv/dist_sender_test.go
@@ -330,7 +330,7 @@ func TestRetryOnNotLeaderError(t *testing.T) {
 		}),
 	}
 	ds := NewDistSender(ctx, g)
-	call := proto.PutCall(proto.Key("a"), []byte("value"))
+	call := proto.PutCall(proto.Key("a"), proto.Value{Bytes: []byte("value")})
 	reply := call.Reply.(*proto.PutResponse)
 	ds.Send(context.Background(), call)
 	if err := reply.GoError(); err != nil {
@@ -390,7 +390,7 @@ func TestEvictCacheOnError(t *testing.T) {
 		ds := NewDistSender(ctx, g)
 		ds.updateLeaderCache(1, leader)
 
-		call := proto.PutCall(proto.Key("a"), []byte("value"))
+		call := proto.PutCall(proto.Key("a"), proto.Value{Bytes: []byte("value")})
 		reply := call.Reply.(*proto.PutResponse)
 		ds.Send(context.Background(), call)
 		if err := reply.GoError(); err != nil && err.Error() != "boom" {

--- a/proto/call.go
+++ b/proto/call.go
@@ -75,10 +75,8 @@ func IncrementCall(key Key, increment int64) Call {
 	}
 }
 
-// PutCall returns a Call object initialized to put value as a byte slice at
-// key.
-func PutCall(key Key, valueBytes []byte) Call {
-	value := Value{Bytes: valueBytes}
+// PutCall returns a Call object initialized to put the value at key.
+func PutCall(key Key, value Value) Call {
 	value.InitChecksum(key)
 	return Call{
 		Args: &PutRequest{
@@ -120,17 +118,7 @@ func PutProtoCall(key Key, msg gogoproto.Message) Call {
 	if err != nil {
 		return Call{Err: err}
 	}
-	value := Value{Bytes: data}
-	value.InitChecksum(key)
-	return Call{
-		Args: &PutRequest{
-			RequestHeader: RequestHeader{
-				Key: key,
-			},
-			Value: value,
-		},
-		Reply: &PutResponse{},
-	}
+	return PutCall(key, Value{Bytes: data})
 }
 
 // DeleteCall returns a Call object initialized to delete the value at key.

--- a/server/server_test.go
+++ b/server/server_test.go
@@ -328,7 +328,7 @@ func TestMultiRangeScanDeleteRange(t *testing.T) {
 	}
 	var call proto.Call
 	for i, k := range writes {
-		call = proto.PutCall(k, k)
+		call = proto.PutCall(k, proto.Value{Bytes: k})
 		call.Args.Header().User = storage.UserRoot
 		tds.Send(context.Background(), call)
 		if err := call.Reply.Header().GoError(); err != nil {
@@ -417,7 +417,7 @@ func TestMultiRangeScanWithMaxResults(t *testing.T) {
 
 		var call proto.Call
 		for _, k := range tc.keys {
-			call = proto.PutCall(k, k)
+			call = proto.PutCall(k, proto.Value{Bytes: k})
 			call.Args.Header().User = storage.UserRoot
 			tds.Send(context.Background(), call)
 			if err := call.Reply.Header().GoError(); err != nil {

--- a/server/status/feed_test.go
+++ b/server/status/feed_test.go
@@ -100,7 +100,7 @@ func TestNodeEventFeed(t *testing.T) {
 		{
 			name: "Put",
 			publishTo: func(nef status.NodeEventFeed) {
-				call := proto.PutCall(proto.Key("abc"), []byte("def"))
+				call := proto.PutCall(proto.Key("abc"), proto.Value{Bytes: []byte("def")})
 				nef.CallComplete(call.Args, call.Reply)
 			},
 			expected: &status.CallSuccessEvent{


### PR DESCRIPTION
Added proto.PutBytesCall to capture the previous behavior.
