### PR TITLE
Binary search tuples in evalTupleIN now that they are sorted

### DIFF
--- a/sql/analyze.go
+++ b/sql/analyze.go
@@ -30,7 +30,7 @@ import (
 
 // analyzeExpr analyzes and simplifies an expression, returning a list of
 // expressions of a list of expressions. The top-level list contains
-// disjunctions (a.k.a OR expressions). The second-level contains conjuntions
+// disjunctions (a.k.a OR expressions). The second-level contains conjunctions
 // (a.k.a. AND expressions). For example:
 //
 //   (a AND b) OR c -> [[a, b], c]
@@ -1222,8 +1222,6 @@ func simplifyComparisonExpr(n *parser.ComparisonExpr) parser.Expr {
 			return n
 		case parser.In, parser.NotIn:
 			tuple := n.Right.(parser.DTuple)
-			sort.Sort(tuple)
-			tuple = uniqTuple(tuple)
 			if len(tuple) == 0 {
 				return parser.DBool(false)
 			}
@@ -1276,20 +1274,6 @@ func makePrefixRange(prefix parser.DString, datum parser.Expr, complete bool) pa
 			Right:    parser.DString(roachpb.Key(prefix).PrefixEnd()),
 		},
 	}
-}
-
-func uniqTuple(tuple parser.DTuple) parser.DTuple {
-	n := 0
-	for i := 0; i < len(tuple); i++ {
-		if tuple[i] == parser.DNull {
-			continue
-		}
-		if n == 0 || tuple[n-1].Compare(tuple[i]) < 0 {
-			tuple[n] = tuple[i]
-			n++
-		}
-	}
-	return tuple[:n]
 }
 
 func mergeSorted(a, b parser.DTuple) parser.DTuple {

--- a/sql/parser/datum.go
+++ b/sql/parser/datum.go
@@ -22,6 +22,7 @@ import (
 	"fmt"
 	"math"
 	"reflect"
+	"sort"
 	"strconv"
 	"time"
 
@@ -561,6 +562,26 @@ func (d DTuple) Less(i, j int) bool {
 
 func (d DTuple) Swap(i, j int) {
 	d[i], d[j] = d[j], d[i]
+}
+
+// Normalize sorts and uniques the datum tuple.
+func (d *DTuple) Normalize() {
+	sort.Sort(d)
+	d.makeUnique()
+}
+
+func (d *DTuple) makeUnique() {
+	n := 0
+	for i := 0; i < len(*d); i++ {
+		if (*d)[i] == DNull {
+			continue
+		}
+		if n == 0 || (*d)[n-1].Compare((*d)[i]) < 0 {
+			(*d)[n] = (*d)[i]
+			n++
+		}
+	}
+	*d = (*d)[:n]
 }
 
 type dNull struct{}

--- a/sql/parser/eval.go
+++ b/sql/parser/eval.go
@@ -520,41 +520,15 @@ var evalTupleEQ = cmpOp{
 }
 
 var evalTupleIN = cmpOp{
-	fn: func(arg, values Datum, _ *interface{}) (in DBool, err error) {
+	fn: func(arg, values Datum, _ *interface{}) (DBool, error) {
 		if arg == DNull {
 			return DBool(false), nil
 		}
 
 		vtuple := values.(DTuple)
-
-		if _, ok := arg.(DTuple); !ok {
-			defer func() {
-				if r := recover(); r != nil {
-					switch t := r.(type) {
-					case string:
-						err = errors.New(t)
-					default:
-						panic(t)
-					}
-				}
-			}()
-			i := sort.Search(len(vtuple), func(i int) bool { return vtuple[i].Compare(arg) >= 0 })
-			return DBool(i < len(vtuple) && vtuple[i].Compare(arg) == 0), nil
-		} else {
-			for _, val := range vtuple {
-				d, err := evalComparisonEq(arg, val)
-				if err != nil {
-					return DummyBool, err
-				}
-				if v, err := getBool(d); err != nil {
-					return DummyBool, err
-				} else if v {
-					return v, nil
-				}
-			}
-		}
-
-		return DBool(false), nil
+		i := sort.Search(len(vtuple), func(i int) bool { return vtuple[i].Compare(arg) >= 0 })
+		found := i < len(vtuple) && vtuple[i].Compare(arg) == 0
+		return DBool(found), nil
 	},
 }
 

--- a/sql/parser/eval.go
+++ b/sql/parser/eval.go
@@ -23,6 +23,7 @@ import (
 	"math"
 	"reflect"
 	"regexp"
+	"sort"
 	"strconv"
 	"strings"
 	"time"
@@ -519,33 +520,26 @@ var evalTupleEQ = cmpOp{
 }
 
 var evalTupleIN = cmpOp{
-	fn: func(arg, values Datum, _ *interface{}) (DBool, error) {
+	fn: func(arg, values Datum, _ *interface{}) (in DBool, err error) {
 		if arg == DNull {
 			return DBool(false), nil
 		}
 
 		vtuple := values.(DTuple)
 
-		// TODO(pmattis): If we're evaluating the expression multiple times we should
-		// use a map when possible. This works as long as arg is not a tuple. Note
-		// that the usage of the map is currently disabled via the "&& false" because
-		// building the map is a pessimization if we're only evaluating the
-		// expression once. We need to determine when the expression will be
-		// evaluated multiple times before enabling. Also need to figure out a way to
-		// use the map approach for tuples. One idea is to encode the tuples into
-		// strings and then use a map of strings.
-		if _, ok := arg.(DTuple); !ok && false {
-			m := make(map[Datum]struct{}, len(vtuple))
-			for _, val := range vtuple {
-				if reflect.TypeOf(arg) != reflect.TypeOf(val) {
-					return DummyBool, fmt.Errorf("unsupported comparison operator: <%s> %s <%s>",
-						arg.Type(), EQ, val.Type())
+		if _, ok := arg.(DTuple); !ok {
+			defer func() {
+				if r := recover(); r != nil {
+					switch t := r.(type) {
+					case string:
+						err = errors.New(t)
+					default:
+						panic(t)
+					}
 				}
-				m[val] = struct{}{}
-			}
-			if _, exists := m[arg]; exists {
-				return DBool(true), nil
-			}
+			}()
+			i := sort.Search(len(vtuple), func(i int) bool { return vtuple[i].Compare(arg) >= 0 })
+			return DBool(i < len(vtuple) && vtuple[i].Compare(arg) == 0), nil
 		} else {
 			for _, val := range vtuple {
 				d, err := evalComparisonEq(arg, val)

--- a/sql/parser/eval_test.go
+++ b/sql/parser/eval_test.go
@@ -200,6 +200,7 @@ func TestEvalExpr(t *testing.T) {
 		{`'2010-09-28 12:00:00.1'::timestamp IN ('2010-09-28 12:00:00.1'::timestamp)`, `true`},
 		{`'34h'::interval IN ('34h'::interval)`, `true`},
 		{`(1,2) IN ((0+1,1+1), (3,4), (5,6))`, `true`},
+		{`(1, 2) IN ((2, 1), (3, 4))`, `false`},
 		// Func expressions.
 		{`length('hel'||'lo')`, `5`},
 		{`lower('HELLO')`, `'hello'`},

--- a/sql/parser/normalize.go
+++ b/sql/parser/normalize.go
@@ -99,6 +99,16 @@ func (v *normalizeVisitor) Visit(expr Expr, pre bool) (Visitor, Expr) {
 
 	// Evaluate constant expressions.
 	if isConst(expr) {
+		// Normalize constant In and NotIn comparison expressions with DTuple datum.
+		if cmp, ok := expr.(*ComparisonExpr); ok {
+			switch cmp.Operator {
+			case In, NotIn:
+				tuple := cmp.Right.(DTuple)
+				tuple.Normalize()
+				cmp.Right = tuple
+			}
+		}
+
 		expr, v.err = v.ctx.EvalExpr(expr)
 		if v.err != nil {
 			return nil, expr
@@ -221,123 +231,129 @@ func (v *normalizeVisitor) normalizeOrExpr(n *OrExpr) (Visitor, Expr) {
 }
 
 func (v *normalizeVisitor) normalizeComparisonExpr(n *ComparisonExpr) (Visitor, Expr) {
-	// We want var nodes (DReference, QualifiedName, etc) to be immediate
-	// children of the comparison expression and not second or third
-	// children. That is, we want trees that look like:
-	//
-	//    cmp            cmp
-	//   /   \          /   \
-	//  a    op        op    a
-	//      /  \      /  \
-	//     1    2    1    2
-	//
-	// Not trees that look like:
-	//
-	//      cmp          cmp        cmp          cmp
-	//     /   \        /   \      /   \        /   \
-	//    op    2      op    2    1    op      1    op
-	//   /  \         /  \            /  \         /  \
-	//  a    1       1    a          a    2       2    a
-
 	switch n.Operator {
 	case EQ, GE, GT, LE, LT:
-		break
-	default:
-		return v, n
-	}
-
-	// We loop attempting to simplify the comparison expression. As a
-	// pre-condition, we know there is at least one variable in the expression
-	// tree or we would not have entered this code path.
-	for {
-		if isConst(n.Left) {
-			switch n.Right.(type) {
-			case *BinaryExpr, DReference, *QualifiedName, ValArg:
-				break
-			default:
+		// We want var nodes (DReference, QualifiedName, etc) to be immediate
+		// children of the comparison expression and not second or third
+		// children. That is, we want trees that look like:
+		//
+		//    cmp            cmp
+		//   /   \          /   \
+		//  a    op        op    a
+		//      /  \      /  \
+		//     1    2    1    2
+		//
+		// Not trees that look like:
+		//
+		//      cmp          cmp        cmp          cmp
+		//     /   \        /   \      /   \        /   \
+		//    op    2      op    2    1    op      1    op
+		//   /  \         /  \            /  \         /  \
+		//  a    1       1    a          a    2       2    a
+		//
+		// We loop attempting to simplify the comparison expression. As a
+		// pre-condition, we know there is at least one variable in the expression
+		// tree or we would not have entered this code path.
+		for {
+			if isConst(n.Left) {
+				switch n.Right.(type) {
+				case *BinaryExpr, DReference, *QualifiedName, ValArg:
+					break
+				default:
+					return v, n
+				}
+				// The left side is const and the right side is a binary expression or a
+				// variable. Flip the comparison op so that the right side is const and
+				// the left side is a binary expression or variable.
+				n.Operator = invertComparisonOp(n.Operator)
+				n.Left, n.Right = n.Right, n.Left
+			} else if !isConst(n.Right) {
 				return v, n
 			}
-			// The left side is const and the right side is a binary expression or a
-			// variable. Flip the comparison op so that the right side is const and
-			// the left side is a binary expression or variable.
-			n.Operator = invertComparisonOp(n.Operator)
-			n.Left, n.Right = n.Right, n.Left
-		} else if !isConst(n.Right) {
-			return v, n
-		}
 
-		left, ok := n.Left.(*BinaryExpr)
-		if !ok {
-			return v, n
-		}
+			left, ok := n.Left.(*BinaryExpr)
+			if !ok {
+				return v, n
+			}
 
-		// The right is const and the left side is a binary expression. Rotate the
-		// comparison combining portions that are const.
+			// The right is const and the left side is a binary expression. Rotate the
+			// comparison combining portions that are const.
 
-		switch {
-		case isConst(left.Right):
-			//        cmp          cmp
-			//       /   \        /   \
-			//    [+-/]   2  ->  a   [-+*]
-			//   /     \            /     \
-			//  a       1          2       1
+			switch {
+			case isConst(left.Right):
+				//        cmp          cmp
+				//       /   \        /   \
+				//    [+-/]   2  ->  a   [-+*]
+				//   /     \            /     \
+				//  a       1          2       1
 
-			switch left.Operator {
-			case Plus, Minus, Div:
-				n.Left = left.Left
-				left.Left = n.Right
-				if left.Operator == Plus {
-					left.Operator = Minus
-				} else if left.Operator == Minus {
-					left.Operator = Plus
-				} else {
-					left.Operator = Mult
+				switch left.Operator {
+				case Plus, Minus, Div:
+					n.Left = left.Left
+					left.Left = n.Right
+					if left.Operator == Plus {
+						left.Operator = Minus
+					} else if left.Operator == Minus {
+						left.Operator = Plus
+					} else {
+						left.Operator = Mult
+					}
+					// Clear the function cache now that we've changed the operator.
+					left.fn.fn = nil
+					n.Right, v.err = v.ctx.EvalExpr(left)
+					if v.err != nil {
+						return nil, nil
+					}
+					if !isVar(n.Left) {
+						// Continue as long as the left side of the comparison is not a
+						// variable.
+						continue
+					}
 				}
-				// Clear the function cache now that we've changed the operator.
-				left.fn.fn = nil
-				n.Right, v.err = v.ctx.EvalExpr(left)
-				if v.err != nil {
-					return nil, nil
-				}
-				if !isVar(n.Left) {
-					// Continue as long as the left side of the comparison is not a
-					// variable.
-					continue
+
+			case isConst(left.Left):
+				//       cmp              cmp
+				//      /   \            /   \
+				//    [+-]   2  ->     [+-]   a
+				//   /    \           /    \
+				//  1      a         1      2
+
+				switch left.Operator {
+				case Plus, Minus:
+					left.Right, n.Right = n.Right, left.Right
+					if left.Operator == Plus {
+						left.Operator = Minus
+						left.Left, left.Right = left.Right, left.Left
+					} else {
+						n.Operator = invertComparisonOp(n.Operator)
+					}
+					n.Left, v.err = v.ctx.EvalExpr(left)
+					if v.err != nil {
+						return nil, nil
+					}
+					n.Left, n.Right = n.Right, n.Left
+					if !isVar(n.Left) {
+						// Continue as long as the left side of the comparison is not a
+						// variable.
+						continue
+					}
 				}
 			}
 
-		case isConst(left.Left):
-			//       cmp              cmp
-			//      /   \            /   \
-			//    [+-]   2  ->     [+-]   a
-			//   /    \           /    \
-			//  1      a         1      2
-
-			switch left.Operator {
-			case Plus, Minus:
-				left.Right, n.Right = n.Right, left.Right
-				if left.Operator == Plus {
-					left.Operator = Minus
-					left.Left, left.Right = left.Right, left.Left
-				} else {
-					n.Operator = invertComparisonOp(n.Operator)
-				}
-				n.Left, v.err = v.ctx.EvalExpr(left)
-				if v.err != nil {
-					return nil, nil
-				}
-				n.Left, n.Right = n.Right, n.Left
-				if !isVar(n.Left) {
-					// Continue as long as the left side of the comparison is not a
-					// variable.
-					continue
-				}
-			}
+			// We've run out of work to do.
+			break
 		}
-
-		// We've run out of work to do.
-		return v, n
+	case In, NotIn:
+		// If the right tuple in an In or NotIn comparison expression is constant, it can
+		// be normalized.
+		if isConst(n.Right) {
+			tuple := n.Right.(DTuple)
+			tuple.Normalize()
+			n.Right = tuple
+		}
 	}
+
+	return v, n
 }
 
 func invertComparisonOp(op ComparisonOp) ComparisonOp {

--- a/sql/parser/normalize_test.go
+++ b/sql/parser/normalize_test.go
@@ -52,6 +52,8 @@ func TestNormalizeExpr(t *testing.T) {
 		{`a AND false`, `false`},
 		{`a AND NULL`, `a AND NULL`},
 		{`1 IN (1, 2, 3)`, `true`},
+		{`1 IN (3, 2, 1)`, `true`},
+		{`a IN (3, 2, 1)`, `a IN (1, 2, 3)`},
 		{`1 IN (1, 2, a)`, `1 IN (1, 2, a)`},
 		{`a<1`, `a < 1`},
 		{`1>a`, `a < 1`},

--- a/sql/parser/type_check.go
+++ b/sql/parser/type_check.go
@@ -444,32 +444,9 @@ func typeCheckTupleIN(arg, values Datum) error {
 	}
 
 	vtuple := values.(DTuple)
-
-	// TODO(pmattis): If we're evaluating the expression multiple times we should
-	// use a map when possible. This works as long as arg is not a tuple. Note
-	// that the usage of the map is currently disabled via the "&& false" because
-	// building the map is a pessimization if we're only evaluating the
-	// expression once. We need to determine when the expression will be
-	// evaluated multiple times before enabling. Also need to figure out a way to
-	// use the map approach for tuples. One idea is to encode the tuples into
-	// strings and then use a map of strings.
-	if _, ok := arg.(DTuple); !ok && false {
-		m := make(map[Datum]struct{}, len(vtuple))
-		for _, val := range vtuple {
-			if reflect.TypeOf(arg) != reflect.TypeOf(val) {
-				return fmt.Errorf("unsupported comparison operator: <%s> %s <%s>",
-					arg.Type(), EQ, val.Type())
-			}
-			m[val] = struct{}{}
-		}
-		if _, exists := m[arg]; exists {
-			return nil
-		}
-	} else {
-		for _, val := range vtuple {
-			if _, _, err := typeCheckComparisonOp(EQ, arg, val); err != nil {
-				return err
-			}
+	for _, val := range vtuple {
+		if _, _, err := typeCheckComparisonOp(EQ, arg, val); err != nil {
+			return err
 		}
 	}
 


### PR DESCRIPTION
Tuples are now sorted in analyze.go `simplifyComparisonExpr`, so determining if a value is present in the tuple for the `evalTupleIN` operation can use binary search.
