### PR TITLE
drop everything but {End,}Key from roachpb.RequestHeader

### DIFF
--- a/client/sender.go
+++ b/client/sender.go
@@ -101,11 +101,6 @@ func SendWrappedWith(sender Sender, ctx context.Context, h roachpb.BatchRequest_
 		{
 			h := args.Header()
 			ba.CmdID = h.CmdID
-			if ba.RangeID == 0 {
-				// TODO(tschottdorf): still necessary now since not all tests
-				// use the passed in batch header (yet).
-				ba.RangeID = h.RangeID
-			}
 			ba.UserPriority = h.UserPriority
 			ba.Txn = h.Txn
 			ba.ReadConsistency = h.ReadConsistency

--- a/client/sender.go
+++ b/client/sender.go
@@ -99,11 +99,11 @@ func SendWrappedWith(sender Sender, ctx context.Context, h roachpb.BatchRequest_
 		ba.Timestamp = h.Timestamp
 		ba.RangeID = h.RangeID
 		ba.CmdID = h.CmdID
+		ba.ReadConsistency = h.ReadConsistency
 		{
 			h := args.Header()
 			ba.UserPriority = h.UserPriority
 			ba.Txn = h.Txn
-			ba.ReadConsistency = h.ReadConsistency
 		}
 		ba.Add(args)
 		return ba, func(br *roachpb.BatchResponse) roachpb.Response {

--- a/client/sender.go
+++ b/client/sender.go
@@ -97,10 +97,15 @@ func SendWrappedWith(sender Sender, ctx context.Context, h roachpb.BatchRequest_
 	ba, unwrap := func(args roachpb.Request) (*roachpb.BatchRequest, func(*roachpb.BatchResponse) roachpb.Response) {
 		ba := &roachpb.BatchRequest{}
 		ba.Timestamp = h.Timestamp
+		ba.RangeID = h.RangeID
 		{
 			h := args.Header()
 			ba.CmdID = h.CmdID
-			ba.RangeID = h.RangeID
+			if ba.RangeID == 0 {
+				// TODO(tschottdorf): still necessary now since not all tests
+				// use the passed in batch header (yet).
+				ba.RangeID = h.RangeID
+			}
 			ba.UserPriority = h.UserPriority
 			ba.Txn = h.Txn
 			ba.ReadConsistency = h.ReadConsistency

--- a/client/sender.go
+++ b/client/sender.go
@@ -96,15 +96,7 @@ func SendWrappedWith(sender Sender, ctx context.Context, h roachpb.BatchRequest_
 	}
 	ba, unwrap := func(args roachpb.Request) (*roachpb.BatchRequest, func(*roachpb.BatchResponse) roachpb.Response) {
 		ba := &roachpb.BatchRequest{}
-		ba.Timestamp = h.Timestamp
-		ba.RangeID = h.RangeID
-		ba.CmdID = h.CmdID
-		ba.ReadConsistency = h.ReadConsistency
-		ba.UserPriority = h.UserPriority
-		{
-			h := args.Header()
-			ba.Txn = h.Txn
-		}
+		ba.BatchRequest_Header = h
 		ba.Add(args)
 		return ba, func(br *roachpb.BatchResponse) roachpb.Response {
 			unwrappedReply := br.Responses[0].GetInner()

--- a/client/sender.go
+++ b/client/sender.go
@@ -86,17 +86,17 @@ func newSender(u *url.URL, ctx *base.Context, retryOptions retry.Options, stoppe
 	return f(u, ctx, retryOptions, stopper)
 }
 
-// SendWrappedAt is a convenience function which wraps the request in a batch
+// SendWrappedWith is a convenience function which wraps the request in a batch
 // and sends it via the provided Sender at the given timestamp. It returns the
 // unwrapped response or an error. It's valid to pass a `nil` context;
 // context.Background() is used in that case.
-func SendWrappedAt(sender Sender, ctx context.Context, ts roachpb.Timestamp, args roachpb.Request) (roachpb.Response, error) {
+func SendWrappedWith(sender Sender, ctx context.Context, h roachpb.BatchRequest_Header, args roachpb.Request) (roachpb.Response, error) {
 	if ctx == nil {
 		ctx = context.Background()
 	}
 	ba, unwrap := func(args roachpb.Request) (*roachpb.BatchRequest, func(*roachpb.BatchResponse) roachpb.Response) {
 		ba := &roachpb.BatchRequest{}
-		ba.Timestamp = ts
+		ba.Timestamp = h.Timestamp
 		{
 			h := args.Header()
 			ba.CmdID = h.CmdID
@@ -128,7 +128,7 @@ func SendWrappedAt(sender Sender, ctx context.Context, ts roachpb.Timestamp, arg
 	return unwrap(br), nil
 }
 
-// SendWrapped is identical to SendWrappedAt with a zero timestamp.
+// SendWrapped is identical to SendWrappedAt with a zero header.
 func SendWrapped(sender Sender, ctx context.Context, args roachpb.Request) (roachpb.Response, error) {
-	return SendWrappedAt(sender, ctx, roachpb.ZeroTimestamp, args)
+	return SendWrappedWith(sender, ctx, roachpb.BatchRequest_Header{}, args)
 }

--- a/client/sender.go
+++ b/client/sender.go
@@ -100,9 +100,9 @@ func SendWrappedWith(sender Sender, ctx context.Context, h roachpb.BatchRequest_
 		ba.RangeID = h.RangeID
 		ba.CmdID = h.CmdID
 		ba.ReadConsistency = h.ReadConsistency
+		ba.UserPriority = h.UserPriority
 		{
 			h := args.Header()
-			ba.UserPriority = h.UserPriority
 			ba.Txn = h.Txn
 		}
 		ba.Add(args)

--- a/client/sender.go
+++ b/client/sender.go
@@ -99,7 +99,6 @@ func SendWrappedAt(sender Sender, ctx context.Context, ts roachpb.Timestamp, arg
 		ba.Timestamp = ts
 		{
 			h := args.Header()
-			ba.Key, ba.EndKey = h.Key, h.EndKey
 			ba.CmdID = h.CmdID
 			ba.Replica = h.Replica
 			ba.RangeID = h.RangeID

--- a/client/sender.go
+++ b/client/sender.go
@@ -98,9 +98,9 @@ func SendWrappedWith(sender Sender, ctx context.Context, h roachpb.BatchRequest_
 		ba := &roachpb.BatchRequest{}
 		ba.Timestamp = h.Timestamp
 		ba.RangeID = h.RangeID
+		ba.CmdID = h.CmdID
 		{
 			h := args.Header()
-			ba.CmdID = h.CmdID
 			ba.UserPriority = h.UserPriority
 			ba.Txn = h.Txn
 			ba.ReadConsistency = h.ReadConsistency

--- a/kv/dist_sender.go
+++ b/kv/dist_sender.go
@@ -213,8 +213,7 @@ func (ds *DistSender) rangeLookup(key roachpb.Key, options lookupOptions,
 	ba.ReadConsistency = roachpb.INCONSISTENT
 	ba.Add(&roachpb.RangeLookupRequest{
 		RequestHeader: roachpb.RequestHeader{
-			Key:             key,
-			ReadConsistency: roachpb.INCONSISTENT,
+			Key: key,
 		},
 		MaxRanges:       ds.rangeLookupMaxRanges,
 		ConsiderIntents: options.considerIntents,

--- a/kv/dist_sender.go
+++ b/kv/dist_sender.go
@@ -473,10 +473,6 @@ func (ds *DistSender) Send(ctx context.Context, ba roachpb.BatchRequest) (*roach
 // which doesn't need to be subdivided further before going to a range (so no
 // mixing of forward and reverse scans, etc).
 func (ds *DistSender) sendChunk(ctx context.Context, ba roachpb.BatchRequest) (*roachpb.BatchResponse, *roachpb.Error) {
-	// TODO(tschottdorf): prepare for removing Key and EndKey from BatchRequest,
-	// making sure that anything that relies on them goes bust.
-	ba.Key, ba.EndKey = nil, nil
-
 	isReverse := ba.IsReverse()
 
 	trace := tracer.FromCtx(ctx)
@@ -550,11 +546,7 @@ func (ds *DistSender) sendChunk(ctx context.Context, ba roachpb.BatchRequest) (*
 				if trErr != nil {
 					return nil, roachpb.NewError(trErr)
 				}
-				// TODO(tschottdorf): make key range on batch redundant. The
-				// requests within dictate it anyways.
-				ba.Key, ba.EndKey = keys.Range(ba)
 				reply, err := ds.sendAttempt(trace, ba, desc)
-				ba.Key, ba.EndKey = nil, nil
 
 				if err != nil {
 					if log.V(1) {

--- a/kv/dist_sender_server_test.go
+++ b/kv/dist_sender_server_test.go
@@ -247,8 +247,9 @@ func TestMultiRangeScanReverseScanInconsistent(t *testing.T) {
 
 	// Scan.
 	sa := roachpb.NewScan(roachpb.Key("a"), roachpb.Key("c"), 0).(*roachpb.ScanRequest)
-	sa.ReadConsistency = roachpb.INCONSISTENT
-	reply, err := client.SendWrapped(ds, nil, sa)
+	reply, err := client.SendWrappedWith(ds, nil, roachpb.BatchRequest_Header{
+		ReadConsistency: roachpb.INCONSISTENT,
+	}, sa)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -263,8 +264,9 @@ func TestMultiRangeScanReverseScanInconsistent(t *testing.T) {
 
 	// ReverseScan.
 	rsa := roachpb.NewReverseScan(roachpb.Key("a"), roachpb.Key("c"), 0).(*roachpb.ReverseScanRequest)
-	rsa.ReadConsistency = roachpb.INCONSISTENT
-	reply, err = client.SendWrapped(ds, nil, rsa)
+	reply, err = client.SendWrappedWith(ds, nil, roachpb.BatchRequest_Header{
+		ReadConsistency: roachpb.INCONSISTENT,
+	}, rsa)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/kv/dist_sender_test.go
+++ b/kv/dist_sender_test.go
@@ -324,7 +324,6 @@ func TestSendRPCOrder(t *testing.T) {
 		}
 
 		args := tc.args
-		args.Header().RangeID = rangeID // Not used in this test, but why not.
 		args.Header().Key = roachpb.Key("a")
 		if roachpb.IsRange(args) {
 			args.Header().EndKey = roachpb.Key("b")
@@ -334,7 +333,9 @@ func TestSendRPCOrder(t *testing.T) {
 		}
 		// Kill the cached NodeDescriptor, enforcing a lookup from Gossip.
 		ds.nodeDescriptor = nil
-		if _, err := client.SendWrapped(ds, nil, args); err != nil {
+		if _, err := client.SendWrappedWith(ds, nil, roachpb.BatchRequest_Header{
+			RangeID: rangeID, // Not used in this test, but why not.
+		}, args); err != nil {
 			t.Errorf("%d: %s", n, err)
 		}
 	}

--- a/kv/dist_sender_test.go
+++ b/kv/dist_sender_test.go
@@ -328,13 +328,15 @@ func TestSendRPCOrder(t *testing.T) {
 		if roachpb.IsRange(args) {
 			args.Header().EndKey = roachpb.Key("b")
 		}
+		consistency := roachpb.CONSISTENT
 		if !tc.consistent {
-			args.Header().ReadConsistency = roachpb.INCONSISTENT
+			consistency = roachpb.INCONSISTENT
 		}
 		// Kill the cached NodeDescriptor, enforcing a lookup from Gossip.
 		ds.nodeDescriptor = nil
 		if _, err := client.SendWrappedWith(ds, nil, roachpb.BatchRequest_Header{
-			RangeID: rangeID, // Not used in this test, but why not.
+			RangeID:         rangeID, // Not used in this test, but why not.
+			ReadConsistency: consistency,
 		}, args); err != nil {
 			t.Errorf("%d: %s", n, err)
 		}

--- a/kv/dist_sender_test.go
+++ b/kv/dist_sender_test.go
@@ -524,10 +524,11 @@ func TestRetryOnWrongReplicaError(t *testing.T) {
 
 	var testFn rpcSendFn = func(_ rpc.Options, method string, addrs []net.Addr, getArgs func(addr net.Addr) proto.Message, getReply func() proto.Message, _ *rpc.Context) ([]proto.Message, error) {
 		ba := getArgs(testAddress).(*roachpb.BatchRequest)
+		key, endKey := keys.Range(*ba)
 		if _, ok := ba.GetArg(roachpb.RangeLookup); ok {
-			if !descStale && bytes.HasPrefix(ba.Key, keys.Meta2Prefix) {
+			if !descStale && bytes.HasPrefix(key, keys.Meta2Prefix) {
 				t.Errorf("unexpected extra lookup for non-stale replica descriptor at %s",
-					ba.Key)
+					key)
 			}
 
 			br := getReply().(*roachpb.BatchResponse)
@@ -536,7 +537,7 @@ func TestRetryOnWrongReplicaError(t *testing.T) {
 			br.Add(r)
 			// If we just returned the stale descriptor, set up returning the
 			// good one next time.
-			if bytes.HasPrefix(ba.Key, keys.Meta2Prefix) {
+			if bytes.HasPrefix(key, keys.Meta2Prefix) {
 				if newRangeDescriptor.StartKey.Equal(badStartKey) {
 					newRangeDescriptor.StartKey = goodStartKey
 				} else {
@@ -548,8 +549,8 @@ func TestRetryOnWrongReplicaError(t *testing.T) {
 		// When the Scan first turns up, update the descriptor for future
 		// range descriptor lookups.
 		if !newRangeDescriptor.StartKey.Equal(goodStartKey) {
-			return nil, &roachpb.RangeKeyMismatchError{RequestStartKey: ba.Key,
-				RequestEndKey: ba.EndKey}
+			return nil, &roachpb.RangeKeyMismatchError{RequestStartKey: key,
+				RequestEndKey: endKey}
 		}
 		return []proto.Message{ba.CreateReply()}, nil
 	}
@@ -726,13 +727,14 @@ func TestMultiRangeMergeStaleDescriptor(t *testing.T) {
 		if method != "Node.Batch" {
 			t.Fatalf("unexpected method:%s", method)
 		}
-		header := getArgs(testAddress).(*roachpb.BatchRequest).BatchRequest_Header
+		ba := getArgs(testAddress).(*roachpb.BatchRequest)
+		key, endKey := keys.Range(*ba)
 		batchReply := getReply().(*roachpb.BatchResponse)
 		reply := &roachpb.ScanResponse{}
 		batchReply.Add(reply)
 		results := []roachpb.KeyValue{}
 		for _, curKV := range existingKVs {
-			if header.Key.Less(curKV.Key.Next()) && curKV.Key.Less(header.EndKey) {
+			if key.Less(curKV.Key.Next()) && curKV.Key.Less(endKey) {
 				results = append(results, curKV)
 			}
 		}

--- a/kv/dist_sender_test.go
+++ b/kv/dist_sender_test.go
@@ -758,8 +758,9 @@ func TestMultiRangeMergeStaleDescriptor(t *testing.T) {
 	ds := NewDistSender(ctx, g)
 	scan := roachpb.NewScan(roachpb.Key("a"), roachpb.Key("d"), 10).(*roachpb.ScanRequest)
 	// Set the Txn info to avoid an OpRequiresTxnError.
-	scan.Txn = &roachpb.Transaction{}
-	reply, err := client.SendWrapped(ds, nil, scan)
+	reply, err := client.SendWrappedWith(ds, nil, roachpb.BatchRequest_Header{
+		Txn: &roachpb.Transaction{},
+	}, scan)
 	if err != nil {
 		t.Fatalf("scan encountered error: %s", err)
 	}

--- a/kv/local_sender.go
+++ b/kv/local_sender.go
@@ -24,6 +24,7 @@ import (
 	"golang.org/x/net/context"
 
 	"github.com/cockroachdb/cockroach/client"
+	"github.com/cockroachdb/cockroach/keys"
 	"github.com/cockroachdb/cockroach/roachpb"
 	"github.com/cockroachdb/cockroach/storage"
 	"github.com/cockroachdb/cockroach/util"
@@ -120,7 +121,8 @@ func (ls *LocalSender) Send(ctx context.Context, ba roachpb.BatchRequest) (*roac
 	if ba.RangeID == 0 || ba.Replica.StoreID == 0 {
 		var repl *roachpb.ReplicaDescriptor
 		var rangeID roachpb.RangeID
-		rangeID, repl, err = ls.lookupReplica(ba.Key, ba.EndKey)
+		key, endKey := keys.Range(ba)
+		rangeID, repl, err = ls.lookupReplica(key, endKey)
 		if err == nil {
 			ba.RangeID = rangeID
 			ba.Replica = *repl
@@ -128,7 +130,6 @@ func (ls *LocalSender) Send(ctx context.Context, ba roachpb.BatchRequest) (*roac
 	}
 
 	ctx = log.Add(ctx,
-		log.Key, ba.Key,
 		log.RangeID, ba.RangeID)
 
 	if err == nil {

--- a/kv/local_sender.go
+++ b/kv/local_sender.go
@@ -215,8 +215,7 @@ func (ls *LocalSender) rangeLookup(key roachpb.Key, options lookupOptions, _ *ro
 	ba.ReadConsistency = roachpb.INCONSISTENT
 	ba.Add(&roachpb.RangeLookupRequest{
 		RequestHeader: roachpb.RequestHeader{
-			Key:             key,
-			ReadConsistency: roachpb.INCONSISTENT,
+			Key: key,
 		},
 		MaxRanges:       1,
 		ConsiderIntents: options.considerIntents,

--- a/kv/txn_coord_sender.go
+++ b/kv/txn_coord_sender.go
@@ -286,20 +286,6 @@ func (tc *TxnCoordSender) startStats() {
 	}
 }
 
-// UpdateForBatch updates the first argument (the header of a request contained
-// in a batch) from the second one (the batch header), returning an error when
-// inconsistencies are found.
-// It is checked that the individual call does not have a UserPriority
-// or Txn set that differs from the batch's.
-// TODO(tschottdorf): will go with #2143.
-func updateForBatch(args roachpb.Request, bHeader roachpb.BatchRequest_Header) error {
-	// Disallow transaction, user and priority on individual calls, unless
-	// equal.
-	aHeader := args.Header()
-	aHeader.Txn = bHeader.Txn // reqs always take Txn from batch
-	return nil
-}
-
 // Send implements the batch.Sender interface. If the request is part of a
 // transaction, the TxnCoordSender adds the transaction to a map of active
 // transactions and begins heartbeating it. Every subsequent request for the
@@ -320,15 +306,6 @@ func (tc *TxnCoordSender) Send(ctx context.Context, ba roachpb.BatchRequest) (*r
 	defer trace.Finalize()
 	defer trace.Epoch("sending batch")()
 	ctx = tracer.ToCtx(ctx, trace)
-
-	// TODO(tschottdorf): No looping through the batch will be necessary once
-	// we've eliminated all the redundancies.
-	for _, arg := range ba.Requests {
-		trace.Event(fmt.Sprintf("%T", arg.GetValue()))
-		if err := updateForBatch(arg.GetInner(), ba.BatchRequest_Header); err != nil {
-			return nil, roachpb.NewError(err)
-		}
-	}
 
 	var id string // optional transaction ID
 	if ba.Txn != nil {

--- a/kv/txn_coord_sender.go
+++ b/kv/txn_coord_sender.go
@@ -610,7 +610,6 @@ func (tc *TxnCoordSender) heartbeat(id string, trace *tracer.Trace, ctx context.
 	hb.Key = txn.Key
 	ba := roachpb.BatchRequest{}
 	ba.Timestamp = tc.clock.Now()
-	ba.Key = txn.Key
 	ba.Txn = &txn
 	ba.Add(hb)
 

--- a/kv/txn_coord_sender.go
+++ b/kv/txn_coord_sender.go
@@ -296,10 +296,6 @@ func updateForBatch(args roachpb.Request, bHeader roachpb.BatchRequest_Header) e
 	// Disallow transaction, user and priority on individual calls, unless
 	// equal.
 	aHeader := args.Header()
-	if aPrio := aHeader.GetUserPriority(); aPrio != roachpb.Default_RequestHeader_UserPriority && aPrio != bHeader.GetUserPriority() {
-		return util.Errorf("conflicting user priority on call in batch")
-	}
-	aHeader.UserPriority = bHeader.UserPriority
 	aHeader.Txn = bHeader.Txn // reqs always take Txn from batch
 	return nil
 }

--- a/kv/txn_coord_sender_test.go
+++ b/kv/txn_coord_sender_test.go
@@ -156,10 +156,11 @@ func TestTxnCoordSenderBeginTransaction(t *testing.T) {
 	defer teardownHeartbeats(s.Sender)
 
 	key := roachpb.Key("key")
-	reply, err := client.SendWrapped(s.Sender, nil, &roachpb.PutRequest{
+	reply, err := client.SendWrappedWith(s.Sender, nil, roachpb.BatchRequest_Header{
+		UserPriority: proto.Int32(-10), // negative user priority is translated into positive priority
+	}, &roachpb.PutRequest{
 		RequestHeader: roachpb.RequestHeader{
-			Key:          key,
-			UserPriority: proto.Int32(-10), // negative user priority is translated into positive priority
+			Key: key,
 			Txn: &roachpb.Transaction{
 				Name:      "test txn",
 				Isolation: roachpb.SNAPSHOT,
@@ -192,10 +193,11 @@ func TestTxnCoordSenderBeginTransactionMinPriority(t *testing.T) {
 	defer s.Stop()
 	defer teardownHeartbeats(s.Sender)
 
-	reply, err := client.SendWrapped(s.Sender, nil, &roachpb.PutRequest{
+	reply, err := client.SendWrappedWith(s.Sender, nil, roachpb.BatchRequest_Header{
+		UserPriority: proto.Int32(-10), // negative user priority is translated into positive priority
+	}, &roachpb.PutRequest{
 		RequestHeader: roachpb.RequestHeader{
-			Key:          roachpb.Key("key"),
-			UserPriority: proto.Int32(-10), // negative user priority is translated into positive priority
+			Key: roachpb.Key("key"),
 			Txn: &roachpb.Transaction{
 				Name:      "test txn",
 				Isolation: roachpb.SNAPSHOT,

--- a/kv/txn_coord_sender_test.go
+++ b/kv/txn_coord_sender_test.go
@@ -83,24 +83,26 @@ func newTxn(clock *hlc.Clock, baseKey roachpb.Key) *roachpb.Transaction {
 
 // createPutRequest returns a ready-made request using the
 // specified key, value & txn ID.
-func createPutRequest(key roachpb.Key, value []byte, txn *roachpb.Transaction) *roachpb.PutRequest {
+func createPutRequest(key roachpb.Key, value []byte, txn *roachpb.Transaction) (*roachpb.PutRequest, roachpb.BatchRequest_Header) {
+	h := roachpb.BatchRequest_Header{}
+	h.Txn = txn
 	return &roachpb.PutRequest{
 		RequestHeader: roachpb.RequestHeader{
 			Key: key,
-			Txn: txn,
 		},
 		Value: roachpb.Value{Bytes: value},
-	}
+	}, h
 }
 
-func createDeleteRangeRequest(key, endKey roachpb.Key, txn *roachpb.Transaction) *roachpb.DeleteRangeRequest {
+func createDeleteRangeRequest(key, endKey roachpb.Key, txn *roachpb.Transaction) (*roachpb.DeleteRangeRequest, roachpb.BatchRequest_Header) {
+	h := roachpb.BatchRequest_Header{}
+	h.Txn = txn
 	return &roachpb.DeleteRangeRequest{
 		RequestHeader: roachpb.RequestHeader{
 			Key:    key,
 			EndKey: endKey,
-			Txn:    txn,
 		},
-	}
+	}, h
 }
 
 // TestTxnCoordSenderAddRequest verifies adding a request creates a
@@ -113,10 +115,10 @@ func TestTxnCoordSenderAddRequest(t *testing.T) {
 	defer teardownHeartbeats(s.Sender)
 
 	txn := newTxn(s.Clock, roachpb.Key("a"))
-	put := createPutRequest(roachpb.Key("a"), []byte("value"), txn)
+	put, h := createPutRequest(roachpb.Key("a"), []byte("value"), txn)
 
 	// Put request will create a new transaction.
-	reply, err := client.SendWrapped(s.Sender, nil, put)
+	reply, err := client.SendWrappedWith(s.Sender, nil, h, put)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -134,8 +136,8 @@ func TestTxnCoordSenderAddRequest(t *testing.T) {
 	s.Sender.Lock()
 	s.Manual.Set(1)
 	s.Sender.Unlock()
-	put.Txn.Writing = true
-	if _, err := client.SendWrapped(s.Sender, nil, put); err != nil {
+	h.Txn.Writing = true
+	if _, err := client.SendWrappedWith(s.Sender, nil, h, put); err != nil {
 		t.Fatal(err)
 	}
 	if len(s.Sender.txns) != 1 {
@@ -158,13 +160,13 @@ func TestTxnCoordSenderBeginTransaction(t *testing.T) {
 	key := roachpb.Key("key")
 	reply, err := client.SendWrappedWith(s.Sender, nil, roachpb.BatchRequest_Header{
 		UserPriority: proto.Int32(-10), // negative user priority is translated into positive priority
+		Txn: &roachpb.Transaction{
+			Name:      "test txn",
+			Isolation: roachpb.SNAPSHOT,
+		},
 	}, &roachpb.PutRequest{
 		RequestHeader: roachpb.RequestHeader{
 			Key: key,
-			Txn: &roachpb.Transaction{
-				Name:      "test txn",
-				Isolation: roachpb.SNAPSHOT,
-			},
 		},
 	})
 	if err != nil {
@@ -195,14 +197,14 @@ func TestTxnCoordSenderBeginTransactionMinPriority(t *testing.T) {
 
 	reply, err := client.SendWrappedWith(s.Sender, nil, roachpb.BatchRequest_Header{
 		UserPriority: proto.Int32(-10), // negative user priority is translated into positive priority
+		Txn: &roachpb.Transaction{
+			Name:      "test txn",
+			Isolation: roachpb.SNAPSHOT,
+			Priority:  11,
+		},
 	}, &roachpb.PutRequest{
 		RequestHeader: roachpb.RequestHeader{
 			Key: roachpb.Key("key"),
-			Txn: &roachpb.Transaction{
-				Name:      "test txn",
-				Isolation: roachpb.SNAPSHOT,
-				Priority:  11,
-			},
 		},
 	})
 	if err != nil {
@@ -236,13 +238,13 @@ func TestTxnCoordSenderKeyRanges(t *testing.T) {
 
 	for _, rng := range ranges {
 		if rng.end != nil {
-			delRangeReq := createDeleteRangeRequest(rng.start, rng.end, txn)
-			if _, err := client.SendWrapped(s.Sender, nil, delRangeReq); err != nil {
+			delRangeReq, h := createDeleteRangeRequest(rng.start, rng.end, txn)
+			if _, err := client.SendWrappedWith(s.Sender, nil, h, delRangeReq); err != nil {
 				t.Fatal(err)
 			}
 		} else {
-			putReq := createPutRequest(rng.start, []byte("value"), txn)
-			if _, err := client.SendWrapped(s.Sender, nil, putReq); err != nil {
+			putReq, h := createPutRequest(rng.start, []byte("value"), txn)
+			if _, err := client.SendWrappedWith(s.Sender, nil, h, putReq); err != nil {
 				t.Fatal(err)
 			}
 		}
@@ -270,12 +272,12 @@ func TestTxnCoordSenderMultipleTxns(t *testing.T) {
 
 	txn1 := newTxn(s.Clock, roachpb.Key("a"))
 	txn2 := newTxn(s.Clock, roachpb.Key("b"))
-	put1 := createPutRequest(roachpb.Key("a"), []byte("value"), txn1)
-	if _, err := client.SendWrapped(s.Sender, nil, put1); err != nil {
+	put1, h := createPutRequest(roachpb.Key("a"), []byte("value"), txn1)
+	if _, err := client.SendWrappedWith(s.Sender, nil, h, put1); err != nil {
 		t.Fatal(err)
 	}
-	put2 := createPutRequest(roachpb.Key("b"), []byte("value"), txn2)
-	if _, err := client.SendWrapped(s.Sender, nil, put2); err != nil {
+	put2, h := createPutRequest(roachpb.Key("b"), []byte("value"), txn2)
+	if _, err := client.SendWrappedWith(s.Sender, nil, h, put2); err != nil {
 		t.Fatal(err)
 	}
 
@@ -296,8 +298,8 @@ func TestTxnCoordSenderHeartbeat(t *testing.T) {
 	s.Sender.heartbeatInterval = 1 * time.Millisecond
 
 	initialTxn := newTxn(s.Clock, roachpb.Key("a"))
-	put := createPutRequest(roachpb.Key("a"), []byte("value"), initialTxn)
-	if reply, err := client.SendWrapped(s.Sender, nil, put); err != nil {
+	put, h := createPutRequest(roachpb.Key("a"), []byte("value"), initialTxn)
+	if reply, err := client.SendWrappedWith(s.Sender, nil, h, put); err != nil {
 		t.Fatal(err)
 	} else {
 		*initialTxn = *reply.Header().Txn
@@ -332,10 +334,11 @@ func getTxn(coord *TxnCoordSender, txn *roachpb.Transaction) (bool, *roachpb.Tra
 	hb := &roachpb.HeartbeatTxnRequest{
 		RequestHeader: roachpb.RequestHeader{
 			Key: txn.Key,
-			Txn: txn,
 		},
 	}
-	reply, err := client.SendWrapped(coord, nil, hb)
+	reply, err := client.SendWrappedWith(coord, nil, roachpb.BatchRequest_Header{
+		Txn: txn,
+	}, hb)
 	if err != nil {
 		return false, nil, err
 	}
@@ -372,18 +375,15 @@ func TestTxnCoordSenderEndTxn(t *testing.T) {
 
 	txn := newTxn(s.Clock, roachpb.Key("a"))
 	key := roachpb.Key("a")
-	put := createPutRequest(key, []byte("value"), txn)
-	reply, err := client.SendWrapped(s.Sender, nil, put)
+	put, h := createPutRequest(key, []byte("value"), txn)
+	reply, err := client.SendWrappedWith(s.Sender, nil, h, put)
 	if err != nil {
 		t.Fatal(err)
 	}
 	pReply := reply.(*roachpb.PutResponse)
-	if _, err := client.SendWrapped(s.Sender, nil, &roachpb.EndTransactionRequest{
-		RequestHeader: roachpb.RequestHeader{
-			Txn: pReply.Header().Txn,
-		},
-		Commit: true,
-	}); err != nil {
+	if _, err := client.SendWrappedWith(s.Sender, nil, roachpb.BatchRequest_Header{
+		Txn: pReply.Header().Txn,
+	}, &roachpb.EndTransactionRequest{Commit: true}); err != nil {
 		t.Fatal(err)
 	}
 	verifyCleanup(key, s.Sender, s.Eng, t)
@@ -400,8 +400,8 @@ func TestTxnCoordSenderCleanupOnAborted(t *testing.T) {
 	key := roachpb.Key("a")
 	txn := newTxn(s.Clock, key)
 	txn.Priority = 1
-	put := createPutRequest(key, []byte("value"), txn)
-	if reply, err := client.SendWrapped(s.Sender, nil, put); err != nil {
+	put, h := createPutRequest(key, []byte("value"), txn)
+	if reply, err := client.SendWrappedWith(s.Sender, nil, h, put); err != nil {
 		t.Fatal(err)
 	} else {
 		txn = reply.Header().Txn
@@ -426,12 +426,11 @@ func TestTxnCoordSenderCleanupOnAborted(t *testing.T) {
 	// Now end the transaction and verify we've cleanup up, even though
 	// end transaction failed.
 	etArgs := &roachpb.EndTransactionRequest{
-		RequestHeader: roachpb.RequestHeader{
-			Txn: txn,
-		},
 		Commit: true,
 	}
-	_, err := client.SendWrapped(s.Sender, nil, etArgs)
+	_, err := client.SendWrappedWith(s.Sender, nil, roachpb.BatchRequest_Header{
+		Txn: txn,
+	}, etArgs)
 	switch err.(type) {
 	case *roachpb.TransactionAbortedError:
 		// Expected
@@ -452,8 +451,8 @@ func TestTxnCoordSenderGC(t *testing.T) {
 	s.Sender.heartbeatInterval = 1 * time.Millisecond
 
 	txn := newTxn(s.Clock, roachpb.Key("a"))
-	put := createPutRequest(roachpb.Key("a"), []byte("value"), txn)
-	if _, err := client.SendWrapped(s.Sender, nil, put); err != nil {
+	put, h := createPutRequest(roachpb.Key("a"), []byte("value"), txn)
+	if _, err := client.SendWrappedWith(s.Sender, nil, h, put); err != nil {
 		t.Fatal(err)
 	}
 
@@ -581,18 +580,17 @@ func TestTxnDrainingNode(t *testing.T) {
 	txn := newTxn(s.Clock, roachpb.Key("a"))
 	key := roachpb.Key("a")
 	beginTxn := func() {
-		put := createPutRequest(key, []byte("value"), txn)
-		if reply, err := client.SendWrapped(s.Sender, nil, put); err != nil {
+		put, h := createPutRequest(key, []byte("value"), txn)
+		if reply, err := client.SendWrappedWith(s.Sender, nil, h, put); err != nil {
 			t.Fatal(err)
 		} else {
 			txn = reply.Header().Txn
 		}
 	}
 	endTxn := func() {
-		if _, err := client.SendWrapped(s.Sender, nil, &roachpb.EndTransactionRequest{
-			RequestHeader: roachpb.RequestHeader{
-				Txn: txn,
-			},
+		if _, err := client.SendWrappedWith(s.Sender, nil, roachpb.BatchRequest_Header{
+			Txn: txn,
+		}, &roachpb.EndTransactionRequest{
 			Commit: true}); err != nil {
 			t.Fatal(err)
 		}
@@ -614,12 +612,13 @@ func TestTxnDrainingNode(t *testing.T) {
 
 	// Attempt to start another transaction, but it should be too late.
 	key = roachpb.Key("key")
-	_, err := client.SendWrapped(s.Sender, nil, &roachpb.PutRequest{
+	_, err := client.SendWrappedWith(s.Sender, nil, roachpb.BatchRequest_Header{
+		Txn: &roachpb.Transaction{
+			Name: "test txn",
+		},
+	}, &roachpb.PutRequest{
 		RequestHeader: roachpb.RequestHeader{
 			Key: key,
-			Txn: &roachpb.Transaction{
-				Name: "test txn",
-			},
 		},
 	})
 	if _, ok := err.(*roachpb.NodeUnavailableError); !ok {
@@ -647,12 +646,11 @@ func TestTxnMultipleCoord(t *testing.T) {
 		{roachpb.NewPut(roachpb.Key("a"), roachpb.Value{}), false, true},
 		{roachpb.NewPut(roachpb.Key("a"), roachpb.Value{}), true, false},
 	} {
-		{
-			txn := newTxn(s.Clock, roachpb.Key("a"))
-			txn.Writing = tc.writing
-			tc.args.Header().Txn = txn
-		}
-		reply, err := client.SendWrapped(s.Sender, nil, tc.args)
+		txn := newTxn(s.Clock, roachpb.Key("a"))
+		txn.Writing = tc.writing
+		reply, err := client.SendWrappedWith(s.Sender, nil, roachpb.BatchRequest_Header{
+			Txn: txn,
+		}, tc.args)
 		if err == nil != tc.ok {
 			t.Errorf("%d: %T (writing=%t): success_expected=%t, but got: %v",
 				i, tc.args, tc.writing, tc.ok, err)
@@ -661,7 +659,7 @@ func TestTxnMultipleCoord(t *testing.T) {
 			continue
 		}
 
-		txn := reply.Header().Txn
+		txn = reply.Header().Txn
 		// The transaction should come back rw if it started rw or if we just
 		// wrote.
 		isWrite := roachpb.IsTransactionWrite(tc.args)
@@ -672,10 +670,9 @@ func TestTxnMultipleCoord(t *testing.T) {
 			continue
 		}
 		// Abort for clean shutdown.
-		if _, err := client.SendWrapped(s.Sender, nil, &roachpb.EndTransactionRequest{
-			RequestHeader: roachpb.RequestHeader{
-				Txn: txn,
-			},
+		if _, err := client.SendWrappedWith(s.Sender, nil, roachpb.BatchRequest_Header{
+			Txn: txn,
+		}, &roachpb.EndTransactionRequest{
 			Commit: false,
 		}); err != nil {
 			t.Fatal(err)

--- a/kv/txn_coord_sender_test.go
+++ b/kv/txn_coord_sender_test.go
@@ -506,14 +506,7 @@ func TestTxnCoordSenderTxnUpdatedOnError(t *testing.T) {
 
 	var testPutReq = &roachpb.PutRequest{
 		RequestHeader: roachpb.RequestHeader{
-			Key:          roachpb.Key("test-key"),
-			UserPriority: proto.Int32(-1),
-			Txn: &roachpb.Transaction{
-				Name: "test txn",
-			},
-			Replica: roachpb.ReplicaDescriptor{
-				NodeID: 12345,
-			},
+			Key: roachpb.Key("test-key"),
 		},
 	}
 
@@ -526,7 +519,15 @@ func TestTxnCoordSenderTxnUpdatedOnError(t *testing.T) {
 		var err error
 		{
 			var r roachpb.Response
-			if r, err = client.SendWrapped(ts, nil, proto.Clone(testPutReq).(roachpb.Request)); err != nil {
+			if r, err = client.SendWrappedWith(ts, nil, roachpb.BatchRequest_Header{
+				UserPriority: proto.Int32(-1),
+				Txn: &roachpb.Transaction{
+					Name: "test txn",
+				},
+				Replica: roachpb.ReplicaDescriptor{
+					NodeID: 12345,
+				},
+			}, proto.Clone(testPutReq).(roachpb.Request)); err != nil {
 				t.Fatal(err)
 			}
 			reply = r.(*roachpb.PutResponse)

--- a/roachpb/api.pb.go
+++ b/roachpb/api.pb.go
@@ -261,16 +261,6 @@ type RequestHeader struct {
 	// that the operation takes place on the key range from Key to EndKey,
 	// including Key and excluding EndKey.
 	EndKey Key `protobuf:"bytes,4,opt,name=end_key,casttype=Key" json:"end_key,omitempty"`
-	// UserPriority specifies priority multiple for non-transactional
-	// commands. This value should be a positive integer [1, 2^31-1).
-	// It's properly viewed as a multiple for how likely this
-	// transaction will be to prevail if a write conflict occurs.
-	// Commands with UserPriority=100 will be 100x less likely to be
-	// aborted as conflicting transactions or non-transactional commands
-	// with UserPriority=1. This value is ignored if Txn is
-	// specified. If neither this value nor Txn is specified, the value
-	// defaults to 1.
-	UserPriority *int32 `protobuf:"varint,7,opt,name=user_priority,def=1" json:"user_priority,omitempty"`
 	// Txn is set non-nil if a transaction is underway. To start a txn,
 	// the first request should set this field to non-nil with name and
 	// isolation level set as desired. The response will contain the
@@ -282,8 +272,6 @@ type RequestHeader struct {
 func (m *RequestHeader) Reset()         { *m = RequestHeader{} }
 func (m *RequestHeader) String() string { return proto.CompactTextString(m) }
 func (*RequestHeader) ProtoMessage()    {}
-
-const Default_RequestHeader_UserPriority int32 = 1
 
 func (m *RequestHeader) GetKey() Key {
 	if m != nil {
@@ -297,13 +285,6 @@ func (m *RequestHeader) GetEndKey() Key {
 		return m.EndKey
 	}
 	return nil
-}
-
-func (m *RequestHeader) GetUserPriority() int32 {
-	if m != nil && m.UserPriority != nil {
-		return *m.UserPriority
-	}
-	return Default_RequestHeader_UserPriority
 }
 
 func (m *RequestHeader) GetTxn() *Transaction {
@@ -1775,11 +1756,6 @@ func (m *RequestHeader) MarshalTo(data []byte) (int, error) {
 		i++
 		i = encodeVarintApi(data, i, uint64(len(m.EndKey)))
 		i += copy(data[i:], m.EndKey)
-	}
-	if m.UserPriority != nil {
-		data[i] = 0x38
-		i++
-		i = encodeVarintApi(data, i, uint64(*m.UserPriority))
 	}
 	if m.Txn != nil {
 		data[i] = 0x42
@@ -3921,9 +3897,6 @@ func (m *RequestHeader) Size() (n int) {
 		l = len(m.EndKey)
 		n += 1 + l + sovApi(uint64(l))
 	}
-	if m.UserPriority != nil {
-		n += 1 + sovApi(uint64(*m.UserPriority))
-	}
 	if m.Txn != nil {
 		l = m.Txn.Size()
 		n += 1 + l + sovApi(uint64(l))
@@ -5045,26 +5018,6 @@ func (m *RequestHeader) Unmarshal(data []byte) error {
 			}
 			m.EndKey = append([]byte{}, data[iNdEx:postIndex]...)
 			iNdEx = postIndex
-		case 7:
-			if wireType != 0 {
-				return fmt.Errorf("proto: wrong wireType = %d for field UserPriority", wireType)
-			}
-			var v int32
-			for shift := uint(0); ; shift += 7 {
-				if shift >= 64 {
-					return ErrIntOverflowApi
-				}
-				if iNdEx >= l {
-					return io.ErrUnexpectedEOF
-				}
-				b := data[iNdEx]
-				iNdEx++
-				v |= (int32(b) & 0x7F) << shift
-				if b < 0x80 {
-					break
-				}
-			}
-			m.UserPriority = &v
 		case 8:
 			if wireType != 2 {
 				return fmt.Errorf("proto: wrong wireType = %d for field Txn", wireType)

--- a/roachpb/api.pb.go
+++ b/roachpb/api.pb.go
@@ -277,10 +277,6 @@ type RequestHeader struct {
 	// fully-initialized transaction with txn ID, priority, initial
 	// timestamp, and maximum timestamp.
 	Txn *Transaction `protobuf:"bytes,8,opt,name=txn" json:"txn,omitempty"`
-	// ReadConsistency specifies the consistency for read
-	// operations. The default is CONSISTENT. This value is ignored for
-	// write operations.
-	ReadConsistency ReadConsistencyType `protobuf:"varint,9,opt,name=read_consistency,enum=cockroach.roachpb.ReadConsistencyType" json:"read_consistency"`
 }
 
 func (m *RequestHeader) Reset()         { *m = RequestHeader{} }
@@ -315,13 +311,6 @@ func (m *RequestHeader) GetTxn() *Transaction {
 		return m.Txn
 	}
 	return nil
-}
-
-func (m *RequestHeader) GetReadConsistency() ReadConsistencyType {
-	if m != nil {
-		return m.ReadConsistency
-	}
-	return CONSISTENT
 }
 
 // ResponseHeader is returned with every storage node response.
@@ -1802,9 +1791,6 @@ func (m *RequestHeader) MarshalTo(data []byte) (int, error) {
 		}
 		i += n1
 	}
-	data[i] = 0x48
-	i++
-	i = encodeVarintApi(data, i, uint64(m.ReadConsistency))
 	return i, nil
 }
 
@@ -3942,7 +3928,6 @@ func (m *RequestHeader) Size() (n int) {
 		l = m.Txn.Size()
 		n += 1 + l + sovApi(uint64(l))
 	}
-	n += 1 + sovApi(uint64(m.ReadConsistency))
 	return n
 }
 
@@ -5113,25 +5098,6 @@ func (m *RequestHeader) Unmarshal(data []byte) error {
 				return err
 			}
 			iNdEx = postIndex
-		case 9:
-			if wireType != 0 {
-				return fmt.Errorf("proto: wrong wireType = %d for field ReadConsistency", wireType)
-			}
-			m.ReadConsistency = 0
-			for shift := uint(0); ; shift += 7 {
-				if shift >= 64 {
-					return ErrIntOverflowApi
-				}
-				if iNdEx >= l {
-					return io.ErrUnexpectedEOF
-				}
-				b := data[iNdEx]
-				iNdEx++
-				m.ReadConsistency |= (ReadConsistencyType(b) & 0x7F) << shift
-				if b < 0x80 {
-					break
-				}
-			}
 		default:
 			iNdEx = preIndex
 			skippy, err := skipApi(data[iNdEx:])

--- a/roachpb/api.pb.go
+++ b/roachpb/api.pb.go
@@ -253,9 +253,6 @@ func (m *ClientCmdID) GetRandom() int64 {
 
 // RequestHeader is supplied with every storage node request.
 type RequestHeader struct {
-	// CmdID is optionally specified for request idempotence
-	// (i.e. replay protection).
-	CmdID ClientCmdID `protobuf:"bytes,2,opt,name=cmd_id" json:"cmd_id"`
 	// The key for request. If the request operates on a range, this
 	// represents the starting key for the range.
 	Key Key `protobuf:"bytes,3,opt,name=key,casttype=Key" json:"key,omitempty"`
@@ -291,13 +288,6 @@ func (m *RequestHeader) String() string { return proto.CompactTextString(m) }
 func (*RequestHeader) ProtoMessage()    {}
 
 const Default_RequestHeader_UserPriority int32 = 1
-
-func (m *RequestHeader) GetCmdID() ClientCmdID {
-	if m != nil {
-		return m.CmdID
-	}
-	return ClientCmdID{}
-}
 
 func (m *RequestHeader) GetKey() Key {
 	if m != nil {
@@ -1785,14 +1775,6 @@ func (m *RequestHeader) MarshalTo(data []byte) (int, error) {
 	_ = i
 	var l int
 	_ = l
-	data[i] = 0x12
-	i++
-	i = encodeVarintApi(data, i, uint64(m.CmdID.Size()))
-	n1, err := m.CmdID.MarshalTo(data[i:])
-	if err != nil {
-		return 0, err
-	}
-	i += n1
 	if m.Key != nil {
 		data[i] = 0x1a
 		i++
@@ -1814,11 +1796,11 @@ func (m *RequestHeader) MarshalTo(data []byte) (int, error) {
 		data[i] = 0x42
 		i++
 		i = encodeVarintApi(data, i, uint64(m.Txn.Size()))
-		n2, err := m.Txn.MarshalTo(data[i:])
+		n1, err := m.Txn.MarshalTo(data[i:])
 		if err != nil {
 			return 0, err
 		}
-		i += n2
+		i += n1
 	}
 	data[i] = 0x48
 	i++
@@ -1844,20 +1826,20 @@ func (m *ResponseHeader) MarshalTo(data []byte) (int, error) {
 	data[i] = 0x12
 	i++
 	i = encodeVarintApi(data, i, uint64(m.Timestamp.Size()))
-	n3, err := m.Timestamp.MarshalTo(data[i:])
+	n2, err := m.Timestamp.MarshalTo(data[i:])
 	if err != nil {
 		return 0, err
 	}
-	i += n3
+	i += n2
 	if m.Txn != nil {
 		data[i] = 0x1a
 		i++
 		i = encodeVarintApi(data, i, uint64(m.Txn.Size()))
-		n4, err := m.Txn.MarshalTo(data[i:])
+		n3, err := m.Txn.MarshalTo(data[i:])
 		if err != nil {
 			return 0, err
 		}
-		i += n4
+		i += n3
 	}
 	return i, nil
 }
@@ -1880,11 +1862,11 @@ func (m *GetRequest) MarshalTo(data []byte) (int, error) {
 	data[i] = 0xa
 	i++
 	i = encodeVarintApi(data, i, uint64(m.RequestHeader.Size()))
-	n5, err := m.RequestHeader.MarshalTo(data[i:])
+	n4, err := m.RequestHeader.MarshalTo(data[i:])
 	if err != nil {
 		return 0, err
 	}
-	i += n5
+	i += n4
 	return i, nil
 }
 
@@ -1906,20 +1888,20 @@ func (m *GetResponse) MarshalTo(data []byte) (int, error) {
 	data[i] = 0xa
 	i++
 	i = encodeVarintApi(data, i, uint64(m.ResponseHeader.Size()))
-	n6, err := m.ResponseHeader.MarshalTo(data[i:])
+	n5, err := m.ResponseHeader.MarshalTo(data[i:])
 	if err != nil {
 		return 0, err
 	}
-	i += n6
+	i += n5
 	if m.Value != nil {
 		data[i] = 0x12
 		i++
 		i = encodeVarintApi(data, i, uint64(m.Value.Size()))
-		n7, err := m.Value.MarshalTo(data[i:])
+		n6, err := m.Value.MarshalTo(data[i:])
 		if err != nil {
 			return 0, err
 		}
-		i += n7
+		i += n6
 	}
 	return i, nil
 }
@@ -1942,19 +1924,19 @@ func (m *PutRequest) MarshalTo(data []byte) (int, error) {
 	data[i] = 0xa
 	i++
 	i = encodeVarintApi(data, i, uint64(m.RequestHeader.Size()))
-	n8, err := m.RequestHeader.MarshalTo(data[i:])
+	n7, err := m.RequestHeader.MarshalTo(data[i:])
+	if err != nil {
+		return 0, err
+	}
+	i += n7
+	data[i] = 0x12
+	i++
+	i = encodeVarintApi(data, i, uint64(m.Value.Size()))
+	n8, err := m.Value.MarshalTo(data[i:])
 	if err != nil {
 		return 0, err
 	}
 	i += n8
-	data[i] = 0x12
-	i++
-	i = encodeVarintApi(data, i, uint64(m.Value.Size()))
-	n9, err := m.Value.MarshalTo(data[i:])
-	if err != nil {
-		return 0, err
-	}
-	i += n9
 	return i, nil
 }
 
@@ -1976,11 +1958,11 @@ func (m *PutResponse) MarshalTo(data []byte) (int, error) {
 	data[i] = 0xa
 	i++
 	i = encodeVarintApi(data, i, uint64(m.ResponseHeader.Size()))
-	n10, err := m.ResponseHeader.MarshalTo(data[i:])
+	n9, err := m.ResponseHeader.MarshalTo(data[i:])
 	if err != nil {
 		return 0, err
 	}
-	i += n10
+	i += n9
 	return i, nil
 }
 
@@ -2002,28 +1984,28 @@ func (m *ConditionalPutRequest) MarshalTo(data []byte) (int, error) {
 	data[i] = 0xa
 	i++
 	i = encodeVarintApi(data, i, uint64(m.RequestHeader.Size()))
-	n11, err := m.RequestHeader.MarshalTo(data[i:])
+	n10, err := m.RequestHeader.MarshalTo(data[i:])
+	if err != nil {
+		return 0, err
+	}
+	i += n10
+	data[i] = 0x12
+	i++
+	i = encodeVarintApi(data, i, uint64(m.Value.Size()))
+	n11, err := m.Value.MarshalTo(data[i:])
 	if err != nil {
 		return 0, err
 	}
 	i += n11
-	data[i] = 0x12
-	i++
-	i = encodeVarintApi(data, i, uint64(m.Value.Size()))
-	n12, err := m.Value.MarshalTo(data[i:])
-	if err != nil {
-		return 0, err
-	}
-	i += n12
 	if m.ExpValue != nil {
 		data[i] = 0x1a
 		i++
 		i = encodeVarintApi(data, i, uint64(m.ExpValue.Size()))
-		n13, err := m.ExpValue.MarshalTo(data[i:])
+		n12, err := m.ExpValue.MarshalTo(data[i:])
 		if err != nil {
 			return 0, err
 		}
-		i += n13
+		i += n12
 	}
 	return i, nil
 }
@@ -2046,11 +2028,11 @@ func (m *ConditionalPutResponse) MarshalTo(data []byte) (int, error) {
 	data[i] = 0xa
 	i++
 	i = encodeVarintApi(data, i, uint64(m.ResponseHeader.Size()))
-	n14, err := m.ResponseHeader.MarshalTo(data[i:])
+	n13, err := m.ResponseHeader.MarshalTo(data[i:])
 	if err != nil {
 		return 0, err
 	}
-	i += n14
+	i += n13
 	return i, nil
 }
 
@@ -2072,11 +2054,11 @@ func (m *IncrementRequest) MarshalTo(data []byte) (int, error) {
 	data[i] = 0xa
 	i++
 	i = encodeVarintApi(data, i, uint64(m.RequestHeader.Size()))
-	n15, err := m.RequestHeader.MarshalTo(data[i:])
+	n14, err := m.RequestHeader.MarshalTo(data[i:])
 	if err != nil {
 		return 0, err
 	}
-	i += n15
+	i += n14
 	data[i] = 0x10
 	i++
 	i = encodeVarintApi(data, i, uint64(m.Increment))
@@ -2101,11 +2083,11 @@ func (m *IncrementResponse) MarshalTo(data []byte) (int, error) {
 	data[i] = 0xa
 	i++
 	i = encodeVarintApi(data, i, uint64(m.ResponseHeader.Size()))
-	n16, err := m.ResponseHeader.MarshalTo(data[i:])
+	n15, err := m.ResponseHeader.MarshalTo(data[i:])
 	if err != nil {
 		return 0, err
 	}
-	i += n16
+	i += n15
 	data[i] = 0x10
 	i++
 	i = encodeVarintApi(data, i, uint64(m.NewValue))
@@ -2130,11 +2112,11 @@ func (m *DeleteRequest) MarshalTo(data []byte) (int, error) {
 	data[i] = 0xa
 	i++
 	i = encodeVarintApi(data, i, uint64(m.RequestHeader.Size()))
-	n17, err := m.RequestHeader.MarshalTo(data[i:])
+	n16, err := m.RequestHeader.MarshalTo(data[i:])
 	if err != nil {
 		return 0, err
 	}
-	i += n17
+	i += n16
 	return i, nil
 }
 
@@ -2156,11 +2138,11 @@ func (m *DeleteResponse) MarshalTo(data []byte) (int, error) {
 	data[i] = 0xa
 	i++
 	i = encodeVarintApi(data, i, uint64(m.ResponseHeader.Size()))
-	n18, err := m.ResponseHeader.MarshalTo(data[i:])
+	n17, err := m.ResponseHeader.MarshalTo(data[i:])
 	if err != nil {
 		return 0, err
 	}
-	i += n18
+	i += n17
 	return i, nil
 }
 
@@ -2182,11 +2164,11 @@ func (m *DeleteRangeRequest) MarshalTo(data []byte) (int, error) {
 	data[i] = 0xa
 	i++
 	i = encodeVarintApi(data, i, uint64(m.RequestHeader.Size()))
-	n19, err := m.RequestHeader.MarshalTo(data[i:])
+	n18, err := m.RequestHeader.MarshalTo(data[i:])
 	if err != nil {
 		return 0, err
 	}
-	i += n19
+	i += n18
 	data[i] = 0x10
 	i++
 	i = encodeVarintApi(data, i, uint64(m.MaxEntriesToDelete))
@@ -2211,11 +2193,11 @@ func (m *DeleteRangeResponse) MarshalTo(data []byte) (int, error) {
 	data[i] = 0xa
 	i++
 	i = encodeVarintApi(data, i, uint64(m.ResponseHeader.Size()))
-	n20, err := m.ResponseHeader.MarshalTo(data[i:])
+	n19, err := m.ResponseHeader.MarshalTo(data[i:])
 	if err != nil {
 		return 0, err
 	}
-	i += n20
+	i += n19
 	data[i] = 0x10
 	i++
 	i = encodeVarintApi(data, i, uint64(m.NumDeleted))
@@ -2240,11 +2222,11 @@ func (m *ScanRequest) MarshalTo(data []byte) (int, error) {
 	data[i] = 0xa
 	i++
 	i = encodeVarintApi(data, i, uint64(m.RequestHeader.Size()))
-	n21, err := m.RequestHeader.MarshalTo(data[i:])
+	n20, err := m.RequestHeader.MarshalTo(data[i:])
 	if err != nil {
 		return 0, err
 	}
-	i += n21
+	i += n20
 	data[i] = 0x10
 	i++
 	i = encodeVarintApi(data, i, uint64(m.MaxResults))
@@ -2269,11 +2251,11 @@ func (m *ScanResponse) MarshalTo(data []byte) (int, error) {
 	data[i] = 0xa
 	i++
 	i = encodeVarintApi(data, i, uint64(m.ResponseHeader.Size()))
-	n22, err := m.ResponseHeader.MarshalTo(data[i:])
+	n21, err := m.ResponseHeader.MarshalTo(data[i:])
 	if err != nil {
 		return 0, err
 	}
-	i += n22
+	i += n21
 	if len(m.Rows) > 0 {
 		for _, msg := range m.Rows {
 			data[i] = 0x12
@@ -2307,11 +2289,11 @@ func (m *ReverseScanRequest) MarshalTo(data []byte) (int, error) {
 	data[i] = 0xa
 	i++
 	i = encodeVarintApi(data, i, uint64(m.RequestHeader.Size()))
-	n23, err := m.RequestHeader.MarshalTo(data[i:])
+	n22, err := m.RequestHeader.MarshalTo(data[i:])
 	if err != nil {
 		return 0, err
 	}
-	i += n23
+	i += n22
 	data[i] = 0x10
 	i++
 	i = encodeVarintApi(data, i, uint64(m.MaxResults))
@@ -2336,11 +2318,11 @@ func (m *ReverseScanResponse) MarshalTo(data []byte) (int, error) {
 	data[i] = 0xa
 	i++
 	i = encodeVarintApi(data, i, uint64(m.ResponseHeader.Size()))
-	n24, err := m.ResponseHeader.MarshalTo(data[i:])
+	n23, err := m.ResponseHeader.MarshalTo(data[i:])
 	if err != nil {
 		return 0, err
 	}
-	i += n24
+	i += n23
 	if len(m.Rows) > 0 {
 		for _, msg := range m.Rows {
 			data[i] = 0x12
@@ -2374,11 +2356,11 @@ func (m *EndTransactionRequest) MarshalTo(data []byte) (int, error) {
 	data[i] = 0xa
 	i++
 	i = encodeVarintApi(data, i, uint64(m.RequestHeader.Size()))
-	n25, err := m.RequestHeader.MarshalTo(data[i:])
+	n24, err := m.RequestHeader.MarshalTo(data[i:])
 	if err != nil {
 		return 0, err
 	}
-	i += n25
+	i += n24
 	data[i] = 0x10
 	i++
 	if m.Commit {
@@ -2391,11 +2373,11 @@ func (m *EndTransactionRequest) MarshalTo(data []byte) (int, error) {
 		data[i] = 0x1a
 		i++
 		i = encodeVarintApi(data, i, uint64(m.InternalCommitTrigger.Size()))
-		n26, err := m.InternalCommitTrigger.MarshalTo(data[i:])
+		n25, err := m.InternalCommitTrigger.MarshalTo(data[i:])
 		if err != nil {
 			return 0, err
 		}
-		i += n26
+		i += n25
 	}
 	if len(m.Intents) > 0 {
 		for _, msg := range m.Intents {
@@ -2430,11 +2412,11 @@ func (m *EndTransactionResponse) MarshalTo(data []byte) (int, error) {
 	data[i] = 0xa
 	i++
 	i = encodeVarintApi(data, i, uint64(m.ResponseHeader.Size()))
-	n27, err := m.ResponseHeader.MarshalTo(data[i:])
+	n26, err := m.ResponseHeader.MarshalTo(data[i:])
 	if err != nil {
 		return 0, err
 	}
-	i += n27
+	i += n26
 	data[i] = 0x10
 	i++
 	i = encodeVarintApi(data, i, uint64(m.CommitWait))
@@ -2467,11 +2449,11 @@ func (m *AdminSplitRequest) MarshalTo(data []byte) (int, error) {
 	data[i] = 0xa
 	i++
 	i = encodeVarintApi(data, i, uint64(m.RequestHeader.Size()))
-	n28, err := m.RequestHeader.MarshalTo(data[i:])
+	n27, err := m.RequestHeader.MarshalTo(data[i:])
 	if err != nil {
 		return 0, err
 	}
-	i += n28
+	i += n27
 	if m.SplitKey != nil {
 		data[i] = 0x12
 		i++
@@ -2499,11 +2481,11 @@ func (m *AdminSplitResponse) MarshalTo(data []byte) (int, error) {
 	data[i] = 0xa
 	i++
 	i = encodeVarintApi(data, i, uint64(m.ResponseHeader.Size()))
-	n29, err := m.ResponseHeader.MarshalTo(data[i:])
+	n28, err := m.ResponseHeader.MarshalTo(data[i:])
 	if err != nil {
 		return 0, err
 	}
-	i += n29
+	i += n28
 	return i, nil
 }
 
@@ -2525,11 +2507,11 @@ func (m *AdminMergeRequest) MarshalTo(data []byte) (int, error) {
 	data[i] = 0xa
 	i++
 	i = encodeVarintApi(data, i, uint64(m.RequestHeader.Size()))
-	n30, err := m.RequestHeader.MarshalTo(data[i:])
+	n29, err := m.RequestHeader.MarshalTo(data[i:])
 	if err != nil {
 		return 0, err
 	}
-	i += n30
+	i += n29
 	return i, nil
 }
 
@@ -2551,11 +2533,11 @@ func (m *AdminMergeResponse) MarshalTo(data []byte) (int, error) {
 	data[i] = 0xa
 	i++
 	i = encodeVarintApi(data, i, uint64(m.ResponseHeader.Size()))
-	n31, err := m.ResponseHeader.MarshalTo(data[i:])
+	n30, err := m.ResponseHeader.MarshalTo(data[i:])
 	if err != nil {
 		return 0, err
 	}
-	i += n31
+	i += n30
 	return i, nil
 }
 
@@ -2577,11 +2559,11 @@ func (m *RangeLookupRequest) MarshalTo(data []byte) (int, error) {
 	data[i] = 0xa
 	i++
 	i = encodeVarintApi(data, i, uint64(m.RequestHeader.Size()))
-	n32, err := m.RequestHeader.MarshalTo(data[i:])
+	n31, err := m.RequestHeader.MarshalTo(data[i:])
 	if err != nil {
 		return 0, err
 	}
-	i += n32
+	i += n31
 	data[i] = 0x10
 	i++
 	i = encodeVarintApi(data, i, uint64(m.MaxRanges))
@@ -2622,11 +2604,11 @@ func (m *RangeLookupResponse) MarshalTo(data []byte) (int, error) {
 	data[i] = 0xa
 	i++
 	i = encodeVarintApi(data, i, uint64(m.ResponseHeader.Size()))
-	n33, err := m.ResponseHeader.MarshalTo(data[i:])
+	n32, err := m.ResponseHeader.MarshalTo(data[i:])
 	if err != nil {
 		return 0, err
 	}
-	i += n33
+	i += n32
 	if len(m.Ranges) > 0 {
 		for _, msg := range m.Ranges {
 			data[i] = 0x12
@@ -2660,11 +2642,11 @@ func (m *HeartbeatTxnRequest) MarshalTo(data []byte) (int, error) {
 	data[i] = 0xa
 	i++
 	i = encodeVarintApi(data, i, uint64(m.RequestHeader.Size()))
-	n34, err := m.RequestHeader.MarshalTo(data[i:])
+	n33, err := m.RequestHeader.MarshalTo(data[i:])
 	if err != nil {
 		return 0, err
 	}
-	i += n34
+	i += n33
 	return i, nil
 }
 
@@ -2686,11 +2668,11 @@ func (m *HeartbeatTxnResponse) MarshalTo(data []byte) (int, error) {
 	data[i] = 0xa
 	i++
 	i = encodeVarintApi(data, i, uint64(m.ResponseHeader.Size()))
-	n35, err := m.ResponseHeader.MarshalTo(data[i:])
+	n34, err := m.ResponseHeader.MarshalTo(data[i:])
 	if err != nil {
 		return 0, err
 	}
-	i += n35
+	i += n34
 	return i, nil
 }
 
@@ -2712,19 +2694,19 @@ func (m *GCRequest) MarshalTo(data []byte) (int, error) {
 	data[i] = 0xa
 	i++
 	i = encodeVarintApi(data, i, uint64(m.RequestHeader.Size()))
-	n36, err := m.RequestHeader.MarshalTo(data[i:])
+	n35, err := m.RequestHeader.MarshalTo(data[i:])
+	if err != nil {
+		return 0, err
+	}
+	i += n35
+	data[i] = 0x12
+	i++
+	i = encodeVarintApi(data, i, uint64(m.GCMeta.Size()))
+	n36, err := m.GCMeta.MarshalTo(data[i:])
 	if err != nil {
 		return 0, err
 	}
 	i += n36
-	data[i] = 0x12
-	i++
-	i = encodeVarintApi(data, i, uint64(m.GCMeta.Size()))
-	n37, err := m.GCMeta.MarshalTo(data[i:])
-	if err != nil {
-		return 0, err
-	}
-	i += n37
 	if len(m.Keys) > 0 {
 		for _, msg := range m.Keys {
 			data[i] = 0x1a
@@ -2764,11 +2746,11 @@ func (m *GCRequest_GCKey) MarshalTo(data []byte) (int, error) {
 	data[i] = 0x12
 	i++
 	i = encodeVarintApi(data, i, uint64(m.Timestamp.Size()))
-	n38, err := m.Timestamp.MarshalTo(data[i:])
+	n37, err := m.Timestamp.MarshalTo(data[i:])
 	if err != nil {
 		return 0, err
 	}
-	i += n38
+	i += n37
 	return i, nil
 }
 
@@ -2790,11 +2772,11 @@ func (m *GCResponse) MarshalTo(data []byte) (int, error) {
 	data[i] = 0xa
 	i++
 	i = encodeVarintApi(data, i, uint64(m.ResponseHeader.Size()))
-	n39, err := m.ResponseHeader.MarshalTo(data[i:])
+	n38, err := m.ResponseHeader.MarshalTo(data[i:])
 	if err != nil {
 		return 0, err
 	}
-	i += n39
+	i += n38
 	return i, nil
 }
 
@@ -2816,43 +2798,43 @@ func (m *PushTxnRequest) MarshalTo(data []byte) (int, error) {
 	data[i] = 0xa
 	i++
 	i = encodeVarintApi(data, i, uint64(m.RequestHeader.Size()))
-	n40, err := m.RequestHeader.MarshalTo(data[i:])
+	n39, err := m.RequestHeader.MarshalTo(data[i:])
+	if err != nil {
+		return 0, err
+	}
+	i += n39
+	data[i] = 0x12
+	i++
+	i = encodeVarintApi(data, i, uint64(m.PusherTxn.Size()))
+	n40, err := m.PusherTxn.MarshalTo(data[i:])
 	if err != nil {
 		return 0, err
 	}
 	i += n40
-	data[i] = 0x12
+	data[i] = 0x1a
 	i++
-	i = encodeVarintApi(data, i, uint64(m.PusherTxn.Size()))
-	n41, err := m.PusherTxn.MarshalTo(data[i:])
+	i = encodeVarintApi(data, i, uint64(m.PusheeTxn.Size()))
+	n41, err := m.PusheeTxn.MarshalTo(data[i:])
 	if err != nil {
 		return 0, err
 	}
 	i += n41
-	data[i] = 0x1a
+	data[i] = 0x22
 	i++
-	i = encodeVarintApi(data, i, uint64(m.PusheeTxn.Size()))
-	n42, err := m.PusheeTxn.MarshalTo(data[i:])
+	i = encodeVarintApi(data, i, uint64(m.PushTo.Size()))
+	n42, err := m.PushTo.MarshalTo(data[i:])
 	if err != nil {
 		return 0, err
 	}
 	i += n42
-	data[i] = 0x22
+	data[i] = 0x2a
 	i++
-	i = encodeVarintApi(data, i, uint64(m.PushTo.Size()))
-	n43, err := m.PushTo.MarshalTo(data[i:])
+	i = encodeVarintApi(data, i, uint64(m.Now.Size()))
+	n43, err := m.Now.MarshalTo(data[i:])
 	if err != nil {
 		return 0, err
 	}
 	i += n43
-	data[i] = 0x2a
-	i++
-	i = encodeVarintApi(data, i, uint64(m.Now.Size()))
-	n44, err := m.Now.MarshalTo(data[i:])
-	if err != nil {
-		return 0, err
-	}
-	i += n44
 	data[i] = 0x30
 	i++
 	i = encodeVarintApi(data, i, uint64(m.PushType))
@@ -2877,20 +2859,20 @@ func (m *PushTxnResponse) MarshalTo(data []byte) (int, error) {
 	data[i] = 0xa
 	i++
 	i = encodeVarintApi(data, i, uint64(m.ResponseHeader.Size()))
-	n45, err := m.ResponseHeader.MarshalTo(data[i:])
+	n44, err := m.ResponseHeader.MarshalTo(data[i:])
 	if err != nil {
 		return 0, err
 	}
-	i += n45
+	i += n44
 	if m.PusheeTxn != nil {
 		data[i] = 0x12
 		i++
 		i = encodeVarintApi(data, i, uint64(m.PusheeTxn.Size()))
-		n46, err := m.PusheeTxn.MarshalTo(data[i:])
+		n45, err := m.PusheeTxn.MarshalTo(data[i:])
 		if err != nil {
 			return 0, err
 		}
-		i += n46
+		i += n45
 	}
 	return i, nil
 }
@@ -2913,19 +2895,19 @@ func (m *ResolveIntentRequest) MarshalTo(data []byte) (int, error) {
 	data[i] = 0xa
 	i++
 	i = encodeVarintApi(data, i, uint64(m.RequestHeader.Size()))
-	n47, err := m.RequestHeader.MarshalTo(data[i:])
+	n46, err := m.RequestHeader.MarshalTo(data[i:])
+	if err != nil {
+		return 0, err
+	}
+	i += n46
+	data[i] = 0x12
+	i++
+	i = encodeVarintApi(data, i, uint64(m.IntentTxn.Size()))
+	n47, err := m.IntentTxn.MarshalTo(data[i:])
 	if err != nil {
 		return 0, err
 	}
 	i += n47
-	data[i] = 0x12
-	i++
-	i = encodeVarintApi(data, i, uint64(m.IntentTxn.Size()))
-	n48, err := m.IntentTxn.MarshalTo(data[i:])
-	if err != nil {
-		return 0, err
-	}
-	i += n48
 	return i, nil
 }
 
@@ -2947,11 +2929,11 @@ func (m *ResolveIntentResponse) MarshalTo(data []byte) (int, error) {
 	data[i] = 0xa
 	i++
 	i = encodeVarintApi(data, i, uint64(m.ResponseHeader.Size()))
-	n49, err := m.ResponseHeader.MarshalTo(data[i:])
+	n48, err := m.ResponseHeader.MarshalTo(data[i:])
 	if err != nil {
 		return 0, err
 	}
-	i += n49
+	i += n48
 	return i, nil
 }
 
@@ -2973,19 +2955,19 @@ func (m *ResolveIntentRangeRequest) MarshalTo(data []byte) (int, error) {
 	data[i] = 0xa
 	i++
 	i = encodeVarintApi(data, i, uint64(m.RequestHeader.Size()))
-	n50, err := m.RequestHeader.MarshalTo(data[i:])
+	n49, err := m.RequestHeader.MarshalTo(data[i:])
+	if err != nil {
+		return 0, err
+	}
+	i += n49
+	data[i] = 0x12
+	i++
+	i = encodeVarintApi(data, i, uint64(m.IntentTxn.Size()))
+	n50, err := m.IntentTxn.MarshalTo(data[i:])
 	if err != nil {
 		return 0, err
 	}
 	i += n50
-	data[i] = 0x12
-	i++
-	i = encodeVarintApi(data, i, uint64(m.IntentTxn.Size()))
-	n51, err := m.IntentTxn.MarshalTo(data[i:])
-	if err != nil {
-		return 0, err
-	}
-	i += n51
 	return i, nil
 }
 
@@ -3007,11 +2989,11 @@ func (m *NoopResponse) MarshalTo(data []byte) (int, error) {
 	data[i] = 0xa
 	i++
 	i = encodeVarintApi(data, i, uint64(m.ResponseHeader.Size()))
-	n52, err := m.ResponseHeader.MarshalTo(data[i:])
+	n51, err := m.ResponseHeader.MarshalTo(data[i:])
 	if err != nil {
 		return 0, err
 	}
-	i += n52
+	i += n51
 	return i, nil
 }
 
@@ -3033,11 +3015,11 @@ func (m *NoopRequest) MarshalTo(data []byte) (int, error) {
 	data[i] = 0xa
 	i++
 	i = encodeVarintApi(data, i, uint64(m.RequestHeader.Size()))
-	n53, err := m.RequestHeader.MarshalTo(data[i:])
+	n52, err := m.RequestHeader.MarshalTo(data[i:])
 	if err != nil {
 		return 0, err
 	}
-	i += n53
+	i += n52
 	return i, nil
 }
 
@@ -3059,11 +3041,11 @@ func (m *ResolveIntentRangeResponse) MarshalTo(data []byte) (int, error) {
 	data[i] = 0xa
 	i++
 	i = encodeVarintApi(data, i, uint64(m.ResponseHeader.Size()))
-	n54, err := m.ResponseHeader.MarshalTo(data[i:])
+	n53, err := m.ResponseHeader.MarshalTo(data[i:])
 	if err != nil {
 		return 0, err
 	}
-	i += n54
+	i += n53
 	return i, nil
 }
 
@@ -3085,19 +3067,19 @@ func (m *MergeRequest) MarshalTo(data []byte) (int, error) {
 	data[i] = 0xa
 	i++
 	i = encodeVarintApi(data, i, uint64(m.RequestHeader.Size()))
-	n55, err := m.RequestHeader.MarshalTo(data[i:])
+	n54, err := m.RequestHeader.MarshalTo(data[i:])
+	if err != nil {
+		return 0, err
+	}
+	i += n54
+	data[i] = 0x12
+	i++
+	i = encodeVarintApi(data, i, uint64(m.Value.Size()))
+	n55, err := m.Value.MarshalTo(data[i:])
 	if err != nil {
 		return 0, err
 	}
 	i += n55
-	data[i] = 0x12
-	i++
-	i = encodeVarintApi(data, i, uint64(m.Value.Size()))
-	n56, err := m.Value.MarshalTo(data[i:])
-	if err != nil {
-		return 0, err
-	}
-	i += n56
 	return i, nil
 }
 
@@ -3119,11 +3101,11 @@ func (m *MergeResponse) MarshalTo(data []byte) (int, error) {
 	data[i] = 0xa
 	i++
 	i = encodeVarintApi(data, i, uint64(m.ResponseHeader.Size()))
-	n57, err := m.ResponseHeader.MarshalTo(data[i:])
+	n56, err := m.ResponseHeader.MarshalTo(data[i:])
 	if err != nil {
 		return 0, err
 	}
-	i += n57
+	i += n56
 	return i, nil
 }
 
@@ -3145,11 +3127,11 @@ func (m *TruncateLogRequest) MarshalTo(data []byte) (int, error) {
 	data[i] = 0xa
 	i++
 	i = encodeVarintApi(data, i, uint64(m.RequestHeader.Size()))
-	n58, err := m.RequestHeader.MarshalTo(data[i:])
+	n57, err := m.RequestHeader.MarshalTo(data[i:])
 	if err != nil {
 		return 0, err
 	}
-	i += n58
+	i += n57
 	data[i] = 0x10
 	i++
 	i = encodeVarintApi(data, i, uint64(m.Index))
@@ -3174,11 +3156,11 @@ func (m *TruncateLogResponse) MarshalTo(data []byte) (int, error) {
 	data[i] = 0xa
 	i++
 	i = encodeVarintApi(data, i, uint64(m.ResponseHeader.Size()))
-	n59, err := m.ResponseHeader.MarshalTo(data[i:])
+	n58, err := m.ResponseHeader.MarshalTo(data[i:])
 	if err != nil {
 		return 0, err
 	}
-	i += n59
+	i += n58
 	return i, nil
 }
 
@@ -3200,19 +3182,19 @@ func (m *LeaderLeaseRequest) MarshalTo(data []byte) (int, error) {
 	data[i] = 0xa
 	i++
 	i = encodeVarintApi(data, i, uint64(m.RequestHeader.Size()))
-	n60, err := m.RequestHeader.MarshalTo(data[i:])
+	n59, err := m.RequestHeader.MarshalTo(data[i:])
+	if err != nil {
+		return 0, err
+	}
+	i += n59
+	data[i] = 0x12
+	i++
+	i = encodeVarintApi(data, i, uint64(m.Lease.Size()))
+	n60, err := m.Lease.MarshalTo(data[i:])
 	if err != nil {
 		return 0, err
 	}
 	i += n60
-	data[i] = 0x12
-	i++
-	i = encodeVarintApi(data, i, uint64(m.Lease.Size()))
-	n61, err := m.Lease.MarshalTo(data[i:])
-	if err != nil {
-		return 0, err
-	}
-	i += n61
 	return i, nil
 }
 
@@ -3234,11 +3216,11 @@ func (m *LeaderLeaseResponse) MarshalTo(data []byte) (int, error) {
 	data[i] = 0xa
 	i++
 	i = encodeVarintApi(data, i, uint64(m.ResponseHeader.Size()))
-	n62, err := m.ResponseHeader.MarshalTo(data[i:])
+	n61, err := m.ResponseHeader.MarshalTo(data[i:])
 	if err != nil {
 		return 0, err
 	}
-	i += n62
+	i += n61
 	return i, nil
 }
 
@@ -3261,151 +3243,151 @@ func (m *RequestUnion) MarshalTo(data []byte) (int, error) {
 		data[i] = 0xa
 		i++
 		i = encodeVarintApi(data, i, uint64(m.Get.Size()))
-		n63, err := m.Get.MarshalTo(data[i:])
+		n62, err := m.Get.MarshalTo(data[i:])
 		if err != nil {
 			return 0, err
 		}
-		i += n63
+		i += n62
 	}
 	if m.Put != nil {
 		data[i] = 0x12
 		i++
 		i = encodeVarintApi(data, i, uint64(m.Put.Size()))
-		n64, err := m.Put.MarshalTo(data[i:])
+		n63, err := m.Put.MarshalTo(data[i:])
 		if err != nil {
 			return 0, err
 		}
-		i += n64
+		i += n63
 	}
 	if m.ConditionalPut != nil {
 		data[i] = 0x1a
 		i++
 		i = encodeVarintApi(data, i, uint64(m.ConditionalPut.Size()))
-		n65, err := m.ConditionalPut.MarshalTo(data[i:])
+		n64, err := m.ConditionalPut.MarshalTo(data[i:])
 		if err != nil {
 			return 0, err
 		}
-		i += n65
+		i += n64
 	}
 	if m.Increment != nil {
 		data[i] = 0x22
 		i++
 		i = encodeVarintApi(data, i, uint64(m.Increment.Size()))
-		n66, err := m.Increment.MarshalTo(data[i:])
+		n65, err := m.Increment.MarshalTo(data[i:])
 		if err != nil {
 			return 0, err
 		}
-		i += n66
+		i += n65
 	}
 	if m.Delete != nil {
 		data[i] = 0x2a
 		i++
 		i = encodeVarintApi(data, i, uint64(m.Delete.Size()))
-		n67, err := m.Delete.MarshalTo(data[i:])
+		n66, err := m.Delete.MarshalTo(data[i:])
 		if err != nil {
 			return 0, err
 		}
-		i += n67
+		i += n66
 	}
 	if m.DeleteRange != nil {
 		data[i] = 0x32
 		i++
 		i = encodeVarintApi(data, i, uint64(m.DeleteRange.Size()))
-		n68, err := m.DeleteRange.MarshalTo(data[i:])
+		n67, err := m.DeleteRange.MarshalTo(data[i:])
 		if err != nil {
 			return 0, err
 		}
-		i += n68
+		i += n67
 	}
 	if m.Scan != nil {
 		data[i] = 0x3a
 		i++
 		i = encodeVarintApi(data, i, uint64(m.Scan.Size()))
-		n69, err := m.Scan.MarshalTo(data[i:])
+		n68, err := m.Scan.MarshalTo(data[i:])
 		if err != nil {
 			return 0, err
 		}
-		i += n69
+		i += n68
 	}
 	if m.EndTransaction != nil {
 		data[i] = 0x42
 		i++
 		i = encodeVarintApi(data, i, uint64(m.EndTransaction.Size()))
-		n70, err := m.EndTransaction.MarshalTo(data[i:])
+		n69, err := m.EndTransaction.MarshalTo(data[i:])
 		if err != nil {
 			return 0, err
 		}
-		i += n70
+		i += n69
 	}
 	if m.AdminSplit != nil {
 		data[i] = 0x4a
 		i++
 		i = encodeVarintApi(data, i, uint64(m.AdminSplit.Size()))
-		n71, err := m.AdminSplit.MarshalTo(data[i:])
+		n70, err := m.AdminSplit.MarshalTo(data[i:])
 		if err != nil {
 			return 0, err
 		}
-		i += n71
+		i += n70
 	}
 	if m.AdminMerge != nil {
 		data[i] = 0x52
 		i++
 		i = encodeVarintApi(data, i, uint64(m.AdminMerge.Size()))
-		n72, err := m.AdminMerge.MarshalTo(data[i:])
+		n71, err := m.AdminMerge.MarshalTo(data[i:])
 		if err != nil {
 			return 0, err
 		}
-		i += n72
+		i += n71
 	}
 	if m.HeartbeatTxn != nil {
 		data[i] = 0x5a
 		i++
 		i = encodeVarintApi(data, i, uint64(m.HeartbeatTxn.Size()))
-		n73, err := m.HeartbeatTxn.MarshalTo(data[i:])
+		n72, err := m.HeartbeatTxn.MarshalTo(data[i:])
 		if err != nil {
 			return 0, err
 		}
-		i += n73
+		i += n72
 	}
 	if m.Gc != nil {
 		data[i] = 0x62
 		i++
 		i = encodeVarintApi(data, i, uint64(m.Gc.Size()))
-		n74, err := m.Gc.MarshalTo(data[i:])
+		n73, err := m.Gc.MarshalTo(data[i:])
 		if err != nil {
 			return 0, err
 		}
-		i += n74
+		i += n73
 	}
 	if m.PushTxn != nil {
 		data[i] = 0x6a
 		i++
 		i = encodeVarintApi(data, i, uint64(m.PushTxn.Size()))
-		n75, err := m.PushTxn.MarshalTo(data[i:])
+		n74, err := m.PushTxn.MarshalTo(data[i:])
 		if err != nil {
 			return 0, err
 		}
-		i += n75
+		i += n74
 	}
 	if m.RangeLookup != nil {
 		data[i] = 0x72
 		i++
 		i = encodeVarintApi(data, i, uint64(m.RangeLookup.Size()))
-		n76, err := m.RangeLookup.MarshalTo(data[i:])
+		n75, err := m.RangeLookup.MarshalTo(data[i:])
 		if err != nil {
 			return 0, err
 		}
-		i += n76
+		i += n75
 	}
 	if m.ResolveIntent != nil {
 		data[i] = 0x7a
 		i++
 		i = encodeVarintApi(data, i, uint64(m.ResolveIntent.Size()))
-		n77, err := m.ResolveIntent.MarshalTo(data[i:])
+		n76, err := m.ResolveIntent.MarshalTo(data[i:])
 		if err != nil {
 			return 0, err
 		}
-		i += n77
+		i += n76
 	}
 	if m.ResolveIntentRange != nil {
 		data[i] = 0x82
@@ -3413,11 +3395,11 @@ func (m *RequestUnion) MarshalTo(data []byte) (int, error) {
 		data[i] = 0x1
 		i++
 		i = encodeVarintApi(data, i, uint64(m.ResolveIntentRange.Size()))
-		n78, err := m.ResolveIntentRange.MarshalTo(data[i:])
+		n77, err := m.ResolveIntentRange.MarshalTo(data[i:])
 		if err != nil {
 			return 0, err
 		}
-		i += n78
+		i += n77
 	}
 	if m.Merge != nil {
 		data[i] = 0x8a
@@ -3425,11 +3407,11 @@ func (m *RequestUnion) MarshalTo(data []byte) (int, error) {
 		data[i] = 0x1
 		i++
 		i = encodeVarintApi(data, i, uint64(m.Merge.Size()))
-		n79, err := m.Merge.MarshalTo(data[i:])
+		n78, err := m.Merge.MarshalTo(data[i:])
 		if err != nil {
 			return 0, err
 		}
-		i += n79
+		i += n78
 	}
 	if m.TruncateLog != nil {
 		data[i] = 0x92
@@ -3437,11 +3419,11 @@ func (m *RequestUnion) MarshalTo(data []byte) (int, error) {
 		data[i] = 0x1
 		i++
 		i = encodeVarintApi(data, i, uint64(m.TruncateLog.Size()))
-		n80, err := m.TruncateLog.MarshalTo(data[i:])
+		n79, err := m.TruncateLog.MarshalTo(data[i:])
 		if err != nil {
 			return 0, err
 		}
-		i += n80
+		i += n79
 	}
 	if m.LeaderLease != nil {
 		data[i] = 0x9a
@@ -3449,11 +3431,11 @@ func (m *RequestUnion) MarshalTo(data []byte) (int, error) {
 		data[i] = 0x1
 		i++
 		i = encodeVarintApi(data, i, uint64(m.LeaderLease.Size()))
-		n81, err := m.LeaderLease.MarshalTo(data[i:])
+		n80, err := m.LeaderLease.MarshalTo(data[i:])
 		if err != nil {
 			return 0, err
 		}
-		i += n81
+		i += n80
 	}
 	if m.ReverseScan != nil {
 		data[i] = 0xa2
@@ -3461,11 +3443,11 @@ func (m *RequestUnion) MarshalTo(data []byte) (int, error) {
 		data[i] = 0x1
 		i++
 		i = encodeVarintApi(data, i, uint64(m.ReverseScan.Size()))
-		n82, err := m.ReverseScan.MarshalTo(data[i:])
+		n81, err := m.ReverseScan.MarshalTo(data[i:])
 		if err != nil {
 			return 0, err
 		}
-		i += n82
+		i += n81
 	}
 	if m.Noop != nil {
 		data[i] = 0xaa
@@ -3473,11 +3455,11 @@ func (m *RequestUnion) MarshalTo(data []byte) (int, error) {
 		data[i] = 0x1
 		i++
 		i = encodeVarintApi(data, i, uint64(m.Noop.Size()))
-		n83, err := m.Noop.MarshalTo(data[i:])
+		n82, err := m.Noop.MarshalTo(data[i:])
 		if err != nil {
 			return 0, err
 		}
-		i += n83
+		i += n82
 	}
 	return i, nil
 }
@@ -3501,151 +3483,151 @@ func (m *ResponseUnion) MarshalTo(data []byte) (int, error) {
 		data[i] = 0xa
 		i++
 		i = encodeVarintApi(data, i, uint64(m.Get.Size()))
-		n84, err := m.Get.MarshalTo(data[i:])
+		n83, err := m.Get.MarshalTo(data[i:])
 		if err != nil {
 			return 0, err
 		}
-		i += n84
+		i += n83
 	}
 	if m.Put != nil {
 		data[i] = 0x12
 		i++
 		i = encodeVarintApi(data, i, uint64(m.Put.Size()))
-		n85, err := m.Put.MarshalTo(data[i:])
+		n84, err := m.Put.MarshalTo(data[i:])
 		if err != nil {
 			return 0, err
 		}
-		i += n85
+		i += n84
 	}
 	if m.ConditionalPut != nil {
 		data[i] = 0x1a
 		i++
 		i = encodeVarintApi(data, i, uint64(m.ConditionalPut.Size()))
-		n86, err := m.ConditionalPut.MarshalTo(data[i:])
+		n85, err := m.ConditionalPut.MarshalTo(data[i:])
 		if err != nil {
 			return 0, err
 		}
-		i += n86
+		i += n85
 	}
 	if m.Increment != nil {
 		data[i] = 0x22
 		i++
 		i = encodeVarintApi(data, i, uint64(m.Increment.Size()))
-		n87, err := m.Increment.MarshalTo(data[i:])
+		n86, err := m.Increment.MarshalTo(data[i:])
 		if err != nil {
 			return 0, err
 		}
-		i += n87
+		i += n86
 	}
 	if m.Delete != nil {
 		data[i] = 0x2a
 		i++
 		i = encodeVarintApi(data, i, uint64(m.Delete.Size()))
-		n88, err := m.Delete.MarshalTo(data[i:])
+		n87, err := m.Delete.MarshalTo(data[i:])
 		if err != nil {
 			return 0, err
 		}
-		i += n88
+		i += n87
 	}
 	if m.DeleteRange != nil {
 		data[i] = 0x32
 		i++
 		i = encodeVarintApi(data, i, uint64(m.DeleteRange.Size()))
-		n89, err := m.DeleteRange.MarshalTo(data[i:])
+		n88, err := m.DeleteRange.MarshalTo(data[i:])
 		if err != nil {
 			return 0, err
 		}
-		i += n89
+		i += n88
 	}
 	if m.Scan != nil {
 		data[i] = 0x3a
 		i++
 		i = encodeVarintApi(data, i, uint64(m.Scan.Size()))
-		n90, err := m.Scan.MarshalTo(data[i:])
+		n89, err := m.Scan.MarshalTo(data[i:])
 		if err != nil {
 			return 0, err
 		}
-		i += n90
+		i += n89
 	}
 	if m.EndTransaction != nil {
 		data[i] = 0x42
 		i++
 		i = encodeVarintApi(data, i, uint64(m.EndTransaction.Size()))
-		n91, err := m.EndTransaction.MarshalTo(data[i:])
+		n90, err := m.EndTransaction.MarshalTo(data[i:])
 		if err != nil {
 			return 0, err
 		}
-		i += n91
+		i += n90
 	}
 	if m.AdminSplit != nil {
 		data[i] = 0x4a
 		i++
 		i = encodeVarintApi(data, i, uint64(m.AdminSplit.Size()))
-		n92, err := m.AdminSplit.MarshalTo(data[i:])
+		n91, err := m.AdminSplit.MarshalTo(data[i:])
 		if err != nil {
 			return 0, err
 		}
-		i += n92
+		i += n91
 	}
 	if m.AdminMerge != nil {
 		data[i] = 0x52
 		i++
 		i = encodeVarintApi(data, i, uint64(m.AdminMerge.Size()))
-		n93, err := m.AdminMerge.MarshalTo(data[i:])
+		n92, err := m.AdminMerge.MarshalTo(data[i:])
 		if err != nil {
 			return 0, err
 		}
-		i += n93
+		i += n92
 	}
 	if m.HeartbeatTxn != nil {
 		data[i] = 0x5a
 		i++
 		i = encodeVarintApi(data, i, uint64(m.HeartbeatTxn.Size()))
-		n94, err := m.HeartbeatTxn.MarshalTo(data[i:])
+		n93, err := m.HeartbeatTxn.MarshalTo(data[i:])
 		if err != nil {
 			return 0, err
 		}
-		i += n94
+		i += n93
 	}
 	if m.Gc != nil {
 		data[i] = 0x62
 		i++
 		i = encodeVarintApi(data, i, uint64(m.Gc.Size()))
-		n95, err := m.Gc.MarshalTo(data[i:])
+		n94, err := m.Gc.MarshalTo(data[i:])
 		if err != nil {
 			return 0, err
 		}
-		i += n95
+		i += n94
 	}
 	if m.PushTxn != nil {
 		data[i] = 0x6a
 		i++
 		i = encodeVarintApi(data, i, uint64(m.PushTxn.Size()))
-		n96, err := m.PushTxn.MarshalTo(data[i:])
+		n95, err := m.PushTxn.MarshalTo(data[i:])
 		if err != nil {
 			return 0, err
 		}
-		i += n96
+		i += n95
 	}
 	if m.RangeLookup != nil {
 		data[i] = 0x72
 		i++
 		i = encodeVarintApi(data, i, uint64(m.RangeLookup.Size()))
-		n97, err := m.RangeLookup.MarshalTo(data[i:])
+		n96, err := m.RangeLookup.MarshalTo(data[i:])
 		if err != nil {
 			return 0, err
 		}
-		i += n97
+		i += n96
 	}
 	if m.ResolveIntent != nil {
 		data[i] = 0x7a
 		i++
 		i = encodeVarintApi(data, i, uint64(m.ResolveIntent.Size()))
-		n98, err := m.ResolveIntent.MarshalTo(data[i:])
+		n97, err := m.ResolveIntent.MarshalTo(data[i:])
 		if err != nil {
 			return 0, err
 		}
-		i += n98
+		i += n97
 	}
 	if m.ResolveIntentRange != nil {
 		data[i] = 0x82
@@ -3653,11 +3635,11 @@ func (m *ResponseUnion) MarshalTo(data []byte) (int, error) {
 		data[i] = 0x1
 		i++
 		i = encodeVarintApi(data, i, uint64(m.ResolveIntentRange.Size()))
-		n99, err := m.ResolveIntentRange.MarshalTo(data[i:])
+		n98, err := m.ResolveIntentRange.MarshalTo(data[i:])
 		if err != nil {
 			return 0, err
 		}
-		i += n99
+		i += n98
 	}
 	if m.Merge != nil {
 		data[i] = 0x8a
@@ -3665,11 +3647,11 @@ func (m *ResponseUnion) MarshalTo(data []byte) (int, error) {
 		data[i] = 0x1
 		i++
 		i = encodeVarintApi(data, i, uint64(m.Merge.Size()))
-		n100, err := m.Merge.MarshalTo(data[i:])
+		n99, err := m.Merge.MarshalTo(data[i:])
 		if err != nil {
 			return 0, err
 		}
-		i += n100
+		i += n99
 	}
 	if m.TruncateLog != nil {
 		data[i] = 0x92
@@ -3677,11 +3659,11 @@ func (m *ResponseUnion) MarshalTo(data []byte) (int, error) {
 		data[i] = 0x1
 		i++
 		i = encodeVarintApi(data, i, uint64(m.TruncateLog.Size()))
-		n101, err := m.TruncateLog.MarshalTo(data[i:])
+		n100, err := m.TruncateLog.MarshalTo(data[i:])
 		if err != nil {
 			return 0, err
 		}
-		i += n101
+		i += n100
 	}
 	if m.LeaderLease != nil {
 		data[i] = 0x9a
@@ -3689,11 +3671,11 @@ func (m *ResponseUnion) MarshalTo(data []byte) (int, error) {
 		data[i] = 0x1
 		i++
 		i = encodeVarintApi(data, i, uint64(m.LeaderLease.Size()))
-		n102, err := m.LeaderLease.MarshalTo(data[i:])
+		n101, err := m.LeaderLease.MarshalTo(data[i:])
 		if err != nil {
 			return 0, err
 		}
-		i += n102
+		i += n101
 	}
 	if m.ReverseScan != nil {
 		data[i] = 0xa2
@@ -3701,11 +3683,11 @@ func (m *ResponseUnion) MarshalTo(data []byte) (int, error) {
 		data[i] = 0x1
 		i++
 		i = encodeVarintApi(data, i, uint64(m.ReverseScan.Size()))
-		n103, err := m.ReverseScan.MarshalTo(data[i:])
+		n102, err := m.ReverseScan.MarshalTo(data[i:])
 		if err != nil {
 			return 0, err
 		}
-		i += n103
+		i += n102
 	}
 	if m.Noop != nil {
 		data[i] = 0xaa
@@ -3713,11 +3695,11 @@ func (m *ResponseUnion) MarshalTo(data []byte) (int, error) {
 		data[i] = 0x1
 		i++
 		i = encodeVarintApi(data, i, uint64(m.Noop.Size()))
-		n104, err := m.Noop.MarshalTo(data[i:])
+		n103, err := m.Noop.MarshalTo(data[i:])
 		if err != nil {
 			return 0, err
 		}
-		i += n104
+		i += n103
 	}
 	return i, nil
 }
@@ -3740,11 +3722,11 @@ func (m *BatchRequest) MarshalTo(data []byte) (int, error) {
 	data[i] = 0xa
 	i++
 	i = encodeVarintApi(data, i, uint64(m.BatchRequest_Header.Size()))
-	n105, err := m.BatchRequest_Header.MarshalTo(data[i:])
+	n104, err := m.BatchRequest_Header.MarshalTo(data[i:])
 	if err != nil {
 		return 0, err
 	}
-	i += n105
+	i += n104
 	if len(m.Requests) > 0 {
 		for _, msg := range m.Requests {
 			data[i] = 0x12
@@ -3778,27 +3760,27 @@ func (m *BatchRequest_Header) MarshalTo(data []byte) (int, error) {
 	data[i] = 0xa
 	i++
 	i = encodeVarintApi(data, i, uint64(m.Timestamp.Size()))
-	n106, err := m.Timestamp.MarshalTo(data[i:])
+	n105, err := m.Timestamp.MarshalTo(data[i:])
+	if err != nil {
+		return 0, err
+	}
+	i += n105
+	data[i] = 0x12
+	i++
+	i = encodeVarintApi(data, i, uint64(m.CmdID.Size()))
+	n106, err := m.CmdID.MarshalTo(data[i:])
 	if err != nil {
 		return 0, err
 	}
 	i += n106
-	data[i] = 0x12
+	data[i] = 0x2a
 	i++
-	i = encodeVarintApi(data, i, uint64(m.CmdID.Size()))
-	n107, err := m.CmdID.MarshalTo(data[i:])
+	i = encodeVarintApi(data, i, uint64(m.Replica.Size()))
+	n107, err := m.Replica.MarshalTo(data[i:])
 	if err != nil {
 		return 0, err
 	}
 	i += n107
-	data[i] = 0x2a
-	i++
-	i = encodeVarintApi(data, i, uint64(m.Replica.Size()))
-	n108, err := m.Replica.MarshalTo(data[i:])
-	if err != nil {
-		return 0, err
-	}
-	i += n108
 	data[i] = 0x30
 	i++
 	i = encodeVarintApi(data, i, uint64(m.RangeID))
@@ -3811,11 +3793,11 @@ func (m *BatchRequest_Header) MarshalTo(data []byte) (int, error) {
 		data[i] = 0x42
 		i++
 		i = encodeVarintApi(data, i, uint64(m.Txn.Size()))
-		n109, err := m.Txn.MarshalTo(data[i:])
+		n108, err := m.Txn.MarshalTo(data[i:])
 		if err != nil {
 			return 0, err
 		}
-		i += n109
+		i += n108
 	}
 	data[i] = 0x48
 	i++
@@ -3841,11 +3823,11 @@ func (m *BatchResponse) MarshalTo(data []byte) (int, error) {
 	data[i] = 0xa
 	i++
 	i = encodeVarintApi(data, i, uint64(m.BatchResponse_Header.Size()))
-	n110, err := m.BatchResponse_Header.MarshalTo(data[i:])
+	n109, err := m.BatchResponse_Header.MarshalTo(data[i:])
 	if err != nil {
 		return 0, err
 	}
-	i += n110
+	i += n109
 	if len(m.Responses) > 0 {
 		for _, msg := range m.Responses {
 			data[i] = 0x12
@@ -3880,29 +3862,29 @@ func (m *BatchResponse_Header) MarshalTo(data []byte) (int, error) {
 		data[i] = 0xa
 		i++
 		i = encodeVarintApi(data, i, uint64(m.Error.Size()))
-		n111, err := m.Error.MarshalTo(data[i:])
+		n110, err := m.Error.MarshalTo(data[i:])
 		if err != nil {
 			return 0, err
 		}
-		i += n111
+		i += n110
 	}
 	data[i] = 0x12
 	i++
 	i = encodeVarintApi(data, i, uint64(m.Timestamp.Size()))
-	n112, err := m.Timestamp.MarshalTo(data[i:])
+	n111, err := m.Timestamp.MarshalTo(data[i:])
 	if err != nil {
 		return 0, err
 	}
-	i += n112
+	i += n111
 	if m.Txn != nil {
 		data[i] = 0x1a
 		i++
 		i = encodeVarintApi(data, i, uint64(m.Txn.Size()))
-		n113, err := m.Txn.MarshalTo(data[i:])
+		n112, err := m.Txn.MarshalTo(data[i:])
 		if err != nil {
 			return 0, err
 		}
-		i += n113
+		i += n112
 	}
 	return i, nil
 }
@@ -3945,8 +3927,6 @@ func (m *ClientCmdID) Size() (n int) {
 func (m *RequestHeader) Size() (n int) {
 	var l int
 	_ = l
-	l = m.CmdID.Size()
-	n += 1 + l + sovApi(uint64(l))
 	if m.Key != nil {
 		l = len(m.Key)
 		n += 1 + l + sovApi(uint64(l))
@@ -5024,36 +5004,6 @@ func (m *RequestHeader) Unmarshal(data []byte) error {
 			return fmt.Errorf("proto: RequestHeader: illegal tag %d (wire type %d)", fieldNum, wire)
 		}
 		switch fieldNum {
-		case 2:
-			if wireType != 2 {
-				return fmt.Errorf("proto: wrong wireType = %d for field CmdID", wireType)
-			}
-			var msglen int
-			for shift := uint(0); ; shift += 7 {
-				if shift >= 64 {
-					return ErrIntOverflowApi
-				}
-				if iNdEx >= l {
-					return io.ErrUnexpectedEOF
-				}
-				b := data[iNdEx]
-				iNdEx++
-				msglen |= (int(b) & 0x7F) << shift
-				if b < 0x80 {
-					break
-				}
-			}
-			if msglen < 0 {
-				return ErrInvalidLengthApi
-			}
-			postIndex := iNdEx + msglen
-			if postIndex > l {
-				return io.ErrUnexpectedEOF
-			}
-			if err := m.CmdID.Unmarshal(data[iNdEx:postIndex]); err != nil {
-				return err
-			}
-			iNdEx = postIndex
 		case 3:
 			if wireType != 2 {
 				return fmt.Errorf("proto: wrong wireType = %d for field Key", wireType)

--- a/roachpb/api.pb.go
+++ b/roachpb/api.pb.go
@@ -264,9 +264,6 @@ type RequestHeader struct {
 	// that the operation takes place on the key range from Key to EndKey,
 	// including Key and excluding EndKey.
 	EndKey Key `protobuf:"bytes,4,opt,name=end_key,casttype=Key" json:"end_key,omitempty"`
-	// Replica specifies the destination for the request. This is a specific
-	// instance of the available replicas belonging to RangeID.
-	Replica ReplicaDescriptor `protobuf:"bytes,5,opt,name=replica" json:"replica"`
 	// RangeID specifies the ID of the Raft consensus group which the key
 	// range belongs to. This is used by the receiving node to route the
 	// request to the correct range.
@@ -318,13 +315,6 @@ func (m *RequestHeader) GetEndKey() Key {
 		return m.EndKey
 	}
 	return nil
-}
-
-func (m *RequestHeader) GetReplica() ReplicaDescriptor {
-	if m != nil {
-		return m.Replica
-	}
-	return ReplicaDescriptor{}
 }
 
 func (m *RequestHeader) GetRangeID() RangeID {
@@ -1826,14 +1816,6 @@ func (m *RequestHeader) MarshalTo(data []byte) (int, error) {
 		i = encodeVarintApi(data, i, uint64(len(m.EndKey)))
 		i += copy(data[i:], m.EndKey)
 	}
-	data[i] = 0x2a
-	i++
-	i = encodeVarintApi(data, i, uint64(m.Replica.Size()))
-	n2, err := m.Replica.MarshalTo(data[i:])
-	if err != nil {
-		return 0, err
-	}
-	i += n2
 	data[i] = 0x30
 	i++
 	i = encodeVarintApi(data, i, uint64(m.RangeID))
@@ -1846,11 +1828,11 @@ func (m *RequestHeader) MarshalTo(data []byte) (int, error) {
 		data[i] = 0x42
 		i++
 		i = encodeVarintApi(data, i, uint64(m.Txn.Size()))
-		n3, err := m.Txn.MarshalTo(data[i:])
+		n2, err := m.Txn.MarshalTo(data[i:])
 		if err != nil {
 			return 0, err
 		}
-		i += n3
+		i += n2
 	}
 	data[i] = 0x48
 	i++
@@ -1876,20 +1858,20 @@ func (m *ResponseHeader) MarshalTo(data []byte) (int, error) {
 	data[i] = 0x12
 	i++
 	i = encodeVarintApi(data, i, uint64(m.Timestamp.Size()))
-	n4, err := m.Timestamp.MarshalTo(data[i:])
+	n3, err := m.Timestamp.MarshalTo(data[i:])
 	if err != nil {
 		return 0, err
 	}
-	i += n4
+	i += n3
 	if m.Txn != nil {
 		data[i] = 0x1a
 		i++
 		i = encodeVarintApi(data, i, uint64(m.Txn.Size()))
-		n5, err := m.Txn.MarshalTo(data[i:])
+		n4, err := m.Txn.MarshalTo(data[i:])
 		if err != nil {
 			return 0, err
 		}
-		i += n5
+		i += n4
 	}
 	return i, nil
 }
@@ -1912,11 +1894,11 @@ func (m *GetRequest) MarshalTo(data []byte) (int, error) {
 	data[i] = 0xa
 	i++
 	i = encodeVarintApi(data, i, uint64(m.RequestHeader.Size()))
-	n6, err := m.RequestHeader.MarshalTo(data[i:])
+	n5, err := m.RequestHeader.MarshalTo(data[i:])
 	if err != nil {
 		return 0, err
 	}
-	i += n6
+	i += n5
 	return i, nil
 }
 
@@ -1938,20 +1920,20 @@ func (m *GetResponse) MarshalTo(data []byte) (int, error) {
 	data[i] = 0xa
 	i++
 	i = encodeVarintApi(data, i, uint64(m.ResponseHeader.Size()))
-	n7, err := m.ResponseHeader.MarshalTo(data[i:])
+	n6, err := m.ResponseHeader.MarshalTo(data[i:])
 	if err != nil {
 		return 0, err
 	}
-	i += n7
+	i += n6
 	if m.Value != nil {
 		data[i] = 0x12
 		i++
 		i = encodeVarintApi(data, i, uint64(m.Value.Size()))
-		n8, err := m.Value.MarshalTo(data[i:])
+		n7, err := m.Value.MarshalTo(data[i:])
 		if err != nil {
 			return 0, err
 		}
-		i += n8
+		i += n7
 	}
 	return i, nil
 }
@@ -1974,19 +1956,19 @@ func (m *PutRequest) MarshalTo(data []byte) (int, error) {
 	data[i] = 0xa
 	i++
 	i = encodeVarintApi(data, i, uint64(m.RequestHeader.Size()))
-	n9, err := m.RequestHeader.MarshalTo(data[i:])
+	n8, err := m.RequestHeader.MarshalTo(data[i:])
+	if err != nil {
+		return 0, err
+	}
+	i += n8
+	data[i] = 0x12
+	i++
+	i = encodeVarintApi(data, i, uint64(m.Value.Size()))
+	n9, err := m.Value.MarshalTo(data[i:])
 	if err != nil {
 		return 0, err
 	}
 	i += n9
-	data[i] = 0x12
-	i++
-	i = encodeVarintApi(data, i, uint64(m.Value.Size()))
-	n10, err := m.Value.MarshalTo(data[i:])
-	if err != nil {
-		return 0, err
-	}
-	i += n10
 	return i, nil
 }
 
@@ -2008,11 +1990,11 @@ func (m *PutResponse) MarshalTo(data []byte) (int, error) {
 	data[i] = 0xa
 	i++
 	i = encodeVarintApi(data, i, uint64(m.ResponseHeader.Size()))
-	n11, err := m.ResponseHeader.MarshalTo(data[i:])
+	n10, err := m.ResponseHeader.MarshalTo(data[i:])
 	if err != nil {
 		return 0, err
 	}
-	i += n11
+	i += n10
 	return i, nil
 }
 
@@ -2034,28 +2016,28 @@ func (m *ConditionalPutRequest) MarshalTo(data []byte) (int, error) {
 	data[i] = 0xa
 	i++
 	i = encodeVarintApi(data, i, uint64(m.RequestHeader.Size()))
-	n12, err := m.RequestHeader.MarshalTo(data[i:])
+	n11, err := m.RequestHeader.MarshalTo(data[i:])
+	if err != nil {
+		return 0, err
+	}
+	i += n11
+	data[i] = 0x12
+	i++
+	i = encodeVarintApi(data, i, uint64(m.Value.Size()))
+	n12, err := m.Value.MarshalTo(data[i:])
 	if err != nil {
 		return 0, err
 	}
 	i += n12
-	data[i] = 0x12
-	i++
-	i = encodeVarintApi(data, i, uint64(m.Value.Size()))
-	n13, err := m.Value.MarshalTo(data[i:])
-	if err != nil {
-		return 0, err
-	}
-	i += n13
 	if m.ExpValue != nil {
 		data[i] = 0x1a
 		i++
 		i = encodeVarintApi(data, i, uint64(m.ExpValue.Size()))
-		n14, err := m.ExpValue.MarshalTo(data[i:])
+		n13, err := m.ExpValue.MarshalTo(data[i:])
 		if err != nil {
 			return 0, err
 		}
-		i += n14
+		i += n13
 	}
 	return i, nil
 }
@@ -2078,11 +2060,11 @@ func (m *ConditionalPutResponse) MarshalTo(data []byte) (int, error) {
 	data[i] = 0xa
 	i++
 	i = encodeVarintApi(data, i, uint64(m.ResponseHeader.Size()))
-	n15, err := m.ResponseHeader.MarshalTo(data[i:])
+	n14, err := m.ResponseHeader.MarshalTo(data[i:])
 	if err != nil {
 		return 0, err
 	}
-	i += n15
+	i += n14
 	return i, nil
 }
 
@@ -2104,11 +2086,11 @@ func (m *IncrementRequest) MarshalTo(data []byte) (int, error) {
 	data[i] = 0xa
 	i++
 	i = encodeVarintApi(data, i, uint64(m.RequestHeader.Size()))
-	n16, err := m.RequestHeader.MarshalTo(data[i:])
+	n15, err := m.RequestHeader.MarshalTo(data[i:])
 	if err != nil {
 		return 0, err
 	}
-	i += n16
+	i += n15
 	data[i] = 0x10
 	i++
 	i = encodeVarintApi(data, i, uint64(m.Increment))
@@ -2133,11 +2115,11 @@ func (m *IncrementResponse) MarshalTo(data []byte) (int, error) {
 	data[i] = 0xa
 	i++
 	i = encodeVarintApi(data, i, uint64(m.ResponseHeader.Size()))
-	n17, err := m.ResponseHeader.MarshalTo(data[i:])
+	n16, err := m.ResponseHeader.MarshalTo(data[i:])
 	if err != nil {
 		return 0, err
 	}
-	i += n17
+	i += n16
 	data[i] = 0x10
 	i++
 	i = encodeVarintApi(data, i, uint64(m.NewValue))
@@ -2162,11 +2144,11 @@ func (m *DeleteRequest) MarshalTo(data []byte) (int, error) {
 	data[i] = 0xa
 	i++
 	i = encodeVarintApi(data, i, uint64(m.RequestHeader.Size()))
-	n18, err := m.RequestHeader.MarshalTo(data[i:])
+	n17, err := m.RequestHeader.MarshalTo(data[i:])
 	if err != nil {
 		return 0, err
 	}
-	i += n18
+	i += n17
 	return i, nil
 }
 
@@ -2188,11 +2170,11 @@ func (m *DeleteResponse) MarshalTo(data []byte) (int, error) {
 	data[i] = 0xa
 	i++
 	i = encodeVarintApi(data, i, uint64(m.ResponseHeader.Size()))
-	n19, err := m.ResponseHeader.MarshalTo(data[i:])
+	n18, err := m.ResponseHeader.MarshalTo(data[i:])
 	if err != nil {
 		return 0, err
 	}
-	i += n19
+	i += n18
 	return i, nil
 }
 
@@ -2214,11 +2196,11 @@ func (m *DeleteRangeRequest) MarshalTo(data []byte) (int, error) {
 	data[i] = 0xa
 	i++
 	i = encodeVarintApi(data, i, uint64(m.RequestHeader.Size()))
-	n20, err := m.RequestHeader.MarshalTo(data[i:])
+	n19, err := m.RequestHeader.MarshalTo(data[i:])
 	if err != nil {
 		return 0, err
 	}
-	i += n20
+	i += n19
 	data[i] = 0x10
 	i++
 	i = encodeVarintApi(data, i, uint64(m.MaxEntriesToDelete))
@@ -2243,11 +2225,11 @@ func (m *DeleteRangeResponse) MarshalTo(data []byte) (int, error) {
 	data[i] = 0xa
 	i++
 	i = encodeVarintApi(data, i, uint64(m.ResponseHeader.Size()))
-	n21, err := m.ResponseHeader.MarshalTo(data[i:])
+	n20, err := m.ResponseHeader.MarshalTo(data[i:])
 	if err != nil {
 		return 0, err
 	}
-	i += n21
+	i += n20
 	data[i] = 0x10
 	i++
 	i = encodeVarintApi(data, i, uint64(m.NumDeleted))
@@ -2272,11 +2254,11 @@ func (m *ScanRequest) MarshalTo(data []byte) (int, error) {
 	data[i] = 0xa
 	i++
 	i = encodeVarintApi(data, i, uint64(m.RequestHeader.Size()))
-	n22, err := m.RequestHeader.MarshalTo(data[i:])
+	n21, err := m.RequestHeader.MarshalTo(data[i:])
 	if err != nil {
 		return 0, err
 	}
-	i += n22
+	i += n21
 	data[i] = 0x10
 	i++
 	i = encodeVarintApi(data, i, uint64(m.MaxResults))
@@ -2301,11 +2283,11 @@ func (m *ScanResponse) MarshalTo(data []byte) (int, error) {
 	data[i] = 0xa
 	i++
 	i = encodeVarintApi(data, i, uint64(m.ResponseHeader.Size()))
-	n23, err := m.ResponseHeader.MarshalTo(data[i:])
+	n22, err := m.ResponseHeader.MarshalTo(data[i:])
 	if err != nil {
 		return 0, err
 	}
-	i += n23
+	i += n22
 	if len(m.Rows) > 0 {
 		for _, msg := range m.Rows {
 			data[i] = 0x12
@@ -2339,11 +2321,11 @@ func (m *ReverseScanRequest) MarshalTo(data []byte) (int, error) {
 	data[i] = 0xa
 	i++
 	i = encodeVarintApi(data, i, uint64(m.RequestHeader.Size()))
-	n24, err := m.RequestHeader.MarshalTo(data[i:])
+	n23, err := m.RequestHeader.MarshalTo(data[i:])
 	if err != nil {
 		return 0, err
 	}
-	i += n24
+	i += n23
 	data[i] = 0x10
 	i++
 	i = encodeVarintApi(data, i, uint64(m.MaxResults))
@@ -2368,11 +2350,11 @@ func (m *ReverseScanResponse) MarshalTo(data []byte) (int, error) {
 	data[i] = 0xa
 	i++
 	i = encodeVarintApi(data, i, uint64(m.ResponseHeader.Size()))
-	n25, err := m.ResponseHeader.MarshalTo(data[i:])
+	n24, err := m.ResponseHeader.MarshalTo(data[i:])
 	if err != nil {
 		return 0, err
 	}
-	i += n25
+	i += n24
 	if len(m.Rows) > 0 {
 		for _, msg := range m.Rows {
 			data[i] = 0x12
@@ -2406,11 +2388,11 @@ func (m *EndTransactionRequest) MarshalTo(data []byte) (int, error) {
 	data[i] = 0xa
 	i++
 	i = encodeVarintApi(data, i, uint64(m.RequestHeader.Size()))
-	n26, err := m.RequestHeader.MarshalTo(data[i:])
+	n25, err := m.RequestHeader.MarshalTo(data[i:])
 	if err != nil {
 		return 0, err
 	}
-	i += n26
+	i += n25
 	data[i] = 0x10
 	i++
 	if m.Commit {
@@ -2423,11 +2405,11 @@ func (m *EndTransactionRequest) MarshalTo(data []byte) (int, error) {
 		data[i] = 0x1a
 		i++
 		i = encodeVarintApi(data, i, uint64(m.InternalCommitTrigger.Size()))
-		n27, err := m.InternalCommitTrigger.MarshalTo(data[i:])
+		n26, err := m.InternalCommitTrigger.MarshalTo(data[i:])
 		if err != nil {
 			return 0, err
 		}
-		i += n27
+		i += n26
 	}
 	if len(m.Intents) > 0 {
 		for _, msg := range m.Intents {
@@ -2462,11 +2444,11 @@ func (m *EndTransactionResponse) MarshalTo(data []byte) (int, error) {
 	data[i] = 0xa
 	i++
 	i = encodeVarintApi(data, i, uint64(m.ResponseHeader.Size()))
-	n28, err := m.ResponseHeader.MarshalTo(data[i:])
+	n27, err := m.ResponseHeader.MarshalTo(data[i:])
 	if err != nil {
 		return 0, err
 	}
-	i += n28
+	i += n27
 	data[i] = 0x10
 	i++
 	i = encodeVarintApi(data, i, uint64(m.CommitWait))
@@ -2499,11 +2481,11 @@ func (m *AdminSplitRequest) MarshalTo(data []byte) (int, error) {
 	data[i] = 0xa
 	i++
 	i = encodeVarintApi(data, i, uint64(m.RequestHeader.Size()))
-	n29, err := m.RequestHeader.MarshalTo(data[i:])
+	n28, err := m.RequestHeader.MarshalTo(data[i:])
 	if err != nil {
 		return 0, err
 	}
-	i += n29
+	i += n28
 	if m.SplitKey != nil {
 		data[i] = 0x12
 		i++
@@ -2531,11 +2513,11 @@ func (m *AdminSplitResponse) MarshalTo(data []byte) (int, error) {
 	data[i] = 0xa
 	i++
 	i = encodeVarintApi(data, i, uint64(m.ResponseHeader.Size()))
-	n30, err := m.ResponseHeader.MarshalTo(data[i:])
+	n29, err := m.ResponseHeader.MarshalTo(data[i:])
 	if err != nil {
 		return 0, err
 	}
-	i += n30
+	i += n29
 	return i, nil
 }
 
@@ -2557,11 +2539,11 @@ func (m *AdminMergeRequest) MarshalTo(data []byte) (int, error) {
 	data[i] = 0xa
 	i++
 	i = encodeVarintApi(data, i, uint64(m.RequestHeader.Size()))
-	n31, err := m.RequestHeader.MarshalTo(data[i:])
+	n30, err := m.RequestHeader.MarshalTo(data[i:])
 	if err != nil {
 		return 0, err
 	}
-	i += n31
+	i += n30
 	return i, nil
 }
 
@@ -2583,11 +2565,11 @@ func (m *AdminMergeResponse) MarshalTo(data []byte) (int, error) {
 	data[i] = 0xa
 	i++
 	i = encodeVarintApi(data, i, uint64(m.ResponseHeader.Size()))
-	n32, err := m.ResponseHeader.MarshalTo(data[i:])
+	n31, err := m.ResponseHeader.MarshalTo(data[i:])
 	if err != nil {
 		return 0, err
 	}
-	i += n32
+	i += n31
 	return i, nil
 }
 
@@ -2609,11 +2591,11 @@ func (m *RangeLookupRequest) MarshalTo(data []byte) (int, error) {
 	data[i] = 0xa
 	i++
 	i = encodeVarintApi(data, i, uint64(m.RequestHeader.Size()))
-	n33, err := m.RequestHeader.MarshalTo(data[i:])
+	n32, err := m.RequestHeader.MarshalTo(data[i:])
 	if err != nil {
 		return 0, err
 	}
-	i += n33
+	i += n32
 	data[i] = 0x10
 	i++
 	i = encodeVarintApi(data, i, uint64(m.MaxRanges))
@@ -2654,11 +2636,11 @@ func (m *RangeLookupResponse) MarshalTo(data []byte) (int, error) {
 	data[i] = 0xa
 	i++
 	i = encodeVarintApi(data, i, uint64(m.ResponseHeader.Size()))
-	n34, err := m.ResponseHeader.MarshalTo(data[i:])
+	n33, err := m.ResponseHeader.MarshalTo(data[i:])
 	if err != nil {
 		return 0, err
 	}
-	i += n34
+	i += n33
 	if len(m.Ranges) > 0 {
 		for _, msg := range m.Ranges {
 			data[i] = 0x12
@@ -2692,11 +2674,11 @@ func (m *HeartbeatTxnRequest) MarshalTo(data []byte) (int, error) {
 	data[i] = 0xa
 	i++
 	i = encodeVarintApi(data, i, uint64(m.RequestHeader.Size()))
-	n35, err := m.RequestHeader.MarshalTo(data[i:])
+	n34, err := m.RequestHeader.MarshalTo(data[i:])
 	if err != nil {
 		return 0, err
 	}
-	i += n35
+	i += n34
 	return i, nil
 }
 
@@ -2718,11 +2700,11 @@ func (m *HeartbeatTxnResponse) MarshalTo(data []byte) (int, error) {
 	data[i] = 0xa
 	i++
 	i = encodeVarintApi(data, i, uint64(m.ResponseHeader.Size()))
-	n36, err := m.ResponseHeader.MarshalTo(data[i:])
+	n35, err := m.ResponseHeader.MarshalTo(data[i:])
 	if err != nil {
 		return 0, err
 	}
-	i += n36
+	i += n35
 	return i, nil
 }
 
@@ -2744,19 +2726,19 @@ func (m *GCRequest) MarshalTo(data []byte) (int, error) {
 	data[i] = 0xa
 	i++
 	i = encodeVarintApi(data, i, uint64(m.RequestHeader.Size()))
-	n37, err := m.RequestHeader.MarshalTo(data[i:])
+	n36, err := m.RequestHeader.MarshalTo(data[i:])
+	if err != nil {
+		return 0, err
+	}
+	i += n36
+	data[i] = 0x12
+	i++
+	i = encodeVarintApi(data, i, uint64(m.GCMeta.Size()))
+	n37, err := m.GCMeta.MarshalTo(data[i:])
 	if err != nil {
 		return 0, err
 	}
 	i += n37
-	data[i] = 0x12
-	i++
-	i = encodeVarintApi(data, i, uint64(m.GCMeta.Size()))
-	n38, err := m.GCMeta.MarshalTo(data[i:])
-	if err != nil {
-		return 0, err
-	}
-	i += n38
 	if len(m.Keys) > 0 {
 		for _, msg := range m.Keys {
 			data[i] = 0x1a
@@ -2796,11 +2778,11 @@ func (m *GCRequest_GCKey) MarshalTo(data []byte) (int, error) {
 	data[i] = 0x12
 	i++
 	i = encodeVarintApi(data, i, uint64(m.Timestamp.Size()))
-	n39, err := m.Timestamp.MarshalTo(data[i:])
+	n38, err := m.Timestamp.MarshalTo(data[i:])
 	if err != nil {
 		return 0, err
 	}
-	i += n39
+	i += n38
 	return i, nil
 }
 
@@ -2822,11 +2804,11 @@ func (m *GCResponse) MarshalTo(data []byte) (int, error) {
 	data[i] = 0xa
 	i++
 	i = encodeVarintApi(data, i, uint64(m.ResponseHeader.Size()))
-	n40, err := m.ResponseHeader.MarshalTo(data[i:])
+	n39, err := m.ResponseHeader.MarshalTo(data[i:])
 	if err != nil {
 		return 0, err
 	}
-	i += n40
+	i += n39
 	return i, nil
 }
 
@@ -2848,43 +2830,43 @@ func (m *PushTxnRequest) MarshalTo(data []byte) (int, error) {
 	data[i] = 0xa
 	i++
 	i = encodeVarintApi(data, i, uint64(m.RequestHeader.Size()))
-	n41, err := m.RequestHeader.MarshalTo(data[i:])
+	n40, err := m.RequestHeader.MarshalTo(data[i:])
+	if err != nil {
+		return 0, err
+	}
+	i += n40
+	data[i] = 0x12
+	i++
+	i = encodeVarintApi(data, i, uint64(m.PusherTxn.Size()))
+	n41, err := m.PusherTxn.MarshalTo(data[i:])
 	if err != nil {
 		return 0, err
 	}
 	i += n41
-	data[i] = 0x12
+	data[i] = 0x1a
 	i++
-	i = encodeVarintApi(data, i, uint64(m.PusherTxn.Size()))
-	n42, err := m.PusherTxn.MarshalTo(data[i:])
+	i = encodeVarintApi(data, i, uint64(m.PusheeTxn.Size()))
+	n42, err := m.PusheeTxn.MarshalTo(data[i:])
 	if err != nil {
 		return 0, err
 	}
 	i += n42
-	data[i] = 0x1a
+	data[i] = 0x22
 	i++
-	i = encodeVarintApi(data, i, uint64(m.PusheeTxn.Size()))
-	n43, err := m.PusheeTxn.MarshalTo(data[i:])
+	i = encodeVarintApi(data, i, uint64(m.PushTo.Size()))
+	n43, err := m.PushTo.MarshalTo(data[i:])
 	if err != nil {
 		return 0, err
 	}
 	i += n43
-	data[i] = 0x22
+	data[i] = 0x2a
 	i++
-	i = encodeVarintApi(data, i, uint64(m.PushTo.Size()))
-	n44, err := m.PushTo.MarshalTo(data[i:])
+	i = encodeVarintApi(data, i, uint64(m.Now.Size()))
+	n44, err := m.Now.MarshalTo(data[i:])
 	if err != nil {
 		return 0, err
 	}
 	i += n44
-	data[i] = 0x2a
-	i++
-	i = encodeVarintApi(data, i, uint64(m.Now.Size()))
-	n45, err := m.Now.MarshalTo(data[i:])
-	if err != nil {
-		return 0, err
-	}
-	i += n45
 	data[i] = 0x30
 	i++
 	i = encodeVarintApi(data, i, uint64(m.PushType))
@@ -2909,20 +2891,20 @@ func (m *PushTxnResponse) MarshalTo(data []byte) (int, error) {
 	data[i] = 0xa
 	i++
 	i = encodeVarintApi(data, i, uint64(m.ResponseHeader.Size()))
-	n46, err := m.ResponseHeader.MarshalTo(data[i:])
+	n45, err := m.ResponseHeader.MarshalTo(data[i:])
 	if err != nil {
 		return 0, err
 	}
-	i += n46
+	i += n45
 	if m.PusheeTxn != nil {
 		data[i] = 0x12
 		i++
 		i = encodeVarintApi(data, i, uint64(m.PusheeTxn.Size()))
-		n47, err := m.PusheeTxn.MarshalTo(data[i:])
+		n46, err := m.PusheeTxn.MarshalTo(data[i:])
 		if err != nil {
 			return 0, err
 		}
-		i += n47
+		i += n46
 	}
 	return i, nil
 }
@@ -2945,19 +2927,19 @@ func (m *ResolveIntentRequest) MarshalTo(data []byte) (int, error) {
 	data[i] = 0xa
 	i++
 	i = encodeVarintApi(data, i, uint64(m.RequestHeader.Size()))
-	n48, err := m.RequestHeader.MarshalTo(data[i:])
+	n47, err := m.RequestHeader.MarshalTo(data[i:])
+	if err != nil {
+		return 0, err
+	}
+	i += n47
+	data[i] = 0x12
+	i++
+	i = encodeVarintApi(data, i, uint64(m.IntentTxn.Size()))
+	n48, err := m.IntentTxn.MarshalTo(data[i:])
 	if err != nil {
 		return 0, err
 	}
 	i += n48
-	data[i] = 0x12
-	i++
-	i = encodeVarintApi(data, i, uint64(m.IntentTxn.Size()))
-	n49, err := m.IntentTxn.MarshalTo(data[i:])
-	if err != nil {
-		return 0, err
-	}
-	i += n49
 	return i, nil
 }
 
@@ -2979,11 +2961,11 @@ func (m *ResolveIntentResponse) MarshalTo(data []byte) (int, error) {
 	data[i] = 0xa
 	i++
 	i = encodeVarintApi(data, i, uint64(m.ResponseHeader.Size()))
-	n50, err := m.ResponseHeader.MarshalTo(data[i:])
+	n49, err := m.ResponseHeader.MarshalTo(data[i:])
 	if err != nil {
 		return 0, err
 	}
-	i += n50
+	i += n49
 	return i, nil
 }
 
@@ -3005,19 +2987,19 @@ func (m *ResolveIntentRangeRequest) MarshalTo(data []byte) (int, error) {
 	data[i] = 0xa
 	i++
 	i = encodeVarintApi(data, i, uint64(m.RequestHeader.Size()))
-	n51, err := m.RequestHeader.MarshalTo(data[i:])
+	n50, err := m.RequestHeader.MarshalTo(data[i:])
+	if err != nil {
+		return 0, err
+	}
+	i += n50
+	data[i] = 0x12
+	i++
+	i = encodeVarintApi(data, i, uint64(m.IntentTxn.Size()))
+	n51, err := m.IntentTxn.MarshalTo(data[i:])
 	if err != nil {
 		return 0, err
 	}
 	i += n51
-	data[i] = 0x12
-	i++
-	i = encodeVarintApi(data, i, uint64(m.IntentTxn.Size()))
-	n52, err := m.IntentTxn.MarshalTo(data[i:])
-	if err != nil {
-		return 0, err
-	}
-	i += n52
 	return i, nil
 }
 
@@ -3039,11 +3021,11 @@ func (m *NoopResponse) MarshalTo(data []byte) (int, error) {
 	data[i] = 0xa
 	i++
 	i = encodeVarintApi(data, i, uint64(m.ResponseHeader.Size()))
-	n53, err := m.ResponseHeader.MarshalTo(data[i:])
+	n52, err := m.ResponseHeader.MarshalTo(data[i:])
 	if err != nil {
 		return 0, err
 	}
-	i += n53
+	i += n52
 	return i, nil
 }
 
@@ -3065,11 +3047,11 @@ func (m *NoopRequest) MarshalTo(data []byte) (int, error) {
 	data[i] = 0xa
 	i++
 	i = encodeVarintApi(data, i, uint64(m.RequestHeader.Size()))
-	n54, err := m.RequestHeader.MarshalTo(data[i:])
+	n53, err := m.RequestHeader.MarshalTo(data[i:])
 	if err != nil {
 		return 0, err
 	}
-	i += n54
+	i += n53
 	return i, nil
 }
 
@@ -3091,11 +3073,11 @@ func (m *ResolveIntentRangeResponse) MarshalTo(data []byte) (int, error) {
 	data[i] = 0xa
 	i++
 	i = encodeVarintApi(data, i, uint64(m.ResponseHeader.Size()))
-	n55, err := m.ResponseHeader.MarshalTo(data[i:])
+	n54, err := m.ResponseHeader.MarshalTo(data[i:])
 	if err != nil {
 		return 0, err
 	}
-	i += n55
+	i += n54
 	return i, nil
 }
 
@@ -3117,19 +3099,19 @@ func (m *MergeRequest) MarshalTo(data []byte) (int, error) {
 	data[i] = 0xa
 	i++
 	i = encodeVarintApi(data, i, uint64(m.RequestHeader.Size()))
-	n56, err := m.RequestHeader.MarshalTo(data[i:])
+	n55, err := m.RequestHeader.MarshalTo(data[i:])
+	if err != nil {
+		return 0, err
+	}
+	i += n55
+	data[i] = 0x12
+	i++
+	i = encodeVarintApi(data, i, uint64(m.Value.Size()))
+	n56, err := m.Value.MarshalTo(data[i:])
 	if err != nil {
 		return 0, err
 	}
 	i += n56
-	data[i] = 0x12
-	i++
-	i = encodeVarintApi(data, i, uint64(m.Value.Size()))
-	n57, err := m.Value.MarshalTo(data[i:])
-	if err != nil {
-		return 0, err
-	}
-	i += n57
 	return i, nil
 }
 
@@ -3151,11 +3133,11 @@ func (m *MergeResponse) MarshalTo(data []byte) (int, error) {
 	data[i] = 0xa
 	i++
 	i = encodeVarintApi(data, i, uint64(m.ResponseHeader.Size()))
-	n58, err := m.ResponseHeader.MarshalTo(data[i:])
+	n57, err := m.ResponseHeader.MarshalTo(data[i:])
 	if err != nil {
 		return 0, err
 	}
-	i += n58
+	i += n57
 	return i, nil
 }
 
@@ -3177,11 +3159,11 @@ func (m *TruncateLogRequest) MarshalTo(data []byte) (int, error) {
 	data[i] = 0xa
 	i++
 	i = encodeVarintApi(data, i, uint64(m.RequestHeader.Size()))
-	n59, err := m.RequestHeader.MarshalTo(data[i:])
+	n58, err := m.RequestHeader.MarshalTo(data[i:])
 	if err != nil {
 		return 0, err
 	}
-	i += n59
+	i += n58
 	data[i] = 0x10
 	i++
 	i = encodeVarintApi(data, i, uint64(m.Index))
@@ -3206,11 +3188,11 @@ func (m *TruncateLogResponse) MarshalTo(data []byte) (int, error) {
 	data[i] = 0xa
 	i++
 	i = encodeVarintApi(data, i, uint64(m.ResponseHeader.Size()))
-	n60, err := m.ResponseHeader.MarshalTo(data[i:])
+	n59, err := m.ResponseHeader.MarshalTo(data[i:])
 	if err != nil {
 		return 0, err
 	}
-	i += n60
+	i += n59
 	return i, nil
 }
 
@@ -3232,19 +3214,19 @@ func (m *LeaderLeaseRequest) MarshalTo(data []byte) (int, error) {
 	data[i] = 0xa
 	i++
 	i = encodeVarintApi(data, i, uint64(m.RequestHeader.Size()))
-	n61, err := m.RequestHeader.MarshalTo(data[i:])
+	n60, err := m.RequestHeader.MarshalTo(data[i:])
+	if err != nil {
+		return 0, err
+	}
+	i += n60
+	data[i] = 0x12
+	i++
+	i = encodeVarintApi(data, i, uint64(m.Lease.Size()))
+	n61, err := m.Lease.MarshalTo(data[i:])
 	if err != nil {
 		return 0, err
 	}
 	i += n61
-	data[i] = 0x12
-	i++
-	i = encodeVarintApi(data, i, uint64(m.Lease.Size()))
-	n62, err := m.Lease.MarshalTo(data[i:])
-	if err != nil {
-		return 0, err
-	}
-	i += n62
 	return i, nil
 }
 
@@ -3266,11 +3248,11 @@ func (m *LeaderLeaseResponse) MarshalTo(data []byte) (int, error) {
 	data[i] = 0xa
 	i++
 	i = encodeVarintApi(data, i, uint64(m.ResponseHeader.Size()))
-	n63, err := m.ResponseHeader.MarshalTo(data[i:])
+	n62, err := m.ResponseHeader.MarshalTo(data[i:])
 	if err != nil {
 		return 0, err
 	}
-	i += n63
+	i += n62
 	return i, nil
 }
 
@@ -3293,151 +3275,151 @@ func (m *RequestUnion) MarshalTo(data []byte) (int, error) {
 		data[i] = 0xa
 		i++
 		i = encodeVarintApi(data, i, uint64(m.Get.Size()))
-		n64, err := m.Get.MarshalTo(data[i:])
+		n63, err := m.Get.MarshalTo(data[i:])
 		if err != nil {
 			return 0, err
 		}
-		i += n64
+		i += n63
 	}
 	if m.Put != nil {
 		data[i] = 0x12
 		i++
 		i = encodeVarintApi(data, i, uint64(m.Put.Size()))
-		n65, err := m.Put.MarshalTo(data[i:])
+		n64, err := m.Put.MarshalTo(data[i:])
 		if err != nil {
 			return 0, err
 		}
-		i += n65
+		i += n64
 	}
 	if m.ConditionalPut != nil {
 		data[i] = 0x1a
 		i++
 		i = encodeVarintApi(data, i, uint64(m.ConditionalPut.Size()))
-		n66, err := m.ConditionalPut.MarshalTo(data[i:])
+		n65, err := m.ConditionalPut.MarshalTo(data[i:])
 		if err != nil {
 			return 0, err
 		}
-		i += n66
+		i += n65
 	}
 	if m.Increment != nil {
 		data[i] = 0x22
 		i++
 		i = encodeVarintApi(data, i, uint64(m.Increment.Size()))
-		n67, err := m.Increment.MarshalTo(data[i:])
+		n66, err := m.Increment.MarshalTo(data[i:])
 		if err != nil {
 			return 0, err
 		}
-		i += n67
+		i += n66
 	}
 	if m.Delete != nil {
 		data[i] = 0x2a
 		i++
 		i = encodeVarintApi(data, i, uint64(m.Delete.Size()))
-		n68, err := m.Delete.MarshalTo(data[i:])
+		n67, err := m.Delete.MarshalTo(data[i:])
 		if err != nil {
 			return 0, err
 		}
-		i += n68
+		i += n67
 	}
 	if m.DeleteRange != nil {
 		data[i] = 0x32
 		i++
 		i = encodeVarintApi(data, i, uint64(m.DeleteRange.Size()))
-		n69, err := m.DeleteRange.MarshalTo(data[i:])
+		n68, err := m.DeleteRange.MarshalTo(data[i:])
 		if err != nil {
 			return 0, err
 		}
-		i += n69
+		i += n68
 	}
 	if m.Scan != nil {
 		data[i] = 0x3a
 		i++
 		i = encodeVarintApi(data, i, uint64(m.Scan.Size()))
-		n70, err := m.Scan.MarshalTo(data[i:])
+		n69, err := m.Scan.MarshalTo(data[i:])
 		if err != nil {
 			return 0, err
 		}
-		i += n70
+		i += n69
 	}
 	if m.EndTransaction != nil {
 		data[i] = 0x42
 		i++
 		i = encodeVarintApi(data, i, uint64(m.EndTransaction.Size()))
-		n71, err := m.EndTransaction.MarshalTo(data[i:])
+		n70, err := m.EndTransaction.MarshalTo(data[i:])
 		if err != nil {
 			return 0, err
 		}
-		i += n71
+		i += n70
 	}
 	if m.AdminSplit != nil {
 		data[i] = 0x4a
 		i++
 		i = encodeVarintApi(data, i, uint64(m.AdminSplit.Size()))
-		n72, err := m.AdminSplit.MarshalTo(data[i:])
+		n71, err := m.AdminSplit.MarshalTo(data[i:])
 		if err != nil {
 			return 0, err
 		}
-		i += n72
+		i += n71
 	}
 	if m.AdminMerge != nil {
 		data[i] = 0x52
 		i++
 		i = encodeVarintApi(data, i, uint64(m.AdminMerge.Size()))
-		n73, err := m.AdminMerge.MarshalTo(data[i:])
+		n72, err := m.AdminMerge.MarshalTo(data[i:])
 		if err != nil {
 			return 0, err
 		}
-		i += n73
+		i += n72
 	}
 	if m.HeartbeatTxn != nil {
 		data[i] = 0x5a
 		i++
 		i = encodeVarintApi(data, i, uint64(m.HeartbeatTxn.Size()))
-		n74, err := m.HeartbeatTxn.MarshalTo(data[i:])
+		n73, err := m.HeartbeatTxn.MarshalTo(data[i:])
 		if err != nil {
 			return 0, err
 		}
-		i += n74
+		i += n73
 	}
 	if m.Gc != nil {
 		data[i] = 0x62
 		i++
 		i = encodeVarintApi(data, i, uint64(m.Gc.Size()))
-		n75, err := m.Gc.MarshalTo(data[i:])
+		n74, err := m.Gc.MarshalTo(data[i:])
 		if err != nil {
 			return 0, err
 		}
-		i += n75
+		i += n74
 	}
 	if m.PushTxn != nil {
 		data[i] = 0x6a
 		i++
 		i = encodeVarintApi(data, i, uint64(m.PushTxn.Size()))
-		n76, err := m.PushTxn.MarshalTo(data[i:])
+		n75, err := m.PushTxn.MarshalTo(data[i:])
 		if err != nil {
 			return 0, err
 		}
-		i += n76
+		i += n75
 	}
 	if m.RangeLookup != nil {
 		data[i] = 0x72
 		i++
 		i = encodeVarintApi(data, i, uint64(m.RangeLookup.Size()))
-		n77, err := m.RangeLookup.MarshalTo(data[i:])
+		n76, err := m.RangeLookup.MarshalTo(data[i:])
 		if err != nil {
 			return 0, err
 		}
-		i += n77
+		i += n76
 	}
 	if m.ResolveIntent != nil {
 		data[i] = 0x7a
 		i++
 		i = encodeVarintApi(data, i, uint64(m.ResolveIntent.Size()))
-		n78, err := m.ResolveIntent.MarshalTo(data[i:])
+		n77, err := m.ResolveIntent.MarshalTo(data[i:])
 		if err != nil {
 			return 0, err
 		}
-		i += n78
+		i += n77
 	}
 	if m.ResolveIntentRange != nil {
 		data[i] = 0x82
@@ -3445,11 +3427,11 @@ func (m *RequestUnion) MarshalTo(data []byte) (int, error) {
 		data[i] = 0x1
 		i++
 		i = encodeVarintApi(data, i, uint64(m.ResolveIntentRange.Size()))
-		n79, err := m.ResolveIntentRange.MarshalTo(data[i:])
+		n78, err := m.ResolveIntentRange.MarshalTo(data[i:])
 		if err != nil {
 			return 0, err
 		}
-		i += n79
+		i += n78
 	}
 	if m.Merge != nil {
 		data[i] = 0x8a
@@ -3457,11 +3439,11 @@ func (m *RequestUnion) MarshalTo(data []byte) (int, error) {
 		data[i] = 0x1
 		i++
 		i = encodeVarintApi(data, i, uint64(m.Merge.Size()))
-		n80, err := m.Merge.MarshalTo(data[i:])
+		n79, err := m.Merge.MarshalTo(data[i:])
 		if err != nil {
 			return 0, err
 		}
-		i += n80
+		i += n79
 	}
 	if m.TruncateLog != nil {
 		data[i] = 0x92
@@ -3469,11 +3451,11 @@ func (m *RequestUnion) MarshalTo(data []byte) (int, error) {
 		data[i] = 0x1
 		i++
 		i = encodeVarintApi(data, i, uint64(m.TruncateLog.Size()))
-		n81, err := m.TruncateLog.MarshalTo(data[i:])
+		n80, err := m.TruncateLog.MarshalTo(data[i:])
 		if err != nil {
 			return 0, err
 		}
-		i += n81
+		i += n80
 	}
 	if m.LeaderLease != nil {
 		data[i] = 0x9a
@@ -3481,11 +3463,11 @@ func (m *RequestUnion) MarshalTo(data []byte) (int, error) {
 		data[i] = 0x1
 		i++
 		i = encodeVarintApi(data, i, uint64(m.LeaderLease.Size()))
-		n82, err := m.LeaderLease.MarshalTo(data[i:])
+		n81, err := m.LeaderLease.MarshalTo(data[i:])
 		if err != nil {
 			return 0, err
 		}
-		i += n82
+		i += n81
 	}
 	if m.ReverseScan != nil {
 		data[i] = 0xa2
@@ -3493,11 +3475,11 @@ func (m *RequestUnion) MarshalTo(data []byte) (int, error) {
 		data[i] = 0x1
 		i++
 		i = encodeVarintApi(data, i, uint64(m.ReverseScan.Size()))
-		n83, err := m.ReverseScan.MarshalTo(data[i:])
+		n82, err := m.ReverseScan.MarshalTo(data[i:])
 		if err != nil {
 			return 0, err
 		}
-		i += n83
+		i += n82
 	}
 	if m.Noop != nil {
 		data[i] = 0xaa
@@ -3505,11 +3487,11 @@ func (m *RequestUnion) MarshalTo(data []byte) (int, error) {
 		data[i] = 0x1
 		i++
 		i = encodeVarintApi(data, i, uint64(m.Noop.Size()))
-		n84, err := m.Noop.MarshalTo(data[i:])
+		n83, err := m.Noop.MarshalTo(data[i:])
 		if err != nil {
 			return 0, err
 		}
-		i += n84
+		i += n83
 	}
 	return i, nil
 }
@@ -3533,151 +3515,151 @@ func (m *ResponseUnion) MarshalTo(data []byte) (int, error) {
 		data[i] = 0xa
 		i++
 		i = encodeVarintApi(data, i, uint64(m.Get.Size()))
-		n85, err := m.Get.MarshalTo(data[i:])
+		n84, err := m.Get.MarshalTo(data[i:])
 		if err != nil {
 			return 0, err
 		}
-		i += n85
+		i += n84
 	}
 	if m.Put != nil {
 		data[i] = 0x12
 		i++
 		i = encodeVarintApi(data, i, uint64(m.Put.Size()))
-		n86, err := m.Put.MarshalTo(data[i:])
+		n85, err := m.Put.MarshalTo(data[i:])
 		if err != nil {
 			return 0, err
 		}
-		i += n86
+		i += n85
 	}
 	if m.ConditionalPut != nil {
 		data[i] = 0x1a
 		i++
 		i = encodeVarintApi(data, i, uint64(m.ConditionalPut.Size()))
-		n87, err := m.ConditionalPut.MarshalTo(data[i:])
+		n86, err := m.ConditionalPut.MarshalTo(data[i:])
 		if err != nil {
 			return 0, err
 		}
-		i += n87
+		i += n86
 	}
 	if m.Increment != nil {
 		data[i] = 0x22
 		i++
 		i = encodeVarintApi(data, i, uint64(m.Increment.Size()))
-		n88, err := m.Increment.MarshalTo(data[i:])
+		n87, err := m.Increment.MarshalTo(data[i:])
 		if err != nil {
 			return 0, err
 		}
-		i += n88
+		i += n87
 	}
 	if m.Delete != nil {
 		data[i] = 0x2a
 		i++
 		i = encodeVarintApi(data, i, uint64(m.Delete.Size()))
-		n89, err := m.Delete.MarshalTo(data[i:])
+		n88, err := m.Delete.MarshalTo(data[i:])
 		if err != nil {
 			return 0, err
 		}
-		i += n89
+		i += n88
 	}
 	if m.DeleteRange != nil {
 		data[i] = 0x32
 		i++
 		i = encodeVarintApi(data, i, uint64(m.DeleteRange.Size()))
-		n90, err := m.DeleteRange.MarshalTo(data[i:])
+		n89, err := m.DeleteRange.MarshalTo(data[i:])
 		if err != nil {
 			return 0, err
 		}
-		i += n90
+		i += n89
 	}
 	if m.Scan != nil {
 		data[i] = 0x3a
 		i++
 		i = encodeVarintApi(data, i, uint64(m.Scan.Size()))
-		n91, err := m.Scan.MarshalTo(data[i:])
+		n90, err := m.Scan.MarshalTo(data[i:])
 		if err != nil {
 			return 0, err
 		}
-		i += n91
+		i += n90
 	}
 	if m.EndTransaction != nil {
 		data[i] = 0x42
 		i++
 		i = encodeVarintApi(data, i, uint64(m.EndTransaction.Size()))
-		n92, err := m.EndTransaction.MarshalTo(data[i:])
+		n91, err := m.EndTransaction.MarshalTo(data[i:])
 		if err != nil {
 			return 0, err
 		}
-		i += n92
+		i += n91
 	}
 	if m.AdminSplit != nil {
 		data[i] = 0x4a
 		i++
 		i = encodeVarintApi(data, i, uint64(m.AdminSplit.Size()))
-		n93, err := m.AdminSplit.MarshalTo(data[i:])
+		n92, err := m.AdminSplit.MarshalTo(data[i:])
 		if err != nil {
 			return 0, err
 		}
-		i += n93
+		i += n92
 	}
 	if m.AdminMerge != nil {
 		data[i] = 0x52
 		i++
 		i = encodeVarintApi(data, i, uint64(m.AdminMerge.Size()))
-		n94, err := m.AdminMerge.MarshalTo(data[i:])
+		n93, err := m.AdminMerge.MarshalTo(data[i:])
 		if err != nil {
 			return 0, err
 		}
-		i += n94
+		i += n93
 	}
 	if m.HeartbeatTxn != nil {
 		data[i] = 0x5a
 		i++
 		i = encodeVarintApi(data, i, uint64(m.HeartbeatTxn.Size()))
-		n95, err := m.HeartbeatTxn.MarshalTo(data[i:])
+		n94, err := m.HeartbeatTxn.MarshalTo(data[i:])
 		if err != nil {
 			return 0, err
 		}
-		i += n95
+		i += n94
 	}
 	if m.Gc != nil {
 		data[i] = 0x62
 		i++
 		i = encodeVarintApi(data, i, uint64(m.Gc.Size()))
-		n96, err := m.Gc.MarshalTo(data[i:])
+		n95, err := m.Gc.MarshalTo(data[i:])
 		if err != nil {
 			return 0, err
 		}
-		i += n96
+		i += n95
 	}
 	if m.PushTxn != nil {
 		data[i] = 0x6a
 		i++
 		i = encodeVarintApi(data, i, uint64(m.PushTxn.Size()))
-		n97, err := m.PushTxn.MarshalTo(data[i:])
+		n96, err := m.PushTxn.MarshalTo(data[i:])
 		if err != nil {
 			return 0, err
 		}
-		i += n97
+		i += n96
 	}
 	if m.RangeLookup != nil {
 		data[i] = 0x72
 		i++
 		i = encodeVarintApi(data, i, uint64(m.RangeLookup.Size()))
-		n98, err := m.RangeLookup.MarshalTo(data[i:])
+		n97, err := m.RangeLookup.MarshalTo(data[i:])
 		if err != nil {
 			return 0, err
 		}
-		i += n98
+		i += n97
 	}
 	if m.ResolveIntent != nil {
 		data[i] = 0x7a
 		i++
 		i = encodeVarintApi(data, i, uint64(m.ResolveIntent.Size()))
-		n99, err := m.ResolveIntent.MarshalTo(data[i:])
+		n98, err := m.ResolveIntent.MarshalTo(data[i:])
 		if err != nil {
 			return 0, err
 		}
-		i += n99
+		i += n98
 	}
 	if m.ResolveIntentRange != nil {
 		data[i] = 0x82
@@ -3685,11 +3667,11 @@ func (m *ResponseUnion) MarshalTo(data []byte) (int, error) {
 		data[i] = 0x1
 		i++
 		i = encodeVarintApi(data, i, uint64(m.ResolveIntentRange.Size()))
-		n100, err := m.ResolveIntentRange.MarshalTo(data[i:])
+		n99, err := m.ResolveIntentRange.MarshalTo(data[i:])
 		if err != nil {
 			return 0, err
 		}
-		i += n100
+		i += n99
 	}
 	if m.Merge != nil {
 		data[i] = 0x8a
@@ -3697,11 +3679,11 @@ func (m *ResponseUnion) MarshalTo(data []byte) (int, error) {
 		data[i] = 0x1
 		i++
 		i = encodeVarintApi(data, i, uint64(m.Merge.Size()))
-		n101, err := m.Merge.MarshalTo(data[i:])
+		n100, err := m.Merge.MarshalTo(data[i:])
 		if err != nil {
 			return 0, err
 		}
-		i += n101
+		i += n100
 	}
 	if m.TruncateLog != nil {
 		data[i] = 0x92
@@ -3709,11 +3691,11 @@ func (m *ResponseUnion) MarshalTo(data []byte) (int, error) {
 		data[i] = 0x1
 		i++
 		i = encodeVarintApi(data, i, uint64(m.TruncateLog.Size()))
-		n102, err := m.TruncateLog.MarshalTo(data[i:])
+		n101, err := m.TruncateLog.MarshalTo(data[i:])
 		if err != nil {
 			return 0, err
 		}
-		i += n102
+		i += n101
 	}
 	if m.LeaderLease != nil {
 		data[i] = 0x9a
@@ -3721,11 +3703,11 @@ func (m *ResponseUnion) MarshalTo(data []byte) (int, error) {
 		data[i] = 0x1
 		i++
 		i = encodeVarintApi(data, i, uint64(m.LeaderLease.Size()))
-		n103, err := m.LeaderLease.MarshalTo(data[i:])
+		n102, err := m.LeaderLease.MarshalTo(data[i:])
 		if err != nil {
 			return 0, err
 		}
-		i += n103
+		i += n102
 	}
 	if m.ReverseScan != nil {
 		data[i] = 0xa2
@@ -3733,11 +3715,11 @@ func (m *ResponseUnion) MarshalTo(data []byte) (int, error) {
 		data[i] = 0x1
 		i++
 		i = encodeVarintApi(data, i, uint64(m.ReverseScan.Size()))
-		n104, err := m.ReverseScan.MarshalTo(data[i:])
+		n103, err := m.ReverseScan.MarshalTo(data[i:])
 		if err != nil {
 			return 0, err
 		}
-		i += n104
+		i += n103
 	}
 	if m.Noop != nil {
 		data[i] = 0xaa
@@ -3745,11 +3727,11 @@ func (m *ResponseUnion) MarshalTo(data []byte) (int, error) {
 		data[i] = 0x1
 		i++
 		i = encodeVarintApi(data, i, uint64(m.Noop.Size()))
-		n105, err := m.Noop.MarshalTo(data[i:])
+		n104, err := m.Noop.MarshalTo(data[i:])
 		if err != nil {
 			return 0, err
 		}
-		i += n105
+		i += n104
 	}
 	return i, nil
 }
@@ -3772,11 +3754,11 @@ func (m *BatchRequest) MarshalTo(data []byte) (int, error) {
 	data[i] = 0xa
 	i++
 	i = encodeVarintApi(data, i, uint64(m.BatchRequest_Header.Size()))
-	n106, err := m.BatchRequest_Header.MarshalTo(data[i:])
+	n105, err := m.BatchRequest_Header.MarshalTo(data[i:])
 	if err != nil {
 		return 0, err
 	}
-	i += n106
+	i += n105
 	if len(m.Requests) > 0 {
 		for _, msg := range m.Requests {
 			data[i] = 0x12
@@ -3810,27 +3792,27 @@ func (m *BatchRequest_Header) MarshalTo(data []byte) (int, error) {
 	data[i] = 0xa
 	i++
 	i = encodeVarintApi(data, i, uint64(m.Timestamp.Size()))
-	n107, err := m.Timestamp.MarshalTo(data[i:])
+	n106, err := m.Timestamp.MarshalTo(data[i:])
+	if err != nil {
+		return 0, err
+	}
+	i += n106
+	data[i] = 0x12
+	i++
+	i = encodeVarintApi(data, i, uint64(m.CmdID.Size()))
+	n107, err := m.CmdID.MarshalTo(data[i:])
 	if err != nil {
 		return 0, err
 	}
 	i += n107
-	data[i] = 0x12
+	data[i] = 0x2a
 	i++
-	i = encodeVarintApi(data, i, uint64(m.CmdID.Size()))
-	n108, err := m.CmdID.MarshalTo(data[i:])
+	i = encodeVarintApi(data, i, uint64(m.Replica.Size()))
+	n108, err := m.Replica.MarshalTo(data[i:])
 	if err != nil {
 		return 0, err
 	}
 	i += n108
-	data[i] = 0x2a
-	i++
-	i = encodeVarintApi(data, i, uint64(m.Replica.Size()))
-	n109, err := m.Replica.MarshalTo(data[i:])
-	if err != nil {
-		return 0, err
-	}
-	i += n109
 	data[i] = 0x30
 	i++
 	i = encodeVarintApi(data, i, uint64(m.RangeID))
@@ -3843,11 +3825,11 @@ func (m *BatchRequest_Header) MarshalTo(data []byte) (int, error) {
 		data[i] = 0x42
 		i++
 		i = encodeVarintApi(data, i, uint64(m.Txn.Size()))
-		n110, err := m.Txn.MarshalTo(data[i:])
+		n109, err := m.Txn.MarshalTo(data[i:])
 		if err != nil {
 			return 0, err
 		}
-		i += n110
+		i += n109
 	}
 	data[i] = 0x48
 	i++
@@ -3873,11 +3855,11 @@ func (m *BatchResponse) MarshalTo(data []byte) (int, error) {
 	data[i] = 0xa
 	i++
 	i = encodeVarintApi(data, i, uint64(m.BatchResponse_Header.Size()))
-	n111, err := m.BatchResponse_Header.MarshalTo(data[i:])
+	n110, err := m.BatchResponse_Header.MarshalTo(data[i:])
 	if err != nil {
 		return 0, err
 	}
-	i += n111
+	i += n110
 	if len(m.Responses) > 0 {
 		for _, msg := range m.Responses {
 			data[i] = 0x12
@@ -3912,29 +3894,29 @@ func (m *BatchResponse_Header) MarshalTo(data []byte) (int, error) {
 		data[i] = 0xa
 		i++
 		i = encodeVarintApi(data, i, uint64(m.Error.Size()))
-		n112, err := m.Error.MarshalTo(data[i:])
+		n111, err := m.Error.MarshalTo(data[i:])
 		if err != nil {
 			return 0, err
 		}
-		i += n112
+		i += n111
 	}
 	data[i] = 0x12
 	i++
 	i = encodeVarintApi(data, i, uint64(m.Timestamp.Size()))
-	n113, err := m.Timestamp.MarshalTo(data[i:])
+	n112, err := m.Timestamp.MarshalTo(data[i:])
 	if err != nil {
 		return 0, err
 	}
-	i += n113
+	i += n112
 	if m.Txn != nil {
 		data[i] = 0x1a
 		i++
 		i = encodeVarintApi(data, i, uint64(m.Txn.Size()))
-		n114, err := m.Txn.MarshalTo(data[i:])
+		n113, err := m.Txn.MarshalTo(data[i:])
 		if err != nil {
 			return 0, err
 		}
-		i += n114
+		i += n113
 	}
 	return i, nil
 }
@@ -3987,8 +3969,6 @@ func (m *RequestHeader) Size() (n int) {
 		l = len(m.EndKey)
 		n += 1 + l + sovApi(uint64(l))
 	}
-	l = m.Replica.Size()
-	n += 1 + l + sovApi(uint64(l))
 	n += 1 + sovApi(uint64(m.RangeID))
 	if m.UserPriority != nil {
 		n += 1 + sovApi(uint64(*m.UserPriority))
@@ -5144,36 +5124,6 @@ func (m *RequestHeader) Unmarshal(data []byte) error {
 				return io.ErrUnexpectedEOF
 			}
 			m.EndKey = append([]byte{}, data[iNdEx:postIndex]...)
-			iNdEx = postIndex
-		case 5:
-			if wireType != 2 {
-				return fmt.Errorf("proto: wrong wireType = %d for field Replica", wireType)
-			}
-			var msglen int
-			for shift := uint(0); ; shift += 7 {
-				if shift >= 64 {
-					return ErrIntOverflowApi
-				}
-				if iNdEx >= l {
-					return io.ErrUnexpectedEOF
-				}
-				b := data[iNdEx]
-				iNdEx++
-				msglen |= (int(b) & 0x7F) << shift
-				if b < 0x80 {
-					break
-				}
-			}
-			if msglen < 0 {
-				return ErrInvalidLengthApi
-			}
-			postIndex := iNdEx + msglen
-			if postIndex > l {
-				return io.ErrUnexpectedEOF
-			}
-			if err := m.Replica.Unmarshal(data[iNdEx:postIndex]); err != nil {
-				return err
-			}
 			iNdEx = postIndex
 		case 6:
 			if wireType != 0 {

--- a/roachpb/api.pb.go
+++ b/roachpb/api.pb.go
@@ -261,12 +261,6 @@ type RequestHeader struct {
 	// that the operation takes place on the key range from Key to EndKey,
 	// including Key and excluding EndKey.
 	EndKey Key `protobuf:"bytes,4,opt,name=end_key,casttype=Key" json:"end_key,omitempty"`
-	// Txn is set non-nil if a transaction is underway. To start a txn,
-	// the first request should set this field to non-nil with name and
-	// isolation level set as desired. The response will contain the
-	// fully-initialized transaction with txn ID, priority, initial
-	// timestamp, and maximum timestamp.
-	Txn *Transaction `protobuf:"bytes,8,opt,name=txn" json:"txn,omitempty"`
 }
 
 func (m *RequestHeader) Reset()         { *m = RequestHeader{} }
@@ -283,13 +277,6 @@ func (m *RequestHeader) GetKey() Key {
 func (m *RequestHeader) GetEndKey() Key {
 	if m != nil {
 		return m.EndKey
-	}
-	return nil
-}
-
-func (m *RequestHeader) GetTxn() *Transaction {
-	if m != nil {
-		return m.Txn
 	}
 	return nil
 }
@@ -1757,16 +1744,6 @@ func (m *RequestHeader) MarshalTo(data []byte) (int, error) {
 		i = encodeVarintApi(data, i, uint64(len(m.EndKey)))
 		i += copy(data[i:], m.EndKey)
 	}
-	if m.Txn != nil {
-		data[i] = 0x42
-		i++
-		i = encodeVarintApi(data, i, uint64(m.Txn.Size()))
-		n1, err := m.Txn.MarshalTo(data[i:])
-		if err != nil {
-			return 0, err
-		}
-		i += n1
-	}
 	return i, nil
 }
 
@@ -1788,20 +1765,20 @@ func (m *ResponseHeader) MarshalTo(data []byte) (int, error) {
 	data[i] = 0x12
 	i++
 	i = encodeVarintApi(data, i, uint64(m.Timestamp.Size()))
-	n2, err := m.Timestamp.MarshalTo(data[i:])
+	n1, err := m.Timestamp.MarshalTo(data[i:])
 	if err != nil {
 		return 0, err
 	}
-	i += n2
+	i += n1
 	if m.Txn != nil {
 		data[i] = 0x1a
 		i++
 		i = encodeVarintApi(data, i, uint64(m.Txn.Size()))
-		n3, err := m.Txn.MarshalTo(data[i:])
+		n2, err := m.Txn.MarshalTo(data[i:])
 		if err != nil {
 			return 0, err
 		}
-		i += n3
+		i += n2
 	}
 	return i, nil
 }
@@ -1824,11 +1801,11 @@ func (m *GetRequest) MarshalTo(data []byte) (int, error) {
 	data[i] = 0xa
 	i++
 	i = encodeVarintApi(data, i, uint64(m.RequestHeader.Size()))
-	n4, err := m.RequestHeader.MarshalTo(data[i:])
+	n3, err := m.RequestHeader.MarshalTo(data[i:])
 	if err != nil {
 		return 0, err
 	}
-	i += n4
+	i += n3
 	return i, nil
 }
 
@@ -1850,20 +1827,20 @@ func (m *GetResponse) MarshalTo(data []byte) (int, error) {
 	data[i] = 0xa
 	i++
 	i = encodeVarintApi(data, i, uint64(m.ResponseHeader.Size()))
-	n5, err := m.ResponseHeader.MarshalTo(data[i:])
+	n4, err := m.ResponseHeader.MarshalTo(data[i:])
 	if err != nil {
 		return 0, err
 	}
-	i += n5
+	i += n4
 	if m.Value != nil {
 		data[i] = 0x12
 		i++
 		i = encodeVarintApi(data, i, uint64(m.Value.Size()))
-		n6, err := m.Value.MarshalTo(data[i:])
+		n5, err := m.Value.MarshalTo(data[i:])
 		if err != nil {
 			return 0, err
 		}
-		i += n6
+		i += n5
 	}
 	return i, nil
 }
@@ -1886,19 +1863,19 @@ func (m *PutRequest) MarshalTo(data []byte) (int, error) {
 	data[i] = 0xa
 	i++
 	i = encodeVarintApi(data, i, uint64(m.RequestHeader.Size()))
-	n7, err := m.RequestHeader.MarshalTo(data[i:])
+	n6, err := m.RequestHeader.MarshalTo(data[i:])
+	if err != nil {
+		return 0, err
+	}
+	i += n6
+	data[i] = 0x12
+	i++
+	i = encodeVarintApi(data, i, uint64(m.Value.Size()))
+	n7, err := m.Value.MarshalTo(data[i:])
 	if err != nil {
 		return 0, err
 	}
 	i += n7
-	data[i] = 0x12
-	i++
-	i = encodeVarintApi(data, i, uint64(m.Value.Size()))
-	n8, err := m.Value.MarshalTo(data[i:])
-	if err != nil {
-		return 0, err
-	}
-	i += n8
 	return i, nil
 }
 
@@ -1920,11 +1897,11 @@ func (m *PutResponse) MarshalTo(data []byte) (int, error) {
 	data[i] = 0xa
 	i++
 	i = encodeVarintApi(data, i, uint64(m.ResponseHeader.Size()))
-	n9, err := m.ResponseHeader.MarshalTo(data[i:])
+	n8, err := m.ResponseHeader.MarshalTo(data[i:])
 	if err != nil {
 		return 0, err
 	}
-	i += n9
+	i += n8
 	return i, nil
 }
 
@@ -1946,28 +1923,28 @@ func (m *ConditionalPutRequest) MarshalTo(data []byte) (int, error) {
 	data[i] = 0xa
 	i++
 	i = encodeVarintApi(data, i, uint64(m.RequestHeader.Size()))
-	n10, err := m.RequestHeader.MarshalTo(data[i:])
+	n9, err := m.RequestHeader.MarshalTo(data[i:])
+	if err != nil {
+		return 0, err
+	}
+	i += n9
+	data[i] = 0x12
+	i++
+	i = encodeVarintApi(data, i, uint64(m.Value.Size()))
+	n10, err := m.Value.MarshalTo(data[i:])
 	if err != nil {
 		return 0, err
 	}
 	i += n10
-	data[i] = 0x12
-	i++
-	i = encodeVarintApi(data, i, uint64(m.Value.Size()))
-	n11, err := m.Value.MarshalTo(data[i:])
-	if err != nil {
-		return 0, err
-	}
-	i += n11
 	if m.ExpValue != nil {
 		data[i] = 0x1a
 		i++
 		i = encodeVarintApi(data, i, uint64(m.ExpValue.Size()))
-		n12, err := m.ExpValue.MarshalTo(data[i:])
+		n11, err := m.ExpValue.MarshalTo(data[i:])
 		if err != nil {
 			return 0, err
 		}
-		i += n12
+		i += n11
 	}
 	return i, nil
 }
@@ -1990,11 +1967,11 @@ func (m *ConditionalPutResponse) MarshalTo(data []byte) (int, error) {
 	data[i] = 0xa
 	i++
 	i = encodeVarintApi(data, i, uint64(m.ResponseHeader.Size()))
-	n13, err := m.ResponseHeader.MarshalTo(data[i:])
+	n12, err := m.ResponseHeader.MarshalTo(data[i:])
 	if err != nil {
 		return 0, err
 	}
-	i += n13
+	i += n12
 	return i, nil
 }
 
@@ -2016,11 +1993,11 @@ func (m *IncrementRequest) MarshalTo(data []byte) (int, error) {
 	data[i] = 0xa
 	i++
 	i = encodeVarintApi(data, i, uint64(m.RequestHeader.Size()))
-	n14, err := m.RequestHeader.MarshalTo(data[i:])
+	n13, err := m.RequestHeader.MarshalTo(data[i:])
 	if err != nil {
 		return 0, err
 	}
-	i += n14
+	i += n13
 	data[i] = 0x10
 	i++
 	i = encodeVarintApi(data, i, uint64(m.Increment))
@@ -2045,11 +2022,11 @@ func (m *IncrementResponse) MarshalTo(data []byte) (int, error) {
 	data[i] = 0xa
 	i++
 	i = encodeVarintApi(data, i, uint64(m.ResponseHeader.Size()))
-	n15, err := m.ResponseHeader.MarshalTo(data[i:])
+	n14, err := m.ResponseHeader.MarshalTo(data[i:])
 	if err != nil {
 		return 0, err
 	}
-	i += n15
+	i += n14
 	data[i] = 0x10
 	i++
 	i = encodeVarintApi(data, i, uint64(m.NewValue))
@@ -2074,11 +2051,11 @@ func (m *DeleteRequest) MarshalTo(data []byte) (int, error) {
 	data[i] = 0xa
 	i++
 	i = encodeVarintApi(data, i, uint64(m.RequestHeader.Size()))
-	n16, err := m.RequestHeader.MarshalTo(data[i:])
+	n15, err := m.RequestHeader.MarshalTo(data[i:])
 	if err != nil {
 		return 0, err
 	}
-	i += n16
+	i += n15
 	return i, nil
 }
 
@@ -2100,11 +2077,11 @@ func (m *DeleteResponse) MarshalTo(data []byte) (int, error) {
 	data[i] = 0xa
 	i++
 	i = encodeVarintApi(data, i, uint64(m.ResponseHeader.Size()))
-	n17, err := m.ResponseHeader.MarshalTo(data[i:])
+	n16, err := m.ResponseHeader.MarshalTo(data[i:])
 	if err != nil {
 		return 0, err
 	}
-	i += n17
+	i += n16
 	return i, nil
 }
 
@@ -2126,11 +2103,11 @@ func (m *DeleteRangeRequest) MarshalTo(data []byte) (int, error) {
 	data[i] = 0xa
 	i++
 	i = encodeVarintApi(data, i, uint64(m.RequestHeader.Size()))
-	n18, err := m.RequestHeader.MarshalTo(data[i:])
+	n17, err := m.RequestHeader.MarshalTo(data[i:])
 	if err != nil {
 		return 0, err
 	}
-	i += n18
+	i += n17
 	data[i] = 0x10
 	i++
 	i = encodeVarintApi(data, i, uint64(m.MaxEntriesToDelete))
@@ -2155,11 +2132,11 @@ func (m *DeleteRangeResponse) MarshalTo(data []byte) (int, error) {
 	data[i] = 0xa
 	i++
 	i = encodeVarintApi(data, i, uint64(m.ResponseHeader.Size()))
-	n19, err := m.ResponseHeader.MarshalTo(data[i:])
+	n18, err := m.ResponseHeader.MarshalTo(data[i:])
 	if err != nil {
 		return 0, err
 	}
-	i += n19
+	i += n18
 	data[i] = 0x10
 	i++
 	i = encodeVarintApi(data, i, uint64(m.NumDeleted))
@@ -2184,11 +2161,11 @@ func (m *ScanRequest) MarshalTo(data []byte) (int, error) {
 	data[i] = 0xa
 	i++
 	i = encodeVarintApi(data, i, uint64(m.RequestHeader.Size()))
-	n20, err := m.RequestHeader.MarshalTo(data[i:])
+	n19, err := m.RequestHeader.MarshalTo(data[i:])
 	if err != nil {
 		return 0, err
 	}
-	i += n20
+	i += n19
 	data[i] = 0x10
 	i++
 	i = encodeVarintApi(data, i, uint64(m.MaxResults))
@@ -2213,11 +2190,11 @@ func (m *ScanResponse) MarshalTo(data []byte) (int, error) {
 	data[i] = 0xa
 	i++
 	i = encodeVarintApi(data, i, uint64(m.ResponseHeader.Size()))
-	n21, err := m.ResponseHeader.MarshalTo(data[i:])
+	n20, err := m.ResponseHeader.MarshalTo(data[i:])
 	if err != nil {
 		return 0, err
 	}
-	i += n21
+	i += n20
 	if len(m.Rows) > 0 {
 		for _, msg := range m.Rows {
 			data[i] = 0x12
@@ -2251,11 +2228,11 @@ func (m *ReverseScanRequest) MarshalTo(data []byte) (int, error) {
 	data[i] = 0xa
 	i++
 	i = encodeVarintApi(data, i, uint64(m.RequestHeader.Size()))
-	n22, err := m.RequestHeader.MarshalTo(data[i:])
+	n21, err := m.RequestHeader.MarshalTo(data[i:])
 	if err != nil {
 		return 0, err
 	}
-	i += n22
+	i += n21
 	data[i] = 0x10
 	i++
 	i = encodeVarintApi(data, i, uint64(m.MaxResults))
@@ -2280,11 +2257,11 @@ func (m *ReverseScanResponse) MarshalTo(data []byte) (int, error) {
 	data[i] = 0xa
 	i++
 	i = encodeVarintApi(data, i, uint64(m.ResponseHeader.Size()))
-	n23, err := m.ResponseHeader.MarshalTo(data[i:])
+	n22, err := m.ResponseHeader.MarshalTo(data[i:])
 	if err != nil {
 		return 0, err
 	}
-	i += n23
+	i += n22
 	if len(m.Rows) > 0 {
 		for _, msg := range m.Rows {
 			data[i] = 0x12
@@ -2318,11 +2295,11 @@ func (m *EndTransactionRequest) MarshalTo(data []byte) (int, error) {
 	data[i] = 0xa
 	i++
 	i = encodeVarintApi(data, i, uint64(m.RequestHeader.Size()))
-	n24, err := m.RequestHeader.MarshalTo(data[i:])
+	n23, err := m.RequestHeader.MarshalTo(data[i:])
 	if err != nil {
 		return 0, err
 	}
-	i += n24
+	i += n23
 	data[i] = 0x10
 	i++
 	if m.Commit {
@@ -2335,11 +2312,11 @@ func (m *EndTransactionRequest) MarshalTo(data []byte) (int, error) {
 		data[i] = 0x1a
 		i++
 		i = encodeVarintApi(data, i, uint64(m.InternalCommitTrigger.Size()))
-		n25, err := m.InternalCommitTrigger.MarshalTo(data[i:])
+		n24, err := m.InternalCommitTrigger.MarshalTo(data[i:])
 		if err != nil {
 			return 0, err
 		}
-		i += n25
+		i += n24
 	}
 	if len(m.Intents) > 0 {
 		for _, msg := range m.Intents {
@@ -2374,11 +2351,11 @@ func (m *EndTransactionResponse) MarshalTo(data []byte) (int, error) {
 	data[i] = 0xa
 	i++
 	i = encodeVarintApi(data, i, uint64(m.ResponseHeader.Size()))
-	n26, err := m.ResponseHeader.MarshalTo(data[i:])
+	n25, err := m.ResponseHeader.MarshalTo(data[i:])
 	if err != nil {
 		return 0, err
 	}
-	i += n26
+	i += n25
 	data[i] = 0x10
 	i++
 	i = encodeVarintApi(data, i, uint64(m.CommitWait))
@@ -2411,11 +2388,11 @@ func (m *AdminSplitRequest) MarshalTo(data []byte) (int, error) {
 	data[i] = 0xa
 	i++
 	i = encodeVarintApi(data, i, uint64(m.RequestHeader.Size()))
-	n27, err := m.RequestHeader.MarshalTo(data[i:])
+	n26, err := m.RequestHeader.MarshalTo(data[i:])
 	if err != nil {
 		return 0, err
 	}
-	i += n27
+	i += n26
 	if m.SplitKey != nil {
 		data[i] = 0x12
 		i++
@@ -2443,11 +2420,11 @@ func (m *AdminSplitResponse) MarshalTo(data []byte) (int, error) {
 	data[i] = 0xa
 	i++
 	i = encodeVarintApi(data, i, uint64(m.ResponseHeader.Size()))
-	n28, err := m.ResponseHeader.MarshalTo(data[i:])
+	n27, err := m.ResponseHeader.MarshalTo(data[i:])
 	if err != nil {
 		return 0, err
 	}
-	i += n28
+	i += n27
 	return i, nil
 }
 
@@ -2469,11 +2446,11 @@ func (m *AdminMergeRequest) MarshalTo(data []byte) (int, error) {
 	data[i] = 0xa
 	i++
 	i = encodeVarintApi(data, i, uint64(m.RequestHeader.Size()))
-	n29, err := m.RequestHeader.MarshalTo(data[i:])
+	n28, err := m.RequestHeader.MarshalTo(data[i:])
 	if err != nil {
 		return 0, err
 	}
-	i += n29
+	i += n28
 	return i, nil
 }
 
@@ -2495,11 +2472,11 @@ func (m *AdminMergeResponse) MarshalTo(data []byte) (int, error) {
 	data[i] = 0xa
 	i++
 	i = encodeVarintApi(data, i, uint64(m.ResponseHeader.Size()))
-	n30, err := m.ResponseHeader.MarshalTo(data[i:])
+	n29, err := m.ResponseHeader.MarshalTo(data[i:])
 	if err != nil {
 		return 0, err
 	}
-	i += n30
+	i += n29
 	return i, nil
 }
 
@@ -2521,11 +2498,11 @@ func (m *RangeLookupRequest) MarshalTo(data []byte) (int, error) {
 	data[i] = 0xa
 	i++
 	i = encodeVarintApi(data, i, uint64(m.RequestHeader.Size()))
-	n31, err := m.RequestHeader.MarshalTo(data[i:])
+	n30, err := m.RequestHeader.MarshalTo(data[i:])
 	if err != nil {
 		return 0, err
 	}
-	i += n31
+	i += n30
 	data[i] = 0x10
 	i++
 	i = encodeVarintApi(data, i, uint64(m.MaxRanges))
@@ -2566,11 +2543,11 @@ func (m *RangeLookupResponse) MarshalTo(data []byte) (int, error) {
 	data[i] = 0xa
 	i++
 	i = encodeVarintApi(data, i, uint64(m.ResponseHeader.Size()))
-	n32, err := m.ResponseHeader.MarshalTo(data[i:])
+	n31, err := m.ResponseHeader.MarshalTo(data[i:])
 	if err != nil {
 		return 0, err
 	}
-	i += n32
+	i += n31
 	if len(m.Ranges) > 0 {
 		for _, msg := range m.Ranges {
 			data[i] = 0x12
@@ -2604,11 +2581,11 @@ func (m *HeartbeatTxnRequest) MarshalTo(data []byte) (int, error) {
 	data[i] = 0xa
 	i++
 	i = encodeVarintApi(data, i, uint64(m.RequestHeader.Size()))
-	n33, err := m.RequestHeader.MarshalTo(data[i:])
+	n32, err := m.RequestHeader.MarshalTo(data[i:])
 	if err != nil {
 		return 0, err
 	}
-	i += n33
+	i += n32
 	return i, nil
 }
 
@@ -2630,11 +2607,11 @@ func (m *HeartbeatTxnResponse) MarshalTo(data []byte) (int, error) {
 	data[i] = 0xa
 	i++
 	i = encodeVarintApi(data, i, uint64(m.ResponseHeader.Size()))
-	n34, err := m.ResponseHeader.MarshalTo(data[i:])
+	n33, err := m.ResponseHeader.MarshalTo(data[i:])
 	if err != nil {
 		return 0, err
 	}
-	i += n34
+	i += n33
 	return i, nil
 }
 
@@ -2656,19 +2633,19 @@ func (m *GCRequest) MarshalTo(data []byte) (int, error) {
 	data[i] = 0xa
 	i++
 	i = encodeVarintApi(data, i, uint64(m.RequestHeader.Size()))
-	n35, err := m.RequestHeader.MarshalTo(data[i:])
+	n34, err := m.RequestHeader.MarshalTo(data[i:])
+	if err != nil {
+		return 0, err
+	}
+	i += n34
+	data[i] = 0x12
+	i++
+	i = encodeVarintApi(data, i, uint64(m.GCMeta.Size()))
+	n35, err := m.GCMeta.MarshalTo(data[i:])
 	if err != nil {
 		return 0, err
 	}
 	i += n35
-	data[i] = 0x12
-	i++
-	i = encodeVarintApi(data, i, uint64(m.GCMeta.Size()))
-	n36, err := m.GCMeta.MarshalTo(data[i:])
-	if err != nil {
-		return 0, err
-	}
-	i += n36
 	if len(m.Keys) > 0 {
 		for _, msg := range m.Keys {
 			data[i] = 0x1a
@@ -2708,11 +2685,11 @@ func (m *GCRequest_GCKey) MarshalTo(data []byte) (int, error) {
 	data[i] = 0x12
 	i++
 	i = encodeVarintApi(data, i, uint64(m.Timestamp.Size()))
-	n37, err := m.Timestamp.MarshalTo(data[i:])
+	n36, err := m.Timestamp.MarshalTo(data[i:])
 	if err != nil {
 		return 0, err
 	}
-	i += n37
+	i += n36
 	return i, nil
 }
 
@@ -2734,11 +2711,11 @@ func (m *GCResponse) MarshalTo(data []byte) (int, error) {
 	data[i] = 0xa
 	i++
 	i = encodeVarintApi(data, i, uint64(m.ResponseHeader.Size()))
-	n38, err := m.ResponseHeader.MarshalTo(data[i:])
+	n37, err := m.ResponseHeader.MarshalTo(data[i:])
 	if err != nil {
 		return 0, err
 	}
-	i += n38
+	i += n37
 	return i, nil
 }
 
@@ -2760,43 +2737,43 @@ func (m *PushTxnRequest) MarshalTo(data []byte) (int, error) {
 	data[i] = 0xa
 	i++
 	i = encodeVarintApi(data, i, uint64(m.RequestHeader.Size()))
-	n39, err := m.RequestHeader.MarshalTo(data[i:])
+	n38, err := m.RequestHeader.MarshalTo(data[i:])
+	if err != nil {
+		return 0, err
+	}
+	i += n38
+	data[i] = 0x12
+	i++
+	i = encodeVarintApi(data, i, uint64(m.PusherTxn.Size()))
+	n39, err := m.PusherTxn.MarshalTo(data[i:])
 	if err != nil {
 		return 0, err
 	}
 	i += n39
-	data[i] = 0x12
+	data[i] = 0x1a
 	i++
-	i = encodeVarintApi(data, i, uint64(m.PusherTxn.Size()))
-	n40, err := m.PusherTxn.MarshalTo(data[i:])
+	i = encodeVarintApi(data, i, uint64(m.PusheeTxn.Size()))
+	n40, err := m.PusheeTxn.MarshalTo(data[i:])
 	if err != nil {
 		return 0, err
 	}
 	i += n40
-	data[i] = 0x1a
+	data[i] = 0x22
 	i++
-	i = encodeVarintApi(data, i, uint64(m.PusheeTxn.Size()))
-	n41, err := m.PusheeTxn.MarshalTo(data[i:])
+	i = encodeVarintApi(data, i, uint64(m.PushTo.Size()))
+	n41, err := m.PushTo.MarshalTo(data[i:])
 	if err != nil {
 		return 0, err
 	}
 	i += n41
-	data[i] = 0x22
+	data[i] = 0x2a
 	i++
-	i = encodeVarintApi(data, i, uint64(m.PushTo.Size()))
-	n42, err := m.PushTo.MarshalTo(data[i:])
+	i = encodeVarintApi(data, i, uint64(m.Now.Size()))
+	n42, err := m.Now.MarshalTo(data[i:])
 	if err != nil {
 		return 0, err
 	}
 	i += n42
-	data[i] = 0x2a
-	i++
-	i = encodeVarintApi(data, i, uint64(m.Now.Size()))
-	n43, err := m.Now.MarshalTo(data[i:])
-	if err != nil {
-		return 0, err
-	}
-	i += n43
 	data[i] = 0x30
 	i++
 	i = encodeVarintApi(data, i, uint64(m.PushType))
@@ -2821,20 +2798,20 @@ func (m *PushTxnResponse) MarshalTo(data []byte) (int, error) {
 	data[i] = 0xa
 	i++
 	i = encodeVarintApi(data, i, uint64(m.ResponseHeader.Size()))
-	n44, err := m.ResponseHeader.MarshalTo(data[i:])
+	n43, err := m.ResponseHeader.MarshalTo(data[i:])
 	if err != nil {
 		return 0, err
 	}
-	i += n44
+	i += n43
 	if m.PusheeTxn != nil {
 		data[i] = 0x12
 		i++
 		i = encodeVarintApi(data, i, uint64(m.PusheeTxn.Size()))
-		n45, err := m.PusheeTxn.MarshalTo(data[i:])
+		n44, err := m.PusheeTxn.MarshalTo(data[i:])
 		if err != nil {
 			return 0, err
 		}
-		i += n45
+		i += n44
 	}
 	return i, nil
 }
@@ -2857,19 +2834,19 @@ func (m *ResolveIntentRequest) MarshalTo(data []byte) (int, error) {
 	data[i] = 0xa
 	i++
 	i = encodeVarintApi(data, i, uint64(m.RequestHeader.Size()))
-	n46, err := m.RequestHeader.MarshalTo(data[i:])
+	n45, err := m.RequestHeader.MarshalTo(data[i:])
+	if err != nil {
+		return 0, err
+	}
+	i += n45
+	data[i] = 0x12
+	i++
+	i = encodeVarintApi(data, i, uint64(m.IntentTxn.Size()))
+	n46, err := m.IntentTxn.MarshalTo(data[i:])
 	if err != nil {
 		return 0, err
 	}
 	i += n46
-	data[i] = 0x12
-	i++
-	i = encodeVarintApi(data, i, uint64(m.IntentTxn.Size()))
-	n47, err := m.IntentTxn.MarshalTo(data[i:])
-	if err != nil {
-		return 0, err
-	}
-	i += n47
 	return i, nil
 }
 
@@ -2891,11 +2868,11 @@ func (m *ResolveIntentResponse) MarshalTo(data []byte) (int, error) {
 	data[i] = 0xa
 	i++
 	i = encodeVarintApi(data, i, uint64(m.ResponseHeader.Size()))
-	n48, err := m.ResponseHeader.MarshalTo(data[i:])
+	n47, err := m.ResponseHeader.MarshalTo(data[i:])
 	if err != nil {
 		return 0, err
 	}
-	i += n48
+	i += n47
 	return i, nil
 }
 
@@ -2917,19 +2894,19 @@ func (m *ResolveIntentRangeRequest) MarshalTo(data []byte) (int, error) {
 	data[i] = 0xa
 	i++
 	i = encodeVarintApi(data, i, uint64(m.RequestHeader.Size()))
-	n49, err := m.RequestHeader.MarshalTo(data[i:])
+	n48, err := m.RequestHeader.MarshalTo(data[i:])
+	if err != nil {
+		return 0, err
+	}
+	i += n48
+	data[i] = 0x12
+	i++
+	i = encodeVarintApi(data, i, uint64(m.IntentTxn.Size()))
+	n49, err := m.IntentTxn.MarshalTo(data[i:])
 	if err != nil {
 		return 0, err
 	}
 	i += n49
-	data[i] = 0x12
-	i++
-	i = encodeVarintApi(data, i, uint64(m.IntentTxn.Size()))
-	n50, err := m.IntentTxn.MarshalTo(data[i:])
-	if err != nil {
-		return 0, err
-	}
-	i += n50
 	return i, nil
 }
 
@@ -2951,11 +2928,11 @@ func (m *NoopResponse) MarshalTo(data []byte) (int, error) {
 	data[i] = 0xa
 	i++
 	i = encodeVarintApi(data, i, uint64(m.ResponseHeader.Size()))
-	n51, err := m.ResponseHeader.MarshalTo(data[i:])
+	n50, err := m.ResponseHeader.MarshalTo(data[i:])
 	if err != nil {
 		return 0, err
 	}
-	i += n51
+	i += n50
 	return i, nil
 }
 
@@ -2977,11 +2954,11 @@ func (m *NoopRequest) MarshalTo(data []byte) (int, error) {
 	data[i] = 0xa
 	i++
 	i = encodeVarintApi(data, i, uint64(m.RequestHeader.Size()))
-	n52, err := m.RequestHeader.MarshalTo(data[i:])
+	n51, err := m.RequestHeader.MarshalTo(data[i:])
 	if err != nil {
 		return 0, err
 	}
-	i += n52
+	i += n51
 	return i, nil
 }
 
@@ -3003,11 +2980,11 @@ func (m *ResolveIntentRangeResponse) MarshalTo(data []byte) (int, error) {
 	data[i] = 0xa
 	i++
 	i = encodeVarintApi(data, i, uint64(m.ResponseHeader.Size()))
-	n53, err := m.ResponseHeader.MarshalTo(data[i:])
+	n52, err := m.ResponseHeader.MarshalTo(data[i:])
 	if err != nil {
 		return 0, err
 	}
-	i += n53
+	i += n52
 	return i, nil
 }
 
@@ -3029,19 +3006,19 @@ func (m *MergeRequest) MarshalTo(data []byte) (int, error) {
 	data[i] = 0xa
 	i++
 	i = encodeVarintApi(data, i, uint64(m.RequestHeader.Size()))
-	n54, err := m.RequestHeader.MarshalTo(data[i:])
+	n53, err := m.RequestHeader.MarshalTo(data[i:])
+	if err != nil {
+		return 0, err
+	}
+	i += n53
+	data[i] = 0x12
+	i++
+	i = encodeVarintApi(data, i, uint64(m.Value.Size()))
+	n54, err := m.Value.MarshalTo(data[i:])
 	if err != nil {
 		return 0, err
 	}
 	i += n54
-	data[i] = 0x12
-	i++
-	i = encodeVarintApi(data, i, uint64(m.Value.Size()))
-	n55, err := m.Value.MarshalTo(data[i:])
-	if err != nil {
-		return 0, err
-	}
-	i += n55
 	return i, nil
 }
 
@@ -3063,11 +3040,11 @@ func (m *MergeResponse) MarshalTo(data []byte) (int, error) {
 	data[i] = 0xa
 	i++
 	i = encodeVarintApi(data, i, uint64(m.ResponseHeader.Size()))
-	n56, err := m.ResponseHeader.MarshalTo(data[i:])
+	n55, err := m.ResponseHeader.MarshalTo(data[i:])
 	if err != nil {
 		return 0, err
 	}
-	i += n56
+	i += n55
 	return i, nil
 }
 
@@ -3089,11 +3066,11 @@ func (m *TruncateLogRequest) MarshalTo(data []byte) (int, error) {
 	data[i] = 0xa
 	i++
 	i = encodeVarintApi(data, i, uint64(m.RequestHeader.Size()))
-	n57, err := m.RequestHeader.MarshalTo(data[i:])
+	n56, err := m.RequestHeader.MarshalTo(data[i:])
 	if err != nil {
 		return 0, err
 	}
-	i += n57
+	i += n56
 	data[i] = 0x10
 	i++
 	i = encodeVarintApi(data, i, uint64(m.Index))
@@ -3118,11 +3095,11 @@ func (m *TruncateLogResponse) MarshalTo(data []byte) (int, error) {
 	data[i] = 0xa
 	i++
 	i = encodeVarintApi(data, i, uint64(m.ResponseHeader.Size()))
-	n58, err := m.ResponseHeader.MarshalTo(data[i:])
+	n57, err := m.ResponseHeader.MarshalTo(data[i:])
 	if err != nil {
 		return 0, err
 	}
-	i += n58
+	i += n57
 	return i, nil
 }
 
@@ -3144,19 +3121,19 @@ func (m *LeaderLeaseRequest) MarshalTo(data []byte) (int, error) {
 	data[i] = 0xa
 	i++
 	i = encodeVarintApi(data, i, uint64(m.RequestHeader.Size()))
-	n59, err := m.RequestHeader.MarshalTo(data[i:])
+	n58, err := m.RequestHeader.MarshalTo(data[i:])
+	if err != nil {
+		return 0, err
+	}
+	i += n58
+	data[i] = 0x12
+	i++
+	i = encodeVarintApi(data, i, uint64(m.Lease.Size()))
+	n59, err := m.Lease.MarshalTo(data[i:])
 	if err != nil {
 		return 0, err
 	}
 	i += n59
-	data[i] = 0x12
-	i++
-	i = encodeVarintApi(data, i, uint64(m.Lease.Size()))
-	n60, err := m.Lease.MarshalTo(data[i:])
-	if err != nil {
-		return 0, err
-	}
-	i += n60
 	return i, nil
 }
 
@@ -3178,11 +3155,11 @@ func (m *LeaderLeaseResponse) MarshalTo(data []byte) (int, error) {
 	data[i] = 0xa
 	i++
 	i = encodeVarintApi(data, i, uint64(m.ResponseHeader.Size()))
-	n61, err := m.ResponseHeader.MarshalTo(data[i:])
+	n60, err := m.ResponseHeader.MarshalTo(data[i:])
 	if err != nil {
 		return 0, err
 	}
-	i += n61
+	i += n60
 	return i, nil
 }
 
@@ -3205,151 +3182,151 @@ func (m *RequestUnion) MarshalTo(data []byte) (int, error) {
 		data[i] = 0xa
 		i++
 		i = encodeVarintApi(data, i, uint64(m.Get.Size()))
-		n62, err := m.Get.MarshalTo(data[i:])
+		n61, err := m.Get.MarshalTo(data[i:])
 		if err != nil {
 			return 0, err
 		}
-		i += n62
+		i += n61
 	}
 	if m.Put != nil {
 		data[i] = 0x12
 		i++
 		i = encodeVarintApi(data, i, uint64(m.Put.Size()))
-		n63, err := m.Put.MarshalTo(data[i:])
+		n62, err := m.Put.MarshalTo(data[i:])
 		if err != nil {
 			return 0, err
 		}
-		i += n63
+		i += n62
 	}
 	if m.ConditionalPut != nil {
 		data[i] = 0x1a
 		i++
 		i = encodeVarintApi(data, i, uint64(m.ConditionalPut.Size()))
-		n64, err := m.ConditionalPut.MarshalTo(data[i:])
+		n63, err := m.ConditionalPut.MarshalTo(data[i:])
 		if err != nil {
 			return 0, err
 		}
-		i += n64
+		i += n63
 	}
 	if m.Increment != nil {
 		data[i] = 0x22
 		i++
 		i = encodeVarintApi(data, i, uint64(m.Increment.Size()))
-		n65, err := m.Increment.MarshalTo(data[i:])
+		n64, err := m.Increment.MarshalTo(data[i:])
 		if err != nil {
 			return 0, err
 		}
-		i += n65
+		i += n64
 	}
 	if m.Delete != nil {
 		data[i] = 0x2a
 		i++
 		i = encodeVarintApi(data, i, uint64(m.Delete.Size()))
-		n66, err := m.Delete.MarshalTo(data[i:])
+		n65, err := m.Delete.MarshalTo(data[i:])
 		if err != nil {
 			return 0, err
 		}
-		i += n66
+		i += n65
 	}
 	if m.DeleteRange != nil {
 		data[i] = 0x32
 		i++
 		i = encodeVarintApi(data, i, uint64(m.DeleteRange.Size()))
-		n67, err := m.DeleteRange.MarshalTo(data[i:])
+		n66, err := m.DeleteRange.MarshalTo(data[i:])
 		if err != nil {
 			return 0, err
 		}
-		i += n67
+		i += n66
 	}
 	if m.Scan != nil {
 		data[i] = 0x3a
 		i++
 		i = encodeVarintApi(data, i, uint64(m.Scan.Size()))
-		n68, err := m.Scan.MarshalTo(data[i:])
+		n67, err := m.Scan.MarshalTo(data[i:])
 		if err != nil {
 			return 0, err
 		}
-		i += n68
+		i += n67
 	}
 	if m.EndTransaction != nil {
 		data[i] = 0x42
 		i++
 		i = encodeVarintApi(data, i, uint64(m.EndTransaction.Size()))
-		n69, err := m.EndTransaction.MarshalTo(data[i:])
+		n68, err := m.EndTransaction.MarshalTo(data[i:])
 		if err != nil {
 			return 0, err
 		}
-		i += n69
+		i += n68
 	}
 	if m.AdminSplit != nil {
 		data[i] = 0x4a
 		i++
 		i = encodeVarintApi(data, i, uint64(m.AdminSplit.Size()))
-		n70, err := m.AdminSplit.MarshalTo(data[i:])
+		n69, err := m.AdminSplit.MarshalTo(data[i:])
 		if err != nil {
 			return 0, err
 		}
-		i += n70
+		i += n69
 	}
 	if m.AdminMerge != nil {
 		data[i] = 0x52
 		i++
 		i = encodeVarintApi(data, i, uint64(m.AdminMerge.Size()))
-		n71, err := m.AdminMerge.MarshalTo(data[i:])
+		n70, err := m.AdminMerge.MarshalTo(data[i:])
 		if err != nil {
 			return 0, err
 		}
-		i += n71
+		i += n70
 	}
 	if m.HeartbeatTxn != nil {
 		data[i] = 0x5a
 		i++
 		i = encodeVarintApi(data, i, uint64(m.HeartbeatTxn.Size()))
-		n72, err := m.HeartbeatTxn.MarshalTo(data[i:])
+		n71, err := m.HeartbeatTxn.MarshalTo(data[i:])
 		if err != nil {
 			return 0, err
 		}
-		i += n72
+		i += n71
 	}
 	if m.Gc != nil {
 		data[i] = 0x62
 		i++
 		i = encodeVarintApi(data, i, uint64(m.Gc.Size()))
-		n73, err := m.Gc.MarshalTo(data[i:])
+		n72, err := m.Gc.MarshalTo(data[i:])
 		if err != nil {
 			return 0, err
 		}
-		i += n73
+		i += n72
 	}
 	if m.PushTxn != nil {
 		data[i] = 0x6a
 		i++
 		i = encodeVarintApi(data, i, uint64(m.PushTxn.Size()))
-		n74, err := m.PushTxn.MarshalTo(data[i:])
+		n73, err := m.PushTxn.MarshalTo(data[i:])
 		if err != nil {
 			return 0, err
 		}
-		i += n74
+		i += n73
 	}
 	if m.RangeLookup != nil {
 		data[i] = 0x72
 		i++
 		i = encodeVarintApi(data, i, uint64(m.RangeLookup.Size()))
-		n75, err := m.RangeLookup.MarshalTo(data[i:])
+		n74, err := m.RangeLookup.MarshalTo(data[i:])
 		if err != nil {
 			return 0, err
 		}
-		i += n75
+		i += n74
 	}
 	if m.ResolveIntent != nil {
 		data[i] = 0x7a
 		i++
 		i = encodeVarintApi(data, i, uint64(m.ResolveIntent.Size()))
-		n76, err := m.ResolveIntent.MarshalTo(data[i:])
+		n75, err := m.ResolveIntent.MarshalTo(data[i:])
 		if err != nil {
 			return 0, err
 		}
-		i += n76
+		i += n75
 	}
 	if m.ResolveIntentRange != nil {
 		data[i] = 0x82
@@ -3357,11 +3334,11 @@ func (m *RequestUnion) MarshalTo(data []byte) (int, error) {
 		data[i] = 0x1
 		i++
 		i = encodeVarintApi(data, i, uint64(m.ResolveIntentRange.Size()))
-		n77, err := m.ResolveIntentRange.MarshalTo(data[i:])
+		n76, err := m.ResolveIntentRange.MarshalTo(data[i:])
 		if err != nil {
 			return 0, err
 		}
-		i += n77
+		i += n76
 	}
 	if m.Merge != nil {
 		data[i] = 0x8a
@@ -3369,11 +3346,11 @@ func (m *RequestUnion) MarshalTo(data []byte) (int, error) {
 		data[i] = 0x1
 		i++
 		i = encodeVarintApi(data, i, uint64(m.Merge.Size()))
-		n78, err := m.Merge.MarshalTo(data[i:])
+		n77, err := m.Merge.MarshalTo(data[i:])
 		if err != nil {
 			return 0, err
 		}
-		i += n78
+		i += n77
 	}
 	if m.TruncateLog != nil {
 		data[i] = 0x92
@@ -3381,11 +3358,11 @@ func (m *RequestUnion) MarshalTo(data []byte) (int, error) {
 		data[i] = 0x1
 		i++
 		i = encodeVarintApi(data, i, uint64(m.TruncateLog.Size()))
-		n79, err := m.TruncateLog.MarshalTo(data[i:])
+		n78, err := m.TruncateLog.MarshalTo(data[i:])
 		if err != nil {
 			return 0, err
 		}
-		i += n79
+		i += n78
 	}
 	if m.LeaderLease != nil {
 		data[i] = 0x9a
@@ -3393,11 +3370,11 @@ func (m *RequestUnion) MarshalTo(data []byte) (int, error) {
 		data[i] = 0x1
 		i++
 		i = encodeVarintApi(data, i, uint64(m.LeaderLease.Size()))
-		n80, err := m.LeaderLease.MarshalTo(data[i:])
+		n79, err := m.LeaderLease.MarshalTo(data[i:])
 		if err != nil {
 			return 0, err
 		}
-		i += n80
+		i += n79
 	}
 	if m.ReverseScan != nil {
 		data[i] = 0xa2
@@ -3405,11 +3382,11 @@ func (m *RequestUnion) MarshalTo(data []byte) (int, error) {
 		data[i] = 0x1
 		i++
 		i = encodeVarintApi(data, i, uint64(m.ReverseScan.Size()))
-		n81, err := m.ReverseScan.MarshalTo(data[i:])
+		n80, err := m.ReverseScan.MarshalTo(data[i:])
 		if err != nil {
 			return 0, err
 		}
-		i += n81
+		i += n80
 	}
 	if m.Noop != nil {
 		data[i] = 0xaa
@@ -3417,11 +3394,11 @@ func (m *RequestUnion) MarshalTo(data []byte) (int, error) {
 		data[i] = 0x1
 		i++
 		i = encodeVarintApi(data, i, uint64(m.Noop.Size()))
-		n82, err := m.Noop.MarshalTo(data[i:])
+		n81, err := m.Noop.MarshalTo(data[i:])
 		if err != nil {
 			return 0, err
 		}
-		i += n82
+		i += n81
 	}
 	return i, nil
 }
@@ -3445,151 +3422,151 @@ func (m *ResponseUnion) MarshalTo(data []byte) (int, error) {
 		data[i] = 0xa
 		i++
 		i = encodeVarintApi(data, i, uint64(m.Get.Size()))
-		n83, err := m.Get.MarshalTo(data[i:])
+		n82, err := m.Get.MarshalTo(data[i:])
 		if err != nil {
 			return 0, err
 		}
-		i += n83
+		i += n82
 	}
 	if m.Put != nil {
 		data[i] = 0x12
 		i++
 		i = encodeVarintApi(data, i, uint64(m.Put.Size()))
-		n84, err := m.Put.MarshalTo(data[i:])
+		n83, err := m.Put.MarshalTo(data[i:])
 		if err != nil {
 			return 0, err
 		}
-		i += n84
+		i += n83
 	}
 	if m.ConditionalPut != nil {
 		data[i] = 0x1a
 		i++
 		i = encodeVarintApi(data, i, uint64(m.ConditionalPut.Size()))
-		n85, err := m.ConditionalPut.MarshalTo(data[i:])
+		n84, err := m.ConditionalPut.MarshalTo(data[i:])
 		if err != nil {
 			return 0, err
 		}
-		i += n85
+		i += n84
 	}
 	if m.Increment != nil {
 		data[i] = 0x22
 		i++
 		i = encodeVarintApi(data, i, uint64(m.Increment.Size()))
-		n86, err := m.Increment.MarshalTo(data[i:])
+		n85, err := m.Increment.MarshalTo(data[i:])
 		if err != nil {
 			return 0, err
 		}
-		i += n86
+		i += n85
 	}
 	if m.Delete != nil {
 		data[i] = 0x2a
 		i++
 		i = encodeVarintApi(data, i, uint64(m.Delete.Size()))
-		n87, err := m.Delete.MarshalTo(data[i:])
+		n86, err := m.Delete.MarshalTo(data[i:])
 		if err != nil {
 			return 0, err
 		}
-		i += n87
+		i += n86
 	}
 	if m.DeleteRange != nil {
 		data[i] = 0x32
 		i++
 		i = encodeVarintApi(data, i, uint64(m.DeleteRange.Size()))
-		n88, err := m.DeleteRange.MarshalTo(data[i:])
+		n87, err := m.DeleteRange.MarshalTo(data[i:])
 		if err != nil {
 			return 0, err
 		}
-		i += n88
+		i += n87
 	}
 	if m.Scan != nil {
 		data[i] = 0x3a
 		i++
 		i = encodeVarintApi(data, i, uint64(m.Scan.Size()))
-		n89, err := m.Scan.MarshalTo(data[i:])
+		n88, err := m.Scan.MarshalTo(data[i:])
 		if err != nil {
 			return 0, err
 		}
-		i += n89
+		i += n88
 	}
 	if m.EndTransaction != nil {
 		data[i] = 0x42
 		i++
 		i = encodeVarintApi(data, i, uint64(m.EndTransaction.Size()))
-		n90, err := m.EndTransaction.MarshalTo(data[i:])
+		n89, err := m.EndTransaction.MarshalTo(data[i:])
 		if err != nil {
 			return 0, err
 		}
-		i += n90
+		i += n89
 	}
 	if m.AdminSplit != nil {
 		data[i] = 0x4a
 		i++
 		i = encodeVarintApi(data, i, uint64(m.AdminSplit.Size()))
-		n91, err := m.AdminSplit.MarshalTo(data[i:])
+		n90, err := m.AdminSplit.MarshalTo(data[i:])
 		if err != nil {
 			return 0, err
 		}
-		i += n91
+		i += n90
 	}
 	if m.AdminMerge != nil {
 		data[i] = 0x52
 		i++
 		i = encodeVarintApi(data, i, uint64(m.AdminMerge.Size()))
-		n92, err := m.AdminMerge.MarshalTo(data[i:])
+		n91, err := m.AdminMerge.MarshalTo(data[i:])
 		if err != nil {
 			return 0, err
 		}
-		i += n92
+		i += n91
 	}
 	if m.HeartbeatTxn != nil {
 		data[i] = 0x5a
 		i++
 		i = encodeVarintApi(data, i, uint64(m.HeartbeatTxn.Size()))
-		n93, err := m.HeartbeatTxn.MarshalTo(data[i:])
+		n92, err := m.HeartbeatTxn.MarshalTo(data[i:])
 		if err != nil {
 			return 0, err
 		}
-		i += n93
+		i += n92
 	}
 	if m.Gc != nil {
 		data[i] = 0x62
 		i++
 		i = encodeVarintApi(data, i, uint64(m.Gc.Size()))
-		n94, err := m.Gc.MarshalTo(data[i:])
+		n93, err := m.Gc.MarshalTo(data[i:])
 		if err != nil {
 			return 0, err
 		}
-		i += n94
+		i += n93
 	}
 	if m.PushTxn != nil {
 		data[i] = 0x6a
 		i++
 		i = encodeVarintApi(data, i, uint64(m.PushTxn.Size()))
-		n95, err := m.PushTxn.MarshalTo(data[i:])
+		n94, err := m.PushTxn.MarshalTo(data[i:])
 		if err != nil {
 			return 0, err
 		}
-		i += n95
+		i += n94
 	}
 	if m.RangeLookup != nil {
 		data[i] = 0x72
 		i++
 		i = encodeVarintApi(data, i, uint64(m.RangeLookup.Size()))
-		n96, err := m.RangeLookup.MarshalTo(data[i:])
+		n95, err := m.RangeLookup.MarshalTo(data[i:])
 		if err != nil {
 			return 0, err
 		}
-		i += n96
+		i += n95
 	}
 	if m.ResolveIntent != nil {
 		data[i] = 0x7a
 		i++
 		i = encodeVarintApi(data, i, uint64(m.ResolveIntent.Size()))
-		n97, err := m.ResolveIntent.MarshalTo(data[i:])
+		n96, err := m.ResolveIntent.MarshalTo(data[i:])
 		if err != nil {
 			return 0, err
 		}
-		i += n97
+		i += n96
 	}
 	if m.ResolveIntentRange != nil {
 		data[i] = 0x82
@@ -3597,11 +3574,11 @@ func (m *ResponseUnion) MarshalTo(data []byte) (int, error) {
 		data[i] = 0x1
 		i++
 		i = encodeVarintApi(data, i, uint64(m.ResolveIntentRange.Size()))
-		n98, err := m.ResolveIntentRange.MarshalTo(data[i:])
+		n97, err := m.ResolveIntentRange.MarshalTo(data[i:])
 		if err != nil {
 			return 0, err
 		}
-		i += n98
+		i += n97
 	}
 	if m.Merge != nil {
 		data[i] = 0x8a
@@ -3609,11 +3586,11 @@ func (m *ResponseUnion) MarshalTo(data []byte) (int, error) {
 		data[i] = 0x1
 		i++
 		i = encodeVarintApi(data, i, uint64(m.Merge.Size()))
-		n99, err := m.Merge.MarshalTo(data[i:])
+		n98, err := m.Merge.MarshalTo(data[i:])
 		if err != nil {
 			return 0, err
 		}
-		i += n99
+		i += n98
 	}
 	if m.TruncateLog != nil {
 		data[i] = 0x92
@@ -3621,11 +3598,11 @@ func (m *ResponseUnion) MarshalTo(data []byte) (int, error) {
 		data[i] = 0x1
 		i++
 		i = encodeVarintApi(data, i, uint64(m.TruncateLog.Size()))
-		n100, err := m.TruncateLog.MarshalTo(data[i:])
+		n99, err := m.TruncateLog.MarshalTo(data[i:])
 		if err != nil {
 			return 0, err
 		}
-		i += n100
+		i += n99
 	}
 	if m.LeaderLease != nil {
 		data[i] = 0x9a
@@ -3633,11 +3610,11 @@ func (m *ResponseUnion) MarshalTo(data []byte) (int, error) {
 		data[i] = 0x1
 		i++
 		i = encodeVarintApi(data, i, uint64(m.LeaderLease.Size()))
-		n101, err := m.LeaderLease.MarshalTo(data[i:])
+		n100, err := m.LeaderLease.MarshalTo(data[i:])
 		if err != nil {
 			return 0, err
 		}
-		i += n101
+		i += n100
 	}
 	if m.ReverseScan != nil {
 		data[i] = 0xa2
@@ -3645,11 +3622,11 @@ func (m *ResponseUnion) MarshalTo(data []byte) (int, error) {
 		data[i] = 0x1
 		i++
 		i = encodeVarintApi(data, i, uint64(m.ReverseScan.Size()))
-		n102, err := m.ReverseScan.MarshalTo(data[i:])
+		n101, err := m.ReverseScan.MarshalTo(data[i:])
 		if err != nil {
 			return 0, err
 		}
-		i += n102
+		i += n101
 	}
 	if m.Noop != nil {
 		data[i] = 0xaa
@@ -3657,11 +3634,11 @@ func (m *ResponseUnion) MarshalTo(data []byte) (int, error) {
 		data[i] = 0x1
 		i++
 		i = encodeVarintApi(data, i, uint64(m.Noop.Size()))
-		n103, err := m.Noop.MarshalTo(data[i:])
+		n102, err := m.Noop.MarshalTo(data[i:])
 		if err != nil {
 			return 0, err
 		}
-		i += n103
+		i += n102
 	}
 	return i, nil
 }
@@ -3684,11 +3661,11 @@ func (m *BatchRequest) MarshalTo(data []byte) (int, error) {
 	data[i] = 0xa
 	i++
 	i = encodeVarintApi(data, i, uint64(m.BatchRequest_Header.Size()))
-	n104, err := m.BatchRequest_Header.MarshalTo(data[i:])
+	n103, err := m.BatchRequest_Header.MarshalTo(data[i:])
 	if err != nil {
 		return 0, err
 	}
-	i += n104
+	i += n103
 	if len(m.Requests) > 0 {
 		for _, msg := range m.Requests {
 			data[i] = 0x12
@@ -3722,27 +3699,27 @@ func (m *BatchRequest_Header) MarshalTo(data []byte) (int, error) {
 	data[i] = 0xa
 	i++
 	i = encodeVarintApi(data, i, uint64(m.Timestamp.Size()))
-	n105, err := m.Timestamp.MarshalTo(data[i:])
+	n104, err := m.Timestamp.MarshalTo(data[i:])
+	if err != nil {
+		return 0, err
+	}
+	i += n104
+	data[i] = 0x12
+	i++
+	i = encodeVarintApi(data, i, uint64(m.CmdID.Size()))
+	n105, err := m.CmdID.MarshalTo(data[i:])
 	if err != nil {
 		return 0, err
 	}
 	i += n105
-	data[i] = 0x12
+	data[i] = 0x2a
 	i++
-	i = encodeVarintApi(data, i, uint64(m.CmdID.Size()))
-	n106, err := m.CmdID.MarshalTo(data[i:])
+	i = encodeVarintApi(data, i, uint64(m.Replica.Size()))
+	n106, err := m.Replica.MarshalTo(data[i:])
 	if err != nil {
 		return 0, err
 	}
 	i += n106
-	data[i] = 0x2a
-	i++
-	i = encodeVarintApi(data, i, uint64(m.Replica.Size()))
-	n107, err := m.Replica.MarshalTo(data[i:])
-	if err != nil {
-		return 0, err
-	}
-	i += n107
 	data[i] = 0x30
 	i++
 	i = encodeVarintApi(data, i, uint64(m.RangeID))
@@ -3755,11 +3732,11 @@ func (m *BatchRequest_Header) MarshalTo(data []byte) (int, error) {
 		data[i] = 0x42
 		i++
 		i = encodeVarintApi(data, i, uint64(m.Txn.Size()))
-		n108, err := m.Txn.MarshalTo(data[i:])
+		n107, err := m.Txn.MarshalTo(data[i:])
 		if err != nil {
 			return 0, err
 		}
-		i += n108
+		i += n107
 	}
 	data[i] = 0x48
 	i++
@@ -3785,11 +3762,11 @@ func (m *BatchResponse) MarshalTo(data []byte) (int, error) {
 	data[i] = 0xa
 	i++
 	i = encodeVarintApi(data, i, uint64(m.BatchResponse_Header.Size()))
-	n109, err := m.BatchResponse_Header.MarshalTo(data[i:])
+	n108, err := m.BatchResponse_Header.MarshalTo(data[i:])
 	if err != nil {
 		return 0, err
 	}
-	i += n109
+	i += n108
 	if len(m.Responses) > 0 {
 		for _, msg := range m.Responses {
 			data[i] = 0x12
@@ -3824,29 +3801,29 @@ func (m *BatchResponse_Header) MarshalTo(data []byte) (int, error) {
 		data[i] = 0xa
 		i++
 		i = encodeVarintApi(data, i, uint64(m.Error.Size()))
-		n110, err := m.Error.MarshalTo(data[i:])
+		n109, err := m.Error.MarshalTo(data[i:])
 		if err != nil {
 			return 0, err
 		}
-		i += n110
+		i += n109
 	}
 	data[i] = 0x12
 	i++
 	i = encodeVarintApi(data, i, uint64(m.Timestamp.Size()))
-	n111, err := m.Timestamp.MarshalTo(data[i:])
+	n110, err := m.Timestamp.MarshalTo(data[i:])
 	if err != nil {
 		return 0, err
 	}
-	i += n111
+	i += n110
 	if m.Txn != nil {
 		data[i] = 0x1a
 		i++
 		i = encodeVarintApi(data, i, uint64(m.Txn.Size()))
-		n112, err := m.Txn.MarshalTo(data[i:])
+		n111, err := m.Txn.MarshalTo(data[i:])
 		if err != nil {
 			return 0, err
 		}
-		i += n112
+		i += n111
 	}
 	return i, nil
 }
@@ -3895,10 +3872,6 @@ func (m *RequestHeader) Size() (n int) {
 	}
 	if m.EndKey != nil {
 		l = len(m.EndKey)
-		n += 1 + l + sovApi(uint64(l))
-	}
-	if m.Txn != nil {
-		l = m.Txn.Size()
 		n += 1 + l + sovApi(uint64(l))
 	}
 	return n
@@ -5017,39 +4990,6 @@ func (m *RequestHeader) Unmarshal(data []byte) error {
 				return io.ErrUnexpectedEOF
 			}
 			m.EndKey = append([]byte{}, data[iNdEx:postIndex]...)
-			iNdEx = postIndex
-		case 8:
-			if wireType != 2 {
-				return fmt.Errorf("proto: wrong wireType = %d for field Txn", wireType)
-			}
-			var msglen int
-			for shift := uint(0); ; shift += 7 {
-				if shift >= 64 {
-					return ErrIntOverflowApi
-				}
-				if iNdEx >= l {
-					return io.ErrUnexpectedEOF
-				}
-				b := data[iNdEx]
-				iNdEx++
-				msglen |= (int(b) & 0x7F) << shift
-				if b < 0x80 {
-					break
-				}
-			}
-			if msglen < 0 {
-				return ErrInvalidLengthApi
-			}
-			postIndex := iNdEx + msglen
-			if postIndex > l {
-				return io.ErrUnexpectedEOF
-			}
-			if m.Txn == nil {
-				m.Txn = &Transaction{}
-			}
-			if err := m.Txn.Unmarshal(data[iNdEx:postIndex]); err != nil {
-				return err
-			}
 			iNdEx = postIndex
 		default:
 			iNdEx = preIndex

--- a/roachpb/api.pb.go
+++ b/roachpb/api.pb.go
@@ -264,10 +264,6 @@ type RequestHeader struct {
 	// that the operation takes place on the key range from Key to EndKey,
 	// including Key and excluding EndKey.
 	EndKey Key `protobuf:"bytes,4,opt,name=end_key,casttype=Key" json:"end_key,omitempty"`
-	// RangeID specifies the ID of the Raft consensus group which the key
-	// range belongs to. This is used by the receiving node to route the
-	// request to the correct range.
-	RangeID RangeID `protobuf:"varint,6,opt,name=range_id,casttype=RangeID" json:"range_id"`
 	// UserPriority specifies priority multiple for non-transactional
 	// commands. This value should be a positive integer [1, 2^31-1).
 	// It's properly viewed as a multiple for how likely this
@@ -315,13 +311,6 @@ func (m *RequestHeader) GetEndKey() Key {
 		return m.EndKey
 	}
 	return nil
-}
-
-func (m *RequestHeader) GetRangeID() RangeID {
-	if m != nil {
-		return m.RangeID
-	}
-	return 0
 }
 
 func (m *RequestHeader) GetUserPriority() int32 {
@@ -1816,9 +1805,6 @@ func (m *RequestHeader) MarshalTo(data []byte) (int, error) {
 		i = encodeVarintApi(data, i, uint64(len(m.EndKey)))
 		i += copy(data[i:], m.EndKey)
 	}
-	data[i] = 0x30
-	i++
-	i = encodeVarintApi(data, i, uint64(m.RangeID))
 	if m.UserPriority != nil {
 		data[i] = 0x38
 		i++
@@ -3969,7 +3955,6 @@ func (m *RequestHeader) Size() (n int) {
 		l = len(m.EndKey)
 		n += 1 + l + sovApi(uint64(l))
 	}
-	n += 1 + sovApi(uint64(m.RangeID))
 	if m.UserPriority != nil {
 		n += 1 + sovApi(uint64(*m.UserPriority))
 	}
@@ -5125,25 +5110,6 @@ func (m *RequestHeader) Unmarshal(data []byte) error {
 			}
 			m.EndKey = append([]byte{}, data[iNdEx:postIndex]...)
 			iNdEx = postIndex
-		case 6:
-			if wireType != 0 {
-				return fmt.Errorf("proto: wrong wireType = %d for field RangeID", wireType)
-			}
-			m.RangeID = 0
-			for shift := uint(0); ; shift += 7 {
-				if shift >= 64 {
-					return ErrIntOverflowApi
-				}
-				if iNdEx >= l {
-					return io.ErrUnexpectedEOF
-				}
-				b := data[iNdEx]
-				iNdEx++
-				m.RangeID |= (RangeID(b) & 0x7F) << shift
-				if b < 0x80 {
-					break
-				}
-			}
 		case 7:
 			if wireType != 0 {
 				return fmt.Errorf("proto: wrong wireType = %d for field UserPriority", wireType)

--- a/roachpb/api.pb.go
+++ b/roachpb/api.pb.go
@@ -1618,17 +1618,7 @@ type BatchRequest_Header struct {
 	Timestamp Timestamp `protobuf:"bytes,1,opt,name=timestamp" json:"timestamp"`
 	// CmdID is optionally specified for request idempotence
 	// (i.e. replay protection).
-	CmdID ClientCmdID `protobuf:"bytes,2,opt,name=cmd_id" json:"cmd_id"`
-	// The key for request. If the request operates on a range, this
-	// represents the starting key for the range.
-	Key Key `protobuf:"bytes,3,opt,name=key,casttype=Key" json:"key,omitempty"`
-	// The end key is empty if the request spans only a single key. Otherwise,
-	// it must order strictly after Key. In such a case, the header indicates
-	// that the operation takes place on the key range from Key to EndKey,
-	// including Key and excluding EndKey.
-	EndKey Key `protobuf:"bytes,4,opt,name=end_key,casttype=Key" json:"end_key,omitempty"`
-	// Replica specifies the destination for the request. This is a specific
-	// instance of the available replicas belonging to RangeID.
+	CmdID   ClientCmdID       `protobuf:"bytes,2,opt,name=cmd_id" json:"cmd_id"`
 	Replica ReplicaDescriptor `protobuf:"bytes,5,opt,name=replica" json:"replica"`
 	// RangeID specifies the ID of the Raft consensus group which the key
 	// range belongs to. This is used by the receiving node to route the
@@ -1674,20 +1664,6 @@ func (m *BatchRequest_Header) GetCmdID() ClientCmdID {
 		return m.CmdID
 	}
 	return ClientCmdID{}
-}
-
-func (m *BatchRequest_Header) GetKey() Key {
-	if m != nil {
-		return m.Key
-	}
-	return nil
-}
-
-func (m *BatchRequest_Header) GetEndKey() Key {
-	if m != nil {
-		return m.EndKey
-	}
-	return nil
 }
 
 func (m *BatchRequest_Header) GetReplica() ReplicaDescriptor {
@@ -3847,18 +3823,6 @@ func (m *BatchRequest_Header) MarshalTo(data []byte) (int, error) {
 		return 0, err
 	}
 	i += n108
-	if m.Key != nil {
-		data[i] = 0x1a
-		i++
-		i = encodeVarintApi(data, i, uint64(len(m.Key)))
-		i += copy(data[i:], m.Key)
-	}
-	if m.EndKey != nil {
-		data[i] = 0x22
-		i++
-		i = encodeVarintApi(data, i, uint64(len(m.EndKey)))
-		i += copy(data[i:], m.EndKey)
-	}
 	data[i] = 0x2a
 	i++
 	i = encodeVarintApi(data, i, uint64(m.Replica.Size()))
@@ -4689,14 +4653,6 @@ func (m *BatchRequest_Header) Size() (n int) {
 	n += 1 + l + sovApi(uint64(l))
 	l = m.CmdID.Size()
 	n += 1 + l + sovApi(uint64(l))
-	if m.Key != nil {
-		l = len(m.Key)
-		n += 1 + l + sovApi(uint64(l))
-	}
-	if m.EndKey != nil {
-		l = len(m.EndKey)
-		n += 1 + l + sovApi(uint64(l))
-	}
 	l = m.Replica.Size()
 	n += 1 + l + sovApi(uint64(l))
 	n += 1 + sovApi(uint64(m.RangeID))
@@ -11521,62 +11477,6 @@ func (m *BatchRequest_Header) Unmarshal(data []byte) error {
 			if err := m.CmdID.Unmarshal(data[iNdEx:postIndex]); err != nil {
 				return err
 			}
-			iNdEx = postIndex
-		case 3:
-			if wireType != 2 {
-				return fmt.Errorf("proto: wrong wireType = %d for field Key", wireType)
-			}
-			var byteLen int
-			for shift := uint(0); ; shift += 7 {
-				if shift >= 64 {
-					return ErrIntOverflowApi
-				}
-				if iNdEx >= l {
-					return io.ErrUnexpectedEOF
-				}
-				b := data[iNdEx]
-				iNdEx++
-				byteLen |= (int(b) & 0x7F) << shift
-				if b < 0x80 {
-					break
-				}
-			}
-			if byteLen < 0 {
-				return ErrInvalidLengthApi
-			}
-			postIndex := iNdEx + byteLen
-			if postIndex > l {
-				return io.ErrUnexpectedEOF
-			}
-			m.Key = append([]byte{}, data[iNdEx:postIndex]...)
-			iNdEx = postIndex
-		case 4:
-			if wireType != 2 {
-				return fmt.Errorf("proto: wrong wireType = %d for field EndKey", wireType)
-			}
-			var byteLen int
-			for shift := uint(0); ; shift += 7 {
-				if shift >= 64 {
-					return ErrIntOverflowApi
-				}
-				if iNdEx >= l {
-					return io.ErrUnexpectedEOF
-				}
-				b := data[iNdEx]
-				iNdEx++
-				byteLen |= (int(b) & 0x7F) << shift
-				if b < 0x80 {
-					break
-				}
-			}
-			if byteLen < 0 {
-				return ErrInvalidLengthApi
-			}
-			postIndex := iNdEx + byteLen
-			if postIndex > l {
-				return io.ErrUnexpectedEOF
-			}
-			m.EndKey = append([]byte{}, data[iNdEx:postIndex]...)
 			iNdEx = postIndex
 		case 5:
 			if wireType != 2 {

--- a/roachpb/api.proto
+++ b/roachpb/api.proto
@@ -81,9 +81,6 @@ message RequestHeader {
   // that the operation takes place on the key range from Key to EndKey,
   // including Key and excluding EndKey.
   optional bytes end_key = 4 [(gogoproto.casttype) = "Key"];
-  // Replica specifies the destination for the request. This is a specific
-  // instance of the available replicas belonging to RangeID.
-  optional ReplicaDescriptor replica = 5 [(gogoproto.nullable) = false];
   // RangeID specifies the ID of the Raft consensus group which the key
   // range belongs to. This is used by the receiving node to route the
   // request to the correct range.

--- a/roachpb/api.proto
+++ b/roachpb/api.proto
@@ -94,10 +94,6 @@ message RequestHeader {
   // fully-initialized transaction with txn ID, priority, initial
   // timestamp, and maximum timestamp.
   optional Transaction txn = 8;
-  // ReadConsistency specifies the consistency for read
-  // operations. The default is CONSISTENT. This value is ignored for
-  // write operations.
-  optional ReadConsistencyType read_consistency = 9 [(gogoproto.nullable) = false];
 }
 
 // ResponseHeader is returned with every storage node response.

--- a/roachpb/api.proto
+++ b/roachpb/api.proto
@@ -81,11 +81,6 @@ message RequestHeader {
   // that the operation takes place on the key range from Key to EndKey,
   // including Key and excluding EndKey.
   optional bytes end_key = 4 [(gogoproto.casttype) = "Key"];
-  // RangeID specifies the ID of the Raft consensus group which the key
-  // range belongs to. This is used by the receiving node to route the
-  // request to the correct range.
-  optional int64 range_id = 6 [(gogoproto.nullable) = false,
-      (gogoproto.customname) = "RangeID", (gogoproto.casttype) = "RangeID"];
   // UserPriority specifies priority multiple for non-transactional
   // commands. This value should be a positive integer [1, 2^31-1).
   // It's properly viewed as a multiple for how likely this

--- a/roachpb/api.proto
+++ b/roachpb/api.proto
@@ -78,12 +78,6 @@ message RequestHeader {
   // that the operation takes place on the key range from Key to EndKey,
   // including Key and excluding EndKey.
   optional bytes end_key = 4 [(gogoproto.casttype) = "Key"];
-  // Txn is set non-nil if a transaction is underway. To start a txn,
-  // the first request should set this field to non-nil with name and
-  // isolation level set as desired. The response will contain the
-  // fully-initialized transaction with txn ID, priority, initial
-  // timestamp, and maximum timestamp.
-  optional Transaction txn = 8;
 }
 
 // ResponseHeader is returned with every storage node response.

--- a/roachpb/api.proto
+++ b/roachpb/api.proto
@@ -78,16 +78,6 @@ message RequestHeader {
   // that the operation takes place on the key range from Key to EndKey,
   // including Key and excluding EndKey.
   optional bytes end_key = 4 [(gogoproto.casttype) = "Key"];
-  // UserPriority specifies priority multiple for non-transactional
-  // commands. This value should be a positive integer [1, 2^31-1).
-  // It's properly viewed as a multiple for how likely this
-  // transaction will be to prevail if a write conflict occurs.
-  // Commands with UserPriority=100 will be 100x less likely to be
-  // aborted as conflicting transactions or non-transactional commands
-  // with UserPriority=1. This value is ignored if Txn is
-  // specified. If neither this value nor Txn is specified, the value
-  // defaults to 1.
-  optional int32 user_priority = 7 [default = 1];
   // Txn is set non-nil if a transaction is underway. To start a txn,
   // the first request should set this field to non-nil with name and
   // isolation level set as desired. The response will contain the

--- a/roachpb/api.proto
+++ b/roachpb/api.proto
@@ -628,16 +628,6 @@ message BatchRequest {
     // CmdID is optionally specified for request idempotence
     // (i.e. replay protection).
     optional ClientCmdID cmd_id = 2 [(gogoproto.nullable) = false, (gogoproto.customname) = "CmdID"];
-    // The key for request. If the request operates on a range, this
-    // represents the starting key for the range.
-    optional bytes key = 3 [(gogoproto.casttype) = "Key"];
-    // The end key is empty if the request spans only a single key. Otherwise,
-    // it must order strictly after Key. In such a case, the header indicates
-    // that the operation takes place on the key range from Key to EndKey,
-    // including Key and excluding EndKey.
-    optional bytes end_key = 4 [(gogoproto.casttype) = "Key"];
-    // Replica specifies the destination for the request. This is a specific
-    // instance of the available replicas belonging to RangeID.
     optional ReplicaDescriptor replica = 5 [(gogoproto.nullable) = false];
     // RangeID specifies the ID of the Raft consensus group which the key
     // range belongs to. This is used by the receiving node to route the

--- a/roachpb/api.proto
+++ b/roachpb/api.proto
@@ -70,9 +70,6 @@ enum ReadConsistencyType {
 
 // RequestHeader is supplied with every storage node request.
 message RequestHeader {
-  // CmdID is optionally specified for request idempotence
-  // (i.e. replay protection).
-  optional ClientCmdID cmd_id = 2 [(gogoproto.nullable) = false, (gogoproto.customname) = "CmdID"];
   // The key for request. If the request operates on a range, this
   // represents the starting key for the range.
   optional bytes key = 3 [(gogoproto.casttype) = "Key"];

--- a/roachpb/api_test.go
+++ b/roachpb/api_test.go
@@ -172,55 +172,6 @@ func TestSetGoErrorCopy(t *testing.T) {
 	}
 }
 
-func TestBatchKeyRange(t *testing.T) {
-	verify := func(br *BatchRequest, start, end Key) {
-		if !br.Key.Equal(start) {
-			t.Errorf("expected batch start key %s; got %s", start, br.Key)
-		}
-		if !br.EndKey.Equal(end) {
-			t.Errorf("expected batch end key %s; got %s", end, br.EndKey)
-		}
-	}
-
-	br := &BatchRequest{}
-	br.Add(&GetRequest{
-		RequestHeader: RequestHeader{
-			Key: Key("a"),
-		},
-	})
-	verify(br, Key("a"), nil)
-	// Add "a" again; shouldn't set end key.
-	br.Add(&GetRequest{
-		RequestHeader: RequestHeader{
-			Key: Key("a"),
-		},
-	})
-	verify(br, Key("a"), nil)
-
-	br.Add(&GetRequest{
-		RequestHeader: RequestHeader{
-			Key: Key("b"),
-		},
-	})
-	verify(br, Key("a"), Key("b"))
-
-	br.Add(&ScanRequest{
-		RequestHeader: RequestHeader{
-			Key:    Key("c"),
-			EndKey: Key("d"),
-		},
-	})
-	verify(br, Key("a"), Key("d"))
-
-	br.Add(&ScanRequest{
-		RequestHeader: RequestHeader{
-			Key:    Key("A"),
-			EndKey: Key("d1"),
-		},
-	})
-	verify(br, Key("A"), Key("d1"))
-}
-
 func TestBatchSplit(t *testing.T) {
 	get := &GetRequest{}
 	scan := &ScanRequest{}

--- a/roachpb/batch.go
+++ b/roachpb/batch.go
@@ -139,23 +139,12 @@ func (br *BatchResponse) Combine(otherBatch *BatchResponse) error {
 	return nil
 }
 
-// Add adds a request to the batch request. The batch key range is
-// expanded to include the key ranges of all requests which it comprises.
+// Add adds a request to the batch request.
 func (ba *BatchRequest) Add(requests ...Request) {
 	for _, args := range requests {
 		union := RequestUnion{}
 		if !union.SetValue(args) {
 			panic(fmt.Sprintf("unable to add %T to batch request", args))
-		}
-
-		h := args.Header()
-		if ba.Key == nil || !ba.Key.Less(h.Key) {
-			ba.Key = h.Key
-		} else if ba.EndKey.Less(h.Key) && !ba.Key.Equal(h.Key) {
-			ba.EndKey = h.Key
-		}
-		if ba.EndKey == nil || (h.EndKey != nil && ba.EndKey.Less(h.EndKey)) {
-			ba.EndKey = h.EndKey
 		}
 		ba.Requests = append(ba.Requests, union)
 	}
@@ -300,7 +289,6 @@ func (*BatchRequest) GetUser() string {
 // TODO(tschottdorf): provisional code.
 func (ba *BatchRequest) ToHeader() RequestHeader {
 	var h RequestHeader
-	h.Key, h.EndKey = ba.Key, ba.EndKey
 	h.CmdID = ba.CmdID
 	h.Replica = ba.Replica
 	h.RangeID = ba.RangeID

--- a/roachpb/batch.go
+++ b/roachpb/batch.go
@@ -289,7 +289,6 @@ func (*BatchRequest) GetUser() string {
 // TODO(tschottdorf): provisional code.
 func (ba *BatchRequest) ToHeader() RequestHeader {
 	var h RequestHeader
-	h.UserPriority = ba.UserPriority
 	h.Txn = ba.Txn
 	return h
 }

--- a/roachpb/batch.go
+++ b/roachpb/batch.go
@@ -291,7 +291,6 @@ func (ba *BatchRequest) ToHeader() RequestHeader {
 	var h RequestHeader
 	h.UserPriority = ba.UserPriority
 	h.Txn = ba.Txn
-	h.ReadConsistency = ba.ReadConsistency
 	return h
 }
 

--- a/roachpb/batch.go
+++ b/roachpb/batch.go
@@ -289,7 +289,6 @@ func (*BatchRequest) GetUser() string {
 // TODO(tschottdorf): provisional code.
 func (ba *BatchRequest) ToHeader() RequestHeader {
 	var h RequestHeader
-	h.CmdID = ba.CmdID
 	h.UserPriority = ba.UserPriority
 	h.Txn = ba.Txn
 	h.ReadConsistency = ba.ReadConsistency

--- a/roachpb/batch.go
+++ b/roachpb/batch.go
@@ -290,7 +290,6 @@ func (*BatchRequest) GetUser() string {
 func (ba *BatchRequest) ToHeader() RequestHeader {
 	var h RequestHeader
 	h.CmdID = ba.CmdID
-	h.Replica = ba.Replica
 	h.RangeID = ba.RangeID
 	h.UserPriority = ba.UserPriority
 	h.Txn = ba.Txn

--- a/roachpb/batch.go
+++ b/roachpb/batch.go
@@ -290,7 +290,6 @@ func (*BatchRequest) GetUser() string {
 func (ba *BatchRequest) ToHeader() RequestHeader {
 	var h RequestHeader
 	h.CmdID = ba.CmdID
-	h.RangeID = ba.RangeID
 	h.UserPriority = ba.UserPriority
 	h.Txn = ba.Txn
 	h.ReadConsistency = ba.ReadConsistency

--- a/roachpb/batch.go
+++ b/roachpb/batch.go
@@ -285,14 +285,6 @@ func (*BatchRequest) GetUser() string {
 	return "node"
 }
 
-// ToHeader creates a RequestHeader from the batch's header.
-// TODO(tschottdorf): provisional code.
-func (ba *BatchRequest) ToHeader() RequestHeader {
-	var h RequestHeader
-	h.Txn = ba.Txn
-	return h
-}
-
 // GoError returns the non-nil error from the proto.Error union.
 func (br *BatchResponse) GoError() error {
 	return br.Error.GoError()

--- a/server/intent_test.go
+++ b/server/intent_test.go
@@ -74,7 +74,7 @@ func TestIntentResolution(t *testing.T) {
 		var result []string
 		var mu sync.Mutex
 		closer := make(chan struct{}, 2)
-		storage.TestingCommandFilter = func(args roachpb.Request) error {
+		storage.TestingCommandFilter = func(args roachpb.Request, _ roachpb.BatchRequest_Header) error {
 			mu.Lock()
 			defer mu.Unlock()
 			header := args.Header()

--- a/server/server_test.go
+++ b/server/server_test.go
@@ -359,8 +359,8 @@ func TestMultiRangeScanDeleteRange(t *testing.T) {
 	}
 
 	scan := roachpb.NewScan(writes[0], writes[len(writes)-1].Next(), 0).(*roachpb.ScanRequest)
-	scan.Txn = &roachpb.Transaction{Name: "MyTxn"}
-	reply, err = client.SendWrappedWith(tds, nil, roachpb.BatchRequest_Header{Timestamp: dr.Timestamp}, scan)
+	txn := &roachpb.Transaction{Name: "MyTxn"}
+	reply, err = client.SendWrappedWith(tds, nil, roachpb.BatchRequest_Header{Txn: txn}, scan)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/server/server_test.go
+++ b/server/server_test.go
@@ -324,7 +324,7 @@ func TestMultiRangeScanDeleteRange(t *testing.T) {
 		// The Put ts may have been pushed by tsCache,
 		// so make sure we see their values in our Scan.
 		delTS = reply.(*roachpb.PutResponse).Timestamp
-		reply, err = client.SendWrappedAt(tds, nil, delTS, scan)
+		reply, err = client.SendWrappedWith(tds, nil, roachpb.BatchRequest_Header{Timestamp: delTS}, scan)
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -345,7 +345,7 @@ func TestMultiRangeScanDeleteRange(t *testing.T) {
 			EndKey: roachpb.Key(writes[len(writes)-1]).Next(),
 		},
 	}
-	reply, err := client.SendWrappedAt(tds, nil, delTS, del)
+	reply, err := client.SendWrappedWith(tds, nil, roachpb.BatchRequest_Header{Timestamp: delTS}, del)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -360,7 +360,7 @@ func TestMultiRangeScanDeleteRange(t *testing.T) {
 
 	scan := roachpb.NewScan(writes[0], writes[len(writes)-1].Next(), 0).(*roachpb.ScanRequest)
 	scan.Txn = &roachpb.Transaction{Name: "MyTxn"}
-	reply, err = client.SendWrappedAt(tds, nil, dr.Timestamp, scan)
+	reply, err = client.SendWrappedWith(tds, nil, roachpb.BatchRequest_Header{Timestamp: dr.Timestamp}, scan)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/sql/main_test.go
+++ b/sql/main_test.go
@@ -45,7 +45,7 @@ func TestMain(m *testing.M) {
 
 // checkEndTransactionTrigger verifies that an EndTransactionRequest
 // that includes intents for the SystemDB keys sets the proper trigger.
-func checkEndTransactionTrigger(req roachpb.Request) error {
+func checkEndTransactionTrigger(req roachpb.Request, _ roachpb.BatchRequest_Header) error {
 	args, ok := req.(*roachpb.EndTransactionRequest)
 	if !ok {
 		return nil

--- a/storage/client_merge_test.go
+++ b/storage/client_merge_test.go
@@ -43,7 +43,7 @@ func adminMergeArgs(key []byte) roachpb.AdminMergeRequest {
 }
 
 func createSplitRanges(store *storage.Store) (*roachpb.RangeDescriptor, *roachpb.RangeDescriptor, error) {
-	args := adminSplitArgs(roachpb.KeyMin, []byte("b"), 1, store.StoreID())
+	args := adminSplitArgs(roachpb.KeyMin, []byte("b"))
 	if _, err := client.SendWrapped(rg1(store), nil, &args); err != nil {
 		return nil, nil, err
 	}
@@ -298,11 +298,11 @@ func TestStoreRangeMergeNonCollocated(t *testing.T) {
 	store := mtc.stores[0]
 
 	// Split into 3 ranges
-	argsSplit := adminSplitArgs(roachpb.KeyMin, []byte("d"), 1, store.StoreID())
+	argsSplit := adminSplitArgs(roachpb.KeyMin, []byte("d"))
 	if _, err := client.SendWrapped(rg1(store), nil, &argsSplit); err != nil {
 		t.Fatalf("Can't split range %s", err)
 	}
-	argsSplit = adminSplitArgs(roachpb.KeyMin, []byte("b"), 1, store.StoreID())
+	argsSplit = adminSplitArgs(roachpb.KeyMin, []byte("b"))
 	if _, err := client.SendWrapped(rg1(store), nil, &argsSplit); err != nil {
 		t.Fatalf("Can't split range %s", err)
 	}

--- a/storage/client_raft_test.go
+++ b/storage/client_raft_test.go
@@ -75,8 +75,10 @@ func TestStoreRecoverFromEngine(t *testing.T) {
 	var rangeID2 roachpb.RangeID
 
 	get := func(store *storage.Store, rangeID roachpb.RangeID, key roachpb.Key) int64 {
-		args := getArgs(key, rangeID, store.StoreID())
-		resp, err := client.SendWrapped(store, nil, &args)
+		args := getArgs(key)
+		resp, err := client.SendWrappedWith(store.TestSender(), nil, roachpb.BatchRequest_Header{
+			RangeID: rangeID,
+		}, &args)
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -99,9 +101,12 @@ func TestStoreRecoverFromEngine(t *testing.T) {
 		store := createTestStoreWithEngine(t, eng, clock, true, nil, stopper)
 
 		increment := func(rangeID roachpb.RangeID, key roachpb.Key, value int64) (*roachpb.IncrementResponse, error) {
-			args := incrementArgs(key, value, rangeID, store.StoreID())
-			resp, err := client.SendWrapped(store, nil, &args)
-			return resp.(*roachpb.IncrementResponse), err
+			args := incrementArgs(key, value)
+			resp, err := client.SendWrappedWith(store.TestSender(), nil, roachpb.BatchRequest_Header{
+				RangeID: rangeID,
+			}, &args)
+			incResp, _ := resp.(*roachpb.IncrementResponse)
+			return incResp, err
 		}
 
 		if _, err := increment(rangeID, key1, 2); err != nil {
@@ -111,7 +116,7 @@ func TestStoreRecoverFromEngine(t *testing.T) {
 			t.Fatal(err)
 		}
 		splitArgs := adminSplitArgs(roachpb.KeyMin, splitKey, rangeID, store.StoreID())
-		if _, err := client.SendWrapped(store, nil, &splitArgs); err != nil {
+		if _, err := client.SendWrapped(store.TestSender(), nil, &splitArgs); err != nil {
 			t.Fatal(err)
 		}
 		rangeID2 = store.LookupReplica(key2, nil).Desc().RangeID
@@ -134,12 +139,14 @@ func TestStoreRecoverFromEngine(t *testing.T) {
 
 	// Raft processing is initialized lazily; issue a no-op write request on each key to
 	// ensure that is has been started.
-	incArgs := incrementArgs(key1, 0, rangeID, store.StoreID())
-	if _, err := client.SendWrapped(store, nil, &incArgs); err != nil {
+	incArgs := incrementArgs(key1, 0)
+	if _, err := client.SendWrapped(store.TestSender(), nil, &incArgs); err != nil {
 		t.Fatal(err)
 	}
-	incArgs = incrementArgs(key2, 0, rangeID2, store.StoreID())
-	if _, err := client.SendWrapped(store, nil, &incArgs); err != nil {
+	incArgs = incrementArgs(key2, 0)
+	if _, err := client.SendWrappedWith(store.TestSender(), nil, roachpb.BatchRequest_Header{
+		RangeID: rangeID2,
+	}, &incArgs); err != nil {
 		t.Fatal(err)
 	}
 
@@ -172,15 +179,15 @@ func TestStoreRecoverWithErrors(t *testing.T) {
 		store := createTestStoreWithEngine(t, eng, clock, true, nil, stopper)
 
 		// Write a bytes value so the increment will fail.
-		putArgs := putArgs(roachpb.Key("a"), []byte("asdf"), 1, store.StoreID())
-		if _, err := client.SendWrapped(store, nil, &putArgs); err != nil {
+		putArgs := putArgs(roachpb.Key("a"), []byte("asdf"))
+		if _, err := client.SendWrapped(store.TestSender(), nil, &putArgs); err != nil {
 			t.Fatal(err)
 		}
 
 		// Try and fail to increment the key. It is important for this test that the
 		// failure be the last thing in the raft log when the store is stopped.
-		incArgs := incrementArgs(roachpb.Key("a"), 42, 1, store.StoreID())
-		if _, err := client.SendWrapped(store, nil, &incArgs); err == nil {
+		incArgs := incrementArgs(roachpb.Key("a"), 42)
+		if _, err := client.SendWrapped(store.TestSender(), nil, &incArgs); err == nil {
 			t.Fatal("did not get expected error")
 		}
 	}()
@@ -193,8 +200,8 @@ func TestStoreRecoverWithErrors(t *testing.T) {
 	store := createTestStoreWithEngine(t, eng, clock, false, nil, engineStopper)
 
 	// Issue a no-op write to lazily initialize raft on the range.
-	incArgs := incrementArgs(roachpb.Key("b"), 0, 1, store.StoreID())
-	if _, err := client.SendWrapped(store, nil, &incArgs); err != nil {
+	incArgs := incrementArgs(roachpb.Key("b"), 0)
+	if _, err := client.SendWrapped(store.TestSender(), nil, &incArgs); err != nil {
 		t.Fatal(err)
 	}
 
@@ -212,8 +219,8 @@ func TestReplicateRange(t *testing.T) {
 	defer mtc.Stop()
 
 	// Issue a command on the first node before replicating.
-	incArgs := incrementArgs([]byte("a"), 5, 1, mtc.stores[0].StoreID())
-	if _, err := client.SendWrapped(mtc.stores[0], nil, &incArgs); err != nil {
+	incArgs := incrementArgs([]byte("a"), 5)
+	if _, err := client.SendWrapped(mtc.stores[0].TestSender(), nil, &incArgs); err != nil {
 		t.Fatal(err)
 	}
 
@@ -254,9 +261,9 @@ func TestReplicateRange(t *testing.T) {
 
 	// Verify that the same data is available on the replica.
 	util.SucceedsWithin(t, 1*time.Second, func() error {
-		getArgs := getArgs([]byte("a"), 1, mtc.stores[1].StoreID())
+		getArgs := getArgs([]byte("a"))
 		getArgs.ReadConsistency = roachpb.INCONSISTENT
-		if reply, err := client.SendWrapped(mtc.stores[1], nil, &getArgs); err != nil {
+		if reply, err := client.SendWrapped(mtc.stores[1].TestSender(), nil, &getArgs); err != nil {
 			return util.Errorf("failed to read data")
 		} else if v := mustGetInt(reply.(*roachpb.GetResponse).Value); v != 5 {
 			return util.Errorf("failed to read correct data: %d", v)
@@ -279,8 +286,8 @@ func TestRestoreReplicas(t *testing.T) {
 
 	// Perform an increment before replication to ensure that commands are not
 	// repeated on restarts.
-	incArgs := incrementArgs([]byte("a"), 23, 1, mtc.stores[0].StoreID())
-	if _, err := client.SendWrapped(mtc.stores[0], nil, &incArgs); err != nil {
+	incArgs := incrementArgs([]byte("a"), 23)
+	if _, err := client.SendWrapped(mtc.stores[0].TestSender(), nil, &incArgs); err != nil {
 		t.Fatal(err)
 	}
 
@@ -306,28 +313,28 @@ func TestRestoreReplicas(t *testing.T) {
 
 	// Send a command on each store. The original store (the leader still)
 	// will succeed.
-	incArgs = incrementArgs([]byte("a"), 5, 1, mtc.stores[0].StoreID())
-	if _, err := client.SendWrapped(mtc.stores[0], nil, &incArgs); err != nil {
+	incArgs = incrementArgs([]byte("a"), 5)
+	if _, err := client.SendWrapped(mtc.stores[0].TestSender(), nil, &incArgs); err != nil {
 		t.Fatal(err)
 	}
 	// The follower will return a not leader error, indicating the command
 	// should be forwarded to the leader.
-	incArgs = incrementArgs([]byte("a"), 11, 1, mtc.stores[1].StoreID())
+	incArgs = incrementArgs([]byte("a"), 11)
 	{
-		_, err := client.SendWrapped(mtc.stores[1], nil, &incArgs)
+		_, err := client.SendWrapped(mtc.stores[1].TestSender(), nil, &incArgs)
 		if _, ok := err.(*roachpb.NotLeaderError); !ok {
 			t.Fatalf("expected not leader error; got %s", err)
 		}
 	}
-	incArgs.Replica.StoreID = mtc.stores[0].StoreID()
-	if _, err := client.SendWrapped(mtc.stores[0], nil, &incArgs); err != nil {
+	// Send again, this time to first store.
+	if _, err := client.SendWrapped(mtc.stores[0].TestSender(), nil, &incArgs); err != nil {
 		t.Fatal(err)
 	}
 
 	if err := util.IsTrueWithin(func() bool {
-		getArgs := getArgs([]byte("a"), 1, mtc.stores[1].StoreID())
+		getArgs := getArgs([]byte("a"))
 		getArgs.ReadConsistency = roachpb.INCONSISTENT
-		reply, err := client.SendWrapped(mtc.stores[1], nil, &getArgs)
+		reply, err := client.SendWrapped(mtc.stores[1].TestSender(), nil, &getArgs)
 		if err != nil {
 			return false
 		}
@@ -444,8 +451,8 @@ func TestReplicateAfterTruncation(t *testing.T) {
 	}
 
 	// Issue a command on the first node before replicating.
-	incArgs := incrementArgs([]byte("a"), 5, 1, mtc.stores[0].StoreID())
-	if _, err := client.SendWrapped(mtc.stores[0], nil, &incArgs); err != nil {
+	incArgs := incrementArgs([]byte("a"), 5)
+	if _, err := client.SendWrapped(mtc.stores[0].TestSender(), nil, &incArgs); err != nil {
 		t.Fatal(err)
 	}
 
@@ -457,14 +464,14 @@ func TestReplicateAfterTruncation(t *testing.T) {
 
 	// Truncate the log at index+1 (log entries < N are removed, so this includes
 	// the increment).
-	truncArgs := truncateLogArgs(index+1, 1, mtc.stores[0].StoreID())
-	if _, err := client.SendWrapped(mtc.stores[0], nil, &truncArgs); err != nil {
+	truncArgs := truncateLogArgs(index + 1)
+	if _, err := client.SendWrapped(mtc.stores[0].TestSender(), nil, &truncArgs); err != nil {
 		t.Fatal(err)
 	}
 
 	// Issue a second command post-truncation.
-	incArgs = incrementArgs([]byte("a"), 11, 1, mtc.stores[0].StoreID())
-	if _, err := client.SendWrapped(mtc.stores[0], nil, &incArgs); err != nil {
+	incArgs = incrementArgs([]byte("a"), 11)
+	if _, err := client.SendWrapped(mtc.stores[0].TestSender(), nil, &incArgs); err != nil {
 		t.Fatal(err)
 	}
 	mvcc := rng.GetMVCCStats()
@@ -480,9 +487,9 @@ func TestReplicateAfterTruncation(t *testing.T) {
 
 	// Once it catches up, the effects of both commands can be seen.
 	if err := util.IsTrueWithin(func() bool {
-		getArgs := getArgs([]byte("a"), 1, mtc.stores[1].StoreID())
+		getArgs := getArgs([]byte("a"))
 		getArgs.ReadConsistency = roachpb.INCONSISTENT
-		reply, err := client.SendWrapped(mtc.stores[1], nil, &getArgs)
+		reply, err := client.SendWrapped(mtc.stores[1].TestSender(), nil, &getArgs)
 		if err != nil {
 			return false
 		}
@@ -505,15 +512,15 @@ func TestReplicateAfterTruncation(t *testing.T) {
 
 	// Send a third command to verify that the log states are synced up so the
 	// new node can accept new commands.
-	incArgs = incrementArgs([]byte("a"), 23, 1, mtc.stores[0].StoreID())
-	if _, err := client.SendWrapped(mtc.stores[0], nil, &incArgs); err != nil {
+	incArgs = incrementArgs([]byte("a"), 23)
+	if _, err := client.SendWrapped(mtc.stores[0].TestSender(), nil, &incArgs); err != nil {
 		t.Fatal(err)
 	}
 
 	if err := util.IsTrueWithin(func() bool {
-		getArgs := getArgs([]byte("a"), 1, mtc.stores[1].StoreID())
+		getArgs := getArgs([]byte("a"))
 		getArgs.ReadConsistency = roachpb.INCONSISTENT
-		reply, err := client.SendWrapped(mtc.stores[1], nil, &getArgs)
+		reply, err := client.SendWrapped(mtc.stores[1].TestSender(), nil, &getArgs)
 		if err != nil {
 			return false
 		}
@@ -788,8 +795,8 @@ func TestProgressWithDownNode(t *testing.T) {
 	rangeID := roachpb.RangeID(1)
 	mtc.replicateRange(rangeID, 0, 1, 2)
 
-	incArgs := incrementArgs([]byte("a"), 5, rangeID, mtc.stores[0].StoreID())
-	if _, err := client.SendWrapped(mtc.stores[0], nil, &incArgs); err != nil {
+	incArgs := incrementArgs([]byte("a"), 5)
+	if _, err := client.SendWrapped(mtc.stores[0].TestSender(), nil, &incArgs); err != nil {
 		t.Fatal(err)
 	}
 
@@ -814,8 +821,8 @@ func TestProgressWithDownNode(t *testing.T) {
 
 	// Stop one of the replicas and issue a new increment.
 	mtc.stopStore(1)
-	incArgs = incrementArgs([]byte("a"), 11, rangeID, mtc.stores[0].StoreID())
-	if _, err := client.SendWrapped(mtc.stores[0], nil, &incArgs); err != nil {
+	incArgs = incrementArgs([]byte("a"), 11)
+	if _, err := client.SendWrapped(mtc.stores[0].TestSender(), nil, &incArgs); err != nil {
 		t.Fatal(err)
 	}
 
@@ -840,8 +847,8 @@ func TestReplicateAddAndRemove(t *testing.T) {
 		rangeID := roachpb.RangeID(1)
 		mtc.replicateRange(rangeID, 0, 3, 1)
 
-		incArgs := incrementArgs([]byte("a"), 5, rangeID, mtc.stores[0].StoreID())
-		if _, err := client.SendWrapped(mtc.stores[0], nil, &incArgs); err != nil {
+		incArgs := incrementArgs([]byte("a"), 5)
+		if _, err := client.SendWrapped(mtc.stores[0].TestSender(), nil, &incArgs); err != nil {
 			t.Fatal(err)
 		}
 
@@ -877,8 +884,8 @@ func TestReplicateAddAndRemove(t *testing.T) {
 		verify([]int64{5, 5, 5, 5})
 
 		// Ensure that the rest of the group can make progress.
-		incArgs = incrementArgs([]byte("a"), 11, rangeID, mtc.stores[0].StoreID())
-		if _, err := client.SendWrapped(mtc.stores[0], nil, &incArgs); err != nil {
+		incArgs = incrementArgs([]byte("a"), 11)
+		if _, err := client.SendWrapped(mtc.stores[0].TestSender(), nil, &incArgs); err != nil {
 			t.Fatal(err)
 		}
 		verify([]int64{16, 5, 16, 16})
@@ -888,8 +895,8 @@ func TestReplicateAddAndRemove(t *testing.T) {
 
 		// Node 1 never sees the increment that was added while it was
 		// down. Perform another increment on the live nodes to verify.
-		incArgs = incrementArgs([]byte("a"), 23, rangeID, mtc.stores[0].StoreID())
-		if _, err := client.SendWrapped(mtc.stores[0], nil, &incArgs); err != nil {
+		incArgs = incrementArgs([]byte("a"), 23)
+		if _, err := client.SendWrapped(mtc.stores[0].TestSender(), nil, &incArgs); err != nil {
 			t.Fatal(err)
 		}
 		verify([]int64{39, 5, 39, 39})
@@ -953,8 +960,8 @@ func TestReplicateAfterSplit(t *testing.T) {
 
 	store0 := mtc.stores[0]
 	// Make the split
-	splitArgs := adminSplitArgs(roachpb.KeyMin, splitKey, rangeID, store0.StoreID())
-	if _, err := client.SendWrapped(store0, nil, &splitArgs); err != nil {
+	splitArgs := adminSplitArgs(roachpb.KeyMin, splitKey, 1, store0.StoreID())
+	if _, err := client.SendWrapped(store0.TestSender(), nil, &splitArgs); err != nil {
 		t.Fatal(err)
 	}
 
@@ -963,8 +970,10 @@ func TestReplicateAfterSplit(t *testing.T) {
 		t.Errorf("got same range id after split")
 	}
 	// Issue an increment for later check.
-	incArgs := incrementArgs(key, 11, rangeID2, store0.StoreID())
-	if _, err := client.SendWrapped(store0, nil, &incArgs); err != nil {
+	incArgs := incrementArgs(key, 11)
+	if _, err := client.SendWrappedWith(store0.TestSender(), nil, roachpb.BatchRequest_Header{
+		RangeID: rangeID2,
+	}, &incArgs); err != nil {
 		t.Fatal(err)
 	}
 	// Now add the second replica.
@@ -975,10 +984,12 @@ func TestReplicateAfterSplit(t *testing.T) {
 	}
 	// Once it catches up, the effects of increment commands can be seen.
 	if err := util.IsTrueWithin(func() bool {
-		getArgs := getArgs(key, rangeID2, mtc.stores[1].StoreID())
+		getArgs := getArgs(key)
 		// Reading on non-leader replica should use inconsistent read
 		getArgs.ReadConsistency = roachpb.INCONSISTENT
-		reply, err := client.SendWrapped(mtc.stores[1], nil, &getArgs)
+		reply, err := client.SendWrappedWith(mtc.stores[1].TestSender(), nil, roachpb.BatchRequest_Header{
+			RangeID: rangeID2,
+		}, &getArgs)
 		if err != nil {
 			return false
 		}
@@ -1069,7 +1080,7 @@ func TestRaftAfterRemoveRange(t *testing.T) {
 
 	// Make the split.
 	splitArgs := adminSplitArgs(roachpb.KeyMin, []byte("b"), roachpb.RangeID(1), mtc.stores[0].StoreID())
-	if _, err := client.SendWrapped(mtc.stores[0], nil, &splitArgs); err != nil {
+	if _, err := client.SendWrapped(mtc.stores[0].TestSender(), nil, &splitArgs); err != nil {
 		t.Fatal(err)
 	}
 

--- a/storage/client_raft_test.go
+++ b/storage/client_raft_test.go
@@ -166,7 +166,7 @@ func TestStoreRecoverWithErrors(t *testing.T) {
 
 	numIncrements := 0
 
-	storage.TestingCommandFilter = func(args roachpb.Request) error {
+	storage.TestingCommandFilter = func(args roachpb.Request, _ roachpb.BatchRequest_Header) error {
 		if _, ok := args.(*roachpb.IncrementRequest); ok && args.Header().Key.Equal(roachpb.Key("a")) {
 			numIncrements++
 		}
@@ -376,7 +376,7 @@ func TestFailedReplicaChange(t *testing.T) {
 	var runFilter atomic.Value
 	runFilter.Store(true)
 
-	storage.TestingCommandFilter = func(args roachpb.Request) error {
+	storage.TestingCommandFilter = func(args roachpb.Request, _ roachpb.BatchRequest_Header) error {
 		if runFilter.Load().(bool) {
 			if et, ok := args.(*roachpb.EndTransactionRequest); ok && et.Commit {
 				return util.Errorf("boom")

--- a/storage/client_raft_test.go
+++ b/storage/client_raft_test.go
@@ -262,8 +262,9 @@ func TestReplicateRange(t *testing.T) {
 	// Verify that the same data is available on the replica.
 	util.SucceedsWithin(t, 1*time.Second, func() error {
 		getArgs := getArgs([]byte("a"))
-		getArgs.ReadConsistency = roachpb.INCONSISTENT
-		if reply, err := client.SendWrapped(rg1(mtc.stores[1]), nil, &getArgs); err != nil {
+		if reply, err := client.SendWrappedWith(rg1(mtc.stores[1]), nil, roachpb.BatchRequest_Header{
+			ReadConsistency: roachpb.INCONSISTENT,
+		}, &getArgs); err != nil {
 			return util.Errorf("failed to read data")
 		} else if v := mustGetInt(reply.(*roachpb.GetResponse).Value); v != 5 {
 			return util.Errorf("failed to read correct data: %d", v)
@@ -333,8 +334,9 @@ func TestRestoreReplicas(t *testing.T) {
 
 	if err := util.IsTrueWithin(func() bool {
 		getArgs := getArgs([]byte("a"))
-		getArgs.ReadConsistency = roachpb.INCONSISTENT
-		reply, err := client.SendWrapped(rg1(mtc.stores[1]), nil, &getArgs)
+		reply, err := client.SendWrappedWith(rg1(mtc.stores[1]), nil, roachpb.BatchRequest_Header{
+			ReadConsistency: roachpb.INCONSISTENT,
+		}, &getArgs)
 		if err != nil {
 			return false
 		}
@@ -488,8 +490,9 @@ func TestReplicateAfterTruncation(t *testing.T) {
 	// Once it catches up, the effects of both commands can be seen.
 	if err := util.IsTrueWithin(func() bool {
 		getArgs := getArgs([]byte("a"))
-		getArgs.ReadConsistency = roachpb.INCONSISTENT
-		reply, err := client.SendWrapped(rg1(mtc.stores[1]), nil, &getArgs)
+		reply, err := client.SendWrappedWith(rg1(mtc.stores[1]), nil, roachpb.BatchRequest_Header{
+			ReadConsistency: roachpb.INCONSISTENT,
+		}, &getArgs)
 		if err != nil {
 			return false
 		}
@@ -519,8 +522,9 @@ func TestReplicateAfterTruncation(t *testing.T) {
 
 	if err := util.IsTrueWithin(func() bool {
 		getArgs := getArgs([]byte("a"))
-		getArgs.ReadConsistency = roachpb.INCONSISTENT
-		reply, err := client.SendWrapped(rg1(mtc.stores[1]), nil, &getArgs)
+		reply, err := client.SendWrappedWith(rg1(mtc.stores[1]), nil, roachpb.BatchRequest_Header{
+			ReadConsistency: roachpb.INCONSISTENT,
+		}, &getArgs)
 		if err != nil {
 			return false
 		}
@@ -986,9 +990,9 @@ func TestReplicateAfterSplit(t *testing.T) {
 	if err := util.IsTrueWithin(func() bool {
 		getArgs := getArgs(key)
 		// Reading on non-leader replica should use inconsistent read
-		getArgs.ReadConsistency = roachpb.INCONSISTENT
 		reply, err := client.SendWrappedWith(rg1(mtc.stores[1]), nil, roachpb.BatchRequest_Header{
-			RangeID: rangeID2,
+			RangeID:         rangeID2,
+			ReadConsistency: roachpb.INCONSISTENT,
 		}, &getArgs)
 		if err != nil {
 			return false

--- a/storage/client_raft_test.go
+++ b/storage/client_raft_test.go
@@ -115,7 +115,7 @@ func TestStoreRecoverFromEngine(t *testing.T) {
 		if _, err := increment(rangeID, key2, 5); err != nil {
 			t.Fatal(err)
 		}
-		splitArgs := adminSplitArgs(roachpb.KeyMin, splitKey, rangeID, store.StoreID())
+		splitArgs := adminSplitArgs(roachpb.KeyMin, splitKey)
 		if _, err := client.SendWrapped(rg1(store), nil, &splitArgs); err != nil {
 			t.Fatal(err)
 		}
@@ -614,7 +614,7 @@ func TestStoreRangeDownReplicate(t *testing.T) {
 		replica := store0.LookupReplica(roachpb.KeyMin, nil)
 		mtc.replicateRange(replica.Desc().RangeID, 0, 1, 2)
 		desc := replica.Desc()
-		splitArgs := adminSplitArgs(splitKey, splitKey, desc.RangeID, store0.StoreID())
+		splitArgs := adminSplitArgs(splitKey, splitKey)
 		if _, err := replica.AdminSplit(splitArgs, desc); err != nil {
 			t.Fatal(err)
 		}
@@ -960,7 +960,7 @@ func TestReplicateAfterSplit(t *testing.T) {
 
 	store0 := mtc.stores[0]
 	// Make the split
-	splitArgs := adminSplitArgs(roachpb.KeyMin, splitKey, 1, store0.StoreID())
+	splitArgs := adminSplitArgs(roachpb.KeyMin, splitKey)
 	if _, err := client.SendWrapped(rg1(store0), nil, &splitArgs); err != nil {
 		t.Fatal(err)
 	}
@@ -1050,8 +1050,7 @@ func TestRangeDescriptorSnapshotRace(t *testing.T) {
 			t.Fatal("failed to look up min range")
 		}
 		desc := rng.Desc()
-		args := adminSplitArgs(roachpb.KeyMin, []byte(fmt.Sprintf("A%03d", i)), desc.RangeID,
-			mtc.stores[0].StoreID())
+		args := adminSplitArgs(roachpb.KeyMin, []byte(fmt.Sprintf("A%03d", i)))
 		if _, err := rng.AdminSplit(args, desc); err != nil {
 			t.Fatal(err)
 		}
@@ -1064,7 +1063,7 @@ func TestRangeDescriptorSnapshotRace(t *testing.T) {
 			t.Fatal("failed to look up max range")
 		}
 		desc := rng.Desc()
-		args := adminSplitArgs(roachpb.KeyMin, []byte(fmt.Sprintf("B%03d", i)), desc.RangeID, mtc.stores[0].StoreID())
+		args := adminSplitArgs(roachpb.KeyMin, []byte(fmt.Sprintf("B%03d", i)))
 		if _, err := rng.AdminSplit(args, desc); err != nil {
 			t.Fatal(err)
 		}
@@ -1079,7 +1078,7 @@ func TestRaftAfterRemoveRange(t *testing.T) {
 	defer mtc.Stop()
 
 	// Make the split.
-	splitArgs := adminSplitArgs(roachpb.KeyMin, []byte("b"), roachpb.RangeID(1), mtc.stores[0].StoreID())
+	splitArgs := adminSplitArgs(roachpb.KeyMin, []byte("b"))
 	if _, err := client.SendWrapped(rg1(mtc.stores[0]), nil, &splitArgs); err != nil {
 		t.Fatal(err)
 	}

--- a/storage/client_range_test.go
+++ b/storage/client_range_test.go
@@ -187,10 +187,10 @@ func TestTxnPutOutOfOrder(t *testing.T) {
 	key := "key"
 	// Set up a filter to so that the get operation at Step 3 will return an error.
 	var numGets int32
-	storage.TestingCommandFilter = func(args roachpb.Request, _ roachpb.BatchRequest_Header) error {
+	storage.TestingCommandFilter = func(args roachpb.Request, h roachpb.BatchRequest_Header) error {
 		if _, ok := args.(*roachpb.GetRequest); ok &&
 			args.Header().Key.Equal(roachpb.Key(key)) &&
-			args.Header().Txn == nil {
+			h.Txn == nil {
 			// The Reader executes two get operations, each of which triggers two get requests
 			// (the first request fails and triggers txn push, and then the second request
 			// succeeds). Returns an error for the fourth get request to avoid timestamp cache

--- a/storage/client_range_test.go
+++ b/storage/client_range_test.go
@@ -325,10 +325,10 @@ func TestRangeLookupUseReverse(t *testing.T) {
 	// Init test ranges:
 	// ["","a"), ["a","c"), ["c","e"), ["e","g") and ["g","\xff\xff").
 	splits := []roachpb.AdminSplitRequest{
-		adminSplitArgs(roachpb.Key("g"), roachpb.Key("g"), 1, store.StoreID()),
-		adminSplitArgs(roachpb.Key("e"), roachpb.Key("e"), 1, store.StoreID()),
-		adminSplitArgs(roachpb.Key("c"), roachpb.Key("c"), 1, store.StoreID()),
-		adminSplitArgs(roachpb.Key("a"), roachpb.Key("a"), 1, store.StoreID()),
+		adminSplitArgs(roachpb.Key("g"), roachpb.Key("g")),
+		adminSplitArgs(roachpb.Key("e"), roachpb.Key("e")),
+		adminSplitArgs(roachpb.Key("c"), roachpb.Key("c")),
+		adminSplitArgs(roachpb.Key("a"), roachpb.Key("a")),
 	}
 
 	for _, split := range splits {

--- a/storage/client_range_test.go
+++ b/storage/client_range_test.go
@@ -60,9 +60,9 @@ func TestRangeCommandClockUpdate(t *testing.T) {
 	// Advance the leader's clock ahead of the followers (by more than
 	// MaxOffset but less than the leader lease) and execute a command.
 	manuals[0].Increment(int64(500 * time.Millisecond))
-	incArgs := incrementArgs([]byte("a"), 5, 1, mtc.stores[0].StoreID())
+	incArgs := incrementArgs([]byte("a"), 5)
 	ts := clocks[0].Now()
-	if _, err := client.SendWrappedWith(mtc.stores[0], nil, roachpb.BatchRequest_Header{Timestamp: ts}, &incArgs); err != nil {
+	if _, err := client.SendWrappedWith(mtc.stores[0].TestSender(), nil, roachpb.BatchRequest_Header{Timestamp: ts}, &incArgs); err != nil {
 		t.Fatal(err)
 	}
 
@@ -110,8 +110,8 @@ func TestRejectFutureCommand(t *testing.T) {
 
 	// First do a write. The first write will advance the clock by MaxOffset
 	// because of the read cache's low water mark.
-	getArgs := putArgs([]byte("b"), []byte("b"), 1, mtc.stores[0].StoreID())
-	if _, err := client.SendWrapped(mtc.stores[0], nil, &getArgs); err != nil {
+	getArgs := putArgs([]byte("b"), []byte("b"))
+	if _, err := client.SendWrapped(mtc.stores[0].TestSender(), nil, &getArgs); err != nil {
 		t.Fatal(err)
 	}
 	if now := clock.Now(); now.WallTime != int64(maxOffset) {
@@ -126,9 +126,9 @@ func TestRejectFutureCommand(t *testing.T) {
 	// Commands with a future timestamp that is within the MaxOffset
 	// bound will be accepted and will cause the clock to advance.
 	for i := int64(0); i < 3; i++ {
-		incArgs := incrementArgs([]byte("a"), 5, 1, mtc.stores[0].StoreID())
+		incArgs := incrementArgs([]byte("a"), 5)
 		ts := roachpb.ZeroTimestamp.Add(startTime+((i+1)*30)*int64(time.Millisecond), 0)
-		if _, err := client.SendWrappedWith(mtc.stores[0], nil, roachpb.BatchRequest_Header{Timestamp: ts}, &incArgs); err != nil {
+		if _, err := client.SendWrappedWith(mtc.stores[0].TestSender(), nil, roachpb.BatchRequest_Header{Timestamp: ts}, &incArgs); err != nil {
 			t.Fatal(err)
 		}
 	}
@@ -137,9 +137,9 @@ func TestRejectFutureCommand(t *testing.T) {
 	}
 
 	// Once the accumulated offset reaches MaxOffset, commands will be rejected.
-	incArgs := incrementArgs([]byte("a"), 11, 1, mtc.stores[0].StoreID())
+	incArgs := incrementArgs([]byte("a"), 11)
 	ts := roachpb.ZeroTimestamp.Add(int64((time.Duration(startTime)+maxOffset+1)*time.Millisecond), 0)
-	if _, err := client.SendWrappedWith(mtc.stores[0], nil, roachpb.BatchRequest_Header{Timestamp: ts}, &incArgs); err == nil {
+	if _, err := client.SendWrappedWith(mtc.stores[0].TestSender(), nil, roachpb.BatchRequest_Header{Timestamp: ts}, &incArgs); err == nil {
 		t.Fatalf("expected clock offset error but got nil")
 	}
 
@@ -289,12 +289,10 @@ func TestTxnPutOutOfOrder(t *testing.T) {
 	priority := int32(math.MaxInt32)
 	requestHeader := roachpb.RequestHeader{
 		Key:          roachpb.Key(key),
-		RangeID:      1,
-		Replica:      roachpb.ReplicaDescriptor{StoreID: store.StoreID()},
 		UserPriority: &priority,
 	}
 	ts := clock.Now()
-	if _, err := client.SendWrappedWith(store, nil, roachpb.BatchRequest_Header{Timestamp: ts}, &roachpb.GetRequest{RequestHeader: requestHeader}); err != nil {
+	if _, err := client.SendWrappedWith(store.TestSender(), nil, roachpb.BatchRequest_Header{Timestamp: ts}, &roachpb.GetRequest{RequestHeader: requestHeader}); err != nil {
 		t.Fatalf("failed to get: %s", err)
 	}
 
@@ -309,7 +307,7 @@ func TestTxnPutOutOfOrder(t *testing.T) {
 	manualClock.Increment(100)
 
 	ts = clock.Now()
-	if _, err := client.SendWrappedWith(store, nil, roachpb.BatchRequest_Header{Timestamp: ts}, &roachpb.GetRequest{RequestHeader: requestHeader}); err == nil {
+	if _, err := client.SendWrappedWith(store.TestSender(), nil, roachpb.BatchRequest_Header{Timestamp: ts}, &roachpb.GetRequest{RequestHeader: requestHeader}); err == nil {
 		t.Fatal("unexpected success of get")
 	}
 
@@ -334,7 +332,7 @@ func TestRangeLookupUseReverse(t *testing.T) {
 	}
 
 	for _, split := range splits {
-		_, err := client.SendWrapped(store, nil, &split)
+		_, err := client.SendWrapped(store.TestSender(), nil, &split)
 		if err != nil {
 			t.Fatalf("%q: split unexpected error: %s", split.SplitKey, err)
 		}
@@ -343,14 +341,12 @@ func TestRangeLookupUseReverse(t *testing.T) {
 	// Resolve the intents.
 	scanArgs := roachpb.ScanRequest{
 		RequestHeader: roachpb.RequestHeader{
-			Key:     roachpb.KeyMin,
-			EndKey:  keys.RangeMetaKey(roachpb.KeyMax),
-			RangeID: 1,
-			Replica: roachpb.ReplicaDescriptor{StoreID: store.StoreID()},
+			Key:    roachpb.KeyMin,
+			EndKey: keys.RangeMetaKey(roachpb.KeyMax),
 		},
 	}
 	util.SucceedsWithin(t, time.Second, func() error {
-		_, err := client.SendWrapped(store, nil, &scanArgs)
+		_, err := client.SendWrapped(store.TestSender(), nil, &scanArgs)
 		return err
 	})
 
@@ -358,8 +354,6 @@ func TestRangeLookupUseReverse(t *testing.T) {
 		return &roachpb.RangeLookupRequest{
 			RequestHeader: roachpb.RequestHeader{
 				Key:             key,
-				RangeID:         1,
-				Replica:         roachpb.ReplicaDescriptor{StoreID: store.StoreID()},
 				ReadConsistency: roachpb.INCONSISTENT,
 			},
 			MaxRanges: maxResults,
@@ -420,7 +414,7 @@ func TestRangeLookupUseReverse(t *testing.T) {
 	}
 
 	for _, test := range testCases {
-		resp, err := client.SendWrapped(store, nil, test.request)
+		resp, err := client.SendWrapped(store.TestSender(), nil, test.request)
 		if err != nil {
 			t.Fatalf("RangeLookup error: %s", err)
 		}

--- a/storage/client_range_test.go
+++ b/storage/client_range_test.go
@@ -62,7 +62,7 @@ func TestRangeCommandClockUpdate(t *testing.T) {
 	manuals[0].Increment(int64(500 * time.Millisecond))
 	incArgs := incrementArgs([]byte("a"), 5)
 	ts := clocks[0].Now()
-	if _, err := client.SendWrappedWith(mtc.stores[0].TestSender(), nil, roachpb.BatchRequest_Header{Timestamp: ts}, &incArgs); err != nil {
+	if _, err := client.SendWrappedWith(rg1(mtc.stores[0]), nil, roachpb.BatchRequest_Header{Timestamp: ts}, &incArgs); err != nil {
 		t.Fatal(err)
 	}
 
@@ -111,7 +111,7 @@ func TestRejectFutureCommand(t *testing.T) {
 	// First do a write. The first write will advance the clock by MaxOffset
 	// because of the read cache's low water mark.
 	getArgs := putArgs([]byte("b"), []byte("b"))
-	if _, err := client.SendWrapped(mtc.stores[0].TestSender(), nil, &getArgs); err != nil {
+	if _, err := client.SendWrapped(rg1(mtc.stores[0]), nil, &getArgs); err != nil {
 		t.Fatal(err)
 	}
 	if now := clock.Now(); now.WallTime != int64(maxOffset) {
@@ -128,7 +128,7 @@ func TestRejectFutureCommand(t *testing.T) {
 	for i := int64(0); i < 3; i++ {
 		incArgs := incrementArgs([]byte("a"), 5)
 		ts := roachpb.ZeroTimestamp.Add(startTime+((i+1)*30)*int64(time.Millisecond), 0)
-		if _, err := client.SendWrappedWith(mtc.stores[0].TestSender(), nil, roachpb.BatchRequest_Header{Timestamp: ts}, &incArgs); err != nil {
+		if _, err := client.SendWrappedWith(rg1(mtc.stores[0]), nil, roachpb.BatchRequest_Header{Timestamp: ts}, &incArgs); err != nil {
 			t.Fatal(err)
 		}
 	}
@@ -139,7 +139,7 @@ func TestRejectFutureCommand(t *testing.T) {
 	// Once the accumulated offset reaches MaxOffset, commands will be rejected.
 	incArgs := incrementArgs([]byte("a"), 11)
 	ts := roachpb.ZeroTimestamp.Add(int64((time.Duration(startTime)+maxOffset+1)*time.Millisecond), 0)
-	if _, err := client.SendWrappedWith(mtc.stores[0].TestSender(), nil, roachpb.BatchRequest_Header{Timestamp: ts}, &incArgs); err == nil {
+	if _, err := client.SendWrappedWith(rg1(mtc.stores[0]), nil, roachpb.BatchRequest_Header{Timestamp: ts}, &incArgs); err == nil {
 		t.Fatalf("expected clock offset error but got nil")
 	}
 
@@ -292,7 +292,7 @@ func TestTxnPutOutOfOrder(t *testing.T) {
 		UserPriority: &priority,
 	}
 	ts := clock.Now()
-	if _, err := client.SendWrappedWith(store.TestSender(), nil, roachpb.BatchRequest_Header{Timestamp: ts}, &roachpb.GetRequest{RequestHeader: requestHeader}); err != nil {
+	if _, err := client.SendWrappedWith(rg1(store), nil, roachpb.BatchRequest_Header{Timestamp: ts}, &roachpb.GetRequest{RequestHeader: requestHeader}); err != nil {
 		t.Fatalf("failed to get: %s", err)
 	}
 
@@ -307,7 +307,7 @@ func TestTxnPutOutOfOrder(t *testing.T) {
 	manualClock.Increment(100)
 
 	ts = clock.Now()
-	if _, err := client.SendWrappedWith(store.TestSender(), nil, roachpb.BatchRequest_Header{Timestamp: ts}, &roachpb.GetRequest{RequestHeader: requestHeader}); err == nil {
+	if _, err := client.SendWrappedWith(rg1(store), nil, roachpb.BatchRequest_Header{Timestamp: ts}, &roachpb.GetRequest{RequestHeader: requestHeader}); err == nil {
 		t.Fatal("unexpected success of get")
 	}
 
@@ -332,7 +332,7 @@ func TestRangeLookupUseReverse(t *testing.T) {
 	}
 
 	for _, split := range splits {
-		_, err := client.SendWrapped(store.TestSender(), nil, &split)
+		_, err := client.SendWrapped(rg1(store), nil, &split)
 		if err != nil {
 			t.Fatalf("%q: split unexpected error: %s", split.SplitKey, err)
 		}
@@ -346,7 +346,7 @@ func TestRangeLookupUseReverse(t *testing.T) {
 		},
 	}
 	util.SucceedsWithin(t, time.Second, func() error {
-		_, err := client.SendWrapped(store.TestSender(), nil, &scanArgs)
+		_, err := client.SendWrapped(rg1(store), nil, &scanArgs)
 		return err
 	})
 
@@ -414,7 +414,7 @@ func TestRangeLookupUseReverse(t *testing.T) {
 	}
 
 	for _, test := range testCases {
-		resp, err := client.SendWrapped(store.TestSender(), nil, test.request)
+		resp, err := client.SendWrapped(rg1(store), nil, test.request)
 		if err != nil {
 			t.Fatalf("RangeLookup error: %s", err)
 		}

--- a/storage/client_range_test.go
+++ b/storage/client_range_test.go
@@ -353,8 +353,7 @@ func TestRangeLookupUseReverse(t *testing.T) {
 	revScanArgs := func(key []byte, maxResults int32) *roachpb.RangeLookupRequest {
 		return &roachpb.RangeLookupRequest{
 			RequestHeader: roachpb.RequestHeader{
-				Key:             key,
-				ReadConsistency: roachpb.INCONSISTENT,
+				Key: key,
 			},
 			MaxRanges: maxResults,
 			Reverse:   true,
@@ -414,7 +413,9 @@ func TestRangeLookupUseReverse(t *testing.T) {
 	}
 
 	for _, test := range testCases {
-		resp, err := client.SendWrapped(rg1(store), nil, test.request)
+		resp, err := client.SendWrappedWith(rg1(store), nil, roachpb.BatchRequest_Header{
+			ReadConsistency: roachpb.INCONSISTENT,
+		}, test.request)
 		if err != nil {
 			t.Fatalf("RangeLookup error: %s", err)
 		}

--- a/storage/client_split_test.go
+++ b/storage/client_split_test.go
@@ -76,7 +76,7 @@ func TestStoreRangeSplitAtIllegalKeys(t *testing.T) {
 		keys.MakeTablePrefix(10 /* system descriptor ID */),
 	} {
 		args := adminSplitArgs(roachpb.KeyMin, key, 1, store.StoreID())
-		_, err := client.SendWrapped(store.TestSender(), nil, &args)
+		_, err := client.SendWrapped(rg1(store), nil, &args)
 		if err == nil {
 			t.Fatalf("%q: split succeeded unexpectedly", key)
 		}
@@ -92,7 +92,7 @@ func TestStoreRangeSplitAtTablePrefix(t *testing.T) {
 
 	key := keys.TableDataPrefix
 	args := adminSplitArgs(key, key, 1, store.StoreID())
-	_, err := client.SendWrapped(store.TestSender(), nil, &args)
+	_, err := client.SendWrapped(rg1(store), nil, &args)
 	if err != nil {
 		t.Fatalf("%q: split unexpected error: %s", key, err)
 	}
@@ -118,16 +118,16 @@ func TestStoreRangeSplitAtRangeBounds(t *testing.T) {
 	defer stopper.Stop()
 
 	args := adminSplitArgs(roachpb.KeyMin, []byte("a"), 1, store.StoreID())
-	if _, err := client.SendWrapped(store.TestSender(), nil, &args); err != nil {
+	if _, err := client.SendWrapped(rg1(store), nil, &args); err != nil {
 		t.Fatal(err)
 	}
 	// This second split will try to split at end of first split range.
-	if _, err := client.SendWrapped(store.TestSender(), nil, &args); err == nil {
+	if _, err := client.SendWrapped(rg1(store), nil, &args); err == nil {
 		t.Fatalf("split succeeded unexpectedly")
 	}
 	// Now try to split at start of new range.
 	args = adminSplitArgs(roachpb.KeyMin, []byte("a"), 2, store.StoreID())
-	if _, err := client.SendWrapped(store.TestSender(), nil, &args); err == nil {
+	if _, err := client.SendWrapped(rg1(store), nil, &args); err == nil {
 		t.Fatalf("split succeeded unexpectedly")
 	}
 }
@@ -148,7 +148,7 @@ func TestStoreRangeSplitConcurrent(t *testing.T) {
 	for i := int32(0); i < concurrentCount; i++ {
 		go func() {
 			args := adminSplitArgs(roachpb.KeyMin, splitKey, 1, store.StoreID())
-			_, err := client.SendWrapped(store.TestSender(), nil, &args)
+			_, err := client.SendWrapped(rg1(store), nil, &args)
 			if err != nil {
 				atomic.AddInt32(&failureCount, 1)
 			}
@@ -187,11 +187,11 @@ func TestStoreRangeSplit(t *testing.T) {
 
 	// First, write some values left and right of the proposed split key.
 	pArgs := putArgs([]byte("c"), content)
-	if _, err := client.SendWrapped(store.TestSender(), nil, &pArgs); err != nil {
+	if _, err := client.SendWrapped(rg1(store), nil, &pArgs); err != nil {
 		t.Fatal(err)
 	}
 	pArgs = putArgs([]byte("x"), content)
-	if _, err := client.SendWrapped(store.TestSender(), nil, &pArgs); err != nil {
+	if _, err := client.SendWrapped(rg1(store), nil, &pArgs); err != nil {
 		t.Fatal(err)
 	}
 
@@ -200,12 +200,12 @@ func TestStoreRangeSplit(t *testing.T) {
 	// the key.
 	lIncArgs := incrementArgs([]byte("apoptosis"), 100)
 	lIncArgs.CmdID = roachpb.ClientCmdID{WallTime: 123, Random: 423}
-	if _, err := client.SendWrapped(store.TestSender(), nil, &lIncArgs); err != nil {
+	if _, err := client.SendWrapped(rg1(store), nil, &lIncArgs); err != nil {
 		t.Fatal(err)
 	}
 	rIncArgs := incrementArgs([]byte("wobble"), 10)
 	rIncArgs.CmdID = roachpb.ClientCmdID{WallTime: 12, Random: 42}
-	if _, err := client.SendWrapped(store.TestSender(), nil, &rIncArgs); err != nil {
+	if _, err := client.SendWrapped(rg1(store), nil, &rIncArgs); err != nil {
 		t.Fatal(err)
 	}
 
@@ -218,7 +218,7 @@ func TestStoreRangeSplit(t *testing.T) {
 
 	// Split the range.
 	args := adminSplitArgs(roachpb.KeyMin, splitKey, 1, store.StoreID())
-	if _, err := client.SendWrapped(store.TestSender(), nil, &args); err != nil {
+	if _, err := client.SendWrapped(rg1(store), nil, &args); err != nil {
 		t.Fatal(err)
 	}
 
@@ -240,13 +240,13 @@ func TestStoreRangeSplit(t *testing.T) {
 
 	// Try to get values from both left and right of where the split happened.
 	gArgs := getArgs([]byte("c"))
-	if reply, err := client.SendWrapped(store.TestSender(), nil, &gArgs); err != nil {
+	if reply, err := client.SendWrapped(rg1(store), nil, &gArgs); err != nil {
 		t.Fatal(err)
 	} else if gReply := reply.(*roachpb.GetResponse); !bytes.Equal(gReply.Value.Bytes, content) {
 		t.Fatalf("actual value %q did not match expected value %q", gReply.Value.Bytes, content)
 	}
 	gArgs = getArgs([]byte("x"))
-	if reply, err := client.SendWrappedWith(store.TestSender(), nil, roachpb.BatchRequest_Header{
+	if reply, err := client.SendWrappedWith(rg1(store), nil, roachpb.BatchRequest_Header{
 		RangeID: newRng.Desc().RangeID,
 	}, &gArgs); err != nil {
 		t.Fatal(err)
@@ -256,7 +256,7 @@ func TestStoreRangeSplit(t *testing.T) {
 
 	// Send out an increment request copied from above (same ClientCmdID) which
 	// remains in the old range.
-	if reply, err := client.SendWrapped(store.TestSender(), nil, &lIncArgs); err != nil {
+	if reply, err := client.SendWrapped(rg1(store), nil, &lIncArgs); err != nil {
 		t.Fatal(err)
 	} else if lIncReply := reply.(*roachpb.IncrementResponse); lIncReply.NewValue != 100 {
 		t.Errorf("response cache broken in old range, expected %d but got %d", lIncArgs.Increment, lIncReply.NewValue)
@@ -264,7 +264,7 @@ func TestStoreRangeSplit(t *testing.T) {
 
 	// Send out the same increment copied from above (same ClientCmdID), but
 	// now to the newly created range (which should hold that key).
-	if reply, err := client.SendWrappedWith(store.TestSender(), nil, roachpb.BatchRequest_Header{
+	if reply, err := client.SendWrappedWith(rg1(store), nil, roachpb.BatchRequest_Header{
 		RangeID: newRng.Desc().RangeID,
 	}, &rIncArgs); err != nil {
 		t.Fatal(err)
@@ -311,7 +311,7 @@ func TestStoreRangeSplitStats(t *testing.T) {
 	// Split the range after the last table data key.
 	keyPrefix := keys.MakeTablePrefix(keys.MaxReservedDescID + 1)
 	args := adminSplitArgs(roachpb.KeyMin, keyPrefix, 1, store.StoreID())
-	if _, err := client.SendWrapped(store.TestSender(), nil, &args); err != nil {
+	if _, err := client.SendWrapped(rg1(store), nil, &args); err != nil {
 		t.Fatal(err)
 	}
 	// Verify empty range has empty stats.
@@ -329,7 +329,7 @@ func TestStoreRangeSplitStats(t *testing.T) {
 		key = append(key, randutil.RandBytes(src, int(src.Int31n(1<<7)))...)
 		val := randutil.RandBytes(src, int(src.Int31n(1<<8)))
 		pArgs := putArgs(key, val)
-		if _, err := client.SendWrappedWith(store.TestSender(), nil, roachpb.BatchRequest_Header{
+		if _, err := client.SendWrappedWith(rg1(store), nil, roachpb.BatchRequest_Header{
 			RangeID: rng.Desc().RangeID,
 		}, &pArgs); err != nil {
 			t.Fatal(err)
@@ -345,7 +345,7 @@ func TestStoreRangeSplitStats(t *testing.T) {
 	midKey := append([]byte(nil), keyPrefix...)
 	midKey = append(midKey, []byte("Z")...)
 	args = adminSplitArgs(keyPrefix, midKey, 0, store.StoreID())
-	if _, err := client.SendWrappedWith(store.TestSender(), nil, roachpb.BatchRequest_Header{
+	if _, err := client.SendWrappedWith(rg1(store), nil, roachpb.BatchRequest_Header{
 		RangeID: rng.Desc().RangeID,
 	}, &args); err != nil {
 		t.Fatal(err)
@@ -393,7 +393,7 @@ func fillRange(store *storage.Store, rangeID roachpb.RangeID, prefix roachpb.Key
 		key := append(append([]byte(nil), prefix...), randutil.RandBytes(src, 100)...)
 		val := randutil.RandBytes(src, int(src.Int31n(1<<8)))
 		pArgs := putArgs(key, val)
-		if _, err := client.SendWrappedWith(store.TestSender(), nil, roachpb.BatchRequest_Header{
+		if _, err := client.SendWrappedWith(rg1(store), nil, roachpb.BatchRequest_Header{
 			RangeID: rangeID,
 		}, &pArgs); err != nil {
 			t.Fatal(err)

--- a/storage/client_split_test.go
+++ b/storage/client_split_test.go
@@ -42,9 +42,7 @@ import (
 func adminSplitArgs(key, splitKey []byte, rangeID roachpb.RangeID, storeID roachpb.StoreID) roachpb.AdminSplitRequest {
 	return roachpb.AdminSplitRequest{
 		RequestHeader: roachpb.RequestHeader{
-			Key:     key,
-			RangeID: rangeID,
-			Replica: roachpb.ReplicaDescriptor{StoreID: storeID},
+			Key: key,
 		},
 		SplitKey: splitKey,
 	}
@@ -78,7 +76,7 @@ func TestStoreRangeSplitAtIllegalKeys(t *testing.T) {
 		keys.MakeTablePrefix(10 /* system descriptor ID */),
 	} {
 		args := adminSplitArgs(roachpb.KeyMin, key, 1, store.StoreID())
-		_, err := client.SendWrapped(store, nil, &args)
+		_, err := client.SendWrapped(store.TestSender(), nil, &args)
 		if err == nil {
 			t.Fatalf("%q: split succeeded unexpectedly", key)
 		}
@@ -94,7 +92,7 @@ func TestStoreRangeSplitAtTablePrefix(t *testing.T) {
 
 	key := keys.TableDataPrefix
 	args := adminSplitArgs(key, key, 1, store.StoreID())
-	_, err := client.SendWrapped(store, nil, &args)
+	_, err := client.SendWrapped(store.TestSender(), nil, &args)
 	if err != nil {
 		t.Fatalf("%q: split unexpected error: %s", key, err)
 	}
@@ -120,16 +118,16 @@ func TestStoreRangeSplitAtRangeBounds(t *testing.T) {
 	defer stopper.Stop()
 
 	args := adminSplitArgs(roachpb.KeyMin, []byte("a"), 1, store.StoreID())
-	if _, err := client.SendWrapped(store, nil, &args); err != nil {
+	if _, err := client.SendWrapped(store.TestSender(), nil, &args); err != nil {
 		t.Fatal(err)
 	}
 	// This second split will try to split at end of first split range.
-	if _, err := client.SendWrapped(store, nil, &args); err == nil {
+	if _, err := client.SendWrapped(store.TestSender(), nil, &args); err == nil {
 		t.Fatalf("split succeeded unexpectedly")
 	}
 	// Now try to split at start of new range.
 	args = adminSplitArgs(roachpb.KeyMin, []byte("a"), 2, store.StoreID())
-	if _, err := client.SendWrapped(store, nil, &args); err == nil {
+	if _, err := client.SendWrapped(store.TestSender(), nil, &args); err == nil {
 		t.Fatalf("split succeeded unexpectedly")
 	}
 }
@@ -150,7 +148,7 @@ func TestStoreRangeSplitConcurrent(t *testing.T) {
 	for i := int32(0); i < concurrentCount; i++ {
 		go func() {
 			args := adminSplitArgs(roachpb.KeyMin, splitKey, 1, store.StoreID())
-			_, err := client.SendWrapped(store, nil, &args)
+			_, err := client.SendWrapped(store.TestSender(), nil, &args)
 			if err != nil {
 				atomic.AddInt32(&failureCount, 1)
 			}
@@ -188,26 +186,26 @@ func TestStoreRangeSplit(t *testing.T) {
 	content := roachpb.Key("asdvb")
 
 	// First, write some values left and right of the proposed split key.
-	pArgs := putArgs([]byte("c"), content, rangeID, store.StoreID())
-	if _, err := client.SendWrapped(store, nil, &pArgs); err != nil {
+	pArgs := putArgs([]byte("c"), content)
+	if _, err := client.SendWrapped(store.TestSender(), nil, &pArgs); err != nil {
 		t.Fatal(err)
 	}
-	pArgs = putArgs([]byte("x"), content, rangeID, store.StoreID())
-	if _, err := client.SendWrapped(store, nil, &pArgs); err != nil {
+	pArgs = putArgs([]byte("x"), content)
+	if _, err := client.SendWrapped(store.TestSender(), nil, &pArgs); err != nil {
 		t.Fatal(err)
 	}
 
 	// Increments are a good way of testing the response cache. Up here, we
 	// address them to the original range, then later to the one that contains
 	// the key.
-	lIncArgs := incrementArgs([]byte("apoptosis"), 100, rangeID, store.StoreID())
+	lIncArgs := incrementArgs([]byte("apoptosis"), 100)
 	lIncArgs.CmdID = roachpb.ClientCmdID{WallTime: 123, Random: 423}
-	if _, err := client.SendWrapped(store, nil, &lIncArgs); err != nil {
+	if _, err := client.SendWrapped(store.TestSender(), nil, &lIncArgs); err != nil {
 		t.Fatal(err)
 	}
-	rIncArgs := incrementArgs([]byte("wobble"), 10, rangeID, store.StoreID())
+	rIncArgs := incrementArgs([]byte("wobble"), 10)
 	rIncArgs.CmdID = roachpb.ClientCmdID{WallTime: 12, Random: 42}
-	if _, err := client.SendWrapped(store, nil, &rIncArgs); err != nil {
+	if _, err := client.SendWrapped(store.TestSender(), nil, &rIncArgs); err != nil {
 		t.Fatal(err)
 	}
 
@@ -220,7 +218,7 @@ func TestStoreRangeSplit(t *testing.T) {
 
 	// Split the range.
 	args := adminSplitArgs(roachpb.KeyMin, splitKey, 1, store.StoreID())
-	if _, err := client.SendWrapped(store, nil, &args); err != nil {
+	if _, err := client.SendWrapped(store.TestSender(), nil, &args); err != nil {
 		t.Fatal(err)
 	}
 
@@ -241,14 +239,16 @@ func TestStoreRangeSplit(t *testing.T) {
 	}
 
 	// Try to get values from both left and right of where the split happened.
-	gArgs := getArgs([]byte("c"), rangeID, store.StoreID())
-	if reply, err := client.SendWrapped(store, nil, &gArgs); err != nil {
+	gArgs := getArgs([]byte("c"))
+	if reply, err := client.SendWrapped(store.TestSender(), nil, &gArgs); err != nil {
 		t.Fatal(err)
 	} else if gReply := reply.(*roachpb.GetResponse); !bytes.Equal(gReply.Value.Bytes, content) {
 		t.Fatalf("actual value %q did not match expected value %q", gReply.Value.Bytes, content)
 	}
-	gArgs = getArgs([]byte("x"), newRng.Desc().RangeID, store.StoreID())
-	if reply, err := client.SendWrapped(store, nil, &gArgs); err != nil {
+	gArgs = getArgs([]byte("x"))
+	if reply, err := client.SendWrappedWith(store.TestSender(), nil, roachpb.BatchRequest_Header{
+		RangeID: newRng.Desc().RangeID,
+	}, &gArgs); err != nil {
 		t.Fatal(err)
 	} else if gReply := reply.(*roachpb.GetResponse); !bytes.Equal(gReply.Value.Bytes, content) {
 		t.Fatalf("actual value %q did not match expected value %q", gReply.Value.Bytes, content)
@@ -256,7 +256,7 @@ func TestStoreRangeSplit(t *testing.T) {
 
 	// Send out an increment request copied from above (same ClientCmdID) which
 	// remains in the old range.
-	if reply, err := client.SendWrapped(store, nil, &lIncArgs); err != nil {
+	if reply, err := client.SendWrapped(store.TestSender(), nil, &lIncArgs); err != nil {
 		t.Fatal(err)
 	} else if lIncReply := reply.(*roachpb.IncrementResponse); lIncReply.NewValue != 100 {
 		t.Errorf("response cache broken in old range, expected %d but got %d", lIncArgs.Increment, lIncReply.NewValue)
@@ -264,8 +264,9 @@ func TestStoreRangeSplit(t *testing.T) {
 
 	// Send out the same increment copied from above (same ClientCmdID), but
 	// now to the newly created range (which should hold that key).
-	rIncArgs.RequestHeader.RangeID = newRng.Desc().RangeID
-	if reply, err := client.SendWrapped(store, nil, &rIncArgs); err != nil {
+	if reply, err := client.SendWrappedWith(store.TestSender(), nil, roachpb.BatchRequest_Header{
+		RangeID: newRng.Desc().RangeID,
+	}, &rIncArgs); err != nil {
 		t.Fatal(err)
 	} else if rIncReply := reply.(*roachpb.IncrementResponse); rIncReply.NewValue != 10 {
 		t.Errorf("response cache not copied correctly to new range, expected %d but got %d", rIncArgs.Increment, rIncReply.NewValue)
@@ -310,7 +311,7 @@ func TestStoreRangeSplitStats(t *testing.T) {
 	// Split the range after the last table data key.
 	keyPrefix := keys.MakeTablePrefix(keys.MaxReservedDescID + 1)
 	args := adminSplitArgs(roachpb.KeyMin, keyPrefix, 1, store.StoreID())
-	if _, err := client.SendWrapped(store, nil, &args); err != nil {
+	if _, err := client.SendWrapped(store.TestSender(), nil, &args); err != nil {
 		t.Fatal(err)
 	}
 	// Verify empty range has empty stats.
@@ -327,8 +328,10 @@ func TestStoreRangeSplitStats(t *testing.T) {
 		key := append([]byte(nil), keyPrefix...)
 		key = append(key, randutil.RandBytes(src, int(src.Int31n(1<<7)))...)
 		val := randutil.RandBytes(src, int(src.Int31n(1<<8)))
-		pArgs := putArgs(key, val, rng.Desc().RangeID, store.StoreID())
-		if _, err := client.SendWrapped(store, nil, &pArgs); err != nil {
+		pArgs := putArgs(key, val)
+		if _, err := client.SendWrappedWith(store.TestSender(), nil, roachpb.BatchRequest_Header{
+			RangeID: rng.Desc().RangeID,
+		}, &pArgs); err != nil {
 			t.Fatal(err)
 		}
 	}
@@ -341,8 +344,10 @@ func TestStoreRangeSplitStats(t *testing.T) {
 	// Split the range at approximate halfway point ("Z" in string "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz").
 	midKey := append([]byte(nil), keyPrefix...)
 	midKey = append(midKey, []byte("Z")...)
-	args = adminSplitArgs(keyPrefix, midKey, rng.Desc().RangeID, store.StoreID())
-	if _, err := client.SendWrapped(store, nil, &args); err != nil {
+	args = adminSplitArgs(keyPrefix, midKey, 0, store.StoreID())
+	if _, err := client.SendWrappedWith(store.TestSender(), nil, roachpb.BatchRequest_Header{
+		RangeID: rng.Desc().RangeID,
+	}, &args); err != nil {
 		t.Fatal(err)
 	}
 
@@ -387,8 +392,10 @@ func fillRange(store *storage.Store, rangeID roachpb.RangeID, prefix roachpb.Key
 		}
 		key := append(append([]byte(nil), prefix...), randutil.RandBytes(src, 100)...)
 		val := randutil.RandBytes(src, int(src.Int31n(1<<8)))
-		pArgs := putArgs(key, val, rangeID, store.StoreID())
-		if _, err := client.SendWrapped(store, nil, &pArgs); err != nil {
+		pArgs := putArgs(key, val)
+		if _, err := client.SendWrappedWith(store.TestSender(), nil, roachpb.BatchRequest_Header{
+			RangeID: rangeID,
+		}, &pArgs); err != nil {
 			t.Fatal(err)
 		}
 	}

--- a/storage/client_test.go
+++ b/storage/client_test.go
@@ -51,6 +51,15 @@ import (
 	"github.com/gogo/protobuf/proto"
 )
 
+func rg1(s *storage.Store) client.Sender {
+	return client.Wrap(s, func(ba roachpb.BatchRequest) roachpb.BatchRequest {
+		if ba.RangeID == 0 {
+			ba.RangeID = 1
+		}
+		return ba
+	})
+}
+
 // createTestStore creates a test store using an in-memory
 // engine. The caller is responsible for stopping the stopper on exit.
 func createTestStore(t *testing.T) (*storage.Store, *stop.Stopper) {

--- a/storage/client_test.go
+++ b/storage/client_test.go
@@ -457,24 +457,20 @@ func (m *multiTestContext) expireLeaderLeases() {
 
 // getArgs returns a GetRequest and GetResponse pair addressed to
 // the default replica for the specified key.
-func getArgs(key []byte, rangeID roachpb.RangeID, storeID roachpb.StoreID) roachpb.GetRequest {
+func getArgs(key []byte) roachpb.GetRequest {
 	return roachpb.GetRequest{
 		RequestHeader: roachpb.RequestHeader{
-			Key:     key,
-			RangeID: rangeID,
-			Replica: roachpb.ReplicaDescriptor{StoreID: storeID},
+			Key: key,
 		},
 	}
 }
 
 // putArgs returns a PutRequest and PutResponse pair addressed to
 // the default replica for the specified key / value.
-func putArgs(key, value []byte, rangeID roachpb.RangeID, storeID roachpb.StoreID) roachpb.PutRequest {
+func putArgs(key, value []byte) roachpb.PutRequest {
 	return roachpb.PutRequest{
 		RequestHeader: roachpb.RequestHeader{
-			Key:     key,
-			RangeID: rangeID,
-			Replica: roachpb.ReplicaDescriptor{StoreID: storeID},
+			Key: key,
 		},
 		Value: roachpb.Value{
 			Bytes: value,
@@ -484,23 +480,18 @@ func putArgs(key, value []byte, rangeID roachpb.RangeID, storeID roachpb.StoreID
 
 // incrementArgs returns an IncrementRequest and IncrementResponse pair
 // addressed to the default replica for the specified key / value.
-func incrementArgs(key []byte, inc int64, rangeID roachpb.RangeID, storeID roachpb.StoreID) roachpb.IncrementRequest {
+func incrementArgs(key []byte, inc int64) roachpb.IncrementRequest {
 	return roachpb.IncrementRequest{
 		RequestHeader: roachpb.RequestHeader{
-			Key:     key,
-			RangeID: rangeID,
-			Replica: roachpb.ReplicaDescriptor{StoreID: storeID},
+			Key: key,
 		},
 		Increment: inc,
 	}
 }
 
-func truncateLogArgs(index uint64, rangeID roachpb.RangeID, storeID roachpb.StoreID) roachpb.TruncateLogRequest {
+func truncateLogArgs(index uint64) roachpb.TruncateLogRequest {
 	return roachpb.TruncateLogRequest{
-		RequestHeader: roachpb.RequestHeader{
-			RangeID: rangeID,
-			Replica: roachpb.ReplicaDescriptor{StoreID: storeID},
-		},
-		Index: index,
+		RequestHeader: roachpb.RequestHeader{},
+		Index:         index,
 	}
 }

--- a/storage/engine/rocksdb/cockroach/roachpb/api.pb.cc
+++ b/storage/engine/rocksdb/cockroach/roachpb/api.pb.cc
@@ -206,11 +206,10 @@ void protobuf_AssignDesc_cockroach_2froachpb_2fapi_2eproto() {
       GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(ClientCmdID, _internal_metadata_),
       -1);
   RequestHeader_descriptor_ = file->message_type(1);
-  static const int RequestHeader_offsets_[7] = {
+  static const int RequestHeader_offsets_[6] = {
     GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(RequestHeader, cmd_id_),
     GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(RequestHeader, key_),
     GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(RequestHeader, end_key_),
-    GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(RequestHeader, range_id_),
     GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(RequestHeader, user_priority_),
     GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(RequestHeader, txn_),
     GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(RequestHeader, read_consistency_),
@@ -1308,229 +1307,228 @@ void protobuf_AddDesc_cockroach_2froachpb_2fapi_2eproto() {
     "to\032\034cockroach/roachpb/data.proto\032\036cockro"
     "ach/roachpb/errors.proto\032\024gogoproto/gogo"
     ".proto\"<\n\013ClientCmdID\022\027\n\twall_time\030\001 \001(\003"
-    "B\004\310\336\037\000\022\024\n\006random\030\002 \001(\003B\004\310\336\037\000\"\273\002\n\rRequest"
+    "B\004\310\336\037\000\022\024\n\006random\030\002 \001(\003B\004\310\336\037\000\"\215\002\n\rRequest"
     "Header\022=\n\006cmd_id\030\002 \001(\0132\036.cockroach.roach"
     "pb.ClientCmdIDB\r\310\336\037\000\342\336\037\005CmdID\022\024\n\003key\030\003 \001"
-    "(\014B\007\372\336\037\003Key\022\030\n\007end_key\030\004 \001(\014B\007\372\336\037\003Key\022,\n"
-    "\010range_id\030\006 \001(\003B\032\310\336\037\000\342\336\037\007RangeID\372\336\037\007Rang"
-    "eID\022\030\n\ruser_priority\030\007 \001(\005:\0011\022+\n\003txn\030\010 \001"
-    "(\0132\036.cockroach.roachpb.Transaction\022F\n\020re"
-    "ad_consistency\030\t \001(\0162&.cockroach.roachpb"
-    ".ReadConsistencyTypeB\004\310\336\037\000\"t\n\016ResponseHe"
-    "ader\0225\n\ttimestamp\030\002 \001(\0132\034.cockroach.roac"
-    "hpb.TimestampB\004\310\336\037\000\022+\n\003txn\030\003 \001(\0132\036.cockr"
-    "oach.roachpb.Transaction\"H\n\nGetRequest\022:"
-    "\n\006header\030\001 \001(\0132 .cockroach.roachpb.Reque"
-    "stHeaderB\010\310\336\037\000\320\336\037\001\"s\n\013GetResponse\022;\n\006hea"
-    "der\030\001 \001(\0132!.cockroach.roachpb.ResponseHe"
-    "aderB\010\310\336\037\000\320\336\037\001\022\'\n\005value\030\002 \001(\0132\030.cockroac"
-    "h.roachpb.Value\"w\n\nPutRequest\022:\n\006header\030"
-    "\001 \001(\0132 .cockroach.roachpb.RequestHeaderB"
-    "\010\310\336\037\000\320\336\037\001\022-\n\005value\030\002 \001(\0132\030.cockroach.roa"
-    "chpb.ValueB\004\310\336\037\000\"J\n\013PutResponse\022;\n\006heade"
-    "r\030\001 \001(\0132!.cockroach.roachpb.ResponseHead"
-    "erB\010\310\336\037\000\320\336\037\001\"\257\001\n\025ConditionalPutRequest\022:"
-    "\n\006header\030\001 \001(\0132 .cockroach.roachpb.Reque"
-    "stHeaderB\010\310\336\037\000\320\336\037\001\022-\n\005value\030\002 \001(\0132\030.cock"
-    "roach.roachpb.ValueB\004\310\336\037\000\022+\n\texp_value\030\003"
-    " \001(\0132\030.cockroach.roachpb.Value\"U\n\026Condit"
-    "ionalPutResponse\022;\n\006header\030\001 \001(\0132!.cockr"
-    "oach.roachpb.ResponseHeaderB\010\310\336\037\000\320\336\037\001\"g\n"
-    "\020IncrementRequest\022:\n\006header\030\001 \001(\0132 .cock"
-    "roach.roachpb.RequestHeaderB\010\310\336\037\000\320\336\037\001\022\027\n"
-    "\tincrement\030\002 \001(\003B\004\310\336\037\000\"i\n\021IncrementRespo"
-    "nse\022;\n\006header\030\001 \001(\0132!.cockroach.roachpb."
-    "ResponseHeaderB\010\310\336\037\000\320\336\037\001\022\027\n\tnew_value\030\002 "
-    "\001(\003B\004\310\336\037\000\"K\n\rDeleteRequest\022:\n\006header\030\001 \001"
-    "(\0132 .cockroach.roachpb.RequestHeaderB\010\310\336"
-    "\037\000\320\336\037\001\"M\n\016DeleteResponse\022;\n\006header\030\001 \001(\013"
-    "2!.cockroach.roachpb.ResponseHeaderB\010\310\336\037"
-    "\000\320\336\037\001\"u\n\022DeleteRangeRequest\022:\n\006header\030\001 "
-    "\001(\0132 .cockroach.roachpb.RequestHeaderB\010\310"
-    "\336\037\000\320\336\037\001\022#\n\025max_entries_to_delete\030\002 \001(\003B\004"
-    "\310\336\037\000\"m\n\023DeleteRangeResponse\022;\n\006header\030\001 "
+    "(\014B\007\372\336\037\003Key\022\030\n\007end_key\030\004 \001(\014B\007\372\336\037\003Key\022\030\n"
+    "\ruser_priority\030\007 \001(\005:\0011\022+\n\003txn\030\010 \001(\0132\036.c"
+    "ockroach.roachpb.Transaction\022F\n\020read_con"
+    "sistency\030\t \001(\0162&.cockroach.roachpb.ReadC"
+    "onsistencyTypeB\004\310\336\037\000\"t\n\016ResponseHeader\0225"
+    "\n\ttimestamp\030\002 \001(\0132\034.cockroach.roachpb.Ti"
+    "mestampB\004\310\336\037\000\022+\n\003txn\030\003 \001(\0132\036.cockroach.r"
+    "oachpb.Transaction\"H\n\nGetRequest\022:\n\006head"
+    "er\030\001 \001(\0132 .cockroach.roachpb.RequestHead"
+    "erB\010\310\336\037\000\320\336\037\001\"s\n\013GetResponse\022;\n\006header\030\001 "
     "\001(\0132!.cockroach.roachpb.ResponseHeaderB\010"
-    "\310\336\037\000\320\336\037\001\022\031\n\013num_deleted\030\002 \001(\003B\004\310\336\037\000\"d\n\013S"
-    "canRequest\022:\n\006header\030\001 \001(\0132 .cockroach.r"
-    "oachpb.RequestHeaderB\010\310\336\037\000\320\336\037\001\022\031\n\013max_re"
-    "sults\030\002 \001(\003B\004\310\336\037\000\"|\n\014ScanResponse\022;\n\006hea"
-    "der\030\001 \001(\0132!.cockroach.roachpb.ResponseHe"
-    "aderB\010\310\336\037\000\320\336\037\001\022/\n\004rows\030\002 \003(\0132\033.cockroach"
-    ".roachpb.KeyValueB\004\310\336\037\000\"k\n\022ReverseScanRe"
-    "quest\022:\n\006header\030\001 \001(\0132 .cockroach.roachp"
-    "b.RequestHeaderB\010\310\336\037\000\320\336\037\001\022\031\n\013max_results"
-    "\030\002 \001(\003B\004\310\336\037\000\"\203\001\n\023ReverseScanResponse\022;\n\006"
-    "header\030\001 \001(\0132!.cockroach.roachpb.Respons"
-    "eHeaderB\010\310\336\037\000\320\336\037\001\022/\n\004rows\030\002 \003(\0132\033.cockro"
-    "ach.roachpb.KeyValueB\004\310\336\037\000\"\346\001\n\025EndTransa"
-    "ctionRequest\022:\n\006header\030\001 \001(\0132 .cockroach"
-    ".roachpb.RequestHeaderB\010\310\336\037\000\320\336\037\001\022\024\n\006comm"
-    "it\030\002 \001(\010B\004\310\336\037\000\022I\n\027internal_commit_trigge"
-    "r\030\003 \001(\0132(.cockroach.roachpb.InternalComm"
-    "itTrigger\0220\n\007intents\030\004 \003(\0132\031.cockroach.r"
-    "oachpb.IntentB\004\310\336\037\000\"\213\001\n\026EndTransactionRe"
-    "sponse\022;\n\006header\030\001 \001(\0132!.cockroach.roach"
-    "pb.ResponseHeaderB\010\310\336\037\000\320\336\037\001\022\031\n\013commit_wa"
-    "it\030\002 \001(\003B\004\310\336\037\000\022\031\n\010resolved\030\003 \003(\014B\007\372\336\037\003Ke"
-    "y\"k\n\021AdminSplitRequest\022:\n\006header\030\001 \001(\0132 "
-    ".cockroach.roachpb.RequestHeaderB\010\310\336\037\000\320\336"
-    "\037\001\022\032\n\tsplit_key\030\002 \001(\014B\007\372\336\037\003Key\"Q\n\022AdminS"
-    "plitResponse\022;\n\006header\030\001 \001(\0132!.cockroach"
-    ".roachpb.ResponseHeaderB\010\310\336\037\000\320\336\037\001\"O\n\021Adm"
-    "inMergeRequest\022:\n\006header\030\001 \001(\0132 .cockroa"
-    "ch.roachpb.RequestHeaderB\010\310\336\037\000\320\336\037\001\"Q\n\022Ad"
-    "minMergeResponse\022;\n\006header\030\001 \001(\0132!.cockr"
-    "oach.roachpb.ResponseHeaderB\010\310\336\037\000\320\336\037\001\"\241\001"
-    "\n\022RangeLookupRequest\022:\n\006header\030\001 \001(\0132 .c"
-    "ockroach.roachpb.RequestHeaderB\010\310\336\037\000\320\336\037\001"
-    "\022\030\n\nmax_ranges\030\002 \001(\005B\004\310\336\037\000\022\036\n\020consider_i"
-    "ntents\030\003 \001(\010B\004\310\336\037\000\022\025\n\007reverse\030\004 \001(\010B\004\310\336\037"
-    "\000\"\214\001\n\023RangeLookupResponse\022;\n\006header\030\001 \001("
+    "\310\336\037\000\320\336\037\001\022\'\n\005value\030\002 \001(\0132\030.cockroach.roac"
+    "hpb.Value\"w\n\nPutRequest\022:\n\006header\030\001 \001(\0132"
+    " .cockroach.roachpb.RequestHeaderB\010\310\336\037\000\320"
+    "\336\037\001\022-\n\005value\030\002 \001(\0132\030.cockroach.roachpb.V"
+    "alueB\004\310\336\037\000\"J\n\013PutResponse\022;\n\006header\030\001 \001("
     "\0132!.cockroach.roachpb.ResponseHeaderB\010\310\336"
-    "\037\000\320\336\037\001\0228\n\006ranges\030\002 \003(\0132\".cockroach.roach"
-    "pb.RangeDescriptorB\004\310\336\037\000\"Q\n\023HeartbeatTxn"
-    "Request\022:\n\006header\030\001 \001(\0132 .cockroach.roac"
-    "hpb.RequestHeaderB\010\310\336\037\000\320\336\037\001\"S\n\024Heartbeat"
-    "TxnResponse\022;\n\006header\030\001 \001(\0132!.cockroach."
-    "roachpb.ResponseHeaderB\010\310\336\037\000\320\336\037\001\"\225\002\n\tGCR"
+    "\037\000\320\336\037\001\"\257\001\n\025ConditionalPutRequest\022:\n\006head"
+    "er\030\001 \001(\0132 .cockroach.roachpb.RequestHead"
+    "erB\010\310\336\037\000\320\336\037\001\022-\n\005value\030\002 \001(\0132\030.cockroach."
+    "roachpb.ValueB\004\310\336\037\000\022+\n\texp_value\030\003 \001(\0132\030"
+    ".cockroach.roachpb.Value\"U\n\026ConditionalP"
+    "utResponse\022;\n\006header\030\001 \001(\0132!.cockroach.r"
+    "oachpb.ResponseHeaderB\010\310\336\037\000\320\336\037\001\"g\n\020Incre"
+    "mentRequest\022:\n\006header\030\001 \001(\0132 .cockroach."
+    "roachpb.RequestHeaderB\010\310\336\037\000\320\336\037\001\022\027\n\tincre"
+    "ment\030\002 \001(\003B\004\310\336\037\000\"i\n\021IncrementResponse\022;\n"
+    "\006header\030\001 \001(\0132!.cockroach.roachpb.Respon"
+    "seHeaderB\010\310\336\037\000\320\336\037\001\022\027\n\tnew_value\030\002 \001(\003B\004\310"
+    "\336\037\000\"K\n\rDeleteRequest\022:\n\006header\030\001 \001(\0132 .c"
+    "ockroach.roachpb.RequestHeaderB\010\310\336\037\000\320\336\037\001"
+    "\"M\n\016DeleteResponse\022;\n\006header\030\001 \001(\0132!.coc"
+    "kroach.roachpb.ResponseHeaderB\010\310\336\037\000\320\336\037\001\""
+    "u\n\022DeleteRangeRequest\022:\n\006header\030\001 \001(\0132 ."
+    "cockroach.roachpb.RequestHeaderB\010\310\336\037\000\320\336\037"
+    "\001\022#\n\025max_entries_to_delete\030\002 \001(\003B\004\310\336\037\000\"m"
+    "\n\023DeleteRangeResponse\022;\n\006header\030\001 \001(\0132!."
+    "cockroach.roachpb.ResponseHeaderB\010\310\336\037\000\320\336"
+    "\037\001\022\031\n\013num_deleted\030\002 \001(\003B\004\310\336\037\000\"d\n\013ScanReq"
+    "uest\022:\n\006header\030\001 \001(\0132 .cockroach.roachpb"
+    ".RequestHeaderB\010\310\336\037\000\320\336\037\001\022\031\n\013max_results\030"
+    "\002 \001(\003B\004\310\336\037\000\"|\n\014ScanResponse\022;\n\006header\030\001 "
+    "\001(\0132!.cockroach.roachpb.ResponseHeaderB\010"
+    "\310\336\037\000\320\336\037\001\022/\n\004rows\030\002 \003(\0132\033.cockroach.roach"
+    "pb.KeyValueB\004\310\336\037\000\"k\n\022ReverseScanRequest\022"
+    ":\n\006header\030\001 \001(\0132 .cockroach.roachpb.Requ"
+    "estHeaderB\010\310\336\037\000\320\336\037\001\022\031\n\013max_results\030\002 \001(\003"
+    "B\004\310\336\037\000\"\203\001\n\023ReverseScanResponse\022;\n\006header"
+    "\030\001 \001(\0132!.cockroach.roachpb.ResponseHeade"
+    "rB\010\310\336\037\000\320\336\037\001\022/\n\004rows\030\002 \003(\0132\033.cockroach.ro"
+    "achpb.KeyValueB\004\310\336\037\000\"\346\001\n\025EndTransactionR"
     "equest\022:\n\006header\030\001 \001(\0132 .cockroach.roach"
-    "pb.RequestHeaderB\010\310\336\037\000\320\336\037\001\022>\n\007gc_meta\030\002 "
-    "\001(\0132\035.cockroach.roachpb.GCMetadataB\016\310\336\037\000"
-    "\342\336\037\006GCMeta\0226\n\004keys\030\003 \003(\0132\".cockroach.roa"
-    "chpb.GCRequest.GCKeyB\004\310\336\037\000\032T\n\005GCKey\022\024\n\003k"
-    "ey\030\001 \001(\014B\007\372\336\037\003Key\0225\n\ttimestamp\030\002 \001(\0132\034.c"
-    "ockroach.roachpb.TimestampB\004\310\336\037\000\"I\n\nGCRe"
+    "pb.RequestHeaderB\010\310\336\037\000\320\336\037\001\022\024\n\006commit\030\002 \001"
+    "(\010B\004\310\336\037\000\022I\n\027internal_commit_trigger\030\003 \001("
+    "\0132(.cockroach.roachpb.InternalCommitTrig"
+    "ger\0220\n\007intents\030\004 \003(\0132\031.cockroach.roachpb"
+    ".IntentB\004\310\336\037\000\"\213\001\n\026EndTransactionResponse"
+    "\022;\n\006header\030\001 \001(\0132!.cockroach.roachpb.Res"
+    "ponseHeaderB\010\310\336\037\000\320\336\037\001\022\031\n\013commit_wait\030\002 \001"
+    "(\003B\004\310\336\037\000\022\031\n\010resolved\030\003 \003(\014B\007\372\336\037\003Key\"k\n\021A"
+    "dminSplitRequest\022:\n\006header\030\001 \001(\0132 .cockr"
+    "oach.roachpb.RequestHeaderB\010\310\336\037\000\320\336\037\001\022\032\n\t"
+    "split_key\030\002 \001(\014B\007\372\336\037\003Key\"Q\n\022AdminSplitRe"
     "sponse\022;\n\006header\030\001 \001(\0132!.cockroach.roach"
-    "pb.ResponseHeaderB\010\310\336\037\000\320\336\037\001\"\337\002\n\016PushTxnR"
-    "equest\022:\n\006header\030\001 \001(\0132 .cockroach.roach"
-    "pb.RequestHeaderB\010\310\336\037\000\320\336\037\001\0228\n\npusher_txn"
-    "\030\002 \001(\0132\036.cockroach.roachpb.TransactionB\004"
-    "\310\336\037\000\0228\n\npushee_txn\030\003 \001(\0132\036.cockroach.roa"
-    "chpb.TransactionB\004\310\336\037\000\0223\n\007push_to\030\004 \001(\0132"
-    "\034.cockroach.roachpb.TimestampB\004\310\336\037\000\022/\n\003n"
-    "ow\030\005 \001(\0132\034.cockroach.roachpb.TimestampB\004"
-    "\310\336\037\000\0227\n\tpush_type\030\006 \001(\0162\036.cockroach.roac"
-    "hpb.PushTxnTypeB\004\310\336\037\000\"\202\001\n\017PushTxnRespons"
-    "e\022;\n\006header\030\001 \001(\0132!.cockroach.roachpb.Re"
-    "sponseHeaderB\010\310\336\037\000\320\336\037\001\0222\n\npushee_txn\030\002 \001"
-    "(\0132\036.cockroach.roachpb.Transaction\"\214\001\n\024R"
-    "esolveIntentRequest\022:\n\006header\030\001 \001(\0132 .co"
-    "ckroach.roachpb.RequestHeaderB\010\310\336\037\000\320\336\037\001\022"
-    "8\n\nintent_txn\030\002 \001(\0132\036.cockroach.roachpb."
-    "TransactionB\004\310\336\037\000\"T\n\025ResolveIntentRespon"
-    "se\022;\n\006header\030\001 \001(\0132!.cockroach.roachpb.R"
-    "esponseHeaderB\010\310\336\037\000\320\336\037\001\"\221\001\n\031ResolveInten"
-    "tRangeRequest\022:\n\006header\030\001 \001(\0132 .cockroac"
+    "pb.ResponseHeaderB\010\310\336\037\000\320\336\037\001\"O\n\021AdminMerg"
+    "eRequest\022:\n\006header\030\001 \001(\0132 .cockroach.roa"
+    "chpb.RequestHeaderB\010\310\336\037\000\320\336\037\001\"Q\n\022AdminMer"
+    "geResponse\022;\n\006header\030\001 \001(\0132!.cockroach.r"
+    "oachpb.ResponseHeaderB\010\310\336\037\000\320\336\037\001\"\241\001\n\022Rang"
+    "eLookupRequest\022:\n\006header\030\001 \001(\0132 .cockroa"
+    "ch.roachpb.RequestHeaderB\010\310\336\037\000\320\336\037\001\022\030\n\nma"
+    "x_ranges\030\002 \001(\005B\004\310\336\037\000\022\036\n\020consider_intents"
+    "\030\003 \001(\010B\004\310\336\037\000\022\025\n\007reverse\030\004 \001(\010B\004\310\336\037\000\"\214\001\n\023"
+    "RangeLookupResponse\022;\n\006header\030\001 \001(\0132!.co"
+    "ckroach.roachpb.ResponseHeaderB\010\310\336\037\000\320\336\037\001"
+    "\0228\n\006ranges\030\002 \003(\0132\".cockroach.roachpb.Ran"
+    "geDescriptorB\004\310\336\037\000\"Q\n\023HeartbeatTxnReques"
+    "t\022:\n\006header\030\001 \001(\0132 .cockroach.roachpb.Re"
+    "questHeaderB\010\310\336\037\000\320\336\037\001\"S\n\024HeartbeatTxnRes"
+    "ponse\022;\n\006header\030\001 \001(\0132!.cockroach.roachp"
+    "b.ResponseHeaderB\010\310\336\037\000\320\336\037\001\"\225\002\n\tGCRequest"
+    "\022:\n\006header\030\001 \001(\0132 .cockroach.roachpb.Req"
+    "uestHeaderB\010\310\336\037\000\320\336\037\001\022>\n\007gc_meta\030\002 \001(\0132\035."
+    "cockroach.roachpb.GCMetadataB\016\310\336\037\000\342\336\037\006GC"
+    "Meta\0226\n\004keys\030\003 \003(\0132\".cockroach.roachpb.G"
+    "CRequest.GCKeyB\004\310\336\037\000\032T\n\005GCKey\022\024\n\003key\030\001 \001"
+    "(\014B\007\372\336\037\003Key\0225\n\ttimestamp\030\002 \001(\0132\034.cockroa"
+    "ch.roachpb.TimestampB\004\310\336\037\000\"I\n\nGCResponse"
+    "\022;\n\006header\030\001 \001(\0132!.cockroach.roachpb.Res"
+    "ponseHeaderB\010\310\336\037\000\320\336\037\001\"\337\002\n\016PushTxnRequest"
+    "\022:\n\006header\030\001 \001(\0132 .cockroach.roachpb.Req"
+    "uestHeaderB\010\310\336\037\000\320\336\037\001\0228\n\npusher_txn\030\002 \001(\013"
+    "2\036.cockroach.roachpb.TransactionB\004\310\336\037\000\0228"
+    "\n\npushee_txn\030\003 \001(\0132\036.cockroach.roachpb.T"
+    "ransactionB\004\310\336\037\000\0223\n\007push_to\030\004 \001(\0132\034.cock"
+    "roach.roachpb.TimestampB\004\310\336\037\000\022/\n\003now\030\005 \001"
+    "(\0132\034.cockroach.roachpb.TimestampB\004\310\336\037\000\0227"
+    "\n\tpush_type\030\006 \001(\0162\036.cockroach.roachpb.Pu"
+    "shTxnTypeB\004\310\336\037\000\"\202\001\n\017PushTxnResponse\022;\n\006h"
+    "eader\030\001 \001(\0132!.cockroach.roachpb.Response"
+    "HeaderB\010\310\336\037\000\320\336\037\001\0222\n\npushee_txn\030\002 \001(\0132\036.c"
+    "ockroach.roachpb.Transaction\"\214\001\n\024Resolve"
+    "IntentRequest\022:\n\006header\030\001 \001(\0132 .cockroac"
     "h.roachpb.RequestHeaderB\010\310\336\037\000\320\336\037\001\0228\n\nint"
     "ent_txn\030\002 \001(\0132\036.cockroach.roachpb.Transa"
-    "ctionB\004\310\336\037\000\"K\n\014NoopResponse\022;\n\006header\030\001 "
-    "\001(\0132!.cockroach.roachpb.ResponseHeaderB\010"
-    "\310\336\037\000\320\336\037\001\"I\n\013NoopRequest\022:\n\006header\030\001 \001(\0132"
-    " .cockroach.roachpb.RequestHeaderB\010\310\336\037\000\320"
-    "\336\037\001\"Y\n\032ResolveIntentRangeResponse\022;\n\006hea"
-    "der\030\001 \001(\0132!.cockroach.roachpb.ResponseHe"
-    "aderB\010\310\336\037\000\320\336\037\001\"y\n\014MergeRequest\022:\n\006header"
-    "\030\001 \001(\0132 .cockroach.roachpb.RequestHeader"
-    "B\010\310\336\037\000\320\336\037\001\022-\n\005value\030\002 \001(\0132\030.cockroach.ro"
-    "achpb.ValueB\004\310\336\037\000\"L\n\rMergeResponse\022;\n\006he"
-    "ader\030\001 \001(\0132!.cockroach.roachpb.ResponseH"
-    "eaderB\010\310\336\037\000\320\336\037\001\"e\n\022TruncateLogRequest\022:\n"
-    "\006header\030\001 \001(\0132 .cockroach.roachpb.Reques"
-    "tHeaderB\010\310\336\037\000\320\336\037\001\022\023\n\005index\030\002 \001(\004B\004\310\336\037\000\"R"
-    "\n\023TruncateLogResponse\022;\n\006header\030\001 \001(\0132!."
+    "ctionB\004\310\336\037\000\"T\n\025ResolveIntentResponse\022;\n\006"
+    "header\030\001 \001(\0132!.cockroach.roachpb.Respons"
+    "eHeaderB\010\310\336\037\000\320\336\037\001\"\221\001\n\031ResolveIntentRange"
+    "Request\022:\n\006header\030\001 \001(\0132 .cockroach.roac"
+    "hpb.RequestHeaderB\010\310\336\037\000\320\336\037\001\0228\n\nintent_tx"
+    "n\030\002 \001(\0132\036.cockroach.roachpb.TransactionB"
+    "\004\310\336\037\000\"K\n\014NoopResponse\022;\n\006header\030\001 \001(\0132!."
     "cockroach.roachpb.ResponseHeaderB\010\310\336\037\000\320\336"
-    "\037\001\"\177\n\022LeaderLeaseRequest\022:\n\006header\030\001 \001(\013"
+    "\037\001\"I\n\013NoopRequest\022:\n\006header\030\001 \001(\0132 .cock"
+    "roach.roachpb.RequestHeaderB\010\310\336\037\000\320\336\037\001\"Y\n"
+    "\032ResolveIntentRangeResponse\022;\n\006header\030\001 "
+    "\001(\0132!.cockroach.roachpb.ResponseHeaderB\010"
+    "\310\336\037\000\320\336\037\001\"y\n\014MergeRequest\022:\n\006header\030\001 \001(\013"
     "2 .cockroach.roachpb.RequestHeaderB\010\310\336\037\000"
-    "\320\336\037\001\022-\n\005lease\030\002 \001(\0132\030.cockroach.roachpb."
-    "LeaseB\004\310\336\037\000\"R\n\023LeaderLeaseResponse\022;\n\006he"
-    "ader\030\001 \001(\0132!.cockroach.roachpb.ResponseH"
-    "eaderB\010\310\336\037\000\320\336\037\001\"\272\t\n\014RequestUnion\022*\n\003get\030"
-    "\001 \001(\0132\035.cockroach.roachpb.GetRequest\022*\n\003"
-    "put\030\002 \001(\0132\035.cockroach.roachpb.PutRequest"
-    "\022A\n\017conditional_put\030\003 \001(\0132(.cockroach.ro"
-    "achpb.ConditionalPutRequest\0226\n\tincrement"
-    "\030\004 \001(\0132#.cockroach.roachpb.IncrementRequ"
-    "est\0220\n\006delete\030\005 \001(\0132 .cockroach.roachpb."
-    "DeleteRequest\022;\n\014delete_range\030\006 \001(\0132%.co"
-    "ckroach.roachpb.DeleteRangeRequest\022,\n\004sc"
-    "an\030\007 \001(\0132\036.cockroach.roachpb.ScanRequest"
-    "\022A\n\017end_transaction\030\010 \001(\0132(.cockroach.ro"
-    "achpb.EndTransactionRequest\0229\n\013admin_spl"
-    "it\030\t \001(\0132$.cockroach.roachpb.AdminSplitR"
-    "equest\0229\n\013admin_merge\030\n \001(\0132$.cockroach."
-    "roachpb.AdminMergeRequest\022=\n\rheartbeat_t"
-    "xn\030\013 \001(\0132&.cockroach.roachpb.HeartbeatTx"
-    "nRequest\022(\n\002gc\030\014 \001(\0132\034.cockroach.roachpb"
-    ".GCRequest\0223\n\010push_txn\030\r \001(\0132!.cockroach"
-    ".roachpb.PushTxnRequest\022;\n\014range_lookup\030"
-    "\016 \001(\0132%.cockroach.roachpb.RangeLookupReq"
-    "uest\022\?\n\016resolve_intent\030\017 \001(\0132\'.cockroach"
-    ".roachpb.ResolveIntentRequest\022J\n\024resolve"
-    "_intent_range\030\020 \001(\0132,.cockroach.roachpb."
-    "ResolveIntentRangeRequest\022.\n\005merge\030\021 \001(\013"
-    "2\037.cockroach.roachpb.MergeRequest\022;\n\014tru"
-    "ncate_log\030\022 \001(\0132%.cockroach.roachpb.Trun"
-    "cateLogRequest\022;\n\014leader_lease\030\023 \001(\0132%.c"
-    "ockroach.roachpb.LeaderLeaseRequest\022;\n\014r"
-    "everse_scan\030\024 \001(\0132%.cockroach.roachpb.Re"
-    "verseScanRequest\022,\n\004noop\030\025 \001(\0132\036.cockroa"
-    "ch.roachpb.NoopRequest:\004\310\240\037\001\"\320\t\n\rRespons"
-    "eUnion\022+\n\003get\030\001 \001(\0132\036.cockroach.roachpb."
-    "GetResponse\022+\n\003put\030\002 \001(\0132\036.cockroach.roa"
-    "chpb.PutResponse\022B\n\017conditional_put\030\003 \001("
-    "\0132).cockroach.roachpb.ConditionalPutResp"
-    "onse\0227\n\tincrement\030\004 \001(\0132$.cockroach.roac"
-    "hpb.IncrementResponse\0221\n\006delete\030\005 \001(\0132!."
-    "cockroach.roachpb.DeleteResponse\022<\n\014dele"
-    "te_range\030\006 \001(\0132&.cockroach.roachpb.Delet"
-    "eRangeResponse\022-\n\004scan\030\007 \001(\0132\037.cockroach"
-    ".roachpb.ScanResponse\022B\n\017end_transaction"
-    "\030\010 \001(\0132).cockroach.roachpb.EndTransactio"
-    "nResponse\022:\n\013admin_split\030\t \001(\0132%.cockroa"
-    "ch.roachpb.AdminSplitResponse\022:\n\013admin_m"
-    "erge\030\n \001(\0132%.cockroach.roachpb.AdminMerg"
-    "eResponse\022>\n\rheartbeat_txn\030\013 \001(\0132\'.cockr"
-    "oach.roachpb.HeartbeatTxnResponse\022)\n\002gc\030"
-    "\014 \001(\0132\035.cockroach.roachpb.GCResponse\0224\n\010"
-    "push_txn\030\r \001(\0132\".cockroach.roachpb.PushT"
-    "xnResponse\022<\n\014range_lookup\030\016 \001(\0132&.cockr"
-    "oach.roachpb.RangeLookupResponse\022@\n\016reso"
-    "lve_intent\030\017 \001(\0132(.cockroach.roachpb.Res"
-    "olveIntentResponse\022K\n\024resolve_intent_ran"
-    "ge\030\020 \001(\0132-.cockroach.roachpb.ResolveInte"
-    "ntRangeResponse\022/\n\005merge\030\021 \001(\0132 .cockroa"
-    "ch.roachpb.MergeResponse\022<\n\014truncate_log"
-    "\030\022 \001(\0132&.cockroach.roachpb.TruncateLogRe"
-    "sponse\022<\n\014leader_lease\030\023 \001(\0132&.cockroach"
-    ".roachpb.LeaderLeaseResponse\022<\n\014reverse_"
-    "scan\030\024 \001(\0132&.cockroach.roachpb.ReverseSc"
-    "anResponse\022-\n\004noop\030\025 \001(\0132\037.cockroach.roa"
-    "chpb.NoopResponse:\004\310\240\037\001\"\212\004\n\014BatchRequest"
-    "\022@\n\006header\030\001 \001(\0132&.cockroach.roachpb.Bat"
-    "chRequest.HeaderB\010\310\336\037\000\320\336\037\001\0227\n\010requests\030\002"
-    " \003(\0132\037.cockroach.roachpb.RequestUnionB\004\310"
-    "\336\037\000\032\370\002\n\006Header\0225\n\ttimestamp\030\001 \001(\0132\034.cock"
-    "roach.roachpb.TimestampB\004\310\336\037\000\022=\n\006cmd_id\030"
-    "\002 \001(\0132\036.cockroach.roachpb.ClientCmdIDB\r\310"
-    "\336\037\000\342\336\037\005CmdID\022;\n\007replica\030\005 \001(\0132$.cockroac"
-    "h.roachpb.ReplicaDescriptorB\004\310\336\037\000\022,\n\010ran"
-    "ge_id\030\006 \001(\003B\032\310\336\037\000\342\336\037\007RangeID\372\336\037\007RangeID\022"
-    "\030\n\ruser_priority\030\007 \001(\005:\0011\022+\n\003txn\030\010 \001(\0132\036"
-    ".cockroach.roachpb.Transaction\022F\n\020read_c"
-    "onsistency\030\t \001(\0162&.cockroach.roachpb.Rea"
-    "dConsistencyTypeB\004\310\336\037\000:\004\230\240\037\000\"\245\002\n\rBatchRe"
-    "sponse\022A\n\006header\030\001 \001(\0132\'.cockroach.roach"
-    "pb.BatchResponse.HeaderB\010\310\336\037\000\320\336\037\001\0229\n\tres"
-    "ponses\030\002 \003(\0132 .cockroach.roachpb.Respons"
-    "eUnionB\004\310\336\037\000\032\225\001\n\006Header\022\'\n\005error\030\001 \001(\0132\030"
-    ".cockroach.roachpb.Error\0225\n\ttimestamp\030\002 "
-    "\001(\0132\034.cockroach.roachpb.TimestampB\004\310\336\037\000\022"
-    "+\n\003txn\030\003 \001(\0132\036.cockroach.roachpb.Transac"
-    "tion*L\n\023ReadConsistencyType\022\016\n\nCONSISTEN"
-    "T\020\000\022\r\n\tCONSENSUS\020\001\022\020\n\014INCONSISTENT\020\002\032\004\210\243"
-    "\036\000*G\n\013PushTxnType\022\022\n\016PUSH_TIMESTAMP\020\000\022\r\n"
-    "\tABORT_TXN\020\001\022\017\n\013CLEANUP_TXN\020\002\032\004\210\243\036\000B\031Z\007r"
-    "oachpb\340\342\036\001\310\342\036\001\320\342\036\001\220\343\036\000", 9102);
+    "\320\336\037\001\022-\n\005value\030\002 \001(\0132\030.cockroach.roachpb."
+    "ValueB\004\310\336\037\000\"L\n\rMergeResponse\022;\n\006header\030\001"
+    " \001(\0132!.cockroach.roachpb.ResponseHeaderB"
+    "\010\310\336\037\000\320\336\037\001\"e\n\022TruncateLogRequest\022:\n\006heade"
+    "r\030\001 \001(\0132 .cockroach.roachpb.RequestHeade"
+    "rB\010\310\336\037\000\320\336\037\001\022\023\n\005index\030\002 \001(\004B\004\310\336\037\000\"R\n\023Trun"
+    "cateLogResponse\022;\n\006header\030\001 \001(\0132!.cockro"
+    "ach.roachpb.ResponseHeaderB\010\310\336\037\000\320\336\037\001\"\177\n\022"
+    "LeaderLeaseRequest\022:\n\006header\030\001 \001(\0132 .coc"
+    "kroach.roachpb.RequestHeaderB\010\310\336\037\000\320\336\037\001\022-"
+    "\n\005lease\030\002 \001(\0132\030.cockroach.roachpb.LeaseB"
+    "\004\310\336\037\000\"R\n\023LeaderLeaseResponse\022;\n\006header\030\001"
+    " \001(\0132!.cockroach.roachpb.ResponseHeaderB"
+    "\010\310\336\037\000\320\336\037\001\"\272\t\n\014RequestUnion\022*\n\003get\030\001 \001(\0132"
+    "\035.cockroach.roachpb.GetRequest\022*\n\003put\030\002 "
+    "\001(\0132\035.cockroach.roachpb.PutRequest\022A\n\017co"
+    "nditional_put\030\003 \001(\0132(.cockroach.roachpb."
+    "ConditionalPutRequest\0226\n\tincrement\030\004 \001(\013"
+    "2#.cockroach.roachpb.IncrementRequest\0220\n"
+    "\006delete\030\005 \001(\0132 .cockroach.roachpb.Delete"
+    "Request\022;\n\014delete_range\030\006 \001(\0132%.cockroac"
+    "h.roachpb.DeleteRangeRequest\022,\n\004scan\030\007 \001"
+    "(\0132\036.cockroach.roachpb.ScanRequest\022A\n\017en"
+    "d_transaction\030\010 \001(\0132(.cockroach.roachpb."
+    "EndTransactionRequest\0229\n\013admin_split\030\t \001"
+    "(\0132$.cockroach.roachpb.AdminSplitRequest"
+    "\0229\n\013admin_merge\030\n \001(\0132$.cockroach.roachp"
+    "b.AdminMergeRequest\022=\n\rheartbeat_txn\030\013 \001"
+    "(\0132&.cockroach.roachpb.HeartbeatTxnReque"
+    "st\022(\n\002gc\030\014 \001(\0132\034.cockroach.roachpb.GCReq"
+    "uest\0223\n\010push_txn\030\r \001(\0132!.cockroach.roach"
+    "pb.PushTxnRequest\022;\n\014range_lookup\030\016 \001(\0132"
+    "%.cockroach.roachpb.RangeLookupRequest\022\?"
+    "\n\016resolve_intent\030\017 \001(\0132\'.cockroach.roach"
+    "pb.ResolveIntentRequest\022J\n\024resolve_inten"
+    "t_range\030\020 \001(\0132,.cockroach.roachpb.Resolv"
+    "eIntentRangeRequest\022.\n\005merge\030\021 \001(\0132\037.coc"
+    "kroach.roachpb.MergeRequest\022;\n\014truncate_"
+    "log\030\022 \001(\0132%.cockroach.roachpb.TruncateLo"
+    "gRequest\022;\n\014leader_lease\030\023 \001(\0132%.cockroa"
+    "ch.roachpb.LeaderLeaseRequest\022;\n\014reverse"
+    "_scan\030\024 \001(\0132%.cockroach.roachpb.ReverseS"
+    "canRequest\022,\n\004noop\030\025 \001(\0132\036.cockroach.roa"
+    "chpb.NoopRequest:\004\310\240\037\001\"\320\t\n\rResponseUnion"
+    "\022+\n\003get\030\001 \001(\0132\036.cockroach.roachpb.GetRes"
+    "ponse\022+\n\003put\030\002 \001(\0132\036.cockroach.roachpb.P"
+    "utResponse\022B\n\017conditional_put\030\003 \001(\0132).co"
+    "ckroach.roachpb.ConditionalPutResponse\0227"
+    "\n\tincrement\030\004 \001(\0132$.cockroach.roachpb.In"
+    "crementResponse\0221\n\006delete\030\005 \001(\0132!.cockro"
+    "ach.roachpb.DeleteResponse\022<\n\014delete_ran"
+    "ge\030\006 \001(\0132&.cockroach.roachpb.DeleteRange"
+    "Response\022-\n\004scan\030\007 \001(\0132\037.cockroach.roach"
+    "pb.ScanResponse\022B\n\017end_transaction\030\010 \001(\013"
+    "2).cockroach.roachpb.EndTransactionRespo"
+    "nse\022:\n\013admin_split\030\t \001(\0132%.cockroach.roa"
+    "chpb.AdminSplitResponse\022:\n\013admin_merge\030\n"
+    " \001(\0132%.cockroach.roachpb.AdminMergeRespo"
+    "nse\022>\n\rheartbeat_txn\030\013 \001(\0132\'.cockroach.r"
+    "oachpb.HeartbeatTxnResponse\022)\n\002gc\030\014 \001(\0132"
+    "\035.cockroach.roachpb.GCResponse\0224\n\010push_t"
+    "xn\030\r \001(\0132\".cockroach.roachpb.PushTxnResp"
+    "onse\022<\n\014range_lookup\030\016 \001(\0132&.cockroach.r"
+    "oachpb.RangeLookupResponse\022@\n\016resolve_in"
+    "tent\030\017 \001(\0132(.cockroach.roachpb.ResolveIn"
+    "tentResponse\022K\n\024resolve_intent_range\030\020 \001"
+    "(\0132-.cockroach.roachpb.ResolveIntentRang"
+    "eResponse\022/\n\005merge\030\021 \001(\0132 .cockroach.roa"
+    "chpb.MergeResponse\022<\n\014truncate_log\030\022 \001(\013"
+    "2&.cockroach.roachpb.TruncateLogResponse"
+    "\022<\n\014leader_lease\030\023 \001(\0132&.cockroach.roach"
+    "pb.LeaderLeaseResponse\022<\n\014reverse_scan\030\024"
+    " \001(\0132&.cockroach.roachpb.ReverseScanResp"
+    "onse\022-\n\004noop\030\025 \001(\0132\037.cockroach.roachpb.N"
+    "oopResponse:\004\310\240\037\001\"\212\004\n\014BatchRequest\022@\n\006he"
+    "ader\030\001 \001(\0132&.cockroach.roachpb.BatchRequ"
+    "est.HeaderB\010\310\336\037\000\320\336\037\001\0227\n\010requests\030\002 \003(\0132\037"
+    ".cockroach.roachpb.RequestUnionB\004\310\336\037\000\032\370\002"
+    "\n\006Header\0225\n\ttimestamp\030\001 \001(\0132\034.cockroach."
+    "roachpb.TimestampB\004\310\336\037\000\022=\n\006cmd_id\030\002 \001(\0132"
+    "\036.cockroach.roachpb.ClientCmdIDB\r\310\336\037\000\342\336\037"
+    "\005CmdID\022;\n\007replica\030\005 \001(\0132$.cockroach.roac"
+    "hpb.ReplicaDescriptorB\004\310\336\037\000\022,\n\010range_id\030"
+    "\006 \001(\003B\032\310\336\037\000\342\336\037\007RangeID\372\336\037\007RangeID\022\030\n\ruse"
+    "r_priority\030\007 \001(\005:\0011\022+\n\003txn\030\010 \001(\0132\036.cockr"
+    "oach.roachpb.Transaction\022F\n\020read_consist"
+    "ency\030\t \001(\0162&.cockroach.roachpb.ReadConsi"
+    "stencyTypeB\004\310\336\037\000:\004\230\240\037\000\"\245\002\n\rBatchResponse"
+    "\022A\n\006header\030\001 \001(\0132\'.cockroach.roachpb.Bat"
+    "chResponse.HeaderB\010\310\336\037\000\320\336\037\001\0229\n\tresponses"
+    "\030\002 \003(\0132 .cockroach.roachpb.ResponseUnion"
+    "B\004\310\336\037\000\032\225\001\n\006Header\022\'\n\005error\030\001 \001(\0132\030.cockr"
+    "oach.roachpb.Error\0225\n\ttimestamp\030\002 \001(\0132\034."
+    "cockroach.roachpb.TimestampB\004\310\336\037\000\022+\n\003txn"
+    "\030\003 \001(\0132\036.cockroach.roachpb.Transaction*L"
+    "\n\023ReadConsistencyType\022\016\n\nCONSISTENT\020\000\022\r\n"
+    "\tCONSENSUS\020\001\022\020\n\014INCONSISTENT\020\002\032\004\210\243\036\000*G\n\013"
+    "PushTxnType\022\022\n\016PUSH_TIMESTAMP\020\000\022\r\n\tABORT"
+    "_TXN\020\001\022\017\n\013CLEANUP_TXN\020\002\032\004\210\243\036\000B\031Z\007roachpb"
+    "\340\342\036\001\310\342\036\001\320\342\036\001\220\343\036\000", 9056);
   ::google::protobuf::MessageFactory::InternalRegisterGeneratedFile(
     "cockroach/roachpb/api.proto", &protobuf_RegisterTypes);
   ClientCmdID::default_instance_ = new ClientCmdID();
@@ -2028,7 +2026,6 @@ void ClientCmdID::clear_random() {
 const int RequestHeader::kCmdIdFieldNumber;
 const int RequestHeader::kKeyFieldNumber;
 const int RequestHeader::kEndKeyFieldNumber;
-const int RequestHeader::kRangeIdFieldNumber;
 const int RequestHeader::kUserPriorityFieldNumber;
 const int RequestHeader::kTxnFieldNumber;
 const int RequestHeader::kReadConsistencyFieldNumber;
@@ -2059,7 +2056,6 @@ void RequestHeader::SharedCtor() {
   cmd_id_ = NULL;
   key_.UnsafeSetDefault(&::google::protobuf::internal::GetEmptyStringAlreadyInited());
   end_key_.UnsafeSetDefault(&::google::protobuf::internal::GetEmptyStringAlreadyInited());
-  range_id_ = GOOGLE_LONGLONG(0);
   user_priority_ = 1;
   txn_ = NULL;
   read_consistency_ = 0;
@@ -2106,7 +2102,7 @@ RequestHeader* RequestHeader::New(::google::protobuf::Arena* arena) const {
 }
 
 void RequestHeader::Clear() {
-  if (_has_bits_[0 / 32] & 127u) {
+  if (_has_bits_[0 / 32] & 63u) {
     if (has_cmd_id()) {
       if (cmd_id_ != NULL) cmd_id_->::cockroach::roachpb::ClientCmdID::Clear();
     }
@@ -2116,7 +2112,6 @@ void RequestHeader::Clear() {
     if (has_end_key()) {
       end_key_.ClearToEmptyNoArena(&::google::protobuf::internal::GetEmptyStringAlreadyInited());
     }
-    range_id_ = GOOGLE_LONGLONG(0);
     user_priority_ = 1;
     if (has_txn()) {
       if (txn_ != NULL) txn_->::cockroach::roachpb::Transaction::Clear();
@@ -2170,21 +2165,6 @@ bool RequestHeader::MergePartialFromCodedStream(
          parse_end_key:
           DO_(::google::protobuf::internal::WireFormatLite::ReadBytes(
                 input, this->mutable_end_key()));
-        } else {
-          goto handle_unusual;
-        }
-        if (input->ExpectTag(48)) goto parse_range_id;
-        break;
-      }
-
-      // optional int64 range_id = 6;
-      case 6: {
-        if (tag == 48) {
-         parse_range_id:
-          DO_((::google::protobuf::internal::WireFormatLite::ReadPrimitive<
-                   ::google::protobuf::int64, ::google::protobuf::internal::WireFormatLite::TYPE_INT64>(
-                 input, &range_id_)));
-          set_has_range_id();
         } else {
           goto handle_unusual;
         }
@@ -2283,11 +2263,6 @@ void RequestHeader::SerializeWithCachedSizes(
       4, this->end_key(), output);
   }
 
-  // optional int64 range_id = 6;
-  if (has_range_id()) {
-    ::google::protobuf::internal::WireFormatLite::WriteInt64(6, this->range_id(), output);
-  }
-
   // optional int32 user_priority = 7 [default = 1];
   if (has_user_priority()) {
     ::google::protobuf::internal::WireFormatLite::WriteInt32(7, this->user_priority(), output);
@@ -2336,11 +2311,6 @@ void RequestHeader::SerializeWithCachedSizes(
         4, this->end_key(), target);
   }
 
-  // optional int64 range_id = 6;
-  if (has_range_id()) {
-    target = ::google::protobuf::internal::WireFormatLite::WriteInt64ToArray(6, this->range_id(), target);
-  }
-
   // optional int32 user_priority = 7 [default = 1];
   if (has_user_priority()) {
     target = ::google::protobuf::internal::WireFormatLite::WriteInt32ToArray(7, this->user_priority(), target);
@@ -2370,7 +2340,7 @@ void RequestHeader::SerializeWithCachedSizes(
 int RequestHeader::ByteSize() const {
   int total_size = 0;
 
-  if (_has_bits_[0 / 32] & 127) {
+  if (_has_bits_[0 / 32] & 63) {
     // optional .cockroach.roachpb.ClientCmdID cmd_id = 2;
     if (has_cmd_id()) {
       total_size += 1 +
@@ -2390,13 +2360,6 @@ int RequestHeader::ByteSize() const {
       total_size += 1 +
         ::google::protobuf::internal::WireFormatLite::BytesSize(
           this->end_key());
-    }
-
-    // optional int64 range_id = 6;
-    if (has_range_id()) {
-      total_size += 1 +
-        ::google::protobuf::internal::WireFormatLite::Int64Size(
-          this->range_id());
     }
 
     // optional int32 user_priority = 7 [default = 1];
@@ -2457,9 +2420,6 @@ void RequestHeader::MergeFrom(const RequestHeader& from) {
       set_has_end_key();
       end_key_.AssignWithDefault(&::google::protobuf::internal::GetEmptyStringAlreadyInited(), from.end_key_);
     }
-    if (from.has_range_id()) {
-      set_range_id(from.range_id());
-    }
     if (from.has_user_priority()) {
       set_user_priority(from.user_priority());
     }
@@ -2500,7 +2460,6 @@ void RequestHeader::InternalSwap(RequestHeader* other) {
   std::swap(cmd_id_, other->cmd_id_);
   key_.Swap(&other->key_);
   end_key_.Swap(&other->end_key_);
-  std::swap(range_id_, other->range_id_);
   std::swap(user_priority_, other->user_priority_);
   std::swap(txn_, other->txn_);
   std::swap(read_consistency_, other->read_consistency_);
@@ -2669,39 +2628,15 @@ void RequestHeader::clear_end_key() {
   // @@protoc_insertion_point(field_set_allocated:cockroach.roachpb.RequestHeader.end_key)
 }
 
-// optional int64 range_id = 6;
-bool RequestHeader::has_range_id() const {
-  return (_has_bits_[0] & 0x00000008u) != 0;
-}
-void RequestHeader::set_has_range_id() {
-  _has_bits_[0] |= 0x00000008u;
-}
-void RequestHeader::clear_has_range_id() {
-  _has_bits_[0] &= ~0x00000008u;
-}
-void RequestHeader::clear_range_id() {
-  range_id_ = GOOGLE_LONGLONG(0);
-  clear_has_range_id();
-}
- ::google::protobuf::int64 RequestHeader::range_id() const {
-  // @@protoc_insertion_point(field_get:cockroach.roachpb.RequestHeader.range_id)
-  return range_id_;
-}
- void RequestHeader::set_range_id(::google::protobuf::int64 value) {
-  set_has_range_id();
-  range_id_ = value;
-  // @@protoc_insertion_point(field_set:cockroach.roachpb.RequestHeader.range_id)
-}
-
 // optional int32 user_priority = 7 [default = 1];
 bool RequestHeader::has_user_priority() const {
-  return (_has_bits_[0] & 0x00000010u) != 0;
+  return (_has_bits_[0] & 0x00000008u) != 0;
 }
 void RequestHeader::set_has_user_priority() {
-  _has_bits_[0] |= 0x00000010u;
+  _has_bits_[0] |= 0x00000008u;
 }
 void RequestHeader::clear_has_user_priority() {
-  _has_bits_[0] &= ~0x00000010u;
+  _has_bits_[0] &= ~0x00000008u;
 }
 void RequestHeader::clear_user_priority() {
   user_priority_ = 1;
@@ -2719,13 +2654,13 @@ void RequestHeader::clear_user_priority() {
 
 // optional .cockroach.roachpb.Transaction txn = 8;
 bool RequestHeader::has_txn() const {
-  return (_has_bits_[0] & 0x00000020u) != 0;
+  return (_has_bits_[0] & 0x00000010u) != 0;
 }
 void RequestHeader::set_has_txn() {
-  _has_bits_[0] |= 0x00000020u;
+  _has_bits_[0] |= 0x00000010u;
 }
 void RequestHeader::clear_has_txn() {
-  _has_bits_[0] &= ~0x00000020u;
+  _has_bits_[0] &= ~0x00000010u;
 }
 void RequestHeader::clear_txn() {
   if (txn_ != NULL) txn_->::cockroach::roachpb::Transaction::Clear();
@@ -2762,13 +2697,13 @@ void RequestHeader::clear_txn() {
 
 // optional .cockroach.roachpb.ReadConsistencyType read_consistency = 9;
 bool RequestHeader::has_read_consistency() const {
-  return (_has_bits_[0] & 0x00000040u) != 0;
+  return (_has_bits_[0] & 0x00000020u) != 0;
 }
 void RequestHeader::set_has_read_consistency() {
-  _has_bits_[0] |= 0x00000040u;
+  _has_bits_[0] |= 0x00000020u;
 }
 void RequestHeader::clear_has_read_consistency() {
-  _has_bits_[0] &= ~0x00000040u;
+  _has_bits_[0] &= ~0x00000020u;
 }
 void RequestHeader::clear_read_consistency() {
   read_consistency_ = 0;

--- a/storage/engine/rocksdb/cockroach/roachpb/api.pb.cc
+++ b/storage/engine/rocksdb/cockroach/roachpb/api.pb.cc
@@ -206,10 +206,9 @@ void protobuf_AssignDesc_cockroach_2froachpb_2fapi_2eproto() {
       GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(ClientCmdID, _internal_metadata_),
       -1);
   RequestHeader_descriptor_ = file->message_type(1);
-  static const int RequestHeader_offsets_[4] = {
+  static const int RequestHeader_offsets_[3] = {
     GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(RequestHeader, key_),
     GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(RequestHeader, end_key_),
-    GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(RequestHeader, user_priority_),
     GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(RequestHeader, txn_),
   };
   RequestHeader_reflection_ =
@@ -1305,225 +1304,224 @@ void protobuf_AddDesc_cockroach_2froachpb_2fapi_2eproto() {
     "to\032\034cockroach/roachpb/data.proto\032\036cockro"
     "ach/roachpb/errors.proto\032\024gogoproto/gogo"
     ".proto\"<\n\013ClientCmdID\022\027\n\twall_time\030\001 \001(\003"
-    "B\004\310\336\037\000\022\024\n\006random\030\002 \001(\003B\004\310\336\037\000\"\206\001\n\rRequest"
-    "Header\022\024\n\003key\030\003 \001(\014B\007\372\336\037\003Key\022\030\n\007end_key\030"
-    "\004 \001(\014B\007\372\336\037\003Key\022\030\n\ruser_priority\030\007 \001(\005:\0011"
-    "\022+\n\003txn\030\010 \001(\0132\036.cockroach.roachpb.Transa"
-    "ction\"t\n\016ResponseHeader\0225\n\ttimestamp\030\002 \001"
-    "(\0132\034.cockroach.roachpb.TimestampB\004\310\336\037\000\022+"
-    "\n\003txn\030\003 \001(\0132\036.cockroach.roachpb.Transact"
-    "ion\"H\n\nGetRequest\022:\n\006header\030\001 \001(\0132 .cock"
-    "roach.roachpb.RequestHeaderB\010\310\336\037\000\320\336\037\001\"s\n"
-    "\013GetResponse\022;\n\006header\030\001 \001(\0132!.cockroach"
-    ".roachpb.ResponseHeaderB\010\310\336\037\000\320\336\037\001\022\'\n\005val"
-    "ue\030\002 \001(\0132\030.cockroach.roachpb.Value\"w\n\nPu"
-    "tRequest\022:\n\006header\030\001 \001(\0132 .cockroach.roa"
-    "chpb.RequestHeaderB\010\310\336\037\000\320\336\037\001\022-\n\005value\030\002 "
-    "\001(\0132\030.cockroach.roachpb.ValueB\004\310\336\037\000\"J\n\013P"
-    "utResponse\022;\n\006header\030\001 \001(\0132!.cockroach.r"
-    "oachpb.ResponseHeaderB\010\310\336\037\000\320\336\037\001\"\257\001\n\025Cond"
-    "itionalPutRequest\022:\n\006header\030\001 \001(\0132 .cock"
-    "roach.roachpb.RequestHeaderB\010\310\336\037\000\320\336\037\001\022-\n"
-    "\005value\030\002 \001(\0132\030.cockroach.roachpb.ValueB\004"
-    "\310\336\037\000\022+\n\texp_value\030\003 \001(\0132\030.cockroach.roac"
-    "hpb.Value\"U\n\026ConditionalPutResponse\022;\n\006h"
-    "eader\030\001 \001(\0132!.cockroach.roachpb.Response"
-    "HeaderB\010\310\336\037\000\320\336\037\001\"g\n\020IncrementRequest\022:\n\006"
-    "header\030\001 \001(\0132 .cockroach.roachpb.Request"
-    "HeaderB\010\310\336\037\000\320\336\037\001\022\027\n\tincrement\030\002 \001(\003B\004\310\336\037"
-    "\000\"i\n\021IncrementResponse\022;\n\006header\030\001 \001(\0132!"
-    ".cockroach.roachpb.ResponseHeaderB\010\310\336\037\000\320"
-    "\336\037\001\022\027\n\tnew_value\030\002 \001(\003B\004\310\336\037\000\"K\n\rDeleteRe"
-    "quest\022:\n\006header\030\001 \001(\0132 .cockroach.roachp"
-    "b.RequestHeaderB\010\310\336\037\000\320\336\037\001\"M\n\016DeleteRespo"
-    "nse\022;\n\006header\030\001 \001(\0132!.cockroach.roachpb."
-    "ResponseHeaderB\010\310\336\037\000\320\336\037\001\"u\n\022DeleteRangeR"
-    "equest\022:\n\006header\030\001 \001(\0132 .cockroach.roach"
-    "pb.RequestHeaderB\010\310\336\037\000\320\336\037\001\022#\n\025max_entrie"
-    "s_to_delete\030\002 \001(\003B\004\310\336\037\000\"m\n\023DeleteRangeRe"
-    "sponse\022;\n\006header\030\001 \001(\0132!.cockroach.roach"
-    "pb.ResponseHeaderB\010\310\336\037\000\320\336\037\001\022\031\n\013num_delet"
-    "ed\030\002 \001(\003B\004\310\336\037\000\"d\n\013ScanRequest\022:\n\006header\030"
-    "\001 \001(\0132 .cockroach.roachpb.RequestHeaderB"
-    "\010\310\336\037\000\320\336\037\001\022\031\n\013max_results\030\002 \001(\003B\004\310\336\037\000\"|\n\014"
-    "ScanResponse\022;\n\006header\030\001 \001(\0132!.cockroach"
-    ".roachpb.ResponseHeaderB\010\310\336\037\000\320\336\037\001\022/\n\004row"
-    "s\030\002 \003(\0132\033.cockroach.roachpb.KeyValueB\004\310\336"
-    "\037\000\"k\n\022ReverseScanRequest\022:\n\006header\030\001 \001(\013"
-    "2 .cockroach.roachpb.RequestHeaderB\010\310\336\037\000"
-    "\320\336\037\001\022\031\n\013max_results\030\002 \001(\003B\004\310\336\037\000\"\203\001\n\023Reve"
-    "rseScanResponse\022;\n\006header\030\001 \001(\0132!.cockro"
-    "ach.roachpb.ResponseHeaderB\010\310\336\037\000\320\336\037\001\022/\n\004"
-    "rows\030\002 \003(\0132\033.cockroach.roachpb.KeyValueB"
-    "\004\310\336\037\000\"\346\001\n\025EndTransactionRequest\022:\n\006heade"
-    "r\030\001 \001(\0132 .cockroach.roachpb.RequestHeade"
-    "rB\010\310\336\037\000\320\336\037\001\022\024\n\006commit\030\002 \001(\010B\004\310\336\037\000\022I\n\027int"
-    "ernal_commit_trigger\030\003 \001(\0132(.cockroach.r"
-    "oachpb.InternalCommitTrigger\0220\n\007intents\030"
-    "\004 \003(\0132\031.cockroach.roachpb.IntentB\004\310\336\037\000\"\213"
-    "\001\n\026EndTransactionResponse\022;\n\006header\030\001 \001("
-    "\0132!.cockroach.roachpb.ResponseHeaderB\010\310\336"
-    "\037\000\320\336\037\001\022\031\n\013commit_wait\030\002 \001(\003B\004\310\336\037\000\022\031\n\010res"
-    "olved\030\003 \003(\014B\007\372\336\037\003Key\"k\n\021AdminSplitReques"
-    "t\022:\n\006header\030\001 \001(\0132 .cockroach.roachpb.Re"
-    "questHeaderB\010\310\336\037\000\320\336\037\001\022\032\n\tsplit_key\030\002 \001(\014"
-    "B\007\372\336\037\003Key\"Q\n\022AdminSplitResponse\022;\n\006heade"
-    "r\030\001 \001(\0132!.cockroach.roachpb.ResponseHead"
-    "erB\010\310\336\037\000\320\336\037\001\"O\n\021AdminMergeRequest\022:\n\006hea"
-    "der\030\001 \001(\0132 .cockroach.roachpb.RequestHea"
-    "derB\010\310\336\037\000\320\336\037\001\"Q\n\022AdminMergeResponse\022;\n\006h"
-    "eader\030\001 \001(\0132!.cockroach.roachpb.Response"
-    "HeaderB\010\310\336\037\000\320\336\037\001\"\241\001\n\022RangeLookupRequest\022"
-    ":\n\006header\030\001 \001(\0132 .cockroach.roachpb.Requ"
-    "estHeaderB\010\310\336\037\000\320\336\037\001\022\030\n\nmax_ranges\030\002 \001(\005B"
-    "\004\310\336\037\000\022\036\n\020consider_intents\030\003 \001(\010B\004\310\336\037\000\022\025\n"
-    "\007reverse\030\004 \001(\010B\004\310\336\037\000\"\214\001\n\023RangeLookupResp"
-    "onse\022;\n\006header\030\001 \001(\0132!.cockroach.roachpb"
-    ".ResponseHeaderB\010\310\336\037\000\320\336\037\001\0228\n\006ranges\030\002 \003("
-    "\0132\".cockroach.roachpb.RangeDescriptorB\004\310"
-    "\336\037\000\"Q\n\023HeartbeatTxnRequest\022:\n\006header\030\001 \001"
-    "(\0132 .cockroach.roachpb.RequestHeaderB\010\310\336"
-    "\037\000\320\336\037\001\"S\n\024HeartbeatTxnResponse\022;\n\006header"
-    "\030\001 \001(\0132!.cockroach.roachpb.ResponseHeade"
-    "rB\010\310\336\037\000\320\336\037\001\"\225\002\n\tGCRequest\022:\n\006header\030\001 \001("
-    "\0132 .cockroach.roachpb.RequestHeaderB\010\310\336\037"
-    "\000\320\336\037\001\022>\n\007gc_meta\030\002 \001(\0132\035.cockroach.roach"
-    "pb.GCMetadataB\016\310\336\037\000\342\336\037\006GCMeta\0226\n\004keys\030\003 "
-    "\003(\0132\".cockroach.roachpb.GCRequest.GCKeyB"
-    "\004\310\336\037\000\032T\n\005GCKey\022\024\n\003key\030\001 \001(\014B\007\372\336\037\003Key\0225\n\t"
+    "B\004\310\336\037\000\022\024\n\006random\030\002 \001(\003B\004\310\336\037\000\"l\n\rRequestH"
+    "eader\022\024\n\003key\030\003 \001(\014B\007\372\336\037\003Key\022\030\n\007end_key\030\004"
+    " \001(\014B\007\372\336\037\003Key\022+\n\003txn\030\010 \001(\0132\036.cockroach.r"
+    "oachpb.Transaction\"t\n\016ResponseHeader\0225\n\t"
     "timestamp\030\002 \001(\0132\034.cockroach.roachpb.Time"
-    "stampB\004\310\336\037\000\"I\n\nGCResponse\022;\n\006header\030\001 \001("
+    "stampB\004\310\336\037\000\022+\n\003txn\030\003 \001(\0132\036.cockroach.roa"
+    "chpb.Transaction\"H\n\nGetRequest\022:\n\006header"
+    "\030\001 \001(\0132 .cockroach.roachpb.RequestHeader"
+    "B\010\310\336\037\000\320\336\037\001\"s\n\013GetResponse\022;\n\006header\030\001 \001("
     "\0132!.cockroach.roachpb.ResponseHeaderB\010\310\336"
-    "\037\000\320\336\037\001\"\337\002\n\016PushTxnRequest\022:\n\006header\030\001 \001("
-    "\0132 .cockroach.roachpb.RequestHeaderB\010\310\336\037"
-    "\000\320\336\037\001\0228\n\npusher_txn\030\002 \001(\0132\036.cockroach.ro"
-    "achpb.TransactionB\004\310\336\037\000\0228\n\npushee_txn\030\003 "
-    "\001(\0132\036.cockroach.roachpb.TransactionB\004\310\336\037"
-    "\000\0223\n\007push_to\030\004 \001(\0132\034.cockroach.roachpb.T"
-    "imestampB\004\310\336\037\000\022/\n\003now\030\005 \001(\0132\034.cockroach."
-    "roachpb.TimestampB\004\310\336\037\000\0227\n\tpush_type\030\006 \001"
-    "(\0162\036.cockroach.roachpb.PushTxnTypeB\004\310\336\037\000"
-    "\"\202\001\n\017PushTxnResponse\022;\n\006header\030\001 \001(\0132!.c"
-    "ockroach.roachpb.ResponseHeaderB\010\310\336\037\000\320\336\037"
-    "\001\0222\n\npushee_txn\030\002 \001(\0132\036.cockroach.roachp"
-    "b.Transaction\"\214\001\n\024ResolveIntentRequest\022:"
-    "\n\006header\030\001 \001(\0132 .cockroach.roachpb.Reque"
-    "stHeaderB\010\310\336\037\000\320\336\037\001\0228\n\nintent_txn\030\002 \001(\0132\036"
-    ".cockroach.roachpb.TransactionB\004\310\336\037\000\"T\n\025"
-    "ResolveIntentResponse\022;\n\006header\030\001 \001(\0132!."
-    "cockroach.roachpb.ResponseHeaderB\010\310\336\037\000\320\336"
-    "\037\001\"\221\001\n\031ResolveIntentRangeRequest\022:\n\006head"
-    "er\030\001 \001(\0132 .cockroach.roachpb.RequestHead"
-    "erB\010\310\336\037\000\320\336\037\001\0228\n\nintent_txn\030\002 \001(\0132\036.cockr"
-    "oach.roachpb.TransactionB\004\310\336\037\000\"K\n\014NoopRe"
-    "sponse\022;\n\006header\030\001 \001(\0132!.cockroach.roach"
-    "pb.ResponseHeaderB\010\310\336\037\000\320\336\037\001\"I\n\013NoopReque"
+    "\037\000\320\336\037\001\022\'\n\005value\030\002 \001(\0132\030.cockroach.roachp"
+    "b.Value\"w\n\nPutRequest\022:\n\006header\030\001 \001(\0132 ."
+    "cockroach.roachpb.RequestHeaderB\010\310\336\037\000\320\336\037"
+    "\001\022-\n\005value\030\002 \001(\0132\030.cockroach.roachpb.Val"
+    "ueB\004\310\336\037\000\"J\n\013PutResponse\022;\n\006header\030\001 \001(\0132"
+    "!.cockroach.roachpb.ResponseHeaderB\010\310\336\037\000"
+    "\320\336\037\001\"\257\001\n\025ConditionalPutRequest\022:\n\006header"
+    "\030\001 \001(\0132 .cockroach.roachpb.RequestHeader"
+    "B\010\310\336\037\000\320\336\037\001\022-\n\005value\030\002 \001(\0132\030.cockroach.ro"
+    "achpb.ValueB\004\310\336\037\000\022+\n\texp_value\030\003 \001(\0132\030.c"
+    "ockroach.roachpb.Value\"U\n\026ConditionalPut"
+    "Response\022;\n\006header\030\001 \001(\0132!.cockroach.roa"
+    "chpb.ResponseHeaderB\010\310\336\037\000\320\336\037\001\"g\n\020Increme"
+    "ntRequest\022:\n\006header\030\001 \001(\0132 .cockroach.ro"
+    "achpb.RequestHeaderB\010\310\336\037\000\320\336\037\001\022\027\n\tincreme"
+    "nt\030\002 \001(\003B\004\310\336\037\000\"i\n\021IncrementResponse\022;\n\006h"
+    "eader\030\001 \001(\0132!.cockroach.roachpb.Response"
+    "HeaderB\010\310\336\037\000\320\336\037\001\022\027\n\tnew_value\030\002 \001(\003B\004\310\336\037"
+    "\000\"K\n\rDeleteRequest\022:\n\006header\030\001 \001(\0132 .coc"
+    "kroach.roachpb.RequestHeaderB\010\310\336\037\000\320\336\037\001\"M"
+    "\n\016DeleteResponse\022;\n\006header\030\001 \001(\0132!.cockr"
+    "oach.roachpb.ResponseHeaderB\010\310\336\037\000\320\336\037\001\"u\n"
+    "\022DeleteRangeRequest\022:\n\006header\030\001 \001(\0132 .co"
+    "ckroach.roachpb.RequestHeaderB\010\310\336\037\000\320\336\037\001\022"
+    "#\n\025max_entries_to_delete\030\002 \001(\003B\004\310\336\037\000\"m\n\023"
+    "DeleteRangeResponse\022;\n\006header\030\001 \001(\0132!.co"
+    "ckroach.roachpb.ResponseHeaderB\010\310\336\037\000\320\336\037\001"
+    "\022\031\n\013num_deleted\030\002 \001(\003B\004\310\336\037\000\"d\n\013ScanReque"
     "st\022:\n\006header\030\001 \001(\0132 .cockroach.roachpb.R"
-    "equestHeaderB\010\310\336\037\000\320\336\037\001\"Y\n\032ResolveIntentR"
-    "angeResponse\022;\n\006header\030\001 \001(\0132!.cockroach"
-    ".roachpb.ResponseHeaderB\010\310\336\037\000\320\336\037\001\"y\n\014Mer"
-    "geRequest\022:\n\006header\030\001 \001(\0132 .cockroach.ro"
-    "achpb.RequestHeaderB\010\310\336\037\000\320\336\037\001\022-\n\005value\030\002"
-    " \001(\0132\030.cockroach.roachpb.ValueB\004\310\336\037\000\"L\n\r"
-    "MergeResponse\022;\n\006header\030\001 \001(\0132!.cockroac"
-    "h.roachpb.ResponseHeaderB\010\310\336\037\000\320\336\037\001\"e\n\022Tr"
-    "uncateLogRequest\022:\n\006header\030\001 \001(\0132 .cockr"
-    "oach.roachpb.RequestHeaderB\010\310\336\037\000\320\336\037\001\022\023\n\005"
-    "index\030\002 \001(\004B\004\310\336\037\000\"R\n\023TruncateLogResponse"
-    "\022;\n\006header\030\001 \001(\0132!.cockroach.roachpb.Res"
-    "ponseHeaderB\010\310\336\037\000\320\336\037\001\"\177\n\022LeaderLeaseRequ"
-    "est\022:\n\006header\030\001 \001(\0132 .cockroach.roachpb."
-    "RequestHeaderB\010\310\336\037\000\320\336\037\001\022-\n\005lease\030\002 \001(\0132\030"
-    ".cockroach.roachpb.LeaseB\004\310\336\037\000\"R\n\023Leader"
-    "LeaseResponse\022;\n\006header\030\001 \001(\0132!.cockroac"
-    "h.roachpb.ResponseHeaderB\010\310\336\037\000\320\336\037\001\"\272\t\n\014R"
-    "equestUnion\022*\n\003get\030\001 \001(\0132\035.cockroach.roa"
-    "chpb.GetRequest\022*\n\003put\030\002 \001(\0132\035.cockroach"
-    ".roachpb.PutRequest\022A\n\017conditional_put\030\003"
-    " \001(\0132(.cockroach.roachpb.ConditionalPutR"
-    "equest\0226\n\tincrement\030\004 \001(\0132#.cockroach.ro"
-    "achpb.IncrementRequest\0220\n\006delete\030\005 \001(\0132 "
-    ".cockroach.roachpb.DeleteRequest\022;\n\014dele"
-    "te_range\030\006 \001(\0132%.cockroach.roachpb.Delet"
-    "eRangeRequest\022,\n\004scan\030\007 \001(\0132\036.cockroach."
-    "roachpb.ScanRequest\022A\n\017end_transaction\030\010"
-    " \001(\0132(.cockroach.roachpb.EndTransactionR"
-    "equest\0229\n\013admin_split\030\t \001(\0132$.cockroach."
-    "roachpb.AdminSplitRequest\0229\n\013admin_merge"
-    "\030\n \001(\0132$.cockroach.roachpb.AdminMergeReq"
-    "uest\022=\n\rheartbeat_txn\030\013 \001(\0132&.cockroach."
-    "roachpb.HeartbeatTxnRequest\022(\n\002gc\030\014 \001(\0132"
-    "\034.cockroach.roachpb.GCRequest\0223\n\010push_tx"
-    "n\030\r \001(\0132!.cockroach.roachpb.PushTxnReque"
-    "st\022;\n\014range_lookup\030\016 \001(\0132%.cockroach.roa"
-    "chpb.RangeLookupRequest\022\?\n\016resolve_inten"
-    "t\030\017 \001(\0132\'.cockroach.roachpb.ResolveInten"
-    "tRequest\022J\n\024resolve_intent_range\030\020 \001(\0132,"
-    ".cockroach.roachpb.ResolveIntentRangeReq"
-    "uest\022.\n\005merge\030\021 \001(\0132\037.cockroach.roachpb."
-    "MergeRequest\022;\n\014truncate_log\030\022 \001(\0132%.coc"
-    "kroach.roachpb.TruncateLogRequest\022;\n\014lea"
-    "der_lease\030\023 \001(\0132%.cockroach.roachpb.Lead"
-    "erLeaseRequest\022;\n\014reverse_scan\030\024 \001(\0132%.c"
-    "ockroach.roachpb.ReverseScanRequest\022,\n\004n"
-    "oop\030\025 \001(\0132\036.cockroach.roachpb.NoopReques"
-    "t:\004\310\240\037\001\"\320\t\n\rResponseUnion\022+\n\003get\030\001 \001(\0132\036"
-    ".cockroach.roachpb.GetResponse\022+\n\003put\030\002 "
-    "\001(\0132\036.cockroach.roachpb.PutResponse\022B\n\017c"
-    "onditional_put\030\003 \001(\0132).cockroach.roachpb"
-    ".ConditionalPutResponse\0227\n\tincrement\030\004 \001"
-    "(\0132$.cockroach.roachpb.IncrementResponse"
-    "\0221\n\006delete\030\005 \001(\0132!.cockroach.roachpb.Del"
-    "eteResponse\022<\n\014delete_range\030\006 \001(\0132&.cock"
-    "roach.roachpb.DeleteRangeResponse\022-\n\004sca"
-    "n\030\007 \001(\0132\037.cockroach.roachpb.ScanResponse"
-    "\022B\n\017end_transaction\030\010 \001(\0132).cockroach.ro"
-    "achpb.EndTransactionResponse\022:\n\013admin_sp"
-    "lit\030\t \001(\0132%.cockroach.roachpb.AdminSplit"
-    "Response\022:\n\013admin_merge\030\n \001(\0132%.cockroac"
-    "h.roachpb.AdminMergeResponse\022>\n\rheartbea"
-    "t_txn\030\013 \001(\0132\'.cockroach.roachpb.Heartbea"
-    "tTxnResponse\022)\n\002gc\030\014 \001(\0132\035.cockroach.roa"
-    "chpb.GCResponse\0224\n\010push_txn\030\r \001(\0132\".cock"
-    "roach.roachpb.PushTxnResponse\022<\n\014range_l"
-    "ookup\030\016 \001(\0132&.cockroach.roachpb.RangeLoo"
-    "kupResponse\022@\n\016resolve_intent\030\017 \001(\0132(.co"
-    "ckroach.roachpb.ResolveIntentResponse\022K\n"
-    "\024resolve_intent_range\030\020 \001(\0132-.cockroach."
-    "roachpb.ResolveIntentRangeResponse\022/\n\005me"
-    "rge\030\021 \001(\0132 .cockroach.roachpb.MergeRespo"
-    "nse\022<\n\014truncate_log\030\022 \001(\0132&.cockroach.ro"
-    "achpb.TruncateLogResponse\022<\n\014leader_leas"
-    "e\030\023 \001(\0132&.cockroach.roachpb.LeaderLeaseR"
-    "esponse\022<\n\014reverse_scan\030\024 \001(\0132&.cockroac"
-    "h.roachpb.ReverseScanResponse\022-\n\004noop\030\025 "
-    "\001(\0132\037.cockroach.roachpb.NoopResponse:\004\310\240"
-    "\037\001\"\212\004\n\014BatchRequest\022@\n\006header\030\001 \001(\0132&.co"
-    "ckroach.roachpb.BatchRequest.HeaderB\010\310\336\037"
-    "\000\320\336\037\001\0227\n\010requests\030\002 \003(\0132\037.cockroach.roac"
-    "hpb.RequestUnionB\004\310\336\037\000\032\370\002\n\006Header\0225\n\ttim"
-    "estamp\030\001 \001(\0132\034.cockroach.roachpb.Timesta"
-    "mpB\004\310\336\037\000\022=\n\006cmd_id\030\002 \001(\0132\036.cockroach.roa"
-    "chpb.ClientCmdIDB\r\310\336\037\000\342\336\037\005CmdID\022;\n\007repli"
-    "ca\030\005 \001(\0132$.cockroach.roachpb.ReplicaDesc"
-    "riptorB\004\310\336\037\000\022,\n\010range_id\030\006 \001(\003B\032\310\336\037\000\342\336\037\007"
-    "RangeID\372\336\037\007RangeID\022\030\n\ruser_priority\030\007 \001("
-    "\005:\0011\022+\n\003txn\030\010 \001(\0132\036.cockroach.roachpb.Tr"
-    "ansaction\022F\n\020read_consistency\030\t \001(\0162&.co"
-    "ckroach.roachpb.ReadConsistencyTypeB\004\310\336\037"
-    "\000:\004\230\240\037\000\"\245\002\n\rBatchResponse\022A\n\006header\030\001 \001("
-    "\0132\'.cockroach.roachpb.BatchResponse.Head"
-    "erB\010\310\336\037\000\320\336\037\001\0229\n\tresponses\030\002 \003(\0132 .cockro"
-    "ach.roachpb.ResponseUnionB\004\310\336\037\000\032\225\001\n\006Head"
-    "er\022\'\n\005error\030\001 \001(\0132\030.cockroach.roachpb.Er"
-    "ror\0225\n\ttimestamp\030\002 \001(\0132\034.cockroach.roach"
-    "pb.TimestampB\004\310\336\037\000\022+\n\003txn\030\003 \001(\0132\036.cockro"
-    "ach.roachpb.Transaction*L\n\023ReadConsisten"
-    "cyType\022\016\n\nCONSISTENT\020\000\022\r\n\tCONSENSUS\020\001\022\020\n"
-    "\014INCONSISTENT\020\002\032\004\210\243\036\000*G\n\013PushTxnType\022\022\n\016"
-    "PUSH_TIMESTAMP\020\000\022\r\n\tABORT_TXN\020\001\022\017\n\013CLEAN"
-    "UP_TXN\020\002\032\004\210\243\036\000B\031Z\007roachpb\340\342\036\001\310\342\036\001\320\342\036\001\220\343\036"
-    "\000", 8921);
+    "equestHeaderB\010\310\336\037\000\320\336\037\001\022\031\n\013max_results\030\002 "
+    "\001(\003B\004\310\336\037\000\"|\n\014ScanResponse\022;\n\006header\030\001 \001("
+    "\0132!.cockroach.roachpb.ResponseHeaderB\010\310\336"
+    "\037\000\320\336\037\001\022/\n\004rows\030\002 \003(\0132\033.cockroach.roachpb"
+    ".KeyValueB\004\310\336\037\000\"k\n\022ReverseScanRequest\022:\n"
+    "\006header\030\001 \001(\0132 .cockroach.roachpb.Reques"
+    "tHeaderB\010\310\336\037\000\320\336\037\001\022\031\n\013max_results\030\002 \001(\003B\004"
+    "\310\336\037\000\"\203\001\n\023ReverseScanResponse\022;\n\006header\030\001"
+    " \001(\0132!.cockroach.roachpb.ResponseHeaderB"
+    "\010\310\336\037\000\320\336\037\001\022/\n\004rows\030\002 \003(\0132\033.cockroach.roac"
+    "hpb.KeyValueB\004\310\336\037\000\"\346\001\n\025EndTransactionReq"
+    "uest\022:\n\006header\030\001 \001(\0132 .cockroach.roachpb"
+    ".RequestHeaderB\010\310\336\037\000\320\336\037\001\022\024\n\006commit\030\002 \001(\010"
+    "B\004\310\336\037\000\022I\n\027internal_commit_trigger\030\003 \001(\0132"
+    "(.cockroach.roachpb.InternalCommitTrigge"
+    "r\0220\n\007intents\030\004 \003(\0132\031.cockroach.roachpb.I"
+    "ntentB\004\310\336\037\000\"\213\001\n\026EndTransactionResponse\022;"
+    "\n\006header\030\001 \001(\0132!.cockroach.roachpb.Respo"
+    "nseHeaderB\010\310\336\037\000\320\336\037\001\022\031\n\013commit_wait\030\002 \001(\003"
+    "B\004\310\336\037\000\022\031\n\010resolved\030\003 \003(\014B\007\372\336\037\003Key\"k\n\021Adm"
+    "inSplitRequest\022:\n\006header\030\001 \001(\0132 .cockroa"
+    "ch.roachpb.RequestHeaderB\010\310\336\037\000\320\336\037\001\022\032\n\tsp"
+    "lit_key\030\002 \001(\014B\007\372\336\037\003Key\"Q\n\022AdminSplitResp"
+    "onse\022;\n\006header\030\001 \001(\0132!.cockroach.roachpb"
+    ".ResponseHeaderB\010\310\336\037\000\320\336\037\001\"O\n\021AdminMergeR"
+    "equest\022:\n\006header\030\001 \001(\0132 .cockroach.roach"
+    "pb.RequestHeaderB\010\310\336\037\000\320\336\037\001\"Q\n\022AdminMerge"
+    "Response\022;\n\006header\030\001 \001(\0132!.cockroach.roa"
+    "chpb.ResponseHeaderB\010\310\336\037\000\320\336\037\001\"\241\001\n\022RangeL"
+    "ookupRequest\022:\n\006header\030\001 \001(\0132 .cockroach"
+    ".roachpb.RequestHeaderB\010\310\336\037\000\320\336\037\001\022\030\n\nmax_"
+    "ranges\030\002 \001(\005B\004\310\336\037\000\022\036\n\020consider_intents\030\003"
+    " \001(\010B\004\310\336\037\000\022\025\n\007reverse\030\004 \001(\010B\004\310\336\037\000\"\214\001\n\023Ra"
+    "ngeLookupResponse\022;\n\006header\030\001 \001(\0132!.cock"
+    "roach.roachpb.ResponseHeaderB\010\310\336\037\000\320\336\037\001\0228"
+    "\n\006ranges\030\002 \003(\0132\".cockroach.roachpb.Range"
+    "DescriptorB\004\310\336\037\000\"Q\n\023HeartbeatTxnRequest\022"
+    ":\n\006header\030\001 \001(\0132 .cockroach.roachpb.Requ"
+    "estHeaderB\010\310\336\037\000\320\336\037\001\"S\n\024HeartbeatTxnRespo"
+    "nse\022;\n\006header\030\001 \001(\0132!.cockroach.roachpb."
+    "ResponseHeaderB\010\310\336\037\000\320\336\037\001\"\225\002\n\tGCRequest\022:"
+    "\n\006header\030\001 \001(\0132 .cockroach.roachpb.Reque"
+    "stHeaderB\010\310\336\037\000\320\336\037\001\022>\n\007gc_meta\030\002 \001(\0132\035.co"
+    "ckroach.roachpb.GCMetadataB\016\310\336\037\000\342\336\037\006GCMe"
+    "ta\0226\n\004keys\030\003 \003(\0132\".cockroach.roachpb.GCR"
+    "equest.GCKeyB\004\310\336\037\000\032T\n\005GCKey\022\024\n\003key\030\001 \001(\014"
+    "B\007\372\336\037\003Key\0225\n\ttimestamp\030\002 \001(\0132\034.cockroach"
+    ".roachpb.TimestampB\004\310\336\037\000\"I\n\nGCResponse\022;"
+    "\n\006header\030\001 \001(\0132!.cockroach.roachpb.Respo"
+    "nseHeaderB\010\310\336\037\000\320\336\037\001\"\337\002\n\016PushTxnRequest\022:"
+    "\n\006header\030\001 \001(\0132 .cockroach.roachpb.Reque"
+    "stHeaderB\010\310\336\037\000\320\336\037\001\0228\n\npusher_txn\030\002 \001(\0132\036"
+    ".cockroach.roachpb.TransactionB\004\310\336\037\000\0228\n\n"
+    "pushee_txn\030\003 \001(\0132\036.cockroach.roachpb.Tra"
+    "nsactionB\004\310\336\037\000\0223\n\007push_to\030\004 \001(\0132\034.cockro"
+    "ach.roachpb.TimestampB\004\310\336\037\000\022/\n\003now\030\005 \001(\013"
+    "2\034.cockroach.roachpb.TimestampB\004\310\336\037\000\0227\n\t"
+    "push_type\030\006 \001(\0162\036.cockroach.roachpb.Push"
+    "TxnTypeB\004\310\336\037\000\"\202\001\n\017PushTxnResponse\022;\n\006hea"
+    "der\030\001 \001(\0132!.cockroach.roachpb.ResponseHe"
+    "aderB\010\310\336\037\000\320\336\037\001\0222\n\npushee_txn\030\002 \001(\0132\036.coc"
+    "kroach.roachpb.Transaction\"\214\001\n\024ResolveIn"
+    "tentRequest\022:\n\006header\030\001 \001(\0132 .cockroach."
+    "roachpb.RequestHeaderB\010\310\336\037\000\320\336\037\001\0228\n\ninten"
+    "t_txn\030\002 \001(\0132\036.cockroach.roachpb.Transact"
+    "ionB\004\310\336\037\000\"T\n\025ResolveIntentResponse\022;\n\006he"
+    "ader\030\001 \001(\0132!.cockroach.roachpb.ResponseH"
+    "eaderB\010\310\336\037\000\320\336\037\001\"\221\001\n\031ResolveIntentRangeRe"
+    "quest\022:\n\006header\030\001 \001(\0132 .cockroach.roachp"
+    "b.RequestHeaderB\010\310\336\037\000\320\336\037\001\0228\n\nintent_txn\030"
+    "\002 \001(\0132\036.cockroach.roachpb.TransactionB\004\310"
+    "\336\037\000\"K\n\014NoopResponse\022;\n\006header\030\001 \001(\0132!.co"
+    "ckroach.roachpb.ResponseHeaderB\010\310\336\037\000\320\336\037\001"
+    "\"I\n\013NoopRequest\022:\n\006header\030\001 \001(\0132 .cockro"
+    "ach.roachpb.RequestHeaderB\010\310\336\037\000\320\336\037\001\"Y\n\032R"
+    "esolveIntentRangeResponse\022;\n\006header\030\001 \001("
+    "\0132!.cockroach.roachpb.ResponseHeaderB\010\310\336"
+    "\037\000\320\336\037\001\"y\n\014MergeRequest\022:\n\006header\030\001 \001(\0132 "
+    ".cockroach.roachpb.RequestHeaderB\010\310\336\037\000\320\336"
+    "\037\001\022-\n\005value\030\002 \001(\0132\030.cockroach.roachpb.Va"
+    "lueB\004\310\336\037\000\"L\n\rMergeResponse\022;\n\006header\030\001 \001"
+    "(\0132!.cockroach.roachpb.ResponseHeaderB\010\310"
+    "\336\037\000\320\336\037\001\"e\n\022TruncateLogRequest\022:\n\006header\030"
+    "\001 \001(\0132 .cockroach.roachpb.RequestHeaderB"
+    "\010\310\336\037\000\320\336\037\001\022\023\n\005index\030\002 \001(\004B\004\310\336\037\000\"R\n\023Trunca"
+    "teLogResponse\022;\n\006header\030\001 \001(\0132!.cockroac"
+    "h.roachpb.ResponseHeaderB\010\310\336\037\000\320\336\037\001\"\177\n\022Le"
+    "aderLeaseRequest\022:\n\006header\030\001 \001(\0132 .cockr"
+    "oach.roachpb.RequestHeaderB\010\310\336\037\000\320\336\037\001\022-\n\005"
+    "lease\030\002 \001(\0132\030.cockroach.roachpb.LeaseB\004\310"
+    "\336\037\000\"R\n\023LeaderLeaseResponse\022;\n\006header\030\001 \001"
+    "(\0132!.cockroach.roachpb.ResponseHeaderB\010\310"
+    "\336\037\000\320\336\037\001\"\272\t\n\014RequestUnion\022*\n\003get\030\001 \001(\0132\035."
+    "cockroach.roachpb.GetRequest\022*\n\003put\030\002 \001("
+    "\0132\035.cockroach.roachpb.PutRequest\022A\n\017cond"
+    "itional_put\030\003 \001(\0132(.cockroach.roachpb.Co"
+    "nditionalPutRequest\0226\n\tincrement\030\004 \001(\0132#"
+    ".cockroach.roachpb.IncrementRequest\0220\n\006d"
+    "elete\030\005 \001(\0132 .cockroach.roachpb.DeleteRe"
+    "quest\022;\n\014delete_range\030\006 \001(\0132%.cockroach."
+    "roachpb.DeleteRangeRequest\022,\n\004scan\030\007 \001(\013"
+    "2\036.cockroach.roachpb.ScanRequest\022A\n\017end_"
+    "transaction\030\010 \001(\0132(.cockroach.roachpb.En"
+    "dTransactionRequest\0229\n\013admin_split\030\t \001(\013"
+    "2$.cockroach.roachpb.AdminSplitRequest\0229"
+    "\n\013admin_merge\030\n \001(\0132$.cockroach.roachpb."
+    "AdminMergeRequest\022=\n\rheartbeat_txn\030\013 \001(\013"
+    "2&.cockroach.roachpb.HeartbeatTxnRequest"
+    "\022(\n\002gc\030\014 \001(\0132\034.cockroach.roachpb.GCReque"
+    "st\0223\n\010push_txn\030\r \001(\0132!.cockroach.roachpb"
+    ".PushTxnRequest\022;\n\014range_lookup\030\016 \001(\0132%."
+    "cockroach.roachpb.RangeLookupRequest\022\?\n\016"
+    "resolve_intent\030\017 \001(\0132\'.cockroach.roachpb"
+    ".ResolveIntentRequest\022J\n\024resolve_intent_"
+    "range\030\020 \001(\0132,.cockroach.roachpb.ResolveI"
+    "ntentRangeRequest\022.\n\005merge\030\021 \001(\0132\037.cockr"
+    "oach.roachpb.MergeRequest\022;\n\014truncate_lo"
+    "g\030\022 \001(\0132%.cockroach.roachpb.TruncateLogR"
+    "equest\022;\n\014leader_lease\030\023 \001(\0132%.cockroach"
+    ".roachpb.LeaderLeaseRequest\022;\n\014reverse_s"
+    "can\030\024 \001(\0132%.cockroach.roachpb.ReverseSca"
+    "nRequest\022,\n\004noop\030\025 \001(\0132\036.cockroach.roach"
+    "pb.NoopRequest:\004\310\240\037\001\"\320\t\n\rResponseUnion\022+"
+    "\n\003get\030\001 \001(\0132\036.cockroach.roachpb.GetRespo"
+    "nse\022+\n\003put\030\002 \001(\0132\036.cockroach.roachpb.Put"
+    "Response\022B\n\017conditional_put\030\003 \001(\0132).cock"
+    "roach.roachpb.ConditionalPutResponse\0227\n\t"
+    "increment\030\004 \001(\0132$.cockroach.roachpb.Incr"
+    "ementResponse\0221\n\006delete\030\005 \001(\0132!.cockroac"
+    "h.roachpb.DeleteResponse\022<\n\014delete_range"
+    "\030\006 \001(\0132&.cockroach.roachpb.DeleteRangeRe"
+    "sponse\022-\n\004scan\030\007 \001(\0132\037.cockroach.roachpb"
+    ".ScanResponse\022B\n\017end_transaction\030\010 \001(\0132)"
+    ".cockroach.roachpb.EndTransactionRespons"
+    "e\022:\n\013admin_split\030\t \001(\0132%.cockroach.roach"
+    "pb.AdminSplitResponse\022:\n\013admin_merge\030\n \001"
+    "(\0132%.cockroach.roachpb.AdminMergeRespons"
+    "e\022>\n\rheartbeat_txn\030\013 \001(\0132\'.cockroach.roa"
+    "chpb.HeartbeatTxnResponse\022)\n\002gc\030\014 \001(\0132\035."
+    "cockroach.roachpb.GCResponse\0224\n\010push_txn"
+    "\030\r \001(\0132\".cockroach.roachpb.PushTxnRespon"
+    "se\022<\n\014range_lookup\030\016 \001(\0132&.cockroach.roa"
+    "chpb.RangeLookupResponse\022@\n\016resolve_inte"
+    "nt\030\017 \001(\0132(.cockroach.roachpb.ResolveInte"
+    "ntResponse\022K\n\024resolve_intent_range\030\020 \001(\013"
+    "2-.cockroach.roachpb.ResolveIntentRangeR"
+    "esponse\022/\n\005merge\030\021 \001(\0132 .cockroach.roach"
+    "pb.MergeResponse\022<\n\014truncate_log\030\022 \001(\0132&"
+    ".cockroach.roachpb.TruncateLogResponse\022<"
+    "\n\014leader_lease\030\023 \001(\0132&.cockroach.roachpb"
+    ".LeaderLeaseResponse\022<\n\014reverse_scan\030\024 \001"
+    "(\0132&.cockroach.roachpb.ReverseScanRespon"
+    "se\022-\n\004noop\030\025 \001(\0132\037.cockroach.roachpb.Noo"
+    "pResponse:\004\310\240\037\001\"\212\004\n\014BatchRequest\022@\n\006head"
+    "er\030\001 \001(\0132&.cockroach.roachpb.BatchReques"
+    "t.HeaderB\010\310\336\037\000\320\336\037\001\0227\n\010requests\030\002 \003(\0132\037.c"
+    "ockroach.roachpb.RequestUnionB\004\310\336\037\000\032\370\002\n\006"
+    "Header\0225\n\ttimestamp\030\001 \001(\0132\034.cockroach.ro"
+    "achpb.TimestampB\004\310\336\037\000\022=\n\006cmd_id\030\002 \001(\0132\036."
+    "cockroach.roachpb.ClientCmdIDB\r\310\336\037\000\342\336\037\005C"
+    "mdID\022;\n\007replica\030\005 \001(\0132$.cockroach.roachp"
+    "b.ReplicaDescriptorB\004\310\336\037\000\022,\n\010range_id\030\006 "
+    "\001(\003B\032\310\336\037\000\342\336\037\007RangeID\372\336\037\007RangeID\022\030\n\ruser_"
+    "priority\030\007 \001(\005:\0011\022+\n\003txn\030\010 \001(\0132\036.cockroa"
+    "ch.roachpb.Transaction\022F\n\020read_consisten"
+    "cy\030\t \001(\0162&.cockroach.roachpb.ReadConsist"
+    "encyTypeB\004\310\336\037\000:\004\230\240\037\000\"\245\002\n\rBatchResponse\022A"
+    "\n\006header\030\001 \001(\0132\'.cockroach.roachpb.Batch"
+    "Response.HeaderB\010\310\336\037\000\320\336\037\001\0229\n\tresponses\030\002"
+    " \003(\0132 .cockroach.roachpb.ResponseUnionB\004"
+    "\310\336\037\000\032\225\001\n\006Header\022\'\n\005error\030\001 \001(\0132\030.cockroa"
+    "ch.roachpb.Error\0225\n\ttimestamp\030\002 \001(\0132\034.co"
+    "ckroach.roachpb.TimestampB\004\310\336\037\000\022+\n\003txn\030\003"
+    " \001(\0132\036.cockroach.roachpb.Transaction*L\n\023"
+    "ReadConsistencyType\022\016\n\nCONSISTENT\020\000\022\r\n\tC"
+    "ONSENSUS\020\001\022\020\n\014INCONSISTENT\020\002\032\004\210\243\036\000*G\n\013Pu"
+    "shTxnType\022\022\n\016PUSH_TIMESTAMP\020\000\022\r\n\tABORT_T"
+    "XN\020\001\022\017\n\013CLEANUP_TXN\020\002\032\004\210\243\036\000B\031Z\007roachpb\340\342"
+    "\036\001\310\342\036\001\320\342\036\001\220\343\036\000", 8894);
   ::google::protobuf::MessageFactory::InternalRegisterGeneratedFile(
     "cockroach/roachpb/api.proto", &protobuf_RegisterTypes);
   ClientCmdID::default_instance_ = new ClientCmdID();
@@ -2020,7 +2018,6 @@ void ClientCmdID::clear_random() {
 #ifndef _MSC_VER
 const int RequestHeader::kKeyFieldNumber;
 const int RequestHeader::kEndKeyFieldNumber;
-const int RequestHeader::kUserPriorityFieldNumber;
 const int RequestHeader::kTxnFieldNumber;
 #endif  // !_MSC_VER
 
@@ -2047,7 +2044,6 @@ void RequestHeader::SharedCtor() {
   _cached_size_ = 0;
   key_.UnsafeSetDefault(&::google::protobuf::internal::GetEmptyStringAlreadyInited());
   end_key_.UnsafeSetDefault(&::google::protobuf::internal::GetEmptyStringAlreadyInited());
-  user_priority_ = 1;
   txn_ = NULL;
   ::memset(_has_bits_, 0, sizeof(_has_bits_));
 }
@@ -2091,14 +2087,13 @@ RequestHeader* RequestHeader::New(::google::protobuf::Arena* arena) const {
 }
 
 void RequestHeader::Clear() {
-  if (_has_bits_[0 / 32] & 15u) {
+  if (_has_bits_[0 / 32] & 7u) {
     if (has_key()) {
       key_.ClearToEmptyNoArena(&::google::protobuf::internal::GetEmptyStringAlreadyInited());
     }
     if (has_end_key()) {
       end_key_.ClearToEmptyNoArena(&::google::protobuf::internal::GetEmptyStringAlreadyInited());
     }
-    user_priority_ = 1;
     if (has_txn()) {
       if (txn_ != NULL) txn_->::cockroach::roachpb::Transaction::Clear();
     }
@@ -2137,21 +2132,6 @@ bool RequestHeader::MergePartialFromCodedStream(
          parse_end_key:
           DO_(::google::protobuf::internal::WireFormatLite::ReadBytes(
                 input, this->mutable_end_key()));
-        } else {
-          goto handle_unusual;
-        }
-        if (input->ExpectTag(56)) goto parse_user_priority;
-        break;
-      }
-
-      // optional int32 user_priority = 7 [default = 1];
-      case 7: {
-        if (tag == 56) {
-         parse_user_priority:
-          DO_((::google::protobuf::internal::WireFormatLite::ReadPrimitive<
-                   ::google::protobuf::int32, ::google::protobuf::internal::WireFormatLite::TYPE_INT32>(
-                 input, &user_priority_)));
-          set_has_user_priority();
         } else {
           goto handle_unusual;
         }
@@ -2209,11 +2189,6 @@ void RequestHeader::SerializeWithCachedSizes(
       4, this->end_key(), output);
   }
 
-  // optional int32 user_priority = 7 [default = 1];
-  if (has_user_priority()) {
-    ::google::protobuf::internal::WireFormatLite::WriteInt32(7, this->user_priority(), output);
-  }
-
   // optional .cockroach.roachpb.Transaction txn = 8;
   if (has_txn()) {
     ::google::protobuf::internal::WireFormatLite::WriteMessageMaybeToArray(
@@ -2244,11 +2219,6 @@ void RequestHeader::SerializeWithCachedSizes(
         4, this->end_key(), target);
   }
 
-  // optional int32 user_priority = 7 [default = 1];
-  if (has_user_priority()) {
-    target = ::google::protobuf::internal::WireFormatLite::WriteInt32ToArray(7, this->user_priority(), target);
-  }
-
   // optional .cockroach.roachpb.Transaction txn = 8;
   if (has_txn()) {
     target = ::google::protobuf::internal::WireFormatLite::
@@ -2267,7 +2237,7 @@ void RequestHeader::SerializeWithCachedSizes(
 int RequestHeader::ByteSize() const {
   int total_size = 0;
 
-  if (_has_bits_[0 / 32] & 15) {
+  if (_has_bits_[0 / 32] & 7) {
     // optional bytes key = 3;
     if (has_key()) {
       total_size += 1 +
@@ -2280,13 +2250,6 @@ int RequestHeader::ByteSize() const {
       total_size += 1 +
         ::google::protobuf::internal::WireFormatLite::BytesSize(
           this->end_key());
-    }
-
-    // optional int32 user_priority = 7 [default = 1];
-    if (has_user_priority()) {
-      total_size += 1 +
-        ::google::protobuf::internal::WireFormatLite::Int32Size(
-          this->user_priority());
     }
 
     // optional .cockroach.roachpb.Transaction txn = 8;
@@ -2331,9 +2294,6 @@ void RequestHeader::MergeFrom(const RequestHeader& from) {
       set_has_end_key();
       end_key_.AssignWithDefault(&::google::protobuf::internal::GetEmptyStringAlreadyInited(), from.end_key_);
     }
-    if (from.has_user_priority()) {
-      set_user_priority(from.user_priority());
-    }
     if (from.has_txn()) {
       mutable_txn()->::cockroach::roachpb::Transaction::MergeFrom(from.txn());
     }
@@ -2367,7 +2327,6 @@ void RequestHeader::Swap(RequestHeader* other) {
 void RequestHeader::InternalSwap(RequestHeader* other) {
   key_.Swap(&other->key_);
   end_key_.Swap(&other->end_key_);
-  std::swap(user_priority_, other->user_priority_);
   std::swap(txn_, other->txn_);
   std::swap(_has_bits_[0], other->_has_bits_[0]);
   _internal_metadata_.Swap(&other->_internal_metadata_);
@@ -2491,39 +2450,15 @@ void RequestHeader::clear_end_key() {
   // @@protoc_insertion_point(field_set_allocated:cockroach.roachpb.RequestHeader.end_key)
 }
 
-// optional int32 user_priority = 7 [default = 1];
-bool RequestHeader::has_user_priority() const {
-  return (_has_bits_[0] & 0x00000004u) != 0;
-}
-void RequestHeader::set_has_user_priority() {
-  _has_bits_[0] |= 0x00000004u;
-}
-void RequestHeader::clear_has_user_priority() {
-  _has_bits_[0] &= ~0x00000004u;
-}
-void RequestHeader::clear_user_priority() {
-  user_priority_ = 1;
-  clear_has_user_priority();
-}
- ::google::protobuf::int32 RequestHeader::user_priority() const {
-  // @@protoc_insertion_point(field_get:cockroach.roachpb.RequestHeader.user_priority)
-  return user_priority_;
-}
- void RequestHeader::set_user_priority(::google::protobuf::int32 value) {
-  set_has_user_priority();
-  user_priority_ = value;
-  // @@protoc_insertion_point(field_set:cockroach.roachpb.RequestHeader.user_priority)
-}
-
 // optional .cockroach.roachpb.Transaction txn = 8;
 bool RequestHeader::has_txn() const {
-  return (_has_bits_[0] & 0x00000008u) != 0;
+  return (_has_bits_[0] & 0x00000004u) != 0;
 }
 void RequestHeader::set_has_txn() {
-  _has_bits_[0] |= 0x00000008u;
+  _has_bits_[0] |= 0x00000004u;
 }
 void RequestHeader::clear_has_txn() {
-  _has_bits_[0] &= ~0x00000008u;
+  _has_bits_[0] &= ~0x00000004u;
 }
 void RequestHeader::clear_txn() {
   if (txn_ != NULL) txn_->::cockroach::roachpb::Transaction::Clear();

--- a/storage/engine/rocksdb/cockroach/roachpb/api.pb.cc
+++ b/storage/engine/rocksdb/cockroach/roachpb/api.pb.cc
@@ -1011,11 +1011,9 @@ void protobuf_AssignDesc_cockroach_2froachpb_2fapi_2eproto() {
       GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(BatchRequest, _internal_metadata_),
       -1);
   BatchRequest_Header_descriptor_ = BatchRequest_descriptor_->nested_type(0);
-  static const int BatchRequest_Header_offsets_[9] = {
+  static const int BatchRequest_Header_offsets_[7] = {
     GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(BatchRequest_Header, timestamp_),
     GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(BatchRequest_Header, cmd_id_),
-    GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(BatchRequest_Header, key_),
-    GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(BatchRequest_Header, end_key_),
     GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(BatchRequest_Header, replica_),
     GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(BatchRequest_Header, range_id_),
     GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(BatchRequest_Header, user_priority_),
@@ -1510,33 +1508,32 @@ void protobuf_AddDesc_cockroach_2froachpb_2fapi_2eproto() {
     "eResponse\022<\n\014reverse_scan\030\024 \001(\0132&.cockro"
     "ach.roachpb.ReverseScanResponse\022-\n\004noop\030"
     "\025 \001(\0132\037.cockroach.roachpb.NoopResponse:\004"
-    "\310\240\037\001\"\272\004\n\014BatchRequest\022@\n\006header\030\001 \001(\0132&."
+    "\310\240\037\001\"\212\004\n\014BatchRequest\022@\n\006header\030\001 \001(\0132&."
     "cockroach.roachpb.BatchRequest.HeaderB\010\310"
     "\336\037\000\320\336\037\001\0227\n\010requests\030\002 \003(\0132\037.cockroach.ro"
-    "achpb.RequestUnionB\004\310\336\037\000\032\250\003\n\006Header\0225\n\tt"
+    "achpb.RequestUnionB\004\310\336\037\000\032\370\002\n\006Header\0225\n\tt"
     "imestamp\030\001 \001(\0132\034.cockroach.roachpb.Times"
     "tampB\004\310\336\037\000\022=\n\006cmd_id\030\002 \001(\0132\036.cockroach.r"
-    "oachpb.ClientCmdIDB\r\310\336\037\000\342\336\037\005CmdID\022\024\n\003key"
-    "\030\003 \001(\014B\007\372\336\037\003Key\022\030\n\007end_key\030\004 \001(\014B\007\372\336\037\003Ke"
-    "y\022;\n\007replica\030\005 \001(\0132$.cockroach.roachpb.R"
-    "eplicaDescriptorB\004\310\336\037\000\022,\n\010range_id\030\006 \001(\003"
-    "B\032\310\336\037\000\342\336\037\007RangeID\372\336\037\007RangeID\022\030\n\ruser_pri"
-    "ority\030\007 \001(\005:\0011\022+\n\003txn\030\010 \001(\0132\036.cockroach."
-    "roachpb.Transaction\022F\n\020read_consistency\030"
-    "\t \001(\0162&.cockroach.roachpb.ReadConsistenc"
-    "yTypeB\004\310\336\037\000:\004\230\240\037\000\"\245\002\n\rBatchResponse\022A\n\006h"
-    "eader\030\001 \001(\0132\'.cockroach.roachpb.BatchRes"
-    "ponse.HeaderB\010\310\336\037\000\320\336\037\001\0229\n\tresponses\030\002 \003("
-    "\0132 .cockroach.roachpb.ResponseUnionB\004\310\336\037"
-    "\000\032\225\001\n\006Header\022\'\n\005error\030\001 \001(\0132\030.cockroach."
-    "roachpb.Error\0225\n\ttimestamp\030\002 \001(\0132\034.cockr"
-    "oach.roachpb.TimestampB\004\310\336\037\000\022+\n\003txn\030\003 \001("
-    "\0132\036.cockroach.roachpb.Transaction*L\n\023Rea"
-    "dConsistencyType\022\016\n\nCONSISTENT\020\000\022\r\n\tCONS"
-    "ENSUS\020\001\022\020\n\014INCONSISTENT\020\002\032\004\210\243\036\000*G\n\013PushT"
-    "xnType\022\022\n\016PUSH_TIMESTAMP\020\000\022\r\n\tABORT_TXN\020"
-    "\001\022\017\n\013CLEANUP_TXN\020\002\032\004\210\243\036\000B\031Z\007roachpb\340\342\036\001\310"
-    "\342\036\001\320\342\036\001\220\343\036\000", 9211);
+    "oachpb.ClientCmdIDB\r\310\336\037\000\342\336\037\005CmdID\022;\n\007rep"
+    "lica\030\005 \001(\0132$.cockroach.roachpb.ReplicaDe"
+    "scriptorB\004\310\336\037\000\022,\n\010range_id\030\006 \001(\003B\032\310\336\037\000\342\336"
+    "\037\007RangeID\372\336\037\007RangeID\022\030\n\ruser_priority\030\007 "
+    "\001(\005:\0011\022+\n\003txn\030\010 \001(\0132\036.cockroach.roachpb."
+    "Transaction\022F\n\020read_consistency\030\t \001(\0162&."
+    "cockroach.roachpb.ReadConsistencyTypeB\004\310"
+    "\336\037\000:\004\230\240\037\000\"\245\002\n\rBatchResponse\022A\n\006header\030\001 "
+    "\001(\0132\'.cockroach.roachpb.BatchResponse.He"
+    "aderB\010\310\336\037\000\320\336\037\001\0229\n\tresponses\030\002 \003(\0132 .cock"
+    "roach.roachpb.ResponseUnionB\004\310\336\037\000\032\225\001\n\006He"
+    "ader\022\'\n\005error\030\001 \001(\0132\030.cockroach.roachpb."
+    "Error\0225\n\ttimestamp\030\002 \001(\0132\034.cockroach.roa"
+    "chpb.TimestampB\004\310\336\037\000\022+\n\003txn\030\003 \001(\0132\036.cock"
+    "roach.roachpb.Transaction*L\n\023ReadConsist"
+    "encyType\022\016\n\nCONSISTENT\020\000\022\r\n\tCONSENSUS\020\001\022"
+    "\020\n\014INCONSISTENT\020\002\032\004\210\243\036\000*G\n\013PushTxnType\022\022"
+    "\n\016PUSH_TIMESTAMP\020\000\022\r\n\tABORT_TXN\020\001\022\017\n\013CLE"
+    "ANUP_TXN\020\002\032\004\210\243\036\000B\031Z\007roachpb\340\342\036\001\310\342\036\001\320\342\036\001\220"
+    "\343\036\000", 9163);
   ::google::protobuf::MessageFactory::InternalRegisterGeneratedFile(
     "cockroach/roachpb/api.proto", &protobuf_RegisterTypes);
   ClientCmdID::default_instance_ = new ClientCmdID();
@@ -22377,8 +22374,6 @@ void ResponseUnion::clear_noop() {
 #ifndef _MSC_VER
 const int BatchRequest_Header::kTimestampFieldNumber;
 const int BatchRequest_Header::kCmdIdFieldNumber;
-const int BatchRequest_Header::kKeyFieldNumber;
-const int BatchRequest_Header::kEndKeyFieldNumber;
 const int BatchRequest_Header::kReplicaFieldNumber;
 const int BatchRequest_Header::kRangeIdFieldNumber;
 const int BatchRequest_Header::kUserPriorityFieldNumber;
@@ -22408,12 +22403,9 @@ BatchRequest_Header::BatchRequest_Header(const BatchRequest_Header& from)
 }
 
 void BatchRequest_Header::SharedCtor() {
-  ::google::protobuf::internal::GetEmptyString();
   _cached_size_ = 0;
   timestamp_ = NULL;
   cmd_id_ = NULL;
-  key_.UnsafeSetDefault(&::google::protobuf::internal::GetEmptyStringAlreadyInited());
-  end_key_.UnsafeSetDefault(&::google::protobuf::internal::GetEmptyStringAlreadyInited());
   replica_ = NULL;
   range_id_ = GOOGLE_LONGLONG(0);
   user_priority_ = 1;
@@ -22428,8 +22420,6 @@ BatchRequest_Header::~BatchRequest_Header() {
 }
 
 void BatchRequest_Header::SharedDtor() {
-  key_.DestroyNoArena(&::google::protobuf::internal::GetEmptyStringAlreadyInited());
-  end_key_.DestroyNoArena(&::google::protobuf::internal::GetEmptyStringAlreadyInited());
   if (this != default_instance_) {
     delete timestamp_;
     delete cmd_id_;
@@ -22464,18 +22454,12 @@ BatchRequest_Header* BatchRequest_Header::New(::google::protobuf::Arena* arena) 
 }
 
 void BatchRequest_Header::Clear() {
-  if (_has_bits_[0 / 32] & 255u) {
+  if (_has_bits_[0 / 32] & 127u) {
     if (has_timestamp()) {
       if (timestamp_ != NULL) timestamp_->::cockroach::roachpb::Timestamp::Clear();
     }
     if (has_cmd_id()) {
       if (cmd_id_ != NULL) cmd_id_->::cockroach::roachpb::ClientCmdID::Clear();
-    }
-    if (has_key()) {
-      key_.ClearToEmptyNoArena(&::google::protobuf::internal::GetEmptyStringAlreadyInited());
-    }
-    if (has_end_key()) {
-      end_key_.ClearToEmptyNoArena(&::google::protobuf::internal::GetEmptyStringAlreadyInited());
     }
     if (has_replica()) {
       if (replica_ != NULL) replica_->::cockroach::roachpb::ReplicaDescriptor::Clear();
@@ -22485,8 +22469,8 @@ void BatchRequest_Header::Clear() {
     if (has_txn()) {
       if (txn_ != NULL) txn_->::cockroach::roachpb::Transaction::Clear();
     }
+    read_consistency_ = 0;
   }
-  read_consistency_ = 0;
   ::memset(_has_bits_, 0, sizeof(_has_bits_));
   if (_internal_metadata_.have_unknown_fields()) {
     mutable_unknown_fields()->Clear();
@@ -22521,32 +22505,6 @@ bool BatchRequest_Header::MergePartialFromCodedStream(
          parse_cmd_id:
           DO_(::google::protobuf::internal::WireFormatLite::ReadMessageNoVirtual(
                input, mutable_cmd_id()));
-        } else {
-          goto handle_unusual;
-        }
-        if (input->ExpectTag(26)) goto parse_key;
-        break;
-      }
-
-      // optional bytes key = 3;
-      case 3: {
-        if (tag == 26) {
-         parse_key:
-          DO_(::google::protobuf::internal::WireFormatLite::ReadBytes(
-                input, this->mutable_key()));
-        } else {
-          goto handle_unusual;
-        }
-        if (input->ExpectTag(34)) goto parse_end_key;
-        break;
-      }
-
-      // optional bytes end_key = 4;
-      case 4: {
-        if (tag == 34) {
-         parse_end_key:
-          DO_(::google::protobuf::internal::WireFormatLite::ReadBytes(
-                input, this->mutable_end_key()));
         } else {
           goto handle_unusual;
         }
@@ -22667,18 +22625,6 @@ void BatchRequest_Header::SerializeWithCachedSizes(
       2, *this->cmd_id_, output);
   }
 
-  // optional bytes key = 3;
-  if (has_key()) {
-    ::google::protobuf::internal::WireFormatLite::WriteBytesMaybeAliased(
-      3, this->key(), output);
-  }
-
-  // optional bytes end_key = 4;
-  if (has_end_key()) {
-    ::google::protobuf::internal::WireFormatLite::WriteBytesMaybeAliased(
-      4, this->end_key(), output);
-  }
-
   // optional .cockroach.roachpb.ReplicaDescriptor replica = 5;
   if (has_replica()) {
     ::google::protobuf::internal::WireFormatLite::WriteMessageMaybeToArray(
@@ -22731,20 +22677,6 @@ void BatchRequest_Header::SerializeWithCachedSizes(
         2, *this->cmd_id_, target);
   }
 
-  // optional bytes key = 3;
-  if (has_key()) {
-    target =
-      ::google::protobuf::internal::WireFormatLite::WriteBytesToArray(
-        3, this->key(), target);
-  }
-
-  // optional bytes end_key = 4;
-  if (has_end_key()) {
-    target =
-      ::google::protobuf::internal::WireFormatLite::WriteBytesToArray(
-        4, this->end_key(), target);
-  }
-
   // optional .cockroach.roachpb.ReplicaDescriptor replica = 5;
   if (has_replica()) {
     target = ::google::protobuf::internal::WireFormatLite::
@@ -22786,7 +22718,7 @@ void BatchRequest_Header::SerializeWithCachedSizes(
 int BatchRequest_Header::ByteSize() const {
   int total_size = 0;
 
-  if (_has_bits_[0 / 32] & 255) {
+  if (_has_bits_[0 / 32] & 127) {
     // optional .cockroach.roachpb.Timestamp timestamp = 1;
     if (has_timestamp()) {
       total_size += 1 +
@@ -22799,20 +22731,6 @@ int BatchRequest_Header::ByteSize() const {
       total_size += 1 +
         ::google::protobuf::internal::WireFormatLite::MessageSizeNoVirtual(
           *this->cmd_id_);
-    }
-
-    // optional bytes key = 3;
-    if (has_key()) {
-      total_size += 1 +
-        ::google::protobuf::internal::WireFormatLite::BytesSize(
-          this->key());
-    }
-
-    // optional bytes end_key = 4;
-    if (has_end_key()) {
-      total_size += 1 +
-        ::google::protobuf::internal::WireFormatLite::BytesSize(
-          this->end_key());
     }
 
     // optional .cockroach.roachpb.ReplicaDescriptor replica = 5;
@@ -22843,13 +22761,13 @@ int BatchRequest_Header::ByteSize() const {
           *this->txn_);
     }
 
-  }
-  // optional .cockroach.roachpb.ReadConsistencyType read_consistency = 9;
-  if (has_read_consistency()) {
-    total_size += 1 +
-      ::google::protobuf::internal::WireFormatLite::EnumSize(this->read_consistency());
-  }
+    // optional .cockroach.roachpb.ReadConsistencyType read_consistency = 9;
+    if (has_read_consistency()) {
+      total_size += 1 +
+        ::google::protobuf::internal::WireFormatLite::EnumSize(this->read_consistency());
+    }
 
+  }
   if (_internal_metadata_.have_unknown_fields()) {
     total_size +=
       ::google::protobuf::internal::WireFormat::ComputeUnknownFieldsSize(
@@ -22882,14 +22800,6 @@ void BatchRequest_Header::MergeFrom(const BatchRequest_Header& from) {
     if (from.has_cmd_id()) {
       mutable_cmd_id()->::cockroach::roachpb::ClientCmdID::MergeFrom(from.cmd_id());
     }
-    if (from.has_key()) {
-      set_has_key();
-      key_.AssignWithDefault(&::google::protobuf::internal::GetEmptyStringAlreadyInited(), from.key_);
-    }
-    if (from.has_end_key()) {
-      set_has_end_key();
-      end_key_.AssignWithDefault(&::google::protobuf::internal::GetEmptyStringAlreadyInited(), from.end_key_);
-    }
     if (from.has_replica()) {
       mutable_replica()->::cockroach::roachpb::ReplicaDescriptor::MergeFrom(from.replica());
     }
@@ -22902,8 +22812,6 @@ void BatchRequest_Header::MergeFrom(const BatchRequest_Header& from) {
     if (from.has_txn()) {
       mutable_txn()->::cockroach::roachpb::Transaction::MergeFrom(from.txn());
     }
-  }
-  if (from._has_bits_[8 / 32] & (0xffu << (8 % 32))) {
     if (from.has_read_consistency()) {
       set_read_consistency(from.read_consistency());
     }
@@ -22937,8 +22845,6 @@ void BatchRequest_Header::Swap(BatchRequest_Header* other) {
 void BatchRequest_Header::InternalSwap(BatchRequest_Header* other) {
   std::swap(timestamp_, other->timestamp_);
   std::swap(cmd_id_, other->cmd_id_);
-  key_.Swap(&other->key_);
-  end_key_.Swap(&other->end_key_);
   std::swap(replica_, other->replica_);
   std::swap(range_id_, other->range_id_);
   std::swap(user_priority_, other->user_priority_);
@@ -23324,121 +23230,15 @@ void BatchRequest_Header::clear_cmd_id() {
   // @@protoc_insertion_point(field_set_allocated:cockroach.roachpb.BatchRequest.Header.cmd_id)
 }
 
-// optional bytes key = 3;
-bool BatchRequest_Header::has_key() const {
-  return (_has_bits_[0] & 0x00000004u) != 0;
-}
-void BatchRequest_Header::set_has_key() {
-  _has_bits_[0] |= 0x00000004u;
-}
-void BatchRequest_Header::clear_has_key() {
-  _has_bits_[0] &= ~0x00000004u;
-}
-void BatchRequest_Header::clear_key() {
-  key_.ClearToEmptyNoArena(&::google::protobuf::internal::GetEmptyStringAlreadyInited());
-  clear_has_key();
-}
- const ::std::string& BatchRequest_Header::key() const {
-  // @@protoc_insertion_point(field_get:cockroach.roachpb.BatchRequest.Header.key)
-  return key_.GetNoArena(&::google::protobuf::internal::GetEmptyStringAlreadyInited());
-}
- void BatchRequest_Header::set_key(const ::std::string& value) {
-  set_has_key();
-  key_.SetNoArena(&::google::protobuf::internal::GetEmptyStringAlreadyInited(), value);
-  // @@protoc_insertion_point(field_set:cockroach.roachpb.BatchRequest.Header.key)
-}
- void BatchRequest_Header::set_key(const char* value) {
-  set_has_key();
-  key_.SetNoArena(&::google::protobuf::internal::GetEmptyStringAlreadyInited(), ::std::string(value));
-  // @@protoc_insertion_point(field_set_char:cockroach.roachpb.BatchRequest.Header.key)
-}
- void BatchRequest_Header::set_key(const void* value, size_t size) {
-  set_has_key();
-  key_.SetNoArena(&::google::protobuf::internal::GetEmptyStringAlreadyInited(),
-      ::std::string(reinterpret_cast<const char*>(value), size));
-  // @@protoc_insertion_point(field_set_pointer:cockroach.roachpb.BatchRequest.Header.key)
-}
- ::std::string* BatchRequest_Header::mutable_key() {
-  set_has_key();
-  // @@protoc_insertion_point(field_mutable:cockroach.roachpb.BatchRequest.Header.key)
-  return key_.MutableNoArena(&::google::protobuf::internal::GetEmptyStringAlreadyInited());
-}
- ::std::string* BatchRequest_Header::release_key() {
-  clear_has_key();
-  return key_.ReleaseNoArena(&::google::protobuf::internal::GetEmptyStringAlreadyInited());
-}
- void BatchRequest_Header::set_allocated_key(::std::string* key) {
-  if (key != NULL) {
-    set_has_key();
-  } else {
-    clear_has_key();
-  }
-  key_.SetAllocatedNoArena(&::google::protobuf::internal::GetEmptyStringAlreadyInited(), key);
-  // @@protoc_insertion_point(field_set_allocated:cockroach.roachpb.BatchRequest.Header.key)
-}
-
-// optional bytes end_key = 4;
-bool BatchRequest_Header::has_end_key() const {
-  return (_has_bits_[0] & 0x00000008u) != 0;
-}
-void BatchRequest_Header::set_has_end_key() {
-  _has_bits_[0] |= 0x00000008u;
-}
-void BatchRequest_Header::clear_has_end_key() {
-  _has_bits_[0] &= ~0x00000008u;
-}
-void BatchRequest_Header::clear_end_key() {
-  end_key_.ClearToEmptyNoArena(&::google::protobuf::internal::GetEmptyStringAlreadyInited());
-  clear_has_end_key();
-}
- const ::std::string& BatchRequest_Header::end_key() const {
-  // @@protoc_insertion_point(field_get:cockroach.roachpb.BatchRequest.Header.end_key)
-  return end_key_.GetNoArena(&::google::protobuf::internal::GetEmptyStringAlreadyInited());
-}
- void BatchRequest_Header::set_end_key(const ::std::string& value) {
-  set_has_end_key();
-  end_key_.SetNoArena(&::google::protobuf::internal::GetEmptyStringAlreadyInited(), value);
-  // @@protoc_insertion_point(field_set:cockroach.roachpb.BatchRequest.Header.end_key)
-}
- void BatchRequest_Header::set_end_key(const char* value) {
-  set_has_end_key();
-  end_key_.SetNoArena(&::google::protobuf::internal::GetEmptyStringAlreadyInited(), ::std::string(value));
-  // @@protoc_insertion_point(field_set_char:cockroach.roachpb.BatchRequest.Header.end_key)
-}
- void BatchRequest_Header::set_end_key(const void* value, size_t size) {
-  set_has_end_key();
-  end_key_.SetNoArena(&::google::protobuf::internal::GetEmptyStringAlreadyInited(),
-      ::std::string(reinterpret_cast<const char*>(value), size));
-  // @@protoc_insertion_point(field_set_pointer:cockroach.roachpb.BatchRequest.Header.end_key)
-}
- ::std::string* BatchRequest_Header::mutable_end_key() {
-  set_has_end_key();
-  // @@protoc_insertion_point(field_mutable:cockroach.roachpb.BatchRequest.Header.end_key)
-  return end_key_.MutableNoArena(&::google::protobuf::internal::GetEmptyStringAlreadyInited());
-}
- ::std::string* BatchRequest_Header::release_end_key() {
-  clear_has_end_key();
-  return end_key_.ReleaseNoArena(&::google::protobuf::internal::GetEmptyStringAlreadyInited());
-}
- void BatchRequest_Header::set_allocated_end_key(::std::string* end_key) {
-  if (end_key != NULL) {
-    set_has_end_key();
-  } else {
-    clear_has_end_key();
-  }
-  end_key_.SetAllocatedNoArena(&::google::protobuf::internal::GetEmptyStringAlreadyInited(), end_key);
-  // @@protoc_insertion_point(field_set_allocated:cockroach.roachpb.BatchRequest.Header.end_key)
-}
-
 // optional .cockroach.roachpb.ReplicaDescriptor replica = 5;
 bool BatchRequest_Header::has_replica() const {
-  return (_has_bits_[0] & 0x00000010u) != 0;
+  return (_has_bits_[0] & 0x00000004u) != 0;
 }
 void BatchRequest_Header::set_has_replica() {
-  _has_bits_[0] |= 0x00000010u;
+  _has_bits_[0] |= 0x00000004u;
 }
 void BatchRequest_Header::clear_has_replica() {
-  _has_bits_[0] &= ~0x00000010u;
+  _has_bits_[0] &= ~0x00000004u;
 }
 void BatchRequest_Header::clear_replica() {
   if (replica_ != NULL) replica_->::cockroach::roachpb::ReplicaDescriptor::Clear();
@@ -23475,13 +23275,13 @@ void BatchRequest_Header::clear_replica() {
 
 // optional int64 range_id = 6;
 bool BatchRequest_Header::has_range_id() const {
-  return (_has_bits_[0] & 0x00000020u) != 0;
+  return (_has_bits_[0] & 0x00000008u) != 0;
 }
 void BatchRequest_Header::set_has_range_id() {
-  _has_bits_[0] |= 0x00000020u;
+  _has_bits_[0] |= 0x00000008u;
 }
 void BatchRequest_Header::clear_has_range_id() {
-  _has_bits_[0] &= ~0x00000020u;
+  _has_bits_[0] &= ~0x00000008u;
 }
 void BatchRequest_Header::clear_range_id() {
   range_id_ = GOOGLE_LONGLONG(0);
@@ -23499,13 +23299,13 @@ void BatchRequest_Header::clear_range_id() {
 
 // optional int32 user_priority = 7 [default = 1];
 bool BatchRequest_Header::has_user_priority() const {
-  return (_has_bits_[0] & 0x00000040u) != 0;
+  return (_has_bits_[0] & 0x00000010u) != 0;
 }
 void BatchRequest_Header::set_has_user_priority() {
-  _has_bits_[0] |= 0x00000040u;
+  _has_bits_[0] |= 0x00000010u;
 }
 void BatchRequest_Header::clear_has_user_priority() {
-  _has_bits_[0] &= ~0x00000040u;
+  _has_bits_[0] &= ~0x00000010u;
 }
 void BatchRequest_Header::clear_user_priority() {
   user_priority_ = 1;
@@ -23523,13 +23323,13 @@ void BatchRequest_Header::clear_user_priority() {
 
 // optional .cockroach.roachpb.Transaction txn = 8;
 bool BatchRequest_Header::has_txn() const {
-  return (_has_bits_[0] & 0x00000080u) != 0;
+  return (_has_bits_[0] & 0x00000020u) != 0;
 }
 void BatchRequest_Header::set_has_txn() {
-  _has_bits_[0] |= 0x00000080u;
+  _has_bits_[0] |= 0x00000020u;
 }
 void BatchRequest_Header::clear_has_txn() {
-  _has_bits_[0] &= ~0x00000080u;
+  _has_bits_[0] &= ~0x00000020u;
 }
 void BatchRequest_Header::clear_txn() {
   if (txn_ != NULL) txn_->::cockroach::roachpb::Transaction::Clear();
@@ -23566,13 +23366,13 @@ void BatchRequest_Header::clear_txn() {
 
 // optional .cockroach.roachpb.ReadConsistencyType read_consistency = 9;
 bool BatchRequest_Header::has_read_consistency() const {
-  return (_has_bits_[0] & 0x00000100u) != 0;
+  return (_has_bits_[0] & 0x00000040u) != 0;
 }
 void BatchRequest_Header::set_has_read_consistency() {
-  _has_bits_[0] |= 0x00000100u;
+  _has_bits_[0] |= 0x00000040u;
 }
 void BatchRequest_Header::clear_has_read_consistency() {
-  _has_bits_[0] &= ~0x00000100u;
+  _has_bits_[0] &= ~0x00000040u;
 }
 void BatchRequest_Header::clear_read_consistency() {
   read_consistency_ = 0;

--- a/storage/engine/rocksdb/cockroach/roachpb/api.pb.cc
+++ b/storage/engine/rocksdb/cockroach/roachpb/api.pb.cc
@@ -206,17 +206,11 @@ void protobuf_AssignDesc_cockroach_2froachpb_2fapi_2eproto() {
       GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(ClientCmdID, _internal_metadata_),
       -1);
   RequestHeader_descriptor_ = file->message_type(1);
-<<<<<<< HEAD
-  static const int RequestHeader_offsets_[5] = {
-=======
-  static const int RequestHeader_offsets_[6] = {
-    GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(RequestHeader, cmd_id_),
->>>>>>> a0fb5b0... make RequestHeader.ReadConsistency obsolete
+  static const int RequestHeader_offsets_[4] = {
     GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(RequestHeader, key_),
     GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(RequestHeader, end_key_),
     GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(RequestHeader, user_priority_),
     GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(RequestHeader, txn_),
-    GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(RequestHeader, read_consistency_),
   };
   RequestHeader_reflection_ =
     ::google::protobuf::internal::GeneratedMessageReflection::NewGeneratedMessageReflection(
@@ -1311,451 +1305,225 @@ void protobuf_AddDesc_cockroach_2froachpb_2fapi_2eproto() {
     "to\032\034cockroach/roachpb/data.proto\032\036cockro"
     "ach/roachpb/errors.proto\032\024gogoproto/gogo"
     ".proto\"<\n\013ClientCmdID\022\027\n\twall_time\030\001 \001(\003"
-<<<<<<< HEAD
-    "B\004\310\336\037\000\022\024\n\006random\030\002 \001(\003B\004\310\336\037\000\"\316\001\n\rRequest"
+    "B\004\310\336\037\000\022\024\n\006random\030\002 \001(\003B\004\310\336\037\000\"\206\001\n\rRequest"
     "Header\022\024\n\003key\030\003 \001(\014B\007\372\336\037\003Key\022\030\n\007end_key\030"
     "\004 \001(\014B\007\372\336\037\003Key\022\030\n\ruser_priority\030\007 \001(\005:\0011"
     "\022+\n\003txn\030\010 \001(\0132\036.cockroach.roachpb.Transa"
-    "ction\022F\n\020read_consistency\030\t \001(\0162&.cockro"
-    "ach.roachpb.ReadConsistencyTypeB\004\310\336\037\000\"t\n"
-    "\016ResponseHeader\0225\n\ttimestamp\030\002 \001(\0132\034.coc"
-    "kroach.roachpb.TimestampB\004\310\336\037\000\022+\n\003txn\030\003 "
-    "\001(\0132\036.cockroach.roachpb.Transaction\"H\n\nG"
-    "etRequest\022:\n\006header\030\001 \001(\0132 .cockroach.ro"
-    "achpb.RequestHeaderB\010\310\336\037\000\320\336\037\001\"s\n\013GetResp"
-    "onse\022;\n\006header\030\001 \001(\0132!.cockroach.roachpb"
-    ".ResponseHeaderB\010\310\336\037\000\320\336\037\001\022\'\n\005value\030\002 \001(\013"
-    "2\030.cockroach.roachpb.Value\"w\n\nPutRequest"
-    "\022:\n\006header\030\001 \001(\0132 .cockroach.roachpb.Req"
-    "uestHeaderB\010\310\336\037\000\320\336\037\001\022-\n\005value\030\002 \001(\0132\030.co"
-    "ckroach.roachpb.ValueB\004\310\336\037\000\"J\n\013PutRespon"
-    "se\022;\n\006header\030\001 \001(\0132!.cockroach.roachpb.R"
-    "esponseHeaderB\010\310\336\037\000\320\336\037\001\"\257\001\n\025ConditionalP"
-    "utRequest\022:\n\006header\030\001 \001(\0132 .cockroach.ro"
-    "achpb.RequestHeaderB\010\310\336\037\000\320\336\037\001\022-\n\005value\030\002"
-    " \001(\0132\030.cockroach.roachpb.ValueB\004\310\336\037\000\022+\n\t"
-    "exp_value\030\003 \001(\0132\030.cockroach.roachpb.Valu"
-    "e\"U\n\026ConditionalPutResponse\022;\n\006header\030\001 "
-    "\001(\0132!.cockroach.roachpb.ResponseHeaderB\010"
-    "\310\336\037\000\320\336\037\001\"g\n\020IncrementRequest\022:\n\006header\030\001"
-    " \001(\0132 .cockroach.roachpb.RequestHeaderB\010"
-    "\310\336\037\000\320\336\037\001\022\027\n\tincrement\030\002 \001(\003B\004\310\336\037\000\"i\n\021Inc"
-    "rementResponse\022;\n\006header\030\001 \001(\0132!.cockroa"
-    "ch.roachpb.ResponseHeaderB\010\310\336\037\000\320\336\037\001\022\027\n\tn"
-    "ew_value\030\002 \001(\003B\004\310\336\037\000\"K\n\rDeleteRequest\022:\n"
-    "\006header\030\001 \001(\0132 .cockroach.roachpb.Reques"
-    "tHeaderB\010\310\336\037\000\320\336\037\001\"M\n\016DeleteResponse\022;\n\006h"
-    "eader\030\001 \001(\0132!.cockroach.roachpb.Response"
-    "HeaderB\010\310\336\037\000\320\336\037\001\"u\n\022DeleteRangeRequest\022:"
-    "\n\006header\030\001 \001(\0132 .cockroach.roachpb.Reque"
-    "stHeaderB\010\310\336\037\000\320\336\037\001\022#\n\025max_entries_to_del"
-    "ete\030\002 \001(\003B\004\310\336\037\000\"m\n\023DeleteRangeResponse\022;"
-    "\n\006header\030\001 \001(\0132!.cockroach.roachpb.Respo"
-    "nseHeaderB\010\310\336\037\000\320\336\037\001\022\031\n\013num_deleted\030\002 \001(\003"
-    "B\004\310\336\037\000\"d\n\013ScanRequest\022:\n\006header\030\001 \001(\0132 ."
-    "cockroach.roachpb.RequestHeaderB\010\310\336\037\000\320\336\037"
-    "\001\022\031\n\013max_results\030\002 \001(\003B\004\310\336\037\000\"|\n\014ScanResp"
-    "onse\022;\n\006header\030\001 \001(\0132!.cockroach.roachpb"
-    ".ResponseHeaderB\010\310\336\037\000\320\336\037\001\022/\n\004rows\030\002 \003(\0132"
-    "\033.cockroach.roachpb.KeyValueB\004\310\336\037\000\"k\n\022Re"
-    "verseScanRequest\022:\n\006header\030\001 \001(\0132 .cockr"
-    "oach.roachpb.RequestHeaderB\010\310\336\037\000\320\336\037\001\022\031\n\013"
-    "max_results\030\002 \001(\003B\004\310\336\037\000\"\203\001\n\023ReverseScanR"
-    "esponse\022;\n\006header\030\001 \001(\0132!.cockroach.roac"
-    "hpb.ResponseHeaderB\010\310\336\037\000\320\336\037\001\022/\n\004rows\030\002 \003"
-    "(\0132\033.cockroach.roachpb.KeyValueB\004\310\336\037\000\"\346\001"
-    "\n\025EndTransactionRequest\022:\n\006header\030\001 \001(\0132"
-    " .cockroach.roachpb.RequestHeaderB\010\310\336\037\000\320"
-    "\336\037\001\022\024\n\006commit\030\002 \001(\010B\004\310\336\037\000\022I\n\027internal_co"
-    "mmit_trigger\030\003 \001(\0132(.cockroach.roachpb.I"
-    "nternalCommitTrigger\0220\n\007intents\030\004 \003(\0132\031."
-    "cockroach.roachpb.IntentB\004\310\336\037\000\"\213\001\n\026EndTr"
-    "ansactionResponse\022;\n\006header\030\001 \001(\0132!.cock"
-    "roach.roachpb.ResponseHeaderB\010\310\336\037\000\320\336\037\001\022\031"
-    "\n\013commit_wait\030\002 \001(\003B\004\310\336\037\000\022\031\n\010resolved\030\003 "
-    "\003(\014B\007\372\336\037\003Key\"k\n\021AdminSplitRequest\022:\n\006hea"
-    "der\030\001 \001(\0132 .cockroach.roachpb.RequestHea"
-    "derB\010\310\336\037\000\320\336\037\001\022\032\n\tsplit_key\030\002 \001(\014B\007\372\336\037\003Ke"
-    "y\"Q\n\022AdminSplitResponse\022;\n\006header\030\001 \001(\0132"
-    "!.cockroach.roachpb.ResponseHeaderB\010\310\336\037\000"
-    "\320\336\037\001\"O\n\021AdminMergeRequest\022:\n\006header\030\001 \001("
-    "\0132 .cockroach.roachpb.RequestHeaderB\010\310\336\037"
-    "\000\320\336\037\001\"Q\n\022AdminMergeResponse\022;\n\006header\030\001 "
-    "\001(\0132!.cockroach.roachpb.ResponseHeaderB\010"
-    "\310\336\037\000\320\336\037\001\"\241\001\n\022RangeLookupRequest\022:\n\006heade"
-    "r\030\001 \001(\0132 .cockroach.roachpb.RequestHeade"
-    "rB\010\310\336\037\000\320\336\037\001\022\030\n\nmax_ranges\030\002 \001(\005B\004\310\336\037\000\022\036\n"
-    "\020consider_intents\030\003 \001(\010B\004\310\336\037\000\022\025\n\007reverse"
-    "\030\004 \001(\010B\004\310\336\037\000\"\214\001\n\023RangeLookupResponse\022;\n\006"
-    "header\030\001 \001(\0132!.cockroach.roachpb.Respons"
-    "eHeaderB\010\310\336\037\000\320\336\037\001\0228\n\006ranges\030\002 \003(\0132\".cock"
-    "roach.roachpb.RangeDescriptorB\004\310\336\037\000\"Q\n\023H"
-    "eartbeatTxnRequest\022:\n\006header\030\001 \001(\0132 .coc"
-    "kroach.roachpb.RequestHeaderB\010\310\336\037\000\320\336\037\001\"S"
-    "\n\024HeartbeatTxnResponse\022;\n\006header\030\001 \001(\0132!"
-    ".cockroach.roachpb.ResponseHeaderB\010\310\336\037\000\320"
-    "\336\037\001\"\225\002\n\tGCRequest\022:\n\006header\030\001 \001(\0132 .cock"
-    "roach.roachpb.RequestHeaderB\010\310\336\037\000\320\336\037\001\022>\n"
-    "\007gc_meta\030\002 \001(\0132\035.cockroach.roachpb.GCMet"
-    "adataB\016\310\336\037\000\342\336\037\006GCMeta\0226\n\004keys\030\003 \003(\0132\".co"
-    "ckroach.roachpb.GCRequest.GCKeyB\004\310\336\037\000\032T\n"
-    "\005GCKey\022\024\n\003key\030\001 \001(\014B\007\372\336\037\003Key\0225\n\ttimestam"
-    "p\030\002 \001(\0132\034.cockroach.roachpb.TimestampB\004\310"
-    "\336\037\000\"I\n\nGCResponse\022;\n\006header\030\001 \001(\0132!.cock"
-    "roach.roachpb.ResponseHeaderB\010\310\336\037\000\320\336\037\001\"\337"
-    "\002\n\016PushTxnRequest\022:\n\006header\030\001 \001(\0132 .cock"
-    "roach.roachpb.RequestHeaderB\010\310\336\037\000\320\336\037\001\0228\n"
-    "\npusher_txn\030\002 \001(\0132\036.cockroach.roachpb.Tr"
-    "ansactionB\004\310\336\037\000\0228\n\npushee_txn\030\003 \001(\0132\036.co"
-    "ckroach.roachpb.TransactionB\004\310\336\037\000\0223\n\007pus"
-    "h_to\030\004 \001(\0132\034.cockroach.roachpb.Timestamp"
-    "B\004\310\336\037\000\022/\n\003now\030\005 \001(\0132\034.cockroach.roachpb."
-    "TimestampB\004\310\336\037\000\0227\n\tpush_type\030\006 \001(\0162\036.coc"
-    "kroach.roachpb.PushTxnTypeB\004\310\336\037\000\"\202\001\n\017Pus"
-    "hTxnResponse\022;\n\006header\030\001 \001(\0132!.cockroach"
-    ".roachpb.ResponseHeaderB\010\310\336\037\000\320\336\037\001\0222\n\npus"
-    "hee_txn\030\002 \001(\0132\036.cockroach.roachpb.Transa"
-    "ction\"\214\001\n\024ResolveIntentRequest\022:\n\006header"
-    "\030\001 \001(\0132 .cockroach.roachpb.RequestHeader"
-    "B\010\310\336\037\000\320\336\037\001\0228\n\nintent_txn\030\002 \001(\0132\036.cockroa"
-    "ch.roachpb.TransactionB\004\310\336\037\000\"T\n\025ResolveI"
-    "ntentResponse\022;\n\006header\030\001 \001(\0132!.cockroac"
-    "h.roachpb.ResponseHeaderB\010\310\336\037\000\320\336\037\001\"\221\001\n\031R"
-    "esolveIntentRangeRequest\022:\n\006header\030\001 \001(\013"
-    "2 .cockroach.roachpb.RequestHeaderB\010\310\336\037\000"
-    "\320\336\037\001\0228\n\nintent_txn\030\002 \001(\0132\036.cockroach.roa"
-    "chpb.TransactionB\004\310\336\037\000\"K\n\014NoopResponse\022;"
-    "\n\006header\030\001 \001(\0132!.cockroach.roachpb.Respo"
-    "nseHeaderB\010\310\336\037\000\320\336\037\001\"I\n\013NoopRequest\022:\n\006he"
-    "ader\030\001 \001(\0132 .cockroach.roachpb.RequestHe"
-    "aderB\010\310\336\037\000\320\336\037\001\"Y\n\032ResolveIntentRangeResp"
-    "onse\022;\n\006header\030\001 \001(\0132!.cockroach.roachpb"
-    ".ResponseHeaderB\010\310\336\037\000\320\336\037\001\"y\n\014MergeReques"
-    "t\022:\n\006header\030\001 \001(\0132 .cockroach.roachpb.Re"
-    "questHeaderB\010\310\336\037\000\320\336\037\001\022-\n\005value\030\002 \001(\0132\030.c"
-    "ockroach.roachpb.ValueB\004\310\336\037\000\"L\n\rMergeRes"
-    "ponse\022;\n\006header\030\001 \001(\0132!.cockroach.roachp"
-    "b.ResponseHeaderB\010\310\336\037\000\320\336\037\001\"e\n\022TruncateLo"
-    "gRequest\022:\n\006header\030\001 \001(\0132 .cockroach.roa"
-    "chpb.RequestHeaderB\010\310\336\037\000\320\336\037\001\022\023\n\005index\030\002 "
-    "\001(\004B\004\310\336\037\000\"R\n\023TruncateLogResponse\022;\n\006head"
-    "er\030\001 \001(\0132!.cockroach.roachpb.ResponseHea"
-    "derB\010\310\336\037\000\320\336\037\001\"\177\n\022LeaderLeaseRequest\022:\n\006h"
-    "eader\030\001 \001(\0132 .cockroach.roachpb.RequestH"
-    "eaderB\010\310\336\037\000\320\336\037\001\022-\n\005lease\030\002 \001(\0132\030.cockroa"
-    "ch.roachpb.LeaseB\004\310\336\037\000\"R\n\023LeaderLeaseRes"
-    "ponse\022;\n\006header\030\001 \001(\0132!.cockroach.roachp"
-    "b.ResponseHeaderB\010\310\336\037\000\320\336\037\001\"\272\t\n\014RequestUn"
-    "ion\022*\n\003get\030\001 \001(\0132\035.cockroach.roachpb.Get"
-    "Request\022*\n\003put\030\002 \001(\0132\035.cockroach.roachpb"
-    ".PutRequest\022A\n\017conditional_put\030\003 \001(\0132(.c"
-    "ockroach.roachpb.ConditionalPutRequest\0226"
-    "\n\tincrement\030\004 \001(\0132#.cockroach.roachpb.In"
-    "crementRequest\0220\n\006delete\030\005 \001(\0132 .cockroa"
-    "ch.roachpb.DeleteRequest\022;\n\014delete_range"
-    "\030\006 \001(\0132%.cockroach.roachpb.DeleteRangeRe"
-    "quest\022,\n\004scan\030\007 \001(\0132\036.cockroach.roachpb."
-    "ScanRequest\022A\n\017end_transaction\030\010 \001(\0132(.c"
-    "ockroach.roachpb.EndTransactionRequest\0229"
-    "\n\013admin_split\030\t \001(\0132$.cockroach.roachpb."
-    "AdminSplitRequest\0229\n\013admin_merge\030\n \001(\0132$"
-    ".cockroach.roachpb.AdminMergeRequest\022=\n\r"
-    "heartbeat_txn\030\013 \001(\0132&.cockroach.roachpb."
-    "HeartbeatTxnRequest\022(\n\002gc\030\014 \001(\0132\034.cockro"
-    "ach.roachpb.GCRequest\0223\n\010push_txn\030\r \001(\0132"
-    "!.cockroach.roachpb.PushTxnRequest\022;\n\014ra"
-    "nge_lookup\030\016 \001(\0132%.cockroach.roachpb.Ran"
-    "geLookupRequest\022\?\n\016resolve_intent\030\017 \001(\0132"
-    "\'.cockroach.roachpb.ResolveIntentRequest"
-    "\022J\n\024resolve_intent_range\030\020 \001(\0132,.cockroa"
-    "ch.roachpb.ResolveIntentRangeRequest\022.\n\005"
-    "merge\030\021 \001(\0132\037.cockroach.roachpb.MergeReq"
-    "uest\022;\n\014truncate_log\030\022 \001(\0132%.cockroach.r"
-    "oachpb.TruncateLogRequest\022;\n\014leader_leas"
-    "e\030\023 \001(\0132%.cockroach.roachpb.LeaderLeaseR"
-    "equest\022;\n\014reverse_scan\030\024 \001(\0132%.cockroach"
-    ".roachpb.ReverseScanRequest\022,\n\004noop\030\025 \001("
-    "\0132\036.cockroach.roachpb.NoopRequest:\004\310\240\037\001\""
-    "\320\t\n\rResponseUnion\022+\n\003get\030\001 \001(\0132\036.cockroa"
-    "ch.roachpb.GetResponse\022+\n\003put\030\002 \001(\0132\036.co"
-    "ckroach.roachpb.PutResponse\022B\n\017condition"
-    "al_put\030\003 \001(\0132).cockroach.roachpb.Conditi"
-    "onalPutResponse\0227\n\tincrement\030\004 \001(\0132$.coc"
-    "kroach.roachpb.IncrementResponse\0221\n\006dele"
-    "te\030\005 \001(\0132!.cockroach.roachpb.DeleteRespo"
-    "nse\022<\n\014delete_range\030\006 \001(\0132&.cockroach.ro"
-    "achpb.DeleteRangeResponse\022-\n\004scan\030\007 \001(\0132"
-    "\037.cockroach.roachpb.ScanResponse\022B\n\017end_"
-    "transaction\030\010 \001(\0132).cockroach.roachpb.En"
-    "dTransactionResponse\022:\n\013admin_split\030\t \001("
-    "\0132%.cockroach.roachpb.AdminSplitResponse"
-    "\022:\n\013admin_merge\030\n \001(\0132%.cockroach.roachp"
-    "b.AdminMergeResponse\022>\n\rheartbeat_txn\030\013 "
-    "\001(\0132\'.cockroach.roachpb.HeartbeatTxnResp"
-    "onse\022)\n\002gc\030\014 \001(\0132\035.cockroach.roachpb.GCR"
-    "esponse\0224\n\010push_txn\030\r \001(\0132\".cockroach.ro"
-    "achpb.PushTxnResponse\022<\n\014range_lookup\030\016 "
-    "\001(\0132&.cockroach.roachpb.RangeLookupRespo"
-    "nse\022@\n\016resolve_intent\030\017 \001(\0132(.cockroach."
-    "roachpb.ResolveIntentResponse\022K\n\024resolve"
-    "_intent_range\030\020 \001(\0132-.cockroach.roachpb."
-    "ResolveIntentRangeResponse\022/\n\005merge\030\021 \001("
-    "\0132 .cockroach.roachpb.MergeResponse\022<\n\014t"
-    "runcate_log\030\022 \001(\0132&.cockroach.roachpb.Tr"
-    "uncateLogResponse\022<\n\014leader_lease\030\023 \001(\0132"
-    "&.cockroach.roachpb.LeaderLeaseResponse\022"
-    "<\n\014reverse_scan\030\024 \001(\0132&.cockroach.roachp"
-    "b.ReverseScanResponse\022-\n\004noop\030\025 \001(\0132\037.co"
-    "ckroach.roachpb.NoopResponse:\004\310\240\037\001\"\212\004\n\014B"
-    "atchRequest\022@\n\006header\030\001 \001(\0132&.cockroach."
-    "roachpb.BatchRequest.HeaderB\010\310\336\037\000\320\336\037\001\0227\n"
-    "\010requests\030\002 \003(\0132\037.cockroach.roachpb.Requ"
-    "estUnionB\004\310\336\037\000\032\370\002\n\006Header\0225\n\ttimestamp\030\001"
-    " \001(\0132\034.cockroach.roachpb.TimestampB\004\310\336\037\000"
-    "\022=\n\006cmd_id\030\002 \001(\0132\036.cockroach.roachpb.Cli"
-    "entCmdIDB\r\310\336\037\000\342\336\037\005CmdID\022;\n\007replica\030\005 \001(\013"
-    "2$.cockroach.roachpb.ReplicaDescriptorB\004"
-    "\310\336\037\000\022,\n\010range_id\030\006 \001(\003B\032\310\336\037\000\342\336\037\007RangeID\372"
-    "\336\037\007RangeID\022\030\n\ruser_priority\030\007 \001(\005:\0011\022+\n\003"
-    "txn\030\010 \001(\0132\036.cockroach.roachpb.Transactio"
-    "n\022F\n\020read_consistency\030\t \001(\0162&.cockroach."
-    "roachpb.ReadConsistencyTypeB\004\310\336\037\000:\004\230\240\037\000\""
-    "\245\002\n\rBatchResponse\022A\n\006header\030\001 \001(\0132\'.cock"
-    "roach.roachpb.BatchResponse.HeaderB\010\310\336\037\000"
-    "\320\336\037\001\0229\n\tresponses\030\002 \003(\0132 .cockroach.roac"
-    "hpb.ResponseUnionB\004\310\336\037\000\032\225\001\n\006Header\022\'\n\005er"
-    "ror\030\001 \001(\0132\030.cockroach.roachpb.Error\0225\n\tt"
-    "imestamp\030\002 \001(\0132\034.cockroach.roachpb.Times"
-    "tampB\004\310\336\037\000\022+\n\003txn\030\003 \001(\0132\036.cockroach.roac"
-    "hpb.Transaction*L\n\023ReadConsistencyType\022\016"
-    "\n\nCONSISTENT\020\000\022\r\n\tCONSENSUS\020\001\022\020\n\014INCONSI"
-    "STENT\020\002\032\004\210\243\036\000*G\n\013PushTxnType\022\022\n\016PUSH_TIM"
-    "ESTAMP\020\000\022\r\n\tABORT_TXN\020\001\022\017\n\013CLEANUP_TXN\020\002"
-    "\032\004\210\243\036\000B\031Z\007roachpb\340\342\036\001\310\342\036\001\320\342\036\001\220\343\036\000", 8993);
-=======
-    "B\004\310\336\037\000\022\024\n\006random\030\002 \001(\003B\004\310\336\037\000\"\215\002\n\rRequest"
-    "Header\022=\n\006cmd_id\030\002 \001(\0132\036.cockroach.roach"
-    "pb.ClientCmdIDB\r\310\336\037\000\342\336\037\005CmdID\022\024\n\003key\030\003 \001"
-    "(\014B\007\372\336\037\003Key\022\030\n\007end_key\030\004 \001(\014B\007\372\336\037\003Key\022\030\n"
-    "\ruser_priority\030\007 \001(\005:\0011\022+\n\003txn\030\010 \001(\0132\036.c"
-    "ockroach.roachpb.Transaction\022F\n\020read_con"
-    "sistency\030\t \001(\0162&.cockroach.roachpb.ReadC"
-    "onsistencyTypeB\004\310\336\037\000\"t\n\016ResponseHeader\0225"
-    "\n\ttimestamp\030\002 \001(\0132\034.cockroach.roachpb.Ti"
-    "mestampB\004\310\336\037\000\022+\n\003txn\030\003 \001(\0132\036.cockroach.r"
-    "oachpb.Transaction\"H\n\nGetRequest\022:\n\006head"
-    "er\030\001 \001(\0132 .cockroach.roachpb.RequestHead"
-    "erB\010\310\336\037\000\320\336\037\001\"s\n\013GetResponse\022;\n\006header\030\001 "
-    "\001(\0132!.cockroach.roachpb.ResponseHeaderB\010"
-    "\310\336\037\000\320\336\037\001\022\'\n\005value\030\002 \001(\0132\030.cockroach.roac"
-    "hpb.Value\"w\n\nPutRequest\022:\n\006header\030\001 \001(\0132"
-    " .cockroach.roachpb.RequestHeaderB\010\310\336\037\000\320"
-    "\336\037\001\022-\n\005value\030\002 \001(\0132\030.cockroach.roachpb.V"
-    "alueB\004\310\336\037\000\"J\n\013PutResponse\022;\n\006header\030\001 \001("
-    "\0132!.cockroach.roachpb.ResponseHeaderB\010\310\336"
-    "\037\000\320\336\037\001\"\257\001\n\025ConditionalPutRequest\022:\n\006head"
-    "er\030\001 \001(\0132 .cockroach.roachpb.RequestHead"
-    "erB\010\310\336\037\000\320\336\037\001\022-\n\005value\030\002 \001(\0132\030.cockroach."
-    "roachpb.ValueB\004\310\336\037\000\022+\n\texp_value\030\003 \001(\0132\030"
-    ".cockroach.roachpb.Value\"U\n\026ConditionalP"
+    "ction\"t\n\016ResponseHeader\0225\n\ttimestamp\030\002 \001"
+    "(\0132\034.cockroach.roachpb.TimestampB\004\310\336\037\000\022+"
+    "\n\003txn\030\003 \001(\0132\036.cockroach.roachpb.Transact"
+    "ion\"H\n\nGetRequest\022:\n\006header\030\001 \001(\0132 .cock"
+    "roach.roachpb.RequestHeaderB\010\310\336\037\000\320\336\037\001\"s\n"
+    "\013GetResponse\022;\n\006header\030\001 \001(\0132!.cockroach"
+    ".roachpb.ResponseHeaderB\010\310\336\037\000\320\336\037\001\022\'\n\005val"
+    "ue\030\002 \001(\0132\030.cockroach.roachpb.Value\"w\n\nPu"
+    "tRequest\022:\n\006header\030\001 \001(\0132 .cockroach.roa"
+    "chpb.RequestHeaderB\010\310\336\037\000\320\336\037\001\022-\n\005value\030\002 "
+    "\001(\0132\030.cockroach.roachpb.ValueB\004\310\336\037\000\"J\n\013P"
     "utResponse\022;\n\006header\030\001 \001(\0132!.cockroach.r"
-    "oachpb.ResponseHeaderB\010\310\336\037\000\320\336\037\001\"g\n\020Incre"
-    "mentRequest\022:\n\006header\030\001 \001(\0132 .cockroach."
-    "roachpb.RequestHeaderB\010\310\336\037\000\320\336\037\001\022\027\n\tincre"
-    "ment\030\002 \001(\003B\004\310\336\037\000\"i\n\021IncrementResponse\022;\n"
-    "\006header\030\001 \001(\0132!.cockroach.roachpb.Respon"
-    "seHeaderB\010\310\336\037\000\320\336\037\001\022\027\n\tnew_value\030\002 \001(\003B\004\310"
-    "\336\037\000\"K\n\rDeleteRequest\022:\n\006header\030\001 \001(\0132 .c"
-    "ockroach.roachpb.RequestHeaderB\010\310\336\037\000\320\336\037\001"
-    "\"M\n\016DeleteResponse\022;\n\006header\030\001 \001(\0132!.coc"
-    "kroach.roachpb.ResponseHeaderB\010\310\336\037\000\320\336\037\001\""
-    "u\n\022DeleteRangeRequest\022:\n\006header\030\001 \001(\0132 ."
-    "cockroach.roachpb.RequestHeaderB\010\310\336\037\000\320\336\037"
-    "\001\022#\n\025max_entries_to_delete\030\002 \001(\003B\004\310\336\037\000\"m"
-    "\n\023DeleteRangeResponse\022;\n\006header\030\001 \001(\0132!."
-    "cockroach.roachpb.ResponseHeaderB\010\310\336\037\000\320\336"
-    "\037\001\022\031\n\013num_deleted\030\002 \001(\003B\004\310\336\037\000\"d\n\013ScanReq"
-    "uest\022:\n\006header\030\001 \001(\0132 .cockroach.roachpb"
-    ".RequestHeaderB\010\310\336\037\000\320\336\037\001\022\031\n\013max_results\030"
-    "\002 \001(\003B\004\310\336\037\000\"|\n\014ScanResponse\022;\n\006header\030\001 "
-    "\001(\0132!.cockroach.roachpb.ResponseHeaderB\010"
-    "\310\336\037\000\320\336\037\001\022/\n\004rows\030\002 \003(\0132\033.cockroach.roach"
-    "pb.KeyValueB\004\310\336\037\000\"k\n\022ReverseScanRequest\022"
-    ":\n\006header\030\001 \001(\0132 .cockroach.roachpb.Requ"
-    "estHeaderB\010\310\336\037\000\320\336\037\001\022\031\n\013max_results\030\002 \001(\003"
-    "B\004\310\336\037\000\"\203\001\n\023ReverseScanResponse\022;\n\006header"
-    "\030\001 \001(\0132!.cockroach.roachpb.ResponseHeade"
-    "rB\010\310\336\037\000\320\336\037\001\022/\n\004rows\030\002 \003(\0132\033.cockroach.ro"
-    "achpb.KeyValueB\004\310\336\037\000\"\346\001\n\025EndTransactionR"
-    "equest\022:\n\006header\030\001 \001(\0132 .cockroach.roach"
-    "pb.RequestHeaderB\010\310\336\037\000\320\336\037\001\022\024\n\006commit\030\002 \001"
-    "(\010B\004\310\336\037\000\022I\n\027internal_commit_trigger\030\003 \001("
-    "\0132(.cockroach.roachpb.InternalCommitTrig"
-    "ger\0220\n\007intents\030\004 \003(\0132\031.cockroach.roachpb"
-    ".IntentB\004\310\336\037\000\"\213\001\n\026EndTransactionResponse"
-    "\022;\n\006header\030\001 \001(\0132!.cockroach.roachpb.Res"
-    "ponseHeaderB\010\310\336\037\000\320\336\037\001\022\031\n\013commit_wait\030\002 \001"
-    "(\003B\004\310\336\037\000\022\031\n\010resolved\030\003 \003(\014B\007\372\336\037\003Key\"k\n\021A"
-    "dminSplitRequest\022:\n\006header\030\001 \001(\0132 .cockr"
-    "oach.roachpb.RequestHeaderB\010\310\336\037\000\320\336\037\001\022\032\n\t"
-    "split_key\030\002 \001(\014B\007\372\336\037\003Key\"Q\n\022AdminSplitRe"
-    "sponse\022;\n\006header\030\001 \001(\0132!.cockroach.roach"
-    "pb.ResponseHeaderB\010\310\336\037\000\320\336\037\001\"O\n\021AdminMerg"
-    "eRequest\022:\n\006header\030\001 \001(\0132 .cockroach.roa"
-    "chpb.RequestHeaderB\010\310\336\037\000\320\336\037\001\"Q\n\022AdminMer"
-    "geResponse\022;\n\006header\030\001 \001(\0132!.cockroach.r"
-    "oachpb.ResponseHeaderB\010\310\336\037\000\320\336\037\001\"\241\001\n\022Rang"
-    "eLookupRequest\022:\n\006header\030\001 \001(\0132 .cockroa"
-    "ch.roachpb.RequestHeaderB\010\310\336\037\000\320\336\037\001\022\030\n\nma"
-    "x_ranges\030\002 \001(\005B\004\310\336\037\000\022\036\n\020consider_intents"
-    "\030\003 \001(\010B\004\310\336\037\000\022\025\n\007reverse\030\004 \001(\010B\004\310\336\037\000\"\214\001\n\023"
-    "RangeLookupResponse\022;\n\006header\030\001 \001(\0132!.co"
-    "ckroach.roachpb.ResponseHeaderB\010\310\336\037\000\320\336\037\001"
-    "\0228\n\006ranges\030\002 \003(\0132\".cockroach.roachpb.Ran"
-    "geDescriptorB\004\310\336\037\000\"Q\n\023HeartbeatTxnReques"
-    "t\022:\n\006header\030\001 \001(\0132 .cockroach.roachpb.Re"
-    "questHeaderB\010\310\336\037\000\320\336\037\001\"S\n\024HeartbeatTxnRes"
-    "ponse\022;\n\006header\030\001 \001(\0132!.cockroach.roachp"
-    "b.ResponseHeaderB\010\310\336\037\000\320\336\037\001\"\225\002\n\tGCRequest"
-    "\022:\n\006header\030\001 \001(\0132 .cockroach.roachpb.Req"
-    "uestHeaderB\010\310\336\037\000\320\336\037\001\022>\n\007gc_meta\030\002 \001(\0132\035."
-    "cockroach.roachpb.GCMetadataB\016\310\336\037\000\342\336\037\006GC"
-    "Meta\0226\n\004keys\030\003 \003(\0132\".cockroach.roachpb.G"
-    "CRequest.GCKeyB\004\310\336\037\000\032T\n\005GCKey\022\024\n\003key\030\001 \001"
-    "(\014B\007\372\336\037\003Key\0225\n\ttimestamp\030\002 \001(\0132\034.cockroa"
-    "ch.roachpb.TimestampB\004\310\336\037\000\"I\n\nGCResponse"
-    "\022;\n\006header\030\001 \001(\0132!.cockroach.roachpb.Res"
-    "ponseHeaderB\010\310\336\037\000\320\336\037\001\"\337\002\n\016PushTxnRequest"
-    "\022:\n\006header\030\001 \001(\0132 .cockroach.roachpb.Req"
-    "uestHeaderB\010\310\336\037\000\320\336\037\001\0228\n\npusher_txn\030\002 \001(\013"
-    "2\036.cockroach.roachpb.TransactionB\004\310\336\037\000\0228"
-    "\n\npushee_txn\030\003 \001(\0132\036.cockroach.roachpb.T"
-    "ransactionB\004\310\336\037\000\0223\n\007push_to\030\004 \001(\0132\034.cock"
-    "roach.roachpb.TimestampB\004\310\336\037\000\022/\n\003now\030\005 \001"
-    "(\0132\034.cockroach.roachpb.TimestampB\004\310\336\037\000\0227"
-    "\n\tpush_type\030\006 \001(\0162\036.cockroach.roachpb.Pu"
-    "shTxnTypeB\004\310\336\037\000\"\202\001\n\017PushTxnResponse\022;\n\006h"
+    "oachpb.ResponseHeaderB\010\310\336\037\000\320\336\037\001\"\257\001\n\025Cond"
+    "itionalPutRequest\022:\n\006header\030\001 \001(\0132 .cock"
+    "roach.roachpb.RequestHeaderB\010\310\336\037\000\320\336\037\001\022-\n"
+    "\005value\030\002 \001(\0132\030.cockroach.roachpb.ValueB\004"
+    "\310\336\037\000\022+\n\texp_value\030\003 \001(\0132\030.cockroach.roac"
+    "hpb.Value\"U\n\026ConditionalPutResponse\022;\n\006h"
     "eader\030\001 \001(\0132!.cockroach.roachpb.Response"
-    "HeaderB\010\310\336\037\000\320\336\037\001\0222\n\npushee_txn\030\002 \001(\0132\036.c"
-    "ockroach.roachpb.Transaction\"\214\001\n\024Resolve"
-    "IntentRequest\022:\n\006header\030\001 \001(\0132 .cockroac"
-    "h.roachpb.RequestHeaderB\010\310\336\037\000\320\336\037\001\0228\n\nint"
-    "ent_txn\030\002 \001(\0132\036.cockroach.roachpb.Transa"
-    "ctionB\004\310\336\037\000\"T\n\025ResolveIntentResponse\022;\n\006"
-    "header\030\001 \001(\0132!.cockroach.roachpb.Respons"
-    "eHeaderB\010\310\336\037\000\320\336\037\001\"\221\001\n\031ResolveIntentRange"
-    "Request\022:\n\006header\030\001 \001(\0132 .cockroach.roac"
-    "hpb.RequestHeaderB\010\310\336\037\000\320\336\037\001\0228\n\nintent_tx"
-    "n\030\002 \001(\0132\036.cockroach.roachpb.TransactionB"
-    "\004\310\336\037\000\"K\n\014NoopResponse\022;\n\006header\030\001 \001(\0132!."
-    "cockroach.roachpb.ResponseHeaderB\010\310\336\037\000\320\336"
-    "\037\001\"I\n\013NoopRequest\022:\n\006header\030\001 \001(\0132 .cock"
-    "roach.roachpb.RequestHeaderB\010\310\336\037\000\320\336\037\001\"Y\n"
-    "\032ResolveIntentRangeResponse\022;\n\006header\030\001 "
-    "\001(\0132!.cockroach.roachpb.ResponseHeaderB\010"
-    "\310\336\037\000\320\336\037\001\"y\n\014MergeRequest\022:\n\006header\030\001 \001(\013"
+    "HeaderB\010\310\336\037\000\320\336\037\001\"g\n\020IncrementRequest\022:\n\006"
+    "header\030\001 \001(\0132 .cockroach.roachpb.Request"
+    "HeaderB\010\310\336\037\000\320\336\037\001\022\027\n\tincrement\030\002 \001(\003B\004\310\336\037"
+    "\000\"i\n\021IncrementResponse\022;\n\006header\030\001 \001(\0132!"
+    ".cockroach.roachpb.ResponseHeaderB\010\310\336\037\000\320"
+    "\336\037\001\022\027\n\tnew_value\030\002 \001(\003B\004\310\336\037\000\"K\n\rDeleteRe"
+    "quest\022:\n\006header\030\001 \001(\0132 .cockroach.roachp"
+    "b.RequestHeaderB\010\310\336\037\000\320\336\037\001\"M\n\016DeleteRespo"
+    "nse\022;\n\006header\030\001 \001(\0132!.cockroach.roachpb."
+    "ResponseHeaderB\010\310\336\037\000\320\336\037\001\"u\n\022DeleteRangeR"
+    "equest\022:\n\006header\030\001 \001(\0132 .cockroach.roach"
+    "pb.RequestHeaderB\010\310\336\037\000\320\336\037\001\022#\n\025max_entrie"
+    "s_to_delete\030\002 \001(\003B\004\310\336\037\000\"m\n\023DeleteRangeRe"
+    "sponse\022;\n\006header\030\001 \001(\0132!.cockroach.roach"
+    "pb.ResponseHeaderB\010\310\336\037\000\320\336\037\001\022\031\n\013num_delet"
+    "ed\030\002 \001(\003B\004\310\336\037\000\"d\n\013ScanRequest\022:\n\006header\030"
+    "\001 \001(\0132 .cockroach.roachpb.RequestHeaderB"
+    "\010\310\336\037\000\320\336\037\001\022\031\n\013max_results\030\002 \001(\003B\004\310\336\037\000\"|\n\014"
+    "ScanResponse\022;\n\006header\030\001 \001(\0132!.cockroach"
+    ".roachpb.ResponseHeaderB\010\310\336\037\000\320\336\037\001\022/\n\004row"
+    "s\030\002 \003(\0132\033.cockroach.roachpb.KeyValueB\004\310\336"
+    "\037\000\"k\n\022ReverseScanRequest\022:\n\006header\030\001 \001(\013"
     "2 .cockroach.roachpb.RequestHeaderB\010\310\336\037\000"
-    "\320\336\037\001\022-\n\005value\030\002 \001(\0132\030.cockroach.roachpb."
-    "ValueB\004\310\336\037\000\"L\n\rMergeResponse\022;\n\006header\030\001"
-    " \001(\0132!.cockroach.roachpb.ResponseHeaderB"
-    "\010\310\336\037\000\320\336\037\001\"e\n\022TruncateLogRequest\022:\n\006heade"
+    "\320\336\037\001\022\031\n\013max_results\030\002 \001(\003B\004\310\336\037\000\"\203\001\n\023Reve"
+    "rseScanResponse\022;\n\006header\030\001 \001(\0132!.cockro"
+    "ach.roachpb.ResponseHeaderB\010\310\336\037\000\320\336\037\001\022/\n\004"
+    "rows\030\002 \003(\0132\033.cockroach.roachpb.KeyValueB"
+    "\004\310\336\037\000\"\346\001\n\025EndTransactionRequest\022:\n\006heade"
     "r\030\001 \001(\0132 .cockroach.roachpb.RequestHeade"
-    "rB\010\310\336\037\000\320\336\037\001\022\023\n\005index\030\002 \001(\004B\004\310\336\037\000\"R\n\023Trun"
-    "cateLogResponse\022;\n\006header\030\001 \001(\0132!.cockro"
-    "ach.roachpb.ResponseHeaderB\010\310\336\037\000\320\336\037\001\"\177\n\022"
-    "LeaderLeaseRequest\022:\n\006header\030\001 \001(\0132 .coc"
-    "kroach.roachpb.RequestHeaderB\010\310\336\037\000\320\336\037\001\022-"
-    "\n\005lease\030\002 \001(\0132\030.cockroach.roachpb.LeaseB"
-    "\004\310\336\037\000\"R\n\023LeaderLeaseResponse\022;\n\006header\030\001"
-    " \001(\0132!.cockroach.roachpb.ResponseHeaderB"
-    "\010\310\336\037\000\320\336\037\001\"\272\t\n\014RequestUnion\022*\n\003get\030\001 \001(\0132"
-    "\035.cockroach.roachpb.GetRequest\022*\n\003put\030\002 "
-    "\001(\0132\035.cockroach.roachpb.PutRequest\022A\n\017co"
-    "nditional_put\030\003 \001(\0132(.cockroach.roachpb."
-    "ConditionalPutRequest\0226\n\tincrement\030\004 \001(\013"
-    "2#.cockroach.roachpb.IncrementRequest\0220\n"
-    "\006delete\030\005 \001(\0132 .cockroach.roachpb.Delete"
-    "Request\022;\n\014delete_range\030\006 \001(\0132%.cockroac"
-    "h.roachpb.DeleteRangeRequest\022,\n\004scan\030\007 \001"
-    "(\0132\036.cockroach.roachpb.ScanRequest\022A\n\017en"
-    "d_transaction\030\010 \001(\0132(.cockroach.roachpb."
-    "EndTransactionRequest\0229\n\013admin_split\030\t \001"
-    "(\0132$.cockroach.roachpb.AdminSplitRequest"
-    "\0229\n\013admin_merge\030\n \001(\0132$.cockroach.roachp"
-    "b.AdminMergeRequest\022=\n\rheartbeat_txn\030\013 \001"
-    "(\0132&.cockroach.roachpb.HeartbeatTxnReque"
-    "st\022(\n\002gc\030\014 \001(\0132\034.cockroach.roachpb.GCReq"
-    "uest\0223\n\010push_txn\030\r \001(\0132!.cockroach.roach"
-    "pb.PushTxnRequest\022;\n\014range_lookup\030\016 \001(\0132"
-    "%.cockroach.roachpb.RangeLookupRequest\022\?"
-    "\n\016resolve_intent\030\017 \001(\0132\'.cockroach.roach"
-    "pb.ResolveIntentRequest\022J\n\024resolve_inten"
-    "t_range\030\020 \001(\0132,.cockroach.roachpb.Resolv"
-    "eIntentRangeRequest\022.\n\005merge\030\021 \001(\0132\037.coc"
-    "kroach.roachpb.MergeRequest\022;\n\014truncate_"
-    "log\030\022 \001(\0132%.cockroach.roachpb.TruncateLo"
-    "gRequest\022;\n\014leader_lease\030\023 \001(\0132%.cockroa"
-    "ch.roachpb.LeaderLeaseRequest\022;\n\014reverse"
-    "_scan\030\024 \001(\0132%.cockroach.roachpb.ReverseS"
-    "canRequest\022,\n\004noop\030\025 \001(\0132\036.cockroach.roa"
-    "chpb.NoopRequest:\004\310\240\037\001\"\320\t\n\rResponseUnion"
-    "\022+\n\003get\030\001 \001(\0132\036.cockroach.roachpb.GetRes"
-    "ponse\022+\n\003put\030\002 \001(\0132\036.cockroach.roachpb.P"
-    "utResponse\022B\n\017conditional_put\030\003 \001(\0132).co"
-    "ckroach.roachpb.ConditionalPutResponse\0227"
-    "\n\tincrement\030\004 \001(\0132$.cockroach.roachpb.In"
-    "crementResponse\0221\n\006delete\030\005 \001(\0132!.cockro"
-    "ach.roachpb.DeleteResponse\022<\n\014delete_ran"
-    "ge\030\006 \001(\0132&.cockroach.roachpb.DeleteRange"
-    "Response\022-\n\004scan\030\007 \001(\0132\037.cockroach.roach"
-    "pb.ScanResponse\022B\n\017end_transaction\030\010 \001(\013"
-    "2).cockroach.roachpb.EndTransactionRespo"
-    "nse\022:\n\013admin_split\030\t \001(\0132%.cockroach.roa"
-    "chpb.AdminSplitResponse\022:\n\013admin_merge\030\n"
-    " \001(\0132%.cockroach.roachpb.AdminMergeRespo"
-    "nse\022>\n\rheartbeat_txn\030\013 \001(\0132\'.cockroach.r"
-    "oachpb.HeartbeatTxnResponse\022)\n\002gc\030\014 \001(\0132"
-    "\035.cockroach.roachpb.GCResponse\0224\n\010push_t"
-    "xn\030\r \001(\0132\".cockroach.roachpb.PushTxnResp"
-    "onse\022<\n\014range_lookup\030\016 \001(\0132&.cockroach.r"
-    "oachpb.RangeLookupResponse\022@\n\016resolve_in"
-    "tent\030\017 \001(\0132(.cockroach.roachpb.ResolveIn"
-    "tentResponse\022K\n\024resolve_intent_range\030\020 \001"
-    "(\0132-.cockroach.roachpb.ResolveIntentRang"
-    "eResponse\022/\n\005merge\030\021 \001(\0132 .cockroach.roa"
-    "chpb.MergeResponse\022<\n\014truncate_log\030\022 \001(\013"
-    "2&.cockroach.roachpb.TruncateLogResponse"
-    "\022<\n\014leader_lease\030\023 \001(\0132&.cockroach.roach"
-    "pb.LeaderLeaseResponse\022<\n\014reverse_scan\030\024"
-    " \001(\0132&.cockroach.roachpb.ReverseScanResp"
-    "onse\022-\n\004noop\030\025 \001(\0132\037.cockroach.roachpb.N"
-    "oopResponse:\004\310\240\037\001\"\212\004\n\014BatchRequest\022@\n\006he"
-    "ader\030\001 \001(\0132&.cockroach.roachpb.BatchRequ"
-    "est.HeaderB\010\310\336\037\000\320\336\037\001\0227\n\010requests\030\002 \003(\0132\037"
-    ".cockroach.roachpb.RequestUnionB\004\310\336\037\000\032\370\002"
-    "\n\006Header\0225\n\ttimestamp\030\001 \001(\0132\034.cockroach."
-    "roachpb.TimestampB\004\310\336\037\000\022=\n\006cmd_id\030\002 \001(\0132"
-    "\036.cockroach.roachpb.ClientCmdIDB\r\310\336\037\000\342\336\037"
-    "\005CmdID\022;\n\007replica\030\005 \001(\0132$.cockroach.roac"
-    "hpb.ReplicaDescriptorB\004\310\336\037\000\022,\n\010range_id\030"
-    "\006 \001(\003B\032\310\336\037\000\342\336\037\007RangeID\372\336\037\007RangeID\022\030\n\ruse"
-    "r_priority\030\007 \001(\005:\0011\022+\n\003txn\030\010 \001(\0132\036.cockr"
-    "oach.roachpb.Transaction\022F\n\020read_consist"
-    "ency\030\t \001(\0162&.cockroach.roachpb.ReadConsi"
-    "stencyTypeB\004\310\336\037\000:\004\230\240\037\000\"\245\002\n\rBatchResponse"
-    "\022A\n\006header\030\001 \001(\0132\'.cockroach.roachpb.Bat"
-    "chResponse.HeaderB\010\310\336\037\000\320\336\037\001\0229\n\tresponses"
-    "\030\002 \003(\0132 .cockroach.roachpb.ResponseUnion"
-    "B\004\310\336\037\000\032\225\001\n\006Header\022\'\n\005error\030\001 \001(\0132\030.cockr"
-    "oach.roachpb.Error\0225\n\ttimestamp\030\002 \001(\0132\034."
-    "cockroach.roachpb.TimestampB\004\310\336\037\000\022+\n\003txn"
-    "\030\003 \001(\0132\036.cockroach.roachpb.Transaction*L"
-    "\n\023ReadConsistencyType\022\016\n\nCONSISTENT\020\000\022\r\n"
-    "\tCONSENSUS\020\001\022\020\n\014INCONSISTENT\020\002\032\004\210\243\036\000*G\n\013"
-    "PushTxnType\022\022\n\016PUSH_TIMESTAMP\020\000\022\r\n\tABORT"
-    "_TXN\020\001\022\017\n\013CLEANUP_TXN\020\002\032\004\210\243\036\000B\031Z\007roachpb"
-    "\340\342\036\001\310\342\036\001\320\342\036\001\220\343\036\000", 9056);
->>>>>>> a0fb5b0... make RequestHeader.ReadConsistency obsolete
+    "rB\010\310\336\037\000\320\336\037\001\022\024\n\006commit\030\002 \001(\010B\004\310\336\037\000\022I\n\027int"
+    "ernal_commit_trigger\030\003 \001(\0132(.cockroach.r"
+    "oachpb.InternalCommitTrigger\0220\n\007intents\030"
+    "\004 \003(\0132\031.cockroach.roachpb.IntentB\004\310\336\037\000\"\213"
+    "\001\n\026EndTransactionResponse\022;\n\006header\030\001 \001("
+    "\0132!.cockroach.roachpb.ResponseHeaderB\010\310\336"
+    "\037\000\320\336\037\001\022\031\n\013commit_wait\030\002 \001(\003B\004\310\336\037\000\022\031\n\010res"
+    "olved\030\003 \003(\014B\007\372\336\037\003Key\"k\n\021AdminSplitReques"
+    "t\022:\n\006header\030\001 \001(\0132 .cockroach.roachpb.Re"
+    "questHeaderB\010\310\336\037\000\320\336\037\001\022\032\n\tsplit_key\030\002 \001(\014"
+    "B\007\372\336\037\003Key\"Q\n\022AdminSplitResponse\022;\n\006heade"
+    "r\030\001 \001(\0132!.cockroach.roachpb.ResponseHead"
+    "erB\010\310\336\037\000\320\336\037\001\"O\n\021AdminMergeRequest\022:\n\006hea"
+    "der\030\001 \001(\0132 .cockroach.roachpb.RequestHea"
+    "derB\010\310\336\037\000\320\336\037\001\"Q\n\022AdminMergeResponse\022;\n\006h"
+    "eader\030\001 \001(\0132!.cockroach.roachpb.Response"
+    "HeaderB\010\310\336\037\000\320\336\037\001\"\241\001\n\022RangeLookupRequest\022"
+    ":\n\006header\030\001 \001(\0132 .cockroach.roachpb.Requ"
+    "estHeaderB\010\310\336\037\000\320\336\037\001\022\030\n\nmax_ranges\030\002 \001(\005B"
+    "\004\310\336\037\000\022\036\n\020consider_intents\030\003 \001(\010B\004\310\336\037\000\022\025\n"
+    "\007reverse\030\004 \001(\010B\004\310\336\037\000\"\214\001\n\023RangeLookupResp"
+    "onse\022;\n\006header\030\001 \001(\0132!.cockroach.roachpb"
+    ".ResponseHeaderB\010\310\336\037\000\320\336\037\001\0228\n\006ranges\030\002 \003("
+    "\0132\".cockroach.roachpb.RangeDescriptorB\004\310"
+    "\336\037\000\"Q\n\023HeartbeatTxnRequest\022:\n\006header\030\001 \001"
+    "(\0132 .cockroach.roachpb.RequestHeaderB\010\310\336"
+    "\037\000\320\336\037\001\"S\n\024HeartbeatTxnResponse\022;\n\006header"
+    "\030\001 \001(\0132!.cockroach.roachpb.ResponseHeade"
+    "rB\010\310\336\037\000\320\336\037\001\"\225\002\n\tGCRequest\022:\n\006header\030\001 \001("
+    "\0132 .cockroach.roachpb.RequestHeaderB\010\310\336\037"
+    "\000\320\336\037\001\022>\n\007gc_meta\030\002 \001(\0132\035.cockroach.roach"
+    "pb.GCMetadataB\016\310\336\037\000\342\336\037\006GCMeta\0226\n\004keys\030\003 "
+    "\003(\0132\".cockroach.roachpb.GCRequest.GCKeyB"
+    "\004\310\336\037\000\032T\n\005GCKey\022\024\n\003key\030\001 \001(\014B\007\372\336\037\003Key\0225\n\t"
+    "timestamp\030\002 \001(\0132\034.cockroach.roachpb.Time"
+    "stampB\004\310\336\037\000\"I\n\nGCResponse\022;\n\006header\030\001 \001("
+    "\0132!.cockroach.roachpb.ResponseHeaderB\010\310\336"
+    "\037\000\320\336\037\001\"\337\002\n\016PushTxnRequest\022:\n\006header\030\001 \001("
+    "\0132 .cockroach.roachpb.RequestHeaderB\010\310\336\037"
+    "\000\320\336\037\001\0228\n\npusher_txn\030\002 \001(\0132\036.cockroach.ro"
+    "achpb.TransactionB\004\310\336\037\000\0228\n\npushee_txn\030\003 "
+    "\001(\0132\036.cockroach.roachpb.TransactionB\004\310\336\037"
+    "\000\0223\n\007push_to\030\004 \001(\0132\034.cockroach.roachpb.T"
+    "imestampB\004\310\336\037\000\022/\n\003now\030\005 \001(\0132\034.cockroach."
+    "roachpb.TimestampB\004\310\336\037\000\0227\n\tpush_type\030\006 \001"
+    "(\0162\036.cockroach.roachpb.PushTxnTypeB\004\310\336\037\000"
+    "\"\202\001\n\017PushTxnResponse\022;\n\006header\030\001 \001(\0132!.c"
+    "ockroach.roachpb.ResponseHeaderB\010\310\336\037\000\320\336\037"
+    "\001\0222\n\npushee_txn\030\002 \001(\0132\036.cockroach.roachp"
+    "b.Transaction\"\214\001\n\024ResolveIntentRequest\022:"
+    "\n\006header\030\001 \001(\0132 .cockroach.roachpb.Reque"
+    "stHeaderB\010\310\336\037\000\320\336\037\001\0228\n\nintent_txn\030\002 \001(\0132\036"
+    ".cockroach.roachpb.TransactionB\004\310\336\037\000\"T\n\025"
+    "ResolveIntentResponse\022;\n\006header\030\001 \001(\0132!."
+    "cockroach.roachpb.ResponseHeaderB\010\310\336\037\000\320\336"
+    "\037\001\"\221\001\n\031ResolveIntentRangeRequest\022:\n\006head"
+    "er\030\001 \001(\0132 .cockroach.roachpb.RequestHead"
+    "erB\010\310\336\037\000\320\336\037\001\0228\n\nintent_txn\030\002 \001(\0132\036.cockr"
+    "oach.roachpb.TransactionB\004\310\336\037\000\"K\n\014NoopRe"
+    "sponse\022;\n\006header\030\001 \001(\0132!.cockroach.roach"
+    "pb.ResponseHeaderB\010\310\336\037\000\320\336\037\001\"I\n\013NoopReque"
+    "st\022:\n\006header\030\001 \001(\0132 .cockroach.roachpb.R"
+    "equestHeaderB\010\310\336\037\000\320\336\037\001\"Y\n\032ResolveIntentR"
+    "angeResponse\022;\n\006header\030\001 \001(\0132!.cockroach"
+    ".roachpb.ResponseHeaderB\010\310\336\037\000\320\336\037\001\"y\n\014Mer"
+    "geRequest\022:\n\006header\030\001 \001(\0132 .cockroach.ro"
+    "achpb.RequestHeaderB\010\310\336\037\000\320\336\037\001\022-\n\005value\030\002"
+    " \001(\0132\030.cockroach.roachpb.ValueB\004\310\336\037\000\"L\n\r"
+    "MergeResponse\022;\n\006header\030\001 \001(\0132!.cockroac"
+    "h.roachpb.ResponseHeaderB\010\310\336\037\000\320\336\037\001\"e\n\022Tr"
+    "uncateLogRequest\022:\n\006header\030\001 \001(\0132 .cockr"
+    "oach.roachpb.RequestHeaderB\010\310\336\037\000\320\336\037\001\022\023\n\005"
+    "index\030\002 \001(\004B\004\310\336\037\000\"R\n\023TruncateLogResponse"
+    "\022;\n\006header\030\001 \001(\0132!.cockroach.roachpb.Res"
+    "ponseHeaderB\010\310\336\037\000\320\336\037\001\"\177\n\022LeaderLeaseRequ"
+    "est\022:\n\006header\030\001 \001(\0132 .cockroach.roachpb."
+    "RequestHeaderB\010\310\336\037\000\320\336\037\001\022-\n\005lease\030\002 \001(\0132\030"
+    ".cockroach.roachpb.LeaseB\004\310\336\037\000\"R\n\023Leader"
+    "LeaseResponse\022;\n\006header\030\001 \001(\0132!.cockroac"
+    "h.roachpb.ResponseHeaderB\010\310\336\037\000\320\336\037\001\"\272\t\n\014R"
+    "equestUnion\022*\n\003get\030\001 \001(\0132\035.cockroach.roa"
+    "chpb.GetRequest\022*\n\003put\030\002 \001(\0132\035.cockroach"
+    ".roachpb.PutRequest\022A\n\017conditional_put\030\003"
+    " \001(\0132(.cockroach.roachpb.ConditionalPutR"
+    "equest\0226\n\tincrement\030\004 \001(\0132#.cockroach.ro"
+    "achpb.IncrementRequest\0220\n\006delete\030\005 \001(\0132 "
+    ".cockroach.roachpb.DeleteRequest\022;\n\014dele"
+    "te_range\030\006 \001(\0132%.cockroach.roachpb.Delet"
+    "eRangeRequest\022,\n\004scan\030\007 \001(\0132\036.cockroach."
+    "roachpb.ScanRequest\022A\n\017end_transaction\030\010"
+    " \001(\0132(.cockroach.roachpb.EndTransactionR"
+    "equest\0229\n\013admin_split\030\t \001(\0132$.cockroach."
+    "roachpb.AdminSplitRequest\0229\n\013admin_merge"
+    "\030\n \001(\0132$.cockroach.roachpb.AdminMergeReq"
+    "uest\022=\n\rheartbeat_txn\030\013 \001(\0132&.cockroach."
+    "roachpb.HeartbeatTxnRequest\022(\n\002gc\030\014 \001(\0132"
+    "\034.cockroach.roachpb.GCRequest\0223\n\010push_tx"
+    "n\030\r \001(\0132!.cockroach.roachpb.PushTxnReque"
+    "st\022;\n\014range_lookup\030\016 \001(\0132%.cockroach.roa"
+    "chpb.RangeLookupRequest\022\?\n\016resolve_inten"
+    "t\030\017 \001(\0132\'.cockroach.roachpb.ResolveInten"
+    "tRequest\022J\n\024resolve_intent_range\030\020 \001(\0132,"
+    ".cockroach.roachpb.ResolveIntentRangeReq"
+    "uest\022.\n\005merge\030\021 \001(\0132\037.cockroach.roachpb."
+    "MergeRequest\022;\n\014truncate_log\030\022 \001(\0132%.coc"
+    "kroach.roachpb.TruncateLogRequest\022;\n\014lea"
+    "der_lease\030\023 \001(\0132%.cockroach.roachpb.Lead"
+    "erLeaseRequest\022;\n\014reverse_scan\030\024 \001(\0132%.c"
+    "ockroach.roachpb.ReverseScanRequest\022,\n\004n"
+    "oop\030\025 \001(\0132\036.cockroach.roachpb.NoopReques"
+    "t:\004\310\240\037\001\"\320\t\n\rResponseUnion\022+\n\003get\030\001 \001(\0132\036"
+    ".cockroach.roachpb.GetResponse\022+\n\003put\030\002 "
+    "\001(\0132\036.cockroach.roachpb.PutResponse\022B\n\017c"
+    "onditional_put\030\003 \001(\0132).cockroach.roachpb"
+    ".ConditionalPutResponse\0227\n\tincrement\030\004 \001"
+    "(\0132$.cockroach.roachpb.IncrementResponse"
+    "\0221\n\006delete\030\005 \001(\0132!.cockroach.roachpb.Del"
+    "eteResponse\022<\n\014delete_range\030\006 \001(\0132&.cock"
+    "roach.roachpb.DeleteRangeResponse\022-\n\004sca"
+    "n\030\007 \001(\0132\037.cockroach.roachpb.ScanResponse"
+    "\022B\n\017end_transaction\030\010 \001(\0132).cockroach.ro"
+    "achpb.EndTransactionResponse\022:\n\013admin_sp"
+    "lit\030\t \001(\0132%.cockroach.roachpb.AdminSplit"
+    "Response\022:\n\013admin_merge\030\n \001(\0132%.cockroac"
+    "h.roachpb.AdminMergeResponse\022>\n\rheartbea"
+    "t_txn\030\013 \001(\0132\'.cockroach.roachpb.Heartbea"
+    "tTxnResponse\022)\n\002gc\030\014 \001(\0132\035.cockroach.roa"
+    "chpb.GCResponse\0224\n\010push_txn\030\r \001(\0132\".cock"
+    "roach.roachpb.PushTxnResponse\022<\n\014range_l"
+    "ookup\030\016 \001(\0132&.cockroach.roachpb.RangeLoo"
+    "kupResponse\022@\n\016resolve_intent\030\017 \001(\0132(.co"
+    "ckroach.roachpb.ResolveIntentResponse\022K\n"
+    "\024resolve_intent_range\030\020 \001(\0132-.cockroach."
+    "roachpb.ResolveIntentRangeResponse\022/\n\005me"
+    "rge\030\021 \001(\0132 .cockroach.roachpb.MergeRespo"
+    "nse\022<\n\014truncate_log\030\022 \001(\0132&.cockroach.ro"
+    "achpb.TruncateLogResponse\022<\n\014leader_leas"
+    "e\030\023 \001(\0132&.cockroach.roachpb.LeaderLeaseR"
+    "esponse\022<\n\014reverse_scan\030\024 \001(\0132&.cockroac"
+    "h.roachpb.ReverseScanResponse\022-\n\004noop\030\025 "
+    "\001(\0132\037.cockroach.roachpb.NoopResponse:\004\310\240"
+    "\037\001\"\212\004\n\014BatchRequest\022@\n\006header\030\001 \001(\0132&.co"
+    "ckroach.roachpb.BatchRequest.HeaderB\010\310\336\037"
+    "\000\320\336\037\001\0227\n\010requests\030\002 \003(\0132\037.cockroach.roac"
+    "hpb.RequestUnionB\004\310\336\037\000\032\370\002\n\006Header\0225\n\ttim"
+    "estamp\030\001 \001(\0132\034.cockroach.roachpb.Timesta"
+    "mpB\004\310\336\037\000\022=\n\006cmd_id\030\002 \001(\0132\036.cockroach.roa"
+    "chpb.ClientCmdIDB\r\310\336\037\000\342\336\037\005CmdID\022;\n\007repli"
+    "ca\030\005 \001(\0132$.cockroach.roachpb.ReplicaDesc"
+    "riptorB\004\310\336\037\000\022,\n\010range_id\030\006 \001(\003B\032\310\336\037\000\342\336\037\007"
+    "RangeID\372\336\037\007RangeID\022\030\n\ruser_priority\030\007 \001("
+    "\005:\0011\022+\n\003txn\030\010 \001(\0132\036.cockroach.roachpb.Tr"
+    "ansaction\022F\n\020read_consistency\030\t \001(\0162&.co"
+    "ckroach.roachpb.ReadConsistencyTypeB\004\310\336\037"
+    "\000:\004\230\240\037\000\"\245\002\n\rBatchResponse\022A\n\006header\030\001 \001("
+    "\0132\'.cockroach.roachpb.BatchResponse.Head"
+    "erB\010\310\336\037\000\320\336\037\001\0229\n\tresponses\030\002 \003(\0132 .cockro"
+    "ach.roachpb.ResponseUnionB\004\310\336\037\000\032\225\001\n\006Head"
+    "er\022\'\n\005error\030\001 \001(\0132\030.cockroach.roachpb.Er"
+    "ror\0225\n\ttimestamp\030\002 \001(\0132\034.cockroach.roach"
+    "pb.TimestampB\004\310\336\037\000\022+\n\003txn\030\003 \001(\0132\036.cockro"
+    "ach.roachpb.Transaction*L\n\023ReadConsisten"
+    "cyType\022\016\n\nCONSISTENT\020\000\022\r\n\tCONSENSUS\020\001\022\020\n"
+    "\014INCONSISTENT\020\002\032\004\210\243\036\000*G\n\013PushTxnType\022\022\n\016"
+    "PUSH_TIMESTAMP\020\000\022\r\n\tABORT_TXN\020\001\022\017\n\013CLEAN"
+    "UP_TXN\020\002\032\004\210\243\036\000B\031Z\007roachpb\340\342\036\001\310\342\036\001\320\342\036\001\220\343\036"
+    "\000", 8921);
   ::google::protobuf::MessageFactory::InternalRegisterGeneratedFile(
     "cockroach/roachpb/api.proto", &protobuf_RegisterTypes);
   ClientCmdID::default_instance_ = new ClientCmdID();
@@ -2254,7 +2022,6 @@ const int RequestHeader::kKeyFieldNumber;
 const int RequestHeader::kEndKeyFieldNumber;
 const int RequestHeader::kUserPriorityFieldNumber;
 const int RequestHeader::kTxnFieldNumber;
-const int RequestHeader::kReadConsistencyFieldNumber;
 #endif  // !_MSC_VER
 
 RequestHeader::RequestHeader()
@@ -2282,7 +2049,6 @@ void RequestHeader::SharedCtor() {
   end_key_.UnsafeSetDefault(&::google::protobuf::internal::GetEmptyStringAlreadyInited());
   user_priority_ = 1;
   txn_ = NULL;
-  read_consistency_ = 0;
   ::memset(_has_bits_, 0, sizeof(_has_bits_));
 }
 
@@ -2325,14 +2091,7 @@ RequestHeader* RequestHeader::New(::google::protobuf::Arena* arena) const {
 }
 
 void RequestHeader::Clear() {
-<<<<<<< HEAD
-  if (_has_bits_[0 / 32] & 31u) {
-=======
-  if (_has_bits_[0 / 32] & 63u) {
-    if (has_cmd_id()) {
-      if (cmd_id_ != NULL) cmd_id_->::cockroach::roachpb::ClientCmdID::Clear();
-    }
->>>>>>> a0fb5b0... make RequestHeader.ReadConsistency obsolete
+  if (_has_bits_[0 / 32] & 15u) {
     if (has_key()) {
       key_.ClearToEmptyNoArena(&::google::protobuf::internal::GetEmptyStringAlreadyInited());
     }
@@ -2343,7 +2102,6 @@ void RequestHeader::Clear() {
     if (has_txn()) {
       if (txn_ != NULL) txn_->::cockroach::roachpb::Transaction::Clear();
     }
-    read_consistency_ = 0;
   }
   ::memset(_has_bits_, 0, sizeof(_has_bits_));
   if (_internal_metadata_.have_unknown_fields()) {
@@ -2410,26 +2168,6 @@ bool RequestHeader::MergePartialFromCodedStream(
         } else {
           goto handle_unusual;
         }
-        if (input->ExpectTag(72)) goto parse_read_consistency;
-        break;
-      }
-
-      // optional .cockroach.roachpb.ReadConsistencyType read_consistency = 9;
-      case 9: {
-        if (tag == 72) {
-         parse_read_consistency:
-          int value;
-          DO_((::google::protobuf::internal::WireFormatLite::ReadPrimitive<
-                   int, ::google::protobuf::internal::WireFormatLite::TYPE_ENUM>(
-                 input, &value)));
-          if (::cockroach::roachpb::ReadConsistencyType_IsValid(value)) {
-            set_read_consistency(static_cast< ::cockroach::roachpb::ReadConsistencyType >(value));
-          } else {
-            mutable_unknown_fields()->AddVarint(9, value);
-          }
-        } else {
-          goto handle_unusual;
-        }
         if (input->ExpectAtEnd()) goto success;
         break;
       }
@@ -2482,12 +2220,6 @@ void RequestHeader::SerializeWithCachedSizes(
       8, *this->txn_, output);
   }
 
-  // optional .cockroach.roachpb.ReadConsistencyType read_consistency = 9;
-  if (has_read_consistency()) {
-    ::google::protobuf::internal::WireFormatLite::WriteEnum(
-      9, this->read_consistency(), output);
-  }
-
   if (_internal_metadata_.have_unknown_fields()) {
     ::google::protobuf::internal::WireFormat::SerializeUnknownFields(
         unknown_fields(), output);
@@ -2524,12 +2256,6 @@ void RequestHeader::SerializeWithCachedSizes(
         8, *this->txn_, target);
   }
 
-  // optional .cockroach.roachpb.ReadConsistencyType read_consistency = 9;
-  if (has_read_consistency()) {
-    target = ::google::protobuf::internal::WireFormatLite::WriteEnumToArray(
-      9, this->read_consistency(), target);
-  }
-
   if (_internal_metadata_.have_unknown_fields()) {
     target = ::google::protobuf::internal::WireFormat::SerializeUnknownFieldsToArray(
         unknown_fields(), target);
@@ -2541,18 +2267,7 @@ void RequestHeader::SerializeWithCachedSizes(
 int RequestHeader::ByteSize() const {
   int total_size = 0;
 
-<<<<<<< HEAD
-  if (_has_bits_[0 / 32] & 31) {
-=======
-  if (_has_bits_[0 / 32] & 63) {
-    // optional .cockroach.roachpb.ClientCmdID cmd_id = 2;
-    if (has_cmd_id()) {
-      total_size += 1 +
-        ::google::protobuf::internal::WireFormatLite::MessageSizeNoVirtual(
-          *this->cmd_id_);
-    }
-
->>>>>>> a0fb5b0... make RequestHeader.ReadConsistency obsolete
+  if (_has_bits_[0 / 32] & 15) {
     // optional bytes key = 3;
     if (has_key()) {
       total_size += 1 +
@@ -2579,12 +2294,6 @@ int RequestHeader::ByteSize() const {
       total_size += 1 +
         ::google::protobuf::internal::WireFormatLite::MessageSizeNoVirtual(
           *this->txn_);
-    }
-
-    // optional .cockroach.roachpb.ReadConsistencyType read_consistency = 9;
-    if (has_read_consistency()) {
-      total_size += 1 +
-        ::google::protobuf::internal::WireFormatLite::EnumSize(this->read_consistency());
     }
 
   }
@@ -2628,9 +2337,6 @@ void RequestHeader::MergeFrom(const RequestHeader& from) {
     if (from.has_txn()) {
       mutable_txn()->::cockroach::roachpb::Transaction::MergeFrom(from.txn());
     }
-    if (from.has_read_consistency()) {
-      set_read_consistency(from.read_consistency());
-    }
   }
   if (from._internal_metadata_.have_unknown_fields()) {
     mutable_unknown_fields()->MergeFrom(from.unknown_fields());
@@ -2663,7 +2369,6 @@ void RequestHeader::InternalSwap(RequestHeader* other) {
   end_key_.Swap(&other->end_key_);
   std::swap(user_priority_, other->user_priority_);
   std::swap(txn_, other->txn_);
-  std::swap(read_consistency_, other->read_consistency_);
   std::swap(_has_bits_[0], other->_has_bits_[0]);
   _internal_metadata_.Swap(&other->_internal_metadata_);
   std::swap(_cached_size_, other->_cached_size_);
@@ -2851,41 +2556,6 @@ void RequestHeader::clear_txn() {
     clear_has_txn();
   }
   // @@protoc_insertion_point(field_set_allocated:cockroach.roachpb.RequestHeader.txn)
-}
-
-// optional .cockroach.roachpb.ReadConsistencyType read_consistency = 9;
-bool RequestHeader::has_read_consistency() const {
-<<<<<<< HEAD
-  return (_has_bits_[0] & 0x00000010u) != 0;
-}
-void RequestHeader::set_has_read_consistency() {
-  _has_bits_[0] |= 0x00000010u;
-}
-void RequestHeader::clear_has_read_consistency() {
-  _has_bits_[0] &= ~0x00000010u;
-=======
-  return (_has_bits_[0] & 0x00000020u) != 0;
-}
-void RequestHeader::set_has_read_consistency() {
-  _has_bits_[0] |= 0x00000020u;
-}
-void RequestHeader::clear_has_read_consistency() {
-  _has_bits_[0] &= ~0x00000020u;
->>>>>>> a0fb5b0... make RequestHeader.ReadConsistency obsolete
-}
-void RequestHeader::clear_read_consistency() {
-  read_consistency_ = 0;
-  clear_has_read_consistency();
-}
- ::cockroach::roachpb::ReadConsistencyType RequestHeader::read_consistency() const {
-  // @@protoc_insertion_point(field_get:cockroach.roachpb.RequestHeader.read_consistency)
-  return static_cast< ::cockroach::roachpb::ReadConsistencyType >(read_consistency_);
-}
- void RequestHeader::set_read_consistency(::cockroach::roachpb::ReadConsistencyType value) {
-  assert(::cockroach::roachpb::ReadConsistencyType_IsValid(value));
-  set_has_read_consistency();
-  read_consistency_ = value;
-  // @@protoc_insertion_point(field_set:cockroach.roachpb.RequestHeader.read_consistency)
 }
 
 #endif  // PROTOBUF_INLINE_NOT_IN_HEADERS

--- a/storage/engine/rocksdb/cockroach/roachpb/api.pb.cc
+++ b/storage/engine/rocksdb/cockroach/roachpb/api.pb.cc
@@ -206,7 +206,12 @@ void protobuf_AssignDesc_cockroach_2froachpb_2fapi_2eproto() {
       GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(ClientCmdID, _internal_metadata_),
       -1);
   RequestHeader_descriptor_ = file->message_type(1);
+<<<<<<< HEAD
   static const int RequestHeader_offsets_[5] = {
+=======
+  static const int RequestHeader_offsets_[6] = {
+    GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(RequestHeader, cmd_id_),
+>>>>>>> a0fb5b0... make RequestHeader.ReadConsistency obsolete
     GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(RequestHeader, key_),
     GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(RequestHeader, end_key_),
     GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(RequestHeader, user_priority_),
@@ -1306,6 +1311,7 @@ void protobuf_AddDesc_cockroach_2froachpb_2fapi_2eproto() {
     "to\032\034cockroach/roachpb/data.proto\032\036cockro"
     "ach/roachpb/errors.proto\032\024gogoproto/gogo"
     ".proto\"<\n\013ClientCmdID\022\027\n\twall_time\030\001 \001(\003"
+<<<<<<< HEAD
     "B\004\310\336\037\000\022\024\n\006random\030\002 \001(\003B\004\310\336\037\000\"\316\001\n\rRequest"
     "Header\022\024\n\003key\030\003 \001(\014B\007\372\336\037\003Key\022\030\n\007end_key\030"
     "\004 \001(\014B\007\372\336\037\003Key\022\030\n\ruser_priority\030\007 \001(\005:\0011"
@@ -1526,6 +1532,230 @@ void protobuf_AddDesc_cockroach_2froachpb_2fapi_2eproto() {
     "STENT\020\002\032\004\210\243\036\000*G\n\013PushTxnType\022\022\n\016PUSH_TIM"
     "ESTAMP\020\000\022\r\n\tABORT_TXN\020\001\022\017\n\013CLEANUP_TXN\020\002"
     "\032\004\210\243\036\000B\031Z\007roachpb\340\342\036\001\310\342\036\001\320\342\036\001\220\343\036\000", 8993);
+=======
+    "B\004\310\336\037\000\022\024\n\006random\030\002 \001(\003B\004\310\336\037\000\"\215\002\n\rRequest"
+    "Header\022=\n\006cmd_id\030\002 \001(\0132\036.cockroach.roach"
+    "pb.ClientCmdIDB\r\310\336\037\000\342\336\037\005CmdID\022\024\n\003key\030\003 \001"
+    "(\014B\007\372\336\037\003Key\022\030\n\007end_key\030\004 \001(\014B\007\372\336\037\003Key\022\030\n"
+    "\ruser_priority\030\007 \001(\005:\0011\022+\n\003txn\030\010 \001(\0132\036.c"
+    "ockroach.roachpb.Transaction\022F\n\020read_con"
+    "sistency\030\t \001(\0162&.cockroach.roachpb.ReadC"
+    "onsistencyTypeB\004\310\336\037\000\"t\n\016ResponseHeader\0225"
+    "\n\ttimestamp\030\002 \001(\0132\034.cockroach.roachpb.Ti"
+    "mestampB\004\310\336\037\000\022+\n\003txn\030\003 \001(\0132\036.cockroach.r"
+    "oachpb.Transaction\"H\n\nGetRequest\022:\n\006head"
+    "er\030\001 \001(\0132 .cockroach.roachpb.RequestHead"
+    "erB\010\310\336\037\000\320\336\037\001\"s\n\013GetResponse\022;\n\006header\030\001 "
+    "\001(\0132!.cockroach.roachpb.ResponseHeaderB\010"
+    "\310\336\037\000\320\336\037\001\022\'\n\005value\030\002 \001(\0132\030.cockroach.roac"
+    "hpb.Value\"w\n\nPutRequest\022:\n\006header\030\001 \001(\0132"
+    " .cockroach.roachpb.RequestHeaderB\010\310\336\037\000\320"
+    "\336\037\001\022-\n\005value\030\002 \001(\0132\030.cockroach.roachpb.V"
+    "alueB\004\310\336\037\000\"J\n\013PutResponse\022;\n\006header\030\001 \001("
+    "\0132!.cockroach.roachpb.ResponseHeaderB\010\310\336"
+    "\037\000\320\336\037\001\"\257\001\n\025ConditionalPutRequest\022:\n\006head"
+    "er\030\001 \001(\0132 .cockroach.roachpb.RequestHead"
+    "erB\010\310\336\037\000\320\336\037\001\022-\n\005value\030\002 \001(\0132\030.cockroach."
+    "roachpb.ValueB\004\310\336\037\000\022+\n\texp_value\030\003 \001(\0132\030"
+    ".cockroach.roachpb.Value\"U\n\026ConditionalP"
+    "utResponse\022;\n\006header\030\001 \001(\0132!.cockroach.r"
+    "oachpb.ResponseHeaderB\010\310\336\037\000\320\336\037\001\"g\n\020Incre"
+    "mentRequest\022:\n\006header\030\001 \001(\0132 .cockroach."
+    "roachpb.RequestHeaderB\010\310\336\037\000\320\336\037\001\022\027\n\tincre"
+    "ment\030\002 \001(\003B\004\310\336\037\000\"i\n\021IncrementResponse\022;\n"
+    "\006header\030\001 \001(\0132!.cockroach.roachpb.Respon"
+    "seHeaderB\010\310\336\037\000\320\336\037\001\022\027\n\tnew_value\030\002 \001(\003B\004\310"
+    "\336\037\000\"K\n\rDeleteRequest\022:\n\006header\030\001 \001(\0132 .c"
+    "ockroach.roachpb.RequestHeaderB\010\310\336\037\000\320\336\037\001"
+    "\"M\n\016DeleteResponse\022;\n\006header\030\001 \001(\0132!.coc"
+    "kroach.roachpb.ResponseHeaderB\010\310\336\037\000\320\336\037\001\""
+    "u\n\022DeleteRangeRequest\022:\n\006header\030\001 \001(\0132 ."
+    "cockroach.roachpb.RequestHeaderB\010\310\336\037\000\320\336\037"
+    "\001\022#\n\025max_entries_to_delete\030\002 \001(\003B\004\310\336\037\000\"m"
+    "\n\023DeleteRangeResponse\022;\n\006header\030\001 \001(\0132!."
+    "cockroach.roachpb.ResponseHeaderB\010\310\336\037\000\320\336"
+    "\037\001\022\031\n\013num_deleted\030\002 \001(\003B\004\310\336\037\000\"d\n\013ScanReq"
+    "uest\022:\n\006header\030\001 \001(\0132 .cockroach.roachpb"
+    ".RequestHeaderB\010\310\336\037\000\320\336\037\001\022\031\n\013max_results\030"
+    "\002 \001(\003B\004\310\336\037\000\"|\n\014ScanResponse\022;\n\006header\030\001 "
+    "\001(\0132!.cockroach.roachpb.ResponseHeaderB\010"
+    "\310\336\037\000\320\336\037\001\022/\n\004rows\030\002 \003(\0132\033.cockroach.roach"
+    "pb.KeyValueB\004\310\336\037\000\"k\n\022ReverseScanRequest\022"
+    ":\n\006header\030\001 \001(\0132 .cockroach.roachpb.Requ"
+    "estHeaderB\010\310\336\037\000\320\336\037\001\022\031\n\013max_results\030\002 \001(\003"
+    "B\004\310\336\037\000\"\203\001\n\023ReverseScanResponse\022;\n\006header"
+    "\030\001 \001(\0132!.cockroach.roachpb.ResponseHeade"
+    "rB\010\310\336\037\000\320\336\037\001\022/\n\004rows\030\002 \003(\0132\033.cockroach.ro"
+    "achpb.KeyValueB\004\310\336\037\000\"\346\001\n\025EndTransactionR"
+    "equest\022:\n\006header\030\001 \001(\0132 .cockroach.roach"
+    "pb.RequestHeaderB\010\310\336\037\000\320\336\037\001\022\024\n\006commit\030\002 \001"
+    "(\010B\004\310\336\037\000\022I\n\027internal_commit_trigger\030\003 \001("
+    "\0132(.cockroach.roachpb.InternalCommitTrig"
+    "ger\0220\n\007intents\030\004 \003(\0132\031.cockroach.roachpb"
+    ".IntentB\004\310\336\037\000\"\213\001\n\026EndTransactionResponse"
+    "\022;\n\006header\030\001 \001(\0132!.cockroach.roachpb.Res"
+    "ponseHeaderB\010\310\336\037\000\320\336\037\001\022\031\n\013commit_wait\030\002 \001"
+    "(\003B\004\310\336\037\000\022\031\n\010resolved\030\003 \003(\014B\007\372\336\037\003Key\"k\n\021A"
+    "dminSplitRequest\022:\n\006header\030\001 \001(\0132 .cockr"
+    "oach.roachpb.RequestHeaderB\010\310\336\037\000\320\336\037\001\022\032\n\t"
+    "split_key\030\002 \001(\014B\007\372\336\037\003Key\"Q\n\022AdminSplitRe"
+    "sponse\022;\n\006header\030\001 \001(\0132!.cockroach.roach"
+    "pb.ResponseHeaderB\010\310\336\037\000\320\336\037\001\"O\n\021AdminMerg"
+    "eRequest\022:\n\006header\030\001 \001(\0132 .cockroach.roa"
+    "chpb.RequestHeaderB\010\310\336\037\000\320\336\037\001\"Q\n\022AdminMer"
+    "geResponse\022;\n\006header\030\001 \001(\0132!.cockroach.r"
+    "oachpb.ResponseHeaderB\010\310\336\037\000\320\336\037\001\"\241\001\n\022Rang"
+    "eLookupRequest\022:\n\006header\030\001 \001(\0132 .cockroa"
+    "ch.roachpb.RequestHeaderB\010\310\336\037\000\320\336\037\001\022\030\n\nma"
+    "x_ranges\030\002 \001(\005B\004\310\336\037\000\022\036\n\020consider_intents"
+    "\030\003 \001(\010B\004\310\336\037\000\022\025\n\007reverse\030\004 \001(\010B\004\310\336\037\000\"\214\001\n\023"
+    "RangeLookupResponse\022;\n\006header\030\001 \001(\0132!.co"
+    "ckroach.roachpb.ResponseHeaderB\010\310\336\037\000\320\336\037\001"
+    "\0228\n\006ranges\030\002 \003(\0132\".cockroach.roachpb.Ran"
+    "geDescriptorB\004\310\336\037\000\"Q\n\023HeartbeatTxnReques"
+    "t\022:\n\006header\030\001 \001(\0132 .cockroach.roachpb.Re"
+    "questHeaderB\010\310\336\037\000\320\336\037\001\"S\n\024HeartbeatTxnRes"
+    "ponse\022;\n\006header\030\001 \001(\0132!.cockroach.roachp"
+    "b.ResponseHeaderB\010\310\336\037\000\320\336\037\001\"\225\002\n\tGCRequest"
+    "\022:\n\006header\030\001 \001(\0132 .cockroach.roachpb.Req"
+    "uestHeaderB\010\310\336\037\000\320\336\037\001\022>\n\007gc_meta\030\002 \001(\0132\035."
+    "cockroach.roachpb.GCMetadataB\016\310\336\037\000\342\336\037\006GC"
+    "Meta\0226\n\004keys\030\003 \003(\0132\".cockroach.roachpb.G"
+    "CRequest.GCKeyB\004\310\336\037\000\032T\n\005GCKey\022\024\n\003key\030\001 \001"
+    "(\014B\007\372\336\037\003Key\0225\n\ttimestamp\030\002 \001(\0132\034.cockroa"
+    "ch.roachpb.TimestampB\004\310\336\037\000\"I\n\nGCResponse"
+    "\022;\n\006header\030\001 \001(\0132!.cockroach.roachpb.Res"
+    "ponseHeaderB\010\310\336\037\000\320\336\037\001\"\337\002\n\016PushTxnRequest"
+    "\022:\n\006header\030\001 \001(\0132 .cockroach.roachpb.Req"
+    "uestHeaderB\010\310\336\037\000\320\336\037\001\0228\n\npusher_txn\030\002 \001(\013"
+    "2\036.cockroach.roachpb.TransactionB\004\310\336\037\000\0228"
+    "\n\npushee_txn\030\003 \001(\0132\036.cockroach.roachpb.T"
+    "ransactionB\004\310\336\037\000\0223\n\007push_to\030\004 \001(\0132\034.cock"
+    "roach.roachpb.TimestampB\004\310\336\037\000\022/\n\003now\030\005 \001"
+    "(\0132\034.cockroach.roachpb.TimestampB\004\310\336\037\000\0227"
+    "\n\tpush_type\030\006 \001(\0162\036.cockroach.roachpb.Pu"
+    "shTxnTypeB\004\310\336\037\000\"\202\001\n\017PushTxnResponse\022;\n\006h"
+    "eader\030\001 \001(\0132!.cockroach.roachpb.Response"
+    "HeaderB\010\310\336\037\000\320\336\037\001\0222\n\npushee_txn\030\002 \001(\0132\036.c"
+    "ockroach.roachpb.Transaction\"\214\001\n\024Resolve"
+    "IntentRequest\022:\n\006header\030\001 \001(\0132 .cockroac"
+    "h.roachpb.RequestHeaderB\010\310\336\037\000\320\336\037\001\0228\n\nint"
+    "ent_txn\030\002 \001(\0132\036.cockroach.roachpb.Transa"
+    "ctionB\004\310\336\037\000\"T\n\025ResolveIntentResponse\022;\n\006"
+    "header\030\001 \001(\0132!.cockroach.roachpb.Respons"
+    "eHeaderB\010\310\336\037\000\320\336\037\001\"\221\001\n\031ResolveIntentRange"
+    "Request\022:\n\006header\030\001 \001(\0132 .cockroach.roac"
+    "hpb.RequestHeaderB\010\310\336\037\000\320\336\037\001\0228\n\nintent_tx"
+    "n\030\002 \001(\0132\036.cockroach.roachpb.TransactionB"
+    "\004\310\336\037\000\"K\n\014NoopResponse\022;\n\006header\030\001 \001(\0132!."
+    "cockroach.roachpb.ResponseHeaderB\010\310\336\037\000\320\336"
+    "\037\001\"I\n\013NoopRequest\022:\n\006header\030\001 \001(\0132 .cock"
+    "roach.roachpb.RequestHeaderB\010\310\336\037\000\320\336\037\001\"Y\n"
+    "\032ResolveIntentRangeResponse\022;\n\006header\030\001 "
+    "\001(\0132!.cockroach.roachpb.ResponseHeaderB\010"
+    "\310\336\037\000\320\336\037\001\"y\n\014MergeRequest\022:\n\006header\030\001 \001(\013"
+    "2 .cockroach.roachpb.RequestHeaderB\010\310\336\037\000"
+    "\320\336\037\001\022-\n\005value\030\002 \001(\0132\030.cockroach.roachpb."
+    "ValueB\004\310\336\037\000\"L\n\rMergeResponse\022;\n\006header\030\001"
+    " \001(\0132!.cockroach.roachpb.ResponseHeaderB"
+    "\010\310\336\037\000\320\336\037\001\"e\n\022TruncateLogRequest\022:\n\006heade"
+    "r\030\001 \001(\0132 .cockroach.roachpb.RequestHeade"
+    "rB\010\310\336\037\000\320\336\037\001\022\023\n\005index\030\002 \001(\004B\004\310\336\037\000\"R\n\023Trun"
+    "cateLogResponse\022;\n\006header\030\001 \001(\0132!.cockro"
+    "ach.roachpb.ResponseHeaderB\010\310\336\037\000\320\336\037\001\"\177\n\022"
+    "LeaderLeaseRequest\022:\n\006header\030\001 \001(\0132 .coc"
+    "kroach.roachpb.RequestHeaderB\010\310\336\037\000\320\336\037\001\022-"
+    "\n\005lease\030\002 \001(\0132\030.cockroach.roachpb.LeaseB"
+    "\004\310\336\037\000\"R\n\023LeaderLeaseResponse\022;\n\006header\030\001"
+    " \001(\0132!.cockroach.roachpb.ResponseHeaderB"
+    "\010\310\336\037\000\320\336\037\001\"\272\t\n\014RequestUnion\022*\n\003get\030\001 \001(\0132"
+    "\035.cockroach.roachpb.GetRequest\022*\n\003put\030\002 "
+    "\001(\0132\035.cockroach.roachpb.PutRequest\022A\n\017co"
+    "nditional_put\030\003 \001(\0132(.cockroach.roachpb."
+    "ConditionalPutRequest\0226\n\tincrement\030\004 \001(\013"
+    "2#.cockroach.roachpb.IncrementRequest\0220\n"
+    "\006delete\030\005 \001(\0132 .cockroach.roachpb.Delete"
+    "Request\022;\n\014delete_range\030\006 \001(\0132%.cockroac"
+    "h.roachpb.DeleteRangeRequest\022,\n\004scan\030\007 \001"
+    "(\0132\036.cockroach.roachpb.ScanRequest\022A\n\017en"
+    "d_transaction\030\010 \001(\0132(.cockroach.roachpb."
+    "EndTransactionRequest\0229\n\013admin_split\030\t \001"
+    "(\0132$.cockroach.roachpb.AdminSplitRequest"
+    "\0229\n\013admin_merge\030\n \001(\0132$.cockroach.roachp"
+    "b.AdminMergeRequest\022=\n\rheartbeat_txn\030\013 \001"
+    "(\0132&.cockroach.roachpb.HeartbeatTxnReque"
+    "st\022(\n\002gc\030\014 \001(\0132\034.cockroach.roachpb.GCReq"
+    "uest\0223\n\010push_txn\030\r \001(\0132!.cockroach.roach"
+    "pb.PushTxnRequest\022;\n\014range_lookup\030\016 \001(\0132"
+    "%.cockroach.roachpb.RangeLookupRequest\022\?"
+    "\n\016resolve_intent\030\017 \001(\0132\'.cockroach.roach"
+    "pb.ResolveIntentRequest\022J\n\024resolve_inten"
+    "t_range\030\020 \001(\0132,.cockroach.roachpb.Resolv"
+    "eIntentRangeRequest\022.\n\005merge\030\021 \001(\0132\037.coc"
+    "kroach.roachpb.MergeRequest\022;\n\014truncate_"
+    "log\030\022 \001(\0132%.cockroach.roachpb.TruncateLo"
+    "gRequest\022;\n\014leader_lease\030\023 \001(\0132%.cockroa"
+    "ch.roachpb.LeaderLeaseRequest\022;\n\014reverse"
+    "_scan\030\024 \001(\0132%.cockroach.roachpb.ReverseS"
+    "canRequest\022,\n\004noop\030\025 \001(\0132\036.cockroach.roa"
+    "chpb.NoopRequest:\004\310\240\037\001\"\320\t\n\rResponseUnion"
+    "\022+\n\003get\030\001 \001(\0132\036.cockroach.roachpb.GetRes"
+    "ponse\022+\n\003put\030\002 \001(\0132\036.cockroach.roachpb.P"
+    "utResponse\022B\n\017conditional_put\030\003 \001(\0132).co"
+    "ckroach.roachpb.ConditionalPutResponse\0227"
+    "\n\tincrement\030\004 \001(\0132$.cockroach.roachpb.In"
+    "crementResponse\0221\n\006delete\030\005 \001(\0132!.cockro"
+    "ach.roachpb.DeleteResponse\022<\n\014delete_ran"
+    "ge\030\006 \001(\0132&.cockroach.roachpb.DeleteRange"
+    "Response\022-\n\004scan\030\007 \001(\0132\037.cockroach.roach"
+    "pb.ScanResponse\022B\n\017end_transaction\030\010 \001(\013"
+    "2).cockroach.roachpb.EndTransactionRespo"
+    "nse\022:\n\013admin_split\030\t \001(\0132%.cockroach.roa"
+    "chpb.AdminSplitResponse\022:\n\013admin_merge\030\n"
+    " \001(\0132%.cockroach.roachpb.AdminMergeRespo"
+    "nse\022>\n\rheartbeat_txn\030\013 \001(\0132\'.cockroach.r"
+    "oachpb.HeartbeatTxnResponse\022)\n\002gc\030\014 \001(\0132"
+    "\035.cockroach.roachpb.GCResponse\0224\n\010push_t"
+    "xn\030\r \001(\0132\".cockroach.roachpb.PushTxnResp"
+    "onse\022<\n\014range_lookup\030\016 \001(\0132&.cockroach.r"
+    "oachpb.RangeLookupResponse\022@\n\016resolve_in"
+    "tent\030\017 \001(\0132(.cockroach.roachpb.ResolveIn"
+    "tentResponse\022K\n\024resolve_intent_range\030\020 \001"
+    "(\0132-.cockroach.roachpb.ResolveIntentRang"
+    "eResponse\022/\n\005merge\030\021 \001(\0132 .cockroach.roa"
+    "chpb.MergeResponse\022<\n\014truncate_log\030\022 \001(\013"
+    "2&.cockroach.roachpb.TruncateLogResponse"
+    "\022<\n\014leader_lease\030\023 \001(\0132&.cockroach.roach"
+    "pb.LeaderLeaseResponse\022<\n\014reverse_scan\030\024"
+    " \001(\0132&.cockroach.roachpb.ReverseScanResp"
+    "onse\022-\n\004noop\030\025 \001(\0132\037.cockroach.roachpb.N"
+    "oopResponse:\004\310\240\037\001\"\212\004\n\014BatchRequest\022@\n\006he"
+    "ader\030\001 \001(\0132&.cockroach.roachpb.BatchRequ"
+    "est.HeaderB\010\310\336\037\000\320\336\037\001\0227\n\010requests\030\002 \003(\0132\037"
+    ".cockroach.roachpb.RequestUnionB\004\310\336\037\000\032\370\002"
+    "\n\006Header\0225\n\ttimestamp\030\001 \001(\0132\034.cockroach."
+    "roachpb.TimestampB\004\310\336\037\000\022=\n\006cmd_id\030\002 \001(\0132"
+    "\036.cockroach.roachpb.ClientCmdIDB\r\310\336\037\000\342\336\037"
+    "\005CmdID\022;\n\007replica\030\005 \001(\0132$.cockroach.roac"
+    "hpb.ReplicaDescriptorB\004\310\336\037\000\022,\n\010range_id\030"
+    "\006 \001(\003B\032\310\336\037\000\342\336\037\007RangeID\372\336\037\007RangeID\022\030\n\ruse"
+    "r_priority\030\007 \001(\005:\0011\022+\n\003txn\030\010 \001(\0132\036.cockr"
+    "oach.roachpb.Transaction\022F\n\020read_consist"
+    "ency\030\t \001(\0162&.cockroach.roachpb.ReadConsi"
+    "stencyTypeB\004\310\336\037\000:\004\230\240\037\000\"\245\002\n\rBatchResponse"
+    "\022A\n\006header\030\001 \001(\0132\'.cockroach.roachpb.Bat"
+    "chResponse.HeaderB\010\310\336\037\000\320\336\037\001\0229\n\tresponses"
+    "\030\002 \003(\0132 .cockroach.roachpb.ResponseUnion"
+    "B\004\310\336\037\000\032\225\001\n\006Header\022\'\n\005error\030\001 \001(\0132\030.cockr"
+    "oach.roachpb.Error\0225\n\ttimestamp\030\002 \001(\0132\034."
+    "cockroach.roachpb.TimestampB\004\310\336\037\000\022+\n\003txn"
+    "\030\003 \001(\0132\036.cockroach.roachpb.Transaction*L"
+    "\n\023ReadConsistencyType\022\016\n\nCONSISTENT\020\000\022\r\n"
+    "\tCONSENSUS\020\001\022\020\n\014INCONSISTENT\020\002\032\004\210\243\036\000*G\n\013"
+    "PushTxnType\022\022\n\016PUSH_TIMESTAMP\020\000\022\r\n\tABORT"
+    "_TXN\020\001\022\017\n\013CLEANUP_TXN\020\002\032\004\210\243\036\000B\031Z\007roachpb"
+    "\340\342\036\001\310\342\036\001\320\342\036\001\220\343\036\000", 9056);
+>>>>>>> a0fb5b0... make RequestHeader.ReadConsistency obsolete
   ::google::protobuf::MessageFactory::InternalRegisterGeneratedFile(
     "cockroach/roachpb/api.proto", &protobuf_RegisterTypes);
   ClientCmdID::default_instance_ = new ClientCmdID();
@@ -2095,7 +2325,14 @@ RequestHeader* RequestHeader::New(::google::protobuf::Arena* arena) const {
 }
 
 void RequestHeader::Clear() {
+<<<<<<< HEAD
   if (_has_bits_[0 / 32] & 31u) {
+=======
+  if (_has_bits_[0 / 32] & 63u) {
+    if (has_cmd_id()) {
+      if (cmd_id_ != NULL) cmd_id_->::cockroach::roachpb::ClientCmdID::Clear();
+    }
+>>>>>>> a0fb5b0... make RequestHeader.ReadConsistency obsolete
     if (has_key()) {
       key_.ClearToEmptyNoArena(&::google::protobuf::internal::GetEmptyStringAlreadyInited());
     }
@@ -2304,7 +2541,18 @@ void RequestHeader::SerializeWithCachedSizes(
 int RequestHeader::ByteSize() const {
   int total_size = 0;
 
+<<<<<<< HEAD
   if (_has_bits_[0 / 32] & 31) {
+=======
+  if (_has_bits_[0 / 32] & 63) {
+    // optional .cockroach.roachpb.ClientCmdID cmd_id = 2;
+    if (has_cmd_id()) {
+      total_size += 1 +
+        ::google::protobuf::internal::WireFormatLite::MessageSizeNoVirtual(
+          *this->cmd_id_);
+    }
+
+>>>>>>> a0fb5b0... make RequestHeader.ReadConsistency obsolete
     // optional bytes key = 3;
     if (has_key()) {
       total_size += 1 +
@@ -2607,6 +2855,7 @@ void RequestHeader::clear_txn() {
 
 // optional .cockroach.roachpb.ReadConsistencyType read_consistency = 9;
 bool RequestHeader::has_read_consistency() const {
+<<<<<<< HEAD
   return (_has_bits_[0] & 0x00000010u) != 0;
 }
 void RequestHeader::set_has_read_consistency() {
@@ -2614,6 +2863,15 @@ void RequestHeader::set_has_read_consistency() {
 }
 void RequestHeader::clear_has_read_consistency() {
   _has_bits_[0] &= ~0x00000010u;
+=======
+  return (_has_bits_[0] & 0x00000020u) != 0;
+}
+void RequestHeader::set_has_read_consistency() {
+  _has_bits_[0] |= 0x00000020u;
+}
+void RequestHeader::clear_has_read_consistency() {
+  _has_bits_[0] &= ~0x00000020u;
+>>>>>>> a0fb5b0... make RequestHeader.ReadConsistency obsolete
 }
 void RequestHeader::clear_read_consistency() {
   read_consistency_ = 0;

--- a/storage/engine/rocksdb/cockroach/roachpb/api.pb.cc
+++ b/storage/engine/rocksdb/cockroach/roachpb/api.pb.cc
@@ -206,10 +206,9 @@ void protobuf_AssignDesc_cockroach_2froachpb_2fapi_2eproto() {
       GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(ClientCmdID, _internal_metadata_),
       -1);
   RequestHeader_descriptor_ = file->message_type(1);
-  static const int RequestHeader_offsets_[3] = {
+  static const int RequestHeader_offsets_[2] = {
     GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(RequestHeader, key_),
     GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(RequestHeader, end_key_),
-    GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(RequestHeader, txn_),
   };
   RequestHeader_reflection_ =
     ::google::protobuf::internal::GeneratedMessageReflection::NewGeneratedMessageReflection(
@@ -1304,224 +1303,223 @@ void protobuf_AddDesc_cockroach_2froachpb_2fapi_2eproto() {
     "to\032\034cockroach/roachpb/data.proto\032\036cockro"
     "ach/roachpb/errors.proto\032\024gogoproto/gogo"
     ".proto\"<\n\013ClientCmdID\022\027\n\twall_time\030\001 \001(\003"
-    "B\004\310\336\037\000\022\024\n\006random\030\002 \001(\003B\004\310\336\037\000\"l\n\rRequestH"
+    "B\004\310\336\037\000\022\024\n\006random\030\002 \001(\003B\004\310\336\037\000\"\?\n\rRequestH"
     "eader\022\024\n\003key\030\003 \001(\014B\007\372\336\037\003Key\022\030\n\007end_key\030\004"
-    " \001(\014B\007\372\336\037\003Key\022+\n\003txn\030\010 \001(\0132\036.cockroach.r"
-    "oachpb.Transaction\"t\n\016ResponseHeader\0225\n\t"
-    "timestamp\030\002 \001(\0132\034.cockroach.roachpb.Time"
-    "stampB\004\310\336\037\000\022+\n\003txn\030\003 \001(\0132\036.cockroach.roa"
-    "chpb.Transaction\"H\n\nGetRequest\022:\n\006header"
-    "\030\001 \001(\0132 .cockroach.roachpb.RequestHeader"
-    "B\010\310\336\037\000\320\336\037\001\"s\n\013GetResponse\022;\n\006header\030\001 \001("
-    "\0132!.cockroach.roachpb.ResponseHeaderB\010\310\336"
-    "\037\000\320\336\037\001\022\'\n\005value\030\002 \001(\0132\030.cockroach.roachp"
-    "b.Value\"w\n\nPutRequest\022:\n\006header\030\001 \001(\0132 ."
-    "cockroach.roachpb.RequestHeaderB\010\310\336\037\000\320\336\037"
-    "\001\022-\n\005value\030\002 \001(\0132\030.cockroach.roachpb.Val"
-    "ueB\004\310\336\037\000\"J\n\013PutResponse\022;\n\006header\030\001 \001(\0132"
-    "!.cockroach.roachpb.ResponseHeaderB\010\310\336\037\000"
-    "\320\336\037\001\"\257\001\n\025ConditionalPutRequest\022:\n\006header"
-    "\030\001 \001(\0132 .cockroach.roachpb.RequestHeader"
-    "B\010\310\336\037\000\320\336\037\001\022-\n\005value\030\002 \001(\0132\030.cockroach.ro"
-    "achpb.ValueB\004\310\336\037\000\022+\n\texp_value\030\003 \001(\0132\030.c"
-    "ockroach.roachpb.Value\"U\n\026ConditionalPut"
-    "Response\022;\n\006header\030\001 \001(\0132!.cockroach.roa"
-    "chpb.ResponseHeaderB\010\310\336\037\000\320\336\037\001\"g\n\020Increme"
-    "ntRequest\022:\n\006header\030\001 \001(\0132 .cockroach.ro"
-    "achpb.RequestHeaderB\010\310\336\037\000\320\336\037\001\022\027\n\tincreme"
-    "nt\030\002 \001(\003B\004\310\336\037\000\"i\n\021IncrementResponse\022;\n\006h"
-    "eader\030\001 \001(\0132!.cockroach.roachpb.Response"
-    "HeaderB\010\310\336\037\000\320\336\037\001\022\027\n\tnew_value\030\002 \001(\003B\004\310\336\037"
-    "\000\"K\n\rDeleteRequest\022:\n\006header\030\001 \001(\0132 .coc"
-    "kroach.roachpb.RequestHeaderB\010\310\336\037\000\320\336\037\001\"M"
-    "\n\016DeleteResponse\022;\n\006header\030\001 \001(\0132!.cockr"
-    "oach.roachpb.ResponseHeaderB\010\310\336\037\000\320\336\037\001\"u\n"
-    "\022DeleteRangeRequest\022:\n\006header\030\001 \001(\0132 .co"
-    "ckroach.roachpb.RequestHeaderB\010\310\336\037\000\320\336\037\001\022"
-    "#\n\025max_entries_to_delete\030\002 \001(\003B\004\310\336\037\000\"m\n\023"
-    "DeleteRangeResponse\022;\n\006header\030\001 \001(\0132!.co"
-    "ckroach.roachpb.ResponseHeaderB\010\310\336\037\000\320\336\037\001"
-    "\022\031\n\013num_deleted\030\002 \001(\003B\004\310\336\037\000\"d\n\013ScanReque"
-    "st\022:\n\006header\030\001 \001(\0132 .cockroach.roachpb.R"
-    "equestHeaderB\010\310\336\037\000\320\336\037\001\022\031\n\013max_results\030\002 "
-    "\001(\003B\004\310\336\037\000\"|\n\014ScanResponse\022;\n\006header\030\001 \001("
-    "\0132!.cockroach.roachpb.ResponseHeaderB\010\310\336"
-    "\037\000\320\336\037\001\022/\n\004rows\030\002 \003(\0132\033.cockroach.roachpb"
-    ".KeyValueB\004\310\336\037\000\"k\n\022ReverseScanRequest\022:\n"
+    " \001(\014B\007\372\336\037\003Key\"t\n\016ResponseHeader\0225\n\ttimes"
+    "tamp\030\002 \001(\0132\034.cockroach.roachpb.Timestamp"
+    "B\004\310\336\037\000\022+\n\003txn\030\003 \001(\0132\036.cockroach.roachpb."
+    "Transaction\"H\n\nGetRequest\022:\n\006header\030\001 \001("
+    "\0132 .cockroach.roachpb.RequestHeaderB\010\310\336\037"
+    "\000\320\336\037\001\"s\n\013GetResponse\022;\n\006header\030\001 \001(\0132!.c"
+    "ockroach.roachpb.ResponseHeaderB\010\310\336\037\000\320\336\037"
+    "\001\022\'\n\005value\030\002 \001(\0132\030.cockroach.roachpb.Val"
+    "ue\"w\n\nPutRequest\022:\n\006header\030\001 \001(\0132 .cockr"
+    "oach.roachpb.RequestHeaderB\010\310\336\037\000\320\336\037\001\022-\n\005"
+    "value\030\002 \001(\0132\030.cockroach.roachpb.ValueB\004\310"
+    "\336\037\000\"J\n\013PutResponse\022;\n\006header\030\001 \001(\0132!.coc"
+    "kroach.roachpb.ResponseHeaderB\010\310\336\037\000\320\336\037\001\""
+    "\257\001\n\025ConditionalPutRequest\022:\n\006header\030\001 \001("
+    "\0132 .cockroach.roachpb.RequestHeaderB\010\310\336\037"
+    "\000\320\336\037\001\022-\n\005value\030\002 \001(\0132\030.cockroach.roachpb"
+    ".ValueB\004\310\336\037\000\022+\n\texp_value\030\003 \001(\0132\030.cockro"
+    "ach.roachpb.Value\"U\n\026ConditionalPutRespo"
+    "nse\022;\n\006header\030\001 \001(\0132!.cockroach.roachpb."
+    "ResponseHeaderB\010\310\336\037\000\320\336\037\001\"g\n\020IncrementReq"
+    "uest\022:\n\006header\030\001 \001(\0132 .cockroach.roachpb"
+    ".RequestHeaderB\010\310\336\037\000\320\336\037\001\022\027\n\tincrement\030\002 "
+    "\001(\003B\004\310\336\037\000\"i\n\021IncrementResponse\022;\n\006header"
+    "\030\001 \001(\0132!.cockroach.roachpb.ResponseHeade"
+    "rB\010\310\336\037\000\320\336\037\001\022\027\n\tnew_value\030\002 \001(\003B\004\310\336\037\000\"K\n\r"
+    "DeleteRequest\022:\n\006header\030\001 \001(\0132 .cockroac"
+    "h.roachpb.RequestHeaderB\010\310\336\037\000\320\336\037\001\"M\n\016Del"
+    "eteResponse\022;\n\006header\030\001 \001(\0132!.cockroach."
+    "roachpb.ResponseHeaderB\010\310\336\037\000\320\336\037\001\"u\n\022Dele"
+    "teRangeRequest\022:\n\006header\030\001 \001(\0132 .cockroa"
+    "ch.roachpb.RequestHeaderB\010\310\336\037\000\320\336\037\001\022#\n\025ma"
+    "x_entries_to_delete\030\002 \001(\003B\004\310\336\037\000\"m\n\023Delet"
+    "eRangeResponse\022;\n\006header\030\001 \001(\0132!.cockroa"
+    "ch.roachpb.ResponseHeaderB\010\310\336\037\000\320\336\037\001\022\031\n\013n"
+    "um_deleted\030\002 \001(\003B\004\310\336\037\000\"d\n\013ScanRequest\022:\n"
     "\006header\030\001 \001(\0132 .cockroach.roachpb.Reques"
     "tHeaderB\010\310\336\037\000\320\336\037\001\022\031\n\013max_results\030\002 \001(\003B\004"
-    "\310\336\037\000\"\203\001\n\023ReverseScanResponse\022;\n\006header\030\001"
-    " \001(\0132!.cockroach.roachpb.ResponseHeaderB"
-    "\010\310\336\037\000\320\336\037\001\022/\n\004rows\030\002 \003(\0132\033.cockroach.roac"
-    "hpb.KeyValueB\004\310\336\037\000\"\346\001\n\025EndTransactionReq"
-    "uest\022:\n\006header\030\001 \001(\0132 .cockroach.roachpb"
-    ".RequestHeaderB\010\310\336\037\000\320\336\037\001\022\024\n\006commit\030\002 \001(\010"
-    "B\004\310\336\037\000\022I\n\027internal_commit_trigger\030\003 \001(\0132"
-    "(.cockroach.roachpb.InternalCommitTrigge"
-    "r\0220\n\007intents\030\004 \003(\0132\031.cockroach.roachpb.I"
-    "ntentB\004\310\336\037\000\"\213\001\n\026EndTransactionResponse\022;"
-    "\n\006header\030\001 \001(\0132!.cockroach.roachpb.Respo"
-    "nseHeaderB\010\310\336\037\000\320\336\037\001\022\031\n\013commit_wait\030\002 \001(\003"
-    "B\004\310\336\037\000\022\031\n\010resolved\030\003 \003(\014B\007\372\336\037\003Key\"k\n\021Adm"
-    "inSplitRequest\022:\n\006header\030\001 \001(\0132 .cockroa"
-    "ch.roachpb.RequestHeaderB\010\310\336\037\000\320\336\037\001\022\032\n\tsp"
-    "lit_key\030\002 \001(\014B\007\372\336\037\003Key\"Q\n\022AdminSplitResp"
-    "onse\022;\n\006header\030\001 \001(\0132!.cockroach.roachpb"
-    ".ResponseHeaderB\010\310\336\037\000\320\336\037\001\"O\n\021AdminMergeR"
-    "equest\022:\n\006header\030\001 \001(\0132 .cockroach.roach"
-    "pb.RequestHeaderB\010\310\336\037\000\320\336\037\001\"Q\n\022AdminMerge"
-    "Response\022;\n\006header\030\001 \001(\0132!.cockroach.roa"
-    "chpb.ResponseHeaderB\010\310\336\037\000\320\336\037\001\"\241\001\n\022RangeL"
-    "ookupRequest\022:\n\006header\030\001 \001(\0132 .cockroach"
-    ".roachpb.RequestHeaderB\010\310\336\037\000\320\336\037\001\022\030\n\nmax_"
-    "ranges\030\002 \001(\005B\004\310\336\037\000\022\036\n\020consider_intents\030\003"
-    " \001(\010B\004\310\336\037\000\022\025\n\007reverse\030\004 \001(\010B\004\310\336\037\000\"\214\001\n\023Ra"
-    "ngeLookupResponse\022;\n\006header\030\001 \001(\0132!.cock"
-    "roach.roachpb.ResponseHeaderB\010\310\336\037\000\320\336\037\001\0228"
-    "\n\006ranges\030\002 \003(\0132\".cockroach.roachpb.Range"
-    "DescriptorB\004\310\336\037\000\"Q\n\023HeartbeatTxnRequest\022"
+    "\310\336\037\000\"|\n\014ScanResponse\022;\n\006header\030\001 \001(\0132!.c"
+    "ockroach.roachpb.ResponseHeaderB\010\310\336\037\000\320\336\037"
+    "\001\022/\n\004rows\030\002 \003(\0132\033.cockroach.roachpb.KeyV"
+    "alueB\004\310\336\037\000\"k\n\022ReverseScanRequest\022:\n\006head"
+    "er\030\001 \001(\0132 .cockroach.roachpb.RequestHead"
+    "erB\010\310\336\037\000\320\336\037\001\022\031\n\013max_results\030\002 \001(\003B\004\310\336\037\000\""
+    "\203\001\n\023ReverseScanResponse\022;\n\006header\030\001 \001(\0132"
+    "!.cockroach.roachpb.ResponseHeaderB\010\310\336\037\000"
+    "\320\336\037\001\022/\n\004rows\030\002 \003(\0132\033.cockroach.roachpb.K"
+    "eyValueB\004\310\336\037\000\"\346\001\n\025EndTransactionRequest\022"
     ":\n\006header\030\001 \001(\0132 .cockroach.roachpb.Requ"
-    "estHeaderB\010\310\336\037\000\320\336\037\001\"S\n\024HeartbeatTxnRespo"
-    "nse\022;\n\006header\030\001 \001(\0132!.cockroach.roachpb."
-    "ResponseHeaderB\010\310\336\037\000\320\336\037\001\"\225\002\n\tGCRequest\022:"
-    "\n\006header\030\001 \001(\0132 .cockroach.roachpb.Reque"
-    "stHeaderB\010\310\336\037\000\320\336\037\001\022>\n\007gc_meta\030\002 \001(\0132\035.co"
-    "ckroach.roachpb.GCMetadataB\016\310\336\037\000\342\336\037\006GCMe"
-    "ta\0226\n\004keys\030\003 \003(\0132\".cockroach.roachpb.GCR"
-    "equest.GCKeyB\004\310\336\037\000\032T\n\005GCKey\022\024\n\003key\030\001 \001(\014"
-    "B\007\372\336\037\003Key\0225\n\ttimestamp\030\002 \001(\0132\034.cockroach"
-    ".roachpb.TimestampB\004\310\336\037\000\"I\n\nGCResponse\022;"
-    "\n\006header\030\001 \001(\0132!.cockroach.roachpb.Respo"
-    "nseHeaderB\010\310\336\037\000\320\336\037\001\"\337\002\n\016PushTxnRequest\022:"
-    "\n\006header\030\001 \001(\0132 .cockroach.roachpb.Reque"
-    "stHeaderB\010\310\336\037\000\320\336\037\001\0228\n\npusher_txn\030\002 \001(\0132\036"
-    ".cockroach.roachpb.TransactionB\004\310\336\037\000\0228\n\n"
-    "pushee_txn\030\003 \001(\0132\036.cockroach.roachpb.Tra"
-    "nsactionB\004\310\336\037\000\0223\n\007push_to\030\004 \001(\0132\034.cockro"
-    "ach.roachpb.TimestampB\004\310\336\037\000\022/\n\003now\030\005 \001(\013"
-    "2\034.cockroach.roachpb.TimestampB\004\310\336\037\000\0227\n\t"
-    "push_type\030\006 \001(\0162\036.cockroach.roachpb.Push"
-    "TxnTypeB\004\310\336\037\000\"\202\001\n\017PushTxnResponse\022;\n\006hea"
+    "estHeaderB\010\310\336\037\000\320\336\037\001\022\024\n\006commit\030\002 \001(\010B\004\310\336\037"
+    "\000\022I\n\027internal_commit_trigger\030\003 \001(\0132(.coc"
+    "kroach.roachpb.InternalCommitTrigger\0220\n\007"
+    "intents\030\004 \003(\0132\031.cockroach.roachpb.Intent"
+    "B\004\310\336\037\000\"\213\001\n\026EndTransactionResponse\022;\n\006hea"
     "der\030\001 \001(\0132!.cockroach.roachpb.ResponseHe"
-    "aderB\010\310\336\037\000\320\336\037\001\0222\n\npushee_txn\030\002 \001(\0132\036.coc"
-    "kroach.roachpb.Transaction\"\214\001\n\024ResolveIn"
-    "tentRequest\022:\n\006header\030\001 \001(\0132 .cockroach."
-    "roachpb.RequestHeaderB\010\310\336\037\000\320\336\037\001\0228\n\ninten"
-    "t_txn\030\002 \001(\0132\036.cockroach.roachpb.Transact"
-    "ionB\004\310\336\037\000\"T\n\025ResolveIntentResponse\022;\n\006he"
-    "ader\030\001 \001(\0132!.cockroach.roachpb.ResponseH"
-    "eaderB\010\310\336\037\000\320\336\037\001\"\221\001\n\031ResolveIntentRangeRe"
-    "quest\022:\n\006header\030\001 \001(\0132 .cockroach.roachp"
-    "b.RequestHeaderB\010\310\336\037\000\320\336\037\001\0228\n\nintent_txn\030"
-    "\002 \001(\0132\036.cockroach.roachpb.TransactionB\004\310"
-    "\336\037\000\"K\n\014NoopResponse\022;\n\006header\030\001 \001(\0132!.co"
-    "ckroach.roachpb.ResponseHeaderB\010\310\336\037\000\320\336\037\001"
-    "\"I\n\013NoopRequest\022:\n\006header\030\001 \001(\0132 .cockro"
-    "ach.roachpb.RequestHeaderB\010\310\336\037\000\320\336\037\001\"Y\n\032R"
-    "esolveIntentRangeResponse\022;\n\006header\030\001 \001("
-    "\0132!.cockroach.roachpb.ResponseHeaderB\010\310\336"
-    "\037\000\320\336\037\001\"y\n\014MergeRequest\022:\n\006header\030\001 \001(\0132 "
-    ".cockroach.roachpb.RequestHeaderB\010\310\336\037\000\320\336"
-    "\037\001\022-\n\005value\030\002 \001(\0132\030.cockroach.roachpb.Va"
-    "lueB\004\310\336\037\000\"L\n\rMergeResponse\022;\n\006header\030\001 \001"
-    "(\0132!.cockroach.roachpb.ResponseHeaderB\010\310"
-    "\336\037\000\320\336\037\001\"e\n\022TruncateLogRequest\022:\n\006header\030"
-    "\001 \001(\0132 .cockroach.roachpb.RequestHeaderB"
-    "\010\310\336\037\000\320\336\037\001\022\023\n\005index\030\002 \001(\004B\004\310\336\037\000\"R\n\023Trunca"
-    "teLogResponse\022;\n\006header\030\001 \001(\0132!.cockroac"
-    "h.roachpb.ResponseHeaderB\010\310\336\037\000\320\336\037\001\"\177\n\022Le"
-    "aderLeaseRequest\022:\n\006header\030\001 \001(\0132 .cockr"
-    "oach.roachpb.RequestHeaderB\010\310\336\037\000\320\336\037\001\022-\n\005"
-    "lease\030\002 \001(\0132\030.cockroach.roachpb.LeaseB\004\310"
-    "\336\037\000\"R\n\023LeaderLeaseResponse\022;\n\006header\030\001 \001"
-    "(\0132!.cockroach.roachpb.ResponseHeaderB\010\310"
-    "\336\037\000\320\336\037\001\"\272\t\n\014RequestUnion\022*\n\003get\030\001 \001(\0132\035."
-    "cockroach.roachpb.GetRequest\022*\n\003put\030\002 \001("
-    "\0132\035.cockroach.roachpb.PutRequest\022A\n\017cond"
-    "itional_put\030\003 \001(\0132(.cockroach.roachpb.Co"
-    "nditionalPutRequest\0226\n\tincrement\030\004 \001(\0132#"
-    ".cockroach.roachpb.IncrementRequest\0220\n\006d"
-    "elete\030\005 \001(\0132 .cockroach.roachpb.DeleteRe"
-    "quest\022;\n\014delete_range\030\006 \001(\0132%.cockroach."
-    "roachpb.DeleteRangeRequest\022,\n\004scan\030\007 \001(\013"
-    "2\036.cockroach.roachpb.ScanRequest\022A\n\017end_"
-    "transaction\030\010 \001(\0132(.cockroach.roachpb.En"
-    "dTransactionRequest\0229\n\013admin_split\030\t \001(\013"
-    "2$.cockroach.roachpb.AdminSplitRequest\0229"
-    "\n\013admin_merge\030\n \001(\0132$.cockroach.roachpb."
-    "AdminMergeRequest\022=\n\rheartbeat_txn\030\013 \001(\013"
-    "2&.cockroach.roachpb.HeartbeatTxnRequest"
-    "\022(\n\002gc\030\014 \001(\0132\034.cockroach.roachpb.GCReque"
-    "st\0223\n\010push_txn\030\r \001(\0132!.cockroach.roachpb"
-    ".PushTxnRequest\022;\n\014range_lookup\030\016 \001(\0132%."
-    "cockroach.roachpb.RangeLookupRequest\022\?\n\016"
-    "resolve_intent\030\017 \001(\0132\'.cockroach.roachpb"
-    ".ResolveIntentRequest\022J\n\024resolve_intent_"
-    "range\030\020 \001(\0132,.cockroach.roachpb.ResolveI"
-    "ntentRangeRequest\022.\n\005merge\030\021 \001(\0132\037.cockr"
-    "oach.roachpb.MergeRequest\022;\n\014truncate_lo"
-    "g\030\022 \001(\0132%.cockroach.roachpb.TruncateLogR"
-    "equest\022;\n\014leader_lease\030\023 \001(\0132%.cockroach"
-    ".roachpb.LeaderLeaseRequest\022;\n\014reverse_s"
-    "can\030\024 \001(\0132%.cockroach.roachpb.ReverseSca"
-    "nRequest\022,\n\004noop\030\025 \001(\0132\036.cockroach.roach"
-    "pb.NoopRequest:\004\310\240\037\001\"\320\t\n\rResponseUnion\022+"
-    "\n\003get\030\001 \001(\0132\036.cockroach.roachpb.GetRespo"
-    "nse\022+\n\003put\030\002 \001(\0132\036.cockroach.roachpb.Put"
-    "Response\022B\n\017conditional_put\030\003 \001(\0132).cock"
-    "roach.roachpb.ConditionalPutResponse\0227\n\t"
-    "increment\030\004 \001(\0132$.cockroach.roachpb.Incr"
-    "ementResponse\0221\n\006delete\030\005 \001(\0132!.cockroac"
-    "h.roachpb.DeleteResponse\022<\n\014delete_range"
-    "\030\006 \001(\0132&.cockroach.roachpb.DeleteRangeRe"
-    "sponse\022-\n\004scan\030\007 \001(\0132\037.cockroach.roachpb"
-    ".ScanResponse\022B\n\017end_transaction\030\010 \001(\0132)"
-    ".cockroach.roachpb.EndTransactionRespons"
-    "e\022:\n\013admin_split\030\t \001(\0132%.cockroach.roach"
-    "pb.AdminSplitResponse\022:\n\013admin_merge\030\n \001"
-    "(\0132%.cockroach.roachpb.AdminMergeRespons"
-    "e\022>\n\rheartbeat_txn\030\013 \001(\0132\'.cockroach.roa"
-    "chpb.HeartbeatTxnResponse\022)\n\002gc\030\014 \001(\0132\035."
-    "cockroach.roachpb.GCResponse\0224\n\010push_txn"
-    "\030\r \001(\0132\".cockroach.roachpb.PushTxnRespon"
-    "se\022<\n\014range_lookup\030\016 \001(\0132&.cockroach.roa"
-    "chpb.RangeLookupResponse\022@\n\016resolve_inte"
-    "nt\030\017 \001(\0132(.cockroach.roachpb.ResolveInte"
-    "ntResponse\022K\n\024resolve_intent_range\030\020 \001(\013"
-    "2-.cockroach.roachpb.ResolveIntentRangeR"
-    "esponse\022/\n\005merge\030\021 \001(\0132 .cockroach.roach"
-    "pb.MergeResponse\022<\n\014truncate_log\030\022 \001(\0132&"
-    ".cockroach.roachpb.TruncateLogResponse\022<"
-    "\n\014leader_lease\030\023 \001(\0132&.cockroach.roachpb"
-    ".LeaderLeaseResponse\022<\n\014reverse_scan\030\024 \001"
-    "(\0132&.cockroach.roachpb.ReverseScanRespon"
-    "se\022-\n\004noop\030\025 \001(\0132\037.cockroach.roachpb.Noo"
-    "pResponse:\004\310\240\037\001\"\212\004\n\014BatchRequest\022@\n\006head"
-    "er\030\001 \001(\0132&.cockroach.roachpb.BatchReques"
-    "t.HeaderB\010\310\336\037\000\320\336\037\001\0227\n\010requests\030\002 \003(\0132\037.c"
-    "ockroach.roachpb.RequestUnionB\004\310\336\037\000\032\370\002\n\006"
-    "Header\0225\n\ttimestamp\030\001 \001(\0132\034.cockroach.ro"
-    "achpb.TimestampB\004\310\336\037\000\022=\n\006cmd_id\030\002 \001(\0132\036."
-    "cockroach.roachpb.ClientCmdIDB\r\310\336\037\000\342\336\037\005C"
-    "mdID\022;\n\007replica\030\005 \001(\0132$.cockroach.roachp"
-    "b.ReplicaDescriptorB\004\310\336\037\000\022,\n\010range_id\030\006 "
-    "\001(\003B\032\310\336\037\000\342\336\037\007RangeID\372\336\037\007RangeID\022\030\n\ruser_"
-    "priority\030\007 \001(\005:\0011\022+\n\003txn\030\010 \001(\0132\036.cockroa"
-    "ch.roachpb.Transaction\022F\n\020read_consisten"
-    "cy\030\t \001(\0162&.cockroach.roachpb.ReadConsist"
-    "encyTypeB\004\310\336\037\000:\004\230\240\037\000\"\245\002\n\rBatchResponse\022A"
-    "\n\006header\030\001 \001(\0132\'.cockroach.roachpb.Batch"
-    "Response.HeaderB\010\310\336\037\000\320\336\037\001\0229\n\tresponses\030\002"
-    " \003(\0132 .cockroach.roachpb.ResponseUnionB\004"
-    "\310\336\037\000\032\225\001\n\006Header\022\'\n\005error\030\001 \001(\0132\030.cockroa"
-    "ch.roachpb.Error\0225\n\ttimestamp\030\002 \001(\0132\034.co"
-    "ckroach.roachpb.TimestampB\004\310\336\037\000\022+\n\003txn\030\003"
-    " \001(\0132\036.cockroach.roachpb.Transaction*L\n\023"
-    "ReadConsistencyType\022\016\n\nCONSISTENT\020\000\022\r\n\tC"
-    "ONSENSUS\020\001\022\020\n\014INCONSISTENT\020\002\032\004\210\243\036\000*G\n\013Pu"
-    "shTxnType\022\022\n\016PUSH_TIMESTAMP\020\000\022\r\n\tABORT_T"
-    "XN\020\001\022\017\n\013CLEANUP_TXN\020\002\032\004\210\243\036\000B\031Z\007roachpb\340\342"
-    "\036\001\310\342\036\001\320\342\036\001\220\343\036\000", 8894);
+    "aderB\010\310\336\037\000\320\336\037\001\022\031\n\013commit_wait\030\002 \001(\003B\004\310\336\037"
+    "\000\022\031\n\010resolved\030\003 \003(\014B\007\372\336\037\003Key\"k\n\021AdminSpl"
+    "itRequest\022:\n\006header\030\001 \001(\0132 .cockroach.ro"
+    "achpb.RequestHeaderB\010\310\336\037\000\320\336\037\001\022\032\n\tsplit_k"
+    "ey\030\002 \001(\014B\007\372\336\037\003Key\"Q\n\022AdminSplitResponse\022"
+    ";\n\006header\030\001 \001(\0132!.cockroach.roachpb.Resp"
+    "onseHeaderB\010\310\336\037\000\320\336\037\001\"O\n\021AdminMergeReques"
+    "t\022:\n\006header\030\001 \001(\0132 .cockroach.roachpb.Re"
+    "questHeaderB\010\310\336\037\000\320\336\037\001\"Q\n\022AdminMergeRespo"
+    "nse\022;\n\006header\030\001 \001(\0132!.cockroach.roachpb."
+    "ResponseHeaderB\010\310\336\037\000\320\336\037\001\"\241\001\n\022RangeLookup"
+    "Request\022:\n\006header\030\001 \001(\0132 .cockroach.roac"
+    "hpb.RequestHeaderB\010\310\336\037\000\320\336\037\001\022\030\n\nmax_range"
+    "s\030\002 \001(\005B\004\310\336\037\000\022\036\n\020consider_intents\030\003 \001(\010B"
+    "\004\310\336\037\000\022\025\n\007reverse\030\004 \001(\010B\004\310\336\037\000\"\214\001\n\023RangeLo"
+    "okupResponse\022;\n\006header\030\001 \001(\0132!.cockroach"
+    ".roachpb.ResponseHeaderB\010\310\336\037\000\320\336\037\001\0228\n\006ran"
+    "ges\030\002 \003(\0132\".cockroach.roachpb.RangeDescr"
+    "iptorB\004\310\336\037\000\"Q\n\023HeartbeatTxnRequest\022:\n\006he"
+    "ader\030\001 \001(\0132 .cockroach.roachpb.RequestHe"
+    "aderB\010\310\336\037\000\320\336\037\001\"S\n\024HeartbeatTxnResponse\022;"
+    "\n\006header\030\001 \001(\0132!.cockroach.roachpb.Respo"
+    "nseHeaderB\010\310\336\037\000\320\336\037\001\"\225\002\n\tGCRequest\022:\n\006hea"
+    "der\030\001 \001(\0132 .cockroach.roachpb.RequestHea"
+    "derB\010\310\336\037\000\320\336\037\001\022>\n\007gc_meta\030\002 \001(\0132\035.cockroa"
+    "ch.roachpb.GCMetadataB\016\310\336\037\000\342\336\037\006GCMeta\0226\n"
+    "\004keys\030\003 \003(\0132\".cockroach.roachpb.GCReques"
+    "t.GCKeyB\004\310\336\037\000\032T\n\005GCKey\022\024\n\003key\030\001 \001(\014B\007\372\336\037"
+    "\003Key\0225\n\ttimestamp\030\002 \001(\0132\034.cockroach.roac"
+    "hpb.TimestampB\004\310\336\037\000\"I\n\nGCResponse\022;\n\006hea"
+    "der\030\001 \001(\0132!.cockroach.roachpb.ResponseHe"
+    "aderB\010\310\336\037\000\320\336\037\001\"\337\002\n\016PushTxnRequest\022:\n\006hea"
+    "der\030\001 \001(\0132 .cockroach.roachpb.RequestHea"
+    "derB\010\310\336\037\000\320\336\037\001\0228\n\npusher_txn\030\002 \001(\0132\036.cock"
+    "roach.roachpb.TransactionB\004\310\336\037\000\0228\n\npushe"
+    "e_txn\030\003 \001(\0132\036.cockroach.roachpb.Transact"
+    "ionB\004\310\336\037\000\0223\n\007push_to\030\004 \001(\0132\034.cockroach.r"
+    "oachpb.TimestampB\004\310\336\037\000\022/\n\003now\030\005 \001(\0132\034.co"
+    "ckroach.roachpb.TimestampB\004\310\336\037\000\0227\n\tpush_"
+    "type\030\006 \001(\0162\036.cockroach.roachpb.PushTxnTy"
+    "peB\004\310\336\037\000\"\202\001\n\017PushTxnResponse\022;\n\006header\030\001"
+    " \001(\0132!.cockroach.roachpb.ResponseHeaderB"
+    "\010\310\336\037\000\320\336\037\001\0222\n\npushee_txn\030\002 \001(\0132\036.cockroac"
+    "h.roachpb.Transaction\"\214\001\n\024ResolveIntentR"
+    "equest\022:\n\006header\030\001 \001(\0132 .cockroach.roach"
+    "pb.RequestHeaderB\010\310\336\037\000\320\336\037\001\0228\n\nintent_txn"
+    "\030\002 \001(\0132\036.cockroach.roachpb.TransactionB\004"
+    "\310\336\037\000\"T\n\025ResolveIntentResponse\022;\n\006header\030"
+    "\001 \001(\0132!.cockroach.roachpb.ResponseHeader"
+    "B\010\310\336\037\000\320\336\037\001\"\221\001\n\031ResolveIntentRangeRequest"
+    "\022:\n\006header\030\001 \001(\0132 .cockroach.roachpb.Req"
+    "uestHeaderB\010\310\336\037\000\320\336\037\001\0228\n\nintent_txn\030\002 \001(\013"
+    "2\036.cockroach.roachpb.TransactionB\004\310\336\037\000\"K"
+    "\n\014NoopResponse\022;\n\006header\030\001 \001(\0132!.cockroa"
+    "ch.roachpb.ResponseHeaderB\010\310\336\037\000\320\336\037\001\"I\n\013N"
+    "oopRequest\022:\n\006header\030\001 \001(\0132 .cockroach.r"
+    "oachpb.RequestHeaderB\010\310\336\037\000\320\336\037\001\"Y\n\032Resolv"
+    "eIntentRangeResponse\022;\n\006header\030\001 \001(\0132!.c"
+    "ockroach.roachpb.ResponseHeaderB\010\310\336\037\000\320\336\037"
+    "\001\"y\n\014MergeRequest\022:\n\006header\030\001 \001(\0132 .cock"
+    "roach.roachpb.RequestHeaderB\010\310\336\037\000\320\336\037\001\022-\n"
+    "\005value\030\002 \001(\0132\030.cockroach.roachpb.ValueB\004"
+    "\310\336\037\000\"L\n\rMergeResponse\022;\n\006header\030\001 \001(\0132!."
+    "cockroach.roachpb.ResponseHeaderB\010\310\336\037\000\320\336"
+    "\037\001\"e\n\022TruncateLogRequest\022:\n\006header\030\001 \001(\013"
+    "2 .cockroach.roachpb.RequestHeaderB\010\310\336\037\000"
+    "\320\336\037\001\022\023\n\005index\030\002 \001(\004B\004\310\336\037\000\"R\n\023TruncateLog"
+    "Response\022;\n\006header\030\001 \001(\0132!.cockroach.roa"
+    "chpb.ResponseHeaderB\010\310\336\037\000\320\336\037\001\"\177\n\022LeaderL"
+    "easeRequest\022:\n\006header\030\001 \001(\0132 .cockroach."
+    "roachpb.RequestHeaderB\010\310\336\037\000\320\336\037\001\022-\n\005lease"
+    "\030\002 \001(\0132\030.cockroach.roachpb.LeaseB\004\310\336\037\000\"R"
+    "\n\023LeaderLeaseResponse\022;\n\006header\030\001 \001(\0132!."
+    "cockroach.roachpb.ResponseHeaderB\010\310\336\037\000\320\336"
+    "\037\001\"\272\t\n\014RequestUnion\022*\n\003get\030\001 \001(\0132\035.cockr"
+    "oach.roachpb.GetRequest\022*\n\003put\030\002 \001(\0132\035.c"
+    "ockroach.roachpb.PutRequest\022A\n\017condition"
+    "al_put\030\003 \001(\0132(.cockroach.roachpb.Conditi"
+    "onalPutRequest\0226\n\tincrement\030\004 \001(\0132#.cock"
+    "roach.roachpb.IncrementRequest\0220\n\006delete"
+    "\030\005 \001(\0132 .cockroach.roachpb.DeleteRequest"
+    "\022;\n\014delete_range\030\006 \001(\0132%.cockroach.roach"
+    "pb.DeleteRangeRequest\022,\n\004scan\030\007 \001(\0132\036.co"
+    "ckroach.roachpb.ScanRequest\022A\n\017end_trans"
+    "action\030\010 \001(\0132(.cockroach.roachpb.EndTran"
+    "sactionRequest\0229\n\013admin_split\030\t \001(\0132$.co"
+    "ckroach.roachpb.AdminSplitRequest\0229\n\013adm"
+    "in_merge\030\n \001(\0132$.cockroach.roachpb.Admin"
+    "MergeRequest\022=\n\rheartbeat_txn\030\013 \001(\0132&.co"
+    "ckroach.roachpb.HeartbeatTxnRequest\022(\n\002g"
+    "c\030\014 \001(\0132\034.cockroach.roachpb.GCRequest\0223\n"
+    "\010push_txn\030\r \001(\0132!.cockroach.roachpb.Push"
+    "TxnRequest\022;\n\014range_lookup\030\016 \001(\0132%.cockr"
+    "oach.roachpb.RangeLookupRequest\022\?\n\016resol"
+    "ve_intent\030\017 \001(\0132\'.cockroach.roachpb.Reso"
+    "lveIntentRequest\022J\n\024resolve_intent_range"
+    "\030\020 \001(\0132,.cockroach.roachpb.ResolveIntent"
+    "RangeRequest\022.\n\005merge\030\021 \001(\0132\037.cockroach."
+    "roachpb.MergeRequest\022;\n\014truncate_log\030\022 \001"
+    "(\0132%.cockroach.roachpb.TruncateLogReques"
+    "t\022;\n\014leader_lease\030\023 \001(\0132%.cockroach.roac"
+    "hpb.LeaderLeaseRequest\022;\n\014reverse_scan\030\024"
+    " \001(\0132%.cockroach.roachpb.ReverseScanRequ"
+    "est\022,\n\004noop\030\025 \001(\0132\036.cockroach.roachpb.No"
+    "opRequest:\004\310\240\037\001\"\320\t\n\rResponseUnion\022+\n\003get"
+    "\030\001 \001(\0132\036.cockroach.roachpb.GetResponse\022+"
+    "\n\003put\030\002 \001(\0132\036.cockroach.roachpb.PutRespo"
+    "nse\022B\n\017conditional_put\030\003 \001(\0132).cockroach"
+    ".roachpb.ConditionalPutResponse\0227\n\tincre"
+    "ment\030\004 \001(\0132$.cockroach.roachpb.Increment"
+    "Response\0221\n\006delete\030\005 \001(\0132!.cockroach.roa"
+    "chpb.DeleteResponse\022<\n\014delete_range\030\006 \001("
+    "\0132&.cockroach.roachpb.DeleteRangeRespons"
+    "e\022-\n\004scan\030\007 \001(\0132\037.cockroach.roachpb.Scan"
+    "Response\022B\n\017end_transaction\030\010 \001(\0132).cock"
+    "roach.roachpb.EndTransactionResponse\022:\n\013"
+    "admin_split\030\t \001(\0132%.cockroach.roachpb.Ad"
+    "minSplitResponse\022:\n\013admin_merge\030\n \001(\0132%."
+    "cockroach.roachpb.AdminMergeResponse\022>\n\r"
+    "heartbeat_txn\030\013 \001(\0132\'.cockroach.roachpb."
+    "HeartbeatTxnResponse\022)\n\002gc\030\014 \001(\0132\035.cockr"
+    "oach.roachpb.GCResponse\0224\n\010push_txn\030\r \001("
+    "\0132\".cockroach.roachpb.PushTxnResponse\022<\n"
+    "\014range_lookup\030\016 \001(\0132&.cockroach.roachpb."
+    "RangeLookupResponse\022@\n\016resolve_intent\030\017 "
+    "\001(\0132(.cockroach.roachpb.ResolveIntentRes"
+    "ponse\022K\n\024resolve_intent_range\030\020 \001(\0132-.co"
+    "ckroach.roachpb.ResolveIntentRangeRespon"
+    "se\022/\n\005merge\030\021 \001(\0132 .cockroach.roachpb.Me"
+    "rgeResponse\022<\n\014truncate_log\030\022 \001(\0132&.cock"
+    "roach.roachpb.TruncateLogResponse\022<\n\014lea"
+    "der_lease\030\023 \001(\0132&.cockroach.roachpb.Lead"
+    "erLeaseResponse\022<\n\014reverse_scan\030\024 \001(\0132&."
+    "cockroach.roachpb.ReverseScanResponse\022-\n"
+    "\004noop\030\025 \001(\0132\037.cockroach.roachpb.NoopResp"
+    "onse:\004\310\240\037\001\"\212\004\n\014BatchRequest\022@\n\006header\030\001 "
+    "\001(\0132&.cockroach.roachpb.BatchRequest.Hea"
+    "derB\010\310\336\037\000\320\336\037\001\0227\n\010requests\030\002 \003(\0132\037.cockro"
+    "ach.roachpb.RequestUnionB\004\310\336\037\000\032\370\002\n\006Heade"
+    "r\0225\n\ttimestamp\030\001 \001(\0132\034.cockroach.roachpb"
+    ".TimestampB\004\310\336\037\000\022=\n\006cmd_id\030\002 \001(\0132\036.cockr"
+    "oach.roachpb.ClientCmdIDB\r\310\336\037\000\342\336\037\005CmdID\022"
+    ";\n\007replica\030\005 \001(\0132$.cockroach.roachpb.Rep"
+    "licaDescriptorB\004\310\336\037\000\022,\n\010range_id\030\006 \001(\003B\032"
+    "\310\336\037\000\342\336\037\007RangeID\372\336\037\007RangeID\022\030\n\ruser_prior"
+    "ity\030\007 \001(\005:\0011\022+\n\003txn\030\010 \001(\0132\036.cockroach.ro"
+    "achpb.Transaction\022F\n\020read_consistency\030\t "
+    "\001(\0162&.cockroach.roachpb.ReadConsistencyT"
+    "ypeB\004\310\336\037\000:\004\230\240\037\000\"\245\002\n\rBatchResponse\022A\n\006hea"
+    "der\030\001 \001(\0132\'.cockroach.roachpb.BatchRespo"
+    "nse.HeaderB\010\310\336\037\000\320\336\037\001\0229\n\tresponses\030\002 \003(\0132"
+    " .cockroach.roachpb.ResponseUnionB\004\310\336\037\000\032"
+    "\225\001\n\006Header\022\'\n\005error\030\001 \001(\0132\030.cockroach.ro"
+    "achpb.Error\0225\n\ttimestamp\030\002 \001(\0132\034.cockroa"
+    "ch.roachpb.TimestampB\004\310\336\037\000\022+\n\003txn\030\003 \001(\0132"
+    "\036.cockroach.roachpb.Transaction*L\n\023ReadC"
+    "onsistencyType\022\016\n\nCONSISTENT\020\000\022\r\n\tCONSEN"
+    "SUS\020\001\022\020\n\014INCONSISTENT\020\002\032\004\210\243\036\000*G\n\013PushTxn"
+    "Type\022\022\n\016PUSH_TIMESTAMP\020\000\022\r\n\tABORT_TXN\020\001\022"
+    "\017\n\013CLEANUP_TXN\020\002\032\004\210\243\036\000B\031Z\007roachpb\340\342\036\001\310\342\036"
+    "\001\320\342\036\001\220\343\036\000", 8849);
   ::google::protobuf::MessageFactory::InternalRegisterGeneratedFile(
     "cockroach/roachpb/api.proto", &protobuf_RegisterTypes);
   ClientCmdID::default_instance_ = new ClientCmdID();
@@ -2018,7 +2016,6 @@ void ClientCmdID::clear_random() {
 #ifndef _MSC_VER
 const int RequestHeader::kKeyFieldNumber;
 const int RequestHeader::kEndKeyFieldNumber;
-const int RequestHeader::kTxnFieldNumber;
 #endif  // !_MSC_VER
 
 RequestHeader::RequestHeader()
@@ -2028,7 +2025,6 @@ RequestHeader::RequestHeader()
 }
 
 void RequestHeader::InitAsDefaultInstance() {
-  txn_ = const_cast< ::cockroach::roachpb::Transaction*>(&::cockroach::roachpb::Transaction::default_instance());
 }
 
 RequestHeader::RequestHeader(const RequestHeader& from)
@@ -2044,7 +2040,6 @@ void RequestHeader::SharedCtor() {
   _cached_size_ = 0;
   key_.UnsafeSetDefault(&::google::protobuf::internal::GetEmptyStringAlreadyInited());
   end_key_.UnsafeSetDefault(&::google::protobuf::internal::GetEmptyStringAlreadyInited());
-  txn_ = NULL;
   ::memset(_has_bits_, 0, sizeof(_has_bits_));
 }
 
@@ -2057,7 +2052,6 @@ void RequestHeader::SharedDtor() {
   key_.DestroyNoArena(&::google::protobuf::internal::GetEmptyStringAlreadyInited());
   end_key_.DestroyNoArena(&::google::protobuf::internal::GetEmptyStringAlreadyInited());
   if (this != default_instance_) {
-    delete txn_;
   }
 }
 
@@ -2087,15 +2081,12 @@ RequestHeader* RequestHeader::New(::google::protobuf::Arena* arena) const {
 }
 
 void RequestHeader::Clear() {
-  if (_has_bits_[0 / 32] & 7u) {
+  if (_has_bits_[0 / 32] & 3u) {
     if (has_key()) {
       key_.ClearToEmptyNoArena(&::google::protobuf::internal::GetEmptyStringAlreadyInited());
     }
     if (has_end_key()) {
       end_key_.ClearToEmptyNoArena(&::google::protobuf::internal::GetEmptyStringAlreadyInited());
-    }
-    if (has_txn()) {
-      if (txn_ != NULL) txn_->::cockroach::roachpb::Transaction::Clear();
     }
   }
   ::memset(_has_bits_, 0, sizeof(_has_bits_));
@@ -2132,19 +2123,6 @@ bool RequestHeader::MergePartialFromCodedStream(
          parse_end_key:
           DO_(::google::protobuf::internal::WireFormatLite::ReadBytes(
                 input, this->mutable_end_key()));
-        } else {
-          goto handle_unusual;
-        }
-        if (input->ExpectTag(66)) goto parse_txn;
-        break;
-      }
-
-      // optional .cockroach.roachpb.Transaction txn = 8;
-      case 8: {
-        if (tag == 66) {
-         parse_txn:
-          DO_(::google::protobuf::internal::WireFormatLite::ReadMessageNoVirtual(
-               input, mutable_txn()));
         } else {
           goto handle_unusual;
         }
@@ -2189,12 +2167,6 @@ void RequestHeader::SerializeWithCachedSizes(
       4, this->end_key(), output);
   }
 
-  // optional .cockroach.roachpb.Transaction txn = 8;
-  if (has_txn()) {
-    ::google::protobuf::internal::WireFormatLite::WriteMessageMaybeToArray(
-      8, *this->txn_, output);
-  }
-
   if (_internal_metadata_.have_unknown_fields()) {
     ::google::protobuf::internal::WireFormat::SerializeUnknownFields(
         unknown_fields(), output);
@@ -2219,13 +2191,6 @@ void RequestHeader::SerializeWithCachedSizes(
         4, this->end_key(), target);
   }
 
-  // optional .cockroach.roachpb.Transaction txn = 8;
-  if (has_txn()) {
-    target = ::google::protobuf::internal::WireFormatLite::
-      WriteMessageNoVirtualToArray(
-        8, *this->txn_, target);
-  }
-
   if (_internal_metadata_.have_unknown_fields()) {
     target = ::google::protobuf::internal::WireFormat::SerializeUnknownFieldsToArray(
         unknown_fields(), target);
@@ -2237,7 +2202,7 @@ void RequestHeader::SerializeWithCachedSizes(
 int RequestHeader::ByteSize() const {
   int total_size = 0;
 
-  if (_has_bits_[0 / 32] & 7) {
+  if (_has_bits_[0 / 32] & 3) {
     // optional bytes key = 3;
     if (has_key()) {
       total_size += 1 +
@@ -2250,13 +2215,6 @@ int RequestHeader::ByteSize() const {
       total_size += 1 +
         ::google::protobuf::internal::WireFormatLite::BytesSize(
           this->end_key());
-    }
-
-    // optional .cockroach.roachpb.Transaction txn = 8;
-    if (has_txn()) {
-      total_size += 1 +
-        ::google::protobuf::internal::WireFormatLite::MessageSizeNoVirtual(
-          *this->txn_);
     }
 
   }
@@ -2294,9 +2252,6 @@ void RequestHeader::MergeFrom(const RequestHeader& from) {
       set_has_end_key();
       end_key_.AssignWithDefault(&::google::protobuf::internal::GetEmptyStringAlreadyInited(), from.end_key_);
     }
-    if (from.has_txn()) {
-      mutable_txn()->::cockroach::roachpb::Transaction::MergeFrom(from.txn());
-    }
   }
   if (from._internal_metadata_.have_unknown_fields()) {
     mutable_unknown_fields()->MergeFrom(from.unknown_fields());
@@ -2327,7 +2282,6 @@ void RequestHeader::Swap(RequestHeader* other) {
 void RequestHeader::InternalSwap(RequestHeader* other) {
   key_.Swap(&other->key_);
   end_key_.Swap(&other->end_key_);
-  std::swap(txn_, other->txn_);
   std::swap(_has_bits_[0], other->_has_bits_[0]);
   _internal_metadata_.Swap(&other->_internal_metadata_);
   std::swap(_cached_size_, other->_cached_size_);
@@ -2448,49 +2402,6 @@ void RequestHeader::clear_end_key() {
   }
   end_key_.SetAllocatedNoArena(&::google::protobuf::internal::GetEmptyStringAlreadyInited(), end_key);
   // @@protoc_insertion_point(field_set_allocated:cockroach.roachpb.RequestHeader.end_key)
-}
-
-// optional .cockroach.roachpb.Transaction txn = 8;
-bool RequestHeader::has_txn() const {
-  return (_has_bits_[0] & 0x00000004u) != 0;
-}
-void RequestHeader::set_has_txn() {
-  _has_bits_[0] |= 0x00000004u;
-}
-void RequestHeader::clear_has_txn() {
-  _has_bits_[0] &= ~0x00000004u;
-}
-void RequestHeader::clear_txn() {
-  if (txn_ != NULL) txn_->::cockroach::roachpb::Transaction::Clear();
-  clear_has_txn();
-}
- const ::cockroach::roachpb::Transaction& RequestHeader::txn() const {
-  // @@protoc_insertion_point(field_get:cockroach.roachpb.RequestHeader.txn)
-  return txn_ != NULL ? *txn_ : *default_instance_->txn_;
-}
- ::cockroach::roachpb::Transaction* RequestHeader::mutable_txn() {
-  set_has_txn();
-  if (txn_ == NULL) {
-    txn_ = new ::cockroach::roachpb::Transaction;
-  }
-  // @@protoc_insertion_point(field_mutable:cockroach.roachpb.RequestHeader.txn)
-  return txn_;
-}
- ::cockroach::roachpb::Transaction* RequestHeader::release_txn() {
-  clear_has_txn();
-  ::cockroach::roachpb::Transaction* temp = txn_;
-  txn_ = NULL;
-  return temp;
-}
- void RequestHeader::set_allocated_txn(::cockroach::roachpb::Transaction* txn) {
-  delete txn_;
-  txn_ = txn;
-  if (txn) {
-    set_has_txn();
-  } else {
-    clear_has_txn();
-  }
-  // @@protoc_insertion_point(field_set_allocated:cockroach.roachpb.RequestHeader.txn)
 }
 
 #endif  // PROTOBUF_INLINE_NOT_IN_HEADERS

--- a/storage/engine/rocksdb/cockroach/roachpb/api.pb.cc
+++ b/storage/engine/rocksdb/cockroach/roachpb/api.pb.cc
@@ -206,8 +206,7 @@ void protobuf_AssignDesc_cockroach_2froachpb_2fapi_2eproto() {
       GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(ClientCmdID, _internal_metadata_),
       -1);
   RequestHeader_descriptor_ = file->message_type(1);
-  static const int RequestHeader_offsets_[6] = {
-    GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(RequestHeader, cmd_id_),
+  static const int RequestHeader_offsets_[5] = {
     GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(RequestHeader, key_),
     GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(RequestHeader, end_key_),
     GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(RequestHeader, user_priority_),
@@ -1307,228 +1306,226 @@ void protobuf_AddDesc_cockroach_2froachpb_2fapi_2eproto() {
     "to\032\034cockroach/roachpb/data.proto\032\036cockro"
     "ach/roachpb/errors.proto\032\024gogoproto/gogo"
     ".proto\"<\n\013ClientCmdID\022\027\n\twall_time\030\001 \001(\003"
-    "B\004\310\336\037\000\022\024\n\006random\030\002 \001(\003B\004\310\336\037\000\"\215\002\n\rRequest"
-    "Header\022=\n\006cmd_id\030\002 \001(\0132\036.cockroach.roach"
-    "pb.ClientCmdIDB\r\310\336\037\000\342\336\037\005CmdID\022\024\n\003key\030\003 \001"
-    "(\014B\007\372\336\037\003Key\022\030\n\007end_key\030\004 \001(\014B\007\372\336\037\003Key\022\030\n"
-    "\ruser_priority\030\007 \001(\005:\0011\022+\n\003txn\030\010 \001(\0132\036.c"
-    "ockroach.roachpb.Transaction\022F\n\020read_con"
-    "sistency\030\t \001(\0162&.cockroach.roachpb.ReadC"
-    "onsistencyTypeB\004\310\336\037\000\"t\n\016ResponseHeader\0225"
-    "\n\ttimestamp\030\002 \001(\0132\034.cockroach.roachpb.Ti"
-    "mestampB\004\310\336\037\000\022+\n\003txn\030\003 \001(\0132\036.cockroach.r"
-    "oachpb.Transaction\"H\n\nGetRequest\022:\n\006head"
-    "er\030\001 \001(\0132 .cockroach.roachpb.RequestHead"
-    "erB\010\310\336\037\000\320\336\037\001\"s\n\013GetResponse\022;\n\006header\030\001 "
-    "\001(\0132!.cockroach.roachpb.ResponseHeaderB\010"
-    "\310\336\037\000\320\336\037\001\022\'\n\005value\030\002 \001(\0132\030.cockroach.roac"
-    "hpb.Value\"w\n\nPutRequest\022:\n\006header\030\001 \001(\0132"
-    " .cockroach.roachpb.RequestHeaderB\010\310\336\037\000\320"
-    "\336\037\001\022-\n\005value\030\002 \001(\0132\030.cockroach.roachpb.V"
-    "alueB\004\310\336\037\000\"J\n\013PutResponse\022;\n\006header\030\001 \001("
-    "\0132!.cockroach.roachpb.ResponseHeaderB\010\310\336"
-    "\037\000\320\336\037\001\"\257\001\n\025ConditionalPutRequest\022:\n\006head"
-    "er\030\001 \001(\0132 .cockroach.roachpb.RequestHead"
-    "erB\010\310\336\037\000\320\336\037\001\022-\n\005value\030\002 \001(\0132\030.cockroach."
-    "roachpb.ValueB\004\310\336\037\000\022+\n\texp_value\030\003 \001(\0132\030"
-    ".cockroach.roachpb.Value\"U\n\026ConditionalP"
-    "utResponse\022;\n\006header\030\001 \001(\0132!.cockroach.r"
-    "oachpb.ResponseHeaderB\010\310\336\037\000\320\336\037\001\"g\n\020Incre"
-    "mentRequest\022:\n\006header\030\001 \001(\0132 .cockroach."
-    "roachpb.RequestHeaderB\010\310\336\037\000\320\336\037\001\022\027\n\tincre"
-    "ment\030\002 \001(\003B\004\310\336\037\000\"i\n\021IncrementResponse\022;\n"
-    "\006header\030\001 \001(\0132!.cockroach.roachpb.Respon"
-    "seHeaderB\010\310\336\037\000\320\336\037\001\022\027\n\tnew_value\030\002 \001(\003B\004\310"
-    "\336\037\000\"K\n\rDeleteRequest\022:\n\006header\030\001 \001(\0132 .c"
-    "ockroach.roachpb.RequestHeaderB\010\310\336\037\000\320\336\037\001"
-    "\"M\n\016DeleteResponse\022;\n\006header\030\001 \001(\0132!.coc"
-    "kroach.roachpb.ResponseHeaderB\010\310\336\037\000\320\336\037\001\""
-    "u\n\022DeleteRangeRequest\022:\n\006header\030\001 \001(\0132 ."
-    "cockroach.roachpb.RequestHeaderB\010\310\336\037\000\320\336\037"
-    "\001\022#\n\025max_entries_to_delete\030\002 \001(\003B\004\310\336\037\000\"m"
-    "\n\023DeleteRangeResponse\022;\n\006header\030\001 \001(\0132!."
-    "cockroach.roachpb.ResponseHeaderB\010\310\336\037\000\320\336"
-    "\037\001\022\031\n\013num_deleted\030\002 \001(\003B\004\310\336\037\000\"d\n\013ScanReq"
-    "uest\022:\n\006header\030\001 \001(\0132 .cockroach.roachpb"
-    ".RequestHeaderB\010\310\336\037\000\320\336\037\001\022\031\n\013max_results\030"
-    "\002 \001(\003B\004\310\336\037\000\"|\n\014ScanResponse\022;\n\006header\030\001 "
-    "\001(\0132!.cockroach.roachpb.ResponseHeaderB\010"
-    "\310\336\037\000\320\336\037\001\022/\n\004rows\030\002 \003(\0132\033.cockroach.roach"
-    "pb.KeyValueB\004\310\336\037\000\"k\n\022ReverseScanRequest\022"
-    ":\n\006header\030\001 \001(\0132 .cockroach.roachpb.Requ"
-    "estHeaderB\010\310\336\037\000\320\336\037\001\022\031\n\013max_results\030\002 \001(\003"
-    "B\004\310\336\037\000\"\203\001\n\023ReverseScanResponse\022;\n\006header"
-    "\030\001 \001(\0132!.cockroach.roachpb.ResponseHeade"
-    "rB\010\310\336\037\000\320\336\037\001\022/\n\004rows\030\002 \003(\0132\033.cockroach.ro"
-    "achpb.KeyValueB\004\310\336\037\000\"\346\001\n\025EndTransactionR"
-    "equest\022:\n\006header\030\001 \001(\0132 .cockroach.roach"
-    "pb.RequestHeaderB\010\310\336\037\000\320\336\037\001\022\024\n\006commit\030\002 \001"
-    "(\010B\004\310\336\037\000\022I\n\027internal_commit_trigger\030\003 \001("
-    "\0132(.cockroach.roachpb.InternalCommitTrig"
-    "ger\0220\n\007intents\030\004 \003(\0132\031.cockroach.roachpb"
-    ".IntentB\004\310\336\037\000\"\213\001\n\026EndTransactionResponse"
-    "\022;\n\006header\030\001 \001(\0132!.cockroach.roachpb.Res"
-    "ponseHeaderB\010\310\336\037\000\320\336\037\001\022\031\n\013commit_wait\030\002 \001"
-    "(\003B\004\310\336\037\000\022\031\n\010resolved\030\003 \003(\014B\007\372\336\037\003Key\"k\n\021A"
-    "dminSplitRequest\022:\n\006header\030\001 \001(\0132 .cockr"
-    "oach.roachpb.RequestHeaderB\010\310\336\037\000\320\336\037\001\022\032\n\t"
-    "split_key\030\002 \001(\014B\007\372\336\037\003Key\"Q\n\022AdminSplitRe"
-    "sponse\022;\n\006header\030\001 \001(\0132!.cockroach.roach"
-    "pb.ResponseHeaderB\010\310\336\037\000\320\336\037\001\"O\n\021AdminMerg"
-    "eRequest\022:\n\006header\030\001 \001(\0132 .cockroach.roa"
-    "chpb.RequestHeaderB\010\310\336\037\000\320\336\037\001\"Q\n\022AdminMer"
-    "geResponse\022;\n\006header\030\001 \001(\0132!.cockroach.r"
-    "oachpb.ResponseHeaderB\010\310\336\037\000\320\336\037\001\"\241\001\n\022Rang"
-    "eLookupRequest\022:\n\006header\030\001 \001(\0132 .cockroa"
-    "ch.roachpb.RequestHeaderB\010\310\336\037\000\320\336\037\001\022\030\n\nma"
-    "x_ranges\030\002 \001(\005B\004\310\336\037\000\022\036\n\020consider_intents"
-    "\030\003 \001(\010B\004\310\336\037\000\022\025\n\007reverse\030\004 \001(\010B\004\310\336\037\000\"\214\001\n\023"
-    "RangeLookupResponse\022;\n\006header\030\001 \001(\0132!.co"
-    "ckroach.roachpb.ResponseHeaderB\010\310\336\037\000\320\336\037\001"
-    "\0228\n\006ranges\030\002 \003(\0132\".cockroach.roachpb.Ran"
-    "geDescriptorB\004\310\336\037\000\"Q\n\023HeartbeatTxnReques"
-    "t\022:\n\006header\030\001 \001(\0132 .cockroach.roachpb.Re"
-    "questHeaderB\010\310\336\037\000\320\336\037\001\"S\n\024HeartbeatTxnRes"
-    "ponse\022;\n\006header\030\001 \001(\0132!.cockroach.roachp"
-    "b.ResponseHeaderB\010\310\336\037\000\320\336\037\001\"\225\002\n\tGCRequest"
+    "B\004\310\336\037\000\022\024\n\006random\030\002 \001(\003B\004\310\336\037\000\"\316\001\n\rRequest"
+    "Header\022\024\n\003key\030\003 \001(\014B\007\372\336\037\003Key\022\030\n\007end_key\030"
+    "\004 \001(\014B\007\372\336\037\003Key\022\030\n\ruser_priority\030\007 \001(\005:\0011"
+    "\022+\n\003txn\030\010 \001(\0132\036.cockroach.roachpb.Transa"
+    "ction\022F\n\020read_consistency\030\t \001(\0162&.cockro"
+    "ach.roachpb.ReadConsistencyTypeB\004\310\336\037\000\"t\n"
+    "\016ResponseHeader\0225\n\ttimestamp\030\002 \001(\0132\034.coc"
+    "kroach.roachpb.TimestampB\004\310\336\037\000\022+\n\003txn\030\003 "
+    "\001(\0132\036.cockroach.roachpb.Transaction\"H\n\nG"
+    "etRequest\022:\n\006header\030\001 \001(\0132 .cockroach.ro"
+    "achpb.RequestHeaderB\010\310\336\037\000\320\336\037\001\"s\n\013GetResp"
+    "onse\022;\n\006header\030\001 \001(\0132!.cockroach.roachpb"
+    ".ResponseHeaderB\010\310\336\037\000\320\336\037\001\022\'\n\005value\030\002 \001(\013"
+    "2\030.cockroach.roachpb.Value\"w\n\nPutRequest"
     "\022:\n\006header\030\001 \001(\0132 .cockroach.roachpb.Req"
-    "uestHeaderB\010\310\336\037\000\320\336\037\001\022>\n\007gc_meta\030\002 \001(\0132\035."
-    "cockroach.roachpb.GCMetadataB\016\310\336\037\000\342\336\037\006GC"
-    "Meta\0226\n\004keys\030\003 \003(\0132\".cockroach.roachpb.G"
-    "CRequest.GCKeyB\004\310\336\037\000\032T\n\005GCKey\022\024\n\003key\030\001 \001"
-    "(\014B\007\372\336\037\003Key\0225\n\ttimestamp\030\002 \001(\0132\034.cockroa"
-    "ch.roachpb.TimestampB\004\310\336\037\000\"I\n\nGCResponse"
-    "\022;\n\006header\030\001 \001(\0132!.cockroach.roachpb.Res"
-    "ponseHeaderB\010\310\336\037\000\320\336\037\001\"\337\002\n\016PushTxnRequest"
-    "\022:\n\006header\030\001 \001(\0132 .cockroach.roachpb.Req"
-    "uestHeaderB\010\310\336\037\000\320\336\037\001\0228\n\npusher_txn\030\002 \001(\013"
-    "2\036.cockroach.roachpb.TransactionB\004\310\336\037\000\0228"
-    "\n\npushee_txn\030\003 \001(\0132\036.cockroach.roachpb.T"
-    "ransactionB\004\310\336\037\000\0223\n\007push_to\030\004 \001(\0132\034.cock"
-    "roach.roachpb.TimestampB\004\310\336\037\000\022/\n\003now\030\005 \001"
-    "(\0132\034.cockroach.roachpb.TimestampB\004\310\336\037\000\0227"
-    "\n\tpush_type\030\006 \001(\0162\036.cockroach.roachpb.Pu"
-    "shTxnTypeB\004\310\336\037\000\"\202\001\n\017PushTxnResponse\022;\n\006h"
+    "uestHeaderB\010\310\336\037\000\320\336\037\001\022-\n\005value\030\002 \001(\0132\030.co"
+    "ckroach.roachpb.ValueB\004\310\336\037\000\"J\n\013PutRespon"
+    "se\022;\n\006header\030\001 \001(\0132!.cockroach.roachpb.R"
+    "esponseHeaderB\010\310\336\037\000\320\336\037\001\"\257\001\n\025ConditionalP"
+    "utRequest\022:\n\006header\030\001 \001(\0132 .cockroach.ro"
+    "achpb.RequestHeaderB\010\310\336\037\000\320\336\037\001\022-\n\005value\030\002"
+    " \001(\0132\030.cockroach.roachpb.ValueB\004\310\336\037\000\022+\n\t"
+    "exp_value\030\003 \001(\0132\030.cockroach.roachpb.Valu"
+    "e\"U\n\026ConditionalPutResponse\022;\n\006header\030\001 "
+    "\001(\0132!.cockroach.roachpb.ResponseHeaderB\010"
+    "\310\336\037\000\320\336\037\001\"g\n\020IncrementRequest\022:\n\006header\030\001"
+    " \001(\0132 .cockroach.roachpb.RequestHeaderB\010"
+    "\310\336\037\000\320\336\037\001\022\027\n\tincrement\030\002 \001(\003B\004\310\336\037\000\"i\n\021Inc"
+    "rementResponse\022;\n\006header\030\001 \001(\0132!.cockroa"
+    "ch.roachpb.ResponseHeaderB\010\310\336\037\000\320\336\037\001\022\027\n\tn"
+    "ew_value\030\002 \001(\003B\004\310\336\037\000\"K\n\rDeleteRequest\022:\n"
+    "\006header\030\001 \001(\0132 .cockroach.roachpb.Reques"
+    "tHeaderB\010\310\336\037\000\320\336\037\001\"M\n\016DeleteResponse\022;\n\006h"
     "eader\030\001 \001(\0132!.cockroach.roachpb.Response"
-    "HeaderB\010\310\336\037\000\320\336\037\001\0222\n\npushee_txn\030\002 \001(\0132\036.c"
-    "ockroach.roachpb.Transaction\"\214\001\n\024Resolve"
-    "IntentRequest\022:\n\006header\030\001 \001(\0132 .cockroac"
-    "h.roachpb.RequestHeaderB\010\310\336\037\000\320\336\037\001\0228\n\nint"
-    "ent_txn\030\002 \001(\0132\036.cockroach.roachpb.Transa"
-    "ctionB\004\310\336\037\000\"T\n\025ResolveIntentResponse\022;\n\006"
-    "header\030\001 \001(\0132!.cockroach.roachpb.Respons"
-    "eHeaderB\010\310\336\037\000\320\336\037\001\"\221\001\n\031ResolveIntentRange"
-    "Request\022:\n\006header\030\001 \001(\0132 .cockroach.roac"
-    "hpb.RequestHeaderB\010\310\336\037\000\320\336\037\001\0228\n\nintent_tx"
-    "n\030\002 \001(\0132\036.cockroach.roachpb.TransactionB"
-    "\004\310\336\037\000\"K\n\014NoopResponse\022;\n\006header\030\001 \001(\0132!."
-    "cockroach.roachpb.ResponseHeaderB\010\310\336\037\000\320\336"
-    "\037\001\"I\n\013NoopRequest\022:\n\006header\030\001 \001(\0132 .cock"
-    "roach.roachpb.RequestHeaderB\010\310\336\037\000\320\336\037\001\"Y\n"
-    "\032ResolveIntentRangeResponse\022;\n\006header\030\001 "
+    "HeaderB\010\310\336\037\000\320\336\037\001\"u\n\022DeleteRangeRequest\022:"
+    "\n\006header\030\001 \001(\0132 .cockroach.roachpb.Reque"
+    "stHeaderB\010\310\336\037\000\320\336\037\001\022#\n\025max_entries_to_del"
+    "ete\030\002 \001(\003B\004\310\336\037\000\"m\n\023DeleteRangeResponse\022;"
+    "\n\006header\030\001 \001(\0132!.cockroach.roachpb.Respo"
+    "nseHeaderB\010\310\336\037\000\320\336\037\001\022\031\n\013num_deleted\030\002 \001(\003"
+    "B\004\310\336\037\000\"d\n\013ScanRequest\022:\n\006header\030\001 \001(\0132 ."
+    "cockroach.roachpb.RequestHeaderB\010\310\336\037\000\320\336\037"
+    "\001\022\031\n\013max_results\030\002 \001(\003B\004\310\336\037\000\"|\n\014ScanResp"
+    "onse\022;\n\006header\030\001 \001(\0132!.cockroach.roachpb"
+    ".ResponseHeaderB\010\310\336\037\000\320\336\037\001\022/\n\004rows\030\002 \003(\0132"
+    "\033.cockroach.roachpb.KeyValueB\004\310\336\037\000\"k\n\022Re"
+    "verseScanRequest\022:\n\006header\030\001 \001(\0132 .cockr"
+    "oach.roachpb.RequestHeaderB\010\310\336\037\000\320\336\037\001\022\031\n\013"
+    "max_results\030\002 \001(\003B\004\310\336\037\000\"\203\001\n\023ReverseScanR"
+    "esponse\022;\n\006header\030\001 \001(\0132!.cockroach.roac"
+    "hpb.ResponseHeaderB\010\310\336\037\000\320\336\037\001\022/\n\004rows\030\002 \003"
+    "(\0132\033.cockroach.roachpb.KeyValueB\004\310\336\037\000\"\346\001"
+    "\n\025EndTransactionRequest\022:\n\006header\030\001 \001(\0132"
+    " .cockroach.roachpb.RequestHeaderB\010\310\336\037\000\320"
+    "\336\037\001\022\024\n\006commit\030\002 \001(\010B\004\310\336\037\000\022I\n\027internal_co"
+    "mmit_trigger\030\003 \001(\0132(.cockroach.roachpb.I"
+    "nternalCommitTrigger\0220\n\007intents\030\004 \003(\0132\031."
+    "cockroach.roachpb.IntentB\004\310\336\037\000\"\213\001\n\026EndTr"
+    "ansactionResponse\022;\n\006header\030\001 \001(\0132!.cock"
+    "roach.roachpb.ResponseHeaderB\010\310\336\037\000\320\336\037\001\022\031"
+    "\n\013commit_wait\030\002 \001(\003B\004\310\336\037\000\022\031\n\010resolved\030\003 "
+    "\003(\014B\007\372\336\037\003Key\"k\n\021AdminSplitRequest\022:\n\006hea"
+    "der\030\001 \001(\0132 .cockroach.roachpb.RequestHea"
+    "derB\010\310\336\037\000\320\336\037\001\022\032\n\tsplit_key\030\002 \001(\014B\007\372\336\037\003Ke"
+    "y\"Q\n\022AdminSplitResponse\022;\n\006header\030\001 \001(\0132"
+    "!.cockroach.roachpb.ResponseHeaderB\010\310\336\037\000"
+    "\320\336\037\001\"O\n\021AdminMergeRequest\022:\n\006header\030\001 \001("
+    "\0132 .cockroach.roachpb.RequestHeaderB\010\310\336\037"
+    "\000\320\336\037\001\"Q\n\022AdminMergeResponse\022;\n\006header\030\001 "
     "\001(\0132!.cockroach.roachpb.ResponseHeaderB\010"
-    "\310\336\037\000\320\336\037\001\"y\n\014MergeRequest\022:\n\006header\030\001 \001(\013"
-    "2 .cockroach.roachpb.RequestHeaderB\010\310\336\037\000"
-    "\320\336\037\001\022-\n\005value\030\002 \001(\0132\030.cockroach.roachpb."
-    "ValueB\004\310\336\037\000\"L\n\rMergeResponse\022;\n\006header\030\001"
-    " \001(\0132!.cockroach.roachpb.ResponseHeaderB"
-    "\010\310\336\037\000\320\336\037\001\"e\n\022TruncateLogRequest\022:\n\006heade"
+    "\310\336\037\000\320\336\037\001\"\241\001\n\022RangeLookupRequest\022:\n\006heade"
     "r\030\001 \001(\0132 .cockroach.roachpb.RequestHeade"
-    "rB\010\310\336\037\000\320\336\037\001\022\023\n\005index\030\002 \001(\004B\004\310\336\037\000\"R\n\023Trun"
-    "cateLogResponse\022;\n\006header\030\001 \001(\0132!.cockro"
-    "ach.roachpb.ResponseHeaderB\010\310\336\037\000\320\336\037\001\"\177\n\022"
-    "LeaderLeaseRequest\022:\n\006header\030\001 \001(\0132 .coc"
-    "kroach.roachpb.RequestHeaderB\010\310\336\037\000\320\336\037\001\022-"
-    "\n\005lease\030\002 \001(\0132\030.cockroach.roachpb.LeaseB"
-    "\004\310\336\037\000\"R\n\023LeaderLeaseResponse\022;\n\006header\030\001"
-    " \001(\0132!.cockroach.roachpb.ResponseHeaderB"
-    "\010\310\336\037\000\320\336\037\001\"\272\t\n\014RequestUnion\022*\n\003get\030\001 \001(\0132"
-    "\035.cockroach.roachpb.GetRequest\022*\n\003put\030\002 "
-    "\001(\0132\035.cockroach.roachpb.PutRequest\022A\n\017co"
-    "nditional_put\030\003 \001(\0132(.cockroach.roachpb."
-    "ConditionalPutRequest\0226\n\tincrement\030\004 \001(\013"
-    "2#.cockroach.roachpb.IncrementRequest\0220\n"
-    "\006delete\030\005 \001(\0132 .cockroach.roachpb.Delete"
-    "Request\022;\n\014delete_range\030\006 \001(\0132%.cockroac"
-    "h.roachpb.DeleteRangeRequest\022,\n\004scan\030\007 \001"
-    "(\0132\036.cockroach.roachpb.ScanRequest\022A\n\017en"
-    "d_transaction\030\010 \001(\0132(.cockroach.roachpb."
-    "EndTransactionRequest\0229\n\013admin_split\030\t \001"
-    "(\0132$.cockroach.roachpb.AdminSplitRequest"
-    "\0229\n\013admin_merge\030\n \001(\0132$.cockroach.roachp"
-    "b.AdminMergeRequest\022=\n\rheartbeat_txn\030\013 \001"
-    "(\0132&.cockroach.roachpb.HeartbeatTxnReque"
-    "st\022(\n\002gc\030\014 \001(\0132\034.cockroach.roachpb.GCReq"
-    "uest\0223\n\010push_txn\030\r \001(\0132!.cockroach.roach"
-    "pb.PushTxnRequest\022;\n\014range_lookup\030\016 \001(\0132"
-    "%.cockroach.roachpb.RangeLookupRequest\022\?"
-    "\n\016resolve_intent\030\017 \001(\0132\'.cockroach.roach"
-    "pb.ResolveIntentRequest\022J\n\024resolve_inten"
-    "t_range\030\020 \001(\0132,.cockroach.roachpb.Resolv"
-    "eIntentRangeRequest\022.\n\005merge\030\021 \001(\0132\037.coc"
-    "kroach.roachpb.MergeRequest\022;\n\014truncate_"
-    "log\030\022 \001(\0132%.cockroach.roachpb.TruncateLo"
-    "gRequest\022;\n\014leader_lease\030\023 \001(\0132%.cockroa"
-    "ch.roachpb.LeaderLeaseRequest\022;\n\014reverse"
-    "_scan\030\024 \001(\0132%.cockroach.roachpb.ReverseS"
-    "canRequest\022,\n\004noop\030\025 \001(\0132\036.cockroach.roa"
-    "chpb.NoopRequest:\004\310\240\037\001\"\320\t\n\rResponseUnion"
-    "\022+\n\003get\030\001 \001(\0132\036.cockroach.roachpb.GetRes"
-    "ponse\022+\n\003put\030\002 \001(\0132\036.cockroach.roachpb.P"
-    "utResponse\022B\n\017conditional_put\030\003 \001(\0132).co"
-    "ckroach.roachpb.ConditionalPutResponse\0227"
-    "\n\tincrement\030\004 \001(\0132$.cockroach.roachpb.In"
-    "crementResponse\0221\n\006delete\030\005 \001(\0132!.cockro"
-    "ach.roachpb.DeleteResponse\022<\n\014delete_ran"
-    "ge\030\006 \001(\0132&.cockroach.roachpb.DeleteRange"
-    "Response\022-\n\004scan\030\007 \001(\0132\037.cockroach.roach"
-    "pb.ScanResponse\022B\n\017end_transaction\030\010 \001(\013"
-    "2).cockroach.roachpb.EndTransactionRespo"
-    "nse\022:\n\013admin_split\030\t \001(\0132%.cockroach.roa"
-    "chpb.AdminSplitResponse\022:\n\013admin_merge\030\n"
-    " \001(\0132%.cockroach.roachpb.AdminMergeRespo"
-    "nse\022>\n\rheartbeat_txn\030\013 \001(\0132\'.cockroach.r"
-    "oachpb.HeartbeatTxnResponse\022)\n\002gc\030\014 \001(\0132"
-    "\035.cockroach.roachpb.GCResponse\0224\n\010push_t"
-    "xn\030\r \001(\0132\".cockroach.roachpb.PushTxnResp"
-    "onse\022<\n\014range_lookup\030\016 \001(\0132&.cockroach.r"
-    "oachpb.RangeLookupResponse\022@\n\016resolve_in"
-    "tent\030\017 \001(\0132(.cockroach.roachpb.ResolveIn"
-    "tentResponse\022K\n\024resolve_intent_range\030\020 \001"
-    "(\0132-.cockroach.roachpb.ResolveIntentRang"
-    "eResponse\022/\n\005merge\030\021 \001(\0132 .cockroach.roa"
-    "chpb.MergeResponse\022<\n\014truncate_log\030\022 \001(\013"
-    "2&.cockroach.roachpb.TruncateLogResponse"
-    "\022<\n\014leader_lease\030\023 \001(\0132&.cockroach.roach"
-    "pb.LeaderLeaseResponse\022<\n\014reverse_scan\030\024"
-    " \001(\0132&.cockroach.roachpb.ReverseScanResp"
-    "onse\022-\n\004noop\030\025 \001(\0132\037.cockroach.roachpb.N"
-    "oopResponse:\004\310\240\037\001\"\212\004\n\014BatchRequest\022@\n\006he"
-    "ader\030\001 \001(\0132&.cockroach.roachpb.BatchRequ"
-    "est.HeaderB\010\310\336\037\000\320\336\037\001\0227\n\010requests\030\002 \003(\0132\037"
-    ".cockroach.roachpb.RequestUnionB\004\310\336\037\000\032\370\002"
-    "\n\006Header\0225\n\ttimestamp\030\001 \001(\0132\034.cockroach."
-    "roachpb.TimestampB\004\310\336\037\000\022=\n\006cmd_id\030\002 \001(\0132"
-    "\036.cockroach.roachpb.ClientCmdIDB\r\310\336\037\000\342\336\037"
-    "\005CmdID\022;\n\007replica\030\005 \001(\0132$.cockroach.roac"
-    "hpb.ReplicaDescriptorB\004\310\336\037\000\022,\n\010range_id\030"
-    "\006 \001(\003B\032\310\336\037\000\342\336\037\007RangeID\372\336\037\007RangeID\022\030\n\ruse"
-    "r_priority\030\007 \001(\005:\0011\022+\n\003txn\030\010 \001(\0132\036.cockr"
-    "oach.roachpb.Transaction\022F\n\020read_consist"
-    "ency\030\t \001(\0162&.cockroach.roachpb.ReadConsi"
-    "stencyTypeB\004\310\336\037\000:\004\230\240\037\000\"\245\002\n\rBatchResponse"
-    "\022A\n\006header\030\001 \001(\0132\'.cockroach.roachpb.Bat"
-    "chResponse.HeaderB\010\310\336\037\000\320\336\037\001\0229\n\tresponses"
-    "\030\002 \003(\0132 .cockroach.roachpb.ResponseUnion"
-    "B\004\310\336\037\000\032\225\001\n\006Header\022\'\n\005error\030\001 \001(\0132\030.cockr"
-    "oach.roachpb.Error\0225\n\ttimestamp\030\002 \001(\0132\034."
-    "cockroach.roachpb.TimestampB\004\310\336\037\000\022+\n\003txn"
-    "\030\003 \001(\0132\036.cockroach.roachpb.Transaction*L"
-    "\n\023ReadConsistencyType\022\016\n\nCONSISTENT\020\000\022\r\n"
-    "\tCONSENSUS\020\001\022\020\n\014INCONSISTENT\020\002\032\004\210\243\036\000*G\n\013"
-    "PushTxnType\022\022\n\016PUSH_TIMESTAMP\020\000\022\r\n\tABORT"
-    "_TXN\020\001\022\017\n\013CLEANUP_TXN\020\002\032\004\210\243\036\000B\031Z\007roachpb"
-    "\340\342\036\001\310\342\036\001\320\342\036\001\220\343\036\000", 9056);
+    "rB\010\310\336\037\000\320\336\037\001\022\030\n\nmax_ranges\030\002 \001(\005B\004\310\336\037\000\022\036\n"
+    "\020consider_intents\030\003 \001(\010B\004\310\336\037\000\022\025\n\007reverse"
+    "\030\004 \001(\010B\004\310\336\037\000\"\214\001\n\023RangeLookupResponse\022;\n\006"
+    "header\030\001 \001(\0132!.cockroach.roachpb.Respons"
+    "eHeaderB\010\310\336\037\000\320\336\037\001\0228\n\006ranges\030\002 \003(\0132\".cock"
+    "roach.roachpb.RangeDescriptorB\004\310\336\037\000\"Q\n\023H"
+    "eartbeatTxnRequest\022:\n\006header\030\001 \001(\0132 .coc"
+    "kroach.roachpb.RequestHeaderB\010\310\336\037\000\320\336\037\001\"S"
+    "\n\024HeartbeatTxnResponse\022;\n\006header\030\001 \001(\0132!"
+    ".cockroach.roachpb.ResponseHeaderB\010\310\336\037\000\320"
+    "\336\037\001\"\225\002\n\tGCRequest\022:\n\006header\030\001 \001(\0132 .cock"
+    "roach.roachpb.RequestHeaderB\010\310\336\037\000\320\336\037\001\022>\n"
+    "\007gc_meta\030\002 \001(\0132\035.cockroach.roachpb.GCMet"
+    "adataB\016\310\336\037\000\342\336\037\006GCMeta\0226\n\004keys\030\003 \003(\0132\".co"
+    "ckroach.roachpb.GCRequest.GCKeyB\004\310\336\037\000\032T\n"
+    "\005GCKey\022\024\n\003key\030\001 \001(\014B\007\372\336\037\003Key\0225\n\ttimestam"
+    "p\030\002 \001(\0132\034.cockroach.roachpb.TimestampB\004\310"
+    "\336\037\000\"I\n\nGCResponse\022;\n\006header\030\001 \001(\0132!.cock"
+    "roach.roachpb.ResponseHeaderB\010\310\336\037\000\320\336\037\001\"\337"
+    "\002\n\016PushTxnRequest\022:\n\006header\030\001 \001(\0132 .cock"
+    "roach.roachpb.RequestHeaderB\010\310\336\037\000\320\336\037\001\0228\n"
+    "\npusher_txn\030\002 \001(\0132\036.cockroach.roachpb.Tr"
+    "ansactionB\004\310\336\037\000\0228\n\npushee_txn\030\003 \001(\0132\036.co"
+    "ckroach.roachpb.TransactionB\004\310\336\037\000\0223\n\007pus"
+    "h_to\030\004 \001(\0132\034.cockroach.roachpb.Timestamp"
+    "B\004\310\336\037\000\022/\n\003now\030\005 \001(\0132\034.cockroach.roachpb."
+    "TimestampB\004\310\336\037\000\0227\n\tpush_type\030\006 \001(\0162\036.coc"
+    "kroach.roachpb.PushTxnTypeB\004\310\336\037\000\"\202\001\n\017Pus"
+    "hTxnResponse\022;\n\006header\030\001 \001(\0132!.cockroach"
+    ".roachpb.ResponseHeaderB\010\310\336\037\000\320\336\037\001\0222\n\npus"
+    "hee_txn\030\002 \001(\0132\036.cockroach.roachpb.Transa"
+    "ction\"\214\001\n\024ResolveIntentRequest\022:\n\006header"
+    "\030\001 \001(\0132 .cockroach.roachpb.RequestHeader"
+    "B\010\310\336\037\000\320\336\037\001\0228\n\nintent_txn\030\002 \001(\0132\036.cockroa"
+    "ch.roachpb.TransactionB\004\310\336\037\000\"T\n\025ResolveI"
+    "ntentResponse\022;\n\006header\030\001 \001(\0132!.cockroac"
+    "h.roachpb.ResponseHeaderB\010\310\336\037\000\320\336\037\001\"\221\001\n\031R"
+    "esolveIntentRangeRequest\022:\n\006header\030\001 \001(\013"
+    "2 .cockroach.roachpb.RequestHeaderB\010\310\336\037\000"
+    "\320\336\037\001\0228\n\nintent_txn\030\002 \001(\0132\036.cockroach.roa"
+    "chpb.TransactionB\004\310\336\037\000\"K\n\014NoopResponse\022;"
+    "\n\006header\030\001 \001(\0132!.cockroach.roachpb.Respo"
+    "nseHeaderB\010\310\336\037\000\320\336\037\001\"I\n\013NoopRequest\022:\n\006he"
+    "ader\030\001 \001(\0132 .cockroach.roachpb.RequestHe"
+    "aderB\010\310\336\037\000\320\336\037\001\"Y\n\032ResolveIntentRangeResp"
+    "onse\022;\n\006header\030\001 \001(\0132!.cockroach.roachpb"
+    ".ResponseHeaderB\010\310\336\037\000\320\336\037\001\"y\n\014MergeReques"
+    "t\022:\n\006header\030\001 \001(\0132 .cockroach.roachpb.Re"
+    "questHeaderB\010\310\336\037\000\320\336\037\001\022-\n\005value\030\002 \001(\0132\030.c"
+    "ockroach.roachpb.ValueB\004\310\336\037\000\"L\n\rMergeRes"
+    "ponse\022;\n\006header\030\001 \001(\0132!.cockroach.roachp"
+    "b.ResponseHeaderB\010\310\336\037\000\320\336\037\001\"e\n\022TruncateLo"
+    "gRequest\022:\n\006header\030\001 \001(\0132 .cockroach.roa"
+    "chpb.RequestHeaderB\010\310\336\037\000\320\336\037\001\022\023\n\005index\030\002 "
+    "\001(\004B\004\310\336\037\000\"R\n\023TruncateLogResponse\022;\n\006head"
+    "er\030\001 \001(\0132!.cockroach.roachpb.ResponseHea"
+    "derB\010\310\336\037\000\320\336\037\001\"\177\n\022LeaderLeaseRequest\022:\n\006h"
+    "eader\030\001 \001(\0132 .cockroach.roachpb.RequestH"
+    "eaderB\010\310\336\037\000\320\336\037\001\022-\n\005lease\030\002 \001(\0132\030.cockroa"
+    "ch.roachpb.LeaseB\004\310\336\037\000\"R\n\023LeaderLeaseRes"
+    "ponse\022;\n\006header\030\001 \001(\0132!.cockroach.roachp"
+    "b.ResponseHeaderB\010\310\336\037\000\320\336\037\001\"\272\t\n\014RequestUn"
+    "ion\022*\n\003get\030\001 \001(\0132\035.cockroach.roachpb.Get"
+    "Request\022*\n\003put\030\002 \001(\0132\035.cockroach.roachpb"
+    ".PutRequest\022A\n\017conditional_put\030\003 \001(\0132(.c"
+    "ockroach.roachpb.ConditionalPutRequest\0226"
+    "\n\tincrement\030\004 \001(\0132#.cockroach.roachpb.In"
+    "crementRequest\0220\n\006delete\030\005 \001(\0132 .cockroa"
+    "ch.roachpb.DeleteRequest\022;\n\014delete_range"
+    "\030\006 \001(\0132%.cockroach.roachpb.DeleteRangeRe"
+    "quest\022,\n\004scan\030\007 \001(\0132\036.cockroach.roachpb."
+    "ScanRequest\022A\n\017end_transaction\030\010 \001(\0132(.c"
+    "ockroach.roachpb.EndTransactionRequest\0229"
+    "\n\013admin_split\030\t \001(\0132$.cockroach.roachpb."
+    "AdminSplitRequest\0229\n\013admin_merge\030\n \001(\0132$"
+    ".cockroach.roachpb.AdminMergeRequest\022=\n\r"
+    "heartbeat_txn\030\013 \001(\0132&.cockroach.roachpb."
+    "HeartbeatTxnRequest\022(\n\002gc\030\014 \001(\0132\034.cockro"
+    "ach.roachpb.GCRequest\0223\n\010push_txn\030\r \001(\0132"
+    "!.cockroach.roachpb.PushTxnRequest\022;\n\014ra"
+    "nge_lookup\030\016 \001(\0132%.cockroach.roachpb.Ran"
+    "geLookupRequest\022\?\n\016resolve_intent\030\017 \001(\0132"
+    "\'.cockroach.roachpb.ResolveIntentRequest"
+    "\022J\n\024resolve_intent_range\030\020 \001(\0132,.cockroa"
+    "ch.roachpb.ResolveIntentRangeRequest\022.\n\005"
+    "merge\030\021 \001(\0132\037.cockroach.roachpb.MergeReq"
+    "uest\022;\n\014truncate_log\030\022 \001(\0132%.cockroach.r"
+    "oachpb.TruncateLogRequest\022;\n\014leader_leas"
+    "e\030\023 \001(\0132%.cockroach.roachpb.LeaderLeaseR"
+    "equest\022;\n\014reverse_scan\030\024 \001(\0132%.cockroach"
+    ".roachpb.ReverseScanRequest\022,\n\004noop\030\025 \001("
+    "\0132\036.cockroach.roachpb.NoopRequest:\004\310\240\037\001\""
+    "\320\t\n\rResponseUnion\022+\n\003get\030\001 \001(\0132\036.cockroa"
+    "ch.roachpb.GetResponse\022+\n\003put\030\002 \001(\0132\036.co"
+    "ckroach.roachpb.PutResponse\022B\n\017condition"
+    "al_put\030\003 \001(\0132).cockroach.roachpb.Conditi"
+    "onalPutResponse\0227\n\tincrement\030\004 \001(\0132$.coc"
+    "kroach.roachpb.IncrementResponse\0221\n\006dele"
+    "te\030\005 \001(\0132!.cockroach.roachpb.DeleteRespo"
+    "nse\022<\n\014delete_range\030\006 \001(\0132&.cockroach.ro"
+    "achpb.DeleteRangeResponse\022-\n\004scan\030\007 \001(\0132"
+    "\037.cockroach.roachpb.ScanResponse\022B\n\017end_"
+    "transaction\030\010 \001(\0132).cockroach.roachpb.En"
+    "dTransactionResponse\022:\n\013admin_split\030\t \001("
+    "\0132%.cockroach.roachpb.AdminSplitResponse"
+    "\022:\n\013admin_merge\030\n \001(\0132%.cockroach.roachp"
+    "b.AdminMergeResponse\022>\n\rheartbeat_txn\030\013 "
+    "\001(\0132\'.cockroach.roachpb.HeartbeatTxnResp"
+    "onse\022)\n\002gc\030\014 \001(\0132\035.cockroach.roachpb.GCR"
+    "esponse\0224\n\010push_txn\030\r \001(\0132\".cockroach.ro"
+    "achpb.PushTxnResponse\022<\n\014range_lookup\030\016 "
+    "\001(\0132&.cockroach.roachpb.RangeLookupRespo"
+    "nse\022@\n\016resolve_intent\030\017 \001(\0132(.cockroach."
+    "roachpb.ResolveIntentResponse\022K\n\024resolve"
+    "_intent_range\030\020 \001(\0132-.cockroach.roachpb."
+    "ResolveIntentRangeResponse\022/\n\005merge\030\021 \001("
+    "\0132 .cockroach.roachpb.MergeResponse\022<\n\014t"
+    "runcate_log\030\022 \001(\0132&.cockroach.roachpb.Tr"
+    "uncateLogResponse\022<\n\014leader_lease\030\023 \001(\0132"
+    "&.cockroach.roachpb.LeaderLeaseResponse\022"
+    "<\n\014reverse_scan\030\024 \001(\0132&.cockroach.roachp"
+    "b.ReverseScanResponse\022-\n\004noop\030\025 \001(\0132\037.co"
+    "ckroach.roachpb.NoopResponse:\004\310\240\037\001\"\212\004\n\014B"
+    "atchRequest\022@\n\006header\030\001 \001(\0132&.cockroach."
+    "roachpb.BatchRequest.HeaderB\010\310\336\037\000\320\336\037\001\0227\n"
+    "\010requests\030\002 \003(\0132\037.cockroach.roachpb.Requ"
+    "estUnionB\004\310\336\037\000\032\370\002\n\006Header\0225\n\ttimestamp\030\001"
+    " \001(\0132\034.cockroach.roachpb.TimestampB\004\310\336\037\000"
+    "\022=\n\006cmd_id\030\002 \001(\0132\036.cockroach.roachpb.Cli"
+    "entCmdIDB\r\310\336\037\000\342\336\037\005CmdID\022;\n\007replica\030\005 \001(\013"
+    "2$.cockroach.roachpb.ReplicaDescriptorB\004"
+    "\310\336\037\000\022,\n\010range_id\030\006 \001(\003B\032\310\336\037\000\342\336\037\007RangeID\372"
+    "\336\037\007RangeID\022\030\n\ruser_priority\030\007 \001(\005:\0011\022+\n\003"
+    "txn\030\010 \001(\0132\036.cockroach.roachpb.Transactio"
+    "n\022F\n\020read_consistency\030\t \001(\0162&.cockroach."
+    "roachpb.ReadConsistencyTypeB\004\310\336\037\000:\004\230\240\037\000\""
+    "\245\002\n\rBatchResponse\022A\n\006header\030\001 \001(\0132\'.cock"
+    "roach.roachpb.BatchResponse.HeaderB\010\310\336\037\000"
+    "\320\336\037\001\0229\n\tresponses\030\002 \003(\0132 .cockroach.roac"
+    "hpb.ResponseUnionB\004\310\336\037\000\032\225\001\n\006Header\022\'\n\005er"
+    "ror\030\001 \001(\0132\030.cockroach.roachpb.Error\0225\n\tt"
+    "imestamp\030\002 \001(\0132\034.cockroach.roachpb.Times"
+    "tampB\004\310\336\037\000\022+\n\003txn\030\003 \001(\0132\036.cockroach.roac"
+    "hpb.Transaction*L\n\023ReadConsistencyType\022\016"
+    "\n\nCONSISTENT\020\000\022\r\n\tCONSENSUS\020\001\022\020\n\014INCONSI"
+    "STENT\020\002\032\004\210\243\036\000*G\n\013PushTxnType\022\022\n\016PUSH_TIM"
+    "ESTAMP\020\000\022\r\n\tABORT_TXN\020\001\022\017\n\013CLEANUP_TXN\020\002"
+    "\032\004\210\243\036\000B\031Z\007roachpb\340\342\036\001\310\342\036\001\320\342\036\001\220\343\036\000", 8993);
   ::google::protobuf::MessageFactory::InternalRegisterGeneratedFile(
     "cockroach/roachpb/api.proto", &protobuf_RegisterTypes);
   ClientCmdID::default_instance_ = new ClientCmdID();
@@ -2023,7 +2020,6 @@ void ClientCmdID::clear_random() {
 // ===================================================================
 
 #ifndef _MSC_VER
-const int RequestHeader::kCmdIdFieldNumber;
 const int RequestHeader::kKeyFieldNumber;
 const int RequestHeader::kEndKeyFieldNumber;
 const int RequestHeader::kUserPriorityFieldNumber;
@@ -2038,7 +2034,6 @@ RequestHeader::RequestHeader()
 }
 
 void RequestHeader::InitAsDefaultInstance() {
-  cmd_id_ = const_cast< ::cockroach::roachpb::ClientCmdID*>(&::cockroach::roachpb::ClientCmdID::default_instance());
   txn_ = const_cast< ::cockroach::roachpb::Transaction*>(&::cockroach::roachpb::Transaction::default_instance());
 }
 
@@ -2053,7 +2048,6 @@ RequestHeader::RequestHeader(const RequestHeader& from)
 void RequestHeader::SharedCtor() {
   ::google::protobuf::internal::GetEmptyString();
   _cached_size_ = 0;
-  cmd_id_ = NULL;
   key_.UnsafeSetDefault(&::google::protobuf::internal::GetEmptyStringAlreadyInited());
   end_key_.UnsafeSetDefault(&::google::protobuf::internal::GetEmptyStringAlreadyInited());
   user_priority_ = 1;
@@ -2071,7 +2065,6 @@ void RequestHeader::SharedDtor() {
   key_.DestroyNoArena(&::google::protobuf::internal::GetEmptyStringAlreadyInited());
   end_key_.DestroyNoArena(&::google::protobuf::internal::GetEmptyStringAlreadyInited());
   if (this != default_instance_) {
-    delete cmd_id_;
     delete txn_;
   }
 }
@@ -2102,10 +2095,7 @@ RequestHeader* RequestHeader::New(::google::protobuf::Arena* arena) const {
 }
 
 void RequestHeader::Clear() {
-  if (_has_bits_[0 / 32] & 63u) {
-    if (has_cmd_id()) {
-      if (cmd_id_ != NULL) cmd_id_->::cockroach::roachpb::ClientCmdID::Clear();
-    }
+  if (_has_bits_[0 / 32] & 31u) {
     if (has_key()) {
       key_.ClearToEmptyNoArena(&::google::protobuf::internal::GetEmptyStringAlreadyInited());
     }
@@ -2134,22 +2124,9 @@ bool RequestHeader::MergePartialFromCodedStream(
     tag = p.first;
     if (!p.second) goto handle_unusual;
     switch (::google::protobuf::internal::WireFormatLite::GetTagFieldNumber(tag)) {
-      // optional .cockroach.roachpb.ClientCmdID cmd_id = 2;
-      case 2: {
-        if (tag == 18) {
-          DO_(::google::protobuf::internal::WireFormatLite::ReadMessageNoVirtual(
-               input, mutable_cmd_id()));
-        } else {
-          goto handle_unusual;
-        }
-        if (input->ExpectTag(26)) goto parse_key;
-        break;
-      }
-
       // optional bytes key = 3;
       case 3: {
         if (tag == 26) {
-         parse_key:
           DO_(::google::protobuf::internal::WireFormatLite::ReadBytes(
                 input, this->mutable_key()));
         } else {
@@ -2245,12 +2222,6 @@ failure:
 void RequestHeader::SerializeWithCachedSizes(
     ::google::protobuf::io::CodedOutputStream* output) const {
   // @@protoc_insertion_point(serialize_start:cockroach.roachpb.RequestHeader)
-  // optional .cockroach.roachpb.ClientCmdID cmd_id = 2;
-  if (has_cmd_id()) {
-    ::google::protobuf::internal::WireFormatLite::WriteMessageMaybeToArray(
-      2, *this->cmd_id_, output);
-  }
-
   // optional bytes key = 3;
   if (has_key()) {
     ::google::protobuf::internal::WireFormatLite::WriteBytesMaybeAliased(
@@ -2290,13 +2261,6 @@ void RequestHeader::SerializeWithCachedSizes(
 ::google::protobuf::uint8* RequestHeader::SerializeWithCachedSizesToArray(
     ::google::protobuf::uint8* target) const {
   // @@protoc_insertion_point(serialize_to_array_start:cockroach.roachpb.RequestHeader)
-  // optional .cockroach.roachpb.ClientCmdID cmd_id = 2;
-  if (has_cmd_id()) {
-    target = ::google::protobuf::internal::WireFormatLite::
-      WriteMessageNoVirtualToArray(
-        2, *this->cmd_id_, target);
-  }
-
   // optional bytes key = 3;
   if (has_key()) {
     target =
@@ -2340,14 +2304,7 @@ void RequestHeader::SerializeWithCachedSizes(
 int RequestHeader::ByteSize() const {
   int total_size = 0;
 
-  if (_has_bits_[0 / 32] & 63) {
-    // optional .cockroach.roachpb.ClientCmdID cmd_id = 2;
-    if (has_cmd_id()) {
-      total_size += 1 +
-        ::google::protobuf::internal::WireFormatLite::MessageSizeNoVirtual(
-          *this->cmd_id_);
-    }
-
+  if (_has_bits_[0 / 32] & 31) {
     // optional bytes key = 3;
     if (has_key()) {
       total_size += 1 +
@@ -2409,9 +2366,6 @@ void RequestHeader::MergeFrom(const ::google::protobuf::Message& from) {
 void RequestHeader::MergeFrom(const RequestHeader& from) {
   if (GOOGLE_PREDICT_FALSE(&from == this)) MergeFromFail(__LINE__);
   if (from._has_bits_[0 / 32] & (0xffu << (0 % 32))) {
-    if (from.has_cmd_id()) {
-      mutable_cmd_id()->::cockroach::roachpb::ClientCmdID::MergeFrom(from.cmd_id());
-    }
     if (from.has_key()) {
       set_has_key();
       key_.AssignWithDefault(&::google::protobuf::internal::GetEmptyStringAlreadyInited(), from.key_);
@@ -2457,7 +2411,6 @@ void RequestHeader::Swap(RequestHeader* other) {
   InternalSwap(other);
 }
 void RequestHeader::InternalSwap(RequestHeader* other) {
-  std::swap(cmd_id_, other->cmd_id_);
   key_.Swap(&other->key_);
   end_key_.Swap(&other->end_key_);
   std::swap(user_priority_, other->user_priority_);
@@ -2479,58 +2432,15 @@ void RequestHeader::InternalSwap(RequestHeader* other) {
 #if PROTOBUF_INLINE_NOT_IN_HEADERS
 // RequestHeader
 
-// optional .cockroach.roachpb.ClientCmdID cmd_id = 2;
-bool RequestHeader::has_cmd_id() const {
-  return (_has_bits_[0] & 0x00000001u) != 0;
-}
-void RequestHeader::set_has_cmd_id() {
-  _has_bits_[0] |= 0x00000001u;
-}
-void RequestHeader::clear_has_cmd_id() {
-  _has_bits_[0] &= ~0x00000001u;
-}
-void RequestHeader::clear_cmd_id() {
-  if (cmd_id_ != NULL) cmd_id_->::cockroach::roachpb::ClientCmdID::Clear();
-  clear_has_cmd_id();
-}
- const ::cockroach::roachpb::ClientCmdID& RequestHeader::cmd_id() const {
-  // @@protoc_insertion_point(field_get:cockroach.roachpb.RequestHeader.cmd_id)
-  return cmd_id_ != NULL ? *cmd_id_ : *default_instance_->cmd_id_;
-}
- ::cockroach::roachpb::ClientCmdID* RequestHeader::mutable_cmd_id() {
-  set_has_cmd_id();
-  if (cmd_id_ == NULL) {
-    cmd_id_ = new ::cockroach::roachpb::ClientCmdID;
-  }
-  // @@protoc_insertion_point(field_mutable:cockroach.roachpb.RequestHeader.cmd_id)
-  return cmd_id_;
-}
- ::cockroach::roachpb::ClientCmdID* RequestHeader::release_cmd_id() {
-  clear_has_cmd_id();
-  ::cockroach::roachpb::ClientCmdID* temp = cmd_id_;
-  cmd_id_ = NULL;
-  return temp;
-}
- void RequestHeader::set_allocated_cmd_id(::cockroach::roachpb::ClientCmdID* cmd_id) {
-  delete cmd_id_;
-  cmd_id_ = cmd_id;
-  if (cmd_id) {
-    set_has_cmd_id();
-  } else {
-    clear_has_cmd_id();
-  }
-  // @@protoc_insertion_point(field_set_allocated:cockroach.roachpb.RequestHeader.cmd_id)
-}
-
 // optional bytes key = 3;
 bool RequestHeader::has_key() const {
-  return (_has_bits_[0] & 0x00000002u) != 0;
+  return (_has_bits_[0] & 0x00000001u) != 0;
 }
 void RequestHeader::set_has_key() {
-  _has_bits_[0] |= 0x00000002u;
+  _has_bits_[0] |= 0x00000001u;
 }
 void RequestHeader::clear_has_key() {
-  _has_bits_[0] &= ~0x00000002u;
+  _has_bits_[0] &= ~0x00000001u;
 }
 void RequestHeader::clear_key() {
   key_.ClearToEmptyNoArena(&::google::protobuf::internal::GetEmptyStringAlreadyInited());
@@ -2577,13 +2487,13 @@ void RequestHeader::clear_key() {
 
 // optional bytes end_key = 4;
 bool RequestHeader::has_end_key() const {
-  return (_has_bits_[0] & 0x00000004u) != 0;
+  return (_has_bits_[0] & 0x00000002u) != 0;
 }
 void RequestHeader::set_has_end_key() {
-  _has_bits_[0] |= 0x00000004u;
+  _has_bits_[0] |= 0x00000002u;
 }
 void RequestHeader::clear_has_end_key() {
-  _has_bits_[0] &= ~0x00000004u;
+  _has_bits_[0] &= ~0x00000002u;
 }
 void RequestHeader::clear_end_key() {
   end_key_.ClearToEmptyNoArena(&::google::protobuf::internal::GetEmptyStringAlreadyInited());
@@ -2630,13 +2540,13 @@ void RequestHeader::clear_end_key() {
 
 // optional int32 user_priority = 7 [default = 1];
 bool RequestHeader::has_user_priority() const {
-  return (_has_bits_[0] & 0x00000008u) != 0;
+  return (_has_bits_[0] & 0x00000004u) != 0;
 }
 void RequestHeader::set_has_user_priority() {
-  _has_bits_[0] |= 0x00000008u;
+  _has_bits_[0] |= 0x00000004u;
 }
 void RequestHeader::clear_has_user_priority() {
-  _has_bits_[0] &= ~0x00000008u;
+  _has_bits_[0] &= ~0x00000004u;
 }
 void RequestHeader::clear_user_priority() {
   user_priority_ = 1;
@@ -2654,13 +2564,13 @@ void RequestHeader::clear_user_priority() {
 
 // optional .cockroach.roachpb.Transaction txn = 8;
 bool RequestHeader::has_txn() const {
-  return (_has_bits_[0] & 0x00000010u) != 0;
+  return (_has_bits_[0] & 0x00000008u) != 0;
 }
 void RequestHeader::set_has_txn() {
-  _has_bits_[0] |= 0x00000010u;
+  _has_bits_[0] |= 0x00000008u;
 }
 void RequestHeader::clear_has_txn() {
-  _has_bits_[0] &= ~0x00000010u;
+  _has_bits_[0] &= ~0x00000008u;
 }
 void RequestHeader::clear_txn() {
   if (txn_ != NULL) txn_->::cockroach::roachpb::Transaction::Clear();
@@ -2697,13 +2607,13 @@ void RequestHeader::clear_txn() {
 
 // optional .cockroach.roachpb.ReadConsistencyType read_consistency = 9;
 bool RequestHeader::has_read_consistency() const {
-  return (_has_bits_[0] & 0x00000020u) != 0;
+  return (_has_bits_[0] & 0x00000010u) != 0;
 }
 void RequestHeader::set_has_read_consistency() {
-  _has_bits_[0] |= 0x00000020u;
+  _has_bits_[0] |= 0x00000010u;
 }
 void RequestHeader::clear_has_read_consistency() {
-  _has_bits_[0] &= ~0x00000020u;
+  _has_bits_[0] &= ~0x00000010u;
 }
 void RequestHeader::clear_read_consistency() {
   read_consistency_ = 0;

--- a/storage/engine/rocksdb/cockroach/roachpb/api.pb.cc
+++ b/storage/engine/rocksdb/cockroach/roachpb/api.pb.cc
@@ -206,11 +206,10 @@ void protobuf_AssignDesc_cockroach_2froachpb_2fapi_2eproto() {
       GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(ClientCmdID, _internal_metadata_),
       -1);
   RequestHeader_descriptor_ = file->message_type(1);
-  static const int RequestHeader_offsets_[8] = {
+  static const int RequestHeader_offsets_[7] = {
     GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(RequestHeader, cmd_id_),
     GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(RequestHeader, key_),
     GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(RequestHeader, end_key_),
-    GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(RequestHeader, replica_),
     GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(RequestHeader, range_id_),
     GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(RequestHeader, user_priority_),
     GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(RequestHeader, txn_),
@@ -1309,231 +1308,229 @@ void protobuf_AddDesc_cockroach_2froachpb_2fapi_2eproto() {
     "to\032\034cockroach/roachpb/data.proto\032\036cockro"
     "ach/roachpb/errors.proto\032\024gogoproto/gogo"
     ".proto\"<\n\013ClientCmdID\022\027\n\twall_time\030\001 \001(\003"
-    "B\004\310\336\037\000\022\024\n\006random\030\002 \001(\003B\004\310\336\037\000\"\370\002\n\rRequest"
+    "B\004\310\336\037\000\022\024\n\006random\030\002 \001(\003B\004\310\336\037\000\"\273\002\n\rRequest"
     "Header\022=\n\006cmd_id\030\002 \001(\0132\036.cockroach.roach"
     "pb.ClientCmdIDB\r\310\336\037\000\342\336\037\005CmdID\022\024\n\003key\030\003 \001"
-    "(\014B\007\372\336\037\003Key\022\030\n\007end_key\030\004 \001(\014B\007\372\336\037\003Key\022;\n"
-    "\007replica\030\005 \001(\0132$.cockroach.roachpb.Repli"
-    "caDescriptorB\004\310\336\037\000\022,\n\010range_id\030\006 \001(\003B\032\310\336"
-    "\037\000\342\336\037\007RangeID\372\336\037\007RangeID\022\030\n\ruser_priorit"
-    "y\030\007 \001(\005:\0011\022+\n\003txn\030\010 \001(\0132\036.cockroach.roac"
-    "hpb.Transaction\022F\n\020read_consistency\030\t \001("
-    "\0162&.cockroach.roachpb.ReadConsistencyTyp"
-    "eB\004\310\336\037\000\"t\n\016ResponseHeader\0225\n\ttimestamp\030\002"
-    " \001(\0132\034.cockroach.roachpb.TimestampB\004\310\336\037\000"
-    "\022+\n\003txn\030\003 \001(\0132\036.cockroach.roachpb.Transa"
-    "ction\"H\n\nGetRequest\022:\n\006header\030\001 \001(\0132 .co"
-    "ckroach.roachpb.RequestHeaderB\010\310\336\037\000\320\336\037\001\""
-    "s\n\013GetResponse\022;\n\006header\030\001 \001(\0132!.cockroa"
-    "ch.roachpb.ResponseHeaderB\010\310\336\037\000\320\336\037\001\022\'\n\005v"
-    "alue\030\002 \001(\0132\030.cockroach.roachpb.Value\"w\n\n"
-    "PutRequest\022:\n\006header\030\001 \001(\0132 .cockroach.r"
-    "oachpb.RequestHeaderB\010\310\336\037\000\320\336\037\001\022-\n\005value\030"
-    "\002 \001(\0132\030.cockroach.roachpb.ValueB\004\310\336\037\000\"J\n"
-    "\013PutResponse\022;\n\006header\030\001 \001(\0132!.cockroach"
-    ".roachpb.ResponseHeaderB\010\310\336\037\000\320\336\037\001\"\257\001\n\025Co"
-    "nditionalPutRequest\022:\n\006header\030\001 \001(\0132 .co"
-    "ckroach.roachpb.RequestHeaderB\010\310\336\037\000\320\336\037\001\022"
-    "-\n\005value\030\002 \001(\0132\030.cockroach.roachpb.Value"
-    "B\004\310\336\037\000\022+\n\texp_value\030\003 \001(\0132\030.cockroach.ro"
-    "achpb.Value\"U\n\026ConditionalPutResponse\022;\n"
-    "\006header\030\001 \001(\0132!.cockroach.roachpb.Respon"
-    "seHeaderB\010\310\336\037\000\320\336\037\001\"g\n\020IncrementRequest\022:"
+    "(\014B\007\372\336\037\003Key\022\030\n\007end_key\030\004 \001(\014B\007\372\336\037\003Key\022,\n"
+    "\010range_id\030\006 \001(\003B\032\310\336\037\000\342\336\037\007RangeID\372\336\037\007Rang"
+    "eID\022\030\n\ruser_priority\030\007 \001(\005:\0011\022+\n\003txn\030\010 \001"
+    "(\0132\036.cockroach.roachpb.Transaction\022F\n\020re"
+    "ad_consistency\030\t \001(\0162&.cockroach.roachpb"
+    ".ReadConsistencyTypeB\004\310\336\037\000\"t\n\016ResponseHe"
+    "ader\0225\n\ttimestamp\030\002 \001(\0132\034.cockroach.roac"
+    "hpb.TimestampB\004\310\336\037\000\022+\n\003txn\030\003 \001(\0132\036.cockr"
+    "oach.roachpb.Transaction\"H\n\nGetRequest\022:"
     "\n\006header\030\001 \001(\0132 .cockroach.roachpb.Reque"
-    "stHeaderB\010\310\336\037\000\320\336\037\001\022\027\n\tincrement\030\002 \001(\003B\004\310"
-    "\336\037\000\"i\n\021IncrementResponse\022;\n\006header\030\001 \001(\013"
-    "2!.cockroach.roachpb.ResponseHeaderB\010\310\336\037"
-    "\000\320\336\037\001\022\027\n\tnew_value\030\002 \001(\003B\004\310\336\037\000\"K\n\rDelete"
-    "Request\022:\n\006header\030\001 \001(\0132 .cockroach.roac"
-    "hpb.RequestHeaderB\010\310\336\037\000\320\336\037\001\"M\n\016DeleteRes"
-    "ponse\022;\n\006header\030\001 \001(\0132!.cockroach.roachp"
-    "b.ResponseHeaderB\010\310\336\037\000\320\336\037\001\"u\n\022DeleteRang"
-    "eRequest\022:\n\006header\030\001 \001(\0132 .cockroach.roa"
-    "chpb.RequestHeaderB\010\310\336\037\000\320\336\037\001\022#\n\025max_entr"
-    "ies_to_delete\030\002 \001(\003B\004\310\336\037\000\"m\n\023DeleteRange"
-    "Response\022;\n\006header\030\001 \001(\0132!.cockroach.roa"
-    "chpb.ResponseHeaderB\010\310\336\037\000\320\336\037\001\022\031\n\013num_del"
-    "eted\030\002 \001(\003B\004\310\336\037\000\"d\n\013ScanRequest\022:\n\006heade"
-    "r\030\001 \001(\0132 .cockroach.roachpb.RequestHeade"
-    "rB\010\310\336\037\000\320\336\037\001\022\031\n\013max_results\030\002 \001(\003B\004\310\336\037\000\"|"
-    "\n\014ScanResponse\022;\n\006header\030\001 \001(\0132!.cockroa"
-    "ch.roachpb.ResponseHeaderB\010\310\336\037\000\320\336\037\001\022/\n\004r"
-    "ows\030\002 \003(\0132\033.cockroach.roachpb.KeyValueB\004"
-    "\310\336\037\000\"k\n\022ReverseScanRequest\022:\n\006header\030\001 \001"
-    "(\0132 .cockroach.roachpb.RequestHeaderB\010\310\336"
-    "\037\000\320\336\037\001\022\031\n\013max_results\030\002 \001(\003B\004\310\336\037\000\"\203\001\n\023Re"
-    "verseScanResponse\022;\n\006header\030\001 \001(\0132!.cock"
-    "roach.roachpb.ResponseHeaderB\010\310\336\037\000\320\336\037\001\022/"
-    "\n\004rows\030\002 \003(\0132\033.cockroach.roachpb.KeyValu"
-    "eB\004\310\336\037\000\"\346\001\n\025EndTransactionRequest\022:\n\006hea"
-    "der\030\001 \001(\0132 .cockroach.roachpb.RequestHea"
-    "derB\010\310\336\037\000\320\336\037\001\022\024\n\006commit\030\002 \001(\010B\004\310\336\037\000\022I\n\027i"
-    "nternal_commit_trigger\030\003 \001(\0132(.cockroach"
-    ".roachpb.InternalCommitTrigger\0220\n\007intent"
-    "s\030\004 \003(\0132\031.cockroach.roachpb.IntentB\004\310\336\037\000"
-    "\"\213\001\n\026EndTransactionResponse\022;\n\006header\030\001 "
-    "\001(\0132!.cockroach.roachpb.ResponseHeaderB\010"
-    "\310\336\037\000\320\336\037\001\022\031\n\013commit_wait\030\002 \001(\003B\004\310\336\037\000\022\031\n\010r"
-    "esolved\030\003 \003(\014B\007\372\336\037\003Key\"k\n\021AdminSplitRequ"
-    "est\022:\n\006header\030\001 \001(\0132 .cockroach.roachpb."
-    "RequestHeaderB\010\310\336\037\000\320\336\037\001\022\032\n\tsplit_key\030\002 \001"
-    "(\014B\007\372\336\037\003Key\"Q\n\022AdminSplitResponse\022;\n\006hea"
+    "stHeaderB\010\310\336\037\000\320\336\037\001\"s\n\013GetResponse\022;\n\006hea"
     "der\030\001 \001(\0132!.cockroach.roachpb.ResponseHe"
-    "aderB\010\310\336\037\000\320\336\037\001\"O\n\021AdminMergeRequest\022:\n\006h"
-    "eader\030\001 \001(\0132 .cockroach.roachpb.RequestH"
-    "eaderB\010\310\336\037\000\320\336\037\001\"Q\n\022AdminMergeResponse\022;\n"
-    "\006header\030\001 \001(\0132!.cockroach.roachpb.Respon"
-    "seHeaderB\010\310\336\037\000\320\336\037\001\"\241\001\n\022RangeLookupReques"
-    "t\022:\n\006header\030\001 \001(\0132 .cockroach.roachpb.Re"
-    "questHeaderB\010\310\336\037\000\320\336\037\001\022\030\n\nmax_ranges\030\002 \001("
-    "\005B\004\310\336\037\000\022\036\n\020consider_intents\030\003 \001(\010B\004\310\336\037\000\022"
-    "\025\n\007reverse\030\004 \001(\010B\004\310\336\037\000\"\214\001\n\023RangeLookupRe"
-    "sponse\022;\n\006header\030\001 \001(\0132!.cockroach.roach"
-    "pb.ResponseHeaderB\010\310\336\037\000\320\336\037\001\0228\n\006ranges\030\002 "
-    "\003(\0132\".cockroach.roachpb.RangeDescriptorB"
-    "\004\310\336\037\000\"Q\n\023HeartbeatTxnRequest\022:\n\006header\030\001"
-    " \001(\0132 .cockroach.roachpb.RequestHeaderB\010"
-    "\310\336\037\000\320\336\037\001\"S\n\024HeartbeatTxnResponse\022;\n\006head"
-    "er\030\001 \001(\0132!.cockroach.roachpb.ResponseHea"
-    "derB\010\310\336\037\000\320\336\037\001\"\225\002\n\tGCRequest\022:\n\006header\030\001 "
+    "aderB\010\310\336\037\000\320\336\037\001\022\'\n\005value\030\002 \001(\0132\030.cockroac"
+    "h.roachpb.Value\"w\n\nPutRequest\022:\n\006header\030"
+    "\001 \001(\0132 .cockroach.roachpb.RequestHeaderB"
+    "\010\310\336\037\000\320\336\037\001\022-\n\005value\030\002 \001(\0132\030.cockroach.roa"
+    "chpb.ValueB\004\310\336\037\000\"J\n\013PutResponse\022;\n\006heade"
+    "r\030\001 \001(\0132!.cockroach.roachpb.ResponseHead"
+    "erB\010\310\336\037\000\320\336\037\001\"\257\001\n\025ConditionalPutRequest\022:"
+    "\n\006header\030\001 \001(\0132 .cockroach.roachpb.Reque"
+    "stHeaderB\010\310\336\037\000\320\336\037\001\022-\n\005value\030\002 \001(\0132\030.cock"
+    "roach.roachpb.ValueB\004\310\336\037\000\022+\n\texp_value\030\003"
+    " \001(\0132\030.cockroach.roachpb.Value\"U\n\026Condit"
+    "ionalPutResponse\022;\n\006header\030\001 \001(\0132!.cockr"
+    "oach.roachpb.ResponseHeaderB\010\310\336\037\000\320\336\037\001\"g\n"
+    "\020IncrementRequest\022:\n\006header\030\001 \001(\0132 .cock"
+    "roach.roachpb.RequestHeaderB\010\310\336\037\000\320\336\037\001\022\027\n"
+    "\tincrement\030\002 \001(\003B\004\310\336\037\000\"i\n\021IncrementRespo"
+    "nse\022;\n\006header\030\001 \001(\0132!.cockroach.roachpb."
+    "ResponseHeaderB\010\310\336\037\000\320\336\037\001\022\027\n\tnew_value\030\002 "
+    "\001(\003B\004\310\336\037\000\"K\n\rDeleteRequest\022:\n\006header\030\001 \001"
+    "(\0132 .cockroach.roachpb.RequestHeaderB\010\310\336"
+    "\037\000\320\336\037\001\"M\n\016DeleteResponse\022;\n\006header\030\001 \001(\013"
+    "2!.cockroach.roachpb.ResponseHeaderB\010\310\336\037"
+    "\000\320\336\037\001\"u\n\022DeleteRangeRequest\022:\n\006header\030\001 "
     "\001(\0132 .cockroach.roachpb.RequestHeaderB\010\310"
-    "\336\037\000\320\336\037\001\022>\n\007gc_meta\030\002 \001(\0132\035.cockroach.roa"
-    "chpb.GCMetadataB\016\310\336\037\000\342\336\037\006GCMeta\0226\n\004keys\030"
-    "\003 \003(\0132\".cockroach.roachpb.GCRequest.GCKe"
-    "yB\004\310\336\037\000\032T\n\005GCKey\022\024\n\003key\030\001 \001(\014B\007\372\336\037\003Key\0225"
-    "\n\ttimestamp\030\002 \001(\0132\034.cockroach.roachpb.Ti"
-    "mestampB\004\310\336\037\000\"I\n\nGCResponse\022;\n\006header\030\001 "
+    "\336\037\000\320\336\037\001\022#\n\025max_entries_to_delete\030\002 \001(\003B\004"
+    "\310\336\037\000\"m\n\023DeleteRangeResponse\022;\n\006header\030\001 "
     "\001(\0132!.cockroach.roachpb.ResponseHeaderB\010"
-    "\310\336\037\000\320\336\037\001\"\337\002\n\016PushTxnRequest\022:\n\006header\030\001 "
-    "\001(\0132 .cockroach.roachpb.RequestHeaderB\010\310"
-    "\336\037\000\320\336\037\001\0228\n\npusher_txn\030\002 \001(\0132\036.cockroach."
-    "roachpb.TransactionB\004\310\336\037\000\0228\n\npushee_txn\030"
-    "\003 \001(\0132\036.cockroach.roachpb.TransactionB\004\310"
-    "\336\037\000\0223\n\007push_to\030\004 \001(\0132\034.cockroach.roachpb"
-    ".TimestampB\004\310\336\037\000\022/\n\003now\030\005 \001(\0132\034.cockroac"
-    "h.roachpb.TimestampB\004\310\336\037\000\0227\n\tpush_type\030\006"
-    " \001(\0162\036.cockroach.roachpb.PushTxnTypeB\004\310\336"
-    "\037\000\"\202\001\n\017PushTxnResponse\022;\n\006header\030\001 \001(\0132!"
-    ".cockroach.roachpb.ResponseHeaderB\010\310\336\037\000\320"
-    "\336\037\001\0222\n\npushee_txn\030\002 \001(\0132\036.cockroach.roac"
-    "hpb.Transaction\"\214\001\n\024ResolveIntentRequest"
-    "\022:\n\006header\030\001 \001(\0132 .cockroach.roachpb.Req"
-    "uestHeaderB\010\310\336\037\000\320\336\037\001\0228\n\nintent_txn\030\002 \001(\013"
-    "2\036.cockroach.roachpb.TransactionB\004\310\336\037\000\"T"
-    "\n\025ResolveIntentResponse\022;\n\006header\030\001 \001(\0132"
-    "!.cockroach.roachpb.ResponseHeaderB\010\310\336\037\000"
-    "\320\336\037\001\"\221\001\n\031ResolveIntentRangeRequest\022:\n\006he"
-    "ader\030\001 \001(\0132 .cockroach.roachpb.RequestHe"
-    "aderB\010\310\336\037\000\320\336\037\001\0228\n\nintent_txn\030\002 \001(\0132\036.coc"
-    "kroach.roachpb.TransactionB\004\310\336\037\000\"K\n\014Noop"
-    "Response\022;\n\006header\030\001 \001(\0132!.cockroach.roa"
-    "chpb.ResponseHeaderB\010\310\336\037\000\320\336\037\001\"I\n\013NoopReq"
-    "uest\022:\n\006header\030\001 \001(\0132 .cockroach.roachpb"
-    ".RequestHeaderB\010\310\336\037\000\320\336\037\001\"Y\n\032ResolveInten"
-    "tRangeResponse\022;\n\006header\030\001 \001(\0132!.cockroa"
-    "ch.roachpb.ResponseHeaderB\010\310\336\037\000\320\336\037\001\"y\n\014M"
-    "ergeRequest\022:\n\006header\030\001 \001(\0132 .cockroach."
-    "roachpb.RequestHeaderB\010\310\336\037\000\320\336\037\001\022-\n\005value"
-    "\030\002 \001(\0132\030.cockroach.roachpb.ValueB\004\310\336\037\000\"L"
-    "\n\rMergeResponse\022;\n\006header\030\001 \001(\0132!.cockro"
-    "ach.roachpb.ResponseHeaderB\010\310\336\037\000\320\336\037\001\"e\n\022"
-    "TruncateLogRequest\022:\n\006header\030\001 \001(\0132 .coc"
-    "kroach.roachpb.RequestHeaderB\010\310\336\037\000\320\336\037\001\022\023"
-    "\n\005index\030\002 \001(\004B\004\310\336\037\000\"R\n\023TruncateLogRespon"
-    "se\022;\n\006header\030\001 \001(\0132!.cockroach.roachpb.R"
-    "esponseHeaderB\010\310\336\037\000\320\336\037\001\"\177\n\022LeaderLeaseRe"
+    "\310\336\037\000\320\336\037\001\022\031\n\013num_deleted\030\002 \001(\003B\004\310\336\037\000\"d\n\013S"
+    "canRequest\022:\n\006header\030\001 \001(\0132 .cockroach.r"
+    "oachpb.RequestHeaderB\010\310\336\037\000\320\336\037\001\022\031\n\013max_re"
+    "sults\030\002 \001(\003B\004\310\336\037\000\"|\n\014ScanResponse\022;\n\006hea"
+    "der\030\001 \001(\0132!.cockroach.roachpb.ResponseHe"
+    "aderB\010\310\336\037\000\320\336\037\001\022/\n\004rows\030\002 \003(\0132\033.cockroach"
+    ".roachpb.KeyValueB\004\310\336\037\000\"k\n\022ReverseScanRe"
     "quest\022:\n\006header\030\001 \001(\0132 .cockroach.roachp"
-    "b.RequestHeaderB\010\310\336\037\000\320\336\037\001\022-\n\005lease\030\002 \001(\013"
-    "2\030.cockroach.roachpb.LeaseB\004\310\336\037\000\"R\n\023Lead"
-    "erLeaseResponse\022;\n\006header\030\001 \001(\0132!.cockro"
-    "ach.roachpb.ResponseHeaderB\010\310\336\037\000\320\336\037\001\"\272\t\n"
-    "\014RequestUnion\022*\n\003get\030\001 \001(\0132\035.cockroach.r"
-    "oachpb.GetRequest\022*\n\003put\030\002 \001(\0132\035.cockroa"
-    "ch.roachpb.PutRequest\022A\n\017conditional_put"
-    "\030\003 \001(\0132(.cockroach.roachpb.ConditionalPu"
-    "tRequest\0226\n\tincrement\030\004 \001(\0132#.cockroach."
-    "roachpb.IncrementRequest\0220\n\006delete\030\005 \001(\013"
-    "2 .cockroach.roachpb.DeleteRequest\022;\n\014de"
-    "lete_range\030\006 \001(\0132%.cockroach.roachpb.Del"
-    "eteRangeRequest\022,\n\004scan\030\007 \001(\0132\036.cockroac"
-    "h.roachpb.ScanRequest\022A\n\017end_transaction"
-    "\030\010 \001(\0132(.cockroach.roachpb.EndTransactio"
-    "nRequest\0229\n\013admin_split\030\t \001(\0132$.cockroac"
-    "h.roachpb.AdminSplitRequest\0229\n\013admin_mer"
-    "ge\030\n \001(\0132$.cockroach.roachpb.AdminMergeR"
-    "equest\022=\n\rheartbeat_txn\030\013 \001(\0132&.cockroac"
-    "h.roachpb.HeartbeatTxnRequest\022(\n\002gc\030\014 \001("
-    "\0132\034.cockroach.roachpb.GCRequest\0223\n\010push_"
-    "txn\030\r \001(\0132!.cockroach.roachpb.PushTxnReq"
-    "uest\022;\n\014range_lookup\030\016 \001(\0132%.cockroach.r"
-    "oachpb.RangeLookupRequest\022\?\n\016resolve_int"
-    "ent\030\017 \001(\0132\'.cockroach.roachpb.ResolveInt"
-    "entRequest\022J\n\024resolve_intent_range\030\020 \001(\013"
-    "2,.cockroach.roachpb.ResolveIntentRangeR"
-    "equest\022.\n\005merge\030\021 \001(\0132\037.cockroach.roachp"
-    "b.MergeRequest\022;\n\014truncate_log\030\022 \001(\0132%.c"
-    "ockroach.roachpb.TruncateLogRequest\022;\n\014l"
-    "eader_lease\030\023 \001(\0132%.cockroach.roachpb.Le"
-    "aderLeaseRequest\022;\n\014reverse_scan\030\024 \001(\0132%"
-    ".cockroach.roachpb.ReverseScanRequest\022,\n"
-    "\004noop\030\025 \001(\0132\036.cockroach.roachpb.NoopRequ"
-    "est:\004\310\240\037\001\"\320\t\n\rResponseUnion\022+\n\003get\030\001 \001(\013"
-    "2\036.cockroach.roachpb.GetResponse\022+\n\003put\030"
-    "\002 \001(\0132\036.cockroach.roachpb.PutResponse\022B\n"
-    "\017conditional_put\030\003 \001(\0132).cockroach.roach"
-    "pb.ConditionalPutResponse\0227\n\tincrement\030\004"
-    " \001(\0132$.cockroach.roachpb.IncrementRespon"
-    "se\0221\n\006delete\030\005 \001(\0132!.cockroach.roachpb.D"
-    "eleteResponse\022<\n\014delete_range\030\006 \001(\0132&.co"
-    "ckroach.roachpb.DeleteRangeResponse\022-\n\004s"
-    "can\030\007 \001(\0132\037.cockroach.roachpb.ScanRespon"
-    "se\022B\n\017end_transaction\030\010 \001(\0132).cockroach."
-    "roachpb.EndTransactionResponse\022:\n\013admin_"
-    "split\030\t \001(\0132%.cockroach.roachpb.AdminSpl"
-    "itResponse\022:\n\013admin_merge\030\n \001(\0132%.cockro"
-    "ach.roachpb.AdminMergeResponse\022>\n\rheartb"
-    "eat_txn\030\013 \001(\0132\'.cockroach.roachpb.Heartb"
-    "eatTxnResponse\022)\n\002gc\030\014 \001(\0132\035.cockroach.r"
-    "oachpb.GCResponse\0224\n\010push_txn\030\r \001(\0132\".co"
-    "ckroach.roachpb.PushTxnResponse\022<\n\014range"
-    "_lookup\030\016 \001(\0132&.cockroach.roachpb.RangeL"
-    "ookupResponse\022@\n\016resolve_intent\030\017 \001(\0132(."
-    "cockroach.roachpb.ResolveIntentResponse\022"
-    "K\n\024resolve_intent_range\030\020 \001(\0132-.cockroac"
-    "h.roachpb.ResolveIntentRangeResponse\022/\n\005"
-    "merge\030\021 \001(\0132 .cockroach.roachpb.MergeRes"
-    "ponse\022<\n\014truncate_log\030\022 \001(\0132&.cockroach."
-    "roachpb.TruncateLogResponse\022<\n\014leader_le"
-    "ase\030\023 \001(\0132&.cockroach.roachpb.LeaderLeas"
-    "eResponse\022<\n\014reverse_scan\030\024 \001(\0132&.cockro"
-    "ach.roachpb.ReverseScanResponse\022-\n\004noop\030"
-    "\025 \001(\0132\037.cockroach.roachpb.NoopResponse:\004"
-    "\310\240\037\001\"\212\004\n\014BatchRequest\022@\n\006header\030\001 \001(\0132&."
-    "cockroach.roachpb.BatchRequest.HeaderB\010\310"
-    "\336\037\000\320\336\037\001\0227\n\010requests\030\002 \003(\0132\037.cockroach.ro"
-    "achpb.RequestUnionB\004\310\336\037\000\032\370\002\n\006Header\0225\n\tt"
-    "imestamp\030\001 \001(\0132\034.cockroach.roachpb.Times"
-    "tampB\004\310\336\037\000\022=\n\006cmd_id\030\002 \001(\0132\036.cockroach.r"
-    "oachpb.ClientCmdIDB\r\310\336\037\000\342\336\037\005CmdID\022;\n\007rep"
-    "lica\030\005 \001(\0132$.cockroach.roachpb.ReplicaDe"
-    "scriptorB\004\310\336\037\000\022,\n\010range_id\030\006 \001(\003B\032\310\336\037\000\342\336"
-    "\037\007RangeID\372\336\037\007RangeID\022\030\n\ruser_priority\030\007 "
-    "\001(\005:\0011\022+\n\003txn\030\010 \001(\0132\036.cockroach.roachpb."
-    "Transaction\022F\n\020read_consistency\030\t \001(\0162&."
-    "cockroach.roachpb.ReadConsistencyTypeB\004\310"
-    "\336\037\000:\004\230\240\037\000\"\245\002\n\rBatchResponse\022A\n\006header\030\001 "
-    "\001(\0132\'.cockroach.roachpb.BatchResponse.He"
-    "aderB\010\310\336\037\000\320\336\037\001\0229\n\tresponses\030\002 \003(\0132 .cock"
-    "roach.roachpb.ResponseUnionB\004\310\336\037\000\032\225\001\n\006He"
-    "ader\022\'\n\005error\030\001 \001(\0132\030.cockroach.roachpb."
-    "Error\0225\n\ttimestamp\030\002 \001(\0132\034.cockroach.roa"
-    "chpb.TimestampB\004\310\336\037\000\022+\n\003txn\030\003 \001(\0132\036.cock"
-    "roach.roachpb.Transaction*L\n\023ReadConsist"
-    "encyType\022\016\n\nCONSISTENT\020\000\022\r\n\tCONSENSUS\020\001\022"
-    "\020\n\014INCONSISTENT\020\002\032\004\210\243\036\000*G\n\013PushTxnType\022\022"
-    "\n\016PUSH_TIMESTAMP\020\000\022\r\n\tABORT_TXN\020\001\022\017\n\013CLE"
-    "ANUP_TXN\020\002\032\004\210\243\036\000B\031Z\007roachpb\340\342\036\001\310\342\036\001\320\342\036\001\220"
-    "\343\036\000", 9163);
+    "b.RequestHeaderB\010\310\336\037\000\320\336\037\001\022\031\n\013max_results"
+    "\030\002 \001(\003B\004\310\336\037\000\"\203\001\n\023ReverseScanResponse\022;\n\006"
+    "header\030\001 \001(\0132!.cockroach.roachpb.Respons"
+    "eHeaderB\010\310\336\037\000\320\336\037\001\022/\n\004rows\030\002 \003(\0132\033.cockro"
+    "ach.roachpb.KeyValueB\004\310\336\037\000\"\346\001\n\025EndTransa"
+    "ctionRequest\022:\n\006header\030\001 \001(\0132 .cockroach"
+    ".roachpb.RequestHeaderB\010\310\336\037\000\320\336\037\001\022\024\n\006comm"
+    "it\030\002 \001(\010B\004\310\336\037\000\022I\n\027internal_commit_trigge"
+    "r\030\003 \001(\0132(.cockroach.roachpb.InternalComm"
+    "itTrigger\0220\n\007intents\030\004 \003(\0132\031.cockroach.r"
+    "oachpb.IntentB\004\310\336\037\000\"\213\001\n\026EndTransactionRe"
+    "sponse\022;\n\006header\030\001 \001(\0132!.cockroach.roach"
+    "pb.ResponseHeaderB\010\310\336\037\000\320\336\037\001\022\031\n\013commit_wa"
+    "it\030\002 \001(\003B\004\310\336\037\000\022\031\n\010resolved\030\003 \003(\014B\007\372\336\037\003Ke"
+    "y\"k\n\021AdminSplitRequest\022:\n\006header\030\001 \001(\0132 "
+    ".cockroach.roachpb.RequestHeaderB\010\310\336\037\000\320\336"
+    "\037\001\022\032\n\tsplit_key\030\002 \001(\014B\007\372\336\037\003Key\"Q\n\022AdminS"
+    "plitResponse\022;\n\006header\030\001 \001(\0132!.cockroach"
+    ".roachpb.ResponseHeaderB\010\310\336\037\000\320\336\037\001\"O\n\021Adm"
+    "inMergeRequest\022:\n\006header\030\001 \001(\0132 .cockroa"
+    "ch.roachpb.RequestHeaderB\010\310\336\037\000\320\336\037\001\"Q\n\022Ad"
+    "minMergeResponse\022;\n\006header\030\001 \001(\0132!.cockr"
+    "oach.roachpb.ResponseHeaderB\010\310\336\037\000\320\336\037\001\"\241\001"
+    "\n\022RangeLookupRequest\022:\n\006header\030\001 \001(\0132 .c"
+    "ockroach.roachpb.RequestHeaderB\010\310\336\037\000\320\336\037\001"
+    "\022\030\n\nmax_ranges\030\002 \001(\005B\004\310\336\037\000\022\036\n\020consider_i"
+    "ntents\030\003 \001(\010B\004\310\336\037\000\022\025\n\007reverse\030\004 \001(\010B\004\310\336\037"
+    "\000\"\214\001\n\023RangeLookupResponse\022;\n\006header\030\001 \001("
+    "\0132!.cockroach.roachpb.ResponseHeaderB\010\310\336"
+    "\037\000\320\336\037\001\0228\n\006ranges\030\002 \003(\0132\".cockroach.roach"
+    "pb.RangeDescriptorB\004\310\336\037\000\"Q\n\023HeartbeatTxn"
+    "Request\022:\n\006header\030\001 \001(\0132 .cockroach.roac"
+    "hpb.RequestHeaderB\010\310\336\037\000\320\336\037\001\"S\n\024Heartbeat"
+    "TxnResponse\022;\n\006header\030\001 \001(\0132!.cockroach."
+    "roachpb.ResponseHeaderB\010\310\336\037\000\320\336\037\001\"\225\002\n\tGCR"
+    "equest\022:\n\006header\030\001 \001(\0132 .cockroach.roach"
+    "pb.RequestHeaderB\010\310\336\037\000\320\336\037\001\022>\n\007gc_meta\030\002 "
+    "\001(\0132\035.cockroach.roachpb.GCMetadataB\016\310\336\037\000"
+    "\342\336\037\006GCMeta\0226\n\004keys\030\003 \003(\0132\".cockroach.roa"
+    "chpb.GCRequest.GCKeyB\004\310\336\037\000\032T\n\005GCKey\022\024\n\003k"
+    "ey\030\001 \001(\014B\007\372\336\037\003Key\0225\n\ttimestamp\030\002 \001(\0132\034.c"
+    "ockroach.roachpb.TimestampB\004\310\336\037\000\"I\n\nGCRe"
+    "sponse\022;\n\006header\030\001 \001(\0132!.cockroach.roach"
+    "pb.ResponseHeaderB\010\310\336\037\000\320\336\037\001\"\337\002\n\016PushTxnR"
+    "equest\022:\n\006header\030\001 \001(\0132 .cockroach.roach"
+    "pb.RequestHeaderB\010\310\336\037\000\320\336\037\001\0228\n\npusher_txn"
+    "\030\002 \001(\0132\036.cockroach.roachpb.TransactionB\004"
+    "\310\336\037\000\0228\n\npushee_txn\030\003 \001(\0132\036.cockroach.roa"
+    "chpb.TransactionB\004\310\336\037\000\0223\n\007push_to\030\004 \001(\0132"
+    "\034.cockroach.roachpb.TimestampB\004\310\336\037\000\022/\n\003n"
+    "ow\030\005 \001(\0132\034.cockroach.roachpb.TimestampB\004"
+    "\310\336\037\000\0227\n\tpush_type\030\006 \001(\0162\036.cockroach.roac"
+    "hpb.PushTxnTypeB\004\310\336\037\000\"\202\001\n\017PushTxnRespons"
+    "e\022;\n\006header\030\001 \001(\0132!.cockroach.roachpb.Re"
+    "sponseHeaderB\010\310\336\037\000\320\336\037\001\0222\n\npushee_txn\030\002 \001"
+    "(\0132\036.cockroach.roachpb.Transaction\"\214\001\n\024R"
+    "esolveIntentRequest\022:\n\006header\030\001 \001(\0132 .co"
+    "ckroach.roachpb.RequestHeaderB\010\310\336\037\000\320\336\037\001\022"
+    "8\n\nintent_txn\030\002 \001(\0132\036.cockroach.roachpb."
+    "TransactionB\004\310\336\037\000\"T\n\025ResolveIntentRespon"
+    "se\022;\n\006header\030\001 \001(\0132!.cockroach.roachpb.R"
+    "esponseHeaderB\010\310\336\037\000\320\336\037\001\"\221\001\n\031ResolveInten"
+    "tRangeRequest\022:\n\006header\030\001 \001(\0132 .cockroac"
+    "h.roachpb.RequestHeaderB\010\310\336\037\000\320\336\037\001\0228\n\nint"
+    "ent_txn\030\002 \001(\0132\036.cockroach.roachpb.Transa"
+    "ctionB\004\310\336\037\000\"K\n\014NoopResponse\022;\n\006header\030\001 "
+    "\001(\0132!.cockroach.roachpb.ResponseHeaderB\010"
+    "\310\336\037\000\320\336\037\001\"I\n\013NoopRequest\022:\n\006header\030\001 \001(\0132"
+    " .cockroach.roachpb.RequestHeaderB\010\310\336\037\000\320"
+    "\336\037\001\"Y\n\032ResolveIntentRangeResponse\022;\n\006hea"
+    "der\030\001 \001(\0132!.cockroach.roachpb.ResponseHe"
+    "aderB\010\310\336\037\000\320\336\037\001\"y\n\014MergeRequest\022:\n\006header"
+    "\030\001 \001(\0132 .cockroach.roachpb.RequestHeader"
+    "B\010\310\336\037\000\320\336\037\001\022-\n\005value\030\002 \001(\0132\030.cockroach.ro"
+    "achpb.ValueB\004\310\336\037\000\"L\n\rMergeResponse\022;\n\006he"
+    "ader\030\001 \001(\0132!.cockroach.roachpb.ResponseH"
+    "eaderB\010\310\336\037\000\320\336\037\001\"e\n\022TruncateLogRequest\022:\n"
+    "\006header\030\001 \001(\0132 .cockroach.roachpb.Reques"
+    "tHeaderB\010\310\336\037\000\320\336\037\001\022\023\n\005index\030\002 \001(\004B\004\310\336\037\000\"R"
+    "\n\023TruncateLogResponse\022;\n\006header\030\001 \001(\0132!."
+    "cockroach.roachpb.ResponseHeaderB\010\310\336\037\000\320\336"
+    "\037\001\"\177\n\022LeaderLeaseRequest\022:\n\006header\030\001 \001(\013"
+    "2 .cockroach.roachpb.RequestHeaderB\010\310\336\037\000"
+    "\320\336\037\001\022-\n\005lease\030\002 \001(\0132\030.cockroach.roachpb."
+    "LeaseB\004\310\336\037\000\"R\n\023LeaderLeaseResponse\022;\n\006he"
+    "ader\030\001 \001(\0132!.cockroach.roachpb.ResponseH"
+    "eaderB\010\310\336\037\000\320\336\037\001\"\272\t\n\014RequestUnion\022*\n\003get\030"
+    "\001 \001(\0132\035.cockroach.roachpb.GetRequest\022*\n\003"
+    "put\030\002 \001(\0132\035.cockroach.roachpb.PutRequest"
+    "\022A\n\017conditional_put\030\003 \001(\0132(.cockroach.ro"
+    "achpb.ConditionalPutRequest\0226\n\tincrement"
+    "\030\004 \001(\0132#.cockroach.roachpb.IncrementRequ"
+    "est\0220\n\006delete\030\005 \001(\0132 .cockroach.roachpb."
+    "DeleteRequest\022;\n\014delete_range\030\006 \001(\0132%.co"
+    "ckroach.roachpb.DeleteRangeRequest\022,\n\004sc"
+    "an\030\007 \001(\0132\036.cockroach.roachpb.ScanRequest"
+    "\022A\n\017end_transaction\030\010 \001(\0132(.cockroach.ro"
+    "achpb.EndTransactionRequest\0229\n\013admin_spl"
+    "it\030\t \001(\0132$.cockroach.roachpb.AdminSplitR"
+    "equest\0229\n\013admin_merge\030\n \001(\0132$.cockroach."
+    "roachpb.AdminMergeRequest\022=\n\rheartbeat_t"
+    "xn\030\013 \001(\0132&.cockroach.roachpb.HeartbeatTx"
+    "nRequest\022(\n\002gc\030\014 \001(\0132\034.cockroach.roachpb"
+    ".GCRequest\0223\n\010push_txn\030\r \001(\0132!.cockroach"
+    ".roachpb.PushTxnRequest\022;\n\014range_lookup\030"
+    "\016 \001(\0132%.cockroach.roachpb.RangeLookupReq"
+    "uest\022\?\n\016resolve_intent\030\017 \001(\0132\'.cockroach"
+    ".roachpb.ResolveIntentRequest\022J\n\024resolve"
+    "_intent_range\030\020 \001(\0132,.cockroach.roachpb."
+    "ResolveIntentRangeRequest\022.\n\005merge\030\021 \001(\013"
+    "2\037.cockroach.roachpb.MergeRequest\022;\n\014tru"
+    "ncate_log\030\022 \001(\0132%.cockroach.roachpb.Trun"
+    "cateLogRequest\022;\n\014leader_lease\030\023 \001(\0132%.c"
+    "ockroach.roachpb.LeaderLeaseRequest\022;\n\014r"
+    "everse_scan\030\024 \001(\0132%.cockroach.roachpb.Re"
+    "verseScanRequest\022,\n\004noop\030\025 \001(\0132\036.cockroa"
+    "ch.roachpb.NoopRequest:\004\310\240\037\001\"\320\t\n\rRespons"
+    "eUnion\022+\n\003get\030\001 \001(\0132\036.cockroach.roachpb."
+    "GetResponse\022+\n\003put\030\002 \001(\0132\036.cockroach.roa"
+    "chpb.PutResponse\022B\n\017conditional_put\030\003 \001("
+    "\0132).cockroach.roachpb.ConditionalPutResp"
+    "onse\0227\n\tincrement\030\004 \001(\0132$.cockroach.roac"
+    "hpb.IncrementResponse\0221\n\006delete\030\005 \001(\0132!."
+    "cockroach.roachpb.DeleteResponse\022<\n\014dele"
+    "te_range\030\006 \001(\0132&.cockroach.roachpb.Delet"
+    "eRangeResponse\022-\n\004scan\030\007 \001(\0132\037.cockroach"
+    ".roachpb.ScanResponse\022B\n\017end_transaction"
+    "\030\010 \001(\0132).cockroach.roachpb.EndTransactio"
+    "nResponse\022:\n\013admin_split\030\t \001(\0132%.cockroa"
+    "ch.roachpb.AdminSplitResponse\022:\n\013admin_m"
+    "erge\030\n \001(\0132%.cockroach.roachpb.AdminMerg"
+    "eResponse\022>\n\rheartbeat_txn\030\013 \001(\0132\'.cockr"
+    "oach.roachpb.HeartbeatTxnResponse\022)\n\002gc\030"
+    "\014 \001(\0132\035.cockroach.roachpb.GCResponse\0224\n\010"
+    "push_txn\030\r \001(\0132\".cockroach.roachpb.PushT"
+    "xnResponse\022<\n\014range_lookup\030\016 \001(\0132&.cockr"
+    "oach.roachpb.RangeLookupResponse\022@\n\016reso"
+    "lve_intent\030\017 \001(\0132(.cockroach.roachpb.Res"
+    "olveIntentResponse\022K\n\024resolve_intent_ran"
+    "ge\030\020 \001(\0132-.cockroach.roachpb.ResolveInte"
+    "ntRangeResponse\022/\n\005merge\030\021 \001(\0132 .cockroa"
+    "ch.roachpb.MergeResponse\022<\n\014truncate_log"
+    "\030\022 \001(\0132&.cockroach.roachpb.TruncateLogRe"
+    "sponse\022<\n\014leader_lease\030\023 \001(\0132&.cockroach"
+    ".roachpb.LeaderLeaseResponse\022<\n\014reverse_"
+    "scan\030\024 \001(\0132&.cockroach.roachpb.ReverseSc"
+    "anResponse\022-\n\004noop\030\025 \001(\0132\037.cockroach.roa"
+    "chpb.NoopResponse:\004\310\240\037\001\"\212\004\n\014BatchRequest"
+    "\022@\n\006header\030\001 \001(\0132&.cockroach.roachpb.Bat"
+    "chRequest.HeaderB\010\310\336\037\000\320\336\037\001\0227\n\010requests\030\002"
+    " \003(\0132\037.cockroach.roachpb.RequestUnionB\004\310"
+    "\336\037\000\032\370\002\n\006Header\0225\n\ttimestamp\030\001 \001(\0132\034.cock"
+    "roach.roachpb.TimestampB\004\310\336\037\000\022=\n\006cmd_id\030"
+    "\002 \001(\0132\036.cockroach.roachpb.ClientCmdIDB\r\310"
+    "\336\037\000\342\336\037\005CmdID\022;\n\007replica\030\005 \001(\0132$.cockroac"
+    "h.roachpb.ReplicaDescriptorB\004\310\336\037\000\022,\n\010ran"
+    "ge_id\030\006 \001(\003B\032\310\336\037\000\342\336\037\007RangeID\372\336\037\007RangeID\022"
+    "\030\n\ruser_priority\030\007 \001(\005:\0011\022+\n\003txn\030\010 \001(\0132\036"
+    ".cockroach.roachpb.Transaction\022F\n\020read_c"
+    "onsistency\030\t \001(\0162&.cockroach.roachpb.Rea"
+    "dConsistencyTypeB\004\310\336\037\000:\004\230\240\037\000\"\245\002\n\rBatchRe"
+    "sponse\022A\n\006header\030\001 \001(\0132\'.cockroach.roach"
+    "pb.BatchResponse.HeaderB\010\310\336\037\000\320\336\037\001\0229\n\tres"
+    "ponses\030\002 \003(\0132 .cockroach.roachpb.Respons"
+    "eUnionB\004\310\336\037\000\032\225\001\n\006Header\022\'\n\005error\030\001 \001(\0132\030"
+    ".cockroach.roachpb.Error\0225\n\ttimestamp\030\002 "
+    "\001(\0132\034.cockroach.roachpb.TimestampB\004\310\336\037\000\022"
+    "+\n\003txn\030\003 \001(\0132\036.cockroach.roachpb.Transac"
+    "tion*L\n\023ReadConsistencyType\022\016\n\nCONSISTEN"
+    "T\020\000\022\r\n\tCONSENSUS\020\001\022\020\n\014INCONSISTENT\020\002\032\004\210\243"
+    "\036\000*G\n\013PushTxnType\022\022\n\016PUSH_TIMESTAMP\020\000\022\r\n"
+    "\tABORT_TXN\020\001\022\017\n\013CLEANUP_TXN\020\002\032\004\210\243\036\000B\031Z\007r"
+    "oachpb\340\342\036\001\310\342\036\001\320\342\036\001\220\343\036\000", 9102);
   ::google::protobuf::MessageFactory::InternalRegisterGeneratedFile(
     "cockroach/roachpb/api.proto", &protobuf_RegisterTypes);
   ClientCmdID::default_instance_ = new ClientCmdID();
@@ -2031,7 +2028,6 @@ void ClientCmdID::clear_random() {
 const int RequestHeader::kCmdIdFieldNumber;
 const int RequestHeader::kKeyFieldNumber;
 const int RequestHeader::kEndKeyFieldNumber;
-const int RequestHeader::kReplicaFieldNumber;
 const int RequestHeader::kRangeIdFieldNumber;
 const int RequestHeader::kUserPriorityFieldNumber;
 const int RequestHeader::kTxnFieldNumber;
@@ -2046,7 +2042,6 @@ RequestHeader::RequestHeader()
 
 void RequestHeader::InitAsDefaultInstance() {
   cmd_id_ = const_cast< ::cockroach::roachpb::ClientCmdID*>(&::cockroach::roachpb::ClientCmdID::default_instance());
-  replica_ = const_cast< ::cockroach::roachpb::ReplicaDescriptor*>(&::cockroach::roachpb::ReplicaDescriptor::default_instance());
   txn_ = const_cast< ::cockroach::roachpb::Transaction*>(&::cockroach::roachpb::Transaction::default_instance());
 }
 
@@ -2064,7 +2059,6 @@ void RequestHeader::SharedCtor() {
   cmd_id_ = NULL;
   key_.UnsafeSetDefault(&::google::protobuf::internal::GetEmptyStringAlreadyInited());
   end_key_.UnsafeSetDefault(&::google::protobuf::internal::GetEmptyStringAlreadyInited());
-  replica_ = NULL;
   range_id_ = GOOGLE_LONGLONG(0);
   user_priority_ = 1;
   txn_ = NULL;
@@ -2082,7 +2076,6 @@ void RequestHeader::SharedDtor() {
   end_key_.DestroyNoArena(&::google::protobuf::internal::GetEmptyStringAlreadyInited());
   if (this != default_instance_) {
     delete cmd_id_;
-    delete replica_;
     delete txn_;
   }
 }
@@ -2113,7 +2106,7 @@ RequestHeader* RequestHeader::New(::google::protobuf::Arena* arena) const {
 }
 
 void RequestHeader::Clear() {
-  if (_has_bits_[0 / 32] & 255u) {
+  if (_has_bits_[0 / 32] & 127u) {
     if (has_cmd_id()) {
       if (cmd_id_ != NULL) cmd_id_->::cockroach::roachpb::ClientCmdID::Clear();
     }
@@ -2122,9 +2115,6 @@ void RequestHeader::Clear() {
     }
     if (has_end_key()) {
       end_key_.ClearToEmptyNoArena(&::google::protobuf::internal::GetEmptyStringAlreadyInited());
-    }
-    if (has_replica()) {
-      if (replica_ != NULL) replica_->::cockroach::roachpb::ReplicaDescriptor::Clear();
     }
     range_id_ = GOOGLE_LONGLONG(0);
     user_priority_ = 1;
@@ -2180,19 +2170,6 @@ bool RequestHeader::MergePartialFromCodedStream(
          parse_end_key:
           DO_(::google::protobuf::internal::WireFormatLite::ReadBytes(
                 input, this->mutable_end_key()));
-        } else {
-          goto handle_unusual;
-        }
-        if (input->ExpectTag(42)) goto parse_replica;
-        break;
-      }
-
-      // optional .cockroach.roachpb.ReplicaDescriptor replica = 5;
-      case 5: {
-        if (tag == 42) {
-         parse_replica:
-          DO_(::google::protobuf::internal::WireFormatLite::ReadMessageNoVirtual(
-               input, mutable_replica()));
         } else {
           goto handle_unusual;
         }
@@ -2306,12 +2283,6 @@ void RequestHeader::SerializeWithCachedSizes(
       4, this->end_key(), output);
   }
 
-  // optional .cockroach.roachpb.ReplicaDescriptor replica = 5;
-  if (has_replica()) {
-    ::google::protobuf::internal::WireFormatLite::WriteMessageMaybeToArray(
-      5, *this->replica_, output);
-  }
-
   // optional int64 range_id = 6;
   if (has_range_id()) {
     ::google::protobuf::internal::WireFormatLite::WriteInt64(6, this->range_id(), output);
@@ -2365,13 +2336,6 @@ void RequestHeader::SerializeWithCachedSizes(
         4, this->end_key(), target);
   }
 
-  // optional .cockroach.roachpb.ReplicaDescriptor replica = 5;
-  if (has_replica()) {
-    target = ::google::protobuf::internal::WireFormatLite::
-      WriteMessageNoVirtualToArray(
-        5, *this->replica_, target);
-  }
-
   // optional int64 range_id = 6;
   if (has_range_id()) {
     target = ::google::protobuf::internal::WireFormatLite::WriteInt64ToArray(6, this->range_id(), target);
@@ -2406,7 +2370,7 @@ void RequestHeader::SerializeWithCachedSizes(
 int RequestHeader::ByteSize() const {
   int total_size = 0;
 
-  if (_has_bits_[0 / 32] & 255) {
+  if (_has_bits_[0 / 32] & 127) {
     // optional .cockroach.roachpb.ClientCmdID cmd_id = 2;
     if (has_cmd_id()) {
       total_size += 1 +
@@ -2426,13 +2390,6 @@ int RequestHeader::ByteSize() const {
       total_size += 1 +
         ::google::protobuf::internal::WireFormatLite::BytesSize(
           this->end_key());
-    }
-
-    // optional .cockroach.roachpb.ReplicaDescriptor replica = 5;
-    if (has_replica()) {
-      total_size += 1 +
-        ::google::protobuf::internal::WireFormatLite::MessageSizeNoVirtual(
-          *this->replica_);
     }
 
     // optional int64 range_id = 6;
@@ -2500,9 +2457,6 @@ void RequestHeader::MergeFrom(const RequestHeader& from) {
       set_has_end_key();
       end_key_.AssignWithDefault(&::google::protobuf::internal::GetEmptyStringAlreadyInited(), from.end_key_);
     }
-    if (from.has_replica()) {
-      mutable_replica()->::cockroach::roachpb::ReplicaDescriptor::MergeFrom(from.replica());
-    }
     if (from.has_range_id()) {
       set_range_id(from.range_id());
     }
@@ -2546,7 +2500,6 @@ void RequestHeader::InternalSwap(RequestHeader* other) {
   std::swap(cmd_id_, other->cmd_id_);
   key_.Swap(&other->key_);
   end_key_.Swap(&other->end_key_);
-  std::swap(replica_, other->replica_);
   std::swap(range_id_, other->range_id_);
   std::swap(user_priority_, other->user_priority_);
   std::swap(txn_, other->txn_);
@@ -2716,58 +2669,15 @@ void RequestHeader::clear_end_key() {
   // @@protoc_insertion_point(field_set_allocated:cockroach.roachpb.RequestHeader.end_key)
 }
 
-// optional .cockroach.roachpb.ReplicaDescriptor replica = 5;
-bool RequestHeader::has_replica() const {
-  return (_has_bits_[0] & 0x00000008u) != 0;
-}
-void RequestHeader::set_has_replica() {
-  _has_bits_[0] |= 0x00000008u;
-}
-void RequestHeader::clear_has_replica() {
-  _has_bits_[0] &= ~0x00000008u;
-}
-void RequestHeader::clear_replica() {
-  if (replica_ != NULL) replica_->::cockroach::roachpb::ReplicaDescriptor::Clear();
-  clear_has_replica();
-}
- const ::cockroach::roachpb::ReplicaDescriptor& RequestHeader::replica() const {
-  // @@protoc_insertion_point(field_get:cockroach.roachpb.RequestHeader.replica)
-  return replica_ != NULL ? *replica_ : *default_instance_->replica_;
-}
- ::cockroach::roachpb::ReplicaDescriptor* RequestHeader::mutable_replica() {
-  set_has_replica();
-  if (replica_ == NULL) {
-    replica_ = new ::cockroach::roachpb::ReplicaDescriptor;
-  }
-  // @@protoc_insertion_point(field_mutable:cockroach.roachpb.RequestHeader.replica)
-  return replica_;
-}
- ::cockroach::roachpb::ReplicaDescriptor* RequestHeader::release_replica() {
-  clear_has_replica();
-  ::cockroach::roachpb::ReplicaDescriptor* temp = replica_;
-  replica_ = NULL;
-  return temp;
-}
- void RequestHeader::set_allocated_replica(::cockroach::roachpb::ReplicaDescriptor* replica) {
-  delete replica_;
-  replica_ = replica;
-  if (replica) {
-    set_has_replica();
-  } else {
-    clear_has_replica();
-  }
-  // @@protoc_insertion_point(field_set_allocated:cockroach.roachpb.RequestHeader.replica)
-}
-
 // optional int64 range_id = 6;
 bool RequestHeader::has_range_id() const {
-  return (_has_bits_[0] & 0x00000010u) != 0;
+  return (_has_bits_[0] & 0x00000008u) != 0;
 }
 void RequestHeader::set_has_range_id() {
-  _has_bits_[0] |= 0x00000010u;
+  _has_bits_[0] |= 0x00000008u;
 }
 void RequestHeader::clear_has_range_id() {
-  _has_bits_[0] &= ~0x00000010u;
+  _has_bits_[0] &= ~0x00000008u;
 }
 void RequestHeader::clear_range_id() {
   range_id_ = GOOGLE_LONGLONG(0);
@@ -2785,13 +2695,13 @@ void RequestHeader::clear_range_id() {
 
 // optional int32 user_priority = 7 [default = 1];
 bool RequestHeader::has_user_priority() const {
-  return (_has_bits_[0] & 0x00000020u) != 0;
+  return (_has_bits_[0] & 0x00000010u) != 0;
 }
 void RequestHeader::set_has_user_priority() {
-  _has_bits_[0] |= 0x00000020u;
+  _has_bits_[0] |= 0x00000010u;
 }
 void RequestHeader::clear_has_user_priority() {
-  _has_bits_[0] &= ~0x00000020u;
+  _has_bits_[0] &= ~0x00000010u;
 }
 void RequestHeader::clear_user_priority() {
   user_priority_ = 1;
@@ -2809,13 +2719,13 @@ void RequestHeader::clear_user_priority() {
 
 // optional .cockroach.roachpb.Transaction txn = 8;
 bool RequestHeader::has_txn() const {
-  return (_has_bits_[0] & 0x00000040u) != 0;
+  return (_has_bits_[0] & 0x00000020u) != 0;
 }
 void RequestHeader::set_has_txn() {
-  _has_bits_[0] |= 0x00000040u;
+  _has_bits_[0] |= 0x00000020u;
 }
 void RequestHeader::clear_has_txn() {
-  _has_bits_[0] &= ~0x00000040u;
+  _has_bits_[0] &= ~0x00000020u;
 }
 void RequestHeader::clear_txn() {
   if (txn_ != NULL) txn_->::cockroach::roachpb::Transaction::Clear();
@@ -2852,13 +2762,13 @@ void RequestHeader::clear_txn() {
 
 // optional .cockroach.roachpb.ReadConsistencyType read_consistency = 9;
 bool RequestHeader::has_read_consistency() const {
-  return (_has_bits_[0] & 0x00000080u) != 0;
+  return (_has_bits_[0] & 0x00000040u) != 0;
 }
 void RequestHeader::set_has_read_consistency() {
-  _has_bits_[0] |= 0x00000080u;
+  _has_bits_[0] |= 0x00000040u;
 }
 void RequestHeader::clear_has_read_consistency() {
-  _has_bits_[0] &= ~0x00000080u;
+  _has_bits_[0] &= ~0x00000040u;
 }
 void RequestHeader::clear_read_consistency() {
   read_consistency_ = 0;

--- a/storage/engine/rocksdb/cockroach/roachpb/api.pb.h
+++ b/storage/engine/rocksdb/cockroach/roachpb/api.pb.h
@@ -333,15 +333,6 @@ class RequestHeader : public ::google::protobuf::Message {
   ::std::string* release_end_key();
   void set_allocated_end_key(::std::string* end_key);
 
-  // optional .cockroach.roachpb.ReplicaDescriptor replica = 5;
-  bool has_replica() const;
-  void clear_replica();
-  static const int kReplicaFieldNumber = 5;
-  const ::cockroach::roachpb::ReplicaDescriptor& replica() const;
-  ::cockroach::roachpb::ReplicaDescriptor* mutable_replica();
-  ::cockroach::roachpb::ReplicaDescriptor* release_replica();
-  void set_allocated_replica(::cockroach::roachpb::ReplicaDescriptor* replica);
-
   // optional int64 range_id = 6;
   bool has_range_id() const;
   void clear_range_id();
@@ -380,8 +371,6 @@ class RequestHeader : public ::google::protobuf::Message {
   inline void clear_has_key();
   inline void set_has_end_key();
   inline void clear_has_end_key();
-  inline void set_has_replica();
-  inline void clear_has_replica();
   inline void set_has_range_id();
   inline void clear_has_range_id();
   inline void set_has_user_priority();
@@ -397,7 +386,6 @@ class RequestHeader : public ::google::protobuf::Message {
   ::cockroach::roachpb::ClientCmdID* cmd_id_;
   ::google::protobuf::internal::ArenaStringPtr key_;
   ::google::protobuf::internal::ArenaStringPtr end_key_;
-  ::cockroach::roachpb::ReplicaDescriptor* replica_;
   ::google::protobuf::int64 range_id_;
   ::cockroach::roachpb::Transaction* txn_;
   ::google::protobuf::int32 user_priority_;
@@ -6204,58 +6192,15 @@ inline void RequestHeader::set_allocated_end_key(::std::string* end_key) {
   // @@protoc_insertion_point(field_set_allocated:cockroach.roachpb.RequestHeader.end_key)
 }
 
-// optional .cockroach.roachpb.ReplicaDescriptor replica = 5;
-inline bool RequestHeader::has_replica() const {
-  return (_has_bits_[0] & 0x00000008u) != 0;
-}
-inline void RequestHeader::set_has_replica() {
-  _has_bits_[0] |= 0x00000008u;
-}
-inline void RequestHeader::clear_has_replica() {
-  _has_bits_[0] &= ~0x00000008u;
-}
-inline void RequestHeader::clear_replica() {
-  if (replica_ != NULL) replica_->::cockroach::roachpb::ReplicaDescriptor::Clear();
-  clear_has_replica();
-}
-inline const ::cockroach::roachpb::ReplicaDescriptor& RequestHeader::replica() const {
-  // @@protoc_insertion_point(field_get:cockroach.roachpb.RequestHeader.replica)
-  return replica_ != NULL ? *replica_ : *default_instance_->replica_;
-}
-inline ::cockroach::roachpb::ReplicaDescriptor* RequestHeader::mutable_replica() {
-  set_has_replica();
-  if (replica_ == NULL) {
-    replica_ = new ::cockroach::roachpb::ReplicaDescriptor;
-  }
-  // @@protoc_insertion_point(field_mutable:cockroach.roachpb.RequestHeader.replica)
-  return replica_;
-}
-inline ::cockroach::roachpb::ReplicaDescriptor* RequestHeader::release_replica() {
-  clear_has_replica();
-  ::cockroach::roachpb::ReplicaDescriptor* temp = replica_;
-  replica_ = NULL;
-  return temp;
-}
-inline void RequestHeader::set_allocated_replica(::cockroach::roachpb::ReplicaDescriptor* replica) {
-  delete replica_;
-  replica_ = replica;
-  if (replica) {
-    set_has_replica();
-  } else {
-    clear_has_replica();
-  }
-  // @@protoc_insertion_point(field_set_allocated:cockroach.roachpb.RequestHeader.replica)
-}
-
 // optional int64 range_id = 6;
 inline bool RequestHeader::has_range_id() const {
-  return (_has_bits_[0] & 0x00000010u) != 0;
+  return (_has_bits_[0] & 0x00000008u) != 0;
 }
 inline void RequestHeader::set_has_range_id() {
-  _has_bits_[0] |= 0x00000010u;
+  _has_bits_[0] |= 0x00000008u;
 }
 inline void RequestHeader::clear_has_range_id() {
-  _has_bits_[0] &= ~0x00000010u;
+  _has_bits_[0] &= ~0x00000008u;
 }
 inline void RequestHeader::clear_range_id() {
   range_id_ = GOOGLE_LONGLONG(0);
@@ -6273,13 +6218,13 @@ inline void RequestHeader::set_range_id(::google::protobuf::int64 value) {
 
 // optional int32 user_priority = 7 [default = 1];
 inline bool RequestHeader::has_user_priority() const {
-  return (_has_bits_[0] & 0x00000020u) != 0;
+  return (_has_bits_[0] & 0x00000010u) != 0;
 }
 inline void RequestHeader::set_has_user_priority() {
-  _has_bits_[0] |= 0x00000020u;
+  _has_bits_[0] |= 0x00000010u;
 }
 inline void RequestHeader::clear_has_user_priority() {
-  _has_bits_[0] &= ~0x00000020u;
+  _has_bits_[0] &= ~0x00000010u;
 }
 inline void RequestHeader::clear_user_priority() {
   user_priority_ = 1;
@@ -6297,13 +6242,13 @@ inline void RequestHeader::set_user_priority(::google::protobuf::int32 value) {
 
 // optional .cockroach.roachpb.Transaction txn = 8;
 inline bool RequestHeader::has_txn() const {
-  return (_has_bits_[0] & 0x00000040u) != 0;
+  return (_has_bits_[0] & 0x00000020u) != 0;
 }
 inline void RequestHeader::set_has_txn() {
-  _has_bits_[0] |= 0x00000040u;
+  _has_bits_[0] |= 0x00000020u;
 }
 inline void RequestHeader::clear_has_txn() {
-  _has_bits_[0] &= ~0x00000040u;
+  _has_bits_[0] &= ~0x00000020u;
 }
 inline void RequestHeader::clear_txn() {
   if (txn_ != NULL) txn_->::cockroach::roachpb::Transaction::Clear();
@@ -6340,13 +6285,13 @@ inline void RequestHeader::set_allocated_txn(::cockroach::roachpb::Transaction* 
 
 // optional .cockroach.roachpb.ReadConsistencyType read_consistency = 9;
 inline bool RequestHeader::has_read_consistency() const {
-  return (_has_bits_[0] & 0x00000080u) != 0;
+  return (_has_bits_[0] & 0x00000040u) != 0;
 }
 inline void RequestHeader::set_has_read_consistency() {
-  _has_bits_[0] |= 0x00000080u;
+  _has_bits_[0] |= 0x00000040u;
 }
 inline void RequestHeader::clear_has_read_consistency() {
-  _has_bits_[0] &= ~0x00000080u;
+  _has_bits_[0] &= ~0x00000040u;
 }
 inline void RequestHeader::clear_read_consistency() {
   read_consistency_ = 0;

--- a/storage/engine/rocksdb/cockroach/roachpb/api.pb.h
+++ b/storage/engine/rocksdb/cockroach/roachpb/api.pb.h
@@ -5595,30 +5595,6 @@ class BatchRequest_Header : public ::google::protobuf::Message {
   ::cockroach::roachpb::ClientCmdID* release_cmd_id();
   void set_allocated_cmd_id(::cockroach::roachpb::ClientCmdID* cmd_id);
 
-  // optional bytes key = 3;
-  bool has_key() const;
-  void clear_key();
-  static const int kKeyFieldNumber = 3;
-  const ::std::string& key() const;
-  void set_key(const ::std::string& value);
-  void set_key(const char* value);
-  void set_key(const void* value, size_t size);
-  ::std::string* mutable_key();
-  ::std::string* release_key();
-  void set_allocated_key(::std::string* key);
-
-  // optional bytes end_key = 4;
-  bool has_end_key() const;
-  void clear_end_key();
-  static const int kEndKeyFieldNumber = 4;
-  const ::std::string& end_key() const;
-  void set_end_key(const ::std::string& value);
-  void set_end_key(const char* value);
-  void set_end_key(const void* value, size_t size);
-  ::std::string* mutable_end_key();
-  ::std::string* release_end_key();
-  void set_allocated_end_key(::std::string* end_key);
-
   // optional .cockroach.roachpb.ReplicaDescriptor replica = 5;
   bool has_replica() const;
   void clear_replica();
@@ -5664,10 +5640,6 @@ class BatchRequest_Header : public ::google::protobuf::Message {
   inline void clear_has_timestamp();
   inline void set_has_cmd_id();
   inline void clear_has_cmd_id();
-  inline void set_has_key();
-  inline void clear_has_key();
-  inline void set_has_end_key();
-  inline void clear_has_end_key();
   inline void set_has_replica();
   inline void clear_has_replica();
   inline void set_has_range_id();
@@ -5684,8 +5656,6 @@ class BatchRequest_Header : public ::google::protobuf::Message {
   mutable int _cached_size_;
   ::cockroach::roachpb::Timestamp* timestamp_;
   ::cockroach::roachpb::ClientCmdID* cmd_id_;
-  ::google::protobuf::internal::ArenaStringPtr key_;
-  ::google::protobuf::internal::ArenaStringPtr end_key_;
   ::cockroach::roachpb::ReplicaDescriptor* replica_;
   ::google::protobuf::int64 range_id_;
   ::cockroach::roachpb::Transaction* txn_;
@@ -11676,121 +11646,15 @@ inline void BatchRequest_Header::set_allocated_cmd_id(::cockroach::roachpb::Clie
   // @@protoc_insertion_point(field_set_allocated:cockroach.roachpb.BatchRequest.Header.cmd_id)
 }
 
-// optional bytes key = 3;
-inline bool BatchRequest_Header::has_key() const {
-  return (_has_bits_[0] & 0x00000004u) != 0;
-}
-inline void BatchRequest_Header::set_has_key() {
-  _has_bits_[0] |= 0x00000004u;
-}
-inline void BatchRequest_Header::clear_has_key() {
-  _has_bits_[0] &= ~0x00000004u;
-}
-inline void BatchRequest_Header::clear_key() {
-  key_.ClearToEmptyNoArena(&::google::protobuf::internal::GetEmptyStringAlreadyInited());
-  clear_has_key();
-}
-inline const ::std::string& BatchRequest_Header::key() const {
-  // @@protoc_insertion_point(field_get:cockroach.roachpb.BatchRequest.Header.key)
-  return key_.GetNoArena(&::google::protobuf::internal::GetEmptyStringAlreadyInited());
-}
-inline void BatchRequest_Header::set_key(const ::std::string& value) {
-  set_has_key();
-  key_.SetNoArena(&::google::protobuf::internal::GetEmptyStringAlreadyInited(), value);
-  // @@protoc_insertion_point(field_set:cockroach.roachpb.BatchRequest.Header.key)
-}
-inline void BatchRequest_Header::set_key(const char* value) {
-  set_has_key();
-  key_.SetNoArena(&::google::protobuf::internal::GetEmptyStringAlreadyInited(), ::std::string(value));
-  // @@protoc_insertion_point(field_set_char:cockroach.roachpb.BatchRequest.Header.key)
-}
-inline void BatchRequest_Header::set_key(const void* value, size_t size) {
-  set_has_key();
-  key_.SetNoArena(&::google::protobuf::internal::GetEmptyStringAlreadyInited(),
-      ::std::string(reinterpret_cast<const char*>(value), size));
-  // @@protoc_insertion_point(field_set_pointer:cockroach.roachpb.BatchRequest.Header.key)
-}
-inline ::std::string* BatchRequest_Header::mutable_key() {
-  set_has_key();
-  // @@protoc_insertion_point(field_mutable:cockroach.roachpb.BatchRequest.Header.key)
-  return key_.MutableNoArena(&::google::protobuf::internal::GetEmptyStringAlreadyInited());
-}
-inline ::std::string* BatchRequest_Header::release_key() {
-  clear_has_key();
-  return key_.ReleaseNoArena(&::google::protobuf::internal::GetEmptyStringAlreadyInited());
-}
-inline void BatchRequest_Header::set_allocated_key(::std::string* key) {
-  if (key != NULL) {
-    set_has_key();
-  } else {
-    clear_has_key();
-  }
-  key_.SetAllocatedNoArena(&::google::protobuf::internal::GetEmptyStringAlreadyInited(), key);
-  // @@protoc_insertion_point(field_set_allocated:cockroach.roachpb.BatchRequest.Header.key)
-}
-
-// optional bytes end_key = 4;
-inline bool BatchRequest_Header::has_end_key() const {
-  return (_has_bits_[0] & 0x00000008u) != 0;
-}
-inline void BatchRequest_Header::set_has_end_key() {
-  _has_bits_[0] |= 0x00000008u;
-}
-inline void BatchRequest_Header::clear_has_end_key() {
-  _has_bits_[0] &= ~0x00000008u;
-}
-inline void BatchRequest_Header::clear_end_key() {
-  end_key_.ClearToEmptyNoArena(&::google::protobuf::internal::GetEmptyStringAlreadyInited());
-  clear_has_end_key();
-}
-inline const ::std::string& BatchRequest_Header::end_key() const {
-  // @@protoc_insertion_point(field_get:cockroach.roachpb.BatchRequest.Header.end_key)
-  return end_key_.GetNoArena(&::google::protobuf::internal::GetEmptyStringAlreadyInited());
-}
-inline void BatchRequest_Header::set_end_key(const ::std::string& value) {
-  set_has_end_key();
-  end_key_.SetNoArena(&::google::protobuf::internal::GetEmptyStringAlreadyInited(), value);
-  // @@protoc_insertion_point(field_set:cockroach.roachpb.BatchRequest.Header.end_key)
-}
-inline void BatchRequest_Header::set_end_key(const char* value) {
-  set_has_end_key();
-  end_key_.SetNoArena(&::google::protobuf::internal::GetEmptyStringAlreadyInited(), ::std::string(value));
-  // @@protoc_insertion_point(field_set_char:cockroach.roachpb.BatchRequest.Header.end_key)
-}
-inline void BatchRequest_Header::set_end_key(const void* value, size_t size) {
-  set_has_end_key();
-  end_key_.SetNoArena(&::google::protobuf::internal::GetEmptyStringAlreadyInited(),
-      ::std::string(reinterpret_cast<const char*>(value), size));
-  // @@protoc_insertion_point(field_set_pointer:cockroach.roachpb.BatchRequest.Header.end_key)
-}
-inline ::std::string* BatchRequest_Header::mutable_end_key() {
-  set_has_end_key();
-  // @@protoc_insertion_point(field_mutable:cockroach.roachpb.BatchRequest.Header.end_key)
-  return end_key_.MutableNoArena(&::google::protobuf::internal::GetEmptyStringAlreadyInited());
-}
-inline ::std::string* BatchRequest_Header::release_end_key() {
-  clear_has_end_key();
-  return end_key_.ReleaseNoArena(&::google::protobuf::internal::GetEmptyStringAlreadyInited());
-}
-inline void BatchRequest_Header::set_allocated_end_key(::std::string* end_key) {
-  if (end_key != NULL) {
-    set_has_end_key();
-  } else {
-    clear_has_end_key();
-  }
-  end_key_.SetAllocatedNoArena(&::google::protobuf::internal::GetEmptyStringAlreadyInited(), end_key);
-  // @@protoc_insertion_point(field_set_allocated:cockroach.roachpb.BatchRequest.Header.end_key)
-}
-
 // optional .cockroach.roachpb.ReplicaDescriptor replica = 5;
 inline bool BatchRequest_Header::has_replica() const {
-  return (_has_bits_[0] & 0x00000010u) != 0;
+  return (_has_bits_[0] & 0x00000004u) != 0;
 }
 inline void BatchRequest_Header::set_has_replica() {
-  _has_bits_[0] |= 0x00000010u;
+  _has_bits_[0] |= 0x00000004u;
 }
 inline void BatchRequest_Header::clear_has_replica() {
-  _has_bits_[0] &= ~0x00000010u;
+  _has_bits_[0] &= ~0x00000004u;
 }
 inline void BatchRequest_Header::clear_replica() {
   if (replica_ != NULL) replica_->::cockroach::roachpb::ReplicaDescriptor::Clear();
@@ -11827,13 +11691,13 @@ inline void BatchRequest_Header::set_allocated_replica(::cockroach::roachpb::Rep
 
 // optional int64 range_id = 6;
 inline bool BatchRequest_Header::has_range_id() const {
-  return (_has_bits_[0] & 0x00000020u) != 0;
+  return (_has_bits_[0] & 0x00000008u) != 0;
 }
 inline void BatchRequest_Header::set_has_range_id() {
-  _has_bits_[0] |= 0x00000020u;
+  _has_bits_[0] |= 0x00000008u;
 }
 inline void BatchRequest_Header::clear_has_range_id() {
-  _has_bits_[0] &= ~0x00000020u;
+  _has_bits_[0] &= ~0x00000008u;
 }
 inline void BatchRequest_Header::clear_range_id() {
   range_id_ = GOOGLE_LONGLONG(0);
@@ -11851,13 +11715,13 @@ inline void BatchRequest_Header::set_range_id(::google::protobuf::int64 value) {
 
 // optional int32 user_priority = 7 [default = 1];
 inline bool BatchRequest_Header::has_user_priority() const {
-  return (_has_bits_[0] & 0x00000040u) != 0;
+  return (_has_bits_[0] & 0x00000010u) != 0;
 }
 inline void BatchRequest_Header::set_has_user_priority() {
-  _has_bits_[0] |= 0x00000040u;
+  _has_bits_[0] |= 0x00000010u;
 }
 inline void BatchRequest_Header::clear_has_user_priority() {
-  _has_bits_[0] &= ~0x00000040u;
+  _has_bits_[0] &= ~0x00000010u;
 }
 inline void BatchRequest_Header::clear_user_priority() {
   user_priority_ = 1;
@@ -11875,13 +11739,13 @@ inline void BatchRequest_Header::set_user_priority(::google::protobuf::int32 val
 
 // optional .cockroach.roachpb.Transaction txn = 8;
 inline bool BatchRequest_Header::has_txn() const {
-  return (_has_bits_[0] & 0x00000080u) != 0;
+  return (_has_bits_[0] & 0x00000020u) != 0;
 }
 inline void BatchRequest_Header::set_has_txn() {
-  _has_bits_[0] |= 0x00000080u;
+  _has_bits_[0] |= 0x00000020u;
 }
 inline void BatchRequest_Header::clear_has_txn() {
-  _has_bits_[0] &= ~0x00000080u;
+  _has_bits_[0] &= ~0x00000020u;
 }
 inline void BatchRequest_Header::clear_txn() {
   if (txn_ != NULL) txn_->::cockroach::roachpb::Transaction::Clear();
@@ -11918,13 +11782,13 @@ inline void BatchRequest_Header::set_allocated_txn(::cockroach::roachpb::Transac
 
 // optional .cockroach.roachpb.ReadConsistencyType read_consistency = 9;
 inline bool BatchRequest_Header::has_read_consistency() const {
-  return (_has_bits_[0] & 0x00000100u) != 0;
+  return (_has_bits_[0] & 0x00000040u) != 0;
 }
 inline void BatchRequest_Header::set_has_read_consistency() {
-  _has_bits_[0] |= 0x00000100u;
+  _has_bits_[0] |= 0x00000040u;
 }
 inline void BatchRequest_Header::clear_has_read_consistency() {
-  _has_bits_[0] &= ~0x00000100u;
+  _has_bits_[0] &= ~0x00000040u;
 }
 inline void BatchRequest_Header::clear_read_consistency() {
   read_consistency_ = 0;

--- a/storage/engine/rocksdb/cockroach/roachpb/api.pb.h
+++ b/storage/engine/rocksdb/cockroach/roachpb/api.pb.h
@@ -6196,6 +6196,7 @@ inline void RequestHeader::set_allocated_txn(::cockroach::roachpb::Transaction* 
 
 // optional .cockroach.roachpb.ReadConsistencyType read_consistency = 9;
 inline bool RequestHeader::has_read_consistency() const {
+<<<<<<< HEAD
   return (_has_bits_[0] & 0x00000010u) != 0;
 }
 inline void RequestHeader::set_has_read_consistency() {
@@ -6203,6 +6204,15 @@ inline void RequestHeader::set_has_read_consistency() {
 }
 inline void RequestHeader::clear_has_read_consistency() {
   _has_bits_[0] &= ~0x00000010u;
+=======
+  return (_has_bits_[0] & 0x00000020u) != 0;
+}
+inline void RequestHeader::set_has_read_consistency() {
+  _has_bits_[0] |= 0x00000020u;
+}
+inline void RequestHeader::clear_has_read_consistency() {
+  _has_bits_[0] &= ~0x00000020u;
+>>>>>>> a0fb5b0... make RequestHeader.ReadConsistency obsolete
 }
 inline void RequestHeader::clear_read_consistency() {
   read_consistency_ = 0;

--- a/storage/engine/rocksdb/cockroach/roachpb/api.pb.h
+++ b/storage/engine/rocksdb/cockroach/roachpb/api.pb.h
@@ -324,13 +324,6 @@ class RequestHeader : public ::google::protobuf::Message {
   ::std::string* release_end_key();
   void set_allocated_end_key(::std::string* end_key);
 
-  // optional int32 user_priority = 7 [default = 1];
-  bool has_user_priority() const;
-  void clear_user_priority();
-  static const int kUserPriorityFieldNumber = 7;
-  ::google::protobuf::int32 user_priority() const;
-  void set_user_priority(::google::protobuf::int32 value);
-
   // optional .cockroach.roachpb.Transaction txn = 8;
   bool has_txn() const;
   void clear_txn();
@@ -346,8 +339,6 @@ class RequestHeader : public ::google::protobuf::Message {
   inline void clear_has_key();
   inline void set_has_end_key();
   inline void clear_has_end_key();
-  inline void set_has_user_priority();
-  inline void clear_has_user_priority();
   inline void set_has_txn();
   inline void clear_has_txn();
 
@@ -357,7 +348,6 @@ class RequestHeader : public ::google::protobuf::Message {
   ::google::protobuf::internal::ArenaStringPtr key_;
   ::google::protobuf::internal::ArenaStringPtr end_key_;
   ::cockroach::roachpb::Transaction* txn_;
-  ::google::protobuf::int32 user_priority_;
   friend void  protobuf_AddDesc_cockroach_2froachpb_2fapi_2eproto();
   friend void protobuf_AssignDesc_cockroach_2froachpb_2fapi_2eproto();
   friend void protobuf_ShutdownFile_cockroach_2froachpb_2fapi_2eproto();
@@ -6117,39 +6107,15 @@ inline void RequestHeader::set_allocated_end_key(::std::string* end_key) {
   // @@protoc_insertion_point(field_set_allocated:cockroach.roachpb.RequestHeader.end_key)
 }
 
-// optional int32 user_priority = 7 [default = 1];
-inline bool RequestHeader::has_user_priority() const {
-  return (_has_bits_[0] & 0x00000004u) != 0;
-}
-inline void RequestHeader::set_has_user_priority() {
-  _has_bits_[0] |= 0x00000004u;
-}
-inline void RequestHeader::clear_has_user_priority() {
-  _has_bits_[0] &= ~0x00000004u;
-}
-inline void RequestHeader::clear_user_priority() {
-  user_priority_ = 1;
-  clear_has_user_priority();
-}
-inline ::google::protobuf::int32 RequestHeader::user_priority() const {
-  // @@protoc_insertion_point(field_get:cockroach.roachpb.RequestHeader.user_priority)
-  return user_priority_;
-}
-inline void RequestHeader::set_user_priority(::google::protobuf::int32 value) {
-  set_has_user_priority();
-  user_priority_ = value;
-  // @@protoc_insertion_point(field_set:cockroach.roachpb.RequestHeader.user_priority)
-}
-
 // optional .cockroach.roachpb.Transaction txn = 8;
 inline bool RequestHeader::has_txn() const {
-  return (_has_bits_[0] & 0x00000008u) != 0;
+  return (_has_bits_[0] & 0x00000004u) != 0;
 }
 inline void RequestHeader::set_has_txn() {
-  _has_bits_[0] |= 0x00000008u;
+  _has_bits_[0] |= 0x00000004u;
 }
 inline void RequestHeader::clear_has_txn() {
-  _has_bits_[0] &= ~0x00000008u;
+  _has_bits_[0] &= ~0x00000004u;
 }
 inline void RequestHeader::clear_txn() {
   if (txn_ != NULL) txn_->::cockroach::roachpb::Transaction::Clear();

--- a/storage/engine/rocksdb/cockroach/roachpb/api.pb.h
+++ b/storage/engine/rocksdb/cockroach/roachpb/api.pb.h
@@ -300,15 +300,6 @@ class RequestHeader : public ::google::protobuf::Message {
 
   // accessors -------------------------------------------------------
 
-  // optional .cockroach.roachpb.ClientCmdID cmd_id = 2;
-  bool has_cmd_id() const;
-  void clear_cmd_id();
-  static const int kCmdIdFieldNumber = 2;
-  const ::cockroach::roachpb::ClientCmdID& cmd_id() const;
-  ::cockroach::roachpb::ClientCmdID* mutable_cmd_id();
-  ::cockroach::roachpb::ClientCmdID* release_cmd_id();
-  void set_allocated_cmd_id(::cockroach::roachpb::ClientCmdID* cmd_id);
-
   // optional bytes key = 3;
   bool has_key() const;
   void clear_key();
@@ -358,8 +349,6 @@ class RequestHeader : public ::google::protobuf::Message {
 
   // @@protoc_insertion_point(class_scope:cockroach.roachpb.RequestHeader)
  private:
-  inline void set_has_cmd_id();
-  inline void clear_has_cmd_id();
   inline void set_has_key();
   inline void clear_has_key();
   inline void set_has_end_key();
@@ -374,7 +363,6 @@ class RequestHeader : public ::google::protobuf::Message {
   ::google::protobuf::internal::InternalMetadataWithArena _internal_metadata_;
   ::google::protobuf::uint32 _has_bits_[1];
   mutable int _cached_size_;
-  ::cockroach::roachpb::ClientCmdID* cmd_id_;
   ::google::protobuf::internal::ArenaStringPtr key_;
   ::google::protobuf::internal::ArenaStringPtr end_key_;
   ::cockroach::roachpb::Transaction* txn_;
@@ -6033,58 +6021,15 @@ inline void ClientCmdID::set_random(::google::protobuf::int64 value) {
 
 // RequestHeader
 
-// optional .cockroach.roachpb.ClientCmdID cmd_id = 2;
-inline bool RequestHeader::has_cmd_id() const {
-  return (_has_bits_[0] & 0x00000001u) != 0;
-}
-inline void RequestHeader::set_has_cmd_id() {
-  _has_bits_[0] |= 0x00000001u;
-}
-inline void RequestHeader::clear_has_cmd_id() {
-  _has_bits_[0] &= ~0x00000001u;
-}
-inline void RequestHeader::clear_cmd_id() {
-  if (cmd_id_ != NULL) cmd_id_->::cockroach::roachpb::ClientCmdID::Clear();
-  clear_has_cmd_id();
-}
-inline const ::cockroach::roachpb::ClientCmdID& RequestHeader::cmd_id() const {
-  // @@protoc_insertion_point(field_get:cockroach.roachpb.RequestHeader.cmd_id)
-  return cmd_id_ != NULL ? *cmd_id_ : *default_instance_->cmd_id_;
-}
-inline ::cockroach::roachpb::ClientCmdID* RequestHeader::mutable_cmd_id() {
-  set_has_cmd_id();
-  if (cmd_id_ == NULL) {
-    cmd_id_ = new ::cockroach::roachpb::ClientCmdID;
-  }
-  // @@protoc_insertion_point(field_mutable:cockroach.roachpb.RequestHeader.cmd_id)
-  return cmd_id_;
-}
-inline ::cockroach::roachpb::ClientCmdID* RequestHeader::release_cmd_id() {
-  clear_has_cmd_id();
-  ::cockroach::roachpb::ClientCmdID* temp = cmd_id_;
-  cmd_id_ = NULL;
-  return temp;
-}
-inline void RequestHeader::set_allocated_cmd_id(::cockroach::roachpb::ClientCmdID* cmd_id) {
-  delete cmd_id_;
-  cmd_id_ = cmd_id;
-  if (cmd_id) {
-    set_has_cmd_id();
-  } else {
-    clear_has_cmd_id();
-  }
-  // @@protoc_insertion_point(field_set_allocated:cockroach.roachpb.RequestHeader.cmd_id)
-}
-
 // optional bytes key = 3;
 inline bool RequestHeader::has_key() const {
-  return (_has_bits_[0] & 0x00000002u) != 0;
+  return (_has_bits_[0] & 0x00000001u) != 0;
 }
 inline void RequestHeader::set_has_key() {
-  _has_bits_[0] |= 0x00000002u;
+  _has_bits_[0] |= 0x00000001u;
 }
 inline void RequestHeader::clear_has_key() {
-  _has_bits_[0] &= ~0x00000002u;
+  _has_bits_[0] &= ~0x00000001u;
 }
 inline void RequestHeader::clear_key() {
   key_.ClearToEmptyNoArena(&::google::protobuf::internal::GetEmptyStringAlreadyInited());
@@ -6131,13 +6076,13 @@ inline void RequestHeader::set_allocated_key(::std::string* key) {
 
 // optional bytes end_key = 4;
 inline bool RequestHeader::has_end_key() const {
-  return (_has_bits_[0] & 0x00000004u) != 0;
+  return (_has_bits_[0] & 0x00000002u) != 0;
 }
 inline void RequestHeader::set_has_end_key() {
-  _has_bits_[0] |= 0x00000004u;
+  _has_bits_[0] |= 0x00000002u;
 }
 inline void RequestHeader::clear_has_end_key() {
-  _has_bits_[0] &= ~0x00000004u;
+  _has_bits_[0] &= ~0x00000002u;
 }
 inline void RequestHeader::clear_end_key() {
   end_key_.ClearToEmptyNoArena(&::google::protobuf::internal::GetEmptyStringAlreadyInited());
@@ -6184,13 +6129,13 @@ inline void RequestHeader::set_allocated_end_key(::std::string* end_key) {
 
 // optional int32 user_priority = 7 [default = 1];
 inline bool RequestHeader::has_user_priority() const {
-  return (_has_bits_[0] & 0x00000008u) != 0;
+  return (_has_bits_[0] & 0x00000004u) != 0;
 }
 inline void RequestHeader::set_has_user_priority() {
-  _has_bits_[0] |= 0x00000008u;
+  _has_bits_[0] |= 0x00000004u;
 }
 inline void RequestHeader::clear_has_user_priority() {
-  _has_bits_[0] &= ~0x00000008u;
+  _has_bits_[0] &= ~0x00000004u;
 }
 inline void RequestHeader::clear_user_priority() {
   user_priority_ = 1;
@@ -6208,13 +6153,13 @@ inline void RequestHeader::set_user_priority(::google::protobuf::int32 value) {
 
 // optional .cockroach.roachpb.Transaction txn = 8;
 inline bool RequestHeader::has_txn() const {
-  return (_has_bits_[0] & 0x00000010u) != 0;
+  return (_has_bits_[0] & 0x00000008u) != 0;
 }
 inline void RequestHeader::set_has_txn() {
-  _has_bits_[0] |= 0x00000010u;
+  _has_bits_[0] |= 0x00000008u;
 }
 inline void RequestHeader::clear_has_txn() {
-  _has_bits_[0] &= ~0x00000010u;
+  _has_bits_[0] &= ~0x00000008u;
 }
 inline void RequestHeader::clear_txn() {
   if (txn_ != NULL) txn_->::cockroach::roachpb::Transaction::Clear();
@@ -6251,13 +6196,13 @@ inline void RequestHeader::set_allocated_txn(::cockroach::roachpb::Transaction* 
 
 // optional .cockroach.roachpb.ReadConsistencyType read_consistency = 9;
 inline bool RequestHeader::has_read_consistency() const {
-  return (_has_bits_[0] & 0x00000020u) != 0;
+  return (_has_bits_[0] & 0x00000010u) != 0;
 }
 inline void RequestHeader::set_has_read_consistency() {
-  _has_bits_[0] |= 0x00000020u;
+  _has_bits_[0] |= 0x00000010u;
 }
 inline void RequestHeader::clear_has_read_consistency() {
-  _has_bits_[0] &= ~0x00000020u;
+  _has_bits_[0] &= ~0x00000010u;
 }
 inline void RequestHeader::clear_read_consistency() {
   read_consistency_ = 0;

--- a/storage/engine/rocksdb/cockroach/roachpb/api.pb.h
+++ b/storage/engine/rocksdb/cockroach/roachpb/api.pb.h
@@ -324,30 +324,18 @@ class RequestHeader : public ::google::protobuf::Message {
   ::std::string* release_end_key();
   void set_allocated_end_key(::std::string* end_key);
 
-  // optional .cockroach.roachpb.Transaction txn = 8;
-  bool has_txn() const;
-  void clear_txn();
-  static const int kTxnFieldNumber = 8;
-  const ::cockroach::roachpb::Transaction& txn() const;
-  ::cockroach::roachpb::Transaction* mutable_txn();
-  ::cockroach::roachpb::Transaction* release_txn();
-  void set_allocated_txn(::cockroach::roachpb::Transaction* txn);
-
   // @@protoc_insertion_point(class_scope:cockroach.roachpb.RequestHeader)
  private:
   inline void set_has_key();
   inline void clear_has_key();
   inline void set_has_end_key();
   inline void clear_has_end_key();
-  inline void set_has_txn();
-  inline void clear_has_txn();
 
   ::google::protobuf::internal::InternalMetadataWithArena _internal_metadata_;
   ::google::protobuf::uint32 _has_bits_[1];
   mutable int _cached_size_;
   ::google::protobuf::internal::ArenaStringPtr key_;
   ::google::protobuf::internal::ArenaStringPtr end_key_;
-  ::cockroach::roachpb::Transaction* txn_;
   friend void  protobuf_AddDesc_cockroach_2froachpb_2fapi_2eproto();
   friend void protobuf_AssignDesc_cockroach_2froachpb_2fapi_2eproto();
   friend void protobuf_ShutdownFile_cockroach_2froachpb_2fapi_2eproto();
@@ -6105,49 +6093,6 @@ inline void RequestHeader::set_allocated_end_key(::std::string* end_key) {
   }
   end_key_.SetAllocatedNoArena(&::google::protobuf::internal::GetEmptyStringAlreadyInited(), end_key);
   // @@protoc_insertion_point(field_set_allocated:cockroach.roachpb.RequestHeader.end_key)
-}
-
-// optional .cockroach.roachpb.Transaction txn = 8;
-inline bool RequestHeader::has_txn() const {
-  return (_has_bits_[0] & 0x00000004u) != 0;
-}
-inline void RequestHeader::set_has_txn() {
-  _has_bits_[0] |= 0x00000004u;
-}
-inline void RequestHeader::clear_has_txn() {
-  _has_bits_[0] &= ~0x00000004u;
-}
-inline void RequestHeader::clear_txn() {
-  if (txn_ != NULL) txn_->::cockroach::roachpb::Transaction::Clear();
-  clear_has_txn();
-}
-inline const ::cockroach::roachpb::Transaction& RequestHeader::txn() const {
-  // @@protoc_insertion_point(field_get:cockroach.roachpb.RequestHeader.txn)
-  return txn_ != NULL ? *txn_ : *default_instance_->txn_;
-}
-inline ::cockroach::roachpb::Transaction* RequestHeader::mutable_txn() {
-  set_has_txn();
-  if (txn_ == NULL) {
-    txn_ = new ::cockroach::roachpb::Transaction;
-  }
-  // @@protoc_insertion_point(field_mutable:cockroach.roachpb.RequestHeader.txn)
-  return txn_;
-}
-inline ::cockroach::roachpb::Transaction* RequestHeader::release_txn() {
-  clear_has_txn();
-  ::cockroach::roachpb::Transaction* temp = txn_;
-  txn_ = NULL;
-  return temp;
-}
-inline void RequestHeader::set_allocated_txn(::cockroach::roachpb::Transaction* txn) {
-  delete txn_;
-  txn_ = txn;
-  if (txn) {
-    set_has_txn();
-  } else {
-    clear_has_txn();
-  }
-  // @@protoc_insertion_point(field_set_allocated:cockroach.roachpb.RequestHeader.txn)
 }
 
 // -------------------------------------------------------------------

--- a/storage/engine/rocksdb/cockroach/roachpb/api.pb.h
+++ b/storage/engine/rocksdb/cockroach/roachpb/api.pb.h
@@ -340,13 +340,6 @@ class RequestHeader : public ::google::protobuf::Message {
   ::cockroach::roachpb::Transaction* release_txn();
   void set_allocated_txn(::cockroach::roachpb::Transaction* txn);
 
-  // optional .cockroach.roachpb.ReadConsistencyType read_consistency = 9;
-  bool has_read_consistency() const;
-  void clear_read_consistency();
-  static const int kReadConsistencyFieldNumber = 9;
-  ::cockroach::roachpb::ReadConsistencyType read_consistency() const;
-  void set_read_consistency(::cockroach::roachpb::ReadConsistencyType value);
-
   // @@protoc_insertion_point(class_scope:cockroach.roachpb.RequestHeader)
  private:
   inline void set_has_key();
@@ -357,8 +350,6 @@ class RequestHeader : public ::google::protobuf::Message {
   inline void clear_has_user_priority();
   inline void set_has_txn();
   inline void clear_has_txn();
-  inline void set_has_read_consistency();
-  inline void clear_has_read_consistency();
 
   ::google::protobuf::internal::InternalMetadataWithArena _internal_metadata_;
   ::google::protobuf::uint32 _has_bits_[1];
@@ -367,7 +358,6 @@ class RequestHeader : public ::google::protobuf::Message {
   ::google::protobuf::internal::ArenaStringPtr end_key_;
   ::cockroach::roachpb::Transaction* txn_;
   ::google::protobuf::int32 user_priority_;
-  int read_consistency_;
   friend void  protobuf_AddDesc_cockroach_2froachpb_2fapi_2eproto();
   friend void protobuf_AssignDesc_cockroach_2froachpb_2fapi_2eproto();
   friend void protobuf_ShutdownFile_cockroach_2froachpb_2fapi_2eproto();
@@ -6192,41 +6182,6 @@ inline void RequestHeader::set_allocated_txn(::cockroach::roachpb::Transaction* 
     clear_has_txn();
   }
   // @@protoc_insertion_point(field_set_allocated:cockroach.roachpb.RequestHeader.txn)
-}
-
-// optional .cockroach.roachpb.ReadConsistencyType read_consistency = 9;
-inline bool RequestHeader::has_read_consistency() const {
-<<<<<<< HEAD
-  return (_has_bits_[0] & 0x00000010u) != 0;
-}
-inline void RequestHeader::set_has_read_consistency() {
-  _has_bits_[0] |= 0x00000010u;
-}
-inline void RequestHeader::clear_has_read_consistency() {
-  _has_bits_[0] &= ~0x00000010u;
-=======
-  return (_has_bits_[0] & 0x00000020u) != 0;
-}
-inline void RequestHeader::set_has_read_consistency() {
-  _has_bits_[0] |= 0x00000020u;
-}
-inline void RequestHeader::clear_has_read_consistency() {
-  _has_bits_[0] &= ~0x00000020u;
->>>>>>> a0fb5b0... make RequestHeader.ReadConsistency obsolete
-}
-inline void RequestHeader::clear_read_consistency() {
-  read_consistency_ = 0;
-  clear_has_read_consistency();
-}
-inline ::cockroach::roachpb::ReadConsistencyType RequestHeader::read_consistency() const {
-  // @@protoc_insertion_point(field_get:cockroach.roachpb.RequestHeader.read_consistency)
-  return static_cast< ::cockroach::roachpb::ReadConsistencyType >(read_consistency_);
-}
-inline void RequestHeader::set_read_consistency(::cockroach::roachpb::ReadConsistencyType value) {
-  assert(::cockroach::roachpb::ReadConsistencyType_IsValid(value));
-  set_has_read_consistency();
-  read_consistency_ = value;
-  // @@protoc_insertion_point(field_set:cockroach.roachpb.RequestHeader.read_consistency)
 }
 
 // -------------------------------------------------------------------

--- a/storage/engine/rocksdb/cockroach/roachpb/api.pb.h
+++ b/storage/engine/rocksdb/cockroach/roachpb/api.pb.h
@@ -333,13 +333,6 @@ class RequestHeader : public ::google::protobuf::Message {
   ::std::string* release_end_key();
   void set_allocated_end_key(::std::string* end_key);
 
-  // optional int64 range_id = 6;
-  bool has_range_id() const;
-  void clear_range_id();
-  static const int kRangeIdFieldNumber = 6;
-  ::google::protobuf::int64 range_id() const;
-  void set_range_id(::google::protobuf::int64 value);
-
   // optional int32 user_priority = 7 [default = 1];
   bool has_user_priority() const;
   void clear_user_priority();
@@ -371,8 +364,6 @@ class RequestHeader : public ::google::protobuf::Message {
   inline void clear_has_key();
   inline void set_has_end_key();
   inline void clear_has_end_key();
-  inline void set_has_range_id();
-  inline void clear_has_range_id();
   inline void set_has_user_priority();
   inline void clear_has_user_priority();
   inline void set_has_txn();
@@ -386,7 +377,6 @@ class RequestHeader : public ::google::protobuf::Message {
   ::cockroach::roachpb::ClientCmdID* cmd_id_;
   ::google::protobuf::internal::ArenaStringPtr key_;
   ::google::protobuf::internal::ArenaStringPtr end_key_;
-  ::google::protobuf::int64 range_id_;
   ::cockroach::roachpb::Transaction* txn_;
   ::google::protobuf::int32 user_priority_;
   int read_consistency_;
@@ -6192,39 +6182,15 @@ inline void RequestHeader::set_allocated_end_key(::std::string* end_key) {
   // @@protoc_insertion_point(field_set_allocated:cockroach.roachpb.RequestHeader.end_key)
 }
 
-// optional int64 range_id = 6;
-inline bool RequestHeader::has_range_id() const {
-  return (_has_bits_[0] & 0x00000008u) != 0;
-}
-inline void RequestHeader::set_has_range_id() {
-  _has_bits_[0] |= 0x00000008u;
-}
-inline void RequestHeader::clear_has_range_id() {
-  _has_bits_[0] &= ~0x00000008u;
-}
-inline void RequestHeader::clear_range_id() {
-  range_id_ = GOOGLE_LONGLONG(0);
-  clear_has_range_id();
-}
-inline ::google::protobuf::int64 RequestHeader::range_id() const {
-  // @@protoc_insertion_point(field_get:cockroach.roachpb.RequestHeader.range_id)
-  return range_id_;
-}
-inline void RequestHeader::set_range_id(::google::protobuf::int64 value) {
-  set_has_range_id();
-  range_id_ = value;
-  // @@protoc_insertion_point(field_set:cockroach.roachpb.RequestHeader.range_id)
-}
-
 // optional int32 user_priority = 7 [default = 1];
 inline bool RequestHeader::has_user_priority() const {
-  return (_has_bits_[0] & 0x00000010u) != 0;
+  return (_has_bits_[0] & 0x00000008u) != 0;
 }
 inline void RequestHeader::set_has_user_priority() {
-  _has_bits_[0] |= 0x00000010u;
+  _has_bits_[0] |= 0x00000008u;
 }
 inline void RequestHeader::clear_has_user_priority() {
-  _has_bits_[0] &= ~0x00000010u;
+  _has_bits_[0] &= ~0x00000008u;
 }
 inline void RequestHeader::clear_user_priority() {
   user_priority_ = 1;
@@ -6242,13 +6208,13 @@ inline void RequestHeader::set_user_priority(::google::protobuf::int32 value) {
 
 // optional .cockroach.roachpb.Transaction txn = 8;
 inline bool RequestHeader::has_txn() const {
-  return (_has_bits_[0] & 0x00000020u) != 0;
+  return (_has_bits_[0] & 0x00000010u) != 0;
 }
 inline void RequestHeader::set_has_txn() {
-  _has_bits_[0] |= 0x00000020u;
+  _has_bits_[0] |= 0x00000010u;
 }
 inline void RequestHeader::clear_has_txn() {
-  _has_bits_[0] &= ~0x00000020u;
+  _has_bits_[0] &= ~0x00000010u;
 }
 inline void RequestHeader::clear_txn() {
   if (txn_ != NULL) txn_->::cockroach::roachpb::Transaction::Clear();
@@ -6285,13 +6251,13 @@ inline void RequestHeader::set_allocated_txn(::cockroach::roachpb::Transaction* 
 
 // optional .cockroach.roachpb.ReadConsistencyType read_consistency = 9;
 inline bool RequestHeader::has_read_consistency() const {
-  return (_has_bits_[0] & 0x00000040u) != 0;
+  return (_has_bits_[0] & 0x00000020u) != 0;
 }
 inline void RequestHeader::set_has_read_consistency() {
-  _has_bits_[0] |= 0x00000040u;
+  _has_bits_[0] |= 0x00000020u;
 }
 inline void RequestHeader::clear_has_read_consistency() {
-  _has_bits_[0] &= ~0x00000040u;
+  _has_bits_[0] &= ~0x00000020u;
 }
 inline void RequestHeader::clear_read_consistency() {
   read_consistency_ = 0;

--- a/storage/gc_queue_test.go
+++ b/storage/gc_queue_test.go
@@ -193,7 +193,7 @@ func TestGCQueueProcess(t *testing.T) {
 				dArgs.Txn.OrigTimestamp = datum.ts
 				dArgs.Txn.Timestamp = datum.ts
 			}
-			if _, err := client.SendWrappedAt(tc.rng, tc.rng.context(), datum.ts, &dArgs); err != nil {
+			if _, err := client.SendWrappedWith(tc.rng, tc.rng.context(), roachpb.BatchRequest_Header{Timestamp: datum.ts}, &dArgs); err != nil {
 				t.Fatalf("%d: could not delete data: %s", i, err)
 			}
 		} else {
@@ -203,7 +203,7 @@ func TestGCQueueProcess(t *testing.T) {
 				pArgs.Txn.OrigTimestamp = datum.ts
 				pArgs.Txn.Timestamp = datum.ts
 			}
-			if _, err := client.SendWrappedAt(tc.rng, tc.rng.context(), datum.ts, &pArgs); err != nil {
+			if _, err := client.SendWrappedWith(tc.rng, tc.rng.context(), roachpb.BatchRequest_Header{Timestamp: datum.ts}, &pArgs); err != nil {
 				t.Fatalf("%d: could not put data: %s", i, err)
 			}
 		}

--- a/storage/gc_queue_test.go
+++ b/storage/gc_queue_test.go
@@ -193,17 +193,17 @@ func TestGCQueueProcess(t *testing.T) {
 				dArgs.Txn.OrigTimestamp = datum.ts
 				dArgs.Txn.Timestamp = datum.ts
 			}
-			if _, err := client.SendWrappedWith(tc.rng, tc.rng.context(), roachpb.BatchRequest_Header{Timestamp: datum.ts}, &dArgs); err != nil {
+			if _, err := client.SendWrappedWith(tc.Sender(), tc.rng.context(), roachpb.BatchRequest_Header{Timestamp: datum.ts}, &dArgs); err != nil {
 				t.Fatalf("%d: could not delete data: %s", i, err)
 			}
 		} else {
-			pArgs := putArgs(datum.key, []byte("value"), tc.rng.Desc().RangeID, tc.store.StoreID())
+			pArgs := putArgs(datum.key, []byte("value"))
 			if datum.txn {
 				pArgs.Txn = newTransaction("test", datum.key, 1, roachpb.SERIALIZABLE, tc.clock)
 				pArgs.Txn.OrigTimestamp = datum.ts
 				pArgs.Txn.Timestamp = datum.ts
 			}
-			if _, err := client.SendWrappedWith(tc.rng, tc.rng.context(), roachpb.BatchRequest_Header{Timestamp: datum.ts}, &pArgs); err != nil {
+			if _, err := client.SendWrappedWith(tc.Sender(), tc.rng.context(), roachpb.BatchRequest_Header{Timestamp: datum.ts}, &pArgs); err != nil {
 				t.Fatalf("%d: could not put data: %s", i, err)
 			}
 		}
@@ -332,9 +332,9 @@ func TestGCQueueIntentResolution(t *testing.T) {
 		// 5 puts per transaction.
 		// TODO(spencerkimball): benchmark with ~50k.
 		for j := 0; j < 5; j++ {
-			pArgs := putArgs(roachpb.Key(fmt.Sprintf("%d-%05d", i, j)), []byte("value"), tc.rng.Desc().RangeID, tc.store.StoreID())
+			pArgs := putArgs(roachpb.Key(fmt.Sprintf("%d-%05d", i, j)), []byte("value"))
 			pArgs.Txn = txns[i]
-			if _, err := client.SendWrapped(tc.rng, tc.rng.context(), &pArgs); err != nil {
+			if _, err := client.SendWrapped(tc.Sender(), tc.rng.context(), &pArgs); err != nil {
 				t.Fatalf("%d: could not put data: %s", i, err)
 			}
 		}

--- a/storage/gc_queue_test.go
+++ b/storage/gc_queue_test.go
@@ -187,7 +187,7 @@ func TestGCQueueProcess(t *testing.T) {
 
 	for i, datum := range data {
 		if datum.del {
-			dArgs := deleteArgs(datum.key, tc.rng.Desc().RangeID, tc.store.StoreID())
+			dArgs := deleteArgs(datum.key)
 			if datum.txn {
 				dArgs.Txn = newTransaction("test", datum.key, 1, roachpb.SERIALIZABLE, tc.clock)
 				dArgs.Txn.OrigTimestamp = datum.ts

--- a/storage/replica.go
+++ b/storage/replica.go
@@ -344,11 +344,6 @@ func (r *Replica) requestLeaderLease(timestamp roachpb.Timestamp) error {
 	args := &roachpb.LeaderLeaseRequest{
 		RequestHeader: roachpb.RequestHeader{
 			Key: desc.StartKey,
-			CmdID: roachpb.ClientCmdID{
-				WallTime: r.rm.Clock().Now().WallTime,
-				Random:   rand.Int63(),
-			},
-			RangeID: desc.RangeID,
 		},
 		Lease: roachpb.Lease{
 			Start:      timestamp,
@@ -357,6 +352,11 @@ func (r *Replica) requestLeaderLease(timestamp roachpb.Timestamp) error {
 		},
 	}
 	ba := &roachpb.BatchRequest{}
+	ba.RangeID = desc.RangeID
+	ba.CmdID = roachpb.ClientCmdID{
+		WallTime: r.rm.Clock().Now().WallTime,
+		Random:   rand.Int63(),
+	}
 	ba.Add(args)
 	// Send lease request directly to raft in order to skip unnecessary
 	// checks from normal request machinery, (e.g. the command queue).

--- a/storage/replica.go
+++ b/storage/replica.go
@@ -1180,7 +1180,10 @@ func (r *Replica) executeBatch(batch engine.Engine, ms *engine.MVCCStats, ba *ro
 
 		args.Header().Txn = ba.Txn // use latest Txn
 
-		reply, curIntents, err := r.executeCmd(batch, ms, ts, args)
+		var header roachpb.BatchRequest_Header
+		header.Timestamp = ts
+
+		reply, curIntents, err := r.executeCmd(batch, ms, header, args)
 		{
 			// Undo any changes to the header.
 			*args.Header() = origHeader

--- a/storage/replica_command.go
+++ b/storage/replica_command.go
@@ -177,7 +177,7 @@ func (r *Replica) executeCmd(batch engine.Engine, ms *engine.MVCCStats, h roachp
 func (r *Replica) Get(batch engine.Engine, h roachpb.BatchRequest_Header, args roachpb.GetRequest) (roachpb.GetResponse, []roachpb.Intent, error) {
 	var reply roachpb.GetResponse
 
-	val, intents, err := engine.MVCCGet(batch, args.Key, h.Timestamp, args.ReadConsistency == roachpb.CONSISTENT, args.Txn)
+	val, intents, err := engine.MVCCGet(batch, args.Key, h.Timestamp, h.ReadConsistency == roachpb.CONSISTENT, args.Txn)
 	reply.Value = val
 	return reply, intents, err
 }
@@ -231,7 +231,7 @@ func (r *Replica) DeleteRange(batch engine.Engine, ms *engine.MVCCStats, h roach
 func (r *Replica) Scan(batch engine.Engine, h roachpb.BatchRequest_Header, args roachpb.ScanRequest) (roachpb.ScanResponse, []roachpb.Intent, error) {
 	var reply roachpb.ScanResponse
 
-	rows, intents, err := engine.MVCCScan(batch, args.Key, args.EndKey, args.MaxResults, h.Timestamp, args.ReadConsistency == roachpb.CONSISTENT, args.Txn)
+	rows, intents, err := engine.MVCCScan(batch, args.Key, args.EndKey, args.MaxResults, h.Timestamp, h.ReadConsistency == roachpb.CONSISTENT, args.Txn)
 	reply.Rows = rows
 	return reply, intents, err
 }
@@ -242,7 +242,7 @@ func (r *Replica) ReverseScan(batch engine.Engine, h roachpb.BatchRequest_Header
 	var reply roachpb.ReverseScanResponse
 
 	rows, intents, err := engine.MVCCReverseScan(batch, args.Key, args.EndKey, args.MaxResults, h.Timestamp,
-		args.ReadConsistency == roachpb.CONSISTENT, args.Txn)
+		h.ReadConsistency == roachpb.CONSISTENT, args.Txn)
 	reply.Rows = rows
 	return reply, intents, err
 }
@@ -534,7 +534,7 @@ func (r *Replica) RangeLookup(batch engine.Engine, h roachpb.BatchRequest_Header
 	if rangeCount < 1 {
 		return reply, nil, util.Errorf("Range lookup specified invalid maximum range count %d: must be > 0", rangeCount)
 	}
-	consistent := args.ReadConsistency != roachpb.INCONSISTENT
+	consistent := h.ReadConsistency != roachpb.INCONSISTENT
 	if consistent && args.ConsiderIntents {
 		return reply, nil, util.Errorf("can not read consistently and special-case intents")
 	}

--- a/storage/replica_command.go
+++ b/storage/replica_command.go
@@ -55,7 +55,7 @@ func (r *Replica) executeCmd(batch engine.Engine, ms *engine.MVCCStats, h roachp
 
 	// If a unittest filter was installed, check for an injected error; otherwise, continue.
 	if TestingCommandFilter != nil {
-		if err := TestingCommandFilter(args); err != nil {
+		if err := TestingCommandFilter(args, h); err != nil {
 			return nil, nil, err
 		}
 	}

--- a/storage/replica_command.go
+++ b/storage/replica_command.go
@@ -40,16 +40,16 @@ import (
 // appropriate storage API command. It returns the response, an error,
 // and a slice of intents that were skipped during execution.
 // If an error is returned, any returned intents should still be resolved.
-func (r *Replica) executeCmd(batch engine.Engine, ms *engine.MVCCStats, ts roachpb.Timestamp, args roachpb.Request) (roachpb.Response, []roachpb.Intent, error) {
+func (r *Replica) executeCmd(batch engine.Engine, ms *engine.MVCCStats, h roachpb.BatchRequest_Header, args roachpb.Request) (roachpb.Response, []roachpb.Intent, error) {
 	// Verify key is contained within range here to catch any range split
 	// or merge activity.
-	header := args.Header()
+	ts := h.Timestamp
 
 	if _, ok := args.(*roachpb.NoopRequest); ok {
 		return &roachpb.NoopResponse{}, nil, nil
 	}
 
-	if err := r.checkCmdHeader(header); err != nil {
+	if err := r.checkCmdHeader(args.Header()); err != nil {
 		return nil, nil, err
 	}
 
@@ -66,75 +66,75 @@ func (r *Replica) executeCmd(batch engine.Engine, ms *engine.MVCCStats, ts roach
 	switch tArgs := args.(type) {
 	case *roachpb.GetRequest:
 		var resp roachpb.GetResponse
-		resp, intents, err = r.Get(batch, ts, *tArgs)
+		resp, intents, err = r.Get(batch, h, *tArgs)
 		reply = &resp
 	case *roachpb.PutRequest:
 		var resp roachpb.PutResponse
-		resp, err = r.Put(batch, ms, ts, *tArgs)
+		resp, err = r.Put(batch, ms, h, *tArgs)
 		reply = &resp
 	case *roachpb.ConditionalPutRequest:
 		var resp roachpb.ConditionalPutResponse
-		resp, err = r.ConditionalPut(batch, ms, ts, *tArgs)
+		resp, err = r.ConditionalPut(batch, ms, h, *tArgs)
 		reply = &resp
 	case *roachpb.IncrementRequest:
 		var resp roachpb.IncrementResponse
-		resp, err = r.Increment(batch, ms, ts, *tArgs)
+		resp, err = r.Increment(batch, ms, h, *tArgs)
 		reply = &resp
 	case *roachpb.DeleteRequest:
 		var resp roachpb.DeleteResponse
-		resp, err = r.Delete(batch, ms, ts, *tArgs)
+		resp, err = r.Delete(batch, ms, h, *tArgs)
 		reply = &resp
 	case *roachpb.DeleteRangeRequest:
 		var resp roachpb.DeleteRangeResponse
-		resp, err = r.DeleteRange(batch, ms, ts, *tArgs)
+		resp, err = r.DeleteRange(batch, ms, h, *tArgs)
 		reply = &resp
 	case *roachpb.ScanRequest:
 		var resp roachpb.ScanResponse
-		resp, intents, err = r.Scan(batch, ts, *tArgs)
+		resp, intents, err = r.Scan(batch, h, *tArgs)
 		reply = &resp
 	case *roachpb.ReverseScanRequest:
 		var resp roachpb.ReverseScanResponse
-		resp, intents, err = r.ReverseScan(batch, ts, *tArgs)
+		resp, intents, err = r.ReverseScan(batch, h, *tArgs)
 		reply = &resp
 	case *roachpb.EndTransactionRequest:
 		var resp roachpb.EndTransactionResponse
-		resp, intents, err = r.EndTransaction(batch, ms, ts, *tArgs)
+		resp, intents, err = r.EndTransaction(batch, ms, h, *tArgs)
 		reply = &resp
 	case *roachpb.RangeLookupRequest:
 		var resp roachpb.RangeLookupResponse
-		resp, intents, err = r.RangeLookup(batch, ts, *tArgs)
+		resp, intents, err = r.RangeLookup(batch, h, *tArgs)
 		reply = &resp
 	case *roachpb.HeartbeatTxnRequest:
 		var resp roachpb.HeartbeatTxnResponse
-		resp, err = r.HeartbeatTxn(batch, ms, ts, *tArgs)
+		resp, err = r.HeartbeatTxn(batch, ms, h, *tArgs)
 		reply = &resp
 	case *roachpb.GCRequest:
 		var resp roachpb.GCResponse
-		resp, err = r.GC(batch, ms, ts, *tArgs)
+		resp, err = r.GC(batch, ms, h, *tArgs)
 		reply = &resp
 	case *roachpb.PushTxnRequest:
 		var resp roachpb.PushTxnResponse
-		resp, err = r.PushTxn(batch, ms, ts, *tArgs)
+		resp, err = r.PushTxn(batch, ms, h, *tArgs)
 		reply = &resp
 	case *roachpb.ResolveIntentRequest:
 		var resp roachpb.ResolveIntentResponse
-		resp, err = r.ResolveIntent(batch, ms, ts, *tArgs)
+		resp, err = r.ResolveIntent(batch, ms, h, *tArgs)
 		reply = &resp
 	case *roachpb.ResolveIntentRangeRequest:
 		var resp roachpb.ResolveIntentRangeResponse
-		resp, err = r.ResolveIntentRange(batch, ms, ts, *tArgs)
+		resp, err = r.ResolveIntentRange(batch, ms, h, *tArgs)
 		reply = &resp
 	case *roachpb.MergeRequest:
 		var resp roachpb.MergeResponse
-		resp, err = r.Merge(batch, ms, ts, *tArgs)
+		resp, err = r.Merge(batch, ms, h, *tArgs)
 		reply = &resp
 	case *roachpb.TruncateLogRequest:
 		var resp roachpb.TruncateLogResponse
-		resp, err = r.TruncateLog(batch, ms, ts, *tArgs)
+		resp, err = r.TruncateLog(batch, ms, h, *tArgs)
 		reply = &resp
 	case *roachpb.LeaderLeaseRequest:
 		var resp roachpb.LeaderLeaseResponse
-		resp, err = r.LeaderLease(batch, ms, ts, *tArgs)
+		resp, err = r.LeaderLease(batch, ms, h, *tArgs)
 		reply = &resp
 	default:
 		err = util.Errorf("unrecognized command %s", args.Method())
@@ -174,74 +174,74 @@ func (r *Replica) executeCmd(batch engine.Engine, ms *engine.MVCCStats, ts roach
 }
 
 // Get returns the value for a specified key.
-func (r *Replica) Get(batch engine.Engine, ts roachpb.Timestamp, args roachpb.GetRequest) (roachpb.GetResponse, []roachpb.Intent, error) {
+func (r *Replica) Get(batch engine.Engine, h roachpb.BatchRequest_Header, args roachpb.GetRequest) (roachpb.GetResponse, []roachpb.Intent, error) {
 	var reply roachpb.GetResponse
 
-	val, intents, err := engine.MVCCGet(batch, args.Key, ts, args.ReadConsistency == roachpb.CONSISTENT, args.Txn)
+	val, intents, err := engine.MVCCGet(batch, args.Key, h.Timestamp, args.ReadConsistency == roachpb.CONSISTENT, args.Txn)
 	reply.Value = val
 	return reply, intents, err
 }
 
 // Put sets the value for a specified key.
-func (r *Replica) Put(batch engine.Engine, ms *engine.MVCCStats, ts roachpb.Timestamp, args roachpb.PutRequest) (roachpb.PutResponse, error) {
+func (r *Replica) Put(batch engine.Engine, ms *engine.MVCCStats, h roachpb.BatchRequest_Header, args roachpb.PutRequest) (roachpb.PutResponse, error) {
 	var reply roachpb.PutResponse
 
-	return reply, engine.MVCCPut(batch, ms, args.Key, ts, args.Value, args.Txn)
+	return reply, engine.MVCCPut(batch, ms, args.Key, h.Timestamp, args.Value, args.Txn)
 }
 
 // ConditionalPut sets the value for a specified key only if
 // the expected value matches. If not, the return value contains
 // the actual value.
-func (r *Replica) ConditionalPut(batch engine.Engine, ms *engine.MVCCStats, ts roachpb.Timestamp, args roachpb.ConditionalPutRequest) (roachpb.ConditionalPutResponse, error) {
+func (r *Replica) ConditionalPut(batch engine.Engine, ms *engine.MVCCStats, h roachpb.BatchRequest_Header, args roachpb.ConditionalPutRequest) (roachpb.ConditionalPutResponse, error) {
 	var reply roachpb.ConditionalPutResponse
 
-	return reply, engine.MVCCConditionalPut(batch, ms, args.Key, ts, args.Value, args.ExpValue, args.Txn)
+	return reply, engine.MVCCConditionalPut(batch, ms, args.Key, h.Timestamp, args.Value, args.ExpValue, args.Txn)
 }
 
 // Increment increments the value (interpreted as varint64 encoded) and
 // returns the newly incremented value (encoded as varint64). If no value
 // exists for the key, zero is incremented.
-func (r *Replica) Increment(batch engine.Engine, ms *engine.MVCCStats, ts roachpb.Timestamp, args roachpb.IncrementRequest) (roachpb.IncrementResponse, error) {
+func (r *Replica) Increment(batch engine.Engine, ms *engine.MVCCStats, h roachpb.BatchRequest_Header, args roachpb.IncrementRequest) (roachpb.IncrementResponse, error) {
 	var reply roachpb.IncrementResponse
 
-	newVal, err := engine.MVCCIncrement(batch, ms, args.Key, ts, args.Txn, args.Increment)
+	newVal, err := engine.MVCCIncrement(batch, ms, args.Key, h.Timestamp, args.Txn, args.Increment)
 	reply.NewValue = newVal
 	return reply, err
 }
 
 // Delete deletes the key and value specified by key.
-func (r *Replica) Delete(batch engine.Engine, ms *engine.MVCCStats, ts roachpb.Timestamp, args roachpb.DeleteRequest) (roachpb.DeleteResponse, error) {
+func (r *Replica) Delete(batch engine.Engine, ms *engine.MVCCStats, h roachpb.BatchRequest_Header, args roachpb.DeleteRequest) (roachpb.DeleteResponse, error) {
 	var reply roachpb.DeleteResponse
 
-	return reply, engine.MVCCDelete(batch, ms, args.Key, ts, args.Txn)
+	return reply, engine.MVCCDelete(batch, ms, args.Key, h.Timestamp, args.Txn)
 }
 
 // DeleteRange deletes the range of key/value pairs specified by
 // start and end keys.
-func (r *Replica) DeleteRange(batch engine.Engine, ms *engine.MVCCStats, ts roachpb.Timestamp, args roachpb.DeleteRangeRequest) (roachpb.DeleteRangeResponse, error) {
+func (r *Replica) DeleteRange(batch engine.Engine, ms *engine.MVCCStats, h roachpb.BatchRequest_Header, args roachpb.DeleteRangeRequest) (roachpb.DeleteRangeResponse, error) {
 	var reply roachpb.DeleteRangeResponse
 
-	numDel, err := engine.MVCCDeleteRange(batch, ms, args.Key, args.EndKey, args.MaxEntriesToDelete, ts, args.Txn)
+	numDel, err := engine.MVCCDeleteRange(batch, ms, args.Key, args.EndKey, args.MaxEntriesToDelete, h.Timestamp, args.Txn)
 	reply.NumDeleted = numDel
 	return reply, err
 }
 
 // Scan scans the key range specified by start key through end key in ascending
 // order up to some maximum number of results.
-func (r *Replica) Scan(batch engine.Engine, ts roachpb.Timestamp, args roachpb.ScanRequest) (roachpb.ScanResponse, []roachpb.Intent, error) {
+func (r *Replica) Scan(batch engine.Engine, h roachpb.BatchRequest_Header, args roachpb.ScanRequest) (roachpb.ScanResponse, []roachpb.Intent, error) {
 	var reply roachpb.ScanResponse
 
-	rows, intents, err := engine.MVCCScan(batch, args.Key, args.EndKey, args.MaxResults, ts, args.ReadConsistency == roachpb.CONSISTENT, args.Txn)
+	rows, intents, err := engine.MVCCScan(batch, args.Key, args.EndKey, args.MaxResults, h.Timestamp, args.ReadConsistency == roachpb.CONSISTENT, args.Txn)
 	reply.Rows = rows
 	return reply, intents, err
 }
 
 // ReverseScan scans the key range specified by start key through end key in
 // descending order up to some maximum number of results.
-func (r *Replica) ReverseScan(batch engine.Engine, ts roachpb.Timestamp, args roachpb.ReverseScanRequest) (roachpb.ReverseScanResponse, []roachpb.Intent, error) {
+func (r *Replica) ReverseScan(batch engine.Engine, h roachpb.BatchRequest_Header, args roachpb.ReverseScanRequest) (roachpb.ReverseScanResponse, []roachpb.Intent, error) {
 	var reply roachpb.ReverseScanResponse
 
-	rows, intents, err := engine.MVCCReverseScan(batch, args.Key, args.EndKey, args.MaxResults, ts,
+	rows, intents, err := engine.MVCCReverseScan(batch, args.Key, args.EndKey, args.MaxResults, h.Timestamp,
 		args.ReadConsistency == roachpb.CONSISTENT, args.Txn)
 	reply.Rows = rows
 	return reply, intents, err
@@ -251,8 +251,9 @@ func (r *Replica) ReverseScan(batch engine.Engine, ts roachpb.Timestamp, args ro
 // transaction according to the args.Commit parameter.
 // TODO(tschottdorf): return nil reply on any error. The error itself
 // must be the authoritative source of information.
-func (r *Replica) EndTransaction(batch engine.Engine, ms *engine.MVCCStats, ts roachpb.Timestamp, args roachpb.EndTransactionRequest) (roachpb.EndTransactionResponse, []roachpb.Intent, error) {
+func (r *Replica) EndTransaction(batch engine.Engine, ms *engine.MVCCStats, h roachpb.BatchRequest_Header, args roachpb.EndTransactionRequest) (roachpb.EndTransactionResponse, []roachpb.Intent, error) {
 	var reply roachpb.EndTransactionResponse
+	ts := h.Timestamp // all we're going to use from the header.
 
 	if args.Txn == nil {
 		return reply, nil, util.Errorf("no transaction specified to EndTransaction")
@@ -525,8 +526,9 @@ func intersectIntent(intent roachpb.Intent, desc roachpb.RangeDescriptor) (middl
 // are likely to be desired by their current workload. The Reverse flag
 // specifies whether descriptors are prefetched in descending or ascending
 // order.
-func (r *Replica) RangeLookup(batch engine.Engine, ts roachpb.Timestamp, args roachpb.RangeLookupRequest) (roachpb.RangeLookupResponse, []roachpb.Intent, error) {
+func (r *Replica) RangeLookup(batch engine.Engine, h roachpb.BatchRequest_Header, args roachpb.RangeLookupRequest) (roachpb.RangeLookupResponse, []roachpb.Intent, error) {
 	var reply roachpb.RangeLookupResponse
+	ts := h.Timestamp // all we're going to use from the header.
 
 	rangeCount := int64(args.MaxRanges)
 	if rangeCount < 1 {
@@ -706,8 +708,9 @@ func (r *Replica) RangeLookup(batch engine.Engine, ts roachpb.Timestamp, args ro
 // HeartbeatTxn updates the transaction status and heartbeat
 // timestamp after receiving transaction heartbeat messages from
 // coordinator. Returns the updated transaction.
-func (r *Replica) HeartbeatTxn(batch engine.Engine, ms *engine.MVCCStats, ts roachpb.Timestamp, args roachpb.HeartbeatTxnRequest) (roachpb.HeartbeatTxnResponse, error) {
+func (r *Replica) HeartbeatTxn(batch engine.Engine, ms *engine.MVCCStats, h roachpb.BatchRequest_Header, args roachpb.HeartbeatTxnRequest) (roachpb.HeartbeatTxnResponse, error) {
 	var reply roachpb.HeartbeatTxnResponse
+	ts := h.Timestamp // all we're going to use from the header.
 
 	if args.Txn == nil {
 		return reply, util.Errorf("no transaction specified to HeartbeatTxn")
@@ -746,11 +749,11 @@ func (r *Replica) HeartbeatTxn(batch engine.Engine, ms *engine.MVCCStats, ts roa
 // specified in the arguments. MVCCGarbageCollect is invoked on each
 // listed key along with the expiration timestamp. The GC metadata
 // specified in the args is persisted after GC.
-func (r *Replica) GC(batch engine.Engine, ms *engine.MVCCStats, ts roachpb.Timestamp, args roachpb.GCRequest) (roachpb.GCResponse, error) {
+func (r *Replica) GC(batch engine.Engine, ms *engine.MVCCStats, h roachpb.BatchRequest_Header, args roachpb.GCRequest) (roachpb.GCResponse, error) {
 	var reply roachpb.GCResponse
 
 	// Garbage collect the specified keys by expiration timestamps.
-	if err := engine.MVCCGarbageCollect(batch, ms, args.Keys, ts); err != nil {
+	if err := engine.MVCCGarbageCollect(batch, ms, args.Keys, h.Timestamp); err != nil {
 		return reply, err
 	}
 
@@ -796,7 +799,7 @@ func (r *Replica) GC(batch engine.Engine, ms *engine.MVCCStats, ts roachpb.Times
 // Higher Txn Priority: If pushee txn has a higher priority than
 // pusher, return TransactionPushError. Transaction will be retried
 // with priority one less than the pushee's higher priority.
-func (r *Replica) PushTxn(batch engine.Engine, ms *engine.MVCCStats, ts roachpb.Timestamp, args roachpb.PushTxnRequest) (roachpb.PushTxnResponse, error) {
+func (r *Replica) PushTxn(batch engine.Engine, ms *engine.MVCCStats, h roachpb.BatchRequest_Header, args roachpb.PushTxnRequest) (roachpb.PushTxnResponse, error) {
 	var reply roachpb.PushTxnResponse
 
 	if !bytes.Equal(args.Key, args.PusheeTxn.Key) {
@@ -933,20 +936,20 @@ func (r *Replica) PushTxn(batch engine.Engine, ms *engine.MVCCStats, ts roachpb.
 
 // ResolveIntent resolves a write intent from the specified key
 // according to the status of the transaction which created it.
-func (r *Replica) ResolveIntent(batch engine.Engine, ms *engine.MVCCStats, ts roachpb.Timestamp, args roachpb.ResolveIntentRequest) (roachpb.ResolveIntentResponse, error) {
+func (r *Replica) ResolveIntent(batch engine.Engine, ms *engine.MVCCStats, h roachpb.BatchRequest_Header, args roachpb.ResolveIntentRequest) (roachpb.ResolveIntentResponse, error) {
 	var reply roachpb.ResolveIntentResponse
 
-	err := engine.MVCCResolveWriteIntent(batch, ms, args.Key, ts, &args.IntentTxn)
+	err := engine.MVCCResolveWriteIntent(batch, ms, args.Key, h.Timestamp, &args.IntentTxn)
 	return reply, err
 }
 
 // ResolveIntentRange resolves write intents in the specified
 // key range according to the status of the transaction which created it.
 func (r *Replica) ResolveIntentRange(batch engine.Engine, ms *engine.MVCCStats,
-	ts roachpb.Timestamp, args roachpb.ResolveIntentRangeRequest) (roachpb.ResolveIntentRangeResponse, error) {
+	h roachpb.BatchRequest_Header, args roachpb.ResolveIntentRangeRequest) (roachpb.ResolveIntentRangeResponse, error) {
 	var reply roachpb.ResolveIntentRangeResponse
 
-	_, err := engine.MVCCResolveWriteIntentRange(batch, ms, args.Key, args.EndKey, 0, ts, &args.IntentTxn)
+	_, err := engine.MVCCResolveWriteIntentRange(batch, ms, args.Key, args.EndKey, 0, h.Timestamp, &args.IntentTxn)
 	return reply, err
 }
 
@@ -955,14 +958,14 @@ func (r *Replica) ResolveIntentRange(batch engine.Engine, ms *engine.MVCCStats,
 // Cockroach for the efficient accumulation of certain values. Due to the
 // difficulty of making these operations transactional, merges are not currently
 // exposed directly to clients. Merged values are explicitly not MVCC data.
-func (r *Replica) Merge(batch engine.Engine, ms *engine.MVCCStats, ts roachpb.Timestamp, args roachpb.MergeRequest) (roachpb.MergeResponse, error) {
+func (r *Replica) Merge(batch engine.Engine, ms *engine.MVCCStats, h roachpb.BatchRequest_Header, args roachpb.MergeRequest) (roachpb.MergeResponse, error) {
 	var reply roachpb.MergeResponse
 
 	return reply, engine.MVCCMerge(batch, ms, args.Key, args.Value)
 }
 
 // TruncateLog discards a prefix of the raft log.
-func (r *Replica) TruncateLog(batch engine.Engine, ms *engine.MVCCStats, ts roachpb.Timestamp, args roachpb.TruncateLogRequest) (roachpb.TruncateLogResponse, error) {
+func (r *Replica) TruncateLog(batch engine.Engine, ms *engine.MVCCStats, h roachpb.BatchRequest_Header, args roachpb.TruncateLogRequest) (roachpb.TruncateLogResponse, error) {
 	var reply roachpb.TruncateLogResponse
 
 	// args.Index is the first index to keep.
@@ -992,7 +995,7 @@ func (r *Replica) TruncateLog(batch engine.Engine, ms *engine.MVCCStats, ts roac
 // holder, the expiration will be extended or shortened as indicated. For a new
 // lease, all duties required of the range leader are commenced, including
 // clearing the command queue and timestamp cache.
-func (r *Replica) LeaderLease(batch engine.Engine, ms *engine.MVCCStats, ts roachpb.Timestamp, args roachpb.LeaderLeaseRequest) (roachpb.LeaderLeaseResponse, error) {
+func (r *Replica) LeaderLease(batch engine.Engine, ms *engine.MVCCStats, h roachpb.BatchRequest_Header, args roachpb.LeaderLeaseRequest) (roachpb.LeaderLeaseResponse, error) {
 	var reply roachpb.LeaderLeaseResponse
 
 	r.Lock()

--- a/storage/replica_test.go
+++ b/storage/replica_test.go
@@ -185,10 +185,9 @@ func (tc *testContext) Start(t testing.TB) {
 
 func (tc *testContext) Sender() client.Sender {
 	return client.Wrap(tc.rng, func(ba roachpb.BatchRequest) roachpb.BatchRequest {
-		if tc.rng != nil && tc.rng.Desc() != nil {
-			ba.RangeID = tc.rng.Desc().RangeID
+		if ba.RangeID != 0 {
+			ba.RangeID = 1
 		}
-		ba.Replica = roachpb.ReplicaDescriptor{StoreID: tc.store.StoreID()}
 		return ba
 	})
 }

--- a/storage/replica_test.go
+++ b/storage/replica_test.go
@@ -2879,8 +2879,7 @@ func TestRangeLookup(t *testing.T) {
 	for _, c := range testCases {
 		resp, err := client.SendWrapped(tc.Sender(), nil, &roachpb.RangeLookupRequest{
 			RequestHeader: roachpb.RequestHeader{
-				RangeID: 1,
-				Key:     c.key,
+				Key: c.key,
 			},
 			MaxRanges: 1,
 			Reverse:   c.reverse,

--- a/storage/store.go
+++ b/storage/store.go
@@ -1234,7 +1234,7 @@ func (s *Store) Send(ctx context.Context, ba roachpb.BatchRequest) (*roachpb.Bat
 			if ok {
 				args := ba.Requests[index].GetInner()
 				// TODO(tschottdorf): implications of using the batch ts here?
-				err = s.resolveWriteIntentError(ctx, wiErr, rng, args, ba.Timestamp, pushType)
+				err = s.resolveWriteIntentError(ctx, wiErr, rng, args, ba.Timestamp, ba.GetUserPriority(), pushType)
 				// Make sure that if an index is carried in the error, it
 				// remains the one corresponding to the batch here.
 				if iErr, ok := err.(roachpb.IndexedError); ok {
@@ -1311,9 +1311,8 @@ func (s *Store) Send(ctx context.Context, ba roachpb.BatchRequest) (*roachpb.Bat
 // c) resolving intents upon EndTransaction which are not local to the given
 //    range. This is the only path in which the transaction is going to be
 //    in non-pending state and doesn't require a push.
-func (s *Store) resolveWriteIntentError(ctx context.Context, wiErr *roachpb.WriteIntentError, rng *Replica, args roachpb.Request, pushTo roachpb.Timestamp, pushType roachpb.PushTxnType) error {
+func (s *Store) resolveWriteIntentError(ctx context.Context, wiErr *roachpb.WriteIntentError, rng *Replica, args roachpb.Request, pushTo roachpb.Timestamp, priority int32, pushType roachpb.PushTxnType) error {
 	method := args.Method()
-	priority := args.Header().GetUserPriority()
 	pusherTxn := args.Header().Txn
 	_, _ = method, pushTo
 	readOnly := roachpb.IsReadOnly(args)

--- a/storage/store.go
+++ b/storage/store.go
@@ -1714,3 +1714,14 @@ func (s *Store) PublishStatus() error {
 func (s *Store) SetRangeRetryOptions(ro retry.Options) {
 	s.ctx.RangeRetryOptions = ro
 }
+
+// testSender sets RangeID to one (unless already non-zero) and sends to the
+// Store. For unit-testing only.
+func (s *Store) testSender() client.Sender {
+	return client.Wrap(s, func(ba roachpb.BatchRequest) roachpb.BatchRequest {
+		if ba.RangeID == 0 {
+			ba.RangeID = 1
+		}
+		return ba
+	})
+}

--- a/storage/store.go
+++ b/storage/store.go
@@ -743,7 +743,6 @@ func (s *Store) GetReplica(rangeID roachpb.RangeID) (*Replica, error) {
 	if rng, ok := s.replicas[rangeID]; ok {
 		return rng, nil
 	}
-	log.Warningf("AOU")
 	return nil, roachpb.NewRangeNotFoundError(rangeID)
 }
 
@@ -1724,4 +1723,9 @@ func (s *Store) testSender() client.Sender {
 		}
 		return ba
 	})
+}
+
+// TestSender is a temporary method to expose testSender() to storage_test.
+func (s *Store) TestSender() client.Sender {
+	return s.testSender()
 }

--- a/storage/store.go
+++ b/storage/store.go
@@ -1713,19 +1713,3 @@ func (s *Store) PublishStatus() error {
 func (s *Store) SetRangeRetryOptions(ro retry.Options) {
 	s.ctx.RangeRetryOptions = ro
 }
-
-// testSender sets RangeID to one (unless already non-zero) and sends to the
-// Store. For unit-testing only.
-func (s *Store) testSender() client.Sender {
-	return client.Wrap(s, func(ba roachpb.BatchRequest) roachpb.BatchRequest {
-		if ba.RangeID == 0 {
-			ba.RangeID = 1
-		}
-		return ba
-	})
-}
-
-// TestSender is a temporary method to expose testSender() to storage_test.
-func (s *Store) TestSender() client.Sender {
-	return s.testSender()
-}

--- a/storage/store.go
+++ b/storage/store.go
@@ -1234,7 +1234,7 @@ func (s *Store) Send(ctx context.Context, ba roachpb.BatchRequest) (*roachpb.Bat
 			if ok {
 				args := ba.Requests[index].GetInner()
 				// TODO(tschottdorf): implications of using the batch ts here?
-				err = s.resolveWriteIntentError(ctx, wiErr, rng, args, ba.Timestamp, ba.GetUserPriority(), pushType)
+				err = s.resolveWriteIntentError(ctx, wiErr, rng, args, ba.BatchRequest_Header, pushType)
 				// Make sure that if an index is carried in the error, it
 				// remains the one corresponding to the batch here.
 				if iErr, ok := err.(roachpb.IndexedError); ok {
@@ -1311,11 +1311,10 @@ func (s *Store) Send(ctx context.Context, ba roachpb.BatchRequest) (*roachpb.Bat
 // c) resolving intents upon EndTransaction which are not local to the given
 //    range. This is the only path in which the transaction is going to be
 //    in non-pending state and doesn't require a push.
-func (s *Store) resolveWriteIntentError(ctx context.Context, wiErr *roachpb.WriteIntentError, rng *Replica, args roachpb.Request, pushTo roachpb.Timestamp, priority int32, pushType roachpb.PushTxnType) error {
+func (s *Store) resolveWriteIntentError(ctx context.Context, wiErr *roachpb.WriteIntentError, rng *Replica, args roachpb.Request, h roachpb.BatchRequest_Header, pushType roachpb.PushTxnType) error {
 	method := args.Method()
-	pusherTxn := args.Header().Txn
-	_, _ = method, pushTo
-	readOnly := roachpb.IsReadOnly(args)
+	pusherTxn := h.Txn
+	readOnly := roachpb.IsReadOnly(args) // TODO(tschottdorf): pass as param
 	args = nil
 
 	if log.V(6) {
@@ -1346,7 +1345,7 @@ func (s *Store) resolveWriteIntentError(ctx context.Context, wiErr *roachpb.Writ
 	// txn with only the priority set.
 	if pusherTxn == nil {
 		pusherTxn = &roachpb.Transaction{
-			Priority: roachpb.MakePriority(priority),
+			Priority: roachpb.MakePriority(h.GetUserPriority()),
 		}
 	}
 	var pushReqs []roachpb.Request
@@ -1357,7 +1356,7 @@ func (s *Store) resolveWriteIntentError(ctx context.Context, wiErr *roachpb.Writ
 			},
 			PusherTxn: *pusherTxn,
 			PusheeTxn: intent.Txn,
-			PushTo:    pushTo,
+			PushTo:    h.Timestamp,
 			// The timestamp is used by PushTxn for figuring out whether the
 			// transaction is abandoned. If we used the argument's timestamp
 			// here, we would run into busy loops because that timestamp

--- a/storage/store_test.go
+++ b/storage/store_test.go
@@ -445,7 +445,6 @@ func TestStoreExecuteNoop(t *testing.T) {
 	store, _, stopper := createTestStore(t)
 	defer stopper.Stop()
 	ba := roachpb.BatchRequest{}
-	ba.Key = nil // intentional
 	ba.RangeID = 1
 	ba.Replica = roachpb.ReplicaDescriptor{StoreID: store.StoreID()}
 	ba.Add(&roachpb.GetRequest{RequestHeader: roachpb.RequestHeader{Key: roachpb.Key("a")}})

--- a/storage/store_test.go
+++ b/storage/store_test.go
@@ -82,6 +82,15 @@ type responseAdder interface {
 	Add(reply roachpb.Response)
 }
 
+func (s *Store) testSender() client.Sender {
+	return client.Wrap(s, func(ba roachpb.BatchRequest) roachpb.BatchRequest {
+		if ba.RangeID == 0 {
+			ba.RangeID = 1
+		}
+		return ba
+	})
+}
+
 // Send forwards the call to the single store. This is a poor man's
 // version of kv.TxnCoordSender, but it serves the purposes of
 // supporting tests in this package. Transactions are not supported.


### PR DESCRIPTION
another major refactor. It won't be fun to review, but at least the individual commits are reasonably self-contained.
I'm going to give this a close review myself tomorrow (there are probably some typos/...), but someone else definitely should do the same. Mild concern: Changes in the tests may have changed their semantics (dropping a Txn somewhere, sending to the wrong Range) - I've paid close attention, but with the hundreds of tests touched here something might've gone wrong.
