### PR TITLE
Fix use of cached binaries in acceptance tests.

### DIFF
--- a/build/circle-deps.sh
+++ b/build/circle-deps.sh
@@ -17,8 +17,14 @@ if [ "${1-}" = "docker" ]; then
   # Create the cache directories to avoid errors on `ln` below.
   mkdir -p /uicache/{bower_components,node_modules,typings}
 
-  # Symlink the cache into the source tree.
-  ln -s /uicache/{bower_components,node_modules,typings} ui/
+  # Symlink the cache into the source tree if they don't exist.
+  # In circleci they never do, but this script can also be run
+  # locally where they might.
+  for i in bower_components node_modules typings; do
+    if ! [ -e ui/$i ]; then
+      ln -s /uicache/$i ui/$i
+    fi
+  done
   time make -C ui {bower,npm,tsd}.installed
 
   # Restore previously cached build artifacts.


### PR DESCRIPTION
Partially reverts #2713 with a comment explaining why it should
be the way it was.

Attempt to fix the use of `circle-local.sh` in a dev environment
but don't get all the way there.
