### PR TITLE
Use the primary key name constant instead of string literals

### DIFF
--- a/sql/driver/driver_test.go
+++ b/sql/driver/driver_test.go
@@ -24,6 +24,7 @@ import (
 	"testing"
 
 	"github.com/cockroachdb/cockroach/server"
+	"github.com/cockroachdb/cockroach/structured"
 	"github.com/cockroachdb/cockroach/testutils"
 	"github.com/cockroachdb/cockroach/util/leaktest"
 )
@@ -349,7 +350,7 @@ CREATE TABLE t.users (
 	results := readAll(t, rows)
 	expected := [][]string{
 		{"Table", "Name", "Unique", "Seq", "Column"},
-		{"users", "primary", "true", "1", "id"},
+		{"users", structured.PrimaryKeyIndexName, "true", "1", "id"},
 		{"users", "foo", "false", "1", "name"},
 		{"users", "bar", "true", "1", "id"},
 		{"users", "bar", "true", "2", "name"},

--- a/sql/driver/driver_test.go
+++ b/sql/driver/driver_test.go
@@ -469,6 +469,8 @@ func TestInsertSelectDelete(t *testing.T) {
 				expectedResultSlice = append(expectedResultSlice, rowWithNil)
 			case 1:
 				expectedResultSlice = append(expectedResultSlice[:1], append(resultSlice{rowWithNil}, expectedResultSlice[1:]...)...)
+			default:
+				t.Fatalf("unexpected value %d", i)
 			}
 
 			if err := verifyResults(expectedResultSlice, results); err != nil {

--- a/sql/table.go
+++ b/sql/table.go
@@ -76,7 +76,7 @@ func makeTableDesc(p *parser.CreateTable) (structured.TableDescriptor, error) {
 					ColumnNames: []string{string(d.Name)},
 				}
 				if d.PrimaryKey {
-					index.Name = "primary"
+					index.Name = structured.PrimaryKeyIndexName
 				}
 				desc.Indexes = append(desc.Indexes, index)
 			}
@@ -87,7 +87,7 @@ func makeTableDesc(p *parser.CreateTable) (structured.TableDescriptor, error) {
 				ColumnNames: d.Columns,
 			}
 			if d.PrimaryKey {
-				index.Name = "primary"
+				index.Name = structured.PrimaryKeyIndexName
 			}
 			desc.Indexes = append(desc.Indexes, index)
 		default:

--- a/sql/table_test.go
+++ b/sql/table_test.go
@@ -123,7 +123,7 @@ func TestMakeTableDescIndexes(t *testing.T) {
 		{
 			"a INT PRIMARY KEY",
 			structured.IndexDescriptor{
-				Name:        "primary",
+				Name:        structured.PrimaryKeyIndexName,
 				Unique:      true,
 				ColumnNames: []string{"a"},
 			},
@@ -155,7 +155,7 @@ func TestMakeTableDescIndexes(t *testing.T) {
 		{
 			"a INT, b INT, PRIMARY KEY (a, b)",
 			structured.IndexDescriptor{
-				Name:        "primary",
+				Name:        structured.PrimaryKeyIndexName,
 				Unique:      true,
 				ColumnNames: []string{"a", "b"},
 			},


### PR DESCRIPTION
Second commit addresses a comment by @tschottdorf on #1913.
