### PR TITLE
Fix TestResponseCacheInflight to correctly wait inflight requests

### DIFF
--- a/storage/response_cache_test.go
+++ b/storage/response_cache_test.go
@@ -194,12 +194,10 @@ func TestResponseCacheInflight(t *testing.T) {
 			close(doneChan)
 		}()
 	}
-	for count := 0; count < 2; count++ {
+	for _, doneChan := range doneChans {
 		select {
-		case <-doneChans[0]:
-			count++
-		case <-doneChans[1]:
-			count++
+		case <-doneChan:
+			break
 		case <-time.After(100 * time.Millisecond):
 			t.Fatalf("concurrent gets to cache did not complete")
 		}


### PR DESCRIPTION
It was broken in two ways:
- "count" was incremented in both at "for" post statement and inside the "for" loop.
- "case <- c" can proceed multiple times when c has been closed.

The test normally passes, but it sometimes panics with engine._Cfunc_DBGet().
