### PR TITLE
roachpb: `SetProto` -> `GetBytesChecked` doesn't error

### DIFF
--- a/cli/sql_util.go
+++ b/cli/sql_util.go
@@ -157,7 +157,7 @@ func formatVal(val interface{}) string {
 	switch t := val.(type) {
 	case nil:
 		return "NULL"
-	case string:
+	case []byte:
 		// Ensure that binary protobufs print escaped.
 		return fmt.Sprintf("%q", t)
 	}

--- a/cli/sql_util_test.go
+++ b/cli/sql_util_test.go
@@ -80,9 +80,9 @@ OK
 	}
 
 	expectedRows := [][]string{
-		{`"parentID"`, `"INT"`, `true`, `NULL`},
-		{`"name"`, `"STRING"`, `true`, `NULL`},
-		{`"id"`, `"INT"`, `true`, `NULL`},
+		{`parentID`, `INT`, `true`, `NULL`},
+		{`name`, `STRING`, `true`, `NULL`},
+		{`id`, `INT`, `true`, `NULL`},
 	}
 	if !reflect.DeepEqual(expectedRows, rows) {
 		t.Fatalf("expected:\n%v\ngot:\n%v", expectedRows, rows)
@@ -93,13 +93,13 @@ OK
 	}
 
 	expected = `
-+------------+----------+------+---------+
-|   Field    |   Type   | Null | Default |
-+------------+----------+------+---------+
-| "parentID" | "INT"    | true | NULL    |
-| "name"     | "STRING" | true | NULL    |
-| "id"       | "INT"    | true | NULL    |
-+------------+----------+------+---------+
++----------+--------+------+---------+
+|  Field   |  Type  | Null | Default |
++----------+--------+------+---------+
+| parentID | INT    | true | NULL    |
+| name     | STRING | true | NULL    |
+| id       | INT    | true | NULL    |
++----------+--------+------+---------+
 `
 
 	if a, e := b.String(), expected[1:]; a != e {
@@ -113,11 +113,11 @@ OK
 	}
 
 	expected = `
-+----------+--------------+----+
-| parentID |     name     | id |
-+----------+--------------+----+
-| 1        | "descriptor" | 3  |
-+----------+--------------+----+
++----------+------------+----+
+| parentID |    name    | id |
++----------+------------+----+
+| 1        | descriptor | 3  |
++----------+------------+----+
 `
 	if a, e := b.String(), expected[1:]; a != e {
 		t.Fatalf("expected output:\n%s\ngot:\n%s", e, a)

--- a/roachpb/data.go
+++ b/roachpb/data.go
@@ -315,7 +315,7 @@ func (v *Value) SetProto(msg proto.Message) error {
 	if err != nil {
 		return err
 	}
-	v.Bytes = data
+	v.SetBytes(data)
 	return nil
 }
 

--- a/roachpb/data_test.go
+++ b/roachpb/data_test.go
@@ -22,6 +22,7 @@ import (
 	"math"
 	"math/rand"
 	"testing"
+	"time"
 
 	"github.com/cockroachdb/cockroach/util/uuid"
 )
@@ -265,6 +266,37 @@ func TestValueChecksumWithBytes(t *testing.T) {
 	v.Bytes = []byte("abcd")
 	if err := v.Verify(k); err == nil {
 		t.Error("expected checksum verification failure on different value")
+	}
+}
+
+func TestSetGetChecked(t *testing.T) {
+	v := Value{}
+
+	v.SetBytes(nil)
+	if _, err := v.GetBytesChecked(); err != nil {
+		t.Fatal(err)
+	}
+
+	v.SetFloat(1.1)
+	if _, err := v.GetFloat(); err != nil {
+		t.Fatal(err)
+	}
+
+	v.SetInt(1)
+	if _, err := v.GetInt(); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := v.SetProto(&Value{}); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := v.GetBytesChecked(); err != nil {
+		t.Fatal(err)
+	}
+
+	v.SetTime(time.Time{})
+	if _, err := v.GetTime(); err != nil {
+		t.Fatal(err)
 	}
 }
 


### PR DESCRIPTION
Also fixes cli to print protobufs correctly now that they come back
as `[]byte`s rather than `string`s.

Fixes #2754.
