### PR TITLE
Update etcd dependency.

### DIFF
--- a/GLOCKFILE
+++ b/GLOCKFILE
@@ -15,7 +15,7 @@ github.com/cockroachdb/c-protobuf 6a18bfcdd5169966cd1235edb71d749c950216e8
 github.com/cockroachdb/c-rocksdb 7fc876fe79b96de0e25069c9ae27e6444637bd54
 github.com/cockroachdb/c-snappy 618733f9e5bab8463b9049117a335a7a1bfc9fd5
 github.com/cockroachdb/yacc ebd0d590252fe4f6d9b5053511875810dd1f91a1
-github.com/coreos/etcd 25c87f13fdc678c1f02a34ae8ca0171ff25e764f
+github.com/coreos/etcd a94118893c184cf902122d4034defa40f0f8b324
 github.com/cpuguy83/go-md2man 71acacd42f85e5e82f70a55327789582a5200a90
 github.com/docker/docker ba019dc0d0a89b3152fc3791495af2ddf18e173d
 github.com/elazarl/go-bindata-assetfs d5cac425555ca5cf00694df246e04f05e6a55150


### PR DESCRIPTION
Fixes two nil pointer panics in raft.
