### PR TITLE
addendum to #1487: weed out stray clients after server closes

### DIFF
--- a/rpc/server.go
+++ b/rpc/server.go
@@ -154,14 +154,11 @@ func (s *Server) Serve(handler http.Handler) {
 
 			switch state {
 			case http.StateNew:
-				select {
-				case <-s.context.Stopper.ShouldStop():
-					// Shutting down? Just close the new connection immediately.
+				if s.closed {
 					conn.Close()
-				default:
-					s.activeConns[conn] = struct{}{}
+					return
 				}
-
+				s.activeConns[conn] = struct{}{}
 			case http.StateHijacked, http.StateClosed:
 				delete(s.activeConns, conn)
 			}


### PR DESCRIPTION
in #1487, we attempted to fix a race in which incoming requests
would still be accepted even though the server had already shut
down. It appears that the race wasn't fixed completely. The minor
change here could make sure the hole is plugged (if this part of
the code is the source of the issue).
see https://circleci.com/gh/tschottdorf/cockroach/944 for a relevant
test failure (clean master post #1487).
