### PR TITLE
fix double negation issues

### DIFF
--- a/sql/parser/expr.go
+++ b/sql/parser/expr.go
@@ -402,7 +402,15 @@ type UnaryExpr struct {
 }
 
 func (node *UnaryExpr) String() string {
-	return fmt.Sprintf("%s%s", node.Operator, node.Expr)
+	extra := ""
+	if node.Operator == UnaryMinus {
+		// We don't want to end up printing --5 since `--` indicates a comment.
+		// Instead, space them out to "- -".
+		if nNode, ok := node.Expr.(*UnaryExpr); ok && nNode.Operator == UnaryMinus {
+			extra = " "
+		}
+	}
+	return fmt.Sprintf("%s%s%s", node.Operator, extra, node.Expr)
 }
 
 // FuncExpr represents a function call.

--- a/sql/parser/parse_test.go
+++ b/sql/parser/parse_test.go
@@ -81,6 +81,7 @@ func TestParse(t *testing.T) {
 		{`INSERT INTO a DEFAULT VALUES`},
 
 		{`SELECT 1+1`},
+		{`SELECT - -5`},
 		{`SELECT -1`},
 		{`SELECT +1`},
 		{`SELECT .1`},
@@ -267,6 +268,11 @@ func TestParse2(t *testing.T) {
 		// Shorthand type cast.
 		{`SELECT '1'::INT`,
 			`SELECT CAST('1' AS INT)`},
+		// Double negation. See #1800.
+		{`SELECT *,-/* comment */-5`,
+			`SELECT *, - -5`},
+		{"SELECT -\n-5",
+			`SELECT - -5`},
 	}
 	for _, d := range testData {
 		stmts, err := Parse(d.sql)


### PR DESCRIPTION
found via go-fuzz:

> SELECT*,-
> --
> -5
> data0: "SELECT *, --5"
> panic: syntax error at or near "EOF"
> SELECT *, --5
>              ^

ping @dvyukov
