### PR TITLE
More aggressively trim the build cache.

### DIFF
--- a/build/circle-deps.sh
+++ b/build/circle-deps.sh
@@ -71,7 +71,9 @@ grep -v '^cmd' GLOCKFILE | glock sync -n
 # passing "docker" as the first argument.
 $(dirname $0)/builder.sh $0 docker
 
-# Clear the cache of any files that haven't been modified in more than 3 days.
-find "${cachedir}" -mmin +4320 -ls -delete
+# Clear the cache of any files that haven't been modified in more than
+# 12 hours. Note that the "build-cache restore" call above will
+# "touch" any cache files that are used by the current run.
+find "${cachedir}" -mmin +720 -ls -delete
 du -sh "${cachedir}"
 ls -lh "${cachedir}"


### PR DESCRIPTION
Restoring of the cache is taking longer and longer on CircleCI. Looks
like the initial setting of 3 days was too long. Even this setting (12
hours) might be too long. But let's see how this works first.
