### PR TITLE
Read db/table descriptors from system config on common ops.

### DIFF
--- a/client/util.go
+++ b/client/util.go
@@ -108,5 +108,5 @@ func marshalValue(v interface{}) (proto.Value, error) {
 		return r, nil
 	}
 
-	return r, fmt.Errorf("unable to marshal value: %s", v)
+	return r, fmt.Errorf("unable to marshal value: %v", v)
 }

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -125,7 +125,7 @@ func TestGet(t *testing.T) {
 	cfg := config.SystemConfig{}
 	for tcNum, tc := range testCases {
 		cfg.Values = tc.values
-		val, found := cfg.Get([]byte(tc.key))
+		val, found := cfg.GetValue([]byte(tc.key))
 		if found != tc.found {
 			t.Errorf("#%d: expected found=%t", tcNum, tc.found)
 			continue

--- a/server/server.go
+++ b/server/server.go
@@ -137,7 +137,7 @@ func NewServer(ctx *Context, stopper *stop.Stopper) (*Server, error) {
 		return nil, err
 	}
 
-	s.sqlServer = sql.MakeHTTPServer(&s.ctx.Context, *s.db)
+	s.sqlServer = sql.MakeHTTPServer(&s.ctx.Context, *s.db, s.gossip)
 
 	// TODO(bdarnell): make StoreConfig configurable.
 	nCtx := storage.StoreContext{

--- a/server/testserver.go
+++ b/server/testserver.go
@@ -18,6 +18,7 @@
 package server
 
 import (
+	"github.com/cockroachdb/cockroach/client"
 	"github.com/cockroachdb/cockroach/config"
 	"github.com/cockroachdb/cockroach/gossip"
 	"github.com/cockroachdb/cockroach/proto"
@@ -115,10 +116,18 @@ func (ts *TestServer) Clock() *hlc.Clock {
 	return nil
 }
 
-//TsDB returns the ts.DB instance used by the TestServer.
+// TsDB returns the ts.DB instance used by the TestServer.
 func (ts *TestServer) TsDB() *ts.DB {
 	if ts != nil {
 		return ts.tsDB
+	}
+	return nil
+}
+
+// DB returns the client.DB instance used by the TestServer.
+func (ts *TestServer) DB() *client.DB {
+	if ts != nil {
+		return ts.db
 	}
 	return nil
 }

--- a/sql/bank_test.go
+++ b/sql/bank_test.go
@@ -26,16 +26,22 @@ import (
 	"testing"
 
 	"github.com/cockroachdb/cockroach/server"
+	cockroachSql "github.com/cockroachdb/cockroach/sql"
 	"github.com/cockroachdb/cockroach/util/log"
 )
 
 var maxTransfer = flag.Int("max-transfer", 999, "Maximum amount to transfer in one transaction.")
 var numAccounts = flag.Int("num-accounts", 999, "Number of accounts.")
+var skipCache = flag.Bool("skip-cache", false, "Do not use descriptor cache.")
 
 // BenchmarkBank mirrors the SQL performed by examples/sql_bank, but structured
 // as a benchmark for easier usage of the Go performance analysis tools like
 // pprof, memprof and trace.
 func BenchmarkBank(b *testing.B) {
+	prev := cockroachSql.TestingDisableDescriptorCache
+	cockroachSql.TestingDisableDescriptorCache = *skipCache
+	defer func() { cockroachSql.TestingDisableDescriptorCache = prev }()
+
 	s := server.StartTestServer(b)
 	defer s.Stop()
 

--- a/sql/config.go
+++ b/sql/config.go
@@ -32,7 +32,7 @@ func init() {
 // GetZoneConfig returns the zone config for the object with 'id'.
 func GetZoneConfig(cfg *config.SystemConfig, id uint32) (*config.ZoneConfig, error) {
 	// Look in the zones table.
-	if val, ok := cfg.Get(MakeZoneKey(ID(id))); ok {
+	if val, ok := cfg.GetValue(MakeZoneKey(ID(id))); ok {
 		zone := &config.ZoneConfig{}
 		if err := gogoproto.Unmarshal(val, zone); err != nil {
 			return nil, err
@@ -43,7 +43,7 @@ func GetZoneConfig(cfg *config.SystemConfig, id uint32) (*config.ZoneConfig, err
 
 	// No zone config for this ID. We need to figure out if it's a database
 	// or table. Lookup its descriptor.
-	rawDesc, ok := cfg.Get(MakeDescMetadataKey(ID(id)))
+	rawDesc, ok := cfg.GetValue(MakeDescMetadataKey(ID(id)))
 	if !ok {
 		// No descriptor. This table/db could have been deleted,
 		// just return the default config.

--- a/sql/descriptor_cache.go
+++ b/sql/descriptor_cache.go
@@ -1,0 +1,103 @@
+// Copyright 2015 The Cockroach Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+// implied. See the License for the specific language governing
+// permissions and limitations under the License. See the AUTHORS file
+// for names of contributors.
+//
+// Author: Marc Berhault (marc@cockroachlabs.com)
+
+package sql
+
+import (
+	"fmt"
+
+	"github.com/cockroachdb/cockroach/sql/parser"
+	gogoproto "github.com/gogo/protobuf/proto"
+)
+
+// TestingDisableDescriptorCache is used by tests and benchmarks to disable
+// the descriptor cache functionality. All lookups will bypass the cache
+// and use the DB client.
+var TestingDisableDescriptorCache bool
+
+// getCachedTableDesc looks for a table descriptor in the descriptor cache.
+// Looks up the database descriptor, followed by the table descriptor.
+//
+// Returns: the table descriptor, whether it comes from the cache, and an error.
+func (p *planner) getCachedTableDesc(qname *parser.QualifiedName) (*TableDescriptor, bool, error) {
+	if err := qname.NormalizeTableName(p.session.Database); err != nil {
+		return nil, false, err
+	}
+	dbDesc, cached, err := p.getCachedDatabaseDesc(qname.Database())
+	if err != nil {
+		return nil, false, err
+	}
+
+	desc := &TableDescriptor{}
+	// Only attempt cached lookup if the database descriptor was found in the cache.
+	if cached {
+		if err := p.getCachedDescriptor(tableKey{dbDesc.ID, qname.Table()}, desc); err == nil {
+			return desc, true, nil
+		}
+		// Problem, or not found in the cache: fall back on KV lookup.
+	}
+
+	if err := p.getDescriptor(tableKey{dbDesc.ID, qname.Table()}, desc); err != nil {
+		return nil, false, err
+	}
+	return desc, false, nil
+}
+
+// getCachedDatabaseDesc looks for a database descriptor in the descriptor cache.
+// If there is an error looking up in the descriptor cache, or if not found, falls
+// back on kv lookup.
+//
+// The system DB is never looked up in the cache as we may be performing operations
+// on it that really need to know the current values.
+// Returns: the database descriptor, whether it comes from the cache, and an error.
+func (p *planner) getCachedDatabaseDesc(name string) (*DatabaseDescriptor, bool, error) {
+	if !TestingDisableDescriptorCache && name != SystemDB.Name {
+		desc := &DatabaseDescriptor{}
+		if err := p.getCachedDescriptor(databaseKey{name}, desc); err == nil {
+			return desc, true, nil
+		}
+		// Problem looking up in the cache: fall back on non-cached version.
+	}
+	d, err := p.getDatabaseDesc(name)
+	return d, false, err
+}
+
+// getCachedDescriptor looks for a database descriptor in the descriptor cache.
+func (p *planner) getCachedDescriptor(plainKey descriptorKey, descriptor descriptorProto) error {
+	kv, found := p.systemConfig.Get(plainKey.Key())
+	if !found {
+		return fmt.Errorf("%s %q does not exist in system cache", descriptor.TypeName(), plainKey.Name())
+	}
+
+	id, err := kv.Value.GetInt()
+	if err != nil {
+		return err
+	}
+
+	descKey := MakeDescMetadataKey(ID(id))
+	kv, found = p.systemConfig.Get(descKey)
+	if !found {
+		return fmt.Errorf("%s %q has name entry, but no descriptor in system cache",
+			descriptor.TypeName(), plainKey.Name())
+	}
+
+	if err := gogoproto.Unmarshal(kv.Value.Bytes, descriptor); err != nil {
+		return err
+	}
+
+	return descriptor.Validate()
+}

--- a/sql/descriptor_cache_test.go
+++ b/sql/descriptor_cache_test.go
@@ -1,0 +1,247 @@
+// Copyright 2015 The Cockroach Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+// implied. See the License for the specific language governing
+// permissions and limitations under the License. See the AUTHORS file
+// for names of contributors.
+//
+// Author: Marc Berhault (marc@cockroachlabs.com)
+
+package sql_test
+
+import (
+	"testing"
+	"time"
+
+	"github.com/cockroachdb/cockroach/client"
+	"github.com/cockroachdb/cockroach/config"
+	"github.com/cockroachdb/cockroach/gossip"
+	"github.com/cockroachdb/cockroach/keys"
+	"github.com/cockroachdb/cockroach/server"
+	"github.com/cockroachdb/cockroach/sql"
+	"github.com/cockroachdb/cockroach/util"
+	"github.com/cockroachdb/cockroach/util/leaktest"
+	gogoproto "github.com/gogo/protobuf/proto"
+)
+
+var configID = sql.ID(1)
+var configDescKey = sql.MakeDescMetadataKey(keys.MaxReservedDescID)
+
+// forceNewConfig forces a system config update by writing a bogus descriptor with an
+// incremented value inside. It then repeatedly fetches the gossip config until the
+// just-written descriptor is found.
+func forceNewConfig(t *testing.T, s *server.TestServer) (*config.SystemConfig, error) {
+	configID++
+	configDesc := sql.DatabaseDescriptor{
+		Name:       "sentinel",
+		ID:         configID,
+		Privileges: &sql.PrivilegeDescriptor{},
+	}
+
+	// This needs to be done in a transaction with the system trigger set.
+	if err := s.DB().Txn(func(txn *client.Txn) error {
+		txn.SetSystemDBTrigger()
+		return txn.Put(configDescKey, &configDesc)
+	}); err != nil {
+		t.Fatal(err)
+	}
+	return waitForConfigChange(t, s)
+}
+
+func waitForConfigChange(t *testing.T, s *server.TestServer) (cfg *config.SystemConfig, err error) {
+	var foundDesc sql.DatabaseDescriptor
+	err = util.IsTrueWithin(func() bool {
+		cfg = s.Gossip().GetSystemConfig()
+		if cfg == nil {
+			return false
+		}
+		raw, ok := cfg.GetValue(configDescKey)
+		if !ok {
+			return false
+		}
+		if err2 := gogoproto.Unmarshal(raw, &foundDesc); err2 != nil {
+			t.Fatalf("could not unmarshal raw value: %s", err2)
+			return false
+		}
+		return foundDesc.ID == configID
+	}, 10*time.Second)
+	return
+}
+
+// TestDescriptorCacheSchemaMutation shows how the cache can hide
+// failures when mutating the schema and operating on it.
+// When the operation adds a new value, this works fine since the
+// cache descriptor tries on KV. However, entries that exist in the
+// cache but not in KV will behave badly.
+// This always fails with transactions. Without transaction, it is
+// too dependent on timing to test reliable.
+func TestDescriptorCacheSchemaMutation(t *testing.T) {
+	defer leaktest.AfterTest(t)
+	s, sqlDB, _ := setup(t)
+	defer cleanup(s, sqlDB)
+
+	// Create the database, table and do a basic op in a transaction.
+	// The cache falls back on KV lookups so should have no issues.
+	if _, err := sqlDB.Exec(`
+BEGIN TRANSACTION;
+CREATE DATABASE test;
+CREATE TABLE test.test (k INT PRIMARY KEY, v INT);
+SELECT * FROM test.test;
+COMMIT TRANSACTION;
+`); err != nil {
+		t.Fatal(err)
+	}
+
+	// Wait for system config load.
+	if _, err := forceNewConfig(t, s); err != nil {
+		t.Fatalf("failed to get latest system config: %s", err)
+	}
+
+	// Drop a table and perform a select within the same sql transaction.
+	// The table is found in the cache, so the select succeeds.
+	if _, err := sqlDB.Exec(`
+BEGIN TRANSACTION;
+DROP TABLE test.test;
+SELECT * FROM test.test;
+COMMIT TRANSACTION;
+`); err != nil {
+		t.Fatal(err)
+	}
+
+	sql.TestingDisableDescriptorCache = true
+	defer func() { sql.TestingDisableDescriptorCache = false }()
+	// With caching disabled, this fails. We intentionally execute statements separately
+	// to ensure 'SELECT' is the failing one.
+	if _, err := sqlDB.Exec(`CREATE TABLE test.test (k INT PRIMARY KEY, v INT)`); err != nil {
+		t.Fatal(err)
+	}
+	tx, err := sqlDB.Begin()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := tx.Exec(`DROP TABLE test.test`); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := tx.Exec(`SELECT * FROM test.test`); err == nil {
+		t.Fatal("unexpected success")
+	}
+	_ = tx.Rollback()
+}
+
+// TestDescriptorCache populates the system config with fake entries
+// and verifies that the cache uses them.
+func TestDescriptorCache(t *testing.T) {
+	defer leaktest.AfterTest(t)
+	s, sqlDB, _ := setup(t)
+	defer cleanup(s, sqlDB)
+
+	if _, err := sqlDB.Exec(`CREATE DATABASE test`); err != nil {
+		t.Fatal(err)
+	}
+
+	// Create two tables. We'll be populating them with different data.
+	if _, err := sqlDB.Exec(`CREATE TABLE test.test1 (k INT PRIMARY KEY, v INT)`); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := sqlDB.Exec(`CREATE TABLE test.test2 (k INT PRIMARY KEY, v INT)`); err != nil {
+		t.Fatal(err)
+	}
+
+	// Put some data into each table. test1 has one row, test2 has two.
+	if _, err := sqlDB.Exec(`INSERT INTO test.test1 VALUES (1, 1)`); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := sqlDB.Exec(`INSERT INTO test.test2 VALUES (2, 2), (3, 3)`); err != nil {
+		t.Fatal(err)
+	}
+
+	// Wait for system config load.
+	cfg, err := forceNewConfig(t, s)
+	if err != nil {
+		t.Fatalf("failed to get latest system config: %s", err)
+	}
+
+	dbID := keys.MaxReservedDescID + 1
+	test1NameKey := sql.MakeNameMetadataKey(sql.ID(dbID), "test1")
+	test2NameKey := sql.MakeNameMetadataKey(sql.ID(dbID), "test2")
+	test1Index, ok := cfg.GetIndex(test1NameKey)
+	if !ok {
+		t.Fatalf("%s not found", test1NameKey)
+	}
+
+	test2Index, ok := cfg.GetIndex(test2NameKey)
+	if !ok {
+		t.Fatalf("%s not found", test2NameKey)
+	}
+
+	// Swap the namespace entries for the 'test1' and 'test2' tables in the system config.
+	// This means that "test.test1" will resolve to the object ID for test2, and vice-versa.
+	cfg.Values[test1Index].Value, cfg.Values[test2Index].Value =
+		cfg.Values[test2Index].Value, cfg.Values[test1Index].Value
+	// Gossip it and wait. We increment the fake descriptor in the system config and
+	// wait for the callback to have it.
+	configID++
+	configDesc := sql.DatabaseDescriptor{
+		Name:       "sentinel",
+		ID:         configID,
+		Privileges: &sql.PrivilegeDescriptor{},
+	}
+	raw, err := gogoproto.Marshal(&configDesc)
+	if err != nil {
+		t.Fatal(err)
+	}
+	configDescIndex, ok := cfg.GetIndex(configDescKey)
+	if !ok {
+		t.Fatalf("%s not found", configDescKey)
+	}
+	cfg.Values[configDescIndex].Value.Bytes = raw
+	if err := s.Gossip().AddInfoProto(gossip.KeySystemConfig, cfg, 0); err != nil {
+		t.Fatal(err)
+	}
+
+	if _, err := waitForConfigChange(t, s); err != nil {
+		t.Fatal(err)
+	}
+
+	// Pfeww. That was tedious. Now count the number of entries in each table.
+	// We just waited for the config, so the cache should have it.
+	// test1 was hacked to point to test2 which has two entries.
+	count := 0
+	if err := sqlDB.QueryRow(`SELECT COUNT(*) FROM test.test1`).Scan(&count); err != nil {
+		t.Fatal(err)
+	}
+	if e := 2; count != e {
+		t.Errorf("Bad number of rows from hacked test1, expected %d, got %d", e, count)
+	}
+	// test2 was hacked to point to test1 which has one entry.
+	if err := sqlDB.QueryRow(`SELECT COUNT(*) FROM test.test2`).Scan(&count); err != nil {
+		t.Fatal(err)
+	}
+	if e := 1; count != e {
+		t.Errorf("Bad number of rows from hacked test2, expected %d, got %d", e, count)
+	}
+
+	// Now try again without caching.
+	sql.TestingDisableDescriptorCache = true
+	defer func() { sql.TestingDisableDescriptorCache = false }()
+	if err := sqlDB.QueryRow(`SELECT COUNT(*) FROM test.test1`).Scan(&count); err != nil {
+		t.Fatal(err)
+	}
+	if e := 1; count != e {
+		t.Errorf("Bad number of rows from test1, expected %d, got %d", e, count)
+	}
+	if err := sqlDB.QueryRow(`SELECT COUNT(*) FROM test.test2`).Scan(&count); err != nil {
+		t.Fatal(err)
+	}
+	if e := 2; count != e {
+		t.Errorf("Bad number of rows from test2, expected %d, got %d", e, count)
+	}
+}

--- a/sql/executor.go
+++ b/sql/executor.go
@@ -22,9 +22,12 @@ import (
 	"fmt"
 	"net/http"
 	"strconv"
+	"sync"
 	"time"
 
 	"github.com/cockroachdb/cockroach/client"
+	"github.com/cockroachdb/cockroach/config"
+	"github.com/cockroachdb/cockroach/gossip"
 	"github.com/cockroachdb/cockroach/proto"
 	"github.com/cockroachdb/cockroach/sql/driver"
 	"github.com/cockroachdb/cockroach/sql/parser"
@@ -39,11 +42,18 @@ var errTransactionInProgress = errors.New("there is already a transaction in pro
 type Executor struct {
 	db     client.DB
 	nodeID uint32
+
+	// System Config and mutex.
+	systemConfig   *config.SystemConfig
+	systemConfigMu sync.RWMutex
 }
 
-// NewExecutor creates an Executor.
-func NewExecutor(db client.DB) Executor {
-	return Executor{db: db}
+// NewExecutor creates an Executor and registers a callback on the
+// system config.
+func NewExecutor(db client.DB, gossip *gossip.Gossip) *Executor {
+	exec := &Executor{db: db}
+	gossip.RegisterSystemConfigCallback(exec.updateSystemConfig)
+	return exec
 }
 
 // SetNodeID sets the node ID for the SQL server.
@@ -51,14 +61,30 @@ func (e *Executor) SetNodeID(nodeID proto.NodeID) {
 	e.nodeID = uint32(nodeID)
 }
 
+// updateSystemConfig is called whenever the system config gossip entry is updated.
+func (e *Executor) updateSystemConfig(cfg *config.SystemConfig) {
+	e.systemConfigMu.Lock()
+	defer e.systemConfigMu.Unlock()
+	e.systemConfig = cfg
+}
+
+// getSystemConfig returns a pointer to the latest system config. May be nil,
+// if the gossip callback has not run.
+func (e *Executor) getSystemConfig() *config.SystemConfig {
+	e.systemConfigMu.RLock()
+	defer e.systemConfigMu.RUnlock()
+	return e.systemConfig
+}
+
 // Execute the statement(s) in the given request and return a response.
 // On error, the returned integer is an HTTP error code.
-func (e Executor) Execute(args driver.Request) (driver.Response, int, error) {
+func (e *Executor) Execute(args driver.Request) (driver.Response, int, error) {
 	planMaker := planner{
 		user: args.GetUser(),
 		evalCtx: parser.EvalContext{
 			NodeID: e.nodeID,
 		},
+		systemConfig: e.getSystemConfig(),
 	}
 	// Pick up current session state.
 	if err := gogoproto.Unmarshal(args.Session, &planMaker.session); err != nil {
@@ -98,7 +124,7 @@ func (e Executor) Execute(args driver.Request) (driver.Response, int, error) {
 
 // exec executes the request. Any error encountered is returned; it is
 // the caller's responsibility to update the response.
-func (e Executor) execStmts(sql string, params parameters, planMaker *planner) driver.Response {
+func (e *Executor) execStmts(sql string, params parameters, planMaker *planner) driver.Response {
 	var resp driver.Response
 	stmts, err := parser.Parse(sql, parser.Syntax(planMaker.session.Syntax))
 	if err != nil {
@@ -117,7 +143,7 @@ func (e Executor) execStmts(sql string, params parameters, planMaker *planner) d
 	return resp
 }
 
-func (e Executor) execStmt(stmt parser.Statement, params parameters, planMaker *planner) (driver.Result, error) {
+func (e *Executor) execStmt(stmt parser.Statement, params parameters, planMaker *planner) (driver.Result, error) {
 	var result driver.Result
 	switch stmt.(type) {
 	case *parser.BeginTransaction:

--- a/sql/http_server.go
+++ b/sql/http_server.go
@@ -25,6 +25,7 @@ import (
 
 	"github.com/cockroachdb/cockroach/base"
 	"github.com/cockroachdb/cockroach/client"
+	"github.com/cockroachdb/cockroach/gossip"
 	"github.com/cockroachdb/cockroach/security"
 	"github.com/cockroachdb/cockroach/sql/driver"
 	"github.com/cockroachdb/cockroach/util"
@@ -36,12 +37,12 @@ var allowedEncodings = []util.EncodingType{util.JSONEncoding, util.ProtoEncoding
 // It accepts either JSON or serialized protobuf content types.
 type HTTPServer struct {
 	context *base.Context
-	Executor
+	*Executor
 }
 
 // MakeHTTPServer creates an HTTPServer.
-func MakeHTTPServer(ctx *base.Context, db client.DB) HTTPServer {
-	return HTTPServer{context: ctx, Executor: NewExecutor(db)}
+func MakeHTTPServer(ctx *base.Context, db client.DB, gossip *gossip.Gossip) HTTPServer {
+	return HTTPServer{context: ctx, Executor: NewExecutor(db, gossip)}
 }
 
 // ServeHTTP serves the SQL API by treating the request URL path

--- a/sql/insert.go
+++ b/sql/insert.go
@@ -32,7 +32,7 @@ import (
 //   Notes: postgres requires INSERT. No "on duplicate key update" option.
 //          mysql requires INSERT. Also requires UPDATE on "ON DUPLICATE KEY UPDATE".
 func (p *planner) Insert(n *parser.Insert) (planNode, error) {
-	tableDesc, err := p.getTableDesc(n.Table)
+	tableDesc, _, err := p.getCachedTableDesc(n.Table)
 	if err != nil {
 		return nil, err
 	}

--- a/sql/split_test.go
+++ b/sql/split_test.go
@@ -98,7 +98,7 @@ func TestSplitOnTableBoundaries(t *testing.T) {
 			t.Fatalf("failed to retrieve range list: %s", err)
 		}
 		return num == 2
-	}, 500*time.Millisecond); err != nil {
+	}, 10*time.Second); err != nil {
 		t.Errorf("missing split: %s", err)
 	}
 
@@ -125,7 +125,7 @@ func TestSplitOnTableBoundaries(t *testing.T) {
 		}
 		t.Logf("Num ranges: %d", num)
 		return num == 3
-	}, 500*time.Millisecond); err != nil {
+	}, 10*time.Second); err != nil {
 		t.Errorf("missing split: %s", err)
 	}
 


### PR DESCRIPTION
For `SELECT`, `INSERT`, `UPDATE`, and `DELETE` only.

Planners get a copy of the gossiped system config at execution time.
DB and Table descriptors are read from the cache.

If something is not found (or is corrupt) in the cache, fall back to the
standard lookup. However, if a database descriptor is not found in the
cache, do not attempt to lookup the table descriptor in the cache.

Bank example benchmark comparison:

```
benchmark              old ns/op     new ns/op     delta
BenchmarkBank-8        2546883       586224        -76.98%
```

TODO: I'm working on tests for cache lookups, especially for inconsistent data. This will take a little while longer.
