### PR TITLE
Rename test base contexts to reflect user (root or node)

### DIFF
--- a/client/http_sender_test.go
+++ b/client/http_sender_test.go
@@ -42,7 +42,7 @@ var (
 )
 
 func startTestHTTPServer(handler http.Handler) (*httptest.Server, string) {
-	ctx := testutils.NewServerTestBaseContext()
+	ctx := testutils.NewNodeTestBaseContext()
 
 	httpServer := httptest.NewUnstartedServer(handler)
 	tlsConfig, err := ctx.GetServerTLSConfig()
@@ -87,7 +87,7 @@ func TestHTTPSenderSend(t *testing.T) {
 	}))
 	defer server.Close()
 
-	sender, err := newHTTPSender(addr, testutils.NewTestBaseContext(), defaultRetryOptions)
+	sender, err := newHTTPSender(addr, testutils.NewRootTestBaseContext(), defaultRetryOptions)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -144,7 +144,7 @@ func TestHTTPSenderRetryResponseCodes(t *testing.T) {
 			w.Write(body)
 		}))
 
-		sender, err := newHTTPSender(addr, testutils.NewTestBaseContext(), retryOptions)
+		sender, err := newHTTPSender(addr, testutils.NewRootTestBaseContext(), retryOptions)
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -207,7 +207,7 @@ func TestHTTPSenderRetryHTTPSendError(t *testing.T) {
 		}))
 
 		s = server
-		sender, err := newHTTPSender(addr, testutils.NewTestBaseContext(), retryOptions)
+		sender, err := newHTTPSender(addr, testutils.NewRootTestBaseContext(), retryOptions)
 		if err != nil {
 			t.Fatal(err)
 		}

--- a/gossip/gossip_test.go
+++ b/gossip/gossip_test.go
@@ -31,14 +31,13 @@ import (
 	"github.com/cockroachdb/cockroach/util/leaktest"
 )
 
-var testBaseContext = testutils.NewTestBaseContext()
-var serverTestBaseContext = testutils.NewServerTestBaseContext()
+var rootTestBaseContext = testutils.NewRootTestBaseContext()
 var insecureTestBaseContext = &base.Context{Insecure: true, User: security.NodeUser}
 
 // TestGossipInfoStore verifies operation of gossip instance infostore.
 func TestGossipInfoStore(t *testing.T) {
 	defer leaktest.AfterTest(t)
-	rpcContext := rpc.NewContext(testBaseContext, hlc.NewClock(hlc.UnixNano), nil)
+	rpcContext := rpc.NewContext(rootTestBaseContext, hlc.NewClock(hlc.UnixNano), nil)
 	g := New(rpcContext, TestInterval, TestBootstrap)
 	if err := g.AddInfo("i", int64(1), time.Hour); err != nil {
 		t.Fatal(err)
@@ -73,7 +72,7 @@ func TestGossipInfoStore(t *testing.T) {
 // gossip instance infostore.
 func TestGossipGroupsInfoStore(t *testing.T) {
 	defer leaktest.AfterTest(t)
-	rpcContext := rpc.NewContext(testBaseContext, hlc.NewClock(hlc.UnixNano), nil)
+	rpcContext := rpc.NewContext(rootTestBaseContext, hlc.NewClock(hlc.UnixNano), nil)
 	g := New(rpcContext, TestInterval, TestBootstrap)
 
 	// For int64.

--- a/kv/local_test_cluster.go
+++ b/kv/local_test_cluster.go
@@ -117,7 +117,7 @@ func (ltc *LocalTestCluster) Start(t util.Tester) {
 	ltc.Manual = hlc.NewManualClock(0)
 	ltc.Clock = hlc.NewClock(ltc.Manual.UnixNano)
 	ltc.Stopper = util.NewStopper()
-	rpcContext := rpc.NewContext(testutils.NewTestBaseContext(), ltc.Clock, ltc.Stopper)
+	rpcContext := rpc.NewContext(testutils.NewRootTestBaseContext(), ltc.Clock, ltc.Stopper)
 	ltc.Gossip = gossip.New(rpcContext, gossip.TestInterval, gossip.TestBootstrap)
 	ltc.Eng = engine.NewInMem(proto.Attributes{}, 50<<20)
 	ltc.lSender = newRetryableLocalSender(NewLocalSender())

--- a/rpc/main_test.go
+++ b/rpc/main_test.go
@@ -28,22 +28,22 @@ import (
 	"github.com/cockroachdb/cockroach/util/leaktest"
 )
 
-// NewTestContext returns a rpc.Context for testing.
-// It is meant to be used by rpc clients.
-func NewTestContext(clock *hlc.Clock, stopper *util.Stopper) *Context {
+// NewRootTestContext returns a rpc.Context for testing.
+// It is meant to be used by clients.
+func NewRootTestContext(clock *hlc.Clock, stopper *util.Stopper) *Context {
 	if clock == nil {
 		clock = hlc.NewClock(hlc.UnixNano)
 	}
-	return NewContext(testutils.NewTestBaseContext(), clock, stopper)
+	return NewContext(testutils.NewRootTestBaseContext(), clock, stopper)
 }
 
-// NewServerTestContext returns a rpc.Context for testing.
-// It is meant to be used by rpc servers.
-func NewServerTestContext(clock *hlc.Clock, stopper *util.Stopper) *Context {
+// NewNodeTestContext returns a rpc.Context for testing.
+// It is meant to be used by nodes.
+func NewNodeTestContext(clock *hlc.Clock, stopper *util.Stopper) *Context {
 	if clock == nil {
 		clock = hlc.NewClock(hlc.UnixNano)
 	}
-	return NewContext(testutils.NewServerTestBaseContext(), clock, stopper)
+	return NewContext(testutils.NewNodeTestBaseContext(), clock, stopper)
 }
 
 func init() {

--- a/security/certs_test.go
+++ b/security/certs_test.go
@@ -115,7 +115,7 @@ func TestUseCerts(t *testing.T) {
 	defer s.Stop()
 
 	// Insecure mode.
-	clientContext := testutils.NewTestBaseContext()
+	clientContext := testutils.NewRootTestBaseContext()
 	clientContext.Insecure = true
 	httpClient, err := clientContext.GetHTTPClient()
 	if err != nil {
@@ -132,7 +132,7 @@ func TestUseCerts(t *testing.T) {
 	}
 
 	// Secure mode but no Certs directory: permissive config.
-	clientContext = testutils.NewTestBaseContext()
+	clientContext = testutils.NewRootTestBaseContext()
 	clientContext.Certs = ""
 	httpClient, err = clientContext.GetHTTPClient()
 	if err != nil {
@@ -167,7 +167,7 @@ func TestUseCerts(t *testing.T) {
 	}
 
 	// New client. With certs this time.
-	clientContext = testutils.NewTestBaseContext()
+	clientContext = testutils.NewRootTestBaseContext()
 	clientContext.Certs = certsDir
 	httpClient, err = clientContext.GetHTTPClient()
 	if err != nil {

--- a/server/authentication_test.go
+++ b/server/authentication_test.go
@@ -67,7 +67,7 @@ func TestSSLEnforcement(t *testing.T) {
 	}
 
 	// HTTPS with client certs.
-	certsContext := testutils.NewTestBaseContext()
+	certsContext := testutils.NewRootTestBaseContext()
 	client, err := certsContext.GetHTTPClient()
 	if err != nil {
 		t.Fatalf("error initializing http client: %s", err)
@@ -86,7 +86,7 @@ func TestSSLEnforcement(t *testing.T) {
 	}
 
 	// HTTPS without client certs.
-	noCertsContext := testutils.NewTestBaseContext()
+	noCertsContext := testutils.NewRootTestBaseContext()
 	noCertsContext.Certs = ""
 	client, err = noCertsContext.GetHTTPClient()
 	if err != nil {
@@ -106,7 +106,7 @@ func TestSSLEnforcement(t *testing.T) {
 	}
 
 	// Plain http.
-	insecureContext := testutils.NewTestBaseContext()
+	insecureContext := testutils.NewRootTestBaseContext()
 	insecureContext.Insecure = true
 	client, err = insecureContext.GetHTTPClient()
 	if err != nil {

--- a/server/node_test.go
+++ b/server/node_test.go
@@ -52,14 +52,13 @@ func createTestNode(addr net.Addr, engines []engine.Engine, gossipBS net.Addr, t
 
 	stopper := util.NewStopper()
 	ctx.Clock = hlc.NewClock(hlc.UnixNano)
-	serverContext := rpc.NewContext(serverTestBaseContext, ctx.Clock, stopper)
+	nodeRPCContext := rpc.NewContext(nodeTestBaseContext, ctx.Clock, stopper)
 	ctx.ScanInterval = 10 * time.Hour
-	rpcServer := rpc.NewServer(addr, serverContext)
+	rpcServer := rpc.NewServer(addr, nodeRPCContext)
 	if err := rpcServer.Start(); err != nil {
 		t.Fatal(err)
 	}
-	rpcContext := rpc.NewContext(serverTestBaseContext, ctx.Clock, stopper)
-	g := gossip.New(rpcContext, testContext.GossipInterval, testContext.GossipBootstrapResolvers)
+	g := gossip.New(nodeRPCContext, testContext.GossipInterval, testContext.GossipBootstrapResolvers)
 	if gossipBS != nil {
 		// Handle possibility of a :0 port specification.
 		if gossipBS == addr {

--- a/server/raft_transport_test.go
+++ b/server/raft_transport_test.go
@@ -43,8 +43,8 @@ func TestSendAndReceive(t *testing.T) {
 	defer leaktest.AfterTest(t)
 	stopper := util.NewStopper()
 	defer stopper.Stop()
-	rpcContext := rpc.NewContext(serverTestBaseContext, hlc.NewClock(hlc.UnixNano), stopper)
-	g := gossip.New(rpcContext, gossip.TestInterval, gossip.TestBootstrap)
+	nodeRPCContext := rpc.NewContext(nodeTestBaseContext, hlc.NewClock(hlc.UnixNano), stopper)
+	g := gossip.New(nodeRPCContext, gossip.TestInterval, gossip.TestBootstrap)
 
 	// Create several servers, each of which has two stores (A multiraft node ID addresses
 	// a store).
@@ -59,13 +59,13 @@ func TestSendAndReceive(t *testing.T) {
 	transports := []multiraft.Transport{}
 	channels := []ChannelServer{}
 	for serverIndex := 0; serverIndex < numServers; serverIndex++ {
-		server := rpc.NewServer(util.CreateTestAddr("tcp"), rpcContext)
+		server := rpc.NewServer(util.CreateTestAddr("tcp"), nodeRPCContext)
 		if err := server.Start(); err != nil {
 			t.Fatal(err)
 		}
 		defer server.Close()
 
-		transport, err := newRPCTransport(g, server, rpcContext)
+		transport, err := newRPCTransport(g, server, nodeRPCContext)
 		if err != nil {
 			t.Fatalf("Unexpected error creating transport, Error: %s", err)
 		}

--- a/server/server_test.go
+++ b/server/server_test.go
@@ -40,8 +40,8 @@ import (
 )
 
 var testContext = NewTestContext()
-var testBaseContext = testutils.NewTestBaseContext()
-var serverTestBaseContext = testutils.NewServerTestBaseContext()
+var rootTestBaseContext = testutils.NewRootTestBaseContext()
+var nodeTestBaseContext = testutils.NewNodeTestBaseContext()
 
 // createTestConfigFile creates a temporary file and writes the
 // testConfig yaml data to it. The caller is responsible for

--- a/storage/client_test.go
+++ b/storage/client_test.go
@@ -42,7 +42,7 @@ import (
 	"github.com/cockroachdb/cockroach/util/hlc"
 )
 
-var testBaseContext = testutils.NewTestBaseContext()
+var rootTestBaseContext = testutils.NewRootTestBaseContext()
 
 // createTestStore creates a test store using an in-memory
 // engine. The caller is responsible for closing the store on exit.
@@ -58,7 +58,7 @@ func createTestStore(t *testing.T) (*storage.Store, *util.Stopper) {
 func createTestStoreWithEngine(t *testing.T, eng engine.Engine, clock *hlc.Clock,
 	bootstrap bool, context *storage.StoreContext) (*storage.Store, *util.Stopper) {
 	stopper := util.NewStopper()
-	rpcContext := rpc.NewContext(testBaseContext, hlc.NewClock(hlc.UnixNano), stopper)
+	rpcContext := rpc.NewContext(rootTestBaseContext, hlc.NewClock(hlc.UnixNano), stopper)
 	if context == nil {
 		// make a copy
 		ctx := storage.TestStoreContext
@@ -135,7 +135,7 @@ func (m *multiTestContext) Start(t *testing.T, numStores int) {
 		m.clock = hlc.NewClock(m.manualClock.UnixNano)
 	}
 	if m.gossip == nil {
-		rpcContext := rpc.NewContext(testBaseContext, m.clock, nil)
+		rpcContext := rpc.NewContext(rootTestBaseContext, m.clock, nil)
 		m.gossip = gossip.New(rpcContext, gossip.TestInterval, gossip.TestBootstrap)
 	}
 	if m.transport == nil {

--- a/storage/range_test.go
+++ b/storage/range_test.go
@@ -119,7 +119,7 @@ func (tc *testContext) Start(t testing.TB) {
 		tc.stopper = util.NewStopper()
 	}
 	if tc.gossip == nil {
-		rpcContext := rpc.NewContext(testBaseContext, hlc.NewClock(hlc.UnixNano), tc.stopper)
+		rpcContext := rpc.NewContext(rootTestBaseContext, hlc.NewClock(hlc.UnixNano), tc.stopper)
 		tc.gossip = gossip.New(rpcContext, gossip.TestInterval, gossip.TestBootstrap)
 	}
 	if tc.manualClock == nil {

--- a/storage/store_test.go
+++ b/storage/store_test.go
@@ -51,7 +51,7 @@ var testIdent = proto.StoreIdent{
 	StoreID:   1,
 }
 
-var testBaseContext = testutils.NewTestBaseContext()
+var rootTestBaseContext = testutils.NewRootTestBaseContext()
 
 // setTestRetryOptions sets aggressive retries with a limit on number
 // of attempts so we don't get stuck behind indefinite backoff/retry
@@ -149,7 +149,7 @@ func (db *testSender) sendOne(call proto.Call) {
 // responsible for stopping the stopper upon completion.
 func createTestStoreWithoutStart(t *testing.T) (*Store, *hlc.ManualClock, *util.Stopper) {
 	stopper := util.NewStopper()
-	rpcContext := rpc.NewContext(testBaseContext, hlc.NewClock(hlc.UnixNano), stopper)
+	rpcContext := rpc.NewContext(rootTestBaseContext, hlc.NewClock(hlc.UnixNano), stopper)
 	ctx := TestStoreContext
 	ctx.Gossip = gossip.New(rpcContext, gossip.TestInterval, gossip.TestBootstrap)
 	manual := hlc.NewManualClock(0)

--- a/testutils/base.go
+++ b/testutils/base.go
@@ -28,19 +28,20 @@ import (
 // This uses embedded certs and the "root" user (default client user).
 // The "root" user has client certificates only.
 func NewRootTestBaseContext() *base.Context {
-	return &base.Context{
-		Certs: security.EmbeddedCertsDir,
-		User:  security.RootUser,
-	}
+	return newTestBaseContext(security.RootUser)
 }
 
 // NewNodeTestBaseContext creates a base context for testing.
 // This uses embedded certs and the "node" user (default node user).
 // The "node" user has both server and client certificates.
 func NewNodeTestBaseContext() *base.Context {
+	return newTestBaseContext(security.NodeUser)
+}
+
+func newTestBaseContext(user string) *base.Context {
 	return &base.Context{
 		Certs: security.EmbeddedCertsDir,
-		User:  security.NodeUser,
+		User:  user,
 	}
 }
 

--- a/testutils/base.go
+++ b/testutils/base.go
@@ -24,22 +24,20 @@ import (
 	"github.com/cockroachdb/cockroach/security"
 )
 
-// NewTestBaseContext creates a base context for testing.
+// NewRootTestBaseContext creates a base context for testing.
 // This uses embedded certs and the "root" user (default client user).
-// The certs file loader is overriden in individual main_test files.
-// This is meant to be used by external clients (as opposed to nodes).
-func NewTestBaseContext() *base.Context {
+// The "root" user has client certificates only.
+func NewRootTestBaseContext() *base.Context {
 	return &base.Context{
 		Certs: security.EmbeddedCertsDir,
 		User:  security.RootUser,
 	}
 }
 
-// NewServerTestBaseContext creates a base context for testing.
+// NewNodeTestBaseContext creates a base context for testing.
 // This uses embedded certs and the "node" user (default node user).
-// The certs file loader is overriden in individual main_test files.
-// This is meant to be used by nodes and node-clients (node-node requests).
-func NewServerTestBaseContext() *base.Context {
+// The "node" user has both server and client certificates.
+func NewNodeTestBaseContext() *base.Context {
 	return &base.Context{
 		Certs: security.EmbeddedCertsDir,
 		User:  security.NodeUser,
@@ -49,5 +47,5 @@ func NewServerTestBaseContext() *base.Context {
 // NewTestHTTPClient creates a HTTP client on the fly using a test context.
 // Useful when contexts don't need to be reused.
 func NewTestHTTPClient() (*http.Client, error) {
-	return NewTestBaseContext().GetHTTPClient()
+	return NewRootTestBaseContext().GetHTTPClient()
 }

--- a/ts/server_test.go
+++ b/ts/server_test.go
@@ -29,7 +29,7 @@ import (
 	"github.com/cockroachdb/cockroach/util/leaktest"
 )
 
-var testContext = testutils.NewTestBaseContext()
+var rootTestBaseContext = testutils.NewRootTestBaseContext()
 
 func TestHttpQuery(t *testing.T) {
 	defer leaktest.AfterTest(t)
@@ -141,7 +141,7 @@ func TestHttpQuery(t *testing.T) {
 	}
 
 	response := &proto.TimeSeriesQueryResponse{}
-	session := testutils.NewTestHTTPSession(t, testContext, tsrv.ServingAddr())
+	session := testutils.NewTestHTTPSession(t, rootTestBaseContext, tsrv.ServingAddr())
 	session.PostProto(ts.URLQuery, &proto.TimeSeriesQueryRequest{
 		StartNanos: 500 * 1e9,
 		EndNanos:   526 * 1e9,


### PR DESCRIPTION
This is to clarify the proper usage of root vs node contexts.
Some places may still be using the wrong one, but this will be caught
when http endpoints validate requested user vs cert user.
