### PR TITLE
Changed Value.GetInteger() to return an error.

### DIFF
--- a/client/db.go
+++ b/client/db.go
@@ -87,8 +87,8 @@ func (kv *KeyValue) ValueBytes() []byte {
 	return kv.Value.([]byte)
 }
 
-// ValueInt returns the value as an int64. This method will panic if the
-// value's type is not an int64.
+// ValueInt returns the value decoded as an int64. This method will panic if
+// the value cannot be decoded as an int64.
 func (kv *KeyValue) ValueInt() int64 {
 	if kv.Value == nil {
 		return 0
@@ -96,7 +96,11 @@ func (kv *KeyValue) ValueInt() int64 {
 	if i, ok := kv.Value.(*int64); ok {
 		return *i
 	}
-	_, uint64val := roachencoding.DecodeUint64(kv.ValueBytes())
+	b := kv.ValueBytes()
+	if len(b) == 0 {
+		return 0
+	}
+	_, uint64val := roachencoding.DecodeUint64(b)
 	return int64(uint64val)
 }
 

--- a/client/table.go
+++ b/client/table.go
@@ -925,19 +925,35 @@ func unmarshalTableValue(src *proto.Value, dest reflect.Value) error {
 
 	switch dest.Kind() {
 	case reflect.Bool:
-		dest.SetBool(src.GetInteger() != 0)
+		i, err := src.GetInteger()
+		if err != nil {
+			return err
+		}
+		dest.SetBool(i != 0)
 		return nil
 
 	case reflect.Int, reflect.Int8, reflect.Int16, reflect.Int32, reflect.Int64:
-		dest.SetInt(src.GetInteger())
+		i, err := src.GetInteger()
+		if err != nil {
+			return err
+		}
+		dest.SetInt(i)
 		return nil
 
 	case reflect.Uint, reflect.Uint8, reflect.Uint16, reflect.Uint32, reflect.Uint64, reflect.Uintptr:
-		dest.SetUint(uint64(src.GetInteger()))
+		i, err := src.GetInteger()
+		if err != nil {
+			return err
+		}
+		dest.SetUint(uint64(i))
 		return nil
 
 	case reflect.Float32, reflect.Float64:
-		dest.SetFloat(math.Float64frombits(uint64(src.GetInteger())))
+		i, err := src.GetInteger()
+		if err != nil {
+			return err
+		}
+		dest.SetFloat(math.Float64frombits(uint64(i)))
 		return nil
 
 	case reflect.String:

--- a/proto/api.pb.go
+++ b/proto/api.pb.go
@@ -298,7 +298,7 @@ func (m *ResponseHeader) GetTxn() *Transaction {
 	return nil
 }
 
-// A GetRequest is arguments to the Get() method.
+// A GetRequest is the argument for the Get() method.
 type GetRequest struct {
 	RequestHeader    `protobuf:"bytes,1,opt,name=header,embedded=header" json:"header"`
 	XXX_unrecognized []byte `json:"-"`
@@ -327,9 +327,7 @@ func (m *GetResponse) GetValue() *Value {
 	return nil
 }
 
-// A PutRequest is arguments to the Put() method. Note that to write
-// an empty value, the value parameter is still specified, but Bytes
-// is set to nil.
+// A PutRequest is the argument to the Put() method.
 type PutRequest struct {
 	RequestHeader    `protobuf:"bytes,1,opt,name=header,embedded=header" json:"header"`
 	Value            Value  `protobuf:"bytes,2,opt,name=value" json:"value"`
@@ -357,7 +355,7 @@ func (m *PutResponse) Reset()         { *m = PutResponse{} }
 func (m *PutResponse) String() string { return proto1.CompactTextString(m) }
 func (*PutResponse) ProtoMessage()    {}
 
-// A ConditionalPutRequest is arguments to the ConditionalPut() method.
+// A ConditionalPutRequest is the argument to the ConditionalPut() method.
 //
 // - Returns true and sets value if ExpValue equals existing value.
 // - If key doesn't exist and ExpValue is nil, sets value.
@@ -403,7 +401,7 @@ func (m *ConditionalPutResponse) Reset()         { *m = ConditionalPutResponse{}
 func (m *ConditionalPutResponse) String() string { return proto1.CompactTextString(m) }
 func (*ConditionalPutResponse) ProtoMessage()    {}
 
-// An IncrementRequest is arguments to the Increment() method. It
+// An IncrementRequest is the argument to the Increment() method. It
 // increments the value for key, and returns the new value. If no
 // value exists for a key, incrementing by 0 is not a noop, but will
 // create a zero value. IncrementRequest cannot be called on a key set
@@ -446,7 +444,7 @@ func (m *IncrementResponse) GetNewValue() int64 {
 	return 0
 }
 
-// A DeleteRequest is arguments to the Delete() method.
+// A DeleteRequest is the argument to the Delete() method.
 type DeleteRequest struct {
 	RequestHeader    `protobuf:"bytes,1,opt,name=header,embedded=header" json:"header"`
 	XXX_unrecognized []byte `json:"-"`
@@ -466,7 +464,7 @@ func (m *DeleteResponse) Reset()         { *m = DeleteResponse{} }
 func (m *DeleteResponse) String() string { return proto1.CompactTextString(m) }
 func (*DeleteResponse) ProtoMessage()    {}
 
-// A DeleteRangeRequest is arguments to the DeleteRange method. It
+// A DeleteRangeRequest is the argument to the DeleteRange() method. It
 // specifies the range of keys to delete.
 type DeleteRangeRequest struct {
 	RequestHeader `protobuf:"bytes,1,opt,name=header,embedded=header" json:"header"`
@@ -507,7 +505,7 @@ func (m *DeleteRangeResponse) GetNumDeleted() int64 {
 	return 0
 }
 
-// A ScanRequest is arguments to the Scan() method. It specifies the
+// A ScanRequest is the argument to the Scan() method. It specifies the
 // start and end keys for the scan and the maximum number of results.
 type ScanRequest struct {
 	RequestHeader `protobuf:"bytes,1,opt,name=header,embedded=header" json:"header"`
@@ -546,8 +544,8 @@ func (m *ScanResponse) GetRows() []KeyValue {
 	return nil
 }
 
-// An EndTransactionRequest is arguments to the EndTransaction() method.
-// It specifies whether to commit or roll back an extant transaction.
+// An EndTransactionRequest is the argument to the EndTransaction() method. It
+// specifies whether to commit or roll back an extant transaction.
 type EndTransactionRequest struct {
 	RequestHeader `protobuf:"bytes,1,opt,name=header,embedded=header" json:"header"`
 	// False to abort and rollback.
@@ -801,7 +799,7 @@ func (m *BatchResponse) GetResponses() []ResponseUnion {
 	return nil
 }
 
-// An AdminSplitRequest is arguments to the AdminSplit() method. The
+// An AdminSplitRequest is the argument to the AdminSplit() method. The
 // existing range which contains RequestHeader.Key is split by
 // split_key. If split_key is not specified, then this method will
 // determine a split key that is roughly halfway through the
@@ -842,7 +840,7 @@ func (m *AdminSplitResponse) Reset()         { *m = AdminSplitResponse{} }
 func (m *AdminSplitResponse) String() string { return proto1.CompactTextString(m) }
 func (*AdminSplitResponse) ProtoMessage()    {}
 
-// An AdminMergeRequest is arguments to the AdminMerge() method. A
+// An AdminMergeRequest is the argument to the AdminMerge() method. A
 // merge is performed by calling AdminMerge on the left-hand range of
 // two consecutive ranges (i.e. the range which contains keys which
 // sort first). This range will be the subsuming range and the right

--- a/proto/api.proto
+++ b/proto/api.proto
@@ -135,7 +135,7 @@ message ResponseHeader {
   optional Transaction txn = 3;
 }
 
-// A GetRequest is arguments to the Get() method.
+// A GetRequest is the argument for the Get() method.
 message GetRequest {
   optional RequestHeader header = 1 [(gogoproto.nullable) = false, (gogoproto.embed) = true];
 }
@@ -147,9 +147,7 @@ message GetResponse {
   optional Value value = 2;
 }
 
-// A PutRequest is arguments to the Put() method. Note that to write
-// an empty value, the value parameter is still specified, but Bytes
-// is set to nil.
+// A PutRequest is the argument to the Put() method.
 message PutRequest {
   optional RequestHeader header = 1 [(gogoproto.nullable) = false, (gogoproto.embed) = true];
   optional Value value = 2 [(gogoproto.nullable) = false];
@@ -160,7 +158,7 @@ message PutResponse {
   optional ResponseHeader header = 1 [(gogoproto.nullable) = false, (gogoproto.embed) = true];
 }
 
-// A ConditionalPutRequest is arguments to the ConditionalPut() method.
+// A ConditionalPutRequest is the argument to the ConditionalPut() method.
 //
 // - Returns true and sets value if ExpValue equals existing value.
 // - If key doesn't exist and ExpValue is nil, sets value.
@@ -182,7 +180,7 @@ message ConditionalPutResponse {
   optional ResponseHeader header = 1 [(gogoproto.nullable) = false, (gogoproto.embed) = true];
 }
 
-// An IncrementRequest is arguments to the Increment() method. It
+// An IncrementRequest is the argument to the Increment() method. It
 // increments the value for key, and returns the new value. If no
 // value exists for a key, incrementing by 0 is not a noop, but will
 // create a zero value. IncrementRequest cannot be called on a key set
@@ -201,7 +199,7 @@ message IncrementResponse {
   optional int64 new_value = 2 [(gogoproto.nullable) = false];
 }
 
-// A DeleteRequest is arguments to the Delete() method.
+// A DeleteRequest is the argument to the Delete() method.
 message DeleteRequest {
   optional RequestHeader header = 1 [(gogoproto.nullable) = false, (gogoproto.embed) = true];
 }
@@ -211,7 +209,7 @@ message DeleteResponse {
   optional ResponseHeader header = 1 [(gogoproto.nullable) = false, (gogoproto.embed) = true];
 }
 
-// A DeleteRangeRequest is arguments to the DeleteRange method. It
+// A DeleteRangeRequest is the argument to the DeleteRange() method. It
 // specifies the range of keys to delete.
 message DeleteRangeRequest {
   optional RequestHeader header = 1 [(gogoproto.nullable) = false, (gogoproto.embed) = true];
@@ -228,7 +226,7 @@ message DeleteRangeResponse {
   optional int64 num_deleted = 2 [(gogoproto.nullable) = false];
 }
 
-// A ScanRequest is arguments to the Scan() method. It specifies the
+// A ScanRequest is the argument to the Scan() method. It specifies the
 // start and end keys for the scan and the maximum number of results.
 message ScanRequest {
   optional RequestHeader header = 1 [(gogoproto.nullable) = false, (gogoproto.embed) = true];
@@ -243,8 +241,8 @@ message ScanResponse {
   repeated KeyValue rows = 2 [(gogoproto.nullable) = false];
 }
 
-// An EndTransactionRequest is arguments to the EndTransaction() method.
-// It specifies whether to commit or roll back an extant transaction.
+// An EndTransactionRequest is the argument to the EndTransaction() method. It
+// specifies whether to commit or roll back an extant transaction.
 message EndTransactionRequest {
   optional RequestHeader header = 1 [(gogoproto.nullable) = false, (gogoproto.embed) = true];
   // False to abort and rollback.
@@ -327,7 +325,7 @@ message BatchResponse {
   repeated ResponseUnion responses = 2 [(gogoproto.nullable) = false];
 }
 
-// An AdminSplitRequest is arguments to the AdminSplit() method. The
+// An AdminSplitRequest is the argument to the AdminSplit() method. The
 // existing range which contains RequestHeader.Key is split by
 // split_key. If split_key is not specified, then this method will
 // determine a split key that is roughly halfway through the
@@ -358,7 +356,7 @@ message AdminSplitResponse {
   optional ResponseHeader header = 1 [(gogoproto.nullable) = false, (gogoproto.embed) = true];
 }
 
-// An AdminMergeRequest is arguments to the AdminMerge() method. A
+// An AdminMergeRequest is the argument to the AdminMerge() method. A
 // merge is performed by calling AdminMerge on the left-hand range of
 // two consecutive ranges (i.e. the range which contains keys which
 // sort first). This range will be the subsuming range and the right

--- a/storage/client_event_test.go
+++ b/storage/client_event_test.go
@@ -217,7 +217,7 @@ func TestMultiStoreEventFeed(t *testing.T) {
 			if err != nil {
 				return err
 			}
-			if a, e := val.GetInteger(), int64(5); a != e {
+			if a, e := mustGetInteger(val), int64(5); a != e {
 				return util.Errorf("expected aa = %d, got %d", e, a)
 			}
 		}

--- a/storage/client_raft_test.go
+++ b/storage/client_raft_test.go
@@ -39,6 +39,16 @@ import (
 	"github.com/coreos/etcd/raft"
 )
 
+// mustGetInteger decodes an int64 value from the bytes field of the receiver
+// and panics if the bytes field is not 0 or 8 bytes in length.
+func mustGetInteger(v *proto.Value) int64 {
+	i, err := v.GetInteger()
+	if err != nil {
+		panic(err)
+	}
+	return i
+}
+
 // TestStoreRecoverFromEngine verifies that the store recovers all ranges and their contents
 // after being stopped and recreated.
 func TestStoreRecoverFromEngine(t *testing.T) {
@@ -59,7 +69,7 @@ func TestStoreRecoverFromEngine(t *testing.T) {
 		if err != nil {
 			t.Fatal(err)
 		}
-		return resp.Value.GetInteger()
+		return mustGetInteger(resp.Value)
 	}
 	validate := func(store *storage.Store) {
 		if val := get(store, raftID, key1); val != 13 {
@@ -239,7 +249,7 @@ func TestReplicateRange(t *testing.T) {
 		if err := mtc.stores[1].ExecuteCmd(context.Background(), proto.Call{Args: getArgs, Reply: getResp}); err != nil {
 			return util.Errorf("failed to read data")
 		}
-		if v := getResp.Value.GetInteger(); v != 5 {
+		if v := mustGetInteger(getResp.Value); v != 5 {
 			return util.Errorf("failed to read correct data: %d", v)
 		}
 		return nil
@@ -310,7 +320,7 @@ func TestRestoreReplicas(t *testing.T) {
 		if err := mtc.stores[1].ExecuteCmd(context.Background(), proto.Call{Args: getArgs, Reply: getResp}); err != nil {
 			return false
 		}
-		return getResp.Value.GetInteger() == 39
+		return mustGetInteger(getResp.Value) == 39
 	}, 1*time.Second); err != nil {
 		t.Fatal(err)
 	}
@@ -456,9 +466,9 @@ func TestReplicateAfterTruncation(t *testing.T) {
 			return false
 		}
 		if log.V(1) {
-			log.Infof("read value %d", getResp.Value.GetInteger())
+			log.Infof("read value %d", mustGetInteger(getResp.Value))
 		}
-		return getResp.Value.GetInteger() == 16
+		return mustGetInteger(getResp.Value) == 16
 	}, 1*time.Second); err != nil {
 		t.Fatal(err)
 	}
@@ -484,8 +494,8 @@ func TestReplicateAfterTruncation(t *testing.T) {
 		if err := mtc.stores[1].ExecuteCmd(context.Background(), proto.Call{Args: getArgs, Reply: getResp}); err != nil {
 			return false
 		}
-		log.Infof("read value %d", getResp.Value.GetInteger())
-		return getResp.Value.GetInteger() == 39
+		log.Infof("read value %d", mustGetInteger(getResp.Value))
+		return mustGetInteger(getResp.Value) == 39
 	}, 1*time.Second); err != nil {
 		t.Fatal(err)
 	}
@@ -550,7 +560,7 @@ func TestProgressWithDownNode(t *testing.T) {
 				if err != nil {
 					return err
 				}
-				values = append(values, val.GetInteger())
+				values = append(values, mustGetInteger(val))
 			}
 			if !reflect.DeepEqual(expected, values) {
 				return util.Errorf("expected %v, got %v", expected, values)
@@ -601,7 +611,7 @@ func TestReplicateAddAndRemove(t *testing.T) {
 					if err != nil {
 						return err
 					}
-					values = append(values, val.GetInteger())
+					values = append(values, mustGetInteger(val))
 				}
 				if !reflect.DeepEqual(expected, values) {
 					return util.Errorf("expected %v, got %v", expected, values)
@@ -723,9 +733,9 @@ func TestReplicateAfterSplit(t *testing.T) {
 			return false
 		}
 		if log.V(1) {
-			log.Infof("read value %d", getResp.Value.GetInteger())
+			log.Infof("read value %d", mustGetInteger(getResp.Value))
 		}
-		return getResp.Value.GetInteger() == 11
+		return mustGetInteger(getResp.Value) == 11
 	}, 1*time.Second); err != nil {
 		t.Fatal(err)
 	}

--- a/storage/client_range_test.go
+++ b/storage/client_range_test.go
@@ -69,7 +69,7 @@ func TestRangeCommandClockUpdate(t *testing.T) {
 			if err != nil {
 				return err
 			}
-			values = append(values, val.GetInteger())
+			values = append(values, mustGetInteger(val))
 		}
 		if !reflect.DeepEqual(values, []int64{5, 5, 5}) {
 			return util.Errorf("expected (5, 5, 5), got %v", values)
@@ -146,7 +146,7 @@ func TestRejectFutureCommand(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if v := val.GetInteger(); v != 15 {
+	if v := mustGetInteger(val); v != 15 {
 		t.Errorf("expected 15, got %v", v)
 	}
 }

--- a/storage/engine/mvcc.go
+++ b/storage/engine/mvcc.go
@@ -738,14 +738,10 @@ func MVCCIncrement(engine Engine, ms *proto.MVCCStats, key proto.Key, timestamp 
 		return 0, err
 	}
 
-	if value != nil {
-		if n := len(value.Bytes); n != 0 && n != 8 {
-			return 0, util.Errorf("cannot increment key %q which does not contain an integer value: %+v",
-				key, *value)
-		}
+	int64Val, err := value.GetInteger()
+	if err != nil {
+		return 0, util.Errorf("key %q does not contain an integer value", key)
 	}
-
-	int64Val := value.GetInteger()
 
 	// Check for overflow and underflow.
 	if encoding.WillOverflow(int64Val, inc) {


### PR DESCRIPTION
Added Value.MustGetInteger() which maintains the previous behavior of
GetInteger() and panics on being unable to decode the value as an
integer.

Miscellaneous comment fixes.
