### PR TITLE
Record time series from different nodes/stores using "source" field

### DIFF
--- a/server/status/recorder_test.go
+++ b/server/status/recorder_test.go
@@ -21,6 +21,7 @@ import (
 	"fmt"
 	"reflect"
 	"sort"
+	"strconv"
 	"testing"
 
 	"github.com/cockroachdb/cockroach/roachpb"
@@ -41,7 +42,10 @@ func (a byTimeAndName) Less(i, j int) bool {
 	if a[i].Name != a[j].Name {
 		return a[i].Name < a[j].Name
 	}
-	return a[i].Datapoints[0].TimestampNanos < a[j].Datapoints[0].TimestampNanos
+	if a[i].Datapoints[0].TimestampNanos != a[j].Datapoints[0].TimestampNanos {
+		return a[i].Datapoints[0].TimestampNanos < a[j].Datapoints[0].TimestampNanos
+	}
+	return a[i].Source < a[j].Source
 }
 
 var _ sort.Interface = byTimeAndName{}
@@ -205,7 +209,8 @@ func TestNodeStatusRecorder(t *testing.T) {
 
 	generateNodeData := func(nodeId int, name string, time, val int64) ts.TimeSeriesData {
 		return ts.TimeSeriesData{
-			Name: fmt.Sprintf(nodeTimeSeriesNameFmt, name, roachpb.StoreID(nodeId)),
+			Name:   fmt.Sprintf(nodeTimeSeriesNameFmt, name),
+			Source: strconv.FormatInt(int64(nodeId), 10),
 			Datapoints: []*ts.TimeSeriesDatapoint{
 				{
 					TimestampNanos: time,
@@ -217,7 +222,8 @@ func TestNodeStatusRecorder(t *testing.T) {
 
 	generateStoreData := func(storeId int, name string, time, val int64) ts.TimeSeriesData {
 		return ts.TimeSeriesData{
-			Name: fmt.Sprintf(storeTimeSeriesNameFmt, name, roachpb.StoreID(storeId)),
+			Name:   fmt.Sprintf(storeTimeSeriesNameFmt, name),
+			Source: strconv.FormatInt(int64(storeId), 10),
 			Datapoints: []*ts.TimeSeriesDatapoint{
 				{
 					TimestampNanos: time,
@@ -278,7 +284,7 @@ func TestNodeStatusRecorder(t *testing.T) {
 	sort.Sort(byTimeAndName(actual))
 	sort.Sort(byTimeAndName(expected))
 	if a, e := actual, expected; !reflect.DeepEqual(a, e) {
-		t.Errorf("recorder did not yield expected time series collection; expected %v, got %v", e, a)
+		t.Errorf("recorder did not yield expected time series collection; expected:\n %v, got:\n %v", e, a)
 	}
 
 	expectedNodeSummary := &NodeStatus{
@@ -329,9 +335,9 @@ func TestNodeStatusRecorder(t *testing.T) {
 	sort.Sort(byStoreDescID(storeSummaries))
 	sort.Sort(byStoreID(nodeSummary.StoreIDs))
 	if a, e := nodeSummary, expectedNodeSummary; !reflect.DeepEqual(a, e) {
-		t.Errorf("recorder did not produce expected NodeSummary; expected %v, got %v", e, a)
+		t.Errorf("recorder did not produce expected NodeSummary; expected:\n %v\n got:\n %v", e, a)
 	}
 	if a, e := storeSummaries, expectedStoreSummaries; !reflect.DeepEqual(a, e) {
-		t.Errorf("recorder did not produce expected StoreSummaries; expected %v, got %v", e, a)
+		t.Errorf("recorder did not produce expected StoreSummaries; expected:\n %v, got:\n %v", e, a)
 	}
 }

--- a/server/status/runtime.go
+++ b/server/status/runtime.go
@@ -20,6 +20,7 @@ package status
 import (
 	"fmt"
 	"runtime"
+	"strconv"
 	"syscall"
 	"time"
 
@@ -35,6 +36,7 @@ import (
 type RuntimeStatRecorder struct {
 	nodeID        roachpb.NodeID
 	clock         *hlc.Clock
+	source        string
 	lastDataCount int
 
 	// The last recorded values of some statistics are kept to compute
@@ -53,6 +55,7 @@ func NewRuntimeStatRecorder(nodeID roachpb.NodeID, clock *hlc.Clock) *RuntimeSta
 	return &RuntimeStatRecorder{
 		nodeID: nodeID,
 		clock:  clock,
+		source: strconv.FormatInt(int64(nodeID), 10),
 	}
 }
 
@@ -61,7 +64,8 @@ func NewRuntimeStatRecorder(nodeID roachpb.NodeID, clock *hlc.Clock) *RuntimeSta
 func (rsr *RuntimeStatRecorder) record(timestampNanos int64, name string,
 	data float64) ts.TimeSeriesData {
 	return ts.TimeSeriesData{
-		Name: fmt.Sprintf(runtimeStatTimeSeriesNameFmt, name, rsr.nodeID),
+		Name:   fmt.Sprintf(runtimeStatTimeSeriesNameFmt, name),
+		Source: rsr.source,
 		Datapoints: []*ts.TimeSeriesDatapoint{
 			{
 				TimestampNanos: timestampNanos,

--- a/ui/ts/models/metrics.ts
+++ b/ui/ts/models/metrics.ts
@@ -112,6 +112,10 @@ module Models {
          */
         series(): string;
         /**
+         * sources returns the data sources to which this query is restrained.
+         */
+        sources(): string[];
+        /**
          * title returns a display-friendly title for this series.
          */
         title(): string;
@@ -123,10 +127,12 @@ module Models {
       class AvgSelector implements Selector {
         constructor(private seriesName: string) { }
         title: Utils.ChainProperty<string, AvgSelector> = Utils.ChainProp(this, this.seriesName);
+        sources: Utils.ChainProperty<string[], AvgSelector> = Utils.ChainProp(this, []);
         series: () => string = () => { return this.seriesName; };
         request: () => Proto.QueryRequest = (): Proto.QueryRequest => {
           return {
             name: this.seriesName,
+            sources: this.sources(),
             aggregator: Proto.QueryAggregator.AVG
           };
         };
@@ -137,12 +143,14 @@ module Models {
        * of the supplied time series.
        */
       class AvgRateSelector implements Selector {
-        constructor(private seriesName: string) { }
+        constructor(private seriesName: string) {}
         title: Utils.ChainProperty<string, AvgRateSelector> = Utils.ChainProp(this, this.seriesName);
+        sources: Utils.ChainProperty<string[], AvgRateSelector> = Utils.ChainProp(this, []);
         series: () => string = () => { return this.seriesName; };
         request: () => Proto.QueryRequest = (): Proto.QueryRequest => {
           return {
             name: this.seriesName,
+            sources: this.sources(),
             aggregator: Proto.QueryAggregator.AVG_RATE
           };
         };

--- a/ui/ts/models/proto.ts
+++ b/ui/ts/models/proto.ts
@@ -239,6 +239,7 @@ module Models {
      */
     export interface QueryRequest {
       name: string;
+      sources: string[];
       aggregator: QueryAggregator;
     }
 

--- a/ui/ts/pages/nodes.ts
+++ b/ui/ts/pages/nodes.ts
@@ -29,8 +29,8 @@ module AdminViews {
 
     let nodeStatuses: Models.Status.Nodes = new Models.Status.Nodes();
 
-    function _nodeMetric(nodeId: string, metric: string): string {
-      return "cr.node." + metric + "." + nodeId;
+    function _nodeMetric(metric: string): string {
+      return "cr.node." + metric;
     }
 
     /**
@@ -175,13 +175,15 @@ module AdminViews {
           this._query = Metrics.NewQuery();
           this._addChart(
             Metrics.NewAxis(
-              Metrics.Select.AvgRate(_nodeMetric(nodeId, "calls.success"))
+              Metrics.Select.AvgRate(_nodeMetric("calls.success"))
+                .sources([nodeId])
                 .title("Successful Calls")
               )
               .label("Count / 10 sec."));
           this._addChart(
             Metrics.NewAxis(
-              Metrics.Select.AvgRate(_nodeMetric(nodeId, "calls.error"))
+              Metrics.Select.AvgRate(_nodeMetric("calls.error"))
+                .sources([nodeId])
                 .title("Error Calls")
               )
               .label("Count / 10 sec."));

--- a/ui/ts/pages/stores.ts
+++ b/ui/ts/pages/stores.ts
@@ -27,8 +27,8 @@ module AdminViews {
     import StoreStatus = Models.Proto.StoreStatus;
     let storeStatuses: Models.Status.Stores = new Models.Status.Stores();
 
-    function _storeMetric(storeId: string, metric: string): string {
-      return "cr.store." + metric + "." + storeId;
+    function _storeMetric(metric: string): string {
+      return "cr.store." + metric;
     }
 
     /**
@@ -177,42 +177,48 @@ module AdminViews {
           this._query = Metrics.NewQuery();
           this._addChart(
             Metrics.NewAxis(
-              Metrics.Select.Avg(_storeMetric(storeId, "keycount"))
+              Metrics.Select.Avg(_storeMetric("keycount"))
+                .sources([storeId])
                 .title("Key Count")
               )
               .label("Count")
             );
           this._addChart(
             Metrics.NewAxis(
-              Metrics.Select.Avg(_storeMetric(storeId, "livecount"))
+              Metrics.Select.Avg(_storeMetric("livecount"))
+                .sources([storeId])
                 .title("Live Value Count")
               )
               .label("Count")
             );
           this._addChart(
             Metrics.NewAxis(
-              Metrics.Select.Avg(_storeMetric(storeId, "valcount"))
+              Metrics.Select.Avg(_storeMetric("valcount"))
+                .sources([storeId])
                 .title("Total Value Count")
               )
               .label("Count")
             );
           this._addChart(
             Metrics.NewAxis(
-              Metrics.Select.Avg(_storeMetric(storeId, "intentcount"))
+              Metrics.Select.Avg(_storeMetric("intentcount"))
+                .sources([storeId])
                 .title("Intent Count")
               )
               .label("Count")
             );
           this._addChart(
             Metrics.NewAxis(
-              Metrics.Select.Avg(_storeMetric(storeId, "ranges"))
+              Metrics.Select.Avg(_storeMetric("ranges"))
+                .sources([storeId])
                 .title("Range Count")
               )
               .label("Count")
             );
           this._addChart(
             Metrics.NewAxis(
-              Metrics.Select.Avg(_storeMetric(storeId, "livebytes"))
+              Metrics.Select.Avg(_storeMetric("livebytes"))
+                .sources([storeId])
                 .title("Live Bytes")
               )
               .label("Bytes")


### PR DESCRIPTION
Two commits in pursuit of #2722 

First commit modifies the backend to record time series using the "source" field; as of this commit, different Nodes/Stores will record their time series with the same metric name, but different sources (previously, each Node/Store used unique metric names).  This will allow for aggregation queries across multiple nodes/stores.

Second commit modifies the admin UI to consume the new time series; no additional functionality has been added, but the change was necessary for the Admin UI to continue working.
