### PR TITLE
Remove error return value from ExecuteCmd

### DIFF
--- a/client/client_test.go
+++ b/client/client_test.go
@@ -175,7 +175,7 @@ func TestClientRetryNonTxn(t *testing.T) {
 					}
 					close(doneCall)
 					if err != nil {
-						t.Fatalf("%d: expected success on non-txn call to %s; got %s", i, err, test.args.Method())
+						t.Fatalf("%d: expected success on non-txn call to %s; got %s", i, test.args.Method(), err)
 					}
 				}()
 				sender.wait()

--- a/storage/client_merge_test.go
+++ b/storage/client_merge_test.go
@@ -47,7 +47,8 @@ func adminMergeArgs(key []byte, raftID proto.RaftID, storeID proto.StoreID) (*pr
 
 func createSplitRanges(store *storage.Store) (*proto.RangeDescriptor, *proto.RangeDescriptor, error) {
 	args, reply := adminSplitArgs(proto.KeyMin, []byte("b"), 1, store.StoreID())
-	if err := store.ExecuteCmd(context.Background(), proto.Call{Args: args, Reply: reply}); err != nil {
+	store.ExecuteCmd(context.Background(), proto.Call{Args: args, Reply: reply})
+	if err := reply.GoError(); err != nil {
 		return nil, nil, err
 	}
 
@@ -75,8 +76,8 @@ func TestStoreRangeMergeTwoEmptyRanges(t *testing.T) {
 
 	// Merge the b range back into the a range.
 	args, reply := adminMergeArgs(proto.KeyMin, 1, store.StoreID())
-	err = store.ExecuteCmd(context.Background(), proto.Call{Args: args, Reply: reply})
-	if err != nil {
+	store.ExecuteCmd(context.Background(), proto.Call{Args: args, Reply: reply})
+	if err = reply.GoError(); err != nil {
 		t.Fatal(err)
 	}
 
@@ -105,29 +106,34 @@ func TestStoreRangeMergeWithData(t *testing.T) {
 
 	// Write some values left and right of the proposed split key.
 	pArgs, pReply := putArgs([]byte("aaa"), content, aDesc.RaftID, store.StoreID())
-	if err := store.ExecuteCmd(context.Background(), proto.Call{Args: pArgs, Reply: pReply}); err != nil {
+	store.ExecuteCmd(context.Background(), proto.Call{Args: pArgs, Reply: pReply})
+	if err := pReply.GoError(); err != nil {
 		t.Fatal(err)
 	}
 	pArgs, pReply = putArgs([]byte("ccc"), content, bDesc.RaftID, store.StoreID())
-	if err := store.ExecuteCmd(context.Background(), proto.Call{Args: pArgs, Reply: pReply}); err != nil {
+	store.ExecuteCmd(context.Background(), proto.Call{Args: pArgs, Reply: pReply})
+	if err := pReply.GoError(); err != nil {
 		t.Fatal(err)
 	}
 
 	// Confirm the values are there.
 	gArgs, gReply := getArgs([]byte("aaa"), aDesc.RaftID, store.StoreID())
-	if err := store.ExecuteCmd(context.Background(), proto.Call{Args: gArgs, Reply: gReply}); err != nil ||
+	store.ExecuteCmd(context.Background(), proto.Call{Args: gArgs, Reply: gReply})
+	if err := gReply.GoError(); err != nil ||
 		!bytes.Equal(gReply.Value.Bytes, content) {
 		t.Fatal(err)
 	}
 	gArgs, gReply = getArgs([]byte("ccc"), bDesc.RaftID, store.StoreID())
-	if err := store.ExecuteCmd(context.Background(), proto.Call{Args: gArgs, Reply: gReply}); err != nil ||
+	store.ExecuteCmd(context.Background(), proto.Call{Args: gArgs, Reply: gReply})
+	if err := gReply.GoError(); err != nil ||
 		!bytes.Equal(gReply.Value.Bytes, content) {
 		t.Fatal(err)
 	}
 
 	// Merge the b range back into the a range.
 	args, reply := adminMergeArgs(proto.KeyMin, 1, store.StoreID())
-	if err := store.ExecuteCmd(context.Background(), proto.Call{Args: args, Reply: reply}); err != nil {
+	store.ExecuteCmd(context.Background(), proto.Call{Args: args, Reply: reply})
+	if err := reply.GoError(); err != nil {
 		t.Fatal(err)
 	}
 
@@ -154,33 +160,39 @@ func TestStoreRangeMergeWithData(t *testing.T) {
 
 	// Try to get values from after the merge.
 	gArgs, gReply = getArgs([]byte("aaa"), rangeA.Desc().RaftID, store.StoreID())
-	if err := store.ExecuteCmd(context.Background(), proto.Call{Args: gArgs, Reply: gReply}); err != nil ||
+	store.ExecuteCmd(context.Background(), proto.Call{Args: gArgs, Reply: gReply})
+	if err := gReply.GoError(); err != nil ||
 		!bytes.Equal(gReply.Value.Bytes, content) {
 		t.Fatal(err)
 	}
 	gArgs, gReply = getArgs([]byte("ccc"), rangeB.Desc().RaftID, store.StoreID())
-	if err := store.ExecuteCmd(context.Background(), proto.Call{Args: gArgs, Reply: gReply}); err != nil ||
+	store.ExecuteCmd(context.Background(), proto.Call{Args: gArgs, Reply: gReply})
+	if err := gReply.GoError(); err != nil ||
 		!bytes.Equal(gReply.Value.Bytes, content) {
 		t.Fatal(err)
 	}
 
 	// Put new values after the merge on both sides.
 	pArgs, pReply = putArgs([]byte("aaaa"), content, rangeA.Desc().RaftID, store.StoreID())
-	if err = store.ExecuteCmd(context.Background(), proto.Call{Args: pArgs, Reply: pReply}); err != nil {
+	store.ExecuteCmd(context.Background(), proto.Call{Args: pArgs, Reply: pReply})
+	if err = pReply.GoError(); err != nil {
 		t.Fatal(err)
 	}
 	pArgs, pReply = putArgs([]byte("cccc"), content, rangeB.Desc().RaftID, store.StoreID())
-	if err = store.ExecuteCmd(context.Background(), proto.Call{Args: pArgs, Reply: pReply}); err != nil {
+	store.ExecuteCmd(context.Background(), proto.Call{Args: pArgs, Reply: pReply})
+	if err = pReply.GoError(); err != nil {
 		t.Fatal(err)
 	}
 
 	// Try to get the newly placed values.
 	gArgs, gReply = getArgs([]byte("aaaa"), rangeA.Desc().RaftID, store.StoreID())
-	if err := store.ExecuteCmd(context.Background(), proto.Call{Args: gArgs, Reply: gReply}); err != nil || !bytes.Equal(gReply.Value.Bytes, content) {
+	store.ExecuteCmd(context.Background(), proto.Call{Args: gArgs, Reply: gReply})
+	if err := gReply.GoError(); err != nil || !bytes.Equal(gReply.Value.Bytes, content) {
 		t.Fatal(err)
 	}
 	gArgs, gReply = getArgs([]byte("cccc"), rangeA.Desc().RaftID, store.StoreID())
-	if err := store.ExecuteCmd(context.Background(), proto.Call{Args: gArgs, Reply: gReply}); err != nil ||
+	store.ExecuteCmd(context.Background(), proto.Call{Args: gArgs, Reply: gReply})
+	if err := gReply.GoError(); err != nil ||
 		!bytes.Equal(gReply.Value.Bytes, content) {
 		t.Fatal(err)
 	}
@@ -194,7 +206,8 @@ func TestStoreRangeMergeLastRange(t *testing.T) {
 
 	// Merge last range.
 	args, reply := adminMergeArgs(proto.KeyMin, 1, store.StoreID())
-	if err := store.ExecuteCmd(context.Background(), proto.Call{Args: args, Reply: reply}); err != nil {
+	store.ExecuteCmd(context.Background(), proto.Call{Args: args, Reply: reply})
+	if err := reply.GoError(); err != nil {
 		t.Fatalf("merge of last range should be a noop: %s", err)
 	}
 }
@@ -208,11 +221,13 @@ func TestStoreRangeMergeNonConsecutive(t *testing.T) {
 
 	// Split into 3 ranges
 	argsSplit, replySplit := adminSplitArgs(proto.KeyMin, []byte("d"), 1, store.StoreID())
-	if err := store.ExecuteCmd(context.Background(), proto.Call{Args: argsSplit, Reply: replySplit}); err != nil {
+	store.ExecuteCmd(context.Background(), proto.Call{Args: argsSplit, Reply: replySplit})
+	if err := replySplit.GoError(); err != nil {
 		t.Fatalf("Can't split range %s", err)
 	}
 	argsSplit, replySplit = adminSplitArgs(proto.KeyMin, []byte("b"), 1, store.StoreID())
-	if err := store.ExecuteCmd(context.Background(), proto.Call{Args: argsSplit, Reply: replySplit}); err != nil {
+	store.ExecuteCmd(context.Background(), proto.Call{Args: argsSplit, Reply: replySplit})
+	if err := replySplit.GoError(); err != nil {
 		t.Fatalf("Can't split range %s", err)
 	}
 

--- a/storage/client_split_test.go
+++ b/storage/client_split_test.go
@@ -82,8 +82,8 @@ func TestStoreRangeSplitAtIllegalKeys(t *testing.T) {
 		keys.MakeKey(keys.ConfigZonePrefix, []byte("a")),
 	} {
 		args, reply := adminSplitArgs(proto.KeyMin, key, 1, store.StoreID())
-		err := store.ExecuteCmd(context.Background(), proto.Call{Args: args, Reply: reply})
-		if err == nil {
+		store.ExecuteCmd(context.Background(), proto.Call{Args: args, Reply: reply})
+		if err := reply.GoError(); err == nil {
 			t.Fatalf("%q: split succeeded unexpectedly", key)
 		}
 	}
@@ -100,16 +100,19 @@ func TestStoreRangeSplitAtRangeBounds(t *testing.T) {
 	defer stopper.Stop()
 
 	args, reply := adminSplitArgs(proto.KeyMin, []byte("a"), 1, store.StoreID())
-	if err := store.ExecuteCmd(context.Background(), proto.Call{Args: args, Reply: reply}); err != nil {
+	store.ExecuteCmd(context.Background(), proto.Call{Args: args, Reply: reply})
+	if err := reply.GoError(); err != nil {
 		t.Fatal(err)
 	}
 	// This second split will try to split at end of first split range.
-	if err := store.ExecuteCmd(context.Background(), proto.Call{Args: args, Reply: reply}); err == nil {
+	store.ExecuteCmd(context.Background(), proto.Call{Args: args, Reply: reply})
+	if err := reply.GoError(); err == nil {
 		t.Fatalf("split succeeded unexpectedly")
 	}
 	// Now try to split at start of new range.
 	args, reply = adminSplitArgs(proto.KeyMin, []byte("a"), 2, store.StoreID())
-	if err := store.ExecuteCmd(context.Background(), proto.Call{Args: args, Reply: reply}); err == nil {
+	store.ExecuteCmd(context.Background(), proto.Call{Args: args, Reply: reply})
+	if err := reply.GoError(); err == nil {
 		t.Fatalf("split succeeded unexpectedly")
 	}
 }
@@ -129,8 +132,8 @@ func TestStoreRangeSplitConcurrent(t *testing.T) {
 	for i := int32(0); i < concurrentCount; i++ {
 		go func() {
 			args, reply := adminSplitArgs(proto.KeyMin, []byte("a"), 1, store.StoreID())
-			err := store.ExecuteCmd(context.Background(), proto.Call{Args: args, Reply: reply})
-			if err != nil {
+			store.ExecuteCmd(context.Background(), proto.Call{Args: args, Reply: reply})
+			if err := reply.GoError(); err != nil {
 				if matched, regexpErr := regexp.MatchString("range is already split at key", err.Error()); !matched || regexpErr != nil {
 					t.Errorf("error %s didn't match regex %v", err, regexpErr)
 				} else {
@@ -159,11 +162,13 @@ func TestStoreRangeSplit(t *testing.T) {
 
 	// First, write some values left and right of the proposed split key.
 	pArgs, pReply := putArgs([]byte("c"), content, raftID, store.StoreID())
-	if err := store.ExecuteCmd(context.Background(), proto.Call{Args: pArgs, Reply: pReply}); err != nil {
+	store.ExecuteCmd(context.Background(), proto.Call{Args: pArgs, Reply: pReply})
+	if err := pReply.GoError(); err != nil {
 		t.Fatal(err)
 	}
 	pArgs, pReply = putArgs([]byte("x"), content, raftID, store.StoreID())
-	if err := store.ExecuteCmd(context.Background(), proto.Call{Args: pArgs, Reply: pReply}); err != nil {
+	store.ExecuteCmd(context.Background(), proto.Call{Args: pArgs, Reply: pReply})
+	if err := pReply.GoError(); err != nil {
 		t.Fatal(err)
 	}
 
@@ -172,12 +177,14 @@ func TestStoreRangeSplit(t *testing.T) {
 	// the key.
 	lIncArgs, lIncReply := incrementArgs([]byte("apoptosis"), 100, raftID, store.StoreID())
 	lIncArgs.CmdID = proto.ClientCmdID{WallTime: 123, Random: 423}
-	if err := store.ExecuteCmd(context.Background(), proto.Call{Args: lIncArgs, Reply: lIncReply}); err != nil {
+	store.ExecuteCmd(context.Background(), proto.Call{Args: lIncArgs, Reply: lIncReply})
+	if err := lIncReply.GoError(); err != nil {
 		t.Fatal(err)
 	}
 	rIncArgs, rIncReply := incrementArgs([]byte("wobble"), 10, raftID, store.StoreID())
 	rIncArgs.CmdID = proto.ClientCmdID{WallTime: 12, Random: 42}
-	if err := store.ExecuteCmd(context.Background(), proto.Call{Args: rIncArgs, Reply: rIncReply}); err != nil {
+	store.ExecuteCmd(context.Background(), proto.Call{Args: rIncArgs, Reply: rIncReply})
+	if err := rIncReply.GoError(); err != nil {
 		t.Fatal(err)
 	}
 
@@ -190,7 +197,8 @@ func TestStoreRangeSplit(t *testing.T) {
 
 	// Split the range.
 	args, reply := adminSplitArgs(proto.KeyMin, splitKey, 1, store.StoreID())
-	if err := store.ExecuteCmd(context.Background(), proto.Call{Args: args, Reply: reply}); err != nil {
+	store.ExecuteCmd(context.Background(), proto.Call{Args: args, Reply: reply})
+	if err := reply.GoError(); err != nil {
 		t.Fatal(err)
 	}
 
@@ -212,12 +220,14 @@ func TestStoreRangeSplit(t *testing.T) {
 
 	// Try to get values from both left and right of where the split happened.
 	gArgs, gReply := getArgs([]byte("c"), raftID, store.StoreID())
-	if err := store.ExecuteCmd(context.Background(), proto.Call{Args: gArgs, Reply: gReply}); err != nil ||
+	store.ExecuteCmd(context.Background(), proto.Call{Args: gArgs, Reply: gReply})
+	if err := gReply.GoError(); err != nil ||
 		!bytes.Equal(gReply.Value.Bytes, content) {
 		t.Fatal(err)
 	}
 	gArgs, gReply = getArgs([]byte("x"), newRng.Desc().RaftID, store.StoreID())
-	if err := store.ExecuteCmd(context.Background(), proto.Call{Args: gArgs, Reply: gReply}); err != nil ||
+	store.ExecuteCmd(context.Background(), proto.Call{Args: gArgs, Reply: gReply})
+	if err := gReply.GoError(); err != nil ||
 		!bytes.Equal(gReply.Value.Bytes, content) {
 		t.Fatal(err)
 	}
@@ -225,7 +235,8 @@ func TestStoreRangeSplit(t *testing.T) {
 	// Send out an increment request copied from above (same ClientCmdID) which
 	// remains in the old range.
 	lIncReply = &proto.IncrementResponse{}
-	if err := store.ExecuteCmd(context.Background(), proto.Call{Args: lIncArgs, Reply: lIncReply}); err != nil {
+	store.ExecuteCmd(context.Background(), proto.Call{Args: lIncArgs, Reply: lIncReply})
+	if err := lIncReply.GoError(); err != nil {
 		t.Fatal(err)
 	}
 	if lIncReply.NewValue != 100 {
@@ -236,7 +247,8 @@ func TestStoreRangeSplit(t *testing.T) {
 	// now to the newly created range (which should hold that key).
 	rIncArgs.RequestHeader.RaftID = newRng.Desc().RaftID
 	rIncReply = &proto.IncrementResponse{}
-	if err := store.ExecuteCmd(context.Background(), proto.Call{Args: rIncArgs, Reply: rIncReply}); err != nil {
+	store.ExecuteCmd(context.Background(), proto.Call{Args: rIncArgs, Reply: rIncReply})
+	if err := rIncReply.GoError(); err != nil {
 		t.Fatal(err)
 	}
 	if rIncReply.NewValue != 10 {
@@ -281,7 +293,8 @@ func TestStoreRangeSplitStats(t *testing.T) {
 
 	// Split the range at the first user key.
 	args, reply := adminSplitArgs(proto.KeyMin, proto.Key("\x01"), 1, store.StoreID())
-	if err := store.ExecuteCmd(context.Background(), proto.Call{Args: args, Reply: reply}); err != nil {
+	store.ExecuteCmd(context.Background(), proto.Call{Args: args, Reply: reply})
+	if err := reply.GoError(); err != nil {
 		t.Fatal(err)
 	}
 	// Verify empty range has empty stats.
@@ -299,7 +312,8 @@ func TestStoreRangeSplitStats(t *testing.T) {
 		val := util.RandBytes(src, int(src.Int31n(1<<8)))
 		pArgs, pReply := putArgs(key, val, rng.Desc().RaftID, store.StoreID())
 		pArgs.Timestamp = store.Clock().Now()
-		if err := store.ExecuteCmd(context.Background(), proto.Call{Args: pArgs, Reply: pReply}); err != nil {
+		store.ExecuteCmd(context.Background(), proto.Call{Args: pArgs, Reply: pReply})
+		if err := pReply.GoError(); err != nil {
 			t.Fatal(err)
 		}
 	}
@@ -311,7 +325,8 @@ func TestStoreRangeSplitStats(t *testing.T) {
 
 	// Split the range at approximate halfway point ("Z" in string "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz").
 	args, reply = adminSplitArgs(proto.Key("\x01"), proto.Key("Z"), rng.Desc().RaftID, store.StoreID())
-	if err := store.ExecuteCmd(context.Background(), proto.Call{Args: args, Reply: reply}); err != nil {
+	store.ExecuteCmd(context.Background(), proto.Call{Args: args, Reply: reply})
+	if err := reply.GoError(); err != nil {
 		t.Fatal(err)
 	}
 
@@ -358,7 +373,8 @@ func fillRange(store *storage.Store, raftID proto.RaftID, prefix proto.Key, byte
 		val := util.RandBytes(src, int(src.Int31n(1<<8)))
 		pArgs, pReply := putArgs(key, val, raftID, store.StoreID())
 		pArgs.Timestamp = store.Clock().Now()
-		if err := store.ExecuteCmd(context.Background(), proto.Call{Args: pArgs, Reply: pReply}); err != nil {
+		store.ExecuteCmd(context.Background(), proto.Call{Args: pArgs, Reply: pReply})
+		if err := pReply.GoError(); err != nil {
 			t.Fatal(err)
 		}
 	}

--- a/storage/client_status_test.go
+++ b/storage/client_status_test.go
@@ -42,7 +42,8 @@ import (
 func compareStoreStatus(t *testing.T, store *storage.Store, expectedStoreStatus *proto.StoreStatus, testNumber int) *proto.StoreStatus {
 	storeStatusKey := keys.StoreStatusKey(int32(store.Ident.StoreID))
 	gArgs, gReply := getArgs(storeStatusKey, 1, store.Ident.StoreID)
-	if err := store.ExecuteCmd(context.Background(), proto.Call{Args: gArgs, Reply: gReply}); err != nil {
+	store.ExecuteCmd(context.Background(), proto.Call{Args: gArgs, Reply: gReply})
+	if err := gReply.GoError(); err != nil {
 		t.Fatalf("%v: failure getting store status: %s", testNumber, err)
 	}
 	if gReply.Value == nil {
@@ -119,7 +120,8 @@ func TestStoreStatus(t *testing.T) {
 	// Perform a read from the range to ensure that the raft election has
 	// completed.  We do not expect a value to be present.
 	gArgs, gReply := getArgs([]byte("a"), rng.Desc().RaftID, store.StoreID())
-	if err := store.ExecuteCmd(context.Background(), proto.Call{Args: gArgs, Reply: gReply}); err != nil {
+	store.ExecuteCmd(context.Background(), proto.Call{Args: gArgs, Reply: gReply})
+	if err := gReply.GoError(); err != nil {
 		t.Fatal(err)
 	}
 
@@ -146,11 +148,13 @@ func TestStoreStatus(t *testing.T) {
 
 	// Write some values left and right of the proposed split key.
 	pArgs, pReply := putArgs([]byte("a"), content, rng.Desc().RaftID, store.StoreID())
-	if err := store.ExecuteCmd(context.Background(), proto.Call{Args: pArgs, Reply: pReply}); err != nil {
+	store.ExecuteCmd(context.Background(), proto.Call{Args: pArgs, Reply: pReply})
+	if err := pReply.GoError(); err != nil {
 		t.Fatal(err)
 	}
 	pArgs, pReply = putArgs([]byte("c"), content, rng.Desc().RaftID, store.StoreID())
-	if err := store.ExecuteCmd(context.Background(), proto.Call{Args: pArgs, Reply: pReply}); err != nil {
+	store.ExecuteCmd(context.Background(), proto.Call{Args: pArgs, Reply: pReply})
+	if err := pReply.GoError(); err != nil {
 		t.Fatal(err)
 	}
 
@@ -176,7 +180,8 @@ func TestStoreStatus(t *testing.T) {
 
 	// Split the range.
 	args, reply := adminSplitArgs(proto.KeyMin, splitKey, rng.Desc().RaftID, store.StoreID())
-	if err := store.ExecuteCmd(context.Background(), proto.Call{Args: args, Reply: reply}); err != nil {
+	store.ExecuteCmd(context.Background(), proto.Call{Args: args, Reply: reply})
+	if err := reply.GoError(); err != nil {
 		t.Fatal(err)
 	}
 
@@ -203,12 +208,14 @@ func TestStoreStatus(t *testing.T) {
 	// Write some values left and right of the split key.
 	rng = store.LookupRange([]byte("aa"), nil)
 	pArgs, pReply = putArgs([]byte("aa"), content, rng.Desc().RaftID, store.StoreID())
-	if err := store.ExecuteCmd(context.Background(), proto.Call{Args: pArgs, Reply: pReply}); err != nil {
+	store.ExecuteCmd(context.Background(), proto.Call{Args: pArgs, Reply: pReply})
+	if err := pReply.GoError(); err != nil {
 		t.Fatal(err)
 	}
 	rng2 := store.LookupRange([]byte("cc"), nil)
 	pArgs, pReply = putArgs([]byte("cc"), content, rng2.Desc().RaftID, store.StoreID())
-	if err := store.ExecuteCmd(context.Background(), proto.Call{Args: pArgs, Reply: pReply}); err != nil {
+	store.ExecuteCmd(context.Background(), proto.Call{Args: pArgs, Reply: pReply})
+	if err := pReply.GoError(); err != nil {
 		t.Fatal(err)
 	}
 

--- a/storage/range_test.go
+++ b/storage/range_test.go
@@ -2401,7 +2401,7 @@ func TestInternalRangeLookup(t *testing.T) {
 		proto.MakeKey(keys.Meta1Prefix, proto.KeyMax),
 	} {
 		reply := proto.InternalRangeLookupResponse{}
-		if err := tc.store.ExecuteCmd(context.Background(), proto.Call{
+		tc.store.ExecuteCmd(context.Background(), proto.Call{
 			Args: &proto.InternalRangeLookupRequest{
 				RequestHeader: proto.RequestHeader{
 					RaftID: 1,
@@ -2410,7 +2410,8 @@ func TestInternalRangeLookup(t *testing.T) {
 				MaxRanges: 1,
 			},
 			Reply: &reply,
-		}); err != nil {
+		})
+		if err := reply.GoError(); err != nil {
 			t.Fatal(err)
 		}
 		expected := []proto.RangeDescriptor{*tc.rng.Desc()}

--- a/storage/store_test.go
+++ b/storage/store_test.go
@@ -810,11 +810,9 @@ func TestStoreResolveWriteIntent(t *testing.T) {
 				t.Errorf("expected pushee to be aborted; got %s", txn.Status)
 			}
 		} else {
-			rErr, ok := err.(*proto.TransactionPushError)
-			if !ok {
+			if rErr, ok := err.(*proto.TransactionPushError); !ok {
 				t.Errorf("expected txn push error; got %s", err)
-			}
-			if !bytes.Equal(rErr.PusheeTxn.ID, pushee.ID) {
+			} else if !bytes.Equal(rErr.PusheeTxn.ID, pushee.ID) {
 				t.Errorf("expected txn to match pushee %q; got %s", pushee.ID, rErr)
 			}
 			// Trying again should fail again.

--- a/storage/store_test.go
+++ b/storage/store_test.go
@@ -135,9 +135,7 @@ func (db *testSender) sendOne(call proto.Call) {
 			call.Reply.Header().SetGoError(util.Errorf("own replica missing in range"))
 		}
 		header.Replica = *replica
-		if err := db.store.ExecuteCmd(context.Background(), call); err != nil {
-			call.Reply.Header().SetGoError(err)
-		}
+		db.store.ExecuteCmd(context.Background(), call)
 	} else {
 		call.Reply.Header().SetGoError(proto.NewRangeKeyMismatchError(header.Key, header.EndKey, nil))
 	}
@@ -455,11 +453,13 @@ func TestStoreExecuteCmd(t *testing.T) {
 	gArgs, gReply := getArgs([]byte("a"), 1, store.StoreID())
 
 	// Try a successful get request.
-	if err := store.ExecuteCmd(context.Background(), proto.Call{Args: gArgs, Reply: gReply}); err != nil {
+	store.ExecuteCmd(context.Background(), proto.Call{Args: gArgs, Reply: gReply})
+	if err := gReply.GoError(); err != nil {
 		t.Fatal(err)
 	}
 	pArgs, pReply := putArgs([]byte("a"), []byte("aaa"), 1, store.StoreID())
-	if err := store.ExecuteCmd(context.Background(), proto.Call{Args: pArgs, Reply: pReply}); err != nil {
+	store.ExecuteCmd(context.Background(), proto.Call{Args: pArgs, Reply: pReply})
+	if err := pReply.GoError(); err != nil {
 		t.Fatal(err)
 	}
 }
@@ -474,41 +474,48 @@ func TestStoreVerifyKeys(t *testing.T) {
 
 	// Start with a too-long key on a get.
 	gArgs, gReply := getArgs(tooLongKey, 1, store.StoreID())
-	if err := store.ExecuteCmd(context.Background(), proto.Call{Args: gArgs, Reply: gReply}); err == nil {
+	store.ExecuteCmd(context.Background(), proto.Call{Args: gArgs, Reply: gReply})
+	if err := gReply.GoError(); err == nil {
 		t.Fatal("expected error for key too long")
 	}
 	// Try a start key == KeyMax.
 	gArgs.Key = proto.KeyMax
-	if err := store.ExecuteCmd(context.Background(), proto.Call{Args: gArgs, Reply: gReply}); err == nil {
+	store.ExecuteCmd(context.Background(), proto.Call{Args: gArgs, Reply: gReply})
+	if err := gReply.GoError(); err == nil {
 		t.Fatal("expected error for start key == KeyMax")
 	}
 	// Try a get with an end key specified (get requires only a start key and should fail).
 	gArgs.EndKey = proto.KeyMax
-	if err := store.ExecuteCmd(context.Background(), proto.Call{Args: gArgs, Reply: gReply}); err == nil {
+	store.ExecuteCmd(context.Background(), proto.Call{Args: gArgs, Reply: gReply})
+	if err := gReply.GoError(); err == nil {
 		t.Fatal("expected error for end key specified on a non-range-based operation")
 	}
 	// Try a scan with too-long EndKey.
 	sArgs, sReply := scanArgs(proto.KeyMin, tooLongKey, 1, store.StoreID())
-	if err := store.ExecuteCmd(context.Background(), proto.Call{Args: sArgs, Reply: sReply}); err == nil {
+	store.ExecuteCmd(context.Background(), proto.Call{Args: sArgs, Reply: sReply})
+	if err := sReply.GoError(); err == nil {
 		t.Fatal("expected error for end key too long")
 	}
 	// Try a scan with end key < start key.
 	sArgs.Key = []byte("b")
 	sArgs.EndKey = []byte("a")
-	if err := store.ExecuteCmd(context.Background(), proto.Call{Args: sArgs, Reply: sReply}); err == nil {
+	store.ExecuteCmd(context.Background(), proto.Call{Args: sArgs, Reply: sReply})
+	if err := sReply.GoError(); err == nil {
 		t.Fatal("expected error for end key < start")
 	}
 	// Try a scan with start key == end key.
 	sArgs.Key = []byte("a")
 	sArgs.EndKey = sArgs.Key
-	if err := store.ExecuteCmd(context.Background(), proto.Call{Args: sArgs, Reply: sReply}); err == nil {
+	store.ExecuteCmd(context.Background(), proto.Call{Args: sArgs, Reply: sReply})
+	if err := sReply.GoError(); err == nil {
 		t.Fatal("expected error for start == end key")
 	}
 	// Try a put to meta2 key which would otherwise exceed maximum key
 	// length, but is accepted because of the meta prefix.
 	meta2KeyMax := keys.MakeKey(keys.Meta2Prefix, proto.KeyMax)
 	pArgs, pReply := putArgs(meta2KeyMax, []byte("value"), 1, store.StoreID())
-	if err := store.ExecuteCmd(context.Background(), proto.Call{Args: pArgs, Reply: pReply}); err != nil {
+	store.ExecuteCmd(context.Background(), proto.Call{Args: pArgs, Reply: pReply})
+	if err := pReply.GoError(); err != nil {
 		t.Fatalf("unexpected error on put to meta2 value: %s", err)
 	}
 	// Try to put a range descriptor record for a start key which is
@@ -516,7 +523,8 @@ func TestStoreVerifyKeys(t *testing.T) {
 	key := append([]byte{}, proto.KeyMax...)
 	key[len(key)-1] = 0x01
 	pArgs, pReply = putArgs(keys.RangeDescriptorKey(key), []byte("value"), 1, store.StoreID())
-	if err := store.ExecuteCmd(context.Background(), proto.Call{Args: pArgs, Reply: pReply}); err != nil {
+	store.ExecuteCmd(context.Background(), proto.Call{Args: pArgs, Reply: pReply})
+	if err := pReply.GoError(); err != nil {
 		t.Fatalf("unexpected error on put to range descriptor for KeyMax value: %s", err)
 	}
 	// Try a put to txn record for a meta2 key (note that this doesn't
@@ -524,7 +532,8 @@ func TestStoreVerifyKeys(t *testing.T) {
 	// but are instead manipulated only through txn methods).
 	pArgs, pReply = putArgs(keys.TransactionKey(meta2KeyMax, []byte(util.NewUUID4())),
 		[]byte("value"), 1, store.StoreID())
-	if err := store.ExecuteCmd(context.Background(), proto.Call{Args: pArgs, Reply: pReply}); err != nil {
+	store.ExecuteCmd(context.Background(), proto.Call{Args: pArgs, Reply: pReply})
+	if err := pReply.GoError(); err != nil {
 		t.Fatalf("unexpected error on put to txn meta2 value: %s", err)
 	}
 }
@@ -537,8 +546,8 @@ func TestStoreExecuteCmdUpdateTime(t *testing.T) {
 	args, reply := getArgs([]byte("a"), 1, store.StoreID())
 	args.Timestamp = store.ctx.Clock.Now()
 	args.Timestamp.WallTime += (100 * time.Millisecond).Nanoseconds()
-	err := store.ExecuteCmd(context.Background(), proto.Call{Args: args, Reply: reply})
-	if err != nil {
+	store.ExecuteCmd(context.Background(), proto.Call{Args: args, Reply: reply})
+	if err := reply.GoError(); err != nil {
 		t.Fatal(err)
 	}
 	ts := store.ctx.Clock.Timestamp()
@@ -557,8 +566,8 @@ func TestStoreExecuteCmdWithZeroTime(t *testing.T) {
 
 	// Set clock to time 1.
 	mc.Set(1)
-	err := store.ExecuteCmd(context.Background(), proto.Call{Args: args, Reply: reply})
-	if err != nil {
+	store.ExecuteCmd(context.Background(), proto.Call{Args: args, Reply: reply})
+	if err := reply.GoError(); err != nil {
 		t.Fatal(err)
 	}
 	// The Logical time will increase over the course of the command
@@ -586,8 +595,8 @@ func TestStoreExecuteCmdWithClockOffset(t *testing.T) {
 	// Set args timestamp to exceed max offset.
 	args.Timestamp = store.ctx.Clock.Now()
 	args.Timestamp.WallTime += maxOffset.Nanoseconds() + 1
-	err := store.ExecuteCmd(context.Background(), proto.Call{Args: args, Reply: reply})
-	if err == nil {
+	store.ExecuteCmd(context.Background(), proto.Call{Args: args, Reply: reply})
+	if err := reply.GoError(); err == nil {
 		t.Error("expected max offset clock error")
 	}
 }
@@ -598,8 +607,8 @@ func TestStoreExecuteCmdBadRange(t *testing.T) {
 	store, _, stopper := createTestStore(t)
 	defer stopper.Stop()
 	args, reply := getArgs([]byte("0"), 2, store.StoreID()) // no range ID 2
-	err := store.ExecuteCmd(context.Background(), proto.Call{Args: args, Reply: reply})
-	if err == nil {
+	store.ExecuteCmd(context.Background(), proto.Call{Args: args, Reply: reply})
+	if err := reply.GoError(); err == nil {
 		t.Error("expected invalid range")
 	}
 }
@@ -640,15 +649,16 @@ func TestStoreExecuteCmdOutOfRange(t *testing.T) {
 	// Range 1 is from KeyMin to "b", so reading "b" from range 1 should
 	// fail because it's just after the range boundary.
 	args, reply := getArgs([]byte("b"), 1, store.StoreID())
-	err := store.ExecuteCmd(context.Background(), proto.Call{Args: args, Reply: reply})
-	if err == nil {
+	store.ExecuteCmd(context.Background(), proto.Call{Args: args, Reply: reply})
+	if err := reply.GoError(); err == nil {
 		t.Error("expected key to be out of range")
 	}
 
 	// Range 2 is from "b" to KeyMax, so reading "a" from range 2 should
 	// fail because it's before the start of the range.
 	args, reply = getArgs([]byte("a"), rng2.Desc().RaftID, store.StoreID())
-	if err := store.ExecuteCmd(context.Background(), proto.Call{Args: args, Reply: reply}); err == nil {
+	store.ExecuteCmd(context.Background(), proto.Call{Args: args, Reply: reply})
+	if err := reply.GoError(); err == nil {
 		t.Error("expected key to be out of range")
 	}
 }
@@ -747,7 +757,8 @@ func TestStoreSetRangesMaxBytes(t *testing.T) {
 	key := keys.MakeKey(keys.ConfigZonePrefix, proto.Key("a"))
 	pArgs, pReply := putArgs(key, data, 1, store.StoreID())
 	pArgs.Timestamp = store.ctx.Clock.Now()
-	if err := store.ExecuteCmd(context.Background(), proto.Call{Args: pArgs, Reply: pReply}); err != nil {
+	store.ExecuteCmd(context.Background(), proto.Call{Args: pArgs, Reply: pReply})
+	if err := pReply.GoError(); err != nil {
 		t.Fatal(err)
 	}
 
@@ -788,14 +799,16 @@ func TestStoreResolveWriteIntent(t *testing.T) {
 		pArgs, pReply := putArgs(key, []byte("value"), 1, store.StoreID())
 		pArgs.Timestamp = store.ctx.Clock.Now()
 		pArgs.Txn = pushee
-		if err := store.ExecuteCmd(context.Background(), proto.Call{Args: pArgs, Reply: pReply}); err != nil {
+		store.ExecuteCmd(context.Background(), proto.Call{Args: pArgs, Reply: pReply})
+		if err := pReply.GoError(); err != nil {
 			t.Fatal(err)
 		}
 
 		// Now, try a put using the pusher's txn.
 		pArgs.Timestamp = store.ctx.Clock.Now()
 		pArgs.Txn = pusher
-		err := store.ExecuteCmd(context.Background(), proto.Call{Args: pArgs, Reply: pReply})
+		store.ExecuteCmd(context.Background(), proto.Call{Args: pArgs, Reply: pReply})
+		err := pReply.GoError()
 		if resolvable {
 			if err != nil {
 				t.Errorf("expected intent resolved; got unexpected error: %s", err)
@@ -816,7 +829,8 @@ func TestStoreResolveWriteIntent(t *testing.T) {
 				t.Errorf("expected txn to match pushee %q; got %s", pushee.ID, rErr)
 			}
 			// Trying again should fail again.
-			if err = store.ExecuteCmd(context.Background(), proto.Call{Args: pArgs, Reply: pReply}); err == nil {
+			store.ExecuteCmd(context.Background(), proto.Call{Args: pArgs, Reply: pReply})
+			if err = pReply.GoError(); err == nil {
 				t.Errorf("expected another error on latent write intent but succeeded")
 			}
 		}
@@ -840,7 +854,8 @@ func TestStoreResolveWriteIntentRollback(t *testing.T) {
 	args, reply := incrementArgs(key, 1, 1, store.StoreID())
 	args.Timestamp = store.ctx.Clock.Now()
 	args.Txn = pushee
-	if err := store.ExecuteCmd(context.Background(), proto.Call{Args: args, Reply: reply}); err != nil {
+	store.ExecuteCmd(context.Background(), proto.Call{Args: args, Reply: reply})
+	if err := reply.GoError(); err != nil {
 		t.Fatal(err)
 	}
 
@@ -848,7 +863,8 @@ func TestStoreResolveWriteIntentRollback(t *testing.T) {
 	args.Timestamp = store.ctx.Clock.Now()
 	args.Txn = pusher
 	args.Increment = 2
-	if err := store.ExecuteCmd(context.Background(), proto.Call{Args: args, Reply: reply}); err != nil {
+	store.ExecuteCmd(context.Background(), proto.Call{Args: args, Reply: reply})
+	if err := reply.GoError(); err != nil {
 		t.Errorf("expected increment to succeed: %s", err)
 	}
 	if reply.NewValue != 2 {
@@ -893,7 +909,8 @@ func TestStoreResolveWriteIntentPushOnRead(t *testing.T) {
 		// First, write original value.
 		args, reply := putArgs(key, []byte("value1"), 1, store.StoreID())
 		args.Timestamp = store.ctx.Clock.Now()
-		if err := store.ExecuteCmd(context.Background(), proto.Call{Args: args, Reply: reply}); err != nil {
+		store.ExecuteCmd(context.Background(), proto.Call{Args: args, Reply: reply})
+		if err := reply.GoError(); err != nil {
 			t.Fatal(err)
 		}
 
@@ -901,7 +918,8 @@ func TestStoreResolveWriteIntentPushOnRead(t *testing.T) {
 		args.Timestamp = store.ctx.Clock.Now()
 		args.Txn = pushee
 		args.Value.Bytes = []byte("value2")
-		if err := store.ExecuteCmd(context.Background(), proto.Call{Args: args, Reply: reply}); err != nil {
+		store.ExecuteCmd(context.Background(), proto.Call{Args: args, Reply: reply})
+		if err := reply.GoError(); err != nil {
 			t.Fatal(err)
 		}
 
@@ -909,7 +927,8 @@ func TestStoreResolveWriteIntentPushOnRead(t *testing.T) {
 		gArgs, gReply := getArgs(key, 1, store.StoreID())
 		gArgs.Timestamp = store.ctx.Clock.Now()
 		gArgs.Txn = pusher
-		err := store.ExecuteCmd(context.Background(), proto.Call{Args: gArgs, Reply: gReply})
+		store.ExecuteCmd(context.Background(), proto.Call{Args: gArgs, Reply: gReply})
+		err := gReply.GoError()
 		if test.resolvable {
 			if err != nil {
 				t.Errorf("%d: expected read to succeed: %s", i, err)
@@ -923,7 +942,8 @@ func TestStoreResolveWriteIntentPushOnRead(t *testing.T) {
 			// verify commit fails with TransactionRetryError.
 			etArgs, etReply := endTxnArgs(pushee, true, 1, store.StoreID())
 			etArgs.Timestamp = pushee.Timestamp
-			err := store.ExecuteCmd(context.Background(), proto.Call{Args: etArgs, Reply: etReply})
+			store.ExecuteCmd(context.Background(), proto.Call{Args: etArgs, Reply: etReply})
+			err := etReply.GoError()
 
 			expTimestamp := gArgs.Timestamp
 			expTimestamp.Logical++
@@ -978,7 +998,8 @@ func TestStoreResolveWriteIntentSnapshotIsolation(t *testing.T) {
 	// First, write original value.
 	args, reply := putArgs(key, []byte("value1"), 1, store.StoreID())
 	args.Timestamp = store.ctx.Clock.Now()
-	if err := store.ExecuteCmd(context.Background(), proto.Call{Args: args, Reply: reply}); err != nil {
+	store.ExecuteCmd(context.Background(), proto.Call{Args: args, Reply: reply})
+	if err := reply.GoError(); err != nil {
 		t.Fatal(err)
 	}
 
@@ -986,7 +1007,8 @@ func TestStoreResolveWriteIntentSnapshotIsolation(t *testing.T) {
 	args.Timestamp = store.ctx.Clock.Now()
 	args.Txn = pushee
 	args.Value.Bytes = []byte("value2")
-	if err := store.ExecuteCmd(context.Background(), proto.Call{Args: args, Reply: reply}); err != nil {
+	store.ExecuteCmd(context.Background(), proto.Call{Args: args, Reply: reply})
+	if err := reply.GoError(); err != nil {
 		t.Fatal(err)
 	}
 
@@ -994,7 +1016,8 @@ func TestStoreResolveWriteIntentSnapshotIsolation(t *testing.T) {
 	gArgs, gReply := getArgs(key, 1, store.StoreID())
 	gArgs.Timestamp = store.ctx.Clock.Now()
 	gArgs.Txn = pusher
-	if err := store.ExecuteCmd(context.Background(), proto.Call{Args: gArgs, Reply: gReply}); err != nil {
+	store.ExecuteCmd(context.Background(), proto.Call{Args: gArgs, Reply: gReply})
+	if err := gReply.GoError(); err != nil {
 		t.Errorf("expected read to succeed: %s", err)
 	} else if !bytes.Equal(gReply.Value.Bytes, []byte("value1")) {
 		t.Errorf("expected bytes to be %q, got %q", "value1", gReply.Value.Bytes)
@@ -1005,7 +1028,8 @@ func TestStoreResolveWriteIntentSnapshotIsolation(t *testing.T) {
 	// commit timestamp is equal to gArgs.Timestamp + 1.
 	etArgs, etReply := endTxnArgs(pushee, true, 1, store.StoreID())
 	etArgs.Timestamp = pushee.Timestamp
-	if err := store.ExecuteCmd(context.Background(), proto.Call{Args: etArgs, Reply: etReply}); err != nil {
+	store.ExecuteCmd(context.Background(), proto.Call{Args: etArgs, Reply: etReply})
+	if err := etReply.GoError(); err != nil {
 		t.Fatal(err)
 	}
 	expTimestamp := gArgs.Timestamp
@@ -1031,7 +1055,8 @@ func TestStoreResolveWriteIntentNoTxn(t *testing.T) {
 	args, reply := putArgs(key, []byte("value1"), 1, store.StoreID())
 	args.Timestamp = pushee.Timestamp
 	args.Txn = pushee
-	if err := store.ExecuteCmd(context.Background(), proto.Call{Args: args, Reply: reply}); err != nil {
+	store.ExecuteCmd(context.Background(), proto.Call{Args: args, Reply: reply})
+	if err := reply.GoError(); err != nil {
 		t.Fatal(err)
 	}
 
@@ -1039,7 +1064,8 @@ func TestStoreResolveWriteIntentNoTxn(t *testing.T) {
 	gArgs, gReply := getArgs(key, 1, store.StoreID())
 	gArgs.Timestamp = store.ctx.Clock.Now()
 	gArgs.UserPriority = gogoproto.Int32(math.MaxInt32)
-	if err := store.ExecuteCmd(context.Background(), proto.Call{Args: gArgs, Reply: gReply}); err != nil {
+	store.ExecuteCmd(context.Background(), proto.Call{Args: gArgs, Reply: gReply})
+	if err := gReply.GoError(); err != nil {
 		t.Errorf("expected read to succeed: %s", err)
 	} else if gReply.Value != nil {
 		t.Errorf("expected value to be nil, got %+v", gReply.Value)
@@ -1050,7 +1076,8 @@ func TestStoreResolveWriteIntentNoTxn(t *testing.T) {
 	args.Value.Bytes = []byte("value2")
 	args.Txn = nil
 	args.UserPriority = gogoproto.Int32(math.MaxInt32)
-	if err := store.ExecuteCmd(context.Background(), proto.Call{Args: args, Reply: reply}); err != nil {
+	store.ExecuteCmd(context.Background(), proto.Call{Args: args, Reply: reply})
+	if err := reply.GoError(); err != nil {
 		t.Errorf("expected success aborting pushee's txn; got %s", err)
 	}
 
@@ -1081,7 +1108,8 @@ func TestStoreResolveWriteIntentNoTxn(t *testing.T) {
 	// been aborted.
 	etArgs, etReply := endTxnArgs(pushee, true, 1, store.StoreID())
 	etArgs.Timestamp = pushee.Timestamp
-	err := store.ExecuteCmd(context.Background(), proto.Call{Args: etArgs, Reply: etReply})
+	store.ExecuteCmd(context.Background(), proto.Call{Args: etArgs, Reply: etReply})
+	err := etReply.GoError()
 	if err == nil {
 		t.Errorf("unexpected success committing transaction")
 	}
@@ -1104,7 +1132,8 @@ func TestStoreReadInconsistent(t *testing.T) {
 
 		// First, write keyA.
 		args, reply := putArgs(keyA, []byte("value1"), 1, store.StoreID())
-		if err := store.ExecuteCmd(context.Background(), proto.Call{Args: args, Reply: reply}); err != nil {
+		store.ExecuteCmd(context.Background(), proto.Call{Args: args, Reply: reply})
+		if err := reply.GoError(); err != nil {
 			t.Fatal(err)
 		}
 
@@ -1122,14 +1151,16 @@ func TestStoreReadInconsistent(t *testing.T) {
 			args.Key = txn.Key
 			args.Timestamp = txn.Timestamp
 			args.Txn = txn
-			if err := store.ExecuteCmd(context.Background(), proto.Call{Args: args, Reply: reply}); err != nil {
+			store.ExecuteCmd(context.Background(), proto.Call{Args: args, Reply: reply})
+			if err := reply.GoError(); err != nil {
 				t.Fatal(err)
 			}
 		}
 		// End txn B, but without resolving the intent.
 		etArgs, etReply := endTxnArgs(txnB, true, 1, store.StoreID())
 		etArgs.Timestamp = txnB.Timestamp
-		if err := store.ExecuteCmd(context.Background(), proto.Call{Args: etArgs, Reply: etReply}); err != nil {
+		store.ExecuteCmd(context.Background(), proto.Call{Args: etArgs, Reply: etReply})
+		if err := etReply.GoError(); err != nil {
 			t.Fatal(err)
 		}
 
@@ -1138,13 +1169,15 @@ func TestStoreReadInconsistent(t *testing.T) {
 		gArgs, gReply := getArgs(keyA, 1, store.StoreID())
 		gArgs.Timestamp = store.ctx.Clock.Now()
 		gArgs.ReadConsistency = proto.INCONSISTENT
-		if err := store.ExecuteCmd(context.Background(), proto.Call{Args: gArgs, Reply: gReply}); err != nil {
+		store.ExecuteCmd(context.Background(), proto.Call{Args: gArgs, Reply: gReply})
+		if err := gReply.GoError(); err != nil {
 			t.Errorf("expected read to succeed: %s", err)
 		} else if gReply.Value == nil || !bytes.Equal(gReply.Value.Bytes, []byte("value1")) {
 			t.Errorf("expected value %q, got %+v", []byte("value1"), gReply.Value)
 		}
 		gArgs.Key = keyB
-		if err := store.ExecuteCmd(context.Background(), proto.Call{Args: gArgs, Reply: gReply}); err != nil {
+		store.ExecuteCmd(context.Background(), proto.Call{Args: gArgs, Reply: gReply})
+		if err := gReply.GoError(); err != nil {
 			t.Errorf("expected read to succeed: %s", err)
 		}
 		// The new value of B will not be read at first.
@@ -1154,7 +1187,8 @@ func TestStoreReadInconsistent(t *testing.T) {
 		// However, it will be read eventually, as B's intent can be
 		// resolved asynchronously as txn B is committed.
 		util.SucceedsWithin(t, 500*time.Millisecond, func() error {
-			if err := store.ExecuteCmd(context.Background(), proto.Call{Args: gArgs, Reply: gReply}); err != nil {
+			store.ExecuteCmd(context.Background(), proto.Call{Args: gArgs, Reply: gReply})
+			if err := gReply.GoError(); err != nil {
 				return util.Errorf("expected read to succeed: %s", err)
 			} else if gReply.Value == nil || !bytes.Equal(gReply.Value.Bytes, []byte("value2")) {
 				return util.Errorf("expected value %q, got %+v", []byte("value2"), gReply.Value)
@@ -1165,7 +1199,8 @@ func TestStoreReadInconsistent(t *testing.T) {
 		// Scan keys and verify results.
 		sArgs, sReply := scanArgs(keyA, keyB.Next(), 1, store.StoreID())
 		sArgs.ReadConsistency = proto.INCONSISTENT
-		if err := store.ExecuteCmd(context.Background(), proto.Call{Args: sArgs, Reply: sReply}); err != nil {
+		store.ExecuteCmd(context.Background(), proto.Call{Args: sArgs, Reply: sReply})
+		if err := sReply.GoError(); err != nil {
 			t.Errorf("expected scan to succeed: %s", err)
 		}
 		if l := len(sReply.Rows); l != 2 {
@@ -1231,7 +1266,8 @@ func TestStoreScanIntents(t *testing.T) {
 			}
 			args, reply := putArgs(key, []byte(fmt.Sprintf("value%02d", j)), 1, store.StoreID())
 			args.Txn = txn
-			if err := store.ExecuteCmd(context.Background(), proto.Call{Args: args, Reply: reply}); err != nil {
+			store.ExecuteCmd(context.Background(), proto.Call{Args: args, Reply: reply})
+			if err := reply.GoError(); err != nil {
 				t.Fatal(err)
 			}
 		}
@@ -1245,7 +1281,8 @@ func TestStoreScanIntents(t *testing.T) {
 		}
 		done := make(chan struct{})
 		go func(sArgs proto.Request, sReply proto.Response) {
-			if err := store.ExecuteCmd(context.Background(), proto.Call{Args: sArgs, Reply: sReply}); err != nil {
+			store.ExecuteCmd(context.Background(), proto.Call{Args: sArgs, Reply: sReply})
+			if err := sReply.Header().GoError(); err != nil {
 				t.Fatal(err)
 			}
 			close(done)
@@ -1270,7 +1307,8 @@ func TestStoreScanIntents(t *testing.T) {
 				// Commit the unpushable txn so the read can finish.
 				etArgs, etReply := endTxnArgs(txn, true, 1, store.StoreID())
 				etArgs.Timestamp = txn.Timestamp
-				if err := store.ExecuteCmd(context.Background(), proto.Call{Args: etArgs, Reply: etReply}); err != nil {
+				store.ExecuteCmd(context.Background(), proto.Call{Args: etArgs, Reply: etReply})
+				if err := etReply.GoError(); err != nil {
 					t.Fatal(err)
 				}
 				<-done
@@ -1296,7 +1334,8 @@ func TestStoreScanInconsistentResolvesIntents(t *testing.T) {
 		keys = append(keys, key)
 		args, reply := putArgs(key, []byte(fmt.Sprintf("value%02d", j)), 1, store.StoreID())
 		args.Txn = txn
-		if err := store.ExecuteCmd(context.Background(), proto.Call{Args: args, Reply: reply}); err != nil {
+		store.ExecuteCmd(context.Background(), proto.Call{Args: args, Reply: reply})
+		if err := reply.GoError(); err != nil {
 			t.Fatal(err)
 		}
 	}
@@ -1304,7 +1343,8 @@ func TestStoreScanInconsistentResolvesIntents(t *testing.T) {
 	// Now, commit txn without resolving intents.
 	etArgs, etReply := endTxnArgs(txn, true, 1, store.StoreID())
 	etArgs.Timestamp = txn.Timestamp
-	if err := store.ExecuteCmd(context.Background(), proto.Call{Args: etArgs, Reply: etReply}); err != nil {
+	store.ExecuteCmd(context.Background(), proto.Call{Args: etArgs, Reply: etReply})
+	if err := etReply.GoError(); err != nil {
 		t.Fatal(err)
 	}
 
@@ -1312,7 +1352,8 @@ func TestStoreScanInconsistentResolvesIntents(t *testing.T) {
 	sArgs, sReply := scanArgs(keys[0], keys[9].Next(), 1, store.StoreID())
 	sArgs.ReadConsistency = proto.INCONSISTENT
 	util.SucceedsWithin(t, 500*time.Millisecond, func() error {
-		if err := store.ExecuteCmd(context.Background(), proto.Call{Args: sArgs, Reply: sReply}); err != nil {
+		store.ExecuteCmd(context.Background(), proto.Call{Args: sArgs, Reply: sReply})
+		if err := sReply.GoError(); err != nil {
 			return err
 		}
 		if len(sReply.Rows) != 10 {


### PR DESCRIPTION
This is already returned on the Call's reply header.

This refactor introduced a test failure (see the first commit which fixes the error message for that test), but I'm not sure why.
