### PR TITLE
Add --max-results flag to range list command

### DIFF
--- a/cli/cli_test.go
+++ b/cli/cli_test.go
@@ -90,10 +90,12 @@ func Example_basic() {
 	// "a"	"1"
 	// "b"	"2"
 	// "c"	"3"
+	// 3 result(s)
 	// kv revscan
 	// "c"	"3"
 	// "b"	"2"
 	// "a"	"1"
+	// 3 result(s)
 	// kv del a c
 	// kv get a
 	// "a" not found
@@ -112,9 +114,11 @@ func Example_basic() {
 	// kv scan
 	// "b"	"2"
 	// "c"	"\x00\x00\x00\x00\x00\x00\x00*"
+	// 2 result(s)
 	// kv revscan
 	// "c"	"\x00\x00\x00\x00\x00\x00\x00*"
 	// "b"	"2"
+	// 2 result(s)
 	// kv inc c b
 	// invalid increment: b: strconv.ParseInt: parsing "b": invalid syntax
 	// quit
@@ -145,6 +149,7 @@ func Example_quoted() {
 	// "a\x01"	"日本語"
 	// "a\x02"	"日本語"
 	// "a\x03"	"日本語"
+	// 4 result(s)
 	// kv get a\x00
 	// "日本語"
 	// kv del a\x00
@@ -174,6 +179,7 @@ func Example_insecure() {
 	// kv --insecure scan
 	// "a"	"1"
 	// "b"	"2"
+	// 2 result(s)
 	// quit --insecure
 	// node drained and shutdown: ok
 }
@@ -201,41 +207,49 @@ func Example_ranges() {
 	// "b"	"2"
 	// "c"	"3"
 	// "d"	"4"
+	// 4 result(s)
 	// kv revscan
 	// "d"	"4"
 	// "c"	"3"
 	// "b"	"2"
 	// "a"	"1"
+	// 4 result(s)
 	// range split c
 	// range ls
 	// ""-"c" [1]
 	// 	0: node-id=1 store-id=1
 	// "c"-"\xff\xff" [2]
 	// 	0: node-id=1 store-id=1
+	// 2 result(s)
 	// kv scan
 	// "a"	"1"
 	// "b"	"2"
 	// "c"	"3"
 	// "d"	"4"
+	// 4 result(s)
 	// kv revscan
 	// "d"	"4"
 	// "c"	"3"
 	// "b"	"2"
 	// "a"	"1"
+	// 4 result(s)
 	// range merge b
 	// range ls
 	// ""-"\xff\xff" [1]
 	// 	0: node-id=1 store-id=1
+	// 1 result(s)
 	// kv scan
 	// "a"	"1"
 	// "b"	"2"
 	// "c"	"3"
 	// "d"	"4"
+	// 4 result(s)
 	// kv revscan
 	// "d"	"4"
 	// "c"	"3"
 	// "b"	"2"
 	// "a"	"1"
+	// 4 result(s)
 	// quit
 	// node drained and shutdown: ok
 }
@@ -253,11 +267,17 @@ func Example_logging() {
 
 	// Output:
 	// kv --alsologtostderr=false scan
+	// 0 result(s)
 	// kv --log-backtrace-at=foo.go:1 scan
+	// 0 result(s)
 	// kv --log-dir='' scan
+	// 0 result(s)
 	// kv --logtostderr=true scan
+	// 0 result(s)
 	// kv --verbosity=0 scan
+	// 0 result(s)
 	// kv --vmodule=foo=1 scan
+	// 0 result(s)
 	// quit
 	// node drained and shutdown: ok
 }
@@ -268,6 +288,9 @@ func Example_max_results() {
 	c.Run("kv put a 1 b 2 c 3 d 4")
 	c.Run("kv scan --max-results=3")
 	c.Run("kv revscan --max-results=2")
+	c.Run("range split c")
+	c.Run("range split d")
+	c.Run("range ls --max-results=2")
 	c.Run("quit")
 
 	// Output:
@@ -276,9 +299,19 @@ func Example_max_results() {
 	// "a"	"1"
 	// "b"	"2"
 	// "c"	"3"
+	// 3 result(s)
 	// kv revscan --max-results=2
 	// "d"	"4"
 	// "c"	"3"
+	// 2 result(s)
+	// range split c
+	// range split d
+	// range ls --max-results=2
+	// ""-"c" [1]
+	// 	0: node-id=1 store-id=1
+	// "c"-"d" [2]
+	// 	0: node-id=1 store-id=1
+	// 2 result(s)
 	// quit
 	// node drained and shutdown: ok
 }

--- a/cli/flags.go
+++ b/cli/flags.go
@@ -27,6 +27,8 @@ import (
 	"github.com/spf13/cobra"
 )
 
+var maxResults int64
+
 // pflagValue wraps flag.Value and implements the extra methods of the
 // pflag.Value interface.
 type pflagValue struct {
@@ -226,10 +228,10 @@ func initFlags(ctx *server.Context) {
 		f.StringVar(&ctx.Certs, "certs", ctx.Certs, flagUsage["certs"])
 	}
 
-	// Max results flag for scan and reverse scan.
-	for _, cmd := range []*cobra.Command{scanCmd, reverseScanCmd} {
+	// Max results flag for scan, reverse scan, and range list.
+	for _, cmd := range []*cobra.Command{scanCmd, reverseScanCmd, lsRangesCmd} {
 		f := cmd.Flags()
-		f.Int64Var(&maxResults, "max-results", defaultMaxResults, flagUsage["max-results"])
+		f.Int64Var(&maxResults, "max-results", 1000, flagUsage["max-results"])
 	}
 }
 

--- a/cli/kv.go
+++ b/cli/kv.go
@@ -33,10 +33,6 @@ import (
 	"github.com/spf13/cobra"
 )
 
-const defaultMaxResults = 1000
-
-var maxResults int64
-
 var osExit = os.Exit
 var osStderr = os.Stderr
 
@@ -318,6 +314,7 @@ func showResult(rows []client.KeyValue) {
 		key := proto.Key(row.Key)
 		fmt.Printf("%s\t%q\n", key, row.Value)
 	}
+	fmt.Printf("%d result(s)\n", len(rows))
 }
 
 var kvCmds = []*cobra.Command{

--- a/cli/range.go
+++ b/cli/range.go
@@ -33,8 +33,6 @@ var lsRangesCmd = &cobra.Command{
 	Short: "lists the ranges",
 	Long: `
 Lists the ranges in a cluster.
-
-Caveat: Currently only lists up to 1000 rangges.
 `,
 	Run: runLsRanges,
 }
@@ -55,7 +53,7 @@ func runLsRanges(cmd *cobra.Command, args []string) {
 	if kvDB == nil {
 		return
 	}
-	rows, err := kvDB.Scan(startKey, keys.Meta2Prefix.PrefixEnd(), 1000)
+	rows, err := kvDB.Scan(startKey, keys.Meta2Prefix.PrefixEnd(), maxResults)
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "scan failed: %s\n", err)
 		osExit(1)
@@ -74,6 +72,7 @@ func runLsRanges(cmd *cobra.Command, args []string) {
 				i, replica.NodeID, replica.StoreID)
 		}
 	}
+	fmt.Printf("%d result(s)\n", len(rows))
 }
 
 // A splitRangeCmd command splits a range.


### PR DESCRIPTION
1. Add --max-results flag to range list command. 
2. Add a log to display the total results count.
