### PR TITLE
Make TestEncodeDecodeTime pass with go 1.4

### DIFF
--- a/util/encoding/encoding_test.go
+++ b/util/encoding/encoding_test.go
@@ -651,7 +651,7 @@ func TestEncodeDecodeTime(t *testing.T) {
 	// zeroTime. The positive, increasing, duration offsets are automatically
 	// genarated below.
 	testCases := []string{
-		"-1345600h45m34s234ms",
+		"-134560h45m34s234ms0ns",
 		"-600h45m34s234ms",
 		"-590h47m34s234ms",
 		"-310h45m34s234ms",
@@ -705,7 +705,7 @@ func TestEncodeDecodeTime(t *testing.T) {
 	}
 
 	// Check that the encoding hasn't changed.
-	if a, e := lastEncoded, []byte("\x0e\x01 \xbc\x0e\xae\r\r\xf2\x8e\x80"); !bytes.Equal(a, e) {
+	if a, e := lastEncoded, []byte("\r\x1cߤ\xae\r\r\xf2\x8e\x80"); !bytes.Equal(a, e) {
 		t.Errorf("encoding has changed:\nexpected %q\nactual %q", e, a)
 	}
 }


### PR DESCRIPTION
I haven't looked into details, but it seems `time.ParseDuration()` returns different values between go 1.4 and go 1.5. For example,
- in go 1.4, time.ParseDuration("1000000h1ms") returns 1000000h0m0.000999936s.
- in go 1.5, the same method call returns 1000000h0m0.001s.

There might be a better way to fix, but using a smaller value in the test fixes the problem.
