### PR TITLE
set maxBytes of range after initial snapshot applied

### DIFF
--- a/storage/client_raft_test.go
+++ b/storage/client_raft_test.go
@@ -723,6 +723,9 @@ func TestReplicateAfterSplit(t *testing.T) {
 	// Now add the second replica.
 	mtc.replicateRange(raftID2, 0, 1)
 
+	if mtc.stores[1].LookupRange(key, nil).GetMaxBytes() == 0 {
+		t.Error("Range MaxBytes is not set after snapshot applied")
+	}
 	// Once it catches up, the effects of increment commands can be seen.
 	if err := util.IsTrueWithin(func() bool {
 		getArgs, getResp := getArgs(key, raftID2, mtc.stores[1].StoreID())

--- a/storage/store.go
+++ b/storage/store.go
@@ -1029,16 +1029,10 @@ func (s *Store) SplitRange(origRng, newRng *Range) error {
 		return util.Errorf("couldn't insert range %v in rangesByKey btree", newRng)
 	}
 
-	// Update the max bytes of the range. Just copying it from the
-	// original range does not work since the original range and
-	// the new range might belong to different zones.
-	zone, err := lookupZoneConfig(s.ctx.Gossip, newRng)
-	if err != nil {
-		return util.Errorf("couldn't find a zone config for range %v", newRng)
+	// Update the max bytes and other information of the new range.
+	if err := newRng.updateRangeInfo(); err != nil {
+		return err
 	}
-	newRng.SetMaxBytes(zone.RangeMaxBytes)
-
-	// TODO(kkaneda): Update configHashes and other fields as well (Issue # 1362)?
 
 	s.feed.splitRange(origRng, newRng)
 	return s.processRangeDescriptorUpdateLocked(origRng)


### PR DESCRIPTION
After a range is created from Raft message and a initial snapshot is applied, the maxBytes in range may not be set if there is no updating for zoneConfigs of this key range. 
