### PR TITLE
Tablify namespace and descriptor storage.

### DIFF
--- a/cli/kv.go
+++ b/cli/kv.go
@@ -300,7 +300,9 @@ func initScanArgs(args []string) (startKey, endKey proto.Key) {
 	if len(args) >= 2 {
 		endKey = proto.Key(unquoteArg(args[1], false))
 	} else {
-		endKey = proto.KeyMax
+		// Exclude table data keys by default. The user can explicitly request them
+		// by passing \xff\xff for the end key.
+		endKey = keys.TableDataPrefix
 	}
 	return startKey, endKey
 }

--- a/keys/constants.go
+++ b/keys/constants.go
@@ -158,14 +158,10 @@ var (
 	// DescIDGenerator is the global descriptor ID generator sequence used for
 	// table and namespace IDs.
 	DescIDGenerator = MakeKey(SystemPrefix, proto.Key("desc-idgen"))
-	// DescMetadataPrefix is the key prefix for all descriptor metadata.
-	DescMetadataPrefix = MakeKey(SystemPrefix, proto.Key("desc-"))
 	// NodeIDGenerator is the global node ID generator sequence.
 	NodeIDGenerator = MakeKey(SystemPrefix, proto.Key("node-idgen"))
 	// RangeIDGenerator is the global range ID generator sequence.
 	RangeIDGenerator = MakeKey(SystemPrefix, proto.Key("range-idgen"))
-	// NameMetadataPrefix is the key prefix for all name metadata.
-	NameMetadataPrefix = MakeKey(SystemPrefix, proto.Key("name-"))
 	// StoreIDGenerator is the global store ID generator sequence.
 	StoreIDGenerator = MakeKey(SystemPrefix, proto.Key("store-idgen"))
 	// RangeTreeRoot specifies the root range in the range tree.
@@ -177,7 +173,9 @@ var (
 	StatusStorePrefix = MakeKey(StatusPrefix, proto.Key("store-"))
 	// StatusNodePrefix stores all status info for nodes.
 	StatusNodePrefix = MakeKey(StatusPrefix, proto.Key("node-"))
-	// TableDataPrefix prefixes all Table data to aid in transitioning
-	// key:value data to Table data, and for ease of debugging.
-	TableDataPrefix = proto.Key("table-")
+
+	// TableDataPrefix prefixes all table data. It is specifically chosen to
+	// occur after the range of common user data prefixes so that tests which use
+	// those prefixes will not see table data.
+	TableDataPrefix = proto.Key("\xff")
 )

--- a/kv/dist_sender_server_test.go
+++ b/kv/dist_sender_server_test.go
@@ -260,7 +260,7 @@ func TestSingleRangeReverseScan(t *testing.T) {
 	// Case 3: Test proto.KeyMax
 	if rows, err := db.ReverseScan("g", proto.KeyMax, 0); err != nil {
 		t.Fatalf("unexpected error on ReverseScan: %s", err)
-	} else if l := len(rows); l != 2 {
+	} else if l := len(rows); l != 8 {
 		t.Errorf("expected 2 rows; got %d", l)
 	}
 	// Case 4: Test keys.SystemMax

--- a/server/node_test.go
+++ b/server/node_test.go
@@ -132,6 +132,12 @@ func TestBootstrapCluster(t *testing.T) {
 		proto.Key("\x00store-idgen"),
 		proto.Key("\x00user"),
 		proto.Key("\x00zone"),
+		proto.Key("\xff\t\x02\t\x01\bsystem\x00\x01\t\x03"),
+		proto.Key("\xff\t\x02\t\x01\t\x01descriptor\x00\x01\t\x03"),
+		proto.Key("\xff\t\x02\t\x01\t\x01namespace\x00\x01\t\x03"),
+		proto.Key("\xff\t\x03\t\x01\t\x01\t\x02"),
+		proto.Key("\xff\t\x03\t\x01\t\x02\t\x02"),
+		proto.Key("\xff\t\x03\t\x01\t\x03\t\x02"),
 	}
 	if !reflect.DeepEqual(keys, expectedKeys) {
 		t.Errorf("expected keys mismatch:\n%s\n  -- vs. -- \n\n%s",

--- a/sql/create_test.go
+++ b/sql/create_test.go
@@ -21,6 +21,7 @@ import (
 	"testing"
 
 	"github.com/cockroachdb/cockroach/keys"
+	"github.com/cockroachdb/cockroach/proto"
 	"github.com/cockroachdb/cockroach/sql"
 	"github.com/cockroachdb/cockroach/testutils"
 	"github.com/cockroachdb/cockroach/util/leaktest"
@@ -67,10 +68,11 @@ func TestDatabaseDescriptor(t *testing.T) {
 		t.Fatalf("expected descriptor ID == %d, got %d", expectedCounter, actual)
 	}
 
-	if kvs, err := kvDB.Scan(keys.NameMetadataPrefix, keys.NameMetadataPrefix.PrefixEnd(), 0); err != nil {
+	start := proto.Key(sql.MakeTablePrefix(sql.NamespaceTable.ID))
+	if kvs, err := kvDB.Scan(start, start.PrefixEnd(), 0); err != nil {
 		t.Fatal(err)
 	} else {
-		if a, e := len(kvs), 0; a != e {
+		if a, e := len(kvs), 3; a != e {
 			t.Fatalf("expected %d keys to have been written, found %d keys", e, a)
 		}
 	}

--- a/sql/delete_test.go
+++ b/sql/delete_test.go
@@ -55,7 +55,7 @@ INSERT INTO t.kv VALUES ('c', 'e'), ('a', 'c'), ('b', 'd');
 		t.Fatalf("TableDescriptor %q does not exist", nameKey)
 	}
 
-	descKey := gr.ValueBytes()
+	descKey := sql.MakeDescMetadataKey(sql.ID(gr.ValueInt()))
 	desc := sql.TableDescriptor{}
 	if err := kvDB.GetProto(descKey, &desc); err != nil {
 		t.Fatal(err)

--- a/sql/drop.go
+++ b/sql/drop.go
@@ -59,7 +59,8 @@ func (p *planner) DropTable(n *parser.DropTable) (planNode, error) {
 		}
 
 		tableDesc := TableDescriptor{}
-		if err := p.txn.GetProto(gr.ValueBytes(), &tableDesc); err != nil {
+		descKey := MakeDescMetadataKey(ID(gr.ValueInt()))
+		if err := p.txn.GetProto(descKey, &tableDesc); err != nil {
 			return nil, err
 		}
 		if err := tableDesc.Validate(); err != nil {
@@ -75,7 +76,6 @@ func (p *planner) DropTable(n *parser.DropTable) (planNode, error) {
 		}
 
 		// Delete table descriptor
-		descKey := gr.ValueBytes()
 		b := &client.Batch{}
 		b.Del(descKey)
 		b.Del(nameKey)
@@ -113,7 +113,7 @@ func (p *planner) DropDatabase(n *parser.DropDatabase) (planNode, error) {
 		return nil, fmt.Errorf("database %q does not exist", n.Name)
 	}
 
-	descKey := gr.ValueBytes()
+	descKey := MakeDescMetadataKey(ID(gr.ValueInt()))
 	desc := DatabaseDescriptor{}
 	if err := p.txn.GetProto(descKey, &desc); err != nil {
 		return nil, err

--- a/sql/drop_test.go
+++ b/sql/drop_test.go
@@ -51,7 +51,7 @@ INSERT INTO t.kv VALUES ('c', 'e'), ('a', 'c'), ('b', 'd');
 		t.Fatalf("TableDescriptor %q does not exist", nameKey)
 	}
 
-	descKey := gr.ValueBytes()
+	descKey := sql.MakeDescMetadataKey(sql.ID(gr.ValueInt()))
 	desc := sql.TableDescriptor{}
 	if err := kvDB.GetProto(descKey, &desc); err != nil {
 		t.Fatal(err)
@@ -113,7 +113,7 @@ INSERT INTO t.kv VALUES ('c', 'e'), ('a', 'c'), ('b', 'd');
 	if !r.Exists() {
 		t.Fatalf(`database "t" does not exist`)
 	}
-	dbDescKey := r.ValueBytes()
+	dbDescKey := sql.MakeDescMetadataKey(sql.ID(r.ValueInt()))
 	dbDesc := sql.DatabaseDescriptor{}
 	if err := kvDB.GetProto(dbDescKey, &dbDesc); err != nil {
 		t.Fatal(err)
@@ -127,7 +127,7 @@ INSERT INTO t.kv VALUES ('c', 'e'), ('a', 'c'), ('b', 'd');
 	if !gr.Exists() {
 		t.Fatalf(`table "kv" does not exist`)
 	}
-	tbDescKey := gr.ValueBytes()
+	tbDescKey := sql.MakeDescMetadataKey(sql.ID(gr.ValueInt()))
 	tbDesc := sql.TableDescriptor{}
 	if err := kvDB.GetProto(tbDescKey, &tbDesc); err != nil {
 		t.Fatal(err)

--- a/sql/insert_test.go
+++ b/sql/insert_test.go
@@ -57,7 +57,7 @@ INSERT INTO t.kv VALUES ('c', 'e'), ('a', 'c'), ('b', 'd');
 		t.Fatalf("TableDescriptor %q does not exist", nameKey)
 	}
 
-	descKey := gr.ValueBytes()
+	descKey := sql.MakeDescMetadataKey(sql.ID(gr.ValueInt()))
 	desc := sql.TableDescriptor{}
 	if err := kvDB.GetProto(descKey, &desc); err != nil {
 		t.Fatal(err)

--- a/sql/keys.go
+++ b/sql/keys.go
@@ -66,21 +66,27 @@ func equalName(a, b string) bool {
 	return normalizeName(a) == normalizeName(b)
 }
 
-// MakeNameMetadataKey returns the key for the name.
+// MakeNameMetadataKey returns the key for the name. Pass name == "" in order
+// to generate the prefix key to use to scan over all of the names for the
+// specified parentID.
 func MakeNameMetadataKey(parentID ID, name string) proto.Key {
 	name = normalizeName(name)
-	k := make([]byte, 0, len(keys.NameMetadataPrefix)+encoding.MaxUvarintSize+len(name))
-	k = append(k, keys.NameMetadataPrefix...)
+	k := MakeTablePrefix(NamespaceTable.ID)
+	k = encoding.EncodeUvarint(k, uint64(NamespaceTable.PrimaryIndex.ID))
 	k = encoding.EncodeUvarint(k, uint64(parentID))
-	k = append(k, name...)
+	if name != "" {
+		k = encoding.EncodeBytes(k, []byte(name))
+		k = encoding.EncodeUvarint(k, uint64(NamespaceTable.Columns[2].ID))
+	}
 	return k
 }
 
 // MakeDescMetadataKey returns the key for the descriptor.
 func MakeDescMetadataKey(descID ID) proto.Key {
-	k := make([]byte, 0, len(keys.DescMetadataPrefix)+encoding.MaxUvarintSize)
-	k = append(k, keys.DescMetadataPrefix...)
+	k := MakeTablePrefix(DescriptorTable.ID)
+	k = encoding.EncodeUvarint(k, uint64(DescriptorTable.PrimaryIndex.ID))
 	k = encoding.EncodeUvarint(k, uint64(descID))
+	k = encoding.EncodeUvarint(k, uint64(DescriptorTable.Columns[1].ID))
 	return k
 }
 

--- a/sql/keys_test.go
+++ b/sql/keys_test.go
@@ -47,9 +47,9 @@ func TestKeyAddress(t *testing.T) {
 	testCases := []struct {
 		key, expAddress proto.Key
 	}{
-		{MakeNameMetadataKey(0, "foo"), proto.Key("\x00name-\bfoo")},
-		{MakeNameMetadataKey(0, "BAR"), proto.Key("\x00name-\bbar")},
-		{MakeDescMetadataKey(123), proto.Key("\x00desc-\t{")},
+		{MakeNameMetadataKey(0, "foo"), proto.Key("\xff\t\x02\t\x01\bfoo\x00\x01\t\x03")},
+		{MakeNameMetadataKey(0, "BAR"), proto.Key("\xff\t\x02\t\x01\bbar\x00\x01\t\x03")},
+		{MakeDescMetadataKey(123), proto.Key("\xff\t\x03\t\x01\t{\t\x02")},
 	}
 	for i, test := range testCases {
 		result := keys.KeyAddress(test.key)

--- a/sql/rename.go
+++ b/sql/rename.go
@@ -55,7 +55,7 @@ func (p *planner) RenameDatabase(n *parser.RenameDatabase) (planNode, error) {
 	dbDesc.SetName(string(n.NewName))
 
 	b := client.Batch{}
-	b.CPut(databaseKey{string(n.NewName)}.Key(), descKey, nil)
+	b.CPut(databaseKey{string(n.NewName)}.Key(), dbDesc.GetID(), nil)
 	b.Put(descKey, dbDesc)
 	b.Del(databaseKey{string(n.Name)}.Key())
 
@@ -125,7 +125,7 @@ func (p *planner) RenameTable(n *parser.RenameTable) (planNode, error) {
 
 	b := client.Batch{}
 	b.Put(descKey, tableDesc)
-	b.CPut(newTbKey, descKey, nil)
+	b.CPut(newTbKey, tableDesc.GetID(), nil)
 	b.Del(tbKey)
 	if err := p.txn.Run(&b); err != nil {
 		if _, ok := err.(*proto.ConditionFailedError); ok {

--- a/sql/table.go
+++ b/sql/table.go
@@ -44,7 +44,11 @@ func (tk tableKey) Name() string {
 
 func makeTableDesc(p *parser.CreateTable) (TableDescriptor, error) {
 	desc := TableDescriptor{}
+	if err := p.Table.NormalizeTableName(""); err != nil {
+		return desc, err
+	}
 	desc.Name = p.Table.Table()
+
 	for _, def := range p.Defs {
 		switch d := def.(type) {
 		case *parser.ColumnTableDef:
@@ -147,7 +151,7 @@ func (p *planner) getTableNames(dbDesc *DatabaseDescriptor) (parser.QualifiedNam
 
 	var qualifiedNames parser.QualifiedNames
 	for _, row := range sr {
-		tableName := string(bytes.TrimPrefix(row.Key, prefix))
+		_, tableName := encoding.DecodeBytes(bytes.TrimPrefix(row.Key, prefix), nil)
 		qname := &parser.QualifiedName{
 			Base:     parser.Name(dbDesc.Name),
 			Indirect: parser.Indirection{parser.NameIndirection(tableName)},

--- a/sql/testdata/database
+++ b/sql/testdata/database
@@ -15,6 +15,7 @@ SHOW DATABASES
 ----
 Database
 a
+system
 test
 
 statement ok
@@ -29,6 +30,7 @@ SHOW DATABASES
 a
 b
 c
+system
 test
 
 statement ok
@@ -65,6 +67,7 @@ SHOW DATABASES
 Database
 a
 c
+system
 test
 
 statement ok

--- a/sql/testdata/rename_database
+++ b/sql/testdata/rename_database
@@ -1,6 +1,7 @@
 query T
 SHOW DATABASES
 ----
+system
 test
 
 query TTT
@@ -38,6 +39,7 @@ SHOW GRANTS ON DATABASE test
 query T
 SHOW DATABASES
 ----
+system
 u
 
 # check the name in descriptor is also changed
@@ -83,5 +85,6 @@ ALTER DATABASE t RENAME TO v
 query T
 SHOW DATABASES
 ----
+system
 t
 u

--- a/sql/testdata/system
+++ b/sql/testdata/system
@@ -1,0 +1,35 @@
+query T
+SHOW DATABASES
+----
+system
+test
+
+query T
+SHOW TABLES FROM system
+----
+descriptor
+namespace
+
+query ITTB
+EXPLAIN (DEBUG) SELECT * FROM system.namespace
+----
+0 /namespace/primary/0/'system'/id     1    true
+1 /namespace/primary/0/'test'/id       1000 true
+2 /namespace/primary/1/'descriptor'/id 3    true
+3 /namespace/primary/1/'namespace'/id  2    true
+
+query ITI
+SELECT * FROM system.namespace
+----
+0 system     1
+0 test       1000
+1 descriptor 3
+1 namespace  2
+
+query I
+SELECT id FROM system.descriptor
+----
+1
+2
+3
+1000

--- a/sql/update_test.go
+++ b/sql/update_test.go
@@ -57,7 +57,7 @@ INSERT INTO t.kv VALUES ('c', 'e'), ('a', 'c'), ('b', 'd');
 		t.Fatalf("TableDescriptor %q does not exist", nameKey)
 	}
 
-	descKey := gr.ValueBytes()
+	descKey := sql.MakeDescMetadataKey(sql.ID(gr.ValueInt()))
 	desc := sql.TableDescriptor{}
 	if err := kvDB.GetProto(descKey, &desc); err != nil {
 		t.Fatal(err)

--- a/storage/gc_queue_test.go
+++ b/storage/gc_queue_test.go
@@ -234,7 +234,7 @@ func TestGCQueueProcess(t *testing.T) {
 		{key8, ts2},
 	}
 	// Read data directly from engine to avoid intent errors from MVCC.
-	kvs, err := engine.Scan(tc.store.Engine(), engine.MVCCEncodeKey(key1), engine.MVCCEncodeKey(proto.KeyMax), 0)
+	kvs, err := engine.Scan(tc.store.Engine(), engine.MVCCEncodeKey(key1), engine.MVCCEncodeKey(keys.TableDataPrefix), 0)
 	if err != nil {
 		t.Fatal(err)
 	}


### PR DESCRIPTION
Removed keys.{Desc,Name}MetadataPrefix. Changed keys.TableDataPrefix so
that it lies outside of the "normal" range of user data keys.

Added namespace and descriptor tables and initialize a few keys so that
they can be used to locate themselves. The namespace table values now
contain the integer descriptor ID instead of the former descriptor key.

Fixed various tests which had assumptions broken by the above changes.

Fixes #2113.
