### PR TITLE
client EndTransaction handling wrt txn.Writing

### DIFF
--- a/client/txn.go
+++ b/client/txn.go
@@ -65,10 +65,16 @@ func (ts *txnSender) Send(ctx context.Context, call proto.Call) {
 // Txn is an in-progress distributed database transaction. A Txn is not safe for
 // concurrent use by multiple goroutines.
 type Txn struct {
-	db           DB
-	wrapped      Sender
-	txn          proto.Transaction
-	haveTxnWrite bool // True if there were transactional writes
+	db      DB
+	wrapped Sender
+	txn     proto.Transaction
+	// haveTxnWrite is true as soon as the current attempt contains a write
+	// (prior to sending). This is in contrast to txn.Writing, which is set
+	// by the coordinator when the first intent has been created, and which
+	// does not reset in-between retries. As such, haveTxnWrite helps deter-
+	// mine whether it makes sense to add an EndTransaction when txn.Writing
+	// is (still) unset.
+	haveTxnWrite bool
 	haveEndTxn   bool // True if there was an explicit EndTransaction
 }
 

--- a/client/txn_test.go
+++ b/client/txn_test.go
@@ -50,13 +50,20 @@ func newTestSender(handler func(proto.Call)) SenderFunc {
 			header.Txn.ID = txnID
 		}
 		call.Reply.Reset()
+		var writing bool
 		switch call.Args.(type) {
 		case *proto.PutRequest:
 			gogoproto.Merge(call.Reply, testPutResp)
+			writing = true
+		case *proto.EndTransactionRequest:
+			writing = true
 		default:
 			// Do nothing.
 		}
 		call.Reply.Header().Txn = gogoproto.Clone(call.Args.Header().Txn).(*proto.Transaction)
+		if txn := call.Reply.Header().Txn; txn != nil {
+			txn.Writing = writing
+		}
 
 		if handler != nil {
 			handler(call)

--- a/client/txn_test.go
+++ b/client/txn_test.go
@@ -243,8 +243,8 @@ func TestCommitTransactionOnce(t *testing.T) {
 	}
 }
 
-// TestAbortReadOnlyTransaction verifies that transaction is aborted
-// upon failed invocation of the retryable func.
+// TestAbortReadOnlyTransaction verifies that aborting a read-only
+// transaction does not prompt an EndTransaction call.
 func TestAbortReadOnlyTransaction(t *testing.T) {
 	defer leaktest.AfterTest(t)
 	db := newDB(newTestSender(func(call proto.Call) {
@@ -256,6 +256,44 @@ func TestAbortReadOnlyTransaction(t *testing.T) {
 		return errors.New("foo")
 	}); err == nil {
 		t.Error("expected error on abort")
+	}
+}
+
+// TestEndWriteRestartReadOnlyTransaction verifies that if
+// a transaction writes, then restarts and turns read-only,
+// an explicit EndTransaction call is still sent if retry-
+// able didn't, regardless of whether there is an error
+// or not.
+func TestEndWriteRestartReadOnlyTransaction(t *testing.T) {
+	defer leaktest.AfterTest(t)
+	for _, success := range []bool{true, false} {
+		expCalls := []proto.Method{proto.Put, proto.EndTransaction}
+		var calls []proto.Method
+		db := newDB(newTestSender(func(call proto.Call) {
+			calls = append(calls, call.Method())
+		}))
+		ok := false
+		if err := db.Txn(func(txn *Txn) error {
+			if !ok {
+				if err := txn.Put("consider", "phlebas"); err != nil {
+					t.Fatal(err)
+				}
+				ok = true
+				return &proto.Error{
+					Message:            "boom",
+					TransactionRestart: proto.TransactionRestart_IMMEDIATE,
+				}
+			}
+			if !success {
+				return errors.New("aborting on purpose")
+			}
+			return nil
+		}); err == nil != success {
+			t.Errorf("expected error: %t, got error: %v", !success, err)
+		}
+		if !reflect.DeepEqual(expCalls, calls) {
+			t.Fatalf("expected %v, got %v", expCalls, calls)
+		}
 	}
 }
 

--- a/kv/db_test.go
+++ b/kv/db_test.go
@@ -196,6 +196,7 @@ func TestKVDBEndTransactionWithTriggers(t *testing.T) {
 		// stripped. In this case, we set the start key to "bar" for a
 		// split of the default range; start key must be "" in this case.
 		b := &client.Batch{}
+		b.Put("foo", "only here to make this a rw transaction")
 		b.InternalAddCall(proto.Call{
 			Args: &proto.EndTransactionRequest{
 				RequestHeader: proto.RequestHeader{Key: proto.Key("foo")},

--- a/kv/txn_coord_sender_test.go
+++ b/kv/txn_coord_sender_test.go
@@ -537,20 +537,6 @@ func (ts *testSender) Send(_ context.Context, call proto.Call) {
 func (ts *testSender) Close() {
 }
 
-var testPutReq = &proto.PutRequest{
-	RequestHeader: proto.RequestHeader{
-		Key:          proto.Key("test-key"),
-		User:         security.RootUser,
-		UserPriority: gogoproto.Int32(-1),
-		Txn: &proto.Transaction{
-			Name: "test txn",
-		},
-		Replica: proto.Replica{
-			NodeID: 12345,
-		},
-	},
-}
-
 // TestTxnCoordSenderTxnUpdatedOnError verifies that errors adjust the
 // response transaction's timestamp and priority as appropriate.
 func TestTxnCoordSenderTxnUpdatedOnError(t *testing.T) {
@@ -580,6 +566,22 @@ func TestTxnCoordSenderTxnUpdatedOnError(t *testing.T) {
 		{&proto.TransactionRetryError{Txn: proto.Transaction{
 			Timestamp: makeTS(10, 10), Priority: int32(10)}}, 1, 10,
 			makeTS(10, 10), makeTS(10, 10), false},
+	}
+
+	// testPutReq is mutated in the course of this test and the test data
+	// reflect that.
+	var testPutReq = &proto.PutRequest{
+		RequestHeader: proto.RequestHeader{
+			Key:          proto.Key("test-key"),
+			User:         security.RootUser,
+			UserPriority: gogoproto.Int32(-1),
+			Txn: &proto.Transaction{
+				Name: "test txn",
+			},
+			Replica: proto.Replica{
+				NodeID: 12345,
+			},
+		},
 	}
 
 	for i, test := range testCases {

--- a/proto/data.go
+++ b/proto/data.go
@@ -487,6 +487,10 @@ func (t *Transaction) Update(o *Transaction) {
 	t.CertainNodes = NodeList{Nodes: append(Int32Slice(nil),
 		o.CertainNodes.Nodes...)}
 	t.UpgradePriority(o.Priority)
+	if t.Writing && !o.Writing {
+		panic("r/w status regression")
+	}
+	t.Writing = o.Writing
 }
 
 // UpgradePriority sets transaction priority to the maximum of current

--- a/proto/data.pb.go
+++ b/proto/data.pb.go
@@ -531,7 +531,8 @@ type Transaction struct {
 	// txn_coord_sender, with brief comments referring here.
 	// See https://github.com/cockroachdb/cockroach/pull/221.
 	CertainNodes NodeList `protobuf:"bytes,12,opt,name=certain_nodes" json:"certain_nodes"`
-	// Writing is true when the Transaction is not read-only.
+	// Writing is true if the transaction has previously executed a successful
+	// write request, i.e. a request that may have left intents (across retries).
 	Writing          bool   `protobuf:"varint,13,opt" json:"Writing"`
 	XXX_unrecognized []byte `json:"-"`
 }

--- a/proto/data.proto
+++ b/proto/data.proto
@@ -231,7 +231,8 @@ message Transaction {
   // txn_coord_sender, with brief comments referring here.
   // See https://github.com/cockroachdb/cockroach/pull/221.
   optional NodeList certain_nodes = 12 [(gogoproto.nullable) = false];
-  // Writing is true when the Transaction is not read-only.
+  // Writing is true if the transaction has previously executed a successful
+  // write request, i.e. a request that may have left intents (across retries).
   optional bool Writing = 13 [(gogoproto.nullable) = false];
 }
 

--- a/storage/replica_command.go
+++ b/storage/replica_command.go
@@ -853,6 +853,7 @@ func (r *Replica) PushTxn(batch engine.Engine, ms *engine.MVCCStats, args proto.
 	}
 
 	// Persist the pushed transaction using zero timestamp for inline value.
+	reply.PusheeTxn.Writing = true // required; see comment on the proto
 	if err := engine.MVCCPutProto(batch, ms, key, proto.ZeroTimestamp, nil, reply.PusheeTxn); err != nil {
 		return reply, err
 	}

--- a/storage/replica_test.go
+++ b/storage/replica_test.go
@@ -1952,6 +1952,7 @@ func TestPushTxnUpgradeExistingTxn(t *testing.T) {
 		expTxn.Timestamp = test.expTS
 		expTxn.Status = proto.ABORTED
 		expTxn.LastHeartbeat = &test.startTS
+		expTxn.Writing = true // always set for physical txn table entries
 
 		if !reflect.DeepEqual(expTxn, reply.PusheeTxn) {
 			t.Errorf("unexpected push txn in trial %d; expected %+v, got %+v", i, expTxn, reply.PusheeTxn)


### PR DESCRIPTION
We have a field `Writing` on `proto.Transaction` which is set to true at `TxnCoordSender` when the first intent has been laid down (and which never flips back to `false` until the `Txn` ends).
`client.Txn`, on the other hand, has state `txn.haveTxnWrite` which tracks whether a write has been
sent or been queued for sending in the current **attempt**.

This change makes sure that we use `txn.Writing` to determine whether an `EndTransaction` call is necessary. Additionally, it ensures that if no such call is necessary, we don't send `EndTransaction` (which currently amounts to an error, and it is better to keep it that way to more reliably spot bugs). The latter actually requires `haveTxnWrite and Writing`; everything else just uses `Writing`.
