### PR TITLE
allow started tasks to be tracked

### DIFF
--- a/multiraft/transport_test.go
+++ b/multiraft/transport_test.go
@@ -53,9 +53,9 @@ func (lt *localInterceptableTransport) start() {
 		for {
 			select {
 			case msg := <-lt.messages:
-				if lt.stopper.StartTask() {
+				if task := lt.stopper.StartTask(); task.Ok() {
 					lt.handleMessage(msg)
-					lt.stopper.FinishTask()
+					task.Done()
 				}
 
 			case <-lt.stopper.ShouldStop():

--- a/server/node.go
+++ b/server/node.go
@@ -310,11 +310,13 @@ func (n *Node) initStores(engines []engine.Engine, stopper *stop.Stopper) error 
 	}
 
 	// Bootstrap any uninitialized stores asynchronously.
-	if bootstraps.Len() > 0 && stopper.StartTask() {
-		go func() {
-			n.bootstrapStores(bootstraps, stopper)
-			stopper.FinishTask()
-		}()
+	if bootstraps.Len() > 0 {
+		if task := stopper.StartTask(); task.Ok() {
+			go func() {
+				n.bootstrapStores(bootstraps, stopper)
+				task.Done()
+			}()
+		}
 	}
 
 	return nil

--- a/storage/id_alloc.go
+++ b/storage/id_alloc.go
@@ -100,12 +100,13 @@ func (ia *idAllocator) start() {
 					res client.KeyValue
 				)
 				for r := retry.Start(idAllocationRetryOpts); r.Next(); {
-					if !ia.stopper.StartTask() {
+					task := ia.stopper.StartTask()
+					if !task.Ok() {
 						return
 					}
 					idKey := ia.idKey.Load().(proto.Key)
 					res, err = ia.db.Inc(idKey, int64(ia.blockSize))
-					ia.stopper.FinishTask()
+					task.Done()
 
 					if err == nil {
 						newValue = res.ValueInt()

--- a/storage/queue.go
+++ b/storage/queue.go
@@ -235,10 +235,11 @@ func (bq *baseQueue) processLoop(clock *hlc.Clock, stopper *stop.Stopper) {
 }
 
 func (bq *baseQueue) processOne(clock *hlc.Clock, stopper *stop.Stopper) {
-	if !stopper.StartTask() {
+	task := stopper.StartTask()
+	if !task.Ok() {
 		return
 	}
-	defer stopper.FinishTask()
+	defer task.Done()
 
 	start := time.Now()
 	bq.Lock()

--- a/storage/store.go
+++ b/storage/store.go
@@ -1427,7 +1427,7 @@ func (s *Store) resolveWriteIntentError(ctx context.Context, wiErr *proto.WriteI
 		}
 		resolveReply := &proto.InternalResolveIntentResponse{}
 
-		if s.stopper.StartTask() {
+		if task := s.stopper.StartTask(); task.Ok() {
 			wg.Add(1)
 			ctx := tracer.ToCtx(ctx, trace.Fork())
 
@@ -1438,7 +1438,7 @@ func (s *Store) resolveWriteIntentError(ctx context.Context, wiErr *proto.WriteI
 						log.Warningc(ctx, "resolve for key %s failed: %s", intentKey, resolveErr)
 					}
 				}
-				s.stopper.FinishTask()
+				task.Done()
 			}(ctx)
 		}
 	}

--- a/ts/db.go
+++ b/ts/db.go
@@ -87,10 +87,11 @@ func (p *poller) start() {
 // poll retrieves data from the underlying DataSource a single time, storing any
 // returned time series data on the server.
 func (p *poller) poll() {
-	if !p.stopper.StartTask() {
+	task := p.stopper.StartTask()
+	if !task.Ok() {
 		return
 	}
-	defer p.stopper.FinishTask()
+	defer task.Done()
 
 	data := p.source.GetTimeSeriesData()
 	if len(data) == 0 {


### PR DESCRIPTION
it's interesting to see which tasks are running, especially
when graceful shutdown does not work (see 1490).

```
[...]server/cli/start.go:166] 3 running tasks
    1x /Users/tschottdorf/go/src/github.com/cockroachdb/cockroach/storage/queue.go:238
    2x /Users/tschottdorf/go/src/github.com/cockroachdb/cockroach/kv/txn_coord_sender.go:189
```

the `StartTask` api needed to change for that. I'm happy with the new one,
but that may be my personal preference and if it doesn't sit well with the rest
of you, I'm ok with that.
