### PR TITLE
Stricter enforcement of splitable ranges in queues.

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -242,3 +242,9 @@ func (s *SystemConfig) ComputeSplitKeys(startKey, endKey proto.Key) []proto.Key 
 
 	return splitKeys
 }
+
+// NeedsSplit returns whether the range [startKey, endKey) needs a split due
+// to zone configs.
+func (s *SystemConfig) NeedsSplit(startKey, endKey proto.Key) bool {
+	return len(s.ComputeSplitKeys(startKey, endKey)) > 0
+}

--- a/storage/gc_queue.go
+++ b/storage/gc_queue.go
@@ -87,9 +87,10 @@ func (gcq *gcQueue) acceptsUnsplitRanges() bool {
 func (gcq *gcQueue) shouldQueue(now proto.Timestamp, repl *Replica,
 	sysCfg *config.SystemConfig) (shouldQ bool, priority float64) {
 
-	zone, err := sysCfg.GetZoneConfigForKey(repl.Desc().StartKey)
+	desc := repl.Desc()
+	zone, err := sysCfg.GetZoneConfigForKey(desc.StartKey)
 	if err != nil {
-		log.Errorf("could not find GC policy for range %+v: %s", repl.Desc(), err)
+		log.Errorf("could not find GC policy for range %s: %s", repl, err)
 		return
 	}
 	policy := zone.GC
@@ -126,9 +127,9 @@ func (gcq *gcQueue) process(now proto.Timestamp, repl *Replica,
 	defer snap.Close()
 
 	// Lookup the GC policy for the zone containing this key range.
-	zone, err := sysCfg.GetZoneConfigForKey(repl.Desc().StartKey)
+	zone, err := sysCfg.GetZoneConfigForKey(desc.StartKey)
 	if err != nil {
-		return fmt.Errorf("could not find GC policy for range %+v: %s", repl.Desc(), err)
+		return fmt.Errorf("could not find GC policy for range %s: %s", repl, err)
 	}
 	policy := zone.GC
 

--- a/storage/gc_queue.go
+++ b/storage/gc_queue.go
@@ -18,15 +18,16 @@
 package storage
 
 import (
+	"fmt"
 	"math"
 	"sync"
 	"time"
 
 	"github.com/cockroachdb/cockroach/client"
 	"github.com/cockroachdb/cockroach/config"
+	"github.com/cockroachdb/cockroach/gossip"
 	"github.com/cockroachdb/cockroach/proto"
 	"github.com/cockroachdb/cockroach/storage/engine"
-	"github.com/cockroachdb/cockroach/util"
 	"github.com/cockroachdb/cockroach/util/log"
 	gogoproto "github.com/gogo/protobuf/proto"
 )
@@ -63,9 +64,9 @@ type gcQueue struct {
 }
 
 // newGCQueue returns a new instance of gcQueue.
-func newGCQueue() *gcQueue {
+func newGCQueue(gossip *gossip.Gossip) *gcQueue {
 	gcq := &gcQueue{}
-	gcq.baseQueue = newBaseQueue("gc", gcq, gcQueueMaxSize)
+	gcq.baseQueue = newBaseQueue("gc", gcq, gossip, gcQueueMaxSize)
 	return gcq
 }
 
@@ -73,16 +74,25 @@ func (gcq *gcQueue) needsLeaderLease() bool {
 	return true
 }
 
+// acceptsUnsplitRanges is false because the proper GC
+// policy cannot be determined for ranges that span zone configs.
+func (gcq *gcQueue) acceptsUnsplitRanges() bool {
+	return false
+}
+
 // shouldQueue determines whether a replica should be queued for garbage
 // collection, and if so, at what priority. Returns true for shouldQ
 // in the event that the cumulative ages of GC'able bytes or extant
 // intents exceed thresholds.
-func (gcq *gcQueue) shouldQueue(now proto.Timestamp, repl *Replica) (shouldQ bool, priority float64) {
-	policy, err := gcq.lookupGCPolicy(repl)
+func (gcq *gcQueue) shouldQueue(now proto.Timestamp, repl *Replica,
+	sysCfg *config.SystemConfig) (shouldQ bool, priority float64) {
+
+	zone, err := sysCfg.GetZoneConfigForKey(repl.Desc().StartKey)
 	if err != nil {
-		log.Errorf("GC policy: %s", err)
+		log.Errorf("could not find GC policy for range %+v: %s", repl.Desc(), err)
 		return
 	}
+	policy := zone.GC
 
 	// GC score is the total GC'able bytes age normalized by 1 MB * the replica's TTL in seconds.
 	gcScore := float64(repl.stats.GetGCBytesAge(now.WallTime)) / float64(policy.TTLSeconds) / float64(gcByteCountNormalization)
@@ -106,7 +116,9 @@ func (gcq *gcQueue) shouldQueue(now proto.Timestamp, repl *Replica) (shouldQ boo
 // collector for each key and associated set of values. GC'd keys are batched
 // into GC calls. Extant intents are resolved if intents are older than
 // intentAgeThreshold.
-func (gcq *gcQueue) process(now proto.Timestamp, repl *Replica) error {
+func (gcq *gcQueue) process(now proto.Timestamp, repl *Replica,
+	sysCfg *config.SystemConfig) error {
+
 	snap := repl.rm.Engine().NewSnapshot()
 	desc := repl.Desc()
 	iter := newRangeDataIterator(desc, snap)
@@ -114,10 +126,11 @@ func (gcq *gcQueue) process(now proto.Timestamp, repl *Replica) error {
 	defer snap.Close()
 
 	// Lookup the GC policy for the zone containing this key range.
-	policy, err := gcq.lookupGCPolicy(repl)
+	zone, err := sysCfg.GetZoneConfigForKey(repl.Desc().StartKey)
 	if err != nil {
-		return err
+		return fmt.Errorf("could not find GC policy for range %+v: %s", repl.Desc(), err)
 	}
+	policy := zone.GC
 
 	gcMeta := proto.NewGCMetadata(now.WallTime)
 	gc := engine.NewGarbageCollector(now, *policy)
@@ -307,28 +320,4 @@ func (gcq *gcQueue) pushTxn(repl *Replica, now proto.Timestamp, txn *proto.Trans
 	}
 	// Update the supplied txn on successful push.
 	*txn = *br.Responses[0].GetValue().(*proto.PushTxnResponse).PusheeTxn
-}
-
-// lookupGCPolicy finds the GC policy for 'repl'.
-// If the range needs to be split, aborts.
-func (gcq *gcQueue) lookupGCPolicy(repl *Replica) (*config.GCPolicy, error) {
-	// Load the system config.
-	cfg, err := repl.rm.Gossip().GetSystemConfig()
-	if err != nil {
-		return nil, err
-	}
-
-	desc := repl.Desc()
-	if len(cfg.ComputeSplitKeys(desc.StartKey, desc.EndKey)) > 0 {
-		// If the replica's range needs splitting, error out.
-		return nil, util.Errorf("%v spans multiple ranges, must be split first", desc)
-	}
-
-	// Find the zone config for this range.
-	zone, err := cfg.GetZoneConfigForKey(desc.StartKey)
-	if err != nil {
-		return nil, err
-	}
-
-	return zone.GC, nil
 }

--- a/storage/queue.go
+++ b/storage/queue.go
@@ -24,6 +24,8 @@ import (
 	"sync/atomic"
 	"time"
 
+	"github.com/cockroachdb/cockroach/config"
+	"github.com/cockroachdb/cockroach/gossip"
 	"github.com/cockroachdb/cockroach/proto"
 	"github.com/cockroachdb/cockroach/util/hlc"
 	"github.com/cockroachdb/cockroach/util/log"
@@ -85,13 +87,18 @@ type queueImpl interface {
 	// lease to operate on a replica.
 	needsLeaderLease() bool
 
-	// shouldQueue accepts current time and a replica and returns whether
-	// it should be queued and if so, at what priority.
-	shouldQueue(proto.Timestamp, *Replica) (shouldQueue bool, priority float64)
+	// acceptsUnsplitRanges returns whether this queue can process
+	// ranges that need to be split due to zone config settings.
+	// Ranges are checked before calling shouldQueue and process.
+	acceptsUnsplitRanges() bool
 
-	// process accepts current time and a replica and executes
-	// queue-specific work on it.
-	process(proto.Timestamp, *Replica) error
+	// shouldQueue accepts current time, a replica, and the system config
+	// and returns whether it should be queued and if so, at what priority.
+	shouldQueue(proto.Timestamp, *Replica, *config.SystemConfig) (shouldQueue bool, priority float64)
+
+	// process accepts current time, a replica, and the system config
+	// and executes queue-specific work on it.
+	process(proto.Timestamp, *Replica, *config.SystemConfig) error
 
 	// timer returns a duration to wait between processing the next item
 	// from the queue.
@@ -106,6 +113,7 @@ type queueImpl interface {
 type baseQueue struct {
 	name       string
 	impl       queueImpl
+	gossip     *gossip.Gossip
 	maxSize    int                            // Maximum number of replicas to queue
 	incoming   chan struct{}                  // Channel signaled when a new replica is added to the queue.
 	sync.Mutex                                // Mutex protects priorityQ and replicas
@@ -121,10 +129,11 @@ type baseQueue struct {
 // maxSize doesn't prevent new replicas from being added, it just
 // limits the total size. Higher priority replicas can still be
 // added; their addition simply removes the lowest priority replica.
-func newBaseQueue(name string, impl queueImpl, maxSize int) *baseQueue {
+func newBaseQueue(name string, impl queueImpl, gossip *gossip.Gossip, maxSize int) *baseQueue {
 	return &baseQueue{
 		name:     name,
 		impl:     impl,
+		gossip:   gossip,
 		maxSize:  maxSize,
 		incoming: make(chan struct{}, 1),
 		replicas: map[proto.RangeID]*replicaItem{},
@@ -170,9 +179,26 @@ func (bq *baseQueue) Add(repl *Replica, priority float64) error {
 // not be added, as the replica with the lowest priority will be
 // dropped.
 func (bq *baseQueue) MaybeAdd(repl *Replica, now proto.Timestamp) {
+	// Load the system config.
+	cfg, err := bq.gossip.GetSystemConfig()
+	if err != nil {
+		log.Error(err)
+		return
+	}
+
+	if !bq.impl.acceptsUnsplitRanges() &&
+		cfg.NeedsSplit(repl.Desc().StartKey, repl.Desc().EndKey) {
+		// Range needs to be split due to zone configs, but queue does
+		// not accept unsplit ranges.
+		if log.V(3) {
+			log.Infof("this replica of %s needs to be split; skipping...", repl)
+		}
+		return
+	}
+
 	bq.Lock()
 	defer bq.Unlock()
-	should, priority := bq.impl.shouldQueue(now, repl)
+	should, priority := bq.impl.shouldQueue(now, repl, cfg)
 	if err := bq.addInternal(repl, should, priority); err != nil && log.V(3) {
 		log.Infof("couldn't add %s to queue %s: %s", repl, bq.name, err)
 	}
@@ -285,33 +311,55 @@ func (bq *baseQueue) processLoop(clock *hlc.Clock, stopper *stop.Stopper) {
 }
 
 func (bq *baseQueue) processOne(clock *hlc.Clock) {
+	// Load the system config.
+	cfg, err := bq.gossip.GetSystemConfig()
+	if err != nil {
+		log.Error(err)
+		return
+	}
+
 	start := time.Now()
 	bq.Lock()
 	repl := bq.pop()
 	bq.Unlock()
-	if repl != nil {
-		now := clock.Now()
+
+	if repl == nil {
+		return
+	}
+
+	now := clock.Now()
+
+	if !bq.impl.acceptsUnsplitRanges() &&
+		cfg.NeedsSplit(repl.Desc().StartKey, repl.Desc().EndKey) {
+		// Range needs to be split due to zone configs, but queue does
+		// not accept unsplit ranges.
 		if log.V(3) {
-			log.Infof("processing replica %s from %s queue...", repl, bq.name)
+			log.Infof("this replica of %s needs to be split; skipping...", repl)
 		}
-		// If the queue requires a replica to have the range leader lease in
-		// order to be processed, check whether this replica has leader lease
-		// and renew or acquire if necessary.
-		if bq.impl.needsLeaderLease() {
-			// Create a "fake" get request in order to invoke redirectOnOrAcquireLease.
-			args := &proto.GetRequest{RequestHeader: proto.RequestHeader{Timestamp: now}}
-			if err := repl.redirectOnOrAcquireLeaderLease(nil /* Trace */, args.Header().Timestamp); err != nil {
-				if log.V(3) {
-					log.Infof("this replica of %s could not acquire leader lease; skipping...", repl)
-				}
-				return
+		return
+	}
+
+	if log.V(3) {
+		log.Infof("processing replica %s from %s queue...", repl, bq.name)
+	}
+
+	// If the queue requires a replica to have the range leader lease in
+	// order to be processed, check whether this replica has leader lease
+	// and renew or acquire if necessary.
+	if bq.impl.needsLeaderLease() {
+		// Create a "fake" get request in order to invoke redirectOnOrAcquireLease.
+		args := &proto.GetRequest{RequestHeader: proto.RequestHeader{Timestamp: now}}
+		if err := repl.redirectOnOrAcquireLeaderLease(nil /* Trace */, args.Header().Timestamp); err != nil {
+			if log.V(3) {
+				log.Infof("this replica of %s could not acquire leader lease; skipping...", repl)
 			}
+			return
 		}
-		if err := bq.impl.process(now, repl); err != nil {
-			log.Errorf("failure processing replica %s from %s queue: %s", repl, bq.name, err)
-		} else if log.V(2) {
-			log.Infof("processed replica %s from %s queue in %s", repl, bq.name, time.Now().Sub(start))
-		}
+	}
+	if err := bq.impl.process(now, repl, cfg); err != nil {
+		log.Errorf("failure processing replica %s from %s queue: %s", repl, bq.name, err)
+	} else if log.V(2) {
+		log.Infof("processed replica %s from %s queue in %s", repl, bq.name, time.Now().Sub(start))
 	}
 }
 

--- a/storage/queue_test.go
+++ b/storage/queue_test.go
@@ -23,12 +23,35 @@ import (
 	"testing"
 	"time"
 
+	"github.com/cockroachdb/cockroach/base"
+	"github.com/cockroachdb/cockroach/config"
+	"github.com/cockroachdb/cockroach/gossip"
+	"github.com/cockroachdb/cockroach/keys"
 	"github.com/cockroachdb/cockroach/proto"
+	"github.com/cockroachdb/cockroach/rpc"
 	"github.com/cockroachdb/cockroach/util"
 	"github.com/cockroachdb/cockroach/util/hlc"
 	"github.com/cockroachdb/cockroach/util/leaktest"
 	"github.com/cockroachdb/cockroach/util/stop"
 )
+
+func gossipForTest(t *testing.T) (*gossip.Gossip, *stop.Stopper) {
+	stopper := stop.NewStopper()
+
+	// Setup fake zone config handler.
+	config.TestingSetupZoneConfigHook(stopper)
+
+	rpcContext := rpc.NewContext(&base.Context{}, hlc.NewClock(hlc.UnixNano), stopper)
+	g := gossip.New(rpcContext, gossip.TestInterval, gossip.TestBootstrap)
+
+	// Put an empty system config into gossip.
+	if err := g.AddInfoProto(gossip.KeySystemConfig,
+		&config.SystemConfig{}, 0); err != nil {
+		t.Fatal(err)
+	}
+
+	return g, stopper
+}
 
 // testQueueImpl implements queueImpl with a closure for shouldQueue.
 type testQueueImpl struct {
@@ -36,15 +59,17 @@ type testQueueImpl struct {
 	processed     int32
 	duration      time.Duration
 	blocker       chan struct{} // timer() blocks on this if not nil
+	acceptUnsplit bool
 }
 
-func (tq *testQueueImpl) needsLeaderLease() bool { return false }
+func (tq *testQueueImpl) needsLeaderLease() bool     { return false }
+func (tq *testQueueImpl) acceptsUnsplitRanges() bool { return tq.acceptUnsplit }
 
-func (tq *testQueueImpl) shouldQueue(now proto.Timestamp, r *Replica) (bool, float64) {
+func (tq *testQueueImpl) shouldQueue(now proto.Timestamp, r *Replica, _ *config.SystemConfig) (bool, float64) {
 	return tq.shouldQueueFn(now, r)
 }
 
-func (tq *testQueueImpl) process(now proto.Timestamp, r *Replica) error {
+func (tq *testQueueImpl) process(now proto.Timestamp, r *Replica, _ *config.SystemConfig) error {
 	atomic.AddInt32(&tq.processed, 1)
 	return nil
 }
@@ -101,6 +126,9 @@ func TestQueuePriorityQueue(t *testing.T) {
 // queued, updating an existing range, and removing a range.
 func TestBaseQueueAddUpdateAndRemove(t *testing.T) {
 	defer leaktest.AfterTest(t)
+	g, stopper := gossipForTest(t)
+	defer stopper.Stop()
+
 	r1 := &Replica{}
 	if err := r1.setDesc(&proto.RangeDescriptor{RangeID: 1}); err != nil {
 		t.Fatal(err)
@@ -122,7 +150,7 @@ func TestBaseQueueAddUpdateAndRemove(t *testing.T) {
 			return shouldAddMap[r], priorityMap[r]
 		},
 	}
-	bq := newBaseQueue("test", testQueue, 2)
+	bq := newBaseQueue("test", testQueue, g, 2)
 	bq.MaybeAdd(r1, proto.ZeroTimestamp)
 	bq.MaybeAdd(r2, proto.ZeroTimestamp)
 	if bq.Length() != 2 {
@@ -187,6 +215,9 @@ func TestBaseQueueAddUpdateAndRemove(t *testing.T) {
 // ShouldQueue method.
 func TestBaseQueueAdd(t *testing.T) {
 	defer leaktest.AfterTest(t)
+	g, stopper := gossipForTest(t)
+	defer stopper.Stop()
+
 	r := &Replica{}
 	if err := r.setDesc(&proto.RangeDescriptor{RangeID: 1}); err != nil {
 		t.Fatal(err)
@@ -196,7 +227,7 @@ func TestBaseQueueAdd(t *testing.T) {
 			return false, 0.0
 		},
 	}
-	bq := newBaseQueue("test", testQueue, 1)
+	bq := newBaseQueue("test", testQueue, g, 1)
 	bq.MaybeAdd(r, proto.ZeroTimestamp)
 	if bq.Length() != 0 {
 		t.Fatalf("expected length 0; got %d", bq.Length())
@@ -213,6 +244,9 @@ func TestBaseQueueAdd(t *testing.T) {
 // processed according to the timer function.
 func TestBaseQueueProcess(t *testing.T) {
 	defer leaktest.AfterTest(t)
+	g, stopper := gossipForTest(t)
+	defer stopper.Stop()
+
 	r1 := &Replica{}
 	if err := r1.setDesc(&proto.RangeDescriptor{RangeID: 1}); err != nil {
 		t.Fatal(err)
@@ -229,12 +263,10 @@ func TestBaseQueueProcess(t *testing.T) {
 			return
 		},
 	}
-	bq := newBaseQueue("test", testQueue, 2)
-	stopper := stop.NewStopper()
+	bq := newBaseQueue("test", testQueue, g, 2)
 	mc := hlc.NewManualClock(0)
 	clock := hlc.NewClock(mc.UnixNano)
 	bq.Start(clock, stopper)
-	defer stopper.Stop()
 
 	bq.MaybeAdd(r1, proto.ZeroTimestamp)
 	bq.MaybeAdd(r2, proto.ZeroTimestamp)
@@ -261,6 +293,9 @@ func TestBaseQueueProcess(t *testing.T) {
 // not processed.
 func TestBaseQueueAddRemove(t *testing.T) {
 	defer leaktest.AfterTest(t)
+	g, stopper := gossipForTest(t)
+	defer stopper.Stop()
+
 	r := &Replica{}
 	if err := r.setDesc(&proto.RangeDescriptor{RangeID: 1}); err != nil {
 		t.Fatal(err)
@@ -273,12 +308,10 @@ func TestBaseQueueAddRemove(t *testing.T) {
 			return
 		},
 	}
-	bq := newBaseQueue("test", testQueue, 2)
-	stopper := stop.NewStopper()
+	bq := newBaseQueue("test", testQueue, g, 2)
 	mc := hlc.NewManualClock(0)
 	clock := hlc.NewClock(mc.UnixNano)
 	bq.Start(clock, stopper)
-	defer stopper.Stop()
 
 	bq.MaybeAdd(r, proto.ZeroTimestamp)
 	bq.MaybeRemove(r)
@@ -294,5 +327,101 @@ func TestBaseQueueAddRemove(t *testing.T) {
 
 	if pc := atomic.LoadInt32(&testQueue.processed); pc > 0 {
 		t.Errorf("expected processed count of 0; got %d", pc)
+	}
+}
+
+// TestAcceptsUnplitRanges verifies that ranges that need to split are properly
+// rejected when the queue has 'acceptsUnsplitRanges = false'.
+func TestAcceptsUnplitRanges(t *testing.T) {
+	defer leaktest.AfterTest(t)
+	g, stopper := gossipForTest(t)
+	defer stopper.Stop()
+
+	// This range can never be split due to zone configs boundaries.
+	neverSplits := &Replica{}
+	if err := neverSplits.setDesc(&proto.RangeDescriptor{
+		RangeID:  1,
+		StartKey: proto.KeyMin,
+		EndKey:   keys.UserTableDataMin,
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	// This range will need to be split after user db/table entries are created.
+	willSplit := &Replica{}
+	if err := willSplit.setDesc(&proto.RangeDescriptor{
+		RangeID:  2,
+		StartKey: keys.UserTableDataMin,
+		EndKey:   proto.KeyMax,
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	var queued int32
+	testQueue := &testQueueImpl{
+		shouldQueueFn: func(now proto.Timestamp, r *Replica) (shouldQueue bool, priority float64) {
+			// Always queue ranges if they make it past the base queue's logic.
+			atomic.AddInt32(&queued, 1)
+			return true, float64(r.Desc().RangeID)
+		},
+		acceptUnsplit: false,
+	}
+
+	bq := newBaseQueue("test", testQueue, g, 2)
+	mc := hlc.NewManualClock(0)
+	clock := hlc.NewClock(mc.UnixNano)
+	bq.Start(clock, stopper)
+
+	// Check our config.
+	sysCfg, err := g.GetSystemConfig()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if sysCfg.NeedsSplit(neverSplits.Desc().StartKey, neverSplits.Desc().EndKey) {
+		t.Fatal("System config says range needs to be split")
+	}
+	if sysCfg.NeedsSplit(willSplit.Desc().StartKey, willSplit.Desc().EndKey) {
+		t.Fatal("System config says range needs to be split")
+	}
+
+	// There are no user db/table entries, everything should be added and
+	// processed as usual.
+	bq.MaybeAdd(neverSplits, proto.ZeroTimestamp)
+	bq.MaybeAdd(willSplit, proto.ZeroTimestamp)
+
+	if err := util.IsTrueWithin(func() bool {
+		return atomic.LoadInt32(&testQueue.processed) == 2
+	}, 250*time.Millisecond); err != nil {
+		t.Error(err)
+	}
+
+	if pc := atomic.LoadInt32(&queued); pc != 2 {
+		t.Errorf("expected queued count of 2; got %d", pc)
+	}
+
+	// Now add a user object, it will trigger a split.
+	// The range willSplit starts begins at the beginning of the user data range,
+	// which means keys.MaxReservedDescID+1.
+	config.TestingSetZoneConfig(keys.MaxReservedDescID+10, &config.ZoneConfig{RangeMaxBytes: 1 << 20})
+
+	// Check our config.
+	if sysCfg.NeedsSplit(neverSplits.Desc().StartKey, neverSplits.Desc().EndKey) {
+		t.Fatal("System config says range needs to be split")
+	}
+	if !sysCfg.NeedsSplit(willSplit.Desc().StartKey, willSplit.Desc().EndKey) {
+		t.Fatal("System config says range does not need to be split")
+	}
+
+	bq.MaybeAdd(neverSplits, proto.ZeroTimestamp)
+	bq.MaybeAdd(willSplit, proto.ZeroTimestamp)
+
+	if err := util.IsTrueWithin(func() bool {
+		return atomic.LoadInt32(&testQueue.processed) == 3
+	}, 250*time.Millisecond); err != nil {
+		t.Error(err)
+	}
+
+	if pc := atomic.LoadInt32(&queued); pc != 3 {
+		t.Errorf("expected queued count of 3; got %d", pc)
 	}
 }

--- a/storage/replicate_queue.go
+++ b/storage/replicate_queue.go
@@ -82,7 +82,7 @@ func (rq replicateQueue) shouldQueue(now proto.Timestamp, repl *Replica,
 		return
 	}
 
-	action, priority := rq.allocator.ComputeAction(*zone, repl.Desc())
+	action, priority := rq.allocator.ComputeAction(*zone, desc)
 	if action == aaNoop {
 		return false, 0
 	}

--- a/storage/split_queue.go
+++ b/storage/split_queue.go
@@ -113,7 +113,7 @@ func (sq *splitQueue) process(now proto.Timestamp, rng *Replica,
 	if float64(rng.stats.GetSize())/float64(zone.RangeMaxBytes) > 1 {
 		log.Infof("splitting %s size=%d max=%d", rng, rng.stats.GetSize(), zone.RangeMaxBytes)
 		if _, err = rng.AddCmd(rng.context(), &proto.AdminSplitRequest{
-			RequestHeader: proto.RequestHeader{Key: rng.Desc().StartKey},
+			RequestHeader: proto.RequestHeader{Key: desc.StartKey},
 		}); err != nil {
 			return err
 		}

--- a/storage/split_queue_test.go
+++ b/storage/split_queue_test.go
@@ -74,6 +74,11 @@ func TestSplitQueueShouldQueue(t *testing.T) {
 
 	splitQ := newSplitQueue(nil, tc.gossip)
 
+	cfg, err := tc.gossip.GetSystemConfig()
+	if err != nil {
+		t.Fatal(err)
+	}
+
 	for i, test := range testCases {
 		if err := tc.rng.stats.SetMVCCStats(tc.rng.rm.Engine(), engine.MVCCStats{KeyBytes: test.bytes}); err != nil {
 			t.Fatal(err)
@@ -84,7 +89,7 @@ func TestSplitQueueShouldQueue(t *testing.T) {
 		if err := tc.rng.setDesc(&copy); err != nil {
 			t.Fatal(err)
 		}
-		shouldQ, priority := splitQ.shouldQueue(proto.ZeroTimestamp, tc.rng)
+		shouldQ, priority := splitQ.shouldQueue(proto.ZeroTimestamp, tc.rng, cfg)
 		if shouldQ != test.shouldQ {
 			t.Errorf("%d: should queue expected %t; got %t", i, test.shouldQ, shouldQ)
 		}

--- a/storage/store.go
+++ b/storage/store.go
@@ -372,11 +372,11 @@ func NewStore(ctx StoreContext, eng engine.Engine, nodeDesc *proto.NodeDescripto
 
 	// Add range scanner and configure with queues.
 	s.scanner = newReplicaScanner(ctx.ScanInterval, ctx.ScanMaxIdleTime, newStoreRangeSet(s))
-	s.gcQueue = newGCQueue()
+	s.gcQueue = newGCQueue(s.ctx.Gossip)
 	s._splitQueue = newSplitQueue(s.db, s.ctx.Gossip)
-	s.verifyQueue = newVerifyQueue(s.ReplicaCount)
+	s.verifyQueue = newVerifyQueue(s.ctx.Gossip, s.ReplicaCount)
 	s.replicateQueue = makeReplicateQueue(s.ctx.Gossip, s.allocator(), s.ctx.Clock)
-	s._rangeGCQueue = newRangeGCQueue(s.db)
+	s._rangeGCQueue = newRangeGCQueue(s.db, s.ctx.Gossip)
 	s.scanner.AddQueues(s.gcQueue, s._splitQueue, s.verifyQueue, s.replicateQueue, s._rangeGCQueue)
 
 	return s

--- a/storage/verify_queue_test.go
+++ b/storage/verify_queue_test.go
@@ -53,10 +53,10 @@ func TestVerifyQueueShouldQueue(t *testing.T) {
 		{makeTS(verificationInterval.Nanoseconds()*2, 0), true, 2},
 	}
 
-	verifyQ := newVerifyQueue(nil)
+	verifyQ := newVerifyQueue(tc.gossip, nil)
 
 	for i, test := range testCases {
-		shouldQ, priority := verifyQ.shouldQueue(test.now, tc.rng)
+		shouldQ, priority := verifyQ.shouldQueue(test.now, tc.rng, nil /* system config not used */)
 		if shouldQ != test.shouldQ {
 			t.Errorf("%d: should queue expected %t; got %t", i, test.shouldQ, shouldQ)
 		}


### PR DESCRIPTION
Fixes #2499

Add a new queue implementation method: `acceptsUnsplitRanges`
If false, ranges are checked for needed splits due to zone configs
(zone boundaries only, not max size).
The check is performed both before `shouldQueue` and `process`.

Since we're loading the system config, pass it along to the
`shouldQueue` and `process` methods. Some queues use it, and we want
to make sure we work using the same information.

Queues that accept ranges that need splitting:
- range_gc_queue
- split_queue (obviously)
- verify_queue

Queues that don't accept ranges that need splitting.
- gc_queue (looks up GC policy)
- replicate_queue (looks up attributes)

The only difference with previous behavior is in the replicate_queue's
`process` method which did not bail out on ranges that needed splitting,
although its `shouldQueue` method did check.
