### PR TITLE
Reduce log spam in tests.

### DIFF
--- a/multiraft/multiraft.go
+++ b/multiraft/multiraft.go
@@ -502,7 +502,9 @@ func (s *state) start() {
 					// TODO(tschottdorf) still shouldn't hurt to move this part outside,
 					// but suddenly tests will start failing. Should investigate.
 					if _, ok := s.groups[req.GroupID]; !ok {
-						log.Infof("node %v: got message for unknown group %d; creating it", s.nodeID, req.GroupID)
+						if log.V(1) {
+							log.Infof("node %v: got message for unknown group %d; creating it", s.nodeID, req.GroupID)
+						}
 						if err := s.createGroup(req.GroupID); err != nil {
 							log.Warningf("Error creating group %d: %s", req.GroupID, err)
 							break

--- a/rpc/server.go
+++ b/rpc/server.go
@@ -345,9 +345,11 @@ func (s *Server) readRequests(codec rpc.ServerCodec, responses chan<- serverResp
 
 	for {
 		req, meth, args, err := s.readRequest(codec)
-		if err == io.EOF || err == io.ErrUnexpectedEOF {
-			return
-		} else if err != nil {
+		if err != nil {
+			if err == io.EOF || err == io.ErrUnexpectedEOF ||
+				strings.HasSuffix(err.Error(), "use of closed network connection") {
+				return
+			}
 			log.Warningf("rpc: server cannot decode request: %s", err)
 			return
 		}

--- a/storage/engine/rocksdb.go
+++ b/storage/engine/rocksdb.go
@@ -95,9 +95,7 @@ func (r *RocksDB) Open() error {
 		return nil
 	}
 
-	if len(r.dir) == 0 {
-		log.Infof("opening in-memory rocksdb instance")
-	} else {
+	if len(r.dir) != 0 {
 		log.Infof("opening rocksdb instance at %q", r.dir)
 	}
 	status := C.DBOpen(&r.rdb, goToCSlice([]byte(r.dir)),

--- a/storage/replica.go
+++ b/storage/replica.go
@@ -978,8 +978,10 @@ func (r *Replica) maybeGossipFirstRange() error {
 	ctx := r.context()
 
 	// Gossip the cluster ID from all replicas of the first range.
-	log.Infoc(ctx, "gossiping cluster id %s from store %d, range %d", r.rm.ClusterID(),
-		r.rm.StoreID(), r.Desc().RangeID)
+	if log.V(1) {
+		log.Infoc(ctx, "gossiping cluster id %s from store %d, range %d", r.rm.ClusterID(),
+			r.rm.StoreID(), r.Desc().RangeID)
+	}
 	if err := r.rm.Gossip().AddInfo(gossip.KeyClusterID, r.rm.ClusterID(), clusterIDGossipTTL); err != nil {
 		log.Errorc(ctx, "failed to gossip cluster ID: %s", err)
 	}
@@ -987,11 +989,15 @@ func (r *Replica) maybeGossipFirstRange() error {
 	if ok, err := r.getLeaseForGossip(ctx); !ok || err != nil {
 		return err
 	}
-	log.Infoc(ctx, "gossiping sentinel from store %d, range %d", r.rm.StoreID(), r.Desc().RangeID)
+	if log.V(1) {
+		log.Infoc(ctx, "gossiping sentinel from store %d, range %d", r.rm.StoreID(), r.Desc().RangeID)
+	}
 	if err := r.rm.Gossip().AddInfo(gossip.KeySentinel, r.rm.ClusterID(), clusterIDGossipTTL); err != nil {
 		log.Errorc(ctx, "failed to gossip cluster ID: %s", err)
 	}
-	log.Infoc(ctx, "gossiping first range from store %d, range %d", r.rm.StoreID(), r.Desc().RangeID)
+	if log.V(1) {
+		log.Infoc(ctx, "gossiping first range from store %d, range %d", r.rm.StoreID(), r.Desc().RangeID)
+	}
 	if err := r.rm.Gossip().AddInfo(gossip.KeyFirstRangeDescriptor, *r.Desc(), configGossipTTL); err != nil {
 		log.Errorc(ctx, "failed to gossip first range metadata: %s", err)
 	}
@@ -1046,7 +1052,9 @@ func (r *Replica) maybeGossipConfigsLocked(match func(configPrefix proto.Key) bo
 			}
 			if prevHash, ok := r.configHashes[i]; !ok || !bytes.Equal(prevHash, hash) {
 				r.configHashes[i] = hash
-				log.Infoc(ctx, "gossiping %s config from store %d, range %d", cd.gossipKey, r.rm.StoreID(), r.Desc().RangeID)
+				if log.V(1) {
+					log.Infoc(ctx, "gossiping %s config from store %d, range %d", cd.gossipKey, r.rm.StoreID(), r.Desc().RangeID)
+				}
 				if err := r.rm.Gossip().AddInfo(cd.gossipKey, configMap, 0); err != nil {
 					log.Errorc(ctx, "failed to gossip %s configMap: %s", cd.gossipKey, err)
 				}


### PR DESCRIPTION
Downgrade some logs to V(1) and remove some unhelpful lines entirely.

`go test -v ./storage` now logs 922 lines, down from 2372.
