### PR TITLE
Use go 1.5 in CI

### DIFF
--- a/build/builder.sh
+++ b/build/builder.sh
@@ -6,7 +6,7 @@ image="cockroachdb/builder"
 
 function init() {
   docker build --tag="${image}" - <<EOF
-FROM golang:1.4.2
+FROM golang:1.5
 
 RUN apt-get update -y && \
  apt-get dist-upgrade -y && \

--- a/build/devbase/Dockerfile
+++ b/build/devbase/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.4.2
+FROM golang:1.5
 
 MAINTAINER Tobias Schottdorf <tobias.schottdorf@gmail.com>
 


### PR DESCRIPTION
This image uses go1.5beta3 right now, but it gets regular updates. See https://github.com/docker-library/golang/pull/56.
