### PR TITLE
Transform > constraints into >= constraints.

### DIFF
--- a/sql/analyze_test.go
+++ b/sql/analyze_test.go
@@ -25,6 +25,28 @@ import (
 	"github.com/cockroachdb/cockroach/util/leaktest"
 )
 
+var testTableDesc = &TableDescriptor{
+	Name: "test",
+	ID:   1000,
+	Columns: []ColumnDescriptor{
+		{Name: "a", Type: ColumnType{Kind: ColumnType_INT}},
+		{Name: "b", Type: ColumnType{Kind: ColumnType_INT}},
+		{Name: "c", Type: ColumnType{Kind: ColumnType_INT}},
+		{Name: "d", Type: ColumnType{Kind: ColumnType_INT}},
+		{Name: "e", Type: ColumnType{Kind: ColumnType_INT}},
+	},
+	PrimaryIndex: IndexDescriptor{
+		Name: "primary", Unique: true, ColumnNames: []string{"a"},
+	},
+	Privileges: NewDefaultPrivilegeDescriptor(),
+}
+
+func init() {
+	if err := testTableDesc.AllocateIDs(); err != nil {
+		panic(err)
+	}
+}
+
 func parseAndNormalizeExpr(t *testing.T, sql string) (parser.Expr, qvalMap) {
 	q, err := parser.ParseTraditional("SELECT " + sql)
 	if err != nil {
@@ -39,15 +61,7 @@ func parseAndNormalizeExpr(t *testing.T, sql string) (parser.Expr, qvalMap) {
 	// Perform qualified name resolution because {analyze,simplify}Expr want
 	// expressions containing qvalues.
 	s := &scanNode{}
-	s.desc = &TableDescriptor{
-		Columns: []ColumnDescriptor{
-			{Name: "a", ID: 1, Type: ColumnType{Kind: ColumnType_INT}},
-			{Name: "b", ID: 2, Type: ColumnType{Kind: ColumnType_INT}},
-			{Name: "c", ID: 3, Type: ColumnType{Kind: ColumnType_INT}},
-			{Name: "d", ID: 4, Type: ColumnType{Kind: ColumnType_INT}},
-			{Name: "e", ID: 5, Type: ColumnType{Kind: ColumnType_INT}},
-		},
-	}
+	s.desc = testTableDesc
 	s.visibleCols = s.desc.Columns
 
 	r, err = s.resolveQNames(r)

--- a/sql/logic_test.go
+++ b/sql/logic_test.go
@@ -458,14 +458,22 @@ func (t *logicTest) execQuery(query logicQuery) {
 
 		fmt.Fprintf(tw, "%s: expected:\n", query.pos)
 		for i := 0; i < len(query.expectedResults); i += len(cols) {
-			for _, value := range query.expectedResults[i : i+len(cols)] {
+			end := i + len(cols)
+			if end > len(query.expectedResults) {
+				end = len(query.expectedResults)
+			}
+			for _, value := range query.expectedResults[i:end] {
 				fmt.Fprintf(tw, "%q\t", value)
 			}
 			fmt.Fprint(tw, "\n")
 		}
 		fmt.Fprint(tw, "but found:\n")
 		for i := 0; i < len(results); i += len(cols) {
-			for _, value := range results[i : i+len(cols)] {
+			end := i + len(cols)
+			if end > len(results) {
+				end = len(results)
+			}
+			for _, value := range results[i:end] {
 				fmt.Fprintf(tw, "%q\t", value)
 			}
 			fmt.Fprint(tw, "\n")

--- a/sql/select_test.go
+++ b/sql/select_test.go
@@ -24,7 +24,7 @@ import (
 )
 
 func makeTestIndex(t *testing.T, columns []string) (*TableDescriptor, *IndexDescriptor) {
-	desc := *testTableDesc
+	desc := testTableDesc()
 	desc.Indexes = append(desc.Indexes, IndexDescriptor{
 		Name:        "foo",
 		ColumnNames: columns,
@@ -32,7 +32,7 @@ func makeTestIndex(t *testing.T, columns []string) (*TableDescriptor, *IndexDesc
 	if err := desc.AllocateIDs(); err != nil {
 		t.Fatal(err)
 	}
-	return &desc, &desc.Indexes[len(desc.Indexes)-1]
+	return desc, &desc.Indexes[len(desc.Indexes)-1]
 }
 
 func makeConstraints(t *testing.T, sql string, desc *TableDescriptor,

--- a/sql/select_test.go
+++ b/sql/select_test.go
@@ -1,0 +1,206 @@
+// Copyright 2015 The Cockroach Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+// implied. See the License for the specific language governing
+// permissions and limitations under the License. See the AUTHORS file
+// for names of contributors.
+//
+// Author: Peter Mattis (peter@cockroachlabs.com)
+
+package sql
+
+import (
+	"testing"
+
+	"github.com/cockroachdb/cockroach/util/leaktest"
+)
+
+func makeTestIndex(t *testing.T, columns []string) (*TableDescriptor, *IndexDescriptor) {
+	desc := *testTableDesc
+	desc.Indexes = append(desc.Indexes, IndexDescriptor{
+		Name:        "foo",
+		ColumnNames: columns,
+	})
+	if err := desc.AllocateIDs(); err != nil {
+		t.Fatal(err)
+	}
+	return &desc, &desc.Indexes[len(desc.Indexes)-1]
+}
+
+func makeConstraints(t *testing.T, sql string, desc *TableDescriptor,
+	index *IndexDescriptor) indexConstraints {
+	expr, _ := parseAndNormalizeExpr(t, sql)
+	exprs := analyzeExpr(expr)
+
+	c := &indexInfo{
+		desc:     desc,
+		index:    index,
+		covering: true,
+	}
+	c.analyzeRanges(exprs)
+	return c.constraints
+}
+
+func TestMakeConstraints(t *testing.T) {
+	defer leaktest.AfterTest(t)
+
+	testData := []struct {
+		expr     string
+		columns  []string
+		expected string
+	}{
+		{`a = 1`, []string{"b"}, `[]`},
+		{`a = 1`, []string{"a"}, `[a = 1]`},
+		{`a != 1`, []string{"a"}, `[]`},
+		{`a > 1`, []string{"a"}, `[a >= 2]`},
+		{`a >= 1`, []string{"a"}, `[a >= 1]`},
+		{`a < 1`, []string{"a"}, `[a < 1]`},
+		{`a <= 1`, []string{"a"}, `[a <= 1]`},
+
+		{`a IN (1,2,3)`, []string{"a"}, `[a IN (1, 2, 3)]`},
+		{`a IN (1,2,3) AND b = 1`, []string{"a", "b"}, `[a IN (1, 2, 3), b = 1]`},
+		{`a = 1 AND b IN (1,2,3)`, []string{"a", "b"}, `[a = 1, b IN (1, 2, 3)]`},
+
+		{`a = 1 AND b = 1`, []string{"a", "b"}, `[a = 1, b = 1]`},
+		{`a = 1 AND b != 1`, []string{"a", "b"}, `[a = 1]`},
+		{`a = 1 AND b > 1`, []string{"a", "b"}, `[a = 1, b >= 2]`},
+		{`a = 1 AND b >= 1`, []string{"a", "b"}, `[a = 1, b >= 1]`},
+		{`a = 1 AND b < 1`, []string{"a", "b"}, `[a = 1, b < 1]`},
+		{`a = 1 AND b <= 1`, []string{"a", "b"}, `[a = 1, b <= 1]`},
+
+		{`a != 1 AND b = 1`, []string{"a", "b"}, `[]`},
+		{`a != 1 AND b != 1`, []string{"a", "b"}, `[]`},
+		{`a != 1 AND b > 1`, []string{"a", "b"}, `[]`},
+		{`a != 1 AND b >= 1`, []string{"a", "b"}, `[]`},
+		{`a != 1 AND b < 1`, []string{"a", "b"}, `[]`},
+		{`a != 1 AND b <= 1`, []string{"a", "b"}, `[]`},
+
+		{`a > 1 AND b = 1`, []string{"a", "b"}, `[a >= 2, b = 1]`},
+		{`a > 1 AND b != 1`, []string{"a", "b"}, `[a >= 2]`},
+		{`a > 1 AND b > 1`, []string{"a", "b"}, `[a >= 2, b >= 2]`},
+		{`a > 1 AND b >= 1`, []string{"a", "b"}, `[a >= 2, b >= 1]`},
+		{`a > 1 AND b < 1`, []string{"a", "b"}, `[a >= 2]`},
+		{`a > 1 AND b <= 1`, []string{"a", "b"}, `[a >= 2]`},
+
+		{`a >= 1 AND b = 1`, []string{"a", "b"}, `[a >= 1, b = 1]`},
+		{`a >= 1 AND b != 1`, []string{"a", "b"}, `[a >= 1]`},
+		{`a >= 1 AND b > 1`, []string{"a", "b"}, `[a >= 1, b >= 2]`},
+		{`a >= 1 AND b >= 1`, []string{"a", "b"}, `[a >= 1, b >= 1]`},
+		{`a >= 1 AND b < 1`, []string{"a", "b"}, `[a >= 1]`},
+		{`a >= 1 AND b <= 1`, []string{"a", "b"}, `[a >= 1]`},
+
+		{`a < 1 AND b = 1`, []string{"a", "b"}, `[a < 1]`},
+		{`a < 1 AND b != 1`, []string{"a", "b"}, `[a < 1]`},
+		{`a < 1 AND b > 1`, []string{"a", "b"}, `[a < 1]`},
+		{`a < 1 AND b >= 1`, []string{"a", "b"}, `[a < 1]`},
+		{`a < 1 AND b < 1`, []string{"a", "b"}, `[a < 1]`},
+		{`a < 1 AND b <= 1`, []string{"a", "b"}, `[a < 1]`},
+
+		{`a <= 1 AND b = 1`, []string{"a", "b"}, `[a <= 1, b = 1]`},
+		{`a <= 1 AND b != 1`, []string{"a", "b"}, `[a <= 1]`},
+		{`a <= 1 AND b > 1`, []string{"a", "b"}, `[a <= 1]`},
+		{`a <= 1 AND b >= 1`, []string{"a", "b"}, `[a <= 1]`},
+		{`a <= 1 AND b < 1`, []string{"a", "b"}, `[a <= 1, b < 1]`},
+		{`a <= 1 AND b <= 1`, []string{"a", "b"}, `[a <= 1, b <= 1]`},
+
+		{`a IN (1) AND b = 1`, []string{"a", "b"}, `[a IN (1), b = 1]`},
+		{`a IN (1) AND b != 1`, []string{"a", "b"}, `[a IN (1)]`},
+		{`a IN (1) AND b > 1`, []string{"a", "b"}, `[a IN (1), b >= 2]`},
+		{`a IN (1) AND b >= 1`, []string{"a", "b"}, `[a IN (1), b >= 1]`},
+		{`a IN (1) AND b < 1`, []string{"a", "b"}, `[a IN (1), b < 1]`},
+		{`a IN (1) AND b <= 1`, []string{"a", "b"}, `[a IN (1), b <= 1]`},
+	}
+	for _, d := range testData {
+		desc, index := makeTestIndex(t, d.columns)
+		constraints := makeConstraints(t, d.expr, desc, index)
+		if s := constraints.String(); d.expected != s {
+			t.Errorf("%s: expected %s, but found %s", d.expr, d.expected, s)
+		}
+	}
+}
+
+func TestMakeSpans(t *testing.T) {
+	defer leaktest.AfterTest(t)
+
+	testData := []struct {
+		expr     string
+		columns  []string
+		expected string
+	}{
+		{`a = 1`, []string{"a"}, `/1-/2`},
+		{`a != 1`, []string{"a"}, `-`},
+		{`a > 1`, []string{"a"}, `/2-`},
+		{`a >= 1`, []string{"a"}, `/1-`},
+		{`a < 1`, []string{"a"}, `-/1`},
+		{`a <= 1`, []string{"a"}, `-/2`},
+
+		{`a IN (1,2,3)`, []string{"a"}, `/1-/2 /2-/3 /3-/4`},
+		{`a IN (1,2,3) AND b = 1`, []string{"a", "b"}, `/1/1-/1/2 /2/1-/2/2 /3/1-/3/2`},
+		{`a = 1 AND b IN (1,2,3)`, []string{"a", "b"}, `/1/1-/1/2 /1/2-/1/3 /1/3-/1/4`},
+
+		{`a = 1 AND b = 1`, []string{"a", "b"}, `/1/1-/1/2`},
+		{`a = 1 AND b != 1`, []string{"a", "b"}, `/1-/2`},
+		{`a = 1 AND b > 1`, []string{"a", "b"}, `/1/2-/2`},
+		{`a = 1 AND b >= 1`, []string{"a", "b"}, `/1/1-/2`},
+		{`a = 1 AND b < 1`, []string{"a", "b"}, `/1-/1/1`},
+		{`a = 1 AND b <= 1`, []string{"a", "b"}, `/1-/1/2`},
+
+		{`a != 1 AND b = 1`, []string{"a", "b"}, `-`},
+		{`a != 1 AND b != 1`, []string{"a", "b"}, `-`},
+		{`a != 1 AND b > 1`, []string{"a", "b"}, `-`},
+		{`a != 1 AND b >= 1`, []string{"a", "b"}, `-`},
+		{`a != 1 AND b < 1`, []string{"a", "b"}, `-`},
+		{`a != 1 AND b <= 1`, []string{"a", "b"}, `-`},
+
+		{`a > 1 AND b = 1`, []string{"a", "b"}, `/2/1-`},
+		{`a > 1 AND b != 1`, []string{"a", "b"}, `/2-`},
+		{`a > 1 AND b > 1`, []string{"a", "b"}, `/2/2-`},
+		{`a > 1 AND b >= 1`, []string{"a", "b"}, `/2/1-`},
+		{`a > 1 AND b < 1`, []string{"a", "b"}, `/2-`},
+		{`a > 1 AND b <= 1`, []string{"a", "b"}, `/2-`},
+
+		{`a >= 1 AND b = 1`, []string{"a", "b"}, `/1/1-`},
+		{`a >= 1 AND b != 1`, []string{"a", "b"}, `/1-`},
+		{`a >= 1 AND b > 1`, []string{"a", "b"}, `/1/2-`},
+		{`a >= 1 AND b >= 1`, []string{"a", "b"}, `/1/1-`},
+		{`a >= 1 AND b < 1`, []string{"a", "b"}, `/1-`},
+		{`a >= 1 AND b <= 1`, []string{"a", "b"}, `/1-`},
+
+		{`a < 1 AND b = 1`, []string{"a", "b"}, `-/1`},
+		{`a < 1 AND b != 1`, []string{"a", "b"}, `-/1`},
+		{`a < 1 AND b > 1`, []string{"a", "b"}, `-/1`},
+		{`a < 1 AND b >= 1`, []string{"a", "b"}, `-/1`},
+		{`a < 1 AND b < 1`, []string{"a", "b"}, `-/1`},
+		{`a < 1 AND b <= 1`, []string{"a", "b"}, `-/1`},
+
+		{`a <= 1 AND b = 1`, []string{"a", "b"}, `-/1/2`},
+		{`a <= 1 AND b != 1`, []string{"a", "b"}, `-/2`},
+		{`a <= 1 AND b > 1`, []string{"a", "b"}, `-/2`},
+		{`a <= 1 AND b >= 1`, []string{"a", "b"}, `-/2`},
+		{`a <= 1 AND b < 1`, []string{"a", "b"}, `-/1/1`},
+		{`a <= 1 AND b <= 1`, []string{"a", "b"}, `-/1/2`},
+
+		{`a IN (1) AND b = 1`, []string{"a", "b"}, `/1/1-/1/2`},
+		{`a IN (1) AND b != 1`, []string{"a", "b"}, `/1-/2`},
+		{`a IN (1) AND b > 1`, []string{"a", "b"}, `/1/2-/2`},
+		{`a IN (1) AND b >= 1`, []string{"a", "b"}, `/1/1-/2`},
+		{`a IN (1) AND b < 1`, []string{"a", "b"}, `/1-/1/1`},
+		{`a IN (1) AND b <= 1`, []string{"a", "b"}, `/1-/1/2`},
+	}
+	for _, d := range testData {
+		desc, index := makeTestIndex(t, d.columns)
+		constraints := makeConstraints(t, d.expr, desc, index)
+		spans := makeSpans(constraints, desc.ID, index.ID)
+		if s := prettySpans(spans, desc, index); d.expected != s {
+			t.Errorf("%s: expected %s, but found %s", d.expr, d.expected, s)
+		}
+	}
+}

--- a/sql/testdata/explain_plan
+++ b/sql/testdata/explain_plan
@@ -14,6 +14,12 @@ Level  Type  Description
 0      scan  t@primary
 
 query ITT colnames
+EXPLAIN SELECT * FROM t WHERE k = 1 OR k = 3
+----
+Level  Type  Description
+0      scan  t@primary /1-/2 /3-/4
+
+query ITT colnames
 EXPLAIN VALUES (1, 2, 3), (4, 5, 6)
 ----
 Level  Type    Description

--- a/sql/testdata/order_by
+++ b/sql/testdata/order_by
@@ -33,7 +33,7 @@ query ITT
 EXPLAIN SELECT a, b FROM t ORDER BY b
 ----
 0 sort +b
-1 scan t@primary
+1 scan t@primary -
 
 query II
 SELECT a, b FROM t ORDER BY b DESC
@@ -46,7 +46,7 @@ query ITT
 EXPLAIN SELECT a, b FROM t ORDER BY b DESC
 ----
 0 sort -b
-1 scan t@primary
+1 scan t@primary -
 
 query II
 SELECT a FROM t ORDER BY 1 DESC
@@ -87,7 +87,7 @@ query ITT
 EXPLAIN SELECT b FROM t ORDER BY a DESC
 ----
 0 nosort -a
-1 revscan t@primary
+1 revscan t@primary -
 
 statement ok
 INSERT INTO t VALUES (4, 7), (5, 7)
@@ -185,7 +185,7 @@ EXPLAIN (DEBUG) SELECT * FROM abc ORDER BY a
 query ITT
 EXPLAIN SELECT * FROM abc ORDER BY a
 ----
-0 scan abc@primary
+0 scan abc@primary -
 
 query ITTB
 EXPLAIN (DEBUG) SELECT a, b FROM abc ORDER BY b, a
@@ -196,7 +196,7 @@ EXPLAIN (DEBUG) SELECT a, b FROM abc ORDER BY b, a
 query ITT
 EXPLAIN SELECT a, b FROM abc ORDER BY b, a
 ----
-0 scan abc@ba
+0 scan abc@ba -
 
 query ITTB
 EXPLAIN (DEBUG) SELECT b, c FROM abc ORDER BY b, c
@@ -221,7 +221,7 @@ EXPLAIN (DEBUG) SELECT a FROM abc ORDER BY a DESC
 query ITT
 EXPLAIN SELECT a FROM abc ORDER BY a DESC
 ----
-0 revscan abc@primary
+0 revscan abc@primary -
 
 query I
 SELECT a FROM abc ORDER BY a DESC

--- a/sql/testdata/select_index
+++ b/sql/testdata/select_index
@@ -103,19 +103,11 @@ EXPLAIN (DEBUG) SELECT * FROM t WHERE a = 1 AND b > 'b'
 query ITTB
 EXPLAIN (DEBUG) SELECT * FROM t WHERE a > 0 AND b > 'b'
 ----
-0 /t/primary/1/'a' NULL false
-1 /t/primary/1/'b' NULL false
-2 /t/primary/1/'c' NULL true
+0 /t/primary/1/'c' NULL true
 
-# TODO(pmattis): This should scan 0 keys, but the way we scan greater
-# than a key is broken. We should really transfer "a > 0" into "a >=
-# 1". This is possible for integer keys.
 query ITTB
 EXPLAIN (DEBUG) SELECT * FROM t WHERE a > 1 AND b > 'b'
 ----
-0 /t/primary/1/'a' NULL false
-1 /t/primary/1/'b' NULL false
-2 /t/primary/1/'c' NULL false
 
 query ITTB
 EXPLAIN (DEBUG) SELECT * FROM t WHERE a = 1 AND 'a' < b AND 'c' > b


### PR DESCRIPTION
Transform the last <=, = or IN constraint into a < constraint. The > to

> = transforms plays nicer with the inclusive nature of the scan start key.
> The <=/=/IN to < transform plays nicer with the exclusive nature of the
> scan end key.

Added pretty output of the scanned spans to EXPLAIN (plan).

Added tests for make{Constraints,Spans}.

Simplify comparisons to NULL which are always false.
