### PR TITLE
log (some) traces directly, avoiding a Feed

### DIFF
--- a/server/server.go
+++ b/server/server.go
@@ -119,7 +119,14 @@ func NewServer(ctx *Context, stopper *stop.Stopper) (*Server, error) {
 	s.gossip = gossip.New(rpcContext, s.ctx.GossipInterval, s.ctx.GossipBootstrapResolvers)
 
 	feed := &util.Feed{}
-	tracer := tracer.NewTracer(feed, addr)
+	var logPub tracer.CallbackPublisher = func(tr *tracer.Trace) {
+		// Log all Traces on V(2), only Transactions and slow requests on V(1).
+		if log.V(2) || (log.V(1) && (tr.ID[0:1] == "t" ||
+			tr.Content[0].Duration > time.Second)) {
+			log.Infof("received trace:\n%s\n", tr)
+		}
+	}
+	tracer := tracer.NewTracer(logPub, addr)
 
 	ds := kv.NewDistSender(&kv.DistSenderContext{Clock: s.clock}, s.gossip)
 	sender := kv.NewTxnCoordSender(ds, s.clock, ctx.Linearizable, tracer, s.stopper)

--- a/server/status/feed.go
+++ b/server/status/feed.go
@@ -23,7 +23,6 @@ import (
 
 	"github.com/cockroachdb/cockroach/proto"
 	"github.com/cockroachdb/cockroach/util"
-	"github.com/cockroachdb/cockroach/util/tracer"
 )
 
 // StartNodeEvent is published when a node is started.
@@ -134,8 +133,6 @@ type NodeEventListener interface {
 	OnStartNode(event *StartNodeEvent)
 	OnCallSuccess(event *CallSuccessEvent)
 	OnCallError(event *CallErrorEvent)
-	// TODO(tschottdorf): break this out into a TraceEventListener.
-	OnTrace(event *tracer.Trace)
 }
 
 // ProcessNodeEvents reads node events from the supplied channel and passes them
@@ -147,8 +144,6 @@ func ProcessNodeEvents(l NodeEventListener, sub *util.Subscription) {
 		switch specificEvent := event.(type) {
 		case *StartNodeEvent:
 			l.OnStartNode(specificEvent)
-		case *tracer.Trace:
-			l.OnTrace(specificEvent)
 		case *CallSuccessEvent:
 			l.OnCallSuccess(specificEvent)
 		case *CallErrorEvent:

--- a/server/status/monitor.go
+++ b/server/status/monitor.go
@@ -25,8 +25,6 @@ import (
 	"github.com/cockroachdb/cockroach/storage"
 	"github.com/cockroachdb/cockroach/storage/engine"
 	"github.com/cockroachdb/cockroach/util"
-	"github.com/cockroachdb/cockroach/util/log"
-	"github.com/cockroachdb/cockroach/util/tracer"
 )
 
 // StoreStatusMonitor monitors the status of a single store on the server.
@@ -209,14 +207,6 @@ func (nsm *NodeStatusMonitor) OnCallSuccess(event *CallSuccessEvent) {
 // method is part of the implementation of NodeEventListener.
 func (nsm *NodeStatusMonitor) OnCallError(event *CallErrorEvent) {
 	atomic.AddInt64(&nsm.callErrors, 1)
-}
-
-// OnTrace receives Trace objects from a node event subscription. This method
-// is part of the implementation of NodeEventListener.
-func (nsm *NodeStatusMonitor) OnTrace(trace *tracer.Trace) {
-	if log.V(2) {
-		log.Infof("received trace:\n%s", trace)
-	}
 }
 
 // rangeDataAccumulator maintains a set of accumulated stats for a set of

--- a/storage/range.go
+++ b/storage/range.go
@@ -375,6 +375,9 @@ func (r *Range) requestLeaderLease(timestamp proto.Timestamp) error {
 //  will not incur latency waiting for the command to complete.
 //  Reads, however, must wait.
 func (r *Range) redirectOnOrAcquireLeaderLease(trace *tracer.Trace, timestamp proto.Timestamp) error {
+	// The primary merit of this Trace entry is that it measures the time spent
+	// waiting for the mutex.
+	defer trace.Epoch("verifying leader lease")()
 	r.llMu.Lock()
 	defer r.llMu.Unlock()
 

--- a/util/feed.go
+++ b/util/feed.go
@@ -87,9 +87,15 @@ type Feed struct {
 	subscribers []*Subscription
 }
 
+// A Publisher consumes events. The caller must not access objects after
+// handing them off to the Publisher.
+type Publisher interface {
+	Publish(interface{})
+}
+
 // Publish publishes a event into the Feed, which will eventually be received by
 // all Subscribers to the feed. Events published to a closed feed, or to a feed
-// with no Subscribers, will be ignored.
+// with no Subscribers, will be ignored. A Feed is a Publisher.
 func (f *Feed) Publish(event interface{}) {
 	if f == nil {
 		return


### PR DESCRIPTION
logging to the Feed can panic at high volumes, and
for now having a callback directly deal with the
traces is more adequate for current use (debugging).

functionally this is a no-op, except that slow
transactions are now always logged, even without
V(2).
