### PR TITLE
Add "user" command to sql logic test.

### DIFF
--- a/sql/driver/permission_test.go
+++ b/sql/driver/permission_test.go
@@ -78,43 +78,6 @@ func TestInsecure(t *testing.T) {
 	}
 }
 
-func TestDefaultPrivileges(t *testing.T) {
-	defer leaktest.AfterTest(t)
-	s, dbRoot, dbTest := setupMultiuser(t)
-	defer cleanupMultiuser(s, dbRoot, dbTest)
-
-	// All statements must succeed with dbRoot.
-	// Statements with success==true must succeed with dbTest.
-	// They are evaluated in order, with dbTest first followed by dbRoot.
-	testCases := []struct {
-		query   string
-		success bool
-	}{
-		/* Database-level permissions */
-		{`CREATE DATABASE foo`, false},
-
-		{`SHOW DATABASES`, true},
-		{`SET DATABASE = foo`, true},
-
-		{`CREATE TABLE tbl (id INT PRIMARY KEY)`, false},
-
-		{`SHOW TABLES`, true},
-		{`SHOW GRANTS ON DATABASE foo`, true},
-
-		{`GRANT ALL ON DATABASE foo TO bar`, false},
-		{`REVOKE ALL ON DATABASE foo FROM bar`, false},
-	}
-
-	for _, tc := range testCases {
-		if _, err := dbTest.Exec(tc.query); (err == nil) != tc.success {
-			t.Fatalf("statement %q using testuser has err=%s, expected success=%t", tc.query, err, tc.success)
-		}
-		if _, err := dbRoot.Exec(tc.query); err != nil {
-			t.Fatalf("statement %q using root failed: %v", tc.query, err)
-		}
-	}
-}
-
 func TestReadPrivileges(t *testing.T) {
 	defer leaktest.AfterTest(t)
 	s, dbRoot, dbTest := setupMultiuser(t)

--- a/sql/testdata/privileges
+++ b/sql/testdata/privileges
@@ -1,0 +1,52 @@
+# Test default database-level permissions.
+# Default user is "root".
+statement ok
+CREATE DATABASE a
+
+statement ok
+SHOW DATABASES
+
+statement ok
+SET DATABASE = a
+
+statement ok
+CREATE TABLE t (id INT PRIMARY KEY)
+
+statement ok
+SHOW TABLES
+
+statement ok
+SHOW GRANTS ON DATABASE a
+
+statement ok
+GRANT ALL ON DATABASE a TO bar
+
+statement ok
+REVOKE ALL ON DATABASE a FROM bar
+
+# Switch to a user without any privileges.
+user testuser
+
+statement error only root is allowed to create databases
+CREATE DATABASE b
+
+statement ok
+SHOW DATABASES
+
+statement ok
+SET DATABASE = a
+
+statement error user testuser does not have WRITE privilege on database a
+CREATE TABLE t2 (id INT PRIMARY KEY)
+
+statement ok
+SHOW TABLES
+
+statement ok
+SHOW GRANTS ON DATABASE a
+
+statement error user testuser does not have WRITE privilege on database a
+GRANT ALL ON DATABASE a TO bar
+
+statement error user testuser does not have WRITE privilege on database a
+REVOKE ALL ON DATABASE a FROM bar


### PR DESCRIPTION
This changes the DB client with the specified user.
We keep all clients for re-use and close.

Migrate privilege test to sql logic test (more to follow)
