### PR TITLE
Add EXPLAIN (plan).

### DIFF
--- a/sql/logic_test.go
+++ b/sql/logic_test.go
@@ -402,7 +402,10 @@ func (t *logicTest) execQuery(query logicQuery) {
 		for _, v := range vals {
 			nullStr := v.(*sql.NullString)
 			if nullStr.Valid {
-				results = append(results, nullStr.String)
+				// We split string results on whitespace and append a separate result
+				// for each string. A bit unusual, but otherwise we can't match strings
+				// containing whitespace.
+				results = append(results, strings.Fields(nullStr.String)...)
 			} else {
 				results = append(results, "NULL")
 			}

--- a/sql/parser/sql.go
+++ b/sql/parser/sql.go
@@ -5843,6 +5843,7 @@ func (sqlrcvr *sqlParserImpl) Parse(sqllex sqlLexer) int {
 	var sqllval sqlSymType
 	var sqlVAL sqlSymType
 	var sqlDollar []sqlSymType
+	_ = sqlDollar // silence set and not used
 	sqlS := make([]sqlSymType, sqlMaxDepth)
 
 	Nerrs := 0   /* number of errors */

--- a/sql/plan.go
+++ b/sql/plan.go
@@ -136,6 +136,8 @@ type planNode interface {
 	Next() bool
 	// Err returns the error, if any, encountered during iteration.
 	Err() error
+	// ExplainPlan returns a name and description and a list of child nodes.
+	ExplainPlan() (name, description string, children []planNode)
 }
 
 var _ planNode = &scanNode{}

--- a/sql/scan.go
+++ b/sql/scan.go
@@ -136,6 +136,21 @@ func (n *scanNode) Err() error {
 	return n.err
 }
 
+func (n *scanNode) ExplainPlan() (name, description string, children []planNode) {
+	if n.reverse {
+		name = "revscan"
+	} else {
+		name = "scan"
+	}
+	if n.desc == nil {
+		description = "-"
+	} else {
+		// TODO(pmattis): Display the start and end keys used for the scan?
+		description = fmt.Sprintf("%s@%s", n.desc.Name, n.index.Name)
+	}
+	return name, description, nil
+}
+
 func (n *scanNode) initFrom(p *planner, from parser.TableExprs) error {
 	switch len(from) {
 	case 0:

--- a/sql/testdata/explain_debug
+++ b/sql/testdata/explain_debug
@@ -14,7 +14,7 @@ EXPLAIN (DEBUG) SELECT * FROM abc
 RowIdx  Key  Value  Output
 
 statement ok
-INSERT INTO abc VALUES (1, 'one', 1.1), (2, 'two', NULL), (3, 'three')
+INSERT INTO abc VALUES (1, 'one', 1.1), (2, 'two', NULL), (3, 'three', NULL)
 
 query ITTB
 EXPLAIN (DEBUG) SELECT * FROM abc

--- a/sql/testdata/explain_plan
+++ b/sql/testdata/explain_plan
@@ -1,0 +1,26 @@
+statement ok
+CREATE TABLE t (
+  k INT PRIMARY KEY,
+  v INT
+)
+
+statement ok
+INSERT INTO t VALUES (1, 2)
+
+query ITT colnames
+EXPLAIN SELECT * FROM t
+----
+Level  Type  Description
+0      scan  t@primary
+
+query ITT colnames
+EXPLAIN VALUES (1, 2, 3), (4, 5, 6)
+----
+Level  Type    Description
+0      values  3 columns, 2 rows
+
+query ITT colnames
+EXPLAIN VALUES (1)
+----
+Level  Type    Description
+0      values  1 column, 1 row

--- a/sql/testdata/order_by
+++ b/sql/testdata/order_by
@@ -14,12 +14,24 @@ SELECT a, b FROM t ORDER BY b
 2 8
 1 9
 
+query ITT
+EXPLAIN SELECT a, b FROM t ORDER BY b
+----
+0 sort +b
+1 scan t@primary
+
 query II
 SELECT a, b FROM t ORDER BY b DESC
 ----
 1 9
 2 8
 3 7
+
+query ITT
+EXPLAIN SELECT a, b FROM t ORDER BY b DESC
+----
+0 sort -b
+1 scan t@primary
 
 query II
 SELECT a FROM t ORDER BY 1 DESC
@@ -55,6 +67,12 @@ SELECT b FROM t ORDER BY a DESC
 7
 8
 9
+
+query ITT
+EXPLAIN SELECT b FROM t ORDER BY a DESC
+----
+0 nosort -a
+1 revscan t@primary
 
 statement ok
 INSERT INTO t VALUES (4, 7), (5, 7)
@@ -140,11 +158,21 @@ EXPLAIN (DEBUG) SELECT * FROM abc ORDER BY a
 1 /abc/primary/4/5/6   NULL  NULL
 1 /abc/primary/4/5/6/d 'two' true
 
+query ITT
+EXPLAIN SELECT * FROM abc ORDER BY a
+----
+0 scan abc@primary
+
 query ITTB
 EXPLAIN (DEBUG) SELECT a, b FROM abc ORDER BY b, a
 ----
 0 /abc/ba/2/1/1/2/3 NULL true
 1 /abc/ba/5/4/4/5/6 NULL true
+
+query ITT
+EXPLAIN SELECT a, b FROM abc ORDER BY b, a
+----
+0 scan abc@ba
 
 query ITTB
 EXPLAIN (DEBUG) SELECT b, c FROM abc ORDER BY b, c
@@ -166,9 +194,13 @@ EXPLAIN (DEBUG) SELECT a FROM abc ORDER BY a DESC
 1 /abc/primary/1/2/3/d 'one' NULL
 1 /abc/primary/1/2/3   NULL  true
 
-query ITTB
+query ITT
+EXPLAIN SELECT a FROM abc ORDER BY a DESC
+----
+0 revscan abc@primary
+
+query I
 SELECT a FROM abc ORDER BY a DESC
 ----
 4
 1
-

--- a/sql/testdata/values
+++ b/sql/testdata/values
@@ -1,0 +1,10 @@
+query ITT colnames
+VALUES (1, 2, 3), (4, 5, 6)
+----
+column1 column2 column3
+1       2       3
+4       5       6
+
+query error VALUES lists must all be the same length
+VALUES (1), (2, 3)
+----


### PR DESCRIPTION
The output is pretty redumentary, containing Level, Type and Description
field. The Level field indicates the level in the query plan tree (with
0 indicating the root). The Type indicates the type of the plan
node (currently scan, revscan, sort, nosort, or values). The Description
is some node specificy information, such as the table/index being
scanned or the keys being sorted on.

Fixed a buglet in valuesNode: the values lists must all be the same
length.

Fixes #2172.
