### PR TITLE
Revert "Keys for the table data"

### DIFF
--- a/keys/constants.go
+++ b/keys/constants.go
@@ -164,8 +164,6 @@ var (
 	NodeIDGenerator = MakeKey(SystemPrefix, proto.Key("node-idgen"))
 	// RangeIDGenerator is the global range ID generator sequence.
 	RangeIDGenerator = MakeKey(SystemPrefix, proto.Key("range-idgen"))
-	// SchemaPrefix specifies key prefixes for schema definitions.
-	SchemaPrefix = MakeKey(SystemPrefix, proto.Key("schema"))
 	// NameMetadataPrefix is the key prefix for all name metadata.
 	NameMetadataPrefix = MakeKey(SystemPrefix, proto.Key("name-"))
 	// StoreIDGenerator is the global store ID generator sequence.

--- a/sql/delete.go
+++ b/sql/delete.go
@@ -70,7 +70,7 @@ func (p *planner) Delete(n *parser.Delete) (planNode, error) {
 	}
 
 	primaryIndex := tableDesc.PrimaryIndex
-	primaryIndexKeyPrefix := encodeIndexKeyPrefix(tableDesc.ID, primaryIndex.ID)
+	primaryIndexKeyPrefix := structured.MakeIndexKeyPrefix(tableDesc.ID, primaryIndex.ID)
 
 	b := client.Batch{}
 

--- a/sql/insert.go
+++ b/sql/insert.go
@@ -71,7 +71,7 @@ func (p *planner) Insert(n *parser.Insert) (planNode, error) {
 	}
 
 	primaryIndex := tableDesc.PrimaryIndex
-	primaryIndexKeyPrefix := encodeIndexKeyPrefix(tableDesc.ID, primaryIndex.ID)
+	primaryIndexKeyPrefix := structured.MakeIndexKeyPrefix(tableDesc.ID, primaryIndex.ID)
 
 	b := client.Batch{}
 
@@ -102,7 +102,7 @@ func (p *planner) Insert(n *parser.Insert) (planNode, error) {
 
 		// Write the row.
 		for i, val := range values {
-			key := encodeColumnKey(cols[i], primaryIndexKey)
+			key := structured.MakeColumnKey(cols[i].ID, primaryIndexKey)
 			if log.V(2) {
 				log.Infof("CPut %q -> %v", key, val)
 			}

--- a/sql/scan.go
+++ b/sql/scan.go
@@ -67,7 +67,7 @@ func (n *scanNode) Next() bool {
 			n.primaryKey = []byte{}
 		} else {
 			// Retrieve all of the keys that start with our index key prefix.
-			startKey := proto.Key(encodeIndexKeyPrefix(n.desc.ID, n.desc.PrimaryIndex.ID))
+			startKey := proto.Key(structured.MakeIndexKeyPrefix(n.desc.ID, n.desc.PrimaryIndex.ID))
 			endKey := startKey.PrefixEnd()
 			// TODO(pmattis): Currently we retrieve all of the key/value pairs for
 			// the table. We could enhance this code so that it retrieves the

--- a/sql/table.go
+++ b/sql/table.go
@@ -153,21 +153,6 @@ func (p *planner) getTableNames(dbDesc *structured.DatabaseDescriptor) (parser.Q
 	return qualifiedNames, nil
 }
 
-func encodeTablePrefix(tableID structured.ID) []byte {
-	var key []byte
-	key = append(key, keys.TableDataPrefix...)
-	key = encoding.EncodeUvarint(key, uint64(tableID))
-	return key
-}
-
-func encodeIndexKeyPrefix(tableID, indexID structured.ID) []byte {
-	var key []byte
-	key = append(key, keys.TableDataPrefix...)
-	key = encoding.EncodeUvarint(key, uint64(tableID))
-	key = encoding.EncodeUvarint(key, uint64(indexID))
-	return key
-}
-
 func encodeIndexKey(columnIDs []structured.ID, colMap map[structured.ID]int, values []parser.Datum, indexKey []byte) ([]byte, bool, error) {
 	var key []byte
 	var containsNull bool
@@ -193,12 +178,6 @@ func encodeIndexKey(columnIDs []structured.ID, colMap map[structured.ID]int, val
 		}
 	}
 	return key, containsNull, nil
-}
-
-func encodeColumnKey(col structured.ColumnDescriptor, primaryKey []byte) []byte {
-	var key []byte
-	key = append(key, primaryKey...)
-	return encoding.EncodeUvarint(key, uint64(col.ID))
 }
 
 func encodeTableKey(b []byte, val parser.Datum) ([]byte, error) {
@@ -278,7 +257,7 @@ func encodeSecondaryIndexes(tableID structured.ID, indexes []structured.IndexDes
 	colMap map[structured.ID]int, values []parser.Datum, primaryIndexKeySuffix []byte) ([]indexEntry, error) {
 	var secondaryIndexEntries []indexEntry
 	for _, secondaryIndex := range indexes {
-		secondaryIndexKeyPrefix := encodeIndexKeyPrefix(tableID, secondaryIndex.ID)
+		secondaryIndexKeyPrefix := structured.MakeIndexKeyPrefix(tableID, secondaryIndex.ID)
 		secondaryIndexKey, containsNull, err := encodeIndexKey(secondaryIndex.ColumnIDs, colMap, values, secondaryIndexKeyPrefix)
 		if err != nil {
 			return nil, err

--- a/sql/truncate.go
+++ b/sql/truncate.go
@@ -23,6 +23,7 @@ import (
 	"github.com/cockroachdb/cockroach/client"
 	"github.com/cockroachdb/cockroach/proto"
 	"github.com/cockroachdb/cockroach/sql/parser"
+	"github.com/cockroachdb/cockroach/structured"
 	"github.com/cockroachdb/cockroach/util/log"
 )
 
@@ -44,7 +45,7 @@ func (p *planner) Truncate(n *parser.Truncate) (planNode, error) {
 				p.user, parser.PrivilegeWrite, tableDesc.Name)
 		}
 
-		tablePrefix := encodeTablePrefix(tableDesc.ID)
+		tablePrefix := structured.MakeTablePrefix(tableDesc.ID)
 
 		// Delete rows and indexes starting with the table's prefix.
 		tableStartKey := proto.Key(tablePrefix)

--- a/sql/update.go
+++ b/sql/update.go
@@ -90,7 +90,7 @@ func (p *planner) Update(n *parser.Update) (planNode, error) {
 	}
 
 	primaryIndex := tableDesc.PrimaryIndex
-	primaryIndexKeyPrefix := encodeIndexKeyPrefix(tableDesc.ID, primaryIndex.ID)
+	primaryIndexKeyPrefix := structured.MakeIndexKeyPrefix(tableDesc.ID, primaryIndex.ID)
 
 	// Evaluate all the column value expressions.
 	vals := make([]parser.Datum, 0, 10)
@@ -157,7 +157,7 @@ func (p *planner) Update(n *parser.Update) (planNode, error) {
 
 		// add the new values
 		for i, val := range vals {
-			key := encodeColumnKey(cols[i], primaryIndexKey)
+			key := structured.MakeColumnKey(cols[i].ID, primaryIndexKey)
 			if log.V(2) {
 				log.Infof("Put %q -> %v", key, val)
 			}

--- a/structured/keys.go
+++ b/structured/keys.go
@@ -25,7 +25,7 @@ import (
 	"github.com/cockroachdb/cockroach/util/encoding"
 )
 
-// MakeNameMetadataKey returns the key for the namespace.
+// MakeNameMetadataKey returns the key for the name.
 func MakeNameMetadataKey(parentID ID, name string) proto.Key {
 	name = strings.ToLower(name)
 	k := make([]byte, 0, len(keys.NameMetadataPrefix)+encoding.MaxUvarintSize+len(name))
@@ -35,10 +35,34 @@ func MakeNameMetadataKey(parentID ID, name string) proto.Key {
 	return k
 }
 
-// MakeDescMetadataKey returns the key for the table in namespaceID.
+// MakeDescMetadataKey returns the key for the descriptor.
 func MakeDescMetadataKey(descID ID) proto.Key {
 	k := make([]byte, 0, len(keys.DescMetadataPrefix)+encoding.MaxUvarintSize)
 	k = append(k, keys.DescMetadataPrefix...)
 	k = encoding.EncodeUvarint(k, uint64(descID))
 	return k
+}
+
+// MakeColumnKey returns the key for the column in the given row.
+func MakeColumnKey(colID ID, primaryKey []byte) proto.Key {
+	var key []byte
+	key = append(key, primaryKey...)
+	return encoding.EncodeUvarint(key, uint64(colID))
+}
+
+// MakeTablePrefix returns the key prefix used for the table's data.
+func MakeTablePrefix(tableID ID) []byte {
+	var key []byte
+	key = append(key, keys.TableDataPrefix...)
+	key = encoding.EncodeUvarint(key, uint64(tableID))
+	return key
+}
+
+// MakeIndexKeyPrefix returns the key prefix used for the index's data.
+func MakeIndexKeyPrefix(tableID, indexID ID) []byte {
+	var key []byte
+	key = append(key, keys.TableDataPrefix...)
+	key = encoding.EncodeUvarint(key, uint64(tableID))
+	key = encoding.EncodeUvarint(key, uint64(indexID))
+	return key
 }


### PR DESCRIPTION
This reverts commit 0ab33c1695c79728aed8d77ecbd16306192d6894.

Looks like this code was never used. Any objections to removing it? @vivekmenezes @petermattis 
