### PR TITLE
update have{TxnWrite,EndTxn} independently

### DIFF
--- a/client/txn.go
+++ b/client/txn.go
@@ -332,7 +332,8 @@ func (txn *Txn) updateState(calls []proto.Call) {
 func (txn *Txn) updateStateForRequest(r proto.Request) {
 	if !txn.haveTxnWrite {
 		txn.haveTxnWrite = proto.IsTransactionWrite(r)
-	} else if _, ok := r.(*proto.EndTransactionRequest); ok {
+	}
+	if _, ok := r.(*proto.EndTransactionRequest); ok {
 		txn.haveEndTxn = true
 	}
 }

--- a/client/txn_test.go
+++ b/client/txn_test.go
@@ -196,12 +196,14 @@ func TestCommitTransactionOnce(t *testing.T) {
 		count++
 	}))
 	if err := db.Txn(func(txn *Txn) error {
-		return txn.Commit(&Batch{})
+		b := &Batch{}
+		b.Put("z", "adding a write exposed a bug in #1882")
+		return txn.Commit(b)
 	}); err != nil {
 		t.Errorf("unexpected error on commit: %s", err)
 	}
 	if count != 1 {
-		t.Errorf("expected single invocation of EndTransaction; got %d", count)
+		t.Errorf("expected single Batch, got %d sent calls", count)
 	}
 }
 


### PR DESCRIPTION
the only reason the test passed is because the explicit commit
also checks that there was no write command in the batch, which
was true so far.
