### PR TITLE
fix caller defaultPattern

### DIFF
--- a/util/caller/resolver_test.go
+++ b/util/caller/resolver_test.go
@@ -19,11 +19,12 @@ package caller
 
 import (
 	"path/filepath"
+	"regexp"
 	"testing"
 )
 
 func TestCallResolver(t *testing.T) {
-	cr := NewCallResolver(0, `resolver_test\.go.*$`)
+	cr := NewCallResolver(0, regexp.MustCompile(`resolver_test\.go.*$`))
 	// Also test that caching doesn't have obvious hiccups.
 	for i := 0; i < 2; i++ {
 		if l := len(cr.cache); l != i {


### PR DESCRIPTION
the previous one matches incorrectly when `src` appears before GOPATH.
added TODO for Ben.
