### PR TITLE
Run all `go vet` checks.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -127,6 +127,9 @@ check:
 	@echo "errcheck"
 	@! errcheck -ignore 'bytes:Write.*,io:(Close|Write),net:Close,net/http:(Close|Write),net/rpc:Close,os:Close,database/sql:Close,github.com/spf13/cobra:Usage' $(PKG) | grep -vE 'yacc\.go:'
 	@echo "vet"
+	@! go tool vet . 2>&1 | \
+	  grep -vE '^vet: cannot process directory .git'
+	@echo "vet --shadow"
 	@! go tool vet --shadow . 2>&1 | \
 	  grep -vE '(declaration of err shadows|^vet: cannot process directory \.git)'
 	@echo "golint"

--- a/rpc/server_test.go
+++ b/rpc/server_test.go
@@ -74,7 +74,7 @@ func TestDuplicateRegistration(t *testing.T) {
 	s := NewServer(util.CreateTestAddr("tcp"), NewNodeTestContext(nil, stopper))
 	heartbeat := &Heartbeat{}
 	if err := s.Register("Foo.Bar", heartbeat.Ping, &proto.PingRequest{}); err != nil {
-		t.Fatalf("unexpected failure on first registration: %s", s)
+		t.Fatalf("unexpected failure on first registration: %s", err)
 	}
 	if err := s.Register("Foo.Bar", heartbeat.Ping, &proto.PingRequest{}); err == nil {
 		t.Fatalf("unexpected success on second registration")

--- a/server/status.go
+++ b/server/status.go
@@ -443,7 +443,7 @@ func (s *statusServer) handleLogsLocal(w http.ResponseWriter, r *http.Request, _
 	}
 	if maxEntries < 1 {
 		http.Error(w,
-			fmt.Sprintf("max: %s should be set to a value greater than 0", maxEntries),
+			fmt.Sprintf("max: %d should be set to a value greater than 0", maxEntries),
 			http.StatusBadRequest)
 		return
 	}

--- a/storage/client_merge_test.go
+++ b/storage/client_merge_test.go
@@ -116,13 +116,13 @@ func TestStoreRangeMergeWithData(t *testing.T) {
 	if reply, err := store.ExecuteCmd(context.Background(), &gArgs); err != nil {
 		t.Fatal(err)
 	} else if gReply := reply.(*proto.GetResponse); !bytes.Equal(gReply.Value.Bytes, content) {
-		t.Fatal("actual value %q did not match expected value %q", gReply.Value.Bytes, content)
+		t.Fatalf("actual value %q did not match expected value %q", gReply.Value.Bytes, content)
 	}
 	gArgs = getArgs([]byte("ccc"), bDesc.RaftID, store.StoreID())
 	if reply, err := store.ExecuteCmd(context.Background(), &gArgs); err != nil {
 		t.Fatal(err)
 	} else if gReply := reply.(*proto.GetResponse); !bytes.Equal(gReply.Value.Bytes, content) {
-		t.Fatal("actual value %q did not match expected value %q", gReply.Value.Bytes, content)
+		t.Fatalf("actual value %q did not match expected value %q", gReply.Value.Bytes, content)
 	}
 
 	// Merge the b range back into the a range.
@@ -157,13 +157,13 @@ func TestStoreRangeMergeWithData(t *testing.T) {
 	if reply, err := store.ExecuteCmd(context.Background(), &gArgs); err != nil {
 		t.Fatal(err)
 	} else if gReply := reply.(*proto.GetResponse); !bytes.Equal(gReply.Value.Bytes, content) {
-		t.Fatal("actual value %q did not match expected value %q", gReply.Value.Bytes, content)
+		t.Fatalf("actual value %q did not match expected value %q", gReply.Value.Bytes, content)
 	}
 	gArgs = getArgs([]byte("ccc"), rangeB.Desc().RaftID, store.StoreID())
 	if reply, err := store.ExecuteCmd(context.Background(), &gArgs); err != nil {
 		t.Fatal(err)
 	} else if gReply := reply.(*proto.GetResponse); !bytes.Equal(gReply.Value.Bytes, content) {
-		t.Fatal("actual value %q did not match expected value %q", gReply.Value.Bytes, content)
+		t.Fatalf("actual value %q did not match expected value %q", gReply.Value.Bytes, content)
 	}
 
 	// Put new values after the merge on both sides.
@@ -181,13 +181,13 @@ func TestStoreRangeMergeWithData(t *testing.T) {
 	if reply, err := store.ExecuteCmd(context.Background(), &gArgs); err != nil {
 		t.Fatal(err)
 	} else if gReply := reply.(*proto.GetResponse); !bytes.Equal(gReply.Value.Bytes, content) {
-		t.Fatal("actual value %q did not match expected value %q", gReply.Value.Bytes, content)
+		t.Fatalf("actual value %q did not match expected value %q", gReply.Value.Bytes, content)
 	}
 	gArgs = getArgs([]byte("cccc"), rangeA.Desc().RaftID, store.StoreID())
 	if reply, err := store.ExecuteCmd(context.Background(), &gArgs); err != nil {
 		t.Fatal(err)
 	} else if gReply := reply.(*proto.GetResponse); !bytes.Equal(gReply.Value.Bytes, content) {
-		t.Fatal("actual value %q did not match expected value %q", gReply.Value.Bytes, content)
+		t.Fatalf("actual value %q did not match expected value %q", gReply.Value.Bytes, content)
 	}
 }
 

--- a/storage/client_split_test.go
+++ b/storage/client_split_test.go
@@ -243,13 +243,13 @@ func TestStoreRangeSplit(t *testing.T) {
 	if reply, err := store.ExecuteCmd(context.Background(), &gArgs); err != nil {
 		t.Fatal(err)
 	} else if gReply := reply.(*proto.GetResponse); !bytes.Equal(gReply.Value.Bytes, content) {
-		t.Fatal("actual value %q did not match expected value %q", gReply.Value.Bytes, content)
+		t.Fatalf("actual value %q did not match expected value %q", gReply.Value.Bytes, content)
 	}
 	gArgs = getArgs([]byte("x"), newRng.Desc().RaftID, store.StoreID())
 	if reply, err := store.ExecuteCmd(context.Background(), &gArgs); err != nil {
 		t.Fatal(err)
 	} else if gReply := reply.(*proto.GetResponse); !bytes.Equal(gReply.Value.Bytes, content) {
-		t.Fatal("actual value %q did not match expected value %q", gReply.Value.Bytes, content)
+		t.Fatalf("actual value %q did not match expected value %q", gReply.Value.Bytes, content)
 	}
 
 	// Send out an increment request copied from above (same ClientCmdID) which

--- a/storage/range.go
+++ b/storage/range.go
@@ -796,7 +796,7 @@ func (r *Range) processRaftCommand(idKey cmdIDKey, index uint64, raftCmd proto.I
 	execDone()
 
 	if cmd != nil {
-		cmd.done <- proto.ResponseWithError{reply, err}
+		cmd.done <- proto.ResponseWithError{Reply: reply, Err: err}
 	} else if err != nil && log.V(1) {
 		log.Errorc(r.context(), "error executing raft command %s: %s", args.Method(), err)
 	}
@@ -921,7 +921,8 @@ func (r *Range) applyRaftCommandInBatch(ctx context.Context, index uint64, origi
 		if reply == nil {
 			reply = args.CreateReply()
 		}
-		if err := r.respCache.PutResponse(batch, args.Header().CmdID, proto.ResponseWithError{reply, rErr}); err != nil {
+		if err := r.respCache.PutResponse(batch, args.Header().CmdID,
+			proto.ResponseWithError{Reply: reply, Err: rErr}); err != nil {
 			log.Fatalc(ctx, "putting a response cache entry in a batch should never fail: %s", err)
 		}
 	}

--- a/storage/range_test.go
+++ b/storage/range_test.go
@@ -1529,7 +1529,8 @@ func TestRangeResponseCacheStoredError(t *testing.T) {
 	pastReply := proto.IncrementResponse{}
 	pastError := errors.New("boom")
 	var expError error = &proto.Error{Message: pastError.Error()}
-	_ = tc.rng.respCache.PutResponse(tc.engine, cmdID, proto.ResponseWithError{&pastReply, pastError})
+	_ = tc.rng.respCache.PutResponse(tc.engine, cmdID,
+		proto.ResponseWithError{Reply: &pastReply, Err: pastError})
 
 	args := incrementArgs([]byte("a"), 1, 1, tc.store.StoreID())
 	args.CmdID = cmdID

--- a/storage/response_cache.go
+++ b/storage/response_cache.go
@@ -94,7 +94,7 @@ func (rc *ResponseCache) GetResponse(e engine.Engine, cmdID proto.ClientCmdID) (
 		resp := rwResp.GetValue().(proto.Response)
 		header := resp.Header()
 		defer func() { header.Error = nil }()
-		return proto.ResponseWithError{resp, header.GoError()}, nil
+		return proto.ResponseWithError{Reply: resp, Err: header.GoError()}, nil
 	}
 	return proto.ResponseWithError{}, nil
 }

--- a/storage/response_cache_test.go
+++ b/storage/response_cache_test.go
@@ -56,7 +56,7 @@ func TestResponseCachePutGetClearData(t *testing.T) {
 		t.Fatalf("unxpected read error :%s", readErr)
 	}
 	// Put value of 1 for test response.
-	if err := rc.PutResponse(e, cmdID, proto.ResponseWithError{&incR, nil}); err != nil {
+	if err := rc.PutResponse(e, cmdID, proto.ResponseWithError{Reply: &incR, Err: nil}); err != nil {
 		t.Errorf("unexpected error putting response: %s", err)
 	}
 	// Get should now return 1.
@@ -83,7 +83,7 @@ func TestResponseCacheEmptyCmdID(t *testing.T) {
 	rc, e := createTestResponseCache(t, 1)
 	cmdID := proto.ClientCmdID{}
 	// Put value of 1 for test response.
-	if err := rc.PutResponse(e, cmdID, proto.ResponseWithError{&incR, nil}); err != nil {
+	if err := rc.PutResponse(e, cmdID, proto.ResponseWithError{Reply: &incR, Err: nil}); err != nil {
 		t.Errorf("unexpected error putting response: %s", err)
 	}
 	// Get should return !ok.
@@ -102,7 +102,7 @@ func TestResponseCacheCopyInto(t *testing.T) {
 	rc2, _ := createTestResponseCache(t, 2)
 	cmdID := makeCmdID(1, 1)
 	// Store an increment with new value one in the first cache.
-	if err := rc1.PutResponse(e, cmdID, proto.ResponseWithError{&incR, nil}); err != nil {
+	if err := rc1.PutResponse(e, cmdID, proto.ResponseWithError{Reply: &incR, Err: nil}); err != nil {
 		t.Errorf("unexpected error putting response: %s", err)
 	}
 	// Copy the first cache into the second.
@@ -130,7 +130,7 @@ func TestResponseCacheCopyFrom(t *testing.T) {
 	rc2, _ := createTestResponseCache(t, 2)
 	cmdID := makeCmdID(1, 1)
 	// Store an increment with new value one in the first cache.
-	if err := rc1.PutResponse(e, cmdID, proto.ResponseWithError{&incR, nil}); err != nil {
+	if err := rc1.PutResponse(e, cmdID, proto.ResponseWithError{Reply: &incR, Err: nil}); err != nil {
 		t.Errorf("unexpected error putting response: %s", err)
 	}
 
@@ -216,7 +216,7 @@ func TestResponseCacheShouldCache(t *testing.T) {
 	reply := proto.PutResponse{}
 
 	for i, test := range testCases {
-		if shouldCache := rc.shouldCacheResponse(proto.ResponseWithError{&reply, test.err}); shouldCache != test.shouldCache {
+		if shouldCache := rc.shouldCacheResponse(proto.ResponseWithError{Reply: &reply, Err: test.err}); shouldCache != test.shouldCache {
 			t.Errorf("%d: expected cache? %t; got %t", i, test.shouldCache, shouldCache)
 		}
 	}
@@ -235,7 +235,7 @@ func TestResponseCacheGC(t *testing.T) {
 	// Add response for cmdID with timestamp at time=1ns.
 	copyIncR := incR
 	copyIncR.Timestamp.WallTime = 1
-	if err := rc.PutResponse(eng, cmdID, proto.ResponseWithError{&copyIncR, nil}); err != nil {
+	if err := rc.PutResponse(eng, cmdID, proto.ResponseWithError{Reply: &copyIncR, Err: nil}); err != nil {
 		t.Fatalf("unexpected error putting responpse: %s", err)
 	}
 	eng.SetGCTimeouts(0, 0) // avoids GC


### PR DESCRIPTION
`go vet` with a flag like `--shadow` only runs checks that are
explicitly requested; the `--all` flag is ignored in this case.
Run `go vet` twice, once with `--shadow` and once with the
default (`--all`), and fix up all issues this found.
