### PR TITLE
Disable TestStoreRangeDownReplicate

### DIFF
--- a/storage/client_raft_test.go
+++ b/storage/client_raft_test.go
@@ -583,6 +583,11 @@ func getRangeMetadata(key proto.Key, mtc *multiTestContext, t *testing.T) proto.
 // over-replicated ranges and remove replicas from them.
 func TestStoreRangeDownReplicate(t *testing.T) {
 	defer leaktest.AfterTest(t)
+	// #2547, this test is running very slow in circle CI and not completing
+	// with ten seconds. This *may* be due to the speed of the VMs, but test
+	// output also indicates that the test may be getting stuck. Disabling until
+	// it can be investigated.
+	t.Skip("TODO(mrtracy)")
 	mtc := startMultiTestContext(t, 5)
 	defer mtc.Stop()
 	store0 := mtc.stores[0]


### PR DESCRIPTION
This test is timing out in CircleCI. It _might_ be possible to fix by extending
the timeout, but based on the log output there may be a problem with the test
framework causing an "infinite loop" of sorts in the DistSender.
