### PR TITLE
Add support for ORDER BY.

### DIFF
--- a/sql/logic_test.go
+++ b/sql/logic_test.go
@@ -468,6 +468,7 @@ func TestLogic(t *testing.T) {
 			logicTestPath + "/test/index/delete/*/*.test",
 			logicTestPath + "/test/index/in/*/*.test",
 			logicTestPath + "/test/index/orderby/*/*.test",
+			logicTestPath + "/test/index/orderby_nosort/*/*.test",
 
 			// TODO(pmattis): We don't support aggregate functions.
 			// logicTestPath + "/test/random/expr/*.test",
@@ -477,9 +478,6 @@ func TestLogic(t *testing.T) {
 
 			// TODO(pmattis): We don't support views.
 			// logicTestPath + "/test/index/view/*/*.test",
-
-			// TODO(pmattis): We don't support order by.
-			// logicTestPath + "/test/index/orderby_nosort/*/*.test",
 
 			// TODO(pmattis): We don't support joins.
 			// [uses joins] logicTestPath + "/test/index/random/*/*.test",

--- a/sql/plan.go
+++ b/sql/plan.go
@@ -122,6 +122,10 @@ type planNode interface {
 	// Columns returns the column names. The length of the returned slice is
 	// guaranteed to be equal to the length of the tuple returned by Values().
 	Columns() []string
+	// The indexes of the columns the output is ordered by. Indexes are 1-based
+	// and negative indexes indicate descending ordering. The []int result may be
+	// nil if no ordering has been performed.
+	Ordering() []int
 	// Values returns the values at the current row. The result is only valid
 	// until the next call to Next().
 	Values() parser.DTuple
@@ -133,6 +137,7 @@ type planNode interface {
 }
 
 var _ planNode = &scanNode{}
+var _ planNode = &sortNode{}
 var _ planNode = &valuesNode{}
 
-// TODO(pmattis): orderByNode, groupByNode, joinNode.
+// TODO(pmattis): groupByNode, joinNode.

--- a/sql/sort.go
+++ b/sql/sort.go
@@ -1,0 +1,237 @@
+// Copyright 2015 The Cockroach Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+// implied. See the License for the specific language governing
+// permissions and limitations under the License. See the AUTHORS file
+// for names of contributors.
+//
+// Author: Peter Mattis (peter@cockroachlabs.com)
+
+package sql
+
+import (
+	"fmt"
+	"sort"
+
+	"github.com/cockroachdb/cockroach/sql/parser"
+	"github.com/cockroachdb/cockroach/util/log"
+)
+
+// orderBy constructs a sortNode based on the ORDER BY clause. Construction of
+// the sortNode might adjust the number of render targets in the scanNode if
+// any ordering expressions are specified.
+func (p *planner) orderBy(n *parser.Select, s *scanNode) (*sortNode, error) {
+	if n.OrderBy == nil {
+		return nil, nil
+	}
+
+	// We grab a copy of columns here because we might add new render targets
+	// below. This is the set of columns requested by the query.
+	columns := s.Columns()
+	var ordering []int
+
+	for _, o := range n.OrderBy {
+		index := 0
+
+		// Normalize the expression which has the side-effect of evaluating
+		// constant expressions and unwrapping expressions like "((a))" to "a".
+		expr, err := parser.NormalizeExpr(o.Expr)
+		if err != nil {
+			return nil, err
+		}
+
+		if qname, ok := expr.(*parser.QualifiedName); ok {
+			if len(qname.Indirect) == 0 {
+				// Look for an output column that matches the qualified name. This
+				// handles cases like:
+				//
+				//   SELECT a AS b FROM t ORDER BY b
+				target := string(qname.Base)
+				for j, col := range columns {
+					if equalName(target, col) {
+						index = j + 1
+						break
+					}
+				}
+			}
+
+			if index == 0 {
+				// No output column matched the qualified name, so look for an existing
+				// render target that matches the column name. This handles cases like:
+				//
+				//   SELECT a AS b FROM t ORDER BY a
+				if err := qname.NormalizeColumnName(); err != nil {
+					return nil, err
+				}
+				if qname.Table() == "" || equalName(s.desc.Alias, qname.Table()) {
+					for j, r := range s.render {
+						if qval, ok := r.(*qvalue); ok {
+							if equalName(qval.col.Name, qname.Column()) {
+								index = j + 1
+								break
+							}
+						}
+					}
+				}
+			}
+		}
+
+		if index == 0 {
+			// The order by expression matched neither an output column nor an
+			// existing render target.
+			if datum, ok := expr.(parser.Datum); ok {
+				// If we evaluated to an int, use that as an index to order by. This
+				// handles cases like:
+				//
+				//   SELECT * FROM t ORDER BY 1
+				i, ok := datum.(parser.DInt)
+				if !ok {
+					return nil, fmt.Errorf("invalid ORDER BY: %s", expr)
+				}
+				index = int(i)
+				if index < 1 || index > len(columns) {
+					return nil, fmt.Errorf("invalid ORDER BY index: %d not in range [1, %d]",
+						index, len(columns))
+				}
+			} else {
+				// Add a new render expression to use for ordering. This handles cases
+				// were the expression is either not a qualified name or is a qualified
+				// name that is otherwise not referenced by the query:
+				//
+				//   SELECT a FROM t ORDER by b
+				//   SELECT a, b FROM t ORDER by a+b
+				if err := s.addRender(parser.SelectExpr{Expr: expr}); err != nil {
+					return nil, err
+				}
+				index = len(s.columns)
+			}
+		}
+
+		if o.Direction == parser.Descending {
+			index = -index
+		}
+		ordering = append(ordering, index)
+	}
+
+	return &sortNode{columns: columns, ordering: ordering}, nil
+}
+
+type sortNode struct {
+	plan     planNode
+	columns  []string
+	ordering []int
+	values   *valuesNode
+	err      error
+}
+
+func (n *sortNode) Columns() []string {
+	return n.columns
+}
+
+func (n *sortNode) Ordering() []int {
+	return n.ordering
+}
+
+func (n *sortNode) Values() parser.DTuple {
+	// If an ordering expression was used the number of columns in each row might
+	// differ from the number of columns requested, so trim the result.
+	v := n.values.Values()
+	return v[:len(n.columns)]
+}
+
+func (n *sortNode) Next() bool {
+	if n.values == nil {
+		if !n.initValues() {
+			return false
+		}
+	}
+	return n.values.Next()
+}
+
+func (n *sortNode) Err() error {
+	return n.err
+}
+
+// wrap the supplied planNode with the sortNode if sorting is required.
+func (n *sortNode) wrap(plan planNode) planNode {
+	if n != nil {
+		// Check to see if the requested ordering is compatible with the existing
+		// ordering.
+		existingOrdering := plan.Ordering()
+		for i := range n.ordering {
+			if i >= len(existingOrdering) || n.ordering[i] != existingOrdering[i] {
+				if log.V(2) {
+					log.Infof("Sort: %d != %d", existingOrdering, n.ordering)
+				}
+				n.plan = plan
+				return n
+			}
+		}
+	}
+
+	if log.V(2) {
+		log.Infof("Sort: no sorting required")
+	}
+	return plan
+}
+
+func (n *sortNode) initValues() bool {
+	// TODO(pmattis): If the result set is large, we might need to perform the
+	// sort on disk.
+	n.values = &valuesNode{}
+	for n.plan.Next() {
+		values := n.plan.Values()
+		valuesCopy := make(parser.DTuple, len(values))
+		copy(valuesCopy, values)
+		n.values.rows = append(n.values.rows, valuesCopy)
+	}
+	n.err = n.plan.Err()
+	if n.err != nil {
+		return false
+	}
+	sort.Sort(n)
+	return true
+}
+
+func (n *sortNode) Len() int {
+	return len(n.values.rows)
+}
+
+func (n *sortNode) Less(i, j int) bool {
+	// TODO(pmattis): An alternative to this type of field-based comparison would
+	// be to construct a sort-key per row using encodeTableKey(). Using a
+	// sort-key approach would likely fit better with a disk-based sort.
+	ra, rb := n.values.rows[i], n.values.rows[j]
+	for _, k := range n.ordering {
+		var da, db parser.Datum
+		if k < 0 {
+			da = rb[-(k + 1)]
+			db = ra[-(k + 1)]
+		} else {
+			da = ra[k-1]
+			db = rb[k-1]
+		}
+		// TODO(pmattis): This is assuming that the datum types are compatible. I'm
+		// not sure this always holds as `CASE` expressions can return different
+		// types for a column for different rows. Investigate how other RDBMs
+		// handle this.
+		if c := da.Compare(db); c < 0 {
+			return true
+		} else if c > 0 {
+			return false
+		}
+	}
+	return true
+}
+
+func (n *sortNode) Swap(i, j int) {
+	n.values.rows[i], n.values.rows[j] = n.values.rows[j], n.values.rows[i]
+}

--- a/sql/testdata/order_by
+++ b/sql/testdata/order_by
@@ -1,0 +1,120 @@
+statement ok
+CREATE TABLE t (
+  a INT PRIMARY KEY,
+  b INT
+)
+
+statement ok
+INSERT INTO t VALUES (1, 9), (2, 8), (3, 7)
+
+query II
+SELECT a, b FROM t ORDER BY b
+----
+3 7
+2 8
+1 9
+
+query II
+SELECT a, b FROM t ORDER BY b DESC
+----
+1 9
+2 8
+3 7
+
+query II
+SELECT a FROM t ORDER BY 1 DESC
+----
+3
+2
+1
+
+query II
+SELECT a AS foo, b FROM t ORDER BY foo DESC
+----
+3 7
+2 8
+1 9
+
+query II
+SELECT a AS "foo.bar", b FROM t ORDER BY "foo.bar" DESC
+----
+3 7
+2 8
+1 9
+
+query II
+SELECT a AS foo, b FROM t ORDER BY a DESC
+----
+3 7
+2 8
+1 9
+
+query I
+SELECT b FROM t ORDER BY a DESC
+----
+7
+8
+9
+
+statement ok
+INSERT INTO t VALUES (4, 7), (5, 7)
+
+query II
+SELECT a, b FROM t WHERE b = 7 ORDER BY b, a
+----
+3 7
+4 7
+5 7
+
+query II
+SELECT a, b FROM t ORDER BY b, a DESC
+----
+5 7
+4 7
+3 7
+2 8
+1 9
+
+SELECT II
+SELECT a, b, a+b AS ab FROM t WHERE b = 7 ORDER BY ab DESC, a
+----
+5 7 12
+4 7 11
+1 9 10
+2 8 10
+3 7 10
+
+
+query I
+SELECT a FROM t ORDER BY a+b DESC, a
+----
+5
+4
+1
+2
+3
+
+query I
+SELECT a FROM t ORDER BY (((a)))
+----
+1
+2
+3
+4
+5
+
+query error invalid ORDER BY index: 0 not in range \[1, 2\]
+SELECT * FROM t ORDER BY 0
+----
+
+query error invalid ORDER BY: true
+SELECT * FROM t ORDER BY true
+----
+
+query error qualified name "t.foo" not found
+SELECT * FROM t ORDER BY foo
+----
+
+query error qualified name "a.b" not found
+SELECT a FROM t ORDER BY a.b
+----

--- a/sql/values.go
+++ b/sql/values.go
@@ -52,6 +52,10 @@ func (n *valuesNode) Columns() []string {
 	return n.columns
 }
 
+func (n *valuesNode) Ordering() []int {
+	return nil
+}
+
 func (n *valuesNode) Values() parser.DTuple {
 	return n.rows[n.nextRow-1]
 }


### PR DESCRIPTION
Sorting is currently performed in memory. Ordering is not taken into
consideration during index selection, but sorting is not performed if
the output is already in the correct order.

Fixes #2096.
