### PR TITLE
Standardize use of util.Errorf in sql/: for TODOs only

### DIFF
--- a/sql/create.go
+++ b/sql/create.go
@@ -25,6 +25,7 @@ import (
 	"github.com/cockroachdb/cockroach/security"
 	"github.com/cockroachdb/cockroach/sql/parser"
 	"github.com/cockroachdb/cockroach/sql/privilege"
+	"github.com/cockroachdb/cockroach/util"
 	"github.com/cockroachdb/cockroach/util/log"
 )
 
@@ -143,7 +144,7 @@ func (p *planner) CreateIndex(n *parser.CreateIndex) (planNode, error) {
 
 	if err := p.txn.Run(&b); err != nil {
 		if tErr, ok := err.(*proto.ConditionFailedError); ok {
-			return nil, fmt.Errorf("duplicate key value %q violates unique constraint %s", tErr.ActualValue.Bytes, "TODO(tamird)")
+			return nil, util.Errorf("duplicate key value %q violates unique constraint %s", tErr.ActualValue.Bytes, "TODO(tamird)")
 		}
 		return nil, err
 	}

--- a/sql/descriptor.go
+++ b/sql/descriptor.go
@@ -142,7 +142,7 @@ func (p *planner) getDescriptorFromTargetList(targets parser.TargetList) (descri
 	}
 
 	if targets.Tables == nil {
-		return nil, util.Errorf("no targets speciied")
+		return nil, fmt.Errorf("no targets specified")
 	}
 
 	if len(targets.Tables) == 0 {

--- a/sql/explain.go
+++ b/sql/explain.go
@@ -22,6 +22,7 @@ import (
 	"strings"
 
 	"github.com/cockroachdb/cockroach/sql/parser"
+	"github.com/cockroachdb/cockroach/util"
 )
 
 type explainMode int
@@ -81,7 +82,7 @@ func markDebug(plan planNode, mode explainMode) (planNode, error) {
 		return markDebug(t.plan, mode)
 
 	default:
-		return nil, fmt.Errorf("TODO(pmattis): unimplemented %T", plan)
+		return nil, util.Errorf("TODO(pmattis): unimplemented %T", plan)
 	}
 }
 

--- a/sql/insert.go
+++ b/sql/insert.go
@@ -24,6 +24,7 @@ import (
 	"github.com/cockroachdb/cockroach/proto"
 	"github.com/cockroachdb/cockroach/sql/parser"
 	"github.com/cockroachdb/cockroach/sql/privilege"
+	"github.com/cockroachdb/cockroach/util"
 	"github.com/cockroachdb/cockroach/util/log"
 )
 
@@ -151,7 +152,7 @@ func (p *planner) Insert(n *parser.Insert) (planNode, error) {
 	}
 	if err := p.txn.Run(&b); err != nil {
 		if tErr, ok := err.(*proto.ConditionFailedError); ok {
-			return nil, fmt.Errorf("duplicate key value %q violates unique constraint %s", tErr.ActualValue.Bytes, "TODO(tamird)")
+			return nil, util.Errorf("duplicate key value %q violates unique constraint %s", tErr.ActualValue.Bytes, "TODO(tamird)")
 		}
 		return nil, err
 	}

--- a/sql/parser/eval.go
+++ b/sql/parser/eval.go
@@ -25,6 +25,8 @@ import (
 	"reflect"
 	"strconv"
 	"strings"
+
+	"github.com/cockroachdb/cockroach/util"
 )
 
 var errZeroModulus = errors.New("zero modulus")
@@ -745,7 +747,7 @@ func evalComparisonOp(op ComparisonOp, left, right Datum) (Datum, error) {
 
 	switch op {
 	case Like, NotLike:
-		return DNull, fmt.Errorf("TODO(pmattis): unsupported comparison operator: %s", op)
+		return DNull, util.Errorf("TODO(pmattis): unsupported comparison operator: %s", op)
 	}
 
 	return DNull, fmt.Errorf("unsupported comparison operator: <%s> %s <%s>",

--- a/sql/select.go
+++ b/sql/select.go
@@ -25,6 +25,7 @@ import (
 
 	"github.com/cockroachdb/cockroach/proto"
 	"github.com/cockroachdb/cockroach/sql/parser"
+	"github.com/cockroachdb/cockroach/util"
 	"github.com/cockroachdb/cockroach/util/log"
 )
 
@@ -56,7 +57,7 @@ func (p *planner) Select(n *parser.Select) (planNode, error) {
 		// TODO(pmattis): orderBy currently uses deep knowledge of the
 		// scanNode. Need to lift that out or make orderBy compatible with
 		// groupNode as well.
-		return nil, fmt.Errorf("TODO(pmattis): unimplemented ORDER BY with GROUP BY/aggregation")
+		return nil, util.Errorf("TODO(pmattis): unimplemented ORDER BY with GROUP BY/aggregation")
 	}
 	sort, err := p.orderBy(n, scan)
 	if err != nil {

--- a/sql/show.go
+++ b/sql/show.go
@@ -23,6 +23,7 @@ import (
 	"strings"
 
 	"github.com/cockroachdb/cockroach/sql/parser"
+	"github.com/cockroachdb/cockroach/util"
 	"github.com/cockroachdb/cockroach/util/encoding"
 )
 
@@ -93,7 +94,7 @@ func (p *planner) ShowDatabases(n *parser.ShowDatabases) (planNode, error) {
 //          mysql only returns the user's privileges.
 func (p *planner) ShowGrants(n *parser.ShowGrants) (planNode, error) {
 	if n.Targets == nil {
-		return nil, fmt.Errorf("TODO(marc): implement SHOW GRANT with no targets")
+		return nil, util.Errorf("TODO(marc): implement SHOW GRANT with no targets")
 	}
 	descriptor, err := p.getDescriptorFromTargetList(*n.Targets)
 	if err != nil {

--- a/sql/update.go
+++ b/sql/update.go
@@ -25,6 +25,7 @@ import (
 	"github.com/cockroachdb/cockroach/proto"
 	"github.com/cockroachdb/cockroach/sql/parser"
 	"github.com/cockroachdb/cockroach/sql/privilege"
+	"github.com/cockroachdb/cockroach/util"
 	"github.com/cockroachdb/cockroach/util/log"
 )
 
@@ -193,7 +194,7 @@ func (p *planner) Update(n *parser.Update) (planNode, error) {
 
 	if err := p.txn.Run(&b); err != nil {
 		if tErr, ok := err.(*proto.ConditionFailedError); ok {
-			return nil, fmt.Errorf("duplicate key value %q violates unique constraint %s", tErr.ActualValue.Bytes, "TODO(tamird)")
+			return nil, util.Errorf("duplicate key value %q violates unique constraint %s", tErr.ActualValue.Bytes, "TODO(tamird)")
 		}
 		return nil, err
 	}


### PR DESCRIPTION
I found my self encountering todos (eg: `explain (debug) delete`) and having to dig around for it. Let's use util.Errorf when returning a TODO.
