### PR TITLE
Increase tolerance of TestRetryExceedsMaxBackoff

### DIFF
--- a/util/retry/retry_test.go
+++ b/util/retry/retry_test.go
@@ -28,13 +28,13 @@ func TestRetryExceedsMaxBackoff(t *testing.T) {
 	opts := Options{
 		InitialBackoff: time.Microsecond * 10,
 		MaxBackoff:     time.Microsecond * 10,
-		Multiplier:     10e4,
+		Multiplier:     1e5,
 		MaxRetries:     1,
 	}
 
 	// tolerate a duration two orders of magnitude lower than if MaxBackoff is
 	// not respected.
-	fudgeFactor := opts.Multiplier / 10e2
+	fudgeFactor := opts.Multiplier / 100
 
 	attempts := 0
 	start := time.Now()


### PR DESCRIPTION
This test flaked in a circle CI build, increasing the duration tolerance.

It was supposed to be verifying that the execution time was two orders of
magnitude faster than the worst-case scenario where MaxBackoff was not being
respected.  It was actually constraining to three orders of magnitude less (10e2
is 1000).

build in question: https://circleci.com/gh/cockroachdb/cockroach/6411
