### PR TITLE
Don't use the table writer for zones config output.

### DIFF
--- a/cli/sql.go
+++ b/cli/sql.go
@@ -111,7 +111,7 @@ func runTerm(cmd *cobra.Command, args []string) {
 		fullStmt := strings.Join(stmt, "\n")
 		liner.AppendHistory(fullStmt)
 
-		if err := runQuery(db, fullStmt); err != nil {
+		if err := runPrettyQuery(db, fullStmt); err != nil {
 			fmt.Fprintln(osStdout, err)
 		}
 

--- a/cli/user.go
+++ b/cli/user.go
@@ -40,7 +40,7 @@ func runGetUser(cmd *cobra.Command, args []string) {
 		return
 	}
 	db := makeSQLClient()
-	err := runQuery(db, `SELECT * FROM system.users WHERE username=$1`, args[0])
+	err := runPrettyQuery(db, `SELECT * FROM system.users WHERE username=$1`, args[0])
 	if err != nil {
 		log.Error(err)
 		return
@@ -63,7 +63,7 @@ func runLsUsers(cmd *cobra.Command, args []string) {
 		return
 	}
 	db := makeSQLClient()
-	err := runQuery(db, `SELECT username FROM system.users`)
+	err := runPrettyQuery(db, `SELECT username FROM system.users`)
 	if err != nil {
 		log.Error(err)
 		return
@@ -86,7 +86,7 @@ func runRmUser(cmd *cobra.Command, args []string) {
 		return
 	}
 	db := makeSQLClient()
-	err := runQuery(db, `DELETE FROM system.users WHERE username=$1`, args[0])
+	err := runPrettyQuery(db, `DELETE FROM system.users WHERE username=$1`, args[0])
 	if err != nil {
 		log.Error(err)
 		return
@@ -120,7 +120,7 @@ func runSetUser(cmd *cobra.Command, args []string) {
 	}
 	db := makeSQLClient()
 	// TODO(marc): switch to UPSERT.
-	err = runQuery(db, `INSERT INTO system.users VALUES ($1, $2)`, args[0], hashed)
+	err = runPrettyQuery(db, `INSERT INTO system.users VALUES ($1, $2)`, args[0], hashed)
 	if err != nil {
 		log.Error(err)
 		return


### PR DESCRIPTION
This will make it easier to copy/paste.

Example:

```
$ ./cockroach zone --dev set 1000 /tmp/zone
$ ./cockroach zone --dev set 1010 /tmp/zone
$ ./cockroach zone --dev get 1000
replicas:
- attrs: [us-east-1a, ssd]
- attrs: [us-east-1b, ssd]
- attrs: [us-west-1b, ssd]
range_min_bytes: 8388608
range_max_bytes: 67108864

$./cockroach zone --dev ls
Object 1000:
replicas:
- attrs: [us-east-1a, ssd]
- attrs: [us-east-1b, ssd]
- attrs: [us-west-1b, ssd]
range_min_bytes: 8388608
range_max_bytes: 67108864

Object 1010:
replicas:
- attrs: [us-east-1a, ssd]
- attrs: [us-east-1b, ssd]
- attrs: [us-west-1b, ssd]
range_min_bytes: 8388608
range_max_bytes: 67108864
```
