### PR TITLE
Return (response, error) #4

### DIFF
--- a/storage/client_test.go
+++ b/storage/client_test.go
@@ -345,22 +345,20 @@ func (m *multiTestContext) unreplicateRange(raftID proto.RaftID, source, dest in
 
 // getArgs returns a GetRequest and GetResponse pair addressed to
 // the default replica for the specified key.
-func getArgs(key []byte, raftID proto.RaftID, storeID proto.StoreID) (*proto.GetRequest, *proto.GetResponse) {
-	args := &proto.GetRequest{
+func getArgs(key []byte, raftID proto.RaftID, storeID proto.StoreID) proto.GetRequest {
+	return proto.GetRequest{
 		RequestHeader: proto.RequestHeader{
 			Key:     key,
 			RaftID:  raftID,
 			Replica: proto.Replica{StoreID: storeID},
 		},
 	}
-	reply := &proto.GetResponse{}
-	return args, reply
 }
 
 // putArgs returns a PutRequest and PutResponse pair addressed to
 // the default replica for the specified key / value.
-func putArgs(key, value []byte, raftID proto.RaftID, storeID proto.StoreID) (*proto.PutRequest, *proto.PutResponse) {
-	args := &proto.PutRequest{
+func putArgs(key, value []byte, raftID proto.RaftID, storeID proto.StoreID) proto.PutRequest {
+	return proto.PutRequest{
 		RequestHeader: proto.RequestHeader{
 			Key:     key,
 			RaftID:  raftID,
@@ -370,14 +368,12 @@ func putArgs(key, value []byte, raftID proto.RaftID, storeID proto.StoreID) (*pr
 			Bytes: value,
 		},
 	}
-	reply := &proto.PutResponse{}
-	return args, reply
 }
 
 // incrementArgs returns an IncrementRequest and IncrementResponse pair
 // addressed to the default replica for the specified key / value.
-func incrementArgs(key []byte, inc int64, raftID proto.RaftID, storeID proto.StoreID) (*proto.IncrementRequest, *proto.IncrementResponse) {
-	args := &proto.IncrementRequest{
+func incrementArgs(key []byte, inc int64, raftID proto.RaftID, storeID proto.StoreID) proto.IncrementRequest {
+	return proto.IncrementRequest{
 		RequestHeader: proto.RequestHeader{
 			Key:     key,
 			RaftID:  raftID,
@@ -385,19 +381,14 @@ func incrementArgs(key []byte, inc int64, raftID proto.RaftID, storeID proto.Sto
 		},
 		Increment: inc,
 	}
-	reply := &proto.IncrementResponse{}
-	return args, reply
 }
 
-func internalTruncateLogArgs(index uint64, raftID proto.RaftID, storeID proto.StoreID) (
-	*proto.InternalTruncateLogRequest, *proto.InternalTruncateLogResponse) {
-	args := &proto.InternalTruncateLogRequest{
+func internalTruncateLogArgs(index uint64, raftID proto.RaftID, storeID proto.StoreID) proto.InternalTruncateLogRequest {
+	return proto.InternalTruncateLogRequest{
 		RequestHeader: proto.RequestHeader{
 			RaftID:  raftID,
 			Replica: proto.Replica{StoreID: storeID},
 		},
 		Index: index,
 	}
-	reply := &proto.InternalTruncateLogResponse{}
-	return args, reply
 }

--- a/storage/range.go
+++ b/storage/range.go
@@ -354,12 +354,11 @@ func (r *Range) requestLeaderLease(timestamp proto.Timestamp) error {
 	// Note that the command itself isn't traced, but usually the caller
 	// waiting for the result has an active Trace.
 	errChan, pendingCmd := r.proposeRaftCommand(r.context(), args)
-	var err error
-	if err = <-errChan; err == nil {
-		// Next if the command was committed, wait for the range to apply it.
-		err = (<-pendingCmd.done).Err
+	if err := <-errChan; err != nil {
+		return err
 	}
-	return err
+	// Next if the command was committed, wait for the range to apply it.
+	return (<-pendingCmd.done).Err
 }
 
 // redirectOnOrAcquireLeaderLease checks whether this replica has the


### PR DESCRIPTION
Working on this PR I discovered that shadowing `err` is a serious footgun, so I'm going to suggest that we tighten up our linters to prevent that. I've started working on that already, and it results in some annoying contortions, but the sad reality is that shadowing `err` is quite a dangerous pattern.

Anyway, the next PR in this series will require changing `Sender`, so I expect it'll be bigger than the past few have been. Apologies in advance.
