### PR TITLE
fix #1483: add SetGoError on NotLeaderError

### DIFF
--- a/storage/range.go
+++ b/storage/range.go
@@ -828,7 +828,9 @@ func (r *Range) applyRaftCommand(ctx context.Context, index uint64, originNode p
 		// same ClientCmdID and would get the distributed sender stuck in an
 		// infinite loop, retrieving a stale NotLeaderError over and over
 		// again, even when proposing at the correct replica.
-		return r.newNotLeaderError(lease, originNode)
+		err := r.newNotLeaderError(lease, originNode)
+		reply.Header().SetGoError(err)
+		return err
 	}
 
 	// Anything happening from now on needs to enter the response cache.


### PR DESCRIPTION
when applyRaftCommand returned a NotLeaderError,
it forgot to put that into the header.

This is not the pretty fix (normally
one would refactor) but @spencerkimball has
an open PR #1512  and will likely want to pick this up
since the bug exists in his version as well.

fixes #1483 
