### PR TITLE
bug fix: Error format will cause index out of range panic

### DIFF
--- a/util/log/structured.go
+++ b/util/log/structured.go
@@ -116,7 +116,7 @@ func parseFormatWithArgs(format string, args []interface{}) (string, []LogEntry_
 
 		// TODO(spencer): should arg numbers dynamic precision be
 		// supported? They're so rare, better to just panic here for now.
-		if i < end && format[i] == '[' || format[i] == '*' {
+		if i < end && (format[i] == '[' || format[i] == '*') {
 			panic(fmt.Sprintf("arg numbers in format not supported by logger: %s", format))
 		}
 

--- a/util/log/structured_test.go
+++ b/util/log/structured_test.go
@@ -100,6 +100,13 @@ func TestSetLogEntry(t *testing.T) {
 				{Type: "log.testArg", Str: "10-->foo", Json: []byte("{\"StrVal\":\"foo\",\"IntVal\":10}")},
 			},
 		}},
+		// Error format test.
+		{nil, "Error format s%", []interface{}{"foo"}, LogEntry{
+			Format: "Error format s",
+			Args: []LogEntry_Arg{
+				{Type: "string", Str: "foo"},
+			},
+		}},
 	}
 	for i, test := range testCases {
 		entry := &LogEntry{}


### PR DESCRIPTION
Error format will cause `index out of range` panic in util/log .
For example: `log.Infof("test : s%","test" )` 

```
panic: runtime error: index out of range

goroutine 1 [running]:
github.com/cockroachdb/cockroach/util/log.parseFormatWithArgs(0x116f890, 0xe, 0xc2080b5bb8, 0x1, 0x1, 0x0, 0x0, 0x0, 0x0, 0x0)
        /home/thunder/go/path/src/github.com/cockroachdb/cockroach/util/log/structured.go:119 +0xeab
github.com/cockroachdb/cockroach/util/log.setLogEntry(0x0, 0x0, 0x116f890, 0xe, 0xc2080b5bb8, 0x1, 0x1, 0xc208088000)
        /home/thunder/go/path/src/github.com/cockroachdb/cockroach/util/log/structured.go:60 +0x67
github.com/cockroachdb/cockroach/util/log.AddStructured(0x0, 0x0, 0x0, 0x2, 0x116f890, 0xe, 0xc2080b5bb8, 0x1, 0x1)
        /home/thunder/go/path/src/github.com/cockroachdb/cockroach/util/log/structured.go:38 +0xdb
github.com/cockroachdb/cockroach/util/log.logDepth(0x0, 0x0, 0x1, 0xc200000000, 0x116f890, 0xe, 0xc2080b5bb8, 0x1, 0x1)
        /home/thunder/go/path/src/github.com/cockroachdb/cockroach/util/log/log.go:65 +0x82
github.com/cockroachdb/cockroach/util/log.Infof(0x116f890, 0xe, 0xc2080b5bb8, 0x1, 0x1)
        /home/thunder/go/path/src/github.com/cockroachdb/cockroach/util/log/log.go:85 +0x75
```
