### PR TITLE
Return an error if a read request finds a write intent with a greater epoch

### DIFF
--- a/storage/engine/mvcc.go
+++ b/storage/engine/mvcc.go
@@ -534,6 +534,10 @@ func mvccGetInternal(engine Engine, key proto.Key, metaKey proto.EncodedKey,
 		// we're now reading. In this case, we skip the intent.
 		var err error
 		if ownIntent && txn.Epoch != meta.Txn.Epoch {
+			if txn.Epoch < meta.Txn.Epoch {
+				return nil, nil, util.Errorf("failed to read with epoch %d due to a write intent with epoch %d",
+					txn.Epoch, meta.Txn.Epoch)
+			}
 			valueKey, err = getValue(engine, latestKey.Next(), MVCCEncodeKey(key.Next()), value)
 		} else {
 			var ok bool

--- a/storage/engine/mvcc_test.go
+++ b/storage/engine/mvcc_test.go
@@ -1469,6 +1469,22 @@ func TestMVCCReadWithDiffEpochs(t *testing.T) {
 	}
 }
 
+// TestMVCCReadWithOldEpoch writes a value first using epoch 2, then
+// reads using epoch 1 to verify that the read will fail.
+func TestMVCCReadWithOldEpoch(t *testing.T) {
+	defer leaktest.AfterTest(t)
+	engine := createTestEngine()
+	defer engine.Close()
+
+	if err := MVCCPut(engine, nil, testKey1, makeTS(1, 0), value2, txn1e2); err != nil {
+		t.Fatal(err)
+	}
+	_, _, err := MVCCGet(engine, testKey1, makeTS(2, 0), true, txn1)
+	if err == nil {
+		t.Fatalf("unexpected success of get")
+	}
+}
+
 // TestMVCCReadWithPushedTimestamp verifies that a read for a value
 // written by the transaction, but then subsequently pushed, can still
 // be read by the txn at the later timestamp, even if an earlier


### PR DESCRIPTION
Does this make sense? This might not happen in practice, but can be a nice safe guard. We
have a similar check in `mvccPutInternal`.
