### PR TITLE
build: cache ui dependencies in CI 

### DIFF
--- a/build/Dockerfile
+++ b/build/Dockerfile
@@ -1,0 +1,16 @@
+FROM golang:1.5
+
+MAINTAINER Peter Mattis <peter@cockroachlabs.com>
+
+RUN curl --silent --location https://deb.nodesource.com/setup_4.x | bash - && \
+ apt-get dist-upgrade -y && \
+ apt-get install --no-install-recommends --auto-remove -y git build-essential file nodejs && \
+ apt-get clean autoclean && \
+ apt-get autoremove -y && \
+ rm -rf /tmp/*
+
+RUN go get golang.org/x/tools/cmd/vet
+
+ENV SKIP_BOOTSTRAP=1
+
+CMD ["/bin/bash"]

--- a/build/build-docker-deploy.sh
+++ b/build/build-docker-deploy.sh
@@ -27,4 +27,4 @@ fi
 $(dirname $0)/builder.sh $0 docker
 
 # Build the image.
-docker build -t cockroachdb/cockroach "$(dirname $0)/deploy"
+docker build --tag=cockroachdb/cockroach "$(dirname $0)/deploy"

--- a/build/builder.sh
+++ b/build/builder.sh
@@ -5,20 +5,7 @@ set -eu
 image="cockroachdb/builder"
 
 function init() {
-  docker build --tag="${image}" - <<EOF
-FROM golang:1.5
-
-RUN curl --silent --location https://deb.nodesource.com/setup_4.x | bash - && \
- apt-get dist-upgrade -y && \
- apt-get install --no-install-recommends --auto-remove -y git build-essential file nodejs && \
- apt-get clean autoclean && \
- apt-get autoremove -y && \
- rm -rf /tmp/*
-RUN go get golang.org/x/tools/cmd/vet
-ENV SKIP_BOOTSTRAP=1
-
-CMD ["/bin/bash"]
-EOF
+  docker build --tag="${image}" "$(dirname $0)"
 }
 
 if [ "${1-}" = "pull" ]; then

--- a/build/builder.sh
+++ b/build/builder.sh
@@ -41,19 +41,20 @@ if [ -t 0 ]; then
   tty="--tty"
 fi
 
+buildcache_dir="buildcache"
+uicache_dir="uicache"
+
 # Run our build container with a set of volumes mounted that will
 # allow the container to store persistent build data on the host
 # computer.
 # -i causes some commands (including `git diff`) to attempt to use
 # a pager, so we override $PAGER to disable.
 docker run -i ${tty-} ${rm} \
-  --volume="${gopath0}/src:/go/src" \
+  --volume="${gopath0}:/go" \
+  --volume="${HOME}/${buildcache_dir}:/${buildcache_dir}" \
+  --volume="${HOME}/${uicache_dir}:/${uicache_dir}" \
   --volume="${PWD}:/go/src/github.com/cockroachdb/cockroach" \
-  --volume="${gopath0}/pkg:/go/pkg" \
-  --volume="${gopath0}/pkg/linux_amd64_netgo:/usr/src/go/pkg/linux_amd64_netgo" \
-  --volume="${gopath0}/pkg/linux_amd64_race:/usr/src/go/pkg/linux_amd64_race" \
-  --volume="${gopath0}/bin/linux_amd64:/go/bin" \
   --workdir="/go/src/github.com/cockroachdb/cockroach" \
-  --env="CACHE=/go/pkg/cache" \
+  --env="CACHE=/${buildcache_dir}" \
   --env="PAGER=cat" \
   "${image}" "$@"

--- a/build/circle-deps.sh
+++ b/build/circle-deps.sh
@@ -11,6 +11,14 @@ set -eux
 if [ "${1-}" = "docker" ]; then
   cmds=$(grep '^cmd' GLOCKFILE | grep -v glock | awk '{print $2}')
 
+  # `"$GOPATH"/pkg/cache` is `cachedir` on the host computer.
+  # Create the cache directories to avoid errors on `ln` below.
+  mkdir -p "$GOPATH"/pkg/cache/{bower_components,node_modules,typings}
+
+  # Symlink the cache into the source tree.
+  ln -s "$GOPATH"/pkg/cache/{bower_components,node_modules,typings} ui/
+  time make -C ui {bower,npm,tsd}.installed
+
   # Restore previously cached build artifacts.
   time go install github.com/cockroachdb/build-cache
   time build-cache restore . .:race,test ${cmds}
@@ -31,7 +39,7 @@ cachedir="${gopath0}/pkg/cache"
 # The tag for the cockroachdb/builder image. If the image is changed
 # (for example, adding "npm"), a new image should be pushed using
 # "build/builder.sh push" and the new tag value placed here.
-tag="20150928-162648"
+tag="20150929-133252"
 
 mkdir -p "${cachedir}"
 du -sh "${cachedir}"

--- a/circle.yml
+++ b/circle.yml
@@ -10,6 +10,9 @@ checkout:
 dependencies:
   override:
     - build/circle-deps.sh
+  cache_directories:
+    - ~/buildcache
+    - ~/uicache
 
 test:
   override:


### PR DESCRIPTION
Closes #2705.

More useful now that we have npm, bower, and tsd.
