### PR TITLE
Normalize shell scripts to spaces rather than tabs

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -120,6 +120,8 @@ acceptance:
 
 .PHONY: check
 check:
+	@echo "checking for tabs in shell scripts"
+	@! git grep -F '	' -- '*.sh'
 	@echo "checking for \"path\" imports"
 	@! git grep -F '"path"' -- '*.go'
 	@echo "errcheck"

--- a/build/builder.sh
+++ b/build/builder.sh
@@ -44,7 +44,7 @@ if [ "${CIRCLECI:-}" = "true" ]; then
 else
     rm="--rm"
 fi
-	   
+
 tty=""
 if test -t 0; then
     tty="--tty"

--- a/build/circle-deps.sh
+++ b/build/circle-deps.sh
@@ -9,25 +9,25 @@ set -ex
 # the argument causing the commands in the if-branch to be executed
 # within the docker container.
 if [ "${1:-}" = "docker" ]; then
-    cmds=$(grep '^cmd' GLOCKFILE | grep -v glock | awk '{print $2}')
+  cmds=$(grep '^cmd' GLOCKFILE | grep -v glock | awk '{print $2}')
 
-    # Pretend we're already bootstrapped, so that `make` doesn't go
-    # through the bootstrap process which would glock sync and run
-    # build/devbase/deps.sh (unnecessarily).
-    touch .bootstrap
+  # Pretend we're already bootstrapped, so that `make` doesn't go
+  # through the bootstrap process which would glock sync and run
+  # build/devbase/deps.sh (unnecessarily).
+  touch .bootstrap
 
-    # Restore previously cached build artifacts.
-    time go install github.com/cockroachdb/build-cache
-    time build-cache restore . .:race,test ${cmds}
-    # Build everything needed by circle-test.sh.
-    time go test -race -v -i ./...
-    time go install -v ${cmds}
-    time make GITHOOKS= install
-    time (cd acceptance; go test -v -c -tags acceptance)
-    # Cache the current build artifacts for future builds.
-    time build-cache save . .:race,test ${cmds}
+  # Restore previously cached build artifacts.
+  time go install github.com/cockroachdb/build-cache
+  time build-cache restore . .:race,test ${cmds}
+  # Build everything needed by circle-test.sh.
+  time go test -race -v -i ./...
+  time go install -v ${cmds}
+  time make GITHOOKS= install
+  time (cd acceptance; go test -v -c -tags acceptance)
+  # Cache the current build artifacts for future builds.
+  time build-cache save . .:race,test ${cmds}
 
-    exit 0
+  exit 0
 fi
 
 gopath0="${GOPATH%%:*}"
@@ -43,18 +43,18 @@ du -sh "${cachedir}"
 ls -lh "${cachedir}"
 
 if ! docker images | grep -q "${tag}"; then
-    # If there's a base image cached, load it. A click on CircleCI's "Clear
-    # Cache" will make sure we start with a clean slate.
-    rm -f "$(ls ${cachedir}/builder*.tar 2>/dev/null | grep -v ${tag})"
-    builder="${cachedir}/builder.${tag}.tar"
-    if [[ ! -e "${builder}" ]]; then
-	time docker pull "cockroachdb/builder:${tag}"
-	docker tag -f "cockroachdb/builder:${tag}" "cockroachdb/builder:latest"
-	time docker save "cockroachdb/builder:${tag}" > "${builder}"
-    else
-	time docker load -i "${builder}"
-	docker tag -f "cockroachdb/builder:${tag}" "cockroachdb/builder:latest"
-    fi
+  # If there's a base image cached, load it. A click on CircleCI's "Clear
+  # Cache" will make sure we start with a clean slate.
+  rm -f "$(ls ${cachedir}/builder*.tar 2>/dev/null | grep -v ${tag})"
+  builder="${cachedir}/builder.${tag}.tar"
+  if [[ ! -e "${builder}" ]]; then
+    time docker pull "cockroachdb/builder:${tag}"
+    docker tag -f "cockroachdb/builder:${tag}" "cockroachdb/builder:latest"
+    time docker save "cockroachdb/builder:${tag}" > "${builder}"
+  else
+    time docker load -i "${builder}"
+    docker tag -f "cockroachdb/builder:${tag}" "cockroachdb/builder:latest"
+  fi
 fi
 
 # TODO(pmattis): This script differs from build/devbase/deps.sh. It

--- a/build/circle-test.sh
+++ b/build/circle-test.sh
@@ -4,12 +4,12 @@ set -e
 
 outdir="${TMPDIR}"
 if [ "${CIRCLE_ARTIFACTS}" != "" ]; then
-    outdir="${CIRCLE_ARTIFACTS}"
+  outdir="${CIRCLE_ARTIFACTS}"
 fi
 
 builder=$(dirname $0)/builder.sh
 
-# 1. Run "make check" to verify coding guidelines. 
+# 1. Run "make check" to verify coding guidelines.
 echo "make check"
 time ${builder} make GITHOOKS= check | tee "${outdir}/check.log"
 # Early exit on failure.
@@ -25,80 +25,81 @@ test ${PIPESTATUS[0]} -eq 0
 match='^panic|^[Gg]oroutine \d+|(read|write) by.*goroutine|DATA RACE'
 echo "make test"
 time ${builder} make GITHOOKS= test \
-     TESTFLAGS='-v --verbosity=1 --vmodule=monitor=2' | \
-     tr -d '\r' | tee "${outdir}/test.log" | \
-     grep -E "^\--- (PASS|FAIL)|^(FAIL|ok)|${match}" |
-     awk '{print "test:", $0}'
+  TESTFLAGS='-v --verbosity=1 --vmodule=monitor=2' | \
+  tr -d '\r' | tee "${outdir}/test.log" | \
+  grep -E "^\--- (PASS|FAIL)|^(FAIL|ok)|${match}" |
+  awk '{print "test:", $0}'
 test_status=${PIPESTATUS[0]}
 testrace_status=0
 
 # 4. Run "make testrace" only if "make test" succeeded.
 if [ ${test_status} -eq 0 ]; then
-    echo "make testrace"
-    time ${builder} make GITHOOKS= testrace \
-	 TESTFLAGS='-v --verbosity=1 --vmodule=monitor=2' | \
-	 tr -d '\r' | tee "${outdir}/testrace.log" | \
-	 grep -E "^\--- (PASS|FAIL)|^(FAIL|ok)|${match}" |
-	 awk '{print "race:", $0}'
+  echo "make testrace"
+  time ${builder} make GITHOOKS= testrace \
+    TESTFLAGS='-v --verbosity=1 --vmodule=monitor=2' | \
+    tr -d '\r' | tee "${outdir}/testrace.log" | \
+    grep -E "^\--- (PASS|FAIL)|^(FAIL|ok)|${match}" |
+    awk '{print "race:", $0}'
     testrace_status=${PIPESTATUS[0]}
 else
-    testrace_status=0
+  testrace_status=0
 fi
 
 # 5a. Translate the log output to xml to integrate with CircleCI
 # better.
 if [ "${CIRCLE_TEST_REPORTS}" != "" ]; then
-    if [ -f "${outdir}/test.log" ]; then
-	mkdir -p "${CIRCLE_TEST_REPORTS}/go"
-	${builder} go2xunit < "${outdir}/test.log" \
-	       > "${CIRCLE_TEST_REPORTS}/go/test.xml"
-    fi
-    if [ -f "${outdir}/testrace.log" ]; then
-	mkdir -p "${CIRCLE_TEST_REPORTS}/race"
-	${builder} go2xunit < "${outdir}/testrace.log" \
-	       > "${CIRCLE_TEST_REPORTS}/race/testrace.xml"
-    fi
+  if [ -f "${outdir}/test.log" ]; then
+    mkdir -p "${CIRCLE_TEST_REPORTS}/go"
+    ${builder} go2xunit < "${outdir}/test.log" \
+      > "${CIRCLE_TEST_REPORTS}/go/test.xml"
+  fi
+  if [ -f "${outdir}/testrace.log" ]; then
+    mkdir -p "${CIRCLE_TEST_REPORTS}/race"
+    ${builder} go2xunit < "${outdir}/testrace.log" \
+      > "${CIRCLE_TEST_REPORTS}/race/testrace.xml"
+  fi
 fi
 
 # 5b. Generate the slow test output.
 find "${outdir}" -name 'test*.log' -type f -exec \
-     grep -F ': Test' {} ';' | \
-     sed -E 's/(--- PASS: |\(|\))//g' | \
-     awk '{ print $2, $1 }' | sort -rn | head -n 10 \
-     > "${outdir}/slow.txt"
+  grep -F ': Test' {} ';' | \
+  sed -E 's/(--- PASS: |\(|\))//g' | \
+  awk '{ print $2, $1 }' | sort -rn | head -n 10 \
+  > "${outdir}/slow.txt"
 
 # 5c. Generate the excerpt output and fail if it is non-empty.
 find "${outdir}" -name 'test*.log' -type f -exec \
-     grep -B 5 -A 10 -E "^\-{0,3} *FAIL|${match}" {} ';' > "${outdir}/excerpt.txt"
+  grep -B 5 -A 10 -E "^\-{0,3} *FAIL|${match}" {} ';' > "${outdir}/excerpt.txt"
+
 if [ -s "${outdir}/excerpt.txt" -o ${test_status} -ne 0 -o ${testrace_status} -ne 0 ]; then
-    if [ ${test_status} -ne 0 ]; then
-	echo "FAIL: 'make test' exited with ${test_status}"
-    fi
-    if [ ${testrace_status} -ne 0 ]; then
-	echo "FAIL: 'make testrace' exited with ${testrace_status}"
-    fi
-    if [ -s "${outdir}/excerpt.txt" ]; then
-	echo "FAIL: excerpt.txt is not empty (${outdir}/excerpt.txt)"
-	echo
-	head -100 "${outdir}/excerpt.txt"
-    fi
+  if [ ${test_status} -ne 0 ]; then
+    echo "FAIL: 'make test' exited with ${test_status}"
+  fi
+  if [ ${testrace_status} -ne 0 ]; then
+    echo "FAIL: 'make testrace' exited with ${testrace_status}"
+  fi
+  if [ -s "${outdir}/excerpt.txt" ]; then
+    echo "FAIL: excerpt.txt is not empty (${outdir}/excerpt.txt)"
+    echo
+    head -100 "${outdir}/excerpt.txt"
+  fi
 
-    if [ "${CIRCLE_BRANCH}" = "master" ] && [ -n "${GITHUB_API_TOKEN}" ]; then
-        curl -X POST -H "Authorization: token ${GITHUB_API_TOKEN}" \
-             "https://api.github.com/repos/${CIRCLE_PROJECT_USERNAME}/${CIRCLE_PROJECT_REPONAME}/issues" \
-             -d "{ \"title\": \"Test failure in CI build ${CIRCLE_BUILD_NUM}\", \"body\": \"The following test appears to have failed:\n\n[#${CIRCLE_BUILD_NUM}](https://circleci.com/gh/${CIRCLE_PROJECT_USERNAME}/${CIRCLE_PROJECT_REPONAME}/${CIRCLE_BUILD_NUM}):\n\n\`\`\`\n$(python -c 'import json,sys; print json.dumps(sys.stdin.read()).strip("\"")' < ${outdir}/excerpt.txt)\n\`\`\`\nPlease assign, take a look and update the issue accordingly.\", \"labels\": [\"test-failure\"] }" > /dev/null
-        echo "Found test/race failures in test logs, see excerpt.log and the newly created issue on our issue tracker"
-    fi
+  if [ "${CIRCLE_BRANCH}" = "master" ] && [ -n "${GITHUB_API_TOKEN}" ]; then
+    curl -X POST -H "Authorization: token ${GITHUB_API_TOKEN}" \
+      "https://api.github.com/repos/${CIRCLE_PROJECT_USERNAME}/${CIRCLE_PROJECT_REPONAME}/issues" \
+      -d "{ \"title\": \"Test failure in CI build ${CIRCLE_BUILD_NUM}\", \"body\": \"The following test appears to have failed:\n\n[#${CIRCLE_BUILD_NUM}](https://circleci.com/gh/${CIRCLE_PROJECT_USERNAME}/${CIRCLE_PROJECT_REPONAME}/${CIRCLE_BUILD_NUM}):\n\n\`\`\`\n$(python -c 'import json,sys; print json.dumps(sys.stdin.read()).strip("\"")' < ${outdir}/excerpt.txt)\n\`\`\`\nPlease assign, take a look and update the issue accordingly.\", \"labels\": [\"test-failure\"] }" > /dev/null
+    echo "Found test/race failures in test logs, see excerpt.log and the newly created issue on our issue tracker"
+  fi
 
-    exit 1
+  exit 1
 fi
 
 # 6. Run the acceptance tests (only on Linux). We can run the
 # acceptance tests on the Mac's, but circle-deps.sh only built the
 # acceptance tests for Linux.
 if [ "$(uname)" = "Linux" ]; then
-    cd $(dirname $0)/../acceptance
-    time ./acceptance.test -test.v -test.timeout -5m
+  cd $(dirname $0)/../acceptance
+  time ./acceptance.test -test.v -test.timeout -5m
 else
-    echo "skipping acceptance tests on $(uname): use 'make acceptance' instead"
+  echo "skipping acceptance tests on $(uname): use 'make acceptance' instead"
 fi

--- a/build/init-docker.sh
+++ b/build/init-docker.sh
@@ -3,12 +3,12 @@
 set -eu
 
 if [ "${DOCKER_HOST:-}" = "" -a "$(uname)" = "Darwin" ]; then
-    if ! type -P "boot2docker" >& /dev/null; then
-	echo "boot2docker not found!"
-	exit 1
-    fi
-    echo "boot2docker shellinit # initializing DOCKER_* env variables"
-    eval $(boot2docker shellinit 2>/dev/null)
+  if ! type -P "boot2docker" >& /dev/null; then
+    echo "boot2docker not found!"
+    exit 1
+  fi
+  echo "boot2docker shellinit # initializing DOCKER_* env variables"
+  eval $(boot2docker shellinit 2>/dev/null)
 fi
 
 # Verify that Docker is installed.

--- a/build/push-docker-deploy.sh
+++ b/build/push-docker-deploy.sh
@@ -6,8 +6,8 @@ $(dirname $0)/build-docker-deploy.sh
 
 cd $(dirname $0)/../acceptance
 if [ -f ./acceptance.test ]; then
-    time ./acceptance.test -i cockroachdb/cockroach -b /cockroach/cockroach \
-	 -test.v -test.timeout -5m
+  time ./acceptance.test -i cockroachdb/cockroach -b /cockroach/cockroach \
+    -test.v -test.timeout -5m
 fi
 
 docker tag cockroachdb/cockroach:latest cockroachdb/cockroach:${VERSION}

--- a/util/leaktest/add-leaktest.sh
+++ b/util/leaktest/add-leaktest.sh
@@ -15,19 +15,19 @@
 set -eu
 
 sed -i'~' -e '
-    /^func Test.*(t \*testing.T) {/ {
-        # Skip past the test declaration
-        n
-        # If the next line does not call AfterTest, insert it.
-        /leaktest.AfterTest/! i\
-            defer leaktest.AfterTest(t)
-    }
+  /^func Test.*(t \*testing.T) {/ {
+    # Skip past the test declaration
+    n
+    # If the next line does not call AfterTest, insert it.
+    /leaktest.AfterTest/! i\
+      defer leaktest.AfterTest(t)
+  }
 ' $@
 
 for i in $@; do
-    if ! cmp -s $i $i~ ; then
-	# goimports will adjust indentation and add any necessary import.
-	goimports -w $i
-    fi
-    rm -f $i~
+  if ! cmp -s $i $i~ ; then
+    # goimports will adjust indentation and add any necessary import.
+    goimports -w $i
+  fi
+  rm -f $i~
 done


### PR DESCRIPTION
Tested with `ag --sh "\t"`.

@bdarnell removed this from #1833 
