### PR TITLE
Add basic WHERE clause support.

### DIFF
--- a/sql/driver/driver_test.go
+++ b/sql/driver/driver_test.go
@@ -340,4 +340,20 @@ CREATE TABLE t.kv (
 	if !reflect.DeepEqual(expectedResults, results) {
 		t.Fatalf("expected %s, but got %s", expectedResults, results)
 	}
+
+	// TODO(pmattis): We need much more testing of WHERE clauses. Need to think
+	// through the whole testing story in general.
+	rows, err = db.Query("SELECT * FROM t.kv WHERE k IN ('a', 'c')")
+	if err != nil {
+		t.Fatal(err)
+	}
+	results = readAll(t, rows)
+	expectedResults = [][]string{
+		{"k", "v"},
+		{"a", "b"},
+		{"c", "d"},
+	}
+	if !reflect.DeepEqual(expectedResults, results) {
+		t.Fatalf("expected %s, but got %s", expectedResults, results)
+	}
 }

--- a/sql/parser/builtins.go
+++ b/sql/parser/builtins.go
@@ -24,7 +24,7 @@ import (
 
 type builtin struct {
 	nArgs int
-	fn    func(args dtuple) (Datum, error)
+	fn    func(args DTuple) (Datum, error)
 }
 
 // The map from function name to function data. Keep the list of functions
@@ -62,15 +62,15 @@ type builtin struct {
 // functions.
 var builtins = map[string]builtin{
 	"length": stringBuiltin(func(s string) (Datum, error) {
-		return dint(len(s)), nil
+		return DInt(len(s)), nil
 	}),
 
 	"lower": stringBuiltin(func(s string) (Datum, error) {
-		return dstring(strings.ToLower(s)), nil
+		return DString(strings.ToLower(s)), nil
 	}),
 
 	"upper": stringBuiltin(func(s string) (Datum, error) {
-		return dstring(strings.ToUpper(s)), nil
+		return DString(strings.ToUpper(s)), nil
 	}),
 }
 
@@ -82,8 +82,8 @@ func argTypeError(arg Datum, expected string) error {
 func stringBuiltin(f func(string) (Datum, error)) builtin {
 	return builtin{
 		nArgs: 1,
-		fn: func(args dtuple) (Datum, error) {
-			s, ok := args[0].(dstring)
+		fn: func(args DTuple) (Datum, error) {
+			s, ok := args[0].(DString)
 			if !ok {
 				return null, argTypeError(args[0], "string")
 			}

--- a/sql/parser/eval_test.go
+++ b/sql/parser/eval_test.go
@@ -57,11 +57,11 @@ func TestEvalExpr(t *testing.T) {
 		{`'a' || 'b'`, `ab`, nil},
 		{`'a' || (1 + 2)`, `a3`, nil},
 		// Column lookup.
-		{`a`, `1`, mapEnv{"a": dint(1)}},
-		{`a`, `3.1`, mapEnv{"a": dfloat(3.1)}},
-		{`a`, `c`, mapEnv{"a": dstring("c")}},
-		{`a.b + 1`, `2`, mapEnv{"a.b": dint(1)}},
-		{`a OR b`, `true`, mapEnv{"a": dbool(false), "b": dbool(true)}},
+		{`a`, `1`, mapEnv{"a": DInt(1)}},
+		{`a`, `3.1`, mapEnv{"a": DFloat(3.1)}},
+		{`a`, `c`, mapEnv{"a": DString("c")}},
+		{`a.b + 1`, `2`, mapEnv{"a.b": DInt(1)}},
+		{`a OR b`, `true`, mapEnv{"a": DBool(false), "b": DBool(true)}},
 		// Boolean expressions.
 		{`false AND true`, `false`, nil},
 		{`false AND NULL`, `false`, nil},


### PR DESCRIPTION
Basic in the sense that we simply evaluate the WHERE clause expression
for each row before the row is output. No analysis of the WHERE clause
is performed to determine if an index could be used or if additional
columns are necessary beyond those present in the select expressions.

Fixes #1624.
