### PR TITLE
Fix EncodeFloat.

### DIFF
--- a/util/encoding/float.go
+++ b/util/encoding/float.go
@@ -119,7 +119,7 @@ func DecodeFloat(buf []byte, tmp []byte) ([]byte, float64) {
 		e, m := decodeLargeNumber(false, buf[:idx+1], tmp)
 		return buf[idx+1:], makeFloatFromMandE(false, e, m, tmp)
 	case buf[0] >= 0x17 && buf[0] < 0x22:
-		// Positive large.
+		// Positive medium.
 		e, m := decodeMediumNumber(false, buf[:idx+1], tmp)
 		return buf[idx+1:], makeFloatFromMandE(false, e, m, tmp)
 	case buf[0] == 0x16:
@@ -154,7 +154,7 @@ func floatMandE(b []byte, f float64) (int, []byte) {
 	// Use strconv.FormatFloat to handle the intricacies of determining how much
 	// precision is necessary to precisely represent f. The 'e' format is
 	// d.dddde±dd.
-	b = strconv.AppendFloat(b, f, 'e', -1, 64)
+	b = strconv.AppendFloat(b[len(b):], f, 'e', -1, 64)
 	if len(b) < 4 {
 		// The formatted float must be at least 4 bytes ("1e+0") or something
 		// unexpected has occurred.

--- a/util/encoding/float_test.go
+++ b/util/encoding/float_test.go
@@ -146,6 +146,12 @@ func TestEncodeFloat(t *testing.T) {
 			t.Errorf("unexpected mismatch for %v. got %v", c.Value, dec)
 		}
 	}
+
+	// Test that appending the float to an existing buffer works.
+	enc := EncodeFloat([]byte("hello"), 1.23)
+	if _, dec := DecodeFloat(enc[5:], nil); dec != 1.23 {
+		t.Errorf("unexpected mismatch for %v. got %v", 1.23, dec)
+	}
 }
 
 func BenchmarkEncodeFloat(b *testing.B) {


### PR DESCRIPTION
Previous optimization work broke encoding to a non-empty buffer. This
showed up in the full sqllogictests.
