### PR TITLE
Take longer naps in TestTxn*

### DIFF
--- a/kv/txn_correctness_test.go
+++ b/kv/txn_correctness_test.go
@@ -513,7 +513,7 @@ func (hv *historyVerifier) runHistory(historyIdx int, priorities []int32,
 	for i, txnCmds := range txnMap {
 		go func(i int, txnCmds []*cmd) {
 			if err := hv.runTxn(i, priorities[i-1], isolations[i-1], txnCmds, db, t); err != nil {
-				t.Errorf("unexpected failure running transaction %d (%s): %v", i, cmds, err)
+				t.Errorf("(%s): unexpected failure running %s: %v", cmds, cmds[i], err)
 			}
 		}(i, txnCmds)
 	}

--- a/kv/txn_correctness_test.go
+++ b/kv/txn_correctness_test.go
@@ -44,8 +44,8 @@ import (
 func setCorrectnessRetryOptions(lSender *retryableLocalSender) {
 	client.DefaultTxnRetryOptions = retry.Options{
 		InitialBackoff: 1 * time.Millisecond,
-		MaxBackoff:     5 * time.Millisecond,
-		Multiplier:     2,
+		MaxBackoff:     50 * time.Millisecond,
+		Multiplier:     10,
 		MaxRetries:     2,
 	}
 

--- a/storage/client_raft_test.go
+++ b/storage/client_raft_test.go
@@ -140,6 +140,7 @@ func TestStoreRecoverFromEngine(t *testing.T) {
 // applied so they are not retried after recovery.
 func TestStoreRecoverWithErrors(t *testing.T) {
 	defer leaktest.AfterTest(t)
+	defer func() { storage.TestingCommandFilter = nil }()
 	manual := hlc.NewManualClock(0)
 	clock := hlc.NewClock(manual.UnixNano)
 	eng := engine.NewInMem(proto.Attributes{}, 1<<20)
@@ -152,9 +153,6 @@ func TestStoreRecoverWithErrors(t *testing.T) {
 		}
 		return false
 	}
-	defer func() {
-		storage.TestingCommandFilter = nil
-	}()
 
 	func() {
 		store, stopper := createTestStoreWithEngine(t, eng, clock, true, nil)
@@ -344,9 +342,8 @@ func TestRestoreReplicas(t *testing.T) {
 
 func TestFailedReplicaChange(t *testing.T) {
 	defer leaktest.AfterTest(t)
-	defer func() {
-		storage.TestingCommandFilter = nil
-	}()
+	defer func() { storage.TestingCommandFilter = nil }()
+
 	mtc := startMultiTestContext(t, 2)
 	defer mtc.Stop()
 

--- a/storage/range_test.go
+++ b/storage/range_test.go
@@ -1041,10 +1041,11 @@ func TestRangeUpdateTSCache(t *testing.T) {
 // range.
 func TestRangeCommandQueue(t *testing.T) {
 	defer leaktest.AfterTest(t)
+	defer func() { TestingCommandFilter = nil }()
+
 	tc := testContext{}
 	tc.Start(t)
 	defer tc.Stop()
-	defer func() { TestingCommandFilter = nil }()
 
 	// Intercept commands with matching command IDs and block them.
 	blockingStart := make(chan struct{}, 1)
@@ -1153,9 +1154,10 @@ func TestRangeCommandQueue(t *testing.T) {
 // not wait for pending commands to complete through Raft.
 func TestRangeCommandQueueInconsistent(t *testing.T) {
 	defer leaktest.AfterTest(t)
+	defer func() { TestingCommandFilter = nil }()
+
 	tc := testContext{}
 	tc.Start(t)
-	defer func() { TestingCommandFilter = nil }()
 	defer tc.Stop()
 
 	key := proto.Key("key1")

--- a/storage/store_test.go
+++ b/storage/store_test.go
@@ -1187,8 +1187,9 @@ func TestStoreReadInconsistent(t *testing.T) {
 // them in one fell swoop using both consistent and inconsistent reads.
 func TestStoreScanIntents(t *testing.T) {
 	defer leaktest.AfterTest(t)
-	store, _, stopper := createTestStore(t)
 	defer func() { TestingCommandFilter = nil }()
+
+	store, _, stopper := createTestStore(t)
 	defer stopper.Stop()
 
 	var count int32


### PR DESCRIPTION
Many of these tests cause some transactions to be repeatedly pushed.
Normally, those transactions would retry at the sender indefinitely,
but this test has places to be, so it limits the number of attempts
to make sure things finish in a timely manner.

Unfortunately this approach is inherently racy as it expects
transactions that are able to make progress in the context of their
history to not exhaust the retries allotted to them. If these
transactions retry faster than their pushers are able to commit, the
test will spuriously fail.

This commit increases backoff duration for these retries to increase
the probability that progress-capable transactins do not eagerly
exhaust their allotted retries.
