### PR TITLE
return errors with Batch index

### DIFF
--- a/storage/replica.go
+++ b/storage/replica.go
@@ -1133,7 +1133,7 @@ func (r *Replica) executeBatch(batch engine.Engine, ms *engine.MVCCStats, ba *pr
 	// so the code is fairly clumsy and tries to overwrite as much as it can
 	// from the batch. There'll certainly be some more iterations to stream-
 	// line the code in this loop.
-	for _, union := range ba.Requests {
+	for index, union := range ba.Requests {
 		// Execute the command.
 		args := union.GetInner()
 
@@ -1162,7 +1162,7 @@ func (r *Replica) executeBatch(batch engine.Engine, ms *engine.MVCCStats, ba *pr
 		}
 
 		if err != nil {
-			return nil, intents, err
+			return nil, intents, &errWithIndex{err: err, index: index}
 		}
 
 		// Add the response to the batch, updating the timestamp.

--- a/storage/replica_test.go
+++ b/storage/replica_test.go
@@ -65,6 +65,13 @@ func testRangeDescriptor() *proto.RangeDescriptor {
 	}
 }
 
+func unwrapIndexedError(err error) error {
+	if iErr, ok := err.(*errWithIndex); ok {
+		return iErr.err
+	}
+	return err
+}
+
 // boostrapMode controls how the first range is created in testContext.
 type bootstrapMode int
 
@@ -1682,6 +1689,7 @@ func TestEndTransactionWithPushedTimestamp(t *testing.T) {
 		args.Timestamp = tc.clock.Now()
 
 		resp, err := tc.rng.AddCmd(tc.rng.context(), &args)
+		err = unwrapIndexedError(err)
 
 		if test.expErr {
 			if err == nil {
@@ -1889,6 +1897,7 @@ func TestEndTransactionResolveOnlyLocalIntents(t *testing.T) {
 	// Check if the intent in the other range has not yet been resolved.
 	gArgs := getArgs(splitKey, newRng.Desc().RangeID, tc.store.StoreID())
 	_, err := newRng.AddCmd(newRng.context(), &gArgs)
+	err = unwrapIndexedError(err)
 	if _, ok := err.(*proto.WriteIntentError); !ok {
 		t.Errorf("expected write intent error, but got %s", err)
 	}
@@ -2094,6 +2103,7 @@ func TestPushTxnHeartbeatTimeout(t *testing.T) {
 			t.Errorf("expected success on trial %d? %t; got err %s", i, test.expSuccess, err)
 		}
 		if err != nil {
+			err = unwrapIndexedError(err)
 			if _, ok := err.(*proto.TransactionPushError); !ok {
 				t.Errorf("expected txn push error: %s", err)
 			}
@@ -2159,6 +2169,7 @@ func TestPushTxnPriorities(t *testing.T) {
 			t.Errorf("expected success on trial %d? %t; got err %s", i, test.expSuccess, err)
 		}
 		if err != nil {
+			err = unwrapIndexedError(err)
 			if _, ok := err.(*proto.TransactionPushError); !ok {
 				t.Errorf("expected txn push error: %s", err)
 			}
@@ -2517,6 +2528,8 @@ func TestConditionFailedError(t *testing.T) {
 	}
 
 	_, err := tc.rng.AddCmd(tc.rng.context(), &args)
+
+	err = unwrapIndexedError(err)
 
 	if cErr, ok := err.(*proto.ConditionFailedError); err == nil || !ok {
 		t.Fatalf("expected ConditionFailedError, got %T with content %+v",
@@ -3104,4 +3117,40 @@ func TestIntentIntersect(t *testing.T) {
 			t.Errorf("%d: wanted %v, got %v", i, tc.exp, all)
 		}
 	}
+}
+
+// TestBatchErrorWithIndex tests that when an individual entry in a batch
+// results in an error, the index of this command is propagated along with
+// the error.
+func TestBatchErrorWithIndex(t *testing.T) {
+	defer leaktest.AfterTest(t)
+	tc := testContext{}
+	tc.Start(t)
+	defer tc.Stop()
+
+	ba := &proto.BatchRequest{}
+	ba.RangeID = tc.rng.Desc().RangeID
+	ba.Replica.StoreID = tc.store.StoreID()
+	ba.Add(&proto.PutRequest{
+		RequestHeader: proto.RequestHeader{Key: proto.Key("k")},
+		Value:         proto.Value{Bytes: []byte("not nil")},
+	})
+	ba.Add(&proto.ConditionalPutRequest{
+		RequestHeader: proto.RequestHeader{Key: proto.Key("k")},
+		Value:         proto.Value{Bytes: []byte("irrelevant")},
+		ExpValue:      nil, // not true after above Put
+	})
+	// This one is never executed.
+	ba.Add(&proto.GetRequest{
+		RequestHeader: proto.RequestHeader{Key: proto.Key("k")},
+	})
+
+	if _, err := tc.rng.AddCmd(tc.rng.context(), ba); err == nil {
+		t.Fatal("expected an error")
+	} else if iErr, ok := err.(*errWithIndex); !ok {
+		t.Fatalf("expected indexed error, got %s", err)
+	} else if iErr.index != 1 || !testutils.IsError(err, "unexpected value") {
+		t.Fatalf("invalid index or error type: %s", iErr)
+	}
+
 }


### PR DESCRIPTION
when executing an individual request in a batch yields an error, an
errWithIndex wrapping the slot number and the original error is returned.
`Store.ExecuteCmd` currently unwraps and discards this (it will be propagated
all the way to the client in future changes). Related to #1891.
