### PR TITLE
Replace the use of ParenExpr with a new DReference node.

### DIFF
--- a/sql/parser/eval.go
+++ b/sql/parser/eval.go
@@ -140,6 +140,12 @@ func (d dNull) String() string {
 	return "NULL"
 }
 
+// DReference holds a pointer to a Datum. It is used as a level of indirection
+// to replace QualifiedNames with a node whose value can change on each row.
+type DReference interface {
+	Datum() Datum
+}
+
 var (
 	boolType   = reflect.TypeOf(DBool(false))
 	intType    = reflect.TypeOf(DInt(0))
@@ -406,6 +412,9 @@ func EvalExpr(expr Expr) (Datum, error) {
 			tuple = append(tuple, d)
 		}
 		return tuple, nil
+
+	case DReference:
+		return t.Datum(), nil
 
 	case Datum:
 		return t, nil

--- a/sql/parser/walk.go
+++ b/sql/parser/walk.go
@@ -101,6 +101,9 @@ func WalkExpr(v Visitor, expr Expr) Expr {
 			t[i] = WalkExpr(v, t[i])
 		}
 
+	case DReference:
+		// Terminal node: nothing to do.
+
 	case Datum:
 		// Terminal node: nothing to do.
 


### PR DESCRIPTION
DReference has similar functionality to ParenExpr for qvalue, but allows
expression analysis after qualified name resolution to map that
DRereference nodes back to the column descriptor. This is necessary for
index selection which will analyze expressions after qualified name
resolution.
