### PR TITLE
Refactor applyRaftCommand by breaking it into two methods.

### DIFF
--- a/storage/range.go
+++ b/storage/range.go
@@ -805,7 +805,7 @@ func (r *Range) applyRaftCommand(ctx context.Context, index uint64, originNode p
 
 	// Advance the last applied index and commit the batch.
 	if err := setAppliedIndex(batch, r.Desc().RaftID, index); err != nil {
-		rErr = newReplicaCorruptionError(util.Errorf("could not advance applied index"), err, rErr)
+		log.Fatalc(ctx, "setting applied index in a batch should never fail: %s", err)
 	}
 	if err := batch.Commit(); err != nil {
 		rErr = newReplicaCorruptionError(util.Errorf("could not commit batch"), err, rErr)
@@ -891,7 +891,7 @@ func (r *Range) applyRaftCommandHelper(ctx context.Context, index uint64, origin
 		if rErr == nil {
 			// If command was successful, flush the MVCC stats to the batch.
 			if err := r.stats.MergeMVCCStats(batch, ms, args.Header().Timestamp.WallTime); err != nil {
-				return batch, newReplicaCorruptionError(util.Errorf("could not merge MVCC stats"), err, rErr)
+				log.Fatalc(ctx, "setting mvcc stats in a batch should never fail: %s", err)
 			}
 		} else {
 			// Otherwise, reset the batch to clear out partial execution and
@@ -900,7 +900,7 @@ func (r *Range) applyRaftCommandHelper(ctx context.Context, index uint64, origin
 			batch = r.rm.Engine().NewBatch()
 		}
 		if err := r.respCache.PutResponse(batch, args.Header().CmdID, reply); err != nil {
-			return batch, newReplicaCorruptionError(util.Errorf("could not put to response cache"), err, rErr)
+			log.Fatalc(ctx, "putting a response cache entry in a batch should never fail: %s", err)
 		}
 	}
 

--- a/storage/response_cache_test.go
+++ b/storage/response_cache_test.go
@@ -88,7 +88,7 @@ func TestResponseCacheEmptyCmdID(t *testing.T) {
 	}
 }
 
-// TestResponseCacheCopy tests that responses cached in one cache get
+// TestResponseCacheCopyInto tests that responses cached in one cache get
 // transferred correctly to another cache using CopyInto().
 func TestResponseCacheCopyInto(t *testing.T) {
 	defer leaktest.AfterTest(t)

--- a/storage/response_cache_test.go
+++ b/storage/response_cache_test.go
@@ -32,8 +32,8 @@ var incR = proto.IncrementResponse{
 
 // createTestResponseCache creates an in-memory engine and
 // returns a response cache using the supplied Raft ID.
-func createTestResponseCache(t *testing.T, raftID proto.RaftID) *ResponseCache {
-	return NewResponseCache(raftID, engine.NewInMem(proto.Attributes{}, 1<<20))
+func createTestResponseCache(t *testing.T, raftID proto.RaftID) (*ResponseCache, engine.Engine) {
+	return NewResponseCache(raftID), engine.NewInMem(proto.Attributes{}, 1<<20)
 }
 
 func makeCmdID(wallTime, random int64) proto.ClientCmdID {
@@ -47,26 +47,26 @@ func makeCmdID(wallTime, random int64) proto.ClientCmdID {
 // clearing the cache.
 func TestResponseCachePutGetClearData(t *testing.T) {
 	defer leaktest.AfterTest(t)
-	rc := createTestResponseCache(t, 1)
+	rc, e := createTestResponseCache(t, 1)
 	cmdID := makeCmdID(1, 1)
 	val := proto.IncrementResponse{}
 	// Start with a get for an unseen cmdID.
-	if ok, err := rc.GetResponse(cmdID, &val); ok || err != nil {
+	if ok, err := rc.GetResponse(e, cmdID, &val); ok || err != nil {
 		t.Errorf("expected no response for id %+v; got %+v, %v", cmdID, val, err)
 	}
 	// Put value of 1 for test response.
-	if err := rc.PutResponse(cmdID, &incR); err != nil {
+	if err := rc.PutResponse(e, cmdID, &incR); err != nil {
 		t.Errorf("unexpected error putting response: %v", err)
 	}
 	// Get should now return 1.
-	if ok, err := rc.GetResponse(cmdID, &val); !ok || err != nil || val.NewValue != 1 {
+	if ok, err := rc.GetResponse(e, cmdID, &val); !ok || err != nil || val.NewValue != 1 {
 		t.Errorf("unexpected failure getting response: %t, %v, %+v", ok, err, val)
 	}
-	if err := rc.ClearData(); err != nil {
+	if err := rc.ClearData(e); err != nil {
 		t.Error(err)
 	}
 	// The previously present response should be gone.
-	if ok, err := rc.GetResponse(cmdID, &val); ok {
+	if ok, err := rc.GetResponse(e, cmdID, &val); ok {
 		t.Errorf("unexpected success getting response: %t, %v, %+v", ok, err, val)
 	}
 }
@@ -75,39 +75,40 @@ func TestResponseCachePutGetClearData(t *testing.T) {
 // command id. All calls should be noops.
 func TestResponseCacheEmptyCmdID(t *testing.T) {
 	defer leaktest.AfterTest(t)
-	rc := createTestResponseCache(t, 1)
+	rc, e := createTestResponseCache(t, 1)
 	cmdID := proto.ClientCmdID{}
 	val := proto.IncrementResponse{}
 	// Put value of 1 for test response.
-	if err := rc.PutResponse(cmdID, &incR); err != nil {
+	if err := rc.PutResponse(e, cmdID, &incR); err != nil {
 		t.Errorf("unexpected error putting response: %v", err)
 	}
 	// Get should return !ok.
-	if ok, err := rc.GetResponse(cmdID, &val); ok || err != nil {
+	if ok, err := rc.GetResponse(e, cmdID, &val); ok || err != nil {
 		t.Errorf("unexpected success getting response: %v, %v, %+v", ok, err, val)
 	}
 }
 
-// TestResponseCacheCopyInto tests that responses cached in one cache get
+// TestResponseCacheCopy tests that responses cached in one cache get
 // transferred correctly to another cache using CopyInto().
 func TestResponseCacheCopyInto(t *testing.T) {
 	defer leaktest.AfterTest(t)
-	rc1, rc2 := createTestResponseCache(t, 1), createTestResponseCache(t, 2)
+	rc1, e := createTestResponseCache(t, 1)
+	rc2, _ := createTestResponseCache(t, 2)
 	cmdID := makeCmdID(1, 1)
 	// Store an increment with new value one in the first cache.
 	val := proto.IncrementResponse{}
-	if err := rc1.PutResponse(cmdID, &incR); err != nil {
+	if err := rc1.PutResponse(e, cmdID, &incR); err != nil {
 		t.Errorf("unexpected error putting response: %v", err)
 	}
 	// Copy the first cache into the second.
-	if err := rc1.CopyInto(rc2.engine, rc2.raftID); err != nil {
+	if err := rc1.CopyInto(e, rc2.raftID); err != nil {
 		t.Errorf("unexpected error while copying response cache: %v", err)
 	}
 	// Get should return 1 for both caches.
-	if ok, err := rc1.GetResponse(cmdID, &val); !ok || err != nil || val.NewValue != 1 {
+	if ok, err := rc1.GetResponse(e, cmdID, &val); !ok || err != nil || val.NewValue != 1 {
 		t.Errorf("unexpected failure getting response from source: %t, %v, %+v", ok, err, val)
 	}
-	if ok, err := rc2.GetResponse(cmdID, &val); !ok || err != nil || val.NewValue != 1 {
+	if ok, err := rc2.GetResponse(e, cmdID, &val); !ok || err != nil || val.NewValue != 1 {
 		t.Errorf("unexpected failure getting response from destination: %t, %v, %+v", ok, err, val)
 	}
 }
@@ -116,24 +117,25 @@ func TestResponseCacheCopyInto(t *testing.T) {
 // transferred correctly to another cache using CopyFrom().
 func TestResponseCacheCopyFrom(t *testing.T) {
 	defer leaktest.AfterTest(t)
-	rc1, rc2 := createTestResponseCache(t, 1), createTestResponseCache(t, 2)
+	rc1, e := createTestResponseCache(t, 1)
+	rc2, _ := createTestResponseCache(t, 2)
 	cmdID := makeCmdID(1, 1)
 	// Store an increment with new value one in the first cache.
 	val := proto.IncrementResponse{}
-	if err := rc1.PutResponse(cmdID, &incR); err != nil {
+	if err := rc1.PutResponse(e, cmdID, &incR); err != nil {
 		t.Errorf("unexpected error putting response: %v", err)
 	}
 
 	// Copy the first cache into the second.
-	if err := rc2.CopyFrom(rc1.engine, rc1.raftID); err != nil {
+	if err := rc2.CopyFrom(e, rc1.raftID); err != nil {
 		t.Errorf("unexpected error while copying response cache: %v", err)
 	}
 
 	// Get should return 1 for both caches.
-	if ok, err := rc1.GetResponse(cmdID, &val); !ok || err != nil || val.NewValue != 1 {
+	if ok, err := rc1.GetResponse(e, cmdID, &val); !ok || err != nil || val.NewValue != 1 {
 		t.Errorf("unexpected failure getting response from source: %t, %v, %+v", ok, err, val)
 	}
-	if ok, err := rc2.GetResponse(cmdID, &val); !ok || err != nil || val.NewValue != 1 {
+	if ok, err := rc2.GetResponse(e, cmdID, &val); !ok || err != nil || val.NewValue != 1 {
 		t.Errorf("unexpected failure getting response from source: %t, %v, %+v", ok, err, val)
 	}
 }
@@ -142,11 +144,11 @@ func TestResponseCacheCopyFrom(t *testing.T) {
 // invocations do not block on same keys.
 func TestResponseCacheInflight(t *testing.T) {
 	defer leaktest.AfterTest(t)
-	rc := createTestResponseCache(t, 1)
+	rc, e := createTestResponseCache(t, 1)
 	cmdID := makeCmdID(1, 1)
 	val := proto.IncrementResponse{}
 	// Add inflight for cmdID.
-	if ok, err := rc.GetResponse(cmdID, &val); ok || err != nil {
+	if ok, err := rc.GetResponse(e, cmdID, &val); ok || err != nil {
 		t.Errorf("unexpected response or error: %t, %v", ok, err)
 	}
 	// Make two requests for response from cmdID, which is inflight.
@@ -155,7 +157,7 @@ func TestResponseCacheInflight(t *testing.T) {
 		doneChan := done
 		go func() {
 			val2 := proto.IncrementResponse{}
-			if ok, err := rc.GetResponse(cmdID, &val2); ok || err != nil {
+			if ok, err := rc.GetResponse(e, cmdID, &val2); ok || err != nil {
 				t.Errorf("unexpectedly found value for response cache entry %+v: %s", cmdID, err)
 			}
 			close(doneChan)
@@ -176,7 +178,7 @@ func TestResponseCacheInflight(t *testing.T) {
 // TestResponseCacheShouldCache verifies conditions for caching responses.
 func TestResponseCacheShouldCache(t *testing.T) {
 	defer leaktest.AfterTest(t)
-	rc := createTestResponseCache(t, 1)
+	rc, _ := createTestResponseCache(t, 1)
 
 	testCases := []struct {
 		err         error
@@ -194,6 +196,7 @@ func TestResponseCacheShouldCache(t *testing.T) {
 		{&proto.ConditionFailedError{}, true},
 		{&proto.WriteIntentError{}, false},
 		{&proto.WriteTooOldError{}, false},
+		{&proto.NotLeaderError{}, false},
 	}
 
 	for i, test := range testCases {
@@ -212,26 +215,26 @@ func TestResponseCacheGC(t *testing.T) {
 	eng := engine.NewInMem(proto.Attributes{Attrs: []string{"ssd"}}, 1<<30)
 	defer eng.Close()
 
-	rc := NewResponseCache(1, eng)
+	rc := NewResponseCache(1)
 	cmdID := makeCmdID(1, 1)
 
 	// Add response for cmdID with timestamp at time=1ns.
 	copyIncR := incR
 	copyIncR.Timestamp.WallTime = 1
-	if err := rc.PutResponse(cmdID, &copyIncR); err != nil {
+	if err := rc.PutResponse(eng, cmdID, &copyIncR); err != nil {
 		t.Fatalf("unexpected error putting responpse: %v", err)
 	}
 	eng.SetGCTimeouts(0, 0) // avoids GC
 	eng.CompactRange(nil, nil)
 	val := proto.IncrementResponse{}
-	if ok, err := rc.GetResponse(cmdID, &val); !ok || err != nil || val.NewValue != 1 {
+	if ok, err := rc.GetResponse(eng, cmdID, &val); !ok || err != nil || val.NewValue != 1 {
 		t.Fatalf("unexpected response or error: %t, %v, %+v", ok, err, val)
 	}
 
 	// Now set minRCacheTS to 1, which will GC.
 	eng.SetGCTimeouts(0, 1)
 	eng.CompactRange(nil, nil)
-	if ok, err := rc.GetResponse(cmdID, &val); ok || err != nil {
+	if ok, err := rc.GetResponse(eng, cmdID, &val); ok || err != nil {
 		t.Errorf("unexpected response or error: %t, %v", ok, err)
 	}
 }

--- a/storage/store.go
+++ b/storage/store.go
@@ -1247,7 +1247,7 @@ func (s *Store) ExecuteCmd(ctx context.Context, call proto.Call) error {
 		}
 
 		if err = rng.AddCmd(ctx, proto.Call{Args: args, Reply: reply}, true); err == nil {
-			return retry.Break, err
+			return retry.Break, nil
 		}
 
 		// Maybe resolve a potential write intent error. We do this here


### PR DESCRIPTION
This eliminates some of the confusion around the nested defer statements and makes
it easier to reason about the response cache and the returned vs. set-in-reply errors.

Removed pre-loaded WriteTooOldError from Range.AddWriteCmd(). It might have been necessary
at one point or another, but there's no remaining justification for it and it might be
responsible for some of the recent issues.

Changed ResponseCache methods to always accept the engine instead of having engine stored
at instantiation. This allows us to set the response cache as part of the same batch as
the executed command.
