### PR TITLE
Increase the timeout of TestStoreRangeManySplits from 1s to 5s

### DIFF
--- a/storage/client_split_test.go
+++ b/storage/client_split_test.go
@@ -540,7 +540,7 @@ func TestStoreRangeManySplits(t *testing.T) {
 			keys = append(keys, r.Key)
 		}
 		return reflect.DeepEqual(keys, expKeys)
-	}, 1*time.Second); err != nil {
+	}, 5*time.Second); err != nil {
 		t.Errorf("expected splits not found: %s", err)
 	}
 


### PR DESCRIPTION
The timeout is already set to 5 seconds for the second round split. This commit changes the timeout of the first round split to 5 seconds as well.

Fix #1501
