### PR TITLE
Remove usage of encoding.MustDecode* routines.

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -98,13 +98,8 @@ func ObjectIDForKey(key proto.Key) (uint32, bool) {
 	}
 
 	// Consume first encoded int.
-	defer func() {
-		// Nothing to do, default return values mean "could not decode", which is
-		// definitely the case if DecodeUvarint panics.
-		_ = recover()
-	}()
-	_, id64 := encoding.MustDecodeUvarint(remaining)
-	return uint32(id64), true
+	_, id64, err := encoding.DecodeUvarint(remaining)
+	return uint32(id64), err == nil
 }
 
 // GetValue searches the kv list for 'key' and returns its

--- a/storage/engine/mvcc_test.go
+++ b/storage/engine/mvcc_test.go
@@ -2411,7 +2411,10 @@ func TestMVCCGarbageCollect(t *testing.T) {
 		t.Fatal(err)
 	}
 	for i, kv := range kvsn {
-		key, ts, _ := MVCCDecodeKey(kv.Key)
+		key, ts, _, err := MVCCDecodeKey(kv.Key)
+		if err != nil {
+			t.Fatal(err)
+		}
 		if log.V(1) {
 			log.Infof("%d: %q, ts=%s", i, key, ts)
 		}
@@ -2444,7 +2447,10 @@ func TestMVCCGarbageCollect(t *testing.T) {
 		t.Fatalf("number of kvs %d != expected %d", len(kvs), len(expEncKeys))
 	}
 	for i, kv := range kvs {
-		key, ts, _ := MVCCDecodeKey(kv.Key)
+		key, ts, _, err := MVCCDecodeKey(kv.Key)
+		if err != nil {
+			t.Fatal(err)
+		}
 		log.Infof("%d: %q, ts=%s", i, key, ts)
 		if !kv.Key.Equal(expEncKeys[i]) {
 			t.Errorf("%d: expected key %q; got %q", i, expEncKeys[i], kv.Key)

--- a/storage/gc_queue.go
+++ b/storage/gc_queue.go
@@ -205,7 +205,11 @@ func (gcq *gcQueue) process(now proto.Timestamp, repl *Replica,
 
 	// Iterate through the keys and values of this replica's range.
 	for ; iter.Valid(); iter.Next() {
-		baseKey, ts, isValue := engine.MVCCDecodeKey(iter.Key())
+		baseKey, ts, isValue, err := engine.MVCCDecodeKey(iter.Key())
+		if err != nil {
+			log.Errorf("unable to decode MVCC key: %q: %v", iter.Key(), err)
+			continue
+		}
 		if !isValue {
 			// Moving to the next key (& values).
 			processKeysAndValues()

--- a/storage/range_data_iter_test.go
+++ b/storage/range_data_iter_test.go
@@ -177,8 +177,14 @@ func disabledTestRangeDataIterator(t *testing.T) {
 			t.Fatal("there are more keys in the iteration than expected")
 		}
 		if key := iter.Key(); !key.Equal(curKeys[i]) {
-			k1, ts1, _ := engine.MVCCDecodeKey(key)
-			k2, ts2, _ := engine.MVCCDecodeKey(curKeys[i])
+			k1, ts1, _, err := engine.MVCCDecodeKey(key)
+			if err != nil {
+				t.Fatal(err)
+			}
+			k2, ts2, _, err := engine.MVCCDecodeKey(curKeys[i])
+			if err != nil {
+				t.Fatal(err)
+			}
 			t.Errorf("%d: expected %q(%d); got %q(%d)", i, k2, ts2, k1, ts1)
 		}
 		i++
@@ -209,7 +215,10 @@ func disabledTestRangeDataIterator(t *testing.T) {
 		defer iter.Close()
 		i = 0
 		for ; iter.Valid(); iter.Next() {
-			k1, ts1, _ := engine.MVCCDecodeKey(iter.Key())
+			k1, ts1, _, err := engine.MVCCDecodeKey(iter.Key())
+			if err != nil {
+				t.Fatal(err)
+			}
 			if bytes.HasPrefix(k1, keys.StatusPrefix) {
 				// Some data is written into the system prefix by Store.BootstrapRange,
 				// but it is not in our expected key list so skip it.
@@ -217,7 +226,10 @@ func disabledTestRangeDataIterator(t *testing.T) {
 				continue
 			}
 			if key := iter.Key(); !key.Equal(test.keys[i]) {
-				k2, ts2, _ := engine.MVCCDecodeKey(test.keys[i])
+				k2, ts2, _, err := engine.MVCCDecodeKey(test.keys[i])
+				if err != nil {
+					t.Fatal(err)
+				}
 				t.Errorf("%d: key mismatch %q(%d) != %q(%d)", i, k1, ts1, k2, ts2)
 			}
 			i++

--- a/storage/response_cache.go
+++ b/storage/response_cache.go
@@ -202,7 +202,10 @@ func (rc *ResponseCache) shouldCacheResponse(replyWithErr proto.ResponseWithErro
 
 func (rc *ResponseCache) decodeResponseCacheKey(encKey proto.EncodedKey) (proto.ClientCmdID, error) {
 	ret := proto.ClientCmdID{}
-	key, _, isValue := engine.MVCCDecodeKey(encKey)
+	key, _, isValue, err := engine.MVCCDecodeKey(encKey)
+	if err != nil {
+		return ret, err
+	}
 	if isValue {
 		return ret, util.Errorf("key %s is not a raw MVCC value", encKey)
 	}
@@ -211,7 +214,7 @@ func (rc *ResponseCache) decodeResponseCacheKey(encKey proto.EncodedKey) (proto.
 	}
 	// Cut the prefix and the Range ID.
 	b := key[len(keys.LocalRangeIDPrefix):]
-	b, _, err := encoding.DecodeUvarint(b)
+	b, _, err = encoding.DecodeUvarint(b)
 	if err != nil {
 		return ret, err
 	}

--- a/storage/store.go
+++ b/storage/store.go
@@ -489,7 +489,10 @@ func (s *Store) Start(stopper *stop.Stopper) error {
 	if _, err := engine.MVCCIterate(s.engine, start, end, now, false /* !consistent */, nil, /* txn */
 		false /* !reverse */, func(kv proto.KeyValue) (bool, error) {
 			// Only consider range metadata entries; ignore others.
-			_, suffix, _ := keys.DecodeRangeKey(kv.Key)
+			_, suffix, _, err := keys.DecodeRangeKey(kv.Key)
+			if err != nil {
+				return false, err
+			}
 			if !suffix.Equal(keys.LocalRangeDescriptorSuffix) {
 				return false, nil
 			}

--- a/ts/db_test.go
+++ b/ts/db_test.go
@@ -107,7 +107,10 @@ func (tm *testModel) assertModelCorrect() {
 		var buf bytes.Buffer
 		buf.WriteString("Found unexpected differences in model data and actual data:\n")
 		for k, vActual := range actualData {
-			n, s, r, ts := DecodeDataKey([]byte(k))
+			n, s, r, ts, err := DecodeDataKey([]byte(k))
+			if err != nil {
+				tm.t.Fatal(err)
+			}
 			if vModel, ok := tm.modelData[k]; !ok {
 				fmt.Fprintf(&buf, "\tKey %s/%s@%d, r:%d from actual data was not found in model", n, s, ts, r)
 			} else {
@@ -129,7 +132,10 @@ func (tm *testModel) assertModelCorrect() {
 
 		// Detect keys in model which were not present in the actual data.
 		for k := range tm.modelData {
-			n, s, r, ts := DecodeDataKey([]byte(k))
+			n, s, r, ts, err := DecodeDataKey([]byte(k))
+			if err != nil {
+				tm.t.Fatal(err)
+			}
 			if _, ok := actualData[k]; !ok {
 				fmt.Fprintf(&buf, "Key %s/%s@%d, r:%d from model was not found in actual data", n, s, ts, r)
 			}

--- a/ts/keys_test.go
+++ b/ts/keys_test.go
@@ -72,7 +72,11 @@ func TestDataKeys(t *testing.T) {
 		tc.timestamp = (tc.timestamp / tc.resolution.KeyDuration()) * tc.resolution.KeyDuration()
 
 		d := tc
-		d.name, d.source, d.resolution, d.timestamp = DecodeDataKey(encoded)
+		var err error
+		d.name, d.source, d.resolution, d.timestamp, err = DecodeDataKey(encoded)
+		if err != nil {
+			t.Fatal(err)
+		}
 		if !reflect.DeepEqual(d, tc) {
 			t.Errorf("case %d, decoded values %v did not match expected %v", i, d, tc)
 		}

--- a/ts/query.go
+++ b/ts/query.go
@@ -419,7 +419,10 @@ func (db *DB) Query(query TimeSeriesQueryRequest_Query, r Resolution,
 			return nil, nil, err
 		}
 
-		_, source, _, _ := DecodeDataKey(row.Key)
+		_, source, _, _, err := DecodeDataKey(row.Key)
+		if err != nil {
+			return nil, nil, err
+		}
 		if _, ok := sourceSpans[source]; !ok {
 			sourceSpans[source] = &dataSpan{
 				startNanos:  startNanos,

--- a/util/encoding/encoding.go
+++ b/util/encoding/encoding.go
@@ -52,16 +52,6 @@ func DecodeUint32(b []byte) ([]byte, uint32, error) {
 	return b[4:], v, nil
 }
 
-// MustDecodeUint32Decreasing is a wrapper around DecodeUint32Decreasing which
-// panics if an error occurs.
-func MustDecodeUint32Decreasing(b []byte) ([]byte, uint32) {
-	b, u, err := DecodeUint32Decreasing(b)
-	if err != nil {
-		panic(err)
-	}
-	return b, u
-}
-
 // DecodeUint32Decreasing decodes a uint32 value which was encoded
 // using EncodeUint32Decreasing.
 func DecodeUint32Decreasing(b []byte) ([]byte, uint32, error) {
@@ -96,16 +86,6 @@ func DecodeUint64(b []byte) ([]byte, uint64, error) {
 		(uint64(b[4]) << 24) | (uint64(b[5]) << 16) |
 		(uint64(b[6]) << 8) | uint64(b[7])
 	return b[8:], v, nil
-}
-
-// MustDecodeUint64Decreasing is a wrapper around DecodeUint64Decreasing which
-// panics if an error occurs.
-func MustDecodeUint64Decreasing(b []byte) ([]byte, uint64) {
-	b, u, err := DecodeUint64Decreasing(b)
-	if err != nil {
-		panic(err)
-	}
-	return b, u
 }
 
 // DecodeUint64Decreasing decodes a uint64 value which was encoded
@@ -158,16 +138,6 @@ func EncodeVarint(b []byte, v int64) []byte {
 // reverse order, from largest to smallest.
 func EncodeVarintDecreasing(b []byte, v int64) []byte {
 	return EncodeVarint(b, ^v)
-}
-
-// MustDecodeVarint is a wrapper around DecodeVarint which panics if an error
-// occurs.
-func MustDecodeVarint(b []byte) ([]byte, int64) {
-	b, i, err := DecodeVarint(b)
-	if err != nil {
-		panic(err)
-	}
-	return b, i
 }
 
 // DecodeVarint decodes a varint encoded int64 from the input
@@ -278,16 +248,6 @@ func EncodeUvarintDecreasing(b []byte, v uint64) []byte {
 		return append(b, intMin, byte(v>>56), byte(v>>48), byte(v>>40), byte(v>>32),
 			byte(v>>24), byte(v>>16), byte(v>>8), byte(v))
 	}
-}
-
-// MustDecodeUvarint is a wrapper around DecodeUvarint which panics if an error
-// occurs.
-func MustDecodeUvarint(b []byte) ([]byte, uint64) {
-	b, u, err := DecodeUvarint(b)
-	if err != nil {
-		panic(err)
-	}
-	return b, u
 }
 
 // DecodeUvarint decodes a varint encoded uint64 from the input
@@ -424,16 +384,6 @@ func decodeBytes(b []byte, r []byte, e escapes) ([]byte, []byte, error) {
 
 		b = b[i+2:]
 	}
-}
-
-// MustDecodeBytes is a wrapper around DecodeBytes which panics if an error
-// occurs.
-func MustDecodeBytes(b []byte, r []byte) ([]byte, []byte) {
-	b, r, err := DecodeBytes(b, r)
-	if err != nil {
-		panic(err)
-	}
-	return b, r
 }
 
 // DecodeBytes decodes a []byte value from the input buffer which was


### PR DESCRIPTION
Propagate decoding errors everywhere except from keys.KeyAddress().

Fixes #2671.
