### PR TITLE
Change system.descriptor column from desc to descriptor.

### DIFF
--- a/sql/doc.go
+++ b/sql/doc.go
@@ -69,8 +69,8 @@ database/table name to ID and from ID to descriptor:
   );
 
   CREATE TABLE system.descriptor (
-    "id"   INT PRIMARY KEY,
-    "desc" BLOB
+    "id"         INT PRIMARY KEY,
+    "descriptor" BLOB
   );
 
 The reserved ID of 0 is used for the "root" of the namespace in which the
@@ -82,7 +82,7 @@ system effectively does a query like:
 And given a database/table ID, the system looks up the descriptor using a query
 like:
 
-  SELECT desc FROM system.descriptor WHERE id = <ID>
+  SELECT descriptor FROM system.descriptor WHERE id = <ID>
 
 Primary Key Addressing
 

--- a/sql/system.go
+++ b/sql/system.go
@@ -45,22 +45,22 @@ const (
 	// TODO(marc): wouldn't it be better to use a pre-parsed version?
 	namespaceTableSchema = `
 CREATE TABLE system.namespace (
-  "parentID" INT,
-  "name"     CHAR,
-  "id"       INT,
+  parentID INT,
+  name     CHAR,
+  id       INT,
   PRIMARY KEY (parentID, name)
 );`
 
 	descriptorTableSchema = `
 CREATE TABLE system.descriptor (
-  "id"   INT PRIMARY KEY,
-  "desc" BLOB
+  id         INT PRIMARY KEY,
+  descriptor BLOB
 );`
 
 	usersTableSchema = `
 CREATE TABLE system.users (
-  "username"       CHAR PRIMARY KEY,
-  "hashedPassword" BLOB
+  username       CHAR PRIMARY KEY,
+  hashedPassword BLOB
 );`
 )
 

--- a/sql/testdata/system
+++ b/sql/testdata/system
@@ -38,6 +38,27 @@ SELECT id FROM system.descriptor
 4
 1000
 
+# Verify format of system tables.
+query TTT
+SHOW COLUMNS FROM system.namespace;
+----
+parentID INT    true
+name     STRING true
+id       INT    true
+
+query TTT
+SHOW COLUMNS FROM system.descriptor;
+----
+id         INT   true
+descriptor BYTES true
+
+query TTT
+SHOW COLUMNS FROM system.users;
+----
+username       STRING true
+hashedPassword BYTES  true
+
+# Verify default privileges on system tables.
 query TTT
 SHOW GRANTS ON DATABASE system
 ----


### PR DESCRIPTION
Fixes #2304.

Also remove quotes from column names in `CREATE TABLE` statements
so that we may catch reserved keywords in the future.
Add system table column listing to testdata.
