### PR TITLE
use (*Replica).resolveIntents in GC queue

### DIFF
--- a/storage/gc_queue_test.go
+++ b/storage/gc_queue_test.go
@@ -368,7 +368,7 @@ func TestGCQueueLookupGCPolicy(t *testing.T) {
 		ReplicaAttrs:  []proto.Attributes{},
 		RangeMinBytes: 1 << 10,
 		RangeMaxBytes: 1 << 18,
-		// Note thtere is no GC set here, so we should select the
+		// Note that there is no GC set here, so we should select the
 		// hierarchical parent's GC policy; in this case, zoneConfig1.
 	}
 	configs := []*config.PrefixConfig{

--- a/storage/replica_test.go
+++ b/storage/replica_test.go
@@ -814,6 +814,7 @@ func TestRangeNoGossipFromNonLeader(t *testing.T) {
 	}
 	req2 := endTxnArgs(txn, true /* commit */, rangeID, tc.store.StoreID())
 	req2.Timestamp = txn.Timestamp
+	req2.Intents = []proto.Intent{{Key: key}}
 	if _, err := tc.store.ExecuteCmd(tc.rng.context(), &req2); err != nil {
 		t.Fatal(err)
 	}


### PR DESCRIPTION
future changes will require a follow-up RPC to resolveIntents
and so it makes sense to have a single point through which all
intents are resolved.
