### PR TITLE
Fix duplicate output in slow.txt and excerpt.txt.

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -48,11 +48,11 @@ test:
     - "[ -f ${CIRCLE_ARTIFACTS}/test.log ] && docker run -i cockroachdb/cockroach-dev shell /go/bin/go2xunit < ${CIRCLE_ARTIFACTS}/test.log > ${CIRCLE_TEST_REPORTS}/go/test.xml"
     - "[ -f ${CIRCLE_ARTIFACTS}/testrace.log ] && docker run -i cockroachdb/cockroach-dev shell /go/bin/go2xunit < ${CIRCLE_ARTIFACTS}/testrace.log > ${CIRCLE_TEST_REPORTS}/race/testrace.xml"
     - |
-      find "${CIRCLE_ARTIFACTS}" -name '*.log' -type f -exec \
+      find "${CIRCLE_ARTIFACTS}" -name 'test*.log' -type f -exec \
         grep -F ': Test' {} ';' | sed -E 's/(--- PASS: |\(|\))//g' | awk '{ print $2, $1 }' | sort -rn | head -n 10 \
         >> "${CIRCLE_ARTIFACTS}"/slow.txt
     - |
-      find "${CIRCLE_ARTIFACTS}" -name '*.log' -type f -exec \
+      find "${CIRCLE_ARTIFACTS}" -name 'test*.log' -type f -exec \
         grep -B 5 -A 10 -E '^\-{0,3} *FAIL|^panic|^[Gg]oroutine \d+|(read|write) by.*goroutine|DATA RACE' {} ';' \
         >> "${CIRCLE_ARTIFACTS}"/excerpt.txt
     - |


### PR DESCRIPTION
The test logs can be found in both test*.log and the numerically-named
docker log output.
