### PR TITLE
Create a goroutine per outstanding txn on GC instead of one per intent.

### DIFF
--- a/storage/gc_queue.go
+++ b/storage/gc_queue.go
@@ -135,10 +135,13 @@ func (gcq *gcQueue) process(now proto.Timestamp, rng *Replica) error {
 	}
 	var mu sync.Mutex
 	var oldestIntentNanos int64 = math.MaxInt64
-	var wg sync.WaitGroup
 	var expBaseKey proto.Key
 	var keys []proto.EncodedKey
 	var vals [][]byte
+
+	// Maps from txn ID to txn and intent key slice.
+	txnMap := map[string]*proto.Transaction{}
+	intentMap := map[string][]proto.Key{}
 
 	// updateOldestIntent atomically updates the oldest intent.
 	updateOldestIntent := func(intentNanos int64) {
@@ -164,13 +167,14 @@ func (gcq *gcQueue) process(now proto.Timestamp, rng *Replica) error {
 				// intent resolution if older than the threshold.
 				startIdx := 1
 				if meta.Txn != nil {
-					// Resolve intent asynchronously in a goroutine if the intent
-					// is older than the intent expiration threshold.
+					// Keep track of intent to resolve if older than the intent
+					// expiration threshold.
 					if meta.Timestamp.Less(intentExp) {
-						wg.Add(1)
-						go gcq.resolveIntent(rng, expBaseKey, meta, updateOldestIntent, &wg)
+						id := string(meta.Txn.ID)
+						txnMap[id] = meta.Txn
+						intentMap[id] = append(intentMap[id], expBaseKey)
 					} else {
-						updateOldestIntent(meta.Timestamp.WallTime)
+						updateOldestIntent(meta.Txn.OrigTimestamp.WallTime)
 					}
 					// With an active intent, GC ignores MVCC metadata & intent value.
 					startIdx = 2
@@ -222,11 +226,38 @@ func (gcq *gcQueue) process(now proto.Timestamp, rng *Replica) error {
 		gcArgs.EndKey = gcArgs.Keys[len(gcArgs.Keys)-1].Key
 	}
 
-	// Wait for any outstanding intent resolves and set oldest extant intent.
+	// Process push transactions in parallel.
+	var wg sync.WaitGroup
+	for _, txn := range txnMap {
+		wg.Add(1)
+		go gcq.pushTxn(rng, now, txn, updateOldestIntent, &wg)
+	}
 	wg.Wait()
-	gcMeta.OldestIntentNanos = gogoproto.Int64(oldestIntentNanos)
+
+	// Resolve all intents.
+	// TODO(spencer): use a batch here when available.
+	for id, txn := range txnMap {
+		if txn.Status != proto.PENDING {
+			// The transaction was successfully pushed, so resolve the intents.
+			for _, key := range intentMap[id] {
+				resolveArgs := &proto.ResolveIntentRequest{
+					RequestHeader: proto.RequestHeader{
+						Timestamp: now,
+						Key:       key,
+						User:      security.RootUser,
+						Txn:       txn,
+					},
+				}
+				if _, err := rng.AddCmd(rng.context(), resolveArgs); err != nil {
+					log.Warningf("resolve of key %q failed: %s", key, err)
+					updateOldestIntent(txn.OrigTimestamp.WallTime)
+				}
+			}
+		}
+	}
 
 	// Send GC request through range.
+	gcMeta.OldestIntentNanos = gogoproto.Int64(oldestIntentNanos)
 	gcArgs.GCMeta = *gcMeta
 	if _, err := rng.AddCmd(rng.context(), gcArgs); err != nil {
 		return err
@@ -247,53 +278,39 @@ func (gcq *gcQueue) timer() time.Duration {
 	return gcQueueTimerDuration
 }
 
-// resolveIntent resolves the intent at key by attempting to abort the
-// transaction and resolve the intent. If the transaction cannot be
-// aborted or intent cannot be resolved, the oldestIntentNanos value
-// is atomically updated to the min of oldestIntentNanos and the
-// intent's timestamp. The wait group is signaled on completion.
-func (gcq *gcQueue) resolveIntent(rng *Replica, key proto.Key, meta *engine.MVCCMetadata,
-	updateOldestIntent func(int64), wg *sync.WaitGroup) {
+// pushTxn attempts to abort the txn via push. If the transaction
+// cannot be aborted, the oldestIntentNanos value is atomically
+// updated to the min of oldestIntentNanos and the intent's
+// timestamp. The wait group is signaled on completion.
+func (gcq *gcQueue) pushTxn(rng *Replica, now proto.Timestamp, txn *proto.Transaction, updateOldestIntent func(int64), wg *sync.WaitGroup) {
 	defer wg.Done() // signal wait group always on completion
-
-	log.Infof("resolving intent at %q ts=%s", key, meta.Timestamp)
+	if log.V(1) {
+		log.Infof("pushing txn %s ts=%s", txn, txn.OrigTimestamp)
+	}
 
 	// Attempt to push the transaction which created the intent.
-	now := rng.rm.Clock().Now()
 	pushArgs := &proto.PushTxnRequest{
 		RequestHeader: proto.RequestHeader{
 			Timestamp:    now,
-			Key:          meta.Txn.Key,
+			Key:          txn.Key,
 			User:         security.RootUser,
 			UserPriority: gogoproto.Int32(proto.MaxPriority),
 			Txn:          nil,
 		},
 		Now:       now,
-		PusheeTxn: *meta.Txn,
+		PusheeTxn: *txn,
 		PushType:  proto.ABORT_TXN,
 	}
 	pushReply := &proto.PushTxnResponse{}
 	b := &client.Batch{}
 	b.InternalAddCall(proto.Call{Args: pushArgs, Reply: pushReply})
 	if err := rng.rm.DB().Run(b); err != nil {
-		log.Warningf("push of txn %s failed: %s", meta.Txn, err)
-		updateOldestIntent(meta.Timestamp.WallTime)
+		log.Warningf("push of txn %s failed: %s", txn, err)
+		updateOldestIntent(txn.OrigTimestamp.WallTime)
 		return
 	}
-
-	// We pushed the transaction successfully, so resolve the intent.
-	resolveArgs := &proto.ResolveIntentRequest{
-		RequestHeader: proto.RequestHeader{
-			Timestamp: now,
-			Key:       key,
-			User:      security.RootUser,
-			Txn:       pushReply.PusheeTxn,
-		},
-	}
-	if _, err := rng.AddCmd(rng.context(), resolveArgs); err != nil {
-		log.Warningf("resolve of key %q failed: %s", key, err)
-		updateOldestIntent(meta.Timestamp.WallTime)
-	}
+	// Update the supplied txn on successful push.
+	*txn = *pushReply.PusheeTxn
 }
 
 // lookupGCPolicy queries the gossip prefix config map based on the

--- a/storage/gc_queue_test.go
+++ b/storage/gc_queue_test.go
@@ -18,6 +18,7 @@
 package storage
 
 import (
+	"fmt"
 	"math"
 	"testing"
 
@@ -27,6 +28,7 @@ import (
 	"github.com/cockroachdb/cockroach/storage/engine"
 	"github.com/cockroachdb/cockroach/util/leaktest"
 	"github.com/cockroachdb/cockroach/util/log"
+	gogoproto "github.com/gogo/protobuf/proto"
 )
 
 // makeTS creates a new hybrid logical timestamp.
@@ -128,8 +130,8 @@ func TestGCQueueProcess(t *testing.T) {
 
 	ts1 := makeTS(now-2*24*60*60*1E9+1, 0)                     // 2d old (add one nanosecond so we're not using zero timestamp)
 	ts2 := makeTS(now-25*60*60*1E9, 0)                         // GC will occur at time=25 hours
-	ts3 := makeTS(now-(intentAgeThreshold.Nanoseconds()+1), 0) // 2h+1ns old
-	ts4 := makeTS(now-(intentAgeThreshold.Nanoseconds()-1), 0) // 2h-ns old
+	ts3 := makeTS(now-intentAgeThreshold.Nanoseconds(), 0)     // 2h old
+	ts4 := makeTS(now-(intentAgeThreshold.Nanoseconds()-1), 0) // 2h-1ns old
 	ts5 := makeTS(now-1E9, 0)                                  // 1s old
 	key1 := proto.Key("a")
 	key2 := proto.Key("b")
@@ -167,14 +169,14 @@ func TestGCQueueProcess(t *testing.T) {
 		{key5, ts2, true, false},
 		// For key6, expect no values to GC because most recent value is intent.
 		{key6, ts1, false, false},
-		{key6, ts5, true, true},
+		{key6, ts5, false, true},
 		// For key7, expect no values to GC because intent is exactly 2h old.
 		{key7, ts2, false, false},
-		{key7, ts4, true, true},
+		{key7, ts4, false, true},
 		// For key8, expect most recent value to resolve by aborting, which will clean it up.
 		{key8, ts2, false, false},
 		{key8, ts3, true, true},
-		// /For key9, resolve naked intent with no remaining values.
+		// For key9, resolve naked intent with no remaining values.
 		{key9, ts3, true, false},
 	}
 
@@ -184,6 +186,7 @@ func TestGCQueueProcess(t *testing.T) {
 			dArgs.Timestamp = datum.ts
 			if datum.txn {
 				dArgs.Txn = newTransaction("test", datum.key, 1, proto.SERIALIZABLE, tc.clock)
+				dArgs.Txn.OrigTimestamp = datum.ts
 				dArgs.Txn.Timestamp = datum.ts
 			}
 			if _, err := tc.rng.AddCmd(tc.rng.context(), &dArgs); err != nil {
@@ -194,6 +197,7 @@ func TestGCQueueProcess(t *testing.T) {
 			pArgs.Timestamp = datum.ts
 			if datum.txn {
 				pArgs.Txn = newTransaction("test", datum.key, 1, proto.SERIALIZABLE, tc.clock)
+				pArgs.Txn.OrigTimestamp = datum.ts
 				pArgs.Txn.Timestamp = datum.ts
 			}
 			if _, err := tc.rng.AddCmd(tc.rng.context(), &pArgs); err != nil {
@@ -205,7 +209,7 @@ func TestGCQueueProcess(t *testing.T) {
 	// Process through a scan queue.
 	gcQ := newGCQueue()
 	if err := gcQ.process(tc.clock.Now(), tc.rng); err != nil {
-		t.Error(err)
+		t.Fatal(err)
 	}
 
 	expKVs := []struct {
@@ -285,6 +289,65 @@ func TestGCQueueProcess(t *testing.T) {
 	}
 	if gcMeta.LastScanNanos != ts.WallTime {
 		t.Errorf("expected walltime nanos %d; got %d", gcMeta.LastScanNanos, ts.WallTime)
+	}
+}
+
+// TestGCQueueIntentResolution verifies intent resolution with many
+// intents spanning just two transactions.
+func TestGCQueueIntentResolution(t *testing.T) {
+	defer leaktest.AfterTest(t)
+	tc := testContext{}
+	tc.Start(t)
+	defer tc.Stop()
+
+	const now int64 = 48 * 60 * 60 * 1E9 // 2d past the epoch
+	tc.manualClock.Set(now)
+
+	txns := []*proto.Transaction{
+		newTransaction("txn1", proto.Key("0-00000"), 1, proto.SERIALIZABLE, tc.clock),
+		newTransaction("txn2", proto.Key("1-00000"), 1, proto.SERIALIZABLE, tc.clock),
+	}
+	intentResolveTS := makeTS(now-intentAgeThreshold.Nanoseconds(), 0)
+	txns[0].OrigTimestamp = intentResolveTS
+	txns[0].Timestamp = intentResolveTS
+	txns[1].OrigTimestamp = intentResolveTS
+	txns[1].Timestamp = intentResolveTS
+
+	// Two transactions.
+	for i := 0; i < 2; i++ {
+		// 50,000 puts per transaction.
+		// TODO(spencer): increase back to 50000 once batching support is available.
+		for j := 0; j < 5000; j++ {
+			pArgs := putArgs(proto.Key(fmt.Sprintf("%d-%05d", i, j)), []byte("value"), tc.rng.Desc().RangeID, tc.store.StoreID())
+			pArgs.Timestamp = makeTS(1, 0)
+			pArgs.Txn = txns[i]
+			if _, err := tc.rng.AddCmd(tc.rng.context(), &pArgs); err != nil {
+				t.Fatalf("%d: could not put data: %s", i, err)
+			}
+		}
+	}
+
+	// Process through a scan queue.
+	gcQ := newGCQueue()
+	if err := gcQ.process(tc.clock.Now(), tc.rng); err != nil {
+		t.Fatal(err)
+	}
+
+	// Iterate through all values to ensure intents have been fully resolved.
+	meta := &engine.MVCCMetadata{}
+	err := tc.store.Engine().Iterate(engine.MVCCEncodeKey(proto.KeyMin), engine.MVCCEncodeKey(proto.KeyMax), func(kv proto.RawKeyValue) (bool, error) {
+		if key, _, isValue := engine.MVCCDecodeKey(kv.Key); !isValue {
+			if err := gogoproto.Unmarshal(kv.Value, meta); err != nil {
+				t.Fatalf("unable to unmarshal mvcc metadata for key %s", key)
+			}
+			if meta.Txn != nil {
+				t.Fatalf("non-nil Txn after GC for key %s", key)
+			}
+		}
+		return false, nil
+	})
+	if err != nil {
+		t.Fatal(err)
 	}
 }
 


### PR DESCRIPTION
This avoids pushing the same txn many times in the likely event that multiple
intents are found for the same txn. It also avoids starting many goroutines to
service intents.

TODO: Use proto.Batch for intents for efficient resolution.

Fixes #1869
