### PR TITLE
kv: remove outdated test

### DIFF
--- a/kv/txn_coord_sender_test.go
+++ b/kv/txn_coord_sender_test.go
@@ -629,30 +629,6 @@ func TestTxnDrainingNode(t *testing.T) {
 	<-s.Stopper.IsStopped()
 }
 
-// TestTxnCoordIdempotentCleanup verifies that cleanupTxn is idempotent.
-func TestTxnCoordIdempotentCleanup(t *testing.T) {
-	defer leaktest.AfterTest(t)
-	s := createTestDB(t)
-	defer s.Stop()
-
-	txn := newTxn(s.Clock, proto.Key("a"))
-	key := proto.Key("a")
-	put := createPutRequest(key, []byte("value"), txn)
-	if _, err := batchutil.SendWrapped(s.Sender, put); err != nil {
-		t.Fatal(err)
-	}
-	s.Sender.cleanupTxn(nil, *txn) // first call
-	if _, err := batchutil.SendWrapped(s.Sender, &proto.EndTransactionRequest{
-		RequestHeader: proto.RequestHeader{
-			Timestamp: txn.Timestamp,
-			Txn:       txn,
-		},
-		Commit: true,
-	}); /* second call */ err != nil {
-		t.Fatal(err)
-	}
-}
-
 // TestTxnMultipleCoord checks that a coordinator uses the Writing flag to
 // enforce that only one coordinator can be used for transactional writes.
 func TestTxnMultipleCoord(t *testing.T) {


### PR DESCRIPTION
the first call would signal the heartbeat goroutine to terminate,
which could recycle the txn metadata before the second call via
EndTransaction would happen (in that case, EndTransaction would
fail).

Switching the order removed that issue.

fixes #2541.
