### PR TITLE
Disallow shadowing `err`

### DIFF
--- a/GLOCKFILE
+++ b/GLOCKFILE
@@ -4,7 +4,6 @@ cmd github.com/cockroachdb/yacc
 cmd github.com/gogo/protobuf/protoc-gen-gogo
 cmd github.com/golang/lint/golint
 cmd github.com/jteeuwen/go-bindata/go-bindata
-cmd github.com/kisielk/errcheck
 cmd github.com/robfig/glock
 cmd github.com/tebeka/go2xunit
 cmd golang.org/x/tools/cmd/goimports
@@ -26,7 +25,6 @@ github.com/google/btree cc6329d4279e3f025a53a83c397d2339b5705c45
 github.com/inconshreveable/mousetrap 76626ae9c91c4f2a10f34cad8ce83ea42c93bb75
 github.com/jteeuwen/go-bindata 38ae5514e62bacad046221ad7f54e7a54e3ccd7b
 github.com/julienschmidt/httprouter 70708e46004c7bcb09b70e685a8b74a690135387
-github.com/kisielk/errcheck 76bf61ee4096ee72636739d4472186b5de5641db
 github.com/kisielk/gotool d678387370a2eb9b5b0a33218bc8c9d8de15b6be
 github.com/lib/pq a8d8d01c4f91602f876bf5aa210274e8203a6b45
 github.com/montanaflynn/stats 44fb56da2a2a67d394dec0e18a82dd316f192529

--- a/Makefile
+++ b/Makefile
@@ -131,12 +131,11 @@ acceptance:
 check:
 	! git grep -F '"path"' -- '*.go'
 	! errcheck -ignore 'bytes:Write.*,io:(Close|Write),net:Close,net/http:(Close|Write),net/rpc:Close,os:Close,database/sql:Close,github.com/spf13/cobra:Usage' $(PKG) | grep -vE 'yacc\.go:'
-	! go-nyet $(PKG) | grep -vE '(Weird type of StarExpr|Unknown types|`matchIndex`|`c`|Illegal range|cannot process directory \.git|yacc\.go:)' # TODO(tamird): https://github.com/barakmich/go-nyet/pull/10
 	# https://golang.org/pkg/database/sql/driver/#Result :(
 	! golint $(PKG) | grep -vE '(\.pb\.go|embedded\.go|yyEofCode|_string\.go|LastInsertId|sql\.y|yacc\.go)'
 	! gofmt -s -l . | grep -vF 'No Exceptions'
 	! goimports -l . | grep -vF 'No Exceptions'
-	! go tool vet --shadow --shadowstrict . 2>&1 | grep -vE '(\.pb\.go|yacc\.go|declaration of err shadows|cannot process directory \.git)'
+	! go tool vet --shadow --shadowstrict . 2>&1 | grep -vE '(\.pb\.go|yacc\.go|cannot process directory \.git)' # https://github.com/golang/go/issues/11727
 
 .PHONY: clean
 clean:

--- a/cli/sql.go
+++ b/cli/sql.go
@@ -127,13 +127,13 @@ func runTerm(cmd *cobra.Command, args []string) {
 
 	// We need to switch to raw mode. Unfortunately, this masks
 	// signals-from-keyboard, meaning that ctrl-C cannot be caught.
-	oldState, err := terminal.MakeRaw(0)
-	if err != nil {
+	if oldState, err := terminal.MakeRaw(0); err != nil {
 		panic(err)
+	} else {
+		defer func() {
+			_ = terminal.Restore(0, oldState)
+		}()
 	}
-	defer func() {
-		_ = terminal.Restore(0, oldState)
-	}()
 
 	term := terminal.NewTerminal(readWriter, "> ")
 	for {

--- a/cli/start.go
+++ b/cli/start.go
@@ -60,8 +60,7 @@ func runInit(cmd *cobra.Command, args []string) {
 	// Default user for servers.
 	Context.User = security.NodeUser
 	// First initialize the Context as it is used in other places.
-	err := Context.Init("init")
-	if err != nil {
+	if err := Context.Init("init"); err != nil {
 		log.Errorf("failed to initialize context: %s", err)
 		return
 	}

--- a/client/db.go
+++ b/client/db.go
@@ -202,7 +202,7 @@ func Open(addr string, opts ...Option) (*DB, error) {
 	if err != nil {
 		return nil, err
 	}
-	ctx := &base.Context{}
+	ctx := base.Context{}
 	ctx.InitDefaults()
 	if u.User != nil {
 		ctx.User = u.User.Username()
@@ -213,7 +213,7 @@ func Open(addr string, opts ...Option) (*DB, error) {
 		ctx.Certs = dir[0]
 	}
 
-	sender, err := newSender(u, ctx)
+	sender, err := newSender(u, &ctx)
 	if err != nil {
 		return nil, err
 	}

--- a/client/db.go
+++ b/client/db.go
@@ -225,11 +225,11 @@ func Open(addr string, opts ...Option) (*DB, error) {
 	}
 
 	if priority := q["priority"]; len(priority) > 0 {
-		p, err := strconv.Atoi(priority[0])
-		if err != nil {
-			return nil, err
+		if p, parseErr := strconv.Atoi(priority[0]); parseErr == nil {
+			db.userPriority = int32(p)
+		} else {
+			return nil, parseErr
 		}
-		db.userPriority = int32(p)
 	}
 
 	for _, opt := range opts {

--- a/client/table.go
+++ b/client/table.go
@@ -353,13 +353,13 @@ func (db *DB) RenameTable(oldPath, newPath string) error {
 			return err
 		}
 		newNameKey := keys.MakeNameMetadataKey(newNSID, newName)
-		b := &Batch{}
+		b := Batch{}
 		b.Put(descKey, &desc)
 		// If the new name already exists the conditional put will fail causing the
 		// transaction to fail.
 		b.CPut(newNameKey, descKey, nil)
 		b.Del(oldNameKey)
-		return txn.Commit(b)
+		return txn.Commit(&b)
 	})
 }
 

--- a/examples/kv_bank/main.go
+++ b/examples/kv_bank/main.go
@@ -116,8 +116,7 @@ func (bank *Bank) continuouslyTransferMoney(cash int64) {
 			}
 			// Read from value.
 			fromAccount := &Account{}
-			err := fromAccount.decode(batchRead.Results[0].Rows[0].ValueBytes())
-			if err != nil {
+			if err := fromAccount.decode(batchRead.Results[0].Rows[0].ValueBytes()); err != nil {
 				return err
 			}
 			// Ensure there is enough cash.
@@ -134,24 +133,24 @@ func (bank *Bank) continuouslyTransferMoney(cash int64) {
 			batchWrite := &client.Batch{}
 			fromAccount.Balance -= exchangeAmount
 			toAccount.Balance += exchangeAmount
-			if fromValue, err := fromAccount.encode(); err != nil {
-				return err
-			} else if toValue, err := toAccount.encode(); err != nil {
-				return err
+			if fromValue, fromErr := fromAccount.encode(); fromErr != nil {
+				return fromErr
+			} else if toValue, toErr := toAccount.encode(); toErr != nil {
+				return toErr
 			} else {
 				batchWrite.Put(from, fromValue)
 				batchWrite.Put(to, toValue)
 			}
 			return runner.Run(batchWrite)
 		}
-		var err error
 		if *useTransaction {
-			err = bank.db.Txn(func(txn *client.Txn) error { return transferMoney(txn) })
+			if err := bank.db.Txn(func(txn *client.Txn) error { return transferMoney(txn) }); err != nil {
+				log.Fatal(err)
+			}
 		} else {
-			err = transferMoney(bank.db)
-		}
-		if err != nil {
-			log.Fatal(err)
+			if err := transferMoney(bank.db); err != nil {
+				log.Fatal(err)
+			}
 		}
 		atomic.AddInt32(&bank.numTransfers, 1)
 	}

--- a/gossip/gossip_test.go
+++ b/gossip/gossip_test.go
@@ -82,16 +82,15 @@ func TestGossipGroupsInfoStore(t *testing.T) {
 			t.Fatal(err)
 		}
 	}
-	values, err := g.GetGroupInfos("i")
-	if err != nil {
+	if values, err := g.GetGroupInfos("i"); err != nil {
 		t.Errorf("error fetching int64 group: %v", err)
-	}
-	if len(values) != 3 {
+	} else if len(values) != 3 {
 		t.Errorf("incorrect number of values in group: %v", values)
-	}
-	for i := 0; i < 3; i++ {
-		if values[i].(int64) != int64(i) {
-			t.Errorf("index %d has incorrect value: %d, expected %d", i, values[i].(int64), i)
+	} else {
+		for i := 0; i < 3; i++ {
+			if values[i].(int64) != int64(i) {
+				t.Errorf("index %d has incorrect value: %d, expected %d", i, values[i].(int64), i)
+			}
 		}
 	}
 	if _, err := g.GetGroupInfos("i2"); err == nil {
@@ -107,16 +106,15 @@ func TestGossipGroupsInfoStore(t *testing.T) {
 			t.Fatal(err)
 		}
 	}
-	values, err = g.GetGroupInfos("f")
-	if err != nil {
+	if values, err := g.GetGroupInfos("f"); err != nil {
 		t.Errorf("error fetching float64 group: %v", err)
-	}
-	if len(values) != 3 {
+	} else if len(values) != 3 {
 		t.Errorf("incorrect number of values in group: %v", values)
-	}
-	for i := 0; i < 3; i++ {
-		if values[i].(float64) != float64(i) {
-			t.Errorf("index %d has incorrect value: %f, expected %d", i, values[i].(float64), i)
+	} else {
+		for i := 0; i < 3; i++ {
+			if values[i].(float64) != float64(i) {
+				t.Errorf("index %d has incorrect value: %f, expected %d", i, values[i].(float64), i)
+			}
 		}
 	}
 
@@ -129,16 +127,15 @@ func TestGossipGroupsInfoStore(t *testing.T) {
 			t.Fatal(err)
 		}
 	}
-	values, err = g.GetGroupInfos("s")
-	if err != nil {
+	if values, err := g.GetGroupInfos("s"); err != nil {
 		t.Errorf("error fetching string group: %v", err)
-	}
-	if len(values) != 3 {
+	} else if len(values) != 3 {
 		t.Errorf("incorrect number of values in group: %v", values)
-	}
-	for i := 0; i < 3; i++ {
-		if values[i].(string) != fmt.Sprintf("%d", i) {
-			t.Errorf("index %d has incorrect value: %d, expected %s", i, values[i], fmt.Sprintf("%d", i))
+	} else {
+		for i := 0; i < 3; i++ {
+			if values[i].(string) != fmt.Sprintf("%d", i) {
+				t.Errorf("index %d has incorrect value: %d, expected %s", i, values[i], fmt.Sprintf("%d", i))
+			}
 		}
 	}
 }

--- a/gossip/group_test.go
+++ b/gossip/group_test.go
@@ -134,11 +134,9 @@ func TestSameKeyInserts(t *testing.T) {
 	defer leaktest.AfterTest(t)
 	group := newGroup("a", 1, MinGroup)
 	info1 := newTestInfo("a.a", int64(1))
-	changed, err := group.addInfo(info1)
-	if err != nil {
+	if changed, err := group.addInfo(info1); err != nil {
 		t.Error(err)
-	}
-	if !changed {
+	} else if !changed {
 		t.Error("expected changed contents to be true on first insert")
 	}
 
@@ -152,20 +150,16 @@ func TestSameKeyInserts(t *testing.T) {
 	// Two successively larger timestamps always win.
 	info3 := newTestInfo("a.a", int64(1))
 	info3.Timestamp = info1.Timestamp + 1
-	changed, err = group.addInfo(info3)
-	if err != nil {
+	if changed, err := group.addInfo(info3); err != nil {
 		t.Error(err)
-	}
-	if changed {
+	} else if changed {
 		t.Error("expected changed to be false on successive timestamp but same value")
 	}
 	info4 := newTestInfo("a.a", int64(2)) // change value
 	info4.Timestamp = info1.Timestamp + 2
-	changed, err = group.addInfo(info4)
-	if err != nil {
+	if changed, err := group.addInfo(info4); err != nil {
 		t.Error(err)
-	}
-	if !changed {
+	} else if !changed {
 		t.Error("expected changed to be true on successive timestamp with different value")
 	}
 }

--- a/kv/db_test.go
+++ b/kv/db_test.go
@@ -200,7 +200,7 @@ func TestKVDBTransaction(t *testing.T) {
 
 	key := proto.Key("db-txn-test")
 	value := []byte("value")
-	err := db.Txn(func(txn *client.Txn) error {
+	if err := db.Txn(func(txn *client.Txn) error {
 		// Use snapshot isolation so non-transactional read can always push.
 		txn.SetSnapshotIsolation()
 
@@ -222,8 +222,7 @@ func TestKVDBTransaction(t *testing.T) {
 			t.Errorf("expected value %q; got %q", value, gr.ValueBytes())
 		}
 		return nil
-	})
-	if err != nil {
+	}); err != nil {
 		t.Errorf("expected success on commit; got %s", err)
 	}
 

--- a/kv/dist_sender_test.go
+++ b/kv/dist_sender_test.go
@@ -65,7 +65,7 @@ func makeTestGossip(t *testing.T) (*gossip.Gossip, func()) {
 		{proto.KeyMin, nil, permConfig},
 	})
 	if err != nil {
-		t.Fatalf("failed to make prefix config map, err: %s", err.Error())
+		t.Fatalf("failed to make prefix config map, err: %s", err)
 	}
 	if err := g.AddInfo(gossip.KeySentinel, "cluster1", time.Hour); err != nil {
 		t.Fatal(err)
@@ -607,7 +607,7 @@ func TestVerifyPermissions(t *testing.T) {
 	}
 	configMap, err := storage.NewPrefixConfigMap(configs)
 	if err != nil {
-		t.Fatalf("failed to make prefix config map, err: %s", err.Error())
+		t.Fatalf("failed to make prefix config map, err: %s", err)
 	}
 	if err := ds.gossip.AddInfo(gossip.KeyConfigPermission, configMap, time.Hour); err != nil {
 		t.Fatal(err)

--- a/kv/local_sender_test.go
+++ b/kv/local_sender_test.go
@@ -69,7 +69,7 @@ func TestLocalSenderVisitStores(t *testing.T) {
 	visit := make([]bool, numStores)
 	err := ls.VisitStores(func(s *storage.Store) error { visit[s.Ident.StoreID] = true; return nil })
 	if err != nil {
-		t.Errorf("unexpected error on visit: %s", err.Error())
+		t.Errorf("unexpected error on visit: %s", err)
 	}
 
 	for i, visited := range visit {
@@ -102,7 +102,7 @@ func TestLocalSenderGetStore(t *testing.T) {
 		t.Errorf("expected storeID to be %d but was %d",
 			s.Ident.StoreID, store.Ident.StoreID)
 	} else if err != nil {
-		t.Errorf("expected no error, instead had err=%s", err.Error())
+		t.Errorf("expected no error, instead had err=%s", err)
 	}
 }
 

--- a/kv/range_cache_test.go
+++ b/kv/range_cache_test.go
@@ -131,7 +131,7 @@ func (db *testDescriptorDB) assertLookupCount(t *testing.T, expected int, key st
 func doLookup(t *testing.T, rc *rangeDescriptorCache, key string) *proto.RangeDescriptor {
 	r, err := rc.LookupRangeDescriptor(proto.Key(key), lookupOptions{})
 	if err != nil {
-		t.Fatalf("Unexpected error from LookupRangeDescriptor: %s", err.Error())
+		t.Fatalf("Unexpected error from LookupRangeDescriptor: %s", err)
 	}
 	if !r.ContainsKey(keys.KeyAddress(proto.Key(key))) {
 		t.Fatalf("Returned range did not contain key: %s-%s, %s", r.StartKey, r.EndKey, key)

--- a/rpc/codec/conn.go
+++ b/rpc/codec/conn.go
@@ -88,9 +88,9 @@ func (c *baseConn) write(w io.Writer, data []byte) error {
 
 func (c *baseConn) recvProto(m proto.Message,
 	uncompressedSize uint32, decompressor decompressFunc) error {
-	size, err := binary.ReadUvarint(c.r)
-	if err != nil {
-		return err
+	size, readErr := binary.ReadUvarint(c.r)
+	if readErr != nil {
+		return readErr
 	}
 	if size == 0 {
 		return nil

--- a/rpc/codec/rpc_test.go
+++ b/rpc/codec/rpc_test.go
@@ -94,9 +94,9 @@ func TestAll(t *testing.T) {
 }
 
 func listenAndServeArithAndEchoService(network, addr string) (net.Addr, error) {
-	clients, err := net.Listen(network, addr)
-	if err != nil {
-		return nil, err
+	clients, listenErr := net.Listen(network, addr)
+	if listenErr != nil {
+		return nil, listenErr
 	}
 	srv := rpc.NewServer()
 	if err := srv.RegisterName("ArithService", new(Arith)); err != nil {
@@ -157,14 +157,14 @@ func testArithClient(t *testing.T, client *rpc.Client) {
 	args.A = 1
 	args.B = 0
 	if err = client.Call("ArithService.Div", &args, &reply); err.Error() != "divide by zero" {
-		t.Fatalf(`arith.Error: expected = "%s", got = "%s"`, "divide by zero", err.Error())
+		t.Fatalf(`arith.Error: expected = "%s", got = "%s"`, "divide by zero", err)
 	}
 
 	// Error
 	args.A = 1
 	args.B = 2
 	if err = client.Call("ArithService.Error", &args, &reply); err.Error() != "ArithError" {
-		t.Fatalf(`arith.Error: expected = "%s", got = "%s"`, "ArithError", err.Error())
+		t.Fatalf(`arith.Error: expected = "%s", got = "%s"`, "ArithError", err)
 	}
 }
 
@@ -277,10 +277,9 @@ func randString(n int) string {
 
 func listenAndServeEchoService(network, addr string,
 	serveConn func(srv *rpc.Server, conn io.ReadWriteCloser)) (net.Listener, error) {
-	l, err := net.Listen(network, addr)
-	if err != nil {
-		fmt.Printf("failed to listen on %s: %s\n", addr, err)
-		return nil, err
+	l, listenErr := net.Listen(network, addr)
+	if listenErr != nil {
+		return nil, listenErr
 	}
 	srv := rpc.NewServer()
 	if err := srv.RegisterName("EchoService", new(Echo)); err != nil {
@@ -408,9 +407,9 @@ func BenchmarkEchoProtoRPC64K(b *testing.B) {
 }
 
 func benchmarkEchoProtoHTTP(b *testing.B, size int) {
-	l, err := net.Listen("tcp", "127.0.0.1:0")
-	if err != nil {
-		b.Fatal(err)
+	l, listenErr := net.Listen("tcp", "127.0.0.1:0")
+	if listenErr != nil {
+		b.Fatal(listenErr)
 	}
 	defer l.Close()
 

--- a/rpc/server_test.go
+++ b/rpc/server_test.go
@@ -95,9 +95,9 @@ func TestUnregisteredMethod(t *testing.T) {
 
 	// Sending an invalid method fails cleanly, but leaves the connection
 	// in a valid state.
-	_, err := sendRPC(opts, []net.Addr{s.Addr()}, nodeContext, "Foo.Bar",
-		&proto.PingRequest{}, &proto.PingResponse{})
-	if !testutils.IsError(err, ".*rpc: couldn't find method: Foo.Bar") {
+	if _, err := sendRPC(
+		opts, []net.Addr{s.Addr()}, nodeContext, "Foo.Bar", &proto.PingRequest{}, &proto.PingResponse{},
+	); !testutils.IsError(err, ".*rpc: couldn't find method: Foo.Bar") {
 		t.Fatalf("expected 'couldn't find method' but got %s", err)
 	}
 	if _, err := sendPing(opts, []net.Addr{s.Addr()}, nodeContext); err != nil {

--- a/server/admin_test.go
+++ b/server/admin_test.go
@@ -88,12 +88,10 @@ func TestAdminDebugPprof(t *testing.T) {
 	s := StartTestServer(t)
 	defer s.Stop()
 
-	body, err := getText(s.Ctx.RequestScheme() + "://" + s.ServingAddr() + debugEndpoint + "pprof/block")
-	if err != nil {
+	if body, err := getText(s.Ctx.RequestScheme() + "://" + s.ServingAddr() + debugEndpoint + "pprof/block"); err != nil {
 		t.Fatal(err)
-	}
-	if matches, err := regexp.MatchString(".*contention:\ncycles/second=.*", string(body)); !matches || err != nil {
-		t.Errorf("expected match: %t; err nil: %v", matches, err)
+	} else if re := regexp.MustCompile(".*contention:\ncycles/second=.*"); !re.Match(body) {
+		t.Errorf("expected %s to match %s", body, re)
 	}
 }
 
@@ -126,12 +124,11 @@ range_max_bytes: 67108864
 `, "attributes for at least one replica must be specified in zone config"},
 	}
 
-	httpClient, err := testContext.GetHTTPClient()
-	if err != nil {
-		t.Fatal(err)
+	httpClient, clientErr := testContext.GetHTTPClient()
+	if clientErr != nil {
+		t.Fatal(clientErr)
 	}
 	for i, test := range testData {
-		re := regexp.MustCompile(test.expErr)
 		req, err := http.NewRequest("POST", fmt.Sprintf("%s://%s%s/%s", s.Ctx.RequestScheme(), s.ServingAddr(), zonePathPrefix, "foo"), strings.NewReader(test.zone))
 		if err != nil {
 			t.Fatal(err)
@@ -148,7 +145,7 @@ range_max_bytes: 67108864
 		}
 		if resp.StatusCode == http.StatusOK {
 			t.Errorf("%d: expected error", i)
-		} else if !re.MatchString(string(b)) {
+		} else if re := regexp.MustCompile(test.expErr); !re.MatchString(string(b)) {
 			t.Errorf("%d: expected error matching %q; got %s", i, test.expErr, b)
 		}
 	}

--- a/server/node.go
+++ b/server/node.go
@@ -108,8 +108,9 @@ func BootstrapCluster(clusterID string, engines []engine.Engine, stopper *stop.S
 	// Create a KV DB with a local sender.
 	lSender := kv.NewLocalSender()
 	sender := kv.NewTxnCoordSender(lSender, ctx.Clock, false, nil, stopper)
-	var err error
-	if ctx.DB, err = client.Open("//root@", client.SenderOpt(sender)); err != nil {
+	if db, err := client.Open("//root@", client.SenderOpt(sender)); err == nil {
+		ctx.DB = db
+	} else {
 		return nil, err
 	}
 	ctx.Transport = multiraft.NewLocalRPCTransport()

--- a/server/node_test.go
+++ b/server/node_test.go
@@ -185,8 +185,7 @@ func TestNodeJoin(t *testing.T) {
 	defer leaktest.AfterTest(t)
 	stopper := stop.NewStopper()
 	e := engine.NewInMem(proto.Attributes{}, 1<<20)
-	_, err := BootstrapCluster("cluster-1", []engine.Engine{e}, stopper)
-	if err != nil {
+	if _, err := BootstrapCluster("cluster-1", []engine.Engine{e}, stopper); err != nil {
 		t.Fatal(err)
 	}
 	stopper.Stop()
@@ -400,9 +399,9 @@ func TestStatusSummaries(t *testing.T) {
 	defer ts.Stop()
 
 	// Retrieve the first store from the Node.
-	s, err := ts.node.lSender.GetStore(proto.StoreID(1))
-	if err != nil {
-		t.Fatal(err)
+	s, storeErr := ts.node.lSender.GetStore(proto.StoreID(1))
+	if storeErr != nil {
+		t.Fatal(storeErr)
 	}
 
 	s.WaitForInit()
@@ -412,9 +411,9 @@ func TestStatusSummaries(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	storeDesc, err := s.Descriptor()
-	if err != nil {
-		t.Fatal(err)
+	storeDesc, descErr := s.Descriptor()
+	if descErr != nil {
+		t.Fatal(descErr)
 	}
 
 	expectedNodeStatus := &status.NodeStatus{

--- a/server/raft_transport.go
+++ b/server/raft_transport.go
@@ -143,9 +143,9 @@ func (t *rpcTransport) processQueue(raftNodeID proto.RaftNodeID) {
 	}()
 
 	nodeID, _ := proto.DecodeRaftNodeID(raftNodeID)
-	addr, err := t.gossip.GetNodeIDAddress(nodeID)
-	if err != nil {
-		log.Errorf("could not get address for node %d: %s", nodeID, err)
+	addr, gossipErr := t.gossip.GetNodeIDAddress(nodeID)
+	if gossipErr != nil {
+		log.Errorf("could not get address for node %d: %s", nodeID, gossipErr)
 		return
 	}
 	client := rpc.NewClient(addr, t.rpcContext)

--- a/server/server.go
+++ b/server/server.go
@@ -84,8 +84,7 @@ func NewServer(ctx *Context, stopper *stop.Stopper) (*Server, error) {
 	}
 
 	addr := ctx.Addr
-	_, err := net.ResolveTCPAddr("tcp", addr)
-	if err != nil {
+	if _, err := net.ResolveTCPAddr("tcp", addr); err != nil {
 		return nil, util.Errorf("unable to resolve RPC address %q: %v", addr, err)
 	}
 
@@ -122,19 +121,22 @@ func NewServer(ctx *Context, stopper *stop.Stopper) (*Server, error) {
 
 	ds := kv.NewDistSender(&kv.DistSenderContext{Clock: s.clock}, s.gossip)
 	sender := kv.NewTxnCoordSender(ds, s.clock, ctx.Linearizable, tracer, s.stopper)
-	if s.db, err = client.Open("//root@", client.SenderOpt(sender)); err != nil {
+	if db, err := client.Open("//root@", client.SenderOpt(sender)); err == nil {
+		s.db = db
+	} else {
 		return nil, err
 	}
 
-	s.raftTransport, err = newRPCTransport(s.gossip, s.rpc, rpcContext)
-	if err != nil {
+	if transport, err := newRPCTransport(s.gossip, s.rpc, rpcContext); err == nil {
+		s.raftTransport = transport
+	} else {
 		return nil, err
 	}
 	s.stopper.AddCloser(s.raftTransport)
 
 	s.kvDB = kv.NewDBServer(&s.ctx.Context, sender)
 	if s.ctx.ExperimentalRPCServer {
-		if err = s.kvDB.RegisterRPC(s.rpc); err != nil {
+		if err := s.kvDB.RegisterRPC(s.rpc); err != nil {
 			return nil, err
 		}
 	}

--- a/server/server_test.go
+++ b/server/server_test.go
@@ -230,9 +230,9 @@ func TestAcceptEncoding(t *testing.T) {
 	s := StartTestServer(t)
 	defer s.Stop()
 	// We can't use the standard test client. Create our own.
-	tlsConfig, err := testContext.GetClientTLSConfig()
-	if err != nil {
-		t.Fatal(err)
+	tlsConfig, tlsErr := testContext.GetClientTLSConfig()
+	if tlsErr != nil {
+		t.Fatal(tlsErr)
 	}
 	client := &http.Client{
 		Transport: &http.Transport{

--- a/server/status/feed_test.go
+++ b/server/status/feed_test.go
@@ -246,19 +246,18 @@ func TestServerNodeEventFeed(t *testing.T) {
 		ner.readEvents(sub)
 	})
 
-	db, err := client.Open("https://root@" + s.ServingAddr() + "?certs=" + security.EmbeddedCertsDir)
-	if err != nil {
-		t.Fatal(err)
+	db, clientErr := client.Open("https://root@" + s.ServingAddr() + "?certs=" + security.EmbeddedCertsDir)
+	if clientErr != nil {
+		t.Fatal(clientErr)
 	}
 
 	// Add some data in a transaction
-	err = db.Txn(func(txn *client.Txn) error {
+	if err := db.Txn(func(txn *client.Txn) error {
 		b := &client.Batch{}
 		b.Put("a", "asdf")
 		b.Put("c", "jkl;")
 		return txn.Commit(b)
-	})
-	if err != nil {
+	}); err != nil {
 		t.Fatalf("error putting data to db: %s", err)
 	}
 
@@ -268,7 +267,7 @@ func TestServerNodeEventFeed(t *testing.T) {
 	}
 
 	// Scan, which should fail.
-	if _, err = db.Scan("b", "a", 0); err == nil {
+	if _, err := db.Scan("b", "a", 0); err == nil {
 		t.Fatal("expected scan to fail.")
 	}
 

--- a/server/testserver.go
+++ b/server/testserver.go
@@ -155,9 +155,9 @@ func (ts *TestServer) Start() error {
 		ts.Ctx = NewTestContext()
 	}
 
-	var err error
-	ts.Server, err = NewServer(ts.Ctx, stop.NewStopper())
-	if err != nil {
+	if s, err := NewServer(ts.Ctx, stop.NewStopper()); err == nil {
+		ts.Server = s
+	} else {
 		return err
 	}
 
@@ -179,12 +179,7 @@ func (ts *TestServer) Start() error {
 		}
 		stopper.Stop()
 	}
-	err = ts.Server.Start(true)
-	if err != nil {
-		return err
-	}
-
-	return nil
+	return ts.Server.Start(true)
 }
 
 // ServingAddr returns the rpc server's address. Should be used by clients.

--- a/sql/parser/eval.go
+++ b/sql/parser/eval.go
@@ -457,8 +457,8 @@ func evalAndExpr(expr *AndExpr, env Env) (Datum, error) {
 	if left == null {
 		return null, nil
 	}
-	if v, err := getBool(left); err != nil {
-		return null, err
+	if v, getBoolErr := getBool(left); getBoolErr != nil {
+		return null, getBoolErr
 	} else if !v {
 		return v, nil
 	}
@@ -469,8 +469,8 @@ func evalAndExpr(expr *AndExpr, env Env) (Datum, error) {
 	if right == null {
 		return null, nil
 	}
-	if v, err := getBool(right); err != nil {
-		return null, err
+	if v, getBoolErr := getBool(right); getBoolErr != nil {
+		return null, getBoolErr
 	} else if !v {
 		return v, nil
 	}
@@ -483,8 +483,8 @@ func evalOrExpr(expr *OrExpr, env Env) (Datum, error) {
 		return null, err
 	}
 	if left != null {
-		if v, err := getBool(left); err != nil {
-			return null, err
+		if v, getBoolErr := getBool(left); getBoolErr != nil {
+			return null, getBoolErr
 		} else if v {
 			return v, nil
 		}
@@ -496,8 +496,8 @@ func evalOrExpr(expr *OrExpr, env Env) (Datum, error) {
 	if right == null {
 		return null, nil
 	}
-	if v, err := getBool(right); err != nil {
-		return null, err
+	if v, getBoolErr := getBool(right); getBoolErr != nil {
+		return null, getBoolErr
 	} else if v {
 		return v, nil
 	}
@@ -527,9 +527,9 @@ func evalRangeCond(expr *RangeCond, env Env) (Datum, error) {
 	// AND left <= to". The only tricky part is that we evaluate "left" only
 	// once.
 
-	left, err := EvalExpr(expr.Left, env)
-	if err != nil {
-		return null, err
+	left, evalErr := EvalExpr(expr.Left, env)
+	if evalErr != nil {
+		return null, evalErr
 	}
 
 	limits := [2]struct {
@@ -693,9 +693,9 @@ func evalCaseExpr(expr *CaseExpr, env Env) (Datum, error) {
 		// CASE <val> WHEN <expr> THEN ...
 		//
 		// For each "when" expression we compare for equality to <val>.
-		val, err := EvalExpr(expr.Expr, env)
-		if err != nil {
-			return null, err
+		val, evalErr := EvalExpr(expr.Expr, env)
+		if evalErr != nil {
+			return null, evalErr
 		}
 
 		for _, when := range expr.Whens {
@@ -707,8 +707,8 @@ func evalCaseExpr(expr *CaseExpr, env Env) (Datum, error) {
 			if err != nil {
 				return null, err
 			}
-			if v, err := getBool(d); err != nil {
-				return null, err
+			if v, getBoolErr := getBool(d); getBoolErr != nil {
+				return null, getBoolErr
 			} else if v {
 				return EvalExpr(when.Val, env)
 			}
@@ -720,8 +720,8 @@ func evalCaseExpr(expr *CaseExpr, env Env) (Datum, error) {
 			if err != nil {
 				return null, err
 			}
-			if v, err := getBool(d); err != nil {
-				return null, err
+			if v, getBoolErr := getBool(d); getBoolErr != nil {
+				return null, getBoolErr
 			} else if v {
 				return EvalExpr(when.Val, env)
 			}
@@ -745,8 +745,8 @@ func evalTupleEQ(ldatum, rdatum Datum) (Datum, error) {
 		if err != nil {
 			return null, err
 		}
-		if v, err := getBool(d); err != nil {
-			return null, err
+		if v, getBoolErr := getBool(d); getBoolErr != nil {
+			return null, getBoolErr
 		} else if !v {
 			return v, nil
 		}
@@ -789,8 +789,8 @@ func evalTupleIN(arg, values Datum) (Datum, error) {
 			if err != nil {
 				return null, err
 			}
-			if v, err := getBool(d); err != nil {
-				return null, err
+			if v, getBoolErr := getBool(d); getBoolErr != nil {
+				return null, getBoolErr
 			} else if v {
 				return v, nil
 			}

--- a/sql/parser/eval_test.go
+++ b/sql/parser/eval_test.go
@@ -184,9 +184,9 @@ func TestEvalExprError(t *testing.T) {
 		// {`~0 + 1`, `0`, nil},
 	}
 	for _, d := range testData {
-		q, err := Parse("SELECT " + d.expr)
-		if err != nil {
-			t.Fatalf("%s: %v", d.expr, err)
+		q, parseErr := Parse("SELECT " + d.expr)
+		if parseErr != nil {
+			t.Fatalf("%s: %v", d.expr, parseErr)
 		}
 		expr := q[0].(*Select).Exprs[0].(*NonStarExpr).Expr
 		if _, err := EvalExpr(expr, mapEnv{}); !testutils.IsError(err, d.expected) {

--- a/storage/client_event_test.go
+++ b/storage/client_event_test.go
@@ -232,13 +232,12 @@ func TestMultiStoreEventFeed(t *testing.T) {
 	mtc.replicateRange(raftID, 0, 1, 2)
 
 	// Add some data in a transaction
-	err := mtc.db.Txn(func(txn *client.Txn) error {
+	if err := mtc.db.Txn(func(txn *client.Txn) error {
 		b := &client.Batch{}
 		b.Put("a", "asdf")
 		b.Put("c", "jkl;")
 		return txn.Commit(b)
-	})
-	if err != nil {
+	}); err != nil {
 		t.Fatalf("error putting data to db: %s", err)
 	}
 

--- a/storage/client_merge_test.go
+++ b/storage/client_merge_test.go
@@ -98,9 +98,9 @@ func TestStoreRangeMergeWithData(t *testing.T) {
 	store, stopper := createTestStore(t)
 	defer stopper.Stop()
 
-	aDesc, bDesc, err := createSplitRanges(store)
-	if err != nil {
-		t.Fatal(err)
+	aDesc, bDesc, splitErr := createSplitRanges(store)
+	if splitErr != nil {
+		t.Fatal(splitErr)
 	}
 
 	// Write some values left and right of the proposed split key.
@@ -166,11 +166,11 @@ func TestStoreRangeMergeWithData(t *testing.T) {
 
 	// Put new values after the merge on both sides.
 	pArgs, pReply = putArgs([]byte("aaaa"), content, rangeA.Desc().RaftID, store.StoreID())
-	if err = store.ExecuteCmd(context.Background(), proto.Call{Args: pArgs, Reply: pReply}); err != nil {
+	if err := store.ExecuteCmd(context.Background(), proto.Call{Args: pArgs, Reply: pReply}); err != nil {
 		t.Fatal(err)
 	}
 	pArgs, pReply = putArgs([]byte("cccc"), content, rangeB.Desc().RaftID, store.StoreID())
-	if err = store.ExecuteCmd(context.Background(), proto.Call{Args: pArgs, Reply: pReply}); err != nil {
+	if err := store.ExecuteCmd(context.Background(), proto.Call{Args: pArgs, Reply: pReply}); err != nil {
 		t.Fatal(err)
 	}
 

--- a/storage/client_range_test.go
+++ b/storage/client_range_test.go
@@ -216,8 +216,7 @@ func TestTxnPutOutOfOrder(t *testing.T) {
 
 	// Put an initial value.
 	initVal := []byte("initVal")
-	err := store.DB().Put(key, initVal)
-	if err != nil {
+	if err := store.DB().Put(key, initVal); err != nil {
 		t.Fatalf("failed to put: %s", err)
 	}
 
@@ -298,8 +297,7 @@ func TestTxnPutOutOfOrder(t *testing.T) {
 		},
 		Reply: &proto.GetResponse{},
 	}
-	err = store.ExecuteCmd(context.Background(), getCall)
-	if err != nil {
+	if err := store.ExecuteCmd(context.Background(), getCall); err != nil {
 		t.Fatalf("failed to get: %s", err)
 	}
 
@@ -321,8 +319,7 @@ func TestTxnPutOutOfOrder(t *testing.T) {
 		Reply: &proto.GetResponse{},
 	}
 
-	err = store.ExecuteCmd(context.Background(), getCall)
-	if err == nil {
+	if err := store.ExecuteCmd(context.Background(), getCall); err == nil {
 		t.Fatal("unexpected success of get")
 	}
 

--- a/storage/engine/engine.go
+++ b/storage/engine/engine.go
@@ -172,9 +172,9 @@ func PutProto(engine Engine, key proto.EncodedKey, msg gogoproto.Message) (keyBy
 // value is returned.
 func Increment(engine Engine, key proto.EncodedKey, inc int64) (int64, error) {
 	// First retrieve existing value.
-	val, err := engine.Get(key)
-	if err != nil {
-		return 0, err
+	val, getErr := engine.Get(key)
+	if getErr != nil {
+		return 0, getErr
 	}
 	var int64Val int64
 	// If the value exists, attempt to decode it as a varint.

--- a/storage/engine/merge_test.go
+++ b/storage/engine/merge_test.go
@@ -296,11 +296,11 @@ func unmarshalTimeSeries(t testing.TB, b []byte) *proto.InternalTimeSeriesData {
 	}
 	var mvccValue MVCCMetadata
 	if err := gogoproto.Unmarshal(b, &mvccValue); err != nil {
-		t.Fatalf("error unmarshalling time series in text: %s", err.Error())
+		t.Fatalf("error unmarshalling time series in text: %s", err)
 	}
 	valueTS, err := proto.InternalTimeSeriesDataFromValue(mvccValue.Value)
 	if err != nil {
-		t.Fatalf("error unmarshalling time series in text: %s", err.Error())
+		t.Fatalf("error unmarshalling time series in text: %s", err)
 	}
 	return valueTS
 }

--- a/storage/engine/mvcc_test.go
+++ b/storage/engine/mvcc_test.go
@@ -155,8 +155,7 @@ func TestMVCCPutWithTxn(t *testing.T) {
 	engine := createTestEngine()
 	defer engine.Close()
 
-	err := MVCCPut(engine, nil, testKey1, makeTS(0, 1), value1, txn1)
-	if err != nil {
+	if err := MVCCPut(engine, nil, testKey1, makeTS(0, 1), value1, txn1); err != nil {
 		t.Fatal(err)
 	}
 
@@ -177,8 +176,7 @@ func TestMVCCPutWithoutTxn(t *testing.T) {
 	engine := createTestEngine()
 	defer engine.Close()
 
-	err := MVCCPut(engine, nil, testKey1, makeTS(0, 1), value1, nil)
-	if err != nil {
+	if err := MVCCPut(engine, nil, testKey1, makeTS(0, 1), value1, nil); err != nil {
 		t.Fatal(err)
 	}
 
@@ -413,11 +411,9 @@ func TestMVCCGetUncertainty(t *testing.T) {
 		t.Fatal(err)
 	}
 	// Read with transaction, should get a value back.
-	val, _, err := MVCCGet(engine, testKey1, makeTS(7, 0), true, txn)
-	if err != nil {
+	if val, _, err := MVCCGet(engine, testKey1, makeTS(7, 0), true, txn); err != nil {
 		t.Fatal(err)
-	}
-	if val == nil || !bytes.Equal(val.Bytes, value1.Bytes) {
+	} else if val == nil || !bytes.Equal(val.Bytes, value1.Bytes) {
 		t.Fatalf("wanted %q, got %v", value1.Bytes, val)
 	}
 
@@ -689,12 +685,10 @@ func TestMVCCGetInconsistent(t *testing.T) {
 	defer engine.Close()
 
 	// Put two values to key 1, the latest with a txn.
-	err := MVCCPut(engine, nil, testKey1, makeTS(1, 0), value1, nil)
-	if err != nil {
+	if err := MVCCPut(engine, nil, testKey1, makeTS(1, 0), value1, nil); err != nil {
 		t.Fatal(err)
 	}
-	err = MVCCPut(engine, nil, testKey1, makeTS(2, 0), value2, txn1)
-	if err != nil {
+	if err := MVCCPut(engine, nil, testKey1, makeTS(2, 0), value2, txn1); err != nil {
 		t.Fatal(err)
 	}
 
@@ -721,8 +715,7 @@ func TestMVCCGetInconsistent(t *testing.T) {
 	}
 
 	// Write a single intent for key 2 and verify get returns empty.
-	err = MVCCPut(engine, nil, testKey2, makeTS(2, 0), value1, txn2)
-	if err != nil {
+	if err := MVCCPut(engine, nil, testKey2, makeTS(2, 0), value1, txn2); err != nil {
 		t.Fatal(err)
 	}
 	val, intents, err := MVCCGet(engine, testKey2, makeTS(2, 0), false, nil)
@@ -770,15 +763,9 @@ func TestMVCCGetProtoInconsistent(t *testing.T) {
 	// Inconsistent get will fetch value1 for any timestamp.
 	for _, ts := range []proto.Timestamp{makeTS(1, 0), makeTS(2, 0)} {
 		val.Reset()
-		found, err := MVCCGetProto(engine, testKey1, ts, false, nil, val)
-		if ts.Less(makeTS(2, 0)) {
-			if err != nil {
-				t.Fatal(err)
-			}
-		} else if err != nil {
-			t.Fatal(err)
-		}
-		if !found {
+		if found, getProtoErr := MVCCGetProto(engine, testKey1, ts, false, nil, val); getProtoErr != nil {
+			t.Fatal(getProtoErr)
+		} else if !found {
 			t.Errorf("expected to find result with inconsistent read")
 		}
 		if !bytes.Equal(val.Value, []byte("value1")) {

--- a/storage/gc_queue.go
+++ b/storage/gc_queue.go
@@ -115,9 +115,9 @@ func (gcq *gcQueue) process(now proto.Timestamp, rng *Range) error {
 	defer snap.Close()
 
 	// Lookup the GC policy for the zone containing this key range.
-	policy, err := gcq.lookupGCPolicy(rng)
-	if err != nil {
-		return err
+	policy, lookupErr := gcq.lookupGCPolicy(rng)
+	if lookupErr != nil {
+		return lookupErr
 	}
 
 	gcMeta := proto.NewGCMetadata(now.WallTime)

--- a/storage/range_command.go
+++ b/storage/range_command.go
@@ -431,9 +431,9 @@ func (r *Range) InternalRangeLookup(batch engine.Engine, args proto.InternalRang
 		// the other value (within a few tries).
 		if rand.Intn(2) == 0 {
 			key, txn := intents[0].Key, &intents[0].Txn
-			val, _, err := engine.MVCCGet(batch, key, txn.Timestamp, true, txn)
-			if err != nil {
-				return reply, nil, err
+			val, _, getErr := engine.MVCCGet(batch, key, txn.Timestamp, true, txn)
+			if getErr != nil {
+				return reply, nil, getErr
 			}
 			kvs = []proto.KeyValue{{Key: key, Value: *val}}
 		}

--- a/storage/range_tree.go
+++ b/storage/range_tree.go
@@ -236,9 +236,9 @@ func (tc *treeContext) walkUpRot23(node *proto.RangeTreeNode) (*proto.RangeTreeN
 		return nil, err
 	}
 	if left != nil {
-		leftLeft, err := tc.getNode(left.LeftKey)
-		if err != nil {
-			return nil, err
+		leftLeft, leftLeftErr := tc.getNode(left.LeftKey)
+		if leftLeftErr != nil {
+			return nil, leftLeftErr
 		}
 		if isRed(left) && isRed(leftLeft) {
 			node, err = tc.rotateRight(node)

--- a/storage/store_test.go
+++ b/storage/store_test.go
@@ -797,10 +797,10 @@ func TestStoreResolveWriteIntent(t *testing.T) {
 		// Now, try a put using the pusher's txn.
 		pArgs.Timestamp = store.ctx.Clock.Now()
 		pArgs.Txn = pusher
-		err := store.ExecuteCmd(context.Background(), proto.Call{Args: &pArgs, Reply: pArgs.CreateReply()})
+		execErr := store.ExecuteCmd(context.Background(), proto.Call{Args: &pArgs, Reply: pArgs.CreateReply()})
 		if resolvable {
-			if err != nil {
-				t.Errorf("expected intent resolved; got unexpected error: %s", err)
+			if execErr != nil {
+				t.Errorf("expected intent resolved; got unexpected error: %s", execErr)
 			}
 			txnKey := keys.TransactionKey(pushee.Key, pushee.ID)
 			var txn proto.Transaction
@@ -812,13 +812,13 @@ func TestStoreResolveWriteIntent(t *testing.T) {
 				t.Errorf("expected pushee to be aborted; got %s", txn.Status)
 			}
 		} else {
-			if rErr, ok := err.(*proto.TransactionPushError); !ok {
-				t.Errorf("expected txn push error; got %s", err)
+			if rErr, ok := execErr.(*proto.TransactionPushError); !ok {
+				t.Errorf("expected txn push error; got %s", execErr)
 			} else if !bytes.Equal(rErr.PusheeTxn.ID, pushee.ID) {
 				t.Errorf("expected txn to match pushee %q; got %s", pushee.ID, rErr)
 			}
 			// Trying again should fail again.
-			if err = store.ExecuteCmd(context.Background(), proto.Call{Args: &pArgs, Reply: pArgs.CreateReply()}); err == nil {
+			if err := store.ExecuteCmd(context.Background(), proto.Call{Args: &pArgs, Reply: pArgs.CreateReply()}); err == nil {
 				t.Errorf("expected another error on latent write intent but succeeded")
 			}
 		}

--- a/ts/db.go
+++ b/ts/db.go
@@ -112,9 +112,9 @@ func (db *DB) StoreData(r Resolution, data []proto.TimeSeriesData) error {
 			return err
 		}
 		for _, idata := range idatas {
-			value, err := idata.ToValue()
-			if err != nil {
-				return err
+			value, toValueErr := idata.ToValue()
+			if toValueErr != nil {
+				return toValueErr
 			}
 			kvs = append(kvs, proto.KeyValue{
 				Key:   MakeDataKey(d.Name, d.Source, r, idata.StartTimestampNanos),

--- a/ts/db_test.go
+++ b/ts/db_test.go
@@ -77,9 +77,9 @@ func (tm *testModel) getActualData() map[string]*proto.Value {
 	// Scan over all TS Keys stored in the engine
 	startKey := keyDataPrefix
 	endKey := keyDataPrefix.PrefixEnd()
-	keyValues, _, err := engine.MVCCScan(tm.Eng, startKey, endKey, 0, tm.Clock.Now(), true, nil)
-	if err != nil {
-		tm.t.Fatalf("error scanning TS data from engine: %s", err.Error())
+	keyValues, _, scanErr := engine.MVCCScan(tm.Eng, startKey, endKey, 0, tm.Clock.Now(), true, nil)
+	if scanErr != nil {
+		tm.t.Fatalf("error scanning TS data from engine: %s", scanErr)
 	}
 
 	kvMap := make(map[string]*proto.Value)
@@ -150,30 +150,30 @@ func (tm *testModel) storeInModel(r Resolution, data proto.TimeSeriesData) {
 	tm.seenSources[data.Source] = true
 
 	// Process and store data in the model.
-	internalData, err := data.ToInternal(r.KeyDuration(), r.SampleDuration())
-	if err != nil {
-		tm.t.Fatalf("test could not convert time series to internal format: %s", err.Error())
+	internalData, toInternalErr := data.ToInternal(r.KeyDuration(), r.SampleDuration())
+	if toInternalErr != nil {
+		tm.t.Fatalf("test could not convert time series to internal format: %s", toInternalErr)
 	}
 
 	for _, idata := range internalData {
 		key := MakeDataKey(data.Name, data.Source, r, idata.StartTimestampNanos)
 		keyStr := string(key)
 
-		existing, ok := tm.modelData[keyStr]
 		var newTs *proto.InternalTimeSeriesData
-		if ok {
+		if existing, ok := tm.modelData[keyStr]; ok {
 			existingTs, err := proto.InternalTimeSeriesDataFromValue(existing)
 			if err != nil {
-				tm.t.Fatalf("test could not extract time series from existing model value: %s", err.Error())
+				tm.t.Fatalf("test could not extract time series from existing model value: %s", err)
 			}
 			newTs, err = engine.MergeInternalTimeSeriesData(existingTs, idata)
 			if err != nil {
-				tm.t.Fatalf("test could not merge time series into model value: %s", err.Error())
+				tm.t.Fatalf("test could not merge time series into model value: %s", err)
 			}
 		} else {
+			var err error
 			newTs, err = engine.MergeInternalTimeSeriesData(idata)
 			if err != nil {
-				tm.t.Fatalf("test could not merge time series into model value: %s", err.Error())
+				tm.t.Fatalf("test could not merge time series into model value: %s", err)
 			}
 		}
 		val, err := newTs.ToValue()
@@ -189,7 +189,7 @@ func (tm *testModel) storeInModel(r Resolution, data proto.TimeSeriesData) {
 func (tm *testModel) storeTimeSeriesData(r Resolution, data []proto.TimeSeriesData) {
 	// Store data in the system under test.
 	if err := tm.DB.StoreData(r, data); err != nil {
-		tm.t.Fatalf("error storing time series data: %s", err.Error())
+		tm.t.Fatalf("error storing time series data: %s", err)
 	}
 
 	// Store data in the model.

--- a/ts/query_test.go
+++ b/ts/query_test.go
@@ -216,9 +216,9 @@ func (tm *testModel) assertQuery(name string, agg *proto.TimeSeriesQueryAggregat
 		Name:       name,
 		Aggregator: agg,
 	}
-	actualDatapoints, actualSources, err := tm.DB.Query(q, r, start, end)
-	if err != nil {
-		tm.t.Fatal(err)
+	actualDatapoints, actualSources, queryErr := tm.DB.Query(q, r, start, end)
+	if queryErr != nil {
+		tm.t.Fatal(queryErr)
 	}
 	if a, e := len(actualDatapoints), expectedDatapointCount; a != e {
 		tm.t.Fatalf("query expected %d datapoints, got %d", e, a)

--- a/ts/server.go
+++ b/ts/server.go
@@ -84,9 +84,9 @@ func (s *Server) handleQuery(w http.ResponseWriter, r *http.Request, _ httproute
 		Results: make([]*proto.TimeSeriesQueryResponse_Result, 0, len(request.Queries)),
 	}
 	for _, q := range request.Queries {
-		datapoints, sources, err := s.db.Query(q, Resolution10s, request.StartNanos, request.EndNanos)
-		if err != nil {
-			http.Error(w, err.Error(), http.StatusInternalServerError)
+		datapoints, sources, queryErr := s.db.Query(q, Resolution10s, request.StartNanos, request.EndNanos)
+		if queryErr != nil {
+			http.Error(w, queryErr.Error(), http.StatusInternalServerError)
 			return
 		}
 		response.Results = append(response.Results, &proto.TimeSeriesQueryResponse_Result{

--- a/util/encoding/encoding_test.go
+++ b/util/encoding/encoding_test.go
@@ -56,8 +56,7 @@ func TestChecksums(t *testing.T) {
 		return err == nil
 	}
 
-	_, err := unwrapChecksum([]byte("does not matter"), []byte("srt"))
-	if err == nil {
+	if _, err := unwrapChecksum([]byte("does not matter"), []byte("srt")); err == nil {
 		t.Fatalf("expected error unwrapping a too short string")
 	}
 

--- a/util/log/clog.go
+++ b/util/log/clog.go
@@ -953,9 +953,9 @@ func (sb *syncBuffer) rotateFile(now time.Time) error {
 			Line:   int32(line),
 			Format: format,
 		}
-		n, err := sb.file.Write(encodeLogEntry(&entry))
-		if err != nil {
-			panic(err)
+		n, fatalErr := sb.file.Write(encodeLogEntry(&entry))
+		if fatalErr != nil {
+			panic(fatalErr)
 		}
 		sb.nbytes += uint64(n)
 	}

--- a/util/log/file.go
+++ b/util/log/file.go
@@ -213,9 +213,9 @@ type FileInfo struct {
 // on the local node, in any of the configured log directories.
 func ListLogFiles() ([]FileInfo, error) {
 	var results []FileInfo
-	infos, err := ioutil.ReadDir(*logDir)
-	if err != nil {
-		return results, err
+	infos, readDirErr := ioutil.ReadDir(*logDir)
+	if readDirErr != nil {
+		return results, readDirErr
 	}
 	for _, info := range infos {
 		details, err := getFileDetails(info)
@@ -297,9 +297,9 @@ func selectFiles(logFiles []FileInfo, severity Severity, endTimestamp int64) []F
 // 'pattern' if provided. The logs entries are returned in reverse chronological
 // order.
 func FetchEntriesFromFiles(severity Severity, startTimestamp, endTimestamp int64, maxEntries int, pattern *regexp.Regexp) ([]LogEntry, error) {
-	logFiles, err := ListLogFiles()
-	if err != nil {
-		return nil, err
+	logFiles, listErr := ListLogFiles()
+	if listErr != nil {
+		return nil, listErr
 	}
 
 	selectedFiles := selectFiles(logFiles, severity, endTimestamp)

--- a/util/log/structured.go
+++ b/util/log/structured.go
@@ -52,7 +52,7 @@ func getJSON(arg interface{}) []byte {
 
 	jsonBytes, err := json.Marshal(arg)
 	if err != nil {
-		return []byte(fmt.Sprintf("{\"error\": %q}", err.Error()))
+		return []byte(fmt.Sprintf("{\"error\": %q}", err))
 	}
 	return jsonBytes
 }

--- a/util/testing_test.go
+++ b/util/testing_test.go
@@ -26,10 +26,9 @@ import (
 // verifyAddr starts a server listener at the specified addr and
 // then dials a client to verify a connection is established.
 func verifyAddr(addr net.Addr, t *testing.T) {
-	ln, err := net.Listen(addr.Network(), addr.String())
-	if err != nil {
-		t.Error(err)
-		return
+	ln, listenErr := net.Listen(addr.Network(), addr.String())
+	if listenErr != nil {
+		t.Fatal(listenErr)
 	}
 
 	acceptChan := make(chan struct{})
@@ -44,8 +43,7 @@ func verifyAddr(addr net.Addr, t *testing.T) {
 	addr = ln.Addr()
 	conn, err := net.Dial(addr.Network(), addr.String())
 	if err != nil {
-		t.Errorf("could not connect to %s", addr)
-		return
+		t.Fatalf("could not connect to %s", addr)
 	}
 	select {
 	case <-acceptChan:


### PR DESCRIPTION
Also removes `go-nyet` in favour of `go tool vet`.
