### PR TITLE
Pass sql user to DB operations: #1830

### DIFF
--- a/client/db.go
+++ b/client/db.go
@@ -237,13 +237,13 @@ func Open(addr string, opts ...Option) (*DB, error) {
 	return db, nil
 }
 
-// CopyWithNewUser constructs a new DB object from the current one.
+// CopyWithNewUser constructs a new DB object from an existing one.
 // It shares the sender and retry options, but allows a new user.
 // This changes the default "requested user", but does not change
 // the "authenticated user" in secure mode.
 // This is useful only when the authenticated user can act as multiple
 // users and needs to reuse clients (currently only true for the node user).
-func (db *DB) CopyWithNewUser(user string) *DB {
+func CopyWithNewUser(db *DB, user string) *DB {
 	newDB := &DB{}
 	*newDB = *db
 	newDB.user = user

--- a/client/db.go
+++ b/client/db.go
@@ -237,6 +237,19 @@ func Open(addr string, opts ...Option) (*DB, error) {
 	return db, nil
 }
 
+// CopyWithNewUser constructs a new DB object from the current one.
+// It shares the sender and retry options, but allows a new user.
+// This changes the default "requested user", but does not change
+// the "authenticated user" in secure mode.
+// This is useful only when the authenticated user can act as multiple
+// users and needs to reuse clients (currently only true for the node user).
+func (db *DB) CopyWithNewUser(user string) *DB {
+	newDB := &DB{}
+	*newDB = *db
+	newDB.user = user
+	return newDB
+}
+
 // NewBatch creates and returns a new empty batch object for use with the DB.
 func (db *DB) NewBatch() *Batch {
 	return &Batch{DB: db}

--- a/sql/driver/driver_test.go
+++ b/sql/driver/driver_test.go
@@ -559,16 +559,15 @@ func TestPermissions(t *testing.T) {
 	}
 
 	// Now try operations with "test-user". They should all fail.
-	// TODO: modify this test once permissions are applied properly.
-	if _, err := testUser.Exec(`CREATE DATABASE baz`); err != nil {
-		t.Fatal(err)
+	if _, err := testUser.Exec(`CREATE DATABASE baz`); err == nil {
+		t.Fatal("unexpected success")
 	}
-	if _, err := testUser.Exec(`CREATE TABLE baz.bar (k INT PRIMARY KEY, v INT)`); err != nil {
-		t.Fatal(err)
+	if _, err := testUser.Exec(`CREATE TABLE baz.bar (k INT PRIMARY KEY, v INT)`); err == nil {
+		t.Fatal("unexpected success")
 	}
 	// Insert into root's table.
-	if _, err := testUser.Exec(`INSERT INTO foo.bar VALUES (2, 3)`); err != nil {
-		t.Fatal(err)
+	if _, err := testUser.Exec(`INSERT INTO foo.bar VALUES (2, 3)`); err == nil {
+		t.Fatal("unexpected success")
 	}
 
 }

--- a/sql/driver/driver_test.go
+++ b/sql/driver/driver_test.go
@@ -533,3 +533,42 @@ func TestInsecure(t *testing.T) {
 		t.Fatal(err)
 	}
 }
+
+// TestPermissions is currently a negative test: permissions are not enforced.
+func TestPermissions(t *testing.T) {
+	defer leaktest.AfterTest(t)
+	s, db := setup(t)
+	defer cleanup(s, db)
+
+	testUser, err := sql.Open("cockroach", "https://test-user@"+s.ServingAddr()+"?certs=test_certs")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() {
+		_ = testUser.Close()
+	}()
+
+	if _, err := db.Exec(`CREATE DATABASE foo`); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := db.Exec(`CREATE TABLE foo.bar (k INT PRIMARY KEY, v INT)`); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := db.Exec(`INSERT INTO foo.bar VALUES (1, 2)`); err != nil {
+		t.Fatal(err)
+	}
+
+	// Now try operations with "test-user". They should all fail.
+	// TODO: modify this test once permissions are applied properly.
+	if _, err := testUser.Exec(`CREATE DATABASE baz`); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := testUser.Exec(`CREATE TABLE baz.bar (k INT PRIMARY KEY, v INT)`); err != nil {
+		t.Fatal(err)
+	}
+	// Insert into root's table.
+	if _, err := testUser.Exec(`INSERT INTO foo.bar VALUES (2, 3)`); err != nil {
+		t.Fatal(err)
+	}
+
+}

--- a/sql/server.go
+++ b/sql/server.go
@@ -128,7 +128,7 @@ func (s *Server) exec(req driver.Request) (driver.Response, error) {
 	// Pick up current session state, but override the user.
 	// The authentication hook already verified that GetUser returns something,
 	// even in insecure mode.
-	planner := planner{db: s.db.CopyWithNewUser(req.GetUser())}
+	planner := planner{db: client.CopyWithNewUser(s.db, req.GetUser())}
 	if req.Session != nil {
 		// TODO(tschottdorf) will have to validate the Session information (for
 		// instance, whether access to the stored database is permitted).

--- a/sql/server.go
+++ b/sql/server.go
@@ -125,8 +125,10 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 func (s *Server) exec(req driver.Request) (driver.Response, error) {
 	var resp driver.Response
 
-	// Pick up current session state.
-	planner := planner{db: s.db}
+	// Pick up current session state, but override the user.
+	// The authentication hook already verified that GetUser returns something,
+	// even in insecure mode.
+	planner := planner{db: s.db.CopyWithNewUser(req.GetUser())}
 	if req.Session != nil {
 		// TODO(tschottdorf) will have to validate the Session information (for
 		// instance, whether access to the stored database is permitted).


### PR DESCRIPTION
This test just shows that permissions are not currently enforced for the sql interface. See #1830 
