### PR TITLE
Clean up removed range replica on ChangeReplicas commit trigger.

### DIFF
--- a/proto/api.go
+++ b/proto/api.go
@@ -46,11 +46,11 @@ func (ccid ClientCmdID) TraceName() string {
 }
 
 const (
-	isAdmin = 1 << iota
-	isRead
-	isWrite
-	isTxnWrite
-	isRange
+	isAdmin    = 1 << iota // admin cmds don't go through raft, but run on leader
+	isRead                 // read-only cmds don't go through raft, but may run on leader
+	isWrite                // write cmds go through raft and must be proposed on leader
+	isTxnWrite             // txn write cmds start heartbeat and are marked for intent resolution
+	isRange                // range commands may span multiple keys
 )
 
 // IsAdmin returns true if the request requires admin permissions.

--- a/proto/data.pb.go
+++ b/proto/data.pb.go
@@ -333,8 +333,10 @@ type ChangeReplicasTrigger struct {
 	NodeID     NodeID            `protobuf:"varint,1,opt,name=node_id,casttype=NodeID" json:"node_id"`
 	StoreID    StoreID           `protobuf:"varint,2,opt,name=store_id,casttype=StoreID" json:"store_id"`
 	ChangeType ReplicaChangeType `protobuf:"varint,3,opt,name=change_type,enum=cockroach.proto.ReplicaChangeType" json:"change_type"`
+	// The replica being modified.
+	Replica Replica `protobuf:"bytes,4,opt,name=replica" json:"replica"`
 	// The new replica list with this change applied.
-	UpdatedReplicas  []Replica `protobuf:"bytes,4,rep,name=updated_replicas" json:"updated_replicas"`
+	UpdatedReplicas  []Replica `protobuf:"bytes,5,rep,name=updated_replicas" json:"updated_replicas"`
 	XXX_unrecognized []byte    `json:"-"`
 }
 
@@ -347,6 +349,13 @@ func (m *ChangeReplicasTrigger) GetChangeType() ReplicaChangeType {
 		return m.ChangeType
 	}
 	return ADD_REPLICA
+}
+
+func (m *ChangeReplicasTrigger) GetReplica() Replica {
+	if m != nil {
+		return m.Replica
+	}
+	return Replica{}
 }
 
 func (m *ChangeReplicasTrigger) GetUpdatedReplicas() []Replica {
@@ -1352,6 +1361,30 @@ func (m *ChangeReplicasTrigger) Unmarshal(data []byte) error {
 				}
 			}
 		case 4:
+			if wireType != 2 {
+				return fmt.Errorf("proto: wrong wireType = %d for field Replica", wireType)
+			}
+			var msglen int
+			for shift := uint(0); ; shift += 7 {
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := data[iNdEx]
+				iNdEx++
+				msglen |= (int(b) & 0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			postIndex := iNdEx + msglen
+			if postIndex > l {
+				return io.ErrUnexpectedEOF
+			}
+			if err := m.Replica.Unmarshal(data[iNdEx:postIndex]); err != nil {
+				return err
+			}
+			iNdEx = postIndex
+		case 5:
 			if wireType != 2 {
 				return fmt.Errorf("proto: wrong wireType = %d for field UpdatedReplicas", wireType)
 			}
@@ -2413,6 +2446,8 @@ func (m *ChangeReplicasTrigger) Size() (n int) {
 	n += 1 + sovData(uint64(m.NodeID))
 	n += 1 + sovData(uint64(m.StoreID))
 	n += 1 + sovData(uint64(m.ChangeType))
+	l = m.Replica.Size()
+	n += 1 + l + sovData(uint64(l))
 	if len(m.UpdatedReplicas) > 0 {
 		for _, e := range m.UpdatedReplicas {
 			l = e.Size()
@@ -2824,9 +2859,17 @@ func (m *ChangeReplicasTrigger) MarshalTo(data []byte) (n int, err error) {
 	data[i] = 0x18
 	i++
 	i = encodeVarintData(data, i, uint64(m.ChangeType))
+	data[i] = 0x22
+	i++
+	i = encodeVarintData(data, i, uint64(m.Replica.Size()))
+	n6, err := m.Replica.MarshalTo(data[i:])
+	if err != nil {
+		return 0, err
+	}
+	i += n6
 	if len(m.UpdatedReplicas) > 0 {
 		for _, msg := range m.UpdatedReplicas {
-			data[i] = 0x22
+			data[i] = 0x2a
 			i++
 			i = encodeVarintData(data, i, uint64(msg.Size()))
 			n, err := msg.MarshalTo(data[i:])
@@ -2861,31 +2904,31 @@ func (m *InternalCommitTrigger) MarshalTo(data []byte) (n int, err error) {
 		data[i] = 0xa
 		i++
 		i = encodeVarintData(data, i, uint64(m.SplitTrigger.Size()))
-		n6, err := m.SplitTrigger.MarshalTo(data[i:])
-		if err != nil {
-			return 0, err
-		}
-		i += n6
-	}
-	if m.MergeTrigger != nil {
-		data[i] = 0x12
-		i++
-		i = encodeVarintData(data, i, uint64(m.MergeTrigger.Size()))
-		n7, err := m.MergeTrigger.MarshalTo(data[i:])
+		n7, err := m.SplitTrigger.MarshalTo(data[i:])
 		if err != nil {
 			return 0, err
 		}
 		i += n7
 	}
-	if m.ChangeReplicasTrigger != nil {
-		data[i] = 0x1a
+	if m.MergeTrigger != nil {
+		data[i] = 0x12
 		i++
-		i = encodeVarintData(data, i, uint64(m.ChangeReplicasTrigger.Size()))
-		n8, err := m.ChangeReplicasTrigger.MarshalTo(data[i:])
+		i = encodeVarintData(data, i, uint64(m.MergeTrigger.Size()))
+		n8, err := m.MergeTrigger.MarshalTo(data[i:])
 		if err != nil {
 			return 0, err
 		}
 		i += n8
+	}
+	if m.ChangeReplicasTrigger != nil {
+		data[i] = 0x1a
+		i++
+		i = encodeVarintData(data, i, uint64(m.ChangeReplicasTrigger.Size()))
+		n9, err := m.ChangeReplicasTrigger.MarshalTo(data[i:])
+		if err != nil {
+			return 0, err
+		}
+		i += n9
 	}
 	if m.XXX_unrecognized != nil {
 		i += copy(data[i:], m.XXX_unrecognized)
@@ -2909,22 +2952,22 @@ func (m *NodeList) MarshalTo(data []byte) (n int, err error) {
 	var l int
 	_ = l
 	if len(m.Nodes) > 0 {
-		data10 := make([]byte, len(m.Nodes)*10)
-		var j9 int
+		data11 := make([]byte, len(m.Nodes)*10)
+		var j10 int
 		for _, num1 := range m.Nodes {
 			num := uint64(num1)
 			for num >= 1<<7 {
-				data10[j9] = uint8(uint64(num)&0x7f | 0x80)
+				data11[j10] = uint8(uint64(num)&0x7f | 0x80)
 				num >>= 7
-				j9++
+				j10++
 			}
-			data10[j9] = uint8(num)
-			j9++
+			data11[j10] = uint8(num)
+			j10++
 		}
 		data[i] = 0xa
 		i++
-		i = encodeVarintData(data, i, uint64(j9))
-		i += copy(data[i:], data10[:j9])
+		i = encodeVarintData(data, i, uint64(j10))
+		i += copy(data[i:], data11[:j10])
 	}
 	if m.XXX_unrecognized != nil {
 		i += copy(data[i:], m.XXX_unrecognized)
@@ -2979,44 +3022,44 @@ func (m *Transaction) MarshalTo(data []byte) (n int, err error) {
 		data[i] = 0x42
 		i++
 		i = encodeVarintData(data, i, uint64(m.LastHeartbeat.Size()))
-		n11, err := m.LastHeartbeat.MarshalTo(data[i:])
+		n12, err := m.LastHeartbeat.MarshalTo(data[i:])
 		if err != nil {
 			return 0, err
 		}
-		i += n11
+		i += n12
 	}
 	data[i] = 0x4a
 	i++
 	i = encodeVarintData(data, i, uint64(m.Timestamp.Size()))
-	n12, err := m.Timestamp.MarshalTo(data[i:])
-	if err != nil {
-		return 0, err
-	}
-	i += n12
-	data[i] = 0x52
-	i++
-	i = encodeVarintData(data, i, uint64(m.OrigTimestamp.Size()))
-	n13, err := m.OrigTimestamp.MarshalTo(data[i:])
+	n13, err := m.Timestamp.MarshalTo(data[i:])
 	if err != nil {
 		return 0, err
 	}
 	i += n13
-	data[i] = 0x5a
+	data[i] = 0x52
 	i++
-	i = encodeVarintData(data, i, uint64(m.MaxTimestamp.Size()))
-	n14, err := m.MaxTimestamp.MarshalTo(data[i:])
+	i = encodeVarintData(data, i, uint64(m.OrigTimestamp.Size()))
+	n14, err := m.OrigTimestamp.MarshalTo(data[i:])
 	if err != nil {
 		return 0, err
 	}
 	i += n14
-	data[i] = 0x62
+	data[i] = 0x5a
 	i++
-	i = encodeVarintData(data, i, uint64(m.CertainNodes.Size()))
-	n15, err := m.CertainNodes.MarshalTo(data[i:])
+	i = encodeVarintData(data, i, uint64(m.MaxTimestamp.Size()))
+	n15, err := m.MaxTimestamp.MarshalTo(data[i:])
 	if err != nil {
 		return 0, err
 	}
 	i += n15
+	data[i] = 0x62
+	i++
+	i = encodeVarintData(data, i, uint64(m.CertainNodes.Size()))
+	n16, err := m.CertainNodes.MarshalTo(data[i:])
+	if err != nil {
+		return 0, err
+	}
+	i += n16
 	data[i] = 0x68
 	i++
 	if m.Writing {
@@ -3049,19 +3092,19 @@ func (m *Lease) MarshalTo(data []byte) (n int, err error) {
 	data[i] = 0xa
 	i++
 	i = encodeVarintData(data, i, uint64(m.Start.Size()))
-	n16, err := m.Start.MarshalTo(data[i:])
-	if err != nil {
-		return 0, err
-	}
-	i += n16
-	data[i] = 0x12
-	i++
-	i = encodeVarintData(data, i, uint64(m.Expiration.Size()))
-	n17, err := m.Expiration.MarshalTo(data[i:])
+	n17, err := m.Start.MarshalTo(data[i:])
 	if err != nil {
 		return 0, err
 	}
 	i += n17
+	data[i] = 0x12
+	i++
+	i = encodeVarintData(data, i, uint64(m.Expiration.Size()))
+	n18, err := m.Expiration.MarshalTo(data[i:])
+	if err != nil {
+		return 0, err
+	}
+	i += n18
 	data[i] = 0x18
 	i++
 	i = encodeVarintData(data, i, uint64(m.RaftNodeID))
@@ -3101,11 +3144,11 @@ func (m *Intent) MarshalTo(data []byte) (n int, err error) {
 	data[i] = 0x1a
 	i++
 	i = encodeVarintData(data, i, uint64(m.Txn.Size()))
-	n18, err := m.Txn.MarshalTo(data[i:])
+	n19, err := m.Txn.MarshalTo(data[i:])
 	if err != nil {
 		return 0, err
 	}
-	i += n18
+	i += n19
 	if m.XXX_unrecognized != nil {
 		i += copy(data[i:], m.XXX_unrecognized)
 	}

--- a/proto/data.proto
+++ b/proto/data.proto
@@ -120,9 +120,10 @@ message ChangeReplicasTrigger {
   optional int32 store_id = 2 [(gogoproto.nullable) = false,
       (gogoproto.customname) = "StoreID", (gogoproto.casttype) = "StoreID"];
   optional ReplicaChangeType change_type = 3 [(gogoproto.nullable) = false];
-
+  // The replica being modified.
+  optional Replica replica = 4 [(gogoproto.nullable) = false];
   // The new replica list with this change applied.
-  repeated Replica updated_replicas = 4 [(gogoproto.nullable) = false];
+  repeated Replica updated_replicas = 5 [(gogoproto.nullable) = false];
 }
 
 // CommitTrigger encapsulates all of the internal-only commit triggers.

--- a/proto/internal.pb.go
+++ b/proto/internal.pb.go
@@ -708,7 +708,8 @@ func (m *InternalBatchResponse) GetResponses() []InternalResponseUnion {
 
 // A ReadWriteCmdResponse is a union type containing instances of all
 // mutating commands. Note that any entry added here must be handled
-// in storage/engine/db.cc in GetResponseHeader().
+// in storage/engine/db.cc in GetResponseHeader(). This message is used
+// for storing responses to mutating commands in the response cache.
 type ReadWriteCmdResponse struct {
 	Put                        *PutResponse                        `protobuf:"bytes,1,opt,name=put" json:"put,omitempty"`
 	ConditionalPut             *ConditionalPutResponse             `protobuf:"bytes,2,opt,name=conditional_put" json:"conditional_put,omitempty"`

--- a/proto/internal.proto
+++ b/proto/internal.proto
@@ -282,7 +282,8 @@ message InternalBatchResponse {
 
 // A ReadWriteCmdResponse is a union type containing instances of all
 // mutating commands. Note that any entry added here must be handled
-// in storage/engine/db.cc in GetResponseHeader().
+// in storage/engine/db.cc in GetResponseHeader(). This message is used
+// for storing responses to mutating commands in the response cache.
 message ReadWriteCmdResponse {
   option (gogoproto.onlyone) = true;
   oneof value {

--- a/rpc/client.go
+++ b/rpc/client.go
@@ -94,9 +94,8 @@ type Client struct {
 // nil to use defaults (i.e. indefinite retries with exponential
 // backoff).
 //
-// The Client.Ready channel is closed after the client has connected
-// and completed one successful heartbeat. The Closed channel is
-// closed if the client's Close() method is invoked.
+// The Closed channel is closed if the client's Close() method is
+// invoked.
 func NewClient(addr net.Addr, context *Context) *Client {
 	clientMu.Lock()
 	defer clientMu.Unlock()

--- a/storage/client_raft_test.go
+++ b/storage/client_raft_test.go
@@ -619,7 +619,7 @@ func TestReplicateAddAndRemove(t *testing.T) {
 					values = append(values, mustGetInteger(val))
 				}
 				if !reflect.DeepEqual(expected, values) {
-					return util.Errorf("expected %v, got %v", expected, values)
+					return util.Errorf("addFirst: %t, expected %v, got %v", addFirst, expected, values)
 				}
 				return nil
 			})
@@ -657,13 +657,8 @@ func TestReplicateAddAndRemove(t *testing.T) {
 		}
 		verify([]int64{39, 5, 39, 39})
 
-		// TODO(bdarnell): when we have GC of removed ranges, verify that
-		// the downed node removes the data from this range after coming
-		// back up.
-
 		// Wait out the leader lease and the unleased duration to make the range GC'able.
-		mtc.manualClock.Increment(int64(storage.DefaultLeaderLeaseDuration) +
-			int64(storage.RangeGCQueueUnleasedDuration) + 1)
+		mtc.manualClock.Increment(int64(storage.RangeGCQueueInactivityThreshold+storage.DefaultLeaderLeaseDuration) + 1)
 		mtc.stores[1].ForceRangeGCScan(t)
 
 		// The removed store no longer has any of the data from the range.

--- a/storage/engine/rocksdb/cockroach/proto/data.pb.cc
+++ b/storage/engine/rocksdb/cockroach/proto/data.pb.cc
@@ -192,10 +192,11 @@ void protobuf_AssignDesc_cockroach_2fproto_2fdata_2eproto() {
       GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(MergeTrigger, _internal_metadata_),
       -1);
   ChangeReplicasTrigger_descriptor_ = file->message_type(7);
-  static const int ChangeReplicasTrigger_offsets_[4] = {
+  static const int ChangeReplicasTrigger_offsets_[5] = {
     GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(ChangeReplicasTrigger, node_id_),
     GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(ChangeReplicasTrigger, store_id_),
     GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(ChangeReplicasTrigger, change_type_),
+    GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(ChangeReplicasTrigger, replica_),
     GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(ChangeReplicasTrigger, updated_replicas_),
   };
   ChangeReplicasTrigger_reflection_ =
@@ -425,47 +426,48 @@ void protobuf_AddDesc_cockroach_2fproto_2fdata_2eproto() {
     "\310\336\037\000\"\210\001\n\014MergeTrigger\022<\n\014updated_desc\030\001 "
     "\001(\0132 .cockroach.proto.RangeDescriptorB\004\310"
     "\336\037\000\022:\n\020subsumed_raft_id\030\002 \001(\003B \310\336\037\000\342\336\037\016S"
-    "ubsumedRaftID\372\336\037\006RaftID\"\351\001\n\025ChangeReplic"
+    "ubsumedRaftID\372\336\037\006RaftID\"\232\002\n\025ChangeReplic"
     "asTrigger\022)\n\007node_id\030\001 \001(\005B\030\310\336\037\000\342\336\037\006Node"
     "ID\372\336\037\006NodeID\022,\n\010store_id\030\002 \001(\005B\032\310\336\037\000\342\336\037\007"
     "StoreID\372\336\037\007StoreID\022=\n\013change_type\030\003 \001(\0162"
     "\".cockroach.proto.ReplicaChangeTypeB\004\310\336\037"
-    "\000\0228\n\020updated_replicas\030\004 \003(\0132\030.cockroach."
-    "proto.ReplicaB\004\310\336\037\000\"\314\001\n\025InternalCommitTr"
-    "igger\0224\n\rsplit_trigger\030\001 \001(\0132\035.cockroach"
-    ".proto.SplitTrigger\0224\n\rmerge_trigger\030\002 \001"
-    "(\0132\035.cockroach.proto.MergeTrigger\022G\n\027cha"
-    "nge_replicas_trigger\030\003 \001(\0132&.cockroach.p"
-    "roto.ChangeReplicasTrigger\"\035\n\010NodeList\022\021"
-    "\n\005nodes\030\001 \003(\005B\002\020\001\"\234\004\n\013Transaction\022\022\n\004nam"
-    "e\030\001 \001(\tB\004\310\336\037\000\022\024\n\003key\030\002 \001(\014B\007\372\336\037\003Key\022\022\n\002i"
-    "d\030\003 \001(\014B\006\342\336\037\002ID\022\026\n\010priority\030\004 \001(\005B\004\310\336\037\000\022"
-    "7\n\tisolation\030\005 \001(\0162\036.cockroach.proto.Iso"
-    "lationTypeB\004\310\336\037\000\0228\n\006status\030\006 \001(\0162\".cockr"
-    "oach.proto.TransactionStatusB\004\310\336\037\000\022\023\n\005ep"
-    "och\030\007 \001(\005B\004\310\336\037\000\0222\n\016last_heartbeat\030\010 \001(\0132"
-    "\032.cockroach.proto.Timestamp\0223\n\ttimestamp"
-    "\030\t \001(\0132\032.cockroach.proto.TimestampB\004\310\336\037\000"
-    "\0228\n\016orig_timestamp\030\n \001(\0132\032.cockroach.pro"
-    "to.TimestampB\004\310\336\037\000\0227\n\rmax_timestamp\030\013 \001("
-    "\0132\032.cockroach.proto.TimestampB\004\310\336\037\000\0226\n\rc"
-    "ertain_nodes\030\014 \001(\0132\031.cockroach.proto.Nod"
-    "eListB\004\310\336\037\000\022\025\n\007Writing\030\r \001(\010B\004\310\336\037\000:\004\230\240\037\000"
-    "\"\254\001\n\005Lease\022/\n\005start\030\001 \001(\0132\032.cockroach.pr"
-    "oto.TimestampB\004\310\336\037\000\0224\n\nexpiration\030\002 \001(\0132"
-    "\032.cockroach.proto.TimestampB\004\310\336\037\000\0226\n\014raf"
-    "t_node_id\030\003 \001(\004B \310\336\037\000\342\336\037\nRaftNodeID\372\336\037\nR"
-    "aftNodeID:\004\230\240\037\000\"i\n\006Intent\022\024\n\003key\030\001 \001(\014B\007"
-    "\372\336\037\003Key\022\030\n\007end_key\030\002 \001(\014B\007\372\336\037\003Key\022/\n\003txn"
-    "\030\003 \001(\0132\034.cockroach.proto.TransactionB\004\310\336"
-    "\037\000\"H\n\nGCMetadata\022\035\n\017last_scan_nanos\030\001 \001("
-    "\003B\004\310\336\037\000\022\033\n\023oldest_intent_nanos\030\002 \001(\003*>\n\021"
-    "ReplicaChangeType\022\017\n\013ADD_REPLICA\020\000\022\022\n\016RE"
-    "MOVE_REPLICA\020\001\032\004\210\243\036\000*5\n\rIsolationType\022\020\n"
-    "\014SERIALIZABLE\020\000\022\014\n\010SNAPSHOT\020\001\032\004\210\243\036\000*B\n\021T"
-    "ransactionStatus\022\013\n\007PENDING\020\000\022\r\n\tCOMMITT"
-    "ED\020\001\022\013\n\007ABORTED\020\002\032\004\210\243\036\000B\023Z\005proto\340\342\036\001\310\342\036\001"
-    "\320\342\036\001", 2404);
+    "\000\022/\n\007replica\030\004 \001(\0132\030.cockroach.proto.Rep"
+    "licaB\004\310\336\037\000\0228\n\020updated_replicas\030\005 \003(\0132\030.c"
+    "ockroach.proto.ReplicaB\004\310\336\037\000\"\314\001\n\025Interna"
+    "lCommitTrigger\0224\n\rsplit_trigger\030\001 \001(\0132\035."
+    "cockroach.proto.SplitTrigger\0224\n\rmerge_tr"
+    "igger\030\002 \001(\0132\035.cockroach.proto.MergeTrigg"
+    "er\022G\n\027change_replicas_trigger\030\003 \001(\0132&.co"
+    "ckroach.proto.ChangeReplicasTrigger\"\035\n\010N"
+    "odeList\022\021\n\005nodes\030\001 \003(\005B\002\020\001\"\234\004\n\013Transacti"
+    "on\022\022\n\004name\030\001 \001(\tB\004\310\336\037\000\022\024\n\003key\030\002 \001(\014B\007\372\336\037"
+    "\003Key\022\022\n\002id\030\003 \001(\014B\006\342\336\037\002ID\022\026\n\010priority\030\004 \001"
+    "(\005B\004\310\336\037\000\0227\n\tisolation\030\005 \001(\0162\036.cockroach."
+    "proto.IsolationTypeB\004\310\336\037\000\0228\n\006status\030\006 \001("
+    "\0162\".cockroach.proto.TransactionStatusB\004\310"
+    "\336\037\000\022\023\n\005epoch\030\007 \001(\005B\004\310\336\037\000\0222\n\016last_heartbe"
+    "at\030\010 \001(\0132\032.cockroach.proto.Timestamp\0223\n\t"
+    "timestamp\030\t \001(\0132\032.cockroach.proto.Timest"
+    "ampB\004\310\336\037\000\0228\n\016orig_timestamp\030\n \001(\0132\032.cock"
+    "roach.proto.TimestampB\004\310\336\037\000\0227\n\rmax_times"
+    "tamp\030\013 \001(\0132\032.cockroach.proto.TimestampB\004"
+    "\310\336\037\000\0226\n\rcertain_nodes\030\014 \001(\0132\031.cockroach."
+    "proto.NodeListB\004\310\336\037\000\022\025\n\007Writing\030\r \001(\010B\004\310"
+    "\336\037\000:\004\230\240\037\000\"\254\001\n\005Lease\022/\n\005start\030\001 \001(\0132\032.coc"
+    "kroach.proto.TimestampB\004\310\336\037\000\0224\n\nexpirati"
+    "on\030\002 \001(\0132\032.cockroach.proto.TimestampB\004\310\336"
+    "\037\000\0226\n\014raft_node_id\030\003 \001(\004B \310\336\037\000\342\336\037\nRaftNo"
+    "deID\372\336\037\nRaftNodeID:\004\230\240\037\000\"i\n\006Intent\022\024\n\003ke"
+    "y\030\001 \001(\014B\007\372\336\037\003Key\022\030\n\007end_key\030\002 \001(\014B\007\372\336\037\003K"
+    "ey\022/\n\003txn\030\003 \001(\0132\034.cockroach.proto.Transa"
+    "ctionB\004\310\336\037\000\"H\n\nGCMetadata\022\035\n\017last_scan_n"
+    "anos\030\001 \001(\003B\004\310\336\037\000\022\033\n\023oldest_intent_nanos\030"
+    "\002 \001(\003*>\n\021ReplicaChangeType\022\017\n\013ADD_REPLIC"
+    "A\020\000\022\022\n\016REMOVE_REPLICA\020\001\032\004\210\243\036\000*5\n\rIsolati"
+    "onType\022\020\n\014SERIALIZABLE\020\000\022\014\n\010SNAPSHOT\020\001\032\004"
+    "\210\243\036\000*B\n\021TransactionStatus\022\013\n\007PENDING\020\000\022\r"
+    "\n\tCOMMITTED\020\001\022\013\n\007ABORTED\020\002\032\004\210\243\036\000B\023Z\005prot"
+    "o\340\342\036\001\310\342\036\001\320\342\036\001", 2453);
   ::google::protobuf::MessageFactory::InternalRegisterGeneratedFile(
     "cockroach/proto/data.proto", &protobuf_RegisterTypes);
   Timestamp::default_instance_ = new Timestamp();
@@ -3406,6 +3408,7 @@ void MergeTrigger::clear_subsumed_raft_id() {
 const int ChangeReplicasTrigger::kNodeIdFieldNumber;
 const int ChangeReplicasTrigger::kStoreIdFieldNumber;
 const int ChangeReplicasTrigger::kChangeTypeFieldNumber;
+const int ChangeReplicasTrigger::kReplicaFieldNumber;
 const int ChangeReplicasTrigger::kUpdatedReplicasFieldNumber;
 #endif  // !_MSC_VER
 
@@ -3416,6 +3419,7 @@ ChangeReplicasTrigger::ChangeReplicasTrigger()
 }
 
 void ChangeReplicasTrigger::InitAsDefaultInstance() {
+  replica_ = const_cast< ::cockroach::proto::Replica*>(&::cockroach::proto::Replica::default_instance());
 }
 
 ChangeReplicasTrigger::ChangeReplicasTrigger(const ChangeReplicasTrigger& from)
@@ -3431,6 +3435,7 @@ void ChangeReplicasTrigger::SharedCtor() {
   node_id_ = 0;
   store_id_ = 0;
   change_type_ = 0;
+  replica_ = NULL;
   ::memset(_has_bits_, 0, sizeof(_has_bits_));
 }
 
@@ -3441,6 +3446,7 @@ ChangeReplicasTrigger::~ChangeReplicasTrigger() {
 
 void ChangeReplicasTrigger::SharedDtor() {
   if (this != default_instance_) {
+    delete replica_;
   }
 }
 
@@ -3478,9 +3484,12 @@ void ChangeReplicasTrigger::Clear() {
            ZR_HELPER_(last) - ZR_HELPER_(first) + sizeof(last));\
 } while (0)
 
-  if (_has_bits_[0 / 32] & 7u) {
+  if (_has_bits_[0 / 32] & 15u) {
     ZR_(node_id_, store_id_);
     change_type_ = 0;
+    if (has_replica()) {
+      if (replica_ != NULL) replica_->::cockroach::proto::Replica::Clear();
+    }
   }
 
 #undef ZR_HELPER_
@@ -3548,13 +3557,26 @@ bool ChangeReplicasTrigger::MergePartialFromCodedStream(
         } else {
           goto handle_unusual;
         }
-        if (input->ExpectTag(34)) goto parse_updated_replicas;
+        if (input->ExpectTag(34)) goto parse_replica;
         break;
       }
 
-      // repeated .cockroach.proto.Replica updated_replicas = 4;
+      // optional .cockroach.proto.Replica replica = 4;
       case 4: {
         if (tag == 34) {
+         parse_replica:
+          DO_(::google::protobuf::internal::WireFormatLite::ReadMessageNoVirtual(
+               input, mutable_replica()));
+        } else {
+          goto handle_unusual;
+        }
+        if (input->ExpectTag(42)) goto parse_updated_replicas;
+        break;
+      }
+
+      // repeated .cockroach.proto.Replica updated_replicas = 5;
+      case 5: {
+        if (tag == 42) {
          parse_updated_replicas:
           DO_(input->IncrementRecursionDepth());
          parse_loop_updated_replicas:
@@ -3563,7 +3585,7 @@ bool ChangeReplicasTrigger::MergePartialFromCodedStream(
         } else {
           goto handle_unusual;
         }
-        if (input->ExpectTag(34)) goto parse_loop_updated_replicas;
+        if (input->ExpectTag(42)) goto parse_loop_updated_replicas;
         input->UnsafeDecrementRecursionDepth();
         if (input->ExpectAtEnd()) goto success;
         break;
@@ -3610,10 +3632,16 @@ void ChangeReplicasTrigger::SerializeWithCachedSizes(
       3, this->change_type(), output);
   }
 
-  // repeated .cockroach.proto.Replica updated_replicas = 4;
+  // optional .cockroach.proto.Replica replica = 4;
+  if (has_replica()) {
+    ::google::protobuf::internal::WireFormatLite::WriteMessageMaybeToArray(
+      4, *this->replica_, output);
+  }
+
+  // repeated .cockroach.proto.Replica updated_replicas = 5;
   for (unsigned int i = 0, n = this->updated_replicas_size(); i < n; i++) {
     ::google::protobuf::internal::WireFormatLite::WriteMessageMaybeToArray(
-      4, this->updated_replicas(i), output);
+      5, this->updated_replicas(i), output);
   }
 
   if (_internal_metadata_.have_unknown_fields()) {
@@ -3642,11 +3670,18 @@ void ChangeReplicasTrigger::SerializeWithCachedSizes(
       3, this->change_type(), target);
   }
 
-  // repeated .cockroach.proto.Replica updated_replicas = 4;
+  // optional .cockroach.proto.Replica replica = 4;
+  if (has_replica()) {
+    target = ::google::protobuf::internal::WireFormatLite::
+      WriteMessageNoVirtualToArray(
+        4, *this->replica_, target);
+  }
+
+  // repeated .cockroach.proto.Replica updated_replicas = 5;
   for (unsigned int i = 0, n = this->updated_replicas_size(); i < n; i++) {
     target = ::google::protobuf::internal::WireFormatLite::
       WriteMessageNoVirtualToArray(
-        4, this->updated_replicas(i), target);
+        5, this->updated_replicas(i), target);
   }
 
   if (_internal_metadata_.have_unknown_fields()) {
@@ -3660,7 +3695,7 @@ void ChangeReplicasTrigger::SerializeWithCachedSizes(
 int ChangeReplicasTrigger::ByteSize() const {
   int total_size = 0;
 
-  if (_has_bits_[0 / 32] & 7) {
+  if (_has_bits_[0 / 32] & 15) {
     // optional int32 node_id = 1;
     if (has_node_id()) {
       total_size += 1 +
@@ -3681,8 +3716,15 @@ int ChangeReplicasTrigger::ByteSize() const {
         ::google::protobuf::internal::WireFormatLite::EnumSize(this->change_type());
     }
 
+    // optional .cockroach.proto.Replica replica = 4;
+    if (has_replica()) {
+      total_size += 1 +
+        ::google::protobuf::internal::WireFormatLite::MessageSizeNoVirtual(
+          *this->replica_);
+    }
+
   }
-  // repeated .cockroach.proto.Replica updated_replicas = 4;
+  // repeated .cockroach.proto.Replica updated_replicas = 5;
   total_size += 1 * this->updated_replicas_size();
   for (int i = 0; i < this->updated_replicas_size(); i++) {
     total_size +=
@@ -3726,6 +3768,9 @@ void ChangeReplicasTrigger::MergeFrom(const ChangeReplicasTrigger& from) {
     if (from.has_change_type()) {
       set_change_type(from.change_type());
     }
+    if (from.has_replica()) {
+      mutable_replica()->::cockroach::proto::Replica::MergeFrom(from.replica());
+    }
   }
   if (from._internal_metadata_.have_unknown_fields()) {
     mutable_unknown_fields()->MergeFrom(from.unknown_fields());
@@ -3757,6 +3802,7 @@ void ChangeReplicasTrigger::InternalSwap(ChangeReplicasTrigger* other) {
   std::swap(node_id_, other->node_id_);
   std::swap(store_id_, other->store_id_);
   std::swap(change_type_, other->change_type_);
+  std::swap(replica_, other->replica_);
   updated_replicas_.UnsafeArenaSwap(&other->updated_replicas_);
   std::swap(_has_bits_[0], other->_has_bits_[0]);
   _internal_metadata_.Swap(&other->_internal_metadata_);
@@ -3847,7 +3893,50 @@ void ChangeReplicasTrigger::clear_change_type() {
   // @@protoc_insertion_point(field_set:cockroach.proto.ChangeReplicasTrigger.change_type)
 }
 
-// repeated .cockroach.proto.Replica updated_replicas = 4;
+// optional .cockroach.proto.Replica replica = 4;
+bool ChangeReplicasTrigger::has_replica() const {
+  return (_has_bits_[0] & 0x00000008u) != 0;
+}
+void ChangeReplicasTrigger::set_has_replica() {
+  _has_bits_[0] |= 0x00000008u;
+}
+void ChangeReplicasTrigger::clear_has_replica() {
+  _has_bits_[0] &= ~0x00000008u;
+}
+void ChangeReplicasTrigger::clear_replica() {
+  if (replica_ != NULL) replica_->::cockroach::proto::Replica::Clear();
+  clear_has_replica();
+}
+ const ::cockroach::proto::Replica& ChangeReplicasTrigger::replica() const {
+  // @@protoc_insertion_point(field_get:cockroach.proto.ChangeReplicasTrigger.replica)
+  return replica_ != NULL ? *replica_ : *default_instance_->replica_;
+}
+ ::cockroach::proto::Replica* ChangeReplicasTrigger::mutable_replica() {
+  set_has_replica();
+  if (replica_ == NULL) {
+    replica_ = new ::cockroach::proto::Replica;
+  }
+  // @@protoc_insertion_point(field_mutable:cockroach.proto.ChangeReplicasTrigger.replica)
+  return replica_;
+}
+ ::cockroach::proto::Replica* ChangeReplicasTrigger::release_replica() {
+  clear_has_replica();
+  ::cockroach::proto::Replica* temp = replica_;
+  replica_ = NULL;
+  return temp;
+}
+ void ChangeReplicasTrigger::set_allocated_replica(::cockroach::proto::Replica* replica) {
+  delete replica_;
+  replica_ = replica;
+  if (replica) {
+    set_has_replica();
+  } else {
+    clear_has_replica();
+  }
+  // @@protoc_insertion_point(field_set_allocated:cockroach.proto.ChangeReplicasTrigger.replica)
+}
+
+// repeated .cockroach.proto.Replica updated_replicas = 5;
 int ChangeReplicasTrigger::updated_replicas_size() const {
   return updated_replicas_.size();
 }

--- a/storage/engine/rocksdb/cockroach/proto/data.pb.h
+++ b/storage/engine/rocksdb/cockroach/proto/data.pb.h
@@ -963,10 +963,19 @@ class ChangeReplicasTrigger : public ::google::protobuf::Message {
   ::cockroach::proto::ReplicaChangeType change_type() const;
   void set_change_type(::cockroach::proto::ReplicaChangeType value);
 
-  // repeated .cockroach.proto.Replica updated_replicas = 4;
+  // optional .cockroach.proto.Replica replica = 4;
+  bool has_replica() const;
+  void clear_replica();
+  static const int kReplicaFieldNumber = 4;
+  const ::cockroach::proto::Replica& replica() const;
+  ::cockroach::proto::Replica* mutable_replica();
+  ::cockroach::proto::Replica* release_replica();
+  void set_allocated_replica(::cockroach::proto::Replica* replica);
+
+  // repeated .cockroach.proto.Replica updated_replicas = 5;
   int updated_replicas_size() const;
   void clear_updated_replicas();
-  static const int kUpdatedReplicasFieldNumber = 4;
+  static const int kUpdatedReplicasFieldNumber = 5;
   const ::cockroach::proto::Replica& updated_replicas(int index) const;
   ::cockroach::proto::Replica* mutable_updated_replicas(int index);
   ::cockroach::proto::Replica* add_updated_replicas();
@@ -983,12 +992,15 @@ class ChangeReplicasTrigger : public ::google::protobuf::Message {
   inline void clear_has_store_id();
   inline void set_has_change_type();
   inline void clear_has_change_type();
+  inline void set_has_replica();
+  inline void clear_has_replica();
 
   ::google::protobuf::internal::InternalMetadataWithArena _internal_metadata_;
   ::google::protobuf::uint32 _has_bits_[1];
   mutable int _cached_size_;
   ::google::protobuf::int32 node_id_;
   ::google::protobuf::int32 store_id_;
+  ::cockroach::proto::Replica* replica_;
   ::google::protobuf::RepeatedPtrField< ::cockroach::proto::Replica > updated_replicas_;
   int change_type_;
   friend void  protobuf_AddDesc_cockroach_2fproto_2fdata_2eproto();
@@ -2559,7 +2571,50 @@ inline void ChangeReplicasTrigger::set_change_type(::cockroach::proto::ReplicaCh
   // @@protoc_insertion_point(field_set:cockroach.proto.ChangeReplicasTrigger.change_type)
 }
 
-// repeated .cockroach.proto.Replica updated_replicas = 4;
+// optional .cockroach.proto.Replica replica = 4;
+inline bool ChangeReplicasTrigger::has_replica() const {
+  return (_has_bits_[0] & 0x00000008u) != 0;
+}
+inline void ChangeReplicasTrigger::set_has_replica() {
+  _has_bits_[0] |= 0x00000008u;
+}
+inline void ChangeReplicasTrigger::clear_has_replica() {
+  _has_bits_[0] &= ~0x00000008u;
+}
+inline void ChangeReplicasTrigger::clear_replica() {
+  if (replica_ != NULL) replica_->::cockroach::proto::Replica::Clear();
+  clear_has_replica();
+}
+inline const ::cockroach::proto::Replica& ChangeReplicasTrigger::replica() const {
+  // @@protoc_insertion_point(field_get:cockroach.proto.ChangeReplicasTrigger.replica)
+  return replica_ != NULL ? *replica_ : *default_instance_->replica_;
+}
+inline ::cockroach::proto::Replica* ChangeReplicasTrigger::mutable_replica() {
+  set_has_replica();
+  if (replica_ == NULL) {
+    replica_ = new ::cockroach::proto::Replica;
+  }
+  // @@protoc_insertion_point(field_mutable:cockroach.proto.ChangeReplicasTrigger.replica)
+  return replica_;
+}
+inline ::cockroach::proto::Replica* ChangeReplicasTrigger::release_replica() {
+  clear_has_replica();
+  ::cockroach::proto::Replica* temp = replica_;
+  replica_ = NULL;
+  return temp;
+}
+inline void ChangeReplicasTrigger::set_allocated_replica(::cockroach::proto::Replica* replica) {
+  delete replica_;
+  replica_ = replica;
+  if (replica) {
+    set_has_replica();
+  } else {
+    clear_has_replica();
+  }
+  // @@protoc_insertion_point(field_set_allocated:cockroach.proto.ChangeReplicasTrigger.replica)
+}
+
+// repeated .cockroach.proto.Replica updated_replicas = 5;
 inline int ChangeReplicasTrigger::updated_replicas_size() const {
   return updated_replicas_.size();
 }

--- a/storage/range.go
+++ b/storage/range.go
@@ -163,6 +163,7 @@ type rangeManager interface {
 	allocator() *allocator
 	Gossip() *gossip.Gossip
 	splitQueue() *splitQueue
+	rangeGCQueue() *rangeGCQueue
 	Stopper() *stop.Stopper
 	EventFeed() StoreEventFeed
 	Context(context.Context) context.Context
@@ -253,7 +254,7 @@ func NewRange(desc *proto.RangeDescriptor, rm rangeManager) (*Range, error) {
 
 // String returns a string representation of the range.
 func (r *Range) String() string {
-	return fmt.Sprintf("range=%d [%s - %s)", r.Desc().RaftID, r.Desc().StartKey, r.Desc().EndKey)
+	return fmt.Sprintf("range=%d (%s-%s)", r.Desc().RaftID, r.Desc().StartKey, r.Desc().EndKey)
 }
 
 // Destroy cleans up all data associated with this range.

--- a/storage/range_test.go
+++ b/storage/range_test.go
@@ -168,7 +168,7 @@ func (tc *testContext) Start(t testing.TB) {
 		// Now that we have our actual store, monkey patch the sender used in ctx.DB.
 		sender.store = tc.store
 		// We created the store without a real KV client, so it can't perform splits.
-		tc.store._splitQueue.disabled = true
+		tc.store.splitQueue().SetDisabled(true)
 
 		if tc.rng == nil && tc.bootstrapMode == bootstrapRangeWithMetadata {
 			if err := tc.store.BootstrapRange(); err != nil {


### PR DESCRIPTION
With the addition of the replica being removed to the trigger protobuf
message, as well as a manual add method on the queue, replicas are now
GC'd quickly in the common case. This allows far less pressure to be
put on the range gc queue, as replicas only need be checked against
the definitive range metadata records infrequently.
