### PR TITLE
Add Timestamp sql parameter.

### DIFF
--- a/sql/driver/wire.go
+++ b/sql/driver/wire.go
@@ -20,14 +20,15 @@ package driver
 import (
 	"fmt"
 	"strconv"
-
-	"github.com/cockroachdb/cockroach/sql/parser"
+	"time"
 )
 
 const (
 	// Endpoint is the URL path prefix which accepts incoming
 	// HTTP requests for the SQL API.
 	Endpoint = "/sql/"
+
+	timestampWithOffsetZoneFormat = "2006-01-02 15:04:05.999999999-07:00"
 )
 
 func (d Datum) String() string {
@@ -48,6 +49,8 @@ func (d Datum) String() string {
 		return string(t)
 	case *string:
 		return *t
+	case *Datum_Timestamp:
+		return time.Unix((*t).Sec, int64((*t).Nsec)).UTC().Format(timestampWithOffsetZoneFormat)
 	default:
 		panic(fmt.Sprintf("unexpected type %T", t))
 	}
@@ -61,51 +64,4 @@ func (Request) Method() Method {
 // CreateReply creates an empty response for the request.
 func (Request) CreateReply() Response {
 	return Response{}
-}
-
-// GetParameters returns the Params slice as a `parameters`.
-func (r Request) GetParameters() Parameters {
-	return Parameters(r.Params)
-}
-
-// Parameters implements the parser.Args interface.
-type Parameters []Datum
-
-// Arg implements the parser.Args interface.
-func (p Parameters) Arg(name string) (parser.Datum, bool) {
-	if len(name) == 0 {
-		// This shouldn't happen unless the parser let through an invalid parameter
-		// specification.
-		panic(fmt.Sprintf("invalid empty parameter name"))
-	}
-	if ch := name[0]; ch < '0' || ch > '9' {
-		// TODO(pmattis): Add support for named parameters (vs the numbered
-		// parameter support below).
-		return nil, false
-	}
-	i, err := strconv.ParseInt(name, 10, 0)
-	if err != nil {
-		return nil, false
-	}
-	if i < 1 || int(i) > len(p) {
-		return nil, false
-	}
-	arg := p[i-1].GetValue()
-	if arg == nil {
-		return parser.DNull, true
-	}
-	switch t := arg.(type) {
-	case *bool:
-		return parser.DBool(*t), true
-	case *int64:
-		return parser.DInt(*t), true
-	case *float64:
-		return parser.DFloat(*t), true
-	case []byte:
-		return parser.DString(t), true
-	case *string:
-		return parser.DString(*t), true
-	default:
-		panic(fmt.Sprintf("unexpected type %T", t))
-	}
 }

--- a/sql/driver/wire.proto
+++ b/sql/driver/wire.proto
@@ -29,6 +29,15 @@ option (gogoproto.goproto_unrecognized_all) = false;
 
 message Datum {
   option (gogoproto.goproto_stringer) = false;
+  
+  // Timestamp represents an absolute timestamp devoid of time-zone.
+  message Timestamp {
+    // The time in seconds since, January 1, 1970 UTC (Unix time).
+    optional int64 sec = 1 [(gogoproto.nullable) = false];
+    // nsec specifies a non-negative nanosecond offset within sec.
+    // It must be in the range [0, 999999999].
+    optional uint32 nsec = 2 [(gogoproto.nullable) = false];
+  }
 
   // Using explicit proto types provides convenient access when using json. If
   // we used a Kind+Bytes approach the json interface would involve base64
@@ -40,6 +49,10 @@ message Datum {
     double float_val = 3;
     bytes bytes_val = 4;
     string string_val = 5;
+    Timestamp time_val = 6;
+    // TODO(vivek): Add additional types like Date and Interval that are
+    // supported by Cockroach but not supported by the Go sql driver. These
+    // will be useful for drivers in other languages.
   }
 
   // TODO(pmattis): How to add end-to-end checksumming? Just adding a checksum

--- a/sql/parser/eval.go
+++ b/sql/parser/eval.go
@@ -929,6 +929,9 @@ func init() {
 	cmpOps[cmpArgs{In, intType, tupleType}] = evalTupleIN
 	cmpOps[cmpArgs{In, floatType, tupleType}] = evalTupleIN
 	cmpOps[cmpArgs{In, stringType, tupleType}] = evalTupleIN
+	cmpOps[cmpArgs{In, dateType, tupleType}] = evalTupleIN
+	cmpOps[cmpArgs{In, timestampType, tupleType}] = evalTupleIN
+	cmpOps[cmpArgs{In, intervalType, tupleType}] = evalTupleIN
 	cmpOps[cmpArgs{In, tupleType, tupleType}] = evalTupleIN
 }
 
@@ -1475,6 +1478,10 @@ func evalCastExpr(expr *CastExpr) (Datum, error) {
 			// TODO(vivek): we might consider using the postgres format as well.
 			d, err := time.ParseDuration(string(d.(DString)))
 			return DInterval{Duration: d}, err
+
+		case DInt:
+			// An integer duration represents a duration in nanoseconds.
+			return DInterval{Duration: time.Duration(d.(DInt))}, nil
 		}
 		// TODO(pmattis): unimplemented.
 		// case *DecimalType:

--- a/sql/parser/eval_test.go
+++ b/sql/parser/eval_test.go
@@ -136,6 +136,9 @@ func TestEvalExpr(t *testing.T) {
 		{`1 NOT IN (2, 3, 4)`, `true`},
 		{`1+1 IN (2, 3, 4)`, `true`},
 		{`'a0' IN ('a'||0::char, 'b'||1::char, 'c'||2::char)`, `true`},
+		{`'2012-09-21'::date IN ('2012-09-21'::date)`, `true`},
+		{`'2010-09-28 12:00:00.1'::timestamp IN ('2010-09-28 12:00:00.1'::timestamp)`, `true`},
+		{`'34h'::interval IN ('34h'::interval)`, `true`},
 		{`(1,2) IN ((0+1,1+1), (3,4), (5,6))`, `true`},
 		// Func expressions.
 		{`length('hel'||'lo')`, `5`},
@@ -187,6 +190,7 @@ func TestEvalExpr(t *testing.T) {
 		{`'2010-09-28 12:00:00.1-07:00'::timestamp`, `2010-09-28 19:00:00.1+00:00`},
 		{`('2010-09-28'::date)::timestamp`, `2010-09-28 00:00:00+00:00`},
 		{`'12h2m1s23ms'::interval`, `12h2m1.023s`},
+		{`1::interval`, `1ns`},
 		{`'2010-09-28'::date + '12h2m'::interval`, `2010-09-28 12:02:00+00:00`},
 		{`'12h2m'::interval + '2010-09-28'::date`, `2010-09-28 12:02:00+00:00`},
 		{`'2010-09-28'::date - '12h2m'::interval`, `2010-09-27 11:58:00+00:00`},

--- a/sql/parser/type_check.go
+++ b/sql/parser/type_check.go
@@ -458,7 +458,7 @@ func typeCheckCastExpr(expr *CastExpr) (Datum, error) {
 
 	case *IntervalType:
 		switch dummyExpr {
-		case DummyString:
+		case DummyString, DummyInt:
 			return DummyInterval, nil
 		}
 

--- a/sql/parser/type_check_test.go
+++ b/sql/parser/type_check_test.go
@@ -65,7 +65,6 @@ func TestTypeCheckExprError(t *testing.T) {
 		{`1::decimal`, `invalid cast: int -> DECIMAL`},
 		{`1::date`, `invalid cast: int -> DATE`},
 		{`1::timestamp`, `invalid cast: int -> TIMESTAMP`},
-		{`1::interval`, `invalid cast: int -> INTERVAL`},
 		{`CASE 'one' WHEN 1 THEN 1 WHEN 'two' THEN 2 END`, `incompatible condition type`},
 		{`CASE 1 WHEN 1 THEN 'one' WHEN 2 THEN 2 END`, `incompatible value type`},
 		{`CASE 1 WHEN 1 THEN 'one' ELSE 2 END`, `incompatible value type`},


### PR DESCRIPTION
Allow casting of integer to interval type.

Get rid of sql/driver -> sql/parser dependency.

Fixes #2328.
