### PR TITLE
remove Txn entry on EndTransaction if all intents local

### DIFF
--- a/storage/client_range_test.go
+++ b/storage/client_range_test.go
@@ -390,7 +390,7 @@ func TestInternalRangeLookupUseReverse(t *testing.T) {
 	for _, test := range testCases {
 		resp, err := store.ExecuteCmd(context.Background(), test.request)
 		if err != nil {
-			t.Fatalf("InternalRangeLookup error: %s", err)
+			t.Fatalf("RangeLookup error: %s", err)
 		}
 
 		rlReply := resp.(*proto.RangeLookupResponse)

--- a/storage/replica.go
+++ b/storage/replica.go
@@ -84,6 +84,12 @@ const (
 // storage_test packages.
 var TestingCommandFilter func(proto.Request) error
 
+// This flag controls whether Transaction entries are automatically gc'ed
+// upon EndTransaction if they only have local intents (which can be
+// resolved synchronously with EndTransaction). Certain tests become
+// simpler with this being turned off.
+var txnAutoGC = true
+
 // raftInitialLogIndex is the starting point for the raft log. We bootstrap
 // the raft membership by synthesizing a snapshot as if there were some
 // discarded prefix to the log, so we must begin the log at an arbitrary


### PR DESCRIPTION
this is the first part of #2062. next up will be setting up garbage collection the "slow" way, via the gc queue.
