### PR TITLE
Remove StartAdminServer

### DIFF
--- a/client/admin_test.go
+++ b/client/admin_test.go
@@ -30,11 +30,11 @@ import (
 // Example_accounting shows how to use the admin client to
 // get/set/list/delete accounting configs.
 func Example_accounting() {
-	ctx, stopper := server.StartAdminServer()
-	defer stopper.Stop()
+	s := server.StartTestServer(nil)
+	defer s.Stop()
 
 	context := testutils.NewRootTestBaseContext()
-	client := client.NewAdminClient(context, ctx.Addr, client.Accounting)
+	client := client.NewAdminClient(context, s.ServingAddr(), client.Accounting)
 
 	const yamlConfig = `cluster_id: test`
 	const jsonConfig = `{
@@ -123,11 +123,11 @@ func Example_accounting() {
 // Example_permission shows how to use the admin client to
 // get/set/list/delete permission configs.
 func Example_permission() {
-	ctx, stopper := server.StartAdminServer()
-	defer stopper.Stop()
+	s := server.StartTestServer(nil)
+	defer s.Stop()
 
 	context := testutils.NewRootTestBaseContext()
-	client := client.NewAdminClient(context, ctx.Addr, client.Permission)
+	client := client.NewAdminClient(context, s.ServingAddr(), client.Permission)
 
 	const yamlConfig = `
 read: [readonly, readwrite]
@@ -239,11 +239,11 @@ write: [readwrite, writeonly]
 // Example_user shows how to use the admin client to
 // get/set/list/delete user configs.
 func Example_user() {
-	ctx, stopper := server.StartAdminServer()
-	defer stopper.Stop()
+	s := server.StartTestServer(nil)
+	defer s.Stop()
 
 	context := testutils.NewRootTestBaseContext()
-	client := client.NewAdminClient(context, ctx.Addr, client.User)
+	client := client.NewAdminClient(context, s.ServingAddr(), client.User)
 
 	const yamlConfig = `hashed_password:
  - 10
@@ -340,11 +340,11 @@ func Example_user() {
 // Example_zone shows how to use the admin client to
 // get/set/list/delete zone configs.
 func Example_zone() {
-	ctx, stopper := server.StartAdminServer()
-	defer stopper.Stop()
+	s := server.StartTestServer(nil)
+	defer s.Stop()
 
 	context := testutils.NewRootTestBaseContext()
-	client := client.NewAdminClient(context, ctx.Addr, client.Zone)
+	client := client.NewAdminClient(context, s.ServingAddr(), client.Zone)
 
 	const yamlConfig = `
 replicas:

--- a/server/admin_test.go
+++ b/server/admin_test.go
@@ -65,10 +65,10 @@ func getJSON(url string) (interface{}, error) {
 // available via the /debug/vars link.
 func TestAdminDebugExpVar(t *testing.T) {
 	defer leaktest.AfterTest(t)
-	ctx, stopper := StartAdminServer()
-	defer stopper.Stop()
+	s := StartTestServer(t)
+	defer s.Stop()
 
-	jI, err := getJSON(ctx.RequestScheme() + "://" + ctx.Addr + debugEndpoint + "vars")
+	jI, err := getJSON(s.Ctx.RequestScheme() + "://" + s.ServingAddr() + debugEndpoint + "vars")
 	if err != nil {
 		t.Fatalf("failed to fetch JSON: %v", err)
 	}
@@ -85,10 +85,10 @@ func TestAdminDebugExpVar(t *testing.T) {
 // via the /debug/pprof/* links.
 func TestAdminDebugPprof(t *testing.T) {
 	defer leaktest.AfterTest(t)
-	ctx, stopper := StartAdminServer()
-	defer stopper.Stop()
+	s := StartTestServer(t)
+	defer s.Stop()
 
-	body, err := getText(ctx.RequestScheme() + "://" + ctx.Addr + debugEndpoint + "pprof/block")
+	body, err := getText(s.Ctx.RequestScheme() + "://" + s.ServingAddr() + debugEndpoint + "pprof/block")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -101,8 +101,8 @@ func TestAdminDebugPprof(t *testing.T) {
 // responses.
 func TestSetZoneInvalid(t *testing.T) {
 	defer leaktest.AfterTest(t)
-	ctx, stopper := StartAdminServer()
-	defer stopper.Stop()
+	s := StartTestServer(t)
+	defer s.Stop()
 
 	testData := []struct {
 		zone   string
@@ -132,7 +132,7 @@ range_max_bytes: 67108864
 	}
 	for i, test := range testData {
 		re := regexp.MustCompile(test.expErr)
-		req, err := http.NewRequest("POST", fmt.Sprintf("%s://%s%s/%s", ctx.RequestScheme(), ctx.Addr, zonePathPrefix, "foo"), strings.NewReader(test.zone))
+		req, err := http.NewRequest("POST", fmt.Sprintf("%s://%s%s/%s", s.Ctx.RequestScheme(), s.ServingAddr(), zonePathPrefix, "foo"), strings.NewReader(test.zone))
 		if err != nil {
 			t.Fatal(err)
 		}


### PR DESCRIPTION
This was moved around earlier, but was only used in a handful of test
cases. Better to use the more common StartTestServer.
