### PR TITLE
Sim: Add Replica Action

### DIFF
--- a/proto/api.go
+++ b/proto/api.go
@@ -29,6 +29,13 @@ import (
 // A RangeID is a unique ID associated to a Raft consensus group.
 type RangeID int64
 
+// RangeIDSlice implements sort.Interface.
+type RangeIDSlice []RangeID
+
+func (r RangeIDSlice) Len() int           { return len(r) }
+func (r RangeIDSlice) Swap(i, j int)      { r[i], r[j] = r[j], r[i] }
+func (r RangeIDSlice) Less(i, j int) bool { return r[i] < r[j] }
+
 // IsEmpty returns true if the client command ID has zero values.
 func (ccid ClientCmdID) IsEmpty() bool {
 	return ccid.WallTime == 0 && ccid.Random == 0

--- a/proto/metadata.go
+++ b/proto/metadata.go
@@ -31,6 +31,13 @@ import (
 // NodeID is a custom type for a cockroach node ID. (not a raft node ID)
 type NodeID int32
 
+// NodeIDSlice implements sort.Interface.
+type NodeIDSlice []NodeID
+
+func (n NodeIDSlice) Len() int           { return len(n) }
+func (n NodeIDSlice) Swap(i, j int)      { n[i], n[j] = n[j], n[i] }
+func (n NodeIDSlice) Less(i, j int) bool { return n[i] < n[j] }
+
 // String implements the fmt.Stringer interface.
 // It is used to format the ID for use in Gossip keys.
 func (n NodeID) String() string {
@@ -39,6 +46,13 @@ func (n NodeID) String() string {
 
 // StoreID is a custom type for a cockroach store ID.
 type StoreID int32
+
+// StoreIDSlice implements sort.Interface.
+type StoreIDSlice []StoreID
+
+func (s StoreIDSlice) Len() int           { return len(s) }
+func (s StoreIDSlice) Swap(i, j int)      { s[i], s[j] = s[j], s[i] }
+func (s StoreIDSlice) Less(i, j int) bool { return s[i] < s[j] }
 
 // String implements the fmt.Stringer interface.
 // It is used to format the ID for use in Gossip keys.

--- a/storage/allocator.go
+++ b/storage/allocator.go
@@ -61,11 +61,12 @@ const (
 // recommended by the allocator.
 type AllocatorAction int
 
+// These are the possible allocator actions.
 const (
-	aaNoop AllocatorAction = iota
-	aaRemove
-	aaAdd
-	aaRemoveDead
+	AANoop AllocatorAction = iota
+	AARemove
+	AAAdd
+	AARemoveDead
 )
 
 // RebalancingOptions are configurable options which effect the way that the
@@ -135,7 +136,7 @@ func (a *Allocator) ComputeAction(zone config.ZoneConfig, desc *proto.RangeDescr
 		// Adjust the priority by the number of dead replicas the range has.
 		quorum := computeQuorum(len(desc.Replicas))
 		liveReplicas := len(desc.Replicas) - len(deadReplicas)
-		return aaRemoveDead, removeDeadReplicaPriority + float64(quorum-liveReplicas)
+		return AARemoveDead, removeDeadReplicaPriority + float64(quorum-liveReplicas)
 	}
 
 	// TODO(mrtracy): Handle non-homogenous and mismatched attribute sets.
@@ -146,17 +147,17 @@ func (a *Allocator) ComputeAction(zone config.ZoneConfig, desc *proto.RangeDescr
 		// Priority is adjusted by the difference between the current replica
 		// count and the quorum of the desired replica count.
 		neededQuorum := computeQuorum(need)
-		return aaAdd, addMissingReplicaPriority + float64(neededQuorum-have)
+		return AAAdd, addMissingReplicaPriority + float64(neededQuorum-have)
 	}
 	if have > need {
 		// Range is over-replicated, and should remove a replica.
 		// Ranges with an even number of replicas get extra priority because
 		// they have a more fragile quorum.
-		return aaRemove, removeExtraReplicaPriority - float64(have%2)
+		return AARemove, removeExtraReplicaPriority - float64(have%2)
 	}
 
 	// Nothing to do.
-	return aaNoop, 0
+	return AANoop, 0
 }
 
 // AllocateTarget returns a suitable store for a new allocation with the
@@ -308,9 +309,9 @@ func (a Allocator) RebalanceTarget(required proto.Attributes, existing []proto.R
 	return s
 }
 
-// shouldRebalance returns whether the specified store should attempt to
+// ShouldRebalance returns whether the specified store should attempt to
 // rebalance a replica to another store.
-func (a Allocator) shouldRebalance(storeID proto.StoreID) bool {
+func (a Allocator) ShouldRebalance(storeID proto.StoreID) bool {
 	if !a.options.AllowRebalance {
 		return false
 	}

--- a/storage/allocator_test.go
+++ b/storage/allocator_test.go
@@ -441,10 +441,10 @@ func TestAllocatorRebalance(t *testing.T) {
 		}
 	}
 
-	// Verify shouldRebalance results.
+	// Verify ShouldRebalance results.
 	a.options.Deterministic = true
 	for i, store := range stores {
-		result := a.shouldRebalance(store.StoreID)
+		result := a.ShouldRebalance(store.StoreID)
 		if expResult := (i >= 2); expResult != result {
 			t.Errorf("%d: expected rebalance %t; got %t", i, expResult, result)
 		}
@@ -490,10 +490,10 @@ func TestAllocatorRebalanceByCapacity(t *testing.T) {
 		}
 	}
 
-	// Verify shouldRebalance results.
+	// Verify ShouldRebalance results.
 	a.options.Deterministic = true
 	for i, store := range stores {
-		result := a.shouldRebalance(store.StoreID)
+		result := a.ShouldRebalance(store.StoreID)
 		if expResult := (i < 3); expResult != result {
 			t.Errorf("%d: expected rebalance %t; got %t", i, expResult, result)
 		}
@@ -541,10 +541,10 @@ func TestAllocatorRebalanceByCount(t *testing.T) {
 		}
 	}
 
-	// Verify shouldRebalance results.
+	// Verify ShouldRebalance results.
 	a.options.Deterministic = true
 	for i, store := range stores {
-		result := a.shouldRebalance(store.StoreID)
+		result := a.ShouldRebalance(store.StoreID)
 		if expResult := (i < 3); expResult != result {
 			t.Errorf("%d: expected rebalance %t; got %t", i, expResult, result)
 		}
@@ -702,7 +702,7 @@ func TestAllocatorComputeAction(t *testing.T) {
 					},
 				},
 			},
-			expectedAction: aaRemoveDead,
+			expectedAction: AARemoveDead,
 		},
 		// Needs Three replicas, one is on a dead store.
 		{
@@ -740,7 +740,7 @@ func TestAllocatorComputeAction(t *testing.T) {
 					},
 				},
 			},
-			expectedAction: aaRemoveDead,
+			expectedAction: AARemoveDead,
 		},
 		// Needs five replicas, one is on a dead store.
 		{
@@ -788,7 +788,7 @@ func TestAllocatorComputeAction(t *testing.T) {
 					},
 				},
 			},
-			expectedAction: aaRemoveDead,
+			expectedAction: AARemoveDead,
 		},
 		// Needs Three replicas, have two
 		{
@@ -821,7 +821,7 @@ func TestAllocatorComputeAction(t *testing.T) {
 					},
 				},
 			},
-			expectedAction: aaAdd,
+			expectedAction: AAAdd,
 		},
 		// Needs Five replicas, have four.
 		{
@@ -870,7 +870,7 @@ func TestAllocatorComputeAction(t *testing.T) {
 					},
 				},
 			},
-			expectedAction: aaAdd,
+			expectedAction: AAAdd,
 		},
 		// Need three replicas, have four.
 		{
@@ -913,7 +913,7 @@ func TestAllocatorComputeAction(t *testing.T) {
 					},
 				},
 			},
-			expectedAction: aaRemove,
+			expectedAction: AARemove,
 		},
 		// Need three replicas, have five.
 		{
@@ -961,7 +961,7 @@ func TestAllocatorComputeAction(t *testing.T) {
 					},
 				},
 			},
-			expectedAction: aaRemove,
+			expectedAction: AARemove,
 		},
 		// Three replicas have three, none of the replicas in the store pool.
 		{
@@ -999,7 +999,7 @@ func TestAllocatorComputeAction(t *testing.T) {
 					},
 				},
 			},
-			expectedAction: aaNoop,
+			expectedAction: AANoop,
 		},
 		// Three replicas have three.
 		{
@@ -1037,7 +1037,7 @@ func TestAllocatorComputeAction(t *testing.T) {
 					},
 				},
 			},
-			expectedAction: aaNoop,
+			expectedAction: AANoop,
 		},
 	}
 
@@ -1048,7 +1048,7 @@ func TestAllocatorComputeAction(t *testing.T) {
 			t.Errorf("Test case %d expected action %d, got action %d", i, tcase.expectedAction, action)
 			continue
 		}
-		if tcase.expectedAction != aaNoop && priority >= lastPriority {
+		if tcase.expectedAction != AANoop && priority >= lastPriority {
 			t.Errorf("Test cases should have descending priority. Case %d had priority %f, previous case had priority %f", i, priority, lastPriority)
 		}
 		lastPriority = priority
@@ -1118,7 +1118,7 @@ func Example_rebalancing() {
 		// Next loop through test stores and maybe rebalance.
 		for j := 0; j < len(testStores); j++ {
 			ts := &testStores[j]
-			if alloc.shouldRebalance(ts.StoreID) {
+			if alloc.ShouldRebalance(ts.StoreID) {
 				target := alloc.RebalanceTarget(proto.Attributes{}, []proto.Replica{{NodeID: ts.Node.NodeID, StoreID: ts.StoreID}})
 				if target != nil {
 					testStores[j].rebalance(&testStores[int(target.StoreID)], alloc.randGen.Int63n(1<<20))

--- a/storage/replicate_queue.go
+++ b/storage/replicate_queue.go
@@ -84,11 +84,11 @@ func (rq replicateQueue) shouldQueue(now proto.Timestamp, repl *Replica,
 	}
 
 	action, priority := rq.allocator.ComputeAction(*zone, desc)
-	if action != aaNoop {
+	if action != AANoop {
 		return true, priority
 	}
 	// See if there is a rebalancing opportunity present.
-	shouldRebalance := rq.allocator.shouldRebalance(repl.rm.StoreID())
+	shouldRebalance := rq.allocator.ShouldRebalance(repl.rm.StoreID())
 	return shouldRebalance, 0
 }
 
@@ -111,7 +111,7 @@ func (rq replicateQueue) process(now proto.Timestamp, repl *Replica, sysCfg *con
 	}
 
 	switch action {
-	case aaAdd:
+	case AAAdd:
 		newStore, err := rq.allocator.AllocateTarget(zone.ReplicaAttrs[0], desc.Replicas, true, nil)
 		if err != nil {
 			return err
@@ -123,7 +123,7 @@ func (rq replicateQueue) process(now proto.Timestamp, repl *Replica, sysCfg *con
 		if err = repl.ChangeReplicas(proto.ADD_REPLICA, newReplica, desc); err != nil {
 			return err
 		}
-	case aaRemove:
+	case AARemove:
 		removeReplica, err := rq.allocator.RemoveTarget(desc.Replicas)
 		if err != nil {
 			return err
@@ -135,7 +135,7 @@ func (rq replicateQueue) process(now proto.Timestamp, repl *Replica, sysCfg *con
 		if removeReplica.StoreID == repl.rm.StoreID() {
 			return nil
 		}
-	case aaRemoveDead:
+	case AARemoveDead:
 		if len(deadReplicas) == 0 {
 			if log.V(1) {
 				log.Warningf("Range of replica %s was identified as having dead replicas, but no dead replicas were found.", repl)
@@ -145,7 +145,7 @@ func (rq replicateQueue) process(now proto.Timestamp, repl *Replica, sysCfg *con
 		if err = repl.ChangeReplicas(proto.REMOVE_REPLICA, deadReplicas[0], desc); err != nil {
 			return err
 		}
-	case aaNoop:
+	case AANoop:
 		// The Noop case will result if this replica was queued in order to
 		// rebalance. Attempt to find a rebalancing target.
 		rebalanceStore := rq.allocator.RebalanceTarget(zone.ReplicaAttrs[0], desc.Replicas)

--- a/storage/simulation/cluster.go
+++ b/storage/simulation/cluster.go
@@ -19,6 +19,7 @@ package main
 
 import (
 	"bytes"
+	"fmt"
 	"math/rand"
 	"sort"
 
@@ -45,9 +46,11 @@ type Cluster struct {
 	storeGossiper *gossiputil.StoreGossiper
 	nodes         map[proto.NodeID]*Node
 	stores        map[proto.StoreID]*Store
+	storeIDs      []proto.StoreID // sorted
 	ranges        map[proto.RangeID]*Range
 	rand          *rand.Rand
 	seed          int64
+	epoch         int
 }
 
 // createCluster generates a new cluster using the provided stopper and the
@@ -80,14 +83,14 @@ func createCluster(stopper *stop.Stopper, nodeCount int) *Cluster {
 
 	// Add a single range and add to this first node's first store.
 	firstRange := c.addRange()
-	firstRange.attachRangeToStore(c.stores[proto.StoreID(0)])
+	firstRange.addReplica(c.stores[proto.StoreID(0)])
 	return c
 }
 
 // addNewNodeWithStore adds new node with a single store.
 func (c *Cluster) addNewNodeWithStore() {
 	nodeID := proto.NodeID(len(c.nodes))
-	c.nodes[nodeID] = newNode(nodeID)
+	c.nodes[nodeID] = newNode(nodeID, c.gossip)
 	c.addStore(nodeID)
 }
 
@@ -97,6 +100,18 @@ func (c *Cluster) addStore(nodeID proto.NodeID) *Store {
 	s := n.addNewStore()
 	storeID, _ := s.getIDs()
 	c.stores[storeID] = s
+
+	// Save a sorted array of store IDs since to avoid having to calculate them
+	// multiple times.
+	var storeIDs []int
+	for storeID := range c.stores {
+		storeIDs = append(storeIDs, int(storeID))
+	}
+	sort.Ints(storeIDs)
+	c.storeIDs = []proto.StoreID{}
+	for _, storeID := range storeIDs {
+		c.storeIDs = append(c.storeIDs, proto.StoreID(storeID))
+	}
 	return s
 }
 
@@ -104,29 +119,125 @@ func (c *Cluster) addStore(nodeID proto.NodeID) *Store {
 // store.
 func (c *Cluster) addRange() *Range {
 	rangeID := proto.RangeID(len(c.ranges))
-	newRng := newRange(rangeID)
+	newRng := newRange(rangeID, c.allocator)
 	c.ranges[rangeID] = newRng
 	return newRng
 }
 
+// splitRangeRandom splits a random range from within the cluster.
 func (c *Cluster) splitRangeRandom() {
 	rangeID := proto.RangeID(c.rand.Int63n(int64(len(c.ranges))))
 	c.splitRange(rangeID)
 }
 
+// splitRangeLast splits the last added range in the cluster.
 func (c *Cluster) splitRangeLast() {
 	rangeID := proto.RangeID(len(c.ranges) - 1)
 	c.splitRange(rangeID)
 }
 
+// splitRange "splits" a range. This split creates a new range with new
+// replicas on the same stores as the passed in range. The new range has the
+// same zone config as the original range.
 func (c *Cluster) splitRange(rangeID proto.RangeID) {
 	newRange := c.addRange()
 	originalRange := c.ranges[rangeID]
 	newRange.splitRange(originalRange)
 }
 
+// runEpoch steps through a single instance of the simulator. Each epoch
+// performs the following steps:
+// 1) The status of every store is gossiped so the store pool is up to date.
+// 2) Each replica on every range calls the allocator to determine if there are
+//    any actions required.
+// 3) The replica on each range with the highest priority executes it's action.
+// 4) The current status of the cluster is output.
+func (c *Cluster) runEpoch() {
+	c.epoch++
+
+	// Gossip all the store updates.
+	c.gossipStores()
+
+	// Determine next operations for all ranges. The reason for doing this as
+	// a distinct step from execution, is to have each range consider its
+	// situation as it currently stands at each epoch.
+	c.prepareActions()
+
+	// Execute the determined operations.
+	c.performActions()
+
+	// Output the update.
+	fmt.Println(c.StringEpoch())
+}
+
+// gossipStores gossips all the most recent status for all stores.
+func (c *Cluster) gossipStores() {
+	storesRangeCounts := make(map[proto.StoreID]int)
+	for _, r := range c.ranges {
+		for _, storeID := range r.getStoreIDs() {
+			storesRangeCounts[storeID]++
+		}
+	}
+
+	c.storeGossiper.GossipWithFunction(c.storeIDs, func() {
+		for storeID, store := range c.stores {
+			if err := store.gossipStore(storesRangeCounts[storeID]); err != nil {
+				fmt.Printf("Error gossiping store %d: %s\n", storeID, err)
+			}
+		}
+	})
+}
+
+// prepareActions walks through each replica and determines if any action is
+// required using the allocator.
+func (c *Cluster) prepareActions() {
+	for _, r := range c.ranges {
+		r.Lock()
+		for storeID, replica := range r.replicas {
+			replica.action, replica.priority = r.allocator.ComputeAction(r.zone, &r.desc)
+			if replica.action == storage.AANoop {
+				replica.rebalance = r.allocator.ShouldRebalance(storeID)
+				replica.priority = 0
+			} else {
+				replica.rebalance = false
+			}
+			r.replicas[storeID] = replica
+		}
+		r.Unlock()
+	}
+}
+
+// performActions performs a single action, if required, for each range.
+func (c *Cluster) performActions() {
+	for rangeID, r := range c.ranges {
+		nextAction, rebalance := r.getNextAction()
+		switch nextAction {
+		case storage.AAAdd:
+			newStoreID, err := r.getAllocateTarget()
+			if err != nil {
+				fmt.Printf("Error: %s\n", err)
+				continue
+			}
+			r.addReplica(c.stores[newStoreID])
+		case storage.AARemoveDead:
+			// TODO(bram): implement this.
+			fmt.Printf("Range %d - Repair\n", rangeID)
+		case storage.AARemove:
+			// TODO(bram): implement this.
+			fmt.Printf("Range %d - Remove\n", rangeID)
+		case storage.AANoop:
+			if rebalance {
+				// TODO(bram): implement this.
+				fmt.Printf("Range %d - Rebalance\n", rangeID)
+			}
+		}
+	}
+}
+
 // String prints out the current status of the cluster.
 func (c *Cluster) String() string {
+	var buf bytes.Buffer
+	fmt.Fprintf(&buf, "Cluster Info:\nSeed - %d\tEpoch - %d\n", c.seed, c.epoch)
 	storesRangeCounts := make(map[proto.StoreID]int)
 	for _, r := range c.ranges {
 		for _, storeID := range r.getStoreIDs() {
@@ -140,7 +251,6 @@ func (c *Cluster) String() string {
 	}
 	sort.Ints(nodeIDs)
 
-	var buf bytes.Buffer
 	buf.WriteString("Node Info:\n")
 	for _, nodeID := range nodeIDs {
 		n := c.nodes[proto.NodeID(nodeID)]
@@ -148,14 +258,8 @@ func (c *Cluster) String() string {
 		buf.WriteString("\n")
 	}
 
-	var storeIDs []int
-	for storeID := range c.stores {
-		storeIDs = append(storeIDs, int(storeID))
-	}
-	sort.Ints(storeIDs)
-
 	buf.WriteString("Store Info:\n")
-	for _, storeID := range storeIDs {
+	for _, storeID := range c.storeIDs {
 		s := c.stores[proto.StoreID(storeID)]
 		buf.WriteString(s.String(storesRangeCounts[proto.StoreID(storeID)]))
 		buf.WriteString("\n")
@@ -174,5 +278,38 @@ func (c *Cluster) String() string {
 		buf.WriteString("\n")
 	}
 
+	return buf.String()
+}
+
+// StringEpochHeader creates the string header for epoch outputs based on all
+// of the current stores.
+func (c *Cluster) StringEpochHeader() string {
+	var buf bytes.Buffer
+	buf.WriteString("Store:\t")
+	for _, storeID := range c.storeIDs {
+		fmt.Fprintf(&buf, "%d\t", storeID)
+	}
+	return buf.String()
+}
+
+// StringEpoch create a string with the current free capacity for all stores.
+func (c *Cluster) StringEpoch() string {
+	var buf bytes.Buffer
+	fmt.Fprintf(&buf, "%d:\t", c.epoch)
+
+	// TODO(bram): Consider saving this map in the cluster instead of
+	// recalculating it each time.
+	storesRangeCounts := make(map[proto.StoreID]int)
+	for _, r := range c.ranges {
+		for _, storeID := range r.getStoreIDs() {
+			storesRangeCounts[storeID]++
+		}
+	}
+
+	for _, storeID := range c.storeIDs {
+		store := c.stores[proto.StoreID(storeID)]
+		capacity := store.getCapacity(storesRangeCounts[proto.StoreID(storeID)])
+		fmt.Fprintf(&buf, "%.0f%%\t", float64(capacity.Available)/float64(capacity.Capacity)*100)
+	}
 	return buf.String()
 }

--- a/storage/simulation/main.go
+++ b/storage/simulation/main.go
@@ -30,12 +30,18 @@ func main() {
 	c := createCluster(stopper, 5)
 
 	fmt.Printf("A simulation of the cluster's rebalancing.\n\n")
-	fmt.Printf("Cluster Info:\n%s\n", c)
+	fmt.Println(c)
 
 	// Split a random range 100 times.
-	for i := 0; i < 100; i++ {
+	for i := 0; i < 1000; i++ {
 		c.splitRangeRandom()
 	}
 
-	fmt.Printf("Cluster Info:\n%s\n", c)
+	fmt.Println(c.StringEpochHeader())
+
+	for i := 0; i < 100; i++ {
+		c.runEpoch()
+	}
+
+	fmt.Println(c)
 }

--- a/storage/simulation/range.go
+++ b/storage/simulation/range.go
@@ -174,11 +174,11 @@ func (r *Range) String() string {
 	r.RLock()
 	defer r.RUnlock()
 
-	var storeIDs []int
-	for storeID := range r.stores {
-		storeIDs = append(storeIDs, int(storeID))
+	var storeIDs proto.StoreIDSlice
+	for storeID := range r.replicas {
+		storeIDs = append(storeIDs, storeID)
 	}
-	sort.Ints(storeIDs)
+	sort.Sort(storeIDs)
 
 	var buf bytes.Buffer
 	fmt.Fprintf(&buf, "Range:%d, Factor:%d, Stores:[", r.desc.RangeID, len(r.zone.ReplicaAttrs))

--- a/storage/simulation/range.go
+++ b/storage/simulation/range.go
@@ -23,27 +23,39 @@ import (
 	"sort"
 	"sync"
 
+	"github.com/cockroachdb/cockroach/config"
 	"github.com/cockroachdb/cockroach/proto"
+	"github.com/cockroachdb/cockroach/storage"
 )
 
-const defaultReplicationFactor = 3
+// replica holds the results from calling the allocator as to what the range
+// should do if it was part of the replicate queue and the store to which the
+// replica is attached.
+type replica struct {
+	store     *Store
+	action    storage.AllocatorAction
+	priority  float64
+	rebalance bool
+}
 
 // Range is a simulated cockroach range.
 type Range struct {
 	sync.RWMutex
-	factor int // replication factor
-	desc   proto.RangeDescriptor
-	stores map[proto.StoreID]*Store
+	zone      config.ZoneConfig
+	desc      proto.RangeDescriptor
+	replicas  map[proto.StoreID]replica
+	allocator storage.Allocator
 }
 
 // newRange returns a new range with the given rangeID.
-func newRange(rangeID proto.RangeID) *Range {
+func newRange(rangeID proto.RangeID, allocator storage.Allocator) *Range {
 	return &Range{
 		desc: proto.RangeDescriptor{
 			RangeID: rangeID,
 		},
-		factor: defaultReplicationFactor,
-		stores: make(map[proto.StoreID]*Store),
+		zone:      *config.DefaultZoneConfig,
+		replicas:  make(map[proto.StoreID]replica),
+		allocator: allocator,
 	}
 }
 
@@ -59,23 +71,23 @@ func (r *Range) getDesc() proto.RangeDescriptor {
 	return r.desc
 }
 
-// getFactor returns the range's replication factor.
-func (r *Range) getFactor() int {
+// getFactor returns the range's zone config.
+func (r *Range) getZoneConfig() config.ZoneConfig {
 	r.RLock()
 	defer r.RUnlock()
-	return r.factor
+	return r.zone
 }
 
 // setFactor sets the range's replication factor.
-func (r *Range) setFactor(factor int) {
+func (r *Range) setZoneConfig(zone config.ZoneConfig) {
 	r.Lock()
 	defer r.Unlock()
-	r.factor = factor
+	r.zone = zone
 }
 
-// attachRangeToStore adds a new replica on the passed in store. It adds it to
+// addReplica adds a new replica on the passed in store. It adds it to
 // both the range descriptor and the store map.
-func (r *Range) attachRangeToStore(s *Store) {
+func (r *Range) addReplica(s *Store) {
 	r.Lock()
 	defer r.Unlock()
 	storeID, nodeID := s.getIDs()
@@ -83,7 +95,9 @@ func (r *Range) attachRangeToStore(s *Store) {
 		NodeID:  nodeID,
 		StoreID: storeID,
 	})
-	r.stores[storeID] = s
+	r.replicas[storeID] = replica{
+		store: s,
+	}
 }
 
 // getStoreIDs returns the list of all stores where this range has replicas.
@@ -91,7 +105,7 @@ func (r *Range) getStoreIDs() []proto.StoreID {
 	r.RLock()
 	defer r.RUnlock()
 	var storeIDs []proto.StoreID
-	for storeID := range r.stores {
+	for storeID := range r.replicas {
 		storeIDs = append(storeIDs, storeID)
 	}
 	return storeIDs
@@ -102,8 +116,8 @@ func (r *Range) getStores() map[proto.StoreID]*Store {
 	r.RLock()
 	defer r.RUnlock()
 	stores := make(map[proto.StoreID]*Store)
-	for storeID, store := range r.stores {
-		stores[storeID] = store
+	for storeID, replica := range r.replicas {
+		stores[storeID] = replica.store
 	}
 	return stores
 }
@@ -116,8 +130,43 @@ func (r *Range) splitRange(originalRange *Range) {
 	stores := originalRange.getStores()
 	r.Lock()
 	defer r.Unlock()
-	r.desc.Replicas = desc.Replicas
-	r.stores = stores
+	r.desc.Replicas = append([]proto.Replica(nil), desc.Replicas...)
+	for storeID, store := range stores {
+		r.replicas[storeID] = replica{
+			store: store,
+		}
+	}
+}
+
+// getNextAction returns the action and rebalance from the replica with the
+// highest action priority.
+func (r *Range) getNextAction() (storage.AllocatorAction, bool) {
+	r.RLock()
+	defer r.RUnlock()
+	var topReplica replica
+	if len(r.replicas) == 0 {
+		return storage.AANoop, false
+	}
+	// TODO(bram): This is random. Might want to make it deterministic for
+	// repeatability.
+	for _, replica := range r.replicas {
+		if replica.priority > topReplica.priority {
+			topReplica = replica
+		}
+	}
+	return topReplica.action, topReplica.rebalance
+}
+
+// getAllocateTarget calls allocateTarget for the range and returns the top
+// target store.
+func (r *Range) getAllocateTarget() (proto.StoreID, error) {
+	r.RLock()
+	defer r.RUnlock()
+	newStore, err := r.allocator.AllocateTarget(r.zone.ReplicaAttrs[0], r.desc.Replicas, true, nil)
+	if err != nil {
+		return 0, err
+	}
+	return newStore.StoreID, nil
 }
 
 // String returns a human readable string with details about the range.
@@ -132,7 +181,7 @@ func (r *Range) String() string {
 	sort.Ints(storeIDs)
 
 	var buf bytes.Buffer
-	fmt.Fprintf(&buf, "Range:%d, Factor:%d, Stores:[", r.desc.RangeID, r.factor)
+	fmt.Fprintf(&buf, "Range:%d, Factor:%d, Stores:[", r.desc.RangeID, len(r.zone.ReplicaAttrs))
 
 	first := true
 	for _, storeID := range storeIDs {

--- a/storage/store_pool.go
+++ b/storage/store_pool.go
@@ -309,15 +309,14 @@ func (sp *StorePool) getStoreList(required proto.Attributes, deterministic bool)
 	sp.mu.RLock()
 	defer sp.mu.RUnlock()
 
-	// TODO(bram): Consider adding the sort interface to proto.StoreID.
-	var storeIDs []int
+	var storeIDs proto.StoreIDSlice
 	for storeID := range sp.stores {
-		storeIDs = append(storeIDs, int(storeID))
+		storeIDs = append(storeIDs, storeID)
 	}
 	// Sort the stores by key if deterministic is requested. This is only for
 	// unit testing.
 	if deterministic {
-		sort.Ints(storeIDs)
+		sort.Sort(storeIDs)
 	}
 	sl := new(StoreList)
 	for _, storeID := range storeIDs {


### PR DESCRIPTION
This update adds a few key parts to the allocator simulator:
1 - the concept of epochs, units of time in which each range can perform a single action
2 - adds the gossiping of stores, so the store pool is updated
3 - hooks up the allocator to the ranges
4 - adds the first action, "AddReplica"
