### PR TITLE
Add WalkExpr and FillArgs.

### DIFF
--- a/sql/parser/eval.go
+++ b/sql/parser/eval.go
@@ -37,8 +37,8 @@ import (
 
 // A Datum holds either a bool, int64, float64, string or []Datum.
 type Datum interface {
+	Expr
 	Type() string
-	String() string
 }
 
 var _ Datum = DBool(false)
@@ -64,10 +64,7 @@ func (d DBool) Type() string {
 }
 
 func (d DBool) String() string {
-	if d {
-		return "true"
-	}
-	return "false"
+	return BoolVal(d).String()
 }
 
 // DInt is the int Datum.
@@ -103,7 +100,7 @@ func (d DString) Type() string {
 }
 
 func (d DString) String() string {
-	return string(d)
+	return StrVal(d).String()
 }
 
 // DTuple is the tuple Datum.
@@ -426,6 +423,9 @@ func EvalExpr(expr Expr, env Env) (Datum, error) {
 			tuple = append(tuple, d)
 		}
 		return tuple, nil
+
+	case Datum:
+		return t, nil
 
 	case *Subquery:
 		// The subquery should have been executed before expression evaluation and

--- a/sql/parser/eval_test.go
+++ b/sql/parser/eval_test.go
@@ -56,12 +56,12 @@ func TestEvalExpr(t *testing.T) {
 		// Octal numbers.
 		// TODO(pmattis): {`0755`, `493`, nil},
 		// String concatenation.
-		{`'a' || 'b'`, `ab`, nil},
-		{`'a' || (1 + 2)`, `a3`, nil},
+		{`'a' || 'b'`, `'ab'`, nil},
+		{`'a' || (1 + 2)`, `'a3'`, nil},
 		// Column lookup.
 		{`a`, `1`, mapEnv{"a": DInt(1)}},
 		{`a`, `3.1`, mapEnv{"a": DFloat(3.1)}},
-		{`a`, `c`, mapEnv{"a": DString("c")}},
+		{`a`, `'c'`, mapEnv{"a": DString("c")}},
 		{`a.b + 1`, `2`, mapEnv{"a.b": DInt(1)}},
 		{`a OR b`, `true`, mapEnv{"a": DBool(false), "b": DBool(true)}},
 		// Boolean expressions.
@@ -128,7 +128,7 @@ func TestEvalExpr(t *testing.T) {
 		{`CASE WHEN false THEN 1 ELSE 2 END`, `2`, nil},
 		{`CASE WHEN false THEN 1 WHEN false THEN 2 END`, `NULL`, nil},
 		{`CASE 1+1 WHEN 1 THEN 1 WHEN 2 THEN 2 END`, `2`, nil},
-		{`CASE 1+2 WHEN 1 THEN 1 WHEN 2 THEN 2 ELSE 'doh' END`, `doh`, nil},
+		{`CASE 1+2 WHEN 1 THEN 1 WHEN 2 THEN 2 ELSE 'doh' END`, `'doh'`, nil},
 		// Row (tuple) comparisons.
 		{`ROW(1) = ROW(1)`, `true`, nil},
 		{`ROW(1, true) = (1, NOT false)`, `true`, nil},
@@ -144,8 +144,8 @@ func TestEvalExpr(t *testing.T) {
 		{`(1,2) IN ((0+1,1+1), (3,4), (5,6))`, `true`, nil},
 		// Func expressions.
 		{`length('hel'||'lo')`, `5`, nil},
-		{`lower('HELLO')`, `hello`, nil},
-		{`UPPER('hello')`, `HELLO`, nil},
+		{`lower('HELLO')`, `'hello'`, nil},
+		{`UPPER('hello')`, `'HELLO'`, nil},
 		// Cast expressions.
 		{`true::boolean`, `true`, nil},
 		{`true::int`, `1`, nil},
@@ -181,9 +181,9 @@ func TestEvalExpr(t *testing.T) {
 		{`'0x123'::int + 1`, `292`, nil},
 		{`'0123'::int + 1`, `84`, nil}, // TODO(pmattis): Should we support octal notation?
 		{`'1.23'::float + 1.0`, `2.23`, nil},
-		{`'hello'::text`, `hello`, nil},
+		{`'hello'::text`, `'hello'`, nil},
 		{`CAST('123' AS int) + 1`, `124`, nil},
-		{`'hello'::char(2)`, `he`, nil},
+		{`'hello'::char(2)`, `'he'`, nil},
 	}
 	for _, d := range testData {
 		q, err := Parse("SELECT " + d.expr)

--- a/sql/parser/expr.go
+++ b/sql/parser/expr.go
@@ -52,6 +52,12 @@ func (*UnaryExpr) expr()      {}
 func (*FuncExpr) expr()       {}
 func (*CaseExpr) expr()       {}
 func (*CastExpr) expr()       {}
+func (DBool) expr()           {}
+func (DInt) expr()            {}
+func (DFloat) expr()          {}
+func (DString) expr()         {}
+func (DTuple) expr()          {}
+func (DNull) expr()           {}
 
 // AndExpr represents an AND expression.
 type AndExpr struct {

--- a/sql/parser/walk.go
+++ b/sql/parser/walk.go
@@ -1,0 +1,168 @@
+// Copyright 2015 The Cockroach Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+// implied. See the License for the specific language governing
+// permissions and limitations under the License. See the AUTHORS file
+// for names of contributors.
+//
+// Author: Peter Mattis (peter@cockroachlabs.com)
+
+package parser
+
+import "fmt"
+
+// The Visitor Visit method is invoked for each Expr node encountered by
+// WalkExpr. The returned Expr
+type Visitor interface {
+	Visit(expr Expr) Expr
+}
+
+// WalkExpr traverses the nodes in an expression. It starts by calling
+// v.Visit(expr). It then recursively traverses the children nodes of the
+// expression returned by v.Visit().
+func WalkExpr(v Visitor, expr Expr) Expr {
+	expr = v.Visit(expr)
+
+	switch t := expr.(type) {
+	case *AndExpr:
+		t.Left = WalkExpr(v, t.Left)
+		t.Right = WalkExpr(v, t.Right)
+
+	case *OrExpr:
+		t.Left = WalkExpr(v, t.Left)
+		t.Right = WalkExpr(v, t.Right)
+
+	case *NotExpr:
+		t.Expr = WalkExpr(v, t.Expr)
+
+	case *ParenExpr:
+		t.Expr = WalkExpr(v, t.Expr)
+
+	case *ComparisonExpr:
+		t.Left = WalkExpr(v, t.Left)
+		t.Right = WalkExpr(v, t.Right)
+
+	case *RangeCond:
+		t.Left = WalkExpr(v, t.Left)
+		t.From = WalkExpr(v, t.From)
+		t.To = WalkExpr(v, t.To)
+
+	case *NullCheck:
+		t.Expr = WalkExpr(v, t.Expr)
+
+	case *ExistsExpr:
+		// TODO(pmattis): Should we recurse into the Subquery?
+
+	case BytesVal:
+		// Terminal node: nothing to do.
+
+	case StrVal:
+		// Terminal node: nothing to do.
+
+	case IntVal:
+		// Terminal node: nothing to do.
+
+	case NumVal:
+		// Terminal node: nothing to do.
+
+	case BoolVal:
+		// Terminal node: nothing to do.
+
+	case ValArg:
+		// Terminal node: nothing to do.
+
+	case NullVal:
+		// Terminal node: nothing to do.
+
+	case QualifiedName:
+		// Terminal node: nothing to do.
+
+	case Tuple:
+		for i := range t {
+			t[i] = WalkExpr(v, t[i])
+		}
+
+	case Datum:
+		// Terminal node: nothing to do.
+
+	case *Subquery:
+		// TODO(pmattis): Should we recurse into the Subquery?
+
+	case *BinaryExpr:
+		t.Left = WalkExpr(v, t.Left)
+		t.Right = WalkExpr(v, t.Right)
+
+	case *UnaryExpr:
+		t.Expr = WalkExpr(v, t.Expr)
+
+	case *FuncExpr:
+		for i := range t.Exprs {
+			t.Exprs[i] = WalkExpr(v, t.Exprs[i])
+		}
+
+	case *CaseExpr:
+		if t.Expr != nil {
+			t.Expr = WalkExpr(v, t.Expr)
+		}
+		for _, w := range t.Whens {
+			w.Cond = WalkExpr(v, w.Cond)
+			w.Val = WalkExpr(v, w.Val)
+		}
+		if t.Else != nil {
+			t.Else = WalkExpr(v, t.Else)
+		}
+
+	case *CastExpr:
+		t.Expr = WalkExpr(v, t.Expr)
+
+	default:
+		panic(fmt.Sprintf("unsupported expression type: %T", expr))
+	}
+
+	return expr
+}
+
+// Args defines the interface for retrieving arguments. Return false for the
+// second return value if the argument cannot be found.
+type Args interface {
+	Arg(i int) (Datum, bool)
+}
+
+type argVisitor struct {
+	args Args
+	err  error
+}
+
+var _ Visitor = &argVisitor{}
+
+func (v *argVisitor) Visit(expr Expr) Expr {
+	if v.err != nil {
+		return expr
+	}
+	placeholder, ok := expr.(ValArg)
+	if !ok {
+		return expr
+	}
+	d, found := v.args.Arg(int(placeholder))
+	if !found {
+		v.err = fmt.Errorf("arg %s not found", placeholder)
+		return expr
+	}
+	return d
+}
+
+// FillArgs replaces any placeholder nodes in the expression with arguments
+// supplied with the query.
+func FillArgs(expr Expr, args Args) (Expr, error) {
+	v := argVisitor{args: args}
+	expr = WalkExpr(&v, expr)
+	return expr, v.err
+}

--- a/sql/parser/walk_test.go
+++ b/sql/parser/walk_test.go
@@ -1,0 +1,117 @@
+// Copyright 2015 The Cockroach Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+// implied. See the License for the specific language governing
+// permissions and limitations under the License. See the AUTHORS file
+// for names of contributors.
+//
+// Author: Peter Mattis (peter@cockroachlabs.com)
+
+package parser
+
+import "testing"
+
+type mapArgs map[int]Datum
+
+func (m mapArgs) Arg(i int) (Datum, bool) {
+	d, ok := m[i]
+	return d, ok
+}
+
+// TestFillArgs tests both FillArgs and WalkExpr.
+func TestFillArgs(t *testing.T) {
+	testData := []struct {
+		expr     string
+		expected string
+		args     mapArgs
+	}{
+		{`$1`, `'a'`, mapArgs{1: DString(`a`)}},
+		{`($1, $1, $1)`, `('a', 'a', 'a')`, mapArgs{1: DString(`a`)}},
+		{`$1 & $2`, `1&2`, mapArgs{1: DInt(1), 2: DInt(2)}},
+		{`$1 | $2`, `1|2`, mapArgs{1: DInt(1), 2: DInt(2)}},
+		{`$1 # $2`, `1#2`, mapArgs{1: DInt(1), 2: DInt(2)}},
+		{`$1 + $2`, `1+2`, mapArgs{1: DInt(1), 2: DInt(2)}},
+		{`$1 - $2`, `1-2`, mapArgs{1: DInt(1), 2: DInt(2)}},
+		{`$1 * $2`, `1*2`, mapArgs{1: DInt(1), 2: DInt(2)}},
+		{`$1 % $2`, `1%2`, mapArgs{1: DInt(1), 2: DInt(2)}},
+		{`$1 / $2`, `1/2`, mapArgs{1: DInt(1), 2: DInt(2)}},
+		{`$1 / $2`, `1/2`, mapArgs{1: DInt(1), 2: DInt(2)}},
+		{`$1 + $2 + ($3 * $4)`, `1+2+(3*4)`,
+			mapArgs{1: DInt(1), 2: DInt(2), 3: DInt(3), 4: DInt(4)}},
+		{`$1 || $2`, `'a'||'b'`, mapArgs{1: DString("a"), 2: DString("b")}},
+		{`$1 OR $2`, `true OR false`, mapArgs{1: DBool(true), 2: DBool(false)}},
+		{`$1 AND $2`, `true AND false`, mapArgs{1: DBool(true), 2: DBool(false)}},
+		{`$1 = $2`, `1 = 2`, mapArgs{1: DInt(1), 2: DInt(2)}},
+		{`$1 != $2`, `1 != 2`, mapArgs{1: DInt(1), 2: DInt(2)}},
+		{`$1 <> $2`, `1 != 2`, mapArgs{1: DInt(1), 2: DInt(2)}},
+		{`$1 < $2`, `1 < 2`, mapArgs{1: DInt(1), 2: DInt(2)}},
+		{`$1 <= $2`, `1 <= 2`, mapArgs{1: DInt(1), 2: DInt(2)}},
+		{`$1 > $2`, `1 > 2`, mapArgs{1: DInt(1), 2: DInt(2)}},
+		{`$1 >= $2`, `1 >= 2`, mapArgs{1: DInt(1), 2: DInt(2)}},
+		{`$1 IS NULL`, `1 IS NULL`, mapArgs{1: DInt(1)}},
+		{`$1 IS NOT NULL`, `1 IS NOT NULL`, mapArgs{1: DInt(1)}},
+		{`$1 BETWEEN $2 AND $3`, `1 BETWEEN 2 AND 3`, mapArgs{1: DInt(1), 2: DInt(2), 3: DInt(3)}},
+		{`$1 NOT BETWEEN $2 AND $3`, `1 NOT BETWEEN 2 AND 3`,
+			mapArgs{1: DInt(1), 2: DInt(2), 3: DInt(3)}},
+		{`CASE WHEN $1 THEN $2 END`, `CASE WHEN 1 THEN 2 END`, mapArgs{1: DInt(1), 2: DInt(2)}},
+		{`CASE WHEN $1 THEN $2 ELSE $3 END`, `CASE WHEN 1 THEN 2 ELSE 3 END`,
+			mapArgs{1: DInt(1), 2: DInt(2), 3: DInt(3)}},
+		{`CASE $1 WHEN $2 THEN $3 ELSE $4 END`, `CASE 1 WHEN 2 THEN 3 ELSE 4 END`,
+			mapArgs{1: DInt(1), 2: DInt(2), 3: DInt(3), 4: DInt(4)}},
+		{`($1, $2) = ($3, $4)`, `(1, 2) = (3, 4)`,
+			mapArgs{1: DInt(1), 2: DInt(2), 3: DInt(3), 4: DInt(4)}},
+		{`$1 IN ($2, $3)`, `1 IN (2, 3)`,
+			mapArgs{1: DInt(1), 2: DInt(2), 3: DInt(3)}},
+		{`$1 NOT IN ($2, $3)`, `1 NOT IN (2, 3)`,
+			mapArgs{1: DInt(1), 2: DInt(2), 3: DInt(3)}},
+		{`length($1)`, `length('a')`, mapArgs{1: DString("a")}},
+		{`length($1, $2)`, `length('a', 'b')`, mapArgs{1: DString("a"), 2: DString("b")}},
+		{`CAST($1 AS INT)`, `CAST(1.1 AS INT)`, mapArgs{1: DFloat(1.1)}},
+	}
+
+	for _, d := range testData {
+		q, err := Parse("SELECT " + d.expr)
+		if err != nil {
+			t.Fatalf("%s: %v", d.expr, err)
+		}
+		expr := q[0].(*Select).Exprs[0].(*NonStarExpr).Expr
+		expr, err = FillArgs(expr, d.args)
+		if err != nil {
+			t.Fatalf("%s: %v", d.expr, err)
+		}
+		if s := expr.String(); d.expected != s {
+			t.Errorf("%s: expected %s, but found %s", d.expr, d.expected, s)
+		}
+	}
+}
+
+func TestFillArgsError(t *testing.T) {
+	testData := []struct {
+		expr     string
+		expected string
+		args     mapArgs
+	}{
+		{`$1`, `arg $1 not found`, mapArgs{}},
+		{`$2 AND $1`, `arg $2 not found`, mapArgs{}},
+	}
+	for _, d := range testData {
+		q, err := Parse("SELECT " + d.expr)
+		if err != nil {
+			t.Fatalf("%s: %v", d.expr, err)
+		}
+		expr := q[0].(*Select).Exprs[0].(*NonStarExpr).Expr
+		if _, err = FillArgs(expr, d.args); err == nil {
+			t.Fatalf("%s: expected failure, but found success", d.expr)
+		} else if d.expected != err.Error() {
+			t.Fatalf("%s: expected %s, but found %v", d.expr, d.expected, err)
+		}
+	}
+}

--- a/sql/set.go
+++ b/sql/set.go
@@ -39,7 +39,12 @@ func (p *planner) Set(n *parser.Set) (planNode, error) {
 		if err != nil {
 			return nil, err
 		}
-		p.session.Database = val.String()
+		if s, ok := val.(parser.DString); ok {
+			p.session.Database = string(s)
+		} else if !ok {
+			return nil, fmt.Errorf("database: requires a single string value: %s is a %s",
+				n.Values[0], val.Type())
+		}
 	default:
 		return nil, util.Errorf("unknown variable: %s", name)
 	}


### PR DESCRIPTION
WalkExpr walks over the nodes in an expression using a visitor
pattern. FillArgs utilizes WalkExpr to replace placeholder nodes with
argument values. Changed Datum to be an Expr in order to enable a simple
FillArgs implementation.

See #1616.
