### PR TITLE
DNM: remove testutils from production binary?

### DIFF
--- a/cli/flags_test.go
+++ b/cli/flags_test.go
@@ -55,6 +55,7 @@ func TestNoLinkForbidden(t *testing.T) {
 	for _, forbidden := range []string{
 		"testing", // defines flags
 		"github.com/cockroachdb/cockroach/security/securitytest", // contains certificates
+		"github.com/cockroachdb/cockroach/testutils",
 	} {
 		if _, ok := imports[forbidden]; ok {
 			t.Errorf("The cockroach binary includes %s, which is forbidden", forbidden)

--- a/sql/driver/link_test.go
+++ b/sql/driver/link_test.go
@@ -40,6 +40,7 @@ func TestNoLinkForbidden(t *testing.T) {
 		"C",       // cross compilation
 		"testing", // defines flags
 		"github.com/cockroachdb/cockroach/util/log", // defines flags
+		"github.com/cockroachdb/cockroach/testutils",
 	} {
 		if _, ok := imports[forbidden]; ok {
 			t.Errorf("sql/driver includes %s, which is forbidden", forbidden)


### PR DESCRIPTION
ping @tamird. `kv` currently imports `testutils` for
use in the test server. I wonder if we're happy with
it. Stumbled upon the issue when moving `batchutil`
out of `testutils`.

tests currently fail due to the above.
