### PR TITLE
Add basic request tracing facility

### DIFF
--- a/kv/local_test_cluster.go
+++ b/kv/local_test_cluster.go
@@ -121,7 +121,7 @@ func (ltc *LocalTestCluster) Start(t util.Tester) {
 	ltc.Gossip = gossip.New(rpcContext, gossip.TestInterval, gossip.TestBootstrap)
 	ltc.Eng = engine.NewInMem(proto.Attributes{}, 50<<20)
 	ltc.lSender = newRetryableLocalSender(NewLocalSender())
-	ltc.Sender = NewTxnCoordSender(ltc.lSender, ltc.Clock, false, ltc.Stopper)
+	ltc.Sender = NewTxnCoordSender(ltc.lSender, ltc.Clock, false, nil, ltc.Stopper)
 	var err error
 	if ltc.DB, err = client.Open("//root@", client.SenderOpt(ltc.Sender)); err != nil {
 		t.Fatal(err)

--- a/kv/txn_coord_sender_test.go
+++ b/kv/txn_coord_sender_test.go
@@ -558,7 +558,7 @@ func TestTxnCoordSenderTxnUpdatedOnError(t *testing.T) {
 		defer stopper.Stop()
 		ts := NewTxnCoordSender(newTestSender(func(call proto.Call) {
 			call.Reply.Header().SetGoError(test.err)
-		}), clock, false, stopper)
+		}), clock, false, nil, stopper)
 		reply := &proto.PutResponse{}
 		ts.Send(context.Background(), proto.Call{Args: testPutReq, Reply: reply})
 
@@ -600,7 +600,7 @@ func TestTxnCoordSenderBatchTransaction(t *testing.T) {
 	ts := NewTxnCoordSender(newTestSender(func(call proto.Call) {
 		called = true
 		return
-	}), clock, false, stopper)
+	}), clock, false, nil, stopper)
 
 	testCases := []struct{ batch, arg, ok bool }{
 		{false, false, true},

--- a/kv/txn_test.go
+++ b/kv/txn_test.go
@@ -175,7 +175,7 @@ func verifyUncertainty(concurrency int, maxOffset time.Duration, t *testing.T) {
 			// higher values require roughly offset/5 restarts.
 			txnClock.SetMaxOffset(maxOffset)
 
-			sender := NewTxnCoordSender(s.lSender, txnClock, false, s.Stopper)
+			sender := NewTxnCoordSender(s.lSender, txnClock, false, nil, s.Stopper)
 			txnDB, err := client.Open("//root@", client.SenderOpt(sender))
 			if err != nil {
 				t.Fatal(err)

--- a/proto/data.go
+++ b/proto/data.go
@@ -411,6 +411,26 @@ func (t *Transaction) Equal(s *Transaction) bool {
 	return TxnIDEqual(t.ID, s.ID)
 }
 
+// TraceID implements tracer.Traceable. For a nontrivial Transaction, it
+// returns 't', followed by the transaction ID. Otherwise, the empty string is
+// returned.
+func (t *Transaction) TraceID() string {
+	if t == nil || len(t.ID) == 0 {
+		return ""
+	}
+	s := util.UUID(t.ID).String()
+	return "t" + s
+}
+
+// TraceName implements tracer.Traceable. It returns TraceID, but using the
+// short version of the UUID.
+func (t *Transaction) TraceName() string {
+	if t == nil || len(t.ID) == 0 {
+		return "(none)"
+	}
+	return "t" + t.Short()
+}
+
 // MakePriority generates a random priority value, biased by the
 // specified userPriority. If userPriority=100, the resulting
 // priority is 100x more likely to be probabilistically greater
@@ -516,8 +536,8 @@ func (t Transaction) String() string {
 }
 
 // Short returns the short form of the Transaction's UUID.
-func (t Transaction) Short() string {
-	return util.UUID(t.ID).Short()
+func (t *Transaction) Short() string {
+	return util.UUID(t.GetID()).Short()
 }
 
 // NewGCMetadata returns a GCMetadata initialized to have a ByteCounts

--- a/server/server_test.go
+++ b/server/server_test.go
@@ -301,7 +301,7 @@ func TestMultiRangeScanDeleteRange(t *testing.T) {
 	s := StartTestServer(t)
 	defer s.Stop()
 	ds := kv.NewDistSender(&kv.DistSenderContext{Clock: s.Clock()}, s.Gossip())
-	tds := kv.NewTxnCoordSender(ds, s.Clock(), testContext.Linearizable, s.stopper)
+	tds := kv.NewTxnCoordSender(ds, s.Clock(), testContext.Linearizable, nil, s.stopper)
 
 	if err := s.node.ctx.DB.AdminSplit("m"); err != nil {
 		t.Fatal(err)
@@ -403,7 +403,7 @@ func TestMultiRangeScanWithMaxResults(t *testing.T) {
 	for i, tc := range testCases {
 		s := StartTestServer(t)
 		ds := kv.NewDistSender(&kv.DistSenderContext{Clock: s.Clock()}, s.Gossip())
-		tds := kv.NewTxnCoordSender(ds, s.Clock(), testContext.Linearizable, s.stopper)
+		tds := kv.NewTxnCoordSender(ds, s.Clock(), testContext.Linearizable, nil, s.stopper)
 
 		for _, sk := range tc.splitKeys {
 			if err := s.node.ctx.DB.AdminSplit(sk); err != nil {

--- a/server/status/feed.go
+++ b/server/status/feed.go
@@ -23,6 +23,7 @@ import (
 
 	"github.com/cockroachdb/cockroach/proto"
 	"github.com/cockroachdb/cockroach/util"
+	"github.com/cockroachdb/cockroach/util/tracer"
 )
 
 // StartNodeEvent is published when a node is started.
@@ -133,6 +134,8 @@ type NodeEventListener interface {
 	OnStartNode(event *StartNodeEvent)
 	OnCallSuccess(event *CallSuccessEvent)
 	OnCallError(event *CallErrorEvent)
+	// TODO(tschottdorf): break this out into a TraceEventListener.
+	OnTrace(event *tracer.Trace)
 }
 
 // ProcessNodeEvents reads node events from the supplied channel and passes them
@@ -144,6 +147,8 @@ func ProcessNodeEvents(l NodeEventListener, sub *util.Subscription) {
 		switch specificEvent := event.(type) {
 		case *StartNodeEvent:
 			l.OnStartNode(specificEvent)
+		case *tracer.Trace:
+			l.OnTrace(specificEvent)
 		case *CallSuccessEvent:
 			l.OnCallSuccess(specificEvent)
 		case *CallErrorEvent:

--- a/server/status/monitor.go
+++ b/server/status/monitor.go
@@ -25,6 +25,8 @@ import (
 	"github.com/cockroachdb/cockroach/storage"
 	"github.com/cockroachdb/cockroach/storage/engine"
 	"github.com/cockroachdb/cockroach/util"
+	"github.com/cockroachdb/cockroach/util/log"
+	"github.com/cockroachdb/cockroach/util/tracer"
 )
 
 // StoreStatusMonitor monitors the status of a single store on the server.
@@ -207,6 +209,14 @@ func (nsm *NodeStatusMonitor) OnCallSuccess(event *CallSuccessEvent) {
 // method is part of the implementation of NodeEventListener.
 func (nsm *NodeStatusMonitor) OnCallError(event *CallErrorEvent) {
 	atomic.AddInt64(&nsm.callErrors, 1)
+}
+
+// OnTrace receives Trace objects from a node event subscription. This method
+// is part of the implementation of NodeEventListener.
+func (nsm *NodeStatusMonitor) OnTrace(trace *tracer.Trace) {
+	if log.V(2) {
+		log.Infof("received trace:\n%s", trace)
+	}
 }
 
 // rangeDataAccumulator maintains a set of accumulated stats for a set of

--- a/storage/client_test.go
+++ b/storage/client_test.go
@@ -66,7 +66,7 @@ func createTestStoreWithEngine(t *testing.T, eng engine.Engine, clock *hlc.Clock
 	}
 	context.Gossip = gossip.New(rpcContext, gossip.TestInterval, gossip.TestBootstrap)
 	lSender := kv.NewLocalSender()
-	sender := kv.NewTxnCoordSender(lSender, clock, false, stopper)
+	sender := kv.NewTxnCoordSender(lSender, clock, false, nil, stopper)
 	context.Clock = clock
 	var err error
 	if context.DB, err = client.Open("//root@", client.SenderOpt(sender)); err != nil {
@@ -150,7 +150,7 @@ func (m *multiTestContext) Start(t *testing.T, numStores int) {
 	m.senders = append(m.senders, kv.NewLocalSender())
 
 	if m.db == nil {
-		sender := kv.NewTxnCoordSender(m.senders[0], m.clock, false, m.clientStopper)
+		sender := kv.NewTxnCoordSender(m.senders[0], m.clock, false, nil, m.clientStopper)
 		var err error
 		if m.db, err = client.Open("//root@", client.SenderOpt(sender)); err != nil {
 			t.Fatal(err)

--- a/storage/queue.go
+++ b/storage/queue.go
@@ -255,7 +255,7 @@ func (bq *baseQueue) processOne(clock *hlc.Clock, stopper *util.Stopper) {
 		if bq.impl.needsLeaderLease() {
 			// Create a "fake" get request in order to invoke redirectOnOrAcquireLease.
 			args := &proto.GetRequest{RequestHeader: proto.RequestHeader{Timestamp: now}}
-			if err := rng.redirectOnOrAcquireLeaderLease(args.Header().Timestamp); err != nil {
+			if err := rng.redirectOnOrAcquireLeaderLease(nil /* Trace */, args.Header().Timestamp); err != nil {
 				if log.V(1) {
 					log.Infof("this replica of %s could not acquire leader lease; skipping...", rng)
 				}

--- a/storage/range_test.go
+++ b/storage/range_test.go
@@ -430,7 +430,7 @@ func TestRangeLeaderLease(t *testing.T) {
 		t.Errorf("expected another replica to have leader lease")
 	}
 
-	err := tc.rng.redirectOnOrAcquireLeaderLease(tc.clock.Now())
+	err := tc.rng.redirectOnOrAcquireLeaderLease(nil, tc.clock.Now())
 	if lErr, ok := err.(*proto.NotLeaderError); !ok || lErr == nil {
 		t.Fatalf("wanted NotLeaderError, got %s", err)
 	}

--- a/storage/store.go
+++ b/storage/store.go
@@ -36,6 +36,7 @@ import (
 	"github.com/cockroachdb/cockroach/util/hlc"
 	"github.com/cockroachdb/cockroach/util/log"
 	"github.com/cockroachdb/cockroach/util/retry"
+	"github.com/cockroachdb/cockroach/util/tracer"
 	"github.com/coreos/etcd/raft"
 	"github.com/coreos/etcd/raft/raftpb"
 	gogoproto "github.com/gogo/protobuf/proto"
@@ -313,6 +314,9 @@ type StoreContext struct {
 
 	// EventFeed is a feed to which this store will publish events.
 	EventFeed *util.Feed
+
+	// Tracer is a request tracer.
+	Tracer *tracer.Tracer
 }
 
 // Valid returns true if the StoreContext is populated correctly.
@@ -352,7 +356,7 @@ func NewStore(ctx StoreContext, eng engine.Engine, nodeDesc *proto.NodeDescripto
 
 	s := &Store{
 		ctx:          ctx,
-		db:           ctx.DB,
+		db:           ctx.DB, // TODO(tschottdorf) remove redundancy.
 		engine:       eng,
 		_allocator:   newAllocator(ctx.Gossip),
 		ranges:       map[proto.RaftID]*Range{},
@@ -976,6 +980,9 @@ func (s *Store) Stopper() *util.Stopper { return s.stopper }
 // EventFeed accessor.
 func (s *Store) EventFeed() StoreEventFeed { return s.feed }
 
+// Tracer accessor.
+func (s *Store) Tracer() *tracer.Tracer { return s.ctx.Tracer }
+
 // NewRangeDescriptor creates a new descriptor based on start and end
 // keys and the supplied proto.Replicas slice. It allocates new Raft
 // and range IDs to fill out the supplied replicas.
@@ -1212,6 +1219,7 @@ func (s *Store) RangeCount() int {
 func (s *Store) ExecuteCmd(ctx context.Context, call proto.Call) error {
 	args, reply := call.Args, call.Reply
 	ctx = s.Context(ctx)
+	trace := tracer.FromCtx(ctx)
 	// If the request has a zero timestamp, initialize to this node's clock.
 	header := args.Header()
 	if err := verifyKeys(header.Key, header.EndKey, proto.IsRange(call.Args)); err != nil {
@@ -1238,8 +1246,16 @@ func (s *Store) ExecuteCmd(ctx context.Context, call proto.Call) error {
 		s.ctx.Clock.Update(header.Timestamp)
 	}
 
-	// Backoff and retry loop for handling errors.
-	for r := retry.Start(s.ctx.RangeRetryOptions); r.Next(); {
+	defer trace.Epoch("executing " + args.Method().String())()
+	// Backoff and retry loop for handling errors. Backoff times are measured
+	// in the Trace.
+	next := func(r *retry.Retry) bool {
+		if r.CurrentAttempt() > 0 {
+			defer trace.Epoch("backoff")()
+		}
+		return r.Next()
+	}
+	for r := retry.Start(s.ctx.RangeRetryOptions); next(&r); {
 		// Add the command to the range for execution; exit retry loop on success.
 		reply.Reset()
 
@@ -1265,12 +1281,14 @@ func (s *Store) ExecuteCmd(ctx context.Context, call proto.Call) error {
 			} else {
 				pushType = proto.PUSH_TIMESTAMP
 			}
+
 			err = s.resolveWriteIntentError(ctx, wiErr, rng, args, pushType)
 			reply.Header().SetGoError(err)
 		}
 
 		switch t := err.(type) {
 		case *proto.WriteTooOldError:
+			trace.Event(fmt.Sprintf("error: %T", err))
 			// Update request timestamp and retry immediately.
 			header.Timestamp = t.ExistingTimestamp.Next()
 			r.Reset()
@@ -1279,6 +1297,7 @@ func (s *Store) ExecuteCmd(ctx context.Context, call proto.Call) error {
 			}
 			continue
 		case *proto.WriteIntentError:
+			trace.Event(fmt.Sprintf("error: %T", err))
 			// If write intent error is resolved, exit retry/backoff loop to
 			// immediately retry.
 			if t.Resolved {
@@ -1323,6 +1342,8 @@ func (s *Store) resolveWriteIntentError(ctx context.Context, wiErr *proto.WriteI
 	if log.V(6) {
 		log.Infoc(ctx, "resolving write intent %s", wiErr)
 	}
+	trace := tracer.FromCtx(ctx)
+	defer trace.Epoch("intent resolution")()
 
 	// Attempt to push the transaction(s) which created the conflicting intent(s).
 	now := s.Clock().Now()
@@ -1388,6 +1409,7 @@ func (s *Store) resolveWriteIntentError(ctx context.Context, wiErr *proto.WriteI
 	var wg sync.WaitGroup
 
 	// We pushed the transaction(s) successfully, so resolve the intent(s).
+	trace.Event("resolving intents [async]")
 	for i, intent := range wiErr.Intents {
 		pushReply := bReply.Responses[i].InternalPushTxn
 		intentKey := intent.Key
@@ -1406,8 +1428,9 @@ func (s *Store) resolveWriteIntentError(ctx context.Context, wiErr *proto.WriteI
 
 		if s.stopper.StartTask() {
 			wg.Add(1)
+			ctx := tracer.ToCtx(ctx, trace.Fork())
 
-			go func() {
+			go func(ctx context.Context) {
 				resolveErr := rng.addWriteCmd(ctx, resolveArgs, resolveReply, &wg)
 				if resolveErr != nil {
 					if log.V(1) {
@@ -1415,7 +1438,7 @@ func (s *Store) resolveWriteIntentError(ctx context.Context, wiErr *proto.WriteI
 					}
 				}
 				s.stopper.FinishTask()
-			}()
+			}(ctx)
 		}
 	}
 

--- a/util/feed.go
+++ b/util/feed.go
@@ -91,6 +91,9 @@ type Feed struct {
 // all Subscribers to the feed. Events published to a closed feed, or to a feed
 // with no Subscribers, will be ignored.
 func (f *Feed) Publish(event interface{}) {
+	if f == nil {
+		return
+	}
 	f.Lock()
 	defer f.Unlock()
 	if f.closed || len(f.subscribers) == 0 {
@@ -124,7 +127,7 @@ func (f *Feed) Subscribe() *Subscription {
 
 	f.Lock()
 	defer f.Unlock()
-	if !f.closed {
+	if f != nil && !f.closed {
 		f.subscribers = append(f.subscribers, sub)
 	} else {
 		close(sub.events)
@@ -136,6 +139,9 @@ func (f *Feed) Subscribe() *Subscription {
 // immediately when the Feed is closed. After closure, any new Subscribers will
 // be closed immediately and attempts to Publish will be ignored.
 func (f *Feed) Close() {
+	if f == nil {
+		return
+	}
 	f.Lock()
 	defer f.Unlock()
 	if !f.closed {
@@ -151,6 +157,9 @@ func (f *Feed) Close() {
 // channel; however, there may still be unprocessed Events remaining in the
 // channel.
 func (s *Subscription) Unsubscribe() {
+	if s == nil {
+		return
+	}
 	s.feed.Lock()
 	defer s.feed.Unlock()
 	if !s.feed.closed {

--- a/util/retry/retry.go
+++ b/util/retry/retry.go
@@ -73,6 +73,12 @@ func (r *Retry) Reset() {
 	r.isReset = true
 }
 
+// CurrentAttempt it is zero initally and increases with each call to Next()
+// which does not immediately follow a Reset().
+func (r *Retry) CurrentAttempt() int {
+	return r.currentAttempt
+}
+
 func (r Retry) retryIn() time.Duration {
 	backoff := float64(r.opts.InitialBackoff) * math.Pow(r.opts.Multiplier, float64(r.currentAttempt))
 	if maxBackoff := float64(r.opts.MaxBackoff); backoff > maxBackoff {

--- a/util/retry/retry_test.go
+++ b/util/retry/retry_test.go
@@ -22,6 +22,7 @@ import (
 	"time"
 
 	"github.com/cockroachdb/cockroach/util"
+	_ "github.com/cockroachdb/cockroach/util/log" // enable flags
 )
 
 func TestRetryExceedsMaxBackoff(t *testing.T) {

--- a/util/testing.go
+++ b/util/testing.go
@@ -149,3 +149,12 @@ func SucceedsWithin(t Tester, duration time.Duration, fn func() error) {
 	}
 	t.Fatal(ErrorfSkipFrames(1, "condition failed to evaluate within %s: %s", duration, lastErr))
 }
+
+// Panics calls the supplied function and returns true if and only if it panics.
+func Panics(f func()) (panics bool) {
+	defer func() {
+		panics = recover() != nil
+	}()
+	f()
+	return
+}

--- a/util/tracer/context.go
+++ b/util/tracer/context.go
@@ -1,0 +1,42 @@
+// Copyright 2015 The Cockroach Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+// implied. See the License for the specific language governing
+// permissions and limitations under the License. See the AUTHORS file
+// for names of contributors.
+//
+// Author: Tobias Schottdorf (tobias.schottdorf@gmail.com)
+
+package tracer
+
+import "golang.org/x/net/context"
+
+// contextKeyType is a dummy type to avoid naming collisions with other
+// package's context keys.
+type contextKeyType int
+
+// contextKey is the key claimed for storing and retrieving a Trace from
+// a context.Context.
+const contextKey contextKeyType = 0
+
+// FromCtx is a helper to pass a Trace in a context.Context. It returns the
+// Trace stored at ContextKey or nil.
+func FromCtx(ctx context.Context) *Trace {
+	if t, ok := ctx.Value(contextKey).(*Trace); ok {
+		return t
+	}
+	return nil
+}
+
+// ToCtx is a helper to store a Trace in a context.Context under ContextKey.
+func ToCtx(ctx context.Context, trace *Trace) context.Context {
+	return context.WithValue(ctx, contextKey, trace)
+}

--- a/util/tracer/context_test.go
+++ b/util/tracer/context_test.go
@@ -1,0 +1,31 @@
+// Copyright 2015 The Cockroach Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+// implied. See the License for the specific language governing
+// permissions and limitations under the License. See the AUTHORS file
+// for names of contributors.
+//
+// Author: Tobias Schottdorf (tobias.schottdorf@gmail.com)
+
+package tracer
+
+import (
+	"testing"
+
+	"golang.org/x/net/context"
+)
+
+func TestContext(t *testing.T) {
+	ctx := ToCtx(context.Background(), NewTracer(nil, "").NewTrace(traceID(5)))
+	if tr := FromCtx(ctx); tr == nil || tr.ID != "5" {
+		t.Fatalf("trace got lost: %+v", tr)
+	}
+}

--- a/util/tracer/resolver.go
+++ b/util/tracer/resolver.go
@@ -1,0 +1,111 @@
+// Copyright 2015 The Cockroach Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+// implied. See the License for the specific language governing
+// permissions and limitations under the License. See the AUTHORS file
+// for names of contributors.
+//
+// Author: Tobias Schottdorf (tobias.schottdorf@gmail.com)
+
+package tracer
+
+import (
+	"bytes"
+	"runtime"
+	"sort"
+	"strconv"
+	"strings"
+	"sync"
+)
+
+// A CallResolver is a helping hand around runtime.Caller() to look up file,
+// line and name of the calling function. CallResolver caches the results of
+// its lookups and strips the uninteresting prefix from both the caller's
+// location and name; see NewCallResolver().
+// TODO(tschottdorf): consolidate this object with the Caller code we use in
+// logging.
+type CallResolver struct {
+	mu          sync.Mutex
+	cache       map[string]string
+	stripPrefix string
+}
+
+// NewCallResolver returns a CallResolver. The caller's path (or, if offset >
+// 0, the caller up the stack's) is resolved and numStrip components dropped.
+// The resulting location is taken as a base path of the resolver; all calls
+// from inside that path will resolve relative to it. A value of -1 disables
+// this feature.
+func NewCallResolver(offset int, numStrip int) *CallResolver {
+	cr := &CallResolver{
+		cache: map[string]string{},
+	}
+	if numStrip < 0 {
+		return cr
+	}
+	_, file, _, ok := runtime.Caller(offset + 1)
+	if !ok {
+		panic("could not look up callsite of NewCallResolver")
+	}
+	fileParts := strings.Split(file, "/")
+	cr.stripPrefix = strings.Join(fileParts[:len(fileParts)-numStrip-1], "/") + "/"
+	return cr
+}
+
+func (cr *CallResolver) unknown() (string, string) {
+	return "???", "???"
+}
+
+// Lookup returns the (reduced) file:line and function of the caller at the
+// requested depth.
+func (cr *CallResolver) Lookup(depth int) (fileline, fun string) {
+	pc, file, line, ok := runtime.Caller(depth + 1)
+	if !ok || cr == nil {
+		return cr.unknown()
+	}
+	if strings.HasPrefix(file, cr.stripPrefix) {
+		file = file[len(cr.stripPrefix):]
+	}
+	fileline = file + ":" + strconv.Itoa(line)
+	cr.mu.Lock()
+	defer cr.mu.Unlock()
+	if v, ok := cr.cache[fileline]; ok {
+		return fileline, v
+	}
+	if f := runtime.FuncForPC(pc); f != nil {
+		fun := f.Name()
+		if indSlash := strings.LastIndex(fun, "/"); indSlash != -1 {
+			fun = fun[indSlash+1:]
+			if indDot := strings.Index(fun, "."); indDot != -1 {
+				fun = fun[indDot+1:]
+			}
+		}
+		cr.cache[fileline] = fun
+	} else {
+		cr.cache[fileline] = "???"
+	}
+	return fileline, cr.cache[fileline]
+}
+
+// String implements fmt.Stringer.
+func (cr *CallResolver) String() string {
+	cr.mu.Lock()
+	defer cr.mu.Unlock()
+	var keys []string
+	for k := range cr.cache {
+		keys = append(keys, k)
+	}
+	sort.Strings(keys)
+	var buf bytes.Buffer
+	for _, k := range keys {
+		_, _ = buf.WriteString(cr.cache[k] + ":\n\t" + k + "\n")
+	}
+	return buf.String()
+}

--- a/util/tracer/resolver_test.go
+++ b/util/tracer/resolver_test.go
@@ -1,0 +1,37 @@
+// Copyright 2015 The Cockroach Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+// implied. See the License for the specific language governing
+// permissions and limitations under the License. See the AUTHORS file
+// for names of contributors.
+//
+// Author: Tobias Schottdorf (tobias.schottdorf@gmail.com)
+
+package tracer
+
+import (
+	"regexp"
+	"testing"
+)
+
+func TestCallResolver(t *testing.T) {
+	cr := NewCallResolver(0, 1)
+	fileline, fun := func() (string, string) {
+		return cr.Lookup(1)
+	}()
+	if matched, err := regexp.MatchString(`^tracer/resolver_test\.go`, fileline); !matched || err != nil {
+		t.Fatalf("wrong file:line '%s'", fileline)
+	}
+	if fun != "TestCallResolver" {
+		t.Fatalf("unexpected caller reported: %s", fun)
+	}
+
+}

--- a/util/tracer/tracer.go
+++ b/util/tracer/tracer.go
@@ -1,0 +1,218 @@
+// Copyright 2015 The Cockroach Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+// implied. See the License for the specific language governing
+// permissions and limitations under the License. See the AUTHORS file
+// for names of contributors.
+//
+// Author: Tobias Schottdorf (tobias.schottdorf@gmail.com)
+
+package tracer
+
+import (
+	"bytes"
+	"fmt"
+	"math"
+	"strings"
+	"text/tabwriter"
+	"time"
+
+	"github.com/cockroachdb/cockroach/util"
+)
+
+// A Traceable object has a Trace identifier attached to it.
+type Traceable interface {
+	// TraceID is the unique ID for the tracee.
+	TraceID() string
+	// TraceName is a short and "sufficiently unique" human-readable
+	// representation of the tracee.
+	TraceName() string
+}
+
+// A TraceItem is an entry in a Trace.
+type TraceItem struct {
+	depth      int32
+	Origin     string
+	Name       string
+	Timestamp  time.Time
+	Duration   time.Duration
+	Func, File string
+	HLC        time.Time // TODO(tschottdorf) HLC timestamp
+}
+
+// A Trace is created by a Tracer and records the path of a request within (a
+// connected part of) the system. It contains the ID of the traced object and a
+// slice of trace entries. In typical usage the Epoch() and Event() methods are
+// called at various stages to record the path the associated request takes
+// through the system; when the request goes out of scope, a call to Finalize
+// marks the end of the Trace, at which point it publishes itself to an
+// associated `util.Feed`. A request may create multiple Traces as it passes
+// through different parts of a distributed systems.
+// A Trace is not safe for concurrent access.
+//
+// TODO(tschottdorf): not allowing concurrent access is the right thing to do
+// semantically, but we pass a Trace along with a context.Context, which
+// explicitly encourages sharing of values. Might want to add that just for
+// that reason, but for now it's convenient to let the race detector check what
+// we do with the Trace.
+type Trace struct {
+	// IDs is the unique identifier for the request in this trace.
+	ID string
+	// Name is a human-readable identifier for the request in this trace.
+	Name string
+	// Content is a trace, containing call sites and timings in the order in
+	// which they happened.
+	Content []TraceItem
+	tracer  *Tracer // origin tracer for clock, publishing...
+	depth   int32
+}
+
+// Event adds an Epoch with zero duration to the Trace.
+func (t *Trace) Event(name string) {
+	if t == nil {
+		return
+	}
+	t.epoch(name)()
+	t.Content[len(t.Content)-1].Duration = 0
+}
+
+// Epoch begins a phase in the life of the Trace, starting the measurement of
+// its duration. The returned function needs to be called when the measurement
+// is complete; failure to do so results in a panic() when Finalize() is
+// called. The suggested pattern of usage is, where possible,
+// `defer trace.Epoch("<name>")()`.
+func (t *Trace) Epoch(name string) func() {
+	if t == nil {
+		return func() {}
+	}
+	return t.epoch(name)
+}
+
+func (t *Trace) epoch(name string) func() {
+	if t.depth < 0 {
+		panic("use of finalized Trace:\n" + t.String())
+	}
+	t.depth++
+	pos := t.add(name)
+	called := false
+	return func() {
+		if called {
+			panic("epoch terminated twice")
+		}
+		called = true
+		t.Content[pos].Duration = t.tracer.now().Sub(t.Content[pos].Timestamp)
+		t.depth--
+	}
+}
+
+// Finalize submits the Trace to the underlying feed. If there is an open
+// Epoch, a panic occurs.
+func (t *Trace) Finalize() {
+	if t == nil {
+		return
+	}
+	if t.depth != 0 {
+		panic("attempt to finalize unbalanced trace:\n" + t.String())
+	}
+	t.depth = math.MinInt32
+	t.tracer.feed.Publish(t) // by reference
+}
+
+func (t *Trace) add(name string) int {
+	// Must be called with two callers to the client.
+	// (Client->Event|Epoch->epoch->add)
+	file, fun := t.tracer.callers.Lookup(3)
+	t.Content = append(t.Content, TraceItem{
+		depth:     t.depth,
+		Origin:    t.tracer.origin,
+		File:      file,
+		Func:      fun,
+		Timestamp: t.tracer.now(),
+		Name:      name,
+	})
+	return len(t.Content) - 1
+}
+
+// Fork creates a new Trace, equal to (but autonomous from) that which created
+// the original Trace.
+func (t *Trace) Fork() *Trace {
+	if t == nil {
+		return nil
+	}
+	return t.tracer.newTrace(t.ID, t.Name)
+}
+
+// String implements fmt.Stringer. It prints a human-readable breakdown of the
+// Trace.
+func (t Trace) String() string {
+	const tab = "\t"
+	buf := bytes.NewBuffer(nil)
+	w := &tabwriter.Writer{}
+	w.Init(buf, 1, 1, 0, ' ', 0)
+	fmt.Fprintln(w, "Name", tab, "Origin", tab, "Ts", tab, "Dur", tab, "Desc", tab, "File")
+
+	const traceTimeFormat = "15:04:05.000000"
+	for _, c := range t.Content {
+		var namePrefix string
+		if c.depth > 1 {
+			namePrefix = strings.Repeat("·", int(c.depth-1))
+		}
+		fmt.Fprintln(w, t.Name, tab, c.Origin, tab,
+			c.Timestamp.Format(traceTimeFormat), tab, c.Duration, tab,
+			namePrefix+c.Name, tab, c.File)
+	}
+
+	_ = w.Flush()
+	return buf.String()
+}
+
+// A Tracer is used to follow requests across the system (or across systems).
+// Requests must implement the Traceable interface and can be traced by invoking
+// NewTrace(), which returns a Trace object initialized to publish itself to a
+// util.Feed registered by the Tracer on completion.
+type Tracer struct {
+	origin  string // owner of this Tracer, i.e. Host ID
+	callers *CallResolver
+	feed    *util.Feed
+	now     func() time.Time
+}
+
+// NewTracer returns a new Tracer whose created Traces publish to the given feed.
+// The origin is an identifier of the system, for instance a host ID.
+func NewTracer(f *util.Feed, origin string) *Tracer {
+	return &Tracer{
+		origin:  origin,
+		now:     time.Now,
+		callers: NewCallResolver(1 /* stack offset */, 1),
+		feed:    f,
+	}
+}
+
+var dummyTracer = &Tracer{
+	now: func() time.Time { return time.Time{} },
+}
+
+// NewTrace creates a Trace for the given Traceable.
+func (t *Tracer) NewTrace(tracee Traceable) *Trace {
+	if t == nil {
+		t = dummyTracer
+	}
+	return t.newTrace(tracee.TraceID(), tracee.TraceName())
+}
+
+func (t *Tracer) newTrace(id, name string) *Trace {
+	return &Trace{
+		ID:     id,
+		Name:   name,
+		tracer: t,
+	}
+
+}

--- a/util/tracer/tracer_test.go
+++ b/util/tracer/tracer_test.go
@@ -1,0 +1,155 @@
+// Copyright 2015 The Cockroach Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+// implied. See the License for the specific language governing
+// permissions and limitations under the License. See the AUTHORS file
+// for names of contributors.
+//
+// Author: Tobias Schottdorf (tobias.schottdorf@gmail.com)
+
+package tracer
+
+import (
+	"reflect"
+	"strconv"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/cockroachdb/cockroach/util"
+	_ "github.com/cockroachdb/cockroach/util/log" // enable flags
+)
+
+type traceID int
+
+func (id traceID) TraceID() string {
+	return strconv.Itoa(int(id))
+}
+
+func (id traceID) TraceName() string {
+	return id.TraceID()
+}
+
+func TestTracer(t *testing.T) {
+	f := &util.Feed{}
+	sub := f.Subscribe()
+	const origin = ":8081"
+	tracer := NewTracer(f, origin)
+
+	now := &time.Time{}
+
+	add := func(t time.Duration) {
+		then := now.Add(t)
+		now = &then
+	}
+
+	tracer.now = func() time.Time {
+		return *now
+	}
+
+	// TODO(tschottdorf): Test some more.
+	req1 := traceID(10)
+	t1 := tracer.NewTrace(req1)
+
+	e1a := t1.Epoch("A1")
+	add(10 * time.Millisecond)
+	e1b := t1.Epoch("A2")
+	add(5 * time.Millisecond)
+	t1.Event("E3")
+	add(2 * time.Millisecond)
+	t1.Event("E4")
+	add(3 * time.Millisecond)
+	e1b() // 10ms elapsed
+	add(10 * time.Millisecond)
+	e1a() // 30ms elapsed
+	t1.Finalize()
+
+	if !util.Panics(e1a) || !util.Panics(e1b) {
+		t.Fatalf("expected a panic when ending an epoch twice")
+	}
+
+	f.Close()
+
+	expTraces := []Trace{
+		{ID: "10", Content: []TraceItem{
+			{
+				depth:    1,
+				Name:     "A1",
+				Duration: 30 * time.Millisecond,
+			},
+			{
+				depth:     2,
+				Timestamp: time.Time{}.Add(10 * time.Millisecond),
+				Name:      "A2",
+				Duration:  10 * time.Millisecond,
+			},
+			{
+				depth:     3,
+				Timestamp: time.Time{}.Add(15 * time.Millisecond),
+				Name:      "E3",
+			},
+			{
+				depth:     3,
+				Timestamp: time.Time{}.Add(17 * time.Millisecond),
+				Name:      "E4",
+			},
+		}},
+	}
+	for {
+		event := <-sub.Events()
+		if event == nil {
+			break
+		}
+		trace := event.(*Trace)
+
+		if len(expTraces) == 0 {
+			t.Fatalf("unexpected extra trace: %s", trace)
+		}
+		expTrace := expTraces[0]
+		expTraces = expTraces[1:]
+		if !reflect.DeepEqual(expTrace.ID, trace.ID) {
+			t.Errorf("expected ID %s, got %s", expTrace.ID, trace.ID)
+		}
+		tc := trace.Content
+		for i, v := range tc {
+			if !strings.Contains(v.Func, "TestTracer") || !strings.Contains(v.File, "tracer_test.go") {
+				t.Errorf("invalid callsite in trace: %s %s", v.Func, v.File)
+			}
+			if v.Origin != origin {
+				t.Fatalf("unexpected origin %s", v.Origin)
+			}
+			tc[i].Func, tc[i].File, tc[i].Origin = "", "", ""
+		}
+		if !reflect.DeepEqual(expTrace.Content, trace.Content) {
+			t.Fatalf("unexpected content:\n%+v\nwanted:\n%+v", trace, expTrace)
+		}
+	}
+	if len(expTraces) > 0 {
+		t.Fatalf("missing traces:\n%+v", expTraces)
+	}
+}
+
+func TestNilTracer(t *testing.T) {
+	trace := (*Tracer)(nil).NewTrace(traceID(9))
+	defer trace.Epoch("A")()
+	trace.Event("B")
+	trace.Event("C")
+	trace.Event("D")
+	trace.Epoch("E")()
+}
+
+func TestEpochBalance(t *testing.T) {
+	trace := (*Tracer)(nil).NewTrace(traceID(9))
+	trace.Epoch("never finalized")
+	if !util.Panics(func() { trace.Finalize() }) {
+		t.Fatalf("should panic when Finalize is called too early")
+	}
+}


### PR DESCRIPTION
For discussion:
added the `tracer` package, providing facilities to trace requests through the cluster.

reworked API based on the suggestions from the first proposal: a Trace is
autonomous, and submits itself on `Finalize()`. For tracing requests, have
- `trace.Event("x happened")` and
- `fn := trace.Epoch("stuff begins now"); fn() // stuff ends now`, with its<br />
  most convenient use case `defer trace.Epoch("x")()`.

Epochs and Events generate the same entries, but the former with nonzero
duration. Each entry has a depth, so nested epochs can be displayed nicely:

single-request increment, node side. Note that the total duration of the call
(609.166us) is right at the top; the nested epochs below divvy it up.

```
ID                 Origin              Ts                 Dur          Desc                    File
1435427552[...]    macts.local:8001    13:52:32.200487    609.166µs    node                    server/node.go:564
1435427552[...]    macts.local:8001    13:52:32.200515    576.619µs    ·executing Increment    storage/store.go:1271
1435427552[...]    macts.local:8001    13:52:32.200554    538.349µs    ··range                 storage/range.go:517
1435427552[...]    macts.local:8001    13:52:32.200561    0            ···write path           storage/range.go:526
1435427552[...]    macts.local:8001    13:52:32.200576    515.994µs    ···raft                 storage/range.go:703
1435427552[...]    macts.local:8001    13:52:32.200583    48.923µs     ····proposing           storage/range.go:765
1435427552[...]    macts.local:8001    13:52:32.200971    107.385µs    ····executing           storage/range.go:799
```

`EndTransaction` on the client gateway side:

```
I0627 13:52:32.785017   53305 monitor.go:211] received trace:
ID          Origin              Ts                 Dur            Desc                             File
2f2ecd58    macts.local:8001    13:52:32.743443    11.079554ms    coordinated sender               kv/txn_coord_sender.go:324
2f2ecd58    macts.local:8001    13:52:32.743451    1.57359ms      ·sending EndTransaction          kv/dist_sender.go:638
2f2ecd58    macts.local:8001    13:52:32.743455    5.607µs        ··meta descriptor lookup         kv/dist_sender.go:675
2f2ecd58    macts.local:8001    13:52:32.743483    0              ··sending to macts.local:8001    rpc/send.go:178
```

Transactional `Get` which hits an intent, attempts to resolve it
asynchronously, backs off and gets an error not retryable at the store level.

```
ID          Origin              Ts                 Dur             Desc                   File
3de447e3    macts.local:8001    13:52:32.888115    139.456068ms    node                   server/node.go:564
3de447e3    macts.local:8001    13:52:32.888125    126.494154ms    ·executing Get         storage/store.go:1271
3de447e3    macts.local:8001    13:52:32.888128    110.367783ms    ··range                storage/range.go:517
3de447e3    macts.local:8001    13:52:32.888131    110.364629ms    ···read path           storage/range.go:523
3de447e3    macts.local:8001    13:52:32.998509    16.098773ms     ··intent resolution    storage/store.go:1343
3de447e3    macts.local:8001    13:52:33.014457    150.888µs       ···range               storage/range.go:517
3de447e3    macts.local:8001    13:52:33.014460    0               ····write path         storage/range.go:526
3de447e3    macts.local:8001    13:52:33.014489    0               ····raft [async]       storage/range.go:698
3de447e3    macts.local:8001    13:52:33.014625    165.802µs       ·backoff               storage/store.go:1264
3de447e3    macts.local:8001    13:52:33.014796    12.765902ms     ·executing Get         storage/store.go:1271
3de447e3    macts.local:8001    13:52:33.014802    12.759787ms     ··range                storage/range.go:517
3de447e3    macts.local:8001    13:52:33.014805    12.755809ms     ···read path           storage/range.go:523
3de447e3    macts.local:8001    13:52:33.027566    0               ·not successful        storage/store.go:1266
```

TODO:
- convert to protos
- metadata handling? (ex: peer at request boundary)
- figure out persisting and viewing Traces (as discussed in PR)
