### PR TITLE
Ban the use of `path` and replace with `filepath`

### DIFF
--- a/GLOCKFILE
+++ b/GLOCKFILE
@@ -22,7 +22,7 @@ github.com/gogo/protobuf 64f27bf06efee53589314a6e5a4af34cdd85adf6
 github.com/golang/lint 7b7f4364ff76043e6c3610281525fabc0d90f0e4
 github.com/google/btree cc6329d4279e3f025a53a83c397d2339b5705c45
 github.com/inconshreveable/mousetrap 76626ae9c91c4f2a10f34cad8ce83ea42c93bb75
-github.com/jteeuwen/go-bindata 91db54b0401d0679b3cf743142e4f3c86b4aaa4e
+github.com/jteeuwen/go-bindata 38ae5514e62bacad046221ad7f54e7a54e3ccd7b
 github.com/julienschmidt/httprouter 70708e46004c7bcb09b70e685a8b74a690135387
 github.com/kisielk/errcheck 76bf61ee4096ee72636739d4472186b5de5641db
 github.com/kisielk/gotool d678387370a2eb9b5b0a33218bc8c9d8de15b6be
@@ -32,7 +32,7 @@ github.com/samalba/dockerclient 12570e600d71374233e5056ba315f657ced496c7
 github.com/spf13/cobra 66816bcd0378e248c613e3c443c020f544c28804
 github.com/spf13/pflag 67cbc198fd11dab704b214c1e629a97af392c085
 github.com/tebeka/go2xunit c36d9abe091675dcdd8c291f3153c8d438dd788f
+golang.org/x/crypto cc04154d65fb9296747569b107cfd05380b1ea3e
 golang.org/x/net 8bfde94a845cb31000de3266ac83edbda58dab09
 golang.org/x/tools a87e08b564e401b7961951e02f1cb2197c2cbb60
-golang.org/x/crypto cc04154d65fb9296747569b107cfd05380b1ea3e
 gopkg.in/yaml.v1 9f9df34309c04878acc86042b16630b0f696e1de

--- a/Makefile
+++ b/Makefile
@@ -129,6 +129,7 @@ acceptance:
 
 .PHONY: check
 check:
+	! git grep -F '"path"' -- '*.go'
 	errcheck -ignore 'bytes:Write.*,io:(Close|Write),net:Close,net/http:(Close|Write),net/rpc:Close,os:Close,database/sql:Close,github.com/spf13/cobra:Usage' $(PKG)
 	! go-nyet $(PKG) | grep -vE '(Weird type of StarExpr|Unknown types|`matchIndex`|`c`|cannot process directory \.git)' # TODO(tamird): https://github.com/barakmich/go-nyet/pull/10
 	# https://golang.org/pkg/database/sql/driver/#Result :(

--- a/security/certs.go
+++ b/security/certs.go
@@ -23,7 +23,7 @@ import (
 	"crypto/x509"
 	"encoding/pem"
 	"os"
-	"path"
+	"path/filepath"
 
 	"github.com/cockroachdb/cockroach/util"
 )
@@ -45,8 +45,8 @@ func clientKeyFile(username string) string {
 // directory, parses them, and returns the x509 certificate and private key.
 func loadCACertAndKey(certsDir string) (*x509.Certificate, crypto.PrivateKey, error) {
 	// Load the CA certificate.
-	caCertPath := path.Join(certsDir, "ca.crt")
-	caKeyPath := path.Join(certsDir, "ca.key")
+	caCertPath := filepath.Join(certsDir, "ca.crt")
+	caKeyPath := filepath.Join(certsDir, "ca.key")
 
 	// LoadX509KeyPair does a bunch of validation, including len(Certificates) != 0.
 	caCert, err := tls.LoadX509KeyPair(caCertPath, caKeyPath)
@@ -81,7 +81,7 @@ func writeCertificateAndKey(certsDir string, prefix string,
 	}
 
 	// Write certificate to file.
-	certFilePath := path.Join(certsDir, prefix+".crt")
+	certFilePath := filepath.Join(certsDir, prefix+".crt")
 	certFile, err := os.OpenFile(certFilePath, os.O_WRONLY|os.O_CREATE|os.O_EXCL, 0644)
 	if err != nil {
 		return util.Errorf("error creating certificate file %s: %s", certFilePath, err)
@@ -98,7 +98,7 @@ func writeCertificateAndKey(certsDir string, prefix string,
 	}
 
 	// Write key to file.
-	keyFilePath := path.Join(certsDir, prefix+".key")
+	keyFilePath := filepath.Join(certsDir, prefix+".key")
 	keyFile, err := os.OpenFile(keyFilePath, os.O_WRONLY|os.O_CREATE|os.O_EXCL, 0600)
 	if err != nil {
 		return util.Errorf("error create key file %s: %s", keyFilePath, err)

--- a/security/securitytest/embedded.go
+++ b/security/securitytest/embedded.go
@@ -19,7 +19,6 @@ import (
 	"io"
 	"io/ioutil"
 	"os"
-	"path"
 	"path/filepath"
 	"strings"
 	"time"
@@ -361,7 +360,7 @@ func RestoreAsset(dir, name string) error {
 	if err != nil {
 		return err
 	}
-	err = os.MkdirAll(_filePath(dir, path.Dir(name)), os.FileMode(0755))
+	err = os.MkdirAll(_filePath(dir, filepath.Dir(name)), os.FileMode(0755))
 	if err != nil {
 		return err
 	}
@@ -385,7 +384,7 @@ func RestoreAssets(dir, name string) error {
 	}
 	// Dir
 	for _, child := range children {
-		err = RestoreAssets(dir, path.Join(name, child))
+		err = RestoreAssets(dir, filepath.Join(name, child))
 		if err != nil {
 			return err
 		}

--- a/security/tls.go
+++ b/security/tls.go
@@ -24,7 +24,7 @@ import (
 	"crypto/tls"
 	"crypto/x509"
 	"io/ioutil"
-	"path"
+	"path/filepath"
 
 	"github.com/cockroachdb/cockroach/util"
 )
@@ -58,15 +58,15 @@ func ResetReadFileFn() {
 // We should never have username != "node", but this is a good way to
 // catch tests that use the wrong users.
 func LoadServerTLSConfig(certDir, username string) (*tls.Config, error) {
-	certPEM, err := readFileFn(path.Join(certDir, username+".server.crt"))
+	certPEM, err := readFileFn(filepath.Join(certDir, username+".server.crt"))
 	if err != nil {
 		return nil, err
 	}
-	keyPEM, err := readFileFn(path.Join(certDir, username+".server.key"))
+	keyPEM, err := readFileFn(filepath.Join(certDir, username+".server.key"))
 	if err != nil {
 		return nil, err
 	}
-	caPEM, err := readFileFn(path.Join(certDir, "ca.crt"))
+	caPEM, err := readFileFn(filepath.Join(certDir, "ca.crt"))
 	if err != nil {
 		return nil, err
 	}
@@ -121,15 +121,15 @@ func LoadInsecureTLSConfig() *tls.Config {
 // - <username>.client.key -- the certificate key
 // If the path is prefixed with "embedded=", load the embedded certs.
 func LoadClientTLSConfig(certDir, username string) (*tls.Config, error) {
-	certPEM, err := readFileFn(path.Join(certDir, clientCertFile(username)))
+	certPEM, err := readFileFn(filepath.Join(certDir, clientCertFile(username)))
 	if err != nil {
 		return nil, err
 	}
-	keyPEM, err := readFileFn(path.Join(certDir, clientKeyFile(username)))
+	keyPEM, err := readFileFn(filepath.Join(certDir, clientKeyFile(username)))
 	if err != nil {
 		return nil, err
 	}
-	caPEM, err := readFileFn(path.Join(certDir, "ca.crt"))
+	caPEM, err := readFileFn(filepath.Join(certDir, "ca.crt"))
 	if err != nil {
 		return nil, err
 	}

--- a/ui/embedded.go
+++ b/ui/embedded.go
@@ -20,7 +20,6 @@ import (
 	"io"
 	"io/ioutil"
 	"os"
-	"path"
 	"path/filepath"
 	"strings"
 	"time"
@@ -406,7 +405,7 @@ func RestoreAsset(dir, name string) error {
 	if err != nil {
 		return err
 	}
-	err = os.MkdirAll(_filePath(dir, path.Dir(name)), os.FileMode(0755))
+	err = os.MkdirAll(_filePath(dir, filepath.Dir(name)), os.FileMode(0755))
 	if err != nil {
 		return err
 	}
@@ -430,7 +429,7 @@ func RestoreAssets(dir, name string) error {
 	}
 	// Dir
 	for _, child := range children {
-		err = RestoreAssets(dir, path.Join(name, child))
+		err = RestoreAssets(dir, filepath.Join(name, child))
 		if err != nil {
 			return err
 		}

--- a/util/caller/resolver.go
+++ b/util/caller/resolver.go
@@ -19,7 +19,7 @@ package caller
 
 import (
 	"os"
-	"path"
+	"path/filepath"
 	"regexp"
 	"runtime"
 	"strings"
@@ -86,7 +86,7 @@ func (cr *CallResolver) Lookup(depth int) (file string, line int, fun string) {
 		if len(matches) == 1 {
 			file = matches[0]
 		} else {
-			file = path.Join(matches[1:]...)
+			file = filepath.Join(matches[1:]...)
 		}
 	}
 

--- a/util/caller/resolver_test.go
+++ b/util/caller/resolver_test.go
@@ -18,7 +18,7 @@
 package caller
 
 import (
-	"path"
+	"path/filepath"
 	"testing"
 )
 
@@ -51,7 +51,7 @@ func TestDefaultCallResolver(t *testing.T) {
 			t.Fatalf("unexpected caller reported: %s", fun)
 		}
 
-		if file != path.Join("util", "caller", "resolver_test.go") {
+		if file != filepath.Join("util", "caller", "resolver_test.go") {
 			t.Fatalf("wrong file '%s'", file)
 		}
 	}

--- a/util/log/clog_test.go
+++ b/util/log/clog_test.go
@@ -22,7 +22,6 @@ import (
 	"io/ioutil"
 	stdLog "log"
 	"os"
-	"path"
 	"path/filepath"
 	"regexp"
 	"strings"
@@ -321,12 +320,12 @@ func TestListLogFiles(t *testing.T) {
 	if !ok {
 		t.Fatal("info wasn't created")
 	}
-	infoName := path.Base(info.file.Name())
+	infoName := filepath.Base(info.file.Name())
 	warn, ok = logging.file[WarningLog].(*syncBuffer)
 	if !ok {
 		t.Fatal("warning wasn't created")
 	}
-	warnName := path.Base(warn.file.Name())
+	warnName := filepath.Base(warn.file.Name())
 	results, err := ListLogFiles()
 	if err != nil {
 		t.Fatal(err)
@@ -354,7 +353,7 @@ func TestGetLogReader(t *testing.T) {
 	if !ok {
 		t.Fatal("warning wasn't created")
 	}
-	warnName := path.Base(warn.file.Name())
+	warnName := filepath.Base(warn.file.Name())
 
 	testCases := []struct {
 		filename string
@@ -370,8 +369,8 @@ func TestGetLogReader(t *testing.T) {
 		// File not matching log RE.
 		{"cockroach.WARNING", false, true},
 		{"cockroach.WARNING", true, true},
-		{path.Join(*logDir, "cockroach.WARNING"), false, true},
-		{path.Join(*logDir, "cockroach.WARNING"), true, true},
+		{filepath.Join(*logDir, "cockroach.WARNING"), false, true},
+		{filepath.Join(*logDir, "cockroach.WARNING"), true, true},
 		// Relative filename is specified.
 		{warnName, true, false},
 		{warnName, false, false},

--- a/util/log/file.go
+++ b/util/log/file.go
@@ -27,7 +27,6 @@ import (
 	"io/ioutil"
 	"os"
 	"os/user"
-	"path"
 	"path/filepath"
 	"regexp"
 	"sort"
@@ -239,7 +238,7 @@ func ListLogFiles() ([]FileInfo, error) {
 // command, which provides human readable output from an arbitrary file,
 // and is intended to be run locally in a terminal.
 func GetLogReader(filename string, allowAbsolute bool) (io.ReadCloser, error) {
-	if path.IsAbs(filename) {
+	if filepath.IsAbs(filename) {
 		if !allowAbsolute {
 			return nil, fmt.Errorf("absolute pathnames are forbidden: %s", filename)
 		}
@@ -248,7 +247,7 @@ func GetLogReader(filename string, allowAbsolute bool) (io.ReadCloser, error) {
 		}
 	}
 	// Verify there are no path separators in the a non-absolute pathname.
-	if path.Base(filename) != filename {
+	if filepath.Base(filename) != filename {
 		return nil, fmt.Errorf("pathnames must be basenames only: %s", filename)
 	}
 	if !logFileRE.MatchString(filename) {
@@ -256,7 +255,7 @@ func GetLogReader(filename string, allowAbsolute bool) (io.ReadCloser, error) {
 	}
 	var reader io.ReadCloser
 	var err error
-	filename = path.Join(*logDir, filename)
+	filename = filepath.Join(*logDir, filename)
 	if verifyFile(filename) == nil {
 		reader, err = os.Open(filename)
 		if err == nil {


### PR DESCRIPTION
`path` seems to be useful for dealing with URLs, but does the wrong
thing when dealing with non-slashed paths (e.g. on Windows).
