### PR TITLE
Turn off buggy test for now.

### DIFF
--- a/acceptance/status_server_test.go
+++ b/acceptance/status_server_test.go
@@ -80,6 +80,7 @@ func checkNode(t *testing.T, client *http.Client, node *localcluster.Container, 
 // TestStatusServer starts up an N node cluster and tests the status server on
 // each node.
 func TestStatusServer(t *testing.T) {
+	t.Skipf("TODO(Bram): Test is flaky - fix it.")
 	l := localcluster.Create(*numNodes, stopper)
 	l.ForceLogging = true
 	l.Start()


### PR DESCRIPTION
This test fails occasionally (and too often for my liking).  Turning it off to keep the master build clean.
I'll fix it and reenable it.
