### PR TITLE
SIM: Convert perform action to be store centric.

### DIFF
--- a/storage/simulation/main.go
+++ b/storage/simulation/main.go
@@ -42,10 +42,10 @@ func main() {
 	}
 
 	// TODO(bram): only flush when on manual stepping (once that enabled).
-	_ = c.epochWriter.Flush()
+	c.flush()
 	for i := 0; i < 100; i++ {
 		c.runEpoch()
-		_ = c.epochWriter.Flush()
+		c.flush()
 	}
 
 	fmt.Println(c)

--- a/storage/simulation/range.go
+++ b/storage/simulation/range.go
@@ -101,23 +101,6 @@ func (r *Range) splitRange(originalRange *Range) {
 	}
 }
 
-// getNextAction returns the action and rebalance from the replica with the
-// highest action priority.
-func (r *Range) getNextAction() (storage.AllocatorAction, bool) {
-	var topReplica replica
-	if len(r.replicas) == 0 {
-		return storage.AllocatorNoop, false
-	}
-	// TODO(bram): This is random. Might want to make it deterministic for
-	// repeatability.
-	for _, replica := range r.replicas {
-		if replica.priority > topReplica.priority {
-			topReplica = replica
-		}
-	}
-	return topReplica.action, topReplica.rebalance
-}
-
 // getAllocateTarget calls allocateTarget for the range and returns the top
 // target store.
 func (r *Range) getAllocateTarget() (proto.StoreID, error) {


### PR DESCRIPTION
This change changes the way in which actions are taken.
If the past, it was a single action per range.  This didn't approximate what our actual system does. 
Now, it's a single action per store.
Once a store has started performing an action on a range, it "locks" the range and any subsequence store that tries to perform another action the range will encounter a conflict and forfeit it's action for the epoch.  This is designed to be similar to what will occur when two or more stores try to perform actions against the same range descriptor.
