### PR TITLE
Update Read.me with clarifying language, SQL, "What is CockroachDB" 

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@
 
 ## What is CockroachDB
 
-CockroachDB is a distributed SQL database built on top of a key:value datastore. It was designed to support ACID transactional semantics and versioned values as first-class features. The primary design goal is global consistency and survivability, hence the name. CockroachDB aims to tolerate disk, machine, rack, and even datacenter failures with minimal latency disruption and no manual intervention. CockroachDB nodes (RoachNodes) are symmetric; a design goal is homogenous deployment (one binary) with minimal configuration.
+CockroachDB is a distributed SQL database built on top of a transactional and consistent key:value store. The primary design goals are support for ACID transactions, horizontal scalability, and survivability, hence the name. CockroachDB implements a Raft consensus algorithm for consistency. It aims to tolerate disk, machine, rack, and even datacenter failures with minimal latency disruption and no manual intervention. CockroachDB nodes (RoachNodes) are symmetric; a design goal is homogenous deployment (one binary) with minimal configuration.
 
 ## Status
 
@@ -37,7 +37,7 @@ If you don't want to use Docker,
 
 #### Bootstrap and talk to a single node
 
-Getting a RoachNode node up and running is easy. If you have the `cockroach` binary, skip over the next shell session. Most users however will want to run the following:
+Getting a RoachNode up and running is easy. If you have the `cockroach` binary, skip over the next shell session. Most users however will want to run the following:
 
 ```bash
 # Get the latest image from the registry. Skip if you already have an image
@@ -157,11 +157,7 @@ For a quick design overview, see the [CockroachDB tech talk slides](https://docs
 or watch a [presentation](#talks).
 
 
-CockroachDB is a distributed SQL database built on top of a key:value datastore. It was designed to support ACID transactional semantics and versioned values as first-class features. The primary design goal is global consistency and survivability, hence the name. CockroachDB aims to tolerate disk,
-machine, rack, and even datacenter failures with minimal latency
-disruption and no manual intervention. RoachNodes are symmetric;
-a design goal is one binary with minimal configuration and no required
-auxiliary services.
+CockroachDB is a distributed SQL database built on top of a transactional and consistent key:value store. The primary design goals are support for ACID transactions, horizontal scalability and survivability, hence the name. CockroachDB implements a Raft consensus algorithm for consistency. It aims to tolerate disk, machine, rack, and even datacenter failures with minimal latency disruption and no manual intervention. CockroachDB nodes (RoachNodes) are symmetric; a design goal is homogenous deployment (one binary) with minimal configuration.
 
 CockroachDB implements a single, monolithic sorted map from key to value
 where both keys and values are byte strings (not unicode). CockroachDB
@@ -288,7 +284,7 @@ write-optimized (HBase, Cassandra, SQLite3/LSM, CockroachDB).
 
 CockroachDB implements a layered architecture, with various
 subdirectories implementing layers as appropriate. The highest level of
-abstraction is the [SQL layer][5], which is currently in development and depends
+abstraction is the [SQL layer][5], which depends
 directly on the structured data API. The structured
 data API provides familiar relational concepts such as schemas,
 tables, columns, and indexes. The structured data API in turn depends
@@ -312,8 +308,7 @@ replicas.
 
 ## Client Architecture
 
-RoachNodes serve client traffic using a fully-featured key/value
-DB API which accepts requests as either application/x-protobuf or
+RoachNodes serve client traffic using a fully-featured SQL API which accepts requests as either application/x-protobuf or
 application/json. Client implementations consist of an HTTP sender
 (transport) and a transactional sender which implements a simple
 exponential backoff / retry protocol, depending on CockroachDB error

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@
 
 ## What is CockroachDB
 
-CockroachDB is a distributed SQL database built on top of a key:value datastore, with support for ACID transactional semantics and versioned values as first-class features. The primary design goal is global consistency and survivability, hence the name. CockroachDB aims to tolerate disk, machine, rack, and even datacenter failures with minimal latency disruption and no manual intervention. CockroachDB nodes (RoachNodes) are symmetric; a design goal is homogenous deployment (one binary) with minimal configuration.
+CockroachDB is a distributed SQL database built on top of a key:value datastore. It was designed to support ACID transactional semantics and versioned values as first-class features. The primary design goal is global consistency and survivability, hence the name. CockroachDB aims to tolerate disk, machine, rack, and even datacenter failures with minimal latency disruption and no manual intervention. CockroachDB nodes (RoachNodes) are symmetric; a design goal is homogenous deployment (one binary) with minimal configuration.
 
 ## Status
 
@@ -153,14 +153,11 @@ Once that's done, take a look at our [open issues](https://github.com/cockroachd
 
 This is an overview. For an in depth discussion of the design, see the [design doc](https://github.com/cockroachdb/cockroach/blob/master/docs/design.md).
 
-For a quick design overview, see the [CockroachDB tech talk slides](https://docs.google.com/presentation/d/1e3TOxImRg6_nyMZspXvzb2u43D6gnS5422vAIN7J1n8/edit?usp=sharing)
+For a quick design overview, see the [CockroachDB tech talk slides](https://docs.google.com/presentation/d/1tPPhnpJ3UwyYMe4MT8jhqCrE9ZNrUMqsvXAbd97DZ2E/edit#slide=id.p)
 or watch a [presentation](#talks).
 
 
-CockroachDB is a distributed key/value datastore which supports ACID
-transactional semantics and versioned values as first-class
-features. The primary design goal is global consistency and
-survivability, hence the name. CockroachDB aims to tolerate disk,
+CockroachDB is a distributed SQL database built on top of a key:value datastore. It was designed to support ACID transactional semantics and versioned values as first-class features. The primary design goal is global consistency and survivability, hence the name. CockroachDB aims to tolerate disk,
 machine, rack, and even datacenter failures with minimal latency
 disruption and no manual intervention. RoachNodes are symmetric;
 a design goal is one binary with minimal configuration and no required

--- a/README.md
+++ b/README.md
@@ -7,23 +7,26 @@
 
 **Table of Contents**
 
+- [What is CockroachDB](#what-is-cockroachdb)
 - [Status](#status)
-- [Running Cockroach Locally](#running-cockroach-locally)
-- [Deploying Cockroach in production](#deploying-cockroach-in-production)
+- [Running CockroachDB Locally](#running-cockroach-locally)
+- [Deploying CockroachDB in production](#deploying-cockroach-in-production)
 - [Getting in touch and contributing](#get-in-touch)
 - [Talks](#talks)
 - [Design](#design) and [Datastore Goal Articulation](#datastore-goal-articulation)
 - [Architecture](#architecture) and [Client Architecture](#client-architecture)
 
-[![WIRED on CockroachDB](/resource/doc/wired-preview.png?raw=true)](http://www.wired.com/2014/07/cockroachdb/)
+## What is CockroachDB
+
+CockroachDB is a distributed SQL database built on top of a key:value datastore, with support for ACID transactional semantics and versioned values as first-class features. The primary design goal is global consistency and survivability, hence the name. CockroachDB aims to tolerate disk, machine, rack, and even datacenter failures with minimal latency disruption and no manual intervention. CockroachDB nodes (RoachNodes) are symmetric; a design goal is homogenous deployment (one binary) with minimal configuration.
 
 ## Status
 
-See our
+CockroachDB is currently in alpha. See our
 [Roadmap](https://github.com/cockroachdb/cockroach/issues/2132) and
-[Issues](https://github.com/cockroachdb/cockroach/issues)
+[Issues](https://github.com/cockroachdb/cockroach/issues) for a list of features planned or in development. 
 
-## Running Cockroach Locally
+## Running CockroachDB Locally
 
 Getting started is most convenient using a recent version (>1.2) of [Docker](http://docs.docker.com/installation/).
 
@@ -34,7 +37,7 @@ If you don't want to use Docker,
 
 #### Bootstrap and talk to a single node
 
-Getting a Cockroach node up and running is easy. If you have the `cockroach` binary, skip over the next shell session. Most users however will want to run the following:
+Getting a RoachNode node up and running is easy. If you have the `cockroach` binary, skip over the next shell session. Most users however will want to run the following:
 
 ```bash
 # Get the latest image from the registry. Skip if you already have an image
@@ -109,9 +112,9 @@ Now let's talk to this node. The easiest way to do that is to use the `cockroach
 Check out `./cockroach help` to see all available commands.
 
 
-## Deploying Cockroach in production
+## Deploying CockroachDB in production
 
-To run a cockroach cluster on various cloud platforms using [docker machine](http://docs.docker.com/machine/),
+To run a CockroachDB cluster on various cloud platforms using [docker machine](http://docs.docker.com/machine/),
 see [cockroach-prod](https://github.com/cockroachdb/cockroach-prod)
 
 
@@ -132,11 +135,11 @@ Once that's done, take a look at our [open issues](https://github.com/cockroachd
 ## Talks
 
 * [Venue: Data Driven NYC](https://youtu.be/TA-Jw78Ms_4), by [Spencer Kimball] (https://github.com/spencerkimball) on (06/16/2015), 23min.<br />
-  A short, less technical presentation of Cockroach.
+  A short, less technical presentation of CockroachDB.
 * [Venue: NY Enterprise Technology Meetup](https://www.youtube.com/watch?v=SXAEZlpsHNE), by [Tobias Schottdorf](https://github.com/tschottdorf) on (06/10/2015), 15min.<br />
   A short, non-technical talk with a small cluster survivability demo.
 * [Venue: CoreOS Fest](https://www.youtube.com/watch?v=LI7uaaYeYmQ), by [Spencer Kimball](https://github.com/spencerkimball) on (05/27/2015), 25min.<br />
-  An introduction to the goals and design of Cockroach DB. The recommended talk to watch if all you have time for is one.
+  An introduction to the goals and design of CockroachDB. The recommended talk to watch if all you have time for is one.
 * [Venue: The Go Devroom FOSDEM 2015](https://www.youtube.com/watch?v=ndKj77VW2eM&index=2&list=PLtLJO5JKE5YDK74RZm67xfwaDgeCj7oqb), by [Tobias Schottdorf](https://github.com/tschottdorf) on (03/04/2015), 45min.<br />
   The most technical talk given thus far, going through the implementation of transactions in some detail.
 
@@ -150,25 +153,25 @@ Once that's done, take a look at our [open issues](https://github.com/cockroachd
 
 This is an overview. For an in depth discussion of the design, see the [design doc](https://github.com/cockroachdb/cockroach/blob/master/docs/design.md).
 
-For a quick design overview, see the [Cockroach tech talk slides](https://docs.google.com/presentation/d/1e3TOxImRg6_nyMZspXvzb2u43D6gnS5422vAIN7J1n8/edit?usp=sharing)
+For a quick design overview, see the [CockroachDB tech talk slides](https://docs.google.com/presentation/d/1e3TOxImRg6_nyMZspXvzb2u43D6gnS5422vAIN7J1n8/edit?usp=sharing)
 or watch a [presentation](#talks).
 
 
-Cockroach is a distributed key/value datastore which supports ACID
+CockroachDB is a distributed key/value datastore which supports ACID
 transactional semantics and versioned values as first-class
 features. The primary design goal is global consistency and
-survivability, hence the name. Cockroach aims to tolerate disk,
+survivability, hence the name. CockroachDB aims to tolerate disk,
 machine, rack, and even datacenter failures with minimal latency
-disruption and no manual intervention. Cockroach nodes are symmetric;
+disruption and no manual intervention. RoachNodes are symmetric;
 a design goal is one binary with minimal configuration and no required
 auxiliary services.
 
-Cockroach implements a single, monolithic sorted map from key to value
-where both keys and values are byte strings (not unicode). Cockroach
+CockroachDB implements a single, monolithic sorted map from key to value
+where both keys and values are byte strings (not unicode). CockroachDB
 scales linearly (theoretically up to 4 exabytes (4E) of logical
 data). The map is composed of one or more ranges and each range is
 backed by data stored in [RocksDB][0] (a variant of [LevelDB][1]), and is
-replicated to a total of three or more cockroach servers. Ranges are
+replicated to a total of three or more CockroachDB servers. Ranges are
 defined by start and end keys. Ranges are merged and split to maintain
 total byte size within a globally configurable min/max size
 interval. Range sizes default to target 64M in order to facilitate
@@ -190,18 +193,18 @@ are guaranteed by [Raft][2]; this is the fast commit path. Otherwise, a
 non-locking distributed commit protocol is employed between affected
 ranges.
 
-Cockroach provides snapshot isolation (SI) and serializable snapshot
+CockroachDB provides snapshot isolation (SI) and serializable snapshot
 isolation (SSI) semantics, allowing externally consistent, lock-free
 reads and writes--both from an historical snapshot timestamp and from
 the current wall clock time. SI provides lock-free reads and writes
 but still allows write skew. SSI eliminates write skew, but introduces
 a performance hit in the case of a contentious system. SSI is the
 default isolation; clients must consciously decide to trade
-correctness for performance. Cockroach implements a limited form of
+correctness for performance. CockroachDB implements a limited form of
 linearalizability, providing ordering for any observer or chain of
 observers.
 
-Similar to [Spanner][3] directories, Cockroach allows configuration of
+Similar to [Spanner][3] directories, CockroachDB allows configuration of
 arbitrary zones of data. This allows replication factor, storage
 device type, and/or datacenter location to be chosen to optimize
 performance and/or availability. Unlike Spanner, zones are monolithic
@@ -280,26 +283,26 @@ sorted-order storage algorithm selection. Btree stores are
 read-optimized (Oracle, SQLServer, Postgres, SQLite2, MySQL, MongoDB,
 CouchDB), hybrid stores are read-optimized with better
 write-throughput (Tokutek MySQL/MongoDB), while LSM-variants are
-write-optimized (HBase, Cassandra, SQLite3/LSM, Cockroach).
+write-optimized (HBase, Cassandra, SQLite3/LSM, CockroachDB).
 
 ![Read vs. Write Optimization Spectrum](/resource/doc/read-vs-write.png?raw=true)
 
 ## Architecture
 
-Cockroach implements a layered architecture, with various
+CockroachDB implements a layered architecture, with various
 subdirectories implementing layers as appropriate. The highest level of
-abstraction is the SQL layer (currently not implemented). It depends
-directly on the [structured data API][5] ([structured/][6]). The structured
+abstraction is the [SQL layer][5], which is currently in development and depends
+directly on the structured data API. The structured
 data API provides familiar relational concepts such as schemas,
 tables, columns, and indexes. The structured data API in turn depends
 on the [distributed key value store][7] ([kv/][8]). The distributed key
 value store handles the details of range addressing to provide the
 abstraction of a single, monolithic key value store. It communicates
-with any number of [cockroach nodes][9] ([server/][10]), storing the actual
+with any number of [RoachNodes][9] ([server/][10]), storing the actual
 data. Each node contains one or more [stores][11] ([storage/][12]), one per
 physical device.
 
-![Cockroach Architecture](/resource/doc/architecture.png?raw=true)
+![CockroachDB Architecture](/resource/doc/architecture.png?raw=true)
 
 Each store contains potentially many ranges, the lowest-level unit of
 key-value data. Ranges are replicated using the [Raft][2] consensus
@@ -312,11 +315,11 @@ replicas.
 
 ## Client Architecture
 
-Cockroach nodes serve client traffic using a fully-featured key/value
+RoachNodes serve client traffic using a fully-featured key/value
 DB API which accepts requests as either application/x-protobuf or
 application/json. Client implementations consist of an HTTP sender
 (transport) and a transactional sender which implements a simple
-exponential backoff / retry protocol, depending on Cockroach error
+exponential backoff / retry protocol, depending on CockroachDB error
 codes.
 
 The DB client gateway accepts incoming requests and sends them
@@ -328,13 +331,12 @@ index metadata, caches the results, and routes internode RPC traffic
 based on where the index metadata indicates keys are located in the
 distributed cluster.
 
-In addition to the gateway for external DB client traffic, each Cockroach
-node provides the full key/value API (including all internal methods) via
+In addition to the gateway for external DB client traffic, each RoachNode provides the full key/value API (including all internal methods) via
 a Go RPC server endpoint. The RPC server endpoint forwards requests to one
 or more local stores depending on the specified key range.
 
-Internally, each Cockroach node uses the Go implementation of the
-Cockroach client in order to transactionally update system key/value
+Internally, each RoachNode uses the Go implementation of the
+CockroachDB client in order to transactionally update system key/value
 data; for example during split and merge operations to update index
 metadata records. Unlike an external application, the internal client
 eschews the HTTP sender and instead directly shares the transaction
@@ -347,8 +349,7 @@ coordinator and distributed sender used by the DB client gateway.
 [2]: https://ramcloud.stanford.edu/wiki/download/attachments/11370504/raft.pdf
 [3]: http://research.google.com/archive/spanner.html
 [4]: http://research.google.com/pubs/pub36971.html
-[5]: http://godoc.org/github.com/cockroachdb/cockroach/structured
-[6]: https://github.com/cockroachdb/cockroach/tree/master/structured
+[5]: https://github.com/cockroachdb/cockroach/tree/master/sql
 [7]: http://godoc.org/github.com/cockroachdb/cockroach/kv
 [8]: https://github.com/cockroachdb/cockroach/tree/master/kv
 [9]: http://godoc.org/github.com/cockroachdb/cockroach/server


### PR DESCRIPTION
Update Read.me per Simson's comments and some style changes:
- added "What is CockroachDB"  section
- removed 2014 Wired article
- updated Status
- find-replace Cockroach --> Cockroach DB
- find-replace Cockroach nodes --> RoachNodes
- added link to SQL branch
- in Architecture, changed "CockroachDB is a distributed database...." sentence to include SQL + link to SQL branch
- removed link to structured data api because the link is dead
- In "Design," updated the URL to tech talk slides to a more recent deck. I was getting an error message when opening the currently linked deck.
