### PR TITLE
Store unmarshalled system config in gossip.

### DIFF
--- a/storage/gc_queue_test.go
+++ b/storage/gc_queue_test.go
@@ -91,9 +91,9 @@ func TestGCQueueShouldQueue(t *testing.T) {
 	}
 
 	gcQ := newGCQueue(tc.gossip)
-	cfg, err := tc.gossip.GetSystemConfig()
-	if err != nil {
-		t.Fatal(err)
+	cfg := tc.gossip.GetSystemConfig()
+	if cfg == nil {
+		t.Fatal("nil config")
 	}
 
 	for i, test := range testCases {
@@ -209,9 +209,9 @@ func TestGCQueueProcess(t *testing.T) {
 		}
 	}
 
-	cfg, err := tc.gossip.GetSystemConfig()
-	if err != nil {
-		t.Fatal(err)
+	cfg := tc.gossip.GetSystemConfig()
+	if cfg == nil {
+		t.Fatal("nil config")
 	}
 
 	// Process through a scan queue.
@@ -335,9 +335,9 @@ func TestGCQueueIntentResolution(t *testing.T) {
 		}
 	}
 
-	cfg, err := tc.gossip.GetSystemConfig()
-	if err != nil {
-		t.Fatal(err)
+	cfg := tc.gossip.GetSystemConfig()
+	if cfg == nil {
+		t.Fatal("nil config")
 	}
 
 	// Process through a scan queue.
@@ -348,7 +348,7 @@ func TestGCQueueIntentResolution(t *testing.T) {
 
 	// Iterate through all values to ensure intents have been fully resolved.
 	meta := &engine.MVCCMetadata{}
-	err = tc.store.Engine().Iterate(engine.MVCCEncodeKey(proto.KeyMin), engine.MVCCEncodeKey(proto.KeyMax), func(kv proto.RawKeyValue) (bool, error) {
+	err := tc.store.Engine().Iterate(engine.MVCCEncodeKey(proto.KeyMin), engine.MVCCEncodeKey(proto.KeyMax), func(kv proto.RawKeyValue) (bool, error) {
 		if key, _, isValue := engine.MVCCDecodeKey(kv.Key); !isValue {
 			if err := gogoproto.Unmarshal(kv.Value, meta); err != nil {
 				t.Fatalf("unable to unmarshal mvcc metadata for key %s", key)

--- a/storage/queue.go
+++ b/storage/queue.go
@@ -180,9 +180,9 @@ func (bq *baseQueue) Add(repl *Replica, priority float64) error {
 // dropped.
 func (bq *baseQueue) MaybeAdd(repl *Replica, now proto.Timestamp) {
 	// Load the system config.
-	cfg, err := bq.gossip.GetSystemConfig()
-	if err != nil {
-		log.Error(err)
+	cfg := bq.gossip.GetSystemConfig()
+	if cfg == nil {
+		log.Infof("no system config available. skipping...")
 		return
 	}
 
@@ -323,9 +323,9 @@ func (bq *baseQueue) processOne(clock *hlc.Clock) {
 	now := clock.Now()
 
 	// Load the system config.
-	cfg, err := bq.gossip.GetSystemConfig()
-	if err != nil {
-		log.Error(err)
+	cfg := bq.gossip.GetSystemConfig()
+	if cfg == nil {
+		log.Infof("no system config available. skipping...")
 		return
 	}
 

--- a/storage/queue_test.go
+++ b/storage/queue_test.go
@@ -50,6 +50,13 @@ func gossipForTest(t *testing.T) (*gossip.Gossip, *stop.Stopper) {
 		t.Fatal(err)
 	}
 
+	// Wait for SystemConfig.
+	if err := util.IsTrueWithin(func() bool {
+		return g.GetSystemConfig() != nil
+	}, 100*time.Millisecond); err != nil {
+		t.Fatal(err)
+	}
+
 	return g, stopper
 }
 
@@ -373,9 +380,9 @@ func TestAcceptsUnsplitRanges(t *testing.T) {
 	bq.Start(clock, stopper)
 
 	// Check our config.
-	sysCfg, err := g.GetSystemConfig()
-	if err != nil {
-		t.Fatal(err)
+	sysCfg := g.GetSystemConfig()
+	if sysCfg == nil {
+		t.Fatal("nil config")
 	}
 	if sysCfg.NeedsSplit(neverSplits.Desc().StartKey, neverSplits.Desc().EndKey) {
 		t.Fatal("System config says range needs to be split")

--- a/storage/replica_raftstorage.go
+++ b/storage/replica_raftstorage.go
@@ -18,6 +18,7 @@
 package storage
 
 import (
+	"fmt"
 	"sync/atomic"
 	"unsafe"
 
@@ -348,9 +349,9 @@ func (r *Replica) updateRangeInfo() error {
 	// since the original range and the new range might belong
 	// to different zones.
 	// Load the system config.
-	cfg, err := r.rm.Gossip().GetSystemConfig()
-	if err != nil {
-		return err
+	cfg := r.rm.Gossip().GetSystemConfig()
+	if cfg == nil {
+		return fmt.Errorf("no system config available")
 	}
 
 	// Find zone config for this range.

--- a/storage/split_queue_test.go
+++ b/storage/split_queue_test.go
@@ -74,9 +74,9 @@ func TestSplitQueueShouldQueue(t *testing.T) {
 
 	splitQ := newSplitQueue(nil, tc.gossip)
 
-	cfg, err := tc.gossip.GetSystemConfig()
-	if err != nil {
-		t.Fatal(err)
+	cfg := tc.gossip.GetSystemConfig()
+	if cfg == nil {
+		t.Fatal("nil config")
 	}
 
 	for i, test := range testCases {


### PR DESCRIPTION
Fixes #2530

This is done outside of the infostore to avoid unmarshalling under the
main gossip lock.
Instead, the system config gets its own set of callbacks and its own
lock.
