### PR TITLE
Decode values of unique indexes during scanning.

### DIFF
--- a/sql/select.go
+++ b/sql/select.go
@@ -605,8 +605,11 @@ func (v *indexInfo) isCoveringIndex(qvals qvalMap) bool {
 	}
 
 	for colID := range qvals {
+		// All indexes contain the primary key columns. Unique indexes contain
+		// those columns in the value and non-unique indexes contain those columns
+		// in the key in order to make them unique.
 		if !v.index.containsColumnID(colID) &&
-			(v.index.Unique || !v.desc.PrimaryIndex.containsColumnID(colID)) {
+			!v.desc.PrimaryIndex.containsColumnID(colID) {
 			return false
 		}
 	}

--- a/sql/table.go
+++ b/sql/table.go
@@ -260,6 +260,13 @@ func decodeIndexKey(desc *TableDescriptor,
 		return nil, fmt.Errorf("%s: unexpected index ID: %d != %d", desc.Name, index.ID, indexID)
 	}
 
+	return decodeKeyVals(vals, key)
+}
+
+// decodeKeyVals decodes the values that are part of the key. Vals is a slice
+// returned from makeKeyVals. The remaining bytes in the key after decoding the
+// values are returned.
+func decodeKeyVals(vals []parser.Datum, key []byte) ([]byte, error) {
 	for j := range vals {
 		switch vals[j].(type) {
 		case parser.DInt:

--- a/sql/testdata/explain_debug
+++ b/sql/testdata/explain_debug
@@ -32,9 +32,9 @@ EXPLAIN (DEBUG) SELECT * FROM abc WHERE a = 2
 query ITTB
 EXPLAIN (DEBUG) SELECT * FROM abc@foo
 ----
-0  /abc/foo/'one'    NULL  true
-1  /abc/foo/'three'  NULL  true
-2  /abc/foo/'two'    NULL  true
+0  /abc/foo/'one'    /1/'one'   true
+1  /abc/foo/'three'  /3/'three' true
+2  /abc/foo/'two'    /2/'two'   true
 
 query ITTB
 EXPLAIN (DEBUG) SELECT * FROM abc@bar

--- a/sql/testdata/order_by
+++ b/sql/testdata/order_by
@@ -149,14 +149,14 @@ EXPLAIN (DEBUG) SELECT a, b FROM abc ORDER BY b, a
 query ITTB
 EXPLAIN (DEBUG) SELECT b, c FROM abc ORDER BY b, c
 ----
-0 /abc/bc/2/3 NULL true
-1 /abc/bc/5/6 NULL true
+0 /abc/bc/2/3 /1/2/3 true
+1 /abc/bc/5/6 /4/5/6 true
 
 query ITTB
-EXPLAIN (DEBUG) SELECT b FROM abc ORDER BY b
+EXPLAIN (DEBUG) SELECT a, b, c FROM abc ORDER BY b
 ----
-0 /abc/bc/2/3 NULL true
-1 /abc/bc/5/6 NULL true
+0 /abc/bc/2/3 /1/2/3 true
+1 /abc/bc/5/6 /4/5/6 true
 
 query ITTB
 EXPLAIN (DEBUG) SELECT a FROM abc ORDER BY a DESC


### PR DESCRIPTION
Previously the values of unique indexes were being ignored. Now they are
decoded and utilized for expression evaluation.
