### PR TITLE
Use gulp to watch files/livereload

### DIFF
--- a/ui/Makefile
+++ b/ui/Makefile
@@ -43,10 +43,11 @@ GO_BINDATA := $(GOPATH_BIN)/go-bindata
 TYPESCRIPT_TARGET       := build/app.js
 TEST_TARGET             := build/test.js
 CSS_TARGET              := build/app.css
-STYL_OPTIONS            :=
+CSS_DEBUG_TARGET        := build/app_debug.css
 REMOTE_DEPS             := npm.installed bower.installed tsd.installed
 INDEX                   := index.html
 GOBINDATA_DEPS          := $(TYPESCRIPT_TARGET) $(CSS_TARGET)
+GOBINDATA_DEBUG_DEPS    := $(TYPESCRIPT_TARGET) $(CSS_DEBUG_TARGET)
 GOBINDATA_SOURCES       := $(BOWER_COMPONENTS)/d3/d3.min.js \
                            $(BOWER_COMPONENTS)/lodash/lodash.min.js \
                            $(BOWER_COMPONENTS)/mithril/mithril.js \
@@ -63,7 +64,6 @@ GOBINDATA_TARGET        := ./embedded.go
 GOBINDATA_DEBUG_TARGET  := ./embedded_debug.go
 
 .PHONY:
-all: STYL_OPTIONS += --compress
 all: $(GOBINDATA_TARGET) $(TEST_TARGET)
 	rm -f $(GOBINDATA_DEBUG_TARGET)
 
@@ -91,7 +91,10 @@ $(TEST_TARGET): $(shell find $(TS_ROOT)) $(REMOTE_DEPS)
 	tsc -p $(TEST_ROOT)
 
 $(CSS_TARGET): $(shell find $(STYL_ROOT)) npm.installed bower.installed
-	stylus $(STYL_OPTIONS) $(STYL_ROOT)/app.styl --out build/
+	stylus --compress $(STYL_ROOT)/app.styl --out $@
+
+$(CSS_DEBUG_TARGET): $(shell find $(STYL_ROOT)) npm.installed bower.installed
+	stylus $(STYL_ROOT)/app.styl --out $@
 
 $(GOBINDATA_TARGET): $(GOBINDATA_DEPS) bower.installed release/$(INDEX)
 	rm -f $(INDEX)
@@ -101,11 +104,11 @@ $(GOBINDATA_TARGET): $(GOBINDATA_DEPS) bower.installed release/$(INDEX)
 	gofmt -s -w $@
 	goimports -w $@
 
-$(GOBINDATA_DEBUG_TARGET): $(GOBINDATA_DEPS) bower.installed debug/$(INDEX)
+$(GOBINDATA_DEBUG_TARGET): $(GOBINDATA_DEBUG_DEPS) bower.installed debug/$(INDEX)
 	rm -f $(INDEX)
 	cp debug/$(INDEX) $(INDEX)
 	chmod a-w $(INDEX)
-	$(GO_BINDATA) -nometadata -pkg ui -o $@ -debug $(GOBINDATA_DEPS) $(INDEX) $(GOBINDATA_DEBUG_SOURCES)
+	$(GO_BINDATA) -nometadata -pkg ui -o $@ -debug $(GOBINDATA_DEBUG_DEPS) $(INDEX) $(GOBINDATA_DEBUG_SOURCES)
 
 watch: debug
 	gulp watch

--- a/ui/Makefile
+++ b/ui/Makefile
@@ -94,11 +94,15 @@ $(CSS_TARGET): $(shell find $(STYL_ROOT)) npm.installed bower.installed
 	stylus $(STYL_OPTIONS) $(STYL_ROOT)/app.styl --out build/
 
 $(GOBINDATA_TARGET): $(GOBINDATA_DEPS) bower.installed release/$(INDEX)
+	rm -f $(INDEX)
 	cp release/$(INDEX) $(INDEX)
+	chmod a-w $(INDEX)
 	$(GO_BINDATA) -nometadata -pkg ui -o $@ $(GOBINDATA_DEPS) $(INDEX) $(GOBINDATA_SOURCES)
 	gofmt -s -w $@
 	goimports -w $@
 
 $(GOBINDATA_DEBUG_TARGET): $(GOBINDATA_DEPS) bower.installed debug/$(INDEX)
+	rm -f $(INDEX)
 	cp debug/$(INDEX) $(INDEX)
+	chmod a-w $(INDEX)
 	$(GO_BINDATA) -nometadata -pkg ui -o $@ -debug $(GOBINDATA_DEPS) $(INDEX) $(GOBINDATA_DEBUG_SOURCES)

--- a/ui/Makefile
+++ b/ui/Makefile
@@ -15,6 +15,13 @@
 #
 # Author: Tamir Duberstein (tamird@gmail.com)
 
+# NOTE: for some reason bash is necessary for updating the PATH to work
+# See http://stackoverflow.com/questions/8941110/how-i-could-add-dir-to-path-in-makefile
+SHELL            := /bin/bash
+
+# Update the path to prefer binstubs over globals
+PATH             := node_modules/.bin:$(PATH)
+
 REPO_ROOT        := $(realpath ..)
 ORG_ROOT         := $(REPO_ROOT)/..
 GITHUB_ROOT      := $(ORG_ROOT)/..
@@ -65,7 +72,7 @@ debug: $(GOBINDATA_DEBUG_TARGET) $(TEST_TARGET)
 	rm -f $(GOBINDATA_TARGET)
 
 bower.installed: bower.json npm.installed
-	$(NODE_MODULES)/.bin/bower install --config.interactive=false --allow-root
+	bower install --config.interactive=false --allow-root
 	touch $@
 
 npm.installed: npm-shrinkwrap.json
@@ -73,18 +80,18 @@ npm.installed: npm-shrinkwrap.json
 	touch $@
 
 tsd.installed: tsd.json npm.installed
-	$(NODE_MODULES)/.bin/tsd install
+	tsd install
 	touch $@
 
 $(TYPESCRIPT_TARGET): $(shell find $(TS_ROOT)) $(REMOTE_DEPS)
-	$(NODE_MODULES)/.bin/tsc -p $(TS_ROOT)
-	$(NODE_MODULES)/.bin/tslint -c $(TS_ROOT)/tslint.json $(shell find $(TS_ROOT) -name '*.ts' -not -path '*external*')
+	tsc -p $(TS_ROOT)
+	tslint -c $(TS_ROOT)/tslint.json $(shell find $(TS_ROOT) -name '*.ts' -not -path '*external*')
 
 $(TEST_TARGET): $(shell find $(TS_ROOT)) $(REMOTE_DEPS)
-	$(NODE_MODULES)/.bin/tsc -p $(TEST_ROOT)
+	tsc -p $(TEST_ROOT)
 
 $(CSS_TARGET): $(shell find $(STYL_ROOT)) npm.installed bower.installed
-	$(NODE_MODULES)/.bin/stylus $(STYL_OPTIONS) $(STYL_ROOT)/app.styl --out build/
+	stylus $(STYL_OPTIONS) $(STYL_ROOT)/app.styl --out build/
 
 $(GOBINDATA_TARGET): $(GOBINDATA_DEPS) bower.installed release/$(INDEX)
 	cp release/$(INDEX) $(INDEX)

--- a/ui/Makefile
+++ b/ui/Makefile
@@ -106,3 +106,6 @@ $(GOBINDATA_DEBUG_TARGET): $(GOBINDATA_DEPS) bower.installed debug/$(INDEX)
 	cp debug/$(INDEX) $(INDEX)
 	chmod a-w $(INDEX)
 	$(GO_BINDATA) -nometadata -pkg ui -o $@ -debug $(GOBINDATA_DEPS) $(INDEX) $(GOBINDATA_DEBUG_SOURCES)
+
+watch: debug
+	gulp watch

--- a/ui/README.md
+++ b/ui/README.md
@@ -28,6 +28,18 @@ Before committing, be sure to run `make` to generate a non-debug version of
 `embedded.go`. This is enforced by our build system, but forgetting to do this
 will result in wasted time waiting for the build.
 
+## Watch/Livereload
+If you want to automatically recompile/copy the typescript/stylus/index files, 
+you can use `make watch`. This runs [Gulp](http://gulpjs.com/) under the hood. 
+
+The website can also automatically pick up your changes with [LiveReload]
+(http://livereload.com/) while `make watch` is running. The [Chrome LiveReload Plugin]
+(https://chrome.google.com/webstore/detail/livereload/jnihajbhpnppcggbcgedagnkighmdlei?hl=en)
+is an easy way to take advantage of this.
+
+Note that if you add a new file, you'll need to restart `make watch` and run 
+`make build` in the project root again.
+
 ## Dependencies
 Our admin UI is compiled using a collection of tools that depends on
 [nodejs](https://nodejs.org/), so you'll want to have that installed.

--- a/ui/debug/index.html
+++ b/ui/debug/index.html
@@ -22,7 +22,7 @@ Author: Bram Gruneir (bram+code@cockroachlabs.com)
     <meta charset="utf-8">
     <link href='https://fonts.googleapis.com/css?family=Source+Sans+Pro:400,900|Source+Code+Pro' rel='stylesheet' type='text/css'>
     <link rel="stylesheet" href="/bower_components/nvd3/build/nv.d3.css">
-    <link rel="stylesheet" href="/build/app.css">
+    <link rel="stylesheet" href="/build/app_debug.css">
     <script src="/bower_components/d3/d3.js"></script>
     <script src="/bower_components/lodash/lodash.js"></script>
     <script src="/bower_components/mithril/mithril.js"></script>

--- a/ui/gulpfile.js
+++ b/ui/gulpfile.js
@@ -1,0 +1,53 @@
+'use strict';
+
+// imports
+var gulp = require('gulp')
+    ,stylus = require('gulp-stylus')
+    ,ts = require('gulp-typescript')
+    ,livereload = require('gulp-livereload')
+    ,del = require('del')
+    ;
+
+// generate css from styl files
+gulp.task('stylus', function () {
+    return gulp.src('styl/app.styl')
+        .pipe(stylus({
+            compress: true
+        }))
+        .pipe(gulp.dest('build'))
+        .pipe(livereload());
+});
+
+//typescript
+var tsProject = ts.createProject('./ts/tsconfig.json', {outFile: './build/app.js'});
+gulp.task('typescript', function () {
+    return tsProject.src()
+        .pipe(ts(tsProject))
+        .js
+        .pipe(gulp.dest('.'))
+        .pipe(livereload());
+});
+
+gulp.task('deleteIndex', function () {
+   return del('index.html');
+});
+
+// copy index.html
+gulp.task('copyIndex', ['deleteIndex'], function () {
+    return gulp.src('debug/index.html')
+        .pipe(gulp.dest('./', {mode: '0444'}))
+        .pipe(livereload());
+});
+
+// watch files for changes
+gulp.task('watch', function () {
+
+    livereload.listen();
+
+    gulp.watch('styl/**/*.styl', ['stylus']);
+    gulp.watch('ts/**/*.ts', ['typescript']);
+    gulp.watch('debug/index.html', ['copyIndex']);
+});
+
+// default task is watch
+gulp.task('default', ['watch']);

--- a/ui/gulpfile.js
+++ b/ui/gulpfile.js
@@ -6,14 +6,14 @@ var gulp = require('gulp')
     ,ts = require('gulp-typescript')
     ,livereload = require('gulp-livereload')
     ,del = require('del')
+    ,rename = require('gulp-rename')
     ;
 
 // generate css from styl files
 gulp.task('stylus', function () {
     return gulp.src('styl/app.styl')
-        .pipe(stylus({
-            compress: true
-        }))
+        .pipe(stylus())
+        .pipe(rename('app_debug.css'))
         .pipe(gulp.dest('build'))
         .pipe(livereload());
 });

--- a/ui/npm-shrinkwrap.json
+++ b/ui/npm-shrinkwrap.json
@@ -5,6 +5,17 @@
     "abbrev": {
       "version": "1.0.7"
     },
+    "accord": {
+      "version": "0.20.3",
+      "dependencies": {
+        "glob": {
+          "version": "5.0.15"
+        },
+        "semver": {
+          "version": "4.3.6"
+        }
+      }
+    },
     "amdefine": {
       "version": "1.0.0"
     },
@@ -26,6 +37,9 @@
     "argparse": {
       "version": "1.0.2"
     },
+    "array-differ": {
+      "version": "1.0.0"
+    },
     "array-filter": {
       "version": "0.0.1"
     },
@@ -34,6 +48,15 @@
     },
     "array-reduce": {
       "version": "0.0.0"
+    },
+    "array-union": {
+      "version": "1.0.1"
+    },
+    "array-uniq": {
+      "version": "1.0.2"
+    },
+    "arrify": {
+      "version": "1.0.0"
     },
     "asn1": {
       "version": "0.1.11"
@@ -53,6 +76,9 @@
     "balanced-match": {
       "version": "0.2.0"
     },
+    "beeper": {
+      "version": "1.1.0"
+    },
     "binary": {
       "version": "0.3.0"
     },
@@ -61,6 +87,14 @@
     },
     "bluebird": {
       "version": "1.2.4"
+    },
+    "body-parser": {
+      "version": "1.14.1",
+      "dependencies": {
+        "qs": {
+          "version": "5.1.0"
+        }
+      }
     },
     "boom": {
       "version": "0.4.2"
@@ -119,6 +153,15 @@
     "buffers": {
       "version": "0.1.1"
     },
+    "bytes": {
+      "version": "2.1.0"
+    },
+    "camelcase": {
+      "version": "1.2.1"
+    },
+    "camelcase-keys": {
+      "version": "1.0.0"
+    },
     "cardinal": {
       "version": "0.4.4"
     },
@@ -143,6 +186,12 @@
     "cli-width": {
       "version": "1.0.1"
     },
+    "clone": {
+      "version": "1.0.2"
+    },
+    "clone-stats": {
+      "version": "0.0.1"
+    },
     "code-point-at": {
       "version": "1.0.0"
     },
@@ -163,6 +212,12 @@
         }
       }
     },
+    "content-type": {
+      "version": "1.0.1"
+    },
+    "convert-source-map": {
+      "version": "1.1.1"
+    },
     "core-util-is": {
       "version": "1.0.1"
     },
@@ -177,6 +232,9 @@
     },
     "d": {
       "version": "0.1.1"
+    },
+    "dateformat": {
+      "version": "1.0.11"
     },
     "debug": {
       "version": "2.2.0"
@@ -195,15 +253,40 @@
     "deep-freeze": {
       "version": "0.0.1"
     },
+    "defaults": {
+      "version": "1.0.2",
+      "dependencies": {
+        "clone": {
+          "version": "0.1.19"
+        }
+      }
+    },
     "definition-header": {
       "version": "0.1.0"
+    },
+    "del": {
+      "version": "2.0.2",
+      "dependencies": {
+        "object-assign": {
+          "version": "4.0.1"
+        }
+      }
     },
     "delayed-stream": {
       "version": "0.0.5"
     },
+    "depd": {
+      "version": "1.1.0"
+    },
+    "deprecated": {
+      "version": "0.0.1"
+    },
     "detect-indent": {
       "version": "0.2.0",
       "dependencies": {
+        "get-stdin": {
+          "version": "0.1.0"
+        },
         "minimist": {
           "version": "0.1.0"
         }
@@ -215,6 +298,14 @@
     "duplexer": {
       "version": "0.1.1"
     },
+    "duplexer2": {
+      "version": "0.0.2",
+      "dependencies": {
+        "readable-stream": {
+          "version": "1.1.13"
+        }
+      }
+    },
     "duplexify": {
       "version": "3.4.2",
       "dependencies": {
@@ -225,6 +316,9 @@
           "version": "2.0.2"
         }
       }
+    },
+    "ee-first": {
+      "version": "1.1.1"
     },
     "end-of-stream": {
       "version": "1.1.0"
@@ -259,20 +353,32 @@
     "exit-hook": {
       "version": "1.1.1"
     },
+    "extend": {
+      "version": "2.0.1"
+    },
     "extsprintf": {
       "version": "1.0.3"
+    },
+    "faye-websocket": {
+      "version": "0.7.3"
     },
     "figures": {
       "version": "1.4.0"
     },
-    "findup-sync": {
-      "version": "0.2.1",
+    "find-index": {
+      "version": "0.1.1"
+    },
+    "first-chunk-stream": {
+      "version": "1.0.0"
+    },
+    "flagged-respawn": {
+      "version": "0.3.1"
+    },
+    "fobject": {
+      "version": "0.0.3",
       "dependencies": {
-        "glob": {
-          "version": "4.3.5"
-        },
-        "minimatch": {
-          "version": "2.0.10"
+        "semver": {
+          "version": "4.3.6"
         }
       }
     },
@@ -312,6 +418,9 @@
         }
       }
     },
+    "gaze": {
+      "version": "0.5.1"
+    },
     "get-stdin": {
       "version": "0.1.0"
     },
@@ -326,6 +435,54 @@
         }
       }
     },
+    "glob-stream": {
+      "version": "3.1.18",
+      "dependencies": {
+        "minimatch": {
+          "version": "2.0.10"
+        },
+        "through2": {
+          "version": "0.6.5"
+        }
+      }
+    },
+    "glob-watcher": {
+      "version": "0.0.6"
+    },
+    "glob2base": {
+      "version": "0.0.12"
+    },
+    "globby": {
+      "version": "3.0.1",
+      "dependencies": {
+        "glob": {
+          "version": "5.0.15"
+        },
+        "object-assign": {
+          "version": "4.0.1"
+        }
+      }
+    },
+    "globule": {
+      "version": "0.1.0",
+      "dependencies": {
+        "glob": {
+          "version": "3.1.21"
+        },
+        "graceful-fs": {
+          "version": "1.2.3"
+        },
+        "inherits": {
+          "version": "1.0.2"
+        },
+        "lodash": {
+          "version": "1.0.2"
+        },
+        "minimatch": {
+          "version": "0.2.14"
+        }
+      }
+    },
     "got": {
       "version": "3.3.1",
       "dependencies": {
@@ -336,6 +493,93 @@
     },
     "graceful-fs": {
       "version": "3.0.8"
+    },
+    "gulp": {
+      "version": "3.9.0",
+      "dependencies": {
+        "minimist": {
+          "version": "1.2.0"
+        },
+        "semver": {
+          "version": "4.3.6"
+        }
+      }
+    },
+    "gulp-livereload": {
+      "version": "3.8.1",
+      "dependencies": {
+        "ansi-regex": {
+          "version": "0.2.1"
+        },
+        "ansi-styles": {
+          "version": "1.1.0"
+        },
+        "chalk": {
+          "version": "0.5.1"
+        },
+        "has-ansi": {
+          "version": "0.1.0"
+        },
+        "strip-ansi": {
+          "version": "0.3.0"
+        },
+        "supports-color": {
+          "version": "0.2.0"
+        }
+      }
+    },
+    "gulp-stylus": {
+      "version": "2.0.7"
+    },
+    "gulp-typescript": {
+      "version": "2.9.0",
+      "dependencies": {
+        "clone": {
+          "version": "0.2.0"
+        },
+        "glob-stream": {
+          "version": "4.1.1",
+          "dependencies": {
+            "through2": {
+              "version": "0.6.5"
+            }
+          }
+        },
+        "glob-watcher": {
+          "version": "0.0.8"
+        },
+        "minimatch": {
+          "version": "2.0.10"
+        },
+        "source-map": {
+          "version": "0.5.1"
+        },
+        "unique-stream": {
+          "version": "2.2.0"
+        },
+        "vinyl": {
+          "version": "0.4.6"
+        },
+        "vinyl-fs": {
+          "version": "1.0.0",
+          "dependencies": {
+            "through2": {
+              "version": "0.6.5"
+            }
+          }
+        }
+      }
+    },
+    "gulp-util": {
+      "version": "3.0.6",
+      "dependencies": {
+        "minimist": {
+          "version": "1.2.0"
+        },
+        "object-assign": {
+          "version": "3.0.0"
+        }
+      }
     },
     "handlebars": {
       "version": "2.0.0",
@@ -354,8 +598,28 @@
     "hoek": {
       "version": "0.9.1"
     },
+    "http-errors": {
+      "version": "1.3.1"
+    },
     "http-signature": {
       "version": "0.10.1"
+    },
+    "iconv-lite": {
+      "version": "0.4.12"
+    },
+    "indent-string": {
+      "version": "1.2.2",
+      "dependencies": {
+        "get-stdin": {
+          "version": "4.0.1"
+        },
+        "minimist": {
+          "version": "1.2.0"
+        }
+      }
+    },
+    "indx": {
+      "version": "0.2.3"
     },
     "infinity-agent": {
       "version": "2.0.3"
@@ -442,16 +706,31 @@
         }
       }
     },
+    "interpret": {
+      "version": "0.6.6"
+    },
     "intersect": {
       "version": "0.0.3"
     },
     "is-absolute": {
       "version": "0.1.7"
     },
+    "is-finite": {
+      "version": "1.0.1"
+    },
     "is-fullwidth-code-point": {
       "version": "1.0.0"
     },
     "is-npm": {
+      "version": "1.0.0"
+    },
+    "is-path-cwd": {
+      "version": "1.0.0"
+    },
+    "is-path-in-cwd": {
+      "version": "1.0.0"
+    },
+    "is-path-inside": {
       "version": "1.0.0"
     },
     "is-redirect": {
@@ -465,6 +744,9 @@
     },
     "is-stream": {
       "version": "1.0.1"
+    },
+    "is-utf8": {
+      "version": "0.2.0"
     },
     "isarray": {
       "version": "0.0.1"
@@ -515,17 +797,85 @@
     "lazy.js": {
       "version": "0.3.2"
     },
+    "liftoff": {
+      "version": "2.2.0",
+      "dependencies": {
+        "findup-sync": {
+          "version": "0.3.0"
+        },
+        "glob": {
+          "version": "5.0.15"
+        }
+      }
+    },
+    "livereload-js": {
+      "version": "2.2.2"
+    },
     "lockfile": {
       "version": "1.0.1"
     },
     "lodash": {
       "version": "3.10.1"
     },
+    "lodash._baseassign": {
+      "version": "3.2.0"
+    },
+    "lodash._basecopy": {
+      "version": "3.0.1"
+    },
+    "lodash._basetostring": {
+      "version": "3.0.1"
+    },
+    "lodash._basevalues": {
+      "version": "3.0.0"
+    },
+    "lodash._bindcallback": {
+      "version": "3.0.1"
+    },
+    "lodash._createassigner": {
+      "version": "3.1.1"
+    },
     "lodash._getnative": {
       "version": "3.9.1"
     },
+    "lodash._isiterateecall": {
+      "version": "3.0.9"
+    },
+    "lodash._reescape": {
+      "version": "3.0.0"
+    },
+    "lodash._reevaluate": {
+      "version": "3.0.0"
+    },
+    "lodash._reinterpolate": {
+      "version": "3.0.0"
+    },
+    "lodash.assign": {
+      "version": "3.2.0"
+    },
     "lodash.debounce": {
       "version": "3.1.1"
+    },
+    "lodash.escape": {
+      "version": "3.0.0"
+    },
+    "lodash.isarguments": {
+      "version": "3.0.4"
+    },
+    "lodash.isarray": {
+      "version": "3.0.4"
+    },
+    "lodash.keys": {
+      "version": "3.1.2"
+    },
+    "lodash.restparam": {
+      "version": "3.6.1"
+    },
+    "lodash.template": {
+      "version": "3.6.2"
+    },
+    "lodash.templatesettings": {
+      "version": "3.1.0"
     },
     "lowercase-keys": {
       "version": "1.0.0"
@@ -536,6 +886,9 @@
     "lru-queue": {
       "version": "0.1.0"
     },
+    "map-obj": {
+      "version": "1.0.1"
+    },
     "map-stream": {
       "version": "0.1.0"
     },
@@ -545,8 +898,30 @@
     "md5-o-matic": {
       "version": "0.1.1"
     },
+    "media-typer": {
+      "version": "0.3.0"
+    },
     "memoizee": {
       "version": "0.3.9"
+    },
+    "meow": {
+      "version": "3.3.0",
+      "dependencies": {
+        "minimist": {
+          "version": "1.2.0"
+        },
+        "object-assign": {
+          "version": "3.0.0"
+        }
+      }
+    },
+    "merge-stream": {
+      "version": "0.1.8",
+      "dependencies": {
+        "through2": {
+          "version": "0.6.5"
+        }
+      }
     },
     "mime": {
       "version": "1.3.4"
@@ -556,6 +931,20 @@
     },
     "mime-types": {
       "version": "1.0.2"
+    },
+    "mini-lr": {
+      "version": "0.1.8",
+      "dependencies": {
+        "debug": {
+          "version": "2.0.0"
+        },
+        "ms": {
+          "version": "0.6.2"
+        },
+        "qs": {
+          "version": "2.2.5"
+        }
+      }
     },
     "minichain": {
       "version": "0.0.1"
@@ -600,6 +989,9 @@
     "ms": {
       "version": "0.7.1"
     },
+    "multipipe": {
+      "version": "0.1.2"
+    },
     "mute-stream": {
       "version": "0.0.4"
     },
@@ -616,7 +1008,7 @@
       "version": "3.0.4"
     },
     "npm": {
-      "version": "3.3.4",
+      "version": "3.3.5",
       "dependencies": {
         "abbrev": {
           "version": "1.0.7"
@@ -1043,7 +1435,7 @@
           "version": "1.0.2"
         },
         "npm-install-checks": {
-          "version": "2.0.0"
+          "version": "2.0.1"
         },
         "npm-package-arg": {
           "version": "4.0.2"
@@ -1109,7 +1501,7 @@
           "version": "2.0.1"
         },
         "read-package-tree": {
-          "version": "5.1.0"
+          "version": "5.1.2"
         },
         "readable-stream": {
           "version": "1.1.13"
@@ -1121,7 +1513,7 @@
           "version": "3.0.1"
         },
         "request": {
-          "version": "2.62.0"
+          "version": "2.63.0"
         },
         "retry": {
           "version": "0.8.0"
@@ -1244,6 +1636,9 @@
     "object-assign": {
       "version": "2.1.1"
     },
+    "on-finished": {
+      "version": "2.3.0"
+    },
     "once": {
       "version": "1.3.2"
     },
@@ -1258,6 +1653,17 @@
     },
     "optimist": {
       "version": "0.6.1"
+    },
+    "orchestrator": {
+      "version": "0.3.7",
+      "dependencies": {
+        "end-of-stream": {
+          "version": "0.1.5"
+        }
+      }
+    },
+    "ordered-read-streams": {
+      "version": "0.1.0"
     },
     "os-homedir": {
       "version": "1.0.1"
@@ -1290,14 +1696,23 @@
     "package-json": {
       "version": "1.2.0"
     },
+    "parseurl": {
+      "version": "1.3.0"
+    },
     "parsimmon": {
       "version": "0.5.1"
     },
     "path-is-absolute": {
       "version": "1.0.0"
     },
+    "path-is-inside": {
+      "version": "1.0.1"
+    },
     "pause-stream": {
       "version": "0.0.11"
+    },
+    "pify": {
+      "version": "2.2.0"
     },
     "pinkie": {
       "version": "1.0.0"
@@ -1310,6 +1725,9 @@
     },
     "prepend-http": {
       "version": "1.0.3"
+    },
+    "pretty-hrtime": {
+      "version": "1.0.1"
     },
     "process-nextick-args": {
       "version": "1.0.3"
@@ -1325,6 +1743,9 @@
     },
     "qs": {
       "version": "2.3.3"
+    },
+    "raw-body": {
+      "version": "2.1.4"
     },
     "rc": {
       "version": "1.1.1",
@@ -1359,11 +1780,20 @@
         }
       }
     },
+    "rechoir": {
+      "version": "0.6.2"
+    },
     "redeyed": {
       "version": "0.4.4"
     },
     "registry-url": {
       "version": "3.0.3"
+    },
+    "repeating": {
+      "version": "1.1.3"
+    },
+    "replace-ext": {
+      "version": "0.0.1"
     },
     "request": {
       "version": "2.53.0",
@@ -1399,6 +1829,9 @@
     },
     "request-replay": {
       "version": "0.2.0"
+    },
+    "resolve": {
+      "version": "1.1.6"
     },
     "restore-cursor": {
       "version": "1.0.1"
@@ -1437,6 +1870,9 @@
         }
       }
     },
+    "sequencify": {
+      "version": "0.0.7"
+    },
     "shell-quote": {
       "version": "1.4.3"
     },
@@ -1461,8 +1897,17 @@
     "sprintf-js": {
       "version": "1.0.3"
     },
+    "stat-mode": {
+      "version": "0.2.1"
+    },
+    "statuses": {
+      "version": "1.2.1"
+    },
     "stream-combiner": {
       "version": "0.0.4"
+    },
+    "stream-consume": {
+      "version": "0.1.0"
     },
     "string_decoder": {
       "version": "0.10.31"
@@ -1478,6 +1923,9 @@
     },
     "strip-ansi": {
       "version": "3.0.0"
+    },
+    "strip-bom": {
+      "version": "1.0.0"
     },
     "strip-json-comments": {
       "version": "0.1.3"
@@ -1515,6 +1963,20 @@
     },
     "through": {
       "version": "2.3.8"
+    },
+    "through2": {
+      "version": "2.0.0",
+      "dependencies": {
+        "readable-stream": {
+          "version": "2.0.2"
+        }
+      }
+    },
+    "through2-filter": {
+      "version": "2.0.0"
+    },
+    "tildify": {
+      "version": "1.1.1"
     },
     "timed-out": {
       "version": "2.0.0"
@@ -1556,6 +2018,9 @@
         "ansi-styles": {
           "version": "1.1.0"
         },
+        "event-stream": {
+          "version": "3.1.7"
+        },
         "has-ansi": {
           "version": "0.1.0"
         },
@@ -1574,6 +2039,9 @@
         "semver": {
           "version": "4.3.6"
         },
+        "split": {
+          "version": "0.2.10"
+        },
         "strip-ansi": {
           "version": "0.3.0"
         },
@@ -1591,13 +2059,35 @@
       }
     },
     "tslint": {
-      "version": "2.5.0"
+      "version": "2.5.0",
+      "dependencies": {
+        "findup-sync": {
+          "version": "0.2.1"
+        },
+        "glob": {
+          "version": "4.3.5"
+        },
+        "minimatch": {
+          "version": "2.0.10"
+        }
+      }
     },
     "tunnel-agent": {
       "version": "0.4.1"
     },
     "type-detect": {
       "version": "0.1.2"
+    },
+    "type-is": {
+      "version": "1.6.9",
+      "dependencies": {
+        "mime-db": {
+          "version": "1.19.0"
+        },
+        "mime-types": {
+          "version": "2.1.7"
+        }
+      }
     },
     "typescript": {
       "version": "1.6.2"
@@ -1616,8 +2106,14 @@
     "underscore.string": {
       "version": "3.1.1"
     },
+    "unique-stream": {
+      "version": "1.0.0"
+    },
     "universal-analytics": {
       "version": "0.3.9"
+    },
+    "unpipe": {
+      "version": "1.0.0"
     },
     "update-notifier": {
       "version": "0.3.2"
@@ -1634,8 +2130,40 @@
     "uuid": {
       "version": "2.0.1"
     },
+    "v8flags": {
+      "version": "2.0.10"
+    },
     "verror": {
       "version": "1.4.0"
+    },
+    "vinyl": {
+      "version": "0.5.3"
+    },
+    "vinyl-fs": {
+      "version": "0.3.14",
+      "dependencies": {
+        "clone": {
+          "version": "0.2.0"
+        },
+        "through2": {
+          "version": "0.6.5"
+        },
+        "vinyl": {
+          "version": "0.4.6"
+        }
+      }
+    },
+    "vinyl-sourcemaps-apply": {
+      "version": "0.1.4"
+    },
+    "websocket-driver": {
+      "version": "0.6.2"
+    },
+    "websocket-extensions": {
+      "version": "0.1.1"
+    },
+    "when": {
+      "version": "3.7.3"
     },
     "which": {
       "version": "1.1.2"

--- a/ui/npm-shrinkwrap.json
+++ b/ui/npm-shrinkwrap.json
@@ -345,7 +345,7 @@
       "version": "0.3.3"
     },
     "event-stream": {
-      "version": "3.1.7"
+      "version": "3.3.1"
     },
     "exit": {
       "version": "0.1.2"
@@ -367,6 +367,14 @@
     },
     "find-index": {
       "version": "0.1.1"
+    },
+    "findup-sync": {
+      "version": "0.3.0",
+      "dependencies": {
+        "glob": {
+          "version": "5.0.15"
+        }
+      }
     },
     "first-chunk-stream": {
       "version": "1.0.0"
@@ -422,7 +430,7 @@
       "version": "0.5.1"
     },
     "get-stdin": {
-      "version": "0.1.0"
+      "version": "5.0.0"
     },
     "github": {
       "version": "0.2.4"
@@ -527,6 +535,9 @@
           "version": "0.2.0"
         }
       }
+    },
+    "gulp-rename": {
+      "version": "1.2.2"
     },
     "gulp-stylus": {
       "version": "2.0.7"
@@ -798,15 +809,7 @@
       "version": "0.3.2"
     },
     "liftoff": {
-      "version": "2.2.0",
-      "dependencies": {
-        "findup-sync": {
-          "version": "0.3.0"
-        },
-        "glob": {
-          "version": "5.0.15"
-        }
-      }
+      "version": "2.2.0"
     },
     "livereload-js": {
       "version": "2.2.2"
@@ -1892,13 +1895,10 @@
       "version": "0.1.43"
     },
     "split": {
-      "version": "0.2.10"
+      "version": "0.3.3"
     },
     "sprintf-js": {
       "version": "1.0.3"
-    },
-    "stat-mode": {
-      "version": "0.2.1"
     },
     "statuses": {
       "version": "1.2.1"
@@ -2119,7 +2119,7 @@
       "version": "0.3.2"
     },
     "uri-templates": {
-      "version": "0.1.7"
+      "version": "0.1.8"
     },
     "user-home": {
       "version": "1.1.1"

--- a/ui/package.json
+++ b/ui/package.json
@@ -7,6 +7,7 @@
     "del": "^2.0.2",
     "gulp": "^3.9.0",
     "gulp-livereload": "^3.8.0",
+    "gulp-rename": "^1.2.2",
     "gulp-stylus": "^2.0.7",
     "gulp-typescript": "^2.9.0",
     "npm": "^3.3.4",

--- a/ui/package.json
+++ b/ui/package.json
@@ -4,6 +4,11 @@
   "private": true,
   "dependencies": {
     "bower": ">=1.5.3",
+    "del": "^2.0.2",
+    "gulp": "^3.9.0",
+    "gulp-livereload": "^3.8.0",
+    "gulp-stylus": "^2.0.7",
+    "gulp-typescript": "^2.9.0",
     "npm": "^3.3.4",
     "shonkwrap": "^1.1.2",
     "stylus": ">=0.51.1",


### PR DESCRIPTION
The main reason to use Gulp is Livereload, which makes it a lot easier to make visual changes.

I've also switched to use Bower to manage frontend dependencies and tsd to manage Typescript definitions. The exception is the mithril.d.js file, which we've made some modifications to.

This shouldn't add any extra dependencies except for when developing.
