### PR TITLE
Decrease default for `bank --num-parallel-transfers`.

### DIFF
--- a/examples/bank/bank.go
+++ b/examples/bank/bank.go
@@ -41,7 +41,7 @@ var useTransaction = flag.Bool("use-transaction", true, "Turn off to disable tra
 var firstAccount = flag.Int("first-account", 0, "First account in the account range.")
 var numAccounts = flag.Int("num-accounts", 1000, "Number of accounts in the account range.")
 
-var numParallelTransfers = flag.Int("num-parallel-transfers", 100, "Number of parallel transfers.")
+var numParallelTransfers = flag.Int("num-parallel-transfers", 50, "Number of parallel transfers.")
 
 // Bank stores all the bank related state.
 type Bank struct {


### PR DESCRIPTION
Since each parallel transfer requires two file descriptors (one for the
client and one for the server), the previous default was high enough to
run into errors under the OSX default ulimit (256).

Closes #1664 
