### PR TITLE
Add internal proxying call for log entry retrieval from different nodes.

### DIFF
--- a/server/server.go
+++ b/server/server.go
@@ -154,7 +154,7 @@ func NewServer(ctx *Context, stopper *stop.Stopper) (*Server, error) {
 	}
 	s.node = NewNode(nCtx)
 	s.admin = newAdminServer(s.db, s.stopper)
-	s.status = newStatusServer(s.db, s.gossip)
+	s.status = newStatusServer(s.db, s.gossip, ctx)
 	s.tsDB = ts.NewDB(s.db)
 	s.tsServer = ts.NewServer(s.tsDB)
 	s.stopper.AddCloser(nCtx.EventFeed)


### PR DESCRIPTION
This will break the log listing section in the ui.

Hard to test in our unit testing, might try to make an acceptance test for this.
