### PR TITLE
Use `trap` to generate post-build artifacts

### DIFF
--- a/acceptance/run.sh
+++ b/acceptance/run.sh
@@ -2,8 +2,8 @@
 
 set -eu
 
-cd $(dirname $0)/..
-source build/init-docker.sh
-build/builder.sh make install
+source $(dirname $0)/../build/init-docker.sh
+$(dirname $0)/../build/builder.sh make install
+
 set -x
-go test -v -tags acceptance ./acceptance ${GOFLAGS:-} -run "${TESTS:-.*}" -timeout ${TESTTIMEOUT:-5m} ${TESTFLAGS:-}
+go test -tags acceptance ./acceptance ${GOFLAGS-} -run "${TESTS-.*}" -timeout ${TESTTIMEOUT-5m} ${TESTFLAGS-}

--- a/build/build-docker-deploy.sh
+++ b/build/build-docker-deploy.sh
@@ -11,7 +11,7 @@ set -euo pipefail
 # itself inside of docker passing "docker" as the argument causing the
 # commands in the if-branch to be executed within the docker
 # container.
-if [ "${1:-}" = "docker" ]; then
+if [ "${1-}" = "docker" ]; then
     time make STATIC=1 release
 
     # Make sure the created binary is statically linked.  Seems

--- a/build/builder.sh
+++ b/build/builder.sh
@@ -5,7 +5,7 @@ set -eu
 image="cockroachdb/builder"
 
 function init() {
-    docker build --tag="${image}" - <<EOF
+  docker build --tag="${image}" - <<EOF
 FROM golang:1.4.2
 
 RUN apt-get update -y && \
@@ -21,39 +21,38 @@ CMD ["/bin/bash"]
 EOF
 }
 
-if [ "${1:-}" = "init" ]; then
-    init
-    exit 0
+if [ "${1-}" = "init" ]; then
+  init
+  exit 0
 fi
 
-if [ "${1:-}" = "push" ]; then
-    init
-    tag="$(date +%Y%m%d-%H%M%S)"
-    docker tag "${image}" "${image}:${tag}"
-    docker push "${image}:${tag}"
-    exit 0
+if [ "${1-}" = "push" ]; then
+  init
+  tag="$(date +%Y%m%d-%H%M%S)"
+  docker tag "${image}" "${image}:${tag}"
+  docker push "${image}:${tag}"
+  exit 0
 fi
 
 gopath0="${GOPATH%%:*}"
 
-if [ "${CIRCLECI:-}" = "true" ]; then
-    # HACK: Removal of docker containers fails on circleci with the
-    # error: "Driver btrfs failed to remove root filesystem". So if
-    # we're running on circleci, just leave the containers around.
-    rm=""
+if [ "${CIRCLECI-}" = "true" ]; then
+  # HACK: Removal of docker containers fails on circleci with the
+  # error: "Driver btrfs failed to remove root filesystem". So if
+  # we're running on circleci, just leave the containers around.
+  rm=""
 else
-    rm="--rm"
+  rm="--rm"
 fi
 
-tty=""
-if test -t 0; then
-    tty="--tty"
+if [ -t 0 ]; then
+  tty="--tty"
 fi
 
 # Run our build container with a set of volumes mounted that will
 # allow the container to store persistent build data on the host
 # computer.
-docker run -i ${tty} ${rm} \
+docker run -i ${tty-} ${rm} \
   --volume="${gopath0}/src:/go/src" \
   --volume="${PWD}:/go/src/github.com/cockroachdb/cockroach" \
   --volume="${gopath0}/pkg:/go/pkg" \

--- a/build/circle-deps.sh
+++ b/build/circle-deps.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-set -ex
+set -eux
 
 # This is mildly tricky: This script runs itself recursively. The
 # first time it is run it does not take the if-branch below and
@@ -8,7 +8,7 @@ set -ex
 # builder.sh script to run itself inside of docker passing "docker" as
 # the argument causing the commands in the if-branch to be executed
 # within the docker container.
-if [ "${1:-}" = "docker" ]; then
+if [ "${1-}" = "docker" ]; then
   cmds=$(grep '^cmd' GLOCKFILE | grep -v glock | awk '{print $2}')
 
   # Pretend we're already bootstrapped, so that `make` doesn't go

--- a/build/circle-deps.sh
+++ b/build/circle-deps.sh
@@ -23,7 +23,7 @@ if [ "${1-}" = "docker" ]; then
   time go test -race -v -i ./...
   time go install -v ${cmds}
   time make GITHOOKS= install
-  time (cd acceptance; go test -v -c -tags acceptance)
+  time go test -v -c -tags acceptance ./acceptance
   # Cache the current build artifacts for future builds.
   time build-cache save . .:race,test ${cmds}
 

--- a/build/circle-test.sh
+++ b/build/circle-test.sh
@@ -1,105 +1,101 @@
 #!/bin/bash
 
-set -e
+set -euo pipefail
 
-outdir="${TMPDIR}"
-if [ "${CIRCLE_ARTIFACTS}" != "" ]; then
+if [ -n "${CIRCLE_ARTIFACTS-}" ]; then
   outdir="${CIRCLE_ARTIFACTS}"
+elif [ -n "${TMPDIR-}" ]; then
+  outdir="${TMPDIR}"
+else
+  outdir=""
 fi
 
 builder=$(dirname $0)/builder.sh
+match='^panic|^[Gg]oroutine \d+|(read|write) by.*goroutine|DATA RACE'
+
+prepare_artifacts() {
+  ret=$?
+
+  # Translate the log output to xml to integrate with CircleCI
+  # better.
+  if [ -n "${CIRCLE_TEST_REPORTS-}" ]; then
+    if [ -f "${outdir}/test.log" ]; then
+      mkdir -p "${CIRCLE_TEST_REPORTS}/test"
+      ${builder} go2xunit < "${outdir}/test.log" \
+        > "${CIRCLE_TEST_REPORTS}/test/test.xml"
+    fi
+    if [ -f "${outdir}/testrace.log" ]; then
+      mkdir -p "${CIRCLE_TEST_REPORTS}/race"
+      ${builder} go2xunit < "${outdir}/testrace.log" \
+        > "${CIRCLE_TEST_REPORTS}/race/testrace.xml"
+    fi
+  fi
+
+  # Generate the slow test output.
+  # We use `tail` below (instead of `sort -r | head` ) to work around
+  # the fact that `set -o pipefail` doesn't like it if `sort` exits
+  # with a SIGPIPE error code (which piping to `head` can cause).
+  find "${outdir}" -name 'test*.log' -type f -exec \
+    grep -F ': Test' {} ';' | \
+    sed -E 's/(--- PASS: |\(|\))//g' | \
+    awk '{ print $2, $1 }' | sort -n | tail -n 10 \
+    > "${outdir}/slow.txt"
+
+  # Generate the excerpt output and fail if it is non-empty.
+  find "${outdir}" -name 'test*.log' -type f -exec \
+    grep -B 5 -A 10 -E "^\-{0,3} *FAIL|${match}" {} ';' > "${outdir}/excerpt.txt"
+
+  if [ -s "${outdir}/excerpt.txt" ]; then
+    ret=1
+
+    echo "FAIL: excerpt.txt is not empty (${outdir}/excerpt.txt)"
+    echo
+    head -n 100 "${outdir}/excerpt.txt"
+  fi
+
+  if [ $ret -ne 0 ]; then
+    if [ "${CIRCLE_BRANCH-}" = "master" ] && [ -n "${GITHUB_API_TOKEN-}" ]; then
+      curl -X POST -H "Authorization: token ${GITHUB_API_TOKEN}" \
+        "https://api.github.com/repos/${CIRCLE_PROJECT_USERNAME}/${CIRCLE_PROJECT_REPONAME}/issues" \
+        -d "{ \"title\": \"Test failure in CI build ${CIRCLE_BUILD_NUM}\", \"body\": \"The following test appears to have failed:\n\n[#${CIRCLE_BUILD_NUM}](https://circleci.com/gh/${CIRCLE_PROJECT_USERNAME}/${CIRCLE_PROJECT_REPONAME}/${CIRCLE_BUILD_NUM}):\n\n\`\`\`\n$(python -c 'import json,sys; print json.dumps(sys.stdin.read()).strip("\"")' < ${outdir}/excerpt.txt)\n\`\`\`\nPlease assign, take a look and update the issue accordingly.\", \"labels\": [\"test-failure\"] }" > /dev/null
+      echo "Found test/race failures in test logs, see excerpt.log and the newly created issue on our issue tracker"
+    fi
+
+    exit $ret
+  fi
+}
+
+trap prepare_artifacts EXIT
 
 # 1. Run "make check" to verify coding guidelines.
 echo "make check"
 time ${builder} make GITHOOKS= check | tee "${outdir}/check.log"
-# Early exit on failure.
-test ${PIPESTATUS[0]} -eq 0
 
 # 2. Verify that "go generate" was run.
 echo "verifying generated files"
 time ${builder} /bin/bash -c "(go generate ./... && git ls-files --modified --deleted --others --exclude-standard | diff /dev/null -) || (git add -A && git diff -u HEAD && false)" | tee "${outdir}/generate.log"
-# Early exit on failure.
-test ${PIPESTATUS[0]} -eq 0
 
 # 3. Run "make test".
-match='^panic|^[Gg]oroutine \d+|(read|write) by.*goroutine|DATA RACE'
 echo "make test"
 time ${builder} make GITHOOKS= test \
   TESTFLAGS='-v --verbosity=1 --vmodule=monitor=2' | \
   tr -d '\r' | tee "${outdir}/test.log" | \
   grep -E "^\--- (PASS|FAIL)|^(FAIL|ok)|${match}" |
   awk '{print "test:", $0}'
-test_status=${PIPESTATUS[0]}
-testrace_status=0
 
-# 4. Run "make testrace" only if "make test" succeeded.
-if [ ${test_status} -eq 0 ]; then
-  echo "make testrace"
-  time ${builder} make GITHOOKS= testrace \
-    TESTFLAGS='-v --verbosity=1 --vmodule=monitor=2' | \
-    tr -d '\r' | tee "${outdir}/testrace.log" | \
-    grep -E "^\--- (PASS|FAIL)|^(FAIL|ok)|${match}" |
-    awk '{print "race:", $0}'
-    testrace_status=${PIPESTATUS[0]}
-else
-  testrace_status=0
-fi
+# 4. Run "make testrace".
+echo "make testrace"
+time ${builder} make GITHOOKS= testrace \
+  TESTFLAGS='-v --verbosity=1 --vmodule=monitor=2' | \
+  tr -d '\r' | tee "${outdir}/testrace.log" | \
+  grep -E "^\--- (PASS|FAIL)|^(FAIL|ok)|${match}" |
+  awk '{print "race:", $0}'
 
-# 5a. Translate the log output to xml to integrate with CircleCI
-# better.
-if [ "${CIRCLE_TEST_REPORTS}" != "" ]; then
-  if [ -f "${outdir}/test.log" ]; then
-    mkdir -p "${CIRCLE_TEST_REPORTS}/go"
-    ${builder} go2xunit < "${outdir}/test.log" \
-      > "${CIRCLE_TEST_REPORTS}/go/test.xml"
-  fi
-  if [ -f "${outdir}/testrace.log" ]; then
-    mkdir -p "${CIRCLE_TEST_REPORTS}/race"
-    ${builder} go2xunit < "${outdir}/testrace.log" \
-      > "${CIRCLE_TEST_REPORTS}/race/testrace.xml"
-  fi
-fi
-
-# 5b. Generate the slow test output.
-find "${outdir}" -name 'test*.log' -type f -exec \
-  grep -F ': Test' {} ';' | \
-  sed -E 's/(--- PASS: |\(|\))//g' | \
-  awk '{ print $2, $1 }' | sort -rn | head -n 10 \
-  > "${outdir}/slow.txt"
-
-# 5c. Generate the excerpt output and fail if it is non-empty.
-find "${outdir}" -name 'test*.log' -type f -exec \
-  grep -B 5 -A 10 -E "^\-{0,3} *FAIL|${match}" {} ';' > "${outdir}/excerpt.txt"
-
-if [ -s "${outdir}/excerpt.txt" -o ${test_status} -ne 0 -o ${testrace_status} -ne 0 ]; then
-  if [ ${test_status} -ne 0 ]; then
-    echo "FAIL: 'make test' exited with ${test_status}"
-  fi
-  if [ ${testrace_status} -ne 0 ]; then
-    echo "FAIL: 'make testrace' exited with ${testrace_status}"
-  fi
-  if [ -s "${outdir}/excerpt.txt" ]; then
-    echo "FAIL: excerpt.txt is not empty (${outdir}/excerpt.txt)"
-    echo
-    head -100 "${outdir}/excerpt.txt"
-  fi
-
-  if [ "${CIRCLE_BRANCH}" = "master" ] && [ -n "${GITHUB_API_TOKEN}" ]; then
-    curl -X POST -H "Authorization: token ${GITHUB_API_TOKEN}" \
-      "https://api.github.com/repos/${CIRCLE_PROJECT_USERNAME}/${CIRCLE_PROJECT_REPONAME}/issues" \
-      -d "{ \"title\": \"Test failure in CI build ${CIRCLE_BUILD_NUM}\", \"body\": \"The following test appears to have failed:\n\n[#${CIRCLE_BUILD_NUM}](https://circleci.com/gh/${CIRCLE_PROJECT_USERNAME}/${CIRCLE_PROJECT_REPONAME}/${CIRCLE_BUILD_NUM}):\n\n\`\`\`\n$(python -c 'import json,sys; print json.dumps(sys.stdin.read()).strip("\"")' < ${outdir}/excerpt.txt)\n\`\`\`\nPlease assign, take a look and update the issue accordingly.\", \"labels\": [\"test-failure\"] }" > /dev/null
-    echo "Found test/race failures in test logs, see excerpt.log and the newly created issue on our issue tracker"
-  fi
-
-  exit 1
-fi
-
-# 6. Run the acceptance tests (only on Linux). We can run the
+# 5. Run the acceptance tests (only on Linux). We can run the
 # acceptance tests on the Mac's, but circle-deps.sh only built the
 # acceptance tests for Linux.
 if [ "$(uname)" = "Linux" ]; then
-  cd $(dirname $0)/../acceptance
-  time ./acceptance.test -test.v -test.timeout -5m
+  time $(dirname $0)/../acceptance.test -test.v -test.timeout 5m
 else
   echo "skipping acceptance tests on $(uname): use 'make acceptance' instead"
 fi

--- a/build/deploy/cockroach.sh
+++ b/build/deploy/cockroach.sh
@@ -2,7 +2,7 @@
 
 set -eu
 
-if [ "${1:-}" = "shell" ]; then
+if [ "${1-}" = "shell" ]; then
   shift
   /bin/sh "$@"
 else

--- a/build/init-docker.sh
+++ b/build/init-docker.sh
@@ -2,7 +2,7 @@
 
 set -eu
 
-if [ "${DOCKER_HOST:-}" = "" -a "$(uname)" = "Darwin" ]; then
+if [ "${DOCKER_HOST-}" = "" -a "$(uname)" = "Darwin" ]; then
   if ! type -P "boot2docker" >& /dev/null; then
     echo "boot2docker not found!"
     exit 1


### PR DESCRIPTION
Use trap to do all the at-exit work.
