### PR TITLE
Enforce restricted privileges on system objects

### DIFF
--- a/sql/privilege/privilege.go
+++ b/sql/privilege/privilege.go
@@ -42,6 +42,11 @@ const (
 	UPDATE
 )
 
+// Mask returns the bitmask for a given privilege.
+func (k Kind) Mask() uint32 {
+	return 1 << k
+}
+
 // ByValue is just an array of privilege kinds sorted by value.
 var ByValue = [...]Kind{
 	ALL, CREATE, DROP, GRANT, SELECT, INSERT, DELETE, UPDATE,
@@ -92,7 +97,7 @@ func (pl List) SortedString() string {
 func (pl List) ToBitField() uint32 {
 	var ret uint32
 	for _, p := range pl {
-		ret |= (1 << p)
+		ret |= p.Mask()
 	}
 	return ret
 }
@@ -103,7 +108,7 @@ func (pl List) ToBitField() uint32 {
 func ListFromBitField(m uint32) List {
 	ret := List{}
 	for _, p := range ByValue {
-		if m&(1<<p) != 0 {
+		if m&p.Mask() != 0 {
 			ret = append(ret, p)
 		}
 	}

--- a/sql/rename.go
+++ b/sql/rename.go
@@ -54,6 +54,10 @@ func (p *planner) RenameDatabase(n *parser.RenameDatabase) (planNode, error) {
 	descKey := MakeDescMetadataKey(dbDesc.GetID())
 	dbDesc.SetName(string(n.NewName))
 
+	if err := dbDesc.Validate(); err != nil {
+		return nil, err
+	}
+
 	b := client.Batch{}
 	b.CPut(databaseKey{string(n.NewName)}.Key(), dbDesc.GetID(), nil)
 	b.Put(descKey, dbDesc)
@@ -135,6 +139,10 @@ func (p *planner) RenameTable(n *parser.RenameTable) (planNode, error) {
 
 	newTbKey := tableKey{targetDbDesc.ID, n.NewName.Table()}.Key()
 	descKey := MakeDescMetadataKey(tableDesc.GetID())
+
+	if err := tableDesc.Validate(); err != nil {
+		return nil, err
+	}
 
 	b := client.Batch{}
 	b.Put(descKey, tableDesc)

--- a/sql/structured.go
+++ b/sql/structured.go
@@ -42,10 +42,14 @@ const (
 	// PrimaryKeyIndexName is the name of the index for the primary key.
 	PrimaryKeyIndexName = "primary"
 	// MaxReservedDescID is the maximum reserved descriptor ID.
+	// All objects with ID <= MaxReservedDescID are system object
+	// with special rules.
 	MaxReservedDescID ID = 999
 	// RootNamespaceID is the ID of the root namespace.
 	RootNamespaceID ID = 0
 
+	// System IDs should be kept in sync with IsSystem methods on
+	// DatabaseDescriptor and TableDescriptor.
 	// systemDatabaseID is the ID of the system database.
 	systemDatabaseID ID = 1
 	// namespaceTableID is the ID of the namespace table.
@@ -59,11 +63,9 @@ var ErrMissingPrimaryKey = errors.New("table must contain a primary key")
 
 // SystemDB is the descriptor for the system database.
 var SystemDB = DatabaseDescriptor{
-	Name: "system",
-	ID:   systemDatabaseID,
-	// TODO(marc): The system database and namespace and descriptor tables should
-	// be read-only by everyone (including root).
-	Privileges: NewDefaultDatabasePrivilegeDescriptor(),
+	Name:       "system",
+	ID:         systemDatabaseID,
+	Privileges: NewSystemObjectPrivilegeDescriptor(),
 }
 
 // NamespaceTable is the descriptor for the namespace table.
@@ -110,6 +112,11 @@ CREATE TABLE system.descriptor (
 	if err := DescriptorTable.AllocateIDs(); err != nil {
 		log.Fatal(err)
 	}
+}
+
+// IsSystemID returns true if this ID is reserved for system objects.
+func IsSystemID(id ID) bool {
+	return id > 0 && id <= MaxReservedDescID
 }
 
 func validateName(name, typ string) error {
@@ -178,11 +185,13 @@ func (desc *TableDescriptor) AllocateIDs() error {
 		}
 	}
 
-	// This is sort of ugly. We want to make sure the descriptor is valid, except
-	// for checking the table ID. So we whack in a valid table ID for the
-	// duration of the call to Validate.
+	// This is sort of ugly. If the descriptor does not have an ID, we hack one in
+	// to pass the table ID check. We use a non-reserved ID, reserved ones being set
+	// before AllocateIDs.
 	savedID := desc.ID
-	desc.ID = 1
+	if desc.ID == 0 {
+		desc.ID = MaxReservedDescID + 1
+	}
 	err := desc.Validate()
 	desc.ID = savedID
 	return err
@@ -284,7 +293,7 @@ func (desc *TableDescriptor) Validate() error {
 		}
 	}
 	// Validate the privilege descriptor.
-	return desc.Privileges.Validate()
+	return desc.Privileges.Validate(IsSystemID(desc.GetID()))
 }
 
 // FindColumnByName finds the column with specified name.
@@ -355,5 +364,5 @@ func (desc *DatabaseDescriptor) Validate() error {
 		return fmt.Errorf("invalid database ID 0")
 	}
 	// Validate the privilege descriptor.
-	return desc.Privileges.Validate()
+	return desc.Privileges.Validate(IsSystemID(desc.GetID()))
 }

--- a/sql/structured_test.go
+++ b/sql/structured_test.go
@@ -29,7 +29,7 @@ func TestAllocateIDs(t *testing.T) {
 	defer leaktest.AfterTest(t)
 
 	desc := sql.TableDescriptor{
-		ID:   1,
+		ID:   sql.MaxReservedDescID + 1,
 		Name: "foo",
 		Columns: []sql.ColumnDescriptor{
 			{Name: "a"},
@@ -46,7 +46,7 @@ func TestAllocateIDs(t *testing.T) {
 	}
 
 	expected := sql.TableDescriptor{
-		ID:   1,
+		ID:   sql.MaxReservedDescID + 1,
 		Name: "foo",
 		Columns: []sql.ColumnDescriptor{
 			{ID: 1, Name: "a"},

--- a/sql/testdata/grant_database
+++ b/sql/testdata/grant_database
@@ -10,7 +10,7 @@ a        root ALL
 statement error TODO\(marc\): implement SHOW GRANT with no targets
 SHOW GRANTS
 
-statement error root user does not have ALL privileges
+statement error user root does not have ALL privileges
 REVOKE SELECT ON DATABASE a FROM root
 
 statement ok

--- a/sql/testdata/system
+++ b/sql/testdata/system
@@ -33,3 +33,64 @@ SELECT id FROM system.descriptor
 2
 3
 1000
+
+query TTT
+SHOW GRANTS ON DATABASE system
+----
+system root GRANT,SELECT
+
+query TTT
+SHOW GRANTS ON system.namespace
+----
+namespace root GRANT,SELECT
+
+query TTT
+SHOW GRANTS ON system.descriptor
+----
+descriptor root GRANT,SELECT
+
+# Non-root users can have privileges on system objects, but limited to GRANT, SELECT.
+statement error user testuser must not have ALL privileges on system objects
+GRANT ALL ON DATABASE system TO testuser
+
+statement error user testuser must not have INSERT privileges on system objects
+GRANT GRANT, SELECT, INSERT ON DATABASE system TO testuser
+
+statement ok
+GRANT GRANT, SELECT ON DATABASE system TO testuser
+
+statement error user testuser must not have ALL privileges on system objects
+GRANT ALL ON system.namespace TO testuser
+
+statement error user testuser must not have INSERT privileges on system objects
+GRANT GRANT, SELECT, INSERT ON system.namespace TO testuser
+
+statement ok
+GRANT GRANT, SELECT ON system.namespace TO testuser
+
+statement ok
+GRANT SELECT ON system.descriptor TO testuser
+
+statement error user root must have GRANT, SELECT privileges on system objects
+GRANT ALL ON DATABASE system TO root
+
+statement error user root must not have INSERT, DELETE privileges on system objects
+GRANT DELETE, INSERT ON DATABASE system TO root
+
+statement error user root must have GRANT, SELECT privileges on system objects
+GRANT ALL ON system.namespace TO root
+
+statement error user root must not have INSERT, DELETE privileges on system objects
+GRANT DELETE, INSERT ON system.descriptor TO root
+
+statement error user root must have GRANT, SELECT privileges on system objects
+GRANT ALL ON system.descriptor TO root
+
+statement error user root must have GRANT, SELECT privileges on system objects
+REVOKE GRANT ON DATABASE system FROM root
+
+statement error user root must have GRANT, SELECT privileges on system objects
+REVOKE GRANT ON system.namespace FROM root
+
+statement error user root does not have privileges
+REVOKE ALL ON system.namespace FROM root


### PR DESCRIPTION
Privileges on system objects (database system and its tables)
require exactly GRANT, SELECT for root.

Other users can have privileges, but no more than GRANT and SELECT.

This effectively makes system objects read-only to root by default,
while allowing read-only access to anyone else through the GRANT call.
