### PR TITLE
Add the actual content to a gossip callback.

### DIFF
--- a/gossip/gossip.go
+++ b/gossip/gossip.go
@@ -276,7 +276,7 @@ func (g *Gossip) GetInfosAsJSON() ([]byte, error) {
 // of info denoted by key. The contentsChanged bool indicates whether
 // the info contents were updated. False indicates the info timestamp
 // was refreshed, but its contents remained unchanged.
-type Callback func(key string, contentsChanged bool)
+type Callback func(key string, contentsChanged bool, content interface{})
 
 // RegisterCallback registers a callback for a key pattern to be
 // invoked whenever new info for a gossip key matching pattern is

--- a/gossip/infostore.go
+++ b/gossip/infostore.go
@@ -167,7 +167,7 @@ func (is *infoStore) addInfo(i *info) error {
 	if i.seq > is.MaxSeq {
 		is.MaxSeq = i.seq
 	}
-	is.processCallbacks(i.Key, contentsChanged)
+	is.processCallbacks(i.Key, contentsChanged, i.Val)
 	return nil
 }
 
@@ -203,7 +203,7 @@ func (is *infoStore) registerCallback(pattern string, method Callback) {
 	// Run callbacks in a goroutine to avoid mutex reentry.
 	go func() {
 		for _, i := range infos {
-			method(i.Key, true /* contentsChanged */)
+			method(i.Key, true /* contentsChanged */, i.Val)
 		}
 	}()
 }
@@ -211,7 +211,7 @@ func (is *infoStore) registerCallback(pattern string, method Callback) {
 // processCallbacks processes callbacks for the specified key by
 // matching callback regular expression against the key and invoking
 // the corresponding callback method on a match.
-func (is *infoStore) processCallbacks(key string, contentsChanged bool) {
+func (is *infoStore) processCallbacks(key string, contentsChanged bool, content interface{}) {
 	var matches []callback
 	for _, cb := range is.callbacks {
 		if cb.pattern.MatchString(key) {
@@ -221,7 +221,7 @@ func (is *infoStore) processCallbacks(key string, contentsChanged bool) {
 	// Run callbacks in a goroutine to avoid mutex reentry.
 	go func() {
 		for _, cb := range matches {
-			cb.method(key, contentsChanged)
+			cb.method(key, contentsChanged, content)
 		}
 	}()
 }

--- a/gossip/infostore_test.go
+++ b/gossip/infostore_test.go
@@ -298,7 +298,7 @@ type callbackRecord struct {
 	sync.Mutex
 }
 
-func (cr *callbackRecord) Add(key string, contentsChanged bool) {
+func (cr *callbackRecord) Add(key string, contentsChanged bool, _ interface{}) {
 	cr.Lock()
 	defer cr.Unlock()
 	cr.keys = append(cr.keys, fmt.Sprintf("%s-%t", key, contentsChanged))

--- a/storage/allocator.go
+++ b/storage/allocator.go
@@ -142,7 +142,7 @@ func storeDescFromGossip(key string, g *gossip.Gossip) (*proto.StoreDescriptor, 
 
 // storeGossipUpdate is a gossip callback triggered whenever store information
 // is gossiped. It just tracks the gossiped keys.
-func (a *allocator) storeGossipUpdate(key string, _ bool) {
+func (a *allocator) storeGossipUpdate(key string, _ bool, _ interface{}) {
 	a.Lock()
 	defer a.Unlock()
 

--- a/storage/allocator_test.go
+++ b/storage/allocator_test.go
@@ -57,7 +57,7 @@ var multiDCConfig = config.ZoneConfig{
 func gossipStores(g *gossip.Gossip, stores []*proto.StoreDescriptor, t *testing.T) {
 	var wg sync.WaitGroup
 	wg.Add(len(stores))
-	g.RegisterCallback(gossip.MakePrefixPattern(gossip.KeyStorePrefix), func(_ string, _ bool) { wg.Done() })
+	g.RegisterCallback(gossip.MakePrefixPattern(gossip.KeyStorePrefix), func(_ string, _ bool, _ interface{}) { wg.Done() })
 
 	for _, s := range stores {
 		keyStoreGossip := gossip.MakeStoreKey(s.StoreID)
@@ -538,8 +538,9 @@ func TestAllocatorCapacityGossipUpdate(t *testing.T) {
 
 	// Order and value of contentsChanged shouldn't matter.
 	key := "testkey"
-	s.allocator().storeGossipUpdate(key, true)
-	s.allocator().storeGossipUpdate(key, false)
+	var content interface{}
+	s.allocator().storeGossipUpdate(key, true, content)
+	s.allocator().storeGossipUpdate(key, false, content)
 
 	expectedKeys := map[string]struct{}{key: {}}
 	s.allocator().Lock()
@@ -665,7 +666,7 @@ func Example_rebalancing() {
 	alloc.deterministic = true
 
 	var wg sync.WaitGroup
-	g.RegisterCallback(gossip.MakePrefixPattern(gossip.KeyStorePrefix), func(_ string, _ bool) { wg.Done() })
+	g.RegisterCallback(gossip.MakePrefixPattern(gossip.KeyStorePrefix), func(_ string, _ bool, _ interface{}) { wg.Done() })
 
 	const generations = 100
 	const nodes = 20

--- a/storage/client_raft_test.go
+++ b/storage/client_raft_test.go
@@ -518,7 +518,7 @@ func TestStoreRangeReplicate(t *testing.T) {
 	var wg sync.WaitGroup
 	wg.Add(len(mtc.stores))
 	key := gossip.MakePrefixPattern(gossip.KeyStorePrefix)
-	mtc.stores[0].Gossip().RegisterCallback(key, func(_ string, _ bool) { wg.Done() })
+	mtc.stores[0].Gossip().RegisterCallback(key, func(_ string, _ bool, _ interface{}) { wg.Done() })
 	for _, s := range mtc.stores {
 		s.GossipStore()
 	}

--- a/storage/store.go
+++ b/storage/store.go
@@ -653,19 +653,14 @@ func (s *Store) maybeGossipConfigs() error {
 
 // configGossipUpdate is a callback for gossip updates to
 // configuration maps which affect range split boundaries.
-func (s *Store) configGossipUpdate(key string, contentsChanged bool) {
+func (s *Store) configGossipUpdate(key string, contentsChanged bool, content interface{}) {
 	if !contentsChanged {
 		return // Skip update if it's just a newer timestamp or fewer hops to info
 	}
 	ctx := s.Context(nil)
-	info, err := s.ctx.Gossip.GetInfo(key)
-	if err != nil {
-		log.Errorc(ctx, "unable to fetch %s config from gossip: %s", key, err)
-		return
-	}
-	configMap, ok := info.(config.PrefixConfigMap)
+	configMap, ok := content.(config.PrefixConfigMap)
 	if !ok {
-		log.Errorc(ctx, "gossiped info is not a prefix configuration map: %+v", info)
+		log.Errorc(ctx, "gossiped info is not a prefix configuration map: %+v", content)
 		return
 	}
 	s.maybeSplitRangesByConfigs(configMap)


### PR DESCRIPTION
The typical call to a gossip callback will be to perform some action
after receiving the updated content. Only getting the key and not
the content itself forces the caller to perform another locking call
to the infostore. This removes the need for the second call.
