### PR TITLE
Do not require client certs on ts endpoints: #1609

### DIFF
--- a/server/authentication_test.go
+++ b/server/authentication_test.go
@@ -79,15 +79,15 @@ func TestSSLEnforcement(t *testing.T) {
 		{"GET", statusNodeKeyPrefix, noCertsContext, true, http.StatusOK},
 		{"GET", statusNodeKeyPrefix, insecureContext, false, -1},
 
+		// /ts/: ts.Server: no auth.
+		{"GET", ts.URLPrefix, certsContext, true, http.StatusNotFound},
+		{"GET", ts.URLPrefix, noCertsContext, true, http.StatusNotFound},
+		{"GET", ts.URLPrefix, insecureContext, false, -1},
+
 		// /kv/db/: kv.DBServer. These are proto reqs, but we can at least get past auth.
 		{"GET", kv.DBPrefix + "Get", certsContext, true, http.StatusBadRequest},
 		{"GET", kv.DBPrefix + "Get", noCertsContext, true, http.StatusUnauthorized},
 		{"GET", kv.DBPrefix + "Get", insecureContext, false, -1},
-
-		// /ts/: ts.Server.
-		{"GET", ts.URLPrefix, certsContext, true, http.StatusNotFound},
-		{"GET", ts.URLPrefix, noCertsContext, true, http.StatusUnauthorized},
-		{"GET", ts.URLPrefix, insecureContext, false, -1},
 	}
 
 	for tcNum, tc := range testCases {

--- a/server/server.go
+++ b/server/server.go
@@ -213,14 +213,11 @@ func (s *Server) initHTTP() {
 	s.mux.Handle(adminEndpoint, s.admin)
 	s.mux.Handle(debugEndpoint, s.admin)
 	s.mux.Handle(statusKeyPrefix, s.status)
+	s.mux.Handle(ts.URLPrefix, s.tsServer)
 
 	// KV handles its own authentication, verifying user certificates against
 	// the requested user.
 	s.mux.Handle(kv.DBPrefix, s.kvDB)
-	// TS requests do not have a user, so only check that client certificates are
-	// present if required.
-	// TODO(marc): we should have one, but this may come with status-page user handling.
-	s.mux.HandleFunc(ts.URLPrefix, s.authenticateRequest(s.tsServer))
 	// The SQL wire format does not currently have a requested user.
 	// TODO(marc): we need do figure out how to do sql wire auth.
 	s.mux.HandleFunc(sqlwire.Endpoint, s.authenticateRequest(s.sqlServer))


### PR DESCRIPTION
TS will be using cookie auth when it's there.
