### PR TITLE
Don't fail on missing system config.

### DIFF
--- a/storage/store.go
+++ b/storage/store.go
@@ -957,6 +957,9 @@ func (s *Store) SplitRange(origRng, newRng *Replica) error {
 	}
 
 	// Update the max bytes and other information of the new range.
+	// This may not happen if the system config has not yet been loaded.
+	// Since this is done under the store lock, system config update will
+	// properly set these fields.
 	if err := newRng.updateRangeInfo(); err != nil {
 		return err
 	}


### PR DESCRIPTION
Fixes #2566

When the system config is not loaded, MaxBytes will remain 0 and
be ignored for split purposes.
It will be properly updated the next time the system config callback
runs.
