### PR TITLE
Give SQL transactions a debug name

### DIFF
--- a/client/client_test.go
+++ b/client/client_test.go
@@ -485,7 +485,7 @@ func concurrentIncrements(db *client.DB, t *testing.T) {
 			wgStart.Wait()
 
 			if err := db.Txn(func(txn *client.Txn) error {
-				txn.SetDebugName(fmt.Sprintf("test-%d", i))
+				txn.SetDebugName(fmt.Sprintf("test-%d", i), 0)
 
 				// Retrieve the other key.
 				gr, err := txn.Get(readKey)

--- a/client/db.go
+++ b/client/db.go
@@ -416,7 +416,9 @@ func (db *DB) Run(b *Batch) error {
 //
 // TODO(pmattis): Allow transaction options to be specified.
 func (db *DB) Txn(retryable func(txn *Txn) error) error {
-	return newTxn(*db).exec(retryable)
+	txn := NewTxn(*db)
+	txn.SetDebugName("", 1)
+	return txn.exec(retryable)
 }
 
 // send runs the specified calls synchronously in a single batch and

--- a/client/db_test.go
+++ b/client/db_test.go
@@ -349,7 +349,6 @@ func TestCommonMethods(t *testing.T) {
 		key{dbType, "Run"}:                   {},
 		key{dbType, "Txn"}:                   {},
 		key{txnType, "CommitInBatch"}:        {},
-		key{txnType, "ToProto"}:              {},
 		key{txnType, "Commit"}:               {},
 		key{txnType, "Rollback"}:             {},
 		key{txnType, "DebugName"}:            {},

--- a/client/txn.go
+++ b/client/txn.go
@@ -78,30 +78,25 @@ type Txn struct {
 	haveEndTxn   bool // True if there was an explicit EndTransaction
 }
 
-func newTxn(db DB) *Txn {
+// NewTxn returns a new txn.
+func NewTxn(db DB) *Txn {
 	txn := &Txn{
 		db:      db,
 		wrapped: db.Sender,
 	}
 	txn.db.Sender = (*txnSender)(txn)
-
-	// Caller's caller.
-	file, line, fun := caller.Lookup(2)
-	txn.Proto.Name = fmt.Sprintf("%s:%d %s", file, line, fun)
 	return txn
-}
-
-// NewTxn returns a new txn.
-func NewTxn(db DB) *Txn {
-	return newTxn(db)
 }
 
 // SetDebugName sets the debug name associated with the transaction which will
 // appear in log files and the web UI. Each transaction starts out with an
 // automatically assigned debug name composed of the file and line number where
 // the transaction was created.
-func (txn *Txn) SetDebugName(name string) {
-	file, line, _ := caller.Lookup(1)
+func (txn *Txn) SetDebugName(name string, depth int) {
+	file, line, fun := caller.Lookup(depth + 1)
+	if name == "" {
+		name = fun
+	}
 	txn.Proto.Name = fmt.Sprintf("%s:%d %s", file, line, name)
 }
 

--- a/client/txn_test.go
+++ b/client/txn_test.go
@@ -123,7 +123,7 @@ func TestTxnResetTxnOnAbort(t *testing.T) {
 	txn.db.Sender.Send(context.Background(),
 		proto.Call{Args: testPutReq, Reply: &proto.PutResponse{}})
 
-	if len(txn.txn.ID) != 0 {
+	if len(txn.Proto.ID) != 0 {
 		t.Errorf("expected txn to be cleared")
 	}
 }

--- a/kv/txn_coord_sender.go
+++ b/kv/txn_coord_sender.go
@@ -513,7 +513,7 @@ func (tc *TxnCoordSender) sendOne(ctx context.Context, call proto.Call) {
 		}
 		call.Reply.Reset()
 		if err := tmpDB.Txn(func(txn *client.Txn) error {
-			txn.SetDebugName("auto-wrap")
+			txn.SetDebugName("auto-wrap", 0)
 			b := &client.Batch{}
 			b.InternalAddCall(call)
 			return txn.CommitInBatch(b)

--- a/kv/txn_correctness_test.go
+++ b/kv/txn_correctness_test.go
@@ -563,7 +563,7 @@ func (hv *historyVerifier) runTxn(txnIdx int, priority int32,
 	var retry int
 	txnName := fmt.Sprintf("txn%d", txnIdx)
 	err := db.Txn(func(txn *client.Txn) error {
-		txn.SetDebugName(txnName)
+		txn.SetDebugName(txnName, 0)
 		if isolation == proto.SNAPSHOT {
 			txn.SetSnapshotIsolation()
 		}

--- a/sql/server.go
+++ b/sql/server.go
@@ -219,6 +219,7 @@ func (s *Server) execStmt(stmt parser.Statement, req driver.Request, planMaker *
 			// Start a transaction here and not in planMaker to prevent begin
 			// transaction from being called within an auto-transaction below.
 			planMaker.txn = client.NewTxn(*s.db)
+			planMaker.txn.SetDebugName("sql", 0)
 		}
 	} else if planMaker.txn.Proto.Status == proto.ABORTED {
 		switch stmt := stmt.(type) {

--- a/sql/server.go
+++ b/sql/server.go
@@ -115,7 +115,9 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	}
 	// Open a pending transaction if needed.
 	if planMaker.session.Txn != nil {
-		planMaker.txn = client.NewTxnFromProto(*s.db, *planMaker.session.Txn)
+		txn := client.NewTxn(*s.db)
+		txn.Proto = *planMaker.session.Txn
+		planMaker.txn = txn
 	}
 
 	// Send the Request for SQL execution and set the application-level error
@@ -125,8 +127,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	// Send back the session state even if there were application-level errors.
 	// Add transaction to session state.
 	if planMaker.txn != nil {
-		t := planMaker.txn.ToProto()
-		planMaker.session.Txn = &t
+		planMaker.session.Txn = &planMaker.txn.Proto
 	} else {
 		planMaker.session.Txn = nil
 	}
@@ -219,7 +220,7 @@ func (s *Server) execStmt(stmt parser.Statement, req driver.Request, planMaker *
 			// transaction from being called within an auto-transaction below.
 			planMaker.txn = client.NewTxn(*s.db)
 		}
-	} else if planMaker.txn.ToProto().Status == proto.ABORTED {
+	} else if planMaker.txn.Proto.Status == proto.ABORTED {
 		switch stmt := stmt.(type) {
 		case *parser.CommitTransaction, *parser.RollbackTransaction:
 			// Reset to allow starting a new transaction.


### PR DESCRIPTION
Just "sql" for now.

Easier to review commit-by-commit, first one is cleanup.
