### PR TITLE
Introduce ReplicaIDs as described in #1865.

### DIFF
--- a/proto/data.pb.go
+++ b/proto/data.pb.go
@@ -337,6 +337,7 @@ type ChangeReplicasTrigger struct {
 	Replica Replica `protobuf:"bytes,4,opt,name=replica" json:"replica"`
 	// The new replica list with this change applied.
 	UpdatedReplicas  []Replica `protobuf:"bytes,5,rep,name=updated_replicas" json:"updated_replicas"`
+	NextReplicaID    ReplicaID `protobuf:"varint,6,opt,name=next_replica_id,casttype=ReplicaID" json:"next_replica_id"`
 	XXX_unrecognized []byte    `json:"-"`
 }
 
@@ -1471,6 +1472,22 @@ func (m *ChangeReplicasTrigger) Unmarshal(data []byte) error {
 				return err
 			}
 			iNdEx = postIndex
+		case 6:
+			if wireType != 0 {
+				return fmt.Errorf("proto: wrong wireType = %d for field NextReplicaID", wireType)
+			}
+			m.NextReplicaID = 0
+			for shift := uint(0); ; shift += 7 {
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := data[iNdEx]
+				iNdEx++
+				m.NextReplicaID |= (ReplicaID(b) & 0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
 		default:
 			var sizeOfWire int
 			for {
@@ -2596,6 +2613,7 @@ func (m *ChangeReplicasTrigger) Size() (n int) {
 			n += 1 + l + sovData(uint64(l))
 		}
 	}
+	n += 1 + sovData(uint64(m.NextReplicaID))
 	if m.XXX_unrecognized != nil {
 		n += len(m.XXX_unrecognized)
 	}
@@ -3021,6 +3039,9 @@ func (m *ChangeReplicasTrigger) MarshalTo(data []byte) (n int, err error) {
 			i += n
 		}
 	}
+	data[i] = 0x30
+	i++
+	i = encodeVarintData(data, i, uint64(m.NextReplicaID))
 	if m.XXX_unrecognized != nil {
 		i += copy(data[i:], m.XXX_unrecognized)
 	}

--- a/proto/data.proto
+++ b/proto/data.proto
@@ -124,6 +124,8 @@ message ChangeReplicasTrigger {
   optional Replica replica = 4 [(gogoproto.nullable) = false];
   // The new replica list with this change applied.
   repeated Replica updated_replicas = 5 [(gogoproto.nullable) = false];
+  optional int32 next_replica_id = 6 [(gogoproto.nullable) = false,
+      (gogoproto.customname) = "NextReplicaID", (gogoproto.casttype) = "ReplicaID"];
 }
 
 // CommitTrigger encapsulates all of the internal-only commit triggers.

--- a/proto/metadata.proto
+++ b/proto/metadata.proto
@@ -36,9 +36,8 @@ message Attributes {
 }
 
 // Replica describes a replica location by node ID (corresponds to a
-// host:port via lookup on gossip network), store ID (identifies the
-// device) and associated attributes. Replicas are stored in Range
-// lookup records (meta1, meta2).
+// host:port via lookup on gossip network) and store ID (identifies the
+// device).
 message Replica {
   option (gogoproto.goproto_stringer) = false;
 
@@ -46,6 +45,12 @@ message Replica {
       (gogoproto.customname) = "NodeID", (gogoproto.casttype) = "NodeID"];
   optional int32 store_id = 2 [(gogoproto.nullable) = false,
       (gogoproto.customname) = "StoreID", (gogoproto.casttype) = "StoreID"];
+
+  // ReplicaID uniquely identifies a replica instance. If a range is removed from
+  // a store and then re-added to the same store, the new instance will have a
+  // higher ReplicaID.
+  optional int32 replica_id = 3 [(gogoproto.nullable) = false,
+      (gogoproto.customname) = "ReplicaID", (gogoproto.casttype) = "ReplicaID"];
 }
 
 // RangeDescriptor is the value stored in a range metadata key.
@@ -60,9 +65,14 @@ message RangeDescriptor {
   // contained in this range - it will be contained in the immediately
   // subsequent range.
   optional bytes end_key = 3 [(gogoproto.casttype) = "Key"];
-  // Replicas is the set of replicas on which this range is stored, the
-  // ordering being arbitrary and subject to permutation.
+  // Replicas is the set of nodes/stores on which replicas of this
+  // range are stored, the ordering being arbitrary and subject to
+  // permutation.
   repeated Replica replicas = 4 [(gogoproto.nullable) = false];
+
+  // NextReplicaID is a counter used to generate replica IDs.
+  optional int32 next_replica_id = 5 [(gogoproto.nullable) = false,
+      (gogoproto.customname) = "NextReplicaID", (gogoproto.casttype) = "ReplicaID"];
 }
 
 // TODO(bram): this comment has rotted, there is no size.

--- a/storage/client_raft_test.go
+++ b/storage/client_raft_test.go
@@ -663,6 +663,16 @@ func TestReplicateAddAndRemove(t *testing.T) {
 
 		// The removed store no longer has any of the data from the range.
 		verify([]int64{39, 0, 39, 39})
+
+		desc := mtc.stores[0].LookupReplica(proto.KeyMin, nil).Desc()
+		replicaIDsByStore := map[proto.StoreID]proto.ReplicaID{}
+		for _, rep := range desc.Replicas {
+			replicaIDsByStore[rep.StoreID] = rep.ReplicaID
+		}
+		expected := map[proto.StoreID]proto.ReplicaID{1: 1, 4: 2, 3: 4}
+		if !reflect.DeepEqual(expected, replicaIDsByStore) {
+			t.Fatalf("expected replica IDs to be %v but got %v", expected, replicaIDsByStore)
+		}
 	}
 }
 

--- a/storage/engine/rocksdb/cockroach/proto/data.pb.cc
+++ b/storage/engine/rocksdb/cockroach/proto/data.pb.cc
@@ -192,12 +192,13 @@ void protobuf_AssignDesc_cockroach_2fproto_2fdata_2eproto() {
       GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(MergeTrigger, _internal_metadata_),
       -1);
   ChangeReplicasTrigger_descriptor_ = file->message_type(7);
-  static const int ChangeReplicasTrigger_offsets_[5] = {
+  static const int ChangeReplicasTrigger_offsets_[6] = {
     GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(ChangeReplicasTrigger, node_id_),
     GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(ChangeReplicasTrigger, store_id_),
     GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(ChangeReplicasTrigger, change_type_),
     GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(ChangeReplicasTrigger, replica_),
     GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(ChangeReplicasTrigger, updated_replicas_),
+    GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(ChangeReplicasTrigger, next_replica_id_),
   };
   ChangeReplicasTrigger_reflection_ =
     ::google::protobuf::internal::GeneratedMessageReflection::NewGeneratedMessageReflection(
@@ -426,48 +427,49 @@ void protobuf_AddDesc_cockroach_2fproto_2fdata_2eproto() {
     "B\004\310\336\037\000\"\213\001\n\014MergeTrigger\022<\n\014updated_desc\030"
     "\001 \001(\0132 .cockroach.proto.RangeDescriptorB"
     "\004\310\336\037\000\022=\n\021subsumed_range_id\030\002 \001(\003B\"\310\336\037\000\342\336"
-    "\037\017SubsumedRangeID\372\336\037\007RangeID\"\232\002\n\025ChangeR"
+    "\037\017SubsumedRangeID\372\336\037\007RangeID\"\327\002\n\025ChangeR"
     "eplicasTrigger\022)\n\007node_id\030\001 \001(\005B\030\310\336\037\000\342\336\037"
     "\006NodeID\372\336\037\006NodeID\022,\n\010store_id\030\002 \001(\005B\032\310\336\037"
     "\000\342\336\037\007StoreID\372\336\037\007StoreID\022=\n\013change_type\030\003"
     " \001(\0162\".cockroach.proto.ReplicaChangeType"
     "B\004\310\336\037\000\022/\n\007replica\030\004 \001(\0132\030.cockroach.prot"
     "o.ReplicaB\004\310\336\037\000\0228\n\020updated_replicas\030\005 \003("
-    "\0132\030.cockroach.proto.ReplicaB\004\310\336\037\000\"\314\001\n\025In"
-    "ternalCommitTrigger\0224\n\rsplit_trigger\030\001 \001"
-    "(\0132\035.cockroach.proto.SplitTrigger\0224\n\rmer"
-    "ge_trigger\030\002 \001(\0132\035.cockroach.proto.Merge"
-    "Trigger\022G\n\027change_replicas_trigger\030\003 \001(\013"
-    "2&.cockroach.proto.ChangeReplicasTrigger"
-    "\"\035\n\010NodeList\022\021\n\005nodes\030\001 \003(\005B\002\020\001\"\234\004\n\013Tran"
-    "saction\022\022\n\004name\030\001 \001(\tB\004\310\336\037\000\022\024\n\003key\030\002 \001(\014"
-    "B\007\372\336\037\003Key\022\022\n\002id\030\003 \001(\014B\006\342\336\037\002ID\022\026\n\010priorit"
-    "y\030\004 \001(\005B\004\310\336\037\000\0227\n\tisolation\030\005 \001(\0162\036.cockr"
-    "oach.proto.IsolationTypeB\004\310\336\037\000\0228\n\006status"
-    "\030\006 \001(\0162\".cockroach.proto.TransactionStat"
-    "usB\004\310\336\037\000\022\023\n\005epoch\030\007 \001(\005B\004\310\336\037\000\0222\n\016last_he"
-    "artbeat\030\010 \001(\0132\032.cockroach.proto.Timestam"
-    "p\0223\n\ttimestamp\030\t \001(\0132\032.cockroach.proto.T"
-    "imestampB\004\310\336\037\000\0228\n\016orig_timestamp\030\n \001(\0132\032"
-    ".cockroach.proto.TimestampB\004\310\336\037\000\0227\n\rmax_"
-    "timestamp\030\013 \001(\0132\032.cockroach.proto.Timest"
-    "ampB\004\310\336\037\000\0226\n\rcertain_nodes\030\014 \001(\0132\031.cockr"
-    "oach.proto.NodeListB\004\310\336\037\000\022\025\n\007Writing\030\r \001"
-    "(\010B\004\310\336\037\000:\004\230\240\037\000\"\254\001\n\005Lease\022/\n\005start\030\001 \001(\0132"
-    "\032.cockroach.proto.TimestampB\004\310\336\037\000\0224\n\nexp"
-    "iration\030\002 \001(\0132\032.cockroach.proto.Timestam"
-    "pB\004\310\336\037\000\0226\n\014raft_node_id\030\003 \001(\004B \310\336\037\000\342\336\037\nR"
-    "aftNodeID\372\336\037\nRaftNodeID:\004\230\240\037\000\"i\n\006Intent\022"
-    "\024\n\003key\030\001 \001(\014B\007\372\336\037\003Key\022\030\n\007end_key\030\002 \001(\014B\007"
-    "\372\336\037\003Key\022/\n\003txn\030\003 \001(\0132\034.cockroach.proto.T"
-    "ransactionB\004\310\336\037\000\"H\n\nGCMetadata\022\035\n\017last_s"
-    "can_nanos\030\001 \001(\003B\004\310\336\037\000\022\033\n\023oldest_intent_n"
-    "anos\030\002 \001(\003*>\n\021ReplicaChangeType\022\017\n\013ADD_R"
-    "EPLICA\020\000\022\022\n\016REMOVE_REPLICA\020\001\032\004\210\243\036\000*5\n\rIs"
-    "olationType\022\020\n\014SERIALIZABLE\020\000\022\014\n\010SNAPSHO"
-    "T\020\001\032\004\210\243\036\000*B\n\021TransactionStatus\022\013\n\007PENDIN"
-    "G\020\000\022\r\n\tCOMMITTED\020\001\022\013\n\007ABORTED\020\002\032\004\210\243\036\000B\023Z"
-    "\005proto\340\342\036\001\310\342\036\001\320\342\036\001", 2458);
+    "\0132\030.cockroach.proto.ReplicaB\004\310\336\037\000\022;\n\017nex"
+    "t_replica_id\030\006 \001(\005B\"\310\336\037\000\342\336\037\rNextReplicaI"
+    "D\372\336\037\tReplicaID\"\314\001\n\025InternalCommitTrigger"
+    "\0224\n\rsplit_trigger\030\001 \001(\0132\035.cockroach.prot"
+    "o.SplitTrigger\0224\n\rmerge_trigger\030\002 \001(\0132\035."
+    "cockroach.proto.MergeTrigger\022G\n\027change_r"
+    "eplicas_trigger\030\003 \001(\0132&.cockroach.proto."
+    "ChangeReplicasTrigger\"\035\n\010NodeList\022\021\n\005nod"
+    "es\030\001 \003(\005B\002\020\001\"\234\004\n\013Transaction\022\022\n\004name\030\001 \001"
+    "(\tB\004\310\336\037\000\022\024\n\003key\030\002 \001(\014B\007\372\336\037\003Key\022\022\n\002id\030\003 \001"
+    "(\014B\006\342\336\037\002ID\022\026\n\010priority\030\004 \001(\005B\004\310\336\037\000\0227\n\tis"
+    "olation\030\005 \001(\0162\036.cockroach.proto.Isolatio"
+    "nTypeB\004\310\336\037\000\0228\n\006status\030\006 \001(\0162\".cockroach."
+    "proto.TransactionStatusB\004\310\336\037\000\022\023\n\005epoch\030\007"
+    " \001(\005B\004\310\336\037\000\0222\n\016last_heartbeat\030\010 \001(\0132\032.coc"
+    "kroach.proto.Timestamp\0223\n\ttimestamp\030\t \001("
+    "\0132\032.cockroach.proto.TimestampB\004\310\336\037\000\0228\n\016o"
+    "rig_timestamp\030\n \001(\0132\032.cockroach.proto.Ti"
+    "mestampB\004\310\336\037\000\0227\n\rmax_timestamp\030\013 \001(\0132\032.c"
+    "ockroach.proto.TimestampB\004\310\336\037\000\0226\n\rcertai"
+    "n_nodes\030\014 \001(\0132\031.cockroach.proto.NodeList"
+    "B\004\310\336\037\000\022\025\n\007Writing\030\r \001(\010B\004\310\336\037\000:\004\230\240\037\000\"\254\001\n\005"
+    "Lease\022/\n\005start\030\001 \001(\0132\032.cockroach.proto.T"
+    "imestampB\004\310\336\037\000\0224\n\nexpiration\030\002 \001(\0132\032.coc"
+    "kroach.proto.TimestampB\004\310\336\037\000\0226\n\014raft_nod"
+    "e_id\030\003 \001(\004B \310\336\037\000\342\336\037\nRaftNodeID\372\336\037\nRaftNo"
+    "deID:\004\230\240\037\000\"i\n\006Intent\022\024\n\003key\030\001 \001(\014B\007\372\336\037\003K"
+    "ey\022\030\n\007end_key\030\002 \001(\014B\007\372\336\037\003Key\022/\n\003txn\030\003 \001("
+    "\0132\034.cockroach.proto.TransactionB\004\310\336\037\000\"H\n"
+    "\nGCMetadata\022\035\n\017last_scan_nanos\030\001 \001(\003B\004\310\336"
+    "\037\000\022\033\n\023oldest_intent_nanos\030\002 \001(\003*>\n\021Repli"
+    "caChangeType\022\017\n\013ADD_REPLICA\020\000\022\022\n\016REMOVE_"
+    "REPLICA\020\001\032\004\210\243\036\000*5\n\rIsolationType\022\020\n\014SERI"
+    "ALIZABLE\020\000\022\014\n\010SNAPSHOT\020\001\032\004\210\243\036\000*B\n\021Transa"
+    "ctionStatus\022\013\n\007PENDING\020\000\022\r\n\tCOMMITTED\020\001\022"
+    "\013\n\007ABORTED\020\002\032\004\210\243\036\000B\023Z\005proto\340\342\036\001\310\342\036\001\320\342\036\001", 2519);
   ::google::protobuf::MessageFactory::InternalRegisterGeneratedFile(
     "cockroach/proto/data.proto", &protobuf_RegisterTypes);
   Timestamp::default_instance_ = new Timestamp();
@@ -3410,6 +3412,7 @@ const int ChangeReplicasTrigger::kStoreIdFieldNumber;
 const int ChangeReplicasTrigger::kChangeTypeFieldNumber;
 const int ChangeReplicasTrigger::kReplicaFieldNumber;
 const int ChangeReplicasTrigger::kUpdatedReplicasFieldNumber;
+const int ChangeReplicasTrigger::kNextReplicaIdFieldNumber;
 #endif  // !_MSC_VER
 
 ChangeReplicasTrigger::ChangeReplicasTrigger()
@@ -3436,6 +3439,7 @@ void ChangeReplicasTrigger::SharedCtor() {
   store_id_ = 0;
   change_type_ = 0;
   replica_ = NULL;
+  next_replica_id_ = 0;
   ::memset(_has_bits_, 0, sizeof(_has_bits_));
 }
 
@@ -3484,9 +3488,9 @@ void ChangeReplicasTrigger::Clear() {
            ZR_HELPER_(last) - ZR_HELPER_(first) + sizeof(last));\
 } while (0)
 
-  if (_has_bits_[0 / 32] & 15u) {
+  if (_has_bits_[0 / 32] & 47u) {
     ZR_(node_id_, store_id_);
-    change_type_ = 0;
+    ZR_(change_type_, next_replica_id_);
     if (has_replica()) {
       if (replica_ != NULL) replica_->::cockroach::proto::Replica::Clear();
     }
@@ -3587,6 +3591,21 @@ bool ChangeReplicasTrigger::MergePartialFromCodedStream(
         }
         if (input->ExpectTag(42)) goto parse_loop_updated_replicas;
         input->UnsafeDecrementRecursionDepth();
+        if (input->ExpectTag(48)) goto parse_next_replica_id;
+        break;
+      }
+
+      // optional int32 next_replica_id = 6;
+      case 6: {
+        if (tag == 48) {
+         parse_next_replica_id:
+          DO_((::google::protobuf::internal::WireFormatLite::ReadPrimitive<
+                   ::google::protobuf::int32, ::google::protobuf::internal::WireFormatLite::TYPE_INT32>(
+                 input, &next_replica_id_)));
+          set_has_next_replica_id();
+        } else {
+          goto handle_unusual;
+        }
         if (input->ExpectAtEnd()) goto success;
         break;
       }
@@ -3644,6 +3663,11 @@ void ChangeReplicasTrigger::SerializeWithCachedSizes(
       5, this->updated_replicas(i), output);
   }
 
+  // optional int32 next_replica_id = 6;
+  if (has_next_replica_id()) {
+    ::google::protobuf::internal::WireFormatLite::WriteInt32(6, this->next_replica_id(), output);
+  }
+
   if (_internal_metadata_.have_unknown_fields()) {
     ::google::protobuf::internal::WireFormat::SerializeUnknownFields(
         unknown_fields(), output);
@@ -3684,6 +3708,11 @@ void ChangeReplicasTrigger::SerializeWithCachedSizes(
         5, this->updated_replicas(i), target);
   }
 
+  // optional int32 next_replica_id = 6;
+  if (has_next_replica_id()) {
+    target = ::google::protobuf::internal::WireFormatLite::WriteInt32ToArray(6, this->next_replica_id(), target);
+  }
+
   if (_internal_metadata_.have_unknown_fields()) {
     target = ::google::protobuf::internal::WireFormat::SerializeUnknownFieldsToArray(
         unknown_fields(), target);
@@ -3695,7 +3724,7 @@ void ChangeReplicasTrigger::SerializeWithCachedSizes(
 int ChangeReplicasTrigger::ByteSize() const {
   int total_size = 0;
 
-  if (_has_bits_[0 / 32] & 15) {
+  if (_has_bits_[0 / 32] & 47) {
     // optional int32 node_id = 1;
     if (has_node_id()) {
       total_size += 1 +
@@ -3721,6 +3750,13 @@ int ChangeReplicasTrigger::ByteSize() const {
       total_size += 1 +
         ::google::protobuf::internal::WireFormatLite::MessageSizeNoVirtual(
           *this->replica_);
+    }
+
+    // optional int32 next_replica_id = 6;
+    if (has_next_replica_id()) {
+      total_size += 1 +
+        ::google::protobuf::internal::WireFormatLite::Int32Size(
+          this->next_replica_id());
     }
 
   }
@@ -3771,6 +3807,9 @@ void ChangeReplicasTrigger::MergeFrom(const ChangeReplicasTrigger& from) {
     if (from.has_replica()) {
       mutable_replica()->::cockroach::proto::Replica::MergeFrom(from.replica());
     }
+    if (from.has_next_replica_id()) {
+      set_next_replica_id(from.next_replica_id());
+    }
   }
   if (from._internal_metadata_.have_unknown_fields()) {
     mutable_unknown_fields()->MergeFrom(from.unknown_fields());
@@ -3804,6 +3843,7 @@ void ChangeReplicasTrigger::InternalSwap(ChangeReplicasTrigger* other) {
   std::swap(change_type_, other->change_type_);
   std::swap(replica_, other->replica_);
   updated_replicas_.UnsafeArenaSwap(&other->updated_replicas_);
+  std::swap(next_replica_id_, other->next_replica_id_);
   std::swap(_has_bits_[0], other->_has_bits_[0]);
   _internal_metadata_.Swap(&other->_internal_metadata_);
   std::swap(_cached_size_, other->_cached_size_);
@@ -3964,6 +4004,30 @@ ChangeReplicasTrigger::updated_replicas() const {
 ChangeReplicasTrigger::mutable_updated_replicas() {
   // @@protoc_insertion_point(field_mutable_list:cockroach.proto.ChangeReplicasTrigger.updated_replicas)
   return &updated_replicas_;
+}
+
+// optional int32 next_replica_id = 6;
+bool ChangeReplicasTrigger::has_next_replica_id() const {
+  return (_has_bits_[0] & 0x00000020u) != 0;
+}
+void ChangeReplicasTrigger::set_has_next_replica_id() {
+  _has_bits_[0] |= 0x00000020u;
+}
+void ChangeReplicasTrigger::clear_has_next_replica_id() {
+  _has_bits_[0] &= ~0x00000020u;
+}
+void ChangeReplicasTrigger::clear_next_replica_id() {
+  next_replica_id_ = 0;
+  clear_has_next_replica_id();
+}
+ ::google::protobuf::int32 ChangeReplicasTrigger::next_replica_id() const {
+  // @@protoc_insertion_point(field_get:cockroach.proto.ChangeReplicasTrigger.next_replica_id)
+  return next_replica_id_;
+}
+ void ChangeReplicasTrigger::set_next_replica_id(::google::protobuf::int32 value) {
+  set_has_next_replica_id();
+  next_replica_id_ = value;
+  // @@protoc_insertion_point(field_set:cockroach.proto.ChangeReplicasTrigger.next_replica_id)
 }
 
 #endif  // PROTOBUF_INLINE_NOT_IN_HEADERS

--- a/storage/engine/rocksdb/cockroach/proto/data.pb.h
+++ b/storage/engine/rocksdb/cockroach/proto/data.pb.h
@@ -984,6 +984,13 @@ class ChangeReplicasTrigger : public ::google::protobuf::Message {
   ::google::protobuf::RepeatedPtrField< ::cockroach::proto::Replica >*
       mutable_updated_replicas();
 
+  // optional int32 next_replica_id = 6;
+  bool has_next_replica_id() const;
+  void clear_next_replica_id();
+  static const int kNextReplicaIdFieldNumber = 6;
+  ::google::protobuf::int32 next_replica_id() const;
+  void set_next_replica_id(::google::protobuf::int32 value);
+
   // @@protoc_insertion_point(class_scope:cockroach.proto.ChangeReplicasTrigger)
  private:
   inline void set_has_node_id();
@@ -994,6 +1001,8 @@ class ChangeReplicasTrigger : public ::google::protobuf::Message {
   inline void clear_has_change_type();
   inline void set_has_replica();
   inline void clear_has_replica();
+  inline void set_has_next_replica_id();
+  inline void clear_has_next_replica_id();
 
   ::google::protobuf::internal::InternalMetadataWithArena _internal_metadata_;
   ::google::protobuf::uint32 _has_bits_[1];
@@ -1001,8 +1010,9 @@ class ChangeReplicasTrigger : public ::google::protobuf::Message {
   ::google::protobuf::int32 node_id_;
   ::google::protobuf::int32 store_id_;
   ::cockroach::proto::Replica* replica_;
-  ::google::protobuf::RepeatedPtrField< ::cockroach::proto::Replica > updated_replicas_;
   int change_type_;
+  ::google::protobuf::int32 next_replica_id_;
+  ::google::protobuf::RepeatedPtrField< ::cockroach::proto::Replica > updated_replicas_;
   friend void  protobuf_AddDesc_cockroach_2fproto_2fdata_2eproto();
   friend void protobuf_AssignDesc_cockroach_2fproto_2fdata_2eproto();
   friend void protobuf_ShutdownFile_cockroach_2fproto_2fdata_2eproto();
@@ -2642,6 +2652,30 @@ inline ::google::protobuf::RepeatedPtrField< ::cockroach::proto::Replica >*
 ChangeReplicasTrigger::mutable_updated_replicas() {
   // @@protoc_insertion_point(field_mutable_list:cockroach.proto.ChangeReplicasTrigger.updated_replicas)
   return &updated_replicas_;
+}
+
+// optional int32 next_replica_id = 6;
+inline bool ChangeReplicasTrigger::has_next_replica_id() const {
+  return (_has_bits_[0] & 0x00000020u) != 0;
+}
+inline void ChangeReplicasTrigger::set_has_next_replica_id() {
+  _has_bits_[0] |= 0x00000020u;
+}
+inline void ChangeReplicasTrigger::clear_has_next_replica_id() {
+  _has_bits_[0] &= ~0x00000020u;
+}
+inline void ChangeReplicasTrigger::clear_next_replica_id() {
+  next_replica_id_ = 0;
+  clear_has_next_replica_id();
+}
+inline ::google::protobuf::int32 ChangeReplicasTrigger::next_replica_id() const {
+  // @@protoc_insertion_point(field_get:cockroach.proto.ChangeReplicasTrigger.next_replica_id)
+  return next_replica_id_;
+}
+inline void ChangeReplicasTrigger::set_next_replica_id(::google::protobuf::int32 value) {
+  set_has_next_replica_id();
+  next_replica_id_ = value;
+  // @@protoc_insertion_point(field_set:cockroach.proto.ChangeReplicasTrigger.next_replica_id)
 }
 
 // -------------------------------------------------------------------

--- a/storage/engine/rocksdb/cockroach/proto/metadata.pb.cc
+++ b/storage/engine/rocksdb/cockroach/proto/metadata.pb.cc
@@ -71,9 +71,10 @@ void protobuf_AssignDesc_cockroach_2fproto_2fmetadata_2eproto() {
       GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(Attributes, _internal_metadata_),
       -1);
   Replica_descriptor_ = file->message_type(1);
-  static const int Replica_offsets_[2] = {
+  static const int Replica_offsets_[3] = {
     GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(Replica, node_id_),
     GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(Replica, store_id_),
+    GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(Replica, replica_id_),
   };
   Replica_reflection_ =
     ::google::protobuf::internal::GeneratedMessageReflection::NewGeneratedMessageReflection(
@@ -87,11 +88,12 @@ void protobuf_AssignDesc_cockroach_2fproto_2fmetadata_2eproto() {
       GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(Replica, _internal_metadata_),
       -1);
   RangeDescriptor_descriptor_ = file->message_type(2);
-  static const int RangeDescriptor_offsets_[4] = {
+  static const int RangeDescriptor_offsets_[5] = {
     GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(RangeDescriptor, range_id_),
     GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(RangeDescriptor, start_key_),
     GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(RangeDescriptor, end_key_),
     GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(RangeDescriptor, replicas_),
+    GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(RangeDescriptor, next_replica_id_),
   };
   RangeDescriptor_reflection_ =
     ::google::protobuf::internal::GeneratedMessageReflection::NewGeneratedMessageReflection(
@@ -254,31 +256,34 @@ void protobuf_AddDesc_cockroach_2fproto_2fmetadata_2eproto() {
     "ach.proto\032\024gogoproto/gogo.proto\032$cockroa"
     "ch/util/unresolved_addr.proto\"8\n\nAttribu"
     "tes\022$\n\005attrs\030\001 \003(\tB\025\362\336\037\021yaml:\"attrs,flow"
-    "\":\004\230\240\037\000\"h\n\007Replica\022)\n\007node_id\030\001 \001(\005B\030\310\336\037"
-    "\000\342\336\037\006NodeID\372\336\037\006NodeID\022,\n\010store_id\030\002 \001(\005B"
-    "\032\310\336\037\000\342\336\037\007StoreID\372\336\037\007StoreID:\004\230\240\037\000\"\247\001\n\017Ra"
-    "ngeDescriptor\022,\n\010range_id\030\001 \001(\003B\032\310\336\037\000\342\336\037"
-    "\007RangeID\372\336\037\007RangeID\022\032\n\tstart_key\030\002 \001(\014B\007"
-    "\372\336\037\003Key\022\030\n\007end_key\030\003 \001(\014B\007\372\336\037\003Key\0220\n\010rep"
-    "licas\030\004 \003(\0132\030.cockroach.proto.ReplicaB\004\310"
-    "\336\037\000\"&\n\tRangeTree\022\031\n\010root_key\030\001 \001(\014B\007\372\336\037\003"
-    "Key\"\216\001\n\rRangeTreeNode\022\024\n\003key\030\001 \001(\014B\007\372\336\037\003"
-    "Key\022\023\n\005black\030\002 \001(\010B\004\310\336\037\000\022\033\n\nparent_key\030\003"
-    " \001(\014B\007\372\336\037\003Key\022\031\n\010left_key\030\004 \001(\014B\007\332\336\037\003Key"
-    "\022\032\n\tright_key\030\005 \001(\014B\007\332\336\037\003Key\"Z\n\rStoreCap"
-    "acity\022\026\n\010Capacity\030\001 \001(\003B\004\310\336\037\000\022\027\n\tAvailab"
-    "le\030\002 \001(\003B\004\310\336\037\000\022\030\n\nRangeCount\030\003 \001(\005B\004\310\336\037\000"
-    "\"\244\001\n\016NodeDescriptor\022)\n\007node_id\030\001 \001(\005B\030\310\336"
-    "\037\000\342\336\037\006NodeID\372\336\037\006NodeID\0225\n\007address\030\002 \001(\0132"
-    "\036.cockroach.util.UnresolvedAddrB\004\310\336\037\000\0220\n"
-    "\005attrs\030\003 \001(\0132\033.cockroach.proto.Attribute"
-    "sB\004\310\336\037\000\"\336\001\n\017StoreDescriptor\022,\n\010store_id\030"
-    "\001 \001(\005B\032\310\336\037\000\342\336\037\007StoreID\372\336\037\007StoreID\0220\n\005att"
-    "rs\030\002 \001(\0132\033.cockroach.proto.AttributesB\004\310"
-    "\336\037\000\0223\n\004node\030\003 \001(\0132\037.cockroach.proto.Node"
-    "DescriptorB\004\310\336\037\000\0226\n\010capacity\030\004 \001(\0132\036.coc"
-    "kroach.proto.StoreCapacityB\004\310\336\037\000B\023Z\005prot"
-    "o\340\342\036\001\310\342\036\001\320\342\036\001", 1133);
+    "\":\004\230\240\037\000\"\234\001\n\007Replica\022)\n\007node_id\030\001 \001(\005B\030\310\336"
+    "\037\000\342\336\037\006NodeID\372\336\037\006NodeID\022,\n\010store_id\030\002 \001(\005"
+    "B\032\310\336\037\000\342\336\037\007StoreID\372\336\037\007StoreID\0222\n\nreplica_"
+    "id\030\003 \001(\005B\036\310\336\037\000\342\336\037\tReplicaID\372\336\037\tReplicaID"
+    ":\004\230\240\037\000\"\344\001\n\017RangeDescriptor\022,\n\010range_id\030\001"
+    " \001(\003B\032\310\336\037\000\342\336\037\007RangeID\372\336\037\007RangeID\022\032\n\tstar"
+    "t_key\030\002 \001(\014B\007\372\336\037\003Key\022\030\n\007end_key\030\003 \001(\014B\007\372"
+    "\336\037\003Key\0220\n\010replicas\030\004 \003(\0132\030.cockroach.pro"
+    "to.ReplicaB\004\310\336\037\000\022;\n\017next_replica_id\030\005 \001("
+    "\005B\"\310\336\037\000\342\336\037\rNextReplicaID\372\336\037\tReplicaID\"&\n"
+    "\tRangeTree\022\031\n\010root_key\030\001 \001(\014B\007\372\336\037\003Key\"\216\001"
+    "\n\rRangeTreeNode\022\024\n\003key\030\001 \001(\014B\007\372\336\037\003Key\022\023\n"
+    "\005black\030\002 \001(\010B\004\310\336\037\000\022\033\n\nparent_key\030\003 \001(\014B\007"
+    "\372\336\037\003Key\022\031\n\010left_key\030\004 \001(\014B\007\332\336\037\003Key\022\032\n\tri"
+    "ght_key\030\005 \001(\014B\007\332\336\037\003Key\"Z\n\rStoreCapacity\022"
+    "\026\n\010Capacity\030\001 \001(\003B\004\310\336\037\000\022\027\n\tAvailable\030\002 \001"
+    "(\003B\004\310\336\037\000\022\030\n\nRangeCount\030\003 \001(\005B\004\310\336\037\000\"\244\001\n\016N"
+    "odeDescriptor\022)\n\007node_id\030\001 \001(\005B\030\310\336\037\000\342\336\037\006"
+    "NodeID\372\336\037\006NodeID\0225\n\007address\030\002 \001(\0132\036.cock"
+    "roach.util.UnresolvedAddrB\004\310\336\037\000\0220\n\005attrs"
+    "\030\003 \001(\0132\033.cockroach.proto.AttributesB\004\310\336\037"
+    "\000\"\336\001\n\017StoreDescriptor\022,\n\010store_id\030\001 \001(\005B"
+    "\032\310\336\037\000\342\336\037\007StoreID\372\336\037\007StoreID\0220\n\005attrs\030\002 \001"
+    "(\0132\033.cockroach.proto.AttributesB\004\310\336\037\000\0223\n"
+    "\004node\030\003 \001(\0132\037.cockroach.proto.NodeDescri"
+    "ptorB\004\310\336\037\000\0226\n\010capacity\030\004 \001(\0132\036.cockroach"
+    ".proto.StoreCapacityB\004\310\336\037\000B\023Z\005proto\340\342\036\001\310"
+    "\342\036\001\320\342\036\001", 1247);
   ::google::protobuf::MessageFactory::InternalRegisterGeneratedFile(
     "cockroach/proto/metadata.proto", &protobuf_RegisterTypes);
   Attributes::default_instance_ = new Attributes();
@@ -622,6 +627,7 @@ Attributes::mutable_attrs() {
 #ifndef _MSC_VER
 const int Replica::kNodeIdFieldNumber;
 const int Replica::kStoreIdFieldNumber;
+const int Replica::kReplicaIdFieldNumber;
 #endif  // !_MSC_VER
 
 Replica::Replica()
@@ -645,6 +651,7 @@ void Replica::SharedCtor() {
   _cached_size_ = 0;
   node_id_ = 0;
   store_id_ = 0;
+  replica_id_ = 0;
   ::memset(_has_bits_, 0, sizeof(_has_bits_));
 }
 
@@ -692,7 +699,7 @@ void Replica::Clear() {
            ZR_HELPER_(last) - ZR_HELPER_(first) + sizeof(last));\
 } while (0)
 
-  ZR_(node_id_, store_id_);
+  ZR_(node_id_, replica_id_);
 
 #undef ZR_HELPER_
 #undef ZR_
@@ -738,6 +745,21 @@ bool Replica::MergePartialFromCodedStream(
         } else {
           goto handle_unusual;
         }
+        if (input->ExpectTag(24)) goto parse_replica_id;
+        break;
+      }
+
+      // optional int32 replica_id = 3;
+      case 3: {
+        if (tag == 24) {
+         parse_replica_id:
+          DO_((::google::protobuf::internal::WireFormatLite::ReadPrimitive<
+                   ::google::protobuf::int32, ::google::protobuf::internal::WireFormatLite::TYPE_INT32>(
+                 input, &replica_id_)));
+          set_has_replica_id();
+        } else {
+          goto handle_unusual;
+        }
         if (input->ExpectAtEnd()) goto success;
         break;
       }
@@ -777,6 +799,11 @@ void Replica::SerializeWithCachedSizes(
     ::google::protobuf::internal::WireFormatLite::WriteInt32(2, this->store_id(), output);
   }
 
+  // optional int32 replica_id = 3;
+  if (has_replica_id()) {
+    ::google::protobuf::internal::WireFormatLite::WriteInt32(3, this->replica_id(), output);
+  }
+
   if (_internal_metadata_.have_unknown_fields()) {
     ::google::protobuf::internal::WireFormat::SerializeUnknownFields(
         unknown_fields(), output);
@@ -797,6 +824,11 @@ void Replica::SerializeWithCachedSizes(
     target = ::google::protobuf::internal::WireFormatLite::WriteInt32ToArray(2, this->store_id(), target);
   }
 
+  // optional int32 replica_id = 3;
+  if (has_replica_id()) {
+    target = ::google::protobuf::internal::WireFormatLite::WriteInt32ToArray(3, this->replica_id(), target);
+  }
+
   if (_internal_metadata_.have_unknown_fields()) {
     target = ::google::protobuf::internal::WireFormat::SerializeUnknownFieldsToArray(
         unknown_fields(), target);
@@ -808,7 +840,7 @@ void Replica::SerializeWithCachedSizes(
 int Replica::ByteSize() const {
   int total_size = 0;
 
-  if (_has_bits_[0 / 32] & 3) {
+  if (_has_bits_[0 / 32] & 7) {
     // optional int32 node_id = 1;
     if (has_node_id()) {
       total_size += 1 +
@@ -821,6 +853,13 @@ int Replica::ByteSize() const {
       total_size += 1 +
         ::google::protobuf::internal::WireFormatLite::Int32Size(
           this->store_id());
+    }
+
+    // optional int32 replica_id = 3;
+    if (has_replica_id()) {
+      total_size += 1 +
+        ::google::protobuf::internal::WireFormatLite::Int32Size(
+          this->replica_id());
     }
 
   }
@@ -856,6 +895,9 @@ void Replica::MergeFrom(const Replica& from) {
     if (from.has_store_id()) {
       set_store_id(from.store_id());
     }
+    if (from.has_replica_id()) {
+      set_replica_id(from.replica_id());
+    }
   }
   if (from._internal_metadata_.have_unknown_fields()) {
     mutable_unknown_fields()->MergeFrom(from.unknown_fields());
@@ -886,6 +928,7 @@ void Replica::Swap(Replica* other) {
 void Replica::InternalSwap(Replica* other) {
   std::swap(node_id_, other->node_id_);
   std::swap(store_id_, other->store_id_);
+  std::swap(replica_id_, other->replica_id_);
   std::swap(_has_bits_[0], other->_has_bits_[0]);
   _internal_metadata_.Swap(&other->_internal_metadata_);
   std::swap(_cached_size_, other->_cached_size_);
@@ -950,6 +993,30 @@ void Replica::clear_store_id() {
   // @@protoc_insertion_point(field_set:cockroach.proto.Replica.store_id)
 }
 
+// optional int32 replica_id = 3;
+bool Replica::has_replica_id() const {
+  return (_has_bits_[0] & 0x00000004u) != 0;
+}
+void Replica::set_has_replica_id() {
+  _has_bits_[0] |= 0x00000004u;
+}
+void Replica::clear_has_replica_id() {
+  _has_bits_[0] &= ~0x00000004u;
+}
+void Replica::clear_replica_id() {
+  replica_id_ = 0;
+  clear_has_replica_id();
+}
+ ::google::protobuf::int32 Replica::replica_id() const {
+  // @@protoc_insertion_point(field_get:cockroach.proto.Replica.replica_id)
+  return replica_id_;
+}
+ void Replica::set_replica_id(::google::protobuf::int32 value) {
+  set_has_replica_id();
+  replica_id_ = value;
+  // @@protoc_insertion_point(field_set:cockroach.proto.Replica.replica_id)
+}
+
 #endif  // PROTOBUF_INLINE_NOT_IN_HEADERS
 
 // ===================================================================
@@ -959,6 +1026,7 @@ const int RangeDescriptor::kRangeIdFieldNumber;
 const int RangeDescriptor::kStartKeyFieldNumber;
 const int RangeDescriptor::kEndKeyFieldNumber;
 const int RangeDescriptor::kReplicasFieldNumber;
+const int RangeDescriptor::kNextReplicaIdFieldNumber;
 #endif  // !_MSC_VER
 
 RangeDescriptor::RangeDescriptor()
@@ -984,6 +1052,7 @@ void RangeDescriptor::SharedCtor() {
   range_id_ = GOOGLE_LONGLONG(0);
   start_key_.UnsafeSetDefault(&::google::protobuf::internal::GetEmptyStringAlreadyInited());
   end_key_.UnsafeSetDefault(&::google::protobuf::internal::GetEmptyStringAlreadyInited());
+  next_replica_id_ = 0;
   ::memset(_has_bits_, 0, sizeof(_has_bits_));
 }
 
@@ -1025,7 +1094,7 @@ RangeDescriptor* RangeDescriptor::New(::google::protobuf::Arena* arena) const {
 }
 
 void RangeDescriptor::Clear() {
-  if (_has_bits_[0 / 32] & 7u) {
+  if (_has_bits_[0 / 32] & 23u) {
     range_id_ = GOOGLE_LONGLONG(0);
     if (has_start_key()) {
       start_key_.ClearToEmptyNoArena(&::google::protobuf::internal::GetEmptyStringAlreadyInited());
@@ -1033,6 +1102,7 @@ void RangeDescriptor::Clear() {
     if (has_end_key()) {
       end_key_.ClearToEmptyNoArena(&::google::protobuf::internal::GetEmptyStringAlreadyInited());
     }
+    next_replica_id_ = 0;
   }
   replicas_.Clear();
   ::memset(_has_bits_, 0, sizeof(_has_bits_));
@@ -1104,6 +1174,21 @@ bool RangeDescriptor::MergePartialFromCodedStream(
         }
         if (input->ExpectTag(34)) goto parse_loop_replicas;
         input->UnsafeDecrementRecursionDepth();
+        if (input->ExpectTag(40)) goto parse_next_replica_id;
+        break;
+      }
+
+      // optional int32 next_replica_id = 5;
+      case 5: {
+        if (tag == 40) {
+         parse_next_replica_id:
+          DO_((::google::protobuf::internal::WireFormatLite::ReadPrimitive<
+                   ::google::protobuf::int32, ::google::protobuf::internal::WireFormatLite::TYPE_INT32>(
+                 input, &next_replica_id_)));
+          set_has_next_replica_id();
+        } else {
+          goto handle_unusual;
+        }
         if (input->ExpectAtEnd()) goto success;
         break;
       }
@@ -1156,6 +1241,11 @@ void RangeDescriptor::SerializeWithCachedSizes(
       4, this->replicas(i), output);
   }
 
+  // optional int32 next_replica_id = 5;
+  if (has_next_replica_id()) {
+    ::google::protobuf::internal::WireFormatLite::WriteInt32(5, this->next_replica_id(), output);
+  }
+
   if (_internal_metadata_.have_unknown_fields()) {
     ::google::protobuf::internal::WireFormat::SerializeUnknownFields(
         unknown_fields(), output);
@@ -1192,6 +1282,11 @@ void RangeDescriptor::SerializeWithCachedSizes(
         4, this->replicas(i), target);
   }
 
+  // optional int32 next_replica_id = 5;
+  if (has_next_replica_id()) {
+    target = ::google::protobuf::internal::WireFormatLite::WriteInt32ToArray(5, this->next_replica_id(), target);
+  }
+
   if (_internal_metadata_.have_unknown_fields()) {
     target = ::google::protobuf::internal::WireFormat::SerializeUnknownFieldsToArray(
         unknown_fields(), target);
@@ -1203,7 +1298,7 @@ void RangeDescriptor::SerializeWithCachedSizes(
 int RangeDescriptor::ByteSize() const {
   int total_size = 0;
 
-  if (_has_bits_[0 / 32] & 7) {
+  if (_has_bits_[0 / 32] & 23) {
     // optional int64 range_id = 1;
     if (has_range_id()) {
       total_size += 1 +
@@ -1223,6 +1318,13 @@ int RangeDescriptor::ByteSize() const {
       total_size += 1 +
         ::google::protobuf::internal::WireFormatLite::BytesSize(
           this->end_key());
+    }
+
+    // optional int32 next_replica_id = 5;
+    if (has_next_replica_id()) {
+      total_size += 1 +
+        ::google::protobuf::internal::WireFormatLite::Int32Size(
+          this->next_replica_id());
     }
 
   }
@@ -1272,6 +1374,9 @@ void RangeDescriptor::MergeFrom(const RangeDescriptor& from) {
       set_has_end_key();
       end_key_.AssignWithDefault(&::google::protobuf::internal::GetEmptyStringAlreadyInited(), from.end_key_);
     }
+    if (from.has_next_replica_id()) {
+      set_next_replica_id(from.next_replica_id());
+    }
   }
   if (from._internal_metadata_.have_unknown_fields()) {
     mutable_unknown_fields()->MergeFrom(from.unknown_fields());
@@ -1304,6 +1409,7 @@ void RangeDescriptor::InternalSwap(RangeDescriptor* other) {
   start_key_.Swap(&other->start_key_);
   end_key_.Swap(&other->end_key_);
   replicas_.UnsafeArenaSwap(&other->replicas_);
+  std::swap(next_replica_id_, other->next_replica_id_);
   std::swap(_has_bits_[0], other->_has_bits_[0]);
   _internal_metadata_.Swap(&other->_internal_metadata_);
   std::swap(_cached_size_, other->_cached_size_);
@@ -1478,6 +1584,30 @@ RangeDescriptor::replicas() const {
 RangeDescriptor::mutable_replicas() {
   // @@protoc_insertion_point(field_mutable_list:cockroach.proto.RangeDescriptor.replicas)
   return &replicas_;
+}
+
+// optional int32 next_replica_id = 5;
+bool RangeDescriptor::has_next_replica_id() const {
+  return (_has_bits_[0] & 0x00000010u) != 0;
+}
+void RangeDescriptor::set_has_next_replica_id() {
+  _has_bits_[0] |= 0x00000010u;
+}
+void RangeDescriptor::clear_has_next_replica_id() {
+  _has_bits_[0] &= ~0x00000010u;
+}
+void RangeDescriptor::clear_next_replica_id() {
+  next_replica_id_ = 0;
+  clear_has_next_replica_id();
+}
+ ::google::protobuf::int32 RangeDescriptor::next_replica_id() const {
+  // @@protoc_insertion_point(field_get:cockroach.proto.RangeDescriptor.next_replica_id)
+  return next_replica_id_;
+}
+ void RangeDescriptor::set_next_replica_id(::google::protobuf::int32 value) {
+  set_has_next_replica_id();
+  next_replica_id_ = value;
+  // @@protoc_insertion_point(field_set:cockroach.proto.RangeDescriptor.next_replica_id)
 }
 
 #endif  // PROTOBUF_INLINE_NOT_IN_HEADERS

--- a/storage/engine/rocksdb/cockroach/proto/metadata.pb.h
+++ b/storage/engine/rocksdb/cockroach/proto/metadata.pb.h
@@ -224,18 +224,28 @@ class Replica : public ::google::protobuf::Message {
   ::google::protobuf::int32 store_id() const;
   void set_store_id(::google::protobuf::int32 value);
 
+  // optional int32 replica_id = 3;
+  bool has_replica_id() const;
+  void clear_replica_id();
+  static const int kReplicaIdFieldNumber = 3;
+  ::google::protobuf::int32 replica_id() const;
+  void set_replica_id(::google::protobuf::int32 value);
+
   // @@protoc_insertion_point(class_scope:cockroach.proto.Replica)
  private:
   inline void set_has_node_id();
   inline void clear_has_node_id();
   inline void set_has_store_id();
   inline void clear_has_store_id();
+  inline void set_has_replica_id();
+  inline void clear_has_replica_id();
 
   ::google::protobuf::internal::InternalMetadataWithArena _internal_metadata_;
   ::google::protobuf::uint32 _has_bits_[1];
   mutable int _cached_size_;
   ::google::protobuf::int32 node_id_;
   ::google::protobuf::int32 store_id_;
+  ::google::protobuf::int32 replica_id_;
   friend void  protobuf_AddDesc_cockroach_2fproto_2fmetadata_2eproto();
   friend void protobuf_AssignDesc_cockroach_2fproto_2fmetadata_2eproto();
   friend void protobuf_ShutdownFile_cockroach_2fproto_2fmetadata_2eproto();
@@ -352,6 +362,13 @@ class RangeDescriptor : public ::google::protobuf::Message {
   ::google::protobuf::RepeatedPtrField< ::cockroach::proto::Replica >*
       mutable_replicas();
 
+  // optional int32 next_replica_id = 5;
+  bool has_next_replica_id() const;
+  void clear_next_replica_id();
+  static const int kNextReplicaIdFieldNumber = 5;
+  ::google::protobuf::int32 next_replica_id() const;
+  void set_next_replica_id(::google::protobuf::int32 value);
+
   // @@protoc_insertion_point(class_scope:cockroach.proto.RangeDescriptor)
  private:
   inline void set_has_range_id();
@@ -360,6 +377,8 @@ class RangeDescriptor : public ::google::protobuf::Message {
   inline void clear_has_start_key();
   inline void set_has_end_key();
   inline void clear_has_end_key();
+  inline void set_has_next_replica_id();
+  inline void clear_has_next_replica_id();
 
   ::google::protobuf::internal::InternalMetadataWithArena _internal_metadata_;
   ::google::protobuf::uint32 _has_bits_[1];
@@ -368,6 +387,7 @@ class RangeDescriptor : public ::google::protobuf::Message {
   ::google::protobuf::internal::ArenaStringPtr start_key_;
   ::google::protobuf::internal::ArenaStringPtr end_key_;
   ::google::protobuf::RepeatedPtrField< ::cockroach::proto::Replica > replicas_;
+  ::google::protobuf::int32 next_replica_id_;
   friend void  protobuf_AddDesc_cockroach_2fproto_2fmetadata_2eproto();
   friend void protobuf_AssignDesc_cockroach_2fproto_2fmetadata_2eproto();
   friend void protobuf_ShutdownFile_cockroach_2fproto_2fmetadata_2eproto();
@@ -1079,6 +1099,30 @@ inline void Replica::set_store_id(::google::protobuf::int32 value) {
   // @@protoc_insertion_point(field_set:cockroach.proto.Replica.store_id)
 }
 
+// optional int32 replica_id = 3;
+inline bool Replica::has_replica_id() const {
+  return (_has_bits_[0] & 0x00000004u) != 0;
+}
+inline void Replica::set_has_replica_id() {
+  _has_bits_[0] |= 0x00000004u;
+}
+inline void Replica::clear_has_replica_id() {
+  _has_bits_[0] &= ~0x00000004u;
+}
+inline void Replica::clear_replica_id() {
+  replica_id_ = 0;
+  clear_has_replica_id();
+}
+inline ::google::protobuf::int32 Replica::replica_id() const {
+  // @@protoc_insertion_point(field_get:cockroach.proto.Replica.replica_id)
+  return replica_id_;
+}
+inline void Replica::set_replica_id(::google::protobuf::int32 value) {
+  set_has_replica_id();
+  replica_id_ = value;
+  // @@protoc_insertion_point(field_set:cockroach.proto.Replica.replica_id)
+}
+
 // -------------------------------------------------------------------
 
 // RangeDescriptor
@@ -1241,6 +1285,30 @@ inline ::google::protobuf::RepeatedPtrField< ::cockroach::proto::Replica >*
 RangeDescriptor::mutable_replicas() {
   // @@protoc_insertion_point(field_mutable_list:cockroach.proto.RangeDescriptor.replicas)
   return &replicas_;
+}
+
+// optional int32 next_replica_id = 5;
+inline bool RangeDescriptor::has_next_replica_id() const {
+  return (_has_bits_[0] & 0x00000010u) != 0;
+}
+inline void RangeDescriptor::set_has_next_replica_id() {
+  _has_bits_[0] |= 0x00000010u;
+}
+inline void RangeDescriptor::clear_has_next_replica_id() {
+  _has_bits_[0] &= ~0x00000010u;
+}
+inline void RangeDescriptor::clear_next_replica_id() {
+  next_replica_id_ = 0;
+  clear_has_next_replica_id();
+}
+inline ::google::protobuf::int32 RangeDescriptor::next_replica_id() const {
+  // @@protoc_insertion_point(field_get:cockroach.proto.RangeDescriptor.next_replica_id)
+  return next_replica_id_;
+}
+inline void RangeDescriptor::set_next_replica_id(::google::protobuf::int32 value) {
+  set_has_next_replica_id();
+  next_replica_id_ = value;
+  // @@protoc_insertion_point(field_set:cockroach.proto.RangeDescriptor.next_replica_id)
 }
 
 // -------------------------------------------------------------------


### PR DESCRIPTION
The replica IDs are stored and propagated through replica updates,
but not yet used.
