### PR TITLE
Refactor multiraft.LocalRPCTransport to use cockroach/rpc.

### DIFF
--- a/kv/local_test_cluster.go
+++ b/kv/local_test_cluster.go
@@ -127,7 +127,7 @@ func (ltc *LocalTestCluster) Start(t util.Tester) {
 	if ltc.DB, err = client.Open("//root@", client.SenderOpt(ltc.Sender)); err != nil {
 		t.Fatal(err)
 	}
-	transport := multiraft.NewLocalRPCTransport()
+	transport := multiraft.NewLocalRPCTransport(ltc.Stopper)
 	ltc.Stopper.AddCloser(transport)
 	ctx := storage.TestStoreContext
 	ctx.Clock = ltc.Clock

--- a/multiraft/multiraft_test.go
+++ b/multiraft/multiraft_test.go
@@ -55,7 +55,7 @@ type testCluster struct {
 
 func newTestCluster(transport Transport, size int, stopper *stop.Stopper, t *testing.T) *testCluster {
 	if transport == nil {
-		transport = NewLocalRPCTransport()
+		transport = NewLocalRPCTransport(stopper)
 	}
 	stopper.AddCloser(transport)
 	cluster := &testCluster{

--- a/rpc/client.go
+++ b/rpc/client.go
@@ -158,7 +158,7 @@ func (c *Client) internalConn() *internalConn {
 
 // connect attempts a single connection attempt. On success, updates `c.conn`.
 func (c *Client) connect() error {
-	conn, err := tlsDialHTTP(c.addr.NetworkField, c.addr.StringField, c.tlsConfig)
+	conn, err := TLSDialHTTP(c.addr.NetworkField, c.addr.StringField, c.tlsConfig)
 	if err != nil {
 		return err
 	}

--- a/rpc/tls.go
+++ b/rpc/tls.go
@@ -61,8 +61,8 @@ func tlsDial(network, address string, config *tls.Config) (net.Conn, error) {
 	return tls.DialWithDialer(&defaultDialer, network, address, config)
 }
 
-// tlsDialHTTP connects to an HTTP RPC server at the specified address.
-func tlsDialHTTP(network, address string, config *tls.Config) (net.Conn, error) {
+// TLSDialHTTP connects to an HTTP RPC server at the specified address.
+func TLSDialHTTP(network, address string, config *tls.Config) (net.Conn, error) {
 	conn, err := tlsDial(network, address, config)
 	if err != nil {
 		return conn, err

--- a/server/node.go
+++ b/server/node.go
@@ -112,7 +112,7 @@ func BootstrapCluster(clusterID string, engines []engine.Engine, stopper *stop.S
 	if ctx.DB, err = client.Open("//root@", client.SenderOpt(sender)); err != nil {
 		return nil, err
 	}
-	ctx.Transport = multiraft.NewLocalRPCTransport()
+	ctx.Transport = multiraft.NewLocalRPCTransport(stopper)
 	for i, eng := range engines {
 		sIdent := proto.StoreIdent{
 			ClusterID: clusterID,

--- a/server/node_test.go
+++ b/server/node_test.go
@@ -75,7 +75,8 @@ func createTestNode(addr net.Addr, engines []engine.Engine, gossipBS net.Addr, t
 		t.Fatal(err)
 	}
 	// TODO(bdarnell): arrange to have the transport closed.
-	ctx.Transport = multiraft.NewLocalRPCTransport()
+	// (or attach LocalRPCTransport.Close to the stopper)
+	ctx.Transport = multiraft.NewLocalRPCTransport(stopper)
 	ctx.EventFeed = &util.Feed{}
 	node := NewNode(ctx)
 	return rpcServer, ctx.Clock, node, stopper

--- a/storage/client_test.go
+++ b/storage/client_test.go
@@ -73,7 +73,7 @@ func createTestStoreWithEngine(t *testing.T, eng engine.Engine, clock *hlc.Clock
 	if context.DB, err = client.Open("//root@", client.SenderOpt(sender)); err != nil {
 		t.Fatal(err)
 	}
-	context.Transport = multiraft.NewLocalRPCTransport()
+	context.Transport = multiraft.NewLocalRPCTransport(stopper)
 	// TODO(bdarnell): arrange to have the transport closed.
 	store := storage.NewStore(*context, eng, &proto.NodeDescriptor{NodeID: 1})
 	if bootstrap {
@@ -139,12 +139,11 @@ func (m *multiTestContext) Start(t *testing.T, numStores int) {
 		rpcContext := rpc.NewContext(rootTestBaseContext, m.clock, nil)
 		m.gossip = gossip.New(rpcContext, gossip.TestInterval, gossip.TestBootstrap)
 	}
-	if m.transport == nil {
-		m.transport = multiraft.NewLocalRPCTransport()
-	}
-
 	if m.clientStopper == nil {
 		m.clientStopper = stop.NewStopper()
+	}
+	if m.transport == nil {
+		m.transport = multiraft.NewLocalRPCTransport(m.clientStopper)
 	}
 
 	// Always create the first sender.

--- a/storage/store_test.go
+++ b/storage/store_test.go
@@ -172,7 +172,7 @@ func createTestStoreWithoutStart(t *testing.T) (*Store, *hlc.ManualClock, *stop.
 	manual := hlc.NewManualClock(0)
 	ctx.Clock = hlc.NewClock(manual.UnixNano)
 	eng := engine.NewInMem(proto.Attributes{}, 10<<20)
-	ctx.Transport = multiraft.NewLocalRPCTransport()
+	ctx.Transport = multiraft.NewLocalRPCTransport(stopper)
 	stopper.AddCloser(ctx.Transport)
 	sender := &testSender{}
 	var err error
@@ -210,10 +210,10 @@ func TestStoreInitAndBootstrap(t *testing.T) {
 	manual := hlc.NewManualClock(0)
 	ctx.Clock = hlc.NewClock(manual.UnixNano)
 	eng := engine.NewInMem(proto.Attributes{}, 1<<20)
-	ctx.Transport = multiraft.NewLocalRPCTransport()
 	stopper := stop.NewStopper()
-	stopper.AddCloser(ctx.Transport)
 	defer stopper.Stop()
+	ctx.Transport = multiraft.NewLocalRPCTransport(stopper)
+	stopper.AddCloser(ctx.Transport)
 	store := NewStore(ctx, eng, &proto.NodeDescriptor{NodeID: 1})
 
 	// Can't start as haven't bootstrapped.
@@ -260,10 +260,10 @@ func TestBootstrapOfNonEmptyStore(t *testing.T) {
 	ctx := TestStoreContext
 	manual := hlc.NewManualClock(0)
 	ctx.Clock = hlc.NewClock(manual.UnixNano)
-	ctx.Transport = multiraft.NewLocalRPCTransport()
 	stopper := stop.NewStopper()
-	stopper.AddCloser(ctx.Transport)
 	defer stopper.Stop()
+	ctx.Transport = multiraft.NewLocalRPCTransport(stopper)
+	stopper.AddCloser(ctx.Transport)
 	store := NewStore(ctx, eng, &proto.NodeDescriptor{NodeID: 1})
 
 	// Can't init as haven't bootstrapped.


### PR DESCRIPTION
We need in-order delivery here to fix #1769. With this change, the test
suite passes on go 1.5b2.

Fixes #1769.
