### PR TITLE
Fix subquery handling.

### DIFF
--- a/examples/sql_bank/main.go
+++ b/examples/sql_bank/main.go
@@ -56,7 +56,7 @@ func moveMoney(db *sql.DB) {
 			update := `
 UPDATE bank.accounts
   SET balance = CASE id WHEN $1 THEN balance-$3 WHEN $2 THEN balance+$3 END
-  WHERE id IN ($1, $2) AND true IN (SELECT balance >= $3 FROM bank.accounts WHERE id = $1)
+  WHERE id IN ($1, $2) AND (SELECT balance >= $3 FROM bank.accounts WHERE id = $1)
 `
 			if _, err := db.Exec(update, from, to, amount); err != nil {
 				if log.V(1) {

--- a/sql/bank_test.go
+++ b/sql/bank_test.go
@@ -95,7 +95,7 @@ CREATE TABLE IF NOT EXISTS bank.accounts (
 			update := `
 UPDATE bank.accounts
   SET balance = CASE id WHEN $1 THEN balance-$3 WHEN $2 THEN balance+$3 END
-  WHERE id IN ($1, $2) AND true IN (SELECT balance >= $3 FROM bank.accounts WHERE id = $1)
+  WHERE id IN ($1, $2) AND (SELECT balance >= $3 FROM bank.accounts WHERE id = $1)
 `
 			if _, err = db.Exec(update, from, to, amount); err != nil {
 				if log.V(1) {

--- a/sql/parser/normalize.go
+++ b/sql/parser/normalize.go
@@ -240,7 +240,7 @@ func (v *normalizeVisitor) normalizeComparisonExpr(n *ComparisonExpr) (Visitor, 
 	for {
 		if isConst(n.Left) {
 			switch n.Right.(type) {
-			case *BinaryExpr, DReference, *ExistsExpr, *QualifiedName, *Subquery, ValArg:
+			case *BinaryExpr, DReference, *QualifiedName, ValArg:
 				break
 			default:
 				return v, n
@@ -378,7 +378,7 @@ func isConst(expr Expr) bool {
 
 func isVar(expr Expr) bool {
 	switch expr.(type) {
-	case DReference, *ExistsExpr, *QualifiedName, *Subquery, ValArg:
+	case DReference, *QualifiedName, ValArg:
 		return true
 	}
 	return false

--- a/sql/parser/normalize_test.go
+++ b/sql/parser/normalize_test.go
@@ -75,6 +75,9 @@ func TestNormalizeExpr(t *testing.T) {
 		{`random()`, `random()`},
 		{`notARealMethod()`, `notARealMethod()`},
 		{`-9223372036854775808`, `-9223372036854775808`},
+		{`(SELECT 1)`, `(SELECT 1)`},
+		{`(1, 2, 3) = (SELECT 1, 2, 3)`, `(1, 2, 3) = (SELECT 1, 2, 3)`},
+		{`(1, 2, 3) IN (SELECT 1, 2, 3)`, `(1, 2, 3) IN (SELECT 1, 2, 3)`},
 	}
 	for _, d := range testData {
 		q, err := ParseTraditional("SELECT " + d.expr)

--- a/sql/parser/type_check.go
+++ b/sql/parser/type_check.go
@@ -74,8 +74,7 @@ func TypeCheckExpr(expr Expr) (Datum, error) {
 		return DummyBool, nil
 
 	case *ExistsExpr:
-		// The subquery within the exists should have been executed before
-		// expression evaluation and the exists nodes replaced with the result.
+		return TypeCheckExpr(t.Subquery)
 
 	case BytesVal, StrVal:
 		return DummyString, nil
@@ -113,8 +112,9 @@ func TypeCheckExpr(expr Expr) (Datum, error) {
 		return t, nil
 
 	case *Subquery:
-		// The subquery should have been executed before expression evaluation and
-		// the result placed into the expression tree.
+		// Avoid type checking subqueries. We need the subquery to be expanded in
+		// order to do so properly.
+		return DNull, nil
 
 	case *BinaryExpr:
 		return typeCheckBinaryExpr(t)

--- a/sql/parser/type_check_test.go
+++ b/sql/parser/type_check_test.go
@@ -30,6 +30,7 @@ func TestTypeCheckExpr(t *testing.T) {
 		`1 = NULL`,
 		`true AND NULL`,
 		`NULL OR false`,
+		`1 IN (SELECT 1)`,
 	}
 	for _, d := range testData {
 		q, err := ParseTraditional("SELECT " + d)

--- a/sql/plan.go
+++ b/sql/plan.go
@@ -37,13 +37,6 @@ type planner struct {
 // plan needs to be iterated over using planNode.Next() and planNode.Values()
 // in order to retrieve matching rows.
 func (p *planner) makePlan(stmt parser.Statement) (planNode, error) {
-	// TODO(pmattis): It is somewhat premature to expand subqueries here as we
-	// should make sure the statement is otherwise valid first. But it is
-	// correct.
-	if err := p.expandSubqueries(stmt); err != nil {
-		return nil, err
-	}
-
 	switch n := stmt.(type) {
 	case *parser.BeginTransaction:
 		return p.BeginTransaction(n)

--- a/sql/select.go
+++ b/sql/select.go
@@ -73,58 +73,6 @@ func (p *planner) Select(n *parser.Select) (planNode, error) {
 	return sort.wrap(group.wrap(plan)), nil
 }
 
-type subqueryVisitor struct {
-	*planner
-	err error
-}
-
-var _ parser.Visitor = &subqueryVisitor{}
-
-func (v *subqueryVisitor) Visit(expr parser.Expr, pre bool) (parser.Visitor, parser.Expr) {
-	if !pre || v.err != nil {
-		return nil, expr
-	}
-	subquery, ok := expr.(*parser.Subquery)
-	if !ok {
-		return v, expr
-	}
-	var plan planNode
-	if plan, v.err = v.makePlan(subquery.Select); v.err != nil {
-		return nil, expr
-	}
-	var rows parser.DTuple
-	for plan.Next() {
-		values := plan.Values()
-		switch len(values) {
-		case 1:
-			// TODO(pmattis): This seems hokey, but if we don't do this then the
-			// subquery expands to a tuple of tuples instead of a tuple of values and
-			// an expression like "k IN (SELECT foo FROM bar)" will fail because
-			// we're comparing a single value against a tuple. Perhaps comparison of
-			// a single value against a tuple should succeed if the tuple is one
-			// element in length.
-			rows = append(rows, values[0])
-		default:
-			// The result from plan.Values() is only valid until the next call to
-			// plan.Next(), so make a copy.
-			valuesCopy := make(parser.DTuple, len(values))
-			copy(valuesCopy, values)
-			rows = append(rows, valuesCopy)
-		}
-	}
-	v.err = plan.Err()
-	if v.err != nil {
-		return nil, expr
-	}
-	return v, rows
-}
-
-func (p *planner) expandSubqueries(stmt parser.Statement) error {
-	v := subqueryVisitor{planner: p}
-	parser.WalkStmt(&v, stmt)
-	return v.err
-}
-
 // selectIndex analyzes the scanNode to determine if there is an index
 // available that can fulfill the query with a more restrictive scan.
 //

--- a/sql/select.go
+++ b/sql/select.go
@@ -39,7 +39,7 @@ import (
 //   Notes: postgres requires SELECT. Also requires UPDATE on "FOR UPDATE".
 //          mysql requires SELECT.
 func (p *planner) Select(n *parser.Select) (planNode, error) {
-	scan := &scanNode{txn: p.txn}
+	scan := &scanNode{planner: p, txn: p.txn}
 	if err := scan.initFrom(p, n.From); err != nil {
 		return nil, err
 	}

--- a/sql/subquery.go
+++ b/sql/subquery.go
@@ -17,7 +17,11 @@
 
 package sql
 
-import "github.com/cockroachdb/cockroach/sql/parser"
+import (
+	"fmt"
+
+	"github.com/cockroachdb/cockroach/sql/parser"
+)
 
 func (p *planner) expandSubqueries(stmt parser.Statement) error {
 	v := subqueryVisitor{planner: p}
@@ -27,46 +31,125 @@ func (p *planner) expandSubqueries(stmt parser.Statement) error {
 
 type subqueryVisitor struct {
 	*planner
-	err error
+	path []parser.Expr // parent expressions
+	err  error
 }
 
 var _ parser.Visitor = &subqueryVisitor{}
 
 func (v *subqueryVisitor) Visit(expr parser.Expr, pre bool) (parser.Visitor, parser.Expr) {
-	if !pre || v.err != nil {
+	if v.err != nil {
 		return nil, expr
 	}
+	if !pre {
+		v.path = v.path[:len(v.path)-1]
+		return nil, expr
+	}
+	v.path = append(v.path, expr)
+
 	subquery, ok := expr.(*parser.Subquery)
 	if !ok {
 		return v, expr
 	}
+
 	var plan planNode
 	if plan, v.err = v.makePlan(subquery.Select); v.err != nil {
 		return nil, expr
 	}
-	var rows parser.DTuple
-	for plan.Next() {
-		values := plan.Values()
-		switch len(values) {
+
+	columns, multipleRows := v.getSubqueryContext()
+	if columns != len(plan.Columns()) {
+		switch columns {
 		case 1:
-			// TODO(pmattis): This seems hokey, but if we don't do this then the
-			// subquery expands to a tuple of tuples instead of a tuple of values and
-			// an expression like "k IN (SELECT foo FROM bar)" will fail because
-			// we're comparing a single value against a tuple. Perhaps comparison of
-			// a single value against a tuple should succeed if the tuple is one
-			// element in length.
-			rows = append(rows, values[0])
+			v.err = fmt.Errorf("subquery must return only one column")
 		default:
-			// The result from plan.Values() is only valid until the next call to
-			// plan.Next(), so make a copy.
-			valuesCopy := make(parser.DTuple, len(values))
-			copy(valuesCopy, values)
-			rows = append(rows, valuesCopy)
+			v.err = fmt.Errorf("subquery must return %d columns", columns)
+		}
+		return nil, expr
+	}
+
+	var result parser.Expr
+	if multipleRows {
+		var rows parser.DTuple
+		for plan.Next() {
+			values := plan.Values()
+			switch len(values) {
+			case 1:
+				// This seems hokey, but if we don't do this then the subquery expands to
+				// a tuple of tuples instead of a tuple of values and an expression like
+				// "k IN (SELECT foo FROM bar)" will fail because we're comparing a
+				// single value against a tuple. Perhaps comparison of a single value
+				// against a tuple should succeed if the tuple is one element in length.
+				rows = append(rows, values[0])
+			default:
+				// The result from plan.Values() is only valid until the next call to
+				// plan.Next(), so make a copy.
+				valuesCopy := make(parser.DTuple, len(values))
+				copy(valuesCopy, values)
+				rows = append(rows, valuesCopy)
+			}
+		}
+		result = rows
+	} else {
+		result = parser.DNull
+		for plan.Next() {
+			values := plan.Values()
+			switch len(values) {
+			case 1:
+				result = values[0]
+			default:
+				valuesCopy := make(parser.DTuple, len(values))
+				copy(valuesCopy, values)
+				result = valuesCopy
+			}
+			if plan.Next() {
+				v.err = fmt.Errorf("more than one row returned by a subquery used as an expression")
+				return nil, expr
+			}
 		}
 	}
+
 	v.err = plan.Err()
 	if v.err != nil {
 		return nil, expr
 	}
-	return v, rows
+	return v, result
+}
+
+// getSubqueryContext returns the number of columns and rows the subquery is
+// allowed to have.
+func (v *subqueryVisitor) getSubqueryContext() (columns int, multipleRows bool) {
+	for i := len(v.path) - 1; i >= 0; i-- {
+		switch e := v.path[i].(type) {
+		case *parser.ComparisonExpr:
+			// The subquery must occur on the right hand side of the comparison.
+			//
+			// TODO(pmattis): Figure out a way to lift this restriction so that we
+			// can support:
+			//
+			//   SELECT (SELECT 1, 2) = (SELECT 1, 2)
+			//
+			// TODO(pmattis): Subquery expansion currently happens before expression
+			// normalization. This seems wrong. Should perform subquery expansion
+			// after qnames are resolved, normalization and type checking.
+			columns = 1
+			switch t := e.Left.(type) {
+			case parser.Row:
+				columns = len(t)
+			case parser.Tuple:
+				columns = len(t)
+			case parser.DTuple:
+				columns = len(t)
+			}
+
+			switch e.Operator {
+			case parser.In, parser.NotIn:
+				// The IN and NOT IN operators allow multipleRows.
+				return columns, true
+			}
+
+			return columns, false
+		}
+	}
+	return 1, false
 }

--- a/sql/subquery.go
+++ b/sql/subquery.go
@@ -1,0 +1,72 @@
+// Copyright 2015 The Cockroach Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+// implied. See the License for the specific language governing
+// permissions and limitations under the License. See the AUTHORS file
+// for names of contributors.
+//
+// Author: Peter Mattis (peter@cockroachlabs.com)
+
+package sql
+
+import "github.com/cockroachdb/cockroach/sql/parser"
+
+func (p *planner) expandSubqueries(stmt parser.Statement) error {
+	v := subqueryVisitor{planner: p}
+	parser.WalkStmt(&v, stmt)
+	return v.err
+}
+
+type subqueryVisitor struct {
+	*planner
+	err error
+}
+
+var _ parser.Visitor = &subqueryVisitor{}
+
+func (v *subqueryVisitor) Visit(expr parser.Expr, pre bool) (parser.Visitor, parser.Expr) {
+	if !pre || v.err != nil {
+		return nil, expr
+	}
+	subquery, ok := expr.(*parser.Subquery)
+	if !ok {
+		return v, expr
+	}
+	var plan planNode
+	if plan, v.err = v.makePlan(subquery.Select); v.err != nil {
+		return nil, expr
+	}
+	var rows parser.DTuple
+	for plan.Next() {
+		values := plan.Values()
+		switch len(values) {
+		case 1:
+			// TODO(pmattis): This seems hokey, but if we don't do this then the
+			// subquery expands to a tuple of tuples instead of a tuple of values and
+			// an expression like "k IN (SELECT foo FROM bar)" will fail because
+			// we're comparing a single value against a tuple. Perhaps comparison of
+			// a single value against a tuple should succeed if the tuple is one
+			// element in length.
+			rows = append(rows, values[0])
+		default:
+			// The result from plan.Values() is only valid until the next call to
+			// plan.Next(), so make a copy.
+			valuesCopy := make(parser.DTuple, len(values))
+			copy(valuesCopy, values)
+			rows = append(rows, valuesCopy)
+		}
+	}
+	v.err = plan.Err()
+	if v.err != nil {
+		return nil, expr
+	}
+	return v, rows
+}

--- a/sql/testdata/subquery
+++ b/sql/testdata/subquery
@@ -23,15 +23,15 @@ SELECT (1, 2, 3) != (SELECT 1, 2, 3)
 ----
 false
 
-query error subquery must return only one column
+query error subquery must return only one column, found 2
 SELECT (SELECT 1, 2)
 ----
 
-query error subquery must return only one column
+query error subquery must return only one column, found 2
 SELECT 1 IN (SELECT 1, 2)
 ----
 
-query error subquery must return 2 columns
+query error subquery must return 2 columns, found 1
 SELECT (1, 2) IN (SELECT 1)
 ----
 

--- a/sql/testdata/subquery
+++ b/sql/testdata/subquery
@@ -1,0 +1,69 @@
+query I
+SELECT (SELECT 1)
+----
+1
+
+query B
+SELECT 1 IN (SELECT 1)
+----
+true
+
+query B
+SELECT (1, 2, 3) IN (SELECT 1, 2, 3)
+----
+true
+
+query B
+SELECT (1, 2, 3) = (SELECT 1, 2, 3)
+----
+true
+
+query B
+SELECT (1, 2, 3) != (SELECT 1, 2, 3)
+----
+false
+
+query error subquery must return only one column
+SELECT (SELECT 1, 2)
+----
+
+query error subquery must return only one column
+SELECT 1 IN (SELECT 1, 2)
+----
+
+query error subquery must return 2 columns
+SELECT (1, 2) IN (SELECT 1)
+----
+
+statement ok
+CREATE TABLE abc (a INT PRIMARY KEY, b INT, c INT)
+
+statement ok
+INSERT INTO abc VALUES (1, 2, 3), (4, 5, 6)
+
+query error subquery must return 2 columns
+SELECT (1, 2) IN (SELECT * FROM abc)
+----
+
+query B
+SELECT (1, 2) IN (SELECT a, b FROM abc)
+----
+true
+
+query B
+SELECT (1, 2) IN (SELECT a, b FROM abc WHERE false)
+----
+false
+
+query error subquery must return only one column
+SELECT (SELECT * FROM abc)
+----
+
+query error more than one row returned by a subquery used as an expression
+SELECT (SELECT a FROM abc)
+----
+
+query I
+SELECT (SELECT a FROM abc WHERE false)
+----
+NULL


### PR DESCRIPTION
When processing a subquery determine whether it is being used in a single
or multi-value context and how many columns the subquery should contain.

Fixes #2402.
