### PR TITLE
enforce timestamp set for all cmds entering Store.Send

### DIFF
--- a/storage/replica.go
+++ b/storage/replica.go
@@ -415,14 +415,6 @@ func (r *Replica) redirectOnOrAcquireLeaderLease(trace *tracer.Trace, timestamp 
 	return err
 }
 
-// WaitForLeaderLease is used from unittests to wait until this range
-// has the leader lease.
-func (r *Replica) WaitForLeaderLease(t util.Tester) {
-	util.SucceedsWithin(t, 1*time.Second, func() error {
-		return r.requestLeaderLease(r.rm.Clock().Now())
-	})
-}
-
 // isInitialized is true if we know the metadata of this range, either
 // because we created it or we have received an initial snapshot from
 // another node. It is false when a range has been created in response

--- a/storage/store.go
+++ b/storage/store.go
@@ -1178,6 +1178,10 @@ func (s *Store) Send(ctx context.Context, ba roachpb.BatchRequest) (*roachpb.Bat
 		// advances the local node's clock to a high water mark from
 		// amongst all nodes with which it has interacted.
 		s.ctx.Clock.Update(header.Timestamp)
+	} else if ba.Txn == nil {
+		// TODO(tschottdorf): possibly consolidate this with other locations
+		// doing the same (but it's definitely required here).
+		ba.Timestamp.Forward(s.Clock().Now())
 	}
 
 	defer trace.Epoch(fmt.Sprintf("executing %d requests", len(ba.Requests)))()


### PR DESCRIPTION
otherwise, TestStoreRangeRebalance encounters rare failures:
- lease gets obtained by range X on store Y
- that range gets removed
- lease active, and no request can succeed because the check
  uses the zero timestamp

of course that is just one manifestation of the more general issue.

I'm going to clean up timestamp, but this fixes an immediate source
of sporadic test failures by deadlock.
