### PR TITLE
update processInsertRows

### DIFF
--- a/sql/parser/eval.go
+++ b/sql/parser/eval.go
@@ -365,11 +365,25 @@ func (e mapEnv) Get(name string) (Datum, bool) {
 	return d, ok
 }
 
+// nilEnv is an empty environment. It's useful to avoid nil checks.
+type nilEnv struct{}
+
+func (*nilEnv) Get(_ string) (Datum, bool) {
+	return nil, false
+}
+
+var emptyEnv *nilEnv
+
 // EvalExpr evaluates an SQL expression in the context of an
 // environment. Expression evaluation is a mostly straightforward walk over the
 // parse tree. The only significant complexity is the handling of types and
 // implicit conversions. See binOps and cmpOps for more details.
 func EvalExpr(expr Expr, env Env) (Datum, error) {
+	if env == nil {
+		// This avoids having to worry about `env` being a nil interface
+		// anywhere else.
+		env = emptyEnv
+	}
 	switch t := expr.(type) {
 	case *AndExpr:
 		return evalAndExpr(t, env)

--- a/sql/sqlserver/server.go
+++ b/sql/sqlserver/server.go
@@ -151,6 +151,8 @@ func (s *Server) exec(call sqlwire.Call) error {
 	// Pick up current session state.
 	var session Session
 	if req.Session != nil {
+		// TODO(tschottdorf) will have to validate the Session information (for
+		// instance, whether access to the stored database is permitted).
 		if err := gogoproto.Unmarshal(req.Session, &session); err != nil {
 			return err
 		}

--- a/sql/sqlserver/server.go
+++ b/sql/sqlserver/server.go
@@ -88,6 +88,7 @@ func NewServer(ctx *base.Context, db *client.DB) *Server {
 // present, in the same format as the request's incoming Content-Type
 // header.
 func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	defer r.Body.Close()
 	method := r.URL.Path
 	if !strings.HasPrefix(method, sqlwire.Endpoint) {
 		http.Error(w, http.StatusText(http.StatusNotFound), http.StatusNotFound)
@@ -110,7 +111,6 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 
 	// Unmarshal the request.
 	reqBody, err := ioutil.ReadAll(r.Body)
-	defer r.Body.Close()
 	if err != nil {
 		http.Error(w, err.Error(), http.StatusInternalServerError)
 		return

--- a/sql/sqlserver/server.go
+++ b/sql/sqlserver/server.go
@@ -434,7 +434,7 @@ func (s *Server) Insert(session *Session, p *parser.Insert, args []sqlwire.Datum
 
 	// Transform the values into a rows object. This expands SELECT statements or
 	// generates rows from the values contained within the query.
-	r, err := s.processInsertRows(p.Rows)
+	r, err := s.processSelect(p.Rows)
 	if err != nil {
 		return err
 	}
@@ -674,7 +674,7 @@ func (s *Server) processColumns(desc *structured.TableDescriptor,
 	return cols, nil
 }
 
-func (s *Server) processInsertRows(node parser.SelectStatement) (rows []sqlwire.Result_Row, err error) {
+func (s *Server) processSelect(node parser.SelectStatement) (rows []sqlwire.Result_Row, err error) {
 	switch nt := node.(type) {
 	// case *parser.Select:
 	// case *parser.Union:

--- a/sql/sqlserver/server.go
+++ b/sql/sqlserver/server.go
@@ -674,7 +674,7 @@ func (s *Server) processColumns(desc *structured.TableDescriptor,
 	return cols, nil
 }
 
-func (s *Server) processSelect(node parser.SelectStatement) (rows []sqlwire.Result_Row, err error) {
+func (s *Server) processSelect(node parser.SelectStatement) (rows []sqlwire.Result_Row, _ error) {
 	switch nt := node.(type) {
 	// case *parser.Select:
 	// case *parser.Union:
@@ -689,8 +689,7 @@ func (s *Server) processSelect(node parser.SelectStatement) (rows []sqlwire.Resu
 			if !ok {
 				// A one-element DTuple is currently turned into whatever its
 				// underlying element is, so we have to massage here.
-				// TODO(tschottdorf): Is that desired behaviour on behalf of
-				// EvalExpr?
+				// See #1741.
 				dTuple = parser.DTuple([]parser.Datum{data})
 			}
 			var vals []sqlwire.Datum
@@ -707,14 +706,14 @@ func (s *Server) processSelect(node parser.SelectStatement) (rows []sqlwire.Resu
 				case parser.DNull:
 					vals = append(vals, sqlwire.Datum{})
 				default:
-					return rows, util.Errorf("TODO(pmattis): unsupported node: %T", val)
+					return rows, util.Errorf("unsupported node: %T", val)
 				}
 			}
 			rows = append(rows, sqlwire.Result_Row{Values: vals})
 		}
 		return rows, nil
 	}
-	return rows, util.Errorf("TODO(pmattis): unsupported node: %T", node)
+	return nil, util.Errorf("TODO(pmattis): unsupported node: %T", node)
 }
 
 // TODO(pmattis): The key encoding and decoding routines belong in either

--- a/sql/sqlserver/server_test.go
+++ b/sql/sqlserver/server_test.go
@@ -25,7 +25,7 @@ import (
 	"github.com/cockroachdb/cockroach/sql/sqlwire"
 )
 
-func TestProcessInsertRows(t *testing.T) {
+func TestProcessSelect(t *testing.T) {
 	s := (*Server)(nil) // enough for now
 
 	vInt := int64(5)
@@ -82,7 +82,7 @@ func TestProcessInsertRows(t *testing.T) {
 	}
 
 	for i, tc := range testCases {
-		rows, err := s.processInsertRows(tc.stmt)
+		rows, err := s.processSelect(tc.stmt)
 		if err == nil != tc.ok {
 			t.Errorf("%d: error_expected=%t, but got error %v", i, tc.ok, err)
 		}

--- a/sql/sqlserver/server_test.go
+++ b/sql/sqlserver/server_test.go
@@ -1,0 +1,93 @@
+// Copyright 2015 The Cockroach Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+// implied. See the License for the specific language governing
+// permissions and limitations under the License. See the AUTHORS file
+// for names of contributors.
+//
+// Author: Tobias Schottdorf
+
+package sqlserver
+
+import (
+	"reflect"
+	"testing"
+
+	"github.com/cockroachdb/cockroach/sql/parser"
+	"github.com/cockroachdb/cockroach/sql/sqlwire"
+)
+
+func TestProcessInsertRows(t *testing.T) {
+	s := (*Server)(nil) // enough for now
+
+	vInt := int64(5)
+	vFloat := float64(3.14159)
+	vStr := "five"
+	vBool := true
+
+	dInt := sqlwire.Datum{IntVal: &vInt}
+	dFloat := sqlwire.Datum{FloatVal: &vFloat}
+	dStr := sqlwire.Datum{StringVal: &vStr}
+	dBool := sqlwire.Datum{BoolVal: &vBool}
+
+	// Floats aren't generated from processInsertRows. A parser.NumVal currently
+	// turns into a StringVal datum.
+	_, _ = vFloat, dFloat
+
+	asRow := func(datums ...sqlwire.Datum) []sqlwire.Result_Row {
+		return []sqlwire.Result_Row{
+			{Values: datums},
+		}
+	}
+
+	testCases := []struct {
+		stmt parser.SelectStatement
+		rows []sqlwire.Result_Row
+		ok   bool
+	}{
+		{
+			parser.Values{{parser.IntVal(vInt)}},
+			asRow(dInt),
+			true,
+		},
+		{
+			// This one will likely have to change.
+			parser.Values{{parser.NumVal("five")}},
+			asRow(dStr),
+			true,
+		},
+		{
+			parser.Values{{parser.StrVal(vStr)}},
+			asRow(dStr),
+			true,
+		},
+		{
+			parser.Values{{parser.BytesVal(vStr)}},
+			asRow(dStr), // string, not bytes!
+			true,
+		},
+		{
+			parser.Values{{parser.BoolVal(vBool)}},
+			asRow(dBool),
+			true,
+		},
+	}
+
+	for i, tc := range testCases {
+		rows, err := s.processInsertRows(tc.stmt)
+		if err == nil != tc.ok {
+			t.Errorf("%d: error_expected=%t, but got error %v", i, tc.ok, err)
+		}
+		if !reflect.DeepEqual(rows, tc.rows) {
+			t.Errorf("%d: expected rows:\n%+v\nactual rows:\n%+v", i, tc.rows, rows)
+		}
+	}
+}


### PR DESCRIPTION
I wanted this shell session to work for an upcoming presentation:

``` sql
CREATE DATABASE cr
CREATE TABLE cr.employees (id int PRIMARY KEY NOT NULL, name varchar(255))
INSERT INTO cr VALUES(1, "Craig")
```

which previously failed since `IntVal` wasn't handled. This part of the code is likely far from complete and seems generic enough to go somewhere else (maybe an interface implemented by those `Expr`s which correspond to a datum?). I'm happy to complete it but am not familiar enough with the code or the current plans at this point. In particular, trying to insert a float will probably not work because it's treated as `StringVal`, not `NumVal`. Are we just going to call `strconv.FormatFloat`? That seems awkward.
