### PR TITLE
Add cbrt math builtin function.

### DIFF
--- a/sql/parser/builtins.go
+++ b/sql/parser/builtins.go
@@ -475,6 +475,12 @@ var builtins = map[string][]builtin{
 		}),
 	},
 
+	"cbrt": {
+		floatBuiltin1(func(x float64) (Datum, error) {
+			return DFloat(math.Cbrt(x)), nil
+		}),
+	},
+
 	"ceil":    {ceilImpl},
 	"ceiling": {ceilImpl},
 

--- a/sql/testdata/builtin_function
+++ b/sql/testdata/builtin_function
@@ -503,6 +503,11 @@ SELECT sqrt(-1.0), sqrt(4.0)
 NaN 2
 
 query T
+SELECT cbrt(-1.0), cbrt(27.0)
+----
+-1 3
+
+query T
 SELECT tan(-5.0), tan(0.0), tan(5.0)
 ----
 3.3805150062465854 0 -3.3805150062465854


### PR DESCRIPTION
See #2042. The implementation uses `math.Cbrt`, which seems to give better results than `math.Pow(x, 1.0/3)`.
