### PR TITLE
Support non-covering indexes.

### DIFF
--- a/sql/explain.go
+++ b/sql/explain.go
@@ -78,6 +78,9 @@ func markDebug(plan planNode, mode explainMode) (planNode, error) {
 		t.explain = mode
 		return t, nil
 
+	case *indexJoinNode:
+		return markDebug(t.index, mode)
+
 	case *sortNode:
 		return markDebug(t.plan, mode)
 

--- a/sql/join.go
+++ b/sql/join.go
@@ -1,0 +1,146 @@
+// Copyright 2015 The Cockroach Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+// implied. See the License for the specific language governing
+// permissions and limitations under the License. See the AUTHORS file
+// for names of contributors.
+//
+// Author: Peter Mattis (peter@cockroachlabs.com)
+
+package sql
+
+import (
+	"github.com/cockroachdb/cockroach/proto"
+	"github.com/cockroachdb/cockroach/sql/parser"
+	"github.com/cockroachdb/cockroach/util/log"
+)
+
+const joinBatchSize = 100
+
+// An indexJoinNode implements joining of results from an index with the rows
+// of a table. The index side of the join is pulled first and the resulting
+// rows are used to lookup rows in the table. The work is batched: we pull
+// joinBatchSize rows from the index and use the primary key to construct spans
+// that are looked up in the table.
+type indexJoinNode struct {
+	index            *scanNode
+	table            *scanNode
+	primaryKeyPrefix proto.Key
+	colIDtoRowIndex  map[ColumnID]int
+	err              error
+}
+
+func makeIndexJoin(indexScan *scanNode) (*indexJoinNode, error) {
+	// Copy the index scan node into a new table scan node and reset the fields
+	// that were set up for the index scan.
+	table := &scanNode{}
+	*table = *indexScan
+	table.index = &table.desc.PrimaryIndex
+	table.spans = nil
+	table.reverse = false
+	table.isSecondaryIndex = false
+	table.initOrdering()
+
+	// Reset the render targets for the index scan to be exactly the primary key
+	// columns.
+	indexScan.render = nil
+	colIDtoRowIndex := map[ColumnID]int{}
+	for i, colName := range table.desc.PrimaryIndex.ColumnNames {
+		sexpr := parser.SelectExpr{
+			Expr: &parser.QualifiedName{Base: parser.Name(colName)},
+		}
+		if err := indexScan.addRender(sexpr); err != nil {
+			return nil, err
+		}
+		colIDtoRowIndex[table.desc.PrimaryIndex.ColumnIDs[i]] = i
+	}
+	indexScan.initOrdering()
+
+	primaryKeyPrefix := proto.Key(MakeIndexKeyPrefix(table.desc.ID, table.index.ID))
+
+	return &indexJoinNode{
+		index:            indexScan,
+		table:            table,
+		primaryKeyPrefix: primaryKeyPrefix,
+		colIDtoRowIndex:  colIDtoRowIndex,
+	}, nil
+}
+
+func (n *indexJoinNode) Columns() []string {
+	return n.table.Columns()
+}
+
+func (n *indexJoinNode) Ordering() []int {
+	return n.table.Ordering()
+}
+
+func (n *indexJoinNode) Values() parser.DTuple {
+	return n.table.Values()
+}
+
+func (n *indexJoinNode) Next() bool {
+	// First, try to pull rows from the table.
+	if n.table.kvs != nil && n.table.Next() {
+		return true
+	}
+	if n.err = n.table.Err(); n.err != nil {
+		return false
+	}
+
+	// The table is out of rows. Pull primary keys from the index.
+	n.table.kvs = nil
+	n.table.kvIndex = 0
+	n.table.spans = n.table.spans[0:0]
+
+	for len(n.table.spans) < joinBatchSize {
+		if !n.index.Next() {
+			// The index is out of rows or an error occurred.
+			if n.err = n.index.Err(); n.err != nil {
+				return false
+			}
+			if len(n.table.spans) == 0 {
+				// The index is out of rows.
+				return false
+			}
+			break
+		}
+		vals := n.index.Values()
+		if log.V(3) {
+			log.Infof("primary key vals: %v", vals)
+		}
+
+		var primaryIndexKey []byte
+		primaryIndexKey, _, n.err = encodeIndexKey(
+			n.table.index.ColumnIDs, n.colIDtoRowIndex, vals, n.primaryKeyPrefix)
+		if n.err != nil {
+			return false
+		}
+		key := proto.Key(primaryIndexKey)
+		n.table.spans = append(n.table.spans, span{
+			start: key,
+			end:   key.PrefixEnd(),
+		})
+	}
+
+	if n.table.Next() {
+		return true
+	}
+	n.err = n.table.Err()
+	return false
+}
+
+func (n *indexJoinNode) Err() error {
+	return n.err
+}
+
+func (n *indexJoinNode) ExplainPlan() (name, description string, children []planNode) {
+	return "index-join", "", []planNode{n.index, n.table}
+}

--- a/sql/plan.go
+++ b/sql/plan.go
@@ -148,9 +148,8 @@ type planNode interface {
 }
 
 var _ planNode = &groupNode{}
+var _ planNode = &indexJoinNode{}
 var _ planNode = &limitNode{}
 var _ planNode = &scanNode{}
 var _ planNode = &sortNode{}
 var _ planNode = &valuesNode{}
-
-// TODO(pmattis): joinNode.

--- a/sql/scan.go
+++ b/sql/scan.go
@@ -310,25 +310,27 @@ func (n *scanNode) initScan() bool {
 		}
 	}
 
-	// Prepare our index key vals slice.
-	if n.valTypes, n.err = makeKeyVals(n.desc, n.columnIDs); n.err != nil {
-		return false
-	}
-	n.vals = make([]parser.Datum, len(n.valTypes))
-
-	if n.isSecondaryIndex && n.index.Unique {
-		// Unique secondary indexes have a value that is the primary index
-		// key. Prepare implicitVals for use in decoding this value.
-		if n.implicitValTypes, n.err = makeKeyVals(n.desc, n.index.ImplicitColumnIDs); n.err != nil {
+	if n.valTypes == nil {
+		// Prepare our index key vals slice.
+		if n.valTypes, n.err = makeKeyVals(n.desc, n.columnIDs); n.err != nil {
 			return false
 		}
-		n.implicitVals = make([]parser.Datum, len(n.implicitValTypes))
-	}
+		n.vals = make([]parser.Datum, len(n.valTypes))
 
-	// Prepare a map from column ID to column kind used for unmarshalling values.
-	n.colKind = make(colKindMap, len(n.desc.Columns))
-	for _, col := range n.desc.Columns {
-		n.colKind[col.ID] = col.Type.Kind
+		if n.isSecondaryIndex && n.index.Unique {
+			// Unique secondary indexes have a value that is the primary index
+			// key. Prepare implicitVals for use in decoding this value.
+			if n.implicitValTypes, n.err = makeKeyVals(n.desc, n.index.ImplicitColumnIDs); n.err != nil {
+				return false
+			}
+			n.implicitVals = make([]parser.Datum, len(n.implicitValTypes))
+		}
+
+		// Prepare a map from column ID to column kind used for unmarshalling values.
+		n.colKind = make(colKindMap, len(n.desc.Columns))
+		for _, col := range n.desc.Columns {
+			n.colKind[col.ID] = col.Type.Kind
+		}
 	}
 	return true
 }

--- a/sql/testdata/select_non_covering_index
+++ b/sql/testdata/select_non_covering_index
@@ -43,3 +43,23 @@ query III
 SELECT * FROM t WHERE c = 6
 ----
 4 5 6
+
+query III
+SELECT * FROM t WHERE c > 0 ORDER BY c DESC
+----
+4 5 6
+1 2 3
+
+query ITT
+EXPLAIN SELECT * FROM t WHERE c > 0 ORDER BY c DESC
+----
+0 index-join
+1 revscan    t@c /1-
+1 scan       t@primary
+
+query ITT
+EXPLAIN SELECT * FROM t WHERE c > 0 ORDER BY c
+----
+0 index-join
+1 scan       t@c /1-
+1 scan       t@primary

--- a/sql/testdata/select_non_covering_index
+++ b/sql/testdata/select_non_covering_index
@@ -1,0 +1,45 @@
+statement ok
+CREATE TABLE t (
+  a INT PRIMARY KEY,
+  b INT,
+  c INT,
+  INDEX b (b),
+  UNIQUE INDEX c (c)
+)
+
+statement ok
+INSERT INTO t VALUES (1, 2, 3), (4, 5, 6)
+
+query ITT
+EXPLAIN SELECT * FROM t WHERE b = 2
+----
+0 index-join
+1 scan       t@b /2-/3
+1 scan       t@primary
+
+query ITTB
+EXPLAIN (DEBUG) SELECT * FROM t WHERE b = 2
+----
+0 /t/b/2/1 NULL true
+
+query III
+SELECT * FROM t WHERE b = 2
+----
+1 2 3
+
+query ITT
+EXPLAIN SELECT * FROM t WHERE c = 6
+----
+0 index-join
+1 scan       t@c /6-/7
+1 scan       t@primary
+
+query ITTB
+EXPLAIN (DEBUG) SELECT * FROM t WHERE c = 6
+----
+0 /t/c/6 /4 true
+
+query III
+SELECT * FROM t WHERE c = 6
+----
+4 5 6


### PR DESCRIPTION
Added indexJoinNode which is a simplified type of join used during index
scans which have to lookup the full row.

Fixes #2190.
