### PR TITLE
Disable another test due to the same error occurring.

### DIFF
--- a/server/status_test.go
+++ b/server/status_test.go
@@ -499,6 +499,7 @@ func TestNodeStatusResponse(t *testing.T) {
 // results.
 func TestStoreStatusResponse(t *testing.T) {
 	defer leaktest.AfterTest(t)
+	t.Skip("TODO(bram): disabled until #2440 is fixed")
 	ts := startServer(t)
 	defer ts.Stop()
 


### PR DESCRIPTION
Seems like there's an issue starting the testserver.  This should unblock our build for now.
