### PR TITLE
fix the raft/coord error race (once more)

### DIFF
--- a/kv/txn_coord_sender.go
+++ b/kv/txn_coord_sender.go
@@ -616,6 +616,8 @@ func (tc *TxnCoordSender) updateState(ctx context.Context, ba roachpb.BatchReque
 	newTxn := &roachpb.Transaction{}
 	newTxn.Update(ba.GetTxn())
 	err := pErr.GoError()
+	// TODO(bdarnell): We're writing to errors here (and where using ErrorWithIndex);
+	// since there's no concept of ownership copy-on-write is always preferable.
 	switch t := err.(type) {
 	case nil:
 		newTxn.Update(br.GetTxn())


### PR DESCRIPTION
multiraft actually leaked the error into the
callback, which is fine for immutable errors
but that's not what our errors generally are.
Instead, just stringify the error first; that
works fine for the intended purpose there.

ping #2537.
