### PR TITLE
AdminMerge: make check for collocated replicas transactional

### DIFF
--- a/kv/dist_sender_server_test.go
+++ b/kv/dist_sender_server_test.go
@@ -311,7 +311,7 @@ func TestReverseScanWithSplitAndMerge(t *testing.T) {
 
 	// Case 2: encounter with range merge .
 	// Merge the range ["e", "g") and ["g", "\xff\xff") .
-	if err := db.AdminMerge("g"); err != nil {
+	if err := db.AdminMerge("e"); err != nil {
 		t.Fatal(err)
 	}
 	if rows, err := db.ReverseScan("d", "g", 0); err != nil {


### PR DESCRIPTION
This lets us fix TestStoreRangeMergeNonConsecutive (which was misnamed)
without relying on delicate operations like Store.RemoveReplica.

Fixes #2363.
