### PR TITLE
Add unique_id() builtin.

### DIFF
--- a/server/server.go
+++ b/server/server.go
@@ -193,6 +193,8 @@ func (s *Server) Start(selfBootstrap bool) error {
 	// Begin recording status summaries.
 	s.startWriteSummaries()
 
+	s.sqlServer.SetNodeID(s.node.Descriptor.NodeID)
+
 	log.Infof("starting %s server at %s", s.ctx.HTTPRequestScheme(), s.rpc.Addr())
 	s.initHTTP()
 	s.rpc.Serve(s)

--- a/sql/analyze_test.go
+++ b/sql/analyze_test.go
@@ -54,7 +54,7 @@ func parseAndNormalizeExpr(t *testing.T, sql string) (parser.Expr, qvalMap) {
 		t.Fatalf("%s: %v", sql, err)
 	}
 	expr := q[0].(*parser.Select).Exprs[0].Expr
-	expr, err = parser.NormalizeExpr(parser.EvalContext{}, expr)
+	expr, err = (parser.EvalContext{}).NormalizeExpr(expr)
 	if err != nil {
 		t.Fatalf("%s: %v", sql, err)
 	}

--- a/sql/analyze_test.go
+++ b/sql/analyze_test.go
@@ -54,7 +54,7 @@ func parseAndNormalizeExpr(t *testing.T, sql string) (parser.Expr, qvalMap) {
 		t.Fatalf("%s: %v", sql, err)
 	}
 	expr := q[0].(*parser.Select).Exprs[0].Expr
-	expr, err = parser.NormalizeExpr(expr)
+	expr, err = parser.NormalizeExpr(parser.EvalContext{}, expr)
 	if err != nil {
 		t.Fatalf("%s: %v", sql, err)
 	}
@@ -87,11 +87,11 @@ func checkEquivExpr(a, b parser.Expr, qvals qvalMap) error {
 		for _, q := range qvals {
 			q.datum = v
 		}
-		da, err := parser.EvalExpr(a)
+		da, err := (parser.EvalContext{}).EvalExpr(a)
 		if err != nil {
 			return fmt.Errorf("%s: %v", a, err)
 		}
-		db, err := parser.EvalExpr(b)
+		db, err := (parser.EvalContext{}).EvalExpr(b)
 		if err != nil {
 			return fmt.Errorf("%s: %v", b, err)
 		}

--- a/sql/executor.go
+++ b/sql/executor.go
@@ -55,13 +55,13 @@ func (e *Executor) SetNodeID(nodeID proto.NodeID) {
 // Execute the statement(s) in the given request and return a response.
 // On error, the returned integer is an HTTP error code.
 func (e Executor) Execute(args driver.Request) (driver.Response, int, error) {
-	// Pick up current session state.
 	planMaker := planner{
 		user: args.GetUser(),
 		evalCtx: parser.EvalContext{
 			NodeID: e.nodeID,
 		},
 	}
+	// Pick up current session state.
 	if err := gogoproto.Unmarshal(args.Session, &planMaker.session); err != nil {
 		return args.CreateReply(), http.StatusBadRequest, err
 	}

--- a/sql/group.go
+++ b/sql/group.go
@@ -72,6 +72,7 @@ func (p *planner) groupBy(n *parser.Select, s *scanNode) (*groupNode, error) {
 	}
 
 	group := &groupNode{
+		planner: p,
 		columns: s.columns,
 		render:  s.render,
 		funcs:   funcs,
@@ -93,6 +94,7 @@ func (p *planner) groupBy(n *parser.Select, s *scanNode) (*groupNode, error) {
 }
 
 type groupNode struct {
+	planner   *planner
 	plan      planNode
 	columns   []string
 	row       parser.DTuple
@@ -146,7 +148,7 @@ func (n *groupNode) Next() bool {
 	// Render the results.
 	n.row = make([]parser.Datum, len(n.render))
 	for i, r := range n.render {
-		n.row[i], n.err = parser.EvalExpr(r)
+		n.row[i], n.err = n.planner.evalCtx.EvalExpr(r)
 		if n.err != nil {
 			return false
 		}

--- a/sql/http_server.go
+++ b/sql/http_server.go
@@ -25,10 +25,8 @@ import (
 
 	"github.com/cockroachdb/cockroach/base"
 	"github.com/cockroachdb/cockroach/client"
-	"github.com/cockroachdb/cockroach/proto"
 	"github.com/cockroachdb/cockroach/security"
 	"github.com/cockroachdb/cockroach/sql/driver"
-	"github.com/cockroachdb/cockroach/sql/parser"
 	"github.com/cockroachdb/cockroach/util"
 )
 
@@ -109,9 +107,4 @@ func (s HTTPServer) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	if _, err := w.Write(body); err != nil {
 		http.Error(w, err.Error(), http.StatusInternalServerError)
 	}
-}
-
-// SetNodeID sets the node ID for the SQL server.
-func (s HTTPServer) SetNodeID(nodeID proto.NodeID) {
-	parser.SetNodeID(uint32(nodeID))
 }

--- a/sql/http_server.go
+++ b/sql/http_server.go
@@ -25,8 +25,10 @@ import (
 
 	"github.com/cockroachdb/cockroach/base"
 	"github.com/cockroachdb/cockroach/client"
+	"github.com/cockroachdb/cockroach/proto"
 	"github.com/cockroachdb/cockroach/security"
 	"github.com/cockroachdb/cockroach/sql/driver"
+	"github.com/cockroachdb/cockroach/sql/parser"
 	"github.com/cockroachdb/cockroach/util"
 )
 
@@ -107,4 +109,9 @@ func (s HTTPServer) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	if _, err := w.Write(body); err != nil {
 		http.Error(w, err.Error(), http.StatusInternalServerError)
 	}
+}
+
+// SetNodeID sets the node ID for the SQL server.
+func (s HTTPServer) SetNodeID(nodeID proto.NodeID) {
+	parser.SetNodeID(uint32(nodeID))
 }

--- a/sql/insert.go
+++ b/sql/insert.go
@@ -76,7 +76,7 @@ func (p *planner) Insert(n *parser.Insert) (planNode, error) {
 
 	// Construct the default expressions. The returned slice will be nil if no
 	// column in the table has a default expression.
-	defaultExprs, err := makeDefaultExprs(cols)
+	defaultExprs, err := p.makeDefaultExprs(cols)
 	if err != nil {
 		return nil, err
 	}
@@ -108,7 +108,7 @@ func (p *planner) Insert(n *parser.Insert) (planNode, error) {
 				rowVals = append(rowVals, parser.DNull)
 				continue
 			}
-			d, err := parser.EvalExpr(defaultExprs[i])
+			d, err := p.evalCtx.EvalExpr(defaultExprs[i])
 			if err != nil {
 				return nil, err
 			}
@@ -256,7 +256,7 @@ func (p *planner) fillDefaults(defaultExprs []parser.Expr,
 	return rows, nil
 }
 
-func makeDefaultExprs(cols []ColumnDescriptor) ([]parser.Expr, error) {
+func (p *planner) makeDefaultExprs(cols []ColumnDescriptor) ([]parser.Expr, error) {
 	// Check to see if any of the columns have DEFAULT expressions. If there are
 	// no DEFAULT expressions, we don't bother with constructing the defaults map
 	// as the defaults are all NULL.
@@ -282,7 +282,7 @@ func makeDefaultExprs(cols []ColumnDescriptor) ([]parser.Expr, error) {
 		if err != nil {
 			return nil, err
 		}
-		expr, err = parser.NormalizeExpr(expr)
+		expr, err = parser.NormalizeExpr(p.evalCtx, expr)
 		if err != nil {
 			return nil, err
 		}

--- a/sql/insert.go
+++ b/sql/insert.go
@@ -282,7 +282,7 @@ func (p *planner) makeDefaultExprs(cols []ColumnDescriptor) ([]parser.Expr, erro
 		if err != nil {
 			return nil, err
 		}
-		expr, err = parser.NormalizeExpr(p.evalCtx, expr)
+		expr, err = p.evalCtx.NormalizeExpr(expr)
 		if err != nil {
 			return nil, err
 		}

--- a/sql/limit.go
+++ b/sql/limit.go
@@ -26,9 +26,9 @@ import (
 )
 
 // limit constructs a limitNode based on the LIMIT and OFFSET clauses.
-func (*planner) limit(n *parser.Select, p planNode) (planNode, error) {
+func (p *planner) limit(n *parser.Select, plan planNode) (planNode, error) {
 	if n.Limit == nil {
-		return p, nil
+		return plan, nil
 	}
 
 	var count, offset int64
@@ -51,11 +51,11 @@ func (*planner) limit(n *parser.Select, p planNode) (planNode, error) {
 				return nil, fmt.Errorf("argument of %s must not contain variables", datum.name)
 			}
 
-			normalized, err := parser.NormalizeExpr(datum.src)
+			normalized, err := parser.NormalizeExpr(p.evalCtx, datum.src)
 			if err != nil {
 				return nil, err
 			}
-			dstDatum, err := parser.EvalExpr(normalized)
+			dstDatum, err := p.evalCtx.EvalExpr(normalized)
 			if err != nil {
 				return nil, err
 			}
@@ -74,7 +74,7 @@ func (*planner) limit(n *parser.Select, p planNode) (planNode, error) {
 		}
 	}
 
-	return &limitNode{planNode: p, count: count, offset: offset}, nil
+	return &limitNode{planNode: plan, count: count, offset: offset}, nil
 }
 
 type limitNode struct {

--- a/sql/limit.go
+++ b/sql/limit.go
@@ -51,7 +51,7 @@ func (p *planner) limit(n *parser.Select, plan planNode) (planNode, error) {
 				return nil, fmt.Errorf("argument of %s must not contain variables", datum.name)
 			}
 
-			normalized, err := parser.NormalizeExpr(p.evalCtx, datum.src)
+			normalized, err := p.evalCtx.NormalizeExpr(datum.src)
 			if err != nil {
 				return nil, err
 			}

--- a/sql/parser/builtins.go
+++ b/sql/parser/builtins.go
@@ -35,6 +35,7 @@ import (
 	"unicode/utf8"
 
 	"github.com/cockroachdb/cockroach/util/encoding"
+	"github.com/cockroachdb/cockroach/util/uuid"
 )
 
 var errEmptyInputString = errors.New("the input string must not be empty")
@@ -347,6 +348,17 @@ var builtins = map[string][]builtin{
 			impure:     true,
 			fn: func(ctx EvalContext, args DTuple) (Datum, error) {
 				return generateUniqueID(ctx.NodeID), nil
+			},
+		},
+	},
+
+	"uuid_v4": {
+		builtin{
+			types:      typeList{},
+			returnType: DummyBytes,
+			impure:     true,
+			fn: func(ctx EvalContext, args DTuple) (Datum, error) {
+				return DBytes(uuid.NewUUID4()), nil
 			},
 		},
 	},

--- a/sql/parser/builtins.go
+++ b/sql/parser/builtins.go
@@ -342,7 +342,7 @@ var builtins = map[string][]builtin{
 		},
 	},
 
-	"unique_bytes": {
+	"experimental_unique_bytes": {
 		builtin{
 			types:      typeList{},
 			returnType: DummyBytes,
@@ -353,7 +353,7 @@ var builtins = map[string][]builtin{
 		},
 	},
 
-	"unique_int": {
+	"experimental_unique_int": {
 		builtin{
 			types:      typeList{},
 			returnType: DummyInt,
@@ -364,7 +364,7 @@ var builtins = map[string][]builtin{
 		},
 	},
 
-	"uuid_v4": {
+	"experimental_uuid_v4": {
 		builtin{
 			types:      typeList{},
 			returnType: DummyBytes,

--- a/sql/parser/eval_test.go
+++ b/sql/parser/eval_test.go
@@ -276,10 +276,10 @@ func TestEvalExpr(t *testing.T) {
 			t.Fatalf("%s: %v", d.expr, err)
 		}
 		expr := q[0].(*Select).Exprs[0].Expr
-		if expr, err = NormalizeExpr(expr); err != nil {
+		if expr, err = NormalizeExpr(defaultContext, expr); err != nil {
 			t.Fatalf("%s: %v", d.expr, err)
 		}
-		r, err := EvalExpr(expr)
+		r, err := defaultContext.EvalExpr(expr)
 		if err != nil {
 			t.Fatalf("%s: %v", d.expr, err)
 		}
@@ -310,7 +310,7 @@ func TestEvalExprError(t *testing.T) {
 			t.Fatalf("%s: %v", d.expr, err)
 		}
 		expr := q[0].(*Select).Exprs[0].Expr
-		if _, err := EvalExpr(expr); !testutils.IsError(err, regexp.QuoteMeta(d.expected)) {
+		if _, err := defaultContext.EvalExpr(expr); !testutils.IsError(err, regexp.QuoteMeta(d.expected)) {
 			t.Errorf("%s: expected %s, but found %v", d.expr, d.expected, err)
 		}
 	}

--- a/sql/parser/eval_test.go
+++ b/sql/parser/eval_test.go
@@ -276,7 +276,7 @@ func TestEvalExpr(t *testing.T) {
 			t.Fatalf("%s: %v", d.expr, err)
 		}
 		expr := q[0].(*Select).Exprs[0].Expr
-		if expr, err = NormalizeExpr(defaultContext, expr); err != nil {
+		if expr, err = defaultContext.NormalizeExpr(expr); err != nil {
 			t.Fatalf("%s: %v", d.expr, err)
 		}
 		r, err := defaultContext.EvalExpr(expr)

--- a/sql/parser/normalize.go
+++ b/sql/parser/normalize.go
@@ -32,7 +32,7 @@ import (
 //   a + 1 = 2             -> a = 1
 //   a BETWEEN b AND c     -> (a >= b) AND (a <= c)
 //   a NOT BETWEEN b AND c -> (a < b) OR (a > c)
-func NormalizeExpr(ctx EvalContext, expr Expr) (Expr, error) {
+func (ctx EvalContext) NormalizeExpr(expr Expr) (Expr, error) {
 	v := normalizeVisitor{ctx: ctx}
 	expr = WalkExpr(&v, expr)
 	return expr, v.err

--- a/sql/parser/normalize_test.go
+++ b/sql/parser/normalize_test.go
@@ -85,7 +85,7 @@ func TestNormalizeExpr(t *testing.T) {
 			t.Fatalf("%s: %v", d.expr, err)
 		}
 		expr := q[0].(*Select).Exprs[0].Expr
-		r, err := NormalizeExpr(expr)
+		r, err := NormalizeExpr(defaultContext, expr)
 		if err != nil {
 			t.Fatalf("%s: %v", d.expr, err)
 		}
@@ -108,7 +108,7 @@ func TestNormalizeExprError(t *testing.T) {
 			t.Fatalf("%s: %v", d.expr, err)
 		}
 		expr := q[0].(*Select).Exprs[0].Expr
-		if _, err := NormalizeExpr(expr); !testutils.IsError(err, d.expected) {
+		if _, err := NormalizeExpr(defaultContext, expr); !testutils.IsError(err, d.expected) {
 			t.Errorf("%s: expected %s, but found %v", d.expr, d.expected, err)
 		}
 	}

--- a/sql/parser/normalize_test.go
+++ b/sql/parser/normalize_test.go
@@ -85,7 +85,7 @@ func TestNormalizeExpr(t *testing.T) {
 			t.Fatalf("%s: %v", d.expr, err)
 		}
 		expr := q[0].(*Select).Exprs[0].Expr
-		r, err := NormalizeExpr(defaultContext, expr)
+		r, err := defaultContext.NormalizeExpr(expr)
 		if err != nil {
 			t.Fatalf("%s: %v", d.expr, err)
 		}
@@ -108,7 +108,7 @@ func TestNormalizeExprError(t *testing.T) {
 			t.Fatalf("%s: %v", d.expr, err)
 		}
 		expr := q[0].(*Select).Exprs[0].Expr
-		if _, err := NormalizeExpr(defaultContext, expr); !testutils.IsError(err, d.expected) {
+		if _, err := defaultContext.NormalizeExpr(expr); !testutils.IsError(err, d.expected) {
 			t.Errorf("%s: expected %s, but found %v", d.expr, d.expected, err)
 		}
 	}

--- a/sql/parser/type_check.go
+++ b/sql/parser/type_check.go
@@ -29,9 +29,9 @@ import (
 // TypeCheckExpr. It returns returns an error if either of
 // NormalizeExpr or TypeCheckExpr return one, and otherwise returns
 // the Expr returned by NormalizeExpr.
-func NormalizeAndTypeCheckExpr(expr Expr) (Expr, error) {
+func NormalizeAndTypeCheckExpr(ctx EvalContext, expr Expr) (Expr, error) {
 	var err error
-	expr, err = NormalizeExpr(expr)
+	expr, err = NormalizeExpr(ctx, expr)
 	if err != nil {
 		return nil, err
 	}
@@ -321,7 +321,7 @@ func typeCheckFuncExpr(expr *FuncExpr) (Datum, error) {
 
 	// Function lookup succeeded but `fn` doesn't encode its return type.
 	// We need to call the function with dummy arguments.
-	res, err := expr.fn.fn(dummyArgs)
+	res, err := expr.fn.fn(defaultContext, dummyArgs)
 	if err != nil {
 		return nil, fmt.Errorf("%s: %v", expr.Name, err)
 	}

--- a/sql/parser/type_check.go
+++ b/sql/parser/type_check.go
@@ -29,9 +29,9 @@ import (
 // TypeCheckExpr. It returns returns an error if either of
 // NormalizeExpr or TypeCheckExpr return one, and otherwise returns
 // the Expr returned by NormalizeExpr.
-func NormalizeAndTypeCheckExpr(ctx EvalContext, expr Expr) (Expr, error) {
+func (ctx EvalContext) NormalizeAndTypeCheckExpr(expr Expr) (Expr, error) {
 	var err error
-	expr, err = NormalizeExpr(ctx, expr)
+	expr, err = ctx.NormalizeExpr(expr)
 	if err != nil {
 		return nil, err
 	}

--- a/sql/plan.go
+++ b/sql/plan.go
@@ -31,6 +31,7 @@ type planner struct {
 	txn     *client.Txn
 	session Session
 	user    string
+	evalCtx parser.EvalContext
 }
 
 // makePlan creates the query plan for a single SQL statement. The returned

--- a/sql/scan.go
+++ b/sql/scan.go
@@ -343,7 +343,7 @@ func (n *scanNode) initWhere(where *parser.Where) error {
 	if n.err == nil {
 		// Normalize the expression (this will also evaluate any branches that are
 		// constant).
-		n.filter, n.err = parser.NormalizeExpr(n.planner.evalCtx, n.filter)
+		n.filter, n.err = n.planner.evalCtx.NormalizeExpr(n.filter)
 	}
 	if n.err == nil {
 		var whereType parser.Datum
@@ -468,7 +468,7 @@ func (n *scanNode) addRender(target parser.SelectExpr) error {
 	}
 	// Type check the expression to memoize operators and functions.
 	var normalized parser.Expr
-	if normalized, n.err = parser.NormalizeAndTypeCheckExpr(n.planner.evalCtx, resolved); n.err != nil {
+	if normalized, n.err = n.planner.evalCtx.NormalizeAndTypeCheckExpr(resolved); n.err != nil {
 		return n.err
 	}
 	if normalized, n.err = n.planner.expandSubqueries(normalized, 1); n.err != nil {

--- a/sql/scan.go
+++ b/sql/scan.go
@@ -343,7 +343,7 @@ func (n *scanNode) initWhere(where *parser.Where) error {
 	if n.err == nil {
 		// Normalize the expression (this will also evaluate any branches that are
 		// constant).
-		n.filter, n.err = parser.NormalizeExpr(n.filter)
+		n.filter, n.err = parser.NormalizeExpr(n.planner.evalCtx, n.filter)
 	}
 	if n.err == nil {
 		var whereType parser.Datum
@@ -468,7 +468,7 @@ func (n *scanNode) addRender(target parser.SelectExpr) error {
 	}
 	// Type check the expression to memoize operators and functions.
 	var normalized parser.Expr
-	if normalized, n.err = parser.NormalizeAndTypeCheckExpr(resolved); n.err != nil {
+	if normalized, n.err = parser.NormalizeAndTypeCheckExpr(n.planner.evalCtx, resolved); n.err != nil {
 		return n.err
 	}
 	if normalized, n.err = n.planner.expandSubqueries(normalized, 1); n.err != nil {
@@ -619,7 +619,7 @@ func (n *scanNode) filterRow() bool {
 	}
 
 	var d parser.Datum
-	d, n.err = parser.EvalExpr(n.filter)
+	d, n.err = n.planner.evalCtx.EvalExpr(n.filter)
 	if n.err != nil {
 		return false
 	}
@@ -639,7 +639,7 @@ func (n *scanNode) renderRow() {
 		n.row = make([]parser.Datum, len(n.render))
 	}
 	for i, e := range n.render {
-		n.row[i], n.err = parser.EvalExpr(e)
+		n.row[i], n.err = n.planner.evalCtx.EvalExpr(e)
 		if n.err != nil {
 			return
 		}

--- a/sql/set.go
+++ b/sql/set.go
@@ -33,7 +33,7 @@ func (p *planner) Set(n *parser.Set) (planNode, error) {
 	name := strings.ToUpper(n.Name.String())
 	switch name {
 	case `DATABASE`:
-		dbName, err := getStringVal(name, n.Values)
+		dbName, err := p.getStringVal(name, n.Values)
 		if err != nil {
 			return nil, err
 		}
@@ -46,7 +46,7 @@ func (p *planner) Set(n *parser.Set) (planNode, error) {
 		p.session.Database = dbName
 
 	case `SYNTAX`:
-		s, err := getStringVal(name, n.Values)
+		s, err := p.getStringVal(name, n.Values)
 		if err != nil {
 			return nil, err
 		}
@@ -65,11 +65,11 @@ func (p *planner) Set(n *parser.Set) (planNode, error) {
 	return &valuesNode{}, nil
 }
 
-func getStringVal(name string, values parser.Exprs) (string, error) {
+func (p *planner) getStringVal(name string, values parser.Exprs) (string, error) {
 	if len(values) != 1 {
 		return "", fmt.Errorf("%s: requires a single string value", name)
 	}
-	val, err := parser.EvalExpr(values[0])
+	val, err := p.evalCtx.EvalExpr(values[0])
 	if err != nil {
 		return "", err
 	}

--- a/sql/sort.go
+++ b/sql/sort.go
@@ -44,7 +44,7 @@ func (p *planner) orderBy(n *parser.Select, s *scanNode) (*sortNode, error) {
 
 		// Normalize the expression which has the side-effect of evaluating
 		// constant expressions and unwrapping expressions like "((a))" to "a".
-		expr, err := parser.NormalizeExpr(o.Expr)
+		expr, err := parser.NormalizeExpr(p.evalCtx, o.Expr)
 		if err != nil {
 			return nil, err
 		}

--- a/sql/sort.go
+++ b/sql/sort.go
@@ -44,7 +44,7 @@ func (p *planner) orderBy(n *parser.Select, s *scanNode) (*sortNode, error) {
 
 		// Normalize the expression which has the side-effect of evaluating
 		// constant expressions and unwrapping expressions like "((a))" to "a".
-		expr, err := parser.NormalizeExpr(p.evalCtx, o.Expr)
+		expr, err := p.evalCtx.NormalizeExpr(o.Expr)
 		if err != nil {
 			return nil, err
 		}

--- a/sql/testdata/builtin_function
+++ b/sql/testdata/builtin_function
@@ -588,16 +588,16 @@ SELECT translate('a‰ÒÁ', 'aÒ', '∏p')
 ∏‰pÁ
 
 query B
-SELECT unique_bytes() < unique_bytes(), length(unique_bytes())
+SELECT experimental_unique_bytes() < experimental_unique_bytes(), length(experimental_unique_bytes())
 ----
 true 9
 
 query B
-SELECT unique_int() < unique_int()
+SELECT experimental_unique_int() < experimental_unique_int()
 ----
 true
 
 query B
-SELECT uuid_v4() != uuid_v4(), length(uuid_v4())
+SELECT experimental_uuid_v4() != experimental_uuid_v4(), length(experimental_uuid_v4())
 ----
 true 16

--- a/sql/testdata/builtin_function
+++ b/sql/testdata/builtin_function
@@ -588,9 +588,14 @@ SELECT translate('a‰ÒÁ', 'aÒ', '∏p')
 ∏‰pÁ
 
 query B
-SELECT unique_id() < unique_id(), length(unique_id())
+SELECT unique_bytes() < unique_bytes(), length(unique_bytes())
 ----
-true 13
+true 9
+
+query B
+SELECT unique_int() < unique_int()
+----
+true
 
 query B
 SELECT uuid_v4() != uuid_v4(), length(uuid_v4())

--- a/sql/testdata/builtin_function
+++ b/sql/testdata/builtin_function
@@ -586,3 +586,8 @@ query T
 SELECT translate('a‰ÒÁ', 'aÒ', '∏p')
 ----
 ∏‰pÁ
+
+query B
+SELECT unique_id() < unique_id(), length(unique_id())
+----
+true 13

--- a/sql/testdata/builtin_function
+++ b/sql/testdata/builtin_function
@@ -591,3 +591,8 @@ query B
 SELECT unique_id() < unique_id(), length(unique_id())
 ----
 true 13
+
+query B
+SELECT uuid_v4() != uuid_v4(), length(uuid_v4())
+----
+true 16

--- a/sql/update.go
+++ b/sql/update.go
@@ -88,7 +88,7 @@ func (p *planner) Update(n *parser.Update) (planNode, error) {
 		}
 	}
 
-	defaultExprs, err := makeDefaultExprs(cols)
+	defaultExprs, err := p.makeDefaultExprs(cols)
 	if err != nil {
 		return nil, err
 	}

--- a/sql/values.go
+++ b/sql/values.go
@@ -32,7 +32,7 @@ func (p *planner) Values(n parser.Values) (planNode, error) {
 
 	nCols := 0
 	for _, tuple := range n {
-		data, err := parser.EvalExpr(tuple)
+		data, err := p.evalCtx.EvalExpr(tuple)
 		if err != nil {
 			return nil, err
 		}


### PR DESCRIPTION
Unique IDs are composed of the current time in milliseconds, a 31-bit
random number and a 32-bit node-id. If two unique IDs are generated within
the same millisecond on a server, the random number is incremented instead
of being generated fresh. This ensures that unique ID generation is
monotonic on a single server and k-sorted across servers.

Fixes #2513.
