### PR TITLE
Adjustments to the SQL logic test framework.

### DIFF
--- a/sql/testdata/database
+++ b/sql/testdata/database
@@ -10,11 +10,12 @@ CREATE DATABASE IF NOT EXISTS a
 statement error empty database name
 CREATE DATABASE ""
 
-query T
+query T colnames
 SHOW DATABASES
 ----
 Database
 a
+test
 
 statement ok
 CREATE DATABASE b
@@ -25,8 +26,7 @@ CREATE DATABASE c
 query T
 SHOW DATABASES
 ----
-Database
 a
 b
 c
-
+test

--- a/sql/testdata/delete
+++ b/sql/testdata/delete
@@ -1,38 +1,32 @@
 statement ok
-CREATE DATABASE t
-
-statement ok
-CREATE TABLE t.kv (
+CREATE TABLE kv (
   k INT PRIMARY KEY,
   v INT
 )
 
 statement ok
-INSERT INTO t.kv VALUES (1, 2), (3, 4), (5, 6), (7, 8)
+INSERT INTO kv VALUES (1, 2), (3, 4), (5, 6), (7, 8)
 
 query II
-SELECT * FROM t.kv
+SELECT * FROM kv
 ----
-k v
 1 2
 3 4
 5 6
 7 8
 
 statement ok
-DELETE FROM t.kv WHERE k=3 OR v=6
+DELETE FROM kv WHERE k=3 OR v=6
 
 query II
-SELECT * FROM t.kv
+SELECT * FROM kv
 ----
-k v
 1 2
 7 8
 
 statement ok
-DELETE FROM t.kv
+DELETE FROM kv
 
 query II
-SELECT * FROM t.kv
+SELECT * FROM kv
 ----
-k v

--- a/sql/testdata/grant
+++ b/sql/testdata/grant
@@ -1,7 +1,7 @@
 statement ok
 CREATE DATABASE a
 
-query TTT
+query TTT colnames
 SHOW GRANTS ON DATABASE a
 ----
 Database User Privileges
@@ -25,7 +25,6 @@ GRANT ALL ON DATABASE a TO readwrite, "test-user"
 query TTT
 SHOW GRANTS ON DATABASE a
 ----
-Database User      Privileges
 a        readwrite READ,WRITE
 a        root      READ,WRITE
 a        test-user READ,WRITE
@@ -33,7 +32,6 @@ a        test-user READ,WRITE
 query TTT
 SHOW GRANTS ON DATABASE a FOR readwrite, "test-user"
 ----
-Database User      Privileges
 a        readwrite READ,WRITE
 a        test-user READ,WRITE
 
@@ -43,7 +41,6 @@ REVOKE WRITE ON DATABASE a FROM "test-user",readwrite
 query TTT
 SHOW GRANTS ON DATABASE a
 ----
-Database User      Privileges
 a        readwrite READ
 a        root      READ,WRITE
 a        test-user READ
@@ -51,7 +48,6 @@ a        test-user READ
 query TTT
 SHOW GRANTS ON DATABASE a FOR readwrite, "test-user"
 ----
-Database User      Privileges
 a        readwrite READ
 a        test-user READ
 
@@ -61,14 +57,12 @@ REVOKE READ ON DATABASE a FROM "test-user"
 query TTT
 SHOW GRANTS ON DATABASE a
 ----
-Database User      Privileges
 a        readwrite READ
 a        root      READ,WRITE
 
 query TTT
 SHOW GRANTS ON DATABASE a FOR readwrite, "test-user"
 ----
-Database User      Privileges
 a        readwrite READ
 
 statement ok
@@ -77,10 +71,8 @@ REVOKE ALL ON DATABASE a FROM readwrite,"test-user"
 query TTT
 SHOW GRANTS ON DATABASE a
 ----
-Database User      Privileges
 a        root      READ,WRITE
 
 query TTT
 SHOW GRANTS ON DATABASE a FOR readwrite, "test-user"
 ----
-Database User      Privileges

--- a/sql/testdata/insert
+++ b/sql/testdata/insert
@@ -1,49 +1,44 @@
-statement ok
-CREATE DATABASE t
-
 statement error structured.TableDescriptor .* does not exist
-INSERT INTO t.kv VALUES ('a', 'b')
+INSERT INTO kv VALUES ('a', 'b')
 
 statement ok
-CREATE TABLE t.kv (
+CREATE TABLE kv (
   k CHAR PRIMARY KEY,
   v CHAR,
   CONSTRAINT a UNIQUE (v)
 )
 
 query TT
-SELECT * FROM t.kv
+SELECT * FROM kv
 ----
-k v
 
 statement error invalid values for columns
-INSERT INTO t.kv VALUES ('a')
+INSERT INTO kv VALUES ('a')
 
 statement error missing .* primary key column
-INSERT INTO t.kv (v) VALUES ('a')
+INSERT INTO kv (v) VALUES ('a')
 
 statement ok
-INSERT INTO t.kv VALUES ('nil', NULL)
+INSERT INTO kv VALUES ('nil', NULL)
 
 statement ok
-INSERT INTO t.kv (k,v) VALUES ('a', 'b'), ('c', 'd')
+INSERT INTO kv (k,v) VALUES ('a', 'b'), ('c', 'd')
 
 statement ok
-INSERT INTO t.kv VALUES ('e', 'f')
+INSERT INTO kv VALUES ('e', 'f')
 
 statement error duplicate key value .* violates unique constraint
-INSERT INTO t.kv VALUES ('e', 'f')
+INSERT INTO kv VALUES ('e', 'f')
 
 statement ok
-INSERT INTO t.kv VALUES ('f', 'g')
+INSERT INTO kv VALUES ('f', 'g')
 
 statement error duplicate key value .* violates unique constraint
-INSERT INTO t.kv VALUES ('g', 'g')
+INSERT INTO kv VALUES ('g', 'g')
 
 query TT
-SELECT * FROM t.kv
+SELECT * FROM kv
 ----
-k   v
 a   b
 c   d
 e   f
@@ -51,7 +46,7 @@ f   g
 nil NULL
 
 statement ok
-CREATE TABLE t.kv2 (
+CREATE TABLE kv2 (
   k CHAR,
   v CHAR,
   CONSTRAINT a UNIQUE (v),
@@ -59,12 +54,11 @@ CREATE TABLE t.kv2 (
 )
 
 statement ok
-INSERT INTO t.kv2 VALUES ('a', 'b'), ('c', 'd'), ('e', 'f'), ('f', 'g')
+INSERT INTO kv2 VALUES ('a', 'b'), ('c', 'd'), ('e', 'f'), ('f', 'g')
 
 query TT
-SELECT * FROM t.kv2
+SELECT * FROM kv2
 ----
-k   v
 a   b
 c   d
 e   f

--- a/sql/testdata/select
+++ b/sql/testdata/select
@@ -4,9 +4,8 @@ query I
 SELECT 1
 ----
 1
-1
 
-query II
+query II colnames
 SELECT 1+1 AS two, 2+2 AS four
 ----
 two four
@@ -15,40 +14,37 @@ two four
 # SELECT expression tests.
 
 statement ok
-CREATE DATABASE t
+CREATE TABLE abc (a INT PRIMARY KEY, b INT, c INT)
 
 statement ok
-CREATE TABLE t.abc (a INT PRIMARY KEY, b INT, c INT)
+INSERT INTO abc VALUES (1, 2, 3)
 
-statement ok
-INSERT INTO t.abc VALUES (1, 2, 3)
-
-query III
-SELECT * FROM t.abc
+query III colnames
+SELECT * FROM abc
 ----
 a b c
 1 2 3
 
-query IIIIII
-SELECT *,* FROM t.abc
+query IIIIII colnames
+SELECT *,* FROM abc
 ----
 a b c a b c
 1 2 3 1 2 3
 
-query IIII
-SELECT a,a,a,a FROM t.abc
+query IIII colnames
+SELECT a,a,a,a FROM abc
 ----
 a a a a
 1 1 1 1
 
-query II
-SELECT a,c FROM t.abc
+query II colnames
+SELECT a,c FROM abc
 ----
 a c
 1 3
 
-query I
-SELECT a+b+c AS foo FROM t.abc
+query I colnames
+SELECT a+b+c AS foo FROM abc
 ----
 foo
 6
@@ -56,24 +52,22 @@ foo
 # SELECT of NULL value.
 
 statement ok
-CREATE TABLE t.kv (k CHAR PRIMARY KEY, v CHAR)
+CREATE TABLE kv (k CHAR PRIMARY KEY, v CHAR)
 
 statement ok
-INSERT INTO t.kv (k) VALUES ('a')
+INSERT INTO kv (k) VALUES ('a')
 
 query TT
-SELECT * FROM t.kv
+SELECT * FROM kv
 ----
-k v
 a NULL
 
 query TT
-SELECT k,v FROM t.kv
+SELECT k,v FROM kv
 ----
-k v
 a NULL
 
 query T
-SELECT k FROM t.kv
+SELECT k FROM kv
 ----
 1 value hashing to 60b725f10c9c85c70d97880dfe8191b3

--- a/sql/testdata/table
+++ b/sql/testdata/table
@@ -1,17 +1,17 @@
 statement ok
-CREATE DATABASE t
+SET DATABASE = ""
 
 statement error no database specified
 CREATE TABLE a (id INT PRIMARY KEY)
 
 statement ok
-CREATE TABLE t.a (id INT PRIMARY KEY)
+CREATE TABLE test.a (id INT PRIMARY KEY)
 
 statement error structured.TableDescriptor .* already exists
-CREATE TABLE t.a (id INT PRIMARY KEY)
+CREATE TABLE test.a (id INT PRIMARY KEY)
 
 statement ok
-SET DATABASE = t
+SET DATABASE = test
 
 statement error structured.TableDescriptor .* already exists
 CREATE TABLE a (id INT PRIMARY KEY)
@@ -19,8 +19,8 @@ CREATE TABLE a (id INT PRIMARY KEY)
 statement ok
 CREATE TABLE IF NOT EXISTS a (id INT PRIMARY KEY)
 
-query T
-SHOW TABLES FROM t
+query T colnames
+SHOW TABLES FROM test
 ----
 Table
 a
@@ -32,9 +32,8 @@ statement ok
 CREATE TABLE c (id INT PRIMARY KEY)
 
 query T
-SHOW TABLES FROM t
+SHOW TABLES FROM test
 ----
-Table
 a
 b
 c
@@ -51,7 +50,7 @@ SHOW COLUMNS FROM foo.users
 ----
 
 query error structured.TableDescriptor .* does not exist
-SHOW COLUMNS FROM t.users
+SHOW COLUMNS FROM test.users
 ----
 
 query error no database specified
@@ -63,11 +62,11 @@ SHOW INDEX FROM foo.users
 ----
 
 query error structured.TableDescriptor .* does not exist
-SHOW INDEX FROM t.users
+SHOW INDEX FROM test.users
 ----
 
 statement ok
-CREATE TABLE t.users (
+CREATE TABLE test.users (
   id    INT PRIMARY KEY,
   name  VARCHAR NOT NULL,
   title VARCHAR,
@@ -75,16 +74,16 @@ CREATE TABLE t.users (
   CONSTRAINT bar UNIQUE (id, name)
 )
 
-query TTT
-SHOW COLUMNS FROM t.users
+query TTT colnames
+SHOW COLUMNS FROM test.users
 ----
 Field Type Null
 id    INT  true
 name  CHAR false
 title CHAR true
 
-query TTTTT
-SHOW INDEX FROM t.users
+query TTTTT colnames
+SHOW INDEX FROM test.users
 ----
 Table Name    Unique Seq Column
 users primary true   1   id

--- a/sql/testdata/truncate
+++ b/sql/testdata/truncate
@@ -1,28 +1,23 @@
 statement ok
-CREATE DATABASE t
-
-statement ok
-CREATE TABLE t.kv (
+CREATE TABLE kv (
   k INT PRIMARY KEY,
   v INT
 )
 
 statement ok
-INSERT INTO t.kv VALUES (1, 2), (3, 4), (5, 6), (7, 8)
+INSERT INTO kv VALUES (1, 2), (3, 4), (5, 6), (7, 8)
 
 query II
-SELECT * FROM t.kv
+SELECT * FROM kv
 ----
-k v
 1 2
 3 4
 5 6
 7 8
 
 statement ok
-TRUNCATE TABLE t.kv
+TRUNCATE TABLE kv
 
 query II
-SELECT * FROM t.kv
+SELECT * FROM kv
 ----
-k v

--- a/sql/testdata/update
+++ b/sql/testdata/update
@@ -1,29 +1,25 @@
 statement ok
-CREATE DATABASE t
-
-statement ok
-CREATE TABLE t.kv (
+CREATE TABLE kv (
   k INT PRIMARY KEY,
   v INT
 )
 
 statement ok
-INSERT INTO t.kv VALUES (1, 2), (3, 4), (5, 6), (7, 8)
+INSERT INTO kv VALUES (1, 2), (3, 4), (5, 6), (7, 8)
 
 statement ok
-UPDATE t.kv SET v = 9 WHERE k IN (1, 3)
+UPDATE kv SET v = 9 WHERE k IN (1, 3)
 
 query II
-SELECT * FROM t.kv
+SELECT * FROM kv
 ----
-k v
 1 9
 3 9
 5 6
 7 8
 
 statement error column "m" does not exist
-UPDATE t.kv SET m = 9 WHERE k IN (1, 3)
+UPDATE kv SET m = 9 WHERE k IN (1, 3)
 
 statement error primary key column "k" cannot be updated
-UPDATE t.kv SET k = 9 WHERE k IN (1, 3)
+UPDATE kv SET k = 9 WHERE k IN (1, 3)

--- a/sql/testdata/where
+++ b/sql/testdata/where
@@ -1,24 +1,19 @@
 statement ok
-CREATE DATABASE t
-
-statement ok
-CREATE TABLE t.kv (
+CREATE TABLE kv (
   k INT PRIMARY KEY,
   v INT
 )
 
 statement ok
-INSERT INTO t.kv VALUES (1, 2), (3, 4), (5, 6), (7, 8)
+INSERT INTO kv VALUES (1, 2), (3, 4), (5, 6), (7, 8)
 
 query II
-SELECT * FROM t.kv WHERE k IN (1, 3)
+SELECT * FROM kv WHERE k IN (1, 3)
 ----
-k v
 1 2
 3 4
 
 query II
-SELECT * FROM t.kv WHERE v IN (6)
+SELECT * FROM kv WHERE v IN (6)
 ----
-k v
 5 6


### PR DESCRIPTION
Added support for a "colnames" query option which controls whether the
column names are printed at the start of query results. Defaults to
false since this is an extension of the sqllogictest format. Adjusted
the existing tests to use this where needed.

Created a default "test" database and set the session database to "test"
as part of the framework. The sqllogictest data files expect an
environment in which tables can be created with qualification.

Added a "-d" flag that allows changing which test data files are used.
