### PR TITLE
Create system.users table.

### DIFF
--- a/kv/dist_sender_server_test.go
+++ b/kv/dist_sender_server_test.go
@@ -258,10 +258,11 @@ func TestSingleRangeReverseScan(t *testing.T) {
 		t.Errorf("expected 2 rows; got %d", l)
 	}
 	// Case 3: Test proto.KeyMax
+	// TODO(marc): this depends on the sql system objects.
 	if rows, err := db.ReverseScan("g", proto.KeyMax, 0); err != nil {
 		t.Fatalf("unexpected error on ReverseScan: %s", err)
-	} else if l := len(rows); l != 8 {
-		t.Errorf("expected 2 rows; got %d", l)
+	} else if l := len(rows); l != 10 {
+		t.Errorf("expected 10 rows; got %d", l)
 	}
 	// Case 4: Test keys.SystemMax
 	if rows, err := db.ReverseScan(keys.SystemMax, "b", 0); err != nil {

--- a/server/node_test.go
+++ b/server/node_test.go
@@ -121,6 +121,7 @@ func TestBootstrapCluster(t *testing.T) {
 	for _, kv := range rows {
 		keys = append(keys, kv.Key)
 	}
+	// TODO(marc): this depends on the sql system objects.
 	var expectedKeys = []proto.Key{
 		proto.MakeKey(proto.Key("\x00\x00meta1"), proto.KeyMax),
 		proto.MakeKey(proto.Key("\x00\x00meta2"), proto.KeyMax),
@@ -133,9 +134,11 @@ func TestBootstrapCluster(t *testing.T) {
 		proto.Key("\xff\n\x02\n\x01\tsystem\x00\x01\n\x03"),
 		proto.Key("\xff\n\x02\n\x01\n\x01descriptor\x00\x01\n\x03"),
 		proto.Key("\xff\n\x02\n\x01\n\x01namespace\x00\x01\n\x03"),
+		proto.Key("\xff\n\x02\n\x01\n\x01users\x00\x01\n\x03"),
 		proto.Key("\xff\n\x03\n\x01\n\x01\n\x02"),
 		proto.Key("\xff\n\x03\n\x01\n\x02\n\x02"),
 		proto.Key("\xff\n\x03\n\x01\n\x03\n\x02"),
+		proto.Key("\xff\n\x03\n\x01\n\x04\n\x02"),
 	}
 	if !reflect.DeepEqual(keys, expectedKeys) {
 		t.Errorf("expected keys mismatch:\n%s\n  -- vs. -- \n\n%s",

--- a/sql/create_test.go
+++ b/sql/create_test.go
@@ -72,7 +72,8 @@ func TestDatabaseDescriptor(t *testing.T) {
 	if kvs, err := kvDB.Scan(start, start.PrefixEnd(), 0); err != nil {
 		t.Fatal(err)
 	} else {
-		if a, e := len(kvs), 3; a != e {
+		// TODO(marc): this is the number of system tables + 1.
+		if a, e := len(kvs), 4; a != e {
 			t.Fatalf("expected %d keys to have been written, found %d keys", e, a)
 		}
 	}

--- a/sql/database.go
+++ b/sql/database.go
@@ -38,7 +38,7 @@ func (dk databaseKey) Name() string {
 func makeDatabaseDesc(p *parser.CreateDatabase) DatabaseDescriptor {
 	return DatabaseDescriptor{
 		Name:       p.Name.String(),
-		Privileges: NewDefaultDatabasePrivilegeDescriptor(),
+		Privileges: NewDefaultPrivilegeDescriptor(),
 	}
 }
 

--- a/sql/privilege/privilege.go
+++ b/sql/privilege/privilege.go
@@ -42,6 +42,13 @@ const (
 	UPDATE
 )
 
+// Predefined sets of privileges.
+var (
+	ReadData      = List{GRANT, SELECT}
+	WriteData     = List{INSERT, DELETE, UPDATE}
+	ReadWriteData = List{GRANT, SELECT, INSERT, DELETE, UPDATE}
+)
+
 // Mask returns the bitmask for a given privilege.
 func (k Kind) Mask() uint32 {
 	return 1 << k

--- a/sql/structured.go
+++ b/sql/structured.go
@@ -256,7 +256,7 @@ func (desc *TableDescriptor) Validate() error {
 		}
 	}
 	// Validate the privilege descriptor.
-	return desc.Privileges.Validate(IsSystemID(desc.GetID()))
+	return desc.Privileges.Validate(desc.GetID())
 }
 
 // FindColumnByName finds the column with specified name.
@@ -337,5 +337,5 @@ func (desc *DatabaseDescriptor) Validate() error {
 		return fmt.Errorf("invalid database ID 0")
 	}
 	// Validate the privilege descriptor.
-	return desc.Privileges.Validate(IsSystemID(desc.GetID()))
+	return desc.Privileges.Validate(desc.GetID())
 }

--- a/sql/structured_test.go
+++ b/sql/structured_test.go
@@ -42,7 +42,7 @@ func TestAllocateIDs(t *testing.T) {
 			{Name: "d", ColumnNames: []string{"b", "a"}},
 			{Name: "e", ColumnNames: []string{"b"}},
 		},
-		Privileges: sql.NewDefaultDatabasePrivilegeDescriptor(),
+		Privileges: sql.NewDefaultPrivilegeDescriptor(),
 	}
 	if err := desc.AllocateIDs(); err != nil {
 		t.Fatal(err)
@@ -63,7 +63,7 @@ func TestAllocateIDs(t *testing.T) {
 			{ID: 3, Name: "e", ColumnIDs: []sql.ColumnID{2}, ColumnNames: []string{"b"},
 				ImplicitColumnIDs: []sql.ColumnID{1}},
 		},
-		Privileges:   sql.NewDefaultDatabasePrivilegeDescriptor(),
+		Privileges:   sql.NewDefaultPrivilegeDescriptor(),
 		NextColumnID: 4,
 		NextIndexID:  4,
 	}

--- a/sql/testdata/system
+++ b/sql/testdata/system
@@ -9,6 +9,7 @@ SHOW TABLES FROM system
 ----
 descriptor
 namespace
+users
 
 query ITTB
 EXPLAIN (DEBUG) SELECT * FROM system.namespace
@@ -17,6 +18,7 @@ EXPLAIN (DEBUG) SELECT * FROM system.namespace
 1 /namespace/primary/0/'test'/id       1000 true
 2 /namespace/primary/1/'descriptor'/id 3    true
 3 /namespace/primary/1/'namespace'/id  2    true
+4 /namespace/primary/1/'users'/id      4    true
 
 query ITI
 SELECT * FROM system.namespace
@@ -25,6 +27,7 @@ SELECT * FROM system.namespace
 0 test       1000
 1 descriptor 3
 1 namespace  2
+1 users      4
 
 query I
 SELECT id FROM system.descriptor
@@ -32,6 +35,7 @@ SELECT id FROM system.descriptor
 1
 2
 3
+4
 1000
 
 query TTT
@@ -48,6 +52,11 @@ query TTT
 SHOW GRANTS ON system.descriptor
 ----
 descriptor root GRANT,SELECT
+
+query TTT
+SHOW GRANTS ON system.users
+----
+users root DELETE,GRANT,INSERT,SELECT,UPDATE
 
 # Non-root users can have privileges on system objects, but limited to GRANT, SELECT.
 statement error user testuser must not have ALL privileges on system objects


### PR DESCRIPTION
Work towards #2090.

This creates a new system table storing username/hashed-password
that is currently in the users config (removal will come next).

The main part of this change is applying custom permissions based
on the system table. descriptor and namespace are read-only,
but users needs to be modified.
