### PR TITLE
Add Rebalancing Command-line switch

### DIFF
--- a/cli/flags.go
+++ b/cli/flags.go
@@ -141,6 +141,9 @@ var flagUsage = map[string]string{
 	"max-results": `
         Define the maximum number of results that will be retrieved.
 `,
+	"allow-rebalancing": `
+        Enables this server to rebalance replicas to other stores on the cluster.
+`,
 }
 
 func normalizeStdFlagName(s string) string {
@@ -178,6 +181,7 @@ func initFlags(ctx *server.Context) {
 		f.StringVar(&ctx.Stores, "stores", ctx.Stores, flagUsage["stores"])
 		f.DurationVar(&ctx.MaxOffset, "max-offset", ctx.MaxOffset, flagUsage["max-offset"])
 		f.DurationVar(&ctx.MetricsFrequency, "metrics-frequency", ctx.MetricsFrequency, flagUsage["metrics-frequency"])
+		f.BoolVar(&ctx.AllowRebalancing, "allow-rebalancing", ctx.AllowRebalancing, flagUsage["allow-rebalancing"])
 
 		// Security flags.
 		f.StringVar(&ctx.Certs, "certs", ctx.Certs, flagUsage["certs"])

--- a/server/context.go
+++ b/server/context.go
@@ -44,6 +44,7 @@ const (
 	defaultScanMaxIdleTime    = 5 * time.Second
 	defaultMetricsFrequency   = 10 * time.Second
 	defaultTimeUntilStoreDead = 5 * time.Minute
+	defaultAllowRebalancing   = false
 )
 
 // Context holds parameters needed to setup a server.
@@ -97,6 +98,9 @@ type Context struct {
 	// The value is split evenly between the stores if there are more than one.
 	CacheSize int64
 
+	// Enables this server to rebalance replicas to other servers.
+	AllowRebalancing bool
+
 	// Parsed values.
 
 	// Engines is the storage instances specified by Stores.
@@ -138,6 +142,7 @@ func NewContext() *Context {
 		ScanMaxIdleTime:    defaultScanMaxIdleTime,
 		MetricsFrequency:   defaultMetricsFrequency,
 		TimeUntilStoreDead: defaultTimeUntilStoreDead,
+		AllowRebalancing:   defaultAllowRebalancing,
 	}
 	// Initializes base context defaults.
 	ctx.InitDefaults()

--- a/server/server.go
+++ b/server/server.go
@@ -150,6 +150,9 @@ func NewServer(ctx *Context, stopper *stop.Stopper) (*Server, error) {
 		EventFeed:       feed,
 		Tracer:          tracer,
 		StorePool:       s.storePool,
+		RebalancingOptions: storage.RebalancingOptions{
+			AllowRebalance: s.ctx.AllowRebalancing,
+		},
 	}
 	s.node = NewNode(nCtx)
 	s.admin = newAdminServer(s.db, s.stopper)


### PR DESCRIPTION
Three commits which create a command-line switch to enable rebalancing on a node.  The first commit ameliorates a number of frequent panics that occurred in `resolveIntents()` on a replica that is being rebalanced; after fixing this issue, I am convinced that rebalancing is sufficiently stable to add a command line flag for it.

I am not enabling it by default due to issue #768, which is very likely to result in panics on clusters with rebalancing enabled  (although on a shorter term than the `resolveIntents()` issue here).
