### PR TITLE
Add support for SIMILAR TO and NOT SIMILAR TO pattern matching commands

### DIFF
--- a/sql/analyze.go
+++ b/sql/analyze.go
@@ -1084,7 +1084,7 @@ func simplifyComparisonExpr(n *parser.ComparisonExpr) parser.Expr {
 	// simplifyExpr cannot handle them. For example, "lower(a) = 'foo'"
 	if isVar(n.Left) && isDatum(n.Right) {
 		// All of the comparison operators have the property that when comparing to
-		// NULL they evaulate to NULL (see evalComparisonOp). NULL is not the same
+		// NULL they evaluate to NULL (see evalComparisonOp). NULL is not the same
 		// as false, but in the context of a WHERE clause, NULL is considered
 		// not-true which is the same as false.
 		if n.Right == parser.DNull {
@@ -1132,7 +1132,8 @@ func simplifyComparisonExpr(n *parser.ComparisonExpr) parser.Expr {
 		case parser.SimilarTo:
 			// a SIMILAR TO "foo.*" -> a >= "foo" AND a < "fop"
 			if d, ok := n.Right.(parser.DString); ok {
-				if re, err := regexp.Compile(string(d)); err == nil {
+				pattern := parser.SimilarEscape(string(d))
+				if re, err := regexp.Compile(pattern); err == nil {
 					prefix, complete := re.LiteralPrefix()
 					return makePrefixRange(parser.DString(prefix), n.Left, complete)
 				}

--- a/sql/analyze_test.go
+++ b/sql/analyze_test.go
@@ -207,11 +207,10 @@ func TestSimplifyExpr(t *testing.T) {
 		{`i LIKE 'foo%'`, `i >= 'foo' AND i < 'fop'`},
 		{`i LIKE 'foo_'`, `i >= 'foo' AND i < 'fop'`},
 		{`i LIKE 'bar_foo%'`, `i >= 'bar' AND i < 'bas'`},
-		// TODO(pmattis): unsupported comparison operator: SIMILAR TO
-		// {`i SIMILAR TO '.*'`, `true`},
-		// {`i SIMILAR TO 'foo'`, `i = 'foo'`},
-		// {`i SIMILAR TO 'foo.*'`, `i >= 'foo' AND i < 'fop'`},
-		// {`i SIMILAR TO '(foo|foobar).*'`, `i >= 'foo' AND i < 'fop'`},
+		{`i SIMILAR TO '%'`, `true`},
+		{`i SIMILAR TO 'foo'`, `i = 'foo'`},
+		{`i SIMILAR TO 'foo%'`, `i >= 'foo' AND i < 'fop'`},
+		{`i SIMILAR TO '(foo|foobar)%'`, `i >= 'foo' AND i < 'fop'`},
 	}
 	for _, d := range testData {
 		expr, _ := parseAndNormalizeExpr(t, d.expr)
@@ -240,9 +239,8 @@ func TestSimplifyNotExpr(t *testing.T) {
 		{`NOT a NOT IN (1, 2)`, `a IN (1, 2)`, true},
 		{`NOT i LIKE 'foo'`, `true`, false},
 		{`NOT i NOT LIKE 'foo'`, `i = 'foo'`, false},
-		// TODO(pmattis): unsupported comparison operator: SIMILAR TO
-		// {`NOT i SIMILAR TO 'foo'`, `true`, false},
-		// {`NOT i NOT SIMILAR TO 'foo'`, `i = 'foo'`, false},
+		{`NOT i SIMILAR TO 'foo'`, `true`, false},
+		{`NOT i NOT SIMILAR TO 'foo'`, `i = 'foo'`, false},
 		{`NOT (a != 1 AND b != 1)`, `a = 1 OR b = 1`, false},
 		{`NOT (a != 1 OR a < 1)`, `a = 1`, false},
 	}

--- a/sql/parser/type_check.go
+++ b/sql/parser/type_check.go
@@ -200,6 +200,9 @@ func typeCheckComparisonOp(op ComparisonOp, dummyLeft, dummyRight Datum) (Datum,
 	case NotLike:
 		// NotLike(left, right) is implemented as !Like(left, right)
 		op = Like
+	case NotSimilarTo:
+		// NotSimilarTo(left, right) is implemented as !SimilarTo(left, right)
+		op = SimilarTo
 	}
 
 	lType := reflect.TypeOf(dummyLeft)
@@ -219,11 +222,6 @@ func typeCheckComparisonOp(op ComparisonOp, dummyLeft, dummyRight Datum) (Datum,
 		}
 
 		return cmpOpResultType, nil
-	}
-
-	switch op {
-	case SimilarTo, NotSimilarTo:
-		return nil, util.Errorf("TODO(pmattis): unsupported comparison operator: %s", op)
 	}
 
 	return nil, fmt.Errorf("unsupported comparison operator: <%s> %s <%s>",


### PR DESCRIPTION
See #2242.
Based on the [PostgreSQL docs](http://www.postgresql.org/docs/9.0/static/functions-matching.html) and [Firebird docs](http://www.firebirdsql.org/refdocs/langrefupd25-similar-to.html), it looks like the the only variation between SQL-style regular expressions and POSIX regular expressions is their handling of wildcards. I haven't been able to find any other differences, so it's pretty simple to make the translation to standard regexp patterns.

Questions:
- Because errors while compiling the regexp are a very real possibility here, should I do anything more than just returning a regexp compilation error here?
- For here and above with LIKE, I'm wondering if [`regexp.Compile`](https://golang.org/pkg/regexp/#Compile) or [`regexp.CompilePOSIX`](https://golang.org/pkg/regexp/#CompilePOSIX) is the right choice. I haven't seen any specific reasons why the extra restrictions placed on the POSIX regular expressions would be needed, but I wanted to run the issue by someone anyway.
