### PR TITLE
Define some common spans.

### DIFF
--- a/cli/kv.go
+++ b/cli/kv.go
@@ -348,14 +348,14 @@ func initScanArgs(args []string) (startKey, endKey proto.Key) {
 		startKey = proto.Key(unquoteArg(args[0], false))
 	} else {
 		// Start with the first key after the system key range.
-		startKey = keys.SystemMax
+		startKey = keys.UserDataSpan.Start
 	}
 	if len(args) >= 2 {
 		endKey = proto.Key(unquoteArg(args[1], false))
 	} else {
 		// Exclude table data keys by default. The user can explicitly request them
 		// by passing \xff\xff for the end key.
-		endKey = keys.TableDataPrefix
+		endKey = keys.UserDataSpan.End
 	}
 	return startKey, endKey
 }

--- a/keys/constants.go
+++ b/keys/constants.go
@@ -169,4 +169,16 @@ var (
 	// occur after the range of common user data prefixes so that tests which use
 	// those prefixes will not see table data.
 	TableDataPrefix = proto.Key("\xff")
+
+	// UserTableDataMin is the start key of user structured data.
+	UserTableDataMin = MakeTablePrefix(MaxReservedDescID + 1)
+)
+
+const (
+	// MaxReservedDescID is the maximum value of the system IDs
+	// under 'TableDataPrefix'.
+	// It is here only so that we may define keys/ranges using it.
+	// NOTE: this is not great, but the alternative is to
+	// move all the ID/keying from sql/ here, or drop ID entirely.
+	MaxReservedDescID = 999
 )

--- a/keys/keys.go
+++ b/keys/keys.go
@@ -314,3 +314,11 @@ func MetaReverseScanBounds(key proto.Key) (proto.Key, proto.Key, error) {
 	// second record (exclusive in MVCCReverseScan), hence key.Next() below.
 	return key[:len(Meta1Prefix)], key.Next(), nil
 }
+
+// MakeTablePrefix returns the key prefix used for the table's data.
+func MakeTablePrefix(tableID uint32) []byte {
+	var key []byte
+	key = append(key, TableDataPrefix...)
+	key = encoding.EncodeUvarint(key, uint64(tableID))
+	return key
+}

--- a/keys/spans.go
+++ b/keys/spans.go
@@ -1,0 +1,46 @@
+// Copyright 2015 The Cockroach Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+// implied. See the License for the specific language governing
+// permissions and limitations under the License. See the AUTHORS file
+// for names of contributors.
+//
+// Author: Marc Berhault (marc@cockroachlabs.com)
+
+package keys
+
+import "github.com/cockroachdb/cockroach/proto"
+
+// Span describes a span of keys: [start,end).
+// This will correspond to one or more range.
+type Span struct {
+	Start, End proto.Key
+}
+
+var (
+	// Meta1Span holds all first level addressing.
+	Meta1Span = Span{proto.KeyMin, Meta2Prefix}
+
+	// ZoneConfigSpan is the range for all zone configs.
+	ZoneConfigSpan = Span{ConfigZonePrefix, ConfigZonePrefix.PrefixEnd()}
+
+	// UserDataSpan is the non-meta and non-structured portion of the key space.
+	UserDataSpan = Span{SystemMax, TableDataPrefix}
+
+	// SystemDBSpan is the range of system objects for structured data.
+	SystemDBSpan = Span{TableDataPrefix, UserTableDataMin}
+
+	// NoSplitSpans describes the ranges that should never be split.
+	// Meta1Span: needed to find other ranges.
+	// ZoneConfigSpan: configs are hierarchical by prefix.
+	// SystemDBSpan: system objects have interdepencies.
+	NoSplitSpans = []Span{Meta1Span, ZoneConfigSpan, SystemDBSpan}
+)

--- a/kv/dist_sender_server_test.go
+++ b/kv/dist_sender_server_test.go
@@ -342,26 +342,3 @@ func TestStartEqualsEndKeyScan(t *testing.T) {
 		t.Fatalf("unexpected error on reverse scan with startkey == endkey: %v", err)
 	}
 }
-
-// TestSplitByMeta2KeyMax check range splitting at key Meta2KeyMax should
-// fail as Meta2KeyMax is not a valid split key.
-func TestSplitByMeta2KeyMax(t *testing.T) {
-	defer leaktest.AfterTest(t)
-	s := server.StartTestServer(t)
-	db := createTestClient(t, s.ServingAddr())
-	defer s.Stop()
-
-	ch := make(chan struct{})
-	go func() {
-		if err := db.AdminSplit(keys.Meta2KeyMax); err == nil {
-			t.Fatalf("range split on Meta2KeyMax should fail")
-		}
-		close(ch)
-	}()
-
-	select {
-	case <-ch:
-	case <-time.After(5 * time.Second):
-		t.Error("range split on Meta2KeyMax timed out")
-	}
-}

--- a/sql/create_test.go
+++ b/sql/create_test.go
@@ -68,7 +68,7 @@ func TestDatabaseDescriptor(t *testing.T) {
 		t.Fatalf("expected descriptor ID == %d, got %d", expectedCounter, actual)
 	}
 
-	start := proto.Key(sql.MakeTablePrefix(sql.NamespaceTable.ID))
+	start := proto.Key(keys.MakeTablePrefix(uint32(sql.NamespaceTable.ID)))
 	if kvs, err := kvDB.Scan(start, start.PrefixEnd(), 0); err != nil {
 		t.Fatal(err)
 	} else {

--- a/sql/keys.go
+++ b/sql/keys.go
@@ -71,7 +71,7 @@ func equalName(a, b string) bool {
 // specified parentID.
 func MakeNameMetadataKey(parentID ID, name string) proto.Key {
 	name = normalizeName(name)
-	k := MakeTablePrefix(NamespaceTable.ID)
+	k := keys.MakeTablePrefix(uint32(NamespaceTable.ID))
 	k = encoding.EncodeUvarint(k, uint64(NamespaceTable.PrimaryIndex.ID))
 	k = encoding.EncodeUvarint(k, uint64(parentID))
 	if name != "" {
@@ -83,7 +83,7 @@ func MakeNameMetadataKey(parentID ID, name string) proto.Key {
 
 // MakeDescMetadataKey returns the key for the descriptor.
 func MakeDescMetadataKey(descID ID) proto.Key {
-	k := MakeTablePrefix(DescriptorTable.ID)
+	k := keys.MakeTablePrefix(uint32(DescriptorTable.ID))
 	k = encoding.EncodeUvarint(k, uint64(DescriptorTable.PrimaryIndex.ID))
 	k = encoding.EncodeUvarint(k, uint64(descID))
 	k = encoding.EncodeUvarint(k, uint64(DescriptorTable.Columns[1].ID))
@@ -95,14 +95,6 @@ func MakeColumnKey(colID ColumnID, primaryKey []byte) proto.Key {
 	var key []byte
 	key = append(key, primaryKey...)
 	return encoding.EncodeUvarint(key, uint64(colID))
-}
-
-// MakeTablePrefix returns the key prefix used for the table's data.
-func MakeTablePrefix(tableID ID) []byte {
-	var key []byte
-	key = append(key, keys.TableDataPrefix...)
-	key = encoding.EncodeUvarint(key, uint64(tableID))
-	return key
 }
 
 // MakeIndexKeyPrefix returns the key prefix used for the index's data.

--- a/sql/system.go
+++ b/sql/system.go
@@ -31,7 +31,7 @@ const (
 	// MaxReservedDescID is the maximum reserved descriptor ID.
 	// All objects with ID <= MaxReservedDescID are system object
 	// with special rules.
-	MaxReservedDescID ID = 999
+	MaxReservedDescID ID = keys.MaxReservedDescID
 	// RootNamespaceID is the ID of the root namespace.
 	RootNamespaceID ID = 0
 

--- a/sql/truncate.go
+++ b/sql/truncate.go
@@ -19,6 +19,7 @@ package sql
 
 import (
 	"github.com/cockroachdb/cockroach/client"
+	"github.com/cockroachdb/cockroach/keys"
 	"github.com/cockroachdb/cockroach/proto"
 	"github.com/cockroachdb/cockroach/sql/parser"
 	"github.com/cockroachdb/cockroach/sql/privilege"
@@ -42,7 +43,7 @@ func (p *planner) Truncate(n *parser.Truncate) (planNode, error) {
 			return nil, err
 		}
 
-		tablePrefix := MakeTablePrefix(tableDesc.ID)
+		tablePrefix := keys.MakeTablePrefix(uint32(tableDesc.ID))
 
 		// Delete rows and indexes starting with the table's prefix.
 		tableStartKey := proto.Key(tablePrefix)

--- a/storage/client_split_test.go
+++ b/storage/client_split_test.go
@@ -76,7 +76,9 @@ func TestStoreRangeSplitAtIllegalKeys(t *testing.T) {
 		keys.Meta1Prefix,
 		keys.MakeKey(keys.Meta1Prefix, []byte("a")),
 		keys.MakeKey(keys.Meta1Prefix, proto.KeyMax),
+		keys.Meta2KeyMax,
 		keys.MakeKey(keys.ConfigZonePrefix, []byte("a")),
+		keys.MakeTablePrefix(10 /* system descriptor ID */),
 	} {
 		args := adminSplitArgs(proto.KeyMin, key, 1, store.StoreID())
 		_, err := store.ExecuteCmd(context.Background(), &args)


### PR DESCRIPTION
Work towards #2179.

Define a handful of basic spans and use them.
The annoying part of this change is moving some structured logic
into keys/, without having to move all of it.
