### PR TITLE
fix stray access to RocksDB

### DIFF
--- a/util/stop/stopper.go
+++ b/util/stop/stopper.go
@@ -126,8 +126,8 @@ func (s *Stopper) RunAsyncTask(f func()) bool {
 	}
 	// Call f.
 	go func() {
+		defer s.runPostlude(taskKey)
 		f()
-		s.runPostlude(taskKey)
 	}()
 	return true
 }


### PR DESCRIPTION
previously, a timeout could lead to a stray
goroutine trying to use the engine, leading
to a rather obscure C++ NPE.

See discussion in #2521.
