### PR TITLE
Adds StorePool

### DIFF
--- a/cli/flags.go
+++ b/cli/flags.go
@@ -122,6 +122,11 @@ var flagUsage = map[string]string{
         Adjusts the max idle time of the scanner. This speeds up the scanner on small
         clusters to be more responsive.
 `,
+	"time-until-store-dead": `
+		Adjusts the timeout for stores.  If there's been no gossiped updated
+		from a store after this time, the store is considered unavailable.
+        Replicas on an unavailable store will be moved to available ones.
+`,
 	"stores": `
         A comma-separated list of stores, specified by a colon-separated list
         of device attributes followed by '=' and either a filepath for a
@@ -172,8 +177,7 @@ func initFlags(ctx *server.Context) {
 		f.StringVar(&ctx.Attrs, "attrs", ctx.Attrs, flagUsage["attrs"])
 		f.StringVar(&ctx.Stores, "stores", ctx.Stores, flagUsage["stores"])
 		f.DurationVar(&ctx.MaxOffset, "max-offset", ctx.MaxOffset, flagUsage["max-offset"])
-		f.DurationVar(&ctx.MetricsFrequency, "metrics-frequency", ctx.MetricsFrequency,
-			flagUsage["metrics-frequency"])
+		f.DurationVar(&ctx.MetricsFrequency, "metrics-frequency", ctx.MetricsFrequency, flagUsage["metrics-frequency"])
 
 		// Security flags.
 		f.StringVar(&ctx.Certs, "certs", ctx.Certs, flagUsage["certs"])
@@ -181,8 +185,7 @@ func initFlags(ctx *server.Context) {
 
 		// Gossip flags.
 		f.StringVar(&ctx.GossipBootstrap, "gossip", ctx.GossipBootstrap, flagUsage["gossip"])
-		f.DurationVar(&ctx.GossipInterval, "gossip-interval", ctx.GossipInterval,
-			flagUsage["gossip-interval"])
+		f.DurationVar(&ctx.GossipInterval, "gossip-interval", ctx.GossipInterval, flagUsage["gossip-interval"])
 
 		// KV flags.
 		f.BoolVar(&ctx.Linearizable, "linearizable", ctx.Linearizable, flagUsage["linearizable"])
@@ -190,8 +193,8 @@ func initFlags(ctx *server.Context) {
 		// Engine flags.
 		f.Int64Var(&ctx.CacheSize, "cache-size", ctx.CacheSize, flagUsage["cache-size"])
 		f.DurationVar(&ctx.ScanInterval, "scan-interval", ctx.ScanInterval, flagUsage["scan-interval"])
-		f.DurationVar(&ctx.ScanMaxIdleTime, "scan-max-idle-time", ctx.ScanMaxIdleTime,
-			flagUsage["scan-max-idle-time"])
+		f.DurationVar(&ctx.ScanMaxIdleTime, "scan-max-idle-time", ctx.ScanMaxIdleTime, flagUsage["scan-max-idle-time"])
+		f.DurationVar(&ctx.TimeUntilStoreDead, "time-until-store-dead", ctx.TimeUntilStoreDead, flagUsage["time-until-store-dead"])
 
 		if err := startCmd.MarkFlagRequired("gossip"); err != nil {
 			panic(err)

--- a/docs/RFCS/store_pool.md
+++ b/docs/RFCS/store_pool.md
@@ -25,7 +25,7 @@ local source of truth for those decisions.
 # Detailed design
 
 ## Configuration
-Add a new configuration setting called `timeoutUntilStoreDead` which contains
+Add a new configuration setting called `TimeUntilStoreDead` which contains
 the number of seconds after which if a store was not heard from, it is
 considered dead. The default value for this will be 5 minutes.
 
@@ -39,13 +39,13 @@ of heath statistic about the store. It will also maintain a `lastUpdatedTime`
 which will be set whenever a store descriptor is updated. When this happens,
 if the store was previously marked as dead, it will restored. To maintain this
 map, a callback from gossip for store descriptors will be added. When this
-`lastUpdatedTime` is longer than the `timeoutUntilStoreDead`, the store is
+`lastUpdatedTime` is longer than the `TimeUntilStoreDead`, the store is
 considered dead and any replicas on this store may be removed. Note that that
 the work to remove replicas is performed elsewhere.
 
 Monitor will maintain a timespan `timeUntilNextDead` which is calculated by
 taking the nearest `lastUpdatedTime` for all the stores and adding
-`timeoutUntilStoreDead` and the store ID associated with the timeout.
+`TimeUntilStoreDead` and the store ID associated with the timeout.
 
 Monitor will trigger on `timeUntilNextDead` which when triggered checks to see
 if that store has not been updated.

--- a/server/context.go
+++ b/server/context.go
@@ -35,13 +35,14 @@ import (
 
 // Context defaults.
 const (
-	defaultAddr             = ":8080"
-	defaultMaxOffset        = 250 * time.Millisecond
-	defaultGossipInterval   = 2 * time.Second
-	defaultCacheSize        = 1 << 30 // GB
-	defaultScanInterval     = 10 * time.Minute
-	defaultScanMaxIdleTime  = 5 * time.Second
-	defaultMetricsFrequency = 10 * time.Second
+	defaultAddr               = ":8080"
+	defaultMaxOffset          = 250 * time.Millisecond
+	defaultGossipInterval     = 2 * time.Second
+	defaultCacheSize          = 1 << 30 // GB
+	defaultScanInterval       = 10 * time.Minute
+	defaultScanMaxIdleTime    = 5 * time.Second
+	defaultMetricsFrequency   = 10 * time.Second
+	defaultTimeUntilStoreDead = 5 * time.Minute
 )
 
 // Context holds parameters needed to setup a server.
@@ -123,18 +124,23 @@ type Context struct {
 	// MetricsFrequency determines the frequency at which the server should
 	// record internal metrics.
 	MetricsFrequency time.Duration
+
+	// TimeUntilStoreDead is the time after which if there is no new gossiped
+	// information about a store, it is considered dead.
+	TimeUntilStoreDead time.Duration
 }
 
 // NewContext returns a Context with default values.
 func NewContext() *Context {
 	ctx := &Context{
-		Addr:             defaultAddr,
-		MaxOffset:        defaultMaxOffset,
-		GossipInterval:   defaultGossipInterval,
-		CacheSize:        defaultCacheSize,
-		ScanInterval:     defaultScanInterval,
-		ScanMaxIdleTime:  defaultScanMaxIdleTime,
-		MetricsFrequency: defaultMetricsFrequency,
+		Addr:               defaultAddr,
+		MaxOffset:          defaultMaxOffset,
+		GossipInterval:     defaultGossipInterval,
+		CacheSize:          defaultCacheSize,
+		ScanInterval:       defaultScanInterval,
+		ScanMaxIdleTime:    defaultScanMaxIdleTime,
+		MetricsFrequency:   defaultMetricsFrequency,
+		TimeUntilStoreDead: defaultTimeUntilStoreDead,
 	}
 	// Initializes base context defaults.
 	ctx.InitDefaults()

--- a/server/testserver.go
+++ b/server/testserver.go
@@ -76,6 +76,7 @@ func NewTestContext() *Context {
 	ctx.Addr = "127.0.0.1:0"
 	// Set standard "node" user for intra-cluster traffic.
 	ctx.User = security.NodeUser
+
 	return ctx
 }
 

--- a/storage/allocator_test.go
+++ b/storage/allocator_test.go
@@ -22,15 +22,17 @@ package storage
 import (
 	"fmt"
 	"math/rand"
-	"reflect"
-	"sort"
 	"sync"
 	"testing"
 
+	"github.com/cockroachdb/cockroach/base"
 	"github.com/cockroachdb/cockroach/config"
 	"github.com/cockroachdb/cockroach/gossip"
 	"github.com/cockroachdb/cockroach/proto"
+	"github.com/cockroachdb/cockroach/rpc"
+	"github.com/cockroachdb/cockroach/util/hlc"
 	"github.com/cockroachdb/cockroach/util/leaktest"
+	"github.com/cockroachdb/cockroach/util/stop"
 )
 
 var simpleZoneConfig = config.ZoneConfig{
@@ -61,7 +63,7 @@ type storeGossiper struct {
 	g           *gossip.Gossip
 	wg          sync.WaitGroup
 	mu          sync.Mutex
-	storeKeyMap map[string]bool
+	storeKeyMap map[string]struct{}
 }
 
 // newStoreGossiper creates a store gossiper for use by tests. It adds the
@@ -69,12 +71,12 @@ type storeGossiper struct {
 func newStoreGossiper(g *gossip.Gossip) *storeGossiper {
 	sg := &storeGossiper{
 		g:           g,
-		storeKeyMap: make(map[string]bool),
+		storeKeyMap: make(map[string]struct{}),
 	}
 	g.RegisterCallback(gossip.MakePrefixPattern(gossip.KeyStorePrefix), func(key string, _ []byte) {
 		sg.mu.Lock()
 		defer sg.mu.Unlock()
-		if sg.storeKeyMap[key] {
+		if _, ok := sg.storeKeyMap[key]; ok {
 			sg.wg.Done()
 		}
 	})
@@ -85,11 +87,11 @@ func newStoreGossiper(g *gossip.Gossip) *storeGossiper {
 // is gossiped before returning.
 func (sg *storeGossiper) gossipStores(stores []*proto.StoreDescriptor, t *testing.T) {
 	sg.mu.Lock()
-	sg.storeKeyMap = make(map[string]bool)
+	sg.storeKeyMap = make(map[string]struct{})
 	sg.wg.Add(len(stores))
 	for _, s := range stores {
 		storeKey := gossip.MakeStoreKey(s.StoreID)
-		sg.storeKeyMap[storeKey] = true
+		sg.storeKeyMap[storeKey] = struct{}{}
 		// Gossip store descriptor.
 		err := sg.g.AddInfoProto(storeKey, s, 0)
 		if err != nil {
@@ -207,12 +209,23 @@ var multiDCStores = []*proto.StoreDescriptor{
 	},
 }
 
+// createTestAllocator creates a stopper, gossip, store pool and allocator for
+// use in tests. Stopper must be stopped by the caller.
+func createTestAllocator() (*stop.Stopper, *gossip.Gossip, *StorePool, *allocator) {
+	stopper := stop.NewStopper()
+	rpcContext := rpc.NewContext(&base.Context{}, hlc.NewClock(hlc.UnixNano), stopper)
+	g := gossip.New(rpcContext, gossip.TestInterval, gossip.TestBootstrap)
+	storePool := NewStorePool(g, TestTimeUntilStoreDeadOff, stopper)
+	a := newAllocator(storePool)
+	return stopper, g, storePool, a
+}
+
 func TestAllocatorSimpleRetrieval(t *testing.T) {
 	defer leaktest.AfterTest(t)
-	s, _, stopper := createTestStore(t)
+	stopper, g, _, a := createTestAllocator()
 	defer stopper.Stop()
-	newStoreGossiper(s.Gossip()).gossipStores(singleStore, t)
-	result, err := s.allocator().AllocateTarget(simpleZoneConfig.ReplicaAttrs[0], []proto.Replica{}, false)
+	newStoreGossiper(g).gossipStores(singleStore, t)
+	result, err := a.AllocateTarget(simpleZoneConfig.ReplicaAttrs[0], []proto.Replica{}, false)
 	if err != nil {
 		t.Errorf("Unable to perform allocation: %v", err)
 	}
@@ -223,9 +236,9 @@ func TestAllocatorSimpleRetrieval(t *testing.T) {
 
 func TestAllocatorNoAvailableDisks(t *testing.T) {
 	defer leaktest.AfterTest(t)
-	s, _, stopper := createTestStore(t)
+	stopper, _, _, a := createTestAllocator()
 	defer stopper.Stop()
-	result, err := s.allocator().AllocateTarget(simpleZoneConfig.ReplicaAttrs[0], []proto.Replica{}, false)
+	result, err := a.AllocateTarget(simpleZoneConfig.ReplicaAttrs[0], []proto.Replica{}, false)
 	if result != nil {
 		t.Errorf("expected nil result: %+v", result)
 	}
@@ -236,10 +249,10 @@ func TestAllocatorNoAvailableDisks(t *testing.T) {
 
 func TestAllocatorThreeDisksSameDC(t *testing.T) {
 	defer leaktest.AfterTest(t)
-	s, _, stopper := createTestStore(t)
+	stopper, g, _, a := createTestAllocator()
 	defer stopper.Stop()
-	newStoreGossiper(s.Gossip()).gossipStores(sameDCStores, t)
-	result1, err := s.allocator().AllocateTarget(multiDisksConfig.ReplicaAttrs[0], []proto.Replica{}, false)
+	newStoreGossiper(g).gossipStores(sameDCStores, t)
+	result1, err := a.AllocateTarget(multiDisksConfig.ReplicaAttrs[0], []proto.Replica{}, false)
 	if err != nil {
 		t.Fatalf("Unable to perform allocation: %v", err)
 	}
@@ -252,7 +265,7 @@ func TestAllocatorThreeDisksSameDC(t *testing.T) {
 			StoreID: result1.StoreID,
 		},
 	}
-	result2, err := s.allocator().AllocateTarget(multiDisksConfig.ReplicaAttrs[1], exReplicas, false)
+	result2, err := a.AllocateTarget(multiDisksConfig.ReplicaAttrs[1], exReplicas, false)
 	if err != nil {
 		t.Errorf("Unable to perform allocation: %v", err)
 	}
@@ -262,7 +275,7 @@ func TestAllocatorThreeDisksSameDC(t *testing.T) {
 	if result1.Node.NodeID == result2.Node.NodeID {
 		t.Errorf("Expected node ids to be different %+v vs %+v", result1, result2)
 	}
-	result3, err := s.allocator().AllocateTarget(multiDisksConfig.ReplicaAttrs[2], []proto.Replica{}, false)
+	result3, err := a.AllocateTarget(multiDisksConfig.ReplicaAttrs[2], []proto.Replica{}, false)
 	if err != nil {
 		t.Errorf("Unable to perform allocation: %v", err)
 	}
@@ -273,14 +286,14 @@ func TestAllocatorThreeDisksSameDC(t *testing.T) {
 
 func TestAllocatorTwoDatacenters(t *testing.T) {
 	defer leaktest.AfterTest(t)
-	s, _, stopper := createTestStore(t)
+	stopper, g, _, a := createTestAllocator()
 	defer stopper.Stop()
-	newStoreGossiper(s.Gossip()).gossipStores(multiDCStores, t)
-	result1, err := s.allocator().AllocateTarget(multiDCConfig.ReplicaAttrs[0], []proto.Replica{}, false)
+	newStoreGossiper(g).gossipStores(multiDCStores, t)
+	result1, err := a.AllocateTarget(multiDCConfig.ReplicaAttrs[0], []proto.Replica{}, false)
 	if err != nil {
 		t.Fatalf("Unable to perform allocation: %v", err)
 	}
-	result2, err := s.allocator().AllocateTarget(multiDCConfig.ReplicaAttrs[1], []proto.Replica{}, false)
+	result2, err := a.AllocateTarget(multiDCConfig.ReplicaAttrs[1], []proto.Replica{}, false)
 	if err != nil {
 		t.Fatalf("Unable to perform allocation: %v", err)
 	}
@@ -288,7 +301,7 @@ func TestAllocatorTwoDatacenters(t *testing.T) {
 		t.Errorf("Expected nodes 1 & 2: %+v vs %+v", result1.Node, result2.Node)
 	}
 	// Verify that no result is forthcoming if we already have a replica.
-	_, err = s.allocator().AllocateTarget(multiDCConfig.ReplicaAttrs[1], []proto.Replica{
+	_, err = a.AllocateTarget(multiDCConfig.ReplicaAttrs[1], []proto.Replica{
 		{
 			NodeID:  result2.Node.NodeID,
 			StoreID: result2.StoreID,
@@ -301,10 +314,10 @@ func TestAllocatorTwoDatacenters(t *testing.T) {
 
 func TestAllocatorExistingReplica(t *testing.T) {
 	defer leaktest.AfterTest(t)
-	s, _, stopper := createTestStore(t)
+	stopper, g, _, a := createTestAllocator()
 	defer stopper.Stop()
-	newStoreGossiper(s.Gossip()).gossipStores(sameDCStores, t)
-	result, err := s.allocator().AllocateTarget(multiDisksConfig.ReplicaAttrs[1], []proto.Replica{
+	newStoreGossiper(g).gossipStores(sameDCStores, t)
+	result, err := a.AllocateTarget(multiDisksConfig.ReplicaAttrs[1], []proto.Replica{
 		{
 			NodeID:  2,
 			StoreID: 2,
@@ -323,9 +336,9 @@ func TestAllocatorExistingReplica(t *testing.T) {
 // if necessary to find an allocation target.
 func TestAllocatorRelaxConstraints(t *testing.T) {
 	defer leaktest.AfterTest(t)
-	s, _, stopper := createTestStore(t)
+	stopper, g, _, a := createTestAllocator()
 	defer stopper.Stop()
-	newStoreGossiper(s.Gossip()).gossipStores(multiDCStores, t)
+	newStoreGossiper(g).gossipStores(multiDCStores, t)
 
 	testCases := []struct {
 		required         []string // attribute strings
@@ -358,7 +371,7 @@ func TestAllocatorRelaxConstraints(t *testing.T) {
 		for _, id := range test.existing {
 			existing = append(existing, proto.Replica{NodeID: proto.NodeID(id), StoreID: proto.StoreID(id)})
 		}
-		result, err := s.allocator().AllocateTarget(proto.Attributes{Attrs: test.required}, existing, test.relaxConstraints)
+		result, err := a.AllocateTarget(proto.Attributes{Attrs: test.required}, existing, test.relaxConstraints)
 		if haveErr := (err != nil); haveErr != test.expErr {
 			t.Errorf("%d: expected error %t; got %t: %s", i, test.expErr, haveErr, err)
 		} else if err == nil && proto.StoreID(test.expID) != result.StoreID {
@@ -371,7 +384,7 @@ func TestAllocatorRelaxConstraints(t *testing.T) {
 // towards least loaded stores.
 func TestAllocatorRandomAllocation(t *testing.T) {
 	defer leaktest.AfterTest(t)
-	s, _, stopper := createTestStore(t)
+	stopper, g, _, a := createTestAllocator()
 	defer stopper.Stop()
 
 	stores := []*proto.StoreDescriptor{
@@ -396,13 +409,13 @@ func TestAllocatorRandomAllocation(t *testing.T) {
 			Capacity: proto.StoreCapacity{Capacity: 200, Available: 0},
 		},
 	}
-	newStoreGossiper(s.Gossip()).gossipStores(stores, t)
+	newStoreGossiper(g).gossipStores(stores, t)
 
 	// Every allocation will randomly choose 3 of the 4, meaning either
 	// store 1 or store 2 will be chosen, as the least loaded of the
 	// three random choices is returned.
 	for i := 0; i < 10; i++ {
-		result, err := s.allocator().AllocateTarget(proto.Attributes{}, []proto.Replica{}, false)
+		result, err := a.AllocateTarget(proto.Attributes{}, []proto.Replica{}, false)
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -416,7 +429,7 @@ func TestAllocatorRandomAllocation(t *testing.T) {
 // randomly from amongst stores over the minAvailCapacityThreshold.
 func TestAllocatorRebalance(t *testing.T) {
 	defer leaktest.AfterTest(t)
-	s, _, stopper := createTestStore(t)
+	stopper, g, _, a := createTestAllocator()
 	defer stopper.Stop()
 
 	stores := []*proto.StoreDescriptor{
@@ -441,11 +454,11 @@ func TestAllocatorRebalance(t *testing.T) {
 			Capacity: proto.StoreCapacity{Capacity: 100, Available: (100 - int64(100*maxFractionUsedThreshold)) / 2},
 		},
 	}
-	newStoreGossiper(s.Gossip()).gossipStores(stores, t)
+	newStoreGossiper(g).gossipStores(stores, t)
 
 	// Every rebalance target must be either stores 1 or 2.
 	for i := 0; i < 10; i++ {
-		result := s.allocator().RebalanceTarget(proto.Attributes{}, []proto.Replica{})
+		result := a.RebalanceTarget(proto.Attributes{}, []proto.Replica{})
 		if result == nil {
 			t.Fatal("nil result")
 		}
@@ -456,7 +469,7 @@ func TestAllocatorRebalance(t *testing.T) {
 
 	// Verify shouldRebalance results.
 	for i, store := range stores {
-		result := s.allocator().ShouldRebalance(store)
+		result := a.ShouldRebalance(store)
 		if expResult := (i >= 2); expResult != result {
 			t.Errorf("%d: expected rebalance %t; got %t", i, expResult, result)
 		}
@@ -467,7 +480,7 @@ func TestAllocatorRebalance(t *testing.T) {
 // a standard deviation of the mean are chosen.
 func TestAllocatorRebalanceByCapacity(t *testing.T) {
 	defer leaktest.AfterTest(t)
-	s, _, stopper := createTestStore(t)
+	stopper, g, _, a := createTestAllocator()
 	defer stopper.Stop()
 
 	stores := []*proto.StoreDescriptor{
@@ -492,11 +505,11 @@ func TestAllocatorRebalanceByCapacity(t *testing.T) {
 			Capacity: proto.StoreCapacity{Capacity: 100, Available: 80},
 		},
 	}
-	newStoreGossiper(s.Gossip()).gossipStores(stores, t)
+	newStoreGossiper(g).gossipStores(stores, t)
 
 	// Every rebalance target must be store 4 (if not nil).
 	for i := 0; i < 10; i++ {
-		result := s.allocator().RebalanceTarget(proto.Attributes{}, []proto.Replica{})
+		result := a.RebalanceTarget(proto.Attributes{}, []proto.Replica{})
 		if result != nil && result.StoreID != 4 {
 			t.Errorf("expected store 4; got %d", result.StoreID)
 		}
@@ -504,7 +517,7 @@ func TestAllocatorRebalanceByCapacity(t *testing.T) {
 
 	// Verify shouldRebalance results.
 	for i, store := range stores {
-		result := s.allocator().ShouldRebalance(store)
+		result := a.ShouldRebalance(store)
 		if expResult := (i < 3); expResult != result {
 			t.Errorf("%d: expected rebalance %t; got %t", i, expResult, result)
 		}
@@ -516,7 +529,7 @@ func TestAllocatorRebalanceByCapacity(t *testing.T) {
 // exceed the maxAvailCapacityThreshold.
 func TestAllocatorRebalanceByCount(t *testing.T) {
 	defer leaktest.AfterTest(t)
-	s, _, stopper := createTestStore(t)
+	stopper, g, _, a := createTestAllocator()
 	defer stopper.Stop()
 
 	// Setup the stores so that only one is below the standard deviation threshold.
@@ -542,11 +555,11 @@ func TestAllocatorRebalanceByCount(t *testing.T) {
 			Capacity: proto.StoreCapacity{Capacity: 100, Available: 97, RangeCount: 5},
 		},
 	}
-	newStoreGossiper(s.Gossip()).gossipStores(stores, t)
+	newStoreGossiper(g).gossipStores(stores, t)
 
 	// Every rebalance target must be store 4 (or nil for case of missing the only option).
 	for i := 0; i < 10; i++ {
-		result := s.allocator().RebalanceTarget(proto.Attributes{}, []proto.Replica{})
+		result := a.RebalanceTarget(proto.Attributes{}, []proto.Replica{})
 		if result != nil && result.StoreID != 4 {
 			t.Errorf("expected store 4; got %d", result.StoreID)
 		}
@@ -554,7 +567,7 @@ func TestAllocatorRebalanceByCount(t *testing.T) {
 
 	// Verify shouldRebalance results.
 	for i, store := range stores {
-		result := s.allocator().ShouldRebalance(store)
+		result := a.ShouldRebalance(store)
 		if expResult := (i < 3); expResult != result {
 			t.Errorf("%d: expected rebalance %t; got %t", i, expResult, result)
 		}
@@ -565,7 +578,7 @@ func TestAllocatorRebalanceByCount(t *testing.T) {
 // the one with the lowest capacity.
 func TestAllocatorRemoveTarget(t *testing.T) {
 	defer leaktest.AfterTest(t)
-	s, _, stopper := createTestStore(t)
+	stopper, g, _, a := createTestAllocator()
 	defer stopper.Stop()
 
 	// List of replicas that will be passed to RemoveTarget
@@ -615,10 +628,10 @@ func TestAllocatorRemoveTarget(t *testing.T) {
 			Capacity: proto.StoreCapacity{Capacity: 100, Available: 65, RangeCount: 5},
 		},
 	}
-	sg := newStoreGossiper(s.Gossip())
+	sg := newStoreGossiper(g)
 	sg.gossipStores(stores, t)
 
-	targetRepl, err := s.allocator().RemoveTarget(replicas)
+	targetRepl, err := a.RemoveTarget(replicas)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -652,118 +665,12 @@ func TestAllocatorRemoveTarget(t *testing.T) {
 	}
 	sg.gossipStores(stores, t)
 
-	targetRepl, err = s.allocator().RemoveTarget(replicas)
+	targetRepl, err = a.RemoveTarget(replicas)
 	if err != nil {
 		t.Fatal(err)
 	}
 	if a, e := targetRepl, replicas[1]; a != e {
 		t.Fatalf("RemoveTarget did not select expected replica; expected %v, got %v", e, a)
-	}
-}
-
-func TestAllocatorCapacityGossipUpdate(t *testing.T) {
-	defer leaktest.AfterTest(t)
-	s, _, stopper := createTestStore(t)
-	defer stopper.Stop()
-
-	// Order and value of contentsChanged shouldn't matter.
-	key := "testkey"
-	s.allocator().storeGossipUpdate(key, nil)
-	s.allocator().storeGossipUpdate(key, nil)
-
-	expectedKeys := map[string]struct{}{key: {}}
-	s.allocator().Lock()
-	actualKeys := s.allocator().storeKeys
-	s.allocator().Unlock()
-
-	if !reflect.DeepEqual(expectedKeys, actualKeys) {
-		t.Errorf("expected to fetch %+v, instead %+v", expectedKeys, actualKeys)
-	}
-}
-
-func TestAllocatorGetStoreList(t *testing.T) {
-	defer leaktest.AfterTest(t)
-	s, _, stopper := createTestStore(t)
-	defer stopper.Stop()
-	required := []string{"ssd", "dc"}
-	// Nothing yet.
-	if sl := s.allocator().getStoreList(proto.Attributes{Attrs: required}); len(sl.stores) != 0 {
-		t.Errorf("expected no stores, instead %+v", sl.stores)
-	}
-
-	matchingStore := proto.StoreDescriptor{
-		StoreID: 1,
-		Node:    proto.NodeDescriptor{NodeID: 1},
-		Attrs:   proto.Attributes{Attrs: required},
-	}
-	supersetStore := proto.StoreDescriptor{
-		StoreID: 2,
-		Node:    proto.NodeDescriptor{NodeID: 1},
-		Attrs:   proto.Attributes{Attrs: append(required, "db")},
-	}
-	unmatchingStore := proto.StoreDescriptor{
-		StoreID: 3,
-		Node:    proto.NodeDescriptor{NodeID: 1},
-		Attrs:   proto.Attributes{Attrs: []string{"ssd", "otherdc"}},
-	}
-	emptyStore := proto.StoreDescriptor{
-		StoreID: 4,
-		Node:    proto.NodeDescriptor{NodeID: 1},
-		Attrs:   proto.Attributes{},
-	}
-
-	newStoreGossiper(s.Gossip()).gossipStores([]*proto.StoreDescriptor{
-		&matchingStore,
-		&supersetStore,
-		&unmatchingStore,
-		&emptyStore,
-	}, t)
-	expected := []string{matchingStore.Attrs.SortedString(), supersetStore.Attrs.SortedString()}
-	sort.Strings(expected)
-
-	verifyFunc := func() {
-		var actual []string
-		sl := s.allocator().getStoreList(proto.Attributes{Attrs: required})
-		for _, store := range sl.stores {
-			actual = append(actual, store.Attrs.SortedString())
-		}
-		sort.Strings(actual)
-		if !reflect.DeepEqual(expected, actual) {
-			t.Errorf("expected %+v Attrs, instead %+v", expected, actual)
-		}
-	}
-
-	// Check expected matches actual result.
-	verifyFunc()
-
-	// NOTE: this is cheating, but we're going to directly modify the
-	// attributes of unmatchingStore to make it match and verify that
-	// we still don't get the unmatching store because the storeList
-	// result is cached by the allocator.
-	unmatchingStore.Attrs.Attrs = append([]string(nil), required...)
-	verifyFunc()
-}
-
-// TestAllocatorGarbageCollection ensures removal of capacity gossip keys in
-// the map, if their gossip does not exist when we try to retrieve them.
-func TestAllocatorGarbageCollection(t *testing.T) {
-	defer leaktest.AfterTest(t)
-	s, _, stopper := createTestStore(t)
-	defer stopper.Stop()
-
-	s.allocator().storeKeys = map[string]struct{}{
-		"key0": {},
-		"key1": {},
-	}
-	required := []string{}
-
-	// No gossip added for either key, so they should be removed.
-	sl := s.allocator().getStoreList(proto.Attributes{Attrs: required})
-	if len(sl.stores) != 0 {
-		t.Errorf("expected no stores found, instead %+v", sl.stores)
-	}
-	if len(s.allocator().storeKeys) != 0 {
-		t.Errorf("expected keys to be cleared, instead are %+v", s.allocator().storeKeys)
 	}
 }
 
@@ -790,7 +697,10 @@ func Example_rebalancing() {
 	// Model a set of stores in a cluster,
 	// randomly adding / removing stores and adding bytes.
 	g := gossip.New(nil, 0, nil)
-	alloc := newAllocator(g)
+	stopper := stop.NewStopper()
+	defer stopper.Stop()
+	sp := NewStorePool(g, TestTimeUntilStoreDeadOff, stopper)
+	alloc := newAllocator(sp)
 	alloc.randGen = rand.New(rand.NewSource(0))
 	alloc.deterministic = true
 
@@ -868,55 +778,55 @@ func Example_rebalancing() {
 	fmt.Printf("Total bytes=%d, ranges=%d\n", totBytes, totRanges)
 
 	// Output:
-	// 999 000 000 000 000 000 000 739 000 000 000 000 000 000 000 000 000 000 000 000
-	// 999 107 000 000 204 000 000 375 000 000 000 000 000 000 000 000 000 000 536 000
-	// 999 310 000 262 872 000 000 208 000 705 000 526 000 000 439 000 000 607 933 000
-	// 812 258 000 220 999 673 402 480 000 430 516 374 000 431 318 000 551 714 917 000
-	// 582 625 185 334 720 589 647 619 000 300 483 352 279 502 208 665 816 684 999 374
-	// 751 617 771 542 738 676 665 525 309 435 612 449 457 616 306 837 993 754 999 445
-	// 759 659 828 478 693 622 594 591 349 458 630 538 526 613 462 827 879 787 999 550
-	// 861 658 828 559 801 660 681 560 487 529 652 686 642 716 575 999 989 875 989 581
-	// 775 647 724 557 779 662 670 494 535 502 681 676 624 695 561 961 999 772 888 592
-	// 856 712 753 661 767 658 717 606 529 615 755 699 672 700 576 955 999 755 861 671
-	// 882 735 776 685 844 643 740 578 610 688 787 741 661 767 587 999 955 809 803 731
-	// 958 716 789 719 861 689 821 608 634 724 800 782 694 799 619 994 999 851 812 818
-	// 949 726 788 664 873 633 749 599 680 714 790 728 663 842 628 999 978 816 823 791
-	// 923 698 792 712 816 605 774 651 661 728 802 718 670 819 714 999 966 801 829 791
-	// 962 779 847 737 900 675 811 691 745 778 835 812 680 894 790 999 989 872 923 799
-	// 967 812 826 772 891 685 828 683 761 808 864 820 643 873 783 969 999 873 910 781
-	// 923 813 837 739 867 672 792 664 773 772 879 803 610 845 740 957 999 867 912 732
-	// 952 803 866 759 881 655 765 668 803 772 929 762 601 844 751 973 999 892 864 731
-	// 970 777 867 800 859 639 774 662 787 760 906 751 595 854 732 989 999 853 859 762
-	// 943 776 872 787 861 686 780 663 789 793 926 784 612 832 733 999 968 868 827 767
-	// 914 801 912 802 878 704 800 685 818 808 939 759 627 844 717 999 976 872 828 757
-	// 935 806 911 797 887 710 798 711 826 824 938 775 614 870 716 999 986 886 803 767
-	// 991 851 898 856 872 795 828 782 826 852 963 797 710 868 775 994 999 923 896 794
-	// 999 924 866 877 884 883 886 836 846 869 953 851 762 887 858 985 949 900 917 836
-	// 999 910 887 878 897 890 906 868 906 903 983 947 801 895 913 976 924 890 904 898
-	// 955 884 888 916 886 879 901 872 898 883 999 874 829 888 892 937 918 889 891 862
-	// 974 952 957 990 950 976 945 946 980 961 999 975 942 926 957 994 965 946 960 960
-	// 949 929 952 999 929 961 943 946 993 918 984 961 952 919 953 950 952 941 949 934
-	// 907 999 916 935 903 903 909 907 960 939 973 912 901 885 916 910 941 911 906 913
-	// 939 999 948 948 945 962 951 954 952 964 996 942 975 962 962 956 971 969 975 969
-	// 940 974 964 947 971 975 949 954 953 970 992 971 981 973 948 962 999 969 978 975
-	// 950 971 953 938 962 967 930 964 953 978 999 945 974 972 951 950 998 951 949 962
-	// 934 946 943 936 942 949 929 956 928 970 989 944 945 923 987 927 999 942 931 944
-	// 939 957 942 958 951 970 937 946 930 950 940 959 963 937 973 943 999 931 949 940
-	// 933 935 945 929 933 960 937 935 919 918 930 931 950 924 969 935 999 943 949 926
-	// 959 941 948 952 948 957 936 937 943 930 955 962 953 949 980 948 999 934 980 942
-	// 950 973 954 962 949 964 935 949 925 936 951 962 979 962 999 942 990 948 969 959
-	// 937 993 958 949 960 960 942 954 969 950 951 952 974 970 999 927 979 964 975 944
-	// 981 986 971 968 964 984 954 959 985 979 966 963 994 963 999 970 991 971 988 965
-	// 967 997 961 957 959 985 956 940 955 955 957 955 970 952 979 964 999 951 960 968
-	// 937 969 931 950 945 954 932 925 954 946 944 926 955 938 957 949 999 934 947 938
-	// 958 967 954 955 971 973 946 934 979 947 944 958 954 954 960 948 999 936 960 951
-	// 950 948 940 958 937 955 928 927 953 923 935 939 934 921 934 934 999 922 940 938
-	// 960 960 929 962 955 955 926 935 957 928 939 941 938 926 941 924 999 923 957 942
-	// 979 958 947 987 980 972 945 943 984 939 951 943 944 946 942 942 999 928 970 943
-	// 981 941 931 961 969 962 927 935 985 925 964 945 946 939 946 938 999 933 964 928
-	// 980 944 929 970 973 955 942 937 977 920 955 929 937 946 935 933 999 947 956 926
-	// 980 948 926 981 938 939 936 936 963 949 965 935 943 946 933 933 999 947 955 943
-	// 968 959 945 941 929 926 924 941 970 951 959 941 924 952 931 943 999 941 951 950
-	// 961 946 930 923 933 932 953 937 954 940 964 944 931 952 939 935 999 936 945 948
-	// Total bytes=996294324, ranges=1897
+	// 999 000 000 000 000 000 000 000 000 000 000 000 000 000 000 000 000 739 000 000
+	// 999 107 000 000 000 000 000 000 000 000 177 000 000 000 204 000 000 734 000 000
+	// 929 288 000 168 000 057 623 000 114 272 471 000 000 565 385 000 000 999 000 284
+	// 683 367 133 087 000 527 381 607 379 380 502 000 188 824 490 295 420 999 000 490
+	// 540 443 380 319 000 438 382 534 599 579 602 000 268 859 601 374 450 999 000 532
+	// 412 428 539 429 170 332 424 696 505 439 503 691 327 752 427 437 451 999 076 441
+	// 496 583 662 586 280 431 499 714 564 578 540 661 431 784 548 516 547 999 329 589
+	// 502 563 646 541 430 428 576 693 633 578 537 577 455 803 573 596 528 999 402 639
+	// 603 641 764 638 764 521 650 764 713 683 648 652 579 860 610 731 665 999 463 749
+	// 615 642 779 688 813 459 650 791 728 702 743 614 526 829 600 767 760 999 497 700
+	// 677 677 879 787 867 518 700 852 775 801 793 666 526 820 601 843 767 999 544 772
+	// 723 696 866 838 853 589 730 882 800 768 782 695 567 776 656 836 832 999 613 832
+	// 830 764 936 879 976 673 824 974 864 825 835 761 703 874 700 909 888 999 635 957
+	// 832 766 949 842 995 730 839 965 870 843 790 765 693 931 706 936 936 999 683 948
+	// 866 787 990 851 999 780 867 968 892 847 783 787 708 912 768 963 951 954 681 942
+	// 844 768 995 866 999 811 836 952 931 849 764 763 716 923 758 980 907 921 705 927
+	// 866 780 999 897 979 844 858 975 968 897 762 772 739 939 731 984 909 912 752 931
+	// 895 818 999 918 991 884 916 936 942 899 790 780 775 930 779 976 963 893 752 920
+	// 832 782 999 865 978 854 908 902 887 886 760 785 747 903 762 924 911 830 750 876
+	// 864 804 999 856 987 855 939 911 905 909 735 818 808 909 757 941 956 807 761 875
+	// 892 839 999 901 977 871 933 930 931 910 766 812 831 908 768 969 935 861 793 867
+	// 908 858 982 911 994 872 947 951 960 935 798 832 835 895 786 999 951 873 790 863
+	// 881 863 963 908 991 845 919 941 959 939 801 815 832 876 783 999 959 877 798 822
+	// 907 929 962 930 942 904 901 925 955 940 871 985 921 902 873 999 991 894 908 926
+	// 892 923 956 939 976 961 904 933 958 942 914 979 925 907 940 999 982 906 929 922
+	// 913 928 940 921 930 913 913 929 925 918 920 963 923 923 940 999 928 909 923 948
+	// 924 950 910 947 926 918 917 933 944 920 907 917 911 920 914 999 921 909 915 939
+	// 908 933 920 946 940 936 935 931 957 924 914 914 915 936 929 999 929 934 924 906
+	// 946 943 954 968 961 966 966 935 951 940 935 959 949 950 938 996 941 981 955 999
+	// 940 926 938 941 930 935 934 935 958 897 941 955 931 943 944 971 949 941 972 999
+	// 950 952 944 957 935 953 951 938 972 932 957 988 943 950 970 961 947 968 970 999
+	// 966 959 957 945 956 964 973 947 991 946 966 985 966 980 986 962 967 958 959 999
+	// 941 964 956 979 959 983 992 937 999 948 976 961 950 996 987 944 968 949 961 968
+	// 982 975 932 950 960 969 955 980 977 944 956 944 920 943 999 940 947 938 937 951
+	// 977 970 935 953 960 965 980 957 991 943 938 956 945 971 999 936 939 952 948 944
+	// 993 969 987 951 988 979 999 966 983 957 948 971 971 956 990 958 967 955 979 983
+	// 969 935 955 952 936 961 979 943 975 954 938 957 967 959 950 977 940 999 956 964
+	// 964 953 975 956 923 972 978 952 974 962 939 946 952 947 952 984 944 999 947 974
+	// 957 966 969 951 950 977 984 935 940 954 962 956 957 953 952 965 943 999 957 975
+	// 974 984 982 953 947 968 999 953 940 956 972 946 973 954 948 958 953 987 970 961
+	// 976 980 976 948 946 955 999 963 952 962 962 941 955 946 926 944 952 951 957 944
+	// 988 975 951 938 957 972 999 963 973 963 968 948 958 948 945 954 963 943 945 959
+	// 999 977 958 930 955 957 993 954 983 955 952 945 953 947 923 963 945 939 972 953
+	// 999 970 928 975 945 938 983 956 954 933 939 938 940 921 923 958 935 933 962 938
+	// 999 970 915 961 935 923 993 932 929 926 935 925 927 931 917 947 938 929 959 921
+	// 999 949 953 933 929 952 984 922 935 943 931 942 932 951 934 957 935 926 947 920
+	// 999 957 948 937 943 951 992 926 927 938 930 934 943 953 946 945 938 935 953 941
+	// 999 958 962 932 934 938 989 935 930 921 927 935 932 957 926 945 935 921 949 932
+	// 989 962 950 942 927 941 999 943 926 936 931 930 926 959 923 943 931 928 951 945
+	// 999 960 952 934 933 935 995 939 928 938 924 929 971 946 927 950 932 933 943 947
+	// Total bytes=1001793961, ranges=1898
 }

--- a/storage/client_test.go
+++ b/storage/client_test.go
@@ -97,6 +97,7 @@ type multiTestContext struct {
 	manualClock  *hlc.ManualClock
 	clock        *hlc.Clock
 	gossip       *gossip.Gossip
+	storePool    *storage.StorePool
 	transport    multiraft.Transport
 	db           *client.DB
 	feed         *util.Feed
@@ -142,6 +143,9 @@ func (m *multiTestContext) Start(t *testing.T, numStores int) {
 	}
 	if m.transport == nil {
 		m.transport = multiraft.NewLocalRPCTransport(m.clientStopper)
+	}
+	if m.storePool == nil {
+		m.storePool = storage.NewStorePool(m.gossip, storage.TestTimeUntilStoreDeadOff, m.clientStopper)
 	}
 
 	// Always create the first sender.
@@ -189,6 +193,7 @@ func (m *multiTestContext) makeContext(i int) storage.StoreContext {
 	ctx.Clock = m.clocks[i]
 	ctx.DB = m.db
 	ctx.Gossip = m.gossip
+	ctx.StorePool = m.storePool
 	ctx.Transport = m.transport
 	ctx.EventFeed = m.feed
 	return ctx

--- a/storage/store.go
+++ b/storage/store.go
@@ -289,6 +289,7 @@ type StoreContext struct {
 	Clock     *hlc.Clock
 	DB        *client.DB
 	Gossip    *gossip.Gossip
+	StorePool *StorePool
 	Transport multiraft.Transport
 
 	// RangeRetryOptions are the retry options when retryable errors are

--- a/storage/store.go
+++ b/storage/store.go
@@ -317,6 +317,10 @@ type StoreContext struct {
 	// stores.
 	ScanMaxIdleTime time.Duration
 
+	// TimeUntilStoreDead is the time after which if there is no new gossiped
+	// information about a store, it can be considered dead.
+	TimeUntilStoreDead time.Duration
+
 	// EventFeed is a feed to which this store will publish events.
 	EventFeed *util.Feed
 
@@ -363,7 +367,7 @@ func NewStore(ctx StoreContext, eng engine.Engine, nodeDesc *proto.NodeDescripto
 		ctx:            ctx,
 		db:             ctx.DB, // TODO(tschottdorf) remove redundancy.
 		engine:         eng,
-		_allocator:     newAllocator(ctx.Gossip),
+		_allocator:     newAllocator(ctx.StorePool),
 		replicas:       map[proto.RangeID]*Replica{},
 		replicasByKey:  btree.New(64 /* degree */),
 		uninitReplicas: map[proto.RangeID]*Replica{},

--- a/storage/store_pool.go
+++ b/storage/store_pool.go
@@ -1,0 +1,211 @@
+// Copyright 2015 The Cockroach Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+// implied. See the License for the specific language governing
+// permissions and limitations under the License. See the AUTHORS file
+// for names of contributors.
+//
+// Author: Bram Gruneir (bram+code@cockroachlabs.com)
+
+package storage
+
+import (
+	"container/heap"
+	"sync"
+	"time"
+
+	gogoproto "github.com/gogo/protobuf/proto"
+
+	"github.com/cockroachdb/cockroach/gossip"
+	"github.com/cockroachdb/cockroach/proto"
+	"github.com/cockroachdb/cockroach/util/hlc"
+	"github.com/cockroachdb/cockroach/util/log"
+	"github.com/cockroachdb/cockroach/util/stop"
+)
+
+// TestTimeUntilStoreDead is the default TimeUntilStoreDead for running tests.
+const TestTimeUntilStoreDead = 10 * time.Millisecond
+
+type storeDetail struct {
+	desc            proto.StoreDescriptor
+	dead            bool
+	timesDied       int
+	foundDeadOn     time.Time
+	lastUpdatedTime time.Time // This is also the priority for the queue.
+	index           int       // index of the item in the heap, required for heap.Interface
+}
+
+// markDead sets the storeDetail to dead(inactive).
+func (sd *storeDetail) markDead(foundDeadOn time.Time) {
+	sd.dead = true
+	sd.foundDeadOn = foundDeadOn
+	sd.timesDied++
+	log.Warningf("store %s on node %s is now considered offline", sd.desc.StoreID, sd.desc.Node.NodeID)
+}
+
+// markAlive sets the storeDetail to alive(active) and saves the updated time
+// and descriptor.
+func (sd *storeDetail) markAlive(foundAliveOn time.Time, storeDesc proto.StoreDescriptor) {
+	sd.desc = storeDesc
+	sd.dead = false
+	sd.lastUpdatedTime = foundAliveOn
+}
+
+// storePoolPQ implements the heap.Interface (which includes  sort.Interface)
+// and holds storeDetail. storePoolPQ is not threadsafe.
+type storePoolPQ []*storeDetail
+
+// Len implements the sort.Interface.
+func (pq storePoolPQ) Len() int {
+	return len(pq)
+}
+
+// Less implements the sort.Interface.
+func (pq storePoolPQ) Less(i, j int) bool {
+	return pq[i].lastUpdatedTime.Before(pq[j].lastUpdatedTime)
+}
+
+// Swap implements the sort.Interface.
+func (pq storePoolPQ) Swap(i, j int) {
+	pq[i], pq[j] = pq[j], pq[i]
+	pq[i].index, pq[j].index = i, j
+}
+
+// Push implements the heap.Interface.
+func (pq *storePoolPQ) Push(x interface{}) {
+	n := len(*pq)
+	item := x.(*storeDetail)
+	item.index = n
+	*pq = append(*pq, item)
+}
+
+// Pop implements the heap.Interface.
+func (pq *storePoolPQ) Pop() interface{} {
+	old := *pq
+	n := len(old)
+	item := old[n-1]
+	item.index = -1 // for safety
+	*pq = old[0 : n-1]
+	return item
+}
+
+// peek returns the next value in the priority queue without dequeuing it.
+func (pq storePoolPQ) peek() *storeDetail {
+	if len(pq) == 0 {
+		return nil
+	}
+	return pq[0]
+}
+
+// enqueue either adds the detail to the queue or updates its location in the
+// priority queue.
+func (pq *storePoolPQ) enqueue(detail *storeDetail) {
+	if detail.index < 0 {
+		heap.Push(pq, detail)
+	} else {
+		heap.Fix(pq, detail.index)
+	}
+}
+
+// dequeue removes the next detail from the priority queue.
+func (pq *storePoolPQ) dequeue() *storeDetail {
+	if len(*pq) == 0 {
+		return nil
+	}
+	return heap.Pop(pq).(*storeDetail)
+}
+
+// StorePool maintains a list of all known stores in the cluster and
+// information on their health.
+type StorePool struct {
+	gossip             *gossip.Gossip
+	clock              *hlc.Clock
+	timeUntilStoreDead time.Duration
+
+	mu     sync.RWMutex // Protects stores and queue.
+	stores map[proto.StoreID]*storeDetail
+	queue  storePoolPQ
+}
+
+// NewStorePool creates a StorePool and registers the store updating callback
+// with gossip.
+func NewStorePool(g *gossip.Gossip, timeUntilStoreDead time.Duration, stopper *stop.Stopper) *StorePool {
+	sp := &StorePool{
+		timeUntilStoreDead: timeUntilStoreDead,
+		stores:             make(map[proto.StoreID]*storeDetail),
+	}
+	heap.Init(&sp.queue)
+
+	storeRegex := gossip.MakePrefixPattern(gossip.KeyStorePrefix)
+	g.RegisterCallback(storeRegex, sp.storeGossipUpdate)
+
+	sp.start(stopper)
+
+	return sp
+}
+
+// storeGossipUpdate The gossip callback used to keep the StorePool up to date.
+func (sp *StorePool) storeGossipUpdate(_ string, content []byte) {
+	var storeDesc proto.StoreDescriptor
+	if err := gogoproto.Unmarshal(content, &storeDesc); err != nil {
+		log.Error(err)
+		return
+	}
+
+	sp.mu.Lock()
+	defer sp.mu.Unlock()
+	// Does this storeDetail exist yet?
+	detail, ok := sp.stores[storeDesc.StoreID]
+	if !ok {
+		// Setting index to -1 ensures this gets added to the queue.
+		detail = &storeDetail{index: -1}
+		sp.stores[storeDesc.StoreID] = detail
+	}
+	detail.markAlive(time.Now(), storeDesc)
+	sp.queue.enqueue(detail)
+}
+
+// start will run continuously and mark stores as offline if they haven't been
+// heard from in longer than timeUntilStoreDead.
+func (sp *StorePool) start(stopper *stop.Stopper) {
+	stopper.RunWorker(func() {
+		for {
+			var timeout time.Duration
+			sp.mu.Lock()
+			detail := sp.queue.peek()
+			if detail == nil {
+				// No stores yet, wait the full timeout.
+				timeout = sp.timeUntilStoreDead
+			} else {
+				// Check to see if the store should be marked as dead.
+				deadAsOf := detail.lastUpdatedTime.Add(sp.timeUntilStoreDead)
+				now := time.Now()
+				if now.After(deadAsOf) {
+					deadDetail := sp.queue.dequeue()
+					deadDetail.markDead(now)
+					// The next store might be dead as well, set the timeout to
+					// 0 to process it immediately.
+					timeout = 0
+				} else {
+					// Store is still alive, schedule the next check for when
+					// it should timeout.
+					timeout = deadAsOf.Sub(now)
+				}
+			}
+			sp.mu.Unlock()
+			select {
+			case <-time.After(timeout):
+			case <-stopper.ShouldStop():
+				return
+			}
+		}
+	})
+}

--- a/storage/store_pool_test.go
+++ b/storage/store_pool_test.go
@@ -1,0 +1,186 @@
+// Copyright 2015 The Cockroach Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+// implied. See the License for the specific language governing
+// permissions and limitations under the License. See the AUTHORS file
+// for names of contributors.
+//
+// Author: Bram Gruneir (bram+code@cockroachlabs.com)
+
+package storage
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/cockroachdb/cockroach/base"
+	"github.com/cockroachdb/cockroach/gossip"
+	"github.com/cockroachdb/cockroach/proto"
+	"github.com/cockroachdb/cockroach/rpc"
+	"github.com/cockroachdb/cockroach/util"
+	"github.com/cockroachdb/cockroach/util/hlc"
+	"github.com/cockroachdb/cockroach/util/leaktest"
+	"github.com/cockroachdb/cockroach/util/stop"
+)
+
+var uniqueStore = []*proto.StoreDescriptor{
+	{
+		StoreID: 2,
+		Attrs:   proto.Attributes{Attrs: []string{"ssd"}},
+		Node: proto.NodeDescriptor{
+			NodeID: 2,
+			Attrs:  proto.Attributes{Attrs: []string{"a"}},
+		},
+		Capacity: proto.StoreCapacity{
+			Capacity:  100,
+			Available: 200,
+		},
+	},
+}
+
+// createTestStorePool creates a stopper, gossip and storePool for use in
+// tests. Stopper must be stopped by the caller.
+func createTestStorePool() (*stop.Stopper, *gossip.Gossip, *StorePool) {
+	stopper := stop.NewStopper()
+	rpcContext := rpc.NewContext(&base.Context{}, hlc.NewClock(hlc.UnixNano), stopper)
+	g := gossip.New(rpcContext, gossip.TestInterval, gossip.TestBootstrap)
+	storePool := NewStorePool(g, TestTimeUntilStoreDead, stopper)
+	return stopper, g, storePool
+}
+
+// TestStorePoolGossipUpdate ensures that the gossip callback in StorePool
+// correctly updates a store's details.
+func TestStorePoolGossipUpdate(t *testing.T) {
+	defer leaktest.AfterTest(t)
+	stopper, g, sp := createTestStorePool()
+	defer stopper.Stop()
+	sg := newStoreGossiper(g)
+
+	sp.mu.RLock()
+	if _, ok := sp.stores[2]; ok {
+		t.Fatalf("store 2 is already in the pool's store list")
+	}
+	sp.mu.RUnlock()
+
+	sg.gossipStores(uniqueStore, t)
+
+	sp.mu.RLock()
+	if _, ok := sp.stores[2]; !ok {
+		t.Fatalf("store 2 isn't in the pool's store list")
+	}
+	if e, a := 1, sp.queue.Len(); e > a {
+		t.Fatalf("wrong number of stores in the queue expected at least:%d actual:%d", e, a)
+	}
+	sp.mu.RUnlock()
+}
+
+// waitUntilDead will block until the specified store is marked as dead.
+func waitUntilDead(t *testing.T, sp *StorePool, storeID proto.StoreID) {
+	util.SucceedsWithin(t, 3*TestTimeUntilStoreDead, func() error {
+		sp.mu.RLock()
+		defer sp.mu.RUnlock()
+		store, ok := sp.stores[storeID]
+		if !ok {
+			t.Fatalf("store %s isn't in the pool's store list", storeID)
+		}
+		exitcode := store.dead
+
+		if exitcode {
+			return nil
+		}
+		return errors.New("store not marked as dead yet")
+	})
+}
+
+// TestStorePoolGossipUpdate ensures that a store is marked as dead after it
+// times out and that it will be revived after a new update is received.
+func TestStorePoolDies(t *testing.T) {
+	defer leaktest.AfterTest(t)
+	stopper, g, sp := createTestStorePool()
+	defer stopper.Stop()
+	sg := newStoreGossiper(g)
+	sg.gossipStores(uniqueStore, t)
+
+	{
+		sp.mu.RLock()
+		store2, ok := sp.stores[2]
+		if !ok {
+			t.Fatalf("store 2 isn't in the pool's store list")
+		}
+		if store2.dead {
+			t.Errorf("store 2 is dead before it times out")
+		}
+		if e, a := 0, store2.timesDied; e != a {
+			t.Errorf("store 2 has been counted dead %d times, expected %d", a, e)
+		}
+		if store2.index == -1 {
+			t.Errorf("store 2 is mot the queue, it should be")
+		}
+		if e, a := 1, sp.queue.Len(); e > a {
+			t.Errorf("wrong number of stores in the queue expected to be at least:%d actual:%d", e, a)
+		}
+		sp.mu.RUnlock()
+	}
+
+	// Timeout store 2.
+	waitUntilDead(t, sp, 2)
+	{
+		sp.mu.RLock()
+		store2, ok := sp.stores[2]
+		if !ok {
+			t.Fatalf("store 2 isn't in the pool's store list")
+		}
+		if e, a := 1, store2.timesDied; e != a {
+			t.Errorf("store 2 has been counted dead %d times, expected %d", a, e)
+		}
+		if store2.index != -1 {
+			t.Errorf("store 2 is in the queue, it shouldn't be")
+		}
+		sp.mu.RUnlock()
+	}
+
+	sg.gossipStores(uniqueStore, t)
+
+	{
+		sp.mu.RLock()
+		store2, ok := sp.stores[2]
+		if !ok {
+			t.Fatalf("store 2 isn't in the pool's store list")
+		}
+		if store2.dead {
+			t.Errorf("store 2 is dead still, it should be alive")
+		}
+		if e, a := 1, store2.timesDied; e != a {
+			t.Errorf("store 2 has been counted dead %d times, expected %d", a, e)
+		}
+		if store2.index == -1 {
+			t.Errorf("store 2 is mot the queue, it should be")
+		}
+		sp.mu.RUnlock()
+	}
+
+	// Timeout store 2 again.
+	waitUntilDead(t, sp, 2)
+	{
+		sp.mu.RLock()
+		store2, ok := sp.stores[2]
+		if !ok {
+			t.Fatalf("store 2 isn't in the pool's store list")
+		}
+		if e, a := 2, store2.timesDied; e != a {
+			t.Errorf("store 2 has been counted dead %d times, expected %d", a, e)
+		}
+		if store2.index != -1 {
+			t.Errorf("store 2 is in the queue, it shouldn't be")
+		}
+		sp.mu.RUnlock()
+	}
+}

--- a/storage/store_test.go
+++ b/storage/store_test.go
@@ -162,6 +162,7 @@ func createTestStoreWithoutStart(t *testing.T) (*Store, *hlc.ManualClock, *stop.
 	rpcContext := rpc.NewContext(&base.Context{}, hlc.NewClock(hlc.UnixNano), stopper)
 	ctx := TestStoreContext
 	ctx.Gossip = gossip.New(rpcContext, gossip.TestInterval, gossip.TestBootstrap)
+	ctx.StorePool = NewStorePool(ctx.Gossip, TestTimeUntilStoreDead, stopper)
 	manual := hlc.NewManualClock(0)
 	ctx.Clock = hlc.NewClock(manual.UnixNano)
 	eng := engine.NewInMem(proto.Attributes{}, 10<<20)

--- a/storage/store_test.go
+++ b/storage/store_test.go
@@ -162,7 +162,7 @@ func createTestStoreWithoutStart(t *testing.T) (*Store, *hlc.ManualClock, *stop.
 	rpcContext := rpc.NewContext(&base.Context{}, hlc.NewClock(hlc.UnixNano), stopper)
 	ctx := TestStoreContext
 	ctx.Gossip = gossip.New(rpcContext, gossip.TestInterval, gossip.TestBootstrap)
-	ctx.StorePool = NewStorePool(ctx.Gossip, TestTimeUntilStoreDead, stopper)
+	ctx.StorePool = NewStorePool(ctx.Gossip, testTimeUntilStoreDead, stopper)
 	manual := hlc.NewManualClock(0)
 	ctx.Clock = hlc.NewClock(manual.UnixNano)
 	eng := engine.NewInMem(proto.Attributes{}, 10<<20)


### PR DESCRIPTION
StorePool will keep a list of alive/dead nodes as per the RPC from #2191
The allocator uses StorePool to ensure that the stores being picked are indeed alive.

Next up will be:
- get the scanner to sniff out replicas on failed stores
