### PR TITLE
log traces

### DIFF
--- a/build/circle-test.sh
+++ b/build/circle-test.sh
@@ -94,7 +94,7 @@ time ${builder} /bin/bash -c "(go generate ./... && git ls-files --modified --de
 # 3. Run "make test".
 echo "make test"
 time ${builder} make test \
-  TESTFLAGS='-v --verbosity=1 --vmodule=monitor=2' | \
+  TESTFLAGS='-v --verbosity=1 --vmodule=monitor=2,tracer=2' | \
   tr -d '\r' | tee "${outdir}/test.log" | \
   grep -E "^\--- (PASS|FAIL)|^(FAIL|ok)|${match}" |
   awk '{print "test:", $0}'


### PR DESCRIPTION
a recent change (1cbbbe53aebedce2acde1d6f6047931577b2a468) removed the traces from the logs for
some of the `storage` tests, but they're very helpful there.
