### PR TITLE
remove `error` and related impls from *proto.Error

### DIFF
--- a/client/txn.go
+++ b/client/txn.go
@@ -49,6 +49,8 @@ func (ts *txnSender) Send(ctx context.Context, call proto.Call) {
 	call.Args.Header().Txn = &ts.Proto
 	ts.wrapped.Send(ctx, call)
 
+	// TODO(tschottdorf): see about using only the top-level *proto.Error
+	// information for this restart logic (includes adding the Txn).
 	err := call.Reply.Header().GoError()
 	// Only successful requests can carry an updated Txn in their response
 	// header. Any error (e.g. a restart) can have a Txn attached to them as

--- a/client/txn_test.go
+++ b/client/txn_test.go
@@ -304,10 +304,7 @@ func TestEndWriteRestartReadOnlyTransaction(t *testing.T) {
 					t.Fatal(err)
 				}
 				ok = true
-				return &proto.Error{
-					Message:            "boom",
-					TransactionRestart: proto.TransactionRestart_IMMEDIATE,
-				}
+				return &proto.TransactionRetryError{} // immediate txn retry
 			}
 			if !success {
 				return errors.New("aborting on purpose")
@@ -360,7 +357,6 @@ func TestRunTransactionRetryOnErrors(t *testing.T) {
 		{&proto.TransactionAbortedError{}, true},
 		{&proto.TransactionPushError{}, true},
 		{&proto.TransactionRetryError{}, true},
-		{&proto.Error{}, false},
 		{&proto.RangeNotFoundError{}, false},
 		{&proto.RangeKeyMismatchError{}, false},
 		{&proto.TransactionStatusError{}, false},
@@ -411,7 +407,6 @@ func TestAbortTransactionOnCommitErrors(t *testing.T) {
 		{&proto.TransactionAbortedError{}, false},
 		{&proto.TransactionPushError{}, true},
 		{&proto.TransactionRetryError{}, true},
-		{&proto.Error{}, true},
 		{&proto.RangeNotFoundError{}, true},
 		{&proto.RangeKeyMismatchError{}, true},
 		{&proto.TransactionStatusError{}, true},

--- a/proto/api_test.go
+++ b/proto/api_test.go
@@ -46,10 +46,10 @@ func TestResponseHeaderSetGoError(t *testing.T) {
 	rh := ResponseHeader{}
 	rh.SetGoError(&testError{})
 	err := rh.GoError()
-	if _, ok := err.(*Error); !ok {
-		t.Errorf("expected set error to be type Error; got %T", err)
+	if err.Error() != "test" {
+		t.Fatalf("unexpected error: %s", err)
 	}
-	if !err.(*Error).Retryable {
+	if !rh.Error.Retryable {
 		t.Error("expected generic error to be retryable")
 	}
 }
@@ -150,10 +150,10 @@ func TestCombinable(t *testing.T) {
 
 func TestSetGoErrorCopy(t *testing.T) {
 	rh := ResponseHeader{}
-	err := &Error{Message: "test123"}
-	rh.SetGoError(err)
-	err.Message = "321tset"
-	if rh.Error.Message != "test123" {
+	oErr := &Error{Message: "test123"}
+	rh.Error = oErr
+	rh.SetGoError(&testError{})
+	if oErr.Message != "test123" {
 		t.Fatalf("SetGoError did not create a new error")
 	}
 }

--- a/server/status/feed.go
+++ b/server/status/feed.go
@@ -76,7 +76,7 @@ func (nef NodeEventFeed) CallComplete(args proto.Request, reply proto.Response) 
 		method = ba.Requests[0].GetInner().Method()
 	}
 	if err := reply.Header().Error; err != nil &&
-		err.CanRestartTransaction() == proto.TransactionRestart_ABORT {
+		err.TransactionRestart == proto.TransactionRestart_ABORT {
 		nef.f.Publish(&CallErrorEvent{
 			NodeID: nef.id,
 			Method: method,

--- a/storage/replica_test.go
+++ b/storage/replica_test.go
@@ -1512,7 +1512,6 @@ func TestRangeResponseCacheStoredError(t *testing.T) {
 	br := proto.BatchResponse{}
 	br.Add(&incReply)
 	pastError := errors.New("boom")
-	var expError error = &proto.Error{Message: pastError.Error()}
 	_ = tc.rng.respCache.PutResponse(tc.engine, cmdID,
 		proto.ResponseWithError{Reply: &br, Err: pastError})
 
@@ -1521,10 +1520,8 @@ func TestRangeResponseCacheStoredError(t *testing.T) {
 	_, err := tc.rng.AddCmd(tc.rng.context(), &args)
 	if err == nil {
 		t.Fatal("expected to see cached error but got nil")
-	} else if ge, ok := err.(*proto.Error); !ok {
-		t.Fatalf("expected proto.Error but got %s", err)
-	} else if !reflect.DeepEqual(ge, expError) {
-		t.Fatalf("expected <%T> %+v but got <%T> %+v", expError, expError, ge, ge)
+	} else if !testutils.IsError(err, pastError.Error()) {
+		t.Fatalf("expected '%s', but got %s", pastError, err)
 	}
 }
 

--- a/storage/response_cache_test.go
+++ b/storage/response_cache_test.go
@@ -218,7 +218,6 @@ func TestResponseCacheShouldCache(t *testing.T) {
 		{&proto.TransactionAbortedError{}, true},
 		{&proto.TransactionPushError{}, true},
 		{&proto.TransactionRetryError{}, true},
-		{&proto.Error{}, true},
 		{&proto.RangeNotFoundError{}, true},
 		{&proto.RangeKeyMismatchError{}, true},
 		{&proto.TransactionStatusError{}, true},


### PR DESCRIPTION
in preparation for #1891.
