### PR TITLE
Remove commented multiTestContext.rpcSend

### DIFF
--- a/storage/client_test.go
+++ b/storage/client_test.go
@@ -223,6 +223,14 @@ func (m *multiTestContext) Stop() {
 	}
 }
 
+// rpcSend implements the client.rpcSender interface. This implementation of "rpcSend" is
+// used to multiplex calls between many local senders in a simple way; It sends
+// the request to each localSender of a multiTestContext in order, stopping if
+// the request succeeds or any error other than RangeKeyMismatch is returned.
+//
+// TODO(mrtracy): remove once #2141 is merged and multiTestContext begins using
+// DistSender. This simple implementation will likely be incorrect in some
+// untested cases and is a temporary measure until DistSender is hooked up.
 func (m *multiTestContext) rpcSend(_ rpc.Options, _ string, _ []net.Addr,
 	getArgs func(addr net.Addr) gogoproto.Message,
 	getReply func() gogoproto.Message, _ *rpc.Context) ([]gogoproto.Message, error) {
@@ -283,72 +291,6 @@ func (m *multiTestContext) rpcSend(_ rpc.Options, _ string, _ []net.Addr,
 	}
 	return []gogoproto.Message{call.Reply}, call.Reply.Header().GoError()
 }
-
-/*
-
-<<<<<<< HEAD
-=======
-// Send implements the client.Sender interface. This implementation of "Send" is
-// used to multiplex calls between many local senders in a simple way; It sends
-// the request to each localSender of a multiTestContext in order, stopping if
-// the request succeeds or any error other than RangeKeyMismatch is returned.
-///
-// TODO(mrtracy): remove once #2141 is merged and multiTestContext begins using
-// DistSender. This simple implementation will likely be incorrect in some
-// untested cases and is a temporary measure until DistSender is hooked up.
-func (m *multiTestContext) rpcSend(ctx context.Context, call proto.Call) {
-	maxRetries := len(m.senders) * 2
-	// Iterate over all stores in the test context, looking for a suitable
-	// replica. In the case of a RangeKeyMismatchError, retry the request on the
-	// next store. In the case of a NotLeaderError, attempt the new leader next.
-	// Because NotLeaderErrors will adjust the index of our loop, a second
-	// "maxRetries" count is used to bound the number of retries.
-	nextIdx := 0
-	for total := 0; total < maxRetries; total++ {
-		call.Reply.Header().SetGoError(nil)
-		call.Args.Header().Replica = proto.Replica{}
-		m.senders[nextIdx].Send(ctx, call)
-		if err := call.Reply.Header().GoError(); err != nil {
-			switch err := err.(type) {
-			case *proto.RangeKeyMismatchError:
-				// Try the next localSender if this localSender did not have the
-				// requested range.
-				nextIdx++
-				nextIdx %= len(m.senders)
-				continue
-			case *proto.NotLeaderError:
-				// localSender has the range, is *not* the Leader, but the
-				// Leader is not known; this can happen if the leader is removed
-				// from the group. Move the manual clock forward in an attempt to
-				// expire the lease. Also increment nextIdx: the discovered replica might be
-				// a removed copy which has not been GCed.
-				if err.Leader == nil {
-					m.expireLeaderLeases()
-					nextIdx++
-					nextIdx %= len(m.senders)
-					continue
-				}
-				// If the leader IS known, retry the request against the leader.
-				foundLeader := false
-				for i, s := range m.stores {
-					if s.StoreID() == err.Leader.StoreID {
-						nextIdx = i
-						foundLeader = true
-						break
-					}
-				}
-				// If the current leader was known but wasn't found in our
-				// collection of stores, break out of the loop; this should
-				// never happen in a correctly configured test.
-				if foundLeader {
-					continue
-				}
-			}
-		}
-		break
-	}
-}
-*/
 
 func (m *multiTestContext) makeContext(i int) storage.StoreContext {
 	var ctx storage.StoreContext


### PR DESCRIPTION
This looks like some leftover from conflict resolution.

I'm not sure about the TODO comment. #2141 was merged, but multiTestContext.Start() still calls it. Simply replacing that with localSender didn't work.
