### PR TITLE
Tiny fix: Make a header key same as a transaction key in Admin{Split,Merge}

### DIFF
--- a/storage/replica_command.go
+++ b/storage/replica_command.go
@@ -1119,7 +1119,7 @@ func (r *Replica) AdminSplit(args proto.AdminSplitRequest, desc *proto.RangeDesc
 		// loop do it, in order to provide a split trigger.
 		b.InternalAddCall(proto.Call{
 			Args: &proto.EndTransactionRequest{
-				RequestHeader: proto.RequestHeader{Key: args.Key},
+				RequestHeader: proto.RequestHeader{Key: newDesc.StartKey},
 				Commit:        true,
 				InternalCommitTrigger: &proto.InternalCommitTrigger{
 					SplitTrigger: &proto.SplitTrigger{
@@ -1290,7 +1290,7 @@ func (r *Replica) AdminMerge(args proto.AdminMergeRequest, desc *proto.RangeDesc
 		// loop do it, in order to provide a merge trigger.
 		b.InternalAddCall(proto.Call{
 			Args: &proto.EndTransactionRequest{
-				RequestHeader: proto.RequestHeader{Key: args.Key},
+				RequestHeader: proto.RequestHeader{Key: updatedDesc.StartKey},
 				Commit:        true,
 				InternalCommitTrigger: &proto.InternalCommitTrigger{
 					MergeTrigger: &proto.MergeTrigger{


### PR DESCRIPTION
For a txn created from AdminSplit, its txn key is created from the start key of the second half of split. It does not always match with `Args.Key` (e.g., the second admin split request in `splitQueue.process`).

For a txn created from AdminMerge, a txn key is created from the start key of a subsuming range.

`TxnCoordSender.sendOne()` will anyway override a header key with a transaction key, but it would be nice to have the matching value for better readability.
