### PR TITLE
Fix incorrect use of `break` in retry loop in RPC client.

### DIFF
--- a/rpc/client.go
+++ b/rpc/client.go
@@ -172,10 +172,10 @@ func (c *Client) connect(opts *retry.Options, context *Context) error {
 			return err
 		}
 
-		break
+		return nil
 	}
 
-	return nil
+	return util.Errorf("system is stopping")
 }
 
 // IsConnected returns whether the client is connected.


### PR DESCRIPTION
This caused a panic during tests in which a client would incorrectly
report success during the shutdown process.

Fixes #1563.
