### PR TITLE
Convert cli zones commands to use system.zones table.

### DIFF
--- a/cli/sql_util_test.go
+++ b/cli/sql_util_test.go
@@ -103,4 +103,27 @@ OK
 		t.Fatalf("expected output:\n%s\ngot:\n%s", e, a)
 	}
 	b.Reset()
+
+	// Test custom formatting.
+	newFormat := func(val interface{}) string {
+		return fmt.Sprintf("--> %#v <--", val)
+	}
+
+	if err := runQueryWithFormat(db, fmtMap{"name": newFormat},
+		`SELECT * FROM system.namespace WHERE name=$1`, "descriptor"); err != nil {
+		t.Fatal(err)
+	}
+
+	expected = `
++----------+----------------------+----+
+| parentID |         name         | id |
++----------+----------------------+----+
+| 1        | --> "descriptor" <-- | 3  |
++----------+----------------------+----+
+`
+	if a, e := b.String(), expected[1:]; a != e {
+		t.Fatalf("expected output:\n%s\ngot:\n%s", e, a)
+	}
+	b.Reset()
+
 }

--- a/cli/user.go
+++ b/cli/user.go
@@ -34,7 +34,6 @@ Fetches and displays the user configuration for <username>.
 	Run: runGetUser,
 }
 
-// runGetUser invokes the REST API with GET action and username as path.
 func runGetUser(cmd *cobra.Command, args []string) {
 	if len(args) != 1 {
 		cmd.Usage()
@@ -58,8 +57,6 @@ List all user configs.
 	Run: runLsUsers,
 }
 
-// runLsUsers invokes the REST API with GET action and no path, which
-// fetches a list of all user configuration.
 func runLsUsers(cmd *cobra.Command, args []string) {
 	if len(args) > 0 {
 		cmd.Usage()
@@ -83,7 +80,6 @@ Remove an existing user config by username.
 	Run: runRmUser,
 }
 
-// runRmUser invokes the REST API with DELETE action and username as path.
 func runRmUser(cmd *cobra.Command, args []string) {
 	if len(args) != 1 {
 		cmd.Usage()
@@ -108,8 +104,8 @@ for the password.
 	Run: runSetUser,
 }
 
-// runSetUser invokes the REST API with POST action and username as
-// path. Prompts for the password twice on stdin.
+// runSetUser prompts for a password, then inserts the user and hash
+// into the system.users table.
 // TODO(marc): once we have more fields in the user config, we will need
 // to allow changing just some of them (eg: change email, but leave password).
 func runSetUser(cmd *cobra.Command, args []string) {
@@ -123,6 +119,7 @@ func runSetUser(cmd *cobra.Command, args []string) {
 		return
 	}
 	db := makeSQLClient()
+	// TODO(marc): switch to UPSERT.
 	err = runQuery(db, `INSERT INTO system.users VALUES ($1, $2)`, args[0], hashed)
 	if err != nil {
 		log.Error(err)

--- a/client/admin.go
+++ b/client/admin.go
@@ -35,8 +35,6 @@ const (
 
 	// Quit only handles Get requests.
 	Quit = "quit"
-	// Zone expects config.ZoneConfig.
-	Zone = "zones"
 )
 
 // AdminClient issues http requests to admin endpoints.


### PR DESCRIPTION
Work for #2505.

All cli/zones commands now use standard sql commands on the system.zones
table.

Additionally, the `get` and `ls` commands convert the raw proto into the
yaml representation, which is what is also expected on `set`.
The ls output gets a bit crowded.

I still need to add translation for object IDs to/from db/table names.

Example:

``` shell
$ ./cockroach zone --dev set 1000 /tmp/zone
$ ./cockroach zone --dev set 1001 /tmp/zone
$ ./cockroach zone --dev get 1000
+------+--------------------------------+
|  id  |             config             |
+------+--------------------------------+
| 1000 | replicas:                      |
|      | - attrs: [us-east-1a, ssd]     |
|      | - attrs: [us-east-1b, ssd]     |
|      | - attrs: [us-west-1b, ssd]     |
|      | range_min_bytes: 8388608       |
|      | range_max_bytes: 67108864      |
+------+--------------------------------+
$ ./cockroach zone --dev ls
+------+--------------------------------+
|  id  |             config             |
+------+--------------------------------+
| 1000 | replicas:                      |
|      | - attrs: [us-east-1a, ssd]     |
|      | - attrs: [us-east-1b, ssd]     |
|      | - attrs: [us-west-1b, ssd]     |
|      | range_min_bytes: 8388608       |
|      | range_max_bytes: 67108864      |
| 1001 | replicas:                      |
|      | - attrs: [us-east-1a, ssd]     |
|      | - attrs: [us-east-1b, ssd]     |
|      | - attrs: [us-west-1b, ssd]     |
|      | range_min_bytes: 8388608       |
|      | range_max_bytes: 67108864      |
+------+--------------------------------+
```
