### PR TITLE
Always check primary key values for type-correctness

### DIFF
--- a/sql/table.go
+++ b/sql/table.go
@@ -321,7 +321,7 @@ func encodeSecondaryIndexes(tableID structured.ID, indexes []structured.IndexDes
 // TODO(tamird): make this not panic. Not critical, since a panic here
 // will just tank a single goroutine on the server and be silently
 // swallowed.
-func prepareVal(col structured.ColumnDescriptor, val parser.Expr) (interface{}, error) {
+func convertDatum(col structured.ColumnDescriptor, val parser.Datum) (interface{}, error) {
 	if val == parser.DNull {
 		return nil, nil
 	}


### PR DESCRIPTION
This regressed with the optimization to stop writing these columns in
ffa6f603d61241d4ebabd712b74ad03e5a01cf40.

@petermattis cc @thschroeter

This will be tested in #2078 - that PR is currently blocked on this.
