### PR TITLE
Add max results flag for scan command.

### DIFF
--- a/cli/cli_test.go
+++ b/cli/cli_test.go
@@ -230,3 +230,20 @@ func Example_logging() {
 	// kv --verbosity=0 scan
 	// kv --vmodule=foo=1 scan
 }
+
+func Example_max_results() {
+	c := newCLITest()
+
+	c.Run("kv put a 1 b 2 c 3 d 4")
+	c.Run("kv scan --max-results=3")
+	c.Run("quit")
+
+	// Output:
+	// kv put a 1 b 2 c 3 d 4
+	// kv scan --max-results=3
+	// "a"	"1"
+	// "b"	"2"
+	// "c"	"3"
+	// quit
+	// node drained and shutdown: ok
+}

--- a/cli/flags.go
+++ b/cli/flags.go
@@ -124,6 +124,9 @@ var flagUsage = map[string]string{
 
           --stores=hdd:7200rpm=/mnt/hda1,ssd=/mnt/ssd01,ssd=/mnt/ssd02,mem=1073741824.
 `,
+	"max-results": `
+        Define the maximum number of results that will be retrieved.
+`,
 }
 
 func normalizeStdFlagName(s string) string {
@@ -208,6 +211,12 @@ func initFlags(ctx *server.Context) {
 		f.StringVar(&ctx.Addr, "addr", ctx.Addr, flagUsage["addr"])
 		f.BoolVar(&ctx.Insecure, "insecure", ctx.Insecure, flagUsage["insecure"])
 		f.StringVar(&ctx.Certs, "certs", ctx.Certs, flagUsage["certs"])
+	}
+
+	{
+		// Max results flag for scan
+		f := scanCmd.Flags()
+		f.Int64Var(&maxResults, "max-results", defaultMaxResults, flagUsage["max-results"])
 	}
 }
 

--- a/cli/kv.go
+++ b/cli/kv.go
@@ -33,6 +33,10 @@ import (
 	"github.com/spf13/cobra"
 )
 
+const defaultMaxResults = 1000
+
+var maxResults int64
+
 var osExit = os.Exit
 var osStderr = os.Stderr
 
@@ -224,9 +228,7 @@ var scanCmd = &cobra.Command{
 Fetches and display the key/value pairs for a range. If no <start-key>
 is specified then all (non-system) key/value pairs are retrieved. If no
 <end-key> is specified then all keys greater than or equal to <start-key>
-are retrieved.
-
-Caveat: Currently only retrieves up to 1000 keys.
+are retrieved. 
 `,
 	Run: runScan,
 }
@@ -256,8 +258,7 @@ func runScan(cmd *cobra.Command, args []string) {
 	if kvDB == nil {
 		return
 	}
-	// TODO(pmattis): Add a flag for the number of results to scan.
-	rows, err := kvDB.Scan(startKey, endKey, 1000)
+	rows, err := kvDB.Scan(startKey, endKey, maxResults)
 	if err != nil {
 		fmt.Fprintf(osStderr, "scan failed: %s\n", err)
 		osExit(1)


### PR DESCRIPTION
Execute command: ./cockroach kv scan --help

```
Fetches and display the key/value pairs for a range. If no <start-key>
is specified then all (non-system) key/value pairs are retrieved. If no
<end-key> is specified then all keys greater than or equal to <start-key>
are retrieved.

Usage: 
  cockroach kv scan [options] [<start-key> [<end-key>]] [flags]

Flags:
  -h, --help=false: help for scan
      --max-results=1000: 
        Define the maximum number of results that will be retrieved.
```
