### PR TITLE
Added normalizeName and equalName.

### DIFF
--- a/GLOCKFILE
+++ b/GLOCKFILE
@@ -36,5 +36,6 @@ github.com/spf13/pflag 67cbc198fd11dab704b214c1e629a97af392c085
 github.com/tebeka/go2xunit d45000af2242dd0e7b8c7b07d82a1068adc5fd40
 golang.org/x/crypto cc04154d65fb9296747569b107cfd05380b1ea3e
 golang.org/x/net 8bfde94a845cb31000de3266ac83edbda58dab09
+golang.org/x/text d4cc1b1e16b49d6dafc4982403b40fe89c512cd5
 golang.org/x/tools d02228d1857b9f49cd0252788516ff5584266eb6
 gopkg.in/yaml.v1 9f9df34309c04878acc86042b16630b0f696e1de

--- a/build/devbase/deps
+++ b/build/devbase/deps
@@ -25,4 +25,6 @@ golang.org/x/crypto/bcrypt
 golang.org/x/crypto/blowfish
 golang.org/x/crypto/ssh/terminal
 golang.org/x/net/context
+golang.org/x/text/transform
+golang.org/x/text/unicode/norm
 gopkg.in/yaml.v1

--- a/sql/scan.go
+++ b/sql/scan.go
@@ -21,7 +21,6 @@ import (
 	"bytes"
 	"fmt"
 	"math"
-	"strings"
 
 	"github.com/cockroachdb/cockroach/client"
 	"github.com/cockroachdb/cockroach/proto"
@@ -130,9 +129,9 @@ func (n *scanNode) initFrom(p *planner, from parser.TableExprs) error {
 		// This is only kosher because we know that getAliasedDesc() succeeded.
 		qname := from[0].(*parser.AliasedTableExpr).Expr.(*parser.QualifiedName)
 		indexName := qname.Index()
-		if indexName != "" && !strings.EqualFold(n.desc.PrimaryIndex.Name, indexName) {
+		if indexName != "" && !equalName(n.desc.PrimaryIndex.Name, indexName) {
 			for i := range n.desc.Indexes {
-				if strings.EqualFold(n.desc.Indexes[i].Name, indexName) {
+				if equalName(n.desc.Indexes[i].Name, indexName) {
 					// Remove all but the matching index from the descriptor.
 					n.desc.Indexes = n.desc.Indexes[i : i+1]
 					n.index = &n.desc.Indexes[0]
@@ -251,7 +250,7 @@ func (n *scanNode) addRender(target parser.SelectExpr) error {
 				return fmt.Errorf("\"%s\" cannot be aliased", qname)
 			}
 			tableName := qname.Table()
-			if tableName != "" && !strings.EqualFold(n.desc.Alias, tableName) {
+			if tableName != "" && !equalName(n.desc.Alias, tableName) {
 				return fmt.Errorf("table \"%s\" not found", tableName)
 			}
 
@@ -583,7 +582,7 @@ func (v *qnameVisitor) Visit(expr parser.Expr) parser.Expr {
 	if desc != nil {
 		name := qname.Column()
 		for _, col := range v.visibleCols {
-			if !strings.EqualFold(name, col.Name) {
+			if !equalName(name, col.Name) {
 				continue
 			}
 			return v.getQVal(col)
@@ -602,7 +601,7 @@ func (v *qnameVisitor) getDesc(qname *parser.QualifiedName) *TableDescriptor {
 		qname.Base = parser.Name(v.desc.Alias)
 		return v.desc
 	}
-	if strings.EqualFold(v.desc.Alias, string(qname.Base)) {
+	if equalName(v.desc.Alias, string(qname.Base)) {
 		return v.desc
 	}
 	return nil


### PR DESCRIPTION
Database and table names are normalized to lowercase/NFC before being
encoded in name metadata keys. Names are now compared using equalName
instead of strings.EqualFold.

Fixes #2044.
