### PR TITLE
Tweak log format.

### DIFF
--- a/util/log/clog.go
+++ b/util/log/clog.go
@@ -510,13 +510,16 @@ func formatHeader(s Severity, now time.Time, threadID int32, file string, line i
 	n += buf.nDigits(6, n, now.Nanosecond()/1000, '0')
 	tmp[n] = ' '
 	n++
-	n += buf.nDigits(7, n, int(threadID), ' ')
+	n += buf.someDigits(n, int(threadID))
 	tmp[n] = ' '
 	n++
 	buf.Write(tmp[:n])
 	buf.WriteString(file)
 	tmp[0] = ':'
 	n = buf.someDigits(1, int(line))
+	n++
+	// Extra space between the header and the actual message for scannability.
+	tmp[n] = ' '
 	n++
 	if colors != nil {
 		n += copy(tmp[n:], []byte("\033[0m")) // reset


### PR DESCRIPTION
Don't pad "thread IDs" to 7 characters (they're typically 5, at least
while we're logging the PID instead of a thread ID). Add an extra space
in between the header and the log message for clarity (I've found the
logs more difficult to scan since the `]` was removed in 7997091)
