### PR TITLE
Support aggregate functions.

### DIFF
--- a/sql/group.go
+++ b/sql/group.go
@@ -1,0 +1,441 @@
+// Copyright 2015 The Cockroach Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+// implied. See the License for the specific language governing
+// permissions and limitations under the License. See the AUTHORS file
+// for names of contributors.
+//
+// Author: Peter Mattis (peter@cockroachlabs.com)
+
+package sql
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/cockroachdb/cockroach/sql/parser"
+	"github.com/cockroachdb/cockroach/util/log"
+)
+
+var aggregates = map[string]aggregateImpl{
+	"avg":   &avgAggregate{},
+	"count": &countAggregate{},
+	"max":   &maxAggregate{},
+	"min":   &minAggregate{},
+	"sum":   &sumAggregate{},
+}
+
+func (p *planner) groupBy(n *parser.Select, s *scanNode) (*groupNode, error) {
+	// TODO(pmattis): This only handles aggregate functions, not GROUP BY.
+
+	// Loop over the render expressions and extract any aggregate functions.
+	var funcs []*aggregateFunc
+	for i, r := range s.render {
+		r, f, err := extractAggregateFuncs(r)
+		if err != nil {
+			return nil, err
+		}
+		s.render[i] = r
+		funcs = append(funcs, f...)
+	}
+	if len(funcs) == 0 {
+		return nil, nil
+	}
+
+	// Aggregation is being performed. Loop over the render expressions again and
+	// verify that the only qvalues mentioned by GROUP BY expressions are allowed
+	// outside of the aggregate function arguments. For example, the following is
+	// illegal because k is used outside of the aggregate function and not part
+	// of a GROUP BY expression.
+	//
+	//   SELECT COUNT(k), k FROM kv GROUP BY v
+	for _, r := range s.render {
+		if err := checkAggregateExpr(r); err != nil {
+			return nil, err
+		}
+	}
+
+	if log.V(2) {
+		strs := make([]string, 0, len(funcs))
+		for _, f := range funcs {
+			strs = append(strs, f.val.String())
+		}
+		log.Infof("Group: %s", strings.Join(strs, ", "))
+	}
+
+	group := &groupNode{
+		columns: s.columns,
+		render:  s.render,
+		funcs:   funcs,
+	}
+
+	// Replace the render expressions in the scanNode with expressions that
+	// compute only the arguments to the aggregate expressions.
+	s.columns = make([]string, 0, len(funcs))
+	s.render = make([]parser.Expr, 0, len(funcs))
+	for _, f := range funcs {
+		if len(f.val.Exprs) != 1 {
+			panic(fmt.Sprintf("%s has %d arguments (expected 1)", f.val.Name, len(f.val.Exprs)))
+		}
+		s.columns = append(s.columns, f.val.String())
+		s.render = append(s.render, f.val.Exprs[0])
+	}
+
+	return group, nil
+}
+
+type groupNode struct {
+	plan      planNode
+	columns   []string
+	row       parser.DTuple
+	render    []parser.Expr
+	funcs     []*aggregateFunc
+	needGroup bool
+	err       error
+}
+
+func (n *groupNode) Columns() []string {
+	return n.columns
+}
+
+func (n *groupNode) Ordering() []int {
+	return n.plan.Ordering()
+}
+
+func (n *groupNode) Values() parser.DTuple {
+	return n.row
+}
+
+func (n *groupNode) Next() bool {
+	if !n.needGroup {
+		return false
+	}
+	n.needGroup = false
+
+	// Loop over the rows passing the values into the corresponding aggregation
+	// functions.
+	for n.plan.Next() {
+		values := n.plan.Values()
+		for i, f := range n.funcs {
+			if n.err = f.impl.Add(values[i]); n.err != nil {
+				return false
+			}
+		}
+	}
+
+	n.err = n.plan.Err()
+	if n.err != nil {
+		return false
+	}
+
+	// Fill in the aggregate function result value.
+	for _, f := range n.funcs {
+		if f.val.datum, n.err = f.impl.Result(); n.err != nil {
+			return false
+		}
+	}
+
+	// Render the results.
+	n.row = make([]parser.Datum, len(n.render))
+	for i, r := range n.render {
+		n.row[i], n.err = parser.EvalExpr(r)
+		if n.err != nil {
+			return false
+		}
+	}
+
+	return n.err == nil
+}
+
+func (n *groupNode) Err() error {
+	return n.err
+}
+
+func (n *groupNode) ExplainPlan() (name, description string, children []planNode) {
+	name = "group"
+	strs := make([]string, 0, len(n.funcs))
+	for _, f := range n.funcs {
+		strs = append(strs, f.val.String())
+	}
+	description = strings.Join(strs, ", ")
+	return name, description, []planNode{n.plan}
+}
+
+// wrap the supplied planNode with the groupNode if grouping/aggregation is required.
+func (n *groupNode) wrap(plan planNode) planNode {
+	if n == nil {
+		return plan
+	}
+	n.plan = plan
+	n.needGroup = true
+	return n
+}
+
+type extractAggregatesVisitor struct {
+	funcs []*aggregateFunc
+	err   error
+}
+
+var _ parser.Visitor = &extractAggregatesVisitor{}
+
+func (v *extractAggregatesVisitor) Visit(expr parser.Expr, pre bool) (parser.Visitor, parser.Expr) {
+	if !pre || v.err != nil {
+		return nil, expr
+	}
+	switch t := expr.(type) {
+	case *parser.FuncExpr:
+		if len(t.Name.Indirect) > 0 {
+			break
+		}
+		if impl, ok := aggregates[strings.ToLower(string(t.Name.Base))]; ok {
+			f := &aggregateFunc{
+				val: aggregateValue{
+					FuncExpr: t,
+				},
+				impl: impl.New(),
+			}
+			v.funcs = append(v.funcs, f)
+			return nil, &f.val
+		}
+	}
+	return v, expr
+}
+
+func extractAggregateFuncs(expr parser.Expr) (parser.Expr, []*aggregateFunc, error) {
+	v := extractAggregatesVisitor{}
+	expr = parser.WalkExpr(&v, expr)
+	return expr, v.funcs, v.err
+}
+
+type checkAggregateVisitor struct {
+	err error
+}
+
+var _ parser.Visitor = &checkAggregateVisitor{}
+
+func (v *checkAggregateVisitor) Visit(expr parser.Expr, pre bool) (parser.Visitor, parser.Expr) {
+	if !pre || v.err != nil {
+		return nil, expr
+	}
+	switch t := expr.(type) {
+	case *qvalue:
+		// TODO(pmattis): Check that the qvalue is part of a GROUP BY expression.
+		v.err = fmt.Errorf("column \"%s\" must appear in the GROUP BY clause or be used in an aggregate function", t.col.Name)
+		return nil, expr
+	}
+	return v, expr
+}
+
+func checkAggregateExpr(expr parser.Expr) error {
+	v := checkAggregateVisitor{}
+	_ = parser.WalkExpr(&v, expr)
+	return v.err
+}
+
+type aggregateValue struct {
+	datum parser.Datum
+	// Tricky: we embed a parser.FuncExpr so that aggregateValue implements
+	// parser.expr()! Note that we can't just implement aggregateValue.expr() as
+	// that interface method is defined in the wrong package.
+	*parser.FuncExpr
+}
+
+var _ parser.DReference = &aggregateValue{}
+
+func (v *aggregateValue) Datum() parser.Datum {
+	return v.datum
+}
+
+type aggregateFunc struct {
+	val  aggregateValue
+	impl aggregateImpl
+}
+
+type aggregateImpl interface {
+	New() aggregateImpl
+	Add(parser.Datum) error
+	Result() (parser.Datum, error)
+}
+
+var _ aggregateImpl = &avgAggregate{}
+var _ aggregateImpl = &countAggregate{}
+var _ aggregateImpl = &maxAggregate{}
+var _ aggregateImpl = &minAggregate{}
+var _ aggregateImpl = &sumAggregate{}
+
+type avgAggregate struct {
+	sumAggregate
+	count int
+}
+
+func (a *avgAggregate) New() aggregateImpl {
+	return &avgAggregate{}
+}
+
+func (a *avgAggregate) Add(datum parser.Datum) error {
+	if datum == parser.DNull {
+		return nil
+	}
+	if err := a.sumAggregate.Add(datum); err != nil {
+		return err
+	}
+	a.count++
+	return nil
+}
+
+func (a *avgAggregate) Result() (parser.Datum, error) {
+	sum, err := a.sumAggregate.Result()
+	if err != nil {
+		return parser.DNull, err
+	}
+	if sum == parser.DNull {
+		return sum, nil
+	}
+	switch t := sum.(type) {
+	case parser.DInt:
+		return parser.DFloat(t) / parser.DFloat(a.count), nil
+	case parser.DFloat:
+		return t / parser.DFloat(a.count), nil
+	default:
+		return parser.DNull, fmt.Errorf("unexpected SUM result type: %s", t.Type())
+	}
+}
+
+type countAggregate struct {
+	count int
+}
+
+func (a *countAggregate) New() aggregateImpl {
+	return &countAggregate{}
+}
+
+func (a *countAggregate) Add(datum parser.Datum) error {
+	if datum == parser.DNull {
+		return nil
+	}
+	switch t := datum.(type) {
+	case parser.DTuple:
+		for _, d := range t {
+			if d != parser.DNull {
+				a.count++
+				break
+			}
+		}
+	default:
+		a.count++
+	}
+	return nil
+}
+
+func (a *countAggregate) Result() (parser.Datum, error) {
+	return parser.DInt(a.count), nil
+}
+
+type maxAggregate struct {
+	max parser.Datum
+}
+
+func (a *maxAggregate) New() aggregateImpl {
+	return &maxAggregate{}
+}
+
+func (a *maxAggregate) Add(datum parser.Datum) error {
+	if datum == parser.DNull {
+		return nil
+	}
+	if a.max == nil {
+		a.max = datum
+		return nil
+	}
+	c := a.max.Compare(datum)
+	if c < 0 {
+		a.max = datum
+	}
+	return nil
+}
+
+func (a *maxAggregate) Result() (parser.Datum, error) {
+	if a.max == nil {
+		return parser.DNull, nil
+	}
+	return a.max, nil
+}
+
+type minAggregate struct {
+	min parser.Datum
+}
+
+func (a *minAggregate) New() aggregateImpl {
+	return &minAggregate{}
+}
+
+func (a *minAggregate) Add(datum parser.Datum) error {
+	if datum == parser.DNull {
+		return nil
+	}
+	if a.min == nil {
+		a.min = datum
+		return nil
+	}
+	c := a.min.Compare(datum)
+	if c > 0 {
+		a.min = datum
+	}
+	return nil
+}
+
+func (a *minAggregate) Result() (parser.Datum, error) {
+	if a.min == nil {
+		return parser.DNull, nil
+	}
+	return a.min, nil
+}
+
+type sumAggregate struct {
+	sum parser.Datum
+}
+
+func (a *sumAggregate) New() aggregateImpl {
+	return &sumAggregate{}
+}
+
+func (a *sumAggregate) Add(datum parser.Datum) error {
+	if datum == parser.DNull {
+		return nil
+	}
+	if a.sum == nil {
+		a.sum = datum
+		return nil
+	}
+
+	switch t := datum.(type) {
+	case parser.DInt:
+		if v, ok := a.sum.(parser.DInt); ok {
+			a.sum = v + t
+			return nil
+		}
+
+	case parser.DFloat:
+		if v, ok := a.sum.(parser.DFloat); ok {
+			a.sum = v + t
+			return nil
+		}
+	}
+
+	return fmt.Errorf("unexpected SUM argument type: %s", datum.Type())
+}
+
+func (a *sumAggregate) Result() (parser.Datum, error) {
+	if a.sum == nil {
+		return parser.DNull, nil
+	}
+	return a.sum, nil
+}

--- a/sql/parser/eval.go
+++ b/sql/parser/eval.go
@@ -75,10 +75,10 @@ func (d DBool) Compare(other Datum) int {
 		// Anything other than a DBool compares greater (e.g. `true > NULL`).
 		return 1
 	}
-	if d && !v {
+	if !d && v {
 		return -1
 	}
-	if !v && d {
+	if d && !v {
 		return 1
 	}
 	return 0

--- a/sql/plan.go
+++ b/sql/plan.go
@@ -140,8 +140,9 @@ type planNode interface {
 	ExplainPlan() (name, description string, children []planNode)
 }
 
+var _ planNode = &groupNode{}
 var _ planNode = &scanNode{}
 var _ planNode = &sortNode{}
 var _ planNode = &valuesNode{}
 
-// TODO(pmattis): groupByNode, joinNode.
+// TODO(pmattis): joinNode.

--- a/sql/testdata/aggregate
+++ b/sql/testdata/aggregate
@@ -1,0 +1,116 @@
+statement ok
+CREATE TABLE kv (
+  k INT PRIMARY KEY,
+  v INT
+)
+
+statement OK
+INSERT INTO kv VALUES (1, 2), (3, 4), (5, NULL)
+
+query error column "k" must appear in the GROUP BY clause or be used in an aggregate function
+SELECT COUNT(*), k FROM kv
+----
+3
+
+query error syntax error at or near ","
+SELECT COUNT(*, 1) FROM kv
+----
+
+query error unknown signature for COUNT: COUNT\(int, int\)
+SELECT COUNT(k, v) FROM kv
+----
+
+query error unimplemented ORDER BY with GROUP BY/aggregation
+SELECT COUNT(k) FROM kv ORDER BY v
+----
+
+query I colnames
+SELECT COUNT(*), COUNT(kv.*), COUNT(k), COUNT(kv.v) FROM kv
+----
+COUNT(*) COUNT(kv.*) COUNT(k) COUNT(kv.v)
+3        3           3        2
+
+query I
+SELECT COUNT((k, v)) FROM kv
+----
+3
+
+query I
+SELECT COUNT(k)+COUNT(kv.v) FROM kv
+----
+5
+
+query IIII
+SELECT MIN(k), MAX(k), MIN(v), MAX(v) FROM kv
+----
+1 5 2 4
+
+query IIII
+SELECT MIN(k), MAX(k), MIN(v), MAX(v) FROM kv WHERE k > 5
+----
+NULL NULL NULL NULL
+
+query RRII
+SELECT AVG(k), AVG(v), SUM(k), SUM(v) FROM kv
+----
+3 3 9 6
+
+query R
+SELECT AVG(k) * 2.0 + MAX(v)::float FROM kv
+----
+10
+
+query ITT
+EXPLAIN SELECT COUNT(k) FROM kv
+----
+0 group COUNT(k)
+1 scan  kv@primary
+
+statement ok
+CREATE TABLE abc (
+  a CHAR PRIMARY KEY,
+  b FLOAT,
+  c BOOLEAN
+)
+
+statement ok
+INSERT INTO abc VALUES ('one', 1.5, true), ('two', 2.0, false)
+
+query RRR
+SELECT MIN(a), MIN(b), MIN(c) FROM abc
+----
+one 1.5 false
+
+query RRR
+SELECT MAX(a), MAX(b), MAX(c) FROM abc
+----
+two 2 true
+
+query RR
+SELECT AVG(b), SUM(b) FROM abc
+----
+1.75 3.5
+
+query error unknown signature for AVG: AVG\(string\)
+SELECT AVG(a) FROM abc
+----
+
+query error unknown signature for AVG: AVG\(bool\)
+SELECT AVG(c) FROM abc
+----
+
+query error unknown signature for AVG: AVG\(tuple\)
+SELECT AVG((a,c)) FROM abc
+----
+
+query error unknown signature for SUM: SUM\(string\)
+SELECT SUM(a) FROM abc
+----
+
+query error unknown signature for SUM: SUM\(bool\)
+SELECT SUM(c) FROM abc
+----
+
+query error unknown signature for SUM: SUM\(tuple\)
+SELECT SUM((a,c)) FROM abc
+----


### PR DESCRIPTION
Added planner.groupBy which analyzes looks for any aggregate functions
in the select targets. If an aggregate function is found, we check to
make sure the select targets are valid and then rewrite the scanNode so
that it outputs the argument expressions for the aggregates.

Fixes #2043.
