### PR TITLE
Fix cobra help template.

### DIFF
--- a/cli/cli.go
+++ b/cli/cli.go
@@ -85,7 +85,7 @@ func init() {
 	// shown unnecessarily and it doesn't place a newline before the
 	// "Flags:" section if there are no subcommands. We should really
 	// get these tweaks merged upstream.
-	cockroachCmd.SetUsageTemplate(`{{ $cmd := . }}Usage: {{if .Runnable}}
+	cockroachCmd.SetUsageTemplate(`{{ $cmd := . }}Usage:{{if .Runnable}}
   {{.UseLine}}{{if .HasFlags}} [flags]{{end}}{{end}}{{if .HasSubCommands}}
   {{ .CommandPath}} [command]{{end}}{{if gt .Aliases 0}}
 
@@ -94,9 +94,9 @@ Aliases:
 {{end}}{{if .HasExample}}
 
 Examples:
-{{ .Example }}{{end}}{{ if .HasRunnableSubCommands}}
+{{ .Example }}{{end}}{{ if .HasNonHelpSubCommands}}
 
-Available Commands: {{range .Commands}}{{if and (.Runnable) (not .Deprecated)}}
+Available Commands:{{range .Commands}}{{if and (.Runnable) (not .Deprecated)}}
   {{rpad .Name .NamePadding }} {{.Short}}{{end}}{{end}}{{end}}
 {{ if .HasLocalFlags}}
 Flags:


### PR DESCRIPTION
Some template function names changed in
https://github.com/spf13/cobra/pull/122/files which we picked up when
syncing.

The plain output was:

``` shell
$ ./cockroach
Usage:
  cockroach [command]
```

Also add a test for usage output. There are a few oddities about it,
but we want to make sure we don't lose the entire help message just
because the template changed again.

Also remove trailing whitespace characters on "Usage:" and "Available
Commands:" lines.
