### PR TITLE
Simplify AND-IN expressions.

### DIFF
--- a/sql/analyze_test.go
+++ b/sql/analyze_test.go
@@ -309,6 +309,10 @@ func TestSimplifyAndExprCheck(t *testing.T) {
 		{`a = 1 AND a <= 1`, `a = 1`, true},
 		{`a = 1 AND a <= 2`, `a = 1`, true},
 		{`a = 2 AND a <= 1`, `false`, true},
+		{`a = 1 AND a IN (1)`, `a = 1`, true},
+		{`a = 1 AND a IN (2)`, `false`, true},
+		{`a = 2 AND a IN (1)`, `false`, true},
+		{`a = 2 AND a IN (0, 1, 2, 3, 4)`, `a = 2`, true},
 
 		{`a != 1 AND a = 1`, `false`, true},
 		{`a != 1 AND a = 2`, `a = 2`, true},
@@ -347,6 +351,10 @@ func TestSimplifyAndExprCheck(t *testing.T) {
 		{`a > 1 AND a <= 1`, `false`, true},
 		{`a > 1 AND a <= 2`, `a > 1 AND a <= 2`, true},
 		{`a > 2 AND a <= 1`, `false`, true},
+		{`a > 1 AND a IN (1)`, `false`, true},
+		{`a > 1 AND a IN (2)`, `a IN (2)`, true},
+		{`a > 2 AND a IN (1)`, `false`, true},
+		{`a > 2 AND a IN (0, 1, 2, 3, 4)`, `a IN (3, 4)`, true},
 
 		{`a >= 1 AND a = 1`, `a = 1`, true},
 		{`a >= 1 AND a = 2`, `a = 2`, true},
@@ -366,6 +374,10 @@ func TestSimplifyAndExprCheck(t *testing.T) {
 		{`a >= 1 AND a <= 1`, `a = 1`, true},
 		{`a >= 1 AND a <= 2`, `a >= 1 AND a <= 2`, true},
 		{`a >= 2 AND a <= 1`, `false`, true},
+		{`a >= 1 AND a IN (1)`, `a IN (1)`, true},
+		{`a >= 1 AND a IN (2)`, `a IN (2)`, true},
+		{`a >= 2 AND a IN (1)`, `false`, true},
+		{`a >= 2 AND a IN (0, 1, 2, 3, 4)`, `a IN (2, 3, 4)`, true},
 
 		{`a < 1 AND a = 1`, `false`, true},
 		{`a < 1 AND a = 2`, `false`, true},
@@ -385,6 +397,10 @@ func TestSimplifyAndExprCheck(t *testing.T) {
 		{`a < 1 AND a <= 1`, `a < 1`, true},
 		{`a < 1 AND a <= 2`, `a < 1`, true},
 		{`a < 2 AND a <= 1`, `a <= 1`, true},
+		{`a < 1 AND a IN (1)`, `false`, true},
+		{`a < 1 AND a IN (2)`, `false`, true},
+		{`a < 2 AND a IN (1)`, `a IN (1)`, true},
+		{`a < 2 AND a IN (0, 1, 2, 3, 4)`, `a IN (0, 1)`, true},
 
 		{`a <= 1 AND a = 1`, `a = 1`, true},
 		{`a <= 1 AND a = 2`, `false`, true},
@@ -404,6 +420,17 @@ func TestSimplifyAndExprCheck(t *testing.T) {
 		{`a <= 1 AND a <= 1`, `a <= 1`, true},
 		{`a <= 1 AND a <= 2`, `a <= 1`, true},
 		{`a <= 2 AND a <= 1`, `a <= 1`, true},
+		{`a <= 1 AND a IN (1)`, `a IN (1)`, true},
+		{`a <= 1 AND a IN (2)`, `false`, true},
+		{`a <= 2 AND a IN (1)`, `a IN (1)`, true},
+		{`a <= 2 AND a IN (0, 1, 2, 3, 4)`, `a IN (0, 1, 2)`, true},
+
+		{`a IN (1) AND a IN (1)`, `a IN (1)`, true},
+		{`a IN (1) AND a IN (2)`, `false`, true},
+		{`a IN (2) AND a IN (1)`, `false`, true},
+		{`a IN (1) AND a IN (1, 2, 3, 4, 5)`, `a IN (1)`, true},
+		{`a IN (2, 4) AND a IN (1, 2, 3, 4, 5)`, `a IN (2, 4)`, true},
+		{`a IN (4, 2) AND a IN (5, 4, 3, 2, 1)`, `a IN (2, 4)`, true},
 	}
 	for _, d := range testData {
 		expr1, qvals := parseAndNormalizeExpr(t, d.expr)

--- a/sql/select_test.go
+++ b/sql/select_test.go
@@ -69,17 +69,10 @@ func TestMakeConstraints(t *testing.T) {
 		{`a IN (1,2,3) AND b = 1`, []string{"a", "b"}, `[a IN (1, 2, 3), b = 1]`},
 		{`a = 1 AND b IN (1,2,3)`, []string{"a", "b"}, `[a = 1, b IN (1, 2, 3)]`},
 
-		// Prefer IN over >, <, >= and <=.
-		{`a > 1 AND a IN (1, 2)`, []string{"a"}, `[a IN (1, 2)]`},
-		{`a >= 1 AND a IN (1, 2)`, []string{"a"}, `[a IN (1, 2)]`},
-		{`a < 1 AND a IN (1, 2)`, []string{"a"}, `[a IN (1, 2)]`},
-		{`a <= 1 AND a IN (1, 2)`, []string{"a"}, `[a IN (1, 2)]`},
-		{`a IN (1, 2) AND a > 1`, []string{"a"}, `[a IN (1, 2)]`},
-		{`a IN (1, 2) AND a >= 1`, []string{"a"}, `[a IN (1, 2)]`},
-		{`a IN (1, 2) AND a < 1`, []string{"a"}, `[a IN (1, 2)]`},
-		{`a IN (1, 2) AND a <= 1`, []string{"a"}, `[a IN (1, 2)]`},
-
 		// Prefer EQ over IN.
+		//
+		// TODO(pmattis): We could conceivably propagate the "a = 1" down to the IN
+		// expression and simplify. Doesn't seem worth it at this time.
 		{`a = 1 AND (a, b) IN ((1, 2))`, []string{"a", "b"}, `[a = 1]`},
 		{`(a, b) IN ((1, 2)) AND a = 1`, []string{"a", "b"}, `[a = 1]`},
 


### PR DESCRIPTION
Simplify expressions of the form "a = 1 AND a IN (1, 2, 3)".

Fixes #2358.
