### PR TITLE
Allow a node to be removed from raft while it is the leader.

### DIFF
--- a/multiraft/clock.go
+++ b/multiraft/clock.go
@@ -61,8 +61,21 @@ func (m *manualTicker) Chan() <-chan time.Time {
 	return m.ch
 }
 
+// Tick sends a tick to MultiRaft, blocking until MultiRaft is ready
+// to receive it. Use this when it is important to send a specific
+// number of ticks.
 func (m *manualTicker) Tick() {
 	m.ch <- time.Time{}
+}
+
+// NonBlockingTick tries to send a tick to MultiRaft, silently
+// dropping it if MultiRaft is not listening. Use this when sending
+// ticks from a background thread that may race with shutdown.
+func (m *manualTicker) NonBlockingTick() {
+	select {
+	case m.ch <- time.Time{}:
+	default:
+	}
 }
 
 func (m *manualTicker) Close() { /* do nothing */ }

--- a/multiraft/multiraft_test.go
+++ b/multiraft/multiraft_test.go
@@ -432,7 +432,7 @@ func TestRemoveLeader(t *testing.T) {
 				return
 			case <-ticker.C:
 				for _, t := range cluster.tickers {
-					t.Tick()
+					t.NonBlockingTick()
 				}
 			}
 		}

--- a/multiraft/multiraft_test.go
+++ b/multiraft/multiraft_test.go
@@ -392,6 +392,78 @@ func TestMembershipChange(t *testing.T) {
 		}*/
 }
 
+// TestRemoveLeader ensures that a group will recover if a node is
+// removed from the group while it is leader. Since visibility into
+// the raft state is limited, we create a three-node group in a
+// six-node cluster. This group is migrated one node at a time from
+// the first three nodes to the last three. In the process the initial
+// leader must have removed itself.
+func TestRemoveLeader(t *testing.T) {
+	defer leaktest.AfterTest(t)
+	stopper := stop.NewStopper()
+	const clusterSize = 6
+	const groupSize = 3
+	cluster := newTestCluster(nil, clusterSize, stopper, t)
+	defer stopper.Stop()
+
+	// Consume and apply the membership change events.
+	for i := 0; i < clusterSize; i++ {
+		go func(i int) {
+			for {
+				if e, ok := <-cluster.events[i].MembershipChangeCommitted; ok {
+					e.Callback(nil)
+				} else {
+					return
+				}
+			}
+		}(i)
+	}
+
+	// Tick all the clocks in the background to ensure that all the
+	// necessary elections are triggered.
+	// TODO(bdarnell): newTestCluster should have an option to use a
+	// real clock instead of a manual one.
+	stopper.RunWorker(func() {
+		ticker := time.NewTicker(10 * time.Millisecond)
+		defer ticker.Stop()
+		for {
+			select {
+			case <-stopper.ShouldStop():
+				return
+			case <-ticker.C:
+				for _, t := range cluster.tickers {
+					t.Tick()
+				}
+			}
+		}
+	})
+
+	// Create a group with three members.
+	groupID := proto.RangeID(1)
+	cluster.createGroup(groupID, 0, groupSize)
+
+	// Move the group one node at a time from the first three nodes to
+	// the last three. In the process, we necessarily remove the leader
+	// and trigger at least one new election among the new nodes.
+	for i := 0; i < groupSize; i++ {
+		log.Infof("adding node %d", i+groupSize)
+		ch := cluster.nodes[i].ChangeGroupMembership(groupID, makeCommandID(),
+			raftpb.ConfChangeAddNode,
+			cluster.nodes[i+groupSize].nodeID, nil)
+		if err := <-ch; err != nil {
+			t.Fatal(err)
+		}
+
+		log.Infof("removing node %d", i)
+		ch = cluster.nodes[i].ChangeGroupMembership(groupID, makeCommandID(),
+			raftpb.ConfChangeRemoveNode,
+			cluster.nodes[i].nodeID, nil)
+		if err := <-ch; err != nil {
+			t.Fatal(err)
+		}
+	}
+}
+
 func TestRapidMembershipChange(t *testing.T) {
 	defer leaktest.AfterTest(t)
 	stopper := stop.NewStopper()


### PR DESCRIPTION
Previously, removed nodes would still be counted as members of the
group for purposes of coalesced heartbeats. If the node was leader
when it was removed, this would prevent any further elections in the
group (as long as the removed node was alive).

This should unblock the repair/rebalancing work, although it doesn't fix #2291. I have some more tests for this change (to be added to `storage/client_raft_test.go`) but they are blocked on @tschottdorf's batch mega-PR.
