### PR TITLE
Narrow scope of `err` whenever convenient

### DIFF
--- a/acceptance/localcluster/docker.go
+++ b/acceptance/localcluster/docker.go
@@ -237,8 +237,7 @@ func (c *Container) Wait() error {
 		return err
 	}
 	var r struct{ StatusCode int }
-	err = json.Unmarshal(body, &r)
-	if err != nil {
+	if err := json.Unmarshal(body, &r); err != nil {
 		return err
 	}
 	if r.StatusCode != 0 {

--- a/cli/sql.go
+++ b/cli/sql.go
@@ -127,13 +127,13 @@ func runTerm(cmd *cobra.Command, args []string) {
 
 	// We need to switch to raw mode. Unfortunately, this masks
 	// signals-from-keyboard, meaning that ctrl-C cannot be caught.
-	oldState, err := terminal.MakeRaw(0)
-	if err != nil {
+	if oldState, err := terminal.MakeRaw(0); err != nil {
 		panic(err)
+	} else {
+		defer func() {
+			_ = terminal.Restore(0, oldState)
+		}()
 	}
-	defer func() {
-		_ = terminal.Restore(0, oldState)
-	}()
 
 	term := terminal.NewTerminal(readWriter, "> ")
 	for {

--- a/cli/start.go
+++ b/cli/start.go
@@ -60,8 +60,7 @@ func runInit(cmd *cobra.Command, args []string) {
 	// Default user for servers.
 	Context.User = security.NodeUser
 	// First initialize the Context as it is used in other places.
-	err := Context.Init("init")
-	if err != nil {
+	if err := Context.Init("init"); err != nil {
 		log.Errorf("failed to initialize context: %s", err)
 		return
 	}
@@ -127,8 +126,7 @@ func runStart(cmd *cobra.Command, args []string) {
 		return
 	}
 
-	err = s.Start(false)
-	if err != nil {
+	if err := s.Start(false); err != nil {
 		log.Errorf("cockroach server exited with error: %s", err)
 		return
 	}

--- a/client/admin.go
+++ b/client/admin.go
@@ -120,7 +120,7 @@ func (a *AdminClient) List() ([]string, error) {
 		Data []string `json:"d"`
 	}
 	var w wrapper
-	if err = json.Unmarshal(body, &w); err != nil {
+	if err := json.Unmarshal(body, &w); err != nil {
 		return nil, util.Errorf("unable to parse response %q: %s", body, err)
 	}
 

--- a/client/admin_test.go
+++ b/client/admin_test.go
@@ -88,12 +88,10 @@ func Example_accounting() {
 	fmt.Printf("Accounting prefixes: %q\n", keys)
 
 	// Remove keys: the default one cannot be removed.
-	err = client.Delete("")
-	if err == nil {
+	if err := client.Delete(""); err == nil {
 		log.Fatal("expected error")
 	}
-	err = client.Delete("db 2")
-	if err != nil {
+	if err := client.Delete("db 2"); err != nil {
 		log.Fatal(err)
 	}
 
@@ -199,12 +197,10 @@ write: [readwrite, writeonly]
 	fmt.Printf("Permission prefixes: %q\n", keys)
 
 	// Remove keys: the default one cannot be removed.
-	err = client.Delete("")
-	if err == nil {
+	if err := client.Delete(""); err == nil {
 		log.Fatal("expected error")
 	}
-	err = client.Delete("db 2")
-	if err != nil {
+	if err := client.Delete("db 2"); err != nil {
 		log.Fatal(err)
 	}
 
@@ -311,12 +307,10 @@ func Example_user() {
 	fmt.Printf("Users: %q\n", keys)
 
 	// Remove keys: the default one cannot be removed.
-	err = client.Delete("")
-	if err == nil {
+	if err := client.Delete(""); err == nil {
 		log.Fatal("expected error")
 	}
-	err = client.Delete("db 2")
-	if err != nil {
+	if err := client.Delete("db 2"); err != nil {
 		log.Fatal(err)
 	}
 
@@ -434,12 +428,10 @@ range_max_bytes: 67108864
 	fmt.Printf("Zone prefixes: %q\n", keys)
 
 	// Remove keys: the default one cannot be removed.
-	err = client.Delete("")
-	if err == nil {
+	if err := client.Delete(""); err == nil {
 		log.Fatal("expected error")
 	}
-	err = client.Delete("db 2")
-	if err != nil {
+	if err := client.Delete("db 2"); err != nil {
 		log.Fatal(err)
 	}
 

--- a/client/client_test.go
+++ b/client/client_test.go
@@ -558,12 +558,10 @@ func TestClientPermissions(t *testing.T) {
 
 	value := []byte("value")
 	for tcNum, tc := range testCases {
-		err := tc.client.Put(tc.path, value)
-		if err == nil != tc.success {
+		if err := tc.client.Put(tc.path, value); err == nil != tc.success {
 			t.Errorf("#%d: expected success=%t, got err=%s", tcNum, tc.success, err)
 		}
-		_, err = tc.client.Get(tc.path)
-		if err == nil != tc.success {
+		if _, err := tc.client.Get(tc.path); err == nil != tc.success {
 			t.Errorf("#%d: expected success=%t, got err=%s", tcNum, tc.success, err)
 		}
 	}

--- a/client/db_test.go
+++ b/client/db_test.go
@@ -87,7 +87,7 @@ func ExampleDB_CPut() {
 	}
 	fmt.Printf("aa=%s\n", result.ValueBytes())
 
-	if err = db.CPut("aa", "3", "1"); err == nil {
+	if err := db.CPut("aa", "3", "1"); err == nil {
 		panic("expected error from conditional put")
 	}
 	result, err = db.Get("aa")
@@ -96,7 +96,7 @@ func ExampleDB_CPut() {
 	}
 	fmt.Printf("aa=%s\n", result.ValueBytes())
 
-	if err = db.CPut("bb", "4", "1"); err == nil {
+	if err := db.CPut("bb", "4", "1"); err == nil {
 		panic("expected error from conditional put")
 	}
 	result, err = db.Get("bb")
@@ -104,7 +104,7 @@ func ExampleDB_CPut() {
 		panic(err)
 	}
 	fmt.Printf("bb=%s\n", result.ValueBytes())
-	if err = db.CPut("bb", "4", nil); err != nil {
+	if err := db.CPut("bb", "4", nil); err != nil {
 		panic(err)
 	}
 	result, err = db.Get("bb")

--- a/client/table.go
+++ b/client/table.go
@@ -287,11 +287,11 @@ func (db *DB) CreateTable(desc *structured.TableDescriptor) error {
 		return fmt.Errorf("table \"%s\" already exists", desc.Name)
 	}
 
-	ir, err := db.Inc(keys.DescIDGenerator, 1)
-	if err != nil {
+	if ir, err := db.Inc(keys.DescIDGenerator, 1); err == nil {
+		desc.ID = uint32(ir.ValueInt() - 1)
+	} else {
 		return err
 	}
-	desc.ID = uint32(ir.ValueInt() - 1)
 
 	// TODO(pmattis): Be cognizant of error messages when this is ported to the
 	// server. The error currently returned below is likely going to be difficult

--- a/examples/sql_bank/main.go
+++ b/examples/sql_bank/main.go
@@ -49,7 +49,7 @@ func moveMoney(db *sql.DB) {
 		if err != nil {
 			log.Fatal(err)
 		}
-		if _, err = tx.Exec("SET TRANSACTION ISOLATION LEVEL SERIALIZABLE"); err != nil {
+		if _, err := tx.Exec("SET TRANSACTION ISOLATION LEVEL SERIALIZABLE"); err != nil {
 			log.Fatal(err)
 		}
 		rows, err := tx.Query("SELECT id, balance FROM accounts WHERE id IN ($1, $2)", from, to)
@@ -57,7 +57,7 @@ func moveMoney(db *sql.DB) {
 			if log.V(1) {
 				log.Warning(err)
 			}
-			if err = tx.Rollback(); err != nil {
+			if err := tx.Rollback(); err != nil {
 				log.Fatal(err)
 			}
 			continue
@@ -65,7 +65,7 @@ func moveMoney(db *sql.DB) {
 		var fromBalance, toBalance int
 		for rows.Next() {
 			var id, balance int
-			if err = rows.Scan(&id, &balance); err != nil {
+			if err := rows.Scan(&id, &balance); err != nil {
 				log.Fatal(err)
 			}
 			switch id {
@@ -78,25 +78,25 @@ func moveMoney(db *sql.DB) {
 			}
 		}
 
-		if _, err = tx.Exec("UPDATE accounts SET balance=$2 WHERE id=$1", from, fromBalance-amount); err != nil {
+		if _, err := tx.Exec("UPDATE accounts SET balance=$2 WHERE id=$1", from, fromBalance-amount); err != nil {
 			if log.V(1) {
 				log.Warning(err)
 			}
-			if err = tx.Rollback(); err != nil {
+			if err := tx.Rollback(); err != nil {
 				log.Fatal(err)
 			}
 			continue
 		}
-		if _, err = tx.Exec("UPDATE accounts SET balance=$2 WHERE id=$1", to, toBalance+amount); err != nil {
+		if _, err := tx.Exec("UPDATE accounts SET balance=$2 WHERE id=$1", to, toBalance+amount); err != nil {
 			if log.V(1) {
 				log.Warning(err)
 			}
-			if err = tx.Rollback(); err != nil {
+			if err := tx.Rollback(); err != nil {
 				log.Fatal(err)
 			}
 			continue
 		}
-		if err = tx.Commit(); err != nil {
+		if err := tx.Commit(); err != nil {
 			if log.V(1) {
 				log.Warning(err)
 			}
@@ -124,12 +124,12 @@ func verifyBank(db *sql.DB) {
 		}
 		for rows.Next() {
 			var balance int64
-			if err = rows.Scan(&balance); err != nil {
+			if err := rows.Scan(&balance); err != nil {
 				log.Fatal(err)
 			}
 			sum += balance
 		}
-		if err = tx.Commit(); err != nil {
+		if err := tx.Commit(); err != nil {
 			log.Fatal(err)
 		}
 	}
@@ -160,16 +160,16 @@ func main() {
 
 	db.SetMaxOpenConns(concurrency)
 
-	if _, err = db.Exec("CREATE TABLE IF NOT EXISTS accounts (id BIGINT UNIQUE NOT NULL, balance BIGINT NOT NULL)"); err != nil {
+	if _, err := db.Exec("CREATE TABLE IF NOT EXISTS accounts (id BIGINT UNIQUE NOT NULL, balance BIGINT NOT NULL)"); err != nil {
 		log.Fatal(err)
 	}
 
-	if _, err = db.Exec("TRUNCATE TABLE accounts"); err != nil {
+	if _, err := db.Exec("TRUNCATE TABLE accounts"); err != nil {
 		log.Fatal(err)
 	}
 
 	for i := 0; i < numAccounts; i++ {
-		if _, err = db.Exec("INSERT INTO accounts (id, balance) VALUES ($1, $2)", i, 0); err != nil {
+		if _, err := db.Exec("INSERT INTO accounts (id, balance) VALUES ($1, $2)", i, 0); err != nil {
 			log.Fatal(err)
 		}
 	}

--- a/gossip/gossip_test.go
+++ b/gossip/gossip_test.go
@@ -82,16 +82,15 @@ func TestGossipGroupsInfoStore(t *testing.T) {
 			t.Fatal(err)
 		}
 	}
-	values, err := g.GetGroupInfos("i")
-	if err != nil {
+	if values, err := g.GetGroupInfos("i"); err != nil {
 		t.Errorf("error fetching int64 group: %v", err)
-	}
-	if len(values) != 3 {
+	} else if len(values) != 3 {
 		t.Errorf("incorrect number of values in group: %v", values)
-	}
-	for i := 0; i < 3; i++ {
-		if values[i].(int64) != int64(i) {
-			t.Errorf("index %d has incorrect value: %d, expected %d", i, values[i].(int64), i)
+	} else {
+		for i := 0; i < 3; i++ {
+			if values[i].(int64) != int64(i) {
+				t.Errorf("index %d has incorrect value: %d, expected %d", i, values[i].(int64), i)
+			}
 		}
 	}
 	if _, err := g.GetGroupInfos("i2"); err == nil {
@@ -107,16 +106,15 @@ func TestGossipGroupsInfoStore(t *testing.T) {
 			t.Fatal(err)
 		}
 	}
-	values, err = g.GetGroupInfos("f")
-	if err != nil {
+	if values, err := g.GetGroupInfos("f"); err != nil {
 		t.Errorf("error fetching float64 group: %v", err)
-	}
-	if len(values) != 3 {
+	} else if len(values) != 3 {
 		t.Errorf("incorrect number of values in group: %v", values)
-	}
-	for i := 0; i < 3; i++ {
-		if values[i].(float64) != float64(i) {
-			t.Errorf("index %d has incorrect value: %f, expected %d", i, values[i].(float64), i)
+	} else {
+		for i := 0; i < 3; i++ {
+			if values[i].(float64) != float64(i) {
+				t.Errorf("index %d has incorrect value: %f, expected %d", i, values[i].(float64), i)
+			}
 		}
 	}
 
@@ -129,16 +127,15 @@ func TestGossipGroupsInfoStore(t *testing.T) {
 			t.Fatal(err)
 		}
 	}
-	values, err = g.GetGroupInfos("s")
-	if err != nil {
+	if values, err := g.GetGroupInfos("s"); err != nil {
 		t.Errorf("error fetching string group: %v", err)
-	}
-	if len(values) != 3 {
+	} else if len(values) != 3 {
 		t.Errorf("incorrect number of values in group: %v", values)
-	}
-	for i := 0; i < 3; i++ {
-		if values[i].(string) != fmt.Sprintf("%d", i) {
-			t.Errorf("index %d has incorrect value: %d, expected %s", i, values[i], fmt.Sprintf("%d", i))
+	} else {
+		for i := 0; i < 3; i++ {
+			if values[i].(string) != fmt.Sprintf("%d", i) {
+				t.Errorf("index %d has incorrect value: %d, expected %s", i, values[i], fmt.Sprintf("%d", i))
+			}
 		}
 	}
 }

--- a/gossip/group_test.go
+++ b/gossip/group_test.go
@@ -134,11 +134,9 @@ func TestSameKeyInserts(t *testing.T) {
 	defer leaktest.AfterTest(t)
 	group := newGroup("a", 1, MinGroup)
 	info1 := newTestInfo("a.a", int64(1))
-	changed, err := group.addInfo(info1)
-	if err != nil {
+	if changed, err := group.addInfo(info1); err != nil {
 		t.Error(err)
-	}
-	if !changed {
+	} else if !changed {
 		t.Error("expected changed contents to be true on first insert")
 	}
 
@@ -152,20 +150,16 @@ func TestSameKeyInserts(t *testing.T) {
 	// Two successively larger timestamps always win.
 	info3 := newTestInfo("a.a", int64(1))
 	info3.Timestamp = info1.Timestamp + 1
-	changed, err = group.addInfo(info3)
-	if err != nil {
+	if changed, err := group.addInfo(info3); err != nil {
 		t.Error(err)
-	}
-	if changed {
+	} else if changed {
 		t.Error("expected changed to be false on successive timestamp but same value")
 	}
 	info4 := newTestInfo("a.a", int64(2)) // change value
 	info4.Timestamp = info1.Timestamp + 2
-	changed, err = group.addInfo(info4)
-	if err != nil {
+	if changed, err := group.addInfo(info4); err != nil {
 		t.Error(err)
-	}
-	if !changed {
+	} else if !changed {
 		t.Error("expected changed to be true on successive timestamp with different value")
 	}
 }

--- a/kv/db_test.go
+++ b/kv/db_test.go
@@ -200,7 +200,7 @@ func TestKVDBTransaction(t *testing.T) {
 
 	key := proto.Key("db-txn-test")
 	value := []byte("value")
-	err := db.Txn(func(txn *client.Txn) error {
+	if err := db.Txn(func(txn *client.Txn) error {
 		// Use snapshot isolation so non-transactional read can always push.
 		txn.SetSnapshotIsolation()
 
@@ -222,8 +222,7 @@ func TestKVDBTransaction(t *testing.T) {
 			t.Errorf("expected value %q; got %q", value, gr.ValueBytes())
 		}
 		return nil
-	})
-	if err != nil {
+	}); err != nil {
 		t.Errorf("expected success on commit; got %s", err)
 	}
 

--- a/kv/dist_sender.go
+++ b/kv/dist_sender.go
@@ -322,15 +322,9 @@ func (ds *DistSender) getFirstRangeDescriptor() (*proto.RangeDescriptor, error) 
 // subsequent ranges which are likely to be requested soon by the current
 // workload.
 func (ds *DistSender) getRangeDescriptors(key proto.Key, options lookupOptions) ([]proto.RangeDescriptor, error) {
-	var (
-		// metadataKey is sent to internalRangeLookup to find the
-		// RangeDescriptor which contains key.
-		metadataKey = keys.RangeMetaKey(key)
-		// desc is the RangeDescriptor for the range which contains
-		// metadataKey.
-		desc *proto.RangeDescriptor
-		err  error
-	)
+	// metadataKey is sent to internalRangeLookup to find the
+	// RangeDescriptor which contains key.
+	metadataKey := keys.RangeMetaKey(key)
 	if bytes.Equal(metadataKey, proto.KeyMin) {
 		// In this case, the requested key is stored in the cluster's first
 		// range. Return the first range, which is always gossiped and not
@@ -341,9 +335,15 @@ func (ds *DistSender) getRangeDescriptors(key proto.Key, options lookupOptions) 
 		}
 		return []proto.RangeDescriptor{*rd}, nil
 	}
+
+	// desc is the RangeDescriptor for the range which contains
+	// metadataKey.
+	var desc *proto.RangeDescriptor
+	var err error
 	if bytes.HasPrefix(metadataKey, keys.Meta1Prefix) {
 		// In this case, desc is the cluster's first range.
-		if desc, err = ds.getFirstRangeDescriptor(); err != nil {
+		desc, err = ds.getFirstRangeDescriptor()
+		if err != nil {
 			return nil, err
 		}
 	} else {

--- a/kv/dist_sender_test.go
+++ b/kv/dist_sender_test.go
@@ -65,7 +65,7 @@ func makeTestGossip(t *testing.T) (*gossip.Gossip, func()) {
 		{proto.KeyMin, nil, permConfig},
 	})
 	if err != nil {
-		t.Fatalf("failed to make prefix config map, err: %s", err.Error())
+		t.Fatalf("failed to make prefix config map, err: %s", err)
 	}
 	if err := g.AddInfo(gossip.KeySentinel, "cluster1", time.Hour); err != nil {
 		t.Fatal(err)
@@ -607,7 +607,7 @@ func TestVerifyPermissions(t *testing.T) {
 	}
 	configMap, err := storage.NewPrefixConfigMap(configs)
 	if err != nil {
-		t.Fatalf("failed to make prefix config map, err: %s", err.Error())
+		t.Fatalf("failed to make prefix config map, err: %s", err)
 	}
 	if err := ds.gossip.AddInfo(gossip.KeyConfigPermission, configMap, time.Hour); err != nil {
 		t.Fatal(err)

--- a/kv/local_sender_test.go
+++ b/kv/local_sender_test.go
@@ -69,7 +69,7 @@ func TestLocalSenderVisitStores(t *testing.T) {
 	visit := make([]bool, numStores)
 	err := ls.VisitStores(func(s *storage.Store) error { visit[s.Ident.StoreID] = true; return nil })
 	if err != nil {
-		t.Errorf("unexpected error on visit: %s", err.Error())
+		t.Errorf("unexpected error on visit: %s", err)
 	}
 
 	for i, visited := range visit {
@@ -102,7 +102,7 @@ func TestLocalSenderGetStore(t *testing.T) {
 		t.Errorf("expected storeID to be %d but was %d",
 			s.Ident.StoreID, store.Ident.StoreID)
 	} else if err != nil {
-		t.Errorf("expected no error, instead had err=%s", err.Error())
+		t.Errorf("expected no error, instead had err=%s", err)
 	}
 }
 

--- a/kv/range_cache_test.go
+++ b/kv/range_cache_test.go
@@ -131,7 +131,7 @@ func (db *testDescriptorDB) assertLookupCount(t *testing.T, expected int, key st
 func doLookup(t *testing.T, rc *rangeDescriptorCache, key string) *proto.RangeDescriptor {
 	r, err := rc.LookupRangeDescriptor(proto.Key(key), lookupOptions{})
 	if err != nil {
-		t.Fatalf("Unexpected error from LookupRangeDescriptor: %s", err.Error())
+		t.Fatalf("Unexpected error from LookupRangeDescriptor: %s", err)
 	}
 	if !r.ContainsKey(keys.KeyAddress(proto.Key(key))) {
 		t.Fatalf("Returned range did not contain key: %s-%s, %s", r.StartKey, r.EndKey, key)

--- a/kv/txn_test.go
+++ b/kv/txn_test.go
@@ -22,7 +22,6 @@ import (
 	"bytes"
 	"errors"
 	"fmt"
-	"reflect"
 	"sync"
 	"testing"
 	"time"
@@ -188,7 +187,7 @@ func verifyUncertainty(concurrency int, maxOffset time.Duration, t *testing.T) {
 					if _, ok := err.(*proto.ReadWithinUncertaintyIntervalError); ok {
 						return err
 					}
-					return util.Errorf("unexpected read error of type %s: %s", reflect.TypeOf(err), err)
+					return util.Errorf("unexpected read error of type %T: %s", err, err)
 				}
 				if !gr.Exists() {
 					return util.Errorf("no value read")
@@ -523,7 +522,7 @@ func TestTxnRepeatGetWithRangeSplit(t *testing.T) {
 	// Wait till txnA finish put(a).
 	<-ch
 
-	err := s.DB.Txn(func(txn *client.Txn) error {
+	if err := s.DB.Txn(func(txn *client.Txn) error {
 		// Use snapshot isolation.
 		txn.SetSnapshotIsolation()
 
@@ -563,8 +562,7 @@ func TestTxnRepeatGetWithRangeSplit(t *testing.T) {
 			t.Fatalf("Repeat read same key in same txn but get different value gr1 nil gr2 %v", gr2.Value)
 		}
 		return nil
-	})
-	if err != nil {
+	}); err != nil {
 		t.Fatal(err)
 	}
 }

--- a/proto/internal_test.go
+++ b/proto/internal_test.go
@@ -48,30 +48,24 @@ func TestTimeSeriesToValue(t *testing.T) {
 	}
 
 	// Wrap the TSD into a Value
-	valueOriginal, err := tsOriginal.ToValue()
-	if err != nil {
-		t.Fatalf("error marshaling InternalTimeSeriesData: %s", err.Error())
-	}
-	if a, e := valueOriginal.GetTag(), _CR_TS.String(); a != e {
+	if valueOriginal, err := tsOriginal.ToValue(); err != nil {
+		t.Fatalf("error marshaling InternalTimeSeriesData: %s", err)
+	} else if a, e := valueOriginal.GetTag(), _CR_TS.String(); a != e {
 		t.Errorf("Value did not have expected tag value of %s, had %s", e, a)
-	}
+	} else {
+		// Ensure the Value's 'bytes' field contains the marshalled TSD
+		if tsEncoded, err := gogoproto.Marshal(tsOriginal); err != nil {
+			t.Fatalf("error marshaling TimeSeriesData: %s", err)
+		} else if a, e := valueOriginal.Bytes, tsEncoded; !bytes.Equal(a, e) {
+			t.Errorf("bytes field was not properly encoded: expected %v, got %v", e, a)
+		}
 
-	// Ensure the Value's 'bytes' field contains the marshalled TSD
-	tsEncoded, err := gogoproto.Marshal(tsOriginal)
-	if err != nil {
-		t.Fatalf("error marshaling TimeSeriesData: %s", err.Error())
-	}
-	if a, e := valueOriginal.Bytes, tsEncoded; !bytes.Equal(a, e) {
-		t.Errorf("bytes field was not properly encoded: expected %v, got %v", e, a)
-	}
-
-	// Extract the TSD from the Value
-	tsNew, err := InternalTimeSeriesDataFromValue(valueOriginal)
-	if err != nil {
-		t.Errorf("error extracting Time Series: %s", err.Error())
-	}
-	if !gogoproto.Equal(tsOriginal, tsNew) {
-		t.Errorf("extracted time series not equivalent to original; %v != %v", tsNew, tsOriginal)
+		// Extract the TSD from the Value
+		if tsNew, err := InternalTimeSeriesDataFromValue(valueOriginal); err != nil {
+			t.Errorf("error extracting Time Series: %s", err)
+		} else if !gogoproto.Equal(tsOriginal, tsNew) {
+			t.Errorf("extracted time series not equivalent to original; %v != %v", tsNew, tsOriginal)
+		}
 	}
 
 	// Make sure ExtractTimeSeries doesn't work on non-TimeSeries values

--- a/proto/timeseries_test.go
+++ b/proto/timeseries_test.go
@@ -130,7 +130,7 @@ func TestToInternal(t *testing.T) {
 		actual, err := tc.input.ToInternal(tc.keyDuration, tc.sampleDuration)
 		if err != nil {
 			if !tc.expectsError {
-				t.Errorf("unexpected error from case %d: %s", i, err.Error())
+				t.Errorf("unexpected error from case %d: %s", i, err)
 			}
 			continue
 		} else if tc.expectsError {

--- a/rpc/codec/rpc_test.go
+++ b/rpc/codec/rpc_test.go
@@ -121,12 +121,11 @@ func listenAndServeArithAndEchoService(network, addr string) (net.Addr, error) {
 func testArithClient(t *testing.T, client *rpc.Client) {
 	var args message.ArithRequest
 	var reply message.ArithResponse
-	var err error
 
 	// Add
 	args.A = 1
 	args.B = 2
-	if err = client.Call("ArithService.Add", &args, &reply); err != nil {
+	if err := client.Call("ArithService.Add", &args, &reply); err != nil {
 		t.Fatalf(`arith.Add: %v`, err)
 	}
 	if reply.GetC() != 3 {
@@ -136,7 +135,7 @@ func testArithClient(t *testing.T, client *rpc.Client) {
 	// Mul
 	args.A = 2
 	args.B = 3
-	if err = client.Call("ArithService.Mul", &args, &reply); err != nil {
+	if err := client.Call("ArithService.Mul", &args, &reply); err != nil {
 		t.Fatalf(`arith.Mul: %v`, err)
 	}
 	if reply.GetC() != 6 {
@@ -146,7 +145,7 @@ func testArithClient(t *testing.T, client *rpc.Client) {
 	// Div
 	args.A = 13
 	args.B = 5
-	if err = client.Call("ArithService.Div", &args, &reply); err != nil {
+	if err := client.Call("ArithService.Div", &args, &reply); err != nil {
 		t.Fatalf(`arith.Div: %v`, err)
 	}
 	if reply.GetC() != 2 {
@@ -156,15 +155,15 @@ func testArithClient(t *testing.T, client *rpc.Client) {
 	// Div zero
 	args.A = 1
 	args.B = 0
-	if err = client.Call("ArithService.Div", &args, &reply); err.Error() != "divide by zero" {
-		t.Fatalf(`arith.Error: expected = "%s", got = "%s"`, "divide by zero", err.Error())
+	if err := client.Call("ArithService.Div", &args, &reply); err.Error() != "divide by zero" {
+		t.Fatalf(`arith.Error: expected = "%s", got = "%s"`, "divide by zero", err)
 	}
 
 	// Error
 	args.A = 1
 	args.B = 2
-	if err = client.Call("ArithService.Error", &args, &reply); err.Error() != "ArithError" {
-		t.Fatalf(`arith.Error: expected = "%s", got = "%s"`, "ArithError", err.Error())
+	if err := client.Call("ArithService.Error", &args, &reply); err.Error() != "ArithError" {
+		t.Fatalf(`arith.Error: expected = "%s", got = "%s"`, "ArithError", err)
 	}
 }
 
@@ -246,11 +245,10 @@ func testArithClientAsync(t *testing.T, client *rpc.Client) {
 func testEchoClient(t *testing.T, client *rpc.Client) {
 	var args message.EchoRequest
 	var reply message.EchoResponse
-	var err error
 
 	// EchoService.Echo
 	args.Msg = "Hello, Protobuf-RPC"
-	if err = client.Call("EchoService.Echo", &args, &reply); err != nil {
+	if err := client.Call("EchoService.Echo", &args, &reply); err != nil {
 		t.Fatalf(`EchoService.Echo: %v`, err)
 	}
 	if reply.GetMsg() != args.GetMsg() {
@@ -279,7 +277,6 @@ func listenAndServeEchoService(network, addr string,
 	serveConn func(srv *rpc.Server, conn io.ReadWriteCloser)) (net.Listener, error) {
 	l, err := net.Listen(network, addr)
 	if err != nil {
-		fmt.Printf("failed to listen on %s: %s\n", addr, err)
 		return nil, err
 	}
 	srv := rpc.NewServer()

--- a/rpc/heartbeat_test.go
+++ b/rpc/heartbeat_test.go
@@ -130,7 +130,7 @@ func TestUpdateOffsetOnHeartbeat(t *testing.T) {
 			MeasuredAt:  20,
 		},
 	}
-	if err = client.connect(); err != nil {
+	if err := client.connect(); err != nil {
 		t.Fatal(err)
 	}
 

--- a/rpc/server_test.go
+++ b/rpc/server_test.go
@@ -95,9 +95,9 @@ func TestUnregisteredMethod(t *testing.T) {
 
 	// Sending an invalid method fails cleanly, but leaves the connection
 	// in a valid state.
-	_, err := sendRPC(opts, []net.Addr{s.Addr()}, nodeContext, "Foo.Bar",
-		&proto.PingRequest{}, &proto.PingResponse{})
-	if !testutils.IsError(err, ".*rpc: couldn't find method: Foo.Bar") {
+	if _, err := sendRPC(
+		opts, []net.Addr{s.Addr()}, nodeContext, "Foo.Bar", &proto.PingRequest{}, &proto.PingResponse{},
+	); !testutils.IsError(err, ".*rpc: couldn't find method: Foo.Bar") {
 		t.Fatalf("expected 'couldn't find method' but got %s", err)
 	}
 	if _, err := sendPing(opts, []net.Addr{s.Addr()}, nodeContext); err != nil {

--- a/security/tls_test.go
+++ b/security/tls_test.go
@@ -43,15 +43,15 @@ func TestLoadTLSConfig(t *testing.T) {
 		t.Fatalf("Couldn't parse test cert: %v", err)
 	}
 
-	if err = verifyX509Cert(x509Cert, "localhost", config.RootCAs); err != nil {
+	if err := verifyX509Cert(x509Cert, "localhost", config.RootCAs); err != nil {
 		t.Errorf("Couldn't verify test cert against server CA: %v", err)
 	}
 
-	if err = verifyX509Cert(x509Cert, "localhost", config.ClientCAs); err != nil {
+	if err := verifyX509Cert(x509Cert, "localhost", config.ClientCAs); err != nil {
 		t.Errorf("Couldn't verify test cert against client CA: %v", err)
 	}
 
-	if err = verifyX509Cert(x509Cert, "google.com", config.RootCAs); err == nil {
+	if err := verifyX509Cert(x509Cert, "google.com", config.RootCAs); err == nil {
 		t.Errorf("Verified test cert for wrong hostname")
 	}
 }

--- a/server/admin.go
+++ b/server/admin.go
@@ -191,7 +191,7 @@ func (s *adminServer) handlePutAction(handler actionHandler, w http.ResponseWrit
 		return
 	}
 	defer r.Body.Close()
-	if err = handler.Put(path, b, r); err != nil {
+	if err := handler.Put(path, b, r); err != nil {
 		http.Error(w, err.Error(), http.StatusInternalServerError)
 		return
 	}
@@ -219,7 +219,7 @@ func (s *adminServer) handleDeleteAction(handler actionHandler, w http.ResponseW
 		http.Error(w, err.Error(), http.StatusBadRequest)
 		return
 	}
-	if err = handler.Delete(path, r); err != nil {
+	if err := handler.Delete(path, r); err != nil {
 		http.Error(w, err.Error(), http.StatusInternalServerError)
 		return
 	}

--- a/server/admin_test.go
+++ b/server/admin_test.go
@@ -89,11 +89,9 @@ func TestAdminDebugPprof(t *testing.T) {
 	s := StartTestServer(t)
 	defer s.Stop()
 
-	body, err := getText(s.Ctx.RequestScheme() + "://" + s.ServingAddr() + debugEndpoint + "pprof/block")
-	if err != nil {
+	if body, err := getText(s.Ctx.RequestScheme() + "://" + s.ServingAddr() + debugEndpoint + "pprof/block"); err != nil {
 		t.Fatal(err)
-	}
-	if exp := "contention:\ncycles/second="; !bytes.Contains(body, []byte(exp)) {
+	} else if exp := "contention:\ncycles/second="; !bytes.Contains(body, []byte(exp)) {
 		t.Errorf("expected %s to contain %s", body, exp)
 	}
 }
@@ -132,7 +130,6 @@ range_max_bytes: 67108864
 		t.Fatal(err)
 	}
 	for i, test := range testData {
-		re := regexp.MustCompile(test.expErr)
 		req, err := http.NewRequest("POST", fmt.Sprintf("%s://%s%s/%s", s.Ctx.RequestScheme(), s.ServingAddr(), zonePathPrefix, "foo"), strings.NewReader(test.zone))
 		if err != nil {
 			t.Fatal(err)
@@ -149,7 +146,7 @@ range_max_bytes: 67108864
 		}
 		if resp.StatusCode == http.StatusOK {
 			t.Errorf("%d: expected error", i)
-		} else if !re.MatchString(string(b)) {
+		} else if re := regexp.MustCompile(test.expErr); !re.MatchString(string(b)) {
 			t.Errorf("%d: expected error matching %q; got %s", i, test.expErr, b)
 		}
 	}

--- a/server/node.go
+++ b/server/node.go
@@ -108,8 +108,9 @@ func BootstrapCluster(clusterID string, engines []engine.Engine, stopper *stop.S
 	// Create a KV DB with a local sender.
 	lSender := kv.NewLocalSender()
 	sender := kv.NewTxnCoordSender(lSender, ctx.Clock, false, nil, stopper)
-	var err error
-	if ctx.DB, err = client.Open("//root@", client.SenderOpt(sender)); err != nil {
+	if db, err := client.Open("//root@", client.SenderOpt(sender)); err == nil {
+		ctx.DB = db
+	} else {
 		return nil, err
 	}
 	ctx.Transport = multiraft.NewLocalRPCTransport()
@@ -218,7 +219,7 @@ func (n *Node) initNodeID(id proto.NodeID) {
 	// Gossip the node descriptor to make this node addressable by node ID.
 	n.Descriptor.NodeID = id
 	log.Infof("new node allocated ID %d", n.Descriptor.NodeID)
-	if err = n.ctx.Gossip.SetNodeDescriptor(&n.Descriptor); err != nil {
+	if err := n.ctx.Gossip.SetNodeDescriptor(&n.Descriptor); err != nil {
 		log.Fatalf("couldn't gossip descriptor for node %d: %s", n.Descriptor.NodeID, err)
 	}
 }

--- a/server/node_test.go
+++ b/server/node_test.go
@@ -185,8 +185,7 @@ func TestNodeJoin(t *testing.T) {
 	defer leaktest.AfterTest(t)
 	stopper := stop.NewStopper()
 	e := engine.NewInMem(proto.Attributes{}, 1<<20)
-	_, err := BootstrapCluster("cluster-1", []engine.Engine{e}, stopper)
-	if err != nil {
+	if _, err := BootstrapCluster("cluster-1", []engine.Engine{e}, stopper); err != nil {
 		t.Fatal(err)
 	}
 	stopper.Stop()
@@ -247,7 +246,7 @@ func TestCorruptedClusterID(t *testing.T) {
 		NodeID:    1,
 		StoreID:   1,
 	}
-	if err = engine.MVCCPutProto(e, nil, keys.StoreIdentKey(), proto.ZeroTimestamp, nil, &sIdent); err != nil {
+	if err := engine.MVCCPutProto(e, nil, keys.StoreIdentKey(), proto.ZeroTimestamp, nil, &sIdent); err != nil {
 		t.Fatal(err)
 	}
 
@@ -540,13 +539,9 @@ func TestStatusSummaries(t *testing.T) {
 		},
 		SplitKey: splitKey,
 	}
-	var reply *proto.AdminSplitResponse
 	if replyI, err := ts.node.executeCmd(args); err != nil {
 		t.Fatal(err)
-	} else {
-		reply = replyI.(*proto.AdminSplitResponse)
-	}
-	if reply.Error != nil {
+	} else if reply := replyI.(*proto.AdminSplitResponse); reply.Error != nil {
 		t.Fatal(reply.Error)
 	}
 

--- a/server/server.go
+++ b/server/server.go
@@ -84,8 +84,7 @@ func NewServer(ctx *Context, stopper *stop.Stopper) (*Server, error) {
 	}
 
 	addr := ctx.Addr
-	_, err := net.ResolveTCPAddr("tcp", addr)
-	if err != nil {
+	if _, err := net.ResolveTCPAddr("tcp", addr); err != nil {
 		return nil, util.Errorf("unable to resolve RPC address %q: %v", addr, err)
 	}
 
@@ -122,19 +121,22 @@ func NewServer(ctx *Context, stopper *stop.Stopper) (*Server, error) {
 
 	ds := kv.NewDistSender(&kv.DistSenderContext{Clock: s.clock}, s.gossip)
 	sender := kv.NewTxnCoordSender(ds, s.clock, ctx.Linearizable, tracer, s.stopper)
-	if s.db, err = client.Open("//root@", client.SenderOpt(sender)); err != nil {
+	if db, err := client.Open("//root@", client.SenderOpt(sender)); err == nil {
+		s.db = db
+	} else {
 		return nil, err
 	}
 
-	s.raftTransport, err = newRPCTransport(s.gossip, s.rpc, rpcContext)
-	if err != nil {
+	if transport, err := newRPCTransport(s.gossip, s.rpc, rpcContext); err == nil {
+		s.raftTransport = transport
+	} else {
 		return nil, err
 	}
 	s.stopper.AddCloser(s.raftTransport)
 
 	s.kvDB = kv.NewDBServer(&s.ctx.Context, sender)
 	if s.ctx.ExperimentalRPCServer {
-		if err = s.kvDB.RegisterRPC(s.rpc); err != nil {
+		if err := s.kvDB.RegisterRPC(s.rpc); err != nil {
 			return nil, err
 		}
 	}

--- a/server/status/feed_test.go
+++ b/server/status/feed_test.go
@@ -252,13 +252,12 @@ func TestServerNodeEventFeed(t *testing.T) {
 	}
 
 	// Add some data in a transaction
-	err = db.Txn(func(txn *client.Txn) error {
+	if err := db.Txn(func(txn *client.Txn) error {
 		b := &client.Batch{}
 		b.Put("a", "asdf")
 		b.Put("c", "jkl;")
 		return txn.Commit(b)
-	})
-	if err != nil {
+	}); err != nil {
 		t.Fatalf("error putting data to db: %s", err)
 	}
 
@@ -268,7 +267,7 @@ func TestServerNodeEventFeed(t *testing.T) {
 	}
 
 	// Scan, which should fail.
-	if _, err = db.Scan("b", "a", 0); err == nil {
+	if _, err := db.Scan("b", "a", 0); err == nil {
 		t.Fatal("expected scan to fail.")
 	}
 

--- a/server/status_test.go
+++ b/server/status_test.go
@@ -119,7 +119,7 @@ func TestStatusJson(t *testing.T) {
 				t.Fatal(err)
 			}
 			if re := regexp.MustCompile(spec.expected); !re.Match(body) {
-				t.Errorf("expected match %s; got %s", spec.expected, body)
+				t.Errorf("expected %s to match %s", body, spec.expected)
 			}
 		}
 	}
@@ -192,7 +192,7 @@ func TestStatusGossipJson(t *testing.T) {
 			t.Fatal(err)
 		}
 		data := &infos{}
-		if err = json.Unmarshal(body, &data); err != nil {
+		if err := json.Unmarshal(body, &data); err != nil {
 			t.Fatal(err)
 		}
 		if data.Infos.Accounting == nil {
@@ -289,17 +289,17 @@ func startServer(t *testing.T, keyPrefix string) TestServer {
 // correctly.
 func TestStatusLocalLogs(t *testing.T) {
 	defer leaktest.AfterTest(t)
-	dir, err := ioutil.TempDir("", "local_log_test")
-	if err != nil {
+	if dir, err := ioutil.TempDir("", "local_log_test"); err != nil {
 		t.Fatal(err)
+	} else {
+		log.EnableLogFileOutput(dir)
+		defer func() {
+			log.DisableLogFileOutput()
+			if err := os.RemoveAll(dir); err != nil {
+				t.Fatal(err)
+			}
+		}()
 	}
-	log.EnableLogFileOutput(dir)
-	defer func() {
-		log.DisableLogFileOutput()
-		if err := os.RemoveAll(dir); err != nil {
-			t.Fatal(err)
-		}
-	}()
 
 	ts := startServer(t, statusLocalLogFileKeyPrefix)
 	defer ts.Stop()

--- a/server/testserver.go
+++ b/server/testserver.go
@@ -156,9 +156,9 @@ func (ts *TestServer) Start() error {
 		ts.Ctx = NewTestContext()
 	}
 
-	var err error
-	ts.Server, err = NewServer(ts.Ctx, stop.NewStopper())
-	if err != nil {
+	if s, err := NewServer(ts.Ctx, stop.NewStopper()); err == nil {
+		ts.Server = s
+	} else {
 		return err
 	}
 
@@ -174,21 +174,17 @@ func (ts *TestServer) Start() error {
 
 	if !ts.SkipBootstrap {
 		stopper := stop.NewStopper()
-		_, err := BootstrapCluster("cluster-1", ts.Ctx.Engines, stopper)
-		if err != nil {
+		if _, err := BootstrapCluster("cluster-1", ts.Ctx.Engines, stopper); err != nil {
 			return util.Errorf("could not bootstrap cluster: %s", err)
 		}
 		stopper.Stop()
 	}
+
 	if err := ts.Server.Start(true); err != nil {
 		return err
 	}
 
-	if err := testutils.SetDefaultRangeReplicaNum(ts.db, 1); err != nil {
-		return err
-	}
-
-	return nil
+	return testutils.SetDefaultRangeReplicaNum(ts.db, 1)
 }
 
 // ServingAddr returns the rpc server's address. Should be used by clients.

--- a/sql/server.go
+++ b/sql/server.go
@@ -140,8 +140,8 @@ func (s *Server) exec(req driver.Request) (driver.Response, error) {
 	}
 	for _, stmt := range stmts {
 		// TODO(pmattis): Fill placeholders.
-		var plan planNode
-		if plan, err = planner.makePlan(stmt); err != nil {
+		plan, err := planner.makePlan(stmt)
+		if err != nil {
 			return resp, err
 		}
 

--- a/storage/addressing.go
+++ b/storage/addressing.go
@@ -40,8 +40,7 @@ func delMeta(b *client.Batch, key proto.Key, desc *proto.RangeDescriptor) {
 // and meta2 range addressing records for the left and right ranges
 // caused by a split.
 func splitRangeAddressing(b *client.Batch, left, right *proto.RangeDescriptor) error {
-	var err error
-	if err = rangeAddressing(b, left, putMeta); err != nil {
+	if err := rangeAddressing(b, left, putMeta); err != nil {
 		return err
 	}
 	return rangeAddressing(b, right, putMeta)
@@ -52,8 +51,7 @@ func splitRangeAddressing(b *client.Batch, left, right *proto.RangeDescriptor) e
 // the new merged range. Left is the range descriptor for the "left"
 // range before merging and merged describes the left to right merge.
 func mergeRangeAddressing(b *client.Batch, left, merged *proto.RangeDescriptor) error {
-	var err error
-	if err = rangeAddressing(b, left, delMeta); err != nil {
+	if err := rangeAddressing(b, left, delMeta); err != nil {
 		return err
 	}
 	return rangeAddressing(b, merged, putMeta)

--- a/storage/client_event_test.go
+++ b/storage/client_event_test.go
@@ -232,13 +232,12 @@ func TestMultiStoreEventFeed(t *testing.T) {
 	mtc.replicateRange(raftID, 0, 1, 2)
 
 	// Add some data in a transaction
-	err := mtc.db.Txn(func(txn *client.Txn) error {
+	if err := mtc.db.Txn(func(txn *client.Txn) error {
 		b := &client.Batch{}
 		b.Put("a", "asdf")
 		b.Put("c", "jkl;")
 		return txn.Commit(b)
-	})
-	if err != nil {
+	}); err != nil {
 		t.Fatalf("error putting data to db: %s", err)
 	}
 

--- a/storage/client_merge_test.go
+++ b/storage/client_merge_test.go
@@ -111,8 +111,10 @@ func TestStoreRangeMergeWithData(t *testing.T) {
 		t.Fatal(err)
 	}
 
+	var gArgs proto.GetRequest
+
 	// Confirm the values are there.
-	gArgs := getArgs([]byte("aaa"), aDesc.RaftID, store.StoreID())
+	gArgs = getArgs([]byte("aaa"), aDesc.RaftID, store.StoreID())
 	if reply, err := store.ExecuteCmd(context.Background(), &gArgs); err != nil {
 		t.Fatal(err)
 	} else if gReply := reply.(*proto.GetResponse); !bytes.Equal(gReply.Value.Bytes, content) {
@@ -168,11 +170,11 @@ func TestStoreRangeMergeWithData(t *testing.T) {
 
 	// Put new values after the merge on both sides.
 	pArgs = putArgs([]byte("aaaa"), content, rangeA.Desc().RaftID, store.StoreID())
-	if _, err = store.ExecuteCmd(context.Background(), &pArgs); err != nil {
+	if _, err := store.ExecuteCmd(context.Background(), &pArgs); err != nil {
 		t.Fatal(err)
 	}
 	pArgs = putArgs([]byte("cccc"), content, rangeB.Desc().RaftID, store.StoreID())
-	if _, err = store.ExecuteCmd(context.Background(), &pArgs); err != nil {
+	if _, err := store.ExecuteCmd(context.Background(), &pArgs); err != nil {
 		t.Fatal(err)
 	}
 

--- a/storage/client_raft_test.go
+++ b/storage/client_raft_test.go
@@ -20,7 +20,6 @@ package storage_test
 import (
 	"fmt"
 	"reflect"
-	"strings"
 	"sync"
 	"sync/atomic"
 	"testing"
@@ -33,6 +32,7 @@ import (
 	"github.com/cockroachdb/cockroach/proto"
 	"github.com/cockroachdb/cockroach/storage"
 	"github.com/cockroachdb/cockroach/storage/engine"
+	"github.com/cockroachdb/cockroach/testutils"
 	"github.com/cockroachdb/cockroach/util"
 	"github.com/cockroachdb/cockroach/util/hlc"
 	"github.com/cockroachdb/cockroach/util/leaktest"
@@ -211,11 +211,10 @@ func TestReplicateRange(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	if err := rng.ChangeReplicas(proto.ADD_REPLICA,
-		proto.Replica{
-			NodeID:  mtc.stores[1].Ident.NodeID,
-			StoreID: mtc.stores[1].Ident.StoreID,
-		}); err != nil {
+	if err := rng.ChangeReplicas(proto.ADD_REPLICA, proto.Replica{
+		NodeID:  mtc.stores[1].Ident.NodeID,
+		StoreID: mtc.stores[1].Ident.StoreID,
+	}); err != nil {
 		t.Fatal(err)
 	}
 	// Verify no intent remains on range descriptor key.
@@ -273,11 +272,10 @@ func TestRestoreReplicas(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	if err := firstRng.ChangeReplicas(proto.ADD_REPLICA,
-		proto.Replica{
-			NodeID:  mtc.stores[1].Ident.NodeID,
-			StoreID: mtc.stores[1].Ident.StoreID,
-		}); err != nil {
+	if err := firstRng.ChangeReplicas(proto.ADD_REPLICA, proto.Replica{
+		NodeID:  mtc.stores[1].Ident.NodeID,
+		StoreID: mtc.stores[1].Ident.StoreID,
+	}); err != nil {
 		t.Fatal(err)
 	}
 
@@ -366,12 +364,10 @@ func TestFailedReplicaChange(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	err = rng.ChangeReplicas(proto.ADD_REPLICA,
-		proto.Replica{
-			NodeID:  mtc.stores[1].Ident.NodeID,
-			StoreID: mtc.stores[1].Ident.StoreID,
-		})
-	if err == nil || !strings.Contains(err.Error(), "boom") {
+	if err := rng.ChangeReplicas(proto.ADD_REPLICA, proto.Replica{
+		NodeID:  mtc.stores[1].Ident.NodeID,
+		StoreID: mtc.stores[1].Ident.StoreID,
+	}); !testutils.IsError(err, "boom") {
 		t.Fatalf("did not get expected error: %s", err)
 	}
 
@@ -385,12 +381,10 @@ func TestFailedReplicaChange(t *testing.T) {
 	// can succeed.
 	runFilter.Store(false)
 
-	err = rng.ChangeReplicas(proto.ADD_REPLICA,
-		proto.Replica{
-			NodeID:  mtc.stores[1].Ident.NodeID,
-			StoreID: mtc.stores[1].Ident.StoreID,
-		})
-	if err != nil {
+	if err := rng.ChangeReplicas(proto.ADD_REPLICA, proto.Replica{
+		NodeID:  mtc.stores[1].Ident.NodeID,
+		StoreID: mtc.stores[1].Ident.StoreID,
+	}); err != nil {
 		t.Fatal(err)
 	}
 
@@ -450,11 +444,10 @@ func TestReplicateAfterTruncation(t *testing.T) {
 	mvcc := rng.GetMVCCStats()
 
 	// Now add the second replica.
-	if err := rng.ChangeReplicas(proto.ADD_REPLICA,
-		proto.Replica{
-			NodeID:  mtc.stores[1].Ident.NodeID,
-			StoreID: mtc.stores[1].Ident.StoreID,
-		}); err != nil {
+	if err := rng.ChangeReplicas(proto.ADD_REPLICA, proto.Replica{
+		NodeID:  mtc.stores[1].Ident.NodeID,
+		StoreID: mtc.stores[1].Ident.StoreID,
+	}); err != nil {
 		t.Fatal(err)
 	}
 

--- a/storage/client_range_test.go
+++ b/storage/client_range_test.go
@@ -216,8 +216,7 @@ func TestTxnPutOutOfOrder(t *testing.T) {
 
 	// Put an initial value.
 	initVal := []byte("initVal")
-	err := store.DB().Put(key, initVal)
-	if err != nil {
+	if err := store.DB().Put(key, initVal); err != nil {
 		t.Fatalf("failed to put: %s", err)
 	}
 
@@ -292,8 +291,8 @@ func TestTxnPutOutOfOrder(t *testing.T) {
 		UserPriority: &priority,
 		Timestamp:    clock.Now(),
 	}
-	_, err = store.ExecuteCmd(context.Background(), &proto.GetRequest{RequestHeader: requestHeader})
-	if err != nil {
+
+	if _, err := store.ExecuteCmd(context.Background(), &proto.GetRequest{RequestHeader: requestHeader}); err != nil {
 		t.Fatalf("failed to get: %s", err)
 	}
 
@@ -308,8 +307,8 @@ func TestTxnPutOutOfOrder(t *testing.T) {
 	manualClock.Increment(100)
 
 	requestHeader.Timestamp = clock.Now()
-	_, err = store.ExecuteCmd(context.Background(), &proto.GetRequest{RequestHeader: requestHeader})
-	if err == nil {
+
+	if _, err := store.ExecuteCmd(context.Background(), &proto.GetRequest{RequestHeader: requestHeader}); err == nil {
 		t.Fatal("unexpected success of get")
 	}
 

--- a/storage/client_split_test.go
+++ b/storage/client_split_test.go
@@ -99,20 +99,19 @@ func TestStoreRangeSplitBetweenConfigPrefix(t *testing.T) {
 	key := keys.MakeKey(keys.SystemPrefix, []byte("tsd"))
 
 	args := adminSplitArgs(proto.KeyMin, key, 1, store.StoreID())
-	_, err := store.ExecuteCmd(context.Background(), &args)
-	if err != nil {
+	if _, err := store.ExecuteCmd(context.Background(), &args); err != nil {
 		t.Fatalf("%q: split unexpected error: %s", key, err)
 	}
 
 	// Update configs to trigger gossip in both of the ranges.
 	acctConfig := &proto.AcctConfig{}
 	key = keys.MakeKey(keys.ConfigAccountingPrefix, proto.KeyMin)
-	if err = store.DB().Put(key, acctConfig); err != nil {
+	if err := store.DB().Put(key, acctConfig); err != nil {
 		t.Fatal(err)
 	}
 	zoneConfig := &proto.ZoneConfig{}
 	key = keys.MakeKey(keys.ConfigZonePrefix, proto.KeyMin)
-	if err = store.DB().Put(key, zoneConfig); err != nil {
+	if err := store.DB().Put(key, zoneConfig); err != nil {
 		t.Fatal(err)
 	}
 }

--- a/storage/engine/merge_test.go
+++ b/storage/engine/merge_test.go
@@ -262,7 +262,7 @@ func TestGoMerge(t *testing.T) {
 		// operates directly on marshalled bytes.
 		result, err := goMerge(c.existing, c.update)
 		if err != nil {
-			t.Errorf("goMerge error on case %d: %s", i, err.Error())
+			t.Errorf("goMerge error on case %d: %s", i, err)
 			continue
 		}
 		resultTS := unmarshalTimeSeries(t, result)
@@ -277,7 +277,7 @@ func TestGoMerge(t *testing.T) {
 			resultTS, err = MergeInternalTimeSeriesData(existingTS, updateTS)
 		}
 		if err != nil {
-			t.Errorf("MergeInternalTimeSeriesData error on case %d: %s", i, err.Error())
+			t.Errorf("MergeInternalTimeSeriesData error on case %d: %s", i, err)
 			continue
 		}
 		if a, e := resultTS, expectedTS; !reflect.DeepEqual(a, e) {
@@ -296,11 +296,11 @@ func unmarshalTimeSeries(t testing.TB, b []byte) *proto.InternalTimeSeriesData {
 	}
 	var mvccValue MVCCMetadata
 	if err := gogoproto.Unmarshal(b, &mvccValue); err != nil {
-		t.Fatalf("error unmarshalling time series in text: %s", err.Error())
+		t.Fatalf("error unmarshalling time series in text: %s", err)
 	}
 	valueTS, err := proto.InternalTimeSeriesDataFromValue(mvccValue.Value)
 	if err != nil {
-		t.Fatalf("error unmarshalling time series in text: %s", err.Error())
+		t.Fatalf("error unmarshalling time series in text: %s", err)
 	}
 	return valueTS
 }

--- a/storage/engine/mvcc.go
+++ b/storage/engine/mvcc.go
@@ -895,7 +895,7 @@ func MVCCMerge(engine Engine, ms *MVCCStats, key proto.Key, value proto.Value) e
 	if err != nil {
 		return err
 	}
-	if err = engine.Merge(metaKey, data); err != nil {
+	if err := engine.Merge(metaKey, data); err != nil {
 		return err
 	}
 	updateStatsOnMerge(ms, key, int64(len(value.Bytes)))
@@ -915,8 +915,7 @@ func MVCCDeleteRange(engine Engine, ms *MVCCStats, key, endKey proto.Key, max in
 
 	num := int64(0)
 	for _, kv := range kvs {
-		err = MVCCDelete(engine, ms, kv.Key, timestamp, txn)
-		if err != nil {
+		if err := MVCCDelete(engine, ms, kv.Key, timestamp, txn); err != nil {
 			return num, err
 		}
 		num++
@@ -1070,8 +1069,8 @@ func MVCCResolveWriteIntent(engine Engine, ms *MVCCStats, key proto.Key, timesta
 	}
 
 	metaKey := MVCCEncodeKey(key)
-	meta := &MVCCMetadata{}
-	ok, origMetaKeySize, origMetaValSize, err := engine.GetProto(metaKey, meta)
+	var meta MVCCMetadata
+	ok, origMetaKeySize, origMetaValSize, err := engine.GetProto(metaKey, &meta)
 	if err != nil {
 		return err
 	}
@@ -1092,7 +1091,7 @@ func MVCCResolveWriteIntent(engine Engine, ms *MVCCStats, key proto.Key, timesta
 	pushed := txn.Status == proto.PENDING && meta.Txn.Timestamp.Less(txn.Timestamp)
 	if (commit || pushed) && meta.Txn.Epoch == txn.Epoch {
 		origTimestamp := meta.Timestamp
-		newMeta := *meta
+		newMeta := meta
 		newMeta.Timestamp = txn.Timestamp
 		if pushed { // keep intent if we're pushing timestamp
 			newMeta.Txn = txn
@@ -1118,10 +1117,10 @@ func MVCCResolveWriteIntent(engine Engine, ms *MVCCStats, key proto.Key, timesta
 			if err != nil {
 				return err
 			}
-			if err = engine.Clear(origKey); err != nil {
+			if err := engine.Clear(origKey); err != nil {
 				return err
 			}
-			if err = engine.Put(newKey, valBytes); err != nil {
+			if err := engine.Put(newKey, valBytes); err != nil {
 				return err
 			}
 		}
@@ -1156,38 +1155,37 @@ func MVCCResolveWriteIntent(engine Engine, ms *MVCCStats, key proto.Key, timesta
 	}
 	// If there is no other version, we should just clean up the key entirely.
 	if len(kvs) == 0 {
-		if err = engine.Clear(metaKey); err != nil {
+		if err := engine.Clear(metaKey); err != nil {
 			return err
 		}
 		// Clear stat counters attributable to the intent we're aborting.
-		updateStatsOnAbort(ms, key, origMetaKeySize, origMetaValSize, 0, 0, meta, nil, origAgeSeconds, 0)
+		updateStatsOnAbort(ms, key, origMetaKeySize, origMetaValSize, 0, 0, &meta, nil, origAgeSeconds, 0)
 	} else {
 		_, ts, isValue := MVCCDecodeKey(kvs[0].Key)
 		if !isValue {
 			return util.Errorf("expected an MVCC value key: %s", kvs[0].Key)
 		}
 		// Get the bytes for the next version so we have size for stat counts.
-		value := MVCCValue{}
-		var valueSize int64
-		ok, _, valueSize, err = engine.GetProto(kvs[0].Key, &value)
+		var value MVCCValue
+		ok, _, valueSize, err := engine.GetProto(kvs[0].Key, &value)
 		if err != nil || !ok {
 			return util.Errorf("unable to fetch previous version for key %q (%t): %s", kvs[0].Key, ok, err)
 		}
 		// Update the keyMetadata with the next version.
-		newMeta := &MVCCMetadata{
+		newMeta := MVCCMetadata{
 			Timestamp: ts,
 			Deleted:   value.Deleted,
 			KeyBytes:  mvccVersionTimestampSize,
 			ValBytes:  valueSize,
 		}
-		metaKeySize, metaValSize, err := PutProto(engine, metaKey, newMeta)
+		metaKeySize, metaValSize, err := PutProto(engine, metaKey, &newMeta)
 		if err != nil {
 			return err
 		}
 		restoredAgeSeconds := timestamp.WallTime/1E9 - ts.WallTime/1E9
 
 		// Update stat counters with older version.
-		updateStatsOnAbort(ms, key, origMetaKeySize, origMetaValSize, metaKeySize, metaValSize, meta, newMeta, origAgeSeconds, restoredAgeSeconds)
+		updateStatsOnAbort(ms, key, origMetaKeySize, origMetaValSize, metaKeySize, metaValSize, &meta, &newMeta, origAgeSeconds, restoredAgeSeconds)
 	}
 
 	return nil
@@ -1221,8 +1219,7 @@ func MVCCResolveWriteIntentRange(engine Engine, ms *MVCCStats, key, endKey proto
 		if isValue {
 			return 0, util.Errorf("expected an MVCC metadata key: %s", kvs[0].Key)
 		}
-		err = MVCCResolveWriteIntent(engine, ms, currentKey, timestamp, txn)
-		if err != nil {
+		if err := MVCCResolveWriteIntent(engine, ms, currentKey, timestamp, txn); err != nil {
 			log.Warningf("failed to resolve intent for key %q: %v", currentKey, err)
 		} else {
 			num++

--- a/storage/engine/mvcc_test.go
+++ b/storage/engine/mvcc_test.go
@@ -31,6 +31,7 @@ import (
 
 	"github.com/cockroachdb/cockroach/keys"
 	"github.com/cockroachdb/cockroach/proto"
+	"github.com/cockroachdb/cockroach/testutils"
 	"github.com/cockroachdb/cockroach/util/hlc"
 	"github.com/cockroachdb/cockroach/util/leaktest"
 	"github.com/cockroachdb/cockroach/util/log"
@@ -155,8 +156,7 @@ func TestMVCCPutWithTxn(t *testing.T) {
 	engine := createTestEngine()
 	defer engine.Close()
 
-	err := MVCCPut(engine, nil, testKey1, makeTS(0, 1), value1, txn1)
-	if err != nil {
+	if err := MVCCPut(engine, nil, testKey1, makeTS(0, 1), value1, txn1); err != nil {
 		t.Fatal(err)
 	}
 
@@ -177,8 +177,7 @@ func TestMVCCPutWithoutTxn(t *testing.T) {
 	engine := createTestEngine()
 	defer engine.Close()
 
-	err := MVCCPut(engine, nil, testKey1, makeTS(0, 1), value1, nil)
-	if err != nil {
+	if err := MVCCPut(engine, nil, testKey1, makeTS(0, 1), value1, nil); err != nil {
 		t.Fatal(err)
 	}
 
@@ -447,11 +446,9 @@ func TestMVCCGetUncertainty(t *testing.T) {
 		t.Fatal(err)
 	}
 	// Read with transaction, should get a value back.
-	val, _, err := MVCCGet(engine, testKey1, makeTS(7, 0), true, txn)
-	if err != nil {
+	if val, _, err := MVCCGet(engine, testKey1, makeTS(7, 0), true, txn); err != nil {
 		t.Fatal(err)
-	}
-	if val == nil || !bytes.Equal(val.Bytes, value1.Bytes) {
+	} else if val == nil || !bytes.Equal(val.Bytes, value1.Bytes) {
 		t.Fatalf("wanted %q, got %v", value1.Bytes, val)
 	}
 
@@ -723,12 +720,10 @@ func TestMVCCGetInconsistent(t *testing.T) {
 	defer engine.Close()
 
 	// Put two values to key 1, the latest with a txn.
-	err := MVCCPut(engine, nil, testKey1, makeTS(1, 0), value1, nil)
-	if err != nil {
+	if err := MVCCPut(engine, nil, testKey1, makeTS(1, 0), value1, nil); err != nil {
 		t.Fatal(err)
 	}
-	err = MVCCPut(engine, nil, testKey1, makeTS(2, 0), value2, txn1)
-	if err != nil {
+	if err := MVCCPut(engine, nil, testKey1, makeTS(2, 0), value2, txn1); err != nil {
 		t.Fatal(err)
 	}
 
@@ -755,8 +750,7 @@ func TestMVCCGetInconsistent(t *testing.T) {
 	}
 
 	// Write a single intent for key 2 and verify get returns empty.
-	err = MVCCPut(engine, nil, testKey2, makeTS(2, 0), value1, txn2)
-	if err != nil {
+	if err := MVCCPut(engine, nil, testKey2, makeTS(2, 0), value1, txn2); err != nil {
 		t.Fatal(err)
 	}
 	val, intents, err := MVCCGet(engine, testKey2, makeTS(2, 0), false, nil)
@@ -804,15 +798,9 @@ func TestMVCCGetProtoInconsistent(t *testing.T) {
 	// Inconsistent get will fetch value1 for any timestamp.
 	for _, ts := range []proto.Timestamp{makeTS(1, 0), makeTS(2, 0)} {
 		val.Reset()
-		found, err := MVCCGetProto(engine, testKey1, ts, false, nil, val)
-		if ts.Less(makeTS(2, 0)) {
-			if err != nil {
-				t.Fatal(err)
-			}
-		} else if err != nil {
+		if found, err := MVCCGetProto(engine, testKey1, ts, false, nil, val); err != nil {
 			t.Fatal(err)
-		}
-		if !found {
+		} else if !found {
 			t.Errorf("expected to find result with inconsistent read")
 		}
 		if !bytes.Equal(val.Value, []byte("value1")) {
@@ -824,11 +812,9 @@ func TestMVCCGetProtoInconsistent(t *testing.T) {
 	if err := MVCCPut(engine, nil, testKey2, makeTS(2, 0), proto.Value{Bytes: value1}, txn2); err != nil {
 		t.Fatal(err)
 	}
-	found, err := MVCCGetProto(engine, testKey2, makeTS(2, 0), false, nil, val)
-	if err != nil {
+	if found, err := MVCCGetProto(engine, testKey2, makeTS(2, 0), false, nil, val); err != nil {
 		t.Fatal(err)
-	}
-	if found {
+	} else if found {
 		t.Errorf("expected no result; got %+v", val)
 	}
 
@@ -842,14 +828,10 @@ func TestMVCCGetProtoInconsistent(t *testing.T) {
 		t.Fatal(err)
 	}
 	val.Reset()
-	found, err = MVCCGetProto(engine, testKey3, makeTS(1, 0), false, nil, val)
-	if err == nil {
-		t.Errorf("expected error reading malformed data")
-	} else if !strings.Contains(err.Error(), "unexpected EOF") {
-		t.Errorf("expected EOF error, got %s", err)
-	}
-	if !found {
+	if found, err := MVCCGetProto(engine, testKey3, makeTS(1, 0), false, nil, val); !found {
 		t.Errorf("expected to find result with malformed data")
+	} else if !testutils.IsError(err, "unexpected EOF") {
+		t.Errorf("expected EOF error, got %s", err)
 	}
 }
 
@@ -1558,7 +1540,7 @@ func TestMVCCResolveWithUpdatedTimestamp(t *testing.T) {
 
 	// Resolve with a higher commit timestamp -- this should rewrite the
 	// intent when making it permanent.
-	if err = MVCCResolveWriteIntent(engine, nil, testKey1, makeTS(1, 0), makeTxn(txn1Commit, makeTS(1, 0))); err != nil {
+	if err := MVCCResolveWriteIntent(engine, nil, testKey1, makeTS(1, 0), makeTxn(txn1Commit, makeTS(1, 0))); err != nil {
 		t.Fatal(err)
 	}
 
@@ -1598,7 +1580,7 @@ func TestMVCCResolveWithPushedTimestamp(t *testing.T) {
 
 	// Resolve with a higher commit timestamp, but with still-pending transaction.
 	// This represents a straightforward push (i.e. from a read/write conflict).
-	if err = MVCCResolveWriteIntent(engine, nil, testKey1, makeTS(1, 0), makeTxn(txn1, makeTS(1, 0))); err != nil {
+	if err := MVCCResolveWriteIntent(engine, nil, testKey1, makeTS(1, 0), makeTxn(txn1, makeTS(1, 0))); err != nil {
 		t.Fatal(err)
 	}
 

--- a/storage/gc_queue.go
+++ b/storage/gc_queue.go
@@ -314,7 +314,7 @@ func (gcq *gcQueue) lookupGCPolicy(rng *Range) (proto.GCPolicy, error) {
 	// This could be the case if the zone config is new and the range
 	// hasn't been split yet along the new boundary.
 	var gc *proto.GCPolicy
-	if err = configMap.VisitPrefixesHierarchically(rng.Desc().StartKey, func(start, end proto.Key, config interface{}) (bool, error) {
+	if err := configMap.VisitPrefixesHierarchically(rng.Desc().StartKey, func(start, end proto.Key, config interface{}) (bool, error) {
 		zone := config.(*proto.ZoneConfig)
 		if zone.GC != nil {
 			rng.RLock()

--- a/storage/id_alloc_test.go
+++ b/storage/id_alloc_test.go
@@ -20,7 +20,6 @@ package storage
 import (
 	"log"
 	"sort"
-	"strings"
 	"sync"
 	"testing"
 	"time"
@@ -28,6 +27,7 @@ import (
 	"github.com/cockroachdb/cockroach/keys"
 	"github.com/cockroachdb/cockroach/proto"
 	"github.com/cockroachdb/cockroach/storage/engine"
+	"github.com/cockroachdb/cockroach/testutils"
 	"github.com/cockroachdb/cockroach/util/leaktest"
 )
 
@@ -142,11 +142,9 @@ func TestAllocateErrorAndRecovery(t *testing.T) {
 		t.Errorf("failed to create IDAllocator: %v", err)
 	}
 
-	firstID, err := idAlloc.Allocate()
-	if err != nil {
+	if firstID, err := idAlloc.Allocate(); err != nil {
 		t.Fatal(err)
-	}
-	if firstID != 2 {
+	} else if firstID != 2 {
 		t.Errorf("expected ID is 2, but got: %d", firstID)
 	}
 
@@ -228,9 +226,7 @@ func TestAllocateWithStopper(t *testing.T) {
 
 	stopper.Stop()
 
-	if _, err := idAlloc.Allocate(); err == nil {
-		t.Errorf("unexpected success")
-	} else if !strings.Contains(err.Error(), "system is draining") {
+	if _, err := idAlloc.Allocate(); !testutils.IsError(err, "system is draining") {
 		t.Errorf("unexpected error: %s", err)
 	}
 }

--- a/storage/range_raftstorage.go
+++ b/storage/range_raftstorage.go
@@ -110,16 +110,14 @@ func (r *Range) Entries(lo, hi, maxBytes uint64) ([]raftpb.Entry, error) {
 // Term implements the raft.Storage interface.
 func (r *Range) Term(i uint64) (uint64, error) {
 	ents, err := r.Entries(i, i+1, 0)
-	if err == raft.ErrUnavailable {
-		ts, err := r.raftTruncatedState()
-		if err != nil {
-			return 0, err
+	if err != nil {
+		if err == raft.ErrUnavailable {
+			if ts, err := r.raftTruncatedState(); err != nil {
+				return 0, err
+			} else if i == ts.Index {
+				return ts.Term, nil
+			}
 		}
-		if i == ts.Index {
-			return ts.Term, nil
-		}
-		return 0, raft.ErrUnavailable
-	} else if err != nil {
 		return 0, err
 	}
 	if len(ents) == 0 {

--- a/storage/range_test.go
+++ b/storage/range_test.go
@@ -393,7 +393,6 @@ func TestRangeRangeBoundsChecking(t *testing.T) {
 	gArgs := getArgs(proto.Key("b"), 1, tc.store.StoreID())
 
 	_, err := tc.rng.AddCmd(tc.rng.context(), &gArgs)
-
 	if _, ok := err.(*proto.RangeKeyMismatchError); !ok {
 		t.Errorf("expected range key mismatch error: %s", err)
 	}
@@ -481,7 +480,6 @@ func TestRangeNotLeaderError(t *testing.T) {
 
 	for i, test := range testCases {
 		_, err := tc.rng.AddCmd(tc.rng.context(), test)
-
 		if _, ok := err.(*proto.NotLeaderError); !ok {
 			t.Errorf("%d: expected not leader error: %s", i, err)
 		}
@@ -1060,9 +1058,7 @@ func TestRangeUpdateTSCache(t *testing.T) {
 	gArgs := getArgs([]byte("a"), 1, tc.store.StoreID())
 	gArgs.Timestamp = tc.clock.Now()
 
-	_, err := tc.rng.AddCmd(tc.rng.context(), &gArgs)
-
-	if err != nil {
+	if _, err := tc.rng.AddCmd(tc.rng.context(), &gArgs); err != nil {
 		t.Error(err)
 	}
 	// Set clock to time 2s for write.
@@ -1071,9 +1067,7 @@ func TestRangeUpdateTSCache(t *testing.T) {
 	pArgs := putArgs([]byte("b"), []byte("1"), 1, tc.store.StoreID())
 	pArgs.Timestamp = tc.clock.Now()
 
-	_, err = tc.rng.AddCmd(tc.rng.context(), &pArgs)
-
-	if err != nil {
+	if _, err := tc.rng.AddCmd(tc.rng.context(), &pArgs); err != nil {
 		t.Error(err)
 	}
 	// Verify the timestamp cache has rTS=1s and wTS=0s for "a".
@@ -1137,9 +1131,7 @@ func TestRangeCommandQueue(t *testing.T) {
 			args := readOrWriteArgs(key1, test.cmd1Read, tc.rng.Desc().RaftID, tc.store.StoreID())
 			args.Header().User = "Foo"
 
-			_, err := tc.rng.AddCmd(tc.rng.context(), args)
-
-			if err != nil {
+			if _, err := tc.rng.AddCmd(tc.rng.context(), args); err != nil {
 				t.Fatalf("test %d: %s", i, err)
 			}
 			close(cmd1Done)
@@ -1152,9 +1144,7 @@ func TestRangeCommandQueue(t *testing.T) {
 		go func() {
 			args := readOrWriteArgs(key1, test.cmd2Read, tc.rng.Desc().RaftID, tc.store.StoreID())
 
-			_, err := tc.rng.AddCmd(tc.rng.context(), args)
-
-			if err != nil {
+			if _, err := tc.rng.AddCmd(tc.rng.context(), args); err != nil {
 				t.Fatalf("test %d: %s", i, err)
 			}
 			close(cmd2Done)
@@ -1165,9 +1155,7 @@ func TestRangeCommandQueue(t *testing.T) {
 		go func() {
 			args := readOrWriteArgs(key2, true, tc.rng.Desc().RaftID, tc.store.StoreID())
 
-			_, err := tc.rng.AddCmd(tc.rng.context(), args)
-
-			if err != nil {
+			if _, err := tc.rng.AddCmd(tc.rng.context(), args); err != nil {
 				t.Fatalf("test %d: %s", i, err)
 			}
 			close(cmd3Done)
@@ -1232,9 +1220,7 @@ func TestRangeCommandQueueInconsistent(t *testing.T) {
 		args := putArgs(key, []byte("value"), tc.rng.Desc().RaftID, tc.store.StoreID())
 		args.CmdID.Random = 1
 
-		_, err := tc.rng.AddCmd(tc.rng.context(), &args)
-
-		if err != nil {
+		if _, err := tc.rng.AddCmd(tc.rng.context(), &args); err != nil {
 			t.Fatal(err)
 		}
 		close(cmd1Done)
@@ -1248,9 +1234,7 @@ func TestRangeCommandQueueInconsistent(t *testing.T) {
 		args := getArgs(key, tc.rng.Desc().RaftID, tc.store.StoreID())
 		args.ReadConsistency = proto.INCONSISTENT
 
-		_, err := tc.rng.AddCmd(tc.rng.context(), &args)
-
-		if err != nil {
+		if _, err := tc.rng.AddCmd(tc.rng.context(), &args); err != nil {
 			t.Fatal(err)
 		}
 		close(cmd2Done)
@@ -1287,9 +1271,7 @@ func TestRangeUseTSCache(t *testing.T) {
 	args := getArgs([]byte("a"), 1, tc.store.StoreID())
 	args.Timestamp = tc.clock.Now()
 
-	_, err := tc.rng.AddCmd(tc.rng.context(), &args)
-
-	if err != nil {
+	if _, err := tc.rng.AddCmd(tc.rng.context(), &args); err != nil {
 		t.Error(err)
 	}
 	pArgs := putArgs([]byte("a"), []byte("value"), 1, tc.store.StoreID())
@@ -1318,9 +1300,7 @@ func TestRangeNoTSCacheInconsistent(t *testing.T) {
 	args.Timestamp = tc.clock.Now()
 	args.ReadConsistency = proto.INCONSISTENT
 
-	_, err := tc.rng.AddCmd(tc.rng.context(), &args)
-
-	if err != nil {
+	if _, err := tc.rng.AddCmd(tc.rng.context(), &args); err != nil {
 		t.Error(err)
 	}
 	pArgs := putArgs([]byte("a"), []byte("value"), 1, tc.store.StoreID())
@@ -1405,12 +1385,9 @@ func TestRangeNoTimestampIncrementWithinTxn(t *testing.T) {
 	pArgs.Txn = txn
 	pArgs.Timestamp = pArgs.Txn.Timestamp
 
-	reply, err := tc.rng.AddCmd(tc.rng.context(), &pArgs)
-	if err != nil {
+	if reply, err := tc.rng.AddCmd(tc.rng.context(), &pArgs); err != nil {
 		t.Fatal(err)
-	}
-	pReply := reply.(*proto.PutResponse)
-	if !pReply.Timestamp.Equal(pArgs.Timestamp) {
+	} else if pReply := reply.(*proto.PutResponse); !pReply.Timestamp.Equal(pArgs.Timestamp) {
 		t.Errorf("expected timestamp to remain %s; got %s", pArgs.Timestamp, pReply.Timestamp)
 	}
 
@@ -1419,11 +1396,9 @@ func TestRangeNoTimestampIncrementWithinTxn(t *testing.T) {
 	expTS := pArgs.Timestamp
 	expTS.Logical++
 
-	if reply, err = tc.rng.AddCmd(tc.rng.context(), &pArgs); err == nil {
+	if reply, err := tc.rng.AddCmd(tc.rng.context(), &pArgs); err == nil {
 		t.Errorf("expected write intent error")
-	}
-	pReply = reply.(*proto.PutResponse)
-	if !pReply.Timestamp.Equal(expTS) {
+	} else if pReply := reply.(*proto.PutResponse); !pReply.Timestamp.Equal(expTS) {
 		t.Errorf("expected timestamp to increment to %s; got %s", expTS, pReply.Timestamp)
 	}
 }
@@ -1496,22 +1471,18 @@ func TestRangeResponseCacheReadError(t *testing.T) {
 	args := incrementArgs([]byte("a"), 1, 1, tc.store.StoreID())
 	args.CmdID = proto.ClientCmdID{WallTime: 1, Random: 1}
 
-	_, err := tc.rng.AddCmd(tc.rng.context(), &args)
-
-	if err != nil {
+	if _, err := tc.rng.AddCmd(tc.rng.context(), &args); err != nil {
 		t.Fatal(err)
 	}
 
 	// Overwrite repsonse cache entry with garbage for the last op.
 	key := keys.ResponseCacheKey(tc.rng.Desc().RaftID, &args.CmdID)
-	err = engine.MVCCPut(tc.engine, nil, key, proto.ZeroTimestamp, proto.Value{Bytes: []byte("\xff")}, nil)
-	if err != nil {
+	if err := engine.MVCCPut(tc.engine, nil, key, proto.ZeroTimestamp, proto.Value{Bytes: []byte("\xff")}, nil); err != nil {
 		t.Fatal(err)
 	}
 
 	// Now try increment again and verify error.
-	_, err = tc.rng.AddCmd(tc.rng.context(), &args)
-	if err == nil {
+	if _, err := tc.rng.AddCmd(tc.rng.context(), &args); err == nil {
 		t.Fatal(err)
 	}
 }
@@ -1533,8 +1504,7 @@ func TestRangeResponseCacheStoredError(t *testing.T) {
 
 	args := incrementArgs([]byte("a"), 1, 1, tc.store.StoreID())
 	args.CmdID = cmdID
-	_, err := tc.rng.AddCmd(tc.rng.context(), &args)
-	if err == nil {
+	if _, err := tc.rng.AddCmd(tc.rng.context(), &args); err == nil {
 		t.Fatal("expected to see cached error but got nil")
 	} else if ge, ok := err.(*proto.Error); !ok {
 		t.Fatalf("expected proto.Error but got %s", err)
@@ -1700,8 +1670,7 @@ func TestEndTransactionWithIncrementedEpoch(t *testing.T) {
 	hbArgs := heartbeatArgs(txn, 1, tc.store.StoreID())
 	hbArgs.Timestamp = txn.Timestamp
 
-	_, err := tc.rng.AddCmd(tc.rng.context(), &hbArgs)
-	if err != nil {
+	if _, err := tc.rng.AddCmd(tc.rng.context(), &hbArgs); err != nil {
 		t.Error(err)
 	}
 
@@ -2246,7 +2215,7 @@ func TestInternalMerge(t *testing.T) {
 		mergeArgs := internalMergeArgs(key, proto.Value{Bytes: []byte(str)}, 1, tc.store.StoreID())
 
 		if _, err := tc.rng.AddCmd(tc.rng.context(), &mergeArgs); err != nil {
-			t.Fatalf("unexpected error from InternalMerge: %s", err.Error())
+			t.Fatalf("unexpected error from InternalMerge: %s", err)
 		}
 	}
 
@@ -2396,7 +2365,7 @@ func TestConditionFailedError(t *testing.T) {
 
 	_, err := tc.rng.AddCmd(tc.rng.context(), &args)
 
-	if cErr, ok := err.(*proto.ConditionFailedError); err == nil || !ok {
+	if cErr, ok := err.(*proto.ConditionFailedError); !ok {
 		t.Fatalf("expected ConditionFailedError, got %T with content %+v",
 			err, err)
 	} else if v := cErr.ActualValue; v == nil || !bytes.Equal(v.Bytes, value) {
@@ -2473,23 +2442,19 @@ func TestReplicaCorruption(t *testing.T) {
 	defer tc.Stop()
 
 	args := putArgs(proto.Key("test"), []byte("value"), tc.rng.Desc().RaftID, tc.store.StoreID())
-	_, err := tc.rng.AddCmd(tc.rng.context(), &args)
-	if err != nil {
+	if _, err := tc.rng.AddCmd(tc.rng.context(), &args); err != nil {
 		t.Fatal(err)
 	}
 	// Set the stored applied index sky high.
 	newIndex := 2*atomic.LoadUint64(&tc.rng.appliedIndex) + 1
 	atomic.StoreUint64(&tc.rng.appliedIndex, newIndex)
 	// Not really needed, but let's be thorough.
-	err = setAppliedIndex(tc.rng.rm.Engine(), tc.rng.Desc().RaftID, newIndex)
-	if err != nil {
+	if err := setAppliedIndex(tc.rng.rm.Engine(), tc.rng.Desc().RaftID, newIndex); err != nil {
 		t.Fatal(err)
 	}
 	// Should mark replica corrupt (and panic as a result) since we messed
 	// with the applied index.
-	_, err = tc.rng.AddCmd(tc.rng.context(), &args)
-
-	if err == nil || !strings.Contains(err.Error(), "replica corruption (processed=true)") {
+	if _, err := tc.rng.AddCmd(tc.rng.context(), &args); testutils.IsError(err, "replica corruption (processed=true)") {
 		t.Fatalf("unexpected error: %s", err)
 	}
 }
@@ -2537,12 +2502,11 @@ func TestRangeDanglingMetaIntent(t *testing.T) {
 	}
 
 	var rlReply *proto.InternalRangeLookupResponse
-
-	reply, err := tc.rng.AddCmd(tc.rng.context(), rlArgs)
-	if err != nil {
+	if reply, err := tc.rng.AddCmd(tc.rng.context(), rlArgs); err == nil {
+		rlReply = reply.(*proto.InternalRangeLookupResponse)
+	} else {
 		t.Fatal(err)
 	}
-	rlReply = reply.(*proto.InternalRangeLookupResponse)
 
 	origDesc := rlReply.Ranges[0]
 	newDesc := origDesc
@@ -2566,27 +2530,28 @@ func TestRangeDanglingMetaIntent(t *testing.T) {
 	rlArgs.Key = keys.RangeMetaKey(proto.Key("A"))
 	rlArgs.Timestamp = proto.ZeroTimestamp
 
-	reply, err = tc.rng.AddCmd(tc.rng.context(), rlArgs)
-	if err != nil {
+	if reply, err := tc.rng.AddCmd(tc.rng.context(), rlArgs); err != nil {
 		t.Errorf("unexpected lookup error: %s", err)
-	}
-	rlReply = reply.(*proto.InternalRangeLookupResponse)
-	if !reflect.DeepEqual(rlReply.Ranges[0], origDesc) {
-		t.Errorf("expected original descriptor %s; got %s", &origDesc, &rlReply.Ranges[0])
+	} else {
+		rlReply := reply.(*proto.InternalRangeLookupResponse)
+		if !reflect.DeepEqual(rlReply.Ranges[0], origDesc) {
+			t.Errorf("expected original descriptor %s; got %s", &origDesc, &rlReply.Ranges[0])
+		}
 	}
 
 	// Switch to consistent lookups, which should run into the intent.
 	rlArgs.ReadConsistency = proto.CONSISTENT
-	_, err = tc.rng.AddCmd(tc.rng.context(), rlArgs)
-	if _, ok := err.(*proto.WriteIntentError); !ok {
-		t.Fatalf("expected WriteIntentError, not %s", err)
+	{
+		_, err := tc.rng.AddCmd(tc.rng.context(), rlArgs)
+		if _, ok := err.(*proto.WriteIntentError); !ok {
+			t.Fatalf("expected WriteIntentError, not %s", err)
+		}
 	}
 
 	// Try 100 lookups with IgnoreIntents. Expect to see each descriptor at least once.
 	// First, try this consistently, which should not be allowed.
 	rlArgs.IgnoreIntents = true
-	_, err = tc.rng.AddCmd(tc.rng.context(), rlArgs)
-	if !testutils.IsError(err, "can not read consistently and skip intents") {
+	if _, err := tc.rng.AddCmd(tc.rng.context(), rlArgs); !testutils.IsError(err, "can not read consistently and skip intents") {
 		t.Fatalf("wanted specific error, not %s", err)
 	}
 	// After changing back to inconsistent lookups, should be good to go.
@@ -2599,12 +2564,13 @@ func TestRangeDanglingMetaIntent(t *testing.T) {
 		clonedRLArgs := gogoproto.Clone(rlArgs).(*proto.InternalRangeLookupRequest)
 		clonedRLArgs.Timestamp = proto.ZeroTimestamp
 
-		reply, err = tc.rng.AddCmd(tc.rng.context(), clonedRLArgs)
-		if err != nil {
+		var seen proto.RangeDescriptor
+		if reply, err := tc.rng.AddCmd(tc.rng.context(), clonedRLArgs); err == nil {
+			seen = reply.(*proto.InternalRangeLookupResponse).Ranges[0]
+		} else {
 			t.Fatal(err)
 		}
-		rlReply = reply.(*proto.InternalRangeLookupResponse)
-		seen := rlReply.Ranges[0]
+
 		if reflect.DeepEqual(seen, origDesc) {
 			origSeen = true
 		} else if reflect.DeepEqual(seen, newDesc) {
@@ -2677,9 +2643,7 @@ func benchmarkEvents(b *testing.B, sendEvents, consumeEvents bool) {
 	args := incrementArgs([]byte("a"), 1, 1, tc.store.StoreID())
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
-		_, err := tc.rng.AddCmd(tc.rng.context(), &args)
-
-		if err != nil {
+		if _, err := tc.rng.AddCmd(tc.rng.context(), &args); err != nil {
 			b.Fatal(err)
 		}
 	}

--- a/storage/replicate_queue.go
+++ b/storage/replicate_queue.go
@@ -112,7 +112,7 @@ func (rq *replicateQueue) process(now proto.Timestamp, rng *Range) error {
 		NodeID:  newReplica.Node.NodeID,
 		StoreID: newReplica.StoreID,
 	}
-	if err = rng.ChangeReplicas(proto.ADD_REPLICA, replica); err != nil {
+	if err := rng.ChangeReplicas(proto.ADD_REPLICA, replica); err != nil {
 		return err
 	}
 

--- a/storage/split_queue.go
+++ b/storage/split_queue.go
@@ -103,7 +103,7 @@ func (sq *splitQueue) process(now proto.Timestamp, rng *Range) error {
 	// FIXME: why is this implementation not the same as the one above?
 	if float64(rng.stats.GetSize())/float64(zone.RangeMaxBytes) > 1 {
 		log.Infof("splitting %s size=%d max=%d", rng, rng.stats.GetSize(), zone.RangeMaxBytes)
-		if _, err = rng.AddCmd(rng.context(), &proto.AdminSplitRequest{
+		if _, err := rng.AddCmd(rng.context(), &proto.AdminSplitRequest{
 			RequestHeader: proto.RequestHeader{Key: rng.Desc().StartKey},
 		}); err != nil {
 			return err

--- a/storage/store.go
+++ b/storage/store.go
@@ -456,7 +456,7 @@ func (s *Store) Start(stopper *stop.Stopper) error {
 	start := keys.RangeDescriptorKey(proto.KeyMin)
 	end := keys.RangeDescriptorKey(proto.KeyMax)
 
-	if s.multiraft, err = multiraft.NewMultiRaft(s.RaftNodeID(), &multiraft.Config{
+	if mr, err := multiraft.NewMultiRaft(s.RaftNodeID(), &multiraft.Config{
 		Transport:              s.ctx.Transport,
 		Storage:                s,
 		StateMachine:           s,
@@ -468,7 +468,9 @@ func (s *Store) Start(stopper *stop.Stopper) error {
 		// unbuffered. Temporarily give it some breathing room until the underlying
 		// deadlock is fixed. See #1185, #1193.
 		EventBufferSize: 1000,
-	}, s.stopper); err != nil {
+	}, s.stopper); err == nil {
+		s.multiraft = mr
+	} else {
 		return err
 	}
 
@@ -775,17 +777,14 @@ func (s *Store) Bootstrap(ident proto.StoreIdent, stopper *stop.Stopper) error {
 		return util.Errorf("store %s: unable to access: %s", s.engine, err)
 	} else if len(kvs) > 0 {
 		// See if this is an already-bootstrapped store.
-		ok, err := engine.MVCCGetProto(s.engine, keys.StoreIdentKey(), proto.ZeroTimestamp, true, nil, &s.Ident)
-		if err != nil {
+		if ok, err := engine.MVCCGetProto(s.engine, keys.StoreIdentKey(), proto.ZeroTimestamp, true, nil, &s.Ident); err != nil {
 			return util.Errorf("store %s is non-empty but cluster ID could not be determined: %s", s.engine, err)
-		}
-		if ok {
+		} else if ok {
 			return util.Errorf("store %s already belongs to cockroach cluster %s", s.engine, s.Ident.ClusterID)
 		}
 		return util.Errorf("store %s is not-empty and has invalid contents (first key: %q)", s.engine, kvs[0].Key)
 	}
-	err = engine.MVCCPutProto(s.engine, nil, keys.StoreIdentKey(), proto.ZeroTimestamp, nil, &s.Ident)
-	return err
+	return engine.MVCCPutProto(s.engine, nil, keys.StoreIdentKey(), proto.ZeroTimestamp, nil, &s.Ident)
 }
 
 // GetRange fetches a range by Raft ID. Returns an error if no range is found.
@@ -1049,7 +1048,7 @@ func (s *Store) MergeRange(subsumingRng *Range, updatedEndKey proto.Key, subsume
 	}
 
 	// Remove and destroy the subsumed range.
-	if err = s.RemoveRange(subsumedRng); err != nil {
+	if err := s.RemoveRange(subsumedRng); err != nil {
 		return util.Errorf("cannot remove range %s", err)
 	}
 
@@ -1535,18 +1534,17 @@ func (s *Store) GroupStorage(groupID proto.RaftID) multiraft.WriteableGroupStora
 	r, ok := s.ranges[groupID]
 	if !ok {
 		var err error
-		r, err = NewRange(&proto.RangeDescriptor{
+		if r, err = NewRange(&proto.RangeDescriptor{
 			RaftID: groupID,
 			// TODO(bdarnell): other fields are unknown; need to populate them from
 			// snapshot.
-		}, s)
-		if err != nil {
+		}, s); err != nil {
 			panic(err) // TODO(bdarnell)
 		}
 		// Add the range to range map, but not rangesByKey since
 		// the range's start key is unknown. The range will be
 		// added to rangesByKey later when a snapshot is applied.
-		if err = s.addRangeToRangeMap(r); err != nil {
+		if err := s.addRangeToRangeMap(r); err != nil {
 			panic(err) // TODO(bdarnell)
 		}
 		s.uninitRanges[r.Desc().RaftID] = r

--- a/storage/store_test.go
+++ b/storage/store_test.go
@@ -439,7 +439,7 @@ func TestStoreRangeSet(t *testing.T) {
 	// Split the first range to insert a new range as second range.
 	// The range is never visited with this iteration.
 	rng := createRange(store, 11, proto.Key("a000"), proto.Key("a01"))
-	if err = store.SplitRange(store.LookupRange(proto.Key("a00"), nil), rng); err != nil {
+	if err := store.SplitRange(store.LookupRange(proto.Key("a00"), nil), rng); err != nil {
 		t.Fatal(err)
 	}
 	// Estimated count will still be 9, as it's cached.
@@ -639,7 +639,7 @@ func splitTestRange(store *Store, key, splitKey proto.Key, t *testing.T) *Range 
 	if err != nil {
 		t.Fatal(err)
 	}
-	if err = store.SplitRange(rng, newRng); err != nil {
+	if err := store.SplitRange(rng, newRng); err != nil {
 		t.Fatal(err)
 	}
 	return newRng
@@ -818,8 +818,7 @@ func TestStoreResolveWriteIntent(t *testing.T) {
 			}
 			txnKey := keys.TransactionKey(pushee.Key, pushee.ID)
 			var txn proto.Transaction
-			ok, err := engine.MVCCGetProto(store.Engine(), txnKey, proto.ZeroTimestamp, true, nil, &txn)
-			if !ok || err != nil {
+			if ok, err := engine.MVCCGetProto(store.Engine(), txnKey, proto.ZeroTimestamp, true, nil, &txn); !ok || err != nil {
 				t.Fatalf("not found or err: %s", err)
 			}
 			if txn.Status != proto.ABORTED {
@@ -832,7 +831,7 @@ func TestStoreResolveWriteIntent(t *testing.T) {
 				t.Errorf("expected txn to match pushee %q; got %s", pushee.ID, rErr)
 			}
 			// Trying again should fail again.
-			if _, err = store.ExecuteCmd(context.Background(), &pArgs); err == nil {
+			if _, err := store.ExecuteCmd(context.Background(), &pArgs); err == nil {
 				t.Errorf("expected another error on latent write intent but succeeded")
 			}
 		}

--- a/structured/structured_test.go
+++ b/structured/structured_test.go
@@ -244,7 +244,7 @@ func TestValidateTableDesc(t *testing.T) {
 		if err := d.desc.Validate(); err == nil {
 			t.Errorf("%d: expected \"%s\", but found success: %+v", i, d.err, d.desc)
 		} else if d.err != err.Error() {
-			t.Errorf("%d: expected \"%s\", but found \"%s\"", i, d.err, err.Error())
+			t.Errorf("%d: expected \"%s\", but found \"%s\"", i, d.err, err)
 		}
 	}
 }

--- a/ts/db_test.go
+++ b/ts/db_test.go
@@ -79,7 +79,7 @@ func (tm *testModel) getActualData() map[string]*proto.Value {
 	endKey := keyDataPrefix.PrefixEnd()
 	keyValues, _, err := engine.MVCCScan(tm.Eng, startKey, endKey, 0, tm.Clock.Now(), true, nil)
 	if err != nil {
-		tm.t.Fatalf("error scanning TS data from engine: %s", err.Error())
+		tm.t.Fatalf("error scanning TS data from engine: %s", err)
 	}
 
 	kvMap := make(map[string]*proto.Value)
@@ -152,28 +152,28 @@ func (tm *testModel) storeInModel(r Resolution, data proto.TimeSeriesData) {
 	// Process and store data in the model.
 	internalData, err := data.ToInternal(r.KeyDuration(), r.SampleDuration())
 	if err != nil {
-		tm.t.Fatalf("test could not convert time series to internal format: %s", err.Error())
+		tm.t.Fatalf("test could not convert time series to internal format: %s", err)
 	}
 
 	for _, idata := range internalData {
 		key := MakeDataKey(data.Name, data.Source, r, idata.StartTimestampNanos)
 		keyStr := string(key)
 
-		existing, ok := tm.modelData[keyStr]
 		var newTs *proto.InternalTimeSeriesData
-		if ok {
+		if existing, ok := tm.modelData[keyStr]; ok {
 			existingTs, err := proto.InternalTimeSeriesDataFromValue(existing)
 			if err != nil {
-				tm.t.Fatalf("test could not extract time series from existing model value: %s", err.Error())
+				tm.t.Fatalf("test could not extract time series from existing model value: %s", err)
 			}
 			newTs, err = engine.MergeInternalTimeSeriesData(existingTs, idata)
 			if err != nil {
-				tm.t.Fatalf("test could not merge time series into model value: %s", err.Error())
+				tm.t.Fatalf("test could not merge time series into model value: %s", err)
 			}
 		} else {
+			var err error
 			newTs, err = engine.MergeInternalTimeSeriesData(idata)
 			if err != nil {
-				tm.t.Fatalf("test could not merge time series into model value: %s", err.Error())
+				tm.t.Fatalf("test could not merge time series into model value: %s", err)
 			}
 		}
 		val, err := newTs.ToValue()
@@ -189,7 +189,7 @@ func (tm *testModel) storeInModel(r Resolution, data proto.TimeSeriesData) {
 func (tm *testModel) storeTimeSeriesData(r Resolution, data []proto.TimeSeriesData) {
 	// Store data in the system under test.
 	if err := tm.DB.StoreData(r, data); err != nil {
-		tm.t.Fatalf("error storing time series data: %s", err.Error())
+		tm.t.Fatalf("error storing time series data: %s", err)
 	}
 
 	// Store data in the model.

--- a/ts/server.go
+++ b/ts/server.go
@@ -61,18 +61,20 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 // for one or more metrics over a specific time span. Query requests have a
 // significant body and thus are POST requests.
 func (s *Server) handleQuery(w http.ResponseWriter, r *http.Request, _ httprouter.Params) {
-	request := &proto.TimeSeriesQueryRequest{}
+	request := proto.TimeSeriesQueryRequest{}
 
 	// Unmarshal query request.
-	reqBody, err := ioutil.ReadAll(r.Body)
-	defer r.Body.Close()
-	if err != nil {
-		http.Error(w, err.Error(), http.StatusInternalServerError)
-		return
-	}
-	if err := util.UnmarshalRequest(r, reqBody, request, util.AllEncodings); err != nil {
-		http.Error(w, err.Error(), http.StatusBadRequest)
-		return
+	{
+		reqBody, err := ioutil.ReadAll(r.Body)
+		defer r.Body.Close()
+		if err != nil {
+			http.Error(w, err.Error(), http.StatusInternalServerError)
+			return
+		}
+		if err := util.UnmarshalRequest(r, reqBody, &request, util.AllEncodings); err != nil {
+			http.Error(w, err.Error(), http.StatusBadRequest)
+			return
+		}
 	}
 
 	if len(request.Queries) == 0 {

--- a/util/encoding/encoding_test.go
+++ b/util/encoding/encoding_test.go
@@ -56,8 +56,7 @@ func TestChecksums(t *testing.T) {
 		return err == nil
 	}
 
-	_, err := unwrapChecksum([]byte("does not matter"), []byte("srt"))
-	if err == nil {
+	if _, err := unwrapChecksum([]byte("does not matter"), []byte("srt")); err == nil {
 		t.Fatalf("expected error unwrapping a too short string")
 	}
 

--- a/util/error_test.go
+++ b/util/error_test.go
@@ -31,7 +31,7 @@ func TestErrorf(t *testing.T) {
 	file, line, _ := caller.Lookup(0)
 	expected := fmt.Sprintf("%sfoo: 1 3.140000", fmt.Sprintf(errorPrefixFormat, file, line-1))
 	if expected != err.Error() {
-		t.Errorf("expected %s, got %s", expected, err.Error())
+		t.Errorf("expected %s, got %s", expected, err)
 	}
 }
 
@@ -45,7 +45,7 @@ func TestErrorfSkipFrames(t *testing.T) {
 	file, line, _ := caller.Lookup(0)
 	expected := fmt.Sprintf("%sfoo: 1 3.140000", fmt.Sprintf(errorPrefixFormat, file, line-1))
 	if expected != err.Error() {
-		t.Errorf("expected %s, got %s", expected, err.Error())
+		t.Errorf("expected %s, got %s", expected, err)
 	}
 }
 
@@ -56,7 +56,7 @@ func TestError(t *testing.T) {
 	file, line, _ := caller.Lookup(0)
 	expected := fmt.Sprintf("%sfoo 1 3.14", fmt.Sprintf(errorPrefixFormat, file, line-1))
 	if expected != err.Error() {
-		t.Errorf("expected %s, got %s", expected, err.Error())
+		t.Errorf("expected %s, got %s", expected, err)
 	}
 }
 
@@ -70,6 +70,6 @@ func TestErrorSkipFrames(t *testing.T) {
 	file, line, _ := caller.Lookup(0)
 	expected := fmt.Sprintf("%sfoo 1 3.14", fmt.Sprintf(errorPrefixFormat, file, line-1))
 	if expected != err.Error() {
-		t.Errorf("expected %s, got %s", expected, err.Error())
+		t.Errorf("expected %s, got %s", expected, err)
 	}
 }

--- a/util/log/clog.go
+++ b/util/log/clog.go
@@ -934,11 +934,13 @@ func (sb *syncBuffer) rotateFile(now time.Time) error {
 			return err
 		}
 	}
-	var err error
-	sb.file, _, err = create(sb.sev, now)
-	sb.nbytes = 0
-	if err != nil {
-		return err
+	{
+		file, _, err := create(sb.sev, now)
+		sb.nbytes = 0
+		if err != nil {
+			return err
+		}
+		sb.file = file
 	}
 
 	sb.Writer = bufio.NewWriterSize(sb.file, bufferSize)
@@ -962,7 +964,7 @@ func (sb *syncBuffer) rotateFile(now time.Time) error {
 		}
 		sb.nbytes += uint64(n)
 	}
-	return err
+	return nil
 }
 
 // bufferSize sizes the buffer associated with each log file. It's large

--- a/util/log/structured.go
+++ b/util/log/structured.go
@@ -52,7 +52,7 @@ func getJSON(arg interface{}) []byte {
 
 	jsonBytes, err := json.Marshal(arg)
 	if err != nil {
-		return []byte(fmt.Sprintf("{\"error\": %q}", err.Error()))
+		return []byte(fmt.Sprintf("{\"error\": %q}", err))
 	}
 	return jsonBytes
 }

--- a/util/testing_test.go
+++ b/util/testing_test.go
@@ -28,14 +28,12 @@ import (
 func verifyAddr(addr net.Addr, t *testing.T) {
 	ln, err := net.Listen(addr.Network(), addr.String())
 	if err != nil {
-		t.Error(err)
-		return
+		t.Fatal(err)
 	}
 
 	acceptChan := make(chan struct{})
 	go func() {
-		_, err := ln.Accept()
-		if err != nil {
+		if _, err := ln.Accept(); err != nil {
 			t.Error(err)
 		}
 		close(acceptChan)
@@ -44,8 +42,7 @@ func verifyAddr(addr net.Addr, t *testing.T) {
 	addr = ln.Addr()
 	conn, err := net.Dial(addr.Network(), addr.String())
 	if err != nil {
-		t.Errorf("could not connect to %s", addr)
-		return
+		t.Fatalf("could not connect to %s: %s", addr, err)
 	}
 	select {
 	case <-acceptChan:


### PR DESCRIPTION
Two commits here: first one removes go-nyet, second one is the part of #1735 that is uncontroversial in my opinion. Thought it'd be good to land this separately from ongoing discussion in #1735.

The main pattern to notice in the second commit is that `err` is always shadowed when used in a block scope, unless the assignment is explicitly intended to mutate (such as in the case of a named return). I think this makes things clearer, but others may disagree.

The second pattern to notice is the block scoping of `foo, err` when `foo` is only used to define a derivative value. In other words, `foo, err` have become block scoped in cases where it was convenient to leak `foo` or a derivative of `foo` into the wrapping scope from within the block.
