### PR TITLE
Enforce shadow check, excepting err and pb.go

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -136,7 +136,7 @@ check:
 	! golint $(PKG) | grep -vE '(\.pb\.go|embedded\.go|yyEofCode|_string\.go|LastInsertId)'
 	! gofmt -s -l . | grep -vF 'No Exceptions'
 	! goimports -l . | grep -vF 'No Exceptions'
-	go vet $(PKG)
+	! go tool vet --shadow --shadowstrict . 2>&1 |grep -vE '(\.pb\.go|declaration of err shadows)'
 
 .PHONY: clean
 clean:

--- a/Makefile
+++ b/Makefile
@@ -136,7 +136,7 @@ check:
 	! golint $(PKG) | grep -vE '(\.pb\.go|embedded\.go|yyEofCode|_string\.go|LastInsertId)'
 	! gofmt -s -l . | grep -vF 'No Exceptions'
 	! goimports -l . | grep -vF 'No Exceptions'
-	! go tool vet --shadow --shadowstrict . 2>&1 |grep -vE '(\.pb\.go|declaration of err shadows)'
+	! go tool vet --shadow --shadowstrict . 2>&1 | grep -vE '(\.pb\.go|declaration of err shadows)'
 
 .PHONY: clean
 clean:

--- a/kv/range_cache.go
+++ b/kv/range_cache.go
@@ -246,11 +246,11 @@ func (rdc *rangeDescriptorCache) clearOverlappingCachedRangeDescriptors(key, met
 	// should be cleared out in favor of a KeyMin->"m" descriptor.
 	k, v, ok := rdc.rangeCache.Ceil(rangeCacheKey(metaKey))
 	if ok {
-		desc := v.(*proto.RangeDescriptor)
+		descriptor := v.(*proto.RangeDescriptor)
 		addrKey := keys.KeyAddress(key)
-		if !addrKey.Less(desc.StartKey) && !desc.EndKey.Less(addrKey) {
+		if !addrKey.Less(descriptor.StartKey) && !descriptor.EndKey.Less(addrKey) {
 			if log.V(1) {
-				log.Infof("clearing overlapping descriptor: key=%s desc=%s", k, desc)
+				log.Infof("clearing overlapping descriptor: key=%s desc=%s", k, descriptor)
 			}
 			rdc.rangeCache.Del(k.(rangeCacheKey))
 		}

--- a/kv/txn_coord_sender_test.go
+++ b/kv/txn_coord_sender_test.go
@@ -282,9 +282,9 @@ func TestTxnCoordSenderHeartbeat(t *testing.T) {
 	// Set heartbeat interval to 1ms for testing.
 	s.Sender.heartbeatInterval = 1 * time.Millisecond
 
-	txn := newTxn(s.Clock, proto.Key("a"))
+	initialTxn := newTxn(s.Clock, proto.Key("a"))
 	call := proto.Call{
-		Args:  createPutRequest(proto.Key("a"), []byte("value"), txn),
+		Args:  createPutRequest(proto.Key("a"), []byte("value"), initialTxn),
 		Reply: &proto.PutResponse{}}
 	if err := sendCall(s.Sender, call); err != nil {
 		t.Fatal(err)
@@ -294,7 +294,7 @@ func TestTxnCoordSenderHeartbeat(t *testing.T) {
 	var heartbeatTS proto.Timestamp
 	for i := 0; i < 3; i++ {
 		if err := util.IsTrueWithin(func() bool {
-			ok, txn, err := getTxn(s.Sender, txn)
+			ok, txn, err := getTxn(s.Sender, initialTxn)
 			if !ok || err != nil {
 				return false
 			}

--- a/server/status/monitor.go
+++ b/server/status/monitor.go
@@ -80,7 +80,7 @@ func (nsm *NodeStatusMonitor) GetStoreMonitor(id proto.StoreID) *StoreStatusMoni
 	// lock.
 	nsm.Lock()
 	defer nsm.Unlock()
-	if s, ok := nsm.stores[id]; ok {
+	if s, ok = nsm.stores[id]; ok {
 		return s
 	}
 	s = &StoreStatusMonitor{

--- a/storage/client_event_test.go
+++ b/storage/client_event_test.go
@@ -165,7 +165,7 @@ func (ser *storeEventReader) updateCountString() string {
 
 			for _, methodID := range methodIDs {
 				method := proto.Method(methodID)
-				if count, ok := countset[method]; ok {
+				if count, okCount := countset[method]; okCount {
 					fmt.Fprintf(w, "\tproto.%s:\t%d,\n", method, count)
 				} else {
 					panic("unreachable!")

--- a/storage/client_raft_test.go
+++ b/storage/client_raft_test.go
@@ -399,11 +399,11 @@ func TestFailedReplicaChange(t *testing.T) {
 	// complain about goroutines involved in the process).
 	if err := util.IsTrueWithin(func() bool {
 		for _, store := range mtc.stores {
-			rng, err := store.GetRange(1)
+			rang, err := store.GetRange(1)
 			if err != nil {
 				return false
 			}
-			if len(rng.Desc().Replicas) == 1 {
+			if len(rang.Desc().Replicas) == 1 {
 				return false
 			}
 		}

--- a/storage/engine/engine_test.go
+++ b/storage/engine/engine_test.go
@@ -428,7 +428,7 @@ func TestEngineScan1(t *testing.T) {
 		// a special case in engine.scan, that's why we test it here.
 		startKeys := []proto.EncodedKey{proto.EncodedKey("cat"), proto.EncodedKey("")}
 		for _, startKey := range startKeys {
-			keyvals, err := Scan(engine, startKey, proto.EncodedKey(proto.KeyMax), 0)
+			keyvals, err = Scan(engine, startKey, proto.EncodedKey(proto.KeyMax), 0)
 			if err != nil {
 				t.Fatalf("could not run scan: %v", err)
 			}

--- a/storage/range_raftstorage.go
+++ b/storage/range_raftstorage.go
@@ -249,7 +249,7 @@ func (r *Range) Snapshot() (raftpb.Snapshot, error) {
 	if err != nil {
 		// MVCCGetProto may return WriteIntentErrors in addition to a valid value.
 		// We can't resolve intents at this level so just ignore the error.
-		if _, ok := err.(*proto.WriteIntentError); !ok {
+		if _, ok = err.(*proto.WriteIntentError); !ok {
 			return raftpb.Snapshot{}, util.Errorf("failed to get desc: %s", err)
 		}
 	}

--- a/testutils/http.go
+++ b/testutils/http.go
@@ -77,8 +77,8 @@ func (ths *TestHTTPSession) Post(relative string, body []byte) []byte {
 
 	defer resp.Body.Close()
 	if resp.StatusCode != http.StatusOK {
-		body, _ := ioutil.ReadAll(resp.Body)
-		ths.t.Fatalf("unexpected status code: %v, %s", resp.StatusCode, body)
+		respBody, _ := ioutil.ReadAll(resp.Body)
+		ths.t.Fatalf("unexpected status code: %v, %s", resp.StatusCode, respBody)
 	}
 	returnedContentType := resp.Header.Get(util.ContentTypeHeader)
 	if returnedContentType != util.JSONContentType {

--- a/util/cache/cache.go
+++ b/util/cache/cache.go
@@ -305,7 +305,8 @@ func (oc *OrderedCache) length() int {
 
 // Ceil returns the smallest cache entry greater than or equal to key.
 func (oc *OrderedCache) Ceil(key interface{}) (k, v interface{}, ok bool) {
-	if e, ok := oc.llrb.Ceil(&entry{key: key}).(*entry); ok {
+	var e *entry
+	if e, ok = oc.llrb.Ceil(&entry{key: key}).(*entry); ok {
 		return e.key, e.value, true
 	}
 	return
@@ -313,7 +314,8 @@ func (oc *OrderedCache) Ceil(key interface{}) (k, v interface{}, ok bool) {
 
 // Floor returns the greatest cache entry less than or equal to key.
 func (oc *OrderedCache) Floor(key interface{}) (k, v interface{}, ok bool) {
-	if e, ok := oc.llrb.Floor(&entry{key: key}).(*entry); ok {
+	var e *entry
+	if e, ok = oc.llrb.Floor(&entry{key: key}).(*entry); ok {
 		return e.key, e.value, true
 	}
 	return

--- a/util/cache/cache.go
+++ b/util/cache/cache.go
@@ -304,21 +304,19 @@ func (oc *OrderedCache) length() int {
 }
 
 // Ceil returns the smallest cache entry greater than or equal to key.
-func (oc *OrderedCache) Ceil(key interface{}) (k, v interface{}, ok bool) {
-	var e *entry
-	if e, ok = oc.llrb.Ceil(&entry{key: key}).(*entry); ok {
+func (oc *OrderedCache) Ceil(key interface{}) (interface{}, interface{}, bool) {
+	if e, ok := oc.llrb.Ceil(&entry{key: key}).(*entry); ok {
 		return e.key, e.value, true
 	}
-	return
+	return nil, nil, false
 }
 
 // Floor returns the greatest cache entry less than or equal to key.
-func (oc *OrderedCache) Floor(key interface{}) (k, v interface{}, ok bool) {
-	var e *entry
-	if e, ok = oc.llrb.Floor(&entry{key: key}).(*entry); ok {
+func (oc *OrderedCache) Floor(key interface{}) (interface{}, interface{}, bool) {
+	if e, ok := oc.llrb.Floor(&entry{key: key}).(*entry); ok {
 		return e.key, e.value, true
 	}
-	return
+	return nil, nil, false
 }
 
 // Do invokes f on all of the entries in the cache.

--- a/util/caller/resolver.go
+++ b/util/caller/resolver.go
@@ -96,7 +96,7 @@ func (cr *CallResolver) Lookup(depth int) (file string, line int, fun string) {
 	}
 	cr.mu.Lock()
 	defer cr.mu.Unlock()
-	if v, ok := cr.cache[pc]; ok {
+	if v, okCache := cr.cache[pc]; okCache {
 		return v.file, v.line, v.fun
 	}
 	if matches := cr.re.FindStringSubmatch(file); matches != nil {


### PR DESCRIPTION
Most of these are trivial and would not cause issues (we should probably even whitelist "ok"). A handful could cause subtle bugs during refactoring.
