### PR TITLE
move InternalCommitTrigger.Intents one level up

### DIFF
--- a/proto/api.pb.go
+++ b/proto/api.pb.go
@@ -550,7 +550,9 @@ type EndTransactionRequest struct {
 	// internal use only and will be ignored if requested through the
 	// public-facing KV API.
 	InternalCommitTrigger *InternalCommitTrigger `protobuf:"bytes,3,opt,name=internal_commit_trigger" json:"internal_commit_trigger,omitempty"`
-	XXX_unrecognized      []byte                 `json:"-"`
+	// List of intents written by the transaction.
+	Intents          []Intent `protobuf:"bytes,4,rep,name=intents" json:"intents"`
+	XXX_unrecognized []byte   `json:"-"`
 }
 
 func (m *EndTransactionRequest) Reset()         { *m = EndTransactionRequest{} }
@@ -567,6 +569,13 @@ func (m *EndTransactionRequest) GetCommit() bool {
 func (m *EndTransactionRequest) GetInternalCommitTrigger() *InternalCommitTrigger {
 	if m != nil {
 		return m.InternalCommitTrigger
+	}
+	return nil
+}
+
+func (m *EndTransactionRequest) GetIntents() []Intent {
+	if m != nil {
+		return m.Intents
 	}
 	return nil
 }
@@ -2544,6 +2553,31 @@ func (m *EndTransactionRequest) Unmarshal(data []byte) error {
 				return err
 			}
 			iNdEx = postIndex
+		case 4:
+			if wireType != 2 {
+				return fmt.Errorf("proto: wrong wireType = %d for field Intents", wireType)
+			}
+			var msglen int
+			for shift := uint(0); ; shift += 7 {
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := data[iNdEx]
+				iNdEx++
+				msglen |= (int(b) & 0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			postIndex := iNdEx + msglen
+			if postIndex > l {
+				return io.ErrUnexpectedEOF
+			}
+			m.Intents = append(m.Intents, Intent{})
+			if err := m.Intents[len(m.Intents)-1].Unmarshal(data[iNdEx:postIndex]); err != nil {
+				return err
+			}
+			iNdEx = postIndex
 		default:
 			var sizeOfWire int
 			for {
@@ -4102,6 +4136,12 @@ func (m *EndTransactionRequest) Size() (n int) {
 		l = m.InternalCommitTrigger.Size()
 		n += 1 + l + sovApi(uint64(l))
 	}
+	if len(m.Intents) > 0 {
+		for _, e := range m.Intents {
+			l = e.Size()
+			n += 1 + l + sovApi(uint64(l))
+		}
+	}
 	if m.XXX_unrecognized != nil {
 		n += len(m.XXX_unrecognized)
 	}
@@ -4970,6 +5010,18 @@ func (m *EndTransactionRequest) MarshalTo(data []byte) (n int, err error) {
 			return 0, err
 		}
 		i += n27
+	}
+	if len(m.Intents) > 0 {
+		for _, msg := range m.Intents {
+			data[i] = 0x22
+			i++
+			i = encodeVarintApi(data, i, uint64(msg.Size()))
+			n, err := msg.MarshalTo(data[i:])
+			if err != nil {
+				return 0, err
+			}
+			i += n
+		}
 	}
 	if m.XXX_unrecognized != nil {
 		i += copy(data[i:], m.XXX_unrecognized)

--- a/proto/api.proto
+++ b/proto/api.proto
@@ -251,6 +251,8 @@ message EndTransactionRequest {
   // internal use only and will be ignored if requested through the
   // public-facing KV API.
   optional InternalCommitTrigger internal_commit_trigger = 3;
+  // List of intents written by the transaction.
+  repeated Intent intents = 4 [(gogoproto.nullable) = false];
 }
 
 // An EndTransactionResponse is the return value from the

--- a/proto/data.proto
+++ b/proto/data.proto
@@ -130,11 +130,6 @@ message InternalCommitTrigger {
   optional SplitTrigger split_trigger = 1;
   optional MergeTrigger merge_trigger = 2;
   optional ChangeReplicasTrigger change_replicas_trigger = 3;
-
-  // List of intents to resolve on commit or abort. Note that keys
-  // listed here will only be resolved if they fall on the same range
-  // that the transaction was started on.
-  repeated bytes intents = 4 [(gogoproto.casttype) = "Key"];
 }
 
 // IsolationType TODO(jiajia) Needs documentation.
@@ -252,10 +247,11 @@ message Lease {
       (gogoproto.customname) = "RaftNodeID", (gogoproto.casttype) = "RaftNodeID"];
 }
 
-// Intent groups a key and a transaction.
+// Intent is used to communicate the location of an intent.
 message Intent {
   optional bytes key = 1 [(gogoproto.casttype) = "Key"];
-  optional Transaction txn = 2 [(gogoproto.nullable) = false];
+  optional bytes end_key = 2 [(gogoproto.casttype) = "Key"];
+  optional Transaction txn = 3 [(gogoproto.nullable) = false];
 }
 
 // GCMetadata holds information about the last complete key/value

--- a/storage/engine/rocksdb/cockroach/proto/api.pb.cc
+++ b/storage/engine/rocksdb/cockroach/proto/api.pb.cc
@@ -411,10 +411,11 @@ void protobuf_AssignDesc_cockroach_2fproto_2fapi_2eproto() {
       GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(ScanResponse, _internal_metadata_),
       -1);
   EndTransactionRequest_descriptor_ = file->message_type(17);
-  static const int EndTransactionRequest_offsets_[3] = {
+  static const int EndTransactionRequest_offsets_[4] = {
     GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(EndTransactionRequest, header_),
     GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(EndTransactionRequest, commit_),
     GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(EndTransactionRequest, internal_commit_trigger_),
+    GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(EndTransactionRequest, intents_),
   };
   EndTransactionRequest_reflection_ =
     ::google::protobuf::internal::GeneratedMessageReflection::NewGeneratedMessageReflection(
@@ -784,56 +785,57 @@ void protobuf_AddDesc_cockroach_2fproto_2fapi_2eproto() {
     "\"x\n\014ScanResponse\0229\n\006header\030\001 \001(\0132\037.cockr"
     "oach.proto.ResponseHeaderB\010\310\336\037\000\320\336\037\001\022-\n\004r"
     "ows\030\002 \003(\0132\031.cockroach.proto.KeyValueB\004\310\336"
-    "\037\000\"\260\001\n\025EndTransactionRequest\0228\n\006header\030\001"
+    "\037\000\"\340\001\n\025EndTransactionRequest\0228\n\006header\030\001"
     " \001(\0132\036.cockroach.proto.RequestHeaderB\010\310\336"
     "\037\000\320\336\037\001\022\024\n\006commit\030\002 \001(\010B\004\310\336\037\000\022G\n\027internal"
     "_commit_trigger\030\003 \001(\0132&.cockroach.proto."
-    "InternalCommitTrigger\"\211\001\n\026EndTransaction"
-    "Response\0229\n\006header\030\001 \001(\0132\037.cockroach.pro"
-    "to.ResponseHeaderB\010\310\336\037\000\320\336\037\001\022\031\n\013commit_wa"
-    "it\030\002 \001(\003B\004\310\336\037\000\022\031\n\010resolved\030\003 \003(\014B\007\372\336\037\003Ke"
-    "y\"\320\003\n\014RequestUnion\022*\n\003get\030\002 \001(\0132\033.cockro"
-    "ach.proto.GetRequestH\000\022*\n\003put\030\003 \001(\0132\033.co"
-    "ckroach.proto.PutRequestH\000\022A\n\017conditiona"
-    "l_put\030\004 \001(\0132&.cockroach.proto.Conditiona"
-    "lPutRequestH\000\0226\n\tincrement\030\005 \001(\0132!.cockr"
-    "oach.proto.IncrementRequestH\000\0220\n\006delete\030"
-    "\006 \001(\0132\036.cockroach.proto.DeleteRequestH\000\022"
-    ";\n\014delete_range\030\007 \001(\0132#.cockroach.proto."
-    "DeleteRangeRequestH\000\022,\n\004scan\030\010 \001(\0132\034.coc"
-    "kroach.proto.ScanRequestH\000\022A\n\017end_transa"
-    "ction\030\t \001(\0132&.cockroach.proto.EndTransac"
-    "tionRequestH\000:\004\310\240\037\001B\007\n\005value\"\331\003\n\rRespons"
-    "eUnion\022+\n\003get\030\002 \001(\0132\034.cockroach.proto.Ge"
-    "tResponseH\000\022+\n\003put\030\003 \001(\0132\034.cockroach.pro"
-    "to.PutResponseH\000\022B\n\017conditional_put\030\004 \001("
-    "\0132\'.cockroach.proto.ConditionalPutRespon"
-    "seH\000\0227\n\tincrement\030\005 \001(\0132\".cockroach.prot"
-    "o.IncrementResponseH\000\0221\n\006delete\030\006 \001(\0132\037."
-    "cockroach.proto.DeleteResponseH\000\022<\n\014dele"
-    "te_range\030\007 \001(\0132$.cockroach.proto.DeleteR"
-    "angeResponseH\000\022-\n\004scan\030\010 \001(\0132\035.cockroach"
-    ".proto.ScanResponseH\000\022B\n\017end_transaction"
-    "\030\t \001(\0132\'.cockroach.proto.EndTransactionR"
-    "esponseH\000:\004\310\240\037\001B\007\n\005value\"\177\n\014BatchRequest"
-    "\0228\n\006header\030\001 \001(\0132\036.cockroach.proto.Reque"
-    "stHeaderB\010\310\336\037\000\320\336\037\001\0225\n\010requests\030\002 \003(\0132\035.c"
-    "ockroach.proto.RequestUnionB\004\310\336\037\000\"\203\001\n\rBa"
-    "tchResponse\0229\n\006header\030\001 \001(\0132\037.cockroach."
-    "proto.ResponseHeaderB\010\310\336\037\000\320\336\037\001\0227\n\trespon"
-    "ses\030\002 \003(\0132\036.cockroach.proto.ResponseUnio"
-    "nB\004\310\336\037\000\"i\n\021AdminSplitRequest\0228\n\006header\030\001"
-    " \001(\0132\036.cockroach.proto.RequestHeaderB\010\310\336"
-    "\037\000\320\336\037\001\022\032\n\tsplit_key\030\002 \001(\014B\007\372\336\037\003Key\"O\n\022Ad"
-    "minSplitResponse\0229\n\006header\030\001 \001(\0132\037.cockr"
-    "oach.proto.ResponseHeaderB\010\310\336\037\000\320\336\037\001\"M\n\021A"
-    "dminMergeRequest\0228\n\006header\030\001 \001(\0132\036.cockr"
-    "oach.proto.RequestHeaderB\010\310\336\037\000\320\336\037\001\"O\n\022Ad"
-    "minMergeResponse\0229\n\006header\030\001 \001(\0132\037.cockr"
-    "oach.proto.ResponseHeaderB\010\310\336\037\000\320\336\037\001*L\n\023R"
-    "eadConsistencyType\022\016\n\nCONSISTENT\020\000\022\r\n\tCO"
-    "NSENSUS\020\001\022\020\n\014INCONSISTENT\020\002\032\004\210\243\036\000B\023Z\005pro"
-    "to\340\342\036\001\310\342\036\001\320\342\036\001", 4214);
+    "InternalCommitTrigger\022.\n\007intents\030\004 \003(\0132\027"
+    ".cockroach.proto.IntentB\004\310\336\037\000\"\211\001\n\026EndTra"
+    "nsactionResponse\0229\n\006header\030\001 \001(\0132\037.cockr"
+    "oach.proto.ResponseHeaderB\010\310\336\037\000\320\336\037\001\022\031\n\013c"
+    "ommit_wait\030\002 \001(\003B\004\310\336\037\000\022\031\n\010resolved\030\003 \003(\014"
+    "B\007\372\336\037\003Key\"\320\003\n\014RequestUnion\022*\n\003get\030\002 \001(\0132"
+    "\033.cockroach.proto.GetRequestH\000\022*\n\003put\030\003 "
+    "\001(\0132\033.cockroach.proto.PutRequestH\000\022A\n\017co"
+    "nditional_put\030\004 \001(\0132&.cockroach.proto.Co"
+    "nditionalPutRequestH\000\0226\n\tincrement\030\005 \001(\013"
+    "2!.cockroach.proto.IncrementRequestH\000\0220\n"
+    "\006delete\030\006 \001(\0132\036.cockroach.proto.DeleteRe"
+    "questH\000\022;\n\014delete_range\030\007 \001(\0132#.cockroac"
+    "h.proto.DeleteRangeRequestH\000\022,\n\004scan\030\010 \001"
+    "(\0132\034.cockroach.proto.ScanRequestH\000\022A\n\017en"
+    "d_transaction\030\t \001(\0132&.cockroach.proto.En"
+    "dTransactionRequestH\000:\004\310\240\037\001B\007\n\005value\"\331\003\n"
+    "\rResponseUnion\022+\n\003get\030\002 \001(\0132\034.cockroach."
+    "proto.GetResponseH\000\022+\n\003put\030\003 \001(\0132\034.cockr"
+    "oach.proto.PutResponseH\000\022B\n\017conditional_"
+    "put\030\004 \001(\0132\'.cockroach.proto.ConditionalP"
+    "utResponseH\000\0227\n\tincrement\030\005 \001(\0132\".cockro"
+    "ach.proto.IncrementResponseH\000\0221\n\006delete\030"
+    "\006 \001(\0132\037.cockroach.proto.DeleteResponseH\000"
+    "\022<\n\014delete_range\030\007 \001(\0132$.cockroach.proto"
+    ".DeleteRangeResponseH\000\022-\n\004scan\030\010 \001(\0132\035.c"
+    "ockroach.proto.ScanResponseH\000\022B\n\017end_tra"
+    "nsaction\030\t \001(\0132\'.cockroach.proto.EndTran"
+    "sactionResponseH\000:\004\310\240\037\001B\007\n\005value\"\177\n\014Batc"
+    "hRequest\0228\n\006header\030\001 \001(\0132\036.cockroach.pro"
+    "to.RequestHeaderB\010\310\336\037\000\320\336\037\001\0225\n\010requests\030\002"
+    " \003(\0132\035.cockroach.proto.RequestUnionB\004\310\336\037"
+    "\000\"\203\001\n\rBatchResponse\0229\n\006header\030\001 \001(\0132\037.co"
+    "ckroach.proto.ResponseHeaderB\010\310\336\037\000\320\336\037\001\0227"
+    "\n\tresponses\030\002 \003(\0132\036.cockroach.proto.Resp"
+    "onseUnionB\004\310\336\037\000\"i\n\021AdminSplitRequest\0228\n\006"
+    "header\030\001 \001(\0132\036.cockroach.proto.RequestHe"
+    "aderB\010\310\336\037\000\320\336\037\001\022\032\n\tsplit_key\030\002 \001(\014B\007\372\336\037\003K"
+    "ey\"O\n\022AdminSplitResponse\0229\n\006header\030\001 \001(\013"
+    "2\037.cockroach.proto.ResponseHeaderB\010\310\336\037\000\320"
+    "\336\037\001\"M\n\021AdminMergeRequest\0228\n\006header\030\001 \001(\013"
+    "2\036.cockroach.proto.RequestHeaderB\010\310\336\037\000\320\336"
+    "\037\001\"O\n\022AdminMergeResponse\0229\n\006header\030\001 \001(\013"
+    "2\037.cockroach.proto.ResponseHeaderB\010\310\336\037\000\320"
+    "\336\037\001*L\n\023ReadConsistencyType\022\016\n\nCONSISTENT"
+    "\020\000\022\r\n\tCONSENSUS\020\001\022\020\n\014INCONSISTENT\020\002\032\004\210\243\036"
+    "\000B\023Z\005proto\340\342\036\001\310\342\036\001\320\342\036\001", 4262);
   ::google::protobuf::MessageFactory::InternalRegisterGeneratedFile(
     "cockroach/proto/api.proto", &protobuf_RegisterTypes);
   ClientCmdID::default_instance_ = new ClientCmdID();
@@ -7512,6 +7514,7 @@ ScanResponse::mutable_rows() {
 const int EndTransactionRequest::kHeaderFieldNumber;
 const int EndTransactionRequest::kCommitFieldNumber;
 const int EndTransactionRequest::kInternalCommitTriggerFieldNumber;
+const int EndTransactionRequest::kIntentsFieldNumber;
 #endif  // !_MSC_VER
 
 EndTransactionRequest::EndTransactionRequest()
@@ -7588,6 +7591,7 @@ void EndTransactionRequest::Clear() {
       if (internal_commit_trigger_ != NULL) internal_commit_trigger_->::cockroach::proto::InternalCommitTrigger::Clear();
     }
   }
+  intents_.Clear();
   ::memset(_has_bits_, 0, sizeof(_has_bits_));
   if (_internal_metadata_.have_unknown_fields()) {
     mutable_unknown_fields()->Clear();
@@ -7640,6 +7644,23 @@ bool EndTransactionRequest::MergePartialFromCodedStream(
         } else {
           goto handle_unusual;
         }
+        if (input->ExpectTag(34)) goto parse_intents;
+        break;
+      }
+
+      // repeated .cockroach.proto.Intent intents = 4;
+      case 4: {
+        if (tag == 34) {
+         parse_intents:
+          DO_(input->IncrementRecursionDepth());
+         parse_loop_intents:
+          DO_(::google::protobuf::internal::WireFormatLite::ReadMessageNoVirtualNoRecursionDepth(
+                input, add_intents()));
+        } else {
+          goto handle_unusual;
+        }
+        if (input->ExpectTag(34)) goto parse_loop_intents;
+        input->UnsafeDecrementRecursionDepth();
         if (input->ExpectAtEnd()) goto success;
         break;
       }
@@ -7686,6 +7707,12 @@ void EndTransactionRequest::SerializeWithCachedSizes(
       3, *this->internal_commit_trigger_, output);
   }
 
+  // repeated .cockroach.proto.Intent intents = 4;
+  for (unsigned int i = 0, n = this->intents_size(); i < n; i++) {
+    ::google::protobuf::internal::WireFormatLite::WriteMessageMaybeToArray(
+      4, this->intents(i), output);
+  }
+
   if (_internal_metadata_.have_unknown_fields()) {
     ::google::protobuf::internal::WireFormat::SerializeUnknownFields(
         unknown_fields(), output);
@@ -7713,6 +7740,13 @@ void EndTransactionRequest::SerializeWithCachedSizes(
     target = ::google::protobuf::internal::WireFormatLite::
       WriteMessageNoVirtualToArray(
         3, *this->internal_commit_trigger_, target);
+  }
+
+  // repeated .cockroach.proto.Intent intents = 4;
+  for (unsigned int i = 0, n = this->intents_size(); i < n; i++) {
+    target = ::google::protobuf::internal::WireFormatLite::
+      WriteMessageNoVirtualToArray(
+        4, this->intents(i), target);
   }
 
   if (_internal_metadata_.have_unknown_fields()) {
@@ -7747,6 +7781,14 @@ int EndTransactionRequest::ByteSize() const {
     }
 
   }
+  // repeated .cockroach.proto.Intent intents = 4;
+  total_size += 1 * this->intents_size();
+  for (int i = 0; i < this->intents_size(); i++) {
+    total_size +=
+      ::google::protobuf::internal::WireFormatLite::MessageSizeNoVirtual(
+        this->intents(i));
+  }
+
   if (_internal_metadata_.have_unknown_fields()) {
     total_size +=
       ::google::protobuf::internal::WireFormat::ComputeUnknownFieldsSize(
@@ -7772,6 +7814,7 @@ void EndTransactionRequest::MergeFrom(const ::google::protobuf::Message& from) {
 
 void EndTransactionRequest::MergeFrom(const EndTransactionRequest& from) {
   if (GOOGLE_PREDICT_FALSE(&from == this)) MergeFromFail(__LINE__);
+  intents_.MergeFrom(from.intents_);
   if (from._has_bits_[0 / 32] & (0xffu << (0 % 32))) {
     if (from.has_header()) {
       mutable_header()->::cockroach::proto::RequestHeader::MergeFrom(from.header());
@@ -7813,6 +7856,7 @@ void EndTransactionRequest::InternalSwap(EndTransactionRequest* other) {
   std::swap(header_, other->header_);
   std::swap(commit_, other->commit_);
   std::swap(internal_commit_trigger_, other->internal_commit_trigger_);
+  intents_.UnsafeArenaSwap(&other->intents_);
   std::swap(_has_bits_[0], other->_has_bits_[0]);
   _internal_metadata_.Swap(&other->_internal_metadata_);
   std::swap(_cached_size_, other->_cached_size_);
@@ -7937,6 +7981,36 @@ void EndTransactionRequest::clear_internal_commit_trigger() {
     clear_has_internal_commit_trigger();
   }
   // @@protoc_insertion_point(field_set_allocated:cockroach.proto.EndTransactionRequest.internal_commit_trigger)
+}
+
+// repeated .cockroach.proto.Intent intents = 4;
+int EndTransactionRequest::intents_size() const {
+  return intents_.size();
+}
+void EndTransactionRequest::clear_intents() {
+  intents_.Clear();
+}
+ const ::cockroach::proto::Intent& EndTransactionRequest::intents(int index) const {
+  // @@protoc_insertion_point(field_get:cockroach.proto.EndTransactionRequest.intents)
+  return intents_.Get(index);
+}
+ ::cockroach::proto::Intent* EndTransactionRequest::mutable_intents(int index) {
+  // @@protoc_insertion_point(field_mutable:cockroach.proto.EndTransactionRequest.intents)
+  return intents_.Mutable(index);
+}
+ ::cockroach::proto::Intent* EndTransactionRequest::add_intents() {
+  // @@protoc_insertion_point(field_add:cockroach.proto.EndTransactionRequest.intents)
+  return intents_.Add();
+}
+ const ::google::protobuf::RepeatedPtrField< ::cockroach::proto::Intent >&
+EndTransactionRequest::intents() const {
+  // @@protoc_insertion_point(field_list:cockroach.proto.EndTransactionRequest.intents)
+  return intents_;
+}
+ ::google::protobuf::RepeatedPtrField< ::cockroach::proto::Intent >*
+EndTransactionRequest::mutable_intents() {
+  // @@protoc_insertion_point(field_mutable_list:cockroach.proto.EndTransactionRequest.intents)
+  return &intents_;
 }
 
 #endif  // PROTOBUF_INLINE_NOT_IN_HEADERS

--- a/storage/engine/rocksdb/cockroach/proto/api.pb.h
+++ b/storage/engine/rocksdb/cockroach/proto/api.pb.h
@@ -1982,6 +1982,18 @@ class EndTransactionRequest : public ::google::protobuf::Message {
   ::cockroach::proto::InternalCommitTrigger* release_internal_commit_trigger();
   void set_allocated_internal_commit_trigger(::cockroach::proto::InternalCommitTrigger* internal_commit_trigger);
 
+  // repeated .cockroach.proto.Intent intents = 4;
+  int intents_size() const;
+  void clear_intents();
+  static const int kIntentsFieldNumber = 4;
+  const ::cockroach::proto::Intent& intents(int index) const;
+  ::cockroach::proto::Intent* mutable_intents(int index);
+  ::cockroach::proto::Intent* add_intents();
+  const ::google::protobuf::RepeatedPtrField< ::cockroach::proto::Intent >&
+      intents() const;
+  ::google::protobuf::RepeatedPtrField< ::cockroach::proto::Intent >*
+      mutable_intents();
+
   // @@protoc_insertion_point(class_scope:cockroach.proto.EndTransactionRequest)
  private:
   inline void set_has_header();
@@ -1996,6 +2008,7 @@ class EndTransactionRequest : public ::google::protobuf::Message {
   mutable int _cached_size_;
   ::cockroach::proto::RequestHeader* header_;
   ::cockroach::proto::InternalCommitTrigger* internal_commit_trigger_;
+  ::google::protobuf::RepeatedPtrField< ::cockroach::proto::Intent > intents_;
   bool commit_;
   friend void  protobuf_AddDesc_cockroach_2fproto_2fapi_2eproto();
   friend void protobuf_AssignDesc_cockroach_2fproto_2fapi_2eproto();
@@ -4776,6 +4789,36 @@ inline void EndTransactionRequest::set_allocated_internal_commit_trigger(::cockr
     clear_has_internal_commit_trigger();
   }
   // @@protoc_insertion_point(field_set_allocated:cockroach.proto.EndTransactionRequest.internal_commit_trigger)
+}
+
+// repeated .cockroach.proto.Intent intents = 4;
+inline int EndTransactionRequest::intents_size() const {
+  return intents_.size();
+}
+inline void EndTransactionRequest::clear_intents() {
+  intents_.Clear();
+}
+inline const ::cockroach::proto::Intent& EndTransactionRequest::intents(int index) const {
+  // @@protoc_insertion_point(field_get:cockroach.proto.EndTransactionRequest.intents)
+  return intents_.Get(index);
+}
+inline ::cockroach::proto::Intent* EndTransactionRequest::mutable_intents(int index) {
+  // @@protoc_insertion_point(field_mutable:cockroach.proto.EndTransactionRequest.intents)
+  return intents_.Mutable(index);
+}
+inline ::cockroach::proto::Intent* EndTransactionRequest::add_intents() {
+  // @@protoc_insertion_point(field_add:cockroach.proto.EndTransactionRequest.intents)
+  return intents_.Add();
+}
+inline const ::google::protobuf::RepeatedPtrField< ::cockroach::proto::Intent >&
+EndTransactionRequest::intents() const {
+  // @@protoc_insertion_point(field_list:cockroach.proto.EndTransactionRequest.intents)
+  return intents_;
+}
+inline ::google::protobuf::RepeatedPtrField< ::cockroach::proto::Intent >*
+EndTransactionRequest::mutable_intents() {
+  // @@protoc_insertion_point(field_mutable_list:cockroach.proto.EndTransactionRequest.intents)
+  return &intents_;
 }
 
 // -------------------------------------------------------------------

--- a/storage/engine/rocksdb/cockroach/proto/data.pb.cc
+++ b/storage/engine/rocksdb/cockroach/proto/data.pb.cc
@@ -210,11 +210,10 @@ void protobuf_AssignDesc_cockroach_2fproto_2fdata_2eproto() {
       GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(ChangeReplicasTrigger, _internal_metadata_),
       -1);
   InternalCommitTrigger_descriptor_ = file->message_type(8);
-  static const int InternalCommitTrigger_offsets_[4] = {
+  static const int InternalCommitTrigger_offsets_[3] = {
     GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(InternalCommitTrigger, split_trigger_),
     GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(InternalCommitTrigger, merge_trigger_),
     GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(InternalCommitTrigger, change_replicas_trigger_),
-    GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(InternalCommitTrigger, intents_),
   };
   InternalCommitTrigger_reflection_ =
     ::google::protobuf::internal::GeneratedMessageReflection::NewGeneratedMessageReflection(
@@ -287,8 +286,9 @@ void protobuf_AssignDesc_cockroach_2fproto_2fdata_2eproto() {
       GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(Lease, _internal_metadata_),
       -1);
   Intent_descriptor_ = file->message_type(12);
-  static const int Intent_offsets_[2] = {
+  static const int Intent_offsets_[3] = {
     GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(Intent, key_),
+    GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(Intent, end_key_),
     GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(Intent, txn_),
   };
   Intent_reflection_ =
@@ -431,33 +431,33 @@ void protobuf_AddDesc_cockroach_2fproto_2fdata_2eproto() {
     "StoreID\372\336\037\007StoreID\022=\n\013change_type\030\003 \001(\0162"
     "\".cockroach.proto.ReplicaChangeTypeB\004\310\336\037"
     "\000\0228\n\020updated_replicas\030\004 \003(\0132\030.cockroach."
-    "proto.ReplicaB\004\310\336\037\000\"\346\001\n\025InternalCommitTr"
+    "proto.ReplicaB\004\310\336\037\000\"\314\001\n\025InternalCommitTr"
     "igger\0224\n\rsplit_trigger\030\001 \001(\0132\035.cockroach"
     ".proto.SplitTrigger\0224\n\rmerge_trigger\030\002 \001"
     "(\0132\035.cockroach.proto.MergeTrigger\022G\n\027cha"
     "nge_replicas_trigger\030\003 \001(\0132&.cockroach.p"
-    "roto.ChangeReplicasTrigger\022\030\n\007intents\030\004 "
-    "\003(\014B\007\372\336\037\003Key\"\035\n\010NodeList\022\021\n\005nodes\030\001 \003(\005B"
-    "\002\020\001\"\234\004\n\013Transaction\022\022\n\004name\030\001 \001(\tB\004\310\336\037\000\022"
-    "\024\n\003key\030\002 \001(\014B\007\372\336\037\003Key\022\022\n\002id\030\003 \001(\014B\006\342\336\037\002I"
-    "D\022\026\n\010priority\030\004 \001(\005B\004\310\336\037\000\0227\n\tisolation\030\005"
-    " \001(\0162\036.cockroach.proto.IsolationTypeB\004\310\336"
-    "\037\000\0228\n\006status\030\006 \001(\0162\".cockroach.proto.Tra"
-    "nsactionStatusB\004\310\336\037\000\022\023\n\005epoch\030\007 \001(\005B\004\310\336\037"
-    "\000\0222\n\016last_heartbeat\030\010 \001(\0132\032.cockroach.pr"
-    "oto.Timestamp\0223\n\ttimestamp\030\t \001(\0132\032.cockr"
-    "oach.proto.TimestampB\004\310\336\037\000\0228\n\016orig_times"
-    "tamp\030\n \001(\0132\032.cockroach.proto.TimestampB\004"
-    "\310\336\037\000\0227\n\rmax_timestamp\030\013 \001(\0132\032.cockroach."
-    "proto.TimestampB\004\310\336\037\000\0226\n\rcertain_nodes\030\014"
-    " \001(\0132\031.cockroach.proto.NodeListB\004\310\336\037\000\022\025\n"
-    "\007Writing\030\r \001(\010B\004\310\336\037\000:\004\230\240\037\000\"\254\001\n\005Lease\022/\n\005"
-    "start\030\001 \001(\0132\032.cockroach.proto.TimestampB"
-    "\004\310\336\037\000\0224\n\nexpiration\030\002 \001(\0132\032.cockroach.pr"
-    "oto.TimestampB\004\310\336\037\000\0226\n\014raft_node_id\030\003 \001("
-    "\004B \310\336\037\000\342\336\037\nRaftNodeID\372\336\037\nRaftNodeID:\004\230\240\037"
-    "\000\"O\n\006Intent\022\024\n\003key\030\001 \001(\014B\007\372\336\037\003Key\022/\n\003txn"
-    "\030\002 \001(\0132\034.cockroach.proto.TransactionB\004\310\336"
+    "roto.ChangeReplicasTrigger\"\035\n\010NodeList\022\021"
+    "\n\005nodes\030\001 \003(\005B\002\020\001\"\234\004\n\013Transaction\022\022\n\004nam"
+    "e\030\001 \001(\tB\004\310\336\037\000\022\024\n\003key\030\002 \001(\014B\007\372\336\037\003Key\022\022\n\002i"
+    "d\030\003 \001(\014B\006\342\336\037\002ID\022\026\n\010priority\030\004 \001(\005B\004\310\336\037\000\022"
+    "7\n\tisolation\030\005 \001(\0162\036.cockroach.proto.Iso"
+    "lationTypeB\004\310\336\037\000\0228\n\006status\030\006 \001(\0162\".cockr"
+    "oach.proto.TransactionStatusB\004\310\336\037\000\022\023\n\005ep"
+    "och\030\007 \001(\005B\004\310\336\037\000\0222\n\016last_heartbeat\030\010 \001(\0132"
+    "\032.cockroach.proto.Timestamp\0223\n\ttimestamp"
+    "\030\t \001(\0132\032.cockroach.proto.TimestampB\004\310\336\037\000"
+    "\0228\n\016orig_timestamp\030\n \001(\0132\032.cockroach.pro"
+    "to.TimestampB\004\310\336\037\000\0227\n\rmax_timestamp\030\013 \001("
+    "\0132\032.cockroach.proto.TimestampB\004\310\336\037\000\0226\n\rc"
+    "ertain_nodes\030\014 \001(\0132\031.cockroach.proto.Nod"
+    "eListB\004\310\336\037\000\022\025\n\007Writing\030\r \001(\010B\004\310\336\037\000:\004\230\240\037\000"
+    "\"\254\001\n\005Lease\022/\n\005start\030\001 \001(\0132\032.cockroach.pr"
+    "oto.TimestampB\004\310\336\037\000\0224\n\nexpiration\030\002 \001(\0132"
+    "\032.cockroach.proto.TimestampB\004\310\336\037\000\0226\n\014raf"
+    "t_node_id\030\003 \001(\004B \310\336\037\000\342\336\037\nRaftNodeID\372\336\037\nR"
+    "aftNodeID:\004\230\240\037\000\"i\n\006Intent\022\024\n\003key\030\001 \001(\014B\007"
+    "\372\336\037\003Key\022\030\n\007end_key\030\002 \001(\014B\007\372\336\037\003Key\022/\n\003txn"
+    "\030\003 \001(\0132\034.cockroach.proto.TransactionB\004\310\336"
     "\037\000\"H\n\nGCMetadata\022\035\n\017last_scan_nanos\030\001 \001("
     "\003B\004\310\336\037\000\022\033\n\023oldest_intent_nanos\030\002 \001(\003*>\n\021"
     "ReplicaChangeType\022\017\n\013ADD_REPLICA\020\000\022\022\n\016RE"
@@ -3885,7 +3885,6 @@ ChangeReplicasTrigger::mutable_updated_replicas() {
 const int InternalCommitTrigger::kSplitTriggerFieldNumber;
 const int InternalCommitTrigger::kMergeTriggerFieldNumber;
 const int InternalCommitTrigger::kChangeReplicasTriggerFieldNumber;
-const int InternalCommitTrigger::kIntentsFieldNumber;
 #endif  // !_MSC_VER
 
 InternalCommitTrigger::InternalCommitTrigger()
@@ -3909,7 +3908,6 @@ InternalCommitTrigger::InternalCommitTrigger(const InternalCommitTrigger& from)
 }
 
 void InternalCommitTrigger::SharedCtor() {
-  ::google::protobuf::internal::GetEmptyString();
   _cached_size_ = 0;
   split_trigger_ = NULL;
   merge_trigger_ = NULL;
@@ -3967,7 +3965,6 @@ void InternalCommitTrigger::Clear() {
       if (change_replicas_trigger_ != NULL) change_replicas_trigger_->::cockroach::proto::ChangeReplicasTrigger::Clear();
     }
   }
-  intents_.Clear();
   ::memset(_has_bits_, 0, sizeof(_has_bits_));
   if (_internal_metadata_.have_unknown_fields()) {
     mutable_unknown_fields()->Clear();
@@ -4018,20 +4015,6 @@ bool InternalCommitTrigger::MergePartialFromCodedStream(
         } else {
           goto handle_unusual;
         }
-        if (input->ExpectTag(34)) goto parse_intents;
-        break;
-      }
-
-      // repeated bytes intents = 4;
-      case 4: {
-        if (tag == 34) {
-         parse_intents:
-          DO_(::google::protobuf::internal::WireFormatLite::ReadBytes(
-                input, this->add_intents()));
-        } else {
-          goto handle_unusual;
-        }
-        if (input->ExpectTag(34)) goto parse_intents;
         if (input->ExpectAtEnd()) goto success;
         break;
       }
@@ -4079,12 +4062,6 @@ void InternalCommitTrigger::SerializeWithCachedSizes(
       3, *this->change_replicas_trigger_, output);
   }
 
-  // repeated bytes intents = 4;
-  for (int i = 0; i < this->intents_size(); i++) {
-    ::google::protobuf::internal::WireFormatLite::WriteBytes(
-      4, this->intents(i), output);
-  }
-
   if (_internal_metadata_.have_unknown_fields()) {
     ::google::protobuf::internal::WireFormat::SerializeUnknownFields(
         unknown_fields(), output);
@@ -4114,12 +4091,6 @@ void InternalCommitTrigger::SerializeWithCachedSizes(
     target = ::google::protobuf::internal::WireFormatLite::
       WriteMessageNoVirtualToArray(
         3, *this->change_replicas_trigger_, target);
-  }
-
-  // repeated bytes intents = 4;
-  for (int i = 0; i < this->intents_size(); i++) {
-    target = ::google::protobuf::internal::WireFormatLite::
-      WriteBytesToArray(4, this->intents(i), target);
   }
 
   if (_internal_metadata_.have_unknown_fields()) {
@@ -4156,13 +4127,6 @@ int InternalCommitTrigger::ByteSize() const {
     }
 
   }
-  // repeated bytes intents = 4;
-  total_size += 1 * this->intents_size();
-  for (int i = 0; i < this->intents_size(); i++) {
-    total_size += ::google::protobuf::internal::WireFormatLite::BytesSize(
-      this->intents(i));
-  }
-
   if (_internal_metadata_.have_unknown_fields()) {
     total_size +=
       ::google::protobuf::internal::WireFormat::ComputeUnknownFieldsSize(
@@ -4188,7 +4152,6 @@ void InternalCommitTrigger::MergeFrom(const ::google::protobuf::Message& from) {
 
 void InternalCommitTrigger::MergeFrom(const InternalCommitTrigger& from) {
   if (GOOGLE_PREDICT_FALSE(&from == this)) MergeFromFail(__LINE__);
-  intents_.MergeFrom(from.intents_);
   if (from._has_bits_[0 / 32] & (0xffu << (0 % 32))) {
     if (from.has_split_trigger()) {
       mutable_split_trigger()->::cockroach::proto::SplitTrigger::MergeFrom(from.split_trigger());
@@ -4230,7 +4193,6 @@ void InternalCommitTrigger::InternalSwap(InternalCommitTrigger* other) {
   std::swap(split_trigger_, other->split_trigger_);
   std::swap(merge_trigger_, other->merge_trigger_);
   std::swap(change_replicas_trigger_, other->change_replicas_trigger_);
-  intents_.UnsafeArenaSwap(&other->intents_);
   std::swap(_has_bits_[0], other->_has_bits_[0]);
   _internal_metadata_.Swap(&other->_internal_metadata_);
   std::swap(_cached_size_, other->_cached_size_);
@@ -4374,60 +4336,6 @@ void InternalCommitTrigger::clear_change_replicas_trigger() {
     clear_has_change_replicas_trigger();
   }
   // @@protoc_insertion_point(field_set_allocated:cockroach.proto.InternalCommitTrigger.change_replicas_trigger)
-}
-
-// repeated bytes intents = 4;
-int InternalCommitTrigger::intents_size() const {
-  return intents_.size();
-}
-void InternalCommitTrigger::clear_intents() {
-  intents_.Clear();
-}
- const ::std::string& InternalCommitTrigger::intents(int index) const {
-  // @@protoc_insertion_point(field_get:cockroach.proto.InternalCommitTrigger.intents)
-  return intents_.Get(index);
-}
- ::std::string* InternalCommitTrigger::mutable_intents(int index) {
-  // @@protoc_insertion_point(field_mutable:cockroach.proto.InternalCommitTrigger.intents)
-  return intents_.Mutable(index);
-}
- void InternalCommitTrigger::set_intents(int index, const ::std::string& value) {
-  // @@protoc_insertion_point(field_set:cockroach.proto.InternalCommitTrigger.intents)
-  intents_.Mutable(index)->assign(value);
-}
- void InternalCommitTrigger::set_intents(int index, const char* value) {
-  intents_.Mutable(index)->assign(value);
-  // @@protoc_insertion_point(field_set_char:cockroach.proto.InternalCommitTrigger.intents)
-}
- void InternalCommitTrigger::set_intents(int index, const void* value, size_t size) {
-  intents_.Mutable(index)->assign(
-    reinterpret_cast<const char*>(value), size);
-  // @@protoc_insertion_point(field_set_pointer:cockroach.proto.InternalCommitTrigger.intents)
-}
- ::std::string* InternalCommitTrigger::add_intents() {
-  return intents_.Add();
-}
- void InternalCommitTrigger::add_intents(const ::std::string& value) {
-  intents_.Add()->assign(value);
-  // @@protoc_insertion_point(field_add:cockroach.proto.InternalCommitTrigger.intents)
-}
- void InternalCommitTrigger::add_intents(const char* value) {
-  intents_.Add()->assign(value);
-  // @@protoc_insertion_point(field_add_char:cockroach.proto.InternalCommitTrigger.intents)
-}
- void InternalCommitTrigger::add_intents(const void* value, size_t size) {
-  intents_.Add()->assign(reinterpret_cast<const char*>(value), size);
-  // @@protoc_insertion_point(field_add_pointer:cockroach.proto.InternalCommitTrigger.intents)
-}
- const ::google::protobuf::RepeatedPtrField< ::std::string>&
-InternalCommitTrigger::intents() const {
-  // @@protoc_insertion_point(field_list:cockroach.proto.InternalCommitTrigger.intents)
-  return intents_;
-}
- ::google::protobuf::RepeatedPtrField< ::std::string>*
-InternalCommitTrigger::mutable_intents() {
-  // @@protoc_insertion_point(field_mutable_list:cockroach.proto.InternalCommitTrigger.intents)
-  return &intents_;
 }
 
 #endif  // PROTOBUF_INLINE_NOT_IN_HEADERS
@@ -6441,6 +6349,7 @@ void Lease::clear_raft_node_id() {
 
 #ifndef _MSC_VER
 const int Intent::kKeyFieldNumber;
+const int Intent::kEndKeyFieldNumber;
 const int Intent::kTxnFieldNumber;
 #endif  // !_MSC_VER
 
@@ -6466,6 +6375,7 @@ void Intent::SharedCtor() {
   ::google::protobuf::internal::GetEmptyString();
   _cached_size_ = 0;
   key_.UnsafeSetDefault(&::google::protobuf::internal::GetEmptyStringAlreadyInited());
+  end_key_.UnsafeSetDefault(&::google::protobuf::internal::GetEmptyStringAlreadyInited());
   txn_ = NULL;
   ::memset(_has_bits_, 0, sizeof(_has_bits_));
 }
@@ -6477,6 +6387,7 @@ Intent::~Intent() {
 
 void Intent::SharedDtor() {
   key_.DestroyNoArena(&::google::protobuf::internal::GetEmptyStringAlreadyInited());
+  end_key_.DestroyNoArena(&::google::protobuf::internal::GetEmptyStringAlreadyInited());
   if (this != default_instance_) {
     delete txn_;
   }
@@ -6508,9 +6419,12 @@ Intent* Intent::New(::google::protobuf::Arena* arena) const {
 }
 
 void Intent::Clear() {
-  if (_has_bits_[0 / 32] & 3u) {
+  if (_has_bits_[0 / 32] & 7u) {
     if (has_key()) {
       key_.ClearToEmptyNoArena(&::google::protobuf::internal::GetEmptyStringAlreadyInited());
+    }
+    if (has_end_key()) {
+      end_key_.ClearToEmptyNoArena(&::google::protobuf::internal::GetEmptyStringAlreadyInited());
     }
     if (has_txn()) {
       if (txn_ != NULL) txn_->::cockroach::proto::Transaction::Clear();
@@ -6540,13 +6454,26 @@ bool Intent::MergePartialFromCodedStream(
         } else {
           goto handle_unusual;
         }
-        if (input->ExpectTag(18)) goto parse_txn;
+        if (input->ExpectTag(18)) goto parse_end_key;
         break;
       }
 
-      // optional .cockroach.proto.Transaction txn = 2;
+      // optional bytes end_key = 2;
       case 2: {
         if (tag == 18) {
+         parse_end_key:
+          DO_(::google::protobuf::internal::WireFormatLite::ReadBytes(
+                input, this->mutable_end_key()));
+        } else {
+          goto handle_unusual;
+        }
+        if (input->ExpectTag(26)) goto parse_txn;
+        break;
+      }
+
+      // optional .cockroach.proto.Transaction txn = 3;
+      case 3: {
+        if (tag == 26) {
          parse_txn:
           DO_(::google::protobuf::internal::WireFormatLite::ReadMessageNoVirtual(
                input, mutable_txn()));
@@ -6588,10 +6515,16 @@ void Intent::SerializeWithCachedSizes(
       1, this->key(), output);
   }
 
-  // optional .cockroach.proto.Transaction txn = 2;
+  // optional bytes end_key = 2;
+  if (has_end_key()) {
+    ::google::protobuf::internal::WireFormatLite::WriteBytesMaybeAliased(
+      2, this->end_key(), output);
+  }
+
+  // optional .cockroach.proto.Transaction txn = 3;
   if (has_txn()) {
     ::google::protobuf::internal::WireFormatLite::WriteMessageMaybeToArray(
-      2, *this->txn_, output);
+      3, *this->txn_, output);
   }
 
   if (_internal_metadata_.have_unknown_fields()) {
@@ -6611,11 +6544,18 @@ void Intent::SerializeWithCachedSizes(
         1, this->key(), target);
   }
 
-  // optional .cockroach.proto.Transaction txn = 2;
+  // optional bytes end_key = 2;
+  if (has_end_key()) {
+    target =
+      ::google::protobuf::internal::WireFormatLite::WriteBytesToArray(
+        2, this->end_key(), target);
+  }
+
+  // optional .cockroach.proto.Transaction txn = 3;
   if (has_txn()) {
     target = ::google::protobuf::internal::WireFormatLite::
       WriteMessageNoVirtualToArray(
-        2, *this->txn_, target);
+        3, *this->txn_, target);
   }
 
   if (_internal_metadata_.have_unknown_fields()) {
@@ -6629,7 +6569,7 @@ void Intent::SerializeWithCachedSizes(
 int Intent::ByteSize() const {
   int total_size = 0;
 
-  if (_has_bits_[0 / 32] & 3) {
+  if (_has_bits_[0 / 32] & 7) {
     // optional bytes key = 1;
     if (has_key()) {
       total_size += 1 +
@@ -6637,7 +6577,14 @@ int Intent::ByteSize() const {
           this->key());
     }
 
-    // optional .cockroach.proto.Transaction txn = 2;
+    // optional bytes end_key = 2;
+    if (has_end_key()) {
+      total_size += 1 +
+        ::google::protobuf::internal::WireFormatLite::BytesSize(
+          this->end_key());
+    }
+
+    // optional .cockroach.proto.Transaction txn = 3;
     if (has_txn()) {
       total_size += 1 +
         ::google::protobuf::internal::WireFormatLite::MessageSizeNoVirtual(
@@ -6675,6 +6622,10 @@ void Intent::MergeFrom(const Intent& from) {
       set_has_key();
       key_.AssignWithDefault(&::google::protobuf::internal::GetEmptyStringAlreadyInited(), from.key_);
     }
+    if (from.has_end_key()) {
+      set_has_end_key();
+      end_key_.AssignWithDefault(&::google::protobuf::internal::GetEmptyStringAlreadyInited(), from.end_key_);
+    }
     if (from.has_txn()) {
       mutable_txn()->::cockroach::proto::Transaction::MergeFrom(from.txn());
     }
@@ -6707,6 +6658,7 @@ void Intent::Swap(Intent* other) {
 }
 void Intent::InternalSwap(Intent* other) {
   key_.Swap(&other->key_);
+  end_key_.Swap(&other->end_key_);
   std::swap(txn_, other->txn_);
   std::swap(_has_bits_[0], other->_has_bits_[0]);
   _internal_metadata_.Swap(&other->_internal_metadata_);
@@ -6777,15 +6729,68 @@ void Intent::clear_key() {
   // @@protoc_insertion_point(field_set_allocated:cockroach.proto.Intent.key)
 }
 
-// optional .cockroach.proto.Transaction txn = 2;
-bool Intent::has_txn() const {
+// optional bytes end_key = 2;
+bool Intent::has_end_key() const {
   return (_has_bits_[0] & 0x00000002u) != 0;
 }
-void Intent::set_has_txn() {
+void Intent::set_has_end_key() {
   _has_bits_[0] |= 0x00000002u;
 }
-void Intent::clear_has_txn() {
+void Intent::clear_has_end_key() {
   _has_bits_[0] &= ~0x00000002u;
+}
+void Intent::clear_end_key() {
+  end_key_.ClearToEmptyNoArena(&::google::protobuf::internal::GetEmptyStringAlreadyInited());
+  clear_has_end_key();
+}
+ const ::std::string& Intent::end_key() const {
+  // @@protoc_insertion_point(field_get:cockroach.proto.Intent.end_key)
+  return end_key_.GetNoArena(&::google::protobuf::internal::GetEmptyStringAlreadyInited());
+}
+ void Intent::set_end_key(const ::std::string& value) {
+  set_has_end_key();
+  end_key_.SetNoArena(&::google::protobuf::internal::GetEmptyStringAlreadyInited(), value);
+  // @@protoc_insertion_point(field_set:cockroach.proto.Intent.end_key)
+}
+ void Intent::set_end_key(const char* value) {
+  set_has_end_key();
+  end_key_.SetNoArena(&::google::protobuf::internal::GetEmptyStringAlreadyInited(), ::std::string(value));
+  // @@protoc_insertion_point(field_set_char:cockroach.proto.Intent.end_key)
+}
+ void Intent::set_end_key(const void* value, size_t size) {
+  set_has_end_key();
+  end_key_.SetNoArena(&::google::protobuf::internal::GetEmptyStringAlreadyInited(),
+      ::std::string(reinterpret_cast<const char*>(value), size));
+  // @@protoc_insertion_point(field_set_pointer:cockroach.proto.Intent.end_key)
+}
+ ::std::string* Intent::mutable_end_key() {
+  set_has_end_key();
+  // @@protoc_insertion_point(field_mutable:cockroach.proto.Intent.end_key)
+  return end_key_.MutableNoArena(&::google::protobuf::internal::GetEmptyStringAlreadyInited());
+}
+ ::std::string* Intent::release_end_key() {
+  clear_has_end_key();
+  return end_key_.ReleaseNoArena(&::google::protobuf::internal::GetEmptyStringAlreadyInited());
+}
+ void Intent::set_allocated_end_key(::std::string* end_key) {
+  if (end_key != NULL) {
+    set_has_end_key();
+  } else {
+    clear_has_end_key();
+  }
+  end_key_.SetAllocatedNoArena(&::google::protobuf::internal::GetEmptyStringAlreadyInited(), end_key);
+  // @@protoc_insertion_point(field_set_allocated:cockroach.proto.Intent.end_key)
+}
+
+// optional .cockroach.proto.Transaction txn = 3;
+bool Intent::has_txn() const {
+  return (_has_bits_[0] & 0x00000004u) != 0;
+}
+void Intent::set_has_txn() {
+  _has_bits_[0] |= 0x00000004u;
+}
+void Intent::clear_has_txn() {
+  _has_bits_[0] &= ~0x00000004u;
 }
 void Intent::clear_txn() {
   if (txn_ != NULL) txn_->::cockroach::proto::Transaction::Clear();

--- a/storage/engine/rocksdb/cockroach/proto/data.pb.h
+++ b/storage/engine/rocksdb/cockroach/proto/data.pb.h
@@ -1091,22 +1091,6 @@ class InternalCommitTrigger : public ::google::protobuf::Message {
   ::cockroach::proto::ChangeReplicasTrigger* release_change_replicas_trigger();
   void set_allocated_change_replicas_trigger(::cockroach::proto::ChangeReplicasTrigger* change_replicas_trigger);
 
-  // repeated bytes intents = 4;
-  int intents_size() const;
-  void clear_intents();
-  static const int kIntentsFieldNumber = 4;
-  const ::std::string& intents(int index) const;
-  ::std::string* mutable_intents(int index);
-  void set_intents(int index, const ::std::string& value);
-  void set_intents(int index, const char* value);
-  void set_intents(int index, const void* value, size_t size);
-  ::std::string* add_intents();
-  void add_intents(const ::std::string& value);
-  void add_intents(const char* value);
-  void add_intents(const void* value, size_t size);
-  const ::google::protobuf::RepeatedPtrField< ::std::string>& intents() const;
-  ::google::protobuf::RepeatedPtrField< ::std::string>* mutable_intents();
-
   // @@protoc_insertion_point(class_scope:cockroach.proto.InternalCommitTrigger)
  private:
   inline void set_has_split_trigger();
@@ -1122,7 +1106,6 @@ class InternalCommitTrigger : public ::google::protobuf::Message {
   ::cockroach::proto::SplitTrigger* split_trigger_;
   ::cockroach::proto::MergeTrigger* merge_trigger_;
   ::cockroach::proto::ChangeReplicasTrigger* change_replicas_trigger_;
-  ::google::protobuf::RepeatedPtrField< ::std::string> intents_;
   friend void  protobuf_AddDesc_cockroach_2fproto_2fdata_2eproto();
   friend void protobuf_AssignDesc_cockroach_2fproto_2fdata_2eproto();
   friend void protobuf_ShutdownFile_cockroach_2fproto_2fdata_2eproto();
@@ -1648,10 +1631,22 @@ class Intent : public ::google::protobuf::Message {
   ::std::string* release_key();
   void set_allocated_key(::std::string* key);
 
-  // optional .cockroach.proto.Transaction txn = 2;
+  // optional bytes end_key = 2;
+  bool has_end_key() const;
+  void clear_end_key();
+  static const int kEndKeyFieldNumber = 2;
+  const ::std::string& end_key() const;
+  void set_end_key(const ::std::string& value);
+  void set_end_key(const char* value);
+  void set_end_key(const void* value, size_t size);
+  ::std::string* mutable_end_key();
+  ::std::string* release_end_key();
+  void set_allocated_end_key(::std::string* end_key);
+
+  // optional .cockroach.proto.Transaction txn = 3;
   bool has_txn() const;
   void clear_txn();
-  static const int kTxnFieldNumber = 2;
+  static const int kTxnFieldNumber = 3;
   const ::cockroach::proto::Transaction& txn() const;
   ::cockroach::proto::Transaction* mutable_txn();
   ::cockroach::proto::Transaction* release_txn();
@@ -1661,6 +1656,8 @@ class Intent : public ::google::protobuf::Message {
  private:
   inline void set_has_key();
   inline void clear_has_key();
+  inline void set_has_end_key();
+  inline void clear_has_end_key();
   inline void set_has_txn();
   inline void clear_has_txn();
 
@@ -1668,6 +1665,7 @@ class Intent : public ::google::protobuf::Message {
   ::google::protobuf::uint32 _has_bits_[1];
   mutable int _cached_size_;
   ::google::protobuf::internal::ArenaStringPtr key_;
+  ::google::protobuf::internal::ArenaStringPtr end_key_;
   ::cockroach::proto::Transaction* txn_;
   friend void  protobuf_AddDesc_cockroach_2fproto_2fdata_2eproto();
   friend void protobuf_AssignDesc_cockroach_2fproto_2fdata_2eproto();
@@ -2724,60 +2722,6 @@ inline void InternalCommitTrigger::set_allocated_change_replicas_trigger(::cockr
   // @@protoc_insertion_point(field_set_allocated:cockroach.proto.InternalCommitTrigger.change_replicas_trigger)
 }
 
-// repeated bytes intents = 4;
-inline int InternalCommitTrigger::intents_size() const {
-  return intents_.size();
-}
-inline void InternalCommitTrigger::clear_intents() {
-  intents_.Clear();
-}
-inline const ::std::string& InternalCommitTrigger::intents(int index) const {
-  // @@protoc_insertion_point(field_get:cockroach.proto.InternalCommitTrigger.intents)
-  return intents_.Get(index);
-}
-inline ::std::string* InternalCommitTrigger::mutable_intents(int index) {
-  // @@protoc_insertion_point(field_mutable:cockroach.proto.InternalCommitTrigger.intents)
-  return intents_.Mutable(index);
-}
-inline void InternalCommitTrigger::set_intents(int index, const ::std::string& value) {
-  // @@protoc_insertion_point(field_set:cockroach.proto.InternalCommitTrigger.intents)
-  intents_.Mutable(index)->assign(value);
-}
-inline void InternalCommitTrigger::set_intents(int index, const char* value) {
-  intents_.Mutable(index)->assign(value);
-  // @@protoc_insertion_point(field_set_char:cockroach.proto.InternalCommitTrigger.intents)
-}
-inline void InternalCommitTrigger::set_intents(int index, const void* value, size_t size) {
-  intents_.Mutable(index)->assign(
-    reinterpret_cast<const char*>(value), size);
-  // @@protoc_insertion_point(field_set_pointer:cockroach.proto.InternalCommitTrigger.intents)
-}
-inline ::std::string* InternalCommitTrigger::add_intents() {
-  return intents_.Add();
-}
-inline void InternalCommitTrigger::add_intents(const ::std::string& value) {
-  intents_.Add()->assign(value);
-  // @@protoc_insertion_point(field_add:cockroach.proto.InternalCommitTrigger.intents)
-}
-inline void InternalCommitTrigger::add_intents(const char* value) {
-  intents_.Add()->assign(value);
-  // @@protoc_insertion_point(field_add_char:cockroach.proto.InternalCommitTrigger.intents)
-}
-inline void InternalCommitTrigger::add_intents(const void* value, size_t size) {
-  intents_.Add()->assign(reinterpret_cast<const char*>(value), size);
-  // @@protoc_insertion_point(field_add_pointer:cockroach.proto.InternalCommitTrigger.intents)
-}
-inline const ::google::protobuf::RepeatedPtrField< ::std::string>&
-InternalCommitTrigger::intents() const {
-  // @@protoc_insertion_point(field_list:cockroach.proto.InternalCommitTrigger.intents)
-  return intents_;
-}
-inline ::google::protobuf::RepeatedPtrField< ::std::string>*
-InternalCommitTrigger::mutable_intents() {
-  // @@protoc_insertion_point(field_mutable_list:cockroach.proto.InternalCommitTrigger.intents)
-  return &intents_;
-}
-
 // -------------------------------------------------------------------
 
 // NodeList
@@ -3483,15 +3427,68 @@ inline void Intent::set_allocated_key(::std::string* key) {
   // @@protoc_insertion_point(field_set_allocated:cockroach.proto.Intent.key)
 }
 
-// optional .cockroach.proto.Transaction txn = 2;
-inline bool Intent::has_txn() const {
+// optional bytes end_key = 2;
+inline bool Intent::has_end_key() const {
   return (_has_bits_[0] & 0x00000002u) != 0;
 }
-inline void Intent::set_has_txn() {
+inline void Intent::set_has_end_key() {
   _has_bits_[0] |= 0x00000002u;
 }
-inline void Intent::clear_has_txn() {
+inline void Intent::clear_has_end_key() {
   _has_bits_[0] &= ~0x00000002u;
+}
+inline void Intent::clear_end_key() {
+  end_key_.ClearToEmptyNoArena(&::google::protobuf::internal::GetEmptyStringAlreadyInited());
+  clear_has_end_key();
+}
+inline const ::std::string& Intent::end_key() const {
+  // @@protoc_insertion_point(field_get:cockroach.proto.Intent.end_key)
+  return end_key_.GetNoArena(&::google::protobuf::internal::GetEmptyStringAlreadyInited());
+}
+inline void Intent::set_end_key(const ::std::string& value) {
+  set_has_end_key();
+  end_key_.SetNoArena(&::google::protobuf::internal::GetEmptyStringAlreadyInited(), value);
+  // @@protoc_insertion_point(field_set:cockroach.proto.Intent.end_key)
+}
+inline void Intent::set_end_key(const char* value) {
+  set_has_end_key();
+  end_key_.SetNoArena(&::google::protobuf::internal::GetEmptyStringAlreadyInited(), ::std::string(value));
+  // @@protoc_insertion_point(field_set_char:cockroach.proto.Intent.end_key)
+}
+inline void Intent::set_end_key(const void* value, size_t size) {
+  set_has_end_key();
+  end_key_.SetNoArena(&::google::protobuf::internal::GetEmptyStringAlreadyInited(),
+      ::std::string(reinterpret_cast<const char*>(value), size));
+  // @@protoc_insertion_point(field_set_pointer:cockroach.proto.Intent.end_key)
+}
+inline ::std::string* Intent::mutable_end_key() {
+  set_has_end_key();
+  // @@protoc_insertion_point(field_mutable:cockroach.proto.Intent.end_key)
+  return end_key_.MutableNoArena(&::google::protobuf::internal::GetEmptyStringAlreadyInited());
+}
+inline ::std::string* Intent::release_end_key() {
+  clear_has_end_key();
+  return end_key_.ReleaseNoArena(&::google::protobuf::internal::GetEmptyStringAlreadyInited());
+}
+inline void Intent::set_allocated_end_key(::std::string* end_key) {
+  if (end_key != NULL) {
+    set_has_end_key();
+  } else {
+    clear_has_end_key();
+  }
+  end_key_.SetAllocatedNoArena(&::google::protobuf::internal::GetEmptyStringAlreadyInited(), end_key);
+  // @@protoc_insertion_point(field_set_allocated:cockroach.proto.Intent.end_key)
+}
+
+// optional .cockroach.proto.Transaction txn = 3;
+inline bool Intent::has_txn() const {
+  return (_has_bits_[0] & 0x00000004u) != 0;
+}
+inline void Intent::set_has_txn() {
+  _has_bits_[0] |= 0x00000004u;
+}
+inline void Intent::clear_has_txn() {
+  _has_bits_[0] &= ~0x00000004u;
 }
 inline void Intent::clear_txn() {
   if (txn_ != NULL) txn_->::cockroach::proto::Transaction::Clear();


### PR DESCRIPTION
and add EndKey to Intent (unused at this point).

this is part of #1873. Passing the `Intent`s via `EndTransaction`
is going to be how intents are resolved at the `Range` level.
