### PR TITLE
Use home-grown RPC server instead of net/rpc.Server.

### DIFF
--- a/gossip/server.go
+++ b/gossip/server.go
@@ -30,6 +30,7 @@ import (
 	"github.com/cockroachdb/cockroach/util"
 	"github.com/cockroachdb/cockroach/util/log"
 	"github.com/cockroachdb/cockroach/util/stop"
+	gogoproto "github.com/gogo/protobuf/proto"
 )
 
 type clientInfo struct {
@@ -65,7 +66,7 @@ func newServer(interval time.Duration) *server {
 // Gossip receives gossiped information from a peer node.
 // The received delta is combined with the infostore, and this
 // node's own gossip is returned to requesting client.
-func (s *server) Gossip(argsI interface{}) (interface{}, error) {
+func (s *server) Gossip(argsI gogoproto.Message) (gogoproto.Message, error) {
 	args := argsI.(*proto.GossipRequest)
 	reply := &proto.GossipResponse{}
 	s.mu.Lock()

--- a/kv/db.go
+++ b/kv/db.go
@@ -30,6 +30,7 @@ import (
 	"github.com/cockroachdb/cockroach/rpc"
 	"github.com/cockroachdb/cockroach/security"
 	"github.com/cockroachdb/cockroach/util"
+	gogoproto "github.com/gogo/protobuf/proto"
 )
 
 const (
@@ -203,7 +204,7 @@ func (s *DBServer) RegisterRPC(rpcServer *rpc.Server) error {
 }
 
 // executeCmd creates a proto.Call struct and sends it via our local sender.
-func (s *DBServer) executeCmd(argsI interface{}) (interface{}, error) {
+func (s *DBServer) executeCmd(argsI gogoproto.Message) (gogoproto.Message, error) {
 	args := argsI.(proto.Request)
 	reply := args.CreateReply()
 	s.sender.Send(context.TODO(), proto.Call{Args: args, Reply: reply})

--- a/rpc/client_test.go
+++ b/rpc/client_test.go
@@ -18,7 +18,6 @@
 package rpc
 
 import (
-	"net/rpc"
 	"testing"
 	"time"
 
@@ -106,7 +105,7 @@ func TestClientHeartbeatBadServer(t *testing.T) {
 	// The client should fail the heartbeat and be recycled.
 	<-c.Closed
 
-	if err := s.RegisterName("Heartbeat", heartbeat); err != nil {
+	if err := heartbeat.Register(s); err != nil {
 		t.Fatalf("Unable to register heartbeat service: %s", err)
 	}
 	// Same thing, but now the heartbeat service exists.
@@ -130,7 +129,7 @@ func TestOffsetMeasurement(t *testing.T) {
 		clock:              serverClock,
 		remoteClockMonitor: newRemoteClockMonitor(serverClock),
 	}
-	if err := s.RegisterName("Heartbeat", heartbeat); err != nil {
+	if err := heartbeat.Register(s); err != nil {
 		t.Fatalf("Unable to register heartbeat service: %s", err)
 	}
 
@@ -177,7 +176,7 @@ func TestDelayedOffsetMeasurement(t *testing.T) {
 		clock:              serverClock,
 		remoteClockMonitor: newRemoteClockMonitor(serverClock),
 	}
-	if err := s.RegisterName("Heartbeat", heartbeat); err != nil {
+	if err := heartbeat.Register(s); err != nil {
 		t.Fatalf("Unable to register heartbeat service: %s", err)
 	}
 
@@ -228,7 +227,7 @@ func TestFailedOffestMeasurement(t *testing.T) {
 		ready:              make(chan struct{}),
 		stopper:            stopper,
 	}
-	if err := s.RegisterName("Heartbeat", heartbeat); err != nil {
+	if err := heartbeat.Register(s); err != nil {
 		t.Fatalf("Unable to register heartbeat service: %s", err)
 	}
 
@@ -273,9 +272,9 @@ func createTestServer(serverClock *hlc.Clock, stopper *stop.Stopper, t *testing.
 	// Create the server so that we can register a manual clock.
 	addr := util.CreateTestAddr("tcp")
 	s := &Server{
-		Server:  rpc.NewServer(),
 		context: nodeContext,
 		addr:    addr,
+		methods: map[string]method{},
 	}
 	if err := s.Start(); err != nil {
 		t.Fatal(err)

--- a/rpc/codec/conn.go
+++ b/rpc/codec/conn.go
@@ -120,5 +120,16 @@ func (c *baseConn) recvProto(m proto.Message,
 }
 
 func protoUnmarshal(src []byte, uncompressedSize uint32, msg proto.Message) error {
+	return nilSafeUnmarshal(src, msg)
+}
+
+// nilSafeUnmarshal is a wrapper around proto.Unmarshal which is a
+// noop if msg is nil. This is useful in parts of the protocol that
+// need to read and discard frames whose protobuf type cannot be
+// known.
+func nilSafeUnmarshal(src []byte, msg proto.Message) error {
+	if msg == nil {
+		return nil
+	}
 	return proto.Unmarshal(src, msg)
 }

--- a/rpc/codec/lz4.go
+++ b/rpc/codec/lz4.go
@@ -87,7 +87,7 @@ func lz4Decode(src []byte, uncompressedSize uint32, m proto.Message) error {
 	if len(src) == 0 || len(src) == int(uncompressedSize) {
 		// len(src) == int(uncompressedSize) indicates the data was not
 		// compressible.
-		return proto.Unmarshal(src, m)
+		return nilSafeUnmarshal(src, m)
 	}
 
 	var dst unsafe.Pointer
@@ -100,7 +100,7 @@ func lz4Decode(src []byte, uncompressedSize uint32, m proto.Message) error {
 	// We call through directly to proto.Unmarshal so that we don't have
 	// to allocate a slice for "dst" or have some awkward interface
 	// where the caller has to deallocate "dst".
-	err := proto.Unmarshal(unsafeSlice(dst, C.size_t(dLen)), m)
+	err := nilSafeUnmarshal(unsafeSlice(dst, C.size_t(dLen)), m)
 	C.free(dst)
 	return err
 }

--- a/rpc/codec/snappy.go
+++ b/rpc/codec/snappy.go
@@ -111,7 +111,7 @@ func snappyEncode(src []byte, w func([]byte) error) error {
 // uncompressed data into m.
 func snappyDecode(src []byte, uncompressedSize uint32, m proto.Message) error {
 	if len(src) == 0 {
-		return proto.Unmarshal(nil, m)
+		return nilSafeUnmarshal(nil, m)
 	}
 
 	var dLen C.size_t
@@ -126,7 +126,7 @@ func snappyDecode(src []byte, uncompressedSize uint32, m proto.Message) error {
 	// We call through directly to proto.Unmarshal so that we don't have
 	// to allocate a slice for "dst" or have some awkward interface
 	// where the caller has to deallocate "dst".
-	err := proto.Unmarshal(unsafeSlice(dst, dLen), m)
+	err := nilSafeUnmarshal(unsafeSlice(dst, dLen), m)
 	C.free(dst)
 	return err
 }

--- a/rpc/heartbeat.go
+++ b/rpc/heartbeat.go
@@ -21,6 +21,7 @@ import (
 	"github.com/cockroachdb/cockroach/proto"
 	"github.com/cockroachdb/cockroach/util/hlc"
 	"github.com/cockroachdb/cockroach/util/stop"
+	gogoproto "github.com/gogo/protobuf/proto"
 )
 
 // A HeartbeatService exposes a method to echo its request params. It doubles
@@ -48,7 +49,7 @@ func (hs *HeartbeatService) Register(server *Server) error {
 // server's current clock value, allowing the requester to measure its clock.
 // The requester should also estimate its offset from this server along
 // with the requester's address.
-func (hs *HeartbeatService) Ping(argsI interface{}) (interface{}, error) {
+func (hs *HeartbeatService) Ping(argsI gogoproto.Message) (gogoproto.Message, error) {
 	args := argsI.(*proto.PingRequest)
 	reply := &proto.PingResponse{}
 	reply.Pong = args.Ping
@@ -80,7 +81,7 @@ func (mhs *ManualHeartbeatService) Register(server *Server) error {
 }
 
 // Ping waits until the heartbeat service is ready to respond to a Heartbeat.
-func (mhs *ManualHeartbeatService) Ping(args interface{}) (interface{}, error) {
+func (mhs *ManualHeartbeatService) Ping(args gogoproto.Message) (gogoproto.Message, error) {
 	select {
 	case <-mhs.ready:
 	case <-mhs.stopper.ShouldStop():

--- a/rpc/heartbeat_test.go
+++ b/rpc/heartbeat_test.go
@@ -39,9 +39,11 @@ func TestHeartbeatReply(t *testing.T) {
 	request := &proto.PingRequest{
 		Ping: "testPing",
 	}
-	response := &proto.PingResponse{}
-	if err := heartbeat.Ping(request, response); err != nil {
+	var response *proto.PingResponse
+	if responseI, err := heartbeat.Ping(request); err != nil {
 		t.Fatal(err)
+	} else {
+		response = responseI.(*proto.PingResponse)
 	}
 
 	if response.Pong != request.Ping {
@@ -71,13 +73,17 @@ func TestManualHeartbeat(t *testing.T) {
 		Ping: "testManual",
 	}
 	manualHeartbeat.ready <- struct{}{}
-	manualResponse := &proto.PingResponse{}
-	regularResponse := &proto.PingResponse{}
-	if err := regularHeartbeat.Ping(request, regularResponse); err != nil {
+	var manualResponse *proto.PingResponse
+	var regularResponse *proto.PingResponse
+	if resp, err := regularHeartbeat.Ping(request); err != nil {
 		t.Fatal(err)
+	} else {
+		regularResponse = resp.(*proto.PingResponse)
 	}
-	if err := manualHeartbeat.Ping(request, manualResponse); err != nil {
+	if resp, err := manualHeartbeat.Ping(request); err != nil {
 		t.Fatal(err)
+	} else {
+		manualResponse = resp.(*proto.PingResponse)
 	}
 
 	// Ensure that the response is the same as with a normal heartbeat.

--- a/rpc/send_test.go
+++ b/rpc/send_test.go
@@ -382,11 +382,17 @@ func createAndStartNewServer(t *testing.T, ctx *Context) *Server {
 
 // sendPing sends Ping requests to specified addresses using Send.
 func sendPing(opts Options, addrs []net.Addr, rpcContext *Context) ([]interface{}, error) {
+	return sendRPC(opts, addrs, rpcContext, "Heartbeat.Ping",
+		&proto.PingRequest{}, &proto.PingResponse{})
+}
+
+func sendRPC(opts Options, addrs []net.Addr, rpcContext *Context, name string,
+	args, reply gogoproto.Message) ([]interface{}, error) {
 	getArgs := func(addr net.Addr) interface{} {
-		return &proto.PingRequest{}
+		return args
 	}
 	getReply := func() interface{} {
-		return &proto.PingResponse{}
+		return reply
 	}
-	return Send(opts, "Heartbeat.Ping", addrs, getArgs, getReply, rpcContext)
+	return Send(opts, name, addrs, getArgs, getReply, rpcContext)
 }

--- a/rpc/send_test.go
+++ b/rpc/send_test.go
@@ -28,6 +28,7 @@ import (
 	"github.com/cockroachdb/cockroach/util/leaktest"
 	"github.com/cockroachdb/cockroach/util/retry"
 	"github.com/cockroachdb/cockroach/util/stop"
+	gogoproto "github.com/gogo/protobuf/proto"
 )
 
 func TestInvalidAddrLength(t *testing.T) {
@@ -181,7 +182,7 @@ func TestUnretryableError(t *testing.T) {
 
 type Heartbeat struct{}
 
-func (h *Heartbeat) Ping(args interface{}) (interface{}, error) {
+func (h *Heartbeat) Ping(args gogoproto.Message) (gogoproto.Message, error) {
 	time.Sleep(50 * time.Millisecond)
 	return &proto.PingResponse{}, nil
 }

--- a/rpc/server.go
+++ b/rpc/server.go
@@ -23,6 +23,7 @@ import (
 	"net"
 	"net/http"
 	"net/rpc"
+	"reflect"
 	"strings"
 	"sync"
 
@@ -30,8 +31,18 @@ import (
 	"github.com/cockroachdb/cockroach/security"
 	"github.com/cockroachdb/cockroach/util"
 	"github.com/cockroachdb/cockroach/util/log"
-	"github.com/gogo/protobuf/proto"
 )
+
+type method struct {
+	handler func(interface{}) (interface{}, error)
+	reqType reflect.Type
+}
+
+type serverResponse struct {
+	req   *rpc.Request
+	reply interface{}
+	err   error
+}
 
 // Server is a Cockroach-specific RPC server with an embedded go RPC
 // server struct. By default it handles a simple heartbeat protocol
@@ -39,8 +50,7 @@ import (
 //
 // TODO(spencer): heartbeat protocol should also measure link latency.
 type Server struct {
-	*rpc.Server              // Embedded RPC server instance
-	listener    net.Listener // Server listener
+	listener net.Listener // Server listener
 
 	activeConns map[net.Conn]struct{}
 	handler     http.Handler
@@ -51,23 +61,49 @@ type Server struct {
 	addr           net.Addr              // Server address; may change if picking unused port
 	closed         bool                  // Set upon invocation of Close()
 	closeCallbacks []func(conn net.Conn) // Slice of callbacks to invoke on conn close
+	methods        map[string]method
 }
 
 // NewServer creates a new instance of Server.
 func NewServer(addr net.Addr, context *Context) *Server {
 	s := &Server{
-		Server:  rpc.NewServer(),
 		context: context,
 		addr:    addr,
+		methods: map[string]method{},
 	}
 	heartbeat := &HeartbeatService{
 		clock:              context.localClock,
 		remoteClockMonitor: context.RemoteClocks,
 	}
-	if err := s.RegisterName("Heartbeat", heartbeat); err != nil {
+	if err := heartbeat.Register(s); err != nil {
 		log.Fatalf("unable to register heartbeat service with RPC server: %s", err)
 	}
 	return s
+}
+
+// Register a new method handler. `name` is a qualified name of the form "Service.Name".
+// `handler` is a function that takes an argument of the same type as `reqPrototype`.
+// Both the argument and return value of 'handler' should be a pointer to a protocol
+// message type.
+func (s *Server) Register(name string, handler func(interface{}) (interface{}, error),
+	reqPrototype interface{}) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	if _, ok := s.methods[name]; ok {
+		return util.Errorf("method %s already registered", name)
+	}
+	reqType := reflect.TypeOf(reqPrototype)
+	if reqType.Kind() != reflect.Ptr {
+		// net/rpc supports non-pointer requests, but we always use pointers
+		// and things are a little simpler this way.
+		return util.Errorf("request type not a pointer")
+	}
+	s.methods[name] = method{
+		handler: handler,
+		reqType: reqType,
+	}
+	return nil
 }
 
 // AddCloseCallback adds a callback to the closeCallbacks slice to
@@ -112,7 +148,31 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	}
 	security.LogTLSState("RPC", r.TLS)
 	io.WriteString(conn, "HTTP/1.0 "+connected+"\n\n")
-	s.serveConn(conn, authHook)
+
+	codec := codec.NewServerCodec(conn, authHook)
+	responses := make(chan serverResponse)
+	var wg sync.WaitGroup
+	wg.Add(2)
+	go func() {
+		s.readRequests(codec, responses)
+		wg.Done()
+	}()
+	go func() {
+		s.sendResponses(codec, responses)
+		wg.Done()
+	}()
+	wg.Wait()
+
+	codec.Close()
+
+	s.mu.Lock()
+	if s.closeCallbacks != nil {
+		for _, cb := range s.closeCallbacks {
+			cb(conn)
+		}
+	}
+	s.mu.Unlock()
+	conn.Close()
 }
 
 // Listen listens on the configured address but does not start
@@ -252,16 +312,77 @@ func (s *Server) Close() {
 	}
 }
 
-// serveConn synchronously serves a single connection. When the
-// connection is closed, close callbacks are invoked.
-func (s *Server) serveConn(conn net.Conn, authHook func(proto.Message) error) {
-	s.ServeCodec(codec.NewServerCodec(conn, authHook))
-	s.mu.Lock()
-	if s.closeCallbacks != nil {
-		for _, cb := range s.closeCallbacks {
-			cb(conn)
+// readRequests synchronously reads a stream of requests from a
+// connection. Each request is handled in a new background goroutine;
+// when the handler finishes the response is written to the responses
+// channel. When the connection is closed (and any pending requests
+// have finished), we close the responses channel.
+func (s *Server) readRequests(codec rpc.ServerCodec, responses chan<- serverResponse) {
+	var wg sync.WaitGroup
+	defer func() {
+		wg.Wait()
+		close(responses)
+	}()
+
+	for {
+		req, meth, args, err := s.readRequest(codec)
+		if err == io.EOF || err == io.ErrUnexpectedEOF {
+			return
+		} else if err != nil {
+			log.Warningf("rpc: server cannot decode request: %s", err)
+			return
+		}
+
+		wg.Add(1)
+		go func() {
+			reply, err := meth.handler(args)
+			responses <- serverResponse{
+				req:   req,
+				reply: reply,
+				err:   err,
+			}
+			wg.Done()
+		}()
+	}
+}
+
+// readRequest reads a single request from a connection.
+func (s *Server) readRequest(codec rpc.ServerCodec) (req *rpc.Request, m method,
+	args interface{}, err error) {
+	req = &rpc.Request{}
+	if err = codec.ReadRequestHeader(req); err != nil {
+		return
+	}
+
+	s.mu.RLock()
+	var ok bool
+	m, ok = s.methods[req.ServiceMethod]
+	s.mu.RUnlock()
+	if !ok {
+		err = util.Errorf("rpc: can't find method %s", req.ServiceMethod)
+		return
+	}
+
+	args = reflect.New(m.reqType.Elem()).Interface()
+	err = codec.ReadRequestBody(args)
+	return
+}
+
+// sendResponses sends a stream of responses on a connection, and
+// exits when the channel is closed.
+func (s *Server) sendResponses(codec rpc.ServerCodec, responses <-chan serverResponse) {
+	for resp := range responses {
+		rpcResp := rpc.Response{
+			ServiceMethod: resp.req.ServiceMethod,
+			Seq:           resp.req.Seq,
+		}
+		if resp.err != nil {
+			rpcResp.Error = resp.err.Error()
+		}
+		if err := codec.WriteResponse(&rpcResp, resp.reply); err != nil {
+			log.Warningf("rpc: write response failed")
+			// TODO(bdarnell): what to do at this point? close the connection?
+			// net/rpc just swallows the error.
 		}
 	}
-	s.mu.Unlock()
-	conn.Close()
 }

--- a/rpc/server.go
+++ b/rpc/server.go
@@ -153,15 +153,12 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	codec := codec.NewServerCodec(conn, authHook)
 	responses := make(chan serverResponse)
 	var wg sync.WaitGroup
-	wg.Add(2)
-	go func() {
-		s.readRequests(codec, responses)
-		wg.Done()
-	}()
+	wg.Add(1)
 	go func() {
 		s.sendResponses(codec, responses)
 		wg.Done()
 	}()
+	s.readRequests(codec, responses)
 	wg.Wait()
 
 	codec.Close()

--- a/server/node.go
+++ b/server/node.go
@@ -40,6 +40,7 @@ import (
 	"github.com/cockroachdb/cockroach/util/log"
 	"github.com/cockroachdb/cockroach/util/stop"
 	"github.com/cockroachdb/cockroach/util/tracer"
+	gogoproto "github.com/gogo/protobuf/proto"
 )
 
 const (
@@ -476,7 +477,7 @@ func (n *Node) publishStoreStatuses() error {
 }
 
 // executeCmd creates a proto.Call struct and sends it via our local sender.
-func (n *Node) executeCmd(argsI interface{}) (interface{}, error) {
+func (n *Node) executeCmd(argsI gogoproto.Message) (gogoproto.Message, error) {
 	args := argsI.(proto.Request)
 	reply := args.CreateReply()
 	// TODO(tschottdorf) get a hold of the client's ID, add it to the

--- a/server/node_test.go
+++ b/server/node_test.go
@@ -540,10 +540,11 @@ func TestStatusSummaries(t *testing.T) {
 		},
 		SplitKey: splitKey,
 	}
-	ns := (*nodeServer)(ts.node)
-	reply := &proto.AdminSplitResponse{}
-	if err := ns.AdminSplit(args, reply); err != nil {
+	var reply *proto.AdminSplitResponse
+	if replyI, err := ts.node.executeCmd(args); err != nil {
 		t.Fatal(err)
+	} else {
+		reply = replyI.(*proto.AdminSplitResponse)
 	}
 	if reply.Error != nil {
 		t.Fatal(reply.Error)

--- a/server/raft_transport.go
+++ b/server/raft_transport.go
@@ -64,36 +64,35 @@ func newRPCTransport(gossip *gossip.Gossip, rpcServer *rpc.Server, rpcContext *r
 		queues:     make(map[proto.RaftNodeID]chan *multiraft.RaftMessageRequest),
 	}
 
-	err := t.rpcServer.RegisterName(raftServiceName, (*transportRPCServer)(t))
-	if err != nil {
+	if err := t.rpcServer.Register(raftMessageName, t.RaftMessage,
+		&proto.RaftMessageRequest{}); err != nil {
 		return nil, err
 	}
 
 	return t, nil
 }
 
-// transportRPCServer is a type alias to separate RPC methods
-// (which net/rpc finds via reflection) from others.
-type transportRPCServer rpcTransport
-
 // RaftMessage proxies the incoming request to the listening server interface.
-func (t *transportRPCServer) RaftMessage(protoReq *proto.RaftMessageRequest,
-	resp *proto.RaftMessageResponse) error {
+func (t *rpcTransport) RaftMessage(args interface{}) (interface{}, error) {
+	protoReq := args.(*proto.RaftMessageRequest)
 	// Convert from proto to internal formats.
 	req := &multiraft.RaftMessageRequest{GroupID: protoReq.GroupID}
 	if err := req.Message.Unmarshal(protoReq.Msg); err != nil {
-		return err
+		return nil, err
 	}
 
 	t.mu.Lock()
 	server, ok := t.servers[proto.RaftNodeID(req.Message.To)]
 	t.mu.Unlock()
 
-	if ok {
-		return server.RaftMessage(req, &multiraft.RaftMessageResponse{})
+	if !ok {
+		return nil, util.Errorf("Unable to proxy message to node: %d", req.Message.To)
 	}
 
-	return util.Errorf("Unable to proxy message to node: %d", req.Message.To)
+	// Raft responses are empty so we don't actually need to convert between
+	// multiraft's internal struct and the external proto representation.
+	err := server.RaftMessage(req, &multiraft.RaftMessageResponse{})
+	return &proto.RaftMessageResponse{}, err
 }
 
 // Listen implements the multiraft.Transport interface by registering a ServerInterface

--- a/server/raft_transport.go
+++ b/server/raft_transport.go
@@ -28,6 +28,7 @@ import (
 	"github.com/cockroachdb/cockroach/rpc"
 	"github.com/cockroachdb/cockroach/util"
 	"github.com/cockroachdb/cockroach/util/log"
+	gogoproto "github.com/gogo/protobuf/proto"
 
 	gorpc "net/rpc"
 )
@@ -73,7 +74,7 @@ func newRPCTransport(gossip *gossip.Gossip, rpcServer *rpc.Server, rpcContext *r
 }
 
 // RaftMessage proxies the incoming request to the listening server interface.
-func (t *rpcTransport) RaftMessage(args interface{}) (interface{}, error) {
+func (t *rpcTransport) RaftMessage(args gogoproto.Message) (gogoproto.Message, error) {
 	protoReq := args.(*proto.RaftMessageRequest)
 	// Convert from proto to internal formats.
 	req := &multiraft.RaftMessageRequest{GroupID: protoReq.GroupID}


### PR DESCRIPTION
The wire protocol is unchanged; the biggest difference in this commit is
that method registration is now explicit instead of being
reflection-based and the method signatures have been changed. This
change is motivated by a desire to replace the goroutine-spawning
behavior of net/rpc.Server (see #1669), although this commit does not
change that behavior yet.
