### PR TITLE
Really skip bootstrapping.

### DIFF
--- a/build/builder.sh
+++ b/build/builder.sh
@@ -16,6 +16,7 @@ RUN apt-get update -y && \
  rm -rf /tmp/* && \
  ln -s /usr/bin/nodejs /usr/bin/node
 RUN go get golang.org/x/tools/cmd/vet
+ENV SKIP_BOOTSTRAP=1
 
 CMD ["/bin/bash"]
 EOF

--- a/build/circle-deps.sh
+++ b/build/circle-deps.sh
@@ -11,11 +11,6 @@ set -eux
 if [ "${1-}" = "docker" ]; then
   cmds=$(grep '^cmd' GLOCKFILE | grep -v glock | awk '{print $2}')
 
-  # Skip bootstrapping, so that `make` doesn't go through the
-  # bootstrap process which would install glock and glock sync
-  # unnecessarily.
-  export SKIP_BOOTSTRAP=1
-
   # Restore previously cached build artifacts.
   time go install github.com/cockroachdb/build-cache
   time build-cache restore . .:race,test ${cmds}
@@ -36,7 +31,7 @@ cachedir="${gopath0}/pkg/cache"
 # The tag for the cockroachdb/builder image. If the image is changed
 # (for example, adding "npm"), a new image should be pushed using
 # "build/builder.sh push" and the new tag value placed here.
-tag="20150911-124101"
+tag="20150920-200733"
 
 mkdir -p "${cachedir}"
 du -sh "${cachedir}"

--- a/build/circle-test.sh
+++ b/build/circle-test.sh
@@ -2,8 +2,6 @@
 
 set -euo pipefail
 
-export SKIP_BOOTSTRAP=1
-
 if [ -n "${CIRCLE_ARTIFACTS-}" ]; then
   outdir="${CIRCLE_ARTIFACTS}"
 elif [ -n "${TMPDIR-}" ]; then


### PR DESCRIPTION
The make commands are run within the builder container and running
containers by default strip the environment.
