### PR TITLE
Relax restrictions on CLI `cockroach log` command.

### DIFF
--- a/cli/log.go
+++ b/cli/log.go
@@ -44,7 +44,7 @@ unless --color=off is specified.
 // log file named in arguments.
 func runLog(cmd *cobra.Command, args []string) {
 	for _, arg := range args {
-		reader, err := log.GetLogReader(arg, true /* allowAbsolute */)
+		reader, err := log.GetLogReader(arg, false /* !restricted */)
 		if err != nil {
 			log.Error(err)
 			break

--- a/server/status.go
+++ b/server/status.go
@@ -316,7 +316,7 @@ func (s *statusServer) handleLogFilesList(w http.ResponseWriter, r *http.Request
 func (s *statusServer) handleLogFileLocal(w http.ResponseWriter, r *http.Request, ps httprouter.Params) {
 	log.Flush()
 	file := ps.ByName("file")
-	reader, err := log.GetLogReader(file, false /* !allowAbsolute */)
+	reader, err := log.GetLogReader(file, true /* restricted */)
 	if reader == nil || err != nil {
 		log.Errorf("log file %s could not be opened: %s", file, err)
 		http.NotFound(w, r)

--- a/util/log/main_test.go
+++ b/util/log/main_test.go
@@ -1,0 +1,36 @@
+// Copyright 2015 The Cockroach Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+// implied. See the License for the specific language governing
+// permissions and limitations under the License. See the AUTHORS file
+// for names of contributors.
+//
+// Author: Ben Darnell
+
+package log
+
+import (
+	"io/ioutil"
+	"os"
+	"testing"
+)
+
+func TestMain(m *testing.M) {
+	tmpDir, err := ioutil.TempDir("", "logtest")
+	if err != nil {
+		Fatalf("could not create temporary directory: %s", err)
+	}
+	defer func() {
+		_ = os.RemoveAll(tmpDir)
+	}()
+	*logDir = tmpDir
+	os.Exit(m.Run())
+}

--- a/util/log/main_test.go
+++ b/util/log/main_test.go
@@ -29,7 +29,9 @@ func TestMain(m *testing.M) {
 		Fatalf("could not create temporary directory: %s", err)
 	}
 	defer func() {
-		_ = os.RemoveAll(tmpDir)
+		if err := os.RemoveAll(tmpDir); err != nil {
+			Errorf("failed to clean up temp directory: %s", err)
+		}
 	}()
 	*logDir = tmpDir
 	os.Exit(m.Run())


### PR DESCRIPTION
Relative paths and symlinks are now supported, making it easier
to work with logs from the acceptance tests.
