### PR TITLE
Always make sure to clear out range cache entries which overlap on insert.

### DIFF
--- a/kv/dist_sender.go
+++ b/kv/dist_sender.go
@@ -559,10 +559,10 @@ func (ds *DistSender) sendAttempt(desc *proto.RangeDescriptor, call proto.Call) 
 	return retry.Break, nil
 }
 
-// getDescriptors takes a call and looks up the corresponding range descriptors
-// associated to it. First, the range descriptor for call.Args.Key is looked up;
-// second, if call.Args.EndKey exceeds that of the returned descriptor, the
-// next descriptor is obtained as well.
+// getDescriptors takes a call and looks up the corresponding range
+// descriptors associated with it. First, the range descriptor for
+// call.Args.Key is looked up. If call.Args.EndKey exceeds that of the
+// returned descriptor, the next descriptor is obtained as well.
 func (ds *DistSender) getDescriptors(call proto.Call) (*proto.RangeDescriptor, *proto.RangeDescriptor, error) {
 	// If this is an InternalPushTxn, set ignoreIntents option as
 	// necessary. This prevents a potential infinite loop; see the

--- a/kv/dist_sender.go
+++ b/kv/dist_sender.go
@@ -655,18 +655,14 @@ func (ds *DistSender) Send(_ context.Context, call proto.Call) {
 
 		var desc, descNext *proto.RangeDescriptor
 		err := retry.WithBackoff(retryOpts, func() (retry.Status, error) {
-			var err error
+			var descErr error
 			// Get range descriptor (or, when spanning range, descriptors).
 			// sendAttempt below may clear them on certain errors, so we
 			// refresh (likely from the cache) on every retry.
-			desc, descNext, err = ds.getDescriptors(call)
-			// getDescriptors may fail retryably if the first range isn't
-			// available via Gossip.
-			if err != nil {
-				if rErr, ok := err.(util.Retryable); ok && rErr.CanRetry() {
-					return retry.Continue, err
-				}
-				return retry.Break, err
+			desc, descNext, descErr = ds.getDescriptors(call)
+			// If getDescriptors fails, we don't fish for retryable errors.
+			if descErr != nil {
+				return retry.Break, descErr
 			}
 			// Truncate the request to our current range, making sure not to
 			// touch it unless we have to (it is illegal to send EndKey on
@@ -736,11 +732,15 @@ func (ds *DistSender) Send(_ context.Context, call proto.Call) {
 
 		// In next iteration, query next range.
 		args.Header().Key = descNext.StartKey
+		log.Infof("starting next range: %s", descNext.StartKey)
+		log.Infof("desc: %s", desc)
+		log.Infof("descNext: %s", descNext)
 
 		// This is a multi-range request, make a new reply object for
 		// subsequent iterations of the loop.
 		curReply = args.CreateReply()
 	}
+	log.Infof("done with dist sender loop: %s", call.Method().String())
 	call.Reply = finalReply
 }
 

--- a/kv/dist_sender_test.go
+++ b/kv/dist_sender_test.go
@@ -454,7 +454,7 @@ func TestEvictCacheOnError(t *testing.T) {
 		if cur := ds.leaderCache.Lookup(1); reflect.DeepEqual(cur, &proto.Replica{}) && !tc.shouldClearLeader {
 			t.Errorf("%d: leader cache eviction: shouldClearLeader=%t, but value is %v", i, tc.shouldClearLeader, cur)
 		}
-		_, cachedDesc := ds.rangeCache.getCachedRangeDescriptor(call.Args.Header().Key, false)
+		_, cachedDesc := ds.rangeCache.getCachedRangeDescriptor(call.Args.Header().Key)
 		if cachedDesc == nil != tc.shouldClearReplica {
 			t.Errorf("%d: unexpected second replica lookup behaviour: wanted=%t", i, tc.shouldClearReplica)
 		}

--- a/kv/dist_sender_test.go
+++ b/kv/dist_sender_test.go
@@ -454,7 +454,7 @@ func TestEvictCacheOnError(t *testing.T) {
 		if cur := ds.leaderCache.Lookup(1); reflect.DeepEqual(cur, &proto.Replica{}) && !tc.shouldClearLeader {
 			t.Errorf("%d: leader cache eviction: shouldClearLeader=%t, but value is %v", i, tc.shouldClearLeader, cur)
 		}
-		_, cachedDesc := ds.rangeCache.getCachedRangeDescriptor(call.Args.Header().Key)
+		_, cachedDesc := ds.rangeCache.getCachedRangeDescriptor(call.Args.Header().Key, false)
 		if cachedDesc == nil != tc.shouldClearReplica {
 			t.Errorf("%d: unexpected second replica lookup behaviour: wanted=%t", i, tc.shouldClearReplica)
 		}

--- a/kv/dist_sender_test.go
+++ b/kv/dist_sender_test.go
@@ -376,7 +376,9 @@ func TestRetryOnDescriptorLookupError(t *testing.T) {
 	ctx := &DistSenderContext{
 		rpcSend: testFn,
 		rangeDescriptorDB: mockRangeDescriptorDB(func(_ proto.Key, _ lookupOptions) (_ []proto.RangeDescriptor, err error) {
-			err, errors = errors[0], errors[1:]
+			// Return next error and truncate the prefix of the errors array.
+			err = errors[0]
+			errors = errors[1:]
 			return []proto.RangeDescriptor{testRangeDescriptor}, err
 		}),
 	}

--- a/kv/dist_sender_test.go
+++ b/kv/dist_sender_test.go
@@ -375,9 +375,9 @@ func TestRetryOnDescriptorLookupError(t *testing.T) {
 
 	ctx := &DistSenderContext{
 		rpcSend: testFn,
-		rangeDescriptorDB: mockRangeDescriptorDB(func(_ proto.Key, _ lookupOptions) (_ []proto.RangeDescriptor, err error) {
+		rangeDescriptorDB: mockRangeDescriptorDB(func(_ proto.Key, _ lookupOptions) ([]proto.RangeDescriptor, error) {
 			// Return next error and truncate the prefix of the errors array.
-			err = errors[0]
+			err := errors[0]
 			errors = errors[1:]
 			return []proto.RangeDescriptor{testRangeDescriptor}, err
 		}),

--- a/kv/range_cache.go
+++ b/kv/range_cache.go
@@ -136,7 +136,15 @@ func (rmc *rangeDescriptorCache) LookupRangeDescriptor(key proto.Key,
 		// the correct range. Using the start key would require using
 		// Floor() which is a possibility for our llrb-based OrderedCache
 		// but not possible for RocksDB.
-		rmc.rangeCache.Add(rangeCacheKey(keys.RangeMetaKey(rs[i].EndKey)), &rs[i])
+
+		// Before adding a new descriptor, make sure we clear out any
+		// pre-existing, overlapping descriptor which might have been
+		// re-inserted due to concurrent range lookups.
+		rangeKey := keys.RangeMetaKey(rs[i].EndKey)
+		if k, r := rmc.getCachedRangeDescriptorLocked(rangeKey, true); r != nil {
+			rmc.rangeCache.Del(k)
+		}
+		rmc.rangeCache.Add(rangeCacheKey(rangeKey), &rs[i])
 	}
 	if len(rs) == 0 {
 		log.Fatalf("no range descriptors returned for %s", key)
@@ -160,7 +168,7 @@ func (rmc *rangeDescriptorCache) EvictCachedRangeDescriptor(descKey proto.Key, s
 	rmc.rangeCacheMu.Lock()
 	defer rmc.rangeCacheMu.Unlock()
 
-	rngKey, cachedDesc := rmc.getCachedRangeDescriptorLocked(descKey)
+	rngKey, cachedDesc := rmc.getCachedRangeDescriptorLocked(descKey, false)
 	// Note that we're doing a "compare-and-erase": If seenDesc is not nil,
 	// we want to clean the cache only if it equals the cached range
 	// descriptor as a pointer. If not, then likely some other caller
@@ -183,7 +191,7 @@ func (rmc *rangeDescriptorCache) EvictCachedRangeDescriptor(descKey proto.Key, s
 		// evict that key as well. This loop ends after the meta1 range, which
 		// returns KeyMin as its metadata key.
 		descKey = keys.RangeMetaKey(descKey)
-		rngKey, cachedDesc = rmc.getCachedRangeDescriptorLocked(descKey)
+		rngKey, cachedDesc = rmc.getCachedRangeDescriptorLocked(descKey, false)
 	}
 }
 
@@ -195,18 +203,21 @@ func (rmc *rangeDescriptorCache) getCachedRangeDescriptor(key proto.Key) (
 	rangeCacheKey, *proto.RangeDescriptor) {
 	rmc.rangeCacheMu.RLock()
 	defer rmc.rangeCacheMu.RUnlock()
-	return rmc.getCachedRangeDescriptorLocked(key)
+	return rmc.getCachedRangeDescriptorLocked(key, false)
 }
 
 // getCachedRangeDescriptorLocked is a helper function to retrieve the
 // descriptor of the range which contains the given key, if present in the
 // cache. It is assumed that the caller holds a read lock on rmc.rangeCacheMu.
-func (rmc *rangeDescriptorCache) getCachedRangeDescriptorLocked(key proto.Key) (
+func (rmc *rangeDescriptorCache) getCachedRangeDescriptorLocked(key proto.Key, inclusive bool) (
 	rangeCacheKey, *proto.RangeDescriptor) {
-	// We want to look up the range descriptor for key. The cache is
-	// indexed using the end-key of the range, but the end-key is
-	// non-inclusive. So we access the cache using key.Next().
-	metaKey := keys.RangeMetaKey(key.Next())
+	// The cache is indexed using the end-key of the range, but the
+	// end-key is non-inclusive. If inclusive is false, we access the
+	// cache using key.Next().
+	if !inclusive {
+		key = key.Next()
+	}
+	metaKey := keys.RangeMetaKey(key)
 
 	k, v, ok := rmc.rangeCache.Ceil(rangeCacheKey(metaKey))
 	if !ok {

--- a/util/cache/cache.go
+++ b/util/cache/cache.go
@@ -327,6 +327,14 @@ func (oc *OrderedCache) Do(f func(k, v interface{})) {
 	})
 }
 
+// DoRange invokes f on all cache entries in the range of from -> to.
+func (oc *OrderedCache) DoRange(f func(k, v interface{}), from, to interface{}) {
+	oc.llrb.DoRange(func(e llrb.Comparable) (done bool) {
+		f(e.(*entry).key, e.(*entry).value)
+		return
+	}, &entry{key: from}, &entry{key: to})
+}
+
 // IntervalCache is a cache which supports querying of intervals which
 // match a key or range of keys. It is backed by an interval tree. See
 // comments in UnorderedCache for more details on cache functionality.


### PR DESCRIPTION
This bug showed up with lots of CPUs as all of the intents created when
splitting the range get resolved in parallel and end up inserting old
range descriptors after eviction was complete. This would leave
overlapping descriptors such as ""-"m", ""-"\xff\xff", which would cause
dist sender to scan indefinitely.

Fixes #1459.
