### PR TITLE
show diff when `gofmt -s` complains

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -132,7 +132,7 @@ check:
 	  grep -vE '(\.pb\.go|embedded\.go|_string\.go|LastInsertId|sql/parser/(yaccpar|sql\.y):)' \
 	  # https://golang.org/pkg/database/sql/driver/#Result :(
 	@echo "gofmt (simplify)"
-	@! gofmt -s -l . 2>&1 | grep -vE '^\.git/'
+	@! gofmt -s -d -l . 2>&1 | grep -vE '^\.git/'
 	@echo "goimports"
 	@! goimports -l . | grep -vF 'No Exceptions'
 


### PR DESCRIPTION
example output:

```
$ make check
[...]
gofmt (simplify)
sql/parser/encode.go
diff sql/parser/encode.go gofmt/sql/parser/encode.go
--- [...]/gofmt611472593     2015-07-26 09:39:48.000000000 -0400
+++ [...]/gofmt340897276     2015-07-26 09:39:48.000000000 -0400
@@ -53,7 +53,7 @@
        if start == 0 {
                buf = append(buf, ') // begin xxx string if nothing was escaped
        }
-       buf = append(buf, in[start:len(in)]...)
+       buf = append(buf, in[start:]...)
        buf = append(buf, ')
        return buf
 }
make: *** [check] Error 1
```
