### PR TITLE
Add database descriptor.

### DIFF
--- a/sql/create_test.go
+++ b/sql/create_test.go
@@ -1,0 +1,128 @@
+// Copyright 2015 The Cockroach Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+// implied. See the License for the specific language governing
+// permissions and limitations under the License. See the AUTHORS file
+// for names of contributors.
+//
+// Author: Marc Berhault (marc@cockroachlabs.com)
+
+package sql_test
+
+import (
+	"database/sql"
+	"testing"
+
+	"github.com/cockroachdb/cockroach/client"
+	"github.com/cockroachdb/cockroach/keys"
+	"github.com/cockroachdb/cockroach/server"
+	"github.com/cockroachdb/cockroach/structured"
+	"github.com/cockroachdb/cockroach/util/leaktest"
+)
+
+func setup(t *testing.T) (*server.TestServer, *sql.DB, *client.DB) {
+	s := server.StartTestServer(nil)
+	sqlDB, err := sql.Open("cockroach", "https://root@"+s.ServingAddr()+"?certs=test_certs")
+	if err != nil {
+		t.Fatal(err)
+	}
+	kvDB, err := client.Open("https://root@" + s.ServingAddr() + "?certs=test_certs")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	return s, sqlDB, kvDB
+}
+
+func cleanup(s *server.TestServer, db *sql.DB) {
+	_ = db.Close()
+	s.Stop()
+}
+
+func TestDatabaseDescriptor(t *testing.T) {
+	defer leaktest.AfterTest(t)
+	s, sqlDB, kvDB := setup(t)
+	defer cleanup(s, sqlDB)
+
+	// The first `MaxReservedDescID` (plus 0) are set aside.
+	expectedCounter := int64(structured.MaxReservedDescID + 1)
+
+	// Test values before creating the database.
+	// descriptor ID counter.
+	if ir, err := kvDB.Get(keys.DescIDGenerator); err != nil {
+		t.Fatal(err)
+	} else if ir.ValueInt() != expectedCounter {
+		t.Fatalf("expected descriptor ID == %d, got %d", expectedCounter, ir.ValueInt())
+	}
+
+	// Database name.
+	nameKey := keys.MakeNameMetadataKey(structured.RootNamespaceID, "test")
+	if gr, err := kvDB.Get(nameKey); err != nil {
+		t.Fatal(err)
+	} else if gr.Exists() {
+		t.Fatal("expected non-existing key")
+	}
+
+	if _, err := sqlDB.Exec(`CREATE DATABASE test`); err != nil {
+		t.Fatal(err)
+	}
+	expectedCounter++
+
+	// Check keys again.
+	// descriptor ID counter.
+	if ir, err := kvDB.Get(keys.DescIDGenerator); err != nil {
+		t.Fatal(err)
+	} else if ir.ValueInt() != expectedCounter {
+		t.Fatalf("expected descriptor ID == %d, got %d", expectedCounter, ir.ValueInt())
+	}
+
+	// Database name.
+	if gr, err := kvDB.Get(nameKey); err != nil {
+		t.Fatal(err)
+	} else if !gr.Exists() {
+		t.Fatal("key is missing")
+	}
+
+	// database descriptor.
+	descKey := keys.MakeDescMetadataKey(uint32(expectedCounter - 1))
+	if gr, err := kvDB.Get(descKey); err != nil {
+		t.Fatal(err)
+	} else if !gr.Exists() {
+		t.Fatal("key is missing")
+	}
+
+	// Now try to create it again. We should fail, but not increment the counter.
+	if _, err := sqlDB.Exec(`CREATE DATABASE test`); err == nil {
+		t.Fatal("failure expected")
+	}
+
+	// Check keys again.
+	// descriptor ID counter.
+	if ir, err := kvDB.Get(keys.DescIDGenerator); err != nil {
+		t.Fatal(err)
+	} else if ir.ValueInt() != expectedCounter {
+		t.Fatalf("expected descriptor ID == %d, got %d", expectedCounter, ir.ValueInt())
+	}
+
+	// Database name.
+	if gr, err := kvDB.Get(nameKey); err != nil {
+		t.Fatal(err)
+	} else if !gr.Exists() {
+		t.Fatal("key is missing")
+	}
+
+	// database descriptor.
+	if gr, err := kvDB.Get(descKey); err != nil {
+		t.Fatal(err)
+	} else if !gr.Exists() {
+		t.Fatal("key is missing")
+	}
+}

--- a/sql/database.go
+++ b/sql/database.go
@@ -1,0 +1,43 @@
+// Copyright 2015 The Cockroach Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+// implied. See the License for the specific language governing
+// permissions and limitations under the License. See the AUTHORS file
+// for names of contributors.
+//
+// Author: Marc Berhault (marc@cockroachlabs.com)
+
+package sql
+
+import (
+	"github.com/cockroachdb/cockroach/keys"
+	"github.com/cockroachdb/cockroach/security"
+	"github.com/cockroachdb/cockroach/sql/parser"
+	"github.com/cockroachdb/cockroach/structured"
+)
+
+func makeDatabaseDesc(p *parser.CreateDatabase) structured.DatabaseDescriptor {
+	return structured.DatabaseDescriptor{
+		Name:  p.Name.String(),
+		Read:  []string{security.RootUser},
+		Write: []string{security.RootUser},
+	}
+}
+
+// getDatabaseDesc looks up the database descriptor given its name.
+func (p *planner) getDatabaseDesc(name string) (*structured.DatabaseDescriptor, error) {
+	nameKey := keys.MakeNameMetadataKey(structured.RootNamespaceID, name)
+	desc := structured.DatabaseDescriptor{}
+	if err := p.getDescriptor(nameKey, &desc); err != nil {
+		return nil, err
+	}
+	return &desc, nil
+}

--- a/sql/database_test.go
+++ b/sql/database_test.go
@@ -1,0 +1,49 @@
+// Copyright 2015 The Cockroach Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+// implied. See the License for the specific language governing
+// permissions and limitations under the License. See the AUTHORS file
+// for names of contributors.
+//
+// Author: Marc Berhault (marc@cockroachlabs.com)
+
+package sql
+
+import (
+	"testing"
+
+	"github.com/cockroachdb/cockroach/security"
+	"github.com/cockroachdb/cockroach/sql/parser"
+	"github.com/cockroachdb/cockroach/util/leaktest"
+)
+
+func TestMakeDatabaseDesc(t *testing.T) {
+	defer leaktest.AfterTest(t)
+
+	stmt, err := parser.Parse("CREATE DATABASE test")
+	if err != nil {
+		t.Fatal(err)
+	}
+	desc := makeDatabaseDesc(stmt[0].(*parser.CreateDatabase))
+	if desc.Name != "test" {
+		t.Fatalf("expected Name == test, got %s", desc.Name)
+	}
+	// ID is not set yet.
+	if desc.ID != 0 {
+		t.Fatalf("expected ID == 0, got %d", desc.ID)
+	}
+	if len(desc.Read) != 1 || desc.Read[0] != security.RootUser {
+		t.Fatalf("expected read == [root], got: %v", desc.Read)
+	}
+	if len(desc.Write) != 1 || desc.Write[0] != security.RootUser {
+		t.Fatalf("expected write == [root], got: %v", desc.Write)
+	}
+}

--- a/sql/descriptor.go
+++ b/sql/descriptor.go
@@ -1,0 +1,93 @@
+// Copyright 2015 The Cockroach Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+// implied. See the License for the specific language governing
+// permissions and limitations under the License. See the AUTHORS file
+// for names of contributors.
+//
+// Author: Marc Berhault (marc@cockroachlabs.com)
+
+package sql
+
+import (
+	"fmt"
+
+	"github.com/cockroachdb/cockroach/client"
+	"github.com/cockroachdb/cockroach/keys"
+	"github.com/cockroachdb/cockroach/proto"
+	gogoproto "github.com/gogo/protobuf/proto"
+)
+
+// descriptorProto is the interface needed by writeDescriptor and getDescriptor.
+type descriptorProto interface {
+	gogoproto.Message
+	GetID() uint32
+	SetID(uint32)
+	Validate() error
+}
+
+// writeDescriptor takes a Table or Database descriptor and writes it
+// if needed, incrementing the descriptor counter.
+func (p *planner) writeDescriptor(key proto.Key, descriptor descriptorProto, ifNotExists bool) error {
+	// Check whether key exists.
+	gr, err := p.db.Get(key)
+	if err != nil {
+		return err
+	}
+
+	if gr.Exists() {
+		if ifNotExists {
+			// Noop.
+			return nil
+		}
+		// Key exists, but we don't want it to: error out.
+		// TODO(marc): prettify the error (strip stuff off the type name)
+		return fmt.Errorf("%T \"%s\" already exists", descriptor, key.String())
+	}
+
+	// Increment unique descriptor counter.
+	if ir, err := p.db.Inc(keys.DescIDGenerator, 1); err == nil {
+		descriptor.SetID(uint32(ir.ValueInt() - 1))
+	} else {
+		return err
+	}
+
+	// TODO(pmattis): The error currently returned below is likely going to be
+	// difficult to interpret.
+	// TODO(pmattis): Need to handle if-not-exists here as well.
+	descKey := keys.MakeDescMetadataKey(descriptor.GetID())
+	return p.db.Txn(func(txn *client.Txn) error {
+		b := &client.Batch{}
+		b.CPut(key, descKey, nil)
+		b.CPut(descKey, descriptor, nil)
+		return txn.Commit(b)
+	})
+}
+
+// getDescriptor looks up the descriptor at `key`, validates it,
+// and unmarshals it into `descriptor`.
+func (p *planner) getDescriptor(key proto.Key, descriptor descriptorProto) error {
+	gr, err := p.db.Get(key)
+	if err != nil {
+		return err
+	}
+	if !gr.Exists() {
+		// TODO(marc): prettify the error (strip stuff off the type name)
+		return fmt.Errorf("%T \"%s\" does not exist", descriptor, key.String())
+	}
+
+	descKey := gr.ValueBytes()
+	if err := p.db.GetProto(descKey, descriptor); err != nil {
+		return err
+	}
+
+	return descriptor.Validate()
+}

--- a/sql/driver/driver_test.go
+++ b/sql/driver/driver_test.go
@@ -81,7 +81,7 @@ func TestCreateDatabase(t *testing.T) {
 	if _, err := db.Exec(`CREATE DATABASE foo`); err != nil {
 		t.Fatal(err)
 	}
-	if _, err := db.Exec(`CREATE DATABASE foo`); !isError(err, "database .* already exists") {
+	if _, err := db.Exec(`CREATE DATABASE foo`); !isError(err, "\\*structured.DatabaseDescriptor .* already exists") {
 		t.Fatalf("expected failure, but found success")
 	}
 	if _, err := db.Exec(`CREATE DATABASE IF NOT EXISTS foo`); err != nil {
@@ -139,14 +139,14 @@ func TestCreateTable(t *testing.T) {
 	if _, err := db.Exec("CREATE TABLE t.users " + cols); err != nil {
 		t.Fatal(err)
 	}
-	if _, err := db.Exec("CREATE TABLE t.users " + cols); !isError(err, "table .* already exists") {
+	if _, err := db.Exec("CREATE TABLE t.users " + cols); !isError(err, "\\*structured.TableDescriptor .* already exists") {
 		t.Fatal(err)
 	}
 
 	if _, err := db.Exec("SET DATABASE = t"); err != nil {
 		t.Fatal(err)
 	}
-	if _, err := db.Exec("CREATE TABLE users " + cols); !isError(err, "table .* already exists") {
+	if _, err := db.Exec("CREATE TABLE users " + cols); !isError(err, "\\*structured.TableDescriptor .* already exists") {
 		t.Fatal(err)
 	}
 	if _, err := db.Exec("CREATE TABLE IF NOT EXISTS users " + cols); err != nil {
@@ -216,13 +216,13 @@ CREATE TABLE t.users (
   title VARCHAR
 )`
 
-	if _, err := db.Query("SHOW COLUMNS FROM t.users"); !isError(err, "database .* does not exist") {
+	if _, err := db.Query("SHOW COLUMNS FROM t.users"); !isError(err, "\\*structured.DatabaseDescriptor .* does not exist") {
 		t.Fatal(err)
 	}
 	if _, err := db.Exec("CREATE DATABASE t"); err != nil {
 		t.Fatal(err)
 	}
-	if _, err := db.Query("SHOW COLUMNS FROM t.users"); !isError(err, "table .* does not exist") {
+	if _, err := db.Query("SHOW COLUMNS FROM t.users"); !isError(err, "\\*structured.TableDescriptor .* does not exist") {
 		t.Fatal(err)
 	}
 	if _, err := db.Query("SHOW COLUMNS FROM users"); !isError(err, "no database specified") {
@@ -262,13 +262,13 @@ CREATE TABLE t.users (
   CONSTRAINT bar UNIQUE (id, name)
 )`
 
-	if _, err := db.Query("SHOW INDEX FROM t.users"); !isError(err, "database .* does not exist") {
+	if _, err := db.Query("SHOW INDEX FROM t.users"); !isError(err, "\\*structured.DatabaseDescriptor .* does not exist") {
 		t.Fatal(err)
 	}
 	if _, err := db.Exec("CREATE DATABASE t"); err != nil {
 		t.Fatal(err)
 	}
-	if _, err := db.Query("SHOW INDEX FROM t.users"); !isError(err, "table .* does not exist") {
+	if _, err := db.Query("SHOW INDEX FROM t.users"); !isError(err, "\\*structured.TableDescriptor .* does not exist") {
 		t.Fatal(err)
 	}
 	if _, err := db.Query("SHOW INDEX FROM users"); !isError(err, "no database specified") {
@@ -326,7 +326,7 @@ func TestInsertSelectDelete(t *testing.T) {
 		if _, err := db.Exec(fmt.Sprintf(`CREATE DATABASE ` + testcase.db)); err != nil {
 			t.Fatal(err)
 		}
-		if _, err := db.Exec(fmt.Sprintf(`INSERT INTO %s.kv VALUES ('a', 'b')`, testcase.db)); !isError(err, "table .* does not exist") {
+		if _, err := db.Exec(fmt.Sprintf(`INSERT INTO %s.kv VALUES ('a', 'b')`, testcase.db)); !isError(err, "\\*structured.TableDescriptor .* does not exist") {
 			t.Fatal(err)
 		}
 		if _, err := db.Exec(fmt.Sprintf(testcase.schema, testcase.db)); err != nil {

--- a/sql/main_test.go
+++ b/sql/main_test.go
@@ -1,0 +1,36 @@
+// Copyright 2015 The Cockroach Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+// implied. See the License for the specific language governing
+// permissions and limitations under the License. See the AUTHORS file
+// for names of contributors.
+//
+// Author: Marc Berhault (marc@cockroachlabs.com)
+
+package sql_test
+
+import (
+	"testing"
+
+	"github.com/cockroachdb/cockroach/security"
+	"github.com/cockroachdb/cockroach/security/securitytest"
+	"github.com/cockroachdb/cockroach/util/leaktest"
+)
+
+func init() {
+	security.SetReadFileFn(securitytest.Asset)
+}
+
+//go:generate ../util/leaktest/add-leaktest.sh *_test.go
+
+func TestMain(m *testing.M) {
+	leaktest.TestMainWithLeakCheck(m)
+}

--- a/sql/show.go
+++ b/sql/show.go
@@ -89,11 +89,11 @@ func (p *planner) ShowTables(n *parser.ShowTables) (planNode, error) {
 		}
 		n.Name = append(n.Name, p.session.Database)
 	}
-	dbID, err := p.lookupDatabase(n.Name.String())
+	dbDesc, err := p.getDatabaseDesc(n.Name.String())
 	if err != nil {
 		return nil, err
 	}
-	prefix := keys.MakeNameMetadataKey(dbID, "")
+	prefix := keys.MakeNameMetadataKey(dbDesc.ID, "")
 	sr, err := p.db.Scan(prefix, prefix.PrefixEnd(), 0)
 	if err != nil {
 		return nil, err

--- a/sql/table.go
+++ b/sql/table.go
@@ -97,6 +97,25 @@ func makeTableDesc(p *parser.CreateTable) (structured.TableDescriptor, error) {
 	return desc, nil
 }
 
+func (p *planner) getTableDesc(qname parser.QualifiedName) (
+	*structured.TableDescriptor, error) {
+	normalized, err := p.normalizeTableName(qname)
+	if err != nil {
+		return nil, err
+	}
+	dbDesc, err := p.getDatabaseDesc(normalized.Database())
+	if err != nil {
+		return nil, err
+	}
+
+	nameKey := keys.MakeNameMetadataKey(dbDesc.ID, normalized.Table())
+	desc := structured.TableDescriptor{}
+	if err := p.getDescriptor(nameKey, &desc); err != nil {
+		return nil, err
+	}
+	return &desc, nil
+}
+
 func encodeIndexKeyPrefix(tableID, indexID uint32) []byte {
 	var key []byte
 	key = append(key, keys.TableDataPrefix...)

--- a/sql/values_test.go
+++ b/sql/values_test.go
@@ -23,9 +23,11 @@ import (
 	"testing"
 
 	"github.com/cockroachdb/cockroach/sql/parser"
+	"github.com/cockroachdb/cockroach/util/leaktest"
 )
 
 func TestValues(t *testing.T) {
+	defer leaktest.AfterTest(t)
 	p := planner{}
 
 	vInt := int64(5)

--- a/structured/structured.go
+++ b/structured/structured.go
@@ -36,6 +36,11 @@ func validateName(name, typ string) error {
 	return nil
 }
 
+// SetID is needed to implement descriptorProto in sql/create.go
+func (desc *TableDescriptor) SetID(id uint32) {
+	desc.ID = id
+}
+
 // AllocateIDs allocates column and index ids for any column or index which has
 // an ID of 0.
 func (desc *TableDescriptor) AllocateIDs() error {
@@ -225,4 +230,28 @@ func (c *ColumnType) SQLString() string {
 		}
 	}
 	return c.Kind.String()
+}
+
+// SetID is needed to implement descriptorProto in sql/create.go
+func (desc *DatabaseDescriptor) SetID(id uint32) {
+	desc.ID = id
+}
+
+// Validate validates that the database descriptor is well formed.
+// Checks include validate the database name, and verifying that there
+// is at least one read and write user.
+func (desc *DatabaseDescriptor) Validate() error {
+	if err := validateName(desc.Name, "descriptor"); err != nil {
+		return err
+	}
+	if desc.ID == 0 {
+		return fmt.Errorf("invalid database ID 0")
+	}
+	if len(desc.Read) == 0 {
+		return fmt.Errorf("empty Read permissions")
+	}
+	if len(desc.Write) == 0 {
+		return fmt.Errorf("empty Write permissions")
+	}
+	return nil
 }

--- a/structured/structured.pb.go
+++ b/structured/structured.pb.go
@@ -13,6 +13,7 @@
 		ColumnDescriptor
 		IndexDescriptor
 		TableDescriptor
+		DatabaseDescriptor
 */
 package structured
 
@@ -274,6 +275,52 @@ func (m *TableDescriptor) GetNextIndexID() uint32 {
 		return m.NextIndexID
 	}
 	return 0
+}
+
+// DatabaseDescriptor represents a namespace (aka database) and is stored
+// in a structured metadata key. The DatabaseDescriptor has a globally-unique
+// ID shared with the TableDescriptor ID.
+// Permissions are applied to all tables in the namespace.
+type DatabaseDescriptor struct {
+	Name string `protobuf:"bytes,1,opt,name=name" json:"name"`
+	ID   uint32 `protobuf:"varint,2,opt,name=id" json:"id"`
+	// lists of users with read permissions.
+	Read []string `protobuf:"bytes,3,rep,name=read" json:"read,omitempty" yaml:"read,omitempty"`
+	// lists of users with write permissions.
+	Write            []string `protobuf:"bytes,4,rep,name=write" json:"write,omitempty" yaml:"write,omitempty"`
+	XXX_unrecognized []byte   `json:"-"`
+}
+
+func (m *DatabaseDescriptor) Reset()         { *m = DatabaseDescriptor{} }
+func (m *DatabaseDescriptor) String() string { return proto.CompactTextString(m) }
+func (*DatabaseDescriptor) ProtoMessage()    {}
+
+func (m *DatabaseDescriptor) GetName() string {
+	if m != nil {
+		return m.Name
+	}
+	return ""
+}
+
+func (m *DatabaseDescriptor) GetID() uint32 {
+	if m != nil {
+		return m.ID
+	}
+	return 0
+}
+
+func (m *DatabaseDescriptor) GetRead() []string {
+	if m != nil {
+		return m.Read
+	}
+	return nil
+}
+
+func (m *DatabaseDescriptor) GetWrite() []string {
+	if m != nil {
+		return m.Write
+	}
+	return nil
 }
 
 func init() {
@@ -784,6 +831,130 @@ func (m *TableDescriptor) Unmarshal(data []byte) error {
 
 	return nil
 }
+func (m *DatabaseDescriptor) Unmarshal(data []byte) error {
+	l := len(data)
+	iNdEx := 0
+	for iNdEx < l {
+		var wire uint64
+		for shift := uint(0); ; shift += 7 {
+			if iNdEx >= l {
+				return io.ErrUnexpectedEOF
+			}
+			b := data[iNdEx]
+			iNdEx++
+			wire |= (uint64(b) & 0x7F) << shift
+			if b < 0x80 {
+				break
+			}
+		}
+		fieldNum := int32(wire >> 3)
+		wireType := int(wire & 0x7)
+		switch fieldNum {
+		case 1:
+			if wireType != 2 {
+				return fmt.Errorf("proto: wrong wireType = %d for field Name", wireType)
+			}
+			var stringLen uint64
+			for shift := uint(0); ; shift += 7 {
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := data[iNdEx]
+				iNdEx++
+				stringLen |= (uint64(b) & 0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			postIndex := iNdEx + int(stringLen)
+			if postIndex > l {
+				return io.ErrUnexpectedEOF
+			}
+			m.Name = string(data[iNdEx:postIndex])
+			iNdEx = postIndex
+		case 2:
+			if wireType != 0 {
+				return fmt.Errorf("proto: wrong wireType = %d for field ID", wireType)
+			}
+			for shift := uint(0); ; shift += 7 {
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := data[iNdEx]
+				iNdEx++
+				m.ID |= (uint32(b) & 0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+		case 3:
+			if wireType != 2 {
+				return fmt.Errorf("proto: wrong wireType = %d for field Read", wireType)
+			}
+			var stringLen uint64
+			for shift := uint(0); ; shift += 7 {
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := data[iNdEx]
+				iNdEx++
+				stringLen |= (uint64(b) & 0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			postIndex := iNdEx + int(stringLen)
+			if postIndex > l {
+				return io.ErrUnexpectedEOF
+			}
+			m.Read = append(m.Read, string(data[iNdEx:postIndex]))
+			iNdEx = postIndex
+		case 4:
+			if wireType != 2 {
+				return fmt.Errorf("proto: wrong wireType = %d for field Write", wireType)
+			}
+			var stringLen uint64
+			for shift := uint(0); ; shift += 7 {
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := data[iNdEx]
+				iNdEx++
+				stringLen |= (uint64(b) & 0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			postIndex := iNdEx + int(stringLen)
+			if postIndex > l {
+				return io.ErrUnexpectedEOF
+			}
+			m.Write = append(m.Write, string(data[iNdEx:postIndex]))
+			iNdEx = postIndex
+		default:
+			var sizeOfWire int
+			for {
+				sizeOfWire++
+				wire >>= 7
+				if wire == 0 {
+					break
+				}
+			}
+			iNdEx -= sizeOfWire
+			skippy, err := skipStructured(data[iNdEx:])
+			if err != nil {
+				return err
+			}
+			if (iNdEx + skippy) > l {
+				return io.ErrUnexpectedEOF
+			}
+			m.XXX_unrecognized = append(m.XXX_unrecognized, data[iNdEx:iNdEx+skippy]...)
+			iNdEx += skippy
+		}
+	}
+
+	return nil
+}
 func skipStructured(data []byte) (n int, err error) {
 	l := len(data)
 	iNdEx := 0
@@ -939,6 +1110,30 @@ func (m *TableDescriptor) Size() (n int) {
 		}
 	}
 	n += 1 + sovStructured(uint64(m.NextIndexID))
+	if m.XXX_unrecognized != nil {
+		n += len(m.XXX_unrecognized)
+	}
+	return n
+}
+
+func (m *DatabaseDescriptor) Size() (n int) {
+	var l int
+	_ = l
+	l = len(m.Name)
+	n += 1 + l + sovStructured(uint64(l))
+	n += 1 + sovStructured(uint64(m.ID))
+	if len(m.Read) > 0 {
+		for _, s := range m.Read {
+			l = len(s)
+			n += 1 + l + sovStructured(uint64(l))
+		}
+	}
+	if len(m.Write) > 0 {
+		for _, s := range m.Write {
+			l = len(s)
+			n += 1 + l + sovStructured(uint64(l))
+		}
+	}
 	if m.XXX_unrecognized != nil {
 		n += len(m.XXX_unrecognized)
 	}
@@ -1142,6 +1337,64 @@ func (m *TableDescriptor) MarshalTo(data []byte) (n int, err error) {
 	data[i] = 0x30
 	i++
 	i = encodeVarintStructured(data, i, uint64(m.NextIndexID))
+	if m.XXX_unrecognized != nil {
+		i += copy(data[i:], m.XXX_unrecognized)
+	}
+	return i, nil
+}
+
+func (m *DatabaseDescriptor) Marshal() (data []byte, err error) {
+	size := m.Size()
+	data = make([]byte, size)
+	n, err := m.MarshalTo(data)
+	if err != nil {
+		return nil, err
+	}
+	return data[:n], nil
+}
+
+func (m *DatabaseDescriptor) MarshalTo(data []byte) (n int, err error) {
+	var i int
+	_ = i
+	var l int
+	_ = l
+	data[i] = 0xa
+	i++
+	i = encodeVarintStructured(data, i, uint64(len(m.Name)))
+	i += copy(data[i:], m.Name)
+	data[i] = 0x10
+	i++
+	i = encodeVarintStructured(data, i, uint64(m.ID))
+	if len(m.Read) > 0 {
+		for _, s := range m.Read {
+			data[i] = 0x1a
+			i++
+			l = len(s)
+			for l >= 1<<7 {
+				data[i] = uint8(uint64(l)&0x7f | 0x80)
+				l >>= 7
+				i++
+			}
+			data[i] = uint8(l)
+			i++
+			i += copy(data[i:], s)
+		}
+	}
+	if len(m.Write) > 0 {
+		for _, s := range m.Write {
+			data[i] = 0x22
+			i++
+			l = len(s)
+			for l >= 1<<7 {
+				data[i] = uint8(uint64(l)&0x7f | 0x80)
+				l >>= 7
+				i++
+			}
+			data[i] = uint8(l)
+			i++
+			i += copy(data[i:], s)
+		}
+	}
 	if m.XXX_unrecognized != nil {
 		i += copy(data[i:], m.XXX_unrecognized)
 	}

--- a/structured/structured.proto
+++ b/structured/structured.proto
@@ -84,3 +84,16 @@ message TableDescriptor {
   optional uint32 next_index_id = 6 [(gogoproto.nullable) = false,
       (gogoproto.customname) = "NextIndexID"];
 }
+
+// DatabaseDescriptor represents a namespace (aka database) and is stored
+// in a structured metadata key. The DatabaseDescriptor has a globally-unique
+// ID shared with the TableDescriptor ID.
+// Permissions are applied to all tables in the namespace.
+message DatabaseDescriptor {
+  optional string name = 1 [(gogoproto.nullable) = false];
+  optional uint32 id = 2 [(gogoproto.nullable) = false, (gogoproto.customname) = "ID"];
+  // lists of users with read permissions.
+  repeated string read = 3 [(gogoproto.moretags) = "yaml:\"read,omitempty\""];
+  // lists of users with write permissions.
+  repeated string write = 4 [(gogoproto.moretags) = "yaml:\"write,omitempty\""];
+}


### PR DESCRIPTION
Change database descriptor to a root/name -> <database ID key>
add <database ID key> -> <database descriptor>

The descriptor contains the name, ID, and read/write permissions.

More tests to follow, and possibly a bit of refactoring of the table
descriptor stuff.
This is step 1 of #1830. Actual permissions will come separately.
