### PR TITLE
response cache & replica corruption handling

### DIFF
--- a/proto/data.go
+++ b/proto/data.go
@@ -602,3 +602,15 @@ func (l Lease) String() string {
 	tStr := t.Format("15:04:05.000")
 	return fmt.Sprintf("replica %d:%d %s +%.3fs", nodeID, storeID, tStr, float64(l.Expiration.WallTime-l.Start.WallTime)/1E9)
 }
+
+// Covers returns true if the given timestamp is strictly less than the
+// Lease expiration, which indicates that the lease holder is authorized
+// to carry out operations with that timestamp.
+func (l Lease) Covers(timestamp Timestamp) bool {
+	return timestamp.Less(l.Expiration)
+}
+
+// OwnedBy returns whether the lease owner is equal to the given RaftNodeID.
+func (l Lease) OwnedBy(id RaftNodeID) bool {
+	return l.RaftNodeID == id
+}

--- a/storage/store.go
+++ b/storage/store.go
@@ -1605,8 +1605,8 @@ func (s *Store) updateStoreStatus() {
 				replicatedRangeCount++
 			}
 
-			// If the range has the leader lease, then it's available.
-			if _, expired := rng.HasLeaderLease(timestamp); !expired {
+			// If any replica holds the leader lease, the range is available.
+			if rng.getLease().Covers(timestamp) {
 				availableRangeCount++
 			} else {
 				// If there is no leader lease, then as long as more than 50%


### PR DESCRIPTION
- always update response cache in applyRaftCommand, allowing early returns
- add replicaCorruptionError, bogus handling and test
- anticipate #1400 by not using reply.Header().GoError() as authoritative
  error source and by setting it only in r.processRaftCommand (though
  it is still set in r.executeCmd and below) for now
- deduplicate some logic around the verification of leader leases
- move leadership check from applyRaftCommand to processRaftCommand and add
  a comment
