### PR TITLE
drop RequestHeader.Timestamp

### DIFF
--- a/client/sender.go
+++ b/client/sender.go
@@ -86,10 +86,10 @@ func newSender(u *url.URL, ctx *base.Context, retryOptions retry.Options, stoppe
 	return f(u, ctx, retryOptions, stopper)
 }
 
-// SendWrappedAt is a convenience function which wraps the request in a batch,
-// and send it via the provided Sender at the given timestamp. It returns the
+// SendWrappedAt is a convenience function which wraps the request in a batch
+// and sends it via the provided Sender at the given timestamp. It returns the
 // unwrapped response or an error. It's valid to pass a `nil` context;
-// context.TODO() is used in that case.
+// context.Background() is used in that case.
 func SendWrappedAt(sender Sender, ctx context.Context, ts roachpb.Timestamp, args roachpb.Request) (roachpb.Response, error) {
 	if ctx == nil {
 		ctx = context.Background()

--- a/client/sender.go
+++ b/client/sender.go
@@ -94,7 +94,7 @@ func SendWrappedAt(sender Sender, ctx context.Context, ts roachpb.Timestamp, arg
 	if ctx == nil {
 		ctx = context.Background()
 	}
-	args.Header().Timestamp = roachpb.ZeroTimestamp // scrub the field
+	args.Header().DeprecatedTimestamp = roachpb.ZeroTimestamp // scrub the field
 	ba, unwrap := func(args roachpb.Request) (*roachpb.BatchRequest, func(*roachpb.BatchResponse) roachpb.Response) {
 		ba := &roachpb.BatchRequest{}
 		ba.Timestamp = ts

--- a/client/sender.go
+++ b/client/sender.go
@@ -94,7 +94,6 @@ func SendWrappedAt(sender Sender, ctx context.Context, ts roachpb.Timestamp, arg
 	if ctx == nil {
 		ctx = context.Background()
 	}
-	args.Header().DeprecatedTimestamp = roachpb.ZeroTimestamp // scrub the field
 	ba, unwrap := func(args roachpb.Request) (*roachpb.BatchRequest, func(*roachpb.BatchResponse) roachpb.Response) {
 		ba := &roachpb.BatchRequest{}
 		ba.Timestamp = ts

--- a/client/sender.go
+++ b/client/sender.go
@@ -30,7 +30,6 @@ import (
 	"github.com/cockroachdb/cockroach/util/log"
 	"github.com/cockroachdb/cockroach/util/retry"
 	"github.com/cockroachdb/cockroach/util/stop"
-	"github.com/gogo/protobuf/proto"
 )
 
 // defaultRetryOptions sets the retry options for handling retryable errors and
@@ -95,13 +94,13 @@ func SendWrappedAt(sender Sender, ctx context.Context, ts roachpb.Timestamp, arg
 	if ctx == nil {
 		ctx = context.Background()
 	}
+	args.Header().Timestamp = roachpb.ZeroTimestamp // scrub the field
 	ba, unwrap := func(args roachpb.Request) (*roachpb.BatchRequest, func(*roachpb.BatchResponse) roachpb.Response) {
 		ba := &roachpb.BatchRequest{}
+		ba.Timestamp = ts
 		{
-			h := *(proto.Clone(args.Header()).(*roachpb.RequestHeader))
-			h.Timestamp = roachpb.ZeroTimestamp
+			h := args.Header()
 			ba.Key, ba.EndKey = h.Key, h.EndKey
-			ba.Timestamp = ts
 			ba.CmdID = h.CmdID
 			ba.Replica = h.Replica
 			ba.RangeID = h.RangeID

--- a/kv/txn_coord_sender_test.go
+++ b/kv/txn_coord_sender_test.go
@@ -86,9 +86,8 @@ func newTxn(clock *hlc.Clock, baseKey roachpb.Key) *roachpb.Transaction {
 func createPutRequest(key roachpb.Key, value []byte, txn *roachpb.Transaction) *roachpb.PutRequest {
 	return &roachpb.PutRequest{
 		RequestHeader: roachpb.RequestHeader{
-			Key:                 key,
-			DeprecatedTimestamp: txn.Timestamp,
-			Txn:                 txn,
+			Key: key,
+			Txn: txn,
 		},
 		Value: roachpb.Value{Bytes: value},
 	}
@@ -97,10 +96,9 @@ func createPutRequest(key roachpb.Key, value []byte, txn *roachpb.Transaction) *
 func createDeleteRangeRequest(key, endKey roachpb.Key, txn *roachpb.Transaction) *roachpb.DeleteRangeRequest {
 	return &roachpb.DeleteRangeRequest{
 		RequestHeader: roachpb.RequestHeader{
-			Key:                 key,
-			EndKey:              endKey,
-			DeprecatedTimestamp: txn.Timestamp,
-			Txn:                 txn,
+			Key:    key,
+			EndKey: endKey,
+			Txn:    txn,
 		},
 	}
 }
@@ -380,8 +378,7 @@ func TestTxnCoordSenderEndTxn(t *testing.T) {
 	pReply := reply.(*roachpb.PutResponse)
 	if _, err := client.SendWrapped(s.Sender, nil, &roachpb.EndTransactionRequest{
 		RequestHeader: roachpb.RequestHeader{
-			DeprecatedTimestamp: txn.Timestamp,
-			Txn:                 pReply.Header().Txn,
+			Txn: pReply.Header().Txn,
 		},
 		Commit: true,
 	}); err != nil {
@@ -428,8 +425,7 @@ func TestTxnCoordSenderCleanupOnAborted(t *testing.T) {
 	// end transaction failed.
 	etArgs := &roachpb.EndTransactionRequest{
 		RequestHeader: roachpb.RequestHeader{
-			DeprecatedTimestamp: txn.Timestamp,
-			Txn:                 txn,
+			Txn: txn,
 		},
 		Commit: true,
 	}
@@ -592,8 +588,7 @@ func TestTxnDrainingNode(t *testing.T) {
 	endTxn := func() {
 		if _, err := client.SendWrapped(s.Sender, nil, &roachpb.EndTransactionRequest{
 			RequestHeader: roachpb.RequestHeader{
-				DeprecatedTimestamp: txn.Timestamp,
-				Txn:                 txn,
+				Txn: txn,
 			},
 			Commit: true}); err != nil {
 			t.Fatal(err)
@@ -676,8 +671,7 @@ func TestTxnMultipleCoord(t *testing.T) {
 		// Abort for clean shutdown.
 		if _, err := client.SendWrapped(s.Sender, nil, &roachpb.EndTransactionRequest{
 			RequestHeader: roachpb.RequestHeader{
-				DeprecatedTimestamp: txn.Timestamp,
-				Txn:                 txn,
+				Txn: txn,
 			},
 			Commit: false,
 		}); err != nil {

--- a/kv/txn_coord_sender_test.go
+++ b/kv/txn_coord_sender_test.go
@@ -86,9 +86,9 @@ func newTxn(clock *hlc.Clock, baseKey roachpb.Key) *roachpb.Transaction {
 func createPutRequest(key roachpb.Key, value []byte, txn *roachpb.Transaction) *roachpb.PutRequest {
 	return &roachpb.PutRequest{
 		RequestHeader: roachpb.RequestHeader{
-			Key:       key,
-			Timestamp: txn.Timestamp,
-			Txn:       txn,
+			Key:                 key,
+			DeprecatedTimestamp: txn.Timestamp,
+			Txn:                 txn,
 		},
 		Value: roachpb.Value{Bytes: value},
 	}
@@ -97,10 +97,10 @@ func createPutRequest(key roachpb.Key, value []byte, txn *roachpb.Transaction) *
 func createDeleteRangeRequest(key, endKey roachpb.Key, txn *roachpb.Transaction) *roachpb.DeleteRangeRequest {
 	return &roachpb.DeleteRangeRequest{
 		RequestHeader: roachpb.RequestHeader{
-			Key:       key,
-			EndKey:    endKey,
-			Timestamp: txn.Timestamp,
-			Txn:       txn,
+			Key:                 key,
+			EndKey:              endKey,
+			DeprecatedTimestamp: txn.Timestamp,
+			Txn:                 txn,
 		},
 	}
 }
@@ -380,8 +380,8 @@ func TestTxnCoordSenderEndTxn(t *testing.T) {
 	pReply := reply.(*roachpb.PutResponse)
 	if _, err := client.SendWrapped(s.Sender, nil, &roachpb.EndTransactionRequest{
 		RequestHeader: roachpb.RequestHeader{
-			Timestamp: txn.Timestamp,
-			Txn:       pReply.Header().Txn,
+			DeprecatedTimestamp: txn.Timestamp,
+			Txn:                 pReply.Header().Txn,
 		},
 		Commit: true,
 	}); err != nil {
@@ -428,8 +428,8 @@ func TestTxnCoordSenderCleanupOnAborted(t *testing.T) {
 	// end transaction failed.
 	etArgs := &roachpb.EndTransactionRequest{
 		RequestHeader: roachpb.RequestHeader{
-			Timestamp: txn.Timestamp,
-			Txn:       txn,
+			DeprecatedTimestamp: txn.Timestamp,
+			Txn:                 txn,
 		},
 		Commit: true,
 	}
@@ -592,8 +592,8 @@ func TestTxnDrainingNode(t *testing.T) {
 	endTxn := func() {
 		if _, err := client.SendWrapped(s.Sender, nil, &roachpb.EndTransactionRequest{
 			RequestHeader: roachpb.RequestHeader{
-				Timestamp: txn.Timestamp,
-				Txn:       txn,
+				DeprecatedTimestamp: txn.Timestamp,
+				Txn:                 txn,
 			},
 			Commit: true}); err != nil {
 			t.Fatal(err)
@@ -676,8 +676,8 @@ func TestTxnMultipleCoord(t *testing.T) {
 		// Abort for clean shutdown.
 		if _, err := client.SendWrapped(s.Sender, nil, &roachpb.EndTransactionRequest{
 			RequestHeader: roachpb.RequestHeader{
-				Timestamp: txn.Timestamp,
-				Txn:       txn,
+				DeprecatedTimestamp: txn.Timestamp,
+				Txn:                 txn,
 			},
 			Commit: false,
 		}); err != nil {

--- a/roachpb/api.pb.go
+++ b/roachpb/api.pb.go
@@ -253,10 +253,10 @@ func (m *ClientCmdID) GetRandom() int64 {
 
 // RequestHeader is supplied with every storage node request.
 type RequestHeader struct {
-	// Timestamp specifies time at which read or writes should be
+	// DeprecatedTimestamp specifies time at which read or writes should be
 	// performed. If the timestamp is set to zero value, its value
 	// is initialized to the wall time of the receiving node.
-	Timestamp Timestamp `protobuf:"bytes,1,opt,name=timestamp" json:"timestamp"`
+	DeprecatedTimestamp Timestamp `protobuf:"bytes,1,opt,name=deprecated_timestamp" json:"deprecated_timestamp"`
 	// CmdID is optionally specified for request idempotence
 	// (i.e. replay protection).
 	CmdID ClientCmdID `protobuf:"bytes,2,opt,name=cmd_id" json:"cmd_id"`
@@ -303,9 +303,9 @@ func (*RequestHeader) ProtoMessage()    {}
 
 const Default_RequestHeader_UserPriority int32 = 1
 
-func (m *RequestHeader) GetTimestamp() Timestamp {
+func (m *RequestHeader) GetDeprecatedTimestamp() Timestamp {
 	if m != nil {
-		return m.Timestamp
+		return m.DeprecatedTimestamp
 	}
 	return Timestamp{}
 }
@@ -1843,8 +1843,8 @@ func (m *RequestHeader) MarshalTo(data []byte) (int, error) {
 	_ = l
 	data[i] = 0xa
 	i++
-	i = encodeVarintApi(data, i, uint64(m.Timestamp.Size()))
-	n1, err := m.Timestamp.MarshalTo(data[i:])
+	i = encodeVarintApi(data, i, uint64(m.DeprecatedTimestamp.Size()))
+	n1, err := m.DeprecatedTimestamp.MarshalTo(data[i:])
 	if err != nil {
 		return 0, err
 	}
@@ -4032,7 +4032,7 @@ func (m *ClientCmdID) Size() (n int) {
 func (m *RequestHeader) Size() (n int) {
 	var l int
 	_ = l
-	l = m.Timestamp.Size()
+	l = m.DeprecatedTimestamp.Size()
 	n += 1 + l + sovApi(uint64(l))
 	l = m.CmdID.Size()
 	n += 1 + l + sovApi(uint64(l))
@@ -5126,7 +5126,7 @@ func (m *RequestHeader) Unmarshal(data []byte) error {
 		switch fieldNum {
 		case 1:
 			if wireType != 2 {
-				return fmt.Errorf("proto: wrong wireType = %d for field Timestamp", wireType)
+				return fmt.Errorf("proto: wrong wireType = %d for field DeprecatedTimestamp", wireType)
 			}
 			var msglen int
 			for shift := uint(0); ; shift += 7 {
@@ -5150,7 +5150,7 @@ func (m *RequestHeader) Unmarshal(data []byte) error {
 			if postIndex > l {
 				return io.ErrUnexpectedEOF
 			}
-			if err := m.Timestamp.Unmarshal(data[iNdEx:postIndex]); err != nil {
+			if err := m.DeprecatedTimestamp.Unmarshal(data[iNdEx:postIndex]); err != nil {
 				return err
 			}
 			iNdEx = postIndex

--- a/roachpb/api.pb.go
+++ b/roachpb/api.pb.go
@@ -253,10 +253,6 @@ func (m *ClientCmdID) GetRandom() int64 {
 
 // RequestHeader is supplied with every storage node request.
 type RequestHeader struct {
-	// DeprecatedTimestamp specifies time at which read or writes should be
-	// performed. If the timestamp is set to zero value, its value
-	// is initialized to the wall time of the receiving node.
-	DeprecatedTimestamp Timestamp `protobuf:"bytes,1,opt,name=deprecated_timestamp" json:"deprecated_timestamp"`
 	// CmdID is optionally specified for request idempotence
 	// (i.e. replay protection).
 	CmdID ClientCmdID `protobuf:"bytes,2,opt,name=cmd_id" json:"cmd_id"`
@@ -302,13 +298,6 @@ func (m *RequestHeader) String() string { return proto.CompactTextString(m) }
 func (*RequestHeader) ProtoMessage()    {}
 
 const Default_RequestHeader_UserPriority int32 = 1
-
-func (m *RequestHeader) GetDeprecatedTimestamp() Timestamp {
-	if m != nil {
-		return m.DeprecatedTimestamp
-	}
-	return Timestamp{}
-}
 
 func (m *RequestHeader) GetCmdID() ClientCmdID {
 	if m != nil {
@@ -1841,22 +1830,14 @@ func (m *RequestHeader) MarshalTo(data []byte) (int, error) {
 	_ = i
 	var l int
 	_ = l
-	data[i] = 0xa
+	data[i] = 0x12
 	i++
-	i = encodeVarintApi(data, i, uint64(m.DeprecatedTimestamp.Size()))
-	n1, err := m.DeprecatedTimestamp.MarshalTo(data[i:])
+	i = encodeVarintApi(data, i, uint64(m.CmdID.Size()))
+	n1, err := m.CmdID.MarshalTo(data[i:])
 	if err != nil {
 		return 0, err
 	}
 	i += n1
-	data[i] = 0x12
-	i++
-	i = encodeVarintApi(data, i, uint64(m.CmdID.Size()))
-	n2, err := m.CmdID.MarshalTo(data[i:])
-	if err != nil {
-		return 0, err
-	}
-	i += n2
 	if m.Key != nil {
 		data[i] = 0x1a
 		i++
@@ -1872,11 +1853,11 @@ func (m *RequestHeader) MarshalTo(data []byte) (int, error) {
 	data[i] = 0x2a
 	i++
 	i = encodeVarintApi(data, i, uint64(m.Replica.Size()))
-	n3, err := m.Replica.MarshalTo(data[i:])
+	n2, err := m.Replica.MarshalTo(data[i:])
 	if err != nil {
 		return 0, err
 	}
-	i += n3
+	i += n2
 	data[i] = 0x30
 	i++
 	i = encodeVarintApi(data, i, uint64(m.RangeID))
@@ -1889,11 +1870,11 @@ func (m *RequestHeader) MarshalTo(data []byte) (int, error) {
 		data[i] = 0x42
 		i++
 		i = encodeVarintApi(data, i, uint64(m.Txn.Size()))
-		n4, err := m.Txn.MarshalTo(data[i:])
+		n3, err := m.Txn.MarshalTo(data[i:])
 		if err != nil {
 			return 0, err
 		}
-		i += n4
+		i += n3
 	}
 	data[i] = 0x48
 	i++
@@ -1919,20 +1900,20 @@ func (m *ResponseHeader) MarshalTo(data []byte) (int, error) {
 	data[i] = 0x12
 	i++
 	i = encodeVarintApi(data, i, uint64(m.Timestamp.Size()))
-	n5, err := m.Timestamp.MarshalTo(data[i:])
+	n4, err := m.Timestamp.MarshalTo(data[i:])
 	if err != nil {
 		return 0, err
 	}
-	i += n5
+	i += n4
 	if m.Txn != nil {
 		data[i] = 0x1a
 		i++
 		i = encodeVarintApi(data, i, uint64(m.Txn.Size()))
-		n6, err := m.Txn.MarshalTo(data[i:])
+		n5, err := m.Txn.MarshalTo(data[i:])
 		if err != nil {
 			return 0, err
 		}
-		i += n6
+		i += n5
 	}
 	return i, nil
 }
@@ -1955,11 +1936,11 @@ func (m *GetRequest) MarshalTo(data []byte) (int, error) {
 	data[i] = 0xa
 	i++
 	i = encodeVarintApi(data, i, uint64(m.RequestHeader.Size()))
-	n7, err := m.RequestHeader.MarshalTo(data[i:])
+	n6, err := m.RequestHeader.MarshalTo(data[i:])
 	if err != nil {
 		return 0, err
 	}
-	i += n7
+	i += n6
 	return i, nil
 }
 
@@ -1981,20 +1962,20 @@ func (m *GetResponse) MarshalTo(data []byte) (int, error) {
 	data[i] = 0xa
 	i++
 	i = encodeVarintApi(data, i, uint64(m.ResponseHeader.Size()))
-	n8, err := m.ResponseHeader.MarshalTo(data[i:])
+	n7, err := m.ResponseHeader.MarshalTo(data[i:])
 	if err != nil {
 		return 0, err
 	}
-	i += n8
+	i += n7
 	if m.Value != nil {
 		data[i] = 0x12
 		i++
 		i = encodeVarintApi(data, i, uint64(m.Value.Size()))
-		n9, err := m.Value.MarshalTo(data[i:])
+		n8, err := m.Value.MarshalTo(data[i:])
 		if err != nil {
 			return 0, err
 		}
-		i += n9
+		i += n8
 	}
 	return i, nil
 }
@@ -2017,19 +1998,19 @@ func (m *PutRequest) MarshalTo(data []byte) (int, error) {
 	data[i] = 0xa
 	i++
 	i = encodeVarintApi(data, i, uint64(m.RequestHeader.Size()))
-	n10, err := m.RequestHeader.MarshalTo(data[i:])
+	n9, err := m.RequestHeader.MarshalTo(data[i:])
+	if err != nil {
+		return 0, err
+	}
+	i += n9
+	data[i] = 0x12
+	i++
+	i = encodeVarintApi(data, i, uint64(m.Value.Size()))
+	n10, err := m.Value.MarshalTo(data[i:])
 	if err != nil {
 		return 0, err
 	}
 	i += n10
-	data[i] = 0x12
-	i++
-	i = encodeVarintApi(data, i, uint64(m.Value.Size()))
-	n11, err := m.Value.MarshalTo(data[i:])
-	if err != nil {
-		return 0, err
-	}
-	i += n11
 	return i, nil
 }
 
@@ -2051,11 +2032,11 @@ func (m *PutResponse) MarshalTo(data []byte) (int, error) {
 	data[i] = 0xa
 	i++
 	i = encodeVarintApi(data, i, uint64(m.ResponseHeader.Size()))
-	n12, err := m.ResponseHeader.MarshalTo(data[i:])
+	n11, err := m.ResponseHeader.MarshalTo(data[i:])
 	if err != nil {
 		return 0, err
 	}
-	i += n12
+	i += n11
 	return i, nil
 }
 
@@ -2077,28 +2058,28 @@ func (m *ConditionalPutRequest) MarshalTo(data []byte) (int, error) {
 	data[i] = 0xa
 	i++
 	i = encodeVarintApi(data, i, uint64(m.RequestHeader.Size()))
-	n13, err := m.RequestHeader.MarshalTo(data[i:])
+	n12, err := m.RequestHeader.MarshalTo(data[i:])
+	if err != nil {
+		return 0, err
+	}
+	i += n12
+	data[i] = 0x12
+	i++
+	i = encodeVarintApi(data, i, uint64(m.Value.Size()))
+	n13, err := m.Value.MarshalTo(data[i:])
 	if err != nil {
 		return 0, err
 	}
 	i += n13
-	data[i] = 0x12
-	i++
-	i = encodeVarintApi(data, i, uint64(m.Value.Size()))
-	n14, err := m.Value.MarshalTo(data[i:])
-	if err != nil {
-		return 0, err
-	}
-	i += n14
 	if m.ExpValue != nil {
 		data[i] = 0x1a
 		i++
 		i = encodeVarintApi(data, i, uint64(m.ExpValue.Size()))
-		n15, err := m.ExpValue.MarshalTo(data[i:])
+		n14, err := m.ExpValue.MarshalTo(data[i:])
 		if err != nil {
 			return 0, err
 		}
-		i += n15
+		i += n14
 	}
 	return i, nil
 }
@@ -2121,11 +2102,11 @@ func (m *ConditionalPutResponse) MarshalTo(data []byte) (int, error) {
 	data[i] = 0xa
 	i++
 	i = encodeVarintApi(data, i, uint64(m.ResponseHeader.Size()))
-	n16, err := m.ResponseHeader.MarshalTo(data[i:])
+	n15, err := m.ResponseHeader.MarshalTo(data[i:])
 	if err != nil {
 		return 0, err
 	}
-	i += n16
+	i += n15
 	return i, nil
 }
 
@@ -2147,11 +2128,11 @@ func (m *IncrementRequest) MarshalTo(data []byte) (int, error) {
 	data[i] = 0xa
 	i++
 	i = encodeVarintApi(data, i, uint64(m.RequestHeader.Size()))
-	n17, err := m.RequestHeader.MarshalTo(data[i:])
+	n16, err := m.RequestHeader.MarshalTo(data[i:])
 	if err != nil {
 		return 0, err
 	}
-	i += n17
+	i += n16
 	data[i] = 0x10
 	i++
 	i = encodeVarintApi(data, i, uint64(m.Increment))
@@ -2176,11 +2157,11 @@ func (m *IncrementResponse) MarshalTo(data []byte) (int, error) {
 	data[i] = 0xa
 	i++
 	i = encodeVarintApi(data, i, uint64(m.ResponseHeader.Size()))
-	n18, err := m.ResponseHeader.MarshalTo(data[i:])
+	n17, err := m.ResponseHeader.MarshalTo(data[i:])
 	if err != nil {
 		return 0, err
 	}
-	i += n18
+	i += n17
 	data[i] = 0x10
 	i++
 	i = encodeVarintApi(data, i, uint64(m.NewValue))
@@ -2205,11 +2186,11 @@ func (m *DeleteRequest) MarshalTo(data []byte) (int, error) {
 	data[i] = 0xa
 	i++
 	i = encodeVarintApi(data, i, uint64(m.RequestHeader.Size()))
-	n19, err := m.RequestHeader.MarshalTo(data[i:])
+	n18, err := m.RequestHeader.MarshalTo(data[i:])
 	if err != nil {
 		return 0, err
 	}
-	i += n19
+	i += n18
 	return i, nil
 }
 
@@ -2231,11 +2212,11 @@ func (m *DeleteResponse) MarshalTo(data []byte) (int, error) {
 	data[i] = 0xa
 	i++
 	i = encodeVarintApi(data, i, uint64(m.ResponseHeader.Size()))
-	n20, err := m.ResponseHeader.MarshalTo(data[i:])
+	n19, err := m.ResponseHeader.MarshalTo(data[i:])
 	if err != nil {
 		return 0, err
 	}
-	i += n20
+	i += n19
 	return i, nil
 }
 
@@ -2257,11 +2238,11 @@ func (m *DeleteRangeRequest) MarshalTo(data []byte) (int, error) {
 	data[i] = 0xa
 	i++
 	i = encodeVarintApi(data, i, uint64(m.RequestHeader.Size()))
-	n21, err := m.RequestHeader.MarshalTo(data[i:])
+	n20, err := m.RequestHeader.MarshalTo(data[i:])
 	if err != nil {
 		return 0, err
 	}
-	i += n21
+	i += n20
 	data[i] = 0x10
 	i++
 	i = encodeVarintApi(data, i, uint64(m.MaxEntriesToDelete))
@@ -2286,11 +2267,11 @@ func (m *DeleteRangeResponse) MarshalTo(data []byte) (int, error) {
 	data[i] = 0xa
 	i++
 	i = encodeVarintApi(data, i, uint64(m.ResponseHeader.Size()))
-	n22, err := m.ResponseHeader.MarshalTo(data[i:])
+	n21, err := m.ResponseHeader.MarshalTo(data[i:])
 	if err != nil {
 		return 0, err
 	}
-	i += n22
+	i += n21
 	data[i] = 0x10
 	i++
 	i = encodeVarintApi(data, i, uint64(m.NumDeleted))
@@ -2315,11 +2296,11 @@ func (m *ScanRequest) MarshalTo(data []byte) (int, error) {
 	data[i] = 0xa
 	i++
 	i = encodeVarintApi(data, i, uint64(m.RequestHeader.Size()))
-	n23, err := m.RequestHeader.MarshalTo(data[i:])
+	n22, err := m.RequestHeader.MarshalTo(data[i:])
 	if err != nil {
 		return 0, err
 	}
-	i += n23
+	i += n22
 	data[i] = 0x10
 	i++
 	i = encodeVarintApi(data, i, uint64(m.MaxResults))
@@ -2344,11 +2325,11 @@ func (m *ScanResponse) MarshalTo(data []byte) (int, error) {
 	data[i] = 0xa
 	i++
 	i = encodeVarintApi(data, i, uint64(m.ResponseHeader.Size()))
-	n24, err := m.ResponseHeader.MarshalTo(data[i:])
+	n23, err := m.ResponseHeader.MarshalTo(data[i:])
 	if err != nil {
 		return 0, err
 	}
-	i += n24
+	i += n23
 	if len(m.Rows) > 0 {
 		for _, msg := range m.Rows {
 			data[i] = 0x12
@@ -2382,11 +2363,11 @@ func (m *ReverseScanRequest) MarshalTo(data []byte) (int, error) {
 	data[i] = 0xa
 	i++
 	i = encodeVarintApi(data, i, uint64(m.RequestHeader.Size()))
-	n25, err := m.RequestHeader.MarshalTo(data[i:])
+	n24, err := m.RequestHeader.MarshalTo(data[i:])
 	if err != nil {
 		return 0, err
 	}
-	i += n25
+	i += n24
 	data[i] = 0x10
 	i++
 	i = encodeVarintApi(data, i, uint64(m.MaxResults))
@@ -2411,11 +2392,11 @@ func (m *ReverseScanResponse) MarshalTo(data []byte) (int, error) {
 	data[i] = 0xa
 	i++
 	i = encodeVarintApi(data, i, uint64(m.ResponseHeader.Size()))
-	n26, err := m.ResponseHeader.MarshalTo(data[i:])
+	n25, err := m.ResponseHeader.MarshalTo(data[i:])
 	if err != nil {
 		return 0, err
 	}
-	i += n26
+	i += n25
 	if len(m.Rows) > 0 {
 		for _, msg := range m.Rows {
 			data[i] = 0x12
@@ -2449,11 +2430,11 @@ func (m *EndTransactionRequest) MarshalTo(data []byte) (int, error) {
 	data[i] = 0xa
 	i++
 	i = encodeVarintApi(data, i, uint64(m.RequestHeader.Size()))
-	n27, err := m.RequestHeader.MarshalTo(data[i:])
+	n26, err := m.RequestHeader.MarshalTo(data[i:])
 	if err != nil {
 		return 0, err
 	}
-	i += n27
+	i += n26
 	data[i] = 0x10
 	i++
 	if m.Commit {
@@ -2466,11 +2447,11 @@ func (m *EndTransactionRequest) MarshalTo(data []byte) (int, error) {
 		data[i] = 0x1a
 		i++
 		i = encodeVarintApi(data, i, uint64(m.InternalCommitTrigger.Size()))
-		n28, err := m.InternalCommitTrigger.MarshalTo(data[i:])
+		n27, err := m.InternalCommitTrigger.MarshalTo(data[i:])
 		if err != nil {
 			return 0, err
 		}
-		i += n28
+		i += n27
 	}
 	if len(m.Intents) > 0 {
 		for _, msg := range m.Intents {
@@ -2505,11 +2486,11 @@ func (m *EndTransactionResponse) MarshalTo(data []byte) (int, error) {
 	data[i] = 0xa
 	i++
 	i = encodeVarintApi(data, i, uint64(m.ResponseHeader.Size()))
-	n29, err := m.ResponseHeader.MarshalTo(data[i:])
+	n28, err := m.ResponseHeader.MarshalTo(data[i:])
 	if err != nil {
 		return 0, err
 	}
-	i += n29
+	i += n28
 	data[i] = 0x10
 	i++
 	i = encodeVarintApi(data, i, uint64(m.CommitWait))
@@ -2542,11 +2523,11 @@ func (m *AdminSplitRequest) MarshalTo(data []byte) (int, error) {
 	data[i] = 0xa
 	i++
 	i = encodeVarintApi(data, i, uint64(m.RequestHeader.Size()))
-	n30, err := m.RequestHeader.MarshalTo(data[i:])
+	n29, err := m.RequestHeader.MarshalTo(data[i:])
 	if err != nil {
 		return 0, err
 	}
-	i += n30
+	i += n29
 	if m.SplitKey != nil {
 		data[i] = 0x12
 		i++
@@ -2574,11 +2555,11 @@ func (m *AdminSplitResponse) MarshalTo(data []byte) (int, error) {
 	data[i] = 0xa
 	i++
 	i = encodeVarintApi(data, i, uint64(m.ResponseHeader.Size()))
-	n31, err := m.ResponseHeader.MarshalTo(data[i:])
+	n30, err := m.ResponseHeader.MarshalTo(data[i:])
 	if err != nil {
 		return 0, err
 	}
-	i += n31
+	i += n30
 	return i, nil
 }
 
@@ -2600,11 +2581,11 @@ func (m *AdminMergeRequest) MarshalTo(data []byte) (int, error) {
 	data[i] = 0xa
 	i++
 	i = encodeVarintApi(data, i, uint64(m.RequestHeader.Size()))
-	n32, err := m.RequestHeader.MarshalTo(data[i:])
+	n31, err := m.RequestHeader.MarshalTo(data[i:])
 	if err != nil {
 		return 0, err
 	}
-	i += n32
+	i += n31
 	return i, nil
 }
 
@@ -2626,11 +2607,11 @@ func (m *AdminMergeResponse) MarshalTo(data []byte) (int, error) {
 	data[i] = 0xa
 	i++
 	i = encodeVarintApi(data, i, uint64(m.ResponseHeader.Size()))
-	n33, err := m.ResponseHeader.MarshalTo(data[i:])
+	n32, err := m.ResponseHeader.MarshalTo(data[i:])
 	if err != nil {
 		return 0, err
 	}
-	i += n33
+	i += n32
 	return i, nil
 }
 
@@ -2652,11 +2633,11 @@ func (m *RangeLookupRequest) MarshalTo(data []byte) (int, error) {
 	data[i] = 0xa
 	i++
 	i = encodeVarintApi(data, i, uint64(m.RequestHeader.Size()))
-	n34, err := m.RequestHeader.MarshalTo(data[i:])
+	n33, err := m.RequestHeader.MarshalTo(data[i:])
 	if err != nil {
 		return 0, err
 	}
-	i += n34
+	i += n33
 	data[i] = 0x10
 	i++
 	i = encodeVarintApi(data, i, uint64(m.MaxRanges))
@@ -2697,11 +2678,11 @@ func (m *RangeLookupResponse) MarshalTo(data []byte) (int, error) {
 	data[i] = 0xa
 	i++
 	i = encodeVarintApi(data, i, uint64(m.ResponseHeader.Size()))
-	n35, err := m.ResponseHeader.MarshalTo(data[i:])
+	n34, err := m.ResponseHeader.MarshalTo(data[i:])
 	if err != nil {
 		return 0, err
 	}
-	i += n35
+	i += n34
 	if len(m.Ranges) > 0 {
 		for _, msg := range m.Ranges {
 			data[i] = 0x12
@@ -2735,11 +2716,11 @@ func (m *HeartbeatTxnRequest) MarshalTo(data []byte) (int, error) {
 	data[i] = 0xa
 	i++
 	i = encodeVarintApi(data, i, uint64(m.RequestHeader.Size()))
-	n36, err := m.RequestHeader.MarshalTo(data[i:])
+	n35, err := m.RequestHeader.MarshalTo(data[i:])
 	if err != nil {
 		return 0, err
 	}
-	i += n36
+	i += n35
 	return i, nil
 }
 
@@ -2761,11 +2742,11 @@ func (m *HeartbeatTxnResponse) MarshalTo(data []byte) (int, error) {
 	data[i] = 0xa
 	i++
 	i = encodeVarintApi(data, i, uint64(m.ResponseHeader.Size()))
-	n37, err := m.ResponseHeader.MarshalTo(data[i:])
+	n36, err := m.ResponseHeader.MarshalTo(data[i:])
 	if err != nil {
 		return 0, err
 	}
-	i += n37
+	i += n36
 	return i, nil
 }
 
@@ -2787,19 +2768,19 @@ func (m *GCRequest) MarshalTo(data []byte) (int, error) {
 	data[i] = 0xa
 	i++
 	i = encodeVarintApi(data, i, uint64(m.RequestHeader.Size()))
-	n38, err := m.RequestHeader.MarshalTo(data[i:])
+	n37, err := m.RequestHeader.MarshalTo(data[i:])
+	if err != nil {
+		return 0, err
+	}
+	i += n37
+	data[i] = 0x12
+	i++
+	i = encodeVarintApi(data, i, uint64(m.GCMeta.Size()))
+	n38, err := m.GCMeta.MarshalTo(data[i:])
 	if err != nil {
 		return 0, err
 	}
 	i += n38
-	data[i] = 0x12
-	i++
-	i = encodeVarintApi(data, i, uint64(m.GCMeta.Size()))
-	n39, err := m.GCMeta.MarshalTo(data[i:])
-	if err != nil {
-		return 0, err
-	}
-	i += n39
 	if len(m.Keys) > 0 {
 		for _, msg := range m.Keys {
 			data[i] = 0x1a
@@ -2839,11 +2820,11 @@ func (m *GCRequest_GCKey) MarshalTo(data []byte) (int, error) {
 	data[i] = 0x12
 	i++
 	i = encodeVarintApi(data, i, uint64(m.Timestamp.Size()))
-	n40, err := m.Timestamp.MarshalTo(data[i:])
+	n39, err := m.Timestamp.MarshalTo(data[i:])
 	if err != nil {
 		return 0, err
 	}
-	i += n40
+	i += n39
 	return i, nil
 }
 
@@ -2865,11 +2846,11 @@ func (m *GCResponse) MarshalTo(data []byte) (int, error) {
 	data[i] = 0xa
 	i++
 	i = encodeVarintApi(data, i, uint64(m.ResponseHeader.Size()))
-	n41, err := m.ResponseHeader.MarshalTo(data[i:])
+	n40, err := m.ResponseHeader.MarshalTo(data[i:])
 	if err != nil {
 		return 0, err
 	}
-	i += n41
+	i += n40
 	return i, nil
 }
 
@@ -2891,43 +2872,43 @@ func (m *PushTxnRequest) MarshalTo(data []byte) (int, error) {
 	data[i] = 0xa
 	i++
 	i = encodeVarintApi(data, i, uint64(m.RequestHeader.Size()))
-	n42, err := m.RequestHeader.MarshalTo(data[i:])
+	n41, err := m.RequestHeader.MarshalTo(data[i:])
+	if err != nil {
+		return 0, err
+	}
+	i += n41
+	data[i] = 0x12
+	i++
+	i = encodeVarintApi(data, i, uint64(m.PusherTxn.Size()))
+	n42, err := m.PusherTxn.MarshalTo(data[i:])
 	if err != nil {
 		return 0, err
 	}
 	i += n42
-	data[i] = 0x12
+	data[i] = 0x1a
 	i++
-	i = encodeVarintApi(data, i, uint64(m.PusherTxn.Size()))
-	n43, err := m.PusherTxn.MarshalTo(data[i:])
+	i = encodeVarintApi(data, i, uint64(m.PusheeTxn.Size()))
+	n43, err := m.PusheeTxn.MarshalTo(data[i:])
 	if err != nil {
 		return 0, err
 	}
 	i += n43
-	data[i] = 0x1a
+	data[i] = 0x22
 	i++
-	i = encodeVarintApi(data, i, uint64(m.PusheeTxn.Size()))
-	n44, err := m.PusheeTxn.MarshalTo(data[i:])
+	i = encodeVarintApi(data, i, uint64(m.PushTo.Size()))
+	n44, err := m.PushTo.MarshalTo(data[i:])
 	if err != nil {
 		return 0, err
 	}
 	i += n44
-	data[i] = 0x22
+	data[i] = 0x2a
 	i++
-	i = encodeVarintApi(data, i, uint64(m.PushTo.Size()))
-	n45, err := m.PushTo.MarshalTo(data[i:])
+	i = encodeVarintApi(data, i, uint64(m.Now.Size()))
+	n45, err := m.Now.MarshalTo(data[i:])
 	if err != nil {
 		return 0, err
 	}
 	i += n45
-	data[i] = 0x2a
-	i++
-	i = encodeVarintApi(data, i, uint64(m.Now.Size()))
-	n46, err := m.Now.MarshalTo(data[i:])
-	if err != nil {
-		return 0, err
-	}
-	i += n46
 	data[i] = 0x30
 	i++
 	i = encodeVarintApi(data, i, uint64(m.PushType))
@@ -2952,20 +2933,20 @@ func (m *PushTxnResponse) MarshalTo(data []byte) (int, error) {
 	data[i] = 0xa
 	i++
 	i = encodeVarintApi(data, i, uint64(m.ResponseHeader.Size()))
-	n47, err := m.ResponseHeader.MarshalTo(data[i:])
+	n46, err := m.ResponseHeader.MarshalTo(data[i:])
 	if err != nil {
 		return 0, err
 	}
-	i += n47
+	i += n46
 	if m.PusheeTxn != nil {
 		data[i] = 0x12
 		i++
 		i = encodeVarintApi(data, i, uint64(m.PusheeTxn.Size()))
-		n48, err := m.PusheeTxn.MarshalTo(data[i:])
+		n47, err := m.PusheeTxn.MarshalTo(data[i:])
 		if err != nil {
 			return 0, err
 		}
-		i += n48
+		i += n47
 	}
 	return i, nil
 }
@@ -2988,19 +2969,19 @@ func (m *ResolveIntentRequest) MarshalTo(data []byte) (int, error) {
 	data[i] = 0xa
 	i++
 	i = encodeVarintApi(data, i, uint64(m.RequestHeader.Size()))
-	n49, err := m.RequestHeader.MarshalTo(data[i:])
+	n48, err := m.RequestHeader.MarshalTo(data[i:])
+	if err != nil {
+		return 0, err
+	}
+	i += n48
+	data[i] = 0x12
+	i++
+	i = encodeVarintApi(data, i, uint64(m.IntentTxn.Size()))
+	n49, err := m.IntentTxn.MarshalTo(data[i:])
 	if err != nil {
 		return 0, err
 	}
 	i += n49
-	data[i] = 0x12
-	i++
-	i = encodeVarintApi(data, i, uint64(m.IntentTxn.Size()))
-	n50, err := m.IntentTxn.MarshalTo(data[i:])
-	if err != nil {
-		return 0, err
-	}
-	i += n50
 	return i, nil
 }
 
@@ -3022,11 +3003,11 @@ func (m *ResolveIntentResponse) MarshalTo(data []byte) (int, error) {
 	data[i] = 0xa
 	i++
 	i = encodeVarintApi(data, i, uint64(m.ResponseHeader.Size()))
-	n51, err := m.ResponseHeader.MarshalTo(data[i:])
+	n50, err := m.ResponseHeader.MarshalTo(data[i:])
 	if err != nil {
 		return 0, err
 	}
-	i += n51
+	i += n50
 	return i, nil
 }
 
@@ -3048,19 +3029,19 @@ func (m *ResolveIntentRangeRequest) MarshalTo(data []byte) (int, error) {
 	data[i] = 0xa
 	i++
 	i = encodeVarintApi(data, i, uint64(m.RequestHeader.Size()))
-	n52, err := m.RequestHeader.MarshalTo(data[i:])
+	n51, err := m.RequestHeader.MarshalTo(data[i:])
+	if err != nil {
+		return 0, err
+	}
+	i += n51
+	data[i] = 0x12
+	i++
+	i = encodeVarintApi(data, i, uint64(m.IntentTxn.Size()))
+	n52, err := m.IntentTxn.MarshalTo(data[i:])
 	if err != nil {
 		return 0, err
 	}
 	i += n52
-	data[i] = 0x12
-	i++
-	i = encodeVarintApi(data, i, uint64(m.IntentTxn.Size()))
-	n53, err := m.IntentTxn.MarshalTo(data[i:])
-	if err != nil {
-		return 0, err
-	}
-	i += n53
 	return i, nil
 }
 
@@ -3082,11 +3063,11 @@ func (m *NoopResponse) MarshalTo(data []byte) (int, error) {
 	data[i] = 0xa
 	i++
 	i = encodeVarintApi(data, i, uint64(m.ResponseHeader.Size()))
-	n54, err := m.ResponseHeader.MarshalTo(data[i:])
+	n53, err := m.ResponseHeader.MarshalTo(data[i:])
 	if err != nil {
 		return 0, err
 	}
-	i += n54
+	i += n53
 	return i, nil
 }
 
@@ -3108,11 +3089,11 @@ func (m *NoopRequest) MarshalTo(data []byte) (int, error) {
 	data[i] = 0xa
 	i++
 	i = encodeVarintApi(data, i, uint64(m.RequestHeader.Size()))
-	n55, err := m.RequestHeader.MarshalTo(data[i:])
+	n54, err := m.RequestHeader.MarshalTo(data[i:])
 	if err != nil {
 		return 0, err
 	}
-	i += n55
+	i += n54
 	return i, nil
 }
 
@@ -3134,11 +3115,11 @@ func (m *ResolveIntentRangeResponse) MarshalTo(data []byte) (int, error) {
 	data[i] = 0xa
 	i++
 	i = encodeVarintApi(data, i, uint64(m.ResponseHeader.Size()))
-	n56, err := m.ResponseHeader.MarshalTo(data[i:])
+	n55, err := m.ResponseHeader.MarshalTo(data[i:])
 	if err != nil {
 		return 0, err
 	}
-	i += n56
+	i += n55
 	return i, nil
 }
 
@@ -3160,19 +3141,19 @@ func (m *MergeRequest) MarshalTo(data []byte) (int, error) {
 	data[i] = 0xa
 	i++
 	i = encodeVarintApi(data, i, uint64(m.RequestHeader.Size()))
-	n57, err := m.RequestHeader.MarshalTo(data[i:])
+	n56, err := m.RequestHeader.MarshalTo(data[i:])
+	if err != nil {
+		return 0, err
+	}
+	i += n56
+	data[i] = 0x12
+	i++
+	i = encodeVarintApi(data, i, uint64(m.Value.Size()))
+	n57, err := m.Value.MarshalTo(data[i:])
 	if err != nil {
 		return 0, err
 	}
 	i += n57
-	data[i] = 0x12
-	i++
-	i = encodeVarintApi(data, i, uint64(m.Value.Size()))
-	n58, err := m.Value.MarshalTo(data[i:])
-	if err != nil {
-		return 0, err
-	}
-	i += n58
 	return i, nil
 }
 
@@ -3194,11 +3175,11 @@ func (m *MergeResponse) MarshalTo(data []byte) (int, error) {
 	data[i] = 0xa
 	i++
 	i = encodeVarintApi(data, i, uint64(m.ResponseHeader.Size()))
-	n59, err := m.ResponseHeader.MarshalTo(data[i:])
+	n58, err := m.ResponseHeader.MarshalTo(data[i:])
 	if err != nil {
 		return 0, err
 	}
-	i += n59
+	i += n58
 	return i, nil
 }
 
@@ -3220,11 +3201,11 @@ func (m *TruncateLogRequest) MarshalTo(data []byte) (int, error) {
 	data[i] = 0xa
 	i++
 	i = encodeVarintApi(data, i, uint64(m.RequestHeader.Size()))
-	n60, err := m.RequestHeader.MarshalTo(data[i:])
+	n59, err := m.RequestHeader.MarshalTo(data[i:])
 	if err != nil {
 		return 0, err
 	}
-	i += n60
+	i += n59
 	data[i] = 0x10
 	i++
 	i = encodeVarintApi(data, i, uint64(m.Index))
@@ -3249,11 +3230,11 @@ func (m *TruncateLogResponse) MarshalTo(data []byte) (int, error) {
 	data[i] = 0xa
 	i++
 	i = encodeVarintApi(data, i, uint64(m.ResponseHeader.Size()))
-	n61, err := m.ResponseHeader.MarshalTo(data[i:])
+	n60, err := m.ResponseHeader.MarshalTo(data[i:])
 	if err != nil {
 		return 0, err
 	}
-	i += n61
+	i += n60
 	return i, nil
 }
 
@@ -3275,19 +3256,19 @@ func (m *LeaderLeaseRequest) MarshalTo(data []byte) (int, error) {
 	data[i] = 0xa
 	i++
 	i = encodeVarintApi(data, i, uint64(m.RequestHeader.Size()))
-	n62, err := m.RequestHeader.MarshalTo(data[i:])
+	n61, err := m.RequestHeader.MarshalTo(data[i:])
+	if err != nil {
+		return 0, err
+	}
+	i += n61
+	data[i] = 0x12
+	i++
+	i = encodeVarintApi(data, i, uint64(m.Lease.Size()))
+	n62, err := m.Lease.MarshalTo(data[i:])
 	if err != nil {
 		return 0, err
 	}
 	i += n62
-	data[i] = 0x12
-	i++
-	i = encodeVarintApi(data, i, uint64(m.Lease.Size()))
-	n63, err := m.Lease.MarshalTo(data[i:])
-	if err != nil {
-		return 0, err
-	}
-	i += n63
 	return i, nil
 }
 
@@ -3309,11 +3290,11 @@ func (m *LeaderLeaseResponse) MarshalTo(data []byte) (int, error) {
 	data[i] = 0xa
 	i++
 	i = encodeVarintApi(data, i, uint64(m.ResponseHeader.Size()))
-	n64, err := m.ResponseHeader.MarshalTo(data[i:])
+	n63, err := m.ResponseHeader.MarshalTo(data[i:])
 	if err != nil {
 		return 0, err
 	}
-	i += n64
+	i += n63
 	return i, nil
 }
 
@@ -3336,151 +3317,151 @@ func (m *RequestUnion) MarshalTo(data []byte) (int, error) {
 		data[i] = 0xa
 		i++
 		i = encodeVarintApi(data, i, uint64(m.Get.Size()))
-		n65, err := m.Get.MarshalTo(data[i:])
+		n64, err := m.Get.MarshalTo(data[i:])
 		if err != nil {
 			return 0, err
 		}
-		i += n65
+		i += n64
 	}
 	if m.Put != nil {
 		data[i] = 0x12
 		i++
 		i = encodeVarintApi(data, i, uint64(m.Put.Size()))
-		n66, err := m.Put.MarshalTo(data[i:])
+		n65, err := m.Put.MarshalTo(data[i:])
 		if err != nil {
 			return 0, err
 		}
-		i += n66
+		i += n65
 	}
 	if m.ConditionalPut != nil {
 		data[i] = 0x1a
 		i++
 		i = encodeVarintApi(data, i, uint64(m.ConditionalPut.Size()))
-		n67, err := m.ConditionalPut.MarshalTo(data[i:])
+		n66, err := m.ConditionalPut.MarshalTo(data[i:])
 		if err != nil {
 			return 0, err
 		}
-		i += n67
+		i += n66
 	}
 	if m.Increment != nil {
 		data[i] = 0x22
 		i++
 		i = encodeVarintApi(data, i, uint64(m.Increment.Size()))
-		n68, err := m.Increment.MarshalTo(data[i:])
+		n67, err := m.Increment.MarshalTo(data[i:])
 		if err != nil {
 			return 0, err
 		}
-		i += n68
+		i += n67
 	}
 	if m.Delete != nil {
 		data[i] = 0x2a
 		i++
 		i = encodeVarintApi(data, i, uint64(m.Delete.Size()))
-		n69, err := m.Delete.MarshalTo(data[i:])
+		n68, err := m.Delete.MarshalTo(data[i:])
 		if err != nil {
 			return 0, err
 		}
-		i += n69
+		i += n68
 	}
 	if m.DeleteRange != nil {
 		data[i] = 0x32
 		i++
 		i = encodeVarintApi(data, i, uint64(m.DeleteRange.Size()))
-		n70, err := m.DeleteRange.MarshalTo(data[i:])
+		n69, err := m.DeleteRange.MarshalTo(data[i:])
 		if err != nil {
 			return 0, err
 		}
-		i += n70
+		i += n69
 	}
 	if m.Scan != nil {
 		data[i] = 0x3a
 		i++
 		i = encodeVarintApi(data, i, uint64(m.Scan.Size()))
-		n71, err := m.Scan.MarshalTo(data[i:])
+		n70, err := m.Scan.MarshalTo(data[i:])
 		if err != nil {
 			return 0, err
 		}
-		i += n71
+		i += n70
 	}
 	if m.EndTransaction != nil {
 		data[i] = 0x42
 		i++
 		i = encodeVarintApi(data, i, uint64(m.EndTransaction.Size()))
-		n72, err := m.EndTransaction.MarshalTo(data[i:])
+		n71, err := m.EndTransaction.MarshalTo(data[i:])
 		if err != nil {
 			return 0, err
 		}
-		i += n72
+		i += n71
 	}
 	if m.AdminSplit != nil {
 		data[i] = 0x4a
 		i++
 		i = encodeVarintApi(data, i, uint64(m.AdminSplit.Size()))
-		n73, err := m.AdminSplit.MarshalTo(data[i:])
+		n72, err := m.AdminSplit.MarshalTo(data[i:])
 		if err != nil {
 			return 0, err
 		}
-		i += n73
+		i += n72
 	}
 	if m.AdminMerge != nil {
 		data[i] = 0x52
 		i++
 		i = encodeVarintApi(data, i, uint64(m.AdminMerge.Size()))
-		n74, err := m.AdminMerge.MarshalTo(data[i:])
+		n73, err := m.AdminMerge.MarshalTo(data[i:])
 		if err != nil {
 			return 0, err
 		}
-		i += n74
+		i += n73
 	}
 	if m.HeartbeatTxn != nil {
 		data[i] = 0x5a
 		i++
 		i = encodeVarintApi(data, i, uint64(m.HeartbeatTxn.Size()))
-		n75, err := m.HeartbeatTxn.MarshalTo(data[i:])
+		n74, err := m.HeartbeatTxn.MarshalTo(data[i:])
 		if err != nil {
 			return 0, err
 		}
-		i += n75
+		i += n74
 	}
 	if m.Gc != nil {
 		data[i] = 0x62
 		i++
 		i = encodeVarintApi(data, i, uint64(m.Gc.Size()))
-		n76, err := m.Gc.MarshalTo(data[i:])
+		n75, err := m.Gc.MarshalTo(data[i:])
 		if err != nil {
 			return 0, err
 		}
-		i += n76
+		i += n75
 	}
 	if m.PushTxn != nil {
 		data[i] = 0x6a
 		i++
 		i = encodeVarintApi(data, i, uint64(m.PushTxn.Size()))
-		n77, err := m.PushTxn.MarshalTo(data[i:])
+		n76, err := m.PushTxn.MarshalTo(data[i:])
 		if err != nil {
 			return 0, err
 		}
-		i += n77
+		i += n76
 	}
 	if m.RangeLookup != nil {
 		data[i] = 0x72
 		i++
 		i = encodeVarintApi(data, i, uint64(m.RangeLookup.Size()))
-		n78, err := m.RangeLookup.MarshalTo(data[i:])
+		n77, err := m.RangeLookup.MarshalTo(data[i:])
 		if err != nil {
 			return 0, err
 		}
-		i += n78
+		i += n77
 	}
 	if m.ResolveIntent != nil {
 		data[i] = 0x7a
 		i++
 		i = encodeVarintApi(data, i, uint64(m.ResolveIntent.Size()))
-		n79, err := m.ResolveIntent.MarshalTo(data[i:])
+		n78, err := m.ResolveIntent.MarshalTo(data[i:])
 		if err != nil {
 			return 0, err
 		}
-		i += n79
+		i += n78
 	}
 	if m.ResolveIntentRange != nil {
 		data[i] = 0x82
@@ -3488,11 +3469,11 @@ func (m *RequestUnion) MarshalTo(data []byte) (int, error) {
 		data[i] = 0x1
 		i++
 		i = encodeVarintApi(data, i, uint64(m.ResolveIntentRange.Size()))
-		n80, err := m.ResolveIntentRange.MarshalTo(data[i:])
+		n79, err := m.ResolveIntentRange.MarshalTo(data[i:])
 		if err != nil {
 			return 0, err
 		}
-		i += n80
+		i += n79
 	}
 	if m.Merge != nil {
 		data[i] = 0x8a
@@ -3500,11 +3481,11 @@ func (m *RequestUnion) MarshalTo(data []byte) (int, error) {
 		data[i] = 0x1
 		i++
 		i = encodeVarintApi(data, i, uint64(m.Merge.Size()))
-		n81, err := m.Merge.MarshalTo(data[i:])
+		n80, err := m.Merge.MarshalTo(data[i:])
 		if err != nil {
 			return 0, err
 		}
-		i += n81
+		i += n80
 	}
 	if m.TruncateLog != nil {
 		data[i] = 0x92
@@ -3512,11 +3493,11 @@ func (m *RequestUnion) MarshalTo(data []byte) (int, error) {
 		data[i] = 0x1
 		i++
 		i = encodeVarintApi(data, i, uint64(m.TruncateLog.Size()))
-		n82, err := m.TruncateLog.MarshalTo(data[i:])
+		n81, err := m.TruncateLog.MarshalTo(data[i:])
 		if err != nil {
 			return 0, err
 		}
-		i += n82
+		i += n81
 	}
 	if m.LeaderLease != nil {
 		data[i] = 0x9a
@@ -3524,11 +3505,11 @@ func (m *RequestUnion) MarshalTo(data []byte) (int, error) {
 		data[i] = 0x1
 		i++
 		i = encodeVarintApi(data, i, uint64(m.LeaderLease.Size()))
-		n83, err := m.LeaderLease.MarshalTo(data[i:])
+		n82, err := m.LeaderLease.MarshalTo(data[i:])
 		if err != nil {
 			return 0, err
 		}
-		i += n83
+		i += n82
 	}
 	if m.ReverseScan != nil {
 		data[i] = 0xa2
@@ -3536,11 +3517,11 @@ func (m *RequestUnion) MarshalTo(data []byte) (int, error) {
 		data[i] = 0x1
 		i++
 		i = encodeVarintApi(data, i, uint64(m.ReverseScan.Size()))
-		n84, err := m.ReverseScan.MarshalTo(data[i:])
+		n83, err := m.ReverseScan.MarshalTo(data[i:])
 		if err != nil {
 			return 0, err
 		}
-		i += n84
+		i += n83
 	}
 	if m.Noop != nil {
 		data[i] = 0xaa
@@ -3548,11 +3529,11 @@ func (m *RequestUnion) MarshalTo(data []byte) (int, error) {
 		data[i] = 0x1
 		i++
 		i = encodeVarintApi(data, i, uint64(m.Noop.Size()))
-		n85, err := m.Noop.MarshalTo(data[i:])
+		n84, err := m.Noop.MarshalTo(data[i:])
 		if err != nil {
 			return 0, err
 		}
-		i += n85
+		i += n84
 	}
 	return i, nil
 }
@@ -3576,151 +3557,151 @@ func (m *ResponseUnion) MarshalTo(data []byte) (int, error) {
 		data[i] = 0xa
 		i++
 		i = encodeVarintApi(data, i, uint64(m.Get.Size()))
-		n86, err := m.Get.MarshalTo(data[i:])
+		n85, err := m.Get.MarshalTo(data[i:])
 		if err != nil {
 			return 0, err
 		}
-		i += n86
+		i += n85
 	}
 	if m.Put != nil {
 		data[i] = 0x12
 		i++
 		i = encodeVarintApi(data, i, uint64(m.Put.Size()))
-		n87, err := m.Put.MarshalTo(data[i:])
+		n86, err := m.Put.MarshalTo(data[i:])
 		if err != nil {
 			return 0, err
 		}
-		i += n87
+		i += n86
 	}
 	if m.ConditionalPut != nil {
 		data[i] = 0x1a
 		i++
 		i = encodeVarintApi(data, i, uint64(m.ConditionalPut.Size()))
-		n88, err := m.ConditionalPut.MarshalTo(data[i:])
+		n87, err := m.ConditionalPut.MarshalTo(data[i:])
 		if err != nil {
 			return 0, err
 		}
-		i += n88
+		i += n87
 	}
 	if m.Increment != nil {
 		data[i] = 0x22
 		i++
 		i = encodeVarintApi(data, i, uint64(m.Increment.Size()))
-		n89, err := m.Increment.MarshalTo(data[i:])
+		n88, err := m.Increment.MarshalTo(data[i:])
 		if err != nil {
 			return 0, err
 		}
-		i += n89
+		i += n88
 	}
 	if m.Delete != nil {
 		data[i] = 0x2a
 		i++
 		i = encodeVarintApi(data, i, uint64(m.Delete.Size()))
-		n90, err := m.Delete.MarshalTo(data[i:])
+		n89, err := m.Delete.MarshalTo(data[i:])
 		if err != nil {
 			return 0, err
 		}
-		i += n90
+		i += n89
 	}
 	if m.DeleteRange != nil {
 		data[i] = 0x32
 		i++
 		i = encodeVarintApi(data, i, uint64(m.DeleteRange.Size()))
-		n91, err := m.DeleteRange.MarshalTo(data[i:])
+		n90, err := m.DeleteRange.MarshalTo(data[i:])
 		if err != nil {
 			return 0, err
 		}
-		i += n91
+		i += n90
 	}
 	if m.Scan != nil {
 		data[i] = 0x3a
 		i++
 		i = encodeVarintApi(data, i, uint64(m.Scan.Size()))
-		n92, err := m.Scan.MarshalTo(data[i:])
+		n91, err := m.Scan.MarshalTo(data[i:])
 		if err != nil {
 			return 0, err
 		}
-		i += n92
+		i += n91
 	}
 	if m.EndTransaction != nil {
 		data[i] = 0x42
 		i++
 		i = encodeVarintApi(data, i, uint64(m.EndTransaction.Size()))
-		n93, err := m.EndTransaction.MarshalTo(data[i:])
+		n92, err := m.EndTransaction.MarshalTo(data[i:])
 		if err != nil {
 			return 0, err
 		}
-		i += n93
+		i += n92
 	}
 	if m.AdminSplit != nil {
 		data[i] = 0x4a
 		i++
 		i = encodeVarintApi(data, i, uint64(m.AdminSplit.Size()))
-		n94, err := m.AdminSplit.MarshalTo(data[i:])
+		n93, err := m.AdminSplit.MarshalTo(data[i:])
 		if err != nil {
 			return 0, err
 		}
-		i += n94
+		i += n93
 	}
 	if m.AdminMerge != nil {
 		data[i] = 0x52
 		i++
 		i = encodeVarintApi(data, i, uint64(m.AdminMerge.Size()))
-		n95, err := m.AdminMerge.MarshalTo(data[i:])
+		n94, err := m.AdminMerge.MarshalTo(data[i:])
 		if err != nil {
 			return 0, err
 		}
-		i += n95
+		i += n94
 	}
 	if m.HeartbeatTxn != nil {
 		data[i] = 0x5a
 		i++
 		i = encodeVarintApi(data, i, uint64(m.HeartbeatTxn.Size()))
-		n96, err := m.HeartbeatTxn.MarshalTo(data[i:])
+		n95, err := m.HeartbeatTxn.MarshalTo(data[i:])
 		if err != nil {
 			return 0, err
 		}
-		i += n96
+		i += n95
 	}
 	if m.Gc != nil {
 		data[i] = 0x62
 		i++
 		i = encodeVarintApi(data, i, uint64(m.Gc.Size()))
-		n97, err := m.Gc.MarshalTo(data[i:])
+		n96, err := m.Gc.MarshalTo(data[i:])
 		if err != nil {
 			return 0, err
 		}
-		i += n97
+		i += n96
 	}
 	if m.PushTxn != nil {
 		data[i] = 0x6a
 		i++
 		i = encodeVarintApi(data, i, uint64(m.PushTxn.Size()))
-		n98, err := m.PushTxn.MarshalTo(data[i:])
+		n97, err := m.PushTxn.MarshalTo(data[i:])
 		if err != nil {
 			return 0, err
 		}
-		i += n98
+		i += n97
 	}
 	if m.RangeLookup != nil {
 		data[i] = 0x72
 		i++
 		i = encodeVarintApi(data, i, uint64(m.RangeLookup.Size()))
-		n99, err := m.RangeLookup.MarshalTo(data[i:])
+		n98, err := m.RangeLookup.MarshalTo(data[i:])
 		if err != nil {
 			return 0, err
 		}
-		i += n99
+		i += n98
 	}
 	if m.ResolveIntent != nil {
 		data[i] = 0x7a
 		i++
 		i = encodeVarintApi(data, i, uint64(m.ResolveIntent.Size()))
-		n100, err := m.ResolveIntent.MarshalTo(data[i:])
+		n99, err := m.ResolveIntent.MarshalTo(data[i:])
 		if err != nil {
 			return 0, err
 		}
-		i += n100
+		i += n99
 	}
 	if m.ResolveIntentRange != nil {
 		data[i] = 0x82
@@ -3728,11 +3709,11 @@ func (m *ResponseUnion) MarshalTo(data []byte) (int, error) {
 		data[i] = 0x1
 		i++
 		i = encodeVarintApi(data, i, uint64(m.ResolveIntentRange.Size()))
-		n101, err := m.ResolveIntentRange.MarshalTo(data[i:])
+		n100, err := m.ResolveIntentRange.MarshalTo(data[i:])
 		if err != nil {
 			return 0, err
 		}
-		i += n101
+		i += n100
 	}
 	if m.Merge != nil {
 		data[i] = 0x8a
@@ -3740,11 +3721,11 @@ func (m *ResponseUnion) MarshalTo(data []byte) (int, error) {
 		data[i] = 0x1
 		i++
 		i = encodeVarintApi(data, i, uint64(m.Merge.Size()))
-		n102, err := m.Merge.MarshalTo(data[i:])
+		n101, err := m.Merge.MarshalTo(data[i:])
 		if err != nil {
 			return 0, err
 		}
-		i += n102
+		i += n101
 	}
 	if m.TruncateLog != nil {
 		data[i] = 0x92
@@ -3752,11 +3733,11 @@ func (m *ResponseUnion) MarshalTo(data []byte) (int, error) {
 		data[i] = 0x1
 		i++
 		i = encodeVarintApi(data, i, uint64(m.TruncateLog.Size()))
-		n103, err := m.TruncateLog.MarshalTo(data[i:])
+		n102, err := m.TruncateLog.MarshalTo(data[i:])
 		if err != nil {
 			return 0, err
 		}
-		i += n103
+		i += n102
 	}
 	if m.LeaderLease != nil {
 		data[i] = 0x9a
@@ -3764,11 +3745,11 @@ func (m *ResponseUnion) MarshalTo(data []byte) (int, error) {
 		data[i] = 0x1
 		i++
 		i = encodeVarintApi(data, i, uint64(m.LeaderLease.Size()))
-		n104, err := m.LeaderLease.MarshalTo(data[i:])
+		n103, err := m.LeaderLease.MarshalTo(data[i:])
 		if err != nil {
 			return 0, err
 		}
-		i += n104
+		i += n103
 	}
 	if m.ReverseScan != nil {
 		data[i] = 0xa2
@@ -3776,11 +3757,11 @@ func (m *ResponseUnion) MarshalTo(data []byte) (int, error) {
 		data[i] = 0x1
 		i++
 		i = encodeVarintApi(data, i, uint64(m.ReverseScan.Size()))
-		n105, err := m.ReverseScan.MarshalTo(data[i:])
+		n104, err := m.ReverseScan.MarshalTo(data[i:])
 		if err != nil {
 			return 0, err
 		}
-		i += n105
+		i += n104
 	}
 	if m.Noop != nil {
 		data[i] = 0xaa
@@ -3788,11 +3769,11 @@ func (m *ResponseUnion) MarshalTo(data []byte) (int, error) {
 		data[i] = 0x1
 		i++
 		i = encodeVarintApi(data, i, uint64(m.Noop.Size()))
-		n106, err := m.Noop.MarshalTo(data[i:])
+		n105, err := m.Noop.MarshalTo(data[i:])
 		if err != nil {
 			return 0, err
 		}
-		i += n106
+		i += n105
 	}
 	return i, nil
 }
@@ -3815,11 +3796,11 @@ func (m *BatchRequest) MarshalTo(data []byte) (int, error) {
 	data[i] = 0xa
 	i++
 	i = encodeVarintApi(data, i, uint64(m.BatchRequest_Header.Size()))
-	n107, err := m.BatchRequest_Header.MarshalTo(data[i:])
+	n106, err := m.BatchRequest_Header.MarshalTo(data[i:])
 	if err != nil {
 		return 0, err
 	}
-	i += n107
+	i += n106
 	if len(m.Requests) > 0 {
 		for _, msg := range m.Requests {
 			data[i] = 0x12
@@ -3853,19 +3834,19 @@ func (m *BatchRequest_Header) MarshalTo(data []byte) (int, error) {
 	data[i] = 0xa
 	i++
 	i = encodeVarintApi(data, i, uint64(m.Timestamp.Size()))
-	n108, err := m.Timestamp.MarshalTo(data[i:])
+	n107, err := m.Timestamp.MarshalTo(data[i:])
+	if err != nil {
+		return 0, err
+	}
+	i += n107
+	data[i] = 0x12
+	i++
+	i = encodeVarintApi(data, i, uint64(m.CmdID.Size()))
+	n108, err := m.CmdID.MarshalTo(data[i:])
 	if err != nil {
 		return 0, err
 	}
 	i += n108
-	data[i] = 0x12
-	i++
-	i = encodeVarintApi(data, i, uint64(m.CmdID.Size()))
-	n109, err := m.CmdID.MarshalTo(data[i:])
-	if err != nil {
-		return 0, err
-	}
-	i += n109
 	if m.Key != nil {
 		data[i] = 0x1a
 		i++
@@ -3881,11 +3862,11 @@ func (m *BatchRequest_Header) MarshalTo(data []byte) (int, error) {
 	data[i] = 0x2a
 	i++
 	i = encodeVarintApi(data, i, uint64(m.Replica.Size()))
-	n110, err := m.Replica.MarshalTo(data[i:])
+	n109, err := m.Replica.MarshalTo(data[i:])
 	if err != nil {
 		return 0, err
 	}
-	i += n110
+	i += n109
 	data[i] = 0x30
 	i++
 	i = encodeVarintApi(data, i, uint64(m.RangeID))
@@ -3898,11 +3879,11 @@ func (m *BatchRequest_Header) MarshalTo(data []byte) (int, error) {
 		data[i] = 0x42
 		i++
 		i = encodeVarintApi(data, i, uint64(m.Txn.Size()))
-		n111, err := m.Txn.MarshalTo(data[i:])
+		n110, err := m.Txn.MarshalTo(data[i:])
 		if err != nil {
 			return 0, err
 		}
-		i += n111
+		i += n110
 	}
 	data[i] = 0x48
 	i++
@@ -3928,11 +3909,11 @@ func (m *BatchResponse) MarshalTo(data []byte) (int, error) {
 	data[i] = 0xa
 	i++
 	i = encodeVarintApi(data, i, uint64(m.BatchResponse_Header.Size()))
-	n112, err := m.BatchResponse_Header.MarshalTo(data[i:])
+	n111, err := m.BatchResponse_Header.MarshalTo(data[i:])
 	if err != nil {
 		return 0, err
 	}
-	i += n112
+	i += n111
 	if len(m.Responses) > 0 {
 		for _, msg := range m.Responses {
 			data[i] = 0x12
@@ -3967,29 +3948,29 @@ func (m *BatchResponse_Header) MarshalTo(data []byte) (int, error) {
 		data[i] = 0xa
 		i++
 		i = encodeVarintApi(data, i, uint64(m.Error.Size()))
-		n113, err := m.Error.MarshalTo(data[i:])
+		n112, err := m.Error.MarshalTo(data[i:])
 		if err != nil {
 			return 0, err
 		}
-		i += n113
+		i += n112
 	}
 	data[i] = 0x12
 	i++
 	i = encodeVarintApi(data, i, uint64(m.Timestamp.Size()))
-	n114, err := m.Timestamp.MarshalTo(data[i:])
+	n113, err := m.Timestamp.MarshalTo(data[i:])
 	if err != nil {
 		return 0, err
 	}
-	i += n114
+	i += n113
 	if m.Txn != nil {
 		data[i] = 0x1a
 		i++
 		i = encodeVarintApi(data, i, uint64(m.Txn.Size()))
-		n115, err := m.Txn.MarshalTo(data[i:])
+		n114, err := m.Txn.MarshalTo(data[i:])
 		if err != nil {
 			return 0, err
 		}
-		i += n115
+		i += n114
 	}
 	return i, nil
 }
@@ -4032,8 +4013,6 @@ func (m *ClientCmdID) Size() (n int) {
 func (m *RequestHeader) Size() (n int) {
 	var l int
 	_ = l
-	l = m.DeprecatedTimestamp.Size()
-	n += 1 + l + sovApi(uint64(l))
 	l = m.CmdID.Size()
 	n += 1 + l + sovApi(uint64(l))
 	if m.Key != nil {
@@ -5124,36 +5103,6 @@ func (m *RequestHeader) Unmarshal(data []byte) error {
 			return fmt.Errorf("proto: RequestHeader: illegal tag %d (wire type %d)", fieldNum, wire)
 		}
 		switch fieldNum {
-		case 1:
-			if wireType != 2 {
-				return fmt.Errorf("proto: wrong wireType = %d for field DeprecatedTimestamp", wireType)
-			}
-			var msglen int
-			for shift := uint(0); ; shift += 7 {
-				if shift >= 64 {
-					return ErrIntOverflowApi
-				}
-				if iNdEx >= l {
-					return io.ErrUnexpectedEOF
-				}
-				b := data[iNdEx]
-				iNdEx++
-				msglen |= (int(b) & 0x7F) << shift
-				if b < 0x80 {
-					break
-				}
-			}
-			if msglen < 0 {
-				return ErrInvalidLengthApi
-			}
-			postIndex := iNdEx + msglen
-			if postIndex > l {
-				return io.ErrUnexpectedEOF
-			}
-			if err := m.DeprecatedTimestamp.Unmarshal(data[iNdEx:postIndex]); err != nil {
-				return err
-			}
-			iNdEx = postIndex
 		case 2:
 			if wireType != 2 {
 				return fmt.Errorf("proto: wrong wireType = %d for field CmdID", wireType)

--- a/roachpb/api.proto
+++ b/roachpb/api.proto
@@ -70,10 +70,6 @@ enum ReadConsistencyType {
 
 // RequestHeader is supplied with every storage node request.
 message RequestHeader {
-  // DeprecatedTimestamp specifies time at which read or writes should be
-  // performed. If the timestamp is set to zero value, its value
-  // is initialized to the wall time of the receiving node.
-  optional Timestamp deprecated_timestamp = 1 [(gogoproto.nullable) = false];
   // CmdID is optionally specified for request idempotence
   // (i.e. replay protection).
   optional ClientCmdID cmd_id = 2 [(gogoproto.nullable) = false, (gogoproto.customname) = "CmdID"];

--- a/roachpb/api.proto
+++ b/roachpb/api.proto
@@ -70,10 +70,10 @@ enum ReadConsistencyType {
 
 // RequestHeader is supplied with every storage node request.
 message RequestHeader {
-  // Timestamp specifies time at which read or writes should be
+  // DeprecatedTimestamp specifies time at which read or writes should be
   // performed. If the timestamp is set to zero value, its value
   // is initialized to the wall time of the receiving node.
-  optional Timestamp timestamp = 1 [(gogoproto.nullable) = false];
+  optional Timestamp deprecated_timestamp = 1 [(gogoproto.nullable) = false];
   // CmdID is optionally specified for request idempotence
   // (i.e. replay protection).
   optional ClientCmdID cmd_id = 2 [(gogoproto.nullable) = false, (gogoproto.customname) = "CmdID"];

--- a/roachpb/batch.go
+++ b/roachpb/batch.go
@@ -302,7 +302,7 @@ func (ba *BatchRequest) ToHeader() RequestHeader {
 	var h RequestHeader
 	h.Key, h.EndKey = ba.Key, ba.EndKey
 	h.CmdID = ba.CmdID
-	h.Timestamp = ba.Timestamp
+	h.DeprecatedTimestamp = ba.Timestamp
 	h.Replica = ba.Replica
 	h.RangeID = ba.RangeID
 	h.UserPriority = ba.UserPriority

--- a/roachpb/batch.go
+++ b/roachpb/batch.go
@@ -302,7 +302,6 @@ func (ba *BatchRequest) ToHeader() RequestHeader {
 	var h RequestHeader
 	h.Key, h.EndKey = ba.Key, ba.EndKey
 	h.CmdID = ba.CmdID
-	h.DeprecatedTimestamp = ba.Timestamp
 	h.Replica = ba.Replica
 	h.RangeID = ba.RangeID
 	h.UserPriority = ba.UserPriority

--- a/server/server_test.go
+++ b/server/server_test.go
@@ -324,7 +324,7 @@ func TestMultiRangeScanDeleteRange(t *testing.T) {
 		// The Put ts may have been pushed by tsCache,
 		// so make sure we see their values in our Scan.
 		delTS = reply.(*roachpb.PutResponse).Timestamp
-		scan.Timestamp = delTS
+		scan.DeprecatedTimestamp = delTS
 		reply, err = client.SendWrapped(tds, nil, scan)
 		if err != nil {
 			t.Fatal(err)
@@ -342,9 +342,9 @@ func TestMultiRangeScanDeleteRange(t *testing.T) {
 
 	del := &roachpb.DeleteRangeRequest{
 		RequestHeader: roachpb.RequestHeader{
-			Key:       writes[0],
-			EndKey:    roachpb.Key(writes[len(writes)-1]).Next(),
-			Timestamp: delTS,
+			Key:                 writes[0],
+			EndKey:              roachpb.Key(writes[len(writes)-1]).Next(),
+			DeprecatedTimestamp: delTS,
 		},
 	}
 	reply, err := client.SendWrapped(tds, nil, del)
@@ -361,7 +361,7 @@ func TestMultiRangeScanDeleteRange(t *testing.T) {
 	}
 
 	scan := roachpb.NewScan(writes[0], writes[len(writes)-1].Next(), 0).(*roachpb.ScanRequest)
-	scan.Timestamp = dr.Timestamp
+	scan.DeprecatedTimestamp = dr.Timestamp
 	scan.Txn = &roachpb.Transaction{Name: "MyTxn"}
 	reply, err = client.SendWrapped(tds, nil, scan)
 	if err != nil {
@@ -418,7 +418,7 @@ func TestMultiRangeScanWithMaxResults(t *testing.T) {
 			for maxResults := 1; maxResults <= len(tc.keys)-start+1; maxResults++ {
 				scan := roachpb.NewScan(tc.keys[start], tc.keys[len(tc.keys)-1].Next(),
 					int64(maxResults))
-				scan.Header().Timestamp = reply.Header().Timestamp
+				scan.Header().DeprecatedTimestamp = reply.Header().Timestamp
 				reply, err := client.SendWrapped(tds, nil, scan)
 				if err != nil {
 					t.Fatal(err)

--- a/server/server_test.go
+++ b/server/server_test.go
@@ -324,8 +324,7 @@ func TestMultiRangeScanDeleteRange(t *testing.T) {
 		// The Put ts may have been pushed by tsCache,
 		// so make sure we see their values in our Scan.
 		delTS = reply.(*roachpb.PutResponse).Timestamp
-		scan.DeprecatedTimestamp = delTS
-		reply, err = client.SendWrapped(tds, nil, scan)
+		reply, err = client.SendWrappedAt(tds, nil, delTS, scan)
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -342,12 +341,11 @@ func TestMultiRangeScanDeleteRange(t *testing.T) {
 
 	del := &roachpb.DeleteRangeRequest{
 		RequestHeader: roachpb.RequestHeader{
-			Key:                 writes[0],
-			EndKey:              roachpb.Key(writes[len(writes)-1]).Next(),
-			DeprecatedTimestamp: delTS,
+			Key:    writes[0],
+			EndKey: roachpb.Key(writes[len(writes)-1]).Next(),
 		},
 	}
-	reply, err := client.SendWrapped(tds, nil, del)
+	reply, err := client.SendWrappedAt(tds, nil, delTS, del)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -361,9 +359,8 @@ func TestMultiRangeScanDeleteRange(t *testing.T) {
 	}
 
 	scan := roachpb.NewScan(writes[0], writes[len(writes)-1].Next(), 0).(*roachpb.ScanRequest)
-	scan.DeprecatedTimestamp = dr.Timestamp
 	scan.Txn = &roachpb.Transaction{Name: "MyTxn"}
-	reply, err = client.SendWrapped(tds, nil, scan)
+	reply, err = client.SendWrappedAt(tds, nil, dr.Timestamp, scan)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -402,12 +399,9 @@ func TestMultiRangeScanWithMaxResults(t *testing.T) {
 			}
 		}
 
-		var reply roachpb.Response
 		for _, k := range tc.keys {
 			put := roachpb.NewPut(k, roachpb.Value{Bytes: k})
-			var err error
-			reply, err = client.SendWrapped(tds, nil, put)
-			if err != nil {
+			if _, err := client.SendWrapped(tds, nil, put); err != nil {
 				t.Fatal(err)
 			}
 		}
@@ -418,7 +412,6 @@ func TestMultiRangeScanWithMaxResults(t *testing.T) {
 			for maxResults := 1; maxResults <= len(tc.keys)-start+1; maxResults++ {
 				scan := roachpb.NewScan(tc.keys[start], tc.keys[len(tc.keys)-1].Next(),
 					int64(maxResults))
-				scan.Header().DeprecatedTimestamp = reply.Header().Timestamp
 				reply, err := client.SendWrapped(tds, nil, scan)
 				if err != nil {
 					t.Fatal(err)

--- a/storage/client_range_test.go
+++ b/storage/client_range_test.go
@@ -61,8 +61,8 @@ func TestRangeCommandClockUpdate(t *testing.T) {
 	// MaxOffset but less than the leader lease) and execute a command.
 	manuals[0].Increment(int64(500 * time.Millisecond))
 	incArgs := incrementArgs([]byte("a"), 5, 1, mtc.stores[0].StoreID())
-	incArgs.DeprecatedTimestamp = clocks[0].Now()
-	if _, err := client.SendWrapped(mtc.stores[0], nil, &incArgs); err != nil {
+	ts := clocks[0].Now()
+	if _, err := client.SendWrappedAt(mtc.stores[0], nil, ts, &incArgs); err != nil {
 		t.Fatal(err)
 	}
 

--- a/storage/client_range_test.go
+++ b/storage/client_range_test.go
@@ -292,9 +292,9 @@ func TestTxnPutOutOfOrder(t *testing.T) {
 		RangeID:      1,
 		Replica:      roachpb.ReplicaDescriptor{StoreID: store.StoreID()},
 		UserPriority: &priority,
-		Timestamp:    clock.Now(),
 	}
-	if _, err := client.SendWrapped(store, nil, &roachpb.GetRequest{RequestHeader: requestHeader}); err != nil {
+	ts := clock.Now()
+	if _, err := client.SendWrappedAt(store, nil, ts, &roachpb.GetRequest{RequestHeader: requestHeader}); err != nil {
 		t.Fatalf("failed to get: %s", err)
 	}
 
@@ -308,8 +308,8 @@ func TestTxnPutOutOfOrder(t *testing.T) {
 	// timestamp cache from being updated).
 	manualClock.Increment(100)
 
-	requestHeader.Timestamp = clock.Now()
-	if _, err := client.SendWrapped(store, nil, &roachpb.GetRequest{RequestHeader: requestHeader}); err == nil {
+	ts = clock.Now()
+	if _, err := client.SendWrappedAt(store, nil, ts, &roachpb.GetRequest{RequestHeader: requestHeader}); err == nil {
 		t.Fatal("unexpected success of get")
 	}
 

--- a/storage/client_range_test.go
+++ b/storage/client_range_test.go
@@ -61,7 +61,7 @@ func TestRangeCommandClockUpdate(t *testing.T) {
 	// MaxOffset but less than the leader lease) and execute a command.
 	manuals[0].Increment(int64(500 * time.Millisecond))
 	incArgs := incrementArgs([]byte("a"), 5, 1, mtc.stores[0].StoreID())
-	incArgs.Timestamp = clocks[0].Now()
+	incArgs.DeprecatedTimestamp = clocks[0].Now()
 	if _, err := client.SendWrapped(mtc.stores[0], nil, &incArgs); err != nil {
 		t.Fatal(err)
 	}

--- a/storage/client_split_test.go
+++ b/storage/client_split_test.go
@@ -328,7 +328,7 @@ func TestStoreRangeSplitStats(t *testing.T) {
 		key = append(key, randutil.RandBytes(src, int(src.Int31n(1<<7)))...)
 		val := randutil.RandBytes(src, int(src.Int31n(1<<8)))
 		pArgs := putArgs(key, val, rng.Desc().RangeID, store.StoreID())
-		pArgs.Timestamp = store.Clock().Now()
+		pArgs.DeprecatedTimestamp = store.Clock().Now()
 		if _, err := client.SendWrapped(store, nil, &pArgs); err != nil {
 			t.Fatal(err)
 		}
@@ -389,7 +389,7 @@ func fillRange(store *storage.Store, rangeID roachpb.RangeID, prefix roachpb.Key
 		key := append(append([]byte(nil), prefix...), randutil.RandBytes(src, 100)...)
 		val := randutil.RandBytes(src, int(src.Int31n(1<<8)))
 		pArgs := putArgs(key, val, rangeID, store.StoreID())
-		pArgs.Timestamp = store.Clock().Now()
+		pArgs.DeprecatedTimestamp = store.Clock().Now()
 		if _, err := client.SendWrapped(store, nil, &pArgs); err != nil {
 			t.Fatal(err)
 		}

--- a/storage/client_split_test.go
+++ b/storage/client_split_test.go
@@ -328,7 +328,6 @@ func TestStoreRangeSplitStats(t *testing.T) {
 		key = append(key, randutil.RandBytes(src, int(src.Int31n(1<<7)))...)
 		val := randutil.RandBytes(src, int(src.Int31n(1<<8)))
 		pArgs := putArgs(key, val, rng.Desc().RangeID, store.StoreID())
-		pArgs.DeprecatedTimestamp = store.Clock().Now()
 		if _, err := client.SendWrapped(store, nil, &pArgs); err != nil {
 			t.Fatal(err)
 		}
@@ -389,7 +388,6 @@ func fillRange(store *storage.Store, rangeID roachpb.RangeID, prefix roachpb.Key
 		key := append(append([]byte(nil), prefix...), randutil.RandBytes(src, 100)...)
 		val := randutil.RandBytes(src, int(src.Int31n(1<<8)))
 		pArgs := putArgs(key, val, rangeID, store.StoreID())
-		pArgs.DeprecatedTimestamp = store.Clock().Now()
 		if _, err := client.SendWrapped(store, nil, &pArgs); err != nil {
 			t.Fatal(err)
 		}

--- a/storage/engine/mvcc.go
+++ b/storage/engine/mvcc.go
@@ -1425,6 +1425,7 @@ func MVCCResolveWriteIntentRange(engine Engine, ms *MVCCStats, key, endKey roach
 // it iterates through the keys listed for garbage collection by the
 // keys slice. The engine iterator is seeked in turn to each listed
 // key, clearing all values with timestamps <= to expiration.
+// The timestamp parameter is used to compute the intent age on GC.
 func MVCCGarbageCollect(engine Engine, ms *MVCCStats, keys []roachpb.GCRequest_GCKey, timestamp roachpb.Timestamp) error {
 	iter := engine.NewIterator()
 

--- a/storage/engine/rocksdb/cockroach/roachpb/api.pb.cc
+++ b/storage/engine/rocksdb/cockroach/roachpb/api.pb.cc
@@ -207,7 +207,7 @@ void protobuf_AssignDesc_cockroach_2froachpb_2fapi_2eproto() {
       -1);
   RequestHeader_descriptor_ = file->message_type(1);
   static const int RequestHeader_offsets_[9] = {
-    GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(RequestHeader, timestamp_),
+    GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(RequestHeader, deprecated_timestamp_),
     GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(RequestHeader, cmd_id_),
     GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(RequestHeader, key_),
     GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(RequestHeader, end_key_),
@@ -1312,233 +1312,233 @@ void protobuf_AddDesc_cockroach_2froachpb_2fapi_2eproto() {
     "to\032\034cockroach/roachpb/data.proto\032\036cockro"
     "ach/roachpb/errors.proto\032\024gogoproto/gogo"
     ".proto\"<\n\013ClientCmdID\022\027\n\twall_time\030\001 \001(\003"
-    "B\004\310\336\037\000\022\024\n\006random\030\002 \001(\003B\004\310\336\037\000\"\257\003\n\rRequest"
-    "Header\0225\n\ttimestamp\030\001 \001(\0132\034.cockroach.ro"
-    "achpb.TimestampB\004\310\336\037\000\022=\n\006cmd_id\030\002 \001(\0132\036."
-    "cockroach.roachpb.ClientCmdIDB\r\310\336\037\000\342\336\037\005C"
-    "mdID\022\024\n\003key\030\003 \001(\014B\007\372\336\037\003Key\022\030\n\007end_key\030\004 "
-    "\001(\014B\007\372\336\037\003Key\022;\n\007replica\030\005 \001(\0132$.cockroac"
-    "h.roachpb.ReplicaDescriptorB\004\310\336\037\000\022,\n\010ran"
-    "ge_id\030\006 \001(\003B\032\310\336\037\000\342\336\037\007RangeID\372\336\037\007RangeID\022"
-    "\030\n\ruser_priority\030\007 \001(\005:\0011\022+\n\003txn\030\010 \001(\0132\036"
-    ".cockroach.roachpb.Transaction\022F\n\020read_c"
-    "onsistency\030\t \001(\0162&.cockroach.roachpb.Rea"
-    "dConsistencyTypeB\004\310\336\037\000\"t\n\016ResponseHeader"
-    "\0225\n\ttimestamp\030\002 \001(\0132\034.cockroach.roachpb."
-    "TimestampB\004\310\336\037\000\022+\n\003txn\030\003 \001(\0132\036.cockroach"
-    ".roachpb.Transaction\"H\n\nGetRequest\022:\n\006he"
-    "ader\030\001 \001(\0132 .cockroach.roachpb.RequestHe"
-    "aderB\010\310\336\037\000\320\336\037\001\"s\n\013GetResponse\022;\n\006header\030"
-    "\001 \001(\0132!.cockroach.roachpb.ResponseHeader"
-    "B\010\310\336\037\000\320\336\037\001\022\'\n\005value\030\002 \001(\0132\030.cockroach.ro"
-    "achpb.Value\"w\n\nPutRequest\022:\n\006header\030\001 \001("
-    "\0132 .cockroach.roachpb.RequestHeaderB\010\310\336\037"
-    "\000\320\336\037\001\022-\n\005value\030\002 \001(\0132\030.cockroach.roachpb"
-    ".ValueB\004\310\336\037\000\"J\n\013PutResponse\022;\n\006header\030\001 "
-    "\001(\0132!.cockroach.roachpb.ResponseHeaderB\010"
-    "\310\336\037\000\320\336\037\001\"\257\001\n\025ConditionalPutRequest\022:\n\006he"
-    "ader\030\001 \001(\0132 .cockroach.roachpb.RequestHe"
-    "aderB\010\310\336\037\000\320\336\037\001\022-\n\005value\030\002 \001(\0132\030.cockroac"
-    "h.roachpb.ValueB\004\310\336\037\000\022+\n\texp_value\030\003 \001(\013"
-    "2\030.cockroach.roachpb.Value\"U\n\026Conditiona"
-    "lPutResponse\022;\n\006header\030\001 \001(\0132!.cockroach"
-    ".roachpb.ResponseHeaderB\010\310\336\037\000\320\336\037\001\"g\n\020Inc"
-    "rementRequest\022:\n\006header\030\001 \001(\0132 .cockroac"
-    "h.roachpb.RequestHeaderB\010\310\336\037\000\320\336\037\001\022\027\n\tinc"
-    "rement\030\002 \001(\003B\004\310\336\037\000\"i\n\021IncrementResponse\022"
-    ";\n\006header\030\001 \001(\0132!.cockroach.roachpb.Resp"
-    "onseHeaderB\010\310\336\037\000\320\336\037\001\022\027\n\tnew_value\030\002 \001(\003B"
-    "\004\310\336\037\000\"K\n\rDeleteRequest\022:\n\006header\030\001 \001(\0132 "
-    ".cockroach.roachpb.RequestHeaderB\010\310\336\037\000\320\336"
-    "\037\001\"M\n\016DeleteResponse\022;\n\006header\030\001 \001(\0132!.c"
-    "ockroach.roachpb.ResponseHeaderB\010\310\336\037\000\320\336\037"
-    "\001\"u\n\022DeleteRangeRequest\022:\n\006header\030\001 \001(\0132"
-    " .cockroach.roachpb.RequestHeaderB\010\310\336\037\000\320"
-    "\336\037\001\022#\n\025max_entries_to_delete\030\002 \001(\003B\004\310\336\037\000"
-    "\"m\n\023DeleteRangeResponse\022;\n\006header\030\001 \001(\0132"
-    "!.cockroach.roachpb.ResponseHeaderB\010\310\336\037\000"
-    "\320\336\037\001\022\031\n\013num_deleted\030\002 \001(\003B\004\310\336\037\000\"d\n\013ScanR"
-    "equest\022:\n\006header\030\001 \001(\0132 .cockroach.roach"
-    "pb.RequestHeaderB\010\310\336\037\000\320\336\037\001\022\031\n\013max_result"
-    "s\030\002 \001(\003B\004\310\336\037\000\"|\n\014ScanResponse\022;\n\006header\030"
-    "\001 \001(\0132!.cockroach.roachpb.ResponseHeader"
-    "B\010\310\336\037\000\320\336\037\001\022/\n\004rows\030\002 \003(\0132\033.cockroach.roa"
-    "chpb.KeyValueB\004\310\336\037\000\"k\n\022ReverseScanReques"
-    "t\022:\n\006header\030\001 \001(\0132 .cockroach.roachpb.Re"
-    "questHeaderB\010\310\336\037\000\320\336\037\001\022\031\n\013max_results\030\002 \001"
-    "(\003B\004\310\336\037\000\"\203\001\n\023ReverseScanResponse\022;\n\006head"
-    "er\030\001 \001(\0132!.cockroach.roachpb.ResponseHea"
-    "derB\010\310\336\037\000\320\336\037\001\022/\n\004rows\030\002 \003(\0132\033.cockroach."
-    "roachpb.KeyValueB\004\310\336\037\000\"\346\001\n\025EndTransactio"
-    "nRequest\022:\n\006header\030\001 \001(\0132 .cockroach.roa"
-    "chpb.RequestHeaderB\010\310\336\037\000\320\336\037\001\022\024\n\006commit\030\002"
-    " \001(\010B\004\310\336\037\000\022I\n\027internal_commit_trigger\030\003 "
-    "\001(\0132(.cockroach.roachpb.InternalCommitTr"
-    "igger\0220\n\007intents\030\004 \003(\0132\031.cockroach.roach"
-    "pb.IntentB\004\310\336\037\000\"\213\001\n\026EndTransactionRespon"
-    "se\022;\n\006header\030\001 \001(\0132!.cockroach.roachpb.R"
-    "esponseHeaderB\010\310\336\037\000\320\336\037\001\022\031\n\013commit_wait\030\002"
-    " \001(\003B\004\310\336\037\000\022\031\n\010resolved\030\003 \003(\014B\007\372\336\037\003Key\"k\n"
-    "\021AdminSplitRequest\022:\n\006header\030\001 \001(\0132 .coc"
-    "kroach.roachpb.RequestHeaderB\010\310\336\037\000\320\336\037\001\022\032"
-    "\n\tsplit_key\030\002 \001(\014B\007\372\336\037\003Key\"Q\n\022AdminSplit"
-    "Response\022;\n\006header\030\001 \001(\0132!.cockroach.roa"
-    "chpb.ResponseHeaderB\010\310\336\037\000\320\336\037\001\"O\n\021AdminMe"
-    "rgeRequest\022:\n\006header\030\001 \001(\0132 .cockroach.r"
-    "oachpb.RequestHeaderB\010\310\336\037\000\320\336\037\001\"Q\n\022AdminM"
-    "ergeResponse\022;\n\006header\030\001 \001(\0132!.cockroach"
-    ".roachpb.ResponseHeaderB\010\310\336\037\000\320\336\037\001\"\241\001\n\022Ra"
-    "ngeLookupRequest\022:\n\006header\030\001 \001(\0132 .cockr"
-    "oach.roachpb.RequestHeaderB\010\310\336\037\000\320\336\037\001\022\030\n\n"
-    "max_ranges\030\002 \001(\005B\004\310\336\037\000\022\036\n\020consider_inten"
-    "ts\030\003 \001(\010B\004\310\336\037\000\022\025\n\007reverse\030\004 \001(\010B\004\310\336\037\000\"\214\001"
-    "\n\023RangeLookupResponse\022;\n\006header\030\001 \001(\0132!."
-    "cockroach.roachpb.ResponseHeaderB\010\310\336\037\000\320\336"
-    "\037\001\0228\n\006ranges\030\002 \003(\0132\".cockroach.roachpb.R"
-    "angeDescriptorB\004\310\336\037\000\"Q\n\023HeartbeatTxnRequ"
-    "est\022:\n\006header\030\001 \001(\0132 .cockroach.roachpb."
-    "RequestHeaderB\010\310\336\037\000\320\336\037\001\"S\n\024HeartbeatTxnR"
-    "esponse\022;\n\006header\030\001 \001(\0132!.cockroach.roac"
-    "hpb.ResponseHeaderB\010\310\336\037\000\320\336\037\001\"\225\002\n\tGCReque"
-    "st\022:\n\006header\030\001 \001(\0132 .cockroach.roachpb.R"
-    "equestHeaderB\010\310\336\037\000\320\336\037\001\022>\n\007gc_meta\030\002 \001(\0132"
-    "\035.cockroach.roachpb.GCMetadataB\016\310\336\037\000\342\336\037\006"
-    "GCMeta\0226\n\004keys\030\003 \003(\0132\".cockroach.roachpb"
-    ".GCRequest.GCKeyB\004\310\336\037\000\032T\n\005GCKey\022\024\n\003key\030\001"
-    " \001(\014B\007\372\336\037\003Key\0225\n\ttimestamp\030\002 \001(\0132\034.cockr"
-    "oach.roachpb.TimestampB\004\310\336\037\000\"I\n\nGCRespon"
-    "se\022;\n\006header\030\001 \001(\0132!.cockroach.roachpb.R"
-    "esponseHeaderB\010\310\336\037\000\320\336\037\001\"\337\002\n\016PushTxnReque"
-    "st\022:\n\006header\030\001 \001(\0132 .cockroach.roachpb.R"
-    "equestHeaderB\010\310\336\037\000\320\336\037\001\0228\n\npusher_txn\030\002 \001"
-    "(\0132\036.cockroach.roachpb.TransactionB\004\310\336\037\000"
-    "\0228\n\npushee_txn\030\003 \001(\0132\036.cockroach.roachpb"
-    ".TransactionB\004\310\336\037\000\0223\n\007push_to\030\004 \001(\0132\034.co"
-    "ckroach.roachpb.TimestampB\004\310\336\037\000\022/\n\003now\030\005"
-    " \001(\0132\034.cockroach.roachpb.TimestampB\004\310\336\037\000"
-    "\0227\n\tpush_type\030\006 \001(\0162\036.cockroach.roachpb."
-    "PushTxnTypeB\004\310\336\037\000\"\202\001\n\017PushTxnResponse\022;\n"
-    "\006header\030\001 \001(\0132!.cockroach.roachpb.Respon"
-    "seHeaderB\010\310\336\037\000\320\336\037\001\0222\n\npushee_txn\030\002 \001(\0132\036"
-    ".cockroach.roachpb.Transaction\"\214\001\n\024Resol"
-    "veIntentRequest\022:\n\006header\030\001 \001(\0132 .cockro"
-    "ach.roachpb.RequestHeaderB\010\310\336\037\000\320\336\037\001\0228\n\ni"
-    "ntent_txn\030\002 \001(\0132\036.cockroach.roachpb.Tran"
-    "sactionB\004\310\336\037\000\"T\n\025ResolveIntentResponse\022;"
+    "B\004\310\336\037\000\022\024\n\006random\030\002 \001(\003B\004\310\336\037\000\"\272\003\n\rRequest"
+    "Header\022@\n\024deprecated_timestamp\030\001 \001(\0132\034.c"
+    "ockroach.roachpb.TimestampB\004\310\336\037\000\022=\n\006cmd_"
+    "id\030\002 \001(\0132\036.cockroach.roachpb.ClientCmdID"
+    "B\r\310\336\037\000\342\336\037\005CmdID\022\024\n\003key\030\003 \001(\014B\007\372\336\037\003Key\022\030\n"
+    "\007end_key\030\004 \001(\014B\007\372\336\037\003Key\022;\n\007replica\030\005 \001(\013"
+    "2$.cockroach.roachpb.ReplicaDescriptorB\004"
+    "\310\336\037\000\022,\n\010range_id\030\006 \001(\003B\032\310\336\037\000\342\336\037\007RangeID\372"
+    "\336\037\007RangeID\022\030\n\ruser_priority\030\007 \001(\005:\0011\022+\n\003"
+    "txn\030\010 \001(\0132\036.cockroach.roachpb.Transactio"
+    "n\022F\n\020read_consistency\030\t \001(\0162&.cockroach."
+    "roachpb.ReadConsistencyTypeB\004\310\336\037\000\"t\n\016Res"
+    "ponseHeader\0225\n\ttimestamp\030\002 \001(\0132\034.cockroa"
+    "ch.roachpb.TimestampB\004\310\336\037\000\022+\n\003txn\030\003 \001(\0132"
+    "\036.cockroach.roachpb.Transaction\"H\n\nGetRe"
+    "quest\022:\n\006header\030\001 \001(\0132 .cockroach.roachp"
+    "b.RequestHeaderB\010\310\336\037\000\320\336\037\001\"s\n\013GetResponse"
+    "\022;\n\006header\030\001 \001(\0132!.cockroach.roachpb.Res"
+    "ponseHeaderB\010\310\336\037\000\320\336\037\001\022\'\n\005value\030\002 \001(\0132\030.c"
+    "ockroach.roachpb.Value\"w\n\nPutRequest\022:\n\006"
+    "header\030\001 \001(\0132 .cockroach.roachpb.Request"
+    "HeaderB\010\310\336\037\000\320\336\037\001\022-\n\005value\030\002 \001(\0132\030.cockro"
+    "ach.roachpb.ValueB\004\310\336\037\000\"J\n\013PutResponse\022;"
     "\n\006header\030\001 \001(\0132!.cockroach.roachpb.Respo"
-    "nseHeaderB\010\310\336\037\000\320\336\037\001\"\221\001\n\031ResolveIntentRan"
-    "geRequest\022:\n\006header\030\001 \001(\0132 .cockroach.ro"
-    "achpb.RequestHeaderB\010\310\336\037\000\320\336\037\001\0228\n\nintent_"
-    "txn\030\002 \001(\0132\036.cockroach.roachpb.Transactio"
-    "nB\004\310\336\037\000\"K\n\014NoopResponse\022;\n\006header\030\001 \001(\0132"
+    "nseHeaderB\010\310\336\037\000\320\336\037\001\"\257\001\n\025ConditionalPutRe"
+    "quest\022:\n\006header\030\001 \001(\0132 .cockroach.roachp"
+    "b.RequestHeaderB\010\310\336\037\000\320\336\037\001\022-\n\005value\030\002 \001(\013"
+    "2\030.cockroach.roachpb.ValueB\004\310\336\037\000\022+\n\texp_"
+    "value\030\003 \001(\0132\030.cockroach.roachpb.Value\"U\n"
+    "\026ConditionalPutResponse\022;\n\006header\030\001 \001(\0132"
     "!.cockroach.roachpb.ResponseHeaderB\010\310\336\037\000"
-    "\320\336\037\001\"I\n\013NoopRequest\022:\n\006header\030\001 \001(\0132 .co"
-    "ckroach.roachpb.RequestHeaderB\010\310\336\037\000\320\336\037\001\""
-    "Y\n\032ResolveIntentRangeResponse\022;\n\006header\030"
-    "\001 \001(\0132!.cockroach.roachpb.ResponseHeader"
-    "B\010\310\336\037\000\320\336\037\001\"y\n\014MergeRequest\022:\n\006header\030\001 \001"
-    "(\0132 .cockroach.roachpb.RequestHeaderB\010\310\336"
-    "\037\000\320\336\037\001\022-\n\005value\030\002 \001(\0132\030.cockroach.roachp"
-    "b.ValueB\004\310\336\037\000\"L\n\rMergeResponse\022;\n\006header"
-    "\030\001 \001(\0132!.cockroach.roachpb.ResponseHeade"
-    "rB\010\310\336\037\000\320\336\037\001\"e\n\022TruncateLogRequest\022:\n\006hea"
+    "\320\336\037\001\"g\n\020IncrementRequest\022:\n\006header\030\001 \001(\013"
+    "2 .cockroach.roachpb.RequestHeaderB\010\310\336\037\000"
+    "\320\336\037\001\022\027\n\tincrement\030\002 \001(\003B\004\310\336\037\000\"i\n\021Increme"
+    "ntResponse\022;\n\006header\030\001 \001(\0132!.cockroach.r"
+    "oachpb.ResponseHeaderB\010\310\336\037\000\320\336\037\001\022\027\n\tnew_v"
+    "alue\030\002 \001(\003B\004\310\336\037\000\"K\n\rDeleteRequest\022:\n\006hea"
     "der\030\001 \001(\0132 .cockroach.roachpb.RequestHea"
-    "derB\010\310\336\037\000\320\336\037\001\022\023\n\005index\030\002 \001(\004B\004\310\336\037\000\"R\n\023Tr"
-    "uncateLogResponse\022;\n\006header\030\001 \001(\0132!.cock"
-    "roach.roachpb.ResponseHeaderB\010\310\336\037\000\320\336\037\001\"\177"
-    "\n\022LeaderLeaseRequest\022:\n\006header\030\001 \001(\0132 .c"
+    "derB\010\310\336\037\000\320\336\037\001\"M\n\016DeleteResponse\022;\n\006heade"
+    "r\030\001 \001(\0132!.cockroach.roachpb.ResponseHead"
+    "erB\010\310\336\037\000\320\336\037\001\"u\n\022DeleteRangeRequest\022:\n\006he"
+    "ader\030\001 \001(\0132 .cockroach.roachpb.RequestHe"
+    "aderB\010\310\336\037\000\320\336\037\001\022#\n\025max_entries_to_delete\030"
+    "\002 \001(\003B\004\310\336\037\000\"m\n\023DeleteRangeResponse\022;\n\006he"
+    "ader\030\001 \001(\0132!.cockroach.roachpb.ResponseH"
+    "eaderB\010\310\336\037\000\320\336\037\001\022\031\n\013num_deleted\030\002 \001(\003B\004\310\336"
+    "\037\000\"d\n\013ScanRequest\022:\n\006header\030\001 \001(\0132 .cock"
+    "roach.roachpb.RequestHeaderB\010\310\336\037\000\320\336\037\001\022\031\n"
+    "\013max_results\030\002 \001(\003B\004\310\336\037\000\"|\n\014ScanResponse"
+    "\022;\n\006header\030\001 \001(\0132!.cockroach.roachpb.Res"
+    "ponseHeaderB\010\310\336\037\000\320\336\037\001\022/\n\004rows\030\002 \003(\0132\033.co"
+    "ckroach.roachpb.KeyValueB\004\310\336\037\000\"k\n\022Revers"
+    "eScanRequest\022:\n\006header\030\001 \001(\0132 .cockroach"
+    ".roachpb.RequestHeaderB\010\310\336\037\000\320\336\037\001\022\031\n\013max_"
+    "results\030\002 \001(\003B\004\310\336\037\000\"\203\001\n\023ReverseScanRespo"
+    "nse\022;\n\006header\030\001 \001(\0132!.cockroach.roachpb."
+    "ResponseHeaderB\010\310\336\037\000\320\336\037\001\022/\n\004rows\030\002 \003(\0132\033"
+    ".cockroach.roachpb.KeyValueB\004\310\336\037\000\"\346\001\n\025En"
+    "dTransactionRequest\022:\n\006header\030\001 \001(\0132 .co"
+    "ckroach.roachpb.RequestHeaderB\010\310\336\037\000\320\336\037\001\022"
+    "\024\n\006commit\030\002 \001(\010B\004\310\336\037\000\022I\n\027internal_commit"
+    "_trigger\030\003 \001(\0132(.cockroach.roachpb.Inter"
+    "nalCommitTrigger\0220\n\007intents\030\004 \003(\0132\031.cock"
+    "roach.roachpb.IntentB\004\310\336\037\000\"\213\001\n\026EndTransa"
+    "ctionResponse\022;\n\006header\030\001 \001(\0132!.cockroac"
+    "h.roachpb.ResponseHeaderB\010\310\336\037\000\320\336\037\001\022\031\n\013co"
+    "mmit_wait\030\002 \001(\003B\004\310\336\037\000\022\031\n\010resolved\030\003 \003(\014B"
+    "\007\372\336\037\003Key\"k\n\021AdminSplitRequest\022:\n\006header\030"
+    "\001 \001(\0132 .cockroach.roachpb.RequestHeaderB"
+    "\010\310\336\037\000\320\336\037\001\022\032\n\tsplit_key\030\002 \001(\014B\007\372\336\037\003Key\"Q\n"
+    "\022AdminSplitResponse\022;\n\006header\030\001 \001(\0132!.co"
+    "ckroach.roachpb.ResponseHeaderB\010\310\336\037\000\320\336\037\001"
+    "\"O\n\021AdminMergeRequest\022:\n\006header\030\001 \001(\0132 ."
+    "cockroach.roachpb.RequestHeaderB\010\310\336\037\000\320\336\037"
+    "\001\"Q\n\022AdminMergeResponse\022;\n\006header\030\001 \001(\0132"
+    "!.cockroach.roachpb.ResponseHeaderB\010\310\336\037\000"
+    "\320\336\037\001\"\241\001\n\022RangeLookupRequest\022:\n\006header\030\001 "
+    "\001(\0132 .cockroach.roachpb.RequestHeaderB\010\310"
+    "\336\037\000\320\336\037\001\022\030\n\nmax_ranges\030\002 \001(\005B\004\310\336\037\000\022\036\n\020con"
+    "sider_intents\030\003 \001(\010B\004\310\336\037\000\022\025\n\007reverse\030\004 \001"
+    "(\010B\004\310\336\037\000\"\214\001\n\023RangeLookupResponse\022;\n\006head"
+    "er\030\001 \001(\0132!.cockroach.roachpb.ResponseHea"
+    "derB\010\310\336\037\000\320\336\037\001\0228\n\006ranges\030\002 \003(\0132\".cockroac"
+    "h.roachpb.RangeDescriptorB\004\310\336\037\000\"Q\n\023Heart"
+    "beatTxnRequest\022:\n\006header\030\001 \001(\0132 .cockroa"
+    "ch.roachpb.RequestHeaderB\010\310\336\037\000\320\336\037\001\"S\n\024He"
+    "artbeatTxnResponse\022;\n\006header\030\001 \001(\0132!.coc"
+    "kroach.roachpb.ResponseHeaderB\010\310\336\037\000\320\336\037\001\""
+    "\225\002\n\tGCRequest\022:\n\006header\030\001 \001(\0132 .cockroac"
+    "h.roachpb.RequestHeaderB\010\310\336\037\000\320\336\037\001\022>\n\007gc_"
+    "meta\030\002 \001(\0132\035.cockroach.roachpb.GCMetadat"
+    "aB\016\310\336\037\000\342\336\037\006GCMeta\0226\n\004keys\030\003 \003(\0132\".cockro"
+    "ach.roachpb.GCRequest.GCKeyB\004\310\336\037\000\032T\n\005GCK"
+    "ey\022\024\n\003key\030\001 \001(\014B\007\372\336\037\003Key\0225\n\ttimestamp\030\002 "
+    "\001(\0132\034.cockroach.roachpb.TimestampB\004\310\336\037\000\""
+    "I\n\nGCResponse\022;\n\006header\030\001 \001(\0132!.cockroac"
+    "h.roachpb.ResponseHeaderB\010\310\336\037\000\320\336\037\001\"\337\002\n\016P"
+    "ushTxnRequest\022:\n\006header\030\001 \001(\0132 .cockroac"
+    "h.roachpb.RequestHeaderB\010\310\336\037\000\320\336\037\001\0228\n\npus"
+    "her_txn\030\002 \001(\0132\036.cockroach.roachpb.Transa"
+    "ctionB\004\310\336\037\000\0228\n\npushee_txn\030\003 \001(\0132\036.cockro"
+    "ach.roachpb.TransactionB\004\310\336\037\000\0223\n\007push_to"
+    "\030\004 \001(\0132\034.cockroach.roachpb.TimestampB\004\310\336"
+    "\037\000\022/\n\003now\030\005 \001(\0132\034.cockroach.roachpb.Time"
+    "stampB\004\310\336\037\000\0227\n\tpush_type\030\006 \001(\0162\036.cockroa"
+    "ch.roachpb.PushTxnTypeB\004\310\336\037\000\"\202\001\n\017PushTxn"
+    "Response\022;\n\006header\030\001 \001(\0132!.cockroach.roa"
+    "chpb.ResponseHeaderB\010\310\336\037\000\320\336\037\001\0222\n\npushee_"
+    "txn\030\002 \001(\0132\036.cockroach.roachpb.Transactio"
+    "n\"\214\001\n\024ResolveIntentRequest\022:\n\006header\030\001 \001"
+    "(\0132 .cockroach.roachpb.RequestHeaderB\010\310\336"
+    "\037\000\320\336\037\001\0228\n\nintent_txn\030\002 \001(\0132\036.cockroach.r"
+    "oachpb.TransactionB\004\310\336\037\000\"T\n\025ResolveInten"
+    "tResponse\022;\n\006header\030\001 \001(\0132!.cockroach.ro"
+    "achpb.ResponseHeaderB\010\310\336\037\000\320\336\037\001\"\221\001\n\031Resol"
+    "veIntentRangeRequest\022:\n\006header\030\001 \001(\0132 .c"
     "ockroach.roachpb.RequestHeaderB\010\310\336\037\000\320\336\037\001"
-    "\022-\n\005lease\030\002 \001(\0132\030.cockroach.roachpb.Leas"
-    "eB\004\310\336\037\000\"R\n\023LeaderLeaseResponse\022;\n\006header"
-    "\030\001 \001(\0132!.cockroach.roachpb.ResponseHeade"
-    "rB\010\310\336\037\000\320\336\037\001\"\272\t\n\014RequestUnion\022*\n\003get\030\001 \001("
-    "\0132\035.cockroach.roachpb.GetRequest\022*\n\003put\030"
-    "\002 \001(\0132\035.cockroach.roachpb.PutRequest\022A\n\017"
-    "conditional_put\030\003 \001(\0132(.cockroach.roachp"
-    "b.ConditionalPutRequest\0226\n\tincrement\030\004 \001"
-    "(\0132#.cockroach.roachpb.IncrementRequest\022"
-    "0\n\006delete\030\005 \001(\0132 .cockroach.roachpb.Dele"
-    "teRequest\022;\n\014delete_range\030\006 \001(\0132%.cockro"
-    "ach.roachpb.DeleteRangeRequest\022,\n\004scan\030\007"
-    " \001(\0132\036.cockroach.roachpb.ScanRequest\022A\n\017"
-    "end_transaction\030\010 \001(\0132(.cockroach.roachp"
-    "b.EndTransactionRequest\0229\n\013admin_split\030\t"
-    " \001(\0132$.cockroach.roachpb.AdminSplitReque"
-    "st\0229\n\013admin_merge\030\n \001(\0132$.cockroach.roac"
-    "hpb.AdminMergeRequest\022=\n\rheartbeat_txn\030\013"
-    " \001(\0132&.cockroach.roachpb.HeartbeatTxnReq"
-    "uest\022(\n\002gc\030\014 \001(\0132\034.cockroach.roachpb.GCR"
-    "equest\0223\n\010push_txn\030\r \001(\0132!.cockroach.roa"
-    "chpb.PushTxnRequest\022;\n\014range_lookup\030\016 \001("
-    "\0132%.cockroach.roachpb.RangeLookupRequest"
-    "\022\?\n\016resolve_intent\030\017 \001(\0132\'.cockroach.roa"
-    "chpb.ResolveIntentRequest\022J\n\024resolve_int"
-    "ent_range\030\020 \001(\0132,.cockroach.roachpb.Reso"
-    "lveIntentRangeRequest\022.\n\005merge\030\021 \001(\0132\037.c"
-    "ockroach.roachpb.MergeRequest\022;\n\014truncat"
-    "e_log\030\022 \001(\0132%.cockroach.roachpb.Truncate"
-    "LogRequest\022;\n\014leader_lease\030\023 \001(\0132%.cockr"
-    "oach.roachpb.LeaderLeaseRequest\022;\n\014rever"
-    "se_scan\030\024 \001(\0132%.cockroach.roachpb.Revers"
-    "eScanRequest\022,\n\004noop\030\025 \001(\0132\036.cockroach.r"
-    "oachpb.NoopRequest:\004\310\240\037\001\"\320\t\n\rResponseUni"
-    "on\022+\n\003get\030\001 \001(\0132\036.cockroach.roachpb.GetR"
-    "esponse\022+\n\003put\030\002 \001(\0132\036.cockroach.roachpb"
-    ".PutResponse\022B\n\017conditional_put\030\003 \001(\0132)."
-    "cockroach.roachpb.ConditionalPutResponse"
-    "\0227\n\tincrement\030\004 \001(\0132$.cockroach.roachpb."
-    "IncrementResponse\0221\n\006delete\030\005 \001(\0132!.cock"
-    "roach.roachpb.DeleteResponse\022<\n\014delete_r"
-    "ange\030\006 \001(\0132&.cockroach.roachpb.DeleteRan"
-    "geResponse\022-\n\004scan\030\007 \001(\0132\037.cockroach.roa"
-    "chpb.ScanResponse\022B\n\017end_transaction\030\010 \001"
-    "(\0132).cockroach.roachpb.EndTransactionRes"
-    "ponse\022:\n\013admin_split\030\t \001(\0132%.cockroach.r"
-    "oachpb.AdminSplitResponse\022:\n\013admin_merge"
-    "\030\n \001(\0132%.cockroach.roachpb.AdminMergeRes"
-    "ponse\022>\n\rheartbeat_txn\030\013 \001(\0132\'.cockroach"
-    ".roachpb.HeartbeatTxnResponse\022)\n\002gc\030\014 \001("
-    "\0132\035.cockroach.roachpb.GCResponse\0224\n\010push"
-    "_txn\030\r \001(\0132\".cockroach.roachpb.PushTxnRe"
-    "sponse\022<\n\014range_lookup\030\016 \001(\0132&.cockroach"
-    ".roachpb.RangeLookupResponse\022@\n\016resolve_"
-    "intent\030\017 \001(\0132(.cockroach.roachpb.Resolve"
-    "IntentResponse\022K\n\024resolve_intent_range\030\020"
-    " \001(\0132-.cockroach.roachpb.ResolveIntentRa"
-    "ngeResponse\022/\n\005merge\030\021 \001(\0132 .cockroach.r"
-    "oachpb.MergeResponse\022<\n\014truncate_log\030\022 \001"
-    "(\0132&.cockroach.roachpb.TruncateLogRespon"
-    "se\022<\n\014leader_lease\030\023 \001(\0132&.cockroach.roa"
-    "chpb.LeaderLeaseResponse\022<\n\014reverse_scan"
-    "\030\024 \001(\0132&.cockroach.roachpb.ReverseScanRe"
-    "sponse\022-\n\004noop\030\025 \001(\0132\037.cockroach.roachpb"
-    ".NoopResponse:\004\310\240\037\001\"\272\004\n\014BatchRequest\022@\n\006"
-    "header\030\001 \001(\0132&.cockroach.roachpb.BatchRe"
-    "quest.HeaderB\010\310\336\037\000\320\336\037\001\0227\n\010requests\030\002 \003(\013"
-    "2\037.cockroach.roachpb.RequestUnionB\004\310\336\037\000\032"
-    "\250\003\n\006Header\0225\n\ttimestamp\030\001 \001(\0132\034.cockroac"
-    "h.roachpb.TimestampB\004\310\336\037\000\022=\n\006cmd_id\030\002 \001("
-    "\0132\036.cockroach.roachpb.ClientCmdIDB\r\310\336\037\000\342"
-    "\336\037\005CmdID\022\024\n\003key\030\003 \001(\014B\007\372\336\037\003Key\022\030\n\007end_ke"
-    "y\030\004 \001(\014B\007\372\336\037\003Key\022;\n\007replica\030\005 \001(\0132$.cock"
-    "roach.roachpb.ReplicaDescriptorB\004\310\336\037\000\022,\n"
-    "\010range_id\030\006 \001(\003B\032\310\336\037\000\342\336\037\007RangeID\372\336\037\007Rang"
-    "eID\022\030\n\ruser_priority\030\007 \001(\005:\0011\022+\n\003txn\030\010 \001"
-    "(\0132\036.cockroach.roachpb.Transaction\022F\n\020re"
-    "ad_consistency\030\t \001(\0162&.cockroach.roachpb"
-    ".ReadConsistencyTypeB\004\310\336\037\000:\004\230\240\037\000\"\245\002\n\rBat"
-    "chResponse\022A\n\006header\030\001 \001(\0132\'.cockroach.r"
-    "oachpb.BatchResponse.HeaderB\010\310\336\037\000\320\336\037\001\0229\n"
-    "\tresponses\030\002 \003(\0132 .cockroach.roachpb.Res"
-    "ponseUnionB\004\310\336\037\000\032\225\001\n\006Header\022\'\n\005error\030\001 \001"
-    "(\0132\030.cockroach.roachpb.Error\0225\n\ttimestam"
-    "p\030\002 \001(\0132\034.cockroach.roachpb.TimestampB\004\310"
-    "\336\037\000\022+\n\003txn\030\003 \001(\0132\036.cockroach.roachpb.Tra"
-    "nsaction*L\n\023ReadConsistencyType\022\016\n\nCONSI"
-    "STENT\020\000\022\r\n\tCONSENSUS\020\001\022\020\n\014INCONSISTENT\020\002"
-    "\032\004\210\243\036\000*G\n\013PushTxnType\022\022\n\016PUSH_TIMESTAMP\020"
-    "\000\022\r\n\tABORT_TXN\020\001\022\017\n\013CLEANUP_TXN\020\002\032\004\210\243\036\000B"
-    "\031Z\007roachpb\340\342\036\001\310\342\036\001\320\342\036\001\220\343\036\000", 9266);
+    "\0228\n\nintent_txn\030\002 \001(\0132\036.cockroach.roachpb"
+    ".TransactionB\004\310\336\037\000\"K\n\014NoopResponse\022;\n\006he"
+    "ader\030\001 \001(\0132!.cockroach.roachpb.ResponseH"
+    "eaderB\010\310\336\037\000\320\336\037\001\"I\n\013NoopRequest\022:\n\006header"
+    "\030\001 \001(\0132 .cockroach.roachpb.RequestHeader"
+    "B\010\310\336\037\000\320\336\037\001\"Y\n\032ResolveIntentRangeResponse"
+    "\022;\n\006header\030\001 \001(\0132!.cockroach.roachpb.Res"
+    "ponseHeaderB\010\310\336\037\000\320\336\037\001\"y\n\014MergeRequest\022:\n"
+    "\006header\030\001 \001(\0132 .cockroach.roachpb.Reques"
+    "tHeaderB\010\310\336\037\000\320\336\037\001\022-\n\005value\030\002 \001(\0132\030.cockr"
+    "oach.roachpb.ValueB\004\310\336\037\000\"L\n\rMergeRespons"
+    "e\022;\n\006header\030\001 \001(\0132!.cockroach.roachpb.Re"
+    "sponseHeaderB\010\310\336\037\000\320\336\037\001\"e\n\022TruncateLogReq"
+    "uest\022:\n\006header\030\001 \001(\0132 .cockroach.roachpb"
+    ".RequestHeaderB\010\310\336\037\000\320\336\037\001\022\023\n\005index\030\002 \001(\004B"
+    "\004\310\336\037\000\"R\n\023TruncateLogResponse\022;\n\006header\030\001"
+    " \001(\0132!.cockroach.roachpb.ResponseHeaderB"
+    "\010\310\336\037\000\320\336\037\001\"\177\n\022LeaderLeaseRequest\022:\n\006heade"
+    "r\030\001 \001(\0132 .cockroach.roachpb.RequestHeade"
+    "rB\010\310\336\037\000\320\336\037\001\022-\n\005lease\030\002 \001(\0132\030.cockroach.r"
+    "oachpb.LeaseB\004\310\336\037\000\"R\n\023LeaderLeaseRespons"
+    "e\022;\n\006header\030\001 \001(\0132!.cockroach.roachpb.Re"
+    "sponseHeaderB\010\310\336\037\000\320\336\037\001\"\272\t\n\014RequestUnion\022"
+    "*\n\003get\030\001 \001(\0132\035.cockroach.roachpb.GetRequ"
+    "est\022*\n\003put\030\002 \001(\0132\035.cockroach.roachpb.Put"
+    "Request\022A\n\017conditional_put\030\003 \001(\0132(.cockr"
+    "oach.roachpb.ConditionalPutRequest\0226\n\tin"
+    "crement\030\004 \001(\0132#.cockroach.roachpb.Increm"
+    "entRequest\0220\n\006delete\030\005 \001(\0132 .cockroach.r"
+    "oachpb.DeleteRequest\022;\n\014delete_range\030\006 \001"
+    "(\0132%.cockroach.roachpb.DeleteRangeReques"
+    "t\022,\n\004scan\030\007 \001(\0132\036.cockroach.roachpb.Scan"
+    "Request\022A\n\017end_transaction\030\010 \001(\0132(.cockr"
+    "oach.roachpb.EndTransactionRequest\0229\n\013ad"
+    "min_split\030\t \001(\0132$.cockroach.roachpb.Admi"
+    "nSplitRequest\0229\n\013admin_merge\030\n \001(\0132$.coc"
+    "kroach.roachpb.AdminMergeRequest\022=\n\rhear"
+    "tbeat_txn\030\013 \001(\0132&.cockroach.roachpb.Hear"
+    "tbeatTxnRequest\022(\n\002gc\030\014 \001(\0132\034.cockroach."
+    "roachpb.GCRequest\0223\n\010push_txn\030\r \001(\0132!.co"
+    "ckroach.roachpb.PushTxnRequest\022;\n\014range_"
+    "lookup\030\016 \001(\0132%.cockroach.roachpb.RangeLo"
+    "okupRequest\022\?\n\016resolve_intent\030\017 \001(\0132\'.co"
+    "ckroach.roachpb.ResolveIntentRequest\022J\n\024"
+    "resolve_intent_range\030\020 \001(\0132,.cockroach.r"
+    "oachpb.ResolveIntentRangeRequest\022.\n\005merg"
+    "e\030\021 \001(\0132\037.cockroach.roachpb.MergeRequest"
+    "\022;\n\014truncate_log\030\022 \001(\0132%.cockroach.roach"
+    "pb.TruncateLogRequest\022;\n\014leader_lease\030\023 "
+    "\001(\0132%.cockroach.roachpb.LeaderLeaseReque"
+    "st\022;\n\014reverse_scan\030\024 \001(\0132%.cockroach.roa"
+    "chpb.ReverseScanRequest\022,\n\004noop\030\025 \001(\0132\036."
+    "cockroach.roachpb.NoopRequest:\004\310\240\037\001\"\320\t\n\r"
+    "ResponseUnion\022+\n\003get\030\001 \001(\0132\036.cockroach.r"
+    "oachpb.GetResponse\022+\n\003put\030\002 \001(\0132\036.cockro"
+    "ach.roachpb.PutResponse\022B\n\017conditional_p"
+    "ut\030\003 \001(\0132).cockroach.roachpb.Conditional"
+    "PutResponse\0227\n\tincrement\030\004 \001(\0132$.cockroa"
+    "ch.roachpb.IncrementResponse\0221\n\006delete\030\005"
+    " \001(\0132!.cockroach.roachpb.DeleteResponse\022"
+    "<\n\014delete_range\030\006 \001(\0132&.cockroach.roachp"
+    "b.DeleteRangeResponse\022-\n\004scan\030\007 \001(\0132\037.co"
+    "ckroach.roachpb.ScanResponse\022B\n\017end_tran"
+    "saction\030\010 \001(\0132).cockroach.roachpb.EndTra"
+    "nsactionResponse\022:\n\013admin_split\030\t \001(\0132%."
+    "cockroach.roachpb.AdminSplitResponse\022:\n\013"
+    "admin_merge\030\n \001(\0132%.cockroach.roachpb.Ad"
+    "minMergeResponse\022>\n\rheartbeat_txn\030\013 \001(\0132"
+    "\'.cockroach.roachpb.HeartbeatTxnResponse"
+    "\022)\n\002gc\030\014 \001(\0132\035.cockroach.roachpb.GCRespo"
+    "nse\0224\n\010push_txn\030\r \001(\0132\".cockroach.roachp"
+    "b.PushTxnResponse\022<\n\014range_lookup\030\016 \001(\0132"
+    "&.cockroach.roachpb.RangeLookupResponse\022"
+    "@\n\016resolve_intent\030\017 \001(\0132(.cockroach.roac"
+    "hpb.ResolveIntentResponse\022K\n\024resolve_int"
+    "ent_range\030\020 \001(\0132-.cockroach.roachpb.Reso"
+    "lveIntentRangeResponse\022/\n\005merge\030\021 \001(\0132 ."
+    "cockroach.roachpb.MergeResponse\022<\n\014trunc"
+    "ate_log\030\022 \001(\0132&.cockroach.roachpb.Trunca"
+    "teLogResponse\022<\n\014leader_lease\030\023 \001(\0132&.co"
+    "ckroach.roachpb.LeaderLeaseResponse\022<\n\014r"
+    "everse_scan\030\024 \001(\0132&.cockroach.roachpb.Re"
+    "verseScanResponse\022-\n\004noop\030\025 \001(\0132\037.cockro"
+    "ach.roachpb.NoopResponse:\004\310\240\037\001\"\272\004\n\014Batch"
+    "Request\022@\n\006header\030\001 \001(\0132&.cockroach.roac"
+    "hpb.BatchRequest.HeaderB\010\310\336\037\000\320\336\037\001\0227\n\010req"
+    "uests\030\002 \003(\0132\037.cockroach.roachpb.RequestU"
+    "nionB\004\310\336\037\000\032\250\003\n\006Header\0225\n\ttimestamp\030\001 \001(\013"
+    "2\034.cockroach.roachpb.TimestampB\004\310\336\037\000\022=\n\006"
+    "cmd_id\030\002 \001(\0132\036.cockroach.roachpb.ClientC"
+    "mdIDB\r\310\336\037\000\342\336\037\005CmdID\022\024\n\003key\030\003 \001(\014B\007\372\336\037\003Ke"
+    "y\022\030\n\007end_key\030\004 \001(\014B\007\372\336\037\003Key\022;\n\007replica\030\005"
+    " \001(\0132$.cockroach.roachpb.ReplicaDescript"
+    "orB\004\310\336\037\000\022,\n\010range_id\030\006 \001(\003B\032\310\336\037\000\342\336\037\007Rang"
+    "eID\372\336\037\007RangeID\022\030\n\ruser_priority\030\007 \001(\005:\0011"
+    "\022+\n\003txn\030\010 \001(\0132\036.cockroach.roachpb.Transa"
+    "ction\022F\n\020read_consistency\030\t \001(\0162&.cockro"
+    "ach.roachpb.ReadConsistencyTypeB\004\310\336\037\000:\004\230"
+    "\240\037\000\"\245\002\n\rBatchResponse\022A\n\006header\030\001 \001(\0132\'."
+    "cockroach.roachpb.BatchResponse.HeaderB\010"
+    "\310\336\037\000\320\336\037\001\0229\n\tresponses\030\002 \003(\0132 .cockroach."
+    "roachpb.ResponseUnionB\004\310\336\037\000\032\225\001\n\006Header\022\'"
+    "\n\005error\030\001 \001(\0132\030.cockroach.roachpb.Error\022"
+    "5\n\ttimestamp\030\002 \001(\0132\034.cockroach.roachpb.T"
+    "imestampB\004\310\336\037\000\022+\n\003txn\030\003 \001(\0132\036.cockroach."
+    "roachpb.Transaction*L\n\023ReadConsistencyTy"
+    "pe\022\016\n\nCONSISTENT\020\000\022\r\n\tCONSENSUS\020\001\022\020\n\014INC"
+    "ONSISTENT\020\002\032\004\210\243\036\000*G\n\013PushTxnType\022\022\n\016PUSH"
+    "_TIMESTAMP\020\000\022\r\n\tABORT_TXN\020\001\022\017\n\013CLEANUP_T"
+    "XN\020\002\032\004\210\243\036\000B\031Z\007roachpb\340\342\036\001\310\342\036\001\320\342\036\001\220\343\036\000", 9277);
   ::google::protobuf::MessageFactory::InternalRegisterGeneratedFile(
     "cockroach/roachpb/api.proto", &protobuf_RegisterTypes);
   ClientCmdID::default_instance_ = new ClientCmdID();
@@ -2033,7 +2033,7 @@ void ClientCmdID::clear_random() {
 // ===================================================================
 
 #ifndef _MSC_VER
-const int RequestHeader::kTimestampFieldNumber;
+const int RequestHeader::kDeprecatedTimestampFieldNumber;
 const int RequestHeader::kCmdIdFieldNumber;
 const int RequestHeader::kKeyFieldNumber;
 const int RequestHeader::kEndKeyFieldNumber;
@@ -2051,7 +2051,7 @@ RequestHeader::RequestHeader()
 }
 
 void RequestHeader::InitAsDefaultInstance() {
-  timestamp_ = const_cast< ::cockroach::roachpb::Timestamp*>(&::cockroach::roachpb::Timestamp::default_instance());
+  deprecated_timestamp_ = const_cast< ::cockroach::roachpb::Timestamp*>(&::cockroach::roachpb::Timestamp::default_instance());
   cmd_id_ = const_cast< ::cockroach::roachpb::ClientCmdID*>(&::cockroach::roachpb::ClientCmdID::default_instance());
   replica_ = const_cast< ::cockroach::roachpb::ReplicaDescriptor*>(&::cockroach::roachpb::ReplicaDescriptor::default_instance());
   txn_ = const_cast< ::cockroach::roachpb::Transaction*>(&::cockroach::roachpb::Transaction::default_instance());
@@ -2068,7 +2068,7 @@ RequestHeader::RequestHeader(const RequestHeader& from)
 void RequestHeader::SharedCtor() {
   ::google::protobuf::internal::GetEmptyString();
   _cached_size_ = 0;
-  timestamp_ = NULL;
+  deprecated_timestamp_ = NULL;
   cmd_id_ = NULL;
   key_.UnsafeSetDefault(&::google::protobuf::internal::GetEmptyStringAlreadyInited());
   end_key_.UnsafeSetDefault(&::google::protobuf::internal::GetEmptyStringAlreadyInited());
@@ -2089,7 +2089,7 @@ void RequestHeader::SharedDtor() {
   key_.DestroyNoArena(&::google::protobuf::internal::GetEmptyStringAlreadyInited());
   end_key_.DestroyNoArena(&::google::protobuf::internal::GetEmptyStringAlreadyInited());
   if (this != default_instance_) {
-    delete timestamp_;
+    delete deprecated_timestamp_;
     delete cmd_id_;
     delete replica_;
     delete txn_;
@@ -2123,8 +2123,8 @@ RequestHeader* RequestHeader::New(::google::protobuf::Arena* arena) const {
 
 void RequestHeader::Clear() {
   if (_has_bits_[0 / 32] & 255u) {
-    if (has_timestamp()) {
-      if (timestamp_ != NULL) timestamp_->::cockroach::roachpb::Timestamp::Clear();
+    if (has_deprecated_timestamp()) {
+      if (deprecated_timestamp_ != NULL) deprecated_timestamp_->::cockroach::roachpb::Timestamp::Clear();
     }
     if (has_cmd_id()) {
       if (cmd_id_ != NULL) cmd_id_->::cockroach::roachpb::ClientCmdID::Clear();
@@ -2161,11 +2161,11 @@ bool RequestHeader::MergePartialFromCodedStream(
     tag = p.first;
     if (!p.second) goto handle_unusual;
     switch (::google::protobuf::internal::WireFormatLite::GetTagFieldNumber(tag)) {
-      // optional .cockroach.roachpb.Timestamp timestamp = 1;
+      // optional .cockroach.roachpb.Timestamp deprecated_timestamp = 1;
       case 1: {
         if (tag == 10) {
           DO_(::google::protobuf::internal::WireFormatLite::ReadMessageNoVirtual(
-               input, mutable_timestamp()));
+               input, mutable_deprecated_timestamp()));
         } else {
           goto handle_unusual;
         }
@@ -2313,10 +2313,10 @@ failure:
 void RequestHeader::SerializeWithCachedSizes(
     ::google::protobuf::io::CodedOutputStream* output) const {
   // @@protoc_insertion_point(serialize_start:cockroach.roachpb.RequestHeader)
-  // optional .cockroach.roachpb.Timestamp timestamp = 1;
-  if (has_timestamp()) {
+  // optional .cockroach.roachpb.Timestamp deprecated_timestamp = 1;
+  if (has_deprecated_timestamp()) {
     ::google::protobuf::internal::WireFormatLite::WriteMessageMaybeToArray(
-      1, *this->timestamp_, output);
+      1, *this->deprecated_timestamp_, output);
   }
 
   // optional .cockroach.roachpb.ClientCmdID cmd_id = 2;
@@ -2375,11 +2375,11 @@ void RequestHeader::SerializeWithCachedSizes(
 ::google::protobuf::uint8* RequestHeader::SerializeWithCachedSizesToArray(
     ::google::protobuf::uint8* target) const {
   // @@protoc_insertion_point(serialize_to_array_start:cockroach.roachpb.RequestHeader)
-  // optional .cockroach.roachpb.Timestamp timestamp = 1;
-  if (has_timestamp()) {
+  // optional .cockroach.roachpb.Timestamp deprecated_timestamp = 1;
+  if (has_deprecated_timestamp()) {
     target = ::google::protobuf::internal::WireFormatLite::
       WriteMessageNoVirtualToArray(
-        1, *this->timestamp_, target);
+        1, *this->deprecated_timestamp_, target);
   }
 
   // optional .cockroach.roachpb.ClientCmdID cmd_id = 2;
@@ -2445,11 +2445,11 @@ int RequestHeader::ByteSize() const {
   int total_size = 0;
 
   if (_has_bits_[0 / 32] & 255) {
-    // optional .cockroach.roachpb.Timestamp timestamp = 1;
-    if (has_timestamp()) {
+    // optional .cockroach.roachpb.Timestamp deprecated_timestamp = 1;
+    if (has_deprecated_timestamp()) {
       total_size += 1 +
         ::google::protobuf::internal::WireFormatLite::MessageSizeNoVirtual(
-          *this->timestamp_);
+          *this->deprecated_timestamp_);
     }
 
     // optional .cockroach.roachpb.ClientCmdID cmd_id = 2;
@@ -2534,8 +2534,8 @@ void RequestHeader::MergeFrom(const ::google::protobuf::Message& from) {
 void RequestHeader::MergeFrom(const RequestHeader& from) {
   if (GOOGLE_PREDICT_FALSE(&from == this)) MergeFromFail(__LINE__);
   if (from._has_bits_[0 / 32] & (0xffu << (0 % 32))) {
-    if (from.has_timestamp()) {
-      mutable_timestamp()->::cockroach::roachpb::Timestamp::MergeFrom(from.timestamp());
+    if (from.has_deprecated_timestamp()) {
+      mutable_deprecated_timestamp()->::cockroach::roachpb::Timestamp::MergeFrom(from.deprecated_timestamp());
     }
     if (from.has_cmd_id()) {
       mutable_cmd_id()->::cockroach::roachpb::ClientCmdID::MergeFrom(from.cmd_id());
@@ -2593,7 +2593,7 @@ void RequestHeader::Swap(RequestHeader* other) {
   InternalSwap(other);
 }
 void RequestHeader::InternalSwap(RequestHeader* other) {
-  std::swap(timestamp_, other->timestamp_);
+  std::swap(deprecated_timestamp_, other->deprecated_timestamp_);
   std::swap(cmd_id_, other->cmd_id_);
   key_.Swap(&other->key_);
   end_key_.Swap(&other->end_key_);
@@ -2618,47 +2618,47 @@ void RequestHeader::InternalSwap(RequestHeader* other) {
 #if PROTOBUF_INLINE_NOT_IN_HEADERS
 // RequestHeader
 
-// optional .cockroach.roachpb.Timestamp timestamp = 1;
-bool RequestHeader::has_timestamp() const {
+// optional .cockroach.roachpb.Timestamp deprecated_timestamp = 1;
+bool RequestHeader::has_deprecated_timestamp() const {
   return (_has_bits_[0] & 0x00000001u) != 0;
 }
-void RequestHeader::set_has_timestamp() {
+void RequestHeader::set_has_deprecated_timestamp() {
   _has_bits_[0] |= 0x00000001u;
 }
-void RequestHeader::clear_has_timestamp() {
+void RequestHeader::clear_has_deprecated_timestamp() {
   _has_bits_[0] &= ~0x00000001u;
 }
-void RequestHeader::clear_timestamp() {
-  if (timestamp_ != NULL) timestamp_->::cockroach::roachpb::Timestamp::Clear();
-  clear_has_timestamp();
+void RequestHeader::clear_deprecated_timestamp() {
+  if (deprecated_timestamp_ != NULL) deprecated_timestamp_->::cockroach::roachpb::Timestamp::Clear();
+  clear_has_deprecated_timestamp();
 }
- const ::cockroach::roachpb::Timestamp& RequestHeader::timestamp() const {
-  // @@protoc_insertion_point(field_get:cockroach.roachpb.RequestHeader.timestamp)
-  return timestamp_ != NULL ? *timestamp_ : *default_instance_->timestamp_;
+ const ::cockroach::roachpb::Timestamp& RequestHeader::deprecated_timestamp() const {
+  // @@protoc_insertion_point(field_get:cockroach.roachpb.RequestHeader.deprecated_timestamp)
+  return deprecated_timestamp_ != NULL ? *deprecated_timestamp_ : *default_instance_->deprecated_timestamp_;
 }
- ::cockroach::roachpb::Timestamp* RequestHeader::mutable_timestamp() {
-  set_has_timestamp();
-  if (timestamp_ == NULL) {
-    timestamp_ = new ::cockroach::roachpb::Timestamp;
+ ::cockroach::roachpb::Timestamp* RequestHeader::mutable_deprecated_timestamp() {
+  set_has_deprecated_timestamp();
+  if (deprecated_timestamp_ == NULL) {
+    deprecated_timestamp_ = new ::cockroach::roachpb::Timestamp;
   }
-  // @@protoc_insertion_point(field_mutable:cockroach.roachpb.RequestHeader.timestamp)
-  return timestamp_;
+  // @@protoc_insertion_point(field_mutable:cockroach.roachpb.RequestHeader.deprecated_timestamp)
+  return deprecated_timestamp_;
 }
- ::cockroach::roachpb::Timestamp* RequestHeader::release_timestamp() {
-  clear_has_timestamp();
-  ::cockroach::roachpb::Timestamp* temp = timestamp_;
-  timestamp_ = NULL;
+ ::cockroach::roachpb::Timestamp* RequestHeader::release_deprecated_timestamp() {
+  clear_has_deprecated_timestamp();
+  ::cockroach::roachpb::Timestamp* temp = deprecated_timestamp_;
+  deprecated_timestamp_ = NULL;
   return temp;
 }
- void RequestHeader::set_allocated_timestamp(::cockroach::roachpb::Timestamp* timestamp) {
-  delete timestamp_;
-  timestamp_ = timestamp;
-  if (timestamp) {
-    set_has_timestamp();
+ void RequestHeader::set_allocated_deprecated_timestamp(::cockroach::roachpb::Timestamp* deprecated_timestamp) {
+  delete deprecated_timestamp_;
+  deprecated_timestamp_ = deprecated_timestamp;
+  if (deprecated_timestamp) {
+    set_has_deprecated_timestamp();
   } else {
-    clear_has_timestamp();
+    clear_has_deprecated_timestamp();
   }
-  // @@protoc_insertion_point(field_set_allocated:cockroach.roachpb.RequestHeader.timestamp)
+  // @@protoc_insertion_point(field_set_allocated:cockroach.roachpb.RequestHeader.deprecated_timestamp)
 }
 
 // optional .cockroach.roachpb.ClientCmdID cmd_id = 2;

--- a/storage/engine/rocksdb/cockroach/roachpb/api.pb.cc
+++ b/storage/engine/rocksdb/cockroach/roachpb/api.pb.cc
@@ -206,8 +206,7 @@ void protobuf_AssignDesc_cockroach_2froachpb_2fapi_2eproto() {
       GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(ClientCmdID, _internal_metadata_),
       -1);
   RequestHeader_descriptor_ = file->message_type(1);
-  static const int RequestHeader_offsets_[9] = {
-    GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(RequestHeader, deprecated_timestamp_),
+  static const int RequestHeader_offsets_[8] = {
     GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(RequestHeader, cmd_id_),
     GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(RequestHeader, key_),
     GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(RequestHeader, end_key_),
@@ -1312,233 +1311,232 @@ void protobuf_AddDesc_cockroach_2froachpb_2fapi_2eproto() {
     "to\032\034cockroach/roachpb/data.proto\032\036cockro"
     "ach/roachpb/errors.proto\032\024gogoproto/gogo"
     ".proto\"<\n\013ClientCmdID\022\027\n\twall_time\030\001 \001(\003"
-    "B\004\310\336\037\000\022\024\n\006random\030\002 \001(\003B\004\310\336\037\000\"\272\003\n\rRequest"
-    "Header\022@\n\024deprecated_timestamp\030\001 \001(\0132\034.c"
-    "ockroach.roachpb.TimestampB\004\310\336\037\000\022=\n\006cmd_"
-    "id\030\002 \001(\0132\036.cockroach.roachpb.ClientCmdID"
-    "B\r\310\336\037\000\342\336\037\005CmdID\022\024\n\003key\030\003 \001(\014B\007\372\336\037\003Key\022\030\n"
-    "\007end_key\030\004 \001(\014B\007\372\336\037\003Key\022;\n\007replica\030\005 \001(\013"
-    "2$.cockroach.roachpb.ReplicaDescriptorB\004"
-    "\310\336\037\000\022,\n\010range_id\030\006 \001(\003B\032\310\336\037\000\342\336\037\007RangeID\372"
-    "\336\037\007RangeID\022\030\n\ruser_priority\030\007 \001(\005:\0011\022+\n\003"
-    "txn\030\010 \001(\0132\036.cockroach.roachpb.Transactio"
-    "n\022F\n\020read_consistency\030\t \001(\0162&.cockroach."
-    "roachpb.ReadConsistencyTypeB\004\310\336\037\000\"t\n\016Res"
-    "ponseHeader\0225\n\ttimestamp\030\002 \001(\0132\034.cockroa"
-    "ch.roachpb.TimestampB\004\310\336\037\000\022+\n\003txn\030\003 \001(\0132"
-    "\036.cockroach.roachpb.Transaction\"H\n\nGetRe"
-    "quest\022:\n\006header\030\001 \001(\0132 .cockroach.roachp"
-    "b.RequestHeaderB\010\310\336\037\000\320\336\037\001\"s\n\013GetResponse"
-    "\022;\n\006header\030\001 \001(\0132!.cockroach.roachpb.Res"
-    "ponseHeaderB\010\310\336\037\000\320\336\037\001\022\'\n\005value\030\002 \001(\0132\030.c"
-    "ockroach.roachpb.Value\"w\n\nPutRequest\022:\n\006"
-    "header\030\001 \001(\0132 .cockroach.roachpb.Request"
-    "HeaderB\010\310\336\037\000\320\336\037\001\022-\n\005value\030\002 \001(\0132\030.cockro"
-    "ach.roachpb.ValueB\004\310\336\037\000\"J\n\013PutResponse\022;"
-    "\n\006header\030\001 \001(\0132!.cockroach.roachpb.Respo"
-    "nseHeaderB\010\310\336\037\000\320\336\037\001\"\257\001\n\025ConditionalPutRe"
-    "quest\022:\n\006header\030\001 \001(\0132 .cockroach.roachp"
-    "b.RequestHeaderB\010\310\336\037\000\320\336\037\001\022-\n\005value\030\002 \001(\013"
-    "2\030.cockroach.roachpb.ValueB\004\310\336\037\000\022+\n\texp_"
-    "value\030\003 \001(\0132\030.cockroach.roachpb.Value\"U\n"
-    "\026ConditionalPutResponse\022;\n\006header\030\001 \001(\0132"
-    "!.cockroach.roachpb.ResponseHeaderB\010\310\336\037\000"
-    "\320\336\037\001\"g\n\020IncrementRequest\022:\n\006header\030\001 \001(\013"
-    "2 .cockroach.roachpb.RequestHeaderB\010\310\336\037\000"
-    "\320\336\037\001\022\027\n\tincrement\030\002 \001(\003B\004\310\336\037\000\"i\n\021Increme"
-    "ntResponse\022;\n\006header\030\001 \001(\0132!.cockroach.r"
-    "oachpb.ResponseHeaderB\010\310\336\037\000\320\336\037\001\022\027\n\tnew_v"
-    "alue\030\002 \001(\003B\004\310\336\037\000\"K\n\rDeleteRequest\022:\n\006hea"
-    "der\030\001 \001(\0132 .cockroach.roachpb.RequestHea"
-    "derB\010\310\336\037\000\320\336\037\001\"M\n\016DeleteResponse\022;\n\006heade"
-    "r\030\001 \001(\0132!.cockroach.roachpb.ResponseHead"
-    "erB\010\310\336\037\000\320\336\037\001\"u\n\022DeleteRangeRequest\022:\n\006he"
-    "ader\030\001 \001(\0132 .cockroach.roachpb.RequestHe"
-    "aderB\010\310\336\037\000\320\336\037\001\022#\n\025max_entries_to_delete\030"
-    "\002 \001(\003B\004\310\336\037\000\"m\n\023DeleteRangeResponse\022;\n\006he"
-    "ader\030\001 \001(\0132!.cockroach.roachpb.ResponseH"
-    "eaderB\010\310\336\037\000\320\336\037\001\022\031\n\013num_deleted\030\002 \001(\003B\004\310\336"
-    "\037\000\"d\n\013ScanRequest\022:\n\006header\030\001 \001(\0132 .cock"
-    "roach.roachpb.RequestHeaderB\010\310\336\037\000\320\336\037\001\022\031\n"
-    "\013max_results\030\002 \001(\003B\004\310\336\037\000\"|\n\014ScanResponse"
-    "\022;\n\006header\030\001 \001(\0132!.cockroach.roachpb.Res"
-    "ponseHeaderB\010\310\336\037\000\320\336\037\001\022/\n\004rows\030\002 \003(\0132\033.co"
-    "ckroach.roachpb.KeyValueB\004\310\336\037\000\"k\n\022Revers"
-    "eScanRequest\022:\n\006header\030\001 \001(\0132 .cockroach"
-    ".roachpb.RequestHeaderB\010\310\336\037\000\320\336\037\001\022\031\n\013max_"
-    "results\030\002 \001(\003B\004\310\336\037\000\"\203\001\n\023ReverseScanRespo"
-    "nse\022;\n\006header\030\001 \001(\0132!.cockroach.roachpb."
-    "ResponseHeaderB\010\310\336\037\000\320\336\037\001\022/\n\004rows\030\002 \003(\0132\033"
-    ".cockroach.roachpb.KeyValueB\004\310\336\037\000\"\346\001\n\025En"
-    "dTransactionRequest\022:\n\006header\030\001 \001(\0132 .co"
+    "B\004\310\336\037\000\022\024\n\006random\030\002 \001(\003B\004\310\336\037\000\"\370\002\n\rRequest"
+    "Header\022=\n\006cmd_id\030\002 \001(\0132\036.cockroach.roach"
+    "pb.ClientCmdIDB\r\310\336\037\000\342\336\037\005CmdID\022\024\n\003key\030\003 \001"
+    "(\014B\007\372\336\037\003Key\022\030\n\007end_key\030\004 \001(\014B\007\372\336\037\003Key\022;\n"
+    "\007replica\030\005 \001(\0132$.cockroach.roachpb.Repli"
+    "caDescriptorB\004\310\336\037\000\022,\n\010range_id\030\006 \001(\003B\032\310\336"
+    "\037\000\342\336\037\007RangeID\372\336\037\007RangeID\022\030\n\ruser_priorit"
+    "y\030\007 \001(\005:\0011\022+\n\003txn\030\010 \001(\0132\036.cockroach.roac"
+    "hpb.Transaction\022F\n\020read_consistency\030\t \001("
+    "\0162&.cockroach.roachpb.ReadConsistencyTyp"
+    "eB\004\310\336\037\000\"t\n\016ResponseHeader\0225\n\ttimestamp\030\002"
+    " \001(\0132\034.cockroach.roachpb.TimestampB\004\310\336\037\000"
+    "\022+\n\003txn\030\003 \001(\0132\036.cockroach.roachpb.Transa"
+    "ction\"H\n\nGetRequest\022:\n\006header\030\001 \001(\0132 .co"
+    "ckroach.roachpb.RequestHeaderB\010\310\336\037\000\320\336\037\001\""
+    "s\n\013GetResponse\022;\n\006header\030\001 \001(\0132!.cockroa"
+    "ch.roachpb.ResponseHeaderB\010\310\336\037\000\320\336\037\001\022\'\n\005v"
+    "alue\030\002 \001(\0132\030.cockroach.roachpb.Value\"w\n\n"
+    "PutRequest\022:\n\006header\030\001 \001(\0132 .cockroach.r"
+    "oachpb.RequestHeaderB\010\310\336\037\000\320\336\037\001\022-\n\005value\030"
+    "\002 \001(\0132\030.cockroach.roachpb.ValueB\004\310\336\037\000\"J\n"
+    "\013PutResponse\022;\n\006header\030\001 \001(\0132!.cockroach"
+    ".roachpb.ResponseHeaderB\010\310\336\037\000\320\336\037\001\"\257\001\n\025Co"
+    "nditionalPutRequest\022:\n\006header\030\001 \001(\0132 .co"
     "ckroach.roachpb.RequestHeaderB\010\310\336\037\000\320\336\037\001\022"
-    "\024\n\006commit\030\002 \001(\010B\004\310\336\037\000\022I\n\027internal_commit"
-    "_trigger\030\003 \001(\0132(.cockroach.roachpb.Inter"
-    "nalCommitTrigger\0220\n\007intents\030\004 \003(\0132\031.cock"
-    "roach.roachpb.IntentB\004\310\336\037\000\"\213\001\n\026EndTransa"
-    "ctionResponse\022;\n\006header\030\001 \001(\0132!.cockroac"
-    "h.roachpb.ResponseHeaderB\010\310\336\037\000\320\336\037\001\022\031\n\013co"
-    "mmit_wait\030\002 \001(\003B\004\310\336\037\000\022\031\n\010resolved\030\003 \003(\014B"
-    "\007\372\336\037\003Key\"k\n\021AdminSplitRequest\022:\n\006header\030"
-    "\001 \001(\0132 .cockroach.roachpb.RequestHeaderB"
-    "\010\310\336\037\000\320\336\037\001\022\032\n\tsplit_key\030\002 \001(\014B\007\372\336\037\003Key\"Q\n"
-    "\022AdminSplitResponse\022;\n\006header\030\001 \001(\0132!.co"
-    "ckroach.roachpb.ResponseHeaderB\010\310\336\037\000\320\336\037\001"
-    "\"O\n\021AdminMergeRequest\022:\n\006header\030\001 \001(\0132 ."
-    "cockroach.roachpb.RequestHeaderB\010\310\336\037\000\320\336\037"
-    "\001\"Q\n\022AdminMergeResponse\022;\n\006header\030\001 \001(\0132"
-    "!.cockroach.roachpb.ResponseHeaderB\010\310\336\037\000"
-    "\320\336\037\001\"\241\001\n\022RangeLookupRequest\022:\n\006header\030\001 "
-    "\001(\0132 .cockroach.roachpb.RequestHeaderB\010\310"
-    "\336\037\000\320\336\037\001\022\030\n\nmax_ranges\030\002 \001(\005B\004\310\336\037\000\022\036\n\020con"
-    "sider_intents\030\003 \001(\010B\004\310\336\037\000\022\025\n\007reverse\030\004 \001"
-    "(\010B\004\310\336\037\000\"\214\001\n\023RangeLookupResponse\022;\n\006head"
-    "er\030\001 \001(\0132!.cockroach.roachpb.ResponseHea"
-    "derB\010\310\336\037\000\320\336\037\001\0228\n\006ranges\030\002 \003(\0132\".cockroac"
-    "h.roachpb.RangeDescriptorB\004\310\336\037\000\"Q\n\023Heart"
-    "beatTxnRequest\022:\n\006header\030\001 \001(\0132 .cockroa"
-    "ch.roachpb.RequestHeaderB\010\310\336\037\000\320\336\037\001\"S\n\024He"
-    "artbeatTxnResponse\022;\n\006header\030\001 \001(\0132!.coc"
-    "kroach.roachpb.ResponseHeaderB\010\310\336\037\000\320\336\037\001\""
-    "\225\002\n\tGCRequest\022:\n\006header\030\001 \001(\0132 .cockroac"
-    "h.roachpb.RequestHeaderB\010\310\336\037\000\320\336\037\001\022>\n\007gc_"
-    "meta\030\002 \001(\0132\035.cockroach.roachpb.GCMetadat"
-    "aB\016\310\336\037\000\342\336\037\006GCMeta\0226\n\004keys\030\003 \003(\0132\".cockro"
-    "ach.roachpb.GCRequest.GCKeyB\004\310\336\037\000\032T\n\005GCK"
-    "ey\022\024\n\003key\030\001 \001(\014B\007\372\336\037\003Key\0225\n\ttimestamp\030\002 "
-    "\001(\0132\034.cockroach.roachpb.TimestampB\004\310\336\037\000\""
-    "I\n\nGCResponse\022;\n\006header\030\001 \001(\0132!.cockroac"
-    "h.roachpb.ResponseHeaderB\010\310\336\037\000\320\336\037\001\"\337\002\n\016P"
-    "ushTxnRequest\022:\n\006header\030\001 \001(\0132 .cockroac"
-    "h.roachpb.RequestHeaderB\010\310\336\037\000\320\336\037\001\0228\n\npus"
-    "her_txn\030\002 \001(\0132\036.cockroach.roachpb.Transa"
-    "ctionB\004\310\336\037\000\0228\n\npushee_txn\030\003 \001(\0132\036.cockro"
-    "ach.roachpb.TransactionB\004\310\336\037\000\0223\n\007push_to"
-    "\030\004 \001(\0132\034.cockroach.roachpb.TimestampB\004\310\336"
-    "\037\000\022/\n\003now\030\005 \001(\0132\034.cockroach.roachpb.Time"
-    "stampB\004\310\336\037\000\0227\n\tpush_type\030\006 \001(\0162\036.cockroa"
-    "ch.roachpb.PushTxnTypeB\004\310\336\037\000\"\202\001\n\017PushTxn"
+    "-\n\005value\030\002 \001(\0132\030.cockroach.roachpb.Value"
+    "B\004\310\336\037\000\022+\n\texp_value\030\003 \001(\0132\030.cockroach.ro"
+    "achpb.Value\"U\n\026ConditionalPutResponse\022;\n"
+    "\006header\030\001 \001(\0132!.cockroach.roachpb.Respon"
+    "seHeaderB\010\310\336\037\000\320\336\037\001\"g\n\020IncrementRequest\022:"
+    "\n\006header\030\001 \001(\0132 .cockroach.roachpb.Reque"
+    "stHeaderB\010\310\336\037\000\320\336\037\001\022\027\n\tincrement\030\002 \001(\003B\004\310"
+    "\336\037\000\"i\n\021IncrementResponse\022;\n\006header\030\001 \001(\013"
+    "2!.cockroach.roachpb.ResponseHeaderB\010\310\336\037"
+    "\000\320\336\037\001\022\027\n\tnew_value\030\002 \001(\003B\004\310\336\037\000\"K\n\rDelete"
+    "Request\022:\n\006header\030\001 \001(\0132 .cockroach.roac"
+    "hpb.RequestHeaderB\010\310\336\037\000\320\336\037\001\"M\n\016DeleteRes"
+    "ponse\022;\n\006header\030\001 \001(\0132!.cockroach.roachp"
+    "b.ResponseHeaderB\010\310\336\037\000\320\336\037\001\"u\n\022DeleteRang"
+    "eRequest\022:\n\006header\030\001 \001(\0132 .cockroach.roa"
+    "chpb.RequestHeaderB\010\310\336\037\000\320\336\037\001\022#\n\025max_entr"
+    "ies_to_delete\030\002 \001(\003B\004\310\336\037\000\"m\n\023DeleteRange"
     "Response\022;\n\006header\030\001 \001(\0132!.cockroach.roa"
-    "chpb.ResponseHeaderB\010\310\336\037\000\320\336\037\001\0222\n\npushee_"
-    "txn\030\002 \001(\0132\036.cockroach.roachpb.Transactio"
-    "n\"\214\001\n\024ResolveIntentRequest\022:\n\006header\030\001 \001"
-    "(\0132 .cockroach.roachpb.RequestHeaderB\010\310\336"
-    "\037\000\320\336\037\001\0228\n\nintent_txn\030\002 \001(\0132\036.cockroach.r"
-    "oachpb.TransactionB\004\310\336\037\000\"T\n\025ResolveInten"
-    "tResponse\022;\n\006header\030\001 \001(\0132!.cockroach.ro"
-    "achpb.ResponseHeaderB\010\310\336\037\000\320\336\037\001\"\221\001\n\031Resol"
-    "veIntentRangeRequest\022:\n\006header\030\001 \001(\0132 .c"
-    "ockroach.roachpb.RequestHeaderB\010\310\336\037\000\320\336\037\001"
-    "\0228\n\nintent_txn\030\002 \001(\0132\036.cockroach.roachpb"
-    ".TransactionB\004\310\336\037\000\"K\n\014NoopResponse\022;\n\006he"
-    "ader\030\001 \001(\0132!.cockroach.roachpb.ResponseH"
-    "eaderB\010\310\336\037\000\320\336\037\001\"I\n\013NoopRequest\022:\n\006header"
-    "\030\001 \001(\0132 .cockroach.roachpb.RequestHeader"
-    "B\010\310\336\037\000\320\336\037\001\"Y\n\032ResolveIntentRangeResponse"
-    "\022;\n\006header\030\001 \001(\0132!.cockroach.roachpb.Res"
-    "ponseHeaderB\010\310\336\037\000\320\336\037\001\"y\n\014MergeRequest\022:\n"
-    "\006header\030\001 \001(\0132 .cockroach.roachpb.Reques"
-    "tHeaderB\010\310\336\037\000\320\336\037\001\022-\n\005value\030\002 \001(\0132\030.cockr"
-    "oach.roachpb.ValueB\004\310\336\037\000\"L\n\rMergeRespons"
-    "e\022;\n\006header\030\001 \001(\0132!.cockroach.roachpb.Re"
-    "sponseHeaderB\010\310\336\037\000\320\336\037\001\"e\n\022TruncateLogReq"
-    "uest\022:\n\006header\030\001 \001(\0132 .cockroach.roachpb"
-    ".RequestHeaderB\010\310\336\037\000\320\336\037\001\022\023\n\005index\030\002 \001(\004B"
-    "\004\310\336\037\000\"R\n\023TruncateLogResponse\022;\n\006header\030\001"
-    " \001(\0132!.cockroach.roachpb.ResponseHeaderB"
-    "\010\310\336\037\000\320\336\037\001\"\177\n\022LeaderLeaseRequest\022:\n\006heade"
+    "chpb.ResponseHeaderB\010\310\336\037\000\320\336\037\001\022\031\n\013num_del"
+    "eted\030\002 \001(\003B\004\310\336\037\000\"d\n\013ScanRequest\022:\n\006heade"
     "r\030\001 \001(\0132 .cockroach.roachpb.RequestHeade"
-    "rB\010\310\336\037\000\320\336\037\001\022-\n\005lease\030\002 \001(\0132\030.cockroach.r"
-    "oachpb.LeaseB\004\310\336\037\000\"R\n\023LeaderLeaseRespons"
-    "e\022;\n\006header\030\001 \001(\0132!.cockroach.roachpb.Re"
-    "sponseHeaderB\010\310\336\037\000\320\336\037\001\"\272\t\n\014RequestUnion\022"
-    "*\n\003get\030\001 \001(\0132\035.cockroach.roachpb.GetRequ"
-    "est\022*\n\003put\030\002 \001(\0132\035.cockroach.roachpb.Put"
-    "Request\022A\n\017conditional_put\030\003 \001(\0132(.cockr"
-    "oach.roachpb.ConditionalPutRequest\0226\n\tin"
-    "crement\030\004 \001(\0132#.cockroach.roachpb.Increm"
-    "entRequest\0220\n\006delete\030\005 \001(\0132 .cockroach.r"
-    "oachpb.DeleteRequest\022;\n\014delete_range\030\006 \001"
-    "(\0132%.cockroach.roachpb.DeleteRangeReques"
-    "t\022,\n\004scan\030\007 \001(\0132\036.cockroach.roachpb.Scan"
-    "Request\022A\n\017end_transaction\030\010 \001(\0132(.cockr"
-    "oach.roachpb.EndTransactionRequest\0229\n\013ad"
-    "min_split\030\t \001(\0132$.cockroach.roachpb.Admi"
-    "nSplitRequest\0229\n\013admin_merge\030\n \001(\0132$.coc"
-    "kroach.roachpb.AdminMergeRequest\022=\n\rhear"
-    "tbeat_txn\030\013 \001(\0132&.cockroach.roachpb.Hear"
-    "tbeatTxnRequest\022(\n\002gc\030\014 \001(\0132\034.cockroach."
-    "roachpb.GCRequest\0223\n\010push_txn\030\r \001(\0132!.co"
-    "ckroach.roachpb.PushTxnRequest\022;\n\014range_"
-    "lookup\030\016 \001(\0132%.cockroach.roachpb.RangeLo"
-    "okupRequest\022\?\n\016resolve_intent\030\017 \001(\0132\'.co"
-    "ckroach.roachpb.ResolveIntentRequest\022J\n\024"
-    "resolve_intent_range\030\020 \001(\0132,.cockroach.r"
-    "oachpb.ResolveIntentRangeRequest\022.\n\005merg"
-    "e\030\021 \001(\0132\037.cockroach.roachpb.MergeRequest"
-    "\022;\n\014truncate_log\030\022 \001(\0132%.cockroach.roach"
-    "pb.TruncateLogRequest\022;\n\014leader_lease\030\023 "
-    "\001(\0132%.cockroach.roachpb.LeaderLeaseReque"
-    "st\022;\n\014reverse_scan\030\024 \001(\0132%.cockroach.roa"
-    "chpb.ReverseScanRequest\022,\n\004noop\030\025 \001(\0132\036."
-    "cockroach.roachpb.NoopRequest:\004\310\240\037\001\"\320\t\n\r"
-    "ResponseUnion\022+\n\003get\030\001 \001(\0132\036.cockroach.r"
-    "oachpb.GetResponse\022+\n\003put\030\002 \001(\0132\036.cockro"
-    "ach.roachpb.PutResponse\022B\n\017conditional_p"
-    "ut\030\003 \001(\0132).cockroach.roachpb.Conditional"
-    "PutResponse\0227\n\tincrement\030\004 \001(\0132$.cockroa"
-    "ch.roachpb.IncrementResponse\0221\n\006delete\030\005"
-    " \001(\0132!.cockroach.roachpb.DeleteResponse\022"
-    "<\n\014delete_range\030\006 \001(\0132&.cockroach.roachp"
-    "b.DeleteRangeResponse\022-\n\004scan\030\007 \001(\0132\037.co"
-    "ckroach.roachpb.ScanResponse\022B\n\017end_tran"
-    "saction\030\010 \001(\0132).cockroach.roachpb.EndTra"
-    "nsactionResponse\022:\n\013admin_split\030\t \001(\0132%."
-    "cockroach.roachpb.AdminSplitResponse\022:\n\013"
-    "admin_merge\030\n \001(\0132%.cockroach.roachpb.Ad"
-    "minMergeResponse\022>\n\rheartbeat_txn\030\013 \001(\0132"
-    "\'.cockroach.roachpb.HeartbeatTxnResponse"
-    "\022)\n\002gc\030\014 \001(\0132\035.cockroach.roachpb.GCRespo"
-    "nse\0224\n\010push_txn\030\r \001(\0132\".cockroach.roachp"
-    "b.PushTxnResponse\022<\n\014range_lookup\030\016 \001(\0132"
-    "&.cockroach.roachpb.RangeLookupResponse\022"
-    "@\n\016resolve_intent\030\017 \001(\0132(.cockroach.roac"
-    "hpb.ResolveIntentResponse\022K\n\024resolve_int"
-    "ent_range\030\020 \001(\0132-.cockroach.roachpb.Reso"
-    "lveIntentRangeResponse\022/\n\005merge\030\021 \001(\0132 ."
-    "cockroach.roachpb.MergeResponse\022<\n\014trunc"
-    "ate_log\030\022 \001(\0132&.cockroach.roachpb.Trunca"
-    "teLogResponse\022<\n\014leader_lease\030\023 \001(\0132&.co"
-    "ckroach.roachpb.LeaderLeaseResponse\022<\n\014r"
-    "everse_scan\030\024 \001(\0132&.cockroach.roachpb.Re"
-    "verseScanResponse\022-\n\004noop\030\025 \001(\0132\037.cockro"
-    "ach.roachpb.NoopResponse:\004\310\240\037\001\"\272\004\n\014Batch"
-    "Request\022@\n\006header\030\001 \001(\0132&.cockroach.roac"
-    "hpb.BatchRequest.HeaderB\010\310\336\037\000\320\336\037\001\0227\n\010req"
-    "uests\030\002 \003(\0132\037.cockroach.roachpb.RequestU"
-    "nionB\004\310\336\037\000\032\250\003\n\006Header\0225\n\ttimestamp\030\001 \001(\013"
-    "2\034.cockroach.roachpb.TimestampB\004\310\336\037\000\022=\n\006"
-    "cmd_id\030\002 \001(\0132\036.cockroach.roachpb.ClientC"
-    "mdIDB\r\310\336\037\000\342\336\037\005CmdID\022\024\n\003key\030\003 \001(\014B\007\372\336\037\003Ke"
-    "y\022\030\n\007end_key\030\004 \001(\014B\007\372\336\037\003Key\022;\n\007replica\030\005"
-    " \001(\0132$.cockroach.roachpb.ReplicaDescript"
-    "orB\004\310\336\037\000\022,\n\010range_id\030\006 \001(\003B\032\310\336\037\000\342\336\037\007Rang"
-    "eID\372\336\037\007RangeID\022\030\n\ruser_priority\030\007 \001(\005:\0011"
-    "\022+\n\003txn\030\010 \001(\0132\036.cockroach.roachpb.Transa"
-    "ction\022F\n\020read_consistency\030\t \001(\0162&.cockro"
-    "ach.roachpb.ReadConsistencyTypeB\004\310\336\037\000:\004\230"
-    "\240\037\000\"\245\002\n\rBatchResponse\022A\n\006header\030\001 \001(\0132\'."
-    "cockroach.roachpb.BatchResponse.HeaderB\010"
-    "\310\336\037\000\320\336\037\001\0229\n\tresponses\030\002 \003(\0132 .cockroach."
-    "roachpb.ResponseUnionB\004\310\336\037\000\032\225\001\n\006Header\022\'"
-    "\n\005error\030\001 \001(\0132\030.cockroach.roachpb.Error\022"
-    "5\n\ttimestamp\030\002 \001(\0132\034.cockroach.roachpb.T"
-    "imestampB\004\310\336\037\000\022+\n\003txn\030\003 \001(\0132\036.cockroach."
-    "roachpb.Transaction*L\n\023ReadConsistencyTy"
-    "pe\022\016\n\nCONSISTENT\020\000\022\r\n\tCONSENSUS\020\001\022\020\n\014INC"
-    "ONSISTENT\020\002\032\004\210\243\036\000*G\n\013PushTxnType\022\022\n\016PUSH"
-    "_TIMESTAMP\020\000\022\r\n\tABORT_TXN\020\001\022\017\n\013CLEANUP_T"
-    "XN\020\002\032\004\210\243\036\000B\031Z\007roachpb\340\342\036\001\310\342\036\001\320\342\036\001\220\343\036\000", 9277);
+    "rB\010\310\336\037\000\320\336\037\001\022\031\n\013max_results\030\002 \001(\003B\004\310\336\037\000\"|"
+    "\n\014ScanResponse\022;\n\006header\030\001 \001(\0132!.cockroa"
+    "ch.roachpb.ResponseHeaderB\010\310\336\037\000\320\336\037\001\022/\n\004r"
+    "ows\030\002 \003(\0132\033.cockroach.roachpb.KeyValueB\004"
+    "\310\336\037\000\"k\n\022ReverseScanRequest\022:\n\006header\030\001 \001"
+    "(\0132 .cockroach.roachpb.RequestHeaderB\010\310\336"
+    "\037\000\320\336\037\001\022\031\n\013max_results\030\002 \001(\003B\004\310\336\037\000\"\203\001\n\023Re"
+    "verseScanResponse\022;\n\006header\030\001 \001(\0132!.cock"
+    "roach.roachpb.ResponseHeaderB\010\310\336\037\000\320\336\037\001\022/"
+    "\n\004rows\030\002 \003(\0132\033.cockroach.roachpb.KeyValu"
+    "eB\004\310\336\037\000\"\346\001\n\025EndTransactionRequest\022:\n\006hea"
+    "der\030\001 \001(\0132 .cockroach.roachpb.RequestHea"
+    "derB\010\310\336\037\000\320\336\037\001\022\024\n\006commit\030\002 \001(\010B\004\310\336\037\000\022I\n\027i"
+    "nternal_commit_trigger\030\003 \001(\0132(.cockroach"
+    ".roachpb.InternalCommitTrigger\0220\n\007intent"
+    "s\030\004 \003(\0132\031.cockroach.roachpb.IntentB\004\310\336\037\000"
+    "\"\213\001\n\026EndTransactionResponse\022;\n\006header\030\001 "
+    "\001(\0132!.cockroach.roachpb.ResponseHeaderB\010"
+    "\310\336\037\000\320\336\037\001\022\031\n\013commit_wait\030\002 \001(\003B\004\310\336\037\000\022\031\n\010r"
+    "esolved\030\003 \003(\014B\007\372\336\037\003Key\"k\n\021AdminSplitRequ"
+    "est\022:\n\006header\030\001 \001(\0132 .cockroach.roachpb."
+    "RequestHeaderB\010\310\336\037\000\320\336\037\001\022\032\n\tsplit_key\030\002 \001"
+    "(\014B\007\372\336\037\003Key\"Q\n\022AdminSplitResponse\022;\n\006hea"
+    "der\030\001 \001(\0132!.cockroach.roachpb.ResponseHe"
+    "aderB\010\310\336\037\000\320\336\037\001\"O\n\021AdminMergeRequest\022:\n\006h"
+    "eader\030\001 \001(\0132 .cockroach.roachpb.RequestH"
+    "eaderB\010\310\336\037\000\320\336\037\001\"Q\n\022AdminMergeResponse\022;\n"
+    "\006header\030\001 \001(\0132!.cockroach.roachpb.Respon"
+    "seHeaderB\010\310\336\037\000\320\336\037\001\"\241\001\n\022RangeLookupReques"
+    "t\022:\n\006header\030\001 \001(\0132 .cockroach.roachpb.Re"
+    "questHeaderB\010\310\336\037\000\320\336\037\001\022\030\n\nmax_ranges\030\002 \001("
+    "\005B\004\310\336\037\000\022\036\n\020consider_intents\030\003 \001(\010B\004\310\336\037\000\022"
+    "\025\n\007reverse\030\004 \001(\010B\004\310\336\037\000\"\214\001\n\023RangeLookupRe"
+    "sponse\022;\n\006header\030\001 \001(\0132!.cockroach.roach"
+    "pb.ResponseHeaderB\010\310\336\037\000\320\336\037\001\0228\n\006ranges\030\002 "
+    "\003(\0132\".cockroach.roachpb.RangeDescriptorB"
+    "\004\310\336\037\000\"Q\n\023HeartbeatTxnRequest\022:\n\006header\030\001"
+    " \001(\0132 .cockroach.roachpb.RequestHeaderB\010"
+    "\310\336\037\000\320\336\037\001\"S\n\024HeartbeatTxnResponse\022;\n\006head"
+    "er\030\001 \001(\0132!.cockroach.roachpb.ResponseHea"
+    "derB\010\310\336\037\000\320\336\037\001\"\225\002\n\tGCRequest\022:\n\006header\030\001 "
+    "\001(\0132 .cockroach.roachpb.RequestHeaderB\010\310"
+    "\336\037\000\320\336\037\001\022>\n\007gc_meta\030\002 \001(\0132\035.cockroach.roa"
+    "chpb.GCMetadataB\016\310\336\037\000\342\336\037\006GCMeta\0226\n\004keys\030"
+    "\003 \003(\0132\".cockroach.roachpb.GCRequest.GCKe"
+    "yB\004\310\336\037\000\032T\n\005GCKey\022\024\n\003key\030\001 \001(\014B\007\372\336\037\003Key\0225"
+    "\n\ttimestamp\030\002 \001(\0132\034.cockroach.roachpb.Ti"
+    "mestampB\004\310\336\037\000\"I\n\nGCResponse\022;\n\006header\030\001 "
+    "\001(\0132!.cockroach.roachpb.ResponseHeaderB\010"
+    "\310\336\037\000\320\336\037\001\"\337\002\n\016PushTxnRequest\022:\n\006header\030\001 "
+    "\001(\0132 .cockroach.roachpb.RequestHeaderB\010\310"
+    "\336\037\000\320\336\037\001\0228\n\npusher_txn\030\002 \001(\0132\036.cockroach."
+    "roachpb.TransactionB\004\310\336\037\000\0228\n\npushee_txn\030"
+    "\003 \001(\0132\036.cockroach.roachpb.TransactionB\004\310"
+    "\336\037\000\0223\n\007push_to\030\004 \001(\0132\034.cockroach.roachpb"
+    ".TimestampB\004\310\336\037\000\022/\n\003now\030\005 \001(\0132\034.cockroac"
+    "h.roachpb.TimestampB\004\310\336\037\000\0227\n\tpush_type\030\006"
+    " \001(\0162\036.cockroach.roachpb.PushTxnTypeB\004\310\336"
+    "\037\000\"\202\001\n\017PushTxnResponse\022;\n\006header\030\001 \001(\0132!"
+    ".cockroach.roachpb.ResponseHeaderB\010\310\336\037\000\320"
+    "\336\037\001\0222\n\npushee_txn\030\002 \001(\0132\036.cockroach.roac"
+    "hpb.Transaction\"\214\001\n\024ResolveIntentRequest"
+    "\022:\n\006header\030\001 \001(\0132 .cockroach.roachpb.Req"
+    "uestHeaderB\010\310\336\037\000\320\336\037\001\0228\n\nintent_txn\030\002 \001(\013"
+    "2\036.cockroach.roachpb.TransactionB\004\310\336\037\000\"T"
+    "\n\025ResolveIntentResponse\022;\n\006header\030\001 \001(\0132"
+    "!.cockroach.roachpb.ResponseHeaderB\010\310\336\037\000"
+    "\320\336\037\001\"\221\001\n\031ResolveIntentRangeRequest\022:\n\006he"
+    "ader\030\001 \001(\0132 .cockroach.roachpb.RequestHe"
+    "aderB\010\310\336\037\000\320\336\037\001\0228\n\nintent_txn\030\002 \001(\0132\036.coc"
+    "kroach.roachpb.TransactionB\004\310\336\037\000\"K\n\014Noop"
+    "Response\022;\n\006header\030\001 \001(\0132!.cockroach.roa"
+    "chpb.ResponseHeaderB\010\310\336\037\000\320\336\037\001\"I\n\013NoopReq"
+    "uest\022:\n\006header\030\001 \001(\0132 .cockroach.roachpb"
+    ".RequestHeaderB\010\310\336\037\000\320\336\037\001\"Y\n\032ResolveInten"
+    "tRangeResponse\022;\n\006header\030\001 \001(\0132!.cockroa"
+    "ch.roachpb.ResponseHeaderB\010\310\336\037\000\320\336\037\001\"y\n\014M"
+    "ergeRequest\022:\n\006header\030\001 \001(\0132 .cockroach."
+    "roachpb.RequestHeaderB\010\310\336\037\000\320\336\037\001\022-\n\005value"
+    "\030\002 \001(\0132\030.cockroach.roachpb.ValueB\004\310\336\037\000\"L"
+    "\n\rMergeResponse\022;\n\006header\030\001 \001(\0132!.cockro"
+    "ach.roachpb.ResponseHeaderB\010\310\336\037\000\320\336\037\001\"e\n\022"
+    "TruncateLogRequest\022:\n\006header\030\001 \001(\0132 .coc"
+    "kroach.roachpb.RequestHeaderB\010\310\336\037\000\320\336\037\001\022\023"
+    "\n\005index\030\002 \001(\004B\004\310\336\037\000\"R\n\023TruncateLogRespon"
+    "se\022;\n\006header\030\001 \001(\0132!.cockroach.roachpb.R"
+    "esponseHeaderB\010\310\336\037\000\320\336\037\001\"\177\n\022LeaderLeaseRe"
+    "quest\022:\n\006header\030\001 \001(\0132 .cockroach.roachp"
+    "b.RequestHeaderB\010\310\336\037\000\320\336\037\001\022-\n\005lease\030\002 \001(\013"
+    "2\030.cockroach.roachpb.LeaseB\004\310\336\037\000\"R\n\023Lead"
+    "erLeaseResponse\022;\n\006header\030\001 \001(\0132!.cockro"
+    "ach.roachpb.ResponseHeaderB\010\310\336\037\000\320\336\037\001\"\272\t\n"
+    "\014RequestUnion\022*\n\003get\030\001 \001(\0132\035.cockroach.r"
+    "oachpb.GetRequest\022*\n\003put\030\002 \001(\0132\035.cockroa"
+    "ch.roachpb.PutRequest\022A\n\017conditional_put"
+    "\030\003 \001(\0132(.cockroach.roachpb.ConditionalPu"
+    "tRequest\0226\n\tincrement\030\004 \001(\0132#.cockroach."
+    "roachpb.IncrementRequest\0220\n\006delete\030\005 \001(\013"
+    "2 .cockroach.roachpb.DeleteRequest\022;\n\014de"
+    "lete_range\030\006 \001(\0132%.cockroach.roachpb.Del"
+    "eteRangeRequest\022,\n\004scan\030\007 \001(\0132\036.cockroac"
+    "h.roachpb.ScanRequest\022A\n\017end_transaction"
+    "\030\010 \001(\0132(.cockroach.roachpb.EndTransactio"
+    "nRequest\0229\n\013admin_split\030\t \001(\0132$.cockroac"
+    "h.roachpb.AdminSplitRequest\0229\n\013admin_mer"
+    "ge\030\n \001(\0132$.cockroach.roachpb.AdminMergeR"
+    "equest\022=\n\rheartbeat_txn\030\013 \001(\0132&.cockroac"
+    "h.roachpb.HeartbeatTxnRequest\022(\n\002gc\030\014 \001("
+    "\0132\034.cockroach.roachpb.GCRequest\0223\n\010push_"
+    "txn\030\r \001(\0132!.cockroach.roachpb.PushTxnReq"
+    "uest\022;\n\014range_lookup\030\016 \001(\0132%.cockroach.r"
+    "oachpb.RangeLookupRequest\022\?\n\016resolve_int"
+    "ent\030\017 \001(\0132\'.cockroach.roachpb.ResolveInt"
+    "entRequest\022J\n\024resolve_intent_range\030\020 \001(\013"
+    "2,.cockroach.roachpb.ResolveIntentRangeR"
+    "equest\022.\n\005merge\030\021 \001(\0132\037.cockroach.roachp"
+    "b.MergeRequest\022;\n\014truncate_log\030\022 \001(\0132%.c"
+    "ockroach.roachpb.TruncateLogRequest\022;\n\014l"
+    "eader_lease\030\023 \001(\0132%.cockroach.roachpb.Le"
+    "aderLeaseRequest\022;\n\014reverse_scan\030\024 \001(\0132%"
+    ".cockroach.roachpb.ReverseScanRequest\022,\n"
+    "\004noop\030\025 \001(\0132\036.cockroach.roachpb.NoopRequ"
+    "est:\004\310\240\037\001\"\320\t\n\rResponseUnion\022+\n\003get\030\001 \001(\013"
+    "2\036.cockroach.roachpb.GetResponse\022+\n\003put\030"
+    "\002 \001(\0132\036.cockroach.roachpb.PutResponse\022B\n"
+    "\017conditional_put\030\003 \001(\0132).cockroach.roach"
+    "pb.ConditionalPutResponse\0227\n\tincrement\030\004"
+    " \001(\0132$.cockroach.roachpb.IncrementRespon"
+    "se\0221\n\006delete\030\005 \001(\0132!.cockroach.roachpb.D"
+    "eleteResponse\022<\n\014delete_range\030\006 \001(\0132&.co"
+    "ckroach.roachpb.DeleteRangeResponse\022-\n\004s"
+    "can\030\007 \001(\0132\037.cockroach.roachpb.ScanRespon"
+    "se\022B\n\017end_transaction\030\010 \001(\0132).cockroach."
+    "roachpb.EndTransactionResponse\022:\n\013admin_"
+    "split\030\t \001(\0132%.cockroach.roachpb.AdminSpl"
+    "itResponse\022:\n\013admin_merge\030\n \001(\0132%.cockro"
+    "ach.roachpb.AdminMergeResponse\022>\n\rheartb"
+    "eat_txn\030\013 \001(\0132\'.cockroach.roachpb.Heartb"
+    "eatTxnResponse\022)\n\002gc\030\014 \001(\0132\035.cockroach.r"
+    "oachpb.GCResponse\0224\n\010push_txn\030\r \001(\0132\".co"
+    "ckroach.roachpb.PushTxnResponse\022<\n\014range"
+    "_lookup\030\016 \001(\0132&.cockroach.roachpb.RangeL"
+    "ookupResponse\022@\n\016resolve_intent\030\017 \001(\0132(."
+    "cockroach.roachpb.ResolveIntentResponse\022"
+    "K\n\024resolve_intent_range\030\020 \001(\0132-.cockroac"
+    "h.roachpb.ResolveIntentRangeResponse\022/\n\005"
+    "merge\030\021 \001(\0132 .cockroach.roachpb.MergeRes"
+    "ponse\022<\n\014truncate_log\030\022 \001(\0132&.cockroach."
+    "roachpb.TruncateLogResponse\022<\n\014leader_le"
+    "ase\030\023 \001(\0132&.cockroach.roachpb.LeaderLeas"
+    "eResponse\022<\n\014reverse_scan\030\024 \001(\0132&.cockro"
+    "ach.roachpb.ReverseScanResponse\022-\n\004noop\030"
+    "\025 \001(\0132\037.cockroach.roachpb.NoopResponse:\004"
+    "\310\240\037\001\"\272\004\n\014BatchRequest\022@\n\006header\030\001 \001(\0132&."
+    "cockroach.roachpb.BatchRequest.HeaderB\010\310"
+    "\336\037\000\320\336\037\001\0227\n\010requests\030\002 \003(\0132\037.cockroach.ro"
+    "achpb.RequestUnionB\004\310\336\037\000\032\250\003\n\006Header\0225\n\tt"
+    "imestamp\030\001 \001(\0132\034.cockroach.roachpb.Times"
+    "tampB\004\310\336\037\000\022=\n\006cmd_id\030\002 \001(\0132\036.cockroach.r"
+    "oachpb.ClientCmdIDB\r\310\336\037\000\342\336\037\005CmdID\022\024\n\003key"
+    "\030\003 \001(\014B\007\372\336\037\003Key\022\030\n\007end_key\030\004 \001(\014B\007\372\336\037\003Ke"
+    "y\022;\n\007replica\030\005 \001(\0132$.cockroach.roachpb.R"
+    "eplicaDescriptorB\004\310\336\037\000\022,\n\010range_id\030\006 \001(\003"
+    "B\032\310\336\037\000\342\336\037\007RangeID\372\336\037\007RangeID\022\030\n\ruser_pri"
+    "ority\030\007 \001(\005:\0011\022+\n\003txn\030\010 \001(\0132\036.cockroach."
+    "roachpb.Transaction\022F\n\020read_consistency\030"
+    "\t \001(\0162&.cockroach.roachpb.ReadConsistenc"
+    "yTypeB\004\310\336\037\000:\004\230\240\037\000\"\245\002\n\rBatchResponse\022A\n\006h"
+    "eader\030\001 \001(\0132\'.cockroach.roachpb.BatchRes"
+    "ponse.HeaderB\010\310\336\037\000\320\336\037\001\0229\n\tresponses\030\002 \003("
+    "\0132 .cockroach.roachpb.ResponseUnionB\004\310\336\037"
+    "\000\032\225\001\n\006Header\022\'\n\005error\030\001 \001(\0132\030.cockroach."
+    "roachpb.Error\0225\n\ttimestamp\030\002 \001(\0132\034.cockr"
+    "oach.roachpb.TimestampB\004\310\336\037\000\022+\n\003txn\030\003 \001("
+    "\0132\036.cockroach.roachpb.Transaction*L\n\023Rea"
+    "dConsistencyType\022\016\n\nCONSISTENT\020\000\022\r\n\tCONS"
+    "ENSUS\020\001\022\020\n\014INCONSISTENT\020\002\032\004\210\243\036\000*G\n\013PushT"
+    "xnType\022\022\n\016PUSH_TIMESTAMP\020\000\022\r\n\tABORT_TXN\020"
+    "\001\022\017\n\013CLEANUP_TXN\020\002\032\004\210\243\036\000B\031Z\007roachpb\340\342\036\001\310"
+    "\342\036\001\320\342\036\001\220\343\036\000", 9211);
   ::google::protobuf::MessageFactory::InternalRegisterGeneratedFile(
     "cockroach/roachpb/api.proto", &protobuf_RegisterTypes);
   ClientCmdID::default_instance_ = new ClientCmdID();
@@ -2033,7 +2031,6 @@ void ClientCmdID::clear_random() {
 // ===================================================================
 
 #ifndef _MSC_VER
-const int RequestHeader::kDeprecatedTimestampFieldNumber;
 const int RequestHeader::kCmdIdFieldNumber;
 const int RequestHeader::kKeyFieldNumber;
 const int RequestHeader::kEndKeyFieldNumber;
@@ -2051,7 +2048,6 @@ RequestHeader::RequestHeader()
 }
 
 void RequestHeader::InitAsDefaultInstance() {
-  deprecated_timestamp_ = const_cast< ::cockroach::roachpb::Timestamp*>(&::cockroach::roachpb::Timestamp::default_instance());
   cmd_id_ = const_cast< ::cockroach::roachpb::ClientCmdID*>(&::cockroach::roachpb::ClientCmdID::default_instance());
   replica_ = const_cast< ::cockroach::roachpb::ReplicaDescriptor*>(&::cockroach::roachpb::ReplicaDescriptor::default_instance());
   txn_ = const_cast< ::cockroach::roachpb::Transaction*>(&::cockroach::roachpb::Transaction::default_instance());
@@ -2068,7 +2064,6 @@ RequestHeader::RequestHeader(const RequestHeader& from)
 void RequestHeader::SharedCtor() {
   ::google::protobuf::internal::GetEmptyString();
   _cached_size_ = 0;
-  deprecated_timestamp_ = NULL;
   cmd_id_ = NULL;
   key_.UnsafeSetDefault(&::google::protobuf::internal::GetEmptyStringAlreadyInited());
   end_key_.UnsafeSetDefault(&::google::protobuf::internal::GetEmptyStringAlreadyInited());
@@ -2089,7 +2084,6 @@ void RequestHeader::SharedDtor() {
   key_.DestroyNoArena(&::google::protobuf::internal::GetEmptyStringAlreadyInited());
   end_key_.DestroyNoArena(&::google::protobuf::internal::GetEmptyStringAlreadyInited());
   if (this != default_instance_) {
-    delete deprecated_timestamp_;
     delete cmd_id_;
     delete replica_;
     delete txn_;
@@ -2123,9 +2117,6 @@ RequestHeader* RequestHeader::New(::google::protobuf::Arena* arena) const {
 
 void RequestHeader::Clear() {
   if (_has_bits_[0 / 32] & 255u) {
-    if (has_deprecated_timestamp()) {
-      if (deprecated_timestamp_ != NULL) deprecated_timestamp_->::cockroach::roachpb::Timestamp::Clear();
-    }
     if (has_cmd_id()) {
       if (cmd_id_ != NULL) cmd_id_->::cockroach::roachpb::ClientCmdID::Clear();
     }
@@ -2143,8 +2134,8 @@ void RequestHeader::Clear() {
     if (has_txn()) {
       if (txn_ != NULL) txn_->::cockroach::roachpb::Transaction::Clear();
     }
+    read_consistency_ = 0;
   }
-  read_consistency_ = 0;
   ::memset(_has_bits_, 0, sizeof(_has_bits_));
   if (_internal_metadata_.have_unknown_fields()) {
     mutable_unknown_fields()->Clear();
@@ -2161,22 +2152,9 @@ bool RequestHeader::MergePartialFromCodedStream(
     tag = p.first;
     if (!p.second) goto handle_unusual;
     switch (::google::protobuf::internal::WireFormatLite::GetTagFieldNumber(tag)) {
-      // optional .cockroach.roachpb.Timestamp deprecated_timestamp = 1;
-      case 1: {
-        if (tag == 10) {
-          DO_(::google::protobuf::internal::WireFormatLite::ReadMessageNoVirtual(
-               input, mutable_deprecated_timestamp()));
-        } else {
-          goto handle_unusual;
-        }
-        if (input->ExpectTag(18)) goto parse_cmd_id;
-        break;
-      }
-
       // optional .cockroach.roachpb.ClientCmdID cmd_id = 2;
       case 2: {
         if (tag == 18) {
-         parse_cmd_id:
           DO_(::google::protobuf::internal::WireFormatLite::ReadMessageNoVirtual(
                input, mutable_cmd_id()));
         } else {
@@ -2313,12 +2291,6 @@ failure:
 void RequestHeader::SerializeWithCachedSizes(
     ::google::protobuf::io::CodedOutputStream* output) const {
   // @@protoc_insertion_point(serialize_start:cockroach.roachpb.RequestHeader)
-  // optional .cockroach.roachpb.Timestamp deprecated_timestamp = 1;
-  if (has_deprecated_timestamp()) {
-    ::google::protobuf::internal::WireFormatLite::WriteMessageMaybeToArray(
-      1, *this->deprecated_timestamp_, output);
-  }
-
   // optional .cockroach.roachpb.ClientCmdID cmd_id = 2;
   if (has_cmd_id()) {
     ::google::protobuf::internal::WireFormatLite::WriteMessageMaybeToArray(
@@ -2375,13 +2347,6 @@ void RequestHeader::SerializeWithCachedSizes(
 ::google::protobuf::uint8* RequestHeader::SerializeWithCachedSizesToArray(
     ::google::protobuf::uint8* target) const {
   // @@protoc_insertion_point(serialize_to_array_start:cockroach.roachpb.RequestHeader)
-  // optional .cockroach.roachpb.Timestamp deprecated_timestamp = 1;
-  if (has_deprecated_timestamp()) {
-    target = ::google::protobuf::internal::WireFormatLite::
-      WriteMessageNoVirtualToArray(
-        1, *this->deprecated_timestamp_, target);
-  }
-
   // optional .cockroach.roachpb.ClientCmdID cmd_id = 2;
   if (has_cmd_id()) {
     target = ::google::protobuf::internal::WireFormatLite::
@@ -2445,13 +2410,6 @@ int RequestHeader::ByteSize() const {
   int total_size = 0;
 
   if (_has_bits_[0 / 32] & 255) {
-    // optional .cockroach.roachpb.Timestamp deprecated_timestamp = 1;
-    if (has_deprecated_timestamp()) {
-      total_size += 1 +
-        ::google::protobuf::internal::WireFormatLite::MessageSizeNoVirtual(
-          *this->deprecated_timestamp_);
-    }
-
     // optional .cockroach.roachpb.ClientCmdID cmd_id = 2;
     if (has_cmd_id()) {
       total_size += 1 +
@@ -2501,13 +2459,13 @@ int RequestHeader::ByteSize() const {
           *this->txn_);
     }
 
-  }
-  // optional .cockroach.roachpb.ReadConsistencyType read_consistency = 9;
-  if (has_read_consistency()) {
-    total_size += 1 +
-      ::google::protobuf::internal::WireFormatLite::EnumSize(this->read_consistency());
-  }
+    // optional .cockroach.roachpb.ReadConsistencyType read_consistency = 9;
+    if (has_read_consistency()) {
+      total_size += 1 +
+        ::google::protobuf::internal::WireFormatLite::EnumSize(this->read_consistency());
+    }
 
+  }
   if (_internal_metadata_.have_unknown_fields()) {
     total_size +=
       ::google::protobuf::internal::WireFormat::ComputeUnknownFieldsSize(
@@ -2534,9 +2492,6 @@ void RequestHeader::MergeFrom(const ::google::protobuf::Message& from) {
 void RequestHeader::MergeFrom(const RequestHeader& from) {
   if (GOOGLE_PREDICT_FALSE(&from == this)) MergeFromFail(__LINE__);
   if (from._has_bits_[0 / 32] & (0xffu << (0 % 32))) {
-    if (from.has_deprecated_timestamp()) {
-      mutable_deprecated_timestamp()->::cockroach::roachpb::Timestamp::MergeFrom(from.deprecated_timestamp());
-    }
     if (from.has_cmd_id()) {
       mutable_cmd_id()->::cockroach::roachpb::ClientCmdID::MergeFrom(from.cmd_id());
     }
@@ -2560,8 +2515,6 @@ void RequestHeader::MergeFrom(const RequestHeader& from) {
     if (from.has_txn()) {
       mutable_txn()->::cockroach::roachpb::Transaction::MergeFrom(from.txn());
     }
-  }
-  if (from._has_bits_[8 / 32] & (0xffu << (8 % 32))) {
     if (from.has_read_consistency()) {
       set_read_consistency(from.read_consistency());
     }
@@ -2593,7 +2546,6 @@ void RequestHeader::Swap(RequestHeader* other) {
   InternalSwap(other);
 }
 void RequestHeader::InternalSwap(RequestHeader* other) {
-  std::swap(deprecated_timestamp_, other->deprecated_timestamp_);
   std::swap(cmd_id_, other->cmd_id_);
   key_.Swap(&other->key_);
   end_key_.Swap(&other->end_key_);
@@ -2618,58 +2570,15 @@ void RequestHeader::InternalSwap(RequestHeader* other) {
 #if PROTOBUF_INLINE_NOT_IN_HEADERS
 // RequestHeader
 
-// optional .cockroach.roachpb.Timestamp deprecated_timestamp = 1;
-bool RequestHeader::has_deprecated_timestamp() const {
-  return (_has_bits_[0] & 0x00000001u) != 0;
-}
-void RequestHeader::set_has_deprecated_timestamp() {
-  _has_bits_[0] |= 0x00000001u;
-}
-void RequestHeader::clear_has_deprecated_timestamp() {
-  _has_bits_[0] &= ~0x00000001u;
-}
-void RequestHeader::clear_deprecated_timestamp() {
-  if (deprecated_timestamp_ != NULL) deprecated_timestamp_->::cockroach::roachpb::Timestamp::Clear();
-  clear_has_deprecated_timestamp();
-}
- const ::cockroach::roachpb::Timestamp& RequestHeader::deprecated_timestamp() const {
-  // @@protoc_insertion_point(field_get:cockroach.roachpb.RequestHeader.deprecated_timestamp)
-  return deprecated_timestamp_ != NULL ? *deprecated_timestamp_ : *default_instance_->deprecated_timestamp_;
-}
- ::cockroach::roachpb::Timestamp* RequestHeader::mutable_deprecated_timestamp() {
-  set_has_deprecated_timestamp();
-  if (deprecated_timestamp_ == NULL) {
-    deprecated_timestamp_ = new ::cockroach::roachpb::Timestamp;
-  }
-  // @@protoc_insertion_point(field_mutable:cockroach.roachpb.RequestHeader.deprecated_timestamp)
-  return deprecated_timestamp_;
-}
- ::cockroach::roachpb::Timestamp* RequestHeader::release_deprecated_timestamp() {
-  clear_has_deprecated_timestamp();
-  ::cockroach::roachpb::Timestamp* temp = deprecated_timestamp_;
-  deprecated_timestamp_ = NULL;
-  return temp;
-}
- void RequestHeader::set_allocated_deprecated_timestamp(::cockroach::roachpb::Timestamp* deprecated_timestamp) {
-  delete deprecated_timestamp_;
-  deprecated_timestamp_ = deprecated_timestamp;
-  if (deprecated_timestamp) {
-    set_has_deprecated_timestamp();
-  } else {
-    clear_has_deprecated_timestamp();
-  }
-  // @@protoc_insertion_point(field_set_allocated:cockroach.roachpb.RequestHeader.deprecated_timestamp)
-}
-
 // optional .cockroach.roachpb.ClientCmdID cmd_id = 2;
 bool RequestHeader::has_cmd_id() const {
-  return (_has_bits_[0] & 0x00000002u) != 0;
+  return (_has_bits_[0] & 0x00000001u) != 0;
 }
 void RequestHeader::set_has_cmd_id() {
-  _has_bits_[0] |= 0x00000002u;
+  _has_bits_[0] |= 0x00000001u;
 }
 void RequestHeader::clear_has_cmd_id() {
-  _has_bits_[0] &= ~0x00000002u;
+  _has_bits_[0] &= ~0x00000001u;
 }
 void RequestHeader::clear_cmd_id() {
   if (cmd_id_ != NULL) cmd_id_->::cockroach::roachpb::ClientCmdID::Clear();
@@ -2706,13 +2615,13 @@ void RequestHeader::clear_cmd_id() {
 
 // optional bytes key = 3;
 bool RequestHeader::has_key() const {
-  return (_has_bits_[0] & 0x00000004u) != 0;
+  return (_has_bits_[0] & 0x00000002u) != 0;
 }
 void RequestHeader::set_has_key() {
-  _has_bits_[0] |= 0x00000004u;
+  _has_bits_[0] |= 0x00000002u;
 }
 void RequestHeader::clear_has_key() {
-  _has_bits_[0] &= ~0x00000004u;
+  _has_bits_[0] &= ~0x00000002u;
 }
 void RequestHeader::clear_key() {
   key_.ClearToEmptyNoArena(&::google::protobuf::internal::GetEmptyStringAlreadyInited());
@@ -2759,13 +2668,13 @@ void RequestHeader::clear_key() {
 
 // optional bytes end_key = 4;
 bool RequestHeader::has_end_key() const {
-  return (_has_bits_[0] & 0x00000008u) != 0;
+  return (_has_bits_[0] & 0x00000004u) != 0;
 }
 void RequestHeader::set_has_end_key() {
-  _has_bits_[0] |= 0x00000008u;
+  _has_bits_[0] |= 0x00000004u;
 }
 void RequestHeader::clear_has_end_key() {
-  _has_bits_[0] &= ~0x00000008u;
+  _has_bits_[0] &= ~0x00000004u;
 }
 void RequestHeader::clear_end_key() {
   end_key_.ClearToEmptyNoArena(&::google::protobuf::internal::GetEmptyStringAlreadyInited());
@@ -2812,13 +2721,13 @@ void RequestHeader::clear_end_key() {
 
 // optional .cockroach.roachpb.ReplicaDescriptor replica = 5;
 bool RequestHeader::has_replica() const {
-  return (_has_bits_[0] & 0x00000010u) != 0;
+  return (_has_bits_[0] & 0x00000008u) != 0;
 }
 void RequestHeader::set_has_replica() {
-  _has_bits_[0] |= 0x00000010u;
+  _has_bits_[0] |= 0x00000008u;
 }
 void RequestHeader::clear_has_replica() {
-  _has_bits_[0] &= ~0x00000010u;
+  _has_bits_[0] &= ~0x00000008u;
 }
 void RequestHeader::clear_replica() {
   if (replica_ != NULL) replica_->::cockroach::roachpb::ReplicaDescriptor::Clear();
@@ -2855,13 +2764,13 @@ void RequestHeader::clear_replica() {
 
 // optional int64 range_id = 6;
 bool RequestHeader::has_range_id() const {
-  return (_has_bits_[0] & 0x00000020u) != 0;
+  return (_has_bits_[0] & 0x00000010u) != 0;
 }
 void RequestHeader::set_has_range_id() {
-  _has_bits_[0] |= 0x00000020u;
+  _has_bits_[0] |= 0x00000010u;
 }
 void RequestHeader::clear_has_range_id() {
-  _has_bits_[0] &= ~0x00000020u;
+  _has_bits_[0] &= ~0x00000010u;
 }
 void RequestHeader::clear_range_id() {
   range_id_ = GOOGLE_LONGLONG(0);
@@ -2879,13 +2788,13 @@ void RequestHeader::clear_range_id() {
 
 // optional int32 user_priority = 7 [default = 1];
 bool RequestHeader::has_user_priority() const {
-  return (_has_bits_[0] & 0x00000040u) != 0;
+  return (_has_bits_[0] & 0x00000020u) != 0;
 }
 void RequestHeader::set_has_user_priority() {
-  _has_bits_[0] |= 0x00000040u;
+  _has_bits_[0] |= 0x00000020u;
 }
 void RequestHeader::clear_has_user_priority() {
-  _has_bits_[0] &= ~0x00000040u;
+  _has_bits_[0] &= ~0x00000020u;
 }
 void RequestHeader::clear_user_priority() {
   user_priority_ = 1;
@@ -2903,13 +2812,13 @@ void RequestHeader::clear_user_priority() {
 
 // optional .cockroach.roachpb.Transaction txn = 8;
 bool RequestHeader::has_txn() const {
-  return (_has_bits_[0] & 0x00000080u) != 0;
+  return (_has_bits_[0] & 0x00000040u) != 0;
 }
 void RequestHeader::set_has_txn() {
-  _has_bits_[0] |= 0x00000080u;
+  _has_bits_[0] |= 0x00000040u;
 }
 void RequestHeader::clear_has_txn() {
-  _has_bits_[0] &= ~0x00000080u;
+  _has_bits_[0] &= ~0x00000040u;
 }
 void RequestHeader::clear_txn() {
   if (txn_ != NULL) txn_->::cockroach::roachpb::Transaction::Clear();
@@ -2946,13 +2855,13 @@ void RequestHeader::clear_txn() {
 
 // optional .cockroach.roachpb.ReadConsistencyType read_consistency = 9;
 bool RequestHeader::has_read_consistency() const {
-  return (_has_bits_[0] & 0x00000100u) != 0;
+  return (_has_bits_[0] & 0x00000080u) != 0;
 }
 void RequestHeader::set_has_read_consistency() {
-  _has_bits_[0] |= 0x00000100u;
+  _has_bits_[0] |= 0x00000080u;
 }
 void RequestHeader::clear_has_read_consistency() {
-  _has_bits_[0] &= ~0x00000100u;
+  _has_bits_[0] &= ~0x00000080u;
 }
 void RequestHeader::clear_read_consistency() {
   read_consistency_ = 0;

--- a/storage/engine/rocksdb/cockroach/roachpb/api.pb.h
+++ b/storage/engine/rocksdb/cockroach/roachpb/api.pb.h
@@ -300,14 +300,14 @@ class RequestHeader : public ::google::protobuf::Message {
 
   // accessors -------------------------------------------------------
 
-  // optional .cockroach.roachpb.Timestamp timestamp = 1;
-  bool has_timestamp() const;
-  void clear_timestamp();
-  static const int kTimestampFieldNumber = 1;
-  const ::cockroach::roachpb::Timestamp& timestamp() const;
-  ::cockroach::roachpb::Timestamp* mutable_timestamp();
-  ::cockroach::roachpb::Timestamp* release_timestamp();
-  void set_allocated_timestamp(::cockroach::roachpb::Timestamp* timestamp);
+  // optional .cockroach.roachpb.Timestamp deprecated_timestamp = 1;
+  bool has_deprecated_timestamp() const;
+  void clear_deprecated_timestamp();
+  static const int kDeprecatedTimestampFieldNumber = 1;
+  const ::cockroach::roachpb::Timestamp& deprecated_timestamp() const;
+  ::cockroach::roachpb::Timestamp* mutable_deprecated_timestamp();
+  ::cockroach::roachpb::Timestamp* release_deprecated_timestamp();
+  void set_allocated_deprecated_timestamp(::cockroach::roachpb::Timestamp* deprecated_timestamp);
 
   // optional .cockroach.roachpb.ClientCmdID cmd_id = 2;
   bool has_cmd_id() const;
@@ -383,8 +383,8 @@ class RequestHeader : public ::google::protobuf::Message {
 
   // @@protoc_insertion_point(class_scope:cockroach.roachpb.RequestHeader)
  private:
-  inline void set_has_timestamp();
-  inline void clear_has_timestamp();
+  inline void set_has_deprecated_timestamp();
+  inline void clear_has_deprecated_timestamp();
   inline void set_has_cmd_id();
   inline void clear_has_cmd_id();
   inline void set_has_key();
@@ -405,7 +405,7 @@ class RequestHeader : public ::google::protobuf::Message {
   ::google::protobuf::internal::InternalMetadataWithArena _internal_metadata_;
   ::google::protobuf::uint32 _has_bits_[1];
   mutable int _cached_size_;
-  ::cockroach::roachpb::Timestamp* timestamp_;
+  ::cockroach::roachpb::Timestamp* deprecated_timestamp_;
   ::cockroach::roachpb::ClientCmdID* cmd_id_;
   ::google::protobuf::internal::ArenaStringPtr key_;
   ::google::protobuf::internal::ArenaStringPtr end_key_;
@@ -6097,47 +6097,47 @@ inline void ClientCmdID::set_random(::google::protobuf::int64 value) {
 
 // RequestHeader
 
-// optional .cockroach.roachpb.Timestamp timestamp = 1;
-inline bool RequestHeader::has_timestamp() const {
+// optional .cockroach.roachpb.Timestamp deprecated_timestamp = 1;
+inline bool RequestHeader::has_deprecated_timestamp() const {
   return (_has_bits_[0] & 0x00000001u) != 0;
 }
-inline void RequestHeader::set_has_timestamp() {
+inline void RequestHeader::set_has_deprecated_timestamp() {
   _has_bits_[0] |= 0x00000001u;
 }
-inline void RequestHeader::clear_has_timestamp() {
+inline void RequestHeader::clear_has_deprecated_timestamp() {
   _has_bits_[0] &= ~0x00000001u;
 }
-inline void RequestHeader::clear_timestamp() {
-  if (timestamp_ != NULL) timestamp_->::cockroach::roachpb::Timestamp::Clear();
-  clear_has_timestamp();
+inline void RequestHeader::clear_deprecated_timestamp() {
+  if (deprecated_timestamp_ != NULL) deprecated_timestamp_->::cockroach::roachpb::Timestamp::Clear();
+  clear_has_deprecated_timestamp();
 }
-inline const ::cockroach::roachpb::Timestamp& RequestHeader::timestamp() const {
-  // @@protoc_insertion_point(field_get:cockroach.roachpb.RequestHeader.timestamp)
-  return timestamp_ != NULL ? *timestamp_ : *default_instance_->timestamp_;
+inline const ::cockroach::roachpb::Timestamp& RequestHeader::deprecated_timestamp() const {
+  // @@protoc_insertion_point(field_get:cockroach.roachpb.RequestHeader.deprecated_timestamp)
+  return deprecated_timestamp_ != NULL ? *deprecated_timestamp_ : *default_instance_->deprecated_timestamp_;
 }
-inline ::cockroach::roachpb::Timestamp* RequestHeader::mutable_timestamp() {
-  set_has_timestamp();
-  if (timestamp_ == NULL) {
-    timestamp_ = new ::cockroach::roachpb::Timestamp;
+inline ::cockroach::roachpb::Timestamp* RequestHeader::mutable_deprecated_timestamp() {
+  set_has_deprecated_timestamp();
+  if (deprecated_timestamp_ == NULL) {
+    deprecated_timestamp_ = new ::cockroach::roachpb::Timestamp;
   }
-  // @@protoc_insertion_point(field_mutable:cockroach.roachpb.RequestHeader.timestamp)
-  return timestamp_;
+  // @@protoc_insertion_point(field_mutable:cockroach.roachpb.RequestHeader.deprecated_timestamp)
+  return deprecated_timestamp_;
 }
-inline ::cockroach::roachpb::Timestamp* RequestHeader::release_timestamp() {
-  clear_has_timestamp();
-  ::cockroach::roachpb::Timestamp* temp = timestamp_;
-  timestamp_ = NULL;
+inline ::cockroach::roachpb::Timestamp* RequestHeader::release_deprecated_timestamp() {
+  clear_has_deprecated_timestamp();
+  ::cockroach::roachpb::Timestamp* temp = deprecated_timestamp_;
+  deprecated_timestamp_ = NULL;
   return temp;
 }
-inline void RequestHeader::set_allocated_timestamp(::cockroach::roachpb::Timestamp* timestamp) {
-  delete timestamp_;
-  timestamp_ = timestamp;
-  if (timestamp) {
-    set_has_timestamp();
+inline void RequestHeader::set_allocated_deprecated_timestamp(::cockroach::roachpb::Timestamp* deprecated_timestamp) {
+  delete deprecated_timestamp_;
+  deprecated_timestamp_ = deprecated_timestamp;
+  if (deprecated_timestamp) {
+    set_has_deprecated_timestamp();
   } else {
-    clear_has_timestamp();
+    clear_has_deprecated_timestamp();
   }
-  // @@protoc_insertion_point(field_set_allocated:cockroach.roachpb.RequestHeader.timestamp)
+  // @@protoc_insertion_point(field_set_allocated:cockroach.roachpb.RequestHeader.deprecated_timestamp)
 }
 
 // optional .cockroach.roachpb.ClientCmdID cmd_id = 2;

--- a/storage/engine/rocksdb/cockroach/roachpb/api.pb.h
+++ b/storage/engine/rocksdb/cockroach/roachpb/api.pb.h
@@ -300,15 +300,6 @@ class RequestHeader : public ::google::protobuf::Message {
 
   // accessors -------------------------------------------------------
 
-  // optional .cockroach.roachpb.Timestamp deprecated_timestamp = 1;
-  bool has_deprecated_timestamp() const;
-  void clear_deprecated_timestamp();
-  static const int kDeprecatedTimestampFieldNumber = 1;
-  const ::cockroach::roachpb::Timestamp& deprecated_timestamp() const;
-  ::cockroach::roachpb::Timestamp* mutable_deprecated_timestamp();
-  ::cockroach::roachpb::Timestamp* release_deprecated_timestamp();
-  void set_allocated_deprecated_timestamp(::cockroach::roachpb::Timestamp* deprecated_timestamp);
-
   // optional .cockroach.roachpb.ClientCmdID cmd_id = 2;
   bool has_cmd_id() const;
   void clear_cmd_id();
@@ -383,8 +374,6 @@ class RequestHeader : public ::google::protobuf::Message {
 
   // @@protoc_insertion_point(class_scope:cockroach.roachpb.RequestHeader)
  private:
-  inline void set_has_deprecated_timestamp();
-  inline void clear_has_deprecated_timestamp();
   inline void set_has_cmd_id();
   inline void clear_has_cmd_id();
   inline void set_has_key();
@@ -405,7 +394,6 @@ class RequestHeader : public ::google::protobuf::Message {
   ::google::protobuf::internal::InternalMetadataWithArena _internal_metadata_;
   ::google::protobuf::uint32 _has_bits_[1];
   mutable int _cached_size_;
-  ::cockroach::roachpb::Timestamp* deprecated_timestamp_;
   ::cockroach::roachpb::ClientCmdID* cmd_id_;
   ::google::protobuf::internal::ArenaStringPtr key_;
   ::google::protobuf::internal::ArenaStringPtr end_key_;
@@ -6097,58 +6085,15 @@ inline void ClientCmdID::set_random(::google::protobuf::int64 value) {
 
 // RequestHeader
 
-// optional .cockroach.roachpb.Timestamp deprecated_timestamp = 1;
-inline bool RequestHeader::has_deprecated_timestamp() const {
-  return (_has_bits_[0] & 0x00000001u) != 0;
-}
-inline void RequestHeader::set_has_deprecated_timestamp() {
-  _has_bits_[0] |= 0x00000001u;
-}
-inline void RequestHeader::clear_has_deprecated_timestamp() {
-  _has_bits_[0] &= ~0x00000001u;
-}
-inline void RequestHeader::clear_deprecated_timestamp() {
-  if (deprecated_timestamp_ != NULL) deprecated_timestamp_->::cockroach::roachpb::Timestamp::Clear();
-  clear_has_deprecated_timestamp();
-}
-inline const ::cockroach::roachpb::Timestamp& RequestHeader::deprecated_timestamp() const {
-  // @@protoc_insertion_point(field_get:cockroach.roachpb.RequestHeader.deprecated_timestamp)
-  return deprecated_timestamp_ != NULL ? *deprecated_timestamp_ : *default_instance_->deprecated_timestamp_;
-}
-inline ::cockroach::roachpb::Timestamp* RequestHeader::mutable_deprecated_timestamp() {
-  set_has_deprecated_timestamp();
-  if (deprecated_timestamp_ == NULL) {
-    deprecated_timestamp_ = new ::cockroach::roachpb::Timestamp;
-  }
-  // @@protoc_insertion_point(field_mutable:cockroach.roachpb.RequestHeader.deprecated_timestamp)
-  return deprecated_timestamp_;
-}
-inline ::cockroach::roachpb::Timestamp* RequestHeader::release_deprecated_timestamp() {
-  clear_has_deprecated_timestamp();
-  ::cockroach::roachpb::Timestamp* temp = deprecated_timestamp_;
-  deprecated_timestamp_ = NULL;
-  return temp;
-}
-inline void RequestHeader::set_allocated_deprecated_timestamp(::cockroach::roachpb::Timestamp* deprecated_timestamp) {
-  delete deprecated_timestamp_;
-  deprecated_timestamp_ = deprecated_timestamp;
-  if (deprecated_timestamp) {
-    set_has_deprecated_timestamp();
-  } else {
-    clear_has_deprecated_timestamp();
-  }
-  // @@protoc_insertion_point(field_set_allocated:cockroach.roachpb.RequestHeader.deprecated_timestamp)
-}
-
 // optional .cockroach.roachpb.ClientCmdID cmd_id = 2;
 inline bool RequestHeader::has_cmd_id() const {
-  return (_has_bits_[0] & 0x00000002u) != 0;
+  return (_has_bits_[0] & 0x00000001u) != 0;
 }
 inline void RequestHeader::set_has_cmd_id() {
-  _has_bits_[0] |= 0x00000002u;
+  _has_bits_[0] |= 0x00000001u;
 }
 inline void RequestHeader::clear_has_cmd_id() {
-  _has_bits_[0] &= ~0x00000002u;
+  _has_bits_[0] &= ~0x00000001u;
 }
 inline void RequestHeader::clear_cmd_id() {
   if (cmd_id_ != NULL) cmd_id_->::cockroach::roachpb::ClientCmdID::Clear();
@@ -6185,13 +6130,13 @@ inline void RequestHeader::set_allocated_cmd_id(::cockroach::roachpb::ClientCmdI
 
 // optional bytes key = 3;
 inline bool RequestHeader::has_key() const {
-  return (_has_bits_[0] & 0x00000004u) != 0;
+  return (_has_bits_[0] & 0x00000002u) != 0;
 }
 inline void RequestHeader::set_has_key() {
-  _has_bits_[0] |= 0x00000004u;
+  _has_bits_[0] |= 0x00000002u;
 }
 inline void RequestHeader::clear_has_key() {
-  _has_bits_[0] &= ~0x00000004u;
+  _has_bits_[0] &= ~0x00000002u;
 }
 inline void RequestHeader::clear_key() {
   key_.ClearToEmptyNoArena(&::google::protobuf::internal::GetEmptyStringAlreadyInited());
@@ -6238,13 +6183,13 @@ inline void RequestHeader::set_allocated_key(::std::string* key) {
 
 // optional bytes end_key = 4;
 inline bool RequestHeader::has_end_key() const {
-  return (_has_bits_[0] & 0x00000008u) != 0;
+  return (_has_bits_[0] & 0x00000004u) != 0;
 }
 inline void RequestHeader::set_has_end_key() {
-  _has_bits_[0] |= 0x00000008u;
+  _has_bits_[0] |= 0x00000004u;
 }
 inline void RequestHeader::clear_has_end_key() {
-  _has_bits_[0] &= ~0x00000008u;
+  _has_bits_[0] &= ~0x00000004u;
 }
 inline void RequestHeader::clear_end_key() {
   end_key_.ClearToEmptyNoArena(&::google::protobuf::internal::GetEmptyStringAlreadyInited());
@@ -6291,13 +6236,13 @@ inline void RequestHeader::set_allocated_end_key(::std::string* end_key) {
 
 // optional .cockroach.roachpb.ReplicaDescriptor replica = 5;
 inline bool RequestHeader::has_replica() const {
-  return (_has_bits_[0] & 0x00000010u) != 0;
+  return (_has_bits_[0] & 0x00000008u) != 0;
 }
 inline void RequestHeader::set_has_replica() {
-  _has_bits_[0] |= 0x00000010u;
+  _has_bits_[0] |= 0x00000008u;
 }
 inline void RequestHeader::clear_has_replica() {
-  _has_bits_[0] &= ~0x00000010u;
+  _has_bits_[0] &= ~0x00000008u;
 }
 inline void RequestHeader::clear_replica() {
   if (replica_ != NULL) replica_->::cockroach::roachpb::ReplicaDescriptor::Clear();
@@ -6334,13 +6279,13 @@ inline void RequestHeader::set_allocated_replica(::cockroach::roachpb::ReplicaDe
 
 // optional int64 range_id = 6;
 inline bool RequestHeader::has_range_id() const {
-  return (_has_bits_[0] & 0x00000020u) != 0;
+  return (_has_bits_[0] & 0x00000010u) != 0;
 }
 inline void RequestHeader::set_has_range_id() {
-  _has_bits_[0] |= 0x00000020u;
+  _has_bits_[0] |= 0x00000010u;
 }
 inline void RequestHeader::clear_has_range_id() {
-  _has_bits_[0] &= ~0x00000020u;
+  _has_bits_[0] &= ~0x00000010u;
 }
 inline void RequestHeader::clear_range_id() {
   range_id_ = GOOGLE_LONGLONG(0);
@@ -6358,13 +6303,13 @@ inline void RequestHeader::set_range_id(::google::protobuf::int64 value) {
 
 // optional int32 user_priority = 7 [default = 1];
 inline bool RequestHeader::has_user_priority() const {
-  return (_has_bits_[0] & 0x00000040u) != 0;
+  return (_has_bits_[0] & 0x00000020u) != 0;
 }
 inline void RequestHeader::set_has_user_priority() {
-  _has_bits_[0] |= 0x00000040u;
+  _has_bits_[0] |= 0x00000020u;
 }
 inline void RequestHeader::clear_has_user_priority() {
-  _has_bits_[0] &= ~0x00000040u;
+  _has_bits_[0] &= ~0x00000020u;
 }
 inline void RequestHeader::clear_user_priority() {
   user_priority_ = 1;
@@ -6382,13 +6327,13 @@ inline void RequestHeader::set_user_priority(::google::protobuf::int32 value) {
 
 // optional .cockroach.roachpb.Transaction txn = 8;
 inline bool RequestHeader::has_txn() const {
-  return (_has_bits_[0] & 0x00000080u) != 0;
+  return (_has_bits_[0] & 0x00000040u) != 0;
 }
 inline void RequestHeader::set_has_txn() {
-  _has_bits_[0] |= 0x00000080u;
+  _has_bits_[0] |= 0x00000040u;
 }
 inline void RequestHeader::clear_has_txn() {
-  _has_bits_[0] &= ~0x00000080u;
+  _has_bits_[0] &= ~0x00000040u;
 }
 inline void RequestHeader::clear_txn() {
   if (txn_ != NULL) txn_->::cockroach::roachpb::Transaction::Clear();
@@ -6425,13 +6370,13 @@ inline void RequestHeader::set_allocated_txn(::cockroach::roachpb::Transaction* 
 
 // optional .cockroach.roachpb.ReadConsistencyType read_consistency = 9;
 inline bool RequestHeader::has_read_consistency() const {
-  return (_has_bits_[0] & 0x00000100u) != 0;
+  return (_has_bits_[0] & 0x00000080u) != 0;
 }
 inline void RequestHeader::set_has_read_consistency() {
-  _has_bits_[0] |= 0x00000100u;
+  _has_bits_[0] |= 0x00000080u;
 }
 inline void RequestHeader::clear_has_read_consistency() {
-  _has_bits_[0] &= ~0x00000100u;
+  _has_bits_[0] &= ~0x00000080u;
 }
 inline void RequestHeader::clear_read_consistency() {
   read_consistency_ = 0;

--- a/storage/gc_queue.go
+++ b/storage/gc_queue.go
@@ -142,8 +142,8 @@ func (gcq *gcQueue) process(now roachpb.Timestamp, repl *Replica,
 
 	gcArgs := &roachpb.GCRequest{
 		RequestHeader: roachpb.RequestHeader{
-			Timestamp: now,
-			RangeID:   desc.RangeID,
+			DeprecatedTimestamp: now,
+			RangeID:             desc.RangeID,
 		},
 	}
 	var mu sync.Mutex
@@ -302,8 +302,8 @@ func (gcq *gcQueue) pushTxn(repl *Replica, now roachpb.Timestamp, txn *roachpb.T
 	// Attempt to push the transaction which created the intent.
 	pushArgs := &roachpb.PushTxnRequest{
 		RequestHeader: roachpb.RequestHeader{
-			Timestamp: now,
-			Key:       txn.Key,
+			DeprecatedTimestamp: now,
+			Key:                 txn.Key,
 		},
 		Now:       now,
 		PusherTxn: roachpb.Transaction{Priority: roachpb.MaxPriority},

--- a/storage/gc_queue.go
+++ b/storage/gc_queue.go
@@ -140,10 +140,13 @@ func (gcq *gcQueue) process(now roachpb.Timestamp, repl *Replica,
 	intentExp := now
 	intentExp.WallTime -= intentAgeThreshold.Nanoseconds()
 
+	// TODO(tschottdorf): execution will use a leader-assigned local
+	// timestamp to compute intent age. While this should be fine, could
+	// consider adding a Now timestamp to GCRequest which would be used
+	// instead.
 	gcArgs := &roachpb.GCRequest{
 		RequestHeader: roachpb.RequestHeader{
-			DeprecatedTimestamp: now,
-			RangeID:             desc.RangeID,
+			RangeID: desc.RangeID,
 		},
 	}
 	var mu sync.Mutex
@@ -302,8 +305,7 @@ func (gcq *gcQueue) pushTxn(repl *Replica, now roachpb.Timestamp, txn *roachpb.T
 	// Attempt to push the transaction which created the intent.
 	pushArgs := &roachpb.PushTxnRequest{
 		RequestHeader: roachpb.RequestHeader{
-			DeprecatedTimestamp: now,
-			Key:                 txn.Key,
+			Key: txn.Key,
 		},
 		Now:       now,
 		PusherTxn: roachpb.Transaction{Priority: roachpb.MaxPriority},

--- a/storage/gc_queue_test.go
+++ b/storage/gc_queue_test.go
@@ -198,7 +198,7 @@ func TestGCQueueProcess(t *testing.T) {
 			}
 		} else {
 			pArgs := putArgs(datum.key, []byte("value"), tc.rng.Desc().RangeID, tc.store.StoreID())
-			pArgs.Timestamp = datum.ts
+			pArgs.DeprecatedTimestamp = datum.ts
 			if datum.txn {
 				pArgs.Txn = newTransaction("test", datum.key, 1, roachpb.SERIALIZABLE, tc.clock)
 				pArgs.Txn.OrigTimestamp = datum.ts
@@ -334,7 +334,7 @@ func TestGCQueueIntentResolution(t *testing.T) {
 		// TODO(spencerkimball): benchmark with ~50k.
 		for j := 0; j < 5; j++ {
 			pArgs := putArgs(roachpb.Key(fmt.Sprintf("%d-%05d", i, j)), []byte("value"), tc.rng.Desc().RangeID, tc.store.StoreID())
-			pArgs.Timestamp = makeTS(1, 0)
+			pArgs.DeprecatedTimestamp = makeTS(1, 0)
 			pArgs.Txn = txns[i]
 			if _, err := client.SendWrapped(tc.rng, tc.rng.context(), &pArgs); err != nil {
 				t.Fatalf("%d: could not put data: %s", i, err)

--- a/storage/gc_queue_test.go
+++ b/storage/gc_queue_test.go
@@ -198,7 +198,6 @@ func TestGCQueueProcess(t *testing.T) {
 			}
 		} else {
 			pArgs := putArgs(datum.key, []byte("value"), tc.rng.Desc().RangeID, tc.store.StoreID())
-			pArgs.DeprecatedTimestamp = datum.ts
 			if datum.txn {
 				pArgs.Txn = newTransaction("test", datum.key, 1, roachpb.SERIALIZABLE, tc.clock)
 				pArgs.Txn.OrigTimestamp = datum.ts
@@ -334,7 +333,6 @@ func TestGCQueueIntentResolution(t *testing.T) {
 		// TODO(spencerkimball): benchmark with ~50k.
 		for j := 0; j < 5; j++ {
 			pArgs := putArgs(roachpb.Key(fmt.Sprintf("%d-%05d", i, j)), []byte("value"), tc.rng.Desc().RangeID, tc.store.StoreID())
-			pArgs.DeprecatedTimestamp = makeTS(1, 0)
 			pArgs.Txn = txns[i]
 			if _, err := client.SendWrapped(tc.rng, tc.rng.context(), &pArgs); err != nil {
 				t.Fatalf("%d: could not put data: %s", i, err)

--- a/storage/gc_queue_test.go
+++ b/storage/gc_queue_test.go
@@ -188,13 +188,12 @@ func TestGCQueueProcess(t *testing.T) {
 	for i, datum := range data {
 		if datum.del {
 			dArgs := deleteArgs(datum.key, tc.rng.Desc().RangeID, tc.store.StoreID())
-			dArgs.Timestamp = datum.ts
 			if datum.txn {
 				dArgs.Txn = newTransaction("test", datum.key, 1, roachpb.SERIALIZABLE, tc.clock)
 				dArgs.Txn.OrigTimestamp = datum.ts
 				dArgs.Txn.Timestamp = datum.ts
 			}
-			if _, err := client.SendWrapped(tc.rng, tc.rng.context(), &dArgs); err != nil {
+			if _, err := client.SendWrappedAt(tc.rng, tc.rng.context(), datum.ts, &dArgs); err != nil {
 				t.Fatalf("%d: could not delete data: %s", i, err)
 			}
 		} else {
@@ -205,7 +204,7 @@ func TestGCQueueProcess(t *testing.T) {
 				pArgs.Txn.OrigTimestamp = datum.ts
 				pArgs.Txn.Timestamp = datum.ts
 			}
-			if _, err := client.SendWrapped(tc.rng, tc.rng.context(), &pArgs); err != nil {
+			if _, err := client.SendWrappedAt(tc.rng, tc.rng.context(), datum.ts, &pArgs); err != nil {
 				t.Fatalf("%d: could not put data: %s", i, err)
 			}
 		}

--- a/storage/queue.go
+++ b/storage/queue.go
@@ -348,8 +348,8 @@ func (bq *baseQueue) processOne(clock *hlc.Clock) {
 	// and renew or acquire if necessary.
 	if bq.impl.needsLeaderLease() {
 		// Create a "fake" get request in order to invoke redirectOnOrAcquireLease.
-		args := &roachpb.GetRequest{RequestHeader: roachpb.RequestHeader{Timestamp: now}}
-		if err := repl.redirectOnOrAcquireLeaderLease(nil /* Trace */, args.Header().Timestamp); err != nil {
+		args := &roachpb.GetRequest{RequestHeader: roachpb.RequestHeader{DeprecatedTimestamp: now}}
+		if err := repl.redirectOnOrAcquireLeaderLease(nil /* Trace */, args.Header().DeprecatedTimestamp); err != nil {
 			if log.V(3) {
 				log.Infof("this replica of %s could not acquire leader lease; skipping...", repl)
 			}

--- a/storage/queue.go
+++ b/storage/queue.go
@@ -348,8 +348,7 @@ func (bq *baseQueue) processOne(clock *hlc.Clock) {
 	// and renew or acquire if necessary.
 	if bq.impl.needsLeaderLease() {
 		// Create a "fake" get request in order to invoke redirectOnOrAcquireLease.
-		args := &roachpb.GetRequest{RequestHeader: roachpb.RequestHeader{DeprecatedTimestamp: now}}
-		if err := repl.redirectOnOrAcquireLeaderLease(nil /* Trace */, args.Header().DeprecatedTimestamp); err != nil {
+		if err := repl.redirectOnOrAcquireLeaderLease(nil /* Trace */, now); err != nil {
 			if log.V(3) {
 				log.Infof("this replica of %s could not acquire leader lease; skipping...", repl)
 			}

--- a/storage/replica.go
+++ b/storage/replica.go
@@ -554,7 +554,7 @@ func setBatchTimestamps(ba roachpb.BatchRequest) {
 		// iteration, bumping up its priority. Unfortunately PushTxn is flagged
 		// as a write command (is it really?). Interim solution.
 		if args := union.GetInner(); args.Method() != roachpb.PushTxn {
-			args.Header().Timestamp.Forward(ba.Timestamp.Add(0, int32(i)))
+			args.Header().Timestamp = ba.Timestamp.Add(0, int32(i))
 		}
 	}
 }

--- a/storage/replica.go
+++ b/storage/replica.go
@@ -1155,7 +1155,7 @@ func (r *Replica) executeBatch(batch engine.Engine, ms *engine.MVCCStats, ba *ro
 			header.Key, header.EndKey = origHeader.Key, origHeader.EndKey
 		}
 		// Set the timestamp for this request.
-		ts := args.Header().DeprecatedTimestamp
+		ts := ba.Timestamp
 		{
 			// TODO(tschottdorf): Special exception because of pending
 			// self-overlap discussion.

--- a/storage/replica.go
+++ b/storage/replica.go
@@ -24,7 +24,6 @@ import (
 	"bytes"
 	"crypto/sha1"
 	"fmt"
-	"math"
 	"math/rand"
 	"sync"
 	"sync/atomic"
@@ -1183,12 +1182,10 @@ func (r *Replica) executeBatch(batch engine.Engine, ms *engine.MVCCStats, ba *ro
 		}
 
 		args.Header().Txn = ba.Txn // use latest Txn
-		// Poison the timestamp which still remains in the header. We must not use it.
-		args.Header().DeprecatedTimestamp = roachpb.Timestamp{WallTime: math.MaxInt64}
 
 		reply, curIntents, err := r.executeCmd(batch, ms, ts, args)
 		{
-			// Undo any changes (in particular the poisoned timestamp).
+			// Undo any changes to the header.
 			*args.Header() = origHeader
 		}
 

--- a/storage/replica.go
+++ b/storage/replica.go
@@ -568,11 +568,6 @@ func setBatchTimestamps(ba roachpb.BatchRequest) {
 func (r *Replica) Send(ctx context.Context, ba roachpb.BatchRequest) (*roachpb.BatchResponse, *roachpb.Error) {
 	var br *roachpb.BatchResponse
 	var err error
-	// Fiddle with the timestamps to make sure that writes can overlap
-	// within this batch.
-	// TODO(tschottdorf): provisional feature to get back to passing tests.
-	// Have to discuss how we go about it.
-	setBatchTimestamps(ba)
 
 	if err := r.checkBatchRequest(ba); err != nil {
 		return nil, roachpb.NewError(err)
@@ -1154,6 +1149,11 @@ func (r *Replica) executeBatch(batch engine.Engine, ms *engine.MVCCStats, ba *ro
 	// accumulate updates to it.
 	isTxn := ba.Txn != nil
 
+	// Fiddle with the timestamps to make sure that writes can overlap
+	// within this batch.
+	// TODO(tschottdorf): provisional feature to get back to passing tests.
+	// Have to discuss how we go about it.
+	setBatchTimestamps(*ba)
 	// TODO(tschottdorf): provisionals ahead. This loop needs to execute each
 	// command and propagate txn and timestamp to the next (and, eventually,
 	// to the batch response header). We're currently in an intermediate stage

--- a/storage/replica.go
+++ b/storage/replica.go
@@ -1190,7 +1190,8 @@ func (r *Replica) executeBatch(batch engine.Engine, ms *engine.MVCCStats, ba *ro
 			header.Txn = ba.Txn // use latest Txn
 		}
 
-		reply, curIntents, err := r.executeCmd(batch, ms, args)
+		ts := header.Timestamp
+		reply, curIntents, err := r.executeCmd(batch, ms, ts, args)
 
 		// Collect intents skipped over the course of execution.
 		if len(curIntents) > 0 {
@@ -1205,7 +1206,7 @@ func (r *Replica) executeBatch(batch engine.Engine, ms *engine.MVCCStats, ba *ro
 		}
 
 		// Add the response to the batch, updating the timestamp.
-		br.Timestamp.Forward(header.Timestamp)
+		br.Timestamp.Forward(ts)
 		br.Add(reply)
 		if isTxn {
 			if txn := reply.Header().Txn; txn != nil {

--- a/storage/replica.go
+++ b/storage/replica.go
@@ -1179,7 +1179,7 @@ func (r *Replica) executeBatch(batch engine.Engine, ms *engine.MVCCStats, ba *ro
 			if delta > 0 && args.Method() != roachpb.PushTxn {
 				ts = ba.Timestamp.Add(0, int32(index))
 			} else if !isTxn {
-				ts = origHeader.Timestamp
+				ts = ba.Timestamp
 			} else {
 				// TODO(tschottdorf): should really replace here and assert that
 				// header.Timestamp is empty, but, alas, not the case at the

--- a/storage/replica_test.go
+++ b/storage/replica_test.go
@@ -305,7 +305,6 @@ func TestRangeReadConsistency(t *testing.T) {
 	tc.rng.setDescWithoutProcessUpdate(rngDesc)
 
 	gArgs := getArgs(roachpb.Key("a"), 1, tc.store.StoreID())
-	gArgs.DeprecatedTimestamp = tc.clock.Now()
 
 	// Try consistent read and verify success.
 
@@ -381,7 +380,6 @@ func TestApplyCmdLeaseError(t *testing.T) {
 	ba.Timestamp = tc.clock.Now()
 	pArgs := putArgs(roachpb.Key("a"), []byte("asd"),
 		tc.rng.Desc().RangeID, tc.store.StoreID())
-	pArgs.DeprecatedTimestamp = ba.Timestamp
 	ba.Add(&pArgs)
 
 	// Lose the lease.
@@ -513,10 +511,9 @@ func TestRangeNotLeaderError(t *testing.T) {
 	})
 
 	header := roachpb.RequestHeader{
-		Key:                 roachpb.Key("a"),
-		RangeID:             tc.rng.Desc().RangeID,
-		Replica:             roachpb.ReplicaDescriptor{StoreID: tc.store.StoreID()},
-		DeprecatedTimestamp: now,
+		Key:     roachpb.Key("a"),
+		RangeID: tc.rng.Desc().RangeID,
+		Replica: roachpb.ReplicaDescriptor{StoreID: tc.store.StoreID()},
 	}
 	testCases := []roachpb.Request{
 		// Admin split covers admin commands.
@@ -538,7 +535,7 @@ func TestRangeNotLeaderError(t *testing.T) {
 	}
 
 	for i, test := range testCases {
-		_, err := client.SendWrapped(tc.rng, tc.rng.context(), test)
+		_, err := client.SendWrappedAt(tc.rng, tc.rng.context(), now, test)
 
 		if _, ok := err.(*roachpb.NotLeaderError); !ok {
 			t.Errorf("%d: expected not leader error: %s", i, err)
@@ -816,20 +813,17 @@ func TestRangeNoGossipFromNonLeader(t *testing.T) {
 	txn := newTransaction("test", key, 1 /* userPriority */, roachpb.SERIALIZABLE, tc.clock)
 	req1 := putArgs(key, nil, rangeID, tc.store.StoreID())
 	req1.Txn = txn
-	req1.DeprecatedTimestamp = txn.Timestamp
 	if _, err := client.SendWrapped(tc.store, nil, &req1); err != nil {
 		t.Fatal(err)
 	}
 	req2 := endTxnArgs(txn, true /* commit */, rangeID, tc.store.StoreID())
-	req2.DeprecatedTimestamp = txn.Timestamp
 	req2.Intents = []roachpb.Intent{{Key: key}}
 	if _, err := client.SendWrapped(tc.store, nil, &req2); err != nil {
 		t.Fatal(err)
 	}
 	// Execute a get to resolve the intent.
 	req3 := getArgs(key, rangeID, tc.store.StoreID())
-	req3.DeprecatedTimestamp = txn.Timestamp
-	if _, err := client.SendWrapped(tc.store, nil, &req3); err != nil {
+	if _, err := client.SendWrappedAt(tc.store, nil, txn.Timestamp, &req3); err != nil {
 		t.Fatal(err)
 	}
 
@@ -871,10 +865,9 @@ func getArgs(key []byte, rangeID roachpb.RangeID, storeID roachpb.StoreID) roach
 func putArgs(key, value []byte, rangeID roachpb.RangeID, storeID roachpb.StoreID) roachpb.PutRequest {
 	return roachpb.PutRequest{
 		RequestHeader: roachpb.RequestHeader{
-			Key:                 key,
-			DeprecatedTimestamp: roachpb.MinTimestamp,
-			RangeID:             rangeID,
-			Replica:             roachpb.ReplicaDescriptor{StoreID: storeID},
+			Key:     key,
+			RangeID: rangeID,
+			Replica: roachpb.ReplicaDescriptor{StoreID: storeID},
 		},
 		Value: roachpb.Value{
 			Bytes: value,
@@ -1063,9 +1056,9 @@ func TestRangeUpdateTSCache(t *testing.T) {
 	t0 := 1 * time.Second
 	tc.manualClock.Set(t0.Nanoseconds())
 	gArgs := getArgs([]byte("a"), 1, tc.store.StoreID())
-	gArgs.DeprecatedTimestamp = tc.clock.Now()
+	ts := tc.clock.Now()
 
-	_, err := client.SendWrapped(tc.rng, tc.rng.context(), &gArgs)
+	_, err := client.SendWrappedAt(tc.rng, tc.rng.context(), ts, &gArgs)
 
 	if err != nil {
 		t.Error(err)
@@ -1074,9 +1067,9 @@ func TestRangeUpdateTSCache(t *testing.T) {
 	t1 := 2 * time.Second
 	tc.manualClock.Set(t1.Nanoseconds())
 	pArgs := putArgs([]byte("b"), []byte("1"), 1, tc.store.StoreID())
-	pArgs.DeprecatedTimestamp = tc.clock.Now()
+	ts = tc.clock.Now()
 
-	_, err = client.SendWrapped(tc.rng, tc.rng.context(), &pArgs)
+	_, err = client.SendWrappedAt(tc.rng, tc.rng.context(), ts, &pArgs)
 
 	if err != nil {
 		t.Error(err)
@@ -1293,7 +1286,6 @@ func TestRangeUseTSCache(t *testing.T) {
 	t0 := 1 * time.Second
 	tc.manualClock.Set(t0.Nanoseconds())
 	args := getArgs([]byte("a"), 1, tc.store.StoreID())
-	args.DeprecatedTimestamp = tc.clock.Now()
 
 	_, err := client.SendWrapped(tc.rng, tc.rng.context(), &args)
 
@@ -1359,7 +1351,6 @@ func TestRangeNoTSCacheUpdateOnFailure(t *testing.T) {
 		// Start by laying down an intent to trip up future read or write to same key.
 		pArgs := putArgs(key, []byte("value"), 1, tc.store.StoreID())
 		pArgs.Txn = newTransaction("test", key, 1, roachpb.SERIALIZABLE, tc.clock)
-		pArgs.DeprecatedTimestamp = pArgs.Txn.Timestamp
 
 		reply, err := client.SendWrapped(tc.rng, tc.rng.context(), &pArgs)
 		if err != nil {
@@ -1369,9 +1360,9 @@ func TestRangeNoTSCacheUpdateOnFailure(t *testing.T) {
 
 		// Now attempt read or write.
 		args := readOrWriteArgs(key, read, tc.rng.Desc().RangeID, tc.store.StoreID())
-		args.Header().DeprecatedTimestamp = tc.clock.Now() // later timestamp
+		ts := tc.clock.Now() // later timestamp
 
-		if _, err := client.SendWrapped(tc.rng, tc.rng.context(), args); err == nil {
+		if _, err := client.SendWrappedAt(tc.rng, tc.rng.context(), ts, args); err == nil {
 			t.Errorf("test %d: expected failure", i)
 		}
 
@@ -1380,8 +1371,8 @@ func TestRangeNoTSCacheUpdateOnFailure(t *testing.T) {
 		if _, err := client.SendWrapped(tc.rng, tc.rng.context(), &pArgs); err != nil {
 			t.Fatalf("test %d: %s", i, err)
 		}
-		if !pReply.Timestamp.Equal(pArgs.DeprecatedTimestamp) {
-			t.Errorf("expected timestamp not to advance %s != %s", pReply.Timestamp, pArgs.DeprecatedTimestamp)
+		if !pReply.Timestamp.Equal(pArgs.Txn.Timestamp) {
+			t.Errorf("expected timestamp not to advance %s != %s", pReply.Timestamp, pArgs.Txn.Timestamp)
 		}
 	}
 }
@@ -1416,8 +1407,8 @@ func TestRangeNoTimestampIncrementWithinTxn(t *testing.T) {
 		t.Fatal(err)
 	}
 	pReply := reply.(*roachpb.PutResponse)
-	if !pReply.Timestamp.Equal(pArgs.DeprecatedTimestamp) {
-		t.Errorf("expected timestamp to remain %s; got %s", pArgs.DeprecatedTimestamp, pReply.Timestamp)
+	if !pReply.Timestamp.Equal(pArgs.Txn.Timestamp) {
+		t.Errorf("expected timestamp to remain %s; got %s", pArgs.Txn.Timestamp, pReply.Timestamp)
 	}
 
 	// Resolve the intent.
@@ -1461,13 +1452,13 @@ func TestRangeIdempotence(t *testing.T) {
 	incFunc := func(idx int) {
 		defer wg.Done()
 		args := incrementArgs([]byte("a"), 1, 1, tc.store.StoreID())
-		args.Header().DeprecatedTimestamp = tc.clock.Now()
+		ts := tc.clock.Now()
 		if idx%2 == 0 {
 			args.CmdID = roachpb.ClientCmdID{WallTime: 1, Random: 1}
 		} else {
 			args.CmdID = roachpb.ClientCmdID{WallTime: 1, Random: int64(idx + 100)}
 		}
-		resp, err := client.SendWrapped(tc.rng, tc.rng.context(), &args)
+		resp, err := client.SendWrappedAt(tc.rng, tc.rng.context(), ts, &args)
 		reply := resp.(*roachpb.IncrementResponse)
 		if err != nil {
 			t.Fatal(err)
@@ -1574,7 +1565,6 @@ func TestEndTransactionWithMalformedSplitTrigger(t *testing.T) {
 	}
 
 	args := endTxnArgs(txn, true /* commit */, 1, tc.store.StoreID())
-	args.DeprecatedTimestamp = txn.Timestamp
 	// Make an EndTransaction request which would fail if not
 	// stripped. In this case, we set the start key to "bar" for a
 	// split of the default range; start key must be "" in this case.
@@ -1605,7 +1595,6 @@ func TestEndTransactionBeforeHeartbeat(t *testing.T) {
 	for _, commit := range []bool{true, false} {
 		txn := newTransaction("test", key, 1, roachpb.SERIALIZABLE, tc.clock)
 		args := endTxnArgs(txn, commit, 1, tc.store.StoreID())
-		args.DeprecatedTimestamp = txn.Timestamp
 
 		resp, err := client.SendWrapped(tc.rng, tc.rng.context(), &args)
 		if err != nil {
@@ -1649,7 +1638,6 @@ func TestEndTransactionAfterHeartbeat(t *testing.T) {
 
 		// Start out with a heartbeat to the transaction.
 		hBA := heartbeatArgs(txn, 1, tc.store.StoreID())
-		hBA.DeprecatedTimestamp = txn.Timestamp
 
 		resp, err := client.SendWrapped(tc.rng, tc.rng.context(), &hBA)
 		if err != nil {
@@ -1661,7 +1649,6 @@ func TestEndTransactionAfterHeartbeat(t *testing.T) {
 		}
 
 		args := endTxnArgs(txn, commit, 1, tc.store.StoreID())
-		args.DeprecatedTimestamp = txn.Timestamp
 
 		resp, err = client.SendWrapped(tc.rng, tc.rng.context(), &args)
 		if err != nil {
@@ -1753,7 +1740,6 @@ func TestEndTransactionWithIncrementedEpoch(t *testing.T) {
 
 	// Start out with a heartbeat to the transaction.
 	hBA := heartbeatArgs(txn, 1, tc.store.StoreID())
-	hBA.DeprecatedTimestamp = txn.Timestamp
 
 	_, err := client.SendWrapped(tc.rng, tc.rng.context(), &hBA)
 	if err != nil {
@@ -1762,7 +1748,6 @@ func TestEndTransactionWithIncrementedEpoch(t *testing.T) {
 
 	// Now end the txn with increased epoch and priority.
 	args := endTxnArgs(txn, true, 1, tc.store.StoreID())
-	args.DeprecatedTimestamp = txn.Timestamp
 	args.Txn.Epoch = txn.Epoch + 1
 	args.Txn.Priority = txn.Priority + 1
 
@@ -1824,7 +1809,6 @@ func TestEndTransactionWithErrors(t *testing.T) {
 		// End the transaction, verify expected error.
 		txn.Key = test.key
 		args := endTxnArgs(txn, true, 1, tc.store.StoreID())
-		args.DeprecatedTimestamp = txn.Timestamp
 
 		if _, err := client.SendWrapped(tc.rng, tc.rng.context(), &args); !testutils.IsError(err, test.expErrRegexp) {
 			t.Errorf("expected %s to match %s", err, test.expErrRegexp)
@@ -1861,7 +1845,6 @@ func TestEndTransactionGC(t *testing.T) {
 	} {
 		txn := newTransaction("test", roachpb.Key("a"), 1, roachpb.SERIALIZABLE, tc.clock)
 		args := endTxnArgs(txn, true, 1, tc.store.StoreID())
-		args.DeprecatedTimestamp = txn.Timestamp
 		args.Intents = test.intents
 		if _, err := client.SendWrapped(tc.rng, tc.rng.context(), &args); err != nil {
 			t.Fatal(err)
@@ -1914,7 +1897,6 @@ func TestEndTransactionResolveOnlyLocalIntents(t *testing.T) {
 
 	// End the transaction and resolve the intents.
 	args := endTxnArgs(txn, true /* commit */, 1, tc.store.StoreID())
-	args.DeprecatedTimestamp = txn.Timestamp
 	args.Intents = []roachpb.Intent{{Key: key, EndKey: splitKey.Next()}}
 	if _, err := client.SendWrapped(tc.rng, tc.rng.context(), &args); err != nil {
 		t.Fatal(err)
@@ -1969,7 +1951,6 @@ func TestPushTxnAlreadyCommittedOrAborted(t *testing.T) {
 
 		// End the pushee's transaction.
 		etArgs := endTxnArgs(pushee, status == roachpb.COMMITTED, 1, tc.store.StoreID())
-		etArgs.DeprecatedTimestamp = pushee.Timestamp
 
 		if _, err := client.SendWrapped(tc.rng, tc.rng.context(), &etArgs); err != nil {
 			t.Fatal(err)
@@ -2030,7 +2011,6 @@ func TestPushTxnUpgradeExistingTxn(t *testing.T) {
 		pushee.Epoch = test.startEpoch
 		pushee.Timestamp = test.startTS
 		hBA := heartbeatArgs(pushee, 1, tc.store.StoreID())
-		hBA.DeprecatedTimestamp = pushee.Timestamp
 
 		if _, err := client.SendWrapped(tc.rng, tc.rng.context(), &hBA); err != nil {
 			t.Fatal(err)
@@ -2332,7 +2312,6 @@ func TestRangeStatsComputation(t *testing.T) {
 
 	// Put a value.
 	pArgs := putArgs([]byte("a"), []byte("value1"), 1, tc.store.StoreID())
-	pArgs.DeprecatedTimestamp = tc.clock.Now()
 
 	if _, err := client.SendWrapped(tc.rng, tc.rng.context(), &pArgs); err != nil {
 		t.Fatal(err)
@@ -2342,8 +2321,7 @@ func TestRangeStatsComputation(t *testing.T) {
 
 	// Put a 2nd value transactionally.
 	pArgs = putArgs([]byte("b"), []byte("value2"), 1, tc.store.StoreID())
-	pArgs.DeprecatedTimestamp = tc.clock.Now()
-	pArgs.Txn = &roachpb.Transaction{ID: uuid.NewUUID4(), Timestamp: pArgs.DeprecatedTimestamp}
+	pArgs.Txn = &roachpb.Transaction{ID: uuid.NewUUID4(), Timestamp: tc.clock.Now()}
 
 	if _, err := client.SendWrapped(tc.rng, tc.rng.context(), &pArgs); err != nil {
 		t.Fatal(err)
@@ -2370,7 +2348,6 @@ func TestRangeStatsComputation(t *testing.T) {
 
 	// Delete the 1st value.
 	dArgs := deleteArgs([]byte("a"), 1, tc.store.StoreID())
-	dArgs.DeprecatedTimestamp = tc.clock.Now()
 
 	if _, err := client.SendWrapped(tc.rng, tc.rng.context(), &dArgs); err != nil {
 		t.Fatal(err)
@@ -2534,10 +2511,9 @@ func TestConditionFailedError(t *testing.T) {
 	}
 	args := roachpb.ConditionalPutRequest{
 		RequestHeader: roachpb.RequestHeader{
-			Key:                 key,
-			DeprecatedTimestamp: roachpb.MinTimestamp,
-			RangeID:             1,
-			Replica:             roachpb.ReplicaDescriptor{StoreID: tc.store.StoreID()},
+			Key:     key,
+			RangeID: 1,
+			Replica: roachpb.ReplicaDescriptor{StoreID: tc.store.StoreID()},
 		},
 		Value: roachpb.Value{
 			Bytes: value,
@@ -2547,7 +2523,7 @@ func TestConditionFailedError(t *testing.T) {
 		},
 	}
 
-	_, err := client.SendWrapped(tc.rng, tc.rng.context(), &args)
+	_, err := client.SendWrappedAt(tc.rng, tc.rng.context(), roachpb.MinTimestamp, &args)
 
 	if cErr, ok := err.(*roachpb.ConditionFailedError); err == nil || !ok {
 		t.Fatalf("expected ConditionFailedError, got %T with content %+v",
@@ -2720,7 +2696,6 @@ func testRangeDanglingMetaIntent(t *testing.T, isReverse bool) {
 	}
 	pArgs := putArgs(keys.RangeMetaKey(key), data, 1, tc.store.StoreID())
 	pArgs.Txn = newTransaction("test", key, 1, roachpb.SERIALIZABLE, tc.clock)
-	pArgs.DeprecatedTimestamp = pArgs.Txn.Timestamp
 
 	if _, err := client.SendWrapped(tc.rng, tc.rng.context(), &pArgs); err != nil {
 		t.Fatal(err)
@@ -2729,9 +2704,8 @@ func testRangeDanglingMetaIntent(t *testing.T, isReverse bool) {
 	// Now lookup the range; should get the value. Since the lookup is
 	// inconsistent, there's no WriteIntentErorr.
 	rlArgs.Key = keys.RangeMetaKey(roachpb.Key("A"))
-	rlArgs.DeprecatedTimestamp = roachpb.ZeroTimestamp
 
-	reply, err = client.SendWrapped(tc.rng, tc.rng.context(), rlArgs)
+	reply, err = client.SendWrappedAt(tc.rng, tc.rng.context(), roachpb.MinTimestamp, rlArgs)
 	if err != nil {
 		t.Errorf("unexpected lookup error: %s", err)
 	}
@@ -2762,7 +2736,6 @@ func testRangeDanglingMetaIntent(t *testing.T, isReverse bool) {
 
 	for i := 0; i < count && !(origSeen && newSeen); i++ {
 		clonedRLArgs := proto.Clone(rlArgs).(*roachpb.RangeLookupRequest)
-		clonedRLArgs.DeprecatedTimestamp = roachpb.ZeroTimestamp
 
 		reply, err = client.SendWrapped(tc.rng, tc.rng.context(), clonedRLArgs)
 		if err != nil {
@@ -2868,7 +2841,6 @@ func TestRangeLookupUseReverseScan(t *testing.T) {
 	// Test ReverseScan without intents.
 	for _, c := range testCases {
 		clonedRLArgs := proto.Clone(rlArgs).(*roachpb.RangeLookupRequest)
-		clonedRLArgs.DeprecatedTimestamp = roachpb.ZeroTimestamp
 		clonedRLArgs.Key = keys.RangeMetaKey(roachpb.Key(c.key))
 		reply, err := client.SendWrapped(tc.rng, tc.rng.context(), clonedRLArgs)
 		if err != nil {
@@ -2889,7 +2861,6 @@ func TestRangeLookupUseReverseScan(t *testing.T) {
 	}
 	pArgs := putArgs(keys.RangeMetaKey(intentRange.EndKey), data, 1, tc.store.StoreID())
 	pArgs.Txn = &roachpb.Transaction{ID: uuid.NewUUID4(), Timestamp: tc.clock.Now()}
-	pArgs.DeprecatedTimestamp = pArgs.Txn.Timestamp
 	if _, err := client.SendWrapped(tc.rng, tc.rng.context(), &pArgs); err != nil {
 		t.Fatal(err)
 	}
@@ -2897,7 +2868,6 @@ func TestRangeLookupUseReverseScan(t *testing.T) {
 	// Test ReverseScan with intents.
 	for _, c := range testCases {
 		clonedRLArgs := proto.Clone(rlArgs).(*roachpb.RangeLookupRequest)
-		clonedRLArgs.DeprecatedTimestamp = roachpb.ZeroTimestamp
 		clonedRLArgs.Key = keys.RangeMetaKey(roachpb.Key(c.key))
 		reply, err := client.SendWrapped(tc.rng, tc.rng.context(), clonedRLArgs)
 		if err != nil {
@@ -3065,8 +3035,8 @@ func TestRequestLeaderEncounterGroupDeleteError(t *testing.T) {
 	gArgs := getArgs(roachpb.Key("a"), 1, tc.store.StoreID())
 	// Force the read command request a new lease.
 	clock := tc.clock
-	gArgs.Header().DeprecatedTimestamp = clock.Update(clock.Now().Add(int64(DefaultLeaderLeaseDuration), 0))
-	_, err = client.SendWrapped(tc.store, nil, &gArgs)
+	ts := clock.Update(clock.Now().Add(int64(DefaultLeaderLeaseDuration), 0))
+	_, err = client.SendWrappedAt(tc.store, nil, ts, &gArgs)
 	if _, ok := err.(*roachpb.RangeNotFoundError); !ok {
 		t.Fatalf("expected a RangeNotFoundError, get %s", err)
 	}

--- a/storage/store.go
+++ b/storage/store.go
@@ -1352,7 +1352,7 @@ func (s *Store) resolveWriteIntentError(ctx context.Context, wiErr *roachpb.Writ
 			},
 			PusherTxn: *pusherTxn,
 			PusheeTxn: intent.Txn,
-			PushTo:    header.Timestamp,
+			PushTo:    header.DeprecatedTimestamp,
 			// The timestamp is used by PushTxn for figuring out whether the
 			// transaction is abandoned. If we used the argument's timestamp
 			// here, we would run into busy loops because that timestamp


### PR DESCRIPTION
this simplifies timestamp handling a lot:
- if a batch txn is set, that timestamp is used (not 100% yet, but close)
- otherwise, if a batch timestamp is set, that one is used
- otherwise, the proposing replica makes one up.

this is the most involved header-related refactor. from now on
it should be smooth sailing.

You'll want to go commit-by-commit and skip those that are indicated
as completely automated.
