### PR TITLE
print rangeCacheKey like proto.Key

### DIFF
--- a/kv/range_cache.go
+++ b/kv/range_cache.go
@@ -33,6 +33,10 @@ import (
 // RangeCache.
 type rangeCacheKey proto.Key
 
+func (a rangeCacheKey) String() string {
+	return proto.Key(a).String()
+}
+
 // Compare implements the llrb.Comparable interface for rangeCacheKey, so that
 // it can be used as a key for util.OrderedCache.
 func (a rangeCacheKey) Compare(b llrb.Comparable) int {


### PR DESCRIPTION
this fixes some log entries which would otherwise
log raw escape sequences in range_cache.go.
