### PR TITLE
replace (proto.Response, error) by (proto.Response, *proto.Error)

### DIFF
--- a/client/provisional.go
+++ b/client/provisional.go
@@ -45,7 +45,7 @@ func SendCallConverted(sender BatchSender, ctx context.Context, call proto.Call)
 		}
 	}
 
-	reply, err := sender.SendBatch(ctx, *call.Args.(*proto.BatchRequest))
+	reply, pErr := sender.SendBatch(ctx, *call.Args.(*proto.BatchRequest))
 
 	if reply != nil {
 		call.Reply.Reset() // required for BatchRequest (concats response otherwise)
@@ -54,8 +54,8 @@ func SendCallConverted(sender BatchSender, ctx context.Context, call proto.Call)
 	if call.Reply.Header().GoError() != nil {
 		panic(proto.ErrorUnexpectedlySet)
 	}
-	if err != nil {
-		call.Reply.Header().SetGoError(err)
+	if pErr != nil {
+		call.Reply.Header().Error = pErr
 	}
 }
 

--- a/client/sender.go
+++ b/client/sender.go
@@ -46,7 +46,7 @@ var defaultRetryOptions = retry.Options{
 // TODO(tschottdorf): do away with client.Sender.
 // TODO(tschottdorf) s/Batch// when client.Sender is out of the way.
 type BatchSender interface {
-	SendBatch(context.Context, proto.BatchRequest) (*proto.BatchResponse, error)
+	SendBatch(context.Context, proto.BatchRequest) (*proto.BatchResponse, *proto.Error)
 }
 
 // Sender is an interface for sending a request to a Key-Value

--- a/kv/batch.go
+++ b/kv/batch.go
@@ -112,10 +112,10 @@ func truncate(br *proto.BatchRequest, desc *proto.RangeDescriptor, from, to prot
 }
 
 // SenderFn is a function that implements a Sender.
-type senderFn func(context.Context, proto.BatchRequest) (*proto.BatchResponse, error)
+type senderFn func(context.Context, proto.BatchRequest) (*proto.BatchResponse, *proto.Error)
 
 // SendBatch implements batch.Sender.
-func (f senderFn) SendBatch(ctx context.Context, ba proto.BatchRequest) (*proto.BatchResponse, error) {
+func (f senderFn) SendBatch(ctx context.Context, ba proto.BatchRequest) (*proto.BatchResponse, *proto.Error) {
 	return f(ctx, ba)
 }
 
@@ -138,7 +138,7 @@ func newChunkingSender(f senderFn) client.BatchSender {
 // that you're multi-range. In those cases, the wrapped sender should return an
 // error so that we split and retry once the chunk which contains
 // EndTransaction (i.e. the last one).
-func (cs *chunkingSender) SendBatch(ctx context.Context, ba proto.BatchRequest) (*proto.BatchResponse, error) {
+func (cs *chunkingSender) SendBatch(ctx context.Context, ba proto.BatchRequest) (*proto.BatchResponse, *proto.Error) {
 	if len(ba.Requests) < 1 {
 		panic("empty batch")
 	}

--- a/kv/dist_sender.go
+++ b/kv/dist_sender.go
@@ -389,7 +389,7 @@ func (ds *DistSender) sendRPC(trace *tracer.Trace, rangeID proto.RangeID, replic
 // Note that `from` and `to` are not necessarily Key and EndKey from a
 // RequestHeader; it's assumed that they've been translated to key addresses
 // already (via KeyAddress).
-func (ds *DistSender) getDescriptors(from, to proto.Key, options lookupOptions) (*proto.RangeDescriptor, bool, func(), error) {
+func (ds *DistSender) getDescriptors(from, to proto.Key, options lookupOptions) (*proto.RangeDescriptor, bool, func(), *proto.Error) {
 	var desc *proto.RangeDescriptor
 	var err error
 	var descKey proto.Key
@@ -401,7 +401,7 @@ func (ds *DistSender) getDescriptors(from, to proto.Key, options lookupOptions) 
 	desc, err = ds.rangeCache.LookupRangeDescriptor(descKey, options)
 
 	if err != nil {
-		return nil, false, nil, err
+		return nil, false, nil, proto.NewError(err)
 	}
 
 	// Checks whether need to get next range descriptor. If so, returns true.
@@ -420,7 +420,7 @@ func (ds *DistSender) getDescriptors(from, to proto.Key, options lookupOptions) 
 }
 
 // sendAttempt gathers and rearranges the replicas, and makes an RPC call.
-func (ds *DistSender) sendAttempt(trace *tracer.Trace, ba proto.BatchRequest, desc *proto.RangeDescriptor) (*proto.BatchResponse, error) {
+func (ds *DistSender) sendAttempt(trace *tracer.Trace, ba proto.BatchRequest, desc *proto.RangeDescriptor) (*proto.BatchResponse, *proto.Error) {
 	defer trace.Epoch("sending RPC")()
 
 	leader := ds.leaderCache.Lookup(proto.RangeID(desc.RangeID))
@@ -446,20 +446,20 @@ func (ds *DistSender) sendAttempt(trace *tracer.Trace, ba proto.BatchRequest, de
 	// TODO(tschottdorf) &ba -> ba
 	resp, err := ds.sendRPC(trace, desc.RangeID, replicas, order, &ba)
 	if err != nil {
-		return nil, err
+		return nil, proto.NewError(err)
 	}
 	// Untangle the error from the received response.
 	br := resp.(*proto.BatchResponse)
-	err = br.GoError()
-	br.Error = nil
-	return br, err
+	pErr := br.Error
+	br.Error = nil // scrub the response error
+	return br, pErr
 }
 
 // SendBatch implements the batch.Sender interface. It subdivides
 // the Batch into batches admissible for sending (preventing certain
 // illegal mixtures of requests), executes each individual part
 // (which may span multiple ranges), and recombines the response.
-func (ds *DistSender) SendBatch(ctx context.Context, ba proto.BatchRequest) (*proto.BatchResponse, error) {
+func (ds *DistSender) SendBatch(ctx context.Context, ba proto.BatchRequest) (*proto.BatchResponse, *proto.Error) {
 	// In the event that timestamp isn't set and read consistency isn't
 	// required, set the timestamp using the local clock.
 	// TODO(tschottdorf): right place for this?
@@ -478,7 +478,7 @@ func (ds *DistSender) SendBatch(ctx context.Context, ba proto.BatchRequest) (*pr
 // sendChunk is in charge of sending an "admissible" piece of batch, i.e. one
 // which doesn't need to be subdivided further before going to a range (so no
 // mixing of forward and reverse scans, etc).
-func (ds *DistSender) sendChunk(ctx context.Context, ba proto.BatchRequest) (*proto.BatchResponse, error) {
+func (ds *DistSender) sendChunk(ctx context.Context, ba proto.BatchRequest) (*proto.BatchResponse, *proto.Error) {
 	// TODO(tschottdorf): prepare for removing Key and EndKey from BatchRequest,
 	// making sure that anything that relies on them goes bust.
 	ba.Key, ba.EndKey = nil, nil
@@ -502,23 +502,22 @@ func (ds *DistSender) sendChunk(ctx context.Context, ba proto.BatchRequest) (*pr
 		var curReply *proto.BatchResponse
 		var desc *proto.RangeDescriptor
 		var needAnother bool
-		var err error
+		var pErr *proto.Error
 		for r := retry.Start(ds.rpcRetryOptions); r.Next(); {
 			// Get range descriptor (or, when spanning range, descriptors). Our
 			// error handling below may clear them on certain errors, so we
 			// refresh (likely from the cache) on every retry.
 			descDone := trace.Epoch("meta descriptor lookup")
 			var evictDesc func()
-
-			desc, needAnother, evictDesc, err = ds.getDescriptors(from, to, options)
+			desc, needAnother, evictDesc, pErr = ds.getDescriptors(from, to, options)
 			descDone()
 
 			// getDescriptors may fail retryably if the first range isn't
 			// available via Gossip.
-			if err != nil {
-				if rErr, ok := err.(retry.Retryable); ok && rErr.CanRetry() {
+			if pErr != nil {
+				if rErr, ok := pErr.GoError().(retry.Retryable); ok && rErr.CanRetry() {
 					if log.V(1) {
-						log.Warning(err)
+						log.Warning(pErr)
 					}
 					continue
 				}
@@ -531,7 +530,7 @@ func (ds *DistSender) sendChunk(ctx context.Context, ba proto.BatchRequest) (*pr
 			// consistency is not required.
 			if needAnother && ba.Txn == nil && ba.IsRange() &&
 				ba.ReadConsistency != proto.INCONSISTENT {
-				return nil, &proto.OpRequiresTxnError{}
+				return nil, proto.NewError(&proto.OpRequiresTxnError{})
 			}
 
 			// It's possible that the returned descriptor misses parts of the
@@ -544,19 +543,19 @@ func (ds *DistSender) sendChunk(ctx context.Context, ba proto.BatchRequest) (*pr
 				continue
 			}
 
-			curReply, err = func() (*proto.BatchResponse, error) {
+			curReply, pErr = func() (*proto.BatchResponse, *proto.Error) {
 				// Truncate the request to our current key range.
 				untruncate, numActive, trErr := truncate(&ba, desc, from, to)
-				if numActive == 0 {
+				if numActive == 0 && trErr == nil {
 					untruncate()
 					// This shouldn't happen in the wild, but some tests
 					// exercise it.
-					return nil, util.Errorf("truncation resulted in empty batch on [%s,%s): %s",
-						from, to, ba)
+					return nil, proto.NewError(util.Errorf("truncation resulted in empty batch on [%s,%s): %s",
+						from, to, ba))
 				}
 				defer untruncate()
 				if trErr != nil {
-					return nil, trErr
+					return nil, proto.NewError(trErr)
 				}
 				// TODO(tschottdorf): make key range on batch redundant. The
 				// requests within dictate it anyways.
@@ -566,13 +565,13 @@ func (ds *DistSender) sendChunk(ctx context.Context, ba proto.BatchRequest) (*pr
 
 				if err != nil {
 					if log.V(1) {
-						log.Warningf("failed to invoke %s: %s", ba, err)
+						log.Warningf("failed to invoke %s: %s", ba, pErr)
 					}
 				}
 				return reply, err
 			}()
 			// If sending succeeded, break this loop.
-			if err == nil {
+			if pErr == nil {
 				break
 			}
 
@@ -580,7 +579,7 @@ func (ds *DistSender) sendChunk(ctx context.Context, ba proto.BatchRequest) (*pr
 			// If retryable, allow retry. For range not found or range
 			// key mismatch errors, we don't backoff on the retry,
 			// but reset the backoff loop so we can retry immediately.
-			switch tErr := err.(type) {
+			switch tErr := pErr.GoError().(type) {
 			case *proto.SendError:
 				// For an RPC error to occur, we must've been unable to contact
 				// any replicas. In this case, likely all nodes are down (or
@@ -596,13 +595,13 @@ func (ds *DistSender) sendChunk(ctx context.Context, ba proto.BatchRequest) (*pr
 					continue
 				}
 			case *proto.RangeNotFoundError, *proto.RangeKeyMismatchError:
-				trace.Event(fmt.Sprintf("reply error: %T", err))
+				trace.Event(fmt.Sprintf("reply error: %T", tErr))
 				// Range descriptor might be out of date - evict it.
 				evictDesc()
 				// On addressing errors, don't backoff; retry immediately.
 				r.Reset()
 				if log.V(1) {
-					log.Warning(err)
+					log.Warning(tErr)
 				}
 				// On retries, allow [uncommitted] intents on range descriptor
 				// lookups to be returned 50% of the time in order to succeed
@@ -615,7 +614,7 @@ func (ds *DistSender) sendChunk(ctx context.Context, ba proto.BatchRequest) (*pr
 				options.considerIntents = true
 				continue
 			case *proto.NotLeaderError:
-				trace.Event(fmt.Sprintf("reply error: %T", err))
+				trace.Event(fmt.Sprintf("reply error: %T", tErr))
 				newLeader := tErr.GetLeader()
 				// Verify that leader is a known replica according to the
 				// descriptor. If not, we've got a stale replica; evict cache.
@@ -632,16 +631,16 @@ func (ds *DistSender) sendChunk(ctx context.Context, ba proto.BatchRequest) (*pr
 				}
 				ds.updateLeaderCache(proto.RangeID(desc.RangeID), *newLeader)
 				if log.V(1) {
-					log.Warning(err)
+					log.Warning(tErr)
 				}
 				r.Reset()
 				continue
 			case retry.Retryable:
 				if tErr.CanRetry() {
 					if log.V(1) {
-						log.Warning(err)
+						log.Warning(tErr)
 					}
-					trace.Event(fmt.Sprintf("reply error: %T", err))
+					trace.Event(fmt.Sprintf("reply error: %T", tErr))
 					continue
 				}
 			}
@@ -649,8 +648,8 @@ func (ds *DistSender) sendChunk(ctx context.Context, ba proto.BatchRequest) (*pr
 		}
 
 		// Immediately return if querying a range failed non-retryably.
-		if err != nil {
-			return nil, err
+		if pErr != nil {
+			return nil, pErr
 		}
 
 		first := br == nil
@@ -661,8 +660,8 @@ func (ds *DistSender) sendChunk(ctx context.Context, ba proto.BatchRequest) (*pr
 			// This was the second or later call in a cross-Range request.
 			// Combine the new response with the existing one.
 			if err := br.Combine(curReply); err != nil {
+				// TODO(tschottdorf): return nil, proto.NewError(err)
 				panic(err)
-				// TODO(tschottdorf): return nil, err
 			}
 		}
 

--- a/kv/dist_sender.go
+++ b/kv/dist_sender.go
@@ -565,7 +565,7 @@ func (ds *DistSender) sendChunk(ctx context.Context, ba proto.BatchRequest) (*pr
 				ba.Key, ba.EndKey = nil, nil
 
 				if err != nil {
-					if log.V(0 /* TODO(tschottdorf): 1 */) {
+					if log.V(1) {
 						log.Warningf("failed to invoke %s: %s", ba, err)
 					}
 				}
@@ -581,7 +581,7 @@ func (ds *DistSender) sendChunk(ctx context.Context, ba proto.BatchRequest) (*pr
 			// key mismatch errors, we don't backoff on the retry,
 			// but reset the backoff loop so we can retry immediately.
 			switch tErr := err.(type) {
-			case *rpc.SendError:
+			case *proto.SendError:
 				// For an RPC error to occur, we must've been unable to contact
 				// any replicas. In this case, likely all nodes are down (or
 				// not getting back to us within a reasonable amount of time).

--- a/kv/dist_sender_test.go
+++ b/kv/dist_sender_test.go
@@ -479,9 +479,14 @@ func TestEvictCacheOnError(t *testing.T) {
 				return []gogoproto.Message{getReply()}, nil
 			}
 			first = false
-			err := rpc.NewSendError("boom", tc.retryable)
 			if tc.rpcError {
-				return nil, err
+				return nil, rpc.NewSendError("boom", tc.retryable)
+			}
+			var err error
+			if tc.retryable {
+				err = &proto.RangeKeyMismatchError{}
+			} else {
+				err = errors.New("boom")
 			}
 			reply := getReply()
 			reply.(proto.Response).Header().SetGoError(err)

--- a/kv/local_sender.go
+++ b/kv/local_sender.go
@@ -148,8 +148,9 @@ func (ls *LocalSender) SendBatch(ctx context.Context, ba proto.BatchRequest) (*p
 		}
 		{
 			var tmpR proto.Response
+			var tmpErr *proto.Error
 			// TODO(tschottdorf): &ba -> ba
-			tmpR, err = store.ExecuteCmd(ctx, &ba)
+			tmpR, tmpErr = store.ExecuteCmd(ctx, &ba)
 			// TODO(tschottdorf): remove this dance once BatchResponse is returned.
 			if tmpR != nil {
 				br = tmpR.(*proto.BatchResponse)
@@ -157,6 +158,7 @@ func (ls *LocalSender) SendBatch(ctx context.Context, ba proto.BatchRequest) (*p
 					panic(proto.ErrorUnexpectedlySet)
 				}
 			}
+			err = tmpErr.GoError()
 		}
 	}
 	// TODO(tschottdorf): Later error needs to be associated to an index

--- a/kv/txn_coord_sender_test.go
+++ b/kv/txn_coord_sender_test.go
@@ -571,8 +571,8 @@ func TestTxnCoordSenderTxnUpdatedOnError(t *testing.T) {
 
 	for i, test := range testCases {
 		stopper := stop.NewStopper()
-		ts := NewTxnCoordSender(senderFn(func(_ context.Context, _ proto.BatchRequest) (*proto.BatchResponse, error) {
-			return nil, test.err
+		ts := NewTxnCoordSender(senderFn(func(_ context.Context, _ proto.BatchRequest) (*proto.BatchResponse, *proto.Error) {
+			return nil, proto.NewError(test.err)
 		}), clock, false, nil, stopper)
 		reply := &proto.PutResponse{}
 		ts.Send(context.Background(), proto.Call{Args: gogoproto.Clone(testPutReq).(proto.Request), Reply: reply})
@@ -616,11 +616,11 @@ func TestTxnCoordSenderBatchTransaction(t *testing.T) {
 	clock := hlc.NewClock(hlc.UnixNano)
 	var called bool
 	var alwaysError = errors.New("success")
-	ts := NewTxnCoordSender(senderFn(func(_ context.Context, _ proto.BatchRequest) (*proto.BatchResponse, error) {
+	ts := NewTxnCoordSender(senderFn(func(_ context.Context, _ proto.BatchRequest) (*proto.BatchResponse, *proto.Error) {
 		called = true
 		// Returning this error is an easy way of preventing heartbeats
 		// to be started for otherwise "successful" calls.
-		return nil, alwaysError
+		return nil, proto.NewError(alwaysError)
 	}), clock, false, nil, stopper)
 
 	pushArg := &proto.PushTxnRequest{}

--- a/proto/api.pb.go
+++ b/proto/api.pb.go
@@ -93,6 +93,7 @@
 		OpRequiresTxnError
 		ConditionFailedError
 		LeaseRejectedError
+		SendError
 		ErrorDetail
 		Error
 		RemoteOffset

--- a/proto/errors.go
+++ b/proto/errors.go
@@ -54,6 +54,16 @@ func (e Error) getDetail() error {
 	return e.Detail.GetValue().(error)
 }
 
+// NewError creates an Error from the given error.
+func NewError(err error) *Error {
+	if err == nil {
+		return nil
+	}
+	e := &Error{}
+	e.SetResponseGoError(err)
+	return e
+}
+
 // GoError returns the non-nil error from the proto.Error union.
 func (e *Error) GoError() error {
 	if e == nil {
@@ -124,6 +134,14 @@ func (e *LeaseRejectedError) Error() string {
 func (e *LeaseRejectedError) CanRetry() bool {
 	return false
 }
+
+// Error formats error.
+func (s SendError) Error() string {
+	return "failed to send RPC: " + s.Message
+}
+
+// CanRetry implements the Retryable interface.
+func (s SendError) CanRetry() bool { return s.Retryable }
 
 // NewRangeNotFoundError initializes a new RangeNotFoundError.
 func NewRangeNotFoundError(rangeID RangeID) *RangeNotFoundError {

--- a/proto/errors.go
+++ b/proto/errors.go
@@ -64,6 +64,11 @@ func NewError(err error) *Error {
 	return e
 }
 
+// String implements fmt.Stringer.
+func (e *Error) String() string {
+	return e.GoError().Error()
+}
+
 // GoError returns the non-nil error from the proto.Error union.
 func (e *Error) GoError() error {
 	if e == nil {

--- a/proto/errors.proto
+++ b/proto/errors.proto
@@ -148,6 +148,13 @@ message LeaseRejectedError {
   optional Lease Existing = 2 [(gogoproto.nullable) = false];
 }
 
+// A SendError indicates that a message could not be delivered to
+// the desired recipient(s).
+message SendError {
+  optional string message = 1 [(gogoproto.nullable) = false];
+  optional bool retryable = 2 [(gogoproto.nullable) = false];
+}
+
 // ErrorDetail is a union type containing all available errors.
 message ErrorDetail {
   option (gogoproto.onlyone) = true;
@@ -166,6 +173,7 @@ message ErrorDetail {
   optional ConditionFailedError condition_failed = 12;
   optional LeaseRejectedError lease_rejected = 13;
   optional NodeUnavailableError node_unavailable = 14;
+  optional SendError send = 15;
 }
 
 // TransactionRestart indicates how an error should be handled in a

--- a/rpc/send_test.go
+++ b/rpc/send_test.go
@@ -40,7 +40,7 @@ func TestInvalidAddrLength(t *testing.T) {
 	ret, err := Send(Options{N: 1}, "", nil, nil, nil, nil)
 
 	// the expected return is nil and SendError
-	if _, ok := err.(SendError); !ok || ret != nil {
+	if _, ok := err.(*proto.SendError); !ok || ret != nil {
 		t.Fatalf("Shorter addrs should return nil and SendError.")
 	}
 }
@@ -349,10 +349,7 @@ func TestComplexScenarios(t *testing.T) {
 				Reply: reply,
 			}
 			if addrID < numErrors {
-				call.Error = SendError{
-					errMsg:   "test",
-					canRetry: addrID < numRetryableErrors,
-				}
+				call.Error = NewSendError("test", addrID < numRetryableErrors)
 			}
 			done <- &call
 		}

--- a/server/node.go
+++ b/server/node.go
@@ -484,15 +484,15 @@ func (n *Node) executeCmd(argsI gogoproto.Message) (gogoproto.Message, error) {
 	ctx := tracer.ToCtx((*Node)(n).context(), trace)
 
 	ba, unwrap := client.MaybeWrap(args)
-	br, err := n.lSender.SendBatch(ctx, *ba)
-	if err != nil {
+	br, pErr := n.lSender.SendBatch(ctx, *ba)
+	if pErr != nil {
 		br = &proto.BatchResponse{}
-		trace.Event(fmt.Sprintf("error: %T", err))
+		trace.Event(fmt.Sprintf("error: %T", pErr.GoError()))
 	}
-	if br.GoError() != nil {
+	if br.Error != nil {
 		panic(proto.ErrorUnexpectedlySet)
 	}
-	br.SetGoError(err)
+	br.Error = pErr
 	n.feed.CallComplete(ba, br)
 	return unwrap(br), nil
 }

--- a/storage/client_range_test.go
+++ b/storage/client_range_test.go
@@ -296,8 +296,7 @@ func TestTxnPutOutOfOrder(t *testing.T) {
 		UserPriority: &priority,
 		Timestamp:    clock.Now(),
 	}
-	_, err = store.ExecuteCmd(context.Background(), &proto.GetRequest{RequestHeader: requestHeader})
-	if err != nil {
+	if _, err := store.ExecuteCmd(context.Background(), &proto.GetRequest{RequestHeader: requestHeader}); err != nil {
 		t.Fatalf("failed to get: %s", err)
 	}
 
@@ -312,8 +311,7 @@ func TestTxnPutOutOfOrder(t *testing.T) {
 	manualClock.Increment(100)
 
 	requestHeader.Timestamp = clock.Now()
-	_, err = store.ExecuteCmd(context.Background(), &proto.GetRequest{RequestHeader: requestHeader})
-	if err == nil {
+	if _, err := store.ExecuteCmd(context.Background(), &proto.GetRequest{RequestHeader: requestHeader}); err == nil {
 		t.Fatal("unexpected success of get")
 	}
 
@@ -354,8 +352,8 @@ func TestRangeLookupUseReverse(t *testing.T) {
 		},
 	}
 	util.SucceedsWithin(t, time.Second, func() error {
-		_, err := store.ExecuteCmd(context.Background(), &scanArgs)
-		return err
+		_, pErr := store.ExecuteCmd(context.Background(), &scanArgs)
+		return pErr.GoError()
 	})
 
 	revScanArgs := func(key []byte, maxResults int32) *proto.RangeLookupRequest {

--- a/storage/engine/rocksdb/cockroach/proto/errors.pb.cc
+++ b/storage/engine/rocksdb/cockroach/proto/errors.pb.cc
@@ -63,6 +63,9 @@ const ::google::protobuf::internal::GeneratedMessageReflection*
 const ::google::protobuf::Descriptor* LeaseRejectedError_descriptor_ = NULL;
 const ::google::protobuf::internal::GeneratedMessageReflection*
   LeaseRejectedError_reflection_ = NULL;
+const ::google::protobuf::Descriptor* SendError_descriptor_ = NULL;
+const ::google::protobuf::internal::GeneratedMessageReflection*
+  SendError_reflection_ = NULL;
 const ::google::protobuf::Descriptor* ErrorDetail_descriptor_ = NULL;
 const ::google::protobuf::internal::GeneratedMessageReflection*
   ErrorDetail_reflection_ = NULL;
@@ -300,8 +303,24 @@ void protobuf_AssignDesc_cockroach_2fproto_2ferrors_2eproto() {
       sizeof(LeaseRejectedError),
       GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(LeaseRejectedError, _internal_metadata_),
       -1);
-  ErrorDetail_descriptor_ = file->message_type(14);
-  static const int ErrorDetail_offsets_[14] = {
+  SendError_descriptor_ = file->message_type(14);
+  static const int SendError_offsets_[2] = {
+    GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(SendError, message_),
+    GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(SendError, retryable_),
+  };
+  SendError_reflection_ =
+    ::google::protobuf::internal::GeneratedMessageReflection::NewGeneratedMessageReflection(
+      SendError_descriptor_,
+      SendError::default_instance_,
+      SendError_offsets_,
+      GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(SendError, _has_bits_[0]),
+      -1,
+      -1,
+      sizeof(SendError),
+      GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(SendError, _internal_metadata_),
+      -1);
+  ErrorDetail_descriptor_ = file->message_type(15);
+  static const int ErrorDetail_offsets_[15] = {
     GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(ErrorDetail, not_leader_),
     GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(ErrorDetail, range_not_found_),
     GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(ErrorDetail, range_key_mismatch_),
@@ -316,6 +335,7 @@ void protobuf_AssignDesc_cockroach_2fproto_2ferrors_2eproto() {
     GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(ErrorDetail, condition_failed_),
     GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(ErrorDetail, lease_rejected_),
     GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(ErrorDetail, node_unavailable_),
+    GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(ErrorDetail, send_),
   };
   ErrorDetail_reflection_ =
     ::google::protobuf::internal::GeneratedMessageReflection::NewGeneratedMessageReflection(
@@ -328,7 +348,7 @@ void protobuf_AssignDesc_cockroach_2fproto_2ferrors_2eproto() {
       sizeof(ErrorDetail),
       GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(ErrorDetail, _internal_metadata_),
       -1);
-  Error_descriptor_ = file->message_type(15);
+  Error_descriptor_ = file->message_type(16);
   static const int Error_offsets_[4] = {
     GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(Error, message_),
     GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(Error, retryable_),
@@ -388,6 +408,8 @@ void protobuf_RegisterTypes(const ::std::string&) {
   ::google::protobuf::MessageFactory::InternalRegisterGeneratedMessage(
       LeaseRejectedError_descriptor_, &LeaseRejectedError::default_instance());
   ::google::protobuf::MessageFactory::InternalRegisterGeneratedMessage(
+      SendError_descriptor_, &SendError::default_instance());
+  ::google::protobuf::MessageFactory::InternalRegisterGeneratedMessage(
       ErrorDetail_descriptor_, &ErrorDetail::default_instance());
   ::google::protobuf::MessageFactory::InternalRegisterGeneratedMessage(
       Error_descriptor_, &Error::default_instance());
@@ -424,6 +446,8 @@ void protobuf_ShutdownFile_cockroach_2fproto_2ferrors_2eproto() {
   delete ConditionFailedError_reflection_;
   delete LeaseRejectedError::default_instance_;
   delete LeaseRejectedError_reflection_;
+  delete SendError::default_instance_;
+  delete SendError_reflection_;
   delete ErrorDetail::default_instance_;
   delete ErrorDetail_reflection_;
   delete Error::default_instance_;
@@ -479,37 +503,39 @@ void protobuf_AddDesc_cockroach_2fproto_2ferrors_2eproto() {
     "oto.Value\"u\n\022LeaseRejectedError\022/\n\tReque"
     "sted\030\001 \001(\0132\026.cockroach.proto.LeaseB\004\310\336\037\000"
     "\022.\n\010Existing\030\002 \001(\0132\026.cockroach.proto.Lea"
-    "seB\004\310\336\037\000\"\251\007\n\013ErrorDetail\0223\n\nnot_leader\030\001"
-    " \001(\0132\037.cockroach.proto.NotLeaderError\022<\n"
-    "\017range_not_found\030\002 \001(\0132#.cockroach.proto"
-    ".RangeNotFoundError\022B\n\022range_key_mismatc"
-    "h\030\003 \001(\0132&.cockroach.proto.RangeKeyMismat"
-    "chError\022]\n read_within_uncertainty_inter"
-    "val\030\004 \001(\01323.cockroach.proto.ReadWithinUn"
-    "certaintyIntervalError\022E\n\023transaction_ab"
-    "orted\030\005 \001(\0132(.cockroach.proto.Transactio"
-    "nAbortedError\022\?\n\020transaction_push\030\006 \001(\0132"
-    "%.cockroach.proto.TransactionPushError\022A"
-    "\n\021transaction_retry\030\007 \001(\0132&.cockroach.pr"
-    "oto.TransactionRetryError\022C\n\022transaction"
-    "_status\030\010 \001(\0132\'.cockroach.proto.Transact"
-    "ionStatusError\0227\n\014write_intent\030\t \001(\0132!.c"
-    "ockroach.proto.WriteIntentError\0228\n\rwrite"
-    "_too_old\030\n \001(\0132!.cockroach.proto.WriteTo"
-    "oOldError\022<\n\017op_requires_txn\030\013 \001(\0132#.coc"
-    "kroach.proto.OpRequiresTxnError\022\?\n\020condi"
-    "tion_failed\030\014 \001(\0132%.cockroach.proto.Cond"
-    "itionFailedError\022;\n\016lease_rejected\030\r \001(\013"
-    "2#.cockroach.proto.LeaseRejectedError\022\?\n"
-    "\020node_unavailable\030\016 \001(\0132%.cockroach.prot"
-    "o.NodeUnavailableError:\004\310\240\037\001\"\255\001\n\005Error\022\025"
-    "\n\007message\030\001 \001(\tB\004\310\336\037\000\022\027\n\tretryable\030\002 \001(\010"
-    "B\004\310\336\037\000\022F\n\023transaction_restart\030\004 \001(\0162#.co"
-    "ckroach.proto.TransactionRestartB\004\310\336\037\000\022,"
-    "\n\006detail\030\003 \001(\0132\034.cockroach.proto.ErrorDe"
-    "tail*;\n\022TransactionRestart\022\t\n\005ABORT\020\000\022\013\n"
-    "\007BACKOFF\020\001\022\r\n\tIMMEDIATE\020\002B\033Z\005proto\330\341\036\000\340\342"
-    "\036\001\310\342\036\001\320\342\036\001\220\343\036\000", 2774);
+    "seB\004\310\336\037\000\";\n\tSendError\022\025\n\007message\030\001 \001(\tB\004"
+    "\310\336\037\000\022\027\n\tretryable\030\002 \001(\010B\004\310\336\037\000\"\323\007\n\013ErrorD"
+    "etail\0223\n\nnot_leader\030\001 \001(\0132\037.cockroach.pr"
+    "oto.NotLeaderError\022<\n\017range_not_found\030\002 "
+    "\001(\0132#.cockroach.proto.RangeNotFoundError"
+    "\022B\n\022range_key_mismatch\030\003 \001(\0132&.cockroach"
+    ".proto.RangeKeyMismatchError\022]\n read_wit"
+    "hin_uncertainty_interval\030\004 \001(\01323.cockroa"
+    "ch.proto.ReadWithinUncertaintyIntervalEr"
+    "ror\022E\n\023transaction_aborted\030\005 \001(\0132(.cockr"
+    "oach.proto.TransactionAbortedError\022\?\n\020tr"
+    "ansaction_push\030\006 \001(\0132%.cockroach.proto.T"
+    "ransactionPushError\022A\n\021transaction_retry"
+    "\030\007 \001(\0132&.cockroach.proto.TransactionRetr"
+    "yError\022C\n\022transaction_status\030\010 \001(\0132\'.coc"
+    "kroach.proto.TransactionStatusError\0227\n\014w"
+    "rite_intent\030\t \001(\0132!.cockroach.proto.Writ"
+    "eIntentError\0228\n\rwrite_too_old\030\n \001(\0132!.co"
+    "ckroach.proto.WriteTooOldError\022<\n\017op_req"
+    "uires_txn\030\013 \001(\0132#.cockroach.proto.OpRequ"
+    "iresTxnError\022\?\n\020condition_failed\030\014 \001(\0132%"
+    ".cockroach.proto.ConditionFailedError\022;\n"
+    "\016lease_rejected\030\r \001(\0132#.cockroach.proto."
+    "LeaseRejectedError\022\?\n\020node_unavailable\030\016"
+    " \001(\0132%.cockroach.proto.NodeUnavailableEr"
+    "ror\022(\n\004send\030\017 \001(\0132\032.cockroach.proto.Send"
+    "Error:\004\310\240\037\001\"\255\001\n\005Error\022\025\n\007message\030\001 \001(\tB\004"
+    "\310\336\037\000\022\027\n\tretryable\030\002 \001(\010B\004\310\336\037\000\022F\n\023transac"
+    "tion_restart\030\004 \001(\0162#.cockroach.proto.Tra"
+    "nsactionRestartB\004\310\336\037\000\022,\n\006detail\030\003 \001(\0132\034."
+    "cockroach.proto.ErrorDetail*;\n\022Transacti"
+    "onRestart\022\t\n\005ABORT\020\000\022\013\n\007BACKOFF\020\001\022\r\n\tIMM"
+    "EDIATE\020\002B\033Z\005proto\330\341\036\000\340\342\036\001\310\342\036\001\320\342\036\001\220\343\036\000", 2877);
   ::google::protobuf::MessageFactory::InternalRegisterGeneratedFile(
     "cockroach/proto/errors.proto", &protobuf_RegisterTypes);
   NotLeaderError::default_instance_ = new NotLeaderError();
@@ -526,6 +552,7 @@ void protobuf_AddDesc_cockroach_2fproto_2ferrors_2eproto() {
   OpRequiresTxnError::default_instance_ = new OpRequiresTxnError();
   ConditionFailedError::default_instance_ = new ConditionFailedError();
   LeaseRejectedError::default_instance_ = new LeaseRejectedError();
+  SendError::default_instance_ = new SendError();
   ErrorDetail::default_instance_ = new ErrorDetail();
   Error::default_instance_ = new Error();
   NotLeaderError::default_instance_->InitAsDefaultInstance();
@@ -542,6 +569,7 @@ void protobuf_AddDesc_cockroach_2fproto_2ferrors_2eproto() {
   OpRequiresTxnError::default_instance_->InitAsDefaultInstance();
   ConditionFailedError::default_instance_->InitAsDefaultInstance();
   LeaseRejectedError::default_instance_->InitAsDefaultInstance();
+  SendError::default_instance_->InitAsDefaultInstance();
   ErrorDetail::default_instance_->InitAsDefaultInstance();
   Error::default_instance_->InitAsDefaultInstance();
   ::google::protobuf::internal::OnShutdown(&protobuf_ShutdownFile_cockroach_2fproto_2ferrors_2eproto);
@@ -5359,6 +5387,377 @@ void LeaseRejectedError::clear_existing() {
 // ===================================================================
 
 #ifndef _MSC_VER
+const int SendError::kMessageFieldNumber;
+const int SendError::kRetryableFieldNumber;
+#endif  // !_MSC_VER
+
+SendError::SendError()
+  : ::google::protobuf::Message(), _internal_metadata_(NULL) {
+  SharedCtor();
+  // @@protoc_insertion_point(constructor:cockroach.proto.SendError)
+}
+
+void SendError::InitAsDefaultInstance() {
+}
+
+SendError::SendError(const SendError& from)
+  : ::google::protobuf::Message(),
+    _internal_metadata_(NULL) {
+  SharedCtor();
+  MergeFrom(from);
+  // @@protoc_insertion_point(copy_constructor:cockroach.proto.SendError)
+}
+
+void SendError::SharedCtor() {
+  ::google::protobuf::internal::GetEmptyString();
+  _cached_size_ = 0;
+  message_.UnsafeSetDefault(&::google::protobuf::internal::GetEmptyStringAlreadyInited());
+  retryable_ = false;
+  ::memset(_has_bits_, 0, sizeof(_has_bits_));
+}
+
+SendError::~SendError() {
+  // @@protoc_insertion_point(destructor:cockroach.proto.SendError)
+  SharedDtor();
+}
+
+void SendError::SharedDtor() {
+  message_.DestroyNoArena(&::google::protobuf::internal::GetEmptyStringAlreadyInited());
+  if (this != default_instance_) {
+  }
+}
+
+void SendError::SetCachedSize(int size) const {
+  GOOGLE_SAFE_CONCURRENT_WRITES_BEGIN();
+  _cached_size_ = size;
+  GOOGLE_SAFE_CONCURRENT_WRITES_END();
+}
+const ::google::protobuf::Descriptor* SendError::descriptor() {
+  protobuf_AssignDescriptorsOnce();
+  return SendError_descriptor_;
+}
+
+const SendError& SendError::default_instance() {
+  if (default_instance_ == NULL) protobuf_AddDesc_cockroach_2fproto_2ferrors_2eproto();
+  return *default_instance_;
+}
+
+SendError* SendError::default_instance_ = NULL;
+
+SendError* SendError::New(::google::protobuf::Arena* arena) const {
+  SendError* n = new SendError;
+  if (arena != NULL) {
+    arena->Own(n);
+  }
+  return n;
+}
+
+void SendError::Clear() {
+  if (_has_bits_[0 / 32] & 3u) {
+    if (has_message()) {
+      message_.ClearToEmptyNoArena(&::google::protobuf::internal::GetEmptyStringAlreadyInited());
+    }
+    retryable_ = false;
+  }
+  ::memset(_has_bits_, 0, sizeof(_has_bits_));
+  if (_internal_metadata_.have_unknown_fields()) {
+    mutable_unknown_fields()->Clear();
+  }
+}
+
+bool SendError::MergePartialFromCodedStream(
+    ::google::protobuf::io::CodedInputStream* input) {
+#define DO_(EXPRESSION) if (!(EXPRESSION)) goto failure
+  ::google::protobuf::uint32 tag;
+  // @@protoc_insertion_point(parse_start:cockroach.proto.SendError)
+  for (;;) {
+    ::std::pair< ::google::protobuf::uint32, bool> p = input->ReadTagWithCutoff(127);
+    tag = p.first;
+    if (!p.second) goto handle_unusual;
+    switch (::google::protobuf::internal::WireFormatLite::GetTagFieldNumber(tag)) {
+      // optional string message = 1;
+      case 1: {
+        if (tag == 10) {
+          DO_(::google::protobuf::internal::WireFormatLite::ReadString(
+                input, this->mutable_message()));
+          ::google::protobuf::internal::WireFormat::VerifyUTF8StringNamedField(
+            this->message().data(), this->message().length(),
+            ::google::protobuf::internal::WireFormat::PARSE,
+            "cockroach.proto.SendError.message");
+        } else {
+          goto handle_unusual;
+        }
+        if (input->ExpectTag(16)) goto parse_retryable;
+        break;
+      }
+
+      // optional bool retryable = 2;
+      case 2: {
+        if (tag == 16) {
+         parse_retryable:
+          DO_((::google::protobuf::internal::WireFormatLite::ReadPrimitive<
+                   bool, ::google::protobuf::internal::WireFormatLite::TYPE_BOOL>(
+                 input, &retryable_)));
+          set_has_retryable();
+        } else {
+          goto handle_unusual;
+        }
+        if (input->ExpectAtEnd()) goto success;
+        break;
+      }
+
+      default: {
+      handle_unusual:
+        if (tag == 0 ||
+            ::google::protobuf::internal::WireFormatLite::GetTagWireType(tag) ==
+            ::google::protobuf::internal::WireFormatLite::WIRETYPE_END_GROUP) {
+          goto success;
+        }
+        DO_(::google::protobuf::internal::WireFormat::SkipField(
+              input, tag, mutable_unknown_fields()));
+        break;
+      }
+    }
+  }
+success:
+  // @@protoc_insertion_point(parse_success:cockroach.proto.SendError)
+  return true;
+failure:
+  // @@protoc_insertion_point(parse_failure:cockroach.proto.SendError)
+  return false;
+#undef DO_
+}
+
+void SendError::SerializeWithCachedSizes(
+    ::google::protobuf::io::CodedOutputStream* output) const {
+  // @@protoc_insertion_point(serialize_start:cockroach.proto.SendError)
+  // optional string message = 1;
+  if (has_message()) {
+    ::google::protobuf::internal::WireFormat::VerifyUTF8StringNamedField(
+      this->message().data(), this->message().length(),
+      ::google::protobuf::internal::WireFormat::SERIALIZE,
+      "cockroach.proto.SendError.message");
+    ::google::protobuf::internal::WireFormatLite::WriteStringMaybeAliased(
+      1, this->message(), output);
+  }
+
+  // optional bool retryable = 2;
+  if (has_retryable()) {
+    ::google::protobuf::internal::WireFormatLite::WriteBool(2, this->retryable(), output);
+  }
+
+  if (_internal_metadata_.have_unknown_fields()) {
+    ::google::protobuf::internal::WireFormat::SerializeUnknownFields(
+        unknown_fields(), output);
+  }
+  // @@protoc_insertion_point(serialize_end:cockroach.proto.SendError)
+}
+
+::google::protobuf::uint8* SendError::SerializeWithCachedSizesToArray(
+    ::google::protobuf::uint8* target) const {
+  // @@protoc_insertion_point(serialize_to_array_start:cockroach.proto.SendError)
+  // optional string message = 1;
+  if (has_message()) {
+    ::google::protobuf::internal::WireFormat::VerifyUTF8StringNamedField(
+      this->message().data(), this->message().length(),
+      ::google::protobuf::internal::WireFormat::SERIALIZE,
+      "cockroach.proto.SendError.message");
+    target =
+      ::google::protobuf::internal::WireFormatLite::WriteStringToArray(
+        1, this->message(), target);
+  }
+
+  // optional bool retryable = 2;
+  if (has_retryable()) {
+    target = ::google::protobuf::internal::WireFormatLite::WriteBoolToArray(2, this->retryable(), target);
+  }
+
+  if (_internal_metadata_.have_unknown_fields()) {
+    target = ::google::protobuf::internal::WireFormat::SerializeUnknownFieldsToArray(
+        unknown_fields(), target);
+  }
+  // @@protoc_insertion_point(serialize_to_array_end:cockroach.proto.SendError)
+  return target;
+}
+
+int SendError::ByteSize() const {
+  int total_size = 0;
+
+  if (_has_bits_[0 / 32] & 3) {
+    // optional string message = 1;
+    if (has_message()) {
+      total_size += 1 +
+        ::google::protobuf::internal::WireFormatLite::StringSize(
+          this->message());
+    }
+
+    // optional bool retryable = 2;
+    if (has_retryable()) {
+      total_size += 1 + 1;
+    }
+
+  }
+  if (_internal_metadata_.have_unknown_fields()) {
+    total_size +=
+      ::google::protobuf::internal::WireFormat::ComputeUnknownFieldsSize(
+        unknown_fields());
+  }
+  GOOGLE_SAFE_CONCURRENT_WRITES_BEGIN();
+  _cached_size_ = total_size;
+  GOOGLE_SAFE_CONCURRENT_WRITES_END();
+  return total_size;
+}
+
+void SendError::MergeFrom(const ::google::protobuf::Message& from) {
+  if (GOOGLE_PREDICT_FALSE(&from == this)) MergeFromFail(__LINE__);
+  const SendError* source = 
+      ::google::protobuf::internal::DynamicCastToGenerated<const SendError>(
+          &from);
+  if (source == NULL) {
+    ::google::protobuf::internal::ReflectionOps::Merge(from, this);
+  } else {
+    MergeFrom(*source);
+  }
+}
+
+void SendError::MergeFrom(const SendError& from) {
+  if (GOOGLE_PREDICT_FALSE(&from == this)) MergeFromFail(__LINE__);
+  if (from._has_bits_[0 / 32] & (0xffu << (0 % 32))) {
+    if (from.has_message()) {
+      set_has_message();
+      message_.AssignWithDefault(&::google::protobuf::internal::GetEmptyStringAlreadyInited(), from.message_);
+    }
+    if (from.has_retryable()) {
+      set_retryable(from.retryable());
+    }
+  }
+  if (from._internal_metadata_.have_unknown_fields()) {
+    mutable_unknown_fields()->MergeFrom(from.unknown_fields());
+  }
+}
+
+void SendError::CopyFrom(const ::google::protobuf::Message& from) {
+  if (&from == this) return;
+  Clear();
+  MergeFrom(from);
+}
+
+void SendError::CopyFrom(const SendError& from) {
+  if (&from == this) return;
+  Clear();
+  MergeFrom(from);
+}
+
+bool SendError::IsInitialized() const {
+
+  return true;
+}
+
+void SendError::Swap(SendError* other) {
+  if (other == this) return;
+  InternalSwap(other);
+}
+void SendError::InternalSwap(SendError* other) {
+  message_.Swap(&other->message_);
+  std::swap(retryable_, other->retryable_);
+  std::swap(_has_bits_[0], other->_has_bits_[0]);
+  _internal_metadata_.Swap(&other->_internal_metadata_);
+  std::swap(_cached_size_, other->_cached_size_);
+}
+
+::google::protobuf::Metadata SendError::GetMetadata() const {
+  protobuf_AssignDescriptorsOnce();
+  ::google::protobuf::Metadata metadata;
+  metadata.descriptor = SendError_descriptor_;
+  metadata.reflection = SendError_reflection_;
+  return metadata;
+}
+
+#if PROTOBUF_INLINE_NOT_IN_HEADERS
+// SendError
+
+// optional string message = 1;
+bool SendError::has_message() const {
+  return (_has_bits_[0] & 0x00000001u) != 0;
+}
+void SendError::set_has_message() {
+  _has_bits_[0] |= 0x00000001u;
+}
+void SendError::clear_has_message() {
+  _has_bits_[0] &= ~0x00000001u;
+}
+void SendError::clear_message() {
+  message_.ClearToEmptyNoArena(&::google::protobuf::internal::GetEmptyStringAlreadyInited());
+  clear_has_message();
+}
+ const ::std::string& SendError::message() const {
+  // @@protoc_insertion_point(field_get:cockroach.proto.SendError.message)
+  return message_.GetNoArena(&::google::protobuf::internal::GetEmptyStringAlreadyInited());
+}
+ void SendError::set_message(const ::std::string& value) {
+  set_has_message();
+  message_.SetNoArena(&::google::protobuf::internal::GetEmptyStringAlreadyInited(), value);
+  // @@protoc_insertion_point(field_set:cockroach.proto.SendError.message)
+}
+ void SendError::set_message(const char* value) {
+  set_has_message();
+  message_.SetNoArena(&::google::protobuf::internal::GetEmptyStringAlreadyInited(), ::std::string(value));
+  // @@protoc_insertion_point(field_set_char:cockroach.proto.SendError.message)
+}
+ void SendError::set_message(const char* value, size_t size) {
+  set_has_message();
+  message_.SetNoArena(&::google::protobuf::internal::GetEmptyStringAlreadyInited(),
+      ::std::string(reinterpret_cast<const char*>(value), size));
+  // @@protoc_insertion_point(field_set_pointer:cockroach.proto.SendError.message)
+}
+ ::std::string* SendError::mutable_message() {
+  set_has_message();
+  // @@protoc_insertion_point(field_mutable:cockroach.proto.SendError.message)
+  return message_.MutableNoArena(&::google::protobuf::internal::GetEmptyStringAlreadyInited());
+}
+ ::std::string* SendError::release_message() {
+  clear_has_message();
+  return message_.ReleaseNoArena(&::google::protobuf::internal::GetEmptyStringAlreadyInited());
+}
+ void SendError::set_allocated_message(::std::string* message) {
+  if (message != NULL) {
+    set_has_message();
+  } else {
+    clear_has_message();
+  }
+  message_.SetAllocatedNoArena(&::google::protobuf::internal::GetEmptyStringAlreadyInited(), message);
+  // @@protoc_insertion_point(field_set_allocated:cockroach.proto.SendError.message)
+}
+
+// optional bool retryable = 2;
+bool SendError::has_retryable() const {
+  return (_has_bits_[0] & 0x00000002u) != 0;
+}
+void SendError::set_has_retryable() {
+  _has_bits_[0] |= 0x00000002u;
+}
+void SendError::clear_has_retryable() {
+  _has_bits_[0] &= ~0x00000002u;
+}
+void SendError::clear_retryable() {
+  retryable_ = false;
+  clear_has_retryable();
+}
+ bool SendError::retryable() const {
+  // @@protoc_insertion_point(field_get:cockroach.proto.SendError.retryable)
+  return retryable_;
+}
+ void SendError::set_retryable(bool value) {
+  set_has_retryable();
+  retryable_ = value;
+  // @@protoc_insertion_point(field_set:cockroach.proto.SendError.retryable)
+}
+
+#endif  // PROTOBUF_INLINE_NOT_IN_HEADERS
+
+// ===================================================================
+
+#ifndef _MSC_VER
 const int ErrorDetail::kNotLeaderFieldNumber;
 const int ErrorDetail::kRangeNotFoundFieldNumber;
 const int ErrorDetail::kRangeKeyMismatchFieldNumber;
@@ -5373,6 +5772,7 @@ const int ErrorDetail::kOpRequiresTxnFieldNumber;
 const int ErrorDetail::kConditionFailedFieldNumber;
 const int ErrorDetail::kLeaseRejectedFieldNumber;
 const int ErrorDetail::kNodeUnavailableFieldNumber;
+const int ErrorDetail::kSendFieldNumber;
 #endif  // !_MSC_VER
 
 ErrorDetail::ErrorDetail()
@@ -5396,6 +5796,7 @@ void ErrorDetail::InitAsDefaultInstance() {
   condition_failed_ = const_cast< ::cockroach::proto::ConditionFailedError*>(&::cockroach::proto::ConditionFailedError::default_instance());
   lease_rejected_ = const_cast< ::cockroach::proto::LeaseRejectedError*>(&::cockroach::proto::LeaseRejectedError::default_instance());
   node_unavailable_ = const_cast< ::cockroach::proto::NodeUnavailableError*>(&::cockroach::proto::NodeUnavailableError::default_instance());
+  send_ = const_cast< ::cockroach::proto::SendError*>(&::cockroach::proto::SendError::default_instance());
 }
 
 ErrorDetail::ErrorDetail(const ErrorDetail& from)
@@ -5422,6 +5823,7 @@ void ErrorDetail::SharedCtor() {
   condition_failed_ = NULL;
   lease_rejected_ = NULL;
   node_unavailable_ = NULL;
+  send_ = NULL;
   ::memset(_has_bits_, 0, sizeof(_has_bits_));
 }
 
@@ -5446,6 +5848,7 @@ void ErrorDetail::SharedDtor() {
     delete condition_failed_;
     delete lease_rejected_;
     delete node_unavailable_;
+    delete send_;
   }
 }
 
@@ -5501,7 +5904,7 @@ void ErrorDetail::Clear() {
       if (transaction_status_ != NULL) transaction_status_->::cockroach::proto::TransactionStatusError::Clear();
     }
   }
-  if (_has_bits_[8 / 32] & 16128u) {
+  if (_has_bits_[8 / 32] & 32512u) {
     if (has_write_intent()) {
       if (write_intent_ != NULL) write_intent_->::cockroach::proto::WriteIntentError::Clear();
     }
@@ -5519,6 +5922,9 @@ void ErrorDetail::Clear() {
     }
     if (has_node_unavailable()) {
       if (node_unavailable_ != NULL) node_unavailable_->::cockroach::proto::NodeUnavailableError::Clear();
+    }
+    if (has_send()) {
+      if (send_ != NULL) send_->::cockroach::proto::SendError::Clear();
     }
   }
   ::memset(_has_bits_, 0, sizeof(_has_bits_));
@@ -5714,6 +6120,19 @@ bool ErrorDetail::MergePartialFromCodedStream(
         } else {
           goto handle_unusual;
         }
+        if (input->ExpectTag(122)) goto parse_send;
+        break;
+      }
+
+      // optional .cockroach.proto.SendError send = 15;
+      case 15: {
+        if (tag == 122) {
+         parse_send:
+          DO_(::google::protobuf::internal::WireFormatLite::ReadMessageNoVirtual(
+               input, mutable_send()));
+        } else {
+          goto handle_unusual;
+        }
         if (input->ExpectAtEnd()) goto success;
         break;
       }
@@ -5827,6 +6246,12 @@ void ErrorDetail::SerializeWithCachedSizes(
       14, *this->node_unavailable_, output);
   }
 
+  // optional .cockroach.proto.SendError send = 15;
+  if (has_send()) {
+    ::google::protobuf::internal::WireFormatLite::WriteMessageMaybeToArray(
+      15, *this->send_, output);
+  }
+
   if (_internal_metadata_.have_unknown_fields()) {
     ::google::protobuf::internal::WireFormat::SerializeUnknownFields(
         unknown_fields(), output);
@@ -5935,6 +6360,13 @@ void ErrorDetail::SerializeWithCachedSizes(
         14, *this->node_unavailable_, target);
   }
 
+  // optional .cockroach.proto.SendError send = 15;
+  if (has_send()) {
+    target = ::google::protobuf::internal::WireFormatLite::
+      WriteMessageNoVirtualToArray(
+        15, *this->send_, target);
+  }
+
   if (_internal_metadata_.have_unknown_fields()) {
     target = ::google::protobuf::internal::WireFormat::SerializeUnknownFieldsToArray(
         unknown_fields(), target);
@@ -6004,7 +6436,7 @@ int ErrorDetail::ByteSize() const {
     }
 
   }
-  if (_has_bits_[8 / 32] & 16128) {
+  if (_has_bits_[8 / 32] & 32512) {
     // optional .cockroach.proto.WriteIntentError write_intent = 9;
     if (has_write_intent()) {
       total_size += 1 +
@@ -6045,6 +6477,13 @@ int ErrorDetail::ByteSize() const {
       total_size += 1 +
         ::google::protobuf::internal::WireFormatLite::MessageSizeNoVirtual(
           *this->node_unavailable_);
+    }
+
+    // optional .cockroach.proto.SendError send = 15;
+    if (has_send()) {
+      total_size += 1 +
+        ::google::protobuf::internal::WireFormatLite::MessageSizeNoVirtual(
+          *this->send_);
     }
 
   }
@@ -6118,6 +6557,9 @@ void ErrorDetail::MergeFrom(const ErrorDetail& from) {
     if (from.has_node_unavailable()) {
       mutable_node_unavailable()->::cockroach::proto::NodeUnavailableError::MergeFrom(from.node_unavailable());
     }
+    if (from.has_send()) {
+      mutable_send()->::cockroach::proto::SendError::MergeFrom(from.send());
+    }
   }
   if (from._internal_metadata_.have_unknown_fields()) {
     mutable_unknown_fields()->MergeFrom(from.unknown_fields());
@@ -6160,6 +6602,7 @@ void ErrorDetail::InternalSwap(ErrorDetail* other) {
   std::swap(condition_failed_, other->condition_failed_);
   std::swap(lease_rejected_, other->lease_rejected_);
   std::swap(node_unavailable_, other->node_unavailable_);
+  std::swap(send_, other->send_);
   std::swap(_has_bits_[0], other->_has_bits_[0]);
   _internal_metadata_.Swap(&other->_internal_metadata_);
   std::swap(_cached_size_, other->_cached_size_);
@@ -6776,6 +7219,49 @@ void ErrorDetail::clear_node_unavailable() {
     clear_has_node_unavailable();
   }
   // @@protoc_insertion_point(field_set_allocated:cockroach.proto.ErrorDetail.node_unavailable)
+}
+
+// optional .cockroach.proto.SendError send = 15;
+bool ErrorDetail::has_send() const {
+  return (_has_bits_[0] & 0x00004000u) != 0;
+}
+void ErrorDetail::set_has_send() {
+  _has_bits_[0] |= 0x00004000u;
+}
+void ErrorDetail::clear_has_send() {
+  _has_bits_[0] &= ~0x00004000u;
+}
+void ErrorDetail::clear_send() {
+  if (send_ != NULL) send_->::cockroach::proto::SendError::Clear();
+  clear_has_send();
+}
+ const ::cockroach::proto::SendError& ErrorDetail::send() const {
+  // @@protoc_insertion_point(field_get:cockroach.proto.ErrorDetail.send)
+  return send_ != NULL ? *send_ : *default_instance_->send_;
+}
+ ::cockroach::proto::SendError* ErrorDetail::mutable_send() {
+  set_has_send();
+  if (send_ == NULL) {
+    send_ = new ::cockroach::proto::SendError;
+  }
+  // @@protoc_insertion_point(field_mutable:cockroach.proto.ErrorDetail.send)
+  return send_;
+}
+ ::cockroach::proto::SendError* ErrorDetail::release_send() {
+  clear_has_send();
+  ::cockroach::proto::SendError* temp = send_;
+  send_ = NULL;
+  return temp;
+}
+ void ErrorDetail::set_allocated_send(::cockroach::proto::SendError* send) {
+  delete send_;
+  send_ = send;
+  if (send) {
+    set_has_send();
+  } else {
+    clear_has_send();
+  }
+  // @@protoc_insertion_point(field_set_allocated:cockroach.proto.ErrorDetail.send)
 }
 
 #endif  // PROTOBUF_INLINE_NOT_IN_HEADERS

--- a/storage/engine/rocksdb/cockroach/proto/errors.pb.h
+++ b/storage/engine/rocksdb/cockroach/proto/errors.pb.h
@@ -55,6 +55,7 @@ class WriteTooOldError;
 class OpRequiresTxnError;
 class ConditionFailedError;
 class LeaseRejectedError;
+class SendError;
 class ErrorDetail;
 class Error;
 
@@ -1476,6 +1477,110 @@ class LeaseRejectedError : public ::google::protobuf::Message {
 };
 // -------------------------------------------------------------------
 
+class SendError : public ::google::protobuf::Message {
+ public:
+  SendError();
+  virtual ~SendError();
+
+  SendError(const SendError& from);
+
+  inline SendError& operator=(const SendError& from) {
+    CopyFrom(from);
+    return *this;
+  }
+
+  inline const ::google::protobuf::UnknownFieldSet& unknown_fields() const {
+    return _internal_metadata_.unknown_fields();
+  }
+
+  inline ::google::protobuf::UnknownFieldSet* mutable_unknown_fields() {
+    return _internal_metadata_.mutable_unknown_fields();
+  }
+
+  static const ::google::protobuf::Descriptor* descriptor();
+  static const SendError& default_instance();
+
+  void Swap(SendError* other);
+
+  // implements Message ----------------------------------------------
+
+  inline SendError* New() const { return New(NULL); }
+
+  SendError* New(::google::protobuf::Arena* arena) const;
+  void CopyFrom(const ::google::protobuf::Message& from);
+  void MergeFrom(const ::google::protobuf::Message& from);
+  void CopyFrom(const SendError& from);
+  void MergeFrom(const SendError& from);
+  void Clear();
+  bool IsInitialized() const;
+
+  int ByteSize() const;
+  bool MergePartialFromCodedStream(
+      ::google::protobuf::io::CodedInputStream* input);
+  void SerializeWithCachedSizes(
+      ::google::protobuf::io::CodedOutputStream* output) const;
+  ::google::protobuf::uint8* SerializeWithCachedSizesToArray(::google::protobuf::uint8* output) const;
+  int GetCachedSize() const { return _cached_size_; }
+  private:
+  void SharedCtor();
+  void SharedDtor();
+  void SetCachedSize(int size) const;
+  void InternalSwap(SendError* other);
+  private:
+  inline ::google::protobuf::Arena* GetArenaNoVirtual() const {
+    return _internal_metadata_.arena();
+  }
+  inline void* MaybeArenaPtr() const {
+    return _internal_metadata_.raw_arena_ptr();
+  }
+  public:
+
+  ::google::protobuf::Metadata GetMetadata() const;
+
+  // nested types ----------------------------------------------------
+
+  // accessors -------------------------------------------------------
+
+  // optional string message = 1;
+  bool has_message() const;
+  void clear_message();
+  static const int kMessageFieldNumber = 1;
+  const ::std::string& message() const;
+  void set_message(const ::std::string& value);
+  void set_message(const char* value);
+  void set_message(const char* value, size_t size);
+  ::std::string* mutable_message();
+  ::std::string* release_message();
+  void set_allocated_message(::std::string* message);
+
+  // optional bool retryable = 2;
+  bool has_retryable() const;
+  void clear_retryable();
+  static const int kRetryableFieldNumber = 2;
+  bool retryable() const;
+  void set_retryable(bool value);
+
+  // @@protoc_insertion_point(class_scope:cockroach.proto.SendError)
+ private:
+  inline void set_has_message();
+  inline void clear_has_message();
+  inline void set_has_retryable();
+  inline void clear_has_retryable();
+
+  ::google::protobuf::internal::InternalMetadataWithArena _internal_metadata_;
+  ::google::protobuf::uint32 _has_bits_[1];
+  mutable int _cached_size_;
+  ::google::protobuf::internal::ArenaStringPtr message_;
+  bool retryable_;
+  friend void  protobuf_AddDesc_cockroach_2fproto_2ferrors_2eproto();
+  friend void protobuf_AssignDesc_cockroach_2fproto_2ferrors_2eproto();
+  friend void protobuf_ShutdownFile_cockroach_2fproto_2ferrors_2eproto();
+
+  void InitAsDefaultInstance();
+  static SendError* default_instance_;
+};
+// -------------------------------------------------------------------
+
 class ErrorDetail : public ::google::protobuf::Message {
  public:
   ErrorDetail();
@@ -1666,6 +1771,15 @@ class ErrorDetail : public ::google::protobuf::Message {
   ::cockroach::proto::NodeUnavailableError* release_node_unavailable();
   void set_allocated_node_unavailable(::cockroach::proto::NodeUnavailableError* node_unavailable);
 
+  // optional .cockroach.proto.SendError send = 15;
+  bool has_send() const;
+  void clear_send();
+  static const int kSendFieldNumber = 15;
+  const ::cockroach::proto::SendError& send() const;
+  ::cockroach::proto::SendError* mutable_send();
+  ::cockroach::proto::SendError* release_send();
+  void set_allocated_send(::cockroach::proto::SendError* send);
+
   // @@protoc_insertion_point(class_scope:cockroach.proto.ErrorDetail)
  private:
   inline void set_has_not_leader();
@@ -1696,6 +1810,8 @@ class ErrorDetail : public ::google::protobuf::Message {
   inline void clear_has_lease_rejected();
   inline void set_has_node_unavailable();
   inline void clear_has_node_unavailable();
+  inline void set_has_send();
+  inline void clear_has_send();
 
   ::google::protobuf::internal::InternalMetadataWithArena _internal_metadata_;
   ::google::protobuf::uint32 _has_bits_[1];
@@ -1714,6 +1830,7 @@ class ErrorDetail : public ::google::protobuf::Message {
   ::cockroach::proto::ConditionFailedError* condition_failed_;
   ::cockroach::proto::LeaseRejectedError* lease_rejected_;
   ::cockroach::proto::NodeUnavailableError* node_unavailable_;
+  ::cockroach::proto::SendError* send_;
   friend void  protobuf_AddDesc_cockroach_2fproto_2ferrors_2eproto();
   friend void protobuf_AssignDesc_cockroach_2fproto_2ferrors_2eproto();
   friend void protobuf_ShutdownFile_cockroach_2fproto_2ferrors_2eproto();
@@ -2882,6 +2999,87 @@ inline void LeaseRejectedError::set_allocated_existing(::cockroach::proto::Lease
 
 // -------------------------------------------------------------------
 
+// SendError
+
+// optional string message = 1;
+inline bool SendError::has_message() const {
+  return (_has_bits_[0] & 0x00000001u) != 0;
+}
+inline void SendError::set_has_message() {
+  _has_bits_[0] |= 0x00000001u;
+}
+inline void SendError::clear_has_message() {
+  _has_bits_[0] &= ~0x00000001u;
+}
+inline void SendError::clear_message() {
+  message_.ClearToEmptyNoArena(&::google::protobuf::internal::GetEmptyStringAlreadyInited());
+  clear_has_message();
+}
+inline const ::std::string& SendError::message() const {
+  // @@protoc_insertion_point(field_get:cockroach.proto.SendError.message)
+  return message_.GetNoArena(&::google::protobuf::internal::GetEmptyStringAlreadyInited());
+}
+inline void SendError::set_message(const ::std::string& value) {
+  set_has_message();
+  message_.SetNoArena(&::google::protobuf::internal::GetEmptyStringAlreadyInited(), value);
+  // @@protoc_insertion_point(field_set:cockroach.proto.SendError.message)
+}
+inline void SendError::set_message(const char* value) {
+  set_has_message();
+  message_.SetNoArena(&::google::protobuf::internal::GetEmptyStringAlreadyInited(), ::std::string(value));
+  // @@protoc_insertion_point(field_set_char:cockroach.proto.SendError.message)
+}
+inline void SendError::set_message(const char* value, size_t size) {
+  set_has_message();
+  message_.SetNoArena(&::google::protobuf::internal::GetEmptyStringAlreadyInited(),
+      ::std::string(reinterpret_cast<const char*>(value), size));
+  // @@protoc_insertion_point(field_set_pointer:cockroach.proto.SendError.message)
+}
+inline ::std::string* SendError::mutable_message() {
+  set_has_message();
+  // @@protoc_insertion_point(field_mutable:cockroach.proto.SendError.message)
+  return message_.MutableNoArena(&::google::protobuf::internal::GetEmptyStringAlreadyInited());
+}
+inline ::std::string* SendError::release_message() {
+  clear_has_message();
+  return message_.ReleaseNoArena(&::google::protobuf::internal::GetEmptyStringAlreadyInited());
+}
+inline void SendError::set_allocated_message(::std::string* message) {
+  if (message != NULL) {
+    set_has_message();
+  } else {
+    clear_has_message();
+  }
+  message_.SetAllocatedNoArena(&::google::protobuf::internal::GetEmptyStringAlreadyInited(), message);
+  // @@protoc_insertion_point(field_set_allocated:cockroach.proto.SendError.message)
+}
+
+// optional bool retryable = 2;
+inline bool SendError::has_retryable() const {
+  return (_has_bits_[0] & 0x00000002u) != 0;
+}
+inline void SendError::set_has_retryable() {
+  _has_bits_[0] |= 0x00000002u;
+}
+inline void SendError::clear_has_retryable() {
+  _has_bits_[0] &= ~0x00000002u;
+}
+inline void SendError::clear_retryable() {
+  retryable_ = false;
+  clear_has_retryable();
+}
+inline bool SendError::retryable() const {
+  // @@protoc_insertion_point(field_get:cockroach.proto.SendError.retryable)
+  return retryable_;
+}
+inline void SendError::set_retryable(bool value) {
+  set_has_retryable();
+  retryable_ = value;
+  // @@protoc_insertion_point(field_set:cockroach.proto.SendError.retryable)
+}
+
+// -------------------------------------------------------------------
+
 // ErrorDetail
 
 // optional .cockroach.proto.NotLeaderError not_leader = 1;
@@ -3486,6 +3684,49 @@ inline void ErrorDetail::set_allocated_node_unavailable(::cockroach::proto::Node
   // @@protoc_insertion_point(field_set_allocated:cockroach.proto.ErrorDetail.node_unavailable)
 }
 
+// optional .cockroach.proto.SendError send = 15;
+inline bool ErrorDetail::has_send() const {
+  return (_has_bits_[0] & 0x00004000u) != 0;
+}
+inline void ErrorDetail::set_has_send() {
+  _has_bits_[0] |= 0x00004000u;
+}
+inline void ErrorDetail::clear_has_send() {
+  _has_bits_[0] &= ~0x00004000u;
+}
+inline void ErrorDetail::clear_send() {
+  if (send_ != NULL) send_->::cockroach::proto::SendError::Clear();
+  clear_has_send();
+}
+inline const ::cockroach::proto::SendError& ErrorDetail::send() const {
+  // @@protoc_insertion_point(field_get:cockroach.proto.ErrorDetail.send)
+  return send_ != NULL ? *send_ : *default_instance_->send_;
+}
+inline ::cockroach::proto::SendError* ErrorDetail::mutable_send() {
+  set_has_send();
+  if (send_ == NULL) {
+    send_ = new ::cockroach::proto::SendError;
+  }
+  // @@protoc_insertion_point(field_mutable:cockroach.proto.ErrorDetail.send)
+  return send_;
+}
+inline ::cockroach::proto::SendError* ErrorDetail::release_send() {
+  clear_has_send();
+  ::cockroach::proto::SendError* temp = send_;
+  send_ = NULL;
+  return temp;
+}
+inline void ErrorDetail::set_allocated_send(::cockroach::proto::SendError* send) {
+  delete send_;
+  send_ = send;
+  if (send) {
+    set_has_send();
+  } else {
+    clear_has_send();
+  }
+  // @@protoc_insertion_point(field_set_allocated:cockroach.proto.ErrorDetail.send)
+}
+
 // -------------------------------------------------------------------
 
 // Error
@@ -3636,6 +3877,8 @@ inline void Error::set_allocated_detail(::cockroach::proto::ErrorDetail* detail)
 }
 
 #endif  // !PROTOBUF_INLINE_NOT_IN_HEADERS
+// -------------------------------------------------------------------
+
 // -------------------------------------------------------------------
 
 // -------------------------------------------------------------------

--- a/storage/replica_test.go
+++ b/storage/replica_test.go
@@ -3040,7 +3040,10 @@ func TestRequestLeaderEncounterGroupDeleteError(t *testing.T) {
 	// Force the read command request a new lease.
 	clock := tc.clock
 	gArgs.Header().Timestamp = clock.Update(clock.Now().Add(int64(DefaultLeaderLeaseDuration), 0))
-	_, err = tc.store.ExecuteCmd(context.Background(), &gArgs)
+	{
+		_, pErr := tc.store.ExecuteCmd(context.Background(), &gArgs)
+		err = pErr.GoError()
+	}
 	if _, ok := err.(*proto.RangeNotFoundError); !ok {
 		t.Fatalf("expected a RangeNotFoundError, get %s", err)
 	}

--- a/storage/store_test.go
+++ b/storage/store_test.go
@@ -949,7 +949,7 @@ func TestStoreResolveWriteIntentPushOnRead(t *testing.T) {
 				}
 			} else {
 				if _, ok := cErr.GoError().(*proto.TransactionRetryError); !ok {
-					t.Errorf("expected transaction retry error; got %s", pErr)
+					t.Errorf("expected transaction retry error; got %s", cErr)
 				}
 			}
 		} else {


### PR DESCRIPTION
This change replaces `error` with `*proto.Error` along the main request path from `(*Store).ExecuteCmd` upwards. Note that `*proto.Error` isn't an `error` any more (#2579); `.GoError()` gives the `error` as usual.
The bulk of "automatic" changes are in the third commit, and reviewing commit-by-commit is recommended.
With this change, the solution to #1891 is close: `(*Store).ExecuteCmd` is already aware of a failing command's position in the batch (#2581), so once this information is added to the `proto.Error` accordingly, it's going to be available at the client.
