### PR TITLE
Don't marshal a value for primary key columns.

### DIFF
--- a/docs/structured.md
+++ b/docs/structured.md
@@ -134,7 +134,7 @@ before we garbage collect the table in the background.
 ###Data addressing###
 
 The Index data used to find data in the database is stored in the database
-itself at keys with the following prefix: `/TableID/IndexID/Key>`, where TableID
+itself at keys with the following prefix: `/TableID/IndexID/Key`, where TableID
 represents the Table being addressed and IndexID the index in use. The encoding
 used ensures that the data and metadata are well-separated.
 
@@ -146,6 +146,11 @@ unique row in the database. A cell within a row under a particular column is
 addressed by adding the desired ColumnID to the key prefix:
 `/TableID/PrimaryIndexID/Key/ColumnID`. PrimaryIndexID is variable to allow
 changing the primary key.
+
+Every row in a table has a sentinel key that is the primary key prefix with no
+ColumnID suffix: `/TableID/PrimaryIndexID/Key`. This sentinel is created on row
+insertion and removed on row deletion. Column keys are only written if the
+column value is NULL.
 
 **Secondary key addressing**
 

--- a/sql/scan.go
+++ b/sql/scan.go
@@ -139,7 +139,7 @@ func (n *scanNode) Next() bool {
 			}
 		}
 
-		if !n.isSecondaryIndex {
+		if !n.isSecondaryIndex && len(remaining) > 0 {
 			_, colID := encoding.DecodeUvarint(remaining)
 			var col *structured.ColumnDescriptor
 			col, n.err = n.desc.FindColumnByID(structured.ColumnID(colID))


### PR DESCRIPTION
The primary key column values are already encoded in the primary key and
scanNode was never using the value.
