### PR TITLE
Add target that lists 10 slowest tests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -83,6 +83,18 @@ test:
 	$(GO) test -tags '$(TAGS)' $(GOFLAGS) -i $(PKG)
 	$(GO) test -tags '$(TAGS)' $(GOFLAGS) -run $(TESTS) -cpu $(CPUS) $(PKG) -timeout $(TESTTIMEOUT) $(TESTFLAGS)
 
+.PHONY: testslow
+testslow: TESTFLAGS += -v
+testslow:
+	$(GO) test -tags '$(TAGS)' $(GOFLAGS) -i $(PKG)
+	$(GO) test -tags '$(TAGS)' $(GOFLAGS) -run $(TESTS) -cpu $(CPUS) $(PKG) -timeout $(TESTTIMEOUT) $(TESTFLAGS) | grep -F ': Test' | sed -E 's/(--- PASS: |\(|\))//g' | awk '{ print $$2, $$1 }' | sort -rn | head -n 10
+
+.PHONY: testraceslow
+testraceslow: TESTFLAGS += -v
+testraceslow:
+	$(GO) test -tags '$(TAGS)' $(GOFLAGS) -i $(PKG)
+	$(GO) test -tags '$(TAGS)' $(GOFLAGS) -race -run $(TESTS) -cpu $(CPUS) $(PKG) -timeout $(RACETIMEOUT) $(TESTFLAGS) | grep -F ': Test' | sed -E 's/(--- PASS: |\(|\))//g' | awk '{ print $$2, $$1 }' | sort -rn | head -n 10
+
 # "go test -i" builds dependencies and installs them into GOPATH/pkg, but does not run the
 # tests. Run it as a part of "testrace" since race-enabled builds are not covered by
 # "make build", and so they would be built from scratch every time (including the


### PR DESCRIPTION
Output as of this writing:

```
    $ make testslow
    go test -tags ''  -i ./...
    go test -tags ''  -run ".*" -cpu 1 ./... -timeout 15s -v | grep -F ': Test' | sed -E 's/(--- PASS: |\(|\))//g' | awk '{ print $2, $1 }' | sort -rn | head -n 10
    3.11s TestRangeDescriptorSnapshotRace
    1.41s TestTxnDBWriteSkewAnomaly
    1.24s TestTxnDBInconsistentAnalysisAnomaly
    1.01s TestRollover
    0.81s TestTxnDBPhantomReadAnomaly
    0.81s TestRestoreReplicas
    0.79s TestHTTPSenderRetryResponseCodes
    0.63s TestMultiStoreEventFeed
    0.56s TestEvictCacheOnError
    0.54s TestClientRetryNonTxn

    $ make testraceslow
    go test -tags ''  -i ./...
    go test -tags ''  -race -run ".*" -cpu 1 ./... -timeout 5m -v | grep -F ': Test' | sed -E 's/(--- PASS: |\(|\))//g' | awk '{ print $2, $1 }' | sort -rn | head -n 10
    6.21s TestHTTPSenderRetryResponseCodes
    6.00s TestTxnDBWriteSkewAnomaly
    5.47s TestTxnDBInconsistentAnalysisAnomaly
    4.06s TestClientRetryNonTxn
    3.58s TestRangeDescriptorSnapshotRace
    3.16s TestTxnDBPhantomReadAnomaly
    3.08s TestSSLEnforcement
    2.42s TestUseCerts
    2.11s TestKVDBInternalMethods
    2.10s TestTxnDBPhantomDeleteAnomaly
```
