### PR TITLE
Prettify table/database errors

### DIFF
--- a/sql/create.go
+++ b/sql/create.go
@@ -22,7 +22,6 @@ import (
 
 	"github.com/cockroachdb/cockroach/security"
 	"github.com/cockroachdb/cockroach/sql/parser"
-	"github.com/cockroachdb/cockroach/structured"
 )
 
 // CreateDatabase creates a database.
@@ -38,10 +37,9 @@ func (p *planner) CreateDatabase(n *parser.CreateDatabase) (planNode, error) {
 		return nil, fmt.Errorf("only %s is allowed to create databases", security.RootUser)
 	}
 
-	nameKey := structured.MakeNameMetadataKey(structured.RootNamespaceID, string(n.Name))
 	desc := makeDatabaseDesc(n)
 
-	if err := p.writeDescriptor(nameKey, &desc, n.IfNotExists); err != nil {
+	if err := p.writeDescriptor(databaseKey{string(n.Name)}, &desc, n.IfNotExists); err != nil {
 		return nil, err
 	}
 	return &valuesNode{}, nil
@@ -76,8 +74,7 @@ func (p *planner) CreateTable(n *parser.CreateTable) (planNode, error) {
 		return nil, err
 	}
 
-	nameKey := structured.MakeNameMetadataKey(dbDesc.ID, n.Table.Table())
-	if err := p.writeDescriptor(nameKey, &desc, n.IfNotExists); err != nil {
+	if err := p.writeDescriptor(tableKey{dbDesc.ID, n.Table.Table()}, &desc, n.IfNotExists); err != nil {
 		return nil, err
 	}
 	return &valuesNode{}, nil

--- a/sql/database.go
+++ b/sql/database.go
@@ -18,10 +18,24 @@
 package sql
 
 import (
+	"github.com/cockroachdb/cockroach/proto"
 	"github.com/cockroachdb/cockroach/security"
 	"github.com/cockroachdb/cockroach/sql/parser"
 	"github.com/cockroachdb/cockroach/structured"
 )
+
+// databaseKey implements descriptorKey.
+type databaseKey struct {
+	name string
+}
+
+func (dk databaseKey) Key() proto.Key {
+	return structured.MakeNameMetadataKey(structured.RootNamespaceID, dk.name)
+}
+
+func (dk databaseKey) Name() string {
+	return dk.name
+}
 
 func makeDatabaseDesc(p *parser.CreateDatabase) structured.DatabaseDescriptor {
 	return structured.DatabaseDescriptor{
@@ -35,9 +49,8 @@ func makeDatabaseDesc(p *parser.CreateDatabase) structured.DatabaseDescriptor {
 
 // getDatabaseDesc looks up the database descriptor given its name.
 func (p *planner) getDatabaseDesc(name string) (*structured.DatabaseDescriptor, error) {
-	nameKey := structured.MakeNameMetadataKey(structured.RootNamespaceID, name)
 	desc := structured.DatabaseDescriptor{}
-	if err := p.getDescriptor(nameKey, &desc); err != nil {
+	if err := p.getDescriptor(databaseKey{name}, &desc); err != nil {
 		return nil, err
 	}
 	return &desc, nil

--- a/sql/grant.go
+++ b/sql/grant.go
@@ -41,8 +41,8 @@ func (p *planner) Grant(n *parser.Grant) (planNode, error) {
 	}
 
 	if !descriptor.HasPrivilege(p.user, parser.PrivilegeWrite) {
-		return nil, fmt.Errorf("user %s does not have %s privilege on database %s",
-			p.user, parser.PrivilegeWrite, descriptor.GetName())
+		return nil, fmt.Errorf("user %s does not have %s privilege on %s %s",
+			p.user, parser.PrivilegeWrite, descriptor.TypeName(), descriptor.GetName())
 	}
 
 	if err := descriptor.Grant(n); err != nil {

--- a/sql/insert.go
+++ b/sql/insert.go
@@ -51,7 +51,7 @@ func (p *planner) Insert(n *parser.Insert) (planNode, error) {
 	// Verify we have at least the columns that are part of the primary key.
 	for i, id := range tableDesc.PrimaryIndex.ColumnIDs {
 		if _, ok := colIDtoRowIndex[id]; !ok {
-			return nil, fmt.Errorf("missing \"%s\" primary key column", tableDesc.PrimaryIndex.ColumnNames[i])
+			return nil, fmt.Errorf("missing %q primary key column", tableDesc.PrimaryIndex.ColumnNames[i])
 		}
 	}
 

--- a/sql/revoke.go
+++ b/sql/revoke.go
@@ -41,8 +41,8 @@ func (p *planner) Revoke(n *parser.Revoke) (planNode, error) {
 	}
 
 	if !descriptor.HasPrivilege(p.user, parser.PrivilegeWrite) {
-		return nil, fmt.Errorf("user %s does not have %s privilege on database %s",
-			p.user, parser.PrivilegeWrite, descriptor.GetName())
+		return nil, fmt.Errorf("user %s does not have %s privilege on %s %s",
+			p.user, parser.PrivilegeWrite, descriptor.TypeName(), descriptor.GetName())
 	}
 
 	if err := descriptor.Revoke(n); err != nil {

--- a/sql/testdata/database
+++ b/sql/testdata/database
@@ -1,7 +1,7 @@
 statement ok
 CREATE DATABASE a
 
-statement error structured.DatabaseDescriptor .* already exists
+statement error database "a" already exists
 CREATE DATABASE a
 
 statement ok

--- a/sql/testdata/grant_table
+++ b/sql/testdata/grant_table
@@ -11,19 +11,19 @@ Database User      Privileges
 a        readwrite READ,WRITE
 a        root      READ,WRITE
 
-statement error .* does not exist
+statement error table "t" does not exist
 SHOW GRANTS ON a.t
 
-statement error .* does not exist
+statement error table "t" does not exist
 SHOW GRANTS ON t
 
 statement ok
 SET DATABASE = a
 
-statement error .* does not exist
+statement error table "t" does not exist
 SHOW GRANTS ON t
 
-statement error .* does not exist
+statement error table "t" does not exist
 GRANT ALL ON a.t TO readwrite
 
 statement ok

--- a/sql/testdata/insert
+++ b/sql/testdata/insert
@@ -1,4 +1,4 @@
-statement error structured.TableDescriptor .* does not exist
+statement error table "kv" does not exist
 INSERT INTO kv VALUES ('a', 'b')
 
 statement ok
@@ -15,7 +15,7 @@ SELECT * FROM kv
 statement error invalid values for columns
 INSERT INTO kv VALUES ('a')
 
-statement error missing .* primary key column
+statement error missing "k" primary key column
 INSERT INTO kv (v) VALUES ('a')
 
 statement ok

--- a/sql/testdata/set
+++ b/sql/testdata/set
@@ -1,4 +1,4 @@
-statement error .*name-\\bfoo.* does not exist
+statement error database "foo" does not exist
 SET DATABASE = foo
 
 # Ensure that the failing SET DATABASE call did not alter the session.

--- a/sql/testdata/table
+++ b/sql/testdata/table
@@ -7,13 +7,13 @@ CREATE TABLE a (id INT PRIMARY KEY)
 statement ok
 CREATE TABLE test.a (id INT PRIMARY KEY)
 
-statement error structured.TableDescriptor .* already exists
+statement error table "a" already exists
 CREATE TABLE test.a (id INT PRIMARY KEY)
 
 statement ok
 SET DATABASE = test
 
-statement error structured.TableDescriptor .* already exists
+statement error table "a" already exists
 CREATE TABLE a (id INT PRIMARY KEY)
 
 statement ok
@@ -45,11 +45,11 @@ query error no database specified
 SHOW COLUMNS FROM users
 ----
 
-query error structured.DatabaseDescriptor .* does not exist
+query error database "foo" does not exist
 SHOW COLUMNS FROM foo.users
 ----
 
-query error structured.TableDescriptor .* does not exist
+query error table "users" does not exist
 SHOW COLUMNS FROM test.users
 ----
 
@@ -57,11 +57,11 @@ query error no database specified
 SHOW INDEX FROM users
 ----
 
-query error structured.DatabaseDescriptor .* does not exist
+query error database "foo" does not exist
 SHOW INDEX FROM foo.users
 ----
 
-query error structured.TableDescriptor .* does not exist
+query error table "users" does not exist
 SHOW INDEX FROM test.users
 ----
 

--- a/sql/update.go
+++ b/sql/update.go
@@ -53,7 +53,7 @@ func (p *planner) Update(n *parser.Update) (planNode, error) {
 	// Don't allow updating any column that is part of the primary key.
 	for i, id := range tableDesc.PrimaryIndex.ColumnIDs {
 		if _, ok := colIDSet[id]; ok {
-			return nil, fmt.Errorf("primary key column \"%s\" cannot be updated", tableDesc.PrimaryIndex.ColumnNames[i])
+			return nil, fmt.Errorf("primary key column %q cannot be updated", tableDesc.PrimaryIndex.ColumnNames[i])
 		}
 	}
 

--- a/structured/structured.go
+++ b/structured/structured.go
@@ -58,6 +58,11 @@ func (desc *TableDescriptor) SetID(id ID) {
 	desc.ID = id
 }
 
+// TypeName returns the plain type of this descriptor.
+func (desc *TableDescriptor) TypeName() string {
+	return "table"
+}
+
 // AllocateIDs allocates column and index ids for any column or index which has
 // an ID of 0.
 func (desc *TableDescriptor) AllocateIDs() error {
@@ -259,6 +264,11 @@ func (desc *DatabaseDescriptor) GetID() ID {
 // SetID implements the sql.descriptorProto interface.
 func (desc *DatabaseDescriptor) SetID(id ID) {
 	desc.ID = id
+}
+
+// TypeName returns the plain type of this descriptor.
+func (desc *DatabaseDescriptor) TypeName() string {
+	return "database"
 }
 
 // Validate validates that the database descriptor is well formed.


### PR DESCRIPTION
Introduce descriptorKey so that we can keep the db/table name around
and use it in errors.

Add TypeName to db/table descriptor for clearer error messages.
