### PR TITLE
Test lowercase sql statements.

### DIFF
--- a/sql/parser/expr.go
+++ b/sql/parser/expr.go
@@ -21,6 +21,7 @@ import (
 	"bytes"
 	"fmt"
 	"strconv"
+	"strings"
 )
 
 // Expr represents an expression.
@@ -268,7 +269,7 @@ func (n QualifiedName) String() string {
 		}
 		if s == "*" {
 			_, _ = buf.WriteString(s)
-		} else if _, ok := keywords[s]; ok {
+		} else if _, ok := keywords[strings.ToUpper(s)]; ok {
 			fmt.Fprintf(&buf, "\"%s\"", s)
 		} else {
 			encodeSQLIdent(&buf, s)

--- a/sql/parser/expr_test.go
+++ b/sql/parser/expr_test.go
@@ -1,0 +1,47 @@
+// Copyright 2015 The Cockroach Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+// implied. See the License for the specific language governing
+// permissions and limitations under the License. See the AUTHORS file
+// for names of contributors.
+//
+// Author: Marc Berhault (marc@cockroachlabs.com)
+
+package parser
+
+import "testing"
+
+// TestQualifiedName tests the string representation of QualifiedName.
+func TestQualifiedNameString(t *testing.T) {
+	testCases := []struct {
+		in, out string
+	}{
+		{"*", "*"},
+		// Keyword.
+		{"DATABASE", `"DATABASE"`},
+		{"dAtAbAse", `"dAtAbAse"`},
+		// Ident format: starts with [a-zA-Z_] or extended ascii,
+		// and is then followed by [a-zA-Z0-9$_] or extended ascii.
+		{"foo$09", "foo$09"},
+		{"_Ab10", "_Ab10"},
+		// Everything else quotes the string and escapes '"' and '\\'.
+		{".foobar", `".foobar"`},
+		{`".foobar"`, `"\".foobar\""`},
+		{`\".foobar\"`, `"\\\".foobar\\\""`},
+	}
+
+	for _, tc := range testCases {
+		q := QualifiedName{tc.in}
+		if q.String() != tc.out {
+			t.Errorf("expected q.String() == %q, got %q", tc.out, q.String())
+		}
+	}
+}


### PR DESCRIPTION
Fix handling of "set database" to allow lowercase "database".

It's probably fair to debate how we want to handle casing (personally, I like uppercase statements in ad-hoc queries in code, but I hate them when using the shell). At least, we should try to be consistent (previously, you could use "show databases", but not "set database = foo")
