### PR TITLE
Simplify encodeSQL{String,Ident,Bytes} interface.

### DIFF
--- a/sql/parser/datum.go
+++ b/sql/parser/datum.go
@@ -283,8 +283,7 @@ func (d DString) IsMin() bool {
 }
 
 func (d DString) String() string {
-	var scratch [64]byte
-	return string(encodeSQLString(scratch[0:0], []byte(d)))
+	return encodeSQLString(string(d))
 }
 
 // DBytes is the bytes Datum. The underlying type is a string because we want
@@ -331,8 +330,7 @@ func (d DBytes) IsMin() bool {
 }
 
 func (d DBytes) String() string {
-	var scratch [64]byte
-	return string(encodeSQLBytes(scratch[0:0], []byte(d)))
+	return encodeSQLBytes(string(d))
 }
 
 // DDate is the date Datum.

--- a/sql/parser/name.go
+++ b/sql/parser/name.go
@@ -30,7 +30,7 @@ type Name string
 
 // String formats an SQL identifier, applying proper escaping rules.
 func (n Name) String() string {
-	return encIdent(string(n))
+	return encodeSQLIdent(string(n))
 }
 
 // A NameList is a list of identifier.
@@ -45,7 +45,7 @@ func (l NameList) String() string {
 		if i > 0 {
 			_, _ = buf.WriteString(", ")
 		}
-		buf.WriteString(Name(n).String())
+		_, _ = buf.WriteString(Name(n).String())
 	}
 	return buf.String()
 }


### PR DESCRIPTION
Passing in a buf to append to made usage of these functions awkward and
was not actually saving an allocation (the scratch array was being
allocated on the heap due to escape analysis).
