### PR TITLE
delete .bootstrap on `make clean`

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -9,5 +9,4 @@ cockroach
 */*/*/*.test
 client/client_bench_*
 storage/engine/mvcc_scan_*
-build/deploy/build
 certs

--- a/Makefile
+++ b/Makefile
@@ -148,7 +148,7 @@ check:
 clean:
 	$(GO) clean -tags '$(TAGS)' $(GOFLAGS) -i github.com/cockroachdb/...
 	find . -name '*.test' -type f -exec rm -f {} \;
-	rm -rf build/deploy/build
+	rm -rf build/deploy/build .bootstrap
 
 ifneq ($(SKIP_BOOTSTRAP),1)
 

--- a/Makefile
+++ b/Makefile
@@ -148,7 +148,7 @@ check:
 clean:
 	$(GO) clean -tags '$(TAGS)' $(GOFLAGS) -i github.com/cockroachdb/...
 	find . -name '*.test' -type f -exec rm -f {} \;
-	rm -rf build/deploy/build .bootstrap
+	rm -f .bootstrap
 
 ifneq ($(SKIP_BOOTSTRAP),1)
 


### PR DESCRIPTION
otherwise, `make clean build && go generate ./...`
results in:

  make: **\* No rule to make target `../../../bin/protoc', needed by`cockroach/config/config.pb.go'.  Stop.
  main.go:20: running "make": exit status 2
  make: Nothing to be done for `all'.
  rm -f ./embedded_debug.go

and an explicit `glock sync` is needed."
