### PR TITLE
Remove the unused engine.Increment().

### DIFF
--- a/storage/engine/engine.go
+++ b/storage/engine/engine.go
@@ -23,8 +23,6 @@ import (
 	"sync"
 
 	"github.com/cockroachdb/cockroach/proto"
-	"github.com/cockroachdb/cockroach/util"
-	"github.com/cockroachdb/cockroach/util/encoding"
 	gogoproto "github.com/gogo/protobuf/proto"
 )
 
@@ -172,48 +170,6 @@ func PutProto(engine Engine, key proto.EncodedKey, msg gogoproto.Message) (keyBy
 
 	bufferPool.Put(buf)
 	return
-}
-
-// Increment fetches the varint encoded int64 value specified by key
-// and adds "inc" to it then re-encodes as varint. The newly incremented
-// value is returned.
-func Increment(engine Engine, key proto.EncodedKey, inc int64) (int64, error) {
-	// First retrieve existing value.
-	val, err := engine.Get(key)
-	if err != nil {
-		return 0, err
-	}
-	var int64Val int64
-	// If the value exists, attempt to decode it as a varint.
-	if len(val) != 0 {
-		decoded, err := encoding.Decode(key, val)
-		if err != nil {
-			return 0, err
-		}
-		if _, ok := decoded.(int64); !ok {
-			return 0, util.Errorf("received value of wrong type %T", decoded)
-		}
-		int64Val = decoded.(int64)
-	}
-
-	// Check for overflow and underflow.
-	if encoding.WillOverflow(int64Val, inc) {
-		return 0, util.Errorf("key %q with value %d incremented by %d results in overflow", key, int64Val, inc)
-	}
-
-	if inc == 0 {
-		return int64Val, nil
-	}
-
-	r := int64Val + inc
-	encoded, err := encoding.Encode(key, r)
-	if err != nil {
-		return 0, util.Errorf("error encoding %d", r)
-	}
-	if err = engine.Put(key, encoded); err != nil {
-		return 0, err
-	}
-	return r, nil
 }
 
 // Scan returns up to max key/value objects starting from

--- a/storage/engine/engine_test.go
+++ b/storage/engine/engine_test.go
@@ -21,7 +21,6 @@ package engine
 import (
 	"bytes"
 	"fmt"
-	"math"
 	"math/rand"
 	"reflect"
 	"sort"
@@ -433,51 +432,6 @@ func TestEngineScan1(t *testing.T) {
 				t.Fatalf("could not run scan: %v", err)
 			}
 			ensureRangeEqual(t, sortedKeys, keyMap, keyvals)
-		}
-	}, t)
-}
-
-func TestEngineIncrement(t *testing.T) {
-	defer leaktest.AfterTest(t)
-	runWithAllEngines(func(engine Engine, t *testing.T) {
-		// Start with increment of an empty key.
-		val, err := Increment(engine, proto.EncodedKey("a"), 1)
-		if err != nil {
-			t.Fatal(err)
-		}
-		if val != 1 {
-			t.Errorf("expected increment to be %d; got %d", 1, val)
-		}
-		// Increment same key by 1.
-		if val, err = Increment(engine, proto.EncodedKey("a"), 1); err != nil {
-			t.Fatal(err)
-		}
-		if val != 2 {
-			t.Errorf("expected increment to be %d; got %d", 2, val)
-		}
-		// Increment same key by 2.
-		if val, err = Increment(engine, proto.EncodedKey("a"), 2); err != nil {
-			t.Fatal(err)
-		}
-		if val != 4 {
-			t.Errorf("expected increment to be %d; got %d", 4, val)
-		}
-		// Decrement same key by -1.
-		if val, err = Increment(engine, proto.EncodedKey("a"), -1); err != nil {
-			t.Fatal(err)
-		}
-		if val != 3 {
-			t.Errorf("expected increment to be %d; got %d", 3, val)
-		}
-		// Increment same key by max int64 value to cause overflow; should return error.
-		if val, err = Increment(engine, proto.EncodedKey("a"), math.MaxInt64); err == nil {
-			t.Error("expected an overflow error")
-		}
-		if val, err = Increment(engine, proto.EncodedKey("a"), 0); err != nil {
-			t.Fatal(err)
-		}
-		if val != 3 {
-			t.Errorf("expected increment to be %d; got %d", 3, val)
 		}
 	}, t)
 }

--- a/storage/engine/mvcc_test.go
+++ b/storage/engine/mvcc_test.go
@@ -2491,6 +2491,30 @@ func TestResovleIntentWithLowerEpoch(t *testing.T) {
 	}
 }
 
+func TestWillOverflow(t *testing.T) {
+	defer leaktest.AfterTest(t)
+
+	testCases := []struct {
+		a, b     int64
+		overflow bool // will a+b over- or underflow?
+	}{
+		{0, 0, false},
+		{math.MaxInt64, 0, false},
+		{math.MaxInt64, 1, true},
+		{math.MaxInt64, math.MinInt64, false},
+		{math.MinInt64, 0, false},
+		{math.MinInt64, -1, true},
+		{math.MinInt64, math.MinInt64, true},
+	}
+
+	for i, c := range testCases {
+		if willOverflow(c.a, c.b) != c.overflow ||
+			willOverflow(c.b, c.a) != c.overflow {
+			t.Errorf("%d: overflow recognition error", i)
+		}
+	}
+}
+
 // BenchmarkMVCCStats set MVCCStats values.
 func BenchmarkMVCCStats(b *testing.B) {
 	rocksdb := NewInMem(proto.Attributes{Attrs: []string{"ssd"}}, testCacheSize)

--- a/util/encoding/encoding_test.go
+++ b/util/encoding/encoding_test.go
@@ -21,95 +21,12 @@ import (
 	"bytes"
 	"fmt"
 	"math"
-	"reflect"
 	"regexp"
 	"testing"
 	"time"
 
 	"github.com/cockroachdb/cockroach/util/randutil"
 )
-
-func TestEncoding(t *testing.T) {
-	k := []byte("asd")
-	n := int64(3142595)
-	encoded, err := Encode(k, int64(n))
-	if err != nil {
-		t.Errorf("encoding error for %d", n)
-	}
-	decoded, err := Decode(k, encoded)
-	if err != nil {
-		t.Errorf("decoding error for %d", n)
-	}
-	switch v := decoded.(type) {
-	case int64:
-		if v != n {
-			t.Errorf("int64 decoding error, got the wrong result")
-		}
-	default:
-		t.Errorf("int64 decoding error, did not get a uint64 back but instead type %v: %v", reflect.TypeOf(v), v)
-	}
-}
-
-func TestChecksums(t *testing.T) {
-	testKey := []byte("whatever")
-	doubleWrap := func(a []byte) bool {
-		_, err := unwrapChecksum(testKey, wrapChecksum(testKey, a))
-		return err == nil
-	}
-
-	_, err := unwrapChecksum([]byte("does not matter"), []byte("srt"))
-	if err == nil {
-		t.Fatalf("expected error unwrapping a too short string")
-	}
-
-	testCases := [][]byte{
-		[]byte(""),
-		[]byte("Hello"),
-		[]byte("	tab "),
-		func() []byte {
-			b := make([]byte, math.MaxUint8, math.MaxUint8)
-			for i := 0; i < math.MaxUint8; i++ {
-				b[i] = 'z'
-			}
-			return b
-		}(),
-		[]byte("لاحول ولا قوة الا بالله"),
-	}
-
-	for i, c := range testCases {
-		if !doubleWrap(c) {
-			t.Errorf("unexpected integrity error for '%v'", c)
-		}
-		// Glue an extra byte to a copy that kills the checksum.
-		distorted := append(wrapChecksum(testKey, append([]byte(nil), c...)), '1')
-		if _, err := unwrapChecksum(testKey, distorted); err == nil {
-			t.Errorf("%d: unexpected integrity match for corrupt value", i)
-		}
-
-	}
-}
-
-func TestWillOverflow(t *testing.T) {
-	testCases := []struct {
-		a, b     int64
-		overflow bool // will a+b over- or underflow?
-	}{
-		{0, 0, false},
-		{math.MaxInt64, 0, false},
-		{math.MaxInt64, 1, true},
-		{math.MaxInt64, math.MinInt64, false},
-		{math.MinInt64, 0, false},
-		{math.MinInt64, -1, true},
-		{math.MinInt64, math.MinInt64, true},
-	}
-
-	for i, c := range testCases {
-		if WillOverflow(c.a, c.b) != c.overflow ||
-			WillOverflow(c.b, c.a) != c.overflow {
-			t.Errorf("%d: overflow recognition error", i)
-		}
-	}
-}
 
 func testBasicEncodeDecode32(encFunc func([]byte, uint32) []byte,
 	dec func([]byte) ([]byte, uint32), decreasing bool, t *testing.T) {


### PR DESCRIPTION
Removed encoding.{Encode,Decode,wrapChecksum,unwrapChecksum}() which
were only used by engine.Increment(). Move encoding.WillOverflow() to
engine.willOverflow() now that there is only a single usage of that
function.
