### PR TITLE
sql: malformed transactions ops return errors

### DIFF
--- a/sql/server.go
+++ b/sql/server.go
@@ -33,6 +33,7 @@ import (
 )
 
 var errTransactionAborted = errors.New("current transaction is aborted, commands ignored until end of transaction block")
+var errTransactionInProgress = errors.New("there is already a transaction in progress")
 
 type server struct {
 	db client.DB
@@ -99,20 +100,23 @@ func (s server) execStmts(sql string, params parameters, planMaker *planner) dri
 
 func (s server) execStmt(stmt parser.Statement, params parameters, planMaker *planner) (driver.Result, error) {
 	var result driver.Result
-	if planMaker.txn == nil {
-		if _, ok := stmt.(*parser.BeginTransaction); ok {
-			// Start a transaction here and not in planMaker to prevent begin
-			// transaction from being called within an auto-transaction below.
-			planMaker.txn = client.NewTxn(s.db)
-			planMaker.txn.SetDebugName("sql", 0)
+	switch stmt.(type) {
+	case *parser.BeginTransaction:
+		if planMaker.txn != nil {
+			return result, errTransactionInProgress
 		}
-	} else if planMaker.txn.Proto.Status == proto.ABORTED {
-		switch stmt.(type) {
-		case *parser.CommitTransaction, *parser.RollbackTransaction:
+		// Start a transaction here and not in planMaker to prevent begin
+		// transaction from being called within an auto-transaction below.
+		planMaker.txn = client.NewTxn(s.db)
+		planMaker.txn.SetDebugName("sql", 0)
+	case *parser.CommitTransaction, *parser.RollbackTransaction:
+		if planMaker.txn != nil && planMaker.txn.Proto.Status == proto.ABORTED {
 			// Reset to allow starting a new transaction.
 			planMaker.txn = nil
 			return result, nil
-		default:
+		}
+	default:
+		if planMaker.txn != nil && planMaker.txn.Proto.Status == proto.ABORTED {
 			return result, errTransactionAborted
 		}
 	}

--- a/sql/testdata/txn
+++ b/sql/testdata/txn
@@ -131,7 +131,7 @@ SELECT * FROM kv
 ----
 a c
 
-# Ignore BEGIN in the middle of a transaction.
+# BEGIN in the middle of a transaction is an error.
 
 statement ok
 BEGIN TRANSACTION
@@ -139,16 +139,15 @@ BEGIN TRANSACTION
 statement ok
 UPDATE kv SET v = 'b' WHERE k in ('a')
 
-statement ok
+statement error there is already a transaction in progress
 BEGIN TRANSACTION
 
-query TT
+statment error current transaction is aborted, commands ignored until end of transaction block
 SELECT * FROM kv
 ----
-a b
 
 statement ok
-COMMIT TRANSACTION
+ROLLBACK TRANSACTION
 
 # An empty transaction is allowed.
 

--- a/sql/testdata/txn
+++ b/sql/testdata/txn
@@ -61,14 +61,6 @@ SELECT * FROM kv
 ----
 a c
 
-statement ok
-COMMIT TRANSACTION
-
-query TT
-SELECT * FROM kv
-----
-a c
-
 # Statement execution should not depend on request boundaries.
 
 statement ok
@@ -154,10 +146,10 @@ ROLLBACK TRANSACTION
 statement ok
 BEGIN; COMMIT
 
-# Commit/ROLLBACK is ignored when no transaction is in progress.
+# COMMIT/ROLLBACK without a transaction are errors.
 
-statement ok
+statement error there is no transaction in progress
 COMMIT TRANSACTION
 
-statement ok
+statement error there is no transaction in progress
 ROLLBACK TRANSACTION


### PR DESCRIPTION
Normally I'd file an issue, but I had already done this work while chasing other bugs. What do we think? Postgres issues warnings, while mysql happily ignores these cases.
