### PR TITLE
Pass -v if TESTFLAGS is empty.

### DIFF
--- a/acceptance/run.sh
+++ b/acceptance/run.sh
@@ -6,4 +6,4 @@ source $(dirname $0)/../build/init-docker.sh
 $(dirname $0)/../build/builder.sh make install
 
 set -x
-go test -tags acceptance ./acceptance ${GOFLAGS-} -run "${TESTS-.*}" -timeout ${TESTTIMEOUT-5m} ${TESTFLAGS-}
+go test -tags acceptance ./acceptance ${GOFLAGS-} -run "${TESTS-.*}" -timeout ${TESTTIMEOUT-5m} ${TESTFLAGS--v}


### PR DESCRIPTION
Not sure it was intentional to make the acceptance tests so silent when
invoked as "make acceptance", but it's nice to have a little bit of
output to make it clear these long running tests are still proceeding.
