### PR TITLE
Remove 'cover' from GLOCKFILE (partially undoing e7481ded650).

### DIFF
--- a/GLOCKFILE
+++ b/GLOCKFILE
@@ -6,7 +6,6 @@ cmd github.com/golang/lint/golint
 cmd github.com/jteeuwen/go-bindata/go-bindata
 cmd github.com/kisielk/errcheck
 cmd github.com/robfig/glock
-cmd golang.org/x/tools/cmd/cover
 cmd golang.org/x/tools/cmd/goimports
 cmd golang.org/x/tools/cmd/stringer
 bitbucket.org/tebeka/go2xunit 77968f802fb3


### PR DESCRIPTION
'cover', like 'vet', is normally installed by go itself and is
special-cased in 'go get' to install under GOROOT instead of GOPATH.
The user may not have write access to GOROOT, so we should just rely on
'cover' being installed by go instead of installing it with glock.
