### PR TITLE
Miscellaneous changes.

### DIFF
--- a/client/util.go
+++ b/client/util.go
@@ -48,6 +48,7 @@ func marshalValue(v interface{}) (proto.Value, error) {
 		return r, nil
 	}
 
+	// Handle a few common types via a type switch.
 	switch t := v.(type) {
 	case nil:
 		return r, nil
@@ -73,6 +74,9 @@ func marshalValue(v interface{}) (proto.Value, error) {
 		return r, err
 	}
 
+	// Handle all of the Go primitive types besides struct and pointers. This
+	// switch also handles types based on a primitive type (e.g. "type MyInt
+	// int").
 	switch v := reflect.ValueOf(v); v.Kind() {
 	case reflect.Bool:
 		i := int64(0)

--- a/sql/table.go
+++ b/sql/table.go
@@ -466,9 +466,8 @@ func marshalColumnValue(col ColumnDescriptor, val parser.Datum) (interface{}, er
 		if v, ok := val.(parser.DInterval); ok {
 			return v.Duration, nil
 		}
-		// case ColumnType_DECIMAL:
 	default:
-		return nil, fmt.Errorf("unsupported type: %s", val.Type())
+		return nil, util.Errorf("unsupported column type: %s", col.Type.Kind)
 	}
 	return nil, fmt.Errorf("value type %s doesn't match type %s of column %q",
 		val.Type(), col.Type.Kind, col.Name)
@@ -532,6 +531,6 @@ func unmarshalColumnValue(kind ColumnType_Kind, value *proto.Value) (parser.Datu
 		}
 		return parser.DInterval{Duration: time.Duration(v)}, nil
 	default:
-		return nil, fmt.Errorf("unsupported type: %s", kind)
+		return nil, util.Errorf("unsupported column type: %s", kind)
 	}
 }


### PR DESCRIPTION
Added explanatory comments to marshalValue(). Use util.Errorf() instead
of fmt.Errorf() for unexpected errors in
{marshal,unmarshal}ColumnValue().
