### PR TITLE
[ci skip] Create a new RequestHeader and made it a part of KVRequestHeader

### DIFF
--- a/client/batch.go
+++ b/client/batch.go
@@ -359,7 +359,7 @@ func (b *Batch) adminMerge(key interface{}) {
 		return
 	}
 	req := &proto.AdminMergeRequest{
-		RequestHeader: proto.RequestHeader{
+		KVRequestHeader: proto.KVRequestHeader{
 			Key: proto.Key(k),
 		},
 	}
@@ -377,7 +377,7 @@ func (b *Batch) adminSplit(splitKey interface{}) {
 		return
 	}
 	req := &proto.AdminSplitRequest{
-		RequestHeader: proto.RequestHeader{
+		KVRequestHeader: proto.KVRequestHeader{
 			Key: proto.Key(k),
 		},
 	}

--- a/client/db.go
+++ b/client/db.go
@@ -443,9 +443,9 @@ func (db *DB) send(calls ...proto.Call) (err error) {
 	}
 
 	bArgs, bReply := &proto.BatchRequest{}, &proto.BatchResponse{}
-	for _, call := range calls {
-		bArgs.Add(call.Args)
-	}
+	//for _, call := range calls {
+	//bArgs.Add(call.Args)
+	//}
 	err = db.send(proto.Call{Args: bArgs, Reply: bReply})
 
 	// Recover from protobuf merge panics.

--- a/client/http_sender_test.go
+++ b/client/http_sender_test.go
@@ -36,8 +36,8 @@ import (
 var (
 	testKey     = proto.Key("a")
 	testTS      = proto.Timestamp{WallTime: 1, Logical: 1}
-	testPutReq  = &proto.PutRequest{RequestHeader: proto.RequestHeader{Timestamp: testTS, Key: testKey}}
-	testPutResp = &proto.PutResponse{ResponseHeader: proto.ResponseHeader{Timestamp: testTS}}
+	testPutReq  = &proto.PutRequest{KVRequestHeader: proto.KVRequestHeader{RequestHeader: proto.RequestHeader{Timestamp: testTS}, Key: testKey}}
+	testPutResp = &proto.PutResponse{KVResponseHeader: proto.KVResponseHeader{ResponseHeader: proto.ResponseHeader{Timestamp: testTS}}}
 )
 
 func startTestHTTPServer(handler http.Handler) (*httptest.Server, string) {

--- a/kv/db_test.go
+++ b/kv/db_test.go
@@ -139,9 +139,9 @@ func TestKVDBInternalMethods(t *testing.T) {
 	// Verify non-public methods experience bad request errors.
 	db := createTestClient(t, s.ServingAddr())
 	for i, test := range testCases {
-		test.args.Header().Key = proto.Key("a")
+		test.args.KVHeader().Key = proto.Key("a")
 		if proto.IsRange(test.args) {
-			test.args.Header().EndKey = test.args.Header().Key.Next()
+			test.args.KVHeader().EndKey = test.args.KVHeader().Key.Next()
 		}
 		b := &client.Batch{}
 		b.InternalAddCall(proto.Call{Args: test.args, Reply: test.reply})
@@ -168,8 +168,8 @@ func TestKVDBEndTransactionWithTriggers(t *testing.T) {
 		b := &client.Batch{}
 		b.InternalAddCall(proto.Call{
 			Args: &proto.EndTransactionRequest{
-				RequestHeader: proto.RequestHeader{Key: proto.Key("foo")},
-				Commit:        true,
+				KVRequestHeader: proto.KVRequestHeader{Key: proto.Key("foo")},
+				Commit:          true,
 				InternalCommitTrigger: &proto.InternalCommitTrigger{
 					SplitTrigger: &proto.SplitTrigger{
 						UpdatedDesc: proto.RangeDescriptor{StartKey: proto.Key("bar")},

--- a/kv/local_sender.go
+++ b/kv/local_sender.go
@@ -125,7 +125,7 @@ func (ls *LocalSender) Send(ctx context.Context, call proto.Call) {
 
 	// If we aren't given a Replica, then a little bending over
 	// backwards here. This case applies exclusively to unittests.
-	header := call.Args.Header()
+	header := call.Args.KVHeader()
 	if header.RaftID == 0 || header.Replica.StoreID == 0 {
 		var repl *proto.Replica
 		var raftID proto.RaftID

--- a/kv/local_test_cluster.go
+++ b/kv/local_test_cluster.go
@@ -74,7 +74,7 @@ func (rls *retryableLocalSender) Send(_ context.Context, call proto.Call) {
 		if err := call.Reply.Header().GoError(); err != nil {
 			if _, ok := err.(*proto.RangeKeyMismatchError); ok {
 				// Clear request replica.
-				call.Args.Header().Replica = proto.Replica{}
+				call.Args.KVHeader().Replica = proto.Replica{}
 				return retry.Continue, err
 			}
 		}

--- a/proto/api.go
+++ b/proto/api.go
@@ -79,6 +79,7 @@ type Request interface {
 	gogoproto.Message
 	// Header returns the request header.
 	Header() *RequestHeader
+	KVHeader() *KVRequestHeader
 	// Method returns the request method.
 	Method() Method
 	// CreateReply creates a new response object.
@@ -91,6 +92,7 @@ type Response interface {
 	gogoproto.Message
 	// Header returns the response header.
 	Header() *ResponseHeader
+	KVHeader() *KVResponseHeader
 	// Verify verifies response integrity, as applicable.
 	Verify(req Request) error
 }
@@ -170,6 +172,15 @@ func (rh *ResponseHeader) Header() *ResponseHeader {
 	return rh
 }
 
+func (rh *KVRequestHeader) KVHeader() *KVRequestHeader {
+	return rh
+}
+
+// KVHeader implements the KVResponse interface for KVResponseHeader.
+func (rh *KVResponseHeader) KVHeader() *KVResponseHeader {
+	return rh
+}
+
 // Verify implements the Response interface for ResopnseHeader with a
 // default noop. Individual response types should override this method
 // if they contain checksummed data which can be verified.
@@ -237,7 +248,7 @@ func (rh *ResponseHeader) SetGoError(err error) {
 // Verify verifies the integrity of the get response value.
 func (gr *GetResponse) Verify(req Request) error {
 	if gr.Value != nil {
-		return gr.Value.Verify(req.Header().Key)
+		return gr.Value.Verify(req.KVHeader().Key)
 	}
 	return nil
 }
@@ -264,8 +275,8 @@ func (br *BatchRequest) Add(args Request) {
 		panic(fmt.Sprintf("unable to add %T to batch request", args))
 	}
 	if br.Key == nil {
-		br.Key = args.Header().Key
-		br.EndKey = args.Header().EndKey
+		br.Key = args.KVHeader().Key
+		br.EndKey = args.KVHeader().EndKey
 	}
 	br.Requests = append(br.Requests, union)
 }

--- a/proto/api.proto
+++ b/proto/api.proto
@@ -76,25 +76,9 @@ message RequestHeader {
   // CmdID is optionally specified for request idempotence
   // (i.e. replay protection).
   optional ClientCmdID cmd_id = 2 [(gogoproto.nullable) = false, (gogoproto.customname) = "CmdID"];
-  // The key for request. If the request operates on a range, this
-  // represents the starting key for the range.
-  optional bytes key = 3 [(gogoproto.casttype) = "Key"];
-  // The end key is empty if the request spans only a single key. Otherwise,
-  // it must order strictly after Key. In such a case, the header indicates
-  // that the operation takes place on the key range from Key to EndKey,
-  // including Key and excluding EndKey.
-  optional bytes end_key = 4 [(gogoproto.casttype) = "Key"];
   // User is the originating user. Used to lookup priority when
   // scheduling queued operations at target node.
   optional string user = 5 [(gogoproto.nullable) = false];
-  // Replica specifies the destination for the request. This is a specific
-  // instance of the available replicas belonging to RangeID.
-  optional Replica replica = 6 [(gogoproto.nullable) = false];
-  // RaftID specifies the ID of the Raft consensus group which the key
-  // range belongs to. This is used by the receiving node to route the
-  // request to the correct range.
-  optional int64 raft_id = 7 [(gogoproto.nullable) = false,
-      (gogoproto.customname) = "RaftID", (gogoproto.casttype) = "RaftID"];
   // UserPriority specifies priority multiple for non-transactional
   // commands. This value should be a positive integer [1, 2^31-1).
   // It's properly viewed as a multiple for how likely this
@@ -135,27 +119,53 @@ message ResponseHeader {
   optional Transaction txn = 3;
 }
 
+// KVRequestHeader is supplied with every KV node request.
+message KVRequestHeader {
+  optional RequestHeader header = 1 [(gogoproto.nullable) = false, (gogoproto.embed) = true];
+  // The key for request. If the request operates on a range, this
+  // represents the starting key for the range.
+  optional bytes key = 3 [(gogoproto.casttype) = "Key"];
+  // The end key is empty if the request spans only a single key. Otherwise,
+  // it must order strictly after Key. In such a case, the header indicates
+  // that the operation takes place on the key range from Key to EndKey,
+  // including Key and excluding EndKey.
+  optional bytes end_key = 4 [(gogoproto.casttype) = "Key"];
+  // Replica specifies the destination for the request. This is a specific
+  // instance of the available replicas belonging to RangeID.
+  optional Replica replica = 6 [(gogoproto.nullable) = false];
+  // RaftID specifies the ID of the Raft consensus group which the key
+  // range belongs to. This is used by the receiving node to route the
+  // request to the correct range.
+  optional int64 raft_id = 7 [(gogoproto.nullable) = false,
+      (gogoproto.customname) = "RaftID", (gogoproto.casttype) = "RaftID"];
+}
+
+// KVResponseHeader is supplied with every KV node request.
+message KVResponseHeader {
+  optional ResponseHeader header = 1 [(gogoproto.nullable) = false, (gogoproto.embed) = true];
+}
+
 // A GetRequest is the argument for the Get() method.
 message GetRequest {
-  optional RequestHeader header = 1 [(gogoproto.nullable) = false, (gogoproto.embed) = true];
+  optional KVRequestHeader kvheader = 1 [(gogoproto.nullable) = false, (gogoproto.embed) = true];
 }
 
 // A GetResponse is the return value from the Get() method.
 // If the key doesn't exist, returns nil for Value.Bytes.
 message GetResponse {
-  optional ResponseHeader header = 1 [(gogoproto.nullable) = false, (gogoproto.embed) = true];
+  optional KVResponseHeader kvheader = 1 [(gogoproto.nullable) = false, (gogoproto.embed) = true];
   optional Value value = 2;
 }
 
 // A PutRequest is the argument to the Put() method.
 message PutRequest {
-  optional RequestHeader header = 1 [(gogoproto.nullable) = false, (gogoproto.embed) = true];
+  optional KVRequestHeader kvheader = 1 [(gogoproto.nullable) = false, (gogoproto.embed) = true];
   optional Value value = 2 [(gogoproto.nullable) = false];
 }
 
 // A PutResponse is the return value from the Put() method.
 message PutResponse {
-  optional ResponseHeader header = 1 [(gogoproto.nullable) = false, (gogoproto.embed) = true];
+  optional KVResponseHeader kvheader = 1 [(gogoproto.nullable) = false, (gogoproto.embed) = true];
 }
 
 // A ConditionalPutRequest is the argument to the ConditionalPut() method.
@@ -165,7 +175,7 @@ message PutResponse {
 // - If key exists, but value is empty and ExpValue is not nil but empty, sets value.
 // - Otherwise, returns error and the actual value of the key in the response.
 message ConditionalPutRequest {
-  optional RequestHeader header = 1 [(gogoproto.nullable) = false, (gogoproto.embed) = true];
+  optional KVRequestHeader kvheader = 1 [(gogoproto.nullable) = false, (gogoproto.embed) = true];
   // The value to put.
   optional Value value = 2 [(gogoproto.nullable) = false];
   // ExpValue.Bytes empty to test for non-existence. Specify as nil
@@ -177,7 +187,7 @@ message ConditionalPutRequest {
 // A ConditionalPutResponse is the return value from the
 // ConditionalPut() method.
 message ConditionalPutResponse {
-  optional ResponseHeader header = 1 [(gogoproto.nullable) = false, (gogoproto.embed) = true];
+  optional KVResponseHeader kvheader = 1 [(gogoproto.nullable) = false, (gogoproto.embed) = true];
 }
 
 // An IncrementRequest is the argument to the Increment() method. It
@@ -187,7 +197,7 @@ message ConditionalPutResponse {
 // by Put() or ConditionalPut(). Similarly, Put() and ConditionalPut()
 // cannot be invoked on an incremented key.
 message IncrementRequest {
-  optional RequestHeader header = 1 [(gogoproto.nullable) = false, (gogoproto.embed) = true];
+  optional KVRequestHeader kvheader = 1 [(gogoproto.nullable) = false, (gogoproto.embed) = true];
   optional int64 increment = 2 [(gogoproto.nullable) = false];
 }
 
@@ -195,24 +205,24 @@ message IncrementRequest {
 // method. The new value after increment is specified in NewValue. If
 // the value could not be decoded as specified, Error will be set.
 message IncrementResponse {
-  optional ResponseHeader header = 1 [(gogoproto.nullable) = false, (gogoproto.embed) = true];
+  optional KVResponseHeader kvheader = 1 [(gogoproto.nullable) = false, (gogoproto.embed) = true];
   optional int64 new_value = 2 [(gogoproto.nullable) = false];
 }
 
 // A DeleteRequest is the argument to the Delete() method.
 message DeleteRequest {
-  optional RequestHeader header = 1 [(gogoproto.nullable) = false, (gogoproto.embed) = true];
+  optional KVRequestHeader kvheader = 1 [(gogoproto.nullable) = false, (gogoproto.embed) = true];
 }
 
 // A DeleteResponse is the return value from the Delete() method.
 message DeleteResponse {
-  optional ResponseHeader header = 1 [(gogoproto.nullable) = false, (gogoproto.embed) = true];
+  optional KVResponseHeader kvheader = 1 [(gogoproto.nullable) = false, (gogoproto.embed) = true];
 }
 
 // A DeleteRangeRequest is the argument to the DeleteRange() method. It
 // specifies the range of keys to delete.
 message DeleteRangeRequest {
-  optional RequestHeader header = 1 [(gogoproto.nullable) = false, (gogoproto.embed) = true];
+  optional KVRequestHeader kvheader = 1 [(gogoproto.nullable) = false, (gogoproto.embed) = true];
   // If 0, *all* entries between Key (inclusive) and EndKey
   // (exclusive) are deleted. Must be >= 0
   optional int64 max_entries_to_delete = 2 [(gogoproto.nullable) = false];
@@ -221,7 +231,7 @@ message DeleteRangeRequest {
 // A DeleteRangeResponse is the return value from the DeleteRange()
 // method.
 message DeleteRangeResponse {
-  optional ResponseHeader header = 1 [(gogoproto.nullable) = false, (gogoproto.embed) = true];
+  optional KVResponseHeader kvheader = 1 [(gogoproto.nullable) = false, (gogoproto.embed) = true];
   // Number of entries removed.
   optional int64 num_deleted = 2 [(gogoproto.nullable) = false];
 }
@@ -229,14 +239,14 @@ message DeleteRangeResponse {
 // A ScanRequest is the argument to the Scan() method. It specifies the
 // start and end keys for the scan and the maximum number of results.
 message ScanRequest {
-  optional RequestHeader header = 1 [(gogoproto.nullable) = false, (gogoproto.embed) = true];
+  optional KVRequestHeader kvheader = 1 [(gogoproto.nullable) = false, (gogoproto.embed) = true];
   // Must be > 0.
   optional int64 max_results = 2 [(gogoproto.nullable) = false];
 }
 
 // A ScanResponse is the return value from the Scan() method.
 message ScanResponse {
-  optional ResponseHeader header = 1 [(gogoproto.nullable) = false, (gogoproto.embed) = true];
+  optional KVResponseHeader kvheader = 1 [(gogoproto.nullable) = false, (gogoproto.embed) = true];
   // Empty if no rows were scanned.
   repeated KeyValue rows = 2 [(gogoproto.nullable) = false];
 }
@@ -244,7 +254,7 @@ message ScanResponse {
 // An EndTransactionRequest is the argument to the EndTransaction() method. It
 // specifies whether to commit or roll back an extant transaction.
 message EndTransactionRequest {
-  optional RequestHeader header = 1 [(gogoproto.nullable) = false, (gogoproto.embed) = true];
+  optional KVRequestHeader kvheader = 1 [(gogoproto.nullable) = false, (gogoproto.embed) = true];
   // False to abort and rollback.
   optional bool commit = 2 [(gogoproto.nullable) = false];
   // Optional commit triggers. Note that commit triggers are for
@@ -255,7 +265,7 @@ message EndTransactionRequest {
 
 // An EndTransactionResponse is the return value from the
 // EndTransaction() method. The final transaction record is returned
-// as part of the response header. In particular, transaction status
+// as part of the response kvheader. In particular, transaction status
 // and timestamp will be updated to reflect final committed
 // values. Clients may propagate the transaction timestamp as the
 // final txn commit timestamp in order to preserve causal ordering
@@ -264,7 +274,7 @@ message EndTransactionRequest {
 // signalling completion of the transaction to another distributed
 // node to maintain consistency.
 message EndTransactionResponse {
-  optional ResponseHeader header = 1 [(gogoproto.nullable) = false, (gogoproto.embed) = true];
+  optional KVResponseHeader kvheader = 1 [(gogoproto.nullable) = false, (gogoproto.embed) = true];
   // Remaining time (ns).
   optional int64 commit_wait = 2 [(gogoproto.nullable) = false];
   // List of intents resolved by EndTransaction call.
@@ -307,32 +317,32 @@ message ResponseUnion {
 // parallel, or if applicable (based on write-only commands and
 // range-locality), as a single update.
 //
-// The RequestHeader should contain the Key of the first request
+// The KVRequestHeader should contain the Key of the first request
 // in the batch. It also contains the transaction itself; individual
 // calls must not have transactions specified. The same applies to
 // the User and UserPriority fields.
 message BatchRequest {
-  optional RequestHeader header = 1 [(gogoproto.nullable) = false, (gogoproto.embed) = true];
+  optional KVRequestHeader kvheader = 1 [(gogoproto.nullable) = false, (gogoproto.embed) = true];
   repeated RequestUnion requests = 2 [(gogoproto.nullable) = false];
 }
 
 // A BatchResponse contains one or more responses, one per request
 // corresponding to the requests in the matching BatchRequest. The
-// error in the response header is set to the first error from the
+// error in the response kvheader is set to the first error from the
 // slice of responses, if applicable.
 message BatchResponse {
-  optional ResponseHeader header = 1 [(gogoproto.nullable) = false, (gogoproto.embed) = true];
+  optional KVResponseHeader kvheader = 1 [(gogoproto.nullable) = false, (gogoproto.embed) = true];
   repeated ResponseUnion responses = 2 [(gogoproto.nullable) = false];
 }
 
 // An AdminSplitRequest is the argument to the AdminSplit() method. The
-// existing range which contains RequestHeader.Key is split by
+// existing range which contains KVRequestHeader.Key is split by
 // split_key. If split_key is not specified, then this method will
 // determine a split key that is roughly halfway through the
 // range. The existing range is resized to cover only its start key to
 // the split key. The new range created by the split starts at the
 // split key and extends to the original range's end key. If split_key
-// is known, header.key should also be set to split_key.
+// is known, kvheader.key should also be set to split_key.
 //
 // New range IDs for each of the split range's replica and a new Raft
 // ID are generated by the operation. Split requests are done in the
@@ -346,14 +356,14 @@ message BatchResponse {
 // metadata (e.g. response cache and range stats must be copied or
 // recomputed).
 message AdminSplitRequest {
-  optional RequestHeader header = 1 [(gogoproto.nullable) = false, (gogoproto.embed) = true];
+  optional KVRequestHeader kvheader = 1 [(gogoproto.nullable) = false, (gogoproto.embed) = true];
   optional bytes split_key = 2 [(gogoproto.casttype) = "Key"];
 }
 
 // An AdminSplitResponse is the return value from the AdminSplit()
 // method.
 message AdminSplitResponse {
-  optional ResponseHeader header = 1 [(gogoproto.nullable) = false, (gogoproto.embed) = true];
+  optional KVResponseHeader kvheader = 1 [(gogoproto.nullable) = false, (gogoproto.embed) = true];
 }
 
 // An AdminMergeRequest is the argument to the AdminMerge() method. A
@@ -366,11 +376,11 @@ message AdminSplitResponse {
 // of the subsumed range. If AdminMerge is called on the final range
 // in the key space, it is a noop.
 message AdminMergeRequest {
-  optional RequestHeader header = 1 [(gogoproto.nullable) = false, (gogoproto.embed) = true];
+  optional KVRequestHeader kvheader = 1 [(gogoproto.nullable) = false, (gogoproto.embed) = true];
 }
 
 // An AdminMergeResponse is the return value from the AdminMerge()
 // method.
 message AdminMergeResponse {
-  optional ResponseHeader header = 1 [(gogoproto.nullable) = false, (gogoproto.embed) = true];
+  optional KVResponseHeader kvheader = 1 [(gogoproto.nullable) = false, (gogoproto.embed) = true];
 }

--- a/proto/api_test.go
+++ b/proto/api_test.go
@@ -83,7 +83,9 @@ func TestCombinable(t *testing.T) {
 	}
 	// Test that {Scan,DeleteRange}Response properly implement it.
 	sr1 := &ScanResponse{
-		ResponseHeader: ResponseHeader{Timestamp: MinTimestamp},
+		KVResponseHeader: KVResponseHeader{
+			ResponseHeader: ResponseHeader{Timestamp: MinTimestamp},
+		},
 		Rows: []KeyValue{
 			{Key: Key("A"), Value: Value{Bytes: []byte("V")}},
 		},
@@ -94,7 +96,9 @@ func TestCombinable(t *testing.T) {
 	}
 
 	sr2 := &ScanResponse{
-		ResponseHeader: ResponseHeader{Timestamp: MinTimestamp},
+		KVResponseHeader: KVResponseHeader{
+			ResponseHeader: ResponseHeader{Timestamp: MinTimestamp},
+		},
 		Rows: []KeyValue{
 			{Key: Key("B"), Value: Value{Bytes: []byte("W")}},
 		},
@@ -102,8 +106,10 @@ func TestCombinable(t *testing.T) {
 	sr2.Timestamp = MaxTimestamp
 
 	wantedSR := &ScanResponse{
-		ResponseHeader: ResponseHeader{Timestamp: MaxTimestamp},
-		Rows:           append(append([]KeyValue(nil), sr1.Rows...), sr2.Rows...),
+		KVResponseHeader: KVResponseHeader{
+			ResponseHeader: ResponseHeader{Timestamp: MaxTimestamp},
+		},
+		Rows: append(append([]KeyValue(nil), sr1.Rows...), sr2.Rows...),
 	}
 
 	sr1.Combine(sr2)
@@ -114,23 +120,31 @@ func TestCombinable(t *testing.T) {
 	}
 
 	dr1 := &DeleteRangeResponse{
-		ResponseHeader: ResponseHeader{Timestamp: Timestamp{Logical: 100}},
-		NumDeleted:     5,
+		KVResponseHeader: KVResponseHeader{
+			ResponseHeader: ResponseHeader{Timestamp: Timestamp{Logical: 100}},
+		},
+		NumDeleted: 5,
 	}
 	if _, ok := interface{}(dr1).(Combinable); !ok {
 		t.Fatalf("DeleteRangeResponse does not implement Combinable")
 	}
 	dr2 := &DeleteRangeResponse{
-		ResponseHeader: ResponseHeader{Timestamp: Timestamp{Logical: 1}},
-		NumDeleted:     12,
+		KVResponseHeader: KVResponseHeader{
+			ResponseHeader: ResponseHeader{Timestamp: Timestamp{Logical: 1}},
+		},
+		NumDeleted: 12,
 	}
 	dr3 := &DeleteRangeResponse{
-		ResponseHeader: ResponseHeader{Timestamp: Timestamp{Logical: 111}},
-		NumDeleted:     3,
+		KVResponseHeader: KVResponseHeader{
+			ResponseHeader: ResponseHeader{Timestamp: Timestamp{Logical: 111}},
+		},
+		NumDeleted: 3,
 	}
 	wantedDR := &DeleteRangeResponse{
-		ResponseHeader: ResponseHeader{Timestamp: Timestamp{Logical: 111}},
-		NumDeleted:     20,
+		KVResponseHeader: KVResponseHeader{
+			ResponseHeader: ResponseHeader{Timestamp: Timestamp{Logical: 111}},
+		},
+		NumDeleted: 20,
 	}
 	dr2.Combine(dr3)
 	dr1.Combine(dr2)

--- a/proto/call.go
+++ b/proto/call.go
@@ -39,7 +39,7 @@ func (c *Call) Method() Method {
 func GetCall(key Key) Call {
 	return Call{
 		Args: &GetRequest{
-			RequestHeader: RequestHeader{
+			KVRequestHeader: KVRequestHeader{
 				Key: key,
 			},
 		},
@@ -66,7 +66,7 @@ func GetProtoCall(key Key, msg gogoproto.Message) Call {
 func IncrementCall(key Key, increment int64) Call {
 	return Call{
 		Args: &IncrementRequest{
-			RequestHeader: RequestHeader{
+			KVRequestHeader: KVRequestHeader{
 				Key: key,
 			},
 			Increment: increment,
@@ -80,7 +80,7 @@ func PutCall(key Key, value Value) Call {
 	value.InitChecksum(key)
 	return Call{
 		Args: &PutRequest{
-			RequestHeader: RequestHeader{
+			KVRequestHeader: KVRequestHeader{
 				Key: key,
 			},
 			Value: value,
@@ -101,7 +101,7 @@ func ConditionalPutCall(key Key, valueBytes, expValueBytes []byte) Call {
 	}
 	return Call{
 		Args: &ConditionalPutRequest{
-			RequestHeader: RequestHeader{
+			KVRequestHeader: KVRequestHeader{
 				Key: key,
 			},
 			Value:    value,
@@ -125,7 +125,7 @@ func PutProtoCall(key Key, msg gogoproto.Message) Call {
 func DeleteCall(key Key) Call {
 	return Call{
 		Args: &DeleteRequest{
-			RequestHeader: RequestHeader{
+			KVRequestHeader: KVRequestHeader{
 				Key: key,
 			},
 		},
@@ -138,7 +138,7 @@ func DeleteCall(key Key) Call {
 func DeleteRangeCall(startKey, endKey Key) Call {
 	return Call{
 		Args: &DeleteRangeRequest{
-			RequestHeader: RequestHeader{
+			KVRequestHeader: KVRequestHeader{
 				Key:    startKey,
 				EndKey: endKey,
 			},
@@ -152,7 +152,7 @@ func DeleteRangeCall(startKey, endKey Key) Call {
 func ScanCall(key, endKey Key, maxResults int64) Call {
 	return Call{
 		Args: &ScanRequest{
-			RequestHeader: RequestHeader{
+			KVRequestHeader: KVRequestHeader{
 				Key:    key,
 				EndKey: endKey,
 			},

--- a/proto/internal.go
+++ b/proto/internal.go
@@ -61,8 +61,8 @@ func (br *InternalBatchRequest) Add(args Request) {
 		panic(fmt.Sprintf("unable to add %T to internal batch request", args))
 	}
 	if br.Key == nil {
-		br.Key = args.Header().Key
-		br.EndKey = args.Header().EndKey
+		br.Key = args.KVHeader().Key
+		br.EndKey = args.KVHeader().EndKey
 	}
 	br.Requests = append(br.Requests, union)
 }

--- a/proto/internal.pb.go
+++ b/proto/internal.pb.go
@@ -101,8 +101,8 @@ func (x *InternalValueType) UnmarshalJSON(data []byte) error {
 // additional consecutive addressable ranges. Specify max_ranges > 1
 // to pre-fill the range descriptor cache.
 type InternalRangeLookupRequest struct {
-	RequestHeader `protobuf:"bytes,1,opt,name=header,embedded=header" json:"header"`
-	MaxRanges     int32 `protobuf:"varint,2,opt,name=max_ranges" json:"max_ranges"`
+	KVRequestHeader `protobuf:"bytes,1,opt,name=kvheader,embedded=kvheader" json:"kvheader"`
+	MaxRanges       int32 `protobuf:"varint,2,opt,name=max_ranges" json:"max_ranges"`
 	// Ignore intents indicates whether or not intents encountered
 	// while looking up the range info should be resolved. This should
 	// be false in general, except for the case where the lookup is
@@ -136,7 +136,7 @@ func (m *InternalRangeLookupRequest) GetIgnoreIntents() bool {
 // additional consecutive ranges beyond the requested range to pre-fill
 // the range descriptor cache.
 type InternalRangeLookupResponse struct {
-	ResponseHeader   `protobuf:"bytes,1,opt,name=header,embedded=header" json:"header"`
+	KVResponseHeader `protobuf:"bytes,1,opt,name=kvheader,embedded=kvheader" json:"kvheader"`
 	Ranges           []RangeDescriptor `protobuf:"bytes,2,rep,name=ranges" json:"ranges"`
 	XXX_unrecognized []byte            `json:"-"`
 }
@@ -158,7 +158,7 @@ func (m *InternalRangeLookupResponse) GetRanges() []RangeDescriptor {
 // ongoing. Note that this heartbeat message is different from the
 // heartbeat message in the gossip protocol.
 type InternalHeartbeatTxnRequest struct {
-	RequestHeader    `protobuf:"bytes,1,opt,name=header,embedded=header" json:"header"`
+	KVRequestHeader  `protobuf:"bytes,1,opt,name=kvheader,embedded=kvheader" json:"kvheader"`
 	XXX_unrecognized []byte `json:"-"`
 }
 
@@ -172,7 +172,7 @@ func (*InternalHeartbeatTxnRequest) ProtoMessage()    {}
 // know the disposition of the transaction (i.e. aborted, committed or
 // pending).
 type InternalHeartbeatTxnResponse struct {
-	ResponseHeader   `protobuf:"bytes,1,opt,name=header,embedded=header" json:"header"`
+	KVResponseHeader `protobuf:"bytes,1,opt,name=kvheader,embedded=kvheader" json:"kvheader"`
 	XXX_unrecognized []byte `json:"-"`
 }
 
@@ -184,7 +184,7 @@ func (*InternalHeartbeatTxnResponse) ProtoMessage()    {}
 // sent by range leaders after scanning range data to find expired
 // MVCC values.
 type InternalGCRequest struct {
-	RequestHeader    `protobuf:"bytes,1,opt,name=header,embedded=header" json:"header"`
+	KVRequestHeader  `protobuf:"bytes,1,opt,name=kvheader,embedded=kvheader" json:"kvheader"`
 	GCMeta           GCMetadata                `protobuf:"bytes,2,opt,name=gc_meta" json:"gc_meta"`
 	Keys             []InternalGCRequest_GCKey `protobuf:"bytes,3,rep,name=keys" json:"keys"`
 	XXX_unrecognized []byte                    `json:"-"`
@@ -228,7 +228,7 @@ func (m *InternalGCRequest_GCKey) GetTimestamp() Timestamp {
 // An InternalGCResponse is the return value from the InternalGC()
 // method.
 type InternalGCResponse struct {
-	ResponseHeader   `protobuf:"bytes,1,opt,name=header,embedded=header" json:"header"`
+	KVResponseHeader `protobuf:"bytes,1,opt,name=kvheader,embedded=kvheader" json:"kvheader"`
 	XXX_unrecognized []byte `json:"-"`
 }
 
@@ -250,8 +250,8 @@ func (*InternalGCResponse) ProtoMessage()    {}
 // course of action is determined by the specified push type, and by
 // the owning txn's status and priority.
 type InternalPushTxnRequest struct {
-	RequestHeader `protobuf:"bytes,1,opt,name=header,embedded=header" json:"header"`
-	PusheeTxn     Transaction `protobuf:"bytes,2,opt,name=pushee_txn" json:"pushee_txn"`
+	KVRequestHeader `protobuf:"bytes,1,opt,name=kvheader,embedded=kvheader" json:"kvheader"`
+	PusheeTxn       Transaction `protobuf:"bytes,2,opt,name=pushee_txn" json:"pushee_txn"`
 	// Now holds the timestamp used to compare the last heartbeat of the pushee
 	// against. This is necessary since the request header's timestamp does not
 	// necessarily advance with the node clock across retries and hence cannot
@@ -310,7 +310,7 @@ func (m *InternalPushTxnRequest) GetRangeLookup() bool {
 // InternalResolveIntent() on the conflicted key. It returns an error
 // otherwise.
 type InternalPushTxnResponse struct {
-	ResponseHeader `protobuf:"bytes,1,opt,name=header,embedded=header" json:"header"`
+	KVResponseHeader `protobuf:"bytes,1,opt,name=kvheader,embedded=kvheader" json:"kvheader"`
 	// Txn is non-nil if the transaction could be heartbeat and contains
 	// the current value of the transaction.
 	PusheeTxn        *Transaction `protobuf:"bytes,2,opt,name=pushee_txn" json:"pushee_txn,omitempty"`
@@ -333,7 +333,7 @@ func (m *InternalPushTxnResponse) GetPusheeTxn() *Transaction {
 // coordinators and after success calling InternalPushTxn to clean up
 // write intents: either to remove them or commit them.
 type InternalResolveIntentRequest struct {
-	RequestHeader    `protobuf:"bytes,1,opt,name=header,embedded=header" json:"header"`
+	KVRequestHeader  `protobuf:"bytes,1,opt,name=kvheader,embedded=kvheader" json:"kvheader"`
 	XXX_unrecognized []byte `json:"-"`
 }
 
@@ -344,7 +344,7 @@ func (*InternalResolveIntentRequest) ProtoMessage()    {}
 // An InternalResolveIntentResponse is the return value from the
 // InternalResolveIntent() method.
 type InternalResolveIntentResponse struct {
-	ResponseHeader   `protobuf:"bytes,1,opt,name=header,embedded=header" json:"header"`
+	KVResponseHeader `protobuf:"bytes,1,opt,name=kvheader,embedded=kvheader" json:"kvheader"`
 	XXX_unrecognized []byte `json:"-"`
 }
 
@@ -356,7 +356,7 @@ func (*InternalResolveIntentResponse) ProtoMessage()    {}
 // InternalResolveIntentRange() method. This clear write intents
 // for a range of keys to resolve intents created by range ops.
 type InternalResolveIntentRangeRequest struct {
-	RequestHeader    `protobuf:"bytes,1,opt,name=header,embedded=header" json:"header"`
+	KVRequestHeader  `protobuf:"bytes,1,opt,name=kvheader,embedded=kvheader" json:"kvheader"`
 	XXX_unrecognized []byte `json:"-"`
 }
 
@@ -367,7 +367,7 @@ func (*InternalResolveIntentRangeRequest) ProtoMessage()    {}
 // An InternalResolveIntentRangeResponse is the return value from the
 // InternalResolveIntent() method.
 type InternalResolveIntentRangeResponse struct {
-	ResponseHeader   `protobuf:"bytes,1,opt,name=header,embedded=header" json:"header"`
+	KVResponseHeader `protobuf:"bytes,1,opt,name=kvheader,embedded=kvheader" json:"kvheader"`
 	XXX_unrecognized []byte `json:"-"`
 }
 
@@ -379,7 +379,7 @@ func (*InternalResolveIntentRangeResponse) ProtoMessage()    {}
 // specifies a key and a value which should be merged into the existing value at
 // that key.
 type InternalMergeRequest struct {
-	RequestHeader    `protobuf:"bytes,1,opt,name=header,embedded=header" json:"header"`
+	KVRequestHeader  `protobuf:"bytes,1,opt,name=kvheader,embedded=kvheader" json:"kvheader"`
 	Value            Value  `protobuf:"bytes,2,opt,name=value" json:"value"`
 	XXX_unrecognized []byte `json:"-"`
 }
@@ -397,7 +397,7 @@ func (m *InternalMergeRequest) GetValue() Value {
 
 // InternalMergeResponse is the response to an InternalMerge() operation.
 type InternalMergeResponse struct {
-	ResponseHeader   `protobuf:"bytes,1,opt,name=header,embedded=header" json:"header"`
+	KVResponseHeader `protobuf:"bytes,1,opt,name=kvheader,embedded=kvheader" json:"kvheader"`
 	XXX_unrecognized []byte `json:"-"`
 }
 
@@ -411,7 +411,7 @@ func (*InternalMergeResponse) ProtoMessage()    {}
 // to identical as possible. The raft leader can also inform decisions about the cutoff point
 // with its knowledge of the replicas' acknowledgement status.
 type InternalTruncateLogRequest struct {
-	RequestHeader `protobuf:"bytes,1,opt,name=header,embedded=header" json:"header"`
+	KVRequestHeader `protobuf:"bytes,1,opt,name=kvheader,embedded=kvheader" json:"kvheader"`
 	// Log entries < this index are to be discarded.
 	Index            uint64 `protobuf:"varint,2,opt,name=index" json:"index"`
 	XXX_unrecognized []byte `json:"-"`
@@ -430,7 +430,7 @@ func (m *InternalTruncateLogRequest) GetIndex() uint64 {
 
 // InternalTruncateLogResponse is the response to an InternalTruncateLog() operation.
 type InternalTruncateLogResponse struct {
-	ResponseHeader   `protobuf:"bytes,1,opt,name=header,embedded=header" json:"header"`
+	KVResponseHeader `protobuf:"bytes,1,opt,name=kvheader,embedded=kvheader" json:"kvheader"`
 	XXX_unrecognized []byte `json:"-"`
 }
 
@@ -442,7 +442,7 @@ func (*InternalTruncateLogResponse) ProtoMessage()    {}
 // method. It is sent by the store on behalf of one of its ranges upon receipt
 // of a leader election event for that range.
 type InternalLeaderLeaseRequest struct {
-	RequestHeader    `protobuf:"bytes,1,opt,name=header,embedded=header" json:"header"`
+	KVRequestHeader  `protobuf:"bytes,1,opt,name=kvheader,embedded=kvheader" json:"kvheader"`
 	Lease            Lease  `protobuf:"bytes,2,opt,name=lease" json:"lease"`
 	XXX_unrecognized []byte `json:"-"`
 }
@@ -461,7 +461,7 @@ func (m *InternalLeaderLeaseRequest) GetLease() Lease {
 // An InternalLeaderLeaseResponse is the response to an InternalLeaderLease()
 // operation.
 type InternalLeaderLeaseResponse struct {
-	ResponseHeader   `protobuf:"bytes,1,opt,name=header,embedded=header" json:"header"`
+	KVResponseHeader `protobuf:"bytes,1,opt,name=kvheader,embedded=kvheader" json:"kvheader"`
 	XXX_unrecognized []byte `json:"-"`
 }
 
@@ -670,7 +670,7 @@ func (m *InternalResponseUnion) GetInternalResolveIntentRange() *InternalResolve
 //
 // See comments for BatchRequest.
 type InternalBatchRequest struct {
-	RequestHeader    `protobuf:"bytes,1,opt,name=header,embedded=header" json:"header"`
+	KVRequestHeader  `protobuf:"bytes,1,opt,name=kvheader,embedded=kvheader" json:"kvheader"`
 	Requests         []InternalRequestUnion `protobuf:"bytes,2,rep,name=requests" json:"requests"`
 	XXX_unrecognized []byte                 `json:"-"`
 }
@@ -690,7 +690,7 @@ func (m *InternalBatchRequest) GetRequests() []InternalRequestUnion {
 //
 // See comments for BatchResponse.
 type InternalBatchResponse struct {
-	ResponseHeader   `protobuf:"bytes,1,opt,name=header,embedded=header" json:"header"`
+	KVResponseHeader `protobuf:"bytes,1,opt,name=kvheader,embedded=kvheader" json:"kvheader"`
 	Responses        []InternalResponseUnion `protobuf:"bytes,2,rep,name=responses" json:"responses"`
 	XXX_unrecognized []byte                  `json:"-"`
 }
@@ -1283,7 +1283,7 @@ func (m *InternalRangeLookupRequest) Unmarshal(data []byte) error {
 		switch fieldNum {
 		case 1:
 			if wireType != 2 {
-				return fmt.Errorf("proto: wrong wireType = %d for field RequestHeader", wireType)
+				return fmt.Errorf("proto: wrong wireType = %d for field KVRequestHeader", wireType)
 			}
 			var msglen int
 			for shift := uint(0); ; shift += 7 {
@@ -1301,7 +1301,7 @@ func (m *InternalRangeLookupRequest) Unmarshal(data []byte) error {
 			if postIndex > l {
 				return io.ErrUnexpectedEOF
 			}
-			if err := m.RequestHeader.Unmarshal(data[index:postIndex]); err != nil {
+			if err := m.KVRequestHeader.Unmarshal(data[index:postIndex]); err != nil {
 				return err
 			}
 			index = postIndex
@@ -1382,7 +1382,7 @@ func (m *InternalRangeLookupResponse) Unmarshal(data []byte) error {
 		switch fieldNum {
 		case 1:
 			if wireType != 2 {
-				return fmt.Errorf("proto: wrong wireType = %d for field ResponseHeader", wireType)
+				return fmt.Errorf("proto: wrong wireType = %d for field KVResponseHeader", wireType)
 			}
 			var msglen int
 			for shift := uint(0); ; shift += 7 {
@@ -1400,7 +1400,7 @@ func (m *InternalRangeLookupResponse) Unmarshal(data []byte) error {
 			if postIndex > l {
 				return io.ErrUnexpectedEOF
 			}
-			if err := m.ResponseHeader.Unmarshal(data[index:postIndex]); err != nil {
+			if err := m.KVResponseHeader.Unmarshal(data[index:postIndex]); err != nil {
 				return err
 			}
 			index = postIndex
@@ -1474,7 +1474,7 @@ func (m *InternalHeartbeatTxnRequest) Unmarshal(data []byte) error {
 		switch fieldNum {
 		case 1:
 			if wireType != 2 {
-				return fmt.Errorf("proto: wrong wireType = %d for field RequestHeader", wireType)
+				return fmt.Errorf("proto: wrong wireType = %d for field KVRequestHeader", wireType)
 			}
 			var msglen int
 			for shift := uint(0); ; shift += 7 {
@@ -1492,7 +1492,7 @@ func (m *InternalHeartbeatTxnRequest) Unmarshal(data []byte) error {
 			if postIndex > l {
 				return io.ErrUnexpectedEOF
 			}
-			if err := m.RequestHeader.Unmarshal(data[index:postIndex]); err != nil {
+			if err := m.KVRequestHeader.Unmarshal(data[index:postIndex]); err != nil {
 				return err
 			}
 			index = postIndex
@@ -1541,7 +1541,7 @@ func (m *InternalHeartbeatTxnResponse) Unmarshal(data []byte) error {
 		switch fieldNum {
 		case 1:
 			if wireType != 2 {
-				return fmt.Errorf("proto: wrong wireType = %d for field ResponseHeader", wireType)
+				return fmt.Errorf("proto: wrong wireType = %d for field KVResponseHeader", wireType)
 			}
 			var msglen int
 			for shift := uint(0); ; shift += 7 {
@@ -1559,7 +1559,7 @@ func (m *InternalHeartbeatTxnResponse) Unmarshal(data []byte) error {
 			if postIndex > l {
 				return io.ErrUnexpectedEOF
 			}
-			if err := m.ResponseHeader.Unmarshal(data[index:postIndex]); err != nil {
+			if err := m.KVResponseHeader.Unmarshal(data[index:postIndex]); err != nil {
 				return err
 			}
 			index = postIndex
@@ -1608,7 +1608,7 @@ func (m *InternalGCRequest) Unmarshal(data []byte) error {
 		switch fieldNum {
 		case 1:
 			if wireType != 2 {
-				return fmt.Errorf("proto: wrong wireType = %d for field RequestHeader", wireType)
+				return fmt.Errorf("proto: wrong wireType = %d for field KVRequestHeader", wireType)
 			}
 			var msglen int
 			for shift := uint(0); ; shift += 7 {
@@ -1626,7 +1626,7 @@ func (m *InternalGCRequest) Unmarshal(data []byte) error {
 			if postIndex > l {
 				return io.ErrUnexpectedEOF
 			}
-			if err := m.RequestHeader.Unmarshal(data[index:postIndex]); err != nil {
+			if err := m.KVRequestHeader.Unmarshal(data[index:postIndex]); err != nil {
 				return err
 			}
 			index = postIndex
@@ -1813,7 +1813,7 @@ func (m *InternalGCResponse) Unmarshal(data []byte) error {
 		switch fieldNum {
 		case 1:
 			if wireType != 2 {
-				return fmt.Errorf("proto: wrong wireType = %d for field ResponseHeader", wireType)
+				return fmt.Errorf("proto: wrong wireType = %d for field KVResponseHeader", wireType)
 			}
 			var msglen int
 			for shift := uint(0); ; shift += 7 {
@@ -1831,7 +1831,7 @@ func (m *InternalGCResponse) Unmarshal(data []byte) error {
 			if postIndex > l {
 				return io.ErrUnexpectedEOF
 			}
-			if err := m.ResponseHeader.Unmarshal(data[index:postIndex]); err != nil {
+			if err := m.KVResponseHeader.Unmarshal(data[index:postIndex]); err != nil {
 				return err
 			}
 			index = postIndex
@@ -1880,7 +1880,7 @@ func (m *InternalPushTxnRequest) Unmarshal(data []byte) error {
 		switch fieldNum {
 		case 1:
 			if wireType != 2 {
-				return fmt.Errorf("proto: wrong wireType = %d for field RequestHeader", wireType)
+				return fmt.Errorf("proto: wrong wireType = %d for field KVRequestHeader", wireType)
 			}
 			var msglen int
 			for shift := uint(0); ; shift += 7 {
@@ -1898,7 +1898,7 @@ func (m *InternalPushTxnRequest) Unmarshal(data []byte) error {
 			if postIndex > l {
 				return io.ErrUnexpectedEOF
 			}
-			if err := m.RequestHeader.Unmarshal(data[index:postIndex]); err != nil {
+			if err := m.KVRequestHeader.Unmarshal(data[index:postIndex]); err != nil {
 				return err
 			}
 			index = postIndex
@@ -2027,7 +2027,7 @@ func (m *InternalPushTxnResponse) Unmarshal(data []byte) error {
 		switch fieldNum {
 		case 1:
 			if wireType != 2 {
-				return fmt.Errorf("proto: wrong wireType = %d for field ResponseHeader", wireType)
+				return fmt.Errorf("proto: wrong wireType = %d for field KVResponseHeader", wireType)
 			}
 			var msglen int
 			for shift := uint(0); ; shift += 7 {
@@ -2045,7 +2045,7 @@ func (m *InternalPushTxnResponse) Unmarshal(data []byte) error {
 			if postIndex > l {
 				return io.ErrUnexpectedEOF
 			}
-			if err := m.ResponseHeader.Unmarshal(data[index:postIndex]); err != nil {
+			if err := m.KVResponseHeader.Unmarshal(data[index:postIndex]); err != nil {
 				return err
 			}
 			index = postIndex
@@ -2121,7 +2121,7 @@ func (m *InternalResolveIntentRequest) Unmarshal(data []byte) error {
 		switch fieldNum {
 		case 1:
 			if wireType != 2 {
-				return fmt.Errorf("proto: wrong wireType = %d for field RequestHeader", wireType)
+				return fmt.Errorf("proto: wrong wireType = %d for field KVRequestHeader", wireType)
 			}
 			var msglen int
 			for shift := uint(0); ; shift += 7 {
@@ -2139,7 +2139,7 @@ func (m *InternalResolveIntentRequest) Unmarshal(data []byte) error {
 			if postIndex > l {
 				return io.ErrUnexpectedEOF
 			}
-			if err := m.RequestHeader.Unmarshal(data[index:postIndex]); err != nil {
+			if err := m.KVRequestHeader.Unmarshal(data[index:postIndex]); err != nil {
 				return err
 			}
 			index = postIndex
@@ -2188,7 +2188,7 @@ func (m *InternalResolveIntentResponse) Unmarshal(data []byte) error {
 		switch fieldNum {
 		case 1:
 			if wireType != 2 {
-				return fmt.Errorf("proto: wrong wireType = %d for field ResponseHeader", wireType)
+				return fmt.Errorf("proto: wrong wireType = %d for field KVResponseHeader", wireType)
 			}
 			var msglen int
 			for shift := uint(0); ; shift += 7 {
@@ -2206,7 +2206,7 @@ func (m *InternalResolveIntentResponse) Unmarshal(data []byte) error {
 			if postIndex > l {
 				return io.ErrUnexpectedEOF
 			}
-			if err := m.ResponseHeader.Unmarshal(data[index:postIndex]); err != nil {
+			if err := m.KVResponseHeader.Unmarshal(data[index:postIndex]); err != nil {
 				return err
 			}
 			index = postIndex
@@ -2255,7 +2255,7 @@ func (m *InternalResolveIntentRangeRequest) Unmarshal(data []byte) error {
 		switch fieldNum {
 		case 1:
 			if wireType != 2 {
-				return fmt.Errorf("proto: wrong wireType = %d for field RequestHeader", wireType)
+				return fmt.Errorf("proto: wrong wireType = %d for field KVRequestHeader", wireType)
 			}
 			var msglen int
 			for shift := uint(0); ; shift += 7 {
@@ -2273,7 +2273,7 @@ func (m *InternalResolveIntentRangeRequest) Unmarshal(data []byte) error {
 			if postIndex > l {
 				return io.ErrUnexpectedEOF
 			}
-			if err := m.RequestHeader.Unmarshal(data[index:postIndex]); err != nil {
+			if err := m.KVRequestHeader.Unmarshal(data[index:postIndex]); err != nil {
 				return err
 			}
 			index = postIndex
@@ -2322,7 +2322,7 @@ func (m *InternalResolveIntentRangeResponse) Unmarshal(data []byte) error {
 		switch fieldNum {
 		case 1:
 			if wireType != 2 {
-				return fmt.Errorf("proto: wrong wireType = %d for field ResponseHeader", wireType)
+				return fmt.Errorf("proto: wrong wireType = %d for field KVResponseHeader", wireType)
 			}
 			var msglen int
 			for shift := uint(0); ; shift += 7 {
@@ -2340,7 +2340,7 @@ func (m *InternalResolveIntentRangeResponse) Unmarshal(data []byte) error {
 			if postIndex > l {
 				return io.ErrUnexpectedEOF
 			}
-			if err := m.ResponseHeader.Unmarshal(data[index:postIndex]); err != nil {
+			if err := m.KVResponseHeader.Unmarshal(data[index:postIndex]); err != nil {
 				return err
 			}
 			index = postIndex
@@ -2389,7 +2389,7 @@ func (m *InternalMergeRequest) Unmarshal(data []byte) error {
 		switch fieldNum {
 		case 1:
 			if wireType != 2 {
-				return fmt.Errorf("proto: wrong wireType = %d for field RequestHeader", wireType)
+				return fmt.Errorf("proto: wrong wireType = %d for field KVRequestHeader", wireType)
 			}
 			var msglen int
 			for shift := uint(0); ; shift += 7 {
@@ -2407,7 +2407,7 @@ func (m *InternalMergeRequest) Unmarshal(data []byte) error {
 			if postIndex > l {
 				return io.ErrUnexpectedEOF
 			}
-			if err := m.RequestHeader.Unmarshal(data[index:postIndex]); err != nil {
+			if err := m.KVRequestHeader.Unmarshal(data[index:postIndex]); err != nil {
 				return err
 			}
 			index = postIndex
@@ -2480,7 +2480,7 @@ func (m *InternalMergeResponse) Unmarshal(data []byte) error {
 		switch fieldNum {
 		case 1:
 			if wireType != 2 {
-				return fmt.Errorf("proto: wrong wireType = %d for field ResponseHeader", wireType)
+				return fmt.Errorf("proto: wrong wireType = %d for field KVResponseHeader", wireType)
 			}
 			var msglen int
 			for shift := uint(0); ; shift += 7 {
@@ -2498,7 +2498,7 @@ func (m *InternalMergeResponse) Unmarshal(data []byte) error {
 			if postIndex > l {
 				return io.ErrUnexpectedEOF
 			}
-			if err := m.ResponseHeader.Unmarshal(data[index:postIndex]); err != nil {
+			if err := m.KVResponseHeader.Unmarshal(data[index:postIndex]); err != nil {
 				return err
 			}
 			index = postIndex
@@ -2547,7 +2547,7 @@ func (m *InternalTruncateLogRequest) Unmarshal(data []byte) error {
 		switch fieldNum {
 		case 1:
 			if wireType != 2 {
-				return fmt.Errorf("proto: wrong wireType = %d for field RequestHeader", wireType)
+				return fmt.Errorf("proto: wrong wireType = %d for field KVRequestHeader", wireType)
 			}
 			var msglen int
 			for shift := uint(0); ; shift += 7 {
@@ -2565,7 +2565,7 @@ func (m *InternalTruncateLogRequest) Unmarshal(data []byte) error {
 			if postIndex > l {
 				return io.ErrUnexpectedEOF
 			}
-			if err := m.RequestHeader.Unmarshal(data[index:postIndex]); err != nil {
+			if err := m.KVRequestHeader.Unmarshal(data[index:postIndex]); err != nil {
 				return err
 			}
 			index = postIndex
@@ -2629,7 +2629,7 @@ func (m *InternalTruncateLogResponse) Unmarshal(data []byte) error {
 		switch fieldNum {
 		case 1:
 			if wireType != 2 {
-				return fmt.Errorf("proto: wrong wireType = %d for field ResponseHeader", wireType)
+				return fmt.Errorf("proto: wrong wireType = %d for field KVResponseHeader", wireType)
 			}
 			var msglen int
 			for shift := uint(0); ; shift += 7 {
@@ -2647,7 +2647,7 @@ func (m *InternalTruncateLogResponse) Unmarshal(data []byte) error {
 			if postIndex > l {
 				return io.ErrUnexpectedEOF
 			}
-			if err := m.ResponseHeader.Unmarshal(data[index:postIndex]); err != nil {
+			if err := m.KVResponseHeader.Unmarshal(data[index:postIndex]); err != nil {
 				return err
 			}
 			index = postIndex
@@ -2696,7 +2696,7 @@ func (m *InternalLeaderLeaseRequest) Unmarshal(data []byte) error {
 		switch fieldNum {
 		case 1:
 			if wireType != 2 {
-				return fmt.Errorf("proto: wrong wireType = %d for field RequestHeader", wireType)
+				return fmt.Errorf("proto: wrong wireType = %d for field KVRequestHeader", wireType)
 			}
 			var msglen int
 			for shift := uint(0); ; shift += 7 {
@@ -2714,7 +2714,7 @@ func (m *InternalLeaderLeaseRequest) Unmarshal(data []byte) error {
 			if postIndex > l {
 				return io.ErrUnexpectedEOF
 			}
-			if err := m.RequestHeader.Unmarshal(data[index:postIndex]); err != nil {
+			if err := m.KVRequestHeader.Unmarshal(data[index:postIndex]); err != nil {
 				return err
 			}
 			index = postIndex
@@ -2787,7 +2787,7 @@ func (m *InternalLeaderLeaseResponse) Unmarshal(data []byte) error {
 		switch fieldNum {
 		case 1:
 			if wireType != 2 {
-				return fmt.Errorf("proto: wrong wireType = %d for field ResponseHeader", wireType)
+				return fmt.Errorf("proto: wrong wireType = %d for field KVResponseHeader", wireType)
 			}
 			var msglen int
 			for shift := uint(0); ; shift += 7 {
@@ -2805,7 +2805,7 @@ func (m *InternalLeaderLeaseResponse) Unmarshal(data []byte) error {
 			if postIndex > l {
 				return io.ErrUnexpectedEOF
 			}
-			if err := m.ResponseHeader.Unmarshal(data[index:postIndex]); err != nil {
+			if err := m.KVResponseHeader.Unmarshal(data[index:postIndex]); err != nil {
 				return err
 			}
 			index = postIndex
@@ -3534,7 +3534,7 @@ func (m *InternalBatchRequest) Unmarshal(data []byte) error {
 		switch fieldNum {
 		case 1:
 			if wireType != 2 {
-				return fmt.Errorf("proto: wrong wireType = %d for field RequestHeader", wireType)
+				return fmt.Errorf("proto: wrong wireType = %d for field KVRequestHeader", wireType)
 			}
 			var msglen int
 			for shift := uint(0); ; shift += 7 {
@@ -3552,7 +3552,7 @@ func (m *InternalBatchRequest) Unmarshal(data []byte) error {
 			if postIndex > l {
 				return io.ErrUnexpectedEOF
 			}
-			if err := m.RequestHeader.Unmarshal(data[index:postIndex]); err != nil {
+			if err := m.KVRequestHeader.Unmarshal(data[index:postIndex]); err != nil {
 				return err
 			}
 			index = postIndex
@@ -3626,7 +3626,7 @@ func (m *InternalBatchResponse) Unmarshal(data []byte) error {
 		switch fieldNum {
 		case 1:
 			if wireType != 2 {
-				return fmt.Errorf("proto: wrong wireType = %d for field ResponseHeader", wireType)
+				return fmt.Errorf("proto: wrong wireType = %d for field KVResponseHeader", wireType)
 			}
 			var msglen int
 			for shift := uint(0); ; shift += 7 {
@@ -3644,7 +3644,7 @@ func (m *InternalBatchResponse) Unmarshal(data []byte) error {
 			if postIndex > l {
 				return io.ErrUnexpectedEOF
 			}
-			if err := m.ResponseHeader.Unmarshal(data[index:postIndex]); err != nil {
+			if err := m.KVResponseHeader.Unmarshal(data[index:postIndex]); err != nil {
 				return err
 			}
 			index = postIndex
@@ -5694,7 +5694,7 @@ func (this *InternalRaftCommandUnion) SetValue(value interface{}) bool {
 func (m *InternalRangeLookupRequest) Size() (n int) {
 	var l int
 	_ = l
-	l = m.RequestHeader.Size()
+	l = m.KVRequestHeader.Size()
 	n += 1 + l + sovInternal(uint64(l))
 	n += 1 + sovInternal(uint64(m.MaxRanges))
 	n += 2
@@ -5707,7 +5707,7 @@ func (m *InternalRangeLookupRequest) Size() (n int) {
 func (m *InternalRangeLookupResponse) Size() (n int) {
 	var l int
 	_ = l
-	l = m.ResponseHeader.Size()
+	l = m.KVResponseHeader.Size()
 	n += 1 + l + sovInternal(uint64(l))
 	if len(m.Ranges) > 0 {
 		for _, e := range m.Ranges {
@@ -5724,7 +5724,7 @@ func (m *InternalRangeLookupResponse) Size() (n int) {
 func (m *InternalHeartbeatTxnRequest) Size() (n int) {
 	var l int
 	_ = l
-	l = m.RequestHeader.Size()
+	l = m.KVRequestHeader.Size()
 	n += 1 + l + sovInternal(uint64(l))
 	if m.XXX_unrecognized != nil {
 		n += len(m.XXX_unrecognized)
@@ -5735,7 +5735,7 @@ func (m *InternalHeartbeatTxnRequest) Size() (n int) {
 func (m *InternalHeartbeatTxnResponse) Size() (n int) {
 	var l int
 	_ = l
-	l = m.ResponseHeader.Size()
+	l = m.KVResponseHeader.Size()
 	n += 1 + l + sovInternal(uint64(l))
 	if m.XXX_unrecognized != nil {
 		n += len(m.XXX_unrecognized)
@@ -5746,7 +5746,7 @@ func (m *InternalHeartbeatTxnResponse) Size() (n int) {
 func (m *InternalGCRequest) Size() (n int) {
 	var l int
 	_ = l
-	l = m.RequestHeader.Size()
+	l = m.KVRequestHeader.Size()
 	n += 1 + l + sovInternal(uint64(l))
 	l = m.GCMeta.Size()
 	n += 1 + l + sovInternal(uint64(l))
@@ -5780,7 +5780,7 @@ func (m *InternalGCRequest_GCKey) Size() (n int) {
 func (m *InternalGCResponse) Size() (n int) {
 	var l int
 	_ = l
-	l = m.ResponseHeader.Size()
+	l = m.KVResponseHeader.Size()
 	n += 1 + l + sovInternal(uint64(l))
 	if m.XXX_unrecognized != nil {
 		n += len(m.XXX_unrecognized)
@@ -5791,7 +5791,7 @@ func (m *InternalGCResponse) Size() (n int) {
 func (m *InternalPushTxnRequest) Size() (n int) {
 	var l int
 	_ = l
-	l = m.RequestHeader.Size()
+	l = m.KVRequestHeader.Size()
 	n += 1 + l + sovInternal(uint64(l))
 	l = m.PusheeTxn.Size()
 	n += 1 + l + sovInternal(uint64(l))
@@ -5808,7 +5808,7 @@ func (m *InternalPushTxnRequest) Size() (n int) {
 func (m *InternalPushTxnResponse) Size() (n int) {
 	var l int
 	_ = l
-	l = m.ResponseHeader.Size()
+	l = m.KVResponseHeader.Size()
 	n += 1 + l + sovInternal(uint64(l))
 	if m.PusheeTxn != nil {
 		l = m.PusheeTxn.Size()
@@ -5823,7 +5823,7 @@ func (m *InternalPushTxnResponse) Size() (n int) {
 func (m *InternalResolveIntentRequest) Size() (n int) {
 	var l int
 	_ = l
-	l = m.RequestHeader.Size()
+	l = m.KVRequestHeader.Size()
 	n += 1 + l + sovInternal(uint64(l))
 	if m.XXX_unrecognized != nil {
 		n += len(m.XXX_unrecognized)
@@ -5834,7 +5834,7 @@ func (m *InternalResolveIntentRequest) Size() (n int) {
 func (m *InternalResolveIntentResponse) Size() (n int) {
 	var l int
 	_ = l
-	l = m.ResponseHeader.Size()
+	l = m.KVResponseHeader.Size()
 	n += 1 + l + sovInternal(uint64(l))
 	if m.XXX_unrecognized != nil {
 		n += len(m.XXX_unrecognized)
@@ -5845,7 +5845,7 @@ func (m *InternalResolveIntentResponse) Size() (n int) {
 func (m *InternalResolveIntentRangeRequest) Size() (n int) {
 	var l int
 	_ = l
-	l = m.RequestHeader.Size()
+	l = m.KVRequestHeader.Size()
 	n += 1 + l + sovInternal(uint64(l))
 	if m.XXX_unrecognized != nil {
 		n += len(m.XXX_unrecognized)
@@ -5856,7 +5856,7 @@ func (m *InternalResolveIntentRangeRequest) Size() (n int) {
 func (m *InternalResolveIntentRangeResponse) Size() (n int) {
 	var l int
 	_ = l
-	l = m.ResponseHeader.Size()
+	l = m.KVResponseHeader.Size()
 	n += 1 + l + sovInternal(uint64(l))
 	if m.XXX_unrecognized != nil {
 		n += len(m.XXX_unrecognized)
@@ -5867,7 +5867,7 @@ func (m *InternalResolveIntentRangeResponse) Size() (n int) {
 func (m *InternalMergeRequest) Size() (n int) {
 	var l int
 	_ = l
-	l = m.RequestHeader.Size()
+	l = m.KVRequestHeader.Size()
 	n += 1 + l + sovInternal(uint64(l))
 	l = m.Value.Size()
 	n += 1 + l + sovInternal(uint64(l))
@@ -5880,7 +5880,7 @@ func (m *InternalMergeRequest) Size() (n int) {
 func (m *InternalMergeResponse) Size() (n int) {
 	var l int
 	_ = l
-	l = m.ResponseHeader.Size()
+	l = m.KVResponseHeader.Size()
 	n += 1 + l + sovInternal(uint64(l))
 	if m.XXX_unrecognized != nil {
 		n += len(m.XXX_unrecognized)
@@ -5891,7 +5891,7 @@ func (m *InternalMergeResponse) Size() (n int) {
 func (m *InternalTruncateLogRequest) Size() (n int) {
 	var l int
 	_ = l
-	l = m.RequestHeader.Size()
+	l = m.KVRequestHeader.Size()
 	n += 1 + l + sovInternal(uint64(l))
 	n += 1 + sovInternal(uint64(m.Index))
 	if m.XXX_unrecognized != nil {
@@ -5903,7 +5903,7 @@ func (m *InternalTruncateLogRequest) Size() (n int) {
 func (m *InternalTruncateLogResponse) Size() (n int) {
 	var l int
 	_ = l
-	l = m.ResponseHeader.Size()
+	l = m.KVResponseHeader.Size()
 	n += 1 + l + sovInternal(uint64(l))
 	if m.XXX_unrecognized != nil {
 		n += len(m.XXX_unrecognized)
@@ -5914,7 +5914,7 @@ func (m *InternalTruncateLogResponse) Size() (n int) {
 func (m *InternalLeaderLeaseRequest) Size() (n int) {
 	var l int
 	_ = l
-	l = m.RequestHeader.Size()
+	l = m.KVRequestHeader.Size()
 	n += 1 + l + sovInternal(uint64(l))
 	l = m.Lease.Size()
 	n += 1 + l + sovInternal(uint64(l))
@@ -5927,7 +5927,7 @@ func (m *InternalLeaderLeaseRequest) Size() (n int) {
 func (m *InternalLeaderLeaseResponse) Size() (n int) {
 	var l int
 	_ = l
-	l = m.ResponseHeader.Size()
+	l = m.KVResponseHeader.Size()
 	n += 1 + l + sovInternal(uint64(l))
 	if m.XXX_unrecognized != nil {
 		n += len(m.XXX_unrecognized)
@@ -6044,7 +6044,7 @@ func (m *InternalResponseUnion) Size() (n int) {
 func (m *InternalBatchRequest) Size() (n int) {
 	var l int
 	_ = l
-	l = m.RequestHeader.Size()
+	l = m.KVRequestHeader.Size()
 	n += 1 + l + sovInternal(uint64(l))
 	if len(m.Requests) > 0 {
 		for _, e := range m.Requests {
@@ -6061,7 +6061,7 @@ func (m *InternalBatchRequest) Size() (n int) {
 func (m *InternalBatchResponse) Size() (n int) {
 	var l int
 	_ = l
-	l = m.ResponseHeader.Size()
+	l = m.KVResponseHeader.Size()
 	n += 1 + l + sovInternal(uint64(l))
 	if len(m.Responses) > 0 {
 		for _, e := range m.Responses {
@@ -6371,8 +6371,8 @@ func (m *InternalRangeLookupRequest) MarshalTo(data []byte) (n int, err error) {
 	_ = l
 	data[i] = 0xa
 	i++
-	i = encodeVarintInternal(data, i, uint64(m.RequestHeader.Size()))
-	n1, err := m.RequestHeader.MarshalTo(data[i:])
+	i = encodeVarintInternal(data, i, uint64(m.KVRequestHeader.Size()))
+	n1, err := m.KVRequestHeader.MarshalTo(data[i:])
 	if err != nil {
 		return 0, err
 	}
@@ -6411,8 +6411,8 @@ func (m *InternalRangeLookupResponse) MarshalTo(data []byte) (n int, err error) 
 	_ = l
 	data[i] = 0xa
 	i++
-	i = encodeVarintInternal(data, i, uint64(m.ResponseHeader.Size()))
-	n2, err := m.ResponseHeader.MarshalTo(data[i:])
+	i = encodeVarintInternal(data, i, uint64(m.KVResponseHeader.Size()))
+	n2, err := m.KVResponseHeader.MarshalTo(data[i:])
 	if err != nil {
 		return 0, err
 	}
@@ -6452,8 +6452,8 @@ func (m *InternalHeartbeatTxnRequest) MarshalTo(data []byte) (n int, err error) 
 	_ = l
 	data[i] = 0xa
 	i++
-	i = encodeVarintInternal(data, i, uint64(m.RequestHeader.Size()))
-	n3, err := m.RequestHeader.MarshalTo(data[i:])
+	i = encodeVarintInternal(data, i, uint64(m.KVRequestHeader.Size()))
+	n3, err := m.KVRequestHeader.MarshalTo(data[i:])
 	if err != nil {
 		return 0, err
 	}
@@ -6481,8 +6481,8 @@ func (m *InternalHeartbeatTxnResponse) MarshalTo(data []byte) (n int, err error)
 	_ = l
 	data[i] = 0xa
 	i++
-	i = encodeVarintInternal(data, i, uint64(m.ResponseHeader.Size()))
-	n4, err := m.ResponseHeader.MarshalTo(data[i:])
+	i = encodeVarintInternal(data, i, uint64(m.KVResponseHeader.Size()))
+	n4, err := m.KVResponseHeader.MarshalTo(data[i:])
 	if err != nil {
 		return 0, err
 	}
@@ -6510,8 +6510,8 @@ func (m *InternalGCRequest) MarshalTo(data []byte) (n int, err error) {
 	_ = l
 	data[i] = 0xa
 	i++
-	i = encodeVarintInternal(data, i, uint64(m.RequestHeader.Size()))
-	n5, err := m.RequestHeader.MarshalTo(data[i:])
+	i = encodeVarintInternal(data, i, uint64(m.KVRequestHeader.Size()))
+	n5, err := m.KVRequestHeader.MarshalTo(data[i:])
 	if err != nil {
 		return 0, err
 	}
@@ -6594,8 +6594,8 @@ func (m *InternalGCResponse) MarshalTo(data []byte) (n int, err error) {
 	_ = l
 	data[i] = 0xa
 	i++
-	i = encodeVarintInternal(data, i, uint64(m.ResponseHeader.Size()))
-	n8, err := m.ResponseHeader.MarshalTo(data[i:])
+	i = encodeVarintInternal(data, i, uint64(m.KVResponseHeader.Size()))
+	n8, err := m.KVResponseHeader.MarshalTo(data[i:])
 	if err != nil {
 		return 0, err
 	}
@@ -6623,8 +6623,8 @@ func (m *InternalPushTxnRequest) MarshalTo(data []byte) (n int, err error) {
 	_ = l
 	data[i] = 0xa
 	i++
-	i = encodeVarintInternal(data, i, uint64(m.RequestHeader.Size()))
-	n9, err := m.RequestHeader.MarshalTo(data[i:])
+	i = encodeVarintInternal(data, i, uint64(m.KVRequestHeader.Size()))
+	n9, err := m.KVRequestHeader.MarshalTo(data[i:])
 	if err != nil {
 		return 0, err
 	}
@@ -6679,8 +6679,8 @@ func (m *InternalPushTxnResponse) MarshalTo(data []byte) (n int, err error) {
 	_ = l
 	data[i] = 0xa
 	i++
-	i = encodeVarintInternal(data, i, uint64(m.ResponseHeader.Size()))
-	n12, err := m.ResponseHeader.MarshalTo(data[i:])
+	i = encodeVarintInternal(data, i, uint64(m.KVResponseHeader.Size()))
+	n12, err := m.KVResponseHeader.MarshalTo(data[i:])
 	if err != nil {
 		return 0, err
 	}
@@ -6718,8 +6718,8 @@ func (m *InternalResolveIntentRequest) MarshalTo(data []byte) (n int, err error)
 	_ = l
 	data[i] = 0xa
 	i++
-	i = encodeVarintInternal(data, i, uint64(m.RequestHeader.Size()))
-	n14, err := m.RequestHeader.MarshalTo(data[i:])
+	i = encodeVarintInternal(data, i, uint64(m.KVRequestHeader.Size()))
+	n14, err := m.KVRequestHeader.MarshalTo(data[i:])
 	if err != nil {
 		return 0, err
 	}
@@ -6747,8 +6747,8 @@ func (m *InternalResolveIntentResponse) MarshalTo(data []byte) (n int, err error
 	_ = l
 	data[i] = 0xa
 	i++
-	i = encodeVarintInternal(data, i, uint64(m.ResponseHeader.Size()))
-	n15, err := m.ResponseHeader.MarshalTo(data[i:])
+	i = encodeVarintInternal(data, i, uint64(m.KVResponseHeader.Size()))
+	n15, err := m.KVResponseHeader.MarshalTo(data[i:])
 	if err != nil {
 		return 0, err
 	}
@@ -6776,8 +6776,8 @@ func (m *InternalResolveIntentRangeRequest) MarshalTo(data []byte) (n int, err e
 	_ = l
 	data[i] = 0xa
 	i++
-	i = encodeVarintInternal(data, i, uint64(m.RequestHeader.Size()))
-	n16, err := m.RequestHeader.MarshalTo(data[i:])
+	i = encodeVarintInternal(data, i, uint64(m.KVRequestHeader.Size()))
+	n16, err := m.KVRequestHeader.MarshalTo(data[i:])
 	if err != nil {
 		return 0, err
 	}
@@ -6805,8 +6805,8 @@ func (m *InternalResolveIntentRangeResponse) MarshalTo(data []byte) (n int, err 
 	_ = l
 	data[i] = 0xa
 	i++
-	i = encodeVarintInternal(data, i, uint64(m.ResponseHeader.Size()))
-	n17, err := m.ResponseHeader.MarshalTo(data[i:])
+	i = encodeVarintInternal(data, i, uint64(m.KVResponseHeader.Size()))
+	n17, err := m.KVResponseHeader.MarshalTo(data[i:])
 	if err != nil {
 		return 0, err
 	}
@@ -6834,8 +6834,8 @@ func (m *InternalMergeRequest) MarshalTo(data []byte) (n int, err error) {
 	_ = l
 	data[i] = 0xa
 	i++
-	i = encodeVarintInternal(data, i, uint64(m.RequestHeader.Size()))
-	n18, err := m.RequestHeader.MarshalTo(data[i:])
+	i = encodeVarintInternal(data, i, uint64(m.KVRequestHeader.Size()))
+	n18, err := m.KVRequestHeader.MarshalTo(data[i:])
 	if err != nil {
 		return 0, err
 	}
@@ -6871,8 +6871,8 @@ func (m *InternalMergeResponse) MarshalTo(data []byte) (n int, err error) {
 	_ = l
 	data[i] = 0xa
 	i++
-	i = encodeVarintInternal(data, i, uint64(m.ResponseHeader.Size()))
-	n20, err := m.ResponseHeader.MarshalTo(data[i:])
+	i = encodeVarintInternal(data, i, uint64(m.KVResponseHeader.Size()))
+	n20, err := m.KVResponseHeader.MarshalTo(data[i:])
 	if err != nil {
 		return 0, err
 	}
@@ -6900,8 +6900,8 @@ func (m *InternalTruncateLogRequest) MarshalTo(data []byte) (n int, err error) {
 	_ = l
 	data[i] = 0xa
 	i++
-	i = encodeVarintInternal(data, i, uint64(m.RequestHeader.Size()))
-	n21, err := m.RequestHeader.MarshalTo(data[i:])
+	i = encodeVarintInternal(data, i, uint64(m.KVRequestHeader.Size()))
+	n21, err := m.KVRequestHeader.MarshalTo(data[i:])
 	if err != nil {
 		return 0, err
 	}
@@ -6932,8 +6932,8 @@ func (m *InternalTruncateLogResponse) MarshalTo(data []byte) (n int, err error) 
 	_ = l
 	data[i] = 0xa
 	i++
-	i = encodeVarintInternal(data, i, uint64(m.ResponseHeader.Size()))
-	n22, err := m.ResponseHeader.MarshalTo(data[i:])
+	i = encodeVarintInternal(data, i, uint64(m.KVResponseHeader.Size()))
+	n22, err := m.KVResponseHeader.MarshalTo(data[i:])
 	if err != nil {
 		return 0, err
 	}
@@ -6961,8 +6961,8 @@ func (m *InternalLeaderLeaseRequest) MarshalTo(data []byte) (n int, err error) {
 	_ = l
 	data[i] = 0xa
 	i++
-	i = encodeVarintInternal(data, i, uint64(m.RequestHeader.Size()))
-	n23, err := m.RequestHeader.MarshalTo(data[i:])
+	i = encodeVarintInternal(data, i, uint64(m.KVRequestHeader.Size()))
+	n23, err := m.KVRequestHeader.MarshalTo(data[i:])
 	if err != nil {
 		return 0, err
 	}
@@ -6998,8 +6998,8 @@ func (m *InternalLeaderLeaseResponse) MarshalTo(data []byte) (n int, err error) 
 	_ = l
 	data[i] = 0xa
 	i++
-	i = encodeVarintInternal(data, i, uint64(m.ResponseHeader.Size()))
-	n25, err := m.ResponseHeader.MarshalTo(data[i:])
+	i = encodeVarintInternal(data, i, uint64(m.KVResponseHeader.Size()))
+	n25, err := m.KVResponseHeader.MarshalTo(data[i:])
 	if err != nil {
 		return 0, err
 	}
@@ -7301,8 +7301,8 @@ func (m *InternalBatchRequest) MarshalTo(data []byte) (n int, err error) {
 	_ = l
 	data[i] = 0xa
 	i++
-	i = encodeVarintInternal(data, i, uint64(m.RequestHeader.Size()))
-	n48, err := m.RequestHeader.MarshalTo(data[i:])
+	i = encodeVarintInternal(data, i, uint64(m.KVRequestHeader.Size()))
+	n48, err := m.KVRequestHeader.MarshalTo(data[i:])
 	if err != nil {
 		return 0, err
 	}
@@ -7342,8 +7342,8 @@ func (m *InternalBatchResponse) MarshalTo(data []byte) (n int, err error) {
 	_ = l
 	data[i] = 0xa
 	i++
-	i = encodeVarintInternal(data, i, uint64(m.ResponseHeader.Size()))
-	n49, err := m.ResponseHeader.MarshalTo(data[i:])
+	i = encodeVarintInternal(data, i, uint64(m.KVResponseHeader.Size()))
+	n49, err := m.KVResponseHeader.MarshalTo(data[i:])
 	if err != nil {
 		return 0, err
 	}

--- a/proto/internal.proto
+++ b/proto/internal.proto
@@ -35,7 +35,7 @@ option (gogoproto.unmarshaler_all) = true;
 // additional consecutive addressable ranges. Specify max_ranges > 1
 // to pre-fill the range descriptor cache.
 message InternalRangeLookupRequest {
-  optional RequestHeader header = 1 [(gogoproto.nullable) = false, (gogoproto.embed) = true];
+  optional KVRequestHeader kvheader = 1 [(gogoproto.nullable) = false, (gogoproto.embed) = true];
   optional int32 max_ranges = 2 [(gogoproto.nullable) = false];
   // Ignore intents indicates whether or not intents encountered
   // while looking up the range info should be resolved. This should
@@ -51,7 +51,7 @@ message InternalRangeLookupRequest {
 // additional consecutive ranges beyond the requested range to pre-fill
 // the range descriptor cache.
 message InternalRangeLookupResponse {
-  optional ResponseHeader header = 1 [(gogoproto.nullable) = false, (gogoproto.embed) = true];
+  optional KVResponseHeader kvheader = 1 [(gogoproto.nullable) = false, (gogoproto.embed) = true];
   repeated RangeDescriptor ranges = 2 [(gogoproto.nullable) = false];
 }
 
@@ -61,7 +61,7 @@ message InternalRangeLookupResponse {
 // ongoing. Note that this heartbeat message is different from the
 // heartbeat message in the gossip protocol.
 message InternalHeartbeatTxnRequest {
-  optional RequestHeader header = 1 [(gogoproto.nullable) = false, (gogoproto.embed) = true];
+  optional KVRequestHeader kvheader = 1 [(gogoproto.nullable) = false, (gogoproto.embed) = true];
 }
 
 // An InternalHeartbeatTxnResponse is the return value from the
@@ -70,14 +70,14 @@ message InternalHeartbeatTxnRequest {
 // know the disposition of the transaction (i.e. aborted, committed or
 // pending).
 message InternalHeartbeatTxnResponse {
-  optional ResponseHeader header = 1 [(gogoproto.nullable) = false, (gogoproto.embed) = true];
+  optional KVResponseHeader kvheader = 1 [(gogoproto.nullable) = false, (gogoproto.embed) = true];
 }
 
 // An InternalGCRequest is arguments to the InternalGC() method. It's
 // sent by range leaders after scanning range data to find expired
 // MVCC values.
 message InternalGCRequest {
-  optional RequestHeader header = 1 [(gogoproto.nullable) = false, (gogoproto.embed) = true];
+  optional KVRequestHeader kvheader = 1 [(gogoproto.nullable) = false, (gogoproto.embed) = true];
   optional GCMetadata gc_meta = 2 [(gogoproto.nullable) = false, (gogoproto.customname) = "GCMeta"];
 
   message GCKey {
@@ -90,7 +90,7 @@ message InternalGCRequest {
 // An InternalGCResponse is the return value from the InternalGC()
 // method.
 message InternalGCResponse {
-  optional ResponseHeader header = 1 [(gogoproto.nullable) = false, (gogoproto.embed) = true];
+  optional KVResponseHeader kvheader = 1 [(gogoproto.nullable) = false, (gogoproto.embed) = true];
 }
 
 // TxnPushType determines what action to take when pushing a
@@ -119,7 +119,7 @@ enum PushTxnType {
 // course of action is determined by the specified push type, and by
 // the owning txn's status and priority.
 message InternalPushTxnRequest {
-  optional RequestHeader header = 1 [(gogoproto.nullable) = false, (gogoproto.embed) = true];
+  optional KVRequestHeader kvheader = 1 [(gogoproto.nullable) = false, (gogoproto.embed) = true];
   optional Transaction pushee_txn = 2 [(gogoproto.nullable) = false];
   // Now holds the timestamp used to compare the last heartbeat of the pushee
   // against. This is necessary since the request header's timestamp does not
@@ -146,7 +146,7 @@ message InternalPushTxnRequest {
 // InternalResolveIntent() on the conflicted key. It returns an error
 // otherwise.
 message InternalPushTxnResponse {
-  optional ResponseHeader header = 1 [(gogoproto.nullable) = false, (gogoproto.embed) = true];
+  optional KVResponseHeader kvheader = 1 [(gogoproto.nullable) = false, (gogoproto.embed) = true];
   // Txn is non-nil if the transaction could be heartbeat and contains
   // the current value of the transaction.
   optional Transaction pushee_txn = 2;
@@ -157,39 +157,39 @@ message InternalPushTxnResponse {
 // coordinators and after success calling InternalPushTxn to clean up
 // write intents: either to remove them or commit them.
 message InternalResolveIntentRequest {
-  optional RequestHeader header = 1 [(gogoproto.nullable) = false, (gogoproto.embed) = true];
+  optional KVRequestHeader kvheader = 1 [(gogoproto.nullable) = false, (gogoproto.embed) = true];
 }
 
 // An InternalResolveIntentResponse is the return value from the
 // InternalResolveIntent() method.
 message InternalResolveIntentResponse {
-  optional ResponseHeader header = 1 [(gogoproto.nullable) = false, (gogoproto.embed) = true];
+  optional KVResponseHeader kvheader = 1 [(gogoproto.nullable) = false, (gogoproto.embed) = true];
 }
 
 // An InternalResolveIntentRangeRequest is arguments to the
 // InternalResolveIntentRange() method. This clear write intents
 // for a range of keys to resolve intents created by range ops.
 message InternalResolveIntentRangeRequest {
-  optional RequestHeader header = 1 [(gogoproto.nullable) = false, (gogoproto.embed) = true];
+  optional KVRequestHeader kvheader = 1 [(gogoproto.nullable) = false, (gogoproto.embed) = true];
 }
 
 // An InternalResolveIntentRangeResponse is the return value from the
 // InternalResolveIntent() method.
 message InternalResolveIntentRangeResponse {
-  optional ResponseHeader header = 1 [(gogoproto.nullable) = false, (gogoproto.embed) = true];
+  optional KVResponseHeader kvheader = 1 [(gogoproto.nullable) = false, (gogoproto.embed) = true];
 }
 
 // An InternalMergeRequest contains arguments to the InternalMerge() method. It
 // specifies a key and a value which should be merged into the existing value at
 // that key.
 message InternalMergeRequest {
-  optional RequestHeader header = 1 [(gogoproto.nullable) = false, (gogoproto.embed) = true];
+  optional KVRequestHeader kvheader = 1 [(gogoproto.nullable) = false, (gogoproto.embed) = true];
   optional Value value = 2 [(gogoproto.nullable) = false];
 }
 
 // InternalMergeResponse is the response to an InternalMerge() operation.
 message InternalMergeResponse {
-  optional ResponseHeader header = 1 [(gogoproto.nullable) = false, (gogoproto.embed) = true];
+  optional KVResponseHeader kvheader = 1 [(gogoproto.nullable) = false, (gogoproto.embed) = true];
 }
 
 // InternalTruncateLogRequest is used to remove a prefix of the raft log. While there
@@ -198,7 +198,7 @@ message InternalMergeResponse {
 // to identical as possible. The raft leader can also inform decisions about the cutoff point
 // with its knowledge of the replicas' acknowledgement status.
 message InternalTruncateLogRequest {
-  optional RequestHeader header = 1 [(gogoproto.nullable) = false, (gogoproto.embed) = true];
+  optional KVRequestHeader kvheader = 1 [(gogoproto.nullable) = false, (gogoproto.embed) = true];
 
   // Log entries < this index are to be discarded.
   optional uint64 index = 2 [(gogoproto.nullable) = false];
@@ -206,21 +206,21 @@ message InternalTruncateLogRequest {
 
 // InternalTruncateLogResponse is the response to an InternalTruncateLog() operation.
 message InternalTruncateLogResponse {
-  optional ResponseHeader header = 1 [(gogoproto.nullable) = false, (gogoproto.embed) = true];
+  optional KVResponseHeader kvheader = 1 [(gogoproto.nullable) = false, (gogoproto.embed) = true];
 }
 
 // An InternalLeaderLeaseRequest is arguments to the InternalLeaderLease()
 // method. It is sent by the store on behalf of one of its ranges upon receipt
 // of a leader election event for that range.
 message InternalLeaderLeaseRequest {
-  optional RequestHeader header = 1 [(gogoproto.nullable) = false, (gogoproto.embed) = true];
+  optional KVRequestHeader kvheader = 1 [(gogoproto.nullable) = false, (gogoproto.embed) = true];
   optional Lease lease = 2[(gogoproto.nullable) = false];
 }
 
 // An InternalLeaderLeaseResponse is the response to an InternalLeaderLease()
 // operation.
 message InternalLeaderLeaseResponse{
-  optional ResponseHeader header = 1 [(gogoproto.nullable) = false, (gogoproto.embed) = true];
+  optional KVResponseHeader kvheader = 1 [(gogoproto.nullable) = false, (gogoproto.embed) = true];
 }
 
 // An InternalRequestUnion contains exactly one of the optional requests.
@@ -268,7 +268,7 @@ message InternalResponseUnion {
 //
 // See comments for BatchRequest.
 message InternalBatchRequest {
-  optional RequestHeader header = 1 [(gogoproto.nullable) = false, (gogoproto.embed) = true];
+  optional KVRequestHeader kvheader = 1 [(gogoproto.nullable) = false, (gogoproto.embed) = true];
   repeated InternalRequestUnion requests = 2 [(gogoproto.nullable) = false];
 }
 
@@ -276,7 +276,7 @@ message InternalBatchRequest {
 //
 // See comments for BatchResponse.
 message InternalBatchResponse {
-  optional ResponseHeader header = 1 [(gogoproto.nullable) = false, (gogoproto.embed) = true];
+  optional KVResponseHeader kvheader = 1 [(gogoproto.nullable) = false, (gogoproto.embed) = true];
   repeated InternalResponseUnion responses = 2 [(gogoproto.nullable) = false];
 }
 

--- a/server/node_test.go
+++ b/server/node_test.go
@@ -263,7 +263,7 @@ func TestCorruptedClusterID(t *testing.T) {
 func compareStoreStatus(t *testing.T, node *Node, expectedNodeStatus *proto.NodeStatus, testNumber int) *proto.NodeStatus {
 	nodeStatusKey := keys.NodeStatusKey(int32(node.Descriptor.NodeID))
 	request := &proto.GetRequest{
-		RequestHeader: proto.RequestHeader{
+		KVRequestHeader: proto.KVRequestHeader{
 			Key: nodeStatusKey,
 		},
 	}
@@ -422,7 +422,7 @@ func TestNodeStatus(t *testing.T) {
 	// Split the range.
 	rng := s.LookupRange(splitKey, nil)
 	args := &proto.AdminSplitRequest{
-		RequestHeader: proto.RequestHeader{
+		KVRequestHeader: proto.KVRequestHeader{
 			Key:     proto.KeyMin,
 			RaftID:  rng.Desc().RaftID,
 			Replica: proto.Replica{StoreID: s.Ident.StoreID},

--- a/server/server_test.go
+++ b/server/server_test.go
@@ -315,14 +315,14 @@ func TestMultiRangeScanDeleteRange(t *testing.T) {
 	writes := []proto.Key{proto.Key("a"), proto.Key("z")}
 	get := proto.Call{
 		Args: &proto.GetRequest{
-			RequestHeader: proto.RequestHeader{
+			KVRequestHeader: proto.KVRequestHeader{
 				Key: writes[0],
 			},
 		},
 		Reply: &proto.GetResponse{},
 	}
 	get.Args.Header().User = storage.UserRoot
-	get.Args.Header().EndKey = writes[len(writes)-1]
+	get.Args.KVHeader().EndKey = writes[len(writes)-1]
 	tds.Send(context.Background(), get)
 	if err := get.Reply.Header().GoError(); err == nil {
 		t.Errorf("able to call Get with a key range: %v", get)
@@ -354,11 +354,13 @@ func TestMultiRangeScanDeleteRange(t *testing.T) {
 
 	del := proto.Call{
 		Args: &proto.DeleteRangeRequest{
-			RequestHeader: proto.RequestHeader{
-				User:      storage.UserRoot,
-				Key:       writes[0],
-				EndKey:    proto.Key(writes[len(writes)-1]).Next(),
-				Timestamp: call.Reply.Header().Timestamp,
+			KVRequestHeader: proto.KVRequestHeader{
+				RequestHeader: proto.RequestHeader{
+					User:      storage.UserRoot,
+					Timestamp: call.Reply.Header().Timestamp,
+				},
+				Key:    writes[0],
+				EndKey: proto.Key(writes[len(writes)-1]).Next(),
 			},
 		},
 		Reply: &proto.DeleteRangeResponse{},

--- a/server/status/feed_test.go
+++ b/server/status/feed_test.go
@@ -287,23 +287,29 @@ func TestNodeEventFeedTransactionRestart(t *testing.T) {
 	nodeID := proto.NodeID(1)
 
 	nodefeed.CallComplete(&proto.GetRequest{}, &proto.GetResponse{
-		ResponseHeader: proto.ResponseHeader{
-			Error: &proto.Error{
-				TransactionRestart: proto.TransactionRestart_BACKOFF,
+		KVResponseHeader: proto.KVResponseHeader{
+			ResponseHeader: proto.ResponseHeader{
+				Error: &proto.Error{
+					TransactionRestart: proto.TransactionRestart_BACKOFF,
+				},
 			},
 		},
 	})
 	nodefeed.CallComplete(&proto.GetRequest{}, &proto.GetResponse{
-		ResponseHeader: proto.ResponseHeader{
-			Error: &proto.Error{
-				TransactionRestart: proto.TransactionRestart_IMMEDIATE,
+		KVResponseHeader: proto.KVResponseHeader{
+			ResponseHeader: proto.ResponseHeader{
+				Error: &proto.Error{
+					TransactionRestart: proto.TransactionRestart_IMMEDIATE,
+				},
 			},
 		},
 	})
 	nodefeed.CallComplete(&proto.PutRequest{}, &proto.PutResponse{
-		ResponseHeader: proto.ResponseHeader{
-			Error: &proto.Error{
-				TransactionRestart: proto.TransactionRestart_ABORT,
+		KVResponseHeader: proto.KVResponseHeader{
+			ResponseHeader: proto.ResponseHeader{
+				Error: &proto.Error{
+					TransactionRestart: proto.TransactionRestart_ABORT,
+				},
 			},
 		},
 	})

--- a/storage/engine/cockroach/proto/api.pb.cc
+++ b/storage/engine/cockroach/proto/api.pb.cc
@@ -30,6 +30,12 @@ const ::google::protobuf::internal::GeneratedMessageReflection*
 const ::google::protobuf::Descriptor* ResponseHeader_descriptor_ = NULL;
 const ::google::protobuf::internal::GeneratedMessageReflection*
   ResponseHeader_reflection_ = NULL;
+const ::google::protobuf::Descriptor* KVRequestHeader_descriptor_ = NULL;
+const ::google::protobuf::internal::GeneratedMessageReflection*
+  KVRequestHeader_reflection_ = NULL;
+const ::google::protobuf::Descriptor* KVResponseHeader_descriptor_ = NULL;
+const ::google::protobuf::internal::GeneratedMessageReflection*
+  KVResponseHeader_reflection_ = NULL;
 const ::google::protobuf::Descriptor* GetRequest_descriptor_ = NULL;
 const ::google::protobuf::internal::GeneratedMessageReflection*
   GetRequest_reflection_ = NULL;
@@ -150,14 +156,10 @@ void protobuf_AssignDesc_cockroach_2fproto_2fapi_2eproto() {
       GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(ClientCmdID, _internal_metadata_),
       -1);
   RequestHeader_descriptor_ = file->message_type(1);
-  static const int RequestHeader_offsets_[10] = {
+  static const int RequestHeader_offsets_[6] = {
     GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(RequestHeader, timestamp_),
     GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(RequestHeader, cmd_id_),
-    GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(RequestHeader, key_),
-    GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(RequestHeader, end_key_),
     GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(RequestHeader, user_),
-    GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(RequestHeader, replica_),
-    GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(RequestHeader, raft_id_),
     GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(RequestHeader, user_priority_),
     GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(RequestHeader, txn_),
     GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(RequestHeader, read_consistency_),
@@ -190,9 +192,43 @@ void protobuf_AssignDesc_cockroach_2fproto_2fapi_2eproto() {
       sizeof(ResponseHeader),
       GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(ResponseHeader, _internal_metadata_),
       -1);
-  GetRequest_descriptor_ = file->message_type(3);
+  KVRequestHeader_descriptor_ = file->message_type(3);
+  static const int KVRequestHeader_offsets_[5] = {
+    GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(KVRequestHeader, header_),
+    GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(KVRequestHeader, key_),
+    GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(KVRequestHeader, end_key_),
+    GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(KVRequestHeader, replica_),
+    GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(KVRequestHeader, raft_id_),
+  };
+  KVRequestHeader_reflection_ =
+    ::google::protobuf::internal::GeneratedMessageReflection::NewGeneratedMessageReflection(
+      KVRequestHeader_descriptor_,
+      KVRequestHeader::default_instance_,
+      KVRequestHeader_offsets_,
+      GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(KVRequestHeader, _has_bits_[0]),
+      -1,
+      -1,
+      sizeof(KVRequestHeader),
+      GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(KVRequestHeader, _internal_metadata_),
+      -1);
+  KVResponseHeader_descriptor_ = file->message_type(4);
+  static const int KVResponseHeader_offsets_[1] = {
+    GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(KVResponseHeader, header_),
+  };
+  KVResponseHeader_reflection_ =
+    ::google::protobuf::internal::GeneratedMessageReflection::NewGeneratedMessageReflection(
+      KVResponseHeader_descriptor_,
+      KVResponseHeader::default_instance_,
+      KVResponseHeader_offsets_,
+      GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(KVResponseHeader, _has_bits_[0]),
+      -1,
+      -1,
+      sizeof(KVResponseHeader),
+      GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(KVResponseHeader, _internal_metadata_),
+      -1);
+  GetRequest_descriptor_ = file->message_type(5);
   static const int GetRequest_offsets_[1] = {
-    GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(GetRequest, header_),
+    GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(GetRequest, kvheader_),
   };
   GetRequest_reflection_ =
     ::google::protobuf::internal::GeneratedMessageReflection::NewGeneratedMessageReflection(
@@ -205,9 +241,9 @@ void protobuf_AssignDesc_cockroach_2fproto_2fapi_2eproto() {
       sizeof(GetRequest),
       GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(GetRequest, _internal_metadata_),
       -1);
-  GetResponse_descriptor_ = file->message_type(4);
+  GetResponse_descriptor_ = file->message_type(6);
   static const int GetResponse_offsets_[2] = {
-    GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(GetResponse, header_),
+    GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(GetResponse, kvheader_),
     GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(GetResponse, value_),
   };
   GetResponse_reflection_ =
@@ -221,9 +257,9 @@ void protobuf_AssignDesc_cockroach_2fproto_2fapi_2eproto() {
       sizeof(GetResponse),
       GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(GetResponse, _internal_metadata_),
       -1);
-  PutRequest_descriptor_ = file->message_type(5);
+  PutRequest_descriptor_ = file->message_type(7);
   static const int PutRequest_offsets_[2] = {
-    GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(PutRequest, header_),
+    GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(PutRequest, kvheader_),
     GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(PutRequest, value_),
   };
   PutRequest_reflection_ =
@@ -237,9 +273,9 @@ void protobuf_AssignDesc_cockroach_2fproto_2fapi_2eproto() {
       sizeof(PutRequest),
       GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(PutRequest, _internal_metadata_),
       -1);
-  PutResponse_descriptor_ = file->message_type(6);
+  PutResponse_descriptor_ = file->message_type(8);
   static const int PutResponse_offsets_[1] = {
-    GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(PutResponse, header_),
+    GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(PutResponse, kvheader_),
   };
   PutResponse_reflection_ =
     ::google::protobuf::internal::GeneratedMessageReflection::NewGeneratedMessageReflection(
@@ -252,9 +288,9 @@ void protobuf_AssignDesc_cockroach_2fproto_2fapi_2eproto() {
       sizeof(PutResponse),
       GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(PutResponse, _internal_metadata_),
       -1);
-  ConditionalPutRequest_descriptor_ = file->message_type(7);
+  ConditionalPutRequest_descriptor_ = file->message_type(9);
   static const int ConditionalPutRequest_offsets_[3] = {
-    GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(ConditionalPutRequest, header_),
+    GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(ConditionalPutRequest, kvheader_),
     GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(ConditionalPutRequest, value_),
     GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(ConditionalPutRequest, exp_value_),
   };
@@ -269,9 +305,9 @@ void protobuf_AssignDesc_cockroach_2fproto_2fapi_2eproto() {
       sizeof(ConditionalPutRequest),
       GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(ConditionalPutRequest, _internal_metadata_),
       -1);
-  ConditionalPutResponse_descriptor_ = file->message_type(8);
+  ConditionalPutResponse_descriptor_ = file->message_type(10);
   static const int ConditionalPutResponse_offsets_[1] = {
-    GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(ConditionalPutResponse, header_),
+    GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(ConditionalPutResponse, kvheader_),
   };
   ConditionalPutResponse_reflection_ =
     ::google::protobuf::internal::GeneratedMessageReflection::NewGeneratedMessageReflection(
@@ -284,9 +320,9 @@ void protobuf_AssignDesc_cockroach_2fproto_2fapi_2eproto() {
       sizeof(ConditionalPutResponse),
       GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(ConditionalPutResponse, _internal_metadata_),
       -1);
-  IncrementRequest_descriptor_ = file->message_type(9);
+  IncrementRequest_descriptor_ = file->message_type(11);
   static const int IncrementRequest_offsets_[2] = {
-    GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(IncrementRequest, header_),
+    GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(IncrementRequest, kvheader_),
     GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(IncrementRequest, increment_),
   };
   IncrementRequest_reflection_ =
@@ -300,9 +336,9 @@ void protobuf_AssignDesc_cockroach_2fproto_2fapi_2eproto() {
       sizeof(IncrementRequest),
       GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(IncrementRequest, _internal_metadata_),
       -1);
-  IncrementResponse_descriptor_ = file->message_type(10);
+  IncrementResponse_descriptor_ = file->message_type(12);
   static const int IncrementResponse_offsets_[2] = {
-    GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(IncrementResponse, header_),
+    GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(IncrementResponse, kvheader_),
     GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(IncrementResponse, new_value_),
   };
   IncrementResponse_reflection_ =
@@ -316,9 +352,9 @@ void protobuf_AssignDesc_cockroach_2fproto_2fapi_2eproto() {
       sizeof(IncrementResponse),
       GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(IncrementResponse, _internal_metadata_),
       -1);
-  DeleteRequest_descriptor_ = file->message_type(11);
+  DeleteRequest_descriptor_ = file->message_type(13);
   static const int DeleteRequest_offsets_[1] = {
-    GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(DeleteRequest, header_),
+    GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(DeleteRequest, kvheader_),
   };
   DeleteRequest_reflection_ =
     ::google::protobuf::internal::GeneratedMessageReflection::NewGeneratedMessageReflection(
@@ -331,9 +367,9 @@ void protobuf_AssignDesc_cockroach_2fproto_2fapi_2eproto() {
       sizeof(DeleteRequest),
       GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(DeleteRequest, _internal_metadata_),
       -1);
-  DeleteResponse_descriptor_ = file->message_type(12);
+  DeleteResponse_descriptor_ = file->message_type(14);
   static const int DeleteResponse_offsets_[1] = {
-    GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(DeleteResponse, header_),
+    GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(DeleteResponse, kvheader_),
   };
   DeleteResponse_reflection_ =
     ::google::protobuf::internal::GeneratedMessageReflection::NewGeneratedMessageReflection(
@@ -346,9 +382,9 @@ void protobuf_AssignDesc_cockroach_2fproto_2fapi_2eproto() {
       sizeof(DeleteResponse),
       GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(DeleteResponse, _internal_metadata_),
       -1);
-  DeleteRangeRequest_descriptor_ = file->message_type(13);
+  DeleteRangeRequest_descriptor_ = file->message_type(15);
   static const int DeleteRangeRequest_offsets_[2] = {
-    GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(DeleteRangeRequest, header_),
+    GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(DeleteRangeRequest, kvheader_),
     GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(DeleteRangeRequest, max_entries_to_delete_),
   };
   DeleteRangeRequest_reflection_ =
@@ -362,9 +398,9 @@ void protobuf_AssignDesc_cockroach_2fproto_2fapi_2eproto() {
       sizeof(DeleteRangeRequest),
       GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(DeleteRangeRequest, _internal_metadata_),
       -1);
-  DeleteRangeResponse_descriptor_ = file->message_type(14);
+  DeleteRangeResponse_descriptor_ = file->message_type(16);
   static const int DeleteRangeResponse_offsets_[2] = {
-    GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(DeleteRangeResponse, header_),
+    GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(DeleteRangeResponse, kvheader_),
     GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(DeleteRangeResponse, num_deleted_),
   };
   DeleteRangeResponse_reflection_ =
@@ -378,9 +414,9 @@ void protobuf_AssignDesc_cockroach_2fproto_2fapi_2eproto() {
       sizeof(DeleteRangeResponse),
       GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(DeleteRangeResponse, _internal_metadata_),
       -1);
-  ScanRequest_descriptor_ = file->message_type(15);
+  ScanRequest_descriptor_ = file->message_type(17);
   static const int ScanRequest_offsets_[2] = {
-    GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(ScanRequest, header_),
+    GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(ScanRequest, kvheader_),
     GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(ScanRequest, max_results_),
   };
   ScanRequest_reflection_ =
@@ -394,9 +430,9 @@ void protobuf_AssignDesc_cockroach_2fproto_2fapi_2eproto() {
       sizeof(ScanRequest),
       GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(ScanRequest, _internal_metadata_),
       -1);
-  ScanResponse_descriptor_ = file->message_type(16);
+  ScanResponse_descriptor_ = file->message_type(18);
   static const int ScanResponse_offsets_[2] = {
-    GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(ScanResponse, header_),
+    GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(ScanResponse, kvheader_),
     GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(ScanResponse, rows_),
   };
   ScanResponse_reflection_ =
@@ -410,9 +446,9 @@ void protobuf_AssignDesc_cockroach_2fproto_2fapi_2eproto() {
       sizeof(ScanResponse),
       GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(ScanResponse, _internal_metadata_),
       -1);
-  EndTransactionRequest_descriptor_ = file->message_type(17);
+  EndTransactionRequest_descriptor_ = file->message_type(19);
   static const int EndTransactionRequest_offsets_[3] = {
-    GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(EndTransactionRequest, header_),
+    GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(EndTransactionRequest, kvheader_),
     GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(EndTransactionRequest, commit_),
     GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(EndTransactionRequest, internal_commit_trigger_),
   };
@@ -427,9 +463,9 @@ void protobuf_AssignDesc_cockroach_2fproto_2fapi_2eproto() {
       sizeof(EndTransactionRequest),
       GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(EndTransactionRequest, _internal_metadata_),
       -1);
-  EndTransactionResponse_descriptor_ = file->message_type(18);
+  EndTransactionResponse_descriptor_ = file->message_type(20);
   static const int EndTransactionResponse_offsets_[3] = {
-    GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(EndTransactionResponse, header_),
+    GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(EndTransactionResponse, kvheader_),
     GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(EndTransactionResponse, commit_wait_),
     GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(EndTransactionResponse, resolved_),
   };
@@ -444,7 +480,7 @@ void protobuf_AssignDesc_cockroach_2fproto_2fapi_2eproto() {
       sizeof(EndTransactionResponse),
       GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(EndTransactionResponse, _internal_metadata_),
       -1);
-  RequestUnion_descriptor_ = file->message_type(19);
+  RequestUnion_descriptor_ = file->message_type(21);
   static const int RequestUnion_offsets_[9] = {
     PROTO2_GENERATED_DEFAULT_ONEOF_FIELD_OFFSET(RequestUnion_default_oneof_instance_, get_),
     PROTO2_GENERATED_DEFAULT_ONEOF_FIELD_OFFSET(RequestUnion_default_oneof_instance_, put_),
@@ -469,7 +505,7 @@ void protobuf_AssignDesc_cockroach_2fproto_2fapi_2eproto() {
       sizeof(RequestUnion),
       GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(RequestUnion, _internal_metadata_),
       -1);
-  ResponseUnion_descriptor_ = file->message_type(20);
+  ResponseUnion_descriptor_ = file->message_type(22);
   static const int ResponseUnion_offsets_[9] = {
     PROTO2_GENERATED_DEFAULT_ONEOF_FIELD_OFFSET(ResponseUnion_default_oneof_instance_, get_),
     PROTO2_GENERATED_DEFAULT_ONEOF_FIELD_OFFSET(ResponseUnion_default_oneof_instance_, put_),
@@ -494,9 +530,9 @@ void protobuf_AssignDesc_cockroach_2fproto_2fapi_2eproto() {
       sizeof(ResponseUnion),
       GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(ResponseUnion, _internal_metadata_),
       -1);
-  BatchRequest_descriptor_ = file->message_type(21);
+  BatchRequest_descriptor_ = file->message_type(23);
   static const int BatchRequest_offsets_[2] = {
-    GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(BatchRequest, header_),
+    GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(BatchRequest, kvheader_),
     GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(BatchRequest, requests_),
   };
   BatchRequest_reflection_ =
@@ -510,9 +546,9 @@ void protobuf_AssignDesc_cockroach_2fproto_2fapi_2eproto() {
       sizeof(BatchRequest),
       GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(BatchRequest, _internal_metadata_),
       -1);
-  BatchResponse_descriptor_ = file->message_type(22);
+  BatchResponse_descriptor_ = file->message_type(24);
   static const int BatchResponse_offsets_[2] = {
-    GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(BatchResponse, header_),
+    GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(BatchResponse, kvheader_),
     GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(BatchResponse, responses_),
   };
   BatchResponse_reflection_ =
@@ -526,9 +562,9 @@ void protobuf_AssignDesc_cockroach_2fproto_2fapi_2eproto() {
       sizeof(BatchResponse),
       GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(BatchResponse, _internal_metadata_),
       -1);
-  AdminSplitRequest_descriptor_ = file->message_type(23);
+  AdminSplitRequest_descriptor_ = file->message_type(25);
   static const int AdminSplitRequest_offsets_[2] = {
-    GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(AdminSplitRequest, header_),
+    GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(AdminSplitRequest, kvheader_),
     GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(AdminSplitRequest, split_key_),
   };
   AdminSplitRequest_reflection_ =
@@ -542,9 +578,9 @@ void protobuf_AssignDesc_cockroach_2fproto_2fapi_2eproto() {
       sizeof(AdminSplitRequest),
       GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(AdminSplitRequest, _internal_metadata_),
       -1);
-  AdminSplitResponse_descriptor_ = file->message_type(24);
+  AdminSplitResponse_descriptor_ = file->message_type(26);
   static const int AdminSplitResponse_offsets_[1] = {
-    GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(AdminSplitResponse, header_),
+    GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(AdminSplitResponse, kvheader_),
   };
   AdminSplitResponse_reflection_ =
     ::google::protobuf::internal::GeneratedMessageReflection::NewGeneratedMessageReflection(
@@ -557,9 +593,9 @@ void protobuf_AssignDesc_cockroach_2fproto_2fapi_2eproto() {
       sizeof(AdminSplitResponse),
       GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(AdminSplitResponse, _internal_metadata_),
       -1);
-  AdminMergeRequest_descriptor_ = file->message_type(25);
+  AdminMergeRequest_descriptor_ = file->message_type(27);
   static const int AdminMergeRequest_offsets_[1] = {
-    GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(AdminMergeRequest, header_),
+    GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(AdminMergeRequest, kvheader_),
   };
   AdminMergeRequest_reflection_ =
     ::google::protobuf::internal::GeneratedMessageReflection::NewGeneratedMessageReflection(
@@ -572,9 +608,9 @@ void protobuf_AssignDesc_cockroach_2fproto_2fapi_2eproto() {
       sizeof(AdminMergeRequest),
       GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(AdminMergeRequest, _internal_metadata_),
       -1);
-  AdminMergeResponse_descriptor_ = file->message_type(26);
+  AdminMergeResponse_descriptor_ = file->message_type(28);
   static const int AdminMergeResponse_offsets_[1] = {
-    GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(AdminMergeResponse, header_),
+    GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(AdminMergeResponse, kvheader_),
   };
   AdminMergeResponse_reflection_ =
     ::google::protobuf::internal::GeneratedMessageReflection::NewGeneratedMessageReflection(
@@ -606,6 +642,10 @@ void protobuf_RegisterTypes(const ::std::string&) {
       RequestHeader_descriptor_, &RequestHeader::default_instance());
   ::google::protobuf::MessageFactory::InternalRegisterGeneratedMessage(
       ResponseHeader_descriptor_, &ResponseHeader::default_instance());
+  ::google::protobuf::MessageFactory::InternalRegisterGeneratedMessage(
+      KVRequestHeader_descriptor_, &KVRequestHeader::default_instance());
+  ::google::protobuf::MessageFactory::InternalRegisterGeneratedMessage(
+      KVResponseHeader_descriptor_, &KVResponseHeader::default_instance());
   ::google::protobuf::MessageFactory::InternalRegisterGeneratedMessage(
       GetRequest_descriptor_, &GetRequest::default_instance());
   ::google::protobuf::MessageFactory::InternalRegisterGeneratedMessage(
@@ -665,6 +705,10 @@ void protobuf_ShutdownFile_cockroach_2fproto_2fapi_2eproto() {
   delete RequestHeader_reflection_;
   delete ResponseHeader::default_instance_;
   delete ResponseHeader_reflection_;
+  delete KVRequestHeader::default_instance_;
+  delete KVRequestHeader_reflection_;
+  delete KVResponseHeader::default_instance_;
+  delete KVResponseHeader_reflection_;
   delete GetRequest::default_instance_;
   delete GetRequest_reflection_;
   delete GetResponse::default_instance_;
@@ -733,112 +777,120 @@ void protobuf_AddDesc_cockroach_2fproto_2fapi_2eproto() {
     "roach/proto/data.proto\032\034cockroach/proto/"
     "errors.proto\032\024gogoproto/gogo.proto\"<\n\013Cl"
     "ientCmdID\022\027\n\twall_time\030\001 \001(\003B\004\310\336\037\000\022\024\n\006ra"
-    "ndom\030\002 \001(\003B\004\310\336\037\000\"\254\003\n\rRequestHeader\0223\n\tti"
+    "ndom\030\002 \001(\003B\004\310\336\037\000\"\240\002\n\rRequestHeader\0223\n\tti"
     "mestamp\030\001 \001(\0132\032.cockroach.proto.Timestam"
     "pB\004\310\336\037\000\022;\n\006cmd_id\030\002 \001(\0132\034.cockroach.prot"
-    "o.ClientCmdIDB\r\310\336\037\000\342\336\037\005CmdID\022\024\n\003key\030\003 \001("
-    "\014B\007\372\336\037\003Key\022\030\n\007end_key\030\004 \001(\014B\007\372\336\037\003Key\022\022\n\004"
-    "user\030\005 \001(\tB\004\310\336\037\000\022/\n\007replica\030\006 \001(\0132\030.cock"
-    "roach.proto.ReplicaB\004\310\336\037\000\022)\n\007raft_id\030\007 \001"
-    "(\003B\030\310\336\037\000\342\336\037\006RaftID\372\336\037\006RaftID\022\030\n\ruser_pri"
-    "ority\030\010 \001(\005:\0011\022)\n\003txn\030\t \001(\0132\034.cockroach."
-    "proto.Transaction\022D\n\020read_consistency\030\n "
-    "\001(\0162$.cockroach.proto.ReadConsistencyTyp"
-    "eB\004\310\336\037\000\"\227\001\n\016ResponseHeader\022%\n\005error\030\001 \001("
-    "\0132\026.cockroach.proto.Error\0223\n\ttimestamp\030\002"
-    " \001(\0132\032.cockroach.proto.TimestampB\004\310\336\037\000\022)"
-    "\n\003txn\030\003 \001(\0132\034.cockroach.proto.Transactio"
-    "n\"F\n\nGetRequest\0228\n\006header\030\001 \001(\0132\036.cockro"
-    "ach.proto.RequestHeaderB\010\310\336\037\000\320\336\037\001\"o\n\013Get"
-    "Response\0229\n\006header\030\001 \001(\0132\037.cockroach.pro"
-    "to.ResponseHeaderB\010\310\336\037\000\320\336\037\001\022%\n\005value\030\002 \001"
-    "(\0132\026.cockroach.proto.Value\"s\n\nPutRequest"
-    "\0228\n\006header\030\001 \001(\0132\036.cockroach.proto.Reque"
-    "stHeaderB\010\310\336\037\000\320\336\037\001\022+\n\005value\030\002 \001(\0132\026.cock"
-    "roach.proto.ValueB\004\310\336\037\000\"H\n\013PutResponse\0229"
-    "\n\006header\030\001 \001(\0132\037.cockroach.proto.Respons"
-    "eHeaderB\010\310\336\037\000\320\336\037\001\"\251\001\n\025ConditionalPutRequ"
-    "est\0228\n\006header\030\001 \001(\0132\036.cockroach.proto.Re"
-    "questHeaderB\010\310\336\037\000\320\336\037\001\022+\n\005value\030\002 \001(\0132\026.c"
-    "ockroach.proto.ValueB\004\310\336\037\000\022)\n\texp_value\030"
-    "\003 \001(\0132\026.cockroach.proto.Value\"S\n\026Conditi"
-    "onalPutResponse\0229\n\006header\030\001 \001(\0132\037.cockro"
-    "ach.proto.ResponseHeaderB\010\310\336\037\000\320\336\037\001\"e\n\020In"
-    "crementRequest\0228\n\006header\030\001 \001(\0132\036.cockroa"
-    "ch.proto.RequestHeaderB\010\310\336\037\000\320\336\037\001\022\027\n\tincr"
-    "ement\030\002 \001(\003B\004\310\336\037\000\"g\n\021IncrementResponse\0229"
-    "\n\006header\030\001 \001(\0132\037.cockroach.proto.Respons"
-    "eHeaderB\010\310\336\037\000\320\336\037\001\022\027\n\tnew_value\030\002 \001(\003B\004\310\336"
-    "\037\000\"I\n\rDeleteRequest\0228\n\006header\030\001 \001(\0132\036.co"
-    "ckroach.proto.RequestHeaderB\010\310\336\037\000\320\336\037\001\"K\n"
-    "\016DeleteResponse\0229\n\006header\030\001 \001(\0132\037.cockro"
-    "ach.proto.ResponseHeaderB\010\310\336\037\000\320\336\037\001\"s\n\022De"
-    "leteRangeRequest\0228\n\006header\030\001 \001(\0132\036.cockr"
-    "oach.proto.RequestHeaderB\010\310\336\037\000\320\336\037\001\022#\n\025ma"
-    "x_entries_to_delete\030\002 \001(\003B\004\310\336\037\000\"k\n\023Delet"
-    "eRangeResponse\0229\n\006header\030\001 \001(\0132\037.cockroa"
-    "ch.proto.ResponseHeaderB\010\310\336\037\000\320\336\037\001\022\031\n\013num"
-    "_deleted\030\002 \001(\003B\004\310\336\037\000\"b\n\013ScanRequest\0228\n\006h"
-    "eader\030\001 \001(\0132\036.cockroach.proto.RequestHea"
-    "derB\010\310\336\037\000\320\336\037\001\022\031\n\013max_results\030\002 \001(\003B\004\310\336\037\000"
-    "\"x\n\014ScanResponse\0229\n\006header\030\001 \001(\0132\037.cockr"
-    "oach.proto.ResponseHeaderB\010\310\336\037\000\320\336\037\001\022-\n\004r"
-    "ows\030\002 \003(\0132\031.cockroach.proto.KeyValueB\004\310\336"
-    "\037\000\"\260\001\n\025EndTransactionRequest\0228\n\006header\030\001"
-    " \001(\0132\036.cockroach.proto.RequestHeaderB\010\310\336"
-    "\037\000\320\336\037\001\022\024\n\006commit\030\002 \001(\010B\004\310\336\037\000\022G\n\027internal"
-    "_commit_trigger\030\003 \001(\0132&.cockroach.proto."
-    "InternalCommitTrigger\"\211\001\n\026EndTransaction"
-    "Response\0229\n\006header\030\001 \001(\0132\037.cockroach.pro"
-    "to.ResponseHeaderB\010\310\336\037\000\320\336\037\001\022\031\n\013commit_wa"
-    "it\030\002 \001(\003B\004\310\336\037\000\022\031\n\010resolved\030\003 \003(\014B\007\372\336\037\003Ke"
-    "y\"\320\003\n\014RequestUnion\022*\n\003get\030\002 \001(\0132\033.cockro"
-    "ach.proto.GetRequestH\000\022*\n\003put\030\003 \001(\0132\033.co"
-    "ckroach.proto.PutRequestH\000\022A\n\017conditiona"
-    "l_put\030\004 \001(\0132&.cockroach.proto.Conditiona"
-    "lPutRequestH\000\0226\n\tincrement\030\005 \001(\0132!.cockr"
-    "oach.proto.IncrementRequestH\000\0220\n\006delete\030"
-    "\006 \001(\0132\036.cockroach.proto.DeleteRequestH\000\022"
-    ";\n\014delete_range\030\007 \001(\0132#.cockroach.proto."
-    "DeleteRangeRequestH\000\022,\n\004scan\030\010 \001(\0132\034.coc"
-    "kroach.proto.ScanRequestH\000\022A\n\017end_transa"
-    "ction\030\t \001(\0132&.cockroach.proto.EndTransac"
-    "tionRequestH\000:\004\310\240\037\001B\007\n\005value\"\331\003\n\rRespons"
-    "eUnion\022+\n\003get\030\002 \001(\0132\034.cockroach.proto.Ge"
-    "tResponseH\000\022+\n\003put\030\003 \001(\0132\034.cockroach.pro"
-    "to.PutResponseH\000\022B\n\017conditional_put\030\004 \001("
-    "\0132\'.cockroach.proto.ConditionalPutRespon"
-    "seH\000\0227\n\tincrement\030\005 \001(\0132\".cockroach.prot"
-    "o.IncrementResponseH\000\0221\n\006delete\030\006 \001(\0132\037."
-    "cockroach.proto.DeleteResponseH\000\022<\n\014dele"
-    "te_range\030\007 \001(\0132$.cockroach.proto.DeleteR"
-    "angeResponseH\000\022-\n\004scan\030\010 \001(\0132\035.cockroach"
-    ".proto.ScanResponseH\000\022B\n\017end_transaction"
-    "\030\t \001(\0132\'.cockroach.proto.EndTransactionR"
-    "esponseH\000:\004\310\240\037\001B\007\n\005value\"\177\n\014BatchRequest"
-    "\0228\n\006header\030\001 \001(\0132\036.cockroach.proto.Reque"
-    "stHeaderB\010\310\336\037\000\320\336\037\001\0225\n\010requests\030\002 \003(\0132\035.c"
-    "ockroach.proto.RequestUnionB\004\310\336\037\000\"\203\001\n\rBa"
-    "tchResponse\0229\n\006header\030\001 \001(\0132\037.cockroach."
-    "proto.ResponseHeaderB\010\310\336\037\000\320\336\037\001\0227\n\trespon"
-    "ses\030\002 \003(\0132\036.cockroach.proto.ResponseUnio"
-    "nB\004\310\336\037\000\"i\n\021AdminSplitRequest\0228\n\006header\030\001"
-    " \001(\0132\036.cockroach.proto.RequestHeaderB\010\310\336"
-    "\037\000\320\336\037\001\022\032\n\tsplit_key\030\002 \001(\014B\007\372\336\037\003Key\"O\n\022Ad"
-    "minSplitResponse\0229\n\006header\030\001 \001(\0132\037.cockr"
-    "oach.proto.ResponseHeaderB\010\310\336\037\000\320\336\037\001\"M\n\021A"
-    "dminMergeRequest\0228\n\006header\030\001 \001(\0132\036.cockr"
-    "oach.proto.RequestHeaderB\010\310\336\037\000\320\336\037\001\"O\n\022Ad"
-    "minMergeResponse\0229\n\006header\030\001 \001(\0132\037.cockr"
-    "oach.proto.ResponseHeaderB\010\310\336\037\000\320\336\037\001*L\n\023R"
-    "eadConsistencyType\022\016\n\nCONSISTENT\020\000\022\r\n\tCO"
-    "NSENSUS\020\001\022\020\n\014INCONSISTENT\020\002\032\004\210\243\036\000B\023Z\005pro"
-    "to\340\342\036\001\310\342\036\001\320\342\036\001", 4214);
+    "o.ClientCmdIDB\r\310\336\037\000\342\336\037\005CmdID\022\022\n\004user\030\005 \001"
+    "(\tB\004\310\336\037\000\022\030\n\ruser_priority\030\010 \001(\005:\0011\022)\n\003tx"
+    "n\030\t \001(\0132\034.cockroach.proto.Transaction\022D\n"
+    "\020read_consistency\030\n \001(\0162$.cockroach.prot"
+    "o.ReadConsistencyTypeB\004\310\336\037\000\"\227\001\n\016Response"
+    "Header\022%\n\005error\030\001 \001(\0132\026.cockroach.proto."
+    "Error\0223\n\ttimestamp\030\002 \001(\0132\032.cockroach.pro"
+    "to.TimestampB\004\310\336\037\000\022)\n\003txn\030\003 \001(\0132\034.cockro"
+    "ach.proto.Transaction\"\327\001\n\017KVRequestHeade"
+    "r\0228\n\006header\030\001 \001(\0132\036.cockroach.proto.Requ"
+    "estHeaderB\010\310\336\037\000\320\336\037\001\022\024\n\003key\030\003 \001(\014B\007\372\336\037\003Ke"
+    "y\022\030\n\007end_key\030\004 \001(\014B\007\372\336\037\003Key\022/\n\007replica\030\006"
+    " \001(\0132\030.cockroach.proto.ReplicaB\004\310\336\037\000\022)\n\007"
+    "raft_id\030\007 \001(\003B\030\310\336\037\000\342\336\037\006RaftID\372\336\037\006RaftID\""
+    "M\n\020KVResponseHeader\0229\n\006header\030\001 \001(\0132\037.co"
+    "ckroach.proto.ResponseHeaderB\010\310\336\037\000\320\336\037\001\"J"
+    "\n\nGetRequest\022<\n\010kvheader\030\001 \001(\0132 .cockroa"
+    "ch.proto.KVRequestHeaderB\010\310\336\037\000\320\336\037\001\"s\n\013Ge"
+    "tResponse\022=\n\010kvheader\030\001 \001(\0132!.cockroach."
+    "proto.KVResponseHeaderB\010\310\336\037\000\320\336\037\001\022%\n\005valu"
+    "e\030\002 \001(\0132\026.cockroach.proto.Value\"w\n\nPutRe"
+    "quest\022<\n\010kvheader\030\001 \001(\0132 .cockroach.prot"
+    "o.KVRequestHeaderB\010\310\336\037\000\320\336\037\001\022+\n\005value\030\002 \001"
+    "(\0132\026.cockroach.proto.ValueB\004\310\336\037\000\"L\n\013PutR"
+    "esponse\022=\n\010kvheader\030\001 \001(\0132!.cockroach.pr"
+    "oto.KVResponseHeaderB\010\310\336\037\000\320\336\037\001\"\255\001\n\025Condi"
+    "tionalPutRequest\022<\n\010kvheader\030\001 \001(\0132 .coc"
+    "kroach.proto.KVRequestHeaderB\010\310\336\037\000\320\336\037\001\022+"
+    "\n\005value\030\002 \001(\0132\026.cockroach.proto.ValueB\004\310"
+    "\336\037\000\022)\n\texp_value\030\003 \001(\0132\026.cockroach.proto"
+    ".Value\"W\n\026ConditionalPutResponse\022=\n\010kvhe"
+    "ader\030\001 \001(\0132!.cockroach.proto.KVResponseH"
+    "eaderB\010\310\336\037\000\320\336\037\001\"i\n\020IncrementRequest\022<\n\010k"
+    "vheader\030\001 \001(\0132 .cockroach.proto.KVReques"
+    "tHeaderB\010\310\336\037\000\320\336\037\001\022\027\n\tincrement\030\002 \001(\003B\004\310\336"
+    "\037\000\"k\n\021IncrementResponse\022=\n\010kvheader\030\001 \001("
+    "\0132!.cockroach.proto.KVResponseHeaderB\010\310\336"
+    "\037\000\320\336\037\001\022\027\n\tnew_value\030\002 \001(\003B\004\310\336\037\000\"M\n\rDelet"
+    "eRequest\022<\n\010kvheader\030\001 \001(\0132 .cockroach.p"
+    "roto.KVRequestHeaderB\010\310\336\037\000\320\336\037\001\"O\n\016Delete"
+    "Response\022=\n\010kvheader\030\001 \001(\0132!.cockroach.p"
+    "roto.KVResponseHeaderB\010\310\336\037\000\320\336\037\001\"w\n\022Delet"
+    "eRangeRequest\022<\n\010kvheader\030\001 \001(\0132 .cockro"
+    "ach.proto.KVRequestHeaderB\010\310\336\037\000\320\336\037\001\022#\n\025m"
+    "ax_entries_to_delete\030\002 \001(\003B\004\310\336\037\000\"o\n\023Dele"
+    "teRangeResponse\022=\n\010kvheader\030\001 \001(\0132!.cock"
+    "roach.proto.KVResponseHeaderB\010\310\336\037\000\320\336\037\001\022\031"
+    "\n\013num_deleted\030\002 \001(\003B\004\310\336\037\000\"f\n\013ScanRequest"
+    "\022<\n\010kvheader\030\001 \001(\0132 .cockroach.proto.KVR"
+    "equestHeaderB\010\310\336\037\000\320\336\037\001\022\031\n\013max_results\030\002 "
+    "\001(\003B\004\310\336\037\000\"|\n\014ScanResponse\022=\n\010kvheader\030\001 "
+    "\001(\0132!.cockroach.proto.KVResponseHeaderB\010"
+    "\310\336\037\000\320\336\037\001\022-\n\004rows\030\002 \003(\0132\031.cockroach.proto"
+    ".KeyValueB\004\310\336\037\000\"\264\001\n\025EndTransactionReques"
+    "t\022<\n\010kvheader\030\001 \001(\0132 .cockroach.proto.KV"
+    "RequestHeaderB\010\310\336\037\000\320\336\037\001\022\024\n\006commit\030\002 \001(\010B"
+    "\004\310\336\037\000\022G\n\027internal_commit_trigger\030\003 \001(\0132&"
+    ".cockroach.proto.InternalCommitTrigger\"\215"
+    "\001\n\026EndTransactionResponse\022=\n\010kvheader\030\001 "
+    "\001(\0132!.cockroach.proto.KVResponseHeaderB\010"
+    "\310\336\037\000\320\336\037\001\022\031\n\013commit_wait\030\002 \001(\003B\004\310\336\037\000\022\031\n\010r"
+    "esolved\030\003 \003(\014B\007\372\336\037\003Key\"\320\003\n\014RequestUnion\022"
+    "*\n\003get\030\002 \001(\0132\033.cockroach.proto.GetReques"
+    "tH\000\022*\n\003put\030\003 \001(\0132\033.cockroach.proto.PutRe"
+    "questH\000\022A\n\017conditional_put\030\004 \001(\0132&.cockr"
+    "oach.proto.ConditionalPutRequestH\000\0226\n\tin"
+    "crement\030\005 \001(\0132!.cockroach.proto.Incremen"
+    "tRequestH\000\0220\n\006delete\030\006 \001(\0132\036.cockroach.p"
+    "roto.DeleteRequestH\000\022;\n\014delete_range\030\007 \001"
+    "(\0132#.cockroach.proto.DeleteRangeRequestH"
+    "\000\022,\n\004scan\030\010 \001(\0132\034.cockroach.proto.ScanRe"
+    "questH\000\022A\n\017end_transaction\030\t \001(\0132&.cockr"
+    "oach.proto.EndTransactionRequestH\000:\004\310\240\037\001"
+    "B\007\n\005value\"\331\003\n\rResponseUnion\022+\n\003get\030\002 \001(\013"
+    "2\034.cockroach.proto.GetResponseH\000\022+\n\003put\030"
+    "\003 \001(\0132\034.cockroach.proto.PutResponseH\000\022B\n"
+    "\017conditional_put\030\004 \001(\0132\'.cockroach.proto"
+    ".ConditionalPutResponseH\000\0227\n\tincrement\030\005"
+    " \001(\0132\".cockroach.proto.IncrementResponse"
+    "H\000\0221\n\006delete\030\006 \001(\0132\037.cockroach.proto.Del"
+    "eteResponseH\000\022<\n\014delete_range\030\007 \001(\0132$.co"
+    "ckroach.proto.DeleteRangeResponseH\000\022-\n\004s"
+    "can\030\010 \001(\0132\035.cockroach.proto.ScanResponse"
+    "H\000\022B\n\017end_transaction\030\t \001(\0132\'.cockroach."
+    "proto.EndTransactionResponseH\000:\004\310\240\037\001B\007\n\005"
+    "value\"\203\001\n\014BatchRequest\022<\n\010kvheader\030\001 \001(\013"
+    "2 .cockroach.proto.KVRequestHeaderB\010\310\336\037\000"
+    "\320\336\037\001\0225\n\010requests\030\002 \003(\0132\035.cockroach.proto"
+    ".RequestUnionB\004\310\336\037\000\"\207\001\n\rBatchResponse\022=\n"
+    "\010kvheader\030\001 \001(\0132!.cockroach.proto.KVResp"
+    "onseHeaderB\010\310\336\037\000\320\336\037\001\0227\n\tresponses\030\002 \003(\0132"
+    "\036.cockroach.proto.ResponseUnionB\004\310\336\037\000\"m\n"
+    "\021AdminSplitRequest\022<\n\010kvheader\030\001 \001(\0132 .c"
+    "ockroach.proto.KVRequestHeaderB\010\310\336\037\000\320\336\037\001"
+    "\022\032\n\tsplit_key\030\002 \001(\014B\007\372\336\037\003Key\"S\n\022AdminSpl"
+    "itResponse\022=\n\010kvheader\030\001 \001(\0132!.cockroach"
+    ".proto.KVResponseHeaderB\010\310\336\037\000\320\336\037\001\"Q\n\021Adm"
+    "inMergeRequest\022<\n\010kvheader\030\001 \001(\0132 .cockr"
+    "oach.proto.KVRequestHeaderB\010\310\336\037\000\320\336\037\001\"S\n\022"
+    "AdminMergeResponse\022=\n\010kvheader\030\001 \001(\0132!.c"
+    "ockroach.proto.KVResponseHeaderB\010\310\336\037\000\320\336\037"
+    "\001*L\n\023ReadConsistencyType\022\016\n\nCONSISTENT\020\000"
+    "\022\r\n\tCONSENSUS\020\001\022\020\n\014INCONSISTENT\020\002\032\004\210\243\036\000B"
+    "\023Z\005proto\340\342\036\001\310\342\036\001\320\342\036\001", 4460);
   ::google::protobuf::MessageFactory::InternalRegisterGeneratedFile(
     "cockroach/proto/api.proto", &protobuf_RegisterTypes);
   ClientCmdID::default_instance_ = new ClientCmdID();
   RequestHeader::default_instance_ = new RequestHeader();
   ResponseHeader::default_instance_ = new ResponseHeader();
+  KVRequestHeader::default_instance_ = new KVRequestHeader();
+  KVResponseHeader::default_instance_ = new KVResponseHeader();
   GetRequest::default_instance_ = new GetRequest();
   GetResponse::default_instance_ = new GetResponse();
   PutRequest::default_instance_ = new PutRequest();
@@ -868,6 +920,8 @@ void protobuf_AddDesc_cockroach_2fproto_2fapi_2eproto() {
   ClientCmdID::default_instance_->InitAsDefaultInstance();
   RequestHeader::default_instance_->InitAsDefaultInstance();
   ResponseHeader::default_instance_->InitAsDefaultInstance();
+  KVRequestHeader::default_instance_->InitAsDefaultInstance();
+  KVResponseHeader::default_instance_->InitAsDefaultInstance();
   GetRequest::default_instance_->InitAsDefaultInstance();
   GetResponse::default_instance_->InitAsDefaultInstance();
   PutRequest::default_instance_->InitAsDefaultInstance();
@@ -1267,11 +1321,7 @@ void ClientCmdID::clear_random() {
 #ifndef _MSC_VER
 const int RequestHeader::kTimestampFieldNumber;
 const int RequestHeader::kCmdIdFieldNumber;
-const int RequestHeader::kKeyFieldNumber;
-const int RequestHeader::kEndKeyFieldNumber;
 const int RequestHeader::kUserFieldNumber;
-const int RequestHeader::kReplicaFieldNumber;
-const int RequestHeader::kRaftIdFieldNumber;
 const int RequestHeader::kUserPriorityFieldNumber;
 const int RequestHeader::kTxnFieldNumber;
 const int RequestHeader::kReadConsistencyFieldNumber;
@@ -1286,7 +1336,6 @@ RequestHeader::RequestHeader()
 void RequestHeader::InitAsDefaultInstance() {
   timestamp_ = const_cast< ::cockroach::proto::Timestamp*>(&::cockroach::proto::Timestamp::default_instance());
   cmd_id_ = const_cast< ::cockroach::proto::ClientCmdID*>(&::cockroach::proto::ClientCmdID::default_instance());
-  replica_ = const_cast< ::cockroach::proto::Replica*>(&::cockroach::proto::Replica::default_instance());
   txn_ = const_cast< ::cockroach::proto::Transaction*>(&::cockroach::proto::Transaction::default_instance());
 }
 
@@ -1303,11 +1352,7 @@ void RequestHeader::SharedCtor() {
   _cached_size_ = 0;
   timestamp_ = NULL;
   cmd_id_ = NULL;
-  key_.UnsafeSetDefault(&::google::protobuf::internal::GetEmptyStringAlreadyInited());
-  end_key_.UnsafeSetDefault(&::google::protobuf::internal::GetEmptyStringAlreadyInited());
   user_.UnsafeSetDefault(&::google::protobuf::internal::GetEmptyStringAlreadyInited());
-  replica_ = NULL;
-  raft_id_ = GOOGLE_LONGLONG(0);
   user_priority_ = 1;
   txn_ = NULL;
   read_consistency_ = 0;
@@ -1320,13 +1365,10 @@ RequestHeader::~RequestHeader() {
 }
 
 void RequestHeader::SharedDtor() {
-  key_.DestroyNoArena(&::google::protobuf::internal::GetEmptyStringAlreadyInited());
-  end_key_.DestroyNoArena(&::google::protobuf::internal::GetEmptyStringAlreadyInited());
   user_.DestroyNoArena(&::google::protobuf::internal::GetEmptyStringAlreadyInited());
   if (this != default_instance_) {
     delete timestamp_;
     delete cmd_id_;
-    delete replica_;
     delete txn_;
   }
 }
@@ -1357,29 +1399,17 @@ RequestHeader* RequestHeader::New(::google::protobuf::Arena* arena) const {
 }
 
 void RequestHeader::Clear() {
-  if (_has_bits_[0 / 32] & 255u) {
+  if (_has_bits_[0 / 32] & 63u) {
     if (has_timestamp()) {
       if (timestamp_ != NULL) timestamp_->::cockroach::proto::Timestamp::Clear();
     }
     if (has_cmd_id()) {
       if (cmd_id_ != NULL) cmd_id_->::cockroach::proto::ClientCmdID::Clear();
     }
-    if (has_key()) {
-      key_.ClearToEmptyNoArena(&::google::protobuf::internal::GetEmptyStringAlreadyInited());
-    }
-    if (has_end_key()) {
-      end_key_.ClearToEmptyNoArena(&::google::protobuf::internal::GetEmptyStringAlreadyInited());
-    }
     if (has_user()) {
       user_.ClearToEmptyNoArena(&::google::protobuf::internal::GetEmptyStringAlreadyInited());
     }
-    if (has_replica()) {
-      if (replica_ != NULL) replica_->::cockroach::proto::Replica::Clear();
-    }
-    raft_id_ = GOOGLE_LONGLONG(0);
     user_priority_ = 1;
-  }
-  if (_has_bits_[8 / 32] & 768u) {
     if (has_txn()) {
       if (txn_ != NULL) txn_->::cockroach::proto::Transaction::Clear();
     }
@@ -1422,32 +1452,6 @@ bool RequestHeader::MergePartialFromCodedStream(
         } else {
           goto handle_unusual;
         }
-        if (input->ExpectTag(26)) goto parse_key;
-        break;
-      }
-
-      // optional bytes key = 3;
-      case 3: {
-        if (tag == 26) {
-         parse_key:
-          DO_(::google::protobuf::internal::WireFormatLite::ReadBytes(
-                input, this->mutable_key()));
-        } else {
-          goto handle_unusual;
-        }
-        if (input->ExpectTag(34)) goto parse_end_key;
-        break;
-      }
-
-      // optional bytes end_key = 4;
-      case 4: {
-        if (tag == 34) {
-         parse_end_key:
-          DO_(::google::protobuf::internal::WireFormatLite::ReadBytes(
-                input, this->mutable_end_key()));
-        } else {
-          goto handle_unusual;
-        }
         if (input->ExpectTag(42)) goto parse_user;
         break;
       }
@@ -1462,34 +1466,6 @@ bool RequestHeader::MergePartialFromCodedStream(
             this->user().data(), this->user().length(),
             ::google::protobuf::internal::WireFormat::PARSE,
             "cockroach.proto.RequestHeader.user");
-        } else {
-          goto handle_unusual;
-        }
-        if (input->ExpectTag(50)) goto parse_replica;
-        break;
-      }
-
-      // optional .cockroach.proto.Replica replica = 6;
-      case 6: {
-        if (tag == 50) {
-         parse_replica:
-          DO_(::google::protobuf::internal::WireFormatLite::ReadMessageNoVirtual(
-               input, mutable_replica()));
-        } else {
-          goto handle_unusual;
-        }
-        if (input->ExpectTag(56)) goto parse_raft_id;
-        break;
-      }
-
-      // optional int64 raft_id = 7;
-      case 7: {
-        if (tag == 56) {
-         parse_raft_id:
-          DO_((::google::protobuf::internal::WireFormatLite::ReadPrimitive<
-                   ::google::protobuf::int64, ::google::protobuf::internal::WireFormatLite::TYPE_INT64>(
-                 input, &raft_id_)));
-          set_has_raft_id();
         } else {
           goto handle_unusual;
         }
@@ -1582,18 +1558,6 @@ void RequestHeader::SerializeWithCachedSizes(
       2, *this->cmd_id_, output);
   }
 
-  // optional bytes key = 3;
-  if (has_key()) {
-    ::google::protobuf::internal::WireFormatLite::WriteBytesMaybeAliased(
-      3, this->key(), output);
-  }
-
-  // optional bytes end_key = 4;
-  if (has_end_key()) {
-    ::google::protobuf::internal::WireFormatLite::WriteBytesMaybeAliased(
-      4, this->end_key(), output);
-  }
-
   // optional string user = 5;
   if (has_user()) {
     ::google::protobuf::internal::WireFormat::VerifyUTF8StringNamedField(
@@ -1602,17 +1566,6 @@ void RequestHeader::SerializeWithCachedSizes(
       "cockroach.proto.RequestHeader.user");
     ::google::protobuf::internal::WireFormatLite::WriteStringMaybeAliased(
       5, this->user(), output);
-  }
-
-  // optional .cockroach.proto.Replica replica = 6;
-  if (has_replica()) {
-    ::google::protobuf::internal::WireFormatLite::WriteMessageMaybeToArray(
-      6, *this->replica_, output);
-  }
-
-  // optional int64 raft_id = 7;
-  if (has_raft_id()) {
-    ::google::protobuf::internal::WireFormatLite::WriteInt64(7, this->raft_id(), output);
   }
 
   // optional int32 user_priority = 8 [default = 1];
@@ -1656,20 +1609,6 @@ void RequestHeader::SerializeWithCachedSizes(
         2, *this->cmd_id_, target);
   }
 
-  // optional bytes key = 3;
-  if (has_key()) {
-    target =
-      ::google::protobuf::internal::WireFormatLite::WriteBytesToArray(
-        3, this->key(), target);
-  }
-
-  // optional bytes end_key = 4;
-  if (has_end_key()) {
-    target =
-      ::google::protobuf::internal::WireFormatLite::WriteBytesToArray(
-        4, this->end_key(), target);
-  }
-
   // optional string user = 5;
   if (has_user()) {
     ::google::protobuf::internal::WireFormat::VerifyUTF8StringNamedField(
@@ -1679,18 +1618,6 @@ void RequestHeader::SerializeWithCachedSizes(
     target =
       ::google::protobuf::internal::WireFormatLite::WriteStringToArray(
         5, this->user(), target);
-  }
-
-  // optional .cockroach.proto.Replica replica = 6;
-  if (has_replica()) {
-    target = ::google::protobuf::internal::WireFormatLite::
-      WriteMessageNoVirtualToArray(
-        6, *this->replica_, target);
-  }
-
-  // optional int64 raft_id = 7;
-  if (has_raft_id()) {
-    target = ::google::protobuf::internal::WireFormatLite::WriteInt64ToArray(7, this->raft_id(), target);
   }
 
   // optional int32 user_priority = 8 [default = 1];
@@ -1722,7 +1649,7 @@ void RequestHeader::SerializeWithCachedSizes(
 int RequestHeader::ByteSize() const {
   int total_size = 0;
 
-  if (_has_bits_[0 / 32] & 255) {
+  if (_has_bits_[0 / 32] & 63) {
     // optional .cockroach.proto.Timestamp timestamp = 1;
     if (has_timestamp()) {
       total_size += 1 +
@@ -1737,39 +1664,11 @@ int RequestHeader::ByteSize() const {
           *this->cmd_id_);
     }
 
-    // optional bytes key = 3;
-    if (has_key()) {
-      total_size += 1 +
-        ::google::protobuf::internal::WireFormatLite::BytesSize(
-          this->key());
-    }
-
-    // optional bytes end_key = 4;
-    if (has_end_key()) {
-      total_size += 1 +
-        ::google::protobuf::internal::WireFormatLite::BytesSize(
-          this->end_key());
-    }
-
     // optional string user = 5;
     if (has_user()) {
       total_size += 1 +
         ::google::protobuf::internal::WireFormatLite::StringSize(
           this->user());
-    }
-
-    // optional .cockroach.proto.Replica replica = 6;
-    if (has_replica()) {
-      total_size += 1 +
-        ::google::protobuf::internal::WireFormatLite::MessageSizeNoVirtual(
-          *this->replica_);
-    }
-
-    // optional int64 raft_id = 7;
-    if (has_raft_id()) {
-      total_size += 1 +
-        ::google::protobuf::internal::WireFormatLite::Int64Size(
-          this->raft_id());
     }
 
     // optional int32 user_priority = 8 [default = 1];
@@ -1779,8 +1678,6 @@ int RequestHeader::ByteSize() const {
           this->user_priority());
     }
 
-  }
-  if (_has_bits_[8 / 32] & 768) {
     // optional .cockroach.proto.Transaction txn = 9;
     if (has_txn()) {
       total_size += 1 +
@@ -1827,29 +1724,13 @@ void RequestHeader::MergeFrom(const RequestHeader& from) {
     if (from.has_cmd_id()) {
       mutable_cmd_id()->::cockroach::proto::ClientCmdID::MergeFrom(from.cmd_id());
     }
-    if (from.has_key()) {
-      set_has_key();
-      key_.AssignWithDefault(&::google::protobuf::internal::GetEmptyStringAlreadyInited(), from.key_);
-    }
-    if (from.has_end_key()) {
-      set_has_end_key();
-      end_key_.AssignWithDefault(&::google::protobuf::internal::GetEmptyStringAlreadyInited(), from.end_key_);
-    }
     if (from.has_user()) {
       set_has_user();
       user_.AssignWithDefault(&::google::protobuf::internal::GetEmptyStringAlreadyInited(), from.user_);
     }
-    if (from.has_replica()) {
-      mutable_replica()->::cockroach::proto::Replica::MergeFrom(from.replica());
-    }
-    if (from.has_raft_id()) {
-      set_raft_id(from.raft_id());
-    }
     if (from.has_user_priority()) {
       set_user_priority(from.user_priority());
     }
-  }
-  if (from._has_bits_[8 / 32] & (0xffu << (8 % 32))) {
     if (from.has_txn()) {
       mutable_txn()->::cockroach::proto::Transaction::MergeFrom(from.txn());
     }
@@ -1886,11 +1767,7 @@ void RequestHeader::Swap(RequestHeader* other) {
 void RequestHeader::InternalSwap(RequestHeader* other) {
   std::swap(timestamp_, other->timestamp_);
   std::swap(cmd_id_, other->cmd_id_);
-  key_.Swap(&other->key_);
-  end_key_.Swap(&other->end_key_);
   user_.Swap(&other->user_);
-  std::swap(replica_, other->replica_);
-  std::swap(raft_id_, other->raft_id_);
   std::swap(user_priority_, other->user_priority_);
   std::swap(txn_, other->txn_);
   std::swap(read_consistency_, other->read_consistency_);
@@ -1996,121 +1873,15 @@ void RequestHeader::clear_cmd_id() {
   // @@protoc_insertion_point(field_set_allocated:cockroach.proto.RequestHeader.cmd_id)
 }
 
-// optional bytes key = 3;
-bool RequestHeader::has_key() const {
-  return (_has_bits_[0] & 0x00000004u) != 0;
-}
-void RequestHeader::set_has_key() {
-  _has_bits_[0] |= 0x00000004u;
-}
-void RequestHeader::clear_has_key() {
-  _has_bits_[0] &= ~0x00000004u;
-}
-void RequestHeader::clear_key() {
-  key_.ClearToEmptyNoArena(&::google::protobuf::internal::GetEmptyStringAlreadyInited());
-  clear_has_key();
-}
- const ::std::string& RequestHeader::key() const {
-  // @@protoc_insertion_point(field_get:cockroach.proto.RequestHeader.key)
-  return key_.GetNoArena(&::google::protobuf::internal::GetEmptyStringAlreadyInited());
-}
- void RequestHeader::set_key(const ::std::string& value) {
-  set_has_key();
-  key_.SetNoArena(&::google::protobuf::internal::GetEmptyStringAlreadyInited(), value);
-  // @@protoc_insertion_point(field_set:cockroach.proto.RequestHeader.key)
-}
- void RequestHeader::set_key(const char* value) {
-  set_has_key();
-  key_.SetNoArena(&::google::protobuf::internal::GetEmptyStringAlreadyInited(), ::std::string(value));
-  // @@protoc_insertion_point(field_set_char:cockroach.proto.RequestHeader.key)
-}
- void RequestHeader::set_key(const void* value, size_t size) {
-  set_has_key();
-  key_.SetNoArena(&::google::protobuf::internal::GetEmptyStringAlreadyInited(),
-      ::std::string(reinterpret_cast<const char*>(value), size));
-  // @@protoc_insertion_point(field_set_pointer:cockroach.proto.RequestHeader.key)
-}
- ::std::string* RequestHeader::mutable_key() {
-  set_has_key();
-  // @@protoc_insertion_point(field_mutable:cockroach.proto.RequestHeader.key)
-  return key_.MutableNoArena(&::google::protobuf::internal::GetEmptyStringAlreadyInited());
-}
- ::std::string* RequestHeader::release_key() {
-  clear_has_key();
-  return key_.ReleaseNoArena(&::google::protobuf::internal::GetEmptyStringAlreadyInited());
-}
- void RequestHeader::set_allocated_key(::std::string* key) {
-  if (key != NULL) {
-    set_has_key();
-  } else {
-    clear_has_key();
-  }
-  key_.SetAllocatedNoArena(&::google::protobuf::internal::GetEmptyStringAlreadyInited(), key);
-  // @@protoc_insertion_point(field_set_allocated:cockroach.proto.RequestHeader.key)
-}
-
-// optional bytes end_key = 4;
-bool RequestHeader::has_end_key() const {
-  return (_has_bits_[0] & 0x00000008u) != 0;
-}
-void RequestHeader::set_has_end_key() {
-  _has_bits_[0] |= 0x00000008u;
-}
-void RequestHeader::clear_has_end_key() {
-  _has_bits_[0] &= ~0x00000008u;
-}
-void RequestHeader::clear_end_key() {
-  end_key_.ClearToEmptyNoArena(&::google::protobuf::internal::GetEmptyStringAlreadyInited());
-  clear_has_end_key();
-}
- const ::std::string& RequestHeader::end_key() const {
-  // @@protoc_insertion_point(field_get:cockroach.proto.RequestHeader.end_key)
-  return end_key_.GetNoArena(&::google::protobuf::internal::GetEmptyStringAlreadyInited());
-}
- void RequestHeader::set_end_key(const ::std::string& value) {
-  set_has_end_key();
-  end_key_.SetNoArena(&::google::protobuf::internal::GetEmptyStringAlreadyInited(), value);
-  // @@protoc_insertion_point(field_set:cockroach.proto.RequestHeader.end_key)
-}
- void RequestHeader::set_end_key(const char* value) {
-  set_has_end_key();
-  end_key_.SetNoArena(&::google::protobuf::internal::GetEmptyStringAlreadyInited(), ::std::string(value));
-  // @@protoc_insertion_point(field_set_char:cockroach.proto.RequestHeader.end_key)
-}
- void RequestHeader::set_end_key(const void* value, size_t size) {
-  set_has_end_key();
-  end_key_.SetNoArena(&::google::protobuf::internal::GetEmptyStringAlreadyInited(),
-      ::std::string(reinterpret_cast<const char*>(value), size));
-  // @@protoc_insertion_point(field_set_pointer:cockroach.proto.RequestHeader.end_key)
-}
- ::std::string* RequestHeader::mutable_end_key() {
-  set_has_end_key();
-  // @@protoc_insertion_point(field_mutable:cockroach.proto.RequestHeader.end_key)
-  return end_key_.MutableNoArena(&::google::protobuf::internal::GetEmptyStringAlreadyInited());
-}
- ::std::string* RequestHeader::release_end_key() {
-  clear_has_end_key();
-  return end_key_.ReleaseNoArena(&::google::protobuf::internal::GetEmptyStringAlreadyInited());
-}
- void RequestHeader::set_allocated_end_key(::std::string* end_key) {
-  if (end_key != NULL) {
-    set_has_end_key();
-  } else {
-    clear_has_end_key();
-  }
-  end_key_.SetAllocatedNoArena(&::google::protobuf::internal::GetEmptyStringAlreadyInited(), end_key);
-  // @@protoc_insertion_point(field_set_allocated:cockroach.proto.RequestHeader.end_key)
-}
-
 // optional string user = 5;
 bool RequestHeader::has_user() const {
-  return (_has_bits_[0] & 0x00000010u) != 0;
+  return (_has_bits_[0] & 0x00000004u) != 0;
 }
 void RequestHeader::set_has_user() {
-  _has_bits_[0] |= 0x00000010u;
+  _has_bits_[0] |= 0x00000004u;
 }
 void RequestHeader::clear_has_user() {
-  _has_bits_[0] &= ~0x00000010u;
+  _has_bits_[0] &= ~0x00000004u;
 }
 void RequestHeader::clear_user() {
   user_.ClearToEmptyNoArena(&::google::protobuf::internal::GetEmptyStringAlreadyInited());
@@ -2155,82 +1926,15 @@ void RequestHeader::clear_user() {
   // @@protoc_insertion_point(field_set_allocated:cockroach.proto.RequestHeader.user)
 }
 
-// optional .cockroach.proto.Replica replica = 6;
-bool RequestHeader::has_replica() const {
-  return (_has_bits_[0] & 0x00000020u) != 0;
-}
-void RequestHeader::set_has_replica() {
-  _has_bits_[0] |= 0x00000020u;
-}
-void RequestHeader::clear_has_replica() {
-  _has_bits_[0] &= ~0x00000020u;
-}
-void RequestHeader::clear_replica() {
-  if (replica_ != NULL) replica_->::cockroach::proto::Replica::Clear();
-  clear_has_replica();
-}
- const ::cockroach::proto::Replica& RequestHeader::replica() const {
-  // @@protoc_insertion_point(field_get:cockroach.proto.RequestHeader.replica)
-  return replica_ != NULL ? *replica_ : *default_instance_->replica_;
-}
- ::cockroach::proto::Replica* RequestHeader::mutable_replica() {
-  set_has_replica();
-  if (replica_ == NULL) {
-    replica_ = new ::cockroach::proto::Replica;
-  }
-  // @@protoc_insertion_point(field_mutable:cockroach.proto.RequestHeader.replica)
-  return replica_;
-}
- ::cockroach::proto::Replica* RequestHeader::release_replica() {
-  clear_has_replica();
-  ::cockroach::proto::Replica* temp = replica_;
-  replica_ = NULL;
-  return temp;
-}
- void RequestHeader::set_allocated_replica(::cockroach::proto::Replica* replica) {
-  delete replica_;
-  replica_ = replica;
-  if (replica) {
-    set_has_replica();
-  } else {
-    clear_has_replica();
-  }
-  // @@protoc_insertion_point(field_set_allocated:cockroach.proto.RequestHeader.replica)
-}
-
-// optional int64 raft_id = 7;
-bool RequestHeader::has_raft_id() const {
-  return (_has_bits_[0] & 0x00000040u) != 0;
-}
-void RequestHeader::set_has_raft_id() {
-  _has_bits_[0] |= 0x00000040u;
-}
-void RequestHeader::clear_has_raft_id() {
-  _has_bits_[0] &= ~0x00000040u;
-}
-void RequestHeader::clear_raft_id() {
-  raft_id_ = GOOGLE_LONGLONG(0);
-  clear_has_raft_id();
-}
- ::google::protobuf::int64 RequestHeader::raft_id() const {
-  // @@protoc_insertion_point(field_get:cockroach.proto.RequestHeader.raft_id)
-  return raft_id_;
-}
- void RequestHeader::set_raft_id(::google::protobuf::int64 value) {
-  set_has_raft_id();
-  raft_id_ = value;
-  // @@protoc_insertion_point(field_set:cockroach.proto.RequestHeader.raft_id)
-}
-
 // optional int32 user_priority = 8 [default = 1];
 bool RequestHeader::has_user_priority() const {
-  return (_has_bits_[0] & 0x00000080u) != 0;
+  return (_has_bits_[0] & 0x00000008u) != 0;
 }
 void RequestHeader::set_has_user_priority() {
-  _has_bits_[0] |= 0x00000080u;
+  _has_bits_[0] |= 0x00000008u;
 }
 void RequestHeader::clear_has_user_priority() {
-  _has_bits_[0] &= ~0x00000080u;
+  _has_bits_[0] &= ~0x00000008u;
 }
 void RequestHeader::clear_user_priority() {
   user_priority_ = 1;
@@ -2248,13 +1952,13 @@ void RequestHeader::clear_user_priority() {
 
 // optional .cockroach.proto.Transaction txn = 9;
 bool RequestHeader::has_txn() const {
-  return (_has_bits_[0] & 0x00000100u) != 0;
+  return (_has_bits_[0] & 0x00000010u) != 0;
 }
 void RequestHeader::set_has_txn() {
-  _has_bits_[0] |= 0x00000100u;
+  _has_bits_[0] |= 0x00000010u;
 }
 void RequestHeader::clear_has_txn() {
-  _has_bits_[0] &= ~0x00000100u;
+  _has_bits_[0] &= ~0x00000010u;
 }
 void RequestHeader::clear_txn() {
   if (txn_ != NULL) txn_->::cockroach::proto::Transaction::Clear();
@@ -2291,13 +1995,13 @@ void RequestHeader::clear_txn() {
 
 // optional .cockroach.proto.ReadConsistencyType read_consistency = 10;
 bool RequestHeader::has_read_consistency() const {
-  return (_has_bits_[0] & 0x00000200u) != 0;
+  return (_has_bits_[0] & 0x00000020u) != 0;
 }
 void RequestHeader::set_has_read_consistency() {
-  _has_bits_[0] |= 0x00000200u;
+  _has_bits_[0] |= 0x00000020u;
 }
 void RequestHeader::clear_has_read_consistency() {
-  _has_bits_[0] &= ~0x00000200u;
+  _has_bits_[0] &= ~0x00000020u;
 }
 void RequestHeader::clear_read_consistency() {
   read_consistency_ = 0;
@@ -2780,7 +2484,922 @@ void ResponseHeader::clear_txn() {
 // ===================================================================
 
 #ifndef _MSC_VER
-const int GetRequest::kHeaderFieldNumber;
+const int KVRequestHeader::kHeaderFieldNumber;
+const int KVRequestHeader::kKeyFieldNumber;
+const int KVRequestHeader::kEndKeyFieldNumber;
+const int KVRequestHeader::kReplicaFieldNumber;
+const int KVRequestHeader::kRaftIdFieldNumber;
+#endif  // !_MSC_VER
+
+KVRequestHeader::KVRequestHeader()
+  : ::google::protobuf::Message(), _internal_metadata_(NULL) {
+  SharedCtor();
+  // @@protoc_insertion_point(constructor:cockroach.proto.KVRequestHeader)
+}
+
+void KVRequestHeader::InitAsDefaultInstance() {
+  header_ = const_cast< ::cockroach::proto::RequestHeader*>(&::cockroach::proto::RequestHeader::default_instance());
+  replica_ = const_cast< ::cockroach::proto::Replica*>(&::cockroach::proto::Replica::default_instance());
+}
+
+KVRequestHeader::KVRequestHeader(const KVRequestHeader& from)
+  : ::google::protobuf::Message(),
+    _internal_metadata_(NULL) {
+  SharedCtor();
+  MergeFrom(from);
+  // @@protoc_insertion_point(copy_constructor:cockroach.proto.KVRequestHeader)
+}
+
+void KVRequestHeader::SharedCtor() {
+  ::google::protobuf::internal::GetEmptyString();
+  _cached_size_ = 0;
+  header_ = NULL;
+  key_.UnsafeSetDefault(&::google::protobuf::internal::GetEmptyStringAlreadyInited());
+  end_key_.UnsafeSetDefault(&::google::protobuf::internal::GetEmptyStringAlreadyInited());
+  replica_ = NULL;
+  raft_id_ = GOOGLE_LONGLONG(0);
+  ::memset(_has_bits_, 0, sizeof(_has_bits_));
+}
+
+KVRequestHeader::~KVRequestHeader() {
+  // @@protoc_insertion_point(destructor:cockroach.proto.KVRequestHeader)
+  SharedDtor();
+}
+
+void KVRequestHeader::SharedDtor() {
+  key_.DestroyNoArena(&::google::protobuf::internal::GetEmptyStringAlreadyInited());
+  end_key_.DestroyNoArena(&::google::protobuf::internal::GetEmptyStringAlreadyInited());
+  if (this != default_instance_) {
+    delete header_;
+    delete replica_;
+  }
+}
+
+void KVRequestHeader::SetCachedSize(int size) const {
+  GOOGLE_SAFE_CONCURRENT_WRITES_BEGIN();
+  _cached_size_ = size;
+  GOOGLE_SAFE_CONCURRENT_WRITES_END();
+}
+const ::google::protobuf::Descriptor* KVRequestHeader::descriptor() {
+  protobuf_AssignDescriptorsOnce();
+  return KVRequestHeader_descriptor_;
+}
+
+const KVRequestHeader& KVRequestHeader::default_instance() {
+  if (default_instance_ == NULL) protobuf_AddDesc_cockroach_2fproto_2fapi_2eproto();
+  return *default_instance_;
+}
+
+KVRequestHeader* KVRequestHeader::default_instance_ = NULL;
+
+KVRequestHeader* KVRequestHeader::New(::google::protobuf::Arena* arena) const {
+  KVRequestHeader* n = new KVRequestHeader;
+  if (arena != NULL) {
+    arena->Own(n);
+  }
+  return n;
+}
+
+void KVRequestHeader::Clear() {
+  if (_has_bits_[0 / 32] & 31u) {
+    if (has_header()) {
+      if (header_ != NULL) header_->::cockroach::proto::RequestHeader::Clear();
+    }
+    if (has_key()) {
+      key_.ClearToEmptyNoArena(&::google::protobuf::internal::GetEmptyStringAlreadyInited());
+    }
+    if (has_end_key()) {
+      end_key_.ClearToEmptyNoArena(&::google::protobuf::internal::GetEmptyStringAlreadyInited());
+    }
+    if (has_replica()) {
+      if (replica_ != NULL) replica_->::cockroach::proto::Replica::Clear();
+    }
+    raft_id_ = GOOGLE_LONGLONG(0);
+  }
+  ::memset(_has_bits_, 0, sizeof(_has_bits_));
+  if (_internal_metadata_.have_unknown_fields()) {
+    mutable_unknown_fields()->Clear();
+  }
+}
+
+bool KVRequestHeader::MergePartialFromCodedStream(
+    ::google::protobuf::io::CodedInputStream* input) {
+#define DO_(EXPRESSION) if (!(EXPRESSION)) goto failure
+  ::google::protobuf::uint32 tag;
+  // @@protoc_insertion_point(parse_start:cockroach.proto.KVRequestHeader)
+  for (;;) {
+    ::std::pair< ::google::protobuf::uint32, bool> p = input->ReadTagWithCutoff(127);
+    tag = p.first;
+    if (!p.second) goto handle_unusual;
+    switch (::google::protobuf::internal::WireFormatLite::GetTagFieldNumber(tag)) {
+      // optional .cockroach.proto.RequestHeader header = 1;
+      case 1: {
+        if (tag == 10) {
+          DO_(::google::protobuf::internal::WireFormatLite::ReadMessageNoVirtual(
+               input, mutable_header()));
+        } else {
+          goto handle_unusual;
+        }
+        if (input->ExpectTag(26)) goto parse_key;
+        break;
+      }
+
+      // optional bytes key = 3;
+      case 3: {
+        if (tag == 26) {
+         parse_key:
+          DO_(::google::protobuf::internal::WireFormatLite::ReadBytes(
+                input, this->mutable_key()));
+        } else {
+          goto handle_unusual;
+        }
+        if (input->ExpectTag(34)) goto parse_end_key;
+        break;
+      }
+
+      // optional bytes end_key = 4;
+      case 4: {
+        if (tag == 34) {
+         parse_end_key:
+          DO_(::google::protobuf::internal::WireFormatLite::ReadBytes(
+                input, this->mutable_end_key()));
+        } else {
+          goto handle_unusual;
+        }
+        if (input->ExpectTag(50)) goto parse_replica;
+        break;
+      }
+
+      // optional .cockroach.proto.Replica replica = 6;
+      case 6: {
+        if (tag == 50) {
+         parse_replica:
+          DO_(::google::protobuf::internal::WireFormatLite::ReadMessageNoVirtual(
+               input, mutable_replica()));
+        } else {
+          goto handle_unusual;
+        }
+        if (input->ExpectTag(56)) goto parse_raft_id;
+        break;
+      }
+
+      // optional int64 raft_id = 7;
+      case 7: {
+        if (tag == 56) {
+         parse_raft_id:
+          DO_((::google::protobuf::internal::WireFormatLite::ReadPrimitive<
+                   ::google::protobuf::int64, ::google::protobuf::internal::WireFormatLite::TYPE_INT64>(
+                 input, &raft_id_)));
+          set_has_raft_id();
+        } else {
+          goto handle_unusual;
+        }
+        if (input->ExpectAtEnd()) goto success;
+        break;
+      }
+
+      default: {
+      handle_unusual:
+        if (tag == 0 ||
+            ::google::protobuf::internal::WireFormatLite::GetTagWireType(tag) ==
+            ::google::protobuf::internal::WireFormatLite::WIRETYPE_END_GROUP) {
+          goto success;
+        }
+        DO_(::google::protobuf::internal::WireFormat::SkipField(
+              input, tag, mutable_unknown_fields()));
+        break;
+      }
+    }
+  }
+success:
+  // @@protoc_insertion_point(parse_success:cockroach.proto.KVRequestHeader)
+  return true;
+failure:
+  // @@protoc_insertion_point(parse_failure:cockroach.proto.KVRequestHeader)
+  return false;
+#undef DO_
+}
+
+void KVRequestHeader::SerializeWithCachedSizes(
+    ::google::protobuf::io::CodedOutputStream* output) const {
+  // @@protoc_insertion_point(serialize_start:cockroach.proto.KVRequestHeader)
+  // optional .cockroach.proto.RequestHeader header = 1;
+  if (has_header()) {
+    ::google::protobuf::internal::WireFormatLite::WriteMessageMaybeToArray(
+      1, *this->header_, output);
+  }
+
+  // optional bytes key = 3;
+  if (has_key()) {
+    ::google::protobuf::internal::WireFormatLite::WriteBytesMaybeAliased(
+      3, this->key(), output);
+  }
+
+  // optional bytes end_key = 4;
+  if (has_end_key()) {
+    ::google::protobuf::internal::WireFormatLite::WriteBytesMaybeAliased(
+      4, this->end_key(), output);
+  }
+
+  // optional .cockroach.proto.Replica replica = 6;
+  if (has_replica()) {
+    ::google::protobuf::internal::WireFormatLite::WriteMessageMaybeToArray(
+      6, *this->replica_, output);
+  }
+
+  // optional int64 raft_id = 7;
+  if (has_raft_id()) {
+    ::google::protobuf::internal::WireFormatLite::WriteInt64(7, this->raft_id(), output);
+  }
+
+  if (_internal_metadata_.have_unknown_fields()) {
+    ::google::protobuf::internal::WireFormat::SerializeUnknownFields(
+        unknown_fields(), output);
+  }
+  // @@protoc_insertion_point(serialize_end:cockroach.proto.KVRequestHeader)
+}
+
+::google::protobuf::uint8* KVRequestHeader::SerializeWithCachedSizesToArray(
+    ::google::protobuf::uint8* target) const {
+  // @@protoc_insertion_point(serialize_to_array_start:cockroach.proto.KVRequestHeader)
+  // optional .cockroach.proto.RequestHeader header = 1;
+  if (has_header()) {
+    target = ::google::protobuf::internal::WireFormatLite::
+      WriteMessageNoVirtualToArray(
+        1, *this->header_, target);
+  }
+
+  // optional bytes key = 3;
+  if (has_key()) {
+    target =
+      ::google::protobuf::internal::WireFormatLite::WriteBytesToArray(
+        3, this->key(), target);
+  }
+
+  // optional bytes end_key = 4;
+  if (has_end_key()) {
+    target =
+      ::google::protobuf::internal::WireFormatLite::WriteBytesToArray(
+        4, this->end_key(), target);
+  }
+
+  // optional .cockroach.proto.Replica replica = 6;
+  if (has_replica()) {
+    target = ::google::protobuf::internal::WireFormatLite::
+      WriteMessageNoVirtualToArray(
+        6, *this->replica_, target);
+  }
+
+  // optional int64 raft_id = 7;
+  if (has_raft_id()) {
+    target = ::google::protobuf::internal::WireFormatLite::WriteInt64ToArray(7, this->raft_id(), target);
+  }
+
+  if (_internal_metadata_.have_unknown_fields()) {
+    target = ::google::protobuf::internal::WireFormat::SerializeUnknownFieldsToArray(
+        unknown_fields(), target);
+  }
+  // @@protoc_insertion_point(serialize_to_array_end:cockroach.proto.KVRequestHeader)
+  return target;
+}
+
+int KVRequestHeader::ByteSize() const {
+  int total_size = 0;
+
+  if (_has_bits_[0 / 32] & 31) {
+    // optional .cockroach.proto.RequestHeader header = 1;
+    if (has_header()) {
+      total_size += 1 +
+        ::google::protobuf::internal::WireFormatLite::MessageSizeNoVirtual(
+          *this->header_);
+    }
+
+    // optional bytes key = 3;
+    if (has_key()) {
+      total_size += 1 +
+        ::google::protobuf::internal::WireFormatLite::BytesSize(
+          this->key());
+    }
+
+    // optional bytes end_key = 4;
+    if (has_end_key()) {
+      total_size += 1 +
+        ::google::protobuf::internal::WireFormatLite::BytesSize(
+          this->end_key());
+    }
+
+    // optional .cockroach.proto.Replica replica = 6;
+    if (has_replica()) {
+      total_size += 1 +
+        ::google::protobuf::internal::WireFormatLite::MessageSizeNoVirtual(
+          *this->replica_);
+    }
+
+    // optional int64 raft_id = 7;
+    if (has_raft_id()) {
+      total_size += 1 +
+        ::google::protobuf::internal::WireFormatLite::Int64Size(
+          this->raft_id());
+    }
+
+  }
+  if (_internal_metadata_.have_unknown_fields()) {
+    total_size +=
+      ::google::protobuf::internal::WireFormat::ComputeUnknownFieldsSize(
+        unknown_fields());
+  }
+  GOOGLE_SAFE_CONCURRENT_WRITES_BEGIN();
+  _cached_size_ = total_size;
+  GOOGLE_SAFE_CONCURRENT_WRITES_END();
+  return total_size;
+}
+
+void KVRequestHeader::MergeFrom(const ::google::protobuf::Message& from) {
+  if (GOOGLE_PREDICT_FALSE(&from == this)) MergeFromFail(__LINE__);
+  const KVRequestHeader* source = 
+      ::google::protobuf::internal::DynamicCastToGenerated<const KVRequestHeader>(
+          &from);
+  if (source == NULL) {
+    ::google::protobuf::internal::ReflectionOps::Merge(from, this);
+  } else {
+    MergeFrom(*source);
+  }
+}
+
+void KVRequestHeader::MergeFrom(const KVRequestHeader& from) {
+  if (GOOGLE_PREDICT_FALSE(&from == this)) MergeFromFail(__LINE__);
+  if (from._has_bits_[0 / 32] & (0xffu << (0 % 32))) {
+    if (from.has_header()) {
+      mutable_header()->::cockroach::proto::RequestHeader::MergeFrom(from.header());
+    }
+    if (from.has_key()) {
+      set_has_key();
+      key_.AssignWithDefault(&::google::protobuf::internal::GetEmptyStringAlreadyInited(), from.key_);
+    }
+    if (from.has_end_key()) {
+      set_has_end_key();
+      end_key_.AssignWithDefault(&::google::protobuf::internal::GetEmptyStringAlreadyInited(), from.end_key_);
+    }
+    if (from.has_replica()) {
+      mutable_replica()->::cockroach::proto::Replica::MergeFrom(from.replica());
+    }
+    if (from.has_raft_id()) {
+      set_raft_id(from.raft_id());
+    }
+  }
+  if (from._internal_metadata_.have_unknown_fields()) {
+    mutable_unknown_fields()->MergeFrom(from.unknown_fields());
+  }
+}
+
+void KVRequestHeader::CopyFrom(const ::google::protobuf::Message& from) {
+  if (&from == this) return;
+  Clear();
+  MergeFrom(from);
+}
+
+void KVRequestHeader::CopyFrom(const KVRequestHeader& from) {
+  if (&from == this) return;
+  Clear();
+  MergeFrom(from);
+}
+
+bool KVRequestHeader::IsInitialized() const {
+
+  return true;
+}
+
+void KVRequestHeader::Swap(KVRequestHeader* other) {
+  if (other == this) return;
+  InternalSwap(other);
+}
+void KVRequestHeader::InternalSwap(KVRequestHeader* other) {
+  std::swap(header_, other->header_);
+  key_.Swap(&other->key_);
+  end_key_.Swap(&other->end_key_);
+  std::swap(replica_, other->replica_);
+  std::swap(raft_id_, other->raft_id_);
+  std::swap(_has_bits_[0], other->_has_bits_[0]);
+  _internal_metadata_.Swap(&other->_internal_metadata_);
+  std::swap(_cached_size_, other->_cached_size_);
+}
+
+::google::protobuf::Metadata KVRequestHeader::GetMetadata() const {
+  protobuf_AssignDescriptorsOnce();
+  ::google::protobuf::Metadata metadata;
+  metadata.descriptor = KVRequestHeader_descriptor_;
+  metadata.reflection = KVRequestHeader_reflection_;
+  return metadata;
+}
+
+#if PROTOBUF_INLINE_NOT_IN_HEADERS
+// KVRequestHeader
+
+// optional .cockroach.proto.RequestHeader header = 1;
+bool KVRequestHeader::has_header() const {
+  return (_has_bits_[0] & 0x00000001u) != 0;
+}
+void KVRequestHeader::set_has_header() {
+  _has_bits_[0] |= 0x00000001u;
+}
+void KVRequestHeader::clear_has_header() {
+  _has_bits_[0] &= ~0x00000001u;
+}
+void KVRequestHeader::clear_header() {
+  if (header_ != NULL) header_->::cockroach::proto::RequestHeader::Clear();
+  clear_has_header();
+}
+ const ::cockroach::proto::RequestHeader& KVRequestHeader::header() const {
+  // @@protoc_insertion_point(field_get:cockroach.proto.KVRequestHeader.header)
+  return header_ != NULL ? *header_ : *default_instance_->header_;
+}
+ ::cockroach::proto::RequestHeader* KVRequestHeader::mutable_header() {
+  set_has_header();
+  if (header_ == NULL) {
+    header_ = new ::cockroach::proto::RequestHeader;
+  }
+  // @@protoc_insertion_point(field_mutable:cockroach.proto.KVRequestHeader.header)
+  return header_;
+}
+ ::cockroach::proto::RequestHeader* KVRequestHeader::release_header() {
+  clear_has_header();
+  ::cockroach::proto::RequestHeader* temp = header_;
+  header_ = NULL;
+  return temp;
+}
+ void KVRequestHeader::set_allocated_header(::cockroach::proto::RequestHeader* header) {
+  delete header_;
+  header_ = header;
+  if (header) {
+    set_has_header();
+  } else {
+    clear_has_header();
+  }
+  // @@protoc_insertion_point(field_set_allocated:cockroach.proto.KVRequestHeader.header)
+}
+
+// optional bytes key = 3;
+bool KVRequestHeader::has_key() const {
+  return (_has_bits_[0] & 0x00000002u) != 0;
+}
+void KVRequestHeader::set_has_key() {
+  _has_bits_[0] |= 0x00000002u;
+}
+void KVRequestHeader::clear_has_key() {
+  _has_bits_[0] &= ~0x00000002u;
+}
+void KVRequestHeader::clear_key() {
+  key_.ClearToEmptyNoArena(&::google::protobuf::internal::GetEmptyStringAlreadyInited());
+  clear_has_key();
+}
+ const ::std::string& KVRequestHeader::key() const {
+  // @@protoc_insertion_point(field_get:cockroach.proto.KVRequestHeader.key)
+  return key_.GetNoArena(&::google::protobuf::internal::GetEmptyStringAlreadyInited());
+}
+ void KVRequestHeader::set_key(const ::std::string& value) {
+  set_has_key();
+  key_.SetNoArena(&::google::protobuf::internal::GetEmptyStringAlreadyInited(), value);
+  // @@protoc_insertion_point(field_set:cockroach.proto.KVRequestHeader.key)
+}
+ void KVRequestHeader::set_key(const char* value) {
+  set_has_key();
+  key_.SetNoArena(&::google::protobuf::internal::GetEmptyStringAlreadyInited(), ::std::string(value));
+  // @@protoc_insertion_point(field_set_char:cockroach.proto.KVRequestHeader.key)
+}
+ void KVRequestHeader::set_key(const void* value, size_t size) {
+  set_has_key();
+  key_.SetNoArena(&::google::protobuf::internal::GetEmptyStringAlreadyInited(),
+      ::std::string(reinterpret_cast<const char*>(value), size));
+  // @@protoc_insertion_point(field_set_pointer:cockroach.proto.KVRequestHeader.key)
+}
+ ::std::string* KVRequestHeader::mutable_key() {
+  set_has_key();
+  // @@protoc_insertion_point(field_mutable:cockroach.proto.KVRequestHeader.key)
+  return key_.MutableNoArena(&::google::protobuf::internal::GetEmptyStringAlreadyInited());
+}
+ ::std::string* KVRequestHeader::release_key() {
+  clear_has_key();
+  return key_.ReleaseNoArena(&::google::protobuf::internal::GetEmptyStringAlreadyInited());
+}
+ void KVRequestHeader::set_allocated_key(::std::string* key) {
+  if (key != NULL) {
+    set_has_key();
+  } else {
+    clear_has_key();
+  }
+  key_.SetAllocatedNoArena(&::google::protobuf::internal::GetEmptyStringAlreadyInited(), key);
+  // @@protoc_insertion_point(field_set_allocated:cockroach.proto.KVRequestHeader.key)
+}
+
+// optional bytes end_key = 4;
+bool KVRequestHeader::has_end_key() const {
+  return (_has_bits_[0] & 0x00000004u) != 0;
+}
+void KVRequestHeader::set_has_end_key() {
+  _has_bits_[0] |= 0x00000004u;
+}
+void KVRequestHeader::clear_has_end_key() {
+  _has_bits_[0] &= ~0x00000004u;
+}
+void KVRequestHeader::clear_end_key() {
+  end_key_.ClearToEmptyNoArena(&::google::protobuf::internal::GetEmptyStringAlreadyInited());
+  clear_has_end_key();
+}
+ const ::std::string& KVRequestHeader::end_key() const {
+  // @@protoc_insertion_point(field_get:cockroach.proto.KVRequestHeader.end_key)
+  return end_key_.GetNoArena(&::google::protobuf::internal::GetEmptyStringAlreadyInited());
+}
+ void KVRequestHeader::set_end_key(const ::std::string& value) {
+  set_has_end_key();
+  end_key_.SetNoArena(&::google::protobuf::internal::GetEmptyStringAlreadyInited(), value);
+  // @@protoc_insertion_point(field_set:cockroach.proto.KVRequestHeader.end_key)
+}
+ void KVRequestHeader::set_end_key(const char* value) {
+  set_has_end_key();
+  end_key_.SetNoArena(&::google::protobuf::internal::GetEmptyStringAlreadyInited(), ::std::string(value));
+  // @@protoc_insertion_point(field_set_char:cockroach.proto.KVRequestHeader.end_key)
+}
+ void KVRequestHeader::set_end_key(const void* value, size_t size) {
+  set_has_end_key();
+  end_key_.SetNoArena(&::google::protobuf::internal::GetEmptyStringAlreadyInited(),
+      ::std::string(reinterpret_cast<const char*>(value), size));
+  // @@protoc_insertion_point(field_set_pointer:cockroach.proto.KVRequestHeader.end_key)
+}
+ ::std::string* KVRequestHeader::mutable_end_key() {
+  set_has_end_key();
+  // @@protoc_insertion_point(field_mutable:cockroach.proto.KVRequestHeader.end_key)
+  return end_key_.MutableNoArena(&::google::protobuf::internal::GetEmptyStringAlreadyInited());
+}
+ ::std::string* KVRequestHeader::release_end_key() {
+  clear_has_end_key();
+  return end_key_.ReleaseNoArena(&::google::protobuf::internal::GetEmptyStringAlreadyInited());
+}
+ void KVRequestHeader::set_allocated_end_key(::std::string* end_key) {
+  if (end_key != NULL) {
+    set_has_end_key();
+  } else {
+    clear_has_end_key();
+  }
+  end_key_.SetAllocatedNoArena(&::google::protobuf::internal::GetEmptyStringAlreadyInited(), end_key);
+  // @@protoc_insertion_point(field_set_allocated:cockroach.proto.KVRequestHeader.end_key)
+}
+
+// optional .cockroach.proto.Replica replica = 6;
+bool KVRequestHeader::has_replica() const {
+  return (_has_bits_[0] & 0x00000008u) != 0;
+}
+void KVRequestHeader::set_has_replica() {
+  _has_bits_[0] |= 0x00000008u;
+}
+void KVRequestHeader::clear_has_replica() {
+  _has_bits_[0] &= ~0x00000008u;
+}
+void KVRequestHeader::clear_replica() {
+  if (replica_ != NULL) replica_->::cockroach::proto::Replica::Clear();
+  clear_has_replica();
+}
+ const ::cockroach::proto::Replica& KVRequestHeader::replica() const {
+  // @@protoc_insertion_point(field_get:cockroach.proto.KVRequestHeader.replica)
+  return replica_ != NULL ? *replica_ : *default_instance_->replica_;
+}
+ ::cockroach::proto::Replica* KVRequestHeader::mutable_replica() {
+  set_has_replica();
+  if (replica_ == NULL) {
+    replica_ = new ::cockroach::proto::Replica;
+  }
+  // @@protoc_insertion_point(field_mutable:cockroach.proto.KVRequestHeader.replica)
+  return replica_;
+}
+ ::cockroach::proto::Replica* KVRequestHeader::release_replica() {
+  clear_has_replica();
+  ::cockroach::proto::Replica* temp = replica_;
+  replica_ = NULL;
+  return temp;
+}
+ void KVRequestHeader::set_allocated_replica(::cockroach::proto::Replica* replica) {
+  delete replica_;
+  replica_ = replica;
+  if (replica) {
+    set_has_replica();
+  } else {
+    clear_has_replica();
+  }
+  // @@protoc_insertion_point(field_set_allocated:cockroach.proto.KVRequestHeader.replica)
+}
+
+// optional int64 raft_id = 7;
+bool KVRequestHeader::has_raft_id() const {
+  return (_has_bits_[0] & 0x00000010u) != 0;
+}
+void KVRequestHeader::set_has_raft_id() {
+  _has_bits_[0] |= 0x00000010u;
+}
+void KVRequestHeader::clear_has_raft_id() {
+  _has_bits_[0] &= ~0x00000010u;
+}
+void KVRequestHeader::clear_raft_id() {
+  raft_id_ = GOOGLE_LONGLONG(0);
+  clear_has_raft_id();
+}
+ ::google::protobuf::int64 KVRequestHeader::raft_id() const {
+  // @@protoc_insertion_point(field_get:cockroach.proto.KVRequestHeader.raft_id)
+  return raft_id_;
+}
+ void KVRequestHeader::set_raft_id(::google::protobuf::int64 value) {
+  set_has_raft_id();
+  raft_id_ = value;
+  // @@protoc_insertion_point(field_set:cockroach.proto.KVRequestHeader.raft_id)
+}
+
+#endif  // PROTOBUF_INLINE_NOT_IN_HEADERS
+
+// ===================================================================
+
+#ifndef _MSC_VER
+const int KVResponseHeader::kHeaderFieldNumber;
+#endif  // !_MSC_VER
+
+KVResponseHeader::KVResponseHeader()
+  : ::google::protobuf::Message(), _internal_metadata_(NULL) {
+  SharedCtor();
+  // @@protoc_insertion_point(constructor:cockroach.proto.KVResponseHeader)
+}
+
+void KVResponseHeader::InitAsDefaultInstance() {
+  header_ = const_cast< ::cockroach::proto::ResponseHeader*>(&::cockroach::proto::ResponseHeader::default_instance());
+}
+
+KVResponseHeader::KVResponseHeader(const KVResponseHeader& from)
+  : ::google::protobuf::Message(),
+    _internal_metadata_(NULL) {
+  SharedCtor();
+  MergeFrom(from);
+  // @@protoc_insertion_point(copy_constructor:cockroach.proto.KVResponseHeader)
+}
+
+void KVResponseHeader::SharedCtor() {
+  _cached_size_ = 0;
+  header_ = NULL;
+  ::memset(_has_bits_, 0, sizeof(_has_bits_));
+}
+
+KVResponseHeader::~KVResponseHeader() {
+  // @@protoc_insertion_point(destructor:cockroach.proto.KVResponseHeader)
+  SharedDtor();
+}
+
+void KVResponseHeader::SharedDtor() {
+  if (this != default_instance_) {
+    delete header_;
+  }
+}
+
+void KVResponseHeader::SetCachedSize(int size) const {
+  GOOGLE_SAFE_CONCURRENT_WRITES_BEGIN();
+  _cached_size_ = size;
+  GOOGLE_SAFE_CONCURRENT_WRITES_END();
+}
+const ::google::protobuf::Descriptor* KVResponseHeader::descriptor() {
+  protobuf_AssignDescriptorsOnce();
+  return KVResponseHeader_descriptor_;
+}
+
+const KVResponseHeader& KVResponseHeader::default_instance() {
+  if (default_instance_ == NULL) protobuf_AddDesc_cockroach_2fproto_2fapi_2eproto();
+  return *default_instance_;
+}
+
+KVResponseHeader* KVResponseHeader::default_instance_ = NULL;
+
+KVResponseHeader* KVResponseHeader::New(::google::protobuf::Arena* arena) const {
+  KVResponseHeader* n = new KVResponseHeader;
+  if (arena != NULL) {
+    arena->Own(n);
+  }
+  return n;
+}
+
+void KVResponseHeader::Clear() {
+  if (has_header()) {
+    if (header_ != NULL) header_->::cockroach::proto::ResponseHeader::Clear();
+  }
+  ::memset(_has_bits_, 0, sizeof(_has_bits_));
+  if (_internal_metadata_.have_unknown_fields()) {
+    mutable_unknown_fields()->Clear();
+  }
+}
+
+bool KVResponseHeader::MergePartialFromCodedStream(
+    ::google::protobuf::io::CodedInputStream* input) {
+#define DO_(EXPRESSION) if (!(EXPRESSION)) goto failure
+  ::google::protobuf::uint32 tag;
+  // @@protoc_insertion_point(parse_start:cockroach.proto.KVResponseHeader)
+  for (;;) {
+    ::std::pair< ::google::protobuf::uint32, bool> p = input->ReadTagWithCutoff(127);
+    tag = p.first;
+    if (!p.second) goto handle_unusual;
+    switch (::google::protobuf::internal::WireFormatLite::GetTagFieldNumber(tag)) {
+      // optional .cockroach.proto.ResponseHeader header = 1;
+      case 1: {
+        if (tag == 10) {
+          DO_(::google::protobuf::internal::WireFormatLite::ReadMessageNoVirtual(
+               input, mutable_header()));
+        } else {
+          goto handle_unusual;
+        }
+        if (input->ExpectAtEnd()) goto success;
+        break;
+      }
+
+      default: {
+      handle_unusual:
+        if (tag == 0 ||
+            ::google::protobuf::internal::WireFormatLite::GetTagWireType(tag) ==
+            ::google::protobuf::internal::WireFormatLite::WIRETYPE_END_GROUP) {
+          goto success;
+        }
+        DO_(::google::protobuf::internal::WireFormat::SkipField(
+              input, tag, mutable_unknown_fields()));
+        break;
+      }
+    }
+  }
+success:
+  // @@protoc_insertion_point(parse_success:cockroach.proto.KVResponseHeader)
+  return true;
+failure:
+  // @@protoc_insertion_point(parse_failure:cockroach.proto.KVResponseHeader)
+  return false;
+#undef DO_
+}
+
+void KVResponseHeader::SerializeWithCachedSizes(
+    ::google::protobuf::io::CodedOutputStream* output) const {
+  // @@protoc_insertion_point(serialize_start:cockroach.proto.KVResponseHeader)
+  // optional .cockroach.proto.ResponseHeader header = 1;
+  if (has_header()) {
+    ::google::protobuf::internal::WireFormatLite::WriteMessageMaybeToArray(
+      1, *this->header_, output);
+  }
+
+  if (_internal_metadata_.have_unknown_fields()) {
+    ::google::protobuf::internal::WireFormat::SerializeUnknownFields(
+        unknown_fields(), output);
+  }
+  // @@protoc_insertion_point(serialize_end:cockroach.proto.KVResponseHeader)
+}
+
+::google::protobuf::uint8* KVResponseHeader::SerializeWithCachedSizesToArray(
+    ::google::protobuf::uint8* target) const {
+  // @@protoc_insertion_point(serialize_to_array_start:cockroach.proto.KVResponseHeader)
+  // optional .cockroach.proto.ResponseHeader header = 1;
+  if (has_header()) {
+    target = ::google::protobuf::internal::WireFormatLite::
+      WriteMessageNoVirtualToArray(
+        1, *this->header_, target);
+  }
+
+  if (_internal_metadata_.have_unknown_fields()) {
+    target = ::google::protobuf::internal::WireFormat::SerializeUnknownFieldsToArray(
+        unknown_fields(), target);
+  }
+  // @@protoc_insertion_point(serialize_to_array_end:cockroach.proto.KVResponseHeader)
+  return target;
+}
+
+int KVResponseHeader::ByteSize() const {
+  int total_size = 0;
+
+  // optional .cockroach.proto.ResponseHeader header = 1;
+  if (has_header()) {
+    total_size += 1 +
+      ::google::protobuf::internal::WireFormatLite::MessageSizeNoVirtual(
+        *this->header_);
+  }
+
+  if (_internal_metadata_.have_unknown_fields()) {
+    total_size +=
+      ::google::protobuf::internal::WireFormat::ComputeUnknownFieldsSize(
+        unknown_fields());
+  }
+  GOOGLE_SAFE_CONCURRENT_WRITES_BEGIN();
+  _cached_size_ = total_size;
+  GOOGLE_SAFE_CONCURRENT_WRITES_END();
+  return total_size;
+}
+
+void KVResponseHeader::MergeFrom(const ::google::protobuf::Message& from) {
+  if (GOOGLE_PREDICT_FALSE(&from == this)) MergeFromFail(__LINE__);
+  const KVResponseHeader* source = 
+      ::google::protobuf::internal::DynamicCastToGenerated<const KVResponseHeader>(
+          &from);
+  if (source == NULL) {
+    ::google::protobuf::internal::ReflectionOps::Merge(from, this);
+  } else {
+    MergeFrom(*source);
+  }
+}
+
+void KVResponseHeader::MergeFrom(const KVResponseHeader& from) {
+  if (GOOGLE_PREDICT_FALSE(&from == this)) MergeFromFail(__LINE__);
+  if (from._has_bits_[0 / 32] & (0xffu << (0 % 32))) {
+    if (from.has_header()) {
+      mutable_header()->::cockroach::proto::ResponseHeader::MergeFrom(from.header());
+    }
+  }
+  if (from._internal_metadata_.have_unknown_fields()) {
+    mutable_unknown_fields()->MergeFrom(from.unknown_fields());
+  }
+}
+
+void KVResponseHeader::CopyFrom(const ::google::protobuf::Message& from) {
+  if (&from == this) return;
+  Clear();
+  MergeFrom(from);
+}
+
+void KVResponseHeader::CopyFrom(const KVResponseHeader& from) {
+  if (&from == this) return;
+  Clear();
+  MergeFrom(from);
+}
+
+bool KVResponseHeader::IsInitialized() const {
+
+  return true;
+}
+
+void KVResponseHeader::Swap(KVResponseHeader* other) {
+  if (other == this) return;
+  InternalSwap(other);
+}
+void KVResponseHeader::InternalSwap(KVResponseHeader* other) {
+  std::swap(header_, other->header_);
+  std::swap(_has_bits_[0], other->_has_bits_[0]);
+  _internal_metadata_.Swap(&other->_internal_metadata_);
+  std::swap(_cached_size_, other->_cached_size_);
+}
+
+::google::protobuf::Metadata KVResponseHeader::GetMetadata() const {
+  protobuf_AssignDescriptorsOnce();
+  ::google::protobuf::Metadata metadata;
+  metadata.descriptor = KVResponseHeader_descriptor_;
+  metadata.reflection = KVResponseHeader_reflection_;
+  return metadata;
+}
+
+#if PROTOBUF_INLINE_NOT_IN_HEADERS
+// KVResponseHeader
+
+// optional .cockroach.proto.ResponseHeader header = 1;
+bool KVResponseHeader::has_header() const {
+  return (_has_bits_[0] & 0x00000001u) != 0;
+}
+void KVResponseHeader::set_has_header() {
+  _has_bits_[0] |= 0x00000001u;
+}
+void KVResponseHeader::clear_has_header() {
+  _has_bits_[0] &= ~0x00000001u;
+}
+void KVResponseHeader::clear_header() {
+  if (header_ != NULL) header_->::cockroach::proto::ResponseHeader::Clear();
+  clear_has_header();
+}
+ const ::cockroach::proto::ResponseHeader& KVResponseHeader::header() const {
+  // @@protoc_insertion_point(field_get:cockroach.proto.KVResponseHeader.header)
+  return header_ != NULL ? *header_ : *default_instance_->header_;
+}
+ ::cockroach::proto::ResponseHeader* KVResponseHeader::mutable_header() {
+  set_has_header();
+  if (header_ == NULL) {
+    header_ = new ::cockroach::proto::ResponseHeader;
+  }
+  // @@protoc_insertion_point(field_mutable:cockroach.proto.KVResponseHeader.header)
+  return header_;
+}
+ ::cockroach::proto::ResponseHeader* KVResponseHeader::release_header() {
+  clear_has_header();
+  ::cockroach::proto::ResponseHeader* temp = header_;
+  header_ = NULL;
+  return temp;
+}
+ void KVResponseHeader::set_allocated_header(::cockroach::proto::ResponseHeader* header) {
+  delete header_;
+  header_ = header;
+  if (header) {
+    set_has_header();
+  } else {
+    clear_has_header();
+  }
+  // @@protoc_insertion_point(field_set_allocated:cockroach.proto.KVResponseHeader.header)
+}
+
+#endif  // PROTOBUF_INLINE_NOT_IN_HEADERS
+
+// ===================================================================
+
+#ifndef _MSC_VER
+const int GetRequest::kKvheaderFieldNumber;
 #endif  // !_MSC_VER
 
 GetRequest::GetRequest()
@@ -2790,7 +3409,7 @@ GetRequest::GetRequest()
 }
 
 void GetRequest::InitAsDefaultInstance() {
-  header_ = const_cast< ::cockroach::proto::RequestHeader*>(&::cockroach::proto::RequestHeader::default_instance());
+  kvheader_ = const_cast< ::cockroach::proto::KVRequestHeader*>(&::cockroach::proto::KVRequestHeader::default_instance());
 }
 
 GetRequest::GetRequest(const GetRequest& from)
@@ -2803,7 +3422,7 @@ GetRequest::GetRequest(const GetRequest& from)
 
 void GetRequest::SharedCtor() {
   _cached_size_ = 0;
-  header_ = NULL;
+  kvheader_ = NULL;
   ::memset(_has_bits_, 0, sizeof(_has_bits_));
 }
 
@@ -2814,7 +3433,7 @@ GetRequest::~GetRequest() {
 
 void GetRequest::SharedDtor() {
   if (this != default_instance_) {
-    delete header_;
+    delete kvheader_;
   }
 }
 
@@ -2844,8 +3463,8 @@ GetRequest* GetRequest::New(::google::protobuf::Arena* arena) const {
 }
 
 void GetRequest::Clear() {
-  if (has_header()) {
-    if (header_ != NULL) header_->::cockroach::proto::RequestHeader::Clear();
+  if (has_kvheader()) {
+    if (kvheader_ != NULL) kvheader_->::cockroach::proto::KVRequestHeader::Clear();
   }
   ::memset(_has_bits_, 0, sizeof(_has_bits_));
   if (_internal_metadata_.have_unknown_fields()) {
@@ -2863,11 +3482,11 @@ bool GetRequest::MergePartialFromCodedStream(
     tag = p.first;
     if (!p.second) goto handle_unusual;
     switch (::google::protobuf::internal::WireFormatLite::GetTagFieldNumber(tag)) {
-      // optional .cockroach.proto.RequestHeader header = 1;
+      // optional .cockroach.proto.KVRequestHeader kvheader = 1;
       case 1: {
         if (tag == 10) {
           DO_(::google::protobuf::internal::WireFormatLite::ReadMessageNoVirtual(
-               input, mutable_header()));
+               input, mutable_kvheader()));
         } else {
           goto handle_unusual;
         }
@@ -2900,10 +3519,10 @@ failure:
 void GetRequest::SerializeWithCachedSizes(
     ::google::protobuf::io::CodedOutputStream* output) const {
   // @@protoc_insertion_point(serialize_start:cockroach.proto.GetRequest)
-  // optional .cockroach.proto.RequestHeader header = 1;
-  if (has_header()) {
+  // optional .cockroach.proto.KVRequestHeader kvheader = 1;
+  if (has_kvheader()) {
     ::google::protobuf::internal::WireFormatLite::WriteMessageMaybeToArray(
-      1, *this->header_, output);
+      1, *this->kvheader_, output);
   }
 
   if (_internal_metadata_.have_unknown_fields()) {
@@ -2916,11 +3535,11 @@ void GetRequest::SerializeWithCachedSizes(
 ::google::protobuf::uint8* GetRequest::SerializeWithCachedSizesToArray(
     ::google::protobuf::uint8* target) const {
   // @@protoc_insertion_point(serialize_to_array_start:cockroach.proto.GetRequest)
-  // optional .cockroach.proto.RequestHeader header = 1;
-  if (has_header()) {
+  // optional .cockroach.proto.KVRequestHeader kvheader = 1;
+  if (has_kvheader()) {
     target = ::google::protobuf::internal::WireFormatLite::
       WriteMessageNoVirtualToArray(
-        1, *this->header_, target);
+        1, *this->kvheader_, target);
   }
 
   if (_internal_metadata_.have_unknown_fields()) {
@@ -2934,11 +3553,11 @@ void GetRequest::SerializeWithCachedSizes(
 int GetRequest::ByteSize() const {
   int total_size = 0;
 
-  // optional .cockroach.proto.RequestHeader header = 1;
-  if (has_header()) {
+  // optional .cockroach.proto.KVRequestHeader kvheader = 1;
+  if (has_kvheader()) {
     total_size += 1 +
       ::google::protobuf::internal::WireFormatLite::MessageSizeNoVirtual(
-        *this->header_);
+        *this->kvheader_);
   }
 
   if (_internal_metadata_.have_unknown_fields()) {
@@ -2967,8 +3586,8 @@ void GetRequest::MergeFrom(const ::google::protobuf::Message& from) {
 void GetRequest::MergeFrom(const GetRequest& from) {
   if (GOOGLE_PREDICT_FALSE(&from == this)) MergeFromFail(__LINE__);
   if (from._has_bits_[0 / 32] & (0xffu << (0 % 32))) {
-    if (from.has_header()) {
-      mutable_header()->::cockroach::proto::RequestHeader::MergeFrom(from.header());
+    if (from.has_kvheader()) {
+      mutable_kvheader()->::cockroach::proto::KVRequestHeader::MergeFrom(from.kvheader());
     }
   }
   if (from._internal_metadata_.have_unknown_fields()) {
@@ -2998,7 +3617,7 @@ void GetRequest::Swap(GetRequest* other) {
   InternalSwap(other);
 }
 void GetRequest::InternalSwap(GetRequest* other) {
-  std::swap(header_, other->header_);
+  std::swap(kvheader_, other->kvheader_);
   std::swap(_has_bits_[0], other->_has_bits_[0]);
   _internal_metadata_.Swap(&other->_internal_metadata_);
   std::swap(_cached_size_, other->_cached_size_);
@@ -3015,47 +3634,47 @@ void GetRequest::InternalSwap(GetRequest* other) {
 #if PROTOBUF_INLINE_NOT_IN_HEADERS
 // GetRequest
 
-// optional .cockroach.proto.RequestHeader header = 1;
-bool GetRequest::has_header() const {
+// optional .cockroach.proto.KVRequestHeader kvheader = 1;
+bool GetRequest::has_kvheader() const {
   return (_has_bits_[0] & 0x00000001u) != 0;
 }
-void GetRequest::set_has_header() {
+void GetRequest::set_has_kvheader() {
   _has_bits_[0] |= 0x00000001u;
 }
-void GetRequest::clear_has_header() {
+void GetRequest::clear_has_kvheader() {
   _has_bits_[0] &= ~0x00000001u;
 }
-void GetRequest::clear_header() {
-  if (header_ != NULL) header_->::cockroach::proto::RequestHeader::Clear();
-  clear_has_header();
+void GetRequest::clear_kvheader() {
+  if (kvheader_ != NULL) kvheader_->::cockroach::proto::KVRequestHeader::Clear();
+  clear_has_kvheader();
 }
- const ::cockroach::proto::RequestHeader& GetRequest::header() const {
-  // @@protoc_insertion_point(field_get:cockroach.proto.GetRequest.header)
-  return header_ != NULL ? *header_ : *default_instance_->header_;
+ const ::cockroach::proto::KVRequestHeader& GetRequest::kvheader() const {
+  // @@protoc_insertion_point(field_get:cockroach.proto.GetRequest.kvheader)
+  return kvheader_ != NULL ? *kvheader_ : *default_instance_->kvheader_;
 }
- ::cockroach::proto::RequestHeader* GetRequest::mutable_header() {
-  set_has_header();
-  if (header_ == NULL) {
-    header_ = new ::cockroach::proto::RequestHeader;
+ ::cockroach::proto::KVRequestHeader* GetRequest::mutable_kvheader() {
+  set_has_kvheader();
+  if (kvheader_ == NULL) {
+    kvheader_ = new ::cockroach::proto::KVRequestHeader;
   }
-  // @@protoc_insertion_point(field_mutable:cockroach.proto.GetRequest.header)
-  return header_;
+  // @@protoc_insertion_point(field_mutable:cockroach.proto.GetRequest.kvheader)
+  return kvheader_;
 }
- ::cockroach::proto::RequestHeader* GetRequest::release_header() {
-  clear_has_header();
-  ::cockroach::proto::RequestHeader* temp = header_;
-  header_ = NULL;
+ ::cockroach::proto::KVRequestHeader* GetRequest::release_kvheader() {
+  clear_has_kvheader();
+  ::cockroach::proto::KVRequestHeader* temp = kvheader_;
+  kvheader_ = NULL;
   return temp;
 }
- void GetRequest::set_allocated_header(::cockroach::proto::RequestHeader* header) {
-  delete header_;
-  header_ = header;
-  if (header) {
-    set_has_header();
+ void GetRequest::set_allocated_kvheader(::cockroach::proto::KVRequestHeader* kvheader) {
+  delete kvheader_;
+  kvheader_ = kvheader;
+  if (kvheader) {
+    set_has_kvheader();
   } else {
-    clear_has_header();
+    clear_has_kvheader();
   }
-  // @@protoc_insertion_point(field_set_allocated:cockroach.proto.GetRequest.header)
+  // @@protoc_insertion_point(field_set_allocated:cockroach.proto.GetRequest.kvheader)
 }
 
 #endif  // PROTOBUF_INLINE_NOT_IN_HEADERS
@@ -3063,7 +3682,7 @@ void GetRequest::clear_header() {
 // ===================================================================
 
 #ifndef _MSC_VER
-const int GetResponse::kHeaderFieldNumber;
+const int GetResponse::kKvheaderFieldNumber;
 const int GetResponse::kValueFieldNumber;
 #endif  // !_MSC_VER
 
@@ -3074,7 +3693,7 @@ GetResponse::GetResponse()
 }
 
 void GetResponse::InitAsDefaultInstance() {
-  header_ = const_cast< ::cockroach::proto::ResponseHeader*>(&::cockroach::proto::ResponseHeader::default_instance());
+  kvheader_ = const_cast< ::cockroach::proto::KVResponseHeader*>(&::cockroach::proto::KVResponseHeader::default_instance());
   value_ = const_cast< ::cockroach::proto::Value*>(&::cockroach::proto::Value::default_instance());
 }
 
@@ -3088,7 +3707,7 @@ GetResponse::GetResponse(const GetResponse& from)
 
 void GetResponse::SharedCtor() {
   _cached_size_ = 0;
-  header_ = NULL;
+  kvheader_ = NULL;
   value_ = NULL;
   ::memset(_has_bits_, 0, sizeof(_has_bits_));
 }
@@ -3100,7 +3719,7 @@ GetResponse::~GetResponse() {
 
 void GetResponse::SharedDtor() {
   if (this != default_instance_) {
-    delete header_;
+    delete kvheader_;
     delete value_;
   }
 }
@@ -3132,8 +3751,8 @@ GetResponse* GetResponse::New(::google::protobuf::Arena* arena) const {
 
 void GetResponse::Clear() {
   if (_has_bits_[0 / 32] & 3u) {
-    if (has_header()) {
-      if (header_ != NULL) header_->::cockroach::proto::ResponseHeader::Clear();
+    if (has_kvheader()) {
+      if (kvheader_ != NULL) kvheader_->::cockroach::proto::KVResponseHeader::Clear();
     }
     if (has_value()) {
       if (value_ != NULL) value_->::cockroach::proto::Value::Clear();
@@ -3155,11 +3774,11 @@ bool GetResponse::MergePartialFromCodedStream(
     tag = p.first;
     if (!p.second) goto handle_unusual;
     switch (::google::protobuf::internal::WireFormatLite::GetTagFieldNumber(tag)) {
-      // optional .cockroach.proto.ResponseHeader header = 1;
+      // optional .cockroach.proto.KVResponseHeader kvheader = 1;
       case 1: {
         if (tag == 10) {
           DO_(::google::protobuf::internal::WireFormatLite::ReadMessageNoVirtual(
-               input, mutable_header()));
+               input, mutable_kvheader()));
         } else {
           goto handle_unusual;
         }
@@ -3205,10 +3824,10 @@ failure:
 void GetResponse::SerializeWithCachedSizes(
     ::google::protobuf::io::CodedOutputStream* output) const {
   // @@protoc_insertion_point(serialize_start:cockroach.proto.GetResponse)
-  // optional .cockroach.proto.ResponseHeader header = 1;
-  if (has_header()) {
+  // optional .cockroach.proto.KVResponseHeader kvheader = 1;
+  if (has_kvheader()) {
     ::google::protobuf::internal::WireFormatLite::WriteMessageMaybeToArray(
-      1, *this->header_, output);
+      1, *this->kvheader_, output);
   }
 
   // optional .cockroach.proto.Value value = 2;
@@ -3227,11 +3846,11 @@ void GetResponse::SerializeWithCachedSizes(
 ::google::protobuf::uint8* GetResponse::SerializeWithCachedSizesToArray(
     ::google::protobuf::uint8* target) const {
   // @@protoc_insertion_point(serialize_to_array_start:cockroach.proto.GetResponse)
-  // optional .cockroach.proto.ResponseHeader header = 1;
-  if (has_header()) {
+  // optional .cockroach.proto.KVResponseHeader kvheader = 1;
+  if (has_kvheader()) {
     target = ::google::protobuf::internal::WireFormatLite::
       WriteMessageNoVirtualToArray(
-        1, *this->header_, target);
+        1, *this->kvheader_, target);
   }
 
   // optional .cockroach.proto.Value value = 2;
@@ -3253,11 +3872,11 @@ int GetResponse::ByteSize() const {
   int total_size = 0;
 
   if (_has_bits_[0 / 32] & 3) {
-    // optional .cockroach.proto.ResponseHeader header = 1;
-    if (has_header()) {
+    // optional .cockroach.proto.KVResponseHeader kvheader = 1;
+    if (has_kvheader()) {
       total_size += 1 +
         ::google::protobuf::internal::WireFormatLite::MessageSizeNoVirtual(
-          *this->header_);
+          *this->kvheader_);
     }
 
     // optional .cockroach.proto.Value value = 2;
@@ -3294,8 +3913,8 @@ void GetResponse::MergeFrom(const ::google::protobuf::Message& from) {
 void GetResponse::MergeFrom(const GetResponse& from) {
   if (GOOGLE_PREDICT_FALSE(&from == this)) MergeFromFail(__LINE__);
   if (from._has_bits_[0 / 32] & (0xffu << (0 % 32))) {
-    if (from.has_header()) {
-      mutable_header()->::cockroach::proto::ResponseHeader::MergeFrom(from.header());
+    if (from.has_kvheader()) {
+      mutable_kvheader()->::cockroach::proto::KVResponseHeader::MergeFrom(from.kvheader());
     }
     if (from.has_value()) {
       mutable_value()->::cockroach::proto::Value::MergeFrom(from.value());
@@ -3328,7 +3947,7 @@ void GetResponse::Swap(GetResponse* other) {
   InternalSwap(other);
 }
 void GetResponse::InternalSwap(GetResponse* other) {
-  std::swap(header_, other->header_);
+  std::swap(kvheader_, other->kvheader_);
   std::swap(value_, other->value_);
   std::swap(_has_bits_[0], other->_has_bits_[0]);
   _internal_metadata_.Swap(&other->_internal_metadata_);
@@ -3346,47 +3965,47 @@ void GetResponse::InternalSwap(GetResponse* other) {
 #if PROTOBUF_INLINE_NOT_IN_HEADERS
 // GetResponse
 
-// optional .cockroach.proto.ResponseHeader header = 1;
-bool GetResponse::has_header() const {
+// optional .cockroach.proto.KVResponseHeader kvheader = 1;
+bool GetResponse::has_kvheader() const {
   return (_has_bits_[0] & 0x00000001u) != 0;
 }
-void GetResponse::set_has_header() {
+void GetResponse::set_has_kvheader() {
   _has_bits_[0] |= 0x00000001u;
 }
-void GetResponse::clear_has_header() {
+void GetResponse::clear_has_kvheader() {
   _has_bits_[0] &= ~0x00000001u;
 }
-void GetResponse::clear_header() {
-  if (header_ != NULL) header_->::cockroach::proto::ResponseHeader::Clear();
-  clear_has_header();
+void GetResponse::clear_kvheader() {
+  if (kvheader_ != NULL) kvheader_->::cockroach::proto::KVResponseHeader::Clear();
+  clear_has_kvheader();
 }
- const ::cockroach::proto::ResponseHeader& GetResponse::header() const {
-  // @@protoc_insertion_point(field_get:cockroach.proto.GetResponse.header)
-  return header_ != NULL ? *header_ : *default_instance_->header_;
+ const ::cockroach::proto::KVResponseHeader& GetResponse::kvheader() const {
+  // @@protoc_insertion_point(field_get:cockroach.proto.GetResponse.kvheader)
+  return kvheader_ != NULL ? *kvheader_ : *default_instance_->kvheader_;
 }
- ::cockroach::proto::ResponseHeader* GetResponse::mutable_header() {
-  set_has_header();
-  if (header_ == NULL) {
-    header_ = new ::cockroach::proto::ResponseHeader;
+ ::cockroach::proto::KVResponseHeader* GetResponse::mutable_kvheader() {
+  set_has_kvheader();
+  if (kvheader_ == NULL) {
+    kvheader_ = new ::cockroach::proto::KVResponseHeader;
   }
-  // @@protoc_insertion_point(field_mutable:cockroach.proto.GetResponse.header)
-  return header_;
+  // @@protoc_insertion_point(field_mutable:cockroach.proto.GetResponse.kvheader)
+  return kvheader_;
 }
- ::cockroach::proto::ResponseHeader* GetResponse::release_header() {
-  clear_has_header();
-  ::cockroach::proto::ResponseHeader* temp = header_;
-  header_ = NULL;
+ ::cockroach::proto::KVResponseHeader* GetResponse::release_kvheader() {
+  clear_has_kvheader();
+  ::cockroach::proto::KVResponseHeader* temp = kvheader_;
+  kvheader_ = NULL;
   return temp;
 }
- void GetResponse::set_allocated_header(::cockroach::proto::ResponseHeader* header) {
-  delete header_;
-  header_ = header;
-  if (header) {
-    set_has_header();
+ void GetResponse::set_allocated_kvheader(::cockroach::proto::KVResponseHeader* kvheader) {
+  delete kvheader_;
+  kvheader_ = kvheader;
+  if (kvheader) {
+    set_has_kvheader();
   } else {
-    clear_has_header();
+    clear_has_kvheader();
   }
-  // @@protoc_insertion_point(field_set_allocated:cockroach.proto.GetResponse.header)
+  // @@protoc_insertion_point(field_set_allocated:cockroach.proto.GetResponse.kvheader)
 }
 
 // optional .cockroach.proto.Value value = 2;
@@ -3437,7 +4056,7 @@ void GetResponse::clear_value() {
 // ===================================================================
 
 #ifndef _MSC_VER
-const int PutRequest::kHeaderFieldNumber;
+const int PutRequest::kKvheaderFieldNumber;
 const int PutRequest::kValueFieldNumber;
 #endif  // !_MSC_VER
 
@@ -3448,7 +4067,7 @@ PutRequest::PutRequest()
 }
 
 void PutRequest::InitAsDefaultInstance() {
-  header_ = const_cast< ::cockroach::proto::RequestHeader*>(&::cockroach::proto::RequestHeader::default_instance());
+  kvheader_ = const_cast< ::cockroach::proto::KVRequestHeader*>(&::cockroach::proto::KVRequestHeader::default_instance());
   value_ = const_cast< ::cockroach::proto::Value*>(&::cockroach::proto::Value::default_instance());
 }
 
@@ -3462,7 +4081,7 @@ PutRequest::PutRequest(const PutRequest& from)
 
 void PutRequest::SharedCtor() {
   _cached_size_ = 0;
-  header_ = NULL;
+  kvheader_ = NULL;
   value_ = NULL;
   ::memset(_has_bits_, 0, sizeof(_has_bits_));
 }
@@ -3474,7 +4093,7 @@ PutRequest::~PutRequest() {
 
 void PutRequest::SharedDtor() {
   if (this != default_instance_) {
-    delete header_;
+    delete kvheader_;
     delete value_;
   }
 }
@@ -3506,8 +4125,8 @@ PutRequest* PutRequest::New(::google::protobuf::Arena* arena) const {
 
 void PutRequest::Clear() {
   if (_has_bits_[0 / 32] & 3u) {
-    if (has_header()) {
-      if (header_ != NULL) header_->::cockroach::proto::RequestHeader::Clear();
+    if (has_kvheader()) {
+      if (kvheader_ != NULL) kvheader_->::cockroach::proto::KVRequestHeader::Clear();
     }
     if (has_value()) {
       if (value_ != NULL) value_->::cockroach::proto::Value::Clear();
@@ -3529,11 +4148,11 @@ bool PutRequest::MergePartialFromCodedStream(
     tag = p.first;
     if (!p.second) goto handle_unusual;
     switch (::google::protobuf::internal::WireFormatLite::GetTagFieldNumber(tag)) {
-      // optional .cockroach.proto.RequestHeader header = 1;
+      // optional .cockroach.proto.KVRequestHeader kvheader = 1;
       case 1: {
         if (tag == 10) {
           DO_(::google::protobuf::internal::WireFormatLite::ReadMessageNoVirtual(
-               input, mutable_header()));
+               input, mutable_kvheader()));
         } else {
           goto handle_unusual;
         }
@@ -3579,10 +4198,10 @@ failure:
 void PutRequest::SerializeWithCachedSizes(
     ::google::protobuf::io::CodedOutputStream* output) const {
   // @@protoc_insertion_point(serialize_start:cockroach.proto.PutRequest)
-  // optional .cockroach.proto.RequestHeader header = 1;
-  if (has_header()) {
+  // optional .cockroach.proto.KVRequestHeader kvheader = 1;
+  if (has_kvheader()) {
     ::google::protobuf::internal::WireFormatLite::WriteMessageMaybeToArray(
-      1, *this->header_, output);
+      1, *this->kvheader_, output);
   }
 
   // optional .cockroach.proto.Value value = 2;
@@ -3601,11 +4220,11 @@ void PutRequest::SerializeWithCachedSizes(
 ::google::protobuf::uint8* PutRequest::SerializeWithCachedSizesToArray(
     ::google::protobuf::uint8* target) const {
   // @@protoc_insertion_point(serialize_to_array_start:cockroach.proto.PutRequest)
-  // optional .cockroach.proto.RequestHeader header = 1;
-  if (has_header()) {
+  // optional .cockroach.proto.KVRequestHeader kvheader = 1;
+  if (has_kvheader()) {
     target = ::google::protobuf::internal::WireFormatLite::
       WriteMessageNoVirtualToArray(
-        1, *this->header_, target);
+        1, *this->kvheader_, target);
   }
 
   // optional .cockroach.proto.Value value = 2;
@@ -3627,11 +4246,11 @@ int PutRequest::ByteSize() const {
   int total_size = 0;
 
   if (_has_bits_[0 / 32] & 3) {
-    // optional .cockroach.proto.RequestHeader header = 1;
-    if (has_header()) {
+    // optional .cockroach.proto.KVRequestHeader kvheader = 1;
+    if (has_kvheader()) {
       total_size += 1 +
         ::google::protobuf::internal::WireFormatLite::MessageSizeNoVirtual(
-          *this->header_);
+          *this->kvheader_);
     }
 
     // optional .cockroach.proto.Value value = 2;
@@ -3668,8 +4287,8 @@ void PutRequest::MergeFrom(const ::google::protobuf::Message& from) {
 void PutRequest::MergeFrom(const PutRequest& from) {
   if (GOOGLE_PREDICT_FALSE(&from == this)) MergeFromFail(__LINE__);
   if (from._has_bits_[0 / 32] & (0xffu << (0 % 32))) {
-    if (from.has_header()) {
-      mutable_header()->::cockroach::proto::RequestHeader::MergeFrom(from.header());
+    if (from.has_kvheader()) {
+      mutable_kvheader()->::cockroach::proto::KVRequestHeader::MergeFrom(from.kvheader());
     }
     if (from.has_value()) {
       mutable_value()->::cockroach::proto::Value::MergeFrom(from.value());
@@ -3702,7 +4321,7 @@ void PutRequest::Swap(PutRequest* other) {
   InternalSwap(other);
 }
 void PutRequest::InternalSwap(PutRequest* other) {
-  std::swap(header_, other->header_);
+  std::swap(kvheader_, other->kvheader_);
   std::swap(value_, other->value_);
   std::swap(_has_bits_[0], other->_has_bits_[0]);
   _internal_metadata_.Swap(&other->_internal_metadata_);
@@ -3720,47 +4339,47 @@ void PutRequest::InternalSwap(PutRequest* other) {
 #if PROTOBUF_INLINE_NOT_IN_HEADERS
 // PutRequest
 
-// optional .cockroach.proto.RequestHeader header = 1;
-bool PutRequest::has_header() const {
+// optional .cockroach.proto.KVRequestHeader kvheader = 1;
+bool PutRequest::has_kvheader() const {
   return (_has_bits_[0] & 0x00000001u) != 0;
 }
-void PutRequest::set_has_header() {
+void PutRequest::set_has_kvheader() {
   _has_bits_[0] |= 0x00000001u;
 }
-void PutRequest::clear_has_header() {
+void PutRequest::clear_has_kvheader() {
   _has_bits_[0] &= ~0x00000001u;
 }
-void PutRequest::clear_header() {
-  if (header_ != NULL) header_->::cockroach::proto::RequestHeader::Clear();
-  clear_has_header();
+void PutRequest::clear_kvheader() {
+  if (kvheader_ != NULL) kvheader_->::cockroach::proto::KVRequestHeader::Clear();
+  clear_has_kvheader();
 }
- const ::cockroach::proto::RequestHeader& PutRequest::header() const {
-  // @@protoc_insertion_point(field_get:cockroach.proto.PutRequest.header)
-  return header_ != NULL ? *header_ : *default_instance_->header_;
+ const ::cockroach::proto::KVRequestHeader& PutRequest::kvheader() const {
+  // @@protoc_insertion_point(field_get:cockroach.proto.PutRequest.kvheader)
+  return kvheader_ != NULL ? *kvheader_ : *default_instance_->kvheader_;
 }
- ::cockroach::proto::RequestHeader* PutRequest::mutable_header() {
-  set_has_header();
-  if (header_ == NULL) {
-    header_ = new ::cockroach::proto::RequestHeader;
+ ::cockroach::proto::KVRequestHeader* PutRequest::mutable_kvheader() {
+  set_has_kvheader();
+  if (kvheader_ == NULL) {
+    kvheader_ = new ::cockroach::proto::KVRequestHeader;
   }
-  // @@protoc_insertion_point(field_mutable:cockroach.proto.PutRequest.header)
-  return header_;
+  // @@protoc_insertion_point(field_mutable:cockroach.proto.PutRequest.kvheader)
+  return kvheader_;
 }
- ::cockroach::proto::RequestHeader* PutRequest::release_header() {
-  clear_has_header();
-  ::cockroach::proto::RequestHeader* temp = header_;
-  header_ = NULL;
+ ::cockroach::proto::KVRequestHeader* PutRequest::release_kvheader() {
+  clear_has_kvheader();
+  ::cockroach::proto::KVRequestHeader* temp = kvheader_;
+  kvheader_ = NULL;
   return temp;
 }
- void PutRequest::set_allocated_header(::cockroach::proto::RequestHeader* header) {
-  delete header_;
-  header_ = header;
-  if (header) {
-    set_has_header();
+ void PutRequest::set_allocated_kvheader(::cockroach::proto::KVRequestHeader* kvheader) {
+  delete kvheader_;
+  kvheader_ = kvheader;
+  if (kvheader) {
+    set_has_kvheader();
   } else {
-    clear_has_header();
+    clear_has_kvheader();
   }
-  // @@protoc_insertion_point(field_set_allocated:cockroach.proto.PutRequest.header)
+  // @@protoc_insertion_point(field_set_allocated:cockroach.proto.PutRequest.kvheader)
 }
 
 // optional .cockroach.proto.Value value = 2;
@@ -3811,7 +4430,7 @@ void PutRequest::clear_value() {
 // ===================================================================
 
 #ifndef _MSC_VER
-const int PutResponse::kHeaderFieldNumber;
+const int PutResponse::kKvheaderFieldNumber;
 #endif  // !_MSC_VER
 
 PutResponse::PutResponse()
@@ -3821,7 +4440,7 @@ PutResponse::PutResponse()
 }
 
 void PutResponse::InitAsDefaultInstance() {
-  header_ = const_cast< ::cockroach::proto::ResponseHeader*>(&::cockroach::proto::ResponseHeader::default_instance());
+  kvheader_ = const_cast< ::cockroach::proto::KVResponseHeader*>(&::cockroach::proto::KVResponseHeader::default_instance());
 }
 
 PutResponse::PutResponse(const PutResponse& from)
@@ -3834,7 +4453,7 @@ PutResponse::PutResponse(const PutResponse& from)
 
 void PutResponse::SharedCtor() {
   _cached_size_ = 0;
-  header_ = NULL;
+  kvheader_ = NULL;
   ::memset(_has_bits_, 0, sizeof(_has_bits_));
 }
 
@@ -3845,7 +4464,7 @@ PutResponse::~PutResponse() {
 
 void PutResponse::SharedDtor() {
   if (this != default_instance_) {
-    delete header_;
+    delete kvheader_;
   }
 }
 
@@ -3875,8 +4494,8 @@ PutResponse* PutResponse::New(::google::protobuf::Arena* arena) const {
 }
 
 void PutResponse::Clear() {
-  if (has_header()) {
-    if (header_ != NULL) header_->::cockroach::proto::ResponseHeader::Clear();
+  if (has_kvheader()) {
+    if (kvheader_ != NULL) kvheader_->::cockroach::proto::KVResponseHeader::Clear();
   }
   ::memset(_has_bits_, 0, sizeof(_has_bits_));
   if (_internal_metadata_.have_unknown_fields()) {
@@ -3894,11 +4513,11 @@ bool PutResponse::MergePartialFromCodedStream(
     tag = p.first;
     if (!p.second) goto handle_unusual;
     switch (::google::protobuf::internal::WireFormatLite::GetTagFieldNumber(tag)) {
-      // optional .cockroach.proto.ResponseHeader header = 1;
+      // optional .cockroach.proto.KVResponseHeader kvheader = 1;
       case 1: {
         if (tag == 10) {
           DO_(::google::protobuf::internal::WireFormatLite::ReadMessageNoVirtual(
-               input, mutable_header()));
+               input, mutable_kvheader()));
         } else {
           goto handle_unusual;
         }
@@ -3931,10 +4550,10 @@ failure:
 void PutResponse::SerializeWithCachedSizes(
     ::google::protobuf::io::CodedOutputStream* output) const {
   // @@protoc_insertion_point(serialize_start:cockroach.proto.PutResponse)
-  // optional .cockroach.proto.ResponseHeader header = 1;
-  if (has_header()) {
+  // optional .cockroach.proto.KVResponseHeader kvheader = 1;
+  if (has_kvheader()) {
     ::google::protobuf::internal::WireFormatLite::WriteMessageMaybeToArray(
-      1, *this->header_, output);
+      1, *this->kvheader_, output);
   }
 
   if (_internal_metadata_.have_unknown_fields()) {
@@ -3947,11 +4566,11 @@ void PutResponse::SerializeWithCachedSizes(
 ::google::protobuf::uint8* PutResponse::SerializeWithCachedSizesToArray(
     ::google::protobuf::uint8* target) const {
   // @@protoc_insertion_point(serialize_to_array_start:cockroach.proto.PutResponse)
-  // optional .cockroach.proto.ResponseHeader header = 1;
-  if (has_header()) {
+  // optional .cockroach.proto.KVResponseHeader kvheader = 1;
+  if (has_kvheader()) {
     target = ::google::protobuf::internal::WireFormatLite::
       WriteMessageNoVirtualToArray(
-        1, *this->header_, target);
+        1, *this->kvheader_, target);
   }
 
   if (_internal_metadata_.have_unknown_fields()) {
@@ -3965,11 +4584,11 @@ void PutResponse::SerializeWithCachedSizes(
 int PutResponse::ByteSize() const {
   int total_size = 0;
 
-  // optional .cockroach.proto.ResponseHeader header = 1;
-  if (has_header()) {
+  // optional .cockroach.proto.KVResponseHeader kvheader = 1;
+  if (has_kvheader()) {
     total_size += 1 +
       ::google::protobuf::internal::WireFormatLite::MessageSizeNoVirtual(
-        *this->header_);
+        *this->kvheader_);
   }
 
   if (_internal_metadata_.have_unknown_fields()) {
@@ -3998,8 +4617,8 @@ void PutResponse::MergeFrom(const ::google::protobuf::Message& from) {
 void PutResponse::MergeFrom(const PutResponse& from) {
   if (GOOGLE_PREDICT_FALSE(&from == this)) MergeFromFail(__LINE__);
   if (from._has_bits_[0 / 32] & (0xffu << (0 % 32))) {
-    if (from.has_header()) {
-      mutable_header()->::cockroach::proto::ResponseHeader::MergeFrom(from.header());
+    if (from.has_kvheader()) {
+      mutable_kvheader()->::cockroach::proto::KVResponseHeader::MergeFrom(from.kvheader());
     }
   }
   if (from._internal_metadata_.have_unknown_fields()) {
@@ -4029,7 +4648,7 @@ void PutResponse::Swap(PutResponse* other) {
   InternalSwap(other);
 }
 void PutResponse::InternalSwap(PutResponse* other) {
-  std::swap(header_, other->header_);
+  std::swap(kvheader_, other->kvheader_);
   std::swap(_has_bits_[0], other->_has_bits_[0]);
   _internal_metadata_.Swap(&other->_internal_metadata_);
   std::swap(_cached_size_, other->_cached_size_);
@@ -4046,47 +4665,47 @@ void PutResponse::InternalSwap(PutResponse* other) {
 #if PROTOBUF_INLINE_NOT_IN_HEADERS
 // PutResponse
 
-// optional .cockroach.proto.ResponseHeader header = 1;
-bool PutResponse::has_header() const {
+// optional .cockroach.proto.KVResponseHeader kvheader = 1;
+bool PutResponse::has_kvheader() const {
   return (_has_bits_[0] & 0x00000001u) != 0;
 }
-void PutResponse::set_has_header() {
+void PutResponse::set_has_kvheader() {
   _has_bits_[0] |= 0x00000001u;
 }
-void PutResponse::clear_has_header() {
+void PutResponse::clear_has_kvheader() {
   _has_bits_[0] &= ~0x00000001u;
 }
-void PutResponse::clear_header() {
-  if (header_ != NULL) header_->::cockroach::proto::ResponseHeader::Clear();
-  clear_has_header();
+void PutResponse::clear_kvheader() {
+  if (kvheader_ != NULL) kvheader_->::cockroach::proto::KVResponseHeader::Clear();
+  clear_has_kvheader();
 }
- const ::cockroach::proto::ResponseHeader& PutResponse::header() const {
-  // @@protoc_insertion_point(field_get:cockroach.proto.PutResponse.header)
-  return header_ != NULL ? *header_ : *default_instance_->header_;
+ const ::cockroach::proto::KVResponseHeader& PutResponse::kvheader() const {
+  // @@protoc_insertion_point(field_get:cockroach.proto.PutResponse.kvheader)
+  return kvheader_ != NULL ? *kvheader_ : *default_instance_->kvheader_;
 }
- ::cockroach::proto::ResponseHeader* PutResponse::mutable_header() {
-  set_has_header();
-  if (header_ == NULL) {
-    header_ = new ::cockroach::proto::ResponseHeader;
+ ::cockroach::proto::KVResponseHeader* PutResponse::mutable_kvheader() {
+  set_has_kvheader();
+  if (kvheader_ == NULL) {
+    kvheader_ = new ::cockroach::proto::KVResponseHeader;
   }
-  // @@protoc_insertion_point(field_mutable:cockroach.proto.PutResponse.header)
-  return header_;
+  // @@protoc_insertion_point(field_mutable:cockroach.proto.PutResponse.kvheader)
+  return kvheader_;
 }
- ::cockroach::proto::ResponseHeader* PutResponse::release_header() {
-  clear_has_header();
-  ::cockroach::proto::ResponseHeader* temp = header_;
-  header_ = NULL;
+ ::cockroach::proto::KVResponseHeader* PutResponse::release_kvheader() {
+  clear_has_kvheader();
+  ::cockroach::proto::KVResponseHeader* temp = kvheader_;
+  kvheader_ = NULL;
   return temp;
 }
- void PutResponse::set_allocated_header(::cockroach::proto::ResponseHeader* header) {
-  delete header_;
-  header_ = header;
-  if (header) {
-    set_has_header();
+ void PutResponse::set_allocated_kvheader(::cockroach::proto::KVResponseHeader* kvheader) {
+  delete kvheader_;
+  kvheader_ = kvheader;
+  if (kvheader) {
+    set_has_kvheader();
   } else {
-    clear_has_header();
+    clear_has_kvheader();
   }
-  // @@protoc_insertion_point(field_set_allocated:cockroach.proto.PutResponse.header)
+  // @@protoc_insertion_point(field_set_allocated:cockroach.proto.PutResponse.kvheader)
 }
 
 #endif  // PROTOBUF_INLINE_NOT_IN_HEADERS
@@ -4094,7 +4713,7 @@ void PutResponse::clear_header() {
 // ===================================================================
 
 #ifndef _MSC_VER
-const int ConditionalPutRequest::kHeaderFieldNumber;
+const int ConditionalPutRequest::kKvheaderFieldNumber;
 const int ConditionalPutRequest::kValueFieldNumber;
 const int ConditionalPutRequest::kExpValueFieldNumber;
 #endif  // !_MSC_VER
@@ -4106,7 +4725,7 @@ ConditionalPutRequest::ConditionalPutRequest()
 }
 
 void ConditionalPutRequest::InitAsDefaultInstance() {
-  header_ = const_cast< ::cockroach::proto::RequestHeader*>(&::cockroach::proto::RequestHeader::default_instance());
+  kvheader_ = const_cast< ::cockroach::proto::KVRequestHeader*>(&::cockroach::proto::KVRequestHeader::default_instance());
   value_ = const_cast< ::cockroach::proto::Value*>(&::cockroach::proto::Value::default_instance());
   exp_value_ = const_cast< ::cockroach::proto::Value*>(&::cockroach::proto::Value::default_instance());
 }
@@ -4121,7 +4740,7 @@ ConditionalPutRequest::ConditionalPutRequest(const ConditionalPutRequest& from)
 
 void ConditionalPutRequest::SharedCtor() {
   _cached_size_ = 0;
-  header_ = NULL;
+  kvheader_ = NULL;
   value_ = NULL;
   exp_value_ = NULL;
   ::memset(_has_bits_, 0, sizeof(_has_bits_));
@@ -4134,7 +4753,7 @@ ConditionalPutRequest::~ConditionalPutRequest() {
 
 void ConditionalPutRequest::SharedDtor() {
   if (this != default_instance_) {
-    delete header_;
+    delete kvheader_;
     delete value_;
     delete exp_value_;
   }
@@ -4167,8 +4786,8 @@ ConditionalPutRequest* ConditionalPutRequest::New(::google::protobuf::Arena* are
 
 void ConditionalPutRequest::Clear() {
   if (_has_bits_[0 / 32] & 7u) {
-    if (has_header()) {
-      if (header_ != NULL) header_->::cockroach::proto::RequestHeader::Clear();
+    if (has_kvheader()) {
+      if (kvheader_ != NULL) kvheader_->::cockroach::proto::KVRequestHeader::Clear();
     }
     if (has_value()) {
       if (value_ != NULL) value_->::cockroach::proto::Value::Clear();
@@ -4193,11 +4812,11 @@ bool ConditionalPutRequest::MergePartialFromCodedStream(
     tag = p.first;
     if (!p.second) goto handle_unusual;
     switch (::google::protobuf::internal::WireFormatLite::GetTagFieldNumber(tag)) {
-      // optional .cockroach.proto.RequestHeader header = 1;
+      // optional .cockroach.proto.KVRequestHeader kvheader = 1;
       case 1: {
         if (tag == 10) {
           DO_(::google::protobuf::internal::WireFormatLite::ReadMessageNoVirtual(
-               input, mutable_header()));
+               input, mutable_kvheader()));
         } else {
           goto handle_unusual;
         }
@@ -4256,10 +4875,10 @@ failure:
 void ConditionalPutRequest::SerializeWithCachedSizes(
     ::google::protobuf::io::CodedOutputStream* output) const {
   // @@protoc_insertion_point(serialize_start:cockroach.proto.ConditionalPutRequest)
-  // optional .cockroach.proto.RequestHeader header = 1;
-  if (has_header()) {
+  // optional .cockroach.proto.KVRequestHeader kvheader = 1;
+  if (has_kvheader()) {
     ::google::protobuf::internal::WireFormatLite::WriteMessageMaybeToArray(
-      1, *this->header_, output);
+      1, *this->kvheader_, output);
   }
 
   // optional .cockroach.proto.Value value = 2;
@@ -4284,11 +4903,11 @@ void ConditionalPutRequest::SerializeWithCachedSizes(
 ::google::protobuf::uint8* ConditionalPutRequest::SerializeWithCachedSizesToArray(
     ::google::protobuf::uint8* target) const {
   // @@protoc_insertion_point(serialize_to_array_start:cockroach.proto.ConditionalPutRequest)
-  // optional .cockroach.proto.RequestHeader header = 1;
-  if (has_header()) {
+  // optional .cockroach.proto.KVRequestHeader kvheader = 1;
+  if (has_kvheader()) {
     target = ::google::protobuf::internal::WireFormatLite::
       WriteMessageNoVirtualToArray(
-        1, *this->header_, target);
+        1, *this->kvheader_, target);
   }
 
   // optional .cockroach.proto.Value value = 2;
@@ -4317,11 +4936,11 @@ int ConditionalPutRequest::ByteSize() const {
   int total_size = 0;
 
   if (_has_bits_[0 / 32] & 7) {
-    // optional .cockroach.proto.RequestHeader header = 1;
-    if (has_header()) {
+    // optional .cockroach.proto.KVRequestHeader kvheader = 1;
+    if (has_kvheader()) {
       total_size += 1 +
         ::google::protobuf::internal::WireFormatLite::MessageSizeNoVirtual(
-          *this->header_);
+          *this->kvheader_);
     }
 
     // optional .cockroach.proto.Value value = 2;
@@ -4365,8 +4984,8 @@ void ConditionalPutRequest::MergeFrom(const ::google::protobuf::Message& from) {
 void ConditionalPutRequest::MergeFrom(const ConditionalPutRequest& from) {
   if (GOOGLE_PREDICT_FALSE(&from == this)) MergeFromFail(__LINE__);
   if (from._has_bits_[0 / 32] & (0xffu << (0 % 32))) {
-    if (from.has_header()) {
-      mutable_header()->::cockroach::proto::RequestHeader::MergeFrom(from.header());
+    if (from.has_kvheader()) {
+      mutable_kvheader()->::cockroach::proto::KVRequestHeader::MergeFrom(from.kvheader());
     }
     if (from.has_value()) {
       mutable_value()->::cockroach::proto::Value::MergeFrom(from.value());
@@ -4402,7 +5021,7 @@ void ConditionalPutRequest::Swap(ConditionalPutRequest* other) {
   InternalSwap(other);
 }
 void ConditionalPutRequest::InternalSwap(ConditionalPutRequest* other) {
-  std::swap(header_, other->header_);
+  std::swap(kvheader_, other->kvheader_);
   std::swap(value_, other->value_);
   std::swap(exp_value_, other->exp_value_);
   std::swap(_has_bits_[0], other->_has_bits_[0]);
@@ -4421,47 +5040,47 @@ void ConditionalPutRequest::InternalSwap(ConditionalPutRequest* other) {
 #if PROTOBUF_INLINE_NOT_IN_HEADERS
 // ConditionalPutRequest
 
-// optional .cockroach.proto.RequestHeader header = 1;
-bool ConditionalPutRequest::has_header() const {
+// optional .cockroach.proto.KVRequestHeader kvheader = 1;
+bool ConditionalPutRequest::has_kvheader() const {
   return (_has_bits_[0] & 0x00000001u) != 0;
 }
-void ConditionalPutRequest::set_has_header() {
+void ConditionalPutRequest::set_has_kvheader() {
   _has_bits_[0] |= 0x00000001u;
 }
-void ConditionalPutRequest::clear_has_header() {
+void ConditionalPutRequest::clear_has_kvheader() {
   _has_bits_[0] &= ~0x00000001u;
 }
-void ConditionalPutRequest::clear_header() {
-  if (header_ != NULL) header_->::cockroach::proto::RequestHeader::Clear();
-  clear_has_header();
+void ConditionalPutRequest::clear_kvheader() {
+  if (kvheader_ != NULL) kvheader_->::cockroach::proto::KVRequestHeader::Clear();
+  clear_has_kvheader();
 }
- const ::cockroach::proto::RequestHeader& ConditionalPutRequest::header() const {
-  // @@protoc_insertion_point(field_get:cockroach.proto.ConditionalPutRequest.header)
-  return header_ != NULL ? *header_ : *default_instance_->header_;
+ const ::cockroach::proto::KVRequestHeader& ConditionalPutRequest::kvheader() const {
+  // @@protoc_insertion_point(field_get:cockroach.proto.ConditionalPutRequest.kvheader)
+  return kvheader_ != NULL ? *kvheader_ : *default_instance_->kvheader_;
 }
- ::cockroach::proto::RequestHeader* ConditionalPutRequest::mutable_header() {
-  set_has_header();
-  if (header_ == NULL) {
-    header_ = new ::cockroach::proto::RequestHeader;
+ ::cockroach::proto::KVRequestHeader* ConditionalPutRequest::mutable_kvheader() {
+  set_has_kvheader();
+  if (kvheader_ == NULL) {
+    kvheader_ = new ::cockroach::proto::KVRequestHeader;
   }
-  // @@protoc_insertion_point(field_mutable:cockroach.proto.ConditionalPutRequest.header)
-  return header_;
+  // @@protoc_insertion_point(field_mutable:cockroach.proto.ConditionalPutRequest.kvheader)
+  return kvheader_;
 }
- ::cockroach::proto::RequestHeader* ConditionalPutRequest::release_header() {
-  clear_has_header();
-  ::cockroach::proto::RequestHeader* temp = header_;
-  header_ = NULL;
+ ::cockroach::proto::KVRequestHeader* ConditionalPutRequest::release_kvheader() {
+  clear_has_kvheader();
+  ::cockroach::proto::KVRequestHeader* temp = kvheader_;
+  kvheader_ = NULL;
   return temp;
 }
- void ConditionalPutRequest::set_allocated_header(::cockroach::proto::RequestHeader* header) {
-  delete header_;
-  header_ = header;
-  if (header) {
-    set_has_header();
+ void ConditionalPutRequest::set_allocated_kvheader(::cockroach::proto::KVRequestHeader* kvheader) {
+  delete kvheader_;
+  kvheader_ = kvheader;
+  if (kvheader) {
+    set_has_kvheader();
   } else {
-    clear_has_header();
+    clear_has_kvheader();
   }
-  // @@protoc_insertion_point(field_set_allocated:cockroach.proto.ConditionalPutRequest.header)
+  // @@protoc_insertion_point(field_set_allocated:cockroach.proto.ConditionalPutRequest.kvheader)
 }
 
 // optional .cockroach.proto.Value value = 2;
@@ -4555,7 +5174,7 @@ void ConditionalPutRequest::clear_exp_value() {
 // ===================================================================
 
 #ifndef _MSC_VER
-const int ConditionalPutResponse::kHeaderFieldNumber;
+const int ConditionalPutResponse::kKvheaderFieldNumber;
 #endif  // !_MSC_VER
 
 ConditionalPutResponse::ConditionalPutResponse()
@@ -4565,7 +5184,7 @@ ConditionalPutResponse::ConditionalPutResponse()
 }
 
 void ConditionalPutResponse::InitAsDefaultInstance() {
-  header_ = const_cast< ::cockroach::proto::ResponseHeader*>(&::cockroach::proto::ResponseHeader::default_instance());
+  kvheader_ = const_cast< ::cockroach::proto::KVResponseHeader*>(&::cockroach::proto::KVResponseHeader::default_instance());
 }
 
 ConditionalPutResponse::ConditionalPutResponse(const ConditionalPutResponse& from)
@@ -4578,7 +5197,7 @@ ConditionalPutResponse::ConditionalPutResponse(const ConditionalPutResponse& fro
 
 void ConditionalPutResponse::SharedCtor() {
   _cached_size_ = 0;
-  header_ = NULL;
+  kvheader_ = NULL;
   ::memset(_has_bits_, 0, sizeof(_has_bits_));
 }
 
@@ -4589,7 +5208,7 @@ ConditionalPutResponse::~ConditionalPutResponse() {
 
 void ConditionalPutResponse::SharedDtor() {
   if (this != default_instance_) {
-    delete header_;
+    delete kvheader_;
   }
 }
 
@@ -4619,8 +5238,8 @@ ConditionalPutResponse* ConditionalPutResponse::New(::google::protobuf::Arena* a
 }
 
 void ConditionalPutResponse::Clear() {
-  if (has_header()) {
-    if (header_ != NULL) header_->::cockroach::proto::ResponseHeader::Clear();
+  if (has_kvheader()) {
+    if (kvheader_ != NULL) kvheader_->::cockroach::proto::KVResponseHeader::Clear();
   }
   ::memset(_has_bits_, 0, sizeof(_has_bits_));
   if (_internal_metadata_.have_unknown_fields()) {
@@ -4638,11 +5257,11 @@ bool ConditionalPutResponse::MergePartialFromCodedStream(
     tag = p.first;
     if (!p.second) goto handle_unusual;
     switch (::google::protobuf::internal::WireFormatLite::GetTagFieldNumber(tag)) {
-      // optional .cockroach.proto.ResponseHeader header = 1;
+      // optional .cockroach.proto.KVResponseHeader kvheader = 1;
       case 1: {
         if (tag == 10) {
           DO_(::google::protobuf::internal::WireFormatLite::ReadMessageNoVirtual(
-               input, mutable_header()));
+               input, mutable_kvheader()));
         } else {
           goto handle_unusual;
         }
@@ -4675,10 +5294,10 @@ failure:
 void ConditionalPutResponse::SerializeWithCachedSizes(
     ::google::protobuf::io::CodedOutputStream* output) const {
   // @@protoc_insertion_point(serialize_start:cockroach.proto.ConditionalPutResponse)
-  // optional .cockroach.proto.ResponseHeader header = 1;
-  if (has_header()) {
+  // optional .cockroach.proto.KVResponseHeader kvheader = 1;
+  if (has_kvheader()) {
     ::google::protobuf::internal::WireFormatLite::WriteMessageMaybeToArray(
-      1, *this->header_, output);
+      1, *this->kvheader_, output);
   }
 
   if (_internal_metadata_.have_unknown_fields()) {
@@ -4691,11 +5310,11 @@ void ConditionalPutResponse::SerializeWithCachedSizes(
 ::google::protobuf::uint8* ConditionalPutResponse::SerializeWithCachedSizesToArray(
     ::google::protobuf::uint8* target) const {
   // @@protoc_insertion_point(serialize_to_array_start:cockroach.proto.ConditionalPutResponse)
-  // optional .cockroach.proto.ResponseHeader header = 1;
-  if (has_header()) {
+  // optional .cockroach.proto.KVResponseHeader kvheader = 1;
+  if (has_kvheader()) {
     target = ::google::protobuf::internal::WireFormatLite::
       WriteMessageNoVirtualToArray(
-        1, *this->header_, target);
+        1, *this->kvheader_, target);
   }
 
   if (_internal_metadata_.have_unknown_fields()) {
@@ -4709,11 +5328,11 @@ void ConditionalPutResponse::SerializeWithCachedSizes(
 int ConditionalPutResponse::ByteSize() const {
   int total_size = 0;
 
-  // optional .cockroach.proto.ResponseHeader header = 1;
-  if (has_header()) {
+  // optional .cockroach.proto.KVResponseHeader kvheader = 1;
+  if (has_kvheader()) {
     total_size += 1 +
       ::google::protobuf::internal::WireFormatLite::MessageSizeNoVirtual(
-        *this->header_);
+        *this->kvheader_);
   }
 
   if (_internal_metadata_.have_unknown_fields()) {
@@ -4742,8 +5361,8 @@ void ConditionalPutResponse::MergeFrom(const ::google::protobuf::Message& from) 
 void ConditionalPutResponse::MergeFrom(const ConditionalPutResponse& from) {
   if (GOOGLE_PREDICT_FALSE(&from == this)) MergeFromFail(__LINE__);
   if (from._has_bits_[0 / 32] & (0xffu << (0 % 32))) {
-    if (from.has_header()) {
-      mutable_header()->::cockroach::proto::ResponseHeader::MergeFrom(from.header());
+    if (from.has_kvheader()) {
+      mutable_kvheader()->::cockroach::proto::KVResponseHeader::MergeFrom(from.kvheader());
     }
   }
   if (from._internal_metadata_.have_unknown_fields()) {
@@ -4773,7 +5392,7 @@ void ConditionalPutResponse::Swap(ConditionalPutResponse* other) {
   InternalSwap(other);
 }
 void ConditionalPutResponse::InternalSwap(ConditionalPutResponse* other) {
-  std::swap(header_, other->header_);
+  std::swap(kvheader_, other->kvheader_);
   std::swap(_has_bits_[0], other->_has_bits_[0]);
   _internal_metadata_.Swap(&other->_internal_metadata_);
   std::swap(_cached_size_, other->_cached_size_);
@@ -4790,47 +5409,47 @@ void ConditionalPutResponse::InternalSwap(ConditionalPutResponse* other) {
 #if PROTOBUF_INLINE_NOT_IN_HEADERS
 // ConditionalPutResponse
 
-// optional .cockroach.proto.ResponseHeader header = 1;
-bool ConditionalPutResponse::has_header() const {
+// optional .cockroach.proto.KVResponseHeader kvheader = 1;
+bool ConditionalPutResponse::has_kvheader() const {
   return (_has_bits_[0] & 0x00000001u) != 0;
 }
-void ConditionalPutResponse::set_has_header() {
+void ConditionalPutResponse::set_has_kvheader() {
   _has_bits_[0] |= 0x00000001u;
 }
-void ConditionalPutResponse::clear_has_header() {
+void ConditionalPutResponse::clear_has_kvheader() {
   _has_bits_[0] &= ~0x00000001u;
 }
-void ConditionalPutResponse::clear_header() {
-  if (header_ != NULL) header_->::cockroach::proto::ResponseHeader::Clear();
-  clear_has_header();
+void ConditionalPutResponse::clear_kvheader() {
+  if (kvheader_ != NULL) kvheader_->::cockroach::proto::KVResponseHeader::Clear();
+  clear_has_kvheader();
 }
- const ::cockroach::proto::ResponseHeader& ConditionalPutResponse::header() const {
-  // @@protoc_insertion_point(field_get:cockroach.proto.ConditionalPutResponse.header)
-  return header_ != NULL ? *header_ : *default_instance_->header_;
+ const ::cockroach::proto::KVResponseHeader& ConditionalPutResponse::kvheader() const {
+  // @@protoc_insertion_point(field_get:cockroach.proto.ConditionalPutResponse.kvheader)
+  return kvheader_ != NULL ? *kvheader_ : *default_instance_->kvheader_;
 }
- ::cockroach::proto::ResponseHeader* ConditionalPutResponse::mutable_header() {
-  set_has_header();
-  if (header_ == NULL) {
-    header_ = new ::cockroach::proto::ResponseHeader;
+ ::cockroach::proto::KVResponseHeader* ConditionalPutResponse::mutable_kvheader() {
+  set_has_kvheader();
+  if (kvheader_ == NULL) {
+    kvheader_ = new ::cockroach::proto::KVResponseHeader;
   }
-  // @@protoc_insertion_point(field_mutable:cockroach.proto.ConditionalPutResponse.header)
-  return header_;
+  // @@protoc_insertion_point(field_mutable:cockroach.proto.ConditionalPutResponse.kvheader)
+  return kvheader_;
 }
- ::cockroach::proto::ResponseHeader* ConditionalPutResponse::release_header() {
-  clear_has_header();
-  ::cockroach::proto::ResponseHeader* temp = header_;
-  header_ = NULL;
+ ::cockroach::proto::KVResponseHeader* ConditionalPutResponse::release_kvheader() {
+  clear_has_kvheader();
+  ::cockroach::proto::KVResponseHeader* temp = kvheader_;
+  kvheader_ = NULL;
   return temp;
 }
- void ConditionalPutResponse::set_allocated_header(::cockroach::proto::ResponseHeader* header) {
-  delete header_;
-  header_ = header;
-  if (header) {
-    set_has_header();
+ void ConditionalPutResponse::set_allocated_kvheader(::cockroach::proto::KVResponseHeader* kvheader) {
+  delete kvheader_;
+  kvheader_ = kvheader;
+  if (kvheader) {
+    set_has_kvheader();
   } else {
-    clear_has_header();
+    clear_has_kvheader();
   }
-  // @@protoc_insertion_point(field_set_allocated:cockroach.proto.ConditionalPutResponse.header)
+  // @@protoc_insertion_point(field_set_allocated:cockroach.proto.ConditionalPutResponse.kvheader)
 }
 
 #endif  // PROTOBUF_INLINE_NOT_IN_HEADERS
@@ -4838,7 +5457,7 @@ void ConditionalPutResponse::clear_header() {
 // ===================================================================
 
 #ifndef _MSC_VER
-const int IncrementRequest::kHeaderFieldNumber;
+const int IncrementRequest::kKvheaderFieldNumber;
 const int IncrementRequest::kIncrementFieldNumber;
 #endif  // !_MSC_VER
 
@@ -4849,7 +5468,7 @@ IncrementRequest::IncrementRequest()
 }
 
 void IncrementRequest::InitAsDefaultInstance() {
-  header_ = const_cast< ::cockroach::proto::RequestHeader*>(&::cockroach::proto::RequestHeader::default_instance());
+  kvheader_ = const_cast< ::cockroach::proto::KVRequestHeader*>(&::cockroach::proto::KVRequestHeader::default_instance());
 }
 
 IncrementRequest::IncrementRequest(const IncrementRequest& from)
@@ -4862,7 +5481,7 @@ IncrementRequest::IncrementRequest(const IncrementRequest& from)
 
 void IncrementRequest::SharedCtor() {
   _cached_size_ = 0;
-  header_ = NULL;
+  kvheader_ = NULL;
   increment_ = GOOGLE_LONGLONG(0);
   ::memset(_has_bits_, 0, sizeof(_has_bits_));
 }
@@ -4874,7 +5493,7 @@ IncrementRequest::~IncrementRequest() {
 
 void IncrementRequest::SharedDtor() {
   if (this != default_instance_) {
-    delete header_;
+    delete kvheader_;
   }
 }
 
@@ -4905,8 +5524,8 @@ IncrementRequest* IncrementRequest::New(::google::protobuf::Arena* arena) const 
 
 void IncrementRequest::Clear() {
   if (_has_bits_[0 / 32] & 3u) {
-    if (has_header()) {
-      if (header_ != NULL) header_->::cockroach::proto::RequestHeader::Clear();
+    if (has_kvheader()) {
+      if (kvheader_ != NULL) kvheader_->::cockroach::proto::KVRequestHeader::Clear();
     }
     increment_ = GOOGLE_LONGLONG(0);
   }
@@ -4926,11 +5545,11 @@ bool IncrementRequest::MergePartialFromCodedStream(
     tag = p.first;
     if (!p.second) goto handle_unusual;
     switch (::google::protobuf::internal::WireFormatLite::GetTagFieldNumber(tag)) {
-      // optional .cockroach.proto.RequestHeader header = 1;
+      // optional .cockroach.proto.KVRequestHeader kvheader = 1;
       case 1: {
         if (tag == 10) {
           DO_(::google::protobuf::internal::WireFormatLite::ReadMessageNoVirtual(
-               input, mutable_header()));
+               input, mutable_kvheader()));
         } else {
           goto handle_unusual;
         }
@@ -4978,10 +5597,10 @@ failure:
 void IncrementRequest::SerializeWithCachedSizes(
     ::google::protobuf::io::CodedOutputStream* output) const {
   // @@protoc_insertion_point(serialize_start:cockroach.proto.IncrementRequest)
-  // optional .cockroach.proto.RequestHeader header = 1;
-  if (has_header()) {
+  // optional .cockroach.proto.KVRequestHeader kvheader = 1;
+  if (has_kvheader()) {
     ::google::protobuf::internal::WireFormatLite::WriteMessageMaybeToArray(
-      1, *this->header_, output);
+      1, *this->kvheader_, output);
   }
 
   // optional int64 increment = 2;
@@ -4999,11 +5618,11 @@ void IncrementRequest::SerializeWithCachedSizes(
 ::google::protobuf::uint8* IncrementRequest::SerializeWithCachedSizesToArray(
     ::google::protobuf::uint8* target) const {
   // @@protoc_insertion_point(serialize_to_array_start:cockroach.proto.IncrementRequest)
-  // optional .cockroach.proto.RequestHeader header = 1;
-  if (has_header()) {
+  // optional .cockroach.proto.KVRequestHeader kvheader = 1;
+  if (has_kvheader()) {
     target = ::google::protobuf::internal::WireFormatLite::
       WriteMessageNoVirtualToArray(
-        1, *this->header_, target);
+        1, *this->kvheader_, target);
   }
 
   // optional int64 increment = 2;
@@ -5023,11 +5642,11 @@ int IncrementRequest::ByteSize() const {
   int total_size = 0;
 
   if (_has_bits_[0 / 32] & 3) {
-    // optional .cockroach.proto.RequestHeader header = 1;
-    if (has_header()) {
+    // optional .cockroach.proto.KVRequestHeader kvheader = 1;
+    if (has_kvheader()) {
       total_size += 1 +
         ::google::protobuf::internal::WireFormatLite::MessageSizeNoVirtual(
-          *this->header_);
+          *this->kvheader_);
     }
 
     // optional int64 increment = 2;
@@ -5064,8 +5683,8 @@ void IncrementRequest::MergeFrom(const ::google::protobuf::Message& from) {
 void IncrementRequest::MergeFrom(const IncrementRequest& from) {
   if (GOOGLE_PREDICT_FALSE(&from == this)) MergeFromFail(__LINE__);
   if (from._has_bits_[0 / 32] & (0xffu << (0 % 32))) {
-    if (from.has_header()) {
-      mutable_header()->::cockroach::proto::RequestHeader::MergeFrom(from.header());
+    if (from.has_kvheader()) {
+      mutable_kvheader()->::cockroach::proto::KVRequestHeader::MergeFrom(from.kvheader());
     }
     if (from.has_increment()) {
       set_increment(from.increment());
@@ -5098,7 +5717,7 @@ void IncrementRequest::Swap(IncrementRequest* other) {
   InternalSwap(other);
 }
 void IncrementRequest::InternalSwap(IncrementRequest* other) {
-  std::swap(header_, other->header_);
+  std::swap(kvheader_, other->kvheader_);
   std::swap(increment_, other->increment_);
   std::swap(_has_bits_[0], other->_has_bits_[0]);
   _internal_metadata_.Swap(&other->_internal_metadata_);
@@ -5116,47 +5735,47 @@ void IncrementRequest::InternalSwap(IncrementRequest* other) {
 #if PROTOBUF_INLINE_NOT_IN_HEADERS
 // IncrementRequest
 
-// optional .cockroach.proto.RequestHeader header = 1;
-bool IncrementRequest::has_header() const {
+// optional .cockroach.proto.KVRequestHeader kvheader = 1;
+bool IncrementRequest::has_kvheader() const {
   return (_has_bits_[0] & 0x00000001u) != 0;
 }
-void IncrementRequest::set_has_header() {
+void IncrementRequest::set_has_kvheader() {
   _has_bits_[0] |= 0x00000001u;
 }
-void IncrementRequest::clear_has_header() {
+void IncrementRequest::clear_has_kvheader() {
   _has_bits_[0] &= ~0x00000001u;
 }
-void IncrementRequest::clear_header() {
-  if (header_ != NULL) header_->::cockroach::proto::RequestHeader::Clear();
-  clear_has_header();
+void IncrementRequest::clear_kvheader() {
+  if (kvheader_ != NULL) kvheader_->::cockroach::proto::KVRequestHeader::Clear();
+  clear_has_kvheader();
 }
- const ::cockroach::proto::RequestHeader& IncrementRequest::header() const {
-  // @@protoc_insertion_point(field_get:cockroach.proto.IncrementRequest.header)
-  return header_ != NULL ? *header_ : *default_instance_->header_;
+ const ::cockroach::proto::KVRequestHeader& IncrementRequest::kvheader() const {
+  // @@protoc_insertion_point(field_get:cockroach.proto.IncrementRequest.kvheader)
+  return kvheader_ != NULL ? *kvheader_ : *default_instance_->kvheader_;
 }
- ::cockroach::proto::RequestHeader* IncrementRequest::mutable_header() {
-  set_has_header();
-  if (header_ == NULL) {
-    header_ = new ::cockroach::proto::RequestHeader;
+ ::cockroach::proto::KVRequestHeader* IncrementRequest::mutable_kvheader() {
+  set_has_kvheader();
+  if (kvheader_ == NULL) {
+    kvheader_ = new ::cockroach::proto::KVRequestHeader;
   }
-  // @@protoc_insertion_point(field_mutable:cockroach.proto.IncrementRequest.header)
-  return header_;
+  // @@protoc_insertion_point(field_mutable:cockroach.proto.IncrementRequest.kvheader)
+  return kvheader_;
 }
- ::cockroach::proto::RequestHeader* IncrementRequest::release_header() {
-  clear_has_header();
-  ::cockroach::proto::RequestHeader* temp = header_;
-  header_ = NULL;
+ ::cockroach::proto::KVRequestHeader* IncrementRequest::release_kvheader() {
+  clear_has_kvheader();
+  ::cockroach::proto::KVRequestHeader* temp = kvheader_;
+  kvheader_ = NULL;
   return temp;
 }
- void IncrementRequest::set_allocated_header(::cockroach::proto::RequestHeader* header) {
-  delete header_;
-  header_ = header;
-  if (header) {
-    set_has_header();
+ void IncrementRequest::set_allocated_kvheader(::cockroach::proto::KVRequestHeader* kvheader) {
+  delete kvheader_;
+  kvheader_ = kvheader;
+  if (kvheader) {
+    set_has_kvheader();
   } else {
-    clear_has_header();
+    clear_has_kvheader();
   }
-  // @@protoc_insertion_point(field_set_allocated:cockroach.proto.IncrementRequest.header)
+  // @@protoc_insertion_point(field_set_allocated:cockroach.proto.IncrementRequest.kvheader)
 }
 
 // optional int64 increment = 2;
@@ -5188,7 +5807,7 @@ void IncrementRequest::clear_increment() {
 // ===================================================================
 
 #ifndef _MSC_VER
-const int IncrementResponse::kHeaderFieldNumber;
+const int IncrementResponse::kKvheaderFieldNumber;
 const int IncrementResponse::kNewValueFieldNumber;
 #endif  // !_MSC_VER
 
@@ -5199,7 +5818,7 @@ IncrementResponse::IncrementResponse()
 }
 
 void IncrementResponse::InitAsDefaultInstance() {
-  header_ = const_cast< ::cockroach::proto::ResponseHeader*>(&::cockroach::proto::ResponseHeader::default_instance());
+  kvheader_ = const_cast< ::cockroach::proto::KVResponseHeader*>(&::cockroach::proto::KVResponseHeader::default_instance());
 }
 
 IncrementResponse::IncrementResponse(const IncrementResponse& from)
@@ -5212,7 +5831,7 @@ IncrementResponse::IncrementResponse(const IncrementResponse& from)
 
 void IncrementResponse::SharedCtor() {
   _cached_size_ = 0;
-  header_ = NULL;
+  kvheader_ = NULL;
   new_value_ = GOOGLE_LONGLONG(0);
   ::memset(_has_bits_, 0, sizeof(_has_bits_));
 }
@@ -5224,7 +5843,7 @@ IncrementResponse::~IncrementResponse() {
 
 void IncrementResponse::SharedDtor() {
   if (this != default_instance_) {
-    delete header_;
+    delete kvheader_;
   }
 }
 
@@ -5255,8 +5874,8 @@ IncrementResponse* IncrementResponse::New(::google::protobuf::Arena* arena) cons
 
 void IncrementResponse::Clear() {
   if (_has_bits_[0 / 32] & 3u) {
-    if (has_header()) {
-      if (header_ != NULL) header_->::cockroach::proto::ResponseHeader::Clear();
+    if (has_kvheader()) {
+      if (kvheader_ != NULL) kvheader_->::cockroach::proto::KVResponseHeader::Clear();
     }
     new_value_ = GOOGLE_LONGLONG(0);
   }
@@ -5276,11 +5895,11 @@ bool IncrementResponse::MergePartialFromCodedStream(
     tag = p.first;
     if (!p.second) goto handle_unusual;
     switch (::google::protobuf::internal::WireFormatLite::GetTagFieldNumber(tag)) {
-      // optional .cockroach.proto.ResponseHeader header = 1;
+      // optional .cockroach.proto.KVResponseHeader kvheader = 1;
       case 1: {
         if (tag == 10) {
           DO_(::google::protobuf::internal::WireFormatLite::ReadMessageNoVirtual(
-               input, mutable_header()));
+               input, mutable_kvheader()));
         } else {
           goto handle_unusual;
         }
@@ -5328,10 +5947,10 @@ failure:
 void IncrementResponse::SerializeWithCachedSizes(
     ::google::protobuf::io::CodedOutputStream* output) const {
   // @@protoc_insertion_point(serialize_start:cockroach.proto.IncrementResponse)
-  // optional .cockroach.proto.ResponseHeader header = 1;
-  if (has_header()) {
+  // optional .cockroach.proto.KVResponseHeader kvheader = 1;
+  if (has_kvheader()) {
     ::google::protobuf::internal::WireFormatLite::WriteMessageMaybeToArray(
-      1, *this->header_, output);
+      1, *this->kvheader_, output);
   }
 
   // optional int64 new_value = 2;
@@ -5349,11 +5968,11 @@ void IncrementResponse::SerializeWithCachedSizes(
 ::google::protobuf::uint8* IncrementResponse::SerializeWithCachedSizesToArray(
     ::google::protobuf::uint8* target) const {
   // @@protoc_insertion_point(serialize_to_array_start:cockroach.proto.IncrementResponse)
-  // optional .cockroach.proto.ResponseHeader header = 1;
-  if (has_header()) {
+  // optional .cockroach.proto.KVResponseHeader kvheader = 1;
+  if (has_kvheader()) {
     target = ::google::protobuf::internal::WireFormatLite::
       WriteMessageNoVirtualToArray(
-        1, *this->header_, target);
+        1, *this->kvheader_, target);
   }
 
   // optional int64 new_value = 2;
@@ -5373,11 +5992,11 @@ int IncrementResponse::ByteSize() const {
   int total_size = 0;
 
   if (_has_bits_[0 / 32] & 3) {
-    // optional .cockroach.proto.ResponseHeader header = 1;
-    if (has_header()) {
+    // optional .cockroach.proto.KVResponseHeader kvheader = 1;
+    if (has_kvheader()) {
       total_size += 1 +
         ::google::protobuf::internal::WireFormatLite::MessageSizeNoVirtual(
-          *this->header_);
+          *this->kvheader_);
     }
 
     // optional int64 new_value = 2;
@@ -5414,8 +6033,8 @@ void IncrementResponse::MergeFrom(const ::google::protobuf::Message& from) {
 void IncrementResponse::MergeFrom(const IncrementResponse& from) {
   if (GOOGLE_PREDICT_FALSE(&from == this)) MergeFromFail(__LINE__);
   if (from._has_bits_[0 / 32] & (0xffu << (0 % 32))) {
-    if (from.has_header()) {
-      mutable_header()->::cockroach::proto::ResponseHeader::MergeFrom(from.header());
+    if (from.has_kvheader()) {
+      mutable_kvheader()->::cockroach::proto::KVResponseHeader::MergeFrom(from.kvheader());
     }
     if (from.has_new_value()) {
       set_new_value(from.new_value());
@@ -5448,7 +6067,7 @@ void IncrementResponse::Swap(IncrementResponse* other) {
   InternalSwap(other);
 }
 void IncrementResponse::InternalSwap(IncrementResponse* other) {
-  std::swap(header_, other->header_);
+  std::swap(kvheader_, other->kvheader_);
   std::swap(new_value_, other->new_value_);
   std::swap(_has_bits_[0], other->_has_bits_[0]);
   _internal_metadata_.Swap(&other->_internal_metadata_);
@@ -5466,47 +6085,47 @@ void IncrementResponse::InternalSwap(IncrementResponse* other) {
 #if PROTOBUF_INLINE_NOT_IN_HEADERS
 // IncrementResponse
 
-// optional .cockroach.proto.ResponseHeader header = 1;
-bool IncrementResponse::has_header() const {
+// optional .cockroach.proto.KVResponseHeader kvheader = 1;
+bool IncrementResponse::has_kvheader() const {
   return (_has_bits_[0] & 0x00000001u) != 0;
 }
-void IncrementResponse::set_has_header() {
+void IncrementResponse::set_has_kvheader() {
   _has_bits_[0] |= 0x00000001u;
 }
-void IncrementResponse::clear_has_header() {
+void IncrementResponse::clear_has_kvheader() {
   _has_bits_[0] &= ~0x00000001u;
 }
-void IncrementResponse::clear_header() {
-  if (header_ != NULL) header_->::cockroach::proto::ResponseHeader::Clear();
-  clear_has_header();
+void IncrementResponse::clear_kvheader() {
+  if (kvheader_ != NULL) kvheader_->::cockroach::proto::KVResponseHeader::Clear();
+  clear_has_kvheader();
 }
- const ::cockroach::proto::ResponseHeader& IncrementResponse::header() const {
-  // @@protoc_insertion_point(field_get:cockroach.proto.IncrementResponse.header)
-  return header_ != NULL ? *header_ : *default_instance_->header_;
+ const ::cockroach::proto::KVResponseHeader& IncrementResponse::kvheader() const {
+  // @@protoc_insertion_point(field_get:cockroach.proto.IncrementResponse.kvheader)
+  return kvheader_ != NULL ? *kvheader_ : *default_instance_->kvheader_;
 }
- ::cockroach::proto::ResponseHeader* IncrementResponse::mutable_header() {
-  set_has_header();
-  if (header_ == NULL) {
-    header_ = new ::cockroach::proto::ResponseHeader;
+ ::cockroach::proto::KVResponseHeader* IncrementResponse::mutable_kvheader() {
+  set_has_kvheader();
+  if (kvheader_ == NULL) {
+    kvheader_ = new ::cockroach::proto::KVResponseHeader;
   }
-  // @@protoc_insertion_point(field_mutable:cockroach.proto.IncrementResponse.header)
-  return header_;
+  // @@protoc_insertion_point(field_mutable:cockroach.proto.IncrementResponse.kvheader)
+  return kvheader_;
 }
- ::cockroach::proto::ResponseHeader* IncrementResponse::release_header() {
-  clear_has_header();
-  ::cockroach::proto::ResponseHeader* temp = header_;
-  header_ = NULL;
+ ::cockroach::proto::KVResponseHeader* IncrementResponse::release_kvheader() {
+  clear_has_kvheader();
+  ::cockroach::proto::KVResponseHeader* temp = kvheader_;
+  kvheader_ = NULL;
   return temp;
 }
- void IncrementResponse::set_allocated_header(::cockroach::proto::ResponseHeader* header) {
-  delete header_;
-  header_ = header;
-  if (header) {
-    set_has_header();
+ void IncrementResponse::set_allocated_kvheader(::cockroach::proto::KVResponseHeader* kvheader) {
+  delete kvheader_;
+  kvheader_ = kvheader;
+  if (kvheader) {
+    set_has_kvheader();
   } else {
-    clear_has_header();
+    clear_has_kvheader();
   }
-  // @@protoc_insertion_point(field_set_allocated:cockroach.proto.IncrementResponse.header)
+  // @@protoc_insertion_point(field_set_allocated:cockroach.proto.IncrementResponse.kvheader)
 }
 
 // optional int64 new_value = 2;
@@ -5538,7 +6157,7 @@ void IncrementResponse::clear_new_value() {
 // ===================================================================
 
 #ifndef _MSC_VER
-const int DeleteRequest::kHeaderFieldNumber;
+const int DeleteRequest::kKvheaderFieldNumber;
 #endif  // !_MSC_VER
 
 DeleteRequest::DeleteRequest()
@@ -5548,7 +6167,7 @@ DeleteRequest::DeleteRequest()
 }
 
 void DeleteRequest::InitAsDefaultInstance() {
-  header_ = const_cast< ::cockroach::proto::RequestHeader*>(&::cockroach::proto::RequestHeader::default_instance());
+  kvheader_ = const_cast< ::cockroach::proto::KVRequestHeader*>(&::cockroach::proto::KVRequestHeader::default_instance());
 }
 
 DeleteRequest::DeleteRequest(const DeleteRequest& from)
@@ -5561,7 +6180,7 @@ DeleteRequest::DeleteRequest(const DeleteRequest& from)
 
 void DeleteRequest::SharedCtor() {
   _cached_size_ = 0;
-  header_ = NULL;
+  kvheader_ = NULL;
   ::memset(_has_bits_, 0, sizeof(_has_bits_));
 }
 
@@ -5572,7 +6191,7 @@ DeleteRequest::~DeleteRequest() {
 
 void DeleteRequest::SharedDtor() {
   if (this != default_instance_) {
-    delete header_;
+    delete kvheader_;
   }
 }
 
@@ -5602,8 +6221,8 @@ DeleteRequest* DeleteRequest::New(::google::protobuf::Arena* arena) const {
 }
 
 void DeleteRequest::Clear() {
-  if (has_header()) {
-    if (header_ != NULL) header_->::cockroach::proto::RequestHeader::Clear();
+  if (has_kvheader()) {
+    if (kvheader_ != NULL) kvheader_->::cockroach::proto::KVRequestHeader::Clear();
   }
   ::memset(_has_bits_, 0, sizeof(_has_bits_));
   if (_internal_metadata_.have_unknown_fields()) {
@@ -5621,11 +6240,11 @@ bool DeleteRequest::MergePartialFromCodedStream(
     tag = p.first;
     if (!p.second) goto handle_unusual;
     switch (::google::protobuf::internal::WireFormatLite::GetTagFieldNumber(tag)) {
-      // optional .cockroach.proto.RequestHeader header = 1;
+      // optional .cockroach.proto.KVRequestHeader kvheader = 1;
       case 1: {
         if (tag == 10) {
           DO_(::google::protobuf::internal::WireFormatLite::ReadMessageNoVirtual(
-               input, mutable_header()));
+               input, mutable_kvheader()));
         } else {
           goto handle_unusual;
         }
@@ -5658,10 +6277,10 @@ failure:
 void DeleteRequest::SerializeWithCachedSizes(
     ::google::protobuf::io::CodedOutputStream* output) const {
   // @@protoc_insertion_point(serialize_start:cockroach.proto.DeleteRequest)
-  // optional .cockroach.proto.RequestHeader header = 1;
-  if (has_header()) {
+  // optional .cockroach.proto.KVRequestHeader kvheader = 1;
+  if (has_kvheader()) {
     ::google::protobuf::internal::WireFormatLite::WriteMessageMaybeToArray(
-      1, *this->header_, output);
+      1, *this->kvheader_, output);
   }
 
   if (_internal_metadata_.have_unknown_fields()) {
@@ -5674,11 +6293,11 @@ void DeleteRequest::SerializeWithCachedSizes(
 ::google::protobuf::uint8* DeleteRequest::SerializeWithCachedSizesToArray(
     ::google::protobuf::uint8* target) const {
   // @@protoc_insertion_point(serialize_to_array_start:cockroach.proto.DeleteRequest)
-  // optional .cockroach.proto.RequestHeader header = 1;
-  if (has_header()) {
+  // optional .cockroach.proto.KVRequestHeader kvheader = 1;
+  if (has_kvheader()) {
     target = ::google::protobuf::internal::WireFormatLite::
       WriteMessageNoVirtualToArray(
-        1, *this->header_, target);
+        1, *this->kvheader_, target);
   }
 
   if (_internal_metadata_.have_unknown_fields()) {
@@ -5692,11 +6311,11 @@ void DeleteRequest::SerializeWithCachedSizes(
 int DeleteRequest::ByteSize() const {
   int total_size = 0;
 
-  // optional .cockroach.proto.RequestHeader header = 1;
-  if (has_header()) {
+  // optional .cockroach.proto.KVRequestHeader kvheader = 1;
+  if (has_kvheader()) {
     total_size += 1 +
       ::google::protobuf::internal::WireFormatLite::MessageSizeNoVirtual(
-        *this->header_);
+        *this->kvheader_);
   }
 
   if (_internal_metadata_.have_unknown_fields()) {
@@ -5725,8 +6344,8 @@ void DeleteRequest::MergeFrom(const ::google::protobuf::Message& from) {
 void DeleteRequest::MergeFrom(const DeleteRequest& from) {
   if (GOOGLE_PREDICT_FALSE(&from == this)) MergeFromFail(__LINE__);
   if (from._has_bits_[0 / 32] & (0xffu << (0 % 32))) {
-    if (from.has_header()) {
-      mutable_header()->::cockroach::proto::RequestHeader::MergeFrom(from.header());
+    if (from.has_kvheader()) {
+      mutable_kvheader()->::cockroach::proto::KVRequestHeader::MergeFrom(from.kvheader());
     }
   }
   if (from._internal_metadata_.have_unknown_fields()) {
@@ -5756,7 +6375,7 @@ void DeleteRequest::Swap(DeleteRequest* other) {
   InternalSwap(other);
 }
 void DeleteRequest::InternalSwap(DeleteRequest* other) {
-  std::swap(header_, other->header_);
+  std::swap(kvheader_, other->kvheader_);
   std::swap(_has_bits_[0], other->_has_bits_[0]);
   _internal_metadata_.Swap(&other->_internal_metadata_);
   std::swap(_cached_size_, other->_cached_size_);
@@ -5773,47 +6392,47 @@ void DeleteRequest::InternalSwap(DeleteRequest* other) {
 #if PROTOBUF_INLINE_NOT_IN_HEADERS
 // DeleteRequest
 
-// optional .cockroach.proto.RequestHeader header = 1;
-bool DeleteRequest::has_header() const {
+// optional .cockroach.proto.KVRequestHeader kvheader = 1;
+bool DeleteRequest::has_kvheader() const {
   return (_has_bits_[0] & 0x00000001u) != 0;
 }
-void DeleteRequest::set_has_header() {
+void DeleteRequest::set_has_kvheader() {
   _has_bits_[0] |= 0x00000001u;
 }
-void DeleteRequest::clear_has_header() {
+void DeleteRequest::clear_has_kvheader() {
   _has_bits_[0] &= ~0x00000001u;
 }
-void DeleteRequest::clear_header() {
-  if (header_ != NULL) header_->::cockroach::proto::RequestHeader::Clear();
-  clear_has_header();
+void DeleteRequest::clear_kvheader() {
+  if (kvheader_ != NULL) kvheader_->::cockroach::proto::KVRequestHeader::Clear();
+  clear_has_kvheader();
 }
- const ::cockroach::proto::RequestHeader& DeleteRequest::header() const {
-  // @@protoc_insertion_point(field_get:cockroach.proto.DeleteRequest.header)
-  return header_ != NULL ? *header_ : *default_instance_->header_;
+ const ::cockroach::proto::KVRequestHeader& DeleteRequest::kvheader() const {
+  // @@protoc_insertion_point(field_get:cockroach.proto.DeleteRequest.kvheader)
+  return kvheader_ != NULL ? *kvheader_ : *default_instance_->kvheader_;
 }
- ::cockroach::proto::RequestHeader* DeleteRequest::mutable_header() {
-  set_has_header();
-  if (header_ == NULL) {
-    header_ = new ::cockroach::proto::RequestHeader;
+ ::cockroach::proto::KVRequestHeader* DeleteRequest::mutable_kvheader() {
+  set_has_kvheader();
+  if (kvheader_ == NULL) {
+    kvheader_ = new ::cockroach::proto::KVRequestHeader;
   }
-  // @@protoc_insertion_point(field_mutable:cockroach.proto.DeleteRequest.header)
-  return header_;
+  // @@protoc_insertion_point(field_mutable:cockroach.proto.DeleteRequest.kvheader)
+  return kvheader_;
 }
- ::cockroach::proto::RequestHeader* DeleteRequest::release_header() {
-  clear_has_header();
-  ::cockroach::proto::RequestHeader* temp = header_;
-  header_ = NULL;
+ ::cockroach::proto::KVRequestHeader* DeleteRequest::release_kvheader() {
+  clear_has_kvheader();
+  ::cockroach::proto::KVRequestHeader* temp = kvheader_;
+  kvheader_ = NULL;
   return temp;
 }
- void DeleteRequest::set_allocated_header(::cockroach::proto::RequestHeader* header) {
-  delete header_;
-  header_ = header;
-  if (header) {
-    set_has_header();
+ void DeleteRequest::set_allocated_kvheader(::cockroach::proto::KVRequestHeader* kvheader) {
+  delete kvheader_;
+  kvheader_ = kvheader;
+  if (kvheader) {
+    set_has_kvheader();
   } else {
-    clear_has_header();
+    clear_has_kvheader();
   }
-  // @@protoc_insertion_point(field_set_allocated:cockroach.proto.DeleteRequest.header)
+  // @@protoc_insertion_point(field_set_allocated:cockroach.proto.DeleteRequest.kvheader)
 }
 
 #endif  // PROTOBUF_INLINE_NOT_IN_HEADERS
@@ -5821,7 +6440,7 @@ void DeleteRequest::clear_header() {
 // ===================================================================
 
 #ifndef _MSC_VER
-const int DeleteResponse::kHeaderFieldNumber;
+const int DeleteResponse::kKvheaderFieldNumber;
 #endif  // !_MSC_VER
 
 DeleteResponse::DeleteResponse()
@@ -5831,7 +6450,7 @@ DeleteResponse::DeleteResponse()
 }
 
 void DeleteResponse::InitAsDefaultInstance() {
-  header_ = const_cast< ::cockroach::proto::ResponseHeader*>(&::cockroach::proto::ResponseHeader::default_instance());
+  kvheader_ = const_cast< ::cockroach::proto::KVResponseHeader*>(&::cockroach::proto::KVResponseHeader::default_instance());
 }
 
 DeleteResponse::DeleteResponse(const DeleteResponse& from)
@@ -5844,7 +6463,7 @@ DeleteResponse::DeleteResponse(const DeleteResponse& from)
 
 void DeleteResponse::SharedCtor() {
   _cached_size_ = 0;
-  header_ = NULL;
+  kvheader_ = NULL;
   ::memset(_has_bits_, 0, sizeof(_has_bits_));
 }
 
@@ -5855,7 +6474,7 @@ DeleteResponse::~DeleteResponse() {
 
 void DeleteResponse::SharedDtor() {
   if (this != default_instance_) {
-    delete header_;
+    delete kvheader_;
   }
 }
 
@@ -5885,8 +6504,8 @@ DeleteResponse* DeleteResponse::New(::google::protobuf::Arena* arena) const {
 }
 
 void DeleteResponse::Clear() {
-  if (has_header()) {
-    if (header_ != NULL) header_->::cockroach::proto::ResponseHeader::Clear();
+  if (has_kvheader()) {
+    if (kvheader_ != NULL) kvheader_->::cockroach::proto::KVResponseHeader::Clear();
   }
   ::memset(_has_bits_, 0, sizeof(_has_bits_));
   if (_internal_metadata_.have_unknown_fields()) {
@@ -5904,11 +6523,11 @@ bool DeleteResponse::MergePartialFromCodedStream(
     tag = p.first;
     if (!p.second) goto handle_unusual;
     switch (::google::protobuf::internal::WireFormatLite::GetTagFieldNumber(tag)) {
-      // optional .cockroach.proto.ResponseHeader header = 1;
+      // optional .cockroach.proto.KVResponseHeader kvheader = 1;
       case 1: {
         if (tag == 10) {
           DO_(::google::protobuf::internal::WireFormatLite::ReadMessageNoVirtual(
-               input, mutable_header()));
+               input, mutable_kvheader()));
         } else {
           goto handle_unusual;
         }
@@ -5941,10 +6560,10 @@ failure:
 void DeleteResponse::SerializeWithCachedSizes(
     ::google::protobuf::io::CodedOutputStream* output) const {
   // @@protoc_insertion_point(serialize_start:cockroach.proto.DeleteResponse)
-  // optional .cockroach.proto.ResponseHeader header = 1;
-  if (has_header()) {
+  // optional .cockroach.proto.KVResponseHeader kvheader = 1;
+  if (has_kvheader()) {
     ::google::protobuf::internal::WireFormatLite::WriteMessageMaybeToArray(
-      1, *this->header_, output);
+      1, *this->kvheader_, output);
   }
 
   if (_internal_metadata_.have_unknown_fields()) {
@@ -5957,11 +6576,11 @@ void DeleteResponse::SerializeWithCachedSizes(
 ::google::protobuf::uint8* DeleteResponse::SerializeWithCachedSizesToArray(
     ::google::protobuf::uint8* target) const {
   // @@protoc_insertion_point(serialize_to_array_start:cockroach.proto.DeleteResponse)
-  // optional .cockroach.proto.ResponseHeader header = 1;
-  if (has_header()) {
+  // optional .cockroach.proto.KVResponseHeader kvheader = 1;
+  if (has_kvheader()) {
     target = ::google::protobuf::internal::WireFormatLite::
       WriteMessageNoVirtualToArray(
-        1, *this->header_, target);
+        1, *this->kvheader_, target);
   }
 
   if (_internal_metadata_.have_unknown_fields()) {
@@ -5975,11 +6594,11 @@ void DeleteResponse::SerializeWithCachedSizes(
 int DeleteResponse::ByteSize() const {
   int total_size = 0;
 
-  // optional .cockroach.proto.ResponseHeader header = 1;
-  if (has_header()) {
+  // optional .cockroach.proto.KVResponseHeader kvheader = 1;
+  if (has_kvheader()) {
     total_size += 1 +
       ::google::protobuf::internal::WireFormatLite::MessageSizeNoVirtual(
-        *this->header_);
+        *this->kvheader_);
   }
 
   if (_internal_metadata_.have_unknown_fields()) {
@@ -6008,8 +6627,8 @@ void DeleteResponse::MergeFrom(const ::google::protobuf::Message& from) {
 void DeleteResponse::MergeFrom(const DeleteResponse& from) {
   if (GOOGLE_PREDICT_FALSE(&from == this)) MergeFromFail(__LINE__);
   if (from._has_bits_[0 / 32] & (0xffu << (0 % 32))) {
-    if (from.has_header()) {
-      mutable_header()->::cockroach::proto::ResponseHeader::MergeFrom(from.header());
+    if (from.has_kvheader()) {
+      mutable_kvheader()->::cockroach::proto::KVResponseHeader::MergeFrom(from.kvheader());
     }
   }
   if (from._internal_metadata_.have_unknown_fields()) {
@@ -6039,7 +6658,7 @@ void DeleteResponse::Swap(DeleteResponse* other) {
   InternalSwap(other);
 }
 void DeleteResponse::InternalSwap(DeleteResponse* other) {
-  std::swap(header_, other->header_);
+  std::swap(kvheader_, other->kvheader_);
   std::swap(_has_bits_[0], other->_has_bits_[0]);
   _internal_metadata_.Swap(&other->_internal_metadata_);
   std::swap(_cached_size_, other->_cached_size_);
@@ -6056,47 +6675,47 @@ void DeleteResponse::InternalSwap(DeleteResponse* other) {
 #if PROTOBUF_INLINE_NOT_IN_HEADERS
 // DeleteResponse
 
-// optional .cockroach.proto.ResponseHeader header = 1;
-bool DeleteResponse::has_header() const {
+// optional .cockroach.proto.KVResponseHeader kvheader = 1;
+bool DeleteResponse::has_kvheader() const {
   return (_has_bits_[0] & 0x00000001u) != 0;
 }
-void DeleteResponse::set_has_header() {
+void DeleteResponse::set_has_kvheader() {
   _has_bits_[0] |= 0x00000001u;
 }
-void DeleteResponse::clear_has_header() {
+void DeleteResponse::clear_has_kvheader() {
   _has_bits_[0] &= ~0x00000001u;
 }
-void DeleteResponse::clear_header() {
-  if (header_ != NULL) header_->::cockroach::proto::ResponseHeader::Clear();
-  clear_has_header();
+void DeleteResponse::clear_kvheader() {
+  if (kvheader_ != NULL) kvheader_->::cockroach::proto::KVResponseHeader::Clear();
+  clear_has_kvheader();
 }
- const ::cockroach::proto::ResponseHeader& DeleteResponse::header() const {
-  // @@protoc_insertion_point(field_get:cockroach.proto.DeleteResponse.header)
-  return header_ != NULL ? *header_ : *default_instance_->header_;
+ const ::cockroach::proto::KVResponseHeader& DeleteResponse::kvheader() const {
+  // @@protoc_insertion_point(field_get:cockroach.proto.DeleteResponse.kvheader)
+  return kvheader_ != NULL ? *kvheader_ : *default_instance_->kvheader_;
 }
- ::cockroach::proto::ResponseHeader* DeleteResponse::mutable_header() {
-  set_has_header();
-  if (header_ == NULL) {
-    header_ = new ::cockroach::proto::ResponseHeader;
+ ::cockroach::proto::KVResponseHeader* DeleteResponse::mutable_kvheader() {
+  set_has_kvheader();
+  if (kvheader_ == NULL) {
+    kvheader_ = new ::cockroach::proto::KVResponseHeader;
   }
-  // @@protoc_insertion_point(field_mutable:cockroach.proto.DeleteResponse.header)
-  return header_;
+  // @@protoc_insertion_point(field_mutable:cockroach.proto.DeleteResponse.kvheader)
+  return kvheader_;
 }
- ::cockroach::proto::ResponseHeader* DeleteResponse::release_header() {
-  clear_has_header();
-  ::cockroach::proto::ResponseHeader* temp = header_;
-  header_ = NULL;
+ ::cockroach::proto::KVResponseHeader* DeleteResponse::release_kvheader() {
+  clear_has_kvheader();
+  ::cockroach::proto::KVResponseHeader* temp = kvheader_;
+  kvheader_ = NULL;
   return temp;
 }
- void DeleteResponse::set_allocated_header(::cockroach::proto::ResponseHeader* header) {
-  delete header_;
-  header_ = header;
-  if (header) {
-    set_has_header();
+ void DeleteResponse::set_allocated_kvheader(::cockroach::proto::KVResponseHeader* kvheader) {
+  delete kvheader_;
+  kvheader_ = kvheader;
+  if (kvheader) {
+    set_has_kvheader();
   } else {
-    clear_has_header();
+    clear_has_kvheader();
   }
-  // @@protoc_insertion_point(field_set_allocated:cockroach.proto.DeleteResponse.header)
+  // @@protoc_insertion_point(field_set_allocated:cockroach.proto.DeleteResponse.kvheader)
 }
 
 #endif  // PROTOBUF_INLINE_NOT_IN_HEADERS
@@ -6104,7 +6723,7 @@ void DeleteResponse::clear_header() {
 // ===================================================================
 
 #ifndef _MSC_VER
-const int DeleteRangeRequest::kHeaderFieldNumber;
+const int DeleteRangeRequest::kKvheaderFieldNumber;
 const int DeleteRangeRequest::kMaxEntriesToDeleteFieldNumber;
 #endif  // !_MSC_VER
 
@@ -6115,7 +6734,7 @@ DeleteRangeRequest::DeleteRangeRequest()
 }
 
 void DeleteRangeRequest::InitAsDefaultInstance() {
-  header_ = const_cast< ::cockroach::proto::RequestHeader*>(&::cockroach::proto::RequestHeader::default_instance());
+  kvheader_ = const_cast< ::cockroach::proto::KVRequestHeader*>(&::cockroach::proto::KVRequestHeader::default_instance());
 }
 
 DeleteRangeRequest::DeleteRangeRequest(const DeleteRangeRequest& from)
@@ -6128,7 +6747,7 @@ DeleteRangeRequest::DeleteRangeRequest(const DeleteRangeRequest& from)
 
 void DeleteRangeRequest::SharedCtor() {
   _cached_size_ = 0;
-  header_ = NULL;
+  kvheader_ = NULL;
   max_entries_to_delete_ = GOOGLE_LONGLONG(0);
   ::memset(_has_bits_, 0, sizeof(_has_bits_));
 }
@@ -6140,7 +6759,7 @@ DeleteRangeRequest::~DeleteRangeRequest() {
 
 void DeleteRangeRequest::SharedDtor() {
   if (this != default_instance_) {
-    delete header_;
+    delete kvheader_;
   }
 }
 
@@ -6171,8 +6790,8 @@ DeleteRangeRequest* DeleteRangeRequest::New(::google::protobuf::Arena* arena) co
 
 void DeleteRangeRequest::Clear() {
   if (_has_bits_[0 / 32] & 3u) {
-    if (has_header()) {
-      if (header_ != NULL) header_->::cockroach::proto::RequestHeader::Clear();
+    if (has_kvheader()) {
+      if (kvheader_ != NULL) kvheader_->::cockroach::proto::KVRequestHeader::Clear();
     }
     max_entries_to_delete_ = GOOGLE_LONGLONG(0);
   }
@@ -6192,11 +6811,11 @@ bool DeleteRangeRequest::MergePartialFromCodedStream(
     tag = p.first;
     if (!p.second) goto handle_unusual;
     switch (::google::protobuf::internal::WireFormatLite::GetTagFieldNumber(tag)) {
-      // optional .cockroach.proto.RequestHeader header = 1;
+      // optional .cockroach.proto.KVRequestHeader kvheader = 1;
       case 1: {
         if (tag == 10) {
           DO_(::google::protobuf::internal::WireFormatLite::ReadMessageNoVirtual(
-               input, mutable_header()));
+               input, mutable_kvheader()));
         } else {
           goto handle_unusual;
         }
@@ -6244,10 +6863,10 @@ failure:
 void DeleteRangeRequest::SerializeWithCachedSizes(
     ::google::protobuf::io::CodedOutputStream* output) const {
   // @@protoc_insertion_point(serialize_start:cockroach.proto.DeleteRangeRequest)
-  // optional .cockroach.proto.RequestHeader header = 1;
-  if (has_header()) {
+  // optional .cockroach.proto.KVRequestHeader kvheader = 1;
+  if (has_kvheader()) {
     ::google::protobuf::internal::WireFormatLite::WriteMessageMaybeToArray(
-      1, *this->header_, output);
+      1, *this->kvheader_, output);
   }
 
   // optional int64 max_entries_to_delete = 2;
@@ -6265,11 +6884,11 @@ void DeleteRangeRequest::SerializeWithCachedSizes(
 ::google::protobuf::uint8* DeleteRangeRequest::SerializeWithCachedSizesToArray(
     ::google::protobuf::uint8* target) const {
   // @@protoc_insertion_point(serialize_to_array_start:cockroach.proto.DeleteRangeRequest)
-  // optional .cockroach.proto.RequestHeader header = 1;
-  if (has_header()) {
+  // optional .cockroach.proto.KVRequestHeader kvheader = 1;
+  if (has_kvheader()) {
     target = ::google::protobuf::internal::WireFormatLite::
       WriteMessageNoVirtualToArray(
-        1, *this->header_, target);
+        1, *this->kvheader_, target);
   }
 
   // optional int64 max_entries_to_delete = 2;
@@ -6289,11 +6908,11 @@ int DeleteRangeRequest::ByteSize() const {
   int total_size = 0;
 
   if (_has_bits_[0 / 32] & 3) {
-    // optional .cockroach.proto.RequestHeader header = 1;
-    if (has_header()) {
+    // optional .cockroach.proto.KVRequestHeader kvheader = 1;
+    if (has_kvheader()) {
       total_size += 1 +
         ::google::protobuf::internal::WireFormatLite::MessageSizeNoVirtual(
-          *this->header_);
+          *this->kvheader_);
     }
 
     // optional int64 max_entries_to_delete = 2;
@@ -6330,8 +6949,8 @@ void DeleteRangeRequest::MergeFrom(const ::google::protobuf::Message& from) {
 void DeleteRangeRequest::MergeFrom(const DeleteRangeRequest& from) {
   if (GOOGLE_PREDICT_FALSE(&from == this)) MergeFromFail(__LINE__);
   if (from._has_bits_[0 / 32] & (0xffu << (0 % 32))) {
-    if (from.has_header()) {
-      mutable_header()->::cockroach::proto::RequestHeader::MergeFrom(from.header());
+    if (from.has_kvheader()) {
+      mutable_kvheader()->::cockroach::proto::KVRequestHeader::MergeFrom(from.kvheader());
     }
     if (from.has_max_entries_to_delete()) {
       set_max_entries_to_delete(from.max_entries_to_delete());
@@ -6364,7 +6983,7 @@ void DeleteRangeRequest::Swap(DeleteRangeRequest* other) {
   InternalSwap(other);
 }
 void DeleteRangeRequest::InternalSwap(DeleteRangeRequest* other) {
-  std::swap(header_, other->header_);
+  std::swap(kvheader_, other->kvheader_);
   std::swap(max_entries_to_delete_, other->max_entries_to_delete_);
   std::swap(_has_bits_[0], other->_has_bits_[0]);
   _internal_metadata_.Swap(&other->_internal_metadata_);
@@ -6382,47 +7001,47 @@ void DeleteRangeRequest::InternalSwap(DeleteRangeRequest* other) {
 #if PROTOBUF_INLINE_NOT_IN_HEADERS
 // DeleteRangeRequest
 
-// optional .cockroach.proto.RequestHeader header = 1;
-bool DeleteRangeRequest::has_header() const {
+// optional .cockroach.proto.KVRequestHeader kvheader = 1;
+bool DeleteRangeRequest::has_kvheader() const {
   return (_has_bits_[0] & 0x00000001u) != 0;
 }
-void DeleteRangeRequest::set_has_header() {
+void DeleteRangeRequest::set_has_kvheader() {
   _has_bits_[0] |= 0x00000001u;
 }
-void DeleteRangeRequest::clear_has_header() {
+void DeleteRangeRequest::clear_has_kvheader() {
   _has_bits_[0] &= ~0x00000001u;
 }
-void DeleteRangeRequest::clear_header() {
-  if (header_ != NULL) header_->::cockroach::proto::RequestHeader::Clear();
-  clear_has_header();
+void DeleteRangeRequest::clear_kvheader() {
+  if (kvheader_ != NULL) kvheader_->::cockroach::proto::KVRequestHeader::Clear();
+  clear_has_kvheader();
 }
- const ::cockroach::proto::RequestHeader& DeleteRangeRequest::header() const {
-  // @@protoc_insertion_point(field_get:cockroach.proto.DeleteRangeRequest.header)
-  return header_ != NULL ? *header_ : *default_instance_->header_;
+ const ::cockroach::proto::KVRequestHeader& DeleteRangeRequest::kvheader() const {
+  // @@protoc_insertion_point(field_get:cockroach.proto.DeleteRangeRequest.kvheader)
+  return kvheader_ != NULL ? *kvheader_ : *default_instance_->kvheader_;
 }
- ::cockroach::proto::RequestHeader* DeleteRangeRequest::mutable_header() {
-  set_has_header();
-  if (header_ == NULL) {
-    header_ = new ::cockroach::proto::RequestHeader;
+ ::cockroach::proto::KVRequestHeader* DeleteRangeRequest::mutable_kvheader() {
+  set_has_kvheader();
+  if (kvheader_ == NULL) {
+    kvheader_ = new ::cockroach::proto::KVRequestHeader;
   }
-  // @@protoc_insertion_point(field_mutable:cockroach.proto.DeleteRangeRequest.header)
-  return header_;
+  // @@protoc_insertion_point(field_mutable:cockroach.proto.DeleteRangeRequest.kvheader)
+  return kvheader_;
 }
- ::cockroach::proto::RequestHeader* DeleteRangeRequest::release_header() {
-  clear_has_header();
-  ::cockroach::proto::RequestHeader* temp = header_;
-  header_ = NULL;
+ ::cockroach::proto::KVRequestHeader* DeleteRangeRequest::release_kvheader() {
+  clear_has_kvheader();
+  ::cockroach::proto::KVRequestHeader* temp = kvheader_;
+  kvheader_ = NULL;
   return temp;
 }
- void DeleteRangeRequest::set_allocated_header(::cockroach::proto::RequestHeader* header) {
-  delete header_;
-  header_ = header;
-  if (header) {
-    set_has_header();
+ void DeleteRangeRequest::set_allocated_kvheader(::cockroach::proto::KVRequestHeader* kvheader) {
+  delete kvheader_;
+  kvheader_ = kvheader;
+  if (kvheader) {
+    set_has_kvheader();
   } else {
-    clear_has_header();
+    clear_has_kvheader();
   }
-  // @@protoc_insertion_point(field_set_allocated:cockroach.proto.DeleteRangeRequest.header)
+  // @@protoc_insertion_point(field_set_allocated:cockroach.proto.DeleteRangeRequest.kvheader)
 }
 
 // optional int64 max_entries_to_delete = 2;
@@ -6454,7 +7073,7 @@ void DeleteRangeRequest::clear_max_entries_to_delete() {
 // ===================================================================
 
 #ifndef _MSC_VER
-const int DeleteRangeResponse::kHeaderFieldNumber;
+const int DeleteRangeResponse::kKvheaderFieldNumber;
 const int DeleteRangeResponse::kNumDeletedFieldNumber;
 #endif  // !_MSC_VER
 
@@ -6465,7 +7084,7 @@ DeleteRangeResponse::DeleteRangeResponse()
 }
 
 void DeleteRangeResponse::InitAsDefaultInstance() {
-  header_ = const_cast< ::cockroach::proto::ResponseHeader*>(&::cockroach::proto::ResponseHeader::default_instance());
+  kvheader_ = const_cast< ::cockroach::proto::KVResponseHeader*>(&::cockroach::proto::KVResponseHeader::default_instance());
 }
 
 DeleteRangeResponse::DeleteRangeResponse(const DeleteRangeResponse& from)
@@ -6478,7 +7097,7 @@ DeleteRangeResponse::DeleteRangeResponse(const DeleteRangeResponse& from)
 
 void DeleteRangeResponse::SharedCtor() {
   _cached_size_ = 0;
-  header_ = NULL;
+  kvheader_ = NULL;
   num_deleted_ = GOOGLE_LONGLONG(0);
   ::memset(_has_bits_, 0, sizeof(_has_bits_));
 }
@@ -6490,7 +7109,7 @@ DeleteRangeResponse::~DeleteRangeResponse() {
 
 void DeleteRangeResponse::SharedDtor() {
   if (this != default_instance_) {
-    delete header_;
+    delete kvheader_;
   }
 }
 
@@ -6521,8 +7140,8 @@ DeleteRangeResponse* DeleteRangeResponse::New(::google::protobuf::Arena* arena) 
 
 void DeleteRangeResponse::Clear() {
   if (_has_bits_[0 / 32] & 3u) {
-    if (has_header()) {
-      if (header_ != NULL) header_->::cockroach::proto::ResponseHeader::Clear();
+    if (has_kvheader()) {
+      if (kvheader_ != NULL) kvheader_->::cockroach::proto::KVResponseHeader::Clear();
     }
     num_deleted_ = GOOGLE_LONGLONG(0);
   }
@@ -6542,11 +7161,11 @@ bool DeleteRangeResponse::MergePartialFromCodedStream(
     tag = p.first;
     if (!p.second) goto handle_unusual;
     switch (::google::protobuf::internal::WireFormatLite::GetTagFieldNumber(tag)) {
-      // optional .cockroach.proto.ResponseHeader header = 1;
+      // optional .cockroach.proto.KVResponseHeader kvheader = 1;
       case 1: {
         if (tag == 10) {
           DO_(::google::protobuf::internal::WireFormatLite::ReadMessageNoVirtual(
-               input, mutable_header()));
+               input, mutable_kvheader()));
         } else {
           goto handle_unusual;
         }
@@ -6594,10 +7213,10 @@ failure:
 void DeleteRangeResponse::SerializeWithCachedSizes(
     ::google::protobuf::io::CodedOutputStream* output) const {
   // @@protoc_insertion_point(serialize_start:cockroach.proto.DeleteRangeResponse)
-  // optional .cockroach.proto.ResponseHeader header = 1;
-  if (has_header()) {
+  // optional .cockroach.proto.KVResponseHeader kvheader = 1;
+  if (has_kvheader()) {
     ::google::protobuf::internal::WireFormatLite::WriteMessageMaybeToArray(
-      1, *this->header_, output);
+      1, *this->kvheader_, output);
   }
 
   // optional int64 num_deleted = 2;
@@ -6615,11 +7234,11 @@ void DeleteRangeResponse::SerializeWithCachedSizes(
 ::google::protobuf::uint8* DeleteRangeResponse::SerializeWithCachedSizesToArray(
     ::google::protobuf::uint8* target) const {
   // @@protoc_insertion_point(serialize_to_array_start:cockroach.proto.DeleteRangeResponse)
-  // optional .cockroach.proto.ResponseHeader header = 1;
-  if (has_header()) {
+  // optional .cockroach.proto.KVResponseHeader kvheader = 1;
+  if (has_kvheader()) {
     target = ::google::protobuf::internal::WireFormatLite::
       WriteMessageNoVirtualToArray(
-        1, *this->header_, target);
+        1, *this->kvheader_, target);
   }
 
   // optional int64 num_deleted = 2;
@@ -6639,11 +7258,11 @@ int DeleteRangeResponse::ByteSize() const {
   int total_size = 0;
 
   if (_has_bits_[0 / 32] & 3) {
-    // optional .cockroach.proto.ResponseHeader header = 1;
-    if (has_header()) {
+    // optional .cockroach.proto.KVResponseHeader kvheader = 1;
+    if (has_kvheader()) {
       total_size += 1 +
         ::google::protobuf::internal::WireFormatLite::MessageSizeNoVirtual(
-          *this->header_);
+          *this->kvheader_);
     }
 
     // optional int64 num_deleted = 2;
@@ -6680,8 +7299,8 @@ void DeleteRangeResponse::MergeFrom(const ::google::protobuf::Message& from) {
 void DeleteRangeResponse::MergeFrom(const DeleteRangeResponse& from) {
   if (GOOGLE_PREDICT_FALSE(&from == this)) MergeFromFail(__LINE__);
   if (from._has_bits_[0 / 32] & (0xffu << (0 % 32))) {
-    if (from.has_header()) {
-      mutable_header()->::cockroach::proto::ResponseHeader::MergeFrom(from.header());
+    if (from.has_kvheader()) {
+      mutable_kvheader()->::cockroach::proto::KVResponseHeader::MergeFrom(from.kvheader());
     }
     if (from.has_num_deleted()) {
       set_num_deleted(from.num_deleted());
@@ -6714,7 +7333,7 @@ void DeleteRangeResponse::Swap(DeleteRangeResponse* other) {
   InternalSwap(other);
 }
 void DeleteRangeResponse::InternalSwap(DeleteRangeResponse* other) {
-  std::swap(header_, other->header_);
+  std::swap(kvheader_, other->kvheader_);
   std::swap(num_deleted_, other->num_deleted_);
   std::swap(_has_bits_[0], other->_has_bits_[0]);
   _internal_metadata_.Swap(&other->_internal_metadata_);
@@ -6732,47 +7351,47 @@ void DeleteRangeResponse::InternalSwap(DeleteRangeResponse* other) {
 #if PROTOBUF_INLINE_NOT_IN_HEADERS
 // DeleteRangeResponse
 
-// optional .cockroach.proto.ResponseHeader header = 1;
-bool DeleteRangeResponse::has_header() const {
+// optional .cockroach.proto.KVResponseHeader kvheader = 1;
+bool DeleteRangeResponse::has_kvheader() const {
   return (_has_bits_[0] & 0x00000001u) != 0;
 }
-void DeleteRangeResponse::set_has_header() {
+void DeleteRangeResponse::set_has_kvheader() {
   _has_bits_[0] |= 0x00000001u;
 }
-void DeleteRangeResponse::clear_has_header() {
+void DeleteRangeResponse::clear_has_kvheader() {
   _has_bits_[0] &= ~0x00000001u;
 }
-void DeleteRangeResponse::clear_header() {
-  if (header_ != NULL) header_->::cockroach::proto::ResponseHeader::Clear();
-  clear_has_header();
+void DeleteRangeResponse::clear_kvheader() {
+  if (kvheader_ != NULL) kvheader_->::cockroach::proto::KVResponseHeader::Clear();
+  clear_has_kvheader();
 }
- const ::cockroach::proto::ResponseHeader& DeleteRangeResponse::header() const {
-  // @@protoc_insertion_point(field_get:cockroach.proto.DeleteRangeResponse.header)
-  return header_ != NULL ? *header_ : *default_instance_->header_;
+ const ::cockroach::proto::KVResponseHeader& DeleteRangeResponse::kvheader() const {
+  // @@protoc_insertion_point(field_get:cockroach.proto.DeleteRangeResponse.kvheader)
+  return kvheader_ != NULL ? *kvheader_ : *default_instance_->kvheader_;
 }
- ::cockroach::proto::ResponseHeader* DeleteRangeResponse::mutable_header() {
-  set_has_header();
-  if (header_ == NULL) {
-    header_ = new ::cockroach::proto::ResponseHeader;
+ ::cockroach::proto::KVResponseHeader* DeleteRangeResponse::mutable_kvheader() {
+  set_has_kvheader();
+  if (kvheader_ == NULL) {
+    kvheader_ = new ::cockroach::proto::KVResponseHeader;
   }
-  // @@protoc_insertion_point(field_mutable:cockroach.proto.DeleteRangeResponse.header)
-  return header_;
+  // @@protoc_insertion_point(field_mutable:cockroach.proto.DeleteRangeResponse.kvheader)
+  return kvheader_;
 }
- ::cockroach::proto::ResponseHeader* DeleteRangeResponse::release_header() {
-  clear_has_header();
-  ::cockroach::proto::ResponseHeader* temp = header_;
-  header_ = NULL;
+ ::cockroach::proto::KVResponseHeader* DeleteRangeResponse::release_kvheader() {
+  clear_has_kvheader();
+  ::cockroach::proto::KVResponseHeader* temp = kvheader_;
+  kvheader_ = NULL;
   return temp;
 }
- void DeleteRangeResponse::set_allocated_header(::cockroach::proto::ResponseHeader* header) {
-  delete header_;
-  header_ = header;
-  if (header) {
-    set_has_header();
+ void DeleteRangeResponse::set_allocated_kvheader(::cockroach::proto::KVResponseHeader* kvheader) {
+  delete kvheader_;
+  kvheader_ = kvheader;
+  if (kvheader) {
+    set_has_kvheader();
   } else {
-    clear_has_header();
+    clear_has_kvheader();
   }
-  // @@protoc_insertion_point(field_set_allocated:cockroach.proto.DeleteRangeResponse.header)
+  // @@protoc_insertion_point(field_set_allocated:cockroach.proto.DeleteRangeResponse.kvheader)
 }
 
 // optional int64 num_deleted = 2;
@@ -6804,7 +7423,7 @@ void DeleteRangeResponse::clear_num_deleted() {
 // ===================================================================
 
 #ifndef _MSC_VER
-const int ScanRequest::kHeaderFieldNumber;
+const int ScanRequest::kKvheaderFieldNumber;
 const int ScanRequest::kMaxResultsFieldNumber;
 #endif  // !_MSC_VER
 
@@ -6815,7 +7434,7 @@ ScanRequest::ScanRequest()
 }
 
 void ScanRequest::InitAsDefaultInstance() {
-  header_ = const_cast< ::cockroach::proto::RequestHeader*>(&::cockroach::proto::RequestHeader::default_instance());
+  kvheader_ = const_cast< ::cockroach::proto::KVRequestHeader*>(&::cockroach::proto::KVRequestHeader::default_instance());
 }
 
 ScanRequest::ScanRequest(const ScanRequest& from)
@@ -6828,7 +7447,7 @@ ScanRequest::ScanRequest(const ScanRequest& from)
 
 void ScanRequest::SharedCtor() {
   _cached_size_ = 0;
-  header_ = NULL;
+  kvheader_ = NULL;
   max_results_ = GOOGLE_LONGLONG(0);
   ::memset(_has_bits_, 0, sizeof(_has_bits_));
 }
@@ -6840,7 +7459,7 @@ ScanRequest::~ScanRequest() {
 
 void ScanRequest::SharedDtor() {
   if (this != default_instance_) {
-    delete header_;
+    delete kvheader_;
   }
 }
 
@@ -6871,8 +7490,8 @@ ScanRequest* ScanRequest::New(::google::protobuf::Arena* arena) const {
 
 void ScanRequest::Clear() {
   if (_has_bits_[0 / 32] & 3u) {
-    if (has_header()) {
-      if (header_ != NULL) header_->::cockroach::proto::RequestHeader::Clear();
+    if (has_kvheader()) {
+      if (kvheader_ != NULL) kvheader_->::cockroach::proto::KVRequestHeader::Clear();
     }
     max_results_ = GOOGLE_LONGLONG(0);
   }
@@ -6892,11 +7511,11 @@ bool ScanRequest::MergePartialFromCodedStream(
     tag = p.first;
     if (!p.second) goto handle_unusual;
     switch (::google::protobuf::internal::WireFormatLite::GetTagFieldNumber(tag)) {
-      // optional .cockroach.proto.RequestHeader header = 1;
+      // optional .cockroach.proto.KVRequestHeader kvheader = 1;
       case 1: {
         if (tag == 10) {
           DO_(::google::protobuf::internal::WireFormatLite::ReadMessageNoVirtual(
-               input, mutable_header()));
+               input, mutable_kvheader()));
         } else {
           goto handle_unusual;
         }
@@ -6944,10 +7563,10 @@ failure:
 void ScanRequest::SerializeWithCachedSizes(
     ::google::protobuf::io::CodedOutputStream* output) const {
   // @@protoc_insertion_point(serialize_start:cockroach.proto.ScanRequest)
-  // optional .cockroach.proto.RequestHeader header = 1;
-  if (has_header()) {
+  // optional .cockroach.proto.KVRequestHeader kvheader = 1;
+  if (has_kvheader()) {
     ::google::protobuf::internal::WireFormatLite::WriteMessageMaybeToArray(
-      1, *this->header_, output);
+      1, *this->kvheader_, output);
   }
 
   // optional int64 max_results = 2;
@@ -6965,11 +7584,11 @@ void ScanRequest::SerializeWithCachedSizes(
 ::google::protobuf::uint8* ScanRequest::SerializeWithCachedSizesToArray(
     ::google::protobuf::uint8* target) const {
   // @@protoc_insertion_point(serialize_to_array_start:cockroach.proto.ScanRequest)
-  // optional .cockroach.proto.RequestHeader header = 1;
-  if (has_header()) {
+  // optional .cockroach.proto.KVRequestHeader kvheader = 1;
+  if (has_kvheader()) {
     target = ::google::protobuf::internal::WireFormatLite::
       WriteMessageNoVirtualToArray(
-        1, *this->header_, target);
+        1, *this->kvheader_, target);
   }
 
   // optional int64 max_results = 2;
@@ -6989,11 +7608,11 @@ int ScanRequest::ByteSize() const {
   int total_size = 0;
 
   if (_has_bits_[0 / 32] & 3) {
-    // optional .cockroach.proto.RequestHeader header = 1;
-    if (has_header()) {
+    // optional .cockroach.proto.KVRequestHeader kvheader = 1;
+    if (has_kvheader()) {
       total_size += 1 +
         ::google::protobuf::internal::WireFormatLite::MessageSizeNoVirtual(
-          *this->header_);
+          *this->kvheader_);
     }
 
     // optional int64 max_results = 2;
@@ -7030,8 +7649,8 @@ void ScanRequest::MergeFrom(const ::google::protobuf::Message& from) {
 void ScanRequest::MergeFrom(const ScanRequest& from) {
   if (GOOGLE_PREDICT_FALSE(&from == this)) MergeFromFail(__LINE__);
   if (from._has_bits_[0 / 32] & (0xffu << (0 % 32))) {
-    if (from.has_header()) {
-      mutable_header()->::cockroach::proto::RequestHeader::MergeFrom(from.header());
+    if (from.has_kvheader()) {
+      mutable_kvheader()->::cockroach::proto::KVRequestHeader::MergeFrom(from.kvheader());
     }
     if (from.has_max_results()) {
       set_max_results(from.max_results());
@@ -7064,7 +7683,7 @@ void ScanRequest::Swap(ScanRequest* other) {
   InternalSwap(other);
 }
 void ScanRequest::InternalSwap(ScanRequest* other) {
-  std::swap(header_, other->header_);
+  std::swap(kvheader_, other->kvheader_);
   std::swap(max_results_, other->max_results_);
   std::swap(_has_bits_[0], other->_has_bits_[0]);
   _internal_metadata_.Swap(&other->_internal_metadata_);
@@ -7082,47 +7701,47 @@ void ScanRequest::InternalSwap(ScanRequest* other) {
 #if PROTOBUF_INLINE_NOT_IN_HEADERS
 // ScanRequest
 
-// optional .cockroach.proto.RequestHeader header = 1;
-bool ScanRequest::has_header() const {
+// optional .cockroach.proto.KVRequestHeader kvheader = 1;
+bool ScanRequest::has_kvheader() const {
   return (_has_bits_[0] & 0x00000001u) != 0;
 }
-void ScanRequest::set_has_header() {
+void ScanRequest::set_has_kvheader() {
   _has_bits_[0] |= 0x00000001u;
 }
-void ScanRequest::clear_has_header() {
+void ScanRequest::clear_has_kvheader() {
   _has_bits_[0] &= ~0x00000001u;
 }
-void ScanRequest::clear_header() {
-  if (header_ != NULL) header_->::cockroach::proto::RequestHeader::Clear();
-  clear_has_header();
+void ScanRequest::clear_kvheader() {
+  if (kvheader_ != NULL) kvheader_->::cockroach::proto::KVRequestHeader::Clear();
+  clear_has_kvheader();
 }
- const ::cockroach::proto::RequestHeader& ScanRequest::header() const {
-  // @@protoc_insertion_point(field_get:cockroach.proto.ScanRequest.header)
-  return header_ != NULL ? *header_ : *default_instance_->header_;
+ const ::cockroach::proto::KVRequestHeader& ScanRequest::kvheader() const {
+  // @@protoc_insertion_point(field_get:cockroach.proto.ScanRequest.kvheader)
+  return kvheader_ != NULL ? *kvheader_ : *default_instance_->kvheader_;
 }
- ::cockroach::proto::RequestHeader* ScanRequest::mutable_header() {
-  set_has_header();
-  if (header_ == NULL) {
-    header_ = new ::cockroach::proto::RequestHeader;
+ ::cockroach::proto::KVRequestHeader* ScanRequest::mutable_kvheader() {
+  set_has_kvheader();
+  if (kvheader_ == NULL) {
+    kvheader_ = new ::cockroach::proto::KVRequestHeader;
   }
-  // @@protoc_insertion_point(field_mutable:cockroach.proto.ScanRequest.header)
-  return header_;
+  // @@protoc_insertion_point(field_mutable:cockroach.proto.ScanRequest.kvheader)
+  return kvheader_;
 }
- ::cockroach::proto::RequestHeader* ScanRequest::release_header() {
-  clear_has_header();
-  ::cockroach::proto::RequestHeader* temp = header_;
-  header_ = NULL;
+ ::cockroach::proto::KVRequestHeader* ScanRequest::release_kvheader() {
+  clear_has_kvheader();
+  ::cockroach::proto::KVRequestHeader* temp = kvheader_;
+  kvheader_ = NULL;
   return temp;
 }
- void ScanRequest::set_allocated_header(::cockroach::proto::RequestHeader* header) {
-  delete header_;
-  header_ = header;
-  if (header) {
-    set_has_header();
+ void ScanRequest::set_allocated_kvheader(::cockroach::proto::KVRequestHeader* kvheader) {
+  delete kvheader_;
+  kvheader_ = kvheader;
+  if (kvheader) {
+    set_has_kvheader();
   } else {
-    clear_has_header();
+    clear_has_kvheader();
   }
-  // @@protoc_insertion_point(field_set_allocated:cockroach.proto.ScanRequest.header)
+  // @@protoc_insertion_point(field_set_allocated:cockroach.proto.ScanRequest.kvheader)
 }
 
 // optional int64 max_results = 2;
@@ -7154,7 +7773,7 @@ void ScanRequest::clear_max_results() {
 // ===================================================================
 
 #ifndef _MSC_VER
-const int ScanResponse::kHeaderFieldNumber;
+const int ScanResponse::kKvheaderFieldNumber;
 const int ScanResponse::kRowsFieldNumber;
 #endif  // !_MSC_VER
 
@@ -7165,7 +7784,7 @@ ScanResponse::ScanResponse()
 }
 
 void ScanResponse::InitAsDefaultInstance() {
-  header_ = const_cast< ::cockroach::proto::ResponseHeader*>(&::cockroach::proto::ResponseHeader::default_instance());
+  kvheader_ = const_cast< ::cockroach::proto::KVResponseHeader*>(&::cockroach::proto::KVResponseHeader::default_instance());
 }
 
 ScanResponse::ScanResponse(const ScanResponse& from)
@@ -7178,7 +7797,7 @@ ScanResponse::ScanResponse(const ScanResponse& from)
 
 void ScanResponse::SharedCtor() {
   _cached_size_ = 0;
-  header_ = NULL;
+  kvheader_ = NULL;
   ::memset(_has_bits_, 0, sizeof(_has_bits_));
 }
 
@@ -7189,7 +7808,7 @@ ScanResponse::~ScanResponse() {
 
 void ScanResponse::SharedDtor() {
   if (this != default_instance_) {
-    delete header_;
+    delete kvheader_;
   }
 }
 
@@ -7219,8 +7838,8 @@ ScanResponse* ScanResponse::New(::google::protobuf::Arena* arena) const {
 }
 
 void ScanResponse::Clear() {
-  if (has_header()) {
-    if (header_ != NULL) header_->::cockroach::proto::ResponseHeader::Clear();
+  if (has_kvheader()) {
+    if (kvheader_ != NULL) kvheader_->::cockroach::proto::KVResponseHeader::Clear();
   }
   rows_.Clear();
   ::memset(_has_bits_, 0, sizeof(_has_bits_));
@@ -7239,11 +7858,11 @@ bool ScanResponse::MergePartialFromCodedStream(
     tag = p.first;
     if (!p.second) goto handle_unusual;
     switch (::google::protobuf::internal::WireFormatLite::GetTagFieldNumber(tag)) {
-      // optional .cockroach.proto.ResponseHeader header = 1;
+      // optional .cockroach.proto.KVResponseHeader kvheader = 1;
       case 1: {
         if (tag == 10) {
           DO_(::google::protobuf::internal::WireFormatLite::ReadMessageNoVirtual(
-               input, mutable_header()));
+               input, mutable_kvheader()));
         } else {
           goto handle_unusual;
         }
@@ -7293,10 +7912,10 @@ failure:
 void ScanResponse::SerializeWithCachedSizes(
     ::google::protobuf::io::CodedOutputStream* output) const {
   // @@protoc_insertion_point(serialize_start:cockroach.proto.ScanResponse)
-  // optional .cockroach.proto.ResponseHeader header = 1;
-  if (has_header()) {
+  // optional .cockroach.proto.KVResponseHeader kvheader = 1;
+  if (has_kvheader()) {
     ::google::protobuf::internal::WireFormatLite::WriteMessageMaybeToArray(
-      1, *this->header_, output);
+      1, *this->kvheader_, output);
   }
 
   // repeated .cockroach.proto.KeyValue rows = 2;
@@ -7315,11 +7934,11 @@ void ScanResponse::SerializeWithCachedSizes(
 ::google::protobuf::uint8* ScanResponse::SerializeWithCachedSizesToArray(
     ::google::protobuf::uint8* target) const {
   // @@protoc_insertion_point(serialize_to_array_start:cockroach.proto.ScanResponse)
-  // optional .cockroach.proto.ResponseHeader header = 1;
-  if (has_header()) {
+  // optional .cockroach.proto.KVResponseHeader kvheader = 1;
+  if (has_kvheader()) {
     target = ::google::protobuf::internal::WireFormatLite::
       WriteMessageNoVirtualToArray(
-        1, *this->header_, target);
+        1, *this->kvheader_, target);
   }
 
   // repeated .cockroach.proto.KeyValue rows = 2;
@@ -7340,11 +7959,11 @@ void ScanResponse::SerializeWithCachedSizes(
 int ScanResponse::ByteSize() const {
   int total_size = 0;
 
-  // optional .cockroach.proto.ResponseHeader header = 1;
-  if (has_header()) {
+  // optional .cockroach.proto.KVResponseHeader kvheader = 1;
+  if (has_kvheader()) {
     total_size += 1 +
       ::google::protobuf::internal::WireFormatLite::MessageSizeNoVirtual(
-        *this->header_);
+        *this->kvheader_);
   }
 
   // repeated .cockroach.proto.KeyValue rows = 2;
@@ -7382,8 +8001,8 @@ void ScanResponse::MergeFrom(const ScanResponse& from) {
   if (GOOGLE_PREDICT_FALSE(&from == this)) MergeFromFail(__LINE__);
   rows_.MergeFrom(from.rows_);
   if (from._has_bits_[0 / 32] & (0xffu << (0 % 32))) {
-    if (from.has_header()) {
-      mutable_header()->::cockroach::proto::ResponseHeader::MergeFrom(from.header());
+    if (from.has_kvheader()) {
+      mutable_kvheader()->::cockroach::proto::KVResponseHeader::MergeFrom(from.kvheader());
     }
   }
   if (from._internal_metadata_.have_unknown_fields()) {
@@ -7413,7 +8032,7 @@ void ScanResponse::Swap(ScanResponse* other) {
   InternalSwap(other);
 }
 void ScanResponse::InternalSwap(ScanResponse* other) {
-  std::swap(header_, other->header_);
+  std::swap(kvheader_, other->kvheader_);
   rows_.UnsafeArenaSwap(&other->rows_);
   std::swap(_has_bits_[0], other->_has_bits_[0]);
   _internal_metadata_.Swap(&other->_internal_metadata_);
@@ -7431,47 +8050,47 @@ void ScanResponse::InternalSwap(ScanResponse* other) {
 #if PROTOBUF_INLINE_NOT_IN_HEADERS
 // ScanResponse
 
-// optional .cockroach.proto.ResponseHeader header = 1;
-bool ScanResponse::has_header() const {
+// optional .cockroach.proto.KVResponseHeader kvheader = 1;
+bool ScanResponse::has_kvheader() const {
   return (_has_bits_[0] & 0x00000001u) != 0;
 }
-void ScanResponse::set_has_header() {
+void ScanResponse::set_has_kvheader() {
   _has_bits_[0] |= 0x00000001u;
 }
-void ScanResponse::clear_has_header() {
+void ScanResponse::clear_has_kvheader() {
   _has_bits_[0] &= ~0x00000001u;
 }
-void ScanResponse::clear_header() {
-  if (header_ != NULL) header_->::cockroach::proto::ResponseHeader::Clear();
-  clear_has_header();
+void ScanResponse::clear_kvheader() {
+  if (kvheader_ != NULL) kvheader_->::cockroach::proto::KVResponseHeader::Clear();
+  clear_has_kvheader();
 }
- const ::cockroach::proto::ResponseHeader& ScanResponse::header() const {
-  // @@protoc_insertion_point(field_get:cockroach.proto.ScanResponse.header)
-  return header_ != NULL ? *header_ : *default_instance_->header_;
+ const ::cockroach::proto::KVResponseHeader& ScanResponse::kvheader() const {
+  // @@protoc_insertion_point(field_get:cockroach.proto.ScanResponse.kvheader)
+  return kvheader_ != NULL ? *kvheader_ : *default_instance_->kvheader_;
 }
- ::cockroach::proto::ResponseHeader* ScanResponse::mutable_header() {
-  set_has_header();
-  if (header_ == NULL) {
-    header_ = new ::cockroach::proto::ResponseHeader;
+ ::cockroach::proto::KVResponseHeader* ScanResponse::mutable_kvheader() {
+  set_has_kvheader();
+  if (kvheader_ == NULL) {
+    kvheader_ = new ::cockroach::proto::KVResponseHeader;
   }
-  // @@protoc_insertion_point(field_mutable:cockroach.proto.ScanResponse.header)
-  return header_;
+  // @@protoc_insertion_point(field_mutable:cockroach.proto.ScanResponse.kvheader)
+  return kvheader_;
 }
- ::cockroach::proto::ResponseHeader* ScanResponse::release_header() {
-  clear_has_header();
-  ::cockroach::proto::ResponseHeader* temp = header_;
-  header_ = NULL;
+ ::cockroach::proto::KVResponseHeader* ScanResponse::release_kvheader() {
+  clear_has_kvheader();
+  ::cockroach::proto::KVResponseHeader* temp = kvheader_;
+  kvheader_ = NULL;
   return temp;
 }
- void ScanResponse::set_allocated_header(::cockroach::proto::ResponseHeader* header) {
-  delete header_;
-  header_ = header;
-  if (header) {
-    set_has_header();
+ void ScanResponse::set_allocated_kvheader(::cockroach::proto::KVResponseHeader* kvheader) {
+  delete kvheader_;
+  kvheader_ = kvheader;
+  if (kvheader) {
+    set_has_kvheader();
   } else {
-    clear_has_header();
+    clear_has_kvheader();
   }
-  // @@protoc_insertion_point(field_set_allocated:cockroach.proto.ScanResponse.header)
+  // @@protoc_insertion_point(field_set_allocated:cockroach.proto.ScanResponse.kvheader)
 }
 
 // repeated .cockroach.proto.KeyValue rows = 2;
@@ -7509,7 +8128,7 @@ ScanResponse::mutable_rows() {
 // ===================================================================
 
 #ifndef _MSC_VER
-const int EndTransactionRequest::kHeaderFieldNumber;
+const int EndTransactionRequest::kKvheaderFieldNumber;
 const int EndTransactionRequest::kCommitFieldNumber;
 const int EndTransactionRequest::kInternalCommitTriggerFieldNumber;
 #endif  // !_MSC_VER
@@ -7521,7 +8140,7 @@ EndTransactionRequest::EndTransactionRequest()
 }
 
 void EndTransactionRequest::InitAsDefaultInstance() {
-  header_ = const_cast< ::cockroach::proto::RequestHeader*>(&::cockroach::proto::RequestHeader::default_instance());
+  kvheader_ = const_cast< ::cockroach::proto::KVRequestHeader*>(&::cockroach::proto::KVRequestHeader::default_instance());
   internal_commit_trigger_ = const_cast< ::cockroach::proto::InternalCommitTrigger*>(&::cockroach::proto::InternalCommitTrigger::default_instance());
 }
 
@@ -7535,7 +8154,7 @@ EndTransactionRequest::EndTransactionRequest(const EndTransactionRequest& from)
 
 void EndTransactionRequest::SharedCtor() {
   _cached_size_ = 0;
-  header_ = NULL;
+  kvheader_ = NULL;
   commit_ = false;
   internal_commit_trigger_ = NULL;
   ::memset(_has_bits_, 0, sizeof(_has_bits_));
@@ -7548,7 +8167,7 @@ EndTransactionRequest::~EndTransactionRequest() {
 
 void EndTransactionRequest::SharedDtor() {
   if (this != default_instance_) {
-    delete header_;
+    delete kvheader_;
     delete internal_commit_trigger_;
   }
 }
@@ -7580,8 +8199,8 @@ EndTransactionRequest* EndTransactionRequest::New(::google::protobuf::Arena* are
 
 void EndTransactionRequest::Clear() {
   if (_has_bits_[0 / 32] & 7u) {
-    if (has_header()) {
-      if (header_ != NULL) header_->::cockroach::proto::RequestHeader::Clear();
+    if (has_kvheader()) {
+      if (kvheader_ != NULL) kvheader_->::cockroach::proto::KVRequestHeader::Clear();
     }
     commit_ = false;
     if (has_internal_commit_trigger()) {
@@ -7604,11 +8223,11 @@ bool EndTransactionRequest::MergePartialFromCodedStream(
     tag = p.first;
     if (!p.second) goto handle_unusual;
     switch (::google::protobuf::internal::WireFormatLite::GetTagFieldNumber(tag)) {
-      // optional .cockroach.proto.RequestHeader header = 1;
+      // optional .cockroach.proto.KVRequestHeader kvheader = 1;
       case 1: {
         if (tag == 10) {
           DO_(::google::protobuf::internal::WireFormatLite::ReadMessageNoVirtual(
-               input, mutable_header()));
+               input, mutable_kvheader()));
         } else {
           goto handle_unusual;
         }
@@ -7669,10 +8288,10 @@ failure:
 void EndTransactionRequest::SerializeWithCachedSizes(
     ::google::protobuf::io::CodedOutputStream* output) const {
   // @@protoc_insertion_point(serialize_start:cockroach.proto.EndTransactionRequest)
-  // optional .cockroach.proto.RequestHeader header = 1;
-  if (has_header()) {
+  // optional .cockroach.proto.KVRequestHeader kvheader = 1;
+  if (has_kvheader()) {
     ::google::protobuf::internal::WireFormatLite::WriteMessageMaybeToArray(
-      1, *this->header_, output);
+      1, *this->kvheader_, output);
   }
 
   // optional bool commit = 2;
@@ -7696,11 +8315,11 @@ void EndTransactionRequest::SerializeWithCachedSizes(
 ::google::protobuf::uint8* EndTransactionRequest::SerializeWithCachedSizesToArray(
     ::google::protobuf::uint8* target) const {
   // @@protoc_insertion_point(serialize_to_array_start:cockroach.proto.EndTransactionRequest)
-  // optional .cockroach.proto.RequestHeader header = 1;
-  if (has_header()) {
+  // optional .cockroach.proto.KVRequestHeader kvheader = 1;
+  if (has_kvheader()) {
     target = ::google::protobuf::internal::WireFormatLite::
       WriteMessageNoVirtualToArray(
-        1, *this->header_, target);
+        1, *this->kvheader_, target);
   }
 
   // optional bool commit = 2;
@@ -7727,11 +8346,11 @@ int EndTransactionRequest::ByteSize() const {
   int total_size = 0;
 
   if (_has_bits_[0 / 32] & 7) {
-    // optional .cockroach.proto.RequestHeader header = 1;
-    if (has_header()) {
+    // optional .cockroach.proto.KVRequestHeader kvheader = 1;
+    if (has_kvheader()) {
       total_size += 1 +
         ::google::protobuf::internal::WireFormatLite::MessageSizeNoVirtual(
-          *this->header_);
+          *this->kvheader_);
     }
 
     // optional bool commit = 2;
@@ -7773,8 +8392,8 @@ void EndTransactionRequest::MergeFrom(const ::google::protobuf::Message& from) {
 void EndTransactionRequest::MergeFrom(const EndTransactionRequest& from) {
   if (GOOGLE_PREDICT_FALSE(&from == this)) MergeFromFail(__LINE__);
   if (from._has_bits_[0 / 32] & (0xffu << (0 % 32))) {
-    if (from.has_header()) {
-      mutable_header()->::cockroach::proto::RequestHeader::MergeFrom(from.header());
+    if (from.has_kvheader()) {
+      mutable_kvheader()->::cockroach::proto::KVRequestHeader::MergeFrom(from.kvheader());
     }
     if (from.has_commit()) {
       set_commit(from.commit());
@@ -7810,7 +8429,7 @@ void EndTransactionRequest::Swap(EndTransactionRequest* other) {
   InternalSwap(other);
 }
 void EndTransactionRequest::InternalSwap(EndTransactionRequest* other) {
-  std::swap(header_, other->header_);
+  std::swap(kvheader_, other->kvheader_);
   std::swap(commit_, other->commit_);
   std::swap(internal_commit_trigger_, other->internal_commit_trigger_);
   std::swap(_has_bits_[0], other->_has_bits_[0]);
@@ -7829,47 +8448,47 @@ void EndTransactionRequest::InternalSwap(EndTransactionRequest* other) {
 #if PROTOBUF_INLINE_NOT_IN_HEADERS
 // EndTransactionRequest
 
-// optional .cockroach.proto.RequestHeader header = 1;
-bool EndTransactionRequest::has_header() const {
+// optional .cockroach.proto.KVRequestHeader kvheader = 1;
+bool EndTransactionRequest::has_kvheader() const {
   return (_has_bits_[0] & 0x00000001u) != 0;
 }
-void EndTransactionRequest::set_has_header() {
+void EndTransactionRequest::set_has_kvheader() {
   _has_bits_[0] |= 0x00000001u;
 }
-void EndTransactionRequest::clear_has_header() {
+void EndTransactionRequest::clear_has_kvheader() {
   _has_bits_[0] &= ~0x00000001u;
 }
-void EndTransactionRequest::clear_header() {
-  if (header_ != NULL) header_->::cockroach::proto::RequestHeader::Clear();
-  clear_has_header();
+void EndTransactionRequest::clear_kvheader() {
+  if (kvheader_ != NULL) kvheader_->::cockroach::proto::KVRequestHeader::Clear();
+  clear_has_kvheader();
 }
- const ::cockroach::proto::RequestHeader& EndTransactionRequest::header() const {
-  // @@protoc_insertion_point(field_get:cockroach.proto.EndTransactionRequest.header)
-  return header_ != NULL ? *header_ : *default_instance_->header_;
+ const ::cockroach::proto::KVRequestHeader& EndTransactionRequest::kvheader() const {
+  // @@protoc_insertion_point(field_get:cockroach.proto.EndTransactionRequest.kvheader)
+  return kvheader_ != NULL ? *kvheader_ : *default_instance_->kvheader_;
 }
- ::cockroach::proto::RequestHeader* EndTransactionRequest::mutable_header() {
-  set_has_header();
-  if (header_ == NULL) {
-    header_ = new ::cockroach::proto::RequestHeader;
+ ::cockroach::proto::KVRequestHeader* EndTransactionRequest::mutable_kvheader() {
+  set_has_kvheader();
+  if (kvheader_ == NULL) {
+    kvheader_ = new ::cockroach::proto::KVRequestHeader;
   }
-  // @@protoc_insertion_point(field_mutable:cockroach.proto.EndTransactionRequest.header)
-  return header_;
+  // @@protoc_insertion_point(field_mutable:cockroach.proto.EndTransactionRequest.kvheader)
+  return kvheader_;
 }
- ::cockroach::proto::RequestHeader* EndTransactionRequest::release_header() {
-  clear_has_header();
-  ::cockroach::proto::RequestHeader* temp = header_;
-  header_ = NULL;
+ ::cockroach::proto::KVRequestHeader* EndTransactionRequest::release_kvheader() {
+  clear_has_kvheader();
+  ::cockroach::proto::KVRequestHeader* temp = kvheader_;
+  kvheader_ = NULL;
   return temp;
 }
- void EndTransactionRequest::set_allocated_header(::cockroach::proto::RequestHeader* header) {
-  delete header_;
-  header_ = header;
-  if (header) {
-    set_has_header();
+ void EndTransactionRequest::set_allocated_kvheader(::cockroach::proto::KVRequestHeader* kvheader) {
+  delete kvheader_;
+  kvheader_ = kvheader;
+  if (kvheader) {
+    set_has_kvheader();
   } else {
-    clear_has_header();
+    clear_has_kvheader();
   }
-  // @@protoc_insertion_point(field_set_allocated:cockroach.proto.EndTransactionRequest.header)
+  // @@protoc_insertion_point(field_set_allocated:cockroach.proto.EndTransactionRequest.kvheader)
 }
 
 // optional bool commit = 2;
@@ -7944,7 +8563,7 @@ void EndTransactionRequest::clear_internal_commit_trigger() {
 // ===================================================================
 
 #ifndef _MSC_VER
-const int EndTransactionResponse::kHeaderFieldNumber;
+const int EndTransactionResponse::kKvheaderFieldNumber;
 const int EndTransactionResponse::kCommitWaitFieldNumber;
 const int EndTransactionResponse::kResolvedFieldNumber;
 #endif  // !_MSC_VER
@@ -7956,7 +8575,7 @@ EndTransactionResponse::EndTransactionResponse()
 }
 
 void EndTransactionResponse::InitAsDefaultInstance() {
-  header_ = const_cast< ::cockroach::proto::ResponseHeader*>(&::cockroach::proto::ResponseHeader::default_instance());
+  kvheader_ = const_cast< ::cockroach::proto::KVResponseHeader*>(&::cockroach::proto::KVResponseHeader::default_instance());
 }
 
 EndTransactionResponse::EndTransactionResponse(const EndTransactionResponse& from)
@@ -7970,7 +8589,7 @@ EndTransactionResponse::EndTransactionResponse(const EndTransactionResponse& fro
 void EndTransactionResponse::SharedCtor() {
   ::google::protobuf::internal::GetEmptyString();
   _cached_size_ = 0;
-  header_ = NULL;
+  kvheader_ = NULL;
   commit_wait_ = GOOGLE_LONGLONG(0);
   ::memset(_has_bits_, 0, sizeof(_has_bits_));
 }
@@ -7982,7 +8601,7 @@ EndTransactionResponse::~EndTransactionResponse() {
 
 void EndTransactionResponse::SharedDtor() {
   if (this != default_instance_) {
-    delete header_;
+    delete kvheader_;
   }
 }
 
@@ -8013,8 +8632,8 @@ EndTransactionResponse* EndTransactionResponse::New(::google::protobuf::Arena* a
 
 void EndTransactionResponse::Clear() {
   if (_has_bits_[0 / 32] & 3u) {
-    if (has_header()) {
-      if (header_ != NULL) header_->::cockroach::proto::ResponseHeader::Clear();
+    if (has_kvheader()) {
+      if (kvheader_ != NULL) kvheader_->::cockroach::proto::KVResponseHeader::Clear();
     }
     commit_wait_ = GOOGLE_LONGLONG(0);
   }
@@ -8035,11 +8654,11 @@ bool EndTransactionResponse::MergePartialFromCodedStream(
     tag = p.first;
     if (!p.second) goto handle_unusual;
     switch (::google::protobuf::internal::WireFormatLite::GetTagFieldNumber(tag)) {
-      // optional .cockroach.proto.ResponseHeader header = 1;
+      // optional .cockroach.proto.KVResponseHeader kvheader = 1;
       case 1: {
         if (tag == 10) {
           DO_(::google::protobuf::internal::WireFormatLite::ReadMessageNoVirtual(
-               input, mutable_header()));
+               input, mutable_kvheader()));
         } else {
           goto handle_unusual;
         }
@@ -8101,10 +8720,10 @@ failure:
 void EndTransactionResponse::SerializeWithCachedSizes(
     ::google::protobuf::io::CodedOutputStream* output) const {
   // @@protoc_insertion_point(serialize_start:cockroach.proto.EndTransactionResponse)
-  // optional .cockroach.proto.ResponseHeader header = 1;
-  if (has_header()) {
+  // optional .cockroach.proto.KVResponseHeader kvheader = 1;
+  if (has_kvheader()) {
     ::google::protobuf::internal::WireFormatLite::WriteMessageMaybeToArray(
-      1, *this->header_, output);
+      1, *this->kvheader_, output);
   }
 
   // optional int64 commit_wait = 2;
@@ -8128,11 +8747,11 @@ void EndTransactionResponse::SerializeWithCachedSizes(
 ::google::protobuf::uint8* EndTransactionResponse::SerializeWithCachedSizesToArray(
     ::google::protobuf::uint8* target) const {
   // @@protoc_insertion_point(serialize_to_array_start:cockroach.proto.EndTransactionResponse)
-  // optional .cockroach.proto.ResponseHeader header = 1;
-  if (has_header()) {
+  // optional .cockroach.proto.KVResponseHeader kvheader = 1;
+  if (has_kvheader()) {
     target = ::google::protobuf::internal::WireFormatLite::
       WriteMessageNoVirtualToArray(
-        1, *this->header_, target);
+        1, *this->kvheader_, target);
   }
 
   // optional int64 commit_wait = 2;
@@ -8158,11 +8777,11 @@ int EndTransactionResponse::ByteSize() const {
   int total_size = 0;
 
   if (_has_bits_[0 / 32] & 3) {
-    // optional .cockroach.proto.ResponseHeader header = 1;
-    if (has_header()) {
+    // optional .cockroach.proto.KVResponseHeader kvheader = 1;
+    if (has_kvheader()) {
       total_size += 1 +
         ::google::protobuf::internal::WireFormatLite::MessageSizeNoVirtual(
-          *this->header_);
+          *this->kvheader_);
     }
 
     // optional int64 commit_wait = 2;
@@ -8207,8 +8826,8 @@ void EndTransactionResponse::MergeFrom(const EndTransactionResponse& from) {
   if (GOOGLE_PREDICT_FALSE(&from == this)) MergeFromFail(__LINE__);
   resolved_.MergeFrom(from.resolved_);
   if (from._has_bits_[0 / 32] & (0xffu << (0 % 32))) {
-    if (from.has_header()) {
-      mutable_header()->::cockroach::proto::ResponseHeader::MergeFrom(from.header());
+    if (from.has_kvheader()) {
+      mutable_kvheader()->::cockroach::proto::KVResponseHeader::MergeFrom(from.kvheader());
     }
     if (from.has_commit_wait()) {
       set_commit_wait(from.commit_wait());
@@ -8241,7 +8860,7 @@ void EndTransactionResponse::Swap(EndTransactionResponse* other) {
   InternalSwap(other);
 }
 void EndTransactionResponse::InternalSwap(EndTransactionResponse* other) {
-  std::swap(header_, other->header_);
+  std::swap(kvheader_, other->kvheader_);
   std::swap(commit_wait_, other->commit_wait_);
   resolved_.UnsafeArenaSwap(&other->resolved_);
   std::swap(_has_bits_[0], other->_has_bits_[0]);
@@ -8260,47 +8879,47 @@ void EndTransactionResponse::InternalSwap(EndTransactionResponse* other) {
 #if PROTOBUF_INLINE_NOT_IN_HEADERS
 // EndTransactionResponse
 
-// optional .cockroach.proto.ResponseHeader header = 1;
-bool EndTransactionResponse::has_header() const {
+// optional .cockroach.proto.KVResponseHeader kvheader = 1;
+bool EndTransactionResponse::has_kvheader() const {
   return (_has_bits_[0] & 0x00000001u) != 0;
 }
-void EndTransactionResponse::set_has_header() {
+void EndTransactionResponse::set_has_kvheader() {
   _has_bits_[0] |= 0x00000001u;
 }
-void EndTransactionResponse::clear_has_header() {
+void EndTransactionResponse::clear_has_kvheader() {
   _has_bits_[0] &= ~0x00000001u;
 }
-void EndTransactionResponse::clear_header() {
-  if (header_ != NULL) header_->::cockroach::proto::ResponseHeader::Clear();
-  clear_has_header();
+void EndTransactionResponse::clear_kvheader() {
+  if (kvheader_ != NULL) kvheader_->::cockroach::proto::KVResponseHeader::Clear();
+  clear_has_kvheader();
 }
- const ::cockroach::proto::ResponseHeader& EndTransactionResponse::header() const {
-  // @@protoc_insertion_point(field_get:cockroach.proto.EndTransactionResponse.header)
-  return header_ != NULL ? *header_ : *default_instance_->header_;
+ const ::cockroach::proto::KVResponseHeader& EndTransactionResponse::kvheader() const {
+  // @@protoc_insertion_point(field_get:cockroach.proto.EndTransactionResponse.kvheader)
+  return kvheader_ != NULL ? *kvheader_ : *default_instance_->kvheader_;
 }
- ::cockroach::proto::ResponseHeader* EndTransactionResponse::mutable_header() {
-  set_has_header();
-  if (header_ == NULL) {
-    header_ = new ::cockroach::proto::ResponseHeader;
+ ::cockroach::proto::KVResponseHeader* EndTransactionResponse::mutable_kvheader() {
+  set_has_kvheader();
+  if (kvheader_ == NULL) {
+    kvheader_ = new ::cockroach::proto::KVResponseHeader;
   }
-  // @@protoc_insertion_point(field_mutable:cockroach.proto.EndTransactionResponse.header)
-  return header_;
+  // @@protoc_insertion_point(field_mutable:cockroach.proto.EndTransactionResponse.kvheader)
+  return kvheader_;
 }
- ::cockroach::proto::ResponseHeader* EndTransactionResponse::release_header() {
-  clear_has_header();
-  ::cockroach::proto::ResponseHeader* temp = header_;
-  header_ = NULL;
+ ::cockroach::proto::KVResponseHeader* EndTransactionResponse::release_kvheader() {
+  clear_has_kvheader();
+  ::cockroach::proto::KVResponseHeader* temp = kvheader_;
+  kvheader_ = NULL;
   return temp;
 }
- void EndTransactionResponse::set_allocated_header(::cockroach::proto::ResponseHeader* header) {
-  delete header_;
-  header_ = header;
-  if (header) {
-    set_has_header();
+ void EndTransactionResponse::set_allocated_kvheader(::cockroach::proto::KVResponseHeader* kvheader) {
+  delete kvheader_;
+  kvheader_ = kvheader;
+  if (kvheader) {
+    set_has_kvheader();
   } else {
-    clear_has_header();
+    clear_has_kvheader();
   }
-  // @@protoc_insertion_point(field_set_allocated:cockroach.proto.EndTransactionResponse.header)
+  // @@protoc_insertion_point(field_set_allocated:cockroach.proto.EndTransactionResponse.kvheader)
 }
 
 // optional int64 commit_wait = 2;
@@ -10270,7 +10889,7 @@ ResponseUnion::ValueCase ResponseUnion::value_case() const {
 // ===================================================================
 
 #ifndef _MSC_VER
-const int BatchRequest::kHeaderFieldNumber;
+const int BatchRequest::kKvheaderFieldNumber;
 const int BatchRequest::kRequestsFieldNumber;
 #endif  // !_MSC_VER
 
@@ -10281,7 +10900,7 @@ BatchRequest::BatchRequest()
 }
 
 void BatchRequest::InitAsDefaultInstance() {
-  header_ = const_cast< ::cockroach::proto::RequestHeader*>(&::cockroach::proto::RequestHeader::default_instance());
+  kvheader_ = const_cast< ::cockroach::proto::KVRequestHeader*>(&::cockroach::proto::KVRequestHeader::default_instance());
 }
 
 BatchRequest::BatchRequest(const BatchRequest& from)
@@ -10294,7 +10913,7 @@ BatchRequest::BatchRequest(const BatchRequest& from)
 
 void BatchRequest::SharedCtor() {
   _cached_size_ = 0;
-  header_ = NULL;
+  kvheader_ = NULL;
   ::memset(_has_bits_, 0, sizeof(_has_bits_));
 }
 
@@ -10305,7 +10924,7 @@ BatchRequest::~BatchRequest() {
 
 void BatchRequest::SharedDtor() {
   if (this != default_instance_) {
-    delete header_;
+    delete kvheader_;
   }
 }
 
@@ -10335,8 +10954,8 @@ BatchRequest* BatchRequest::New(::google::protobuf::Arena* arena) const {
 }
 
 void BatchRequest::Clear() {
-  if (has_header()) {
-    if (header_ != NULL) header_->::cockroach::proto::RequestHeader::Clear();
+  if (has_kvheader()) {
+    if (kvheader_ != NULL) kvheader_->::cockroach::proto::KVRequestHeader::Clear();
   }
   requests_.Clear();
   ::memset(_has_bits_, 0, sizeof(_has_bits_));
@@ -10355,11 +10974,11 @@ bool BatchRequest::MergePartialFromCodedStream(
     tag = p.first;
     if (!p.second) goto handle_unusual;
     switch (::google::protobuf::internal::WireFormatLite::GetTagFieldNumber(tag)) {
-      // optional .cockroach.proto.RequestHeader header = 1;
+      // optional .cockroach.proto.KVRequestHeader kvheader = 1;
       case 1: {
         if (tag == 10) {
           DO_(::google::protobuf::internal::WireFormatLite::ReadMessageNoVirtual(
-               input, mutable_header()));
+               input, mutable_kvheader()));
         } else {
           goto handle_unusual;
         }
@@ -10409,10 +11028,10 @@ failure:
 void BatchRequest::SerializeWithCachedSizes(
     ::google::protobuf::io::CodedOutputStream* output) const {
   // @@protoc_insertion_point(serialize_start:cockroach.proto.BatchRequest)
-  // optional .cockroach.proto.RequestHeader header = 1;
-  if (has_header()) {
+  // optional .cockroach.proto.KVRequestHeader kvheader = 1;
+  if (has_kvheader()) {
     ::google::protobuf::internal::WireFormatLite::WriteMessageMaybeToArray(
-      1, *this->header_, output);
+      1, *this->kvheader_, output);
   }
 
   // repeated .cockroach.proto.RequestUnion requests = 2;
@@ -10431,11 +11050,11 @@ void BatchRequest::SerializeWithCachedSizes(
 ::google::protobuf::uint8* BatchRequest::SerializeWithCachedSizesToArray(
     ::google::protobuf::uint8* target) const {
   // @@protoc_insertion_point(serialize_to_array_start:cockroach.proto.BatchRequest)
-  // optional .cockroach.proto.RequestHeader header = 1;
-  if (has_header()) {
+  // optional .cockroach.proto.KVRequestHeader kvheader = 1;
+  if (has_kvheader()) {
     target = ::google::protobuf::internal::WireFormatLite::
       WriteMessageNoVirtualToArray(
-        1, *this->header_, target);
+        1, *this->kvheader_, target);
   }
 
   // repeated .cockroach.proto.RequestUnion requests = 2;
@@ -10456,11 +11075,11 @@ void BatchRequest::SerializeWithCachedSizes(
 int BatchRequest::ByteSize() const {
   int total_size = 0;
 
-  // optional .cockroach.proto.RequestHeader header = 1;
-  if (has_header()) {
+  // optional .cockroach.proto.KVRequestHeader kvheader = 1;
+  if (has_kvheader()) {
     total_size += 1 +
       ::google::protobuf::internal::WireFormatLite::MessageSizeNoVirtual(
-        *this->header_);
+        *this->kvheader_);
   }
 
   // repeated .cockroach.proto.RequestUnion requests = 2;
@@ -10498,8 +11117,8 @@ void BatchRequest::MergeFrom(const BatchRequest& from) {
   if (GOOGLE_PREDICT_FALSE(&from == this)) MergeFromFail(__LINE__);
   requests_.MergeFrom(from.requests_);
   if (from._has_bits_[0 / 32] & (0xffu << (0 % 32))) {
-    if (from.has_header()) {
-      mutable_header()->::cockroach::proto::RequestHeader::MergeFrom(from.header());
+    if (from.has_kvheader()) {
+      mutable_kvheader()->::cockroach::proto::KVRequestHeader::MergeFrom(from.kvheader());
     }
   }
   if (from._internal_metadata_.have_unknown_fields()) {
@@ -10529,7 +11148,7 @@ void BatchRequest::Swap(BatchRequest* other) {
   InternalSwap(other);
 }
 void BatchRequest::InternalSwap(BatchRequest* other) {
-  std::swap(header_, other->header_);
+  std::swap(kvheader_, other->kvheader_);
   requests_.UnsafeArenaSwap(&other->requests_);
   std::swap(_has_bits_[0], other->_has_bits_[0]);
   _internal_metadata_.Swap(&other->_internal_metadata_);
@@ -10547,47 +11166,47 @@ void BatchRequest::InternalSwap(BatchRequest* other) {
 #if PROTOBUF_INLINE_NOT_IN_HEADERS
 // BatchRequest
 
-// optional .cockroach.proto.RequestHeader header = 1;
-bool BatchRequest::has_header() const {
+// optional .cockroach.proto.KVRequestHeader kvheader = 1;
+bool BatchRequest::has_kvheader() const {
   return (_has_bits_[0] & 0x00000001u) != 0;
 }
-void BatchRequest::set_has_header() {
+void BatchRequest::set_has_kvheader() {
   _has_bits_[0] |= 0x00000001u;
 }
-void BatchRequest::clear_has_header() {
+void BatchRequest::clear_has_kvheader() {
   _has_bits_[0] &= ~0x00000001u;
 }
-void BatchRequest::clear_header() {
-  if (header_ != NULL) header_->::cockroach::proto::RequestHeader::Clear();
-  clear_has_header();
+void BatchRequest::clear_kvheader() {
+  if (kvheader_ != NULL) kvheader_->::cockroach::proto::KVRequestHeader::Clear();
+  clear_has_kvheader();
 }
- const ::cockroach::proto::RequestHeader& BatchRequest::header() const {
-  // @@protoc_insertion_point(field_get:cockroach.proto.BatchRequest.header)
-  return header_ != NULL ? *header_ : *default_instance_->header_;
+ const ::cockroach::proto::KVRequestHeader& BatchRequest::kvheader() const {
+  // @@protoc_insertion_point(field_get:cockroach.proto.BatchRequest.kvheader)
+  return kvheader_ != NULL ? *kvheader_ : *default_instance_->kvheader_;
 }
- ::cockroach::proto::RequestHeader* BatchRequest::mutable_header() {
-  set_has_header();
-  if (header_ == NULL) {
-    header_ = new ::cockroach::proto::RequestHeader;
+ ::cockroach::proto::KVRequestHeader* BatchRequest::mutable_kvheader() {
+  set_has_kvheader();
+  if (kvheader_ == NULL) {
+    kvheader_ = new ::cockroach::proto::KVRequestHeader;
   }
-  // @@protoc_insertion_point(field_mutable:cockroach.proto.BatchRequest.header)
-  return header_;
+  // @@protoc_insertion_point(field_mutable:cockroach.proto.BatchRequest.kvheader)
+  return kvheader_;
 }
- ::cockroach::proto::RequestHeader* BatchRequest::release_header() {
-  clear_has_header();
-  ::cockroach::proto::RequestHeader* temp = header_;
-  header_ = NULL;
+ ::cockroach::proto::KVRequestHeader* BatchRequest::release_kvheader() {
+  clear_has_kvheader();
+  ::cockroach::proto::KVRequestHeader* temp = kvheader_;
+  kvheader_ = NULL;
   return temp;
 }
- void BatchRequest::set_allocated_header(::cockroach::proto::RequestHeader* header) {
-  delete header_;
-  header_ = header;
-  if (header) {
-    set_has_header();
+ void BatchRequest::set_allocated_kvheader(::cockroach::proto::KVRequestHeader* kvheader) {
+  delete kvheader_;
+  kvheader_ = kvheader;
+  if (kvheader) {
+    set_has_kvheader();
   } else {
-    clear_has_header();
+    clear_has_kvheader();
   }
-  // @@protoc_insertion_point(field_set_allocated:cockroach.proto.BatchRequest.header)
+  // @@protoc_insertion_point(field_set_allocated:cockroach.proto.BatchRequest.kvheader)
 }
 
 // repeated .cockroach.proto.RequestUnion requests = 2;
@@ -10625,7 +11244,7 @@ BatchRequest::mutable_requests() {
 // ===================================================================
 
 #ifndef _MSC_VER
-const int BatchResponse::kHeaderFieldNumber;
+const int BatchResponse::kKvheaderFieldNumber;
 const int BatchResponse::kResponsesFieldNumber;
 #endif  // !_MSC_VER
 
@@ -10636,7 +11255,7 @@ BatchResponse::BatchResponse()
 }
 
 void BatchResponse::InitAsDefaultInstance() {
-  header_ = const_cast< ::cockroach::proto::ResponseHeader*>(&::cockroach::proto::ResponseHeader::default_instance());
+  kvheader_ = const_cast< ::cockroach::proto::KVResponseHeader*>(&::cockroach::proto::KVResponseHeader::default_instance());
 }
 
 BatchResponse::BatchResponse(const BatchResponse& from)
@@ -10649,7 +11268,7 @@ BatchResponse::BatchResponse(const BatchResponse& from)
 
 void BatchResponse::SharedCtor() {
   _cached_size_ = 0;
-  header_ = NULL;
+  kvheader_ = NULL;
   ::memset(_has_bits_, 0, sizeof(_has_bits_));
 }
 
@@ -10660,7 +11279,7 @@ BatchResponse::~BatchResponse() {
 
 void BatchResponse::SharedDtor() {
   if (this != default_instance_) {
-    delete header_;
+    delete kvheader_;
   }
 }
 
@@ -10690,8 +11309,8 @@ BatchResponse* BatchResponse::New(::google::protobuf::Arena* arena) const {
 }
 
 void BatchResponse::Clear() {
-  if (has_header()) {
-    if (header_ != NULL) header_->::cockroach::proto::ResponseHeader::Clear();
+  if (has_kvheader()) {
+    if (kvheader_ != NULL) kvheader_->::cockroach::proto::KVResponseHeader::Clear();
   }
   responses_.Clear();
   ::memset(_has_bits_, 0, sizeof(_has_bits_));
@@ -10710,11 +11329,11 @@ bool BatchResponse::MergePartialFromCodedStream(
     tag = p.first;
     if (!p.second) goto handle_unusual;
     switch (::google::protobuf::internal::WireFormatLite::GetTagFieldNumber(tag)) {
-      // optional .cockroach.proto.ResponseHeader header = 1;
+      // optional .cockroach.proto.KVResponseHeader kvheader = 1;
       case 1: {
         if (tag == 10) {
           DO_(::google::protobuf::internal::WireFormatLite::ReadMessageNoVirtual(
-               input, mutable_header()));
+               input, mutable_kvheader()));
         } else {
           goto handle_unusual;
         }
@@ -10764,10 +11383,10 @@ failure:
 void BatchResponse::SerializeWithCachedSizes(
     ::google::protobuf::io::CodedOutputStream* output) const {
   // @@protoc_insertion_point(serialize_start:cockroach.proto.BatchResponse)
-  // optional .cockroach.proto.ResponseHeader header = 1;
-  if (has_header()) {
+  // optional .cockroach.proto.KVResponseHeader kvheader = 1;
+  if (has_kvheader()) {
     ::google::protobuf::internal::WireFormatLite::WriteMessageMaybeToArray(
-      1, *this->header_, output);
+      1, *this->kvheader_, output);
   }
 
   // repeated .cockroach.proto.ResponseUnion responses = 2;
@@ -10786,11 +11405,11 @@ void BatchResponse::SerializeWithCachedSizes(
 ::google::protobuf::uint8* BatchResponse::SerializeWithCachedSizesToArray(
     ::google::protobuf::uint8* target) const {
   // @@protoc_insertion_point(serialize_to_array_start:cockroach.proto.BatchResponse)
-  // optional .cockroach.proto.ResponseHeader header = 1;
-  if (has_header()) {
+  // optional .cockroach.proto.KVResponseHeader kvheader = 1;
+  if (has_kvheader()) {
     target = ::google::protobuf::internal::WireFormatLite::
       WriteMessageNoVirtualToArray(
-        1, *this->header_, target);
+        1, *this->kvheader_, target);
   }
 
   // repeated .cockroach.proto.ResponseUnion responses = 2;
@@ -10811,11 +11430,11 @@ void BatchResponse::SerializeWithCachedSizes(
 int BatchResponse::ByteSize() const {
   int total_size = 0;
 
-  // optional .cockroach.proto.ResponseHeader header = 1;
-  if (has_header()) {
+  // optional .cockroach.proto.KVResponseHeader kvheader = 1;
+  if (has_kvheader()) {
     total_size += 1 +
       ::google::protobuf::internal::WireFormatLite::MessageSizeNoVirtual(
-        *this->header_);
+        *this->kvheader_);
   }
 
   // repeated .cockroach.proto.ResponseUnion responses = 2;
@@ -10853,8 +11472,8 @@ void BatchResponse::MergeFrom(const BatchResponse& from) {
   if (GOOGLE_PREDICT_FALSE(&from == this)) MergeFromFail(__LINE__);
   responses_.MergeFrom(from.responses_);
   if (from._has_bits_[0 / 32] & (0xffu << (0 % 32))) {
-    if (from.has_header()) {
-      mutable_header()->::cockroach::proto::ResponseHeader::MergeFrom(from.header());
+    if (from.has_kvheader()) {
+      mutable_kvheader()->::cockroach::proto::KVResponseHeader::MergeFrom(from.kvheader());
     }
   }
   if (from._internal_metadata_.have_unknown_fields()) {
@@ -10884,7 +11503,7 @@ void BatchResponse::Swap(BatchResponse* other) {
   InternalSwap(other);
 }
 void BatchResponse::InternalSwap(BatchResponse* other) {
-  std::swap(header_, other->header_);
+  std::swap(kvheader_, other->kvheader_);
   responses_.UnsafeArenaSwap(&other->responses_);
   std::swap(_has_bits_[0], other->_has_bits_[0]);
   _internal_metadata_.Swap(&other->_internal_metadata_);
@@ -10902,47 +11521,47 @@ void BatchResponse::InternalSwap(BatchResponse* other) {
 #if PROTOBUF_INLINE_NOT_IN_HEADERS
 // BatchResponse
 
-// optional .cockroach.proto.ResponseHeader header = 1;
-bool BatchResponse::has_header() const {
+// optional .cockroach.proto.KVResponseHeader kvheader = 1;
+bool BatchResponse::has_kvheader() const {
   return (_has_bits_[0] & 0x00000001u) != 0;
 }
-void BatchResponse::set_has_header() {
+void BatchResponse::set_has_kvheader() {
   _has_bits_[0] |= 0x00000001u;
 }
-void BatchResponse::clear_has_header() {
+void BatchResponse::clear_has_kvheader() {
   _has_bits_[0] &= ~0x00000001u;
 }
-void BatchResponse::clear_header() {
-  if (header_ != NULL) header_->::cockroach::proto::ResponseHeader::Clear();
-  clear_has_header();
+void BatchResponse::clear_kvheader() {
+  if (kvheader_ != NULL) kvheader_->::cockroach::proto::KVResponseHeader::Clear();
+  clear_has_kvheader();
 }
- const ::cockroach::proto::ResponseHeader& BatchResponse::header() const {
-  // @@protoc_insertion_point(field_get:cockroach.proto.BatchResponse.header)
-  return header_ != NULL ? *header_ : *default_instance_->header_;
+ const ::cockroach::proto::KVResponseHeader& BatchResponse::kvheader() const {
+  // @@protoc_insertion_point(field_get:cockroach.proto.BatchResponse.kvheader)
+  return kvheader_ != NULL ? *kvheader_ : *default_instance_->kvheader_;
 }
- ::cockroach::proto::ResponseHeader* BatchResponse::mutable_header() {
-  set_has_header();
-  if (header_ == NULL) {
-    header_ = new ::cockroach::proto::ResponseHeader;
+ ::cockroach::proto::KVResponseHeader* BatchResponse::mutable_kvheader() {
+  set_has_kvheader();
+  if (kvheader_ == NULL) {
+    kvheader_ = new ::cockroach::proto::KVResponseHeader;
   }
-  // @@protoc_insertion_point(field_mutable:cockroach.proto.BatchResponse.header)
-  return header_;
+  // @@protoc_insertion_point(field_mutable:cockroach.proto.BatchResponse.kvheader)
+  return kvheader_;
 }
- ::cockroach::proto::ResponseHeader* BatchResponse::release_header() {
-  clear_has_header();
-  ::cockroach::proto::ResponseHeader* temp = header_;
-  header_ = NULL;
+ ::cockroach::proto::KVResponseHeader* BatchResponse::release_kvheader() {
+  clear_has_kvheader();
+  ::cockroach::proto::KVResponseHeader* temp = kvheader_;
+  kvheader_ = NULL;
   return temp;
 }
- void BatchResponse::set_allocated_header(::cockroach::proto::ResponseHeader* header) {
-  delete header_;
-  header_ = header;
-  if (header) {
-    set_has_header();
+ void BatchResponse::set_allocated_kvheader(::cockroach::proto::KVResponseHeader* kvheader) {
+  delete kvheader_;
+  kvheader_ = kvheader;
+  if (kvheader) {
+    set_has_kvheader();
   } else {
-    clear_has_header();
+    clear_has_kvheader();
   }
-  // @@protoc_insertion_point(field_set_allocated:cockroach.proto.BatchResponse.header)
+  // @@protoc_insertion_point(field_set_allocated:cockroach.proto.BatchResponse.kvheader)
 }
 
 // repeated .cockroach.proto.ResponseUnion responses = 2;
@@ -10980,7 +11599,7 @@ BatchResponse::mutable_responses() {
 // ===================================================================
 
 #ifndef _MSC_VER
-const int AdminSplitRequest::kHeaderFieldNumber;
+const int AdminSplitRequest::kKvheaderFieldNumber;
 const int AdminSplitRequest::kSplitKeyFieldNumber;
 #endif  // !_MSC_VER
 
@@ -10991,7 +11610,7 @@ AdminSplitRequest::AdminSplitRequest()
 }
 
 void AdminSplitRequest::InitAsDefaultInstance() {
-  header_ = const_cast< ::cockroach::proto::RequestHeader*>(&::cockroach::proto::RequestHeader::default_instance());
+  kvheader_ = const_cast< ::cockroach::proto::KVRequestHeader*>(&::cockroach::proto::KVRequestHeader::default_instance());
 }
 
 AdminSplitRequest::AdminSplitRequest(const AdminSplitRequest& from)
@@ -11005,7 +11624,7 @@ AdminSplitRequest::AdminSplitRequest(const AdminSplitRequest& from)
 void AdminSplitRequest::SharedCtor() {
   ::google::protobuf::internal::GetEmptyString();
   _cached_size_ = 0;
-  header_ = NULL;
+  kvheader_ = NULL;
   split_key_.UnsafeSetDefault(&::google::protobuf::internal::GetEmptyStringAlreadyInited());
   ::memset(_has_bits_, 0, sizeof(_has_bits_));
 }
@@ -11018,7 +11637,7 @@ AdminSplitRequest::~AdminSplitRequest() {
 void AdminSplitRequest::SharedDtor() {
   split_key_.DestroyNoArena(&::google::protobuf::internal::GetEmptyStringAlreadyInited());
   if (this != default_instance_) {
-    delete header_;
+    delete kvheader_;
   }
 }
 
@@ -11049,8 +11668,8 @@ AdminSplitRequest* AdminSplitRequest::New(::google::protobuf::Arena* arena) cons
 
 void AdminSplitRequest::Clear() {
   if (_has_bits_[0 / 32] & 3u) {
-    if (has_header()) {
-      if (header_ != NULL) header_->::cockroach::proto::RequestHeader::Clear();
+    if (has_kvheader()) {
+      if (kvheader_ != NULL) kvheader_->::cockroach::proto::KVRequestHeader::Clear();
     }
     if (has_split_key()) {
       split_key_.ClearToEmptyNoArena(&::google::protobuf::internal::GetEmptyStringAlreadyInited());
@@ -11072,11 +11691,11 @@ bool AdminSplitRequest::MergePartialFromCodedStream(
     tag = p.first;
     if (!p.second) goto handle_unusual;
     switch (::google::protobuf::internal::WireFormatLite::GetTagFieldNumber(tag)) {
-      // optional .cockroach.proto.RequestHeader header = 1;
+      // optional .cockroach.proto.KVRequestHeader kvheader = 1;
       case 1: {
         if (tag == 10) {
           DO_(::google::protobuf::internal::WireFormatLite::ReadMessageNoVirtual(
-               input, mutable_header()));
+               input, mutable_kvheader()));
         } else {
           goto handle_unusual;
         }
@@ -11122,10 +11741,10 @@ failure:
 void AdminSplitRequest::SerializeWithCachedSizes(
     ::google::protobuf::io::CodedOutputStream* output) const {
   // @@protoc_insertion_point(serialize_start:cockroach.proto.AdminSplitRequest)
-  // optional .cockroach.proto.RequestHeader header = 1;
-  if (has_header()) {
+  // optional .cockroach.proto.KVRequestHeader kvheader = 1;
+  if (has_kvheader()) {
     ::google::protobuf::internal::WireFormatLite::WriteMessageMaybeToArray(
-      1, *this->header_, output);
+      1, *this->kvheader_, output);
   }
 
   // optional bytes split_key = 2;
@@ -11144,11 +11763,11 @@ void AdminSplitRequest::SerializeWithCachedSizes(
 ::google::protobuf::uint8* AdminSplitRequest::SerializeWithCachedSizesToArray(
     ::google::protobuf::uint8* target) const {
   // @@protoc_insertion_point(serialize_to_array_start:cockroach.proto.AdminSplitRequest)
-  // optional .cockroach.proto.RequestHeader header = 1;
-  if (has_header()) {
+  // optional .cockroach.proto.KVRequestHeader kvheader = 1;
+  if (has_kvheader()) {
     target = ::google::protobuf::internal::WireFormatLite::
       WriteMessageNoVirtualToArray(
-        1, *this->header_, target);
+        1, *this->kvheader_, target);
   }
 
   // optional bytes split_key = 2;
@@ -11170,11 +11789,11 @@ int AdminSplitRequest::ByteSize() const {
   int total_size = 0;
 
   if (_has_bits_[0 / 32] & 3) {
-    // optional .cockroach.proto.RequestHeader header = 1;
-    if (has_header()) {
+    // optional .cockroach.proto.KVRequestHeader kvheader = 1;
+    if (has_kvheader()) {
       total_size += 1 +
         ::google::protobuf::internal::WireFormatLite::MessageSizeNoVirtual(
-          *this->header_);
+          *this->kvheader_);
     }
 
     // optional bytes split_key = 2;
@@ -11211,8 +11830,8 @@ void AdminSplitRequest::MergeFrom(const ::google::protobuf::Message& from) {
 void AdminSplitRequest::MergeFrom(const AdminSplitRequest& from) {
   if (GOOGLE_PREDICT_FALSE(&from == this)) MergeFromFail(__LINE__);
   if (from._has_bits_[0 / 32] & (0xffu << (0 % 32))) {
-    if (from.has_header()) {
-      mutable_header()->::cockroach::proto::RequestHeader::MergeFrom(from.header());
+    if (from.has_kvheader()) {
+      mutable_kvheader()->::cockroach::proto::KVRequestHeader::MergeFrom(from.kvheader());
     }
     if (from.has_split_key()) {
       set_has_split_key();
@@ -11246,7 +11865,7 @@ void AdminSplitRequest::Swap(AdminSplitRequest* other) {
   InternalSwap(other);
 }
 void AdminSplitRequest::InternalSwap(AdminSplitRequest* other) {
-  std::swap(header_, other->header_);
+  std::swap(kvheader_, other->kvheader_);
   split_key_.Swap(&other->split_key_);
   std::swap(_has_bits_[0], other->_has_bits_[0]);
   _internal_metadata_.Swap(&other->_internal_metadata_);
@@ -11264,47 +11883,47 @@ void AdminSplitRequest::InternalSwap(AdminSplitRequest* other) {
 #if PROTOBUF_INLINE_NOT_IN_HEADERS
 // AdminSplitRequest
 
-// optional .cockroach.proto.RequestHeader header = 1;
-bool AdminSplitRequest::has_header() const {
+// optional .cockroach.proto.KVRequestHeader kvheader = 1;
+bool AdminSplitRequest::has_kvheader() const {
   return (_has_bits_[0] & 0x00000001u) != 0;
 }
-void AdminSplitRequest::set_has_header() {
+void AdminSplitRequest::set_has_kvheader() {
   _has_bits_[0] |= 0x00000001u;
 }
-void AdminSplitRequest::clear_has_header() {
+void AdminSplitRequest::clear_has_kvheader() {
   _has_bits_[0] &= ~0x00000001u;
 }
-void AdminSplitRequest::clear_header() {
-  if (header_ != NULL) header_->::cockroach::proto::RequestHeader::Clear();
-  clear_has_header();
+void AdminSplitRequest::clear_kvheader() {
+  if (kvheader_ != NULL) kvheader_->::cockroach::proto::KVRequestHeader::Clear();
+  clear_has_kvheader();
 }
- const ::cockroach::proto::RequestHeader& AdminSplitRequest::header() const {
-  // @@protoc_insertion_point(field_get:cockroach.proto.AdminSplitRequest.header)
-  return header_ != NULL ? *header_ : *default_instance_->header_;
+ const ::cockroach::proto::KVRequestHeader& AdminSplitRequest::kvheader() const {
+  // @@protoc_insertion_point(field_get:cockroach.proto.AdminSplitRequest.kvheader)
+  return kvheader_ != NULL ? *kvheader_ : *default_instance_->kvheader_;
 }
- ::cockroach::proto::RequestHeader* AdminSplitRequest::mutable_header() {
-  set_has_header();
-  if (header_ == NULL) {
-    header_ = new ::cockroach::proto::RequestHeader;
+ ::cockroach::proto::KVRequestHeader* AdminSplitRequest::mutable_kvheader() {
+  set_has_kvheader();
+  if (kvheader_ == NULL) {
+    kvheader_ = new ::cockroach::proto::KVRequestHeader;
   }
-  // @@protoc_insertion_point(field_mutable:cockroach.proto.AdminSplitRequest.header)
-  return header_;
+  // @@protoc_insertion_point(field_mutable:cockroach.proto.AdminSplitRequest.kvheader)
+  return kvheader_;
 }
- ::cockroach::proto::RequestHeader* AdminSplitRequest::release_header() {
-  clear_has_header();
-  ::cockroach::proto::RequestHeader* temp = header_;
-  header_ = NULL;
+ ::cockroach::proto::KVRequestHeader* AdminSplitRequest::release_kvheader() {
+  clear_has_kvheader();
+  ::cockroach::proto::KVRequestHeader* temp = kvheader_;
+  kvheader_ = NULL;
   return temp;
 }
- void AdminSplitRequest::set_allocated_header(::cockroach::proto::RequestHeader* header) {
-  delete header_;
-  header_ = header;
-  if (header) {
-    set_has_header();
+ void AdminSplitRequest::set_allocated_kvheader(::cockroach::proto::KVRequestHeader* kvheader) {
+  delete kvheader_;
+  kvheader_ = kvheader;
+  if (kvheader) {
+    set_has_kvheader();
   } else {
-    clear_has_header();
+    clear_has_kvheader();
   }
-  // @@protoc_insertion_point(field_set_allocated:cockroach.proto.AdminSplitRequest.header)
+  // @@protoc_insertion_point(field_set_allocated:cockroach.proto.AdminSplitRequest.kvheader)
 }
 
 // optional bytes split_key = 2;
@@ -11365,7 +11984,7 @@ void AdminSplitRequest::clear_split_key() {
 // ===================================================================
 
 #ifndef _MSC_VER
-const int AdminSplitResponse::kHeaderFieldNumber;
+const int AdminSplitResponse::kKvheaderFieldNumber;
 #endif  // !_MSC_VER
 
 AdminSplitResponse::AdminSplitResponse()
@@ -11375,7 +11994,7 @@ AdminSplitResponse::AdminSplitResponse()
 }
 
 void AdminSplitResponse::InitAsDefaultInstance() {
-  header_ = const_cast< ::cockroach::proto::ResponseHeader*>(&::cockroach::proto::ResponseHeader::default_instance());
+  kvheader_ = const_cast< ::cockroach::proto::KVResponseHeader*>(&::cockroach::proto::KVResponseHeader::default_instance());
 }
 
 AdminSplitResponse::AdminSplitResponse(const AdminSplitResponse& from)
@@ -11388,7 +12007,7 @@ AdminSplitResponse::AdminSplitResponse(const AdminSplitResponse& from)
 
 void AdminSplitResponse::SharedCtor() {
   _cached_size_ = 0;
-  header_ = NULL;
+  kvheader_ = NULL;
   ::memset(_has_bits_, 0, sizeof(_has_bits_));
 }
 
@@ -11399,7 +12018,7 @@ AdminSplitResponse::~AdminSplitResponse() {
 
 void AdminSplitResponse::SharedDtor() {
   if (this != default_instance_) {
-    delete header_;
+    delete kvheader_;
   }
 }
 
@@ -11429,8 +12048,8 @@ AdminSplitResponse* AdminSplitResponse::New(::google::protobuf::Arena* arena) co
 }
 
 void AdminSplitResponse::Clear() {
-  if (has_header()) {
-    if (header_ != NULL) header_->::cockroach::proto::ResponseHeader::Clear();
+  if (has_kvheader()) {
+    if (kvheader_ != NULL) kvheader_->::cockroach::proto::KVResponseHeader::Clear();
   }
   ::memset(_has_bits_, 0, sizeof(_has_bits_));
   if (_internal_metadata_.have_unknown_fields()) {
@@ -11448,11 +12067,11 @@ bool AdminSplitResponse::MergePartialFromCodedStream(
     tag = p.first;
     if (!p.second) goto handle_unusual;
     switch (::google::protobuf::internal::WireFormatLite::GetTagFieldNumber(tag)) {
-      // optional .cockroach.proto.ResponseHeader header = 1;
+      // optional .cockroach.proto.KVResponseHeader kvheader = 1;
       case 1: {
         if (tag == 10) {
           DO_(::google::protobuf::internal::WireFormatLite::ReadMessageNoVirtual(
-               input, mutable_header()));
+               input, mutable_kvheader()));
         } else {
           goto handle_unusual;
         }
@@ -11485,10 +12104,10 @@ failure:
 void AdminSplitResponse::SerializeWithCachedSizes(
     ::google::protobuf::io::CodedOutputStream* output) const {
   // @@protoc_insertion_point(serialize_start:cockroach.proto.AdminSplitResponse)
-  // optional .cockroach.proto.ResponseHeader header = 1;
-  if (has_header()) {
+  // optional .cockroach.proto.KVResponseHeader kvheader = 1;
+  if (has_kvheader()) {
     ::google::protobuf::internal::WireFormatLite::WriteMessageMaybeToArray(
-      1, *this->header_, output);
+      1, *this->kvheader_, output);
   }
 
   if (_internal_metadata_.have_unknown_fields()) {
@@ -11501,11 +12120,11 @@ void AdminSplitResponse::SerializeWithCachedSizes(
 ::google::protobuf::uint8* AdminSplitResponse::SerializeWithCachedSizesToArray(
     ::google::protobuf::uint8* target) const {
   // @@protoc_insertion_point(serialize_to_array_start:cockroach.proto.AdminSplitResponse)
-  // optional .cockroach.proto.ResponseHeader header = 1;
-  if (has_header()) {
+  // optional .cockroach.proto.KVResponseHeader kvheader = 1;
+  if (has_kvheader()) {
     target = ::google::protobuf::internal::WireFormatLite::
       WriteMessageNoVirtualToArray(
-        1, *this->header_, target);
+        1, *this->kvheader_, target);
   }
 
   if (_internal_metadata_.have_unknown_fields()) {
@@ -11519,11 +12138,11 @@ void AdminSplitResponse::SerializeWithCachedSizes(
 int AdminSplitResponse::ByteSize() const {
   int total_size = 0;
 
-  // optional .cockroach.proto.ResponseHeader header = 1;
-  if (has_header()) {
+  // optional .cockroach.proto.KVResponseHeader kvheader = 1;
+  if (has_kvheader()) {
     total_size += 1 +
       ::google::protobuf::internal::WireFormatLite::MessageSizeNoVirtual(
-        *this->header_);
+        *this->kvheader_);
   }
 
   if (_internal_metadata_.have_unknown_fields()) {
@@ -11552,8 +12171,8 @@ void AdminSplitResponse::MergeFrom(const ::google::protobuf::Message& from) {
 void AdminSplitResponse::MergeFrom(const AdminSplitResponse& from) {
   if (GOOGLE_PREDICT_FALSE(&from == this)) MergeFromFail(__LINE__);
   if (from._has_bits_[0 / 32] & (0xffu << (0 % 32))) {
-    if (from.has_header()) {
-      mutable_header()->::cockroach::proto::ResponseHeader::MergeFrom(from.header());
+    if (from.has_kvheader()) {
+      mutable_kvheader()->::cockroach::proto::KVResponseHeader::MergeFrom(from.kvheader());
     }
   }
   if (from._internal_metadata_.have_unknown_fields()) {
@@ -11583,7 +12202,7 @@ void AdminSplitResponse::Swap(AdminSplitResponse* other) {
   InternalSwap(other);
 }
 void AdminSplitResponse::InternalSwap(AdminSplitResponse* other) {
-  std::swap(header_, other->header_);
+  std::swap(kvheader_, other->kvheader_);
   std::swap(_has_bits_[0], other->_has_bits_[0]);
   _internal_metadata_.Swap(&other->_internal_metadata_);
   std::swap(_cached_size_, other->_cached_size_);
@@ -11600,47 +12219,47 @@ void AdminSplitResponse::InternalSwap(AdminSplitResponse* other) {
 #if PROTOBUF_INLINE_NOT_IN_HEADERS
 // AdminSplitResponse
 
-// optional .cockroach.proto.ResponseHeader header = 1;
-bool AdminSplitResponse::has_header() const {
+// optional .cockroach.proto.KVResponseHeader kvheader = 1;
+bool AdminSplitResponse::has_kvheader() const {
   return (_has_bits_[0] & 0x00000001u) != 0;
 }
-void AdminSplitResponse::set_has_header() {
+void AdminSplitResponse::set_has_kvheader() {
   _has_bits_[0] |= 0x00000001u;
 }
-void AdminSplitResponse::clear_has_header() {
+void AdminSplitResponse::clear_has_kvheader() {
   _has_bits_[0] &= ~0x00000001u;
 }
-void AdminSplitResponse::clear_header() {
-  if (header_ != NULL) header_->::cockroach::proto::ResponseHeader::Clear();
-  clear_has_header();
+void AdminSplitResponse::clear_kvheader() {
+  if (kvheader_ != NULL) kvheader_->::cockroach::proto::KVResponseHeader::Clear();
+  clear_has_kvheader();
 }
- const ::cockroach::proto::ResponseHeader& AdminSplitResponse::header() const {
-  // @@protoc_insertion_point(field_get:cockroach.proto.AdminSplitResponse.header)
-  return header_ != NULL ? *header_ : *default_instance_->header_;
+ const ::cockroach::proto::KVResponseHeader& AdminSplitResponse::kvheader() const {
+  // @@protoc_insertion_point(field_get:cockroach.proto.AdminSplitResponse.kvheader)
+  return kvheader_ != NULL ? *kvheader_ : *default_instance_->kvheader_;
 }
- ::cockroach::proto::ResponseHeader* AdminSplitResponse::mutable_header() {
-  set_has_header();
-  if (header_ == NULL) {
-    header_ = new ::cockroach::proto::ResponseHeader;
+ ::cockroach::proto::KVResponseHeader* AdminSplitResponse::mutable_kvheader() {
+  set_has_kvheader();
+  if (kvheader_ == NULL) {
+    kvheader_ = new ::cockroach::proto::KVResponseHeader;
   }
-  // @@protoc_insertion_point(field_mutable:cockroach.proto.AdminSplitResponse.header)
-  return header_;
+  // @@protoc_insertion_point(field_mutable:cockroach.proto.AdminSplitResponse.kvheader)
+  return kvheader_;
 }
- ::cockroach::proto::ResponseHeader* AdminSplitResponse::release_header() {
-  clear_has_header();
-  ::cockroach::proto::ResponseHeader* temp = header_;
-  header_ = NULL;
+ ::cockroach::proto::KVResponseHeader* AdminSplitResponse::release_kvheader() {
+  clear_has_kvheader();
+  ::cockroach::proto::KVResponseHeader* temp = kvheader_;
+  kvheader_ = NULL;
   return temp;
 }
- void AdminSplitResponse::set_allocated_header(::cockroach::proto::ResponseHeader* header) {
-  delete header_;
-  header_ = header;
-  if (header) {
-    set_has_header();
+ void AdminSplitResponse::set_allocated_kvheader(::cockroach::proto::KVResponseHeader* kvheader) {
+  delete kvheader_;
+  kvheader_ = kvheader;
+  if (kvheader) {
+    set_has_kvheader();
   } else {
-    clear_has_header();
+    clear_has_kvheader();
   }
-  // @@protoc_insertion_point(field_set_allocated:cockroach.proto.AdminSplitResponse.header)
+  // @@protoc_insertion_point(field_set_allocated:cockroach.proto.AdminSplitResponse.kvheader)
 }
 
 #endif  // PROTOBUF_INLINE_NOT_IN_HEADERS
@@ -11648,7 +12267,7 @@ void AdminSplitResponse::clear_header() {
 // ===================================================================
 
 #ifndef _MSC_VER
-const int AdminMergeRequest::kHeaderFieldNumber;
+const int AdminMergeRequest::kKvheaderFieldNumber;
 #endif  // !_MSC_VER
 
 AdminMergeRequest::AdminMergeRequest()
@@ -11658,7 +12277,7 @@ AdminMergeRequest::AdminMergeRequest()
 }
 
 void AdminMergeRequest::InitAsDefaultInstance() {
-  header_ = const_cast< ::cockroach::proto::RequestHeader*>(&::cockroach::proto::RequestHeader::default_instance());
+  kvheader_ = const_cast< ::cockroach::proto::KVRequestHeader*>(&::cockroach::proto::KVRequestHeader::default_instance());
 }
 
 AdminMergeRequest::AdminMergeRequest(const AdminMergeRequest& from)
@@ -11671,7 +12290,7 @@ AdminMergeRequest::AdminMergeRequest(const AdminMergeRequest& from)
 
 void AdminMergeRequest::SharedCtor() {
   _cached_size_ = 0;
-  header_ = NULL;
+  kvheader_ = NULL;
   ::memset(_has_bits_, 0, sizeof(_has_bits_));
 }
 
@@ -11682,7 +12301,7 @@ AdminMergeRequest::~AdminMergeRequest() {
 
 void AdminMergeRequest::SharedDtor() {
   if (this != default_instance_) {
-    delete header_;
+    delete kvheader_;
   }
 }
 
@@ -11712,8 +12331,8 @@ AdminMergeRequest* AdminMergeRequest::New(::google::protobuf::Arena* arena) cons
 }
 
 void AdminMergeRequest::Clear() {
-  if (has_header()) {
-    if (header_ != NULL) header_->::cockroach::proto::RequestHeader::Clear();
+  if (has_kvheader()) {
+    if (kvheader_ != NULL) kvheader_->::cockroach::proto::KVRequestHeader::Clear();
   }
   ::memset(_has_bits_, 0, sizeof(_has_bits_));
   if (_internal_metadata_.have_unknown_fields()) {
@@ -11731,11 +12350,11 @@ bool AdminMergeRequest::MergePartialFromCodedStream(
     tag = p.first;
     if (!p.second) goto handle_unusual;
     switch (::google::protobuf::internal::WireFormatLite::GetTagFieldNumber(tag)) {
-      // optional .cockroach.proto.RequestHeader header = 1;
+      // optional .cockroach.proto.KVRequestHeader kvheader = 1;
       case 1: {
         if (tag == 10) {
           DO_(::google::protobuf::internal::WireFormatLite::ReadMessageNoVirtual(
-               input, mutable_header()));
+               input, mutable_kvheader()));
         } else {
           goto handle_unusual;
         }
@@ -11768,10 +12387,10 @@ failure:
 void AdminMergeRequest::SerializeWithCachedSizes(
     ::google::protobuf::io::CodedOutputStream* output) const {
   // @@protoc_insertion_point(serialize_start:cockroach.proto.AdminMergeRequest)
-  // optional .cockroach.proto.RequestHeader header = 1;
-  if (has_header()) {
+  // optional .cockroach.proto.KVRequestHeader kvheader = 1;
+  if (has_kvheader()) {
     ::google::protobuf::internal::WireFormatLite::WriteMessageMaybeToArray(
-      1, *this->header_, output);
+      1, *this->kvheader_, output);
   }
 
   if (_internal_metadata_.have_unknown_fields()) {
@@ -11784,11 +12403,11 @@ void AdminMergeRequest::SerializeWithCachedSizes(
 ::google::protobuf::uint8* AdminMergeRequest::SerializeWithCachedSizesToArray(
     ::google::protobuf::uint8* target) const {
   // @@protoc_insertion_point(serialize_to_array_start:cockroach.proto.AdminMergeRequest)
-  // optional .cockroach.proto.RequestHeader header = 1;
-  if (has_header()) {
+  // optional .cockroach.proto.KVRequestHeader kvheader = 1;
+  if (has_kvheader()) {
     target = ::google::protobuf::internal::WireFormatLite::
       WriteMessageNoVirtualToArray(
-        1, *this->header_, target);
+        1, *this->kvheader_, target);
   }
 
   if (_internal_metadata_.have_unknown_fields()) {
@@ -11802,11 +12421,11 @@ void AdminMergeRequest::SerializeWithCachedSizes(
 int AdminMergeRequest::ByteSize() const {
   int total_size = 0;
 
-  // optional .cockroach.proto.RequestHeader header = 1;
-  if (has_header()) {
+  // optional .cockroach.proto.KVRequestHeader kvheader = 1;
+  if (has_kvheader()) {
     total_size += 1 +
       ::google::protobuf::internal::WireFormatLite::MessageSizeNoVirtual(
-        *this->header_);
+        *this->kvheader_);
   }
 
   if (_internal_metadata_.have_unknown_fields()) {
@@ -11835,8 +12454,8 @@ void AdminMergeRequest::MergeFrom(const ::google::protobuf::Message& from) {
 void AdminMergeRequest::MergeFrom(const AdminMergeRequest& from) {
   if (GOOGLE_PREDICT_FALSE(&from == this)) MergeFromFail(__LINE__);
   if (from._has_bits_[0 / 32] & (0xffu << (0 % 32))) {
-    if (from.has_header()) {
-      mutable_header()->::cockroach::proto::RequestHeader::MergeFrom(from.header());
+    if (from.has_kvheader()) {
+      mutable_kvheader()->::cockroach::proto::KVRequestHeader::MergeFrom(from.kvheader());
     }
   }
   if (from._internal_metadata_.have_unknown_fields()) {
@@ -11866,7 +12485,7 @@ void AdminMergeRequest::Swap(AdminMergeRequest* other) {
   InternalSwap(other);
 }
 void AdminMergeRequest::InternalSwap(AdminMergeRequest* other) {
-  std::swap(header_, other->header_);
+  std::swap(kvheader_, other->kvheader_);
   std::swap(_has_bits_[0], other->_has_bits_[0]);
   _internal_metadata_.Swap(&other->_internal_metadata_);
   std::swap(_cached_size_, other->_cached_size_);
@@ -11883,47 +12502,47 @@ void AdminMergeRequest::InternalSwap(AdminMergeRequest* other) {
 #if PROTOBUF_INLINE_NOT_IN_HEADERS
 // AdminMergeRequest
 
-// optional .cockroach.proto.RequestHeader header = 1;
-bool AdminMergeRequest::has_header() const {
+// optional .cockroach.proto.KVRequestHeader kvheader = 1;
+bool AdminMergeRequest::has_kvheader() const {
   return (_has_bits_[0] & 0x00000001u) != 0;
 }
-void AdminMergeRequest::set_has_header() {
+void AdminMergeRequest::set_has_kvheader() {
   _has_bits_[0] |= 0x00000001u;
 }
-void AdminMergeRequest::clear_has_header() {
+void AdminMergeRequest::clear_has_kvheader() {
   _has_bits_[0] &= ~0x00000001u;
 }
-void AdminMergeRequest::clear_header() {
-  if (header_ != NULL) header_->::cockroach::proto::RequestHeader::Clear();
-  clear_has_header();
+void AdminMergeRequest::clear_kvheader() {
+  if (kvheader_ != NULL) kvheader_->::cockroach::proto::KVRequestHeader::Clear();
+  clear_has_kvheader();
 }
- const ::cockroach::proto::RequestHeader& AdminMergeRequest::header() const {
-  // @@protoc_insertion_point(field_get:cockroach.proto.AdminMergeRequest.header)
-  return header_ != NULL ? *header_ : *default_instance_->header_;
+ const ::cockroach::proto::KVRequestHeader& AdminMergeRequest::kvheader() const {
+  // @@protoc_insertion_point(field_get:cockroach.proto.AdminMergeRequest.kvheader)
+  return kvheader_ != NULL ? *kvheader_ : *default_instance_->kvheader_;
 }
- ::cockroach::proto::RequestHeader* AdminMergeRequest::mutable_header() {
-  set_has_header();
-  if (header_ == NULL) {
-    header_ = new ::cockroach::proto::RequestHeader;
+ ::cockroach::proto::KVRequestHeader* AdminMergeRequest::mutable_kvheader() {
+  set_has_kvheader();
+  if (kvheader_ == NULL) {
+    kvheader_ = new ::cockroach::proto::KVRequestHeader;
   }
-  // @@protoc_insertion_point(field_mutable:cockroach.proto.AdminMergeRequest.header)
-  return header_;
+  // @@protoc_insertion_point(field_mutable:cockroach.proto.AdminMergeRequest.kvheader)
+  return kvheader_;
 }
- ::cockroach::proto::RequestHeader* AdminMergeRequest::release_header() {
-  clear_has_header();
-  ::cockroach::proto::RequestHeader* temp = header_;
-  header_ = NULL;
+ ::cockroach::proto::KVRequestHeader* AdminMergeRequest::release_kvheader() {
+  clear_has_kvheader();
+  ::cockroach::proto::KVRequestHeader* temp = kvheader_;
+  kvheader_ = NULL;
   return temp;
 }
- void AdminMergeRequest::set_allocated_header(::cockroach::proto::RequestHeader* header) {
-  delete header_;
-  header_ = header;
-  if (header) {
-    set_has_header();
+ void AdminMergeRequest::set_allocated_kvheader(::cockroach::proto::KVRequestHeader* kvheader) {
+  delete kvheader_;
+  kvheader_ = kvheader;
+  if (kvheader) {
+    set_has_kvheader();
   } else {
-    clear_has_header();
+    clear_has_kvheader();
   }
-  // @@protoc_insertion_point(field_set_allocated:cockroach.proto.AdminMergeRequest.header)
+  // @@protoc_insertion_point(field_set_allocated:cockroach.proto.AdminMergeRequest.kvheader)
 }
 
 #endif  // PROTOBUF_INLINE_NOT_IN_HEADERS
@@ -11931,7 +12550,7 @@ void AdminMergeRequest::clear_header() {
 // ===================================================================
 
 #ifndef _MSC_VER
-const int AdminMergeResponse::kHeaderFieldNumber;
+const int AdminMergeResponse::kKvheaderFieldNumber;
 #endif  // !_MSC_VER
 
 AdminMergeResponse::AdminMergeResponse()
@@ -11941,7 +12560,7 @@ AdminMergeResponse::AdminMergeResponse()
 }
 
 void AdminMergeResponse::InitAsDefaultInstance() {
-  header_ = const_cast< ::cockroach::proto::ResponseHeader*>(&::cockroach::proto::ResponseHeader::default_instance());
+  kvheader_ = const_cast< ::cockroach::proto::KVResponseHeader*>(&::cockroach::proto::KVResponseHeader::default_instance());
 }
 
 AdminMergeResponse::AdminMergeResponse(const AdminMergeResponse& from)
@@ -11954,7 +12573,7 @@ AdminMergeResponse::AdminMergeResponse(const AdminMergeResponse& from)
 
 void AdminMergeResponse::SharedCtor() {
   _cached_size_ = 0;
-  header_ = NULL;
+  kvheader_ = NULL;
   ::memset(_has_bits_, 0, sizeof(_has_bits_));
 }
 
@@ -11965,7 +12584,7 @@ AdminMergeResponse::~AdminMergeResponse() {
 
 void AdminMergeResponse::SharedDtor() {
   if (this != default_instance_) {
-    delete header_;
+    delete kvheader_;
   }
 }
 
@@ -11995,8 +12614,8 @@ AdminMergeResponse* AdminMergeResponse::New(::google::protobuf::Arena* arena) co
 }
 
 void AdminMergeResponse::Clear() {
-  if (has_header()) {
-    if (header_ != NULL) header_->::cockroach::proto::ResponseHeader::Clear();
+  if (has_kvheader()) {
+    if (kvheader_ != NULL) kvheader_->::cockroach::proto::KVResponseHeader::Clear();
   }
   ::memset(_has_bits_, 0, sizeof(_has_bits_));
   if (_internal_metadata_.have_unknown_fields()) {
@@ -12014,11 +12633,11 @@ bool AdminMergeResponse::MergePartialFromCodedStream(
     tag = p.first;
     if (!p.second) goto handle_unusual;
     switch (::google::protobuf::internal::WireFormatLite::GetTagFieldNumber(tag)) {
-      // optional .cockroach.proto.ResponseHeader header = 1;
+      // optional .cockroach.proto.KVResponseHeader kvheader = 1;
       case 1: {
         if (tag == 10) {
           DO_(::google::protobuf::internal::WireFormatLite::ReadMessageNoVirtual(
-               input, mutable_header()));
+               input, mutable_kvheader()));
         } else {
           goto handle_unusual;
         }
@@ -12051,10 +12670,10 @@ failure:
 void AdminMergeResponse::SerializeWithCachedSizes(
     ::google::protobuf::io::CodedOutputStream* output) const {
   // @@protoc_insertion_point(serialize_start:cockroach.proto.AdminMergeResponse)
-  // optional .cockroach.proto.ResponseHeader header = 1;
-  if (has_header()) {
+  // optional .cockroach.proto.KVResponseHeader kvheader = 1;
+  if (has_kvheader()) {
     ::google::protobuf::internal::WireFormatLite::WriteMessageMaybeToArray(
-      1, *this->header_, output);
+      1, *this->kvheader_, output);
   }
 
   if (_internal_metadata_.have_unknown_fields()) {
@@ -12067,11 +12686,11 @@ void AdminMergeResponse::SerializeWithCachedSizes(
 ::google::protobuf::uint8* AdminMergeResponse::SerializeWithCachedSizesToArray(
     ::google::protobuf::uint8* target) const {
   // @@protoc_insertion_point(serialize_to_array_start:cockroach.proto.AdminMergeResponse)
-  // optional .cockroach.proto.ResponseHeader header = 1;
-  if (has_header()) {
+  // optional .cockroach.proto.KVResponseHeader kvheader = 1;
+  if (has_kvheader()) {
     target = ::google::protobuf::internal::WireFormatLite::
       WriteMessageNoVirtualToArray(
-        1, *this->header_, target);
+        1, *this->kvheader_, target);
   }
 
   if (_internal_metadata_.have_unknown_fields()) {
@@ -12085,11 +12704,11 @@ void AdminMergeResponse::SerializeWithCachedSizes(
 int AdminMergeResponse::ByteSize() const {
   int total_size = 0;
 
-  // optional .cockroach.proto.ResponseHeader header = 1;
-  if (has_header()) {
+  // optional .cockroach.proto.KVResponseHeader kvheader = 1;
+  if (has_kvheader()) {
     total_size += 1 +
       ::google::protobuf::internal::WireFormatLite::MessageSizeNoVirtual(
-        *this->header_);
+        *this->kvheader_);
   }
 
   if (_internal_metadata_.have_unknown_fields()) {
@@ -12118,8 +12737,8 @@ void AdminMergeResponse::MergeFrom(const ::google::protobuf::Message& from) {
 void AdminMergeResponse::MergeFrom(const AdminMergeResponse& from) {
   if (GOOGLE_PREDICT_FALSE(&from == this)) MergeFromFail(__LINE__);
   if (from._has_bits_[0 / 32] & (0xffu << (0 % 32))) {
-    if (from.has_header()) {
-      mutable_header()->::cockroach::proto::ResponseHeader::MergeFrom(from.header());
+    if (from.has_kvheader()) {
+      mutable_kvheader()->::cockroach::proto::KVResponseHeader::MergeFrom(from.kvheader());
     }
   }
   if (from._internal_metadata_.have_unknown_fields()) {
@@ -12149,7 +12768,7 @@ void AdminMergeResponse::Swap(AdminMergeResponse* other) {
   InternalSwap(other);
 }
 void AdminMergeResponse::InternalSwap(AdminMergeResponse* other) {
-  std::swap(header_, other->header_);
+  std::swap(kvheader_, other->kvheader_);
   std::swap(_has_bits_[0], other->_has_bits_[0]);
   _internal_metadata_.Swap(&other->_internal_metadata_);
   std::swap(_cached_size_, other->_cached_size_);
@@ -12166,47 +12785,47 @@ void AdminMergeResponse::InternalSwap(AdminMergeResponse* other) {
 #if PROTOBUF_INLINE_NOT_IN_HEADERS
 // AdminMergeResponse
 
-// optional .cockroach.proto.ResponseHeader header = 1;
-bool AdminMergeResponse::has_header() const {
+// optional .cockroach.proto.KVResponseHeader kvheader = 1;
+bool AdminMergeResponse::has_kvheader() const {
   return (_has_bits_[0] & 0x00000001u) != 0;
 }
-void AdminMergeResponse::set_has_header() {
+void AdminMergeResponse::set_has_kvheader() {
   _has_bits_[0] |= 0x00000001u;
 }
-void AdminMergeResponse::clear_has_header() {
+void AdminMergeResponse::clear_has_kvheader() {
   _has_bits_[0] &= ~0x00000001u;
 }
-void AdminMergeResponse::clear_header() {
-  if (header_ != NULL) header_->::cockroach::proto::ResponseHeader::Clear();
-  clear_has_header();
+void AdminMergeResponse::clear_kvheader() {
+  if (kvheader_ != NULL) kvheader_->::cockroach::proto::KVResponseHeader::Clear();
+  clear_has_kvheader();
 }
- const ::cockroach::proto::ResponseHeader& AdminMergeResponse::header() const {
-  // @@protoc_insertion_point(field_get:cockroach.proto.AdminMergeResponse.header)
-  return header_ != NULL ? *header_ : *default_instance_->header_;
+ const ::cockroach::proto::KVResponseHeader& AdminMergeResponse::kvheader() const {
+  // @@protoc_insertion_point(field_get:cockroach.proto.AdminMergeResponse.kvheader)
+  return kvheader_ != NULL ? *kvheader_ : *default_instance_->kvheader_;
 }
- ::cockroach::proto::ResponseHeader* AdminMergeResponse::mutable_header() {
-  set_has_header();
-  if (header_ == NULL) {
-    header_ = new ::cockroach::proto::ResponseHeader;
+ ::cockroach::proto::KVResponseHeader* AdminMergeResponse::mutable_kvheader() {
+  set_has_kvheader();
+  if (kvheader_ == NULL) {
+    kvheader_ = new ::cockroach::proto::KVResponseHeader;
   }
-  // @@protoc_insertion_point(field_mutable:cockroach.proto.AdminMergeResponse.header)
-  return header_;
+  // @@protoc_insertion_point(field_mutable:cockroach.proto.AdminMergeResponse.kvheader)
+  return kvheader_;
 }
- ::cockroach::proto::ResponseHeader* AdminMergeResponse::release_header() {
-  clear_has_header();
-  ::cockroach::proto::ResponseHeader* temp = header_;
-  header_ = NULL;
+ ::cockroach::proto::KVResponseHeader* AdminMergeResponse::release_kvheader() {
+  clear_has_kvheader();
+  ::cockroach::proto::KVResponseHeader* temp = kvheader_;
+  kvheader_ = NULL;
   return temp;
 }
- void AdminMergeResponse::set_allocated_header(::cockroach::proto::ResponseHeader* header) {
-  delete header_;
-  header_ = header;
-  if (header) {
-    set_has_header();
+ void AdminMergeResponse::set_allocated_kvheader(::cockroach::proto::KVResponseHeader* kvheader) {
+  delete kvheader_;
+  kvheader_ = kvheader;
+  if (kvheader) {
+    set_has_kvheader();
   } else {
-    clear_has_header();
+    clear_has_kvheader();
   }
-  // @@protoc_insertion_point(field_set_allocated:cockroach.proto.AdminMergeResponse.header)
+  // @@protoc_insertion_point(field_set_allocated:cockroach.proto.AdminMergeResponse.kvheader)
 }
 
 #endif  // PROTOBUF_INLINE_NOT_IN_HEADERS

--- a/storage/engine/cockroach/proto/api.pb.h
+++ b/storage/engine/cockroach/proto/api.pb.h
@@ -45,6 +45,8 @@ void protobuf_ShutdownFile_cockroach_2fproto_2fapi_2eproto();
 class ClientCmdID;
 class RequestHeader;
 class ResponseHeader;
+class KVRequestHeader;
+class KVResponseHeader;
 class GetRequest;
 class GetResponse;
 class PutRequest;
@@ -273,30 +275,6 @@ class RequestHeader : public ::google::protobuf::Message {
   ::cockroach::proto::ClientCmdID* release_cmd_id();
   void set_allocated_cmd_id(::cockroach::proto::ClientCmdID* cmd_id);
 
-  // optional bytes key = 3;
-  bool has_key() const;
-  void clear_key();
-  static const int kKeyFieldNumber = 3;
-  const ::std::string& key() const;
-  void set_key(const ::std::string& value);
-  void set_key(const char* value);
-  void set_key(const void* value, size_t size);
-  ::std::string* mutable_key();
-  ::std::string* release_key();
-  void set_allocated_key(::std::string* key);
-
-  // optional bytes end_key = 4;
-  bool has_end_key() const;
-  void clear_end_key();
-  static const int kEndKeyFieldNumber = 4;
-  const ::std::string& end_key() const;
-  void set_end_key(const ::std::string& value);
-  void set_end_key(const char* value);
-  void set_end_key(const void* value, size_t size);
-  ::std::string* mutable_end_key();
-  ::std::string* release_end_key();
-  void set_allocated_end_key(::std::string* end_key);
-
   // optional string user = 5;
   bool has_user() const;
   void clear_user();
@@ -308,22 +286,6 @@ class RequestHeader : public ::google::protobuf::Message {
   ::std::string* mutable_user();
   ::std::string* release_user();
   void set_allocated_user(::std::string* user);
-
-  // optional .cockroach.proto.Replica replica = 6;
-  bool has_replica() const;
-  void clear_replica();
-  static const int kReplicaFieldNumber = 6;
-  const ::cockroach::proto::Replica& replica() const;
-  ::cockroach::proto::Replica* mutable_replica();
-  ::cockroach::proto::Replica* release_replica();
-  void set_allocated_replica(::cockroach::proto::Replica* replica);
-
-  // optional int64 raft_id = 7;
-  bool has_raft_id() const;
-  void clear_raft_id();
-  static const int kRaftIdFieldNumber = 7;
-  ::google::protobuf::int64 raft_id() const;
-  void set_raft_id(::google::protobuf::int64 value);
 
   // optional int32 user_priority = 8 [default = 1];
   bool has_user_priority() const;
@@ -354,16 +316,8 @@ class RequestHeader : public ::google::protobuf::Message {
   inline void clear_has_timestamp();
   inline void set_has_cmd_id();
   inline void clear_has_cmd_id();
-  inline void set_has_key();
-  inline void clear_has_key();
-  inline void set_has_end_key();
-  inline void clear_has_end_key();
   inline void set_has_user();
   inline void clear_has_user();
-  inline void set_has_replica();
-  inline void clear_has_replica();
-  inline void set_has_raft_id();
-  inline void clear_has_raft_id();
   inline void set_has_user_priority();
   inline void clear_has_user_priority();
   inline void set_has_txn();
@@ -376,11 +330,7 @@ class RequestHeader : public ::google::protobuf::Message {
   mutable int _cached_size_;
   ::cockroach::proto::Timestamp* timestamp_;
   ::cockroach::proto::ClientCmdID* cmd_id_;
-  ::google::protobuf::internal::ArenaStringPtr key_;
-  ::google::protobuf::internal::ArenaStringPtr end_key_;
   ::google::protobuf::internal::ArenaStringPtr user_;
-  ::cockroach::proto::Replica* replica_;
-  ::google::protobuf::int64 raft_id_;
   ::cockroach::proto::Transaction* txn_;
   ::google::protobuf::int32 user_priority_;
   int read_consistency_;
@@ -508,6 +458,240 @@ class ResponseHeader : public ::google::protobuf::Message {
 };
 // -------------------------------------------------------------------
 
+class KVRequestHeader : public ::google::protobuf::Message {
+ public:
+  KVRequestHeader();
+  virtual ~KVRequestHeader();
+
+  KVRequestHeader(const KVRequestHeader& from);
+
+  inline KVRequestHeader& operator=(const KVRequestHeader& from) {
+    CopyFrom(from);
+    return *this;
+  }
+
+  inline const ::google::protobuf::UnknownFieldSet& unknown_fields() const {
+    return _internal_metadata_.unknown_fields();
+  }
+
+  inline ::google::protobuf::UnknownFieldSet* mutable_unknown_fields() {
+    return _internal_metadata_.mutable_unknown_fields();
+  }
+
+  static const ::google::protobuf::Descriptor* descriptor();
+  static const KVRequestHeader& default_instance();
+
+  void Swap(KVRequestHeader* other);
+
+  // implements Message ----------------------------------------------
+
+  inline KVRequestHeader* New() const { return New(NULL); }
+
+  KVRequestHeader* New(::google::protobuf::Arena* arena) const;
+  void CopyFrom(const ::google::protobuf::Message& from);
+  void MergeFrom(const ::google::protobuf::Message& from);
+  void CopyFrom(const KVRequestHeader& from);
+  void MergeFrom(const KVRequestHeader& from);
+  void Clear();
+  bool IsInitialized() const;
+
+  int ByteSize() const;
+  bool MergePartialFromCodedStream(
+      ::google::protobuf::io::CodedInputStream* input);
+  void SerializeWithCachedSizes(
+      ::google::protobuf::io::CodedOutputStream* output) const;
+  ::google::protobuf::uint8* SerializeWithCachedSizesToArray(::google::protobuf::uint8* output) const;
+  int GetCachedSize() const { return _cached_size_; }
+  private:
+  void SharedCtor();
+  void SharedDtor();
+  void SetCachedSize(int size) const;
+  void InternalSwap(KVRequestHeader* other);
+  private:
+  inline ::google::protobuf::Arena* GetArenaNoVirtual() const {
+    return _internal_metadata_.arena();
+  }
+  inline void* MaybeArenaPtr() const {
+    return _internal_metadata_.raw_arena_ptr();
+  }
+  public:
+
+  ::google::protobuf::Metadata GetMetadata() const;
+
+  // nested types ----------------------------------------------------
+
+  // accessors -------------------------------------------------------
+
+  // optional .cockroach.proto.RequestHeader header = 1;
+  bool has_header() const;
+  void clear_header();
+  static const int kHeaderFieldNumber = 1;
+  const ::cockroach::proto::RequestHeader& header() const;
+  ::cockroach::proto::RequestHeader* mutable_header();
+  ::cockroach::proto::RequestHeader* release_header();
+  void set_allocated_header(::cockroach::proto::RequestHeader* header);
+
+  // optional bytes key = 3;
+  bool has_key() const;
+  void clear_key();
+  static const int kKeyFieldNumber = 3;
+  const ::std::string& key() const;
+  void set_key(const ::std::string& value);
+  void set_key(const char* value);
+  void set_key(const void* value, size_t size);
+  ::std::string* mutable_key();
+  ::std::string* release_key();
+  void set_allocated_key(::std::string* key);
+
+  // optional bytes end_key = 4;
+  bool has_end_key() const;
+  void clear_end_key();
+  static const int kEndKeyFieldNumber = 4;
+  const ::std::string& end_key() const;
+  void set_end_key(const ::std::string& value);
+  void set_end_key(const char* value);
+  void set_end_key(const void* value, size_t size);
+  ::std::string* mutable_end_key();
+  ::std::string* release_end_key();
+  void set_allocated_end_key(::std::string* end_key);
+
+  // optional .cockroach.proto.Replica replica = 6;
+  bool has_replica() const;
+  void clear_replica();
+  static const int kReplicaFieldNumber = 6;
+  const ::cockroach::proto::Replica& replica() const;
+  ::cockroach::proto::Replica* mutable_replica();
+  ::cockroach::proto::Replica* release_replica();
+  void set_allocated_replica(::cockroach::proto::Replica* replica);
+
+  // optional int64 raft_id = 7;
+  bool has_raft_id() const;
+  void clear_raft_id();
+  static const int kRaftIdFieldNumber = 7;
+  ::google::protobuf::int64 raft_id() const;
+  void set_raft_id(::google::protobuf::int64 value);
+
+  // @@protoc_insertion_point(class_scope:cockroach.proto.KVRequestHeader)
+ private:
+  inline void set_has_header();
+  inline void clear_has_header();
+  inline void set_has_key();
+  inline void clear_has_key();
+  inline void set_has_end_key();
+  inline void clear_has_end_key();
+  inline void set_has_replica();
+  inline void clear_has_replica();
+  inline void set_has_raft_id();
+  inline void clear_has_raft_id();
+
+  ::google::protobuf::internal::InternalMetadataWithArena _internal_metadata_;
+  ::google::protobuf::uint32 _has_bits_[1];
+  mutable int _cached_size_;
+  ::cockroach::proto::RequestHeader* header_;
+  ::google::protobuf::internal::ArenaStringPtr key_;
+  ::google::protobuf::internal::ArenaStringPtr end_key_;
+  ::cockroach::proto::Replica* replica_;
+  ::google::protobuf::int64 raft_id_;
+  friend void  protobuf_AddDesc_cockroach_2fproto_2fapi_2eproto();
+  friend void protobuf_AssignDesc_cockroach_2fproto_2fapi_2eproto();
+  friend void protobuf_ShutdownFile_cockroach_2fproto_2fapi_2eproto();
+
+  void InitAsDefaultInstance();
+  static KVRequestHeader* default_instance_;
+};
+// -------------------------------------------------------------------
+
+class KVResponseHeader : public ::google::protobuf::Message {
+ public:
+  KVResponseHeader();
+  virtual ~KVResponseHeader();
+
+  KVResponseHeader(const KVResponseHeader& from);
+
+  inline KVResponseHeader& operator=(const KVResponseHeader& from) {
+    CopyFrom(from);
+    return *this;
+  }
+
+  inline const ::google::protobuf::UnknownFieldSet& unknown_fields() const {
+    return _internal_metadata_.unknown_fields();
+  }
+
+  inline ::google::protobuf::UnknownFieldSet* mutable_unknown_fields() {
+    return _internal_metadata_.mutable_unknown_fields();
+  }
+
+  static const ::google::protobuf::Descriptor* descriptor();
+  static const KVResponseHeader& default_instance();
+
+  void Swap(KVResponseHeader* other);
+
+  // implements Message ----------------------------------------------
+
+  inline KVResponseHeader* New() const { return New(NULL); }
+
+  KVResponseHeader* New(::google::protobuf::Arena* arena) const;
+  void CopyFrom(const ::google::protobuf::Message& from);
+  void MergeFrom(const ::google::protobuf::Message& from);
+  void CopyFrom(const KVResponseHeader& from);
+  void MergeFrom(const KVResponseHeader& from);
+  void Clear();
+  bool IsInitialized() const;
+
+  int ByteSize() const;
+  bool MergePartialFromCodedStream(
+      ::google::protobuf::io::CodedInputStream* input);
+  void SerializeWithCachedSizes(
+      ::google::protobuf::io::CodedOutputStream* output) const;
+  ::google::protobuf::uint8* SerializeWithCachedSizesToArray(::google::protobuf::uint8* output) const;
+  int GetCachedSize() const { return _cached_size_; }
+  private:
+  void SharedCtor();
+  void SharedDtor();
+  void SetCachedSize(int size) const;
+  void InternalSwap(KVResponseHeader* other);
+  private:
+  inline ::google::protobuf::Arena* GetArenaNoVirtual() const {
+    return _internal_metadata_.arena();
+  }
+  inline void* MaybeArenaPtr() const {
+    return _internal_metadata_.raw_arena_ptr();
+  }
+  public:
+
+  ::google::protobuf::Metadata GetMetadata() const;
+
+  // nested types ----------------------------------------------------
+
+  // accessors -------------------------------------------------------
+
+  // optional .cockroach.proto.ResponseHeader header = 1;
+  bool has_header() const;
+  void clear_header();
+  static const int kHeaderFieldNumber = 1;
+  const ::cockroach::proto::ResponseHeader& header() const;
+  ::cockroach::proto::ResponseHeader* mutable_header();
+  ::cockroach::proto::ResponseHeader* release_header();
+  void set_allocated_header(::cockroach::proto::ResponseHeader* header);
+
+  // @@protoc_insertion_point(class_scope:cockroach.proto.KVResponseHeader)
+ private:
+  inline void set_has_header();
+  inline void clear_has_header();
+
+  ::google::protobuf::internal::InternalMetadataWithArena _internal_metadata_;
+  ::google::protobuf::uint32 _has_bits_[1];
+  mutable int _cached_size_;
+  ::cockroach::proto::ResponseHeader* header_;
+  friend void  protobuf_AddDesc_cockroach_2fproto_2fapi_2eproto();
+  friend void protobuf_AssignDesc_cockroach_2fproto_2fapi_2eproto();
+  friend void protobuf_ShutdownFile_cockroach_2fproto_2fapi_2eproto();
+
+  void InitAsDefaultInstance();
+  static KVResponseHeader* default_instance_;
+};
+// -------------------------------------------------------------------
+
 class GetRequest : public ::google::protobuf::Message {
  public:
   GetRequest();
@@ -572,24 +756,24 @@ class GetRequest : public ::google::protobuf::Message {
 
   // accessors -------------------------------------------------------
 
-  // optional .cockroach.proto.RequestHeader header = 1;
-  bool has_header() const;
-  void clear_header();
-  static const int kHeaderFieldNumber = 1;
-  const ::cockroach::proto::RequestHeader& header() const;
-  ::cockroach::proto::RequestHeader* mutable_header();
-  ::cockroach::proto::RequestHeader* release_header();
-  void set_allocated_header(::cockroach::proto::RequestHeader* header);
+  // optional .cockroach.proto.KVRequestHeader kvheader = 1;
+  bool has_kvheader() const;
+  void clear_kvheader();
+  static const int kKvheaderFieldNumber = 1;
+  const ::cockroach::proto::KVRequestHeader& kvheader() const;
+  ::cockroach::proto::KVRequestHeader* mutable_kvheader();
+  ::cockroach::proto::KVRequestHeader* release_kvheader();
+  void set_allocated_kvheader(::cockroach::proto::KVRequestHeader* kvheader);
 
   // @@protoc_insertion_point(class_scope:cockroach.proto.GetRequest)
  private:
-  inline void set_has_header();
-  inline void clear_has_header();
+  inline void set_has_kvheader();
+  inline void clear_has_kvheader();
 
   ::google::protobuf::internal::InternalMetadataWithArena _internal_metadata_;
   ::google::protobuf::uint32 _has_bits_[1];
   mutable int _cached_size_;
-  ::cockroach::proto::RequestHeader* header_;
+  ::cockroach::proto::KVRequestHeader* kvheader_;
   friend void  protobuf_AddDesc_cockroach_2fproto_2fapi_2eproto();
   friend void protobuf_AssignDesc_cockroach_2fproto_2fapi_2eproto();
   friend void protobuf_ShutdownFile_cockroach_2fproto_2fapi_2eproto();
@@ -663,14 +847,14 @@ class GetResponse : public ::google::protobuf::Message {
 
   // accessors -------------------------------------------------------
 
-  // optional .cockroach.proto.ResponseHeader header = 1;
-  bool has_header() const;
-  void clear_header();
-  static const int kHeaderFieldNumber = 1;
-  const ::cockroach::proto::ResponseHeader& header() const;
-  ::cockroach::proto::ResponseHeader* mutable_header();
-  ::cockroach::proto::ResponseHeader* release_header();
-  void set_allocated_header(::cockroach::proto::ResponseHeader* header);
+  // optional .cockroach.proto.KVResponseHeader kvheader = 1;
+  bool has_kvheader() const;
+  void clear_kvheader();
+  static const int kKvheaderFieldNumber = 1;
+  const ::cockroach::proto::KVResponseHeader& kvheader() const;
+  ::cockroach::proto::KVResponseHeader* mutable_kvheader();
+  ::cockroach::proto::KVResponseHeader* release_kvheader();
+  void set_allocated_kvheader(::cockroach::proto::KVResponseHeader* kvheader);
 
   // optional .cockroach.proto.Value value = 2;
   bool has_value() const;
@@ -683,15 +867,15 @@ class GetResponse : public ::google::protobuf::Message {
 
   // @@protoc_insertion_point(class_scope:cockroach.proto.GetResponse)
  private:
-  inline void set_has_header();
-  inline void clear_has_header();
+  inline void set_has_kvheader();
+  inline void clear_has_kvheader();
   inline void set_has_value();
   inline void clear_has_value();
 
   ::google::protobuf::internal::InternalMetadataWithArena _internal_metadata_;
   ::google::protobuf::uint32 _has_bits_[1];
   mutable int _cached_size_;
-  ::cockroach::proto::ResponseHeader* header_;
+  ::cockroach::proto::KVResponseHeader* kvheader_;
   ::cockroach::proto::Value* value_;
   friend void  protobuf_AddDesc_cockroach_2fproto_2fapi_2eproto();
   friend void protobuf_AssignDesc_cockroach_2fproto_2fapi_2eproto();
@@ -766,14 +950,14 @@ class PutRequest : public ::google::protobuf::Message {
 
   // accessors -------------------------------------------------------
 
-  // optional .cockroach.proto.RequestHeader header = 1;
-  bool has_header() const;
-  void clear_header();
-  static const int kHeaderFieldNumber = 1;
-  const ::cockroach::proto::RequestHeader& header() const;
-  ::cockroach::proto::RequestHeader* mutable_header();
-  ::cockroach::proto::RequestHeader* release_header();
-  void set_allocated_header(::cockroach::proto::RequestHeader* header);
+  // optional .cockroach.proto.KVRequestHeader kvheader = 1;
+  bool has_kvheader() const;
+  void clear_kvheader();
+  static const int kKvheaderFieldNumber = 1;
+  const ::cockroach::proto::KVRequestHeader& kvheader() const;
+  ::cockroach::proto::KVRequestHeader* mutable_kvheader();
+  ::cockroach::proto::KVRequestHeader* release_kvheader();
+  void set_allocated_kvheader(::cockroach::proto::KVRequestHeader* kvheader);
 
   // optional .cockroach.proto.Value value = 2;
   bool has_value() const;
@@ -786,15 +970,15 @@ class PutRequest : public ::google::protobuf::Message {
 
   // @@protoc_insertion_point(class_scope:cockroach.proto.PutRequest)
  private:
-  inline void set_has_header();
-  inline void clear_has_header();
+  inline void set_has_kvheader();
+  inline void clear_has_kvheader();
   inline void set_has_value();
   inline void clear_has_value();
 
   ::google::protobuf::internal::InternalMetadataWithArena _internal_metadata_;
   ::google::protobuf::uint32 _has_bits_[1];
   mutable int _cached_size_;
-  ::cockroach::proto::RequestHeader* header_;
+  ::cockroach::proto::KVRequestHeader* kvheader_;
   ::cockroach::proto::Value* value_;
   friend void  protobuf_AddDesc_cockroach_2fproto_2fapi_2eproto();
   friend void protobuf_AssignDesc_cockroach_2fproto_2fapi_2eproto();
@@ -869,24 +1053,24 @@ class PutResponse : public ::google::protobuf::Message {
 
   // accessors -------------------------------------------------------
 
-  // optional .cockroach.proto.ResponseHeader header = 1;
-  bool has_header() const;
-  void clear_header();
-  static const int kHeaderFieldNumber = 1;
-  const ::cockroach::proto::ResponseHeader& header() const;
-  ::cockroach::proto::ResponseHeader* mutable_header();
-  ::cockroach::proto::ResponseHeader* release_header();
-  void set_allocated_header(::cockroach::proto::ResponseHeader* header);
+  // optional .cockroach.proto.KVResponseHeader kvheader = 1;
+  bool has_kvheader() const;
+  void clear_kvheader();
+  static const int kKvheaderFieldNumber = 1;
+  const ::cockroach::proto::KVResponseHeader& kvheader() const;
+  ::cockroach::proto::KVResponseHeader* mutable_kvheader();
+  ::cockroach::proto::KVResponseHeader* release_kvheader();
+  void set_allocated_kvheader(::cockroach::proto::KVResponseHeader* kvheader);
 
   // @@protoc_insertion_point(class_scope:cockroach.proto.PutResponse)
  private:
-  inline void set_has_header();
-  inline void clear_has_header();
+  inline void set_has_kvheader();
+  inline void clear_has_kvheader();
 
   ::google::protobuf::internal::InternalMetadataWithArena _internal_metadata_;
   ::google::protobuf::uint32 _has_bits_[1];
   mutable int _cached_size_;
-  ::cockroach::proto::ResponseHeader* header_;
+  ::cockroach::proto::KVResponseHeader* kvheader_;
   friend void  protobuf_AddDesc_cockroach_2fproto_2fapi_2eproto();
   friend void protobuf_AssignDesc_cockroach_2fproto_2fapi_2eproto();
   friend void protobuf_ShutdownFile_cockroach_2fproto_2fapi_2eproto();
@@ -960,14 +1144,14 @@ class ConditionalPutRequest : public ::google::protobuf::Message {
 
   // accessors -------------------------------------------------------
 
-  // optional .cockroach.proto.RequestHeader header = 1;
-  bool has_header() const;
-  void clear_header();
-  static const int kHeaderFieldNumber = 1;
-  const ::cockroach::proto::RequestHeader& header() const;
-  ::cockroach::proto::RequestHeader* mutable_header();
-  ::cockroach::proto::RequestHeader* release_header();
-  void set_allocated_header(::cockroach::proto::RequestHeader* header);
+  // optional .cockroach.proto.KVRequestHeader kvheader = 1;
+  bool has_kvheader() const;
+  void clear_kvheader();
+  static const int kKvheaderFieldNumber = 1;
+  const ::cockroach::proto::KVRequestHeader& kvheader() const;
+  ::cockroach::proto::KVRequestHeader* mutable_kvheader();
+  ::cockroach::proto::KVRequestHeader* release_kvheader();
+  void set_allocated_kvheader(::cockroach::proto::KVRequestHeader* kvheader);
 
   // optional .cockroach.proto.Value value = 2;
   bool has_value() const;
@@ -989,8 +1173,8 @@ class ConditionalPutRequest : public ::google::protobuf::Message {
 
   // @@protoc_insertion_point(class_scope:cockroach.proto.ConditionalPutRequest)
  private:
-  inline void set_has_header();
-  inline void clear_has_header();
+  inline void set_has_kvheader();
+  inline void clear_has_kvheader();
   inline void set_has_value();
   inline void clear_has_value();
   inline void set_has_exp_value();
@@ -999,7 +1183,7 @@ class ConditionalPutRequest : public ::google::protobuf::Message {
   ::google::protobuf::internal::InternalMetadataWithArena _internal_metadata_;
   ::google::protobuf::uint32 _has_bits_[1];
   mutable int _cached_size_;
-  ::cockroach::proto::RequestHeader* header_;
+  ::cockroach::proto::KVRequestHeader* kvheader_;
   ::cockroach::proto::Value* value_;
   ::cockroach::proto::Value* exp_value_;
   friend void  protobuf_AddDesc_cockroach_2fproto_2fapi_2eproto();
@@ -1075,24 +1259,24 @@ class ConditionalPutResponse : public ::google::protobuf::Message {
 
   // accessors -------------------------------------------------------
 
-  // optional .cockroach.proto.ResponseHeader header = 1;
-  bool has_header() const;
-  void clear_header();
-  static const int kHeaderFieldNumber = 1;
-  const ::cockroach::proto::ResponseHeader& header() const;
-  ::cockroach::proto::ResponseHeader* mutable_header();
-  ::cockroach::proto::ResponseHeader* release_header();
-  void set_allocated_header(::cockroach::proto::ResponseHeader* header);
+  // optional .cockroach.proto.KVResponseHeader kvheader = 1;
+  bool has_kvheader() const;
+  void clear_kvheader();
+  static const int kKvheaderFieldNumber = 1;
+  const ::cockroach::proto::KVResponseHeader& kvheader() const;
+  ::cockroach::proto::KVResponseHeader* mutable_kvheader();
+  ::cockroach::proto::KVResponseHeader* release_kvheader();
+  void set_allocated_kvheader(::cockroach::proto::KVResponseHeader* kvheader);
 
   // @@protoc_insertion_point(class_scope:cockroach.proto.ConditionalPutResponse)
  private:
-  inline void set_has_header();
-  inline void clear_has_header();
+  inline void set_has_kvheader();
+  inline void clear_has_kvheader();
 
   ::google::protobuf::internal::InternalMetadataWithArena _internal_metadata_;
   ::google::protobuf::uint32 _has_bits_[1];
   mutable int _cached_size_;
-  ::cockroach::proto::ResponseHeader* header_;
+  ::cockroach::proto::KVResponseHeader* kvheader_;
   friend void  protobuf_AddDesc_cockroach_2fproto_2fapi_2eproto();
   friend void protobuf_AssignDesc_cockroach_2fproto_2fapi_2eproto();
   friend void protobuf_ShutdownFile_cockroach_2fproto_2fapi_2eproto();
@@ -1166,14 +1350,14 @@ class IncrementRequest : public ::google::protobuf::Message {
 
   // accessors -------------------------------------------------------
 
-  // optional .cockroach.proto.RequestHeader header = 1;
-  bool has_header() const;
-  void clear_header();
-  static const int kHeaderFieldNumber = 1;
-  const ::cockroach::proto::RequestHeader& header() const;
-  ::cockroach::proto::RequestHeader* mutable_header();
-  ::cockroach::proto::RequestHeader* release_header();
-  void set_allocated_header(::cockroach::proto::RequestHeader* header);
+  // optional .cockroach.proto.KVRequestHeader kvheader = 1;
+  bool has_kvheader() const;
+  void clear_kvheader();
+  static const int kKvheaderFieldNumber = 1;
+  const ::cockroach::proto::KVRequestHeader& kvheader() const;
+  ::cockroach::proto::KVRequestHeader* mutable_kvheader();
+  ::cockroach::proto::KVRequestHeader* release_kvheader();
+  void set_allocated_kvheader(::cockroach::proto::KVRequestHeader* kvheader);
 
   // optional int64 increment = 2;
   bool has_increment() const;
@@ -1184,15 +1368,15 @@ class IncrementRequest : public ::google::protobuf::Message {
 
   // @@protoc_insertion_point(class_scope:cockroach.proto.IncrementRequest)
  private:
-  inline void set_has_header();
-  inline void clear_has_header();
+  inline void set_has_kvheader();
+  inline void clear_has_kvheader();
   inline void set_has_increment();
   inline void clear_has_increment();
 
   ::google::protobuf::internal::InternalMetadataWithArena _internal_metadata_;
   ::google::protobuf::uint32 _has_bits_[1];
   mutable int _cached_size_;
-  ::cockroach::proto::RequestHeader* header_;
+  ::cockroach::proto::KVRequestHeader* kvheader_;
   ::google::protobuf::int64 increment_;
   friend void  protobuf_AddDesc_cockroach_2fproto_2fapi_2eproto();
   friend void protobuf_AssignDesc_cockroach_2fproto_2fapi_2eproto();
@@ -1267,14 +1451,14 @@ class IncrementResponse : public ::google::protobuf::Message {
 
   // accessors -------------------------------------------------------
 
-  // optional .cockroach.proto.ResponseHeader header = 1;
-  bool has_header() const;
-  void clear_header();
-  static const int kHeaderFieldNumber = 1;
-  const ::cockroach::proto::ResponseHeader& header() const;
-  ::cockroach::proto::ResponseHeader* mutable_header();
-  ::cockroach::proto::ResponseHeader* release_header();
-  void set_allocated_header(::cockroach::proto::ResponseHeader* header);
+  // optional .cockroach.proto.KVResponseHeader kvheader = 1;
+  bool has_kvheader() const;
+  void clear_kvheader();
+  static const int kKvheaderFieldNumber = 1;
+  const ::cockroach::proto::KVResponseHeader& kvheader() const;
+  ::cockroach::proto::KVResponseHeader* mutable_kvheader();
+  ::cockroach::proto::KVResponseHeader* release_kvheader();
+  void set_allocated_kvheader(::cockroach::proto::KVResponseHeader* kvheader);
 
   // optional int64 new_value = 2;
   bool has_new_value() const;
@@ -1285,15 +1469,15 @@ class IncrementResponse : public ::google::protobuf::Message {
 
   // @@protoc_insertion_point(class_scope:cockroach.proto.IncrementResponse)
  private:
-  inline void set_has_header();
-  inline void clear_has_header();
+  inline void set_has_kvheader();
+  inline void clear_has_kvheader();
   inline void set_has_new_value();
   inline void clear_has_new_value();
 
   ::google::protobuf::internal::InternalMetadataWithArena _internal_metadata_;
   ::google::protobuf::uint32 _has_bits_[1];
   mutable int _cached_size_;
-  ::cockroach::proto::ResponseHeader* header_;
+  ::cockroach::proto::KVResponseHeader* kvheader_;
   ::google::protobuf::int64 new_value_;
   friend void  protobuf_AddDesc_cockroach_2fproto_2fapi_2eproto();
   friend void protobuf_AssignDesc_cockroach_2fproto_2fapi_2eproto();
@@ -1368,24 +1552,24 @@ class DeleteRequest : public ::google::protobuf::Message {
 
   // accessors -------------------------------------------------------
 
-  // optional .cockroach.proto.RequestHeader header = 1;
-  bool has_header() const;
-  void clear_header();
-  static const int kHeaderFieldNumber = 1;
-  const ::cockroach::proto::RequestHeader& header() const;
-  ::cockroach::proto::RequestHeader* mutable_header();
-  ::cockroach::proto::RequestHeader* release_header();
-  void set_allocated_header(::cockroach::proto::RequestHeader* header);
+  // optional .cockroach.proto.KVRequestHeader kvheader = 1;
+  bool has_kvheader() const;
+  void clear_kvheader();
+  static const int kKvheaderFieldNumber = 1;
+  const ::cockroach::proto::KVRequestHeader& kvheader() const;
+  ::cockroach::proto::KVRequestHeader* mutable_kvheader();
+  ::cockroach::proto::KVRequestHeader* release_kvheader();
+  void set_allocated_kvheader(::cockroach::proto::KVRequestHeader* kvheader);
 
   // @@protoc_insertion_point(class_scope:cockroach.proto.DeleteRequest)
  private:
-  inline void set_has_header();
-  inline void clear_has_header();
+  inline void set_has_kvheader();
+  inline void clear_has_kvheader();
 
   ::google::protobuf::internal::InternalMetadataWithArena _internal_metadata_;
   ::google::protobuf::uint32 _has_bits_[1];
   mutable int _cached_size_;
-  ::cockroach::proto::RequestHeader* header_;
+  ::cockroach::proto::KVRequestHeader* kvheader_;
   friend void  protobuf_AddDesc_cockroach_2fproto_2fapi_2eproto();
   friend void protobuf_AssignDesc_cockroach_2fproto_2fapi_2eproto();
   friend void protobuf_ShutdownFile_cockroach_2fproto_2fapi_2eproto();
@@ -1459,24 +1643,24 @@ class DeleteResponse : public ::google::protobuf::Message {
 
   // accessors -------------------------------------------------------
 
-  // optional .cockroach.proto.ResponseHeader header = 1;
-  bool has_header() const;
-  void clear_header();
-  static const int kHeaderFieldNumber = 1;
-  const ::cockroach::proto::ResponseHeader& header() const;
-  ::cockroach::proto::ResponseHeader* mutable_header();
-  ::cockroach::proto::ResponseHeader* release_header();
-  void set_allocated_header(::cockroach::proto::ResponseHeader* header);
+  // optional .cockroach.proto.KVResponseHeader kvheader = 1;
+  bool has_kvheader() const;
+  void clear_kvheader();
+  static const int kKvheaderFieldNumber = 1;
+  const ::cockroach::proto::KVResponseHeader& kvheader() const;
+  ::cockroach::proto::KVResponseHeader* mutable_kvheader();
+  ::cockroach::proto::KVResponseHeader* release_kvheader();
+  void set_allocated_kvheader(::cockroach::proto::KVResponseHeader* kvheader);
 
   // @@protoc_insertion_point(class_scope:cockroach.proto.DeleteResponse)
  private:
-  inline void set_has_header();
-  inline void clear_has_header();
+  inline void set_has_kvheader();
+  inline void clear_has_kvheader();
 
   ::google::protobuf::internal::InternalMetadataWithArena _internal_metadata_;
   ::google::protobuf::uint32 _has_bits_[1];
   mutable int _cached_size_;
-  ::cockroach::proto::ResponseHeader* header_;
+  ::cockroach::proto::KVResponseHeader* kvheader_;
   friend void  protobuf_AddDesc_cockroach_2fproto_2fapi_2eproto();
   friend void protobuf_AssignDesc_cockroach_2fproto_2fapi_2eproto();
   friend void protobuf_ShutdownFile_cockroach_2fproto_2fapi_2eproto();
@@ -1550,14 +1734,14 @@ class DeleteRangeRequest : public ::google::protobuf::Message {
 
   // accessors -------------------------------------------------------
 
-  // optional .cockroach.proto.RequestHeader header = 1;
-  bool has_header() const;
-  void clear_header();
-  static const int kHeaderFieldNumber = 1;
-  const ::cockroach::proto::RequestHeader& header() const;
-  ::cockroach::proto::RequestHeader* mutable_header();
-  ::cockroach::proto::RequestHeader* release_header();
-  void set_allocated_header(::cockroach::proto::RequestHeader* header);
+  // optional .cockroach.proto.KVRequestHeader kvheader = 1;
+  bool has_kvheader() const;
+  void clear_kvheader();
+  static const int kKvheaderFieldNumber = 1;
+  const ::cockroach::proto::KVRequestHeader& kvheader() const;
+  ::cockroach::proto::KVRequestHeader* mutable_kvheader();
+  ::cockroach::proto::KVRequestHeader* release_kvheader();
+  void set_allocated_kvheader(::cockroach::proto::KVRequestHeader* kvheader);
 
   // optional int64 max_entries_to_delete = 2;
   bool has_max_entries_to_delete() const;
@@ -1568,15 +1752,15 @@ class DeleteRangeRequest : public ::google::protobuf::Message {
 
   // @@protoc_insertion_point(class_scope:cockroach.proto.DeleteRangeRequest)
  private:
-  inline void set_has_header();
-  inline void clear_has_header();
+  inline void set_has_kvheader();
+  inline void clear_has_kvheader();
   inline void set_has_max_entries_to_delete();
   inline void clear_has_max_entries_to_delete();
 
   ::google::protobuf::internal::InternalMetadataWithArena _internal_metadata_;
   ::google::protobuf::uint32 _has_bits_[1];
   mutable int _cached_size_;
-  ::cockroach::proto::RequestHeader* header_;
+  ::cockroach::proto::KVRequestHeader* kvheader_;
   ::google::protobuf::int64 max_entries_to_delete_;
   friend void  protobuf_AddDesc_cockroach_2fproto_2fapi_2eproto();
   friend void protobuf_AssignDesc_cockroach_2fproto_2fapi_2eproto();
@@ -1651,14 +1835,14 @@ class DeleteRangeResponse : public ::google::protobuf::Message {
 
   // accessors -------------------------------------------------------
 
-  // optional .cockroach.proto.ResponseHeader header = 1;
-  bool has_header() const;
-  void clear_header();
-  static const int kHeaderFieldNumber = 1;
-  const ::cockroach::proto::ResponseHeader& header() const;
-  ::cockroach::proto::ResponseHeader* mutable_header();
-  ::cockroach::proto::ResponseHeader* release_header();
-  void set_allocated_header(::cockroach::proto::ResponseHeader* header);
+  // optional .cockroach.proto.KVResponseHeader kvheader = 1;
+  bool has_kvheader() const;
+  void clear_kvheader();
+  static const int kKvheaderFieldNumber = 1;
+  const ::cockroach::proto::KVResponseHeader& kvheader() const;
+  ::cockroach::proto::KVResponseHeader* mutable_kvheader();
+  ::cockroach::proto::KVResponseHeader* release_kvheader();
+  void set_allocated_kvheader(::cockroach::proto::KVResponseHeader* kvheader);
 
   // optional int64 num_deleted = 2;
   bool has_num_deleted() const;
@@ -1669,15 +1853,15 @@ class DeleteRangeResponse : public ::google::protobuf::Message {
 
   // @@protoc_insertion_point(class_scope:cockroach.proto.DeleteRangeResponse)
  private:
-  inline void set_has_header();
-  inline void clear_has_header();
+  inline void set_has_kvheader();
+  inline void clear_has_kvheader();
   inline void set_has_num_deleted();
   inline void clear_has_num_deleted();
 
   ::google::protobuf::internal::InternalMetadataWithArena _internal_metadata_;
   ::google::protobuf::uint32 _has_bits_[1];
   mutable int _cached_size_;
-  ::cockroach::proto::ResponseHeader* header_;
+  ::cockroach::proto::KVResponseHeader* kvheader_;
   ::google::protobuf::int64 num_deleted_;
   friend void  protobuf_AddDesc_cockroach_2fproto_2fapi_2eproto();
   friend void protobuf_AssignDesc_cockroach_2fproto_2fapi_2eproto();
@@ -1752,14 +1936,14 @@ class ScanRequest : public ::google::protobuf::Message {
 
   // accessors -------------------------------------------------------
 
-  // optional .cockroach.proto.RequestHeader header = 1;
-  bool has_header() const;
-  void clear_header();
-  static const int kHeaderFieldNumber = 1;
-  const ::cockroach::proto::RequestHeader& header() const;
-  ::cockroach::proto::RequestHeader* mutable_header();
-  ::cockroach::proto::RequestHeader* release_header();
-  void set_allocated_header(::cockroach::proto::RequestHeader* header);
+  // optional .cockroach.proto.KVRequestHeader kvheader = 1;
+  bool has_kvheader() const;
+  void clear_kvheader();
+  static const int kKvheaderFieldNumber = 1;
+  const ::cockroach::proto::KVRequestHeader& kvheader() const;
+  ::cockroach::proto::KVRequestHeader* mutable_kvheader();
+  ::cockroach::proto::KVRequestHeader* release_kvheader();
+  void set_allocated_kvheader(::cockroach::proto::KVRequestHeader* kvheader);
 
   // optional int64 max_results = 2;
   bool has_max_results() const;
@@ -1770,15 +1954,15 @@ class ScanRequest : public ::google::protobuf::Message {
 
   // @@protoc_insertion_point(class_scope:cockroach.proto.ScanRequest)
  private:
-  inline void set_has_header();
-  inline void clear_has_header();
+  inline void set_has_kvheader();
+  inline void clear_has_kvheader();
   inline void set_has_max_results();
   inline void clear_has_max_results();
 
   ::google::protobuf::internal::InternalMetadataWithArena _internal_metadata_;
   ::google::protobuf::uint32 _has_bits_[1];
   mutable int _cached_size_;
-  ::cockroach::proto::RequestHeader* header_;
+  ::cockroach::proto::KVRequestHeader* kvheader_;
   ::google::protobuf::int64 max_results_;
   friend void  protobuf_AddDesc_cockroach_2fproto_2fapi_2eproto();
   friend void protobuf_AssignDesc_cockroach_2fproto_2fapi_2eproto();
@@ -1853,14 +2037,14 @@ class ScanResponse : public ::google::protobuf::Message {
 
   // accessors -------------------------------------------------------
 
-  // optional .cockroach.proto.ResponseHeader header = 1;
-  bool has_header() const;
-  void clear_header();
-  static const int kHeaderFieldNumber = 1;
-  const ::cockroach::proto::ResponseHeader& header() const;
-  ::cockroach::proto::ResponseHeader* mutable_header();
-  ::cockroach::proto::ResponseHeader* release_header();
-  void set_allocated_header(::cockroach::proto::ResponseHeader* header);
+  // optional .cockroach.proto.KVResponseHeader kvheader = 1;
+  bool has_kvheader() const;
+  void clear_kvheader();
+  static const int kKvheaderFieldNumber = 1;
+  const ::cockroach::proto::KVResponseHeader& kvheader() const;
+  ::cockroach::proto::KVResponseHeader* mutable_kvheader();
+  ::cockroach::proto::KVResponseHeader* release_kvheader();
+  void set_allocated_kvheader(::cockroach::proto::KVResponseHeader* kvheader);
 
   // repeated .cockroach.proto.KeyValue rows = 2;
   int rows_size() const;
@@ -1876,13 +2060,13 @@ class ScanResponse : public ::google::protobuf::Message {
 
   // @@protoc_insertion_point(class_scope:cockroach.proto.ScanResponse)
  private:
-  inline void set_has_header();
-  inline void clear_has_header();
+  inline void set_has_kvheader();
+  inline void clear_has_kvheader();
 
   ::google::protobuf::internal::InternalMetadataWithArena _internal_metadata_;
   ::google::protobuf::uint32 _has_bits_[1];
   mutable int _cached_size_;
-  ::cockroach::proto::ResponseHeader* header_;
+  ::cockroach::proto::KVResponseHeader* kvheader_;
   ::google::protobuf::RepeatedPtrField< ::cockroach::proto::KeyValue > rows_;
   friend void  protobuf_AddDesc_cockroach_2fproto_2fapi_2eproto();
   friend void protobuf_AssignDesc_cockroach_2fproto_2fapi_2eproto();
@@ -1957,14 +2141,14 @@ class EndTransactionRequest : public ::google::protobuf::Message {
 
   // accessors -------------------------------------------------------
 
-  // optional .cockroach.proto.RequestHeader header = 1;
-  bool has_header() const;
-  void clear_header();
-  static const int kHeaderFieldNumber = 1;
-  const ::cockroach::proto::RequestHeader& header() const;
-  ::cockroach::proto::RequestHeader* mutable_header();
-  ::cockroach::proto::RequestHeader* release_header();
-  void set_allocated_header(::cockroach::proto::RequestHeader* header);
+  // optional .cockroach.proto.KVRequestHeader kvheader = 1;
+  bool has_kvheader() const;
+  void clear_kvheader();
+  static const int kKvheaderFieldNumber = 1;
+  const ::cockroach::proto::KVRequestHeader& kvheader() const;
+  ::cockroach::proto::KVRequestHeader* mutable_kvheader();
+  ::cockroach::proto::KVRequestHeader* release_kvheader();
+  void set_allocated_kvheader(::cockroach::proto::KVRequestHeader* kvheader);
 
   // optional bool commit = 2;
   bool has_commit() const;
@@ -1984,8 +2168,8 @@ class EndTransactionRequest : public ::google::protobuf::Message {
 
   // @@protoc_insertion_point(class_scope:cockroach.proto.EndTransactionRequest)
  private:
-  inline void set_has_header();
-  inline void clear_has_header();
+  inline void set_has_kvheader();
+  inline void clear_has_kvheader();
   inline void set_has_commit();
   inline void clear_has_commit();
   inline void set_has_internal_commit_trigger();
@@ -1994,7 +2178,7 @@ class EndTransactionRequest : public ::google::protobuf::Message {
   ::google::protobuf::internal::InternalMetadataWithArena _internal_metadata_;
   ::google::protobuf::uint32 _has_bits_[1];
   mutable int _cached_size_;
-  ::cockroach::proto::RequestHeader* header_;
+  ::cockroach::proto::KVRequestHeader* kvheader_;
   ::cockroach::proto::InternalCommitTrigger* internal_commit_trigger_;
   bool commit_;
   friend void  protobuf_AddDesc_cockroach_2fproto_2fapi_2eproto();
@@ -2070,14 +2254,14 @@ class EndTransactionResponse : public ::google::protobuf::Message {
 
   // accessors -------------------------------------------------------
 
-  // optional .cockroach.proto.ResponseHeader header = 1;
-  bool has_header() const;
-  void clear_header();
-  static const int kHeaderFieldNumber = 1;
-  const ::cockroach::proto::ResponseHeader& header() const;
-  ::cockroach::proto::ResponseHeader* mutable_header();
-  ::cockroach::proto::ResponseHeader* release_header();
-  void set_allocated_header(::cockroach::proto::ResponseHeader* header);
+  // optional .cockroach.proto.KVResponseHeader kvheader = 1;
+  bool has_kvheader() const;
+  void clear_kvheader();
+  static const int kKvheaderFieldNumber = 1;
+  const ::cockroach::proto::KVResponseHeader& kvheader() const;
+  ::cockroach::proto::KVResponseHeader* mutable_kvheader();
+  ::cockroach::proto::KVResponseHeader* release_kvheader();
+  void set_allocated_kvheader(::cockroach::proto::KVResponseHeader* kvheader);
 
   // optional int64 commit_wait = 2;
   bool has_commit_wait() const;
@@ -2104,15 +2288,15 @@ class EndTransactionResponse : public ::google::protobuf::Message {
 
   // @@protoc_insertion_point(class_scope:cockroach.proto.EndTransactionResponse)
  private:
-  inline void set_has_header();
-  inline void clear_has_header();
+  inline void set_has_kvheader();
+  inline void clear_has_kvheader();
   inline void set_has_commit_wait();
   inline void clear_has_commit_wait();
 
   ::google::protobuf::internal::InternalMetadataWithArena _internal_metadata_;
   ::google::protobuf::uint32 _has_bits_[1];
   mutable int _cached_size_;
-  ::cockroach::proto::ResponseHeader* header_;
+  ::cockroach::proto::KVResponseHeader* kvheader_;
   ::google::protobuf::int64 commit_wait_;
   ::google::protobuf::RepeatedPtrField< ::std::string> resolved_;
   friend void  protobuf_AddDesc_cockroach_2fproto_2fapi_2eproto();
@@ -2566,14 +2750,14 @@ class BatchRequest : public ::google::protobuf::Message {
 
   // accessors -------------------------------------------------------
 
-  // optional .cockroach.proto.RequestHeader header = 1;
-  bool has_header() const;
-  void clear_header();
-  static const int kHeaderFieldNumber = 1;
-  const ::cockroach::proto::RequestHeader& header() const;
-  ::cockroach::proto::RequestHeader* mutable_header();
-  ::cockroach::proto::RequestHeader* release_header();
-  void set_allocated_header(::cockroach::proto::RequestHeader* header);
+  // optional .cockroach.proto.KVRequestHeader kvheader = 1;
+  bool has_kvheader() const;
+  void clear_kvheader();
+  static const int kKvheaderFieldNumber = 1;
+  const ::cockroach::proto::KVRequestHeader& kvheader() const;
+  ::cockroach::proto::KVRequestHeader* mutable_kvheader();
+  ::cockroach::proto::KVRequestHeader* release_kvheader();
+  void set_allocated_kvheader(::cockroach::proto::KVRequestHeader* kvheader);
 
   // repeated .cockroach.proto.RequestUnion requests = 2;
   int requests_size() const;
@@ -2589,13 +2773,13 @@ class BatchRequest : public ::google::protobuf::Message {
 
   // @@protoc_insertion_point(class_scope:cockroach.proto.BatchRequest)
  private:
-  inline void set_has_header();
-  inline void clear_has_header();
+  inline void set_has_kvheader();
+  inline void clear_has_kvheader();
 
   ::google::protobuf::internal::InternalMetadataWithArena _internal_metadata_;
   ::google::protobuf::uint32 _has_bits_[1];
   mutable int _cached_size_;
-  ::cockroach::proto::RequestHeader* header_;
+  ::cockroach::proto::KVRequestHeader* kvheader_;
   ::google::protobuf::RepeatedPtrField< ::cockroach::proto::RequestUnion > requests_;
   friend void  protobuf_AddDesc_cockroach_2fproto_2fapi_2eproto();
   friend void protobuf_AssignDesc_cockroach_2fproto_2fapi_2eproto();
@@ -2670,14 +2854,14 @@ class BatchResponse : public ::google::protobuf::Message {
 
   // accessors -------------------------------------------------------
 
-  // optional .cockroach.proto.ResponseHeader header = 1;
-  bool has_header() const;
-  void clear_header();
-  static const int kHeaderFieldNumber = 1;
-  const ::cockroach::proto::ResponseHeader& header() const;
-  ::cockroach::proto::ResponseHeader* mutable_header();
-  ::cockroach::proto::ResponseHeader* release_header();
-  void set_allocated_header(::cockroach::proto::ResponseHeader* header);
+  // optional .cockroach.proto.KVResponseHeader kvheader = 1;
+  bool has_kvheader() const;
+  void clear_kvheader();
+  static const int kKvheaderFieldNumber = 1;
+  const ::cockroach::proto::KVResponseHeader& kvheader() const;
+  ::cockroach::proto::KVResponseHeader* mutable_kvheader();
+  ::cockroach::proto::KVResponseHeader* release_kvheader();
+  void set_allocated_kvheader(::cockroach::proto::KVResponseHeader* kvheader);
 
   // repeated .cockroach.proto.ResponseUnion responses = 2;
   int responses_size() const;
@@ -2693,13 +2877,13 @@ class BatchResponse : public ::google::protobuf::Message {
 
   // @@protoc_insertion_point(class_scope:cockroach.proto.BatchResponse)
  private:
-  inline void set_has_header();
-  inline void clear_has_header();
+  inline void set_has_kvheader();
+  inline void clear_has_kvheader();
 
   ::google::protobuf::internal::InternalMetadataWithArena _internal_metadata_;
   ::google::protobuf::uint32 _has_bits_[1];
   mutable int _cached_size_;
-  ::cockroach::proto::ResponseHeader* header_;
+  ::cockroach::proto::KVResponseHeader* kvheader_;
   ::google::protobuf::RepeatedPtrField< ::cockroach::proto::ResponseUnion > responses_;
   friend void  protobuf_AddDesc_cockroach_2fproto_2fapi_2eproto();
   friend void protobuf_AssignDesc_cockroach_2fproto_2fapi_2eproto();
@@ -2774,14 +2958,14 @@ class AdminSplitRequest : public ::google::protobuf::Message {
 
   // accessors -------------------------------------------------------
 
-  // optional .cockroach.proto.RequestHeader header = 1;
-  bool has_header() const;
-  void clear_header();
-  static const int kHeaderFieldNumber = 1;
-  const ::cockroach::proto::RequestHeader& header() const;
-  ::cockroach::proto::RequestHeader* mutable_header();
-  ::cockroach::proto::RequestHeader* release_header();
-  void set_allocated_header(::cockroach::proto::RequestHeader* header);
+  // optional .cockroach.proto.KVRequestHeader kvheader = 1;
+  bool has_kvheader() const;
+  void clear_kvheader();
+  static const int kKvheaderFieldNumber = 1;
+  const ::cockroach::proto::KVRequestHeader& kvheader() const;
+  ::cockroach::proto::KVRequestHeader* mutable_kvheader();
+  ::cockroach::proto::KVRequestHeader* release_kvheader();
+  void set_allocated_kvheader(::cockroach::proto::KVRequestHeader* kvheader);
 
   // optional bytes split_key = 2;
   bool has_split_key() const;
@@ -2797,15 +2981,15 @@ class AdminSplitRequest : public ::google::protobuf::Message {
 
   // @@protoc_insertion_point(class_scope:cockroach.proto.AdminSplitRequest)
  private:
-  inline void set_has_header();
-  inline void clear_has_header();
+  inline void set_has_kvheader();
+  inline void clear_has_kvheader();
   inline void set_has_split_key();
   inline void clear_has_split_key();
 
   ::google::protobuf::internal::InternalMetadataWithArena _internal_metadata_;
   ::google::protobuf::uint32 _has_bits_[1];
   mutable int _cached_size_;
-  ::cockroach::proto::RequestHeader* header_;
+  ::cockroach::proto::KVRequestHeader* kvheader_;
   ::google::protobuf::internal::ArenaStringPtr split_key_;
   friend void  protobuf_AddDesc_cockroach_2fproto_2fapi_2eproto();
   friend void protobuf_AssignDesc_cockroach_2fproto_2fapi_2eproto();
@@ -2880,24 +3064,24 @@ class AdminSplitResponse : public ::google::protobuf::Message {
 
   // accessors -------------------------------------------------------
 
-  // optional .cockroach.proto.ResponseHeader header = 1;
-  bool has_header() const;
-  void clear_header();
-  static const int kHeaderFieldNumber = 1;
-  const ::cockroach::proto::ResponseHeader& header() const;
-  ::cockroach::proto::ResponseHeader* mutable_header();
-  ::cockroach::proto::ResponseHeader* release_header();
-  void set_allocated_header(::cockroach::proto::ResponseHeader* header);
+  // optional .cockroach.proto.KVResponseHeader kvheader = 1;
+  bool has_kvheader() const;
+  void clear_kvheader();
+  static const int kKvheaderFieldNumber = 1;
+  const ::cockroach::proto::KVResponseHeader& kvheader() const;
+  ::cockroach::proto::KVResponseHeader* mutable_kvheader();
+  ::cockroach::proto::KVResponseHeader* release_kvheader();
+  void set_allocated_kvheader(::cockroach::proto::KVResponseHeader* kvheader);
 
   // @@protoc_insertion_point(class_scope:cockroach.proto.AdminSplitResponse)
  private:
-  inline void set_has_header();
-  inline void clear_has_header();
+  inline void set_has_kvheader();
+  inline void clear_has_kvheader();
 
   ::google::protobuf::internal::InternalMetadataWithArena _internal_metadata_;
   ::google::protobuf::uint32 _has_bits_[1];
   mutable int _cached_size_;
-  ::cockroach::proto::ResponseHeader* header_;
+  ::cockroach::proto::KVResponseHeader* kvheader_;
   friend void  protobuf_AddDesc_cockroach_2fproto_2fapi_2eproto();
   friend void protobuf_AssignDesc_cockroach_2fproto_2fapi_2eproto();
   friend void protobuf_ShutdownFile_cockroach_2fproto_2fapi_2eproto();
@@ -2971,24 +3155,24 @@ class AdminMergeRequest : public ::google::protobuf::Message {
 
   // accessors -------------------------------------------------------
 
-  // optional .cockroach.proto.RequestHeader header = 1;
-  bool has_header() const;
-  void clear_header();
-  static const int kHeaderFieldNumber = 1;
-  const ::cockroach::proto::RequestHeader& header() const;
-  ::cockroach::proto::RequestHeader* mutable_header();
-  ::cockroach::proto::RequestHeader* release_header();
-  void set_allocated_header(::cockroach::proto::RequestHeader* header);
+  // optional .cockroach.proto.KVRequestHeader kvheader = 1;
+  bool has_kvheader() const;
+  void clear_kvheader();
+  static const int kKvheaderFieldNumber = 1;
+  const ::cockroach::proto::KVRequestHeader& kvheader() const;
+  ::cockroach::proto::KVRequestHeader* mutable_kvheader();
+  ::cockroach::proto::KVRequestHeader* release_kvheader();
+  void set_allocated_kvheader(::cockroach::proto::KVRequestHeader* kvheader);
 
   // @@protoc_insertion_point(class_scope:cockroach.proto.AdminMergeRequest)
  private:
-  inline void set_has_header();
-  inline void clear_has_header();
+  inline void set_has_kvheader();
+  inline void clear_has_kvheader();
 
   ::google::protobuf::internal::InternalMetadataWithArena _internal_metadata_;
   ::google::protobuf::uint32 _has_bits_[1];
   mutable int _cached_size_;
-  ::cockroach::proto::RequestHeader* header_;
+  ::cockroach::proto::KVRequestHeader* kvheader_;
   friend void  protobuf_AddDesc_cockroach_2fproto_2fapi_2eproto();
   friend void protobuf_AssignDesc_cockroach_2fproto_2fapi_2eproto();
   friend void protobuf_ShutdownFile_cockroach_2fproto_2fapi_2eproto();
@@ -3062,24 +3246,24 @@ class AdminMergeResponse : public ::google::protobuf::Message {
 
   // accessors -------------------------------------------------------
 
-  // optional .cockroach.proto.ResponseHeader header = 1;
-  bool has_header() const;
-  void clear_header();
-  static const int kHeaderFieldNumber = 1;
-  const ::cockroach::proto::ResponseHeader& header() const;
-  ::cockroach::proto::ResponseHeader* mutable_header();
-  ::cockroach::proto::ResponseHeader* release_header();
-  void set_allocated_header(::cockroach::proto::ResponseHeader* header);
+  // optional .cockroach.proto.KVResponseHeader kvheader = 1;
+  bool has_kvheader() const;
+  void clear_kvheader();
+  static const int kKvheaderFieldNumber = 1;
+  const ::cockroach::proto::KVResponseHeader& kvheader() const;
+  ::cockroach::proto::KVResponseHeader* mutable_kvheader();
+  ::cockroach::proto::KVResponseHeader* release_kvheader();
+  void set_allocated_kvheader(::cockroach::proto::KVResponseHeader* kvheader);
 
   // @@protoc_insertion_point(class_scope:cockroach.proto.AdminMergeResponse)
  private:
-  inline void set_has_header();
-  inline void clear_has_header();
+  inline void set_has_kvheader();
+  inline void clear_has_kvheader();
 
   ::google::protobuf::internal::InternalMetadataWithArena _internal_metadata_;
   ::google::protobuf::uint32 _has_bits_[1];
   mutable int _cached_size_;
-  ::cockroach::proto::ResponseHeader* header_;
+  ::cockroach::proto::KVResponseHeader* kvheader_;
   friend void  protobuf_AddDesc_cockroach_2fproto_2fapi_2eproto();
   friend void protobuf_AssignDesc_cockroach_2fproto_2fapi_2eproto();
   friend void protobuf_ShutdownFile_cockroach_2fproto_2fapi_2eproto();
@@ -3233,121 +3417,15 @@ inline void RequestHeader::set_allocated_cmd_id(::cockroach::proto::ClientCmdID*
   // @@protoc_insertion_point(field_set_allocated:cockroach.proto.RequestHeader.cmd_id)
 }
 
-// optional bytes key = 3;
-inline bool RequestHeader::has_key() const {
-  return (_has_bits_[0] & 0x00000004u) != 0;
-}
-inline void RequestHeader::set_has_key() {
-  _has_bits_[0] |= 0x00000004u;
-}
-inline void RequestHeader::clear_has_key() {
-  _has_bits_[0] &= ~0x00000004u;
-}
-inline void RequestHeader::clear_key() {
-  key_.ClearToEmptyNoArena(&::google::protobuf::internal::GetEmptyStringAlreadyInited());
-  clear_has_key();
-}
-inline const ::std::string& RequestHeader::key() const {
-  // @@protoc_insertion_point(field_get:cockroach.proto.RequestHeader.key)
-  return key_.GetNoArena(&::google::protobuf::internal::GetEmptyStringAlreadyInited());
-}
-inline void RequestHeader::set_key(const ::std::string& value) {
-  set_has_key();
-  key_.SetNoArena(&::google::protobuf::internal::GetEmptyStringAlreadyInited(), value);
-  // @@protoc_insertion_point(field_set:cockroach.proto.RequestHeader.key)
-}
-inline void RequestHeader::set_key(const char* value) {
-  set_has_key();
-  key_.SetNoArena(&::google::protobuf::internal::GetEmptyStringAlreadyInited(), ::std::string(value));
-  // @@protoc_insertion_point(field_set_char:cockroach.proto.RequestHeader.key)
-}
-inline void RequestHeader::set_key(const void* value, size_t size) {
-  set_has_key();
-  key_.SetNoArena(&::google::protobuf::internal::GetEmptyStringAlreadyInited(),
-      ::std::string(reinterpret_cast<const char*>(value), size));
-  // @@protoc_insertion_point(field_set_pointer:cockroach.proto.RequestHeader.key)
-}
-inline ::std::string* RequestHeader::mutable_key() {
-  set_has_key();
-  // @@protoc_insertion_point(field_mutable:cockroach.proto.RequestHeader.key)
-  return key_.MutableNoArena(&::google::protobuf::internal::GetEmptyStringAlreadyInited());
-}
-inline ::std::string* RequestHeader::release_key() {
-  clear_has_key();
-  return key_.ReleaseNoArena(&::google::protobuf::internal::GetEmptyStringAlreadyInited());
-}
-inline void RequestHeader::set_allocated_key(::std::string* key) {
-  if (key != NULL) {
-    set_has_key();
-  } else {
-    clear_has_key();
-  }
-  key_.SetAllocatedNoArena(&::google::protobuf::internal::GetEmptyStringAlreadyInited(), key);
-  // @@protoc_insertion_point(field_set_allocated:cockroach.proto.RequestHeader.key)
-}
-
-// optional bytes end_key = 4;
-inline bool RequestHeader::has_end_key() const {
-  return (_has_bits_[0] & 0x00000008u) != 0;
-}
-inline void RequestHeader::set_has_end_key() {
-  _has_bits_[0] |= 0x00000008u;
-}
-inline void RequestHeader::clear_has_end_key() {
-  _has_bits_[0] &= ~0x00000008u;
-}
-inline void RequestHeader::clear_end_key() {
-  end_key_.ClearToEmptyNoArena(&::google::protobuf::internal::GetEmptyStringAlreadyInited());
-  clear_has_end_key();
-}
-inline const ::std::string& RequestHeader::end_key() const {
-  // @@protoc_insertion_point(field_get:cockroach.proto.RequestHeader.end_key)
-  return end_key_.GetNoArena(&::google::protobuf::internal::GetEmptyStringAlreadyInited());
-}
-inline void RequestHeader::set_end_key(const ::std::string& value) {
-  set_has_end_key();
-  end_key_.SetNoArena(&::google::protobuf::internal::GetEmptyStringAlreadyInited(), value);
-  // @@protoc_insertion_point(field_set:cockroach.proto.RequestHeader.end_key)
-}
-inline void RequestHeader::set_end_key(const char* value) {
-  set_has_end_key();
-  end_key_.SetNoArena(&::google::protobuf::internal::GetEmptyStringAlreadyInited(), ::std::string(value));
-  // @@protoc_insertion_point(field_set_char:cockroach.proto.RequestHeader.end_key)
-}
-inline void RequestHeader::set_end_key(const void* value, size_t size) {
-  set_has_end_key();
-  end_key_.SetNoArena(&::google::protobuf::internal::GetEmptyStringAlreadyInited(),
-      ::std::string(reinterpret_cast<const char*>(value), size));
-  // @@protoc_insertion_point(field_set_pointer:cockroach.proto.RequestHeader.end_key)
-}
-inline ::std::string* RequestHeader::mutable_end_key() {
-  set_has_end_key();
-  // @@protoc_insertion_point(field_mutable:cockroach.proto.RequestHeader.end_key)
-  return end_key_.MutableNoArena(&::google::protobuf::internal::GetEmptyStringAlreadyInited());
-}
-inline ::std::string* RequestHeader::release_end_key() {
-  clear_has_end_key();
-  return end_key_.ReleaseNoArena(&::google::protobuf::internal::GetEmptyStringAlreadyInited());
-}
-inline void RequestHeader::set_allocated_end_key(::std::string* end_key) {
-  if (end_key != NULL) {
-    set_has_end_key();
-  } else {
-    clear_has_end_key();
-  }
-  end_key_.SetAllocatedNoArena(&::google::protobuf::internal::GetEmptyStringAlreadyInited(), end_key);
-  // @@protoc_insertion_point(field_set_allocated:cockroach.proto.RequestHeader.end_key)
-}
-
 // optional string user = 5;
 inline bool RequestHeader::has_user() const {
-  return (_has_bits_[0] & 0x00000010u) != 0;
+  return (_has_bits_[0] & 0x00000004u) != 0;
 }
 inline void RequestHeader::set_has_user() {
-  _has_bits_[0] |= 0x00000010u;
+  _has_bits_[0] |= 0x00000004u;
 }
 inline void RequestHeader::clear_has_user() {
-  _has_bits_[0] &= ~0x00000010u;
+  _has_bits_[0] &= ~0x00000004u;
 }
 inline void RequestHeader::clear_user() {
   user_.ClearToEmptyNoArena(&::google::protobuf::internal::GetEmptyStringAlreadyInited());
@@ -3392,82 +3470,15 @@ inline void RequestHeader::set_allocated_user(::std::string* user) {
   // @@protoc_insertion_point(field_set_allocated:cockroach.proto.RequestHeader.user)
 }
 
-// optional .cockroach.proto.Replica replica = 6;
-inline bool RequestHeader::has_replica() const {
-  return (_has_bits_[0] & 0x00000020u) != 0;
-}
-inline void RequestHeader::set_has_replica() {
-  _has_bits_[0] |= 0x00000020u;
-}
-inline void RequestHeader::clear_has_replica() {
-  _has_bits_[0] &= ~0x00000020u;
-}
-inline void RequestHeader::clear_replica() {
-  if (replica_ != NULL) replica_->::cockroach::proto::Replica::Clear();
-  clear_has_replica();
-}
-inline const ::cockroach::proto::Replica& RequestHeader::replica() const {
-  // @@protoc_insertion_point(field_get:cockroach.proto.RequestHeader.replica)
-  return replica_ != NULL ? *replica_ : *default_instance_->replica_;
-}
-inline ::cockroach::proto::Replica* RequestHeader::mutable_replica() {
-  set_has_replica();
-  if (replica_ == NULL) {
-    replica_ = new ::cockroach::proto::Replica;
-  }
-  // @@protoc_insertion_point(field_mutable:cockroach.proto.RequestHeader.replica)
-  return replica_;
-}
-inline ::cockroach::proto::Replica* RequestHeader::release_replica() {
-  clear_has_replica();
-  ::cockroach::proto::Replica* temp = replica_;
-  replica_ = NULL;
-  return temp;
-}
-inline void RequestHeader::set_allocated_replica(::cockroach::proto::Replica* replica) {
-  delete replica_;
-  replica_ = replica;
-  if (replica) {
-    set_has_replica();
-  } else {
-    clear_has_replica();
-  }
-  // @@protoc_insertion_point(field_set_allocated:cockroach.proto.RequestHeader.replica)
-}
-
-// optional int64 raft_id = 7;
-inline bool RequestHeader::has_raft_id() const {
-  return (_has_bits_[0] & 0x00000040u) != 0;
-}
-inline void RequestHeader::set_has_raft_id() {
-  _has_bits_[0] |= 0x00000040u;
-}
-inline void RequestHeader::clear_has_raft_id() {
-  _has_bits_[0] &= ~0x00000040u;
-}
-inline void RequestHeader::clear_raft_id() {
-  raft_id_ = GOOGLE_LONGLONG(0);
-  clear_has_raft_id();
-}
-inline ::google::protobuf::int64 RequestHeader::raft_id() const {
-  // @@protoc_insertion_point(field_get:cockroach.proto.RequestHeader.raft_id)
-  return raft_id_;
-}
-inline void RequestHeader::set_raft_id(::google::protobuf::int64 value) {
-  set_has_raft_id();
-  raft_id_ = value;
-  // @@protoc_insertion_point(field_set:cockroach.proto.RequestHeader.raft_id)
-}
-
 // optional int32 user_priority = 8 [default = 1];
 inline bool RequestHeader::has_user_priority() const {
-  return (_has_bits_[0] & 0x00000080u) != 0;
+  return (_has_bits_[0] & 0x00000008u) != 0;
 }
 inline void RequestHeader::set_has_user_priority() {
-  _has_bits_[0] |= 0x00000080u;
+  _has_bits_[0] |= 0x00000008u;
 }
 inline void RequestHeader::clear_has_user_priority() {
-  _has_bits_[0] &= ~0x00000080u;
+  _has_bits_[0] &= ~0x00000008u;
 }
 inline void RequestHeader::clear_user_priority() {
   user_priority_ = 1;
@@ -3485,13 +3496,13 @@ inline void RequestHeader::set_user_priority(::google::protobuf::int32 value) {
 
 // optional .cockroach.proto.Transaction txn = 9;
 inline bool RequestHeader::has_txn() const {
-  return (_has_bits_[0] & 0x00000100u) != 0;
+  return (_has_bits_[0] & 0x00000010u) != 0;
 }
 inline void RequestHeader::set_has_txn() {
-  _has_bits_[0] |= 0x00000100u;
+  _has_bits_[0] |= 0x00000010u;
 }
 inline void RequestHeader::clear_has_txn() {
-  _has_bits_[0] &= ~0x00000100u;
+  _has_bits_[0] &= ~0x00000010u;
 }
 inline void RequestHeader::clear_txn() {
   if (txn_ != NULL) txn_->::cockroach::proto::Transaction::Clear();
@@ -3528,13 +3539,13 @@ inline void RequestHeader::set_allocated_txn(::cockroach::proto::Transaction* tx
 
 // optional .cockroach.proto.ReadConsistencyType read_consistency = 10;
 inline bool RequestHeader::has_read_consistency() const {
-  return (_has_bits_[0] & 0x00000200u) != 0;
+  return (_has_bits_[0] & 0x00000020u) != 0;
 }
 inline void RequestHeader::set_has_read_consistency() {
-  _has_bits_[0] |= 0x00000200u;
+  _has_bits_[0] |= 0x00000020u;
 }
 inline void RequestHeader::clear_has_read_consistency() {
-  _has_bits_[0] &= ~0x00000200u;
+  _has_bits_[0] &= ~0x00000020u;
 }
 inline void RequestHeader::clear_read_consistency() {
   read_consistency_ = 0;
@@ -3686,41 +3697,41 @@ inline void ResponseHeader::set_allocated_txn(::cockroach::proto::Transaction* t
 
 // -------------------------------------------------------------------
 
-// GetRequest
+// KVRequestHeader
 
 // optional .cockroach.proto.RequestHeader header = 1;
-inline bool GetRequest::has_header() const {
+inline bool KVRequestHeader::has_header() const {
   return (_has_bits_[0] & 0x00000001u) != 0;
 }
-inline void GetRequest::set_has_header() {
+inline void KVRequestHeader::set_has_header() {
   _has_bits_[0] |= 0x00000001u;
 }
-inline void GetRequest::clear_has_header() {
+inline void KVRequestHeader::clear_has_header() {
   _has_bits_[0] &= ~0x00000001u;
 }
-inline void GetRequest::clear_header() {
+inline void KVRequestHeader::clear_header() {
   if (header_ != NULL) header_->::cockroach::proto::RequestHeader::Clear();
   clear_has_header();
 }
-inline const ::cockroach::proto::RequestHeader& GetRequest::header() const {
-  // @@protoc_insertion_point(field_get:cockroach.proto.GetRequest.header)
+inline const ::cockroach::proto::RequestHeader& KVRequestHeader::header() const {
+  // @@protoc_insertion_point(field_get:cockroach.proto.KVRequestHeader.header)
   return header_ != NULL ? *header_ : *default_instance_->header_;
 }
-inline ::cockroach::proto::RequestHeader* GetRequest::mutable_header() {
+inline ::cockroach::proto::RequestHeader* KVRequestHeader::mutable_header() {
   set_has_header();
   if (header_ == NULL) {
     header_ = new ::cockroach::proto::RequestHeader;
   }
-  // @@protoc_insertion_point(field_mutable:cockroach.proto.GetRequest.header)
+  // @@protoc_insertion_point(field_mutable:cockroach.proto.KVRequestHeader.header)
   return header_;
 }
-inline ::cockroach::proto::RequestHeader* GetRequest::release_header() {
+inline ::cockroach::proto::RequestHeader* KVRequestHeader::release_header() {
   clear_has_header();
   ::cockroach::proto::RequestHeader* temp = header_;
   header_ = NULL;
   return temp;
 }
-inline void GetRequest::set_allocated_header(::cockroach::proto::RequestHeader* header) {
+inline void KVRequestHeader::set_allocated_header(::cockroach::proto::RequestHeader* header) {
   delete header_;
   header_ = header;
   if (header) {
@@ -3728,54 +3739,321 @@ inline void GetRequest::set_allocated_header(::cockroach::proto::RequestHeader* 
   } else {
     clear_has_header();
   }
-  // @@protoc_insertion_point(field_set_allocated:cockroach.proto.GetRequest.header)
+  // @@protoc_insertion_point(field_set_allocated:cockroach.proto.KVRequestHeader.header)
+}
+
+// optional bytes key = 3;
+inline bool KVRequestHeader::has_key() const {
+  return (_has_bits_[0] & 0x00000002u) != 0;
+}
+inline void KVRequestHeader::set_has_key() {
+  _has_bits_[0] |= 0x00000002u;
+}
+inline void KVRequestHeader::clear_has_key() {
+  _has_bits_[0] &= ~0x00000002u;
+}
+inline void KVRequestHeader::clear_key() {
+  key_.ClearToEmptyNoArena(&::google::protobuf::internal::GetEmptyStringAlreadyInited());
+  clear_has_key();
+}
+inline const ::std::string& KVRequestHeader::key() const {
+  // @@protoc_insertion_point(field_get:cockroach.proto.KVRequestHeader.key)
+  return key_.GetNoArena(&::google::protobuf::internal::GetEmptyStringAlreadyInited());
+}
+inline void KVRequestHeader::set_key(const ::std::string& value) {
+  set_has_key();
+  key_.SetNoArena(&::google::protobuf::internal::GetEmptyStringAlreadyInited(), value);
+  // @@protoc_insertion_point(field_set:cockroach.proto.KVRequestHeader.key)
+}
+inline void KVRequestHeader::set_key(const char* value) {
+  set_has_key();
+  key_.SetNoArena(&::google::protobuf::internal::GetEmptyStringAlreadyInited(), ::std::string(value));
+  // @@protoc_insertion_point(field_set_char:cockroach.proto.KVRequestHeader.key)
+}
+inline void KVRequestHeader::set_key(const void* value, size_t size) {
+  set_has_key();
+  key_.SetNoArena(&::google::protobuf::internal::GetEmptyStringAlreadyInited(),
+      ::std::string(reinterpret_cast<const char*>(value), size));
+  // @@protoc_insertion_point(field_set_pointer:cockroach.proto.KVRequestHeader.key)
+}
+inline ::std::string* KVRequestHeader::mutable_key() {
+  set_has_key();
+  // @@protoc_insertion_point(field_mutable:cockroach.proto.KVRequestHeader.key)
+  return key_.MutableNoArena(&::google::protobuf::internal::GetEmptyStringAlreadyInited());
+}
+inline ::std::string* KVRequestHeader::release_key() {
+  clear_has_key();
+  return key_.ReleaseNoArena(&::google::protobuf::internal::GetEmptyStringAlreadyInited());
+}
+inline void KVRequestHeader::set_allocated_key(::std::string* key) {
+  if (key != NULL) {
+    set_has_key();
+  } else {
+    clear_has_key();
+  }
+  key_.SetAllocatedNoArena(&::google::protobuf::internal::GetEmptyStringAlreadyInited(), key);
+  // @@protoc_insertion_point(field_set_allocated:cockroach.proto.KVRequestHeader.key)
+}
+
+// optional bytes end_key = 4;
+inline bool KVRequestHeader::has_end_key() const {
+  return (_has_bits_[0] & 0x00000004u) != 0;
+}
+inline void KVRequestHeader::set_has_end_key() {
+  _has_bits_[0] |= 0x00000004u;
+}
+inline void KVRequestHeader::clear_has_end_key() {
+  _has_bits_[0] &= ~0x00000004u;
+}
+inline void KVRequestHeader::clear_end_key() {
+  end_key_.ClearToEmptyNoArena(&::google::protobuf::internal::GetEmptyStringAlreadyInited());
+  clear_has_end_key();
+}
+inline const ::std::string& KVRequestHeader::end_key() const {
+  // @@protoc_insertion_point(field_get:cockroach.proto.KVRequestHeader.end_key)
+  return end_key_.GetNoArena(&::google::protobuf::internal::GetEmptyStringAlreadyInited());
+}
+inline void KVRequestHeader::set_end_key(const ::std::string& value) {
+  set_has_end_key();
+  end_key_.SetNoArena(&::google::protobuf::internal::GetEmptyStringAlreadyInited(), value);
+  // @@protoc_insertion_point(field_set:cockroach.proto.KVRequestHeader.end_key)
+}
+inline void KVRequestHeader::set_end_key(const char* value) {
+  set_has_end_key();
+  end_key_.SetNoArena(&::google::protobuf::internal::GetEmptyStringAlreadyInited(), ::std::string(value));
+  // @@protoc_insertion_point(field_set_char:cockroach.proto.KVRequestHeader.end_key)
+}
+inline void KVRequestHeader::set_end_key(const void* value, size_t size) {
+  set_has_end_key();
+  end_key_.SetNoArena(&::google::protobuf::internal::GetEmptyStringAlreadyInited(),
+      ::std::string(reinterpret_cast<const char*>(value), size));
+  // @@protoc_insertion_point(field_set_pointer:cockroach.proto.KVRequestHeader.end_key)
+}
+inline ::std::string* KVRequestHeader::mutable_end_key() {
+  set_has_end_key();
+  // @@protoc_insertion_point(field_mutable:cockroach.proto.KVRequestHeader.end_key)
+  return end_key_.MutableNoArena(&::google::protobuf::internal::GetEmptyStringAlreadyInited());
+}
+inline ::std::string* KVRequestHeader::release_end_key() {
+  clear_has_end_key();
+  return end_key_.ReleaseNoArena(&::google::protobuf::internal::GetEmptyStringAlreadyInited());
+}
+inline void KVRequestHeader::set_allocated_end_key(::std::string* end_key) {
+  if (end_key != NULL) {
+    set_has_end_key();
+  } else {
+    clear_has_end_key();
+  }
+  end_key_.SetAllocatedNoArena(&::google::protobuf::internal::GetEmptyStringAlreadyInited(), end_key);
+  // @@protoc_insertion_point(field_set_allocated:cockroach.proto.KVRequestHeader.end_key)
+}
+
+// optional .cockroach.proto.Replica replica = 6;
+inline bool KVRequestHeader::has_replica() const {
+  return (_has_bits_[0] & 0x00000008u) != 0;
+}
+inline void KVRequestHeader::set_has_replica() {
+  _has_bits_[0] |= 0x00000008u;
+}
+inline void KVRequestHeader::clear_has_replica() {
+  _has_bits_[0] &= ~0x00000008u;
+}
+inline void KVRequestHeader::clear_replica() {
+  if (replica_ != NULL) replica_->::cockroach::proto::Replica::Clear();
+  clear_has_replica();
+}
+inline const ::cockroach::proto::Replica& KVRequestHeader::replica() const {
+  // @@protoc_insertion_point(field_get:cockroach.proto.KVRequestHeader.replica)
+  return replica_ != NULL ? *replica_ : *default_instance_->replica_;
+}
+inline ::cockroach::proto::Replica* KVRequestHeader::mutable_replica() {
+  set_has_replica();
+  if (replica_ == NULL) {
+    replica_ = new ::cockroach::proto::Replica;
+  }
+  // @@protoc_insertion_point(field_mutable:cockroach.proto.KVRequestHeader.replica)
+  return replica_;
+}
+inline ::cockroach::proto::Replica* KVRequestHeader::release_replica() {
+  clear_has_replica();
+  ::cockroach::proto::Replica* temp = replica_;
+  replica_ = NULL;
+  return temp;
+}
+inline void KVRequestHeader::set_allocated_replica(::cockroach::proto::Replica* replica) {
+  delete replica_;
+  replica_ = replica;
+  if (replica) {
+    set_has_replica();
+  } else {
+    clear_has_replica();
+  }
+  // @@protoc_insertion_point(field_set_allocated:cockroach.proto.KVRequestHeader.replica)
+}
+
+// optional int64 raft_id = 7;
+inline bool KVRequestHeader::has_raft_id() const {
+  return (_has_bits_[0] & 0x00000010u) != 0;
+}
+inline void KVRequestHeader::set_has_raft_id() {
+  _has_bits_[0] |= 0x00000010u;
+}
+inline void KVRequestHeader::clear_has_raft_id() {
+  _has_bits_[0] &= ~0x00000010u;
+}
+inline void KVRequestHeader::clear_raft_id() {
+  raft_id_ = GOOGLE_LONGLONG(0);
+  clear_has_raft_id();
+}
+inline ::google::protobuf::int64 KVRequestHeader::raft_id() const {
+  // @@protoc_insertion_point(field_get:cockroach.proto.KVRequestHeader.raft_id)
+  return raft_id_;
+}
+inline void KVRequestHeader::set_raft_id(::google::protobuf::int64 value) {
+  set_has_raft_id();
+  raft_id_ = value;
+  // @@protoc_insertion_point(field_set:cockroach.proto.KVRequestHeader.raft_id)
+}
+
+// -------------------------------------------------------------------
+
+// KVResponseHeader
+
+// optional .cockroach.proto.ResponseHeader header = 1;
+inline bool KVResponseHeader::has_header() const {
+  return (_has_bits_[0] & 0x00000001u) != 0;
+}
+inline void KVResponseHeader::set_has_header() {
+  _has_bits_[0] |= 0x00000001u;
+}
+inline void KVResponseHeader::clear_has_header() {
+  _has_bits_[0] &= ~0x00000001u;
+}
+inline void KVResponseHeader::clear_header() {
+  if (header_ != NULL) header_->::cockroach::proto::ResponseHeader::Clear();
+  clear_has_header();
+}
+inline const ::cockroach::proto::ResponseHeader& KVResponseHeader::header() const {
+  // @@protoc_insertion_point(field_get:cockroach.proto.KVResponseHeader.header)
+  return header_ != NULL ? *header_ : *default_instance_->header_;
+}
+inline ::cockroach::proto::ResponseHeader* KVResponseHeader::mutable_header() {
+  set_has_header();
+  if (header_ == NULL) {
+    header_ = new ::cockroach::proto::ResponseHeader;
+  }
+  // @@protoc_insertion_point(field_mutable:cockroach.proto.KVResponseHeader.header)
+  return header_;
+}
+inline ::cockroach::proto::ResponseHeader* KVResponseHeader::release_header() {
+  clear_has_header();
+  ::cockroach::proto::ResponseHeader* temp = header_;
+  header_ = NULL;
+  return temp;
+}
+inline void KVResponseHeader::set_allocated_header(::cockroach::proto::ResponseHeader* header) {
+  delete header_;
+  header_ = header;
+  if (header) {
+    set_has_header();
+  } else {
+    clear_has_header();
+  }
+  // @@protoc_insertion_point(field_set_allocated:cockroach.proto.KVResponseHeader.header)
+}
+
+// -------------------------------------------------------------------
+
+// GetRequest
+
+// optional .cockroach.proto.KVRequestHeader kvheader = 1;
+inline bool GetRequest::has_kvheader() const {
+  return (_has_bits_[0] & 0x00000001u) != 0;
+}
+inline void GetRequest::set_has_kvheader() {
+  _has_bits_[0] |= 0x00000001u;
+}
+inline void GetRequest::clear_has_kvheader() {
+  _has_bits_[0] &= ~0x00000001u;
+}
+inline void GetRequest::clear_kvheader() {
+  if (kvheader_ != NULL) kvheader_->::cockroach::proto::KVRequestHeader::Clear();
+  clear_has_kvheader();
+}
+inline const ::cockroach::proto::KVRequestHeader& GetRequest::kvheader() const {
+  // @@protoc_insertion_point(field_get:cockroach.proto.GetRequest.kvheader)
+  return kvheader_ != NULL ? *kvheader_ : *default_instance_->kvheader_;
+}
+inline ::cockroach::proto::KVRequestHeader* GetRequest::mutable_kvheader() {
+  set_has_kvheader();
+  if (kvheader_ == NULL) {
+    kvheader_ = new ::cockroach::proto::KVRequestHeader;
+  }
+  // @@protoc_insertion_point(field_mutable:cockroach.proto.GetRequest.kvheader)
+  return kvheader_;
+}
+inline ::cockroach::proto::KVRequestHeader* GetRequest::release_kvheader() {
+  clear_has_kvheader();
+  ::cockroach::proto::KVRequestHeader* temp = kvheader_;
+  kvheader_ = NULL;
+  return temp;
+}
+inline void GetRequest::set_allocated_kvheader(::cockroach::proto::KVRequestHeader* kvheader) {
+  delete kvheader_;
+  kvheader_ = kvheader;
+  if (kvheader) {
+    set_has_kvheader();
+  } else {
+    clear_has_kvheader();
+  }
+  // @@protoc_insertion_point(field_set_allocated:cockroach.proto.GetRequest.kvheader)
 }
 
 // -------------------------------------------------------------------
 
 // GetResponse
 
-// optional .cockroach.proto.ResponseHeader header = 1;
-inline bool GetResponse::has_header() const {
+// optional .cockroach.proto.KVResponseHeader kvheader = 1;
+inline bool GetResponse::has_kvheader() const {
   return (_has_bits_[0] & 0x00000001u) != 0;
 }
-inline void GetResponse::set_has_header() {
+inline void GetResponse::set_has_kvheader() {
   _has_bits_[0] |= 0x00000001u;
 }
-inline void GetResponse::clear_has_header() {
+inline void GetResponse::clear_has_kvheader() {
   _has_bits_[0] &= ~0x00000001u;
 }
-inline void GetResponse::clear_header() {
-  if (header_ != NULL) header_->::cockroach::proto::ResponseHeader::Clear();
-  clear_has_header();
+inline void GetResponse::clear_kvheader() {
+  if (kvheader_ != NULL) kvheader_->::cockroach::proto::KVResponseHeader::Clear();
+  clear_has_kvheader();
 }
-inline const ::cockroach::proto::ResponseHeader& GetResponse::header() const {
-  // @@protoc_insertion_point(field_get:cockroach.proto.GetResponse.header)
-  return header_ != NULL ? *header_ : *default_instance_->header_;
+inline const ::cockroach::proto::KVResponseHeader& GetResponse::kvheader() const {
+  // @@protoc_insertion_point(field_get:cockroach.proto.GetResponse.kvheader)
+  return kvheader_ != NULL ? *kvheader_ : *default_instance_->kvheader_;
 }
-inline ::cockroach::proto::ResponseHeader* GetResponse::mutable_header() {
-  set_has_header();
-  if (header_ == NULL) {
-    header_ = new ::cockroach::proto::ResponseHeader;
+inline ::cockroach::proto::KVResponseHeader* GetResponse::mutable_kvheader() {
+  set_has_kvheader();
+  if (kvheader_ == NULL) {
+    kvheader_ = new ::cockroach::proto::KVResponseHeader;
   }
-  // @@protoc_insertion_point(field_mutable:cockroach.proto.GetResponse.header)
-  return header_;
+  // @@protoc_insertion_point(field_mutable:cockroach.proto.GetResponse.kvheader)
+  return kvheader_;
 }
-inline ::cockroach::proto::ResponseHeader* GetResponse::release_header() {
-  clear_has_header();
-  ::cockroach::proto::ResponseHeader* temp = header_;
-  header_ = NULL;
+inline ::cockroach::proto::KVResponseHeader* GetResponse::release_kvheader() {
+  clear_has_kvheader();
+  ::cockroach::proto::KVResponseHeader* temp = kvheader_;
+  kvheader_ = NULL;
   return temp;
 }
-inline void GetResponse::set_allocated_header(::cockroach::proto::ResponseHeader* header) {
-  delete header_;
-  header_ = header;
-  if (header) {
-    set_has_header();
+inline void GetResponse::set_allocated_kvheader(::cockroach::proto::KVResponseHeader* kvheader) {
+  delete kvheader_;
+  kvheader_ = kvheader;
+  if (kvheader) {
+    set_has_kvheader();
   } else {
-    clear_has_header();
+    clear_has_kvheader();
   }
-  // @@protoc_insertion_point(field_set_allocated:cockroach.proto.GetResponse.header)
+  // @@protoc_insertion_point(field_set_allocated:cockroach.proto.GetResponse.kvheader)
 }
 
 // optional .cockroach.proto.Value value = 2;
@@ -3825,47 +4103,47 @@ inline void GetResponse::set_allocated_value(::cockroach::proto::Value* value) {
 
 // PutRequest
 
-// optional .cockroach.proto.RequestHeader header = 1;
-inline bool PutRequest::has_header() const {
+// optional .cockroach.proto.KVRequestHeader kvheader = 1;
+inline bool PutRequest::has_kvheader() const {
   return (_has_bits_[0] & 0x00000001u) != 0;
 }
-inline void PutRequest::set_has_header() {
+inline void PutRequest::set_has_kvheader() {
   _has_bits_[0] |= 0x00000001u;
 }
-inline void PutRequest::clear_has_header() {
+inline void PutRequest::clear_has_kvheader() {
   _has_bits_[0] &= ~0x00000001u;
 }
-inline void PutRequest::clear_header() {
-  if (header_ != NULL) header_->::cockroach::proto::RequestHeader::Clear();
-  clear_has_header();
+inline void PutRequest::clear_kvheader() {
+  if (kvheader_ != NULL) kvheader_->::cockroach::proto::KVRequestHeader::Clear();
+  clear_has_kvheader();
 }
-inline const ::cockroach::proto::RequestHeader& PutRequest::header() const {
-  // @@protoc_insertion_point(field_get:cockroach.proto.PutRequest.header)
-  return header_ != NULL ? *header_ : *default_instance_->header_;
+inline const ::cockroach::proto::KVRequestHeader& PutRequest::kvheader() const {
+  // @@protoc_insertion_point(field_get:cockroach.proto.PutRequest.kvheader)
+  return kvheader_ != NULL ? *kvheader_ : *default_instance_->kvheader_;
 }
-inline ::cockroach::proto::RequestHeader* PutRequest::mutable_header() {
-  set_has_header();
-  if (header_ == NULL) {
-    header_ = new ::cockroach::proto::RequestHeader;
+inline ::cockroach::proto::KVRequestHeader* PutRequest::mutable_kvheader() {
+  set_has_kvheader();
+  if (kvheader_ == NULL) {
+    kvheader_ = new ::cockroach::proto::KVRequestHeader;
   }
-  // @@protoc_insertion_point(field_mutable:cockroach.proto.PutRequest.header)
-  return header_;
+  // @@protoc_insertion_point(field_mutable:cockroach.proto.PutRequest.kvheader)
+  return kvheader_;
 }
-inline ::cockroach::proto::RequestHeader* PutRequest::release_header() {
-  clear_has_header();
-  ::cockroach::proto::RequestHeader* temp = header_;
-  header_ = NULL;
+inline ::cockroach::proto::KVRequestHeader* PutRequest::release_kvheader() {
+  clear_has_kvheader();
+  ::cockroach::proto::KVRequestHeader* temp = kvheader_;
+  kvheader_ = NULL;
   return temp;
 }
-inline void PutRequest::set_allocated_header(::cockroach::proto::RequestHeader* header) {
-  delete header_;
-  header_ = header;
-  if (header) {
-    set_has_header();
+inline void PutRequest::set_allocated_kvheader(::cockroach::proto::KVRequestHeader* kvheader) {
+  delete kvheader_;
+  kvheader_ = kvheader;
+  if (kvheader) {
+    set_has_kvheader();
   } else {
-    clear_has_header();
+    clear_has_kvheader();
   }
-  // @@protoc_insertion_point(field_set_allocated:cockroach.proto.PutRequest.header)
+  // @@protoc_insertion_point(field_set_allocated:cockroach.proto.PutRequest.kvheader)
 }
 
 // optional .cockroach.proto.Value value = 2;
@@ -3915,94 +4193,94 @@ inline void PutRequest::set_allocated_value(::cockroach::proto::Value* value) {
 
 // PutResponse
 
-// optional .cockroach.proto.ResponseHeader header = 1;
-inline bool PutResponse::has_header() const {
+// optional .cockroach.proto.KVResponseHeader kvheader = 1;
+inline bool PutResponse::has_kvheader() const {
   return (_has_bits_[0] & 0x00000001u) != 0;
 }
-inline void PutResponse::set_has_header() {
+inline void PutResponse::set_has_kvheader() {
   _has_bits_[0] |= 0x00000001u;
 }
-inline void PutResponse::clear_has_header() {
+inline void PutResponse::clear_has_kvheader() {
   _has_bits_[0] &= ~0x00000001u;
 }
-inline void PutResponse::clear_header() {
-  if (header_ != NULL) header_->::cockroach::proto::ResponseHeader::Clear();
-  clear_has_header();
+inline void PutResponse::clear_kvheader() {
+  if (kvheader_ != NULL) kvheader_->::cockroach::proto::KVResponseHeader::Clear();
+  clear_has_kvheader();
 }
-inline const ::cockroach::proto::ResponseHeader& PutResponse::header() const {
-  // @@protoc_insertion_point(field_get:cockroach.proto.PutResponse.header)
-  return header_ != NULL ? *header_ : *default_instance_->header_;
+inline const ::cockroach::proto::KVResponseHeader& PutResponse::kvheader() const {
+  // @@protoc_insertion_point(field_get:cockroach.proto.PutResponse.kvheader)
+  return kvheader_ != NULL ? *kvheader_ : *default_instance_->kvheader_;
 }
-inline ::cockroach::proto::ResponseHeader* PutResponse::mutable_header() {
-  set_has_header();
-  if (header_ == NULL) {
-    header_ = new ::cockroach::proto::ResponseHeader;
+inline ::cockroach::proto::KVResponseHeader* PutResponse::mutable_kvheader() {
+  set_has_kvheader();
+  if (kvheader_ == NULL) {
+    kvheader_ = new ::cockroach::proto::KVResponseHeader;
   }
-  // @@protoc_insertion_point(field_mutable:cockroach.proto.PutResponse.header)
-  return header_;
+  // @@protoc_insertion_point(field_mutable:cockroach.proto.PutResponse.kvheader)
+  return kvheader_;
 }
-inline ::cockroach::proto::ResponseHeader* PutResponse::release_header() {
-  clear_has_header();
-  ::cockroach::proto::ResponseHeader* temp = header_;
-  header_ = NULL;
+inline ::cockroach::proto::KVResponseHeader* PutResponse::release_kvheader() {
+  clear_has_kvheader();
+  ::cockroach::proto::KVResponseHeader* temp = kvheader_;
+  kvheader_ = NULL;
   return temp;
 }
-inline void PutResponse::set_allocated_header(::cockroach::proto::ResponseHeader* header) {
-  delete header_;
-  header_ = header;
-  if (header) {
-    set_has_header();
+inline void PutResponse::set_allocated_kvheader(::cockroach::proto::KVResponseHeader* kvheader) {
+  delete kvheader_;
+  kvheader_ = kvheader;
+  if (kvheader) {
+    set_has_kvheader();
   } else {
-    clear_has_header();
+    clear_has_kvheader();
   }
-  // @@protoc_insertion_point(field_set_allocated:cockroach.proto.PutResponse.header)
+  // @@protoc_insertion_point(field_set_allocated:cockroach.proto.PutResponse.kvheader)
 }
 
 // -------------------------------------------------------------------
 
 // ConditionalPutRequest
 
-// optional .cockroach.proto.RequestHeader header = 1;
-inline bool ConditionalPutRequest::has_header() const {
+// optional .cockroach.proto.KVRequestHeader kvheader = 1;
+inline bool ConditionalPutRequest::has_kvheader() const {
   return (_has_bits_[0] & 0x00000001u) != 0;
 }
-inline void ConditionalPutRequest::set_has_header() {
+inline void ConditionalPutRequest::set_has_kvheader() {
   _has_bits_[0] |= 0x00000001u;
 }
-inline void ConditionalPutRequest::clear_has_header() {
+inline void ConditionalPutRequest::clear_has_kvheader() {
   _has_bits_[0] &= ~0x00000001u;
 }
-inline void ConditionalPutRequest::clear_header() {
-  if (header_ != NULL) header_->::cockroach::proto::RequestHeader::Clear();
-  clear_has_header();
+inline void ConditionalPutRequest::clear_kvheader() {
+  if (kvheader_ != NULL) kvheader_->::cockroach::proto::KVRequestHeader::Clear();
+  clear_has_kvheader();
 }
-inline const ::cockroach::proto::RequestHeader& ConditionalPutRequest::header() const {
-  // @@protoc_insertion_point(field_get:cockroach.proto.ConditionalPutRequest.header)
-  return header_ != NULL ? *header_ : *default_instance_->header_;
+inline const ::cockroach::proto::KVRequestHeader& ConditionalPutRequest::kvheader() const {
+  // @@protoc_insertion_point(field_get:cockroach.proto.ConditionalPutRequest.kvheader)
+  return kvheader_ != NULL ? *kvheader_ : *default_instance_->kvheader_;
 }
-inline ::cockroach::proto::RequestHeader* ConditionalPutRequest::mutable_header() {
-  set_has_header();
-  if (header_ == NULL) {
-    header_ = new ::cockroach::proto::RequestHeader;
+inline ::cockroach::proto::KVRequestHeader* ConditionalPutRequest::mutable_kvheader() {
+  set_has_kvheader();
+  if (kvheader_ == NULL) {
+    kvheader_ = new ::cockroach::proto::KVRequestHeader;
   }
-  // @@protoc_insertion_point(field_mutable:cockroach.proto.ConditionalPutRequest.header)
-  return header_;
+  // @@protoc_insertion_point(field_mutable:cockroach.proto.ConditionalPutRequest.kvheader)
+  return kvheader_;
 }
-inline ::cockroach::proto::RequestHeader* ConditionalPutRequest::release_header() {
-  clear_has_header();
-  ::cockroach::proto::RequestHeader* temp = header_;
-  header_ = NULL;
+inline ::cockroach::proto::KVRequestHeader* ConditionalPutRequest::release_kvheader() {
+  clear_has_kvheader();
+  ::cockroach::proto::KVRequestHeader* temp = kvheader_;
+  kvheader_ = NULL;
   return temp;
 }
-inline void ConditionalPutRequest::set_allocated_header(::cockroach::proto::RequestHeader* header) {
-  delete header_;
-  header_ = header;
-  if (header) {
-    set_has_header();
+inline void ConditionalPutRequest::set_allocated_kvheader(::cockroach::proto::KVRequestHeader* kvheader) {
+  delete kvheader_;
+  kvheader_ = kvheader;
+  if (kvheader) {
+    set_has_kvheader();
   } else {
-    clear_has_header();
+    clear_has_kvheader();
   }
-  // @@protoc_insertion_point(field_set_allocated:cockroach.proto.ConditionalPutRequest.header)
+  // @@protoc_insertion_point(field_set_allocated:cockroach.proto.ConditionalPutRequest.kvheader)
 }
 
 // optional .cockroach.proto.Value value = 2;
@@ -4095,94 +4373,94 @@ inline void ConditionalPutRequest::set_allocated_exp_value(::cockroach::proto::V
 
 // ConditionalPutResponse
 
-// optional .cockroach.proto.ResponseHeader header = 1;
-inline bool ConditionalPutResponse::has_header() const {
+// optional .cockroach.proto.KVResponseHeader kvheader = 1;
+inline bool ConditionalPutResponse::has_kvheader() const {
   return (_has_bits_[0] & 0x00000001u) != 0;
 }
-inline void ConditionalPutResponse::set_has_header() {
+inline void ConditionalPutResponse::set_has_kvheader() {
   _has_bits_[0] |= 0x00000001u;
 }
-inline void ConditionalPutResponse::clear_has_header() {
+inline void ConditionalPutResponse::clear_has_kvheader() {
   _has_bits_[0] &= ~0x00000001u;
 }
-inline void ConditionalPutResponse::clear_header() {
-  if (header_ != NULL) header_->::cockroach::proto::ResponseHeader::Clear();
-  clear_has_header();
+inline void ConditionalPutResponse::clear_kvheader() {
+  if (kvheader_ != NULL) kvheader_->::cockroach::proto::KVResponseHeader::Clear();
+  clear_has_kvheader();
 }
-inline const ::cockroach::proto::ResponseHeader& ConditionalPutResponse::header() const {
-  // @@protoc_insertion_point(field_get:cockroach.proto.ConditionalPutResponse.header)
-  return header_ != NULL ? *header_ : *default_instance_->header_;
+inline const ::cockroach::proto::KVResponseHeader& ConditionalPutResponse::kvheader() const {
+  // @@protoc_insertion_point(field_get:cockroach.proto.ConditionalPutResponse.kvheader)
+  return kvheader_ != NULL ? *kvheader_ : *default_instance_->kvheader_;
 }
-inline ::cockroach::proto::ResponseHeader* ConditionalPutResponse::mutable_header() {
-  set_has_header();
-  if (header_ == NULL) {
-    header_ = new ::cockroach::proto::ResponseHeader;
+inline ::cockroach::proto::KVResponseHeader* ConditionalPutResponse::mutable_kvheader() {
+  set_has_kvheader();
+  if (kvheader_ == NULL) {
+    kvheader_ = new ::cockroach::proto::KVResponseHeader;
   }
-  // @@protoc_insertion_point(field_mutable:cockroach.proto.ConditionalPutResponse.header)
-  return header_;
+  // @@protoc_insertion_point(field_mutable:cockroach.proto.ConditionalPutResponse.kvheader)
+  return kvheader_;
 }
-inline ::cockroach::proto::ResponseHeader* ConditionalPutResponse::release_header() {
-  clear_has_header();
-  ::cockroach::proto::ResponseHeader* temp = header_;
-  header_ = NULL;
+inline ::cockroach::proto::KVResponseHeader* ConditionalPutResponse::release_kvheader() {
+  clear_has_kvheader();
+  ::cockroach::proto::KVResponseHeader* temp = kvheader_;
+  kvheader_ = NULL;
   return temp;
 }
-inline void ConditionalPutResponse::set_allocated_header(::cockroach::proto::ResponseHeader* header) {
-  delete header_;
-  header_ = header;
-  if (header) {
-    set_has_header();
+inline void ConditionalPutResponse::set_allocated_kvheader(::cockroach::proto::KVResponseHeader* kvheader) {
+  delete kvheader_;
+  kvheader_ = kvheader;
+  if (kvheader) {
+    set_has_kvheader();
   } else {
-    clear_has_header();
+    clear_has_kvheader();
   }
-  // @@protoc_insertion_point(field_set_allocated:cockroach.proto.ConditionalPutResponse.header)
+  // @@protoc_insertion_point(field_set_allocated:cockroach.proto.ConditionalPutResponse.kvheader)
 }
 
 // -------------------------------------------------------------------
 
 // IncrementRequest
 
-// optional .cockroach.proto.RequestHeader header = 1;
-inline bool IncrementRequest::has_header() const {
+// optional .cockroach.proto.KVRequestHeader kvheader = 1;
+inline bool IncrementRequest::has_kvheader() const {
   return (_has_bits_[0] & 0x00000001u) != 0;
 }
-inline void IncrementRequest::set_has_header() {
+inline void IncrementRequest::set_has_kvheader() {
   _has_bits_[0] |= 0x00000001u;
 }
-inline void IncrementRequest::clear_has_header() {
+inline void IncrementRequest::clear_has_kvheader() {
   _has_bits_[0] &= ~0x00000001u;
 }
-inline void IncrementRequest::clear_header() {
-  if (header_ != NULL) header_->::cockroach::proto::RequestHeader::Clear();
-  clear_has_header();
+inline void IncrementRequest::clear_kvheader() {
+  if (kvheader_ != NULL) kvheader_->::cockroach::proto::KVRequestHeader::Clear();
+  clear_has_kvheader();
 }
-inline const ::cockroach::proto::RequestHeader& IncrementRequest::header() const {
-  // @@protoc_insertion_point(field_get:cockroach.proto.IncrementRequest.header)
-  return header_ != NULL ? *header_ : *default_instance_->header_;
+inline const ::cockroach::proto::KVRequestHeader& IncrementRequest::kvheader() const {
+  // @@protoc_insertion_point(field_get:cockroach.proto.IncrementRequest.kvheader)
+  return kvheader_ != NULL ? *kvheader_ : *default_instance_->kvheader_;
 }
-inline ::cockroach::proto::RequestHeader* IncrementRequest::mutable_header() {
-  set_has_header();
-  if (header_ == NULL) {
-    header_ = new ::cockroach::proto::RequestHeader;
+inline ::cockroach::proto::KVRequestHeader* IncrementRequest::mutable_kvheader() {
+  set_has_kvheader();
+  if (kvheader_ == NULL) {
+    kvheader_ = new ::cockroach::proto::KVRequestHeader;
   }
-  // @@protoc_insertion_point(field_mutable:cockroach.proto.IncrementRequest.header)
-  return header_;
+  // @@protoc_insertion_point(field_mutable:cockroach.proto.IncrementRequest.kvheader)
+  return kvheader_;
 }
-inline ::cockroach::proto::RequestHeader* IncrementRequest::release_header() {
-  clear_has_header();
-  ::cockroach::proto::RequestHeader* temp = header_;
-  header_ = NULL;
+inline ::cockroach::proto::KVRequestHeader* IncrementRequest::release_kvheader() {
+  clear_has_kvheader();
+  ::cockroach::proto::KVRequestHeader* temp = kvheader_;
+  kvheader_ = NULL;
   return temp;
 }
-inline void IncrementRequest::set_allocated_header(::cockroach::proto::RequestHeader* header) {
-  delete header_;
-  header_ = header;
-  if (header) {
-    set_has_header();
+inline void IncrementRequest::set_allocated_kvheader(::cockroach::proto::KVRequestHeader* kvheader) {
+  delete kvheader_;
+  kvheader_ = kvheader;
+  if (kvheader) {
+    set_has_kvheader();
   } else {
-    clear_has_header();
+    clear_has_kvheader();
   }
-  // @@protoc_insertion_point(field_set_allocated:cockroach.proto.IncrementRequest.header)
+  // @@protoc_insertion_point(field_set_allocated:cockroach.proto.IncrementRequest.kvheader)
 }
 
 // optional int64 increment = 2;
@@ -4213,47 +4491,47 @@ inline void IncrementRequest::set_increment(::google::protobuf::int64 value) {
 
 // IncrementResponse
 
-// optional .cockroach.proto.ResponseHeader header = 1;
-inline bool IncrementResponse::has_header() const {
+// optional .cockroach.proto.KVResponseHeader kvheader = 1;
+inline bool IncrementResponse::has_kvheader() const {
   return (_has_bits_[0] & 0x00000001u) != 0;
 }
-inline void IncrementResponse::set_has_header() {
+inline void IncrementResponse::set_has_kvheader() {
   _has_bits_[0] |= 0x00000001u;
 }
-inline void IncrementResponse::clear_has_header() {
+inline void IncrementResponse::clear_has_kvheader() {
   _has_bits_[0] &= ~0x00000001u;
 }
-inline void IncrementResponse::clear_header() {
-  if (header_ != NULL) header_->::cockroach::proto::ResponseHeader::Clear();
-  clear_has_header();
+inline void IncrementResponse::clear_kvheader() {
+  if (kvheader_ != NULL) kvheader_->::cockroach::proto::KVResponseHeader::Clear();
+  clear_has_kvheader();
 }
-inline const ::cockroach::proto::ResponseHeader& IncrementResponse::header() const {
-  // @@protoc_insertion_point(field_get:cockroach.proto.IncrementResponse.header)
-  return header_ != NULL ? *header_ : *default_instance_->header_;
+inline const ::cockroach::proto::KVResponseHeader& IncrementResponse::kvheader() const {
+  // @@protoc_insertion_point(field_get:cockroach.proto.IncrementResponse.kvheader)
+  return kvheader_ != NULL ? *kvheader_ : *default_instance_->kvheader_;
 }
-inline ::cockroach::proto::ResponseHeader* IncrementResponse::mutable_header() {
-  set_has_header();
-  if (header_ == NULL) {
-    header_ = new ::cockroach::proto::ResponseHeader;
+inline ::cockroach::proto::KVResponseHeader* IncrementResponse::mutable_kvheader() {
+  set_has_kvheader();
+  if (kvheader_ == NULL) {
+    kvheader_ = new ::cockroach::proto::KVResponseHeader;
   }
-  // @@protoc_insertion_point(field_mutable:cockroach.proto.IncrementResponse.header)
-  return header_;
+  // @@protoc_insertion_point(field_mutable:cockroach.proto.IncrementResponse.kvheader)
+  return kvheader_;
 }
-inline ::cockroach::proto::ResponseHeader* IncrementResponse::release_header() {
-  clear_has_header();
-  ::cockroach::proto::ResponseHeader* temp = header_;
-  header_ = NULL;
+inline ::cockroach::proto::KVResponseHeader* IncrementResponse::release_kvheader() {
+  clear_has_kvheader();
+  ::cockroach::proto::KVResponseHeader* temp = kvheader_;
+  kvheader_ = NULL;
   return temp;
 }
-inline void IncrementResponse::set_allocated_header(::cockroach::proto::ResponseHeader* header) {
-  delete header_;
-  header_ = header;
-  if (header) {
-    set_has_header();
+inline void IncrementResponse::set_allocated_kvheader(::cockroach::proto::KVResponseHeader* kvheader) {
+  delete kvheader_;
+  kvheader_ = kvheader;
+  if (kvheader) {
+    set_has_kvheader();
   } else {
-    clear_has_header();
+    clear_has_kvheader();
   }
-  // @@protoc_insertion_point(field_set_allocated:cockroach.proto.IncrementResponse.header)
+  // @@protoc_insertion_point(field_set_allocated:cockroach.proto.IncrementResponse.kvheader)
 }
 
 // optional int64 new_value = 2;
@@ -4284,141 +4562,141 @@ inline void IncrementResponse::set_new_value(::google::protobuf::int64 value) {
 
 // DeleteRequest
 
-// optional .cockroach.proto.RequestHeader header = 1;
-inline bool DeleteRequest::has_header() const {
+// optional .cockroach.proto.KVRequestHeader kvheader = 1;
+inline bool DeleteRequest::has_kvheader() const {
   return (_has_bits_[0] & 0x00000001u) != 0;
 }
-inline void DeleteRequest::set_has_header() {
+inline void DeleteRequest::set_has_kvheader() {
   _has_bits_[0] |= 0x00000001u;
 }
-inline void DeleteRequest::clear_has_header() {
+inline void DeleteRequest::clear_has_kvheader() {
   _has_bits_[0] &= ~0x00000001u;
 }
-inline void DeleteRequest::clear_header() {
-  if (header_ != NULL) header_->::cockroach::proto::RequestHeader::Clear();
-  clear_has_header();
+inline void DeleteRequest::clear_kvheader() {
+  if (kvheader_ != NULL) kvheader_->::cockroach::proto::KVRequestHeader::Clear();
+  clear_has_kvheader();
 }
-inline const ::cockroach::proto::RequestHeader& DeleteRequest::header() const {
-  // @@protoc_insertion_point(field_get:cockroach.proto.DeleteRequest.header)
-  return header_ != NULL ? *header_ : *default_instance_->header_;
+inline const ::cockroach::proto::KVRequestHeader& DeleteRequest::kvheader() const {
+  // @@protoc_insertion_point(field_get:cockroach.proto.DeleteRequest.kvheader)
+  return kvheader_ != NULL ? *kvheader_ : *default_instance_->kvheader_;
 }
-inline ::cockroach::proto::RequestHeader* DeleteRequest::mutable_header() {
-  set_has_header();
-  if (header_ == NULL) {
-    header_ = new ::cockroach::proto::RequestHeader;
+inline ::cockroach::proto::KVRequestHeader* DeleteRequest::mutable_kvheader() {
+  set_has_kvheader();
+  if (kvheader_ == NULL) {
+    kvheader_ = new ::cockroach::proto::KVRequestHeader;
   }
-  // @@protoc_insertion_point(field_mutable:cockroach.proto.DeleteRequest.header)
-  return header_;
+  // @@protoc_insertion_point(field_mutable:cockroach.proto.DeleteRequest.kvheader)
+  return kvheader_;
 }
-inline ::cockroach::proto::RequestHeader* DeleteRequest::release_header() {
-  clear_has_header();
-  ::cockroach::proto::RequestHeader* temp = header_;
-  header_ = NULL;
+inline ::cockroach::proto::KVRequestHeader* DeleteRequest::release_kvheader() {
+  clear_has_kvheader();
+  ::cockroach::proto::KVRequestHeader* temp = kvheader_;
+  kvheader_ = NULL;
   return temp;
 }
-inline void DeleteRequest::set_allocated_header(::cockroach::proto::RequestHeader* header) {
-  delete header_;
-  header_ = header;
-  if (header) {
-    set_has_header();
+inline void DeleteRequest::set_allocated_kvheader(::cockroach::proto::KVRequestHeader* kvheader) {
+  delete kvheader_;
+  kvheader_ = kvheader;
+  if (kvheader) {
+    set_has_kvheader();
   } else {
-    clear_has_header();
+    clear_has_kvheader();
   }
-  // @@protoc_insertion_point(field_set_allocated:cockroach.proto.DeleteRequest.header)
+  // @@protoc_insertion_point(field_set_allocated:cockroach.proto.DeleteRequest.kvheader)
 }
 
 // -------------------------------------------------------------------
 
 // DeleteResponse
 
-// optional .cockroach.proto.ResponseHeader header = 1;
-inline bool DeleteResponse::has_header() const {
+// optional .cockroach.proto.KVResponseHeader kvheader = 1;
+inline bool DeleteResponse::has_kvheader() const {
   return (_has_bits_[0] & 0x00000001u) != 0;
 }
-inline void DeleteResponse::set_has_header() {
+inline void DeleteResponse::set_has_kvheader() {
   _has_bits_[0] |= 0x00000001u;
 }
-inline void DeleteResponse::clear_has_header() {
+inline void DeleteResponse::clear_has_kvheader() {
   _has_bits_[0] &= ~0x00000001u;
 }
-inline void DeleteResponse::clear_header() {
-  if (header_ != NULL) header_->::cockroach::proto::ResponseHeader::Clear();
-  clear_has_header();
+inline void DeleteResponse::clear_kvheader() {
+  if (kvheader_ != NULL) kvheader_->::cockroach::proto::KVResponseHeader::Clear();
+  clear_has_kvheader();
 }
-inline const ::cockroach::proto::ResponseHeader& DeleteResponse::header() const {
-  // @@protoc_insertion_point(field_get:cockroach.proto.DeleteResponse.header)
-  return header_ != NULL ? *header_ : *default_instance_->header_;
+inline const ::cockroach::proto::KVResponseHeader& DeleteResponse::kvheader() const {
+  // @@protoc_insertion_point(field_get:cockroach.proto.DeleteResponse.kvheader)
+  return kvheader_ != NULL ? *kvheader_ : *default_instance_->kvheader_;
 }
-inline ::cockroach::proto::ResponseHeader* DeleteResponse::mutable_header() {
-  set_has_header();
-  if (header_ == NULL) {
-    header_ = new ::cockroach::proto::ResponseHeader;
+inline ::cockroach::proto::KVResponseHeader* DeleteResponse::mutable_kvheader() {
+  set_has_kvheader();
+  if (kvheader_ == NULL) {
+    kvheader_ = new ::cockroach::proto::KVResponseHeader;
   }
-  // @@protoc_insertion_point(field_mutable:cockroach.proto.DeleteResponse.header)
-  return header_;
+  // @@protoc_insertion_point(field_mutable:cockroach.proto.DeleteResponse.kvheader)
+  return kvheader_;
 }
-inline ::cockroach::proto::ResponseHeader* DeleteResponse::release_header() {
-  clear_has_header();
-  ::cockroach::proto::ResponseHeader* temp = header_;
-  header_ = NULL;
+inline ::cockroach::proto::KVResponseHeader* DeleteResponse::release_kvheader() {
+  clear_has_kvheader();
+  ::cockroach::proto::KVResponseHeader* temp = kvheader_;
+  kvheader_ = NULL;
   return temp;
 }
-inline void DeleteResponse::set_allocated_header(::cockroach::proto::ResponseHeader* header) {
-  delete header_;
-  header_ = header;
-  if (header) {
-    set_has_header();
+inline void DeleteResponse::set_allocated_kvheader(::cockroach::proto::KVResponseHeader* kvheader) {
+  delete kvheader_;
+  kvheader_ = kvheader;
+  if (kvheader) {
+    set_has_kvheader();
   } else {
-    clear_has_header();
+    clear_has_kvheader();
   }
-  // @@protoc_insertion_point(field_set_allocated:cockroach.proto.DeleteResponse.header)
+  // @@protoc_insertion_point(field_set_allocated:cockroach.proto.DeleteResponse.kvheader)
 }
 
 // -------------------------------------------------------------------
 
 // DeleteRangeRequest
 
-// optional .cockroach.proto.RequestHeader header = 1;
-inline bool DeleteRangeRequest::has_header() const {
+// optional .cockroach.proto.KVRequestHeader kvheader = 1;
+inline bool DeleteRangeRequest::has_kvheader() const {
   return (_has_bits_[0] & 0x00000001u) != 0;
 }
-inline void DeleteRangeRequest::set_has_header() {
+inline void DeleteRangeRequest::set_has_kvheader() {
   _has_bits_[0] |= 0x00000001u;
 }
-inline void DeleteRangeRequest::clear_has_header() {
+inline void DeleteRangeRequest::clear_has_kvheader() {
   _has_bits_[0] &= ~0x00000001u;
 }
-inline void DeleteRangeRequest::clear_header() {
-  if (header_ != NULL) header_->::cockroach::proto::RequestHeader::Clear();
-  clear_has_header();
+inline void DeleteRangeRequest::clear_kvheader() {
+  if (kvheader_ != NULL) kvheader_->::cockroach::proto::KVRequestHeader::Clear();
+  clear_has_kvheader();
 }
-inline const ::cockroach::proto::RequestHeader& DeleteRangeRequest::header() const {
-  // @@protoc_insertion_point(field_get:cockroach.proto.DeleteRangeRequest.header)
-  return header_ != NULL ? *header_ : *default_instance_->header_;
+inline const ::cockroach::proto::KVRequestHeader& DeleteRangeRequest::kvheader() const {
+  // @@protoc_insertion_point(field_get:cockroach.proto.DeleteRangeRequest.kvheader)
+  return kvheader_ != NULL ? *kvheader_ : *default_instance_->kvheader_;
 }
-inline ::cockroach::proto::RequestHeader* DeleteRangeRequest::mutable_header() {
-  set_has_header();
-  if (header_ == NULL) {
-    header_ = new ::cockroach::proto::RequestHeader;
+inline ::cockroach::proto::KVRequestHeader* DeleteRangeRequest::mutable_kvheader() {
+  set_has_kvheader();
+  if (kvheader_ == NULL) {
+    kvheader_ = new ::cockroach::proto::KVRequestHeader;
   }
-  // @@protoc_insertion_point(field_mutable:cockroach.proto.DeleteRangeRequest.header)
-  return header_;
+  // @@protoc_insertion_point(field_mutable:cockroach.proto.DeleteRangeRequest.kvheader)
+  return kvheader_;
 }
-inline ::cockroach::proto::RequestHeader* DeleteRangeRequest::release_header() {
-  clear_has_header();
-  ::cockroach::proto::RequestHeader* temp = header_;
-  header_ = NULL;
+inline ::cockroach::proto::KVRequestHeader* DeleteRangeRequest::release_kvheader() {
+  clear_has_kvheader();
+  ::cockroach::proto::KVRequestHeader* temp = kvheader_;
+  kvheader_ = NULL;
   return temp;
 }
-inline void DeleteRangeRequest::set_allocated_header(::cockroach::proto::RequestHeader* header) {
-  delete header_;
-  header_ = header;
-  if (header) {
-    set_has_header();
+inline void DeleteRangeRequest::set_allocated_kvheader(::cockroach::proto::KVRequestHeader* kvheader) {
+  delete kvheader_;
+  kvheader_ = kvheader;
+  if (kvheader) {
+    set_has_kvheader();
   } else {
-    clear_has_header();
+    clear_has_kvheader();
   }
-  // @@protoc_insertion_point(field_set_allocated:cockroach.proto.DeleteRangeRequest.header)
+  // @@protoc_insertion_point(field_set_allocated:cockroach.proto.DeleteRangeRequest.kvheader)
 }
 
 // optional int64 max_entries_to_delete = 2;
@@ -4449,47 +4727,47 @@ inline void DeleteRangeRequest::set_max_entries_to_delete(::google::protobuf::in
 
 // DeleteRangeResponse
 
-// optional .cockroach.proto.ResponseHeader header = 1;
-inline bool DeleteRangeResponse::has_header() const {
+// optional .cockroach.proto.KVResponseHeader kvheader = 1;
+inline bool DeleteRangeResponse::has_kvheader() const {
   return (_has_bits_[0] & 0x00000001u) != 0;
 }
-inline void DeleteRangeResponse::set_has_header() {
+inline void DeleteRangeResponse::set_has_kvheader() {
   _has_bits_[0] |= 0x00000001u;
 }
-inline void DeleteRangeResponse::clear_has_header() {
+inline void DeleteRangeResponse::clear_has_kvheader() {
   _has_bits_[0] &= ~0x00000001u;
 }
-inline void DeleteRangeResponse::clear_header() {
-  if (header_ != NULL) header_->::cockroach::proto::ResponseHeader::Clear();
-  clear_has_header();
+inline void DeleteRangeResponse::clear_kvheader() {
+  if (kvheader_ != NULL) kvheader_->::cockroach::proto::KVResponseHeader::Clear();
+  clear_has_kvheader();
 }
-inline const ::cockroach::proto::ResponseHeader& DeleteRangeResponse::header() const {
-  // @@protoc_insertion_point(field_get:cockroach.proto.DeleteRangeResponse.header)
-  return header_ != NULL ? *header_ : *default_instance_->header_;
+inline const ::cockroach::proto::KVResponseHeader& DeleteRangeResponse::kvheader() const {
+  // @@protoc_insertion_point(field_get:cockroach.proto.DeleteRangeResponse.kvheader)
+  return kvheader_ != NULL ? *kvheader_ : *default_instance_->kvheader_;
 }
-inline ::cockroach::proto::ResponseHeader* DeleteRangeResponse::mutable_header() {
-  set_has_header();
-  if (header_ == NULL) {
-    header_ = new ::cockroach::proto::ResponseHeader;
+inline ::cockroach::proto::KVResponseHeader* DeleteRangeResponse::mutable_kvheader() {
+  set_has_kvheader();
+  if (kvheader_ == NULL) {
+    kvheader_ = new ::cockroach::proto::KVResponseHeader;
   }
-  // @@protoc_insertion_point(field_mutable:cockroach.proto.DeleteRangeResponse.header)
-  return header_;
+  // @@protoc_insertion_point(field_mutable:cockroach.proto.DeleteRangeResponse.kvheader)
+  return kvheader_;
 }
-inline ::cockroach::proto::ResponseHeader* DeleteRangeResponse::release_header() {
-  clear_has_header();
-  ::cockroach::proto::ResponseHeader* temp = header_;
-  header_ = NULL;
+inline ::cockroach::proto::KVResponseHeader* DeleteRangeResponse::release_kvheader() {
+  clear_has_kvheader();
+  ::cockroach::proto::KVResponseHeader* temp = kvheader_;
+  kvheader_ = NULL;
   return temp;
 }
-inline void DeleteRangeResponse::set_allocated_header(::cockroach::proto::ResponseHeader* header) {
-  delete header_;
-  header_ = header;
-  if (header) {
-    set_has_header();
+inline void DeleteRangeResponse::set_allocated_kvheader(::cockroach::proto::KVResponseHeader* kvheader) {
+  delete kvheader_;
+  kvheader_ = kvheader;
+  if (kvheader) {
+    set_has_kvheader();
   } else {
-    clear_has_header();
+    clear_has_kvheader();
   }
-  // @@protoc_insertion_point(field_set_allocated:cockroach.proto.DeleteRangeResponse.header)
+  // @@protoc_insertion_point(field_set_allocated:cockroach.proto.DeleteRangeResponse.kvheader)
 }
 
 // optional int64 num_deleted = 2;
@@ -4520,47 +4798,47 @@ inline void DeleteRangeResponse::set_num_deleted(::google::protobuf::int64 value
 
 // ScanRequest
 
-// optional .cockroach.proto.RequestHeader header = 1;
-inline bool ScanRequest::has_header() const {
+// optional .cockroach.proto.KVRequestHeader kvheader = 1;
+inline bool ScanRequest::has_kvheader() const {
   return (_has_bits_[0] & 0x00000001u) != 0;
 }
-inline void ScanRequest::set_has_header() {
+inline void ScanRequest::set_has_kvheader() {
   _has_bits_[0] |= 0x00000001u;
 }
-inline void ScanRequest::clear_has_header() {
+inline void ScanRequest::clear_has_kvheader() {
   _has_bits_[0] &= ~0x00000001u;
 }
-inline void ScanRequest::clear_header() {
-  if (header_ != NULL) header_->::cockroach::proto::RequestHeader::Clear();
-  clear_has_header();
+inline void ScanRequest::clear_kvheader() {
+  if (kvheader_ != NULL) kvheader_->::cockroach::proto::KVRequestHeader::Clear();
+  clear_has_kvheader();
 }
-inline const ::cockroach::proto::RequestHeader& ScanRequest::header() const {
-  // @@protoc_insertion_point(field_get:cockroach.proto.ScanRequest.header)
-  return header_ != NULL ? *header_ : *default_instance_->header_;
+inline const ::cockroach::proto::KVRequestHeader& ScanRequest::kvheader() const {
+  // @@protoc_insertion_point(field_get:cockroach.proto.ScanRequest.kvheader)
+  return kvheader_ != NULL ? *kvheader_ : *default_instance_->kvheader_;
 }
-inline ::cockroach::proto::RequestHeader* ScanRequest::mutable_header() {
-  set_has_header();
-  if (header_ == NULL) {
-    header_ = new ::cockroach::proto::RequestHeader;
+inline ::cockroach::proto::KVRequestHeader* ScanRequest::mutable_kvheader() {
+  set_has_kvheader();
+  if (kvheader_ == NULL) {
+    kvheader_ = new ::cockroach::proto::KVRequestHeader;
   }
-  // @@protoc_insertion_point(field_mutable:cockroach.proto.ScanRequest.header)
-  return header_;
+  // @@protoc_insertion_point(field_mutable:cockroach.proto.ScanRequest.kvheader)
+  return kvheader_;
 }
-inline ::cockroach::proto::RequestHeader* ScanRequest::release_header() {
-  clear_has_header();
-  ::cockroach::proto::RequestHeader* temp = header_;
-  header_ = NULL;
+inline ::cockroach::proto::KVRequestHeader* ScanRequest::release_kvheader() {
+  clear_has_kvheader();
+  ::cockroach::proto::KVRequestHeader* temp = kvheader_;
+  kvheader_ = NULL;
   return temp;
 }
-inline void ScanRequest::set_allocated_header(::cockroach::proto::RequestHeader* header) {
-  delete header_;
-  header_ = header;
-  if (header) {
-    set_has_header();
+inline void ScanRequest::set_allocated_kvheader(::cockroach::proto::KVRequestHeader* kvheader) {
+  delete kvheader_;
+  kvheader_ = kvheader;
+  if (kvheader) {
+    set_has_kvheader();
   } else {
-    clear_has_header();
+    clear_has_kvheader();
   }
-  // @@protoc_insertion_point(field_set_allocated:cockroach.proto.ScanRequest.header)
+  // @@protoc_insertion_point(field_set_allocated:cockroach.proto.ScanRequest.kvheader)
 }
 
 // optional int64 max_results = 2;
@@ -4591,47 +4869,47 @@ inline void ScanRequest::set_max_results(::google::protobuf::int64 value) {
 
 // ScanResponse
 
-// optional .cockroach.proto.ResponseHeader header = 1;
-inline bool ScanResponse::has_header() const {
+// optional .cockroach.proto.KVResponseHeader kvheader = 1;
+inline bool ScanResponse::has_kvheader() const {
   return (_has_bits_[0] & 0x00000001u) != 0;
 }
-inline void ScanResponse::set_has_header() {
+inline void ScanResponse::set_has_kvheader() {
   _has_bits_[0] |= 0x00000001u;
 }
-inline void ScanResponse::clear_has_header() {
+inline void ScanResponse::clear_has_kvheader() {
   _has_bits_[0] &= ~0x00000001u;
 }
-inline void ScanResponse::clear_header() {
-  if (header_ != NULL) header_->::cockroach::proto::ResponseHeader::Clear();
-  clear_has_header();
+inline void ScanResponse::clear_kvheader() {
+  if (kvheader_ != NULL) kvheader_->::cockroach::proto::KVResponseHeader::Clear();
+  clear_has_kvheader();
 }
-inline const ::cockroach::proto::ResponseHeader& ScanResponse::header() const {
-  // @@protoc_insertion_point(field_get:cockroach.proto.ScanResponse.header)
-  return header_ != NULL ? *header_ : *default_instance_->header_;
+inline const ::cockroach::proto::KVResponseHeader& ScanResponse::kvheader() const {
+  // @@protoc_insertion_point(field_get:cockroach.proto.ScanResponse.kvheader)
+  return kvheader_ != NULL ? *kvheader_ : *default_instance_->kvheader_;
 }
-inline ::cockroach::proto::ResponseHeader* ScanResponse::mutable_header() {
-  set_has_header();
-  if (header_ == NULL) {
-    header_ = new ::cockroach::proto::ResponseHeader;
+inline ::cockroach::proto::KVResponseHeader* ScanResponse::mutable_kvheader() {
+  set_has_kvheader();
+  if (kvheader_ == NULL) {
+    kvheader_ = new ::cockroach::proto::KVResponseHeader;
   }
-  // @@protoc_insertion_point(field_mutable:cockroach.proto.ScanResponse.header)
-  return header_;
+  // @@protoc_insertion_point(field_mutable:cockroach.proto.ScanResponse.kvheader)
+  return kvheader_;
 }
-inline ::cockroach::proto::ResponseHeader* ScanResponse::release_header() {
-  clear_has_header();
-  ::cockroach::proto::ResponseHeader* temp = header_;
-  header_ = NULL;
+inline ::cockroach::proto::KVResponseHeader* ScanResponse::release_kvheader() {
+  clear_has_kvheader();
+  ::cockroach::proto::KVResponseHeader* temp = kvheader_;
+  kvheader_ = NULL;
   return temp;
 }
-inline void ScanResponse::set_allocated_header(::cockroach::proto::ResponseHeader* header) {
-  delete header_;
-  header_ = header;
-  if (header) {
-    set_has_header();
+inline void ScanResponse::set_allocated_kvheader(::cockroach::proto::KVResponseHeader* kvheader) {
+  delete kvheader_;
+  kvheader_ = kvheader;
+  if (kvheader) {
+    set_has_kvheader();
   } else {
-    clear_has_header();
+    clear_has_kvheader();
   }
-  // @@protoc_insertion_point(field_set_allocated:cockroach.proto.ScanResponse.header)
+  // @@protoc_insertion_point(field_set_allocated:cockroach.proto.ScanResponse.kvheader)
 }
 
 // repeated .cockroach.proto.KeyValue rows = 2;
@@ -4668,47 +4946,47 @@ ScanResponse::mutable_rows() {
 
 // EndTransactionRequest
 
-// optional .cockroach.proto.RequestHeader header = 1;
-inline bool EndTransactionRequest::has_header() const {
+// optional .cockroach.proto.KVRequestHeader kvheader = 1;
+inline bool EndTransactionRequest::has_kvheader() const {
   return (_has_bits_[0] & 0x00000001u) != 0;
 }
-inline void EndTransactionRequest::set_has_header() {
+inline void EndTransactionRequest::set_has_kvheader() {
   _has_bits_[0] |= 0x00000001u;
 }
-inline void EndTransactionRequest::clear_has_header() {
+inline void EndTransactionRequest::clear_has_kvheader() {
   _has_bits_[0] &= ~0x00000001u;
 }
-inline void EndTransactionRequest::clear_header() {
-  if (header_ != NULL) header_->::cockroach::proto::RequestHeader::Clear();
-  clear_has_header();
+inline void EndTransactionRequest::clear_kvheader() {
+  if (kvheader_ != NULL) kvheader_->::cockroach::proto::KVRequestHeader::Clear();
+  clear_has_kvheader();
 }
-inline const ::cockroach::proto::RequestHeader& EndTransactionRequest::header() const {
-  // @@protoc_insertion_point(field_get:cockroach.proto.EndTransactionRequest.header)
-  return header_ != NULL ? *header_ : *default_instance_->header_;
+inline const ::cockroach::proto::KVRequestHeader& EndTransactionRequest::kvheader() const {
+  // @@protoc_insertion_point(field_get:cockroach.proto.EndTransactionRequest.kvheader)
+  return kvheader_ != NULL ? *kvheader_ : *default_instance_->kvheader_;
 }
-inline ::cockroach::proto::RequestHeader* EndTransactionRequest::mutable_header() {
-  set_has_header();
-  if (header_ == NULL) {
-    header_ = new ::cockroach::proto::RequestHeader;
+inline ::cockroach::proto::KVRequestHeader* EndTransactionRequest::mutable_kvheader() {
+  set_has_kvheader();
+  if (kvheader_ == NULL) {
+    kvheader_ = new ::cockroach::proto::KVRequestHeader;
   }
-  // @@protoc_insertion_point(field_mutable:cockroach.proto.EndTransactionRequest.header)
-  return header_;
+  // @@protoc_insertion_point(field_mutable:cockroach.proto.EndTransactionRequest.kvheader)
+  return kvheader_;
 }
-inline ::cockroach::proto::RequestHeader* EndTransactionRequest::release_header() {
-  clear_has_header();
-  ::cockroach::proto::RequestHeader* temp = header_;
-  header_ = NULL;
+inline ::cockroach::proto::KVRequestHeader* EndTransactionRequest::release_kvheader() {
+  clear_has_kvheader();
+  ::cockroach::proto::KVRequestHeader* temp = kvheader_;
+  kvheader_ = NULL;
   return temp;
 }
-inline void EndTransactionRequest::set_allocated_header(::cockroach::proto::RequestHeader* header) {
-  delete header_;
-  header_ = header;
-  if (header) {
-    set_has_header();
+inline void EndTransactionRequest::set_allocated_kvheader(::cockroach::proto::KVRequestHeader* kvheader) {
+  delete kvheader_;
+  kvheader_ = kvheader;
+  if (kvheader) {
+    set_has_kvheader();
   } else {
-    clear_has_header();
+    clear_has_kvheader();
   }
-  // @@protoc_insertion_point(field_set_allocated:cockroach.proto.EndTransactionRequest.header)
+  // @@protoc_insertion_point(field_set_allocated:cockroach.proto.EndTransactionRequest.kvheader)
 }
 
 // optional bool commit = 2;
@@ -4782,47 +5060,47 @@ inline void EndTransactionRequest::set_allocated_internal_commit_trigger(::cockr
 
 // EndTransactionResponse
 
-// optional .cockroach.proto.ResponseHeader header = 1;
-inline bool EndTransactionResponse::has_header() const {
+// optional .cockroach.proto.KVResponseHeader kvheader = 1;
+inline bool EndTransactionResponse::has_kvheader() const {
   return (_has_bits_[0] & 0x00000001u) != 0;
 }
-inline void EndTransactionResponse::set_has_header() {
+inline void EndTransactionResponse::set_has_kvheader() {
   _has_bits_[0] |= 0x00000001u;
 }
-inline void EndTransactionResponse::clear_has_header() {
+inline void EndTransactionResponse::clear_has_kvheader() {
   _has_bits_[0] &= ~0x00000001u;
 }
-inline void EndTransactionResponse::clear_header() {
-  if (header_ != NULL) header_->::cockroach::proto::ResponseHeader::Clear();
-  clear_has_header();
+inline void EndTransactionResponse::clear_kvheader() {
+  if (kvheader_ != NULL) kvheader_->::cockroach::proto::KVResponseHeader::Clear();
+  clear_has_kvheader();
 }
-inline const ::cockroach::proto::ResponseHeader& EndTransactionResponse::header() const {
-  // @@protoc_insertion_point(field_get:cockroach.proto.EndTransactionResponse.header)
-  return header_ != NULL ? *header_ : *default_instance_->header_;
+inline const ::cockroach::proto::KVResponseHeader& EndTransactionResponse::kvheader() const {
+  // @@protoc_insertion_point(field_get:cockroach.proto.EndTransactionResponse.kvheader)
+  return kvheader_ != NULL ? *kvheader_ : *default_instance_->kvheader_;
 }
-inline ::cockroach::proto::ResponseHeader* EndTransactionResponse::mutable_header() {
-  set_has_header();
-  if (header_ == NULL) {
-    header_ = new ::cockroach::proto::ResponseHeader;
+inline ::cockroach::proto::KVResponseHeader* EndTransactionResponse::mutable_kvheader() {
+  set_has_kvheader();
+  if (kvheader_ == NULL) {
+    kvheader_ = new ::cockroach::proto::KVResponseHeader;
   }
-  // @@protoc_insertion_point(field_mutable:cockroach.proto.EndTransactionResponse.header)
-  return header_;
+  // @@protoc_insertion_point(field_mutable:cockroach.proto.EndTransactionResponse.kvheader)
+  return kvheader_;
 }
-inline ::cockroach::proto::ResponseHeader* EndTransactionResponse::release_header() {
-  clear_has_header();
-  ::cockroach::proto::ResponseHeader* temp = header_;
-  header_ = NULL;
+inline ::cockroach::proto::KVResponseHeader* EndTransactionResponse::release_kvheader() {
+  clear_has_kvheader();
+  ::cockroach::proto::KVResponseHeader* temp = kvheader_;
+  kvheader_ = NULL;
   return temp;
 }
-inline void EndTransactionResponse::set_allocated_header(::cockroach::proto::ResponseHeader* header) {
-  delete header_;
-  header_ = header;
-  if (header) {
-    set_has_header();
+inline void EndTransactionResponse::set_allocated_kvheader(::cockroach::proto::KVResponseHeader* kvheader) {
+  delete kvheader_;
+  kvheader_ = kvheader;
+  if (kvheader) {
+    set_has_kvheader();
   } else {
-    clear_has_header();
+    clear_has_kvheader();
   }
-  // @@protoc_insertion_point(field_set_allocated:cockroach.proto.EndTransactionResponse.header)
+  // @@protoc_insertion_point(field_set_allocated:cockroach.proto.EndTransactionResponse.kvheader)
 }
 
 // optional int64 commit_wait = 2;
@@ -5669,47 +5947,47 @@ inline ResponseUnion::ValueCase ResponseUnion::value_case() const {
 
 // BatchRequest
 
-// optional .cockroach.proto.RequestHeader header = 1;
-inline bool BatchRequest::has_header() const {
+// optional .cockroach.proto.KVRequestHeader kvheader = 1;
+inline bool BatchRequest::has_kvheader() const {
   return (_has_bits_[0] & 0x00000001u) != 0;
 }
-inline void BatchRequest::set_has_header() {
+inline void BatchRequest::set_has_kvheader() {
   _has_bits_[0] |= 0x00000001u;
 }
-inline void BatchRequest::clear_has_header() {
+inline void BatchRequest::clear_has_kvheader() {
   _has_bits_[0] &= ~0x00000001u;
 }
-inline void BatchRequest::clear_header() {
-  if (header_ != NULL) header_->::cockroach::proto::RequestHeader::Clear();
-  clear_has_header();
+inline void BatchRequest::clear_kvheader() {
+  if (kvheader_ != NULL) kvheader_->::cockroach::proto::KVRequestHeader::Clear();
+  clear_has_kvheader();
 }
-inline const ::cockroach::proto::RequestHeader& BatchRequest::header() const {
-  // @@protoc_insertion_point(field_get:cockroach.proto.BatchRequest.header)
-  return header_ != NULL ? *header_ : *default_instance_->header_;
+inline const ::cockroach::proto::KVRequestHeader& BatchRequest::kvheader() const {
+  // @@protoc_insertion_point(field_get:cockroach.proto.BatchRequest.kvheader)
+  return kvheader_ != NULL ? *kvheader_ : *default_instance_->kvheader_;
 }
-inline ::cockroach::proto::RequestHeader* BatchRequest::mutable_header() {
-  set_has_header();
-  if (header_ == NULL) {
-    header_ = new ::cockroach::proto::RequestHeader;
+inline ::cockroach::proto::KVRequestHeader* BatchRequest::mutable_kvheader() {
+  set_has_kvheader();
+  if (kvheader_ == NULL) {
+    kvheader_ = new ::cockroach::proto::KVRequestHeader;
   }
-  // @@protoc_insertion_point(field_mutable:cockroach.proto.BatchRequest.header)
-  return header_;
+  // @@protoc_insertion_point(field_mutable:cockroach.proto.BatchRequest.kvheader)
+  return kvheader_;
 }
-inline ::cockroach::proto::RequestHeader* BatchRequest::release_header() {
-  clear_has_header();
-  ::cockroach::proto::RequestHeader* temp = header_;
-  header_ = NULL;
+inline ::cockroach::proto::KVRequestHeader* BatchRequest::release_kvheader() {
+  clear_has_kvheader();
+  ::cockroach::proto::KVRequestHeader* temp = kvheader_;
+  kvheader_ = NULL;
   return temp;
 }
-inline void BatchRequest::set_allocated_header(::cockroach::proto::RequestHeader* header) {
-  delete header_;
-  header_ = header;
-  if (header) {
-    set_has_header();
+inline void BatchRequest::set_allocated_kvheader(::cockroach::proto::KVRequestHeader* kvheader) {
+  delete kvheader_;
+  kvheader_ = kvheader;
+  if (kvheader) {
+    set_has_kvheader();
   } else {
-    clear_has_header();
+    clear_has_kvheader();
   }
-  // @@protoc_insertion_point(field_set_allocated:cockroach.proto.BatchRequest.header)
+  // @@protoc_insertion_point(field_set_allocated:cockroach.proto.BatchRequest.kvheader)
 }
 
 // repeated .cockroach.proto.RequestUnion requests = 2;
@@ -5746,47 +6024,47 @@ BatchRequest::mutable_requests() {
 
 // BatchResponse
 
-// optional .cockroach.proto.ResponseHeader header = 1;
-inline bool BatchResponse::has_header() const {
+// optional .cockroach.proto.KVResponseHeader kvheader = 1;
+inline bool BatchResponse::has_kvheader() const {
   return (_has_bits_[0] & 0x00000001u) != 0;
 }
-inline void BatchResponse::set_has_header() {
+inline void BatchResponse::set_has_kvheader() {
   _has_bits_[0] |= 0x00000001u;
 }
-inline void BatchResponse::clear_has_header() {
+inline void BatchResponse::clear_has_kvheader() {
   _has_bits_[0] &= ~0x00000001u;
 }
-inline void BatchResponse::clear_header() {
-  if (header_ != NULL) header_->::cockroach::proto::ResponseHeader::Clear();
-  clear_has_header();
+inline void BatchResponse::clear_kvheader() {
+  if (kvheader_ != NULL) kvheader_->::cockroach::proto::KVResponseHeader::Clear();
+  clear_has_kvheader();
 }
-inline const ::cockroach::proto::ResponseHeader& BatchResponse::header() const {
-  // @@protoc_insertion_point(field_get:cockroach.proto.BatchResponse.header)
-  return header_ != NULL ? *header_ : *default_instance_->header_;
+inline const ::cockroach::proto::KVResponseHeader& BatchResponse::kvheader() const {
+  // @@protoc_insertion_point(field_get:cockroach.proto.BatchResponse.kvheader)
+  return kvheader_ != NULL ? *kvheader_ : *default_instance_->kvheader_;
 }
-inline ::cockroach::proto::ResponseHeader* BatchResponse::mutable_header() {
-  set_has_header();
-  if (header_ == NULL) {
-    header_ = new ::cockroach::proto::ResponseHeader;
+inline ::cockroach::proto::KVResponseHeader* BatchResponse::mutable_kvheader() {
+  set_has_kvheader();
+  if (kvheader_ == NULL) {
+    kvheader_ = new ::cockroach::proto::KVResponseHeader;
   }
-  // @@protoc_insertion_point(field_mutable:cockroach.proto.BatchResponse.header)
-  return header_;
+  // @@protoc_insertion_point(field_mutable:cockroach.proto.BatchResponse.kvheader)
+  return kvheader_;
 }
-inline ::cockroach::proto::ResponseHeader* BatchResponse::release_header() {
-  clear_has_header();
-  ::cockroach::proto::ResponseHeader* temp = header_;
-  header_ = NULL;
+inline ::cockroach::proto::KVResponseHeader* BatchResponse::release_kvheader() {
+  clear_has_kvheader();
+  ::cockroach::proto::KVResponseHeader* temp = kvheader_;
+  kvheader_ = NULL;
   return temp;
 }
-inline void BatchResponse::set_allocated_header(::cockroach::proto::ResponseHeader* header) {
-  delete header_;
-  header_ = header;
-  if (header) {
-    set_has_header();
+inline void BatchResponse::set_allocated_kvheader(::cockroach::proto::KVResponseHeader* kvheader) {
+  delete kvheader_;
+  kvheader_ = kvheader;
+  if (kvheader) {
+    set_has_kvheader();
   } else {
-    clear_has_header();
+    clear_has_kvheader();
   }
-  // @@protoc_insertion_point(field_set_allocated:cockroach.proto.BatchResponse.header)
+  // @@protoc_insertion_point(field_set_allocated:cockroach.proto.BatchResponse.kvheader)
 }
 
 // repeated .cockroach.proto.ResponseUnion responses = 2;
@@ -5823,47 +6101,47 @@ BatchResponse::mutable_responses() {
 
 // AdminSplitRequest
 
-// optional .cockroach.proto.RequestHeader header = 1;
-inline bool AdminSplitRequest::has_header() const {
+// optional .cockroach.proto.KVRequestHeader kvheader = 1;
+inline bool AdminSplitRequest::has_kvheader() const {
   return (_has_bits_[0] & 0x00000001u) != 0;
 }
-inline void AdminSplitRequest::set_has_header() {
+inline void AdminSplitRequest::set_has_kvheader() {
   _has_bits_[0] |= 0x00000001u;
 }
-inline void AdminSplitRequest::clear_has_header() {
+inline void AdminSplitRequest::clear_has_kvheader() {
   _has_bits_[0] &= ~0x00000001u;
 }
-inline void AdminSplitRequest::clear_header() {
-  if (header_ != NULL) header_->::cockroach::proto::RequestHeader::Clear();
-  clear_has_header();
+inline void AdminSplitRequest::clear_kvheader() {
+  if (kvheader_ != NULL) kvheader_->::cockroach::proto::KVRequestHeader::Clear();
+  clear_has_kvheader();
 }
-inline const ::cockroach::proto::RequestHeader& AdminSplitRequest::header() const {
-  // @@protoc_insertion_point(field_get:cockroach.proto.AdminSplitRequest.header)
-  return header_ != NULL ? *header_ : *default_instance_->header_;
+inline const ::cockroach::proto::KVRequestHeader& AdminSplitRequest::kvheader() const {
+  // @@protoc_insertion_point(field_get:cockroach.proto.AdminSplitRequest.kvheader)
+  return kvheader_ != NULL ? *kvheader_ : *default_instance_->kvheader_;
 }
-inline ::cockroach::proto::RequestHeader* AdminSplitRequest::mutable_header() {
-  set_has_header();
-  if (header_ == NULL) {
-    header_ = new ::cockroach::proto::RequestHeader;
+inline ::cockroach::proto::KVRequestHeader* AdminSplitRequest::mutable_kvheader() {
+  set_has_kvheader();
+  if (kvheader_ == NULL) {
+    kvheader_ = new ::cockroach::proto::KVRequestHeader;
   }
-  // @@protoc_insertion_point(field_mutable:cockroach.proto.AdminSplitRequest.header)
-  return header_;
+  // @@protoc_insertion_point(field_mutable:cockroach.proto.AdminSplitRequest.kvheader)
+  return kvheader_;
 }
-inline ::cockroach::proto::RequestHeader* AdminSplitRequest::release_header() {
-  clear_has_header();
-  ::cockroach::proto::RequestHeader* temp = header_;
-  header_ = NULL;
+inline ::cockroach::proto::KVRequestHeader* AdminSplitRequest::release_kvheader() {
+  clear_has_kvheader();
+  ::cockroach::proto::KVRequestHeader* temp = kvheader_;
+  kvheader_ = NULL;
   return temp;
 }
-inline void AdminSplitRequest::set_allocated_header(::cockroach::proto::RequestHeader* header) {
-  delete header_;
-  header_ = header;
-  if (header) {
-    set_has_header();
+inline void AdminSplitRequest::set_allocated_kvheader(::cockroach::proto::KVRequestHeader* kvheader) {
+  delete kvheader_;
+  kvheader_ = kvheader;
+  if (kvheader) {
+    set_has_kvheader();
   } else {
-    clear_has_header();
+    clear_has_kvheader();
   }
-  // @@protoc_insertion_point(field_set_allocated:cockroach.proto.AdminSplitRequest.header)
+  // @@protoc_insertion_point(field_set_allocated:cockroach.proto.AdminSplitRequest.kvheader)
 }
 
 // optional bytes split_key = 2;
@@ -5923,144 +6201,148 @@ inline void AdminSplitRequest::set_allocated_split_key(::std::string* split_key)
 
 // AdminSplitResponse
 
-// optional .cockroach.proto.ResponseHeader header = 1;
-inline bool AdminSplitResponse::has_header() const {
+// optional .cockroach.proto.KVResponseHeader kvheader = 1;
+inline bool AdminSplitResponse::has_kvheader() const {
   return (_has_bits_[0] & 0x00000001u) != 0;
 }
-inline void AdminSplitResponse::set_has_header() {
+inline void AdminSplitResponse::set_has_kvheader() {
   _has_bits_[0] |= 0x00000001u;
 }
-inline void AdminSplitResponse::clear_has_header() {
+inline void AdminSplitResponse::clear_has_kvheader() {
   _has_bits_[0] &= ~0x00000001u;
 }
-inline void AdminSplitResponse::clear_header() {
-  if (header_ != NULL) header_->::cockroach::proto::ResponseHeader::Clear();
-  clear_has_header();
+inline void AdminSplitResponse::clear_kvheader() {
+  if (kvheader_ != NULL) kvheader_->::cockroach::proto::KVResponseHeader::Clear();
+  clear_has_kvheader();
 }
-inline const ::cockroach::proto::ResponseHeader& AdminSplitResponse::header() const {
-  // @@protoc_insertion_point(field_get:cockroach.proto.AdminSplitResponse.header)
-  return header_ != NULL ? *header_ : *default_instance_->header_;
+inline const ::cockroach::proto::KVResponseHeader& AdminSplitResponse::kvheader() const {
+  // @@protoc_insertion_point(field_get:cockroach.proto.AdminSplitResponse.kvheader)
+  return kvheader_ != NULL ? *kvheader_ : *default_instance_->kvheader_;
 }
-inline ::cockroach::proto::ResponseHeader* AdminSplitResponse::mutable_header() {
-  set_has_header();
-  if (header_ == NULL) {
-    header_ = new ::cockroach::proto::ResponseHeader;
+inline ::cockroach::proto::KVResponseHeader* AdminSplitResponse::mutable_kvheader() {
+  set_has_kvheader();
+  if (kvheader_ == NULL) {
+    kvheader_ = new ::cockroach::proto::KVResponseHeader;
   }
-  // @@protoc_insertion_point(field_mutable:cockroach.proto.AdminSplitResponse.header)
-  return header_;
+  // @@protoc_insertion_point(field_mutable:cockroach.proto.AdminSplitResponse.kvheader)
+  return kvheader_;
 }
-inline ::cockroach::proto::ResponseHeader* AdminSplitResponse::release_header() {
-  clear_has_header();
-  ::cockroach::proto::ResponseHeader* temp = header_;
-  header_ = NULL;
+inline ::cockroach::proto::KVResponseHeader* AdminSplitResponse::release_kvheader() {
+  clear_has_kvheader();
+  ::cockroach::proto::KVResponseHeader* temp = kvheader_;
+  kvheader_ = NULL;
   return temp;
 }
-inline void AdminSplitResponse::set_allocated_header(::cockroach::proto::ResponseHeader* header) {
-  delete header_;
-  header_ = header;
-  if (header) {
-    set_has_header();
+inline void AdminSplitResponse::set_allocated_kvheader(::cockroach::proto::KVResponseHeader* kvheader) {
+  delete kvheader_;
+  kvheader_ = kvheader;
+  if (kvheader) {
+    set_has_kvheader();
   } else {
-    clear_has_header();
+    clear_has_kvheader();
   }
-  // @@protoc_insertion_point(field_set_allocated:cockroach.proto.AdminSplitResponse.header)
+  // @@protoc_insertion_point(field_set_allocated:cockroach.proto.AdminSplitResponse.kvheader)
 }
 
 // -------------------------------------------------------------------
 
 // AdminMergeRequest
 
-// optional .cockroach.proto.RequestHeader header = 1;
-inline bool AdminMergeRequest::has_header() const {
+// optional .cockroach.proto.KVRequestHeader kvheader = 1;
+inline bool AdminMergeRequest::has_kvheader() const {
   return (_has_bits_[0] & 0x00000001u) != 0;
 }
-inline void AdminMergeRequest::set_has_header() {
+inline void AdminMergeRequest::set_has_kvheader() {
   _has_bits_[0] |= 0x00000001u;
 }
-inline void AdminMergeRequest::clear_has_header() {
+inline void AdminMergeRequest::clear_has_kvheader() {
   _has_bits_[0] &= ~0x00000001u;
 }
-inline void AdminMergeRequest::clear_header() {
-  if (header_ != NULL) header_->::cockroach::proto::RequestHeader::Clear();
-  clear_has_header();
+inline void AdminMergeRequest::clear_kvheader() {
+  if (kvheader_ != NULL) kvheader_->::cockroach::proto::KVRequestHeader::Clear();
+  clear_has_kvheader();
 }
-inline const ::cockroach::proto::RequestHeader& AdminMergeRequest::header() const {
-  // @@protoc_insertion_point(field_get:cockroach.proto.AdminMergeRequest.header)
-  return header_ != NULL ? *header_ : *default_instance_->header_;
+inline const ::cockroach::proto::KVRequestHeader& AdminMergeRequest::kvheader() const {
+  // @@protoc_insertion_point(field_get:cockroach.proto.AdminMergeRequest.kvheader)
+  return kvheader_ != NULL ? *kvheader_ : *default_instance_->kvheader_;
 }
-inline ::cockroach::proto::RequestHeader* AdminMergeRequest::mutable_header() {
-  set_has_header();
-  if (header_ == NULL) {
-    header_ = new ::cockroach::proto::RequestHeader;
+inline ::cockroach::proto::KVRequestHeader* AdminMergeRequest::mutable_kvheader() {
+  set_has_kvheader();
+  if (kvheader_ == NULL) {
+    kvheader_ = new ::cockroach::proto::KVRequestHeader;
   }
-  // @@protoc_insertion_point(field_mutable:cockroach.proto.AdminMergeRequest.header)
-  return header_;
+  // @@protoc_insertion_point(field_mutable:cockroach.proto.AdminMergeRequest.kvheader)
+  return kvheader_;
 }
-inline ::cockroach::proto::RequestHeader* AdminMergeRequest::release_header() {
-  clear_has_header();
-  ::cockroach::proto::RequestHeader* temp = header_;
-  header_ = NULL;
+inline ::cockroach::proto::KVRequestHeader* AdminMergeRequest::release_kvheader() {
+  clear_has_kvheader();
+  ::cockroach::proto::KVRequestHeader* temp = kvheader_;
+  kvheader_ = NULL;
   return temp;
 }
-inline void AdminMergeRequest::set_allocated_header(::cockroach::proto::RequestHeader* header) {
-  delete header_;
-  header_ = header;
-  if (header) {
-    set_has_header();
+inline void AdminMergeRequest::set_allocated_kvheader(::cockroach::proto::KVRequestHeader* kvheader) {
+  delete kvheader_;
+  kvheader_ = kvheader;
+  if (kvheader) {
+    set_has_kvheader();
   } else {
-    clear_has_header();
+    clear_has_kvheader();
   }
-  // @@protoc_insertion_point(field_set_allocated:cockroach.proto.AdminMergeRequest.header)
+  // @@protoc_insertion_point(field_set_allocated:cockroach.proto.AdminMergeRequest.kvheader)
 }
 
 // -------------------------------------------------------------------
 
 // AdminMergeResponse
 
-// optional .cockroach.proto.ResponseHeader header = 1;
-inline bool AdminMergeResponse::has_header() const {
+// optional .cockroach.proto.KVResponseHeader kvheader = 1;
+inline bool AdminMergeResponse::has_kvheader() const {
   return (_has_bits_[0] & 0x00000001u) != 0;
 }
-inline void AdminMergeResponse::set_has_header() {
+inline void AdminMergeResponse::set_has_kvheader() {
   _has_bits_[0] |= 0x00000001u;
 }
-inline void AdminMergeResponse::clear_has_header() {
+inline void AdminMergeResponse::clear_has_kvheader() {
   _has_bits_[0] &= ~0x00000001u;
 }
-inline void AdminMergeResponse::clear_header() {
-  if (header_ != NULL) header_->::cockroach::proto::ResponseHeader::Clear();
-  clear_has_header();
+inline void AdminMergeResponse::clear_kvheader() {
+  if (kvheader_ != NULL) kvheader_->::cockroach::proto::KVResponseHeader::Clear();
+  clear_has_kvheader();
 }
-inline const ::cockroach::proto::ResponseHeader& AdminMergeResponse::header() const {
-  // @@protoc_insertion_point(field_get:cockroach.proto.AdminMergeResponse.header)
-  return header_ != NULL ? *header_ : *default_instance_->header_;
+inline const ::cockroach::proto::KVResponseHeader& AdminMergeResponse::kvheader() const {
+  // @@protoc_insertion_point(field_get:cockroach.proto.AdminMergeResponse.kvheader)
+  return kvheader_ != NULL ? *kvheader_ : *default_instance_->kvheader_;
 }
-inline ::cockroach::proto::ResponseHeader* AdminMergeResponse::mutable_header() {
-  set_has_header();
-  if (header_ == NULL) {
-    header_ = new ::cockroach::proto::ResponseHeader;
+inline ::cockroach::proto::KVResponseHeader* AdminMergeResponse::mutable_kvheader() {
+  set_has_kvheader();
+  if (kvheader_ == NULL) {
+    kvheader_ = new ::cockroach::proto::KVResponseHeader;
   }
-  // @@protoc_insertion_point(field_mutable:cockroach.proto.AdminMergeResponse.header)
-  return header_;
+  // @@protoc_insertion_point(field_mutable:cockroach.proto.AdminMergeResponse.kvheader)
+  return kvheader_;
 }
-inline ::cockroach::proto::ResponseHeader* AdminMergeResponse::release_header() {
-  clear_has_header();
-  ::cockroach::proto::ResponseHeader* temp = header_;
-  header_ = NULL;
+inline ::cockroach::proto::KVResponseHeader* AdminMergeResponse::release_kvheader() {
+  clear_has_kvheader();
+  ::cockroach::proto::KVResponseHeader* temp = kvheader_;
+  kvheader_ = NULL;
   return temp;
 }
-inline void AdminMergeResponse::set_allocated_header(::cockroach::proto::ResponseHeader* header) {
-  delete header_;
-  header_ = header;
-  if (header) {
-    set_has_header();
+inline void AdminMergeResponse::set_allocated_kvheader(::cockroach::proto::KVResponseHeader* kvheader) {
+  delete kvheader_;
+  kvheader_ = kvheader;
+  if (kvheader) {
+    set_has_kvheader();
   } else {
-    clear_has_header();
+    clear_has_kvheader();
   }
-  // @@protoc_insertion_point(field_set_allocated:cockroach.proto.AdminMergeResponse.header)
+  // @@protoc_insertion_point(field_set_allocated:cockroach.proto.AdminMergeResponse.kvheader)
 }
 
 #endif  // !PROTOBUF_INLINE_NOT_IN_HEADERS
+// -------------------------------------------------------------------
+
+// -------------------------------------------------------------------
+
 // -------------------------------------------------------------------
 
 // -------------------------------------------------------------------

--- a/storage/engine/cockroach/proto/internal.pb.cc
+++ b/storage/engine/cockroach/proto/internal.pb.cc
@@ -197,7 +197,7 @@ void protobuf_AssignDesc_cockroach_2fproto_2finternal_2eproto() {
   GOOGLE_CHECK(file != NULL);
   InternalRangeLookupRequest_descriptor_ = file->message_type(0);
   static const int InternalRangeLookupRequest_offsets_[3] = {
-    GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(InternalRangeLookupRequest, header_),
+    GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(InternalRangeLookupRequest, kvheader_),
     GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(InternalRangeLookupRequest, max_ranges_),
     GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(InternalRangeLookupRequest, ignore_intents_),
   };
@@ -214,7 +214,7 @@ void protobuf_AssignDesc_cockroach_2fproto_2finternal_2eproto() {
       -1);
   InternalRangeLookupResponse_descriptor_ = file->message_type(1);
   static const int InternalRangeLookupResponse_offsets_[2] = {
-    GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(InternalRangeLookupResponse, header_),
+    GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(InternalRangeLookupResponse, kvheader_),
     GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(InternalRangeLookupResponse, ranges_),
   };
   InternalRangeLookupResponse_reflection_ =
@@ -230,7 +230,7 @@ void protobuf_AssignDesc_cockroach_2fproto_2finternal_2eproto() {
       -1);
   InternalHeartbeatTxnRequest_descriptor_ = file->message_type(2);
   static const int InternalHeartbeatTxnRequest_offsets_[1] = {
-    GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(InternalHeartbeatTxnRequest, header_),
+    GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(InternalHeartbeatTxnRequest, kvheader_),
   };
   InternalHeartbeatTxnRequest_reflection_ =
     ::google::protobuf::internal::GeneratedMessageReflection::NewGeneratedMessageReflection(
@@ -245,7 +245,7 @@ void protobuf_AssignDesc_cockroach_2fproto_2finternal_2eproto() {
       -1);
   InternalHeartbeatTxnResponse_descriptor_ = file->message_type(3);
   static const int InternalHeartbeatTxnResponse_offsets_[1] = {
-    GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(InternalHeartbeatTxnResponse, header_),
+    GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(InternalHeartbeatTxnResponse, kvheader_),
   };
   InternalHeartbeatTxnResponse_reflection_ =
     ::google::protobuf::internal::GeneratedMessageReflection::NewGeneratedMessageReflection(
@@ -260,7 +260,7 @@ void protobuf_AssignDesc_cockroach_2fproto_2finternal_2eproto() {
       -1);
   InternalGCRequest_descriptor_ = file->message_type(4);
   static const int InternalGCRequest_offsets_[3] = {
-    GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(InternalGCRequest, header_),
+    GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(InternalGCRequest, kvheader_),
     GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(InternalGCRequest, gc_meta_),
     GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(InternalGCRequest, keys_),
   };
@@ -293,7 +293,7 @@ void protobuf_AssignDesc_cockroach_2fproto_2finternal_2eproto() {
       -1);
   InternalGCResponse_descriptor_ = file->message_type(5);
   static const int InternalGCResponse_offsets_[1] = {
-    GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(InternalGCResponse, header_),
+    GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(InternalGCResponse, kvheader_),
   };
   InternalGCResponse_reflection_ =
     ::google::protobuf::internal::GeneratedMessageReflection::NewGeneratedMessageReflection(
@@ -308,7 +308,7 @@ void protobuf_AssignDesc_cockroach_2fproto_2finternal_2eproto() {
       -1);
   InternalPushTxnRequest_descriptor_ = file->message_type(6);
   static const int InternalPushTxnRequest_offsets_[5] = {
-    GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(InternalPushTxnRequest, header_),
+    GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(InternalPushTxnRequest, kvheader_),
     GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(InternalPushTxnRequest, pushee_txn_),
     GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(InternalPushTxnRequest, now_),
     GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(InternalPushTxnRequest, push_type_),
@@ -327,7 +327,7 @@ void protobuf_AssignDesc_cockroach_2fproto_2finternal_2eproto() {
       -1);
   InternalPushTxnResponse_descriptor_ = file->message_type(7);
   static const int InternalPushTxnResponse_offsets_[2] = {
-    GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(InternalPushTxnResponse, header_),
+    GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(InternalPushTxnResponse, kvheader_),
     GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(InternalPushTxnResponse, pushee_txn_),
   };
   InternalPushTxnResponse_reflection_ =
@@ -343,7 +343,7 @@ void protobuf_AssignDesc_cockroach_2fproto_2finternal_2eproto() {
       -1);
   InternalResolveIntentRequest_descriptor_ = file->message_type(8);
   static const int InternalResolveIntentRequest_offsets_[1] = {
-    GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(InternalResolveIntentRequest, header_),
+    GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(InternalResolveIntentRequest, kvheader_),
   };
   InternalResolveIntentRequest_reflection_ =
     ::google::protobuf::internal::GeneratedMessageReflection::NewGeneratedMessageReflection(
@@ -358,7 +358,7 @@ void protobuf_AssignDesc_cockroach_2fproto_2finternal_2eproto() {
       -1);
   InternalResolveIntentResponse_descriptor_ = file->message_type(9);
   static const int InternalResolveIntentResponse_offsets_[1] = {
-    GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(InternalResolveIntentResponse, header_),
+    GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(InternalResolveIntentResponse, kvheader_),
   };
   InternalResolveIntentResponse_reflection_ =
     ::google::protobuf::internal::GeneratedMessageReflection::NewGeneratedMessageReflection(
@@ -373,7 +373,7 @@ void protobuf_AssignDesc_cockroach_2fproto_2finternal_2eproto() {
       -1);
   InternalResolveIntentRangeRequest_descriptor_ = file->message_type(10);
   static const int InternalResolveIntentRangeRequest_offsets_[1] = {
-    GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(InternalResolveIntentRangeRequest, header_),
+    GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(InternalResolveIntentRangeRequest, kvheader_),
   };
   InternalResolveIntentRangeRequest_reflection_ =
     ::google::protobuf::internal::GeneratedMessageReflection::NewGeneratedMessageReflection(
@@ -388,7 +388,7 @@ void protobuf_AssignDesc_cockroach_2fproto_2finternal_2eproto() {
       -1);
   InternalResolveIntentRangeResponse_descriptor_ = file->message_type(11);
   static const int InternalResolveIntentRangeResponse_offsets_[1] = {
-    GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(InternalResolveIntentRangeResponse, header_),
+    GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(InternalResolveIntentRangeResponse, kvheader_),
   };
   InternalResolveIntentRangeResponse_reflection_ =
     ::google::protobuf::internal::GeneratedMessageReflection::NewGeneratedMessageReflection(
@@ -403,7 +403,7 @@ void protobuf_AssignDesc_cockroach_2fproto_2finternal_2eproto() {
       -1);
   InternalMergeRequest_descriptor_ = file->message_type(12);
   static const int InternalMergeRequest_offsets_[2] = {
-    GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(InternalMergeRequest, header_),
+    GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(InternalMergeRequest, kvheader_),
     GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(InternalMergeRequest, value_),
   };
   InternalMergeRequest_reflection_ =
@@ -419,7 +419,7 @@ void protobuf_AssignDesc_cockroach_2fproto_2finternal_2eproto() {
       -1);
   InternalMergeResponse_descriptor_ = file->message_type(13);
   static const int InternalMergeResponse_offsets_[1] = {
-    GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(InternalMergeResponse, header_),
+    GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(InternalMergeResponse, kvheader_),
   };
   InternalMergeResponse_reflection_ =
     ::google::protobuf::internal::GeneratedMessageReflection::NewGeneratedMessageReflection(
@@ -434,7 +434,7 @@ void protobuf_AssignDesc_cockroach_2fproto_2finternal_2eproto() {
       -1);
   InternalTruncateLogRequest_descriptor_ = file->message_type(14);
   static const int InternalTruncateLogRequest_offsets_[2] = {
-    GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(InternalTruncateLogRequest, header_),
+    GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(InternalTruncateLogRequest, kvheader_),
     GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(InternalTruncateLogRequest, index_),
   };
   InternalTruncateLogRequest_reflection_ =
@@ -450,7 +450,7 @@ void protobuf_AssignDesc_cockroach_2fproto_2finternal_2eproto() {
       -1);
   InternalTruncateLogResponse_descriptor_ = file->message_type(15);
   static const int InternalTruncateLogResponse_offsets_[1] = {
-    GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(InternalTruncateLogResponse, header_),
+    GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(InternalTruncateLogResponse, kvheader_),
   };
   InternalTruncateLogResponse_reflection_ =
     ::google::protobuf::internal::GeneratedMessageReflection::NewGeneratedMessageReflection(
@@ -465,7 +465,7 @@ void protobuf_AssignDesc_cockroach_2fproto_2finternal_2eproto() {
       -1);
   InternalLeaderLeaseRequest_descriptor_ = file->message_type(16);
   static const int InternalLeaderLeaseRequest_offsets_[2] = {
-    GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(InternalLeaderLeaseRequest, header_),
+    GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(InternalLeaderLeaseRequest, kvheader_),
     GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(InternalLeaderLeaseRequest, lease_),
   };
   InternalLeaderLeaseRequest_reflection_ =
@@ -481,7 +481,7 @@ void protobuf_AssignDesc_cockroach_2fproto_2finternal_2eproto() {
       -1);
   InternalLeaderLeaseResponse_descriptor_ = file->message_type(17);
   static const int InternalLeaderLeaseResponse_offsets_[1] = {
-    GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(InternalLeaderLeaseResponse, header_),
+    GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(InternalLeaderLeaseResponse, kvheader_),
   };
   InternalLeaderLeaseResponse_reflection_ =
     ::google::protobuf::internal::GeneratedMessageReflection::NewGeneratedMessageReflection(
@@ -552,7 +552,7 @@ void protobuf_AssignDesc_cockroach_2fproto_2finternal_2eproto() {
       -1);
   InternalBatchRequest_descriptor_ = file->message_type(20);
   static const int InternalBatchRequest_offsets_[2] = {
-    GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(InternalBatchRequest, header_),
+    GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(InternalBatchRequest, kvheader_),
     GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(InternalBatchRequest, requests_),
   };
   InternalBatchRequest_reflection_ =
@@ -568,7 +568,7 @@ void protobuf_AssignDesc_cockroach_2fproto_2finternal_2eproto() {
       -1);
   InternalBatchResponse_descriptor_ = file->message_type(21);
   static const int InternalBatchResponse_offsets_[2] = {
-    GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(InternalBatchResponse, header_),
+    GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(InternalBatchResponse, kvheader_),
     GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(InternalBatchResponse, responses_),
   };
   InternalBatchResponse_reflection_ =
@@ -951,189 +951,191 @@ void protobuf_AddDesc_cockroach_2fproto_2finternal_2eproto() {
     "\n\036cockroach/proto/internal.proto\022\017cockro"
     "ach.proto\032\031cockroach/proto/api.proto\032\034co"
     "ckroach/proto/config.proto\032\032cockroach/pr"
-    "oto/data.proto\032\024gogoproto/gogo.proto\"\216\001\n"
-    "\032InternalRangeLookupRequest\0228\n\006header\030\001 "
-    "\001(\0132\036.cockroach.proto.RequestHeaderB\010\310\336\037"
-    "\000\320\336\037\001\022\030\n\nmax_ranges\030\002 \001(\005B\004\310\336\037\000\022\034\n\016ignor"
-    "e_intents\030\003 \001(\010B\004\310\336\037\000\"\220\001\n\033InternalRangeL"
-    "ookupResponse\0229\n\006header\030\001 \001(\0132\037.cockroac"
-    "h.proto.ResponseHeaderB\010\310\336\037\000\320\336\037\001\0226\n\006rang"
-    "es\030\002 \003(\0132 .cockroach.proto.RangeDescript"
-    "orB\004\310\336\037\000\"W\n\033InternalHeartbeatTxnRequest\022"
-    "8\n\006header\030\001 \001(\0132\036.cockroach.proto.Reques"
-    "tHeaderB\010\310\336\037\000\320\336\037\001\"Y\n\034InternalHeartbeatTx"
-    "nResponse\0229\n\006header\030\001 \001(\0132\037.cockroach.pr"
-    "oto.ResponseHeaderB\010\310\336\037\000\320\336\037\001\"\235\002\n\021Interna"
-    "lGCRequest\0228\n\006header\030\001 \001(\0132\036.cockroach.p"
-    "roto.RequestHeaderB\010\310\336\037\000\320\336\037\001\022<\n\007gc_meta\030"
-    "\002 \001(\0132\033.cockroach.proto.GCMetadataB\016\310\336\037\000"
-    "\342\336\037\006GCMeta\022<\n\004keys\030\003 \003(\0132(.cockroach.pro"
-    "to.InternalGCRequest.GCKeyB\004\310\336\037\000\032R\n\005GCKe"
-    "y\022\024\n\003key\030\001 \001(\014B\007\372\336\037\003Key\0223\n\ttimestamp\030\002 \001"
-    "(\0132\032.cockroach.proto.TimestampB\004\310\336\037\000\"O\n\022"
-    "InternalGCResponse\0229\n\006header\030\001 \001(\0132\037.coc"
-    "kroach.proto.ResponseHeaderB\010\310\336\037\000\320\336\037\001\"\214\002"
-    "\n\026InternalPushTxnRequest\0228\n\006header\030\001 \001(\013"
-    "2\036.cockroach.proto.RequestHeaderB\010\310\336\037\000\320\336"
-    "\037\001\0226\n\npushee_txn\030\002 \001(\0132\034.cockroach.proto"
-    ".TransactionB\004\310\336\037\000\022-\n\003now\030\003 \001(\0132\032.cockro"
-    "ach.proto.TimestampB\004\310\336\037\000\0225\n\tpush_type\030\004"
-    " \001(\0162\034.cockroach.proto.PushTxnTypeB\004\310\336\037\000"
-    "\022\032\n\014range_lookup\030\005 \001(\010B\004\310\336\037\000\"\206\001\n\027Interna"
-    "lPushTxnResponse\0229\n\006header\030\001 \001(\0132\037.cockr"
-    "oach.proto.ResponseHeaderB\010\310\336\037\000\320\336\037\001\0220\n\np"
-    "ushee_txn\030\002 \001(\0132\034.cockroach.proto.Transa"
-    "ction\"X\n\034InternalResolveIntentRequest\0228\n"
-    "\006header\030\001 \001(\0132\036.cockroach.proto.RequestH"
-    "eaderB\010\310\336\037\000\320\336\037\001\"Z\n\035InternalResolveIntent"
-    "Response\0229\n\006header\030\001 \001(\0132\037.cockroach.pro"
-    "to.ResponseHeaderB\010\310\336\037\000\320\336\037\001\"]\n!InternalR"
-    "esolveIntentRangeRequest\0228\n\006header\030\001 \001(\013"
-    "2\036.cockroach.proto.RequestHeaderB\010\310\336\037\000\320\336"
-    "\037\001\"_\n\"InternalResolveIntentRangeResponse"
-    "\0229\n\006header\030\001 \001(\0132\037.cockroach.proto.Respo"
-    "nseHeaderB\010\310\336\037\000\320\336\037\001\"}\n\024InternalMergeRequ"
-    "est\0228\n\006header\030\001 \001(\0132\036.cockroach.proto.Re"
-    "questHeaderB\010\310\336\037\000\320\336\037\001\022+\n\005value\030\002 \001(\0132\026.c"
-    "ockroach.proto.ValueB\004\310\336\037\000\"R\n\025InternalMe"
-    "rgeResponse\0229\n\006header\030\001 \001(\0132\037.cockroach."
-    "proto.ResponseHeaderB\010\310\336\037\000\320\336\037\001\"k\n\032Intern"
-    "alTruncateLogRequest\0228\n\006header\030\001 \001(\0132\036.c"
-    "ockroach.proto.RequestHeaderB\010\310\336\037\000\320\336\037\001\022\023"
-    "\n\005index\030\002 \001(\004B\004\310\336\037\000\"X\n\033InternalTruncateL"
-    "ogResponse\0229\n\006header\030\001 \001(\0132\037.cockroach.p"
-    "roto.ResponseHeaderB\010\310\336\037\000\320\336\037\001\"\203\001\n\032Intern"
-    "alLeaderLeaseRequest\0228\n\006header\030\001 \001(\0132\036.c"
-    "ockroach.proto.RequestHeaderB\010\310\336\037\000\320\336\037\001\022+"
-    "\n\005lease\030\002 \001(\0132\026.cockroach.proto.LeaseB\004\310"
-    "\336\037\000\"X\n\033InternalLeaderLeaseResponse\0229\n\006he"
-    "ader\030\001 \001(\0132\037.cockroach.proto.ResponseHea"
-    "derB\010\310\336\037\000\320\336\037\001\"\315\005\n\024InternalRequestUnion\022*"
-    "\n\003get\030\002 \001(\0132\033.cockroach.proto.GetRequest"
-    "H\000\022*\n\003put\030\003 \001(\0132\033.cockroach.proto.PutReq"
-    "uestH\000\022A\n\017conditional_put\030\004 \001(\0132&.cockro"
-    "ach.proto.ConditionalPutRequestH\000\0226\n\tinc"
-    "rement\030\005 \001(\0132!.cockroach.proto.Increment"
-    "RequestH\000\0220\n\006delete\030\006 \001(\0132\036.cockroach.pr"
-    "oto.DeleteRequestH\000\022;\n\014delete_range\030\007 \001("
-    "\0132#.cockroach.proto.DeleteRangeRequestH\000"
-    "\022,\n\004scan\030\010 \001(\0132\034.cockroach.proto.ScanReq"
-    "uestH\000\022A\n\017end_transaction\030\t \001(\0132&.cockro"
-    "ach.proto.EndTransactionRequestH\000\022D\n\021int"
-    "ernal_push_txn\030\036 \001(\0132\'.cockroach.proto.I"
-    "nternalPushTxnRequestH\000\022P\n\027internal_reso"
-    "lve_intent\030\037 \001(\0132-.cockroach.proto.Inter"
-    "nalResolveIntentRequestH\000\022[\n\035internal_re"
-    "solve_intent_range\030  \001(\01322.cockroach.pro"
-    "to.InternalResolveIntentRangeRequestH\000:\004"
-    "\310\240\037\001B\007\n\005value\"\331\005\n\025InternalResponseUnion\022"
-    "+\n\003get\030\002 \001(\0132\034.cockroach.proto.GetRespon"
-    "seH\000\022+\n\003put\030\003 \001(\0132\034.cockroach.proto.PutR"
-    "esponseH\000\022B\n\017conditional_put\030\004 \001(\0132\'.coc"
-    "kroach.proto.ConditionalPutResponseH\000\0227\n"
-    "\tincrement\030\005 \001(\0132\".cockroach.proto.Incre"
-    "mentResponseH\000\0221\n\006delete\030\006 \001(\0132\037.cockroa"
-    "ch.proto.DeleteResponseH\000\022<\n\014delete_rang"
-    "e\030\007 \001(\0132$.cockroach.proto.DeleteRangeRes"
-    "ponseH\000\022-\n\004scan\030\010 \001(\0132\035.cockroach.proto."
-    "ScanResponseH\000\022B\n\017end_transaction\030\t \001(\0132"
-    "\'.cockroach.proto.EndTransactionResponse"
-    "H\000\022E\n\021internal_push_txn\030\036 \001(\0132(.cockroac"
-    "h.proto.InternalPushTxnResponseH\000\022Q\n\027int"
-    "ernal_resolve_intent\030\037 \001(\0132..cockroach.p"
-    "roto.InternalResolveIntentResponseH\000\022\\\n\035"
-    "internal_resolve_intent_range\030  \001(\01323.co"
-    "ckroach.proto.InternalResolveIntentRange"
-    "ResponseH\000:\004\310\240\037\001B\007\n\005value\"\217\001\n\024InternalBa"
-    "tchRequest\0228\n\006header\030\001 \001(\0132\036.cockroach.p"
-    "roto.RequestHeaderB\010\310\336\037\000\320\336\037\001\022=\n\010requests"
-    "\030\002 \003(\0132%.cockroach.proto.InternalRequest"
-    "UnionB\004\310\336\037\000\"\223\001\n\025InternalBatchResponse\0229\n"
-    "\006header\030\001 \001(\0132\037.cockroach.proto.Response"
-    "HeaderB\010\310\336\037\000\320\336\037\001\022\?\n\tresponses\030\002 \003(\0132&.co"
-    "ckroach.proto.InternalResponseUnionB\004\310\336\037"
-    "\000\"\351\007\n\024ReadWriteCmdResponse\022+\n\003put\030\001 \001(\0132"
-    "\034.cockroach.proto.PutResponseH\000\022B\n\017condi"
-    "tional_put\030\002 \001(\0132\'.cockroach.proto.Condi"
-    "tionalPutResponseH\000\0227\n\tincrement\030\003 \001(\0132\""
-    ".cockroach.proto.IncrementResponseH\000\0221\n\006"
-    "delete\030\004 \001(\0132\037.cockroach.proto.DeleteRes"
-    "ponseH\000\022<\n\014delete_range\030\005 \001(\0132$.cockroac"
-    "h.proto.DeleteRangeResponseH\000\022B\n\017end_tra"
-    "nsaction\030\006 \001(\0132\'.cockroach.proto.EndTran"
-    "sactionResponseH\000\022O\n\026internal_heartbeat_"
-    "txn\030\n \001(\0132-.cockroach.proto.InternalHear"
-    "tbeatTxnResponseH\000\022E\n\021internal_push_txn\030"
-    "\013 \001(\0132(.cockroach.proto.InternalPushTxnR"
-    "esponseH\000\022Q\n\027internal_resolve_intent\030\014 \001"
-    "(\0132..cockroach.proto.InternalResolveInte"
-    "ntResponseH\000\022\\\n\035internal_resolve_intent_"
-    "range\030\r \001(\01323.cockroach.proto.InternalRe"
-    "solveIntentRangeResponseH\000\022@\n\016internal_m"
-    "erge\030\016 \001(\0132&.cockroach.proto.InternalMer"
-    "geResponseH\000\022M\n\025internal_truncate_log\030\017 "
-    "\001(\0132,.cockroach.proto.InternalTruncateLo"
-    "gResponseH\000\022:\n\013internal_gc\030\020 \001(\0132#.cockr"
-    "oach.proto.InternalGCResponseH\000\022M\n\025inter"
-    "nal_leader_lease\030\021 \001(\0132,.cockroach.proto"
-    ".InternalLeaderLeaseResponseH\000:\004\310\240\037\001B\007\n\005"
-    "value\"\212\n\n\030InternalRaftCommandUnion\022*\n\003ge"
-    "t\030\002 \001(\0132\033.cockroach.proto.GetRequestH\000\022*"
-    "\n\003put\030\003 \001(\0132\033.cockroach.proto.PutRequest"
-    "H\000\022A\n\017conditional_put\030\004 \001(\0132&.cockroach."
-    "proto.ConditionalPutRequestH\000\0226\n\tincreme"
-    "nt\030\005 \001(\0132!.cockroach.proto.IncrementRequ"
-    "estH\000\0220\n\006delete\030\006 \001(\0132\036.cockroach.proto."
-    "DeleteRequestH\000\022;\n\014delete_range\030\007 \001(\0132#."
-    "cockroach.proto.DeleteRangeRequestH\000\022,\n\004"
-    "scan\030\010 \001(\0132\034.cockroach.proto.ScanRequest"
-    "H\000\022A\n\017end_transaction\030\t \001(\0132&.cockroach."
-    "proto.EndTransactionRequestH\000\022.\n\005batch\030\036"
-    " \001(\0132\035.cockroach.proto.BatchRequestH\000\022L\n"
-    "\025internal_range_lookup\030\037 \001(\0132+.cockroach"
-    ".proto.InternalRangeLookupRequestH\000\022N\n\026i"
-    "nternal_heartbeat_txn\030  \001(\0132,.cockroach."
-    "proto.InternalHeartbeatTxnRequestH\000\022D\n\021i"
-    "nternal_push_txn\030! \001(\0132\'.cockroach.proto"
-    ".InternalPushTxnRequestH\000\022P\n\027internal_re"
-    "solve_intent\030\" \001(\0132-.cockroach.proto.Int"
-    "ernalResolveIntentRequestH\000\022[\n\035internal_"
-    "resolve_intent_range\030# \001(\01322.cockroach.p"
-    "roto.InternalResolveIntentRangeRequestH\000"
-    "\022H\n\027internal_merge_response\030$ \001(\0132%.cock"
-    "roach.proto.InternalMergeRequestH\000\022L\n\025in"
-    "ternal_truncate_log\030% \001(\0132+.cockroach.pr"
-    "oto.InternalTruncateLogRequestH\000\022I\n\013inte"
-    "rnal_gc\030& \001(\0132\".cockroach.proto.Internal"
-    "GCRequestB\016\342\336\037\nInternalGCH\000\022E\n\016internal_"
-    "lease\030\' \001(\0132+.cockroach.proto.InternalLe"
-    "aderLeaseRequestH\000\022\?\n\016internal_batch\030( \001"
-    "(\0132%.cockroach.proto.InternalBatchReques"
-    "tH\000:\004\310\240\037\001B\007\n\005value\"\272\001\n\023InternalRaftComma"
-    "nd\022)\n\007raft_id\030\001 \001(\003B\030\310\336\037\000\342\336\037\006RaftID\372\336\037\006R"
-    "aftID\022:\n\016origin_node_id\030\002 \001(\004B\"\310\336\037\000\342\336\037\014O"
-    "riginNodeID\372\336\037\nRaftNodeID\022<\n\003cmd\030\003 \001(\0132)"
-    ".cockroach.proto.InternalRaftCommandUnio"
-    "nB\004\310\336\037\000\"N\n\022RaftMessageRequest\022+\n\010group_i"
-    "d\030\001 \001(\004B\031\310\336\037\000\342\336\037\007GroupID\372\336\037\006RaftID\022\013\n\003ms"
-    "g\030\002 \001(\014\"\025\n\023RaftMessageResponse\"\236\001\n\026Inter"
-    "nalTimeSeriesData\022#\n\025start_timestamp_nan"
-    "os\030\001 \001(\003B\004\310\336\037\000\022#\n\025sample_duration_nanos\030"
-    "\002 \001(\003B\004\310\336\037\000\022:\n\007samples\030\003 \003(\0132).cockroach"
-    ".proto.InternalTimeSeriesSample\"r\n\030Inter"
-    "nalTimeSeriesSample\022\024\n\006offset\030\001 \001(\005B\004\310\336\037"
-    "\000\022\023\n\005count\030\006 \001(\rB\004\310\336\037\000\022\021\n\003sum\030\007 \001(\001B\004\310\336\037"
-    "\000\022\013\n\003max\030\010 \001(\001\022\013\n\003min\030\t \001(\001\"=\n\022RaftTrunc"
-    "atedState\022\023\n\005index\030\001 \001(\004B\004\310\336\037\000\022\022\n\004term\030\002"
-    " \001(\004B\004\310\336\037\000\"\274\001\n\020RaftSnapshotData\022@\n\020range"
-    "_descriptor\030\001 \001(\0132 .cockroach.proto.Rang"
-    "eDescriptorB\004\310\336\037\000\022>\n\002KV\030\002 \003(\0132*.cockroac"
-    "h.proto.RaftSnapshotData.KeyValueB\006\342\336\037\002K"
-    "V\032&\n\010KeyValue\022\013\n\003key\030\001 \001(\014\022\r\n\005value\030\002 \001("
-    "\014*G\n\013PushTxnType\022\022\n\016PUSH_TIMESTAMP\020\000\022\r\n\t"
-    "ABORT_TXN\020\001\022\017\n\013CLEANUP_TXN\020\002\032\004\210\243\036\000*%\n\021In"
-    "ternalValueType\022\n\n\006_CR_TS\020\001\032\004\210\243\036\000B\023Z\005pro"
-    "to\340\342\036\001\310\342\036\001\320\342\036\001", 7414);
+    "oto/data.proto\032\024gogoproto/gogo.proto\"\222\001\n"
+    "\032InternalRangeLookupRequest\022<\n\010kvheader\030"
+    "\001 \001(\0132 .cockroach.proto.KVRequestHeaderB"
+    "\010\310\336\037\000\320\336\037\001\022\030\n\nmax_ranges\030\002 \001(\005B\004\310\336\037\000\022\034\n\016i"
+    "gnore_intents\030\003 \001(\010B\004\310\336\037\000\"\224\001\n\033InternalRa"
+    "ngeLookupResponse\022=\n\010kvheader\030\001 \001(\0132!.co"
+    "ckroach.proto.KVResponseHeaderB\010\310\336\037\000\320\336\037\001"
+    "\0226\n\006ranges\030\002 \003(\0132 .cockroach.proto.Range"
+    "DescriptorB\004\310\336\037\000\"[\n\033InternalHeartbeatTxn"
+    "Request\022<\n\010kvheader\030\001 \001(\0132 .cockroach.pr"
+    "oto.KVRequestHeaderB\010\310\336\037\000\320\336\037\001\"]\n\034Interna"
+    "lHeartbeatTxnResponse\022=\n\010kvheader\030\001 \001(\0132"
+    "!.cockroach.proto.KVResponseHeaderB\010\310\336\037\000"
+    "\320\336\037\001\"\241\002\n\021InternalGCRequest\022<\n\010kvheader\030\001"
+    " \001(\0132 .cockroach.proto.KVRequestHeaderB\010"
+    "\310\336\037\000\320\336\037\001\022<\n\007gc_meta\030\002 \001(\0132\033.cockroach.pr"
+    "oto.GCMetadataB\016\310\336\037\000\342\336\037\006GCMeta\022<\n\004keys\030\003"
+    " \003(\0132(.cockroach.proto.InternalGCRequest"
+    ".GCKeyB\004\310\336\037\000\032R\n\005GCKey\022\024\n\003key\030\001 \001(\014B\007\372\336\037\003"
+    "Key\0223\n\ttimestamp\030\002 \001(\0132\032.cockroach.proto"
+    ".TimestampB\004\310\336\037\000\"S\n\022InternalGCResponse\022="
+    "\n\010kvheader\030\001 \001(\0132!.cockroach.proto.KVRes"
+    "ponseHeaderB\010\310\336\037\000\320\336\037\001\"\220\002\n\026InternalPushTx"
+    "nRequest\022<\n\010kvheader\030\001 \001(\0132 .cockroach.p"
+    "roto.KVRequestHeaderB\010\310\336\037\000\320\336\037\001\0226\n\npushee"
+    "_txn\030\002 \001(\0132\034.cockroach.proto.Transaction"
+    "B\004\310\336\037\000\022-\n\003now\030\003 \001(\0132\032.cockroach.proto.Ti"
+    "mestampB\004\310\336\037\000\0225\n\tpush_type\030\004 \001(\0162\034.cockr"
+    "oach.proto.PushTxnTypeB\004\310\336\037\000\022\032\n\014range_lo"
+    "okup\030\005 \001(\010B\004\310\336\037\000\"\212\001\n\027InternalPushTxnResp"
+    "onse\022=\n\010kvheader\030\001 \001(\0132!.cockroach.proto"
+    ".KVResponseHeaderB\010\310\336\037\000\320\336\037\001\0220\n\npushee_tx"
+    "n\030\002 \001(\0132\034.cockroach.proto.Transaction\"\\\n"
+    "\034InternalResolveIntentRequest\022<\n\010kvheade"
+    "r\030\001 \001(\0132 .cockroach.proto.KVRequestHeade"
+    "rB\010\310\336\037\000\320\336\037\001\"^\n\035InternalResolveIntentResp"
+    "onse\022=\n\010kvheader\030\001 \001(\0132!.cockroach.proto"
+    ".KVResponseHeaderB\010\310\336\037\000\320\336\037\001\"a\n!InternalR"
+    "esolveIntentRangeRequest\022<\n\010kvheader\030\001 \001"
+    "(\0132 .cockroach.proto.KVRequestHeaderB\010\310\336"
+    "\037\000\320\336\037\001\"c\n\"InternalResolveIntentRangeResp"
+    "onse\022=\n\010kvheader\030\001 \001(\0132!.cockroach.proto"
+    ".KVResponseHeaderB\010\310\336\037\000\320\336\037\001\"\201\001\n\024Internal"
+    "MergeRequest\022<\n\010kvheader\030\001 \001(\0132 .cockroa"
+    "ch.proto.KVRequestHeaderB\010\310\336\037\000\320\336\037\001\022+\n\005va"
+    "lue\030\002 \001(\0132\026.cockroach.proto.ValueB\004\310\336\037\000\""
+    "V\n\025InternalMergeResponse\022=\n\010kvheader\030\001 \001"
+    "(\0132!.cockroach.proto.KVResponseHeaderB\010\310"
+    "\336\037\000\320\336\037\001\"o\n\032InternalTruncateLogRequest\022<\n"
+    "\010kvheader\030\001 \001(\0132 .cockroach.proto.KVRequ"
+    "estHeaderB\010\310\336\037\000\320\336\037\001\022\023\n\005index\030\002 \001(\004B\004\310\336\037\000"
+    "\"\\\n\033InternalTruncateLogResponse\022=\n\010kvhea"
+    "der\030\001 \001(\0132!.cockroach.proto.KVResponseHe"
+    "aderB\010\310\336\037\000\320\336\037\001\"\207\001\n\032InternalLeaderLeaseRe"
+    "quest\022<\n\010kvheader\030\001 \001(\0132 .cockroach.prot"
+    "o.KVRequestHeaderB\010\310\336\037\000\320\336\037\001\022+\n\005lease\030\002 \001"
+    "(\0132\026.cockroach.proto.LeaseB\004\310\336\037\000\"\\\n\033Inte"
+    "rnalLeaderLeaseResponse\022=\n\010kvheader\030\001 \001("
+    "\0132!.cockroach.proto.KVResponseHeaderB\010\310\336"
+    "\037\000\320\336\037\001\"\315\005\n\024InternalRequestUnion\022*\n\003get\030\002"
+    " \001(\0132\033.cockroach.proto.GetRequestH\000\022*\n\003p"
+    "ut\030\003 \001(\0132\033.cockroach.proto.PutRequestH\000\022"
+    "A\n\017conditional_put\030\004 \001(\0132&.cockroach.pro"
+    "to.ConditionalPutRequestH\000\0226\n\tincrement\030"
+    "\005 \001(\0132!.cockroach.proto.IncrementRequest"
+    "H\000\0220\n\006delete\030\006 \001(\0132\036.cockroach.proto.Del"
+    "eteRequestH\000\022;\n\014delete_range\030\007 \001(\0132#.coc"
+    "kroach.proto.DeleteRangeRequestH\000\022,\n\004sca"
+    "n\030\010 \001(\0132\034.cockroach.proto.ScanRequestH\000\022"
+    "A\n\017end_transaction\030\t \001(\0132&.cockroach.pro"
+    "to.EndTransactionRequestH\000\022D\n\021internal_p"
+    "ush_txn\030\036 \001(\0132\'.cockroach.proto.Internal"
+    "PushTxnRequestH\000\022P\n\027internal_resolve_int"
+    "ent\030\037 \001(\0132-.cockroach.proto.InternalReso"
+    "lveIntentRequestH\000\022[\n\035internal_resolve_i"
+    "ntent_range\030  \001(\01322.cockroach.proto.Inte"
+    "rnalResolveIntentRangeRequestH\000:\004\310\240\037\001B\007\n"
+    "\005value\"\331\005\n\025InternalResponseUnion\022+\n\003get\030"
+    "\002 \001(\0132\034.cockroach.proto.GetResponseH\000\022+\n"
+    "\003put\030\003 \001(\0132\034.cockroach.proto.PutResponse"
+    "H\000\022B\n\017conditional_put\030\004 \001(\0132\'.cockroach."
+    "proto.ConditionalPutResponseH\000\0227\n\tincrem"
+    "ent\030\005 \001(\0132\".cockroach.proto.IncrementRes"
+    "ponseH\000\0221\n\006delete\030\006 \001(\0132\037.cockroach.prot"
+    "o.DeleteResponseH\000\022<\n\014delete_range\030\007 \001(\013"
+    "2$.cockroach.proto.DeleteRangeResponseH\000"
+    "\022-\n\004scan\030\010 \001(\0132\035.cockroach.proto.ScanRes"
+    "ponseH\000\022B\n\017end_transaction\030\t \001(\0132\'.cockr"
+    "oach.proto.EndTransactionResponseH\000\022E\n\021i"
+    "nternal_push_txn\030\036 \001(\0132(.cockroach.proto"
+    ".InternalPushTxnResponseH\000\022Q\n\027internal_r"
+    "esolve_intent\030\037 \001(\0132..cockroach.proto.In"
+    "ternalResolveIntentResponseH\000\022\\\n\035interna"
+    "l_resolve_intent_range\030  \001(\01323.cockroach"
+    ".proto.InternalResolveIntentRangeRespons"
+    "eH\000:\004\310\240\037\001B\007\n\005value\"\223\001\n\024InternalBatchRequ"
+    "est\022<\n\010kvheader\030\001 \001(\0132 .cockroach.proto."
+    "KVRequestHeaderB\010\310\336\037\000\320\336\037\001\022=\n\010requests\030\002 "
+    "\003(\0132%.cockroach.proto.InternalRequestUni"
+    "onB\004\310\336\037\000\"\227\001\n\025InternalBatchResponse\022=\n\010kv"
+    "header\030\001 \001(\0132!.cockroach.proto.KVRespons"
+    "eHeaderB\010\310\336\037\000\320\336\037\001\022\?\n\tresponses\030\002 \003(\0132&.c"
+    "ockroach.proto.InternalResponseUnionB\004\310\336"
+    "\037\000\"\351\007\n\024ReadWriteCmdResponse\022+\n\003put\030\001 \001(\013"
+    "2\034.cockroach.proto.PutResponseH\000\022B\n\017cond"
+    "itional_put\030\002 \001(\0132\'.cockroach.proto.Cond"
+    "itionalPutResponseH\000\0227\n\tincrement\030\003 \001(\0132"
+    "\".cockroach.proto.IncrementResponseH\000\0221\n"
+    "\006delete\030\004 \001(\0132\037.cockroach.proto.DeleteRe"
+    "sponseH\000\022<\n\014delete_range\030\005 \001(\0132$.cockroa"
+    "ch.proto.DeleteRangeResponseH\000\022B\n\017end_tr"
+    "ansaction\030\006 \001(\0132\'.cockroach.proto.EndTra"
+    "nsactionResponseH\000\022O\n\026internal_heartbeat"
+    "_txn\030\n \001(\0132-.cockroach.proto.InternalHea"
+    "rtbeatTxnResponseH\000\022E\n\021internal_push_txn"
+    "\030\013 \001(\0132(.cockroach.proto.InternalPushTxn"
+    "ResponseH\000\022Q\n\027internal_resolve_intent\030\014 "
+    "\001(\0132..cockroach.proto.InternalResolveInt"
+    "entResponseH\000\022\\\n\035internal_resolve_intent"
+    "_range\030\r \001(\01323.cockroach.proto.InternalR"
+    "esolveIntentRangeResponseH\000\022@\n\016internal_"
+    "merge\030\016 \001(\0132&.cockroach.proto.InternalMe"
+    "rgeResponseH\000\022M\n\025internal_truncate_log\030\017"
+    " \001(\0132,.cockroach.proto.InternalTruncateL"
+    "ogResponseH\000\022:\n\013internal_gc\030\020 \001(\0132#.cock"
+    "roach.proto.InternalGCResponseH\000\022M\n\025inte"
+    "rnal_leader_lease\030\021 \001(\0132,.cockroach.prot"
+    "o.InternalLeaderLeaseResponseH\000:\004\310\240\037\001B\007\n"
+    "\005value\"\212\n\n\030InternalRaftCommandUnion\022*\n\003g"
+    "et\030\002 \001(\0132\033.cockroach.proto.GetRequestH\000\022"
+    "*\n\003put\030\003 \001(\0132\033.cockroach.proto.PutReques"
+    "tH\000\022A\n\017conditional_put\030\004 \001(\0132&.cockroach"
+    ".proto.ConditionalPutRequestH\000\0226\n\tincrem"
+    "ent\030\005 \001(\0132!.cockroach.proto.IncrementReq"
+    "uestH\000\0220\n\006delete\030\006 \001(\0132\036.cockroach.proto"
+    ".DeleteRequestH\000\022;\n\014delete_range\030\007 \001(\0132#"
+    ".cockroach.proto.DeleteRangeRequestH\000\022,\n"
+    "\004scan\030\010 \001(\0132\034.cockroach.proto.ScanReques"
+    "tH\000\022A\n\017end_transaction\030\t \001(\0132&.cockroach"
+    ".proto.EndTransactionRequestH\000\022.\n\005batch\030"
+    "\036 \001(\0132\035.cockroach.proto.BatchRequestH\000\022L"
+    "\n\025internal_range_lookup\030\037 \001(\0132+.cockroac"
+    "h.proto.InternalRangeLookupRequestH\000\022N\n\026"
+    "internal_heartbeat_txn\030  \001(\0132,.cockroach"
+    ".proto.InternalHeartbeatTxnRequestH\000\022D\n\021"
+    "internal_push_txn\030! \001(\0132\'.cockroach.prot"
+    "o.InternalPushTxnRequestH\000\022P\n\027internal_r"
+    "esolve_intent\030\" \001(\0132-.cockroach.proto.In"
+    "ternalResolveIntentRequestH\000\022[\n\035internal"
+    "_resolve_intent_range\030# \001(\01322.cockroach."
+    "proto.InternalResolveIntentRangeRequestH"
+    "\000\022H\n\027internal_merge_response\030$ \001(\0132%.coc"
+    "kroach.proto.InternalMergeRequestH\000\022L\n\025i"
+    "nternal_truncate_log\030% \001(\0132+.cockroach.p"
+    "roto.InternalTruncateLogRequestH\000\022I\n\013int"
+    "ernal_gc\030& \001(\0132\".cockroach.proto.Interna"
+    "lGCRequestB\016\342\336\037\nInternalGCH\000\022E\n\016internal"
+    "_lease\030\' \001(\0132+.cockroach.proto.InternalL"
+    "eaderLeaseRequestH\000\022\?\n\016internal_batch\030( "
+    "\001(\0132%.cockroach.proto.InternalBatchReque"
+    "stH\000:\004\310\240\037\001B\007\n\005value\"\272\001\n\023InternalRaftComm"
+    "and\022)\n\007raft_id\030\001 \001(\003B\030\310\336\037\000\342\336\037\006RaftID\372\336\037\006"
+    "RaftID\022:\n\016origin_node_id\030\002 \001(\004B\"\310\336\037\000\342\336\037\014"
+    "OriginNodeID\372\336\037\nRaftNodeID\022<\n\003cmd\030\003 \001(\0132"
+    ").cockroach.proto.InternalRaftCommandUni"
+    "onB\004\310\336\037\000\"N\n\022RaftMessageRequest\022+\n\010group_"
+    "id\030\001 \001(\004B\031\310\336\037\000\342\336\037\007GroupID\372\336\037\006RaftID\022\013\n\003m"
+    "sg\030\002 \001(\014\"\025\n\023RaftMessageResponse\"\236\001\n\026Inte"
+    "rnalTimeSeriesData\022#\n\025start_timestamp_na"
+    "nos\030\001 \001(\003B\004\310\336\037\000\022#\n\025sample_duration_nanos"
+    "\030\002 \001(\003B\004\310\336\037\000\022:\n\007samples\030\003 \003(\0132).cockroac"
+    "h.proto.InternalTimeSeriesSample\"r\n\030Inte"
+    "rnalTimeSeriesSample\022\024\n\006offset\030\001 \001(\005B\004\310\336"
+    "\037\000\022\023\n\005count\030\006 \001(\rB\004\310\336\037\000\022\021\n\003sum\030\007 \001(\001B\004\310\336"
+    "\037\000\022\013\n\003max\030\010 \001(\001\022\013\n\003min\030\t \001(\001\"=\n\022RaftTrun"
+    "catedState\022\023\n\005index\030\001 \001(\004B\004\310\336\037\000\022\022\n\004term\030"
+    "\002 \001(\004B\004\310\336\037\000\"\274\001\n\020RaftSnapshotData\022@\n\020rang"
+    "e_descriptor\030\001 \001(\0132 .cockroach.proto.Ran"
+    "geDescriptorB\004\310\336\037\000\022>\n\002KV\030\002 \003(\0132*.cockroa"
+    "ch.proto.RaftSnapshotData.KeyValueB\006\342\336\037\002"
+    "KV\032&\n\010KeyValue\022\013\n\003key\030\001 \001(\014\022\r\n\005value\030\002 \001"
+    "(\014*G\n\013PushTxnType\022\022\n\016PUSH_TIMESTAMP\020\000\022\r\n"
+    "\tABORT_TXN\020\001\022\017\n\013CLEANUP_TXN\020\002\032\004\210\243\036\000*%\n\021I"
+    "nternalValueType\022\n\n\006_CR_TS\020\001\032\004\210\243\036\000B\023Z\005pr"
+    "oto\340\342\036\001\310\342\036\001\320\342\036\001", 7495);
   ::google::protobuf::MessageFactory::InternalRegisterGeneratedFile(
     "cockroach/proto/internal.proto", &protobuf_RegisterTypes);
   InternalRangeLookupRequest::default_instance_ = new InternalRangeLookupRequest();
@@ -1257,7 +1259,7 @@ static void MergeFromFail(int line) {
 // ===================================================================
 
 #ifndef _MSC_VER
-const int InternalRangeLookupRequest::kHeaderFieldNumber;
+const int InternalRangeLookupRequest::kKvheaderFieldNumber;
 const int InternalRangeLookupRequest::kMaxRangesFieldNumber;
 const int InternalRangeLookupRequest::kIgnoreIntentsFieldNumber;
 #endif  // !_MSC_VER
@@ -1269,7 +1271,7 @@ InternalRangeLookupRequest::InternalRangeLookupRequest()
 }
 
 void InternalRangeLookupRequest::InitAsDefaultInstance() {
-  header_ = const_cast< ::cockroach::proto::RequestHeader*>(&::cockroach::proto::RequestHeader::default_instance());
+  kvheader_ = const_cast< ::cockroach::proto::KVRequestHeader*>(&::cockroach::proto::KVRequestHeader::default_instance());
 }
 
 InternalRangeLookupRequest::InternalRangeLookupRequest(const InternalRangeLookupRequest& from)
@@ -1282,7 +1284,7 @@ InternalRangeLookupRequest::InternalRangeLookupRequest(const InternalRangeLookup
 
 void InternalRangeLookupRequest::SharedCtor() {
   _cached_size_ = 0;
-  header_ = NULL;
+  kvheader_ = NULL;
   max_ranges_ = 0;
   ignore_intents_ = false;
   ::memset(_has_bits_, 0, sizeof(_has_bits_));
@@ -1295,7 +1297,7 @@ InternalRangeLookupRequest::~InternalRangeLookupRequest() {
 
 void InternalRangeLookupRequest::SharedDtor() {
   if (this != default_instance_) {
-    delete header_;
+    delete kvheader_;
   }
 }
 
@@ -1335,8 +1337,8 @@ void InternalRangeLookupRequest::Clear() {
 
   if (_has_bits_[0 / 32] & 7u) {
     ZR_(max_ranges_, ignore_intents_);
-    if (has_header()) {
-      if (header_ != NULL) header_->::cockroach::proto::RequestHeader::Clear();
+    if (has_kvheader()) {
+      if (kvheader_ != NULL) kvheader_->::cockroach::proto::KVRequestHeader::Clear();
     }
   }
 
@@ -1359,11 +1361,11 @@ bool InternalRangeLookupRequest::MergePartialFromCodedStream(
     tag = p.first;
     if (!p.second) goto handle_unusual;
     switch (::google::protobuf::internal::WireFormatLite::GetTagFieldNumber(tag)) {
-      // optional .cockroach.proto.RequestHeader header = 1;
+      // optional .cockroach.proto.KVRequestHeader kvheader = 1;
       case 1: {
         if (tag == 10) {
           DO_(::google::protobuf::internal::WireFormatLite::ReadMessageNoVirtual(
-               input, mutable_header()));
+               input, mutable_kvheader()));
         } else {
           goto handle_unusual;
         }
@@ -1426,10 +1428,10 @@ failure:
 void InternalRangeLookupRequest::SerializeWithCachedSizes(
     ::google::protobuf::io::CodedOutputStream* output) const {
   // @@protoc_insertion_point(serialize_start:cockroach.proto.InternalRangeLookupRequest)
-  // optional .cockroach.proto.RequestHeader header = 1;
-  if (has_header()) {
+  // optional .cockroach.proto.KVRequestHeader kvheader = 1;
+  if (has_kvheader()) {
     ::google::protobuf::internal::WireFormatLite::WriteMessageMaybeToArray(
-      1, *this->header_, output);
+      1, *this->kvheader_, output);
   }
 
   // optional int32 max_ranges = 2;
@@ -1452,11 +1454,11 @@ void InternalRangeLookupRequest::SerializeWithCachedSizes(
 ::google::protobuf::uint8* InternalRangeLookupRequest::SerializeWithCachedSizesToArray(
     ::google::protobuf::uint8* target) const {
   // @@protoc_insertion_point(serialize_to_array_start:cockroach.proto.InternalRangeLookupRequest)
-  // optional .cockroach.proto.RequestHeader header = 1;
-  if (has_header()) {
+  // optional .cockroach.proto.KVRequestHeader kvheader = 1;
+  if (has_kvheader()) {
     target = ::google::protobuf::internal::WireFormatLite::
       WriteMessageNoVirtualToArray(
-        1, *this->header_, target);
+        1, *this->kvheader_, target);
   }
 
   // optional int32 max_ranges = 2;
@@ -1481,11 +1483,11 @@ int InternalRangeLookupRequest::ByteSize() const {
   int total_size = 0;
 
   if (_has_bits_[0 / 32] & 7) {
-    // optional .cockroach.proto.RequestHeader header = 1;
-    if (has_header()) {
+    // optional .cockroach.proto.KVRequestHeader kvheader = 1;
+    if (has_kvheader()) {
       total_size += 1 +
         ::google::protobuf::internal::WireFormatLite::MessageSizeNoVirtual(
-          *this->header_);
+          *this->kvheader_);
     }
 
     // optional int32 max_ranges = 2;
@@ -1527,8 +1529,8 @@ void InternalRangeLookupRequest::MergeFrom(const ::google::protobuf::Message& fr
 void InternalRangeLookupRequest::MergeFrom(const InternalRangeLookupRequest& from) {
   if (GOOGLE_PREDICT_FALSE(&from == this)) MergeFromFail(__LINE__);
   if (from._has_bits_[0 / 32] & (0xffu << (0 % 32))) {
-    if (from.has_header()) {
-      mutable_header()->::cockroach::proto::RequestHeader::MergeFrom(from.header());
+    if (from.has_kvheader()) {
+      mutable_kvheader()->::cockroach::proto::KVRequestHeader::MergeFrom(from.kvheader());
     }
     if (from.has_max_ranges()) {
       set_max_ranges(from.max_ranges());
@@ -1564,7 +1566,7 @@ void InternalRangeLookupRequest::Swap(InternalRangeLookupRequest* other) {
   InternalSwap(other);
 }
 void InternalRangeLookupRequest::InternalSwap(InternalRangeLookupRequest* other) {
-  std::swap(header_, other->header_);
+  std::swap(kvheader_, other->kvheader_);
   std::swap(max_ranges_, other->max_ranges_);
   std::swap(ignore_intents_, other->ignore_intents_);
   std::swap(_has_bits_[0], other->_has_bits_[0]);
@@ -1583,47 +1585,47 @@ void InternalRangeLookupRequest::InternalSwap(InternalRangeLookupRequest* other)
 #if PROTOBUF_INLINE_NOT_IN_HEADERS
 // InternalRangeLookupRequest
 
-// optional .cockroach.proto.RequestHeader header = 1;
-bool InternalRangeLookupRequest::has_header() const {
+// optional .cockroach.proto.KVRequestHeader kvheader = 1;
+bool InternalRangeLookupRequest::has_kvheader() const {
   return (_has_bits_[0] & 0x00000001u) != 0;
 }
-void InternalRangeLookupRequest::set_has_header() {
+void InternalRangeLookupRequest::set_has_kvheader() {
   _has_bits_[0] |= 0x00000001u;
 }
-void InternalRangeLookupRequest::clear_has_header() {
+void InternalRangeLookupRequest::clear_has_kvheader() {
   _has_bits_[0] &= ~0x00000001u;
 }
-void InternalRangeLookupRequest::clear_header() {
-  if (header_ != NULL) header_->::cockroach::proto::RequestHeader::Clear();
-  clear_has_header();
+void InternalRangeLookupRequest::clear_kvheader() {
+  if (kvheader_ != NULL) kvheader_->::cockroach::proto::KVRequestHeader::Clear();
+  clear_has_kvheader();
 }
- const ::cockroach::proto::RequestHeader& InternalRangeLookupRequest::header() const {
-  // @@protoc_insertion_point(field_get:cockroach.proto.InternalRangeLookupRequest.header)
-  return header_ != NULL ? *header_ : *default_instance_->header_;
+ const ::cockroach::proto::KVRequestHeader& InternalRangeLookupRequest::kvheader() const {
+  // @@protoc_insertion_point(field_get:cockroach.proto.InternalRangeLookupRequest.kvheader)
+  return kvheader_ != NULL ? *kvheader_ : *default_instance_->kvheader_;
 }
- ::cockroach::proto::RequestHeader* InternalRangeLookupRequest::mutable_header() {
-  set_has_header();
-  if (header_ == NULL) {
-    header_ = new ::cockroach::proto::RequestHeader;
+ ::cockroach::proto::KVRequestHeader* InternalRangeLookupRequest::mutable_kvheader() {
+  set_has_kvheader();
+  if (kvheader_ == NULL) {
+    kvheader_ = new ::cockroach::proto::KVRequestHeader;
   }
-  // @@protoc_insertion_point(field_mutable:cockroach.proto.InternalRangeLookupRequest.header)
-  return header_;
+  // @@protoc_insertion_point(field_mutable:cockroach.proto.InternalRangeLookupRequest.kvheader)
+  return kvheader_;
 }
- ::cockroach::proto::RequestHeader* InternalRangeLookupRequest::release_header() {
-  clear_has_header();
-  ::cockroach::proto::RequestHeader* temp = header_;
-  header_ = NULL;
+ ::cockroach::proto::KVRequestHeader* InternalRangeLookupRequest::release_kvheader() {
+  clear_has_kvheader();
+  ::cockroach::proto::KVRequestHeader* temp = kvheader_;
+  kvheader_ = NULL;
   return temp;
 }
- void InternalRangeLookupRequest::set_allocated_header(::cockroach::proto::RequestHeader* header) {
-  delete header_;
-  header_ = header;
-  if (header) {
-    set_has_header();
+ void InternalRangeLookupRequest::set_allocated_kvheader(::cockroach::proto::KVRequestHeader* kvheader) {
+  delete kvheader_;
+  kvheader_ = kvheader;
+  if (kvheader) {
+    set_has_kvheader();
   } else {
-    clear_has_header();
+    clear_has_kvheader();
   }
-  // @@protoc_insertion_point(field_set_allocated:cockroach.proto.InternalRangeLookupRequest.header)
+  // @@protoc_insertion_point(field_set_allocated:cockroach.proto.InternalRangeLookupRequest.kvheader)
 }
 
 // optional int32 max_ranges = 2;
@@ -1679,7 +1681,7 @@ void InternalRangeLookupRequest::clear_ignore_intents() {
 // ===================================================================
 
 #ifndef _MSC_VER
-const int InternalRangeLookupResponse::kHeaderFieldNumber;
+const int InternalRangeLookupResponse::kKvheaderFieldNumber;
 const int InternalRangeLookupResponse::kRangesFieldNumber;
 #endif  // !_MSC_VER
 
@@ -1690,7 +1692,7 @@ InternalRangeLookupResponse::InternalRangeLookupResponse()
 }
 
 void InternalRangeLookupResponse::InitAsDefaultInstance() {
-  header_ = const_cast< ::cockroach::proto::ResponseHeader*>(&::cockroach::proto::ResponseHeader::default_instance());
+  kvheader_ = const_cast< ::cockroach::proto::KVResponseHeader*>(&::cockroach::proto::KVResponseHeader::default_instance());
 }
 
 InternalRangeLookupResponse::InternalRangeLookupResponse(const InternalRangeLookupResponse& from)
@@ -1703,7 +1705,7 @@ InternalRangeLookupResponse::InternalRangeLookupResponse(const InternalRangeLook
 
 void InternalRangeLookupResponse::SharedCtor() {
   _cached_size_ = 0;
-  header_ = NULL;
+  kvheader_ = NULL;
   ::memset(_has_bits_, 0, sizeof(_has_bits_));
 }
 
@@ -1714,7 +1716,7 @@ InternalRangeLookupResponse::~InternalRangeLookupResponse() {
 
 void InternalRangeLookupResponse::SharedDtor() {
   if (this != default_instance_) {
-    delete header_;
+    delete kvheader_;
   }
 }
 
@@ -1744,8 +1746,8 @@ InternalRangeLookupResponse* InternalRangeLookupResponse::New(::google::protobuf
 }
 
 void InternalRangeLookupResponse::Clear() {
-  if (has_header()) {
-    if (header_ != NULL) header_->::cockroach::proto::ResponseHeader::Clear();
+  if (has_kvheader()) {
+    if (kvheader_ != NULL) kvheader_->::cockroach::proto::KVResponseHeader::Clear();
   }
   ranges_.Clear();
   ::memset(_has_bits_, 0, sizeof(_has_bits_));
@@ -1764,11 +1766,11 @@ bool InternalRangeLookupResponse::MergePartialFromCodedStream(
     tag = p.first;
     if (!p.second) goto handle_unusual;
     switch (::google::protobuf::internal::WireFormatLite::GetTagFieldNumber(tag)) {
-      // optional .cockroach.proto.ResponseHeader header = 1;
+      // optional .cockroach.proto.KVResponseHeader kvheader = 1;
       case 1: {
         if (tag == 10) {
           DO_(::google::protobuf::internal::WireFormatLite::ReadMessageNoVirtual(
-               input, mutable_header()));
+               input, mutable_kvheader()));
         } else {
           goto handle_unusual;
         }
@@ -1818,10 +1820,10 @@ failure:
 void InternalRangeLookupResponse::SerializeWithCachedSizes(
     ::google::protobuf::io::CodedOutputStream* output) const {
   // @@protoc_insertion_point(serialize_start:cockroach.proto.InternalRangeLookupResponse)
-  // optional .cockroach.proto.ResponseHeader header = 1;
-  if (has_header()) {
+  // optional .cockroach.proto.KVResponseHeader kvheader = 1;
+  if (has_kvheader()) {
     ::google::protobuf::internal::WireFormatLite::WriteMessageMaybeToArray(
-      1, *this->header_, output);
+      1, *this->kvheader_, output);
   }
 
   // repeated .cockroach.proto.RangeDescriptor ranges = 2;
@@ -1840,11 +1842,11 @@ void InternalRangeLookupResponse::SerializeWithCachedSizes(
 ::google::protobuf::uint8* InternalRangeLookupResponse::SerializeWithCachedSizesToArray(
     ::google::protobuf::uint8* target) const {
   // @@protoc_insertion_point(serialize_to_array_start:cockroach.proto.InternalRangeLookupResponse)
-  // optional .cockroach.proto.ResponseHeader header = 1;
-  if (has_header()) {
+  // optional .cockroach.proto.KVResponseHeader kvheader = 1;
+  if (has_kvheader()) {
     target = ::google::protobuf::internal::WireFormatLite::
       WriteMessageNoVirtualToArray(
-        1, *this->header_, target);
+        1, *this->kvheader_, target);
   }
 
   // repeated .cockroach.proto.RangeDescriptor ranges = 2;
@@ -1865,11 +1867,11 @@ void InternalRangeLookupResponse::SerializeWithCachedSizes(
 int InternalRangeLookupResponse::ByteSize() const {
   int total_size = 0;
 
-  // optional .cockroach.proto.ResponseHeader header = 1;
-  if (has_header()) {
+  // optional .cockroach.proto.KVResponseHeader kvheader = 1;
+  if (has_kvheader()) {
     total_size += 1 +
       ::google::protobuf::internal::WireFormatLite::MessageSizeNoVirtual(
-        *this->header_);
+        *this->kvheader_);
   }
 
   // repeated .cockroach.proto.RangeDescriptor ranges = 2;
@@ -1907,8 +1909,8 @@ void InternalRangeLookupResponse::MergeFrom(const InternalRangeLookupResponse& f
   if (GOOGLE_PREDICT_FALSE(&from == this)) MergeFromFail(__LINE__);
   ranges_.MergeFrom(from.ranges_);
   if (from._has_bits_[0 / 32] & (0xffu << (0 % 32))) {
-    if (from.has_header()) {
-      mutable_header()->::cockroach::proto::ResponseHeader::MergeFrom(from.header());
+    if (from.has_kvheader()) {
+      mutable_kvheader()->::cockroach::proto::KVResponseHeader::MergeFrom(from.kvheader());
     }
   }
   if (from._internal_metadata_.have_unknown_fields()) {
@@ -1938,7 +1940,7 @@ void InternalRangeLookupResponse::Swap(InternalRangeLookupResponse* other) {
   InternalSwap(other);
 }
 void InternalRangeLookupResponse::InternalSwap(InternalRangeLookupResponse* other) {
-  std::swap(header_, other->header_);
+  std::swap(kvheader_, other->kvheader_);
   ranges_.UnsafeArenaSwap(&other->ranges_);
   std::swap(_has_bits_[0], other->_has_bits_[0]);
   _internal_metadata_.Swap(&other->_internal_metadata_);
@@ -1956,47 +1958,47 @@ void InternalRangeLookupResponse::InternalSwap(InternalRangeLookupResponse* othe
 #if PROTOBUF_INLINE_NOT_IN_HEADERS
 // InternalRangeLookupResponse
 
-// optional .cockroach.proto.ResponseHeader header = 1;
-bool InternalRangeLookupResponse::has_header() const {
+// optional .cockroach.proto.KVResponseHeader kvheader = 1;
+bool InternalRangeLookupResponse::has_kvheader() const {
   return (_has_bits_[0] & 0x00000001u) != 0;
 }
-void InternalRangeLookupResponse::set_has_header() {
+void InternalRangeLookupResponse::set_has_kvheader() {
   _has_bits_[0] |= 0x00000001u;
 }
-void InternalRangeLookupResponse::clear_has_header() {
+void InternalRangeLookupResponse::clear_has_kvheader() {
   _has_bits_[0] &= ~0x00000001u;
 }
-void InternalRangeLookupResponse::clear_header() {
-  if (header_ != NULL) header_->::cockroach::proto::ResponseHeader::Clear();
-  clear_has_header();
+void InternalRangeLookupResponse::clear_kvheader() {
+  if (kvheader_ != NULL) kvheader_->::cockroach::proto::KVResponseHeader::Clear();
+  clear_has_kvheader();
 }
- const ::cockroach::proto::ResponseHeader& InternalRangeLookupResponse::header() const {
-  // @@protoc_insertion_point(field_get:cockroach.proto.InternalRangeLookupResponse.header)
-  return header_ != NULL ? *header_ : *default_instance_->header_;
+ const ::cockroach::proto::KVResponseHeader& InternalRangeLookupResponse::kvheader() const {
+  // @@protoc_insertion_point(field_get:cockroach.proto.InternalRangeLookupResponse.kvheader)
+  return kvheader_ != NULL ? *kvheader_ : *default_instance_->kvheader_;
 }
- ::cockroach::proto::ResponseHeader* InternalRangeLookupResponse::mutable_header() {
-  set_has_header();
-  if (header_ == NULL) {
-    header_ = new ::cockroach::proto::ResponseHeader;
+ ::cockroach::proto::KVResponseHeader* InternalRangeLookupResponse::mutable_kvheader() {
+  set_has_kvheader();
+  if (kvheader_ == NULL) {
+    kvheader_ = new ::cockroach::proto::KVResponseHeader;
   }
-  // @@protoc_insertion_point(field_mutable:cockroach.proto.InternalRangeLookupResponse.header)
-  return header_;
+  // @@protoc_insertion_point(field_mutable:cockroach.proto.InternalRangeLookupResponse.kvheader)
+  return kvheader_;
 }
- ::cockroach::proto::ResponseHeader* InternalRangeLookupResponse::release_header() {
-  clear_has_header();
-  ::cockroach::proto::ResponseHeader* temp = header_;
-  header_ = NULL;
+ ::cockroach::proto::KVResponseHeader* InternalRangeLookupResponse::release_kvheader() {
+  clear_has_kvheader();
+  ::cockroach::proto::KVResponseHeader* temp = kvheader_;
+  kvheader_ = NULL;
   return temp;
 }
- void InternalRangeLookupResponse::set_allocated_header(::cockroach::proto::ResponseHeader* header) {
-  delete header_;
-  header_ = header;
-  if (header) {
-    set_has_header();
+ void InternalRangeLookupResponse::set_allocated_kvheader(::cockroach::proto::KVResponseHeader* kvheader) {
+  delete kvheader_;
+  kvheader_ = kvheader;
+  if (kvheader) {
+    set_has_kvheader();
   } else {
-    clear_has_header();
+    clear_has_kvheader();
   }
-  // @@protoc_insertion_point(field_set_allocated:cockroach.proto.InternalRangeLookupResponse.header)
+  // @@protoc_insertion_point(field_set_allocated:cockroach.proto.InternalRangeLookupResponse.kvheader)
 }
 
 // repeated .cockroach.proto.RangeDescriptor ranges = 2;
@@ -2034,7 +2036,7 @@ InternalRangeLookupResponse::mutable_ranges() {
 // ===================================================================
 
 #ifndef _MSC_VER
-const int InternalHeartbeatTxnRequest::kHeaderFieldNumber;
+const int InternalHeartbeatTxnRequest::kKvheaderFieldNumber;
 #endif  // !_MSC_VER
 
 InternalHeartbeatTxnRequest::InternalHeartbeatTxnRequest()
@@ -2044,7 +2046,7 @@ InternalHeartbeatTxnRequest::InternalHeartbeatTxnRequest()
 }
 
 void InternalHeartbeatTxnRequest::InitAsDefaultInstance() {
-  header_ = const_cast< ::cockroach::proto::RequestHeader*>(&::cockroach::proto::RequestHeader::default_instance());
+  kvheader_ = const_cast< ::cockroach::proto::KVRequestHeader*>(&::cockroach::proto::KVRequestHeader::default_instance());
 }
 
 InternalHeartbeatTxnRequest::InternalHeartbeatTxnRequest(const InternalHeartbeatTxnRequest& from)
@@ -2057,7 +2059,7 @@ InternalHeartbeatTxnRequest::InternalHeartbeatTxnRequest(const InternalHeartbeat
 
 void InternalHeartbeatTxnRequest::SharedCtor() {
   _cached_size_ = 0;
-  header_ = NULL;
+  kvheader_ = NULL;
   ::memset(_has_bits_, 0, sizeof(_has_bits_));
 }
 
@@ -2068,7 +2070,7 @@ InternalHeartbeatTxnRequest::~InternalHeartbeatTxnRequest() {
 
 void InternalHeartbeatTxnRequest::SharedDtor() {
   if (this != default_instance_) {
-    delete header_;
+    delete kvheader_;
   }
 }
 
@@ -2098,8 +2100,8 @@ InternalHeartbeatTxnRequest* InternalHeartbeatTxnRequest::New(::google::protobuf
 }
 
 void InternalHeartbeatTxnRequest::Clear() {
-  if (has_header()) {
-    if (header_ != NULL) header_->::cockroach::proto::RequestHeader::Clear();
+  if (has_kvheader()) {
+    if (kvheader_ != NULL) kvheader_->::cockroach::proto::KVRequestHeader::Clear();
   }
   ::memset(_has_bits_, 0, sizeof(_has_bits_));
   if (_internal_metadata_.have_unknown_fields()) {
@@ -2117,11 +2119,11 @@ bool InternalHeartbeatTxnRequest::MergePartialFromCodedStream(
     tag = p.first;
     if (!p.second) goto handle_unusual;
     switch (::google::protobuf::internal::WireFormatLite::GetTagFieldNumber(tag)) {
-      // optional .cockroach.proto.RequestHeader header = 1;
+      // optional .cockroach.proto.KVRequestHeader kvheader = 1;
       case 1: {
         if (tag == 10) {
           DO_(::google::protobuf::internal::WireFormatLite::ReadMessageNoVirtual(
-               input, mutable_header()));
+               input, mutable_kvheader()));
         } else {
           goto handle_unusual;
         }
@@ -2154,10 +2156,10 @@ failure:
 void InternalHeartbeatTxnRequest::SerializeWithCachedSizes(
     ::google::protobuf::io::CodedOutputStream* output) const {
   // @@protoc_insertion_point(serialize_start:cockroach.proto.InternalHeartbeatTxnRequest)
-  // optional .cockroach.proto.RequestHeader header = 1;
-  if (has_header()) {
+  // optional .cockroach.proto.KVRequestHeader kvheader = 1;
+  if (has_kvheader()) {
     ::google::protobuf::internal::WireFormatLite::WriteMessageMaybeToArray(
-      1, *this->header_, output);
+      1, *this->kvheader_, output);
   }
 
   if (_internal_metadata_.have_unknown_fields()) {
@@ -2170,11 +2172,11 @@ void InternalHeartbeatTxnRequest::SerializeWithCachedSizes(
 ::google::protobuf::uint8* InternalHeartbeatTxnRequest::SerializeWithCachedSizesToArray(
     ::google::protobuf::uint8* target) const {
   // @@protoc_insertion_point(serialize_to_array_start:cockroach.proto.InternalHeartbeatTxnRequest)
-  // optional .cockroach.proto.RequestHeader header = 1;
-  if (has_header()) {
+  // optional .cockroach.proto.KVRequestHeader kvheader = 1;
+  if (has_kvheader()) {
     target = ::google::protobuf::internal::WireFormatLite::
       WriteMessageNoVirtualToArray(
-        1, *this->header_, target);
+        1, *this->kvheader_, target);
   }
 
   if (_internal_metadata_.have_unknown_fields()) {
@@ -2188,11 +2190,11 @@ void InternalHeartbeatTxnRequest::SerializeWithCachedSizes(
 int InternalHeartbeatTxnRequest::ByteSize() const {
   int total_size = 0;
 
-  // optional .cockroach.proto.RequestHeader header = 1;
-  if (has_header()) {
+  // optional .cockroach.proto.KVRequestHeader kvheader = 1;
+  if (has_kvheader()) {
     total_size += 1 +
       ::google::protobuf::internal::WireFormatLite::MessageSizeNoVirtual(
-        *this->header_);
+        *this->kvheader_);
   }
 
   if (_internal_metadata_.have_unknown_fields()) {
@@ -2221,8 +2223,8 @@ void InternalHeartbeatTxnRequest::MergeFrom(const ::google::protobuf::Message& f
 void InternalHeartbeatTxnRequest::MergeFrom(const InternalHeartbeatTxnRequest& from) {
   if (GOOGLE_PREDICT_FALSE(&from == this)) MergeFromFail(__LINE__);
   if (from._has_bits_[0 / 32] & (0xffu << (0 % 32))) {
-    if (from.has_header()) {
-      mutable_header()->::cockroach::proto::RequestHeader::MergeFrom(from.header());
+    if (from.has_kvheader()) {
+      mutable_kvheader()->::cockroach::proto::KVRequestHeader::MergeFrom(from.kvheader());
     }
   }
   if (from._internal_metadata_.have_unknown_fields()) {
@@ -2252,7 +2254,7 @@ void InternalHeartbeatTxnRequest::Swap(InternalHeartbeatTxnRequest* other) {
   InternalSwap(other);
 }
 void InternalHeartbeatTxnRequest::InternalSwap(InternalHeartbeatTxnRequest* other) {
-  std::swap(header_, other->header_);
+  std::swap(kvheader_, other->kvheader_);
   std::swap(_has_bits_[0], other->_has_bits_[0]);
   _internal_metadata_.Swap(&other->_internal_metadata_);
   std::swap(_cached_size_, other->_cached_size_);
@@ -2269,47 +2271,47 @@ void InternalHeartbeatTxnRequest::InternalSwap(InternalHeartbeatTxnRequest* othe
 #if PROTOBUF_INLINE_NOT_IN_HEADERS
 // InternalHeartbeatTxnRequest
 
-// optional .cockroach.proto.RequestHeader header = 1;
-bool InternalHeartbeatTxnRequest::has_header() const {
+// optional .cockroach.proto.KVRequestHeader kvheader = 1;
+bool InternalHeartbeatTxnRequest::has_kvheader() const {
   return (_has_bits_[0] & 0x00000001u) != 0;
 }
-void InternalHeartbeatTxnRequest::set_has_header() {
+void InternalHeartbeatTxnRequest::set_has_kvheader() {
   _has_bits_[0] |= 0x00000001u;
 }
-void InternalHeartbeatTxnRequest::clear_has_header() {
+void InternalHeartbeatTxnRequest::clear_has_kvheader() {
   _has_bits_[0] &= ~0x00000001u;
 }
-void InternalHeartbeatTxnRequest::clear_header() {
-  if (header_ != NULL) header_->::cockroach::proto::RequestHeader::Clear();
-  clear_has_header();
+void InternalHeartbeatTxnRequest::clear_kvheader() {
+  if (kvheader_ != NULL) kvheader_->::cockroach::proto::KVRequestHeader::Clear();
+  clear_has_kvheader();
 }
- const ::cockroach::proto::RequestHeader& InternalHeartbeatTxnRequest::header() const {
-  // @@protoc_insertion_point(field_get:cockroach.proto.InternalHeartbeatTxnRequest.header)
-  return header_ != NULL ? *header_ : *default_instance_->header_;
+ const ::cockroach::proto::KVRequestHeader& InternalHeartbeatTxnRequest::kvheader() const {
+  // @@protoc_insertion_point(field_get:cockroach.proto.InternalHeartbeatTxnRequest.kvheader)
+  return kvheader_ != NULL ? *kvheader_ : *default_instance_->kvheader_;
 }
- ::cockroach::proto::RequestHeader* InternalHeartbeatTxnRequest::mutable_header() {
-  set_has_header();
-  if (header_ == NULL) {
-    header_ = new ::cockroach::proto::RequestHeader;
+ ::cockroach::proto::KVRequestHeader* InternalHeartbeatTxnRequest::mutable_kvheader() {
+  set_has_kvheader();
+  if (kvheader_ == NULL) {
+    kvheader_ = new ::cockroach::proto::KVRequestHeader;
   }
-  // @@protoc_insertion_point(field_mutable:cockroach.proto.InternalHeartbeatTxnRequest.header)
-  return header_;
+  // @@protoc_insertion_point(field_mutable:cockroach.proto.InternalHeartbeatTxnRequest.kvheader)
+  return kvheader_;
 }
- ::cockroach::proto::RequestHeader* InternalHeartbeatTxnRequest::release_header() {
-  clear_has_header();
-  ::cockroach::proto::RequestHeader* temp = header_;
-  header_ = NULL;
+ ::cockroach::proto::KVRequestHeader* InternalHeartbeatTxnRequest::release_kvheader() {
+  clear_has_kvheader();
+  ::cockroach::proto::KVRequestHeader* temp = kvheader_;
+  kvheader_ = NULL;
   return temp;
 }
- void InternalHeartbeatTxnRequest::set_allocated_header(::cockroach::proto::RequestHeader* header) {
-  delete header_;
-  header_ = header;
-  if (header) {
-    set_has_header();
+ void InternalHeartbeatTxnRequest::set_allocated_kvheader(::cockroach::proto::KVRequestHeader* kvheader) {
+  delete kvheader_;
+  kvheader_ = kvheader;
+  if (kvheader) {
+    set_has_kvheader();
   } else {
-    clear_has_header();
+    clear_has_kvheader();
   }
-  // @@protoc_insertion_point(field_set_allocated:cockroach.proto.InternalHeartbeatTxnRequest.header)
+  // @@protoc_insertion_point(field_set_allocated:cockroach.proto.InternalHeartbeatTxnRequest.kvheader)
 }
 
 #endif  // PROTOBUF_INLINE_NOT_IN_HEADERS
@@ -2317,7 +2319,7 @@ void InternalHeartbeatTxnRequest::clear_header() {
 // ===================================================================
 
 #ifndef _MSC_VER
-const int InternalHeartbeatTxnResponse::kHeaderFieldNumber;
+const int InternalHeartbeatTxnResponse::kKvheaderFieldNumber;
 #endif  // !_MSC_VER
 
 InternalHeartbeatTxnResponse::InternalHeartbeatTxnResponse()
@@ -2327,7 +2329,7 @@ InternalHeartbeatTxnResponse::InternalHeartbeatTxnResponse()
 }
 
 void InternalHeartbeatTxnResponse::InitAsDefaultInstance() {
-  header_ = const_cast< ::cockroach::proto::ResponseHeader*>(&::cockroach::proto::ResponseHeader::default_instance());
+  kvheader_ = const_cast< ::cockroach::proto::KVResponseHeader*>(&::cockroach::proto::KVResponseHeader::default_instance());
 }
 
 InternalHeartbeatTxnResponse::InternalHeartbeatTxnResponse(const InternalHeartbeatTxnResponse& from)
@@ -2340,7 +2342,7 @@ InternalHeartbeatTxnResponse::InternalHeartbeatTxnResponse(const InternalHeartbe
 
 void InternalHeartbeatTxnResponse::SharedCtor() {
   _cached_size_ = 0;
-  header_ = NULL;
+  kvheader_ = NULL;
   ::memset(_has_bits_, 0, sizeof(_has_bits_));
 }
 
@@ -2351,7 +2353,7 @@ InternalHeartbeatTxnResponse::~InternalHeartbeatTxnResponse() {
 
 void InternalHeartbeatTxnResponse::SharedDtor() {
   if (this != default_instance_) {
-    delete header_;
+    delete kvheader_;
   }
 }
 
@@ -2381,8 +2383,8 @@ InternalHeartbeatTxnResponse* InternalHeartbeatTxnResponse::New(::google::protob
 }
 
 void InternalHeartbeatTxnResponse::Clear() {
-  if (has_header()) {
-    if (header_ != NULL) header_->::cockroach::proto::ResponseHeader::Clear();
+  if (has_kvheader()) {
+    if (kvheader_ != NULL) kvheader_->::cockroach::proto::KVResponseHeader::Clear();
   }
   ::memset(_has_bits_, 0, sizeof(_has_bits_));
   if (_internal_metadata_.have_unknown_fields()) {
@@ -2400,11 +2402,11 @@ bool InternalHeartbeatTxnResponse::MergePartialFromCodedStream(
     tag = p.first;
     if (!p.second) goto handle_unusual;
     switch (::google::protobuf::internal::WireFormatLite::GetTagFieldNumber(tag)) {
-      // optional .cockroach.proto.ResponseHeader header = 1;
+      // optional .cockroach.proto.KVResponseHeader kvheader = 1;
       case 1: {
         if (tag == 10) {
           DO_(::google::protobuf::internal::WireFormatLite::ReadMessageNoVirtual(
-               input, mutable_header()));
+               input, mutable_kvheader()));
         } else {
           goto handle_unusual;
         }
@@ -2437,10 +2439,10 @@ failure:
 void InternalHeartbeatTxnResponse::SerializeWithCachedSizes(
     ::google::protobuf::io::CodedOutputStream* output) const {
   // @@protoc_insertion_point(serialize_start:cockroach.proto.InternalHeartbeatTxnResponse)
-  // optional .cockroach.proto.ResponseHeader header = 1;
-  if (has_header()) {
+  // optional .cockroach.proto.KVResponseHeader kvheader = 1;
+  if (has_kvheader()) {
     ::google::protobuf::internal::WireFormatLite::WriteMessageMaybeToArray(
-      1, *this->header_, output);
+      1, *this->kvheader_, output);
   }
 
   if (_internal_metadata_.have_unknown_fields()) {
@@ -2453,11 +2455,11 @@ void InternalHeartbeatTxnResponse::SerializeWithCachedSizes(
 ::google::protobuf::uint8* InternalHeartbeatTxnResponse::SerializeWithCachedSizesToArray(
     ::google::protobuf::uint8* target) const {
   // @@protoc_insertion_point(serialize_to_array_start:cockroach.proto.InternalHeartbeatTxnResponse)
-  // optional .cockroach.proto.ResponseHeader header = 1;
-  if (has_header()) {
+  // optional .cockroach.proto.KVResponseHeader kvheader = 1;
+  if (has_kvheader()) {
     target = ::google::protobuf::internal::WireFormatLite::
       WriteMessageNoVirtualToArray(
-        1, *this->header_, target);
+        1, *this->kvheader_, target);
   }
 
   if (_internal_metadata_.have_unknown_fields()) {
@@ -2471,11 +2473,11 @@ void InternalHeartbeatTxnResponse::SerializeWithCachedSizes(
 int InternalHeartbeatTxnResponse::ByteSize() const {
   int total_size = 0;
 
-  // optional .cockroach.proto.ResponseHeader header = 1;
-  if (has_header()) {
+  // optional .cockroach.proto.KVResponseHeader kvheader = 1;
+  if (has_kvheader()) {
     total_size += 1 +
       ::google::protobuf::internal::WireFormatLite::MessageSizeNoVirtual(
-        *this->header_);
+        *this->kvheader_);
   }
 
   if (_internal_metadata_.have_unknown_fields()) {
@@ -2504,8 +2506,8 @@ void InternalHeartbeatTxnResponse::MergeFrom(const ::google::protobuf::Message& 
 void InternalHeartbeatTxnResponse::MergeFrom(const InternalHeartbeatTxnResponse& from) {
   if (GOOGLE_PREDICT_FALSE(&from == this)) MergeFromFail(__LINE__);
   if (from._has_bits_[0 / 32] & (0xffu << (0 % 32))) {
-    if (from.has_header()) {
-      mutable_header()->::cockroach::proto::ResponseHeader::MergeFrom(from.header());
+    if (from.has_kvheader()) {
+      mutable_kvheader()->::cockroach::proto::KVResponseHeader::MergeFrom(from.kvheader());
     }
   }
   if (from._internal_metadata_.have_unknown_fields()) {
@@ -2535,7 +2537,7 @@ void InternalHeartbeatTxnResponse::Swap(InternalHeartbeatTxnResponse* other) {
   InternalSwap(other);
 }
 void InternalHeartbeatTxnResponse::InternalSwap(InternalHeartbeatTxnResponse* other) {
-  std::swap(header_, other->header_);
+  std::swap(kvheader_, other->kvheader_);
   std::swap(_has_bits_[0], other->_has_bits_[0]);
   _internal_metadata_.Swap(&other->_internal_metadata_);
   std::swap(_cached_size_, other->_cached_size_);
@@ -2552,47 +2554,47 @@ void InternalHeartbeatTxnResponse::InternalSwap(InternalHeartbeatTxnResponse* ot
 #if PROTOBUF_INLINE_NOT_IN_HEADERS
 // InternalHeartbeatTxnResponse
 
-// optional .cockroach.proto.ResponseHeader header = 1;
-bool InternalHeartbeatTxnResponse::has_header() const {
+// optional .cockroach.proto.KVResponseHeader kvheader = 1;
+bool InternalHeartbeatTxnResponse::has_kvheader() const {
   return (_has_bits_[0] & 0x00000001u) != 0;
 }
-void InternalHeartbeatTxnResponse::set_has_header() {
+void InternalHeartbeatTxnResponse::set_has_kvheader() {
   _has_bits_[0] |= 0x00000001u;
 }
-void InternalHeartbeatTxnResponse::clear_has_header() {
+void InternalHeartbeatTxnResponse::clear_has_kvheader() {
   _has_bits_[0] &= ~0x00000001u;
 }
-void InternalHeartbeatTxnResponse::clear_header() {
-  if (header_ != NULL) header_->::cockroach::proto::ResponseHeader::Clear();
-  clear_has_header();
+void InternalHeartbeatTxnResponse::clear_kvheader() {
+  if (kvheader_ != NULL) kvheader_->::cockroach::proto::KVResponseHeader::Clear();
+  clear_has_kvheader();
 }
- const ::cockroach::proto::ResponseHeader& InternalHeartbeatTxnResponse::header() const {
-  // @@protoc_insertion_point(field_get:cockroach.proto.InternalHeartbeatTxnResponse.header)
-  return header_ != NULL ? *header_ : *default_instance_->header_;
+ const ::cockroach::proto::KVResponseHeader& InternalHeartbeatTxnResponse::kvheader() const {
+  // @@protoc_insertion_point(field_get:cockroach.proto.InternalHeartbeatTxnResponse.kvheader)
+  return kvheader_ != NULL ? *kvheader_ : *default_instance_->kvheader_;
 }
- ::cockroach::proto::ResponseHeader* InternalHeartbeatTxnResponse::mutable_header() {
-  set_has_header();
-  if (header_ == NULL) {
-    header_ = new ::cockroach::proto::ResponseHeader;
+ ::cockroach::proto::KVResponseHeader* InternalHeartbeatTxnResponse::mutable_kvheader() {
+  set_has_kvheader();
+  if (kvheader_ == NULL) {
+    kvheader_ = new ::cockroach::proto::KVResponseHeader;
   }
-  // @@protoc_insertion_point(field_mutable:cockroach.proto.InternalHeartbeatTxnResponse.header)
-  return header_;
+  // @@protoc_insertion_point(field_mutable:cockroach.proto.InternalHeartbeatTxnResponse.kvheader)
+  return kvheader_;
 }
- ::cockroach::proto::ResponseHeader* InternalHeartbeatTxnResponse::release_header() {
-  clear_has_header();
-  ::cockroach::proto::ResponseHeader* temp = header_;
-  header_ = NULL;
+ ::cockroach::proto::KVResponseHeader* InternalHeartbeatTxnResponse::release_kvheader() {
+  clear_has_kvheader();
+  ::cockroach::proto::KVResponseHeader* temp = kvheader_;
+  kvheader_ = NULL;
   return temp;
 }
- void InternalHeartbeatTxnResponse::set_allocated_header(::cockroach::proto::ResponseHeader* header) {
-  delete header_;
-  header_ = header;
-  if (header) {
-    set_has_header();
+ void InternalHeartbeatTxnResponse::set_allocated_kvheader(::cockroach::proto::KVResponseHeader* kvheader) {
+  delete kvheader_;
+  kvheader_ = kvheader;
+  if (kvheader) {
+    set_has_kvheader();
   } else {
-    clear_has_header();
+    clear_has_kvheader();
   }
-  // @@protoc_insertion_point(field_set_allocated:cockroach.proto.InternalHeartbeatTxnResponse.header)
+  // @@protoc_insertion_point(field_set_allocated:cockroach.proto.InternalHeartbeatTxnResponse.kvheader)
 }
 
 #endif  // PROTOBUF_INLINE_NOT_IN_HEADERS
@@ -2885,7 +2887,7 @@ void InternalGCRequest_GCKey::InternalSwap(InternalGCRequest_GCKey* other) {
 // -------------------------------------------------------------------
 
 #ifndef _MSC_VER
-const int InternalGCRequest::kHeaderFieldNumber;
+const int InternalGCRequest::kKvheaderFieldNumber;
 const int InternalGCRequest::kGcMetaFieldNumber;
 const int InternalGCRequest::kKeysFieldNumber;
 #endif  // !_MSC_VER
@@ -2897,7 +2899,7 @@ InternalGCRequest::InternalGCRequest()
 }
 
 void InternalGCRequest::InitAsDefaultInstance() {
-  header_ = const_cast< ::cockroach::proto::RequestHeader*>(&::cockroach::proto::RequestHeader::default_instance());
+  kvheader_ = const_cast< ::cockroach::proto::KVRequestHeader*>(&::cockroach::proto::KVRequestHeader::default_instance());
   gc_meta_ = const_cast< ::cockroach::proto::GCMetadata*>(&::cockroach::proto::GCMetadata::default_instance());
 }
 
@@ -2911,7 +2913,7 @@ InternalGCRequest::InternalGCRequest(const InternalGCRequest& from)
 
 void InternalGCRequest::SharedCtor() {
   _cached_size_ = 0;
-  header_ = NULL;
+  kvheader_ = NULL;
   gc_meta_ = NULL;
   ::memset(_has_bits_, 0, sizeof(_has_bits_));
 }
@@ -2923,7 +2925,7 @@ InternalGCRequest::~InternalGCRequest() {
 
 void InternalGCRequest::SharedDtor() {
   if (this != default_instance_) {
-    delete header_;
+    delete kvheader_;
     delete gc_meta_;
   }
 }
@@ -2955,8 +2957,8 @@ InternalGCRequest* InternalGCRequest::New(::google::protobuf::Arena* arena) cons
 
 void InternalGCRequest::Clear() {
   if (_has_bits_[0 / 32] & 3u) {
-    if (has_header()) {
-      if (header_ != NULL) header_->::cockroach::proto::RequestHeader::Clear();
+    if (has_kvheader()) {
+      if (kvheader_ != NULL) kvheader_->::cockroach::proto::KVRequestHeader::Clear();
     }
     if (has_gc_meta()) {
       if (gc_meta_ != NULL) gc_meta_->::cockroach::proto::GCMetadata::Clear();
@@ -2979,11 +2981,11 @@ bool InternalGCRequest::MergePartialFromCodedStream(
     tag = p.first;
     if (!p.second) goto handle_unusual;
     switch (::google::protobuf::internal::WireFormatLite::GetTagFieldNumber(tag)) {
-      // optional .cockroach.proto.RequestHeader header = 1;
+      // optional .cockroach.proto.KVRequestHeader kvheader = 1;
       case 1: {
         if (tag == 10) {
           DO_(::google::protobuf::internal::WireFormatLite::ReadMessageNoVirtual(
-               input, mutable_header()));
+               input, mutable_kvheader()));
         } else {
           goto handle_unusual;
         }
@@ -3046,10 +3048,10 @@ failure:
 void InternalGCRequest::SerializeWithCachedSizes(
     ::google::protobuf::io::CodedOutputStream* output) const {
   // @@protoc_insertion_point(serialize_start:cockroach.proto.InternalGCRequest)
-  // optional .cockroach.proto.RequestHeader header = 1;
-  if (has_header()) {
+  // optional .cockroach.proto.KVRequestHeader kvheader = 1;
+  if (has_kvheader()) {
     ::google::protobuf::internal::WireFormatLite::WriteMessageMaybeToArray(
-      1, *this->header_, output);
+      1, *this->kvheader_, output);
   }
 
   // optional .cockroach.proto.GCMetadata gc_meta = 2;
@@ -3074,11 +3076,11 @@ void InternalGCRequest::SerializeWithCachedSizes(
 ::google::protobuf::uint8* InternalGCRequest::SerializeWithCachedSizesToArray(
     ::google::protobuf::uint8* target) const {
   // @@protoc_insertion_point(serialize_to_array_start:cockroach.proto.InternalGCRequest)
-  // optional .cockroach.proto.RequestHeader header = 1;
-  if (has_header()) {
+  // optional .cockroach.proto.KVRequestHeader kvheader = 1;
+  if (has_kvheader()) {
     target = ::google::protobuf::internal::WireFormatLite::
       WriteMessageNoVirtualToArray(
-        1, *this->header_, target);
+        1, *this->kvheader_, target);
   }
 
   // optional .cockroach.proto.GCMetadata gc_meta = 2;
@@ -3107,11 +3109,11 @@ int InternalGCRequest::ByteSize() const {
   int total_size = 0;
 
   if (_has_bits_[0 / 32] & 3) {
-    // optional .cockroach.proto.RequestHeader header = 1;
-    if (has_header()) {
+    // optional .cockroach.proto.KVRequestHeader kvheader = 1;
+    if (has_kvheader()) {
       total_size += 1 +
         ::google::protobuf::internal::WireFormatLite::MessageSizeNoVirtual(
-          *this->header_);
+          *this->kvheader_);
     }
 
     // optional .cockroach.proto.GCMetadata gc_meta = 2;
@@ -3157,8 +3159,8 @@ void InternalGCRequest::MergeFrom(const InternalGCRequest& from) {
   if (GOOGLE_PREDICT_FALSE(&from == this)) MergeFromFail(__LINE__);
   keys_.MergeFrom(from.keys_);
   if (from._has_bits_[0 / 32] & (0xffu << (0 % 32))) {
-    if (from.has_header()) {
-      mutable_header()->::cockroach::proto::RequestHeader::MergeFrom(from.header());
+    if (from.has_kvheader()) {
+      mutable_kvheader()->::cockroach::proto::KVRequestHeader::MergeFrom(from.kvheader());
     }
     if (from.has_gc_meta()) {
       mutable_gc_meta()->::cockroach::proto::GCMetadata::MergeFrom(from.gc_meta());
@@ -3191,7 +3193,7 @@ void InternalGCRequest::Swap(InternalGCRequest* other) {
   InternalSwap(other);
 }
 void InternalGCRequest::InternalSwap(InternalGCRequest* other) {
-  std::swap(header_, other->header_);
+  std::swap(kvheader_, other->kvheader_);
   std::swap(gc_meta_, other->gc_meta_);
   keys_.UnsafeArenaSwap(&other->keys_);
   std::swap(_has_bits_[0], other->_has_bits_[0]);
@@ -3310,47 +3312,47 @@ void InternalGCRequest_GCKey::clear_timestamp() {
 
 // InternalGCRequest
 
-// optional .cockroach.proto.RequestHeader header = 1;
-bool InternalGCRequest::has_header() const {
+// optional .cockroach.proto.KVRequestHeader kvheader = 1;
+bool InternalGCRequest::has_kvheader() const {
   return (_has_bits_[0] & 0x00000001u) != 0;
 }
-void InternalGCRequest::set_has_header() {
+void InternalGCRequest::set_has_kvheader() {
   _has_bits_[0] |= 0x00000001u;
 }
-void InternalGCRequest::clear_has_header() {
+void InternalGCRequest::clear_has_kvheader() {
   _has_bits_[0] &= ~0x00000001u;
 }
-void InternalGCRequest::clear_header() {
-  if (header_ != NULL) header_->::cockroach::proto::RequestHeader::Clear();
-  clear_has_header();
+void InternalGCRequest::clear_kvheader() {
+  if (kvheader_ != NULL) kvheader_->::cockroach::proto::KVRequestHeader::Clear();
+  clear_has_kvheader();
 }
- const ::cockroach::proto::RequestHeader& InternalGCRequest::header() const {
-  // @@protoc_insertion_point(field_get:cockroach.proto.InternalGCRequest.header)
-  return header_ != NULL ? *header_ : *default_instance_->header_;
+ const ::cockroach::proto::KVRequestHeader& InternalGCRequest::kvheader() const {
+  // @@protoc_insertion_point(field_get:cockroach.proto.InternalGCRequest.kvheader)
+  return kvheader_ != NULL ? *kvheader_ : *default_instance_->kvheader_;
 }
- ::cockroach::proto::RequestHeader* InternalGCRequest::mutable_header() {
-  set_has_header();
-  if (header_ == NULL) {
-    header_ = new ::cockroach::proto::RequestHeader;
+ ::cockroach::proto::KVRequestHeader* InternalGCRequest::mutable_kvheader() {
+  set_has_kvheader();
+  if (kvheader_ == NULL) {
+    kvheader_ = new ::cockroach::proto::KVRequestHeader;
   }
-  // @@protoc_insertion_point(field_mutable:cockroach.proto.InternalGCRequest.header)
-  return header_;
+  // @@protoc_insertion_point(field_mutable:cockroach.proto.InternalGCRequest.kvheader)
+  return kvheader_;
 }
- ::cockroach::proto::RequestHeader* InternalGCRequest::release_header() {
-  clear_has_header();
-  ::cockroach::proto::RequestHeader* temp = header_;
-  header_ = NULL;
+ ::cockroach::proto::KVRequestHeader* InternalGCRequest::release_kvheader() {
+  clear_has_kvheader();
+  ::cockroach::proto::KVRequestHeader* temp = kvheader_;
+  kvheader_ = NULL;
   return temp;
 }
- void InternalGCRequest::set_allocated_header(::cockroach::proto::RequestHeader* header) {
-  delete header_;
-  header_ = header;
-  if (header) {
-    set_has_header();
+ void InternalGCRequest::set_allocated_kvheader(::cockroach::proto::KVRequestHeader* kvheader) {
+  delete kvheader_;
+  kvheader_ = kvheader;
+  if (kvheader) {
+    set_has_kvheader();
   } else {
-    clear_has_header();
+    clear_has_kvheader();
   }
-  // @@protoc_insertion_point(field_set_allocated:cockroach.proto.InternalGCRequest.header)
+  // @@protoc_insertion_point(field_set_allocated:cockroach.proto.InternalGCRequest.kvheader)
 }
 
 // optional .cockroach.proto.GCMetadata gc_meta = 2;
@@ -3431,7 +3433,7 @@ InternalGCRequest::mutable_keys() {
 // ===================================================================
 
 #ifndef _MSC_VER
-const int InternalGCResponse::kHeaderFieldNumber;
+const int InternalGCResponse::kKvheaderFieldNumber;
 #endif  // !_MSC_VER
 
 InternalGCResponse::InternalGCResponse()
@@ -3441,7 +3443,7 @@ InternalGCResponse::InternalGCResponse()
 }
 
 void InternalGCResponse::InitAsDefaultInstance() {
-  header_ = const_cast< ::cockroach::proto::ResponseHeader*>(&::cockroach::proto::ResponseHeader::default_instance());
+  kvheader_ = const_cast< ::cockroach::proto::KVResponseHeader*>(&::cockroach::proto::KVResponseHeader::default_instance());
 }
 
 InternalGCResponse::InternalGCResponse(const InternalGCResponse& from)
@@ -3454,7 +3456,7 @@ InternalGCResponse::InternalGCResponse(const InternalGCResponse& from)
 
 void InternalGCResponse::SharedCtor() {
   _cached_size_ = 0;
-  header_ = NULL;
+  kvheader_ = NULL;
   ::memset(_has_bits_, 0, sizeof(_has_bits_));
 }
 
@@ -3465,7 +3467,7 @@ InternalGCResponse::~InternalGCResponse() {
 
 void InternalGCResponse::SharedDtor() {
   if (this != default_instance_) {
-    delete header_;
+    delete kvheader_;
   }
 }
 
@@ -3495,8 +3497,8 @@ InternalGCResponse* InternalGCResponse::New(::google::protobuf::Arena* arena) co
 }
 
 void InternalGCResponse::Clear() {
-  if (has_header()) {
-    if (header_ != NULL) header_->::cockroach::proto::ResponseHeader::Clear();
+  if (has_kvheader()) {
+    if (kvheader_ != NULL) kvheader_->::cockroach::proto::KVResponseHeader::Clear();
   }
   ::memset(_has_bits_, 0, sizeof(_has_bits_));
   if (_internal_metadata_.have_unknown_fields()) {
@@ -3514,11 +3516,11 @@ bool InternalGCResponse::MergePartialFromCodedStream(
     tag = p.first;
     if (!p.second) goto handle_unusual;
     switch (::google::protobuf::internal::WireFormatLite::GetTagFieldNumber(tag)) {
-      // optional .cockroach.proto.ResponseHeader header = 1;
+      // optional .cockroach.proto.KVResponseHeader kvheader = 1;
       case 1: {
         if (tag == 10) {
           DO_(::google::protobuf::internal::WireFormatLite::ReadMessageNoVirtual(
-               input, mutable_header()));
+               input, mutable_kvheader()));
         } else {
           goto handle_unusual;
         }
@@ -3551,10 +3553,10 @@ failure:
 void InternalGCResponse::SerializeWithCachedSizes(
     ::google::protobuf::io::CodedOutputStream* output) const {
   // @@protoc_insertion_point(serialize_start:cockroach.proto.InternalGCResponse)
-  // optional .cockroach.proto.ResponseHeader header = 1;
-  if (has_header()) {
+  // optional .cockroach.proto.KVResponseHeader kvheader = 1;
+  if (has_kvheader()) {
     ::google::protobuf::internal::WireFormatLite::WriteMessageMaybeToArray(
-      1, *this->header_, output);
+      1, *this->kvheader_, output);
   }
 
   if (_internal_metadata_.have_unknown_fields()) {
@@ -3567,11 +3569,11 @@ void InternalGCResponse::SerializeWithCachedSizes(
 ::google::protobuf::uint8* InternalGCResponse::SerializeWithCachedSizesToArray(
     ::google::protobuf::uint8* target) const {
   // @@protoc_insertion_point(serialize_to_array_start:cockroach.proto.InternalGCResponse)
-  // optional .cockroach.proto.ResponseHeader header = 1;
-  if (has_header()) {
+  // optional .cockroach.proto.KVResponseHeader kvheader = 1;
+  if (has_kvheader()) {
     target = ::google::protobuf::internal::WireFormatLite::
       WriteMessageNoVirtualToArray(
-        1, *this->header_, target);
+        1, *this->kvheader_, target);
   }
 
   if (_internal_metadata_.have_unknown_fields()) {
@@ -3585,11 +3587,11 @@ void InternalGCResponse::SerializeWithCachedSizes(
 int InternalGCResponse::ByteSize() const {
   int total_size = 0;
 
-  // optional .cockroach.proto.ResponseHeader header = 1;
-  if (has_header()) {
+  // optional .cockroach.proto.KVResponseHeader kvheader = 1;
+  if (has_kvheader()) {
     total_size += 1 +
       ::google::protobuf::internal::WireFormatLite::MessageSizeNoVirtual(
-        *this->header_);
+        *this->kvheader_);
   }
 
   if (_internal_metadata_.have_unknown_fields()) {
@@ -3618,8 +3620,8 @@ void InternalGCResponse::MergeFrom(const ::google::protobuf::Message& from) {
 void InternalGCResponse::MergeFrom(const InternalGCResponse& from) {
   if (GOOGLE_PREDICT_FALSE(&from == this)) MergeFromFail(__LINE__);
   if (from._has_bits_[0 / 32] & (0xffu << (0 % 32))) {
-    if (from.has_header()) {
-      mutable_header()->::cockroach::proto::ResponseHeader::MergeFrom(from.header());
+    if (from.has_kvheader()) {
+      mutable_kvheader()->::cockroach::proto::KVResponseHeader::MergeFrom(from.kvheader());
     }
   }
   if (from._internal_metadata_.have_unknown_fields()) {
@@ -3649,7 +3651,7 @@ void InternalGCResponse::Swap(InternalGCResponse* other) {
   InternalSwap(other);
 }
 void InternalGCResponse::InternalSwap(InternalGCResponse* other) {
-  std::swap(header_, other->header_);
+  std::swap(kvheader_, other->kvheader_);
   std::swap(_has_bits_[0], other->_has_bits_[0]);
   _internal_metadata_.Swap(&other->_internal_metadata_);
   std::swap(_cached_size_, other->_cached_size_);
@@ -3666,47 +3668,47 @@ void InternalGCResponse::InternalSwap(InternalGCResponse* other) {
 #if PROTOBUF_INLINE_NOT_IN_HEADERS
 // InternalGCResponse
 
-// optional .cockroach.proto.ResponseHeader header = 1;
-bool InternalGCResponse::has_header() const {
+// optional .cockroach.proto.KVResponseHeader kvheader = 1;
+bool InternalGCResponse::has_kvheader() const {
   return (_has_bits_[0] & 0x00000001u) != 0;
 }
-void InternalGCResponse::set_has_header() {
+void InternalGCResponse::set_has_kvheader() {
   _has_bits_[0] |= 0x00000001u;
 }
-void InternalGCResponse::clear_has_header() {
+void InternalGCResponse::clear_has_kvheader() {
   _has_bits_[0] &= ~0x00000001u;
 }
-void InternalGCResponse::clear_header() {
-  if (header_ != NULL) header_->::cockroach::proto::ResponseHeader::Clear();
-  clear_has_header();
+void InternalGCResponse::clear_kvheader() {
+  if (kvheader_ != NULL) kvheader_->::cockroach::proto::KVResponseHeader::Clear();
+  clear_has_kvheader();
 }
- const ::cockroach::proto::ResponseHeader& InternalGCResponse::header() const {
-  // @@protoc_insertion_point(field_get:cockroach.proto.InternalGCResponse.header)
-  return header_ != NULL ? *header_ : *default_instance_->header_;
+ const ::cockroach::proto::KVResponseHeader& InternalGCResponse::kvheader() const {
+  // @@protoc_insertion_point(field_get:cockroach.proto.InternalGCResponse.kvheader)
+  return kvheader_ != NULL ? *kvheader_ : *default_instance_->kvheader_;
 }
- ::cockroach::proto::ResponseHeader* InternalGCResponse::mutable_header() {
-  set_has_header();
-  if (header_ == NULL) {
-    header_ = new ::cockroach::proto::ResponseHeader;
+ ::cockroach::proto::KVResponseHeader* InternalGCResponse::mutable_kvheader() {
+  set_has_kvheader();
+  if (kvheader_ == NULL) {
+    kvheader_ = new ::cockroach::proto::KVResponseHeader;
   }
-  // @@protoc_insertion_point(field_mutable:cockroach.proto.InternalGCResponse.header)
-  return header_;
+  // @@protoc_insertion_point(field_mutable:cockroach.proto.InternalGCResponse.kvheader)
+  return kvheader_;
 }
- ::cockroach::proto::ResponseHeader* InternalGCResponse::release_header() {
-  clear_has_header();
-  ::cockroach::proto::ResponseHeader* temp = header_;
-  header_ = NULL;
+ ::cockroach::proto::KVResponseHeader* InternalGCResponse::release_kvheader() {
+  clear_has_kvheader();
+  ::cockroach::proto::KVResponseHeader* temp = kvheader_;
+  kvheader_ = NULL;
   return temp;
 }
- void InternalGCResponse::set_allocated_header(::cockroach::proto::ResponseHeader* header) {
-  delete header_;
-  header_ = header;
-  if (header) {
-    set_has_header();
+ void InternalGCResponse::set_allocated_kvheader(::cockroach::proto::KVResponseHeader* kvheader) {
+  delete kvheader_;
+  kvheader_ = kvheader;
+  if (kvheader) {
+    set_has_kvheader();
   } else {
-    clear_has_header();
+    clear_has_kvheader();
   }
-  // @@protoc_insertion_point(field_set_allocated:cockroach.proto.InternalGCResponse.header)
+  // @@protoc_insertion_point(field_set_allocated:cockroach.proto.InternalGCResponse.kvheader)
 }
 
 #endif  // PROTOBUF_INLINE_NOT_IN_HEADERS
@@ -3714,7 +3716,7 @@ void InternalGCResponse::clear_header() {
 // ===================================================================
 
 #ifndef _MSC_VER
-const int InternalPushTxnRequest::kHeaderFieldNumber;
+const int InternalPushTxnRequest::kKvheaderFieldNumber;
 const int InternalPushTxnRequest::kPusheeTxnFieldNumber;
 const int InternalPushTxnRequest::kNowFieldNumber;
 const int InternalPushTxnRequest::kPushTypeFieldNumber;
@@ -3728,7 +3730,7 @@ InternalPushTxnRequest::InternalPushTxnRequest()
 }
 
 void InternalPushTxnRequest::InitAsDefaultInstance() {
-  header_ = const_cast< ::cockroach::proto::RequestHeader*>(&::cockroach::proto::RequestHeader::default_instance());
+  kvheader_ = const_cast< ::cockroach::proto::KVRequestHeader*>(&::cockroach::proto::KVRequestHeader::default_instance());
   pushee_txn_ = const_cast< ::cockroach::proto::Transaction*>(&::cockroach::proto::Transaction::default_instance());
   now_ = const_cast< ::cockroach::proto::Timestamp*>(&::cockroach::proto::Timestamp::default_instance());
 }
@@ -3743,7 +3745,7 @@ InternalPushTxnRequest::InternalPushTxnRequest(const InternalPushTxnRequest& fro
 
 void InternalPushTxnRequest::SharedCtor() {
   _cached_size_ = 0;
-  header_ = NULL;
+  kvheader_ = NULL;
   pushee_txn_ = NULL;
   now_ = NULL;
   push_type_ = 0;
@@ -3758,7 +3760,7 @@ InternalPushTxnRequest::~InternalPushTxnRequest() {
 
 void InternalPushTxnRequest::SharedDtor() {
   if (this != default_instance_) {
-    delete header_;
+    delete kvheader_;
     delete pushee_txn_;
     delete now_;
   }
@@ -3800,8 +3802,8 @@ void InternalPushTxnRequest::Clear() {
 
   if (_has_bits_[0 / 32] & 31u) {
     ZR_(push_type_, range_lookup_);
-    if (has_header()) {
-      if (header_ != NULL) header_->::cockroach::proto::RequestHeader::Clear();
+    if (has_kvheader()) {
+      if (kvheader_ != NULL) kvheader_->::cockroach::proto::KVRequestHeader::Clear();
     }
     if (has_pushee_txn()) {
       if (pushee_txn_ != NULL) pushee_txn_->::cockroach::proto::Transaction::Clear();
@@ -3830,11 +3832,11 @@ bool InternalPushTxnRequest::MergePartialFromCodedStream(
     tag = p.first;
     if (!p.second) goto handle_unusual;
     switch (::google::protobuf::internal::WireFormatLite::GetTagFieldNumber(tag)) {
-      // optional .cockroach.proto.RequestHeader header = 1;
+      // optional .cockroach.proto.KVRequestHeader kvheader = 1;
       case 1: {
         if (tag == 10) {
           DO_(::google::protobuf::internal::WireFormatLite::ReadMessageNoVirtual(
-               input, mutable_header()));
+               input, mutable_kvheader()));
         } else {
           goto handle_unusual;
         }
@@ -3928,10 +3930,10 @@ failure:
 void InternalPushTxnRequest::SerializeWithCachedSizes(
     ::google::protobuf::io::CodedOutputStream* output) const {
   // @@protoc_insertion_point(serialize_start:cockroach.proto.InternalPushTxnRequest)
-  // optional .cockroach.proto.RequestHeader header = 1;
-  if (has_header()) {
+  // optional .cockroach.proto.KVRequestHeader kvheader = 1;
+  if (has_kvheader()) {
     ::google::protobuf::internal::WireFormatLite::WriteMessageMaybeToArray(
-      1, *this->header_, output);
+      1, *this->kvheader_, output);
   }
 
   // optional .cockroach.proto.Transaction pushee_txn = 2;
@@ -3967,11 +3969,11 @@ void InternalPushTxnRequest::SerializeWithCachedSizes(
 ::google::protobuf::uint8* InternalPushTxnRequest::SerializeWithCachedSizesToArray(
     ::google::protobuf::uint8* target) const {
   // @@protoc_insertion_point(serialize_to_array_start:cockroach.proto.InternalPushTxnRequest)
-  // optional .cockroach.proto.RequestHeader header = 1;
-  if (has_header()) {
+  // optional .cockroach.proto.KVRequestHeader kvheader = 1;
+  if (has_kvheader()) {
     target = ::google::protobuf::internal::WireFormatLite::
       WriteMessageNoVirtualToArray(
-        1, *this->header_, target);
+        1, *this->kvheader_, target);
   }
 
   // optional .cockroach.proto.Transaction pushee_txn = 2;
@@ -4011,11 +4013,11 @@ int InternalPushTxnRequest::ByteSize() const {
   int total_size = 0;
 
   if (_has_bits_[0 / 32] & 31) {
-    // optional .cockroach.proto.RequestHeader header = 1;
-    if (has_header()) {
+    // optional .cockroach.proto.KVRequestHeader kvheader = 1;
+    if (has_kvheader()) {
       total_size += 1 +
         ::google::protobuf::internal::WireFormatLite::MessageSizeNoVirtual(
-          *this->header_);
+          *this->kvheader_);
     }
 
     // optional .cockroach.proto.Transaction pushee_txn = 2;
@@ -4070,8 +4072,8 @@ void InternalPushTxnRequest::MergeFrom(const ::google::protobuf::Message& from) 
 void InternalPushTxnRequest::MergeFrom(const InternalPushTxnRequest& from) {
   if (GOOGLE_PREDICT_FALSE(&from == this)) MergeFromFail(__LINE__);
   if (from._has_bits_[0 / 32] & (0xffu << (0 % 32))) {
-    if (from.has_header()) {
-      mutable_header()->::cockroach::proto::RequestHeader::MergeFrom(from.header());
+    if (from.has_kvheader()) {
+      mutable_kvheader()->::cockroach::proto::KVRequestHeader::MergeFrom(from.kvheader());
     }
     if (from.has_pushee_txn()) {
       mutable_pushee_txn()->::cockroach::proto::Transaction::MergeFrom(from.pushee_txn());
@@ -4113,7 +4115,7 @@ void InternalPushTxnRequest::Swap(InternalPushTxnRequest* other) {
   InternalSwap(other);
 }
 void InternalPushTxnRequest::InternalSwap(InternalPushTxnRequest* other) {
-  std::swap(header_, other->header_);
+  std::swap(kvheader_, other->kvheader_);
   std::swap(pushee_txn_, other->pushee_txn_);
   std::swap(now_, other->now_);
   std::swap(push_type_, other->push_type_);
@@ -4134,47 +4136,47 @@ void InternalPushTxnRequest::InternalSwap(InternalPushTxnRequest* other) {
 #if PROTOBUF_INLINE_NOT_IN_HEADERS
 // InternalPushTxnRequest
 
-// optional .cockroach.proto.RequestHeader header = 1;
-bool InternalPushTxnRequest::has_header() const {
+// optional .cockroach.proto.KVRequestHeader kvheader = 1;
+bool InternalPushTxnRequest::has_kvheader() const {
   return (_has_bits_[0] & 0x00000001u) != 0;
 }
-void InternalPushTxnRequest::set_has_header() {
+void InternalPushTxnRequest::set_has_kvheader() {
   _has_bits_[0] |= 0x00000001u;
 }
-void InternalPushTxnRequest::clear_has_header() {
+void InternalPushTxnRequest::clear_has_kvheader() {
   _has_bits_[0] &= ~0x00000001u;
 }
-void InternalPushTxnRequest::clear_header() {
-  if (header_ != NULL) header_->::cockroach::proto::RequestHeader::Clear();
-  clear_has_header();
+void InternalPushTxnRequest::clear_kvheader() {
+  if (kvheader_ != NULL) kvheader_->::cockroach::proto::KVRequestHeader::Clear();
+  clear_has_kvheader();
 }
- const ::cockroach::proto::RequestHeader& InternalPushTxnRequest::header() const {
-  // @@protoc_insertion_point(field_get:cockroach.proto.InternalPushTxnRequest.header)
-  return header_ != NULL ? *header_ : *default_instance_->header_;
+ const ::cockroach::proto::KVRequestHeader& InternalPushTxnRequest::kvheader() const {
+  // @@protoc_insertion_point(field_get:cockroach.proto.InternalPushTxnRequest.kvheader)
+  return kvheader_ != NULL ? *kvheader_ : *default_instance_->kvheader_;
 }
- ::cockroach::proto::RequestHeader* InternalPushTxnRequest::mutable_header() {
-  set_has_header();
-  if (header_ == NULL) {
-    header_ = new ::cockroach::proto::RequestHeader;
+ ::cockroach::proto::KVRequestHeader* InternalPushTxnRequest::mutable_kvheader() {
+  set_has_kvheader();
+  if (kvheader_ == NULL) {
+    kvheader_ = new ::cockroach::proto::KVRequestHeader;
   }
-  // @@protoc_insertion_point(field_mutable:cockroach.proto.InternalPushTxnRequest.header)
-  return header_;
+  // @@protoc_insertion_point(field_mutable:cockroach.proto.InternalPushTxnRequest.kvheader)
+  return kvheader_;
 }
- ::cockroach::proto::RequestHeader* InternalPushTxnRequest::release_header() {
-  clear_has_header();
-  ::cockroach::proto::RequestHeader* temp = header_;
-  header_ = NULL;
+ ::cockroach::proto::KVRequestHeader* InternalPushTxnRequest::release_kvheader() {
+  clear_has_kvheader();
+  ::cockroach::proto::KVRequestHeader* temp = kvheader_;
+  kvheader_ = NULL;
   return temp;
 }
- void InternalPushTxnRequest::set_allocated_header(::cockroach::proto::RequestHeader* header) {
-  delete header_;
-  header_ = header;
-  if (header) {
-    set_has_header();
+ void InternalPushTxnRequest::set_allocated_kvheader(::cockroach::proto::KVRequestHeader* kvheader) {
+  delete kvheader_;
+  kvheader_ = kvheader;
+  if (kvheader) {
+    set_has_kvheader();
   } else {
-    clear_has_header();
+    clear_has_kvheader();
   }
-  // @@protoc_insertion_point(field_set_allocated:cockroach.proto.InternalPushTxnRequest.header)
+  // @@protoc_insertion_point(field_set_allocated:cockroach.proto.InternalPushTxnRequest.kvheader)
 }
 
 // optional .cockroach.proto.Transaction pushee_txn = 2;
@@ -4317,7 +4319,7 @@ void InternalPushTxnRequest::clear_range_lookup() {
 // ===================================================================
 
 #ifndef _MSC_VER
-const int InternalPushTxnResponse::kHeaderFieldNumber;
+const int InternalPushTxnResponse::kKvheaderFieldNumber;
 const int InternalPushTxnResponse::kPusheeTxnFieldNumber;
 #endif  // !_MSC_VER
 
@@ -4328,7 +4330,7 @@ InternalPushTxnResponse::InternalPushTxnResponse()
 }
 
 void InternalPushTxnResponse::InitAsDefaultInstance() {
-  header_ = const_cast< ::cockroach::proto::ResponseHeader*>(&::cockroach::proto::ResponseHeader::default_instance());
+  kvheader_ = const_cast< ::cockroach::proto::KVResponseHeader*>(&::cockroach::proto::KVResponseHeader::default_instance());
   pushee_txn_ = const_cast< ::cockroach::proto::Transaction*>(&::cockroach::proto::Transaction::default_instance());
 }
 
@@ -4342,7 +4344,7 @@ InternalPushTxnResponse::InternalPushTxnResponse(const InternalPushTxnResponse& 
 
 void InternalPushTxnResponse::SharedCtor() {
   _cached_size_ = 0;
-  header_ = NULL;
+  kvheader_ = NULL;
   pushee_txn_ = NULL;
   ::memset(_has_bits_, 0, sizeof(_has_bits_));
 }
@@ -4354,7 +4356,7 @@ InternalPushTxnResponse::~InternalPushTxnResponse() {
 
 void InternalPushTxnResponse::SharedDtor() {
   if (this != default_instance_) {
-    delete header_;
+    delete kvheader_;
     delete pushee_txn_;
   }
 }
@@ -4386,8 +4388,8 @@ InternalPushTxnResponse* InternalPushTxnResponse::New(::google::protobuf::Arena*
 
 void InternalPushTxnResponse::Clear() {
   if (_has_bits_[0 / 32] & 3u) {
-    if (has_header()) {
-      if (header_ != NULL) header_->::cockroach::proto::ResponseHeader::Clear();
+    if (has_kvheader()) {
+      if (kvheader_ != NULL) kvheader_->::cockroach::proto::KVResponseHeader::Clear();
     }
     if (has_pushee_txn()) {
       if (pushee_txn_ != NULL) pushee_txn_->::cockroach::proto::Transaction::Clear();
@@ -4409,11 +4411,11 @@ bool InternalPushTxnResponse::MergePartialFromCodedStream(
     tag = p.first;
     if (!p.second) goto handle_unusual;
     switch (::google::protobuf::internal::WireFormatLite::GetTagFieldNumber(tag)) {
-      // optional .cockroach.proto.ResponseHeader header = 1;
+      // optional .cockroach.proto.KVResponseHeader kvheader = 1;
       case 1: {
         if (tag == 10) {
           DO_(::google::protobuf::internal::WireFormatLite::ReadMessageNoVirtual(
-               input, mutable_header()));
+               input, mutable_kvheader()));
         } else {
           goto handle_unusual;
         }
@@ -4459,10 +4461,10 @@ failure:
 void InternalPushTxnResponse::SerializeWithCachedSizes(
     ::google::protobuf::io::CodedOutputStream* output) const {
   // @@protoc_insertion_point(serialize_start:cockroach.proto.InternalPushTxnResponse)
-  // optional .cockroach.proto.ResponseHeader header = 1;
-  if (has_header()) {
+  // optional .cockroach.proto.KVResponseHeader kvheader = 1;
+  if (has_kvheader()) {
     ::google::protobuf::internal::WireFormatLite::WriteMessageMaybeToArray(
-      1, *this->header_, output);
+      1, *this->kvheader_, output);
   }
 
   // optional .cockroach.proto.Transaction pushee_txn = 2;
@@ -4481,11 +4483,11 @@ void InternalPushTxnResponse::SerializeWithCachedSizes(
 ::google::protobuf::uint8* InternalPushTxnResponse::SerializeWithCachedSizesToArray(
     ::google::protobuf::uint8* target) const {
   // @@protoc_insertion_point(serialize_to_array_start:cockroach.proto.InternalPushTxnResponse)
-  // optional .cockroach.proto.ResponseHeader header = 1;
-  if (has_header()) {
+  // optional .cockroach.proto.KVResponseHeader kvheader = 1;
+  if (has_kvheader()) {
     target = ::google::protobuf::internal::WireFormatLite::
       WriteMessageNoVirtualToArray(
-        1, *this->header_, target);
+        1, *this->kvheader_, target);
   }
 
   // optional .cockroach.proto.Transaction pushee_txn = 2;
@@ -4507,11 +4509,11 @@ int InternalPushTxnResponse::ByteSize() const {
   int total_size = 0;
 
   if (_has_bits_[0 / 32] & 3) {
-    // optional .cockroach.proto.ResponseHeader header = 1;
-    if (has_header()) {
+    // optional .cockroach.proto.KVResponseHeader kvheader = 1;
+    if (has_kvheader()) {
       total_size += 1 +
         ::google::protobuf::internal::WireFormatLite::MessageSizeNoVirtual(
-          *this->header_);
+          *this->kvheader_);
     }
 
     // optional .cockroach.proto.Transaction pushee_txn = 2;
@@ -4548,8 +4550,8 @@ void InternalPushTxnResponse::MergeFrom(const ::google::protobuf::Message& from)
 void InternalPushTxnResponse::MergeFrom(const InternalPushTxnResponse& from) {
   if (GOOGLE_PREDICT_FALSE(&from == this)) MergeFromFail(__LINE__);
   if (from._has_bits_[0 / 32] & (0xffu << (0 % 32))) {
-    if (from.has_header()) {
-      mutable_header()->::cockroach::proto::ResponseHeader::MergeFrom(from.header());
+    if (from.has_kvheader()) {
+      mutable_kvheader()->::cockroach::proto::KVResponseHeader::MergeFrom(from.kvheader());
     }
     if (from.has_pushee_txn()) {
       mutable_pushee_txn()->::cockroach::proto::Transaction::MergeFrom(from.pushee_txn());
@@ -4582,7 +4584,7 @@ void InternalPushTxnResponse::Swap(InternalPushTxnResponse* other) {
   InternalSwap(other);
 }
 void InternalPushTxnResponse::InternalSwap(InternalPushTxnResponse* other) {
-  std::swap(header_, other->header_);
+  std::swap(kvheader_, other->kvheader_);
   std::swap(pushee_txn_, other->pushee_txn_);
   std::swap(_has_bits_[0], other->_has_bits_[0]);
   _internal_metadata_.Swap(&other->_internal_metadata_);
@@ -4600,47 +4602,47 @@ void InternalPushTxnResponse::InternalSwap(InternalPushTxnResponse* other) {
 #if PROTOBUF_INLINE_NOT_IN_HEADERS
 // InternalPushTxnResponse
 
-// optional .cockroach.proto.ResponseHeader header = 1;
-bool InternalPushTxnResponse::has_header() const {
+// optional .cockroach.proto.KVResponseHeader kvheader = 1;
+bool InternalPushTxnResponse::has_kvheader() const {
   return (_has_bits_[0] & 0x00000001u) != 0;
 }
-void InternalPushTxnResponse::set_has_header() {
+void InternalPushTxnResponse::set_has_kvheader() {
   _has_bits_[0] |= 0x00000001u;
 }
-void InternalPushTxnResponse::clear_has_header() {
+void InternalPushTxnResponse::clear_has_kvheader() {
   _has_bits_[0] &= ~0x00000001u;
 }
-void InternalPushTxnResponse::clear_header() {
-  if (header_ != NULL) header_->::cockroach::proto::ResponseHeader::Clear();
-  clear_has_header();
+void InternalPushTxnResponse::clear_kvheader() {
+  if (kvheader_ != NULL) kvheader_->::cockroach::proto::KVResponseHeader::Clear();
+  clear_has_kvheader();
 }
- const ::cockroach::proto::ResponseHeader& InternalPushTxnResponse::header() const {
-  // @@protoc_insertion_point(field_get:cockroach.proto.InternalPushTxnResponse.header)
-  return header_ != NULL ? *header_ : *default_instance_->header_;
+ const ::cockroach::proto::KVResponseHeader& InternalPushTxnResponse::kvheader() const {
+  // @@protoc_insertion_point(field_get:cockroach.proto.InternalPushTxnResponse.kvheader)
+  return kvheader_ != NULL ? *kvheader_ : *default_instance_->kvheader_;
 }
- ::cockroach::proto::ResponseHeader* InternalPushTxnResponse::mutable_header() {
-  set_has_header();
-  if (header_ == NULL) {
-    header_ = new ::cockroach::proto::ResponseHeader;
+ ::cockroach::proto::KVResponseHeader* InternalPushTxnResponse::mutable_kvheader() {
+  set_has_kvheader();
+  if (kvheader_ == NULL) {
+    kvheader_ = new ::cockroach::proto::KVResponseHeader;
   }
-  // @@protoc_insertion_point(field_mutable:cockroach.proto.InternalPushTxnResponse.header)
-  return header_;
+  // @@protoc_insertion_point(field_mutable:cockroach.proto.InternalPushTxnResponse.kvheader)
+  return kvheader_;
 }
- ::cockroach::proto::ResponseHeader* InternalPushTxnResponse::release_header() {
-  clear_has_header();
-  ::cockroach::proto::ResponseHeader* temp = header_;
-  header_ = NULL;
+ ::cockroach::proto::KVResponseHeader* InternalPushTxnResponse::release_kvheader() {
+  clear_has_kvheader();
+  ::cockroach::proto::KVResponseHeader* temp = kvheader_;
+  kvheader_ = NULL;
   return temp;
 }
- void InternalPushTxnResponse::set_allocated_header(::cockroach::proto::ResponseHeader* header) {
-  delete header_;
-  header_ = header;
-  if (header) {
-    set_has_header();
+ void InternalPushTxnResponse::set_allocated_kvheader(::cockroach::proto::KVResponseHeader* kvheader) {
+  delete kvheader_;
+  kvheader_ = kvheader;
+  if (kvheader) {
+    set_has_kvheader();
   } else {
-    clear_has_header();
+    clear_has_kvheader();
   }
-  // @@protoc_insertion_point(field_set_allocated:cockroach.proto.InternalPushTxnResponse.header)
+  // @@protoc_insertion_point(field_set_allocated:cockroach.proto.InternalPushTxnResponse.kvheader)
 }
 
 // optional .cockroach.proto.Transaction pushee_txn = 2;
@@ -4691,7 +4693,7 @@ void InternalPushTxnResponse::clear_pushee_txn() {
 // ===================================================================
 
 #ifndef _MSC_VER
-const int InternalResolveIntentRequest::kHeaderFieldNumber;
+const int InternalResolveIntentRequest::kKvheaderFieldNumber;
 #endif  // !_MSC_VER
 
 InternalResolveIntentRequest::InternalResolveIntentRequest()
@@ -4701,7 +4703,7 @@ InternalResolveIntentRequest::InternalResolveIntentRequest()
 }
 
 void InternalResolveIntentRequest::InitAsDefaultInstance() {
-  header_ = const_cast< ::cockroach::proto::RequestHeader*>(&::cockroach::proto::RequestHeader::default_instance());
+  kvheader_ = const_cast< ::cockroach::proto::KVRequestHeader*>(&::cockroach::proto::KVRequestHeader::default_instance());
 }
 
 InternalResolveIntentRequest::InternalResolveIntentRequest(const InternalResolveIntentRequest& from)
@@ -4714,7 +4716,7 @@ InternalResolveIntentRequest::InternalResolveIntentRequest(const InternalResolve
 
 void InternalResolveIntentRequest::SharedCtor() {
   _cached_size_ = 0;
-  header_ = NULL;
+  kvheader_ = NULL;
   ::memset(_has_bits_, 0, sizeof(_has_bits_));
 }
 
@@ -4725,7 +4727,7 @@ InternalResolveIntentRequest::~InternalResolveIntentRequest() {
 
 void InternalResolveIntentRequest::SharedDtor() {
   if (this != default_instance_) {
-    delete header_;
+    delete kvheader_;
   }
 }
 
@@ -4755,8 +4757,8 @@ InternalResolveIntentRequest* InternalResolveIntentRequest::New(::google::protob
 }
 
 void InternalResolveIntentRequest::Clear() {
-  if (has_header()) {
-    if (header_ != NULL) header_->::cockroach::proto::RequestHeader::Clear();
+  if (has_kvheader()) {
+    if (kvheader_ != NULL) kvheader_->::cockroach::proto::KVRequestHeader::Clear();
   }
   ::memset(_has_bits_, 0, sizeof(_has_bits_));
   if (_internal_metadata_.have_unknown_fields()) {
@@ -4774,11 +4776,11 @@ bool InternalResolveIntentRequest::MergePartialFromCodedStream(
     tag = p.first;
     if (!p.second) goto handle_unusual;
     switch (::google::protobuf::internal::WireFormatLite::GetTagFieldNumber(tag)) {
-      // optional .cockroach.proto.RequestHeader header = 1;
+      // optional .cockroach.proto.KVRequestHeader kvheader = 1;
       case 1: {
         if (tag == 10) {
           DO_(::google::protobuf::internal::WireFormatLite::ReadMessageNoVirtual(
-               input, mutable_header()));
+               input, mutable_kvheader()));
         } else {
           goto handle_unusual;
         }
@@ -4811,10 +4813,10 @@ failure:
 void InternalResolveIntentRequest::SerializeWithCachedSizes(
     ::google::protobuf::io::CodedOutputStream* output) const {
   // @@protoc_insertion_point(serialize_start:cockroach.proto.InternalResolveIntentRequest)
-  // optional .cockroach.proto.RequestHeader header = 1;
-  if (has_header()) {
+  // optional .cockroach.proto.KVRequestHeader kvheader = 1;
+  if (has_kvheader()) {
     ::google::protobuf::internal::WireFormatLite::WriteMessageMaybeToArray(
-      1, *this->header_, output);
+      1, *this->kvheader_, output);
   }
 
   if (_internal_metadata_.have_unknown_fields()) {
@@ -4827,11 +4829,11 @@ void InternalResolveIntentRequest::SerializeWithCachedSizes(
 ::google::protobuf::uint8* InternalResolveIntentRequest::SerializeWithCachedSizesToArray(
     ::google::protobuf::uint8* target) const {
   // @@protoc_insertion_point(serialize_to_array_start:cockroach.proto.InternalResolveIntentRequest)
-  // optional .cockroach.proto.RequestHeader header = 1;
-  if (has_header()) {
+  // optional .cockroach.proto.KVRequestHeader kvheader = 1;
+  if (has_kvheader()) {
     target = ::google::protobuf::internal::WireFormatLite::
       WriteMessageNoVirtualToArray(
-        1, *this->header_, target);
+        1, *this->kvheader_, target);
   }
 
   if (_internal_metadata_.have_unknown_fields()) {
@@ -4845,11 +4847,11 @@ void InternalResolveIntentRequest::SerializeWithCachedSizes(
 int InternalResolveIntentRequest::ByteSize() const {
   int total_size = 0;
 
-  // optional .cockroach.proto.RequestHeader header = 1;
-  if (has_header()) {
+  // optional .cockroach.proto.KVRequestHeader kvheader = 1;
+  if (has_kvheader()) {
     total_size += 1 +
       ::google::protobuf::internal::WireFormatLite::MessageSizeNoVirtual(
-        *this->header_);
+        *this->kvheader_);
   }
 
   if (_internal_metadata_.have_unknown_fields()) {
@@ -4878,8 +4880,8 @@ void InternalResolveIntentRequest::MergeFrom(const ::google::protobuf::Message& 
 void InternalResolveIntentRequest::MergeFrom(const InternalResolveIntentRequest& from) {
   if (GOOGLE_PREDICT_FALSE(&from == this)) MergeFromFail(__LINE__);
   if (from._has_bits_[0 / 32] & (0xffu << (0 % 32))) {
-    if (from.has_header()) {
-      mutable_header()->::cockroach::proto::RequestHeader::MergeFrom(from.header());
+    if (from.has_kvheader()) {
+      mutable_kvheader()->::cockroach::proto::KVRequestHeader::MergeFrom(from.kvheader());
     }
   }
   if (from._internal_metadata_.have_unknown_fields()) {
@@ -4909,7 +4911,7 @@ void InternalResolveIntentRequest::Swap(InternalResolveIntentRequest* other) {
   InternalSwap(other);
 }
 void InternalResolveIntentRequest::InternalSwap(InternalResolveIntentRequest* other) {
-  std::swap(header_, other->header_);
+  std::swap(kvheader_, other->kvheader_);
   std::swap(_has_bits_[0], other->_has_bits_[0]);
   _internal_metadata_.Swap(&other->_internal_metadata_);
   std::swap(_cached_size_, other->_cached_size_);
@@ -4926,47 +4928,47 @@ void InternalResolveIntentRequest::InternalSwap(InternalResolveIntentRequest* ot
 #if PROTOBUF_INLINE_NOT_IN_HEADERS
 // InternalResolveIntentRequest
 
-// optional .cockroach.proto.RequestHeader header = 1;
-bool InternalResolveIntentRequest::has_header() const {
+// optional .cockroach.proto.KVRequestHeader kvheader = 1;
+bool InternalResolveIntentRequest::has_kvheader() const {
   return (_has_bits_[0] & 0x00000001u) != 0;
 }
-void InternalResolveIntentRequest::set_has_header() {
+void InternalResolveIntentRequest::set_has_kvheader() {
   _has_bits_[0] |= 0x00000001u;
 }
-void InternalResolveIntentRequest::clear_has_header() {
+void InternalResolveIntentRequest::clear_has_kvheader() {
   _has_bits_[0] &= ~0x00000001u;
 }
-void InternalResolveIntentRequest::clear_header() {
-  if (header_ != NULL) header_->::cockroach::proto::RequestHeader::Clear();
-  clear_has_header();
+void InternalResolveIntentRequest::clear_kvheader() {
+  if (kvheader_ != NULL) kvheader_->::cockroach::proto::KVRequestHeader::Clear();
+  clear_has_kvheader();
 }
- const ::cockroach::proto::RequestHeader& InternalResolveIntentRequest::header() const {
-  // @@protoc_insertion_point(field_get:cockroach.proto.InternalResolveIntentRequest.header)
-  return header_ != NULL ? *header_ : *default_instance_->header_;
+ const ::cockroach::proto::KVRequestHeader& InternalResolveIntentRequest::kvheader() const {
+  // @@protoc_insertion_point(field_get:cockroach.proto.InternalResolveIntentRequest.kvheader)
+  return kvheader_ != NULL ? *kvheader_ : *default_instance_->kvheader_;
 }
- ::cockroach::proto::RequestHeader* InternalResolveIntentRequest::mutable_header() {
-  set_has_header();
-  if (header_ == NULL) {
-    header_ = new ::cockroach::proto::RequestHeader;
+ ::cockroach::proto::KVRequestHeader* InternalResolveIntentRequest::mutable_kvheader() {
+  set_has_kvheader();
+  if (kvheader_ == NULL) {
+    kvheader_ = new ::cockroach::proto::KVRequestHeader;
   }
-  // @@protoc_insertion_point(field_mutable:cockroach.proto.InternalResolveIntentRequest.header)
-  return header_;
+  // @@protoc_insertion_point(field_mutable:cockroach.proto.InternalResolveIntentRequest.kvheader)
+  return kvheader_;
 }
- ::cockroach::proto::RequestHeader* InternalResolveIntentRequest::release_header() {
-  clear_has_header();
-  ::cockroach::proto::RequestHeader* temp = header_;
-  header_ = NULL;
+ ::cockroach::proto::KVRequestHeader* InternalResolveIntentRequest::release_kvheader() {
+  clear_has_kvheader();
+  ::cockroach::proto::KVRequestHeader* temp = kvheader_;
+  kvheader_ = NULL;
   return temp;
 }
- void InternalResolveIntentRequest::set_allocated_header(::cockroach::proto::RequestHeader* header) {
-  delete header_;
-  header_ = header;
-  if (header) {
-    set_has_header();
+ void InternalResolveIntentRequest::set_allocated_kvheader(::cockroach::proto::KVRequestHeader* kvheader) {
+  delete kvheader_;
+  kvheader_ = kvheader;
+  if (kvheader) {
+    set_has_kvheader();
   } else {
-    clear_has_header();
+    clear_has_kvheader();
   }
-  // @@protoc_insertion_point(field_set_allocated:cockroach.proto.InternalResolveIntentRequest.header)
+  // @@protoc_insertion_point(field_set_allocated:cockroach.proto.InternalResolveIntentRequest.kvheader)
 }
 
 #endif  // PROTOBUF_INLINE_NOT_IN_HEADERS
@@ -4974,7 +4976,7 @@ void InternalResolveIntentRequest::clear_header() {
 // ===================================================================
 
 #ifndef _MSC_VER
-const int InternalResolveIntentResponse::kHeaderFieldNumber;
+const int InternalResolveIntentResponse::kKvheaderFieldNumber;
 #endif  // !_MSC_VER
 
 InternalResolveIntentResponse::InternalResolveIntentResponse()
@@ -4984,7 +4986,7 @@ InternalResolveIntentResponse::InternalResolveIntentResponse()
 }
 
 void InternalResolveIntentResponse::InitAsDefaultInstance() {
-  header_ = const_cast< ::cockroach::proto::ResponseHeader*>(&::cockroach::proto::ResponseHeader::default_instance());
+  kvheader_ = const_cast< ::cockroach::proto::KVResponseHeader*>(&::cockroach::proto::KVResponseHeader::default_instance());
 }
 
 InternalResolveIntentResponse::InternalResolveIntentResponse(const InternalResolveIntentResponse& from)
@@ -4997,7 +4999,7 @@ InternalResolveIntentResponse::InternalResolveIntentResponse(const InternalResol
 
 void InternalResolveIntentResponse::SharedCtor() {
   _cached_size_ = 0;
-  header_ = NULL;
+  kvheader_ = NULL;
   ::memset(_has_bits_, 0, sizeof(_has_bits_));
 }
 
@@ -5008,7 +5010,7 @@ InternalResolveIntentResponse::~InternalResolveIntentResponse() {
 
 void InternalResolveIntentResponse::SharedDtor() {
   if (this != default_instance_) {
-    delete header_;
+    delete kvheader_;
   }
 }
 
@@ -5038,8 +5040,8 @@ InternalResolveIntentResponse* InternalResolveIntentResponse::New(::google::prot
 }
 
 void InternalResolveIntentResponse::Clear() {
-  if (has_header()) {
-    if (header_ != NULL) header_->::cockroach::proto::ResponseHeader::Clear();
+  if (has_kvheader()) {
+    if (kvheader_ != NULL) kvheader_->::cockroach::proto::KVResponseHeader::Clear();
   }
   ::memset(_has_bits_, 0, sizeof(_has_bits_));
   if (_internal_metadata_.have_unknown_fields()) {
@@ -5057,11 +5059,11 @@ bool InternalResolveIntentResponse::MergePartialFromCodedStream(
     tag = p.first;
     if (!p.second) goto handle_unusual;
     switch (::google::protobuf::internal::WireFormatLite::GetTagFieldNumber(tag)) {
-      // optional .cockroach.proto.ResponseHeader header = 1;
+      // optional .cockroach.proto.KVResponseHeader kvheader = 1;
       case 1: {
         if (tag == 10) {
           DO_(::google::protobuf::internal::WireFormatLite::ReadMessageNoVirtual(
-               input, mutable_header()));
+               input, mutable_kvheader()));
         } else {
           goto handle_unusual;
         }
@@ -5094,10 +5096,10 @@ failure:
 void InternalResolveIntentResponse::SerializeWithCachedSizes(
     ::google::protobuf::io::CodedOutputStream* output) const {
   // @@protoc_insertion_point(serialize_start:cockroach.proto.InternalResolveIntentResponse)
-  // optional .cockroach.proto.ResponseHeader header = 1;
-  if (has_header()) {
+  // optional .cockroach.proto.KVResponseHeader kvheader = 1;
+  if (has_kvheader()) {
     ::google::protobuf::internal::WireFormatLite::WriteMessageMaybeToArray(
-      1, *this->header_, output);
+      1, *this->kvheader_, output);
   }
 
   if (_internal_metadata_.have_unknown_fields()) {
@@ -5110,11 +5112,11 @@ void InternalResolveIntentResponse::SerializeWithCachedSizes(
 ::google::protobuf::uint8* InternalResolveIntentResponse::SerializeWithCachedSizesToArray(
     ::google::protobuf::uint8* target) const {
   // @@protoc_insertion_point(serialize_to_array_start:cockroach.proto.InternalResolveIntentResponse)
-  // optional .cockroach.proto.ResponseHeader header = 1;
-  if (has_header()) {
+  // optional .cockroach.proto.KVResponseHeader kvheader = 1;
+  if (has_kvheader()) {
     target = ::google::protobuf::internal::WireFormatLite::
       WriteMessageNoVirtualToArray(
-        1, *this->header_, target);
+        1, *this->kvheader_, target);
   }
 
   if (_internal_metadata_.have_unknown_fields()) {
@@ -5128,11 +5130,11 @@ void InternalResolveIntentResponse::SerializeWithCachedSizes(
 int InternalResolveIntentResponse::ByteSize() const {
   int total_size = 0;
 
-  // optional .cockroach.proto.ResponseHeader header = 1;
-  if (has_header()) {
+  // optional .cockroach.proto.KVResponseHeader kvheader = 1;
+  if (has_kvheader()) {
     total_size += 1 +
       ::google::protobuf::internal::WireFormatLite::MessageSizeNoVirtual(
-        *this->header_);
+        *this->kvheader_);
   }
 
   if (_internal_metadata_.have_unknown_fields()) {
@@ -5161,8 +5163,8 @@ void InternalResolveIntentResponse::MergeFrom(const ::google::protobuf::Message&
 void InternalResolveIntentResponse::MergeFrom(const InternalResolveIntentResponse& from) {
   if (GOOGLE_PREDICT_FALSE(&from == this)) MergeFromFail(__LINE__);
   if (from._has_bits_[0 / 32] & (0xffu << (0 % 32))) {
-    if (from.has_header()) {
-      mutable_header()->::cockroach::proto::ResponseHeader::MergeFrom(from.header());
+    if (from.has_kvheader()) {
+      mutable_kvheader()->::cockroach::proto::KVResponseHeader::MergeFrom(from.kvheader());
     }
   }
   if (from._internal_metadata_.have_unknown_fields()) {
@@ -5192,7 +5194,7 @@ void InternalResolveIntentResponse::Swap(InternalResolveIntentResponse* other) {
   InternalSwap(other);
 }
 void InternalResolveIntentResponse::InternalSwap(InternalResolveIntentResponse* other) {
-  std::swap(header_, other->header_);
+  std::swap(kvheader_, other->kvheader_);
   std::swap(_has_bits_[0], other->_has_bits_[0]);
   _internal_metadata_.Swap(&other->_internal_metadata_);
   std::swap(_cached_size_, other->_cached_size_);
@@ -5209,47 +5211,47 @@ void InternalResolveIntentResponse::InternalSwap(InternalResolveIntentResponse* 
 #if PROTOBUF_INLINE_NOT_IN_HEADERS
 // InternalResolveIntentResponse
 
-// optional .cockroach.proto.ResponseHeader header = 1;
-bool InternalResolveIntentResponse::has_header() const {
+// optional .cockroach.proto.KVResponseHeader kvheader = 1;
+bool InternalResolveIntentResponse::has_kvheader() const {
   return (_has_bits_[0] & 0x00000001u) != 0;
 }
-void InternalResolveIntentResponse::set_has_header() {
+void InternalResolveIntentResponse::set_has_kvheader() {
   _has_bits_[0] |= 0x00000001u;
 }
-void InternalResolveIntentResponse::clear_has_header() {
+void InternalResolveIntentResponse::clear_has_kvheader() {
   _has_bits_[0] &= ~0x00000001u;
 }
-void InternalResolveIntentResponse::clear_header() {
-  if (header_ != NULL) header_->::cockroach::proto::ResponseHeader::Clear();
-  clear_has_header();
+void InternalResolveIntentResponse::clear_kvheader() {
+  if (kvheader_ != NULL) kvheader_->::cockroach::proto::KVResponseHeader::Clear();
+  clear_has_kvheader();
 }
- const ::cockroach::proto::ResponseHeader& InternalResolveIntentResponse::header() const {
-  // @@protoc_insertion_point(field_get:cockroach.proto.InternalResolveIntentResponse.header)
-  return header_ != NULL ? *header_ : *default_instance_->header_;
+ const ::cockroach::proto::KVResponseHeader& InternalResolveIntentResponse::kvheader() const {
+  // @@protoc_insertion_point(field_get:cockroach.proto.InternalResolveIntentResponse.kvheader)
+  return kvheader_ != NULL ? *kvheader_ : *default_instance_->kvheader_;
 }
- ::cockroach::proto::ResponseHeader* InternalResolveIntentResponse::mutable_header() {
-  set_has_header();
-  if (header_ == NULL) {
-    header_ = new ::cockroach::proto::ResponseHeader;
+ ::cockroach::proto::KVResponseHeader* InternalResolveIntentResponse::mutable_kvheader() {
+  set_has_kvheader();
+  if (kvheader_ == NULL) {
+    kvheader_ = new ::cockroach::proto::KVResponseHeader;
   }
-  // @@protoc_insertion_point(field_mutable:cockroach.proto.InternalResolveIntentResponse.header)
-  return header_;
+  // @@protoc_insertion_point(field_mutable:cockroach.proto.InternalResolveIntentResponse.kvheader)
+  return kvheader_;
 }
- ::cockroach::proto::ResponseHeader* InternalResolveIntentResponse::release_header() {
-  clear_has_header();
-  ::cockroach::proto::ResponseHeader* temp = header_;
-  header_ = NULL;
+ ::cockroach::proto::KVResponseHeader* InternalResolveIntentResponse::release_kvheader() {
+  clear_has_kvheader();
+  ::cockroach::proto::KVResponseHeader* temp = kvheader_;
+  kvheader_ = NULL;
   return temp;
 }
- void InternalResolveIntentResponse::set_allocated_header(::cockroach::proto::ResponseHeader* header) {
-  delete header_;
-  header_ = header;
-  if (header) {
-    set_has_header();
+ void InternalResolveIntentResponse::set_allocated_kvheader(::cockroach::proto::KVResponseHeader* kvheader) {
+  delete kvheader_;
+  kvheader_ = kvheader;
+  if (kvheader) {
+    set_has_kvheader();
   } else {
-    clear_has_header();
+    clear_has_kvheader();
   }
-  // @@protoc_insertion_point(field_set_allocated:cockroach.proto.InternalResolveIntentResponse.header)
+  // @@protoc_insertion_point(field_set_allocated:cockroach.proto.InternalResolveIntentResponse.kvheader)
 }
 
 #endif  // PROTOBUF_INLINE_NOT_IN_HEADERS
@@ -5257,7 +5259,7 @@ void InternalResolveIntentResponse::clear_header() {
 // ===================================================================
 
 #ifndef _MSC_VER
-const int InternalResolveIntentRangeRequest::kHeaderFieldNumber;
+const int InternalResolveIntentRangeRequest::kKvheaderFieldNumber;
 #endif  // !_MSC_VER
 
 InternalResolveIntentRangeRequest::InternalResolveIntentRangeRequest()
@@ -5267,7 +5269,7 @@ InternalResolveIntentRangeRequest::InternalResolveIntentRangeRequest()
 }
 
 void InternalResolveIntentRangeRequest::InitAsDefaultInstance() {
-  header_ = const_cast< ::cockroach::proto::RequestHeader*>(&::cockroach::proto::RequestHeader::default_instance());
+  kvheader_ = const_cast< ::cockroach::proto::KVRequestHeader*>(&::cockroach::proto::KVRequestHeader::default_instance());
 }
 
 InternalResolveIntentRangeRequest::InternalResolveIntentRangeRequest(const InternalResolveIntentRangeRequest& from)
@@ -5280,7 +5282,7 @@ InternalResolveIntentRangeRequest::InternalResolveIntentRangeRequest(const Inter
 
 void InternalResolveIntentRangeRequest::SharedCtor() {
   _cached_size_ = 0;
-  header_ = NULL;
+  kvheader_ = NULL;
   ::memset(_has_bits_, 0, sizeof(_has_bits_));
 }
 
@@ -5291,7 +5293,7 @@ InternalResolveIntentRangeRequest::~InternalResolveIntentRangeRequest() {
 
 void InternalResolveIntentRangeRequest::SharedDtor() {
   if (this != default_instance_) {
-    delete header_;
+    delete kvheader_;
   }
 }
 
@@ -5321,8 +5323,8 @@ InternalResolveIntentRangeRequest* InternalResolveIntentRangeRequest::New(::goog
 }
 
 void InternalResolveIntentRangeRequest::Clear() {
-  if (has_header()) {
-    if (header_ != NULL) header_->::cockroach::proto::RequestHeader::Clear();
+  if (has_kvheader()) {
+    if (kvheader_ != NULL) kvheader_->::cockroach::proto::KVRequestHeader::Clear();
   }
   ::memset(_has_bits_, 0, sizeof(_has_bits_));
   if (_internal_metadata_.have_unknown_fields()) {
@@ -5340,11 +5342,11 @@ bool InternalResolveIntentRangeRequest::MergePartialFromCodedStream(
     tag = p.first;
     if (!p.second) goto handle_unusual;
     switch (::google::protobuf::internal::WireFormatLite::GetTagFieldNumber(tag)) {
-      // optional .cockroach.proto.RequestHeader header = 1;
+      // optional .cockroach.proto.KVRequestHeader kvheader = 1;
       case 1: {
         if (tag == 10) {
           DO_(::google::protobuf::internal::WireFormatLite::ReadMessageNoVirtual(
-               input, mutable_header()));
+               input, mutable_kvheader()));
         } else {
           goto handle_unusual;
         }
@@ -5377,10 +5379,10 @@ failure:
 void InternalResolveIntentRangeRequest::SerializeWithCachedSizes(
     ::google::protobuf::io::CodedOutputStream* output) const {
   // @@protoc_insertion_point(serialize_start:cockroach.proto.InternalResolveIntentRangeRequest)
-  // optional .cockroach.proto.RequestHeader header = 1;
-  if (has_header()) {
+  // optional .cockroach.proto.KVRequestHeader kvheader = 1;
+  if (has_kvheader()) {
     ::google::protobuf::internal::WireFormatLite::WriteMessageMaybeToArray(
-      1, *this->header_, output);
+      1, *this->kvheader_, output);
   }
 
   if (_internal_metadata_.have_unknown_fields()) {
@@ -5393,11 +5395,11 @@ void InternalResolveIntentRangeRequest::SerializeWithCachedSizes(
 ::google::protobuf::uint8* InternalResolveIntentRangeRequest::SerializeWithCachedSizesToArray(
     ::google::protobuf::uint8* target) const {
   // @@protoc_insertion_point(serialize_to_array_start:cockroach.proto.InternalResolveIntentRangeRequest)
-  // optional .cockroach.proto.RequestHeader header = 1;
-  if (has_header()) {
+  // optional .cockroach.proto.KVRequestHeader kvheader = 1;
+  if (has_kvheader()) {
     target = ::google::protobuf::internal::WireFormatLite::
       WriteMessageNoVirtualToArray(
-        1, *this->header_, target);
+        1, *this->kvheader_, target);
   }
 
   if (_internal_metadata_.have_unknown_fields()) {
@@ -5411,11 +5413,11 @@ void InternalResolveIntentRangeRequest::SerializeWithCachedSizes(
 int InternalResolveIntentRangeRequest::ByteSize() const {
   int total_size = 0;
 
-  // optional .cockroach.proto.RequestHeader header = 1;
-  if (has_header()) {
+  // optional .cockroach.proto.KVRequestHeader kvheader = 1;
+  if (has_kvheader()) {
     total_size += 1 +
       ::google::protobuf::internal::WireFormatLite::MessageSizeNoVirtual(
-        *this->header_);
+        *this->kvheader_);
   }
 
   if (_internal_metadata_.have_unknown_fields()) {
@@ -5444,8 +5446,8 @@ void InternalResolveIntentRangeRequest::MergeFrom(const ::google::protobuf::Mess
 void InternalResolveIntentRangeRequest::MergeFrom(const InternalResolveIntentRangeRequest& from) {
   if (GOOGLE_PREDICT_FALSE(&from == this)) MergeFromFail(__LINE__);
   if (from._has_bits_[0 / 32] & (0xffu << (0 % 32))) {
-    if (from.has_header()) {
-      mutable_header()->::cockroach::proto::RequestHeader::MergeFrom(from.header());
+    if (from.has_kvheader()) {
+      mutable_kvheader()->::cockroach::proto::KVRequestHeader::MergeFrom(from.kvheader());
     }
   }
   if (from._internal_metadata_.have_unknown_fields()) {
@@ -5475,7 +5477,7 @@ void InternalResolveIntentRangeRequest::Swap(InternalResolveIntentRangeRequest* 
   InternalSwap(other);
 }
 void InternalResolveIntentRangeRequest::InternalSwap(InternalResolveIntentRangeRequest* other) {
-  std::swap(header_, other->header_);
+  std::swap(kvheader_, other->kvheader_);
   std::swap(_has_bits_[0], other->_has_bits_[0]);
   _internal_metadata_.Swap(&other->_internal_metadata_);
   std::swap(_cached_size_, other->_cached_size_);
@@ -5492,47 +5494,47 @@ void InternalResolveIntentRangeRequest::InternalSwap(InternalResolveIntentRangeR
 #if PROTOBUF_INLINE_NOT_IN_HEADERS
 // InternalResolveIntentRangeRequest
 
-// optional .cockroach.proto.RequestHeader header = 1;
-bool InternalResolveIntentRangeRequest::has_header() const {
+// optional .cockroach.proto.KVRequestHeader kvheader = 1;
+bool InternalResolveIntentRangeRequest::has_kvheader() const {
   return (_has_bits_[0] & 0x00000001u) != 0;
 }
-void InternalResolveIntentRangeRequest::set_has_header() {
+void InternalResolveIntentRangeRequest::set_has_kvheader() {
   _has_bits_[0] |= 0x00000001u;
 }
-void InternalResolveIntentRangeRequest::clear_has_header() {
+void InternalResolveIntentRangeRequest::clear_has_kvheader() {
   _has_bits_[0] &= ~0x00000001u;
 }
-void InternalResolveIntentRangeRequest::clear_header() {
-  if (header_ != NULL) header_->::cockroach::proto::RequestHeader::Clear();
-  clear_has_header();
+void InternalResolveIntentRangeRequest::clear_kvheader() {
+  if (kvheader_ != NULL) kvheader_->::cockroach::proto::KVRequestHeader::Clear();
+  clear_has_kvheader();
 }
- const ::cockroach::proto::RequestHeader& InternalResolveIntentRangeRequest::header() const {
-  // @@protoc_insertion_point(field_get:cockroach.proto.InternalResolveIntentRangeRequest.header)
-  return header_ != NULL ? *header_ : *default_instance_->header_;
+ const ::cockroach::proto::KVRequestHeader& InternalResolveIntentRangeRequest::kvheader() const {
+  // @@protoc_insertion_point(field_get:cockroach.proto.InternalResolveIntentRangeRequest.kvheader)
+  return kvheader_ != NULL ? *kvheader_ : *default_instance_->kvheader_;
 }
- ::cockroach::proto::RequestHeader* InternalResolveIntentRangeRequest::mutable_header() {
-  set_has_header();
-  if (header_ == NULL) {
-    header_ = new ::cockroach::proto::RequestHeader;
+ ::cockroach::proto::KVRequestHeader* InternalResolveIntentRangeRequest::mutable_kvheader() {
+  set_has_kvheader();
+  if (kvheader_ == NULL) {
+    kvheader_ = new ::cockroach::proto::KVRequestHeader;
   }
-  // @@protoc_insertion_point(field_mutable:cockroach.proto.InternalResolveIntentRangeRequest.header)
-  return header_;
+  // @@protoc_insertion_point(field_mutable:cockroach.proto.InternalResolveIntentRangeRequest.kvheader)
+  return kvheader_;
 }
- ::cockroach::proto::RequestHeader* InternalResolveIntentRangeRequest::release_header() {
-  clear_has_header();
-  ::cockroach::proto::RequestHeader* temp = header_;
-  header_ = NULL;
+ ::cockroach::proto::KVRequestHeader* InternalResolveIntentRangeRequest::release_kvheader() {
+  clear_has_kvheader();
+  ::cockroach::proto::KVRequestHeader* temp = kvheader_;
+  kvheader_ = NULL;
   return temp;
 }
- void InternalResolveIntentRangeRequest::set_allocated_header(::cockroach::proto::RequestHeader* header) {
-  delete header_;
-  header_ = header;
-  if (header) {
-    set_has_header();
+ void InternalResolveIntentRangeRequest::set_allocated_kvheader(::cockroach::proto::KVRequestHeader* kvheader) {
+  delete kvheader_;
+  kvheader_ = kvheader;
+  if (kvheader) {
+    set_has_kvheader();
   } else {
-    clear_has_header();
+    clear_has_kvheader();
   }
-  // @@protoc_insertion_point(field_set_allocated:cockroach.proto.InternalResolveIntentRangeRequest.header)
+  // @@protoc_insertion_point(field_set_allocated:cockroach.proto.InternalResolveIntentRangeRequest.kvheader)
 }
 
 #endif  // PROTOBUF_INLINE_NOT_IN_HEADERS
@@ -5540,7 +5542,7 @@ void InternalResolveIntentRangeRequest::clear_header() {
 // ===================================================================
 
 #ifndef _MSC_VER
-const int InternalResolveIntentRangeResponse::kHeaderFieldNumber;
+const int InternalResolveIntentRangeResponse::kKvheaderFieldNumber;
 #endif  // !_MSC_VER
 
 InternalResolveIntentRangeResponse::InternalResolveIntentRangeResponse()
@@ -5550,7 +5552,7 @@ InternalResolveIntentRangeResponse::InternalResolveIntentRangeResponse()
 }
 
 void InternalResolveIntentRangeResponse::InitAsDefaultInstance() {
-  header_ = const_cast< ::cockroach::proto::ResponseHeader*>(&::cockroach::proto::ResponseHeader::default_instance());
+  kvheader_ = const_cast< ::cockroach::proto::KVResponseHeader*>(&::cockroach::proto::KVResponseHeader::default_instance());
 }
 
 InternalResolveIntentRangeResponse::InternalResolveIntentRangeResponse(const InternalResolveIntentRangeResponse& from)
@@ -5563,7 +5565,7 @@ InternalResolveIntentRangeResponse::InternalResolveIntentRangeResponse(const Int
 
 void InternalResolveIntentRangeResponse::SharedCtor() {
   _cached_size_ = 0;
-  header_ = NULL;
+  kvheader_ = NULL;
   ::memset(_has_bits_, 0, sizeof(_has_bits_));
 }
 
@@ -5574,7 +5576,7 @@ InternalResolveIntentRangeResponse::~InternalResolveIntentRangeResponse() {
 
 void InternalResolveIntentRangeResponse::SharedDtor() {
   if (this != default_instance_) {
-    delete header_;
+    delete kvheader_;
   }
 }
 
@@ -5604,8 +5606,8 @@ InternalResolveIntentRangeResponse* InternalResolveIntentRangeResponse::New(::go
 }
 
 void InternalResolveIntentRangeResponse::Clear() {
-  if (has_header()) {
-    if (header_ != NULL) header_->::cockroach::proto::ResponseHeader::Clear();
+  if (has_kvheader()) {
+    if (kvheader_ != NULL) kvheader_->::cockroach::proto::KVResponseHeader::Clear();
   }
   ::memset(_has_bits_, 0, sizeof(_has_bits_));
   if (_internal_metadata_.have_unknown_fields()) {
@@ -5623,11 +5625,11 @@ bool InternalResolveIntentRangeResponse::MergePartialFromCodedStream(
     tag = p.first;
     if (!p.second) goto handle_unusual;
     switch (::google::protobuf::internal::WireFormatLite::GetTagFieldNumber(tag)) {
-      // optional .cockroach.proto.ResponseHeader header = 1;
+      // optional .cockroach.proto.KVResponseHeader kvheader = 1;
       case 1: {
         if (tag == 10) {
           DO_(::google::protobuf::internal::WireFormatLite::ReadMessageNoVirtual(
-               input, mutable_header()));
+               input, mutable_kvheader()));
         } else {
           goto handle_unusual;
         }
@@ -5660,10 +5662,10 @@ failure:
 void InternalResolveIntentRangeResponse::SerializeWithCachedSizes(
     ::google::protobuf::io::CodedOutputStream* output) const {
   // @@protoc_insertion_point(serialize_start:cockroach.proto.InternalResolveIntentRangeResponse)
-  // optional .cockroach.proto.ResponseHeader header = 1;
-  if (has_header()) {
+  // optional .cockroach.proto.KVResponseHeader kvheader = 1;
+  if (has_kvheader()) {
     ::google::protobuf::internal::WireFormatLite::WriteMessageMaybeToArray(
-      1, *this->header_, output);
+      1, *this->kvheader_, output);
   }
 
   if (_internal_metadata_.have_unknown_fields()) {
@@ -5676,11 +5678,11 @@ void InternalResolveIntentRangeResponse::SerializeWithCachedSizes(
 ::google::protobuf::uint8* InternalResolveIntentRangeResponse::SerializeWithCachedSizesToArray(
     ::google::protobuf::uint8* target) const {
   // @@protoc_insertion_point(serialize_to_array_start:cockroach.proto.InternalResolveIntentRangeResponse)
-  // optional .cockroach.proto.ResponseHeader header = 1;
-  if (has_header()) {
+  // optional .cockroach.proto.KVResponseHeader kvheader = 1;
+  if (has_kvheader()) {
     target = ::google::protobuf::internal::WireFormatLite::
       WriteMessageNoVirtualToArray(
-        1, *this->header_, target);
+        1, *this->kvheader_, target);
   }
 
   if (_internal_metadata_.have_unknown_fields()) {
@@ -5694,11 +5696,11 @@ void InternalResolveIntentRangeResponse::SerializeWithCachedSizes(
 int InternalResolveIntentRangeResponse::ByteSize() const {
   int total_size = 0;
 
-  // optional .cockroach.proto.ResponseHeader header = 1;
-  if (has_header()) {
+  // optional .cockroach.proto.KVResponseHeader kvheader = 1;
+  if (has_kvheader()) {
     total_size += 1 +
       ::google::protobuf::internal::WireFormatLite::MessageSizeNoVirtual(
-        *this->header_);
+        *this->kvheader_);
   }
 
   if (_internal_metadata_.have_unknown_fields()) {
@@ -5727,8 +5729,8 @@ void InternalResolveIntentRangeResponse::MergeFrom(const ::google::protobuf::Mes
 void InternalResolveIntentRangeResponse::MergeFrom(const InternalResolveIntentRangeResponse& from) {
   if (GOOGLE_PREDICT_FALSE(&from == this)) MergeFromFail(__LINE__);
   if (from._has_bits_[0 / 32] & (0xffu << (0 % 32))) {
-    if (from.has_header()) {
-      mutable_header()->::cockroach::proto::ResponseHeader::MergeFrom(from.header());
+    if (from.has_kvheader()) {
+      mutable_kvheader()->::cockroach::proto::KVResponseHeader::MergeFrom(from.kvheader());
     }
   }
   if (from._internal_metadata_.have_unknown_fields()) {
@@ -5758,7 +5760,7 @@ void InternalResolveIntentRangeResponse::Swap(InternalResolveIntentRangeResponse
   InternalSwap(other);
 }
 void InternalResolveIntentRangeResponse::InternalSwap(InternalResolveIntentRangeResponse* other) {
-  std::swap(header_, other->header_);
+  std::swap(kvheader_, other->kvheader_);
   std::swap(_has_bits_[0], other->_has_bits_[0]);
   _internal_metadata_.Swap(&other->_internal_metadata_);
   std::swap(_cached_size_, other->_cached_size_);
@@ -5775,47 +5777,47 @@ void InternalResolveIntentRangeResponse::InternalSwap(InternalResolveIntentRange
 #if PROTOBUF_INLINE_NOT_IN_HEADERS
 // InternalResolveIntentRangeResponse
 
-// optional .cockroach.proto.ResponseHeader header = 1;
-bool InternalResolveIntentRangeResponse::has_header() const {
+// optional .cockroach.proto.KVResponseHeader kvheader = 1;
+bool InternalResolveIntentRangeResponse::has_kvheader() const {
   return (_has_bits_[0] & 0x00000001u) != 0;
 }
-void InternalResolveIntentRangeResponse::set_has_header() {
+void InternalResolveIntentRangeResponse::set_has_kvheader() {
   _has_bits_[0] |= 0x00000001u;
 }
-void InternalResolveIntentRangeResponse::clear_has_header() {
+void InternalResolveIntentRangeResponse::clear_has_kvheader() {
   _has_bits_[0] &= ~0x00000001u;
 }
-void InternalResolveIntentRangeResponse::clear_header() {
-  if (header_ != NULL) header_->::cockroach::proto::ResponseHeader::Clear();
-  clear_has_header();
+void InternalResolveIntentRangeResponse::clear_kvheader() {
+  if (kvheader_ != NULL) kvheader_->::cockroach::proto::KVResponseHeader::Clear();
+  clear_has_kvheader();
 }
- const ::cockroach::proto::ResponseHeader& InternalResolveIntentRangeResponse::header() const {
-  // @@protoc_insertion_point(field_get:cockroach.proto.InternalResolveIntentRangeResponse.header)
-  return header_ != NULL ? *header_ : *default_instance_->header_;
+ const ::cockroach::proto::KVResponseHeader& InternalResolveIntentRangeResponse::kvheader() const {
+  // @@protoc_insertion_point(field_get:cockroach.proto.InternalResolveIntentRangeResponse.kvheader)
+  return kvheader_ != NULL ? *kvheader_ : *default_instance_->kvheader_;
 }
- ::cockroach::proto::ResponseHeader* InternalResolveIntentRangeResponse::mutable_header() {
-  set_has_header();
-  if (header_ == NULL) {
-    header_ = new ::cockroach::proto::ResponseHeader;
+ ::cockroach::proto::KVResponseHeader* InternalResolveIntentRangeResponse::mutable_kvheader() {
+  set_has_kvheader();
+  if (kvheader_ == NULL) {
+    kvheader_ = new ::cockroach::proto::KVResponseHeader;
   }
-  // @@protoc_insertion_point(field_mutable:cockroach.proto.InternalResolveIntentRangeResponse.header)
-  return header_;
+  // @@protoc_insertion_point(field_mutable:cockroach.proto.InternalResolveIntentRangeResponse.kvheader)
+  return kvheader_;
 }
- ::cockroach::proto::ResponseHeader* InternalResolveIntentRangeResponse::release_header() {
-  clear_has_header();
-  ::cockroach::proto::ResponseHeader* temp = header_;
-  header_ = NULL;
+ ::cockroach::proto::KVResponseHeader* InternalResolveIntentRangeResponse::release_kvheader() {
+  clear_has_kvheader();
+  ::cockroach::proto::KVResponseHeader* temp = kvheader_;
+  kvheader_ = NULL;
   return temp;
 }
- void InternalResolveIntentRangeResponse::set_allocated_header(::cockroach::proto::ResponseHeader* header) {
-  delete header_;
-  header_ = header;
-  if (header) {
-    set_has_header();
+ void InternalResolveIntentRangeResponse::set_allocated_kvheader(::cockroach::proto::KVResponseHeader* kvheader) {
+  delete kvheader_;
+  kvheader_ = kvheader;
+  if (kvheader) {
+    set_has_kvheader();
   } else {
-    clear_has_header();
+    clear_has_kvheader();
   }
-  // @@protoc_insertion_point(field_set_allocated:cockroach.proto.InternalResolveIntentRangeResponse.header)
+  // @@protoc_insertion_point(field_set_allocated:cockroach.proto.InternalResolveIntentRangeResponse.kvheader)
 }
 
 #endif  // PROTOBUF_INLINE_NOT_IN_HEADERS
@@ -5823,7 +5825,7 @@ void InternalResolveIntentRangeResponse::clear_header() {
 // ===================================================================
 
 #ifndef _MSC_VER
-const int InternalMergeRequest::kHeaderFieldNumber;
+const int InternalMergeRequest::kKvheaderFieldNumber;
 const int InternalMergeRequest::kValueFieldNumber;
 #endif  // !_MSC_VER
 
@@ -5834,7 +5836,7 @@ InternalMergeRequest::InternalMergeRequest()
 }
 
 void InternalMergeRequest::InitAsDefaultInstance() {
-  header_ = const_cast< ::cockroach::proto::RequestHeader*>(&::cockroach::proto::RequestHeader::default_instance());
+  kvheader_ = const_cast< ::cockroach::proto::KVRequestHeader*>(&::cockroach::proto::KVRequestHeader::default_instance());
   value_ = const_cast< ::cockroach::proto::Value*>(&::cockroach::proto::Value::default_instance());
 }
 
@@ -5848,7 +5850,7 @@ InternalMergeRequest::InternalMergeRequest(const InternalMergeRequest& from)
 
 void InternalMergeRequest::SharedCtor() {
   _cached_size_ = 0;
-  header_ = NULL;
+  kvheader_ = NULL;
   value_ = NULL;
   ::memset(_has_bits_, 0, sizeof(_has_bits_));
 }
@@ -5860,7 +5862,7 @@ InternalMergeRequest::~InternalMergeRequest() {
 
 void InternalMergeRequest::SharedDtor() {
   if (this != default_instance_) {
-    delete header_;
+    delete kvheader_;
     delete value_;
   }
 }
@@ -5892,8 +5894,8 @@ InternalMergeRequest* InternalMergeRequest::New(::google::protobuf::Arena* arena
 
 void InternalMergeRequest::Clear() {
   if (_has_bits_[0 / 32] & 3u) {
-    if (has_header()) {
-      if (header_ != NULL) header_->::cockroach::proto::RequestHeader::Clear();
+    if (has_kvheader()) {
+      if (kvheader_ != NULL) kvheader_->::cockroach::proto::KVRequestHeader::Clear();
     }
     if (has_value()) {
       if (value_ != NULL) value_->::cockroach::proto::Value::Clear();
@@ -5915,11 +5917,11 @@ bool InternalMergeRequest::MergePartialFromCodedStream(
     tag = p.first;
     if (!p.second) goto handle_unusual;
     switch (::google::protobuf::internal::WireFormatLite::GetTagFieldNumber(tag)) {
-      // optional .cockroach.proto.RequestHeader header = 1;
+      // optional .cockroach.proto.KVRequestHeader kvheader = 1;
       case 1: {
         if (tag == 10) {
           DO_(::google::protobuf::internal::WireFormatLite::ReadMessageNoVirtual(
-               input, mutable_header()));
+               input, mutable_kvheader()));
         } else {
           goto handle_unusual;
         }
@@ -5965,10 +5967,10 @@ failure:
 void InternalMergeRequest::SerializeWithCachedSizes(
     ::google::protobuf::io::CodedOutputStream* output) const {
   // @@protoc_insertion_point(serialize_start:cockroach.proto.InternalMergeRequest)
-  // optional .cockroach.proto.RequestHeader header = 1;
-  if (has_header()) {
+  // optional .cockroach.proto.KVRequestHeader kvheader = 1;
+  if (has_kvheader()) {
     ::google::protobuf::internal::WireFormatLite::WriteMessageMaybeToArray(
-      1, *this->header_, output);
+      1, *this->kvheader_, output);
   }
 
   // optional .cockroach.proto.Value value = 2;
@@ -5987,11 +5989,11 @@ void InternalMergeRequest::SerializeWithCachedSizes(
 ::google::protobuf::uint8* InternalMergeRequest::SerializeWithCachedSizesToArray(
     ::google::protobuf::uint8* target) const {
   // @@protoc_insertion_point(serialize_to_array_start:cockroach.proto.InternalMergeRequest)
-  // optional .cockroach.proto.RequestHeader header = 1;
-  if (has_header()) {
+  // optional .cockroach.proto.KVRequestHeader kvheader = 1;
+  if (has_kvheader()) {
     target = ::google::protobuf::internal::WireFormatLite::
       WriteMessageNoVirtualToArray(
-        1, *this->header_, target);
+        1, *this->kvheader_, target);
   }
 
   // optional .cockroach.proto.Value value = 2;
@@ -6013,11 +6015,11 @@ int InternalMergeRequest::ByteSize() const {
   int total_size = 0;
 
   if (_has_bits_[0 / 32] & 3) {
-    // optional .cockroach.proto.RequestHeader header = 1;
-    if (has_header()) {
+    // optional .cockroach.proto.KVRequestHeader kvheader = 1;
+    if (has_kvheader()) {
       total_size += 1 +
         ::google::protobuf::internal::WireFormatLite::MessageSizeNoVirtual(
-          *this->header_);
+          *this->kvheader_);
     }
 
     // optional .cockroach.proto.Value value = 2;
@@ -6054,8 +6056,8 @@ void InternalMergeRequest::MergeFrom(const ::google::protobuf::Message& from) {
 void InternalMergeRequest::MergeFrom(const InternalMergeRequest& from) {
   if (GOOGLE_PREDICT_FALSE(&from == this)) MergeFromFail(__LINE__);
   if (from._has_bits_[0 / 32] & (0xffu << (0 % 32))) {
-    if (from.has_header()) {
-      mutable_header()->::cockroach::proto::RequestHeader::MergeFrom(from.header());
+    if (from.has_kvheader()) {
+      mutable_kvheader()->::cockroach::proto::KVRequestHeader::MergeFrom(from.kvheader());
     }
     if (from.has_value()) {
       mutable_value()->::cockroach::proto::Value::MergeFrom(from.value());
@@ -6088,7 +6090,7 @@ void InternalMergeRequest::Swap(InternalMergeRequest* other) {
   InternalSwap(other);
 }
 void InternalMergeRequest::InternalSwap(InternalMergeRequest* other) {
-  std::swap(header_, other->header_);
+  std::swap(kvheader_, other->kvheader_);
   std::swap(value_, other->value_);
   std::swap(_has_bits_[0], other->_has_bits_[0]);
   _internal_metadata_.Swap(&other->_internal_metadata_);
@@ -6106,47 +6108,47 @@ void InternalMergeRequest::InternalSwap(InternalMergeRequest* other) {
 #if PROTOBUF_INLINE_NOT_IN_HEADERS
 // InternalMergeRequest
 
-// optional .cockroach.proto.RequestHeader header = 1;
-bool InternalMergeRequest::has_header() const {
+// optional .cockroach.proto.KVRequestHeader kvheader = 1;
+bool InternalMergeRequest::has_kvheader() const {
   return (_has_bits_[0] & 0x00000001u) != 0;
 }
-void InternalMergeRequest::set_has_header() {
+void InternalMergeRequest::set_has_kvheader() {
   _has_bits_[0] |= 0x00000001u;
 }
-void InternalMergeRequest::clear_has_header() {
+void InternalMergeRequest::clear_has_kvheader() {
   _has_bits_[0] &= ~0x00000001u;
 }
-void InternalMergeRequest::clear_header() {
-  if (header_ != NULL) header_->::cockroach::proto::RequestHeader::Clear();
-  clear_has_header();
+void InternalMergeRequest::clear_kvheader() {
+  if (kvheader_ != NULL) kvheader_->::cockroach::proto::KVRequestHeader::Clear();
+  clear_has_kvheader();
 }
- const ::cockroach::proto::RequestHeader& InternalMergeRequest::header() const {
-  // @@protoc_insertion_point(field_get:cockroach.proto.InternalMergeRequest.header)
-  return header_ != NULL ? *header_ : *default_instance_->header_;
+ const ::cockroach::proto::KVRequestHeader& InternalMergeRequest::kvheader() const {
+  // @@protoc_insertion_point(field_get:cockroach.proto.InternalMergeRequest.kvheader)
+  return kvheader_ != NULL ? *kvheader_ : *default_instance_->kvheader_;
 }
- ::cockroach::proto::RequestHeader* InternalMergeRequest::mutable_header() {
-  set_has_header();
-  if (header_ == NULL) {
-    header_ = new ::cockroach::proto::RequestHeader;
+ ::cockroach::proto::KVRequestHeader* InternalMergeRequest::mutable_kvheader() {
+  set_has_kvheader();
+  if (kvheader_ == NULL) {
+    kvheader_ = new ::cockroach::proto::KVRequestHeader;
   }
-  // @@protoc_insertion_point(field_mutable:cockroach.proto.InternalMergeRequest.header)
-  return header_;
+  // @@protoc_insertion_point(field_mutable:cockroach.proto.InternalMergeRequest.kvheader)
+  return kvheader_;
 }
- ::cockroach::proto::RequestHeader* InternalMergeRequest::release_header() {
-  clear_has_header();
-  ::cockroach::proto::RequestHeader* temp = header_;
-  header_ = NULL;
+ ::cockroach::proto::KVRequestHeader* InternalMergeRequest::release_kvheader() {
+  clear_has_kvheader();
+  ::cockroach::proto::KVRequestHeader* temp = kvheader_;
+  kvheader_ = NULL;
   return temp;
 }
- void InternalMergeRequest::set_allocated_header(::cockroach::proto::RequestHeader* header) {
-  delete header_;
-  header_ = header;
-  if (header) {
-    set_has_header();
+ void InternalMergeRequest::set_allocated_kvheader(::cockroach::proto::KVRequestHeader* kvheader) {
+  delete kvheader_;
+  kvheader_ = kvheader;
+  if (kvheader) {
+    set_has_kvheader();
   } else {
-    clear_has_header();
+    clear_has_kvheader();
   }
-  // @@protoc_insertion_point(field_set_allocated:cockroach.proto.InternalMergeRequest.header)
+  // @@protoc_insertion_point(field_set_allocated:cockroach.proto.InternalMergeRequest.kvheader)
 }
 
 // optional .cockroach.proto.Value value = 2;
@@ -6197,7 +6199,7 @@ void InternalMergeRequest::clear_value() {
 // ===================================================================
 
 #ifndef _MSC_VER
-const int InternalMergeResponse::kHeaderFieldNumber;
+const int InternalMergeResponse::kKvheaderFieldNumber;
 #endif  // !_MSC_VER
 
 InternalMergeResponse::InternalMergeResponse()
@@ -6207,7 +6209,7 @@ InternalMergeResponse::InternalMergeResponse()
 }
 
 void InternalMergeResponse::InitAsDefaultInstance() {
-  header_ = const_cast< ::cockroach::proto::ResponseHeader*>(&::cockroach::proto::ResponseHeader::default_instance());
+  kvheader_ = const_cast< ::cockroach::proto::KVResponseHeader*>(&::cockroach::proto::KVResponseHeader::default_instance());
 }
 
 InternalMergeResponse::InternalMergeResponse(const InternalMergeResponse& from)
@@ -6220,7 +6222,7 @@ InternalMergeResponse::InternalMergeResponse(const InternalMergeResponse& from)
 
 void InternalMergeResponse::SharedCtor() {
   _cached_size_ = 0;
-  header_ = NULL;
+  kvheader_ = NULL;
   ::memset(_has_bits_, 0, sizeof(_has_bits_));
 }
 
@@ -6231,7 +6233,7 @@ InternalMergeResponse::~InternalMergeResponse() {
 
 void InternalMergeResponse::SharedDtor() {
   if (this != default_instance_) {
-    delete header_;
+    delete kvheader_;
   }
 }
 
@@ -6261,8 +6263,8 @@ InternalMergeResponse* InternalMergeResponse::New(::google::protobuf::Arena* are
 }
 
 void InternalMergeResponse::Clear() {
-  if (has_header()) {
-    if (header_ != NULL) header_->::cockroach::proto::ResponseHeader::Clear();
+  if (has_kvheader()) {
+    if (kvheader_ != NULL) kvheader_->::cockroach::proto::KVResponseHeader::Clear();
   }
   ::memset(_has_bits_, 0, sizeof(_has_bits_));
   if (_internal_metadata_.have_unknown_fields()) {
@@ -6280,11 +6282,11 @@ bool InternalMergeResponse::MergePartialFromCodedStream(
     tag = p.first;
     if (!p.second) goto handle_unusual;
     switch (::google::protobuf::internal::WireFormatLite::GetTagFieldNumber(tag)) {
-      // optional .cockroach.proto.ResponseHeader header = 1;
+      // optional .cockroach.proto.KVResponseHeader kvheader = 1;
       case 1: {
         if (tag == 10) {
           DO_(::google::protobuf::internal::WireFormatLite::ReadMessageNoVirtual(
-               input, mutable_header()));
+               input, mutable_kvheader()));
         } else {
           goto handle_unusual;
         }
@@ -6317,10 +6319,10 @@ failure:
 void InternalMergeResponse::SerializeWithCachedSizes(
     ::google::protobuf::io::CodedOutputStream* output) const {
   // @@protoc_insertion_point(serialize_start:cockroach.proto.InternalMergeResponse)
-  // optional .cockroach.proto.ResponseHeader header = 1;
-  if (has_header()) {
+  // optional .cockroach.proto.KVResponseHeader kvheader = 1;
+  if (has_kvheader()) {
     ::google::protobuf::internal::WireFormatLite::WriteMessageMaybeToArray(
-      1, *this->header_, output);
+      1, *this->kvheader_, output);
   }
 
   if (_internal_metadata_.have_unknown_fields()) {
@@ -6333,11 +6335,11 @@ void InternalMergeResponse::SerializeWithCachedSizes(
 ::google::protobuf::uint8* InternalMergeResponse::SerializeWithCachedSizesToArray(
     ::google::protobuf::uint8* target) const {
   // @@protoc_insertion_point(serialize_to_array_start:cockroach.proto.InternalMergeResponse)
-  // optional .cockroach.proto.ResponseHeader header = 1;
-  if (has_header()) {
+  // optional .cockroach.proto.KVResponseHeader kvheader = 1;
+  if (has_kvheader()) {
     target = ::google::protobuf::internal::WireFormatLite::
       WriteMessageNoVirtualToArray(
-        1, *this->header_, target);
+        1, *this->kvheader_, target);
   }
 
   if (_internal_metadata_.have_unknown_fields()) {
@@ -6351,11 +6353,11 @@ void InternalMergeResponse::SerializeWithCachedSizes(
 int InternalMergeResponse::ByteSize() const {
   int total_size = 0;
 
-  // optional .cockroach.proto.ResponseHeader header = 1;
-  if (has_header()) {
+  // optional .cockroach.proto.KVResponseHeader kvheader = 1;
+  if (has_kvheader()) {
     total_size += 1 +
       ::google::protobuf::internal::WireFormatLite::MessageSizeNoVirtual(
-        *this->header_);
+        *this->kvheader_);
   }
 
   if (_internal_metadata_.have_unknown_fields()) {
@@ -6384,8 +6386,8 @@ void InternalMergeResponse::MergeFrom(const ::google::protobuf::Message& from) {
 void InternalMergeResponse::MergeFrom(const InternalMergeResponse& from) {
   if (GOOGLE_PREDICT_FALSE(&from == this)) MergeFromFail(__LINE__);
   if (from._has_bits_[0 / 32] & (0xffu << (0 % 32))) {
-    if (from.has_header()) {
-      mutable_header()->::cockroach::proto::ResponseHeader::MergeFrom(from.header());
+    if (from.has_kvheader()) {
+      mutable_kvheader()->::cockroach::proto::KVResponseHeader::MergeFrom(from.kvheader());
     }
   }
   if (from._internal_metadata_.have_unknown_fields()) {
@@ -6415,7 +6417,7 @@ void InternalMergeResponse::Swap(InternalMergeResponse* other) {
   InternalSwap(other);
 }
 void InternalMergeResponse::InternalSwap(InternalMergeResponse* other) {
-  std::swap(header_, other->header_);
+  std::swap(kvheader_, other->kvheader_);
   std::swap(_has_bits_[0], other->_has_bits_[0]);
   _internal_metadata_.Swap(&other->_internal_metadata_);
   std::swap(_cached_size_, other->_cached_size_);
@@ -6432,47 +6434,47 @@ void InternalMergeResponse::InternalSwap(InternalMergeResponse* other) {
 #if PROTOBUF_INLINE_NOT_IN_HEADERS
 // InternalMergeResponse
 
-// optional .cockroach.proto.ResponseHeader header = 1;
-bool InternalMergeResponse::has_header() const {
+// optional .cockroach.proto.KVResponseHeader kvheader = 1;
+bool InternalMergeResponse::has_kvheader() const {
   return (_has_bits_[0] & 0x00000001u) != 0;
 }
-void InternalMergeResponse::set_has_header() {
+void InternalMergeResponse::set_has_kvheader() {
   _has_bits_[0] |= 0x00000001u;
 }
-void InternalMergeResponse::clear_has_header() {
+void InternalMergeResponse::clear_has_kvheader() {
   _has_bits_[0] &= ~0x00000001u;
 }
-void InternalMergeResponse::clear_header() {
-  if (header_ != NULL) header_->::cockroach::proto::ResponseHeader::Clear();
-  clear_has_header();
+void InternalMergeResponse::clear_kvheader() {
+  if (kvheader_ != NULL) kvheader_->::cockroach::proto::KVResponseHeader::Clear();
+  clear_has_kvheader();
 }
- const ::cockroach::proto::ResponseHeader& InternalMergeResponse::header() const {
-  // @@protoc_insertion_point(field_get:cockroach.proto.InternalMergeResponse.header)
-  return header_ != NULL ? *header_ : *default_instance_->header_;
+ const ::cockroach::proto::KVResponseHeader& InternalMergeResponse::kvheader() const {
+  // @@protoc_insertion_point(field_get:cockroach.proto.InternalMergeResponse.kvheader)
+  return kvheader_ != NULL ? *kvheader_ : *default_instance_->kvheader_;
 }
- ::cockroach::proto::ResponseHeader* InternalMergeResponse::mutable_header() {
-  set_has_header();
-  if (header_ == NULL) {
-    header_ = new ::cockroach::proto::ResponseHeader;
+ ::cockroach::proto::KVResponseHeader* InternalMergeResponse::mutable_kvheader() {
+  set_has_kvheader();
+  if (kvheader_ == NULL) {
+    kvheader_ = new ::cockroach::proto::KVResponseHeader;
   }
-  // @@protoc_insertion_point(field_mutable:cockroach.proto.InternalMergeResponse.header)
-  return header_;
+  // @@protoc_insertion_point(field_mutable:cockroach.proto.InternalMergeResponse.kvheader)
+  return kvheader_;
 }
- ::cockroach::proto::ResponseHeader* InternalMergeResponse::release_header() {
-  clear_has_header();
-  ::cockroach::proto::ResponseHeader* temp = header_;
-  header_ = NULL;
+ ::cockroach::proto::KVResponseHeader* InternalMergeResponse::release_kvheader() {
+  clear_has_kvheader();
+  ::cockroach::proto::KVResponseHeader* temp = kvheader_;
+  kvheader_ = NULL;
   return temp;
 }
- void InternalMergeResponse::set_allocated_header(::cockroach::proto::ResponseHeader* header) {
-  delete header_;
-  header_ = header;
-  if (header) {
-    set_has_header();
+ void InternalMergeResponse::set_allocated_kvheader(::cockroach::proto::KVResponseHeader* kvheader) {
+  delete kvheader_;
+  kvheader_ = kvheader;
+  if (kvheader) {
+    set_has_kvheader();
   } else {
-    clear_has_header();
+    clear_has_kvheader();
   }
-  // @@protoc_insertion_point(field_set_allocated:cockroach.proto.InternalMergeResponse.header)
+  // @@protoc_insertion_point(field_set_allocated:cockroach.proto.InternalMergeResponse.kvheader)
 }
 
 #endif  // PROTOBUF_INLINE_NOT_IN_HEADERS
@@ -6480,7 +6482,7 @@ void InternalMergeResponse::clear_header() {
 // ===================================================================
 
 #ifndef _MSC_VER
-const int InternalTruncateLogRequest::kHeaderFieldNumber;
+const int InternalTruncateLogRequest::kKvheaderFieldNumber;
 const int InternalTruncateLogRequest::kIndexFieldNumber;
 #endif  // !_MSC_VER
 
@@ -6491,7 +6493,7 @@ InternalTruncateLogRequest::InternalTruncateLogRequest()
 }
 
 void InternalTruncateLogRequest::InitAsDefaultInstance() {
-  header_ = const_cast< ::cockroach::proto::RequestHeader*>(&::cockroach::proto::RequestHeader::default_instance());
+  kvheader_ = const_cast< ::cockroach::proto::KVRequestHeader*>(&::cockroach::proto::KVRequestHeader::default_instance());
 }
 
 InternalTruncateLogRequest::InternalTruncateLogRequest(const InternalTruncateLogRequest& from)
@@ -6504,7 +6506,7 @@ InternalTruncateLogRequest::InternalTruncateLogRequest(const InternalTruncateLog
 
 void InternalTruncateLogRequest::SharedCtor() {
   _cached_size_ = 0;
-  header_ = NULL;
+  kvheader_ = NULL;
   index_ = GOOGLE_ULONGLONG(0);
   ::memset(_has_bits_, 0, sizeof(_has_bits_));
 }
@@ -6516,7 +6518,7 @@ InternalTruncateLogRequest::~InternalTruncateLogRequest() {
 
 void InternalTruncateLogRequest::SharedDtor() {
   if (this != default_instance_) {
-    delete header_;
+    delete kvheader_;
   }
 }
 
@@ -6547,8 +6549,8 @@ InternalTruncateLogRequest* InternalTruncateLogRequest::New(::google::protobuf::
 
 void InternalTruncateLogRequest::Clear() {
   if (_has_bits_[0 / 32] & 3u) {
-    if (has_header()) {
-      if (header_ != NULL) header_->::cockroach::proto::RequestHeader::Clear();
+    if (has_kvheader()) {
+      if (kvheader_ != NULL) kvheader_->::cockroach::proto::KVRequestHeader::Clear();
     }
     index_ = GOOGLE_ULONGLONG(0);
   }
@@ -6568,11 +6570,11 @@ bool InternalTruncateLogRequest::MergePartialFromCodedStream(
     tag = p.first;
     if (!p.second) goto handle_unusual;
     switch (::google::protobuf::internal::WireFormatLite::GetTagFieldNumber(tag)) {
-      // optional .cockroach.proto.RequestHeader header = 1;
+      // optional .cockroach.proto.KVRequestHeader kvheader = 1;
       case 1: {
         if (tag == 10) {
           DO_(::google::protobuf::internal::WireFormatLite::ReadMessageNoVirtual(
-               input, mutable_header()));
+               input, mutable_kvheader()));
         } else {
           goto handle_unusual;
         }
@@ -6620,10 +6622,10 @@ failure:
 void InternalTruncateLogRequest::SerializeWithCachedSizes(
     ::google::protobuf::io::CodedOutputStream* output) const {
   // @@protoc_insertion_point(serialize_start:cockroach.proto.InternalTruncateLogRequest)
-  // optional .cockroach.proto.RequestHeader header = 1;
-  if (has_header()) {
+  // optional .cockroach.proto.KVRequestHeader kvheader = 1;
+  if (has_kvheader()) {
     ::google::protobuf::internal::WireFormatLite::WriteMessageMaybeToArray(
-      1, *this->header_, output);
+      1, *this->kvheader_, output);
   }
 
   // optional uint64 index = 2;
@@ -6641,11 +6643,11 @@ void InternalTruncateLogRequest::SerializeWithCachedSizes(
 ::google::protobuf::uint8* InternalTruncateLogRequest::SerializeWithCachedSizesToArray(
     ::google::protobuf::uint8* target) const {
   // @@protoc_insertion_point(serialize_to_array_start:cockroach.proto.InternalTruncateLogRequest)
-  // optional .cockroach.proto.RequestHeader header = 1;
-  if (has_header()) {
+  // optional .cockroach.proto.KVRequestHeader kvheader = 1;
+  if (has_kvheader()) {
     target = ::google::protobuf::internal::WireFormatLite::
       WriteMessageNoVirtualToArray(
-        1, *this->header_, target);
+        1, *this->kvheader_, target);
   }
 
   // optional uint64 index = 2;
@@ -6665,11 +6667,11 @@ int InternalTruncateLogRequest::ByteSize() const {
   int total_size = 0;
 
   if (_has_bits_[0 / 32] & 3) {
-    // optional .cockroach.proto.RequestHeader header = 1;
-    if (has_header()) {
+    // optional .cockroach.proto.KVRequestHeader kvheader = 1;
+    if (has_kvheader()) {
       total_size += 1 +
         ::google::protobuf::internal::WireFormatLite::MessageSizeNoVirtual(
-          *this->header_);
+          *this->kvheader_);
     }
 
     // optional uint64 index = 2;
@@ -6706,8 +6708,8 @@ void InternalTruncateLogRequest::MergeFrom(const ::google::protobuf::Message& fr
 void InternalTruncateLogRequest::MergeFrom(const InternalTruncateLogRequest& from) {
   if (GOOGLE_PREDICT_FALSE(&from == this)) MergeFromFail(__LINE__);
   if (from._has_bits_[0 / 32] & (0xffu << (0 % 32))) {
-    if (from.has_header()) {
-      mutable_header()->::cockroach::proto::RequestHeader::MergeFrom(from.header());
+    if (from.has_kvheader()) {
+      mutable_kvheader()->::cockroach::proto::KVRequestHeader::MergeFrom(from.kvheader());
     }
     if (from.has_index()) {
       set_index(from.index());
@@ -6740,7 +6742,7 @@ void InternalTruncateLogRequest::Swap(InternalTruncateLogRequest* other) {
   InternalSwap(other);
 }
 void InternalTruncateLogRequest::InternalSwap(InternalTruncateLogRequest* other) {
-  std::swap(header_, other->header_);
+  std::swap(kvheader_, other->kvheader_);
   std::swap(index_, other->index_);
   std::swap(_has_bits_[0], other->_has_bits_[0]);
   _internal_metadata_.Swap(&other->_internal_metadata_);
@@ -6758,47 +6760,47 @@ void InternalTruncateLogRequest::InternalSwap(InternalTruncateLogRequest* other)
 #if PROTOBUF_INLINE_NOT_IN_HEADERS
 // InternalTruncateLogRequest
 
-// optional .cockroach.proto.RequestHeader header = 1;
-bool InternalTruncateLogRequest::has_header() const {
+// optional .cockroach.proto.KVRequestHeader kvheader = 1;
+bool InternalTruncateLogRequest::has_kvheader() const {
   return (_has_bits_[0] & 0x00000001u) != 0;
 }
-void InternalTruncateLogRequest::set_has_header() {
+void InternalTruncateLogRequest::set_has_kvheader() {
   _has_bits_[0] |= 0x00000001u;
 }
-void InternalTruncateLogRequest::clear_has_header() {
+void InternalTruncateLogRequest::clear_has_kvheader() {
   _has_bits_[0] &= ~0x00000001u;
 }
-void InternalTruncateLogRequest::clear_header() {
-  if (header_ != NULL) header_->::cockroach::proto::RequestHeader::Clear();
-  clear_has_header();
+void InternalTruncateLogRequest::clear_kvheader() {
+  if (kvheader_ != NULL) kvheader_->::cockroach::proto::KVRequestHeader::Clear();
+  clear_has_kvheader();
 }
- const ::cockroach::proto::RequestHeader& InternalTruncateLogRequest::header() const {
-  // @@protoc_insertion_point(field_get:cockroach.proto.InternalTruncateLogRequest.header)
-  return header_ != NULL ? *header_ : *default_instance_->header_;
+ const ::cockroach::proto::KVRequestHeader& InternalTruncateLogRequest::kvheader() const {
+  // @@protoc_insertion_point(field_get:cockroach.proto.InternalTruncateLogRequest.kvheader)
+  return kvheader_ != NULL ? *kvheader_ : *default_instance_->kvheader_;
 }
- ::cockroach::proto::RequestHeader* InternalTruncateLogRequest::mutable_header() {
-  set_has_header();
-  if (header_ == NULL) {
-    header_ = new ::cockroach::proto::RequestHeader;
+ ::cockroach::proto::KVRequestHeader* InternalTruncateLogRequest::mutable_kvheader() {
+  set_has_kvheader();
+  if (kvheader_ == NULL) {
+    kvheader_ = new ::cockroach::proto::KVRequestHeader;
   }
-  // @@protoc_insertion_point(field_mutable:cockroach.proto.InternalTruncateLogRequest.header)
-  return header_;
+  // @@protoc_insertion_point(field_mutable:cockroach.proto.InternalTruncateLogRequest.kvheader)
+  return kvheader_;
 }
- ::cockroach::proto::RequestHeader* InternalTruncateLogRequest::release_header() {
-  clear_has_header();
-  ::cockroach::proto::RequestHeader* temp = header_;
-  header_ = NULL;
+ ::cockroach::proto::KVRequestHeader* InternalTruncateLogRequest::release_kvheader() {
+  clear_has_kvheader();
+  ::cockroach::proto::KVRequestHeader* temp = kvheader_;
+  kvheader_ = NULL;
   return temp;
 }
- void InternalTruncateLogRequest::set_allocated_header(::cockroach::proto::RequestHeader* header) {
-  delete header_;
-  header_ = header;
-  if (header) {
-    set_has_header();
+ void InternalTruncateLogRequest::set_allocated_kvheader(::cockroach::proto::KVRequestHeader* kvheader) {
+  delete kvheader_;
+  kvheader_ = kvheader;
+  if (kvheader) {
+    set_has_kvheader();
   } else {
-    clear_has_header();
+    clear_has_kvheader();
   }
-  // @@protoc_insertion_point(field_set_allocated:cockroach.proto.InternalTruncateLogRequest.header)
+  // @@protoc_insertion_point(field_set_allocated:cockroach.proto.InternalTruncateLogRequest.kvheader)
 }
 
 // optional uint64 index = 2;
@@ -6830,7 +6832,7 @@ void InternalTruncateLogRequest::clear_index() {
 // ===================================================================
 
 #ifndef _MSC_VER
-const int InternalTruncateLogResponse::kHeaderFieldNumber;
+const int InternalTruncateLogResponse::kKvheaderFieldNumber;
 #endif  // !_MSC_VER
 
 InternalTruncateLogResponse::InternalTruncateLogResponse()
@@ -6840,7 +6842,7 @@ InternalTruncateLogResponse::InternalTruncateLogResponse()
 }
 
 void InternalTruncateLogResponse::InitAsDefaultInstance() {
-  header_ = const_cast< ::cockroach::proto::ResponseHeader*>(&::cockroach::proto::ResponseHeader::default_instance());
+  kvheader_ = const_cast< ::cockroach::proto::KVResponseHeader*>(&::cockroach::proto::KVResponseHeader::default_instance());
 }
 
 InternalTruncateLogResponse::InternalTruncateLogResponse(const InternalTruncateLogResponse& from)
@@ -6853,7 +6855,7 @@ InternalTruncateLogResponse::InternalTruncateLogResponse(const InternalTruncateL
 
 void InternalTruncateLogResponse::SharedCtor() {
   _cached_size_ = 0;
-  header_ = NULL;
+  kvheader_ = NULL;
   ::memset(_has_bits_, 0, sizeof(_has_bits_));
 }
 
@@ -6864,7 +6866,7 @@ InternalTruncateLogResponse::~InternalTruncateLogResponse() {
 
 void InternalTruncateLogResponse::SharedDtor() {
   if (this != default_instance_) {
-    delete header_;
+    delete kvheader_;
   }
 }
 
@@ -6894,8 +6896,8 @@ InternalTruncateLogResponse* InternalTruncateLogResponse::New(::google::protobuf
 }
 
 void InternalTruncateLogResponse::Clear() {
-  if (has_header()) {
-    if (header_ != NULL) header_->::cockroach::proto::ResponseHeader::Clear();
+  if (has_kvheader()) {
+    if (kvheader_ != NULL) kvheader_->::cockroach::proto::KVResponseHeader::Clear();
   }
   ::memset(_has_bits_, 0, sizeof(_has_bits_));
   if (_internal_metadata_.have_unknown_fields()) {
@@ -6913,11 +6915,11 @@ bool InternalTruncateLogResponse::MergePartialFromCodedStream(
     tag = p.first;
     if (!p.second) goto handle_unusual;
     switch (::google::protobuf::internal::WireFormatLite::GetTagFieldNumber(tag)) {
-      // optional .cockroach.proto.ResponseHeader header = 1;
+      // optional .cockroach.proto.KVResponseHeader kvheader = 1;
       case 1: {
         if (tag == 10) {
           DO_(::google::protobuf::internal::WireFormatLite::ReadMessageNoVirtual(
-               input, mutable_header()));
+               input, mutable_kvheader()));
         } else {
           goto handle_unusual;
         }
@@ -6950,10 +6952,10 @@ failure:
 void InternalTruncateLogResponse::SerializeWithCachedSizes(
     ::google::protobuf::io::CodedOutputStream* output) const {
   // @@protoc_insertion_point(serialize_start:cockroach.proto.InternalTruncateLogResponse)
-  // optional .cockroach.proto.ResponseHeader header = 1;
-  if (has_header()) {
+  // optional .cockroach.proto.KVResponseHeader kvheader = 1;
+  if (has_kvheader()) {
     ::google::protobuf::internal::WireFormatLite::WriteMessageMaybeToArray(
-      1, *this->header_, output);
+      1, *this->kvheader_, output);
   }
 
   if (_internal_metadata_.have_unknown_fields()) {
@@ -6966,11 +6968,11 @@ void InternalTruncateLogResponse::SerializeWithCachedSizes(
 ::google::protobuf::uint8* InternalTruncateLogResponse::SerializeWithCachedSizesToArray(
     ::google::protobuf::uint8* target) const {
   // @@protoc_insertion_point(serialize_to_array_start:cockroach.proto.InternalTruncateLogResponse)
-  // optional .cockroach.proto.ResponseHeader header = 1;
-  if (has_header()) {
+  // optional .cockroach.proto.KVResponseHeader kvheader = 1;
+  if (has_kvheader()) {
     target = ::google::protobuf::internal::WireFormatLite::
       WriteMessageNoVirtualToArray(
-        1, *this->header_, target);
+        1, *this->kvheader_, target);
   }
 
   if (_internal_metadata_.have_unknown_fields()) {
@@ -6984,11 +6986,11 @@ void InternalTruncateLogResponse::SerializeWithCachedSizes(
 int InternalTruncateLogResponse::ByteSize() const {
   int total_size = 0;
 
-  // optional .cockroach.proto.ResponseHeader header = 1;
-  if (has_header()) {
+  // optional .cockroach.proto.KVResponseHeader kvheader = 1;
+  if (has_kvheader()) {
     total_size += 1 +
       ::google::protobuf::internal::WireFormatLite::MessageSizeNoVirtual(
-        *this->header_);
+        *this->kvheader_);
   }
 
   if (_internal_metadata_.have_unknown_fields()) {
@@ -7017,8 +7019,8 @@ void InternalTruncateLogResponse::MergeFrom(const ::google::protobuf::Message& f
 void InternalTruncateLogResponse::MergeFrom(const InternalTruncateLogResponse& from) {
   if (GOOGLE_PREDICT_FALSE(&from == this)) MergeFromFail(__LINE__);
   if (from._has_bits_[0 / 32] & (0xffu << (0 % 32))) {
-    if (from.has_header()) {
-      mutable_header()->::cockroach::proto::ResponseHeader::MergeFrom(from.header());
+    if (from.has_kvheader()) {
+      mutable_kvheader()->::cockroach::proto::KVResponseHeader::MergeFrom(from.kvheader());
     }
   }
   if (from._internal_metadata_.have_unknown_fields()) {
@@ -7048,7 +7050,7 @@ void InternalTruncateLogResponse::Swap(InternalTruncateLogResponse* other) {
   InternalSwap(other);
 }
 void InternalTruncateLogResponse::InternalSwap(InternalTruncateLogResponse* other) {
-  std::swap(header_, other->header_);
+  std::swap(kvheader_, other->kvheader_);
   std::swap(_has_bits_[0], other->_has_bits_[0]);
   _internal_metadata_.Swap(&other->_internal_metadata_);
   std::swap(_cached_size_, other->_cached_size_);
@@ -7065,47 +7067,47 @@ void InternalTruncateLogResponse::InternalSwap(InternalTruncateLogResponse* othe
 #if PROTOBUF_INLINE_NOT_IN_HEADERS
 // InternalTruncateLogResponse
 
-// optional .cockroach.proto.ResponseHeader header = 1;
-bool InternalTruncateLogResponse::has_header() const {
+// optional .cockroach.proto.KVResponseHeader kvheader = 1;
+bool InternalTruncateLogResponse::has_kvheader() const {
   return (_has_bits_[0] & 0x00000001u) != 0;
 }
-void InternalTruncateLogResponse::set_has_header() {
+void InternalTruncateLogResponse::set_has_kvheader() {
   _has_bits_[0] |= 0x00000001u;
 }
-void InternalTruncateLogResponse::clear_has_header() {
+void InternalTruncateLogResponse::clear_has_kvheader() {
   _has_bits_[0] &= ~0x00000001u;
 }
-void InternalTruncateLogResponse::clear_header() {
-  if (header_ != NULL) header_->::cockroach::proto::ResponseHeader::Clear();
-  clear_has_header();
+void InternalTruncateLogResponse::clear_kvheader() {
+  if (kvheader_ != NULL) kvheader_->::cockroach::proto::KVResponseHeader::Clear();
+  clear_has_kvheader();
 }
- const ::cockroach::proto::ResponseHeader& InternalTruncateLogResponse::header() const {
-  // @@protoc_insertion_point(field_get:cockroach.proto.InternalTruncateLogResponse.header)
-  return header_ != NULL ? *header_ : *default_instance_->header_;
+ const ::cockroach::proto::KVResponseHeader& InternalTruncateLogResponse::kvheader() const {
+  // @@protoc_insertion_point(field_get:cockroach.proto.InternalTruncateLogResponse.kvheader)
+  return kvheader_ != NULL ? *kvheader_ : *default_instance_->kvheader_;
 }
- ::cockroach::proto::ResponseHeader* InternalTruncateLogResponse::mutable_header() {
-  set_has_header();
-  if (header_ == NULL) {
-    header_ = new ::cockroach::proto::ResponseHeader;
+ ::cockroach::proto::KVResponseHeader* InternalTruncateLogResponse::mutable_kvheader() {
+  set_has_kvheader();
+  if (kvheader_ == NULL) {
+    kvheader_ = new ::cockroach::proto::KVResponseHeader;
   }
-  // @@protoc_insertion_point(field_mutable:cockroach.proto.InternalTruncateLogResponse.header)
-  return header_;
+  // @@protoc_insertion_point(field_mutable:cockroach.proto.InternalTruncateLogResponse.kvheader)
+  return kvheader_;
 }
- ::cockroach::proto::ResponseHeader* InternalTruncateLogResponse::release_header() {
-  clear_has_header();
-  ::cockroach::proto::ResponseHeader* temp = header_;
-  header_ = NULL;
+ ::cockroach::proto::KVResponseHeader* InternalTruncateLogResponse::release_kvheader() {
+  clear_has_kvheader();
+  ::cockroach::proto::KVResponseHeader* temp = kvheader_;
+  kvheader_ = NULL;
   return temp;
 }
- void InternalTruncateLogResponse::set_allocated_header(::cockroach::proto::ResponseHeader* header) {
-  delete header_;
-  header_ = header;
-  if (header) {
-    set_has_header();
+ void InternalTruncateLogResponse::set_allocated_kvheader(::cockroach::proto::KVResponseHeader* kvheader) {
+  delete kvheader_;
+  kvheader_ = kvheader;
+  if (kvheader) {
+    set_has_kvheader();
   } else {
-    clear_has_header();
+    clear_has_kvheader();
   }
-  // @@protoc_insertion_point(field_set_allocated:cockroach.proto.InternalTruncateLogResponse.header)
+  // @@protoc_insertion_point(field_set_allocated:cockroach.proto.InternalTruncateLogResponse.kvheader)
 }
 
 #endif  // PROTOBUF_INLINE_NOT_IN_HEADERS
@@ -7113,7 +7115,7 @@ void InternalTruncateLogResponse::clear_header() {
 // ===================================================================
 
 #ifndef _MSC_VER
-const int InternalLeaderLeaseRequest::kHeaderFieldNumber;
+const int InternalLeaderLeaseRequest::kKvheaderFieldNumber;
 const int InternalLeaderLeaseRequest::kLeaseFieldNumber;
 #endif  // !_MSC_VER
 
@@ -7124,7 +7126,7 @@ InternalLeaderLeaseRequest::InternalLeaderLeaseRequest()
 }
 
 void InternalLeaderLeaseRequest::InitAsDefaultInstance() {
-  header_ = const_cast< ::cockroach::proto::RequestHeader*>(&::cockroach::proto::RequestHeader::default_instance());
+  kvheader_ = const_cast< ::cockroach::proto::KVRequestHeader*>(&::cockroach::proto::KVRequestHeader::default_instance());
   lease_ = const_cast< ::cockroach::proto::Lease*>(&::cockroach::proto::Lease::default_instance());
 }
 
@@ -7138,7 +7140,7 @@ InternalLeaderLeaseRequest::InternalLeaderLeaseRequest(const InternalLeaderLease
 
 void InternalLeaderLeaseRequest::SharedCtor() {
   _cached_size_ = 0;
-  header_ = NULL;
+  kvheader_ = NULL;
   lease_ = NULL;
   ::memset(_has_bits_, 0, sizeof(_has_bits_));
 }
@@ -7150,7 +7152,7 @@ InternalLeaderLeaseRequest::~InternalLeaderLeaseRequest() {
 
 void InternalLeaderLeaseRequest::SharedDtor() {
   if (this != default_instance_) {
-    delete header_;
+    delete kvheader_;
     delete lease_;
   }
 }
@@ -7182,8 +7184,8 @@ InternalLeaderLeaseRequest* InternalLeaderLeaseRequest::New(::google::protobuf::
 
 void InternalLeaderLeaseRequest::Clear() {
   if (_has_bits_[0 / 32] & 3u) {
-    if (has_header()) {
-      if (header_ != NULL) header_->::cockroach::proto::RequestHeader::Clear();
+    if (has_kvheader()) {
+      if (kvheader_ != NULL) kvheader_->::cockroach::proto::KVRequestHeader::Clear();
     }
     if (has_lease()) {
       if (lease_ != NULL) lease_->::cockroach::proto::Lease::Clear();
@@ -7205,11 +7207,11 @@ bool InternalLeaderLeaseRequest::MergePartialFromCodedStream(
     tag = p.first;
     if (!p.second) goto handle_unusual;
     switch (::google::protobuf::internal::WireFormatLite::GetTagFieldNumber(tag)) {
-      // optional .cockroach.proto.RequestHeader header = 1;
+      // optional .cockroach.proto.KVRequestHeader kvheader = 1;
       case 1: {
         if (tag == 10) {
           DO_(::google::protobuf::internal::WireFormatLite::ReadMessageNoVirtual(
-               input, mutable_header()));
+               input, mutable_kvheader()));
         } else {
           goto handle_unusual;
         }
@@ -7255,10 +7257,10 @@ failure:
 void InternalLeaderLeaseRequest::SerializeWithCachedSizes(
     ::google::protobuf::io::CodedOutputStream* output) const {
   // @@protoc_insertion_point(serialize_start:cockroach.proto.InternalLeaderLeaseRequest)
-  // optional .cockroach.proto.RequestHeader header = 1;
-  if (has_header()) {
+  // optional .cockroach.proto.KVRequestHeader kvheader = 1;
+  if (has_kvheader()) {
     ::google::protobuf::internal::WireFormatLite::WriteMessageMaybeToArray(
-      1, *this->header_, output);
+      1, *this->kvheader_, output);
   }
 
   // optional .cockroach.proto.Lease lease = 2;
@@ -7277,11 +7279,11 @@ void InternalLeaderLeaseRequest::SerializeWithCachedSizes(
 ::google::protobuf::uint8* InternalLeaderLeaseRequest::SerializeWithCachedSizesToArray(
     ::google::protobuf::uint8* target) const {
   // @@protoc_insertion_point(serialize_to_array_start:cockroach.proto.InternalLeaderLeaseRequest)
-  // optional .cockroach.proto.RequestHeader header = 1;
-  if (has_header()) {
+  // optional .cockroach.proto.KVRequestHeader kvheader = 1;
+  if (has_kvheader()) {
     target = ::google::protobuf::internal::WireFormatLite::
       WriteMessageNoVirtualToArray(
-        1, *this->header_, target);
+        1, *this->kvheader_, target);
   }
 
   // optional .cockroach.proto.Lease lease = 2;
@@ -7303,11 +7305,11 @@ int InternalLeaderLeaseRequest::ByteSize() const {
   int total_size = 0;
 
   if (_has_bits_[0 / 32] & 3) {
-    // optional .cockroach.proto.RequestHeader header = 1;
-    if (has_header()) {
+    // optional .cockroach.proto.KVRequestHeader kvheader = 1;
+    if (has_kvheader()) {
       total_size += 1 +
         ::google::protobuf::internal::WireFormatLite::MessageSizeNoVirtual(
-          *this->header_);
+          *this->kvheader_);
     }
 
     // optional .cockroach.proto.Lease lease = 2;
@@ -7344,8 +7346,8 @@ void InternalLeaderLeaseRequest::MergeFrom(const ::google::protobuf::Message& fr
 void InternalLeaderLeaseRequest::MergeFrom(const InternalLeaderLeaseRequest& from) {
   if (GOOGLE_PREDICT_FALSE(&from == this)) MergeFromFail(__LINE__);
   if (from._has_bits_[0 / 32] & (0xffu << (0 % 32))) {
-    if (from.has_header()) {
-      mutable_header()->::cockroach::proto::RequestHeader::MergeFrom(from.header());
+    if (from.has_kvheader()) {
+      mutable_kvheader()->::cockroach::proto::KVRequestHeader::MergeFrom(from.kvheader());
     }
     if (from.has_lease()) {
       mutable_lease()->::cockroach::proto::Lease::MergeFrom(from.lease());
@@ -7378,7 +7380,7 @@ void InternalLeaderLeaseRequest::Swap(InternalLeaderLeaseRequest* other) {
   InternalSwap(other);
 }
 void InternalLeaderLeaseRequest::InternalSwap(InternalLeaderLeaseRequest* other) {
-  std::swap(header_, other->header_);
+  std::swap(kvheader_, other->kvheader_);
   std::swap(lease_, other->lease_);
   std::swap(_has_bits_[0], other->_has_bits_[0]);
   _internal_metadata_.Swap(&other->_internal_metadata_);
@@ -7396,47 +7398,47 @@ void InternalLeaderLeaseRequest::InternalSwap(InternalLeaderLeaseRequest* other)
 #if PROTOBUF_INLINE_NOT_IN_HEADERS
 // InternalLeaderLeaseRequest
 
-// optional .cockroach.proto.RequestHeader header = 1;
-bool InternalLeaderLeaseRequest::has_header() const {
+// optional .cockroach.proto.KVRequestHeader kvheader = 1;
+bool InternalLeaderLeaseRequest::has_kvheader() const {
   return (_has_bits_[0] & 0x00000001u) != 0;
 }
-void InternalLeaderLeaseRequest::set_has_header() {
+void InternalLeaderLeaseRequest::set_has_kvheader() {
   _has_bits_[0] |= 0x00000001u;
 }
-void InternalLeaderLeaseRequest::clear_has_header() {
+void InternalLeaderLeaseRequest::clear_has_kvheader() {
   _has_bits_[0] &= ~0x00000001u;
 }
-void InternalLeaderLeaseRequest::clear_header() {
-  if (header_ != NULL) header_->::cockroach::proto::RequestHeader::Clear();
-  clear_has_header();
+void InternalLeaderLeaseRequest::clear_kvheader() {
+  if (kvheader_ != NULL) kvheader_->::cockroach::proto::KVRequestHeader::Clear();
+  clear_has_kvheader();
 }
- const ::cockroach::proto::RequestHeader& InternalLeaderLeaseRequest::header() const {
-  // @@protoc_insertion_point(field_get:cockroach.proto.InternalLeaderLeaseRequest.header)
-  return header_ != NULL ? *header_ : *default_instance_->header_;
+ const ::cockroach::proto::KVRequestHeader& InternalLeaderLeaseRequest::kvheader() const {
+  // @@protoc_insertion_point(field_get:cockroach.proto.InternalLeaderLeaseRequest.kvheader)
+  return kvheader_ != NULL ? *kvheader_ : *default_instance_->kvheader_;
 }
- ::cockroach::proto::RequestHeader* InternalLeaderLeaseRequest::mutable_header() {
-  set_has_header();
-  if (header_ == NULL) {
-    header_ = new ::cockroach::proto::RequestHeader;
+ ::cockroach::proto::KVRequestHeader* InternalLeaderLeaseRequest::mutable_kvheader() {
+  set_has_kvheader();
+  if (kvheader_ == NULL) {
+    kvheader_ = new ::cockroach::proto::KVRequestHeader;
   }
-  // @@protoc_insertion_point(field_mutable:cockroach.proto.InternalLeaderLeaseRequest.header)
-  return header_;
+  // @@protoc_insertion_point(field_mutable:cockroach.proto.InternalLeaderLeaseRequest.kvheader)
+  return kvheader_;
 }
- ::cockroach::proto::RequestHeader* InternalLeaderLeaseRequest::release_header() {
-  clear_has_header();
-  ::cockroach::proto::RequestHeader* temp = header_;
-  header_ = NULL;
+ ::cockroach::proto::KVRequestHeader* InternalLeaderLeaseRequest::release_kvheader() {
+  clear_has_kvheader();
+  ::cockroach::proto::KVRequestHeader* temp = kvheader_;
+  kvheader_ = NULL;
   return temp;
 }
- void InternalLeaderLeaseRequest::set_allocated_header(::cockroach::proto::RequestHeader* header) {
-  delete header_;
-  header_ = header;
-  if (header) {
-    set_has_header();
+ void InternalLeaderLeaseRequest::set_allocated_kvheader(::cockroach::proto::KVRequestHeader* kvheader) {
+  delete kvheader_;
+  kvheader_ = kvheader;
+  if (kvheader) {
+    set_has_kvheader();
   } else {
-    clear_has_header();
+    clear_has_kvheader();
   }
-  // @@protoc_insertion_point(field_set_allocated:cockroach.proto.InternalLeaderLeaseRequest.header)
+  // @@protoc_insertion_point(field_set_allocated:cockroach.proto.InternalLeaderLeaseRequest.kvheader)
 }
 
 // optional .cockroach.proto.Lease lease = 2;
@@ -7487,7 +7489,7 @@ void InternalLeaderLeaseRequest::clear_lease() {
 // ===================================================================
 
 #ifndef _MSC_VER
-const int InternalLeaderLeaseResponse::kHeaderFieldNumber;
+const int InternalLeaderLeaseResponse::kKvheaderFieldNumber;
 #endif  // !_MSC_VER
 
 InternalLeaderLeaseResponse::InternalLeaderLeaseResponse()
@@ -7497,7 +7499,7 @@ InternalLeaderLeaseResponse::InternalLeaderLeaseResponse()
 }
 
 void InternalLeaderLeaseResponse::InitAsDefaultInstance() {
-  header_ = const_cast< ::cockroach::proto::ResponseHeader*>(&::cockroach::proto::ResponseHeader::default_instance());
+  kvheader_ = const_cast< ::cockroach::proto::KVResponseHeader*>(&::cockroach::proto::KVResponseHeader::default_instance());
 }
 
 InternalLeaderLeaseResponse::InternalLeaderLeaseResponse(const InternalLeaderLeaseResponse& from)
@@ -7510,7 +7512,7 @@ InternalLeaderLeaseResponse::InternalLeaderLeaseResponse(const InternalLeaderLea
 
 void InternalLeaderLeaseResponse::SharedCtor() {
   _cached_size_ = 0;
-  header_ = NULL;
+  kvheader_ = NULL;
   ::memset(_has_bits_, 0, sizeof(_has_bits_));
 }
 
@@ -7521,7 +7523,7 @@ InternalLeaderLeaseResponse::~InternalLeaderLeaseResponse() {
 
 void InternalLeaderLeaseResponse::SharedDtor() {
   if (this != default_instance_) {
-    delete header_;
+    delete kvheader_;
   }
 }
 
@@ -7551,8 +7553,8 @@ InternalLeaderLeaseResponse* InternalLeaderLeaseResponse::New(::google::protobuf
 }
 
 void InternalLeaderLeaseResponse::Clear() {
-  if (has_header()) {
-    if (header_ != NULL) header_->::cockroach::proto::ResponseHeader::Clear();
+  if (has_kvheader()) {
+    if (kvheader_ != NULL) kvheader_->::cockroach::proto::KVResponseHeader::Clear();
   }
   ::memset(_has_bits_, 0, sizeof(_has_bits_));
   if (_internal_metadata_.have_unknown_fields()) {
@@ -7570,11 +7572,11 @@ bool InternalLeaderLeaseResponse::MergePartialFromCodedStream(
     tag = p.first;
     if (!p.second) goto handle_unusual;
     switch (::google::protobuf::internal::WireFormatLite::GetTagFieldNumber(tag)) {
-      // optional .cockroach.proto.ResponseHeader header = 1;
+      // optional .cockroach.proto.KVResponseHeader kvheader = 1;
       case 1: {
         if (tag == 10) {
           DO_(::google::protobuf::internal::WireFormatLite::ReadMessageNoVirtual(
-               input, mutable_header()));
+               input, mutable_kvheader()));
         } else {
           goto handle_unusual;
         }
@@ -7607,10 +7609,10 @@ failure:
 void InternalLeaderLeaseResponse::SerializeWithCachedSizes(
     ::google::protobuf::io::CodedOutputStream* output) const {
   // @@protoc_insertion_point(serialize_start:cockroach.proto.InternalLeaderLeaseResponse)
-  // optional .cockroach.proto.ResponseHeader header = 1;
-  if (has_header()) {
+  // optional .cockroach.proto.KVResponseHeader kvheader = 1;
+  if (has_kvheader()) {
     ::google::protobuf::internal::WireFormatLite::WriteMessageMaybeToArray(
-      1, *this->header_, output);
+      1, *this->kvheader_, output);
   }
 
   if (_internal_metadata_.have_unknown_fields()) {
@@ -7623,11 +7625,11 @@ void InternalLeaderLeaseResponse::SerializeWithCachedSizes(
 ::google::protobuf::uint8* InternalLeaderLeaseResponse::SerializeWithCachedSizesToArray(
     ::google::protobuf::uint8* target) const {
   // @@protoc_insertion_point(serialize_to_array_start:cockroach.proto.InternalLeaderLeaseResponse)
-  // optional .cockroach.proto.ResponseHeader header = 1;
-  if (has_header()) {
+  // optional .cockroach.proto.KVResponseHeader kvheader = 1;
+  if (has_kvheader()) {
     target = ::google::protobuf::internal::WireFormatLite::
       WriteMessageNoVirtualToArray(
-        1, *this->header_, target);
+        1, *this->kvheader_, target);
   }
 
   if (_internal_metadata_.have_unknown_fields()) {
@@ -7641,11 +7643,11 @@ void InternalLeaderLeaseResponse::SerializeWithCachedSizes(
 int InternalLeaderLeaseResponse::ByteSize() const {
   int total_size = 0;
 
-  // optional .cockroach.proto.ResponseHeader header = 1;
-  if (has_header()) {
+  // optional .cockroach.proto.KVResponseHeader kvheader = 1;
+  if (has_kvheader()) {
     total_size += 1 +
       ::google::protobuf::internal::WireFormatLite::MessageSizeNoVirtual(
-        *this->header_);
+        *this->kvheader_);
   }
 
   if (_internal_metadata_.have_unknown_fields()) {
@@ -7674,8 +7676,8 @@ void InternalLeaderLeaseResponse::MergeFrom(const ::google::protobuf::Message& f
 void InternalLeaderLeaseResponse::MergeFrom(const InternalLeaderLeaseResponse& from) {
   if (GOOGLE_PREDICT_FALSE(&from == this)) MergeFromFail(__LINE__);
   if (from._has_bits_[0 / 32] & (0xffu << (0 % 32))) {
-    if (from.has_header()) {
-      mutable_header()->::cockroach::proto::ResponseHeader::MergeFrom(from.header());
+    if (from.has_kvheader()) {
+      mutable_kvheader()->::cockroach::proto::KVResponseHeader::MergeFrom(from.kvheader());
     }
   }
   if (from._internal_metadata_.have_unknown_fields()) {
@@ -7705,7 +7707,7 @@ void InternalLeaderLeaseResponse::Swap(InternalLeaderLeaseResponse* other) {
   InternalSwap(other);
 }
 void InternalLeaderLeaseResponse::InternalSwap(InternalLeaderLeaseResponse* other) {
-  std::swap(header_, other->header_);
+  std::swap(kvheader_, other->kvheader_);
   std::swap(_has_bits_[0], other->_has_bits_[0]);
   _internal_metadata_.Swap(&other->_internal_metadata_);
   std::swap(_cached_size_, other->_cached_size_);
@@ -7722,47 +7724,47 @@ void InternalLeaderLeaseResponse::InternalSwap(InternalLeaderLeaseResponse* othe
 #if PROTOBUF_INLINE_NOT_IN_HEADERS
 // InternalLeaderLeaseResponse
 
-// optional .cockroach.proto.ResponseHeader header = 1;
-bool InternalLeaderLeaseResponse::has_header() const {
+// optional .cockroach.proto.KVResponseHeader kvheader = 1;
+bool InternalLeaderLeaseResponse::has_kvheader() const {
   return (_has_bits_[0] & 0x00000001u) != 0;
 }
-void InternalLeaderLeaseResponse::set_has_header() {
+void InternalLeaderLeaseResponse::set_has_kvheader() {
   _has_bits_[0] |= 0x00000001u;
 }
-void InternalLeaderLeaseResponse::clear_has_header() {
+void InternalLeaderLeaseResponse::clear_has_kvheader() {
   _has_bits_[0] &= ~0x00000001u;
 }
-void InternalLeaderLeaseResponse::clear_header() {
-  if (header_ != NULL) header_->::cockroach::proto::ResponseHeader::Clear();
-  clear_has_header();
+void InternalLeaderLeaseResponse::clear_kvheader() {
+  if (kvheader_ != NULL) kvheader_->::cockroach::proto::KVResponseHeader::Clear();
+  clear_has_kvheader();
 }
- const ::cockroach::proto::ResponseHeader& InternalLeaderLeaseResponse::header() const {
-  // @@protoc_insertion_point(field_get:cockroach.proto.InternalLeaderLeaseResponse.header)
-  return header_ != NULL ? *header_ : *default_instance_->header_;
+ const ::cockroach::proto::KVResponseHeader& InternalLeaderLeaseResponse::kvheader() const {
+  // @@protoc_insertion_point(field_get:cockroach.proto.InternalLeaderLeaseResponse.kvheader)
+  return kvheader_ != NULL ? *kvheader_ : *default_instance_->kvheader_;
 }
- ::cockroach::proto::ResponseHeader* InternalLeaderLeaseResponse::mutable_header() {
-  set_has_header();
-  if (header_ == NULL) {
-    header_ = new ::cockroach::proto::ResponseHeader;
+ ::cockroach::proto::KVResponseHeader* InternalLeaderLeaseResponse::mutable_kvheader() {
+  set_has_kvheader();
+  if (kvheader_ == NULL) {
+    kvheader_ = new ::cockroach::proto::KVResponseHeader;
   }
-  // @@protoc_insertion_point(field_mutable:cockroach.proto.InternalLeaderLeaseResponse.header)
-  return header_;
+  // @@protoc_insertion_point(field_mutable:cockroach.proto.InternalLeaderLeaseResponse.kvheader)
+  return kvheader_;
 }
- ::cockroach::proto::ResponseHeader* InternalLeaderLeaseResponse::release_header() {
-  clear_has_header();
-  ::cockroach::proto::ResponseHeader* temp = header_;
-  header_ = NULL;
+ ::cockroach::proto::KVResponseHeader* InternalLeaderLeaseResponse::release_kvheader() {
+  clear_has_kvheader();
+  ::cockroach::proto::KVResponseHeader* temp = kvheader_;
+  kvheader_ = NULL;
   return temp;
 }
- void InternalLeaderLeaseResponse::set_allocated_header(::cockroach::proto::ResponseHeader* header) {
-  delete header_;
-  header_ = header;
-  if (header) {
-    set_has_header();
+ void InternalLeaderLeaseResponse::set_allocated_kvheader(::cockroach::proto::KVResponseHeader* kvheader) {
+  delete kvheader_;
+  kvheader_ = kvheader;
+  if (kvheader) {
+    set_has_kvheader();
   } else {
-    clear_has_header();
+    clear_has_kvheader();
   }
-  // @@protoc_insertion_point(field_set_allocated:cockroach.proto.InternalLeaderLeaseResponse.header)
+  // @@protoc_insertion_point(field_set_allocated:cockroach.proto.InternalLeaderLeaseResponse.kvheader)
 }
 
 #endif  // PROTOBUF_INLINE_NOT_IN_HEADERS
@@ -10188,7 +10190,7 @@ InternalResponseUnion::ValueCase InternalResponseUnion::value_case() const {
 // ===================================================================
 
 #ifndef _MSC_VER
-const int InternalBatchRequest::kHeaderFieldNumber;
+const int InternalBatchRequest::kKvheaderFieldNumber;
 const int InternalBatchRequest::kRequestsFieldNumber;
 #endif  // !_MSC_VER
 
@@ -10199,7 +10201,7 @@ InternalBatchRequest::InternalBatchRequest()
 }
 
 void InternalBatchRequest::InitAsDefaultInstance() {
-  header_ = const_cast< ::cockroach::proto::RequestHeader*>(&::cockroach::proto::RequestHeader::default_instance());
+  kvheader_ = const_cast< ::cockroach::proto::KVRequestHeader*>(&::cockroach::proto::KVRequestHeader::default_instance());
 }
 
 InternalBatchRequest::InternalBatchRequest(const InternalBatchRequest& from)
@@ -10212,7 +10214,7 @@ InternalBatchRequest::InternalBatchRequest(const InternalBatchRequest& from)
 
 void InternalBatchRequest::SharedCtor() {
   _cached_size_ = 0;
-  header_ = NULL;
+  kvheader_ = NULL;
   ::memset(_has_bits_, 0, sizeof(_has_bits_));
 }
 
@@ -10223,7 +10225,7 @@ InternalBatchRequest::~InternalBatchRequest() {
 
 void InternalBatchRequest::SharedDtor() {
   if (this != default_instance_) {
-    delete header_;
+    delete kvheader_;
   }
 }
 
@@ -10253,8 +10255,8 @@ InternalBatchRequest* InternalBatchRequest::New(::google::protobuf::Arena* arena
 }
 
 void InternalBatchRequest::Clear() {
-  if (has_header()) {
-    if (header_ != NULL) header_->::cockroach::proto::RequestHeader::Clear();
+  if (has_kvheader()) {
+    if (kvheader_ != NULL) kvheader_->::cockroach::proto::KVRequestHeader::Clear();
   }
   requests_.Clear();
   ::memset(_has_bits_, 0, sizeof(_has_bits_));
@@ -10273,11 +10275,11 @@ bool InternalBatchRequest::MergePartialFromCodedStream(
     tag = p.first;
     if (!p.second) goto handle_unusual;
     switch (::google::protobuf::internal::WireFormatLite::GetTagFieldNumber(tag)) {
-      // optional .cockroach.proto.RequestHeader header = 1;
+      // optional .cockroach.proto.KVRequestHeader kvheader = 1;
       case 1: {
         if (tag == 10) {
           DO_(::google::protobuf::internal::WireFormatLite::ReadMessageNoVirtual(
-               input, mutable_header()));
+               input, mutable_kvheader()));
         } else {
           goto handle_unusual;
         }
@@ -10327,10 +10329,10 @@ failure:
 void InternalBatchRequest::SerializeWithCachedSizes(
     ::google::protobuf::io::CodedOutputStream* output) const {
   // @@protoc_insertion_point(serialize_start:cockroach.proto.InternalBatchRequest)
-  // optional .cockroach.proto.RequestHeader header = 1;
-  if (has_header()) {
+  // optional .cockroach.proto.KVRequestHeader kvheader = 1;
+  if (has_kvheader()) {
     ::google::protobuf::internal::WireFormatLite::WriteMessageMaybeToArray(
-      1, *this->header_, output);
+      1, *this->kvheader_, output);
   }
 
   // repeated .cockroach.proto.InternalRequestUnion requests = 2;
@@ -10349,11 +10351,11 @@ void InternalBatchRequest::SerializeWithCachedSizes(
 ::google::protobuf::uint8* InternalBatchRequest::SerializeWithCachedSizesToArray(
     ::google::protobuf::uint8* target) const {
   // @@protoc_insertion_point(serialize_to_array_start:cockroach.proto.InternalBatchRequest)
-  // optional .cockroach.proto.RequestHeader header = 1;
-  if (has_header()) {
+  // optional .cockroach.proto.KVRequestHeader kvheader = 1;
+  if (has_kvheader()) {
     target = ::google::protobuf::internal::WireFormatLite::
       WriteMessageNoVirtualToArray(
-        1, *this->header_, target);
+        1, *this->kvheader_, target);
   }
 
   // repeated .cockroach.proto.InternalRequestUnion requests = 2;
@@ -10374,11 +10376,11 @@ void InternalBatchRequest::SerializeWithCachedSizes(
 int InternalBatchRequest::ByteSize() const {
   int total_size = 0;
 
-  // optional .cockroach.proto.RequestHeader header = 1;
-  if (has_header()) {
+  // optional .cockroach.proto.KVRequestHeader kvheader = 1;
+  if (has_kvheader()) {
     total_size += 1 +
       ::google::protobuf::internal::WireFormatLite::MessageSizeNoVirtual(
-        *this->header_);
+        *this->kvheader_);
   }
 
   // repeated .cockroach.proto.InternalRequestUnion requests = 2;
@@ -10416,8 +10418,8 @@ void InternalBatchRequest::MergeFrom(const InternalBatchRequest& from) {
   if (GOOGLE_PREDICT_FALSE(&from == this)) MergeFromFail(__LINE__);
   requests_.MergeFrom(from.requests_);
   if (from._has_bits_[0 / 32] & (0xffu << (0 % 32))) {
-    if (from.has_header()) {
-      mutable_header()->::cockroach::proto::RequestHeader::MergeFrom(from.header());
+    if (from.has_kvheader()) {
+      mutable_kvheader()->::cockroach::proto::KVRequestHeader::MergeFrom(from.kvheader());
     }
   }
   if (from._internal_metadata_.have_unknown_fields()) {
@@ -10447,7 +10449,7 @@ void InternalBatchRequest::Swap(InternalBatchRequest* other) {
   InternalSwap(other);
 }
 void InternalBatchRequest::InternalSwap(InternalBatchRequest* other) {
-  std::swap(header_, other->header_);
+  std::swap(kvheader_, other->kvheader_);
   requests_.UnsafeArenaSwap(&other->requests_);
   std::swap(_has_bits_[0], other->_has_bits_[0]);
   _internal_metadata_.Swap(&other->_internal_metadata_);
@@ -10465,47 +10467,47 @@ void InternalBatchRequest::InternalSwap(InternalBatchRequest* other) {
 #if PROTOBUF_INLINE_NOT_IN_HEADERS
 // InternalBatchRequest
 
-// optional .cockroach.proto.RequestHeader header = 1;
-bool InternalBatchRequest::has_header() const {
+// optional .cockroach.proto.KVRequestHeader kvheader = 1;
+bool InternalBatchRequest::has_kvheader() const {
   return (_has_bits_[0] & 0x00000001u) != 0;
 }
-void InternalBatchRequest::set_has_header() {
+void InternalBatchRequest::set_has_kvheader() {
   _has_bits_[0] |= 0x00000001u;
 }
-void InternalBatchRequest::clear_has_header() {
+void InternalBatchRequest::clear_has_kvheader() {
   _has_bits_[0] &= ~0x00000001u;
 }
-void InternalBatchRequest::clear_header() {
-  if (header_ != NULL) header_->::cockroach::proto::RequestHeader::Clear();
-  clear_has_header();
+void InternalBatchRequest::clear_kvheader() {
+  if (kvheader_ != NULL) kvheader_->::cockroach::proto::KVRequestHeader::Clear();
+  clear_has_kvheader();
 }
- const ::cockroach::proto::RequestHeader& InternalBatchRequest::header() const {
-  // @@protoc_insertion_point(field_get:cockroach.proto.InternalBatchRequest.header)
-  return header_ != NULL ? *header_ : *default_instance_->header_;
+ const ::cockroach::proto::KVRequestHeader& InternalBatchRequest::kvheader() const {
+  // @@protoc_insertion_point(field_get:cockroach.proto.InternalBatchRequest.kvheader)
+  return kvheader_ != NULL ? *kvheader_ : *default_instance_->kvheader_;
 }
- ::cockroach::proto::RequestHeader* InternalBatchRequest::mutable_header() {
-  set_has_header();
-  if (header_ == NULL) {
-    header_ = new ::cockroach::proto::RequestHeader;
+ ::cockroach::proto::KVRequestHeader* InternalBatchRequest::mutable_kvheader() {
+  set_has_kvheader();
+  if (kvheader_ == NULL) {
+    kvheader_ = new ::cockroach::proto::KVRequestHeader;
   }
-  // @@protoc_insertion_point(field_mutable:cockroach.proto.InternalBatchRequest.header)
-  return header_;
+  // @@protoc_insertion_point(field_mutable:cockroach.proto.InternalBatchRequest.kvheader)
+  return kvheader_;
 }
- ::cockroach::proto::RequestHeader* InternalBatchRequest::release_header() {
-  clear_has_header();
-  ::cockroach::proto::RequestHeader* temp = header_;
-  header_ = NULL;
+ ::cockroach::proto::KVRequestHeader* InternalBatchRequest::release_kvheader() {
+  clear_has_kvheader();
+  ::cockroach::proto::KVRequestHeader* temp = kvheader_;
+  kvheader_ = NULL;
   return temp;
 }
- void InternalBatchRequest::set_allocated_header(::cockroach::proto::RequestHeader* header) {
-  delete header_;
-  header_ = header;
-  if (header) {
-    set_has_header();
+ void InternalBatchRequest::set_allocated_kvheader(::cockroach::proto::KVRequestHeader* kvheader) {
+  delete kvheader_;
+  kvheader_ = kvheader;
+  if (kvheader) {
+    set_has_kvheader();
   } else {
-    clear_has_header();
+    clear_has_kvheader();
   }
-  // @@protoc_insertion_point(field_set_allocated:cockroach.proto.InternalBatchRequest.header)
+  // @@protoc_insertion_point(field_set_allocated:cockroach.proto.InternalBatchRequest.kvheader)
 }
 
 // repeated .cockroach.proto.InternalRequestUnion requests = 2;
@@ -10543,7 +10545,7 @@ InternalBatchRequest::mutable_requests() {
 // ===================================================================
 
 #ifndef _MSC_VER
-const int InternalBatchResponse::kHeaderFieldNumber;
+const int InternalBatchResponse::kKvheaderFieldNumber;
 const int InternalBatchResponse::kResponsesFieldNumber;
 #endif  // !_MSC_VER
 
@@ -10554,7 +10556,7 @@ InternalBatchResponse::InternalBatchResponse()
 }
 
 void InternalBatchResponse::InitAsDefaultInstance() {
-  header_ = const_cast< ::cockroach::proto::ResponseHeader*>(&::cockroach::proto::ResponseHeader::default_instance());
+  kvheader_ = const_cast< ::cockroach::proto::KVResponseHeader*>(&::cockroach::proto::KVResponseHeader::default_instance());
 }
 
 InternalBatchResponse::InternalBatchResponse(const InternalBatchResponse& from)
@@ -10567,7 +10569,7 @@ InternalBatchResponse::InternalBatchResponse(const InternalBatchResponse& from)
 
 void InternalBatchResponse::SharedCtor() {
   _cached_size_ = 0;
-  header_ = NULL;
+  kvheader_ = NULL;
   ::memset(_has_bits_, 0, sizeof(_has_bits_));
 }
 
@@ -10578,7 +10580,7 @@ InternalBatchResponse::~InternalBatchResponse() {
 
 void InternalBatchResponse::SharedDtor() {
   if (this != default_instance_) {
-    delete header_;
+    delete kvheader_;
   }
 }
 
@@ -10608,8 +10610,8 @@ InternalBatchResponse* InternalBatchResponse::New(::google::protobuf::Arena* are
 }
 
 void InternalBatchResponse::Clear() {
-  if (has_header()) {
-    if (header_ != NULL) header_->::cockroach::proto::ResponseHeader::Clear();
+  if (has_kvheader()) {
+    if (kvheader_ != NULL) kvheader_->::cockroach::proto::KVResponseHeader::Clear();
   }
   responses_.Clear();
   ::memset(_has_bits_, 0, sizeof(_has_bits_));
@@ -10628,11 +10630,11 @@ bool InternalBatchResponse::MergePartialFromCodedStream(
     tag = p.first;
     if (!p.second) goto handle_unusual;
     switch (::google::protobuf::internal::WireFormatLite::GetTagFieldNumber(tag)) {
-      // optional .cockroach.proto.ResponseHeader header = 1;
+      // optional .cockroach.proto.KVResponseHeader kvheader = 1;
       case 1: {
         if (tag == 10) {
           DO_(::google::protobuf::internal::WireFormatLite::ReadMessageNoVirtual(
-               input, mutable_header()));
+               input, mutable_kvheader()));
         } else {
           goto handle_unusual;
         }
@@ -10682,10 +10684,10 @@ failure:
 void InternalBatchResponse::SerializeWithCachedSizes(
     ::google::protobuf::io::CodedOutputStream* output) const {
   // @@protoc_insertion_point(serialize_start:cockroach.proto.InternalBatchResponse)
-  // optional .cockroach.proto.ResponseHeader header = 1;
-  if (has_header()) {
+  // optional .cockroach.proto.KVResponseHeader kvheader = 1;
+  if (has_kvheader()) {
     ::google::protobuf::internal::WireFormatLite::WriteMessageMaybeToArray(
-      1, *this->header_, output);
+      1, *this->kvheader_, output);
   }
 
   // repeated .cockroach.proto.InternalResponseUnion responses = 2;
@@ -10704,11 +10706,11 @@ void InternalBatchResponse::SerializeWithCachedSizes(
 ::google::protobuf::uint8* InternalBatchResponse::SerializeWithCachedSizesToArray(
     ::google::protobuf::uint8* target) const {
   // @@protoc_insertion_point(serialize_to_array_start:cockroach.proto.InternalBatchResponse)
-  // optional .cockroach.proto.ResponseHeader header = 1;
-  if (has_header()) {
+  // optional .cockroach.proto.KVResponseHeader kvheader = 1;
+  if (has_kvheader()) {
     target = ::google::protobuf::internal::WireFormatLite::
       WriteMessageNoVirtualToArray(
-        1, *this->header_, target);
+        1, *this->kvheader_, target);
   }
 
   // repeated .cockroach.proto.InternalResponseUnion responses = 2;
@@ -10729,11 +10731,11 @@ void InternalBatchResponse::SerializeWithCachedSizes(
 int InternalBatchResponse::ByteSize() const {
   int total_size = 0;
 
-  // optional .cockroach.proto.ResponseHeader header = 1;
-  if (has_header()) {
+  // optional .cockroach.proto.KVResponseHeader kvheader = 1;
+  if (has_kvheader()) {
     total_size += 1 +
       ::google::protobuf::internal::WireFormatLite::MessageSizeNoVirtual(
-        *this->header_);
+        *this->kvheader_);
   }
 
   // repeated .cockroach.proto.InternalResponseUnion responses = 2;
@@ -10771,8 +10773,8 @@ void InternalBatchResponse::MergeFrom(const InternalBatchResponse& from) {
   if (GOOGLE_PREDICT_FALSE(&from == this)) MergeFromFail(__LINE__);
   responses_.MergeFrom(from.responses_);
   if (from._has_bits_[0 / 32] & (0xffu << (0 % 32))) {
-    if (from.has_header()) {
-      mutable_header()->::cockroach::proto::ResponseHeader::MergeFrom(from.header());
+    if (from.has_kvheader()) {
+      mutable_kvheader()->::cockroach::proto::KVResponseHeader::MergeFrom(from.kvheader());
     }
   }
   if (from._internal_metadata_.have_unknown_fields()) {
@@ -10802,7 +10804,7 @@ void InternalBatchResponse::Swap(InternalBatchResponse* other) {
   InternalSwap(other);
 }
 void InternalBatchResponse::InternalSwap(InternalBatchResponse* other) {
-  std::swap(header_, other->header_);
+  std::swap(kvheader_, other->kvheader_);
   responses_.UnsafeArenaSwap(&other->responses_);
   std::swap(_has_bits_[0], other->_has_bits_[0]);
   _internal_metadata_.Swap(&other->_internal_metadata_);
@@ -10820,47 +10822,47 @@ void InternalBatchResponse::InternalSwap(InternalBatchResponse* other) {
 #if PROTOBUF_INLINE_NOT_IN_HEADERS
 // InternalBatchResponse
 
-// optional .cockroach.proto.ResponseHeader header = 1;
-bool InternalBatchResponse::has_header() const {
+// optional .cockroach.proto.KVResponseHeader kvheader = 1;
+bool InternalBatchResponse::has_kvheader() const {
   return (_has_bits_[0] & 0x00000001u) != 0;
 }
-void InternalBatchResponse::set_has_header() {
+void InternalBatchResponse::set_has_kvheader() {
   _has_bits_[0] |= 0x00000001u;
 }
-void InternalBatchResponse::clear_has_header() {
+void InternalBatchResponse::clear_has_kvheader() {
   _has_bits_[0] &= ~0x00000001u;
 }
-void InternalBatchResponse::clear_header() {
-  if (header_ != NULL) header_->::cockroach::proto::ResponseHeader::Clear();
-  clear_has_header();
+void InternalBatchResponse::clear_kvheader() {
+  if (kvheader_ != NULL) kvheader_->::cockroach::proto::KVResponseHeader::Clear();
+  clear_has_kvheader();
 }
- const ::cockroach::proto::ResponseHeader& InternalBatchResponse::header() const {
-  // @@protoc_insertion_point(field_get:cockroach.proto.InternalBatchResponse.header)
-  return header_ != NULL ? *header_ : *default_instance_->header_;
+ const ::cockroach::proto::KVResponseHeader& InternalBatchResponse::kvheader() const {
+  // @@protoc_insertion_point(field_get:cockroach.proto.InternalBatchResponse.kvheader)
+  return kvheader_ != NULL ? *kvheader_ : *default_instance_->kvheader_;
 }
- ::cockroach::proto::ResponseHeader* InternalBatchResponse::mutable_header() {
-  set_has_header();
-  if (header_ == NULL) {
-    header_ = new ::cockroach::proto::ResponseHeader;
+ ::cockroach::proto::KVResponseHeader* InternalBatchResponse::mutable_kvheader() {
+  set_has_kvheader();
+  if (kvheader_ == NULL) {
+    kvheader_ = new ::cockroach::proto::KVResponseHeader;
   }
-  // @@protoc_insertion_point(field_mutable:cockroach.proto.InternalBatchResponse.header)
-  return header_;
+  // @@protoc_insertion_point(field_mutable:cockroach.proto.InternalBatchResponse.kvheader)
+  return kvheader_;
 }
- ::cockroach::proto::ResponseHeader* InternalBatchResponse::release_header() {
-  clear_has_header();
-  ::cockroach::proto::ResponseHeader* temp = header_;
-  header_ = NULL;
+ ::cockroach::proto::KVResponseHeader* InternalBatchResponse::release_kvheader() {
+  clear_has_kvheader();
+  ::cockroach::proto::KVResponseHeader* temp = kvheader_;
+  kvheader_ = NULL;
   return temp;
 }
- void InternalBatchResponse::set_allocated_header(::cockroach::proto::ResponseHeader* header) {
-  delete header_;
-  header_ = header;
-  if (header) {
-    set_has_header();
+ void InternalBatchResponse::set_allocated_kvheader(::cockroach::proto::KVResponseHeader* kvheader) {
+  delete kvheader_;
+  kvheader_ = kvheader;
+  if (kvheader) {
+    set_has_kvheader();
   } else {
-    clear_has_header();
+    clear_has_kvheader();
   }
-  // @@protoc_insertion_point(field_set_allocated:cockroach.proto.InternalBatchResponse.header)
+  // @@protoc_insertion_point(field_set_allocated:cockroach.proto.InternalBatchResponse.kvheader)
 }
 
 // repeated .cockroach.proto.InternalResponseUnion responses = 2;

--- a/storage/engine/cockroach/proto/internal.pb.h
+++ b/storage/engine/cockroach/proto/internal.pb.h
@@ -180,14 +180,14 @@ class InternalRangeLookupRequest : public ::google::protobuf::Message {
 
   // accessors -------------------------------------------------------
 
-  // optional .cockroach.proto.RequestHeader header = 1;
-  bool has_header() const;
-  void clear_header();
-  static const int kHeaderFieldNumber = 1;
-  const ::cockroach::proto::RequestHeader& header() const;
-  ::cockroach::proto::RequestHeader* mutable_header();
-  ::cockroach::proto::RequestHeader* release_header();
-  void set_allocated_header(::cockroach::proto::RequestHeader* header);
+  // optional .cockroach.proto.KVRequestHeader kvheader = 1;
+  bool has_kvheader() const;
+  void clear_kvheader();
+  static const int kKvheaderFieldNumber = 1;
+  const ::cockroach::proto::KVRequestHeader& kvheader() const;
+  ::cockroach::proto::KVRequestHeader* mutable_kvheader();
+  ::cockroach::proto::KVRequestHeader* release_kvheader();
+  void set_allocated_kvheader(::cockroach::proto::KVRequestHeader* kvheader);
 
   // optional int32 max_ranges = 2;
   bool has_max_ranges() const;
@@ -205,8 +205,8 @@ class InternalRangeLookupRequest : public ::google::protobuf::Message {
 
   // @@protoc_insertion_point(class_scope:cockroach.proto.InternalRangeLookupRequest)
  private:
-  inline void set_has_header();
-  inline void clear_has_header();
+  inline void set_has_kvheader();
+  inline void clear_has_kvheader();
   inline void set_has_max_ranges();
   inline void clear_has_max_ranges();
   inline void set_has_ignore_intents();
@@ -215,7 +215,7 @@ class InternalRangeLookupRequest : public ::google::protobuf::Message {
   ::google::protobuf::internal::InternalMetadataWithArena _internal_metadata_;
   ::google::protobuf::uint32 _has_bits_[1];
   mutable int _cached_size_;
-  ::cockroach::proto::RequestHeader* header_;
+  ::cockroach::proto::KVRequestHeader* kvheader_;
   ::google::protobuf::int32 max_ranges_;
   bool ignore_intents_;
   friend void  protobuf_AddDesc_cockroach_2fproto_2finternal_2eproto();
@@ -291,14 +291,14 @@ class InternalRangeLookupResponse : public ::google::protobuf::Message {
 
   // accessors -------------------------------------------------------
 
-  // optional .cockroach.proto.ResponseHeader header = 1;
-  bool has_header() const;
-  void clear_header();
-  static const int kHeaderFieldNumber = 1;
-  const ::cockroach::proto::ResponseHeader& header() const;
-  ::cockroach::proto::ResponseHeader* mutable_header();
-  ::cockroach::proto::ResponseHeader* release_header();
-  void set_allocated_header(::cockroach::proto::ResponseHeader* header);
+  // optional .cockroach.proto.KVResponseHeader kvheader = 1;
+  bool has_kvheader() const;
+  void clear_kvheader();
+  static const int kKvheaderFieldNumber = 1;
+  const ::cockroach::proto::KVResponseHeader& kvheader() const;
+  ::cockroach::proto::KVResponseHeader* mutable_kvheader();
+  ::cockroach::proto::KVResponseHeader* release_kvheader();
+  void set_allocated_kvheader(::cockroach::proto::KVResponseHeader* kvheader);
 
   // repeated .cockroach.proto.RangeDescriptor ranges = 2;
   int ranges_size() const;
@@ -314,13 +314,13 @@ class InternalRangeLookupResponse : public ::google::protobuf::Message {
 
   // @@protoc_insertion_point(class_scope:cockroach.proto.InternalRangeLookupResponse)
  private:
-  inline void set_has_header();
-  inline void clear_has_header();
+  inline void set_has_kvheader();
+  inline void clear_has_kvheader();
 
   ::google::protobuf::internal::InternalMetadataWithArena _internal_metadata_;
   ::google::protobuf::uint32 _has_bits_[1];
   mutable int _cached_size_;
-  ::cockroach::proto::ResponseHeader* header_;
+  ::cockroach::proto::KVResponseHeader* kvheader_;
   ::google::protobuf::RepeatedPtrField< ::cockroach::proto::RangeDescriptor > ranges_;
   friend void  protobuf_AddDesc_cockroach_2fproto_2finternal_2eproto();
   friend void protobuf_AssignDesc_cockroach_2fproto_2finternal_2eproto();
@@ -395,24 +395,24 @@ class InternalHeartbeatTxnRequest : public ::google::protobuf::Message {
 
   // accessors -------------------------------------------------------
 
-  // optional .cockroach.proto.RequestHeader header = 1;
-  bool has_header() const;
-  void clear_header();
-  static const int kHeaderFieldNumber = 1;
-  const ::cockroach::proto::RequestHeader& header() const;
-  ::cockroach::proto::RequestHeader* mutable_header();
-  ::cockroach::proto::RequestHeader* release_header();
-  void set_allocated_header(::cockroach::proto::RequestHeader* header);
+  // optional .cockroach.proto.KVRequestHeader kvheader = 1;
+  bool has_kvheader() const;
+  void clear_kvheader();
+  static const int kKvheaderFieldNumber = 1;
+  const ::cockroach::proto::KVRequestHeader& kvheader() const;
+  ::cockroach::proto::KVRequestHeader* mutable_kvheader();
+  ::cockroach::proto::KVRequestHeader* release_kvheader();
+  void set_allocated_kvheader(::cockroach::proto::KVRequestHeader* kvheader);
 
   // @@protoc_insertion_point(class_scope:cockroach.proto.InternalHeartbeatTxnRequest)
  private:
-  inline void set_has_header();
-  inline void clear_has_header();
+  inline void set_has_kvheader();
+  inline void clear_has_kvheader();
 
   ::google::protobuf::internal::InternalMetadataWithArena _internal_metadata_;
   ::google::protobuf::uint32 _has_bits_[1];
   mutable int _cached_size_;
-  ::cockroach::proto::RequestHeader* header_;
+  ::cockroach::proto::KVRequestHeader* kvheader_;
   friend void  protobuf_AddDesc_cockroach_2fproto_2finternal_2eproto();
   friend void protobuf_AssignDesc_cockroach_2fproto_2finternal_2eproto();
   friend void protobuf_ShutdownFile_cockroach_2fproto_2finternal_2eproto();
@@ -486,24 +486,24 @@ class InternalHeartbeatTxnResponse : public ::google::protobuf::Message {
 
   // accessors -------------------------------------------------------
 
-  // optional .cockroach.proto.ResponseHeader header = 1;
-  bool has_header() const;
-  void clear_header();
-  static const int kHeaderFieldNumber = 1;
-  const ::cockroach::proto::ResponseHeader& header() const;
-  ::cockroach::proto::ResponseHeader* mutable_header();
-  ::cockroach::proto::ResponseHeader* release_header();
-  void set_allocated_header(::cockroach::proto::ResponseHeader* header);
+  // optional .cockroach.proto.KVResponseHeader kvheader = 1;
+  bool has_kvheader() const;
+  void clear_kvheader();
+  static const int kKvheaderFieldNumber = 1;
+  const ::cockroach::proto::KVResponseHeader& kvheader() const;
+  ::cockroach::proto::KVResponseHeader* mutable_kvheader();
+  ::cockroach::proto::KVResponseHeader* release_kvheader();
+  void set_allocated_kvheader(::cockroach::proto::KVResponseHeader* kvheader);
 
   // @@protoc_insertion_point(class_scope:cockroach.proto.InternalHeartbeatTxnResponse)
  private:
-  inline void set_has_header();
-  inline void clear_has_header();
+  inline void set_has_kvheader();
+  inline void clear_has_kvheader();
 
   ::google::protobuf::internal::InternalMetadataWithArena _internal_metadata_;
   ::google::protobuf::uint32 _has_bits_[1];
   mutable int _cached_size_;
-  ::cockroach::proto::ResponseHeader* header_;
+  ::cockroach::proto::KVResponseHeader* kvheader_;
   friend void  protobuf_AddDesc_cockroach_2fproto_2finternal_2eproto();
   friend void protobuf_AssignDesc_cockroach_2fproto_2finternal_2eproto();
   friend void protobuf_ShutdownFile_cockroach_2fproto_2finternal_2eproto();
@@ -685,14 +685,14 @@ class InternalGCRequest : public ::google::protobuf::Message {
 
   // accessors -------------------------------------------------------
 
-  // optional .cockroach.proto.RequestHeader header = 1;
-  bool has_header() const;
-  void clear_header();
-  static const int kHeaderFieldNumber = 1;
-  const ::cockroach::proto::RequestHeader& header() const;
-  ::cockroach::proto::RequestHeader* mutable_header();
-  ::cockroach::proto::RequestHeader* release_header();
-  void set_allocated_header(::cockroach::proto::RequestHeader* header);
+  // optional .cockroach.proto.KVRequestHeader kvheader = 1;
+  bool has_kvheader() const;
+  void clear_kvheader();
+  static const int kKvheaderFieldNumber = 1;
+  const ::cockroach::proto::KVRequestHeader& kvheader() const;
+  ::cockroach::proto::KVRequestHeader* mutable_kvheader();
+  ::cockroach::proto::KVRequestHeader* release_kvheader();
+  void set_allocated_kvheader(::cockroach::proto::KVRequestHeader* kvheader);
 
   // optional .cockroach.proto.GCMetadata gc_meta = 2;
   bool has_gc_meta() const;
@@ -717,15 +717,15 @@ class InternalGCRequest : public ::google::protobuf::Message {
 
   // @@protoc_insertion_point(class_scope:cockroach.proto.InternalGCRequest)
  private:
-  inline void set_has_header();
-  inline void clear_has_header();
+  inline void set_has_kvheader();
+  inline void clear_has_kvheader();
   inline void set_has_gc_meta();
   inline void clear_has_gc_meta();
 
   ::google::protobuf::internal::InternalMetadataWithArena _internal_metadata_;
   ::google::protobuf::uint32 _has_bits_[1];
   mutable int _cached_size_;
-  ::cockroach::proto::RequestHeader* header_;
+  ::cockroach::proto::KVRequestHeader* kvheader_;
   ::cockroach::proto::GCMetadata* gc_meta_;
   ::google::protobuf::RepeatedPtrField< ::cockroach::proto::InternalGCRequest_GCKey > keys_;
   friend void  protobuf_AddDesc_cockroach_2fproto_2finternal_2eproto();
@@ -801,24 +801,24 @@ class InternalGCResponse : public ::google::protobuf::Message {
 
   // accessors -------------------------------------------------------
 
-  // optional .cockroach.proto.ResponseHeader header = 1;
-  bool has_header() const;
-  void clear_header();
-  static const int kHeaderFieldNumber = 1;
-  const ::cockroach::proto::ResponseHeader& header() const;
-  ::cockroach::proto::ResponseHeader* mutable_header();
-  ::cockroach::proto::ResponseHeader* release_header();
-  void set_allocated_header(::cockroach::proto::ResponseHeader* header);
+  // optional .cockroach.proto.KVResponseHeader kvheader = 1;
+  bool has_kvheader() const;
+  void clear_kvheader();
+  static const int kKvheaderFieldNumber = 1;
+  const ::cockroach::proto::KVResponseHeader& kvheader() const;
+  ::cockroach::proto::KVResponseHeader* mutable_kvheader();
+  ::cockroach::proto::KVResponseHeader* release_kvheader();
+  void set_allocated_kvheader(::cockroach::proto::KVResponseHeader* kvheader);
 
   // @@protoc_insertion_point(class_scope:cockroach.proto.InternalGCResponse)
  private:
-  inline void set_has_header();
-  inline void clear_has_header();
+  inline void set_has_kvheader();
+  inline void clear_has_kvheader();
 
   ::google::protobuf::internal::InternalMetadataWithArena _internal_metadata_;
   ::google::protobuf::uint32 _has_bits_[1];
   mutable int _cached_size_;
-  ::cockroach::proto::ResponseHeader* header_;
+  ::cockroach::proto::KVResponseHeader* kvheader_;
   friend void  protobuf_AddDesc_cockroach_2fproto_2finternal_2eproto();
   friend void protobuf_AssignDesc_cockroach_2fproto_2finternal_2eproto();
   friend void protobuf_ShutdownFile_cockroach_2fproto_2finternal_2eproto();
@@ -892,14 +892,14 @@ class InternalPushTxnRequest : public ::google::protobuf::Message {
 
   // accessors -------------------------------------------------------
 
-  // optional .cockroach.proto.RequestHeader header = 1;
-  bool has_header() const;
-  void clear_header();
-  static const int kHeaderFieldNumber = 1;
-  const ::cockroach::proto::RequestHeader& header() const;
-  ::cockroach::proto::RequestHeader* mutable_header();
-  ::cockroach::proto::RequestHeader* release_header();
-  void set_allocated_header(::cockroach::proto::RequestHeader* header);
+  // optional .cockroach.proto.KVRequestHeader kvheader = 1;
+  bool has_kvheader() const;
+  void clear_kvheader();
+  static const int kKvheaderFieldNumber = 1;
+  const ::cockroach::proto::KVRequestHeader& kvheader() const;
+  ::cockroach::proto::KVRequestHeader* mutable_kvheader();
+  ::cockroach::proto::KVRequestHeader* release_kvheader();
+  void set_allocated_kvheader(::cockroach::proto::KVRequestHeader* kvheader);
 
   // optional .cockroach.proto.Transaction pushee_txn = 2;
   bool has_pushee_txn() const;
@@ -935,8 +935,8 @@ class InternalPushTxnRequest : public ::google::protobuf::Message {
 
   // @@protoc_insertion_point(class_scope:cockroach.proto.InternalPushTxnRequest)
  private:
-  inline void set_has_header();
-  inline void clear_has_header();
+  inline void set_has_kvheader();
+  inline void clear_has_kvheader();
   inline void set_has_pushee_txn();
   inline void clear_has_pushee_txn();
   inline void set_has_now();
@@ -949,7 +949,7 @@ class InternalPushTxnRequest : public ::google::protobuf::Message {
   ::google::protobuf::internal::InternalMetadataWithArena _internal_metadata_;
   ::google::protobuf::uint32 _has_bits_[1];
   mutable int _cached_size_;
-  ::cockroach::proto::RequestHeader* header_;
+  ::cockroach::proto::KVRequestHeader* kvheader_;
   ::cockroach::proto::Transaction* pushee_txn_;
   ::cockroach::proto::Timestamp* now_;
   int push_type_;
@@ -1027,14 +1027,14 @@ class InternalPushTxnResponse : public ::google::protobuf::Message {
 
   // accessors -------------------------------------------------------
 
-  // optional .cockroach.proto.ResponseHeader header = 1;
-  bool has_header() const;
-  void clear_header();
-  static const int kHeaderFieldNumber = 1;
-  const ::cockroach::proto::ResponseHeader& header() const;
-  ::cockroach::proto::ResponseHeader* mutable_header();
-  ::cockroach::proto::ResponseHeader* release_header();
-  void set_allocated_header(::cockroach::proto::ResponseHeader* header);
+  // optional .cockroach.proto.KVResponseHeader kvheader = 1;
+  bool has_kvheader() const;
+  void clear_kvheader();
+  static const int kKvheaderFieldNumber = 1;
+  const ::cockroach::proto::KVResponseHeader& kvheader() const;
+  ::cockroach::proto::KVResponseHeader* mutable_kvheader();
+  ::cockroach::proto::KVResponseHeader* release_kvheader();
+  void set_allocated_kvheader(::cockroach::proto::KVResponseHeader* kvheader);
 
   // optional .cockroach.proto.Transaction pushee_txn = 2;
   bool has_pushee_txn() const;
@@ -1047,15 +1047,15 @@ class InternalPushTxnResponse : public ::google::protobuf::Message {
 
   // @@protoc_insertion_point(class_scope:cockroach.proto.InternalPushTxnResponse)
  private:
-  inline void set_has_header();
-  inline void clear_has_header();
+  inline void set_has_kvheader();
+  inline void clear_has_kvheader();
   inline void set_has_pushee_txn();
   inline void clear_has_pushee_txn();
 
   ::google::protobuf::internal::InternalMetadataWithArena _internal_metadata_;
   ::google::protobuf::uint32 _has_bits_[1];
   mutable int _cached_size_;
-  ::cockroach::proto::ResponseHeader* header_;
+  ::cockroach::proto::KVResponseHeader* kvheader_;
   ::cockroach::proto::Transaction* pushee_txn_;
   friend void  protobuf_AddDesc_cockroach_2fproto_2finternal_2eproto();
   friend void protobuf_AssignDesc_cockroach_2fproto_2finternal_2eproto();
@@ -1130,24 +1130,24 @@ class InternalResolveIntentRequest : public ::google::protobuf::Message {
 
   // accessors -------------------------------------------------------
 
-  // optional .cockroach.proto.RequestHeader header = 1;
-  bool has_header() const;
-  void clear_header();
-  static const int kHeaderFieldNumber = 1;
-  const ::cockroach::proto::RequestHeader& header() const;
-  ::cockroach::proto::RequestHeader* mutable_header();
-  ::cockroach::proto::RequestHeader* release_header();
-  void set_allocated_header(::cockroach::proto::RequestHeader* header);
+  // optional .cockroach.proto.KVRequestHeader kvheader = 1;
+  bool has_kvheader() const;
+  void clear_kvheader();
+  static const int kKvheaderFieldNumber = 1;
+  const ::cockroach::proto::KVRequestHeader& kvheader() const;
+  ::cockroach::proto::KVRequestHeader* mutable_kvheader();
+  ::cockroach::proto::KVRequestHeader* release_kvheader();
+  void set_allocated_kvheader(::cockroach::proto::KVRequestHeader* kvheader);
 
   // @@protoc_insertion_point(class_scope:cockroach.proto.InternalResolveIntentRequest)
  private:
-  inline void set_has_header();
-  inline void clear_has_header();
+  inline void set_has_kvheader();
+  inline void clear_has_kvheader();
 
   ::google::protobuf::internal::InternalMetadataWithArena _internal_metadata_;
   ::google::protobuf::uint32 _has_bits_[1];
   mutable int _cached_size_;
-  ::cockroach::proto::RequestHeader* header_;
+  ::cockroach::proto::KVRequestHeader* kvheader_;
   friend void  protobuf_AddDesc_cockroach_2fproto_2finternal_2eproto();
   friend void protobuf_AssignDesc_cockroach_2fproto_2finternal_2eproto();
   friend void protobuf_ShutdownFile_cockroach_2fproto_2finternal_2eproto();
@@ -1221,24 +1221,24 @@ class InternalResolveIntentResponse : public ::google::protobuf::Message {
 
   // accessors -------------------------------------------------------
 
-  // optional .cockroach.proto.ResponseHeader header = 1;
-  bool has_header() const;
-  void clear_header();
-  static const int kHeaderFieldNumber = 1;
-  const ::cockroach::proto::ResponseHeader& header() const;
-  ::cockroach::proto::ResponseHeader* mutable_header();
-  ::cockroach::proto::ResponseHeader* release_header();
-  void set_allocated_header(::cockroach::proto::ResponseHeader* header);
+  // optional .cockroach.proto.KVResponseHeader kvheader = 1;
+  bool has_kvheader() const;
+  void clear_kvheader();
+  static const int kKvheaderFieldNumber = 1;
+  const ::cockroach::proto::KVResponseHeader& kvheader() const;
+  ::cockroach::proto::KVResponseHeader* mutable_kvheader();
+  ::cockroach::proto::KVResponseHeader* release_kvheader();
+  void set_allocated_kvheader(::cockroach::proto::KVResponseHeader* kvheader);
 
   // @@protoc_insertion_point(class_scope:cockroach.proto.InternalResolveIntentResponse)
  private:
-  inline void set_has_header();
-  inline void clear_has_header();
+  inline void set_has_kvheader();
+  inline void clear_has_kvheader();
 
   ::google::protobuf::internal::InternalMetadataWithArena _internal_metadata_;
   ::google::protobuf::uint32 _has_bits_[1];
   mutable int _cached_size_;
-  ::cockroach::proto::ResponseHeader* header_;
+  ::cockroach::proto::KVResponseHeader* kvheader_;
   friend void  protobuf_AddDesc_cockroach_2fproto_2finternal_2eproto();
   friend void protobuf_AssignDesc_cockroach_2fproto_2finternal_2eproto();
   friend void protobuf_ShutdownFile_cockroach_2fproto_2finternal_2eproto();
@@ -1312,24 +1312,24 @@ class InternalResolveIntentRangeRequest : public ::google::protobuf::Message {
 
   // accessors -------------------------------------------------------
 
-  // optional .cockroach.proto.RequestHeader header = 1;
-  bool has_header() const;
-  void clear_header();
-  static const int kHeaderFieldNumber = 1;
-  const ::cockroach::proto::RequestHeader& header() const;
-  ::cockroach::proto::RequestHeader* mutable_header();
-  ::cockroach::proto::RequestHeader* release_header();
-  void set_allocated_header(::cockroach::proto::RequestHeader* header);
+  // optional .cockroach.proto.KVRequestHeader kvheader = 1;
+  bool has_kvheader() const;
+  void clear_kvheader();
+  static const int kKvheaderFieldNumber = 1;
+  const ::cockroach::proto::KVRequestHeader& kvheader() const;
+  ::cockroach::proto::KVRequestHeader* mutable_kvheader();
+  ::cockroach::proto::KVRequestHeader* release_kvheader();
+  void set_allocated_kvheader(::cockroach::proto::KVRequestHeader* kvheader);
 
   // @@protoc_insertion_point(class_scope:cockroach.proto.InternalResolveIntentRangeRequest)
  private:
-  inline void set_has_header();
-  inline void clear_has_header();
+  inline void set_has_kvheader();
+  inline void clear_has_kvheader();
 
   ::google::protobuf::internal::InternalMetadataWithArena _internal_metadata_;
   ::google::protobuf::uint32 _has_bits_[1];
   mutable int _cached_size_;
-  ::cockroach::proto::RequestHeader* header_;
+  ::cockroach::proto::KVRequestHeader* kvheader_;
   friend void  protobuf_AddDesc_cockroach_2fproto_2finternal_2eproto();
   friend void protobuf_AssignDesc_cockroach_2fproto_2finternal_2eproto();
   friend void protobuf_ShutdownFile_cockroach_2fproto_2finternal_2eproto();
@@ -1403,24 +1403,24 @@ class InternalResolveIntentRangeResponse : public ::google::protobuf::Message {
 
   // accessors -------------------------------------------------------
 
-  // optional .cockroach.proto.ResponseHeader header = 1;
-  bool has_header() const;
-  void clear_header();
-  static const int kHeaderFieldNumber = 1;
-  const ::cockroach::proto::ResponseHeader& header() const;
-  ::cockroach::proto::ResponseHeader* mutable_header();
-  ::cockroach::proto::ResponseHeader* release_header();
-  void set_allocated_header(::cockroach::proto::ResponseHeader* header);
+  // optional .cockroach.proto.KVResponseHeader kvheader = 1;
+  bool has_kvheader() const;
+  void clear_kvheader();
+  static const int kKvheaderFieldNumber = 1;
+  const ::cockroach::proto::KVResponseHeader& kvheader() const;
+  ::cockroach::proto::KVResponseHeader* mutable_kvheader();
+  ::cockroach::proto::KVResponseHeader* release_kvheader();
+  void set_allocated_kvheader(::cockroach::proto::KVResponseHeader* kvheader);
 
   // @@protoc_insertion_point(class_scope:cockroach.proto.InternalResolveIntentRangeResponse)
  private:
-  inline void set_has_header();
-  inline void clear_has_header();
+  inline void set_has_kvheader();
+  inline void clear_has_kvheader();
 
   ::google::protobuf::internal::InternalMetadataWithArena _internal_metadata_;
   ::google::protobuf::uint32 _has_bits_[1];
   mutable int _cached_size_;
-  ::cockroach::proto::ResponseHeader* header_;
+  ::cockroach::proto::KVResponseHeader* kvheader_;
   friend void  protobuf_AddDesc_cockroach_2fproto_2finternal_2eproto();
   friend void protobuf_AssignDesc_cockroach_2fproto_2finternal_2eproto();
   friend void protobuf_ShutdownFile_cockroach_2fproto_2finternal_2eproto();
@@ -1494,14 +1494,14 @@ class InternalMergeRequest : public ::google::protobuf::Message {
 
   // accessors -------------------------------------------------------
 
-  // optional .cockroach.proto.RequestHeader header = 1;
-  bool has_header() const;
-  void clear_header();
-  static const int kHeaderFieldNumber = 1;
-  const ::cockroach::proto::RequestHeader& header() const;
-  ::cockroach::proto::RequestHeader* mutable_header();
-  ::cockroach::proto::RequestHeader* release_header();
-  void set_allocated_header(::cockroach::proto::RequestHeader* header);
+  // optional .cockroach.proto.KVRequestHeader kvheader = 1;
+  bool has_kvheader() const;
+  void clear_kvheader();
+  static const int kKvheaderFieldNumber = 1;
+  const ::cockroach::proto::KVRequestHeader& kvheader() const;
+  ::cockroach::proto::KVRequestHeader* mutable_kvheader();
+  ::cockroach::proto::KVRequestHeader* release_kvheader();
+  void set_allocated_kvheader(::cockroach::proto::KVRequestHeader* kvheader);
 
   // optional .cockroach.proto.Value value = 2;
   bool has_value() const;
@@ -1514,15 +1514,15 @@ class InternalMergeRequest : public ::google::protobuf::Message {
 
   // @@protoc_insertion_point(class_scope:cockroach.proto.InternalMergeRequest)
  private:
-  inline void set_has_header();
-  inline void clear_has_header();
+  inline void set_has_kvheader();
+  inline void clear_has_kvheader();
   inline void set_has_value();
   inline void clear_has_value();
 
   ::google::protobuf::internal::InternalMetadataWithArena _internal_metadata_;
   ::google::protobuf::uint32 _has_bits_[1];
   mutable int _cached_size_;
-  ::cockroach::proto::RequestHeader* header_;
+  ::cockroach::proto::KVRequestHeader* kvheader_;
   ::cockroach::proto::Value* value_;
   friend void  protobuf_AddDesc_cockroach_2fproto_2finternal_2eproto();
   friend void protobuf_AssignDesc_cockroach_2fproto_2finternal_2eproto();
@@ -1597,24 +1597,24 @@ class InternalMergeResponse : public ::google::protobuf::Message {
 
   // accessors -------------------------------------------------------
 
-  // optional .cockroach.proto.ResponseHeader header = 1;
-  bool has_header() const;
-  void clear_header();
-  static const int kHeaderFieldNumber = 1;
-  const ::cockroach::proto::ResponseHeader& header() const;
-  ::cockroach::proto::ResponseHeader* mutable_header();
-  ::cockroach::proto::ResponseHeader* release_header();
-  void set_allocated_header(::cockroach::proto::ResponseHeader* header);
+  // optional .cockroach.proto.KVResponseHeader kvheader = 1;
+  bool has_kvheader() const;
+  void clear_kvheader();
+  static const int kKvheaderFieldNumber = 1;
+  const ::cockroach::proto::KVResponseHeader& kvheader() const;
+  ::cockroach::proto::KVResponseHeader* mutable_kvheader();
+  ::cockroach::proto::KVResponseHeader* release_kvheader();
+  void set_allocated_kvheader(::cockroach::proto::KVResponseHeader* kvheader);
 
   // @@protoc_insertion_point(class_scope:cockroach.proto.InternalMergeResponse)
  private:
-  inline void set_has_header();
-  inline void clear_has_header();
+  inline void set_has_kvheader();
+  inline void clear_has_kvheader();
 
   ::google::protobuf::internal::InternalMetadataWithArena _internal_metadata_;
   ::google::protobuf::uint32 _has_bits_[1];
   mutable int _cached_size_;
-  ::cockroach::proto::ResponseHeader* header_;
+  ::cockroach::proto::KVResponseHeader* kvheader_;
   friend void  protobuf_AddDesc_cockroach_2fproto_2finternal_2eproto();
   friend void protobuf_AssignDesc_cockroach_2fproto_2finternal_2eproto();
   friend void protobuf_ShutdownFile_cockroach_2fproto_2finternal_2eproto();
@@ -1688,14 +1688,14 @@ class InternalTruncateLogRequest : public ::google::protobuf::Message {
 
   // accessors -------------------------------------------------------
 
-  // optional .cockroach.proto.RequestHeader header = 1;
-  bool has_header() const;
-  void clear_header();
-  static const int kHeaderFieldNumber = 1;
-  const ::cockroach::proto::RequestHeader& header() const;
-  ::cockroach::proto::RequestHeader* mutable_header();
-  ::cockroach::proto::RequestHeader* release_header();
-  void set_allocated_header(::cockroach::proto::RequestHeader* header);
+  // optional .cockroach.proto.KVRequestHeader kvheader = 1;
+  bool has_kvheader() const;
+  void clear_kvheader();
+  static const int kKvheaderFieldNumber = 1;
+  const ::cockroach::proto::KVRequestHeader& kvheader() const;
+  ::cockroach::proto::KVRequestHeader* mutable_kvheader();
+  ::cockroach::proto::KVRequestHeader* release_kvheader();
+  void set_allocated_kvheader(::cockroach::proto::KVRequestHeader* kvheader);
 
   // optional uint64 index = 2;
   bool has_index() const;
@@ -1706,15 +1706,15 @@ class InternalTruncateLogRequest : public ::google::protobuf::Message {
 
   // @@protoc_insertion_point(class_scope:cockroach.proto.InternalTruncateLogRequest)
  private:
-  inline void set_has_header();
-  inline void clear_has_header();
+  inline void set_has_kvheader();
+  inline void clear_has_kvheader();
   inline void set_has_index();
   inline void clear_has_index();
 
   ::google::protobuf::internal::InternalMetadataWithArena _internal_metadata_;
   ::google::protobuf::uint32 _has_bits_[1];
   mutable int _cached_size_;
-  ::cockroach::proto::RequestHeader* header_;
+  ::cockroach::proto::KVRequestHeader* kvheader_;
   ::google::protobuf::uint64 index_;
   friend void  protobuf_AddDesc_cockroach_2fproto_2finternal_2eproto();
   friend void protobuf_AssignDesc_cockroach_2fproto_2finternal_2eproto();
@@ -1789,24 +1789,24 @@ class InternalTruncateLogResponse : public ::google::protobuf::Message {
 
   // accessors -------------------------------------------------------
 
-  // optional .cockroach.proto.ResponseHeader header = 1;
-  bool has_header() const;
-  void clear_header();
-  static const int kHeaderFieldNumber = 1;
-  const ::cockroach::proto::ResponseHeader& header() const;
-  ::cockroach::proto::ResponseHeader* mutable_header();
-  ::cockroach::proto::ResponseHeader* release_header();
-  void set_allocated_header(::cockroach::proto::ResponseHeader* header);
+  // optional .cockroach.proto.KVResponseHeader kvheader = 1;
+  bool has_kvheader() const;
+  void clear_kvheader();
+  static const int kKvheaderFieldNumber = 1;
+  const ::cockroach::proto::KVResponseHeader& kvheader() const;
+  ::cockroach::proto::KVResponseHeader* mutable_kvheader();
+  ::cockroach::proto::KVResponseHeader* release_kvheader();
+  void set_allocated_kvheader(::cockroach::proto::KVResponseHeader* kvheader);
 
   // @@protoc_insertion_point(class_scope:cockroach.proto.InternalTruncateLogResponse)
  private:
-  inline void set_has_header();
-  inline void clear_has_header();
+  inline void set_has_kvheader();
+  inline void clear_has_kvheader();
 
   ::google::protobuf::internal::InternalMetadataWithArena _internal_metadata_;
   ::google::protobuf::uint32 _has_bits_[1];
   mutable int _cached_size_;
-  ::cockroach::proto::ResponseHeader* header_;
+  ::cockroach::proto::KVResponseHeader* kvheader_;
   friend void  protobuf_AddDesc_cockroach_2fproto_2finternal_2eproto();
   friend void protobuf_AssignDesc_cockroach_2fproto_2finternal_2eproto();
   friend void protobuf_ShutdownFile_cockroach_2fproto_2finternal_2eproto();
@@ -1880,14 +1880,14 @@ class InternalLeaderLeaseRequest : public ::google::protobuf::Message {
 
   // accessors -------------------------------------------------------
 
-  // optional .cockroach.proto.RequestHeader header = 1;
-  bool has_header() const;
-  void clear_header();
-  static const int kHeaderFieldNumber = 1;
-  const ::cockroach::proto::RequestHeader& header() const;
-  ::cockroach::proto::RequestHeader* mutable_header();
-  ::cockroach::proto::RequestHeader* release_header();
-  void set_allocated_header(::cockroach::proto::RequestHeader* header);
+  // optional .cockroach.proto.KVRequestHeader kvheader = 1;
+  bool has_kvheader() const;
+  void clear_kvheader();
+  static const int kKvheaderFieldNumber = 1;
+  const ::cockroach::proto::KVRequestHeader& kvheader() const;
+  ::cockroach::proto::KVRequestHeader* mutable_kvheader();
+  ::cockroach::proto::KVRequestHeader* release_kvheader();
+  void set_allocated_kvheader(::cockroach::proto::KVRequestHeader* kvheader);
 
   // optional .cockroach.proto.Lease lease = 2;
   bool has_lease() const;
@@ -1900,15 +1900,15 @@ class InternalLeaderLeaseRequest : public ::google::protobuf::Message {
 
   // @@protoc_insertion_point(class_scope:cockroach.proto.InternalLeaderLeaseRequest)
  private:
-  inline void set_has_header();
-  inline void clear_has_header();
+  inline void set_has_kvheader();
+  inline void clear_has_kvheader();
   inline void set_has_lease();
   inline void clear_has_lease();
 
   ::google::protobuf::internal::InternalMetadataWithArena _internal_metadata_;
   ::google::protobuf::uint32 _has_bits_[1];
   mutable int _cached_size_;
-  ::cockroach::proto::RequestHeader* header_;
+  ::cockroach::proto::KVRequestHeader* kvheader_;
   ::cockroach::proto::Lease* lease_;
   friend void  protobuf_AddDesc_cockroach_2fproto_2finternal_2eproto();
   friend void protobuf_AssignDesc_cockroach_2fproto_2finternal_2eproto();
@@ -1983,24 +1983,24 @@ class InternalLeaderLeaseResponse : public ::google::protobuf::Message {
 
   // accessors -------------------------------------------------------
 
-  // optional .cockroach.proto.ResponseHeader header = 1;
-  bool has_header() const;
-  void clear_header();
-  static const int kHeaderFieldNumber = 1;
-  const ::cockroach::proto::ResponseHeader& header() const;
-  ::cockroach::proto::ResponseHeader* mutable_header();
-  ::cockroach::proto::ResponseHeader* release_header();
-  void set_allocated_header(::cockroach::proto::ResponseHeader* header);
+  // optional .cockroach.proto.KVResponseHeader kvheader = 1;
+  bool has_kvheader() const;
+  void clear_kvheader();
+  static const int kKvheaderFieldNumber = 1;
+  const ::cockroach::proto::KVResponseHeader& kvheader() const;
+  ::cockroach::proto::KVResponseHeader* mutable_kvheader();
+  ::cockroach::proto::KVResponseHeader* release_kvheader();
+  void set_allocated_kvheader(::cockroach::proto::KVResponseHeader* kvheader);
 
   // @@protoc_insertion_point(class_scope:cockroach.proto.InternalLeaderLeaseResponse)
  private:
-  inline void set_has_header();
-  inline void clear_has_header();
+  inline void set_has_kvheader();
+  inline void clear_has_kvheader();
 
   ::google::protobuf::internal::InternalMetadataWithArena _internal_metadata_;
   ::google::protobuf::uint32 _has_bits_[1];
   mutable int _cached_size_;
-  ::cockroach::proto::ResponseHeader* header_;
+  ::cockroach::proto::KVResponseHeader* kvheader_;
   friend void  protobuf_AddDesc_cockroach_2fproto_2finternal_2eproto();
   friend void protobuf_AssignDesc_cockroach_2fproto_2finternal_2eproto();
   friend void protobuf_ShutdownFile_cockroach_2fproto_2finternal_2eproto();
@@ -2524,14 +2524,14 @@ class InternalBatchRequest : public ::google::protobuf::Message {
 
   // accessors -------------------------------------------------------
 
-  // optional .cockroach.proto.RequestHeader header = 1;
-  bool has_header() const;
-  void clear_header();
-  static const int kHeaderFieldNumber = 1;
-  const ::cockroach::proto::RequestHeader& header() const;
-  ::cockroach::proto::RequestHeader* mutable_header();
-  ::cockroach::proto::RequestHeader* release_header();
-  void set_allocated_header(::cockroach::proto::RequestHeader* header);
+  // optional .cockroach.proto.KVRequestHeader kvheader = 1;
+  bool has_kvheader() const;
+  void clear_kvheader();
+  static const int kKvheaderFieldNumber = 1;
+  const ::cockroach::proto::KVRequestHeader& kvheader() const;
+  ::cockroach::proto::KVRequestHeader* mutable_kvheader();
+  ::cockroach::proto::KVRequestHeader* release_kvheader();
+  void set_allocated_kvheader(::cockroach::proto::KVRequestHeader* kvheader);
 
   // repeated .cockroach.proto.InternalRequestUnion requests = 2;
   int requests_size() const;
@@ -2547,13 +2547,13 @@ class InternalBatchRequest : public ::google::protobuf::Message {
 
   // @@protoc_insertion_point(class_scope:cockroach.proto.InternalBatchRequest)
  private:
-  inline void set_has_header();
-  inline void clear_has_header();
+  inline void set_has_kvheader();
+  inline void clear_has_kvheader();
 
   ::google::protobuf::internal::InternalMetadataWithArena _internal_metadata_;
   ::google::protobuf::uint32 _has_bits_[1];
   mutable int _cached_size_;
-  ::cockroach::proto::RequestHeader* header_;
+  ::cockroach::proto::KVRequestHeader* kvheader_;
   ::google::protobuf::RepeatedPtrField< ::cockroach::proto::InternalRequestUnion > requests_;
   friend void  protobuf_AddDesc_cockroach_2fproto_2finternal_2eproto();
   friend void protobuf_AssignDesc_cockroach_2fproto_2finternal_2eproto();
@@ -2628,14 +2628,14 @@ class InternalBatchResponse : public ::google::protobuf::Message {
 
   // accessors -------------------------------------------------------
 
-  // optional .cockroach.proto.ResponseHeader header = 1;
-  bool has_header() const;
-  void clear_header();
-  static const int kHeaderFieldNumber = 1;
-  const ::cockroach::proto::ResponseHeader& header() const;
-  ::cockroach::proto::ResponseHeader* mutable_header();
-  ::cockroach::proto::ResponseHeader* release_header();
-  void set_allocated_header(::cockroach::proto::ResponseHeader* header);
+  // optional .cockroach.proto.KVResponseHeader kvheader = 1;
+  bool has_kvheader() const;
+  void clear_kvheader();
+  static const int kKvheaderFieldNumber = 1;
+  const ::cockroach::proto::KVResponseHeader& kvheader() const;
+  ::cockroach::proto::KVResponseHeader* mutable_kvheader();
+  ::cockroach::proto::KVResponseHeader* release_kvheader();
+  void set_allocated_kvheader(::cockroach::proto::KVResponseHeader* kvheader);
 
   // repeated .cockroach.proto.InternalResponseUnion responses = 2;
   int responses_size() const;
@@ -2651,13 +2651,13 @@ class InternalBatchResponse : public ::google::protobuf::Message {
 
   // @@protoc_insertion_point(class_scope:cockroach.proto.InternalBatchResponse)
  private:
-  inline void set_has_header();
-  inline void clear_has_header();
+  inline void set_has_kvheader();
+  inline void clear_has_kvheader();
 
   ::google::protobuf::internal::InternalMetadataWithArena _internal_metadata_;
   ::google::protobuf::uint32 _has_bits_[1];
   mutable int _cached_size_;
-  ::cockroach::proto::ResponseHeader* header_;
+  ::cockroach::proto::KVResponseHeader* kvheader_;
   ::google::protobuf::RepeatedPtrField< ::cockroach::proto::InternalResponseUnion > responses_;
   friend void  protobuf_AddDesc_cockroach_2fproto_2finternal_2eproto();
   friend void protobuf_AssignDesc_cockroach_2fproto_2finternal_2eproto();
@@ -4105,47 +4105,47 @@ class RaftSnapshotData : public ::google::protobuf::Message {
 #if !PROTOBUF_INLINE_NOT_IN_HEADERS
 // InternalRangeLookupRequest
 
-// optional .cockroach.proto.RequestHeader header = 1;
-inline bool InternalRangeLookupRequest::has_header() const {
+// optional .cockroach.proto.KVRequestHeader kvheader = 1;
+inline bool InternalRangeLookupRequest::has_kvheader() const {
   return (_has_bits_[0] & 0x00000001u) != 0;
 }
-inline void InternalRangeLookupRequest::set_has_header() {
+inline void InternalRangeLookupRequest::set_has_kvheader() {
   _has_bits_[0] |= 0x00000001u;
 }
-inline void InternalRangeLookupRequest::clear_has_header() {
+inline void InternalRangeLookupRequest::clear_has_kvheader() {
   _has_bits_[0] &= ~0x00000001u;
 }
-inline void InternalRangeLookupRequest::clear_header() {
-  if (header_ != NULL) header_->::cockroach::proto::RequestHeader::Clear();
-  clear_has_header();
+inline void InternalRangeLookupRequest::clear_kvheader() {
+  if (kvheader_ != NULL) kvheader_->::cockroach::proto::KVRequestHeader::Clear();
+  clear_has_kvheader();
 }
-inline const ::cockroach::proto::RequestHeader& InternalRangeLookupRequest::header() const {
-  // @@protoc_insertion_point(field_get:cockroach.proto.InternalRangeLookupRequest.header)
-  return header_ != NULL ? *header_ : *default_instance_->header_;
+inline const ::cockroach::proto::KVRequestHeader& InternalRangeLookupRequest::kvheader() const {
+  // @@protoc_insertion_point(field_get:cockroach.proto.InternalRangeLookupRequest.kvheader)
+  return kvheader_ != NULL ? *kvheader_ : *default_instance_->kvheader_;
 }
-inline ::cockroach::proto::RequestHeader* InternalRangeLookupRequest::mutable_header() {
-  set_has_header();
-  if (header_ == NULL) {
-    header_ = new ::cockroach::proto::RequestHeader;
+inline ::cockroach::proto::KVRequestHeader* InternalRangeLookupRequest::mutable_kvheader() {
+  set_has_kvheader();
+  if (kvheader_ == NULL) {
+    kvheader_ = new ::cockroach::proto::KVRequestHeader;
   }
-  // @@protoc_insertion_point(field_mutable:cockroach.proto.InternalRangeLookupRequest.header)
-  return header_;
+  // @@protoc_insertion_point(field_mutable:cockroach.proto.InternalRangeLookupRequest.kvheader)
+  return kvheader_;
 }
-inline ::cockroach::proto::RequestHeader* InternalRangeLookupRequest::release_header() {
-  clear_has_header();
-  ::cockroach::proto::RequestHeader* temp = header_;
-  header_ = NULL;
+inline ::cockroach::proto::KVRequestHeader* InternalRangeLookupRequest::release_kvheader() {
+  clear_has_kvheader();
+  ::cockroach::proto::KVRequestHeader* temp = kvheader_;
+  kvheader_ = NULL;
   return temp;
 }
-inline void InternalRangeLookupRequest::set_allocated_header(::cockroach::proto::RequestHeader* header) {
-  delete header_;
-  header_ = header;
-  if (header) {
-    set_has_header();
+inline void InternalRangeLookupRequest::set_allocated_kvheader(::cockroach::proto::KVRequestHeader* kvheader) {
+  delete kvheader_;
+  kvheader_ = kvheader;
+  if (kvheader) {
+    set_has_kvheader();
   } else {
-    clear_has_header();
+    clear_has_kvheader();
   }
-  // @@protoc_insertion_point(field_set_allocated:cockroach.proto.InternalRangeLookupRequest.header)
+  // @@protoc_insertion_point(field_set_allocated:cockroach.proto.InternalRangeLookupRequest.kvheader)
 }
 
 // optional int32 max_ranges = 2;
@@ -4200,47 +4200,47 @@ inline void InternalRangeLookupRequest::set_ignore_intents(bool value) {
 
 // InternalRangeLookupResponse
 
-// optional .cockroach.proto.ResponseHeader header = 1;
-inline bool InternalRangeLookupResponse::has_header() const {
+// optional .cockroach.proto.KVResponseHeader kvheader = 1;
+inline bool InternalRangeLookupResponse::has_kvheader() const {
   return (_has_bits_[0] & 0x00000001u) != 0;
 }
-inline void InternalRangeLookupResponse::set_has_header() {
+inline void InternalRangeLookupResponse::set_has_kvheader() {
   _has_bits_[0] |= 0x00000001u;
 }
-inline void InternalRangeLookupResponse::clear_has_header() {
+inline void InternalRangeLookupResponse::clear_has_kvheader() {
   _has_bits_[0] &= ~0x00000001u;
 }
-inline void InternalRangeLookupResponse::clear_header() {
-  if (header_ != NULL) header_->::cockroach::proto::ResponseHeader::Clear();
-  clear_has_header();
+inline void InternalRangeLookupResponse::clear_kvheader() {
+  if (kvheader_ != NULL) kvheader_->::cockroach::proto::KVResponseHeader::Clear();
+  clear_has_kvheader();
 }
-inline const ::cockroach::proto::ResponseHeader& InternalRangeLookupResponse::header() const {
-  // @@protoc_insertion_point(field_get:cockroach.proto.InternalRangeLookupResponse.header)
-  return header_ != NULL ? *header_ : *default_instance_->header_;
+inline const ::cockroach::proto::KVResponseHeader& InternalRangeLookupResponse::kvheader() const {
+  // @@protoc_insertion_point(field_get:cockroach.proto.InternalRangeLookupResponse.kvheader)
+  return kvheader_ != NULL ? *kvheader_ : *default_instance_->kvheader_;
 }
-inline ::cockroach::proto::ResponseHeader* InternalRangeLookupResponse::mutable_header() {
-  set_has_header();
-  if (header_ == NULL) {
-    header_ = new ::cockroach::proto::ResponseHeader;
+inline ::cockroach::proto::KVResponseHeader* InternalRangeLookupResponse::mutable_kvheader() {
+  set_has_kvheader();
+  if (kvheader_ == NULL) {
+    kvheader_ = new ::cockroach::proto::KVResponseHeader;
   }
-  // @@protoc_insertion_point(field_mutable:cockroach.proto.InternalRangeLookupResponse.header)
-  return header_;
+  // @@protoc_insertion_point(field_mutable:cockroach.proto.InternalRangeLookupResponse.kvheader)
+  return kvheader_;
 }
-inline ::cockroach::proto::ResponseHeader* InternalRangeLookupResponse::release_header() {
-  clear_has_header();
-  ::cockroach::proto::ResponseHeader* temp = header_;
-  header_ = NULL;
+inline ::cockroach::proto::KVResponseHeader* InternalRangeLookupResponse::release_kvheader() {
+  clear_has_kvheader();
+  ::cockroach::proto::KVResponseHeader* temp = kvheader_;
+  kvheader_ = NULL;
   return temp;
 }
-inline void InternalRangeLookupResponse::set_allocated_header(::cockroach::proto::ResponseHeader* header) {
-  delete header_;
-  header_ = header;
-  if (header) {
-    set_has_header();
+inline void InternalRangeLookupResponse::set_allocated_kvheader(::cockroach::proto::KVResponseHeader* kvheader) {
+  delete kvheader_;
+  kvheader_ = kvheader;
+  if (kvheader) {
+    set_has_kvheader();
   } else {
-    clear_has_header();
+    clear_has_kvheader();
   }
-  // @@protoc_insertion_point(field_set_allocated:cockroach.proto.InternalRangeLookupResponse.header)
+  // @@protoc_insertion_point(field_set_allocated:cockroach.proto.InternalRangeLookupResponse.kvheader)
 }
 
 // repeated .cockroach.proto.RangeDescriptor ranges = 2;
@@ -4277,94 +4277,94 @@ InternalRangeLookupResponse::mutable_ranges() {
 
 // InternalHeartbeatTxnRequest
 
-// optional .cockroach.proto.RequestHeader header = 1;
-inline bool InternalHeartbeatTxnRequest::has_header() const {
+// optional .cockroach.proto.KVRequestHeader kvheader = 1;
+inline bool InternalHeartbeatTxnRequest::has_kvheader() const {
   return (_has_bits_[0] & 0x00000001u) != 0;
 }
-inline void InternalHeartbeatTxnRequest::set_has_header() {
+inline void InternalHeartbeatTxnRequest::set_has_kvheader() {
   _has_bits_[0] |= 0x00000001u;
 }
-inline void InternalHeartbeatTxnRequest::clear_has_header() {
+inline void InternalHeartbeatTxnRequest::clear_has_kvheader() {
   _has_bits_[0] &= ~0x00000001u;
 }
-inline void InternalHeartbeatTxnRequest::clear_header() {
-  if (header_ != NULL) header_->::cockroach::proto::RequestHeader::Clear();
-  clear_has_header();
+inline void InternalHeartbeatTxnRequest::clear_kvheader() {
+  if (kvheader_ != NULL) kvheader_->::cockroach::proto::KVRequestHeader::Clear();
+  clear_has_kvheader();
 }
-inline const ::cockroach::proto::RequestHeader& InternalHeartbeatTxnRequest::header() const {
-  // @@protoc_insertion_point(field_get:cockroach.proto.InternalHeartbeatTxnRequest.header)
-  return header_ != NULL ? *header_ : *default_instance_->header_;
+inline const ::cockroach::proto::KVRequestHeader& InternalHeartbeatTxnRequest::kvheader() const {
+  // @@protoc_insertion_point(field_get:cockroach.proto.InternalHeartbeatTxnRequest.kvheader)
+  return kvheader_ != NULL ? *kvheader_ : *default_instance_->kvheader_;
 }
-inline ::cockroach::proto::RequestHeader* InternalHeartbeatTxnRequest::mutable_header() {
-  set_has_header();
-  if (header_ == NULL) {
-    header_ = new ::cockroach::proto::RequestHeader;
+inline ::cockroach::proto::KVRequestHeader* InternalHeartbeatTxnRequest::mutable_kvheader() {
+  set_has_kvheader();
+  if (kvheader_ == NULL) {
+    kvheader_ = new ::cockroach::proto::KVRequestHeader;
   }
-  // @@protoc_insertion_point(field_mutable:cockroach.proto.InternalHeartbeatTxnRequest.header)
-  return header_;
+  // @@protoc_insertion_point(field_mutable:cockroach.proto.InternalHeartbeatTxnRequest.kvheader)
+  return kvheader_;
 }
-inline ::cockroach::proto::RequestHeader* InternalHeartbeatTxnRequest::release_header() {
-  clear_has_header();
-  ::cockroach::proto::RequestHeader* temp = header_;
-  header_ = NULL;
+inline ::cockroach::proto::KVRequestHeader* InternalHeartbeatTxnRequest::release_kvheader() {
+  clear_has_kvheader();
+  ::cockroach::proto::KVRequestHeader* temp = kvheader_;
+  kvheader_ = NULL;
   return temp;
 }
-inline void InternalHeartbeatTxnRequest::set_allocated_header(::cockroach::proto::RequestHeader* header) {
-  delete header_;
-  header_ = header;
-  if (header) {
-    set_has_header();
+inline void InternalHeartbeatTxnRequest::set_allocated_kvheader(::cockroach::proto::KVRequestHeader* kvheader) {
+  delete kvheader_;
+  kvheader_ = kvheader;
+  if (kvheader) {
+    set_has_kvheader();
   } else {
-    clear_has_header();
+    clear_has_kvheader();
   }
-  // @@protoc_insertion_point(field_set_allocated:cockroach.proto.InternalHeartbeatTxnRequest.header)
+  // @@protoc_insertion_point(field_set_allocated:cockroach.proto.InternalHeartbeatTxnRequest.kvheader)
 }
 
 // -------------------------------------------------------------------
 
 // InternalHeartbeatTxnResponse
 
-// optional .cockroach.proto.ResponseHeader header = 1;
-inline bool InternalHeartbeatTxnResponse::has_header() const {
+// optional .cockroach.proto.KVResponseHeader kvheader = 1;
+inline bool InternalHeartbeatTxnResponse::has_kvheader() const {
   return (_has_bits_[0] & 0x00000001u) != 0;
 }
-inline void InternalHeartbeatTxnResponse::set_has_header() {
+inline void InternalHeartbeatTxnResponse::set_has_kvheader() {
   _has_bits_[0] |= 0x00000001u;
 }
-inline void InternalHeartbeatTxnResponse::clear_has_header() {
+inline void InternalHeartbeatTxnResponse::clear_has_kvheader() {
   _has_bits_[0] &= ~0x00000001u;
 }
-inline void InternalHeartbeatTxnResponse::clear_header() {
-  if (header_ != NULL) header_->::cockroach::proto::ResponseHeader::Clear();
-  clear_has_header();
+inline void InternalHeartbeatTxnResponse::clear_kvheader() {
+  if (kvheader_ != NULL) kvheader_->::cockroach::proto::KVResponseHeader::Clear();
+  clear_has_kvheader();
 }
-inline const ::cockroach::proto::ResponseHeader& InternalHeartbeatTxnResponse::header() const {
-  // @@protoc_insertion_point(field_get:cockroach.proto.InternalHeartbeatTxnResponse.header)
-  return header_ != NULL ? *header_ : *default_instance_->header_;
+inline const ::cockroach::proto::KVResponseHeader& InternalHeartbeatTxnResponse::kvheader() const {
+  // @@protoc_insertion_point(field_get:cockroach.proto.InternalHeartbeatTxnResponse.kvheader)
+  return kvheader_ != NULL ? *kvheader_ : *default_instance_->kvheader_;
 }
-inline ::cockroach::proto::ResponseHeader* InternalHeartbeatTxnResponse::mutable_header() {
-  set_has_header();
-  if (header_ == NULL) {
-    header_ = new ::cockroach::proto::ResponseHeader;
+inline ::cockroach::proto::KVResponseHeader* InternalHeartbeatTxnResponse::mutable_kvheader() {
+  set_has_kvheader();
+  if (kvheader_ == NULL) {
+    kvheader_ = new ::cockroach::proto::KVResponseHeader;
   }
-  // @@protoc_insertion_point(field_mutable:cockroach.proto.InternalHeartbeatTxnResponse.header)
-  return header_;
+  // @@protoc_insertion_point(field_mutable:cockroach.proto.InternalHeartbeatTxnResponse.kvheader)
+  return kvheader_;
 }
-inline ::cockroach::proto::ResponseHeader* InternalHeartbeatTxnResponse::release_header() {
-  clear_has_header();
-  ::cockroach::proto::ResponseHeader* temp = header_;
-  header_ = NULL;
+inline ::cockroach::proto::KVResponseHeader* InternalHeartbeatTxnResponse::release_kvheader() {
+  clear_has_kvheader();
+  ::cockroach::proto::KVResponseHeader* temp = kvheader_;
+  kvheader_ = NULL;
   return temp;
 }
-inline void InternalHeartbeatTxnResponse::set_allocated_header(::cockroach::proto::ResponseHeader* header) {
-  delete header_;
-  header_ = header;
-  if (header) {
-    set_has_header();
+inline void InternalHeartbeatTxnResponse::set_allocated_kvheader(::cockroach::proto::KVResponseHeader* kvheader) {
+  delete kvheader_;
+  kvheader_ = kvheader;
+  if (kvheader) {
+    set_has_kvheader();
   } else {
-    clear_has_header();
+    clear_has_kvheader();
   }
-  // @@protoc_insertion_point(field_set_allocated:cockroach.proto.InternalHeartbeatTxnResponse.header)
+  // @@protoc_insertion_point(field_set_allocated:cockroach.proto.InternalHeartbeatTxnResponse.kvheader)
 }
 
 // -------------------------------------------------------------------
@@ -4471,47 +4471,47 @@ inline void InternalGCRequest_GCKey::set_allocated_timestamp(::cockroach::proto:
 
 // InternalGCRequest
 
-// optional .cockroach.proto.RequestHeader header = 1;
-inline bool InternalGCRequest::has_header() const {
+// optional .cockroach.proto.KVRequestHeader kvheader = 1;
+inline bool InternalGCRequest::has_kvheader() const {
   return (_has_bits_[0] & 0x00000001u) != 0;
 }
-inline void InternalGCRequest::set_has_header() {
+inline void InternalGCRequest::set_has_kvheader() {
   _has_bits_[0] |= 0x00000001u;
 }
-inline void InternalGCRequest::clear_has_header() {
+inline void InternalGCRequest::clear_has_kvheader() {
   _has_bits_[0] &= ~0x00000001u;
 }
-inline void InternalGCRequest::clear_header() {
-  if (header_ != NULL) header_->::cockroach::proto::RequestHeader::Clear();
-  clear_has_header();
+inline void InternalGCRequest::clear_kvheader() {
+  if (kvheader_ != NULL) kvheader_->::cockroach::proto::KVRequestHeader::Clear();
+  clear_has_kvheader();
 }
-inline const ::cockroach::proto::RequestHeader& InternalGCRequest::header() const {
-  // @@protoc_insertion_point(field_get:cockroach.proto.InternalGCRequest.header)
-  return header_ != NULL ? *header_ : *default_instance_->header_;
+inline const ::cockroach::proto::KVRequestHeader& InternalGCRequest::kvheader() const {
+  // @@protoc_insertion_point(field_get:cockroach.proto.InternalGCRequest.kvheader)
+  return kvheader_ != NULL ? *kvheader_ : *default_instance_->kvheader_;
 }
-inline ::cockroach::proto::RequestHeader* InternalGCRequest::mutable_header() {
-  set_has_header();
-  if (header_ == NULL) {
-    header_ = new ::cockroach::proto::RequestHeader;
+inline ::cockroach::proto::KVRequestHeader* InternalGCRequest::mutable_kvheader() {
+  set_has_kvheader();
+  if (kvheader_ == NULL) {
+    kvheader_ = new ::cockroach::proto::KVRequestHeader;
   }
-  // @@protoc_insertion_point(field_mutable:cockroach.proto.InternalGCRequest.header)
-  return header_;
+  // @@protoc_insertion_point(field_mutable:cockroach.proto.InternalGCRequest.kvheader)
+  return kvheader_;
 }
-inline ::cockroach::proto::RequestHeader* InternalGCRequest::release_header() {
-  clear_has_header();
-  ::cockroach::proto::RequestHeader* temp = header_;
-  header_ = NULL;
+inline ::cockroach::proto::KVRequestHeader* InternalGCRequest::release_kvheader() {
+  clear_has_kvheader();
+  ::cockroach::proto::KVRequestHeader* temp = kvheader_;
+  kvheader_ = NULL;
   return temp;
 }
-inline void InternalGCRequest::set_allocated_header(::cockroach::proto::RequestHeader* header) {
-  delete header_;
-  header_ = header;
-  if (header) {
-    set_has_header();
+inline void InternalGCRequest::set_allocated_kvheader(::cockroach::proto::KVRequestHeader* kvheader) {
+  delete kvheader_;
+  kvheader_ = kvheader;
+  if (kvheader) {
+    set_has_kvheader();
   } else {
-    clear_has_header();
+    clear_has_kvheader();
   }
-  // @@protoc_insertion_point(field_set_allocated:cockroach.proto.InternalGCRequest.header)
+  // @@protoc_insertion_point(field_set_allocated:cockroach.proto.InternalGCRequest.kvheader)
 }
 
 // optional .cockroach.proto.GCMetadata gc_meta = 2;
@@ -4591,94 +4591,94 @@ InternalGCRequest::mutable_keys() {
 
 // InternalGCResponse
 
-// optional .cockroach.proto.ResponseHeader header = 1;
-inline bool InternalGCResponse::has_header() const {
+// optional .cockroach.proto.KVResponseHeader kvheader = 1;
+inline bool InternalGCResponse::has_kvheader() const {
   return (_has_bits_[0] & 0x00000001u) != 0;
 }
-inline void InternalGCResponse::set_has_header() {
+inline void InternalGCResponse::set_has_kvheader() {
   _has_bits_[0] |= 0x00000001u;
 }
-inline void InternalGCResponse::clear_has_header() {
+inline void InternalGCResponse::clear_has_kvheader() {
   _has_bits_[0] &= ~0x00000001u;
 }
-inline void InternalGCResponse::clear_header() {
-  if (header_ != NULL) header_->::cockroach::proto::ResponseHeader::Clear();
-  clear_has_header();
+inline void InternalGCResponse::clear_kvheader() {
+  if (kvheader_ != NULL) kvheader_->::cockroach::proto::KVResponseHeader::Clear();
+  clear_has_kvheader();
 }
-inline const ::cockroach::proto::ResponseHeader& InternalGCResponse::header() const {
-  // @@protoc_insertion_point(field_get:cockroach.proto.InternalGCResponse.header)
-  return header_ != NULL ? *header_ : *default_instance_->header_;
+inline const ::cockroach::proto::KVResponseHeader& InternalGCResponse::kvheader() const {
+  // @@protoc_insertion_point(field_get:cockroach.proto.InternalGCResponse.kvheader)
+  return kvheader_ != NULL ? *kvheader_ : *default_instance_->kvheader_;
 }
-inline ::cockroach::proto::ResponseHeader* InternalGCResponse::mutable_header() {
-  set_has_header();
-  if (header_ == NULL) {
-    header_ = new ::cockroach::proto::ResponseHeader;
+inline ::cockroach::proto::KVResponseHeader* InternalGCResponse::mutable_kvheader() {
+  set_has_kvheader();
+  if (kvheader_ == NULL) {
+    kvheader_ = new ::cockroach::proto::KVResponseHeader;
   }
-  // @@protoc_insertion_point(field_mutable:cockroach.proto.InternalGCResponse.header)
-  return header_;
+  // @@protoc_insertion_point(field_mutable:cockroach.proto.InternalGCResponse.kvheader)
+  return kvheader_;
 }
-inline ::cockroach::proto::ResponseHeader* InternalGCResponse::release_header() {
-  clear_has_header();
-  ::cockroach::proto::ResponseHeader* temp = header_;
-  header_ = NULL;
+inline ::cockroach::proto::KVResponseHeader* InternalGCResponse::release_kvheader() {
+  clear_has_kvheader();
+  ::cockroach::proto::KVResponseHeader* temp = kvheader_;
+  kvheader_ = NULL;
   return temp;
 }
-inline void InternalGCResponse::set_allocated_header(::cockroach::proto::ResponseHeader* header) {
-  delete header_;
-  header_ = header;
-  if (header) {
-    set_has_header();
+inline void InternalGCResponse::set_allocated_kvheader(::cockroach::proto::KVResponseHeader* kvheader) {
+  delete kvheader_;
+  kvheader_ = kvheader;
+  if (kvheader) {
+    set_has_kvheader();
   } else {
-    clear_has_header();
+    clear_has_kvheader();
   }
-  // @@protoc_insertion_point(field_set_allocated:cockroach.proto.InternalGCResponse.header)
+  // @@protoc_insertion_point(field_set_allocated:cockroach.proto.InternalGCResponse.kvheader)
 }
 
 // -------------------------------------------------------------------
 
 // InternalPushTxnRequest
 
-// optional .cockroach.proto.RequestHeader header = 1;
-inline bool InternalPushTxnRequest::has_header() const {
+// optional .cockroach.proto.KVRequestHeader kvheader = 1;
+inline bool InternalPushTxnRequest::has_kvheader() const {
   return (_has_bits_[0] & 0x00000001u) != 0;
 }
-inline void InternalPushTxnRequest::set_has_header() {
+inline void InternalPushTxnRequest::set_has_kvheader() {
   _has_bits_[0] |= 0x00000001u;
 }
-inline void InternalPushTxnRequest::clear_has_header() {
+inline void InternalPushTxnRequest::clear_has_kvheader() {
   _has_bits_[0] &= ~0x00000001u;
 }
-inline void InternalPushTxnRequest::clear_header() {
-  if (header_ != NULL) header_->::cockroach::proto::RequestHeader::Clear();
-  clear_has_header();
+inline void InternalPushTxnRequest::clear_kvheader() {
+  if (kvheader_ != NULL) kvheader_->::cockroach::proto::KVRequestHeader::Clear();
+  clear_has_kvheader();
 }
-inline const ::cockroach::proto::RequestHeader& InternalPushTxnRequest::header() const {
-  // @@protoc_insertion_point(field_get:cockroach.proto.InternalPushTxnRequest.header)
-  return header_ != NULL ? *header_ : *default_instance_->header_;
+inline const ::cockroach::proto::KVRequestHeader& InternalPushTxnRequest::kvheader() const {
+  // @@protoc_insertion_point(field_get:cockroach.proto.InternalPushTxnRequest.kvheader)
+  return kvheader_ != NULL ? *kvheader_ : *default_instance_->kvheader_;
 }
-inline ::cockroach::proto::RequestHeader* InternalPushTxnRequest::mutable_header() {
-  set_has_header();
-  if (header_ == NULL) {
-    header_ = new ::cockroach::proto::RequestHeader;
+inline ::cockroach::proto::KVRequestHeader* InternalPushTxnRequest::mutable_kvheader() {
+  set_has_kvheader();
+  if (kvheader_ == NULL) {
+    kvheader_ = new ::cockroach::proto::KVRequestHeader;
   }
-  // @@protoc_insertion_point(field_mutable:cockroach.proto.InternalPushTxnRequest.header)
-  return header_;
+  // @@protoc_insertion_point(field_mutable:cockroach.proto.InternalPushTxnRequest.kvheader)
+  return kvheader_;
 }
-inline ::cockroach::proto::RequestHeader* InternalPushTxnRequest::release_header() {
-  clear_has_header();
-  ::cockroach::proto::RequestHeader* temp = header_;
-  header_ = NULL;
+inline ::cockroach::proto::KVRequestHeader* InternalPushTxnRequest::release_kvheader() {
+  clear_has_kvheader();
+  ::cockroach::proto::KVRequestHeader* temp = kvheader_;
+  kvheader_ = NULL;
   return temp;
 }
-inline void InternalPushTxnRequest::set_allocated_header(::cockroach::proto::RequestHeader* header) {
-  delete header_;
-  header_ = header;
-  if (header) {
-    set_has_header();
+inline void InternalPushTxnRequest::set_allocated_kvheader(::cockroach::proto::KVRequestHeader* kvheader) {
+  delete kvheader_;
+  kvheader_ = kvheader;
+  if (kvheader) {
+    set_has_kvheader();
   } else {
-    clear_has_header();
+    clear_has_kvheader();
   }
-  // @@protoc_insertion_point(field_set_allocated:cockroach.proto.InternalPushTxnRequest.header)
+  // @@protoc_insertion_point(field_set_allocated:cockroach.proto.InternalPushTxnRequest.kvheader)
 }
 
 // optional .cockroach.proto.Transaction pushee_txn = 2;
@@ -4820,47 +4820,47 @@ inline void InternalPushTxnRequest::set_range_lookup(bool value) {
 
 // InternalPushTxnResponse
 
-// optional .cockroach.proto.ResponseHeader header = 1;
-inline bool InternalPushTxnResponse::has_header() const {
+// optional .cockroach.proto.KVResponseHeader kvheader = 1;
+inline bool InternalPushTxnResponse::has_kvheader() const {
   return (_has_bits_[0] & 0x00000001u) != 0;
 }
-inline void InternalPushTxnResponse::set_has_header() {
+inline void InternalPushTxnResponse::set_has_kvheader() {
   _has_bits_[0] |= 0x00000001u;
 }
-inline void InternalPushTxnResponse::clear_has_header() {
+inline void InternalPushTxnResponse::clear_has_kvheader() {
   _has_bits_[0] &= ~0x00000001u;
 }
-inline void InternalPushTxnResponse::clear_header() {
-  if (header_ != NULL) header_->::cockroach::proto::ResponseHeader::Clear();
-  clear_has_header();
+inline void InternalPushTxnResponse::clear_kvheader() {
+  if (kvheader_ != NULL) kvheader_->::cockroach::proto::KVResponseHeader::Clear();
+  clear_has_kvheader();
 }
-inline const ::cockroach::proto::ResponseHeader& InternalPushTxnResponse::header() const {
-  // @@protoc_insertion_point(field_get:cockroach.proto.InternalPushTxnResponse.header)
-  return header_ != NULL ? *header_ : *default_instance_->header_;
+inline const ::cockroach::proto::KVResponseHeader& InternalPushTxnResponse::kvheader() const {
+  // @@protoc_insertion_point(field_get:cockroach.proto.InternalPushTxnResponse.kvheader)
+  return kvheader_ != NULL ? *kvheader_ : *default_instance_->kvheader_;
 }
-inline ::cockroach::proto::ResponseHeader* InternalPushTxnResponse::mutable_header() {
-  set_has_header();
-  if (header_ == NULL) {
-    header_ = new ::cockroach::proto::ResponseHeader;
+inline ::cockroach::proto::KVResponseHeader* InternalPushTxnResponse::mutable_kvheader() {
+  set_has_kvheader();
+  if (kvheader_ == NULL) {
+    kvheader_ = new ::cockroach::proto::KVResponseHeader;
   }
-  // @@protoc_insertion_point(field_mutable:cockroach.proto.InternalPushTxnResponse.header)
-  return header_;
+  // @@protoc_insertion_point(field_mutable:cockroach.proto.InternalPushTxnResponse.kvheader)
+  return kvheader_;
 }
-inline ::cockroach::proto::ResponseHeader* InternalPushTxnResponse::release_header() {
-  clear_has_header();
-  ::cockroach::proto::ResponseHeader* temp = header_;
-  header_ = NULL;
+inline ::cockroach::proto::KVResponseHeader* InternalPushTxnResponse::release_kvheader() {
+  clear_has_kvheader();
+  ::cockroach::proto::KVResponseHeader* temp = kvheader_;
+  kvheader_ = NULL;
   return temp;
 }
-inline void InternalPushTxnResponse::set_allocated_header(::cockroach::proto::ResponseHeader* header) {
-  delete header_;
-  header_ = header;
-  if (header) {
-    set_has_header();
+inline void InternalPushTxnResponse::set_allocated_kvheader(::cockroach::proto::KVResponseHeader* kvheader) {
+  delete kvheader_;
+  kvheader_ = kvheader;
+  if (kvheader) {
+    set_has_kvheader();
   } else {
-    clear_has_header();
+    clear_has_kvheader();
   }
-  // @@protoc_insertion_point(field_set_allocated:cockroach.proto.InternalPushTxnResponse.header)
+  // @@protoc_insertion_point(field_set_allocated:cockroach.proto.InternalPushTxnResponse.kvheader)
 }
 
 // optional .cockroach.proto.Transaction pushee_txn = 2;
@@ -4910,235 +4910,235 @@ inline void InternalPushTxnResponse::set_allocated_pushee_txn(::cockroach::proto
 
 // InternalResolveIntentRequest
 
-// optional .cockroach.proto.RequestHeader header = 1;
-inline bool InternalResolveIntentRequest::has_header() const {
+// optional .cockroach.proto.KVRequestHeader kvheader = 1;
+inline bool InternalResolveIntentRequest::has_kvheader() const {
   return (_has_bits_[0] & 0x00000001u) != 0;
 }
-inline void InternalResolveIntentRequest::set_has_header() {
+inline void InternalResolveIntentRequest::set_has_kvheader() {
   _has_bits_[0] |= 0x00000001u;
 }
-inline void InternalResolveIntentRequest::clear_has_header() {
+inline void InternalResolveIntentRequest::clear_has_kvheader() {
   _has_bits_[0] &= ~0x00000001u;
 }
-inline void InternalResolveIntentRequest::clear_header() {
-  if (header_ != NULL) header_->::cockroach::proto::RequestHeader::Clear();
-  clear_has_header();
+inline void InternalResolveIntentRequest::clear_kvheader() {
+  if (kvheader_ != NULL) kvheader_->::cockroach::proto::KVRequestHeader::Clear();
+  clear_has_kvheader();
 }
-inline const ::cockroach::proto::RequestHeader& InternalResolveIntentRequest::header() const {
-  // @@protoc_insertion_point(field_get:cockroach.proto.InternalResolveIntentRequest.header)
-  return header_ != NULL ? *header_ : *default_instance_->header_;
+inline const ::cockroach::proto::KVRequestHeader& InternalResolveIntentRequest::kvheader() const {
+  // @@protoc_insertion_point(field_get:cockroach.proto.InternalResolveIntentRequest.kvheader)
+  return kvheader_ != NULL ? *kvheader_ : *default_instance_->kvheader_;
 }
-inline ::cockroach::proto::RequestHeader* InternalResolveIntentRequest::mutable_header() {
-  set_has_header();
-  if (header_ == NULL) {
-    header_ = new ::cockroach::proto::RequestHeader;
+inline ::cockroach::proto::KVRequestHeader* InternalResolveIntentRequest::mutable_kvheader() {
+  set_has_kvheader();
+  if (kvheader_ == NULL) {
+    kvheader_ = new ::cockroach::proto::KVRequestHeader;
   }
-  // @@protoc_insertion_point(field_mutable:cockroach.proto.InternalResolveIntentRequest.header)
-  return header_;
+  // @@protoc_insertion_point(field_mutable:cockroach.proto.InternalResolveIntentRequest.kvheader)
+  return kvheader_;
 }
-inline ::cockroach::proto::RequestHeader* InternalResolveIntentRequest::release_header() {
-  clear_has_header();
-  ::cockroach::proto::RequestHeader* temp = header_;
-  header_ = NULL;
+inline ::cockroach::proto::KVRequestHeader* InternalResolveIntentRequest::release_kvheader() {
+  clear_has_kvheader();
+  ::cockroach::proto::KVRequestHeader* temp = kvheader_;
+  kvheader_ = NULL;
   return temp;
 }
-inline void InternalResolveIntentRequest::set_allocated_header(::cockroach::proto::RequestHeader* header) {
-  delete header_;
-  header_ = header;
-  if (header) {
-    set_has_header();
+inline void InternalResolveIntentRequest::set_allocated_kvheader(::cockroach::proto::KVRequestHeader* kvheader) {
+  delete kvheader_;
+  kvheader_ = kvheader;
+  if (kvheader) {
+    set_has_kvheader();
   } else {
-    clear_has_header();
+    clear_has_kvheader();
   }
-  // @@protoc_insertion_point(field_set_allocated:cockroach.proto.InternalResolveIntentRequest.header)
+  // @@protoc_insertion_point(field_set_allocated:cockroach.proto.InternalResolveIntentRequest.kvheader)
 }
 
 // -------------------------------------------------------------------
 
 // InternalResolveIntentResponse
 
-// optional .cockroach.proto.ResponseHeader header = 1;
-inline bool InternalResolveIntentResponse::has_header() const {
+// optional .cockroach.proto.KVResponseHeader kvheader = 1;
+inline bool InternalResolveIntentResponse::has_kvheader() const {
   return (_has_bits_[0] & 0x00000001u) != 0;
 }
-inline void InternalResolveIntentResponse::set_has_header() {
+inline void InternalResolveIntentResponse::set_has_kvheader() {
   _has_bits_[0] |= 0x00000001u;
 }
-inline void InternalResolveIntentResponse::clear_has_header() {
+inline void InternalResolveIntentResponse::clear_has_kvheader() {
   _has_bits_[0] &= ~0x00000001u;
 }
-inline void InternalResolveIntentResponse::clear_header() {
-  if (header_ != NULL) header_->::cockroach::proto::ResponseHeader::Clear();
-  clear_has_header();
+inline void InternalResolveIntentResponse::clear_kvheader() {
+  if (kvheader_ != NULL) kvheader_->::cockroach::proto::KVResponseHeader::Clear();
+  clear_has_kvheader();
 }
-inline const ::cockroach::proto::ResponseHeader& InternalResolveIntentResponse::header() const {
-  // @@protoc_insertion_point(field_get:cockroach.proto.InternalResolveIntentResponse.header)
-  return header_ != NULL ? *header_ : *default_instance_->header_;
+inline const ::cockroach::proto::KVResponseHeader& InternalResolveIntentResponse::kvheader() const {
+  // @@protoc_insertion_point(field_get:cockroach.proto.InternalResolveIntentResponse.kvheader)
+  return kvheader_ != NULL ? *kvheader_ : *default_instance_->kvheader_;
 }
-inline ::cockroach::proto::ResponseHeader* InternalResolveIntentResponse::mutable_header() {
-  set_has_header();
-  if (header_ == NULL) {
-    header_ = new ::cockroach::proto::ResponseHeader;
+inline ::cockroach::proto::KVResponseHeader* InternalResolveIntentResponse::mutable_kvheader() {
+  set_has_kvheader();
+  if (kvheader_ == NULL) {
+    kvheader_ = new ::cockroach::proto::KVResponseHeader;
   }
-  // @@protoc_insertion_point(field_mutable:cockroach.proto.InternalResolveIntentResponse.header)
-  return header_;
+  // @@protoc_insertion_point(field_mutable:cockroach.proto.InternalResolveIntentResponse.kvheader)
+  return kvheader_;
 }
-inline ::cockroach::proto::ResponseHeader* InternalResolveIntentResponse::release_header() {
-  clear_has_header();
-  ::cockroach::proto::ResponseHeader* temp = header_;
-  header_ = NULL;
+inline ::cockroach::proto::KVResponseHeader* InternalResolveIntentResponse::release_kvheader() {
+  clear_has_kvheader();
+  ::cockroach::proto::KVResponseHeader* temp = kvheader_;
+  kvheader_ = NULL;
   return temp;
 }
-inline void InternalResolveIntentResponse::set_allocated_header(::cockroach::proto::ResponseHeader* header) {
-  delete header_;
-  header_ = header;
-  if (header) {
-    set_has_header();
+inline void InternalResolveIntentResponse::set_allocated_kvheader(::cockroach::proto::KVResponseHeader* kvheader) {
+  delete kvheader_;
+  kvheader_ = kvheader;
+  if (kvheader) {
+    set_has_kvheader();
   } else {
-    clear_has_header();
+    clear_has_kvheader();
   }
-  // @@protoc_insertion_point(field_set_allocated:cockroach.proto.InternalResolveIntentResponse.header)
+  // @@protoc_insertion_point(field_set_allocated:cockroach.proto.InternalResolveIntentResponse.kvheader)
 }
 
 // -------------------------------------------------------------------
 
 // InternalResolveIntentRangeRequest
 
-// optional .cockroach.proto.RequestHeader header = 1;
-inline bool InternalResolveIntentRangeRequest::has_header() const {
+// optional .cockroach.proto.KVRequestHeader kvheader = 1;
+inline bool InternalResolveIntentRangeRequest::has_kvheader() const {
   return (_has_bits_[0] & 0x00000001u) != 0;
 }
-inline void InternalResolveIntentRangeRequest::set_has_header() {
+inline void InternalResolveIntentRangeRequest::set_has_kvheader() {
   _has_bits_[0] |= 0x00000001u;
 }
-inline void InternalResolveIntentRangeRequest::clear_has_header() {
+inline void InternalResolveIntentRangeRequest::clear_has_kvheader() {
   _has_bits_[0] &= ~0x00000001u;
 }
-inline void InternalResolveIntentRangeRequest::clear_header() {
-  if (header_ != NULL) header_->::cockroach::proto::RequestHeader::Clear();
-  clear_has_header();
+inline void InternalResolveIntentRangeRequest::clear_kvheader() {
+  if (kvheader_ != NULL) kvheader_->::cockroach::proto::KVRequestHeader::Clear();
+  clear_has_kvheader();
 }
-inline const ::cockroach::proto::RequestHeader& InternalResolveIntentRangeRequest::header() const {
-  // @@protoc_insertion_point(field_get:cockroach.proto.InternalResolveIntentRangeRequest.header)
-  return header_ != NULL ? *header_ : *default_instance_->header_;
+inline const ::cockroach::proto::KVRequestHeader& InternalResolveIntentRangeRequest::kvheader() const {
+  // @@protoc_insertion_point(field_get:cockroach.proto.InternalResolveIntentRangeRequest.kvheader)
+  return kvheader_ != NULL ? *kvheader_ : *default_instance_->kvheader_;
 }
-inline ::cockroach::proto::RequestHeader* InternalResolveIntentRangeRequest::mutable_header() {
-  set_has_header();
-  if (header_ == NULL) {
-    header_ = new ::cockroach::proto::RequestHeader;
+inline ::cockroach::proto::KVRequestHeader* InternalResolveIntentRangeRequest::mutable_kvheader() {
+  set_has_kvheader();
+  if (kvheader_ == NULL) {
+    kvheader_ = new ::cockroach::proto::KVRequestHeader;
   }
-  // @@protoc_insertion_point(field_mutable:cockroach.proto.InternalResolveIntentRangeRequest.header)
-  return header_;
+  // @@protoc_insertion_point(field_mutable:cockroach.proto.InternalResolveIntentRangeRequest.kvheader)
+  return kvheader_;
 }
-inline ::cockroach::proto::RequestHeader* InternalResolveIntentRangeRequest::release_header() {
-  clear_has_header();
-  ::cockroach::proto::RequestHeader* temp = header_;
-  header_ = NULL;
+inline ::cockroach::proto::KVRequestHeader* InternalResolveIntentRangeRequest::release_kvheader() {
+  clear_has_kvheader();
+  ::cockroach::proto::KVRequestHeader* temp = kvheader_;
+  kvheader_ = NULL;
   return temp;
 }
-inline void InternalResolveIntentRangeRequest::set_allocated_header(::cockroach::proto::RequestHeader* header) {
-  delete header_;
-  header_ = header;
-  if (header) {
-    set_has_header();
+inline void InternalResolveIntentRangeRequest::set_allocated_kvheader(::cockroach::proto::KVRequestHeader* kvheader) {
+  delete kvheader_;
+  kvheader_ = kvheader;
+  if (kvheader) {
+    set_has_kvheader();
   } else {
-    clear_has_header();
+    clear_has_kvheader();
   }
-  // @@protoc_insertion_point(field_set_allocated:cockroach.proto.InternalResolveIntentRangeRequest.header)
+  // @@protoc_insertion_point(field_set_allocated:cockroach.proto.InternalResolveIntentRangeRequest.kvheader)
 }
 
 // -------------------------------------------------------------------
 
 // InternalResolveIntentRangeResponse
 
-// optional .cockroach.proto.ResponseHeader header = 1;
-inline bool InternalResolveIntentRangeResponse::has_header() const {
+// optional .cockroach.proto.KVResponseHeader kvheader = 1;
+inline bool InternalResolveIntentRangeResponse::has_kvheader() const {
   return (_has_bits_[0] & 0x00000001u) != 0;
 }
-inline void InternalResolveIntentRangeResponse::set_has_header() {
+inline void InternalResolveIntentRangeResponse::set_has_kvheader() {
   _has_bits_[0] |= 0x00000001u;
 }
-inline void InternalResolveIntentRangeResponse::clear_has_header() {
+inline void InternalResolveIntentRangeResponse::clear_has_kvheader() {
   _has_bits_[0] &= ~0x00000001u;
 }
-inline void InternalResolveIntentRangeResponse::clear_header() {
-  if (header_ != NULL) header_->::cockroach::proto::ResponseHeader::Clear();
-  clear_has_header();
+inline void InternalResolveIntentRangeResponse::clear_kvheader() {
+  if (kvheader_ != NULL) kvheader_->::cockroach::proto::KVResponseHeader::Clear();
+  clear_has_kvheader();
 }
-inline const ::cockroach::proto::ResponseHeader& InternalResolveIntentRangeResponse::header() const {
-  // @@protoc_insertion_point(field_get:cockroach.proto.InternalResolveIntentRangeResponse.header)
-  return header_ != NULL ? *header_ : *default_instance_->header_;
+inline const ::cockroach::proto::KVResponseHeader& InternalResolveIntentRangeResponse::kvheader() const {
+  // @@protoc_insertion_point(field_get:cockroach.proto.InternalResolveIntentRangeResponse.kvheader)
+  return kvheader_ != NULL ? *kvheader_ : *default_instance_->kvheader_;
 }
-inline ::cockroach::proto::ResponseHeader* InternalResolveIntentRangeResponse::mutable_header() {
-  set_has_header();
-  if (header_ == NULL) {
-    header_ = new ::cockroach::proto::ResponseHeader;
+inline ::cockroach::proto::KVResponseHeader* InternalResolveIntentRangeResponse::mutable_kvheader() {
+  set_has_kvheader();
+  if (kvheader_ == NULL) {
+    kvheader_ = new ::cockroach::proto::KVResponseHeader;
   }
-  // @@protoc_insertion_point(field_mutable:cockroach.proto.InternalResolveIntentRangeResponse.header)
-  return header_;
+  // @@protoc_insertion_point(field_mutable:cockroach.proto.InternalResolveIntentRangeResponse.kvheader)
+  return kvheader_;
 }
-inline ::cockroach::proto::ResponseHeader* InternalResolveIntentRangeResponse::release_header() {
-  clear_has_header();
-  ::cockroach::proto::ResponseHeader* temp = header_;
-  header_ = NULL;
+inline ::cockroach::proto::KVResponseHeader* InternalResolveIntentRangeResponse::release_kvheader() {
+  clear_has_kvheader();
+  ::cockroach::proto::KVResponseHeader* temp = kvheader_;
+  kvheader_ = NULL;
   return temp;
 }
-inline void InternalResolveIntentRangeResponse::set_allocated_header(::cockroach::proto::ResponseHeader* header) {
-  delete header_;
-  header_ = header;
-  if (header) {
-    set_has_header();
+inline void InternalResolveIntentRangeResponse::set_allocated_kvheader(::cockroach::proto::KVResponseHeader* kvheader) {
+  delete kvheader_;
+  kvheader_ = kvheader;
+  if (kvheader) {
+    set_has_kvheader();
   } else {
-    clear_has_header();
+    clear_has_kvheader();
   }
-  // @@protoc_insertion_point(field_set_allocated:cockroach.proto.InternalResolveIntentRangeResponse.header)
+  // @@protoc_insertion_point(field_set_allocated:cockroach.proto.InternalResolveIntentRangeResponse.kvheader)
 }
 
 // -------------------------------------------------------------------
 
 // InternalMergeRequest
 
-// optional .cockroach.proto.RequestHeader header = 1;
-inline bool InternalMergeRequest::has_header() const {
+// optional .cockroach.proto.KVRequestHeader kvheader = 1;
+inline bool InternalMergeRequest::has_kvheader() const {
   return (_has_bits_[0] & 0x00000001u) != 0;
 }
-inline void InternalMergeRequest::set_has_header() {
+inline void InternalMergeRequest::set_has_kvheader() {
   _has_bits_[0] |= 0x00000001u;
 }
-inline void InternalMergeRequest::clear_has_header() {
+inline void InternalMergeRequest::clear_has_kvheader() {
   _has_bits_[0] &= ~0x00000001u;
 }
-inline void InternalMergeRequest::clear_header() {
-  if (header_ != NULL) header_->::cockroach::proto::RequestHeader::Clear();
-  clear_has_header();
+inline void InternalMergeRequest::clear_kvheader() {
+  if (kvheader_ != NULL) kvheader_->::cockroach::proto::KVRequestHeader::Clear();
+  clear_has_kvheader();
 }
-inline const ::cockroach::proto::RequestHeader& InternalMergeRequest::header() const {
-  // @@protoc_insertion_point(field_get:cockroach.proto.InternalMergeRequest.header)
-  return header_ != NULL ? *header_ : *default_instance_->header_;
+inline const ::cockroach::proto::KVRequestHeader& InternalMergeRequest::kvheader() const {
+  // @@protoc_insertion_point(field_get:cockroach.proto.InternalMergeRequest.kvheader)
+  return kvheader_ != NULL ? *kvheader_ : *default_instance_->kvheader_;
 }
-inline ::cockroach::proto::RequestHeader* InternalMergeRequest::mutable_header() {
-  set_has_header();
-  if (header_ == NULL) {
-    header_ = new ::cockroach::proto::RequestHeader;
+inline ::cockroach::proto::KVRequestHeader* InternalMergeRequest::mutable_kvheader() {
+  set_has_kvheader();
+  if (kvheader_ == NULL) {
+    kvheader_ = new ::cockroach::proto::KVRequestHeader;
   }
-  // @@protoc_insertion_point(field_mutable:cockroach.proto.InternalMergeRequest.header)
-  return header_;
+  // @@protoc_insertion_point(field_mutable:cockroach.proto.InternalMergeRequest.kvheader)
+  return kvheader_;
 }
-inline ::cockroach::proto::RequestHeader* InternalMergeRequest::release_header() {
-  clear_has_header();
-  ::cockroach::proto::RequestHeader* temp = header_;
-  header_ = NULL;
+inline ::cockroach::proto::KVRequestHeader* InternalMergeRequest::release_kvheader() {
+  clear_has_kvheader();
+  ::cockroach::proto::KVRequestHeader* temp = kvheader_;
+  kvheader_ = NULL;
   return temp;
 }
-inline void InternalMergeRequest::set_allocated_header(::cockroach::proto::RequestHeader* header) {
-  delete header_;
-  header_ = header;
-  if (header) {
-    set_has_header();
+inline void InternalMergeRequest::set_allocated_kvheader(::cockroach::proto::KVRequestHeader* kvheader) {
+  delete kvheader_;
+  kvheader_ = kvheader;
+  if (kvheader) {
+    set_has_kvheader();
   } else {
-    clear_has_header();
+    clear_has_kvheader();
   }
-  // @@protoc_insertion_point(field_set_allocated:cockroach.proto.InternalMergeRequest.header)
+  // @@protoc_insertion_point(field_set_allocated:cockroach.proto.InternalMergeRequest.kvheader)
 }
 
 // optional .cockroach.proto.Value value = 2;
@@ -5188,94 +5188,94 @@ inline void InternalMergeRequest::set_allocated_value(::cockroach::proto::Value*
 
 // InternalMergeResponse
 
-// optional .cockroach.proto.ResponseHeader header = 1;
-inline bool InternalMergeResponse::has_header() const {
+// optional .cockroach.proto.KVResponseHeader kvheader = 1;
+inline bool InternalMergeResponse::has_kvheader() const {
   return (_has_bits_[0] & 0x00000001u) != 0;
 }
-inline void InternalMergeResponse::set_has_header() {
+inline void InternalMergeResponse::set_has_kvheader() {
   _has_bits_[0] |= 0x00000001u;
 }
-inline void InternalMergeResponse::clear_has_header() {
+inline void InternalMergeResponse::clear_has_kvheader() {
   _has_bits_[0] &= ~0x00000001u;
 }
-inline void InternalMergeResponse::clear_header() {
-  if (header_ != NULL) header_->::cockroach::proto::ResponseHeader::Clear();
-  clear_has_header();
+inline void InternalMergeResponse::clear_kvheader() {
+  if (kvheader_ != NULL) kvheader_->::cockroach::proto::KVResponseHeader::Clear();
+  clear_has_kvheader();
 }
-inline const ::cockroach::proto::ResponseHeader& InternalMergeResponse::header() const {
-  // @@protoc_insertion_point(field_get:cockroach.proto.InternalMergeResponse.header)
-  return header_ != NULL ? *header_ : *default_instance_->header_;
+inline const ::cockroach::proto::KVResponseHeader& InternalMergeResponse::kvheader() const {
+  // @@protoc_insertion_point(field_get:cockroach.proto.InternalMergeResponse.kvheader)
+  return kvheader_ != NULL ? *kvheader_ : *default_instance_->kvheader_;
 }
-inline ::cockroach::proto::ResponseHeader* InternalMergeResponse::mutable_header() {
-  set_has_header();
-  if (header_ == NULL) {
-    header_ = new ::cockroach::proto::ResponseHeader;
+inline ::cockroach::proto::KVResponseHeader* InternalMergeResponse::mutable_kvheader() {
+  set_has_kvheader();
+  if (kvheader_ == NULL) {
+    kvheader_ = new ::cockroach::proto::KVResponseHeader;
   }
-  // @@protoc_insertion_point(field_mutable:cockroach.proto.InternalMergeResponse.header)
-  return header_;
+  // @@protoc_insertion_point(field_mutable:cockroach.proto.InternalMergeResponse.kvheader)
+  return kvheader_;
 }
-inline ::cockroach::proto::ResponseHeader* InternalMergeResponse::release_header() {
-  clear_has_header();
-  ::cockroach::proto::ResponseHeader* temp = header_;
-  header_ = NULL;
+inline ::cockroach::proto::KVResponseHeader* InternalMergeResponse::release_kvheader() {
+  clear_has_kvheader();
+  ::cockroach::proto::KVResponseHeader* temp = kvheader_;
+  kvheader_ = NULL;
   return temp;
 }
-inline void InternalMergeResponse::set_allocated_header(::cockroach::proto::ResponseHeader* header) {
-  delete header_;
-  header_ = header;
-  if (header) {
-    set_has_header();
+inline void InternalMergeResponse::set_allocated_kvheader(::cockroach::proto::KVResponseHeader* kvheader) {
+  delete kvheader_;
+  kvheader_ = kvheader;
+  if (kvheader) {
+    set_has_kvheader();
   } else {
-    clear_has_header();
+    clear_has_kvheader();
   }
-  // @@protoc_insertion_point(field_set_allocated:cockroach.proto.InternalMergeResponse.header)
+  // @@protoc_insertion_point(field_set_allocated:cockroach.proto.InternalMergeResponse.kvheader)
 }
 
 // -------------------------------------------------------------------
 
 // InternalTruncateLogRequest
 
-// optional .cockroach.proto.RequestHeader header = 1;
-inline bool InternalTruncateLogRequest::has_header() const {
+// optional .cockroach.proto.KVRequestHeader kvheader = 1;
+inline bool InternalTruncateLogRequest::has_kvheader() const {
   return (_has_bits_[0] & 0x00000001u) != 0;
 }
-inline void InternalTruncateLogRequest::set_has_header() {
+inline void InternalTruncateLogRequest::set_has_kvheader() {
   _has_bits_[0] |= 0x00000001u;
 }
-inline void InternalTruncateLogRequest::clear_has_header() {
+inline void InternalTruncateLogRequest::clear_has_kvheader() {
   _has_bits_[0] &= ~0x00000001u;
 }
-inline void InternalTruncateLogRequest::clear_header() {
-  if (header_ != NULL) header_->::cockroach::proto::RequestHeader::Clear();
-  clear_has_header();
+inline void InternalTruncateLogRequest::clear_kvheader() {
+  if (kvheader_ != NULL) kvheader_->::cockroach::proto::KVRequestHeader::Clear();
+  clear_has_kvheader();
 }
-inline const ::cockroach::proto::RequestHeader& InternalTruncateLogRequest::header() const {
-  // @@protoc_insertion_point(field_get:cockroach.proto.InternalTruncateLogRequest.header)
-  return header_ != NULL ? *header_ : *default_instance_->header_;
+inline const ::cockroach::proto::KVRequestHeader& InternalTruncateLogRequest::kvheader() const {
+  // @@protoc_insertion_point(field_get:cockroach.proto.InternalTruncateLogRequest.kvheader)
+  return kvheader_ != NULL ? *kvheader_ : *default_instance_->kvheader_;
 }
-inline ::cockroach::proto::RequestHeader* InternalTruncateLogRequest::mutable_header() {
-  set_has_header();
-  if (header_ == NULL) {
-    header_ = new ::cockroach::proto::RequestHeader;
+inline ::cockroach::proto::KVRequestHeader* InternalTruncateLogRequest::mutable_kvheader() {
+  set_has_kvheader();
+  if (kvheader_ == NULL) {
+    kvheader_ = new ::cockroach::proto::KVRequestHeader;
   }
-  // @@protoc_insertion_point(field_mutable:cockroach.proto.InternalTruncateLogRequest.header)
-  return header_;
+  // @@protoc_insertion_point(field_mutable:cockroach.proto.InternalTruncateLogRequest.kvheader)
+  return kvheader_;
 }
-inline ::cockroach::proto::RequestHeader* InternalTruncateLogRequest::release_header() {
-  clear_has_header();
-  ::cockroach::proto::RequestHeader* temp = header_;
-  header_ = NULL;
+inline ::cockroach::proto::KVRequestHeader* InternalTruncateLogRequest::release_kvheader() {
+  clear_has_kvheader();
+  ::cockroach::proto::KVRequestHeader* temp = kvheader_;
+  kvheader_ = NULL;
   return temp;
 }
-inline void InternalTruncateLogRequest::set_allocated_header(::cockroach::proto::RequestHeader* header) {
-  delete header_;
-  header_ = header;
-  if (header) {
-    set_has_header();
+inline void InternalTruncateLogRequest::set_allocated_kvheader(::cockroach::proto::KVRequestHeader* kvheader) {
+  delete kvheader_;
+  kvheader_ = kvheader;
+  if (kvheader) {
+    set_has_kvheader();
   } else {
-    clear_has_header();
+    clear_has_kvheader();
   }
-  // @@protoc_insertion_point(field_set_allocated:cockroach.proto.InternalTruncateLogRequest.header)
+  // @@protoc_insertion_point(field_set_allocated:cockroach.proto.InternalTruncateLogRequest.kvheader)
 }
 
 // optional uint64 index = 2;
@@ -5306,94 +5306,94 @@ inline void InternalTruncateLogRequest::set_index(::google::protobuf::uint64 val
 
 // InternalTruncateLogResponse
 
-// optional .cockroach.proto.ResponseHeader header = 1;
-inline bool InternalTruncateLogResponse::has_header() const {
+// optional .cockroach.proto.KVResponseHeader kvheader = 1;
+inline bool InternalTruncateLogResponse::has_kvheader() const {
   return (_has_bits_[0] & 0x00000001u) != 0;
 }
-inline void InternalTruncateLogResponse::set_has_header() {
+inline void InternalTruncateLogResponse::set_has_kvheader() {
   _has_bits_[0] |= 0x00000001u;
 }
-inline void InternalTruncateLogResponse::clear_has_header() {
+inline void InternalTruncateLogResponse::clear_has_kvheader() {
   _has_bits_[0] &= ~0x00000001u;
 }
-inline void InternalTruncateLogResponse::clear_header() {
-  if (header_ != NULL) header_->::cockroach::proto::ResponseHeader::Clear();
-  clear_has_header();
+inline void InternalTruncateLogResponse::clear_kvheader() {
+  if (kvheader_ != NULL) kvheader_->::cockroach::proto::KVResponseHeader::Clear();
+  clear_has_kvheader();
 }
-inline const ::cockroach::proto::ResponseHeader& InternalTruncateLogResponse::header() const {
-  // @@protoc_insertion_point(field_get:cockroach.proto.InternalTruncateLogResponse.header)
-  return header_ != NULL ? *header_ : *default_instance_->header_;
+inline const ::cockroach::proto::KVResponseHeader& InternalTruncateLogResponse::kvheader() const {
+  // @@protoc_insertion_point(field_get:cockroach.proto.InternalTruncateLogResponse.kvheader)
+  return kvheader_ != NULL ? *kvheader_ : *default_instance_->kvheader_;
 }
-inline ::cockroach::proto::ResponseHeader* InternalTruncateLogResponse::mutable_header() {
-  set_has_header();
-  if (header_ == NULL) {
-    header_ = new ::cockroach::proto::ResponseHeader;
+inline ::cockroach::proto::KVResponseHeader* InternalTruncateLogResponse::mutable_kvheader() {
+  set_has_kvheader();
+  if (kvheader_ == NULL) {
+    kvheader_ = new ::cockroach::proto::KVResponseHeader;
   }
-  // @@protoc_insertion_point(field_mutable:cockroach.proto.InternalTruncateLogResponse.header)
-  return header_;
+  // @@protoc_insertion_point(field_mutable:cockroach.proto.InternalTruncateLogResponse.kvheader)
+  return kvheader_;
 }
-inline ::cockroach::proto::ResponseHeader* InternalTruncateLogResponse::release_header() {
-  clear_has_header();
-  ::cockroach::proto::ResponseHeader* temp = header_;
-  header_ = NULL;
+inline ::cockroach::proto::KVResponseHeader* InternalTruncateLogResponse::release_kvheader() {
+  clear_has_kvheader();
+  ::cockroach::proto::KVResponseHeader* temp = kvheader_;
+  kvheader_ = NULL;
   return temp;
 }
-inline void InternalTruncateLogResponse::set_allocated_header(::cockroach::proto::ResponseHeader* header) {
-  delete header_;
-  header_ = header;
-  if (header) {
-    set_has_header();
+inline void InternalTruncateLogResponse::set_allocated_kvheader(::cockroach::proto::KVResponseHeader* kvheader) {
+  delete kvheader_;
+  kvheader_ = kvheader;
+  if (kvheader) {
+    set_has_kvheader();
   } else {
-    clear_has_header();
+    clear_has_kvheader();
   }
-  // @@protoc_insertion_point(field_set_allocated:cockroach.proto.InternalTruncateLogResponse.header)
+  // @@protoc_insertion_point(field_set_allocated:cockroach.proto.InternalTruncateLogResponse.kvheader)
 }
 
 // -------------------------------------------------------------------
 
 // InternalLeaderLeaseRequest
 
-// optional .cockroach.proto.RequestHeader header = 1;
-inline bool InternalLeaderLeaseRequest::has_header() const {
+// optional .cockroach.proto.KVRequestHeader kvheader = 1;
+inline bool InternalLeaderLeaseRequest::has_kvheader() const {
   return (_has_bits_[0] & 0x00000001u) != 0;
 }
-inline void InternalLeaderLeaseRequest::set_has_header() {
+inline void InternalLeaderLeaseRequest::set_has_kvheader() {
   _has_bits_[0] |= 0x00000001u;
 }
-inline void InternalLeaderLeaseRequest::clear_has_header() {
+inline void InternalLeaderLeaseRequest::clear_has_kvheader() {
   _has_bits_[0] &= ~0x00000001u;
 }
-inline void InternalLeaderLeaseRequest::clear_header() {
-  if (header_ != NULL) header_->::cockroach::proto::RequestHeader::Clear();
-  clear_has_header();
+inline void InternalLeaderLeaseRequest::clear_kvheader() {
+  if (kvheader_ != NULL) kvheader_->::cockroach::proto::KVRequestHeader::Clear();
+  clear_has_kvheader();
 }
-inline const ::cockroach::proto::RequestHeader& InternalLeaderLeaseRequest::header() const {
-  // @@protoc_insertion_point(field_get:cockroach.proto.InternalLeaderLeaseRequest.header)
-  return header_ != NULL ? *header_ : *default_instance_->header_;
+inline const ::cockroach::proto::KVRequestHeader& InternalLeaderLeaseRequest::kvheader() const {
+  // @@protoc_insertion_point(field_get:cockroach.proto.InternalLeaderLeaseRequest.kvheader)
+  return kvheader_ != NULL ? *kvheader_ : *default_instance_->kvheader_;
 }
-inline ::cockroach::proto::RequestHeader* InternalLeaderLeaseRequest::mutable_header() {
-  set_has_header();
-  if (header_ == NULL) {
-    header_ = new ::cockroach::proto::RequestHeader;
+inline ::cockroach::proto::KVRequestHeader* InternalLeaderLeaseRequest::mutable_kvheader() {
+  set_has_kvheader();
+  if (kvheader_ == NULL) {
+    kvheader_ = new ::cockroach::proto::KVRequestHeader;
   }
-  // @@protoc_insertion_point(field_mutable:cockroach.proto.InternalLeaderLeaseRequest.header)
-  return header_;
+  // @@protoc_insertion_point(field_mutable:cockroach.proto.InternalLeaderLeaseRequest.kvheader)
+  return kvheader_;
 }
-inline ::cockroach::proto::RequestHeader* InternalLeaderLeaseRequest::release_header() {
-  clear_has_header();
-  ::cockroach::proto::RequestHeader* temp = header_;
-  header_ = NULL;
+inline ::cockroach::proto::KVRequestHeader* InternalLeaderLeaseRequest::release_kvheader() {
+  clear_has_kvheader();
+  ::cockroach::proto::KVRequestHeader* temp = kvheader_;
+  kvheader_ = NULL;
   return temp;
 }
-inline void InternalLeaderLeaseRequest::set_allocated_header(::cockroach::proto::RequestHeader* header) {
-  delete header_;
-  header_ = header;
-  if (header) {
-    set_has_header();
+inline void InternalLeaderLeaseRequest::set_allocated_kvheader(::cockroach::proto::KVRequestHeader* kvheader) {
+  delete kvheader_;
+  kvheader_ = kvheader;
+  if (kvheader) {
+    set_has_kvheader();
   } else {
-    clear_has_header();
+    clear_has_kvheader();
   }
-  // @@protoc_insertion_point(field_set_allocated:cockroach.proto.InternalLeaderLeaseRequest.header)
+  // @@protoc_insertion_point(field_set_allocated:cockroach.proto.InternalLeaderLeaseRequest.kvheader)
 }
 
 // optional .cockroach.proto.Lease lease = 2;
@@ -5443,47 +5443,47 @@ inline void InternalLeaderLeaseRequest::set_allocated_lease(::cockroach::proto::
 
 // InternalLeaderLeaseResponse
 
-// optional .cockroach.proto.ResponseHeader header = 1;
-inline bool InternalLeaderLeaseResponse::has_header() const {
+// optional .cockroach.proto.KVResponseHeader kvheader = 1;
+inline bool InternalLeaderLeaseResponse::has_kvheader() const {
   return (_has_bits_[0] & 0x00000001u) != 0;
 }
-inline void InternalLeaderLeaseResponse::set_has_header() {
+inline void InternalLeaderLeaseResponse::set_has_kvheader() {
   _has_bits_[0] |= 0x00000001u;
 }
-inline void InternalLeaderLeaseResponse::clear_has_header() {
+inline void InternalLeaderLeaseResponse::clear_has_kvheader() {
   _has_bits_[0] &= ~0x00000001u;
 }
-inline void InternalLeaderLeaseResponse::clear_header() {
-  if (header_ != NULL) header_->::cockroach::proto::ResponseHeader::Clear();
-  clear_has_header();
+inline void InternalLeaderLeaseResponse::clear_kvheader() {
+  if (kvheader_ != NULL) kvheader_->::cockroach::proto::KVResponseHeader::Clear();
+  clear_has_kvheader();
 }
-inline const ::cockroach::proto::ResponseHeader& InternalLeaderLeaseResponse::header() const {
-  // @@protoc_insertion_point(field_get:cockroach.proto.InternalLeaderLeaseResponse.header)
-  return header_ != NULL ? *header_ : *default_instance_->header_;
+inline const ::cockroach::proto::KVResponseHeader& InternalLeaderLeaseResponse::kvheader() const {
+  // @@protoc_insertion_point(field_get:cockroach.proto.InternalLeaderLeaseResponse.kvheader)
+  return kvheader_ != NULL ? *kvheader_ : *default_instance_->kvheader_;
 }
-inline ::cockroach::proto::ResponseHeader* InternalLeaderLeaseResponse::mutable_header() {
-  set_has_header();
-  if (header_ == NULL) {
-    header_ = new ::cockroach::proto::ResponseHeader;
+inline ::cockroach::proto::KVResponseHeader* InternalLeaderLeaseResponse::mutable_kvheader() {
+  set_has_kvheader();
+  if (kvheader_ == NULL) {
+    kvheader_ = new ::cockroach::proto::KVResponseHeader;
   }
-  // @@protoc_insertion_point(field_mutable:cockroach.proto.InternalLeaderLeaseResponse.header)
-  return header_;
+  // @@protoc_insertion_point(field_mutable:cockroach.proto.InternalLeaderLeaseResponse.kvheader)
+  return kvheader_;
 }
-inline ::cockroach::proto::ResponseHeader* InternalLeaderLeaseResponse::release_header() {
-  clear_has_header();
-  ::cockroach::proto::ResponseHeader* temp = header_;
-  header_ = NULL;
+inline ::cockroach::proto::KVResponseHeader* InternalLeaderLeaseResponse::release_kvheader() {
+  clear_has_kvheader();
+  ::cockroach::proto::KVResponseHeader* temp = kvheader_;
+  kvheader_ = NULL;
   return temp;
 }
-inline void InternalLeaderLeaseResponse::set_allocated_header(::cockroach::proto::ResponseHeader* header) {
-  delete header_;
-  header_ = header;
-  if (header) {
-    set_has_header();
+inline void InternalLeaderLeaseResponse::set_allocated_kvheader(::cockroach::proto::KVResponseHeader* kvheader) {
+  delete kvheader_;
+  kvheader_ = kvheader;
+  if (kvheader) {
+    set_has_kvheader();
   } else {
-    clear_has_header();
+    clear_has_kvheader();
   }
-  // @@protoc_insertion_point(field_set_allocated:cockroach.proto.InternalLeaderLeaseResponse.header)
+  // @@protoc_insertion_point(field_set_allocated:cockroach.proto.InternalLeaderLeaseResponse.kvheader)
 }
 
 // -------------------------------------------------------------------
@@ -6528,47 +6528,47 @@ inline InternalResponseUnion::ValueCase InternalResponseUnion::value_case() cons
 
 // InternalBatchRequest
 
-// optional .cockroach.proto.RequestHeader header = 1;
-inline bool InternalBatchRequest::has_header() const {
+// optional .cockroach.proto.KVRequestHeader kvheader = 1;
+inline bool InternalBatchRequest::has_kvheader() const {
   return (_has_bits_[0] & 0x00000001u) != 0;
 }
-inline void InternalBatchRequest::set_has_header() {
+inline void InternalBatchRequest::set_has_kvheader() {
   _has_bits_[0] |= 0x00000001u;
 }
-inline void InternalBatchRequest::clear_has_header() {
+inline void InternalBatchRequest::clear_has_kvheader() {
   _has_bits_[0] &= ~0x00000001u;
 }
-inline void InternalBatchRequest::clear_header() {
-  if (header_ != NULL) header_->::cockroach::proto::RequestHeader::Clear();
-  clear_has_header();
+inline void InternalBatchRequest::clear_kvheader() {
+  if (kvheader_ != NULL) kvheader_->::cockroach::proto::KVRequestHeader::Clear();
+  clear_has_kvheader();
 }
-inline const ::cockroach::proto::RequestHeader& InternalBatchRequest::header() const {
-  // @@protoc_insertion_point(field_get:cockroach.proto.InternalBatchRequest.header)
-  return header_ != NULL ? *header_ : *default_instance_->header_;
+inline const ::cockroach::proto::KVRequestHeader& InternalBatchRequest::kvheader() const {
+  // @@protoc_insertion_point(field_get:cockroach.proto.InternalBatchRequest.kvheader)
+  return kvheader_ != NULL ? *kvheader_ : *default_instance_->kvheader_;
 }
-inline ::cockroach::proto::RequestHeader* InternalBatchRequest::mutable_header() {
-  set_has_header();
-  if (header_ == NULL) {
-    header_ = new ::cockroach::proto::RequestHeader;
+inline ::cockroach::proto::KVRequestHeader* InternalBatchRequest::mutable_kvheader() {
+  set_has_kvheader();
+  if (kvheader_ == NULL) {
+    kvheader_ = new ::cockroach::proto::KVRequestHeader;
   }
-  // @@protoc_insertion_point(field_mutable:cockroach.proto.InternalBatchRequest.header)
-  return header_;
+  // @@protoc_insertion_point(field_mutable:cockroach.proto.InternalBatchRequest.kvheader)
+  return kvheader_;
 }
-inline ::cockroach::proto::RequestHeader* InternalBatchRequest::release_header() {
-  clear_has_header();
-  ::cockroach::proto::RequestHeader* temp = header_;
-  header_ = NULL;
+inline ::cockroach::proto::KVRequestHeader* InternalBatchRequest::release_kvheader() {
+  clear_has_kvheader();
+  ::cockroach::proto::KVRequestHeader* temp = kvheader_;
+  kvheader_ = NULL;
   return temp;
 }
-inline void InternalBatchRequest::set_allocated_header(::cockroach::proto::RequestHeader* header) {
-  delete header_;
-  header_ = header;
-  if (header) {
-    set_has_header();
+inline void InternalBatchRequest::set_allocated_kvheader(::cockroach::proto::KVRequestHeader* kvheader) {
+  delete kvheader_;
+  kvheader_ = kvheader;
+  if (kvheader) {
+    set_has_kvheader();
   } else {
-    clear_has_header();
+    clear_has_kvheader();
   }
-  // @@protoc_insertion_point(field_set_allocated:cockroach.proto.InternalBatchRequest.header)
+  // @@protoc_insertion_point(field_set_allocated:cockroach.proto.InternalBatchRequest.kvheader)
 }
 
 // repeated .cockroach.proto.InternalRequestUnion requests = 2;
@@ -6605,47 +6605,47 @@ InternalBatchRequest::mutable_requests() {
 
 // InternalBatchResponse
 
-// optional .cockroach.proto.ResponseHeader header = 1;
-inline bool InternalBatchResponse::has_header() const {
+// optional .cockroach.proto.KVResponseHeader kvheader = 1;
+inline bool InternalBatchResponse::has_kvheader() const {
   return (_has_bits_[0] & 0x00000001u) != 0;
 }
-inline void InternalBatchResponse::set_has_header() {
+inline void InternalBatchResponse::set_has_kvheader() {
   _has_bits_[0] |= 0x00000001u;
 }
-inline void InternalBatchResponse::clear_has_header() {
+inline void InternalBatchResponse::clear_has_kvheader() {
   _has_bits_[0] &= ~0x00000001u;
 }
-inline void InternalBatchResponse::clear_header() {
-  if (header_ != NULL) header_->::cockroach::proto::ResponseHeader::Clear();
-  clear_has_header();
+inline void InternalBatchResponse::clear_kvheader() {
+  if (kvheader_ != NULL) kvheader_->::cockroach::proto::KVResponseHeader::Clear();
+  clear_has_kvheader();
 }
-inline const ::cockroach::proto::ResponseHeader& InternalBatchResponse::header() const {
-  // @@protoc_insertion_point(field_get:cockroach.proto.InternalBatchResponse.header)
-  return header_ != NULL ? *header_ : *default_instance_->header_;
+inline const ::cockroach::proto::KVResponseHeader& InternalBatchResponse::kvheader() const {
+  // @@protoc_insertion_point(field_get:cockroach.proto.InternalBatchResponse.kvheader)
+  return kvheader_ != NULL ? *kvheader_ : *default_instance_->kvheader_;
 }
-inline ::cockroach::proto::ResponseHeader* InternalBatchResponse::mutable_header() {
-  set_has_header();
-  if (header_ == NULL) {
-    header_ = new ::cockroach::proto::ResponseHeader;
+inline ::cockroach::proto::KVResponseHeader* InternalBatchResponse::mutable_kvheader() {
+  set_has_kvheader();
+  if (kvheader_ == NULL) {
+    kvheader_ = new ::cockroach::proto::KVResponseHeader;
   }
-  // @@protoc_insertion_point(field_mutable:cockroach.proto.InternalBatchResponse.header)
-  return header_;
+  // @@protoc_insertion_point(field_mutable:cockroach.proto.InternalBatchResponse.kvheader)
+  return kvheader_;
 }
-inline ::cockroach::proto::ResponseHeader* InternalBatchResponse::release_header() {
-  clear_has_header();
-  ::cockroach::proto::ResponseHeader* temp = header_;
-  header_ = NULL;
+inline ::cockroach::proto::KVResponseHeader* InternalBatchResponse::release_kvheader() {
+  clear_has_kvheader();
+  ::cockroach::proto::KVResponseHeader* temp = kvheader_;
+  kvheader_ = NULL;
   return temp;
 }
-inline void InternalBatchResponse::set_allocated_header(::cockroach::proto::ResponseHeader* header) {
-  delete header_;
-  header_ = header;
-  if (header) {
-    set_has_header();
+inline void InternalBatchResponse::set_allocated_kvheader(::cockroach::proto::KVResponseHeader* kvheader) {
+  delete kvheader_;
+  kvheader_ = kvheader;
+  if (kvheader) {
+    set_has_kvheader();
   } else {
-    clear_has_header();
+    clear_has_kvheader();
   }
-  // @@protoc_insertion_point(field_set_allocated:cockroach.proto.InternalBatchResponse.header)
+  // @@protoc_insertion_point(field_set_allocated:cockroach.proto.InternalBatchResponse.kvheader)
 }
 
 // repeated .cockroach.proto.InternalResponseUnion responses = 2;

--- a/storage/engine/db.cc
+++ b/storage/engine/db.cc
@@ -130,29 +130,29 @@ rocksdb::ReadOptions MakeReadOptions(DBSnapshot* snap) {
 // response in the ReadWriteCmdResponse union.
 const cockroach::proto::ResponseHeader* GetResponseHeader(const cockroach::proto::ReadWriteCmdResponse& rwResp) {
   if (rwResp.has_put()) {
-    return &rwResp.put().header();
+    return &rwResp.put().kvheader().header();
   } else if (rwResp.has_conditional_put()) {
-    return &rwResp.conditional_put().header();
+    return &rwResp.conditional_put().kvheader().header();
   } else if (rwResp.has_increment()) {
-    return &rwResp.increment().header();
+    return &rwResp.increment().kvheader().header();
   } else if (rwResp.has_delete_()) {
-    return &rwResp.delete_().header();
+    return &rwResp.delete_().kvheader().header();
   } else if (rwResp.has_delete_range()) {
-    return &rwResp.delete_range().header();
+    return &rwResp.delete_range().kvheader().header();
   } else if (rwResp.has_end_transaction()) {
-    return &rwResp.end_transaction().header();
+    return &rwResp.end_transaction().kvheader().header();
   } else if (rwResp.has_internal_heartbeat_txn()) {
-    return &rwResp.internal_heartbeat_txn().header();
+    return &rwResp.internal_heartbeat_txn().kvheader().header();
   } else if (rwResp.has_internal_gc()) {
-    return &rwResp.internal_gc().header();
+    return &rwResp.internal_gc().kvheader().header();
   } else if (rwResp.has_internal_push_txn()) {
-    return &rwResp.internal_push_txn().header();
+    return &rwResp.internal_push_txn().kvheader().header();
   } else if (rwResp.has_internal_resolve_intent()) {
-    return &rwResp.internal_resolve_intent().header();
+    return &rwResp.internal_resolve_intent().kvheader().header();
   } else if (rwResp.has_internal_merge()) {
-    return &rwResp.internal_merge().header();
+    return &rwResp.internal_merge().kvheader().header();
   } else if (rwResp.has_internal_truncate_log()) {
-    return &rwResp.internal_truncate_log().header();
+    return &rwResp.internal_truncate_log().kvheader().header();
   }
   return NULL;
 }

--- a/storage/queue.go
+++ b/storage/queue.go
@@ -254,7 +254,7 @@ func (bq *baseQueue) processOne(clock *hlc.Clock, stopper *util.Stopper) {
 		// renew or acquire if necessary.
 		if bq.impl.needsLeaderLease() {
 			// Create a "fake" get request in order to invoke redirectOnOrAcquireLease.
-			args := &proto.GetRequest{RequestHeader: proto.RequestHeader{Timestamp: now}}
+			args := &proto.GetRequest{KVRequestHeader: proto.KVRequestHeader{RequestHeader: proto.RequestHeader{Timestamp: now}}}
 			if err := rng.redirectOnOrAcquireLeaderLease(args.Header().Timestamp); err != nil {
 				if log.V(1) {
 					log.Infof("this replica of %s could not acquire leader lease; skipping...", rng)

--- a/storage/range_command.go
+++ b/storage/range_command.go
@@ -42,7 +42,7 @@ import (
 func (r *Range) executeCmd(batch engine.Engine, ms *proto.MVCCStats, args proto.Request, reply proto.Response) ([]proto.Intent, error) {
 	// Verify key is contained within range here to catch any range split
 	// or merge activity.
-	header := args.Header()
+	header := args.KVHeader()
 	if !r.ContainsKeyRange(header.Key, header.EndKey) {
 		err := proto.NewRangeKeyMismatchError(header.Key, header.EndKey, r.Desc())
 		reply.Header().SetGoError(err)
@@ -864,8 +864,8 @@ func (r *Range) AdminSplit(args *proto.AdminSplitRequest, reply *proto.AdminSpli
 		// loop do it, in order to provide a split trigger.
 		b.InternalAddCall(proto.Call{
 			Args: &proto.EndTransactionRequest{
-				RequestHeader: proto.RequestHeader{Key: args.Key},
-				Commit:        true,
+				KVRequestHeader: proto.KVRequestHeader{Key: args.Key},
+				Commit:          true,
 				InternalCommitTrigger: &proto.InternalCommitTrigger{
 					SplitTrigger: &proto.SplitTrigger{
 						UpdatedDesc: updatedDesc,
@@ -1025,8 +1025,8 @@ func (r *Range) AdminMerge(args *proto.AdminMergeRequest, reply *proto.AdminMerg
 		// loop do it, in order to provide a merge trigger.
 		b.InternalAddCall(proto.Call{
 			Args: &proto.EndTransactionRequest{
-				RequestHeader: proto.RequestHeader{Key: args.Key},
-				Commit:        true,
+				KVRequestHeader: proto.KVRequestHeader{Key: args.Key},
+				Commit:          true,
 				InternalCommitTrigger: &proto.InternalCommitTrigger{
 					MergeTrigger: &proto.MergeTrigger{
 						UpdatedDesc:    updatedDesc,
@@ -1153,8 +1153,8 @@ func (r *Range) ChangeReplicas(changeType proto.ReplicaChangeType, replica proto
 		// loop do it, in order to provide a commit trigger.
 		b.InternalAddCall(proto.Call{
 			Args: &proto.EndTransactionRequest{
-				RequestHeader: proto.RequestHeader{Key: updatedDesc.StartKey},
-				Commit:        true,
+				KVRequestHeader: proto.KVRequestHeader{Key: updatedDesc.StartKey},
+				Commit:          true,
 				InternalCommitTrigger: &proto.InternalCommitTrigger{
 					ChangeReplicasTrigger: &proto.ChangeReplicasTrigger{
 						NodeID:          replica.NodeID,

--- a/storage/range_gc_queue.go
+++ b/storage/range_gc_queue.go
@@ -90,7 +90,7 @@ func (q *rangeGCQueue) process(now proto.Timestamp, rng *Range) error {
 	b := &client.Batch{}
 	b.InternalAddCall(proto.Call{
 		Args: &proto.InternalRangeLookupRequest{
-			RequestHeader: proto.RequestHeader{
+			KVRequestHeader: proto.KVRequestHeader{
 				Key: keys.RangeMetaKey(rng.Desc().StartKey),
 			},
 			MaxRanges: 1,

--- a/storage/split_queue.go
+++ b/storage/split_queue.go
@@ -106,7 +106,7 @@ func (sq *splitQueue) process(now proto.Timestamp, rng *Range) error {
 		if err = rng.AddCmd(rng.context(),
 			proto.Call{
 				Args: &proto.AdminSplitRequest{
-					RequestHeader: proto.RequestHeader{Key: rng.Desc().StartKey},
+					KVRequestHeader: proto.KVRequestHeader{Key: rng.Desc().StartKey},
 				},
 				Reply: &proto.AdminSplitResponse{},
 			}, true); err != nil {

--- a/storage/store_test.go
+++ b/storage/store_test.go
@@ -127,7 +127,7 @@ func (db *testSender) sendOne(call proto.Call) {
 		return
 	}
 	// Lookup range and direct request.
-	header := call.Args.Header()
+	header := call.Args.KVHeader()
 	if rng := db.store.LookupRange(header.Key, header.EndKey); rng != nil {
 		header.RaftID = rng.Desc().RaftID
 		replica := rng.GetReplica()

--- a/ts/db.go
+++ b/ts/db.go
@@ -138,7 +138,7 @@ func (db *DB) StoreData(r Resolution, data []proto.TimeSeriesData) error {
 		b := &client.Batch{}
 		b.InternalAddCall(proto.Call{
 			Args: &proto.InternalMergeRequest{
-				RequestHeader: proto.RequestHeader{
+				KVRequestHeader: proto.KVRequestHeader{
 					Key: kv.Key,
 				},
 				Value: kv.Value,


### PR DESCRIPTION
RFC: This code compiles but the tests still need some updates. I'd like to know whether I should take it to the end.

This is to make Request/Response/Call work well with the structured data API allowing us to reuse code to its maximum.

See the changes in proto/api.proto and see its effect on say kv/txn_coord_sender.go

Thanks
