### PR TITLE
Fix TODOs about Subquery and ExistsExpr in WalkExpr.

### DIFF
--- a/sql/analyze.go
+++ b/sql/analyze.go
@@ -96,7 +96,7 @@ func simplifyExpr(e parser.Expr) parser.Expr {
 		return simplifyOrExpr(t)
 	case *parser.ComparisonExpr:
 		return simplifyComparisonExpr(t)
-	case *qvalue:
+	case *qvalue, parser.DBool:
 		return e
 	}
 	// We don't know how to simplify expressions that fall through to here, so

--- a/sql/analyze_test.go
+++ b/sql/analyze_test.go
@@ -150,6 +150,9 @@ func TestSimplifyExpr(t *testing.T) {
 		expr     string
 		expected string
 	}{
+		{`true`, `true`},
+		{`false`, `false`},
+
 		{`f`, `f`},
 		{`f AND g`, `f AND g`},
 		{`f OR g`, `f OR g`},

--- a/sql/bank_test.go
+++ b/sql/bank_test.go
@@ -95,7 +95,7 @@ CREATE TABLE IF NOT EXISTS bank.accounts (
 			update := `
 UPDATE bank.accounts
   SET balance = CASE id WHEN $1 THEN balance-$3 WHEN $2 THEN balance+$3 END
-  WHERE id IN ($1, $2)
+  WHERE id IN ($1, $2) AND true IN (SELECT balance >= $3 FROM bank.accounts WHERE id = $1)
 `
 			if _, err = db.Exec(update, from, to, amount); err != nil {
 				if log.V(1) {

--- a/sql/parser/walk.go
+++ b/sql/parser/walk.go
@@ -67,7 +67,7 @@ func WalkExpr(v Visitor, expr Expr) Expr {
 		t.Expr = WalkExpr(v, t.Expr)
 
 	case *ExistsExpr:
-		// TODO(pmattis): Should we recurse into the Subquery?
+		WalkStmt(v, t.Subquery.Select)
 
 	case BytesVal:
 		// Terminal node: nothing to do.
@@ -112,7 +112,7 @@ func WalkExpr(v Visitor, expr Expr) Expr {
 		// Terminal node: nothing to do.
 
 	case *Subquery:
-		// TODO(pmattis): Should we recurse into the Subquery?
+		WalkStmt(v, t.Select)
 
 	case *BinaryExpr:
 		t.Left = WalkExpr(v, t.Left)

--- a/sql/parser/walk_test.go
+++ b/sql/parser/walk_test.go
@@ -80,6 +80,8 @@ func TestFillArgs(t *testing.T) {
 		{`length($1, $2)`, `length('a', 'b')`, mapArgs{`1`: DString("a"), `2`: DString("b")}},
 		{`CAST($1 AS INT)`, `CAST(1.1 AS INT)`, mapArgs{`1`: DFloat(1.1)}},
 		{`ROW($1, $2, $3)`, `ROW(1, 2, '3')`, mapArgs{`1`: DInt(1), `2`: DInt(2), `3`: DString("3")}},
+		{`(SELECT $1)`, `(SELECT 'a')`, mapArgs{`1`: DString("a")}},
+		{`EXISTS (SELECT $1)`, `EXISTS (SELECT 'a')`, mapArgs{`1`: DString("a")}},
 	}
 
 	for _, d := range testData {

--- a/sql/select.go
+++ b/sql/select.go
@@ -174,6 +174,16 @@ func (p *planner) selectIndex(s *scanNode, ordering []int) (planNode, error) {
 			log.Infof("analyzeExpr: %s -> %s", s.filter, exprs)
 		}
 
+		// Check to see if the filter simplified to a constant.
+		if len(exprs) == 1 && len(exprs[0]) == 1 {
+			if d, ok := exprs[0][0].(parser.DBool); ok && bool(!d) {
+				// The expression simplified to false.
+				s.desc = nil
+				s.index = nil
+				return s, nil
+			}
+		}
+
 		// TODO(pmattis): If "len(exprs) > 1" then we have multiple disjunctive
 		// expressions. For example, "a=1 OR a=3" will get translated into "[[a=1],
 		// [a=3]]". We need to perform index selection independently for each of

--- a/sql/testdata/select_index
+++ b/sql/testdata/select_index
@@ -187,3 +187,8 @@ query ITTB
 EXPLAIN (DEBUG) SELECT * FROM t@ab WHERE a + 1 = 4
 ----
 0 /t/ab/3/4 NULL true
+
+query ITTB
+EXPLAIN SELECT * FROM t WHERE a = 1 AND false
+----
+0 scan -


### PR DESCRIPTION
Fixed a bug in simplifyExpr where the expression "false" would simplify to
"true".

Added handling of "constant" filter expressions to index selection. If
the filter expression is the constant "false", we avoid scanning the
table.

Update the SQL used in the bank example and benchmark to only allow
transfers when a non-negative balance would result.
