### PR TITLE
Refactor and Update Status Server

### DIFF
--- a/acceptance/build_info_test.go
+++ b/acceptance/build_info_test.go
@@ -42,7 +42,7 @@ func TestBuildInfo(t *testing.T) {
 		var r struct {
 			BuildInfo map[string]string
 		}
-		if err := l.Nodes[0].GetJSON("", "/_status/local/", &r); err != nil {
+		if err := l.Nodes[0].GetJSON("", "/_status/details/local", &r); err != nil {
 			return err
 		}
 		for _, key := range []string{"goVersion", "tag", "time", "dependencies"} {

--- a/acceptance/gossip_peerings_test.go
+++ b/acceptance/gossip_peerings_test.go
@@ -55,7 +55,7 @@ func checkGossip(t *testing.T, l *localcluster.Cluster, d time.Duration,
 
 		for i, node := range l.Nodes {
 			var m map[string]interface{}
-			if err := node.GetJSON("", "/_status/gossip", &m); err != nil {
+			if err := node.GetJSON("", "/_status/gossip/local", &m); err != nil {
 				return err
 			}
 			infos := m["infos"].(map[string]interface{})

--- a/cli/flags.go
+++ b/cli/flags.go
@@ -77,7 +77,8 @@ var flagUsage = map[string]string{
           or "self" for single-node systems.
         - unix: unix socket
         - lb: RPC load balancer fowarding to an arbitrary node
-        - http-lb: HTTP load balancer: we query http(s)://<address>/_status/local
+        - http-lb: HTTP load balancer: we query
+          http(s)://<address>/_status/details/local
 `,
 	"gossip-interval": `
         Approximate interval (time.Duration) for gossiping new information to peers.

--- a/gossip/resolver/node_lookup.go
+++ b/gossip/resolver/node_lookup.go
@@ -33,8 +33,8 @@ import (
 const lookupTimeout = time.Second * 3
 
 // nodeLookupResolver implements Resolver.
-// It queries http(s)://<address>/_status/local and extracts the node's address.
-// This is useful for http load balancers which will not forward RPC.
+// It queries http(s)://<address>/_status/details/local and extracts the node's
+// address. This is useful for http load balancers which will not forward RPC.
 // It is never exhausted.
 type nodeLookupResolver struct {
 	context   *base.Context
@@ -79,7 +79,7 @@ func (nl *nodeLookupResolver) GetAddress() (net.Addr, error) {
 
 	nl.exhausted = true
 	// TODO(marc): put common URIs in base and reuse everywhere.
-	url := fmt.Sprintf("%s://%s/_status/local", nl.context.RequestScheme(), nl.addr)
+	url := fmt.Sprintf("%s://%s/_status/details/local", nl.context.RequestScheme(), nl.addr)
 	req, err := http.NewRequest("GET", url, nil)
 	if err != nil {
 		return nil, err

--- a/gossip/resolver/resolver.go
+++ b/gossip/resolver/resolver.go
@@ -48,7 +48,8 @@ var validTypes = map[string]struct{}{
 // - tcp: plain hostname of ip address
 // - lb: load balancer host name or ip: points to an unknown number of backends
 // - unix: unix sockets
-// - http-lb: http load balancer: queries http(s)://<lb>/_status/local for node addresses
+// - http-lb: http load balancer: queries http(s)://<lb>/_status/details/local
+//   for node addresses
 // If "network type" is not specified, "tcp" is assumed.
 func NewResolver(context *base.Context, spec string) (Resolver, error) {
 	parts := strings.Split(spec, "=")

--- a/server/authentication_test.go
+++ b/server/authentication_test.go
@@ -76,9 +76,9 @@ func TestSSLEnforcement(t *testing.T) {
 		{"GET", debugEndpoint + "vars", insecureContext, false, -1},
 
 		// /_status/nodes: server.statusServer: no auth.
-		{"GET", statusNodeKeyPrefix, certsContext, true, http.StatusOK},
-		{"GET", statusNodeKeyPrefix, noCertsContext, true, http.StatusOK},
-		{"GET", statusNodeKeyPrefix, insecureContext, false, -1},
+		{"GET", statusNodesPrefix, certsContext, true, http.StatusOK},
+		{"GET", statusNodesPrefix, noCertsContext, true, http.StatusOK},
+		{"GET", statusNodesPrefix, insecureContext, false, -1},
 
 		// /ts/: ts.Server: no auth.
 		{"GET", ts.URLPrefix, certsContext, true, http.StatusNotFound},

--- a/server/server.go
+++ b/server/server.go
@@ -212,7 +212,7 @@ func (s *Server) initHTTP() {
 	// apply it for all web endpoints.
 	s.mux.Handle(adminEndpoint, s.admin)
 	s.mux.Handle(debugEndpoint, s.admin)
-	s.mux.Handle(statusKeyPrefix, s.status)
+	s.mux.Handle(statusPrefix, s.status)
 	s.mux.Handle(ts.URLPrefix, s.tsServer)
 
 	// KV handles its own authentication, verifying user certificates against


### PR DESCRIPTION
This is a cleanup of the status server.
The biggest change is the removal of the `/_status/local` and instead replacing anywhere that could be scoped to a node, to include the ability to specify any nodeID (or `local`).  So you can now send the request for `/_status/stacks/2` to any node and it will always forward that request to node 2.  Or you could  also request `/_status/stacks/local` and it will return the node's own details.

The next step after this is to write a proper acceptance test for it.
