### PR TITLE
Fix TestRangeGCQueue* to correctly wait for range removal

### DIFF
--- a/storage/client_range_gc_test.go
+++ b/storage/client_range_gc_test.go
@@ -42,7 +42,7 @@ func TestRangeGCQueueDropReplica(t *testing.T) {
 
 	// Make sure the range is removed from the store.
 	util.SucceedsWithin(t, time.Second, func() error {
-		if _, err := mtc.stores[1].GetRange(raftID); testutils.IsError(err, "range .* was not found") {
+		if _, err := mtc.stores[1].GetRange(raftID); !testutils.IsError(err, "range .* was not found") {
 			return util.Error("expected range removal")
 		}
 		return nil
@@ -84,7 +84,7 @@ func TestRangeGCQueueDropReplicaGCOnScan(t *testing.T) {
 	util.SucceedsWithin(t, time.Second, func() error {
 		store := mtc.stores[1]
 		store.ForceRangeGCScan(t)
-		if _, err := store.GetRange(raftID); testutils.IsError(err, "range .* was not found") {
+		if _, err := store.GetRange(raftID); !testutils.IsError(err, "range .* was not found") {
 			return util.Errorf("expected range removal: %s", err)
 		}
 		return nil


### PR DESCRIPTION
The test still fails with `clusterIDGossipTTL = 1 * time.Millisecond`. Here is a log:

```
  ...
I0805 04:50:29.402478 53224 storage/replica.go:1001  gossiping first range from store 1, range 1
W0805 04:50:29.402512 53224 storage/replica.go:968  could not acquire lease for range gossip: raft group deleted
W0805 04:50:29.402533 53224 storage/store.go:584  error gossiping first range data: raft group deleted
I0805 04:50:29.402544 53224 storage/replica.go:989  gossiping cluster id  from store 2, range 1
05 04:43:46.395109 42294 raft/log.go:187  applied(28) is out of range [prevApplied(10), committed(10)]
panic: applied(28) is out of range [prevApplied(10), committed(10)]

goroutine 37 [running]:
github.com/cockroachdb/cockroach/multiraft.(*raftLogger).Panicf(0x4f3bcb0, 0x4bff0b0, 0x3c, 0xc208180ed0, 0x3, 0x3)
        /Users/kaneda/Development/go/src/github.com/cockroachdb/cockroach/multiraft/raft.go:107 +0x188
github.com/coreos/etcd/raft.(*raftLog).appliedTo(0xc208186af0, 0x1c)
        /Users/kaneda/Development/go/src/github.com/coreos/etcd/raft/log.go:187 +0x1d5
github.com/coreos/etcd/raft.newRaft(0xc2081a21e0, 0xc208106f00)
        /Users/kaneda/Development/go/src/github.com/coreos/etcd/raft/raft.go:197 +0x73b
github.com/coreos/etcd/raft.(*multiNode).run(0xc208106ba0)
        /Users/kaneda/Development/go/src/github.com/coreos/etcd/raft/multinode.go:183 +0x2eb
created by github.com/coreos/etcd/raft.StartMultiNode
        /Users/kaneda/Development/go/src/github.com/coreos/etcd/raft/multinode.go:56 +0xb6
  ...
```
