### PR TITLE
Move tracer logging to V(2)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -122,8 +122,8 @@ acceptance:
 check:
 	@echo "checking for tabs in shell scripts"
 	@! git grep -F '	' -- '*.sh'
-	@echo "checking for \"path\" imports"
-	@! git grep -F '"path"' -- '*.go'
+	@echo "checking for forbidden imports"
+	@! go list -f '{{ $$ip := .ImportPath }}{{ range .Imports}}{{ $$ip }}: {{ println . }}{{end}}' $(PKG) | grep -E ' (path|log)$$' | grep -Ev 'util/(log|stop): log$$'
 	@echo "errcheck"
 	@errcheck -ignore 'bytes:Write.*,io:Close,net:Close,net/http:Close,net/rpc:Close,os:Close,database/sql:Close' $(PKG)
 	@echo "vet"

--- a/sql/system.go
+++ b/sql/system.go
@@ -18,13 +18,12 @@
 package sql
 
 import (
-	"log"
-
 	"github.com/cockroachdb/cockroach/keys"
 	"github.com/cockroachdb/cockroach/proto"
 	"github.com/cockroachdb/cockroach/security"
 	"github.com/cockroachdb/cockroach/sql/parser"
 	"github.com/cockroachdb/cockroach/sql/privilege"
+	"github.com/cockroachdb/cockroach/util/log"
 )
 
 const (

--- a/util/stop/stopper.go
+++ b/util/stop/stopper.go
@@ -234,6 +234,7 @@ func (s *Stopper) Quiesce() {
 	defer s.mu.Unlock()
 	s.draining = true
 	for s.numTasks > 0 {
+		// Use stdlib "log" instead of "cockroach/util/log" due to import cycles.
 		log.Print("draining; tasks left:\n", s.runningTasksLocked())
 		// Unlock s.mu, wait for the signal, and lock s.mu.
 		s.drain.Wait()

--- a/util/tracer/tracer.go
+++ b/util/tracer/tracer.go
@@ -20,7 +20,6 @@ package tracer
 import (
 	"bytes"
 	"fmt"
-	"log"
 	"math"
 	"strconv"
 	"strings"
@@ -29,6 +28,7 @@ import (
 
 	"github.com/cockroachdb/cockroach/util"
 	"github.com/cockroachdb/cockroach/util/caller"
+	"github.com/cockroachdb/cockroach/util/log"
 )
 
 // A Traceable object has a Trace identifier attached to it.
@@ -126,7 +126,6 @@ func (t *Trace) Finalize() {
 	}
 	if r := recover(); r != nil {
 		t.Epoch(fmt.Sprintf("panic: %v", r))
-		log.Println(t)
 		panic(r)
 	}
 	if t.depth != 0 {
@@ -135,8 +134,8 @@ func (t *Trace) Finalize() {
 	t.depth = math.MinInt32
 	if t.tracer.feed != nil {
 		t.tracer.feed.Publish(t) // by reference
-	} else {
-		log.Println(t)
+	} else if log.V(2) {
+		log.Info(t)
 	}
 }
 


### PR DESCRIPTION
Always use `cockroach/util/log` instead of `log` (except where import cycles prevent it) and enforce this in `make check`.
