### PR TITLE
Avoid sorting in more situations.

### DIFF
--- a/sql/distinct.go
+++ b/sql/distinct.go
@@ -33,11 +33,16 @@ func (*planner) distinct(n *parser.Select, p planNode) planNode {
 		planNode:   p,
 		suffixSeen: make(map[string]struct{}),
 	}
-	if len(p.Ordering()) != 0 {
+	ordering, prefix := p.Ordering()
+	if len(ordering) != 0 {
 		d.columnsInOrder = make([]bool, len(p.Columns()))
 	}
-	for _, p := range p.Ordering() {
+	for _, p := range ordering {
 		if p == 0 {
+			if prefix > 0 {
+				prefix--
+				continue
+			}
 			break
 		}
 		if p < 0 {

--- a/sql/group.go
+++ b/sql/group.go
@@ -110,7 +110,7 @@ func (n *groupNode) Columns() []string {
 	return n.columns
 }
 
-func (n *groupNode) Ordering() []int {
+func (n *groupNode) Ordering() ([]int, int) {
 	return n.plan.Ordering()
 }
 

--- a/sql/join.go
+++ b/sql/join.go
@@ -38,7 +38,7 @@ type indexJoinNode struct {
 	err              error
 }
 
-func makeIndexJoin(indexScan *scanNode) (*indexJoinNode, error) {
+func makeIndexJoin(indexScan *scanNode, exactPrefix int) (*indexJoinNode, error) {
 	// Copy the index scan node into a new table scan node and reset the fields
 	// that were set up for the index scan.
 	table := &scanNode{}
@@ -47,7 +47,7 @@ func makeIndexJoin(indexScan *scanNode) (*indexJoinNode, error) {
 	table.spans = nil
 	table.reverse = false
 	table.isSecondaryIndex = false
-	table.initOrdering()
+	table.initOrdering(0)
 
 	// We want to the index scan to keep the same render target indexes for
 	// columns which are part of the primary key or part of the index. This
@@ -88,7 +88,7 @@ func makeIndexJoin(indexScan *scanNode) (*indexJoinNode, error) {
 		}
 	}
 
-	indexScan.initOrdering()
+	indexScan.initOrdering(exactPrefix)
 
 	primaryKeyPrefix := proto.Key(MakeIndexKeyPrefix(table.desc.ID, table.index.ID))
 
@@ -104,7 +104,7 @@ func (n *indexJoinNode) Columns() []string {
 	return n.table.Columns()
 }
 
-func (n *indexJoinNode) Ordering() []int {
+func (n *indexJoinNode) Ordering() ([]int, int) {
 	return n.index.Ordering()
 }
 

--- a/sql/plan.go
+++ b/sql/plan.go
@@ -158,9 +158,12 @@ type planNode interface {
 	// guaranteed to be equal to the length of the tuple returned by Values().
 	Columns() []string
 	// The indexes of the columns the output is ordered by. Indexes are 1-based
-	// and negative indexes indicate descending ordering. The []int result may be
-	// nil if no ordering has been performed.
-	Ordering() []int
+	// and negative indexes indicate descending ordering. The ordering return
+	// value may be nil if no ordering has been performed. The prefix return
+	// value indicates the prefix of the ordering for which an exact match has
+	// been performed via filtering. This prefix may safely be ignored for
+	// ordering considerations.
+	Ordering() (ordering []int, prefix int)
 	// Values returns the values at the current row. The result is only valid
 	// until the next call to Next().
 	Values() parser.DTuple

--- a/sql/testdata/aggregate
+++ b/sql/testdata/aggregate
@@ -180,7 +180,7 @@ EXPLAIN SELECT MIN(x) FROM xyz WHERE (y, z) = (2, 3)
 1 scan  xyz@zyx /3/2-/3/3
 
 query ITT
-EXPLAIN SELECT MAX(x) FROM xyz WHERE (y, z) = (2, 3)
+EXPLAIN SELECT MAX(x) FROM xyz WHERE (z, y) = (3, 2)
 ----
 0 group   MAX(x)
 1 revscan xyz@zyx /3/2-/3/3

--- a/sql/testdata/order_by
+++ b/sql/testdata/order_by
@@ -234,3 +234,13 @@ query I
 SELECT a FROM abc ORDER BY a DESC OFFSET 1
 ----
 1
+
+query I
+EXPLAIN SELECT c FROM abc WHERE b = 2 ORDER BY c
+----
+0 scan abc@bc /2-/3
+
+query I
+EXPLAIN SELECT c FROM abc WHERE b = 2 ORDER BY c DESC
+----
+0 revscan abc@bc /2-/3

--- a/sql/values.go
+++ b/sql/values.go
@@ -77,8 +77,8 @@ func (n *valuesNode) Columns() []string {
 	return n.columns
 }
 
-func (n *valuesNode) Ordering() []int {
-	return nil
+func (n *valuesNode) Ordering() ([]int, int) {
+	return nil, 0
 }
 
 func (n *valuesNode) Values() parser.DTuple {


### PR DESCRIPTION
Consider the query:

  SELECT v FROM t WHERE k = 1 ORDER BY v

If there is an index on (k, v) we know that an exact match has been
performed on k and thus the results are already ordered on v and thus no
sorting is required.

Added an additional return value to planNode.Ordering() to indicate the
prefix of the ordering for which an exact match has been performed. A
bit of code reorg allowed sortNode.wrap() to take advantage of this new
info.

See #2636.
