### PR TITLE
Reproduce and fix a query of death

### DIFF
--- a/util/stop/stopper.go
+++ b/util/stop/stopper.go
@@ -111,8 +111,8 @@ func (s *Stopper) RunTask(f func()) bool {
 		return false
 	}
 	// Call f.
+	defer s.runPostlude(taskKey)
 	f()
-	s.runPostlude(taskKey)
 	return true
 }
 

--- a/util/stop/stopper_test.go
+++ b/util/stop/stopper_test.go
@@ -281,3 +281,20 @@ func TestStopperNumTasks(t *testing.T) {
 	}
 	s.Stop()
 }
+
+// TestStopperRunTaskPanic ensures that tasks are not leaked when they panic.
+// RunAsyncTask has a similar bit of logic, but it is not testable because
+// we cannot insert a recover() call in the right place.
+func TestStopperRunTaskPanic(t *testing.T) {
+	s := stop.NewStopper()
+	// If RunTask were not panic-safe, Stop() would deadlock.
+	defer s.Stop()
+	func() {
+		defer func() {
+			_ = recover()
+		}()
+		s.RunTask(func() {
+			panic("ouch")
+		})
+	}()
+}


### PR DESCRIPTION
I'm not sure if this is the right fix. The `default` case of this switch panics if the value is nil, so I added a check for nil, but instead we may want to turn that nil into a `DNull` somewhere else. I haven't dug around to see where exactly the nil is coming from. 

The way in which the newly-added test failed was interesting too: the executor panics, and the panic is caught by the HTTP server, so the process doesn't die. Instead, the test times out, due to a leak in the stopper. The second commit in this branch fixes that.
