### PR TITLE
Tweak system table initialization

### DIFF
--- a/kv/local_test_cluster.go
+++ b/kv/local_test_cluster.go
@@ -139,7 +139,7 @@ func (ltc *LocalTestCluster) Start(t util.Tester) {
 		t.Fatalf("unable to start local test cluster: %s", err)
 	}
 	ltc.lSender.AddStore(ltc.Store)
-	if err := ltc.Store.BootstrapRange(); err != nil {
+	if err := ltc.Store.BootstrapRange(nil); err != nil {
 		t.Fatalf("unable to start local test cluster: %s", err)
 	}
 	if err := ltc.Store.Start(ltc.Stopper); err != nil {

--- a/proto/data.go
+++ b/proto/data.go
@@ -315,6 +315,16 @@ func (v *Value) GetInteger() (int64, error) {
 	return int64(u), nil
 }
 
+// SetProto encodes the specified proto message into the bytes field of the receiver.
+func (v *Value) SetProto(msg gogoproto.Message) error {
+	data, err := gogoproto.Marshal(msg)
+	if err != nil {
+		return err
+	}
+	v.Bytes = data
+	return nil
+}
+
 // computeChecksum computes a checksum based on the provided key and
 // the contents of the value. If the value contains a byte slice, the
 // checksum includes it directly.

--- a/server/node.go
+++ b/server/node.go
@@ -33,6 +33,7 @@ import (
 	"github.com/cockroachdb/cockroach/proto"
 	"github.com/cockroachdb/cockroach/rpc"
 	"github.com/cockroachdb/cockroach/server/status"
+	"github.com/cockroachdb/cockroach/sql"
 	"github.com/cockroachdb/cockroach/storage"
 	"github.com/cockroachdb/cockroach/storage/engine"
 	"github.com/cockroachdb/cockroach/util"
@@ -137,7 +138,10 @@ func BootstrapCluster(clusterID string, engines []engine.Engine, stopper *stop.S
 		// not create the range, just its data.  Only do this if this is the
 		// first store.
 		if i == 0 {
-			if err := s.BootstrapRange(); err != nil {
+			// TODO(marc): this is better than having storage/ import sql, but still
+			// not great. Find a better place to keep those.
+			initialValues := sql.GetInitialSystemValues()
+			if err := s.BootstrapRange(initialValues); err != nil {
 				return nil, err
 			}
 		}

--- a/sql/system.go
+++ b/sql/system.go
@@ -1,0 +1,148 @@
+// Copyright 2015 The Cockroach Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+// implied. See the License for the specific language governing
+// permissions and limitations under the License. See the AUTHORS file
+// for names of contributors.
+//
+// Author: Marc Berhault (marc@cockroachlabs.com)
+
+package sql
+
+import (
+	"log"
+
+	"github.com/cockroachdb/cockroach/keys"
+	"github.com/cockroachdb/cockroach/proto"
+	"github.com/cockroachdb/cockroach/sql/parser"
+)
+
+const (
+	// MaxReservedDescID is the maximum reserved descriptor ID.
+	// All objects with ID <= MaxReservedDescID are system object
+	// with special rules.
+	MaxReservedDescID ID = 999
+	// RootNamespaceID is the ID of the root namespace.
+	RootNamespaceID ID = 0
+
+	// System IDs should remain <= MaxReservedDescID.
+	// systemDatabaseID is the ID of the system database.
+	systemDatabaseID ID = 1
+	// namespaceTableID is the ID of the namespace table.
+	namespaceTableID ID = 2
+	// descriptorTableID is the ID of the descriptor table.
+	descriptorTableID ID = 3
+
+	// sql CREATE commands and full schema for each system table.
+	// TODO(marc): wouldn't it be better to use a pre-parsed version?
+	namespaceTableSchema = `
+CREATE TABLE system.namespace (
+  "parentID" INT,
+  "name"     CHAR,
+  "id"       INT,
+  PRIMARY KEY (parentID, name)
+);`
+
+	descriptorTableSchema = `
+CREATE TABLE system.descriptor (
+  "id"   INT PRIMARY KEY,
+  "desc" BLOB
+);`
+)
+
+var (
+	// SystemDB is the descriptor for the system database.
+	SystemDB = DatabaseDescriptor{
+		Name:       "system",
+		ID:         systemDatabaseID,
+		Privileges: NewSystemObjectPrivilegeDescriptor(),
+	}
+
+	// NamespaceTable is the descriptor for the namespace table.
+	NamespaceTable = createSystemTable(namespaceTableID, namespaceTableSchema)
+
+	// DescriptorTable is the descriptor for the descriptor table.
+	DescriptorTable = createSystemTable(descriptorTableID, descriptorTableSchema)
+)
+
+func createSystemTable(id ID, cmd string) TableDescriptor {
+	stmts, err := parser.Parse(cmd)
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	desc, err := makeTableDesc(stmts[0].(*parser.CreateTable))
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	desc.Privileges = SystemDB.Privileges
+	desc.ID = id
+	if err := desc.AllocateIDs(); err != nil {
+		log.Fatal(err)
+	}
+
+	return desc
+}
+
+// GetInitialSystemValues returns a list of key/value pairs.
+// They are written at cluster bootstrap time (see storage/node.go:BootstrapCLuster).
+func GetInitialSystemValues() []proto.KeyValue {
+	systemData := []struct {
+		parentID ID
+		desc     descriptorProto
+	}{
+		{RootNamespaceID, &SystemDB},
+		{SystemDB.ID, &NamespaceTable},
+		{SystemDB.ID, &DescriptorTable},
+	}
+
+	numEntries := 1 + len(systemData)*2
+	ret := make([]proto.KeyValue, numEntries, numEntries)
+	i := 0
+
+	// We reserve the system IDs.
+	value := proto.Value{}
+	value.SetInteger(int64(MaxReservedDescID + 1))
+	ret[i] = proto.KeyValue{
+		Key:   keys.DescIDGenerator,
+		Value: value,
+	}
+	i++
+
+	// System database and tables.
+	for _, d := range systemData {
+		value = proto.Value{}
+		value.SetInteger(int64(d.desc.GetID()))
+		ret[i] = proto.KeyValue{
+			Key:   MakeNameMetadataKey(d.parentID, d.desc.GetName()),
+			Value: value,
+		}
+		i++
+
+		value = proto.Value{}
+		if err := value.SetProto(d.desc); err != nil {
+			log.Fatalf("could not marshal %v", d.desc)
+		}
+		ret[i] = proto.KeyValue{
+			Key:   MakeDescMetadataKey(d.desc.GetID()),
+			Value: value,
+		}
+		i++
+	}
+
+	return ret
+}
+
+// IsSystemID returns true if this ID is reserved for system objects.
+func IsSystemID(id ID) bool {
+	return id > 0 && id <= MaxReservedDescID
+}

--- a/storage/client_test.go
+++ b/storage/client_test.go
@@ -83,7 +83,7 @@ func createTestStoreWithEngine(t *testing.T, eng engine.Engine, clock *hlc.Clock
 	}
 	lSender.AddStore(store)
 	if bootstrap {
-		if err := store.BootstrapRange(); err != nil {
+		if err := store.BootstrapRange(nil); err != nil {
 			t.Fatal(err)
 		}
 	}
@@ -236,7 +236,7 @@ func (m *multiTestContext) addStore() {
 
 		// Bootstrap the initial range on the first store
 		if idx == 0 {
-			if err := store.BootstrapRange(); err != nil {
+			if err := store.BootstrapRange(nil); err != nil {
 				m.t.Fatal(err)
 			}
 		}

--- a/storage/engine/mvcc.go
+++ b/storage/engine/mvcc.go
@@ -396,11 +396,10 @@ func MVCCGetProto(engine Engine, key proto.Key, timestamp proto.Timestamp, consi
 // MVCCPutProto sets the given key to the protobuf-serialized byte
 // string of msg and the provided timestamp.
 func MVCCPutProto(engine Engine, ms *MVCCStats, key proto.Key, timestamp proto.Timestamp, txn *proto.Transaction, msg gogoproto.Message) error {
-	data, err := gogoproto.Marshal(msg)
-	if err != nil {
+	value := proto.Value{}
+	if err := value.SetProto(msg); err != nil {
 		return err
 	}
-	value := proto.Value{Bytes: data}
 	value.InitChecksum(key)
 	return MVCCPut(engine, ms, key, timestamp, value, txn)
 }

--- a/storage/replica_test.go
+++ b/storage/replica_test.go
@@ -165,7 +165,7 @@ func (tc *testContext) Start(t testing.TB) {
 		tc.store.splitQueue().SetDisabled(true)
 
 		if tc.rng == nil && tc.bootstrapMode == bootstrapRangeWithMetadata {
-			if err := tc.store.BootstrapRange(); err != nil {
+			if err := tc.store.BootstrapRange(nil); err != nil {
 				t.Fatal(err)
 			}
 		}

--- a/storage/store_test.go
+++ b/storage/store_test.go
@@ -178,7 +178,7 @@ func createTestStoreWithoutStart(t *testing.T) (*Store, *hlc.ManualClock, *stop.
 	if err := store.Bootstrap(proto.StoreIdent{NodeID: 1, StoreID: 1}, stopper); err != nil {
 		t.Fatal(err)
 	}
-	if err := store.BootstrapRange(); err != nil {
+	if err := store.BootstrapRange(nil); err != nil {
 		t.Fatal(err)
 	}
 	return store, manual, stopper
@@ -226,7 +226,7 @@ func TestStoreInitAndBootstrap(t *testing.T) {
 	}
 
 	// Bootstrap first range.
-	if err := store.BootstrapRange(); err != nil {
+	if err := store.BootstrapRange(nil); err != nil {
 		t.Errorf("failure to create first range: %s", err)
 	}
 


### PR DESCRIPTION
- move system db/table info to sql/system.go
- relocate KV pairs to be written at bootstrap time

This is still not great, but at least removes storage's dependency on sql.
The system re-org is in advance of all the other tables to be added.
