### PR TITLE
Add parent ID to TableDescriptor

### DIFF
--- a/sql/analyze_test.go
+++ b/sql/analyze_test.go
@@ -27,8 +27,9 @@ import (
 
 func testTableDesc() *TableDescriptor {
 	return &TableDescriptor{
-		Name: "test",
-		ID:   1000,
+		Name:     "test",
+		ID:       1001,
+		ParentID: 1000,
 		Columns: []ColumnDescriptor{
 			{Name: "a", Type: ColumnType{Kind: ColumnType_INT}},
 			{Name: "b", Type: ColumnType{Kind: ColumnType_INT}},

--- a/sql/create.go
+++ b/sql/create.go
@@ -193,7 +193,7 @@ func (p *planner) CreateTable(n *parser.CreateTable) (planNode, error) {
 		return nil, err
 	}
 
-	desc, err := makeTableDesc(n)
+	desc, err := makeTableDesc(n, dbDesc.ID)
 	if err != nil {
 		return nil, err
 	}

--- a/sql/rename.go
+++ b/sql/rename.go
@@ -145,6 +145,7 @@ func (p *planner) RenameTable(n *parser.RenameTable) (planNode, error) {
 	}
 
 	tableDesc.SetName(n.NewName.Table())
+	tableDesc.ParentID = targetDbDesc.ID
 
 	newTbKey := tableKey{targetDbDesc.ID, n.NewName.Table()}.Key()
 	descKey := MakeDescMetadataKey(tableDesc.GetID())

--- a/sql/rename_test.go
+++ b/sql/rename_test.go
@@ -1,0 +1,89 @@
+// Copyright 2015 The Cockroach Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+// implied. See the License for the specific language governing
+// permissions and limitations under the License. See the AUTHORS file
+// for names of contributors.
+//
+// Author: Marc Berhault (marc@cockroachlabs.com)
+
+package sql_test
+
+import (
+	"testing"
+
+	"github.com/cockroachdb/cockroach/sql"
+	"github.com/cockroachdb/cockroach/util/leaktest"
+)
+
+// TestRenameTable tests the table descriptor changes during
+// a rename operation.
+func TestRenameTable(t *testing.T) {
+	defer leaktest.AfterTest(t)
+	s, sqlDB, kvDB := setup(t)
+	defer cleanup(s, sqlDB)
+
+	// The first `MaxReservedDescID` (as well as 0) are set aside.
+	counter := int64(sql.MaxReservedDescID + 1)
+
+	// Table creation should fail, and nothing should have been written.
+	oldDBID := sql.ID(counter)
+	if _, err := sqlDB.Exec(`CREATE DATABASE test`); err != nil {
+		t.Fatal(err)
+	}
+	counter++
+
+	// Create table in 'test'.
+	tableCounter := counter
+	oldName := "foo"
+	if _, err := sqlDB.Exec(`CREATE TABLE test.foo (k INT PRIMARY KEY, v int)`); err != nil {
+		t.Fatal(err)
+	}
+	counter++
+
+	// Check the table descriptor.
+	var descriptor sql.TableDescriptor
+	tableDescKey := sql.MakeDescMetadataKey(sql.ID(tableCounter))
+	if err := kvDB.GetProto(tableDescKey, &descriptor); err != nil {
+		t.Fatal(err)
+	}
+	if descriptor.Name != oldName {
+		t.Fatalf("Wrong table name, expected %s, got: %+v", oldName, descriptor)
+	}
+	if descriptor.ParentID != oldDBID {
+		t.Fatalf("Wrong parent ID on table, expected %d, got: %+v", oldDBID, descriptor)
+	}
+
+	// Create database test2.
+	newDBID := sql.ID(counter)
+	if _, err := sqlDB.Exec(`CREATE DATABASE test2`); err != nil {
+		t.Fatal(err)
+	}
+	counter++
+
+	// Move table to test2 and change its name as well.
+	newName := "bar"
+	if _, err := sqlDB.Exec(`ALTER TABLE test.foo RENAME TO test2.bar`); err != nil {
+		t.Fatal(err)
+	}
+
+	// Check the table descriptor again.
+	if err := kvDB.GetProto(tableDescKey, &descriptor); err != nil {
+		t.Fatal(err)
+	}
+	if descriptor.Name != newName {
+		t.Fatalf("Wrong table name, expected %s, got: %+v", newName, descriptor)
+	}
+	if descriptor.ParentID != newDBID {
+		t.Fatalf("Wrong parent ID on table, expected %d, got: %+v", newDBID, descriptor)
+	}
+
+}

--- a/sql/structured.go
+++ b/sql/structured.go
@@ -216,6 +216,12 @@ func (desc *TableDescriptor) Validate() error {
 		return fmt.Errorf("invalid table ID %d", desc.ID)
 	}
 
+	// ParentID is the ID of the database holding this table.
+	// It is often < ID, except when a table gets moved across databases.
+	if desc.ParentID == 0 {
+		return fmt.Errorf("invalid parent ID %d", desc.ParentID)
+	}
+
 	if len(desc.Columns) == 0 {
 		return errMissingColumns
 	}

--- a/sql/structured.proto
+++ b/sql/structured.proto
@@ -89,18 +89,21 @@ message TableDescriptor {
   // processing and not stored persistently.
   optional string alias = 2 [(gogoproto.nullable) = false];
   optional uint32 id = 3 [(gogoproto.nullable) = false,
+      (gogoproto.customname) = "ParentID", (gogoproto.casttype) = "ID"];
+  // ID of the parent database.
+  optional uint32 parent_id = 4 [(gogoproto.nullable) = false,
       (gogoproto.customname) = "ID", (gogoproto.casttype) = "ID"];
-  repeated ColumnDescriptor columns = 4 [(gogoproto.nullable) = false];
+  repeated ColumnDescriptor columns = 5 [(gogoproto.nullable) = false];
   // next_column_id is used to ensure that deleted column ids are not reused.
-  optional uint32 next_column_id = 5 [(gogoproto.nullable) = false,
+  optional uint32 next_column_id = 6 [(gogoproto.nullable) = false,
       (gogoproto.customname) = "NextColumnID", (gogoproto.casttype) = "ColumnID"];
-  optional IndexDescriptor primary_index = 6 [(gogoproto.nullable) = false];
+  optional IndexDescriptor primary_index = 7 [(gogoproto.nullable) = false];
   // indexes are all the secondary indexes.
-  repeated IndexDescriptor indexes = 7 [(gogoproto.nullable) = false];
+  repeated IndexDescriptor indexes = 8 [(gogoproto.nullable) = false];
   // next_index_id is used to ensure that deleted index ids are not reused.
-  optional uint32 next_index_id = 8 [(gogoproto.nullable) = false,
+  optional uint32 next_index_id = 9 [(gogoproto.nullable) = false,
       (gogoproto.customname) = "NextIndexID", (gogoproto.casttype) = "IndexID"];
-  optional PrivilegeDescriptor privileges = 9;
+  optional PrivilegeDescriptor privileges = 10;
 }
 
 // DatabaseDescriptor represents a namespace (aka database) and is stored

--- a/sql/structured_test.go
+++ b/sql/structured_test.go
@@ -30,8 +30,9 @@ func TestAllocateIDs(t *testing.T) {
 	defer leaktest.AfterTest(t)
 
 	desc := sql.TableDescriptor{
-		ID:   sql.MaxReservedDescID + 1,
-		Name: "foo",
+		ID:       sql.MaxReservedDescID + 2,
+		ParentID: sql.MaxReservedDescID + 1,
+		Name:     "foo",
 		Columns: []sql.ColumnDescriptor{
 			{Name: "a"},
 			{Name: "b"},
@@ -49,8 +50,9 @@ func TestAllocateIDs(t *testing.T) {
 	}
 
 	expected := sql.TableDescriptor{
-		ID:   sql.MaxReservedDescID + 1,
-		Name: "foo",
+		ID:       sql.MaxReservedDescID + 2,
+		ParentID: sql.MaxReservedDescID + 1,
+		Name:     "foo",
 		Columns: []sql.ColumnDescriptor{
 			{ID: 1, Name: "a"},
 			{ID: 2, Name: "b"},
@@ -85,12 +87,15 @@ func TestValidateTableDesc(t *testing.T) {
 			sql.TableDescriptor{}},
 		{`invalid table ID 0`,
 			sql.TableDescriptor{ID: 0, Name: "foo"}},
+		{`invalid parent ID 0`,
+			sql.TableDescriptor{ID: 2, Name: "foo"}},
 		{`table must contain at least 1 column`,
-			sql.TableDescriptor{ID: 1, Name: "foo"}},
+			sql.TableDescriptor{ID: 2, ParentID: 1, Name: "foo"}},
 		{`empty column name`,
 			sql.TableDescriptor{
-				ID:   1,
-				Name: "foo",
+				ID:       2,
+				ParentID: 1,
+				Name:     "foo",
 				Columns: []sql.ColumnDescriptor{
 					{ID: 0},
 				},
@@ -98,8 +103,9 @@ func TestValidateTableDesc(t *testing.T) {
 			}},
 		{`invalid column ID 0`,
 			sql.TableDescriptor{
-				ID:   1,
-				Name: "foo",
+				ID:       2,
+				ParentID: 1,
+				Name:     "foo",
 				Columns: []sql.ColumnDescriptor{
 					{ID: 0, Name: "bar"},
 				},
@@ -107,8 +113,9 @@ func TestValidateTableDesc(t *testing.T) {
 			}},
 		{`table must contain a primary key`,
 			sql.TableDescriptor{
-				ID:   1,
-				Name: "foo",
+				ID:       2,
+				ParentID: 1,
+				Name:     "foo",
 				Columns: []sql.ColumnDescriptor{
 					{ID: 1, Name: "bar"},
 				},
@@ -116,8 +123,9 @@ func TestValidateTableDesc(t *testing.T) {
 			}},
 		{`duplicate column name: "bar"`,
 			sql.TableDescriptor{
-				ID:   1,
-				Name: "foo",
+				ID:       2,
+				ParentID: 1,
+				Name:     "foo",
 				Columns: []sql.ColumnDescriptor{
 					{ID: 1, Name: "bar"},
 					{ID: 1, Name: "bar"},
@@ -126,8 +134,9 @@ func TestValidateTableDesc(t *testing.T) {
 			}},
 		{`column "blah" duplicate ID of column "bar": 1`,
 			sql.TableDescriptor{
-				ID:   1,
-				Name: "foo",
+				ID:       2,
+				ParentID: 1,
+				Name:     "foo",
 				Columns: []sql.ColumnDescriptor{
 					{ID: 1, Name: "bar"},
 					{ID: 1, Name: "blah"},
@@ -136,8 +145,9 @@ func TestValidateTableDesc(t *testing.T) {
 			}},
 		{`table must contain a primary key`,
 			sql.TableDescriptor{
-				ID:   1,
-				Name: "foo",
+				ID:       2,
+				ParentID: 1,
+				Name:     "foo",
 				Columns: []sql.ColumnDescriptor{
 					{ID: 1, Name: "bar"},
 				},
@@ -146,8 +156,9 @@ func TestValidateTableDesc(t *testing.T) {
 			}},
 		{`invalid index ID 0`,
 			sql.TableDescriptor{
-				ID:   1,
-				Name: "foo",
+				ID:       2,
+				ParentID: 1,
+				Name:     "foo",
 				Columns: []sql.ColumnDescriptor{
 					{ID: 1, Name: "bar"},
 				},
@@ -156,8 +167,9 @@ func TestValidateTableDesc(t *testing.T) {
 			}},
 		{`index "bar" must contain at least 1 column`,
 			sql.TableDescriptor{
-				ID:   1,
-				Name: "foo",
+				ID:       2,
+				ParentID: 1,
+				Name:     "foo",
 				Columns: []sql.ColumnDescriptor{
 					{ID: 1, Name: "bar"},
 				},
@@ -171,8 +183,9 @@ func TestValidateTableDesc(t *testing.T) {
 			}},
 		{`mismatched column IDs (1) and names (0)`,
 			sql.TableDescriptor{
-				ID:   1,
-				Name: "foo",
+				ID:       2,
+				ParentID: 1,
+				Name:     "foo",
 				Columns: []sql.ColumnDescriptor{
 					{ID: 1, Name: "bar"},
 				},
@@ -182,8 +195,9 @@ func TestValidateTableDesc(t *testing.T) {
 			}},
 		{`mismatched column IDs (1) and names (2)`,
 			sql.TableDescriptor{
-				ID:   1,
-				Name: "foo",
+				ID:       2,
+				ParentID: 1,
+				Name:     "foo",
 				Columns: []sql.ColumnDescriptor{
 					{ID: 1, Name: "bar"},
 					{ID: 2, Name: "blah"},
@@ -194,8 +208,9 @@ func TestValidateTableDesc(t *testing.T) {
 			}},
 		{`duplicate index name: "bar"`,
 			sql.TableDescriptor{
-				ID:   1,
-				Name: "foo",
+				ID:       2,
+				ParentID: 1,
+				Name:     "foo",
 				Columns: []sql.ColumnDescriptor{
 					{ID: 1, Name: "bar"},
 				},
@@ -208,8 +223,9 @@ func TestValidateTableDesc(t *testing.T) {
 			}},
 		{`index "blah" duplicate ID of index "bar": 1`,
 			sql.TableDescriptor{
-				ID:   1,
-				Name: "foo",
+				ID:       2,
+				ParentID: 1,
+				Name:     "foo",
 				Columns: []sql.ColumnDescriptor{
 					{ID: 1, Name: "bar"},
 				},
@@ -222,8 +238,9 @@ func TestValidateTableDesc(t *testing.T) {
 			}},
 		{`index "bar" column "bar" should have ID 1, but found ID 2`,
 			sql.TableDescriptor{
-				ID:   1,
-				Name: "foo",
+				ID:       2,
+				ParentID: 1,
+				Name:     "foo",
 				Columns: []sql.ColumnDescriptor{
 					{ID: 1, Name: "bar"},
 				},
@@ -233,8 +250,9 @@ func TestValidateTableDesc(t *testing.T) {
 			}},
 		{`index "bar" contains unknown column "blah"`,
 			sql.TableDescriptor{
-				ID:   1,
-				Name: "foo",
+				ID:       2,
+				ParentID: 1,
+				Name:     "foo",
 				Columns: []sql.ColumnDescriptor{
 					{ID: 1, Name: "bar"},
 				},

--- a/sql/system.go
+++ b/sql/system.go
@@ -101,7 +101,7 @@ func createSystemTable(id ID, cmd string) TableDescriptor {
 		log.Fatal(err)
 	}
 
-	desc, err := makeTableDesc(stmts[0].(*parser.CreateTable))
+	desc, err := makeTableDesc(stmts[0].(*parser.CreateTable), systemDatabaseID)
 	if err != nil {
 		log.Fatal(err)
 	}

--- a/sql/table.go
+++ b/sql/table.go
@@ -43,12 +43,13 @@ func (tk tableKey) Name() string {
 	return tk.name
 }
 
-func makeTableDesc(p *parser.CreateTable) (TableDescriptor, error) {
+func makeTableDesc(p *parser.CreateTable, parentID ID) (TableDescriptor, error) {
 	desc := TableDescriptor{}
 	if err := p.Table.NormalizeTableName(""); err != nil {
 		return desc, err
 	}
 	desc.Name = p.Table.Table()
+	desc.ParentID = parentID
 
 	for _, def := range p.Defs {
 		switch d := def.(type) {

--- a/sql/table_test.go
+++ b/sql/table_test.go
@@ -109,7 +109,7 @@ func TestMakeTableDescColumns(t *testing.T) {
 		if err := create.Table.NormalizeTableName(""); err != nil {
 			t.Fatalf("%d: %v", i, err)
 		}
-		schema, err := makeTableDesc(create)
+		schema, err := makeTableDesc(create, 1)
 		if err != nil {
 			t.Fatalf("%d: %v", i, err)
 		}
@@ -197,7 +197,7 @@ func TestMakeTableDescIndexes(t *testing.T) {
 		if err := create.Table.NormalizeTableName(""); err != nil {
 			t.Fatalf("%d: %v", i, err)
 		}
-		schema, err := makeTableDesc(create)
+		schema, err := makeTableDesc(create, 1)
 		if err != nil {
 			t.Fatalf("%d: %v", i, err)
 		}
@@ -222,7 +222,7 @@ func TestPrimaryKeyUnspecified(t *testing.T) {
 	if err := create.Table.NormalizeTableName(""); err != nil {
 		t.Fatal(err)
 	}
-	desc, err := makeTableDesc(create)
+	desc, err := makeTableDesc(create, 1)
 	if err != nil {
 		t.Fatal(err)
 	}


### PR DESCRIPTION
This is needed to go from tableID -> databaseID. It will be used by zone config lookups.
