### PR TITLE
use tcp for gossip testing

### DIFF
--- a/gossip/client_test.go
+++ b/gossip/client_test.go
@@ -38,13 +38,13 @@ const (
 
 // startGossip creates local and remote gossip instances.
 // The remote gossip instance launches its gossip service.
-// We use insecure contexts since we do not have certificates for unix sockets.
+// TODO(mberhault): use a secure context, if possible.
 func startGossip(t *testing.T) (local, remote *Gossip, stopper *util.Stopper) {
 	lclock := hlc.NewClock(hlc.UnixNano)
 	stopper = util.NewStopper()
 	lRPCContext := rpc.NewContext(insecureTestBaseContext, lclock, stopper)
 
-	laddr := util.CreateTestAddr("unix")
+	laddr := util.CreateTestAddr("tcp")
 	lserver := rpc.NewServer(laddr, lRPCContext)
 	if err := lserver.Start(); err != nil {
 		t.Fatal(err)
@@ -59,7 +59,7 @@ func startGossip(t *testing.T) (local, remote *Gossip, stopper *util.Stopper) {
 		t.Fatal(err)
 	}
 	rclock := hlc.NewClock(hlc.UnixNano)
-	raddr := util.CreateTestAddr("unix")
+	raddr := util.CreateTestAddr("tcp")
 	rRPCContext := rpc.NewContext(insecureTestBaseContext, rclock, stopper)
 	rserver := rpc.NewServer(raddr, rRPCContext)
 	if err := rserver.Start(); err != nil {

--- a/gossip/convergence_test.go
+++ b/gossip/convergence_test.go
@@ -35,7 +35,7 @@ import (
 // TODO(spencer): figure out a more deterministic setup, advancing the clock
 // manually and counting cycles accurately instead of relying on real-time sleeps.
 func verifyConvergence(numNodes, maxCycles int, interval time.Duration, t *testing.T) {
-	network := simulation.NewNetwork(numNodes, "unix", interval)
+	network := simulation.NewNetwork(numNodes, "tcp", interval)
 
 	if connectedCycle := network.RunUntilFullyConnected(); connectedCycle > maxCycles {
 		t.Errorf("expected a fully-connected network within %d cycles; took %d",

--- a/kv/dist_sender_test.go
+++ b/kv/dist_sender_test.go
@@ -54,7 +54,7 @@ var testRangeDescriptor = proto.RangeDescriptor{
 var testAddress = util.MakeUnresolvedAddr("tcp", "node1:8080")
 
 func makeTestGossip(t *testing.T) (*gossip.Gossip, func()) {
-	n := simulation.NewNetwork(1, "unix", gossip.TestInterval)
+	n := simulation.NewNetwork(1, "tcp", gossip.TestInterval)
 	g := n.Nodes[0].Gossip
 	permConfig := &proto.PermConfig{
 		Read:  []string{""},
@@ -553,7 +553,7 @@ func TestRetryOnWrongReplicaError(t *testing.T) {
 
 func TestGetFirstRangeDescriptor(t *testing.T) {
 	defer leaktest.AfterTest(t)
-	n := simulation.NewNetwork(3, "unix", gossip.TestInterval)
+	n := simulation.NewNetwork(3, "tcp", gossip.TestInterval)
 	ds := NewDistSender(nil, n.Nodes[0].Gossip)
 	if _, err := ds.getFirstRangeDescriptor(); err == nil {
 		t.Errorf("expected not to find first range descriptor")
@@ -593,7 +593,7 @@ func TestGetFirstRangeDescriptor(t *testing.T) {
 // are checked hierarchically.
 func TestVerifyPermissions(t *testing.T) {
 	defer leaktest.AfterTest(t)
-	n := simulation.NewNetwork(1, "unix", gossip.TestInterval)
+	n := simulation.NewNetwork(1, "tcp", gossip.TestInterval)
 	ds := NewDistSender(nil, n.Nodes[0].Gossip)
 	config1 := &proto.PermConfig{
 		Read:  []string{"read1", "readAll", "rw1", "rwAll"},


### PR DESCRIPTION
we suspect that there is a bug when using unix sockets
which may cause spurious NPEs. see #1563
