### PR TITLE
fix Example naming

### DIFF
--- a/server/accounting_test.go
+++ b/server/accounting_test.go
@@ -32,9 +32,9 @@ import (
 
 const testAcctConfig = `cluster_id: test`
 
-// ExampleSetAndGetAccts sets acct configs for a variety of key
+// Example_setAndGetAccts sets acct configs for a variety of key
 // prefixes and verifies they can be fetched directly.
-func ExampleSetAndGetAccts() {
+func Example_setAndGetAccts() {
 	_, stopper := startAdminServer()
 	defer stopper.Stop()
 
@@ -74,10 +74,10 @@ func ExampleSetAndGetAccts() {
 	// cluster_id: test
 }
 
-// ExampleLsAccts creates a series of acct configs and verifies
+// Example_lsAccts creates a series of acct configs and verifies
 // acct-ls works. First, no regexp lists all acct configs. Second,
 // regexp properly matches results.
-func ExampleLsAccts() {
+func Example_lsAccts() {
 	_, stopper := startAdminServer()
 	defer stopper.Stop()
 
@@ -132,11 +132,11 @@ func ExampleLsAccts() {
 	// db2
 }
 
-// ExampleRmAccts creates a series of acct configs and verifies
+// Example_rmAccts creates a series of acct configs and verifies
 // acct-rm works by deleting some and then all and verifying entries
 // have been removed via acct-ls. Also verify the default acct config
 // cannot be removed.
-func ExampleRmAccts() {
+func Example_rmAccts() {
 	_, stopper := startAdminServer()
 	defer stopper.Stop()
 
@@ -167,10 +167,10 @@ func ExampleRmAccts() {
 	// [default]
 }
 
-// ExampleAcctContentTypes verifies that the Accept header can be used
+// Example_acctContentTypes verifies that the Accept header can be used
 // to control the format of the response and the Content-Type header
 // can be used to specify the format of the request.
-func ExampleAcctContentTypes() {
+func Example_acctContentTypes() {
 	_, stopper := startAdminServer()
 	defer stopper.Stop()
 

--- a/server/cli/cli_test.go
+++ b/server/cli/cli_test.go
@@ -65,7 +65,7 @@ func (c cliTest) Run(line string) {
 	}
 }
 
-func ExampleBasic() {
+func Example_basic() {
 	c := newCLITest()
 
 	c.Run("kv put a 1 b 2")
@@ -105,7 +105,7 @@ func ExampleBasic() {
 	// node drained and shutdown: ok
 }
 
-func ExampleQuoted() {
+func Example_quoted() {
 	c := newCLITest()
 
 	c.Run(`kv put a\x00 日本語`)                                  // UTF-8 input text
@@ -140,7 +140,7 @@ func ExampleQuoted() {
 	// node drained and shutdown: ok
 }
 
-func ExampleInsecure() {
+func Example_insecure() {
 	c := cliTest{}
 	c.TestServer = &server.TestServer{}
 	c.Ctx = server.NewTestContext()
@@ -162,7 +162,7 @@ func ExampleInsecure() {
 	// node drained and shutdown: ok
 }
 
-func ExampleSplitMergeRanges() {
+func Example_ranges() {
 	c := newCLITest()
 
 	c.Run("kv put a 1 b 2 c 3 d 4")
@@ -206,7 +206,7 @@ func ExampleSplitMergeRanges() {
 	// node drained and shutdown: ok
 }
 
-func ExampleGlogFlags() {
+func Example_logging() {
 	c := newCLITest()
 
 	c.Run("kv --alsologtostderr=false scan")

--- a/server/permission_test.go
+++ b/server/permission_test.go
@@ -37,9 +37,9 @@ read: [readonly, readwrite]
 write: [readwrite, writeonly]
 `
 
-// ExampleSetAndGetPerm sets perm configs for a variety of key
+// Example_setAndGetPerm sets perm configs for a variety of key
 // prefixes and verifies they can be fetched directly.
-func ExampleSetAndGetPerms() {
+func Example_setAndGetPerms() {
 	_, stopper := startAdminServer()
 	defer stopper.Stop()
 
@@ -99,10 +99,10 @@ func ExampleSetAndGetPerms() {
 	// - writeonly
 }
 
-// ExampleLsPerms creates a series of perm configs and verifies
+// Example_lsPerms creates a series of perm configs and verifies
 // perm-ls works. First, no regexp lists all perm configs. Second,
 // regexp properly matches results.
-func ExampleLsPerms() {
+func Example_lsPerms() {
 	_, stopper := startAdminServer()
 	defer stopper.Stop()
 
@@ -157,11 +157,11 @@ func ExampleLsPerms() {
 	// db2
 }
 
-// ExampleRmPerms creates a series of perm configs and verifies
+// Example_rmPerms creates a series of perm configs and verifies
 // perm-rm works by deleting some and then all and verifying entries
 // have been removed via perm-ls. Also verify the default perm config
 // cannot be removed.
-func ExampleRmPerms() {
+func Example_rmPerms() {
 	_, stopper := startAdminServer()
 	defer stopper.Stop()
 
@@ -192,10 +192,10 @@ func ExampleRmPerms() {
 	// [default]
 }
 
-// ExamplePermContentTypes verifies that the Accept header can be used
+// Example_permContentTypes verifies that the Accept header can be used
 // to control the format of the response and the Content-Type header
 // can be used to specify the format of the request.
-func ExamplePermContentTypes() {
+func Example_permContentTypes() {
 	_, stopper := startAdminServer()
 	defer stopper.Stop()
 

--- a/server/zone_test.go
+++ b/server/zone_test.go
@@ -39,9 +39,9 @@ range_min_bytes: 1048576
 range_max_bytes: 67108864
 `
 
-// ExampleSetAndGetZone sets zone configs for a variety of key
+// Example_setAndGetZone sets zone configs for a variety of key
 // prefixes and verifies they can be fetched directly.
-func ExampleSetAndGetZone() {
+func Example_setAndGetZone() {
 	_, stopper := startAdminServer()
 	defer stopper.Stop()
 
@@ -101,10 +101,10 @@ func ExampleSetAndGetZone() {
 	// range_max_bytes: 67108864
 }
 
-// ExampleLsZones creates a series of zone configs and verifies
+// Example_lsZones creates a series of zone configs and verifies
 // zone-ls works. First, no regexp lists all zone configs. Second,
 // regexp properly matches results.
-func ExampleLsZones() {
+func Example_lsZones() {
 	_, stopper := startAdminServer()
 	defer stopper.Stop()
 
@@ -159,11 +159,11 @@ func ExampleLsZones() {
 	// db2
 }
 
-// ExampleRmZones creates a series of zone configs and verifies
+// Example_rmZones creates a series of zone configs and verifies
 // zone-rm works by deleting some and then all and verifying entries
 // have been removed via zone-ls. Also verify the default zone cannot
 // be removed.
-func ExampleRmZones() {
+func Example_rmZones() {
 	_, stopper := startAdminServer()
 	defer stopper.Stop()
 
@@ -194,10 +194,10 @@ func ExampleRmZones() {
 	// [default]
 }
 
-// ExampleZoneContentTypes verifies that the Accept header can be used
+// Example_zoneContentTypes verifies that the Accept header can be used
 // to control the format of the response and the Content-Type header
 // can be used to specify the format of the request.
-func ExampleZoneContentTypes() {
+func Example_zoneContentTypes() {
 	_, stopper := startAdminServer()
 	defer stopper.Stop()
 

--- a/storage/allocator_test.go
+++ b/storage/allocator_test.go
@@ -655,9 +655,9 @@ func (ts *testStore) Rebalance(ots *testStore, bytes int64) {
 	ots.Capacity.Available -= bytes
 }
 
-// ExampleAllocatorRebalancing models a set of stores in a cluster,
-// randomly adding / removing stores and adding bytes.
-func ExampleAllocatorRebalancing() {
+func Example_rebalancing() {
+	// Model a set of stores in a cluster,
+	// randomly adding / removing stores and adding bytes.
 	g := gossip.New(nil, 0, nil)
 	alloc := newAllocator(g)
 	alloc.randGen = rand.New(rand.NewSource(0))


### PR DESCRIPTION
godoc expects a very particular format, otherwise it ignores examples.
in particular, package-level examples need to match something like `^Example|Example_[a-z][a-zA-Z]*$^.
See https://godoc.org/github.com/fluhus/godoc-tricks#Examples
