### PR TITLE
Use liner instead of ssh/terminal.

### DIFF
--- a/GLOCKFILE
+++ b/GLOCKFILE
@@ -28,6 +28,7 @@ github.com/kisielk/errcheck 76bf61ee4096ee72636739d4472186b5de5641db
 github.com/kisielk/gotool d678387370a2eb9b5b0a33218bc8c9d8de15b6be
 github.com/lib/pq a8d8d01c4f91602f876bf5aa210274e8203a6b45
 github.com/montanaflynn/stats 44fb56da2a2a67d394dec0e18a82dd316f192529
+github.com/peterh/liner 1bb0d1c1a25ed393d8feb09bab039b2b1b1fbced
 github.com/robfig/glock cb3c3ec56de988289cab7bbd284eddc04dfee6c9
 github.com/samalba/dockerclient 12570e600d71374233e5056ba315f657ced496c7
 github.com/spf13/cobra 66816bcd0378e248c613e3c443c020f544c28804

--- a/build/devbase/deps
+++ b/build/devbase/deps
@@ -17,6 +17,7 @@ github.com/julienschmidt/httprouter
 github.com/lib/pq
 github.com/lib/pq/oid
 github.com/montanaflynn/stats
+github.com/peterh/liner
 github.com/samalba/dockerclient
 github.com/spf13/cobra
 github.com/spf13/pflag


### PR DESCRIPTION
Simpler setup, still has history, ctrl-D, tab completion, etc..
Only change for now is that it ctrl-C abort the current line (it was
previously ignored entirely and the signal was not catchable).
