### PR TITLE
Allow running against the known good sqllogictest files.

### DIFF
--- a/sql/Makefile
+++ b/sql/Makefile
@@ -1,0 +1,3 @@
+.PHONY: bigtest
+bigtest:
+	go test -bigtest -timeout 5h -run '^TestLogic$$'


### PR DESCRIPTION
Added a -bigtest flag which runs the logic test harness against the
known good sqllogictest files.

Changed the test output so that it is only verbose if testing.Verbose()
is true. Print a progress report every 2 seconds. Useful for long
running tests.
