### PR TITLE
Disallow shadowing `err`, without strict

### DIFF
--- a/GLOCKFILE
+++ b/GLOCKFILE
@@ -1,4 +1,3 @@
-cmd github.com/barakmich/go-nyet
 cmd github.com/cockroachdb/c-protobuf/cmd/protoc
 cmd github.com/cockroachdb/yacc
 cmd github.com/gogo/protobuf/protoc-gen-gogo
@@ -10,7 +9,6 @@ cmd github.com/tebeka/go2xunit
 cmd golang.org/x/tools/cmd/goimports
 cmd golang.org/x/tools/cmd/stringer
 github.com/agtorre/gocolorize f42b554bf7f006936130c9bb4f971afd2d87f671
-github.com/barakmich/go-nyet fba7607fa3f727680833b0c44f35b448dbe5c5a8
 github.com/biogo/store e1f74b3c58befe661feed7fa4cf52436de753128
 github.com/cockroachdb/c-lz4 6e71f140a365017bbe0904710007f8725fd3f809
 github.com/cockroachdb/c-protobuf 0f9ab7b988ca7474cf76b9a961ab03c0552abcb3

--- a/Makefile
+++ b/Makefile
@@ -130,13 +130,12 @@ acceptance:
 .PHONY: check
 check:
 	! git grep -F '"path"' -- '*.go'
+	! go tool vet --shadow .  2>&1 | grep -vE '(\.pb\.go|cannot process directory \.git)'
 	! errcheck -ignore 'bytes:Write.*,io:(Close|Write),net:Close,net/http:(Close|Write),net/rpc:Close,os:Close,database/sql:Close,github.com/spf13/cobra:Usage' $(PKG) | grep -vE 'yacc\.go:'
-	! go-nyet $(PKG) | grep -vE '(Weird type of StarExpr|Unknown types|`matchIndex`|`c`|Illegal range|cannot process directory \.git|yacc\.go:)' # TODO(tamird): https://github.com/barakmich/go-nyet/pull/10
 	# https://golang.org/pkg/database/sql/driver/#Result :(
 	! golint $(PKG) | grep -vE '(\.pb\.go|embedded\.go|yyEofCode|_string\.go|LastInsertId|sql\.y|yacc\.go)'
 	! gofmt -s -l . | grep -vF 'No Exceptions'
 	! goimports -l . | grep -vF 'No Exceptions'
-	! go tool vet --shadow --shadowstrict . 2>&1 | grep -vE '(\.pb\.go|yacc\.go|declaration of err shadows|cannot process directory \.git)'
 
 .PHONY: clean
 clean:

--- a/acceptance/localcluster/docker.go
+++ b/acceptance/localcluster/docker.go
@@ -231,8 +231,7 @@ func (c *Container) Wait() error {
 		return err
 	}
 	var r struct{ StatusCode int }
-	err = json.Unmarshal(body, &r)
-	if err != nil {
+	if err := json.Unmarshal(body, &r); err != nil {
 		return err
 	}
 	if r.StatusCode != 0 {

--- a/cli/sql.go
+++ b/cli/sql.go
@@ -127,13 +127,13 @@ func runTerm(cmd *cobra.Command, args []string) {
 
 	// We need to switch to raw mode. Unfortunately, this masks
 	// signals-from-keyboard, meaning that ctrl-C cannot be caught.
-	oldState, err := terminal.MakeRaw(0)
-	if err != nil {
+	if oldState, err := terminal.MakeRaw(0); err != nil {
 		panic(err)
+	} else {
+		defer func() {
+			_ = terminal.Restore(0, oldState)
+		}()
 	}
-	defer func() {
-		_ = terminal.Restore(0, oldState)
-	}()
 
 	term := terminal.NewTerminal(readWriter, "> ")
 	for {

--- a/cli/start.go
+++ b/cli/start.go
@@ -60,8 +60,7 @@ func runInit(cmd *cobra.Command, args []string) {
 	// Default user for servers.
 	Context.User = security.NodeUser
 	// First initialize the Context as it is used in other places.
-	err := Context.Init("init")
-	if err != nil {
+	if err := Context.Init("init"); err != nil {
 		log.Errorf("failed to initialize context: %s", err)
 		return
 	}
@@ -127,8 +126,7 @@ func runStart(cmd *cobra.Command, args []string) {
 		return
 	}
 
-	err = s.Start(false)
-	if err != nil {
+	if err := s.Start(false); err != nil {
 		log.Errorf("cockroach server exited with error: %s", err)
 		return
 	}

--- a/client/admin.go
+++ b/client/admin.go
@@ -120,7 +120,7 @@ func (a *AdminClient) List() ([]string, error) {
 		Data []string `json:"d"`
 	}
 	var w wrapper
-	if err = json.Unmarshal(body, &w); err != nil {
+	if err := json.Unmarshal(body, &w); err != nil {
 		return nil, util.Errorf("unable to parse response %q: %s", body, err)
 	}
 

--- a/client/admin_test.go
+++ b/client/admin_test.go
@@ -88,12 +88,10 @@ func Example_accounting() {
 	fmt.Printf("Accounting prefixes: %q\n", keys)
 
 	// Remove keys: the default one cannot be removed.
-	err = client.Delete("")
-	if err == nil {
+	if err := client.Delete(""); err == nil {
 		log.Fatal("expected error")
 	}
-	err = client.Delete("db 2")
-	if err != nil {
+	if err := client.Delete("db 2"); err != nil {
 		log.Fatal(err)
 	}
 
@@ -199,12 +197,10 @@ write: [readwrite, writeonly]
 	fmt.Printf("Permission prefixes: %q\n", keys)
 
 	// Remove keys: the default one cannot be removed.
-	err = client.Delete("")
-	if err == nil {
+	if err := client.Delete(""); err == nil {
 		log.Fatal("expected error")
 	}
-	err = client.Delete("db 2")
-	if err != nil {
+	if err := client.Delete("db 2"); err != nil {
 		log.Fatal(err)
 	}
 
@@ -311,12 +307,10 @@ func Example_user() {
 	fmt.Printf("Users: %q\n", keys)
 
 	// Remove keys: the default one cannot be removed.
-	err = client.Delete("")
-	if err == nil {
+	if err := client.Delete(""); err == nil {
 		log.Fatal("expected error")
 	}
-	err = client.Delete("db 2")
-	if err != nil {
+	if err := client.Delete("db 2"); err != nil {
 		log.Fatal(err)
 	}
 
@@ -434,12 +428,10 @@ range_max_bytes: 67108864
 	fmt.Printf("Zone prefixes: %q\n", keys)
 
 	// Remove keys: the default one cannot be removed.
-	err = client.Delete("")
-	if err == nil {
+	if err := client.Delete(""); err == nil {
 		log.Fatal("expected error")
 	}
-	err = client.Delete("db 2")
-	if err != nil {
+	if err := client.Delete("db 2"); err != nil {
 		log.Fatal(err)
 	}
 

--- a/client/client_test.go
+++ b/client/client_test.go
@@ -558,12 +558,10 @@ func TestClientPermissions(t *testing.T) {
 
 	value := []byte("value")
 	for tcNum, tc := range testCases {
-		err := tc.client.Put(tc.path, value)
-		if err == nil != tc.success {
+		if err := tc.client.Put(tc.path, value); err == nil != tc.success {
 			t.Errorf("#%d: expected success=%t, got err=%s", tcNum, tc.success, err)
 		}
-		_, err = tc.client.Get(tc.path)
-		if err == nil != tc.success {
+		if _, err := tc.client.Get(tc.path); err == nil != tc.success {
 			t.Errorf("#%d: expected success=%t, got err=%s", tcNum, tc.success, err)
 		}
 	}

--- a/client/db_test.go
+++ b/client/db_test.go
@@ -87,7 +87,7 @@ func ExampleDB_CPut() {
 	}
 	fmt.Printf("aa=%s\n", result.ValueBytes())
 
-	if err = db.CPut("aa", "3", "1"); err == nil {
+	if err := db.CPut("aa", "3", "1"); err == nil {
 		panic("expected error from conditional put")
 	}
 	result, err = db.Get("aa")
@@ -96,7 +96,7 @@ func ExampleDB_CPut() {
 	}
 	fmt.Printf("aa=%s\n", result.ValueBytes())
 
-	if err = db.CPut("bb", "4", "1"); err == nil {
+	if err := db.CPut("bb", "4", "1"); err == nil {
 		panic("expected error from conditional put")
 	}
 	result, err = db.Get("bb")
@@ -104,7 +104,7 @@ func ExampleDB_CPut() {
 		panic(err)
 	}
 	fmt.Printf("bb=%s\n", result.ValueBytes())
-	if err = db.CPut("bb", "4", nil); err != nil {
+	if err := db.CPut("bb", "4", nil); err != nil {
 		panic(err)
 	}
 	result, err = db.Get("bb")

--- a/client/table.go
+++ b/client/table.go
@@ -287,11 +287,11 @@ func (db *DB) CreateTable(desc *structured.TableDescriptor) error {
 		return fmt.Errorf("table \"%s\" already exists", desc.Name)
 	}
 
-	ir, err := db.Inc(keys.DescIDGenerator, 1)
-	if err != nil {
+	if ir, err := db.Inc(keys.DescIDGenerator, 1); err == nil {
+		desc.ID = uint32(ir.ValueInt() - 1)
+	} else {
 		return err
 	}
-	desc.ID = uint32(ir.ValueInt() - 1)
 
 	// TODO(pmattis): Be cognizant of error messages when this is ported to the
 	// server. The error currently returned below is likely going to be difficult

--- a/cockroach.sublime-project
+++ b/cockroach.sublime-project
@@ -1,0 +1,14 @@
+{
+  "folders": [
+    {
+      "path": "."
+    }
+  ],
+  "settings":
+  {
+    "GoOracle": {
+      "oracle_scope": ["github.com/cockroachdb/cockroach"],
+      "env": { "GOPATH": "$HOME/src/go", "PATH": "$GOPATH/bin:/Users/tamird/src/go1.4.2/bin:$PATH" },
+    }
+  },
+}

--- a/cockroach.sublime-workspace
+++ b/cockroach.sublime-workspace
@@ -1,0 +1,1824 @@
+{
+	"auto_complete":
+	{
+		"selected_items":
+		[
+			[
+				"left",
+				"leftErr	error ν"
+			],
+			[
+				"Err",
+				"Error	 ƒ"
+			],
+			[
+				"error",
+				"ErrorDetail	struct ʈ"
+			],
+			[
+				"Sprint",
+				"Sprintf	string ƒ"
+			],
+			[
+				"reply",
+				"replyErr	error ν"
+			],
+			[
+				"Increme",
+				"IncrementResponse	struct ʈ"
+			],
+			[
+				"Endtra",
+				"EndTransactionResponse	struct ʈ"
+			],
+			[
+				"entra",
+				"EndTransactionResponse	struct ʈ"
+			],
+			[
+				"pushtxn",
+				"InternalPushTxnResponse	struct ʈ"
+			],
+			[
+				"endtran",
+				"EndTransactionResponse	struct ʈ"
+			],
+			[
+				"Internalrangelook",
+				"InternalRangeLookupResponse	struct ʈ"
+			],
+			[
+				"InternalRangeLook",
+				"InternalRangeLookupResponse	struct ʈ"
+			],
+			[
+				"InternalRange",
+				"InternalRangeLookupResponse	struct ʈ"
+			],
+			[
+				"GetRE",
+				"GetResponse	struct ʈ"
+			],
+			[
+				"ex",
+				"expErrRegexp	string ν"
+			],
+			[
+				"Erro",
+				"Errorf	 ƒ"
+			],
+			[
+				"Heartbea",
+				"InternalHeartbeatTxnResponse	struct ʈ"
+			],
+			[
+				"split",
+				"splitKey	proto.Key ν"
+			],
+			[
+				"request",
+				"Request	interface ¡"
+			],
+			[
+				"batch",
+				"batchReply	proto.Response ν"
+			],
+			[
+				"prin",
+				"Printf	n int, err error ƒ"
+			],
+			[
+				"er",
+				"Error	*proto.Error ν"
+			],
+			[
+				"respon",
+				"responseWithErr	struct ʈ"
+			],
+			[
+				"AdminMer",
+				"AdminMergeResponse	struct ʈ"
+			],
+			[
+				"adminspli",
+				"AdminSplitResponse	struct ʈ"
+			],
+			[
+				"end",
+				"EndTransactionResponse	struct ʈ"
+			],
+			[
+				"deleterange",
+				"DeleteRangeResponse	struct ʈ"
+			],
+			[
+				"increme",
+				"IncrementResponse	struct ʈ"
+			],
+			[
+				"conditio",
+				"ConditionalPutResponse	struct ʈ"
+			],
+			[
+				"intenrleaderle",
+				"InternalLeaderLeaseResponse	struct ʈ"
+			],
+			[
+				"interntrun",
+				"InternalTruncateLogResponse	struct ʈ"
+			],
+			[
+				"internapush",
+				"InternalPushTxnResponse	struct ʈ"
+			],
+			[
+				"internahea",
+				"InternalHeartbeatTxnResponse	struct ʈ"
+			],
+			[
+				"endtra",
+				"EndTransactionResponse	struct ʈ"
+			],
+			[
+				"cached",
+				"cachedReply	proto.Response ν"
+			],
+			[
+				"str",
+				"String	string ƒ"
+			],
+			[
+				"me",
+				"Message	interface ¡"
+			],
+			[
+				"End",
+				"EndTransactionResponse	struct ʈ"
+			],
+			[
+				"putReq",
+				"putReq2	*proto.PutRequest ν"
+			],
+			[
+				"va",
+				"SetValue	bool ƒ"
+			],
+			[
+				"InternaBatch",
+				"InternalBatchResponse	struct ʈ"
+			],
+			[
+				"proto",
+				"protoError	proto.Error ν"
+			],
+			[
+				"rejected",
+				"rejectedCommit	uint64 ν"
+			],
+			[
+				"re",
+				"rejectedCommit	uint64 ν"
+			],
+			[
+				"reje",
+				"rejectedIndex	uint64 ν"
+			],
+			[
+				"Sp",
+				"Sprintf	string ƒ"
+			],
+			[
+				"resp",
+				"respWithError	sqlwire.ResponseWithError ν"
+			],
+			[
+				"Request",
+				"Request	struct ʈ"
+			],
+			[
+				"E",
+				"Error	*proto.Error ν"
+			],
+			[
+				"Res",
+				"ResponseWithError	struct ʈ"
+			],
+			[
+				"response",
+				"ResponseWithError	struct ʈ"
+			],
+			[
+				"ra",
+				"GetRange	*storage.Range, error ƒ"
+			],
+			[
+				"stop",
+				"stopper	*stop.Stopper ν"
+			],
+			[
+				"Er",
+				"Error	error ƒ"
+			],
+			[
+				"Info",
+				"Infof	 ƒ"
+			],
+			[
+				"Inf",
+				"Infof	 ƒ"
+			],
+			[
+				"err",
+				"Error	error ƒ"
+			],
+			[
+				"ma",
+				"MakeUnresolvedAddr	util.UnresolvedAddr ƒ"
+			],
+			[
+				"un",
+				"UnresolvedAddr	struct ʈ"
+			],
+			[
+				"string",
+				"StringField	string ν"
+			],
+			[
+				"close",
+				"Closed	chan struct ν"
+			],
+			[
+				"hea",
+				"Healthy	<-chan struct ƒ"
+			],
+			[
+				"set",
+				"setUnhealthy	 ƒ"
+			],
+			[
+				"key",
+				"keyDelimeter	 Ɩ"
+			],
+			[
+				"account",
+				"Account	struct ʈ"
+			],
+			[
+				"db",
+				"dbName	*string ν"
+			],
+			[
+				"heart",
+				"Heartbeat	struct ʈ"
+			],
+			[
+				"pr",
+				"Println	n int, err error ƒ"
+			],
+			[
+				"Fata",
+				"Fatal	 ƒ"
+			],
+			[
+				"clo",
+				"Close	 ƒ"
+			],
+			[
+				"retry",
+				"retryOpts	retry.Options ν"
+			],
+			[
+				"s",
+				"IsStopped	<-chan struct ƒ"
+			],
+			[
+				"tls",
+				"tlsConfig	*tls.Config ν"
+			],
+			[
+				"get",
+				"GetClientTLSConfig	*tls.Config, error ƒ"
+			],
+			[
+				"war",
+				"Warning	 ƒ"
+			],
+			[
+				"Store",
+				"StoreID	int32 ʈ"
+			],
+			[
+				"count",
+				"countset	[]string ν"
+			],
+			[
+				"In",
+				"IntSlice	[]int ʈ"
+			],
+			[
+				"int",
+				"IntSlice	[]int ʈ"
+			],
+			[
+				"GO",
+				"GOMAXPROCS	int ƒ"
+			],
+			[
+				"wg",
+				"wgReady	sync.WaitGroup ν"
+			],
+			[
+				"fal",
+				"failureChan	chan error ν"
+			],
+			[
+				"fail",
+				"failureChan	chan error ν"
+			],
+			[
+				"mi",
+				"Microsecond	 Ɩ"
+			],
+			[
+				"expected",
+				"expectedUpdateCount	map[proto.StoreID][]int ν"
+			],
+			[
+				"F",
+				"Fprintf	n int, err error ƒ"
+			],
+			[
+				"Inter",
+				"InternalLeaderLease	 Ɩ"
+			],
+			[
+				"load",
+				"LoadUint32	val uint32 ƒ"
+			],
+			[
+				"uint32",
+				"StoreUint32	 ƒ"
+			],
+			[
+				"add",
+				"AddUint32	new uint32 ƒ"
+			],
+			[
+				"G",
+				"GetValue	interface{} ƒ"
+			],
+			[
+				"Respo",
+				"ResponseWithError	interface ¡"
+			],
+			[
+				"Prin",
+				"Println	n int, err error ƒ"
+			],
+			[
+				"Inc",
+				"increment	int64 ν"
+			],
+			[
+				"Response",
+				"ResponseWithHeader	struct ʈ"
+			],
+			[
+				"res",
+				"ResponseHeader	ResponseHeader ν"
+			],
+			[
+				"orig",
+				"origSeen	bool ν"
+			],
+			[
+				"stopper",
+				"NewStopper	*util.Stopper ƒ"
+			],
+			[
+				"ori",
+				"origSeen	bool ν"
+			],
+			[
+				"internalresol",
+				"InternalResolveIntentRange	 ƒ"
+			],
+			[
+				"args",
+				"argsBounded	bool ν"
+			],
+			[
+				"incre",
+				"incrementFunc	func(idx int, args proto.IncrementRequest, reply proto.IncrementResponse) int64 ν"
+			],
+			[
+				"c",
+				"context	context.Context ƒ"
+			],
+			[
+				"ENGINE",
+				"ENGINE_ROOT"
+			],
+			[
+				"CPU",
+				"CPUS"
+			],
+			[
+				"Reigster",
+				"RegisterName	error ƒ"
+			],
+			[
+				"server",
+				"Server	struct ʈ"
+			],
+			[
+				"ser",
+				"Server	*rpc.Server ν"
+			],
+			[
+				"NewServer",
+				"NewServerTestContext	*Context ƒ"
+			],
+			[
+				"NewSer",
+				"NewServerTestContext	*Context ƒ"
+			],
+			[
+				"ctx",
+				"context	*Context ν"
+			],
+			[
+				"g",
+				"GoError	error ƒ"
+			],
+			[
+				"cur",
+				"currentInterval	time.Duration ƒ"
+			],
+			[
+				"info",
+				"Infof	 ƒ"
+			],
+			[
+				"CP",
+				"CPP_PROTOS"
+			],
+			[
+				"ini",
+				"InitialInterval	time.Duration ν"
+			],
+			[
+				"status",
+				"StatusOK	 Ɩ"
+			],
+			[
+				"Status",
+				"StatusCode	int ν"
+			],
+			[
+				"con",
+				"Continue	 Ɩ"
+			],
+			[
+				"sprin",
+				"Sprintf	string ƒ"
+			],
+			[
+				"sp",
+				"Sprintf	string ƒ"
+			],
+			[
+				"flo",
+				"Float64	float64 ƒ"
+			],
+			[
+				"alt",
+				"AltProtoContentType	 Ɩ"
+			],
+			[
+				"json",
+				"AltJSONContentType	 Ɩ"
+			],
+			[
+				"conten",
+				"ContentTypeHeader	 Ɩ"
+			],
+			[
+				"currn",
+				"currentAttempt	int ν"
+			],
+			[
+				"max",
+				"MaxInterval	time.Duration ν"
+			],
+			[
+				"Engin",
+				"ENGINE_ROOT"
+			]
+		]
+	},
+	"buffers":
+	[
+	],
+	"build_system": "",
+	"build_system_choices":
+	[
+	],
+	"build_varint": "",
+	"command_palette":
+	{
+		"height": 287.0,
+		"last_filter": "blame",
+		"selected_items":
+		[
+			[
+				"blame",
+				"Git: Blame"
+			],
+			[
+				"rust",
+				"Set Syntax: Rust"
+			],
+			[
+				"syngo",
+				"Set Syntax: Go"
+			],
+			[
+				"sort",
+				"Sort Lines"
+			],
+			[
+				"syntaxgo",
+				"Set Syntax: Go"
+			],
+			[
+				"makefile",
+				"Set Syntax: Makefile"
+			],
+			[
+				"install",
+				"Package Control: Install Package"
+			],
+			[
+				"blae",
+				"Git: Blame"
+			],
+			[
+				"makfile",
+				"Set Syntax: Makefile"
+			],
+			[
+				"ruby",
+				"Set Syntax: Ruby"
+			],
+			[
+				"lam",
+				"Git: Blame"
+			],
+			[
+				"makefil",
+				"Set Syntax: Makefile"
+			],
+			[
+				"shell",
+				"Set Syntax: Shell Script (Bash)"
+			],
+			[
+				"make",
+				"Set Syntax: Makefile"
+			],
+			[
+				"blam",
+				"Git: Blame"
+			],
+			[
+				"docker",
+				"Set Syntax: Dockerfile"
+			],
+			[
+				"upp",
+				"Convert Case: Upper Case"
+			],
+			[
+				"uper",
+				"Convert Case: Upper Case"
+			],
+			[
+				"upper",
+				"Convert Case: Upper Case"
+			],
+			[
+				"bash",
+				"Set Syntax: Shell Script (Bash)"
+			],
+			[
+				"makei",
+				"Set Syntax: Makefile"
+			],
+			[
+				"makrdown",
+				"Markdown Preview: Preview in Browser"
+			],
+			[
+				"remove",
+				"Package Control: Remove Package"
+			],
+			[
+				"markdown",
+				"Set Syntax: Markdown GFM"
+			],
+			[
+				"python",
+				"Set Syntax: Python"
+			],
+			[
+				"balme",
+				"Set Syntax: Git Blame"
+			],
+			[
+				"c++",
+				"Set Syntax: C++"
+			],
+			[
+				"go",
+				"Git: Open Modified Files"
+			],
+			[
+				"balem",
+				"GoSublime: Changes & Announcements"
+			],
+			[
+				"insta",
+				"Package Control: Install Package"
+			],
+			[
+				"instal",
+				"Package Control: Install Package"
+			],
+			[
+				"defini",
+				"GoSublime: Goto Definition"
+			]
+		],
+		"width": 467.0
+	},
+	"console":
+	{
+		"height": 256.0,
+		"history":
+		[
+			"clear",
+			"import urllib.request,os,hashlib; h = 'eb2297e1a458f27d836c04bb0cbaf282' + 'd0e7a3098092775ccb37ca9d6b2e4b7d'; pf = 'Package Control.sublime-package'; ipp = sublime.installed_packages_path(); urllib.request.install_opener( urllib.request.build_opener( urllib.request.ProxyHandler()) ); by = urllib.request.urlopen( 'http://packagecontrol.io/' + pf.replace(' ', '%20')).read(); dh = hashlib.sha256(by).hexdigest(); print('Error validating download (got %s instead of %s), please try manual install' % (dh, h)) if dh != h else open(os.path.join( ipp, pf), 'wb' ).write(by)"
+		]
+	},
+	"distraction_free":
+	{
+		"menu_visible": true,
+		"show_minimap": false,
+		"show_open_files": false,
+		"show_tabs": false,
+		"side_bar_visible": false,
+		"status_bar_visible": false
+	},
+	"expanded_folders":
+	[
+		"/Users/tamird/src/go/src/github.com/cockroachdb/cockroach",
+		"/Users/tamird/src/go/src/github.com/cockroachdb/cockroach/util"
+	],
+	"file_history":
+	[
+		"/Users/tamird/src/go/src/github.com/cockroachdb/cockroach/storage/client_raft_test.go",
+		"/Users/tamird/src/go/src/github.com/cockroachdb/cockroach/storage/engine/mvcc.go",
+		"/Users/tamird/src/go/src/github.com/cockroachdb/cockroach/storage/id_alloc_test.go",
+		"/Users/tamird/src/go/src/github.com/cockroachdb/cockroach/ts/db_test.go",
+		"/Users/tamird/src/go/src/github.com/cockroachdb/cockroach/storage/client_merge_test.go",
+		"/Users/tamird/src/go/src/github.com/cockroachdb/cockroach/storage/engine/engine.go",
+		"/Users/tamird/src/go/src/github.com/cockroachdb/cockroach/storage/client_range_test.go",
+		"/Users/tamird/src/go/src/github.com/cockroachdb/cockroach/storage/store_test.go",
+		"/Users/tamird/src/go/src/github.com/cockroachdb/cockroach/ts/db.go",
+		"/Users/tamird/src/go/src/github.com/cockroachdb/cockroach/ts/server.go",
+		"/Users/tamird/src/go/src/github.com/cockroachdb/cockroach/kv/dist_sender_test.go",
+		"/Users/tamird/src/go/src/github.com/cockroachdb/cockroach/kv/local_sender_test.go",
+		"/Users/tamird/src/go/src/github.com/cockroachdb/cockroach/kv/range_cache_test.go",
+		"/Users/tamird/src/go/src/github.com/cockroachdb/cockroach/rpc/codec/rpc_test.go",
+		"/Users/tamird/src/go/src/github.com/cockroachdb/cockroach/storage/range_test.go",
+		"/Users/tamird/src/go/src/github.com/cockroachdb/cockroach/storage/engine/merge_test.go",
+		"/Users/tamird/src/go/src/github.com/cockroachdb/cockroach/util/log/structured.go",
+		"/Users/tamird/src/go/src/github.com/cockroachdb/cockroach/ts/query_test.go",
+		"/Users/tamird/src/go/src/github.com/cockroachdb/cockroach/storage/range_raftstorage.go",
+		"/Users/tamird/src/go/src/github.com/cockroachdb/cockroach/storage/engine/mvcc_test.go",
+		"/Users/tamird/src/go/src/github.com/cockroachdb/cockroach/storage/store.go",
+		"/Users/tamird/src/go/src/github.com/cockroachdb/cockroach/storage/client_event_test.go",
+		"/Users/tamird/src/go/src/github.com/cockroachdb/cockroach/util/log/clog.go",
+		"/Users/tamird/src/go/src/github.com/cockroachdb/cockroach/util/log/file.go",
+		"/Users/tamird/src/go/src/github.com/cockroachdb/cockroach/util/encoding/encoding_test.go",
+		"/Users/tamird/src/go/src/github.com/cockroachdb/cockroach/util/testing_test.go",
+		"/Users/tamird/src/go/src/github.com/cockroachdb/cockroach/.git/COMMIT_EDITMSG",
+		"/Users/tamird/src/go/src/github.com/cockroachdb/cockroach/storage/gc_queue.go",
+		"/Users/tamird/src/go/src/github.com/cockroachdb/cockroach/storage/range_command.go",
+		"/Users/tamird/src/go/src/github.com/cockroachdb/cockroach/storage/range_tree.go",
+		"/Users/tamird/src/go/src/github.com/cockroachdb/cockroach/server/server.go",
+		"/Users/tamird/src/go/src/github.com/cockroachdb/cockroach/sql/sqlserver/server.go",
+		"/Users/tamird/src/go/src/github.com/cockroachdb/cockroach/util/encoding/encoding.go",
+		"/Users/tamird/src/go/src/github.com/cockroachdb/cockroach/sql/parser/eval_test.go",
+		"/Users/tamird/src/go/src/github.com/cockroachdb/cockroach/Makefile",
+		"/Users/tamird/src/go/src/github.com/cockroachdb/cockroach/proto/internal_test.go",
+		"/Users/tamird/src/go/src/github.com/cockroachdb/cockroach/sql/parser/eval.go",
+		"/Users/tamird/src/go/src/github.com/cockroachdb/cockroach/server/testserver.go",
+		"/Users/tamird/src/go/src/github.com/cockroachdb/cockroach/acceptance/localcluster/localcluster.go",
+		"/Users/tamird/src/go/src/github.com/cockroachdb/cockroach/gossip/gossip_test.go",
+		"/Users/tamird/src/go/src/github.com/cockroachdb/cockroach/gossip/group_test.go",
+		"/Users/tamird/src/go/src/github.com/cockroachdb/cockroach/server/status/feed_test.go",
+		"/Users/tamird/src/go/src/github.com/cockroachdb/cockroach/server/status_test.go",
+		"/Users/tamird/src/go/src/github.com/cockroachdb/cockroach/gossip/infostore.go",
+		"/Users/tamird/src/go/src/github.com/cockroachdb/cockroach/server/admin_test.go",
+		"/Users/tamird/src/go/src/github.com/cockroachdb/cockroach/server/server_test.go",
+		"/Users/tamird/src/go1.4.2/src/regexp/regexp.go",
+		"/Users/tamird/src/go/src/github.com/cockroachdb/cockroach/server/node.go",
+		"/Users/tamird/src/go/src/github.com/cockroachdb/cockroach/server/raft_transport.go",
+		"/Users/tamird/src/go/src/github.com/cockroachdb/cockroach/server/node_test.go",
+		"/Users/tamird/src/go/src/github.com/cockroachdb/cockroach/examples/kv_bank/main.go",
+		"/Users/tamird/src/go/src/github.com/cockroachdb/cockroach/rpc/server_test.go",
+		"/Users/tamird/src/go/src/github.com/cockroachdb/cockroach/rpc/codec/conn.go",
+		"/Users/tamird/src/go/src/github.com/cockroachdb/cockroach/client/table.go",
+		"/Users/tamird/src/go/src/github.com/cockroachdb/cockroach/kv/txn_test.go",
+		"/Users/tamird/src/go/src/github.com/cockroachdb/cockroach/client/db.go",
+		"/Users/tamird/src/go/src/github.com/cockroachdb/cockroach/.git/rebase-merge/git-rebase-todo",
+		"/Users/tamird/src/go/src/github.com/cockroachdb/cockroach/cli/start.go",
+		"/Users/tamird/src/go/src/github.com/cockroachdb/cockroach/cli/sql.go",
+		"/Users/tamird/src/go/src/github.com/cockroachdb/cockroach/kv/dist_sender.go",
+		"/Users/tamird/src/go/src/github.com/cockroachdb/cockroach/kv/db_test.go",
+		"/Users/tamird/src/go/src/github.com/cockroachdb/cockroach/cli/log.go",
+		"/Users/tamird/src/go/src/github.com/cockroachdb/cockroach/client/util.go",
+		"/Users/tamird/src/go/src/github.com/cockroachdb/cockroach/kv/local_sender.go",
+		"/Users/tamird/Desktop/golang_meetup_talk.md",
+		"/Users/tamird/src/go/src/github.com/cockroachdb/cockroach/GLOCKFILE",
+		"/Users/tamird/src/go/src/golang.org/x/crypto/ssh/terminal/terminal.go",
+		"/Users/tamird/src/go/src/github.com/cockroachdb/cockroach/client/client_test.go",
+		"/Users/tamird/src/go/src/github.com/cockroachdb/cockroach/client/sender.go",
+		"/Users/tamird/src/go/src/github.com/cockroachdb/cockroach/storage/engine/gc.go",
+		"/Users/tamird/src/go/src/github.com/cockroachdb/cockroach/kv/txn_coord_sender.go",
+		"/Users/tamird/src/go/src/github.com/cockroachdb/cockroach/sql/parser/ast.go",
+		"/Users/tamird/src/go/src/github.com/cockroachdb/cockroach/sql/parser/show.go",
+		"/Users/tamird/src/go/src/github.com/cockroachdb/cockroach/proto/errors.go",
+		"/Users/tamird/src/go/src/github.com/cockroachdb/cockroach/storage/range.go",
+		"/Users/tamird/src/go/src/github.com/cockroachdb/cockroach/storage/response_cache.go",
+		"/Users/tamird/src/go/src/github.com/cockroachdb/cockroach/storage/response_cache_test.go",
+		"/Users/tamird/src/go/src/github.com/cockroachdb/cockroach/keys/errors.go",
+		"/Users/tamird/src/rust/.git/COMMIT_EDITMSG",
+		"/Users/tamird/src/go/src/github.com/cockroachdb/cockroach/proto/api.go",
+		"/Users/tamird/src/go/src/github.com/cockroachdb/cockroach/.git/addp-hunk-edit.diff",
+		"/Users/tamird/src/go/src/github.com/cockroachdb/cockroach/proto/api.pb.go",
+		"/Users/tamird/src/go/src/github.com/cockroachdb/cockroach/proto/data.pb.go",
+		"/Users/tamird/src/rust/src/libstd/sys/unix/backtrace.rs",
+		"/Users/tamird/src/go/src/github.com/cockroachdb/cockroach/sql/sqlwire/wire.proto",
+		"/Users/tamird/src/go/src/github.com/cockroachdb/cockroach/sql/sqlwire/wire.pb.go",
+		"/Users/tamird/src/go/src/github.com/gogo/protobuf/proto/clone.go",
+		"/Users/tamird/src/go/src/github.com/cockroachdb/cockroach/storage/client_split_test.go",
+		"/Users/tamird/src/go/src/github.com/cockroachdb/cockroach/storage/client_test.go",
+		"/Users/tamird/src/rust-build/configure",
+		"/Users/tamird/src/rust-build/config",
+		"/Users/tamird/src/go/src/github.com/cockroachdb/cockroach/storage/engine/rocksdb.go",
+		"/Users/tamird/src/go/src/github.com/cockroachdb/cockroach/storage/id_alloc.go",
+		"/Users/tamird/src/go/src/github.com/cockroachdb/cockroach/storage/gc_queue_test.go",
+		"/Users/tamird/src/go/src/github.com/cockroachdb/cockroach/storage/split_queue.go",
+		"/Users/tamird/src/go/src/github.com/cockroachdb/cockroach/.git/MERGE_MSG",
+		"/Users/tamird/src/go/src/github.com/cockroachdb/cockroach/util/tracer/tracer.go",
+		"/Users/tamird/src/go/src/github.com/cockroachdb/cockroach/cli/cli.go",
+		"/Users/tamird/src/go/src/github.com/cockroachdb/cockroach/util/tabwriter.go",
+		"/Users/tamird/src/go1.4.2/src/text/tabwriter/tabwriter.go",
+		"/Users/tamird/src/go/src/github.com/cockroachdb/cockroach/cockroach.sublime-project",
+		"/Users/tamird/src/go/src/github.com/cockroachdb/cockroach/kv/range_cache.go",
+		"/Users/tamird/src/go/src/github.com/cockroachdb/cockroach/client/txn_test.go",
+		"/Users/tamird/src/go/src/github.com/gogo/protobuf/proto/lib.go",
+		"/Users/tamird/Library/Application Support/Sublime Text 3/Packages/User/Preferences.sublime-settings",
+		"/Users/tamird/src/go/src/github.com/cockroachdb/cockroach/client/batch.go",
+		"/Users/tamird/src/go/src/github.com/cockroachdb/cockroach/storage/range_gc_queue.go",
+		"/Users/tamird/src/go/src/github.com/cockroachdb/cockroach/client/rpc/rpc_sender.go",
+		"/Users/tamird/src/go/src/github.com/cockroachdb/cockroach/client/txn.go",
+		"/Users/tamird/src/go/src/github.com/cockroachdb/cockroach/client/http_sender_test.go",
+		"/Users/tamird/src/go/src/github.com/cockroachdb/cockroach/client/db_internal_test.go",
+		"/Users/tamird/src/go/src/github.com/cockroachdb/cockroach/client/http_sender.go",
+		"/Users/tamird/src/go/src/github.com/cockroachdb/cockroach/proto/call.go",
+		"/Users/tamird/src/go/src/github.com/cockroachdb/cockroach/storage/engine/batch_test.go",
+		"/Users/tamird/Library/Application Support/Sublime Text 3/Packages/GoOracle/User.sublime-settings",
+		"/Users/tamird/Library/Application Support/Sublime Text 3/Packages/GoOracle/Default.sublime-settings",
+		"/Users/tamird/src/go/src/github.com/cockroachdb/cockroach/server/status.go",
+		"/Users/tamird/src/go/src/github.com/cockroachdb/cockroach/client/admin_test.go",
+		"/Users/tamird/src/go/src/github.com/cockroachdb/cockroach/rpc/client.go",
+		"/Users/tamird/src/go/src/github.com/cockroachdb/cockroach/kv/dist_sender_server_test.go",
+		"/Users/tamird/src/go/src/github.com/cockroachdb/cockroach/kv/txn_coord_sender_test.go",
+		"/Users/tamird/src/go/src/github.com/cockroachdb/cockroach/rpc/send.go",
+		"/Users/tamird/src/go/src/github.com/cockroachdb/cockroach/rpc/send_test.go",
+		"/Users/tamird/src/go/src/github.com/cockroachdb/cockroach/gossip/client.go",
+		"/Users/tamird/src/go/src/github.com/cockroachdb/cockroach/gossip/server.go",
+		"/Users/tamird/src/go/src/github.com/cockroachdb/cockroach/util/stop/stopper.go",
+		"/Users/tamird/src/go/src/github.com/cockroachdb/cockroach/rpc/server.go",
+		"/Users/tamird/src/go/src/github.com/cockroachdb/cockroach/storage/queue.go"
+	],
+	"find":
+	{
+		"height": 35.0
+	},
+	"find_in_files":
+	{
+		"height": 93.0,
+		"where_history":
+		[
+			"",
+			"storage/",
+			"storage.",
+			"",
+			"storage/",
+			"proto/",
+			"storage/",
+			"",
+			"storage/",
+			"",
+			"storage/",
+			"",
+			"storage/",
+			"",
+			"-*_test.go",
+			"-*_test.go, storage/",
+			"-*_test.go",
+			"storage/",
+			"",
+			"storage/, -*_test.go",
+			"storage/",
+			"",
+			"storage/",
+			"",
+			"-*_test.go, -proto/",
+			"-*_test.go",
+			"",
+			"client/",
+			"client.",
+			"",
+			"-*.pb.go",
+			"",
+			"sql/",
+			"",
+			"multiraft/",
+			"sql/",
+			"",
+			"log/",
+			"*.go",
+			"",
+			"multiraft/",
+			"",
+			"\\",
+			"multiraft/",
+			"",
+			"*.rs",
+			"",
+			"-*_test.go",
+			"",
+			"*.go",
+			"",
+			"-*_test.go",
+			"-_test.go",
+			"",
+			"log/",
+			"",
+			"engine/",
+			"",
+			"storage/",
+			"",
+			"rocksdb_native/",
+			"",
+			"*.cc",
+			"engine/",
+			"",
+			"proto/",
+			"proto",
+			"log/",
+			"",
+			"-*_test.go",
+			"",
+			"storage/*.go",
+			"storage/",
+			"",
+			"*_test.go",
+			"",
+			"storage/",
+			"-*_test.go",
+			"",
+			"-*.pb.*,-*_test.go,*.go",
+			"",
+			"-*.pb.*,-*_test.go,*.go",
+			"-*.pb.*,-*_test.go",
+			"-*.pb.*",
+			"-*.pb.go",
+			"",
+			"-*_test.go",
+			"",
+			"cli/",
+			"/cli",
+			"-*.pb.*",
+			"",
+			"storage/",
+			"",
+			"storage/*.go",
+			"server/*.go",
+			"server/*",
+			"",
+			"storage/engine/",
+			"*.go, -*.pb.go",
+			"",
+			"kv/",
+			"",
+			"gossip/",
+			"",
+			"-*_test.go, *.go",
+			"-*_test.go",
+			"",
+			"-status/",
+			"",
+			"-*.pb.go, -*.js, -*.ts, -*_test.go",
+			"-*.pb.go, -*.js, -*.ts",
+			"*.go",
+			"",
+			"*.proto",
+			"",
+			"status/",
+			"",
+			"status/",
+			"-status/",
+			"",
+			"status/",
+			"",
+			"status/",
+			"-*.pb.go, -*.js, -*.ts",
+			"-*.pb.go",
+			"",
+			"engine/"
+		]
+	},
+	"find_state":
+	{
+		"case_sensitive": true,
+		"find_history":
+		[
+			"err",
+			"newTs",
+			"existing",
+			"existingTs",
+			"newTs",
+			"err",
+			"		proto.Replica{",
+			"err",
+			"val",
+			"int64Val",
+			"err",
+			"\", err.Error()",
+			"err.Error()",
+			"err",
+			"value",
+			"err",
+			"return",
+			"Errorf",
+			"Error",
+			"err",
+			"pReply",
+			"reply",
+			"err",
+			"data",
+			"err",
+			"firstID",
+			"err",
+			"idAllocErr",
+			"err",
+			"kvs",
+			"err",
+			"lastIndex",
+			"ok",
+			"err",
+			"reply",
+			"err",
+			"leftLeft",
+			"err",
+			"v",
+			"lastIndex",
+			"err",
+			"ents",
+			"txn",
+			"err",
+			"val",
+			"err",
+			"policy",
+			"err",
+			"colID",
+			"err",
+			"primaryKey",
+			"err",
+			"gr",
+			"gr, err :=",
+			"gr, err := s.db.Get",
+			"break",
+			"done",
+			"intents",
+			"encKey",
+			"err",
+			"val",
+			"found",
+			"err",
+			"val",
+			"err",
+			"expr",
+			"q",
+			"err",
+			"v",
+			"cmp",
+			"arg",
+			"left",
+			"err",
+			"getBoolErr",
+			"err",
+			"	if v, err := getBool(left); err != nil {\n		return null, err\n	} else if !v {\n		return v, nil\n	}",
+			"err",
+			"arg",
+			", ",
+			"err",
+			"left, err := EvalExpr(expr.Left, env)",
+			"err",
+			"left",
+			"err",
+			"left",
+			"err",
+			"err.Error()",
+			"err",
+			"etReply",
+			" :=",
+			"reply",
+			"err",
+			"reply",
+			"valueOriginal",
+			"values, err = g.GetGroupInfos(\"s\")",
+			"values",
+			"container",
+			"l",
+			"Client",
+			"client",
+			"err",
+			"dir",
+			"err",
+			"re",
+			"re := regexp.MustCompile(",
+			"re",
+			"re := regexp.MustCompile(",
+			"re := regexp.MustCompile(spec.expected)",
+			"err",
+			"req",
+			"err",
+			"matches",
+			"str",
+			"err",
+			"engines",
+			"err",
+			"tlsConfig",
+			"err",
+			"replyI",
+			"err",
+			"req",
+			"pprofRegex",
+			"err",
+			"MustCompile",
+			"err",
+			"body",
+			"err",
+			"addr"
+		],
+		"highlight": true,
+		"in_selection": false,
+		"preserve_case": false,
+		"regex": false,
+		"replace_history":
+		[
+			"\", err",
+			"aCall",
+			"	",
+			"RejectIndex:",
+			".RejectIndex",
+			"mtc.StartMultiTestContext",
+			"mtc.MultiTestContext",
+			"testing.MultiTestContext",
+			"storage.StartMultiTestContext",
+			"MultiTestContext",
+			"var wire",
+			".GoError()",
+			".ResponseHeader.",
+			"engine.StoreStatus",
+			"NodeStatus",
+			"engine.MVCCStats",
+			"MVCCStats",
+			"StoreStats",
+			"status.StoreStats",
+			"StoreStats",
+			"status.StoreStatus",
+			"status.NodeStatus",
+			"engine.MVCCStats",
+			"status.MVCCStats",
+			"engine.MVCCMetadata",
+			"engine.MVCCValue",
+			"MVCCMetadata",
+			"MVCCValue",
+			"!= http.StatusOK",
+			"util.AcceptHeader",
+			"MaxRetries:",
+			"	Multiplier:",
+			"	InitialBackoff:",
+			"util.GetMethod",
+			"util.PostMethod",
+			"util.GzipEncoding",
+			"util.PlaintextContentType",
+			"util.SnappyEncoding",
+			"util.YAMLContentType",
+			"util.ContentTypeHeader",
+			"util.JSONContentType",
+			"util.AcceptEncodingHeader",
+			"util.ProtoContentType",
+			"",
+			"ExponentialBackOff{\nClock:               backoff.SystemClock,",
+			"",
+			"backoff.ExponentialBackOff{",
+			"return",
+			"return err",
+			"r.Reset()\nreturn err",
+			"r.Stop()\n",
+			"r.Stop\nreturn err",
+			"func(r *retry.Retry) error {",
+			"return nil",
+			"",
+			"Abort",
+			"retry.Flunk",
+			"retry.Succeed",
+			"Error",
+			"Success, nil",
+			"import \"proto",
+			"[(gogoproto.casttype) = \"Key\"];",
+			"\n	",
+			"	",
+			"gogoroach",
+			"",
+			"gogofast",
+			"gofast",
+			"gogoslick_out",
+			"$(GOPATH_BIN)/protoc-gen-gogoslick",
+			"rb_str_new_cstr",
+			"gogoproto.casttype",
+			"(gogoproto.customtype) = \"EncodedKey\"];",
+			"(gogoproto.customtype) = \"Key\"];",
+			"gogoproto.casttype",
+			"\"github.com/gogo/protobuf/proto\"",
+			"  ",
+			"",
+			"createTestConfigFile(t, ",
+			"defer util.CleanupDir(testConfigFn)",
+			"testing.",
+			"testing.CreateTestAddr",
+			"server.StartTestServer(t)",
+			"clustertest.CreateTestDB",
+			"testutils.$1",
+			"testutils$1",
+			"*EmbeddedServer",
+			"EmbeddedServer{}",
+			".EmbeddedServer",
+			"local_test_cluster.LocalTestCluster",
+			"\n		",
+			"$1--$2",
+			"= cobra.Command{",
+			"// Flag: *flag.CommandLine,",
+			"Use:",
+			"cobra.",
+			"\"code.google.com/p/go-commander\""
+		],
+		"reverse": false,
+		"show_context": true,
+		"use_buffer2": true,
+		"whole_word": false,
+		"wrap": true
+	},
+	"groups":
+	[
+		{
+			"sheets":
+			[
+			]
+		}
+	],
+	"incremental_find":
+	{
+		"height": 23.0
+	},
+	"input":
+	{
+		"height": 31.0
+	},
+	"layout":
+	{
+		"cells":
+		[
+			[
+				0,
+				0,
+				1,
+				1
+			]
+		],
+		"cols":
+		[
+			0.0,
+			1.0
+		],
+		"rows":
+		[
+			0.0,
+			1.0
+		]
+	},
+	"menu_visible": true,
+	"output.9o:///Users/tamird/src/go/src/github.com/cockroachdb/cockroach/server/cli":
+	{
+		"height": 100.0
+	},
+	"output.GoSublime-output":
+	{
+		"height": 100.0
+	},
+	"output.GsDoc-output-output":
+	{
+		"height": 100.0
+	},
+	"output.MarGo-output":
+	{
+		"height": 100.0
+	},
+	"output.Oracle Output":
+	{
+		"height": 100.0
+	},
+	"output.find_results":
+	{
+		"height": 0.0
+	},
+	"pinned_build_system": "",
+	"project": "cockroach.sublime-project",
+	"replace":
+	{
+		"height": 42.0
+	},
+	"save_all_on_build": true,
+	"select_file":
+	{
+		"height": 0.0,
+		"last_filter": "",
+		"selected_items":
+		[
+			[
+				"store_test",
+				"storage/store_test.go"
+			],
+			[
+				"evaltest",
+				"sql/parser/eval_test.go"
+			],
+			[
+				"makefile",
+				"Makefile"
+			],
+			[
+				"make",
+				"Makefile"
+			],
+			[
+				"glockfile",
+				"GLOCKFILE"
+			],
+			[
+				"makef",
+				"Makefile"
+			],
+			[
+				"store.go",
+				"storage/store.go"
+			],
+			[
+				"store.ggo",
+				"storage/engine/gc.go"
+			],
+			[
+				"protoerrors.go",
+				"proto/errors.go"
+			],
+			[
+				"protoerro",
+				"proto/errors.go"
+			],
+			[
+				"errors",
+				"keys/errors.go"
+			],
+			[
+				"responsecache",
+				"storage/response_cache.go"
+			],
+			[
+				"rangetest",
+				"storage/range_test.go"
+			],
+			[
+				"responsecach",
+				"storage/response_cache.go"
+			],
+			[
+				"protoapi.pb.go",
+				"proto/api.pb.go"
+			],
+			[
+				"rangecommand",
+				"storage/range_command.go"
+			],
+			[
+				"wire.pro",
+				"sql/sqlwire/wire.proto"
+			],
+			[
+				"kvlocal",
+				"kv/local_sender.go"
+			],
+			[
+				"protoerror.go",
+				"proto/errors.go"
+			],
+			[
+				"kvlocalsender",
+				"kv/local_sender.go"
+			],
+			[
+				"store",
+				"storage/store.go"
+			],
+			[
+				"mvcc.go",
+				"storage/engine/mvcc.go"
+			],
+			[
+				"range.go",
+				"storage/range.go"
+			],
+			[
+				"rangecomm",
+				"storage/range_command.go"
+			],
+			[
+				"range.",
+				"storage/range.go"
+			],
+			[
+				"storage/client_raft_test.go",
+				"storage/client_raft_test.go"
+			],
+			[
+				"cli/sql.go",
+				"cli/sql.go"
+			],
+			[
+				"proto.pb",
+				"proto/api.pb.go"
+			],
+			[
+				"protoapi.pb",
+				"proto/api.pb.go"
+			],
+			[
+				"txn_test",
+				"kv/txn_test.go"
+			],
+			[
+				"txntest",
+				"kv/txn_test.go"
+			],
+			[
+				"txncoo",
+				"kv/txn_coord_sender.go"
+			],
+			[
+				"batch.go",
+				"client/batch.go"
+			],
+			[
+				"call.go",
+				"proto/call.go"
+			],
+			[
+				"batchtest",
+				"storage/engine/batch_test.go"
+			],
+			[
+				"admin_test",
+				"client/admin_test.go"
+			],
+			[
+				"rpcclien",
+				"rpc/client.go"
+			],
+			[
+				"gossip/client.go",
+				"gossip/client.go"
+			],
+			[
+				"rpc/",
+				"rpc/client.go"
+			],
+			[
+				"cliento",
+				"rpc/client.go"
+			],
+			[
+				"send.go",
+				"rpc/send.go"
+			],
+			[
+				"rpcclient",
+				"rpc/client.go"
+			],
+			[
+				"api.prot",
+				"proto/api.proto"
+			],
+			[
+				"protoapi",
+				"proto/api.go"
+			],
+			[
+				"client.go",
+				"rpc/client.go"
+			],
+			[
+				"proto",
+				"proto/errors.proto"
+			],
+			[
+				"protoerr",
+				"proto/errors.go"
+			],
+			[
+				"dissn",
+				"kv/dist_sender.go"
+			],
+			[
+				"sendtest",
+				"rpc/send_test.go"
+			],
+			[
+				"rpcsend",
+				"rpc/send.go"
+			],
+			[
+				"sqlserver",
+				"sql/sqlserver/server.go"
+			],
+			[
+				"sqlsender",
+				"sql/driver/sender.go"
+			],
+			[
+				"sender.go",
+				"client/sender.go"
+			],
+			[
+				"httpsender",
+				"sql/driver/http_sender.go"
+			],
+			[
+				"sender",
+				"sql/driver/sender.go"
+			],
+			[
+				"genproto",
+				"scripts/genproto.sh"
+			],
+			[
+				"raft.proto",
+				"raftpb/raft.proto"
+			],
+			[
+				"progress",
+				"progress.go"
+			],
+			[
+				"multiraft",
+				"multiraft/heartbeat_test.go"
+			],
+			[
+				"sqlserverser",
+				"sql/sqlserver/server.go"
+			],
+			[
+				"httppos",
+				"client/http_post.go"
+			],
+			[
+				"drivertest",
+				"sql/driver/driver_test.go"
+			],
+			[
+				"sqlwire",
+				"sql/sqlwire/wire.proto"
+			],
+			[
+				"wire.proto",
+				"sql/sqlwire/wire.proto"
+			],
+			[
+				"multiraft/",
+				"multiraft/events.go"
+			],
+			[
+				"storetest",
+				"storage/store_test.go"
+			],
+			[
+				"rangecomma",
+				"storage/range_command.go"
+			],
+			[
+				"commandqu",
+				"storage/command_queue.go"
+			],
+			[
+				"range",
+				"storage/range.go"
+			],
+			[
+				"bitflag",
+				"src/librustc_bitflags/lib.rs"
+			],
+			[
+				"try",
+				"src/rt/rust_try.ll"
+			],
+			[
+				".ll",
+				"src/rt/rust_try_msvc_64.ll"
+			],
+			[
+				"transmod.rs",
+				"src/librustc_trans/trans/mod.rs"
+			],
+			[
+				"rustll",
+				"src/rt/rust_try.ll"
+			],
+			[
+				"transcommon",
+				"src/librustc_trans/trans/common.rs"
+			],
+			[
+				"localluste",
+				"run/local-cluster.sh"
+			],
+			[
+				"rpcserver",
+				"rpc/server.go"
+			],
+			[
+				"localcluster",
+				"acceptance/localcluster/localcluster.go"
+			],
+			[
+				"rpcsend.go",
+				"rpc/send.go"
+			],
+			[
+				"rcpsend",
+				"client/rpc/rpc_sender.go"
+			],
+			[
+				"dis",
+				"kv/dist_sender.go"
+			],
+			[
+				"client",
+				"rpc/client.go"
+			],
+			[
+				"circle",
+				"circle.yml"
+			],
+			[
+				"dist",
+				"kv/dist_sender.go"
+			],
+			[
+				"server.go",
+				"rpc/server.go"
+			],
+			[
+				"servero",
+				"rpc/server.go"
+			],
+			[
+				"utiladdr",
+				"util/unresolved_addr.go"
+			],
+			[
+				"client.",
+				"rpc/client.go"
+			],
+			[
+				"local",
+				"run/local-cluster.sh"
+			],
+			[
+				"tracer",
+				"util/tracer/tracer.go"
+			],
+			[
+				"devdocker",
+				"build/devbase/Dockerfile"
+			],
+			[
+				"racer",
+				"util/tracer/tracer.go"
+			],
+			[
+				"circl",
+				"circle.yml"
+			],
+			[
+				"localclu",
+				"run/local-cluster.sh"
+			],
+			[
+				"send",
+				"rpc/send.go"
+			],
+			[
+				"dist_sender",
+				"kv/dist_sender.go"
+			],
+			[
+				"server/server",
+				"server/server.go"
+			],
+			[
+				"stopper.",
+				"util/stop/stopper.go"
+			],
+			[
+				"tracer.",
+				"util/tracer/tracer.go"
+			],
+			[
+				"stopper",
+				"util/stop/stopper.go"
+			],
+			[
+				"rpctest",
+				"rpc_test.go"
+			],
+			[
+				"",
+				"client.go"
+			],
+			[
+				"rpcserver.go",
+				"rpc/server.go"
+			],
+			[
+				"mvcc_test",
+				"storage/engine/mvcc_test.go"
+			],
+			[
+				"makefil",
+				"Makefile"
+			],
+			[
+				"hlc",
+				"util/hlc/hlc.go"
+			],
+			[
+				"rpccclient",
+				"rpc/codec/client.go"
+			],
+			[
+				"distsn",
+				"kv/dist_sender.go"
+			],
+			[
+				"gossipserver",
+				"gossip/server.go"
+			],
+			[
+				"gossip",
+				"gossip/gossip.go"
+			],
+			[
+				"contr",
+				"CONTRIBUTING.md"
+			],
+			[
+				"readme",
+				"README.md"
+			],
+			[
+				"sqlproto",
+				"sql/sqlwire/wire.proto"
+			],
+			[
+				"leaktest",
+				"util/leaktest/leaktest.go"
+			],
+			[
+				"keys.go",
+				"gossip/keys.go"
+			],
+			[
+				"raftrr",
+				"server/raft_transport.go"
+			],
+			[
+				"sqlbank",
+				"examples/sql_bank/main.go"
+			],
+			[
+				"bank.",
+				"examples/bank/bank.go"
+			],
+			[
+				"rocksdb",
+				"storage/engine/rocksdb.go"
+			],
+			[
+				"snappy.go",
+				"rpc/codec/snappy.go"
+			],
+			[
+				"protobu",
+				"build/protobuf.mk"
+			],
+			[
+				"ma",
+				"Makefile"
+			],
+			[
+				"engine",
+				"storage/engine/engine.go"
+			],
+			[
+				"util",
+				"util/error.go"
+			],
+			[
+				"rcpserver",
+				"rpc/server.go"
+			],
+			[
+				"lz4",
+				"rpc/codec/lz4.go"
+			],
+			[
+				"encoding.cc",
+				"storage/engine/rocksdb_native/encoding.cc"
+			],
+			[
+				"encoding",
+				"storage/engine/encoding.h"
+			]
+		],
+		"width": 0.0
+	},
+	"select_project":
+	{
+		"height": 0.0,
+		"last_filter": "",
+		"selected_items":
+		[
+		],
+		"width": 0.0
+	},
+	"select_symbol":
+	{
+		"height": 0.0,
+		"last_filter": "",
+		"selected_items":
+		[
+		],
+		"width": 0.0
+	},
+	"selected_group": 0,
+	"settings":
+	{
+	},
+	"show_minimap": true,
+	"show_open_files": false,
+	"show_tabs": true,
+	"side_bar_visible": true,
+	"side_bar_width": 252.0,
+	"status_bar_visible": true,
+	"template_settings":
+	{
+	}
+}

--- a/examples/sql_bank/main.go
+++ b/examples/sql_bank/main.go
@@ -52,8 +52,10 @@ func moveMoney(db *sql.DB) {
 		if _, err := tx.Exec("SET TRANSACTION ISOLATION LEVEL SERIALIZABLE"); err != nil {
 			log.Fatal(err)
 		}
-		rows, err := tx.Query("SELECT id, balance FROM accounts WHERE id IN ($1, $2)", from, to)
-		if err != nil {
+		var rows *sql.Rows
+		if r, err := tx.Query("SELECT id, balance FROM accounts WHERE id IN ($1, $2)", from, to); err == nil {
+			rows = r
+		} else {
 			if log.V(1) {
 				log.Warning(err)
 			}

--- a/examples/sql_bank/main.go
+++ b/examples/sql_bank/main.go
@@ -49,7 +49,7 @@ func moveMoney(db *sql.DB) {
 		if err != nil {
 			log.Fatal(err)
 		}
-		if _, err = tx.Exec("SET TRANSACTION ISOLATION LEVEL SERIALIZABLE"); err != nil {
+		if _, err := tx.Exec("SET TRANSACTION ISOLATION LEVEL SERIALIZABLE"); err != nil {
 			log.Fatal(err)
 		}
 		rows, err := tx.Query("SELECT id, balance FROM accounts WHERE id IN ($1, $2)", from, to)
@@ -57,7 +57,7 @@ func moveMoney(db *sql.DB) {
 			if log.V(1) {
 				log.Warning(err)
 			}
-			if err = tx.Rollback(); err != nil {
+			if err := tx.Rollback(); err != nil {
 				log.Fatal(err)
 			}
 			continue
@@ -65,7 +65,7 @@ func moveMoney(db *sql.DB) {
 		var fromBalance, toBalance int
 		for rows.Next() {
 			var id, balance int
-			if err = rows.Scan(&id, &balance); err != nil {
+			if err := rows.Scan(&id, &balance); err != nil {
 				log.Fatal(err)
 			}
 			switch id {
@@ -78,25 +78,25 @@ func moveMoney(db *sql.DB) {
 			}
 		}
 
-		if _, err = tx.Exec("UPDATE accounts SET balance=$2 WHERE id=$1", from, fromBalance-amount); err != nil {
+		if _, err := tx.Exec("UPDATE accounts SET balance=$2 WHERE id=$1", from, fromBalance-amount); err != nil {
 			if log.V(1) {
 				log.Warning(err)
 			}
-			if err = tx.Rollback(); err != nil {
+			if err := tx.Rollback(); err != nil {
 				log.Fatal(err)
 			}
 			continue
 		}
-		if _, err = tx.Exec("UPDATE accounts SET balance=$2 WHERE id=$1", to, toBalance+amount); err != nil {
+		if _, err := tx.Exec("UPDATE accounts SET balance=$2 WHERE id=$1", to, toBalance+amount); err != nil {
 			if log.V(1) {
 				log.Warning(err)
 			}
-			if err = tx.Rollback(); err != nil {
+			if err := tx.Rollback(); err != nil {
 				log.Fatal(err)
 			}
 			continue
 		}
-		if err = tx.Commit(); err != nil {
+		if err := tx.Commit(); err != nil {
 			if log.V(1) {
 				log.Warning(err)
 			}
@@ -124,12 +124,12 @@ func verifyBank(db *sql.DB) {
 		}
 		for rows.Next() {
 			var balance int64
-			if err = rows.Scan(&balance); err != nil {
+			if err := rows.Scan(&balance); err != nil {
 				log.Fatal(err)
 			}
 			sum += balance
 		}
-		if err = tx.Commit(); err != nil {
+		if err := tx.Commit(); err != nil {
 			log.Fatal(err)
 		}
 	}
@@ -160,16 +160,16 @@ func main() {
 
 	db.SetMaxOpenConns(concurrency)
 
-	if _, err = db.Exec("CREATE TABLE IF NOT EXISTS accounts (id BIGINT UNIQUE NOT NULL, balance BIGINT NOT NULL)"); err != nil {
+	if _, err := db.Exec("CREATE TABLE IF NOT EXISTS accounts (id BIGINT UNIQUE NOT NULL, balance BIGINT NOT NULL)"); err != nil {
 		log.Fatal(err)
 	}
 
-	if _, err = db.Exec("TRUNCATE TABLE accounts"); err != nil {
+	if _, err := db.Exec("TRUNCATE TABLE accounts"); err != nil {
 		log.Fatal(err)
 	}
 
 	for i := 0; i < numAccounts; i++ {
-		if _, err = db.Exec("INSERT INTO accounts (id, balance) VALUES ($1, $2)", i, 0); err != nil {
+		if _, err := db.Exec("INSERT INTO accounts (id, balance) VALUES ($1, $2)", i, 0); err != nil {
 			log.Fatal(err)
 		}
 	}

--- a/gossip/gossip_test.go
+++ b/gossip/gossip_test.go
@@ -82,16 +82,15 @@ func TestGossipGroupsInfoStore(t *testing.T) {
 			t.Fatal(err)
 		}
 	}
-	values, err := g.GetGroupInfos("i")
-	if err != nil {
+	if values, err := g.GetGroupInfos("i"); err != nil {
 		t.Errorf("error fetching int64 group: %v", err)
-	}
-	if len(values) != 3 {
+	} else if len(values) != 3 {
 		t.Errorf("incorrect number of values in group: %v", values)
-	}
-	for i := 0; i < 3; i++ {
-		if values[i].(int64) != int64(i) {
-			t.Errorf("index %d has incorrect value: %d, expected %d", i, values[i].(int64), i)
+	} else {
+		for i := 0; i < 3; i++ {
+			if values[i].(int64) != int64(i) {
+				t.Errorf("index %d has incorrect value: %d, expected %d", i, values[i].(int64), i)
+			}
 		}
 	}
 	if _, err := g.GetGroupInfos("i2"); err == nil {
@@ -107,16 +106,15 @@ func TestGossipGroupsInfoStore(t *testing.T) {
 			t.Fatal(err)
 		}
 	}
-	values, err = g.GetGroupInfos("f")
-	if err != nil {
+	if values, err := g.GetGroupInfos("f"); err != nil {
 		t.Errorf("error fetching float64 group: %v", err)
-	}
-	if len(values) != 3 {
+	} else if len(values) != 3 {
 		t.Errorf("incorrect number of values in group: %v", values)
-	}
-	for i := 0; i < 3; i++ {
-		if values[i].(float64) != float64(i) {
-			t.Errorf("index %d has incorrect value: %f, expected %d", i, values[i].(float64), i)
+	} else {
+		for i := 0; i < 3; i++ {
+			if values[i].(float64) != float64(i) {
+				t.Errorf("index %d has incorrect value: %f, expected %d", i, values[i].(float64), i)
+			}
 		}
 	}
 
@@ -129,16 +127,15 @@ func TestGossipGroupsInfoStore(t *testing.T) {
 			t.Fatal(err)
 		}
 	}
-	values, err = g.GetGroupInfos("s")
-	if err != nil {
+	if values, err := g.GetGroupInfos("s"); err != nil {
 		t.Errorf("error fetching string group: %v", err)
-	}
-	if len(values) != 3 {
+	} else if len(values) != 3 {
 		t.Errorf("incorrect number of values in group: %v", values)
-	}
-	for i := 0; i < 3; i++ {
-		if values[i].(string) != fmt.Sprintf("%d", i) {
-			t.Errorf("index %d has incorrect value: %d, expected %s", i, values[i], fmt.Sprintf("%d", i))
+	} else {
+		for i := 0; i < 3; i++ {
+			if values[i].(string) != fmt.Sprintf("%d", i) {
+				t.Errorf("index %d has incorrect value: %d, expected %s", i, values[i], fmt.Sprintf("%d", i))
+			}
 		}
 	}
 }

--- a/gossip/group_test.go
+++ b/gossip/group_test.go
@@ -134,11 +134,9 @@ func TestSameKeyInserts(t *testing.T) {
 	defer leaktest.AfterTest(t)
 	group := newGroup("a", 1, MinGroup)
 	info1 := newTestInfo("a.a", int64(1))
-	changed, err := group.addInfo(info1)
-	if err != nil {
+	if changed, err := group.addInfo(info1); err != nil {
 		t.Error(err)
-	}
-	if !changed {
+	} else if !changed {
 		t.Error("expected changed contents to be true on first insert")
 	}
 
@@ -152,20 +150,16 @@ func TestSameKeyInserts(t *testing.T) {
 	// Two successively larger timestamps always win.
 	info3 := newTestInfo("a.a", int64(1))
 	info3.Timestamp = info1.Timestamp + 1
-	changed, err = group.addInfo(info3)
-	if err != nil {
+	if changed, err := group.addInfo(info3); err != nil {
 		t.Error(err)
-	}
-	if changed {
+	} else if changed {
 		t.Error("expected changed to be false on successive timestamp but same value")
 	}
 	info4 := newTestInfo("a.a", int64(2)) // change value
 	info4.Timestamp = info1.Timestamp + 2
-	changed, err = group.addInfo(info4)
-	if err != nil {
+	if changed, err := group.addInfo(info4); err != nil {
 		t.Error(err)
-	}
-	if !changed {
+	} else if !changed {
 		t.Error("expected changed to be true on successive timestamp with different value")
 	}
 }

--- a/kv/db_test.go
+++ b/kv/db_test.go
@@ -200,7 +200,7 @@ func TestKVDBTransaction(t *testing.T) {
 
 	key := proto.Key("db-txn-test")
 	value := []byte("value")
-	err := db.Txn(func(txn *client.Txn) error {
+	if err := db.Txn(func(txn *client.Txn) error {
 		// Use snapshot isolation so non-transactional read can always push.
 		txn.SetSnapshotIsolation()
 
@@ -222,8 +222,7 @@ func TestKVDBTransaction(t *testing.T) {
 			t.Errorf("expected value %q; got %q", value, gr.ValueBytes())
 		}
 		return nil
-	})
-	if err != nil {
+	}); err != nil {
 		t.Errorf("expected success on commit; got %s", err)
 	}
 

--- a/kv/dist_sender_test.go
+++ b/kv/dist_sender_test.go
@@ -65,7 +65,7 @@ func makeTestGossip(t *testing.T) (*gossip.Gossip, func()) {
 		{proto.KeyMin, nil, permConfig},
 	})
 	if err != nil {
-		t.Fatalf("failed to make prefix config map, err: %s", err.Error())
+		t.Fatalf("failed to make prefix config map, err: %s", err)
 	}
 	if err := g.AddInfo(gossip.KeySentinel, "cluster1", time.Hour); err != nil {
 		t.Fatal(err)
@@ -607,7 +607,7 @@ func TestVerifyPermissions(t *testing.T) {
 	}
 	configMap, err := storage.NewPrefixConfigMap(configs)
 	if err != nil {
-		t.Fatalf("failed to make prefix config map, err: %s", err.Error())
+		t.Fatalf("failed to make prefix config map, err: %s", err)
 	}
 	if err := ds.gossip.AddInfo(gossip.KeyConfigPermission, configMap, time.Hour); err != nil {
 		t.Fatal(err)

--- a/kv/local_sender_test.go
+++ b/kv/local_sender_test.go
@@ -69,7 +69,7 @@ func TestLocalSenderVisitStores(t *testing.T) {
 	visit := make([]bool, numStores)
 	err := ls.VisitStores(func(s *storage.Store) error { visit[s.Ident.StoreID] = true; return nil })
 	if err != nil {
-		t.Errorf("unexpected error on visit: %s", err.Error())
+		t.Errorf("unexpected error on visit: %s", err)
 	}
 
 	for i, visited := range visit {
@@ -102,7 +102,7 @@ func TestLocalSenderGetStore(t *testing.T) {
 		t.Errorf("expected storeID to be %d but was %d",
 			s.Ident.StoreID, store.Ident.StoreID)
 	} else if err != nil {
-		t.Errorf("expected no error, instead had err=%s", err.Error())
+		t.Errorf("expected no error, instead had err=%s", err)
 	}
 }
 

--- a/kv/range_cache_test.go
+++ b/kv/range_cache_test.go
@@ -131,7 +131,7 @@ func (db *testDescriptorDB) assertLookupCount(t *testing.T, expected int, key st
 func doLookup(t *testing.T, rc *rangeDescriptorCache, key string) *proto.RangeDescriptor {
 	r, err := rc.LookupRangeDescriptor(proto.Key(key), lookupOptions{})
 	if err != nil {
-		t.Fatalf("Unexpected error from LookupRangeDescriptor: %s", err.Error())
+		t.Fatalf("Unexpected error from LookupRangeDescriptor: %s", err)
 	}
 	if !r.ContainsKey(keys.KeyAddress(proto.Key(key))) {
 		t.Fatalf("Returned range did not contain key: %s-%s, %s", r.StartKey, r.EndKey, key)

--- a/kv/txn_test.go
+++ b/kv/txn_test.go
@@ -540,9 +540,11 @@ func TestTxnRepeatGetWithRangeSplit(t *testing.T) {
 		// Check that we split 1 times in allotted time.
 		if err := util.IsTrueWithin(func() bool {
 			// Scan the meta records.
-			rows, err := s.DB.Scan(keys.Meta2Prefix, keys.MetaMax, 0)
-			if err != nil {
-				t.Fatalf("failed to scan meta2 keys: %s", err)
+			var rows []client.KeyValue
+			if r, scanErr := s.DB.Scan(keys.Meta2Prefix, keys.MetaMax, 0); err == nil {
+				rows = r
+			} else {
+				t.Fatalf("failed to scan meta2 keys: %s", scanErr)
 			}
 			return len(rows) >= 2
 		}, 6*time.Second); err != nil {

--- a/kv/txn_test.go
+++ b/kv/txn_test.go
@@ -22,7 +22,6 @@ import (
 	"bytes"
 	"errors"
 	"fmt"
-	"reflect"
 	"sync"
 	"testing"
 	"time"
@@ -188,7 +187,7 @@ func verifyUncertainty(concurrency int, maxOffset time.Duration, t *testing.T) {
 					if _, ok := err.(*proto.ReadWithinUncertaintyIntervalError); ok {
 						return err
 					}
-					return util.Errorf("unexpected read error of type %s: %s", reflect.TypeOf(err), err)
+					return util.Errorf("unexpected read error of type %T: %s", err, err)
 				}
 				if !gr.Exists() {
 					return util.Errorf("no value read")
@@ -523,7 +522,7 @@ func TestTxnRepeatGetWithRangeSplit(t *testing.T) {
 	// Wait till txnA finish put(a).
 	<-ch
 
-	err := s.DB.Txn(func(txn *client.Txn) error {
+	if err := s.DB.Txn(func(txn *client.Txn) error {
 		// Use snapshot isolation.
 		txn.SetSnapshotIsolation()
 
@@ -563,8 +562,7 @@ func TestTxnRepeatGetWithRangeSplit(t *testing.T) {
 			t.Fatalf("Repeat read same key in same txn but get different value gr1 nil gr2 %v", gr2.Value)
 		}
 		return nil
-	})
-	if err != nil {
+	}); err != nil {
 		t.Fatal(err)
 	}
 }

--- a/proto/internal_test.go
+++ b/proto/internal_test.go
@@ -48,30 +48,24 @@ func TestTimeSeriesToValue(t *testing.T) {
 	}
 
 	// Wrap the TSD into a Value
-	valueOriginal, err := tsOriginal.ToValue()
-	if err != nil {
-		t.Fatalf("error marshaling InternalTimeSeriesData: %s", err.Error())
-	}
-	if a, e := valueOriginal.GetTag(), _CR_TS.String(); a != e {
+	if valueOriginal, err := tsOriginal.ToValue(); err != nil {
+		t.Fatalf("error marshaling InternalTimeSeriesData: %s", err)
+	} else if a, e := valueOriginal.GetTag(), _CR_TS.String(); a != e {
 		t.Errorf("Value did not have expected tag value of %s, had %s", e, a)
-	}
+	} else {
+		// Ensure the Value's 'bytes' field contains the marshalled TSD
+		if tsEncoded, err := gogoproto.Marshal(tsOriginal); err != nil {
+			t.Fatalf("error marshaling TimeSeriesData: %s", err)
+		} else if a, e := valueOriginal.Bytes, tsEncoded; !bytes.Equal(a, e) {
+			t.Errorf("bytes field was not properly encoded: expected %v, got %v", e, a)
+		}
 
-	// Ensure the Value's 'bytes' field contains the marshalled TSD
-	tsEncoded, err := gogoproto.Marshal(tsOriginal)
-	if err != nil {
-		t.Fatalf("error marshaling TimeSeriesData: %s", err.Error())
-	}
-	if a, e := valueOriginal.Bytes, tsEncoded; !bytes.Equal(a, e) {
-		t.Errorf("bytes field was not properly encoded: expected %v, got %v", e, a)
-	}
-
-	// Extract the TSD from the Value
-	tsNew, err := InternalTimeSeriesDataFromValue(valueOriginal)
-	if err != nil {
-		t.Errorf("error extracting Time Series: %s", err.Error())
-	}
-	if !gogoproto.Equal(tsOriginal, tsNew) {
-		t.Errorf("extracted time series not equivalent to original; %v != %v", tsNew, tsOriginal)
+		// Extract the TSD from the Value
+		if tsNew, err := InternalTimeSeriesDataFromValue(valueOriginal); err != nil {
+			t.Errorf("error extracting Time Series: %s", err)
+		} else if !gogoproto.Equal(tsOriginal, tsNew) {
+			t.Errorf("extracted time series not equivalent to original; %v != %v", tsNew, tsOriginal)
+		}
 	}
 
 	// Make sure ExtractTimeSeries doesn't work on non-TimeSeries values

--- a/proto/timeseries_test.go
+++ b/proto/timeseries_test.go
@@ -130,7 +130,7 @@ func TestToInternal(t *testing.T) {
 		actual, err := tc.input.ToInternal(tc.keyDuration, tc.sampleDuration)
 		if err != nil {
 			if !tc.expectsError {
-				t.Errorf("unexpected error from case %d: %s", i, err.Error())
+				t.Errorf("unexpected error from case %d: %s", i, err)
 			}
 			continue
 		} else if tc.expectsError {

--- a/rpc/codec/rpc_test.go
+++ b/rpc/codec/rpc_test.go
@@ -121,12 +121,11 @@ func listenAndServeArithAndEchoService(network, addr string) (net.Addr, error) {
 func testArithClient(t *testing.T, client *rpc.Client) {
 	var args message.ArithRequest
 	var reply message.ArithResponse
-	var err error
 
 	// Add
 	args.A = 1
 	args.B = 2
-	if err = client.Call("ArithService.Add", &args, &reply); err != nil {
+	if err := client.Call("ArithService.Add", &args, &reply); err != nil {
 		t.Fatalf(`arith.Add: %v`, err)
 	}
 	if reply.GetC() != 3 {
@@ -136,7 +135,7 @@ func testArithClient(t *testing.T, client *rpc.Client) {
 	// Mul
 	args.A = 2
 	args.B = 3
-	if err = client.Call("ArithService.Mul", &args, &reply); err != nil {
+	if err := client.Call("ArithService.Mul", &args, &reply); err != nil {
 		t.Fatalf(`arith.Mul: %v`, err)
 	}
 	if reply.GetC() != 6 {
@@ -146,7 +145,7 @@ func testArithClient(t *testing.T, client *rpc.Client) {
 	// Div
 	args.A = 13
 	args.B = 5
-	if err = client.Call("ArithService.Div", &args, &reply); err != nil {
+	if err := client.Call("ArithService.Div", &args, &reply); err != nil {
 		t.Fatalf(`arith.Div: %v`, err)
 	}
 	if reply.GetC() != 2 {
@@ -156,15 +155,15 @@ func testArithClient(t *testing.T, client *rpc.Client) {
 	// Div zero
 	args.A = 1
 	args.B = 0
-	if err = client.Call("ArithService.Div", &args, &reply); err.Error() != "divide by zero" {
-		t.Fatalf(`arith.Error: expected = "%s", got = "%s"`, "divide by zero", err.Error())
+	if err := client.Call("ArithService.Div", &args, &reply); err.Error() != "divide by zero" {
+		t.Fatalf(`arith.Error: expected = "%s", got = "%s"`, "divide by zero", err)
 	}
 
 	// Error
 	args.A = 1
 	args.B = 2
-	if err = client.Call("ArithService.Error", &args, &reply); err.Error() != "ArithError" {
-		t.Fatalf(`arith.Error: expected = "%s", got = "%s"`, "ArithError", err.Error())
+	if err := client.Call("ArithService.Error", &args, &reply); err.Error() != "ArithError" {
+		t.Fatalf(`arith.Error: expected = "%s", got = "%s"`, "ArithError", err)
 	}
 }
 
@@ -246,11 +245,10 @@ func testArithClientAsync(t *testing.T, client *rpc.Client) {
 func testEchoClient(t *testing.T, client *rpc.Client) {
 	var args message.EchoRequest
 	var reply message.EchoResponse
-	var err error
 
 	// EchoService.Echo
 	args.Msg = "Hello, Protobuf-RPC"
-	if err = client.Call("EchoService.Echo", &args, &reply); err != nil {
+	if err := client.Call("EchoService.Echo", &args, &reply); err != nil {
 		t.Fatalf(`EchoService.Echo: %v`, err)
 	}
 	if reply.GetMsg() != args.GetMsg() {
@@ -279,7 +277,6 @@ func listenAndServeEchoService(network, addr string,
 	serveConn func(srv *rpc.Server, conn io.ReadWriteCloser)) (net.Listener, error) {
 	l, err := net.Listen(network, addr)
 	if err != nil {
-		fmt.Printf("failed to listen on %s: %s\n", addr, err)
 		return nil, err
 	}
 	srv := rpc.NewServer()

--- a/rpc/heartbeat_test.go
+++ b/rpc/heartbeat_test.go
@@ -130,7 +130,7 @@ func TestUpdateOffsetOnHeartbeat(t *testing.T) {
 			MeasuredAt:  20,
 		},
 	}
-	if err = client.connect(); err != nil {
+	if err := client.connect(); err != nil {
 		t.Fatal(err)
 	}
 

--- a/rpc/server_test.go
+++ b/rpc/server_test.go
@@ -95,9 +95,9 @@ func TestUnregisteredMethod(t *testing.T) {
 
 	// Sending an invalid method fails cleanly, but leaves the connection
 	// in a valid state.
-	_, err := sendRPC(opts, []net.Addr{s.Addr()}, nodeContext, "Foo.Bar",
-		&proto.PingRequest{}, &proto.PingResponse{})
-	if !testutils.IsError(err, ".*rpc: couldn't find method: Foo.Bar") {
+	if _, err := sendRPC(
+		opts, []net.Addr{s.Addr()}, nodeContext, "Foo.Bar", &proto.PingRequest{}, &proto.PingResponse{},
+	); !testutils.IsError(err, ".*rpc: couldn't find method: Foo.Bar") {
 		t.Fatalf("expected 'couldn't find method' but got %s", err)
 	}
 	if _, err := sendPing(opts, []net.Addr{s.Addr()}, nodeContext); err != nil {

--- a/security/tls_test.go
+++ b/security/tls_test.go
@@ -43,15 +43,15 @@ func TestLoadTLSConfig(t *testing.T) {
 		t.Fatalf("Couldn't parse test cert: %v", err)
 	}
 
-	if err = verifyX509Cert(x509Cert, "localhost", config.RootCAs); err != nil {
+	if err := verifyX509Cert(x509Cert, "localhost", config.RootCAs); err != nil {
 		t.Errorf("Couldn't verify test cert against server CA: %v", err)
 	}
 
-	if err = verifyX509Cert(x509Cert, "localhost", config.ClientCAs); err != nil {
+	if err := verifyX509Cert(x509Cert, "localhost", config.ClientCAs); err != nil {
 		t.Errorf("Couldn't verify test cert against client CA: %v", err)
 	}
 
-	if err = verifyX509Cert(x509Cert, "google.com", config.RootCAs); err == nil {
+	if err := verifyX509Cert(x509Cert, "google.com", config.RootCAs); err == nil {
 		t.Errorf("Verified test cert for wrong hostname")
 	}
 }

--- a/server/admin.go
+++ b/server/admin.go
@@ -191,7 +191,7 @@ func (s *adminServer) handlePutAction(handler actionHandler, w http.ResponseWrit
 		return
 	}
 	defer r.Body.Close()
-	if err = handler.Put(path, b, r); err != nil {
+	if err := handler.Put(path, b, r); err != nil {
 		http.Error(w, err.Error(), http.StatusInternalServerError)
 		return
 	}
@@ -219,7 +219,7 @@ func (s *adminServer) handleDeleteAction(handler actionHandler, w http.ResponseW
 		http.Error(w, err.Error(), http.StatusBadRequest)
 		return
 	}
-	if err = handler.Delete(path, r); err != nil {
+	if err := handler.Delete(path, r); err != nil {
 		http.Error(w, err.Error(), http.StatusInternalServerError)
 		return
 	}

--- a/server/admin_test.go
+++ b/server/admin_test.go
@@ -88,12 +88,10 @@ func TestAdminDebugPprof(t *testing.T) {
 	s := StartTestServer(t)
 	defer s.Stop()
 
-	body, err := getText(s.Ctx.RequestScheme() + "://" + s.ServingAddr() + debugEndpoint + "pprof/block")
-	if err != nil {
+	if body, err := getText(s.Ctx.RequestScheme() + "://" + s.ServingAddr() + debugEndpoint + "pprof/block"); err != nil {
 		t.Fatal(err)
-	}
-	if matches, err := regexp.MatchString(".*contention:\ncycles/second=.*", string(body)); !matches || err != nil {
-		t.Errorf("expected match: %t; err nil: %v", matches, err)
+	} else if re := regexp.MustCompile(".*contention:\ncycles/second=.*"); !re.Match(body) {
+		t.Errorf("expected %s to match %s", body, re)
 	}
 }
 
@@ -131,7 +129,6 @@ range_max_bytes: 67108864
 		t.Fatal(err)
 	}
 	for i, test := range testData {
-		re := regexp.MustCompile(test.expErr)
 		req, err := http.NewRequest("POST", fmt.Sprintf("%s://%s%s/%s", s.Ctx.RequestScheme(), s.ServingAddr(), zonePathPrefix, "foo"), strings.NewReader(test.zone))
 		if err != nil {
 			t.Fatal(err)
@@ -148,7 +145,7 @@ range_max_bytes: 67108864
 		}
 		if resp.StatusCode == http.StatusOK {
 			t.Errorf("%d: expected error", i)
-		} else if !re.MatchString(string(b)) {
+		} else if re := regexp.MustCompile(test.expErr); !re.MatchString(string(b)) {
 			t.Errorf("%d: expected error matching %q; got %s", i, test.expErr, b)
 		}
 	}

--- a/server/node.go
+++ b/server/node.go
@@ -108,8 +108,9 @@ func BootstrapCluster(clusterID string, engines []engine.Engine, stopper *stop.S
 	// Create a KV DB with a local sender.
 	lSender := kv.NewLocalSender()
 	sender := kv.NewTxnCoordSender(lSender, ctx.Clock, false, nil, stopper)
-	var err error
-	if ctx.DB, err = client.Open("//root@", client.SenderOpt(sender)); err != nil {
+	if db, err := client.Open("//root@", client.SenderOpt(sender)); err == nil {
+		ctx.DB = db
+	} else {
 		return nil, err
 	}
 	ctx.Transport = multiraft.NewLocalRPCTransport()
@@ -218,7 +219,7 @@ func (n *Node) initNodeID(id proto.NodeID) {
 	// Gossip the node descriptor to make this node addressable by node ID.
 	n.Descriptor.NodeID = id
 	log.Infof("new node allocated ID %d", n.Descriptor.NodeID)
-	if err = n.ctx.Gossip.SetNodeDescriptor(&n.Descriptor); err != nil {
+	if err := n.ctx.Gossip.SetNodeDescriptor(&n.Descriptor); err != nil {
 		log.Fatalf("couldn't gossip descriptor for node %d: %s", n.Descriptor.NodeID, err)
 	}
 }

--- a/server/node_test.go
+++ b/server/node_test.go
@@ -398,20 +398,22 @@ func TestStatusSummaries(t *testing.T) {
 	}
 	defer ts.Stop()
 
+	var store *storage.Store
 	// Retrieve the first store from the Node.
-	s, err := ts.node.lSender.GetStore(proto.StoreID(1))
-	if err != nil {
+	if s, err := ts.node.lSender.GetStore(proto.StoreID(1)); err == nil {
+		store = s
+	} else {
 		t.Fatal(err)
 	}
 
-	s.WaitForInit()
+	store.WaitForInit()
 	// Perform a read from the range to ensure that the raft election has
 	// completed.  We do not expect a response.
 	if _, err := ts.db.Get("a"); err != nil {
 		t.Fatal(err)
 	}
 
-	storeDesc, err := s.Descriptor()
+	storeDesc, err := store.Descriptor()
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -478,7 +480,7 @@ func TestStatusSummaries(t *testing.T) {
 
 	forceWriteStatus()
 	oldNodeStats := compareNodeStatus(t, ts, expectedNodeStatus, 0)
-	oldStoreStats := compareStoreStatus(t, ts, s, expectedStoreStatus, 0)
+	oldStoreStats := compareStoreStatus(t, ts, store, expectedStoreStatus, 0)
 
 	// Write some values left and right of the proposed split key.
 	content := proto.Key("test content")
@@ -526,16 +528,16 @@ func TestStatusSummaries(t *testing.T) {
 
 	forceWriteStatus()
 	oldNodeStats = compareNodeStatus(t, ts, expectedNodeStatus, 1)
-	oldStoreStats = compareStoreStatus(t, ts, s, expectedStoreStatus, 1)
+	oldStoreStats = compareStoreStatus(t, ts, store, expectedStoreStatus, 1)
 
 	// Split the range.
 	splitKey := proto.Key("b")
-	rng := s.LookupRange(splitKey, nil)
+	rng := store.LookupRange(splitKey, nil)
 	args := &proto.AdminSplitRequest{
 		RequestHeader: proto.RequestHeader{
 			Key:     proto.KeyMin,
 			RaftID:  rng.Desc().RaftID,
-			Replica: proto.Replica{StoreID: s.Ident.StoreID},
+			Replica: proto.Replica{StoreID: store.Ident.StoreID},
 		},
 		SplitKey: splitKey,
 	}
@@ -581,7 +583,7 @@ func TestStatusSummaries(t *testing.T) {
 	}
 	forceWriteStatus()
 	oldNodeStats = compareNodeStatus(t, ts, expectedNodeStatus, 2)
-	oldStoreStats = compareStoreStatus(t, ts, s, expectedStoreStatus, 2)
+	oldStoreStats = compareStoreStatus(t, ts, store, expectedStoreStatus, 2)
 
 	// Write some values left and right of the proposed split key.
 	if err := ts.db.Put("aa", content); err != nil {
@@ -627,5 +629,5 @@ func TestStatusSummaries(t *testing.T) {
 	}
 	forceWriteStatus()
 	compareNodeStatus(t, ts, expectedNodeStatus, 3)
-	compareStoreStatus(t, ts, s, expectedStoreStatus, 3)
+	compareStoreStatus(t, ts, store, expectedStoreStatus, 3)
 }

--- a/server/node_test.go
+++ b/server/node_test.go
@@ -185,8 +185,7 @@ func TestNodeJoin(t *testing.T) {
 	defer leaktest.AfterTest(t)
 	stopper := stop.NewStopper()
 	e := engine.NewInMem(proto.Attributes{}, 1<<20)
-	_, err := BootstrapCluster("cluster-1", []engine.Engine{e}, stopper)
-	if err != nil {
+	if _, err := BootstrapCluster("cluster-1", []engine.Engine{e}, stopper); err != nil {
 		t.Fatal(err)
 	}
 	stopper.Stop()
@@ -247,7 +246,7 @@ func TestCorruptedClusterID(t *testing.T) {
 		NodeID:    1,
 		StoreID:   1,
 	}
-	if err = engine.MVCCPutProto(e, nil, keys.StoreIdentKey(), proto.ZeroTimestamp, nil, &sIdent); err != nil {
+	if err := engine.MVCCPutProto(e, nil, keys.StoreIdentKey(), proto.ZeroTimestamp, nil, &sIdent); err != nil {
 		t.Fatal(err)
 	}
 
@@ -540,13 +539,9 @@ func TestStatusSummaries(t *testing.T) {
 		},
 		SplitKey: splitKey,
 	}
-	var reply *proto.AdminSplitResponse
 	if replyI, err := ts.node.executeCmd(args); err != nil {
 		t.Fatal(err)
-	} else {
-		reply = replyI.(*proto.AdminSplitResponse)
-	}
-	if reply.Error != nil {
+	} else if reply := replyI.(*proto.AdminSplitResponse); reply.Error != nil {
 		t.Fatal(reply.Error)
 	}
 

--- a/server/server.go
+++ b/server/server.go
@@ -84,8 +84,7 @@ func NewServer(ctx *Context, stopper *stop.Stopper) (*Server, error) {
 	}
 
 	addr := ctx.Addr
-	_, err := net.ResolveTCPAddr("tcp", addr)
-	if err != nil {
+	if _, err := net.ResolveTCPAddr("tcp", addr); err != nil {
 		return nil, util.Errorf("unable to resolve RPC address %q: %v", addr, err)
 	}
 
@@ -122,19 +121,22 @@ func NewServer(ctx *Context, stopper *stop.Stopper) (*Server, error) {
 
 	ds := kv.NewDistSender(&kv.DistSenderContext{Clock: s.clock}, s.gossip)
 	sender := kv.NewTxnCoordSender(ds, s.clock, ctx.Linearizable, tracer, s.stopper)
-	if s.db, err = client.Open("//root@", client.SenderOpt(sender)); err != nil {
+	if db, err := client.Open("//root@", client.SenderOpt(sender)); err == nil {
+		s.db = db
+	} else {
 		return nil, err
 	}
 
-	s.raftTransport, err = newRPCTransport(s.gossip, s.rpc, rpcContext)
-	if err != nil {
+	if transport, err := newRPCTransport(s.gossip, s.rpc, rpcContext); err == nil {
+		s.raftTransport = transport
+	} else {
 		return nil, err
 	}
 	s.stopper.AddCloser(s.raftTransport)
 
 	s.kvDB = kv.NewDBServer(&s.ctx.Context, sender)
 	if s.ctx.ExperimentalRPCServer {
-		if err = s.kvDB.RegisterRPC(s.rpc); err != nil {
+		if err := s.kvDB.RegisterRPC(s.rpc); err != nil {
 			return nil, err
 		}
 	}

--- a/server/status/feed_test.go
+++ b/server/status/feed_test.go
@@ -252,13 +252,12 @@ func TestServerNodeEventFeed(t *testing.T) {
 	}
 
 	// Add some data in a transaction
-	err = db.Txn(func(txn *client.Txn) error {
+	if err := db.Txn(func(txn *client.Txn) error {
 		b := &client.Batch{}
 		b.Put("a", "asdf")
 		b.Put("c", "jkl;")
 		return txn.Commit(b)
-	})
-	if err != nil {
+	}); err != nil {
 		t.Fatalf("error putting data to db: %s", err)
 	}
 
@@ -268,7 +267,7 @@ func TestServerNodeEventFeed(t *testing.T) {
 	}
 
 	// Scan, which should fail.
-	if _, err = db.Scan("b", "a", 0); err == nil {
+	if _, err := db.Scan("b", "a", 0); err == nil {
 		t.Fatal("expected scan to fail.")
 	}
 

--- a/server/testserver.go
+++ b/server/testserver.go
@@ -155,9 +155,9 @@ func (ts *TestServer) Start() error {
 		ts.Ctx = NewTestContext()
 	}
 
-	var err error
-	ts.Server, err = NewServer(ts.Ctx, stop.NewStopper())
-	if err != nil {
+	if s, err := NewServer(ts.Ctx, stop.NewStopper()); err == nil {
+		ts.Server = s
+	} else {
 		return err
 	}
 
@@ -173,18 +173,12 @@ func (ts *TestServer) Start() error {
 
 	if !ts.SkipBootstrap {
 		stopper := stop.NewStopper()
-		_, err := BootstrapCluster("cluster-1", ts.Ctx.Engines, stopper)
-		if err != nil {
+		if _, err := BootstrapCluster("cluster-1", ts.Ctx.Engines, stopper); err != nil {
 			return util.Errorf("could not bootstrap cluster: %s", err)
 		}
 		stopper.Stop()
 	}
-	err = ts.Server.Start(true)
-	if err != nil {
-		return err
-	}
-
-	return nil
+	return ts.Server.Start(true)
 }
 
 // ServingAddr returns the rpc server's address. Should be used by clients.

--- a/sql/parser/eval.go
+++ b/sql/parser/eval.go
@@ -450,9 +450,9 @@ func EvalExpr(expr Expr, env Env) (Datum, error) {
 }
 
 func evalAndExpr(expr *AndExpr, env Env) (Datum, error) {
-	left, err := EvalExpr(expr.Left, env)
-	if err != nil {
-		return null, err
+	left, leftErr := EvalExpr(expr.Left, env)
+	if leftErr != nil {
+		return null, leftErr
 	}
 	if left == null {
 		return null, nil
@@ -462,9 +462,9 @@ func evalAndExpr(expr *AndExpr, env Env) (Datum, error) {
 	} else if !v {
 		return v, nil
 	}
-	right, err := EvalExpr(expr.Right, env)
-	if err != nil {
-		return null, err
+	right, rightErr := EvalExpr(expr.Right, env)
+	if rightErr != nil {
+		return null, rightErr
 	}
 	if right == null {
 		return null, nil
@@ -478,9 +478,9 @@ func evalAndExpr(expr *AndExpr, env Env) (Datum, error) {
 }
 
 func evalOrExpr(expr *OrExpr, env Env) (Datum, error) {
-	left, err := EvalExpr(expr.Left, env)
-	if err != nil {
-		return null, err
+	left, leftErr := EvalExpr(expr.Left, env)
+	if leftErr != nil {
+		return null, leftErr
 	}
 	if left != null {
 		if v, err := getBool(left); err != nil {
@@ -489,9 +489,9 @@ func evalOrExpr(expr *OrExpr, env Env) (Datum, error) {
 			return v, nil
 		}
 	}
-	right, err := EvalExpr(expr.Right, env)
-	if err != nil {
-		return null, err
+	right, rightErr := EvalExpr(expr.Right, env)
+	if rightErr != nil {
+		return null, rightErr
 	}
 	if right == null {
 		return null, nil

--- a/storage/addressing.go
+++ b/storage/addressing.go
@@ -40,8 +40,7 @@ func delMeta(b *client.Batch, key proto.Key, desc *proto.RangeDescriptor) {
 // and meta2 range addressing records for the left and right ranges
 // caused by a split.
 func splitRangeAddressing(b *client.Batch, left, right *proto.RangeDescriptor) error {
-	var err error
-	if err = rangeAddressing(b, left, putMeta); err != nil {
+	if err := rangeAddressing(b, left, putMeta); err != nil {
 		return err
 	}
 	return rangeAddressing(b, right, putMeta)
@@ -52,8 +51,7 @@ func splitRangeAddressing(b *client.Batch, left, right *proto.RangeDescriptor) e
 // the new merged range. Left is the range descriptor for the "left"
 // range before merging and merged describes the left to right merge.
 func mergeRangeAddressing(b *client.Batch, left, merged *proto.RangeDescriptor) error {
-	var err error
-	if err = rangeAddressing(b, left, delMeta); err != nil {
+	if err := rangeAddressing(b, left, delMeta); err != nil {
 		return err
 	}
 	return rangeAddressing(b, merged, putMeta)

--- a/storage/client_event_test.go
+++ b/storage/client_event_test.go
@@ -232,13 +232,12 @@ func TestMultiStoreEventFeed(t *testing.T) {
 	mtc.replicateRange(raftID, 0, 1, 2)
 
 	// Add some data in a transaction
-	err := mtc.db.Txn(func(txn *client.Txn) error {
+	if err := mtc.db.Txn(func(txn *client.Txn) error {
 		b := &client.Batch{}
 		b.Put("a", "asdf")
 		b.Put("c", "jkl;")
 		return txn.Commit(b)
-	})
-	if err != nil {
+	}); err != nil {
 		t.Fatalf("error putting data to db: %s", err)
 	}
 

--- a/storage/client_merge_test.go
+++ b/storage/client_merge_test.go
@@ -166,11 +166,11 @@ func TestStoreRangeMergeWithData(t *testing.T) {
 
 	// Put new values after the merge on both sides.
 	pArgs, pReply = putArgs([]byte("aaaa"), content, rangeA.Desc().RaftID, store.StoreID())
-	if err = store.ExecuteCmd(context.Background(), proto.Call{Args: pArgs, Reply: pReply}); err != nil {
+	if err := store.ExecuteCmd(context.Background(), proto.Call{Args: pArgs, Reply: pReply}); err != nil {
 		t.Fatal(err)
 	}
 	pArgs, pReply = putArgs([]byte("cccc"), content, rangeB.Desc().RaftID, store.StoreID())
-	if err = store.ExecuteCmd(context.Background(), proto.Call{Args: pArgs, Reply: pReply}); err != nil {
+	if err := store.ExecuteCmd(context.Background(), proto.Call{Args: pArgs, Reply: pReply}); err != nil {
 		t.Fatal(err)
 	}
 

--- a/storage/client_raft_test.go
+++ b/storage/client_raft_test.go
@@ -20,7 +20,6 @@ package storage_test
 import (
 	"fmt"
 	"reflect"
-	"strings"
 	"sync"
 	"sync/atomic"
 	"testing"
@@ -33,6 +32,7 @@ import (
 	"github.com/cockroachdb/cockroach/proto"
 	"github.com/cockroachdb/cockroach/storage"
 	"github.com/cockroachdb/cockroach/storage/engine"
+	"github.com/cockroachdb/cockroach/testutils"
 	"github.com/cockroachdb/cockroach/util"
 	"github.com/cockroachdb/cockroach/util/hlc"
 	"github.com/cockroachdb/cockroach/util/leaktest"
@@ -211,11 +211,10 @@ func TestReplicateRange(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	if err := rng.ChangeReplicas(proto.ADD_REPLICA,
-		proto.Replica{
-			NodeID:  mtc.stores[1].Ident.NodeID,
-			StoreID: mtc.stores[1].Ident.StoreID,
-		}); err != nil {
+	if err := rng.ChangeReplicas(proto.ADD_REPLICA, proto.Replica{
+		NodeID:  mtc.stores[1].Ident.NodeID,
+		StoreID: mtc.stores[1].Ident.StoreID,
+	}); err != nil {
 		t.Fatal(err)
 	}
 	// Verify no intent remains on range descriptor key.
@@ -274,11 +273,10 @@ func TestRestoreReplicas(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	if err := firstRng.ChangeReplicas(proto.ADD_REPLICA,
-		proto.Replica{
-			NodeID:  mtc.stores[1].Ident.NodeID,
-			StoreID: mtc.stores[1].Ident.StoreID,
-		}); err != nil {
+	if err := firstRng.ChangeReplicas(proto.ADD_REPLICA, proto.Replica{
+		NodeID:  mtc.stores[1].Ident.NodeID,
+		StoreID: mtc.stores[1].Ident.StoreID,
+	}); err != nil {
 		t.Fatal(err)
 	}
 
@@ -366,12 +364,10 @@ func TestFailedReplicaChange(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	err = rng.ChangeReplicas(proto.ADD_REPLICA,
-		proto.Replica{
-			NodeID:  mtc.stores[1].Ident.NodeID,
-			StoreID: mtc.stores[1].Ident.StoreID,
-		})
-	if err == nil || !strings.Contains(err.Error(), "boom") {
+	if err := rng.ChangeReplicas(proto.ADD_REPLICA, proto.Replica{
+		NodeID:  mtc.stores[1].Ident.NodeID,
+		StoreID: mtc.stores[1].Ident.StoreID,
+	}); !testutils.IsError(err, "boom") {
 		t.Fatalf("did not get expected error: %s", err)
 	}
 
@@ -385,12 +381,10 @@ func TestFailedReplicaChange(t *testing.T) {
 	// can succeed.
 	runFilter.Store(false)
 
-	err = rng.ChangeReplicas(proto.ADD_REPLICA,
-		proto.Replica{
-			NodeID:  mtc.stores[1].Ident.NodeID,
-			StoreID: mtc.stores[1].Ident.StoreID,
-		})
-	if err != nil {
+	if err := rng.ChangeReplicas(proto.ADD_REPLICA, proto.Replica{
+		NodeID:  mtc.stores[1].Ident.NodeID,
+		StoreID: mtc.stores[1].Ident.StoreID,
+	}); err != nil {
 		t.Fatal(err)
 	}
 
@@ -450,11 +444,10 @@ func TestReplicateAfterTruncation(t *testing.T) {
 	mvcc := rng.GetMVCCStats()
 
 	// Now add the second replica.
-	if err := rng.ChangeReplicas(proto.ADD_REPLICA,
-		proto.Replica{
-			NodeID:  mtc.stores[1].Ident.NodeID,
-			StoreID: mtc.stores[1].Ident.StoreID,
-		}); err != nil {
+	if err := rng.ChangeReplicas(proto.ADD_REPLICA, proto.Replica{
+		NodeID:  mtc.stores[1].Ident.NodeID,
+		StoreID: mtc.stores[1].Ident.StoreID,
+	}); err != nil {
 		t.Fatal(err)
 	}
 

--- a/storage/client_range_test.go
+++ b/storage/client_range_test.go
@@ -216,8 +216,7 @@ func TestTxnPutOutOfOrder(t *testing.T) {
 
 	// Put an initial value.
 	initVal := []byte("initVal")
-	err := store.DB().Put(key, initVal)
-	if err != nil {
+	if err := store.DB().Put(key, initVal); err != nil {
 		t.Fatalf("failed to put: %s", err)
 	}
 
@@ -298,8 +297,7 @@ func TestTxnPutOutOfOrder(t *testing.T) {
 		},
 		Reply: &proto.GetResponse{},
 	}
-	err = store.ExecuteCmd(context.Background(), getCall)
-	if err != nil {
+	if err := store.ExecuteCmd(context.Background(), getCall); err != nil {
 		t.Fatalf("failed to get: %s", err)
 	}
 
@@ -321,8 +319,7 @@ func TestTxnPutOutOfOrder(t *testing.T) {
 		Reply: &proto.GetResponse{},
 	}
 
-	err = store.ExecuteCmd(context.Background(), getCall)
-	if err == nil {
+	if err := store.ExecuteCmd(context.Background(), getCall); err == nil {
 		t.Fatal("unexpected success of get")
 	}
 

--- a/storage/client_split_test.go
+++ b/storage/client_split_test.go
@@ -101,20 +101,19 @@ func TestStoreRangeSplitBetweenConfigPrefix(t *testing.T) {
 	key := keys.MakeKey(keys.SystemPrefix, []byte("tsd"))
 
 	args, reply := adminSplitArgs(proto.KeyMin, key, 1, store.StoreID())
-	err := store.ExecuteCmd(context.Background(), proto.Call{Args: args, Reply: reply})
-	if err != nil {
+	if err := store.ExecuteCmd(context.Background(), proto.Call{Args: args, Reply: reply}); err != nil {
 		t.Fatalf("%q: split unexpected error: %s", key, err)
 	}
 
 	// Update configs to trigger gossip in both of the ranges.
 	acctConfig := &proto.AcctConfig{}
 	key = keys.MakeKey(keys.ConfigAccountingPrefix, proto.KeyMin)
-	if err = store.DB().Put(key, acctConfig); err != nil {
+	if err := store.DB().Put(key, acctConfig); err != nil {
 		t.Fatal(err)
 	}
 	zoneConfig := &proto.ZoneConfig{}
 	key = keys.MakeKey(keys.ConfigZonePrefix, proto.KeyMin)
-	if err = store.DB().Put(key, zoneConfig); err != nil {
+	if err := store.DB().Put(key, zoneConfig); err != nil {
 		t.Fatal(err)
 	}
 }

--- a/storage/engine/engine.go
+++ b/storage/engine/engine.go
@@ -179,14 +179,14 @@ func Increment(engine Engine, key proto.EncodedKey, inc int64) (int64, error) {
 	var int64Val int64
 	// If the value exists, attempt to decode it as a varint.
 	if len(val) != 0 {
-		if decoded, err := encoding.Decode(key, val); err == nil {
+		if decoded, decodingErr := encoding.Decode(key, val); decodingErr == nil {
 			if in64decoded, ok := decoded.(int64); ok {
 				int64Val = in64decoded
 			} else {
 				return 0, util.Errorf("received value of wrong type %T", decoded)
 			}
 		} else {
-			return 0, err
+			return 0, decodingErr
 		}
 	}
 

--- a/storage/engine/merge_test.go
+++ b/storage/engine/merge_test.go
@@ -262,7 +262,7 @@ func TestGoMerge(t *testing.T) {
 		// operates directly on marshalled bytes.
 		result, err := goMerge(c.existing, c.update)
 		if err != nil {
-			t.Errorf("goMerge error on case %d: %s", i, err.Error())
+			t.Errorf("goMerge error on case %d: %s", i, err)
 			continue
 		}
 		resultTS := unmarshalTimeSeries(t, result)
@@ -277,7 +277,7 @@ func TestGoMerge(t *testing.T) {
 			resultTS, err = MergeInternalTimeSeriesData(existingTS, updateTS)
 		}
 		if err != nil {
-			t.Errorf("MergeInternalTimeSeriesData error on case %d: %s", i, err.Error())
+			t.Errorf("MergeInternalTimeSeriesData error on case %d: %s", i, err)
 			continue
 		}
 		if a, e := resultTS, expectedTS; !reflect.DeepEqual(a, e) {
@@ -296,11 +296,11 @@ func unmarshalTimeSeries(t testing.TB, b []byte) *proto.InternalTimeSeriesData {
 	}
 	var mvccValue MVCCMetadata
 	if err := gogoproto.Unmarshal(b, &mvccValue); err != nil {
-		t.Fatalf("error unmarshalling time series in text: %s", err.Error())
+		t.Fatalf("error unmarshalling time series in text: %s", err)
 	}
 	valueTS, err := proto.InternalTimeSeriesDataFromValue(mvccValue.Value)
 	if err != nil {
-		t.Fatalf("error unmarshalling time series in text: %s", err.Error())
+		t.Fatalf("error unmarshalling time series in text: %s", err)
 	}
 	return valueTS
 }

--- a/storage/engine/mvcc.go
+++ b/storage/engine/mvcc.go
@@ -1006,9 +1006,9 @@ func MVCCIterate(engine Engine, startKey, endKey proto.Key, timestamp proto.Time
 		value, newIntents, err := mvccGetInternal(engine, key, metaKey, timestamp, consistent, txn, getValue, buf)
 		intents = append(intents, newIntents...)
 		if value != nil {
-			done, err := f(proto.KeyValue{Key: key, Value: *value})
-			if err != nil {
-				return nil, err
+			done, cbErr := f(proto.KeyValue{Key: key, Value: *value})
+			if cbErr != nil {
+				return nil, cbErr
 			}
 			if done {
 				break
@@ -1091,9 +1091,9 @@ func MVCCResolveWriteIntent(engine Engine, ms *MVCCStats, key proto.Key, timesta
 		} else {
 			newMeta.Txn = nil
 		}
-		metaKeySize, metaValSize, err := PutProto(engine, metaKey, &newMeta)
-		if err != nil {
-			return err
+		metaKeySize, metaValSize, putErr := PutProto(engine, metaKey, &newMeta)
+		if putErr != nil {
+			return putErr
 		}
 
 		// Update stat counters related to resolving the intent.
@@ -1106,9 +1106,9 @@ func MVCCResolveWriteIntent(engine Engine, ms *MVCCStats, key proto.Key, timesta
 		if !origTimestamp.Equal(txn.Timestamp) {
 			origKey := MVCCEncodeVersionKey(key, origTimestamp)
 			newKey := MVCCEncodeVersionKey(key, txn.Timestamp)
-			valBytes, err := engine.Get(origKey)
-			if err != nil {
-				return err
+			valBytes, getErr := engine.Get(origKey)
+			if getErr != nil {
+				return getErr
 			}
 			if err := engine.Clear(origKey); err != nil {
 				return err

--- a/storage/gc_queue.go
+++ b/storage/gc_queue.go
@@ -314,7 +314,7 @@ func (gcq *gcQueue) lookupGCPolicy(rng *Range) (proto.GCPolicy, error) {
 	// This could be the case if the zone config is new and the range
 	// hasn't been split yet along the new boundary.
 	var gc *proto.GCPolicy
-	if err = configMap.VisitPrefixesHierarchically(rng.Desc().StartKey, func(start, end proto.Key, config interface{}) (bool, error) {
+	if err := configMap.VisitPrefixesHierarchically(rng.Desc().StartKey, func(start, end proto.Key, config interface{}) (bool, error) {
 		zone := config.(*proto.ZoneConfig)
 		if zone.GC != nil {
 			rng.RLock()

--- a/storage/id_alloc_test.go
+++ b/storage/id_alloc_test.go
@@ -20,7 +20,6 @@ package storage
 import (
 	"log"
 	"sort"
-	"strings"
 	"sync"
 	"testing"
 	"time"
@@ -28,6 +27,7 @@ import (
 	"github.com/cockroachdb/cockroach/keys"
 	"github.com/cockroachdb/cockroach/proto"
 	"github.com/cockroachdb/cockroach/storage/engine"
+	"github.com/cockroachdb/cockroach/testutils"
 	"github.com/cockroachdb/cockroach/util/leaktest"
 )
 
@@ -142,11 +142,9 @@ func TestAllocateErrorAndRecovery(t *testing.T) {
 		t.Errorf("failed to create IDAllocator: %v", err)
 	}
 
-	firstID, err := idAlloc.Allocate()
-	if err != nil {
+	if firstID, err := idAlloc.Allocate(); err != nil {
 		t.Fatal(err)
-	}
-	if firstID != 2 {
+	} else if firstID != 2 {
 		t.Errorf("expected ID is 2, but got: %d", firstID)
 	}
 
@@ -228,9 +226,7 @@ func TestAllocateWithStopper(t *testing.T) {
 
 	stopper.Stop()
 
-	if _, err := idAlloc.Allocate(); err == nil {
-		t.Errorf("unexpected success")
-	} else if !strings.Contains(err.Error(), "system is draining") {
+	if _, err := idAlloc.Allocate(); !testutils.IsError(err, "system is draining") {
 		t.Errorf("unexpected error: %s", err)
 	}
 }

--- a/storage/range_raftstorage.go
+++ b/storage/range_raftstorage.go
@@ -110,16 +110,14 @@ func (r *Range) Entries(lo, hi, maxBytes uint64) ([]raftpb.Entry, error) {
 // Term implements the raft.Storage interface.
 func (r *Range) Term(i uint64) (uint64, error) {
 	ents, err := r.Entries(i, i+1, 0)
-	if err == raft.ErrUnavailable {
-		ts, err := r.raftTruncatedState()
-		if err != nil {
-			return 0, err
+	if err != nil {
+		if err == raft.ErrUnavailable {
+			if ts, err := r.raftTruncatedState(); err != nil {
+				return 0, err
+			} else if i == ts.Index {
+				return ts.Term, nil
+			}
 		}
-		if i == ts.Index {
-			return ts.Term, nil
-		}
-		return 0, raft.ErrUnavailable
-	} else if err != nil {
 		return 0, err
 	}
 	if len(ents) == 0 {

--- a/storage/range_raftstorage.go
+++ b/storage/range_raftstorage.go
@@ -112,8 +112,8 @@ func (r *Range) Term(i uint64) (uint64, error) {
 	ents, err := r.Entries(i, i+1, 0)
 	if err != nil {
 		if err == raft.ErrUnavailable {
-			if ts, err := r.raftTruncatedState(); err != nil {
-				return 0, err
+			if ts, truncateErr := r.raftTruncatedState(); truncateErr != nil {
+				return 0, truncateErr
 			} else if i == ts.Index {
 				return ts.Term, nil
 			}

--- a/storage/range_test.go
+++ b/storage/range_test.go
@@ -661,9 +661,9 @@ func TestRangeGossipConfigWithMultipleKeyPrefixes(t *testing.T) {
 		Write: []string{"spencer"},
 	}
 	key := keys.MakeKey(keys.ConfigPermissionPrefix, proto.Key("/db1"))
-	data, err := gogoproto.Marshal(db1Perm)
-	if err != nil {
-		t.Fatal(err)
+	data, marshalErr := gogoproto.Marshal(db1Perm)
+	if marshalErr != nil {
+		t.Fatal(marshalErr)
 	}
 	req := proto.PutRequest{
 		RequestHeader: proto.RequestHeader{Key: key, Timestamp: proto.MinTimestamp},
@@ -702,9 +702,9 @@ func TestRangeGossipConfigUpdates(t *testing.T) {
 		Write: []string{"spencer"},
 	}
 	key := keys.MakeKey(keys.ConfigPermissionPrefix, proto.Key("/db1"))
-	data, err := gogoproto.Marshal(db1Perm)
-	if err != nil {
-		t.Fatal(err)
+	data, marshalErr := gogoproto.Marshal(db1Perm)
+	if marshalErr != nil {
+		t.Fatal(marshalErr)
 	}
 	req := proto.PutRequest{
 		RequestHeader: proto.RequestHeader{Key: key, Timestamp: proto.MinTimestamp},
@@ -2517,9 +2517,9 @@ func TestRangeDanglingMetaIntent(t *testing.T) {
 	newDesc.EndKey = key
 
 	// Write the new descriptor as an intent.
-	data, err := gogoproto.Marshal(&newDesc)
-	if err != nil {
-		t.Fatal(err)
+	data, marshalErr := gogoproto.Marshal(&newDesc)
+	if marshalErr != nil {
+		t.Fatal(marshalErr)
 	}
 	pArgs := putArgs(keys.RangeMetaKey(key), data, 1, tc.store.StoreID())
 	pArgs.Txn = newTransaction("test", key, 1, proto.SERIALIZABLE, tc.clock)
@@ -2545,7 +2545,7 @@ func TestRangeDanglingMetaIntent(t *testing.T) {
 
 	// Switch to consistent lookups, which should run into the intent.
 	rlArgs.ReadConsistency = proto.CONSISTENT
-	_, err = tc.rng.AddCmd(tc.rng.context(), rlArgs)
+	_, err := tc.rng.AddCmd(tc.rng.context(), rlArgs)
 	if _, ok := err.(*proto.WriteIntentError); !ok {
 		t.Fatalf("expected WriteIntentError, not %s", err)
 	}

--- a/storage/range_test.go
+++ b/storage/range_test.go
@@ -2506,14 +2506,13 @@ func TestRangeDanglingMetaIntent(t *testing.T) {
 		MaxRanges: 1,
 	}
 
-	var rlReply *proto.InternalRangeLookupResponse
+	var origDesc proto.RangeDescriptor
 	if reply, err := tc.rng.AddCmd(tc.rng.context(), rlArgs); err == nil {
-		rlReply = reply.(*proto.InternalRangeLookupResponse)
+		origDesc = reply.(*proto.InternalRangeLookupResponse).Ranges[0]
 	} else {
 		t.Fatal(err)
 	}
 
-	origDesc := rlReply.Ranges[0]
 	newDesc := origDesc
 	newDesc.EndKey = key
 

--- a/storage/range_test.go
+++ b/storage/range_test.go
@@ -393,7 +393,6 @@ func TestRangeRangeBoundsChecking(t *testing.T) {
 	gArgs := getArgs(proto.Key("b"), 1, tc.store.StoreID())
 
 	_, err := tc.rng.AddCmd(tc.rng.context(), &gArgs)
-
 	if _, ok := err.(*proto.RangeKeyMismatchError); !ok {
 		t.Errorf("expected range key mismatch error: %s", err)
 	}
@@ -481,7 +480,6 @@ func TestRangeNotLeaderError(t *testing.T) {
 
 	for i, test := range testCases {
 		_, err := tc.rng.AddCmd(tc.rng.context(), test)
-
 		if _, ok := err.(*proto.NotLeaderError); !ok {
 			t.Errorf("%d: expected not leader error: %s", i, err)
 		}
@@ -1066,9 +1064,7 @@ func TestRangeUpdateTSCache(t *testing.T) {
 	gArgs := getArgs([]byte("a"), 1, tc.store.StoreID())
 	gArgs.Timestamp = tc.clock.Now()
 
-	_, err := tc.rng.AddCmd(tc.rng.context(), &gArgs)
-
-	if err != nil {
+	if _, err := tc.rng.AddCmd(tc.rng.context(), &gArgs); err != nil {
 		t.Error(err)
 	}
 	// Set clock to time 2s for write.
@@ -1077,9 +1073,7 @@ func TestRangeUpdateTSCache(t *testing.T) {
 	pArgs := putArgs([]byte("b"), []byte("1"), 1, tc.store.StoreID())
 	pArgs.Timestamp = tc.clock.Now()
 
-	_, err = tc.rng.AddCmd(tc.rng.context(), &pArgs)
-
-	if err != nil {
+	if _, err := tc.rng.AddCmd(tc.rng.context(), &pArgs); err != nil {
 		t.Error(err)
 	}
 	// Verify the timestamp cache has rTS=1s and wTS=0s for "a".
@@ -1143,9 +1137,7 @@ func TestRangeCommandQueue(t *testing.T) {
 			args := readOrWriteArgs(key1, test.cmd1Read, tc.rng.Desc().RaftID, tc.store.StoreID())
 			args.Header().User = "Foo"
 
-			_, err := tc.rng.AddCmd(tc.rng.context(), args)
-
-			if err != nil {
+			if _, err := tc.rng.AddCmd(tc.rng.context(), args); err != nil {
 				t.Fatalf("test %d: %s", i, err)
 			}
 			close(cmd1Done)
@@ -1158,9 +1150,7 @@ func TestRangeCommandQueue(t *testing.T) {
 		go func() {
 			args := readOrWriteArgs(key1, test.cmd2Read, tc.rng.Desc().RaftID, tc.store.StoreID())
 
-			_, err := tc.rng.AddCmd(tc.rng.context(), args)
-
-			if err != nil {
+			if _, err := tc.rng.AddCmd(tc.rng.context(), args); err != nil {
 				t.Fatalf("test %d: %s", i, err)
 			}
 			close(cmd2Done)
@@ -1171,9 +1161,7 @@ func TestRangeCommandQueue(t *testing.T) {
 		go func() {
 			args := readOrWriteArgs(key2, true, tc.rng.Desc().RaftID, tc.store.StoreID())
 
-			_, err := tc.rng.AddCmd(tc.rng.context(), args)
-
-			if err != nil {
+			if _, err := tc.rng.AddCmd(tc.rng.context(), args); err != nil {
 				t.Fatalf("test %d: %s", i, err)
 			}
 			close(cmd3Done)
@@ -1238,9 +1226,7 @@ func TestRangeCommandQueueInconsistent(t *testing.T) {
 		args := putArgs(key, []byte("value"), tc.rng.Desc().RaftID, tc.store.StoreID())
 		args.CmdID.Random = 1
 
-		_, err := tc.rng.AddCmd(tc.rng.context(), &args)
-
-		if err != nil {
+		if _, err := tc.rng.AddCmd(tc.rng.context(), &args); err != nil {
 			t.Fatal(err)
 		}
 		close(cmd1Done)
@@ -1254,9 +1240,7 @@ func TestRangeCommandQueueInconsistent(t *testing.T) {
 		args := getArgs(key, tc.rng.Desc().RaftID, tc.store.StoreID())
 		args.ReadConsistency = proto.INCONSISTENT
 
-		_, err := tc.rng.AddCmd(tc.rng.context(), &args)
-
-		if err != nil {
+		if _, err := tc.rng.AddCmd(tc.rng.context(), &args); err != nil {
 			t.Fatal(err)
 		}
 		close(cmd2Done)
@@ -1293,9 +1277,7 @@ func TestRangeUseTSCache(t *testing.T) {
 	args := getArgs([]byte("a"), 1, tc.store.StoreID())
 	args.Timestamp = tc.clock.Now()
 
-	_, err := tc.rng.AddCmd(tc.rng.context(), &args)
-
-	if err != nil {
+	if _, err := tc.rng.AddCmd(tc.rng.context(), &args); err != nil {
 		t.Error(err)
 	}
 	pArgs := putArgs([]byte("a"), []byte("value"), 1, tc.store.StoreID())
@@ -1324,9 +1306,7 @@ func TestRangeNoTSCacheInconsistent(t *testing.T) {
 	args.Timestamp = tc.clock.Now()
 	args.ReadConsistency = proto.INCONSISTENT
 
-	_, err := tc.rng.AddCmd(tc.rng.context(), &args)
-
-	if err != nil {
+	if _, err := tc.rng.AddCmd(tc.rng.context(), &args); err != nil {
 		t.Error(err)
 	}
 	pArgs := putArgs([]byte("a"), []byte("value"), 1, tc.store.StoreID())
@@ -1411,12 +1391,9 @@ func TestRangeNoTimestampIncrementWithinTxn(t *testing.T) {
 	pArgs.Txn = txn
 	pArgs.Timestamp = pArgs.Txn.Timestamp
 
-	reply, err := tc.rng.AddCmd(tc.rng.context(), &pArgs)
-	if err != nil {
+	if reply, err := tc.rng.AddCmd(tc.rng.context(), &pArgs); err != nil {
 		t.Fatal(err)
-	}
-	pReply := reply.(*proto.PutResponse)
-	if !pReply.Timestamp.Equal(pArgs.Timestamp) {
+	} else if pReply := reply.(*proto.PutResponse); !pReply.Timestamp.Equal(pArgs.Timestamp) {
 		t.Errorf("expected timestamp to remain %s; got %s", pArgs.Timestamp, pReply.Timestamp)
 	}
 
@@ -1425,11 +1402,9 @@ func TestRangeNoTimestampIncrementWithinTxn(t *testing.T) {
 	expTS := pArgs.Timestamp
 	expTS.Logical++
 
-	if reply, err = tc.rng.AddCmd(tc.rng.context(), &pArgs); err == nil {
+	if reply, err := tc.rng.AddCmd(tc.rng.context(), &pArgs); err == nil {
 		t.Errorf("expected write intent error")
-	}
-	pReply = reply.(*proto.PutResponse)
-	if !pReply.Timestamp.Equal(expTS) {
+	} else if pReply := reply.(*proto.PutResponse); !pReply.Timestamp.Equal(expTS) {
 		t.Errorf("expected timestamp to increment to %s; got %s", expTS, pReply.Timestamp)
 	}
 }
@@ -1502,22 +1477,18 @@ func TestRangeResponseCacheReadError(t *testing.T) {
 	args := incrementArgs([]byte("a"), 1, 1, tc.store.StoreID())
 	args.CmdID = proto.ClientCmdID{WallTime: 1, Random: 1}
 
-	_, err := tc.rng.AddCmd(tc.rng.context(), &args)
-
-	if err != nil {
+	if _, err := tc.rng.AddCmd(tc.rng.context(), &args); err != nil {
 		t.Fatal(err)
 	}
 
 	// Overwrite repsonse cache entry with garbage for the last op.
 	key := keys.ResponseCacheKey(tc.rng.Desc().RaftID, &args.CmdID)
-	err = engine.MVCCPut(tc.engine, nil, key, proto.ZeroTimestamp, proto.Value{Bytes: []byte("\xff")}, nil)
-	if err != nil {
+	if err := engine.MVCCPut(tc.engine, nil, key, proto.ZeroTimestamp, proto.Value{Bytes: []byte("\xff")}, nil); err != nil {
 		t.Fatal(err)
 	}
 
 	// Now try increment again and verify error.
-	_, err = tc.rng.AddCmd(tc.rng.context(), &args)
-	if err == nil {
+	if _, err := tc.rng.AddCmd(tc.rng.context(), &args); err == nil {
 		t.Fatal(err)
 	}
 }
@@ -1539,8 +1510,7 @@ func TestRangeResponseCacheStoredError(t *testing.T) {
 
 	args := incrementArgs([]byte("a"), 1, 1, tc.store.StoreID())
 	args.CmdID = cmdID
-	_, err := tc.rng.AddCmd(tc.rng.context(), &args)
-	if err == nil {
+	if _, err := tc.rng.AddCmd(tc.rng.context(), &args); err == nil {
 		t.Fatal("expected to see cached error but got nil")
 	} else if ge, ok := err.(*proto.Error); !ok {
 		t.Fatalf("expected proto.Error but got %s", err)
@@ -1706,8 +1676,7 @@ func TestEndTransactionWithIncrementedEpoch(t *testing.T) {
 	hbArgs := heartbeatArgs(txn, 1, tc.store.StoreID())
 	hbArgs.Timestamp = txn.Timestamp
 
-	_, err := tc.rng.AddCmd(tc.rng.context(), &hbArgs)
-	if err != nil {
+	if _, err := tc.rng.AddCmd(tc.rng.context(), &hbArgs); err != nil {
 		t.Error(err)
 	}
 
@@ -2251,7 +2220,7 @@ func TestInternalMerge(t *testing.T) {
 		mergeArgs := internalMergeArgs(key, proto.Value{Bytes: []byte(str)}, 1, tc.store.StoreID())
 
 		if _, err := tc.rng.AddCmd(tc.rng.context(), &mergeArgs); err != nil {
-			t.Fatalf("unexpected error from InternalMerge: %s", err.Error())
+			t.Fatalf("unexpected error from InternalMerge: %s", err)
 		}
 	}
 
@@ -2401,7 +2370,7 @@ func TestConditionFailedError(t *testing.T) {
 
 	_, err := tc.rng.AddCmd(tc.rng.context(), &args)
 
-	if cErr, ok := err.(*proto.ConditionFailedError); err == nil || !ok {
+	if cErr, ok := err.(*proto.ConditionFailedError); !ok {
 		t.Fatalf("expected ConditionFailedError, got %T with content %+v",
 			err, err)
 	} else if v := cErr.ActualValue; v == nil || !bytes.Equal(v.Bytes, value) {
@@ -2478,23 +2447,19 @@ func TestReplicaCorruption(t *testing.T) {
 	defer tc.Stop()
 
 	args := putArgs(proto.Key("test"), []byte("value"), tc.rng.Desc().RaftID, tc.store.StoreID())
-	_, err := tc.rng.AddCmd(tc.rng.context(), &args)
-	if err != nil {
+	if _, err := tc.rng.AddCmd(tc.rng.context(), &args); err != nil {
 		t.Fatal(err)
 	}
 	// Set the stored applied index sky high.
 	newIndex := 2*atomic.LoadUint64(&tc.rng.appliedIndex) + 1
 	atomic.StoreUint64(&tc.rng.appliedIndex, newIndex)
 	// Not really needed, but let's be thorough.
-	err = setAppliedIndex(tc.rng.rm.Engine(), tc.rng.Desc().RaftID, newIndex)
-	if err != nil {
+	if err := setAppliedIndex(tc.rng.rm.Engine(), tc.rng.Desc().RaftID, newIndex); err != nil {
 		t.Fatal(err)
 	}
 	// Should mark replica corrupt (and panic as a result) since we messed
 	// with the applied index.
-	_, err = tc.rng.AddCmd(tc.rng.context(), &args)
-
-	if err == nil || !strings.Contains(err.Error(), "replica corruption (processed=true)") {
+	if _, err := tc.rng.AddCmd(tc.rng.context(), &args); testutils.IsError(err, "replica corruption (processed=true)") {
 		t.Fatalf("unexpected error: %s", err)
 	}
 }
@@ -2542,12 +2507,11 @@ func TestRangeDanglingMetaIntent(t *testing.T) {
 	}
 
 	var rlReply *proto.InternalRangeLookupResponse
-
-	reply, err := tc.rng.AddCmd(tc.rng.context(), rlArgs)
-	if err != nil {
+	if reply, err := tc.rng.AddCmd(tc.rng.context(), rlArgs); err == nil {
+		rlReply = reply.(*proto.InternalRangeLookupResponse)
+	} else {
 		t.Fatal(err)
 	}
-	rlReply = reply.(*proto.InternalRangeLookupResponse)
 
 	origDesc := rlReply.Ranges[0]
 	newDesc := origDesc
@@ -2571,13 +2535,13 @@ func TestRangeDanglingMetaIntent(t *testing.T) {
 	rlArgs.Key = keys.RangeMetaKey(proto.Key("A"))
 	rlArgs.Timestamp = proto.ZeroTimestamp
 
-	reply, err = tc.rng.AddCmd(tc.rng.context(), rlArgs)
-	if err != nil {
+	if reply, err := tc.rng.AddCmd(tc.rng.context(), rlArgs); err != nil {
 		t.Errorf("unexpected lookup error: %s", err)
-	}
-	rlReply = reply.(*proto.InternalRangeLookupResponse)
-	if !reflect.DeepEqual(rlReply.Ranges[0], origDesc) {
-		t.Errorf("expected original descriptor %s; got %s", &origDesc, &rlReply.Ranges[0])
+	} else {
+		rlReply := reply.(*proto.InternalRangeLookupResponse)
+		if !reflect.DeepEqual(rlReply.Ranges[0], origDesc) {
+			t.Errorf("expected original descriptor %s; got %s", &origDesc, &rlReply.Ranges[0])
+		}
 	}
 
 	// Switch to consistent lookups, which should run into the intent.
@@ -2590,8 +2554,7 @@ func TestRangeDanglingMetaIntent(t *testing.T) {
 	// Try 100 lookups with IgnoreIntents. Expect to see each descriptor at least once.
 	// First, try this consistently, which should not be allowed.
 	rlArgs.IgnoreIntents = true
-	_, err = tc.rng.AddCmd(tc.rng.context(), rlArgs)
-	if !testutils.IsError(err, "can not read consistently and skip intents") {
+	if _, err := tc.rng.AddCmd(tc.rng.context(), rlArgs); !testutils.IsError(err, "can not read consistently and skip intents") {
 		t.Fatalf("wanted specific error, not %s", err)
 	}
 	// After changing back to inconsistent lookups, should be good to go.
@@ -2604,12 +2567,13 @@ func TestRangeDanglingMetaIntent(t *testing.T) {
 		clonedRLArgs := gogoproto.Clone(rlArgs).(*proto.InternalRangeLookupRequest)
 		clonedRLArgs.Timestamp = proto.ZeroTimestamp
 
-		reply, err = tc.rng.AddCmd(tc.rng.context(), clonedRLArgs)
-		if err != nil {
+		var seen proto.RangeDescriptor
+		if reply, err := tc.rng.AddCmd(tc.rng.context(), clonedRLArgs); err == nil {
+			seen = reply.(*proto.InternalRangeLookupResponse).Ranges[0]
+		} else {
 			t.Fatal(err)
 		}
-		rlReply = reply.(*proto.InternalRangeLookupResponse)
-		seen := rlReply.Ranges[0]
+
 		if reflect.DeepEqual(seen, origDesc) {
 			origSeen = true
 		} else if reflect.DeepEqual(seen, newDesc) {
@@ -2684,9 +2648,7 @@ func benchmarkEvents(b *testing.B, sendEvents, consumeEvents bool) {
 	args := incrementArgs([]byte("a"), 1, 1, tc.store.StoreID())
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
-		_, err := tc.rng.AddCmd(tc.rng.context(), &args)
-
-		if err != nil {
+		if _, err := tc.rng.AddCmd(tc.rng.context(), &args); err != nil {
 			b.Fatal(err)
 		}
 	}

--- a/storage/range_tree.go
+++ b/storage/range_tree.go
@@ -224,15 +224,17 @@ func (tc *treeContext) walkUpRot23(node *proto.RangeTreeNode) (*proto.RangeTreeN
 		return nil, err
 	}
 	if isRed(right) && !isRed(left) {
-		node, err = tc.rotateLeft(node)
-		if err != nil {
+		if rotatedLeft, err := tc.rotateLeft(node); err == nil {
+			node = rotatedLeft
+		} else {
 			return nil, err
 		}
 	}
 
 	// Should we rotate right?
-	left, err = tc.getNode(node.LeftKey)
-	if err != nil {
+	if newLeft, err := tc.getNode(node.LeftKey); err == nil {
+		left = newLeft
+	} else {
 		return nil, err
 	}
 	if left != nil {
@@ -241,25 +243,29 @@ func (tc *treeContext) walkUpRot23(node *proto.RangeTreeNode) (*proto.RangeTreeN
 			return nil, err
 		}
 		if isRed(left) && isRed(leftLeft) {
-			node, err = tc.rotateRight(node)
-			if err != nil {
+			if rotatedRight, err := tc.rotateRight(node); err == nil {
+				node = rotatedRight
+			} else {
 				return nil, err
 			}
 		}
 	}
 
 	// Should we flip?
-	right, err = tc.getNode(node.RightKey)
-	if err != nil {
+	if newRight, err := tc.getNode(node.RightKey); err == nil {
+		right = newRight
+	} else {
 		return nil, err
 	}
-	left, err = tc.getNode(node.LeftKey)
-	if err != nil {
+	if newLeft, err := tc.getNode(node.LeftKey); err == nil {
+		left = newLeft
+	} else {
 		return nil, err
 	}
 	if isRed(left) && isRed(right) {
-		node, err = tc.flip(node)
-		if err != nil {
+		if flipped, err := tc.flip(node); err == nil {
+			node = flipped
+		} else {
 			return nil, err
 		}
 	}

--- a/storage/replicate_queue.go
+++ b/storage/replicate_queue.go
@@ -112,7 +112,7 @@ func (rq *replicateQueue) process(now proto.Timestamp, rng *Range) error {
 		NodeID:  newReplica.Node.NodeID,
 		StoreID: newReplica.StoreID,
 	}
-	if err = rng.ChangeReplicas(proto.ADD_REPLICA, replica); err != nil {
+	if err := rng.ChangeReplicas(proto.ADD_REPLICA, replica); err != nil {
 		return err
 	}
 

--- a/storage/split_queue.go
+++ b/storage/split_queue.go
@@ -103,7 +103,7 @@ func (sq *splitQueue) process(now proto.Timestamp, rng *Range) error {
 	// FIXME: why is this implementation not the same as the one above?
 	if float64(rng.stats.GetSize())/float64(zone.RangeMaxBytes) > 1 {
 		log.Infof("splitting %s size=%d max=%d", rng, rng.stats.GetSize(), zone.RangeMaxBytes)
-		if _, err = rng.AddCmd(rng.context(), &proto.AdminSplitRequest{
+		if _, err := rng.AddCmd(rng.context(), &proto.AdminSplitRequest{
 			RequestHeader: proto.RequestHeader{Key: rng.Desc().StartKey},
 		}); err != nil {
 			return err

--- a/storage/store_test.go
+++ b/storage/store_test.go
@@ -425,7 +425,7 @@ func TestStoreRangeSet(t *testing.T) {
 	// Split the first range to insert a new range as second range.
 	// The range is never visited with this iteration.
 	rng := createRange(store, 11, proto.Key("a000"), proto.Key("a01"))
-	if err = store.SplitRange(store.LookupRange(proto.Key("a00"), nil), rng); err != nil {
+	if err := store.SplitRange(store.LookupRange(proto.Key("a00"), nil), rng); err != nil {
 		t.Fatal(err)
 	}
 	// Estimated count will still be 9, as it's cached.
@@ -625,7 +625,7 @@ func splitTestRange(store *Store, key, splitKey proto.Key, t *testing.T) *Range 
 	if err != nil {
 		t.Fatal(err)
 	}
-	if err = store.SplitRange(rng, newRng); err != nil {
+	if err := store.SplitRange(rng, newRng); err != nil {
 		t.Fatal(err)
 	}
 	return newRng
@@ -804,8 +804,7 @@ func TestStoreResolveWriteIntent(t *testing.T) {
 			}
 			txnKey := keys.TransactionKey(pushee.Key, pushee.ID)
 			var txn proto.Transaction
-			ok, err := engine.MVCCGetProto(store.Engine(), txnKey, proto.ZeroTimestamp, true, nil, &txn)
-			if !ok || err != nil {
+			if ok, err := engine.MVCCGetProto(store.Engine(), txnKey, proto.ZeroTimestamp, true, nil, &txn); !ok || err != nil {
 				t.Fatalf("not found or err: %s", err)
 			}
 			if txn.Status != proto.ABORTED {
@@ -818,7 +817,7 @@ func TestStoreResolveWriteIntent(t *testing.T) {
 				t.Errorf("expected txn to match pushee %q; got %s", pushee.ID, rErr)
 			}
 			// Trying again should fail again.
-			if err = store.ExecuteCmd(context.Background(), proto.Call{Args: &pArgs, Reply: pArgs.CreateReply()}); err == nil {
+			if err := store.ExecuteCmd(context.Background(), proto.Call{Args: &pArgs, Reply: pArgs.CreateReply()}); err == nil {
 				t.Errorf("expected another error on latent write intent but succeeded")
 			}
 		}

--- a/storage/store_test.go
+++ b/storage/store_test.go
@@ -798,7 +798,17 @@ func TestStoreResolveWriteIntent(t *testing.T) {
 		pArgs.Timestamp = store.ctx.Clock.Now()
 		pArgs.Txn = pusher
 		err := store.ExecuteCmd(context.Background(), proto.Call{Args: &pArgs, Reply: pArgs.CreateReply()})
-		if resolvable {
+		if !resolvable {
+			if rErr, ok := err.(*proto.TransactionPushError); !ok {
+				t.Errorf("expected txn push error; got %s", err)
+			} else if !bytes.Equal(rErr.PusheeTxn.ID, pushee.ID) {
+				t.Errorf("expected txn to match pushee %q; got %s", pushee.ID, rErr)
+			}
+			// Trying again should fail again.
+			if err := store.ExecuteCmd(context.Background(), proto.Call{Args: &pArgs, Reply: pArgs.CreateReply()}); err == nil {
+				t.Errorf("expected another error on latent write intent but succeeded")
+			}
+		} else {
 			if err != nil {
 				t.Errorf("expected intent resolved; got unexpected error: %s", err)
 			}
@@ -809,16 +819,6 @@ func TestStoreResolveWriteIntent(t *testing.T) {
 			}
 			if txn.Status != proto.ABORTED {
 				t.Errorf("expected pushee to be aborted; got %s", txn.Status)
-			}
-		} else {
-			if rErr, ok := err.(*proto.TransactionPushError); !ok {
-				t.Errorf("expected txn push error; got %s", err)
-			} else if !bytes.Equal(rErr.PusheeTxn.ID, pushee.ID) {
-				t.Errorf("expected txn to match pushee %q; got %s", pushee.ID, rErr)
-			}
-			// Trying again should fail again.
-			if err := store.ExecuteCmd(context.Background(), proto.Call{Args: &pArgs, Reply: pArgs.CreateReply()}); err == nil {
-				t.Errorf("expected another error on latent write intent but succeeded")
 			}
 		}
 	}

--- a/structured/structured_test.go
+++ b/structured/structured_test.go
@@ -244,7 +244,7 @@ func TestValidateTableDesc(t *testing.T) {
 		if err := d.desc.Validate(); err == nil {
 			t.Errorf("%d: expected error, but found success: %+v", i, d.desc)
 		} else if d.err != err.Error() {
-			t.Errorf("%d: expected \"%s\", but found \"%s\"", i, d.err, err.Error())
+			t.Errorf("%d: expected \"%s\", but found \"%s\"", i, d.err, err)
 		}
 	}
 }

--- a/ts/db_test.go
+++ b/ts/db_test.go
@@ -79,7 +79,7 @@ func (tm *testModel) getActualData() map[string]*proto.Value {
 	endKey := keyDataPrefix.PrefixEnd()
 	keyValues, _, err := engine.MVCCScan(tm.Eng, startKey, endKey, 0, tm.Clock.Now(), true, nil)
 	if err != nil {
-		tm.t.Fatalf("error scanning TS data from engine: %s", err.Error())
+		tm.t.Fatalf("error scanning TS data from engine: %s", err)
 	}
 
 	kvMap := make(map[string]*proto.Value)
@@ -152,28 +152,28 @@ func (tm *testModel) storeInModel(r Resolution, data proto.TimeSeriesData) {
 	// Process and store data in the model.
 	internalData, err := data.ToInternal(r.KeyDuration(), r.SampleDuration())
 	if err != nil {
-		tm.t.Fatalf("test could not convert time series to internal format: %s", err.Error())
+		tm.t.Fatalf("test could not convert time series to internal format: %s", err)
 	}
 
 	for _, idata := range internalData {
 		key := MakeDataKey(data.Name, data.Source, r, idata.StartTimestampNanos)
 		keyStr := string(key)
 
-		existing, ok := tm.modelData[keyStr]
 		var newTs *proto.InternalTimeSeriesData
-		if ok {
+		if existing, ok := tm.modelData[keyStr]; ok {
 			existingTs, err := proto.InternalTimeSeriesDataFromValue(existing)
 			if err != nil {
-				tm.t.Fatalf("test could not extract time series from existing model value: %s", err.Error())
+				tm.t.Fatalf("test could not extract time series from existing model value: %s", err)
 			}
 			newTs, err = engine.MergeInternalTimeSeriesData(existingTs, idata)
 			if err != nil {
-				tm.t.Fatalf("test could not merge time series into model value: %s", err.Error())
+				tm.t.Fatalf("test could not merge time series into model value: %s", err)
 			}
 		} else {
+			var err error
 			newTs, err = engine.MergeInternalTimeSeriesData(idata)
 			if err != nil {
-				tm.t.Fatalf("test could not merge time series into model value: %s", err.Error())
+				tm.t.Fatalf("test could not merge time series into model value: %s", err)
 			}
 		}
 		val, err := newTs.ToValue()
@@ -189,7 +189,7 @@ func (tm *testModel) storeInModel(r Resolution, data proto.TimeSeriesData) {
 func (tm *testModel) storeTimeSeriesData(r Resolution, data []proto.TimeSeriesData) {
 	// Store data in the system under test.
 	if err := tm.DB.StoreData(r, data); err != nil {
-		tm.t.Fatalf("error storing time series data: %s", err.Error())
+		tm.t.Fatalf("error storing time series data: %s", err)
 	}
 
 	// Store data in the model.

--- a/ts/server.go
+++ b/ts/server.go
@@ -84,9 +84,9 @@ func (s *Server) handleQuery(w http.ResponseWriter, r *http.Request, _ httproute
 		Results: make([]*proto.TimeSeriesQueryResponse_Result, 0, len(request.Queries)),
 	}
 	for _, q := range request.Queries {
-		datapoints, sources, err := s.db.Query(q, Resolution10s, request.StartNanos, request.EndNanos)
-		if err != nil {
-			http.Error(w, err.Error(), http.StatusInternalServerError)
+		datapoints, sources, queryErr := s.db.Query(q, Resolution10s, request.StartNanos, request.EndNanos)
+		if queryErr != nil {
+			http.Error(w, queryErr.Error(), http.StatusInternalServerError)
 			return
 		}
 		response.Results = append(response.Results, &proto.TimeSeriesQueryResponse_Result{

--- a/util/encoding/encoding_test.go
+++ b/util/encoding/encoding_test.go
@@ -56,8 +56,7 @@ func TestChecksums(t *testing.T) {
 		return err == nil
 	}
 
-	_, err := unwrapChecksum([]byte("does not matter"), []byte("srt"))
-	if err == nil {
+	if _, err := unwrapChecksum([]byte("does not matter"), []byte("srt")); err == nil {
 		t.Fatalf("expected error unwrapping a too short string")
 	}
 

--- a/util/error_test.go
+++ b/util/error_test.go
@@ -31,7 +31,7 @@ func TestErrorf(t *testing.T) {
 	file, line, _ := caller.Lookup(0)
 	expected := fmt.Sprintf("%sfoo: 1 3.140000", fmt.Sprintf(errorPrefixFormat, file, line-1))
 	if expected != err.Error() {
-		t.Errorf("expected %s, got %s", expected, err.Error())
+		t.Errorf("expected %s, got %s", expected, err)
 	}
 }
 
@@ -45,7 +45,7 @@ func TestErrorfSkipFrames(t *testing.T) {
 	file, line, _ := caller.Lookup(0)
 	expected := fmt.Sprintf("%sfoo: 1 3.140000", fmt.Sprintf(errorPrefixFormat, file, line-1))
 	if expected != err.Error() {
-		t.Errorf("expected %s, got %s", expected, err.Error())
+		t.Errorf("expected %s, got %s", expected, err)
 	}
 }
 
@@ -56,7 +56,7 @@ func TestError(t *testing.T) {
 	file, line, _ := caller.Lookup(0)
 	expected := fmt.Sprintf("%sfoo 1 3.14", fmt.Sprintf(errorPrefixFormat, file, line-1))
 	if expected != err.Error() {
-		t.Errorf("expected %s, got %s", expected, err.Error())
+		t.Errorf("expected %s, got %s", expected, err)
 	}
 }
 
@@ -70,6 +70,6 @@ func TestErrorSkipFrames(t *testing.T) {
 	file, line, _ := caller.Lookup(0)
 	expected := fmt.Sprintf("%sfoo 1 3.14", fmt.Sprintf(errorPrefixFormat, file, line-1))
 	if expected != err.Error() {
-		t.Errorf("expected %s, got %s", expected, err.Error())
+		t.Errorf("expected %s, got %s", expected, err)
 	}
 }

--- a/util/log/clog.go
+++ b/util/log/clog.go
@@ -953,9 +953,9 @@ func (sb *syncBuffer) rotateFile(now time.Time) error {
 			Line:   int32(line),
 			Format: format,
 		}
-		n, err := sb.file.Write(encodeLogEntry(&entry))
-		if err != nil {
-			panic(err)
+		n, writeErr := sb.file.Write(encodeLogEntry(&entry))
+		if writeErr != nil {
+			panic(writeErr)
 		}
 		sb.nbytes += uint64(n)
 	}

--- a/util/log/structured.go
+++ b/util/log/structured.go
@@ -52,7 +52,7 @@ func getJSON(arg interface{}) []byte {
 
 	jsonBytes, err := json.Marshal(arg)
 	if err != nil {
-		return []byte(fmt.Sprintf("{\"error\": %q}", err.Error()))
+		return []byte(fmt.Sprintf("{\"error\": %s}", err))
 	}
 	return jsonBytes
 }

--- a/util/testing_test.go
+++ b/util/testing_test.go
@@ -33,8 +33,8 @@ func verifyAddr(addr net.Addr, t *testing.T) {
 
 	acceptChan := make(chan struct{})
 	go func() {
-		if _, err := ln.Accept(); err != nil {
-			t.Error(err)
+		if _, acceptErr := ln.Accept(); acceptErr != nil {
+			t.Error(acceptErr)
 		}
 		close(acceptChan)
 	}()

--- a/util/testing_test.go
+++ b/util/testing_test.go
@@ -28,14 +28,12 @@ import (
 func verifyAddr(addr net.Addr, t *testing.T) {
 	ln, err := net.Listen(addr.Network(), addr.String())
 	if err != nil {
-		t.Error(err)
-		return
+		t.Fatal(err)
 	}
 
 	acceptChan := make(chan struct{})
 	go func() {
-		_, err := ln.Accept()
-		if err != nil {
+		if _, err := ln.Accept(); err != nil {
 			t.Error(err)
 		}
 		close(acceptChan)
@@ -44,8 +42,7 @@ func verifyAddr(addr net.Addr, t *testing.T) {
 	addr = ln.Addr()
 	conn, err := net.Dial(addr.Network(), addr.String())
 	if err != nil {
-		t.Errorf("could not connect to %s", addr)
-		return
+		t.Fatalf("could not connect to %s", addr)
 	}
 	select {
 	case <-acceptChan:


### PR DESCRIPTION
Alternative to #1730. Basically everything is a false positive AFAICT, but the count is pretty small.

The biggest change is the second commit which contains somewhat cosmetic cleanup carried over from #1730.
