### PR TITLE
Readme: Running in Docker doc error

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,7 +64,7 @@ Other operating systems will have a similar set of commands. Please check Docker
 Now we're in an environment that has everything set up, and we start by first initializing the cluster and then firing up the node:
 
 ```bash
-DIR=$(mktemp -d /tmp/dbXXX)
+DIR=$(mktemp -d /tmp/dbXXXXXX)
 # Initialize CA, server, and client certificates. Default directory is --certs=certs
 ./cockroach cert create-ca
 ./cockroach cert create-node 127.0.0.1 localhost $(hostname)


### PR DESCRIPTION
Latest running in docker instructions in readme show the Unix version
of mktemp which ran in container results in.

“/cockroach # DIR=$(mktemp -d /tmp/dbXXX)
mktemp: Invalid argument”

Added extra X’s to match format
“The last six characters of template must be XXXXXX“
http://man7.org/linux/man-pages/man3/mktemp.3.html
