### PR TITLE
Capture log files from the acceptance workers.

### DIFF
--- a/acceptance/localcluster/localcluster.go
+++ b/acceptance/localcluster/localcluster.go
@@ -237,7 +237,11 @@ func (l *Cluster) initCluster() {
 	binds := []string{l.CertsDir + ":/certs"}
 
 	if logDirectory != nil && len(*logDirectory) > 0 {
-		l.LogDir = filepath.Join(pwd, *logDirectory)
+		if filepath.IsAbs(*logDirectory) {
+			l.LogDir = *logDirectory
+		} else {
+			l.LogDir = filepath.Join(pwd, *logDirectory)
+		}
 		binds = append(binds, l.LogDir+":/logs")
 	} else if l.ForceLogging {
 		l.LogDir, err = ioutil.TempDir(pwd, ".localcluster.logs.")

--- a/build/circle-test.sh
+++ b/build/circle-test.sh
@@ -111,7 +111,13 @@ time ${builder} make testrace \
 # acceptance tests on the Mac's, but circle-deps.sh only built the
 # acceptance tests for Linux.
 if [ "$(uname)" = "Linux" ]; then
-  time $(dirname $0)/../acceptance.test -test.v -test.timeout 5m --verbosity=1 --vmodule=monitor=2 | \
+  # Make a place for the containers to write their logs.
+  mkdir -p ${outdir}/acceptance
+
+  # Note that this test requires 2>&1 but the others don't because
+  # this one runs outside the builder container (and inside the
+  # container, something is already combining stdout and stderr).
+  time $(dirname $0)/../acceptance.test -test.v -test.timeout 5m --verbosity=1 --vmodule=monitor=2 -l ${outdir}/acceptance 2>&1 | \
     tr -d '\r' | tee "${outdir}/acceptance.log" | \
     grep -E "^\--- (PASS|FAIL)|^(FAIL|ok)|${match}" |
     awk '{print "acceptance:", $0}'


### PR DESCRIPTION
Capture stderr from the acceptance test master process
so it appears in the "Test Failures" tab.
