### PR TITLE
Range->Replica Housecleaning

### DIFF
--- a/storage/queue.go
+++ b/storage/queue.go
@@ -30,16 +30,16 @@ import (
 	"github.com/cockroachdb/cockroach/util/stop"
 )
 
-// A rangeItem holds a range and its priority for use with a priority queue.
-type rangeItem struct {
+// A replicaItem holds a replica and its priority for use with a priority queue.
+type replicaItem struct {
 	value    *Replica
 	priority float64
 	// The index is needed by update and is maintained by the heap.Interface methods.
 	index int // The index of the item in the heap.
 }
 
-// A priorityQueue implements heap.Interface and holds rangeItems.
-type priorityQueue []*rangeItem
+// A priorityQueue implements heap.Interface and holds replicaItems.
+type priorityQueue []*replicaItem
 
 func (pq priorityQueue) Len() int { return len(pq) }
 
@@ -55,7 +55,7 @@ func (pq priorityQueue) Swap(i, j int) {
 
 func (pq *priorityQueue) Push(x interface{}) {
 	n := len(*pq)
-	item := x.(*rangeItem)
+	item := x.(*replicaItem)
 	item.index = n
 	*pq = append(*pq, item)
 }
@@ -69,27 +69,27 @@ func (pq *priorityQueue) Pop() interface{} {
 	return item
 }
 
-// update modifies the priority of a rangeItem in the queue.
-func (pq *priorityQueue) update(item *rangeItem, priority float64) {
+// update modifies the priority of a replicaItem in the queue.
+func (pq *priorityQueue) update(item *replicaItem, priority float64) {
 	item.priority = priority
 	heap.Fix(pq, item.index)
 }
 
 var (
-	errQueueDisabled   = errors.New("queue disabled")
-	errRangeNotAddable = errors.New("range shouldn't be added to queue")
+	errQueueDisabled     = errors.New("queue disabled")
+	errReplicaNotAddable = errors.New("replica shouldn't be added to queue")
 )
 
 type queueImpl interface {
 	// needsLeaderLease returns whether this queue requires the leader
-	// lease to operate on a range.
+	// lease to operate on a replica.
 	needsLeaderLease() bool
 
-	// shouldQueue accepts current time and a Range and returns whether
+	// shouldQueue accepts current time and a replica and returns whether
 	// it should be queued and if so, at what priority.
 	shouldQueue(proto.Timestamp, *Replica) (shouldQueue bool, priority float64)
 
-	// process accepts current time and a range and executes
+	// process accepts current time and a replica and executes
 	// queue-specific work on it.
 	process(proto.Timestamp, *Replica) error
 
@@ -98,7 +98,7 @@ type queueImpl interface {
 	timer() time.Duration
 }
 
-// baseQueue is the base implementation of the rangeQueue interface.
+// baseQueue is the base implementation of the replicaQueue interface.
 // Queue implementations should embed a baseQueue and implement queueImpl.
 //
 // baseQueue is not thread safe and is intended for usage only from
@@ -106,28 +106,28 @@ type queueImpl interface {
 type baseQueue struct {
 	name       string
 	impl       queueImpl
-	maxSize    int                          // Maximum number of ranges to queue
-	incoming   chan struct{}                // Channel signalled when a new range is added to the queue.
-	sync.Mutex                              // Mutex protects priorityQ and ranges
-	priorityQ  priorityQueue                // The priority queue
-	ranges     map[proto.RangeID]*rangeItem // Map from RangeID to rangeItem (for updating priority)
+	maxSize    int                            // Maximum number of replicas to queue
+	incoming   chan struct{}                  // Channel signalled when a new replica is added to the queue.
+	sync.Mutex                                // Mutex protects priorityQ and replicas
+	priorityQ  priorityQueue                  // The priority queue
+	replicas   map[proto.RangeID]*replicaItem // Map from RangeID to replicaItem (for updating priority)
 	// Some tests in this package disable queues.
 	disabled int32 // updated atomically
 }
 
 // newBaseQueue returns a new instance of baseQueue with the
-// specified shouldQueue function to determine which ranges to queue
+// specified shouldQueue function to determine which replicas to queue
 // and maxSize to limit the growth of the queue. Note that
-// maxSize doesn't prevent new ranges from being added, it just
-// limits the total size. Higher priority ranges can still be
-// added; their addition simply removes the lowest priority range.
+// maxSize doesn't prevent new replicas from being added, it just
+// limits the total size. Higher priority replicas can still be
+// added; their addition simply removes the lowest priority replica.
 func newBaseQueue(name string, impl queueImpl, maxSize int) *baseQueue {
 	return &baseQueue{
 		name:     name,
 		impl:     impl,
 		maxSize:  maxSize,
 		incoming: make(chan struct{}, 1),
-		ranges:   map[proto.RangeID]*rangeItem{},
+		replicas: map[proto.RangeID]*replicaItem{},
 	}
 }
 
@@ -153,64 +153,64 @@ func (bq *baseQueue) Start(clock *hlc.Clock, stopper *stop.Stopper) {
 	bq.processLoop(clock, stopper)
 }
 
-// Add adds the specified range to the queue, regardless of the return
-// value of bq.shouldQueue. The range is added with specified
-// priority. If the queue is too full, the range may not be added, as
-// the range with the lowest priority will be dropped. Returns an
-// error if the range was not added.
-func (bq *baseQueue) Add(rng *Replica, priority float64) error {
+// Add adds the specified replica to the queue, regardless of the return
+// value of bq.shouldQueue. The replica is added with specified
+// priority. If the queue is too full, the replica may not be added, as
+// the replica with the lowest priority will be dropped. Returns an
+// error if the replica was not added.
+func (bq *baseQueue) Add(repl *Replica, priority float64) error {
 	bq.Lock()
 	defer bq.Unlock()
-	return bq.addInternal(rng, true, priority)
+	return bq.addInternal(repl, true, priority)
 }
 
-// MaybeAdd adds the specified range if bq.shouldQueue specifies it
-// should be queued. Ranges are added to the queue using the priority
-// returned by bq.shouldQueue. If the queue is too full, the range may
-// not be added, as the range with the lowest priority will be
+// MaybeAdd adds the specified replica if bq.shouldQueue specifies it
+// should be queued. Replicas are added to the queue using the priority
+// returned by bq.shouldQueue. If the queue is too full, the replica may
+// not be added, as the replica with the lowest priority will be
 // dropped.
-func (bq *baseQueue) MaybeAdd(rng *Replica, now proto.Timestamp) {
+func (bq *baseQueue) MaybeAdd(repl *Replica, now proto.Timestamp) {
 	bq.Lock()
 	defer bq.Unlock()
-	should, priority := bq.impl.shouldQueue(now, rng)
-	if err := bq.addInternal(rng, should, priority); err != nil && log.V(1) {
-		log.Infof("couldn't add %s to queue %s: %s", rng, bq.name, err)
+	should, priority := bq.impl.shouldQueue(now, repl)
+	if err := bq.addInternal(repl, should, priority); err != nil && log.V(1) {
+		log.Infof("couldn't add %s to queue %s: %s", repl, bq.name, err)
 	}
 }
 
-// addInternal adds the range the queue with specified priority. If the
-// range is already queued, updates the existing priority. Expects the
-// queue lock is held by caller. Returns an error if the range was not
+// addInternal adds the replica the queue with specified priority. If the
+// replica is already queued, updates the existing priority. Expects the
+// queue lock is held by caller. Returns an error if the replica was not
 // added.
-func (bq *baseQueue) addInternal(rng *Replica, should bool, priority float64) error {
+func (bq *baseQueue) addInternal(repl *Replica, should bool, priority float64) error {
 	if atomic.LoadInt32(&bq.disabled) == 1 {
 		return errQueueDisabled
 	}
-	item, ok := bq.ranges[rng.Desc().RangeID]
+	item, ok := bq.replicas[repl.Desc().RangeID]
 	if !should {
 		if ok {
 			bq.remove(item.index)
 		}
-		return errRangeNotAddable
+		return errReplicaNotAddable
 	} else if ok {
-		// Range has already been added; update priority.
+		// Replica has already been added; update priority.
 		bq.priorityQ.update(item, priority)
 		return nil
 	}
 
 	if log.V(1) {
-		log.Infof("adding range %s to %s queue", rng, bq.name)
+		log.Infof("adding replica %s to %s queue", repl, bq.name)
 	}
-	item = &rangeItem{value: rng, priority: priority}
+	item = &replicaItem{value: repl, priority: priority}
 	heap.Push(&bq.priorityQ, item)
-	bq.ranges[rng.Desc().RangeID] = item
+	bq.replicas[repl.Desc().RangeID] = item
 
-	// If adding this range has pushed the queue past its maximum size,
+	// If adding this replica has pushed the queue past its maximum size,
 	// remove the lowest priority element.
 	if pqLen := bq.priorityQ.Len(); pqLen > bq.maxSize {
 		bq.remove(pqLen - 1)
 	}
-	// Signal the processLoop that a range has been added.
+	// Signal the processLoop that a replica has been added.
 	select {
 	case bq.incoming <- struct{}{}:
 	default:
@@ -219,13 +219,13 @@ func (bq *baseQueue) addInternal(rng *Replica, should bool, priority float64) er
 	return nil
 }
 
-// MaybeRemove removes the specified range from the queue if enqueued.
-func (bq *baseQueue) MaybeRemove(rng *Replica) {
+// MaybeRemove removes the specified replica from the queue if enqueued.
+func (bq *baseQueue) MaybeRemove(repl *Replica) {
 	bq.Lock()
 	defer bq.Unlock()
-	if item, ok := bq.ranges[rng.Desc().RangeID]; ok {
+	if item, ok := bq.replicas[repl.Desc().RangeID]; ok {
 		if log.V(1) {
-			log.Infof("removing range %s from %s queue", item.value, bq.name)
+			log.Infof("removing replica %s from %s queue", item.value, bq.name)
 		}
 		bq.remove(item.index)
 	}
@@ -234,7 +234,7 @@ func (bq *baseQueue) MaybeRemove(rng *Replica) {
 // processLoop processes the entries in the queue until the provided
 // stopper signals exit.
 //
-// TODO(spencer): current load should factor into range processing timer.
+// TODO(spencer): current load should factor into replica processing timer.
 func (bq *baseQueue) processLoop(clock *hlc.Clock, stopper *stop.Stopper) {
 
 	stopper.RunWorker(func() {
@@ -248,17 +248,17 @@ func (bq *baseQueue) processLoop(clock *hlc.Clock, stopper *stop.Stopper) {
 		for {
 			select {
 			// Incoming signal sets the next time to process if there were previously
-			// no ranges in the queue.
+			// no replicas in the queue.
 			case <-bq.incoming:
 				if nextTime == nil {
-					// When a range is added, wake up immediately. This is mainly
+					// When a replica is added, wake up immediately. This is mainly
 					// to facilitate testing without unnecessary sleeps.
 					nextTime = immediately
 
 					// In case we're in a test, still block on the impl.
 					bq.impl.timer()
 				}
-			// Process ranges as the timer expires.
+			// Process replicas as the timer expires.
 			case <-nextTime:
 				stopper.RunTask(func() {
 					bq.processOne(clock)
@@ -272,7 +272,7 @@ func (bq *baseQueue) processLoop(clock *hlc.Clock, stopper *stop.Stopper) {
 			// Exit on stopper.
 			case <-stopper.ShouldStop():
 				bq.Lock()
-				bq.ranges = map[proto.RangeID]*rangeItem{}
+				bq.replicas = map[proto.RangeID]*replicaItem{}
 				bq.priorityQ = nil
 				bq.Unlock()
 				return
@@ -284,49 +284,49 @@ func (bq *baseQueue) processLoop(clock *hlc.Clock, stopper *stop.Stopper) {
 func (bq *baseQueue) processOne(clock *hlc.Clock) {
 	start := time.Now()
 	bq.Lock()
-	rng := bq.pop()
+	repl := bq.pop()
 	bq.Unlock()
-	if rng != nil {
+	if repl != nil {
 		now := clock.Now()
 		if log.V(1) {
-			log.Infof("processing range %s from %s queue...", rng, bq.name)
+			log.Infof("processing replica %s from %s queue...", repl, bq.name)
 		}
-		// If the queue requires the leader lease to process the
-		// range, check whether this replica has leader lease and
-		// renew or acquire if necessary.
+		// If the queue requires a replica to have the range leader lease in
+		// order to be processed, check whether this replica has leader lease
+		// and renew or acquire if necessary.
 		if bq.impl.needsLeaderLease() {
 			// Create a "fake" get request in order to invoke redirectOnOrAcquireLease.
 			args := &proto.GetRequest{RequestHeader: proto.RequestHeader{Timestamp: now}}
-			if err := rng.redirectOnOrAcquireLeaderLease(nil /* Trace */, args.Header().Timestamp); err != nil {
+			if err := repl.redirectOnOrAcquireLeaderLease(nil /* Trace */, args.Header().Timestamp); err != nil {
 				if log.V(1) {
-					log.Infof("this replica of %s could not acquire leader lease; skipping...", rng)
+					log.Infof("this replica of %s could not acquire leader lease; skipping...", repl)
 				}
 				return
 			}
 		}
-		if err := bq.impl.process(now, rng); err != nil {
-			log.Errorf("failure processing range %s from %s queue: %s", rng, bq.name, err)
+		if err := bq.impl.process(now, repl); err != nil {
+			log.Errorf("failure processing replica %s from %s queue: %s", repl, bq.name, err)
 		} else if log.V(2) {
-			log.Infof("processed range %s from %s queue in %s", rng, bq.name, time.Now().Sub(start))
+			log.Infof("processed replica %s from %s queue in %s", repl, bq.name, time.Now().Sub(start))
 		}
 	}
 }
 
-// pop dequeues the highest priority range in the queue. Returns the
-// range if not empty; otherwise, returns nil. Expects mutex to be
+// pop dequeues the highest priority replica in the queue. Returns the
+// replica if not empty; otherwise, returns nil. Expects mutex to be
 // locked.
 func (bq *baseQueue) pop() *Replica {
 	if bq.priorityQ.Len() == 0 {
 		return nil
 	}
-	item := heap.Pop(&bq.priorityQ).(*rangeItem)
-	delete(bq.ranges, item.value.Desc().RangeID)
+	item := heap.Pop(&bq.priorityQ).(*replicaItem)
+	delete(bq.replicas, item.value.Desc().RangeID)
 	return item.value
 }
 
 // remove removes an element from the priority queue by index. Expects
 // mutex to be locked.
 func (bq *baseQueue) remove(index int) {
-	item := heap.Remove(&bq.priorityQ, index).(*rangeItem)
-	delete(bq.ranges, item.value.Desc().RangeID)
+	item := heap.Remove(&bq.priorityQ, index).(*replicaItem)
+	delete(bq.replicas, item.value.Desc().RangeID)
 }

--- a/storage/queue_test.go
+++ b/storage/queue_test.go
@@ -68,7 +68,7 @@ func TestQueuePriorityQueue(t *testing.T) {
 	expRanges := make([]*Replica, count+1)
 	pq := make(priorityQueue, count)
 	for i := 0; i < count; {
-		pq[i] = &rangeItem{
+		pq[i] = &replicaItem{
 			value:    &Replica{},
 			priority: float64(i),
 			index:    i,
@@ -79,7 +79,7 @@ func TestQueuePriorityQueue(t *testing.T) {
 	heap.Init(&pq)
 
 	// Insert a new item and then modify its priority.
-	priorityItem := &rangeItem{
+	priorityItem := &replicaItem{
 		value:    &Replica{},
 		priority: 1.0,
 	}
@@ -89,7 +89,7 @@ func TestQueuePriorityQueue(t *testing.T) {
 
 	// Take the items out; they should arrive in decreasing priority order.
 	for i := 0; pq.Len() > 0; i++ {
-		item := heap.Pop(&pq).(*rangeItem)
+		item := heap.Pop(&pq).(*replicaItem)
 		if item.value != expRanges[i] {
 			t.Errorf("%d: unexpected range with priority %f", i, item.priority)
 		}

--- a/storage/scanner.go
+++ b/storage/scanner.go
@@ -28,53 +28,53 @@ import (
 	"github.com/cockroachdb/cockroach/util/stop"
 )
 
-// A rangeQueue is a prioritized queue of ranges for which work is
-// scheduled. For example, there's a GC queue for ranges which are due
-// for garbage collection, a rebalance queue to move ranges from full
-// or busy stores, a recovery queue for ranges with dead replicas,
+// A replicaQueue is a prioritized queue of replicas for which work is
+// scheduled. For example, there's a GC queue for replicas which are due
+// for garbage collection, a rebalance queue to move replicas from full
+// or busy stores, a recovery queue for replicas of ranges with dead replicas,
 // etc.
-type rangeQueue interface {
+type replicaQueue interface {
 	// Start launches a goroutine to process the contents of the queue.
 	// The provided stopper is used to signal that the goroutine should exit.
 	Start(*hlc.Clock, *stop.Stopper)
-	// MaybeAdd adds the range to the queue if the range meets
+	// MaybeAdd adds the replica to the queue if the replica meets
 	// the queue's inclusion criteria and the queue is not already
 	// too full, etc.
 	MaybeAdd(*Replica, proto.Timestamp)
-	// MaybeRemove removes the range from the queue if it is present.
+	// MaybeRemove removes the replica from the queue if it is present.
 	MaybeRemove(*Replica)
 }
 
-// A rangeSet provides access to a sequence of ranges to consider
-// for inclusion in range queues. There are no requirements for the
+// A replicaSet provides access to a sequence of replicas to consider
+// for inclusion in replica queues. There are no requirements for the
 // ordering of the iteration.
-type rangeSet interface {
-	// Visit calls the given function for every range in the set btree
+type replicaSet interface {
+	// Visit calls the given function for every replica in the set btree
 	// until the function returns false.
 	Visit(func(*Replica) bool)
-	// EstimatedCount returns the number of ranges estimated to remain
+	// EstimatedCount returns the number of replicas estimated to remain
 	// in the iteration. This value does not need to be exact.
 	EstimatedCount() int
 }
 
 // A storeStats holds statistics over the entire store. Stats is an
-// aggregation of MVCC stats across all ranges in the store.
+// aggregation of MVCC stats across all replicas in the store.
 type storeStats struct {
 	RangeCount int
 	MVCC       engine.MVCCStats
 }
 
-// A rangeScanner iterates over ranges at a measured pace in order to
+// A replicaScanner iterates over replicas at a measured pace in order to
 // complete approximately one full scan per target interval in a large
 // store (in small stores it may complete faster than the target
-// interval).  Each range is tested for inclusion in a sequence of
-// prioritized range queues.
-type rangeScanner struct {
-	targetInterval time.Duration // Target duration interval for scan loop
-	maxIdleTime    time.Duration // Max idle time for scan loop
-	ranges         rangeSet      // Ranges to be scanned
-	queues         []rangeQueue  // Range queues managed by this scanner
-	removed        chan *Replica // Ranges to remove from queues
+// interval).  Each replica is tested for inclusion in a sequence of
+// prioritized replica queues.
+type replicaScanner struct {
+	targetInterval time.Duration  // Target duration interval for scan loop
+	maxIdleTime    time.Duration  // Max idle time for scan loop
+	replicas       replicaSet     // Replicas to be scanned
+	queues         []replicaQueue // Replica queues managed by this scanner
+	removed        chan *Replica  // Replicas to remove from queues
 	// Count of times and total duration through the scanning loop but locked by the completedScan
 	// mutex.
 	completedScan *sync.Cond
@@ -82,27 +82,27 @@ type rangeScanner struct {
 	total         time.Duration
 }
 
-// newRangeScanner creates a new range scanner with the provided loop intervals,
-// range set, and range queues.  If scanFn is not nil, after a complete
+// newReplicaScanner creates a new replica scanner with the provided loop intervals,
+// replica set, and replica queues.  If scanFn is not nil, after a complete
 // loop that function will be called.
-func newRangeScanner(targetInterval, maxIdleTime time.Duration, ranges rangeSet) *rangeScanner {
-	return &rangeScanner{
+func newReplicaScanner(targetInterval, maxIdleTime time.Duration, replicas replicaSet) *replicaScanner {
+	return &replicaScanner{
 		targetInterval: targetInterval,
 		maxIdleTime:    maxIdleTime,
-		ranges:         ranges,
+		replicas:       replicas,
 		removed:        make(chan *Replica, 10),
 		completedScan:  sync.NewCond(&sync.Mutex{}),
 	}
 }
 
-// AddQueues adds a variable arg list of queues to the range scanner.
+// AddQueues adds a variable arg list of queues to the replica scanner.
 // This method may only be called before Start().
-func (rs *rangeScanner) AddQueues(queues ...rangeQueue) {
+func (rs *replicaScanner) AddQueues(queues ...replicaQueue) {
 	rs.queues = append(rs.queues, queues...)
 }
 
 // Start spins up the scanning loop. Call Stop() to exit the loop.
-func (rs *rangeScanner) Start(clock *hlc.Clock, stopper *stop.Stopper) {
+func (rs *replicaScanner) Start(clock *hlc.Clock, stopper *stop.Stopper) {
 	for _, queue := range rs.queues {
 		queue.Start(clock, stopper)
 	}
@@ -110,30 +110,30 @@ func (rs *rangeScanner) Start(clock *hlc.Clock, stopper *stop.Stopper) {
 }
 
 // Count returns the number of times the scanner has cycled through
-// all ranges.
-func (rs *rangeScanner) Count() int64 {
+// all replicas.
+func (rs *replicaScanner) Count() int64 {
 	rs.completedScan.L.Lock()
 	defer rs.completedScan.L.Unlock()
 	return rs.count
 }
 
 // avgScan returns the average scan time of each scan cycle. Used in unittests.
-func (rs *rangeScanner) avgScan() time.Duration {
+func (rs *replicaScanner) avgScan() time.Duration {
 	rs.completedScan.L.Lock()
 	defer rs.completedScan.L.Unlock()
 	return time.Duration(rs.total.Nanoseconds() / int64(rs.count))
 }
 
-// RemoveRange removes a range from any range queues the scanner may
+// RemoveReplica removes a replica from any replica queues the scanner may
 // have placed it in. This method should be called by the Store
-// when a range is removed (e.g. rebalanced or merged).
-func (rs *rangeScanner) RemoveRange(rng *Replica) {
-	rs.removed <- rng
+// when a replica is removed (e.g. rebalanced or merged).
+func (rs *replicaScanner) RemoveReplica(repl *Replica) {
+	rs.removed <- repl
 }
 
 // WaitForScanCompletion waits until the end of the next scan and returns the
 // total number of scans completed so far.
-func (rs *rangeScanner) WaitForScanCompletion() int64 {
+func (rs *replicaScanner) WaitForScanCompletion() int64 {
 	rs.completedScan.L.Lock()
 	defer rs.completedScan.L.Unlock()
 	initalValue := rs.count
@@ -145,13 +145,13 @@ func (rs *rangeScanner) WaitForScanCompletion() int64 {
 
 // paceInterval returns a duration between iterations to allow us to pace
 // the scan.
-func (rs *rangeScanner) paceInterval(start, now time.Time) time.Duration {
+func (rs *replicaScanner) paceInterval(start, now time.Time) time.Duration {
 	elapsed := now.Sub(start)
 	remainingNanos := rs.targetInterval.Nanoseconds() - elapsed.Nanoseconds()
 	if remainingNanos < 0 {
 		remainingNanos = 0
 	}
-	count := rs.ranges.EstimatedCount()
+	count := rs.replicas.EstimatedCount()
 	if count < 1 {
 		count = 1
 	}
@@ -162,12 +162,12 @@ func (rs *rangeScanner) paceInterval(start, now time.Time) time.Duration {
 	return interval
 }
 
-// waitAndProcess waits for the pace interval and processes the range
-// if rng is not nil. The method returns true when the scanner needs
-// to be stopped. The method also removes a range from queues when it
+// waitAndProcess waits for the pace interval and processes the replica
+// if repl is not nil. The method returns true when the scanner needs
+// to be stopped. The method also removes a replica from queues when it
 // is signaled via the removed channel.
-func (rs *rangeScanner) waitAndProcess(start time.Time, clock *hlc.Clock, stopper *stop.Stopper,
-	rng *Replica) bool {
+func (rs *replicaScanner) waitAndProcess(start time.Time, clock *hlc.Clock, stopper *stop.Stopper,
+	repl *Replica) bool {
 	waitInterval := rs.paceInterval(start, time.Now())
 	nextTime := time.After(waitInterval)
 	if log.V(6) {
@@ -176,23 +176,23 @@ func (rs *rangeScanner) waitAndProcess(start time.Time, clock *hlc.Clock, stoppe
 	for {
 		select {
 		case <-nextTime:
-			if rng == nil {
+			if repl == nil {
 				return false
 			}
 
 			return !stopper.RunTask(func() {
-				// Try adding range to all queues.
+				// Try adding replica to all queues.
 				for _, q := range rs.queues {
-					q.MaybeAdd(rng, clock.Now())
+					q.MaybeAdd(repl, clock.Now())
 				}
 			})
-		case rng := <-rs.removed:
-			// Remove range from all queues as applicable.
+		case repl := <-rs.removed:
+			// Remove replica from all queues as applicable.
 			for _, q := range rs.queues {
-				q.MaybeRemove(rng)
+				q.MaybeRemove(repl)
 			}
 			if log.V(6) {
-				log.Infof("removed range %s", rng)
+				log.Infof("removed replica %s", repl)
 			}
 		case <-stopper.ShouldStop():
 			return true
@@ -200,22 +200,22 @@ func (rs *rangeScanner) waitAndProcess(start time.Time, clock *hlc.Clock, stoppe
 	}
 }
 
-// scanLoop loops endlessly, scanning through ranges available via
-// the range set, or until the scanner is stopped. The iteration
+// scanLoop loops endlessly, scanning through replicas available via
+// the replica set, or until the scanner is stopped. The iteration
 // is paced to complete a full scan in approximately the scan interval.
-func (rs *rangeScanner) scanLoop(clock *hlc.Clock, stopper *stop.Stopper) {
+func (rs *replicaScanner) scanLoop(clock *hlc.Clock, stopper *stop.Stopper) {
 	stopper.RunWorker(func() {
 		start := time.Now()
 
 		for {
 			var shouldStop bool
-			if rs.ranges.EstimatedCount() == 0 {
-				// Just wait without processing any range.
+			if rs.replicas.EstimatedCount() == 0 {
+				// Just wait without processing any replica.
 				shouldStop = rs.waitAndProcess(start, clock, stopper, nil)
 			} else {
 				shouldStop = true
-				rs.ranges.Visit(func(rng *Replica) bool {
-					shouldStop = rs.waitAndProcess(start, clock, stopper, rng)
+				rs.replicas.Visit(func(repl *Replica) bool {
+					shouldStop = rs.waitAndProcess(start, clock, stopper, repl)
 					return !shouldStop
 				})
 			}
@@ -228,7 +228,7 @@ func (rs *rangeScanner) scanLoop(clock *hlc.Clock, stopper *stop.Stopper) {
 				rs.completedScan.Broadcast()
 				rs.completedScan.L.Unlock()
 				if log.V(6) {
-					log.Infof("reset range scan iteration")
+					log.Infof("reset replica scan iteration")
 				}
 
 				// Reset iteration and start time.

--- a/storage/scanner_test.go
+++ b/storage/scanner_test.go
@@ -190,7 +190,7 @@ func TestScannerAddToQueues(t *testing.T) {
 	// We don't want to actually consume entries from the queues during this test.
 	q1.setDisabled(true)
 	q2.setDisabled(true)
-	s := newRangeScanner(1*time.Millisecond, 0, ranges)
+	s := newReplicaScanner(1*time.Millisecond, 0, ranges)
 	s.AddQueues(q1, q2)
 	mc := hlc.NewManualClock(0)
 	clock := hlc.NewClock(mc.UnixNano)
@@ -210,7 +210,7 @@ func TestScannerAddToQueues(t *testing.T) {
 		// This is intentionally inside the loop, otherwise this test races as
 		// our removal of the range may be processed before a stray re-queue.
 		// Removing on each attempt makes sure we clean this up as we retry.
-		s.RemoveRange(rng)
+		s.RemoveReplica(rng)
 		c1 := q1.count()
 		c2 := q2.count()
 		log.Infof("q1: %d, q2: %d, wanted: %d", c1, c2, count-1)
@@ -240,7 +240,7 @@ func TestScannerTiming(t *testing.T) {
 	for i, duration := range durations {
 		ranges := newTestRangeSet(count, t)
 		q := &testQueue{}
-		s := newRangeScanner(duration, 0, ranges)
+		s := newReplicaScanner(duration, 0, ranges)
 		s.AddQueues(q)
 		mc := hlc.NewManualClock(0)
 		clock := hlc.NewClock(mc.UnixNano)
@@ -278,16 +278,16 @@ func TestScannerPaceInterval(t *testing.T) {
 	for _, duration := range durations {
 		startTime := time.Now()
 		ranges := newTestRangeSet(count, t)
-		s := newRangeScanner(duration, 0, ranges)
+		s := newReplicaScanner(duration, 0, ranges)
 		interval := s.paceInterval(startTime, startTime)
 		logErrorWhenNotCloseTo(duration/count, interval)
 		// The range set is empty
 		ranges = newTestRangeSet(0, t)
-		s = newRangeScanner(duration, 0, ranges)
+		s = newReplicaScanner(duration, 0, ranges)
 		interval = s.paceInterval(startTime, startTime)
 		logErrorWhenNotCloseTo(duration, interval)
 		ranges = newTestRangeSet(count, t)
-		s = newRangeScanner(duration, 0, ranges)
+		s = newReplicaScanner(duration, 0, ranges)
 		// Move the present to duration time into the future
 		interval = s.paceInterval(startTime, startTime.Add(duration))
 		logErrorWhenNotCloseTo(0, interval)
@@ -299,7 +299,7 @@ func TestScannerEmptyRangeSet(t *testing.T) {
 	defer leaktest.AfterTest(t)
 	ranges := newTestRangeSet(0, t)
 	q := &testQueue{}
-	s := newRangeScanner(1*time.Millisecond, 0, ranges)
+	s := newReplicaScanner(1*time.Millisecond, 0, ranges)
 	s.AddQueues(q)
 	mc := hlc.NewManualClock(0)
 	clock := hlc.NewClock(mc.UnixNano)

--- a/storage/store.go
+++ b/storage/store.go
@@ -265,7 +265,7 @@ type Store struct {
 	verifyQueue    *verifyQueue    // Checksum verification queue
 	replicateQueue *replicateQueue // Replication queue
 	_rangeGCQueue  *rangeGCQueue   // Range GC queue
-	scanner        *rangeScanner   // Range scanner
+	scanner        *replicaScanner // Range scanner
 	feed           StoreEventFeed  // Event Feed
 	multiraft      *multiraft.MultiRaft
 	started        int32
@@ -371,7 +371,7 @@ func NewStore(ctx StoreContext, eng engine.Engine, nodeDesc *proto.NodeDescripto
 	}
 
 	// Add range scanner and configure with queues.
-	s.scanner = newRangeScanner(ctx.ScanInterval, ctx.ScanMaxIdleTime, newStoreRangeSet(s))
+	s.scanner = newReplicaScanner(ctx.ScanInterval, ctx.ScanMaxIdleTime, newStoreRangeSet(s))
 	s.gcQueue = newGCQueue()
 	s._splitQueue = newSplitQueue(s.db, s.ctx.Gossip)
 	s.verifyQueue = newVerifyQueue(s.ReplicaCount)
@@ -1149,7 +1149,7 @@ func (s *Store) RemoveReplica(rng *Replica) error {
 	if s.replicasByKey.Delete(rng) == nil {
 		return util.Errorf("couldn't find range in rangesByKey btree")
 	}
-	s.scanner.RemoveRange(rng)
+	s.scanner.RemoveReplica(rng)
 	return nil
 }
 


### PR DESCRIPTION
The comments and names for store-internal scanners and queues still refer to
Ranges when they should refer to Replicas. This commit cleans up some of the
nomenclature in these files.
