### PR TITLE
Tiny fix: Move splitReservoirSize from mvcc.go to mvcc_test.go

### DIFF
--- a/storage/engine/mvcc.go
+++ b/storage/engine/mvcc.go
@@ -33,8 +33,6 @@ import (
 )
 
 const (
-	// The size of the reservoir used by FindSplitKey.
-	splitReservoirSize = 100
 	// The size of the timestamp portion of MVCC version keys (used to update stats).
 	mvccVersionTimestampSize int64 = 12
 )

--- a/storage/engine/mvcc_test.go
+++ b/storage/engine/mvcc_test.go
@@ -1729,6 +1729,7 @@ func TestFindSplitKey(t *testing.T) {
 	// facility. Assuming that this translates roughly into same-length
 	// values after MVCC encoding, the split key should hence be chosen
 	// as the middle key of the interval.
+	splitReservoirSize := 100
 	for i := 0; i < splitReservoirSize; i++ {
 		k := fmt.Sprintf("%09d", i)
 		v := strings.Repeat("X", 10-len(k))


### PR DESCRIPTION
The const is used only in `TestFindSplitKey`. The test might need to be updated, but I haven'y fully understood the code..
