### PR TITLE
Add support for subqueries.

### DIFF
--- a/sql/server.go
+++ b/sql/server.go
@@ -197,6 +197,10 @@ func (s *Server) exec(req driver.Request) (driver.Response, error) {
 			}
 			result.Rows = append(result.Rows, row)
 		}
+		if err := plan.Err(); err != nil {
+			return resp, err
+		}
+
 		resp.Results = append(resp.Results, result)
 	}
 

--- a/sql/testdata/where
+++ b/sql/testdata/where
@@ -17,3 +17,23 @@ query II
 SELECT * FROM kv WHERE v IN (6)
 ----
 5 6
+
+query II
+SELECT * FROM kv WHERE k IN (SELECT k FROM kv)
+----
+1 2
+3 4
+5 6
+7 8
+
+query II
+SELECT * FROM kv WHERE (k,v) IN (SELECT * FROM kv)
+----
+1 2
+3 4
+5 6
+7 8
+
+query error column "nonexistent" not found
+SELECT * FROM kv WHERE nonexistent = 1
+----


### PR DESCRIPTION
Fixed a buglet where we were swalling errors from query plan execution.

Unbelievably, with the addition of subquery support, the 58K lines of
tests in
https://github.com/gregrahn/sqllogictest/blob/master/test/index/in/10/slt_good_0.test
pass.
