### PR TITLE
Fix usage of StarExpr and SelectStarExpr.

### DIFF
--- a/sql/delete.go
+++ b/sql/delete.go
@@ -44,7 +44,7 @@ func (p *planner) Delete(n *parser.Delete) (planNode, error) {
 	// convenient access to index keys which we are not currently
 	// deleting.
 	node, err := p.Select(&parser.Select{
-		Exprs: parser.SelectExprs{parser.StarSelectExpr},
+		Exprs: parser.SelectExprs{parser.StarSelectExpr()},
 		From:  parser.TableExprs{n.Table},
 		Where: n.Where,
 	})

--- a/sql/parser/expr.go
+++ b/sql/parser/expr.go
@@ -256,8 +256,10 @@ type QualifiedName struct {
 	normalized nameType
 }
 
-// StarExpr is a convenience variable that represents an unqualified "*".
-var StarExpr = &QualifiedName{Indirect: Indirection{unqualifiedStar}}
+// StarExpr is a convenience function that represents an unqualified "*".
+func StarExpr() *QualifiedName {
+	return &QualifiedName{Indirect: Indirection{unqualifiedStar}}
+}
 
 // NormalizeTableName normalizes the qualified name to contain a database name
 // as prefix, returning an error if unable to do so or if the name is not a
@@ -359,8 +361,10 @@ func (n *QualifiedName) NormalizeColumnName() error {
 	// Either table.column, table.*, column[array-indirection] or
 	// table.column[array-indirection].
 	switch n.Indirect[0].(type) {
-	case NameIndirection, StarIndirection:
+	case NameIndirection:
 		// Nothing to do.
+	case StarIndirection:
+		n.Indirect[0] = qualifiedStar
 	case *ArrayIndirection:
 		// column[array-indirection] -> "".column[array-indirection]
 		//

--- a/sql/parser/expr_test.go
+++ b/sql/parser/expr_test.go
@@ -99,6 +99,7 @@ func TestNormalizeColumnName(t *testing.T) {
 	}{
 		{`foo`, `"".foo`, ``},
 		{`"".foo`, `"".foo`, ``},
+		{`*`, `"".*`, ``},
 		{`"".*`, `"".*`, ``},
 		{`foo.bar`, `foo.bar`, ``},
 		{`foo.*`, `foo.*`, ``},

--- a/sql/parser/select.go
+++ b/sql/parser/select.go
@@ -103,9 +103,11 @@ type SelectExpr struct {
 	As   Name
 }
 
-// StarSelectExpr is a convenience variable that represents an unqualified "*"
+// StarSelectExpr is a convenience function that represents an unqualified "*"
 // in a select expression.
-var StarSelectExpr = SelectExpr{Expr: StarExpr}
+func StarSelectExpr() SelectExpr {
+	return SelectExpr{Expr: StarExpr()}
+}
 
 func (node SelectExpr) String() string {
 	var buf bytes.Buffer

--- a/sql/parser/sql.go
+++ b/sql/parser/sql.go
@@ -7878,7 +7878,7 @@ sqldefault:
 		//line sql.y:1780
 		{
 			sqlVAL.stmt = &Select{
-				Exprs:       SelectExprs{StarSelectExpr},
+				Exprs:       SelectExprs{StarSelectExpr()},
 				From:        TableExprs{&AliasedTableExpr{Expr: sqlDollar[2].qname}},
 				tableSelect: true,
 			}
@@ -9522,7 +9522,7 @@ sqldefault:
 		sqlDollar = sqlS[sqlpt-4 : sqlpt+1]
 		//line sql.y:2920
 		{
-			sqlVAL.expr = &FuncExpr{Name: sqlDollar[1].qname, Exprs: Exprs{StarExpr}}
+			sqlVAL.expr = &FuncExpr{Name: sqlDollar[1].qname, Exprs: Exprs{StarExpr()}}
 		}
 	case 703:
 		sqlDollar = sqlS[sqlpt-4 : sqlpt+1]
@@ -10334,7 +10334,7 @@ sqldefault:
 		sqlDollar = sqlS[sqlpt-1 : sqlpt+1]
 		//line sql.y:3396
 		{
-			sqlVAL.selExpr = StarSelectExpr
+			sqlVAL.selExpr = StarSelectExpr()
 		}
 	case 859:
 		sqlDollar = sqlS[sqlpt-1 : sqlpt+1]

--- a/sql/parser/sql.y
+++ b/sql/parser/sql.y
@@ -1779,7 +1779,7 @@ simple_select:
 | TABLE relation_expr
   {
     $$ = &Select{
-      Exprs:       SelectExprs{StarSelectExpr},
+      Exprs:       SelectExprs{StarSelectExpr()},
       From:        TableExprs{&AliasedTableExpr{Expr: $2}},
       tableSelect: true,
     }
@@ -2918,7 +2918,7 @@ func_application:
   }
 | func_name '(' '*' ')'
   {
-    $$ = &FuncExpr{Name: $1, Exprs: Exprs{StarExpr}}
+    $$ = &FuncExpr{Name: $1, Exprs: Exprs{StarExpr()}}
   }
 
 // func_expr and its cousin func_expr_windowless are split out from c_expr just
@@ -3394,7 +3394,7 @@ target_elem:
   }
 | '*'
   {
-    $$ = StarSelectExpr
+    $$ = StarSelectExpr()
   }
 
 // Names and constants.

--- a/sql/update.go
+++ b/sql/update.go
@@ -67,7 +67,7 @@ func (p *planner) Update(n *parser.Update) (planNode, error) {
 	// Query the rows that need updating.
 	// TODO(vivek): Avoid going through Select.
 	row, err := p.Select(&parser.Select{
-		Exprs: parser.SelectExprs{parser.StarSelectExpr},
+		Exprs: parser.SelectExprs{parser.StarSelectExpr()},
 		From:  parser.TableExprs{n.Table},
 		Where: n.Where,
 	})


### PR DESCRIPTION
Using global variables for these convenience expressions was a mistake
as QualifiedNames get modified by Normalize{Table,Column}Name. Switch to
using functions which return new expressions each time.

Unfortunately, there is no good way to test this until we support
COUNT(*) (see #2201).
