### PR TITLE
Return (response, error): address comments

### DIFF
--- a/proto/errors.go
+++ b/proto/errors.go
@@ -23,6 +23,11 @@ import (
 	"github.com/cockroachdb/cockroach/util/retry"
 )
 
+// ErrorUnexpectedlySet is the string we panic on when we assert
+// `ResponseHeader.Error == nil` before calling
+// `ResponseHeader.SetGoError()`.
+const ErrorUnexpectedlySet = "error is unexpectedly set"
+
 // TransactionRestartError is an interface implemented by errors that cause
 // a transaction to be restarted.
 type TransactionRestartError interface {

--- a/proto/errors.go
+++ b/proto/errors.go
@@ -23,6 +23,15 @@ import (
 	"github.com/cockroachdb/cockroach/util/retry"
 )
 
+// ResponseWithError is a tuple of a Response and an error. It is used
+// to pass around a Response with its associated error where that
+// entanglement is necessary (e.g. channels, methods that need to
+// return another error in addition to this one).
+type ResponseWithError struct {
+	Reply Response
+	Err   error
+}
+
 // ErrorUnexpectedlySet is the string we panic on when we assert
 // `ResponseHeader.Error == nil` before calling
 // `ResponseHeader.SetGoError()`.

--- a/storage/client_merge_test.go
+++ b/storage/client_merge_test.go
@@ -254,7 +254,7 @@ func TestStoreRangeMergeNonConsecutive(t *testing.T) {
 	}
 
 	argsMerge, _ := adminMergeArgs(rangeA.Desc().StartKey, 1, store.StoreID())
-	if _, err := rangeA.AdminMerge(argsMerge); !testutils.IsError(err, "ranges not collocated") {
+	if _, err := rangeA.AdminMerge(*argsMerge); !testutils.IsError(err, "ranges not collocated") {
 		t.Fatalf("did not got expected error; got %s", err)
 	}
 

--- a/storage/client_raft_test.go
+++ b/storage/client_raft_test.go
@@ -790,7 +790,7 @@ func TestRangeDescriptorSnapshotRace(t *testing.T) {
 		}
 		args, _ := adminSplitArgs(proto.KeyMin, []byte(fmt.Sprintf("A%03d", i)), rng.Desc().RaftID,
 			mtc.stores[0].StoreID())
-		if _, err := rng.AdminSplit(args); err != nil {
+		if _, err := rng.AdminSplit(*args); err != nil {
 			t.Fatal(err)
 		}
 	}
@@ -802,7 +802,7 @@ func TestRangeDescriptorSnapshotRace(t *testing.T) {
 			t.Fatal("failed to look up max range")
 		}
 		args, _ := adminSplitArgs(proto.KeyMin, []byte(fmt.Sprintf("B%03d", i)), rng.Desc().RaftID, mtc.stores[0].StoreID())
-		if _, err := rng.AdminSplit(args); err != nil {
+		if _, err := rng.AdminSplit(*args); err != nil {
 			t.Fatal(err)
 		}
 	}

--- a/storage/range.go
+++ b/storage/range.go
@@ -587,10 +587,10 @@ func (r *Range) addAdminCmd(ctx context.Context, args proto.Request) (proto.Resp
 
 	switch tArgs := args.(type) {
 	case *proto.AdminSplitRequest:
-		resp, err := r.AdminSplit(tArgs)
+		resp, err := r.AdminSplit(*tArgs)
 		return &resp, err
 	case *proto.AdminMergeRequest:
-		resp, err := r.AdminMerge(tArgs)
+		resp, err := r.AdminMerge(*tArgs)
 		return &resp, err
 	default:
 		return nil, util.Error("unrecognized admin command")

--- a/storage/range.go
+++ b/storage/range.go
@@ -149,17 +149,12 @@ func usesTimestampCache(r proto.Request) bool {
 	return tsCacheMethods[m]
 }
 
-type responseWithErr struct {
-	reply proto.Response
-	err   error
-}
-
 // A pendingCmd holds a done channel for a command sent to Raft. Once
 // committed to the Raft log, the command is executed and the result returned
 // via the done channel.
 type pendingCmd struct {
 	ctx  context.Context
-	done chan responseWithErr // Used to signal waiting RPC handler
+	done chan proto.ResponseWithError // Used to signal waiting RPC handler
 }
 
 // A rangeManager is an interface satisfied by Store through which ranges
@@ -362,7 +357,7 @@ func (r *Range) requestLeaderLease(timestamp proto.Timestamp) error {
 	var err error
 	if err = <-errChan; err == nil {
 		// Next if the command was committed, wait for the range to apply it.
-		err = (<-pendingCmd.done).err
+		err = (<-pendingCmd.done).Err
 	}
 	return err
 }
@@ -738,7 +733,7 @@ func (r *Range) addWriteCmd(ctx context.Context, args proto.Request, wg *sync.Wa
 	if err = <-errChan; err == nil {
 		// Next if the command was committed, wait for the range to apply it.
 		respWithErr := <-pendingCmd.done
-		reply, err = respWithErr.reply, respWithErr.err
+		reply, err = respWithErr.Reply, respWithErr.Err
 	} else if err == multiraft.ErrGroupDeleted {
 		// This error needs to be converted appropriately so that
 		// clients will retry.
@@ -758,7 +753,7 @@ func (r *Range) addWriteCmd(ctx context.Context, args proto.Request, wg *sync.Wa
 func (r *Range) proposeRaftCommand(ctx context.Context, args proto.Request) (<-chan error, *pendingCmd) {
 	pendingCmd := &pendingCmd{
 		ctx:  ctx,
-		done: make(chan responseWithErr, 1),
+		done: make(chan proto.ResponseWithError, 1),
 	}
 	raftCmd := proto.InternalRaftCommand{
 		RaftID:       r.Desc().RaftID,
@@ -812,7 +807,7 @@ func (r *Range) processRaftCommand(idKey cmdIDKey, index uint64, raftCmd proto.I
 	execDone()
 
 	if cmd != nil {
-		cmd.done <- responseWithErr{reply, err}
+		cmd.done <- proto.ResponseWithError{reply, err}
 	} else if err != nil && log.V(1) {
 		log.Errorc(r.context(), "error executing raft command %s: %s", args.Method(), err)
 	}
@@ -904,15 +899,15 @@ func (r *Range) applyRaftCommandInBatch(ctx context.Context, index uint64, origi
 
 	// Check the response cache to ensure idempotency.
 	if proto.IsWrite(args) {
-		if reply, err, readErr := r.respCache.GetResponse(batch, args.Header().CmdID); readErr != nil {
-			return batch, reply, newReplicaCorruptionError(util.Errorf("could not read from response cache"), readErr)
-		} else if reply != nil {
+		if replyWithErr, readErr := r.respCache.GetResponse(batch, args.Header().CmdID); readErr != nil {
+			return batch, nil, newReplicaCorruptionError(util.Errorf("could not read from response cache"), readErr)
+		} else if replyWithErr.Reply != nil {
 			if log.V(1) {
 				log.Infoc(ctx, "found response cache entry for %+v", args.Header().CmdID)
 			}
 			// We successfully read from the response cache, so return whatever error
 			// was present in the cached entry (if any).
-			return batch, reply, err
+			return batch, replyWithErr.Reply, replyWithErr.Err
 		}
 	}
 
@@ -937,7 +932,7 @@ func (r *Range) applyRaftCommandInBatch(ctx context.Context, index uint64, origi
 		if reply == nil {
 			reply = args.CreateReply()
 		}
-		if err := r.respCache.PutResponse(batch, args.Header().CmdID, reply, rErr); err != nil {
+		if err := r.respCache.PutResponse(batch, args.Header().CmdID, proto.ResponseWithError{reply, rErr}); err != nil {
 			log.Fatalc(ctx, "putting a response cache entry in a batch should never fail: %s", err)
 		}
 	}

--- a/storage/range_command.go
+++ b/storage/range_command.go
@@ -37,8 +37,8 @@ import (
 )
 
 // executeCmd switches over the method and multiplexes to execute the
-// appropriate storage API command. It returns an error and, for some calls
-// such as inconsistent reads, the intents they skipped.
+// appropriate storage API command. It returns the response, an error,
+// and a slice of intents that were skipped during execution.
 func (r *Range) executeCmd(batch engine.Engine, ms *engine.MVCCStats, args proto.Request) (proto.Response, []proto.Intent, error) {
 	// Verify key is contained within range here to catch any range split
 	// or merge activity.

--- a/storage/range_command.go
+++ b/storage/range_command.go
@@ -61,71 +61,71 @@ func (r *Range) executeCmd(batch engine.Engine, ms *engine.MVCCStats, args proto
 	switch tArgs := args.(type) {
 	case *proto.GetRequest:
 		var resp proto.GetResponse
-		resp, intents, err = r.Get(batch, tArgs)
+		resp, intents, err = r.Get(batch, *tArgs)
 		reply = &resp
 	case *proto.PutRequest:
 		var resp proto.PutResponse
-		resp, err = r.Put(batch, ms, tArgs)
+		resp, err = r.Put(batch, ms, *tArgs)
 		reply = &resp
 	case *proto.ConditionalPutRequest:
 		var resp proto.ConditionalPutResponse
-		resp, err = r.ConditionalPut(batch, ms, tArgs)
+		resp, err = r.ConditionalPut(batch, ms, *tArgs)
 		reply = &resp
 	case *proto.IncrementRequest:
 		var resp proto.IncrementResponse
-		resp, err = r.Increment(batch, ms, tArgs)
+		resp, err = r.Increment(batch, ms, *tArgs)
 		reply = &resp
 	case *proto.DeleteRequest:
 		var resp proto.DeleteResponse
-		resp, err = r.Delete(batch, ms, tArgs)
+		resp, err = r.Delete(batch, ms, *tArgs)
 		reply = &resp
 	case *proto.DeleteRangeRequest:
 		var resp proto.DeleteRangeResponse
-		resp, err = r.DeleteRange(batch, ms, tArgs)
+		resp, err = r.DeleteRange(batch, ms, *tArgs)
 		reply = &resp
 	case *proto.ScanRequest:
 		var resp proto.ScanResponse
-		resp, intents, err = r.Scan(batch, tArgs)
+		resp, intents, err = r.Scan(batch, *tArgs)
 		reply = &resp
 	case *proto.EndTransactionRequest:
 		var resp proto.EndTransactionResponse
-		resp, err = r.EndTransaction(batch, ms, tArgs)
+		resp, err = r.EndTransaction(batch, ms, *tArgs)
 		reply = &resp
 	case *proto.InternalRangeLookupRequest:
 		var resp proto.InternalRangeLookupResponse
-		resp, intents, err = r.InternalRangeLookup(batch, tArgs)
+		resp, intents, err = r.InternalRangeLookup(batch, *tArgs)
 		reply = &resp
 	case *proto.InternalHeartbeatTxnRequest:
 		var resp proto.InternalHeartbeatTxnResponse
-		resp, err = r.InternalHeartbeatTxn(batch, ms, tArgs)
+		resp, err = r.InternalHeartbeatTxn(batch, ms, *tArgs)
 		reply = &resp
 	case *proto.InternalGCRequest:
 		var resp proto.InternalGCResponse
-		resp, err = r.InternalGC(batch, ms, tArgs)
+		resp, err = r.InternalGC(batch, ms, *tArgs)
 		reply = &resp
 	case *proto.InternalPushTxnRequest:
 		var resp proto.InternalPushTxnResponse
-		resp, err = r.InternalPushTxn(batch, ms, tArgs)
+		resp, err = r.InternalPushTxn(batch, ms, *tArgs)
 		reply = &resp
 	case *proto.InternalResolveIntentRequest:
 		var resp proto.InternalResolveIntentResponse
-		resp, err = r.InternalResolveIntent(batch, ms, tArgs)
+		resp, err = r.InternalResolveIntent(batch, ms, *tArgs)
 		reply = &resp
 	case *proto.InternalResolveIntentRangeRequest:
 		var resp proto.InternalResolveIntentRangeResponse
-		resp, err = r.InternalResolveIntentRange(batch, ms, tArgs)
+		resp, err = r.InternalResolveIntentRange(batch, ms, *tArgs)
 		reply = &resp
 	case *proto.InternalMergeRequest:
 		var resp proto.InternalMergeResponse
-		resp, err = r.InternalMerge(batch, ms, tArgs)
+		resp, err = r.InternalMerge(batch, ms, *tArgs)
 		reply = &resp
 	case *proto.InternalTruncateLogRequest:
 		var resp proto.InternalTruncateLogResponse
-		resp, err = r.InternalTruncateLog(batch, ms, tArgs)
+		resp, err = r.InternalTruncateLog(batch, ms, *tArgs)
 		reply = &resp
 	case *proto.InternalLeaderLeaseRequest:
 		var resp proto.InternalLeaderLeaseResponse
-		resp, err = r.InternalLeaderLease(batch, ms, tArgs)
+		resp, err = r.InternalLeaderLease(batch, ms, *tArgs)
 		reply = &resp
 	default:
 		err = util.Errorf("unrecognized command %s", args.Method())
@@ -164,7 +164,7 @@ func (r *Range) executeCmd(batch engine.Engine, ms *engine.MVCCStats, args proto
 }
 
 // Get returns the value for a specified key.
-func (r *Range) Get(batch engine.Engine, args *proto.GetRequest) (proto.GetResponse, []proto.Intent, error) {
+func (r *Range) Get(batch engine.Engine, args proto.GetRequest) (proto.GetResponse, []proto.Intent, error) {
 	var reply proto.GetResponse
 
 	val, intents, err := engine.MVCCGet(batch, args.Key, args.Timestamp, args.ReadConsistency == proto.CONSISTENT, args.Txn)
@@ -173,7 +173,7 @@ func (r *Range) Get(batch engine.Engine, args *proto.GetRequest) (proto.GetRespo
 }
 
 // Put sets the value for a specified key.
-func (r *Range) Put(batch engine.Engine, ms *engine.MVCCStats, args *proto.PutRequest) (proto.PutResponse, error) {
+func (r *Range) Put(batch engine.Engine, ms *engine.MVCCStats, args proto.PutRequest) (proto.PutResponse, error) {
 	var reply proto.PutResponse
 
 	return reply, engine.MVCCPut(batch, ms, args.Key, args.Timestamp, args.Value, args.Txn)
@@ -182,7 +182,7 @@ func (r *Range) Put(batch engine.Engine, ms *engine.MVCCStats, args *proto.PutRe
 // ConditionalPut sets the value for a specified key only if
 // the expected value matches. If not, the return value contains
 // the actual value.
-func (r *Range) ConditionalPut(batch engine.Engine, ms *engine.MVCCStats, args *proto.ConditionalPutRequest) (proto.ConditionalPutResponse, error) {
+func (r *Range) ConditionalPut(batch engine.Engine, ms *engine.MVCCStats, args proto.ConditionalPutRequest) (proto.ConditionalPutResponse, error) {
 	var reply proto.ConditionalPutResponse
 
 	return reply, engine.MVCCConditionalPut(batch, ms, args.Key, args.Timestamp, args.Value, args.ExpValue, args.Txn)
@@ -191,7 +191,7 @@ func (r *Range) ConditionalPut(batch engine.Engine, ms *engine.MVCCStats, args *
 // Increment increments the value (interpreted as varint64 encoded) and
 // returns the newly incremented value (encoded as varint64). If no value
 // exists for the key, zero is incremented.
-func (r *Range) Increment(batch engine.Engine, ms *engine.MVCCStats, args *proto.IncrementRequest) (proto.IncrementResponse, error) {
+func (r *Range) Increment(batch engine.Engine, ms *engine.MVCCStats, args proto.IncrementRequest) (proto.IncrementResponse, error) {
 	var reply proto.IncrementResponse
 
 	newVal, err := engine.MVCCIncrement(batch, ms, args.Key, args.Timestamp, args.Txn, args.Increment)
@@ -200,7 +200,7 @@ func (r *Range) Increment(batch engine.Engine, ms *engine.MVCCStats, args *proto
 }
 
 // Delete deletes the key and value specified by key.
-func (r *Range) Delete(batch engine.Engine, ms *engine.MVCCStats, args *proto.DeleteRequest) (proto.DeleteResponse, error) {
+func (r *Range) Delete(batch engine.Engine, ms *engine.MVCCStats, args proto.DeleteRequest) (proto.DeleteResponse, error) {
 	var reply proto.DeleteResponse
 
 	return reply, engine.MVCCDelete(batch, ms, args.Key, args.Timestamp, args.Txn)
@@ -208,7 +208,7 @@ func (r *Range) Delete(batch engine.Engine, ms *engine.MVCCStats, args *proto.De
 
 // DeleteRange deletes the range of key/value pairs specified by
 // start and end keys.
-func (r *Range) DeleteRange(batch engine.Engine, ms *engine.MVCCStats, args *proto.DeleteRangeRequest) (proto.DeleteRangeResponse, error) {
+func (r *Range) DeleteRange(batch engine.Engine, ms *engine.MVCCStats, args proto.DeleteRangeRequest) (proto.DeleteRangeResponse, error) {
 	var reply proto.DeleteRangeResponse
 
 	numDel, err := engine.MVCCDeleteRange(batch, ms, args.Key, args.EndKey, args.MaxEntriesToDelete, args.Timestamp, args.Txn)
@@ -219,7 +219,7 @@ func (r *Range) DeleteRange(batch engine.Engine, ms *engine.MVCCStats, args *pro
 // Scan scans the key range specified by start key through end key up
 // to some maximum number of results. The last key of the iteration is
 // returned with the reply.
-func (r *Range) Scan(batch engine.Engine, args *proto.ScanRequest) (proto.ScanResponse, []proto.Intent, error) {
+func (r *Range) Scan(batch engine.Engine, args proto.ScanRequest) (proto.ScanResponse, []proto.Intent, error) {
 	var reply proto.ScanResponse
 
 	rows, intents, err := engine.MVCCScan(batch, args.Key, args.EndKey, args.MaxResults, args.Timestamp, args.ReadConsistency == proto.CONSISTENT, args.Txn)
@@ -229,7 +229,7 @@ func (r *Range) Scan(batch engine.Engine, args *proto.ScanRequest) (proto.ScanRe
 
 // EndTransaction either commits or aborts (rolls back) an extant
 // transaction according to the args.Commit parameter.
-func (r *Range) EndTransaction(batch engine.Engine, ms *engine.MVCCStats, args *proto.EndTransactionRequest) (proto.EndTransactionResponse, error) {
+func (r *Range) EndTransaction(batch engine.Engine, ms *engine.MVCCStats, args proto.EndTransactionRequest) (proto.EndTransactionResponse, error) {
 	var reply proto.EndTransactionResponse
 
 	if args.Txn == nil {
@@ -374,7 +374,7 @@ func (r *Range) EndTransaction(batch engine.Engine, ms *engine.MVCCStats, args *
 // RangeDescriptor. This is intended to serve as a sort of caching pre-fetch,
 // so that the requesting nodes can aggressively cache RangeDescriptors which
 // are likely to be desired by their current workload.
-func (r *Range) InternalRangeLookup(batch engine.Engine, args *proto.InternalRangeLookupRequest) (proto.InternalRangeLookupResponse, []proto.Intent, error) {
+func (r *Range) InternalRangeLookup(batch engine.Engine, args proto.InternalRangeLookupRequest) (proto.InternalRangeLookupResponse, []proto.Intent, error) {
 	var reply proto.InternalRangeLookupResponse
 
 	if err := keys.ValidateRangeMetaKey(args.Key); err != nil {
@@ -464,7 +464,7 @@ func (r *Range) InternalRangeLookup(batch engine.Engine, args *proto.InternalRan
 // InternalHeartbeatTxn updates the transaction status and heartbeat
 // timestamp after receiving transaction heartbeat messages from
 // coordinator. Returns the updated transaction.
-func (r *Range) InternalHeartbeatTxn(batch engine.Engine, ms *engine.MVCCStats, args *proto.InternalHeartbeatTxnRequest) (proto.InternalHeartbeatTxnResponse, error) {
+func (r *Range) InternalHeartbeatTxn(batch engine.Engine, ms *engine.MVCCStats, args proto.InternalHeartbeatTxnRequest) (proto.InternalHeartbeatTxnResponse, error) {
 	var reply proto.InternalHeartbeatTxnResponse
 
 	key := keys.TransactionKey(args.Txn.Key, args.Txn.ID)
@@ -498,7 +498,7 @@ func (r *Range) InternalHeartbeatTxn(batch engine.Engine, ms *engine.MVCCStats, 
 // specified in the arguments. MVCCGarbageCollect is invoked on each
 // listed key along with the expiration timestamp. The GC metadata
 // specified in the args is persisted after GC.
-func (r *Range) InternalGC(batch engine.Engine, ms *engine.MVCCStats, args *proto.InternalGCRequest) (proto.InternalGCResponse, error) {
+func (r *Range) InternalGC(batch engine.Engine, ms *engine.MVCCStats, args proto.InternalGCRequest) (proto.InternalGCResponse, error) {
 	var reply proto.InternalGCResponse
 
 	// Garbage collect the specified keys by expiration timestamps.
@@ -548,7 +548,7 @@ func (r *Range) InternalGC(batch engine.Engine, ms *engine.MVCCStats, args *prot
 // Higher Txn Priority: If pushee txn has a higher priority than
 // pusher, return TransactionPushError. Transaction will be retried
 // with priority one less than the pushee's higher priority.
-func (r *Range) InternalPushTxn(batch engine.Engine, ms *engine.MVCCStats, args *proto.InternalPushTxnRequest) (proto.InternalPushTxnResponse, error) {
+func (r *Range) InternalPushTxn(batch engine.Engine, ms *engine.MVCCStats, args proto.InternalPushTxnRequest) (proto.InternalPushTxnResponse, error) {
 	var reply proto.InternalPushTxnResponse
 
 	if !bytes.Equal(args.Key, args.PusheeTxn.Key) {
@@ -681,7 +681,7 @@ func (r *Range) InternalPushTxn(batch engine.Engine, ms *engine.MVCCStats, args 
 
 // InternalResolveIntent resolves a write intent from the specified key
 // according to the status of the transaction which created it.
-func (r *Range) InternalResolveIntent(batch engine.Engine, ms *engine.MVCCStats, args *proto.InternalResolveIntentRequest) (proto.InternalResolveIntentResponse, error) {
+func (r *Range) InternalResolveIntent(batch engine.Engine, ms *engine.MVCCStats, args proto.InternalResolveIntentRequest) (proto.InternalResolveIntentResponse, error) {
 	var reply proto.InternalResolveIntentResponse
 
 	if args.Txn == nil {
@@ -696,7 +696,7 @@ func (r *Range) InternalResolveIntent(batch engine.Engine, ms *engine.MVCCStats,
 // InternalResolveIntentRange resolves write intents in the specified
 // key range according to the status of the transaction which created it.
 func (r *Range) InternalResolveIntentRange(batch engine.Engine, ms *engine.MVCCStats,
-	args *proto.InternalResolveIntentRangeRequest) (proto.InternalResolveIntentRangeResponse, error) {
+	args proto.InternalResolveIntentRangeRequest) (proto.InternalResolveIntentRangeResponse, error) {
 	var reply proto.InternalResolveIntentRangeResponse
 
 	if args.Txn == nil {
@@ -711,14 +711,14 @@ func (r *Range) InternalResolveIntentRange(batch engine.Engine, ms *engine.MVCCS
 // Cockroach for the efficient accumulation of certain values. Due to the
 // difficulty of making these operations transactional, merges are not currently
 // exposed directly to clients. Merged values are explicitly not MVCC data.
-func (r *Range) InternalMerge(batch engine.Engine, ms *engine.MVCCStats, args *proto.InternalMergeRequest) (proto.InternalMergeResponse, error) {
+func (r *Range) InternalMerge(batch engine.Engine, ms *engine.MVCCStats, args proto.InternalMergeRequest) (proto.InternalMergeResponse, error) {
 	var reply proto.InternalMergeResponse
 
 	return reply, engine.MVCCMerge(batch, ms, args.Key, args.Value)
 }
 
 // InternalTruncateLog discards a prefix of the raft log.
-func (r *Range) InternalTruncateLog(batch engine.Engine, ms *engine.MVCCStats, args *proto.InternalTruncateLogRequest) (proto.InternalTruncateLogResponse, error) {
+func (r *Range) InternalTruncateLog(batch engine.Engine, ms *engine.MVCCStats, args proto.InternalTruncateLogRequest) (proto.InternalTruncateLogResponse, error) {
 	var reply proto.InternalTruncateLogResponse
 
 	// args.Index is the first index to keep.
@@ -749,7 +749,7 @@ func (r *Range) InternalTruncateLog(batch engine.Engine, ms *engine.MVCCStats, a
 // holder, the expiration will be extended or shortened as indicated. For a new
 // lease, all duties required of the range leader are commenced, including
 // clearing the command queue and timestamp cache.
-func (r *Range) InternalLeaderLease(batch engine.Engine, ms *engine.MVCCStats, args *proto.InternalLeaderLeaseRequest) (proto.InternalLeaderLeaseResponse, error) {
+func (r *Range) InternalLeaderLease(batch engine.Engine, ms *engine.MVCCStats, args proto.InternalLeaderLeaseRequest) (proto.InternalLeaderLeaseResponse, error) {
 	var reply proto.InternalLeaderLeaseResponse
 
 	r.Lock()
@@ -834,7 +834,7 @@ func (r *Range) InternalLeaderLease(batch engine.Engine, ms *engine.MVCCStats, a
 // updates the range addressing metadata. The handover of responsibility for
 // the reassigned key range is carried out seamlessly through a split trigger
 // carried out as part of the commit of that transaction.
-func (r *Range) AdminSplit(args *proto.AdminSplitRequest) (proto.AdminSplitResponse, error) {
+func (r *Range) AdminSplit(args proto.AdminSplitRequest) (proto.AdminSplitResponse, error) {
 	var reply proto.AdminSplitResponse
 
 	// Only allow a single split per range at a time.
@@ -1022,7 +1022,7 @@ func (r *Range) splitTrigger(batch engine.Engine, split *proto.SplitTrigger) err
 // the reassigned key range is carried out seamlessly through a merge trigger
 // carried out as part of the commit of that transaction.
 // A merge requires that the two ranges are collocate on the same set of replicas.
-func (r *Range) AdminMerge(args *proto.AdminMergeRequest) (proto.AdminMergeResponse, error) {
+func (r *Range) AdminMerge(args proto.AdminMergeRequest) (proto.AdminMergeResponse, error) {
 	var reply proto.AdminMergeResponse
 
 	// Only allow a single split/merge per range at a time.

--- a/storage/range_test.go
+++ b/storage/range_test.go
@@ -285,7 +285,7 @@ func setLeaderLease(t *testing.T, r *Range, l *proto.Lease) {
 	var err error
 	if err = <-errChan; err == nil {
 		// Next if the command was committed, wait for the range to apply it.
-		err = (<-pendingCmd.done).err
+		err = (<-pendingCmd.done).Err
 	}
 	if err != nil {
 		t.Errorf("failed to set lease: %s", err)
@@ -376,7 +376,7 @@ func TestApplyCmdLeaseError(t *testing.T) {
 	if err := <-errChan; err != nil {
 		t.Fatal(err)
 	}
-	if err := (<-pendingCmd.done).err; err == nil {
+	if err := (<-pendingCmd.done).Err; err == nil {
 		t.Fatalf("expected an error")
 	} else if _, ok := err.(*proto.NotLeaderError); !ok {
 		t.Fatalf("expected not leader error in return, got %s", err)
@@ -1535,7 +1535,7 @@ func TestRangeResponseCacheStoredError(t *testing.T) {
 	pastReply := proto.IncrementResponse{}
 	pastError := errors.New("boom")
 	var expError error = &proto.Error{Message: pastError.Error()}
-	_ = tc.rng.respCache.PutResponse(tc.engine, cmdID, &pastReply, pastError)
+	_ = tc.rng.respCache.PutResponse(tc.engine, cmdID, proto.ResponseWithError{&pastReply, pastError})
 
 	args := incrementArgs([]byte("a"), 1, 1, tc.store.StoreID())
 	args.CmdID = cmdID

--- a/storage/response_cache.go
+++ b/storage/response_cache.go
@@ -19,13 +19,13 @@ package storage
 
 import (
 	"bytes"
+	"fmt"
 
 	"github.com/cockroachdb/cockroach/keys"
 	"github.com/cockroachdb/cockroach/proto"
 	"github.com/cockroachdb/cockroach/storage/engine"
 	"github.com/cockroachdb/cockroach/util"
 	"github.com/cockroachdb/cockroach/util/encoding"
-	"github.com/cockroachdb/cockroach/util/log"
 	gogoproto "github.com/gogo/protobuf/proto"
 )
 
@@ -72,26 +72,31 @@ func (rc *ResponseCache) ClearData(e engine.Engine) error {
 	return err
 }
 
-// GetResponse looks up a response matching the specified cmdID and
-// returns true if found. The response is deserialized into the
-// supplied reply parameter. If no response is found, returns
-// false. If a command is pending already for the cmdID, then this
-// method will block until the the command is completed or the
-// response cache is cleared.
-func (rc *ResponseCache) GetResponse(e engine.Engine, cmdID proto.ClientCmdID) (proto.Response, error) {
+// GetResponse looks up a response matching the specified cmdID. If the
+// response is found, it is returned along with its associated error.
+// If the response is not found, nil is returned for both the response
+// and its error. In all cases, the third return value is the error
+// returned from the engine when reading the on-disk cache.
+func (rc *ResponseCache) GetResponse(e engine.Engine, cmdID proto.ClientCmdID) (proto.Response, error, error) {
 	// Do nothing if command ID is empty.
 	if cmdID.IsEmpty() {
-		return nil, nil
+		return nil, nil, nil
 	}
 
 	// Pull response from the cache and read into reply if available.
-	rwResp := proto.ReadWriteCmdResponse{}
+	var rwResp proto.ReadWriteCmdResponse
 	key := keys.ResponseCacheKey(rc.raftID, &cmdID)
 	ok, err := engine.MVCCGetProto(e, key, proto.ZeroTimestamp, true, nil, &rwResp)
-	if ok && err == nil {
-		return rwResp.GetValue().(proto.Response), nil
+	if err != nil {
+		return nil, nil, err
 	}
-	return nil, err
+	if ok {
+		resp := rwResp.GetValue().(proto.Response)
+		header := resp.Header()
+		defer func() { header.Error = nil }()
+		return resp, header.GoError(), nil
+	}
+	return nil, nil, nil
 }
 
 // CopyInto copies all the cached results from this response cache
@@ -158,32 +163,43 @@ func (rc *ResponseCache) CopyFrom(e engine.Engine, originRaftID proto.RaftID) er
 	})
 }
 
-// PutResponse writes a response to the cache for the specified cmdID.
-func (rc *ResponseCache) PutResponse(e engine.Engine, cmdID proto.ClientCmdID, reply proto.Response) error {
+// PutResponse writes a response and an error associated with it to the
+// cache for the specified cmdID.
+func (rc *ResponseCache) PutResponse(e engine.Engine, cmdID proto.ClientCmdID, reply proto.Response, replyErr error) error {
 	// Do nothing if command ID is empty.
 	if cmdID.IsEmpty() {
 		return nil
 	}
+
 	// Write the response value to the engine.
-	var err error
-	if rc.shouldCacheResponse(reply) {
+	if rc.shouldCacheResponse(reply, replyErr) {
+		// Write the error into the reply before caching.
+		header := reply.Header()
+		header.SetGoError(replyErr)
+		// Be sure to clear it when you're done!
+		defer func() { header.Error = nil }()
+
 		key := keys.ResponseCacheKey(rc.raftID, &cmdID)
-		rwResp := &proto.ReadWriteCmdResponse{}
+		var rwResp proto.ReadWriteCmdResponse
 		if !rwResp.SetValue(reply) {
-			log.Fatalf("response %T not supported by response cache", reply)
+			panic(fmt.Sprintf("response %T not supported by response cache", reply))
 		}
-		err = engine.MVCCPutProto(e, nil, key, proto.ZeroTimestamp, nil, rwResp)
+		return engine.MVCCPutProto(e, nil, key, proto.ZeroTimestamp, nil, &rwResp)
 	}
 
-	return err
+	return nil
 }
 
 // shouldCacheResponse returns whether the response should be cached.
 // Responses with write-too-old, write-intent and not leader errors
 // are retried on the server, and so are not recorded in the response
 // cache in the hopes of retrying to a successful outcome.
-func (rc *ResponseCache) shouldCacheResponse(reply proto.Response) bool {
-	switch reply.Header().GoError().(type) {
+func (rc *ResponseCache) shouldCacheResponse(reply proto.Response, replyErr error) bool {
+	if err := reply.Header().Error; err != nil {
+		panic(proto.ErrorUnexpectedlySet)
+	}
+
+	switch replyErr.(type) {
 	case *proto.WriteTooOldError, *proto.WriteIntentError, *proto.NotLeaderError:
 		return false
 	}

--- a/storage/response_cache_test.go
+++ b/storage/response_cache_test.go
@@ -50,23 +50,29 @@ func TestResponseCachePutGetClearData(t *testing.T) {
 	rc, e := createTestResponseCache(t, 1)
 	cmdID := makeCmdID(1, 1)
 	// Start with a get for an unseen cmdID.
-	if val, err := rc.GetResponse(e, cmdID); val != nil || err != nil {
-		t.Errorf("expected no response for id %+v; got %+v, %v", cmdID, val, err)
+	if val, err, corruptionErr := rc.GetResponse(e, cmdID); val != nil || err != nil {
+		t.Errorf("expected no response for id %+v; got %+v, %s", cmdID, val, err)
+	} else if corruptionErr != nil {
+		t.Fatalf("unxpected corruption error :%s", corruptionErr)
 	}
 	// Put value of 1 for test response.
-	if err := rc.PutResponse(e, cmdID, &incR); err != nil {
-		t.Errorf("unexpected error putting response: %v", err)
+	if err := rc.PutResponse(e, cmdID, &incR, nil); err != nil {
+		t.Errorf("unexpected error putting response: %s", err)
 	}
 	// Get should now return 1.
-	if val, err := rc.GetResponse(e, cmdID); val == nil || err != nil || val.(*proto.IncrementResponse).NewValue != 1 {
-		t.Errorf("unexpected failure getting response: %v, %+v", err, val)
+	if val, err, corruptionErr := rc.GetResponse(e, cmdID); corruptionErr != nil {
+		t.Errorf("unexpected failure getting response: %s", corruptionErr)
+	} else if val == nil || val.(*proto.IncrementResponse).NewValue != 1 || err != nil {
+		t.Errorf("unexpected response: %s, %s", val, err)
 	}
 	if err := rc.ClearData(e); err != nil {
 		t.Error(err)
 	}
 	// The previously present response should be gone.
-	if val, err := rc.GetResponse(e, cmdID); val != nil {
-		t.Errorf("unexpected success getting response: %v, %+v", err, val)
+	if val, err, corruptionErr := rc.GetResponse(e, cmdID); val != nil || err != nil {
+		t.Errorf("unexpected success getting response: %s, %+v", err, val)
+	} else if corruptionErr != nil {
+		t.Fatalf("unxpected corruption error :%s", corruptionErr)
 	}
 }
 
@@ -77,12 +83,14 @@ func TestResponseCacheEmptyCmdID(t *testing.T) {
 	rc, e := createTestResponseCache(t, 1)
 	cmdID := proto.ClientCmdID{}
 	// Put value of 1 for test response.
-	if err := rc.PutResponse(e, cmdID, &incR); err != nil {
-		t.Errorf("unexpected error putting response: %v", err)
+	if err := rc.PutResponse(e, cmdID, &incR, nil); err != nil {
+		t.Errorf("unexpected error putting response: %s", err)
 	}
 	// Get should return !ok.
-	if val, err := rc.GetResponse(e, cmdID); val != nil || err != nil {
-		t.Errorf("unexpected success getting response: %v, %v, %+v", err, val)
+	if val, err, corruptionErr := rc.GetResponse(e, cmdID); val != nil || err != nil {
+		t.Errorf("unexpected success getting response: %s, %+v", err, val)
+	} else if corruptionErr != nil {
+		t.Fatalf("unxpected corruption error :%s", corruptionErr)
 	}
 }
 
@@ -94,19 +102,23 @@ func TestResponseCacheCopyInto(t *testing.T) {
 	rc2, _ := createTestResponseCache(t, 2)
 	cmdID := makeCmdID(1, 1)
 	// Store an increment with new value one in the first cache.
-	if err := rc1.PutResponse(e, cmdID, &incR); err != nil {
-		t.Errorf("unexpected error putting response: %v", err)
+	if err := rc1.PutResponse(e, cmdID, &incR, nil); err != nil {
+		t.Errorf("unexpected error putting response: %s", err)
 	}
 	// Copy the first cache into the second.
 	if err := rc1.CopyInto(e, rc2.raftID); err != nil {
-		t.Errorf("unexpected error while copying response cache: %v", err)
+		t.Errorf("unexpected error while copying response cache: %s", err)
 	}
 	// Get should return 1 for both caches.
-	if val, err := rc1.GetResponse(e, cmdID); val == nil || err != nil || val.(*proto.IncrementResponse).NewValue != 1 {
-		t.Errorf("unexpected failure getting response from source: %v, %+v", err, val)
+	if val, err, corruptionErr := rc1.GetResponse(e, cmdID); val == nil && err == nil || val.(*proto.IncrementResponse).NewValue != 1 {
+		t.Errorf("unexpected failure getting response from source: %s, %+v", err, val)
+	} else if corruptionErr != nil {
+		t.Fatalf("unxpected corruption error :%s", corruptionErr)
 	}
-	if val, err := rc2.GetResponse(e, cmdID); val == nil || err != nil || val.(*proto.IncrementResponse).NewValue != 1 {
-		t.Errorf("unexpected failure getting response from destination: %v, %+v", err, val)
+	if val, err, corruptionErr := rc2.GetResponse(e, cmdID); val == nil && err == nil || val.(*proto.IncrementResponse).NewValue != 1 {
+		t.Errorf("unexpected failure getting response from destination: %s, %+v", err, val)
+	} else if corruptionErr != nil {
+		t.Fatalf("unxpected corruption error :%s", corruptionErr)
 	}
 }
 
@@ -118,21 +130,25 @@ func TestResponseCacheCopyFrom(t *testing.T) {
 	rc2, _ := createTestResponseCache(t, 2)
 	cmdID := makeCmdID(1, 1)
 	// Store an increment with new value one in the first cache.
-	if err := rc1.PutResponse(e, cmdID, &incR); err != nil {
-		t.Errorf("unexpected error putting response: %v", err)
+	if err := rc1.PutResponse(e, cmdID, &incR, nil); err != nil {
+		t.Errorf("unexpected error putting response: %s", err)
 	}
 
 	// Copy the first cache into the second.
 	if err := rc2.CopyFrom(e, rc1.raftID); err != nil {
-		t.Errorf("unexpected error while copying response cache: %v", err)
+		t.Errorf("unexpected error while copying response cache: %s", err)
 	}
 
 	// Get should return 1 for both caches.
-	if val, err := rc1.GetResponse(e, cmdID); val == nil || err != nil || val.(*proto.IncrementResponse).NewValue != 1 {
-		t.Errorf("unexpected failure getting response from source: %v, %+v", err, val)
+	if val, err, corruptionErr := rc1.GetResponse(e, cmdID); val == nil && err == nil || val.(*proto.IncrementResponse).NewValue != 1 {
+		t.Errorf("unexpected failure getting response from source: %s, %+v", err, val)
+	} else if corruptionErr != nil {
+		t.Fatalf("unxpected corruption error :%s", corruptionErr)
 	}
-	if val, err := rc2.GetResponse(e, cmdID); val == nil || err != nil || val.(*proto.IncrementResponse).NewValue != 1 {
-		t.Errorf("unexpected failure getting response from source: %v, %+v", err, val)
+	if val, err, corruptionErr := rc2.GetResponse(e, cmdID); val == nil && err == nil || val.(*proto.IncrementResponse).NewValue != 1 {
+		t.Errorf("unexpected failure getting response from source: %s, %+v", err, val)
+	} else if corruptionErr != nil {
+		t.Fatalf("unxpected corruption error :%s", corruptionErr)
 	}
 }
 
@@ -143,16 +159,20 @@ func TestResponseCacheInflight(t *testing.T) {
 	rc, e := createTestResponseCache(t, 1)
 	cmdID := makeCmdID(1, 1)
 	// Add inflight for cmdID.
-	if val, err := rc.GetResponse(e, cmdID); val != nil || err != nil {
-		t.Errorf("unexpected response or error: %v", err)
+	if val, err, corruptionErr := rc.GetResponse(e, cmdID); val != nil || err != nil {
+		t.Errorf("unexpected response or error: %s", err)
+	} else if corruptionErr != nil {
+		t.Fatalf("unxpected corruption error :%s", corruptionErr)
 	}
 	// Make two requests for response from cmdID, which is inflight.
 	doneChans := []chan struct{}{make(chan struct{}), make(chan struct{})}
 	for _, done := range doneChans {
 		doneChan := done
 		go func() {
-			if val, err := rc.GetResponse(e, cmdID); val != nil || err != nil {
+			if val, err, corruptionErr := rc.GetResponse(e, cmdID); val != nil || err != nil {
 				t.Errorf("unexpectedly found value for response cache entry %+v: %s", cmdID, err)
+			} else if corruptionErr != nil {
+				t.Fatalf("unxpected corruption error :%s", corruptionErr)
 			}
 			close(doneChan)
 		}()
@@ -193,10 +213,10 @@ func TestResponseCacheShouldCache(t *testing.T) {
 		{&proto.NotLeaderError{}, false},
 	}
 
+	reply := proto.PutResponse{}
+
 	for i, test := range testCases {
-		reply := &proto.PutResponse{}
-		reply.SetGoError(test.err)
-		if shouldCache := rc.shouldCacheResponse(reply); shouldCache != test.shouldCache {
+		if shouldCache := rc.shouldCacheResponse(&reply, test.err); shouldCache != test.shouldCache {
 			t.Errorf("%d: expected cache? %t; got %t", i, test.shouldCache, shouldCache)
 		}
 	}
@@ -215,19 +235,23 @@ func TestResponseCacheGC(t *testing.T) {
 	// Add response for cmdID with timestamp at time=1ns.
 	copyIncR := incR
 	copyIncR.Timestamp.WallTime = 1
-	if err := rc.PutResponse(eng, cmdID, &copyIncR); err != nil {
-		t.Fatalf("unexpected error putting responpse: %v", err)
+	if err := rc.PutResponse(eng, cmdID, &copyIncR, nil); err != nil {
+		t.Fatalf("unexpected error putting responpse: %s", err)
 	}
 	eng.SetGCTimeouts(0, 0) // avoids GC
 	eng.CompactRange(nil, nil)
-	if val, err := rc.GetResponse(eng, cmdID); val == nil || err != nil || val.(*proto.IncrementResponse).NewValue != 1 {
-		t.Fatalf("unexpected response or error: %v, %+v", err, val)
+	if val, err, corruptionErr := rc.GetResponse(eng, cmdID); val == nil && err == nil || val.(*proto.IncrementResponse).NewValue != 1 {
+		t.Fatalf("unexpected response or error: %s, %+v", err, val)
+	} else if corruptionErr != nil {
+		t.Fatalf("unxpected corruption error :%s", corruptionErr)
 	}
 
 	// Now set minRCacheTS to 1, which will GC.
 	eng.SetGCTimeouts(0, 1)
 	eng.CompactRange(nil, nil)
-	if val, err := rc.GetResponse(eng, cmdID); val != nil || err != nil {
-		t.Errorf("unexpected response or error: %v", err)
+	if val, err, corruptionErr := rc.GetResponse(eng, cmdID); val != nil && err != nil {
+		t.Fatalf("unexpected response or error: %s, %+v", err, val)
+	} else if corruptionErr != nil {
+		t.Fatalf("unxpected corruption error :%s", corruptionErr)
 	}
 }

--- a/storage/store.go
+++ b/storage/store.go
@@ -1258,10 +1258,10 @@ func (s *Store) ExecuteCmd(ctx context.Context, call proto.Call) error {
 		if addedReply != nil {
 			gogoproto.Merge(reply, addedReply)
 		}
+		if reply.Header().Error != nil {
+			panic(proto.ErrorUnexpectedlySet)
+		}
 		if err != nil {
-			if reply.Header().Error != nil {
-				panic("the world is on fire")
-			}
 			reply.Header().SetGoError(err)
 		}
 


### PR DESCRIPTION
@tschottdorf the last two commits could possibly be replaced with the old `gogoproto.Clone` of the transaction; I don't feel very strongly but I do like that this is slightly safer.
