### PR TITLE
Add "--" to `kv inc` help and examples for negative values.

### DIFF
--- a/server/cli/cli_test.go
+++ b/server/cli/cli_test.go
@@ -76,6 +76,8 @@ func Example_basic() {
 	c.Run("kv inc c 1")
 	c.Run("kv inc c 10")
 	c.Run("kv inc c 100")
+	c.Run("kv inc c -- -60")
+	c.Run("kv inc c -- -9")
 	c.Run("kv scan")
 	c.Run("kv inc c b")
 	c.Run("quit")
@@ -96,9 +98,13 @@ func Example_basic() {
 	// 11
 	// kv inc c 100
 	// 111
+	// kv inc c -- -60
+	// 51
+	// kv inc c -- -9
+	// 42
 	// kv scan
 	// "b"	"2"
-	// "c"	"\x00\x00\x00\x00\x00\x00\x00o"
+	// "c"	"\x00\x00\x00\x00\x00\x00\x00*"
 	// kv inc c b
 	// invalid increment: b: strconv.ParseInt: parsing "b": invalid syntax
 	// quit

--- a/server/cli/kv.go
+++ b/server/cli/kv.go
@@ -143,6 +143,8 @@ var incCmd = &cobra.Command{
 	Long: `
 Increments the value for a key. The increment amount defaults to 1 if
 not specified. Displays the incremented value upon success.
+Negative values need to be prefixed with -- to not get interpreted as
+flags.
 `,
 	Run: runInc,
 }


### PR DESCRIPTION
https://github.com/cockroachdb/cockroach/issues/1286 discusses using negative values with the `kv inc` command like `kv inc mycount -3`. This does not work because `-3` gets interpreted as a flag. 

Cobra does not support negative values as arguments because this is expected behavior and follows unix standards: https://github.com/spf13/cobra/issues/124

So the best thing that can be done is to add a notice for using "--" to the command help and the examples, so novice users like me don't have to google for the problem (because this is how i found this issue).

Closes https://github.com/cockroachdb/cockroach/issues/1286
