### PR TITLE
lock in {Enable,Disable}LogFileOutput

### DIFF
--- a/util/log/clog.go
+++ b/util/log/clog.go
@@ -992,6 +992,11 @@ const bufferSize = 256 * 1024
 // removeFiles clears all the log files.
 func (l *loggingT) removeFiles() error {
 	l.mu.Lock()
+	defer l.mu.Unlock()
+	return l.removeFilesLocked()
+}
+
+func (l *loggingT) removeFilesLocked() error {
 	for s := FatalLog; s >= InfoLog; s-- {
 		if sb, ok := l.file[s].(*syncBuffer); ok {
 			if err := sb.file.Close(); err != nil {
@@ -1003,7 +1008,6 @@ func (l *loggingT) removeFiles() error {
 		}
 		l.file[s] = nil
 	}
-	l.mu.Unlock()
 	return nil
 }
 

--- a/util/log/log.go
+++ b/util/log/log.go
@@ -38,6 +38,8 @@ func FatalOnPanic() {
 // EnableLogFileOutput turns on logging using the specified directory.
 // For unittesting only.
 func EnableLogFileOutput(dir string) {
+	logging.mu.Lock()
+	defer logging.mu.Unlock()
 	*logDir = dir
 	logging.toStderr = false
 	logging.alsoToStderr = true
@@ -45,7 +47,9 @@ func EnableLogFileOutput(dir string) {
 
 // DisableLogFileOutput turns off logging. For unittesting only.
 func DisableLogFileOutput() {
-	if err := logging.removeFiles(); err != nil {
+	logging.mu.Lock()
+	defer logging.mu.Unlock()
+	if err := logging.removeFilesLocked(); err != nil {
 		logging.exit(err)
 	}
 	*logDir = ""


### PR DESCRIPTION
this has not caused issues so far, but on my WIP I have
data races here since even after stopper shutdown, some
moving parts in the system may still log and that can
cause TestStatusLocalLogs to race.
