### PR TITLE
Document decodeIndexKey.

### DIFF
--- a/sql/scan.go
+++ b/sql/scan.go
@@ -130,8 +130,10 @@ func (n *scanNode) Next() bool {
 
 			// This is the first key for the row, initialize the column values that
 			// are part of the primary key.
-			for id := range n.qvals {
-				n.qvals[id].Expr = vals[id]
+			for id, val := range vals {
+				if qval := n.qvals[id]; qval != nil {
+					qval.Expr = val
+				}
 			}
 		}
 
@@ -200,9 +202,6 @@ func (n *scanNode) initScan() bool {
 	// Retrieve all of the keys that start with our index key prefix.
 	startKey := proto.Key(structured.MakeIndexKeyPrefix(n.desc.ID, n.desc.PrimaryIndex.ID))
 	endKey := startKey.PrefixEnd()
-	// TODO(pmattis): Currently we retrieve all of the key/value pairs for
-	// the table. We could enhance this code so that it retrieves the
-	// key/value pairs in chunks.
 	n.kvs, n.err = n.db.Scan(startKey, endKey, 0)
 	if n.err != nil {
 		return false

--- a/sql/table.go
+++ b/sql/table.go
@@ -207,6 +207,13 @@ func encodeTableKey(b []byte, val parser.Datum) ([]byte, error) {
 	return nil, fmt.Errorf("unable to encode table key: %T", val)
 }
 
+// decodeIndexKey decodes the values that are a part of the specified index
+// key. If vals is not-nil, the decoded values are stored there, otherwise they
+// are decoded and tossed (reasonable to do for the primary key index for which
+// there will be multiple keys with the same values). The remaining bytes in
+// the index key are returned which will either be an encoded column ID for the
+// primary key index, the primary key suffix for non-unique secondary indexes
+// or unique secondary indexes containing NULL or empty.
 func decodeIndexKey(desc *structured.TableDescriptor,
 	index structured.IndexDescriptor, vals valMap, key []byte) ([]byte, error) {
 	if !bytes.HasPrefix(key, keys.TableDataPrefix) {

--- a/sql/testdata/select
+++ b/sql/testdata/select
@@ -94,6 +94,10 @@ query error "kv.*" cannot be aliased
 SELECT kv.* AS foo FROM kv
 ----
 
+query error qualified name "bar.kv.*" not found
+SELECT bar.kv.* FROM kv
+----
+
 query T colnames
 SELECT FOO.k FROM kv AS foo WHERE foo.k = 'a'
 ----


### PR DESCRIPTION
Added a test case showing that `SELECT foo.bar.*` currently fails.

Tweaked how scanNode.qvals is filled to loop over the index key values
instead of qvals.
