### PR TITLE
add drop database.

### DIFF
--- a/sql/drop_test.go
+++ b/sql/drop_test.go
@@ -96,3 +96,91 @@ func TestDropTable(t *testing.T) {
 		t.Fatalf("table namekey still exists after the table is dropped")
 	}
 }
+
+func TestDropDatabase(t *testing.T) {
+	defer leaktest.AfterTest(t)
+	s, sqlDB, kvDB := setup(t)
+	defer cleanup(s, sqlDB)
+
+	if _, err := sqlDB.Exec(`
+CREATE DATABASE t;
+CREATE TABLE t.kv (k CHAR PRIMARY KEY, v CHAR);
+INSERT INTO t.kv VALUES ('c', 'e'), ('a', 'c'),('b', 'd')
+`); err != nil {
+		t.Fatal(err)
+	}
+
+	dbNameKey := structured.MakeNameMetadataKey(structured.RootNamespaceID, "t")
+	r, err := kvDB.Get(dbNameKey)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !r.Exists() {
+		t.Fatalf(`database "t" does not exist`)
+	}
+	dbDescKey := r.ValueBytes()
+	dbDesc := structured.DatabaseDescriptor{}
+	if err := kvDB.GetProto(dbDescKey, &dbDesc); err != nil {
+		t.Fatal(err)
+	}
+
+	tbNameKey := structured.MakeNameMetadataKey(dbDesc.ID, "kv")
+	gr, err := kvDB.Get(tbNameKey)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !gr.Exists() {
+		t.Fatalf(`table "kv" does not exist`)
+	}
+	tbDescKey := gr.ValueBytes()
+	tbDesc := structured.TableDescriptor{}
+	if err := kvDB.GetProto(tbDescKey, &tbDesc); err != nil {
+		t.Fatal(err)
+	}
+
+	var tablePrefix []byte
+	tablePrefix = append(tablePrefix, keys.TableDataPrefix...)
+	tablePrefix = encoding.EncodeUvarint(tablePrefix, uint64(tbDesc.ID))
+
+	tableStartKey := proto.Key(tablePrefix)
+	tableEndKey := tableStartKey.PrefixEnd()
+	if kvs, err := kvDB.Scan(tableStartKey, tableEndKey, 0); err != nil {
+		t.Fatal(err)
+	} else if l := 6; len(kvs) != l {
+		t.Fatalf("expected %d key value pairs, but got %d", l, len(kvs))
+	}
+
+	if _, err := sqlDB.Exec("DROP DATABASE t"); err != nil {
+		t.Fatal(err)
+	}
+
+	if kvs, err := kvDB.Scan(tableStartKey, tableEndKey, 0); err != nil {
+		t.Fatal(err)
+	} else if l := 0; len(kvs) != l {
+		t.Fatalf("expected %d key value pairs, but got %d", l, len(kvs))
+	}
+
+	if gr, err := kvDB.Get(tbDescKey); err != nil {
+		t.Fatal(err)
+	} else if gr.Exists() {
+		t.Fatalf("table descriptor still exists after database is dropped")
+	}
+
+	if gr, err := kvDB.Get(tbNameKey); err != nil {
+		t.Fatal(err)
+	} else if gr.Exists() {
+		t.Fatalf("table descriptor key still exists after database is dropped")
+	}
+
+	if gr, err := kvDB.Get(dbDescKey); err != nil {
+		t.Fatal(err)
+	} else if gr.Exists() {
+		t.Fatalf("database descriptor still exists after database is dropped")
+	}
+
+	if gr, err := kvDB.Get(dbNameKey); err != nil {
+		t.Fatal(err)
+	} else if gr.Exists() {
+		t.Fatalf("database descriptor key still exists after database is dropped")
+	}
+}

--- a/sql/plan.go
+++ b/sql/plan.go
@@ -52,6 +52,8 @@ func (p *planner) makePlan(stmt parser.Statement) (planNode, error) {
 		return p.CreateTable(n)
 	case *parser.Delete:
 		return p.Delete(n)
+	case *parser.DropDatabase:
+		return p.DropDatabase(n)
 	case *parser.DropTable:
 		return p.DropTable(n)
 	case *parser.Grant:

--- a/sql/show.go
+++ b/sql/show.go
@@ -155,15 +155,14 @@ func (p *planner) ShowTables(n *parser.ShowTables) (planNode, error) {
 		return nil, err
 	}
 
-	prefix := structured.MakeNameMetadataKey(dbDesc.ID, "")
-	sr, err := p.db.Scan(prefix, prefix.PrefixEnd(), 0)
+	tableNames, err := p.getTableNames(dbDesc)
 	if err != nil {
 		return nil, err
 	}
 	v := &valuesNode{columns: []string{"Table"}}
-	for _, row := range sr {
-		name := string(bytes.TrimPrefix(row.Key, prefix))
-		v.rows = append(v.rows, []parser.Datum{parser.DString(name)})
+	for _, name := range tableNames {
+		v.rows = append(v.rows, []parser.Datum{parser.DString(name.Table())})
 	}
+
 	return v, nil
 }

--- a/sql/testdata/database
+++ b/sql/testdata/database
@@ -30,3 +30,52 @@ a
 b
 c
 test
+
+statement ok
+CREATE TABLE b.a (id INT PRIMARY KEY)
+
+statement ok
+INSERT INTO b.a VALUES (3),(7),(2)
+
+query I
+SELECT * FROM b.a
+----
+2
+3
+7
+
+statement ok
+DROP DATABASE b
+
+statement error database "b" does not exist
+SELECT * FROM b.a
+
+statement error database "b" does not exist
+DROP DATABASE b
+
+statement ok
+DROP DATABASE IF EXISTS b
+
+statement error empty database name
+DROP DATABASE ""
+
+query T colnames
+SHOW DATABASES
+----
+Database
+a
+c
+test
+
+statement ok
+CREATE DATABASE b
+
+statement error table "a" does not exist
+SELECT * FROM b.a
+
+statement ok
+CREATE TABLE b.a (id INT PRIMARY KEY)
+
+query I
+SELECT * FROM b.a
+----

--- a/sql/testdata/privileges_database
+++ b/sql/testdata/privileges_database
@@ -4,6 +4,12 @@ statement ok
 CREATE DATABASE a
 
 statement ok
+DROP DATABASE a
+
+statement ok
+CREATE DATABASE a
+
+statement ok
 SHOW DATABASES
 
 statement ok
@@ -29,6 +35,9 @@ user testuser
 
 statement error only root is allowed to create databases
 CREATE DATABASE b
+
+statement error user testuser does not have WRITE privilege on database a
+DROP DATABASE a
 
 statement ok
 SHOW DATABASES
@@ -61,6 +70,9 @@ user testuser
 
 statement error only root is allowed to create databases
 CREATE DATABASE b
+
+statement error user testuser does not have WRITE privilege on database a
+DROP DATABASE a
 
 statement ok
 SHOW DATABASES
@@ -117,3 +129,16 @@ GRANT ALL ON DATABASE a TO bar
 
 statement ok
 REVOKE ALL ON DATABASE a FROM bar
+
+statement error user testuser does not have WRITE privilege on table a.t
+DROP DATABASE a
+
+user root
+
+statement ok
+GRANT WRITE ON TABLE a.t TO testuser
+
+user testuser
+
+statement ok
+DROP DATABASE a


### PR DESCRIPTION
fixes #1895.
In postgres, drop database can  only be executed when no one is connected to the target database. 
We should figure out how to do something similar later, or there would be problems if some other user is concurrently adding a table to the database when the database is being dropped.
