### PR TITLE
Remove `wait` parameter

### DIFF
--- a/storage/gc_queue.go
+++ b/storage/gc_queue.go
@@ -227,7 +227,7 @@ func (gcq *gcQueue) process(now proto.Timestamp, rng *Range) error {
 
 	// Send GC request through range.
 	gcArgs.GCMeta = *gcMeta
-	if err := rng.AddCmd(rng.context(), proto.Call{Args: gcArgs, Reply: &proto.InternalGCResponse{}}, true); err != nil {
+	if err := rng.AddCmd(rng.context(), proto.Call{Args: gcArgs, Reply: &proto.InternalGCResponse{}}); err != nil {
 		return err
 	}
 
@@ -289,7 +289,7 @@ func (gcq *gcQueue) resolveIntent(rng *Range, key proto.Key, meta *engine.MVCCMe
 			Txn:       pushReply.PusheeTxn,
 		},
 	}
-	if err := rng.AddCmd(rng.context(), proto.Call{Args: resolveArgs, Reply: &proto.InternalResolveIntentResponse{}}, true); err != nil {
+	if err := rng.AddCmd(rng.context(), proto.Call{Args: resolveArgs, Reply: &proto.InternalResolveIntentResponse{}}); err != nil {
 		log.Warningf("resolve of key %q failed: %s", key, err)
 		updateOldestIntent(meta.Timestamp.WallTime)
 	}

--- a/storage/gc_queue_test.go
+++ b/storage/gc_queue_test.go
@@ -187,7 +187,7 @@ func TestGCQueueProcess(t *testing.T) {
 				dArgs.Txn = newTransaction("test", datum.key, 1, proto.SERIALIZABLE, tc.clock)
 				dArgs.Txn.Timestamp = datum.ts
 			}
-			if err := tc.rng.AddCmd(tc.rng.context(), proto.Call{Args: dArgs, Reply: dReply}, true); err != nil {
+			if err := tc.rng.AddCmd(tc.rng.context(), proto.Call{Args: dArgs, Reply: dReply}); err != nil {
 				t.Fatalf("%d: could not delete data: %s", i, err)
 			}
 		} else {
@@ -197,7 +197,7 @@ func TestGCQueueProcess(t *testing.T) {
 				pArgs.Txn = newTransaction("test", datum.key, 1, proto.SERIALIZABLE, tc.clock)
 				pArgs.Txn.Timestamp = datum.ts
 			}
-			if err := tc.rng.AddCmd(tc.rng.context(), proto.Call{Args: pArgs, Reply: pReply}, true); err != nil {
+			if err := tc.rng.AddCmd(tc.rng.context(), proto.Call{Args: pArgs, Reply: pReply}); err != nil {
 				t.Fatalf("%d: could not put data: %s", i, err)
 			}
 		}

--- a/storage/range.go
+++ b/storage/range.go
@@ -628,8 +628,6 @@ func (r *Range) addReadOnlyCmd(ctx context.Context, args proto.Request, reply pr
 // response cache.  If wait is true, will block until the command is
 // complete.
 func (r *Range) addWriteCmd(ctx context.Context, args proto.Request, reply proto.Response, wait bool) error {
-	// Check the response cache in case this is a replay. This call
-	// may block if the same command is already underway.
 	header := args.Header()
 
 	// Add the write to the command queue to gate subsequent overlapping

--- a/storage/range_command.go
+++ b/storage/range_command.go
@@ -43,8 +43,8 @@ func (r *Range) executeCmd(batch engine.Engine, ms *engine.MVCCStats, args proto
 	// Verify key is contained within range here to catch any range split
 	// or merge activity.
 	header := args.Header()
-	if !r.ContainsKeyRange(header.Key, header.EndKey) {
-		err := proto.NewRangeKeyMismatchError(header.Key, header.EndKey, r.Desc())
+
+	if err := r.checkCmdHeader(header); err != nil {
 		reply.Header().SetGoError(err)
 		return nil, err
 	}

--- a/storage/range_test.go
+++ b/storage/range_test.go
@@ -301,7 +301,7 @@ func TestRangeReadConsistency(t *testing.T) {
 
 	// Try consistent read and verify success.
 
-	if err := tc.rng.AddCmd(tc.rng.context(), proto.Call{Args: gArgs, Reply: gReply}, true); err != nil {
+	if err := tc.rng.AddCmd(tc.rng.context(), proto.Call{Args: gArgs, Reply: gReply}); err != nil {
 
 		t.Errorf("expected success on consistent read: %s", err)
 	}
@@ -309,7 +309,7 @@ func TestRangeReadConsistency(t *testing.T) {
 	// Try a consensus read and verify error.
 	gArgs.ReadConsistency = proto.CONSENSUS
 
-	if err := tc.rng.AddCmd(tc.rng.context(), proto.Call{Args: gArgs, Reply: gReply}, true); err == nil {
+	if err := tc.rng.AddCmd(tc.rng.context(), proto.Call{Args: gArgs, Reply: gReply}); err == nil {
 
 		t.Errorf("expected error on consensus read")
 	}
@@ -318,7 +318,7 @@ func TestRangeReadConsistency(t *testing.T) {
 	gArgs.ReadConsistency = proto.INCONSISTENT
 	gArgs.Txn = newTransaction("test", proto.Key("a"), 1, proto.SERIALIZABLE, tc.clock)
 
-	if err := tc.rng.AddCmd(tc.rng.context(), proto.Call{Args: gArgs, Reply: gReply}, true); err == nil {
+	if err := tc.rng.AddCmd(tc.rng.context(), proto.Call{Args: gArgs, Reply: gReply}); err == nil {
 
 		t.Errorf("expected error on inconsistent read within a txn")
 	}
@@ -335,7 +335,7 @@ func TestRangeReadConsistency(t *testing.T) {
 	gArgs.ReadConsistency = proto.CONSISTENT
 	gArgs.Txn = nil
 
-	err := tc.rng.AddCmd(tc.rng.context(), proto.Call{Args: gArgs, Reply: gReply}, true)
+	err := tc.rng.AddCmd(tc.rng.context(), proto.Call{Args: gArgs, Reply: gReply})
 
 	if _, ok := err.(*proto.NotLeaderError); !ok {
 		t.Errorf("expected not leader error; got %s", err)
@@ -343,7 +343,7 @@ func TestRangeReadConsistency(t *testing.T) {
 
 	gArgs.ReadConsistency = proto.INCONSISTENT
 
-	if err := tc.rng.AddCmd(tc.rng.context(), proto.Call{Args: gArgs, Reply: gReply}, true); err != nil {
+	if err := tc.rng.AddCmd(tc.rng.context(), proto.Call{Args: gArgs, Reply: gReply}); err != nil {
 
 		t.Errorf("expected success reading with inconsistent: %s", err)
 	}
@@ -395,7 +395,7 @@ func TestRangeRangeBoundsChecking(t *testing.T) {
 	splitTestRange(tc.store, proto.Key("a"), proto.Key("a"), t)
 	gArgs, gReply := getArgs(proto.Key("b"), 1, tc.store.StoreID())
 
-	err := tc.rng.AddCmd(tc.rng.context(), proto.Call{Args: gArgs, Reply: gReply}, true)
+	err := tc.rng.AddCmd(tc.rng.context(), proto.Call{Args: gArgs, Reply: gReply})
 
 	if _, ok := err.(*proto.RangeKeyMismatchError); !ok {
 		t.Errorf("expected range key mismatch error: %s", err)
@@ -493,7 +493,7 @@ func TestRangeNotLeaderError(t *testing.T) {
 
 	for i, test := range testCases {
 
-		err := tc.rng.AddCmd(tc.rng.context(), proto.Call{Args: test.args, Reply: test.reply}, true)
+		err := tc.rng.AddCmd(tc.rng.context(), proto.Call{Args: test.args, Reply: test.reply})
 
 		if _, ok := err.(*proto.NotLeaderError); !ok {
 			t.Errorf("%d: expected not leader error: %s", i, err)
@@ -685,7 +685,7 @@ func TestRangeGossipConfigWithMultipleKeyPrefixes(t *testing.T) {
 	}
 	reply := &proto.PutResponse{}
 
-	if err := tc.rng.AddCmd(tc.rng.context(), proto.Call{Args: req, Reply: reply}, true); err != nil {
+	if err := tc.rng.AddCmd(tc.rng.context(), proto.Call{Args: req, Reply: reply}); err != nil {
 
 		t.Fatal(err)
 	}
@@ -728,7 +728,7 @@ func TestRangeGossipConfigUpdates(t *testing.T) {
 	}
 	reply := &proto.PutResponse{}
 
-	if err := tc.rng.AddCmd(tc.rng.context(), proto.Call{Args: req, Reply: reply}, true); err != nil {
+	if err := tc.rng.AddCmd(tc.rng.context(), proto.Call{Args: req, Reply: reply}); err != nil {
 
 		t.Fatal(err)
 	}
@@ -971,7 +971,7 @@ func TestAcquireLeaderLease(t *testing.T) {
 
 		test.args.Header().Timestamp = tc.clock.Now()
 
-		if err := tc.rng.AddCmd(tc.rng.context(), proto.Call{Args: test.args, Reply: test.reply}, true); err != nil {
+		if err := tc.rng.AddCmd(tc.rng.context(), proto.Call{Args: test.args, Reply: test.reply}); err != nil {
 
 			t.Fatal(err)
 		}
@@ -1003,7 +1003,7 @@ func TestRangeUpdateTSCache(t *testing.T) {
 	gArgs, gReply := getArgs([]byte("a"), 1, tc.store.StoreID())
 	gArgs.Timestamp = tc.clock.Now()
 
-	err := tc.rng.AddCmd(tc.rng.context(), proto.Call{Args: gArgs, Reply: gReply}, true)
+	err := tc.rng.AddCmd(tc.rng.context(), proto.Call{Args: gArgs, Reply: gReply})
 
 	if err != nil {
 		t.Error(err)
@@ -1014,7 +1014,7 @@ func TestRangeUpdateTSCache(t *testing.T) {
 	pArgs, pReply := putArgs([]byte("b"), []byte("1"), 1, tc.store.StoreID())
 	pArgs.Timestamp = tc.clock.Now()
 
-	err = tc.rng.AddCmd(tc.rng.context(), proto.Call{Args: pArgs, Reply: pReply}, true)
+	err = tc.rng.AddCmd(tc.rng.context(), proto.Call{Args: pArgs, Reply: pReply})
 
 	if err != nil {
 		t.Error(err)
@@ -1080,7 +1080,7 @@ func TestRangeCommandQueue(t *testing.T) {
 			args, reply := readOrWriteArgs(key1, test.cmd1Read, tc.rng.Desc().RaftID, tc.store.StoreID())
 			args.Header().User = "Foo"
 
-			err := tc.rng.AddCmd(tc.rng.context(), proto.Call{Args: args, Reply: reply}, true)
+			err := tc.rng.AddCmd(tc.rng.context(), proto.Call{Args: args, Reply: reply})
 
 			if err != nil {
 				t.Fatalf("test %d: %s", i, err)
@@ -1095,7 +1095,7 @@ func TestRangeCommandQueue(t *testing.T) {
 		go func() {
 			args, reply := readOrWriteArgs(key1, test.cmd2Read, tc.rng.Desc().RaftID, tc.store.StoreID())
 
-			err := tc.rng.AddCmd(tc.rng.context(), proto.Call{Args: args, Reply: reply}, true)
+			err := tc.rng.AddCmd(tc.rng.context(), proto.Call{Args: args, Reply: reply})
 
 			if err != nil {
 				t.Fatalf("test %d: %s", i, err)
@@ -1108,7 +1108,7 @@ func TestRangeCommandQueue(t *testing.T) {
 		go func() {
 			args, reply := readOrWriteArgs(key2, true, tc.rng.Desc().RaftID, tc.store.StoreID())
 
-			err := tc.rng.AddCmd(tc.rng.context(), proto.Call{Args: args, Reply: reply}, true)
+			err := tc.rng.AddCmd(tc.rng.context(), proto.Call{Args: args, Reply: reply})
 
 			if err != nil {
 				t.Fatalf("test %d: %s", i, err)
@@ -1175,7 +1175,7 @@ func TestRangeCommandQueueInconsistent(t *testing.T) {
 		args, reply := putArgs(key, []byte("value"), tc.rng.Desc().RaftID, tc.store.StoreID())
 		args.CmdID.Random = 1
 
-		err := tc.rng.AddCmd(tc.rng.context(), proto.Call{Args: args, Reply: reply}, true)
+		err := tc.rng.AddCmd(tc.rng.context(), proto.Call{Args: args, Reply: reply})
 
 		if err != nil {
 			t.Fatal(err)
@@ -1191,7 +1191,7 @@ func TestRangeCommandQueueInconsistent(t *testing.T) {
 		args, reply := getArgs(key, tc.rng.Desc().RaftID, tc.store.StoreID())
 		args.ReadConsistency = proto.INCONSISTENT
 
-		err := tc.rng.AddCmd(tc.rng.context(), proto.Call{Args: args, Reply: reply}, true)
+		err := tc.rng.AddCmd(tc.rng.context(), proto.Call{Args: args, Reply: reply})
 
 		if err != nil {
 			t.Fatal(err)
@@ -1230,14 +1230,14 @@ func TestRangeUseTSCache(t *testing.T) {
 	args, reply := getArgs([]byte("a"), 1, tc.store.StoreID())
 	args.Timestamp = tc.clock.Now()
 
-	err := tc.rng.AddCmd(tc.rng.context(), proto.Call{Args: args, Reply: reply}, true)
+	err := tc.rng.AddCmd(tc.rng.context(), proto.Call{Args: args, Reply: reply})
 
 	if err != nil {
 		t.Error(err)
 	}
 	pArgs, pReply := putArgs([]byte("a"), []byte("value"), 1, tc.store.StoreID())
 
-	err = tc.rng.AddCmd(tc.rng.context(), proto.Call{Args: pArgs, Reply: pReply}, true)
+	err = tc.rng.AddCmd(tc.rng.context(), proto.Call{Args: pArgs, Reply: pReply})
 
 	if err != nil {
 		t.Fatal(err)
@@ -1261,14 +1261,14 @@ func TestRangeNoTSCacheInconsistent(t *testing.T) {
 	args.Timestamp = tc.clock.Now()
 	args.ReadConsistency = proto.INCONSISTENT
 
-	err := tc.rng.AddCmd(tc.rng.context(), proto.Call{Args: args, Reply: reply}, true)
+	err := tc.rng.AddCmd(tc.rng.context(), proto.Call{Args: args, Reply: reply})
 
 	if err != nil {
 		t.Error(err)
 	}
 	pArgs, pReply := putArgs([]byte("a"), []byte("value"), 1, tc.store.StoreID())
 
-	err = tc.rng.AddCmd(tc.rng.context(), proto.Call{Args: pArgs, Reply: pReply}, true)
+	err = tc.rng.AddCmd(tc.rng.context(), proto.Call{Args: pArgs, Reply: pReply})
 
 	if err != nil {
 		t.Fatal(err)
@@ -1296,7 +1296,7 @@ func TestRangeNoTSCacheUpdateOnFailure(t *testing.T) {
 		pArgs.Txn = newTransaction("test", key, 1, proto.SERIALIZABLE, tc.clock)
 		pArgs.Timestamp = pArgs.Txn.Timestamp
 
-		if err := tc.rng.AddCmd(tc.rng.context(), proto.Call{Args: pArgs, Reply: pReply}, true); err != nil {
+		if err := tc.rng.AddCmd(tc.rng.context(), proto.Call{Args: pArgs, Reply: pReply}); err != nil {
 
 			t.Fatalf("test %d: %s", i, err)
 		}
@@ -1305,14 +1305,14 @@ func TestRangeNoTSCacheUpdateOnFailure(t *testing.T) {
 		args, reply := readOrWriteArgs(key, read, tc.rng.Desc().RaftID, tc.store.StoreID())
 		args.Header().Timestamp = tc.clock.Now() // later timestamp
 
-		if err := tc.rng.AddCmd(tc.rng.context(), proto.Call{Args: args, Reply: reply}, true); err == nil {
+		if err := tc.rng.AddCmd(tc.rng.context(), proto.Call{Args: args, Reply: reply}); err == nil {
 
 			t.Errorf("test %d: expected failure", i)
 		}
 
 		// Write the intent again -- should not have its timestamp upgraded!
 
-		if err := tc.rng.AddCmd(tc.rng.context(), proto.Call{Args: pArgs, Reply: pReply}, true); err != nil {
+		if err := tc.rng.AddCmd(tc.rng.context(), proto.Call{Args: pArgs, Reply: pReply}); err != nil {
 
 			t.Fatalf("test %d: %s", i, err)
 		}
@@ -1340,7 +1340,7 @@ func TestRangeNoTimestampIncrementWithinTxn(t *testing.T) {
 	gArgs.Txn = txn
 	gArgs.Timestamp = txn.Timestamp
 
-	if err := tc.rng.AddCmd(tc.rng.context(), proto.Call{Args: gArgs, Reply: gReply}, true); err != nil {
+	if err := tc.rng.AddCmd(tc.rng.context(), proto.Call{Args: gArgs, Reply: gReply}); err != nil {
 
 		t.Fatal(err)
 	}
@@ -1350,7 +1350,7 @@ func TestRangeNoTimestampIncrementWithinTxn(t *testing.T) {
 	pArgs.Txn = txn
 	pArgs.Timestamp = pArgs.Txn.Timestamp
 
-	if err := tc.rng.AddCmd(tc.rng.context(), proto.Call{Args: pArgs, Reply: pReply}, true); err != nil {
+	if err := tc.rng.AddCmd(tc.rng.context(), proto.Call{Args: pArgs, Reply: pReply}); err != nil {
 
 		t.Fatal(err)
 	}
@@ -1363,7 +1363,7 @@ func TestRangeNoTimestampIncrementWithinTxn(t *testing.T) {
 	expTS := pArgs.Timestamp
 	expTS.Logical++
 
-	if err := tc.rng.AddCmd(tc.rng.context(), proto.Call{Args: pArgs, Reply: pReply}, true); err == nil {
+	if err := tc.rng.AddCmd(tc.rng.context(), proto.Call{Args: pArgs, Reply: pReply}); err == nil {
 
 		t.Errorf("expected write intent error")
 	}
@@ -1396,7 +1396,7 @@ func TestRangeIdempotence(t *testing.T) {
 		} else {
 			args.CmdID = proto.ClientCmdID{WallTime: 1, Random: int64(idx + 100)}
 		}
-		if err := tc.rng.AddCmd(tc.rng.context(), proto.Call{Args: &args, Reply: &reply}, true); err != nil {
+		if err := tc.rng.AddCmd(tc.rng.context(), proto.Call{Args: &args, Reply: &reply}); err != nil {
 			t.Fatal(err)
 		}
 		if idx%2 == 0 && reply.NewValue != 1 {
@@ -1441,7 +1441,7 @@ func TestRangeResponseCacheReadError(t *testing.T) {
 	args, reply := incrementArgs([]byte("a"), 1, 1, tc.store.StoreID())
 	args.CmdID = proto.ClientCmdID{WallTime: 1, Random: 1}
 
-	err := tc.rng.AddCmd(tc.rng.context(), proto.Call{Args: args, Reply: reply}, true)
+	err := tc.rng.AddCmd(tc.rng.context(), proto.Call{Args: args, Reply: reply})
 
 	if err != nil {
 		t.Fatal(err)
@@ -1457,7 +1457,7 @@ func TestRangeResponseCacheReadError(t *testing.T) {
 	// Now try increment again and verify error.
 	reply.Reset()
 
-	err = tc.rng.AddCmd(tc.rng.context(), proto.Call{Args: args, Reply: reply}, true)
+	err = tc.rng.AddCmd(tc.rng.context(), proto.Call{Args: args, Reply: reply})
 
 	if err == nil {
 		t.Fatal(err)
@@ -1486,7 +1486,7 @@ func TestRangeResponseCacheStoredError(t *testing.T) {
 
 	args, reply := incrementArgs([]byte("a"), 1, 1, tc.store.StoreID())
 	args.CmdID = cmdID
-	err := tc.rng.AddCmd(tc.rng.context(), proto.Call{Args: args, Reply: reply}, true)
+	err := tc.rng.AddCmd(tc.rng.context(), proto.Call{Args: args, Reply: reply})
 	if err == nil {
 		t.Fatal("expected to see cached error but got nil")
 	} else if ge, ok := err.(*proto.Error); !ok {
@@ -1510,7 +1510,7 @@ func TestEndTransactionBeforeHeartbeat(t *testing.T) {
 		args, reply := endTxnArgs(txn, commit, 1, tc.store.StoreID())
 		args.Timestamp = txn.Timestamp
 
-		if err := tc.rng.AddCmd(tc.rng.context(), proto.Call{Args: args, Reply: reply}, true); err != nil {
+		if err := tc.rng.AddCmd(tc.rng.context(), proto.Call{Args: args, Reply: reply}); err != nil {
 
 			t.Error(err)
 		}
@@ -1526,7 +1526,7 @@ func TestEndTransactionBeforeHeartbeat(t *testing.T) {
 		// committed txn back, but without last heartbeat timestamp set.
 		hbArgs, hbReply := heartbeatArgs(txn, 1, tc.store.StoreID())
 
-		if err := tc.rng.AddCmd(tc.rng.context(), proto.Call{Args: hbArgs, Reply: hbReply}, true); err != nil {
+		if err := tc.rng.AddCmd(tc.rng.context(), proto.Call{Args: hbArgs, Reply: hbReply}); err != nil {
 
 			t.Error(err)
 		}
@@ -1552,7 +1552,7 @@ func TestEndTransactionAfterHeartbeat(t *testing.T) {
 		hbArgs, hbReply := heartbeatArgs(txn, 1, tc.store.StoreID())
 		hbArgs.Timestamp = txn.Timestamp
 
-		if err := tc.rng.AddCmd(tc.rng.context(), proto.Call{Args: hbArgs, Reply: hbReply}, true); err != nil {
+		if err := tc.rng.AddCmd(tc.rng.context(), proto.Call{Args: hbArgs, Reply: hbReply}); err != nil {
 
 			t.Error(err)
 		}
@@ -1563,7 +1563,7 @@ func TestEndTransactionAfterHeartbeat(t *testing.T) {
 		args, reply := endTxnArgs(txn, commit, 1, tc.store.StoreID())
 		args.Timestamp = txn.Timestamp
 
-		if err := tc.rng.AddCmd(tc.rng.context(), proto.Call{Args: args, Reply: reply}, true); err != nil {
+		if err := tc.rng.AddCmd(tc.rng.context(), proto.Call{Args: args, Reply: reply}); err != nil {
 
 			t.Error(err)
 		}
@@ -1609,7 +1609,7 @@ func TestEndTransactionWithPushedTimestamp(t *testing.T) {
 		tc.manualClock.Set(1)
 		args.Timestamp = tc.clock.Now()
 
-		err := tc.rng.AddCmd(tc.rng.context(), proto.Call{Args: args, Reply: reply}, true)
+		err := tc.rng.AddCmd(tc.rng.context(), proto.Call{Args: args, Reply: reply})
 
 		if test.expErr {
 			if err == nil {
@@ -1648,7 +1648,7 @@ func TestEndTransactionWithIncrementedEpoch(t *testing.T) {
 	hbArgs, hbReply := heartbeatArgs(txn, 1, tc.store.StoreID())
 	hbArgs.Timestamp = txn.Timestamp
 
-	if err := tc.rng.AddCmd(tc.rng.context(), proto.Call{Args: hbArgs, Reply: hbReply}, true); err != nil {
+	if err := tc.rng.AddCmd(tc.rng.context(), proto.Call{Args: hbArgs, Reply: hbReply}); err != nil {
 
 		t.Error(err)
 	}
@@ -1659,7 +1659,7 @@ func TestEndTransactionWithIncrementedEpoch(t *testing.T) {
 	args.Txn.Epoch = txn.Epoch + 1
 	args.Txn.Priority = txn.Priority + 1
 
-	if err := tc.rng.AddCmd(tc.rng.context(), proto.Call{Args: args, Reply: reply}, true); err != nil {
+	if err := tc.rng.AddCmd(tc.rng.context(), proto.Call{Args: args, Reply: reply}); err != nil {
 
 		t.Error(err)
 	}
@@ -1718,7 +1718,7 @@ func TestEndTransactionWithErrors(t *testing.T) {
 		args, reply := endTxnArgs(txn, true, 1, tc.store.StoreID())
 		args.Timestamp = txn.Timestamp
 
-		verifyErrorMatches(tc.rng.AddCmd(tc.rng.context(), proto.Call{Args: args, Reply: reply}, true), test.expErrRegexp, t)
+		verifyErrorMatches(tc.rng.AddCmd(tc.rng.context(), proto.Call{Args: args, Reply: reply}), test.expErrRegexp, t)
 
 	}
 }
@@ -1736,7 +1736,7 @@ func TestInternalPushTxnBadKey(t *testing.T) {
 	args, reply := pushTxnArgs(pusher, pushee, proto.ABORT_TXN, 1, tc.store.StoreID())
 	args.Key = pusher.Key
 
-	verifyErrorMatches(tc.rng.AddCmd(tc.rng.context(), proto.Call{Args: args, Reply: reply}, true), ".*should match pushee.*", t)
+	verifyErrorMatches(tc.rng.AddCmd(tc.rng.context(), proto.Call{Args: args, Reply: reply}), ".*should match pushee.*", t)
 
 }
 
@@ -1759,7 +1759,7 @@ func TestInternalPushTxnAlreadyCommittedOrAborted(t *testing.T) {
 		etArgs, etReply := endTxnArgs(pushee, status == proto.COMMITTED, 1, tc.store.StoreID())
 		etArgs.Timestamp = pushee.Timestamp
 
-		if err := tc.rng.AddCmd(tc.rng.context(), proto.Call{Args: etArgs, Reply: etReply}, true); err != nil {
+		if err := tc.rng.AddCmd(tc.rng.context(), proto.Call{Args: etArgs, Reply: etReply}); err != nil {
 
 			t.Fatal(err)
 		}
@@ -1767,7 +1767,7 @@ func TestInternalPushTxnAlreadyCommittedOrAborted(t *testing.T) {
 		// Now try to push what's already committed or aborted.
 		args, reply := pushTxnArgs(pusher, pushee, proto.ABORT_TXN, 1, tc.store.StoreID())
 
-		if err := tc.rng.AddCmd(tc.rng.context(), proto.Call{Args: args, Reply: reply}, true); err != nil {
+		if err := tc.rng.AddCmd(tc.rng.context(), proto.Call{Args: args, Reply: reply}); err != nil {
 
 			t.Fatal(err)
 		}
@@ -1820,7 +1820,7 @@ func TestInternalPushTxnUpgradeExistingTxn(t *testing.T) {
 		hbArgs, hbReply := heartbeatArgs(pushee, 1, tc.store.StoreID())
 		hbArgs.Timestamp = pushee.Timestamp
 
-		if err := tc.rng.AddCmd(tc.rng.context(), proto.Call{Args: hbArgs, Reply: hbReply}, true); err != nil {
+		if err := tc.rng.AddCmd(tc.rng.context(), proto.Call{Args: hbArgs, Reply: hbReply}); err != nil {
 
 			t.Fatal(err)
 		}
@@ -1830,7 +1830,7 @@ func TestInternalPushTxnUpgradeExistingTxn(t *testing.T) {
 		pushee.Timestamp = test.ts
 		args, reply := pushTxnArgs(pusher, pushee, proto.ABORT_TXN, 1, tc.store.StoreID())
 
-		if err := tc.rng.AddCmd(tc.rng.context(), proto.Call{Args: args, Reply: reply}, true); err != nil {
+		if err := tc.rng.AddCmd(tc.rng.context(), proto.Call{Args: args, Reply: reply}); err != nil {
 
 			t.Fatal(err)
 		}
@@ -1895,7 +1895,7 @@ func TestInternalPushTxnHeartbeatTimeout(t *testing.T) {
 			hbArgs, hbReply := heartbeatArgs(pushee, 1, tc.store.StoreID())
 			hbArgs.Timestamp = *test.heartbeat
 
-			if err := tc.rng.AddCmd(tc.rng.context(), proto.Call{Args: hbArgs, Reply: hbReply}, true); err != nil {
+			if err := tc.rng.AddCmd(tc.rng.context(), proto.Call{Args: hbArgs, Reply: hbReply}); err != nil {
 
 				t.Fatal(err)
 			}
@@ -1910,7 +1910,7 @@ func TestInternalPushTxnHeartbeatTimeout(t *testing.T) {
 		args.Now = args.Timestamp
 		args.Timestamp.Logical = 0
 
-		err := tc.rng.AddCmd(tc.rng.context(), proto.Call{Args: args, Reply: reply}, true)
+		err := tc.rng.AddCmd(tc.rng.context(), proto.Call{Args: args, Reply: reply})
 
 		if test.expSuccess != (err == nil) {
 			t.Errorf("expected success on trial %d? %t; got err %s", i, test.expSuccess, err)
@@ -1975,7 +1975,7 @@ func TestInternalPushTxnPriorities(t *testing.T) {
 		// Now, attempt to push the transaction with intent epoch set appropriately.
 		args, reply := pushTxnArgs(pusher, pushee, test.pushType, 1, tc.store.StoreID())
 
-		err := tc.rng.AddCmd(tc.rng.context(), proto.Call{Args: args, Reply: reply}, true)
+		err := tc.rng.AddCmd(tc.rng.context(), proto.Call{Args: args, Reply: reply})
 
 		if test.expSuccess != (err == nil) {
 			t.Errorf("expected success on trial %d? %t; got err %s", i, test.expSuccess, err)
@@ -2008,7 +2008,7 @@ func TestInternalPushTxnPushTimestamp(t *testing.T) {
 	// Now, push the transaction with args.Abort=false.
 	args, reply := pushTxnArgs(pusher, pushee, proto.PUSH_TIMESTAMP, 1, tc.store.StoreID())
 
-	if err := tc.rng.AddCmd(tc.rng.context(), proto.Call{Args: args, Reply: reply}, true); err != nil {
+	if err := tc.rng.AddCmd(tc.rng.context(), proto.Call{Args: args, Reply: reply}); err != nil {
 
 		t.Errorf("unexpected error on push: %s", err)
 	}
@@ -2042,7 +2042,7 @@ func TestInternalPushTxnPushTimestampAlreadyPushed(t *testing.T) {
 	// Now, push the transaction with args.Abort=false.
 	args, reply := pushTxnArgs(pusher, pushee, proto.PUSH_TIMESTAMP, 1, tc.store.StoreID())
 
-	if err := tc.rng.AddCmd(tc.rng.context(), proto.Call{Args: args, Reply: reply}, true); err != nil {
+	if err := tc.rng.AddCmd(tc.rng.context(), proto.Call{Args: args, Reply: reply}); err != nil {
 
 		t.Errorf("unexpected error on push: %s", err)
 	}
@@ -2066,7 +2066,7 @@ func TestRangeResolveIntentRange(t *testing.T) {
 	for _, key := range []proto.Key{proto.Key("a"), proto.Key("b")} {
 		pArgs, pReply := putArgs(key, []byte("value1"), 1, tc.store.StoreID())
 		pArgs.Txn = txn
-		if err := tc.rng.AddCmd(tc.rng.context(), proto.Call{Args: pArgs, Reply: pReply}, true); err != nil {
+		if err := tc.rng.AddCmd(tc.rng.context(), proto.Call{Args: pArgs, Reply: pReply}); err != nil {
 			t.Fatal(err)
 		}
 	}
@@ -2084,7 +2084,7 @@ func TestRangeResolveIntentRange(t *testing.T) {
 	}
 	rArgs.Txn.Status = proto.COMMITTED
 	rReply := &proto.InternalResolveIntentRangeResponse{}
-	if err := tc.rng.AddCmd(tc.rng.context(), proto.Call{Args: rArgs, Reply: rReply}, true); err != nil {
+	if err := tc.rng.AddCmd(tc.rng.context(), proto.Call{Args: rArgs, Reply: rReply}); err != nil {
 		t.Fatal(err)
 	}
 
@@ -2125,7 +2125,7 @@ func TestRangeStatsComputation(t *testing.T) {
 	pArgs, pReply := putArgs([]byte("a"), []byte("value1"), 1, tc.store.StoreID())
 	pArgs.Timestamp = tc.clock.Now()
 
-	if err := tc.rng.AddCmd(tc.rng.context(), proto.Call{Args: pArgs, Reply: pReply}, true); err != nil {
+	if err := tc.rng.AddCmd(tc.rng.context(), proto.Call{Args: pArgs, Reply: pReply}); err != nil {
 
 		t.Fatal(err)
 	}
@@ -2137,7 +2137,7 @@ func TestRangeStatsComputation(t *testing.T) {
 	pArgs.Timestamp = tc.clock.Now()
 	pArgs.Txn = &proto.Transaction{ID: util.NewUUID4(), Timestamp: pArgs.Timestamp}
 
-	if err := tc.rng.AddCmd(tc.rng.context(), proto.Call{Args: pArgs, Reply: pReply}, true); err != nil {
+	if err := tc.rng.AddCmd(tc.rng.context(), proto.Call{Args: pArgs, Reply: pReply}); err != nil {
 
 		t.Fatal(err)
 	}
@@ -2157,7 +2157,7 @@ func TestRangeStatsComputation(t *testing.T) {
 	rArgs.Txn.Status = proto.COMMITTED
 	rReply := &proto.InternalResolveIntentResponse{}
 
-	if err := tc.rng.AddCmd(tc.rng.context(), proto.Call{Args: rArgs, Reply: rReply}, true); err != nil {
+	if err := tc.rng.AddCmd(tc.rng.context(), proto.Call{Args: rArgs, Reply: rReply}); err != nil {
 
 		t.Fatal(err)
 	}
@@ -2168,7 +2168,7 @@ func TestRangeStatsComputation(t *testing.T) {
 	dArgs, dReply := deleteArgs([]byte("a"), 1, tc.store.StoreID())
 	dArgs.Timestamp = tc.clock.Now()
 
-	if err := tc.rng.AddCmd(tc.rng.context(), proto.Call{Args: dArgs, Reply: dReply}, true); err != nil {
+	if err := tc.rng.AddCmd(tc.rng.context(), proto.Call{Args: dArgs, Reply: dReply}); err != nil {
 
 		t.Fatal(err)
 	}
@@ -2194,7 +2194,7 @@ func TestInternalMerge(t *testing.T) {
 		mergeArgs, resp := internalMergeArgs(key, proto.Value{Bytes: []byte(str)}, 1,
 			tc.store.StoreID())
 
-		if err := tc.rng.AddCmd(tc.rng.context(), proto.Call{Args: mergeArgs, Reply: resp}, true); err != nil {
+		if err := tc.rng.AddCmd(tc.rng.context(), proto.Call{Args: mergeArgs, Reply: resp}); err != nil {
 
 			t.Fatalf("unexpected error from InternalMerge: %s", err.Error())
 		}
@@ -2202,7 +2202,7 @@ func TestInternalMerge(t *testing.T) {
 
 	getArgs, resp := getArgs(key, 1, tc.store.StoreID())
 
-	if err := tc.rng.AddCmd(tc.rng.context(), proto.Call{Args: getArgs, Reply: resp}, true); err != nil {
+	if err := tc.rng.AddCmd(tc.rng.context(), proto.Call{Args: getArgs, Reply: resp}); err != nil {
 
 		t.Fatalf("unexpected error from Get: %s", err.Error())
 	}
@@ -2228,7 +2228,7 @@ func TestInternalTruncateLog(t *testing.T) {
 	for i := 0; i < 10; i++ {
 		args, resp := incrementArgs([]byte("a"), int64(i), 1, tc.store.StoreID())
 
-		if err := tc.rng.AddCmd(tc.rng.context(), proto.Call{Args: args, Reply: resp}, true); err != nil {
+		if err := tc.rng.AddCmd(tc.rng.context(), proto.Call{Args: args, Reply: resp}); err != nil {
 
 			t.Fatal(err)
 		}
@@ -2242,7 +2242,7 @@ func TestInternalTruncateLog(t *testing.T) {
 	// Discard the first half of the log
 	truncateArgs, truncateResp := internalTruncateLogArgs(indexes[5], 1, tc.store.StoreID())
 
-	if err := tc.rng.AddCmd(tc.rng.context(), proto.Call{Args: truncateArgs, Reply: truncateResp}, true); err != nil {
+	if err := tc.rng.AddCmd(tc.rng.context(), proto.Call{Args: truncateArgs, Reply: truncateResp}); err != nil {
 
 		t.Fatal(err)
 	}
@@ -2327,7 +2327,7 @@ func TestConditionFailedError(t *testing.T) {
 	value := []byte("quack")
 	pArgs, pReply := putArgs(key, value, 1, tc.store.StoreID())
 
-	if err := tc.rng.AddCmd(tc.rng.context(), proto.Call{Args: pArgs, Reply: pReply}, true); err != nil {
+	if err := tc.rng.AddCmd(tc.rng.context(), proto.Call{Args: pArgs, Reply: pReply}); err != nil {
 
 		t.Fatal(err)
 	}
@@ -2347,7 +2347,7 @@ func TestConditionFailedError(t *testing.T) {
 	}
 	reply := &proto.ConditionalPutResponse{}
 
-	err := tc.rng.AddCmd(tc.rng.context(), proto.Call{Args: args, Reply: reply}, true)
+	err := tc.rng.AddCmd(tc.rng.context(), proto.Call{Args: args, Reply: reply})
 
 	if cErr, ok := err.(*proto.ConditionFailedError); err == nil || !ok {
 		t.Fatalf("expected ConditionFailedError, got %T with content %+v",
@@ -2398,7 +2398,7 @@ func TestAppliedIndex(t *testing.T) {
 	for i := int64(1); i <= 10; i++ {
 		args, reply := incrementArgs([]byte("a"), i, 1, tc.store.StoreID())
 
-		err := tc.rng.AddCmd(tc.rng.context(), proto.Call{Args: args, Reply: reply}, true)
+		err := tc.rng.AddCmd(tc.rng.context(), proto.Call{Args: args, Reply: reply})
 
 		if err != nil {
 			t.Fatal(err)
@@ -2427,7 +2427,7 @@ func TestReplicaCorruption(t *testing.T) {
 
 	args, reply := putArgs(proto.Key("test"), []byte("value"), tc.rng.Desc().RaftID, tc.store.StoreID())
 	err := tc.rng.AddCmd(tc.rng.context(),
-		proto.Call{Args: args, Reply: reply}, true /* wait */)
+		proto.Call{Args: args, Reply: reply})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -2442,7 +2442,7 @@ func TestReplicaCorruption(t *testing.T) {
 	// Should mark replica corrupt (and panic as a result) since we messed
 	// with the applied index.
 	err = tc.rng.AddCmd(tc.rng.context(),
-		proto.Call{Args: args, Reply: reply}, true /* wait */)
+		proto.Call{Args: args, Reply: reply})
 
 	if err == nil || !strings.Contains(err.Error(), "replica corruption (processed=true)") {
 		t.Fatalf("unexpected error: %s", err)
@@ -2491,7 +2491,7 @@ func TestRangeDanglingMetaIntent(t *testing.T) {
 	}
 	rlReply := &proto.InternalRangeLookupResponse{}
 
-	if err := tc.rng.AddCmd(tc.rng.context(), proto.Call{Args: rlArgs, Reply: rlReply}, true); err != nil {
+	if err := tc.rng.AddCmd(tc.rng.context(), proto.Call{Args: rlArgs, Reply: rlReply}); err != nil {
 
 		t.Fatal(err)
 	}
@@ -2509,7 +2509,7 @@ func TestRangeDanglingMetaIntent(t *testing.T) {
 	pArgs.Txn = newTransaction("test", key, 1, proto.SERIALIZABLE, tc.clock)
 	pArgs.Timestamp = pArgs.Txn.Timestamp
 
-	if err := tc.rng.AddCmd(tc.rng.context(), proto.Call{Args: pArgs, Reply: pReply}, true); err != nil {
+	if err := tc.rng.AddCmd(tc.rng.context(), proto.Call{Args: pArgs, Reply: pReply}); err != nil {
 		t.Fatal(err)
 	}
 
@@ -2517,7 +2517,7 @@ func TestRangeDanglingMetaIntent(t *testing.T) {
 	rlArgs.Key = keys.RangeMetaKey(proto.Key("A"))
 	rlArgs.Timestamp = proto.ZeroTimestamp
 
-	err = tc.rng.AddCmd(tc.rng.context(), proto.Call{Args: rlArgs, Reply: rlReply}, true)
+	err = tc.rng.AddCmd(tc.rng.context(), proto.Call{Args: rlArgs, Reply: rlReply})
 
 	if err != nil {
 		t.Errorf("unexpected lookup error: %s", err)
@@ -2536,7 +2536,7 @@ func TestRangeDanglingMetaIntent(t *testing.T) {
 		clonedRLArgs.Timestamp = proto.ZeroTimestamp
 		rlReply.Reset()
 
-		if err = tc.rng.AddCmd(tc.rng.context(), proto.Call{Args: clonedRLArgs, Reply: rlReply}, true); err != nil {
+		if err = tc.rng.AddCmd(tc.rng.context(), proto.Call{Args: clonedRLArgs, Reply: rlReply}); err != nil {
 			t.Fatal(err)
 		}
 		seen := rlReply.Ranges[0]
@@ -2615,7 +2615,7 @@ func benchmarkEvents(b *testing.B, sendEvents, consumeEvents bool) {
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
 
-		err := tc.rng.AddCmd(tc.rng.context(), proto.Call{Args: args, Reply: reply}, true)
+		err := tc.rng.AddCmd(tc.rng.context(), proto.Call{Args: args, Reply: reply})
 
 		if err != nil {
 			b.Fatal(err)

--- a/storage/split_queue.go
+++ b/storage/split_queue.go
@@ -103,13 +103,12 @@ func (sq *splitQueue) process(now proto.Timestamp, rng *Range) error {
 	// FIXME: why is this implementation not the same as the one above?
 	if float64(rng.stats.GetSize())/float64(zone.RangeMaxBytes) > 1 {
 		log.Infof("splitting %s size=%d max=%d", rng, rng.stats.GetSize(), zone.RangeMaxBytes)
-		if err = rng.AddCmd(rng.context(),
-			proto.Call{
-				Args: &proto.AdminSplitRequest{
-					RequestHeader: proto.RequestHeader{Key: rng.Desc().StartKey},
-				},
-				Reply: &proto.AdminSplitResponse{},
-			}, true); err != nil {
+		if err = rng.AddCmd(rng.context(), proto.Call{
+			Args: &proto.AdminSplitRequest{
+				RequestHeader: proto.RequestHeader{Key: rng.Desc().StartKey},
+			},
+			Reply: &proto.AdminSplitResponse{},
+		}); err != nil {
 			return err
 		}
 	}


### PR DESCRIPTION
The only case that exercised `wait=false` was a call to
`resolveWriteIntentError`, which turns out to have been incorrect; it
would return an error, but that error would be summarily ignored.

This commit removes the `wait` parameter, defaulting the behaviour of
affected methods to the `wait=true` case, with the exception of
`resolveWriteIntentError` which has been changed to do all of its
already best-effort work asynchronously in all cases.
