### PR TITLE
Allow `docker images` to fail so we can capture output

### DIFF
--- a/build/init-docker.sh
+++ b/build/init-docker.sh
@@ -20,9 +20,8 @@ if [[ ! $(type -P "$DOCKER") ]]; then
 fi
 
 # Verify docker is reachable.
-OUT=$(($DOCKER images > /dev/null) 2>&1)
-if [[ ! $? == 0 ]]; then
-  echo "Docker is not reachable. Did you follow installation instructions?"
+OUT=$(($DOCKER images  > /dev/null) 2>&1) || (
+  echo "Docker is not reachable. Is the Docker daemon running?"
   echo "'docker images': $OUT"
   exit 1
-fi
+)


### PR DESCRIPTION
Since this script is `source`d, it inherits the -e from its
`source`rs, meaning we must locally unset it to get the behaviour we
want.
