### PR TITLE
[RFC] Add round to math builtins.

### DIFF
--- a/sql/parser/builtins.go
+++ b/sql/parser/builtins.go
@@ -549,7 +549,19 @@ var builtins = map[string][]builtin{
 		}),
 	},
 
-	// TODO(thschroeter): implement round
+	"round": {
+		builtin{
+			returnType: DummyFloat,
+			types:      typeList{floatType, intType},
+			fn: func(args DTuple) (Datum, error) {
+				n := args[1].(DInt)
+				// TODO(thschroeter): bounds check on n
+				x := args[0].(DFloat)
+				return DFloat(roundDigits(float64(x),
+					int64(n))), nil
+			},
+		},
+	},
 
 	"sin": {
 		floatBuiltin1(func(x float64) (Datum, error) {
@@ -760,4 +772,74 @@ func datumToRawString(datum Datum) (string, error) {
 	}
 
 	return "", fmt.Errorf("argument type unsupported: %s", datum.Type())
+}
+
+// Round rounds x to n digits.
+// Directly taken from CPython's `double_round` in
+// cpython/Object/floatobject.c.
+//
+// TODO(thschroeter):
+// - understand how it works
+// - bounds check for n
+// - test overflow
+func roundDigits(x float64, n int64) float64 {
+	var pow1, pow2, y, z float64
+	ndigits := float64(n)
+
+	if ndigits >= 0 {
+		if ndigits > 22 {
+			/* pow1 and pow2 are each safe from overflow, but
+			   pow1*pow2 ~= pow(10.0, ndigits) might overflow */
+			pow1 = math.Pow(10, ndigits-22)
+			pow2 = 1e22
+		} else {
+			pow1 = math.Pow(10, ndigits)
+			pow2 = 1.0
+		}
+		y = (x * pow1) * pow2
+		/* if y overflows, then rounded value is exactly x */
+		//if (!Py_IS_FINITE(y))
+		//    return PyFloat_FromDouble(x);
+		if math.IsInf(y, 0) {
+			return math.NaN()
+		}
+	} else {
+		pow1 = math.Pow(10, ndigits)
+		//pow2 = 1.0; /* unused; silences a gcc compiler warning */
+		y = x / pow1
+	}
+
+	z = round(y)
+	if math.Abs(y-z) == 0.5 {
+		/* halfway between two integers; use round-half-even */
+		z = 2.0 * round(y/2.0)
+	}
+
+	if ndigits >= 0 {
+		z = (z / pow2) / pow1
+	} else {
+		z *= pow1
+	}
+
+	/* if computation resulted in overflow, raise OverflowError */
+	//if (!Py_IS_FINITE(z)) {
+	//   PyErr_SetString(PyExc_OverflowError,
+	//                    "overflow occurred during round");
+	//  return NULL;
+	//}
+	if math.IsInf(z, 0) {
+		return math.NaN()
+	}
+
+	//return PyFloat_FromDouble(z);
+	return z
+}
+
+func round(x float64) float64 {
+	absx := math.Abs(x)
+	y := math.Floor(absx)
+	if absx-y >= 0.5 {
+		y += 1.0
+	}
+	return math.Copysign(y, x)
 }

--- a/sql/testdata/builtin_function
+++ b/sql/testdata/builtin_function
@@ -477,6 +477,29 @@ SELECT radians(-45.0), radians(45.0)
 ----
 -0.7853981633974483 0.7853981633974483
 
+# round to nearest even
+query T
+SELECT round(1.5, 0), round(2.5, 0)
+----
+2 2
+
+query T
+SELECT round(2.123456789, 5)
+----
+2.12346
+
+# Rounding to negative number of digits is not [yet] postgres compatible.
+# In Postgres round(42.1, -1) is 40.
+query T
+SELECT round(41.2, -1)
+----
+41.2
+
+query T
+SELECT round(-1.7976931348623157e+308, 1), round(1.7976931348623157e+308, 1)
+----
+NaN NaN
+
 query T
 SELECT sign(-2), sign(0), sign(2)
 ----

--- a/sql/testdata/builtin_function
+++ b/sql/testdata/builtin_function
@@ -479,14 +479,25 @@ SELECT radians(-45.0), radians(45.0)
 
 # round to nearest even
 query T
-SELECT round(1.5, 0), round(2.5, 0)
+SELECT round(-2.5, 0), round(-1.5, 0), round(1.5, 0), round(2.5, 0)
 ----
-2 2
+-2 -2 2 2
+
+query T
+SELECT round(-2.5), round(-1.5), round(1.5), round(2.5)
+----
+-2 -2 2 2
 
 query T
 SELECT round(2.123456789, 5)
 ----
 2.12346
+
+# TODO(thschroeter): Fix this test.
+#query T
+#SELECT round(1.0123456789012345678909999, 23)
+#----
+#1.01234567890123456789100
 
 # Rounding to negative number of digits is not [yet] postgres compatible.
 # In Postgres round(42.1, -1) is 40.
@@ -498,7 +509,7 @@ SELECT round(41.2, -1)
 query T
 SELECT round(-1.7976931348623157e+308, 1), round(1.7976931348623157e+308, 1)
 ----
-NaN NaN
+-1.7976931348623157e+308 1.7976931348623157e+308
 
 query T
 SELECT sign(-2), sign(0), sign(2)


### PR DESCRIPTION
Implementation of round taken from CPython.  It returns
`NaN` if overflow is detected.

Needs tests and better understanding of the algorithm.

This implementation is about 6x faster than the
FormatFloat / ParseFloat implementatation.

BenchmarkRound1-8    3000000            576 ns/op
BenchmarkRound2-8   20000000         95.9 ns/op
