### PR TITLE
fix delete apt config file in build-docker-dev.sh

### DIFF
--- a/build/builder.sh
+++ b/build/builder.sh
@@ -13,7 +13,7 @@ RUN apt-get update -y && \
  apt-get install --no-install-recommends --auto-remove -y git build-essential file npm nodejs && \
  apt-get clean autoclean && \
  apt-get autoremove -y && \
- rm -rf /tmp/* /var/lib/{apt,dpkg,cache,log} && \
+ rm -rf /tmp/* && \
  ln -s /usr/bin/nodejs /usr/bin/node && \
  apt-get remove --auto-remove -y npm
 RUN go get golang.org/x/tools/cmd/vet

--- a/build/devbase/Dockerfile
+++ b/build/devbase/Dockerfile
@@ -8,7 +8,7 @@ RUN apt-get update -y && \
 	apt-get install --no-install-recommends --auto-remove -y git build-essential pkg-config file npm && \
  	apt-get clean autoclean && \
  	apt-get autoremove -y && \
- 	rm -rf /tmp/* /var/lib/{apt,dpkg,cache,log} && \
+ 	rm -rf /tmp/* && \
 	ln -s /usr/bin/nodejs /usr/bin/node
 
 ENV GOPATH /go


### PR DESCRIPTION
#1698 In builder.sh and cockroachdb/cockroach/build/devbase/Dockerfile. The script delete /var/lib/{apt,dpkg,cache,log}, these file is apt package management software needed file. apt will be invalid after delete these file.
