### PR TITLE
    Remove the TODO comment for #1362

### DIFF
--- a/storage/range_raftstorage.go
+++ b/storage/range_raftstorage.go
@@ -348,7 +348,9 @@ func (r *Range) updateRangeInfo() error {
 		return util.Errorf("failed to lookup zone config for Range %s: %s", r, err)
 	}
 	r.SetMaxBytes(zone.RangeMaxBytes)
-	// TODO(kkaneda): Update configHashes and other fields as well (#1362)?
+
+	// No need to update configHashes. It will be set when a leader lease calls
+	// maybeGossipConfigs.
 
 	return nil
 }


### PR DESCRIPTION
This change fixes #1362 since `maybeGossipConfigs` updates config hashes. I think this change is mostly no-op since a new range created by split does not hold a lease owned by the replica (and the replica does not gossip the information). 

I also tried tweaking `Store.setRangesMaxBytes` to store `maxBytes` changes in Raft, but didn't complete the change.
