### PR TITLE
Refactor out HTTP POST with retry to its own file

### DIFF
--- a/client/http_post.go
+++ b/client/http_post.go
@@ -1,0 +1,132 @@
+// Copyright 2015 The Cockroach Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+// implied. See the License for the specific language governing
+// permissions and limitations under the License. See the AUTHORS file
+// for names of contributors.
+//
+// Author: Spencer Kimball (spencer@cockroachlabs.com)
+//         Vivek Menezes (vivek@cockroachlabs.com)
+
+package client
+
+import (
+	"bytes"
+	"errors"
+	"fmt"
+	"io"
+	"io/ioutil"
+	"net/http"
+
+	snappy "github.com/cockroachdb/c-snappy"
+	"github.com/cockroachdb/cockroach/base"
+	"github.com/cockroachdb/cockroach/util"
+	"github.com/cockroachdb/cockroach/util/retry"
+	gogoproto "github.com/gogo/protobuf/proto"
+)
+
+// PostContext is the context passed into the Post function
+type PostContext struct {
+	Server    string // The host:port address of the Cockroach gateway node
+	Endpoint  string
+	Client    *http.Client  // The HTTP client
+	Context   *base.Context // The base context: needed for client setup.
+	RetryOpts retry.Options
+}
+
+// HTTPPost posts the req using the HTTP client. The call's method is
+// appended to the endpoint and set as the URL path. The call's arguments
+// are protobuf-serialized and written as the POST body. The content
+// type is set to application/x-protobuf.
+//
+// On success, the response body is unmarshalled into call.Reply.
+//
+// HTTP response codes which are retryable are retried with backoff in a loop
+// using the default retry options. Other errors sending HTTP request are
+// retried indefinitely using the same client command ID to avoid reporting
+// failure when in fact the command may go through and execute successfully. We
+// retry here to eventually get through with the same client command ID and be
+// given the cached response.
+func HTTPPost(c PostContext, request, response gogoproto.Message, method fmt.Stringer) error {
+	retryOpts := c.RetryOpts
+	retryOpts.Tag = fmt.Sprintf("%s %s", c.Context.RequestScheme(), method)
+
+	// Marshal the args into a request body.
+	body, err := gogoproto.Marshal(request)
+	if err != nil {
+		return err
+	}
+
+	url := c.Context.RequestScheme() + "://" + c.Server + c.Endpoint + method.String()
+
+	return retry.WithBackoff(retryOpts, func() (retry.Status, error) {
+		req, err := http.NewRequest("POST", url, bytes.NewReader(body))
+		if err != nil {
+			return retry.Break, err
+		}
+		req.Header.Add(util.ContentTypeHeader, util.ProtoContentType)
+		req.Header.Add(util.AcceptHeader, util.ProtoContentType)
+		req.Header.Add(util.AcceptEncodingHeader, util.SnappyEncoding)
+
+		resp, err := c.Client.Do(req)
+		if err != nil {
+			return retry.Continue, err
+		}
+
+		defer resp.Body.Close()
+
+		switch resp.StatusCode {
+		case http.StatusOK:
+			// We're cool.
+		case http.StatusServiceUnavailable, http.StatusGatewayTimeout, StatusTooManyRequests:
+			// Retry on service unavailable and request timeout.
+			// TODO(spencer): consider respecting the Retry-After header for
+			// backoff / retry duration.
+			return retry.Continue, errors.New(resp.Status)
+		default:
+			// Can't recover from all other errors.
+			return retry.Break, errors.New(resp.Status)
+		}
+
+		if resp.Header.Get(util.ContentEncodingHeader) == util.SnappyEncoding {
+			resp.Body = &snappyReader{body: resp.Body}
+		}
+
+		b, err := ioutil.ReadAll(resp.Body)
+		if err != nil {
+			return retry.Continue, err
+		}
+
+		if err := gogoproto.Unmarshal(b, response); err != nil {
+			return retry.Continue, err
+		}
+
+		return retry.Break, nil
+	})
+}
+
+// snappyReader wraps a response body so it can lazily
+// call snappy.NewReader on the first call to Read
+type snappyReader struct {
+	body io.ReadCloser // underlying Response.Body
+	sr   io.Reader     // lazily-initialized snappy reader
+}
+
+func (s *snappyReader) Read(p []byte) (n int, err error) {
+	if s.sr == nil {
+		s.sr = snappy.NewReader(s.body)
+	}
+	return s.sr.Read(p)
+}
+
+func (s *snappyReader) Close() error {
+	return s.body.Close()
+}

--- a/client/http_post.go
+++ b/client/http_post.go
@@ -37,7 +37,6 @@ import (
 type PostContext struct {
 	Server    string // The host:port address of the Cockroach gateway node
 	Endpoint  string
-	Client    *http.Client  // The HTTP client
 	Context   *base.Context // The base context: needed for client setup.
 	RetryOpts retry.Options
 }
@@ -76,7 +75,12 @@ func HTTPPost(c PostContext, request, response gogoproto.Message, method fmt.Str
 		req.Header.Add(util.AcceptHeader, util.ProtoContentType)
 		req.Header.Add(util.AcceptEncodingHeader, util.SnappyEncoding)
 
-		resp, err := c.Client.Do(req)
+		client, err := c.Context.GetHTTPClient()
+		if err != nil {
+			return retry.Break, err
+		}
+
+		resp, err := client.Do(req)
 		if err != nil {
 			return retry.Continue, err
 		}

--- a/client/http_sender.go
+++ b/client/http_sender.go
@@ -62,9 +62,8 @@ func newHTTPSender(server string, ctx *base.Context, retryOpts retry.Options) (*
 			RetryOpts: retryOpts,
 		},
 	}
-	var err error
-	sender.ctx.Client, err = ctx.GetHTTPClient()
-	if err != nil {
+	// Ensure that the context returns an HTTPClient.
+	if _, err := ctx.GetHTTPClient(); err != nil {
 		return nil, err
 	}
 	return sender, nil

--- a/proto/api.go
+++ b/proto/api.go
@@ -220,18 +220,7 @@ func (rh *ResponseHeader) SetGoError(err error) {
 		return
 	}
 	rh.Error = &Error{}
-	rh.Error.Message = err.Error()
-	if r, ok := err.(util.Retryable); ok {
-		rh.Error.Retryable = r.CanRetry()
-	}
-	if r, ok := err.(TransactionRestartError); ok {
-		rh.Error.TransactionRestart = r.CanRestartTransaction()
-	}
-	// If the specific error type exists in the detail union, set it.
-	detail := &ErrorDetail{}
-	if detail.SetValue(err) {
-		rh.Error.Detail = detail
-	}
+	rh.Error.SetResponseGoError(err)
 }
 
 // Verify verifies the integrity of the get response value.

--- a/server/server_test.go
+++ b/server/server_test.go
@@ -492,7 +492,7 @@ func TestSQLServer(t *testing.T) {
 		// Request with garbage payload.
 		{"Execute", []byte("garbage"), http.StatusBadRequest},
 		// Valid request.
-		{"Execute", body, http.StatusNotImplemented},
+		{"Execute", body, http.StatusOK},
 	}
 	for _, test := range testCases {
 		statusCode := sendURL(t, baseURL+test.command, test.body)

--- a/sql/driver/http_sender.go
+++ b/sql/driver/http_sender.go
@@ -1,4 +1,4 @@
-// Copyright 2014 The Cockroach Authors.
+// Copyright 2015 The Cockroach Authors.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -13,9 +13,10 @@
 // permissions and limitations under the License. See the AUTHORS file
 // for names of contributors.
 //
-// Author: Spencer Kimball (spencer.kimball@gmail.com)
+// Author: Spencer Kimball (spencer@cockroachlabs.com)
+//         Vivek Menezes (vivek@cockroachlabs.com)
 
-package client
+package driver
 
 import (
 	"net/url"
@@ -23,17 +24,9 @@ import (
 	"golang.org/x/net/context"
 
 	"github.com/cockroachdb/cockroach/base"
-	"github.com/cockroachdb/cockroach/proto"
+	"github.com/cockroachdb/cockroach/client"
+	"github.com/cockroachdb/cockroach/sql/sqlwire"
 	"github.com/cockroachdb/cockroach/util/retry"
-)
-
-const (
-	// KVDBEndpoint is the URL path prefix which accepts incoming
-	// HTTP requests for the KV API.
-	KVDBEndpoint = "/kv/db/"
-	// StatusTooManyRequests indicates client should retry due to
-	// server having too many requests.
-	StatusTooManyRequests = 429
 )
 
 func init() {
@@ -46,18 +39,18 @@ func init() {
 }
 
 // httpSender is an implementation of Sender which exposes the
-// Key-Value database provided by a Cockroach cluster by connecting
+// SQL database provided by a Cockroach cluster by connecting
 // via HTTP to a Cockroach node.
 type httpSender struct {
-	ctx PostContext
+	ctx client.PostContext
 }
 
 // newHTTPSender returns a new instance of httpSender.
 func newHTTPSender(server string, ctx *base.Context, retryOpts retry.Options) (*httpSender, error) {
 	sender := &httpSender{
-		ctx: PostContext{
+		ctx: client.PostContext{
 			Server:    server,
-			Endpoint:  KVDBEndpoint,
+			Endpoint:  sqlwire.Endpoint,
 			Context:   ctx,
 			RetryOpts: retryOpts,
 		},
@@ -73,8 +66,8 @@ func newHTTPSender(server string, ctx *base.Context, retryOpts retry.Options) (*
 // Send sends call to Cockroach via an HTTP post. HTTP response codes
 // which are retryable are retried with backoff in a loop using the
 // default retry options.
-func (s *httpSender) Send(_ context.Context, call proto.Call) {
-	if err := HTTPPost(s.ctx, call.Args, call.Reply, call.Method()); err != nil {
+func (s *httpSender) Send(_ context.Context, call sqlwire.Call) {
+	if err := client.HTTPPost(s.ctx, call.Args, call.Reply, call.Args.Method()); err != nil {
 		call.Reply.Header().SetGoError(err)
 	}
 }

--- a/sql/driver/http_sender.go
+++ b/sql/driver/http_sender.go
@@ -55,9 +55,9 @@ func newHTTPSender(server string, ctx *base.Context, retryOpts retry.Options) (*
 			RetryOpts: retryOpts,
 		},
 	}
-	var err error
-	sender.ctx.Client, err = ctx.GetHTTPClient()
-	if err != nil {
+
+	// Ensure that the context returns an HTTPClient.
+	if _, err := ctx.GetHTTPClient(); err != nil {
 		return nil, err
 	}
 	return sender, nil

--- a/sql/driver/http_sender_test.go
+++ b/sql/driver/http_sender_test.go
@@ -1,0 +1,58 @@
+// Copyright 2015 The Cockroach Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+// implied. See the License for the specific language governing
+// permissions and limitations under the License. See the AUTHORS file
+// for names of contributors.
+//
+// Author: Vivek Menezes (vivek@cockroachlabs.com)
+
+package driver
+
+import (
+	"log"
+	"testing"
+
+	"golang.org/x/net/context"
+
+	"github.com/cockroachdb/cockroach/client"
+	"github.com/cockroachdb/cockroach/server"
+	"github.com/cockroachdb/cockroach/sql/sqlwire"
+	"github.com/cockroachdb/cockroach/testutils"
+	"github.com/cockroachdb/cockroach/util/leaktest"
+)
+
+func TestSend(t *testing.T) {
+	defer leaktest.AfterTest(t)
+	s := server.StartTestServer(t)
+	defer s.Stop()
+	sender, err := newHTTPSender(s.ServingAddr(), testutils.NewRootTestBaseContext(), client.DefaultTxnRetryOptions)
+	if err != nil {
+		log.Fatalf("Couldn't create HTTPSender for server:(%s)", s.ServingAddr())
+	}
+	testCases := []struct {
+		req   string
+		reply string
+	}{
+		{"ping", "ping"},
+		{"default", "default"},
+	}
+	for _, test := range testCases {
+		request := &sqlwire.SQLRequest{}
+		request.Cmds = append(request.Cmds, &sqlwire.SQLRequest_Cmd{Sql: &test.req})
+		call := sqlwire.Call{Args: request, Reply: &sqlwire.SQLResponse{}}
+		sender.Send(context.TODO(), call)
+		reply := string(call.Reply.(*sqlwire.SQLResponse).Results[0].Values[0].Blobval)
+		if reply != test.reply {
+			log.Fatalf("Server sent back reply:%s", reply)
+		}
+	}
+}

--- a/sql/driver/sender.go
+++ b/sql/driver/sender.go
@@ -1,0 +1,95 @@
+// Copyright 2015 The Cockroach Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+// implied. See the License for the specific language governing
+// permissions and limitations under the License. See the AUTHORS file
+// for names of contributors.
+//
+// Author: Peter Mattis (peter@cockroachlabs.com)
+
+package driver
+
+import (
+	"fmt"
+	"log"
+	"net/url"
+	"sync"
+	"time"
+
+	"golang.org/x/net/context"
+
+	"github.com/cockroachdb/cockroach/base"
+	"github.com/cockroachdb/cockroach/sql/sqlwire"
+	"github.com/cockroachdb/cockroach/util/retry"
+)
+
+// defaultRetryOptions sets the retry options for handling retryable errors and
+// connection I/O errors.
+var defaultRetryOptions = retry.Options{
+	Backoff:     50 * time.Millisecond,
+	MaxBackoff:  5 * time.Second,
+	Constant:    2,
+	MaxAttempts: 0, // retry indefinitely
+	UseV1Info:   true,
+}
+
+// Sender is an interface for sending a request to a SQL database backend.
+type Sender interface {
+	// Send invokes the Call.Args.Method with Call.Args and sets the result
+	// in Call.Reply.
+	Send(context.Context, sqlwire.Call)
+}
+
+// SenderFunc is an adapter to allow the use of ordinary functions
+// as Senders.
+type SenderFunc func(context.Context, sqlwire.Call)
+
+// Send calls f(ctx, c).
+func (f SenderFunc) Send(ctx context.Context, c sqlwire.Call) {
+	f(ctx, c)
+}
+
+// NewSenderFunc creates a new sender for the registered scheme.
+type NewSenderFunc func(u *url.URL, ctx *base.Context, retryOpts retry.Options) (Sender, error)
+
+var sendersMu sync.Mutex
+var senders = map[string]NewSenderFunc{}
+
+// RegisterSender registers the specified function to be used for
+// creation of a new sender when the specified scheme is encountered.
+func RegisterSender(scheme string, f NewSenderFunc) {
+	if f == nil {
+		log.Fatalf("unable to register nil function for \"%s\"", scheme)
+	}
+	sendersMu.Lock()
+	defer sendersMu.Unlock()
+	if _, ok := senders[scheme]; ok {
+		log.Fatalf("sender already registered for \"%s\"", scheme)
+	}
+	senders[scheme] = f
+}
+
+func newSender(u *url.URL, ctx *base.Context) (Sender, error) {
+	sendersMu.Lock()
+	defer sendersMu.Unlock()
+	f := senders[u.Scheme]
+	if f == nil {
+		return nil, fmt.Errorf("no sender registered for \"%s\"", u.Scheme)
+	}
+	return f(u, ctx, defaultRetryOptions)
+}
+
+func init() {
+	// Register a sender for the empty scheme which return a nil sender.
+	RegisterSender("", func(*url.URL, *base.Context, retry.Options) (Sender, error) {
+		return nil, nil
+	})
+}

--- a/sql/sqlwire/http.go
+++ b/sql/sqlwire/http.go
@@ -18,6 +18,7 @@
 package sqlwire
 
 import (
+	"github.com/cockroachdb/cockroach/proto"
 	gogoproto "github.com/gogo/protobuf/proto"
 )
 
@@ -44,6 +45,12 @@ type Response interface {
 	Header() *SQLResponseHeader
 }
 
+// A Call is a pending database API call.
+type Call struct {
+	Args  Request  // The argument to the command
+	Reply Response // The reply from the command
+}
+
 // Header returns the request header.
 func (r *SQLRequestHeader) Header() *SQLRequestHeader {
 	return r
@@ -62,4 +69,15 @@ func (*SQLRequest) CreateReply() Response {
 // Header returns the response header.
 func (r *SQLResponseHeader) Header() *SQLResponseHeader {
 	return r
+}
+
+// SetGoError converts the specified type into either one of the proto-
+// defined error types or into a Error for all other Go errors.
+func (r *SQLResponseHeader) SetGoError(err error) {
+	if err == nil {
+		r.Error = nil
+		return
+	}
+	r.Error = &proto.Error{}
+	r.Error.SetResponseGoError(err)
 }


### PR DESCRIPTION
Add Call for SQL request/response
Share HTTP Post with SQL and KV rpcs for now

There is some amount of code copying, but I think it's okay. Well Go doesn't have generics.
