### PR TITLE
more work towards getting rid of client.Call

### DIFF
--- a/client/client_test.go
+++ b/client/client_test.go
@@ -72,8 +72,7 @@ func (ss *notifyingSender) wait() {
 func (ss *notifyingSender) Send(ctx context.Context, ba proto.BatchRequest) (*proto.BatchResponse, *proto.Error) {
 	br, pErr := ss.wrapped.Send(ctx, ba)
 	if br != nil && br.Error != nil {
-		log.Warningf("culprit is %T", ss.wrapped)
-		panic(proto.ErrorUnexpectedlySet)
+		panic(proto.ErrorUnexpectedlySet(ss.wrapped, br))
 	}
 	if ss.waiter != nil {
 		ss.waiter.Done()

--- a/client/client_test.go
+++ b/client/client_test.go
@@ -56,7 +56,7 @@ var testUser = server.TestUser
 // being sent.
 type notifyingSender struct {
 	waiter  *sync.WaitGroup
-	wrapped client.BatchSender
+	wrapped client.Sender
 }
 
 func (ss *notifyingSender) reset(waiter *sync.WaitGroup) {
@@ -69,8 +69,8 @@ func (ss *notifyingSender) wait() {
 	ss.waiter = nil
 }
 
-func (ss *notifyingSender) SendBatch(ctx context.Context, ba proto.BatchRequest) (*proto.BatchResponse, *proto.Error) {
-	br, pErr := ss.wrapped.SendBatch(ctx, ba)
+func (ss *notifyingSender) Send(ctx context.Context, ba proto.BatchRequest) (*proto.BatchResponse, *proto.Error) {
+	br, pErr := ss.wrapped.Send(ctx, ba)
 	if br != nil && br.Error != nil {
 		log.Warningf("culprit is %T", ss.wrapped)
 		panic(proto.ErrorUnexpectedlySet)

--- a/client/db_internal_test.go
+++ b/client/db_internal_test.go
@@ -21,6 +21,7 @@ import (
 	"testing"
 
 	"github.com/cockroachdb/cockroach/proto"
+	"github.com/cockroachdb/cockroach/util"
 	"github.com/cockroachdb/cockroach/util/leaktest"
 )
 
@@ -32,7 +33,7 @@ func TestClientCommandID(t *testing.T) {
 	db := NewDB(newTestSender(func(ba proto.BatchRequest) (*proto.BatchResponse, *proto.Error) {
 		count++
 		if ba.CmdID.WallTime == 0 {
-			t.Errorf("expected client command ID to be initialized")
+			return nil, proto.NewError(util.Errorf("expected client command ID to be initialized"))
 		}
 		return &proto.BatchResponse{}, nil
 	}, nil))

--- a/client/db_internal_test.go
+++ b/client/db_internal_test.go
@@ -29,11 +29,12 @@ import (
 func TestClientCommandID(t *testing.T) {
 	defer leaktest.AfterTest(t)
 	count := 0
-	db := NewDB(newTestSender(func(call proto.Call) {
+	db := NewDB(newTestSender(func(ba proto.BatchRequest) (*proto.BatchResponse, *proto.Error) {
 		count++
-		if call.Args.Header().CmdID.WallTime == 0 {
+		if ba.CmdID.WallTime == 0 {
 			t.Errorf("expected client command ID to be initialized")
 		}
+		return &proto.BatchResponse{}, nil
 	}, nil))
 	if err := db.Put("a", "b"); err != nil {
 		t.Error(err)

--- a/client/provisional.go
+++ b/client/provisional.go
@@ -22,7 +22,6 @@ import (
 
 	"github.com/cockroachdb/cockroach/keys"
 	"github.com/cockroachdb/cockroach/proto"
-	"github.com/cockroachdb/cockroach/util/log"
 	"golang.org/x/net/context"
 
 	gogoproto "github.com/gogo/protobuf/proto"
@@ -67,8 +66,7 @@ func sendCallConverted(sender Sender, ctx context.Context, call proto.Call) {
 		gogoproto.Merge(call.Reply, reply)
 	}
 	if call.Reply.Header().GoError() != nil {
-		log.Warningf("culprit is %T", sender)
-		panic(proto.ErrorUnexpectedlySet)
+		panic(proto.ErrorUnexpectedlySet(sender, call.Reply))
 	}
 	if pErr != nil {
 		call.Reply.Header().Error = pErr

--- a/client/provisional.go
+++ b/client/provisional.go
@@ -22,6 +22,7 @@ import (
 
 	"github.com/cockroachdb/cockroach/keys"
 	"github.com/cockroachdb/cockroach/proto"
+	"github.com/cockroachdb/cockroach/util/log"
 	"golang.org/x/net/context"
 
 	gogoproto "github.com/gogo/protobuf/proto"
@@ -52,6 +53,7 @@ func SendCallConverted(sender BatchSender, ctx context.Context, call proto.Call)
 		gogoproto.Merge(call.Reply, reply)
 	}
 	if call.Reply.Header().GoError() != nil {
+		log.Warningf("culprit is %T", sender)
 		panic(proto.ErrorUnexpectedlySet)
 	}
 	if pErr != nil {

--- a/client/rpc_sender.go
+++ b/client/rpc_sender.go
@@ -34,7 +34,7 @@ import (
 )
 
 func init() {
-	f := func(u *url.URL, ctx *base.Context, retryOpts retry.Options, stopper *stop.Stopper) (BatchSender, error) {
+	f := func(u *url.URL, ctx *base.Context, retryOpts retry.Options, stopper *stop.Stopper) (Sender, error) {
 		ctx.Insecure = (u.Scheme != "rpcs")
 		return newRPCSender(u.Host, ctx, retryOpts, stopper)
 	}
@@ -74,13 +74,13 @@ func newRPCSender(server string, context *base.Context, retryOpts retry.Options,
 	}, nil
 }
 
-// SendBatch send a request to Cockroach via RPC. Errors which are retryable
-// are retried with backoff in a loop using the default retry options. Other
-// errors sending the request are retried indefinitely using the same client
-// command ID to avoid reporting failure when in fact the command may have gone
-// through and been executed successfully. We retry here to eventually get
-// through with the same client command ID and be given the cached response.
-func (s *rpcSender) SendBatch(ctx context.Context, ba proto.BatchRequest) (*proto.BatchResponse, *proto.Error) {
+// Batch sends a request to Cockroach via RPC. Errors which are retryable are
+// retried with backoff in a loop using the default retry options. Other errors
+// sending the request are retried indefinitely using the same client command
+// ID to avoid reporting failure when in fact the command may have gone through
+// and been executed successfully. We retry here to eventually get through with
+// the same client command ID and be given the cached response.
+func (s *rpcSender) Send(ctx context.Context, ba proto.BatchRequest) (*proto.BatchResponse, *proto.Error) {
 	method := fmt.Sprintf("Server.%s", proto.Batch)
 
 	var err error

--- a/client/sender.go
+++ b/client/sender.go
@@ -43,18 +43,9 @@ var defaultRetryOptions = retry.Options{
 
 // BatchSender is a new incarnation of client.Sender which only supports batches
 // and uses a request-response pattern.
-// TODO(tschottdorf): do away with client.Sender.
 // TODO(tschottdorf) s/Batch// when client.Sender is out of the way.
 type BatchSender interface {
 	SendBatch(context.Context, proto.BatchRequest) (*proto.BatchResponse, *proto.Error)
-}
-
-// Sender is an interface for sending a request to a Key-Value
-// database backend.
-type Sender interface {
-	// Send invokes the Call.Method with Call.Args and sets the result
-	// in Call.Reply.
-	Send(context.Context, proto.Call)
 }
 
 // SenderFunc is an adapter to allow the use of ordinary functions

--- a/client/txn.go
+++ b/client/txn.go
@@ -49,8 +49,7 @@ func (ts *txnSender) Send(ctx context.Context, ba proto.BatchRequest) (*proto.Ba
 	ba.Txn = &ts.Proto
 	br, pErr := ts.wrapped.Send(ctx, ba)
 	if br != nil && br.Error != nil {
-		log.Warningf("culprit is %T", ts.wrapped)
-		panic(proto.ErrorUnexpectedlySet)
+		panic(proto.ErrorUnexpectedlySet(ts.wrapped, br))
 	}
 
 	// TODO(tschottdorf): see about using only the top-level *proto.Error

--- a/client/txn.go
+++ b/client/txn.go
@@ -45,20 +45,29 @@ var DefaultTxnRetryOptions = retry.Options{
 type txnSender Txn
 
 func (ts *txnSender) Send(ctx context.Context, call proto.Call) {
+	SendCallConverted(ts, context.TODO(), call)
+}
+
+func (ts *txnSender) SendBatch(ctx context.Context, ba proto.BatchRequest) (*proto.BatchResponse, *proto.Error) {
 	// Send call through wrapped sender.
-	call.Args.Header().Txn = &ts.Proto
-	ts.wrapped.Send(ctx, call)
+	ba.Txn = &ts.Proto
+	br, pErr := ts.wrapped.SendBatch(ctx, ba)
+	if br != nil && br.Error != nil {
+		log.Warningf("culprit is %T", ts.wrapped)
+		panic(proto.ErrorUnexpectedlySet)
+	}
 
 	// TODO(tschottdorf): see about using only the top-level *proto.Error
 	// information for this restart logic (includes adding the Txn).
-	err := call.Reply.Header().GoError()
+	err := pErr.GoError()
 	// Only successful requests can carry an updated Txn in their response
 	// header. Any error (e.g. a restart) can have a Txn attached to them as
 	// well; those update our local state in the same way for the next attempt.
 	// The exception is if our transaction was aborted and needs to restart
 	// from scratch, in which case we do just that.
 	if err == nil {
-		ts.Proto.Update(call.Reply.Header().Txn)
+		ts.Proto.Update(br.Txn)
+		return br, nil
 	} else if abrtErr, ok := err.(*proto.TransactionAbortedError); ok {
 		// On Abort, reset the transaction so we start anew on restart.
 		ts.Proto = proto.Transaction{
@@ -70,13 +79,14 @@ func (ts *txnSender) Send(ctx context.Context, call proto.Call) {
 	} else if txnErr, ok := err.(proto.TransactionRestartError); ok {
 		ts.Proto.Update(txnErr.Transaction())
 	}
+	return nil, pErr
 }
 
 // Txn is an in-progress distributed database transaction. A Txn is not safe for
 // concurrent use by multiple goroutines.
 type Txn struct {
 	db      DB
-	wrapped Sender
+	wrapped BatchSender
 	Proto   proto.Transaction
 	// systemDBTrigger is set to true when modifying keys from the
 	// SystemDB span. This sets the SystemDBTrigger on EndTransactionRequest.

--- a/keys/keys.go
+++ b/keys/keys.go
@@ -342,10 +342,10 @@ func MakeTablePrefix(tableID uint32) []byte {
 // through the cracks.
 // TODO(tschottdorf): ideally method on *BatchRequest. See #2198.
 // TODO(tschottdorf): return a keys.Span?
-func Range(br proto.BatchRequest) (proto.Key, proto.Key) {
+func Range(ba proto.BatchRequest) (proto.Key, proto.Key) {
 	from := proto.KeyMax
 	to := proto.KeyMin
-	for _, arg := range br.Requests {
+	for _, arg := range ba.Requests {
 		req := arg.GetInner()
 		if req.Method() == proto.Noop {
 			continue

--- a/kv/batch.go
+++ b/kv/batch.go
@@ -114,8 +114,8 @@ func truncate(br *proto.BatchRequest, desc *proto.RangeDescriptor, from, to prot
 // SenderFn is a function that implements a Sender.
 type senderFn func(context.Context, proto.BatchRequest) (*proto.BatchResponse, *proto.Error)
 
-// SendBatch implements batch.Sender.
-func (f senderFn) SendBatch(ctx context.Context, ba proto.BatchRequest) (*proto.BatchResponse, *proto.Error) {
+// Send implements batch.Sender.
+func (f senderFn) Send(ctx context.Context, ba proto.BatchRequest) (*proto.BatchResponse, *proto.Error) {
 	return f(ctx, ba)
 }
 
@@ -126,11 +126,11 @@ type chunkingSender struct {
 
 // NewChunkingSender returns a new chunking sender which sends through the supplied
 // SenderFn.
-func newChunkingSender(f senderFn) client.BatchSender {
+func newChunkingSender(f senderFn) client.Sender {
 	return &chunkingSender{f: f}
 }
 
-// SendBatch implements Sender.
+// Send implements Sender.
 // TODO(tschottdorf): We actually don't want to chop EndTransaction off for
 // single-range requests (but that happens now since EndTransaction has the
 // isAlone flag). Whether it is one or not is unknown right now (you can only
@@ -138,7 +138,7 @@ func newChunkingSender(f senderFn) client.BatchSender {
 // that you're multi-range. In those cases, the wrapped sender should return an
 // error so that we split and retry once the chunk which contains
 // EndTransaction (i.e. the last one).
-func (cs *chunkingSender) SendBatch(ctx context.Context, ba proto.BatchRequest) (*proto.BatchResponse, *proto.Error) {
+func (cs *chunkingSender) Send(ctx context.Context, ba proto.BatchRequest) (*proto.BatchResponse, *proto.Error) {
 	if len(ba.Requests) < 1 {
 		panic("empty batch")
 	}

--- a/kv/db.go
+++ b/kv/db.go
@@ -85,7 +85,7 @@ func (s *DBServer) executeCmd(argsI gogoproto.Message) (gogoproto.Message, error
 		br = &proto.BatchResponse{}
 	}
 	if br.Error != nil {
-		panic(proto.ErrorUnexpectedlySet)
+		panic(proto.ErrorUnexpectedlySet(s.sender, br))
 	}
 	br.Error = pErr
 	return unwrap(br), nil

--- a/kv/db.go
+++ b/kv/db.go
@@ -49,11 +49,11 @@ var allExternalMethods = [...]proto.Request{
 // It accepts either JSON or serialized protobuf content types.
 type DBServer struct {
 	context *base.Context
-	sender  client.Sender
+	sender  client.BatchSender
 }
 
 // NewDBServer allocates and returns a new DBServer.
-func NewDBServer(ctx *base.Context, sender client.Sender) *DBServer {
+func NewDBServer(ctx *base.Context, sender client.BatchSender) *DBServer {
 	return &DBServer{context: ctx, sender: sender}
 }
 
@@ -76,12 +76,19 @@ func (s *DBServer) RegisterRPC(rpcServer *rpc.Server) error {
 // executeCmd creates a proto.Call struct and sends it via our local sender.
 func (s *DBServer) executeCmd(argsI gogoproto.Message) (gogoproto.Message, error) {
 	args := argsI.(proto.Request)
-	reply := args.CreateReply()
+	ba, unwrap := client.MaybeWrap(args)
 	if err := verifyRequest(args); err != nil {
 		return nil, err
 	}
-	s.sender.Send(context.TODO(), proto.Call{Args: args, Reply: reply})
-	return reply, nil
+	br, pErr := s.sender.SendBatch(context.TODO(), *ba)
+	if pErr != nil {
+		br = &proto.BatchResponse{}
+	}
+	if br.Error != nil {
+		panic(proto.ErrorUnexpectedlySet)
+	}
+	br.Error = pErr
+	return unwrap(br), nil
 }
 
 // verifyRequest checks for illegal inputs in request proto and

--- a/kv/db.go
+++ b/kv/db.go
@@ -49,11 +49,11 @@ var allExternalMethods = [...]proto.Request{
 // It accepts either JSON or serialized protobuf content types.
 type DBServer struct {
 	context *base.Context
-	sender  client.BatchSender
+	sender  client.Sender
 }
 
 // NewDBServer allocates and returns a new DBServer.
-func NewDBServer(ctx *base.Context, sender client.BatchSender) *DBServer {
+func NewDBServer(ctx *base.Context, sender client.Sender) *DBServer {
 	return &DBServer{context: ctx, sender: sender}
 }
 
@@ -80,7 +80,7 @@ func (s *DBServer) executeCmd(argsI gogoproto.Message) (gogoproto.Message, error
 	if err := verifyRequest(args); err != nil {
 		return nil, err
 	}
-	br, pErr := s.sender.SendBatch(context.TODO(), *ba)
+	br, pErr := s.sender.Send(context.TODO(), *ba)
 	if pErr != nil {
 		br = &proto.BatchResponse{}
 	}

--- a/kv/dist_sender_server_test.go
+++ b/kv/dist_sender_server_test.go
@@ -22,8 +22,6 @@ import (
 	"testing"
 	"time"
 
-	"golang.org/x/net/context"
-
 	"github.com/cockroachdb/cockroach/client"
 	"github.com/cockroachdb/cockroach/keys"
 	"github.com/cockroachdb/cockroach/kv"
@@ -254,8 +252,7 @@ func TestMultiRangeScanReverseScanInconsistent(t *testing.T) {
 	sr := call.Reply.(*proto.ScanResponse)
 	sa := call.Args.(*proto.ScanRequest)
 	sa.ReadConsistency = proto.INCONSISTENT
-	client.SendCallConverted(ds, context.Background(), call)
-	if err := sr.GoError(); err != nil {
+	if err := client.SendCall(ds, call); err != nil {
 		t.Fatal(err)
 	}
 	if l := len(sr.Rows); l != 1 {
@@ -270,8 +267,7 @@ func TestMultiRangeScanReverseScanInconsistent(t *testing.T) {
 	rsr := call.Reply.(*proto.ReverseScanResponse)
 	rsa := call.Args.(*proto.ReverseScanRequest)
 	rsa.ReadConsistency = proto.INCONSISTENT
-	client.SendCallConverted(ds, context.Background(), call)
-	if err := rsr.GoError(); err != nil {
+	if err := client.SendCall(ds, call); err != nil {
 		t.Fatal(err)
 	}
 	if l := len(rsr.Rows); l != 1 {

--- a/kv/local_sender.go
+++ b/kv/local_sender.go
@@ -156,7 +156,7 @@ func (ls *LocalSender) Send(ctx context.Context, ba proto.BatchRequest) (*proto.
 	if tmpR != nil {
 		br = tmpR.(*proto.BatchResponse)
 		if br.Error != nil {
-			panic(proto.ErrorUnexpectedlySet)
+			panic(proto.ErrorUnexpectedlySet(store, br))
 		}
 	}
 	return br, pErr

--- a/kv/local_sender.go
+++ b/kv/local_sender.go
@@ -37,7 +37,6 @@ type LocalSender struct {
 	storeMap map[proto.StoreID]*storage.Store // Map from StoreID to Store
 }
 
-var _ client.Sender = &LocalSender{}
 var _ client.BatchSender = &LocalSender{}
 var _ rangeDescriptorDB = &LocalSender{}
 

--- a/kv/local_test_cluster.go
+++ b/kv/local_test_cluster.go
@@ -87,7 +87,7 @@ func (ltc *LocalTestCluster) Start(t util.Tester) {
 			br = &proto.BatchResponse{}
 		}
 		if br.Error != nil {
-			panic(proto.ErrorUnexpectedlySet)
+			panic(proto.ErrorUnexpectedlySet(ltc.localSender, br))
 		}
 		br.Error = pErr
 		return []gogoproto.Message{br}, nil

--- a/kv/txn_coord_sender.go
+++ b/kv/txn_coord_sender.go
@@ -13,7 +13,7 @@
 // permissions and limitations under the License. See the AUTHORS file
 // for names of contributors.
 //
-// Author: Jiajia Han (hanjia18@gmail.com)
+// Author: Tobias Schottdorf (tobias.schottdorf@gmail.com)
 // Author: Spencer Kimball (spencer.kimball@gmail.com)
 
 package kv

--- a/proto/errors.go
+++ b/proto/errors.go
@@ -33,10 +33,11 @@ type ResponseWithError struct {
 	Err   error
 }
 
-// ErrorUnexpectedlySet is the string we panic on when we assert
-// `ResponseHeader.Error == nil` before calling
-// `ResponseHeader.SetGoError()`.
-const ErrorUnexpectedlySet = "error is unexpectedly set"
+// ErrorUnexpectedlySet creates a string to panic with when a response (typically
+// a proto.BatchResponse) unexpectedly has Error set in its response header.
+func ErrorUnexpectedlySet(culprit, response interface{}) string {
+	return fmt.Sprintf("error is unexpectedly set, culprit is %T:\n%+v", culprit, response)
+}
 
 // TransactionRestartError is an interface implemented by errors that cause
 // a transaction to be restarted.

--- a/server/node.go
+++ b/server/node.go
@@ -490,7 +490,7 @@ func (n *Node) executeCmd(argsI gogoproto.Message) (gogoproto.Message, error) {
 		trace.Event(fmt.Sprintf("error: %T", pErr.GoError()))
 	}
 	if br.Error != nil {
-		panic(proto.ErrorUnexpectedlySet)
+		panic(proto.ErrorUnexpectedlySet(n.lSender, br))
 	}
 	br.Error = pErr
 	n.feed.CallComplete(ba, br)

--- a/server/node.go
+++ b/server/node.go
@@ -484,7 +484,7 @@ func (n *Node) executeCmd(argsI gogoproto.Message) (gogoproto.Message, error) {
 	ctx := tracer.ToCtx((*Node)(n).context(), trace)
 
 	ba, unwrap := client.MaybeWrap(args)
-	br, pErr := n.lSender.SendBatch(ctx, *ba)
+	br, pErr := n.lSender.Send(ctx, *ba)
 	if pErr != nil {
 		br = &proto.BatchResponse{}
 		trace.Event(fmt.Sprintf("error: %T", pErr.GoError()))

--- a/server/node_test.go
+++ b/server/node_test.go
@@ -26,8 +26,6 @@ import (
 	"testing"
 	"time"
 
-	"golang.org/x/net/context"
-
 	"github.com/cockroachdb/cockroach/client"
 	"github.com/cockroachdb/cockroach/gossip"
 	"github.com/cockroachdb/cockroach/gossip/resolver"
@@ -45,12 +43,6 @@ import (
 	"github.com/cockroachdb/cockroach/util/leaktest"
 	"github.com/cockroachdb/cockroach/util/stop"
 )
-
-type callDistSender kv.DistSender
-
-func (cds *callDistSender) Send(ctx context.Context, call proto.Call) {
-	client.SendCallConverted((*kv.DistSender)(cds), ctx, call)
-}
 
 // createTestNode creates an rpc server using the specified address,
 // gossip instance, KV database and a node using the specified slice
@@ -78,7 +70,7 @@ func createTestNode(addr net.Addr, engines []engine.Engine, gossipBS net.Addr, t
 		g.Start(rpcServer, stopper)
 	}
 	ctx.Gossip = g
-	sender := (*callDistSender)(kv.NewDistSender(&kv.DistSenderContext{Clock: ctx.Clock}, g))
+	sender := kv.NewDistSender(&kv.DistSenderContext{Clock: ctx.Clock}, g)
 	ctx.DB = client.NewDB(sender)
 	// TODO(bdarnell): arrange to have the transport closed.
 	// (or attach LocalRPCTransport.Close to the stopper)

--- a/storage/response_cache.go
+++ b/storage/response_cache.go
@@ -190,7 +190,7 @@ func (rc *ResponseCache) PutResponse(e engine.Engine, cmdID proto.ClientCmdID, r
 // cache in the hopes of retrying to a successful outcome.
 func (rc *ResponseCache) shouldCacheResponse(replyWithErr proto.ResponseWithError) bool {
 	if err := replyWithErr.Reply.Header().Error; err != nil {
-		panic(proto.ErrorUnexpectedlySet)
+		panic(proto.ErrorUnexpectedlySet(rc, replyWithErr.Reply))
 	}
 
 	switch replyWithErr.Err.(type) {

--- a/storage/store_test.go
+++ b/storage/store_test.go
@@ -88,7 +88,7 @@ type responseAdder interface {
 // Since kv/ depends on storage/, we can't get access to a
 // TxnCoordSender from here.
 // TODO(tschottdorf): {kv->storage}.LocalSender
-func (db *testSender) SendBatch(ctx context.Context, ba proto.BatchRequest) (*proto.BatchResponse, *proto.Error) {
+func (db *testSender) Send(ctx context.Context, ba proto.BatchRequest) (*proto.BatchResponse, *proto.Error) {
 	if et, ok := ba.GetArg(proto.EndTransaction); ok {
 		return nil, proto.NewError(util.Errorf("%s method not supported", et.Method()))
 	}

--- a/storage/store_test.go
+++ b/storage/store_test.go
@@ -82,46 +82,37 @@ type responseAdder interface {
 	Add(reply proto.Response)
 }
 
-func safeSetGoError(reply proto.Response, err error) {
-	if reply.Header().Error != nil {
-		panic(proto.ErrorUnexpectedlySet)
-	}
-	reply.Header().SetGoError(err)
-}
-
 // Send forwards the call to the single store. This is a poor man's
-// version of kv/txn_coord_sender, but it serves the purposes of
+// version of kv.TxnCoordSender, but it serves the purposes of
 // supporting tests in this package. Transactions are not supported.
 // Since kv/ depends on storage/, we can't get access to a
-// txn_coord_sender from here.
-func (db *testSender) Send(_ context.Context, call proto.Call) {
-	switch call.Args.(type) {
-	case *proto.EndTransactionRequest:
-		safeSetGoError(call.Reply, util.Errorf("%s method not supported", call.Method()))
-		return
+// TxnCoordSender from here.
+// TODO(tschottdorf): {kv->storage}.LocalSender
+func (db *testSender) SendBatch(ctx context.Context, ba proto.BatchRequest) (*proto.BatchResponse, *proto.Error) {
+	if et, ok := ba.GetArg(proto.EndTransaction); ok {
+		return nil, proto.NewError(util.Errorf("%s method not supported", et.Method()))
 	}
 	// Lookup range and direct request.
-	header := call.Args.Header()
-	if rng := db.store.LookupReplica(header.Key, header.EndKey); rng != nil {
-		header.RangeID = rng.Desc().RangeID
-		replica := rng.GetReplica()
-		if replica == nil {
-			safeSetGoError(call.Reply, util.Errorf("own replica missing in range"))
-		}
-		header.Replica = *replica
-		reply, err := db.store.ExecuteCmd(context.Background(), call.Args)
-		if reply != nil {
-			gogoproto.Merge(call.Reply, reply)
-		}
-		if call.Reply.Header().Error != nil {
-			panic(proto.ErrorUnexpectedlySet)
-		}
-		if err != nil {
-			call.Reply.Header().Error = err
-		}
-	} else {
-		safeSetGoError(call.Reply, proto.NewRangeKeyMismatchError(header.Key, header.EndKey, nil))
+	key, endKey := keys.Range(ba)
+	rng := db.store.LookupReplica(key, endKey)
+	if rng == nil {
+		return nil, proto.NewError(proto.NewRangeKeyMismatchError(key, endKey, nil))
 	}
+	ba.RangeID = rng.Desc().RangeID
+	replica := rng.GetReplica()
+	if replica == nil {
+		return nil, proto.NewError(util.Errorf("own replica missing in range"))
+	}
+	ba.Replica = *replica
+	reply, pErr := db.store.ExecuteCmd(ctx, &ba)
+	br, _ := reply.(*proto.BatchResponse)
+	if br != nil && br.Error != nil {
+		panic(proto.ErrorUnexpectedlySet)
+	}
+	if pErr != nil {
+		return nil, pErr
+	}
+	return br, nil
 }
 
 // createTestStoreWithoutStart creates a test store using an in-memory

--- a/storage/store_test.go
+++ b/storage/store_test.go
@@ -107,7 +107,7 @@ func (db *testSender) Send(ctx context.Context, ba proto.BatchRequest) (*proto.B
 	reply, pErr := db.store.ExecuteCmd(ctx, &ba)
 	br, _ := reply.(*proto.BatchResponse)
 	if br != nil && br.Error != nil {
-		panic(proto.ErrorUnexpectedlySet)
+		panic(proto.ErrorUnexpectedlySet(db.store, br))
 	}
 	if pErr != nil {
 		return nil, pErr


### PR DESCRIPTION
replaces `client.Sender` with the artist formerly known as `client.BatchSender`.
Some usage of `client.Call` remains, mostly in `client` and in test code (to be tackled next).

@bdarnell feel free to reassign (you made the mistake of looking at the last one :smile:)
