### PR TITLE
Enforce database-level privileges: #1830

### DIFF
--- a/sql/driver/permission_test.go
+++ b/sql/driver/permission_test.go
@@ -1,0 +1,190 @@
+// Copyright 2015 The Cockroach Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+// implied. See the License for the specific language governing
+// permissions and limitations under the License. See the AUTHORS file
+// for names of contributors.
+//
+// Author: Marc Berhault (marc@cockroachlabs.com)
+
+package driver_test
+
+import (
+	"database/sql"
+	"testing"
+
+	"github.com/cockroachdb/cockroach/security"
+	"github.com/cockroachdb/cockroach/server"
+	"github.com/cockroachdb/cockroach/util/leaktest"
+)
+
+var (
+	rootUser = security.RootUser
+	testUser = server.TestUser
+)
+
+// setupMultiuser creates a testserver and two clients, one for "root",
+// the other for "testuser".
+func setupMultiuser(t *testing.T) (*server.TestServer, *sql.DB, *sql.DB) {
+	s := server.StartTestServer(nil)
+	dbRoot, err := sql.Open("cockroach", "https://"+rootUser+"@"+s.ServingAddr()+"?certs=test_certs")
+	if err != nil {
+		t.Fatal(err)
+	}
+	dbTest, err := sql.Open("cockroach", "https://"+testUser+"@"+s.ServingAddr()+"?certs=test_certs")
+	if err != nil {
+		t.Fatal(err)
+	}
+	return s, dbRoot, dbTest
+}
+
+func cleanupMultiuser(s *server.TestServer, dbRoot, dbTest *sql.DB) {
+	_ = dbRoot.Close()
+	_ = dbTest.Close()
+	s.Stop()
+}
+
+func TestInsecure(t *testing.T) {
+	defer leaktest.AfterTest(t)
+	// Start test server in insecure mode.
+	s := &server.TestServer{}
+	s.Ctx = server.NewTestContext()
+	s.Ctx.Insecure = true
+	if err := s.Start(); err != nil {
+		t.Fatalf("Could not start server: %v", err)
+	}
+	t.Logf("Test server listening on %s: %s", s.Ctx.RequestScheme(), s.ServingAddr())
+	defer s.Stop()
+
+	// We can't attempt a connection through HTTPS since the client just retries forever.
+	// DB connection using plain HTTP.
+	db, err := sql.Open("cockroach", "http://root@"+s.ServingAddr())
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() {
+		_ = db.Close()
+	}()
+	if _, err := db.Exec("CREATE DATABASE t"); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestDefaultPrivileges(t *testing.T) {
+	defer leaktest.AfterTest(t)
+	s, dbRoot, dbTest := setupMultiuser(t)
+	defer cleanupMultiuser(s, dbRoot, dbTest)
+
+	// All statements must succeed with dbRoot.
+	// Statements with success==true must succeed with dbTest.
+	// They are evaluated in order, with dbTest first followed by dbRoot.
+	testCases := []struct {
+		query   string
+		success bool
+	}{
+		/* Database-level permissions */
+		{`CREATE DATABASE foo`, false},
+
+		{`SHOW DATABASES`, true},
+		{`SET DATABASE = foo`, true},
+
+		{`CREATE TABLE tbl (id INT PRIMARY KEY)`, false},
+
+		{`SHOW TABLES`, true},
+		{`SHOW GRANTS ON DATABASE foo`, true},
+
+		{`GRANT ALL ON DATABASE foo TO bar`, false},
+		{`REVOKE ALL ON DATABASE foo FROM bar`, false},
+	}
+
+	for _, tc := range testCases {
+		if _, err := dbTest.Exec(tc.query); (err == nil) != tc.success {
+			t.Fatalf("statement %q using testuser has err=%s, expected success=%t", tc.query, err, tc.success)
+		}
+		if _, err := dbRoot.Exec(tc.query); err != nil {
+			t.Fatalf("statement %q using root failed: %v", tc.query, err)
+		}
+	}
+}
+
+func TestReadPrivileges(t *testing.T) {
+	defer leaktest.AfterTest(t)
+	s, dbRoot, dbTest := setupMultiuser(t)
+	defer cleanupMultiuser(s, dbRoot, dbTest)
+
+	if _, err := dbRoot.Exec(`CREATE DATABASE foo`); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := dbRoot.Exec(`GRANT READ ON DATABASE foo TO testuser`); err != nil {
+		t.Fatal(err)
+	}
+
+	// All statements must succeed with dbRoot.
+	// Statements with success==true must succeed with dbTest.
+	// They are evaluated in order, with dbTest first followed by dbRoot.
+	testCases := []struct {
+		query   string
+		success bool
+	}{
+		{`SHOW DATABASES`, true},
+		{`SET DATABASE = foo`, true},
+
+		{`CREATE TABLE tbl (id INT PRIMARY KEY)`, false},
+
+		{`SHOW TABLES`, true},
+		{`SHOW GRANTS ON DATABASE foo`, true},
+
+		{`GRANT ALL ON DATABASE foo TO bar`, false},
+		{`REVOKE ALL ON DATABASE foo FROM bar`, false},
+	}
+
+	for _, tc := range testCases {
+		if _, err := dbTest.Exec(tc.query); (err == nil) != tc.success {
+			t.Fatalf("statement %q using testuser has err=%s, expected success=%t", tc.query, err, tc.success)
+		}
+	}
+}
+
+func TestWritePrivileges(t *testing.T) {
+	defer leaktest.AfterTest(t)
+	s, dbRoot, dbTest := setupMultiuser(t)
+	defer cleanupMultiuser(s, dbRoot, dbTest)
+
+	if _, err := dbRoot.Exec(`CREATE DATABASE foo`); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := dbRoot.Exec(`GRANT WRITE ON DATABASE foo TO testuser`); err != nil {
+		t.Fatal(err)
+	}
+
+	// Statements with success==true must succeed with dbTest.
+	testCases := []struct {
+		query   string
+		success bool
+	}{
+		{`SHOW DATABASES`, true},
+		{`SET DATABASE = foo`, true},
+
+		{`CREATE TABLE tbl (id INT PRIMARY KEY)`, true},
+
+		{`SHOW TABLES`, true},
+		{`SHOW GRANTS ON DATABASE foo`, true},
+
+		{`GRANT ALL ON DATABASE foo TO bar`, true},
+		{`REVOKE ALL ON DATABASE foo FROM bar`, true},
+	}
+
+	for _, tc := range testCases {
+		if _, err := dbTest.Exec(tc.query); (err == nil) != tc.success {
+			t.Fatalf("statement %q using testuser has err=%s, expected success=%t", tc.query, err, tc.success)
+		}
+	}
+}

--- a/sql/grant.go
+++ b/sql/grant.go
@@ -18,6 +18,8 @@
 package sql
 
 import (
+	"fmt"
+
 	"github.com/cockroachdb/cockroach/keys"
 	"github.com/cockroachdb/cockroach/sql/parser"
 	"github.com/cockroachdb/cockroach/util"
@@ -30,6 +32,9 @@ import (
 // TODO(marc): open questions:
 // - should we have root always allowed and not present in the permissions list?
 // - should we make users case-insensitive?
+// Privileges: WRITE on database.
+//   Notes: postgres requires the object owner.
+//          mysql requires the "grant option" and the same privileges, and sometimes superuser.
 func (p *planner) Grant(n *parser.Grant) (planNode, error) {
 	if len(n.Targets.Targets) == 0 {
 		return nil, errEmptyDatabaseName
@@ -43,6 +48,11 @@ func (p *planner) Grant(n *parser.Grant) (planNode, error) {
 	dbDesc, err := p.getDatabaseDesc(n.Targets.Targets[0])
 	if err != nil {
 		return nil, err
+	}
+
+	if !dbDesc.HasPrivilege(p.user, parser.PrivilegeWrite) {
+		return nil, fmt.Errorf("user %s does not have %s privilege on database %s",
+			p.user, parser.PrivilegeWrite, dbDesc.Name)
 	}
 
 	if err := dbDesc.Grant(n); err != nil {

--- a/sql/logic_test.go
+++ b/sql/logic_test.go
@@ -227,7 +227,10 @@ func (t logicTest) run(path string) {
 
 			t.execQuery(db, query)
 
-		case "halt", "skipif", "onlyif":
+		case "halt":
+			break
+
+		case "skipif", "onlyif":
 			t.Fatalf("unimplemented test statement: %s", s.Text())
 		}
 	}
@@ -246,7 +249,7 @@ func (t logicTest) execStatement(db *sql.DB, stmt logicStatement) {
 			t.Fatalf("%s: expected success, but found %v", stmt.pos, err)
 		}
 	case !testutils.IsError(err, stmt.expectErr):
-		t.Fatalf("%s: expected %s, but found %v", stmt.pos, stmt.expectErr, err)
+		t.Fatalf("%s: expected %q, but found %q", stmt.pos, stmt.expectErr, err)
 	}
 }
 
@@ -307,7 +310,7 @@ func (t logicTest) execQuery(db *sql.DB, query logicQuery) {
 			t.Fatalf("%s: expected %s, but found %s\n", query.pos, query.expectedHash, hash)
 		}
 	} else if !reflect.DeepEqual(query.expectedResults, results) {
-		t.Fatalf("%s: expected %v, but found %v\n", query.pos, query.expectedResults, results)
+		t.Fatalf("%s: expected %q, but found %q\n", query.pos, query.expectedResults, results)
 	}
 }
 

--- a/sql/parser/grant.go
+++ b/sql/parser/grant.go
@@ -53,10 +53,17 @@ func (pt PrivilegeType) String() string {
 type PrivilegeList []PrivilegeType
 
 func (pl PrivilegeList) String() string {
+	return pl.Join(", ")
+}
+
+// Join returns the list of privilege names joined using `sep`.
+// The default stringer uses `, `, but we want to be able to
+// get a tight representation of the string.
+func (pl PrivilegeList) Join(sep string) string {
 	var buf bytes.Buffer
 	for i, n := range pl {
 		if i > 0 {
-			_, _ = buf.WriteString(", ")
+			_, _ = buf.WriteString(sep)
 		}
 		buf.WriteString(n.String())
 	}

--- a/sql/plan.go
+++ b/sql/plan.go
@@ -31,6 +31,7 @@ import (
 type planner struct {
 	db      *client.DB
 	session Session
+	user    string
 }
 
 // makePlan creates the query plan for a single SQL statement. The returned

--- a/sql/server.go
+++ b/sql/server.go
@@ -148,7 +148,9 @@ func (s *Server) exec(req driver.Request) (driver.Response, error) {
 	var resp driver.Response
 
 	// Pick up current session state.
-	planner := planner{db: s.db}
+	// The request user is validated in ServeHTTP. Even in insecure mode,
+	// it is guaranteed not to be empty.
+	planner := planner{db: s.db, user: req.GetUser()}
 	if req.Session != nil {
 		// TODO(tschottdorf) will have to validate the Session information (for
 		// instance, whether access to the stored database is permitted).

--- a/sql/set.go
+++ b/sql/set.go
@@ -26,6 +26,8 @@ import (
 )
 
 // Set sets session variables.
+// Privileges: None.
+//   Notes: postgres/mysql do not require privileges for session variables (some exceptions).
 func (p *planner) Set(n *parser.Set) (planNode, error) {
 	// By using QualifiedName.String() here any variables that are keywords will
 	// be double quoted.

--- a/sql/testdata/grant
+++ b/sql/testdata/grant
@@ -1,0 +1,86 @@
+statement ok
+CREATE DATABASE a
+
+query TTT
+SHOW GRANTS ON DATABASE a
+----
+Database User Privileges
+a        root READ,WRITE
+
+statement error .* TODO\(marc\): multiple targets not implemented
+SHOW GRANTS
+
+statement error syntax error
+SHOW GRANTS ON a.tbl
+
+statement error syntax error
+SHOW GRANTS ON tbl
+
+statement error root user does not have read privilege
+REVOKE READ ON DATABASE a FROM root
+
+statement ok
+GRANT ALL ON DATABASE a TO readwrite, "test-user"
+
+query TTT
+SHOW GRANTS ON DATABASE a
+----
+Database User      Privileges
+a        readwrite READ,WRITE
+a        root      READ,WRITE
+a        test-user READ,WRITE
+
+query TTT
+SHOW GRANTS ON DATABASE a FOR readwrite, "test-user"
+----
+Database User      Privileges
+a        readwrite READ,WRITE
+a        test-user READ,WRITE
+
+statement ok
+REVOKE WRITE ON DATABASE a FROM "test-user",readwrite
+
+query TTT
+SHOW GRANTS ON DATABASE a
+----
+Database User      Privileges
+a        readwrite READ
+a        root      READ,WRITE
+a        test-user READ
+
+query TTT
+SHOW GRANTS ON DATABASE a FOR readwrite, "test-user"
+----
+Database User      Privileges
+a        readwrite READ
+a        test-user READ
+
+statement ok
+REVOKE READ ON DATABASE a FROM "test-user"
+
+query TTT
+SHOW GRANTS ON DATABASE a
+----
+Database User      Privileges
+a        readwrite READ
+a        root      READ,WRITE
+
+query TTT
+SHOW GRANTS ON DATABASE a FOR readwrite, "test-user"
+----
+Database User      Privileges
+a        readwrite READ
+
+statement ok
+REVOKE ALL ON DATABASE a FROM readwrite,"test-user"
+
+query TTT
+SHOW GRANTS ON DATABASE a
+----
+Database User      Privileges
+a        root      READ,WRITE
+
+query TTT
+SHOW GRANTS ON DATABASE a FOR readwrite, "test-user"
+----
+Database User      Privileges

--- a/structured/structured.go
+++ b/structured/structured.go
@@ -20,6 +20,7 @@ package structured
 import (
 	"errors"
 	"fmt"
+	"sort"
 
 	"github.com/cockroachdb/cockroach/sql/parser"
 )
@@ -308,4 +309,17 @@ func (desc *DatabaseDescriptor) Show() (UserPrivilegeList, error) {
 	}
 
 	return permissions.Show(), nil
+}
+
+// HasPrivilege returns true if `user` has `privilege` on this descriptor.
+func (desc *DatabaseDescriptor) HasPrivilege(user string, privilege parser.PrivilegeType) bool {
+	var privUsers []string
+	switch privilege {
+	case parser.PrivilegeRead:
+		privUsers = desc.Read
+	case parser.PrivilegeWrite:
+		privUsers = desc.Write
+	}
+	result := sort.SearchStrings(privUsers, user)
+	return result < len(privUsers) && privUsers[result] == user
 }


### PR DESCRIPTION
Enforce read/write db-level privileges.

I've annotated the enforced functions with the privileges required
and notes about what postgres and mysql do. This will be useful when
adding real privileges (eg: create|select|insert|delete|etc...).
