### PR TITLE
requestLeaderLease should convert GroupDeleteError to RangeNotFoundError

### DIFF
--- a/storage/range.go
+++ b/storage/range.go
@@ -35,7 +35,6 @@ import (
 	"github.com/cockroachdb/cockroach/client"
 	"github.com/cockroachdb/cockroach/gossip"
 	"github.com/cockroachdb/cockroach/keys"
-	"github.com/cockroachdb/cockroach/multiraft"
 	"github.com/cockroachdb/cockroach/proto"
 	"github.com/cockroachdb/cockroach/storage/engine"
 	"github.com/cockroachdb/cockroach/util"
@@ -733,11 +732,8 @@ func (r *Range) addWriteCmd(ctx context.Context, args proto.Request, wg *sync.Wa
 		// Next if the command was committed, wait for the range to apply it.
 		respWithErr := <-pendingCmd.done
 		reply, err = respWithErr.Reply, respWithErr.Err
-	} else if err == multiraft.ErrGroupDeleted {
-		// This error needs to be converted appropriately so that
-		// clients will retry.
-		err = proto.NewRangeNotFoundError(r.Desc().RaftID)
 	}
+
 	// As for reads, update timestamp cache with the timestamp
 	// of this write on success. This ensures a strictly higher
 	// timestamp for successive writes to the same key or key range.

--- a/storage/store.go
+++ b/storage/store.go
@@ -1253,6 +1253,10 @@ func (s *Store) ExecuteCmd(ctx context.Context, args proto.Request) (proto.Respo
 		reply, err = rng.AddCmd(ctx, args)
 		if err == nil {
 			return reply, nil
+		} else if err == multiraft.ErrGroupDeleted {
+			// This error needs to be converted appropriately so that
+			// clients will retry.
+			err = proto.NewRangeNotFoundError(rng.Desc().RaftID)
 		}
 
 		// Maybe resolve a potential write intent error. We do this here


### PR DESCRIPTION
Clients will not retry for a GroupDeleteError.
