### PR TITLE
add missing Exprs in Walk

### DIFF
--- a/sql/parser/walk.go
+++ b/sql/parser/walk.go
@@ -86,6 +86,11 @@ func WalkExpr(v Visitor, expr Expr) Expr {
 	case *QualifiedName:
 		// Terminal node: nothing to do.
 
+	case Row:
+		for i := range t {
+			t[i] = WalkExpr(v, t[i])
+		}
+
 	case Tuple:
 		for i := range t {
 			t[i] = WalkExpr(v, t[i])
@@ -93,6 +98,9 @@ func WalkExpr(v Visitor, expr Expr) Expr {
 
 	case Datum:
 		// Terminal node: nothing to do.
+
+	case *StarExpr:
+		// Contains only a terminal node.
 
 	case *Subquery:
 		// TODO(pmattis): Should we recurse into the Subquery?

--- a/sql/parser/walk_test.go
+++ b/sql/parser/walk_test.go
@@ -78,6 +78,7 @@ func TestFillArgs(t *testing.T) {
 		{`length($1)`, `length('a')`, mapArgs{1: DString("a")}},
 		{`length($1, $2)`, `length('a', 'b')`, mapArgs{1: DString("a"), 2: DString("b")}},
 		{`CAST($1 AS INT)`, `CAST(1.1 AS INT)`, mapArgs{1: DFloat(1.1)}},
+		{`ROW($1, $2, $3)`, `ROW(1, 2, '3')`, mapArgs{1: DInt(1), 2: DInt(2), 3: DString("3")}},
 	}
 
 	for _, d := range testData {


### PR DESCRIPTION
(go-fuzz)

Should probably have a test that makes sure `WalkExpr` can handle all implementers of `Expr` at all times.
