### PR TITLE
Fix raft_transport when ReplicaID != StoreID.

### DIFF
--- a/server/raft_transport.go
+++ b/server/raft_transport.go
@@ -80,7 +80,7 @@ func (t *rpcTransport) RaftMessage(args proto.Message, callback func(proto.Messa
 	req := args.(*multiraft.RaftMessageRequest)
 
 	t.mu.Lock()
-	server, ok := t.servers[roachpb.StoreID(req.Message.To)]
+	server, ok := t.servers[req.ToReplica.StoreID]
 	t.mu.Unlock()
 
 	if !ok {


### PR DESCRIPTION
This was insufficiently tested, and this case was encountered only
intermittently when the acceptance tests happened to replicate
a range "out of order".

Fixes #2771.
