### PR TITLE
Add a timeout to `Context.GetHTTPClient()`

### DIFF
--- a/base/context.go
+++ b/base/context.go
@@ -21,6 +21,7 @@ import (
 	"crypto/tls"
 	"net/http"
 	"sync"
+	"time"
 
 	"github.com/cockroachdb/cockroach/security"
 	"github.com/cockroachdb/cockroach/util"
@@ -34,6 +35,9 @@ const (
 	defaultUser     = security.RootUser
 	plainScheme     = "http"
 	sslScheme       = "https"
+
+	// NetworkTimeout is the timeout used for network operations.
+	NetworkTimeout = 3 * time.Second
 )
 
 // Context is embedded by server.Context. A base context is not meant to be
@@ -166,7 +170,10 @@ func (ctx *Context) GetHTTPClient() (*http.Client, error) {
 	if err != nil {
 		return nil, err
 	}
-	ctx.httpClient = &http.Client{Transport: &http.Transport{TLSClientConfig: tlsConfig}}
+	ctx.httpClient = &http.Client{
+		Transport: &http.Transport{TLSClientConfig: tlsConfig},
+		Timeout:   NetworkTimeout,
+	}
 
 	return ctx.httpClient, nil
 }

--- a/gossip/resolver/node_lookup.go
+++ b/gossip/resolver/node_lookup.go
@@ -23,14 +23,11 @@ import (
 	"io/ioutil"
 	"net"
 	"net/http"
-	"time"
 
 	"github.com/cockroachdb/cockroach/base"
 	"github.com/cockroachdb/cockroach/util"
 	"github.com/cockroachdb/cockroach/util/log"
 )
-
-const lookupTimeout = time.Second * 3
 
 // nodeLookupResolver implements Resolver.
 // It queries http(s)://<address>/_status/details/local and extracts the node's
@@ -73,7 +70,7 @@ func (nl *nodeLookupResolver) GetAddress() (net.Addr, error) {
 		}
 		nl.httpClient = &http.Client{
 			Transport: &http.Transport{TLSClientConfig: tlsConfig},
-			Timeout:   lookupTimeout,
+			Timeout:   base.NetworkTimeout,
 		}
 	}
 

--- a/rpc/tls.go
+++ b/rpc/tls.go
@@ -28,8 +28,8 @@ import (
 	"net/http"
 	"net/rpc"
 	"strings"
-	"time"
 
+	"github.com/cockroachdb/cockroach/base"
 	"github.com/cockroachdb/cockroach/util"
 	"github.com/cockroachdb/cockroach/util/log"
 )
@@ -50,7 +50,7 @@ func tlsListen(network, address string, config *tls.Config) (net.Listener, error
 }
 
 var defaultDialer = net.Dialer{
-	Timeout: 3 * time.Second,
+	Timeout: base.NetworkTimeout,
 }
 
 // tlsDial wraps either net.Dial or crypto/tls.Dial, depending on the contents of

--- a/server/server_test.go
+++ b/server/server_test.go
@@ -228,17 +228,9 @@ func TestAcceptEncoding(t *testing.T) {
 	defer leaktest.AfterTest(t)
 	s := StartTestServer(t)
 	defer s.Stop()
-	// We can't use the standard test client. Create our own.
-	tlsConfig, err := testContext.GetClientTLSConfig()
+	client, err := testContext.GetHTTPClient()
 	if err != nil {
 		t.Fatal(err)
-	}
-	client := &http.Client{
-		Transport: &http.Transport{
-			TLSClientConfig:    tlsConfig,
-			Proxy:              http.ProxyFromEnvironment,
-			DisableCompression: true,
-		},
 	}
 
 	testData := []struct {

--- a/server/status.go
+++ b/server/status.go
@@ -26,6 +26,7 @@ import (
 	"strconv"
 	"time"
 
+	"github.com/cockroachdb/cockroach/base"
 	"github.com/cockroachdb/cockroach/client"
 	"github.com/cockroachdb/cockroach/gossip"
 	"github.com/cockroachdb/cockroach/keys"
@@ -89,10 +90,6 @@ const (
 	statusStoresPrefix = "/_status/stores/"
 	// statusStorePattern exposes status for a single store.
 	statusStorePattern = "/_status/stores/:store_id"
-
-	// statusProxyTimeout is the timeout used when proxying a request to another
-	// node.
-	statusProxyTimeout = time.Second
 )
 
 // Pattern for local used when determining the node ID.
@@ -117,7 +114,7 @@ func newStatusServer(db *client.DB, gossip *gossip.Gossip, ctx *Context) *status
 	}
 	httpClient := &http.Client{
 		Transport: &http.Transport{TLSClientConfig: tlsConfig},
-		Timeout:   statusProxyTimeout,
+		Timeout:   base.NetworkTimeout,
 	}
 
 	server := &statusServer{


### PR DESCRIPTION
Also DRY acceptance test client creation.

@bram this should make retry actually work when the server is hanging.
