### PR TITLE
Added SKIP_BOOTSTRAP check.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -150,6 +150,8 @@ clean:
 	find . -name '*.test' -type f -exec rm -f {} \;
 	rm -rf build/deploy/build
 
+ifneq ($(SKIP_BOOTSTRAP),1)
+
 GITHOOKS := $(subst githooks/,.git/hooks/,$(wildcard githooks/*))
 .git/hooks/%: githooks/%
 	@echo installing $<
@@ -170,6 +172,8 @@ $(GLOCK):
 # of them (or their dependencies) change.
 .bootstrap: $(GITHOOKS) $(GLOCK) GLOCKFILE
 	@glock sync github.com/cockroachdb/cockroach
-	@touch $@
+	touch $@
 
 -include .bootstrap
+
+endif

--- a/build/circle-deps.sh
+++ b/build/circle-deps.sh
@@ -11,9 +11,10 @@ set -eux
 if [ "${1-}" = "docker" ]; then
   cmds=$(grep '^cmd' GLOCKFILE | grep -v glock | awk '{print $2}')
 
-  # Pretend we're already bootstrapped, so that `make` doesn't go
-  # through the bootstrap process which would glock sync unnecessarily.
-  touch .bootstrap
+  # Skip bootstrapping, so that `make` doesn't go through the
+  # bootstrap process which would install glock and glock sync
+  # unnecessarily.
+  export SKIP_BOOTSTRAP=1
 
   # Restore previously cached build artifacts.
   time go install github.com/cockroachdb/build-cache
@@ -21,7 +22,7 @@ if [ "${1-}" = "docker" ]; then
   # Build everything needed by circle-test.sh.
   time go test -race -v -i ./...
   time go install -v ${cmds}
-  time make GITHOOKS= install
+  time make install
   time go test -v -c -tags acceptance ./acceptance
   # Cache the current build artifacts for future builds.
   time build-cache save . .:race,test ${cmds}

--- a/build/circle-test.sh
+++ b/build/circle-test.sh
@@ -2,6 +2,8 @@
 
 set -euo pipefail
 
+export SKIP_BOOTSTRAP=1
+
 if [ -n "${CIRCLE_ARTIFACTS-}" ]; then
   outdir="${CIRCLE_ARTIFACTS}"
 elif [ -n "${TMPDIR-}" ]; then
@@ -85,7 +87,7 @@ trap prepare_artifacts EXIT
 
 # 1. Run "make check" to verify coding guidelines.
 echo "make check"
-time ${builder} make GITHOOKS= check | tee "${outdir}/check.log"
+time ${builder} make check | tee "${outdir}/check.log"
 
 # 2. Verify that "go generate" was run.
 echo "verifying generated files"
@@ -93,7 +95,7 @@ time ${builder} /bin/bash -c "(go generate ./... && git ls-files --modified --de
 
 # 3. Run "make test".
 echo "make test"
-time ${builder} make GITHOOKS= test \
+time ${builder} make test \
   TESTFLAGS='-v --verbosity=1 --vmodule=monitor=2' | \
   tr -d '\r' | tee "${outdir}/test.log" | \
   grep -E "^\--- (PASS|FAIL)|^(FAIL|ok)|${match}" |
@@ -101,7 +103,7 @@ time ${builder} make GITHOOKS= test \
 
 # 4. Run "make testrace".
 echo "make testrace"
-time ${builder} make GITHOOKS= testrace \
+time ${builder} make testrace \
   TESTFLAGS='-v --verbosity=1 --vmodule=monitor=2' | \
   tr -d '\r' | tee "${outdir}/testrace.log" | \
   grep -E "^\--- (PASS|FAIL)|^(FAIL|ok)|${match}" |


### PR DESCRIPTION
Skip bootstrapping (installation of githooks and glock) if the
SKIP_BOOTSTRAP environment variable is set to 1. This allows
bootstrapping to be skipped robustly in circleci.
