### PR TITLE
Skip a couple of flaky tests

### DIFF
--- a/storage/client_raft_test.go
+++ b/storage/client_raft_test.go
@@ -835,6 +835,7 @@ func TestProgressWithDownNode(t *testing.T) {
 
 func TestReplicateAddAndRemove(t *testing.T) {
 	defer leaktest.AfterTest(t)
+	t.Skip("TODO(bdarnell): #768")
 
 	// Run the test twice, once adding the replacement before removing
 	// the downed node, and once removing the downed node first.

--- a/storage/client_range_tree_test.go
+++ b/storage/client_range_tree_test.go
@@ -18,7 +18,6 @@
 package storage_test
 
 import (
-	"fmt"
 	"reflect"
 	"testing"
 
@@ -216,12 +215,15 @@ func TestTree(t *testing.T) {
 
 	// To test merging, we just call AdminMerge on the lowest key to merge all
 	// ranges back into a single one.
-	for i := 0; i < len(keys); i++ {
-		if err := db.AdminMerge(roachpb.KeyMin); err != nil {
-			t.Fatal(err)
+	// TODO(bdarnell): re-enable this when merging is more reliable.
+	// https://github.com/cockroachdb/cockroach/issues/2433
+	/*
+		for i := 0; i < len(keys); i++ {
+			if err := db.AdminMerge(roachpb.KeyMin); err != nil {
+				t.Fatal(err)
+			}
+			tree, nodes := loadTree(t, db)
+			VerifyTree(t, tree, nodes, fmt.Sprintf("remove %d", i))
 		}
-		tree, nodes := loadTree(t, db)
-		VerifyTree(t, tree, nodes, fmt.Sprintf("remove %d", i))
-	}
-
+	*/
 }


### PR DESCRIPTION
One will be re-enabled as soon as replica tombstones are ready; one depends on merging and so will stay disabled for some time.
