### PR TITLE
Support the "<type> <str>" syntax.

### DIFF
--- a/sql/parser/parse_test.go
+++ b/sql/parser/parse_test.go
@@ -327,6 +327,15 @@ func TestParse2(t *testing.T) {
 	}{
 		{`CREATE INDEX ON a (b ASC, c DESC)`, `CREATE INDEX ON a (b, c)`},
 
+		{`SELECT BOOL 'foo'`, `SELECT CAST('foo' AS BOOL)`},
+		{`SELECT INT 'foo'`, `SELECT CAST('foo' AS INT)`},
+		{`SELECT REAL 'foo'`, `SELECT CAST('foo' AS REAL)`},
+		{`SELECT DECIMAL 'foo'`, `SELECT CAST('foo' AS DECIMAL)`},
+		{`SELECT DATE 'foo'`, `SELECT CAST('foo' AS DATE)`},
+		{`SELECT TIMESTAMP 'foo'`, `SELECT CAST('foo' AS TIMESTAMP)`},
+		{`SELECT INTERVAL 'foo'`, `SELECT CAST('foo' AS INTERVAL)`},
+		{`SELECT CHAR 'foo'`, `SELECT CAST('foo' AS CHAR)`},
+
 		{`SELECT 0xf0 FROM t`, `SELECT 240 FROM t`},
 		{`SELECT 0xF0 FROM t`, `SELECT 240 FROM t`},
 		// Escaped string literals are not always escaped the same because

--- a/sql/parser/sql.go
+++ b/sql/parser/sql.go
@@ -914,7 +914,7 @@ const sqlEofCode = 1
 const sqlErrCode = 2
 const sqlMaxDepth = 200
 
-//line sql.y:4011
+//line sql.y:4022
 
 //line yacctab:1
 var sqlExca = [...]int{
@@ -10443,52 +10443,57 @@ sqldefault:
 		}
 	case 863:
 		sqlDollar = sqlS[sqlpt-2 : sqlpt+1]
-		//line sql.y:3505
+		//line sql.y:3506
 		{
+			sqlVAL.expr = &CastExpr{Expr: StrVal(sqlDollar[2].str), Type: sqlDollar[1].colType}
 		}
 	case 864:
 		sqlDollar = sqlS[sqlpt-3 : sqlpt+1]
-		//line sql.y:3506
+		//line sql.y:3510
 		{
+			// TODO(pmattis): support opt_interval?
+			sqlVAL.expr = &CastExpr{Expr: StrVal(sqlDollar[2].str), Type: sqlDollar[1].colType}
 		}
 	case 865:
 		sqlDollar = sqlS[sqlpt-5 : sqlpt+1]
-		//line sql.y:3507
+		//line sql.y:3515
 		{
+			// TODO(pmattis): Support the precision specification?
+			sqlVAL.expr = &CastExpr{Expr: StrVal(sqlDollar[5].str), Type: sqlDollar[1].colType}
 		}
 	case 866:
 		sqlDollar = sqlS[sqlpt-1 : sqlpt+1]
-		//line sql.y:3509
+		//line sql.y:3520
 		{
 			sqlVAL.expr = BoolVal(true)
 		}
 	case 867:
 		sqlDollar = sqlS[sqlpt-1 : sqlpt+1]
-		//line sql.y:3513
+		//line sql.y:3524
 		{
 			sqlVAL.expr = BoolVal(false)
 		}
 	case 868:
 		sqlDollar = sqlS[sqlpt-1 : sqlpt+1]
-		//line sql.y:3517
+		//line sql.y:3528
 		{
 			sqlVAL.expr = DNull
 		}
 	case 870:
 		sqlDollar = sqlS[sqlpt-2 : sqlpt+1]
-		//line sql.y:3524
+		//line sql.y:3535
 		{
 			sqlVAL.ival = +sqlDollar[2].ival
 		}
 	case 871:
 		sqlDollar = sqlS[sqlpt-2 : sqlpt+1]
-		//line sql.y:3528
+		//line sql.y:3539
 		{
 			sqlVAL.ival = -sqlDollar[2].ival
 		}
 	case 876:
 		sqlDollar = sqlS[sqlpt-0 : sqlpt+1]
-		//line sql.y:3550
+		//line sql.y:3561
 		{
 			sqlVAL.str = ""
 		}

--- a/sql/parser/sql.y
+++ b/sql/parser/sql.y
@@ -3502,9 +3502,20 @@ a_expr_const:
     $$ = StrVal($1)
   }
 | func_name '(' expr_list opt_sort_clause ')' SCONST {}
-| const_typename SCONST {}
-| const_interval SCONST opt_interval {}
-| const_interval '(' ICONST ')' SCONST {}
+| const_typename SCONST
+  {
+    $$ = &CastExpr{Expr: StrVal($2), Type: $1}
+  }
+| const_interval SCONST opt_interval
+  {
+    // TODO(pmattis): support opt_interval?
+    $$ = &CastExpr{Expr: StrVal($2), Type: $1}
+  }
+| const_interval '(' ICONST ')' SCONST
+  {
+    // TODO(pmattis): Support the precision specification?
+    $$ = &CastExpr{Expr: StrVal($5), Type: $1}
+  }
 | TRUE
   {
     $$ = BoolVal(true)


### PR DESCRIPTION
An expression like "DATE 'foo'" is translated by the parser into
"CAST('foo' AS DATE)". Unlike the general CAST syntax, only a string
constant is allowed, effectively making these expressions literals of
specific types.

Fixes #2330.
