### PR TITLE
Implement replica tombstones.

### DIFF
--- a/keys/constants.go
+++ b/keys/constants.go
@@ -74,6 +74,8 @@ var (
 	LocalResponseCacheSuffix = []byte("res-")
 	// localRaftLeaderLeaseSuffix is the suffix for the raft leader lease.
 	localRaftLeaderLeaseSuffix = []byte("rfll")
+	// localRaftTombstoneSuffix is the suffix for the raft tombstone.
+	localRaftTombstoneSuffix = []byte("rftb")
 	// localRaftHardStateSuffix is the Suffix for the raft HardState.
 	localRaftHardStateSuffix = []byte("rfth")
 	// localRaftAppliedIndexSuffix is the suffix for the raft applied index.

--- a/keys/keys.go
+++ b/keys/keys.go
@@ -104,6 +104,11 @@ func RaftLeaderLeaseKey(rangeID roachpb.RangeID) roachpb.Key {
 	return MakeRangeIDKey(rangeID, localRaftLeaderLeaseSuffix, roachpb.RKey{})
 }
 
+// RaftTombstoneKey returns a system-local key for a raft tombstone.
+func RaftTombstoneKey(rangeID roachpb.RangeID) roachpb.Key {
+	return MakeRangeIDKey(rangeID, localRaftTombstoneSuffix, roachpb.RKey{})
+}
+
 // RaftLastIndexKey returns a system-local key for a raft last index.
 func RaftLastIndexKey(rangeID roachpb.RangeID) roachpb.Key {
 	return MakeRangeIDKey(rangeID, localRaftLastIndexSuffix, roachpb.RKey{})

--- a/multiraft/multiraft_test.go
+++ b/multiraft/multiraft_test.go
@@ -133,8 +133,7 @@ func (c *testCluster) createGroup(groupID roachpb.RangeID, firstNode, numReplica
 		}
 
 		node := c.nodes[firstNode+i]
-		err = node.CreateGroup(groupID)
-		if err != nil {
+		if err := node.CreateGroup(groupID); err != nil {
 			c.t.Fatal(err)
 		}
 	}

--- a/multiraft/multiraft_test.go
+++ b/multiraft/multiraft_test.go
@@ -109,7 +109,10 @@ func (c *testCluster) createGroup(groupID roachpb.RangeID, firstNode, numReplica
 		c.groups[groupID] = append(c.groups[groupID], nodeIndex)
 	}
 	for i := 0; i < numReplicas; i++ {
-		gs := c.storages[firstNode+i].GroupStorage(groupID)
+		gs, err := c.storages[firstNode+i].GroupStorage(groupID, 0)
+		if err != nil {
+			c.t.Fatal(err)
+		}
 		memStorage := gs.(*blockableGroupStorage).s.(*raft.MemoryStorage)
 		if err := memStorage.SetHardState(raftpb.HardState{
 			Commit: 10,
@@ -130,7 +133,7 @@ func (c *testCluster) createGroup(groupID roachpb.RangeID, firstNode, numReplica
 		}
 
 		node := c.nodes[firstNode+i]
-		err := node.CreateGroup(groupID)
+		err = node.CreateGroup(groupID)
 		if err != nil {
 			c.t.Fatal(err)
 		}

--- a/multiraft/storage.go
+++ b/multiraft/storage.go
@@ -44,7 +44,9 @@ type Storage interface {
 	// GroupStorage returns an interface which can be used to access the
 	// storage for the specified group. May return ErrGroupDeleted if
 	// the group cannot be found or if the given replica ID is known to
-	// be out of date.
+	// be out of date. The replicaID may be InvalidReplicaID if the
+	// replica ID is not known; replica-staleness checks should be
+	// disabled in this case.
 	GroupStorage(groupID roachpb.RangeID, replicaID roachpb.ReplicaID) (WriteableGroupStorage, error)
 
 	ReplicaDescriptor(groupID roachpb.RangeID, replicaID roachpb.ReplicaID) (roachpb.ReplicaDescriptor, error)

--- a/multiraft/storage_test.go
+++ b/multiraft/storage_test.go
@@ -36,8 +36,9 @@ func (b *BlockableStorage) Unblock() {
 	b.mu.Unlock()
 }
 
-func (b *BlockableStorage) GroupStorage(g roachpb.RangeID) WriteableGroupStorage {
-	return &blockableGroupStorage{b, b.storage.GroupStorage(g)}
+func (b *BlockableStorage) GroupStorage(g roachpb.RangeID, r roachpb.ReplicaID) (WriteableGroupStorage, error) {
+	gs, err := b.storage.GroupStorage(g, r)
+	return &blockableGroupStorage{b, gs}, err
 }
 
 func (b *BlockableStorage) ReplicaDescriptor(groupID roachpb.RangeID, replicaID roachpb.ReplicaID) (roachpb.ReplicaDescriptor, error) {

--- a/roachpb/api.pb.go
+++ b/roachpb/api.pb.go
@@ -100,6 +100,7 @@
 		InternalTimeSeriesData
 		InternalTimeSeriesSample
 		RaftTruncatedState
+		RaftTombstone
 		RaftSnapshotData
 		Attributes
 		ReplicaDescriptor

--- a/roachpb/internal.proto
+++ b/roachpb/internal.proto
@@ -112,6 +112,12 @@ message RaftTruncatedState {
   optional uint64 term = 2 [(gogoproto.nullable) = false];
 }
 
+// RaftTombstone contains information about a replica that has been deleted.
+message RaftTombstone {
+  optional int32 next_replica_id = 1 [(gogoproto.nullable) = false,
+      (gogoproto.customname) = "NextReplicaID", (gogoproto.casttype) = "ReplicaID"];
+}
+
 // RaftSnapshotData is the payload of a raftpb.Snapshot. It contains a raw copy of
 // all of the range's data and metadata, including the raft log, response cache, etc.
 message RaftSnapshotData {

--- a/storage/client_range_gc_test.go
+++ b/storage/client_range_gc_test.go
@@ -57,7 +57,6 @@ func TestRangeGCQueueDropReplica(t *testing.T) {
 // removes a range from a store that no longer should have a replica.
 func TestRangeGCQueueDropReplicaGCOnScan(t *testing.T) {
 	defer leaktest.AfterTest(t)
-	t.Skip("TODO(bdarnell): #768")
 
 	mtc := startMultiTestContext(t, 3)
 	defer mtc.Stop()

--- a/storage/client_test.go
+++ b/storage/client_test.go
@@ -489,7 +489,7 @@ func (m *multiTestContext) readIntFromEngines(key roachpb.Key) []int64 {
 			results[i], err = val.GetInt()
 		}
 		if err != nil {
-			log.Errorf("error reading %s from engine %d", key, i)
+			log.Errorf("error reading %s from engine %d: %s", key, i, err)
 			results[i] = 0
 		}
 	}

--- a/storage/engine/rocksdb/cockroach/roachpb/internal.pb.cc
+++ b/storage/engine/rocksdb/cockroach/roachpb/internal.pb.cc
@@ -33,6 +33,9 @@ const ::google::protobuf::internal::GeneratedMessageReflection*
 const ::google::protobuf::Descriptor* RaftTruncatedState_descriptor_ = NULL;
 const ::google::protobuf::internal::GeneratedMessageReflection*
   RaftTruncatedState_reflection_ = NULL;
+const ::google::protobuf::Descriptor* RaftTombstone_descriptor_ = NULL;
+const ::google::protobuf::internal::GeneratedMessageReflection*
+  RaftTombstone_reflection_ = NULL;
 const ::google::protobuf::Descriptor* RaftSnapshotData_descriptor_ = NULL;
 const ::google::protobuf::internal::GeneratedMessageReflection*
   RaftSnapshotData_reflection_ = NULL;
@@ -118,7 +121,22 @@ void protobuf_AssignDesc_cockroach_2froachpb_2finternal_2eproto() {
       sizeof(RaftTruncatedState),
       GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(RaftTruncatedState, _internal_metadata_),
       -1);
-  RaftSnapshotData_descriptor_ = file->message_type(4);
+  RaftTombstone_descriptor_ = file->message_type(4);
+  static const int RaftTombstone_offsets_[1] = {
+    GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(RaftTombstone, next_replica_id_),
+  };
+  RaftTombstone_reflection_ =
+    ::google::protobuf::internal::GeneratedMessageReflection::NewGeneratedMessageReflection(
+      RaftTombstone_descriptor_,
+      RaftTombstone::default_instance_,
+      RaftTombstone_offsets_,
+      GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(RaftTombstone, _has_bits_[0]),
+      -1,
+      -1,
+      sizeof(RaftTombstone),
+      GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(RaftTombstone, _internal_metadata_),
+      -1);
+  RaftSnapshotData_descriptor_ = file->message_type(5);
   static const int RaftSnapshotData_offsets_[2] = {
     GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(RaftSnapshotData, range_descriptor_),
     GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(RaftSnapshotData, kv_),
@@ -171,6 +189,8 @@ void protobuf_RegisterTypes(const ::std::string&) {
   ::google::protobuf::MessageFactory::InternalRegisterGeneratedMessage(
       RaftTruncatedState_descriptor_, &RaftTruncatedState::default_instance());
   ::google::protobuf::MessageFactory::InternalRegisterGeneratedMessage(
+      RaftTombstone_descriptor_, &RaftTombstone::default_instance());
+  ::google::protobuf::MessageFactory::InternalRegisterGeneratedMessage(
       RaftSnapshotData_descriptor_, &RaftSnapshotData::default_instance());
   ::google::protobuf::MessageFactory::InternalRegisterGeneratedMessage(
       RaftSnapshotData_KeyValue_descriptor_, &RaftSnapshotData_KeyValue::default_instance());
@@ -187,6 +207,8 @@ void protobuf_ShutdownFile_cockroach_2froachpb_2finternal_2eproto() {
   delete InternalTimeSeriesSample_reflection_;
   delete RaftTruncatedState::default_instance_;
   delete RaftTruncatedState_reflection_;
+  delete RaftTombstone::default_instance_;
+  delete RaftTombstone_reflection_;
   delete RaftSnapshotData::default_instance_;
   delete RaftSnapshotData_reflection_;
   delete RaftSnapshotData_KeyValue::default_instance_;
@@ -219,25 +241,29 @@ void protobuf_AddDesc_cockroach_2froachpb_2finternal_2eproto() {
     "t\030\001 \001(\005B\004\310\336\037\000\022\023\n\005count\030\006 \001(\rB\004\310\336\037\000\022\021\n\003su"
     "m\030\007 \001(\001B\004\310\336\037\000\022\013\n\003max\030\010 \001(\001\022\013\n\003min\030\t \001(\001\""
     "=\n\022RaftTruncatedState\022\023\n\005index\030\001 \001(\004B\004\310\336"
-    "\037\000\022\022\n\004term\030\002 \001(\004B\004\310\336\037\000\"\300\001\n\020RaftSnapshotD"
-    "ata\022B\n\020range_descriptor\030\001 \001(\0132\".cockroac"
-    "h.roachpb.RangeDescriptorB\004\310\336\037\000\022@\n\002KV\030\002 "
-    "\003(\0132,.cockroach.roachpb.RaftSnapshotData"
-    ".KeyValueB\006\342\336\037\002KV\032&\n\010KeyValue\022\013\n\003key\030\001 \001"
-    "(\014\022\r\n\005value\030\002 \001(\014B\031Z\007roachpb\340\342\036\001\310\342\036\001\320\342\036\001"
-    "\220\343\036\000", 884);
+    "\037\000\022\022\n\004term\030\002 \001(\004B\004\310\336\037\000\"L\n\rRaftTombstone\022"
+    ";\n\017next_replica_id\030\001 \001(\005B\"\310\336\037\000\342\336\037\rNextRe"
+    "plicaID\372\336\037\tReplicaID\"\300\001\n\020RaftSnapshotDat"
+    "a\022B\n\020range_descriptor\030\001 \001(\0132\".cockroach."
+    "roachpb.RangeDescriptorB\004\310\336\037\000\022@\n\002KV\030\002 \003("
+    "\0132,.cockroach.roachpb.RaftSnapshotData.K"
+    "eyValueB\006\342\336\037\002KV\032&\n\010KeyValue\022\013\n\003key\030\001 \001(\014"
+    "\022\r\n\005value\030\002 \001(\014B\031Z\007roachpb\340\342\036\001\310\342\036\001\320\342\036\001\220\343"
+    "\036\000", 962);
   ::google::protobuf::MessageFactory::InternalRegisterGeneratedFile(
     "cockroach/roachpb/internal.proto", &protobuf_RegisterTypes);
   RaftCommand::default_instance_ = new RaftCommand();
   InternalTimeSeriesData::default_instance_ = new InternalTimeSeriesData();
   InternalTimeSeriesSample::default_instance_ = new InternalTimeSeriesSample();
   RaftTruncatedState::default_instance_ = new RaftTruncatedState();
+  RaftTombstone::default_instance_ = new RaftTombstone();
   RaftSnapshotData::default_instance_ = new RaftSnapshotData();
   RaftSnapshotData_KeyValue::default_instance_ = new RaftSnapshotData_KeyValue();
   RaftCommand::default_instance_->InitAsDefaultInstance();
   InternalTimeSeriesData::default_instance_->InitAsDefaultInstance();
   InternalTimeSeriesSample::default_instance_->InitAsDefaultInstance();
   RaftTruncatedState::default_instance_->InitAsDefaultInstance();
+  RaftTombstone::default_instance_->InitAsDefaultInstance();
   RaftSnapshotData::default_instance_->InitAsDefaultInstance();
   RaftSnapshotData_KeyValue::default_instance_->InitAsDefaultInstance();
   ::google::protobuf::internal::OnShutdown(&protobuf_ShutdownFile_cockroach_2froachpb_2finternal_2eproto);
@@ -1952,6 +1978,265 @@ void RaftTruncatedState::clear_term() {
   set_has_term();
   term_ = value;
   // @@protoc_insertion_point(field_set:cockroach.roachpb.RaftTruncatedState.term)
+}
+
+#endif  // PROTOBUF_INLINE_NOT_IN_HEADERS
+
+// ===================================================================
+
+#ifndef _MSC_VER
+const int RaftTombstone::kNextReplicaIdFieldNumber;
+#endif  // !_MSC_VER
+
+RaftTombstone::RaftTombstone()
+  : ::google::protobuf::Message(), _internal_metadata_(NULL) {
+  SharedCtor();
+  // @@protoc_insertion_point(constructor:cockroach.roachpb.RaftTombstone)
+}
+
+void RaftTombstone::InitAsDefaultInstance() {
+}
+
+RaftTombstone::RaftTombstone(const RaftTombstone& from)
+  : ::google::protobuf::Message(),
+    _internal_metadata_(NULL) {
+  SharedCtor();
+  MergeFrom(from);
+  // @@protoc_insertion_point(copy_constructor:cockroach.roachpb.RaftTombstone)
+}
+
+void RaftTombstone::SharedCtor() {
+  _cached_size_ = 0;
+  next_replica_id_ = 0;
+  ::memset(_has_bits_, 0, sizeof(_has_bits_));
+}
+
+RaftTombstone::~RaftTombstone() {
+  // @@protoc_insertion_point(destructor:cockroach.roachpb.RaftTombstone)
+  SharedDtor();
+}
+
+void RaftTombstone::SharedDtor() {
+  if (this != default_instance_) {
+  }
+}
+
+void RaftTombstone::SetCachedSize(int size) const {
+  GOOGLE_SAFE_CONCURRENT_WRITES_BEGIN();
+  _cached_size_ = size;
+  GOOGLE_SAFE_CONCURRENT_WRITES_END();
+}
+const ::google::protobuf::Descriptor* RaftTombstone::descriptor() {
+  protobuf_AssignDescriptorsOnce();
+  return RaftTombstone_descriptor_;
+}
+
+const RaftTombstone& RaftTombstone::default_instance() {
+  if (default_instance_ == NULL) protobuf_AddDesc_cockroach_2froachpb_2finternal_2eproto();
+  return *default_instance_;
+}
+
+RaftTombstone* RaftTombstone::default_instance_ = NULL;
+
+RaftTombstone* RaftTombstone::New(::google::protobuf::Arena* arena) const {
+  RaftTombstone* n = new RaftTombstone;
+  if (arena != NULL) {
+    arena->Own(n);
+  }
+  return n;
+}
+
+void RaftTombstone::Clear() {
+  next_replica_id_ = 0;
+  ::memset(_has_bits_, 0, sizeof(_has_bits_));
+  if (_internal_metadata_.have_unknown_fields()) {
+    mutable_unknown_fields()->Clear();
+  }
+}
+
+bool RaftTombstone::MergePartialFromCodedStream(
+    ::google::protobuf::io::CodedInputStream* input) {
+#define DO_(EXPRESSION) if (!(EXPRESSION)) goto failure
+  ::google::protobuf::uint32 tag;
+  // @@protoc_insertion_point(parse_start:cockroach.roachpb.RaftTombstone)
+  for (;;) {
+    ::std::pair< ::google::protobuf::uint32, bool> p = input->ReadTagWithCutoff(127);
+    tag = p.first;
+    if (!p.second) goto handle_unusual;
+    switch (::google::protobuf::internal::WireFormatLite::GetTagFieldNumber(tag)) {
+      // optional int32 next_replica_id = 1;
+      case 1: {
+        if (tag == 8) {
+          DO_((::google::protobuf::internal::WireFormatLite::ReadPrimitive<
+                   ::google::protobuf::int32, ::google::protobuf::internal::WireFormatLite::TYPE_INT32>(
+                 input, &next_replica_id_)));
+          set_has_next_replica_id();
+        } else {
+          goto handle_unusual;
+        }
+        if (input->ExpectAtEnd()) goto success;
+        break;
+      }
+
+      default: {
+      handle_unusual:
+        if (tag == 0 ||
+            ::google::protobuf::internal::WireFormatLite::GetTagWireType(tag) ==
+            ::google::protobuf::internal::WireFormatLite::WIRETYPE_END_GROUP) {
+          goto success;
+        }
+        DO_(::google::protobuf::internal::WireFormat::SkipField(
+              input, tag, mutable_unknown_fields()));
+        break;
+      }
+    }
+  }
+success:
+  // @@protoc_insertion_point(parse_success:cockroach.roachpb.RaftTombstone)
+  return true;
+failure:
+  // @@protoc_insertion_point(parse_failure:cockroach.roachpb.RaftTombstone)
+  return false;
+#undef DO_
+}
+
+void RaftTombstone::SerializeWithCachedSizes(
+    ::google::protobuf::io::CodedOutputStream* output) const {
+  // @@protoc_insertion_point(serialize_start:cockroach.roachpb.RaftTombstone)
+  // optional int32 next_replica_id = 1;
+  if (has_next_replica_id()) {
+    ::google::protobuf::internal::WireFormatLite::WriteInt32(1, this->next_replica_id(), output);
+  }
+
+  if (_internal_metadata_.have_unknown_fields()) {
+    ::google::protobuf::internal::WireFormat::SerializeUnknownFields(
+        unknown_fields(), output);
+  }
+  // @@protoc_insertion_point(serialize_end:cockroach.roachpb.RaftTombstone)
+}
+
+::google::protobuf::uint8* RaftTombstone::SerializeWithCachedSizesToArray(
+    ::google::protobuf::uint8* target) const {
+  // @@protoc_insertion_point(serialize_to_array_start:cockroach.roachpb.RaftTombstone)
+  // optional int32 next_replica_id = 1;
+  if (has_next_replica_id()) {
+    target = ::google::protobuf::internal::WireFormatLite::WriteInt32ToArray(1, this->next_replica_id(), target);
+  }
+
+  if (_internal_metadata_.have_unknown_fields()) {
+    target = ::google::protobuf::internal::WireFormat::SerializeUnknownFieldsToArray(
+        unknown_fields(), target);
+  }
+  // @@protoc_insertion_point(serialize_to_array_end:cockroach.roachpb.RaftTombstone)
+  return target;
+}
+
+int RaftTombstone::ByteSize() const {
+  int total_size = 0;
+
+  // optional int32 next_replica_id = 1;
+  if (has_next_replica_id()) {
+    total_size += 1 +
+      ::google::protobuf::internal::WireFormatLite::Int32Size(
+        this->next_replica_id());
+  }
+
+  if (_internal_metadata_.have_unknown_fields()) {
+    total_size +=
+      ::google::protobuf::internal::WireFormat::ComputeUnknownFieldsSize(
+        unknown_fields());
+  }
+  GOOGLE_SAFE_CONCURRENT_WRITES_BEGIN();
+  _cached_size_ = total_size;
+  GOOGLE_SAFE_CONCURRENT_WRITES_END();
+  return total_size;
+}
+
+void RaftTombstone::MergeFrom(const ::google::protobuf::Message& from) {
+  if (GOOGLE_PREDICT_FALSE(&from == this)) MergeFromFail(__LINE__);
+  const RaftTombstone* source = 
+      ::google::protobuf::internal::DynamicCastToGenerated<const RaftTombstone>(
+          &from);
+  if (source == NULL) {
+    ::google::protobuf::internal::ReflectionOps::Merge(from, this);
+  } else {
+    MergeFrom(*source);
+  }
+}
+
+void RaftTombstone::MergeFrom(const RaftTombstone& from) {
+  if (GOOGLE_PREDICT_FALSE(&from == this)) MergeFromFail(__LINE__);
+  if (from._has_bits_[0 / 32] & (0xffu << (0 % 32))) {
+    if (from.has_next_replica_id()) {
+      set_next_replica_id(from.next_replica_id());
+    }
+  }
+  if (from._internal_metadata_.have_unknown_fields()) {
+    mutable_unknown_fields()->MergeFrom(from.unknown_fields());
+  }
+}
+
+void RaftTombstone::CopyFrom(const ::google::protobuf::Message& from) {
+  if (&from == this) return;
+  Clear();
+  MergeFrom(from);
+}
+
+void RaftTombstone::CopyFrom(const RaftTombstone& from) {
+  if (&from == this) return;
+  Clear();
+  MergeFrom(from);
+}
+
+bool RaftTombstone::IsInitialized() const {
+
+  return true;
+}
+
+void RaftTombstone::Swap(RaftTombstone* other) {
+  if (other == this) return;
+  InternalSwap(other);
+}
+void RaftTombstone::InternalSwap(RaftTombstone* other) {
+  std::swap(next_replica_id_, other->next_replica_id_);
+  std::swap(_has_bits_[0], other->_has_bits_[0]);
+  _internal_metadata_.Swap(&other->_internal_metadata_);
+  std::swap(_cached_size_, other->_cached_size_);
+}
+
+::google::protobuf::Metadata RaftTombstone::GetMetadata() const {
+  protobuf_AssignDescriptorsOnce();
+  ::google::protobuf::Metadata metadata;
+  metadata.descriptor = RaftTombstone_descriptor_;
+  metadata.reflection = RaftTombstone_reflection_;
+  return metadata;
+}
+
+#if PROTOBUF_INLINE_NOT_IN_HEADERS
+// RaftTombstone
+
+// optional int32 next_replica_id = 1;
+bool RaftTombstone::has_next_replica_id() const {
+  return (_has_bits_[0] & 0x00000001u) != 0;
+}
+void RaftTombstone::set_has_next_replica_id() {
+  _has_bits_[0] |= 0x00000001u;
+}
+void RaftTombstone::clear_has_next_replica_id() {
+  _has_bits_[0] &= ~0x00000001u;
+}
+void RaftTombstone::clear_next_replica_id() {
+  next_replica_id_ = 0;
+  clear_has_next_replica_id();
+}
+ ::google::protobuf::int32 RaftTombstone::next_replica_id() const {
+  // @@protoc_insertion_point(field_get:cockroach.roachpb.RaftTombstone.next_replica_id)
+  return next_replica_id_;
+}
+ void RaftTombstone::set_next_replica_id(::google::protobuf::int32 value) {
+  set_has_next_replica_id();
+  next_replica_id_ = value;
+  // @@protoc_insertion_point(field_set:cockroach.roachpb.RaftTombstone.next_replica_id)
 }
 
 #endif  // PROTOBUF_INLINE_NOT_IN_HEADERS

--- a/storage/engine/rocksdb/cockroach/roachpb/internal.pb.h
+++ b/storage/engine/rocksdb/cockroach/roachpb/internal.pb.h
@@ -44,6 +44,7 @@ class RaftCommand;
 class InternalTimeSeriesData;
 class InternalTimeSeriesSample;
 class RaftTruncatedState;
+class RaftTombstone;
 class RaftSnapshotData;
 class RaftSnapshotData_KeyValue;
 
@@ -499,6 +500,95 @@ class RaftTruncatedState : public ::google::protobuf::Message {
 
   void InitAsDefaultInstance();
   static RaftTruncatedState* default_instance_;
+};
+// -------------------------------------------------------------------
+
+class RaftTombstone : public ::google::protobuf::Message {
+ public:
+  RaftTombstone();
+  virtual ~RaftTombstone();
+
+  RaftTombstone(const RaftTombstone& from);
+
+  inline RaftTombstone& operator=(const RaftTombstone& from) {
+    CopyFrom(from);
+    return *this;
+  }
+
+  inline const ::google::protobuf::UnknownFieldSet& unknown_fields() const {
+    return _internal_metadata_.unknown_fields();
+  }
+
+  inline ::google::protobuf::UnknownFieldSet* mutable_unknown_fields() {
+    return _internal_metadata_.mutable_unknown_fields();
+  }
+
+  static const ::google::protobuf::Descriptor* descriptor();
+  static const RaftTombstone& default_instance();
+
+  void Swap(RaftTombstone* other);
+
+  // implements Message ----------------------------------------------
+
+  inline RaftTombstone* New() const { return New(NULL); }
+
+  RaftTombstone* New(::google::protobuf::Arena* arena) const;
+  void CopyFrom(const ::google::protobuf::Message& from);
+  void MergeFrom(const ::google::protobuf::Message& from);
+  void CopyFrom(const RaftTombstone& from);
+  void MergeFrom(const RaftTombstone& from);
+  void Clear();
+  bool IsInitialized() const;
+
+  int ByteSize() const;
+  bool MergePartialFromCodedStream(
+      ::google::protobuf::io::CodedInputStream* input);
+  void SerializeWithCachedSizes(
+      ::google::protobuf::io::CodedOutputStream* output) const;
+  ::google::protobuf::uint8* SerializeWithCachedSizesToArray(::google::protobuf::uint8* output) const;
+  int GetCachedSize() const { return _cached_size_; }
+  private:
+  void SharedCtor();
+  void SharedDtor();
+  void SetCachedSize(int size) const;
+  void InternalSwap(RaftTombstone* other);
+  private:
+  inline ::google::protobuf::Arena* GetArenaNoVirtual() const {
+    return _internal_metadata_.arena();
+  }
+  inline void* MaybeArenaPtr() const {
+    return _internal_metadata_.raw_arena_ptr();
+  }
+  public:
+
+  ::google::protobuf::Metadata GetMetadata() const;
+
+  // nested types ----------------------------------------------------
+
+  // accessors -------------------------------------------------------
+
+  // optional int32 next_replica_id = 1;
+  bool has_next_replica_id() const;
+  void clear_next_replica_id();
+  static const int kNextReplicaIdFieldNumber = 1;
+  ::google::protobuf::int32 next_replica_id() const;
+  void set_next_replica_id(::google::protobuf::int32 value);
+
+  // @@protoc_insertion_point(class_scope:cockroach.roachpb.RaftTombstone)
+ private:
+  inline void set_has_next_replica_id();
+  inline void clear_has_next_replica_id();
+
+  ::google::protobuf::internal::InternalMetadataWithArena _internal_metadata_;
+  ::google::protobuf::uint32 _has_bits_[1];
+  mutable int _cached_size_;
+  ::google::protobuf::int32 next_replica_id_;
+  friend void  protobuf_AddDesc_cockroach_2froachpb_2finternal_2eproto();
+  friend void protobuf_AssignDesc_cockroach_2froachpb_2finternal_2eproto();
+  friend void protobuf_ShutdownFile_cockroach_2froachpb_2finternal_2eproto();
+
+  void InitAsDefaultInstance();
+  static RaftTombstone* default_instance_;
 };
 // -------------------------------------------------------------------
 
@@ -1093,6 +1183,34 @@ inline void RaftTruncatedState::set_term(::google::protobuf::uint64 value) {
 
 // -------------------------------------------------------------------
 
+// RaftTombstone
+
+// optional int32 next_replica_id = 1;
+inline bool RaftTombstone::has_next_replica_id() const {
+  return (_has_bits_[0] & 0x00000001u) != 0;
+}
+inline void RaftTombstone::set_has_next_replica_id() {
+  _has_bits_[0] |= 0x00000001u;
+}
+inline void RaftTombstone::clear_has_next_replica_id() {
+  _has_bits_[0] &= ~0x00000001u;
+}
+inline void RaftTombstone::clear_next_replica_id() {
+  next_replica_id_ = 0;
+  clear_has_next_replica_id();
+}
+inline ::google::protobuf::int32 RaftTombstone::next_replica_id() const {
+  // @@protoc_insertion_point(field_get:cockroach.roachpb.RaftTombstone.next_replica_id)
+  return next_replica_id_;
+}
+inline void RaftTombstone::set_next_replica_id(::google::protobuf::int32 value) {
+  set_has_next_replica_id();
+  next_replica_id_ = value;
+  // @@protoc_insertion_point(field_set:cockroach.roachpb.RaftTombstone.next_replica_id)
+}
+
+// -------------------------------------------------------------------
+
 // RaftSnapshotData_KeyValue
 
 // optional bytes key = 1;
@@ -1279,6 +1397,8 @@ RaftSnapshotData::mutable_kv() {
 }
 
 #endif  // !PROTOBUF_INLINE_NOT_IN_HEADERS
+// -------------------------------------------------------------------
+
 // -------------------------------------------------------------------
 
 // -------------------------------------------------------------------

--- a/storage/range_gc_queue.go
+++ b/storage/range_gc_queue.go
@@ -124,7 +124,6 @@ func (q *rangeGCQueue) process(now roachpb.Timestamp, rng *Replica, _ *config.Sy
 		if err := rng.rm.RemoveReplica(rng); err != nil {
 			return err
 		}
-		// TODO(bdarnell): update Destroy to leave tombstones for removed ranges (#768)
 		// TODO(bdarnell): add some sort of locking to prevent the range
 		// from being recreated while the underlying data is being destroyed.
 		if err := rng.Destroy(); err != nil {

--- a/storage/store.go
+++ b/storage/store.go
@@ -1547,7 +1547,8 @@ func (s *Store) GroupStorage(groupID roachpb.RangeID, replicaID roachpb.ReplicaI
 		if ok, err := engine.MVCCGetProto(s.Engine(), tombstoneKey, roachpb.ZeroTimestamp, true, nil, &tombstone); err != nil {
 			return nil, err
 		} else if ok {
-			if replicaID < tombstone.NextReplicaID {
+			if replicaID != multiraft.InvalidReplicaID &&
+				replicaID < tombstone.NextReplicaID {
 				return nil, multiraft.ErrGroupDeleted
 			}
 		}

--- a/util/testing.go
+++ b/util/testing.go
@@ -136,6 +136,12 @@ func IsTrueWithin(trueFunc func() bool, duration time.Duration) error {
 // an exponential backoff starting at 1ns and ending at the specified
 // duration.
 func SucceedsWithin(t Tester, duration time.Duration, fn func() error) {
+	SucceedsWithinDepth(1, t, duration, fn)
+}
+
+// SucceedsWithinDepth is like SucceedsWithin() but with an additional
+// stack depth offset.
+func SucceedsWithinDepth(depth int, t Tester, duration time.Duration, fn func() error) {
 	deadline := time.Now().Add(duration)
 	var lastErr error
 	for wait := time.Duration(1); time.Now().Before(deadline); wait *= 2 {
@@ -148,7 +154,7 @@ func SucceedsWithin(t Tester, duration time.Duration, fn func() error) {
 		}
 		time.Sleep(wait)
 	}
-	t.Fatal(ErrorfSkipFrames(1, "condition failed to evaluate within %s: %s", duration, lastErr))
+	t.Fatal(ErrorfSkipFrames(1+depth, "condition failed to evaluate within %s: %s", duration, lastErr))
 }
 
 // Panics calls the supplied function and returns true if and only if it panics.


### PR DESCRIPTION
When a replica is removed, leave a tombstone behind, and prevent the
recreation of the same range without a higher replica ID.

Added a new test which demonstrates a split-brain scenario caused by
the reuse of old replica IDs. Also fixes some other tests, but
not all of the ones that it has been blamed for.

Fixes #768.
