### PR TITLE
Make DistSender.sendRPC() return an error when a replica set is empty

### DIFF
--- a/kv/dist_sender.go
+++ b/kv/dist_sender.go
@@ -311,10 +311,7 @@ func (ds *DistSender) getNodeDescriptor() *proto.NodeDescriptor {
 func (ds *DistSender) sendRPC(trace *tracer.Trace, rangeID proto.RangeID, replicas replicaSlice, order rpc.OrderingPolicy,
 	args proto.Request) (proto.Response, error) {
 	if len(replicas) == 0 {
-		// TODO(tschottdorf): this gets in the way of some tests. Consider
-		// refactoring so that gossip is mocked out more easily. Provisional
-		// code. return nil, util.Errorf("%s: replicas set is empty",
-		// args.Method())
+		return nil, util.Errorf("%s: replicas set is empty", args.Method())
 	}
 
 	// Build a slice of replica addresses (if gossiped).
@@ -326,8 +323,7 @@ func (ds *DistSender) sendRPC(trace *tracer.Trace, rangeID proto.RangeID, replic
 		replicaMap[addr.String()] = &replicas[i].Replica
 	}
 	if len(addrs) == 0 {
-		// TODO(tschottdorf): see len(replicas) above.
-		// return nil, noNodeAddrsAvailError{}
+		return nil, noNodeAddrsAvailError{}
 	}
 
 	// TODO(pmattis): This needs to be tested. If it isn't set we'll

--- a/kv/local_test_cluster.go
+++ b/kv/local_test_cluster.go
@@ -68,7 +68,8 @@ type LocalTestCluster struct {
 // to shutdown the server after the test completes.
 func (ltc *LocalTestCluster) Start(t util.Tester) {
 
-	nodeDesc := &proto.NodeDescriptor{NodeID: 1}
+	nodeID := proto.NodeID(1)
+	nodeDesc := &proto.NodeDescriptor{NodeID: nodeID}
 	ltc.tester = t
 	ltc.Manual = hlc.NewManualClock(0)
 	ltc.Clock = hlc.NewClock(ltc.Manual.UnixNano)
@@ -114,7 +115,7 @@ func (ltc *LocalTestCluster) Start(t util.Tester) {
 	ctx.Gossip = ltc.Gossip
 	ctx.Transport = transport
 	ltc.Store = storage.NewStore(ctx, ltc.Eng, nodeDesc)
-	if err := ltc.Store.Bootstrap(proto.StoreIdent{NodeID: 1, StoreID: 1}, ltc.Stopper); err != nil {
+	if err := ltc.Store.Bootstrap(proto.StoreIdent{NodeID: nodeID, StoreID: 1}, ltc.Stopper); err != nil {
 		t.Fatalf("unable to start local test cluster: %s", err)
 	}
 	ltc.localSender.AddStore(ltc.Store)
@@ -123,6 +124,9 @@ func (ltc *LocalTestCluster) Start(t util.Tester) {
 	}
 	if err := ltc.Store.Start(ltc.Stopper); err != nil {
 		t.Fatalf("unable to start local test cluster: %s", err)
+	}
+	if err := ltc.Gossip.SetNodeDescriptor(nodeDesc); err != nil {
+		t.Fatalf("unable to set node descriptor: %s", err)
 	}
 }
 

--- a/storage/client_test.go
+++ b/storage/client_test.go
@@ -338,9 +338,6 @@ func gossipNodeDesc(g *gossip.Gossip, nodeID proto.NodeID) error {
 		// can figure out where requests must be sent.
 		Address: util.MakeUnresolvedAddr("localhost", fmt.Sprintf("%d", nodeID)),
 	}
-	if err := g.AddInfoProto(gossip.MakeNodeIDKey(nodeID), nodeDesc, time.Hour); err != nil {
-		return err
-	}
 	if err := g.SetNodeDescriptor(nodeDesc); err != nil {
 		return err
 	}


### PR DESCRIPTION
This addresses tschottdorf's TODO comment.

The first commit was needed to make all tests pass (similar to what we made to multiTestContext).
