### PR TITLE
Restrict KV endpoint to NodeUser only.

### DIFF
--- a/acceptance/localcluster/localcluster.go
+++ b/acceptance/localcluster/localcluster.go
@@ -312,11 +312,6 @@ func (l *Cluster) createNodeCerts() {
 	maybePanic(security.RunCreateNodeCert(l.CertsDir, 512, nodes))
 }
 
-func (l *Cluster) createClientCerts() {
-	log.Infof("creating client certs")
-	maybePanic(security.RunCreateClientCert(l.CertsDir, 512, security.RootUser))
-}
-
 func (l *Cluster) startNode(i int) *Container {
 	gossipNodes := []string{}
 	for i := range l.Nodes {
@@ -429,7 +424,6 @@ func (l *Cluster) Start() {
 	l.initCluster()
 	l.createCACert()
 	l.createNodeCerts()
-	l.createClientCerts()
 
 	l.monitorStopper = make(chan struct{})
 	go l.monitor(l.monitorStopper)

--- a/acceptance/util.go
+++ b/acceptance/util.go
@@ -30,7 +30,7 @@ import (
 
 // makeDBClient creates a DB client for node 'i' using the cluster certs dir.
 func makeDBClient(t *testing.T, cluster *localcluster.Cluster, node int) *client.DB {
-	return makeDBClientForUser(t, cluster, security.RootUser, node)
+	return makeDBClientForUser(t, cluster, security.NodeUser, node)
 }
 
 // makeDBClientForUser creates a DB client for node 'i' and user 'user'.

--- a/cli/kv.go
+++ b/cli/kv.go
@@ -32,11 +32,11 @@ import (
 )
 
 func makeDBClient() *client.DB {
-	// TODO(pmattis): Initialize the user to something more
-	// reasonable. Perhaps Context.Addr should be considered a URL.
+	// TODO(marc): KV endpoints are now restricted to node users.
+	// This should probably be made more explicit.
 	db, err := client.Open(fmt.Sprintf("%s://%s@%s?certs=%s",
 		context.RequestScheme(),
-		security.RootUser,
+		security.NodeUser,
 		context.Addr,
 		context.Certs))
 	if err != nil {

--- a/cli/sql_util.go
+++ b/cli/sql_util.go
@@ -29,8 +29,8 @@ import (
 )
 
 func makeSQLClient() *sql.DB {
-	// TODO(pmattis): Initialize the user to something more
-	// reasonable. Perhaps Context.Addr should be considered a URL.
+	// Use the sql administrator by default (root user).
+	// TODO(marc): allow passing on the commandline.
 	db, err := sql.Open("cockroach",
 		fmt.Sprintf("%s://%s@%s?certs=%s",
 			context.RequestScheme(),

--- a/client/admin_test.go
+++ b/client/admin_test.go
@@ -33,7 +33,8 @@ func Example_zone() {
 	s := server.StartTestServer(nil)
 	defer s.Stop()
 
-	context := testutils.NewRootTestBaseContext()
+	// There are no particular permissions on admin endpoints for now.
+	context := testutils.NewTestBaseContext(server.TestUser)
 	client := client.NewAdminClient(context, s.ServingAddr(), client.Zone)
 
 	const yamlConfig = `

--- a/client/db.go
+++ b/client/db.go
@@ -147,9 +147,6 @@ func (r Result) String() string {
 type DB struct {
 	Sender Sender
 
-	// user is the default user to set on API calls. If User is set to
-	// non-empty in call arguments, this value is ignored.
-	user string
 	// userPriority is the default user priority to set on API calls. If
 	// userPriority is set non-zero in call arguments, this value is
 	// ignored.
@@ -215,7 +212,6 @@ func Open(addr string, opts ...Option) (*DB, error) {
 
 	db := &DB{
 		Sender:          sender,
-		user:            ctx.User,
 		txnRetryOptions: DefaultTxnRetryOptions,
 	}
 
@@ -439,9 +435,6 @@ func (db *DB) send(calls ...proto.Call) (err error) {
 
 	if len(calls) == 1 {
 		c := calls[0]
-		if c.Args.Header().User == "" {
-			c.Args.Header().User = db.user
-		}
 		if c.Args.Header().UserPriority == nil && db.userPriority != 0 {
 			c.Args.Header().UserPriority = gogoproto.Int32(db.userPriority)
 		}

--- a/client/db_test.go
+++ b/client/db_test.go
@@ -24,6 +24,7 @@ import (
 	"testing"
 
 	"github.com/cockroachdb/cockroach/client"
+	"github.com/cockroachdb/cockroach/security"
 	"github.com/cockroachdb/cockroach/server"
 	"github.com/cockroachdb/cockroach/util/caller"
 	"github.com/cockroachdb/cockroach/util/leaktest"
@@ -32,7 +33,9 @@ import (
 
 func setup() (*server.TestServer, *client.DB) {
 	s := server.StartTestServer(nil)
-	db, err := client.Open("https://root@" + s.ServingAddr() + "?certs=test_certs")
+	db, err := client.Open(fmt.Sprintf("https://%s@%s?certs=test_certs",
+		security.NodeUser,
+		s.ServingAddr()))
 	if err != nil {
 		log.Fatal(err)
 	}
@@ -273,7 +276,7 @@ func ExampleDB_Insecure() {
 	log.Infof("Test server listening on %s: %s", s.Ctx.RequestScheme(), s.ServingAddr())
 	defer s.Stop()
 
-	db, err := client.Open("http://root@" + s.ServingAddr())
+	db, err := client.Open("http://foo@" + s.ServingAddr())
 	if err != nil {
 		log.Fatal(err)
 	}
@@ -300,7 +303,7 @@ func TestOpenArgs(t *testing.T) {
 		addr      string
 		expectErr bool
 	}{
-		{"https://root@" + s.ServingAddr() + "?certs=test_certs", false},
+		{"https://" + server.TestUser + "@" + s.ServingAddr() + "?certs=test_certs", false},
 		{"https://" + s.ServingAddr() + "?certs=test_certs", false},
 		{"https://" + s.ServingAddr() + "?certs=foo", true},
 		{s.ServingAddr(), true},

--- a/client/txn_test.go
+++ b/client/txn_test.go
@@ -130,17 +130,13 @@ func TestTxnResetTxnOnAbort(t *testing.T) {
 
 // TestTransactionConfig verifies the proper unwrapping and
 // re-wrapping of the client's sender when starting a transaction.
-// Also verifies that User and UserPriority are propagated to the
+// Also verifies that the UserPriority is propagated to the
 // transactional client.
 func TestTransactionConfig(t *testing.T) {
 	defer leaktest.AfterTest(t)
 	db := newDB(newTestSender(func(call proto.Call) {}))
-	db.user = "foo"
 	db.userPriority = 101
 	if err := db.Txn(func(txn *Txn) error {
-		if txn.db.user != db.user {
-			t.Errorf("expected txn user %s; got %s", db.user, txn.db.user)
-		}
 		if txn.db.userPriority != db.userPriority {
 			t.Errorf("expected txn user priority %d; got %d", db.userPriority, txn.db.userPriority)
 		}

--- a/examples/kv_bank/main.go
+++ b/examples/kv_bank/main.go
@@ -263,7 +263,8 @@ func main() {
 		security.SetReadFileFn(securitytest.Asset)
 		serv := server.StartTestServer(nil)
 		defer serv.Stop()
-		*dbName = "https://root@" + serv.ServingAddr() + "?certs=test_certs"
+		*dbName = fmt.Sprintf("https://%s@%s?certs=test_certs",
+			security.NodeUser, serv.ServingAddr())
 	}
 	// Create a database handle.
 	db, err := client.Open(*dbName)

--- a/gossip/client_test.go
+++ b/gossip/client_test.go
@@ -21,6 +21,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/cockroachdb/cockroach/base"
 	"github.com/cockroachdb/cockroach/proto"
 	"github.com/cockroachdb/cockroach/rpc"
 	"github.com/cockroachdb/cockroach/util"
@@ -40,7 +41,7 @@ const (
 func startGossip(t *testing.T) (local, remote *Gossip, stopper *stop.Stopper) {
 	lclock := hlc.NewClock(hlc.UnixNano)
 	stopper = stop.NewStopper()
-	lRPCContext := rpc.NewContext(nodeTestBaseContext, lclock, stopper)
+	lRPCContext := rpc.NewContext(&base.Context{Insecure: true}, lclock, stopper)
 
 	laddr := util.CreateTestAddr("tcp")
 	lserver := rpc.NewServer(laddr, lRPCContext)
@@ -56,7 +57,7 @@ func startGossip(t *testing.T) (local, remote *Gossip, stopper *stop.Stopper) {
 	}
 	rclock := hlc.NewClock(hlc.UnixNano)
 	raddr := util.CreateTestAddr("tcp")
-	rRPCContext := rpc.NewContext(nodeTestBaseContext, rclock, stopper)
+	rRPCContext := rpc.NewContext(&base.Context{Insecure: true}, rclock, stopper)
 	rserver := rpc.NewServer(raddr, rRPCContext)
 	if err := rserver.Start(); err != nil {
 		t.Fatal(err)
@@ -97,7 +98,7 @@ func TestClientGossip(t *testing.T) {
 
 	// Use an insecure context. We're talking to unix socket which are not in the certs.
 	lclock := hlc.NewClock(hlc.UnixNano)
-	rpcContext := rpc.NewContext(nodeTestBaseContext, lclock, stopper)
+	rpcContext := rpc.NewContext(&base.Context{Insecure: true}, lclock, stopper)
 	client.start(local, disconnected, rpcContext, stopper)
 
 	util.SucceedsWithin(t, 500*time.Millisecond, func() error {
@@ -125,7 +126,7 @@ func TestClientDisconnectRedundant(t *testing.T) {
 	rAddr := remote.is.NodeAddr
 	lAddr := local.is.NodeAddr
 	lclock := hlc.NewClock(hlc.UnixNano)
-	rpcContext := rpc.NewContext(nodeTestBaseContext, lclock, stopper)
+	rpcContext := rpc.NewContext(&base.Context{Insecure: true}, lclock, stopper)
 	local.startClient(rAddr, rpcContext, stopper)
 	remote.startClient(lAddr, rpcContext, stopper)
 	local.mu.Unlock()

--- a/gossip/gossip_test.go
+++ b/gossip/gossip_test.go
@@ -21,20 +21,17 @@ import (
 	"testing"
 	"time"
 
+	"github.com/cockroachdb/cockroach/base"
 	"github.com/cockroachdb/cockroach/gossip/resolver"
 	"github.com/cockroachdb/cockroach/rpc"
-	"github.com/cockroachdb/cockroach/testutils"
 	"github.com/cockroachdb/cockroach/util/hlc"
 	"github.com/cockroachdb/cockroach/util/leaktest"
 )
 
-var rootTestBaseContext = testutils.NewRootTestBaseContext()
-var nodeTestBaseContext = testutils.NewNodeTestBaseContext()
-
 // TestGossipInfoStore verifies operation of gossip instance infostore.
 func TestGossipInfoStore(t *testing.T) {
 	defer leaktest.AfterTest(t)
-	rpcContext := rpc.NewContext(rootTestBaseContext, hlc.NewClock(hlc.UnixNano), nil)
+	rpcContext := rpc.NewContext(&base.Context{}, hlc.NewClock(hlc.UnixNano), nil)
 	g := New(rpcContext, TestInterval, TestBootstrap)
 	if err := g.AddInfo("i", int64(1), time.Hour); err != nil {
 		t.Fatal(err)
@@ -80,7 +77,7 @@ func TestGossipGetNextBootstrapAddress(t *testing.T) {
 
 	resolvers := []resolver.Resolver{}
 	for _, rs := range resolverSpecs {
-		resolver, err := resolver.NewResolver(nodeTestBaseContext, rs)
+		resolver, err := resolver.NewResolver(&base.Context{}, rs)
 		if err == nil {
 			resolvers = append(resolvers, resolver)
 		}

--- a/kv/dist_sender_server_test.go
+++ b/kv/dist_sender_server_test.go
@@ -27,7 +27,6 @@ import (
 	"github.com/cockroachdb/cockroach/keys"
 	"github.com/cockroachdb/cockroach/kv"
 	"github.com/cockroachdb/cockroach/proto"
-	"github.com/cockroachdb/cockroach/security"
 	"github.com/cockroachdb/cockroach/server"
 	"github.com/cockroachdb/cockroach/storage/engine"
 	"github.com/cockroachdb/cockroach/testutils"
@@ -187,7 +186,6 @@ func TestMultiRangeScanReverseScanInconsistent(t *testing.T) {
 	sr := call.Reply.(*proto.ScanResponse)
 	sa := call.Args.(*proto.ScanRequest)
 	sa.ReadConsistency = proto.INCONSISTENT
-	sa.User = security.RootUser
 	ds.Send(context.Background(), call)
 	if err := sr.GoError(); err != nil {
 		t.Fatal(err)
@@ -204,7 +202,6 @@ func TestMultiRangeScanReverseScanInconsistent(t *testing.T) {
 	rsr := call.Reply.(*proto.ReverseScanResponse)
 	rsa := call.Args.(*proto.ReverseScanRequest)
 	rsa.ReadConsistency = proto.INCONSISTENT
-	rsa.User = security.RootUser
 	ds.Send(context.Background(), call)
 	if err := rsr.GoError(); err != nil {
 		t.Fatal(err)

--- a/kv/local_test_cluster.go
+++ b/kv/local_test_cluster.go
@@ -118,13 +118,13 @@ func (ltc *LocalTestCluster) Start(t util.Tester) {
 	ltc.Manual = hlc.NewManualClock(0)
 	ltc.Clock = hlc.NewClock(ltc.Manual.UnixNano)
 	ltc.Stopper = stop.NewStopper()
-	rpcContext := rpc.NewContext(testutils.NewRootTestBaseContext(), ltc.Clock, ltc.Stopper)
+	rpcContext := rpc.NewContext(testutils.NewNodeTestBaseContext(), ltc.Clock, ltc.Stopper)
 	ltc.Gossip = gossip.New(rpcContext, gossip.TestInterval, gossip.TestBootstrap)
 	ltc.Eng = engine.NewInMem(proto.Attributes{}, 50<<20)
 	ltc.lSender = newRetryableLocalSender(NewLocalSender())
 	ltc.Sender = NewTxnCoordSender(ltc.lSender, ltc.Clock, false, nil, ltc.Stopper)
 	var err error
-	if ltc.DB, err = client.Open("//root@", client.SenderOpt(ltc.Sender)); err != nil {
+	if ltc.DB, err = client.Open("//", client.SenderOpt(ltc.Sender)); err != nil {
 		t.Fatal(err)
 	}
 	transport := multiraft.NewLocalRPCTransport(ltc.Stopper)

--- a/kv/txn_coord_sender_test.go
+++ b/kv/txn_coord_sender_test.go
@@ -30,7 +30,6 @@ import (
 
 	"github.com/cockroachdb/cockroach/client"
 	"github.com/cockroachdb/cockroach/proto"
-	"github.com/cockroachdb/cockroach/security"
 	"github.com/cockroachdb/cockroach/storage/engine"
 	"github.com/cockroachdb/cockroach/util"
 	"github.com/cockroachdb/cockroach/util/caller"
@@ -163,7 +162,6 @@ func TestTxnCoordSenderBeginTransaction(t *testing.T) {
 		Args: &proto.PutRequest{
 			RequestHeader: proto.RequestHeader{
 				Key:          key,
-				User:         security.RootUser,
 				UserPriority: gogoproto.Int32(-10), // negative user priority is translated into positive priority
 				Txn: &proto.Transaction{
 					Name:      "test txn",
@@ -203,7 +201,6 @@ func TestTxnCoordSenderBeginTransactionMinPriority(t *testing.T) {
 		Args: &proto.PutRequest{
 			RequestHeader: proto.RequestHeader{
 				Key:          proto.Key("key"),
-				User:         security.RootUser,
 				UserPriority: gogoproto.Int32(-10), // negative user priority is translated into positive priority
 				Txn: &proto.Transaction{
 					Name:      "test txn",
@@ -573,7 +570,6 @@ func TestTxnCoordSenderTxnUpdatedOnError(t *testing.T) {
 	var testPutReq = &proto.PutRequest{
 		RequestHeader: proto.RequestHeader{
 			Key:          proto.Key("test-key"),
-			User:         security.RootUser,
 			UserPriority: gogoproto.Int32(-1),
 			Txn: &proto.Transaction{
 				Name: "test txn",
@@ -755,8 +751,7 @@ func TestTxnDrainingNode(t *testing.T) {
 	s.Sender.Send(context.Background(), proto.Call{
 		Args: &proto.PutRequest{
 			RequestHeader: proto.RequestHeader{
-				Key:  key,
-				User: security.RootUser,
+				Key: key,
 				Txn: &proto.Transaction{
 					Name: "test txn",
 				},

--- a/kv/txn_test.go
+++ b/kv/txn_test.go
@@ -176,7 +176,7 @@ func verifyUncertainty(concurrency int, maxOffset time.Duration, t *testing.T) {
 			txnClock.SetMaxOffset(maxOffset)
 
 			sender := NewTxnCoordSender(s.lSender, txnClock, false, nil, s.Stopper)
-			txnDB, err := client.Open("//root@", client.SenderOpt(sender))
+			txnDB, err := client.Open("//", client.SenderOpt(sender))
 			if err != nil {
 				t.Fatal(err)
 			}

--- a/proto/api.go
+++ b/proto/api.go
@@ -116,6 +116,13 @@ type Combinable interface {
 	Combine(Response)
 }
 
+// GetUser implements UserRequest.
+// KV messages are always sent by the node user.
+func (rh *RequestHeader) GetUser() string {
+	// TODO(marc): we should use security.NodeUser here, but we need to break cycles first.
+	return "node"
+}
+
 // GetOrCreateCmdID returns the request header's command ID if available.
 // Otherwise, creates a new ClientCmdID, initialized with current time
 // and random salt.

--- a/proto/api.proto
+++ b/proto/api.proto
@@ -85,16 +85,13 @@ message RequestHeader {
   // that the operation takes place on the key range from Key to EndKey,
   // including Key and excluding EndKey.
   optional bytes end_key = 4 [(gogoproto.casttype) = "Key"];
-  // User is the originating user. Used to lookup priority when
-  // scheduling queued operations at target node.
-  optional string user = 5 [(gogoproto.nullable) = false];
   // Replica specifies the destination for the request. This is a specific
   // instance of the available replicas belonging to RangeID.
-  optional Replica replica = 6 [(gogoproto.nullable) = false];
+  optional Replica replica = 5 [(gogoproto.nullable) = false];
   // RangeID specifies the ID of the Raft consensus group which the key
   // range belongs to. This is used by the receiving node to route the
   // request to the correct range.
-  optional int64 range_id = 7 [(gogoproto.nullable) = false,
+  optional int64 range_id = 6 [(gogoproto.nullable) = false,
       (gogoproto.customname) = "RangeID", (gogoproto.casttype) = "RangeID"];
   // UserPriority specifies priority multiple for non-transactional
   // commands. This value should be a positive integer [1, 2^31-1).
@@ -105,17 +102,17 @@ message RequestHeader {
   // with UserPriority=1. This value is ignored if Txn is
   // specified. If neither this value nor Txn is specified, the value
   // defaults to 1.
-  optional int32 user_priority = 8 [default = 1];
+  optional int32 user_priority = 7 [default = 1];
   // Txn is set non-nil if a transaction is underway. To start a txn,
   // the first request should set this field to non-nil with name and
   // isolation level set as desired. The response will contain the
   // fully-initialized transaction with txn ID, priority, initial
   // timestamp, and maximum timestamp.
-  optional Transaction txn = 9;
+  optional Transaction txn = 8;
   // ReadConsistency specifies the consistency for read
   // operations. The default is CONSISTENT. This value is ignored for
   // write operations.
-  optional ReadConsistencyType read_consistency = 10 [(gogoproto.nullable) = false];
+  optional ReadConsistencyType read_consistency = 9 [(gogoproto.nullable) = false];
 }
 
 // ResponseHeader is returned with every storage node response.

--- a/rpc/main_test.go
+++ b/rpc/main_test.go
@@ -28,15 +28,6 @@ import (
 	"github.com/cockroachdb/cockroach/util/stop"
 )
 
-// NewRootTestContext returns a rpc.Context for testing.
-// It is meant to be used by clients.
-func NewRootTestContext(clock *hlc.Clock, stopper *stop.Stopper) *Context {
-	if clock == nil {
-		clock = hlc.NewClock(hlc.UnixNano)
-	}
-	return NewContext(testutils.NewRootTestBaseContext(), clock, stopper)
-}
-
 // NewNodeTestContext returns a rpc.Context for testing.
 // It is meant to be used by nodes.
 func NewNodeTestContext(clock *hlc.Clock, stopper *stop.Stopper) *Context {

--- a/rpc/server.go
+++ b/rpc/server.go
@@ -95,7 +95,7 @@ func NewServer(addr net.Addr, context *Context) *Server {
 // argument of the same type as `reqPrototype`. Both the argument and
 // return value of 'handler' should be a pointer to a protocol message
 // type. The handler function will be executed in a new goroutine.
-// Only system users (root and node) are allowed to use these endpoints.
+// Only the "node" system user is allowed to use these endpoints.
 func (s *Server) Register(name string,
 	handler func(proto.Message) (proto.Message, error),
 	reqPrototype proto.Message) error {
@@ -118,7 +118,7 @@ func (s *Server) RegisterPublic(name string,
 // RPC server's goroutine guarantees that the order of requests as
 // they were read from the connection is preserved.
 // If 'public' is true, all users may call this method, otherwise
-// system users only (root and node).
+// "node" users only.
 func (s *Server) RegisterAsync(name string, public bool,
 	handler func(proto.Message, func(proto.Message, error)),
 	reqPrototype proto.Message) error {

--- a/security/auth.go
+++ b/security/auth.go
@@ -119,7 +119,7 @@ func AuthenticationHook(insecureMode bool, tlsState *tls.ConnectionState) (
 			return util.Errorf("missing User in request: %+v", request)
 		}
 
-		if !public && requestedUser != RootUser && requestedUser != NodeUser {
+		if !public && requestedUser != NodeUser {
 			return util.Errorf("user %s is not allowed", requestedUser)
 		}
 

--- a/security/certs_test.go
+++ b/security/certs_test.go
@@ -115,7 +115,7 @@ func TestUseCerts(t *testing.T) {
 	defer s.Stop()
 
 	// Insecure mode.
-	clientContext := testutils.NewRootTestBaseContext()
+	clientContext := testutils.NewNodeTestBaseContext()
 	clientContext.Insecure = true
 	httpClient, err := clientContext.GetHTTPClient()
 	if err != nil {
@@ -132,7 +132,7 @@ func TestUseCerts(t *testing.T) {
 	}
 
 	// Secure mode but no Certs directory: permissive config.
-	clientContext = testutils.NewRootTestBaseContext()
+	clientContext = testutils.NewNodeTestBaseContext()
 	clientContext.Certs = ""
 	httpClient, err = clientContext.GetHTTPClient()
 	if err != nil {
@@ -167,7 +167,7 @@ func TestUseCerts(t *testing.T) {
 	}
 
 	// New client. With certs this time.
-	clientContext = testutils.NewRootTestBaseContext()
+	clientContext = testutils.NewNodeTestBaseContext()
 	clientContext.Certs = certsDir
 	httpClient, err = clientContext.GetHTTPClient()
 	if err != nil {

--- a/server/admin_test.go
+++ b/server/admin_test.go
@@ -35,7 +35,8 @@ import (
 // getText fetches the HTTP response body as text in the form of a
 // byte slice from the specified URL.
 func getText(url string) ([]byte, error) {
-	client, err := testutils.NewTestHTTPClient()
+	// There are no particular permissions on admin endpoints, TestUser is fine.
+	client, err := testutils.NewTestBaseContext(TestUser).GetHTTPClient()
 	if err != nil {
 		return nil, err
 	}

--- a/server/node.go
+++ b/server/node.go
@@ -110,7 +110,7 @@ func BootstrapCluster(clusterID string, engines []engine.Engine, stopper *stop.S
 	lSender := kv.NewLocalSender()
 	sender := kv.NewTxnCoordSender(lSender, ctx.Clock, false, nil, stopper)
 	var err error
-	if ctx.DB, err = client.Open("//root@", client.SenderOpt(sender)); err != nil {
+	if ctx.DB, err = client.Open("//", client.SenderOpt(sender)); err != nil {
 		return nil, err
 	}
 	ctx.Transport = multiraft.NewLocalRPCTransport(stopper)

--- a/server/node_test.go
+++ b/server/node_test.go
@@ -71,7 +71,7 @@ func createTestNode(addr net.Addr, engines []engine.Engine, gossipBS net.Addr, t
 	}
 	ctx.Gossip = g
 	sender := kv.NewDistSender(&kv.DistSenderContext{Clock: ctx.Clock}, g)
-	if ctx.DB, err = client.Open("//root@", client.SenderOpt(sender)); err != nil {
+	if ctx.DB, err = client.Open("//", client.SenderOpt(sender)); err != nil {
 		t.Fatal(err)
 	}
 	// TODO(bdarnell): arrange to have the transport closed.

--- a/server/server.go
+++ b/server/server.go
@@ -122,7 +122,7 @@ func NewServer(ctx *Context, stopper *stop.Stopper) (*Server, error) {
 
 	ds := kv.NewDistSender(&kv.DistSenderContext{Clock: s.clock}, s.gossip)
 	sender := kv.NewTxnCoordSender(ds, s.clock, ctx.Linearizable, tracer, s.stopper)
-	if s.db, err = client.Open("//root@", client.SenderOpt(sender)); err != nil {
+	if s.db, err = client.Open("//", client.SenderOpt(sender)); err != nil {
 		return nil, err
 	}
 

--- a/server/status/feed_test.go
+++ b/server/status/feed_test.go
@@ -190,7 +190,10 @@ func TestServerNodeEventFeed(t *testing.T) {
 	ner := nodeEventReader{}
 	ner.readEvents(feed)
 
-	db, err := client.Open("https://root@" + s.ServingAddr() + "?certs=" + security.EmbeddedCertsDir)
+	db, err := client.Open(fmt.Sprintf("https://%s@%s?certs=%s",
+		security.NodeUser,
+		s.ServingAddr(),
+		security.EmbeddedCertsDir))
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/storage/engine/rocksdb/cockroach/proto/api.pb.cc
+++ b/storage/engine/rocksdb/cockroach/proto/api.pb.cc
@@ -238,12 +238,11 @@ void protobuf_AssignDesc_cockroach_2fproto_2fapi_2eproto() {
       GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(ClientCmdID, _internal_metadata_),
       -1);
   RequestHeader_descriptor_ = file->message_type(1);
-  static const int RequestHeader_offsets_[10] = {
+  static const int RequestHeader_offsets_[9] = {
     GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(RequestHeader, timestamp_),
     GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(RequestHeader, cmd_id_),
     GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(RequestHeader, key_),
     GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(RequestHeader, end_key_),
-    GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(RequestHeader, user_),
     GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(RequestHeader, replica_),
     GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(RequestHeader, range_id_),
     GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(RequestHeader, user_priority_),
@@ -1263,205 +1262,204 @@ void protobuf_AddDesc_cockroach_2fproto_2fapi_2eproto() {
     "ckroach/proto/data.proto\032\034cockroach/prot"
     "o/errors.proto\032\024gogoproto/gogo.proto\"<\n\013"
     "ClientCmdID\022\027\n\twall_time\030\001 \001(\003B\004\310\336\037\000\022\024\n\006"
-    "random\030\002 \001(\003B\004\310\336\037\000\"\257\003\n\rRequestHeader\0223\n\t"
+    "random\030\002 \001(\003B\004\310\336\037\000\"\233\003\n\rRequestHeader\0223\n\t"
     "timestamp\030\001 \001(\0132\032.cockroach.proto.Timest"
     "ampB\004\310\336\037\000\022;\n\006cmd_id\030\002 \001(\0132\034.cockroach.pr"
     "oto.ClientCmdIDB\r\310\336\037\000\342\336\037\005CmdID\022\024\n\003key\030\003 "
-    "\001(\014B\007\372\336\037\003Key\022\030\n\007end_key\030\004 \001(\014B\007\372\336\037\003Key\022\022"
-    "\n\004user\030\005 \001(\tB\004\310\336\037\000\022/\n\007replica\030\006 \001(\0132\030.co"
-    "ckroach.proto.ReplicaB\004\310\336\037\000\022,\n\010range_id\030"
-    "\007 \001(\003B\032\310\336\037\000\342\336\037\007RangeID\372\336\037\007RangeID\022\030\n\ruse"
-    "r_priority\030\010 \001(\005:\0011\022)\n\003txn\030\t \001(\0132\034.cockr"
-    "oach.proto.Transaction\022D\n\020read_consisten"
-    "cy\030\n \001(\0162$.cockroach.proto.ReadConsisten"
-    "cyTypeB\004\310\336\037\000\"\227\001\n\016ResponseHeader\022%\n\005error"
-    "\030\001 \001(\0132\026.cockroach.proto.Error\0223\n\ttimest"
-    "amp\030\002 \001(\0132\032.cockroach.proto.TimestampB\004\310"
-    "\336\037\000\022)\n\003txn\030\003 \001(\0132\034.cockroach.proto.Trans"
-    "action\"F\n\nGetRequest\0228\n\006header\030\001 \001(\0132\036.c"
-    "ockroach.proto.RequestHeaderB\010\310\336\037\000\320\336\037\001\"o"
-    "\n\013GetResponse\0229\n\006header\030\001 \001(\0132\037.cockroac"
-    "h.proto.ResponseHeaderB\010\310\336\037\000\320\336\037\001\022%\n\005valu"
-    "e\030\002 \001(\0132\026.cockroach.proto.Value\"s\n\nPutRe"
-    "quest\0228\n\006header\030\001 \001(\0132\036.cockroach.proto."
-    "RequestHeaderB\010\310\336\037\000\320\336\037\001\022+\n\005value\030\002 \001(\0132\026"
-    ".cockroach.proto.ValueB\004\310\336\037\000\"H\n\013PutRespo"
-    "nse\0229\n\006header\030\001 \001(\0132\037.cockroach.proto.Re"
-    "sponseHeaderB\010\310\336\037\000\320\336\037\001\"\251\001\n\025ConditionalPu"
-    "tRequest\0228\n\006header\030\001 \001(\0132\036.cockroach.pro"
-    "to.RequestHeaderB\010\310\336\037\000\320\336\037\001\022+\n\005value\030\002 \001("
-    "\0132\026.cockroach.proto.ValueB\004\310\336\037\000\022)\n\texp_v"
-    "alue\030\003 \001(\0132\026.cockroach.proto.Value\"S\n\026Co"
-    "nditionalPutResponse\0229\n\006header\030\001 \001(\0132\037.c"
-    "ockroach.proto.ResponseHeaderB\010\310\336\037\000\320\336\037\001\""
-    "e\n\020IncrementRequest\0228\n\006header\030\001 \001(\0132\036.co"
-    "ckroach.proto.RequestHeaderB\010\310\336\037\000\320\336\037\001\022\027\n"
-    "\tincrement\030\002 \001(\003B\004\310\336\037\000\"g\n\021IncrementRespo"
-    "nse\0229\n\006header\030\001 \001(\0132\037.cockroach.proto.Re"
-    "sponseHeaderB\010\310\336\037\000\320\336\037\001\022\027\n\tnew_value\030\002 \001("
-    "\003B\004\310\336\037\000\"I\n\rDeleteRequest\0228\n\006header\030\001 \001(\013"
-    "2\036.cockroach.proto.RequestHeaderB\010\310\336\037\000\320\336"
-    "\037\001\"K\n\016DeleteResponse\0229\n\006header\030\001 \001(\0132\037.c"
-    "ockroach.proto.ResponseHeaderB\010\310\336\037\000\320\336\037\001\""
-    "s\n\022DeleteRangeRequest\0228\n\006header\030\001 \001(\0132\036."
-    "cockroach.proto.RequestHeaderB\010\310\336\037\000\320\336\037\001\022"
-    "#\n\025max_entries_to_delete\030\002 \001(\003B\004\310\336\037\000\"k\n\023"
-    "DeleteRangeResponse\0229\n\006header\030\001 \001(\0132\037.co"
-    "ckroach.proto.ResponseHeaderB\010\310\336\037\000\320\336\037\001\022\031"
-    "\n\013num_deleted\030\002 \001(\003B\004\310\336\037\000\"b\n\013ScanRequest"
+    "\001(\014B\007\372\336\037\003Key\022\030\n\007end_key\030\004 \001(\014B\007\372\336\037\003Key\022/"
+    "\n\007replica\030\005 \001(\0132\030.cockroach.proto.Replic"
+    "aB\004\310\336\037\000\022,\n\010range_id\030\006 \001(\003B\032\310\336\037\000\342\336\037\007Range"
+    "ID\372\336\037\007RangeID\022\030\n\ruser_priority\030\007 \001(\005:\0011\022"
+    ")\n\003txn\030\010 \001(\0132\034.cockroach.proto.Transacti"
+    "on\022D\n\020read_consistency\030\t \001(\0162$.cockroach"
+    ".proto.ReadConsistencyTypeB\004\310\336\037\000\"\227\001\n\016Res"
+    "ponseHeader\022%\n\005error\030\001 \001(\0132\026.cockroach.p"
+    "roto.Error\0223\n\ttimestamp\030\002 \001(\0132\032.cockroac"
+    "h.proto.TimestampB\004\310\336\037\000\022)\n\003txn\030\003 \001(\0132\034.c"
+    "ockroach.proto.Transaction\"F\n\nGetRequest"
     "\0228\n\006header\030\001 \001(\0132\036.cockroach.proto.Reque"
-    "stHeaderB\010\310\336\037\000\320\336\037\001\022\031\n\013max_results\030\002 \001(\003B"
-    "\004\310\336\037\000\"x\n\014ScanResponse\0229\n\006header\030\001 \001(\0132\037."
-    "cockroach.proto.ResponseHeaderB\010\310\336\037\000\320\336\037\001"
-    "\022-\n\004rows\030\002 \003(\0132\031.cockroach.proto.KeyValu"
-    "eB\004\310\336\037\000\"i\n\022ReverseScanRequest\0228\n\006header\030"
-    "\001 \001(\0132\036.cockroach.proto.RequestHeaderB\010\310"
-    "\336\037\000\320\336\037\001\022\031\n\013max_results\030\002 \001(\003B\004\310\336\037\000\"\177\n\023Re"
-    "verseScanResponse\0229\n\006header\030\001 \001(\0132\037.cock"
-    "roach.proto.ResponseHeaderB\010\310\336\037\000\320\336\037\001\022-\n\004"
-    "rows\030\002 \003(\0132\031.cockroach.proto.KeyValueB\004\310"
-    "\336\037\000\"\340\001\n\025EndTransactionRequest\0228\n\006header\030"
-    "\001 \001(\0132\036.cockroach.proto.RequestHeaderB\010\310"
-    "\336\037\000\320\336\037\001\022\024\n\006commit\030\002 \001(\010B\004\310\336\037\000\022G\n\027interna"
-    "l_commit_trigger\030\003 \001(\0132&.cockroach.proto"
-    ".InternalCommitTrigger\022.\n\007intents\030\004 \003(\0132"
-    "\027.cockroach.proto.IntentB\004\310\336\037\000\"\211\001\n\026EndTr"
-    "ansactionResponse\0229\n\006header\030\001 \001(\0132\037.cock"
-    "roach.proto.ResponseHeaderB\010\310\336\037\000\320\336\037\001\022\031\n\013"
-    "commit_wait\030\002 \001(\003B\004\310\336\037\000\022\031\n\010resolved\030\003 \003("
-    "\014B\007\372\336\037\003Key\"i\n\021AdminSplitRequest\0228\n\006heade"
-    "r\030\001 \001(\0132\036.cockroach.proto.RequestHeaderB"
-    "\010\310\336\037\000\320\336\037\001\022\032\n\tsplit_key\030\002 \001(\014B\007\372\336\037\003Key\"O\n"
-    "\022AdminSplitResponse\0229\n\006header\030\001 \001(\0132\037.co"
-    "ckroach.proto.ResponseHeaderB\010\310\336\037\000\320\336\037\001\"M"
-    "\n\021AdminMergeRequest\0228\n\006header\030\001 \001(\0132\036.co"
-    "ckroach.proto.RequestHeaderB\010\310\336\037\000\320\336\037\001\"O\n"
-    "\022AdminMergeResponse\0229\n\006header\030\001 \001(\0132\037.co"
-    "ckroach.proto.ResponseHeaderB\010\310\336\037\000\320\336\037\001\"\235"
-    "\001\n\022RangeLookupRequest\0228\n\006header\030\001 \001(\0132\036."
-    "cockroach.proto.RequestHeaderB\010\310\336\037\000\320\336\037\001\022"
-    "\030\n\nmax_ranges\030\002 \001(\005B\004\310\336\037\000\022\034\n\016ignore_inte"
-    "nts\030\003 \001(\010B\004\310\336\037\000\022\025\n\007reverse\030\004 \001(\010B\004\310\336\037\000\"\210"
-    "\001\n\023RangeLookupResponse\0229\n\006header\030\001 \001(\0132\037"
-    ".cockroach.proto.ResponseHeaderB\010\310\336\037\000\320\336\037"
-    "\001\0226\n\006ranges\030\002 \003(\0132 .cockroach.proto.Rang"
-    "eDescriptorB\004\310\336\037\000\"O\n\023HeartbeatTxnRequest"
-    "\0228\n\006header\030\001 \001(\0132\036.cockroach.proto.Reque"
-    "stHeaderB\010\310\336\037\000\320\336\037\001\"Q\n\024HeartbeatTxnRespon"
-    "se\0229\n\006header\030\001 \001(\0132\037.cockroach.proto.Res"
-    "ponseHeaderB\010\310\336\037\000\320\336\037\001\"\215\002\n\tGCRequest\0228\n\006h"
-    "eader\030\001 \001(\0132\036.cockroach.proto.RequestHea"
-    "derB\010\310\336\037\000\320\336\037\001\022<\n\007gc_meta\030\002 \001(\0132\033.cockroa"
-    "ch.proto.GCMetadataB\016\310\336\037\000\342\336\037\006GCMeta\0224\n\004k"
-    "eys\030\003 \003(\0132 .cockroach.proto.GCRequest.GC"
-    "KeyB\004\310\336\037\000\032R\n\005GCKey\022\024\n\003key\030\001 \001(\014B\007\372\336\037\003Key"
-    "\0223\n\ttimestamp\030\002 \001(\0132\032.cockroach.proto.Ti"
-    "mestampB\004\310\336\037\000\"G\n\nGCResponse\0229\n\006header\030\001 "
-    "\001(\0132\037.cockroach.proto.ResponseHeaderB\010\310\336"
-    "\037\000\320\336\037\001\"\204\002\n\016PushTxnRequest\0228\n\006header\030\001 \001("
+    "stHeaderB\010\310\336\037\000\320\336\037\001\"o\n\013GetResponse\0229\n\006hea"
+    "der\030\001 \001(\0132\037.cockroach.proto.ResponseHead"
+    "erB\010\310\336\037\000\320\336\037\001\022%\n\005value\030\002 \001(\0132\026.cockroach."
+    "proto.Value\"s\n\nPutRequest\0228\n\006header\030\001 \001("
     "\0132\036.cockroach.proto.RequestHeaderB\010\310\336\037\000\320"
-    "\336\037\001\0226\n\npushee_txn\030\002 \001(\0132\034.cockroach.prot"
-    "o.TransactionB\004\310\336\037\000\022-\n\003now\030\003 \001(\0132\032.cockr"
-    "oach.proto.TimestampB\004\310\336\037\000\0225\n\tpush_type\030"
-    "\004 \001(\0162\034.cockroach.proto.PushTxnTypeB\004\310\336\037"
-    "\000\022\032\n\014range_lookup\030\005 \001(\010B\004\310\336\037\000\"~\n\017PushTxn"
-    "Response\0229\n\006header\030\001 \001(\0132\037.cockroach.pro"
-    "to.ResponseHeaderB\010\310\336\037\000\320\336\037\001\0220\n\npushee_tx"
-    "n\030\002 \001(\0132\034.cockroach.proto.Transaction\"P\n"
-    "\024ResolveIntentRequest\0228\n\006header\030\001 \001(\0132\036."
-    "cockroach.proto.RequestHeaderB\010\310\336\037\000\320\336\037\001\""
-    "R\n\025ResolveIntentResponse\0229\n\006header\030\001 \001(\013"
-    "2\037.cockroach.proto.ResponseHeaderB\010\310\336\037\000\320"
-    "\336\037\001\"U\n\031ResolveIntentRangeRequest\0228\n\006head"
-    "er\030\001 \001(\0132\036.cockroach.proto.RequestHeader"
-    "B\010\310\336\037\000\320\336\037\001\"W\n\032ResolveIntentRangeResponse"
+    "\336\037\001\022+\n\005value\030\002 \001(\0132\026.cockroach.proto.Val"
+    "ueB\004\310\336\037\000\"H\n\013PutResponse\0229\n\006header\030\001 \001(\0132"
+    "\037.cockroach.proto.ResponseHeaderB\010\310\336\037\000\320\336"
+    "\037\001\"\251\001\n\025ConditionalPutRequest\0228\n\006header\030\001"
+    " \001(\0132\036.cockroach.proto.RequestHeaderB\010\310\336"
+    "\037\000\320\336\037\001\022+\n\005value\030\002 \001(\0132\026.cockroach.proto."
+    "ValueB\004\310\336\037\000\022)\n\texp_value\030\003 \001(\0132\026.cockroa"
+    "ch.proto.Value\"S\n\026ConditionalPutResponse"
     "\0229\n\006header\030\001 \001(\0132\037.cockroach.proto.Respo"
-    "nseHeaderB\010\310\336\037\000\320\336\037\001\"u\n\014MergeRequest\0228\n\006h"
-    "eader\030\001 \001(\0132\036.cockroach.proto.RequestHea"
-    "derB\010\310\336\037\000\320\336\037\001\022+\n\005value\030\002 \001(\0132\026.cockroach"
-    ".proto.ValueB\004\310\336\037\000\"J\n\rMergeResponse\0229\n\006h"
-    "eader\030\001 \001(\0132\037.cockroach.proto.ResponseHe"
-    "aderB\010\310\336\037\000\320\336\037\001\"c\n\022TruncateLogRequest\0228\n\006"
-    "header\030\001 \001(\0132\036.cockroach.proto.RequestHe"
-    "aderB\010\310\336\037\000\320\336\037\001\022\023\n\005index\030\002 \001(\004B\004\310\336\037\000\"P\n\023T"
-    "runcateLogResponse\0229\n\006header\030\001 \001(\0132\037.coc"
-    "kroach.proto.ResponseHeaderB\010\310\336\037\000\320\336\037\001\"{\n"
-    "\022LeaderLeaseRequest\0228\n\006header\030\001 \001(\0132\036.co"
-    "ckroach.proto.RequestHeaderB\010\310\336\037\000\320\336\037\001\022+\n"
-    "\005lease\030\002 \001(\0132\026.cockroach.proto.LeaseB\004\310\336"
-    "\037\000\"P\n\023LeaderLeaseResponse\0229\n\006header\030\001 \001("
-    "\0132\037.cockroach.proto.ResponseHeaderB\010\310\336\037\000"
-    "\320\336\037\001\"\221\t\n\014RequestUnion\022*\n\003get\030\001 \001(\0132\033.coc"
-    "kroach.proto.GetRequestH\000\022*\n\003put\030\002 \001(\0132\033"
-    ".cockroach.proto.PutRequestH\000\022A\n\017conditi"
-    "onal_put\030\003 \001(\0132&.cockroach.proto.Conditi"
-    "onalPutRequestH\000\0226\n\tincrement\030\004 \001(\0132!.co"
-    "ckroach.proto.IncrementRequestH\000\0220\n\006dele"
-    "te\030\005 \001(\0132\036.cockroach.proto.DeleteRequest"
-    "H\000\022;\n\014delete_range\030\006 \001(\0132#.cockroach.pro"
-    "to.DeleteRangeRequestH\000\022,\n\004scan\030\007 \001(\0132\034."
-    "cockroach.proto.ScanRequestH\000\022A\n\017end_tra"
-    "nsaction\030\010 \001(\0132&.cockroach.proto.EndTran"
-    "sactionRequestH\000\0229\n\013admin_split\030\t \001(\0132\"."
-    "cockroach.proto.AdminSplitRequestH\000\0229\n\013a"
-    "dmin_merge\030\n \001(\0132\".cockroach.proto.Admin"
-    "MergeRequestH\000\022=\n\rheartbeat_txn\030\013 \001(\0132$."
-    "cockroach.proto.HeartbeatTxnRequestH\000\022(\n"
-    "\002gc\030\014 \001(\0132\032.cockroach.proto.GCRequestH\000\022"
-    "3\n\010push_txn\030\r \001(\0132\037.cockroach.proto.Push"
-    "TxnRequestH\000\022;\n\014range_lookup\030\016 \001(\0132#.coc"
-    "kroach.proto.RangeLookupRequestH\000\022\?\n\016res"
-    "olve_intent\030\017 \001(\0132%.cockroach.proto.Reso"
-    "lveIntentRequestH\000\022J\n\024resolve_intent_ran"
-    "ge\030\020 \001(\0132*.cockroach.proto.ResolveIntent"
-    "RangeRequestH\000\022.\n\005merge\030\021 \001(\0132\035.cockroac"
-    "h.proto.MergeRequestH\000\0227\n\010truncate\030\022 \001(\013"
-    "2#.cockroach.proto.TruncateLogRequestH\000\022"
-    ";\n\014leader_lease\030\023 \001(\0132#.cockroach.proto."
-    "LeaderLeaseRequestH\000\022;\n\014reverse_scan\030\024 \001"
-    "(\0132#.cockroach.proto.ReverseScanRequestH"
-    "\000:\004\310\240\037\001B\007\n\005value\"\246\t\n\rResponseUnion\022+\n\003ge"
-    "t\030\001 \001(\0132\034.cockroach.proto.GetResponseH\000\022"
-    "+\n\003put\030\002 \001(\0132\034.cockroach.proto.PutRespon"
-    "seH\000\022B\n\017conditional_put\030\003 \001(\0132\'.cockroac"
-    "h.proto.ConditionalPutResponseH\000\0227\n\tincr"
-    "ement\030\004 \001(\0132\".cockroach.proto.IncrementR"
-    "esponseH\000\0221\n\006delete\030\005 \001(\0132\037.cockroach.pr"
-    "oto.DeleteResponseH\000\022<\n\014delete_range\030\006 \001"
-    "(\0132$.cockroach.proto.DeleteRangeResponse"
-    "H\000\022-\n\004scan\030\007 \001(\0132\035.cockroach.proto.ScanR"
-    "esponseH\000\022B\n\017end_transaction\030\010 \001(\0132\'.coc"
-    "kroach.proto.EndTransactionResponseH\000\022:\n"
-    "\013admin_split\030\t \001(\0132#.cockroach.proto.Adm"
-    "inSplitResponseH\000\022:\n\013admin_merge\030\n \001(\0132#"
-    ".cockroach.proto.AdminMergeResponseH\000\022>\n"
-    "\rheartbeat_txn\030\013 \001(\0132%.cockroach.proto.H"
-    "eartbeatTxnResponseH\000\022)\n\002gc\030\014 \001(\0132\033.cock"
-    "roach.proto.GCResponseH\000\0224\n\010push_txn\030\r \001"
-    "(\0132 .cockroach.proto.PushTxnResponseH\000\022<"
-    "\n\014range_lookup\030\016 \001(\0132$.cockroach.proto.R"
-    "angeLookupResponseH\000\022@\n\016resolve_intent\030\017"
-    " \001(\0132&.cockroach.proto.ResolveIntentResp"
-    "onseH\000\022K\n\024resolve_intent_range\030\020 \001(\0132+.c"
-    "ockroach.proto.ResolveIntentRangeRespons"
-    "eH\000\022/\n\005merge\030\021 \001(\0132\036.cockroach.proto.Mer"
-    "geResponseH\000\0228\n\010truncate\030\022 \001(\0132$.cockroa"
-    "ch.proto.TruncateLogResponseH\000\022<\n\014leader"
-    "_lease\030\023 \001(\0132$.cockroach.proto.LeaderLea"
-    "seResponseH\000\022<\n\014reverse_scan\030\024 \001(\0132$.coc"
-    "kroach.proto.ReverseScanResponseH\000:\004\310\240\037\001"
-    "B\007\n\005value\"\177\n\014BatchRequest\0228\n\006header\030\001 \001("
-    "\0132\036.cockroach.proto.RequestHeaderB\010\310\336\037\000\320"
-    "\336\037\001\0225\n\010requests\030\002 \003(\0132\035.cockroach.proto."
-    "RequestUnionB\004\310\336\037\000\"\203\001\n\rBatchResponse\0229\n\006"
-    "header\030\001 \001(\0132\037.cockroach.proto.ResponseH"
-    "eaderB\010\310\336\037\000\320\336\037\001\0227\n\tresponses\030\002 \003(\0132\036.coc"
-    "kroach.proto.ResponseUnionB\004\310\336\037\000*L\n\023Read"
-    "ConsistencyType\022\016\n\nCONSISTENT\020\000\022\r\n\tCONSE"
-    "NSUS\020\001\022\020\n\014INCONSISTENT\020\002\032\004\210\243\036\000*G\n\013PushTx"
-    "nType\022\022\n\016PUSH_TIMESTAMP\020\000\022\r\n\tABORT_TXN\020\001"
-    "\022\017\n\013CLEANUP_TXN\020\002\032\004\210\243\036\000B\027Z\005proto\340\342\036\001\310\342\036\001"
-    "\320\342\036\001\220\343\036\000", 8128);
+    "nseHeaderB\010\310\336\037\000\320\336\037\001\"e\n\020IncrementRequest\022"
+    "8\n\006header\030\001 \001(\0132\036.cockroach.proto.Reques"
+    "tHeaderB\010\310\336\037\000\320\336\037\001\022\027\n\tincrement\030\002 \001(\003B\004\310\336"
+    "\037\000\"g\n\021IncrementResponse\0229\n\006header\030\001 \001(\0132"
+    "\037.cockroach.proto.ResponseHeaderB\010\310\336\037\000\320\336"
+    "\037\001\022\027\n\tnew_value\030\002 \001(\003B\004\310\336\037\000\"I\n\rDeleteReq"
+    "uest\0228\n\006header\030\001 \001(\0132\036.cockroach.proto.R"
+    "equestHeaderB\010\310\336\037\000\320\336\037\001\"K\n\016DeleteResponse"
+    "\0229\n\006header\030\001 \001(\0132\037.cockroach.proto.Respo"
+    "nseHeaderB\010\310\336\037\000\320\336\037\001\"s\n\022DeleteRangeReques"
+    "t\0228\n\006header\030\001 \001(\0132\036.cockroach.proto.Requ"
+    "estHeaderB\010\310\336\037\000\320\336\037\001\022#\n\025max_entries_to_de"
+    "lete\030\002 \001(\003B\004\310\336\037\000\"k\n\023DeleteRangeResponse\022"
+    "9\n\006header\030\001 \001(\0132\037.cockroach.proto.Respon"
+    "seHeaderB\010\310\336\037\000\320\336\037\001\022\031\n\013num_deleted\030\002 \001(\003B"
+    "\004\310\336\037\000\"b\n\013ScanRequest\0228\n\006header\030\001 \001(\0132\036.c"
+    "ockroach.proto.RequestHeaderB\010\310\336\037\000\320\336\037\001\022\031"
+    "\n\013max_results\030\002 \001(\003B\004\310\336\037\000\"x\n\014ScanRespons"
+    "e\0229\n\006header\030\001 \001(\0132\037.cockroach.proto.Resp"
+    "onseHeaderB\010\310\336\037\000\320\336\037\001\022-\n\004rows\030\002 \003(\0132\031.coc"
+    "kroach.proto.KeyValueB\004\310\336\037\000\"i\n\022ReverseSc"
+    "anRequest\0228\n\006header\030\001 \001(\0132\036.cockroach.pr"
+    "oto.RequestHeaderB\010\310\336\037\000\320\336\037\001\022\031\n\013max_resul"
+    "ts\030\002 \001(\003B\004\310\336\037\000\"\177\n\023ReverseScanResponse\0229\n"
+    "\006header\030\001 \001(\0132\037.cockroach.proto.Response"
+    "HeaderB\010\310\336\037\000\320\336\037\001\022-\n\004rows\030\002 \003(\0132\031.cockroa"
+    "ch.proto.KeyValueB\004\310\336\037\000\"\340\001\n\025EndTransacti"
+    "onRequest\0228\n\006header\030\001 \001(\0132\036.cockroach.pr"
+    "oto.RequestHeaderB\010\310\336\037\000\320\336\037\001\022\024\n\006commit\030\002 "
+    "\001(\010B\004\310\336\037\000\022G\n\027internal_commit_trigger\030\003 \001"
+    "(\0132&.cockroach.proto.InternalCommitTrigg"
+    "er\022.\n\007intents\030\004 \003(\0132\027.cockroach.proto.In"
+    "tentB\004\310\336\037\000\"\211\001\n\026EndTransactionResponse\0229\n"
+    "\006header\030\001 \001(\0132\037.cockroach.proto.Response"
+    "HeaderB\010\310\336\037\000\320\336\037\001\022\031\n\013commit_wait\030\002 \001(\003B\004\310"
+    "\336\037\000\022\031\n\010resolved\030\003 \003(\014B\007\372\336\037\003Key\"i\n\021AdminS"
+    "plitRequest\0228\n\006header\030\001 \001(\0132\036.cockroach."
+    "proto.RequestHeaderB\010\310\336\037\000\320\336\037\001\022\032\n\tsplit_k"
+    "ey\030\002 \001(\014B\007\372\336\037\003Key\"O\n\022AdminSplitResponse\022"
+    "9\n\006header\030\001 \001(\0132\037.cockroach.proto.Respon"
+    "seHeaderB\010\310\336\037\000\320\336\037\001\"M\n\021AdminMergeRequest\022"
+    "8\n\006header\030\001 \001(\0132\036.cockroach.proto.Reques"
+    "tHeaderB\010\310\336\037\000\320\336\037\001\"O\n\022AdminMergeResponse\022"
+    "9\n\006header\030\001 \001(\0132\037.cockroach.proto.Respon"
+    "seHeaderB\010\310\336\037\000\320\336\037\001\"\235\001\n\022RangeLookupReques"
+    "t\0228\n\006header\030\001 \001(\0132\036.cockroach.proto.Requ"
+    "estHeaderB\010\310\336\037\000\320\336\037\001\022\030\n\nmax_ranges\030\002 \001(\005B"
+    "\004\310\336\037\000\022\034\n\016ignore_intents\030\003 \001(\010B\004\310\336\037\000\022\025\n\007r"
+    "everse\030\004 \001(\010B\004\310\336\037\000\"\210\001\n\023RangeLookupRespon"
+    "se\0229\n\006header\030\001 \001(\0132\037.cockroach.proto.Res"
+    "ponseHeaderB\010\310\336\037\000\320\336\037\001\0226\n\006ranges\030\002 \003(\0132 ."
+    "cockroach.proto.RangeDescriptorB\004\310\336\037\000\"O\n"
+    "\023HeartbeatTxnRequest\0228\n\006header\030\001 \001(\0132\036.c"
+    "ockroach.proto.RequestHeaderB\010\310\336\037\000\320\336\037\001\"Q"
+    "\n\024HeartbeatTxnResponse\0229\n\006header\030\001 \001(\0132\037"
+    ".cockroach.proto.ResponseHeaderB\010\310\336\037\000\320\336\037"
+    "\001\"\215\002\n\tGCRequest\0228\n\006header\030\001 \001(\0132\036.cockro"
+    "ach.proto.RequestHeaderB\010\310\336\037\000\320\336\037\001\022<\n\007gc_"
+    "meta\030\002 \001(\0132\033.cockroach.proto.GCMetadataB"
+    "\016\310\336\037\000\342\336\037\006GCMeta\0224\n\004keys\030\003 \003(\0132 .cockroac"
+    "h.proto.GCRequest.GCKeyB\004\310\336\037\000\032R\n\005GCKey\022\024"
+    "\n\003key\030\001 \001(\014B\007\372\336\037\003Key\0223\n\ttimestamp\030\002 \001(\0132"
+    "\032.cockroach.proto.TimestampB\004\310\336\037\000\"G\n\nGCR"
+    "esponse\0229\n\006header\030\001 \001(\0132\037.cockroach.prot"
+    "o.ResponseHeaderB\010\310\336\037\000\320\336\037\001\"\204\002\n\016PushTxnRe"
+    "quest\0228\n\006header\030\001 \001(\0132\036.cockroach.proto."
+    "RequestHeaderB\010\310\336\037\000\320\336\037\001\0226\n\npushee_txn\030\002 "
+    "\001(\0132\034.cockroach.proto.TransactionB\004\310\336\037\000\022"
+    "-\n\003now\030\003 \001(\0132\032.cockroach.proto.Timestamp"
+    "B\004\310\336\037\000\0225\n\tpush_type\030\004 \001(\0162\034.cockroach.pr"
+    "oto.PushTxnTypeB\004\310\336\037\000\022\032\n\014range_lookup\030\005 "
+    "\001(\010B\004\310\336\037\000\"~\n\017PushTxnResponse\0229\n\006header\030\001"
+    " \001(\0132\037.cockroach.proto.ResponseHeaderB\010\310"
+    "\336\037\000\320\336\037\001\0220\n\npushee_txn\030\002 \001(\0132\034.cockroach."
+    "proto.Transaction\"P\n\024ResolveIntentReques"
+    "t\0228\n\006header\030\001 \001(\0132\036.cockroach.proto.Requ"
+    "estHeaderB\010\310\336\037\000\320\336\037\001\"R\n\025ResolveIntentResp"
+    "onse\0229\n\006header\030\001 \001(\0132\037.cockroach.proto.R"
+    "esponseHeaderB\010\310\336\037\000\320\336\037\001\"U\n\031ResolveIntent"
+    "RangeRequest\0228\n\006header\030\001 \001(\0132\036.cockroach"
+    ".proto.RequestHeaderB\010\310\336\037\000\320\336\037\001\"W\n\032Resolv"
+    "eIntentRangeResponse\0229\n\006header\030\001 \001(\0132\037.c"
+    "ockroach.proto.ResponseHeaderB\010\310\336\037\000\320\336\037\001\""
+    "u\n\014MergeRequest\0228\n\006header\030\001 \001(\0132\036.cockro"
+    "ach.proto.RequestHeaderB\010\310\336\037\000\320\336\037\001\022+\n\005val"
+    "ue\030\002 \001(\0132\026.cockroach.proto.ValueB\004\310\336\037\000\"J"
+    "\n\rMergeResponse\0229\n\006header\030\001 \001(\0132\037.cockro"
+    "ach.proto.ResponseHeaderB\010\310\336\037\000\320\336\037\001\"c\n\022Tr"
+    "uncateLogRequest\0228\n\006header\030\001 \001(\0132\036.cockr"
+    "oach.proto.RequestHeaderB\010\310\336\037\000\320\336\037\001\022\023\n\005in"
+    "dex\030\002 \001(\004B\004\310\336\037\000\"P\n\023TruncateLogResponse\0229"
+    "\n\006header\030\001 \001(\0132\037.cockroach.proto.Respons"
+    "eHeaderB\010\310\336\037\000\320\336\037\001\"{\n\022LeaderLeaseRequest\022"
+    "8\n\006header\030\001 \001(\0132\036.cockroach.proto.Reques"
+    "tHeaderB\010\310\336\037\000\320\336\037\001\022+\n\005lease\030\002 \001(\0132\026.cockr"
+    "oach.proto.LeaseB\004\310\336\037\000\"P\n\023LeaderLeaseRes"
+    "ponse\0229\n\006header\030\001 \001(\0132\037.cockroach.proto."
+    "ResponseHeaderB\010\310\336\037\000\320\336\037\001\"\221\t\n\014RequestUnio"
+    "n\022*\n\003get\030\001 \001(\0132\033.cockroach.proto.GetRequ"
+    "estH\000\022*\n\003put\030\002 \001(\0132\033.cockroach.proto.Put"
+    "RequestH\000\022A\n\017conditional_put\030\003 \001(\0132&.coc"
+    "kroach.proto.ConditionalPutRequestH\000\0226\n\t"
+    "increment\030\004 \001(\0132!.cockroach.proto.Increm"
+    "entRequestH\000\0220\n\006delete\030\005 \001(\0132\036.cockroach"
+    ".proto.DeleteRequestH\000\022;\n\014delete_range\030\006"
+    " \001(\0132#.cockroach.proto.DeleteRangeReques"
+    "tH\000\022,\n\004scan\030\007 \001(\0132\034.cockroach.proto.Scan"
+    "RequestH\000\022A\n\017end_transaction\030\010 \001(\0132&.coc"
+    "kroach.proto.EndTransactionRequestH\000\0229\n\013"
+    "admin_split\030\t \001(\0132\".cockroach.proto.Admi"
+    "nSplitRequestH\000\0229\n\013admin_merge\030\n \001(\0132\".c"
+    "ockroach.proto.AdminMergeRequestH\000\022=\n\rhe"
+    "artbeat_txn\030\013 \001(\0132$.cockroach.proto.Hear"
+    "tbeatTxnRequestH\000\022(\n\002gc\030\014 \001(\0132\032.cockroac"
+    "h.proto.GCRequestH\000\0223\n\010push_txn\030\r \001(\0132\037."
+    "cockroach.proto.PushTxnRequestH\000\022;\n\014rang"
+    "e_lookup\030\016 \001(\0132#.cockroach.proto.RangeLo"
+    "okupRequestH\000\022\?\n\016resolve_intent\030\017 \001(\0132%."
+    "cockroach.proto.ResolveIntentRequestH\000\022J"
+    "\n\024resolve_intent_range\030\020 \001(\0132*.cockroach"
+    ".proto.ResolveIntentRangeRequestH\000\022.\n\005me"
+    "rge\030\021 \001(\0132\035.cockroach.proto.MergeRequest"
+    "H\000\0227\n\010truncate\030\022 \001(\0132#.cockroach.proto.T"
+    "runcateLogRequestH\000\022;\n\014leader_lease\030\023 \001("
+    "\0132#.cockroach.proto.LeaderLeaseRequestH\000"
+    "\022;\n\014reverse_scan\030\024 \001(\0132#.cockroach.proto"
+    ".ReverseScanRequestH\000:\004\310\240\037\001B\007\n\005value\"\246\t\n"
+    "\rResponseUnion\022+\n\003get\030\001 \001(\0132\034.cockroach."
+    "proto.GetResponseH\000\022+\n\003put\030\002 \001(\0132\034.cockr"
+    "oach.proto.PutResponseH\000\022B\n\017conditional_"
+    "put\030\003 \001(\0132\'.cockroach.proto.ConditionalP"
+    "utResponseH\000\0227\n\tincrement\030\004 \001(\0132\".cockro"
+    "ach.proto.IncrementResponseH\000\0221\n\006delete\030"
+    "\005 \001(\0132\037.cockroach.proto.DeleteResponseH\000"
+    "\022<\n\014delete_range\030\006 \001(\0132$.cockroach.proto"
+    ".DeleteRangeResponseH\000\022-\n\004scan\030\007 \001(\0132\035.c"
+    "ockroach.proto.ScanResponseH\000\022B\n\017end_tra"
+    "nsaction\030\010 \001(\0132\'.cockroach.proto.EndTran"
+    "sactionResponseH\000\022:\n\013admin_split\030\t \001(\0132#"
+    ".cockroach.proto.AdminSplitResponseH\000\022:\n"
+    "\013admin_merge\030\n \001(\0132#.cockroach.proto.Adm"
+    "inMergeResponseH\000\022>\n\rheartbeat_txn\030\013 \001(\013"
+    "2%.cockroach.proto.HeartbeatTxnResponseH"
+    "\000\022)\n\002gc\030\014 \001(\0132\033.cockroach.proto.GCRespon"
+    "seH\000\0224\n\010push_txn\030\r \001(\0132 .cockroach.proto"
+    ".PushTxnResponseH\000\022<\n\014range_lookup\030\016 \001(\013"
+    "2$.cockroach.proto.RangeLookupResponseH\000"
+    "\022@\n\016resolve_intent\030\017 \001(\0132&.cockroach.pro"
+    "to.ResolveIntentResponseH\000\022K\n\024resolve_in"
+    "tent_range\030\020 \001(\0132+.cockroach.proto.Resol"
+    "veIntentRangeResponseH\000\022/\n\005merge\030\021 \001(\0132\036"
+    ".cockroach.proto.MergeResponseH\000\0228\n\010trun"
+    "cate\030\022 \001(\0132$.cockroach.proto.TruncateLog"
+    "ResponseH\000\022<\n\014leader_lease\030\023 \001(\0132$.cockr"
+    "oach.proto.LeaderLeaseResponseH\000\022<\n\014reve"
+    "rse_scan\030\024 \001(\0132$.cockroach.proto.Reverse"
+    "ScanResponseH\000:\004\310\240\037\001B\007\n\005value\"\177\n\014BatchRe"
+    "quest\0228\n\006header\030\001 \001(\0132\036.cockroach.proto."
+    "RequestHeaderB\010\310\336\037\000\320\336\037\001\0225\n\010requests\030\002 \003("
+    "\0132\035.cockroach.proto.RequestUnionB\004\310\336\037\000\"\203"
+    "\001\n\rBatchResponse\0229\n\006header\030\001 \001(\0132\037.cockr"
+    "oach.proto.ResponseHeaderB\010\310\336\037\000\320\336\037\001\0227\n\tr"
+    "esponses\030\002 \003(\0132\036.cockroach.proto.Respons"
+    "eUnionB\004\310\336\037\000*L\n\023ReadConsistencyType\022\016\n\nC"
+    "ONSISTENT\020\000\022\r\n\tCONSENSUS\020\001\022\020\n\014INCONSISTE"
+    "NT\020\002\032\004\210\243\036\000*G\n\013PushTxnType\022\022\n\016PUSH_TIMEST"
+    "AMP\020\000\022\r\n\tABORT_TXN\020\001\022\017\n\013CLEANUP_TXN\020\002\032\004\210"
+    "\243\036\000B\027Z\005proto\340\342\036\001\310\342\036\001\320\342\036\001\220\343\036\000", 8108);
   ::google::protobuf::MessageFactory::InternalRegisterGeneratedFile(
     "cockroach/proto/api.proto", &protobuf_RegisterTypes);
   ClientCmdID::default_instance_ = new ClientCmdID();
@@ -1954,7 +1952,6 @@ const int RequestHeader::kTimestampFieldNumber;
 const int RequestHeader::kCmdIdFieldNumber;
 const int RequestHeader::kKeyFieldNumber;
 const int RequestHeader::kEndKeyFieldNumber;
-const int RequestHeader::kUserFieldNumber;
 const int RequestHeader::kReplicaFieldNumber;
 const int RequestHeader::kRangeIdFieldNumber;
 const int RequestHeader::kUserPriorityFieldNumber;
@@ -1990,7 +1987,6 @@ void RequestHeader::SharedCtor() {
   cmd_id_ = NULL;
   key_.UnsafeSetDefault(&::google::protobuf::internal::GetEmptyStringAlreadyInited());
   end_key_.UnsafeSetDefault(&::google::protobuf::internal::GetEmptyStringAlreadyInited());
-  user_.UnsafeSetDefault(&::google::protobuf::internal::GetEmptyStringAlreadyInited());
   replica_ = NULL;
   range_id_ = GOOGLE_LONGLONG(0);
   user_priority_ = 1;
@@ -2007,7 +2003,6 @@ RequestHeader::~RequestHeader() {
 void RequestHeader::SharedDtor() {
   key_.DestroyNoArena(&::google::protobuf::internal::GetEmptyStringAlreadyInited());
   end_key_.DestroyNoArena(&::google::protobuf::internal::GetEmptyStringAlreadyInited());
-  user_.DestroyNoArena(&::google::protobuf::internal::GetEmptyStringAlreadyInited());
   if (this != default_instance_) {
     delete timestamp_;
     delete cmd_id_;
@@ -2055,21 +2050,16 @@ void RequestHeader::Clear() {
     if (has_end_key()) {
       end_key_.ClearToEmptyNoArena(&::google::protobuf::internal::GetEmptyStringAlreadyInited());
     }
-    if (has_user()) {
-      user_.ClearToEmptyNoArena(&::google::protobuf::internal::GetEmptyStringAlreadyInited());
-    }
     if (has_replica()) {
       if (replica_ != NULL) replica_->::cockroach::proto::Replica::Clear();
     }
     range_id_ = GOOGLE_LONGLONG(0);
     user_priority_ = 1;
-  }
-  if (_has_bits_[8 / 32] & 768u) {
     if (has_txn()) {
       if (txn_ != NULL) txn_->::cockroach::proto::Transaction::Clear();
     }
-    read_consistency_ = 0;
   }
+  read_consistency_ = 0;
   ::memset(_has_bits_, 0, sizeof(_has_bits_));
   if (_internal_metadata_.have_unknown_fields()) {
     mutable_unknown_fields()->Clear();
@@ -2133,43 +2123,26 @@ bool RequestHeader::MergePartialFromCodedStream(
         } else {
           goto handle_unusual;
         }
-        if (input->ExpectTag(42)) goto parse_user;
+        if (input->ExpectTag(42)) goto parse_replica;
         break;
       }
 
-      // optional string user = 5;
+      // optional .cockroach.proto.Replica replica = 5;
       case 5: {
         if (tag == 42) {
-         parse_user:
-          DO_(::google::protobuf::internal::WireFormatLite::ReadString(
-                input, this->mutable_user()));
-          ::google::protobuf::internal::WireFormat::VerifyUTF8StringNamedField(
-            this->user().data(), this->user().length(),
-            ::google::protobuf::internal::WireFormat::PARSE,
-            "cockroach.proto.RequestHeader.user");
-        } else {
-          goto handle_unusual;
-        }
-        if (input->ExpectTag(50)) goto parse_replica;
-        break;
-      }
-
-      // optional .cockroach.proto.Replica replica = 6;
-      case 6: {
-        if (tag == 50) {
          parse_replica:
           DO_(::google::protobuf::internal::WireFormatLite::ReadMessageNoVirtual(
                input, mutable_replica()));
         } else {
           goto handle_unusual;
         }
-        if (input->ExpectTag(56)) goto parse_range_id;
+        if (input->ExpectTag(48)) goto parse_range_id;
         break;
       }
 
-      // optional int64 range_id = 7;
-      case 7: {
-        if (tag == 56) {
+      // optional int64 range_id = 6;
+      case 6: {
+        if (tag == 48) {
          parse_range_id:
           DO_((::google::protobuf::internal::WireFormatLite::ReadPrimitive<
                    ::google::protobuf::int64, ::google::protobuf::internal::WireFormatLite::TYPE_INT64>(
@@ -2178,13 +2151,13 @@ bool RequestHeader::MergePartialFromCodedStream(
         } else {
           goto handle_unusual;
         }
-        if (input->ExpectTag(64)) goto parse_user_priority;
+        if (input->ExpectTag(56)) goto parse_user_priority;
         break;
       }
 
-      // optional int32 user_priority = 8 [default = 1];
-      case 8: {
-        if (tag == 64) {
+      // optional int32 user_priority = 7 [default = 1];
+      case 7: {
+        if (tag == 56) {
          parse_user_priority:
           DO_((::google::protobuf::internal::WireFormatLite::ReadPrimitive<
                    ::google::protobuf::int32, ::google::protobuf::internal::WireFormatLite::TYPE_INT32>(
@@ -2193,26 +2166,26 @@ bool RequestHeader::MergePartialFromCodedStream(
         } else {
           goto handle_unusual;
         }
-        if (input->ExpectTag(74)) goto parse_txn;
+        if (input->ExpectTag(66)) goto parse_txn;
         break;
       }
 
-      // optional .cockroach.proto.Transaction txn = 9;
-      case 9: {
-        if (tag == 74) {
+      // optional .cockroach.proto.Transaction txn = 8;
+      case 8: {
+        if (tag == 66) {
          parse_txn:
           DO_(::google::protobuf::internal::WireFormatLite::ReadMessageNoVirtual(
                input, mutable_txn()));
         } else {
           goto handle_unusual;
         }
-        if (input->ExpectTag(80)) goto parse_read_consistency;
+        if (input->ExpectTag(72)) goto parse_read_consistency;
         break;
       }
 
-      // optional .cockroach.proto.ReadConsistencyType read_consistency = 10;
-      case 10: {
-        if (tag == 80) {
+      // optional .cockroach.proto.ReadConsistencyType read_consistency = 9;
+      case 9: {
+        if (tag == 72) {
          parse_read_consistency:
           int value;
           DO_((::google::protobuf::internal::WireFormatLite::ReadPrimitive<
@@ -2221,7 +2194,7 @@ bool RequestHeader::MergePartialFromCodedStream(
           if (::cockroach::proto::ReadConsistencyType_IsValid(value)) {
             set_read_consistency(static_cast< ::cockroach::proto::ReadConsistencyType >(value));
           } else {
-            mutable_unknown_fields()->AddVarint(10, value);
+            mutable_unknown_fields()->AddVarint(9, value);
           }
         } else {
           goto handle_unusual;
@@ -2279,42 +2252,32 @@ void RequestHeader::SerializeWithCachedSizes(
       4, this->end_key(), output);
   }
 
-  // optional string user = 5;
-  if (has_user()) {
-    ::google::protobuf::internal::WireFormat::VerifyUTF8StringNamedField(
-      this->user().data(), this->user().length(),
-      ::google::protobuf::internal::WireFormat::SERIALIZE,
-      "cockroach.proto.RequestHeader.user");
-    ::google::protobuf::internal::WireFormatLite::WriteStringMaybeAliased(
-      5, this->user(), output);
-  }
-
-  // optional .cockroach.proto.Replica replica = 6;
+  // optional .cockroach.proto.Replica replica = 5;
   if (has_replica()) {
     ::google::protobuf::internal::WireFormatLite::WriteMessageMaybeToArray(
-      6, *this->replica_, output);
+      5, *this->replica_, output);
   }
 
-  // optional int64 range_id = 7;
+  // optional int64 range_id = 6;
   if (has_range_id()) {
-    ::google::protobuf::internal::WireFormatLite::WriteInt64(7, this->range_id(), output);
+    ::google::protobuf::internal::WireFormatLite::WriteInt64(6, this->range_id(), output);
   }
 
-  // optional int32 user_priority = 8 [default = 1];
+  // optional int32 user_priority = 7 [default = 1];
   if (has_user_priority()) {
-    ::google::protobuf::internal::WireFormatLite::WriteInt32(8, this->user_priority(), output);
+    ::google::protobuf::internal::WireFormatLite::WriteInt32(7, this->user_priority(), output);
   }
 
-  // optional .cockroach.proto.Transaction txn = 9;
+  // optional .cockroach.proto.Transaction txn = 8;
   if (has_txn()) {
     ::google::protobuf::internal::WireFormatLite::WriteMessageMaybeToArray(
-      9, *this->txn_, output);
+      8, *this->txn_, output);
   }
 
-  // optional .cockroach.proto.ReadConsistencyType read_consistency = 10;
+  // optional .cockroach.proto.ReadConsistencyType read_consistency = 9;
   if (has_read_consistency()) {
     ::google::protobuf::internal::WireFormatLite::WriteEnum(
-      10, this->read_consistency(), output);
+      9, this->read_consistency(), output);
   }
 
   if (_internal_metadata_.have_unknown_fields()) {
@@ -2355,45 +2318,34 @@ void RequestHeader::SerializeWithCachedSizes(
         4, this->end_key(), target);
   }
 
-  // optional string user = 5;
-  if (has_user()) {
-    ::google::protobuf::internal::WireFormat::VerifyUTF8StringNamedField(
-      this->user().data(), this->user().length(),
-      ::google::protobuf::internal::WireFormat::SERIALIZE,
-      "cockroach.proto.RequestHeader.user");
-    target =
-      ::google::protobuf::internal::WireFormatLite::WriteStringToArray(
-        5, this->user(), target);
-  }
-
-  // optional .cockroach.proto.Replica replica = 6;
+  // optional .cockroach.proto.Replica replica = 5;
   if (has_replica()) {
     target = ::google::protobuf::internal::WireFormatLite::
       WriteMessageNoVirtualToArray(
-        6, *this->replica_, target);
+        5, *this->replica_, target);
   }
 
-  // optional int64 range_id = 7;
+  // optional int64 range_id = 6;
   if (has_range_id()) {
-    target = ::google::protobuf::internal::WireFormatLite::WriteInt64ToArray(7, this->range_id(), target);
+    target = ::google::protobuf::internal::WireFormatLite::WriteInt64ToArray(6, this->range_id(), target);
   }
 
-  // optional int32 user_priority = 8 [default = 1];
+  // optional int32 user_priority = 7 [default = 1];
   if (has_user_priority()) {
-    target = ::google::protobuf::internal::WireFormatLite::WriteInt32ToArray(8, this->user_priority(), target);
+    target = ::google::protobuf::internal::WireFormatLite::WriteInt32ToArray(7, this->user_priority(), target);
   }
 
-  // optional .cockroach.proto.Transaction txn = 9;
+  // optional .cockroach.proto.Transaction txn = 8;
   if (has_txn()) {
     target = ::google::protobuf::internal::WireFormatLite::
       WriteMessageNoVirtualToArray(
-        9, *this->txn_, target);
+        8, *this->txn_, target);
   }
 
-  // optional .cockroach.proto.ReadConsistencyType read_consistency = 10;
+  // optional .cockroach.proto.ReadConsistencyType read_consistency = 9;
   if (has_read_consistency()) {
     target = ::google::protobuf::internal::WireFormatLite::WriteEnumToArray(
-      10, this->read_consistency(), target);
+      9, this->read_consistency(), target);
   }
 
   if (_internal_metadata_.have_unknown_fields()) {
@@ -2436,50 +2388,41 @@ int RequestHeader::ByteSize() const {
           this->end_key());
     }
 
-    // optional string user = 5;
-    if (has_user()) {
-      total_size += 1 +
-        ::google::protobuf::internal::WireFormatLite::StringSize(
-          this->user());
-    }
-
-    // optional .cockroach.proto.Replica replica = 6;
+    // optional .cockroach.proto.Replica replica = 5;
     if (has_replica()) {
       total_size += 1 +
         ::google::protobuf::internal::WireFormatLite::MessageSizeNoVirtual(
           *this->replica_);
     }
 
-    // optional int64 range_id = 7;
+    // optional int64 range_id = 6;
     if (has_range_id()) {
       total_size += 1 +
         ::google::protobuf::internal::WireFormatLite::Int64Size(
           this->range_id());
     }
 
-    // optional int32 user_priority = 8 [default = 1];
+    // optional int32 user_priority = 7 [default = 1];
     if (has_user_priority()) {
       total_size += 1 +
         ::google::protobuf::internal::WireFormatLite::Int32Size(
           this->user_priority());
     }
 
-  }
-  if (_has_bits_[8 / 32] & 768) {
-    // optional .cockroach.proto.Transaction txn = 9;
+    // optional .cockroach.proto.Transaction txn = 8;
     if (has_txn()) {
       total_size += 1 +
         ::google::protobuf::internal::WireFormatLite::MessageSizeNoVirtual(
           *this->txn_);
     }
 
-    // optional .cockroach.proto.ReadConsistencyType read_consistency = 10;
-    if (has_read_consistency()) {
-      total_size += 1 +
-        ::google::protobuf::internal::WireFormatLite::EnumSize(this->read_consistency());
-    }
-
   }
+  // optional .cockroach.proto.ReadConsistencyType read_consistency = 9;
+  if (has_read_consistency()) {
+    total_size += 1 +
+      ::google::protobuf::internal::WireFormatLite::EnumSize(this->read_consistency());
+  }
+
   if (_internal_metadata_.have_unknown_fields()) {
     total_size +=
       ::google::protobuf::internal::WireFormat::ComputeUnknownFieldsSize(
@@ -2520,10 +2463,6 @@ void RequestHeader::MergeFrom(const RequestHeader& from) {
       set_has_end_key();
       end_key_.AssignWithDefault(&::google::protobuf::internal::GetEmptyStringAlreadyInited(), from.end_key_);
     }
-    if (from.has_user()) {
-      set_has_user();
-      user_.AssignWithDefault(&::google::protobuf::internal::GetEmptyStringAlreadyInited(), from.user_);
-    }
     if (from.has_replica()) {
       mutable_replica()->::cockroach::proto::Replica::MergeFrom(from.replica());
     }
@@ -2533,11 +2472,11 @@ void RequestHeader::MergeFrom(const RequestHeader& from) {
     if (from.has_user_priority()) {
       set_user_priority(from.user_priority());
     }
-  }
-  if (from._has_bits_[8 / 32] & (0xffu << (8 % 32))) {
     if (from.has_txn()) {
       mutable_txn()->::cockroach::proto::Transaction::MergeFrom(from.txn());
     }
+  }
+  if (from._has_bits_[8 / 32] & (0xffu << (8 % 32))) {
     if (from.has_read_consistency()) {
       set_read_consistency(from.read_consistency());
     }
@@ -2573,7 +2512,6 @@ void RequestHeader::InternalSwap(RequestHeader* other) {
   std::swap(cmd_id_, other->cmd_id_);
   key_.Swap(&other->key_);
   end_key_.Swap(&other->end_key_);
-  user_.Swap(&other->user_);
   std::swap(replica_, other->replica_);
   std::swap(range_id_, other->range_id_);
   std::swap(user_priority_, other->user_priority_);
@@ -2787,68 +2725,15 @@ void RequestHeader::clear_end_key() {
   // @@protoc_insertion_point(field_set_allocated:cockroach.proto.RequestHeader.end_key)
 }
 
-// optional string user = 5;
-bool RequestHeader::has_user() const {
+// optional .cockroach.proto.Replica replica = 5;
+bool RequestHeader::has_replica() const {
   return (_has_bits_[0] & 0x00000010u) != 0;
 }
-void RequestHeader::set_has_user() {
+void RequestHeader::set_has_replica() {
   _has_bits_[0] |= 0x00000010u;
 }
-void RequestHeader::clear_has_user() {
-  _has_bits_[0] &= ~0x00000010u;
-}
-void RequestHeader::clear_user() {
-  user_.ClearToEmptyNoArena(&::google::protobuf::internal::GetEmptyStringAlreadyInited());
-  clear_has_user();
-}
- const ::std::string& RequestHeader::user() const {
-  // @@protoc_insertion_point(field_get:cockroach.proto.RequestHeader.user)
-  return user_.GetNoArena(&::google::protobuf::internal::GetEmptyStringAlreadyInited());
-}
- void RequestHeader::set_user(const ::std::string& value) {
-  set_has_user();
-  user_.SetNoArena(&::google::protobuf::internal::GetEmptyStringAlreadyInited(), value);
-  // @@protoc_insertion_point(field_set:cockroach.proto.RequestHeader.user)
-}
- void RequestHeader::set_user(const char* value) {
-  set_has_user();
-  user_.SetNoArena(&::google::protobuf::internal::GetEmptyStringAlreadyInited(), ::std::string(value));
-  // @@protoc_insertion_point(field_set_char:cockroach.proto.RequestHeader.user)
-}
- void RequestHeader::set_user(const char* value, size_t size) {
-  set_has_user();
-  user_.SetNoArena(&::google::protobuf::internal::GetEmptyStringAlreadyInited(),
-      ::std::string(reinterpret_cast<const char*>(value), size));
-  // @@protoc_insertion_point(field_set_pointer:cockroach.proto.RequestHeader.user)
-}
- ::std::string* RequestHeader::mutable_user() {
-  set_has_user();
-  // @@protoc_insertion_point(field_mutable:cockroach.proto.RequestHeader.user)
-  return user_.MutableNoArena(&::google::protobuf::internal::GetEmptyStringAlreadyInited());
-}
- ::std::string* RequestHeader::release_user() {
-  clear_has_user();
-  return user_.ReleaseNoArena(&::google::protobuf::internal::GetEmptyStringAlreadyInited());
-}
- void RequestHeader::set_allocated_user(::std::string* user) {
-  if (user != NULL) {
-    set_has_user();
-  } else {
-    clear_has_user();
-  }
-  user_.SetAllocatedNoArena(&::google::protobuf::internal::GetEmptyStringAlreadyInited(), user);
-  // @@protoc_insertion_point(field_set_allocated:cockroach.proto.RequestHeader.user)
-}
-
-// optional .cockroach.proto.Replica replica = 6;
-bool RequestHeader::has_replica() const {
-  return (_has_bits_[0] & 0x00000020u) != 0;
-}
-void RequestHeader::set_has_replica() {
-  _has_bits_[0] |= 0x00000020u;
-}
 void RequestHeader::clear_has_replica() {
-  _has_bits_[0] &= ~0x00000020u;
+  _has_bits_[0] &= ~0x00000010u;
 }
 void RequestHeader::clear_replica() {
   if (replica_ != NULL) replica_->::cockroach::proto::Replica::Clear();
@@ -2883,15 +2768,15 @@ void RequestHeader::clear_replica() {
   // @@protoc_insertion_point(field_set_allocated:cockroach.proto.RequestHeader.replica)
 }
 
-// optional int64 range_id = 7;
+// optional int64 range_id = 6;
 bool RequestHeader::has_range_id() const {
-  return (_has_bits_[0] & 0x00000040u) != 0;
+  return (_has_bits_[0] & 0x00000020u) != 0;
 }
 void RequestHeader::set_has_range_id() {
-  _has_bits_[0] |= 0x00000040u;
+  _has_bits_[0] |= 0x00000020u;
 }
 void RequestHeader::clear_has_range_id() {
-  _has_bits_[0] &= ~0x00000040u;
+  _has_bits_[0] &= ~0x00000020u;
 }
 void RequestHeader::clear_range_id() {
   range_id_ = GOOGLE_LONGLONG(0);
@@ -2907,15 +2792,15 @@ void RequestHeader::clear_range_id() {
   // @@protoc_insertion_point(field_set:cockroach.proto.RequestHeader.range_id)
 }
 
-// optional int32 user_priority = 8 [default = 1];
+// optional int32 user_priority = 7 [default = 1];
 bool RequestHeader::has_user_priority() const {
-  return (_has_bits_[0] & 0x00000080u) != 0;
+  return (_has_bits_[0] & 0x00000040u) != 0;
 }
 void RequestHeader::set_has_user_priority() {
-  _has_bits_[0] |= 0x00000080u;
+  _has_bits_[0] |= 0x00000040u;
 }
 void RequestHeader::clear_has_user_priority() {
-  _has_bits_[0] &= ~0x00000080u;
+  _has_bits_[0] &= ~0x00000040u;
 }
 void RequestHeader::clear_user_priority() {
   user_priority_ = 1;
@@ -2931,15 +2816,15 @@ void RequestHeader::clear_user_priority() {
   // @@protoc_insertion_point(field_set:cockroach.proto.RequestHeader.user_priority)
 }
 
-// optional .cockroach.proto.Transaction txn = 9;
+// optional .cockroach.proto.Transaction txn = 8;
 bool RequestHeader::has_txn() const {
-  return (_has_bits_[0] & 0x00000100u) != 0;
+  return (_has_bits_[0] & 0x00000080u) != 0;
 }
 void RequestHeader::set_has_txn() {
-  _has_bits_[0] |= 0x00000100u;
+  _has_bits_[0] |= 0x00000080u;
 }
 void RequestHeader::clear_has_txn() {
-  _has_bits_[0] &= ~0x00000100u;
+  _has_bits_[0] &= ~0x00000080u;
 }
 void RequestHeader::clear_txn() {
   if (txn_ != NULL) txn_->::cockroach::proto::Transaction::Clear();
@@ -2974,15 +2859,15 @@ void RequestHeader::clear_txn() {
   // @@protoc_insertion_point(field_set_allocated:cockroach.proto.RequestHeader.txn)
 }
 
-// optional .cockroach.proto.ReadConsistencyType read_consistency = 10;
+// optional .cockroach.proto.ReadConsistencyType read_consistency = 9;
 bool RequestHeader::has_read_consistency() const {
-  return (_has_bits_[0] & 0x00000200u) != 0;
+  return (_has_bits_[0] & 0x00000100u) != 0;
 }
 void RequestHeader::set_has_read_consistency() {
-  _has_bits_[0] |= 0x00000200u;
+  _has_bits_[0] |= 0x00000100u;
 }
 void RequestHeader::clear_has_read_consistency() {
-  _has_bits_[0] &= ~0x00000200u;
+  _has_bits_[0] &= ~0x00000100u;
 }
 void RequestHeader::clear_read_consistency() {
   read_consistency_ = 0;

--- a/storage/engine/rocksdb/cockroach/proto/api.pb.h
+++ b/storage/engine/rocksdb/cockroach/proto/api.pb.h
@@ -338,54 +338,42 @@ class RequestHeader : public ::google::protobuf::Message {
   ::std::string* release_end_key();
   void set_allocated_end_key(::std::string* end_key);
 
-  // optional string user = 5;
-  bool has_user() const;
-  void clear_user();
-  static const int kUserFieldNumber = 5;
-  const ::std::string& user() const;
-  void set_user(const ::std::string& value);
-  void set_user(const char* value);
-  void set_user(const char* value, size_t size);
-  ::std::string* mutable_user();
-  ::std::string* release_user();
-  void set_allocated_user(::std::string* user);
-
-  // optional .cockroach.proto.Replica replica = 6;
+  // optional .cockroach.proto.Replica replica = 5;
   bool has_replica() const;
   void clear_replica();
-  static const int kReplicaFieldNumber = 6;
+  static const int kReplicaFieldNumber = 5;
   const ::cockroach::proto::Replica& replica() const;
   ::cockroach::proto::Replica* mutable_replica();
   ::cockroach::proto::Replica* release_replica();
   void set_allocated_replica(::cockroach::proto::Replica* replica);
 
-  // optional int64 range_id = 7;
+  // optional int64 range_id = 6;
   bool has_range_id() const;
   void clear_range_id();
-  static const int kRangeIdFieldNumber = 7;
+  static const int kRangeIdFieldNumber = 6;
   ::google::protobuf::int64 range_id() const;
   void set_range_id(::google::protobuf::int64 value);
 
-  // optional int32 user_priority = 8 [default = 1];
+  // optional int32 user_priority = 7 [default = 1];
   bool has_user_priority() const;
   void clear_user_priority();
-  static const int kUserPriorityFieldNumber = 8;
+  static const int kUserPriorityFieldNumber = 7;
   ::google::protobuf::int32 user_priority() const;
   void set_user_priority(::google::protobuf::int32 value);
 
-  // optional .cockroach.proto.Transaction txn = 9;
+  // optional .cockroach.proto.Transaction txn = 8;
   bool has_txn() const;
   void clear_txn();
-  static const int kTxnFieldNumber = 9;
+  static const int kTxnFieldNumber = 8;
   const ::cockroach::proto::Transaction& txn() const;
   ::cockroach::proto::Transaction* mutable_txn();
   ::cockroach::proto::Transaction* release_txn();
   void set_allocated_txn(::cockroach::proto::Transaction* txn);
 
-  // optional .cockroach.proto.ReadConsistencyType read_consistency = 10;
+  // optional .cockroach.proto.ReadConsistencyType read_consistency = 9;
   bool has_read_consistency() const;
   void clear_read_consistency();
-  static const int kReadConsistencyFieldNumber = 10;
+  static const int kReadConsistencyFieldNumber = 9;
   ::cockroach::proto::ReadConsistencyType read_consistency() const;
   void set_read_consistency(::cockroach::proto::ReadConsistencyType value);
 
@@ -399,8 +387,6 @@ class RequestHeader : public ::google::protobuf::Message {
   inline void clear_has_key();
   inline void set_has_end_key();
   inline void clear_has_end_key();
-  inline void set_has_user();
-  inline void clear_has_user();
   inline void set_has_replica();
   inline void clear_has_replica();
   inline void set_has_range_id();
@@ -419,7 +405,6 @@ class RequestHeader : public ::google::protobuf::Message {
   ::cockroach::proto::ClientCmdID* cmd_id_;
   ::google::protobuf::internal::ArenaStringPtr key_;
   ::google::protobuf::internal::ArenaStringPtr end_key_;
-  ::google::protobuf::internal::ArenaStringPtr user_;
   ::cockroach::proto::Replica* replica_;
   ::google::protobuf::int64 range_id_;
   ::cockroach::proto::Transaction* txn_;
@@ -5790,68 +5775,15 @@ inline void RequestHeader::set_allocated_end_key(::std::string* end_key) {
   // @@protoc_insertion_point(field_set_allocated:cockroach.proto.RequestHeader.end_key)
 }
 
-// optional string user = 5;
-inline bool RequestHeader::has_user() const {
+// optional .cockroach.proto.Replica replica = 5;
+inline bool RequestHeader::has_replica() const {
   return (_has_bits_[0] & 0x00000010u) != 0;
 }
-inline void RequestHeader::set_has_user() {
+inline void RequestHeader::set_has_replica() {
   _has_bits_[0] |= 0x00000010u;
 }
-inline void RequestHeader::clear_has_user() {
-  _has_bits_[0] &= ~0x00000010u;
-}
-inline void RequestHeader::clear_user() {
-  user_.ClearToEmptyNoArena(&::google::protobuf::internal::GetEmptyStringAlreadyInited());
-  clear_has_user();
-}
-inline const ::std::string& RequestHeader::user() const {
-  // @@protoc_insertion_point(field_get:cockroach.proto.RequestHeader.user)
-  return user_.GetNoArena(&::google::protobuf::internal::GetEmptyStringAlreadyInited());
-}
-inline void RequestHeader::set_user(const ::std::string& value) {
-  set_has_user();
-  user_.SetNoArena(&::google::protobuf::internal::GetEmptyStringAlreadyInited(), value);
-  // @@protoc_insertion_point(field_set:cockroach.proto.RequestHeader.user)
-}
-inline void RequestHeader::set_user(const char* value) {
-  set_has_user();
-  user_.SetNoArena(&::google::protobuf::internal::GetEmptyStringAlreadyInited(), ::std::string(value));
-  // @@protoc_insertion_point(field_set_char:cockroach.proto.RequestHeader.user)
-}
-inline void RequestHeader::set_user(const char* value, size_t size) {
-  set_has_user();
-  user_.SetNoArena(&::google::protobuf::internal::GetEmptyStringAlreadyInited(),
-      ::std::string(reinterpret_cast<const char*>(value), size));
-  // @@protoc_insertion_point(field_set_pointer:cockroach.proto.RequestHeader.user)
-}
-inline ::std::string* RequestHeader::mutable_user() {
-  set_has_user();
-  // @@protoc_insertion_point(field_mutable:cockroach.proto.RequestHeader.user)
-  return user_.MutableNoArena(&::google::protobuf::internal::GetEmptyStringAlreadyInited());
-}
-inline ::std::string* RequestHeader::release_user() {
-  clear_has_user();
-  return user_.ReleaseNoArena(&::google::protobuf::internal::GetEmptyStringAlreadyInited());
-}
-inline void RequestHeader::set_allocated_user(::std::string* user) {
-  if (user != NULL) {
-    set_has_user();
-  } else {
-    clear_has_user();
-  }
-  user_.SetAllocatedNoArena(&::google::protobuf::internal::GetEmptyStringAlreadyInited(), user);
-  // @@protoc_insertion_point(field_set_allocated:cockroach.proto.RequestHeader.user)
-}
-
-// optional .cockroach.proto.Replica replica = 6;
-inline bool RequestHeader::has_replica() const {
-  return (_has_bits_[0] & 0x00000020u) != 0;
-}
-inline void RequestHeader::set_has_replica() {
-  _has_bits_[0] |= 0x00000020u;
-}
 inline void RequestHeader::clear_has_replica() {
-  _has_bits_[0] &= ~0x00000020u;
+  _has_bits_[0] &= ~0x00000010u;
 }
 inline void RequestHeader::clear_replica() {
   if (replica_ != NULL) replica_->::cockroach::proto::Replica::Clear();
@@ -5886,15 +5818,15 @@ inline void RequestHeader::set_allocated_replica(::cockroach::proto::Replica* re
   // @@protoc_insertion_point(field_set_allocated:cockroach.proto.RequestHeader.replica)
 }
 
-// optional int64 range_id = 7;
+// optional int64 range_id = 6;
 inline bool RequestHeader::has_range_id() const {
-  return (_has_bits_[0] & 0x00000040u) != 0;
+  return (_has_bits_[0] & 0x00000020u) != 0;
 }
 inline void RequestHeader::set_has_range_id() {
-  _has_bits_[0] |= 0x00000040u;
+  _has_bits_[0] |= 0x00000020u;
 }
 inline void RequestHeader::clear_has_range_id() {
-  _has_bits_[0] &= ~0x00000040u;
+  _has_bits_[0] &= ~0x00000020u;
 }
 inline void RequestHeader::clear_range_id() {
   range_id_ = GOOGLE_LONGLONG(0);
@@ -5910,15 +5842,15 @@ inline void RequestHeader::set_range_id(::google::protobuf::int64 value) {
   // @@protoc_insertion_point(field_set:cockroach.proto.RequestHeader.range_id)
 }
 
-// optional int32 user_priority = 8 [default = 1];
+// optional int32 user_priority = 7 [default = 1];
 inline bool RequestHeader::has_user_priority() const {
-  return (_has_bits_[0] & 0x00000080u) != 0;
+  return (_has_bits_[0] & 0x00000040u) != 0;
 }
 inline void RequestHeader::set_has_user_priority() {
-  _has_bits_[0] |= 0x00000080u;
+  _has_bits_[0] |= 0x00000040u;
 }
 inline void RequestHeader::clear_has_user_priority() {
-  _has_bits_[0] &= ~0x00000080u;
+  _has_bits_[0] &= ~0x00000040u;
 }
 inline void RequestHeader::clear_user_priority() {
   user_priority_ = 1;
@@ -5934,15 +5866,15 @@ inline void RequestHeader::set_user_priority(::google::protobuf::int32 value) {
   // @@protoc_insertion_point(field_set:cockroach.proto.RequestHeader.user_priority)
 }
 
-// optional .cockroach.proto.Transaction txn = 9;
+// optional .cockroach.proto.Transaction txn = 8;
 inline bool RequestHeader::has_txn() const {
-  return (_has_bits_[0] & 0x00000100u) != 0;
+  return (_has_bits_[0] & 0x00000080u) != 0;
 }
 inline void RequestHeader::set_has_txn() {
-  _has_bits_[0] |= 0x00000100u;
+  _has_bits_[0] |= 0x00000080u;
 }
 inline void RequestHeader::clear_has_txn() {
-  _has_bits_[0] &= ~0x00000100u;
+  _has_bits_[0] &= ~0x00000080u;
 }
 inline void RequestHeader::clear_txn() {
   if (txn_ != NULL) txn_->::cockroach::proto::Transaction::Clear();
@@ -5977,15 +5909,15 @@ inline void RequestHeader::set_allocated_txn(::cockroach::proto::Transaction* tx
   // @@protoc_insertion_point(field_set_allocated:cockroach.proto.RequestHeader.txn)
 }
 
-// optional .cockroach.proto.ReadConsistencyType read_consistency = 10;
+// optional .cockroach.proto.ReadConsistencyType read_consistency = 9;
 inline bool RequestHeader::has_read_consistency() const {
-  return (_has_bits_[0] & 0x00000200u) != 0;
+  return (_has_bits_[0] & 0x00000100u) != 0;
 }
 inline void RequestHeader::set_has_read_consistency() {
-  _has_bits_[0] |= 0x00000200u;
+  _has_bits_[0] |= 0x00000100u;
 }
 inline void RequestHeader::clear_has_read_consistency() {
-  _has_bits_[0] &= ~0x00000200u;
+  _has_bits_[0] &= ~0x00000100u;
 }
 inline void RequestHeader::clear_read_consistency() {
   read_consistency_ = 0;

--- a/storage/gc_queue.go
+++ b/storage/gc_queue.go
@@ -26,7 +26,6 @@ import (
 	"github.com/cockroachdb/cockroach/config"
 	"github.com/cockroachdb/cockroach/gossip"
 	"github.com/cockroachdb/cockroach/proto"
-	"github.com/cockroachdb/cockroach/security"
 	"github.com/cockroachdb/cockroach/storage/engine"
 	"github.com/cockroachdb/cockroach/util"
 	"github.com/cockroachdb/cockroach/util/log"
@@ -283,7 +282,6 @@ func (gcq *gcQueue) pushTxn(repl *Replica, now proto.Timestamp, txn *proto.Trans
 		RequestHeader: proto.RequestHeader{
 			Timestamp:    now,
 			Key:          txn.Key,
-			User:         security.RootUser,
 			UserPriority: gogoproto.Int32(proto.MaxPriority),
 			Txn:          nil,
 		},

--- a/storage/replica.go
+++ b/storage/replica.go
@@ -36,7 +36,6 @@ import (
 	"github.com/cockroachdb/cockroach/gossip"
 	"github.com/cockroachdb/cockroach/keys"
 	"github.com/cockroachdb/cockroach/proto"
-	"github.com/cockroachdb/cockroach/security"
 	"github.com/cockroachdb/cockroach/storage/engine"
 	"github.com/cockroachdb/cockroach/util"
 	"github.com/cockroachdb/cockroach/util/hlc"
@@ -1185,7 +1184,6 @@ func (r *Replica) resolveIntents(ctx context.Context, intents []proto.Intent) {
 	var wg sync.WaitGroup
 
 	bArgs := &proto.BatchRequest{}
-	bArgs.User = security.RootUser
 	for i := range intents {
 		intent := intents[i] // avoids a race in `i, intent := range ...`
 		var resolveArgs proto.Request
@@ -1198,7 +1196,6 @@ func (r *Replica) resolveIntents(ctx context.Context, intents []proto.Intent) {
 				Timestamp: intent.Txn.Timestamp,
 				Key:       intent.Key,
 				EndKey:    intent.EndKey,
-				User:      security.RootUser,
 				Txn:       &intent.Txn,
 			}
 

--- a/storage/store.go
+++ b/storage/store.go
@@ -1366,7 +1366,6 @@ func (s *Store) resolveWriteIntentError(ctx context.Context, wiErr *proto.WriteI
 	bArgs := &proto.BatchRequest{
 		RequestHeader: proto.RequestHeader{
 			Txn:          header.Txn,
-			User:         header.User,
 			UserPriority: header.UserPriority,
 		},
 	}

--- a/testutils/base.go
+++ b/testutils/base.go
@@ -18,35 +18,21 @@
 package testutils
 
 import (
-	"net/http"
-
 	"github.com/cockroachdb/cockroach/base"
 	"github.com/cockroachdb/cockroach/security"
 )
-
-// NewRootTestBaseContext creates a base context for testing.
-// This uses embedded certs and the "root" user (default client user).
-// The "root" user has client certificates only.
-func NewRootTestBaseContext() *base.Context {
-	return newTestBaseContext(security.RootUser)
-}
 
 // NewNodeTestBaseContext creates a base context for testing.
 // This uses embedded certs and the "node" user (default node user).
 // The "node" user has both server and client certificates.
 func NewNodeTestBaseContext() *base.Context {
-	return newTestBaseContext(security.NodeUser)
+	return NewTestBaseContext(security.NodeUser)
 }
 
-func newTestBaseContext(user string) *base.Context {
+// NewTestBaseContext creates a secure base context for 'user'.
+func NewTestBaseContext(user string) *base.Context {
 	return &base.Context{
 		Certs: security.EmbeddedCertsDir,
 		User:  user,
 	}
-}
-
-// NewTestHTTPClient creates a HTTP client on the fly using a test context.
-// Useful when contexts don't need to be reused.
-func NewTestHTTPClient() (*http.Client, error) {
-	return NewRootTestBaseContext().GetHTTPClient()
 }

--- a/ts/server_test.go
+++ b/ts/server_test.go
@@ -22,14 +22,13 @@ import (
 	"sort"
 	"testing"
 
+	"github.com/cockroachdb/cockroach/base"
 	"github.com/cockroachdb/cockroach/proto"
 	"github.com/cockroachdb/cockroach/server"
 	"github.com/cockroachdb/cockroach/testutils"
 	"github.com/cockroachdb/cockroach/ts"
 	"github.com/cockroachdb/cockroach/util/leaktest"
 )
-
-var rootTestBaseContext = testutils.NewRootTestBaseContext()
 
 func TestHttpQuery(t *testing.T) {
 	defer leaktest.AfterTest(t)
@@ -141,7 +140,7 @@ func TestHttpQuery(t *testing.T) {
 	}
 
 	response := &proto.TimeSeriesQueryResponse{}
-	session := testutils.NewTestHTTPSession(t, rootTestBaseContext, tsrv.ServingAddr())
+	session := testutils.NewTestHTTPSession(t, &base.Context{}, tsrv.ServingAddr())
 	session.PostProto(ts.URLQuery, &proto.TimeSeriesQueryRequest{
 		StartNanos: 500 * 1e9,
 		EndNanos:   526 * 1e9,


### PR DESCRIPTION
Fixes #2089.

This removes permissions for root on the kv endpoints by hard-coding the
requested user to security.NodeUser.
In insecure mode (as always), nothing happens.
In secure mode, you need node client certs to do anything.
