### PR TITLE
sql/driver: misc cleanup

### DIFF
--- a/sql/driver/driver.go
+++ b/sql/driver/driver.go
@@ -26,17 +26,17 @@ import (
 	"github.com/cockroachdb/cockroach/util"
 )
 
+var _ driver.Driver = roachDriver{}
+
 func init() {
-	sql.Register("cockroach", &roachDriver{})
+	sql.Register("cockroach", roachDriver{})
 }
 
 // roachDriver implements the database/sql/driver.Driver interface. Named
 // roachDriver so as not to conflict with the "driver" package name.
 type roachDriver struct{}
 
-var _ driver.Driver = &roachDriver{}
-
-func (d *roachDriver) Open(dsn string) (driver.Conn, error) {
+func (roachDriver) Open(dsn string) (driver.Conn, error) {
 	u, err := url.Parse(dsn)
 	if err != nil {
 		return nil, err

--- a/sql/driver/result.go
+++ b/sql/driver/result.go
@@ -17,6 +17,10 @@
 
 package driver
 
+import "database/sql/driver"
+
+var _ driver.Result = result{}
+
 // TODO(pmattis): Currently unused, but will be needed when we support
 // LastInsertId.
 type result struct {
@@ -24,10 +28,10 @@ type result struct {
 	rowsAffected int64
 }
 
-func (r *result) LastInsertId() (int64, error) {
+func (r result) LastInsertId() (int64, error) {
 	return r.lastInsertID, nil
 }
 
-func (r *result) RowsAffected() (int64, error) {
+func (r result) RowsAffected() (int64, error) {
 	return r.rowsAffected, nil
 }

--- a/sql/driver/rows.go
+++ b/sql/driver/rows.go
@@ -22,26 +22,12 @@ import (
 	"io"
 )
 
-type row []driver.Value
+var _ driver.Rows = &rows{}
 
 type rows struct {
 	columns []string
-	rows    []row
+	rows    [][]driver.Value
 	pos     int // Next iteration index into rows.
-}
-
-// newSingleColumnRows returns a rows structure initialized with a single
-// column of values using the specified column name and values. This is a
-// convenience routine used by operations which return only a single column.
-func newSingleColumnRows(column string, vals []string) *rows {
-	r := make([]row, len(vals))
-	for i, v := range vals {
-		r[i] = row{v}
-	}
-	return &rows{
-		columns: []string{column},
-		rows:    r,
-	}
 }
 
 func (r *rows) Columns() []string {

--- a/sql/driver/stmt.go
+++ b/sql/driver/stmt.go
@@ -19,24 +19,26 @@ package driver
 
 import "database/sql/driver"
 
+var _ driver.Stmt = stmt{}
+
 type stmt struct {
 	conn *conn
 	stmt string
 }
 
-func (s *stmt) Close() error {
+func (stmt) Close() error {
 	return nil
 }
 
-func (s *stmt) NumInput() int {
+func (stmt) NumInput() int {
 	// TODO(pmattis): Count the number of parameters.
 	return -1
 }
 
-func (s *stmt) Exec(args []driver.Value) (driver.Result, error) {
+func (s stmt) Exec(args []driver.Value) (driver.Result, error) {
 	return s.conn.Exec(s.stmt, args)
 }
 
-func (s *stmt) Query(args []driver.Value) (driver.Rows, error) {
+func (s stmt) Query(args []driver.Value) (driver.Rows, error) {
 	return s.conn.Query(s.stmt, args)
 }

--- a/sql/driver/tx.go
+++ b/sql/driver/tx.go
@@ -17,16 +17,20 @@
 
 package driver
 
+import "database/sql/driver"
+
+var _ driver.Tx = tx{}
+
 type tx struct {
 	conn *conn
 }
 
-func (t *tx) Commit() error {
+func (t tx) Commit() error {
 	_, err := t.conn.Exec("COMMIT TRANSACTION", nil)
 	return err
 }
 
-func (t *tx) Rollback() error {
+func (t tx) Rollback() error {
 	_, err := t.conn.Exec("ROLLBACK TRANSACTION", nil)
 	return err
 }

--- a/sql/driver/wire_test.go
+++ b/sql/driver/wire_test.go
@@ -19,47 +19,33 @@ package driver
 
 import (
 	"testing"
+	"time"
 
 	"github.com/cockroachdb/cockroach/util/leaktest"
 )
-
-func dBool(v bool) Datum {
-	return Datum{BoolVal: &v}
-}
-
-func dInt(v int64) Datum {
-	return Datum{IntVal: &v}
-}
-
-func dFloat(v float64) Datum {
-	return Datum{FloatVal: &v}
-}
-
-func dBytes(v []byte) Datum {
-	return Datum{BytesVal: v}
-}
-
-func dString(v string) Datum {
-	return Datum{StringVal: &v}
-}
 
 func TestDatumString(t *testing.T) {
 	defer leaktest.AfterTest(t)
 
 	testData := []struct {
-		datum    Datum
+		value    interface{}
 		expected string
 	}{
-		{Datum{}, "NULL"},
-		{dBool(false), "false"},
-		{dBool(true), "true"},
-		{dInt(-2), "-2"},
-		{dFloat(4.5), "4.5"},
-		{dBytes([]byte("6")), "6"},
-		{dString("hello"), "hello"},
+		{nil, "NULL"},
+		{false, "false"},
+		{true, "true"},
+		{int64(-2), "-2"},
+		{float64(4.5), "4.5"},
+		{[]byte("6"), "6"},
+		{"hello", "hello"},
+		{time.Date(2015, 9, 6, 2, 19, 36, 342, time.UTC), "2015-09-06 02:19:36.000000342 +0000 UTC"},
 	}
 	for i, d := range testData {
-		s := d.datum.String()
+		datum, err := makeDatum(d.value)
+		if err != nil {
+			t.Fatal(err)
+		}
+		s := datum.String()
 		if d.expected != s {
 			t.Errorf("%d: expected %s, but got %s", i, d.expected, s)
 		}


### PR DESCRIPTION
- sql/driver/conn.go: variable renaming
- sql/driver/conn.go: small refactoring
- sql/driver/conn.go: avoid copying a slice
- static interface implementation assertions
- sql/driver.Parameters -> sql.parameters
- sql/driver.Value implements `driver.Valuer`
