### PR TITLE
Specific Source queries in ts.DB.Query()

### DIFF
--- a/ts/db_test.go
+++ b/ts/db_test.go
@@ -50,7 +50,7 @@ import (
 type testModel struct {
 	t           testing.TB
 	modelData   map[string]*roachpb.Value
-	seenSources map[string]bool
+	seenSources map[string]struct{}
 	*kv.LocalTestCluster
 	DB *DB
 }
@@ -61,7 +61,7 @@ func newTestModel(t *testing.T) *testModel {
 	return &testModel{
 		t:                t,
 		modelData:        make(map[string]*roachpb.Value),
-		seenSources:      make(map[string]bool),
+		seenSources:      make(map[string]struct{}),
 		LocalTestCluster: &kv.LocalTestCluster{},
 	}
 }
@@ -156,7 +156,7 @@ func (tm *testModel) assertKeyCount(expected int) {
 
 func (tm *testModel) storeInModel(r Resolution, data TimeSeriesData) {
 	// Note the source, used to construct keys for model queries.
-	tm.seenSources[data.Source] = true
+	tm.seenSources[data.Source] = struct{}{}
 
 	// Process and store data in the model.
 	internalData, err := data.ToInternal(r.KeyDuration(), r.SampleDuration())

--- a/ts/timeseries.proto
+++ b/ts/timeseries.proto
@@ -83,6 +83,9 @@ message TimeSeriesQueryRequest {
         optional string name = 1 [(gogoproto.nullable) = false];
         // The aggregation function to apply to points in the result.
         optional TimeSeriesQueryAggregator aggregator = 2 [default = AVG];
+        // An optional list of sources to restrict the time series query. If no
+        // sources are provided, all sources will be queried.
+        repeated string sources = 3;
     }
 
     // A set of Queries for this request. A request must have at least one


### PR DESCRIPTION
This commit adds the ability to query a time series for a set of specific
sources; previously, all available sources were aggregated for each query.
- Add 'sources' repeated field to TimeSeriesQuery protobuffer message, which
  allows specifying specific sources for a query.
- Implement logic for querying specific sources; instead of using a scan, it now
  constructs all possible keys which could contain TS data for the given series,
  and queries them in a batch.
- Add test for specific source query.
