### PR TITLE
Gossip only when a leader lease is held

### DIFF
--- a/storage/client_split_test.go
+++ b/storage/client_split_test.go
@@ -106,8 +106,16 @@ func TestStoreRangeSplitBetweenConfigPrefix(t *testing.T) {
 		t.Fatalf("%q: split unexpected error: %s", key, err)
 	}
 
-	if err := store.MaybeGossipConfigs(); err != nil {
-		t.Fatalf("error gossiping configs: %s", err)
+	// Update configs to trigger gossip in both of the ranges.
+	acctConfig := &proto.AcctConfig{}
+	key = keys.MakeKey(keys.ConfigAccountingPrefix, proto.KeyMin)
+	if err = store.DB().Put(key, acctConfig); err != nil {
+		t.Fatal(err)
+	}
+	zoneConfig := &proto.ZoneConfig{}
+	key = keys.MakeKey(keys.ConfigZonePrefix, proto.KeyMin)
+	if err = store.DB().Put(key, zoneConfig); err != nil {
+		t.Fatal(err)
 	}
 }
 

--- a/storage/store.go
+++ b/storage/store.go
@@ -594,7 +594,7 @@ func (s *Store) startGossip() {
 
 	s.initComplete.Add(1)
 	s.stopper.RunWorker(func() {
-		if err := s.MaybeGossipConfigs(); err != nil {
+		if err := s.maybeGossipConfigs(); err != nil {
 			log.Warningc(ctx, "error gossiping configs: %s", err)
 		}
 		s.initComplete.Done()
@@ -603,7 +603,7 @@ func (s *Store) startGossip() {
 		for {
 			select {
 			case <-ticker.C:
-				if err := s.MaybeGossipConfigs(); err != nil {
+				if err := s.maybeGossipConfigs(); err != nil {
 					log.Warningc(ctx, "error gossiping configs: %s", err)
 				}
 			case <-s.stopper.ShouldStop():
@@ -624,7 +624,7 @@ func (s *Store) maybeGossipFirstRange() error {
 	return nil
 }
 
-// MaybeGossipConfigs checks which of the store's ranges contain config
+// maybeGossipConfigs checks which of the store's ranges contain config
 // descriptors and lets these ranges gossip them. Config gossip entries do not
 // expire, so this is a rarely needed action in a working cluster - if values
 // change, ranges will update gossip autonomously. However, the lease holder,
@@ -632,7 +632,7 @@ func (s *Store) maybeGossipFirstRange() error {
 // and a new leader lease is only acquired if needed. To account for this rare
 // scenario, we activate the very few ranges that hold config maps
 // periodically.
-func (s *Store) MaybeGossipConfigs() error {
+func (s *Store) maybeGossipConfigs() error {
 	for _, cd := range configDescriptors {
 		rng := s.LookupRange(cd.keyPrefix, nil)
 		if rng == nil {
@@ -647,12 +647,6 @@ func (s *Store) MaybeGossipConfigs() error {
 		if _, err := rng.getLeaseForGossip(s.Context(nil)); err != nil {
 			return err
 		}
-		// Always gossip the configs as there are leader lease acquisition
-		// scenarios in which the config is not gossiped (e.g. leader executes
-		// but crashes before gossiping; comes back up but group goes dormant).
-		rng.maybeGossipConfigs(func(configPrefix proto.Key) bool {
-			return bytes.Equal(configPrefix, cd.keyPrefix)
-		})
 	}
 	return nil
 }


### PR DESCRIPTION
I might be missing something, but this looks unnecessary since non-leader replicas also gossip configs when `applyRaftCommand` is called.
