### PR TITLE
Fix UPDATE where the SET expression contains a qualified name.

### DIFF
--- a/sql/testdata/update
+++ b/sql/testdata/update
@@ -18,6 +18,17 @@ SELECT * FROM kv
 5 6
 7 8
 
+statement ok
+UPDATE kv SET v = k + v
+
+query II
+SELECT * FROM kv
+----
+1 10
+3 12
+5 11
+7 15
+
 statement error column "m" does not exist
 UPDATE kv SET m = 9 WHERE k IN (1, 3)
 


### PR DESCRIPTION
We now use SELECT to render the update values for each row. This allows
statements like "UPDATE t SET v = v + 1" to work.

Fixes #2369.
