### PR TITLE
Rework ID usage in multiraft

### DIFF
--- a/kv/dist_sender.go
+++ b/kv/dist_sender.go
@@ -316,11 +316,11 @@ func (ds *DistSender) sendRPC(trace *tracer.Trace, rangeID proto.RangeID, replic
 
 	// Build a slice of replica addresses (if gossiped).
 	var addrs []net.Addr
-	replicaMap := map[string]*proto.Replica{}
+	replicaMap := map[string]*proto.ReplicaDescriptor{}
 	for i := range replicas {
 		addr := replicas[i].NodeDesc.Address
 		addrs = append(addrs, addr)
-		replicaMap[addr.String()] = &replicas[i].Replica
+		replicaMap[addr.String()] = &replicas[i].ReplicaDescriptor
 	}
 	if len(addrs) == 0 {
 		return nil, noNodeAddrsAvailError{}
@@ -627,7 +627,7 @@ func (ds *DistSender) sendChunk(ctx context.Context, ba proto.BatchRequest) (*pr
 						evictDesc()
 					}
 				} else {
-					newLeader = &proto.Replica{}
+					newLeader = &proto.ReplicaDescriptor{}
 				}
 				ds.updateLeaderCache(proto.RangeID(desc.RangeID), *newLeader)
 				if log.V(1) {
@@ -752,7 +752,7 @@ func (ds *DistSender) sendChunk(ctx context.Context, ba proto.BatchRequest) (*pr
 
 // updateLeaderCache updates the cached leader for the given range,
 // evicting any previous value in the process.
-func (ds *DistSender) updateLeaderCache(rid proto.RangeID, leader proto.Replica) {
+func (ds *DistSender) updateLeaderCache(rid proto.RangeID, leader proto.ReplicaDescriptor) {
 	oldLeader := ds.leaderCache.Lookup(rid)
 	if leader.StoreID != oldLeader.StoreID {
 		if log.V(1) {

--- a/kv/leader_cache.go
+++ b/kv/leader_cache.go
@@ -47,20 +47,20 @@ func newLeaderCache(size int) *leaderCache {
 
 // Lookup consults the cache for the replica cached as the leader of
 // the given Raft consensus group.
-func (lc *leaderCache) Lookup(group proto.RangeID) proto.Replica {
+func (lc *leaderCache) Lookup(group proto.RangeID) proto.ReplicaDescriptor {
 	lc.mu.Lock()
 	defer lc.mu.Unlock()
 	v, ok := lc.cache.Get(group)
 	if !ok || v == nil {
-		return proto.Replica{}
+		return proto.ReplicaDescriptor{}
 	}
-	return *(v.(*proto.Replica))
+	return *(v.(*proto.ReplicaDescriptor))
 }
 
 // Update invalidates the cached leader for the given Raft group.
 // If a replica is passed in, it is inserted into the cache.
 // A StoreID of 0 (empty replica) means evict.
-func (lc *leaderCache) Update(group proto.RangeID, r proto.Replica) {
+func (lc *leaderCache) Update(group proto.RangeID, r proto.ReplicaDescriptor) {
 	lc.mu.Lock()
 	defer lc.mu.Unlock()
 	lc.cache.Del(group)

--- a/kv/leader_cache_test.go
+++ b/kv/leader_cache_test.go
@@ -30,18 +30,18 @@ func TestLeaderCache(t *testing.T) {
 	if r := lc.Lookup(12); r.StoreID != 0 {
 		t.Fatalf("lookup of missing key returned replica: %v", r)
 	}
-	replica := proto.Replica{StoreID: 1}
+	replica := proto.ReplicaDescriptor{StoreID: 1}
 	lc.Update(5, replica)
 	if r := lc.Lookup(5); r.StoreID != 1 {
 		t.Errorf("expected %v, got %v", replica, r)
 	}
-	newReplica := proto.Replica{StoreID: 7}
+	newReplica := proto.ReplicaDescriptor{StoreID: 7}
 	lc.Update(5, newReplica)
 	r := lc.Lookup(5)
 	if r.StoreID != 7 {
 		t.Errorf("expected %v, got %v", newReplica, r)
 	}
-	lc.Update(5, proto.Replica{})
+	lc.Update(5, proto.ReplicaDescriptor{})
 	r = lc.Lookup(5)
 	if r.StoreID != 0 {
 		t.Fatalf("evicted leader returned: %v", r)

--- a/kv/local_sender.go
+++ b/kv/local_sender.go
@@ -118,7 +118,7 @@ func (ls *LocalSender) Send(ctx context.Context, ba proto.BatchRequest) (*proto.
 	// If we aren't given a Replica, then a little bending over
 	// backwards here. This case applies exclusively to unittests.
 	if ba.RangeID == 0 || ba.Replica.StoreID == 0 {
-		var repl *proto.Replica
+		var repl *proto.ReplicaDescriptor
 		var rangeID proto.RangeID
 		rangeID, repl, err = ls.lookupReplica(ba.Key, ba.EndKey)
 		if err == nil {
@@ -167,7 +167,7 @@ func (ls *LocalSender) Send(ctx context.Context, ba proto.BatchRequest) (*proto.
 // Returns RangeID and replica on success; RangeKeyMismatch error
 // if not found.
 // This is only for testing usage; performance doesn't matter.
-func (ls *LocalSender) lookupReplica(start, end proto.Key) (rangeID proto.RangeID, replica *proto.Replica, err error) {
+func (ls *LocalSender) lookupReplica(start, end proto.Key) (rangeID proto.RangeID, replica *proto.ReplicaDescriptor, err error) {
 	ls.mu.RLock()
 	defer ls.mu.RUnlock()
 	var rng *storage.Replica

--- a/kv/local_sender_test.go
+++ b/kv/local_sender_test.go
@@ -105,7 +105,7 @@ func TestLocalSenderGetStore(t *testing.T) {
 	defer leaktest.AfterTest(t)
 	ls := NewLocalSender()
 	store := storage.Store{}
-	replica := proto.Replica{StoreID: store.Ident.StoreID}
+	replica := proto.ReplicaDescriptor{StoreID: store.Ident.StoreID}
 	s, err := ls.GetStore(replica.StoreID)
 	if s != nil || err == nil {
 		t.Errorf("expected no stores in new local sender")
@@ -154,7 +154,7 @@ func TestLocalSenderLookupReplica(t *testing.T) {
 			RangeID:  proto.RangeID(i),
 			StartKey: rng.start,
 			EndKey:   rng.end,
-			Replicas: []proto.Replica{{StoreID: rng.storeID}},
+			Replicas: []proto.ReplicaDescriptor{{StoreID: rng.storeID}},
 		}
 		newRng, err := storage.NewReplica(d[i], s[i])
 		if err != nil {

--- a/kv/replica_slice.go
+++ b/kv/replica_slice.go
@@ -27,7 +27,7 @@ import (
 // replicaInfo extends the Replica structure with the associated node
 // descriptor.
 type replicaInfo struct {
-	proto.Replica
+	proto.ReplicaDescriptor
 	NodeDesc *proto.NodeDescriptor
 }
 
@@ -55,8 +55,8 @@ func newReplicaSlice(gossip *gossip.Gossip, desc *proto.RangeDescriptor) replica
 			continue
 		}
 		replicas = append(replicas, replicaInfo{
-			Replica:  r,
-			NodeDesc: nd,
+			ReplicaDescriptor: r,
+			NodeDesc:          nd,
 		})
 	}
 	return replicas

--- a/kv/replica_slice_test.go
+++ b/kv/replica_slice_test.go
@@ -92,7 +92,7 @@ func TestReplicaSetMoveToFront(t *testing.T) {
 	defer leaktest.AfterTest(t)
 	rs := replicaSlice(nil)
 	for i := 0; i < 5; i++ {
-		rs = append(rs, replicaInfo{Replica: proto.Replica{StoreID: proto.StoreID(i + 1)}})
+		rs = append(rs, replicaInfo{ReplicaDescriptor: proto.ReplicaDescriptor{StoreID: proto.StoreID(i + 1)}})
 	}
 	rs.MoveToFront(0)
 	exp := []proto.StoreID{1, 2, 3, 4, 5}

--- a/kv/txn_coord_sender_test.go
+++ b/kv/txn_coord_sender_test.go
@@ -515,7 +515,7 @@ func TestTxnCoordSenderTxnUpdatedOnError(t *testing.T) {
 			Txn: &proto.Transaction{
 				Name: "test txn",
 			},
-			Replica: proto.Replica{
+			Replica: proto.ReplicaDescriptor{
 				NodeID: 12345,
 			},
 		},

--- a/multiraft/events.go
+++ b/multiraft/events.go
@@ -52,7 +52,7 @@ type EventMembershipChangeCommitted struct {
 	GroupID    proto.RangeID
 	CommandID  string
 	Index      uint64
-	Replica    proto.Replica
+	Replica    proto.ReplicaDescriptor
 	ChangeType raftpb.ConfChangeType
 	Payload    []byte
 

--- a/multiraft/events.go
+++ b/multiraft/events.go
@@ -26,9 +26,9 @@ import (
 // An EventLeaderElection is broadcast when a group starts or completes
 // an election. NodeID is zero when an election is in progress.
 type EventLeaderElection struct {
-	GroupID proto.RangeID
-	NodeID  proto.RaftNodeID
-	Term    uint64
+	GroupID   proto.RangeID
+	ReplicaID proto.ReplicaID
+	Term      uint64
 }
 
 // An EventCommandCommitted is broadcast whenever a command has been committed.
@@ -52,7 +52,7 @@ type EventMembershipChangeCommitted struct {
 	GroupID    proto.RangeID
 	CommandID  string
 	Index      uint64
-	NodeID     proto.RaftNodeID
+	Replica    proto.Replica
 	ChangeType raftpb.ConfChangeType
 	Payload    []byte
 

--- a/multiraft/multiraft.go
+++ b/multiraft/multiraft.go
@@ -1111,7 +1111,7 @@ func (s *state) sendMessage(g *group, msg raftpb.Message) {
 		}
 		fromReplica, err = s.ReplicaDescriptor(groupID, proto.ReplicaID(msg.From))
 		if err != nil {
-			log.Warningf("failed to lookup sending replica %d in group %d: %s", msg.From, groupID, err)
+			log.Warningf("failed to lookup sender replica %d in group %d: %s", msg.From, groupID, err)
 			return
 		}
 	}

--- a/multiraft/multiraft_test.go
+++ b/multiraft/multiraft_test.go
@@ -375,7 +375,7 @@ func TestMembershipChange(t *testing.T) {
 	for i := 1; i < 4; i++ {
 		ch := cluster.nodes[0].ChangeGroupMembership(groupID, makeCommandID(),
 			raftpb.ConfChangeAddNode,
-			proto.Replica{
+			proto.ReplicaDescriptor{
 				NodeID:    cluster.nodes[i].nodeID,
 				StoreID:   proto.StoreID(cluster.nodes[i].nodeID),
 				ReplicaID: proto.ReplicaID(cluster.nodes[i].nodeID),
@@ -463,7 +463,7 @@ func TestRemoveLeader(t *testing.T) {
 		log.Infof("adding node %d", i+groupSize)
 		ch := cluster.nodes[i].ChangeGroupMembership(groupID, makeCommandID(),
 			raftpb.ConfChangeAddNode,
-			proto.Replica{
+			proto.ReplicaDescriptor{
 				NodeID:    cluster.nodes[i+groupSize].nodeID,
 				StoreID:   proto.StoreID(cluster.nodes[i+groupSize].nodeID),
 				ReplicaID: proto.ReplicaID(cluster.nodes[i+groupSize].nodeID),
@@ -475,7 +475,7 @@ func TestRemoveLeader(t *testing.T) {
 		log.Infof("removing node %d", i)
 		ch = cluster.nodes[i].ChangeGroupMembership(groupID, makeCommandID(),
 			raftpb.ConfChangeRemoveNode,
-			proto.Replica{
+			proto.ReplicaDescriptor{
 				NodeID:    cluster.nodes[i].nodeID,
 				StoreID:   proto.StoreID(cluster.nodes[i].nodeID),
 				ReplicaID: proto.ReplicaID(cluster.nodes[i].nodeID),

--- a/multiraft/raft.go
+++ b/multiraft/raft.go
@@ -49,7 +49,7 @@ func (r *raftLogger) prependContext(format string, v []interface{}) string {
 	var s string
 	if r.group != 0 {
 		v2 := append([]interface{}{r.group}, v...)
-		s = fmt.Sprintf("group %d "+format, v2...)
+		s = fmt.Sprintf("[group %d] "+format, v2...)
 	} else {
 		s = fmt.Sprintf(format, v...)
 	}

--- a/multiraft/rpc.pb.go
+++ b/multiraft/rpc.pb.go
@@ -36,8 +36,8 @@ var _ = math.Inf
 // protobuf-based RPC codec.
 type RaftMessageRequest struct {
 	GroupID     github_com_cockroachdb_cockroach_proto.RangeID `protobuf:"varint,1,opt,name=group_id,casttype=github.com/cockroachdb/cockroach/proto.RangeID" json:"group_id"`
-	FromReplica cockroach_proto.Replica                        `protobuf:"bytes,2,opt,name=from_replica" json:"from_replica"`
-	ToReplica   cockroach_proto.Replica                        `protobuf:"bytes,3,opt,name=to_replica" json:"to_replica"`
+	FromReplica cockroach_proto.ReplicaDescriptor              `protobuf:"bytes,2,opt,name=from_replica" json:"from_replica"`
+	ToReplica   cockroach_proto.ReplicaDescriptor              `protobuf:"bytes,3,opt,name=to_replica" json:"to_replica"`
 	Message     raftpb.Message                                 `protobuf:"bytes,4,opt,name=message" json:"message"`
 }
 
@@ -52,18 +52,18 @@ func (m *RaftMessageRequest) GetGroupID() github_com_cockroachdb_cockroach_proto
 	return 0
 }
 
-func (m *RaftMessageRequest) GetFromReplica() cockroach_proto.Replica {
+func (m *RaftMessageRequest) GetFromReplica() cockroach_proto.ReplicaDescriptor {
 	if m != nil {
 		return m.FromReplica
 	}
-	return cockroach_proto.Replica{}
+	return cockroach_proto.ReplicaDescriptor{}
 }
 
-func (m *RaftMessageRequest) GetToReplica() cockroach_proto.Replica {
+func (m *RaftMessageRequest) GetToReplica() cockroach_proto.ReplicaDescriptor {
 	if m != nil {
 		return m.ToReplica
 	}
-	return cockroach_proto.Replica{}
+	return cockroach_proto.ReplicaDescriptor{}
 }
 
 func (m *RaftMessageRequest) GetMessage() raftpb.Message {
@@ -89,7 +89,7 @@ type ConfChangeContext struct {
 	// proto.EndTransactionRequest).
 	Payload []byte `protobuf:"bytes,2,opt,name=payload" json:"payload,omitempty"`
 	// Replica contians full details about the replica being added or removed.
-	Replica cockroach_proto.Replica `protobuf:"bytes,3,opt,name=replica" json:"replica"`
+	Replica cockroach_proto.ReplicaDescriptor `protobuf:"bytes,3,opt,name=replica" json:"replica"`
 }
 
 func (m *ConfChangeContext) Reset()         { *m = ConfChangeContext{} }
@@ -110,11 +110,11 @@ func (m *ConfChangeContext) GetPayload() []byte {
 	return nil
 }
 
-func (m *ConfChangeContext) GetReplica() cockroach_proto.Replica {
+func (m *ConfChangeContext) GetReplica() cockroach_proto.ReplicaDescriptor {
 	if m != nil {
 		return m.Replica
 	}
-	return cockroach_proto.Replica{}
+	return cockroach_proto.ReplicaDescriptor{}
 }
 
 func (m *RaftMessageRequest) Marshal() (data []byte, err error) {

--- a/multiraft/rpc.pb.go
+++ b/multiraft/rpc.pb.go
@@ -88,7 +88,7 @@ type ConfChangeContext struct {
 	// Payload is the application-level command (i.e. an encoded
 	// proto.EndTransactionRequest).
 	Payload []byte `protobuf:"bytes,2,opt,name=payload" json:"payload,omitempty"`
-	// Replica contians full details about the replica being added or removed.
+	// Replica contains full details about the replica being added or removed.
 	Replica cockroach_proto.ReplicaDescriptor `protobuf:"bytes,3,opt,name=replica" json:"replica"`
 }
 

--- a/multiraft/rpc.pb.go
+++ b/multiraft/rpc.pb.go
@@ -11,12 +11,14 @@
 	It has these top-level messages:
 		RaftMessageRequest
 		RaftMessageResponse
+		ConfChangeContext
 */
 package multiraft
 
 import proto "github.com/gogo/protobuf/proto"
 import fmt "fmt"
 import math "math"
+import cockroach_proto "github.com/cockroachdb/cockroach/proto"
 import raftpb "github.com/coreos/etcd/raft/raftpb"
 
 // discarding unused import gogoproto "github.com/cockroachdb/gogoproto"
@@ -33,8 +35,10 @@ var _ = math.Inf
 // RaftMessageRequest is the request used to send raft messages using our
 // protobuf-based RPC codec.
 type RaftMessageRequest struct {
-	GroupID github_com_cockroachdb_cockroach_proto.RangeID `protobuf:"varint,1,opt,name=group_id,casttype=github.com/cockroachdb/cockroach/proto.RangeID" json:"group_id"`
-	Message raftpb.Message                                 `protobuf:"bytes,2,opt,name=message" json:"message"`
+	GroupID     github_com_cockroachdb_cockroach_proto.RangeID `protobuf:"varint,1,opt,name=group_id,casttype=github.com/cockroachdb/cockroach/proto.RangeID" json:"group_id"`
+	FromReplica cockroach_proto.Replica                        `protobuf:"bytes,2,opt,name=from_replica" json:"from_replica"`
+	ToReplica   cockroach_proto.Replica                        `protobuf:"bytes,3,opt,name=to_replica" json:"to_replica"`
+	Message     raftpb.Message                                 `protobuf:"bytes,4,opt,name=message" json:"message"`
 }
 
 func (m *RaftMessageRequest) Reset()         { *m = RaftMessageRequest{} }
@@ -46,6 +50,20 @@ func (m *RaftMessageRequest) GetGroupID() github_com_cockroachdb_cockroach_proto
 		return m.GroupID
 	}
 	return 0
+}
+
+func (m *RaftMessageRequest) GetFromReplica() cockroach_proto.Replica {
+	if m != nil {
+		return m.FromReplica
+	}
+	return cockroach_proto.Replica{}
+}
+
+func (m *RaftMessageRequest) GetToReplica() cockroach_proto.Replica {
+	if m != nil {
+		return m.ToReplica
+	}
+	return cockroach_proto.Replica{}
 }
 
 func (m *RaftMessageRequest) GetMessage() raftpb.Message {
@@ -63,6 +81,41 @@ type RaftMessageResponse struct {
 func (m *RaftMessageResponse) Reset()         { *m = RaftMessageResponse{} }
 func (m *RaftMessageResponse) String() string { return proto.CompactTextString(m) }
 func (*RaftMessageResponse) ProtoMessage()    {}
+
+// ConfChangeContext is encoded in the raftpb.ConfChange.Context field.
+type ConfChangeContext struct {
+	CommandID string `protobuf:"bytes,1,opt,name=command_id" json:"command_id"`
+	// Payload is the application-level command (i.e. an encoded
+	// proto.EndTransactionRequest).
+	Payload []byte `protobuf:"bytes,2,opt,name=payload" json:"payload,omitempty"`
+	// Replica contians full details about the replica being added or removed.
+	Replica cockroach_proto.Replica `protobuf:"bytes,3,opt,name=replica" json:"replica"`
+}
+
+func (m *ConfChangeContext) Reset()         { *m = ConfChangeContext{} }
+func (m *ConfChangeContext) String() string { return proto.CompactTextString(m) }
+func (*ConfChangeContext) ProtoMessage()    {}
+
+func (m *ConfChangeContext) GetCommandID() string {
+	if m != nil {
+		return m.CommandID
+	}
+	return ""
+}
+
+func (m *ConfChangeContext) GetPayload() []byte {
+	if m != nil {
+		return m.Payload
+	}
+	return nil
+}
+
+func (m *ConfChangeContext) GetReplica() cockroach_proto.Replica {
+	if m != nil {
+		return m.Replica
+	}
+	return cockroach_proto.Replica{}
+}
 
 func (m *RaftMessageRequest) Marshal() (data []byte, err error) {
 	size := m.Size()
@@ -84,12 +137,28 @@ func (m *RaftMessageRequest) MarshalTo(data []byte) (int, error) {
 	i = encodeVarintRpc(data, i, uint64(m.GroupID))
 	data[i] = 0x12
 	i++
-	i = encodeVarintRpc(data, i, uint64(m.Message.Size()))
-	n1, err := m.Message.MarshalTo(data[i:])
+	i = encodeVarintRpc(data, i, uint64(m.FromReplica.Size()))
+	n1, err := m.FromReplica.MarshalTo(data[i:])
 	if err != nil {
 		return 0, err
 	}
 	i += n1
+	data[i] = 0x1a
+	i++
+	i = encodeVarintRpc(data, i, uint64(m.ToReplica.Size()))
+	n2, err := m.ToReplica.MarshalTo(data[i:])
+	if err != nil {
+		return 0, err
+	}
+	i += n2
+	data[i] = 0x22
+	i++
+	i = encodeVarintRpc(data, i, uint64(m.Message.Size()))
+	n3, err := m.Message.MarshalTo(data[i:])
+	if err != nil {
+		return 0, err
+	}
+	i += n3
 	return i, nil
 }
 
@@ -108,6 +177,42 @@ func (m *RaftMessageResponse) MarshalTo(data []byte) (int, error) {
 	_ = i
 	var l int
 	_ = l
+	return i, nil
+}
+
+func (m *ConfChangeContext) Marshal() (data []byte, err error) {
+	size := m.Size()
+	data = make([]byte, size)
+	n, err := m.MarshalTo(data)
+	if err != nil {
+		return nil, err
+	}
+	return data[:n], nil
+}
+
+func (m *ConfChangeContext) MarshalTo(data []byte) (int, error) {
+	var i int
+	_ = i
+	var l int
+	_ = l
+	data[i] = 0xa
+	i++
+	i = encodeVarintRpc(data, i, uint64(len(m.CommandID)))
+	i += copy(data[i:], m.CommandID)
+	if m.Payload != nil {
+		data[i] = 0x12
+		i++
+		i = encodeVarintRpc(data, i, uint64(len(m.Payload)))
+		i += copy(data[i:], m.Payload)
+	}
+	data[i] = 0x1a
+	i++
+	i = encodeVarintRpc(data, i, uint64(m.Replica.Size()))
+	n4, err := m.Replica.MarshalTo(data[i:])
+	if err != nil {
+		return 0, err
+	}
+	i += n4
 	return i, nil
 }
 
@@ -142,6 +247,10 @@ func (m *RaftMessageRequest) Size() (n int) {
 	var l int
 	_ = l
 	n += 1 + sovRpc(uint64(m.GroupID))
+	l = m.FromReplica.Size()
+	n += 1 + l + sovRpc(uint64(l))
+	l = m.ToReplica.Size()
+	n += 1 + l + sovRpc(uint64(l))
 	l = m.Message.Size()
 	n += 1 + l + sovRpc(uint64(l))
 	return n
@@ -150,6 +259,20 @@ func (m *RaftMessageRequest) Size() (n int) {
 func (m *RaftMessageResponse) Size() (n int) {
 	var l int
 	_ = l
+	return n
+}
+
+func (m *ConfChangeContext) Size() (n int) {
+	var l int
+	_ = l
+	l = len(m.CommandID)
+	n += 1 + l + sovRpc(uint64(l))
+	if m.Payload != nil {
+		l = len(m.Payload)
+		n += 1 + l + sovRpc(uint64(l))
+	}
+	l = m.Replica.Size()
+	n += 1 + l + sovRpc(uint64(l))
 	return n
 }
 
@@ -215,6 +338,66 @@ func (m *RaftMessageRequest) Unmarshal(data []byte) error {
 				}
 			}
 		case 2:
+			if wireType != 2 {
+				return fmt.Errorf("proto: wrong wireType = %d for field FromReplica", wireType)
+			}
+			var msglen int
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return ErrIntOverflowRpc
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := data[iNdEx]
+				iNdEx++
+				msglen |= (int(b) & 0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			if msglen < 0 {
+				return ErrInvalidLengthRpc
+			}
+			postIndex := iNdEx + msglen
+			if postIndex > l {
+				return io.ErrUnexpectedEOF
+			}
+			if err := m.FromReplica.Unmarshal(data[iNdEx:postIndex]); err != nil {
+				return err
+			}
+			iNdEx = postIndex
+		case 3:
+			if wireType != 2 {
+				return fmt.Errorf("proto: wrong wireType = %d for field ToReplica", wireType)
+			}
+			var msglen int
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return ErrIntOverflowRpc
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := data[iNdEx]
+				iNdEx++
+				msglen |= (int(b) & 0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			if msglen < 0 {
+				return ErrInvalidLengthRpc
+			}
+			postIndex := iNdEx + msglen
+			if postIndex > l {
+				return io.ErrUnexpectedEOF
+			}
+			if err := m.ToReplica.Unmarshal(data[iNdEx:postIndex]); err != nil {
+				return err
+			}
+			iNdEx = postIndex
+		case 4:
 			if wireType != 2 {
 				return fmt.Errorf("proto: wrong wireType = %d for field Message", wireType)
 			}
@@ -294,6 +477,143 @@ func (m *RaftMessageResponse) Unmarshal(data []byte) error {
 			return fmt.Errorf("proto: RaftMessageResponse: illegal tag %d (wire type %d)", fieldNum, wire)
 		}
 		switch fieldNum {
+		default:
+			iNdEx = preIndex
+			skippy, err := skipRpc(data[iNdEx:])
+			if err != nil {
+				return err
+			}
+			if skippy < 0 {
+				return ErrInvalidLengthRpc
+			}
+			if (iNdEx + skippy) > l {
+				return io.ErrUnexpectedEOF
+			}
+			iNdEx += skippy
+		}
+	}
+
+	if iNdEx > l {
+		return io.ErrUnexpectedEOF
+	}
+	return nil
+}
+func (m *ConfChangeContext) Unmarshal(data []byte) error {
+	l := len(data)
+	iNdEx := 0
+	for iNdEx < l {
+		preIndex := iNdEx
+		var wire uint64
+		for shift := uint(0); ; shift += 7 {
+			if shift >= 64 {
+				return ErrIntOverflowRpc
+			}
+			if iNdEx >= l {
+				return io.ErrUnexpectedEOF
+			}
+			b := data[iNdEx]
+			iNdEx++
+			wire |= (uint64(b) & 0x7F) << shift
+			if b < 0x80 {
+				break
+			}
+		}
+		fieldNum := int32(wire >> 3)
+		wireType := int(wire & 0x7)
+		if wireType == 4 {
+			return fmt.Errorf("proto: ConfChangeContext: wiretype end group for non-group")
+		}
+		if fieldNum <= 0 {
+			return fmt.Errorf("proto: ConfChangeContext: illegal tag %d (wire type %d)", fieldNum, wire)
+		}
+		switch fieldNum {
+		case 1:
+			if wireType != 2 {
+				return fmt.Errorf("proto: wrong wireType = %d for field CommandID", wireType)
+			}
+			var stringLen uint64
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return ErrIntOverflowRpc
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := data[iNdEx]
+				iNdEx++
+				stringLen |= (uint64(b) & 0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			intStringLen := int(stringLen)
+			if intStringLen < 0 {
+				return ErrInvalidLengthRpc
+			}
+			postIndex := iNdEx + intStringLen
+			if postIndex > l {
+				return io.ErrUnexpectedEOF
+			}
+			m.CommandID = string(data[iNdEx:postIndex])
+			iNdEx = postIndex
+		case 2:
+			if wireType != 2 {
+				return fmt.Errorf("proto: wrong wireType = %d for field Payload", wireType)
+			}
+			var byteLen int
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return ErrIntOverflowRpc
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := data[iNdEx]
+				iNdEx++
+				byteLen |= (int(b) & 0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			if byteLen < 0 {
+				return ErrInvalidLengthRpc
+			}
+			postIndex := iNdEx + byteLen
+			if postIndex > l {
+				return io.ErrUnexpectedEOF
+			}
+			m.Payload = append([]byte{}, data[iNdEx:postIndex]...)
+			iNdEx = postIndex
+		case 3:
+			if wireType != 2 {
+				return fmt.Errorf("proto: wrong wireType = %d for field Replica", wireType)
+			}
+			var msglen int
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return ErrIntOverflowRpc
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := data[iNdEx]
+				iNdEx++
+				msglen |= (int(b) & 0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			if msglen < 0 {
+				return ErrInvalidLengthRpc
+			}
+			postIndex := iNdEx + msglen
+			if postIndex > l {
+				return io.ErrUnexpectedEOF
+			}
+			if err := m.Replica.Unmarshal(data[iNdEx:postIndex]); err != nil {
+				return err
+			}
+			iNdEx = postIndex
 		default:
 			iNdEx = preIndex
 			skippy, err := skipRpc(data[iNdEx:])

--- a/multiraft/rpc.proto
+++ b/multiraft/rpc.proto
@@ -19,6 +19,7 @@ syntax = "proto2";
 package cockroach.multiraft;
 option go_package = "multiraft";
 
+import "cockroach/proto/metadata.proto";
 import "etcd/raft/raftpb/raft.proto";
 import "gogoproto/gogo.proto";
 
@@ -34,10 +35,26 @@ message RaftMessageRequest {
       (gogoproto.customname) = "GroupID",
       (gogoproto.casttype) = "github.com/cockroachdb/cockroach/proto.RangeID"];
 
-  optional raftpb.Message message = 2 [(gogoproto.nullable) = false];
+  optional proto.Replica from_replica = 2 [(gogoproto.nullable) = false];
+  optional proto.Replica to_replica = 3 [(gogoproto.nullable) = false];
+
+  optional raftpb.Message message = 4 [(gogoproto.nullable) = false];
 }
 
 // RaftMessageResponse is an empty message returned by raft RPCs. If a
 // response is needed it will be sent as a separate message.
 message RaftMessageResponse {
+}
+
+// ConfChangeContext is encoded in the raftpb.ConfChange.Context field.
+message ConfChangeContext {
+  optional string command_id = 1 [(gogoproto.nullable) = false,
+      (gogoproto.customname) = "CommandID"];
+
+  // Payload is the application-level command (i.e. an encoded
+  // proto.EndTransactionRequest).
+  optional bytes payload = 2;
+
+  // Replica contians full details about the replica being added or removed.
+  optional proto.Replica replica = 3 [(gogoproto.nullable) = false];
 }

--- a/multiraft/rpc.proto
+++ b/multiraft/rpc.proto
@@ -35,8 +35,8 @@ message RaftMessageRequest {
       (gogoproto.customname) = "GroupID",
       (gogoproto.casttype) = "github.com/cockroachdb/cockroach/proto.RangeID"];
 
-  optional proto.Replica from_replica = 2 [(gogoproto.nullable) = false];
-  optional proto.Replica to_replica = 3 [(gogoproto.nullable) = false];
+  optional proto.ReplicaDescriptor from_replica = 2 [(gogoproto.nullable) = false];
+  optional proto.ReplicaDescriptor to_replica = 3 [(gogoproto.nullable) = false];
 
   optional raftpb.Message message = 4 [(gogoproto.nullable) = false];
 }
@@ -56,5 +56,5 @@ message ConfChangeContext {
   optional bytes payload = 2;
 
   // Replica contians full details about the replica being added or removed.
-  optional proto.Replica replica = 3 [(gogoproto.nullable) = false];
+  optional proto.ReplicaDescriptor replica = 3 [(gogoproto.nullable) = false];
 }

--- a/multiraft/rpc.proto
+++ b/multiraft/rpc.proto
@@ -55,6 +55,6 @@ message ConfChangeContext {
   // proto.EndTransactionRequest).
   optional bytes payload = 2;
 
-  // Replica contians full details about the replica being added or removed.
+  // Replica contains full details about the replica being added or removed.
   optional proto.ReplicaDescriptor replica = 3 [(gogoproto.nullable) = false];
 }

--- a/multiraft/storage.go
+++ b/multiraft/storage.go
@@ -42,7 +42,7 @@ var _ WriteableGroupStorage = (*raft.MemoryStorage)(nil)
 // of raft data.
 type Storage interface {
 	GroupStorage(groupID proto.RangeID) WriteableGroupStorage
-	ReplicaAddress(groupID proto.RangeID, replicaID proto.ReplicaID) (proto.ReplicaDescriptor, error)
+	ReplicaDescriptor(groupID proto.RangeID, replicaID proto.ReplicaID) (proto.ReplicaDescriptor, error)
 	ReplicaIDForStore(groupID proto.RangeID, storeID proto.StoreID) (proto.ReplicaID, error)
 	ReplicasFromSnapshot(snap raftpb.Snapshot) ([]proto.ReplicaDescriptor, error)
 }
@@ -84,9 +84,9 @@ func (m *MemoryStorage) GroupStorage(groupID proto.RangeID) WriteableGroupStorag
 	return g
 }
 
-// ReplicaAddress implements the Storage interface by returning a
-// dummy address.
-func (m *MemoryStorage) ReplicaAddress(groupID proto.RangeID, replicaID proto.ReplicaID) (proto.ReplicaDescriptor, error) {
+// ReplicaDescriptor implements the Storage interface by returning a
+// dummy descriptor.
+func (m *MemoryStorage) ReplicaDescriptor(groupID proto.RangeID, replicaID proto.ReplicaID) (proto.ReplicaDescriptor, error) {
 	return proto.ReplicaDescriptor{
 		ReplicaID: replicaID,
 		NodeID:    proto.NodeID(replicaID),

--- a/multiraft/storage.go
+++ b/multiraft/storage.go
@@ -42,6 +42,9 @@ var _ WriteableGroupStorage = (*raft.MemoryStorage)(nil)
 // of raft data.
 type Storage interface {
 	GroupStorage(groupID proto.RangeID) WriteableGroupStorage
+	ReplicaAddress(groupID proto.RangeID, replicaID proto.ReplicaID) (proto.Replica, error)
+	ReplicaIDForStore(groupID proto.RangeID, storeID proto.StoreID) (proto.ReplicaID, error)
+	ReplicasFromSnapshot(snap raftpb.Snapshot) ([]proto.Replica, error)
 }
 
 // The StateMachine interface is supplied by the application to manage a persistent
@@ -79,6 +82,26 @@ func (m *MemoryStorage) GroupStorage(groupID proto.RangeID) WriteableGroupStorag
 		m.groups[groupID] = g
 	}
 	return g
+}
+
+// ReplicaAddress implements the Storage interface by returning a
+// dummy address.
+func (m *MemoryStorage) ReplicaAddress(groupID proto.RangeID, replicaID proto.ReplicaID) (proto.Replica, error) {
+	return proto.Replica{
+		ReplicaID: replicaID,
+		NodeID:    proto.NodeID(replicaID),
+		StoreID:   proto.StoreID(replicaID),
+	}, nil
+}
+
+// ReplicaIDForStore implements the Storage interface.
+func (m *MemoryStorage) ReplicaIDForStore(groupID proto.RangeID, storeID proto.StoreID) (proto.ReplicaID, error) {
+	return proto.ReplicaID(storeID), nil
+}
+
+// ReplicasFromSnapshot implements the Storage interface.
+func (m *MemoryStorage) ReplicasFromSnapshot(_ raftpb.Snapshot) ([]proto.Replica, error) {
+	return nil, nil
 }
 
 // groupWriteRequest represents a set of changes to make to a group.

--- a/multiraft/storage.go
+++ b/multiraft/storage.go
@@ -42,9 +42,9 @@ var _ WriteableGroupStorage = (*raft.MemoryStorage)(nil)
 // of raft data.
 type Storage interface {
 	GroupStorage(groupID proto.RangeID) WriteableGroupStorage
-	ReplicaAddress(groupID proto.RangeID, replicaID proto.ReplicaID) (proto.Replica, error)
+	ReplicaAddress(groupID proto.RangeID, replicaID proto.ReplicaID) (proto.ReplicaDescriptor, error)
 	ReplicaIDForStore(groupID proto.RangeID, storeID proto.StoreID) (proto.ReplicaID, error)
-	ReplicasFromSnapshot(snap raftpb.Snapshot) ([]proto.Replica, error)
+	ReplicasFromSnapshot(snap raftpb.Snapshot) ([]proto.ReplicaDescriptor, error)
 }
 
 // The StateMachine interface is supplied by the application to manage a persistent
@@ -86,8 +86,8 @@ func (m *MemoryStorage) GroupStorage(groupID proto.RangeID) WriteableGroupStorag
 
 // ReplicaAddress implements the Storage interface by returning a
 // dummy address.
-func (m *MemoryStorage) ReplicaAddress(groupID proto.RangeID, replicaID proto.ReplicaID) (proto.Replica, error) {
-	return proto.Replica{
+func (m *MemoryStorage) ReplicaAddress(groupID proto.RangeID, replicaID proto.ReplicaID) (proto.ReplicaDescriptor, error) {
+	return proto.ReplicaDescriptor{
 		ReplicaID: replicaID,
 		NodeID:    proto.NodeID(replicaID),
 		StoreID:   proto.StoreID(replicaID),
@@ -100,7 +100,7 @@ func (m *MemoryStorage) ReplicaIDForStore(groupID proto.RangeID, storeID proto.S
 }
 
 // ReplicasFromSnapshot implements the Storage interface.
-func (m *MemoryStorage) ReplicasFromSnapshot(_ raftpb.Snapshot) ([]proto.Replica, error) {
+func (m *MemoryStorage) ReplicasFromSnapshot(_ raftpb.Snapshot) ([]proto.ReplicaDescriptor, error) {
 	return nil, nil
 }
 

--- a/multiraft/storage_test.go
+++ b/multiraft/storage_test.go
@@ -40,7 +40,7 @@ func (b *BlockableStorage) GroupStorage(g proto.RangeID) WriteableGroupStorage {
 	return &blockableGroupStorage{b, b.storage.GroupStorage(g)}
 }
 
-func (b *BlockableStorage) ReplicaAddress(groupID proto.RangeID, replicaID proto.ReplicaID) (proto.Replica, error) {
+func (b *BlockableStorage) ReplicaAddress(groupID proto.RangeID, replicaID proto.ReplicaID) (proto.ReplicaDescriptor, error) {
 	return b.storage.ReplicaAddress(groupID, replicaID)
 }
 
@@ -48,7 +48,7 @@ func (b *BlockableStorage) ReplicaIDForStore(groupID proto.RangeID, storeID prot
 	return b.storage.ReplicaIDForStore(groupID, storeID)
 }
 
-func (b *BlockableStorage) ReplicasFromSnapshot(snap raftpb.Snapshot) ([]proto.Replica, error) {
+func (b *BlockableStorage) ReplicasFromSnapshot(snap raftpb.Snapshot) ([]proto.ReplicaDescriptor, error) {
 	return b.storage.ReplicasFromSnapshot(snap)
 }
 

--- a/multiraft/storage_test.go
+++ b/multiraft/storage_test.go
@@ -40,6 +40,18 @@ func (b *BlockableStorage) GroupStorage(g proto.RangeID) WriteableGroupStorage {
 	return &blockableGroupStorage{b, b.storage.GroupStorage(g)}
 }
 
+func (b *BlockableStorage) ReplicaAddress(groupID proto.RangeID, replicaID proto.ReplicaID) (proto.Replica, error) {
+	return b.storage.ReplicaAddress(groupID, replicaID)
+}
+
+func (b *BlockableStorage) ReplicaIDForStore(groupID proto.RangeID, storeID proto.StoreID) (proto.ReplicaID, error) {
+	return b.storage.ReplicaIDForStore(groupID, storeID)
+}
+
+func (b *BlockableStorage) ReplicasFromSnapshot(snap raftpb.Snapshot) ([]proto.Replica, error) {
+	return b.storage.ReplicasFromSnapshot(snap)
+}
+
 type blockableGroupStorage struct {
 	b *BlockableStorage
 	s WriteableGroupStorage

--- a/multiraft/storage_test.go
+++ b/multiraft/storage_test.go
@@ -40,8 +40,8 @@ func (b *BlockableStorage) GroupStorage(g proto.RangeID) WriteableGroupStorage {
 	return &blockableGroupStorage{b, b.storage.GroupStorage(g)}
 }
 
-func (b *BlockableStorage) ReplicaAddress(groupID proto.RangeID, replicaID proto.ReplicaID) (proto.ReplicaDescriptor, error) {
-	return b.storage.ReplicaAddress(groupID, replicaID)
+func (b *BlockableStorage) ReplicaDescriptor(groupID proto.RangeID, replicaID proto.ReplicaID) (proto.ReplicaDescriptor, error) {
+	return b.storage.ReplicaDescriptor(groupID, replicaID)
 }
 
 func (b *BlockableStorage) ReplicaIDForStore(groupID proto.RangeID, storeID proto.StoreID) (proto.ReplicaID, error) {

--- a/multiraft/transport.go
+++ b/multiraft/transport.go
@@ -33,7 +33,7 @@ import (
 )
 
 // The Transport interface is supplied by the application to manage communication with
-// other nodes. It is responsible for mapping from IDs to some communication channel
+// other nodes. It is responsible for mapping from IDs to some communication channel.
 type Transport interface {
 	// Listen informs the Transport of a local store's ID and callback interface.
 	// The Transport should associate the given id with the server object so other Transport's

--- a/multiraft/transport_test.go
+++ b/multiraft/transport_test.go
@@ -27,7 +27,7 @@ import (
 
 type localInterceptableTransport struct {
 	mu        sync.Mutex
-	listeners map[proto.RaftNodeID]ServerInterface
+	listeners map[proto.StoreID]ServerInterface
 	messages  chan *RaftMessageRequest
 	Events    chan *interceptMessage
 	stopper   *stop.Stopper
@@ -39,7 +39,7 @@ type localInterceptableTransport struct {
 // which they are queued, intercepted and blocked until acknowledged.
 func NewLocalInterceptableTransport(stopper *stop.Stopper) Transport {
 	lt := &localInterceptableTransport{
-		listeners: make(map[proto.RaftNodeID]ServerInterface),
+		listeners: make(map[proto.StoreID]ServerInterface),
 		messages:  make(chan *RaftMessageRequest, 100),
 		Events:    make(chan *interceptMessage),
 		stopper:   stopper,
@@ -77,7 +77,7 @@ func (lt *localInterceptableTransport) handleMessage(msg *RaftMessageRequest) {
 	lt.Events <- iMsg
 	<-ack
 	lt.mu.Lock()
-	srv, ok := lt.listeners[proto.RaftNodeID(msg.Message.To)]
+	srv, ok := lt.listeners[msg.ToReplica.StoreID]
 	lt.mu.Unlock()
 	if !ok {
 		return
@@ -90,14 +90,14 @@ func (lt *localInterceptableTransport) handleMessage(msg *RaftMessageRequest) {
 	}
 }
 
-func (lt *localInterceptableTransport) Listen(id proto.RaftNodeID, server ServerInterface) error {
+func (lt *localInterceptableTransport) Listen(id proto.StoreID, server ServerInterface) error {
 	lt.mu.Lock()
 	defer lt.mu.Unlock()
 	lt.listeners[id] = server
 	return nil
 }
 
-func (lt *localInterceptableTransport) Stop(id proto.RaftNodeID) {
+func (lt *localInterceptableTransport) Stop(id proto.StoreID) {
 	lt.mu.Lock()
 	delete(lt.listeners, id)
 	lt.mu.Unlock()

--- a/proto/api.go
+++ b/proto/api.go
@@ -20,12 +20,18 @@ package proto
 import (
 	"fmt"
 	"math/rand"
+	"strconv"
 
 	gogoproto "github.com/gogo/protobuf/proto"
 )
 
 // A RangeID is a unique ID associated to a Raft consensus group.
 type RangeID int64
+
+// String implements the fmt.Stringer interface.
+func (r RangeID) String() string {
+	return strconv.FormatInt(int64(r), 10)
+}
 
 // RangeIDSlice implements sort.Interface.
 type RangeIDSlice []RangeID

--- a/proto/api.pb.go
+++ b/proto/api.pb.go
@@ -101,7 +101,7 @@
 		RaftTruncatedState
 		RaftSnapshotData
 		Attributes
-		Replica
+		ReplicaDescriptor
 		RangeDescriptor
 		RangeTree
 		RangeTreeNode
@@ -270,7 +270,7 @@ type RequestHeader struct {
 	EndKey Key `protobuf:"bytes,4,opt,name=end_key,casttype=Key" json:"end_key,omitempty"`
 	// Replica specifies the destination for the request. This is a specific
 	// instance of the available replicas belonging to RangeID.
-	Replica Replica `protobuf:"bytes,5,opt,name=replica" json:"replica"`
+	Replica ReplicaDescriptor `protobuf:"bytes,5,opt,name=replica" json:"replica"`
 	// RangeID specifies the ID of the Raft consensus group which the key
 	// range belongs to. This is used by the receiving node to route the
 	// request to the correct range.
@@ -331,11 +331,11 @@ func (m *RequestHeader) GetEndKey() Key {
 	return nil
 }
 
-func (m *RequestHeader) GetReplica() Replica {
+func (m *RequestHeader) GetReplica() ReplicaDescriptor {
 	if m != nil {
 		return m.Replica
 	}
-	return Replica{}
+	return ReplicaDescriptor{}
 }
 
 func (m *RequestHeader) GetRangeID() RangeID {

--- a/proto/api.proto
+++ b/proto/api.proto
@@ -87,7 +87,7 @@ message RequestHeader {
   optional bytes end_key = 4 [(gogoproto.casttype) = "Key"];
   // Replica specifies the destination for the request. This is a specific
   // instance of the available replicas belonging to RangeID.
-  optional Replica replica = 5 [(gogoproto.nullable) = false];
+  optional ReplicaDescriptor replica = 5 [(gogoproto.nullable) = false];
   // RangeID specifies the ID of the Raft consensus group which the key
   // range belongs to. This is used by the receiving node to route the
   // request to the correct range.

--- a/proto/data.go
+++ b/proto/data.go
@@ -640,10 +640,9 @@ func (s Int32Slice) Less(i, j int) bool { return s[i] < s[j] }
 var _ fmt.Stringer = &Lease{}
 
 func (l Lease) String() string {
-	nodeID, storeID := DecodeRaftNodeID(RaftNodeID(l.RaftNodeID))
 	t := time.Unix(l.Start.WallTime/1E9, 0)
 	tStr := t.Format("15:04:05.000")
-	return fmt.Sprintf("replica %d:%d %s +%.3fs", nodeID, storeID, tStr, float64(l.Expiration.WallTime-l.Start.WallTime)/1E9)
+	return fmt.Sprintf("replica %s %s +%.3fs", l.Replica, tStr, float64(l.Expiration.WallTime-l.Start.WallTime)/1E9)
 }
 
 // Covers returns true if the given timestamp is strictly less than the
@@ -653,7 +652,7 @@ func (l Lease) Covers(timestamp Timestamp) bool {
 	return timestamp.Less(l.Expiration)
 }
 
-// OwnedBy returns whether the lease owner is equal to the given RaftNodeID.
-func (l Lease) OwnedBy(id RaftNodeID) bool {
-	return l.RaftNodeID == id
+// OwnedBy returns whether the given store is the lease owner.
+func (l Lease) OwnedBy(storeID StoreID) bool {
+	return l.Replica.StoreID == storeID
 }

--- a/proto/data.pb.go
+++ b/proto/data.pb.go
@@ -411,10 +411,10 @@ type ChangeReplicasTrigger struct {
 	StoreID    StoreID           `protobuf:"varint,2,opt,name=store_id,casttype=StoreID" json:"store_id"`
 	ChangeType ReplicaChangeType `protobuf:"varint,3,opt,name=change_type,enum=cockroach.proto.ReplicaChangeType" json:"change_type"`
 	// The replica being modified.
-	Replica Replica `protobuf:"bytes,4,opt,name=replica" json:"replica"`
+	Replica ReplicaDescriptor `protobuf:"bytes,4,opt,name=replica" json:"replica"`
 	// The new replica list with this change applied.
-	UpdatedReplicas []Replica `protobuf:"bytes,5,rep,name=updated_replicas" json:"updated_replicas"`
-	NextReplicaID   ReplicaID `protobuf:"varint,6,opt,name=next_replica_id,casttype=ReplicaID" json:"next_replica_id"`
+	UpdatedReplicas []ReplicaDescriptor `protobuf:"bytes,5,rep,name=updated_replicas" json:"updated_replicas"`
+	NextReplicaID   ReplicaID           `protobuf:"varint,6,opt,name=next_replica_id,casttype=ReplicaID" json:"next_replica_id"`
 }
 
 func (m *ChangeReplicasTrigger) Reset()         { *m = ChangeReplicasTrigger{} }
@@ -442,14 +442,14 @@ func (m *ChangeReplicasTrigger) GetChangeType() ReplicaChangeType {
 	return ADD_REPLICA
 }
 
-func (m *ChangeReplicasTrigger) GetReplica() Replica {
+func (m *ChangeReplicasTrigger) GetReplica() ReplicaDescriptor {
 	if m != nil {
 		return m.Replica
 	}
-	return Replica{}
+	return ReplicaDescriptor{}
 }
 
-func (m *ChangeReplicasTrigger) GetUpdatedReplicas() []Replica {
+func (m *ChangeReplicasTrigger) GetUpdatedReplicas() []ReplicaDescriptor {
 	if m != nil {
 		return m.UpdatedReplicas
 	}
@@ -705,7 +705,7 @@ type Lease struct {
 	// The expiration is a timestamp at which the lease will expire.
 	Expiration Timestamp `protobuf:"bytes,2,opt,name=expiration" json:"expiration"`
 	// The address of the would-be lease holder.
-	Replica Replica `protobuf:"bytes,3,opt,name=replica" json:"replica"`
+	Replica ReplicaDescriptor `protobuf:"bytes,3,opt,name=replica" json:"replica"`
 }
 
 func (m *Lease) Reset()      { *m = Lease{} }
@@ -725,11 +725,11 @@ func (m *Lease) GetExpiration() Timestamp {
 	return Timestamp{}
 }
 
-func (m *Lease) GetReplica() Replica {
+func (m *Lease) GetReplica() ReplicaDescriptor {
 	if m != nil {
 		return m.Replica
 	}
-	return Replica{}
+	return ReplicaDescriptor{}
 }
 
 // Intent is used to communicate the location of an intent.
@@ -2555,7 +2555,7 @@ func (m *ChangeReplicasTrigger) Unmarshal(data []byte) error {
 			if postIndex > l {
 				return io.ErrUnexpectedEOF
 			}
-			m.UpdatedReplicas = append(m.UpdatedReplicas, Replica{})
+			m.UpdatedReplicas = append(m.UpdatedReplicas, ReplicaDescriptor{})
 			if err := m.UpdatedReplicas[len(m.UpdatedReplicas)-1].Unmarshal(data[iNdEx:postIndex]); err != nil {
 				return err
 			}

--- a/proto/data.pb.go
+++ b/proto/data.pb.go
@@ -704,8 +704,8 @@ type Lease struct {
 	Start Timestamp `protobuf:"bytes,1,opt,name=start" json:"start"`
 	// The expiration is a timestamp at which the lease will expire.
 	Expiration Timestamp `protobuf:"bytes,2,opt,name=expiration" json:"expiration"`
-	// The Raft NodeID on which the would-be lease holder lives.
-	RaftNodeID RaftNodeID `protobuf:"varint,3,opt,name=raft_node_id,casttype=RaftNodeID" json:"raft_node_id"`
+	// The address of the would-be lease holder.
+	Replica Replica `protobuf:"bytes,3,opt,name=replica" json:"replica"`
 }
 
 func (m *Lease) Reset()      { *m = Lease{} }
@@ -725,11 +725,11 @@ func (m *Lease) GetExpiration() Timestamp {
 	return Timestamp{}
 }
 
-func (m *Lease) GetRaftNodeID() RaftNodeID {
+func (m *Lease) GetReplica() Replica {
 	if m != nil {
-		return m.RaftNodeID
+		return m.Replica
 	}
-	return 0
+	return Replica{}
 }
 
 // Intent is used to communicate the location of an intent.
@@ -1314,9 +1314,14 @@ func (m *Lease) MarshalTo(data []byte) (int, error) {
 		return 0, err
 	}
 	i += n19
-	data[i] = 0x18
+	data[i] = 0x1a
 	i++
-	i = encodeVarintData(data, i, uint64(m.RaftNodeID))
+	i = encodeVarintData(data, i, uint64(m.Replica.Size()))
+	n20, err := m.Replica.MarshalTo(data[i:])
+	if err != nil {
+		return 0, err
+	}
+	i += n20
 	return i, nil
 }
 
@@ -1350,11 +1355,11 @@ func (m *Intent) MarshalTo(data []byte) (int, error) {
 	data[i] = 0x1a
 	i++
 	i = encodeVarintData(data, i, uint64(m.Txn.Size()))
-	n20, err := m.Txn.MarshalTo(data[i:])
+	n21, err := m.Txn.MarshalTo(data[i:])
 	if err != nil {
 		return 0, err
 	}
-	i += n20
+	i += n21
 	return i, nil
 }
 
@@ -1592,7 +1597,8 @@ func (m *Lease) Size() (n int) {
 	n += 1 + l + sovData(uint64(l))
 	l = m.Expiration.Size()
 	n += 1 + l + sovData(uint64(l))
-	n += 1 + sovData(uint64(m.RaftNodeID))
+	l = m.Replica.Size()
+	n += 1 + l + sovData(uint64(l))
 	return n
 }
 
@@ -3432,10 +3438,10 @@ func (m *Lease) Unmarshal(data []byte) error {
 			}
 			iNdEx = postIndex
 		case 3:
-			if wireType != 0 {
-				return fmt.Errorf("proto: wrong wireType = %d for field RaftNodeID", wireType)
+			if wireType != 2 {
+				return fmt.Errorf("proto: wrong wireType = %d for field Replica", wireType)
 			}
-			m.RaftNodeID = 0
+			var msglen int
 			for shift := uint(0); ; shift += 7 {
 				if shift >= 64 {
 					return ErrIntOverflowData
@@ -3445,11 +3451,22 @@ func (m *Lease) Unmarshal(data []byte) error {
 				}
 				b := data[iNdEx]
 				iNdEx++
-				m.RaftNodeID |= (RaftNodeID(b) & 0x7F) << shift
+				msglen |= (int(b) & 0x7F) << shift
 				if b < 0x80 {
 					break
 				}
 			}
+			if msglen < 0 {
+				return ErrInvalidLengthData
+			}
+			postIndex := iNdEx + msglen
+			if postIndex > l {
+				return io.ErrUnexpectedEOF
+			}
+			if err := m.Replica.Unmarshal(data[iNdEx:postIndex]); err != nil {
+				return err
+			}
+			iNdEx = postIndex
 		default:
 			iNdEx = preIndex
 			skippy, err := skipData(data[iNdEx:])

--- a/proto/data.proto
+++ b/proto/data.proto
@@ -268,9 +268,8 @@ message Lease {
   optional Timestamp start = 1 [(gogoproto.nullable) = false];
   // The expiration is a timestamp at which the lease will expire.
   optional Timestamp expiration = 2 [(gogoproto.nullable) = false];
-  // The Raft NodeID on which the would-be lease holder lives.
-  optional uint64 raft_node_id = 3 [(gogoproto.nullable) = false,
-      (gogoproto.customname) = "RaftNodeID", (gogoproto.casttype) = "RaftNodeID"];
+  // The address of the would-be lease holder.
+  optional Replica replica = 3 [(gogoproto.nullable) = false];
 }
 
 // Intent is used to communicate the location of an intent.

--- a/proto/data.proto
+++ b/proto/data.proto
@@ -54,7 +54,7 @@ enum ValueType {
   FLOAT = 2;
   BYTES = 3;
   TIME = 4;
-  
+
   // TIMESERIES is applied to values which contain InternalTimeSeriesData.
   TIMESERIES = 100;
 }
@@ -135,9 +135,9 @@ message ChangeReplicasTrigger {
       (gogoproto.customname) = "StoreID", (gogoproto.casttype) = "StoreID"];
   optional ReplicaChangeType change_type = 3 [(gogoproto.nullable) = false];
   // The replica being modified.
-  optional Replica replica = 4 [(gogoproto.nullable) = false];
+  optional ReplicaDescriptor replica = 4 [(gogoproto.nullable) = false];
   // The new replica list with this change applied.
-  repeated Replica updated_replicas = 5 [(gogoproto.nullable) = false];
+  repeated ReplicaDescriptor updated_replicas = 5 [(gogoproto.nullable) = false];
   optional int32 next_replica_id = 6 [(gogoproto.nullable) = false,
       (gogoproto.customname) = "NextReplicaID", (gogoproto.casttype) = "ReplicaID"];
 }
@@ -269,7 +269,7 @@ message Lease {
   // The expiration is a timestamp at which the lease will expire.
   optional Timestamp expiration = 2 [(gogoproto.nullable) = false];
   // The address of the would-be lease holder.
-  optional Replica replica = 3 [(gogoproto.nullable) = false];
+  optional ReplicaDescriptor replica = 3 [(gogoproto.nullable) = false];
 }
 
 // Intent is used to communicate the location of an intent.

--- a/proto/errors.pb.go
+++ b/proto/errors.pb.go
@@ -64,22 +64,22 @@ func (x *TransactionRestart) UnmarshalJSON(data []byte) error {
 // A NotLeaderError indicates that the current range is not the
 // leader. If the leader is known, its Replica is set in the error.
 type NotLeaderError struct {
-	Replica *Replica `protobuf:"bytes,1,opt,name=replica" json:"replica,omitempty"`
-	Leader  *Replica `protobuf:"bytes,2,opt,name=leader" json:"leader,omitempty"`
-	RangeID RangeID  `protobuf:"varint,3,opt,name=range_id,casttype=RangeID" json:"range_id"`
+	Replica *ReplicaDescriptor `protobuf:"bytes,1,opt,name=replica" json:"replica,omitempty"`
+	Leader  *ReplicaDescriptor `protobuf:"bytes,2,opt,name=leader" json:"leader,omitempty"`
+	RangeID RangeID            `protobuf:"varint,3,opt,name=range_id,casttype=RangeID" json:"range_id"`
 }
 
 func (m *NotLeaderError) Reset()      { *m = NotLeaderError{} }
 func (*NotLeaderError) ProtoMessage() {}
 
-func (m *NotLeaderError) GetReplica() *Replica {
+func (m *NotLeaderError) GetReplica() *ReplicaDescriptor {
 	if m != nil {
 		return m.Replica
 	}
 	return nil
 }
 
-func (m *NotLeaderError) GetLeader() *Replica {
+func (m *NotLeaderError) GetLeader() *ReplicaDescriptor {
 	if m != nil {
 		return m.Leader
 	}
@@ -1772,7 +1772,7 @@ func (m *NotLeaderError) Unmarshal(data []byte) error {
 				return io.ErrUnexpectedEOF
 			}
 			if m.Replica == nil {
-				m.Replica = &Replica{}
+				m.Replica = &ReplicaDescriptor{}
 			}
 			if err := m.Replica.Unmarshal(data[iNdEx:postIndex]); err != nil {
 				return err
@@ -1805,7 +1805,7 @@ func (m *NotLeaderError) Unmarshal(data []byte) error {
 				return io.ErrUnexpectedEOF
 			}
 			if m.Leader == nil {
-				m.Leader = &Replica{}
+				m.Leader = &ReplicaDescriptor{}
 			}
 			if err := m.Leader.Unmarshal(data[iNdEx:postIndex]); err != nil {
 				return err

--- a/proto/errors.proto
+++ b/proto/errors.proto
@@ -33,8 +33,8 @@ option (gogoproto.goproto_unrecognized_all) = false;
 // A NotLeaderError indicates that the current range is not the
 // leader. If the leader is known, its Replica is set in the error.
 message NotLeaderError {
-  optional Replica replica = 1;
-  optional Replica leader = 2;
+  optional ReplicaDescriptor replica = 1;
+  optional ReplicaDescriptor leader = 2;
   optional int64 range_id = 3 [(gogoproto.nullable) = false,
       (gogoproto.customname) = "RangeID", (gogoproto.casttype) = "RangeID"];
 }

--- a/proto/internal.pb.go
+++ b/proto/internal.pb.go
@@ -20,9 +20,9 @@ var _ = math.Inf
 // A RaftCommand is a command which can be serialized and sent via
 // raft.
 type RaftCommand struct {
-	RangeID       RangeID      `protobuf:"varint,1,opt,name=range_id,casttype=RangeID" json:"range_id"`
-	OriginReplica Replica      `protobuf:"bytes,2,opt,name=origin_replica" json:"origin_replica"`
-	Cmd           BatchRequest `protobuf:"bytes,3,opt,name=cmd" json:"cmd"`
+	RangeID       RangeID           `protobuf:"varint,1,opt,name=range_id,casttype=RangeID" json:"range_id"`
+	OriginReplica ReplicaDescriptor `protobuf:"bytes,2,opt,name=origin_replica" json:"origin_replica"`
+	Cmd           BatchRequest      `protobuf:"bytes,3,opt,name=cmd" json:"cmd"`
 }
 
 func (m *RaftCommand) Reset()         { *m = RaftCommand{} }
@@ -36,11 +36,11 @@ func (m *RaftCommand) GetRangeID() RangeID {
 	return 0
 }
 
-func (m *RaftCommand) GetOriginReplica() Replica {
+func (m *RaftCommand) GetOriginReplica() ReplicaDescriptor {
 	if m != nil {
 		return m.OriginReplica
 	}
-	return Replica{}
+	return ReplicaDescriptor{}
 }
 
 func (m *RaftCommand) GetCmd() BatchRequest {

--- a/proto/internal.proto
+++ b/proto/internal.proto
@@ -33,8 +33,7 @@ option (gogoproto.goproto_unrecognized_all) = false;
 message RaftCommand {
   optional int64 range_id = 1 [(gogoproto.nullable) = false,
       (gogoproto.customname) = "RangeID", (gogoproto.casttype) = "RangeID"];
-  optional uint64 origin_node_id = 2 [(gogoproto.nullable) = false,
-      (gogoproto.customname) = "OriginNodeID", (gogoproto.casttype) = "RaftNodeID"];
+  optional Replica origin_replica = 2 [(gogoproto.nullable) = false];
   optional BatchRequest cmd = 3 [(gogoproto.nullable) = false];
 }
 

--- a/proto/internal.proto
+++ b/proto/internal.proto
@@ -33,7 +33,7 @@ option (gogoproto.goproto_unrecognized_all) = false;
 message RaftCommand {
   optional int64 range_id = 1 [(gogoproto.nullable) = false,
       (gogoproto.customname) = "RangeID", (gogoproto.casttype) = "RangeID"];
-  optional Replica origin_replica = 2 [(gogoproto.nullable) = false];
+  optional ReplicaDescriptor origin_replica = 2 [(gogoproto.nullable) = false];
   optional BatchRequest cmd = 3 [(gogoproto.nullable) = false];
 }
 

--- a/proto/metadata.go
+++ b/proto/metadata.go
@@ -128,7 +128,7 @@ func (r *RangeDescriptor) ContainsKeyRange(start, end []byte) bool {
 
 // FindReplica returns the replica which matches the specified store
 // ID. If no replica matches, (-1, nil) is returned.
-func (r *RangeDescriptor) FindReplica(storeID StoreID) (int, *Replica) {
+func (r *RangeDescriptor) FindReplica(storeID StoreID) (int, *ReplicaDescriptor) {
 	for i := range r.Replicas {
 		if r.Replicas[i].StoreID == storeID {
 			return i, &r.Replicas[i]

--- a/proto/metadata.go
+++ b/proto/metadata.go
@@ -20,7 +20,6 @@ package proto
 
 import (
 	"bytes"
-	"fmt"
 	"sort"
 	"strconv"
 	"strings"
@@ -63,31 +62,9 @@ func (n StoreID) String() string {
 // ReplicaID is a custom type for a range replica ID.
 type ReplicaID int32
 
-// RaftNodeID is a custom type for a Raft node ID. A raft node ID
-// is composed of a concatenation of NodeID + StoreID.
-type RaftNodeID uint64
-
-// Format implements the fmt.Formatter interface.
-func (n RaftNodeID) Format(f fmt.State, verb rune) {
-	// Note: this implementation doesn't handle the width and precision
-	// specifiers such as "%20.10s".
-	fmt.Fprint(f, strconv.FormatInt(int64(n), 16))
-}
-
-// MakeRaftNodeID packs a NodeID and StoreID into a single uint64 for use in raft.
-func MakeRaftNodeID(n NodeID, s StoreID) RaftNodeID {
-	if n < 0 || s <= 0 {
-		// Zeroes are likely the result of incomplete initialization.
-		// TODO(bdarnell): should we disallow NodeID==0? It should never occur in
-		// production but many tests use it.
-		panic("NodeID must be >= 0 and StoreID must be > 0")
-	}
-	return RaftNodeID(n)<<32 | RaftNodeID(s)
-}
-
-// DecodeRaftNodeID converts a RaftNodeID into its component NodeID and StoreID.
-func DecodeRaftNodeID(n RaftNodeID) (NodeID, StoreID) {
-	return NodeID(n >> 32), StoreID(n & 0xffffffff)
+// String implements the fmt.Stringer interface.
+func (r ReplicaID) String() string {
+	return strconv.FormatInt(int64(r), 10)
 }
 
 // IsSubset returns whether attributes list a is a subset of

--- a/proto/metadata.pb.go
+++ b/proto/metadata.pb.go
@@ -34,10 +34,10 @@ func (m *Attributes) GetAttrs() []string {
 	return nil
 }
 
-// Replica describes a replica location by node ID (corresponds to a
-// host:port via lookup on gossip network) and store ID (identifies the
-// device).
-type Replica struct {
+// ReplicaDescriptor describes a replica location by node ID
+// (corresponds to a host:port via lookup on gossip network) and store
+// ID (identifies the device).
+type ReplicaDescriptor struct {
 	NodeID  NodeID  `protobuf:"varint,1,opt,name=node_id,casttype=NodeID" json:"node_id"`
 	StoreID StoreID `protobuf:"varint,2,opt,name=store_id,casttype=StoreID" json:"store_id"`
 	// ReplicaID uniquely identifies a replica instance. If a range is removed from
@@ -46,25 +46,25 @@ type Replica struct {
 	ReplicaID ReplicaID `protobuf:"varint,3,opt,name=replica_id,casttype=ReplicaID" json:"replica_id"`
 }
 
-func (m *Replica) Reset()         { *m = Replica{} }
-func (m *Replica) String() string { return proto1.CompactTextString(m) }
-func (*Replica) ProtoMessage()    {}
+func (m *ReplicaDescriptor) Reset()         { *m = ReplicaDescriptor{} }
+func (m *ReplicaDescriptor) String() string { return proto1.CompactTextString(m) }
+func (*ReplicaDescriptor) ProtoMessage()    {}
 
-func (m *Replica) GetNodeID() NodeID {
+func (m *ReplicaDescriptor) GetNodeID() NodeID {
 	if m != nil {
 		return m.NodeID
 	}
 	return 0
 }
 
-func (m *Replica) GetStoreID() StoreID {
+func (m *ReplicaDescriptor) GetStoreID() StoreID {
 	if m != nil {
 		return m.StoreID
 	}
 	return 0
 }
 
-func (m *Replica) GetReplicaID() ReplicaID {
+func (m *ReplicaDescriptor) GetReplicaID() ReplicaID {
 	if m != nil {
 		return m.ReplicaID
 	}
@@ -85,7 +85,7 @@ type RangeDescriptor struct {
 	// Replicas is the set of nodes/stores on which replicas of this
 	// range are stored, the ordering being arbitrary and subject to
 	// permutation.
-	Replicas []Replica `protobuf:"bytes,4,rep,name=replicas" json:"replicas"`
+	Replicas []ReplicaDescriptor `protobuf:"bytes,4,rep,name=replicas" json:"replicas"`
 	// NextReplicaID is a counter used to generate replica IDs.
 	NextReplicaID ReplicaID `protobuf:"varint,5,opt,name=next_replica_id,casttype=ReplicaID" json:"next_replica_id"`
 }
@@ -115,7 +115,7 @@ func (m *RangeDescriptor) GetEndKey() Key {
 	return nil
 }
 
-func (m *RangeDescriptor) GetReplicas() []Replica {
+func (m *RangeDescriptor) GetReplicas() []ReplicaDescriptor {
 	if m != nil {
 		return m.Replicas
 	}
@@ -333,7 +333,7 @@ func (m *Attributes) MarshalTo(data []byte) (int, error) {
 	return i, nil
 }
 
-func (m *Replica) Marshal() (data []byte, err error) {
+func (m *ReplicaDescriptor) Marshal() (data []byte, err error) {
 	size := m.Size()
 	data = make([]byte, size)
 	n, err := m.MarshalTo(data)
@@ -343,7 +343,7 @@ func (m *Replica) Marshal() (data []byte, err error) {
 	return data[:n], nil
 }
 
-func (m *Replica) MarshalTo(data []byte) (int, error) {
+func (m *ReplicaDescriptor) MarshalTo(data []byte) (int, error) {
 	var i int
 	_ = i
 	var l int
@@ -630,7 +630,7 @@ func (m *Attributes) Size() (n int) {
 	return n
 }
 
-func (m *Replica) Size() (n int) {
+func (m *ReplicaDescriptor) Size() (n int) {
 	var l int
 	_ = l
 	n += 1 + sovMetadata(uint64(m.NodeID))
@@ -819,7 +819,7 @@ func (m *Attributes) Unmarshal(data []byte) error {
 	}
 	return nil
 }
-func (m *Replica) Unmarshal(data []byte) error {
+func (m *ReplicaDescriptor) Unmarshal(data []byte) error {
 	l := len(data)
 	iNdEx := 0
 	for iNdEx < l {
@@ -842,10 +842,10 @@ func (m *Replica) Unmarshal(data []byte) error {
 		fieldNum := int32(wire >> 3)
 		wireType := int(wire & 0x7)
 		if wireType == 4 {
-			return fmt.Errorf("proto: Replica: wiretype end group for non-group")
+			return fmt.Errorf("proto: ReplicaDescriptor: wiretype end group for non-group")
 		}
 		if fieldNum <= 0 {
-			return fmt.Errorf("proto: Replica: illegal tag %d (wire type %d)", fieldNum, wire)
+			return fmt.Errorf("proto: ReplicaDescriptor: illegal tag %d (wire type %d)", fieldNum, wire)
 		}
 		switch fieldNum {
 		case 1:
@@ -1056,7 +1056,7 @@ func (m *RangeDescriptor) Unmarshal(data []byte) error {
 			if postIndex > l {
 				return io.ErrUnexpectedEOF
 			}
-			m.Replicas = append(m.Replicas, Replica{})
+			m.Replicas = append(m.Replicas, ReplicaDescriptor{})
 			if err := m.Replicas[len(m.Replicas)-1].Unmarshal(data[iNdEx:postIndex]); err != nil {
 				return err
 			}

--- a/proto/metadata.proto
+++ b/proto/metadata.proto
@@ -36,10 +36,10 @@ message Attributes {
   repeated string attrs = 1 [(gogoproto.moretags) = "yaml:\"attrs,flow\""];
 }
 
-// Replica describes a replica location by node ID (corresponds to a
-// host:port via lookup on gossip network) and store ID (identifies the
-// device).
-message Replica {
+// ReplicaDescriptor describes a replica location by node ID
+// (corresponds to a host:port via lookup on gossip network) and store
+// ID (identifies the device).
+message ReplicaDescriptor {
   optional int32 node_id = 1 [(gogoproto.nullable) = false,
       (gogoproto.customname) = "NodeID", (gogoproto.casttype) = "NodeID"];
   optional int32 store_id = 2 [(gogoproto.nullable) = false,
@@ -67,7 +67,7 @@ message RangeDescriptor {
   // Replicas is the set of nodes/stores on which replicas of this
   // range are stored, the ordering being arbitrary and subject to
   // permutation.
-  repeated Replica replicas = 4 [(gogoproto.nullable) = false];
+  repeated ReplicaDescriptor replicas = 4 [(gogoproto.nullable) = false];
 
   // NextReplicaID is a counter used to generate replica IDs.
   optional int32 next_replica_id = 5 [(gogoproto.nullable) = false,

--- a/proto/metadata_test.go
+++ b/proto/metadata_test.go
@@ -64,7 +64,7 @@ func TestAttributesSortedString(t *testing.T) {
 
 func TestRangeDescriptorFindReplica(t *testing.T) {
 	desc := RangeDescriptor{
-		Replicas: []Replica{
+		Replicas: []ReplicaDescriptor{
 			{NodeID: 1, StoreID: 1},
 			{NodeID: 2, StoreID: 2},
 			{NodeID: 3, StoreID: 3},

--- a/server/raft_transport_test.go
+++ b/server/raft_transport_test.go
@@ -124,12 +124,12 @@ func TestSendAndReceive(t *testing.T) {
 					To:   uint64(nodeIDs[to]),
 					Type: raftpb.MsgHeartbeat,
 				},
-				FromReplica: proto.Replica{
+				FromReplica: proto.ReplicaDescriptor{
 					NodeID:    nodeIDs[from],
 					StoreID:   proto.StoreID(nodeIDs[from]),
 					ReplicaID: proto.ReplicaID(nodeIDs[from]),
 				},
-				ToReplica: proto.Replica{
+				ToReplica: proto.ReplicaDescriptor{
 					NodeID:    nodeIDs[to],
 					StoreID:   proto.StoreID(nodeIDs[to]),
 					ReplicaID: proto.ReplicaID(nodeIDs[to]),
@@ -217,12 +217,12 @@ func TestInOrderDelivery(t *testing.T) {
 				From:   uint64(clientNodeID),
 				Commit: uint64(i),
 			},
-			ToReplica: proto.Replica{
+			ToReplica: proto.ReplicaDescriptor{
 				NodeID:    nodeID,
 				StoreID:   proto.StoreID(nodeID),
 				ReplicaID: proto.ReplicaID(nodeID),
 			},
-			FromReplica: proto.Replica{
+			FromReplica: proto.ReplicaDescriptor{
 				NodeID:    clientNodeID,
 				StoreID:   proto.StoreID(clientNodeID),
 				ReplicaID: proto.ReplicaID(clientNodeID),

--- a/server/raft_transport_test.go
+++ b/server/raft_transport_test.go
@@ -72,7 +72,7 @@ func TestSendAndReceive(t *testing.T) {
 	servers := []*rpc.Server{}
 	// All the rest have length numStores (note that several stores share a transport).
 	nextNodeID := proto.NodeID(1)
-	nodeIDs := []proto.RaftNodeID{}
+	nodeIDs := []proto.NodeID{}
 	transports := []multiraft.Transport{}
 	channels := []channelServer{}
 	for serverIndex := 0; serverIndex < numServers; serverIndex++ {
@@ -89,17 +89,16 @@ func TestSendAndReceive(t *testing.T) {
 		defer transport.Close()
 
 		for store := 0; store < storesPerServer; store++ {
-			protoNodeID := nextNodeID
-			nodeID := proto.MakeRaftNodeID(protoNodeID, 1)
+			nodeID := nextNodeID
 			nextNodeID++
 
 			channel := newChannelServer(10, 0)
-			if err := transport.Listen(nodeID, channel); err != nil {
+			if err := transport.Listen(proto.StoreID(nodeID), channel); err != nil {
 				t.Fatal(err)
 			}
 
 			addr := server.Addr()
-			if err := g.AddInfoProto(gossip.MakeNodeIDKey(protoNodeID),
+			if err := g.AddInfoProto(gossip.MakeNodeIDKey(nodeID),
 				&proto.NodeDescriptor{
 					Address: util.MakeUnresolvedAddr(addr.Network(), addr.String()),
 				},
@@ -124,6 +123,16 @@ func TestSendAndReceive(t *testing.T) {
 					From: uint64(nodeIDs[from]),
 					To:   uint64(nodeIDs[to]),
 					Type: raftpb.MsgHeartbeat,
+				},
+				FromReplica: proto.Replica{
+					NodeID:    nodeIDs[from],
+					StoreID:   proto.StoreID(nodeIDs[from]),
+					ReplicaID: proto.ReplicaID(nodeIDs[from]),
+				},
+				ToReplica: proto.Replica{
+					NodeID:    nodeIDs[to],
+					StoreID:   proto.StoreID(nodeIDs[to]),
+					ReplicaID: proto.ReplicaID(nodeIDs[to]),
 				},
 			}
 
@@ -174,19 +183,18 @@ func TestInOrderDelivery(t *testing.T) {
 	defer server.Close()
 
 	const numMessages = 100
-	protoNodeID := proto.NodeID(1)
-	raftNodeID := proto.MakeRaftNodeID(protoNodeID, 1)
+	nodeID := proto.NodeID(1)
 	serverTransport, err := newRPCTransport(g, server, nodeRPCContext)
 	if err != nil {
 		t.Fatal(err)
 	}
 	defer serverTransport.Close()
 	serverChannel := newChannelServer(numMessages, 10*time.Millisecond)
-	if err := serverTransport.Listen(raftNodeID, serverChannel); err != nil {
+	if err := serverTransport.Listen(proto.StoreID(nodeID), serverChannel); err != nil {
 		t.Fatal(err)
 	}
 	addr := server.Addr()
-	if err := g.AddInfoProto(gossip.MakeNodeIDKey(protoNodeID),
+	if err := g.AddInfoProto(gossip.MakeNodeIDKey(nodeID),
 		&proto.NodeDescriptor{
 			Address: util.MakeUnresolvedAddr(addr.Network(), addr.String()),
 		},
@@ -194,7 +202,7 @@ func TestInOrderDelivery(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	clientNodeID := proto.MakeRaftNodeID(2, 2)
+	clientNodeID := proto.NodeID(2)
 	clientTransport, err := newRPCTransport(g, nil, nodeRPCContext)
 	if err != nil {
 		t.Fatal(err)
@@ -205,9 +213,19 @@ func TestInOrderDelivery(t *testing.T) {
 		req := &multiraft.RaftMessageRequest{
 			GroupID: 1,
 			Message: raftpb.Message{
-				To:     uint64(raftNodeID),
+				To:     uint64(nodeID),
 				From:   uint64(clientNodeID),
 				Commit: uint64(i),
+			},
+			ToReplica: proto.Replica{
+				NodeID:    nodeID,
+				StoreID:   proto.StoreID(nodeID),
+				ReplicaID: proto.ReplicaID(nodeID),
+			},
+			FromReplica: proto.Replica{
+				NodeID:    clientNodeID,
+				StoreID:   proto.StoreID(clientNodeID),
+				ReplicaID: proto.ReplicaID(clientNodeID),
 			},
 		}
 		if err := clientTransport.Send(req); err != nil {

--- a/storage/allocator.go
+++ b/storage/allocator.go
@@ -117,7 +117,7 @@ func MakeAllocator(storePool *StorePool, options RebalancingOptions) Allocator {
 
 // getUsedNodes returns a set of node IDs which are already being used
 // to store replicas.
-func getUsedNodes(existing []proto.Replica) map[proto.NodeID]struct{} {
+func getUsedNodes(existing []proto.ReplicaDescriptor) map[proto.NodeID]struct{} {
 	usedNodes := map[proto.NodeID]struct{}{}
 	for _, replica := range existing {
 		usedNodes[replica.NodeID] = struct{}{}
@@ -169,7 +169,7 @@ func (a *Allocator) ComputeAction(zone config.ZoneConfig, desc *proto.RangeDescr
 // filter the results. The function will be passed the storeDesc and the used
 // and new counts. It returns a bool indicating inclusion or exclusion from the
 // set of stores being considered.
-func (a *Allocator) AllocateTarget(required proto.Attributes, existing []proto.Replica, relaxConstraints bool,
+func (a *Allocator) AllocateTarget(required proto.Attributes, existing []proto.ReplicaDescriptor, relaxConstraints bool,
 	filter func(storeDesc *proto.StoreDescriptor, count, used *stat) bool) (*proto.StoreDescriptor, error) {
 	// Because more redundancy is better than less, if relaxConstraints, the
 	// matching here is lenient, and tries to find a target by relaxing an
@@ -218,14 +218,14 @@ func (a *Allocator) AllocateTarget(required proto.Attributes, existing []proto.R
 // the zone config associated with the provided replicas. This will allow it to
 // make correct decisions in the case of ranges with heterogeneous replica
 // requirements (i.e. multiple data centers).
-func (a Allocator) RemoveTarget(existing []proto.Replica) (proto.Replica, error) {
+func (a Allocator) RemoveTarget(existing []proto.ReplicaDescriptor) (proto.ReplicaDescriptor, error) {
 	if len(existing) == 0 {
-		return proto.Replica{}, util.Errorf("must supply at least one replica to allocator.RemoveTarget()")
+		return proto.ReplicaDescriptor{}, util.Errorf("must supply at least one replica to allocator.RemoveTarget()")
 	}
 
 	// Retrieve store descriptors for the provided replicas from the StorePool.
 	type replStore struct {
-		repl  proto.Replica
+		repl  proto.ReplicaDescriptor
 		store *proto.StoreDescriptor
 	}
 	replStores := make([]replStore, len(existing))
@@ -275,7 +275,7 @@ func (a Allocator) RemoveTarget(existing []proto.Replica) (proto.Replica, error)
 // is perfectly fine, as other stores in the cluster will also be
 // doing their probabilistic best to rebalance. This helps prevent
 // a stampeding herd targeting an abnormally under-utilized store.
-func (a Allocator) RebalanceTarget(required proto.Attributes, existing []proto.Replica) *proto.StoreDescriptor {
+func (a Allocator) RebalanceTarget(required proto.Attributes, existing []proto.ReplicaDescriptor) *proto.StoreDescriptor {
 	filter := func(s *proto.StoreDescriptor, count, used *stat) bool {
 		// In clusters with very low disk usage, a store is eligible to be a
 		// rebalancing target if the number of ranges on that store is below
@@ -364,7 +364,7 @@ func (a Allocator) ShouldRebalance(storeID proto.StoreID) bool {
 // replicas. If the supplied filter is nil, it is ignored. Returns the
 // list of matching descriptors, and the store list matching the
 // required attributes.
-func (a Allocator) selectRandom(count int, required proto.Attributes, existing []proto.Replica) ([]*proto.StoreDescriptor, *StoreList) {
+func (a Allocator) selectRandom(count int, required proto.Attributes, existing []proto.ReplicaDescriptor) ([]*proto.StoreDescriptor, *StoreList) {
 	var descs []*proto.StoreDescriptor
 	sl := a.storePool.getStoreList(required, a.options.Deterministic)
 	used := getUsedNodes(existing)

--- a/storage/client_merge_test.go
+++ b/storage/client_merge_test.go
@@ -40,7 +40,7 @@ func adminMergeArgs(key []byte, rangeID proto.RangeID, storeID proto.StoreID) pr
 		RequestHeader: proto.RequestHeader{
 			Key:     key,
 			RangeID: rangeID,
-			Replica: proto.Replica{StoreID: storeID},
+			Replica: proto.ReplicaDescriptor{StoreID: storeID},
 		},
 	}
 }

--- a/storage/client_raft_test.go
+++ b/storage/client_raft_test.go
@@ -225,7 +225,7 @@ func TestReplicateRange(t *testing.T) {
 	}
 
 	if err := rng.ChangeReplicas(proto.ADD_REPLICA,
-		proto.Replica{
+		proto.ReplicaDescriptor{
 			NodeID:  mtc.stores[1].Ident.NodeID,
 			StoreID: mtc.stores[1].Ident.StoreID,
 		}, rng.Desc()); err != nil {
@@ -287,7 +287,7 @@ func TestRestoreReplicas(t *testing.T) {
 	}
 
 	if err := firstRng.ChangeReplicas(proto.ADD_REPLICA,
-		proto.Replica{
+		proto.ReplicaDescriptor{
 			NodeID:  mtc.stores[1].Ident.NodeID,
 			StoreID: mtc.stores[1].Ident.StoreID,
 		}, firstRng.Desc()); err != nil {
@@ -385,7 +385,7 @@ func TestFailedReplicaChange(t *testing.T) {
 	}
 
 	err = rng.ChangeReplicas(proto.ADD_REPLICA,
-		proto.Replica{
+		proto.ReplicaDescriptor{
 			NodeID:  mtc.stores[1].Ident.NodeID,
 			StoreID: mtc.stores[1].Ident.StoreID,
 		}, rng.Desc())
@@ -408,7 +408,7 @@ func TestFailedReplicaChange(t *testing.T) {
 	mtc.manualClock.Increment(10 * storage.DefaultHeartbeatInterval.Nanoseconds())
 
 	err = rng.ChangeReplicas(proto.ADD_REPLICA,
-		proto.Replica{
+		proto.ReplicaDescriptor{
 			NodeID:  mtc.stores[1].Ident.NodeID,
 			StoreID: mtc.stores[1].Ident.StoreID,
 		}, rng.Desc())
@@ -473,7 +473,7 @@ func TestReplicateAfterTruncation(t *testing.T) {
 
 	// Now add the second replica.
 	if err := rng.ChangeReplicas(proto.ADD_REPLICA,
-		proto.Replica{
+		proto.ReplicaDescriptor{
 			NodeID:  mtc.stores[1].Ident.NodeID,
 			StoreID: mtc.stores[1].Ident.StoreID,
 		}, rng.Desc()); err != nil {
@@ -633,7 +633,7 @@ func TestStoreRangeDownReplicate(t *testing.T) {
 	// storeIDset is used to compare the replica sets from different views (i.e.
 	// local range descriptors)
 	type storeIDset map[proto.StoreID]struct{}
-	makeStoreIDset := func(replicas []proto.Replica) storeIDset {
+	makeStoreIDset := func(replicas []proto.ReplicaDescriptor) storeIDset {
 		idSet := make(storeIDset)
 		for _, r := range replicas {
 			idSet[r.StoreID] = struct{}{}
@@ -735,7 +735,7 @@ func TestChangeReplicasDescriptorInvariant(t *testing.T) {
 
 	addReplica := func(storeNum int, desc *proto.RangeDescriptor) error {
 		return repl.ChangeReplicas(proto.ADD_REPLICA,
-			proto.Replica{
+			proto.ReplicaDescriptor{
 				NodeID:  mtc.stores[storeNum].Ident.NodeID,
 				StoreID: mtc.stores[storeNum].Ident.StoreID,
 			},
@@ -1092,12 +1092,12 @@ func TestRaftAfterRemoveRange(t *testing.T) {
 		return util.Errorf("range still exists")
 	})
 
-	replica1 := proto.Replica{
+	replica1 := proto.ReplicaDescriptor{
 		ReplicaID: proto.ReplicaID(mtc.stores[1].StoreID()),
 		NodeID:    proto.NodeID(mtc.stores[1].StoreID()),
 		StoreID:   mtc.stores[1].StoreID(),
 	}
-	replica2 := proto.Replica{
+	replica2 := proto.ReplicaDescriptor{
 		ReplicaID: proto.ReplicaID(mtc.stores[2].StoreID()),
 		NodeID:    proto.NodeID(mtc.stores[2].StoreID()),
 		StoreID:   mtc.stores[2].StoreID(),

--- a/storage/client_range_gc_test.go
+++ b/storage/client_range_gc_test.go
@@ -57,6 +57,7 @@ func TestRangeGCQueueDropReplica(t *testing.T) {
 // removes a range from a store that no longer should have a replica.
 func TestRangeGCQueueDropReplicaGCOnScan(t *testing.T) {
 	defer leaktest.AfterTest(t)
+	t.Skip("TODO(bdarnell): #768")
 
 	mtc := startMultiTestContext(t, 3)
 	defer mtc.Stop()

--- a/storage/client_range_test.go
+++ b/storage/client_range_test.go
@@ -292,7 +292,7 @@ func TestTxnPutOutOfOrder(t *testing.T) {
 	requestHeader := proto.RequestHeader{
 		Key:          proto.Key(key),
 		RangeID:      1,
-		Replica:      proto.Replica{StoreID: store.StoreID()},
+		Replica:      proto.ReplicaDescriptor{StoreID: store.StoreID()},
 		UserPriority: &priority,
 		Timestamp:    clock.Now(),
 	}
@@ -348,7 +348,7 @@ func TestRangeLookupUseReverse(t *testing.T) {
 			Key:     proto.KeyMin,
 			EndKey:  keys.RangeMetaKey(proto.KeyMax),
 			RangeID: 1,
-			Replica: proto.Replica{StoreID: store.StoreID()},
+			Replica: proto.ReplicaDescriptor{StoreID: store.StoreID()},
 		},
 	}
 	util.SucceedsWithin(t, time.Second, func() error {
@@ -361,7 +361,7 @@ func TestRangeLookupUseReverse(t *testing.T) {
 			RequestHeader: proto.RequestHeader{
 				Key:             key,
 				RangeID:         1,
-				Replica:         proto.Replica{StoreID: store.StoreID()},
+				Replica:         proto.ReplicaDescriptor{StoreID: store.StoreID()},
 				ReadConsistency: proto.INCONSISTENT,
 			},
 			MaxRanges: maxResults,

--- a/storage/client_split_test.go
+++ b/storage/client_split_test.go
@@ -46,7 +46,7 @@ func adminSplitArgs(key, splitKey []byte, rangeID proto.RangeID, storeID proto.S
 		RequestHeader: proto.RequestHeader{
 			Key:     key,
 			RangeID: rangeID,
-			Replica: proto.Replica{StoreID: storeID},
+			Replica: proto.ReplicaDescriptor{StoreID: storeID},
 		},
 		SplitKey: splitKey,
 	}

--- a/storage/client_test.go
+++ b/storage/client_test.go
@@ -386,7 +386,7 @@ func (m *multiTestContext) replicateRange(rangeID proto.RangeID, sourceStoreInde
 
 	for _, dest := range dests {
 		err = rng.ChangeReplicas(proto.ADD_REPLICA,
-			proto.Replica{
+			proto.ReplicaDescriptor{
 				NodeID:  m.stores[dest].Ident.NodeID,
 				StoreID: m.stores[dest].Ident.StoreID,
 			}, rng.Desc())
@@ -417,7 +417,7 @@ func (m *multiTestContext) unreplicateRange(rangeID proto.RangeID, source, dest 
 	}
 
 	err = rng.ChangeReplicas(proto.REMOVE_REPLICA,
-		proto.Replica{
+		proto.ReplicaDescriptor{
 			NodeID:  m.idents[dest].NodeID,
 			StoreID: m.idents[dest].StoreID,
 		}, rng.Desc())
@@ -444,7 +444,7 @@ func getArgs(key []byte, rangeID proto.RangeID, storeID proto.StoreID) proto.Get
 		RequestHeader: proto.RequestHeader{
 			Key:     key,
 			RangeID: rangeID,
-			Replica: proto.Replica{StoreID: storeID},
+			Replica: proto.ReplicaDescriptor{StoreID: storeID},
 		},
 	}
 }
@@ -456,7 +456,7 @@ func putArgs(key, value []byte, rangeID proto.RangeID, storeID proto.StoreID) pr
 		RequestHeader: proto.RequestHeader{
 			Key:     key,
 			RangeID: rangeID,
-			Replica: proto.Replica{StoreID: storeID},
+			Replica: proto.ReplicaDescriptor{StoreID: storeID},
 		},
 		Value: proto.Value{
 			Bytes: value,
@@ -471,7 +471,7 @@ func incrementArgs(key []byte, inc int64, rangeID proto.RangeID, storeID proto.S
 		RequestHeader: proto.RequestHeader{
 			Key:     key,
 			RangeID: rangeID,
-			Replica: proto.Replica{StoreID: storeID},
+			Replica: proto.ReplicaDescriptor{StoreID: storeID},
 		},
 		Increment: inc,
 	}
@@ -481,7 +481,7 @@ func truncateLogArgs(index uint64, rangeID proto.RangeID, storeID proto.StoreID)
 	return proto.TruncateLogRequest{
 		RequestHeader: proto.RequestHeader{
 			RangeID: rangeID,
-			Replica: proto.Replica{StoreID: storeID},
+			Replica: proto.ReplicaDescriptor{StoreID: storeID},
 		},
 		Index: index,
 	}

--- a/storage/client_test.go
+++ b/storage/client_test.go
@@ -396,7 +396,7 @@ func (m *multiTestContext) replicateRange(rangeID proto.RangeID, sourceStoreInde
 	}
 
 	// Wait for the replication to complete on all destination nodes.
-	util.SucceedsWithin(m.t, time.Second, func() error {
+	util.SucceedsWithin(m.t, 3*time.Second, func() error {
 		for _, dest := range dests {
 			// Use LookupRange(keys) instead of GetRange(rangeID) to ensure that the
 			// snapshot has been transferred and the descriptor initialized.

--- a/storage/engine/rocksdb/cockroach/proto/api.pb.cc
+++ b/storage/engine/rocksdb/cockroach/proto/api.pb.cc
@@ -1258,211 +1258,212 @@ void protobuf_AddDesc_cockroach_2fproto_2fapi_2eproto() {
     "ckroach/proto/data.proto\032\034cockroach/prot"
     "o/errors.proto\032\024gogoproto/gogo.proto\"<\n\013"
     "ClientCmdID\022\027\n\twall_time\030\001 \001(\003B\004\310\336\037\000\022\024\n\006"
-    "random\030\002 \001(\003B\004\310\336\037\000\"\233\003\n\rRequestHeader\0223\n\t"
+    "random\030\002 \001(\003B\004\310\336\037\000\"\245\003\n\rRequestHeader\0223\n\t"
     "timestamp\030\001 \001(\0132\032.cockroach.proto.Timest"
     "ampB\004\310\336\037\000\022;\n\006cmd_id\030\002 \001(\0132\034.cockroach.pr"
     "oto.ClientCmdIDB\r\310\336\037\000\342\336\037\005CmdID\022\024\n\003key\030\003 "
-    "\001(\014B\007\372\336\037\003Key\022\030\n\007end_key\030\004 \001(\014B\007\372\336\037\003Key\022/"
-    "\n\007replica\030\005 \001(\0132\030.cockroach.proto.Replic"
-    "aB\004\310\336\037\000\022,\n\010range_id\030\006 \001(\003B\032\310\336\037\000\342\336\037\007Range"
-    "ID\372\336\037\007RangeID\022\030\n\ruser_priority\030\007 \001(\005:\0011\022"
-    ")\n\003txn\030\010 \001(\0132\034.cockroach.proto.Transacti"
-    "on\022D\n\020read_consistency\030\t \001(\0162$.cockroach"
-    ".proto.ReadConsistencyTypeB\004\310\336\037\000\"\227\001\n\016Res"
-    "ponseHeader\022%\n\005error\030\001 \001(\0132\026.cockroach.p"
-    "roto.Error\0223\n\ttimestamp\030\002 \001(\0132\032.cockroac"
-    "h.proto.TimestampB\004\310\336\037\000\022)\n\003txn\030\003 \001(\0132\034.c"
-    "ockroach.proto.Transaction\"F\n\nGetRequest"
-    "\0228\n\006header\030\001 \001(\0132\036.cockroach.proto.Reque"
-    "stHeaderB\010\310\336\037\000\320\336\037\001\"o\n\013GetResponse\0229\n\006hea"
+    "\001(\014B\007\372\336\037\003Key\022\030\n\007end_key\030\004 \001(\014B\007\372\336\037\003Key\0229"
+    "\n\007replica\030\005 \001(\0132\".cockroach.proto.Replic"
+    "aDescriptorB\004\310\336\037\000\022,\n\010range_id\030\006 \001(\003B\032\310\336\037"
+    "\000\342\336\037\007RangeID\372\336\037\007RangeID\022\030\n\ruser_priority"
+    "\030\007 \001(\005:\0011\022)\n\003txn\030\010 \001(\0132\034.cockroach.proto"
+    ".Transaction\022D\n\020read_consistency\030\t \001(\0162$"
+    ".cockroach.proto.ReadConsistencyTypeB\004\310\336"
+    "\037\000\"\227\001\n\016ResponseHeader\022%\n\005error\030\001 \001(\0132\026.c"
+    "ockroach.proto.Error\0223\n\ttimestamp\030\002 \001(\0132"
+    "\032.cockroach.proto.TimestampB\004\310\336\037\000\022)\n\003txn"
+    "\030\003 \001(\0132\034.cockroach.proto.Transaction\"F\n\n"
+    "GetRequest\0228\n\006header\030\001 \001(\0132\036.cockroach.p"
+    "roto.RequestHeaderB\010\310\336\037\000\320\336\037\001\"o\n\013GetRespo"
+    "nse\0229\n\006header\030\001 \001(\0132\037.cockroach.proto.Re"
+    "sponseHeaderB\010\310\336\037\000\320\336\037\001\022%\n\005value\030\002 \001(\0132\026."
+    "cockroach.proto.Value\"s\n\nPutRequest\0228\n\006h"
+    "eader\030\001 \001(\0132\036.cockroach.proto.RequestHea"
+    "derB\010\310\336\037\000\320\336\037\001\022+\n\005value\030\002 \001(\0132\026.cockroach"
+    ".proto.ValueB\004\310\336\037\000\"H\n\013PutResponse\0229\n\006hea"
     "der\030\001 \001(\0132\037.cockroach.proto.ResponseHead"
-    "erB\010\310\336\037\000\320\336\037\001\022%\n\005value\030\002 \001(\0132\026.cockroach."
-    "proto.Value\"s\n\nPutRequest\0228\n\006header\030\001 \001("
-    "\0132\036.cockroach.proto.RequestHeaderB\010\310\336\037\000\320"
-    "\336\037\001\022+\n\005value\030\002 \001(\0132\026.cockroach.proto.Val"
-    "ueB\004\310\336\037\000\"H\n\013PutResponse\0229\n\006header\030\001 \001(\0132"
-    "\037.cockroach.proto.ResponseHeaderB\010\310\336\037\000\320\336"
-    "\037\001\"\251\001\n\025ConditionalPutRequest\0228\n\006header\030\001"
-    " \001(\0132\036.cockroach.proto.RequestHeaderB\010\310\336"
-    "\037\000\320\336\037\001\022+\n\005value\030\002 \001(\0132\026.cockroach.proto."
-    "ValueB\004\310\336\037\000\022)\n\texp_value\030\003 \001(\0132\026.cockroa"
-    "ch.proto.Value\"S\n\026ConditionalPutResponse"
-    "\0229\n\006header\030\001 \001(\0132\037.cockroach.proto.Respo"
-    "nseHeaderB\010\310\336\037\000\320\336\037\001\"e\n\020IncrementRequest\022"
-    "8\n\006header\030\001 \001(\0132\036.cockroach.proto.Reques"
-    "tHeaderB\010\310\336\037\000\320\336\037\001\022\027\n\tincrement\030\002 \001(\003B\004\310\336"
-    "\037\000\"g\n\021IncrementResponse\0229\n\006header\030\001 \001(\0132"
-    "\037.cockroach.proto.ResponseHeaderB\010\310\336\037\000\320\336"
-    "\037\001\022\027\n\tnew_value\030\002 \001(\003B\004\310\336\037\000\"I\n\rDeleteReq"
-    "uest\0228\n\006header\030\001 \001(\0132\036.cockroach.proto.R"
-    "equestHeaderB\010\310\336\037\000\320\336\037\001\"K\n\016DeleteResponse"
-    "\0229\n\006header\030\001 \001(\0132\037.cockroach.proto.Respo"
-    "nseHeaderB\010\310\336\037\000\320\336\037\001\"s\n\022DeleteRangeReques"
-    "t\0228\n\006header\030\001 \001(\0132\036.cockroach.proto.Requ"
-    "estHeaderB\010\310\336\037\000\320\336\037\001\022#\n\025max_entries_to_de"
-    "lete\030\002 \001(\003B\004\310\336\037\000\"k\n\023DeleteRangeResponse\022"
-    "9\n\006header\030\001 \001(\0132\037.cockroach.proto.Respon"
-    "seHeaderB\010\310\336\037\000\320\336\037\001\022\031\n\013num_deleted\030\002 \001(\003B"
-    "\004\310\336\037\000\"b\n\013ScanRequest\0228\n\006header\030\001 \001(\0132\036.c"
-    "ockroach.proto.RequestHeaderB\010\310\336\037\000\320\336\037\001\022\031"
-    "\n\013max_results\030\002 \001(\003B\004\310\336\037\000\"x\n\014ScanRespons"
-    "e\0229\n\006header\030\001 \001(\0132\037.cockroach.proto.Resp"
-    "onseHeaderB\010\310\336\037\000\320\336\037\001\022-\n\004rows\030\002 \003(\0132\031.coc"
-    "kroach.proto.KeyValueB\004\310\336\037\000\"i\n\022ReverseSc"
-    "anRequest\0228\n\006header\030\001 \001(\0132\036.cockroach.pr"
-    "oto.RequestHeaderB\010\310\336\037\000\320\336\037\001\022\031\n\013max_resul"
-    "ts\030\002 \001(\003B\004\310\336\037\000\"\177\n\023ReverseScanResponse\0229\n"
-    "\006header\030\001 \001(\0132\037.cockroach.proto.Response"
-    "HeaderB\010\310\336\037\000\320\336\037\001\022-\n\004rows\030\002 \003(\0132\031.cockroa"
-    "ch.proto.KeyValueB\004\310\336\037\000\"\340\001\n\025EndTransacti"
-    "onRequest\0228\n\006header\030\001 \001(\0132\036.cockroach.pr"
-    "oto.RequestHeaderB\010\310\336\037\000\320\336\037\001\022\024\n\006commit\030\002 "
-    "\001(\010B\004\310\336\037\000\022G\n\027internal_commit_trigger\030\003 \001"
-    "(\0132&.cockroach.proto.InternalCommitTrigg"
-    "er\022.\n\007intents\030\004 \003(\0132\027.cockroach.proto.In"
-    "tentB\004\310\336\037\000\"\211\001\n\026EndTransactionResponse\0229\n"
-    "\006header\030\001 \001(\0132\037.cockroach.proto.Response"
-    "HeaderB\010\310\336\037\000\320\336\037\001\022\031\n\013commit_wait\030\002 \001(\003B\004\310"
-    "\336\037\000\022\031\n\010resolved\030\003 \003(\014B\007\372\336\037\003Key\"i\n\021AdminS"
-    "plitRequest\0228\n\006header\030\001 \001(\0132\036.cockroach."
-    "proto.RequestHeaderB\010\310\336\037\000\320\336\037\001\022\032\n\tsplit_k"
-    "ey\030\002 \001(\014B\007\372\336\037\003Key\"O\n\022AdminSplitResponse\022"
-    "9\n\006header\030\001 \001(\0132\037.cockroach.proto.Respon"
-    "seHeaderB\010\310\336\037\000\320\336\037\001\"M\n\021AdminMergeRequest\022"
-    "8\n\006header\030\001 \001(\0132\036.cockroach.proto.Reques"
-    "tHeaderB\010\310\336\037\000\320\336\037\001\"O\n\022AdminMergeResponse\022"
-    "9\n\006header\030\001 \001(\0132\037.cockroach.proto.Respon"
-    "seHeaderB\010\310\336\037\000\320\336\037\001\"\237\001\n\022RangeLookupReques"
-    "t\0228\n\006header\030\001 \001(\0132\036.cockroach.proto.Requ"
-    "estHeaderB\010\310\336\037\000\320\336\037\001\022\030\n\nmax_ranges\030\002 \001(\005B"
-    "\004\310\336\037\000\022\036\n\020consider_intents\030\003 \001(\010B\004\310\336\037\000\022\025\n"
-    "\007reverse\030\004 \001(\010B\004\310\336\037\000\"\210\001\n\023RangeLookupResp"
-    "onse\0229\n\006header\030\001 \001(\0132\037.cockroach.proto.R"
-    "esponseHeaderB\010\310\336\037\000\320\336\037\001\0226\n\006ranges\030\002 \003(\0132"
-    " .cockroach.proto.RangeDescriptorB\004\310\336\037\000\""
-    "O\n\023HeartbeatTxnRequest\0228\n\006header\030\001 \001(\0132\036"
-    ".cockroach.proto.RequestHeaderB\010\310\336\037\000\320\336\037\001"
-    "\"Q\n\024HeartbeatTxnResponse\0229\n\006header\030\001 \001(\013"
-    "2\037.cockroach.proto.ResponseHeaderB\010\310\336\037\000\320"
-    "\336\037\001\"\215\002\n\tGCRequest\0228\n\006header\030\001 \001(\0132\036.cock"
-    "roach.proto.RequestHeaderB\010\310\336\037\000\320\336\037\001\022<\n\007g"
-    "c_meta\030\002 \001(\0132\033.cockroach.proto.GCMetadat"
-    "aB\016\310\336\037\000\342\336\037\006GCMeta\0224\n\004keys\030\003 \003(\0132 .cockro"
-    "ach.proto.GCRequest.GCKeyB\004\310\336\037\000\032R\n\005GCKey"
-    "\022\024\n\003key\030\001 \001(\014B\007\372\336\037\003Key\0223\n\ttimestamp\030\002 \001("
-    "\0132\032.cockroach.proto.TimestampB\004\310\336\037\000\"G\n\nG"
-    "CResponse\0229\n\006header\030\001 \001(\0132\037.cockroach.pr"
-    "oto.ResponseHeaderB\010\310\336\037\000\320\336\037\001\"\232\002\n\016PushTxn"
-    "Request\0228\n\006header\030\001 \001(\0132\036.cockroach.prot"
-    "o.RequestHeaderB\010\310\336\037\000\320\336\037\001\0220\n\npusher_txn\030"
-    "\002 \001(\0132\034.cockroach.proto.Transaction\0226\n\np"
-    "ushee_txn\030\003 \001(\0132\034.cockroach.proto.Transa"
-    "ctionB\004\310\336\037\000\022-\n\003now\030\004 \001(\0132\032.cockroach.pro"
-    "to.TimestampB\004\310\336\037\000\0225\n\tpush_type\030\005 \001(\0162\034."
-    "cockroach.proto.PushTxnTypeB\004\310\336\037\000\"~\n\017Pus"
-    "hTxnResponse\0229\n\006header\030\001 \001(\0132\037.cockroach"
-    ".proto.ResponseHeaderB\010\310\336\037\000\320\336\037\001\0220\n\npushe"
-    "e_txn\030\002 \001(\0132\034.cockroach.proto.Transactio"
-    "n\"\210\001\n\024ResolveIntentRequest\0228\n\006header\030\001 \001"
-    "(\0132\036.cockroach.proto.RequestHeaderB\010\310\336\037\000"
-    "\320\336\037\001\0226\n\nintent_txn\030\002 \001(\0132\034.cockroach.pro"
-    "to.TransactionB\004\310\336\037\000\"R\n\025ResolveIntentRes"
-    "ponse\0229\n\006header\030\001 \001(\0132\037.cockroach.proto."
-    "ResponseHeaderB\010\310\336\037\000\320\336\037\001\"\215\001\n\031ResolveInte"
-    "ntRangeRequest\0228\n\006header\030\001 \001(\0132\036.cockroa"
-    "ch.proto.RequestHeaderB\010\310\336\037\000\320\336\037\001\0226\n\ninte"
-    "nt_txn\030\002 \001(\0132\034.cockroach.proto.Transacti"
-    "onB\004\310\336\037\000\"I\n\014NoopResponse\0229\n\006header\030\001 \001(\013"
-    "2\037.cockroach.proto.ResponseHeaderB\010\310\336\037\000\320"
-    "\336\037\001\"G\n\013NoopRequest\0228\n\006header\030\001 \001(\0132\036.coc"
-    "kroach.proto.RequestHeaderB\010\310\336\037\000\320\336\037\001\"W\n\032"
-    "ResolveIntentRangeResponse\0229\n\006header\030\001 \001"
-    "(\0132\037.cockroach.proto.ResponseHeaderB\010\310\336\037"
-    "\000\320\336\037\001\"u\n\014MergeRequest\0228\n\006header\030\001 \001(\0132\036."
+    "erB\010\310\336\037\000\320\336\037\001\"\251\001\n\025ConditionalPutRequest\0228"
+    "\n\006header\030\001 \001(\0132\036.cockroach.proto.Request"
+    "HeaderB\010\310\336\037\000\320\336\037\001\022+\n\005value\030\002 \001(\0132\026.cockro"
+    "ach.proto.ValueB\004\310\336\037\000\022)\n\texp_value\030\003 \001(\013"
+    "2\026.cockroach.proto.Value\"S\n\026ConditionalP"
+    "utResponse\0229\n\006header\030\001 \001(\0132\037.cockroach.p"
+    "roto.ResponseHeaderB\010\310\336\037\000\320\336\037\001\"e\n\020Increme"
+    "ntRequest\0228\n\006header\030\001 \001(\0132\036.cockroach.pr"
+    "oto.RequestHeaderB\010\310\336\037\000\320\336\037\001\022\027\n\tincrement"
+    "\030\002 \001(\003B\004\310\336\037\000\"g\n\021IncrementResponse\0229\n\006hea"
+    "der\030\001 \001(\0132\037.cockroach.proto.ResponseHead"
+    "erB\010\310\336\037\000\320\336\037\001\022\027\n\tnew_value\030\002 \001(\003B\004\310\336\037\000\"I\n"
+    "\rDeleteRequest\0228\n\006header\030\001 \001(\0132\036.cockroa"
+    "ch.proto.RequestHeaderB\010\310\336\037\000\320\336\037\001\"K\n\016Dele"
+    "teResponse\0229\n\006header\030\001 \001(\0132\037.cockroach.p"
+    "roto.ResponseHeaderB\010\310\336\037\000\320\336\037\001\"s\n\022DeleteR"
+    "angeRequest\0228\n\006header\030\001 \001(\0132\036.cockroach."
+    "proto.RequestHeaderB\010\310\336\037\000\320\336\037\001\022#\n\025max_ent"
+    "ries_to_delete\030\002 \001(\003B\004\310\336\037\000\"k\n\023DeleteRang"
+    "eResponse\0229\n\006header\030\001 \001(\0132\037.cockroach.pr"
+    "oto.ResponseHeaderB\010\310\336\037\000\320\336\037\001\022\031\n\013num_dele"
+    "ted\030\002 \001(\003B\004\310\336\037\000\"b\n\013ScanRequest\0228\n\006header"
+    "\030\001 \001(\0132\036.cockroach.proto.RequestHeaderB\010"
+    "\310\336\037\000\320\336\037\001\022\031\n\013max_results\030\002 \001(\003B\004\310\336\037\000\"x\n\014S"
+    "canResponse\0229\n\006header\030\001 \001(\0132\037.cockroach."
+    "proto.ResponseHeaderB\010\310\336\037\000\320\336\037\001\022-\n\004rows\030\002"
+    " \003(\0132\031.cockroach.proto.KeyValueB\004\310\336\037\000\"i\n"
+    "\022ReverseScanRequest\0228\n\006header\030\001 \001(\0132\036.co"
+    "ckroach.proto.RequestHeaderB\010\310\336\037\000\320\336\037\001\022\031\n"
+    "\013max_results\030\002 \001(\003B\004\310\336\037\000\"\177\n\023ReverseScanR"
+    "esponse\0229\n\006header\030\001 \001(\0132\037.cockroach.prot"
+    "o.ResponseHeaderB\010\310\336\037\000\320\336\037\001\022-\n\004rows\030\002 \003(\013"
+    "2\031.cockroach.proto.KeyValueB\004\310\336\037\000\"\340\001\n\025En"
+    "dTransactionRequest\0228\n\006header\030\001 \001(\0132\036.co"
+    "ckroach.proto.RequestHeaderB\010\310\336\037\000\320\336\037\001\022\024\n"
+    "\006commit\030\002 \001(\010B\004\310\336\037\000\022G\n\027internal_commit_t"
+    "rigger\030\003 \001(\0132&.cockroach.proto.InternalC"
+    "ommitTrigger\022.\n\007intents\030\004 \003(\0132\027.cockroac"
+    "h.proto.IntentB\004\310\336\037\000\"\211\001\n\026EndTransactionR"
+    "esponse\0229\n\006header\030\001 \001(\0132\037.cockroach.prot"
+    "o.ResponseHeaderB\010\310\336\037\000\320\336\037\001\022\031\n\013commit_wai"
+    "t\030\002 \001(\003B\004\310\336\037\000\022\031\n\010resolved\030\003 \003(\014B\007\372\336\037\003Key"
+    "\"i\n\021AdminSplitRequest\0228\n\006header\030\001 \001(\0132\036."
     "cockroach.proto.RequestHeaderB\010\310\336\037\000\320\336\037\001\022"
-    "+\n\005value\030\002 \001(\0132\026.cockroach.proto.ValueB\004"
-    "\310\336\037\000\"J\n\rMergeResponse\0229\n\006header\030\001 \001(\0132\037."
+    "\032\n\tsplit_key\030\002 \001(\014B\007\372\336\037\003Key\"O\n\022AdminSpli"
+    "tResponse\0229\n\006header\030\001 \001(\0132\037.cockroach.pr"
+    "oto.ResponseHeaderB\010\310\336\037\000\320\336\037\001\"M\n\021AdminMer"
+    "geRequest\0228\n\006header\030\001 \001(\0132\036.cockroach.pr"
+    "oto.RequestHeaderB\010\310\336\037\000\320\336\037\001\"O\n\022AdminMerg"
+    "eResponse\0229\n\006header\030\001 \001(\0132\037.cockroach.pr"
+    "oto.ResponseHeaderB\010\310\336\037\000\320\336\037\001\"\237\001\n\022RangeLo"
+    "okupRequest\0228\n\006header\030\001 \001(\0132\036.cockroach."
+    "proto.RequestHeaderB\010\310\336\037\000\320\336\037\001\022\030\n\nmax_ran"
+    "ges\030\002 \001(\005B\004\310\336\037\000\022\036\n\020consider_intents\030\003 \001("
+    "\010B\004\310\336\037\000\022\025\n\007reverse\030\004 \001(\010B\004\310\336\037\000\"\210\001\n\023Range"
+    "LookupResponse\0229\n\006header\030\001 \001(\0132\037.cockroa"
+    "ch.proto.ResponseHeaderB\010\310\336\037\000\320\336\037\001\0226\n\006ran"
+    "ges\030\002 \003(\0132 .cockroach.proto.RangeDescrip"
+    "torB\004\310\336\037\000\"O\n\023HeartbeatTxnRequest\0228\n\006head"
+    "er\030\001 \001(\0132\036.cockroach.proto.RequestHeader"
+    "B\010\310\336\037\000\320\336\037\001\"Q\n\024HeartbeatTxnResponse\0229\n\006he"
+    "ader\030\001 \001(\0132\037.cockroach.proto.ResponseHea"
+    "derB\010\310\336\037\000\320\336\037\001\"\215\002\n\tGCRequest\0228\n\006header\030\001 "
+    "\001(\0132\036.cockroach.proto.RequestHeaderB\010\310\336\037"
+    "\000\320\336\037\001\022<\n\007gc_meta\030\002 \001(\0132\033.cockroach.proto"
+    ".GCMetadataB\016\310\336\037\000\342\336\037\006GCMeta\0224\n\004keys\030\003 \003("
+    "\0132 .cockroach.proto.GCRequest.GCKeyB\004\310\336\037"
+    "\000\032R\n\005GCKey\022\024\n\003key\030\001 \001(\014B\007\372\336\037\003Key\0223\n\ttime"
+    "stamp\030\002 \001(\0132\032.cockroach.proto.TimestampB"
+    "\004\310\336\037\000\"G\n\nGCResponse\0229\n\006header\030\001 \001(\0132\037.co"
+    "ckroach.proto.ResponseHeaderB\010\310\336\037\000\320\336\037\001\"\232"
+    "\002\n\016PushTxnRequest\0228\n\006header\030\001 \001(\0132\036.cock"
+    "roach.proto.RequestHeaderB\010\310\336\037\000\320\336\037\001\0220\n\np"
+    "usher_txn\030\002 \001(\0132\034.cockroach.proto.Transa"
+    "ction\0226\n\npushee_txn\030\003 \001(\0132\034.cockroach.pr"
+    "oto.TransactionB\004\310\336\037\000\022-\n\003now\030\004 \001(\0132\032.coc"
+    "kroach.proto.TimestampB\004\310\336\037\000\0225\n\tpush_typ"
+    "e\030\005 \001(\0162\034.cockroach.proto.PushTxnTypeB\004\310"
+    "\336\037\000\"~\n\017PushTxnResponse\0229\n\006header\030\001 \001(\0132\037"
+    ".cockroach.proto.ResponseHeaderB\010\310\336\037\000\320\336\037"
+    "\001\0220\n\npushee_txn\030\002 \001(\0132\034.cockroach.proto."
+    "Transaction\"\210\001\n\024ResolveIntentRequest\0228\n\006"
+    "header\030\001 \001(\0132\036.cockroach.proto.RequestHe"
+    "aderB\010\310\336\037\000\320\336\037\001\0226\n\nintent_txn\030\002 \001(\0132\034.coc"
+    "kroach.proto.TransactionB\004\310\336\037\000\"R\n\025Resolv"
+    "eIntentResponse\0229\n\006header\030\001 \001(\0132\037.cockro"
+    "ach.proto.ResponseHeaderB\010\310\336\037\000\320\336\037\001\"\215\001\n\031R"
+    "esolveIntentRangeRequest\0228\n\006header\030\001 \001(\013"
+    "2\036.cockroach.proto.RequestHeaderB\010\310\336\037\000\320\336"
+    "\037\001\0226\n\nintent_txn\030\002 \001(\0132\034.cockroach.proto"
+    ".TransactionB\004\310\336\037\000\"I\n\014NoopResponse\0229\n\006he"
+    "ader\030\001 \001(\0132\037.cockroach.proto.ResponseHea"
+    "derB\010\310\336\037\000\320\336\037\001\"G\n\013NoopRequest\0228\n\006header\030\001"
+    " \001(\0132\036.cockroach.proto.RequestHeaderB\010\310\336"
+    "\037\000\320\336\037\001\"W\n\032ResolveIntentRangeResponse\0229\n\006"
+    "header\030\001 \001(\0132\037.cockroach.proto.ResponseH"
+    "eaderB\010\310\336\037\000\320\336\037\001\"u\n\014MergeRequest\0228\n\006heade"
+    "r\030\001 \001(\0132\036.cockroach.proto.RequestHeaderB"
+    "\010\310\336\037\000\320\336\037\001\022+\n\005value\030\002 \001(\0132\026.cockroach.pro"
+    "to.ValueB\004\310\336\037\000\"J\n\rMergeResponse\0229\n\006heade"
+    "r\030\001 \001(\0132\037.cockroach.proto.ResponseHeader"
+    "B\010\310\336\037\000\320\336\037\001\"c\n\022TruncateLogRequest\0228\n\006head"
+    "er\030\001 \001(\0132\036.cockroach.proto.RequestHeader"
+    "B\010\310\336\037\000\320\336\037\001\022\023\n\005index\030\002 \001(\004B\004\310\336\037\000\"P\n\023Trunc"
+    "ateLogResponse\0229\n\006header\030\001 \001(\0132\037.cockroa"
+    "ch.proto.ResponseHeaderB\010\310\336\037\000\320\336\037\001\"{\n\022Lea"
+    "derLeaseRequest\0228\n\006header\030\001 \001(\0132\036.cockro"
+    "ach.proto.RequestHeaderB\010\310\336\037\000\320\336\037\001\022+\n\005lea"
+    "se\030\002 \001(\0132\026.cockroach.proto.LeaseB\004\310\336\037\000\"P"
+    "\n\023LeaderLeaseResponse\0229\n\006header\030\001 \001(\0132\037."
     "cockroach.proto.ResponseHeaderB\010\310\336\037\000\320\336\037\001"
-    "\"c\n\022TruncateLogRequest\0228\n\006header\030\001 \001(\0132\036"
-    ".cockroach.proto.RequestHeaderB\010\310\336\037\000\320\336\037\001"
-    "\022\023\n\005index\030\002 \001(\004B\004\310\336\037\000\"P\n\023TruncateLogResp"
-    "onse\0229\n\006header\030\001 \001(\0132\037.cockroach.proto.R"
-    "esponseHeaderB\010\310\336\037\000\320\336\037\001\"{\n\022LeaderLeaseRe"
-    "quest\0228\n\006header\030\001 \001(\0132\036.cockroach.proto."
-    "RequestHeaderB\010\310\336\037\000\320\336\037\001\022+\n\005lease\030\002 \001(\0132\026"
-    ".cockroach.proto.LeaseB\004\310\336\037\000\"P\n\023LeaderLe"
-    "aseResponse\0229\n\006header\030\001 \001(\0132\037.cockroach."
-    "proto.ResponseHeaderB\010\310\336\037\000\320\336\037\001\"\220\t\n\014Reque"
-    "stUnion\022(\n\003get\030\001 \001(\0132\033.cockroach.proto.G"
-    "etRequest\022(\n\003put\030\002 \001(\0132\033.cockroach.proto"
-    ".PutRequest\022\?\n\017conditional_put\030\003 \001(\0132&.c"
-    "ockroach.proto.ConditionalPutRequest\0224\n\t"
-    "increment\030\004 \001(\0132!.cockroach.proto.Increm"
-    "entRequest\022.\n\006delete\030\005 \001(\0132\036.cockroach.p"
-    "roto.DeleteRequest\0229\n\014delete_range\030\006 \001(\013"
-    "2#.cockroach.proto.DeleteRangeRequest\022*\n"
-    "\004scan\030\007 \001(\0132\034.cockroach.proto.ScanReques"
-    "t\022\?\n\017end_transaction\030\010 \001(\0132&.cockroach.p"
-    "roto.EndTransactionRequest\0227\n\013admin_spli"
-    "t\030\t \001(\0132\".cockroach.proto.AdminSplitRequ"
-    "est\0227\n\013admin_merge\030\n \001(\0132\".cockroach.pro"
-    "to.AdminMergeRequest\022;\n\rheartbeat_txn\030\013 "
-    "\001(\0132$.cockroach.proto.HeartbeatTxnReques"
-    "t\022&\n\002gc\030\014 \001(\0132\032.cockroach.proto.GCReques"
-    "t\0221\n\010push_txn\030\r \001(\0132\037.cockroach.proto.Pu"
-    "shTxnRequest\0229\n\014range_lookup\030\016 \001(\0132#.coc"
-    "kroach.proto.RangeLookupRequest\022=\n\016resol"
-    "ve_intent\030\017 \001(\0132%.cockroach.proto.Resolv"
-    "eIntentRequest\022H\n\024resolve_intent_range\030\020"
-    " \001(\0132*.cockroach.proto.ResolveIntentRang"
-    "eRequest\022,\n\005merge\030\021 \001(\0132\035.cockroach.prot"
-    "o.MergeRequest\0229\n\014truncate_log\030\022 \001(\0132#.c"
-    "ockroach.proto.TruncateLogRequest\0229\n\014lea"
-    "der_lease\030\023 \001(\0132#.cockroach.proto.Leader"
-    "LeaseRequest\0229\n\014reverse_scan\030\024 \001(\0132#.coc"
-    "kroach.proto.ReverseScanRequest\022*\n\004noop\030"
-    "\025 \001(\0132\034.cockroach.proto.NoopRequest:\004\310\240\037"
-    "\001\"\246\t\n\rResponseUnion\022)\n\003get\030\001 \001(\0132\034.cockr"
-    "oach.proto.GetResponse\022)\n\003put\030\002 \001(\0132\034.co"
-    "ckroach.proto.PutResponse\022@\n\017conditional"
-    "_put\030\003 \001(\0132\'.cockroach.proto.Conditional"
-    "PutResponse\0225\n\tincrement\030\004 \001(\0132\".cockroa"
-    "ch.proto.IncrementResponse\022/\n\006delete\030\005 \001"
-    "(\0132\037.cockroach.proto.DeleteResponse\022:\n\014d"
-    "elete_range\030\006 \001(\0132$.cockroach.proto.Dele"
-    "teRangeResponse\022+\n\004scan\030\007 \001(\0132\035.cockroac"
-    "h.proto.ScanResponse\022@\n\017end_transaction\030"
-    "\010 \001(\0132\'.cockroach.proto.EndTransactionRe"
-    "sponse\0228\n\013admin_split\030\t \001(\0132#.cockroach."
-    "proto.AdminSplitResponse\0228\n\013admin_merge\030"
-    "\n \001(\0132#.cockroach.proto.AdminMergeRespon"
-    "se\022<\n\rheartbeat_txn\030\013 \001(\0132%.cockroach.pr"
-    "oto.HeartbeatTxnResponse\022\'\n\002gc\030\014 \001(\0132\033.c"
-    "ockroach.proto.GCResponse\0222\n\010push_txn\030\r "
-    "\001(\0132 .cockroach.proto.PushTxnResponse\022:\n"
-    "\014range_lookup\030\016 \001(\0132$.cockroach.proto.Ra"
-    "ngeLookupResponse\022>\n\016resolve_intent\030\017 \001("
-    "\0132&.cockroach.proto.ResolveIntentRespons"
-    "e\022I\n\024resolve_intent_range\030\020 \001(\0132+.cockro"
-    "ach.proto.ResolveIntentRangeResponse\022-\n\005"
-    "merge\030\021 \001(\0132\036.cockroach.proto.MergeRespo"
-    "nse\022:\n\014truncate_log\030\022 \001(\0132$.cockroach.pr"
-    "oto.TruncateLogResponse\022:\n\014leader_lease\030"
-    "\023 \001(\0132$.cockroach.proto.LeaderLeaseRespo"
-    "nse\022:\n\014reverse_scan\030\024 \001(\0132$.cockroach.pr"
-    "oto.ReverseScanResponse\022+\n\004noop\030\025 \001(\0132\035."
-    "cockroach.proto.NoopResponse:\004\310\240\037\001\"\205\001\n\014B"
-    "atchRequest\0228\n\006header\030\001 \001(\0132\036.cockroach."
-    "proto.RequestHeaderB\010\310\336\037\000\320\336\037\001\0225\n\010request"
-    "s\030\002 \003(\0132\035.cockroach.proto.RequestUnionB\004"
-    "\310\336\037\000:\004\230\240\037\000\"\203\001\n\rBatchResponse\0229\n\006header\030\001"
-    " \001(\0132\037.cockroach.proto.ResponseHeaderB\010\310"
-    "\336\037\000\320\336\037\001\0227\n\tresponses\030\002 \003(\0132\036.cockroach.p"
-    "roto.ResponseUnionB\004\310\336\037\000*L\n\023ReadConsiste"
-    "ncyType\022\016\n\nCONSISTENT\020\000\022\r\n\tCONSENSUS\020\001\022\020"
-    "\n\014INCONSISTENT\020\002\032\004\210\243\036\000*G\n\013PushTxnType\022\022\n"
-    "\016PUSH_TIMESTAMP\020\000\022\r\n\tABORT_TXN\020\001\022\017\n\013CLEA"
-    "NUP_TXN\020\002\032\004\210\243\036\000B\027Z\005proto\340\342\036\001\310\342\036\001\320\342\036\001\220\343\036\000", 8400);
+    "\"\220\t\n\014RequestUnion\022(\n\003get\030\001 \001(\0132\033.cockroa"
+    "ch.proto.GetRequest\022(\n\003put\030\002 \001(\0132\033.cockr"
+    "oach.proto.PutRequest\022\?\n\017conditional_put"
+    "\030\003 \001(\0132&.cockroach.proto.ConditionalPutR"
+    "equest\0224\n\tincrement\030\004 \001(\0132!.cockroach.pr"
+    "oto.IncrementRequest\022.\n\006delete\030\005 \001(\0132\036.c"
+    "ockroach.proto.DeleteRequest\0229\n\014delete_r"
+    "ange\030\006 \001(\0132#.cockroach.proto.DeleteRange"
+    "Request\022*\n\004scan\030\007 \001(\0132\034.cockroach.proto."
+    "ScanRequest\022\?\n\017end_transaction\030\010 \001(\0132&.c"
+    "ockroach.proto.EndTransactionRequest\0227\n\013"
+    "admin_split\030\t \001(\0132\".cockroach.proto.Admi"
+    "nSplitRequest\0227\n\013admin_merge\030\n \001(\0132\".coc"
+    "kroach.proto.AdminMergeRequest\022;\n\rheartb"
+    "eat_txn\030\013 \001(\0132$.cockroach.proto.Heartbea"
+    "tTxnRequest\022&\n\002gc\030\014 \001(\0132\032.cockroach.prot"
+    "o.GCRequest\0221\n\010push_txn\030\r \001(\0132\037.cockroac"
+    "h.proto.PushTxnRequest\0229\n\014range_lookup\030\016"
+    " \001(\0132#.cockroach.proto.RangeLookupReques"
+    "t\022=\n\016resolve_intent\030\017 \001(\0132%.cockroach.pr"
+    "oto.ResolveIntentRequest\022H\n\024resolve_inte"
+    "nt_range\030\020 \001(\0132*.cockroach.proto.Resolve"
+    "IntentRangeRequest\022,\n\005merge\030\021 \001(\0132\035.cock"
+    "roach.proto.MergeRequest\0229\n\014truncate_log"
+    "\030\022 \001(\0132#.cockroach.proto.TruncateLogRequ"
+    "est\0229\n\014leader_lease\030\023 \001(\0132#.cockroach.pr"
+    "oto.LeaderLeaseRequest\0229\n\014reverse_scan\030\024"
+    " \001(\0132#.cockroach.proto.ReverseScanReques"
+    "t\022*\n\004noop\030\025 \001(\0132\034.cockroach.proto.NoopRe"
+    "quest:\004\310\240\037\001\"\246\t\n\rResponseUnion\022)\n\003get\030\001 \001"
+    "(\0132\034.cockroach.proto.GetResponse\022)\n\003put\030"
+    "\002 \001(\0132\034.cockroach.proto.PutResponse\022@\n\017c"
+    "onditional_put\030\003 \001(\0132\'.cockroach.proto.C"
+    "onditionalPutResponse\0225\n\tincrement\030\004 \001(\013"
+    "2\".cockroach.proto.IncrementResponse\022/\n\006"
+    "delete\030\005 \001(\0132\037.cockroach.proto.DeleteRes"
+    "ponse\022:\n\014delete_range\030\006 \001(\0132$.cockroach."
+    "proto.DeleteRangeResponse\022+\n\004scan\030\007 \001(\0132"
+    "\035.cockroach.proto.ScanResponse\022@\n\017end_tr"
+    "ansaction\030\010 \001(\0132\'.cockroach.proto.EndTra"
+    "nsactionResponse\0228\n\013admin_split\030\t \001(\0132#."
+    "cockroach.proto.AdminSplitResponse\0228\n\013ad"
+    "min_merge\030\n \001(\0132#.cockroach.proto.AdminM"
+    "ergeResponse\022<\n\rheartbeat_txn\030\013 \001(\0132%.co"
+    "ckroach.proto.HeartbeatTxnResponse\022\'\n\002gc"
+    "\030\014 \001(\0132\033.cockroach.proto.GCResponse\0222\n\010p"
+    "ush_txn\030\r \001(\0132 .cockroach.proto.PushTxnR"
+    "esponse\022:\n\014range_lookup\030\016 \001(\0132$.cockroac"
+    "h.proto.RangeLookupResponse\022>\n\016resolve_i"
+    "ntent\030\017 \001(\0132&.cockroach.proto.ResolveInt"
+    "entResponse\022I\n\024resolve_intent_range\030\020 \001("
+    "\0132+.cockroach.proto.ResolveIntentRangeRe"
+    "sponse\022-\n\005merge\030\021 \001(\0132\036.cockroach.proto."
+    "MergeResponse\022:\n\014truncate_log\030\022 \001(\0132$.co"
+    "ckroach.proto.TruncateLogResponse\022:\n\014lea"
+    "der_lease\030\023 \001(\0132$.cockroach.proto.Leader"
+    "LeaseResponse\022:\n\014reverse_scan\030\024 \001(\0132$.co"
+    "ckroach.proto.ReverseScanResponse\022+\n\004noo"
+    "p\030\025 \001(\0132\035.cockroach.proto.NoopResponse:\004"
+    "\310\240\037\001\"\205\001\n\014BatchRequest\0228\n\006header\030\001 \001(\0132\036."
+    "cockroach.proto.RequestHeaderB\010\310\336\037\000\320\336\037\001\022"
+    "5\n\010requests\030\002 \003(\0132\035.cockroach.proto.Requ"
+    "estUnionB\004\310\336\037\000:\004\230\240\037\000\"\203\001\n\rBatchResponse\0229"
+    "\n\006header\030\001 \001(\0132\037.cockroach.proto.Respons"
+    "eHeaderB\010\310\336\037\000\320\336\037\001\0227\n\tresponses\030\002 \003(\0132\036.c"
+    "ockroach.proto.ResponseUnionB\004\310\336\037\000*L\n\023Re"
+    "adConsistencyType\022\016\n\nCONSISTENT\020\000\022\r\n\tCON"
+    "SENSUS\020\001\022\020\n\014INCONSISTENT\020\002\032\004\210\243\036\000*G\n\013Push"
+    "TxnType\022\022\n\016PUSH_TIMESTAMP\020\000\022\r\n\tABORT_TXN"
+    "\020\001\022\017\n\013CLEANUP_TXN\020\002\032\004\210\243\036\000B\027Z\005proto\340\342\036\001\310\342"
+    "\036\001\320\342\036\001\220\343\036\000", 8410);
   ::google::protobuf::MessageFactory::InternalRegisterGeneratedFile(
     "cockroach/proto/api.proto", &protobuf_RegisterTypes);
   ClientCmdID::default_instance_ = new ClientCmdID();
@@ -1973,7 +1974,7 @@ RequestHeader::RequestHeader()
 void RequestHeader::InitAsDefaultInstance() {
   timestamp_ = const_cast< ::cockroach::proto::Timestamp*>(&::cockroach::proto::Timestamp::default_instance());
   cmd_id_ = const_cast< ::cockroach::proto::ClientCmdID*>(&::cockroach::proto::ClientCmdID::default_instance());
-  replica_ = const_cast< ::cockroach::proto::Replica*>(&::cockroach::proto::Replica::default_instance());
+  replica_ = const_cast< ::cockroach::proto::ReplicaDescriptor*>(&::cockroach::proto::ReplicaDescriptor::default_instance());
   txn_ = const_cast< ::cockroach::proto::Transaction*>(&::cockroach::proto::Transaction::default_instance());
 }
 
@@ -2056,7 +2057,7 @@ void RequestHeader::Clear() {
       end_key_.ClearToEmptyNoArena(&::google::protobuf::internal::GetEmptyStringAlreadyInited());
     }
     if (has_replica()) {
-      if (replica_ != NULL) replica_->::cockroach::proto::Replica::Clear();
+      if (replica_ != NULL) replica_->::cockroach::proto::ReplicaDescriptor::Clear();
     }
     range_id_ = GOOGLE_LONGLONG(0);
     user_priority_ = 1;
@@ -2132,7 +2133,7 @@ bool RequestHeader::MergePartialFromCodedStream(
         break;
       }
 
-      // optional .cockroach.proto.Replica replica = 5;
+      // optional .cockroach.proto.ReplicaDescriptor replica = 5;
       case 5: {
         if (tag == 42) {
          parse_replica:
@@ -2257,7 +2258,7 @@ void RequestHeader::SerializeWithCachedSizes(
       4, this->end_key(), output);
   }
 
-  // optional .cockroach.proto.Replica replica = 5;
+  // optional .cockroach.proto.ReplicaDescriptor replica = 5;
   if (has_replica()) {
     ::google::protobuf::internal::WireFormatLite::WriteMessageMaybeToArray(
       5, *this->replica_, output);
@@ -2323,7 +2324,7 @@ void RequestHeader::SerializeWithCachedSizes(
         4, this->end_key(), target);
   }
 
-  // optional .cockroach.proto.Replica replica = 5;
+  // optional .cockroach.proto.ReplicaDescriptor replica = 5;
   if (has_replica()) {
     target = ::google::protobuf::internal::WireFormatLite::
       WriteMessageNoVirtualToArray(
@@ -2393,7 +2394,7 @@ int RequestHeader::ByteSize() const {
           this->end_key());
     }
 
-    // optional .cockroach.proto.Replica replica = 5;
+    // optional .cockroach.proto.ReplicaDescriptor replica = 5;
     if (has_replica()) {
       total_size += 1 +
         ::google::protobuf::internal::WireFormatLite::MessageSizeNoVirtual(
@@ -2469,7 +2470,7 @@ void RequestHeader::MergeFrom(const RequestHeader& from) {
       end_key_.AssignWithDefault(&::google::protobuf::internal::GetEmptyStringAlreadyInited(), from.end_key_);
     }
     if (from.has_replica()) {
-      mutable_replica()->::cockroach::proto::Replica::MergeFrom(from.replica());
+      mutable_replica()->::cockroach::proto::ReplicaDescriptor::MergeFrom(from.replica());
     }
     if (from.has_range_id()) {
       set_range_id(from.range_id());
@@ -2730,7 +2731,7 @@ void RequestHeader::clear_end_key() {
   // @@protoc_insertion_point(field_set_allocated:cockroach.proto.RequestHeader.end_key)
 }
 
-// optional .cockroach.proto.Replica replica = 5;
+// optional .cockroach.proto.ReplicaDescriptor replica = 5;
 bool RequestHeader::has_replica() const {
   return (_has_bits_[0] & 0x00000010u) != 0;
 }
@@ -2741,28 +2742,28 @@ void RequestHeader::clear_has_replica() {
   _has_bits_[0] &= ~0x00000010u;
 }
 void RequestHeader::clear_replica() {
-  if (replica_ != NULL) replica_->::cockroach::proto::Replica::Clear();
+  if (replica_ != NULL) replica_->::cockroach::proto::ReplicaDescriptor::Clear();
   clear_has_replica();
 }
- const ::cockroach::proto::Replica& RequestHeader::replica() const {
+ const ::cockroach::proto::ReplicaDescriptor& RequestHeader::replica() const {
   // @@protoc_insertion_point(field_get:cockroach.proto.RequestHeader.replica)
   return replica_ != NULL ? *replica_ : *default_instance_->replica_;
 }
- ::cockroach::proto::Replica* RequestHeader::mutable_replica() {
+ ::cockroach::proto::ReplicaDescriptor* RequestHeader::mutable_replica() {
   set_has_replica();
   if (replica_ == NULL) {
-    replica_ = new ::cockroach::proto::Replica;
+    replica_ = new ::cockroach::proto::ReplicaDescriptor;
   }
   // @@protoc_insertion_point(field_mutable:cockroach.proto.RequestHeader.replica)
   return replica_;
 }
- ::cockroach::proto::Replica* RequestHeader::release_replica() {
+ ::cockroach::proto::ReplicaDescriptor* RequestHeader::release_replica() {
   clear_has_replica();
-  ::cockroach::proto::Replica* temp = replica_;
+  ::cockroach::proto::ReplicaDescriptor* temp = replica_;
   replica_ = NULL;
   return temp;
 }
- void RequestHeader::set_allocated_replica(::cockroach::proto::Replica* replica) {
+ void RequestHeader::set_allocated_replica(::cockroach::proto::ReplicaDescriptor* replica) {
   delete replica_;
   replica_ = replica;
   if (replica) {

--- a/storage/engine/rocksdb/cockroach/proto/api.pb.h
+++ b/storage/engine/rocksdb/cockroach/proto/api.pb.h
@@ -340,14 +340,14 @@ class RequestHeader : public ::google::protobuf::Message {
   ::std::string* release_end_key();
   void set_allocated_end_key(::std::string* end_key);
 
-  // optional .cockroach.proto.Replica replica = 5;
+  // optional .cockroach.proto.ReplicaDescriptor replica = 5;
   bool has_replica() const;
   void clear_replica();
   static const int kReplicaFieldNumber = 5;
-  const ::cockroach::proto::Replica& replica() const;
-  ::cockroach::proto::Replica* mutable_replica();
-  ::cockroach::proto::Replica* release_replica();
-  void set_allocated_replica(::cockroach::proto::Replica* replica);
+  const ::cockroach::proto::ReplicaDescriptor& replica() const;
+  ::cockroach::proto::ReplicaDescriptor* mutable_replica();
+  ::cockroach::proto::ReplicaDescriptor* release_replica();
+  void set_allocated_replica(::cockroach::proto::ReplicaDescriptor* replica);
 
   // optional int64 range_id = 6;
   bool has_range_id() const;
@@ -407,7 +407,7 @@ class RequestHeader : public ::google::protobuf::Message {
   ::cockroach::proto::ClientCmdID* cmd_id_;
   ::google::protobuf::internal::ArenaStringPtr key_;
   ::google::protobuf::internal::ArenaStringPtr end_key_;
-  ::cockroach::proto::Replica* replica_;
+  ::cockroach::proto::ReplicaDescriptor* replica_;
   ::google::protobuf::int64 range_id_;
   ::cockroach::proto::Transaction* txn_;
   ::google::protobuf::int32 user_priority_;
@@ -5981,7 +5981,7 @@ inline void RequestHeader::set_allocated_end_key(::std::string* end_key) {
   // @@protoc_insertion_point(field_set_allocated:cockroach.proto.RequestHeader.end_key)
 }
 
-// optional .cockroach.proto.Replica replica = 5;
+// optional .cockroach.proto.ReplicaDescriptor replica = 5;
 inline bool RequestHeader::has_replica() const {
   return (_has_bits_[0] & 0x00000010u) != 0;
 }
@@ -5992,28 +5992,28 @@ inline void RequestHeader::clear_has_replica() {
   _has_bits_[0] &= ~0x00000010u;
 }
 inline void RequestHeader::clear_replica() {
-  if (replica_ != NULL) replica_->::cockroach::proto::Replica::Clear();
+  if (replica_ != NULL) replica_->::cockroach::proto::ReplicaDescriptor::Clear();
   clear_has_replica();
 }
-inline const ::cockroach::proto::Replica& RequestHeader::replica() const {
+inline const ::cockroach::proto::ReplicaDescriptor& RequestHeader::replica() const {
   // @@protoc_insertion_point(field_get:cockroach.proto.RequestHeader.replica)
   return replica_ != NULL ? *replica_ : *default_instance_->replica_;
 }
-inline ::cockroach::proto::Replica* RequestHeader::mutable_replica() {
+inline ::cockroach::proto::ReplicaDescriptor* RequestHeader::mutable_replica() {
   set_has_replica();
   if (replica_ == NULL) {
-    replica_ = new ::cockroach::proto::Replica;
+    replica_ = new ::cockroach::proto::ReplicaDescriptor;
   }
   // @@protoc_insertion_point(field_mutable:cockroach.proto.RequestHeader.replica)
   return replica_;
 }
-inline ::cockroach::proto::Replica* RequestHeader::release_replica() {
+inline ::cockroach::proto::ReplicaDescriptor* RequestHeader::release_replica() {
   clear_has_replica();
-  ::cockroach::proto::Replica* temp = replica_;
+  ::cockroach::proto::ReplicaDescriptor* temp = replica_;
   replica_ = NULL;
   return temp;
 }
-inline void RequestHeader::set_allocated_replica(::cockroach::proto::Replica* replica) {
+inline void RequestHeader::set_allocated_replica(::cockroach::proto::ReplicaDescriptor* replica) {
   delete replica_;
   replica_ = replica;
   if (replica) {

--- a/storage/engine/rocksdb/cockroach/proto/data.pb.cc
+++ b/storage/engine/rocksdb/cockroach/proto/data.pb.cc
@@ -453,55 +453,56 @@ void protobuf_AddDesc_cockroach_2fproto_2fdata_2eproto() {
     "\000\"\213\001\n\014MergeTrigger\022<\n\014updated_desc\030\001 \001(\013"
     "2 .cockroach.proto.RangeDescriptorB\004\310\336\037\000"
     "\022=\n\021subsumed_range_id\030\002 \001(\003B\"\310\336\037\000\342\336\037\017Sub"
-    "sumedRangeID\372\336\037\007RangeID\"\327\002\n\025ChangeReplic"
+    "sumedRangeID\372\336\037\007RangeID\"\353\002\n\025ChangeReplic"
     "asTrigger\022)\n\007node_id\030\001 \001(\005B\030\310\336\037\000\342\336\037\006Node"
     "ID\372\336\037\006NodeID\022,\n\010store_id\030\002 \001(\005B\032\310\336\037\000\342\336\037\007"
     "StoreID\372\336\037\007StoreID\022=\n\013change_type\030\003 \001(\0162"
     "\".cockroach.proto.ReplicaChangeTypeB\004\310\336\037"
-    "\000\022/\n\007replica\030\004 \001(\0132\030.cockroach.proto.Rep"
-    "licaB\004\310\336\037\000\0228\n\020updated_replicas\030\005 \003(\0132\030.c"
-    "ockroach.proto.ReplicaB\004\310\336\037\000\022;\n\017next_rep"
-    "lica_id\030\006 \001(\005B\"\310\336\037\000\342\336\037\rNextReplicaID\372\336\037\t"
-    "ReplicaID\"C\n\023ModifiedSpanTrigger\022,\n\016syst"
-    "em_db_span\030\001 \001(\010B\024\310\336\037\000\342\336\037\014SystemDBSpan\"\221"
-    "\002\n\025InternalCommitTrigger\0224\n\rsplit_trigge"
-    "r\030\001 \001(\0132\035.cockroach.proto.SplitTrigger\0224"
-    "\n\rmerge_trigger\030\002 \001(\0132\035.cockroach.proto."
-    "MergeTrigger\022G\n\027change_replicas_trigger\030"
-    "\003 \001(\0132&.cockroach.proto.ChangeReplicasTr"
-    "igger\022C\n\025modified_span_trigger\030\004 \001(\0132$.c"
-    "ockroach.proto.ModifiedSpanTrigger\"\035\n\010No"
-    "deList\022\021\n\005nodes\030\001 \003(\005B\002\020\001\"\234\004\n\013Transactio"
-    "n\022\022\n\004name\030\001 \001(\tB\004\310\336\037\000\022\024\n\003key\030\002 \001(\014B\007\372\336\037\003"
-    "Key\022\022\n\002id\030\003 \001(\014B\006\342\336\037\002ID\022\026\n\010priority\030\004 \001("
-    "\005B\004\310\336\037\000\0227\n\tisolation\030\005 \001(\0162\036.cockroach.p"
-    "roto.IsolationTypeB\004\310\336\037\000\0228\n\006status\030\006 \001(\016"
-    "2\".cockroach.proto.TransactionStatusB\004\310\336"
-    "\037\000\022\023\n\005epoch\030\007 \001(\005B\004\310\336\037\000\0222\n\016last_heartbea"
-    "t\030\010 \001(\0132\032.cockroach.proto.Timestamp\0223\n\tt"
-    "imestamp\030\t \001(\0132\032.cockroach.proto.Timesta"
-    "mpB\004\310\336\037\000\0228\n\016orig_timestamp\030\n \001(\0132\032.cockr"
-    "oach.proto.TimestampB\004\310\336\037\000\0227\n\rmax_timest"
-    "amp\030\013 \001(\0132\032.cockroach.proto.TimestampB\004\310"
-    "\336\037\000\0226\n\rcertain_nodes\030\014 \001(\0132\031.cockroach.p"
-    "roto.NodeListB\004\310\336\037\000\022\025\n\007Writing\030\r \001(\010B\004\310\336"
-    "\037\000:\004\230\240\037\000\"\245\001\n\005Lease\022/\n\005start\030\001 \001(\0132\032.cock"
-    "roach.proto.TimestampB\004\310\336\037\000\0224\n\nexpiratio"
-    "n\030\002 \001(\0132\032.cockroach.proto.TimestampB\004\310\336\037"
-    "\000\022/\n\007replica\030\003 \001(\0132\030.cockroach.proto.Rep"
-    "licaB\004\310\336\037\000:\004\230\240\037\000\"i\n\006Intent\022\024\n\003key\030\001 \001(\014B"
-    "\007\372\336\037\003Key\022\030\n\007end_key\030\002 \001(\014B\007\372\336\037\003Key\022/\n\003tx"
-    "n\030\003 \001(\0132\034.cockroach.proto.TransactionB\004\310"
-    "\336\037\000\"H\n\nGCMetadata\022\035\n\017last_scan_nanos\030\001 \001"
-    "(\003B\004\310\336\037\000\022\033\n\023oldest_intent_nanos\030\002 \001(\003*Q\n"
-    "\tValueType\022\013\n\007UNKNOWN\020\000\022\007\n\003INT\020\001\022\t\n\005FLOA"
-    "T\020\002\022\t\n\005BYTES\020\003\022\010\n\004TIME\020\004\022\016\n\nTIMESERIES\020d"
-    "*>\n\021ReplicaChangeType\022\017\n\013ADD_REPLICA\020\000\022\022"
-    "\n\016REMOVE_REPLICA\020\001\032\004\210\243\036\000*5\n\rIsolationTyp"
-    "e\022\020\n\014SERIALIZABLE\020\000\022\014\n\010SNAPSHOT\020\001\032\004\210\243\036\000*"
-    "B\n\021TransactionStatus\022\013\n\007PENDING\020\000\022\r\n\tCOM"
-    "MITTED\020\001\022\013\n\007ABORTED\020\002\032\004\210\243\036\000B\027Z\005proto\340\342\036\001"
-    "\310\342\036\001\320\342\036\001\220\343\036\000", 2772);
+    "\000\0229\n\007replica\030\004 \001(\0132\".cockroach.proto.Rep"
+    "licaDescriptorB\004\310\336\037\000\022B\n\020updated_replicas"
+    "\030\005 \003(\0132\".cockroach.proto.ReplicaDescript"
+    "orB\004\310\336\037\000\022;\n\017next_replica_id\030\006 \001(\005B\"\310\336\037\000\342"
+    "\336\037\rNextReplicaID\372\336\037\tReplicaID\"C\n\023Modifie"
+    "dSpanTrigger\022,\n\016system_db_span\030\001 \001(\010B\024\310\336"
+    "\037\000\342\336\037\014SystemDBSpan\"\221\002\n\025InternalCommitTri"
+    "gger\0224\n\rsplit_trigger\030\001 \001(\0132\035.cockroach."
+    "proto.SplitTrigger\0224\n\rmerge_trigger\030\002 \001("
+    "\0132\035.cockroach.proto.MergeTrigger\022G\n\027chan"
+    "ge_replicas_trigger\030\003 \001(\0132&.cockroach.pr"
+    "oto.ChangeReplicasTrigger\022C\n\025modified_sp"
+    "an_trigger\030\004 \001(\0132$.cockroach.proto.Modif"
+    "iedSpanTrigger\"\035\n\010NodeList\022\021\n\005nodes\030\001 \003("
+    "\005B\002\020\001\"\234\004\n\013Transaction\022\022\n\004name\030\001 \001(\tB\004\310\336\037"
+    "\000\022\024\n\003key\030\002 \001(\014B\007\372\336\037\003Key\022\022\n\002id\030\003 \001(\014B\006\342\336\037"
+    "\002ID\022\026\n\010priority\030\004 \001(\005B\004\310\336\037\000\0227\n\tisolation"
+    "\030\005 \001(\0162\036.cockroach.proto.IsolationTypeB\004"
+    "\310\336\037\000\0228\n\006status\030\006 \001(\0162\".cockroach.proto.T"
+    "ransactionStatusB\004\310\336\037\000\022\023\n\005epoch\030\007 \001(\005B\004\310"
+    "\336\037\000\0222\n\016last_heartbeat\030\010 \001(\0132\032.cockroach."
+    "proto.Timestamp\0223\n\ttimestamp\030\t \001(\0132\032.coc"
+    "kroach.proto.TimestampB\004\310\336\037\000\0228\n\016orig_tim"
+    "estamp\030\n \001(\0132\032.cockroach.proto.Timestamp"
+    "B\004\310\336\037\000\0227\n\rmax_timestamp\030\013 \001(\0132\032.cockroac"
+    "h.proto.TimestampB\004\310\336\037\000\0226\n\rcertain_nodes"
+    "\030\014 \001(\0132\031.cockroach.proto.NodeListB\004\310\336\037\000\022"
+    "\025\n\007Writing\030\r \001(\010B\004\310\336\037\000:\004\230\240\037\000\"\257\001\n\005Lease\022/"
+    "\n\005start\030\001 \001(\0132\032.cockroach.proto.Timestam"
+    "pB\004\310\336\037\000\0224\n\nexpiration\030\002 \001(\0132\032.cockroach."
+    "proto.TimestampB\004\310\336\037\000\0229\n\007replica\030\003 \001(\0132\""
+    ".cockroach.proto.ReplicaDescriptorB\004\310\336\037\000"
+    ":\004\230\240\037\000\"i\n\006Intent\022\024\n\003key\030\001 \001(\014B\007\372\336\037\003Key\022\030"
+    "\n\007end_key\030\002 \001(\014B\007\372\336\037\003Key\022/\n\003txn\030\003 \001(\0132\034."
+    "cockroach.proto.TransactionB\004\310\336\037\000\"H\n\nGCM"
+    "etadata\022\035\n\017last_scan_nanos\030\001 \001(\003B\004\310\336\037\000\022\033"
+    "\n\023oldest_intent_nanos\030\002 \001(\003*Q\n\tValueType"
+    "\022\013\n\007UNKNOWN\020\000\022\007\n\003INT\020\001\022\t\n\005FLOAT\020\002\022\t\n\005BYT"
+    "ES\020\003\022\010\n\004TIME\020\004\022\016\n\nTIMESERIES\020d*>\n\021Replic"
+    "aChangeType\022\017\n\013ADD_REPLICA\020\000\022\022\n\016REMOVE_R"
+    "EPLICA\020\001\032\004\210\243\036\000*5\n\rIsolationType\022\020\n\014SERIA"
+    "LIZABLE\020\000\022\014\n\010SNAPSHOT\020\001\032\004\210\243\036\000*B\n\021Transac"
+    "tionStatus\022\013\n\007PENDING\020\000\022\r\n\tCOMMITTED\020\001\022\013"
+    "\n\007ABORTED\020\002\032\004\210\243\036\000B\027Z\005proto\340\342\036\001\310\342\036\001\320\342\036\001\220\343"
+    "\036\000", 2802);
   ::google::protobuf::MessageFactory::InternalRegisterGeneratedFile(
     "cockroach/proto/data.proto", &protobuf_RegisterTypes);
   Timestamp::default_instance_ = new Timestamp();
@@ -3446,7 +3447,7 @@ ChangeReplicasTrigger::ChangeReplicasTrigger()
 }
 
 void ChangeReplicasTrigger::InitAsDefaultInstance() {
-  replica_ = const_cast< ::cockroach::proto::Replica*>(&::cockroach::proto::Replica::default_instance());
+  replica_ = const_cast< ::cockroach::proto::ReplicaDescriptor*>(&::cockroach::proto::ReplicaDescriptor::default_instance());
 }
 
 ChangeReplicasTrigger::ChangeReplicasTrigger(const ChangeReplicasTrigger& from)
@@ -3516,7 +3517,7 @@ void ChangeReplicasTrigger::Clear() {
     ZR_(node_id_, store_id_);
     ZR_(change_type_, next_replica_id_);
     if (has_replica()) {
-      if (replica_ != NULL) replica_->::cockroach::proto::Replica::Clear();
+      if (replica_ != NULL) replica_->::cockroach::proto::ReplicaDescriptor::Clear();
     }
   }
 
@@ -3589,7 +3590,7 @@ bool ChangeReplicasTrigger::MergePartialFromCodedStream(
         break;
       }
 
-      // optional .cockroach.proto.Replica replica = 4;
+      // optional .cockroach.proto.ReplicaDescriptor replica = 4;
       case 4: {
         if (tag == 34) {
          parse_replica:
@@ -3602,7 +3603,7 @@ bool ChangeReplicasTrigger::MergePartialFromCodedStream(
         break;
       }
 
-      // repeated .cockroach.proto.Replica updated_replicas = 5;
+      // repeated .cockroach.proto.ReplicaDescriptor updated_replicas = 5;
       case 5: {
         if (tag == 42) {
          parse_updated_replicas:
@@ -3675,13 +3676,13 @@ void ChangeReplicasTrigger::SerializeWithCachedSizes(
       3, this->change_type(), output);
   }
 
-  // optional .cockroach.proto.Replica replica = 4;
+  // optional .cockroach.proto.ReplicaDescriptor replica = 4;
   if (has_replica()) {
     ::google::protobuf::internal::WireFormatLite::WriteMessageMaybeToArray(
       4, *this->replica_, output);
   }
 
-  // repeated .cockroach.proto.Replica updated_replicas = 5;
+  // repeated .cockroach.proto.ReplicaDescriptor updated_replicas = 5;
   for (unsigned int i = 0, n = this->updated_replicas_size(); i < n; i++) {
     ::google::protobuf::internal::WireFormatLite::WriteMessageMaybeToArray(
       5, this->updated_replicas(i), output);
@@ -3718,14 +3719,14 @@ void ChangeReplicasTrigger::SerializeWithCachedSizes(
       3, this->change_type(), target);
   }
 
-  // optional .cockroach.proto.Replica replica = 4;
+  // optional .cockroach.proto.ReplicaDescriptor replica = 4;
   if (has_replica()) {
     target = ::google::protobuf::internal::WireFormatLite::
       WriteMessageNoVirtualToArray(
         4, *this->replica_, target);
   }
 
-  // repeated .cockroach.proto.Replica updated_replicas = 5;
+  // repeated .cockroach.proto.ReplicaDescriptor updated_replicas = 5;
   for (unsigned int i = 0, n = this->updated_replicas_size(); i < n; i++) {
     target = ::google::protobuf::internal::WireFormatLite::
       WriteMessageNoVirtualToArray(
@@ -3769,7 +3770,7 @@ int ChangeReplicasTrigger::ByteSize() const {
         ::google::protobuf::internal::WireFormatLite::EnumSize(this->change_type());
     }
 
-    // optional .cockroach.proto.Replica replica = 4;
+    // optional .cockroach.proto.ReplicaDescriptor replica = 4;
     if (has_replica()) {
       total_size += 1 +
         ::google::protobuf::internal::WireFormatLite::MessageSizeNoVirtual(
@@ -3784,7 +3785,7 @@ int ChangeReplicasTrigger::ByteSize() const {
     }
 
   }
-  // repeated .cockroach.proto.Replica updated_replicas = 5;
+  // repeated .cockroach.proto.ReplicaDescriptor updated_replicas = 5;
   total_size += 1 * this->updated_replicas_size();
   for (int i = 0; i < this->updated_replicas_size(); i++) {
     total_size +=
@@ -3829,7 +3830,7 @@ void ChangeReplicasTrigger::MergeFrom(const ChangeReplicasTrigger& from) {
       set_change_type(from.change_type());
     }
     if (from.has_replica()) {
-      mutable_replica()->::cockroach::proto::Replica::MergeFrom(from.replica());
+      mutable_replica()->::cockroach::proto::ReplicaDescriptor::MergeFrom(from.replica());
     }
     if (from.has_next_replica_id()) {
       set_next_replica_id(from.next_replica_id());
@@ -3957,7 +3958,7 @@ void ChangeReplicasTrigger::clear_change_type() {
   // @@protoc_insertion_point(field_set:cockroach.proto.ChangeReplicasTrigger.change_type)
 }
 
-// optional .cockroach.proto.Replica replica = 4;
+// optional .cockroach.proto.ReplicaDescriptor replica = 4;
 bool ChangeReplicasTrigger::has_replica() const {
   return (_has_bits_[0] & 0x00000008u) != 0;
 }
@@ -3968,28 +3969,28 @@ void ChangeReplicasTrigger::clear_has_replica() {
   _has_bits_[0] &= ~0x00000008u;
 }
 void ChangeReplicasTrigger::clear_replica() {
-  if (replica_ != NULL) replica_->::cockroach::proto::Replica::Clear();
+  if (replica_ != NULL) replica_->::cockroach::proto::ReplicaDescriptor::Clear();
   clear_has_replica();
 }
- const ::cockroach::proto::Replica& ChangeReplicasTrigger::replica() const {
+ const ::cockroach::proto::ReplicaDescriptor& ChangeReplicasTrigger::replica() const {
   // @@protoc_insertion_point(field_get:cockroach.proto.ChangeReplicasTrigger.replica)
   return replica_ != NULL ? *replica_ : *default_instance_->replica_;
 }
- ::cockroach::proto::Replica* ChangeReplicasTrigger::mutable_replica() {
+ ::cockroach::proto::ReplicaDescriptor* ChangeReplicasTrigger::mutable_replica() {
   set_has_replica();
   if (replica_ == NULL) {
-    replica_ = new ::cockroach::proto::Replica;
+    replica_ = new ::cockroach::proto::ReplicaDescriptor;
   }
   // @@protoc_insertion_point(field_mutable:cockroach.proto.ChangeReplicasTrigger.replica)
   return replica_;
 }
- ::cockroach::proto::Replica* ChangeReplicasTrigger::release_replica() {
+ ::cockroach::proto::ReplicaDescriptor* ChangeReplicasTrigger::release_replica() {
   clear_has_replica();
-  ::cockroach::proto::Replica* temp = replica_;
+  ::cockroach::proto::ReplicaDescriptor* temp = replica_;
   replica_ = NULL;
   return temp;
 }
- void ChangeReplicasTrigger::set_allocated_replica(::cockroach::proto::Replica* replica) {
+ void ChangeReplicasTrigger::set_allocated_replica(::cockroach::proto::ReplicaDescriptor* replica) {
   delete replica_;
   replica_ = replica;
   if (replica) {
@@ -4000,31 +4001,31 @@ void ChangeReplicasTrigger::clear_replica() {
   // @@protoc_insertion_point(field_set_allocated:cockroach.proto.ChangeReplicasTrigger.replica)
 }
 
-// repeated .cockroach.proto.Replica updated_replicas = 5;
+// repeated .cockroach.proto.ReplicaDescriptor updated_replicas = 5;
 int ChangeReplicasTrigger::updated_replicas_size() const {
   return updated_replicas_.size();
 }
 void ChangeReplicasTrigger::clear_updated_replicas() {
   updated_replicas_.Clear();
 }
- const ::cockroach::proto::Replica& ChangeReplicasTrigger::updated_replicas(int index) const {
+ const ::cockroach::proto::ReplicaDescriptor& ChangeReplicasTrigger::updated_replicas(int index) const {
   // @@protoc_insertion_point(field_get:cockroach.proto.ChangeReplicasTrigger.updated_replicas)
   return updated_replicas_.Get(index);
 }
- ::cockroach::proto::Replica* ChangeReplicasTrigger::mutable_updated_replicas(int index) {
+ ::cockroach::proto::ReplicaDescriptor* ChangeReplicasTrigger::mutable_updated_replicas(int index) {
   // @@protoc_insertion_point(field_mutable:cockroach.proto.ChangeReplicasTrigger.updated_replicas)
   return updated_replicas_.Mutable(index);
 }
- ::cockroach::proto::Replica* ChangeReplicasTrigger::add_updated_replicas() {
+ ::cockroach::proto::ReplicaDescriptor* ChangeReplicasTrigger::add_updated_replicas() {
   // @@protoc_insertion_point(field_add:cockroach.proto.ChangeReplicasTrigger.updated_replicas)
   return updated_replicas_.Add();
 }
- const ::google::protobuf::RepeatedPtrField< ::cockroach::proto::Replica >&
+ const ::google::protobuf::RepeatedPtrField< ::cockroach::proto::ReplicaDescriptor >&
 ChangeReplicasTrigger::updated_replicas() const {
   // @@protoc_insertion_point(field_list:cockroach.proto.ChangeReplicasTrigger.updated_replicas)
   return updated_replicas_;
 }
- ::google::protobuf::RepeatedPtrField< ::cockroach::proto::Replica >*
+ ::google::protobuf::RepeatedPtrField< ::cockroach::proto::ReplicaDescriptor >*
 ChangeReplicasTrigger::mutable_updated_replicas() {
   // @@protoc_insertion_point(field_mutable_list:cockroach.proto.ChangeReplicasTrigger.updated_replicas)
   return &updated_replicas_;
@@ -6446,7 +6447,7 @@ Lease::Lease()
 void Lease::InitAsDefaultInstance() {
   start_ = const_cast< ::cockroach::proto::Timestamp*>(&::cockroach::proto::Timestamp::default_instance());
   expiration_ = const_cast< ::cockroach::proto::Timestamp*>(&::cockroach::proto::Timestamp::default_instance());
-  replica_ = const_cast< ::cockroach::proto::Replica*>(&::cockroach::proto::Replica::default_instance());
+  replica_ = const_cast< ::cockroach::proto::ReplicaDescriptor*>(&::cockroach::proto::ReplicaDescriptor::default_instance());
 }
 
 Lease::Lease(const Lease& from)
@@ -6512,7 +6513,7 @@ void Lease::Clear() {
       if (expiration_ != NULL) expiration_->::cockroach::proto::Timestamp::Clear();
     }
     if (has_replica()) {
-      if (replica_ != NULL) replica_->::cockroach::proto::Replica::Clear();
+      if (replica_ != NULL) replica_->::cockroach::proto::ReplicaDescriptor::Clear();
     }
   }
   ::memset(_has_bits_, 0, sizeof(_has_bits_));
@@ -6556,7 +6557,7 @@ bool Lease::MergePartialFromCodedStream(
         break;
       }
 
-      // optional .cockroach.proto.Replica replica = 3;
+      // optional .cockroach.proto.ReplicaDescriptor replica = 3;
       case 3: {
         if (tag == 26) {
          parse_replica:
@@ -6606,7 +6607,7 @@ void Lease::SerializeWithCachedSizes(
       2, *this->expiration_, output);
   }
 
-  // optional .cockroach.proto.Replica replica = 3;
+  // optional .cockroach.proto.ReplicaDescriptor replica = 3;
   if (has_replica()) {
     ::google::protobuf::internal::WireFormatLite::WriteMessageMaybeToArray(
       3, *this->replica_, output);
@@ -6636,7 +6637,7 @@ void Lease::SerializeWithCachedSizes(
         2, *this->expiration_, target);
   }
 
-  // optional .cockroach.proto.Replica replica = 3;
+  // optional .cockroach.proto.ReplicaDescriptor replica = 3;
   if (has_replica()) {
     target = ::google::protobuf::internal::WireFormatLite::
       WriteMessageNoVirtualToArray(
@@ -6669,7 +6670,7 @@ int Lease::ByteSize() const {
           *this->expiration_);
     }
 
-    // optional .cockroach.proto.Replica replica = 3;
+    // optional .cockroach.proto.ReplicaDescriptor replica = 3;
     if (has_replica()) {
       total_size += 1 +
         ::google::protobuf::internal::WireFormatLite::MessageSizeNoVirtual(
@@ -6710,7 +6711,7 @@ void Lease::MergeFrom(const Lease& from) {
       mutable_expiration()->::cockroach::proto::Timestamp::MergeFrom(from.expiration());
     }
     if (from.has_replica()) {
-      mutable_replica()->::cockroach::proto::Replica::MergeFrom(from.replica());
+      mutable_replica()->::cockroach::proto::ReplicaDescriptor::MergeFrom(from.replica());
     }
   }
   if (from._internal_metadata_.have_unknown_fields()) {
@@ -6845,7 +6846,7 @@ void Lease::clear_expiration() {
   // @@protoc_insertion_point(field_set_allocated:cockroach.proto.Lease.expiration)
 }
 
-// optional .cockroach.proto.Replica replica = 3;
+// optional .cockroach.proto.ReplicaDescriptor replica = 3;
 bool Lease::has_replica() const {
   return (_has_bits_[0] & 0x00000004u) != 0;
 }
@@ -6856,28 +6857,28 @@ void Lease::clear_has_replica() {
   _has_bits_[0] &= ~0x00000004u;
 }
 void Lease::clear_replica() {
-  if (replica_ != NULL) replica_->::cockroach::proto::Replica::Clear();
+  if (replica_ != NULL) replica_->::cockroach::proto::ReplicaDescriptor::Clear();
   clear_has_replica();
 }
- const ::cockroach::proto::Replica& Lease::replica() const {
+ const ::cockroach::proto::ReplicaDescriptor& Lease::replica() const {
   // @@protoc_insertion_point(field_get:cockroach.proto.Lease.replica)
   return replica_ != NULL ? *replica_ : *default_instance_->replica_;
 }
- ::cockroach::proto::Replica* Lease::mutable_replica() {
+ ::cockroach::proto::ReplicaDescriptor* Lease::mutable_replica() {
   set_has_replica();
   if (replica_ == NULL) {
-    replica_ = new ::cockroach::proto::Replica;
+    replica_ = new ::cockroach::proto::ReplicaDescriptor;
   }
   // @@protoc_insertion_point(field_mutable:cockroach.proto.Lease.replica)
   return replica_;
 }
- ::cockroach::proto::Replica* Lease::release_replica() {
+ ::cockroach::proto::ReplicaDescriptor* Lease::release_replica() {
   clear_has_replica();
-  ::cockroach::proto::Replica* temp = replica_;
+  ::cockroach::proto::ReplicaDescriptor* temp = replica_;
   replica_ = NULL;
   return temp;
 }
- void Lease::set_allocated_replica(::cockroach::proto::Replica* replica) {
+ void Lease::set_allocated_replica(::cockroach::proto::ReplicaDescriptor* replica) {
   delete replica_;
   replica_ = replica;
   if (replica) {

--- a/storage/engine/rocksdb/cockroach/proto/data.pb.cc
+++ b/storage/engine/rocksdb/cockroach/proto/data.pb.cc
@@ -294,7 +294,7 @@ void protobuf_AssignDesc_cockroach_2fproto_2fdata_2eproto() {
   static const int Lease_offsets_[3] = {
     GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(Lease, start_),
     GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(Lease, expiration_),
-    GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(Lease, raft_node_id_),
+    GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(Lease, replica_),
   };
   Lease_reflection_ =
     ::google::protobuf::internal::GeneratedMessageReflection::NewGeneratedMessageReflection(
@@ -485,23 +485,23 @@ void protobuf_AddDesc_cockroach_2fproto_2fdata_2eproto() {
     "amp\030\013 \001(\0132\032.cockroach.proto.TimestampB\004\310"
     "\336\037\000\0226\n\rcertain_nodes\030\014 \001(\0132\031.cockroach.p"
     "roto.NodeListB\004\310\336\037\000\022\025\n\007Writing\030\r \001(\010B\004\310\336"
-    "\037\000:\004\230\240\037\000\"\254\001\n\005Lease\022/\n\005start\030\001 \001(\0132\032.cock"
+    "\037\000:\004\230\240\037\000\"\245\001\n\005Lease\022/\n\005start\030\001 \001(\0132\032.cock"
     "roach.proto.TimestampB\004\310\336\037\000\0224\n\nexpiratio"
     "n\030\002 \001(\0132\032.cockroach.proto.TimestampB\004\310\336\037"
-    "\000\0226\n\014raft_node_id\030\003 \001(\004B \310\336\037\000\342\336\037\nRaftNod"
-    "eID\372\336\037\nRaftNodeID:\004\230\240\037\000\"i\n\006Intent\022\024\n\003key"
-    "\030\001 \001(\014B\007\372\336\037\003Key\022\030\n\007end_key\030\002 \001(\014B\007\372\336\037\003Ke"
-    "y\022/\n\003txn\030\003 \001(\0132\034.cockroach.proto.Transac"
-    "tionB\004\310\336\037\000\"H\n\nGCMetadata\022\035\n\017last_scan_na"
-    "nos\030\001 \001(\003B\004\310\336\037\000\022\033\n\023oldest_intent_nanos\030\002"
-    " \001(\003*Q\n\tValueType\022\013\n\007UNKNOWN\020\000\022\007\n\003INT\020\001\022"
-    "\t\n\005FLOAT\020\002\022\t\n\005BYTES\020\003\022\010\n\004TIME\020\004\022\016\n\nTIMES"
-    "ERIES\020d*>\n\021ReplicaChangeType\022\017\n\013ADD_REPL"
-    "ICA\020\000\022\022\n\016REMOVE_REPLICA\020\001\032\004\210\243\036\000*5\n\rIsola"
-    "tionType\022\020\n\014SERIALIZABLE\020\000\022\014\n\010SNAPSHOT\020\001"
-    "\032\004\210\243\036\000*B\n\021TransactionStatus\022\013\n\007PENDING\020\000"
-    "\022\r\n\tCOMMITTED\020\001\022\013\n\007ABORTED\020\002\032\004\210\243\036\000B\027Z\005pr"
-    "oto\340\342\036\001\310\342\036\001\320\342\036\001\220\343\036\000", 2779);
+    "\000\022/\n\007replica\030\003 \001(\0132\030.cockroach.proto.Rep"
+    "licaB\004\310\336\037\000:\004\230\240\037\000\"i\n\006Intent\022\024\n\003key\030\001 \001(\014B"
+    "\007\372\336\037\003Key\022\030\n\007end_key\030\002 \001(\014B\007\372\336\037\003Key\022/\n\003tx"
+    "n\030\003 \001(\0132\034.cockroach.proto.TransactionB\004\310"
+    "\336\037\000\"H\n\nGCMetadata\022\035\n\017last_scan_nanos\030\001 \001"
+    "(\003B\004\310\336\037\000\022\033\n\023oldest_intent_nanos\030\002 \001(\003*Q\n"
+    "\tValueType\022\013\n\007UNKNOWN\020\000\022\007\n\003INT\020\001\022\t\n\005FLOA"
+    "T\020\002\022\t\n\005BYTES\020\003\022\010\n\004TIME\020\004\022\016\n\nTIMESERIES\020d"
+    "*>\n\021ReplicaChangeType\022\017\n\013ADD_REPLICA\020\000\022\022"
+    "\n\016REMOVE_REPLICA\020\001\032\004\210\243\036\000*5\n\rIsolationTyp"
+    "e\022\020\n\014SERIALIZABLE\020\000\022\014\n\010SNAPSHOT\020\001\032\004\210\243\036\000*"
+    "B\n\021TransactionStatus\022\013\n\007PENDING\020\000\022\r\n\tCOM"
+    "MITTED\020\001\022\013\n\007ABORTED\020\002\032\004\210\243\036\000B\027Z\005proto\340\342\036\001"
+    "\310\342\036\001\320\342\036\001\220\343\036\000", 2772);
   ::google::protobuf::MessageFactory::InternalRegisterGeneratedFile(
     "cockroach/proto/data.proto", &protobuf_RegisterTypes);
   Timestamp::default_instance_ = new Timestamp();
@@ -6434,7 +6434,7 @@ void Transaction::clear_writing() {
 #ifndef _MSC_VER
 const int Lease::kStartFieldNumber;
 const int Lease::kExpirationFieldNumber;
-const int Lease::kRaftNodeIdFieldNumber;
+const int Lease::kReplicaFieldNumber;
 #endif  // !_MSC_VER
 
 Lease::Lease()
@@ -6446,6 +6446,7 @@ Lease::Lease()
 void Lease::InitAsDefaultInstance() {
   start_ = const_cast< ::cockroach::proto::Timestamp*>(&::cockroach::proto::Timestamp::default_instance());
   expiration_ = const_cast< ::cockroach::proto::Timestamp*>(&::cockroach::proto::Timestamp::default_instance());
+  replica_ = const_cast< ::cockroach::proto::Replica*>(&::cockroach::proto::Replica::default_instance());
 }
 
 Lease::Lease(const Lease& from)
@@ -6460,7 +6461,7 @@ void Lease::SharedCtor() {
   _cached_size_ = 0;
   start_ = NULL;
   expiration_ = NULL;
-  raft_node_id_ = GOOGLE_ULONGLONG(0);
+  replica_ = NULL;
   ::memset(_has_bits_, 0, sizeof(_has_bits_));
 }
 
@@ -6473,6 +6474,7 @@ void Lease::SharedDtor() {
   if (this != default_instance_) {
     delete start_;
     delete expiration_;
+    delete replica_;
   }
 }
 
@@ -6509,7 +6511,9 @@ void Lease::Clear() {
     if (has_expiration()) {
       if (expiration_ != NULL) expiration_->::cockroach::proto::Timestamp::Clear();
     }
-    raft_node_id_ = GOOGLE_ULONGLONG(0);
+    if (has_replica()) {
+      if (replica_ != NULL) replica_->::cockroach::proto::Replica::Clear();
+    }
   }
   ::memset(_has_bits_, 0, sizeof(_has_bits_));
   if (_internal_metadata_.have_unknown_fields()) {
@@ -6548,18 +6552,16 @@ bool Lease::MergePartialFromCodedStream(
         } else {
           goto handle_unusual;
         }
-        if (input->ExpectTag(24)) goto parse_raft_node_id;
+        if (input->ExpectTag(26)) goto parse_replica;
         break;
       }
 
-      // optional uint64 raft_node_id = 3;
+      // optional .cockroach.proto.Replica replica = 3;
       case 3: {
-        if (tag == 24) {
-         parse_raft_node_id:
-          DO_((::google::protobuf::internal::WireFormatLite::ReadPrimitive<
-                   ::google::protobuf::uint64, ::google::protobuf::internal::WireFormatLite::TYPE_UINT64>(
-                 input, &raft_node_id_)));
-          set_has_raft_node_id();
+        if (tag == 26) {
+         parse_replica:
+          DO_(::google::protobuf::internal::WireFormatLite::ReadMessageNoVirtual(
+               input, mutable_replica()));
         } else {
           goto handle_unusual;
         }
@@ -6604,9 +6606,10 @@ void Lease::SerializeWithCachedSizes(
       2, *this->expiration_, output);
   }
 
-  // optional uint64 raft_node_id = 3;
-  if (has_raft_node_id()) {
-    ::google::protobuf::internal::WireFormatLite::WriteUInt64(3, this->raft_node_id(), output);
+  // optional .cockroach.proto.Replica replica = 3;
+  if (has_replica()) {
+    ::google::protobuf::internal::WireFormatLite::WriteMessageMaybeToArray(
+      3, *this->replica_, output);
   }
 
   if (_internal_metadata_.have_unknown_fields()) {
@@ -6633,9 +6636,11 @@ void Lease::SerializeWithCachedSizes(
         2, *this->expiration_, target);
   }
 
-  // optional uint64 raft_node_id = 3;
-  if (has_raft_node_id()) {
-    target = ::google::protobuf::internal::WireFormatLite::WriteUInt64ToArray(3, this->raft_node_id(), target);
+  // optional .cockroach.proto.Replica replica = 3;
+  if (has_replica()) {
+    target = ::google::protobuf::internal::WireFormatLite::
+      WriteMessageNoVirtualToArray(
+        3, *this->replica_, target);
   }
 
   if (_internal_metadata_.have_unknown_fields()) {
@@ -6664,11 +6669,11 @@ int Lease::ByteSize() const {
           *this->expiration_);
     }
 
-    // optional uint64 raft_node_id = 3;
-    if (has_raft_node_id()) {
+    // optional .cockroach.proto.Replica replica = 3;
+    if (has_replica()) {
       total_size += 1 +
-        ::google::protobuf::internal::WireFormatLite::UInt64Size(
-          this->raft_node_id());
+        ::google::protobuf::internal::WireFormatLite::MessageSizeNoVirtual(
+          *this->replica_);
     }
 
   }
@@ -6704,8 +6709,8 @@ void Lease::MergeFrom(const Lease& from) {
     if (from.has_expiration()) {
       mutable_expiration()->::cockroach::proto::Timestamp::MergeFrom(from.expiration());
     }
-    if (from.has_raft_node_id()) {
-      set_raft_node_id(from.raft_node_id());
+    if (from.has_replica()) {
+      mutable_replica()->::cockroach::proto::Replica::MergeFrom(from.replica());
     }
   }
   if (from._internal_metadata_.have_unknown_fields()) {
@@ -6737,7 +6742,7 @@ void Lease::Swap(Lease* other) {
 void Lease::InternalSwap(Lease* other) {
   std::swap(start_, other->start_);
   std::swap(expiration_, other->expiration_);
-  std::swap(raft_node_id_, other->raft_node_id_);
+  std::swap(replica_, other->replica_);
   std::swap(_has_bits_[0], other->_has_bits_[0]);
   _internal_metadata_.Swap(&other->_internal_metadata_);
   std::swap(_cached_size_, other->_cached_size_);
@@ -6840,28 +6845,47 @@ void Lease::clear_expiration() {
   // @@protoc_insertion_point(field_set_allocated:cockroach.proto.Lease.expiration)
 }
 
-// optional uint64 raft_node_id = 3;
-bool Lease::has_raft_node_id() const {
+// optional .cockroach.proto.Replica replica = 3;
+bool Lease::has_replica() const {
   return (_has_bits_[0] & 0x00000004u) != 0;
 }
-void Lease::set_has_raft_node_id() {
+void Lease::set_has_replica() {
   _has_bits_[0] |= 0x00000004u;
 }
-void Lease::clear_has_raft_node_id() {
+void Lease::clear_has_replica() {
   _has_bits_[0] &= ~0x00000004u;
 }
-void Lease::clear_raft_node_id() {
-  raft_node_id_ = GOOGLE_ULONGLONG(0);
-  clear_has_raft_node_id();
+void Lease::clear_replica() {
+  if (replica_ != NULL) replica_->::cockroach::proto::Replica::Clear();
+  clear_has_replica();
 }
- ::google::protobuf::uint64 Lease::raft_node_id() const {
-  // @@protoc_insertion_point(field_get:cockroach.proto.Lease.raft_node_id)
-  return raft_node_id_;
+ const ::cockroach::proto::Replica& Lease::replica() const {
+  // @@protoc_insertion_point(field_get:cockroach.proto.Lease.replica)
+  return replica_ != NULL ? *replica_ : *default_instance_->replica_;
 }
- void Lease::set_raft_node_id(::google::protobuf::uint64 value) {
-  set_has_raft_node_id();
-  raft_node_id_ = value;
-  // @@protoc_insertion_point(field_set:cockroach.proto.Lease.raft_node_id)
+ ::cockroach::proto::Replica* Lease::mutable_replica() {
+  set_has_replica();
+  if (replica_ == NULL) {
+    replica_ = new ::cockroach::proto::Replica;
+  }
+  // @@protoc_insertion_point(field_mutable:cockroach.proto.Lease.replica)
+  return replica_;
+}
+ ::cockroach::proto::Replica* Lease::release_replica() {
+  clear_has_replica();
+  ::cockroach::proto::Replica* temp = replica_;
+  replica_ = NULL;
+  return temp;
+}
+ void Lease::set_allocated_replica(::cockroach::proto::Replica* replica) {
+  delete replica_;
+  replica_ = replica;
+  if (replica) {
+    set_has_replica();
+  } else {
+    clear_has_replica();
+  }
+  // @@protoc_insertion_point(field_set_allocated:cockroach.proto.Lease.replica)
 }
 
 #endif  // PROTOBUF_INLINE_NOT_IN_HEADERS

--- a/storage/engine/rocksdb/cockroach/proto/data.pb.h
+++ b/storage/engine/rocksdb/cockroach/proto/data.pb.h
@@ -982,25 +982,25 @@ class ChangeReplicasTrigger : public ::google::protobuf::Message {
   ::cockroach::proto::ReplicaChangeType change_type() const;
   void set_change_type(::cockroach::proto::ReplicaChangeType value);
 
-  // optional .cockroach.proto.Replica replica = 4;
+  // optional .cockroach.proto.ReplicaDescriptor replica = 4;
   bool has_replica() const;
   void clear_replica();
   static const int kReplicaFieldNumber = 4;
-  const ::cockroach::proto::Replica& replica() const;
-  ::cockroach::proto::Replica* mutable_replica();
-  ::cockroach::proto::Replica* release_replica();
-  void set_allocated_replica(::cockroach::proto::Replica* replica);
+  const ::cockroach::proto::ReplicaDescriptor& replica() const;
+  ::cockroach::proto::ReplicaDescriptor* mutable_replica();
+  ::cockroach::proto::ReplicaDescriptor* release_replica();
+  void set_allocated_replica(::cockroach::proto::ReplicaDescriptor* replica);
 
-  // repeated .cockroach.proto.Replica updated_replicas = 5;
+  // repeated .cockroach.proto.ReplicaDescriptor updated_replicas = 5;
   int updated_replicas_size() const;
   void clear_updated_replicas();
   static const int kUpdatedReplicasFieldNumber = 5;
-  const ::cockroach::proto::Replica& updated_replicas(int index) const;
-  ::cockroach::proto::Replica* mutable_updated_replicas(int index);
-  ::cockroach::proto::Replica* add_updated_replicas();
-  const ::google::protobuf::RepeatedPtrField< ::cockroach::proto::Replica >&
+  const ::cockroach::proto::ReplicaDescriptor& updated_replicas(int index) const;
+  ::cockroach::proto::ReplicaDescriptor* mutable_updated_replicas(int index);
+  ::cockroach::proto::ReplicaDescriptor* add_updated_replicas();
+  const ::google::protobuf::RepeatedPtrField< ::cockroach::proto::ReplicaDescriptor >&
       updated_replicas() const;
-  ::google::protobuf::RepeatedPtrField< ::cockroach::proto::Replica >*
+  ::google::protobuf::RepeatedPtrField< ::cockroach::proto::ReplicaDescriptor >*
       mutable_updated_replicas();
 
   // optional int32 next_replica_id = 6;
@@ -1028,10 +1028,10 @@ class ChangeReplicasTrigger : public ::google::protobuf::Message {
   mutable int _cached_size_;
   ::google::protobuf::int32 node_id_;
   ::google::protobuf::int32 store_id_;
-  ::cockroach::proto::Replica* replica_;
+  ::cockroach::proto::ReplicaDescriptor* replica_;
   int change_type_;
   ::google::protobuf::int32 next_replica_id_;
-  ::google::protobuf::RepeatedPtrField< ::cockroach::proto::Replica > updated_replicas_;
+  ::google::protobuf::RepeatedPtrField< ::cockroach::proto::ReplicaDescriptor > updated_replicas_;
   friend void  protobuf_AddDesc_cockroach_2fproto_2fdata_2eproto();
   friend void protobuf_AssignDesc_cockroach_2fproto_2fdata_2eproto();
   friend void protobuf_ShutdownFile_cockroach_2fproto_2fdata_2eproto();
@@ -1666,14 +1666,14 @@ class Lease : public ::google::protobuf::Message {
   ::cockroach::proto::Timestamp* release_expiration();
   void set_allocated_expiration(::cockroach::proto::Timestamp* expiration);
 
-  // optional .cockroach.proto.Replica replica = 3;
+  // optional .cockroach.proto.ReplicaDescriptor replica = 3;
   bool has_replica() const;
   void clear_replica();
   static const int kReplicaFieldNumber = 3;
-  const ::cockroach::proto::Replica& replica() const;
-  ::cockroach::proto::Replica* mutable_replica();
-  ::cockroach::proto::Replica* release_replica();
-  void set_allocated_replica(::cockroach::proto::Replica* replica);
+  const ::cockroach::proto::ReplicaDescriptor& replica() const;
+  ::cockroach::proto::ReplicaDescriptor* mutable_replica();
+  ::cockroach::proto::ReplicaDescriptor* release_replica();
+  void set_allocated_replica(::cockroach::proto::ReplicaDescriptor* replica);
 
   // @@protoc_insertion_point(class_scope:cockroach.proto.Lease)
  private:
@@ -1689,7 +1689,7 @@ class Lease : public ::google::protobuf::Message {
   mutable int _cached_size_;
   ::cockroach::proto::Timestamp* start_;
   ::cockroach::proto::Timestamp* expiration_;
-  ::cockroach::proto::Replica* replica_;
+  ::cockroach::proto::ReplicaDescriptor* replica_;
   friend void  protobuf_AddDesc_cockroach_2fproto_2fdata_2eproto();
   friend void protobuf_AssignDesc_cockroach_2fproto_2fdata_2eproto();
   friend void protobuf_ShutdownFile_cockroach_2fproto_2fdata_2eproto();
@@ -2675,7 +2675,7 @@ inline void ChangeReplicasTrigger::set_change_type(::cockroach::proto::ReplicaCh
   // @@protoc_insertion_point(field_set:cockroach.proto.ChangeReplicasTrigger.change_type)
 }
 
-// optional .cockroach.proto.Replica replica = 4;
+// optional .cockroach.proto.ReplicaDescriptor replica = 4;
 inline bool ChangeReplicasTrigger::has_replica() const {
   return (_has_bits_[0] & 0x00000008u) != 0;
 }
@@ -2686,28 +2686,28 @@ inline void ChangeReplicasTrigger::clear_has_replica() {
   _has_bits_[0] &= ~0x00000008u;
 }
 inline void ChangeReplicasTrigger::clear_replica() {
-  if (replica_ != NULL) replica_->::cockroach::proto::Replica::Clear();
+  if (replica_ != NULL) replica_->::cockroach::proto::ReplicaDescriptor::Clear();
   clear_has_replica();
 }
-inline const ::cockroach::proto::Replica& ChangeReplicasTrigger::replica() const {
+inline const ::cockroach::proto::ReplicaDescriptor& ChangeReplicasTrigger::replica() const {
   // @@protoc_insertion_point(field_get:cockroach.proto.ChangeReplicasTrigger.replica)
   return replica_ != NULL ? *replica_ : *default_instance_->replica_;
 }
-inline ::cockroach::proto::Replica* ChangeReplicasTrigger::mutable_replica() {
+inline ::cockroach::proto::ReplicaDescriptor* ChangeReplicasTrigger::mutable_replica() {
   set_has_replica();
   if (replica_ == NULL) {
-    replica_ = new ::cockroach::proto::Replica;
+    replica_ = new ::cockroach::proto::ReplicaDescriptor;
   }
   // @@protoc_insertion_point(field_mutable:cockroach.proto.ChangeReplicasTrigger.replica)
   return replica_;
 }
-inline ::cockroach::proto::Replica* ChangeReplicasTrigger::release_replica() {
+inline ::cockroach::proto::ReplicaDescriptor* ChangeReplicasTrigger::release_replica() {
   clear_has_replica();
-  ::cockroach::proto::Replica* temp = replica_;
+  ::cockroach::proto::ReplicaDescriptor* temp = replica_;
   replica_ = NULL;
   return temp;
 }
-inline void ChangeReplicasTrigger::set_allocated_replica(::cockroach::proto::Replica* replica) {
+inline void ChangeReplicasTrigger::set_allocated_replica(::cockroach::proto::ReplicaDescriptor* replica) {
   delete replica_;
   replica_ = replica;
   if (replica) {
@@ -2718,31 +2718,31 @@ inline void ChangeReplicasTrigger::set_allocated_replica(::cockroach::proto::Rep
   // @@protoc_insertion_point(field_set_allocated:cockroach.proto.ChangeReplicasTrigger.replica)
 }
 
-// repeated .cockroach.proto.Replica updated_replicas = 5;
+// repeated .cockroach.proto.ReplicaDescriptor updated_replicas = 5;
 inline int ChangeReplicasTrigger::updated_replicas_size() const {
   return updated_replicas_.size();
 }
 inline void ChangeReplicasTrigger::clear_updated_replicas() {
   updated_replicas_.Clear();
 }
-inline const ::cockroach::proto::Replica& ChangeReplicasTrigger::updated_replicas(int index) const {
+inline const ::cockroach::proto::ReplicaDescriptor& ChangeReplicasTrigger::updated_replicas(int index) const {
   // @@protoc_insertion_point(field_get:cockroach.proto.ChangeReplicasTrigger.updated_replicas)
   return updated_replicas_.Get(index);
 }
-inline ::cockroach::proto::Replica* ChangeReplicasTrigger::mutable_updated_replicas(int index) {
+inline ::cockroach::proto::ReplicaDescriptor* ChangeReplicasTrigger::mutable_updated_replicas(int index) {
   // @@protoc_insertion_point(field_mutable:cockroach.proto.ChangeReplicasTrigger.updated_replicas)
   return updated_replicas_.Mutable(index);
 }
-inline ::cockroach::proto::Replica* ChangeReplicasTrigger::add_updated_replicas() {
+inline ::cockroach::proto::ReplicaDescriptor* ChangeReplicasTrigger::add_updated_replicas() {
   // @@protoc_insertion_point(field_add:cockroach.proto.ChangeReplicasTrigger.updated_replicas)
   return updated_replicas_.Add();
 }
-inline const ::google::protobuf::RepeatedPtrField< ::cockroach::proto::Replica >&
+inline const ::google::protobuf::RepeatedPtrField< ::cockroach::proto::ReplicaDescriptor >&
 ChangeReplicasTrigger::updated_replicas() const {
   // @@protoc_insertion_point(field_list:cockroach.proto.ChangeReplicasTrigger.updated_replicas)
   return updated_replicas_;
 }
-inline ::google::protobuf::RepeatedPtrField< ::cockroach::proto::Replica >*
+inline ::google::protobuf::RepeatedPtrField< ::cockroach::proto::ReplicaDescriptor >*
 ChangeReplicasTrigger::mutable_updated_replicas() {
   // @@protoc_insertion_point(field_mutable_list:cockroach.proto.ChangeReplicasTrigger.updated_replicas)
   return &updated_replicas_;
@@ -3600,7 +3600,7 @@ inline void Lease::set_allocated_expiration(::cockroach::proto::Timestamp* expir
   // @@protoc_insertion_point(field_set_allocated:cockroach.proto.Lease.expiration)
 }
 
-// optional .cockroach.proto.Replica replica = 3;
+// optional .cockroach.proto.ReplicaDescriptor replica = 3;
 inline bool Lease::has_replica() const {
   return (_has_bits_[0] & 0x00000004u) != 0;
 }
@@ -3611,28 +3611,28 @@ inline void Lease::clear_has_replica() {
   _has_bits_[0] &= ~0x00000004u;
 }
 inline void Lease::clear_replica() {
-  if (replica_ != NULL) replica_->::cockroach::proto::Replica::Clear();
+  if (replica_ != NULL) replica_->::cockroach::proto::ReplicaDescriptor::Clear();
   clear_has_replica();
 }
-inline const ::cockroach::proto::Replica& Lease::replica() const {
+inline const ::cockroach::proto::ReplicaDescriptor& Lease::replica() const {
   // @@protoc_insertion_point(field_get:cockroach.proto.Lease.replica)
   return replica_ != NULL ? *replica_ : *default_instance_->replica_;
 }
-inline ::cockroach::proto::Replica* Lease::mutable_replica() {
+inline ::cockroach::proto::ReplicaDescriptor* Lease::mutable_replica() {
   set_has_replica();
   if (replica_ == NULL) {
-    replica_ = new ::cockroach::proto::Replica;
+    replica_ = new ::cockroach::proto::ReplicaDescriptor;
   }
   // @@protoc_insertion_point(field_mutable:cockroach.proto.Lease.replica)
   return replica_;
 }
-inline ::cockroach::proto::Replica* Lease::release_replica() {
+inline ::cockroach::proto::ReplicaDescriptor* Lease::release_replica() {
   clear_has_replica();
-  ::cockroach::proto::Replica* temp = replica_;
+  ::cockroach::proto::ReplicaDescriptor* temp = replica_;
   replica_ = NULL;
   return temp;
 }
-inline void Lease::set_allocated_replica(::cockroach::proto::Replica* replica) {
+inline void Lease::set_allocated_replica(::cockroach::proto::ReplicaDescriptor* replica) {
   delete replica_;
   replica_ = replica;
   if (replica) {

--- a/storage/engine/rocksdb/cockroach/proto/data.pb.h
+++ b/storage/engine/rocksdb/cockroach/proto/data.pb.h
@@ -1666,12 +1666,14 @@ class Lease : public ::google::protobuf::Message {
   ::cockroach::proto::Timestamp* release_expiration();
   void set_allocated_expiration(::cockroach::proto::Timestamp* expiration);
 
-  // optional uint64 raft_node_id = 3;
-  bool has_raft_node_id() const;
-  void clear_raft_node_id();
-  static const int kRaftNodeIdFieldNumber = 3;
-  ::google::protobuf::uint64 raft_node_id() const;
-  void set_raft_node_id(::google::protobuf::uint64 value);
+  // optional .cockroach.proto.Replica replica = 3;
+  bool has_replica() const;
+  void clear_replica();
+  static const int kReplicaFieldNumber = 3;
+  const ::cockroach::proto::Replica& replica() const;
+  ::cockroach::proto::Replica* mutable_replica();
+  ::cockroach::proto::Replica* release_replica();
+  void set_allocated_replica(::cockroach::proto::Replica* replica);
 
   // @@protoc_insertion_point(class_scope:cockroach.proto.Lease)
  private:
@@ -1679,15 +1681,15 @@ class Lease : public ::google::protobuf::Message {
   inline void clear_has_start();
   inline void set_has_expiration();
   inline void clear_has_expiration();
-  inline void set_has_raft_node_id();
-  inline void clear_has_raft_node_id();
+  inline void set_has_replica();
+  inline void clear_has_replica();
 
   ::google::protobuf::internal::InternalMetadataWithArena _internal_metadata_;
   ::google::protobuf::uint32 _has_bits_[1];
   mutable int _cached_size_;
   ::cockroach::proto::Timestamp* start_;
   ::cockroach::proto::Timestamp* expiration_;
-  ::google::protobuf::uint64 raft_node_id_;
+  ::cockroach::proto::Replica* replica_;
   friend void  protobuf_AddDesc_cockroach_2fproto_2fdata_2eproto();
   friend void protobuf_AssignDesc_cockroach_2fproto_2fdata_2eproto();
   friend void protobuf_ShutdownFile_cockroach_2fproto_2fdata_2eproto();
@@ -3598,28 +3600,47 @@ inline void Lease::set_allocated_expiration(::cockroach::proto::Timestamp* expir
   // @@protoc_insertion_point(field_set_allocated:cockroach.proto.Lease.expiration)
 }
 
-// optional uint64 raft_node_id = 3;
-inline bool Lease::has_raft_node_id() const {
+// optional .cockroach.proto.Replica replica = 3;
+inline bool Lease::has_replica() const {
   return (_has_bits_[0] & 0x00000004u) != 0;
 }
-inline void Lease::set_has_raft_node_id() {
+inline void Lease::set_has_replica() {
   _has_bits_[0] |= 0x00000004u;
 }
-inline void Lease::clear_has_raft_node_id() {
+inline void Lease::clear_has_replica() {
   _has_bits_[0] &= ~0x00000004u;
 }
-inline void Lease::clear_raft_node_id() {
-  raft_node_id_ = GOOGLE_ULONGLONG(0);
-  clear_has_raft_node_id();
+inline void Lease::clear_replica() {
+  if (replica_ != NULL) replica_->::cockroach::proto::Replica::Clear();
+  clear_has_replica();
 }
-inline ::google::protobuf::uint64 Lease::raft_node_id() const {
-  // @@protoc_insertion_point(field_get:cockroach.proto.Lease.raft_node_id)
-  return raft_node_id_;
+inline const ::cockroach::proto::Replica& Lease::replica() const {
+  // @@protoc_insertion_point(field_get:cockroach.proto.Lease.replica)
+  return replica_ != NULL ? *replica_ : *default_instance_->replica_;
 }
-inline void Lease::set_raft_node_id(::google::protobuf::uint64 value) {
-  set_has_raft_node_id();
-  raft_node_id_ = value;
-  // @@protoc_insertion_point(field_set:cockroach.proto.Lease.raft_node_id)
+inline ::cockroach::proto::Replica* Lease::mutable_replica() {
+  set_has_replica();
+  if (replica_ == NULL) {
+    replica_ = new ::cockroach::proto::Replica;
+  }
+  // @@protoc_insertion_point(field_mutable:cockroach.proto.Lease.replica)
+  return replica_;
+}
+inline ::cockroach::proto::Replica* Lease::release_replica() {
+  clear_has_replica();
+  ::cockroach::proto::Replica* temp = replica_;
+  replica_ = NULL;
+  return temp;
+}
+inline void Lease::set_allocated_replica(::cockroach::proto::Replica* replica) {
+  delete replica_;
+  replica_ = replica;
+  if (replica) {
+    set_has_replica();
+  } else {
+    clear_has_replica();
+  }
+  // @@protoc_insertion_point(field_set_allocated:cockroach.proto.Lease.replica)
 }
 
 // -------------------------------------------------------------------

--- a/storage/engine/rocksdb/cockroach/proto/errors.pb.cc
+++ b/storage/engine/rocksdb/cockroach/proto/errors.pb.cc
@@ -491,79 +491,79 @@ void protobuf_AddDesc_cockroach_2fproto_2ferrors_2eproto() {
     "\n\034cockroach/proto/errors.proto\022\017cockroac"
     "h.proto\032\036cockroach/proto/metadata.proto\032"
     "\032cockroach/proto/data.proto\032\024gogoproto/g"
-    "ogo.proto\"\223\001\n\016NotLeaderError\022)\n\007replica\030"
-    "\001 \001(\0132\030.cockroach.proto.Replica\022(\n\006leade"
-    "r\030\002 \001(\0132\030.cockroach.proto.Replica\022,\n\010ran"
-    "ge_id\030\003 \001(\003B\032\310\336\037\000\342\336\037\007RangeID\372\336\037\007RangeID\""
-    "\026\n\024NodeUnavailableError\"B\n\022RangeNotFound"
-    "Error\022,\n\010range_id\030\001 \001(\003B\032\310\336\037\000\342\336\037\007RangeID"
-    "\372\336\037\007RangeID\"\216\001\n\025RangeKeyMismatchError\022\"\n"
-    "\021request_start_key\030\001 \001(\014B\007\372\336\037\003Key\022 \n\017req"
-    "uest_end_key\030\002 \001(\014B\007\372\336\037\003Key\022/\n\005range\030\003 \001"
-    "(\0132 .cockroach.proto.RangeDescriptor\"\363\001\n"
-    "\"ReadWithinUncertaintyIntervalError\0223\n\tt"
-    "imestamp\030\001 \001(\0132\032.cockroach.proto.Timesta"
-    "mpB\004\310\336\037\000\022<\n\022existing_timestamp\030\002 \001(\0132\032.c"
-    "ockroach.proto.TimestampB\004\310\336\037\000\022)\n\007node_i"
-    "d\030\003 \001(\005B\030\310\336\037\000\342\336\037\006NodeID\372\336\037\006NodeID\022/\n\003txn"
-    "\030\004 \001(\0132\034.cockroach.proto.TransactionB\004\310\336"
-    "\037\000\"J\n\027TransactionAbortedError\022/\n\003txn\030\001 \001"
-    "(\0132\034.cockroach.proto.TransactionB\004\310\336\037\000\"y"
-    "\n\024TransactionPushError\022)\n\003txn\030\001 \001(\0132\034.co"
-    "ckroach.proto.Transaction\0226\n\npushee_txn\030"
-    "\002 \001(\0132\034.cockroach.proto.TransactionB\004\310\336\037"
-    "\000\"H\n\025TransactionRetryError\022/\n\003txn\030\001 \001(\0132"
-    "\034.cockroach.proto.TransactionB\004\310\336\037\000\"\\\n\026T"
-    "ransactionStatusError\022/\n\003txn\030\001 \001(\0132\034.coc"
-    "kroach.proto.TransactionB\004\310\336\037\000\022\021\n\003msg\030\002 "
-    "\001(\tB\004\310\336\037\000\"Z\n\020WriteIntentError\022.\n\007intents"
-    "\030\001 \003(\0132\027.cockroach.proto.IntentB\004\310\336\037\000\022\026\n"
-    "\010resolved\030\002 \001(\010B\004\310\336\037\000\"\205\001\n\020WriteTooOldErr"
-    "or\0223\n\ttimestamp\030\001 \001(\0132\032.cockroach.proto."
-    "TimestampB\004\310\336\037\000\022<\n\022existing_timestamp\030\002 "
-    "\001(\0132\032.cockroach.proto.TimestampB\004\310\336\037\000\"\024\n"
-    "\022OpRequiresTxnError\"q\n\024ConditionFailedEr"
-    "ror\022,\n\014actual_value\030\001 \001(\0132\026.cockroach.pr"
-    "oto.Value\022+\n\005index\030\002 \001(\0132\034.cockroach.pro"
-    "to.ErrPosition\"u\n\022LeaseRejectedError\022/\n\t"
-    "Requested\030\001 \001(\0132\026.cockroach.proto.LeaseB"
-    "\004\310\336\037\000\022.\n\010Existing\030\002 \001(\0132\026.cockroach.prot"
-    "o.LeaseB\004\310\336\037\000\";\n\tSendError\022\025\n\007message\030\001 "
-    "\001(\tB\004\310\336\037\000\022\027\n\tretryable\030\002 \001(\010B\004\310\336\037\000\"\323\007\n\013E"
-    "rrorDetail\0223\n\nnot_leader\030\001 \001(\0132\037.cockroa"
-    "ch.proto.NotLeaderError\022<\n\017range_not_fou"
-    "nd\030\002 \001(\0132#.cockroach.proto.RangeNotFound"
-    "Error\022B\n\022range_key_mismatch\030\003 \001(\0132&.cock"
-    "roach.proto.RangeKeyMismatchError\022]\n rea"
-    "d_within_uncertainty_interval\030\004 \001(\01323.co"
-    "ckroach.proto.ReadWithinUncertaintyInter"
-    "valError\022E\n\023transaction_aborted\030\005 \001(\0132(."
-    "cockroach.proto.TransactionAbortedError\022"
-    "\?\n\020transaction_push\030\006 \001(\0132%.cockroach.pr"
-    "oto.TransactionPushError\022A\n\021transaction_"
-    "retry\030\007 \001(\0132&.cockroach.proto.Transactio"
-    "nRetryError\022C\n\022transaction_status\030\010 \001(\0132"
-    "\'.cockroach.proto.TransactionStatusError"
-    "\0227\n\014write_intent\030\t \001(\0132!.cockroach.proto"
-    ".WriteIntentError\0228\n\rwrite_too_old\030\n \001(\013"
-    "2!.cockroach.proto.WriteTooOldError\022<\n\017o"
-    "p_requires_txn\030\013 \001(\0132#.cockroach.proto.O"
-    "pRequiresTxnError\022\?\n\020condition_failed\030\014 "
-    "\001(\0132%.cockroach.proto.ConditionFailedErr"
-    "or\022;\n\016lease_rejected\030\r \001(\0132#.cockroach.p"
-    "roto.LeaseRejectedError\022\?\n\020node_unavaila"
-    "ble\030\016 \001(\0132%.cockroach.proto.NodeUnavaila"
-    "bleError\022(\n\004send\030\017 \001(\0132\032.cockroach.proto"
-    ".SendError:\004\310\240\037\001\"\"\n\013ErrPosition\022\023\n\005index"
-    "\030\001 \001(\005B\004\310\336\037\000\"\332\001\n\005Error\022\025\n\007message\030\001 \001(\tB"
-    "\004\310\336\037\000\022\027\n\tretryable\030\002 \001(\010B\004\310\336\037\000\022F\n\023transa"
-    "ction_restart\030\003 \001(\0162#.cockroach.proto.Tr"
-    "ansactionRestartB\004\310\336\037\000\022,\n\006detail\030\004 \001(\0132\034"
-    ".cockroach.proto.ErrorDetail\022+\n\005index\030\005 "
-    "\001(\0132\034.cockroach.proto.ErrPosition*;\n\022Tra"
-    "nsactionRestart\022\t\n\005ABORT\020\000\022\013\n\007BACKOFF\020\001\022"
-    "\r\n\tIMMEDIATE\020\002B\033Z\005proto\330\341\036\000\340\342\036\001\310\342\036\001\320\342\036\001\220"
-    "\343\036\000", 3003);
+    "ogo.proto\"\247\001\n\016NotLeaderError\0223\n\007replica\030"
+    "\001 \001(\0132\".cockroach.proto.ReplicaDescripto"
+    "r\0222\n\006leader\030\002 \001(\0132\".cockroach.proto.Repl"
+    "icaDescriptor\022,\n\010range_id\030\003 \001(\003B\032\310\336\037\000\342\336\037"
+    "\007RangeID\372\336\037\007RangeID\"\026\n\024NodeUnavailableEr"
+    "ror\"B\n\022RangeNotFoundError\022,\n\010range_id\030\001 "
+    "\001(\003B\032\310\336\037\000\342\336\037\007RangeID\372\336\037\007RangeID\"\216\001\n\025Rang"
+    "eKeyMismatchError\022\"\n\021request_start_key\030\001"
+    " \001(\014B\007\372\336\037\003Key\022 \n\017request_end_key\030\002 \001(\014B\007"
+    "\372\336\037\003Key\022/\n\005range\030\003 \001(\0132 .cockroach.proto"
+    ".RangeDescriptor\"\363\001\n\"ReadWithinUncertain"
+    "tyIntervalError\0223\n\ttimestamp\030\001 \001(\0132\032.coc"
+    "kroach.proto.TimestampB\004\310\336\037\000\022<\n\022existing"
+    "_timestamp\030\002 \001(\0132\032.cockroach.proto.Times"
+    "tampB\004\310\336\037\000\022)\n\007node_id\030\003 \001(\005B\030\310\336\037\000\342\336\037\006Nod"
+    "eID\372\336\037\006NodeID\022/\n\003txn\030\004 \001(\0132\034.cockroach.p"
+    "roto.TransactionB\004\310\336\037\000\"J\n\027TransactionAbo"
+    "rtedError\022/\n\003txn\030\001 \001(\0132\034.cockroach.proto"
+    ".TransactionB\004\310\336\037\000\"y\n\024TransactionPushErr"
+    "or\022)\n\003txn\030\001 \001(\0132\034.cockroach.proto.Transa"
+    "ction\0226\n\npushee_txn\030\002 \001(\0132\034.cockroach.pr"
+    "oto.TransactionB\004\310\336\037\000\"H\n\025TransactionRetr"
+    "yError\022/\n\003txn\030\001 \001(\0132\034.cockroach.proto.Tr"
+    "ansactionB\004\310\336\037\000\"\\\n\026TransactionStatusErro"
+    "r\022/\n\003txn\030\001 \001(\0132\034.cockroach.proto.Transac"
+    "tionB\004\310\336\037\000\022\021\n\003msg\030\002 \001(\tB\004\310\336\037\000\"Z\n\020WriteIn"
+    "tentError\022.\n\007intents\030\001 \003(\0132\027.cockroach.p"
+    "roto.IntentB\004\310\336\037\000\022\026\n\010resolved\030\002 \001(\010B\004\310\336\037"
+    "\000\"\205\001\n\020WriteTooOldError\0223\n\ttimestamp\030\001 \001("
+    "\0132\032.cockroach.proto.TimestampB\004\310\336\037\000\022<\n\022e"
+    "xisting_timestamp\030\002 \001(\0132\032.cockroach.prot"
+    "o.TimestampB\004\310\336\037\000\"\024\n\022OpRequiresTxnError\""
+    "q\n\024ConditionFailedError\022,\n\014actual_value\030"
+    "\001 \001(\0132\026.cockroach.proto.Value\022+\n\005index\030\002"
+    " \001(\0132\034.cockroach.proto.ErrPosition\"u\n\022Le"
+    "aseRejectedError\022/\n\tRequested\030\001 \001(\0132\026.co"
+    "ckroach.proto.LeaseB\004\310\336\037\000\022.\n\010Existing\030\002 "
+    "\001(\0132\026.cockroach.proto.LeaseB\004\310\336\037\000\";\n\tSen"
+    "dError\022\025\n\007message\030\001 \001(\tB\004\310\336\037\000\022\027\n\tretryab"
+    "le\030\002 \001(\010B\004\310\336\037\000\"\323\007\n\013ErrorDetail\0223\n\nnot_le"
+    "ader\030\001 \001(\0132\037.cockroach.proto.NotLeaderEr"
+    "ror\022<\n\017range_not_found\030\002 \001(\0132#.cockroach"
+    ".proto.RangeNotFoundError\022B\n\022range_key_m"
+    "ismatch\030\003 \001(\0132&.cockroach.proto.RangeKey"
+    "MismatchError\022]\n read_within_uncertainty"
+    "_interval\030\004 \001(\01323.cockroach.proto.ReadWi"
+    "thinUncertaintyIntervalError\022E\n\023transact"
+    "ion_aborted\030\005 \001(\0132(.cockroach.proto.Tran"
+    "sactionAbortedError\022\?\n\020transaction_push\030"
+    "\006 \001(\0132%.cockroach.proto.TransactionPushE"
+    "rror\022A\n\021transaction_retry\030\007 \001(\0132&.cockro"
+    "ach.proto.TransactionRetryError\022C\n\022trans"
+    "action_status\030\010 \001(\0132\'.cockroach.proto.Tr"
+    "ansactionStatusError\0227\n\014write_intent\030\t \001"
+    "(\0132!.cockroach.proto.WriteIntentError\0228\n"
+    "\rwrite_too_old\030\n \001(\0132!.cockroach.proto.W"
+    "riteTooOldError\022<\n\017op_requires_txn\030\013 \001(\013"
+    "2#.cockroach.proto.OpRequiresTxnError\022\?\n"
+    "\020condition_failed\030\014 \001(\0132%.cockroach.prot"
+    "o.ConditionFailedError\022;\n\016lease_rejected"
+    "\030\r \001(\0132#.cockroach.proto.LeaseRejectedEr"
+    "ror\022\?\n\020node_unavailable\030\016 \001(\0132%.cockroac"
+    "h.proto.NodeUnavailableError\022(\n\004send\030\017 \001"
+    "(\0132\032.cockroach.proto.SendError:\004\310\240\037\001\"\"\n\013"
+    "ErrPosition\022\023\n\005index\030\001 \001(\005B\004\310\336\037\000\"\332\001\n\005Err"
+    "or\022\025\n\007message\030\001 \001(\tB\004\310\336\037\000\022\027\n\tretryable\030\002"
+    " \001(\010B\004\310\336\037\000\022F\n\023transaction_restart\030\003 \001(\0162"
+    "#.cockroach.proto.TransactionRestartB\004\310\336"
+    "\037\000\022,\n\006detail\030\004 \001(\0132\034.cockroach.proto.Err"
+    "orDetail\022+\n\005index\030\005 \001(\0132\034.cockroach.prot"
+    "o.ErrPosition*;\n\022TransactionRestart\022\t\n\005A"
+    "BORT\020\000\022\013\n\007BACKOFF\020\001\022\r\n\tIMMEDIATE\020\002B\033Z\005pr"
+    "oto\330\341\036\000\340\342\036\001\310\342\036\001\320\342\036\001\220\343\036\000", 3023);
   ::google::protobuf::MessageFactory::InternalRegisterGeneratedFile(
     "cockroach/proto/errors.proto", &protobuf_RegisterTypes);
   NotLeaderError::default_instance_ = new NotLeaderError();
@@ -652,8 +652,8 @@ NotLeaderError::NotLeaderError()
 }
 
 void NotLeaderError::InitAsDefaultInstance() {
-  replica_ = const_cast< ::cockroach::proto::Replica*>(&::cockroach::proto::Replica::default_instance());
-  leader_ = const_cast< ::cockroach::proto::Replica*>(&::cockroach::proto::Replica::default_instance());
+  replica_ = const_cast< ::cockroach::proto::ReplicaDescriptor*>(&::cockroach::proto::ReplicaDescriptor::default_instance());
+  leader_ = const_cast< ::cockroach::proto::ReplicaDescriptor*>(&::cockroach::proto::ReplicaDescriptor::default_instance());
 }
 
 NotLeaderError::NotLeaderError(const NotLeaderError& from)
@@ -712,10 +712,10 @@ NotLeaderError* NotLeaderError::New(::google::protobuf::Arena* arena) const {
 void NotLeaderError::Clear() {
   if (_has_bits_[0 / 32] & 7u) {
     if (has_replica()) {
-      if (replica_ != NULL) replica_->::cockroach::proto::Replica::Clear();
+      if (replica_ != NULL) replica_->::cockroach::proto::ReplicaDescriptor::Clear();
     }
     if (has_leader()) {
-      if (leader_ != NULL) leader_->::cockroach::proto::Replica::Clear();
+      if (leader_ != NULL) leader_->::cockroach::proto::ReplicaDescriptor::Clear();
     }
     range_id_ = GOOGLE_LONGLONG(0);
   }
@@ -735,7 +735,7 @@ bool NotLeaderError::MergePartialFromCodedStream(
     tag = p.first;
     if (!p.second) goto handle_unusual;
     switch (::google::protobuf::internal::WireFormatLite::GetTagFieldNumber(tag)) {
-      // optional .cockroach.proto.Replica replica = 1;
+      // optional .cockroach.proto.ReplicaDescriptor replica = 1;
       case 1: {
         if (tag == 10) {
           DO_(::google::protobuf::internal::WireFormatLite::ReadMessageNoVirtual(
@@ -747,7 +747,7 @@ bool NotLeaderError::MergePartialFromCodedStream(
         break;
       }
 
-      // optional .cockroach.proto.Replica leader = 2;
+      // optional .cockroach.proto.ReplicaDescriptor leader = 2;
       case 2: {
         if (tag == 18) {
          parse_leader:
@@ -800,13 +800,13 @@ failure:
 void NotLeaderError::SerializeWithCachedSizes(
     ::google::protobuf::io::CodedOutputStream* output) const {
   // @@protoc_insertion_point(serialize_start:cockroach.proto.NotLeaderError)
-  // optional .cockroach.proto.Replica replica = 1;
+  // optional .cockroach.proto.ReplicaDescriptor replica = 1;
   if (has_replica()) {
     ::google::protobuf::internal::WireFormatLite::WriteMessageMaybeToArray(
       1, *this->replica_, output);
   }
 
-  // optional .cockroach.proto.Replica leader = 2;
+  // optional .cockroach.proto.ReplicaDescriptor leader = 2;
   if (has_leader()) {
     ::google::protobuf::internal::WireFormatLite::WriteMessageMaybeToArray(
       2, *this->leader_, output);
@@ -827,14 +827,14 @@ void NotLeaderError::SerializeWithCachedSizes(
 ::google::protobuf::uint8* NotLeaderError::SerializeWithCachedSizesToArray(
     ::google::protobuf::uint8* target) const {
   // @@protoc_insertion_point(serialize_to_array_start:cockroach.proto.NotLeaderError)
-  // optional .cockroach.proto.Replica replica = 1;
+  // optional .cockroach.proto.ReplicaDescriptor replica = 1;
   if (has_replica()) {
     target = ::google::protobuf::internal::WireFormatLite::
       WriteMessageNoVirtualToArray(
         1, *this->replica_, target);
   }
 
-  // optional .cockroach.proto.Replica leader = 2;
+  // optional .cockroach.proto.ReplicaDescriptor leader = 2;
   if (has_leader()) {
     target = ::google::protobuf::internal::WireFormatLite::
       WriteMessageNoVirtualToArray(
@@ -858,14 +858,14 @@ int NotLeaderError::ByteSize() const {
   int total_size = 0;
 
   if (_has_bits_[0 / 32] & 7) {
-    // optional .cockroach.proto.Replica replica = 1;
+    // optional .cockroach.proto.ReplicaDescriptor replica = 1;
     if (has_replica()) {
       total_size += 1 +
         ::google::protobuf::internal::WireFormatLite::MessageSizeNoVirtual(
           *this->replica_);
     }
 
-    // optional .cockroach.proto.Replica leader = 2;
+    // optional .cockroach.proto.ReplicaDescriptor leader = 2;
     if (has_leader()) {
       total_size += 1 +
         ::google::protobuf::internal::WireFormatLite::MessageSizeNoVirtual(
@@ -907,10 +907,10 @@ void NotLeaderError::MergeFrom(const NotLeaderError& from) {
   if (GOOGLE_PREDICT_FALSE(&from == this)) MergeFromFail(__LINE__);
   if (from._has_bits_[0 / 32] & (0xffu << (0 % 32))) {
     if (from.has_replica()) {
-      mutable_replica()->::cockroach::proto::Replica::MergeFrom(from.replica());
+      mutable_replica()->::cockroach::proto::ReplicaDescriptor::MergeFrom(from.replica());
     }
     if (from.has_leader()) {
-      mutable_leader()->::cockroach::proto::Replica::MergeFrom(from.leader());
+      mutable_leader()->::cockroach::proto::ReplicaDescriptor::MergeFrom(from.leader());
     }
     if (from.has_range_id()) {
       set_range_id(from.range_id());
@@ -962,7 +962,7 @@ void NotLeaderError::InternalSwap(NotLeaderError* other) {
 #if PROTOBUF_INLINE_NOT_IN_HEADERS
 // NotLeaderError
 
-// optional .cockroach.proto.Replica replica = 1;
+// optional .cockroach.proto.ReplicaDescriptor replica = 1;
 bool NotLeaderError::has_replica() const {
   return (_has_bits_[0] & 0x00000001u) != 0;
 }
@@ -973,28 +973,28 @@ void NotLeaderError::clear_has_replica() {
   _has_bits_[0] &= ~0x00000001u;
 }
 void NotLeaderError::clear_replica() {
-  if (replica_ != NULL) replica_->::cockroach::proto::Replica::Clear();
+  if (replica_ != NULL) replica_->::cockroach::proto::ReplicaDescriptor::Clear();
   clear_has_replica();
 }
- const ::cockroach::proto::Replica& NotLeaderError::replica() const {
+ const ::cockroach::proto::ReplicaDescriptor& NotLeaderError::replica() const {
   // @@protoc_insertion_point(field_get:cockroach.proto.NotLeaderError.replica)
   return replica_ != NULL ? *replica_ : *default_instance_->replica_;
 }
- ::cockroach::proto::Replica* NotLeaderError::mutable_replica() {
+ ::cockroach::proto::ReplicaDescriptor* NotLeaderError::mutable_replica() {
   set_has_replica();
   if (replica_ == NULL) {
-    replica_ = new ::cockroach::proto::Replica;
+    replica_ = new ::cockroach::proto::ReplicaDescriptor;
   }
   // @@protoc_insertion_point(field_mutable:cockroach.proto.NotLeaderError.replica)
   return replica_;
 }
- ::cockroach::proto::Replica* NotLeaderError::release_replica() {
+ ::cockroach::proto::ReplicaDescriptor* NotLeaderError::release_replica() {
   clear_has_replica();
-  ::cockroach::proto::Replica* temp = replica_;
+  ::cockroach::proto::ReplicaDescriptor* temp = replica_;
   replica_ = NULL;
   return temp;
 }
- void NotLeaderError::set_allocated_replica(::cockroach::proto::Replica* replica) {
+ void NotLeaderError::set_allocated_replica(::cockroach::proto::ReplicaDescriptor* replica) {
   delete replica_;
   replica_ = replica;
   if (replica) {
@@ -1005,7 +1005,7 @@ void NotLeaderError::clear_replica() {
   // @@protoc_insertion_point(field_set_allocated:cockroach.proto.NotLeaderError.replica)
 }
 
-// optional .cockroach.proto.Replica leader = 2;
+// optional .cockroach.proto.ReplicaDescriptor leader = 2;
 bool NotLeaderError::has_leader() const {
   return (_has_bits_[0] & 0x00000002u) != 0;
 }
@@ -1016,28 +1016,28 @@ void NotLeaderError::clear_has_leader() {
   _has_bits_[0] &= ~0x00000002u;
 }
 void NotLeaderError::clear_leader() {
-  if (leader_ != NULL) leader_->::cockroach::proto::Replica::Clear();
+  if (leader_ != NULL) leader_->::cockroach::proto::ReplicaDescriptor::Clear();
   clear_has_leader();
 }
- const ::cockroach::proto::Replica& NotLeaderError::leader() const {
+ const ::cockroach::proto::ReplicaDescriptor& NotLeaderError::leader() const {
   // @@protoc_insertion_point(field_get:cockroach.proto.NotLeaderError.leader)
   return leader_ != NULL ? *leader_ : *default_instance_->leader_;
 }
- ::cockroach::proto::Replica* NotLeaderError::mutable_leader() {
+ ::cockroach::proto::ReplicaDescriptor* NotLeaderError::mutable_leader() {
   set_has_leader();
   if (leader_ == NULL) {
-    leader_ = new ::cockroach::proto::Replica;
+    leader_ = new ::cockroach::proto::ReplicaDescriptor;
   }
   // @@protoc_insertion_point(field_mutable:cockroach.proto.NotLeaderError.leader)
   return leader_;
 }
- ::cockroach::proto::Replica* NotLeaderError::release_leader() {
+ ::cockroach::proto::ReplicaDescriptor* NotLeaderError::release_leader() {
   clear_has_leader();
-  ::cockroach::proto::Replica* temp = leader_;
+  ::cockroach::proto::ReplicaDescriptor* temp = leader_;
   leader_ = NULL;
   return temp;
 }
- void NotLeaderError::set_allocated_leader(::cockroach::proto::Replica* leader) {
+ void NotLeaderError::set_allocated_leader(::cockroach::proto::ReplicaDescriptor* leader) {
   delete leader_;
   leader_ = leader;
   if (leader) {

--- a/storage/engine/rocksdb/cockroach/proto/errors.pb.h
+++ b/storage/engine/rocksdb/cockroach/proto/errors.pb.h
@@ -146,23 +146,23 @@ class NotLeaderError : public ::google::protobuf::Message {
 
   // accessors -------------------------------------------------------
 
-  // optional .cockroach.proto.Replica replica = 1;
+  // optional .cockroach.proto.ReplicaDescriptor replica = 1;
   bool has_replica() const;
   void clear_replica();
   static const int kReplicaFieldNumber = 1;
-  const ::cockroach::proto::Replica& replica() const;
-  ::cockroach::proto::Replica* mutable_replica();
-  ::cockroach::proto::Replica* release_replica();
-  void set_allocated_replica(::cockroach::proto::Replica* replica);
+  const ::cockroach::proto::ReplicaDescriptor& replica() const;
+  ::cockroach::proto::ReplicaDescriptor* mutable_replica();
+  ::cockroach::proto::ReplicaDescriptor* release_replica();
+  void set_allocated_replica(::cockroach::proto::ReplicaDescriptor* replica);
 
-  // optional .cockroach.proto.Replica leader = 2;
+  // optional .cockroach.proto.ReplicaDescriptor leader = 2;
   bool has_leader() const;
   void clear_leader();
   static const int kLeaderFieldNumber = 2;
-  const ::cockroach::proto::Replica& leader() const;
-  ::cockroach::proto::Replica* mutable_leader();
-  ::cockroach::proto::Replica* release_leader();
-  void set_allocated_leader(::cockroach::proto::Replica* leader);
+  const ::cockroach::proto::ReplicaDescriptor& leader() const;
+  ::cockroach::proto::ReplicaDescriptor* mutable_leader();
+  ::cockroach::proto::ReplicaDescriptor* release_leader();
+  void set_allocated_leader(::cockroach::proto::ReplicaDescriptor* leader);
 
   // optional int64 range_id = 3;
   bool has_range_id() const;
@@ -183,8 +183,8 @@ class NotLeaderError : public ::google::protobuf::Message {
   ::google::protobuf::internal::InternalMetadataWithArena _internal_metadata_;
   ::google::protobuf::uint32 _has_bits_[1];
   mutable int _cached_size_;
-  ::cockroach::proto::Replica* replica_;
-  ::cockroach::proto::Replica* leader_;
+  ::cockroach::proto::ReplicaDescriptor* replica_;
+  ::cockroach::proto::ReplicaDescriptor* leader_;
   ::google::protobuf::int64 range_id_;
   friend void  protobuf_AddDesc_cockroach_2fproto_2ferrors_2eproto();
   friend void protobuf_AssignDesc_cockroach_2fproto_2ferrors_2eproto();
@@ -2086,7 +2086,7 @@ class Error : public ::google::protobuf::Message {
 #if !PROTOBUF_INLINE_NOT_IN_HEADERS
 // NotLeaderError
 
-// optional .cockroach.proto.Replica replica = 1;
+// optional .cockroach.proto.ReplicaDescriptor replica = 1;
 inline bool NotLeaderError::has_replica() const {
   return (_has_bits_[0] & 0x00000001u) != 0;
 }
@@ -2097,28 +2097,28 @@ inline void NotLeaderError::clear_has_replica() {
   _has_bits_[0] &= ~0x00000001u;
 }
 inline void NotLeaderError::clear_replica() {
-  if (replica_ != NULL) replica_->::cockroach::proto::Replica::Clear();
+  if (replica_ != NULL) replica_->::cockroach::proto::ReplicaDescriptor::Clear();
   clear_has_replica();
 }
-inline const ::cockroach::proto::Replica& NotLeaderError::replica() const {
+inline const ::cockroach::proto::ReplicaDescriptor& NotLeaderError::replica() const {
   // @@protoc_insertion_point(field_get:cockroach.proto.NotLeaderError.replica)
   return replica_ != NULL ? *replica_ : *default_instance_->replica_;
 }
-inline ::cockroach::proto::Replica* NotLeaderError::mutable_replica() {
+inline ::cockroach::proto::ReplicaDescriptor* NotLeaderError::mutable_replica() {
   set_has_replica();
   if (replica_ == NULL) {
-    replica_ = new ::cockroach::proto::Replica;
+    replica_ = new ::cockroach::proto::ReplicaDescriptor;
   }
   // @@protoc_insertion_point(field_mutable:cockroach.proto.NotLeaderError.replica)
   return replica_;
 }
-inline ::cockroach::proto::Replica* NotLeaderError::release_replica() {
+inline ::cockroach::proto::ReplicaDescriptor* NotLeaderError::release_replica() {
   clear_has_replica();
-  ::cockroach::proto::Replica* temp = replica_;
+  ::cockroach::proto::ReplicaDescriptor* temp = replica_;
   replica_ = NULL;
   return temp;
 }
-inline void NotLeaderError::set_allocated_replica(::cockroach::proto::Replica* replica) {
+inline void NotLeaderError::set_allocated_replica(::cockroach::proto::ReplicaDescriptor* replica) {
   delete replica_;
   replica_ = replica;
   if (replica) {
@@ -2129,7 +2129,7 @@ inline void NotLeaderError::set_allocated_replica(::cockroach::proto::Replica* r
   // @@protoc_insertion_point(field_set_allocated:cockroach.proto.NotLeaderError.replica)
 }
 
-// optional .cockroach.proto.Replica leader = 2;
+// optional .cockroach.proto.ReplicaDescriptor leader = 2;
 inline bool NotLeaderError::has_leader() const {
   return (_has_bits_[0] & 0x00000002u) != 0;
 }
@@ -2140,28 +2140,28 @@ inline void NotLeaderError::clear_has_leader() {
   _has_bits_[0] &= ~0x00000002u;
 }
 inline void NotLeaderError::clear_leader() {
-  if (leader_ != NULL) leader_->::cockroach::proto::Replica::Clear();
+  if (leader_ != NULL) leader_->::cockroach::proto::ReplicaDescriptor::Clear();
   clear_has_leader();
 }
-inline const ::cockroach::proto::Replica& NotLeaderError::leader() const {
+inline const ::cockroach::proto::ReplicaDescriptor& NotLeaderError::leader() const {
   // @@protoc_insertion_point(field_get:cockroach.proto.NotLeaderError.leader)
   return leader_ != NULL ? *leader_ : *default_instance_->leader_;
 }
-inline ::cockroach::proto::Replica* NotLeaderError::mutable_leader() {
+inline ::cockroach::proto::ReplicaDescriptor* NotLeaderError::mutable_leader() {
   set_has_leader();
   if (leader_ == NULL) {
-    leader_ = new ::cockroach::proto::Replica;
+    leader_ = new ::cockroach::proto::ReplicaDescriptor;
   }
   // @@protoc_insertion_point(field_mutable:cockroach.proto.NotLeaderError.leader)
   return leader_;
 }
-inline ::cockroach::proto::Replica* NotLeaderError::release_leader() {
+inline ::cockroach::proto::ReplicaDescriptor* NotLeaderError::release_leader() {
   clear_has_leader();
-  ::cockroach::proto::Replica* temp = leader_;
+  ::cockroach::proto::ReplicaDescriptor* temp = leader_;
   leader_ = NULL;
   return temp;
 }
-inline void NotLeaderError::set_allocated_leader(::cockroach::proto::Replica* leader) {
+inline void NotLeaderError::set_allocated_leader(::cockroach::proto::ReplicaDescriptor* leader) {
   delete leader_;
   leader_ = leader;
   if (leader) {

--- a/storage/engine/rocksdb/cockroach/proto/internal.pb.cc
+++ b/storage/engine/rocksdb/cockroach/proto/internal.pb.cc
@@ -52,7 +52,7 @@ void protobuf_AssignDesc_cockroach_2fproto_2finternal_2eproto() {
   RaftCommand_descriptor_ = file->message_type(0);
   static const int RaftCommand_offsets_[3] = {
     GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(RaftCommand, range_id_),
-    GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(RaftCommand, origin_node_id_),
+    GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(RaftCommand, origin_replica_),
     GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(RaftCommand, cmd_),
   };
   RaftCommand_reflection_ =
@@ -206,25 +206,25 @@ void protobuf_AddDesc_cockroach_2fproto_2finternal_2eproto() {
     "\n\036cockroach/proto/internal.proto\022\017cockro"
     "ach.proto\032\031cockroach/proto/api.proto\032\036co"
     "ckroach/proto/metadata.proto\032\024gogoproto/"
-    "gogo.proto\"\251\001\n\013RaftCommand\022,\n\010range_id\030\001"
-    " \001(\003B\032\310\336\037\000\342\336\037\007RangeID\372\336\037\007RangeID\022:\n\016orig"
-    "in_node_id\030\002 \001(\004B\"\310\336\037\000\342\336\037\014OriginNodeID\372\336"
-    "\037\nRaftNodeID\0220\n\003cmd\030\003 \001(\0132\035.cockroach.pr"
-    "oto.BatchRequestB\004\310\336\037\000\"\236\001\n\026InternalTimeS"
-    "eriesData\022#\n\025start_timestamp_nanos\030\001 \001(\003"
-    "B\004\310\336\037\000\022#\n\025sample_duration_nanos\030\002 \001(\003B\004\310"
-    "\336\037\000\022:\n\007samples\030\003 \003(\0132).cockroach.proto.I"
-    "nternalTimeSeriesSample\"r\n\030InternalTimeS"
-    "eriesSample\022\024\n\006offset\030\001 \001(\005B\004\310\336\037\000\022\023\n\005cou"
-    "nt\030\006 \001(\rB\004\310\336\037\000\022\021\n\003sum\030\007 \001(\001B\004\310\336\037\000\022\013\n\003max"
-    "\030\010 \001(\001\022\013\n\003min\030\t \001(\001\"=\n\022RaftTruncatedStat"
-    "e\022\023\n\005index\030\001 \001(\004B\004\310\336\037\000\022\022\n\004term\030\002 \001(\004B\004\310\336"
-    "\037\000\"\274\001\n\020RaftSnapshotData\022@\n\020range_descrip"
-    "tor\030\001 \001(\0132 .cockroach.proto.RangeDescrip"
-    "torB\004\310\336\037\000\022>\n\002KV\030\002 \003(\0132*.cockroach.proto."
-    "RaftSnapshotData.KeyValueB\006\342\336\037\002KV\032&\n\010Key"
-    "Value\022\013\n\003key\030\001 \001(\014\022\r\n\005value\030\002 \001(\014B\027Z\005pro"
-    "to\340\342\036\001\310\342\036\001\320\342\036\001\220\343\036\000", 858);
+    "gogo.proto\"\245\001\n\013RaftCommand\022,\n\010range_id\030\001"
+    " \001(\003B\032\310\336\037\000\342\336\037\007RangeID\372\336\037\007RangeID\0226\n\016orig"
+    "in_replica\030\002 \001(\0132\030.cockroach.proto.Repli"
+    "caB\004\310\336\037\000\0220\n\003cmd\030\003 \001(\0132\035.cockroach.proto."
+    "BatchRequestB\004\310\336\037\000\"\236\001\n\026InternalTimeSerie"
+    "sData\022#\n\025start_timestamp_nanos\030\001 \001(\003B\004\310\336"
+    "\037\000\022#\n\025sample_duration_nanos\030\002 \001(\003B\004\310\336\037\000\022"
+    ":\n\007samples\030\003 \003(\0132).cockroach.proto.Inter"
+    "nalTimeSeriesSample\"r\n\030InternalTimeSerie"
+    "sSample\022\024\n\006offset\030\001 \001(\005B\004\310\336\037\000\022\023\n\005count\030\006"
+    " \001(\rB\004\310\336\037\000\022\021\n\003sum\030\007 \001(\001B\004\310\336\037\000\022\013\n\003max\030\010 \001"
+    "(\001\022\013\n\003min\030\t \001(\001\"=\n\022RaftTruncatedState\022\023\n"
+    "\005index\030\001 \001(\004B\004\310\336\037\000\022\022\n\004term\030\002 \001(\004B\004\310\336\037\000\"\274"
+    "\001\n\020RaftSnapshotData\022@\n\020range_descriptor\030"
+    "\001 \001(\0132 .cockroach.proto.RangeDescriptorB"
+    "\004\310\336\037\000\022>\n\002KV\030\002 \003(\0132*.cockroach.proto.Raft"
+    "SnapshotData.KeyValueB\006\342\336\037\002KV\032&\n\010KeyValu"
+    "e\022\013\n\003key\030\001 \001(\014\022\r\n\005value\030\002 \001(\014B\027Z\005proto\340\342"
+    "\036\001\310\342\036\001\320\342\036\001\220\343\036\000", 854);
   ::google::protobuf::MessageFactory::InternalRegisterGeneratedFile(
     "cockroach/proto/internal.proto", &protobuf_RegisterTypes);
   RaftCommand::default_instance_ = new RaftCommand();
@@ -263,7 +263,7 @@ static void MergeFromFail(int line) {
 
 #ifndef _MSC_VER
 const int RaftCommand::kRangeIdFieldNumber;
-const int RaftCommand::kOriginNodeIdFieldNumber;
+const int RaftCommand::kOriginReplicaFieldNumber;
 const int RaftCommand::kCmdFieldNumber;
 #endif  // !_MSC_VER
 
@@ -274,6 +274,7 @@ RaftCommand::RaftCommand()
 }
 
 void RaftCommand::InitAsDefaultInstance() {
+  origin_replica_ = const_cast< ::cockroach::proto::Replica*>(&::cockroach::proto::Replica::default_instance());
   cmd_ = const_cast< ::cockroach::proto::BatchRequest*>(&::cockroach::proto::BatchRequest::default_instance());
 }
 
@@ -288,7 +289,7 @@ RaftCommand::RaftCommand(const RaftCommand& from)
 void RaftCommand::SharedCtor() {
   _cached_size_ = 0;
   range_id_ = GOOGLE_LONGLONG(0);
-  origin_node_id_ = GOOGLE_ULONGLONG(0);
+  origin_replica_ = NULL;
   cmd_ = NULL;
   ::memset(_has_bits_, 0, sizeof(_has_bits_));
 }
@@ -300,6 +301,7 @@ RaftCommand::~RaftCommand() {
 
 void RaftCommand::SharedDtor() {
   if (this != default_instance_) {
+    delete origin_replica_;
     delete cmd_;
   }
 }
@@ -330,24 +332,15 @@ RaftCommand* RaftCommand::New(::google::protobuf::Arena* arena) const {
 }
 
 void RaftCommand::Clear() {
-#define ZR_HELPER_(f) reinterpret_cast<char*>(\
-  &reinterpret_cast<RaftCommand*>(16)->f)
-
-#define ZR_(first, last) do {\
-  ::memset(&first, 0,\
-           ZR_HELPER_(last) - ZR_HELPER_(first) + sizeof(last));\
-} while (0)
-
   if (_has_bits_[0 / 32] & 7u) {
-    ZR_(range_id_, origin_node_id_);
+    range_id_ = GOOGLE_LONGLONG(0);
+    if (has_origin_replica()) {
+      if (origin_replica_ != NULL) origin_replica_->::cockroach::proto::Replica::Clear();
+    }
     if (has_cmd()) {
       if (cmd_ != NULL) cmd_->::cockroach::proto::BatchRequest::Clear();
     }
   }
-
-#undef ZR_HELPER_
-#undef ZR_
-
   ::memset(_has_bits_, 0, sizeof(_has_bits_));
   if (_internal_metadata_.have_unknown_fields()) {
     mutable_unknown_fields()->Clear();
@@ -374,18 +367,16 @@ bool RaftCommand::MergePartialFromCodedStream(
         } else {
           goto handle_unusual;
         }
-        if (input->ExpectTag(16)) goto parse_origin_node_id;
+        if (input->ExpectTag(18)) goto parse_origin_replica;
         break;
       }
 
-      // optional uint64 origin_node_id = 2;
+      // optional .cockroach.proto.Replica origin_replica = 2;
       case 2: {
-        if (tag == 16) {
-         parse_origin_node_id:
-          DO_((::google::protobuf::internal::WireFormatLite::ReadPrimitive<
-                   ::google::protobuf::uint64, ::google::protobuf::internal::WireFormatLite::TYPE_UINT64>(
-                 input, &origin_node_id_)));
-          set_has_origin_node_id();
+        if (tag == 18) {
+         parse_origin_replica:
+          DO_(::google::protobuf::internal::WireFormatLite::ReadMessageNoVirtual(
+               input, mutable_origin_replica()));
         } else {
           goto handle_unusual;
         }
@@ -436,9 +427,10 @@ void RaftCommand::SerializeWithCachedSizes(
     ::google::protobuf::internal::WireFormatLite::WriteInt64(1, this->range_id(), output);
   }
 
-  // optional uint64 origin_node_id = 2;
-  if (has_origin_node_id()) {
-    ::google::protobuf::internal::WireFormatLite::WriteUInt64(2, this->origin_node_id(), output);
+  // optional .cockroach.proto.Replica origin_replica = 2;
+  if (has_origin_replica()) {
+    ::google::protobuf::internal::WireFormatLite::WriteMessageMaybeToArray(
+      2, *this->origin_replica_, output);
   }
 
   // optional .cockroach.proto.BatchRequest cmd = 3;
@@ -462,9 +454,11 @@ void RaftCommand::SerializeWithCachedSizes(
     target = ::google::protobuf::internal::WireFormatLite::WriteInt64ToArray(1, this->range_id(), target);
   }
 
-  // optional uint64 origin_node_id = 2;
-  if (has_origin_node_id()) {
-    target = ::google::protobuf::internal::WireFormatLite::WriteUInt64ToArray(2, this->origin_node_id(), target);
+  // optional .cockroach.proto.Replica origin_replica = 2;
+  if (has_origin_replica()) {
+    target = ::google::protobuf::internal::WireFormatLite::
+      WriteMessageNoVirtualToArray(
+        2, *this->origin_replica_, target);
   }
 
   // optional .cockroach.proto.BatchRequest cmd = 3;
@@ -493,11 +487,11 @@ int RaftCommand::ByteSize() const {
           this->range_id());
     }
 
-    // optional uint64 origin_node_id = 2;
-    if (has_origin_node_id()) {
+    // optional .cockroach.proto.Replica origin_replica = 2;
+    if (has_origin_replica()) {
       total_size += 1 +
-        ::google::protobuf::internal::WireFormatLite::UInt64Size(
-          this->origin_node_id());
+        ::google::protobuf::internal::WireFormatLite::MessageSizeNoVirtual(
+          *this->origin_replica_);
     }
 
     // optional .cockroach.proto.BatchRequest cmd = 3;
@@ -537,8 +531,8 @@ void RaftCommand::MergeFrom(const RaftCommand& from) {
     if (from.has_range_id()) {
       set_range_id(from.range_id());
     }
-    if (from.has_origin_node_id()) {
-      set_origin_node_id(from.origin_node_id());
+    if (from.has_origin_replica()) {
+      mutable_origin_replica()->::cockroach::proto::Replica::MergeFrom(from.origin_replica());
     }
     if (from.has_cmd()) {
       mutable_cmd()->::cockroach::proto::BatchRequest::MergeFrom(from.cmd());
@@ -572,7 +566,7 @@ void RaftCommand::Swap(RaftCommand* other) {
 }
 void RaftCommand::InternalSwap(RaftCommand* other) {
   std::swap(range_id_, other->range_id_);
-  std::swap(origin_node_id_, other->origin_node_id_);
+  std::swap(origin_replica_, other->origin_replica_);
   std::swap(cmd_, other->cmd_);
   std::swap(_has_bits_[0], other->_has_bits_[0]);
   _internal_metadata_.Swap(&other->_internal_metadata_);
@@ -614,28 +608,47 @@ void RaftCommand::clear_range_id() {
   // @@protoc_insertion_point(field_set:cockroach.proto.RaftCommand.range_id)
 }
 
-// optional uint64 origin_node_id = 2;
-bool RaftCommand::has_origin_node_id() const {
+// optional .cockroach.proto.Replica origin_replica = 2;
+bool RaftCommand::has_origin_replica() const {
   return (_has_bits_[0] & 0x00000002u) != 0;
 }
-void RaftCommand::set_has_origin_node_id() {
+void RaftCommand::set_has_origin_replica() {
   _has_bits_[0] |= 0x00000002u;
 }
-void RaftCommand::clear_has_origin_node_id() {
+void RaftCommand::clear_has_origin_replica() {
   _has_bits_[0] &= ~0x00000002u;
 }
-void RaftCommand::clear_origin_node_id() {
-  origin_node_id_ = GOOGLE_ULONGLONG(0);
-  clear_has_origin_node_id();
+void RaftCommand::clear_origin_replica() {
+  if (origin_replica_ != NULL) origin_replica_->::cockroach::proto::Replica::Clear();
+  clear_has_origin_replica();
 }
- ::google::protobuf::uint64 RaftCommand::origin_node_id() const {
-  // @@protoc_insertion_point(field_get:cockroach.proto.RaftCommand.origin_node_id)
-  return origin_node_id_;
+ const ::cockroach::proto::Replica& RaftCommand::origin_replica() const {
+  // @@protoc_insertion_point(field_get:cockroach.proto.RaftCommand.origin_replica)
+  return origin_replica_ != NULL ? *origin_replica_ : *default_instance_->origin_replica_;
 }
- void RaftCommand::set_origin_node_id(::google::protobuf::uint64 value) {
-  set_has_origin_node_id();
-  origin_node_id_ = value;
-  // @@protoc_insertion_point(field_set:cockroach.proto.RaftCommand.origin_node_id)
+ ::cockroach::proto::Replica* RaftCommand::mutable_origin_replica() {
+  set_has_origin_replica();
+  if (origin_replica_ == NULL) {
+    origin_replica_ = new ::cockroach::proto::Replica;
+  }
+  // @@protoc_insertion_point(field_mutable:cockroach.proto.RaftCommand.origin_replica)
+  return origin_replica_;
+}
+ ::cockroach::proto::Replica* RaftCommand::release_origin_replica() {
+  clear_has_origin_replica();
+  ::cockroach::proto::Replica* temp = origin_replica_;
+  origin_replica_ = NULL;
+  return temp;
+}
+ void RaftCommand::set_allocated_origin_replica(::cockroach::proto::Replica* origin_replica) {
+  delete origin_replica_;
+  origin_replica_ = origin_replica;
+  if (origin_replica) {
+    set_has_origin_replica();
+  } else {
+    clear_has_origin_replica();
+  }
+  // @@protoc_insertion_point(field_set_allocated:cockroach.proto.RaftCommand.origin_replica)
 }
 
 // optional .cockroach.proto.BatchRequest cmd = 3;

--- a/storage/engine/rocksdb/cockroach/proto/internal.pb.cc
+++ b/storage/engine/rocksdb/cockroach/proto/internal.pb.cc
@@ -206,25 +206,25 @@ void protobuf_AddDesc_cockroach_2fproto_2finternal_2eproto() {
     "\n\036cockroach/proto/internal.proto\022\017cockro"
     "ach.proto\032\031cockroach/proto/api.proto\032\036co"
     "ckroach/proto/metadata.proto\032\024gogoproto/"
-    "gogo.proto\"\245\001\n\013RaftCommand\022,\n\010range_id\030\001"
-    " \001(\003B\032\310\336\037\000\342\336\037\007RangeID\372\336\037\007RangeID\0226\n\016orig"
-    "in_replica\030\002 \001(\0132\030.cockroach.proto.Repli"
-    "caB\004\310\336\037\000\0220\n\003cmd\030\003 \001(\0132\035.cockroach.proto."
-    "BatchRequestB\004\310\336\037\000\"\236\001\n\026InternalTimeSerie"
-    "sData\022#\n\025start_timestamp_nanos\030\001 \001(\003B\004\310\336"
-    "\037\000\022#\n\025sample_duration_nanos\030\002 \001(\003B\004\310\336\037\000\022"
-    ":\n\007samples\030\003 \003(\0132).cockroach.proto.Inter"
-    "nalTimeSeriesSample\"r\n\030InternalTimeSerie"
-    "sSample\022\024\n\006offset\030\001 \001(\005B\004\310\336\037\000\022\023\n\005count\030\006"
-    " \001(\rB\004\310\336\037\000\022\021\n\003sum\030\007 \001(\001B\004\310\336\037\000\022\013\n\003max\030\010 \001"
-    "(\001\022\013\n\003min\030\t \001(\001\"=\n\022RaftTruncatedState\022\023\n"
-    "\005index\030\001 \001(\004B\004\310\336\037\000\022\022\n\004term\030\002 \001(\004B\004\310\336\037\000\"\274"
-    "\001\n\020RaftSnapshotData\022@\n\020range_descriptor\030"
-    "\001 \001(\0132 .cockroach.proto.RangeDescriptorB"
-    "\004\310\336\037\000\022>\n\002KV\030\002 \003(\0132*.cockroach.proto.Raft"
-    "SnapshotData.KeyValueB\006\342\336\037\002KV\032&\n\010KeyValu"
-    "e\022\013\n\003key\030\001 \001(\014\022\r\n\005value\030\002 \001(\014B\027Z\005proto\340\342"
-    "\036\001\310\342\036\001\320\342\036\001\220\343\036\000", 854);
+    "gogo.proto\"\257\001\n\013RaftCommand\022,\n\010range_id\030\001"
+    " \001(\003B\032\310\336\037\000\342\336\037\007RangeID\372\336\037\007RangeID\022@\n\016orig"
+    "in_replica\030\002 \001(\0132\".cockroach.proto.Repli"
+    "caDescriptorB\004\310\336\037\000\0220\n\003cmd\030\003 \001(\0132\035.cockro"
+    "ach.proto.BatchRequestB\004\310\336\037\000\"\236\001\n\026Interna"
+    "lTimeSeriesData\022#\n\025start_timestamp_nanos"
+    "\030\001 \001(\003B\004\310\336\037\000\022#\n\025sample_duration_nanos\030\002 "
+    "\001(\003B\004\310\336\037\000\022:\n\007samples\030\003 \003(\0132).cockroach.p"
+    "roto.InternalTimeSeriesSample\"r\n\030Interna"
+    "lTimeSeriesSample\022\024\n\006offset\030\001 \001(\005B\004\310\336\037\000\022"
+    "\023\n\005count\030\006 \001(\rB\004\310\336\037\000\022\021\n\003sum\030\007 \001(\001B\004\310\336\037\000\022"
+    "\013\n\003max\030\010 \001(\001\022\013\n\003min\030\t \001(\001\"=\n\022RaftTruncat"
+    "edState\022\023\n\005index\030\001 \001(\004B\004\310\336\037\000\022\022\n\004term\030\002 \001"
+    "(\004B\004\310\336\037\000\"\274\001\n\020RaftSnapshotData\022@\n\020range_d"
+    "escriptor\030\001 \001(\0132 .cockroach.proto.RangeD"
+    "escriptorB\004\310\336\037\000\022>\n\002KV\030\002 \003(\0132*.cockroach."
+    "proto.RaftSnapshotData.KeyValueB\006\342\336\037\002KV\032"
+    "&\n\010KeyValue\022\013\n\003key\030\001 \001(\014\022\r\n\005value\030\002 \001(\014B"
+    "\027Z\005proto\340\342\036\001\310\342\036\001\320\342\036\001\220\343\036\000", 864);
   ::google::protobuf::MessageFactory::InternalRegisterGeneratedFile(
     "cockroach/proto/internal.proto", &protobuf_RegisterTypes);
   RaftCommand::default_instance_ = new RaftCommand();
@@ -274,7 +274,7 @@ RaftCommand::RaftCommand()
 }
 
 void RaftCommand::InitAsDefaultInstance() {
-  origin_replica_ = const_cast< ::cockroach::proto::Replica*>(&::cockroach::proto::Replica::default_instance());
+  origin_replica_ = const_cast< ::cockroach::proto::ReplicaDescriptor*>(&::cockroach::proto::ReplicaDescriptor::default_instance());
   cmd_ = const_cast< ::cockroach::proto::BatchRequest*>(&::cockroach::proto::BatchRequest::default_instance());
 }
 
@@ -335,7 +335,7 @@ void RaftCommand::Clear() {
   if (_has_bits_[0 / 32] & 7u) {
     range_id_ = GOOGLE_LONGLONG(0);
     if (has_origin_replica()) {
-      if (origin_replica_ != NULL) origin_replica_->::cockroach::proto::Replica::Clear();
+      if (origin_replica_ != NULL) origin_replica_->::cockroach::proto::ReplicaDescriptor::Clear();
     }
     if (has_cmd()) {
       if (cmd_ != NULL) cmd_->::cockroach::proto::BatchRequest::Clear();
@@ -371,7 +371,7 @@ bool RaftCommand::MergePartialFromCodedStream(
         break;
       }
 
-      // optional .cockroach.proto.Replica origin_replica = 2;
+      // optional .cockroach.proto.ReplicaDescriptor origin_replica = 2;
       case 2: {
         if (tag == 18) {
          parse_origin_replica:
@@ -427,7 +427,7 @@ void RaftCommand::SerializeWithCachedSizes(
     ::google::protobuf::internal::WireFormatLite::WriteInt64(1, this->range_id(), output);
   }
 
-  // optional .cockroach.proto.Replica origin_replica = 2;
+  // optional .cockroach.proto.ReplicaDescriptor origin_replica = 2;
   if (has_origin_replica()) {
     ::google::protobuf::internal::WireFormatLite::WriteMessageMaybeToArray(
       2, *this->origin_replica_, output);
@@ -454,7 +454,7 @@ void RaftCommand::SerializeWithCachedSizes(
     target = ::google::protobuf::internal::WireFormatLite::WriteInt64ToArray(1, this->range_id(), target);
   }
 
-  // optional .cockroach.proto.Replica origin_replica = 2;
+  // optional .cockroach.proto.ReplicaDescriptor origin_replica = 2;
   if (has_origin_replica()) {
     target = ::google::protobuf::internal::WireFormatLite::
       WriteMessageNoVirtualToArray(
@@ -487,7 +487,7 @@ int RaftCommand::ByteSize() const {
           this->range_id());
     }
 
-    // optional .cockroach.proto.Replica origin_replica = 2;
+    // optional .cockroach.proto.ReplicaDescriptor origin_replica = 2;
     if (has_origin_replica()) {
       total_size += 1 +
         ::google::protobuf::internal::WireFormatLite::MessageSizeNoVirtual(
@@ -532,7 +532,7 @@ void RaftCommand::MergeFrom(const RaftCommand& from) {
       set_range_id(from.range_id());
     }
     if (from.has_origin_replica()) {
-      mutable_origin_replica()->::cockroach::proto::Replica::MergeFrom(from.origin_replica());
+      mutable_origin_replica()->::cockroach::proto::ReplicaDescriptor::MergeFrom(from.origin_replica());
     }
     if (from.has_cmd()) {
       mutable_cmd()->::cockroach::proto::BatchRequest::MergeFrom(from.cmd());
@@ -608,7 +608,7 @@ void RaftCommand::clear_range_id() {
   // @@protoc_insertion_point(field_set:cockroach.proto.RaftCommand.range_id)
 }
 
-// optional .cockroach.proto.Replica origin_replica = 2;
+// optional .cockroach.proto.ReplicaDescriptor origin_replica = 2;
 bool RaftCommand::has_origin_replica() const {
   return (_has_bits_[0] & 0x00000002u) != 0;
 }
@@ -619,28 +619,28 @@ void RaftCommand::clear_has_origin_replica() {
   _has_bits_[0] &= ~0x00000002u;
 }
 void RaftCommand::clear_origin_replica() {
-  if (origin_replica_ != NULL) origin_replica_->::cockroach::proto::Replica::Clear();
+  if (origin_replica_ != NULL) origin_replica_->::cockroach::proto::ReplicaDescriptor::Clear();
   clear_has_origin_replica();
 }
- const ::cockroach::proto::Replica& RaftCommand::origin_replica() const {
+ const ::cockroach::proto::ReplicaDescriptor& RaftCommand::origin_replica() const {
   // @@protoc_insertion_point(field_get:cockroach.proto.RaftCommand.origin_replica)
   return origin_replica_ != NULL ? *origin_replica_ : *default_instance_->origin_replica_;
 }
- ::cockroach::proto::Replica* RaftCommand::mutable_origin_replica() {
+ ::cockroach::proto::ReplicaDescriptor* RaftCommand::mutable_origin_replica() {
   set_has_origin_replica();
   if (origin_replica_ == NULL) {
-    origin_replica_ = new ::cockroach::proto::Replica;
+    origin_replica_ = new ::cockroach::proto::ReplicaDescriptor;
   }
   // @@protoc_insertion_point(field_mutable:cockroach.proto.RaftCommand.origin_replica)
   return origin_replica_;
 }
- ::cockroach::proto::Replica* RaftCommand::release_origin_replica() {
+ ::cockroach::proto::ReplicaDescriptor* RaftCommand::release_origin_replica() {
   clear_has_origin_replica();
-  ::cockroach::proto::Replica* temp = origin_replica_;
+  ::cockroach::proto::ReplicaDescriptor* temp = origin_replica_;
   origin_replica_ = NULL;
   return temp;
 }
- void RaftCommand::set_allocated_origin_replica(::cockroach::proto::Replica* origin_replica) {
+ void RaftCommand::set_allocated_origin_replica(::cockroach::proto::ReplicaDescriptor* origin_replica) {
   delete origin_replica_;
   origin_replica_ = origin_replica;
   if (origin_replica) {

--- a/storage/engine/rocksdb/cockroach/proto/internal.pb.h
+++ b/storage/engine/rocksdb/cockroach/proto/internal.pb.h
@@ -120,14 +120,14 @@ class RaftCommand : public ::google::protobuf::Message {
   ::google::protobuf::int64 range_id() const;
   void set_range_id(::google::protobuf::int64 value);
 
-  // optional .cockroach.proto.Replica origin_replica = 2;
+  // optional .cockroach.proto.ReplicaDescriptor origin_replica = 2;
   bool has_origin_replica() const;
   void clear_origin_replica();
   static const int kOriginReplicaFieldNumber = 2;
-  const ::cockroach::proto::Replica& origin_replica() const;
-  ::cockroach::proto::Replica* mutable_origin_replica();
-  ::cockroach::proto::Replica* release_origin_replica();
-  void set_allocated_origin_replica(::cockroach::proto::Replica* origin_replica);
+  const ::cockroach::proto::ReplicaDescriptor& origin_replica() const;
+  ::cockroach::proto::ReplicaDescriptor* mutable_origin_replica();
+  ::cockroach::proto::ReplicaDescriptor* release_origin_replica();
+  void set_allocated_origin_replica(::cockroach::proto::ReplicaDescriptor* origin_replica);
 
   // optional .cockroach.proto.BatchRequest cmd = 3;
   bool has_cmd() const;
@@ -151,7 +151,7 @@ class RaftCommand : public ::google::protobuf::Message {
   ::google::protobuf::uint32 _has_bits_[1];
   mutable int _cached_size_;
   ::google::protobuf::int64 range_id_;
-  ::cockroach::proto::Replica* origin_replica_;
+  ::cockroach::proto::ReplicaDescriptor* origin_replica_;
   ::cockroach::proto::BatchRequest* cmd_;
   friend void  protobuf_AddDesc_cockroach_2fproto_2finternal_2eproto();
   friend void protobuf_AssignDesc_cockroach_2fproto_2finternal_2eproto();
@@ -747,7 +747,7 @@ inline void RaftCommand::set_range_id(::google::protobuf::int64 value) {
   // @@protoc_insertion_point(field_set:cockroach.proto.RaftCommand.range_id)
 }
 
-// optional .cockroach.proto.Replica origin_replica = 2;
+// optional .cockroach.proto.ReplicaDescriptor origin_replica = 2;
 inline bool RaftCommand::has_origin_replica() const {
   return (_has_bits_[0] & 0x00000002u) != 0;
 }
@@ -758,28 +758,28 @@ inline void RaftCommand::clear_has_origin_replica() {
   _has_bits_[0] &= ~0x00000002u;
 }
 inline void RaftCommand::clear_origin_replica() {
-  if (origin_replica_ != NULL) origin_replica_->::cockroach::proto::Replica::Clear();
+  if (origin_replica_ != NULL) origin_replica_->::cockroach::proto::ReplicaDescriptor::Clear();
   clear_has_origin_replica();
 }
-inline const ::cockroach::proto::Replica& RaftCommand::origin_replica() const {
+inline const ::cockroach::proto::ReplicaDescriptor& RaftCommand::origin_replica() const {
   // @@protoc_insertion_point(field_get:cockroach.proto.RaftCommand.origin_replica)
   return origin_replica_ != NULL ? *origin_replica_ : *default_instance_->origin_replica_;
 }
-inline ::cockroach::proto::Replica* RaftCommand::mutable_origin_replica() {
+inline ::cockroach::proto::ReplicaDescriptor* RaftCommand::mutable_origin_replica() {
   set_has_origin_replica();
   if (origin_replica_ == NULL) {
-    origin_replica_ = new ::cockroach::proto::Replica;
+    origin_replica_ = new ::cockroach::proto::ReplicaDescriptor;
   }
   // @@protoc_insertion_point(field_mutable:cockroach.proto.RaftCommand.origin_replica)
   return origin_replica_;
 }
-inline ::cockroach::proto::Replica* RaftCommand::release_origin_replica() {
+inline ::cockroach::proto::ReplicaDescriptor* RaftCommand::release_origin_replica() {
   clear_has_origin_replica();
-  ::cockroach::proto::Replica* temp = origin_replica_;
+  ::cockroach::proto::ReplicaDescriptor* temp = origin_replica_;
   origin_replica_ = NULL;
   return temp;
 }
-inline void RaftCommand::set_allocated_origin_replica(::cockroach::proto::Replica* origin_replica) {
+inline void RaftCommand::set_allocated_origin_replica(::cockroach::proto::ReplicaDescriptor* origin_replica) {
   delete origin_replica_;
   origin_replica_ = origin_replica;
   if (origin_replica) {

--- a/storage/engine/rocksdb/cockroach/proto/internal.pb.h
+++ b/storage/engine/rocksdb/cockroach/proto/internal.pb.h
@@ -120,12 +120,14 @@ class RaftCommand : public ::google::protobuf::Message {
   ::google::protobuf::int64 range_id() const;
   void set_range_id(::google::protobuf::int64 value);
 
-  // optional uint64 origin_node_id = 2;
-  bool has_origin_node_id() const;
-  void clear_origin_node_id();
-  static const int kOriginNodeIdFieldNumber = 2;
-  ::google::protobuf::uint64 origin_node_id() const;
-  void set_origin_node_id(::google::protobuf::uint64 value);
+  // optional .cockroach.proto.Replica origin_replica = 2;
+  bool has_origin_replica() const;
+  void clear_origin_replica();
+  static const int kOriginReplicaFieldNumber = 2;
+  const ::cockroach::proto::Replica& origin_replica() const;
+  ::cockroach::proto::Replica* mutable_origin_replica();
+  ::cockroach::proto::Replica* release_origin_replica();
+  void set_allocated_origin_replica(::cockroach::proto::Replica* origin_replica);
 
   // optional .cockroach.proto.BatchRequest cmd = 3;
   bool has_cmd() const;
@@ -140,8 +142,8 @@ class RaftCommand : public ::google::protobuf::Message {
  private:
   inline void set_has_range_id();
   inline void clear_has_range_id();
-  inline void set_has_origin_node_id();
-  inline void clear_has_origin_node_id();
+  inline void set_has_origin_replica();
+  inline void clear_has_origin_replica();
   inline void set_has_cmd();
   inline void clear_has_cmd();
 
@@ -149,7 +151,7 @@ class RaftCommand : public ::google::protobuf::Message {
   ::google::protobuf::uint32 _has_bits_[1];
   mutable int _cached_size_;
   ::google::protobuf::int64 range_id_;
-  ::google::protobuf::uint64 origin_node_id_;
+  ::cockroach::proto::Replica* origin_replica_;
   ::cockroach::proto::BatchRequest* cmd_;
   friend void  protobuf_AddDesc_cockroach_2fproto_2finternal_2eproto();
   friend void protobuf_AssignDesc_cockroach_2fproto_2finternal_2eproto();
@@ -745,28 +747,47 @@ inline void RaftCommand::set_range_id(::google::protobuf::int64 value) {
   // @@protoc_insertion_point(field_set:cockroach.proto.RaftCommand.range_id)
 }
 
-// optional uint64 origin_node_id = 2;
-inline bool RaftCommand::has_origin_node_id() const {
+// optional .cockroach.proto.Replica origin_replica = 2;
+inline bool RaftCommand::has_origin_replica() const {
   return (_has_bits_[0] & 0x00000002u) != 0;
 }
-inline void RaftCommand::set_has_origin_node_id() {
+inline void RaftCommand::set_has_origin_replica() {
   _has_bits_[0] |= 0x00000002u;
 }
-inline void RaftCommand::clear_has_origin_node_id() {
+inline void RaftCommand::clear_has_origin_replica() {
   _has_bits_[0] &= ~0x00000002u;
 }
-inline void RaftCommand::clear_origin_node_id() {
-  origin_node_id_ = GOOGLE_ULONGLONG(0);
-  clear_has_origin_node_id();
+inline void RaftCommand::clear_origin_replica() {
+  if (origin_replica_ != NULL) origin_replica_->::cockroach::proto::Replica::Clear();
+  clear_has_origin_replica();
 }
-inline ::google::protobuf::uint64 RaftCommand::origin_node_id() const {
-  // @@protoc_insertion_point(field_get:cockroach.proto.RaftCommand.origin_node_id)
-  return origin_node_id_;
+inline const ::cockroach::proto::Replica& RaftCommand::origin_replica() const {
+  // @@protoc_insertion_point(field_get:cockroach.proto.RaftCommand.origin_replica)
+  return origin_replica_ != NULL ? *origin_replica_ : *default_instance_->origin_replica_;
 }
-inline void RaftCommand::set_origin_node_id(::google::protobuf::uint64 value) {
-  set_has_origin_node_id();
-  origin_node_id_ = value;
-  // @@protoc_insertion_point(field_set:cockroach.proto.RaftCommand.origin_node_id)
+inline ::cockroach::proto::Replica* RaftCommand::mutable_origin_replica() {
+  set_has_origin_replica();
+  if (origin_replica_ == NULL) {
+    origin_replica_ = new ::cockroach::proto::Replica;
+  }
+  // @@protoc_insertion_point(field_mutable:cockroach.proto.RaftCommand.origin_replica)
+  return origin_replica_;
+}
+inline ::cockroach::proto::Replica* RaftCommand::release_origin_replica() {
+  clear_has_origin_replica();
+  ::cockroach::proto::Replica* temp = origin_replica_;
+  origin_replica_ = NULL;
+  return temp;
+}
+inline void RaftCommand::set_allocated_origin_replica(::cockroach::proto::Replica* origin_replica) {
+  delete origin_replica_;
+  origin_replica_ = origin_replica;
+  if (origin_replica) {
+    set_has_origin_replica();
+  } else {
+    clear_has_origin_replica();
+  }
+  // @@protoc_insertion_point(field_set_allocated:cockroach.proto.RaftCommand.origin_replica)
 }
 
 // optional .cockroach.proto.BatchRequest cmd = 3;

--- a/storage/engine/rocksdb/cockroach/proto/metadata.pb.cc
+++ b/storage/engine/rocksdb/cockroach/proto/metadata.pb.cc
@@ -24,9 +24,9 @@ namespace {
 const ::google::protobuf::Descriptor* Attributes_descriptor_ = NULL;
 const ::google::protobuf::internal::GeneratedMessageReflection*
   Attributes_reflection_ = NULL;
-const ::google::protobuf::Descriptor* Replica_descriptor_ = NULL;
+const ::google::protobuf::Descriptor* ReplicaDescriptor_descriptor_ = NULL;
 const ::google::protobuf::internal::GeneratedMessageReflection*
-  Replica_reflection_ = NULL;
+  ReplicaDescriptor_reflection_ = NULL;
 const ::google::protobuf::Descriptor* RangeDescriptor_descriptor_ = NULL;
 const ::google::protobuf::internal::GeneratedMessageReflection*
   RangeDescriptor_reflection_ = NULL;
@@ -70,22 +70,22 @@ void protobuf_AssignDesc_cockroach_2fproto_2fmetadata_2eproto() {
       sizeof(Attributes),
       GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(Attributes, _internal_metadata_),
       -1);
-  Replica_descriptor_ = file->message_type(1);
-  static const int Replica_offsets_[3] = {
-    GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(Replica, node_id_),
-    GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(Replica, store_id_),
-    GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(Replica, replica_id_),
+  ReplicaDescriptor_descriptor_ = file->message_type(1);
+  static const int ReplicaDescriptor_offsets_[3] = {
+    GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(ReplicaDescriptor, node_id_),
+    GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(ReplicaDescriptor, store_id_),
+    GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(ReplicaDescriptor, replica_id_),
   };
-  Replica_reflection_ =
+  ReplicaDescriptor_reflection_ =
     ::google::protobuf::internal::GeneratedMessageReflection::NewGeneratedMessageReflection(
-      Replica_descriptor_,
-      Replica::default_instance_,
-      Replica_offsets_,
-      GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(Replica, _has_bits_[0]),
+      ReplicaDescriptor_descriptor_,
+      ReplicaDescriptor::default_instance_,
+      ReplicaDescriptor_offsets_,
+      GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(ReplicaDescriptor, _has_bits_[0]),
       -1,
       -1,
-      sizeof(Replica),
-      GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(Replica, _internal_metadata_),
+      sizeof(ReplicaDescriptor),
+      GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(ReplicaDescriptor, _internal_metadata_),
       -1);
   RangeDescriptor_descriptor_ = file->message_type(2);
   static const int RangeDescriptor_offsets_[5] = {
@@ -207,7 +207,7 @@ void protobuf_RegisterTypes(const ::std::string&) {
   ::google::protobuf::MessageFactory::InternalRegisterGeneratedMessage(
       Attributes_descriptor_, &Attributes::default_instance());
   ::google::protobuf::MessageFactory::InternalRegisterGeneratedMessage(
-      Replica_descriptor_, &Replica::default_instance());
+      ReplicaDescriptor_descriptor_, &ReplicaDescriptor::default_instance());
   ::google::protobuf::MessageFactory::InternalRegisterGeneratedMessage(
       RangeDescriptor_descriptor_, &RangeDescriptor::default_instance());
   ::google::protobuf::MessageFactory::InternalRegisterGeneratedMessage(
@@ -227,8 +227,8 @@ void protobuf_RegisterTypes(const ::std::string&) {
 void protobuf_ShutdownFile_cockroach_2fproto_2fmetadata_2eproto() {
   delete Attributes::default_instance_;
   delete Attributes_reflection_;
-  delete Replica::default_instance_;
-  delete Replica_reflection_;
+  delete ReplicaDescriptor::default_instance_;
+  delete ReplicaDescriptor_reflection_;
   delete RangeDescriptor::default_instance_;
   delete RangeDescriptor_reflection_;
   delete RangeTree::default_instance_;
@@ -256,38 +256,38 @@ void protobuf_AddDesc_cockroach_2fproto_2fmetadata_2eproto() {
     "ach.proto\032\024gogoproto/gogo.proto\032$cockroa"
     "ch/util/unresolved_addr.proto\"8\n\nAttribu"
     "tes\022$\n\005attrs\030\001 \003(\tB\025\362\336\037\021yaml:\"attrs,flow"
-    "\":\004\230\240\037\000\"\226\001\n\007Replica\022)\n\007node_id\030\001 \001(\005B\030\310\336"
-    "\037\000\342\336\037\006NodeID\372\336\037\006NodeID\022,\n\010store_id\030\002 \001(\005"
-    "B\032\310\336\037\000\342\336\037\007StoreID\372\336\037\007StoreID\0222\n\nreplica_"
-    "id\030\003 \001(\005B\036\310\336\037\000\342\336\037\tReplicaID\372\336\037\tReplicaID"
-    "\"\344\001\n\017RangeDescriptor\022,\n\010range_id\030\001 \001(\003B\032"
-    "\310\336\037\000\342\336\037\007RangeID\372\336\037\007RangeID\022\032\n\tstart_key\030"
-    "\002 \001(\014B\007\372\336\037\003Key\022\030\n\007end_key\030\003 \001(\014B\007\372\336\037\003Key"
-    "\0220\n\010replicas\030\004 \003(\0132\030.cockroach.proto.Rep"
-    "licaB\004\310\336\037\000\022;\n\017next_replica_id\030\005 \001(\005B\"\310\336\037"
-    "\000\342\336\037\rNextReplicaID\372\336\037\tReplicaID\"&\n\tRange"
-    "Tree\022\031\n\010root_key\030\001 \001(\014B\007\372\336\037\003Key\"\216\001\n\rRang"
-    "eTreeNode\022\024\n\003key\030\001 \001(\014B\007\372\336\037\003Key\022\023\n\005black"
-    "\030\002 \001(\010B\004\310\336\037\000\022\033\n\nparent_key\030\003 \001(\014B\007\372\336\037\003Ke"
-    "y\022\031\n\010left_key\030\004 \001(\014B\007\372\336\037\003Key\022\032\n\tright_ke"
-    "y\030\005 \001(\014B\007\372\336\037\003Key\"Z\n\rStoreCapacity\022\026\n\010Cap"
-    "acity\030\001 \001(\003B\004\310\336\037\000\022\027\n\tAvailable\030\002 \001(\003B\004\310\336"
-    "\037\000\022\030\n\nRangeCount\030\003 \001(\005B\004\310\336\037\000\"\244\001\n\016NodeDes"
-    "criptor\022)\n\007node_id\030\001 \001(\005B\030\310\336\037\000\342\336\037\006NodeID"
-    "\372\336\037\006NodeID\0225\n\007address\030\002 \001(\0132\036.cockroach."
-    "util.UnresolvedAddrB\004\310\336\037\000\0220\n\005attrs\030\003 \001(\013"
-    "2\033.cockroach.proto.AttributesB\004\310\336\037\000\"\336\001\n\017"
-    "StoreDescriptor\022,\n\010store_id\030\001 \001(\005B\032\310\336\037\000\342"
-    "\336\037\007StoreID\372\336\037\007StoreID\0220\n\005attrs\030\002 \001(\0132\033.c"
-    "ockroach.proto.AttributesB\004\310\336\037\000\0223\n\004node\030"
-    "\003 \001(\0132\037.cockroach.proto.NodeDescriptorB\004"
-    "\310\336\037\000\0226\n\010capacity\030\004 \001(\0132\036.cockroach.proto"
-    ".StoreCapacityB\004\310\336\037\000B\027Z\005proto\340\342\036\001\310\342\036\001\320\342\036"
-    "\001\220\343\036\000", 1245);
+    "\":\004\230\240\037\000\"\240\001\n\021ReplicaDescriptor\022)\n\007node_id"
+    "\030\001 \001(\005B\030\310\336\037\000\342\336\037\006NodeID\372\336\037\006NodeID\022,\n\010stor"
+    "e_id\030\002 \001(\005B\032\310\336\037\000\342\336\037\007StoreID\372\336\037\007StoreID\0222"
+    "\n\nreplica_id\030\003 \001(\005B\036\310\336\037\000\342\336\037\tReplicaID\372\336\037"
+    "\tReplicaID\"\356\001\n\017RangeDescriptor\022,\n\010range_"
+    "id\030\001 \001(\003B\032\310\336\037\000\342\336\037\007RangeID\372\336\037\007RangeID\022\032\n\t"
+    "start_key\030\002 \001(\014B\007\372\336\037\003Key\022\030\n\007end_key\030\003 \001("
+    "\014B\007\372\336\037\003Key\022:\n\010replicas\030\004 \003(\0132\".cockroach"
+    ".proto.ReplicaDescriptorB\004\310\336\037\000\022;\n\017next_r"
+    "eplica_id\030\005 \001(\005B\"\310\336\037\000\342\336\037\rNextReplicaID\372\336"
+    "\037\tReplicaID\"&\n\tRangeTree\022\031\n\010root_key\030\001 \001"
+    "(\014B\007\372\336\037\003Key\"\216\001\n\rRangeTreeNode\022\024\n\003key\030\001 \001"
+    "(\014B\007\372\336\037\003Key\022\023\n\005black\030\002 \001(\010B\004\310\336\037\000\022\033\n\npare"
+    "nt_key\030\003 \001(\014B\007\372\336\037\003Key\022\031\n\010left_key\030\004 \001(\014B"
+    "\007\372\336\037\003Key\022\032\n\tright_key\030\005 \001(\014B\007\372\336\037\003Key\"Z\n\r"
+    "StoreCapacity\022\026\n\010Capacity\030\001 \001(\003B\004\310\336\037\000\022\027\n"
+    "\tAvailable\030\002 \001(\003B\004\310\336\037\000\022\030\n\nRangeCount\030\003 \001"
+    "(\005B\004\310\336\037\000\"\244\001\n\016NodeDescriptor\022)\n\007node_id\030\001"
+    " \001(\005B\030\310\336\037\000\342\336\037\006NodeID\372\336\037\006NodeID\0225\n\007addres"
+    "s\030\002 \001(\0132\036.cockroach.util.UnresolvedAddrB"
+    "\004\310\336\037\000\0220\n\005attrs\030\003 \001(\0132\033.cockroach.proto.A"
+    "ttributesB\004\310\336\037\000\"\336\001\n\017StoreDescriptor\022,\n\010s"
+    "tore_id\030\001 \001(\005B\032\310\336\037\000\342\336\037\007StoreID\372\336\037\007StoreI"
+    "D\0220\n\005attrs\030\002 \001(\0132\033.cockroach.proto.Attri"
+    "butesB\004\310\336\037\000\0223\n\004node\030\003 \001(\0132\037.cockroach.pr"
+    "oto.NodeDescriptorB\004\310\336\037\000\0226\n\010capacity\030\004 \001"
+    "(\0132\036.cockroach.proto.StoreCapacityB\004\310\336\037\000"
+    "B\027Z\005proto\340\342\036\001\310\342\036\001\320\342\036\001\220\343\036\000", 1265);
   ::google::protobuf::MessageFactory::InternalRegisterGeneratedFile(
     "cockroach/proto/metadata.proto", &protobuf_RegisterTypes);
   Attributes::default_instance_ = new Attributes();
-  Replica::default_instance_ = new Replica();
+  ReplicaDescriptor::default_instance_ = new ReplicaDescriptor();
   RangeDescriptor::default_instance_ = new RangeDescriptor();
   RangeTree::default_instance_ = new RangeTree();
   RangeTreeNode::default_instance_ = new RangeTreeNode();
@@ -295,7 +295,7 @@ void protobuf_AddDesc_cockroach_2fproto_2fmetadata_2eproto() {
   NodeDescriptor::default_instance_ = new NodeDescriptor();
   StoreDescriptor::default_instance_ = new StoreDescriptor();
   Attributes::default_instance_->InitAsDefaultInstance();
-  Replica::default_instance_->InitAsDefaultInstance();
+  ReplicaDescriptor::default_instance_->InitAsDefaultInstance();
   RangeDescriptor::default_instance_->InitAsDefaultInstance();
   RangeTree::default_instance_->InitAsDefaultInstance();
   RangeTreeNode::default_instance_->InitAsDefaultInstance();
@@ -625,29 +625,29 @@ Attributes::mutable_attrs() {
 // ===================================================================
 
 #ifndef _MSC_VER
-const int Replica::kNodeIdFieldNumber;
-const int Replica::kStoreIdFieldNumber;
-const int Replica::kReplicaIdFieldNumber;
+const int ReplicaDescriptor::kNodeIdFieldNumber;
+const int ReplicaDescriptor::kStoreIdFieldNumber;
+const int ReplicaDescriptor::kReplicaIdFieldNumber;
 #endif  // !_MSC_VER
 
-Replica::Replica()
+ReplicaDescriptor::ReplicaDescriptor()
   : ::google::protobuf::Message(), _internal_metadata_(NULL) {
   SharedCtor();
-  // @@protoc_insertion_point(constructor:cockroach.proto.Replica)
+  // @@protoc_insertion_point(constructor:cockroach.proto.ReplicaDescriptor)
 }
 
-void Replica::InitAsDefaultInstance() {
+void ReplicaDescriptor::InitAsDefaultInstance() {
 }
 
-Replica::Replica(const Replica& from)
+ReplicaDescriptor::ReplicaDescriptor(const ReplicaDescriptor& from)
   : ::google::protobuf::Message(),
     _internal_metadata_(NULL) {
   SharedCtor();
   MergeFrom(from);
-  // @@protoc_insertion_point(copy_constructor:cockroach.proto.Replica)
+  // @@protoc_insertion_point(copy_constructor:cockroach.proto.ReplicaDescriptor)
 }
 
-void Replica::SharedCtor() {
+void ReplicaDescriptor::SharedCtor() {
   _cached_size_ = 0;
   node_id_ = 0;
   store_id_ = 0;
@@ -655,44 +655,44 @@ void Replica::SharedCtor() {
   ::memset(_has_bits_, 0, sizeof(_has_bits_));
 }
 
-Replica::~Replica() {
-  // @@protoc_insertion_point(destructor:cockroach.proto.Replica)
+ReplicaDescriptor::~ReplicaDescriptor() {
+  // @@protoc_insertion_point(destructor:cockroach.proto.ReplicaDescriptor)
   SharedDtor();
 }
 
-void Replica::SharedDtor() {
+void ReplicaDescriptor::SharedDtor() {
   if (this != default_instance_) {
   }
 }
 
-void Replica::SetCachedSize(int size) const {
+void ReplicaDescriptor::SetCachedSize(int size) const {
   GOOGLE_SAFE_CONCURRENT_WRITES_BEGIN();
   _cached_size_ = size;
   GOOGLE_SAFE_CONCURRENT_WRITES_END();
 }
-const ::google::protobuf::Descriptor* Replica::descriptor() {
+const ::google::protobuf::Descriptor* ReplicaDescriptor::descriptor() {
   protobuf_AssignDescriptorsOnce();
-  return Replica_descriptor_;
+  return ReplicaDescriptor_descriptor_;
 }
 
-const Replica& Replica::default_instance() {
+const ReplicaDescriptor& ReplicaDescriptor::default_instance() {
   if (default_instance_ == NULL) protobuf_AddDesc_cockroach_2fproto_2fmetadata_2eproto();
   return *default_instance_;
 }
 
-Replica* Replica::default_instance_ = NULL;
+ReplicaDescriptor* ReplicaDescriptor::default_instance_ = NULL;
 
-Replica* Replica::New(::google::protobuf::Arena* arena) const {
-  Replica* n = new Replica;
+ReplicaDescriptor* ReplicaDescriptor::New(::google::protobuf::Arena* arena) const {
+  ReplicaDescriptor* n = new ReplicaDescriptor;
   if (arena != NULL) {
     arena->Own(n);
   }
   return n;
 }
 
-void Replica::Clear() {
+void ReplicaDescriptor::Clear() {
 #define ZR_HELPER_(f) reinterpret_cast<char*>(\
-  &reinterpret_cast<Replica*>(16)->f)
+  &reinterpret_cast<ReplicaDescriptor*>(16)->f)
 
 #define ZR_(first, last) do {\
   ::memset(&first, 0,\
@@ -710,11 +710,11 @@ void Replica::Clear() {
   }
 }
 
-bool Replica::MergePartialFromCodedStream(
+bool ReplicaDescriptor::MergePartialFromCodedStream(
     ::google::protobuf::io::CodedInputStream* input) {
 #define DO_(EXPRESSION) if (!(EXPRESSION)) goto failure
   ::google::protobuf::uint32 tag;
-  // @@protoc_insertion_point(parse_start:cockroach.proto.Replica)
+  // @@protoc_insertion_point(parse_start:cockroach.proto.ReplicaDescriptor)
   for (;;) {
     ::std::pair< ::google::protobuf::uint32, bool> p = input->ReadTagWithCutoff(127);
     tag = p.first;
@@ -778,17 +778,17 @@ bool Replica::MergePartialFromCodedStream(
     }
   }
 success:
-  // @@protoc_insertion_point(parse_success:cockroach.proto.Replica)
+  // @@protoc_insertion_point(parse_success:cockroach.proto.ReplicaDescriptor)
   return true;
 failure:
-  // @@protoc_insertion_point(parse_failure:cockroach.proto.Replica)
+  // @@protoc_insertion_point(parse_failure:cockroach.proto.ReplicaDescriptor)
   return false;
 #undef DO_
 }
 
-void Replica::SerializeWithCachedSizes(
+void ReplicaDescriptor::SerializeWithCachedSizes(
     ::google::protobuf::io::CodedOutputStream* output) const {
-  // @@protoc_insertion_point(serialize_start:cockroach.proto.Replica)
+  // @@protoc_insertion_point(serialize_start:cockroach.proto.ReplicaDescriptor)
   // optional int32 node_id = 1;
   if (has_node_id()) {
     ::google::protobuf::internal::WireFormatLite::WriteInt32(1, this->node_id(), output);
@@ -808,12 +808,12 @@ void Replica::SerializeWithCachedSizes(
     ::google::protobuf::internal::WireFormat::SerializeUnknownFields(
         unknown_fields(), output);
   }
-  // @@protoc_insertion_point(serialize_end:cockroach.proto.Replica)
+  // @@protoc_insertion_point(serialize_end:cockroach.proto.ReplicaDescriptor)
 }
 
-::google::protobuf::uint8* Replica::SerializeWithCachedSizesToArray(
+::google::protobuf::uint8* ReplicaDescriptor::SerializeWithCachedSizesToArray(
     ::google::protobuf::uint8* target) const {
-  // @@protoc_insertion_point(serialize_to_array_start:cockroach.proto.Replica)
+  // @@protoc_insertion_point(serialize_to_array_start:cockroach.proto.ReplicaDescriptor)
   // optional int32 node_id = 1;
   if (has_node_id()) {
     target = ::google::protobuf::internal::WireFormatLite::WriteInt32ToArray(1, this->node_id(), target);
@@ -833,11 +833,11 @@ void Replica::SerializeWithCachedSizes(
     target = ::google::protobuf::internal::WireFormat::SerializeUnknownFieldsToArray(
         unknown_fields(), target);
   }
-  // @@protoc_insertion_point(serialize_to_array_end:cockroach.proto.Replica)
+  // @@protoc_insertion_point(serialize_to_array_end:cockroach.proto.ReplicaDescriptor)
   return target;
 }
 
-int Replica::ByteSize() const {
+int ReplicaDescriptor::ByteSize() const {
   int total_size = 0;
 
   if (_has_bits_[0 / 32] & 7) {
@@ -874,10 +874,10 @@ int Replica::ByteSize() const {
   return total_size;
 }
 
-void Replica::MergeFrom(const ::google::protobuf::Message& from) {
+void ReplicaDescriptor::MergeFrom(const ::google::protobuf::Message& from) {
   if (GOOGLE_PREDICT_FALSE(&from == this)) MergeFromFail(__LINE__);
-  const Replica* source = 
-      ::google::protobuf::internal::DynamicCastToGenerated<const Replica>(
+  const ReplicaDescriptor* source = 
+      ::google::protobuf::internal::DynamicCastToGenerated<const ReplicaDescriptor>(
           &from);
   if (source == NULL) {
     ::google::protobuf::internal::ReflectionOps::Merge(from, this);
@@ -886,7 +886,7 @@ void Replica::MergeFrom(const ::google::protobuf::Message& from) {
   }
 }
 
-void Replica::MergeFrom(const Replica& from) {
+void ReplicaDescriptor::MergeFrom(const ReplicaDescriptor& from) {
   if (GOOGLE_PREDICT_FALSE(&from == this)) MergeFromFail(__LINE__);
   if (from._has_bits_[0 / 32] & (0xffu << (0 % 32))) {
     if (from.has_node_id()) {
@@ -904,28 +904,28 @@ void Replica::MergeFrom(const Replica& from) {
   }
 }
 
-void Replica::CopyFrom(const ::google::protobuf::Message& from) {
+void ReplicaDescriptor::CopyFrom(const ::google::protobuf::Message& from) {
   if (&from == this) return;
   Clear();
   MergeFrom(from);
 }
 
-void Replica::CopyFrom(const Replica& from) {
+void ReplicaDescriptor::CopyFrom(const ReplicaDescriptor& from) {
   if (&from == this) return;
   Clear();
   MergeFrom(from);
 }
 
-bool Replica::IsInitialized() const {
+bool ReplicaDescriptor::IsInitialized() const {
 
   return true;
 }
 
-void Replica::Swap(Replica* other) {
+void ReplicaDescriptor::Swap(ReplicaDescriptor* other) {
   if (other == this) return;
   InternalSwap(other);
 }
-void Replica::InternalSwap(Replica* other) {
+void ReplicaDescriptor::InternalSwap(ReplicaDescriptor* other) {
   std::swap(node_id_, other->node_id_);
   std::swap(store_id_, other->store_id_);
   std::swap(replica_id_, other->replica_id_);
@@ -934,87 +934,87 @@ void Replica::InternalSwap(Replica* other) {
   std::swap(_cached_size_, other->_cached_size_);
 }
 
-::google::protobuf::Metadata Replica::GetMetadata() const {
+::google::protobuf::Metadata ReplicaDescriptor::GetMetadata() const {
   protobuf_AssignDescriptorsOnce();
   ::google::protobuf::Metadata metadata;
-  metadata.descriptor = Replica_descriptor_;
-  metadata.reflection = Replica_reflection_;
+  metadata.descriptor = ReplicaDescriptor_descriptor_;
+  metadata.reflection = ReplicaDescriptor_reflection_;
   return metadata;
 }
 
 #if PROTOBUF_INLINE_NOT_IN_HEADERS
-// Replica
+// ReplicaDescriptor
 
 // optional int32 node_id = 1;
-bool Replica::has_node_id() const {
+bool ReplicaDescriptor::has_node_id() const {
   return (_has_bits_[0] & 0x00000001u) != 0;
 }
-void Replica::set_has_node_id() {
+void ReplicaDescriptor::set_has_node_id() {
   _has_bits_[0] |= 0x00000001u;
 }
-void Replica::clear_has_node_id() {
+void ReplicaDescriptor::clear_has_node_id() {
   _has_bits_[0] &= ~0x00000001u;
 }
-void Replica::clear_node_id() {
+void ReplicaDescriptor::clear_node_id() {
   node_id_ = 0;
   clear_has_node_id();
 }
- ::google::protobuf::int32 Replica::node_id() const {
-  // @@protoc_insertion_point(field_get:cockroach.proto.Replica.node_id)
+ ::google::protobuf::int32 ReplicaDescriptor::node_id() const {
+  // @@protoc_insertion_point(field_get:cockroach.proto.ReplicaDescriptor.node_id)
   return node_id_;
 }
- void Replica::set_node_id(::google::protobuf::int32 value) {
+ void ReplicaDescriptor::set_node_id(::google::protobuf::int32 value) {
   set_has_node_id();
   node_id_ = value;
-  // @@protoc_insertion_point(field_set:cockroach.proto.Replica.node_id)
+  // @@protoc_insertion_point(field_set:cockroach.proto.ReplicaDescriptor.node_id)
 }
 
 // optional int32 store_id = 2;
-bool Replica::has_store_id() const {
+bool ReplicaDescriptor::has_store_id() const {
   return (_has_bits_[0] & 0x00000002u) != 0;
 }
-void Replica::set_has_store_id() {
+void ReplicaDescriptor::set_has_store_id() {
   _has_bits_[0] |= 0x00000002u;
 }
-void Replica::clear_has_store_id() {
+void ReplicaDescriptor::clear_has_store_id() {
   _has_bits_[0] &= ~0x00000002u;
 }
-void Replica::clear_store_id() {
+void ReplicaDescriptor::clear_store_id() {
   store_id_ = 0;
   clear_has_store_id();
 }
- ::google::protobuf::int32 Replica::store_id() const {
-  // @@protoc_insertion_point(field_get:cockroach.proto.Replica.store_id)
+ ::google::protobuf::int32 ReplicaDescriptor::store_id() const {
+  // @@protoc_insertion_point(field_get:cockroach.proto.ReplicaDescriptor.store_id)
   return store_id_;
 }
- void Replica::set_store_id(::google::protobuf::int32 value) {
+ void ReplicaDescriptor::set_store_id(::google::protobuf::int32 value) {
   set_has_store_id();
   store_id_ = value;
-  // @@protoc_insertion_point(field_set:cockroach.proto.Replica.store_id)
+  // @@protoc_insertion_point(field_set:cockroach.proto.ReplicaDescriptor.store_id)
 }
 
 // optional int32 replica_id = 3;
-bool Replica::has_replica_id() const {
+bool ReplicaDescriptor::has_replica_id() const {
   return (_has_bits_[0] & 0x00000004u) != 0;
 }
-void Replica::set_has_replica_id() {
+void ReplicaDescriptor::set_has_replica_id() {
   _has_bits_[0] |= 0x00000004u;
 }
-void Replica::clear_has_replica_id() {
+void ReplicaDescriptor::clear_has_replica_id() {
   _has_bits_[0] &= ~0x00000004u;
 }
-void Replica::clear_replica_id() {
+void ReplicaDescriptor::clear_replica_id() {
   replica_id_ = 0;
   clear_has_replica_id();
 }
- ::google::protobuf::int32 Replica::replica_id() const {
-  // @@protoc_insertion_point(field_get:cockroach.proto.Replica.replica_id)
+ ::google::protobuf::int32 ReplicaDescriptor::replica_id() const {
+  // @@protoc_insertion_point(field_get:cockroach.proto.ReplicaDescriptor.replica_id)
   return replica_id_;
 }
- void Replica::set_replica_id(::google::protobuf::int32 value) {
+ void ReplicaDescriptor::set_replica_id(::google::protobuf::int32 value) {
   set_has_replica_id();
   replica_id_ = value;
-  // @@protoc_insertion_point(field_set:cockroach.proto.Replica.replica_id)
+  // @@protoc_insertion_point(field_set:cockroach.proto.ReplicaDescriptor.replica_id)
 }
 
 #endif  // PROTOBUF_INLINE_NOT_IN_HEADERS
@@ -1161,7 +1161,7 @@ bool RangeDescriptor::MergePartialFromCodedStream(
         break;
       }
 
-      // repeated .cockroach.proto.Replica replicas = 4;
+      // repeated .cockroach.proto.ReplicaDescriptor replicas = 4;
       case 4: {
         if (tag == 34) {
          parse_replicas:
@@ -1235,7 +1235,7 @@ void RangeDescriptor::SerializeWithCachedSizes(
       3, this->end_key(), output);
   }
 
-  // repeated .cockroach.proto.Replica replicas = 4;
+  // repeated .cockroach.proto.ReplicaDescriptor replicas = 4;
   for (unsigned int i = 0, n = this->replicas_size(); i < n; i++) {
     ::google::protobuf::internal::WireFormatLite::WriteMessageMaybeToArray(
       4, this->replicas(i), output);
@@ -1275,7 +1275,7 @@ void RangeDescriptor::SerializeWithCachedSizes(
         3, this->end_key(), target);
   }
 
-  // repeated .cockroach.proto.Replica replicas = 4;
+  // repeated .cockroach.proto.ReplicaDescriptor replicas = 4;
   for (unsigned int i = 0, n = this->replicas_size(); i < n; i++) {
     target = ::google::protobuf::internal::WireFormatLite::
       WriteMessageNoVirtualToArray(
@@ -1328,7 +1328,7 @@ int RangeDescriptor::ByteSize() const {
     }
 
   }
-  // repeated .cockroach.proto.Replica replicas = 4;
+  // repeated .cockroach.proto.ReplicaDescriptor replicas = 4;
   total_size += 1 * this->replicas_size();
   for (int i = 0; i < this->replicas_size(); i++) {
     total_size +=
@@ -1556,31 +1556,31 @@ void RangeDescriptor::clear_end_key() {
   // @@protoc_insertion_point(field_set_allocated:cockroach.proto.RangeDescriptor.end_key)
 }
 
-// repeated .cockroach.proto.Replica replicas = 4;
+// repeated .cockroach.proto.ReplicaDescriptor replicas = 4;
 int RangeDescriptor::replicas_size() const {
   return replicas_.size();
 }
 void RangeDescriptor::clear_replicas() {
   replicas_.Clear();
 }
- const ::cockroach::proto::Replica& RangeDescriptor::replicas(int index) const {
+ const ::cockroach::proto::ReplicaDescriptor& RangeDescriptor::replicas(int index) const {
   // @@protoc_insertion_point(field_get:cockroach.proto.RangeDescriptor.replicas)
   return replicas_.Get(index);
 }
- ::cockroach::proto::Replica* RangeDescriptor::mutable_replicas(int index) {
+ ::cockroach::proto::ReplicaDescriptor* RangeDescriptor::mutable_replicas(int index) {
   // @@protoc_insertion_point(field_mutable:cockroach.proto.RangeDescriptor.replicas)
   return replicas_.Mutable(index);
 }
- ::cockroach::proto::Replica* RangeDescriptor::add_replicas() {
+ ::cockroach::proto::ReplicaDescriptor* RangeDescriptor::add_replicas() {
   // @@protoc_insertion_point(field_add:cockroach.proto.RangeDescriptor.replicas)
   return replicas_.Add();
 }
- const ::google::protobuf::RepeatedPtrField< ::cockroach::proto::Replica >&
+ const ::google::protobuf::RepeatedPtrField< ::cockroach::proto::ReplicaDescriptor >&
 RangeDescriptor::replicas() const {
   // @@protoc_insertion_point(field_list:cockroach.proto.RangeDescriptor.replicas)
   return replicas_;
 }
- ::google::protobuf::RepeatedPtrField< ::cockroach::proto::Replica >*
+ ::google::protobuf::RepeatedPtrField< ::cockroach::proto::ReplicaDescriptor >*
 RangeDescriptor::mutable_replicas() {
   // @@protoc_insertion_point(field_mutable_list:cockroach.proto.RangeDescriptor.replicas)
   return &replicas_;

--- a/storage/engine/rocksdb/cockroach/proto/metadata.pb.h
+++ b/storage/engine/rocksdb/cockroach/proto/metadata.pb.h
@@ -40,7 +40,7 @@ void protobuf_AssignDesc_cockroach_2fproto_2fmetadata_2eproto();
 void protobuf_ShutdownFile_cockroach_2fproto_2fmetadata_2eproto();
 
 class Attributes;
-class Replica;
+class ReplicaDescriptor;
 class RangeDescriptor;
 class RangeTree;
 class RangeTreeNode;
@@ -146,14 +146,14 @@ class Attributes : public ::google::protobuf::Message {
 };
 // -------------------------------------------------------------------
 
-class Replica : public ::google::protobuf::Message {
+class ReplicaDescriptor : public ::google::protobuf::Message {
  public:
-  Replica();
-  virtual ~Replica();
+  ReplicaDescriptor();
+  virtual ~ReplicaDescriptor();
 
-  Replica(const Replica& from);
+  ReplicaDescriptor(const ReplicaDescriptor& from);
 
-  inline Replica& operator=(const Replica& from) {
+  inline ReplicaDescriptor& operator=(const ReplicaDescriptor& from) {
     CopyFrom(from);
     return *this;
   }
@@ -167,19 +167,19 @@ class Replica : public ::google::protobuf::Message {
   }
 
   static const ::google::protobuf::Descriptor* descriptor();
-  static const Replica& default_instance();
+  static const ReplicaDescriptor& default_instance();
 
-  void Swap(Replica* other);
+  void Swap(ReplicaDescriptor* other);
 
   // implements Message ----------------------------------------------
 
-  inline Replica* New() const { return New(NULL); }
+  inline ReplicaDescriptor* New() const { return New(NULL); }
 
-  Replica* New(::google::protobuf::Arena* arena) const;
+  ReplicaDescriptor* New(::google::protobuf::Arena* arena) const;
   void CopyFrom(const ::google::protobuf::Message& from);
   void MergeFrom(const ::google::protobuf::Message& from);
-  void CopyFrom(const Replica& from);
-  void MergeFrom(const Replica& from);
+  void CopyFrom(const ReplicaDescriptor& from);
+  void MergeFrom(const ReplicaDescriptor& from);
   void Clear();
   bool IsInitialized() const;
 
@@ -194,7 +194,7 @@ class Replica : public ::google::protobuf::Message {
   void SharedCtor();
   void SharedDtor();
   void SetCachedSize(int size) const;
-  void InternalSwap(Replica* other);
+  void InternalSwap(ReplicaDescriptor* other);
   private:
   inline ::google::protobuf::Arena* GetArenaNoVirtual() const {
     return _internal_metadata_.arena();
@@ -231,7 +231,7 @@ class Replica : public ::google::protobuf::Message {
   ::google::protobuf::int32 replica_id() const;
   void set_replica_id(::google::protobuf::int32 value);
 
-  // @@protoc_insertion_point(class_scope:cockroach.proto.Replica)
+  // @@protoc_insertion_point(class_scope:cockroach.proto.ReplicaDescriptor)
  private:
   inline void set_has_node_id();
   inline void clear_has_node_id();
@@ -251,7 +251,7 @@ class Replica : public ::google::protobuf::Message {
   friend void protobuf_ShutdownFile_cockroach_2fproto_2fmetadata_2eproto();
 
   void InitAsDefaultInstance();
-  static Replica* default_instance_;
+  static ReplicaDescriptor* default_instance_;
 };
 // -------------------------------------------------------------------
 
@@ -350,16 +350,16 @@ class RangeDescriptor : public ::google::protobuf::Message {
   ::std::string* release_end_key();
   void set_allocated_end_key(::std::string* end_key);
 
-  // repeated .cockroach.proto.Replica replicas = 4;
+  // repeated .cockroach.proto.ReplicaDescriptor replicas = 4;
   int replicas_size() const;
   void clear_replicas();
   static const int kReplicasFieldNumber = 4;
-  const ::cockroach::proto::Replica& replicas(int index) const;
-  ::cockroach::proto::Replica* mutable_replicas(int index);
-  ::cockroach::proto::Replica* add_replicas();
-  const ::google::protobuf::RepeatedPtrField< ::cockroach::proto::Replica >&
+  const ::cockroach::proto::ReplicaDescriptor& replicas(int index) const;
+  ::cockroach::proto::ReplicaDescriptor* mutable_replicas(int index);
+  ::cockroach::proto::ReplicaDescriptor* add_replicas();
+  const ::google::protobuf::RepeatedPtrField< ::cockroach::proto::ReplicaDescriptor >&
       replicas() const;
-  ::google::protobuf::RepeatedPtrField< ::cockroach::proto::Replica >*
+  ::google::protobuf::RepeatedPtrField< ::cockroach::proto::ReplicaDescriptor >*
       mutable_replicas();
 
   // optional int32 next_replica_id = 5;
@@ -386,7 +386,7 @@ class RangeDescriptor : public ::google::protobuf::Message {
   ::google::protobuf::int64 range_id_;
   ::google::protobuf::internal::ArenaStringPtr start_key_;
   ::google::protobuf::internal::ArenaStringPtr end_key_;
-  ::google::protobuf::RepeatedPtrField< ::cockroach::proto::Replica > replicas_;
+  ::google::protobuf::RepeatedPtrField< ::cockroach::proto::ReplicaDescriptor > replicas_;
   ::google::protobuf::int32 next_replica_id_;
   friend void  protobuf_AddDesc_cockroach_2fproto_2fmetadata_2eproto();
   friend void protobuf_AssignDesc_cockroach_2fproto_2fmetadata_2eproto();
@@ -1049,78 +1049,78 @@ Attributes::mutable_attrs() {
 
 // -------------------------------------------------------------------
 
-// Replica
+// ReplicaDescriptor
 
 // optional int32 node_id = 1;
-inline bool Replica::has_node_id() const {
+inline bool ReplicaDescriptor::has_node_id() const {
   return (_has_bits_[0] & 0x00000001u) != 0;
 }
-inline void Replica::set_has_node_id() {
+inline void ReplicaDescriptor::set_has_node_id() {
   _has_bits_[0] |= 0x00000001u;
 }
-inline void Replica::clear_has_node_id() {
+inline void ReplicaDescriptor::clear_has_node_id() {
   _has_bits_[0] &= ~0x00000001u;
 }
-inline void Replica::clear_node_id() {
+inline void ReplicaDescriptor::clear_node_id() {
   node_id_ = 0;
   clear_has_node_id();
 }
-inline ::google::protobuf::int32 Replica::node_id() const {
-  // @@protoc_insertion_point(field_get:cockroach.proto.Replica.node_id)
+inline ::google::protobuf::int32 ReplicaDescriptor::node_id() const {
+  // @@protoc_insertion_point(field_get:cockroach.proto.ReplicaDescriptor.node_id)
   return node_id_;
 }
-inline void Replica::set_node_id(::google::protobuf::int32 value) {
+inline void ReplicaDescriptor::set_node_id(::google::protobuf::int32 value) {
   set_has_node_id();
   node_id_ = value;
-  // @@protoc_insertion_point(field_set:cockroach.proto.Replica.node_id)
+  // @@protoc_insertion_point(field_set:cockroach.proto.ReplicaDescriptor.node_id)
 }
 
 // optional int32 store_id = 2;
-inline bool Replica::has_store_id() const {
+inline bool ReplicaDescriptor::has_store_id() const {
   return (_has_bits_[0] & 0x00000002u) != 0;
 }
-inline void Replica::set_has_store_id() {
+inline void ReplicaDescriptor::set_has_store_id() {
   _has_bits_[0] |= 0x00000002u;
 }
-inline void Replica::clear_has_store_id() {
+inline void ReplicaDescriptor::clear_has_store_id() {
   _has_bits_[0] &= ~0x00000002u;
 }
-inline void Replica::clear_store_id() {
+inline void ReplicaDescriptor::clear_store_id() {
   store_id_ = 0;
   clear_has_store_id();
 }
-inline ::google::protobuf::int32 Replica::store_id() const {
-  // @@protoc_insertion_point(field_get:cockroach.proto.Replica.store_id)
+inline ::google::protobuf::int32 ReplicaDescriptor::store_id() const {
+  // @@protoc_insertion_point(field_get:cockroach.proto.ReplicaDescriptor.store_id)
   return store_id_;
 }
-inline void Replica::set_store_id(::google::protobuf::int32 value) {
+inline void ReplicaDescriptor::set_store_id(::google::protobuf::int32 value) {
   set_has_store_id();
   store_id_ = value;
-  // @@protoc_insertion_point(field_set:cockroach.proto.Replica.store_id)
+  // @@protoc_insertion_point(field_set:cockroach.proto.ReplicaDescriptor.store_id)
 }
 
 // optional int32 replica_id = 3;
-inline bool Replica::has_replica_id() const {
+inline bool ReplicaDescriptor::has_replica_id() const {
   return (_has_bits_[0] & 0x00000004u) != 0;
 }
-inline void Replica::set_has_replica_id() {
+inline void ReplicaDescriptor::set_has_replica_id() {
   _has_bits_[0] |= 0x00000004u;
 }
-inline void Replica::clear_has_replica_id() {
+inline void ReplicaDescriptor::clear_has_replica_id() {
   _has_bits_[0] &= ~0x00000004u;
 }
-inline void Replica::clear_replica_id() {
+inline void ReplicaDescriptor::clear_replica_id() {
   replica_id_ = 0;
   clear_has_replica_id();
 }
-inline ::google::protobuf::int32 Replica::replica_id() const {
-  // @@protoc_insertion_point(field_get:cockroach.proto.Replica.replica_id)
+inline ::google::protobuf::int32 ReplicaDescriptor::replica_id() const {
+  // @@protoc_insertion_point(field_get:cockroach.proto.ReplicaDescriptor.replica_id)
   return replica_id_;
 }
-inline void Replica::set_replica_id(::google::protobuf::int32 value) {
+inline void ReplicaDescriptor::set_replica_id(::google::protobuf::int32 value) {
   set_has_replica_id();
   replica_id_ = value;
-  // @@protoc_insertion_point(field_set:cockroach.proto.Replica.replica_id)
+  // @@protoc_insertion_point(field_set:cockroach.proto.ReplicaDescriptor.replica_id)
 }
 
 // -------------------------------------------------------------------
@@ -1257,31 +1257,31 @@ inline void RangeDescriptor::set_allocated_end_key(::std::string* end_key) {
   // @@protoc_insertion_point(field_set_allocated:cockroach.proto.RangeDescriptor.end_key)
 }
 
-// repeated .cockroach.proto.Replica replicas = 4;
+// repeated .cockroach.proto.ReplicaDescriptor replicas = 4;
 inline int RangeDescriptor::replicas_size() const {
   return replicas_.size();
 }
 inline void RangeDescriptor::clear_replicas() {
   replicas_.Clear();
 }
-inline const ::cockroach::proto::Replica& RangeDescriptor::replicas(int index) const {
+inline const ::cockroach::proto::ReplicaDescriptor& RangeDescriptor::replicas(int index) const {
   // @@protoc_insertion_point(field_get:cockroach.proto.RangeDescriptor.replicas)
   return replicas_.Get(index);
 }
-inline ::cockroach::proto::Replica* RangeDescriptor::mutable_replicas(int index) {
+inline ::cockroach::proto::ReplicaDescriptor* RangeDescriptor::mutable_replicas(int index) {
   // @@protoc_insertion_point(field_mutable:cockroach.proto.RangeDescriptor.replicas)
   return replicas_.Mutable(index);
 }
-inline ::cockroach::proto::Replica* RangeDescriptor::add_replicas() {
+inline ::cockroach::proto::ReplicaDescriptor* RangeDescriptor::add_replicas() {
   // @@protoc_insertion_point(field_add:cockroach.proto.RangeDescriptor.replicas)
   return replicas_.Add();
 }
-inline const ::google::protobuf::RepeatedPtrField< ::cockroach::proto::Replica >&
+inline const ::google::protobuf::RepeatedPtrField< ::cockroach::proto::ReplicaDescriptor >&
 RangeDescriptor::replicas() const {
   // @@protoc_insertion_point(field_list:cockroach.proto.RangeDescriptor.replicas)
   return replicas_;
 }
-inline ::google::protobuf::RepeatedPtrField< ::cockroach::proto::Replica >*
+inline ::google::protobuf::RepeatedPtrField< ::cockroach::proto::ReplicaDescriptor >*
 RangeDescriptor::mutable_replicas() {
   // @@protoc_insertion_point(field_mutable_list:cockroach.proto.RangeDescriptor.replicas)
   return &replicas_;

--- a/storage/replica.go
+++ b/storage/replica.go
@@ -483,7 +483,7 @@ func (r *Replica) ReplicaDescriptor(replicaID proto.ReplicaID) (proto.ReplicaDes
 		return r.pendingReplica.value, nil
 	}
 	return proto.ReplicaDescriptor{}, util.Errorf("replica %d not found in range %d",
-		replicaID, r.Desc().RangeID)
+		replicaID, desc.RangeID)
 }
 
 // GetMVCCStats returns a copy of the MVCC stats object for this range.
@@ -957,7 +957,7 @@ func (r *Replica) proposeRaftCommand(ctx context.Context, ba *proto.BatchRequest
 		return errChan, pendingCmd
 	}
 	raftCmd := proto.RaftCommand{
-		RangeID:       r.Desc().RangeID,
+		RangeID:       desc.RangeID,
 		OriginReplica: *replica,
 		Cmd:           *ba,
 	}

--- a/storage/replica.go
+++ b/storage/replica.go
@@ -468,8 +468,8 @@ func (r *Replica) GetReplica() *proto.ReplicaDescriptor {
 	return replica
 }
 
-// ReplicaAddress returns information about the given member of this replica's range.
-func (r *Replica) ReplicaAddress(replicaID proto.ReplicaID) (proto.ReplicaDescriptor, error) {
+// ReplicaDescriptor returns information about the given member of this replica's range.
+func (r *Replica) ReplicaDescriptor(replicaID proto.ReplicaID) (proto.ReplicaDescriptor, error) {
 	r.RLock()
 	defer r.RUnlock()
 

--- a/storage/replica_command.go
+++ b/storage/replica_command.go
@@ -1463,7 +1463,7 @@ func (r *Replica) changeReplicasTrigger(change *proto.ChangeReplicasTrigger) err
 //
 // The supplied RangeDescriptor is used as a form of optimistic lock. See the
 // comment of "AdminSplit" for more information on this pattern.
-func (r *Replica) ChangeReplicas(changeType proto.ReplicaChangeType, replica proto.Replica, desc *proto.RangeDescriptor) error {
+func (r *Replica) ChangeReplicas(changeType proto.ReplicaChangeType, replica proto.ReplicaDescriptor, desc *proto.RangeDescriptor) error {
 	r.Lock()
 	for r.pendingReplica.value.ReplicaID != 0 {
 		r.pendingReplica.Wait()
@@ -1471,7 +1471,7 @@ func (r *Replica) ChangeReplicas(changeType proto.ReplicaChangeType, replica pro
 
 	// Validate the request and prepare the new descriptor.
 	updatedDesc := *desc
-	updatedDesc.Replicas = append([]proto.Replica{}, desc.Replicas...)
+	updatedDesc.Replicas = append([]proto.ReplicaDescriptor{}, desc.Replicas...)
 	found := -1       // tracks NodeID && StoreID
 	nodeUsed := false // tracks NodeID only
 	for i, existingRep := range desc.Replicas {
@@ -1550,14 +1550,14 @@ func (r *Replica) ChangeReplicas(changeType proto.ReplicaChangeType, replica pro
 
 func (r *Replica) clearPendingChangeReplicas() {
 	r.Lock()
-	r.pendingReplica.value = proto.Replica{}
+	r.pendingReplica.value = proto.ReplicaDescriptor{}
 	r.pendingReplica.Broadcast()
 	r.Unlock()
 }
 
 // replicaSetsEqual is used in AdminMerge to ensure that the ranges are
 // all collocate on the same set of replicas.
-func replicaSetsEqual(a, b []proto.Replica) bool {
+func replicaSetsEqual(a, b []proto.ReplicaDescriptor) bool {
 	if len(a) != len(b) {
 		return false
 	}

--- a/storage/replica_command.go
+++ b/storage/replica_command.go
@@ -1011,7 +1011,7 @@ func (r *Replica) LeaderLease(batch engine.Engine, ms *engine.MVCCStats, args pr
 	defer r.Unlock()
 
 	prevLease := r.getLease()
-	isExtension := prevLease.RaftNodeID == args.Lease.RaftNodeID
+	isExtension := prevLease.Replica.StoreID == args.Lease.Replica.StoreID
 	effectiveStart := args.Lease.Start
 	// We return this error in "normal" lease-overlap related failures.
 	rErr := &proto.LeaseRejectedError{
@@ -1027,8 +1027,7 @@ func (r *Replica) LeaderLease(batch engine.Engine, ms *engine.MVCCStats, args pr
 
 	// Verify that requestion replica is part of the current replica set.
 	desc := r.Desc()
-	_, requestingStore := proto.DecodeRaftNodeID(args.Lease.RaftNodeID)
-	if idx, _ := desc.FindReplica(requestingStore); idx == -1 {
+	if idx, _ := desc.FindReplica(args.Lease.Replica.StoreID); idx == -1 {
 		return reply, rErr
 	}
 
@@ -1045,7 +1044,7 @@ func (r *Replica) LeaderLease(batch engine.Engine, ms *engine.MVCCStats, args pr
 	// If no old lease exists or this is our lease, we don't need to add an
 	// extra tick. This allows multiple requests from the same replica to
 	// merge without ticking away from the minimal common start timestamp.
-	if prevLease.RaftNodeID == 0 || isExtension {
+	if prevLease.Replica.StoreID == 0 || isExtension {
 		// TODO(tschottdorf) Think about whether it'd be better to go all the
 		// way back to prevLease.Start(), so that whenever the last lease is
 		// the own one, the original start is preserved.
@@ -1079,7 +1078,8 @@ func (r *Replica) LeaderLease(batch engine.Engine, ms *engine.MVCCStats, args pr
 	// clock offset to account for any difference in clocks
 	// between the expiration (set by a remote node) and this
 	// node.
-	if r.getLease().RaftNodeID == r.rm.RaftNodeID() && prevLease.RaftNodeID != r.getLease().RaftNodeID {
+	if r.getLease().Replica.StoreID == r.rm.StoreID() &&
+		prevLease.Replica.StoreID != r.getLease().Replica.StoreID {
 		r.tsCache.SetLowWater(prevLease.Expiration.Add(int64(r.rm.Clock().MaxOffset()), 0))
 		log.Infof("range %d: new leader lease %s", rangeID, args.Lease)
 	}
@@ -1439,6 +1439,7 @@ func (r *Replica) mergeTrigger(batch engine.Engine, merge *proto.MergeTrigger) e
 }
 
 func (r *Replica) changeReplicasTrigger(change *proto.ChangeReplicasTrigger) error {
+	defer r.clearPendingChangeReplicas()
 	cpy := *r.Desc()
 	cpy.Replicas = change.UpdatedReplicas
 	cpy.NextReplicaID = change.NextReplicaID
@@ -1463,6 +1464,11 @@ func (r *Replica) changeReplicasTrigger(change *proto.ChangeReplicasTrigger) err
 // The supplied RangeDescriptor is used as a form of optimistic lock. See the
 // comment of "AdminSplit" for more information on this pattern.
 func (r *Replica) ChangeReplicas(changeType proto.ReplicaChangeType, replica proto.Replica, desc *proto.RangeDescriptor) error {
+	r.Lock()
+	for r.pendingReplica.value.ReplicaID != 0 {
+		r.pendingReplica.Wait()
+	}
+
 	// Validate the request and prepare the new descriptor.
 	updatedDesc := *desc
 	updatedDesc.Replicas = append([]proto.Replica{}, desc.Replicas...)
@@ -1486,6 +1492,10 @@ func (r *Replica) ChangeReplicas(changeType proto.ReplicaChangeType, replica pro
 		replica.ReplicaID = updatedDesc.NextReplicaID
 		updatedDesc.NextReplicaID++
 		updatedDesc.Replicas = append(updatedDesc.Replicas, replica)
+
+		// We need to be able to look up replica information before the change
+		// is official.
+		r.pendingReplica.value = replica
 	} else if changeType == proto.REMOVE_REPLICA {
 		// If that exact node-store combination does not have the replica,
 		// abort the removal.
@@ -1496,6 +1506,8 @@ func (r *Replica) ChangeReplicas(changeType proto.ReplicaChangeType, replica pro
 		updatedDesc.Replicas[found] = updatedDesc.Replicas[len(updatedDesc.Replicas)-1]
 		updatedDesc.Replicas = updatedDesc.Replicas[:len(updatedDesc.Replicas)-1]
 	}
+
+	r.Unlock()
 
 	err := r.rm.DB().Txn(func(txn *client.Txn) error {
 		// Important: the range descriptor must be the first thing touched in the transaction
@@ -1530,9 +1542,17 @@ func (r *Replica) ChangeReplicas(changeType proto.ReplicaChangeType, replica pro
 		return txn.Run(b)
 	})
 	if err != nil {
+		r.clearPendingChangeReplicas()
 		return util.Errorf("change replicas of %d failed: %s", desc.RangeID, err)
 	}
 	return nil
+}
+
+func (r *Replica) clearPendingChangeReplicas() {
+	r.Lock()
+	r.pendingReplica.value = proto.Replica{}
+	r.pendingReplica.Broadcast()
+	r.Unlock()
 }
 
 // replicaSetsEqual is used in AdminMerge to ensure that the ranges are

--- a/storage/replica_raftstorage.go
+++ b/storage/replica_raftstorage.go
@@ -63,7 +63,7 @@ func (r *Replica) InitialState() (raftpb.HardState, raftpb.ConfState, error) {
 	// For uninitalized ranges, membership is unknown at this point.
 	if found || r.isInitialized() {
 		for _, rep := range desc.Replicas {
-			cs.Nodes = append(cs.Nodes, uint64(proto.MakeRaftNodeID(rep.NodeID, rep.StoreID)))
+			cs.Nodes = append(cs.Nodes, uint64(rep.ReplicaID))
 		}
 	}
 
@@ -293,7 +293,7 @@ func (r *Replica) Snapshot() (raftpb.Snapshot, error) {
 	// Synthesize our raftpb.ConfState from desc.
 	var cs raftpb.ConfState
 	for _, rep := range desc.Replicas {
-		cs.Nodes = append(cs.Nodes, uint64(proto.MakeRaftNodeID(rep.NodeID, rep.StoreID)))
+		cs.Nodes = append(cs.Nodes, uint64(rep.ReplicaID))
 	}
 
 	term, err := r.Term(appliedIndex)

--- a/storage/replica_test.go
+++ b/storage/replica_test.go
@@ -56,7 +56,7 @@ func testRangeDescriptor() *proto.RangeDescriptor {
 		RangeID:  1,
 		StartKey: proto.KeyMin,
 		EndKey:   proto.KeyMax,
-		Replicas: []proto.Replica{
+		Replicas: []proto.ReplicaDescriptor{
 			{
 				ReplicaID: 1,
 				NodeID:    1,
@@ -214,13 +214,13 @@ func newTransaction(name string, baseKey proto.Key, userPriority int32,
 		isolation, clock.Now(), clock.MaxOffset().Nanoseconds())
 }
 
-// CreateReplicaSets creates new proto.Replica protos based on an array of
+// CreateReplicaSets creates new proto.ReplicaDescriptor protos based on an array of
 // StoreIDs to aid in testing. Note that this does not actually produce any
 // replicas, it just creates the proto.
-func createReplicaSets(replicaNumbers []proto.StoreID) []proto.Replica {
-	result := []proto.Replica{}
+func createReplicaSets(replicaNumbers []proto.StoreID) []proto.ReplicaDescriptor {
+	result := []proto.ReplicaDescriptor{}
 	for _, replicaNumber := range replicaNumbers {
-		result = append(result, proto.Replica{
+		result = append(result, proto.ReplicaDescriptor{
 			StoreID: replicaNumber,
 		})
 	}
@@ -291,7 +291,7 @@ func TestRangeReadConsistency(t *testing.T) {
 	// Modify range descriptor to include a second replica; leader lease can
 	// only be obtained by Replicas which are part of the range descriptor. This
 	// workaround is sufficient for the purpose of this test.
-	secondReplica := proto.Replica{
+	secondReplica := proto.ReplicaDescriptor{
 		NodeID:    2,
 		StoreID:   2,
 		ReplicaID: 2,
@@ -331,7 +331,7 @@ func TestRangeReadConsistency(t *testing.T) {
 	setLeaderLease(t, tc.rng, &proto.Lease{
 		Start:      start,
 		Expiration: start.Add(10, 0),
-		Replica: proto.Replica{ // a different node
+		Replica: proto.ReplicaDescriptor{ // a different node
 			ReplicaID: 2,
 			NodeID:    2,
 			StoreID:   2,
@@ -364,7 +364,7 @@ func TestApplyCmdLeaseError(t *testing.T) {
 	// Modify range descriptor to include a second replica; leader lease can
 	// only be obtained by Replicas which are part of the range descriptor. This
 	// workaround is sufficient for the purpose of this test.
-	secondReplica := proto.Replica{
+	secondReplica := proto.ReplicaDescriptor{
 		NodeID:    2,
 		StoreID:   2,
 		ReplicaID: 2,
@@ -386,7 +386,7 @@ func TestApplyCmdLeaseError(t *testing.T) {
 	setLeaderLease(t, tc.rng, &proto.Lease{
 		Start:      start,
 		Expiration: start.Add(10, 0),
-		Replica: proto.Replica{ // a different node
+		Replica: proto.ReplicaDescriptor{ // a different node
 			ReplicaID: 2,
 			NodeID:    2,
 			StoreID:   2,
@@ -438,7 +438,7 @@ func TestRangeLeaderLease(t *testing.T) {
 	// Modify range descriptor to include a second replica; leader lease can
 	// only be obtained by Replicas which are part of the range descriptor. This
 	// workaround is sufficient for the purpose of this test.
-	secondReplica := proto.Replica{
+	secondReplica := proto.ReplicaDescriptor{
 		NodeID:    2,
 		StoreID:   2,
 		ReplicaID: 2,
@@ -455,7 +455,7 @@ func TestRangeLeaderLease(t *testing.T) {
 	setLeaderLease(t, tc.rng, &proto.Lease{
 		Start:      now.Add(10, 0),
 		Expiration: now.Add(20, 0),
-		Replica: proto.Replica{
+		Replica: proto.ReplicaDescriptor{
 			ReplicaID: 2,
 			NodeID:    2,
 			StoreID:   2,
@@ -487,7 +487,7 @@ func TestRangeNotLeaderError(t *testing.T) {
 	// Modify range descriptor to include a second replica; leader lease can
 	// only be obtained by Replicas which are part of the range descriptor. This
 	// workaround is sufficient for the purpose of this test.
-	secondReplica := proto.Replica{
+	secondReplica := proto.ReplicaDescriptor{
 		NodeID:    2,
 		StoreID:   2,
 		ReplicaID: 2,
@@ -501,7 +501,7 @@ func TestRangeNotLeaderError(t *testing.T) {
 	setLeaderLease(t, tc.rng, &proto.Lease{
 		Start:      now,
 		Expiration: now.Add(10, 0),
-		Replica: proto.Replica{
+		Replica: proto.ReplicaDescriptor{
 			ReplicaID: 2,
 			NodeID:    2,
 			StoreID:   2,
@@ -511,7 +511,7 @@ func TestRangeNotLeaderError(t *testing.T) {
 	header := proto.RequestHeader{
 		Key:       proto.Key("a"),
 		RangeID:   tc.rng.Desc().RangeID,
-		Replica:   proto.Replica{StoreID: tc.store.StoreID()},
+		Replica:   proto.ReplicaDescriptor{StoreID: tc.store.StoreID()},
 		Timestamp: now,
 	}
 	testCases := []proto.Request{
@@ -553,7 +553,7 @@ func TestRangeGossipConfigsOnLease(t *testing.T) {
 	// Modify range descriptor to include a second replica; leader lease can
 	// only be obtained by Replicas which are part of the range descriptor. This
 	// workaround is sufficient for the purpose of this test.
-	secondReplica := proto.Replica{
+	secondReplica := proto.ReplicaDescriptor{
 		NodeID:    2,
 		StoreID:   2,
 		ReplicaID: 2,
@@ -596,7 +596,7 @@ func TestRangeGossipConfigsOnLease(t *testing.T) {
 	setLeaderLease(t, tc.rng, &proto.Lease{
 		Start:      now,
 		Expiration: now.Add(10, 0),
-		Replica: proto.Replica{
+		Replica: proto.ReplicaDescriptor{
 			ReplicaID: 2,
 			NodeID:    2,
 			StoreID:   2,
@@ -611,7 +611,7 @@ func TestRangeGossipConfigsOnLease(t *testing.T) {
 	setLeaderLease(t, tc.rng, &proto.Lease{
 		Start:      now.Add(11, 0),
 		Expiration: now.Add(20, 0),
-		Replica: proto.Replica{
+		Replica: proto.ReplicaDescriptor{
 			ReplicaID: 1,
 			NodeID:    1,
 			StoreID:   1,
@@ -636,7 +636,7 @@ func TestRangeTSCacheLowWaterOnLease(t *testing.T) {
 	// Modify range descriptor to include a second replica; leader lease can
 	// only be obtained by Replicas which are part of the range descriptor. This
 	// workaround is sufficient for the purpose of this test.
-	secondReplica := proto.Replica{
+	secondReplica := proto.ReplicaDescriptor{
 		NodeID:    2,
 		StoreID:   2,
 		ReplicaID: 2,
@@ -673,7 +673,7 @@ func TestRangeTSCacheLowWaterOnLease(t *testing.T) {
 		setLeaderLease(t, tc.rng, &proto.Lease{
 			Start:      test.start,
 			Expiration: test.expiration,
-			Replica: proto.Replica{
+			Replica: proto.ReplicaDescriptor{
 				ReplicaID: proto.ReplicaID(test.storeID),
 				NodeID:    proto.NodeID(test.storeID),
 				StoreID:   test.storeID,
@@ -702,7 +702,7 @@ func TestRangeLeaderLeaseRejectUnknownRaftNodeID(t *testing.T) {
 	lease := &proto.Lease{
 		Start:      now,
 		Expiration: now.Add(10, 0),
-		Replica: proto.Replica{
+		Replica: proto.ReplicaDescriptor{
 			ReplicaID: 2,
 			NodeID:    2,
 			StoreID:   2,
@@ -860,7 +860,7 @@ func getArgs(key []byte, rangeID proto.RangeID, storeID proto.StoreID) proto.Get
 		RequestHeader: proto.RequestHeader{
 			Key:     key,
 			RangeID: rangeID,
-			Replica: proto.Replica{StoreID: storeID},
+			Replica: proto.ReplicaDescriptor{StoreID: storeID},
 		},
 	}
 }
@@ -873,7 +873,7 @@ func putArgs(key, value []byte, rangeID proto.RangeID, storeID proto.StoreID) pr
 			Key:       key,
 			Timestamp: proto.MinTimestamp,
 			RangeID:   rangeID,
-			Replica:   proto.Replica{StoreID: storeID},
+			Replica:   proto.ReplicaDescriptor{StoreID: storeID},
 		},
 		Value: proto.Value{
 			Bytes: value,
@@ -887,7 +887,7 @@ func deleteArgs(key proto.Key, rangeID proto.RangeID, storeID proto.StoreID) pro
 		RequestHeader: proto.RequestHeader{
 			Key:     key,
 			RangeID: rangeID,
-			Replica: proto.Replica{StoreID: storeID},
+			Replica: proto.ReplicaDescriptor{StoreID: storeID},
 		},
 	}
 }
@@ -911,7 +911,7 @@ func incrementArgs(key []byte, inc int64, rangeID proto.RangeID, storeID proto.S
 		RequestHeader: proto.RequestHeader{
 			Key:     key,
 			RangeID: rangeID,
-			Replica: proto.Replica{StoreID: storeID},
+			Replica: proto.ReplicaDescriptor{StoreID: storeID},
 		},
 		Increment: inc,
 	}
@@ -923,7 +923,7 @@ func scanArgs(start, end []byte, rangeID proto.RangeID, storeID proto.StoreID) p
 			Key:     start,
 			EndKey:  end,
 			RangeID: rangeID,
-			Replica: proto.Replica{StoreID: storeID},
+			Replica: proto.ReplicaDescriptor{StoreID: storeID},
 		},
 	}
 }
@@ -935,7 +935,7 @@ func endTxnArgs(txn *proto.Transaction, commit bool, rangeID proto.RangeID, stor
 		RequestHeader: proto.RequestHeader{
 			Key:     txn.Key, // not allowed when going through TxnCoordSender, but we're not
 			RangeID: rangeID,
-			Replica: proto.Replica{StoreID: storeID},
+			Replica: proto.ReplicaDescriptor{StoreID: storeID},
 			Txn:     txn,
 		},
 		Commit: commit,
@@ -950,7 +950,7 @@ func pushTxnArgs(pusher, pushee *proto.Transaction, pushType proto.PushTxnType, 
 			Key:       pushee.Key,
 			Timestamp: pusher.Timestamp,
 			RangeID:   rangeID,
-			Replica:   proto.Replica{StoreID: storeID},
+			Replica:   proto.ReplicaDescriptor{StoreID: storeID},
 		},
 		Now:       pusher.Timestamp,
 		PusherTxn: pusher,
@@ -965,7 +965,7 @@ func heartbeatArgs(txn *proto.Transaction, rangeID proto.RangeID, storeID proto.
 		RequestHeader: proto.RequestHeader{
 			Key:     txn.Key,
 			RangeID: rangeID,
-			Replica: proto.Replica{StoreID: storeID},
+			Replica: proto.ReplicaDescriptor{StoreID: storeID},
 			Txn:     txn,
 		},
 	}
@@ -979,7 +979,7 @@ func internalMergeArgs(key []byte, value proto.Value, rangeID proto.RangeID, sto
 		RequestHeader: proto.RequestHeader{
 			Key:     key,
 			RangeID: rangeID,
-			Replica: proto.Replica{StoreID: storeID},
+			Replica: proto.ReplicaDescriptor{StoreID: storeID},
 		},
 		Value: value,
 	}
@@ -989,7 +989,7 @@ func truncateLogArgs(index uint64, rangeID proto.RangeID, storeID proto.StoreID)
 	return proto.TruncateLogRequest{
 		RequestHeader: proto.RequestHeader{
 			RangeID: rangeID,
-			Replica: proto.Replica{StoreID: storeID},
+			Replica: proto.ReplicaDescriptor{StoreID: storeID},
 		},
 		Index: index,
 	}
@@ -2290,7 +2290,7 @@ func TestRangeResolveIntentRange(t *testing.T) {
 			Key:     proto.Key("a"),
 			EndKey:  proto.Key("c"),
 			RangeID: tc.rng.Desc().RangeID,
-			Replica: proto.Replica{StoreID: tc.store.StoreID()},
+			Replica: proto.ReplicaDescriptor{StoreID: tc.store.StoreID()},
 		},
 		IntentTxn: *txn,
 	}
@@ -2360,7 +2360,7 @@ func TestRangeStatsComputation(t *testing.T) {
 		RequestHeader: proto.RequestHeader{
 			Key:     pArgs.Key,
 			RangeID: tc.rng.Desc().RangeID,
-			Replica: proto.Replica{StoreID: tc.store.StoreID()},
+			Replica: proto.ReplicaDescriptor{StoreID: tc.store.StoreID()},
 		},
 		IntentTxn: *pArgs.Txn,
 	}
@@ -2541,7 +2541,7 @@ func TestConditionFailedError(t *testing.T) {
 			Key:       key,
 			Timestamp: proto.MinTimestamp,
 			RangeID:   1,
-			Replica:   proto.Replica{StoreID: tc.store.StoreID()},
+			Replica:   proto.ReplicaDescriptor{StoreID: tc.store.StoreID()},
 		},
 		Value: proto.Value{
 			Bytes: value,
@@ -2568,10 +2568,10 @@ func TestReplicaSetsEqual(t *testing.T) {
 	defer leaktest.AfterTest(t)
 	testData := []struct {
 		expected bool
-		a        []proto.Replica
-		b        []proto.Replica
+		a        []proto.ReplicaDescriptor
+		b        []proto.ReplicaDescriptor
 	}{
-		{true, []proto.Replica{}, []proto.Replica{}},
+		{true, []proto.ReplicaDescriptor{}, []proto.ReplicaDescriptor{}},
 		{true, createReplicaSets([]proto.StoreID{1}), createReplicaSets([]proto.StoreID{1})},
 		{true, createReplicaSets([]proto.StoreID{1, 2}), createReplicaSets([]proto.StoreID{1, 2})},
 		{true, createReplicaSets([]proto.StoreID{1, 2}), createReplicaSets([]proto.StoreID{2, 1})},
@@ -2659,7 +2659,7 @@ func TestChangeReplicasDuplicateError(t *testing.T) {
 	tc.Start(t)
 	defer tc.Stop()
 
-	if err := tc.rng.ChangeReplicas(proto.ADD_REPLICA, proto.Replica{
+	if err := tc.rng.ChangeReplicas(proto.ADD_REPLICA, proto.ReplicaDescriptor{
 		NodeID:  tc.store.Ident.NodeID,
 		StoreID: 9999,
 	}, tc.rng.Desc()); err == nil || !strings.Contains(err.Error(),
@@ -2698,7 +2698,7 @@ func testRangeDanglingMetaIntent(t *testing.T, isReverse bool) {
 		RequestHeader: proto.RequestHeader{
 			Key:             keys.RangeMetaKey(key),
 			RangeID:         tc.rng.Desc().RangeID,
-			Replica:         proto.Replica{StoreID: tc.store.StoreID()},
+			Replica:         proto.ReplicaDescriptor{StoreID: tc.store.StoreID()},
 			ReadConsistency: proto.INCONSISTENT,
 		},
 		MaxRanges: 1,
@@ -2848,7 +2848,7 @@ func TestRangeLookupUseReverseScan(t *testing.T) {
 			Key:     keys.RangeMetaKey(proto.Key("a")),
 			EndKey:  keys.RangeMetaKey(proto.Key("z")),
 			RangeID: tc.rng.Desc().RangeID,
-			Replica: proto.Replica{StoreID: tc.store.StoreID()},
+			Replica: proto.ReplicaDescriptor{StoreID: tc.store.StoreID()},
 		},
 		IntentTxn: *txn,
 	}
@@ -2861,7 +2861,7 @@ func TestRangeLookupUseReverseScan(t *testing.T) {
 	rlArgs := &proto.RangeLookupRequest{
 		RequestHeader: proto.RequestHeader{
 			RangeID:         tc.rng.Desc().RangeID,
-			Replica:         proto.Replica{StoreID: tc.store.StoreID()},
+			Replica:         proto.ReplicaDescriptor{StoreID: tc.store.StoreID()},
 			ReadConsistency: proto.INCONSISTENT,
 		},
 		MaxRanges: 1,

--- a/storage/replicate_queue.go
+++ b/storage/replicate_queue.go
@@ -116,7 +116,7 @@ func (rq replicateQueue) process(now proto.Timestamp, repl *Replica, sysCfg *con
 		if err != nil {
 			return err
 		}
-		newReplica := proto.Replica{
+		newReplica := proto.ReplicaDescriptor{
 			NodeID:  newStore.Node.NodeID,
 			StoreID: newStore.StoreID,
 		}
@@ -154,7 +154,7 @@ func (rq replicateQueue) process(now proto.Timestamp, repl *Replica, sysCfg *con
 			// without re-queueing this replica.
 			return nil
 		}
-		rebalanceReplica := proto.Replica{
+		rebalanceReplica := proto.ReplicaDescriptor{
 			NodeID:  rebalanceStore.Node.NodeID,
 			StoreID: rebalanceStore.StoreID,
 		}

--- a/storage/simulation/range.go
+++ b/storage/simulation/range.go
@@ -61,7 +61,7 @@ func newRange(rangeID proto.RangeID, allocator storage.Allocator) *Range {
 // both the range descriptor and the store map.
 func (r *Range) addReplica(s *Store) {
 	storeID, nodeID := s.getIDs()
-	r.desc.Replicas = append(r.desc.Replicas, proto.Replica{
+	r.desc.Replicas = append(r.desc.Replicas, proto.ReplicaDescriptor{
 		NodeID:  nodeID,
 		StoreID: storeID,
 	})
@@ -93,7 +93,7 @@ func (r *Range) getStores() map[proto.StoreID]*Store {
 // replicas in the range.
 func (r *Range) splitRange(originalRange *Range) {
 	stores := originalRange.getStores()
-	r.desc.Replicas = append([]proto.Replica(nil), originalRange.desc.Replicas...)
+	r.desc.Replicas = append([]proto.ReplicaDescriptor(nil), originalRange.desc.Replicas...)
 	for storeID, store := range stores {
 		r.replicas[storeID] = replica{
 			store: store,

--- a/storage/store.go
+++ b/storage/store.go
@@ -1538,13 +1538,13 @@ func (s *Store) GroupStorage(groupID proto.RangeID) multiraft.WriteableGroupStor
 	return r
 }
 
-// ReplicaAddress implements the multiraft.Storage interface.
-func (s *Store) ReplicaAddress(groupID proto.RangeID, replicaID proto.ReplicaID) (proto.ReplicaDescriptor, error) {
+// ReplicaDescriptor implements the multiraft.Storage interface.
+func (s *Store) ReplicaDescriptor(groupID proto.RangeID, replicaID proto.ReplicaID) (proto.ReplicaDescriptor, error) {
 	rep, err := s.GetReplica(groupID)
 	if err != nil {
 		return proto.ReplicaDescriptor{}, err
 	}
-	return rep.ReplicaAddress(replicaID)
+	return rep.ReplicaDescriptor(replicaID)
 }
 
 // ReplicaIDForStore implements the multiraft.Storage interface.

--- a/storage/store.go
+++ b/storage/store.go
@@ -1558,7 +1558,7 @@ func (s *Store) ReplicaIDForStore(groupID proto.RangeID, storeID proto.StoreID) 
 			return rep.ReplicaID, nil
 		}
 	}
-	return 0, util.Errorf("store %s not found as replica of range %s", storeID, groupID)
+	return 0, util.Errorf("store %s not found as replica of range %d", storeID, groupID)
 }
 
 // ReplicasFromSnapshot implements the multiraft.Storage interface.

--- a/storage/store.go
+++ b/storage/store.go
@@ -787,7 +787,7 @@ func (s *Store) BootstrapRange(initialValues []proto.KeyValue) error {
 		StartKey:      proto.KeyMin,
 		EndKey:        proto.KeyMax,
 		NextReplicaID: 2,
-		Replicas: []proto.Replica{
+		Replicas: []proto.ReplicaDescriptor{
 			{
 				NodeID:    1,
 				StoreID:   1,
@@ -890,7 +890,7 @@ func (s *Store) Tracer() *tracer.Tracer { return s.ctx.Tracer }
 // NewRangeDescriptor creates a new descriptor based on start and end
 // keys and the supplied proto.Replicas slice. It allocates new
 // replica IDs to fill out the supplied replicas.
-func (s *Store) NewRangeDescriptor(start, end proto.Key, replicas []proto.Replica) (*proto.RangeDescriptor, error) {
+func (s *Store) NewRangeDescriptor(start, end proto.Key, replicas []proto.ReplicaDescriptor) (*proto.RangeDescriptor, error) {
 	id, err := s.rangeIDAlloc.Allocate()
 	if err != nil {
 		return nil, err
@@ -899,7 +899,7 @@ func (s *Store) NewRangeDescriptor(start, end proto.Key, replicas []proto.Replic
 		RangeID:       proto.RangeID(id),
 		StartKey:      start,
 		EndKey:        end,
-		Replicas:      append([]proto.Replica(nil), replicas...),
+		Replicas:      append([]proto.ReplicaDescriptor(nil), replicas...),
 		NextReplicaID: proto.ReplicaID(len(replicas) + 1),
 	}
 	for i := range desc.Replicas {
@@ -1539,10 +1539,10 @@ func (s *Store) GroupStorage(groupID proto.RangeID) multiraft.WriteableGroupStor
 }
 
 // ReplicaAddress implements the multiraft.Storage interface.
-func (s *Store) ReplicaAddress(groupID proto.RangeID, replicaID proto.ReplicaID) (proto.Replica, error) {
+func (s *Store) ReplicaAddress(groupID proto.RangeID, replicaID proto.ReplicaID) (proto.ReplicaDescriptor, error) {
 	rep, err := s.GetReplica(groupID)
 	if err != nil {
-		return proto.Replica{}, err
+		return proto.ReplicaDescriptor{}, err
 	}
 	return rep.ReplicaAddress(replicaID)
 }
@@ -1562,7 +1562,7 @@ func (s *Store) ReplicaIDForStore(groupID proto.RangeID, storeID proto.StoreID) 
 }
 
 // ReplicasFromSnapshot implements the multiraft.Storage interface.
-func (s *Store) ReplicasFromSnapshot(snap raftpb.Snapshot) ([]proto.Replica, error) {
+func (s *Store) ReplicasFromSnapshot(snap raftpb.Snapshot) ([]proto.ReplicaDescriptor, error) {
 	// TODO(bdarnell): can we avoid parsing this twice?
 	var parsedSnap proto.RaftSnapshotData
 	if err := parsedSnap.Unmarshal(snap.Data); err != nil {

--- a/storage/store_pool.go
+++ b/storage/store_pool.go
@@ -263,8 +263,8 @@ func (sp *StorePool) getStoreDescriptor(storeID proto.StoreID) *proto.StoreDescr
 
 // findDeadReplicas returns any replicas from the supplied slice that are
 // located on dead stores.
-func (sp *StorePool) deadReplicas(repls []proto.Replica) []proto.Replica {
-	var deadReplicas []proto.Replica
+func (sp *StorePool) deadReplicas(repls []proto.ReplicaDescriptor) []proto.ReplicaDescriptor {
+	var deadReplicas []proto.ReplicaDescriptor
 	for _, repl := range repls {
 		if sp.getStoreDetail(repl.StoreID).dead {
 			deadReplicas = append(deadReplicas, repl)

--- a/storage/store_pool_test.go
+++ b/storage/store_pool_test.go
@@ -324,7 +324,7 @@ func TestStorePoolFindDeadReplicas(t *testing.T) {
 		},
 	}
 
-	replicas := []proto.Replica{
+	replicas := []proto.ReplicaDescriptor{
 		{
 			NodeID:    1,
 			StoreID:   1,

--- a/storage/store_test.go
+++ b/storage/store_test.go
@@ -449,7 +449,7 @@ func TestStoreExecuteNoop(t *testing.T) {
 		RequestHeader: proto.RequestHeader{
 			Key:     nil, // intentional
 			RangeID: 1,
-			Replica: proto.Replica{StoreID: store.StoreID()},
+			Replica: proto.ReplicaDescriptor{StoreID: store.StoreID()},
 		},
 	}
 	ba.Add(&proto.GetRequest{RequestHeader: proto.RequestHeader{Key: proto.Key("a")}})
@@ -670,7 +670,7 @@ func TestStoreRangeIDAllocation(t *testing.T) {
 	// Range IDs should be allocated from ID 2 (first alloc'd range)
 	// to rangeIDAllocCount * 3 + 1.
 	for i := 0; i < rangeIDAllocCount*3; i++ {
-		replicas := []proto.Replica{{StoreID: store.StoreID()}}
+		replicas := []proto.ReplicaDescriptor{{StoreID: store.StoreID()}}
 		desc, err := store.NewRangeDescriptor(proto.Key(fmt.Sprintf("%03d", i)), proto.Key(fmt.Sprintf("%03d", i+1)), replicas)
 		if err != nil {
 			t.Fatal(err)

--- a/storage/store_test.go
+++ b/storage/store_test.go
@@ -1370,51 +1370,6 @@ func TestStoreScanInconsistentResolvesIntents(t *testing.T) {
 	})
 }
 
-func TestRaftNodeID(t *testing.T) {
-	defer leaktest.AfterTest(t)
-	cases := []struct {
-		nodeID   proto.NodeID
-		storeID  proto.StoreID
-		expected proto.RaftNodeID
-	}{
-		{0, 1, 1},
-		{1, 1, 0x100000001},
-		{2, 3, 0x200000003},
-		{math.MaxInt32, math.MaxInt32, 0x7fffffff7fffffff},
-	}
-	for _, c := range cases {
-		x := proto.MakeRaftNodeID(c.nodeID, c.storeID)
-		if x != c.expected {
-			t.Errorf("makeRaftNodeID(%v, %v) returned %v; expected %v",
-				c.nodeID, c.storeID, x, c.expected)
-		}
-		n, s := proto.DecodeRaftNodeID(x)
-		if n != c.nodeID || s != c.storeID {
-			t.Errorf("decodeRaftNodeID(%v) returned %v, %v; expected %v, %v",
-				x, n, s, c.nodeID, c.storeID)
-		}
-	}
-
-	panicCases := []struct {
-		nodeID  proto.NodeID
-		storeID proto.StoreID
-	}{
-		{1, 0},
-		{1, -1},
-		{-1, 1},
-	}
-	for _, c := range panicCases {
-		func() {
-			defer func() {
-				_ = recover()
-			}()
-			x := proto.MakeRaftNodeID(c.nodeID, c.storeID)
-			t.Errorf("makeRaftNodeID(%v, %v) returned %v; expected panic",
-				c.nodeID, c.storeID, x)
-		}()
-	}
-}
-
 // TestStoreBadRequests verifies that ExecuteCmd returns errors for
 // bad requests that do not pass key verification.
 //


### PR DESCRIPTION
See docs/RFCS/replica_tombstone.md for motivation and background.

Raft requires that node IDs never be reused; coalesced heartbeats
require that node IDs are consistent across all groups. We must
therefore use different IDs for the two concepts. The never-reused raft
node ID is known as a ReplicaID in cockroach; our node ID and store ID
are used in multiraft for message routing but never make it down to the
raft level.

The mapping from (GroupID, ReplicaID) to (NodeID, StoreID) never changes
once set, so multiraft maintains a cache and there is no need to worry
about invalidations. This cache is populated by three sources: the range
descriptors, incoming snapshots (both loaded from the application via
new methods in the multiraft.Storage interface), and the to/from
addresses of all non-heartbeat raft messages.

The important changes are in the first commit; the other two are just renamings.
