### PR TITLE
Allocator Cleanup

### DIFF
--- a/storage/allocator_test.go
+++ b/storage/allocator_test.go
@@ -225,7 +225,7 @@ func TestAllocatorSimpleRetrieval(t *testing.T) {
 	stopper, g, _, a := createTestAllocator()
 	defer stopper.Stop()
 	newStoreGossiper(g).gossipStores(singleStore, t)
-	result, err := a.AllocateTarget(simpleZoneConfig.ReplicaAttrs[0], []proto.Replica{}, false)
+	result, err := a.allocateTarget(simpleZoneConfig.ReplicaAttrs[0], []proto.Replica{}, false, nil)
 	if err != nil {
 		t.Errorf("Unable to perform allocation: %v", err)
 	}
@@ -238,7 +238,7 @@ func TestAllocatorNoAvailableDisks(t *testing.T) {
 	defer leaktest.AfterTest(t)
 	stopper, _, _, a := createTestAllocator()
 	defer stopper.Stop()
-	result, err := a.AllocateTarget(simpleZoneConfig.ReplicaAttrs[0], []proto.Replica{}, false)
+	result, err := a.allocateTarget(simpleZoneConfig.ReplicaAttrs[0], []proto.Replica{}, false, nil)
 	if result != nil {
 		t.Errorf("expected nil result: %+v", result)
 	}
@@ -252,7 +252,7 @@ func TestAllocatorThreeDisksSameDC(t *testing.T) {
 	stopper, g, _, a := createTestAllocator()
 	defer stopper.Stop()
 	newStoreGossiper(g).gossipStores(sameDCStores, t)
-	result1, err := a.AllocateTarget(multiDisksConfig.ReplicaAttrs[0], []proto.Replica{}, false)
+	result1, err := a.allocateTarget(multiDisksConfig.ReplicaAttrs[0], []proto.Replica{}, false, nil)
 	if err != nil {
 		t.Fatalf("Unable to perform allocation: %v", err)
 	}
@@ -265,7 +265,7 @@ func TestAllocatorThreeDisksSameDC(t *testing.T) {
 			StoreID: result1.StoreID,
 		},
 	}
-	result2, err := a.AllocateTarget(multiDisksConfig.ReplicaAttrs[1], exReplicas, false)
+	result2, err := a.allocateTarget(multiDisksConfig.ReplicaAttrs[1], exReplicas, false, nil)
 	if err != nil {
 		t.Errorf("Unable to perform allocation: %v", err)
 	}
@@ -275,7 +275,7 @@ func TestAllocatorThreeDisksSameDC(t *testing.T) {
 	if result1.Node.NodeID == result2.Node.NodeID {
 		t.Errorf("Expected node ids to be different %+v vs %+v", result1, result2)
 	}
-	result3, err := a.AllocateTarget(multiDisksConfig.ReplicaAttrs[2], []proto.Replica{}, false)
+	result3, err := a.allocateTarget(multiDisksConfig.ReplicaAttrs[2], []proto.Replica{}, false, nil)
 	if err != nil {
 		t.Errorf("Unable to perform allocation: %v", err)
 	}
@@ -289,11 +289,11 @@ func TestAllocatorTwoDatacenters(t *testing.T) {
 	stopper, g, _, a := createTestAllocator()
 	defer stopper.Stop()
 	newStoreGossiper(g).gossipStores(multiDCStores, t)
-	result1, err := a.AllocateTarget(multiDCConfig.ReplicaAttrs[0], []proto.Replica{}, false)
+	result1, err := a.allocateTarget(multiDCConfig.ReplicaAttrs[0], []proto.Replica{}, false, nil)
 	if err != nil {
 		t.Fatalf("Unable to perform allocation: %v", err)
 	}
-	result2, err := a.AllocateTarget(multiDCConfig.ReplicaAttrs[1], []proto.Replica{}, false)
+	result2, err := a.allocateTarget(multiDCConfig.ReplicaAttrs[1], []proto.Replica{}, false, nil)
 	if err != nil {
 		t.Fatalf("Unable to perform allocation: %v", err)
 	}
@@ -301,12 +301,12 @@ func TestAllocatorTwoDatacenters(t *testing.T) {
 		t.Errorf("Expected nodes 1 & 2: %+v vs %+v", result1.Node, result2.Node)
 	}
 	// Verify that no result is forthcoming if we already have a replica.
-	_, err = a.AllocateTarget(multiDCConfig.ReplicaAttrs[1], []proto.Replica{
+	_, err = a.allocateTarget(multiDCConfig.ReplicaAttrs[1], []proto.Replica{
 		{
 			NodeID:  result2.Node.NodeID,
 			StoreID: result2.StoreID,
 		},
-	}, false)
+	}, false, nil)
 	if err == nil {
 		t.Errorf("expected error on allocation without available stores")
 	}
@@ -317,12 +317,12 @@ func TestAllocatorExistingReplica(t *testing.T) {
 	stopper, g, _, a := createTestAllocator()
 	defer stopper.Stop()
 	newStoreGossiper(g).gossipStores(sameDCStores, t)
-	result, err := a.AllocateTarget(multiDisksConfig.ReplicaAttrs[1], []proto.Replica{
+	result, err := a.allocateTarget(multiDisksConfig.ReplicaAttrs[1], []proto.Replica{
 		{
 			NodeID:  2,
 			StoreID: 2,
 		},
-	}, false)
+	}, false, nil)
 	if err != nil {
 		t.Fatalf("Unable to perform allocation: %v", err)
 	}
@@ -371,7 +371,7 @@ func TestAllocatorRelaxConstraints(t *testing.T) {
 		for _, id := range test.existing {
 			existing = append(existing, proto.Replica{NodeID: proto.NodeID(id), StoreID: proto.StoreID(id)})
 		}
-		result, err := a.AllocateTarget(proto.Attributes{Attrs: test.required}, existing, test.relaxConstraints)
+		result, err := a.allocateTarget(proto.Attributes{Attrs: test.required}, existing, test.relaxConstraints, nil)
 		if haveErr := (err != nil); haveErr != test.expErr {
 			t.Errorf("%d: expected error %t; got %t: %s", i, test.expErr, haveErr, err)
 		} else if err == nil && proto.StoreID(test.expID) != result.StoreID {
@@ -415,7 +415,7 @@ func TestAllocatorRandomAllocation(t *testing.T) {
 	// store 1 or store 2 will be chosen, as the least loaded of the
 	// three random choices is returned.
 	for i := 0; i < 10; i++ {
-		result, err := a.AllocateTarget(proto.Attributes{}, []proto.Replica{}, false)
+		result, err := a.allocateTarget(proto.Attributes{}, []proto.Replica{}, false, nil)
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -458,7 +458,7 @@ func TestAllocatorRebalance(t *testing.T) {
 
 	// Every rebalance target must be either stores 1 or 2.
 	for i := 0; i < 10; i++ {
-		result := a.RebalanceTarget(proto.Attributes{}, []proto.Replica{})
+		result := a.rebalanceTarget(proto.Attributes{}, []proto.Replica{})
 		if result == nil {
 			t.Fatal("nil result")
 		}
@@ -469,7 +469,7 @@ func TestAllocatorRebalance(t *testing.T) {
 
 	// Verify shouldRebalance results.
 	for i, store := range stores {
-		result := a.ShouldRebalance(store)
+		result := a.shouldRebalance(store)
 		if expResult := (i >= 2); expResult != result {
 			t.Errorf("%d: expected rebalance %t; got %t", i, expResult, result)
 		}
@@ -509,7 +509,7 @@ func TestAllocatorRebalanceByCapacity(t *testing.T) {
 
 	// Every rebalance target must be store 4 (if not nil).
 	for i := 0; i < 10; i++ {
-		result := a.RebalanceTarget(proto.Attributes{}, []proto.Replica{})
+		result := a.rebalanceTarget(proto.Attributes{}, []proto.Replica{})
 		if result != nil && result.StoreID != 4 {
 			t.Errorf("expected store 4; got %d", result.StoreID)
 		}
@@ -517,7 +517,7 @@ func TestAllocatorRebalanceByCapacity(t *testing.T) {
 
 	// Verify shouldRebalance results.
 	for i, store := range stores {
-		result := a.ShouldRebalance(store)
+		result := a.shouldRebalance(store)
 		if expResult := (i < 3); expResult != result {
 			t.Errorf("%d: expected rebalance %t; got %t", i, expResult, result)
 		}
@@ -559,7 +559,7 @@ func TestAllocatorRebalanceByCount(t *testing.T) {
 
 	// Every rebalance target must be store 4 (or nil for case of missing the only option).
 	for i := 0; i < 10; i++ {
-		result := a.RebalanceTarget(proto.Attributes{}, []proto.Replica{})
+		result := a.rebalanceTarget(proto.Attributes{}, []proto.Replica{})
 		if result != nil && result.StoreID != 4 {
 			t.Errorf("expected store 4; got %d", result.StoreID)
 		}
@@ -567,7 +567,7 @@ func TestAllocatorRebalanceByCount(t *testing.T) {
 
 	// Verify shouldRebalance results.
 	for i, store := range stores {
-		result := a.ShouldRebalance(store)
+		result := a.shouldRebalance(store)
 		if expResult := (i < 3); expResult != result {
 			t.Errorf("%d: expected rebalance %t; got %t", i, expResult, result)
 		}
@@ -631,7 +631,7 @@ func TestAllocatorRemoveTarget(t *testing.T) {
 	sg := newStoreGossiper(g)
 	sg.gossipStores(stores, t)
 
-	targetRepl, err := a.RemoveTarget(replicas)
+	targetRepl, err := a.removeTarget(replicas)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -665,7 +665,7 @@ func TestAllocatorRemoveTarget(t *testing.T) {
 	}
 	sg.gossipStores(stores, t)
 
-	targetRepl, err = a.RemoveTarget(replicas)
+	targetRepl, err = a.removeTarget(replicas)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -678,12 +678,12 @@ type testStore struct {
 	proto.StoreDescriptor
 }
 
-func (ts *testStore) Add(bytes int64) {
+func (ts *testStore) add(bytes int64) {
 	ts.Capacity.RangeCount++
 	ts.Capacity.Available -= bytes
 }
 
-func (ts *testStore) Rebalance(ots *testStore, bytes int64) {
+func (ts *testStore) rebalance(ots *testStore, bytes int64) {
 	if ts.Capacity.RangeCount == 0 || (ts.Capacity.Capacity-ts.Capacity.Available) < bytes {
 		return
 	}
@@ -718,7 +718,7 @@ func Example_rebalancing() {
 		testStores[i].Capacity = proto.StoreCapacity{Capacity: 1 << 30, Available: 1 << 30}
 	}
 	// Initialize the cluster with a single range.
-	testStores[0].Add(alloc.randGen.Int63n(1 << 20))
+	testStores[0].add(alloc.randGen.Int63n(1 << 20))
 
 	for i := 0; i < generations; i++ {
 		// First loop through test stores and add data.
@@ -726,7 +726,7 @@ func Example_rebalancing() {
 		for j := 0; j < len(testStores); j++ {
 			// Add a pretend range to the testStore if there's already one.
 			if testStores[j].Capacity.RangeCount > 0 {
-				testStores[j].Add(alloc.randGen.Int63n(1 << 20))
+				testStores[j].add(alloc.randGen.Int63n(1 << 20))
 			}
 			key := gossip.MakeStoreKey(proto.StoreID(j))
 			if err := g.AddInfoProto(key, &testStores[j].StoreDescriptor, 0); err != nil {
@@ -738,10 +738,10 @@ func Example_rebalancing() {
 		// Next loop through test stores and maybe rebalance.
 		for j := 0; j < len(testStores); j++ {
 			ts := &testStores[j]
-			if alloc.ShouldRebalance(&testStores[j].StoreDescriptor) {
-				target := alloc.RebalanceTarget(proto.Attributes{}, []proto.Replica{{NodeID: ts.Node.NodeID, StoreID: ts.StoreID}})
+			if alloc.shouldRebalance(&testStores[j].StoreDescriptor) {
+				target := alloc.rebalanceTarget(proto.Attributes{}, []proto.Replica{{NodeID: ts.Node.NodeID, StoreID: ts.StoreID}})
 				if target != nil {
-					testStores[j].Rebalance(&testStores[int(target.StoreID)], alloc.randGen.Int63n(1<<20))
+					testStores[j].rebalance(&testStores[int(target.StoreID)], alloc.randGen.Int63n(1<<20))
 				}
 			}
 		}

--- a/storage/allocator_test.go
+++ b/storage/allocator_test.go
@@ -211,12 +211,12 @@ var multiDCStores = []*proto.StoreDescriptor{
 
 // createTestAllocator creates a stopper, gossip, store pool and allocator for
 // use in tests. Stopper must be stopped by the caller.
-func createTestAllocator() (*stop.Stopper, *gossip.Gossip, *StorePool, *allocator) {
+func createTestAllocator() (*stop.Stopper, *gossip.Gossip, *StorePool, allocator) {
 	stopper := stop.NewStopper()
 	rpcContext := rpc.NewContext(&base.Context{}, hlc.NewClock(hlc.UnixNano), stopper)
 	g := gossip.New(rpcContext, gossip.TestInterval, gossip.TestBootstrap)
 	storePool := NewStorePool(g, TestTimeUntilStoreDeadOff, stopper)
-	a := newAllocator(storePool)
+	a := makeAllocator(storePool)
 	return stopper, g, storePool, a
 }
 
@@ -700,7 +700,7 @@ func Example_rebalancing() {
 	stopper := stop.NewStopper()
 	defer stopper.Stop()
 	sp := NewStorePool(g, TestTimeUntilStoreDeadOff, stopper)
-	alloc := newAllocator(sp)
+	alloc := makeAllocator(sp)
 	alloc.randGen = rand.New(rand.NewSource(0))
 	alloc.deterministic = true
 

--- a/storage/replica.go
+++ b/storage/replica.go
@@ -158,7 +158,7 @@ type rangeManager interface {
 	Clock() *hlc.Clock
 	Engine() engine.Engine
 	DB() *client.DB
-	allocator() *allocator
+	allocator() allocator
 	Gossip() *gossip.Gossip
 	splitQueue() *splitQueue
 	rangeGCQueue() *rangeGCQueue

--- a/storage/replicate_queue.go
+++ b/storage/replicate_queue.go
@@ -41,13 +41,12 @@ const (
 type replicateQueue struct {
 	*baseQueue
 	gossip    *gossip.Gossip
-	allocator *allocator
+	allocator allocator
 	clock     *hlc.Clock
 }
 
 // newReplicateQueue returns a new instance of replicateQueue.
-func newReplicateQueue(gossip *gossip.Gossip, allocator *allocator,
-	clock *hlc.Clock) *replicateQueue {
+func newReplicateQueue(gossip *gossip.Gossip, allocator allocator, clock *hlc.Clock) *replicateQueue {
 	rq := &replicateQueue{
 		gossip:    gossip,
 		allocator: allocator,

--- a/storage/replicate_queue.go
+++ b/storage/replicate_queue.go
@@ -108,7 +108,7 @@ func (rq *replicateQueue) process(now proto.Timestamp, repl *Replica) error {
 
 	// TODO(bdarnell): handle non-homogenous ReplicaAttrs.
 	// Allow constraints to be relaxed if necessary.
-	newReplica, err := rq.allocator.AllocateTarget(zone.ReplicaAttrs[0], desc.Replicas, true)
+	newReplica, err := rq.allocator.allocateTarget(zone.ReplicaAttrs[0], desc.Replicas, true, nil)
 	if err != nil {
 		return err
 	}

--- a/storage/store.go
+++ b/storage/store.go
@@ -262,7 +262,7 @@ type Store struct {
 	gcQueue        *gcQueue        // Garbage collection queue
 	_splitQueue    *splitQueue     // Range splitting queue
 	verifyQueue    *verifyQueue    // Checksum verification queue
-	replicateQueue *replicateQueue // Replication queue
+	replicateQueue replicateQueue  // Replication queue
 	_rangeGCQueue  *rangeGCQueue   // Range GC queue
 	scanner        *replicaScanner // Range scanner
 	feed           StoreEventFeed  // Event Feed
@@ -379,7 +379,7 @@ func NewStore(ctx StoreContext, eng engine.Engine, nodeDesc *proto.NodeDescripto
 	s.gcQueue = newGCQueue()
 	s._splitQueue = newSplitQueue(s.db, s.ctx.Gossip)
 	s.verifyQueue = newVerifyQueue(s.ReplicaCount)
-	s.replicateQueue = newReplicateQueue(s.ctx.Gossip, s.allocator(), s.ctx.Clock)
+	s.replicateQueue = makeReplicateQueue(s.ctx.Gossip, s.allocator(), s.ctx.Clock)
 	s._rangeGCQueue = newRangeGCQueue(s.db)
 	s.scanner.AddQueues(s.gcQueue, s._splitQueue, s.verifyQueue, s.replicateQueue, s._rangeGCQueue)
 

--- a/storage/store.go
+++ b/storage/store.go
@@ -257,7 +257,7 @@ type Store struct {
 	ctx            StoreContext
 	db             *client.DB
 	engine         engine.Engine   // The underlying key-value store
-	_allocator     *allocator      // Makes allocation decisions
+	_allocator     allocator       // Makes allocation decisions
 	rangeIDAlloc   *idAllocator    // Range ID allocator
 	gcQueue        *gcQueue        // Garbage collection queue
 	_splitQueue    *splitQueue     // Range splitting queue
@@ -367,7 +367,7 @@ func NewStore(ctx StoreContext, eng engine.Engine, nodeDesc *proto.NodeDescripto
 		ctx:            ctx,
 		db:             ctx.DB, // TODO(tschottdorf) remove redundancy.
 		engine:         eng,
-		_allocator:     newAllocator(ctx.StorePool),
+		_allocator:     makeAllocator(ctx.StorePool),
 		replicas:       map[proto.RangeID]*Replica{},
 		replicasByKey:  btree.New(64 /* degree */),
 		uninitReplicas: map[proto.RangeID]*Replica{},
@@ -948,7 +948,7 @@ func (s *Store) Engine() engine.Engine { return s.engine }
 func (s *Store) DB() *client.DB { return s.ctx.DB }
 
 // Allocator accessor.
-func (s *Store) allocator() *allocator { return s._allocator }
+func (s *Store) allocator() allocator { return s._allocator }
 
 // Gossip accessor.
 func (s *Store) Gossip() *gossip.Gossip { return s.ctx.Gossip }

--- a/storage/store_pool.go
+++ b/storage/store_pool.go
@@ -35,7 +35,7 @@ import (
 const (
 	// testTimeUntilStoreDead is the the test value for TimeUntilStoreDead to
 	// quickly mark stores as dead.
-	testTimeUntilStoreDead = 10 * time.Millisecond
+	testTimeUntilStoreDead = 5 * time.Millisecond
 
 	// TestTimeUntilStoreDeadOff is the test value for TimeUntilStoreDead that
 	// prevents the store pool from marking stores as dead.

--- a/storage/store_pool_test.go
+++ b/storage/store_pool_test.go
@@ -87,7 +87,7 @@ func TestStorePoolGossipUpdate(t *testing.T) {
 
 // waitUntilDead will block until the specified store is marked as dead.
 func waitUntilDead(t *testing.T, sp *StorePool, storeID proto.StoreID) {
-	util.SucceedsWithin(t, 3*testTimeUntilStoreDead, func() error {
+	util.SucceedsWithin(t, 10*testTimeUntilStoreDead, func() error {
 		sp.mu.RLock()
 		defer sp.mu.RUnlock()
 		store, ok := sp.stores[storeID]


### PR DESCRIPTION
- an update to the test timeouts for the store pool
- removing allocator's unneeded mutex since all unsafe code is in the store pool
- removing allocator's unused gossip
- converting the allocator to a non-pointer
- converting the replicate queue to a non-pointer
