### PR TITLE
New suggested fixes for failing MultiCPU tests

### DIFF
--- a/server/status/feed_test.go
+++ b/server/status/feed_test.go
@@ -175,6 +175,12 @@ func (ner *nodeEventReader) recordEvent(event interface{}) {
 			// Ignore this best-effort method.
 			break
 		}
+		if event.Method == proto.InternalRangeLookup {
+			// Due to a race with the server's status recording system, we can't
+			// reliably depend on InternalRangeLookup to occur during the test.
+			// Ignore this method.
+			break
+		}
 		nid = event.NodeID
 		eventStr = event.Method.String()
 	case *status.CallErrorEvent:
@@ -257,8 +263,6 @@ func TestServerNodeEventFeed(t *testing.T) {
 
 	expectedNodeEvents := map[proto.NodeID][]string{
 		proto.NodeID(1): {
-			"InternalRangeLookup",
-			"InternalRangeLookup",
 			"Put",
 			"Put",
 			"EndTransaction",


### PR DESCRIPTION
Suggested fixes for TestServerNodeEventFeed and TestMultiStoreEventFeed.
- Stop expecting "InternalRangeLookup" in TestServerNodeEventFeed
- Break out the update counts in TestMultiStoreEventFeed - I want to investigate
  why this is failing more detail.
