### PR TITLE
Log file names relative to repo root

### DIFF
--- a/util/error.go
+++ b/util/error.go
@@ -19,20 +19,29 @@ package util
 
 import (
 	"fmt"
-	"path/filepath"
+	"os"
 	"runtime"
+	"strings"
 )
 
 const defaultSkip = 2
 const errorPrefixFormat string = "%s:%d: "
 
+// Caller returns the file and line of the Caller or, in case of error,
+// the placeholder ('???', 1).
+func Caller(depth int) (string, int) {
+	if _, file, line, ok := runtime.Caller(1 + depth); ok {
+		list := strings.Split(file, "cockroach"+string(os.PathSeparator))
+		return list[len(list)-1], line
+	}
+	return "???", 1
+}
+
 // getPrefix skips "skip" stack frames to get the file & line number
 // of original caller.
 func getPrefix(skip int, format string) string {
-	if _, file, line, ok := runtime.Caller(skip); ok {
-		return fmt.Sprintf(format, filepath.Base(file), line)
-	}
-	return ""
+	file, line := Caller(skip)
+	return fmt.Sprintf(format, file, line)
 }
 
 // Errorf is a passthrough to fmt.Errorf, with an additional prefix

--- a/util/error_test.go
+++ b/util/error_test.go
@@ -19,8 +19,6 @@ package util
 
 import (
 	"fmt"
-	"path/filepath"
-	"runtime"
 	"testing"
 )
 
@@ -28,11 +26,8 @@ import (
 // file/line prefix.
 func TestErrorf(t *testing.T) {
 	err := Errorf("foo: %d %f", 1, 3.14)
-	_, file, line, ok := runtime.Caller(0)
-	if !ok {
-		t.Fatalf("could not get runtime info for test")
-	}
-	expected := fmt.Sprintf("%sfoo: 1 3.140000", fmt.Sprintf(errorPrefixFormat, filepath.Base(file), line-1))
+	file, line := Caller(0)
+	expected := fmt.Sprintf("%sfoo: 1 3.140000", fmt.Sprintf(errorPrefixFormat, file, line-1))
 	if expected != err.Error() {
 		t.Errorf("expected %s, got %s", expected, err.Error())
 	}
@@ -45,11 +40,8 @@ func TestErrorfSkipFrames(t *testing.T) {
 	func() {
 		err = ErrorfSkipFrames(1, "foo: %d %f", 1, 3.14)
 	}()
-	_, file, line, ok := runtime.Caller(0)
-	if !ok {
-		t.Fatalf("could not get runtime info for test")
-	}
-	expected := fmt.Sprintf("%sfoo: 1 3.140000", fmt.Sprintf(errorPrefixFormat, filepath.Base(file), line-1))
+	file, line := Caller(0)
+	expected := fmt.Sprintf("%sfoo: 1 3.140000", fmt.Sprintf(errorPrefixFormat, file, line-1))
 	if expected != err.Error() {
 		t.Errorf("expected %s, got %s", expected, err.Error())
 	}
@@ -59,11 +51,8 @@ func TestErrorfSkipFrames(t *testing.T) {
 // file/line prefix.
 func TestError(t *testing.T) {
 	err := Error("foo ", 1, 3.14)
-	_, file, line, ok := runtime.Caller(0)
-	if !ok {
-		t.Fatalf("could not get runtime info for test")
-	}
-	expected := fmt.Sprintf("%sfoo 1 3.14", fmt.Sprintf(errorPrefixFormat, filepath.Base(file), line-1))
+	file, line := Caller(0)
+	expected := fmt.Sprintf("%sfoo 1 3.14", fmt.Sprintf(errorPrefixFormat, file, line-1))
 	if expected != err.Error() {
 		t.Errorf("expected %s, got %s", expected, err.Error())
 	}
@@ -76,11 +65,8 @@ func TestErrorSkipFrames(t *testing.T) {
 	func() {
 		err = ErrorSkipFrames(1, "foo ", 1, 3.14)
 	}()
-	_, file, line, ok := runtime.Caller(0)
-	if !ok {
-		t.Fatalf("could not get runtime info for test")
-	}
-	expected := fmt.Sprintf("%sfoo 1 3.14", fmt.Sprintf(errorPrefixFormat, filepath.Base(file), line-1))
+	file, line := Caller(0)
+	expected := fmt.Sprintf("%sfoo 1 3.14", fmt.Sprintf(errorPrefixFormat, file, line-1))
 	if expected != err.Error() {
 		t.Errorf("expected %s, got %s", expected, err.Error())
 	}

--- a/util/log/clog.go
+++ b/util/log/clog.go
@@ -37,6 +37,7 @@ import (
 	"time"
 
 	"github.com/cockroachdb/cockroach/proto"
+	"github.com/cockroachdb/cockroach/util"
 	"github.com/cockroachdb/cockroach/util/encoding"
 	gogoproto "github.com/gogo/protobuf/proto"
 )
@@ -712,25 +713,8 @@ func (l *loggingT) putBuffer(b *buffer) {
 
 var timeNow = time.Now // Stubbed out for testing.
 
-// Caller returns the file and line of the Caller or, in case of error,
-// the placeholder ('???', 1).
-func Caller(depth int) (string, int) {
-	return logging.Caller(depth + 1)
-}
-
 func (l *loggingT) Caller(depth int) (file string, line int) {
-	var ok bool
-	_, file, line, ok = runtime.Caller(1 + depth)
-	if !ok {
-		file = "???"
-		line = 1
-	} else {
-		slash := strings.LastIndex(file, "/")
-		if slash >= 0 {
-			file = file[slash+1:]
-		}
-	}
-	return
+	return util.Caller(depth + 1)
 }
 
 func (l *loggingT) print(s Severity, args ...interface{}) {

--- a/util/log/structured.go
+++ b/util/log/structured.go
@@ -31,7 +31,7 @@ import (
 // AddStructured creates a structured log entry to be written to the
 // specified facility of the logger.
 func AddStructured(ctx context.Context, s Severity, depth int, format string, args []interface{}) {
-	file, line := Caller(depth + 1)
+	file, line := logging.Caller(depth + 1)
 	entry := &proto.LogEntry{}
 	setLogEntry(ctx, format, args, entry)
 	logging.outputLogEntry(s, file, line, false, entry)


### PR DESCRIPTION
This disambiguates logged file names and makes them clickable.
