### PR TITLE
Add support for hexadecimal literals.

### DIFF
--- a/sql/parser/parse_test.go
+++ b/sql/parser/parse_test.go
@@ -307,10 +307,8 @@ func TestParse2(t *testing.T) {
 		sql      string
 		expected string
 	}{
-		// TODO(pmattis): Handle octal and hexadecimal numbers.
-		// {`SELECT 010 FROM t`, ``},
-		// {`SELECT 0xf0 FROM t`, ``},
-		// {`SELECT 0xF0 FROM t`, ``},
+		{`SELECT 0xf0 FROM t`, `SELECT 240 FROM t`},
+		{`SELECT 0xF0 FROM t`, `SELECT 240 FROM t`},
 		// Escaped string literals are not always escaped the same because
 		// '''' and e'\'' scan to the same token. It's more convenient to
 		// prefer escaping ' and \, so we do that.
@@ -466,7 +464,7 @@ CREATE DATABASE a b c
                   ^
 `},
 		{"SELECT 1e-\n-1",
-			`invalid floating point constant
+			`invalid floating point literal
 SELECT 1e-
        ^
 `},
@@ -475,6 +473,13 @@ SELECT 1e-
 SELECT foo''
           ^
 `},
+		{
+			`SELECT 0x FROM t`,
+			`invalid hexadecimal literal
+SELECT 0x FROM t
+       ^
+`,
+		},
 	}
 	for _, d := range testData {
 		_, err := Parse(d.sql)

--- a/sql/parser/scan_test.go
+++ b/sql/parser/scan_test.go
@@ -163,6 +163,10 @@ func TestScanNumber(t *testing.T) {
 		id       int
 	}{
 		{`1`, `1`, ICONST},
+		{`0x1`, `0x1`, ICONST},
+		{`0X2`, `0X2`, ICONST},
+		{`0xff`, `0xff`, ICONST},
+		{`0xff.`, `0xff`, ICONST},
 		{`12345`, `12345`, ICONST},
 		{`1.`, `1.`, FCONST},
 		{`.1`, `.1`, FCONST},
@@ -193,7 +197,7 @@ func TestScanNumber(t *testing.T) {
 func TestScanParam(t *testing.T) {
 	testData := []struct {
 		sql      string
-		expected int
+		expected int64
 	}{
 		{`$1`, 1},
 		{`$1a`, 1},
@@ -267,9 +271,15 @@ func TestScanError(t *testing.T) {
 		sql string
 		err string
 	}{
-		{`1e`, "invalid floating point constant"},
-		{`1e-`, "invalid floating point constant"},
-		{`1e+`, "invalid floating point constant"},
+		{`1e`, "invalid floating point literal"},
+		{`1e-`, "invalid floating point literal"},
+		{`1e+`, "invalid floating point literal"},
+		{`0x`, "invalid hexadecimal literal"},
+		{`1x`, "invalid hexadecimal literal"},
+		{`1.x`, "invalid hexadecimal literal"},
+		{`1.0x`, "invalid hexadecimal literal"},
+		{`0x0x`, "invalid hexadecimal literal"},
+		{`00x0x`, "invalid hexadecimal literal"},
 		{`9223372036854775808`, "value out of range"},
 		{`$9223372036854775808`, "value out of range"},
 	}

--- a/sql/parser/sql.go
+++ b/sql/parser/sql.go
@@ -13,7 +13,7 @@ type sqlSymType struct {
 	id             int
 	pos            int
 	empty          struct{}
-	ival           int
+	ival           int64
 	str            string
 	strs           []string
 	qname          *QualifiedName
@@ -8662,13 +8662,13 @@ sqldefault:
 		sqlDollar = sqlS[sqlpt-3 : sqlpt+1]
 		//line sql.y:2358
 		{
-			sqlVAL.colType = &DecimalType{Prec: sqlDollar[2].ival}
+			sqlVAL.colType = &DecimalType{Prec: int(sqlDollar[2].ival)}
 		}
 	case 539:
 		sqlDollar = sqlS[sqlpt-5 : sqlpt+1]
 		//line sql.y:2362
 		{
-			sqlVAL.colType = &DecimalType{Prec: sqlDollar[2].ival, Scale: sqlDollar[4].ival}
+			sqlVAL.colType = &DecimalType{Prec: int(sqlDollar[2].ival), Scale: int(sqlDollar[4].ival)}
 		}
 	case 540:
 		sqlDollar = sqlS[sqlpt-0 : sqlpt+1]
@@ -8710,7 +8710,7 @@ sqldefault:
 		sqlDollar = sqlS[sqlpt-2 : sqlpt+1]
 		//line sql.y:2393
 		{
-			sqlVAL.colType = &FloatType{Name: astFloat, Prec: sqlDollar[2].ival}
+			sqlVAL.colType = &FloatType{Name: astFloat, Prec: int(sqlDollar[2].ival)}
 		}
 	case 547:
 		sqlDollar = sqlS[sqlpt-2 : sqlpt+1]
@@ -8761,7 +8761,7 @@ sqldefault:
 		sqlDollar = sqlS[sqlpt-5 : sqlpt+1]
 		//line sql.y:2444
 		{
-			sqlVAL.colType = &BitType{N: sqlDollar[4].ival}
+			sqlVAL.colType = &BitType{N: int(sqlDollar[4].ival)}
 		}
 	case 559:
 		sqlDollar = sqlS[sqlpt-2 : sqlpt+1]
@@ -8774,7 +8774,7 @@ sqldefault:
 		//line sql.y:2466
 		{
 			sqlVAL.colType = sqlDollar[1].colType
-			sqlVAL.colType.(*CharType).N = sqlDollar[3].ival
+			sqlVAL.colType.(*CharType).N = int(sqlDollar[3].ival)
 		}
 	case 565:
 		sqlDollar = sqlS[sqlpt-2 : sqlpt+1]

--- a/sql/parser/sql.y
+++ b/sql/parser/sql.y
@@ -27,7 +27,7 @@ import "github.com/cockroachdb/cockroach/sql/privilege"
   id             int
   pos            int
   empty          struct{}
-  ival           int
+  ival           int64
   str            string
   strs           []string
   qname          *QualifiedName
@@ -2356,11 +2356,11 @@ const_typename:
 opt_numeric_modifiers:
   '(' ICONST ')'
   {
-    $$ = &DecimalType{Prec: $2}
+    $$ = &DecimalType{Prec: int($2)}
   }
 | '(' ICONST ',' ICONST ')'
   {
-    $$ = &DecimalType{Prec: $2, Scale: $4}
+    $$ = &DecimalType{Prec: int($2), Scale: int($4)}
   }
 | /* EMPTY */
   {
@@ -2391,7 +2391,7 @@ numeric:
   }
 | FLOAT opt_float
   {
-    $$ = &FloatType{Name: astFloat, Prec: $2}
+    $$ = &FloatType{Name: astFloat, Prec: int($2)}
   }
 | DOUBLE PRECISION
   {
@@ -2442,7 +2442,7 @@ const_bit:
 bit_with_length:
   BIT opt_varying '(' ICONST ')'
   {
-    $$ = &BitType{N: $4}
+    $$ = &BitType{N: int($4)}
   }
 
 bit_without_length:
@@ -2465,7 +2465,7 @@ character_with_length:
   character_base '(' ICONST ')' opt_charset
   {
     $$ = $1
-    $$.(*CharType).N = $3
+    $$.(*CharType).N = int($3)
   }
 
 character_without_length:


### PR DESCRIPTION
Changed the type of sqlSymType.ival from int to int64. We require
integers to be 64-bit, so be explicit about it.
