### PR TITLE
Fix error handling in delete and update processing.

### DIFF
--- a/sql/delete.go
+++ b/sql/delete.go
@@ -73,9 +73,6 @@ func (p *planner) Delete(n *parser.Delete) (planNode, error) {
 	b := client.Batch{}
 
 	for node.Next() {
-		if err := node.Err(); err != nil {
-			return nil, err
-		}
 		values := node.Values()
 
 		primaryIndexKeySuffix, _, err := encodeIndexKey(primaryIndex.ColumnIDs, colIDtoRowIndex, values, nil)
@@ -104,6 +101,10 @@ func (p *planner) Delete(n *parser.Delete) (planNode, error) {
 			log.Infof("DelRange %q - %q", rowStartKey, rowEndKey)
 		}
 		b.DelRange(rowStartKey, rowEndKey)
+	}
+
+	if err := node.Err(); err != nil {
+		return nil, err
 	}
 
 	if err := p.txn.Run(&b); err != nil {

--- a/sql/testdata/delete
+++ b/sql/testdata/delete
@@ -30,3 +30,6 @@ DELETE FROM kv
 query II
 SELECT * FROM kv
 ----
+
+statement error qualified name "kv.nonexistent" not found
+DELETE FROM kv WHERE nonexistent = 1

--- a/sql/testdata/update
+++ b/sql/testdata/update
@@ -83,3 +83,6 @@ query TT
 SELECT * FROM kv3
 ----
 a   b
+
+statement error qualified name "kv3.nonexistent" not found
+UPDATE kv3 SET v = NULL WHERE nonexistent = 'a'

--- a/sql/update.go
+++ b/sql/update.go
@@ -114,9 +114,6 @@ func (p *planner) Update(n *parser.Update) (planNode, error) {
 	// Update all the rows.
 	b := client.Batch{}
 	for row.Next() {
-		if err := row.Err(); err != nil {
-			return nil, err
-		}
 		rowVals := row.Values()
 		primaryIndexKeySuffix, _, err := encodeIndexKey(primaryIndex.ColumnIDs, colIDtoRowIndex, rowVals, nil)
 		if err != nil {
@@ -179,6 +176,10 @@ func (p *planner) Update(n *parser.Update) (planNode, error) {
 				b.Del(key)
 			}
 		}
+	}
+
+	if err := row.Err(); err != nil {
+		return nil, err
 	}
 
 	if err := p.txn.Run(&b); err != nil {


### PR DESCRIPTION
planNode.Err() will only return a non-nil error if planNode.Next()
returned false. If planNode.Next() returns true we are guaranteed that
planNode.Err() will return nil until the next call to planNode.Next().
