### PR TITLE
Do not ignore an old write when it comes after a newer write

### DIFF
--- a/storage/engine/mvcc.go
+++ b/storage/engine/mvcc.go
@@ -738,10 +738,9 @@ func mvccPutInternal(engine Engine, ms *MVCCStats, key proto.Key, timestamp prot
 				// The current Put operation does not come from the same
 				// transaction.
 				return &proto.WriteIntentError{Intents: []proto.Intent{{Key: key, Txn: *meta.Txn}}}
-			} else if txn.Epoch < meta.Txn.Epoch || timestamp.Less(meta.Timestamp) {
-				// Ignore old writes from the current transaction; it's just an
-				// RPC arriving out of order.
-				return nil
+			} else if txn.Epoch < meta.Txn.Epoch {
+				return util.Errorf("put with epoch %d came after put with epoch %d in txn %s",
+					txn.Epoch, meta.Txn.Epoch, txn.ID)
 			}
 
 			// We are replacing our own older write intent. If we are

--- a/storage/engine/mvcc_test.go
+++ b/storage/engine/mvcc_test.go
@@ -206,7 +206,7 @@ func TestMVCCPutOutOfOrder(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	// Put operation with earlier walltime. Will be ignored.
+	// Put operation with earlier walltime. Will NOT be ignored.
 	err = MVCCPut(engine, nil, testKey1, makeTS(1, 0), value2, txn1)
 	if err != nil {
 		t.Fatal(err)
@@ -216,12 +216,12 @@ func TestMVCCPutOutOfOrder(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if !bytes.Equal(value.Bytes, value1.Bytes) {
+	if !bytes.Equal(value.Bytes, value2.Bytes) {
 		t.Fatalf("the value should be %s, but got %s",
-			value1.Bytes, value.Bytes)
+			value2.Bytes, value.Bytes)
 	}
 
-	// Another put operation with earlier logical time. Will be ignored.
+	// Another put operation with earlier logical time. Will NOT be ignored.
 	err = MVCCPut(engine, nil, testKey1, makeTS(2, 0), value2, txn1)
 	if err != nil {
 		t.Fatal(err)
@@ -231,9 +231,9 @@ func TestMVCCPutOutOfOrder(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if !bytes.Equal(value.Bytes, value1.Bytes) {
+	if !bytes.Equal(value.Bytes, value2.Bytes) {
 		t.Fatalf("the value should be %s, but got %s",
-			value1.Bytes, value.Bytes)
+			value2.Bytes, value.Bytes)
 	}
 }
 
@@ -1315,8 +1315,8 @@ func TestMVCCWriteWithDiffTimestampsAndEpochs(t *testing.T) {
 		t.Fatal(err)
 	}
 	// Try a write with an earlier epoch; again ignored.
-	if err := MVCCPut(engine, nil, testKey1, makeTS(1, 0), value1, txn1); err != nil {
-		t.Fatal(err)
+	if err := MVCCPut(engine, nil, testKey1, makeTS(1, 0), value1, txn1); err == nil {
+		t.Fatal("unexpected success of a write with an earlier epoch")
 	}
 	// Try a write with different value using both later timestamp and epoch.
 	if err := MVCCPut(engine, nil, testKey1, makeTS(1, 0), value3, txn1e2); err != nil {


### PR DESCRIPTION
The test triggers it with the following steps:

1) Txn executes a put operation with time T.

2) Before the txn is committed, another client sends a get operation with time T+100. This triggers the txn restart.

3) The client sends another get operation with time T+200. The write intent is resolved (and the txn timestamp is pushed to T+200), but the actual get operation has not yet been executed (and hence the timestamp cache has not been updated).

4) The restarted txn executes the put operation again. The timestamp of the operation is T+100, and it will be ignored.

Ignoring the out-of-order put operation causes a bit weird behavior. In the above example, a get issued in the same txn after Step 4 will not see the put.
