### PR TITLE
Normalize expressions.

### DIFF
--- a/sql/parser/eval.go
+++ b/sql/parser/eval.go
@@ -450,13 +450,12 @@ func evalAndExpr(expr *AndExpr) (Datum, error) {
 	if err != nil {
 		return DNull, err
 	}
-	if left == DNull {
-		return DNull, nil
-	}
-	if v, err := getBool(left); err != nil {
-		return DNull, err
-	} else if !v {
-		return v, nil
+	if left != DNull {
+		if v, err := getBool(left); err != nil {
+			return DNull, err
+		} else if !v {
+			return v, nil
+		}
 	}
 	right, err := EvalExpr(expr.Right)
 	if err != nil {
@@ -470,7 +469,7 @@ func evalAndExpr(expr *AndExpr) (Datum, error) {
 	} else if !v {
 		return v, nil
 	}
-	return DBool(true), nil
+	return left, nil
 }
 
 func evalOrExpr(expr *OrExpr) (Datum, error) {

--- a/sql/parser/eval_test.go
+++ b/sql/parser/eval_test.go
@@ -66,7 +66,7 @@ func TestEvalExpr(t *testing.T) {
 		{`true AND false`, `false`},
 		{`true AND NULL`, `NULL`},
 		{`NULL AND true`, `NULL`},
-		{`NULL AND false`, `NULL`},
+		{`NULL AND false`, `false`},
 		{`NULL AND NULL`, `NULL`},
 		{`false OR true`, `true`},
 		{`false OR NULL`, `NULL`},

--- a/sql/parser/normalize.go
+++ b/sql/parser/normalize.go
@@ -1,0 +1,359 @@
+// Copyright 2015 The Cockroach Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+// implied. See the License for the specific language governing
+// permissions and limitations under the License. See the AUTHORS file
+// for names of contributors.
+//
+// Author: Peter Mattis (peter@cockroachlabs.com)
+
+package parser
+
+import "fmt"
+
+// NormalizeExpr normalizes an expression, simplifying where possible, but
+// guaranteeing that the result of evaluating the expression is
+// unchanged. Example normalizations:
+//
+//   (a)                   -> a
+//   ROW(a, b, c)          -> (a, b, c)
+//   a = 1 + 1             -> a = 2
+//   a + 1 = 2             -> a = 1
+//   a BETWEEN b AND c     -> (a >= b) AND (a <= c)
+//   a NOT BETWEEN b AND c -> (a < b) OR (a > c)
+func NormalizeExpr(expr Expr) (Expr, error) {
+	v := normalizeVisitor{}
+	expr = WalkExpr(&v, expr)
+	return expr, v.err
+}
+
+type normalizeVisitor struct {
+	err error
+}
+
+var _ Visitor = &normalizeVisitor{}
+
+func (v *normalizeVisitor) Visit(expr Expr, pre bool) (Visitor, Expr) {
+	if v.err != nil {
+		return nil, expr
+	}
+
+	if pre {
+		switch t := expr.(type) {
+		case *ParenExpr:
+			// (a) -> a
+			return v.Visit(t.Expr, true)
+
+		case Row:
+			// ROW(a, b, c) -> (a, b, c)
+			return v.Visit(Tuple(t), true)
+
+		case *RangeCond:
+			return v.Visit(v.normalizeRangeCond(t), true)
+		}
+
+		return v, expr
+	}
+
+	// Evaluate constant expressions.
+	if IsConst(expr) {
+		expr, v.err = EvalExpr(expr)
+		if v.err != nil {
+			return nil, expr
+		}
+	} else {
+		switch t := expr.(type) {
+		case *AndExpr:
+			return v.normalizeAndExpr(t)
+
+		case *OrExpr:
+			return v.normalizeOrExpr(t)
+
+		case *ComparisonExpr:
+			return v.normalizeComparisonExpr(t)
+		}
+	}
+	return v, expr
+}
+
+func (v *normalizeVisitor) normalizeRangeCond(n *RangeCond) Expr {
+	var expr Expr
+	if n.Not {
+		// "a NOT BETWEEN b AND c" -> "a < b OR a > c"
+		expr = &OrExpr{
+			Left: &ComparisonExpr{
+				Operator: LT,
+				Left:     n.Left,
+				Right:    n.From,
+			},
+			Right: &ComparisonExpr{
+				Operator: GT,
+				Left:     n.Left,
+				Right:    n.To,
+			},
+		}
+	} else {
+		// "a BETWEEN b AND c" -> "a >= b AND a <= c"
+		expr = &AndExpr{
+			Left: &ComparisonExpr{
+				Operator: GE,
+				Left:     n.Left,
+				Right:    n.From,
+			},
+			Right: &ComparisonExpr{
+				Operator: LE,
+				Left:     n.Left,
+				Right:    n.To,
+			},
+		}
+	}
+	return expr
+}
+
+func (v *normalizeVisitor) normalizeAndExpr(n *AndExpr) (Visitor, Expr) {
+	// Use short-circuit evaluation to simplify AND expressions.
+	if IsConst(n.Left) {
+		n.Left, v.err = EvalExpr(n.Left)
+		if v.err != nil {
+			return nil, n
+		}
+		if n.Left != DNull {
+			if d, err := getBool(n.Left.(Datum)); err != nil {
+				return v, DNull
+			} else if !d {
+				return v, n.Left
+			}
+			return v, n.Right
+		}
+		return v, n
+	}
+	if IsConst(n.Right) {
+		n.Right, v.err = EvalExpr(n.Right)
+		if v.err != nil {
+			return nil, n
+		}
+		if n.Right != DNull {
+			if d, err := getBool(n.Right.(Datum)); err != nil {
+				return v, DNull
+			} else if d {
+				return v, n.Left
+			}
+			return v, n.Right
+		}
+		return v, n
+	}
+	return v, n
+}
+
+func (v *normalizeVisitor) normalizeOrExpr(n *OrExpr) (Visitor, Expr) {
+	// Use short-circuit evaluation to simplify OR expressions.
+	if IsConst(n.Left) {
+		n.Left, v.err = EvalExpr(n.Left)
+		if v.err != nil {
+			return nil, n
+		}
+		if n.Left != DNull {
+			if d, err := getBool(n.Left.(Datum)); err != nil {
+				return v, DNull
+			} else if d {
+				return v, n.Left
+			}
+			return v, n.Right
+		}
+	}
+	if IsConst(n.Right) {
+		n.Right, v.err = EvalExpr(n.Right)
+		if v.err != nil {
+			return nil, n
+		}
+		if n.Right != DNull {
+			if d, err := getBool(n.Right.(Datum)); err != nil {
+				return v, DNull
+			} else if d {
+				return v, n.Right
+			}
+			return v, n.Left
+		}
+	}
+	return v, n
+}
+
+func (v *normalizeVisitor) normalizeComparisonExpr(n *ComparisonExpr) (Visitor, Expr) {
+	// We want var nodes (DReference, QualifiedName, etc) to be immediate
+	// children of the comparison expression and not second or third
+	// children. That is, we want trees that look like:
+	//
+	//    cmp            cmp
+	//   /   \          /   \
+	//  a    op        op    a
+	//      /  \      /  \
+	//     1    2    1    2
+	//
+	// Not trees that look like:
+	//
+	//      cmp          cmp        cmp          cmp
+	//     /   \        /   \      /   \        /   \
+	//    op    2      op    2    1    op      1    op
+	//   /  \         /  \            /  \         /  \
+	//  a    1       1    a          a    2       2    a
+
+	switch n.Operator {
+	case EQ, GE, GT, LE, LT:
+		break
+	default:
+		return v, n
+	}
+
+	// We loop attempting to simplify the comparison expression. As a
+	// pre-condition, we know there is at least one variable in the expression
+	// tree or we would not have entered this code path.
+	for {
+		if IsConst(n.Left) {
+			switch n.Right.(type) {
+			case *BinaryExpr, DReference, *ExistsExpr, *QualifiedName, *Subquery, ValArg:
+				break
+			default:
+				return v, n
+			}
+			// The left side is const and the right side is a binary expression or a
+			// variable. Flip the comparison op so that the right side is const and
+			// the left side is a binary expression or variable.
+			n.Operator = invertComparisonOp(n.Operator)
+			n.Left, n.Right = n.Right, n.Left
+		} else if !IsConst(n.Right) {
+			return v, n
+		}
+
+		left, ok := n.Left.(*BinaryExpr)
+		if !ok {
+			return v, n
+		}
+
+		// The right is const and the left side is a binary expression. Rotate the
+		// comparison combining portions that are const.
+
+		switch {
+		case IsConst(left.Right):
+			//        cmp          cmp
+			//       /   \        /   \
+			//    [+-/]   2  ->  a   [-+*]
+			//   /     \            /     \
+			//  a       1          2       1
+
+			switch left.Operator {
+			case Plus, Minus, Div:
+				n.Left = left.Left
+				left.Left = n.Right
+				if left.Operator == Plus {
+					left.Operator = Minus
+				} else if left.Operator == Minus {
+					left.Operator = Plus
+				} else {
+					left.Operator = Mult
+				}
+				n.Right, v.err = EvalExpr(left)
+				if v.err != nil {
+					return nil, nil
+				}
+				if !isVar(n.Left) {
+					// Continue as long as the left side of the comparison is not a
+					// variable.
+					continue
+				}
+
+				// TODO(pmattis): Handle Div?
+			}
+
+		case IsConst(left.Left):
+			//       cmp              cmp
+			//      /   \            /   \
+			//    [+-]   2  ->     [+-]   a
+			//   /    \           /    \
+			//  1      a         1      2
+
+			switch left.Operator {
+			case Plus, Minus:
+				left.Right, n.Right = n.Right, left.Right
+				if left.Operator == Plus {
+					left.Operator = Minus
+					left.Left, left.Right = left.Right, left.Left
+				} else {
+					n.Operator = invertComparisonOp(n.Operator)
+				}
+				n.Left, v.err = EvalExpr(left)
+				if v.err != nil {
+					return nil, nil
+				}
+				n.Left, n.Right = n.Right, n.Left
+				if !isVar(n.Left) {
+					// Continue as long as the left side of the comparison is not a
+					// variable.
+					continue
+				}
+
+				// TODO(pmattis): Handle Div?
+			}
+		}
+
+		// We've run out of work to do.
+		return v, n
+	}
+}
+
+func invertComparisonOp(op ComparisonOp) ComparisonOp {
+	switch op {
+	case EQ:
+		return EQ
+	case GE:
+		return LE
+	case GT:
+		return LT
+	case LE:
+		return GE
+	case LT:
+		return GT
+	default:
+		panic(fmt.Sprintf("unable to invert: %s", op))
+	}
+}
+
+type isConstVisitor struct {
+	isConst bool
+}
+
+var _ Visitor = &isConstVisitor{}
+
+func (v *isConstVisitor) Visit(expr Expr, pre bool) (Visitor, Expr) {
+	if pre && v.isConst {
+		switch expr.(type) {
+		case DReference, *ExistsExpr, *QualifiedName, *Subquery, ValArg:
+			v.isConst = false
+			return nil, expr
+		}
+	}
+	return v, expr
+}
+
+// IsConst returns true if the expression contains only constant values
+// (i.e. it does not contain a DReference).
+func IsConst(expr Expr) bool {
+	v := isConstVisitor{isConst: true}
+	expr = WalkExpr(&v, expr)
+	return v.isConst
+}
+
+func isVar(expr Expr) bool {
+	switch expr.(type) {
+	case DReference, *ExistsExpr, *QualifiedName, *Subquery, ValArg:
+		return true
+	}
+	return false
+}

--- a/sql/parser/normalize_test.go
+++ b/sql/parser/normalize_test.go
@@ -1,0 +1,84 @@
+// Copyright 2015 The Cockroach Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+// implied. See the License for the specific language governing
+// permissions and limitations under the License. See the AUTHORS file
+// for names of contributors.
+//
+// Author: Peter Mattis (peter@cockroachlabs.com)
+
+package parser
+
+import "testing"
+
+func TestNormalizeExpr(t *testing.T) {
+	testData := []struct {
+		expr     string
+		expected string
+	}{
+		{`(a)`, `a`},
+		{`((((a))))`, `a`},
+		{`ROW(a)`, `(a)`},
+		{`a BETWEEN b AND c`, `a >= b AND a <= c`},
+		{`a NOT BETWEEN b AND c`, `a < b OR a > c`},
+		{`1+1`, `2`},
+		{`(1+1,2+2,3+3)`, `(2, 4, 6)`},
+		{`a+(1+1)`, `a + 2`},
+		{`1+1+a`, `2 + a`},
+		{`a=1+1`, `a = 2`},
+		{`a=1+(2*3)-4`, `a = 3`},
+		{`true OR a`, `true`},
+		{`false OR a`, `a`},
+		{`NULL OR a`, `NULL OR a`},
+		{`a OR true`, `true`},
+		{`a OR false`, `a`},
+		{`a OR NULL`, `a OR NULL`},
+		{`true AND a`, `a`},
+		{`false AND a`, `false`},
+		{`NULL AND a`, `NULL AND a`},
+		{`a AND true`, `a`},
+		{`a AND false`, `false`},
+		{`a AND NULL`, `a AND NULL`},
+		{`1 IN (1, 2, 3)`, `true`},
+		{`1 IN (1, 2, a)`, `1 IN (1, 2, a)`},
+		{`a<1`, `a < 1`},
+		{`1>a`, `a < 1`},
+		{`(a+1)=2`, `a = 1`},
+		{`(a-1)>=2`, `a >= 3`},
+		{`(1+a)<=2`, `a <= 1`},
+		{`(1-a)>2`, `a < -1`},
+		{`2<(a+1)`, `a > 1`},
+		{`2>(a-1)`, `a < 3`},
+		{`2<(1+a)`, `a > 1`},
+		{`2>(1-a)`, `a > -1`},
+		{`(a+(1+1))=2`, `a = 0`},
+		{`((a+1)+1)=2`, `a = 0`},
+		{`a+1+1=2`, `a = 0`},
+		{`1+1>=(b+c)`, `b + c <= 2`},
+		{`b+c<=1+1`, `b + c <= 2`},
+		{`a/2=1`, `a = 2`},
+		{`1=a/2`, `a = 2`},
+	}
+	for _, d := range testData {
+		q, err := Parse("SELECT " + d.expr)
+		if err != nil {
+			t.Fatalf("%s: %v", d.expr, err)
+		}
+		expr := q[0].(*Select).Exprs[0].Expr
+		r, err := NormalizeExpr(expr)
+		if err != nil {
+			t.Fatalf("%s: %v", d.expr, err)
+		}
+		if s := r.String(); d.expected != s {
+			t.Errorf("%s: expected %s, but found %s", d.expr, d.expected, s)
+		}
+	}
+}

--- a/sql/parser/walk.go
+++ b/sql/parser/walk.go
@@ -21,14 +21,17 @@ import "fmt"
 
 // The Visitor Visit method is invoked for each Expr node encountered by
 // WalkExpr. The returned Expr replaces the pointer to the visited expression
-// in the parent node and can be used for rewriting expressions.
+// in the parent node and can be used for rewriting expressions. The pre
+// argument indicates whether the visit is a pre-order or post-order visit. On
+// a pre-order visit, if the result Visitor is nil children nodes are skipped
+// from the traversal.
 type Visitor interface {
 	Visit(expr Expr, pre bool) (Visitor, Expr)
 }
 
 // WalkExpr traverses the nodes in an expression. It starts by calling
-// v.Visit(expr, true). If the visitor returned by v.Pre(expr) is not nil it
-// recursively calls WalkExpr on the children of the node returned by
+// v.Visit(expr, true). If the visitor returned by v.Visit(expr, true) is not
+// nil it recursively calls WalkExpr on the children of the node returned by
 // v.Visit(expr, true) and finishes with a call to v.Visit(expr, false).
 func WalkExpr(v Visitor, expr Expr) Expr {
 	v, expr = v.Visit(expr, true)

--- a/sql/testdata/select_index
+++ b/sql/testdata/select_index
@@ -152,11 +152,7 @@ EXPLAIN (DEBUG) SELECT * FROM t@ab WHERE a < 3 OR a > 3
 1 /t/ab/3/4/3 NULL false
 2 /t/ab/5/6/5 NULL true
 
-# TODO(pmattis): We should be able to restrict the scan in this case,
-# but currently don't.
 query ITTB
 EXPLAIN (DEBUG) SELECT * FROM t@ab WHERE a + 1 = 4
 ----
-0 /t/ab/1/2/1 NULL false
-1 /t/ab/3/4/3 NULL true
-2 /t/ab/5/6/5 NULL false
+0 /t/ab/3/4/3 NULL true


### PR DESCRIPTION
Added NormalizeExpr which performs various bits of expression
normalization. The most important of these normalizations are the
evaluation of constant branches of the expression and the rewriting of
expressions so that "variables" are isolated on the left sides of
comparisons.

Fixes #1943.
