### PR TITLE
Introduce a BeginTransaction request.

### DIFF
--- a/client/batch.go
+++ b/client/batch.go
@@ -157,6 +157,7 @@ func (b *Batch) fillResults(br *roachpb.BatchResponse, pErr *roachpb.Error) erro
 				row.Key = []byte(args.(*roachpb.DeleteRequest).Key)
 
 			case *roachpb.DeleteRangeRequest:
+			case *roachpb.BeginTransactionRequest:
 			case *roachpb.EndTransactionRequest:
 			case *roachpb.AdminMergeRequest:
 			case *roachpb.AdminSplitRequest:

--- a/client/txn.go
+++ b/client/txn.go
@@ -408,26 +408,42 @@ func (txn *Txn) send(reqs ...roachpb.Request) (*roachpb.BatchResponse, *roachpb.
 		return &roachpb.BatchResponse{}, nil
 	}
 
-	lastReq := reqs[lastIndex]
-	// haveTxnWrite tracks intention to write. This is in contrast to
-	// txn.Proto.Writing, which is set by the coordinator when the first
-	// intent has been created, and which lives for the life of the
-	// transaction.
-	haveTxnWrite := roachpb.IsTransactionWrite(lastReq)
+	// firstWriteIndex is set to the index of the first command which is
+	// a transactional write. If != -1, this indicates an intention to
+	// write. This is in contrast to txn.Proto.Writing, which is set by
+	// the coordinator when the first intent has been created, and which
+	// lives for the life of the transaction.
+	firstWriteIndex := -1
+	var firstWriteKey roachpb.Key
 
-	for _, args := range reqs[:lastIndex] {
-		if _, ok := args.(*roachpb.EndTransactionRequest); ok {
-			return nil, roachpb.NewError(util.Errorf("%s sent as non-terminal call", args.Method()))
+	for i, args := range reqs {
+		if i < lastIndex {
+			if _, ok := args.(*roachpb.EndTransactionRequest); ok {
+				return nil, roachpb.NewError(util.Errorf("%s sent as non-terminal call", args.Method()))
+			}
 		}
-
-		if !haveTxnWrite {
-			haveTxnWrite = roachpb.IsTransactionWrite(args)
+		if roachpb.IsTransactionWrite(args) && firstWriteIndex == -1 {
+			firstWriteKey = args.Header().Key
+			firstWriteIndex = i
 		}
 	}
 
-	endTxnRequest, haveEndTxn := lastReq.(*roachpb.EndTransactionRequest)
+	haveTxnWrite := firstWriteIndex != -1
+	endTxnRequest, haveEndTxn := reqs[lastIndex].(*roachpb.EndTransactionRequest)
+	needBeginTxn := !txn.Proto.Writing && haveTxnWrite
 	needEndTxn := txn.Proto.Writing || haveTxnWrite
 	elideEndTxn := haveEndTxn && !needEndTxn
+
+	// If we're not yet writing in this txn, but intend to, insert a
+	// begin transaction request before the first write command.
+	if needBeginTxn {
+		bt := &roachpb.BeginTransactionRequest{
+			Span: roachpb.Span{
+				Key: firstWriteKey,
+			},
+		}
+		reqs = append(append(append([]roachpb.Request(nil), reqs[:firstWriteIndex]...), []roachpb.Request{bt}...), reqs[firstWriteIndex:]...)
+	}
 
 	if elideEndTxn {
 		reqs = reqs[:lastIndex]
@@ -443,6 +459,25 @@ func (txn *Txn) send(reqs ...roachpb.Request) (*roachpb.BatchResponse, *roachpb.
 			txn.Proto.Status = roachpb.COMMITTED
 		} else {
 			txn.Proto.Status = roachpb.ABORTED
+		}
+	}
+
+	// If we inserted a begin transaction request, remove it here.
+	if needBeginTxn {
+		if br != nil && br.Responses != nil {
+			br.Responses = append(br.Responses[:firstWriteIndex], br.Responses[firstWriteIndex+1:]...)
+		}
+		// Handle case where inserted begin txn confused an indexed error.
+		if iErr, ok := pErr.(roachpb.IndexedError); ok {
+			if idx, idxSpecified := iErr.ErrorIndex(); idxSpecified {
+				switch idx {
+				case firstWriteIndex: // error w/ begin txn; return err w/o index
+					iErr.Index = nil
+					return nil, iErr
+				case idx > firstWriteIndex: // error after begin txn; decrement index
+					iErr.SetErrorIndex(idx - 1)
+				}
+			}
 		}
 	}
 	return br, pErr

--- a/client/txn_test.go
+++ b/client/txn_test.go
@@ -45,6 +45,8 @@ func newDB(sender Sender) *DB {
 	}
 }
 
+// TestSender mocks out some of the txn coordinator sender's
+// functionality. It responds to PutRequests using testPutResp.
 func newTestSender(pre, post func(roachpb.BatchRequest) (*roachpb.BatchResponse, *roachpb.Error)) SenderFunc {
 	txnKey := roachpb.Key("test-txn")
 	txnID := []byte(uuid.NewUUID4())
@@ -68,9 +70,16 @@ func newTestSender(pre, post func(roachpb.BatchRequest) (*roachpb.BatchResponse,
 		}
 		var writing bool
 		status := roachpb.PENDING
-		if _, ok := ba.GetArg(roachpb.Put); ok {
-			br.Add(proto.Clone(testPutResp).(roachpb.Response))
-			writing = true
+		for i, req := range ba.Requests {
+			args := req.GetInner()
+			if _, ok := args.(*roachpb.PutRequest); ok {
+				if !br.Responses[i].SetValue(proto.Clone(testPutResp).(roachpb.Response)) {
+					panic("failed to set put response")
+				}
+			}
+			if roachpb.IsTransactionWrite(args) {
+				writing = true
+			}
 		}
 		if args, ok := ba.GetArg(roachpb.EndTransaction); ok {
 			et := args.(*roachpb.EndTransactionRequest)
@@ -240,20 +249,63 @@ func TestCommitReadOnlyTransactionExplicit(t *testing.T) {
 // upon successful invocation of the retryable func.
 func TestCommitMutatingTransaction(t *testing.T) {
 	defer leaktest.AfterTest(t)
+
 	var calls []roachpb.Method
 	db := newDB(newTestSender(func(ba roachpb.BatchRequest) (*roachpb.BatchResponse, *roachpb.Error) {
 		calls = append(calls, ba.Methods()...)
+		if bt, ok := ba.GetArg(roachpb.BeginTransaction); ok && !bt.Header().Key.Equal(roachpb.Key("a")) {
+			t.Errorf("expected begin transaction key to be \"a\"; got %s", bt.Header().Key)
+		}
 		if et, ok := ba.GetArg(roachpb.EndTransaction); ok && !et.(*roachpb.EndTransactionRequest).Commit {
 			t.Errorf("expected commit to be true")
 		}
 		return ba.CreateReply(), nil
 	}, nil))
+
+	// Test all transactional write methods.
+	testArgs := []struct {
+		f         func(txn *Txn) error
+		expMethod roachpb.Method
+	}{
+		{func(txn *Txn) error { return txn.Put("a", "b") }, roachpb.Put},
+		{func(txn *Txn) error { return txn.CPut("a", "b", nil) }, roachpb.ConditionalPut},
+		{func(txn *Txn) error {
+			_, err := txn.Inc("a", 1)
+			return err
+		}, roachpb.Increment},
+		{func(txn *Txn) error { return txn.Del("a") }, roachpb.Delete},
+		{func(txn *Txn) error { return txn.DelRange("a", "b") }, roachpb.DeleteRange},
+	}
+	for i, test := range testArgs {
+		calls = []roachpb.Method{}
+		if err := db.Txn(func(txn *Txn) error {
+			return test.f(txn)
+		}); err != nil {
+			t.Errorf("%d: unexpected error on commit: %s", i, err)
+		}
+		expectedCalls := []roachpb.Method{roachpb.BeginTransaction, test.expMethod, roachpb.EndTransaction}
+		if !reflect.DeepEqual(expectedCalls, calls) {
+			t.Errorf("%d: expected %s, got %s", i, expectedCalls, calls)
+		}
+	}
+}
+
+// TestTxnInsertBeginTransaction verifies that a begin transaction
+// request is inserted just before the first mutating command.
+func TestTxnInsertBeginTransaction(t *testing.T) {
+	defer leaktest.AfterTest(t)
+	var calls []roachpb.Method
+	db := newDB(newTestSender(func(ba roachpb.BatchRequest) (*roachpb.BatchResponse, *roachpb.Error) {
+		calls = append(calls, ba.Methods()...)
+		return ba.CreateReply(), nil
+	}, nil))
 	if err := db.Txn(func(txn *Txn) error {
+		txn.Get("foo")
 		return txn.Put("a", "b")
 	}); err != nil {
 		t.Errorf("unexpected error on commit: %s", err)
 	}
-	expectedCalls := []roachpb.Method{roachpb.Put, roachpb.EndTransaction}
+	expectedCalls := []roachpb.Method{roachpb.Get, roachpb.BeginTransaction, roachpb.Put, roachpb.EndTransaction}
 	if !reflect.DeepEqual(expectedCalls, calls) {
 		t.Errorf("expected %s, got %s", expectedCalls, calls)
 	}
@@ -306,7 +358,7 @@ func TestAbortReadOnlyTransaction(t *testing.T) {
 func TestEndWriteRestartReadOnlyTransaction(t *testing.T) {
 	defer leaktest.AfterTest(t)
 	for _, success := range []bool{true, false} {
-		expCalls := []roachpb.Method{roachpb.Put, roachpb.EndTransaction}
+		expCalls := []roachpb.Method{roachpb.BeginTransaction, roachpb.Put, roachpb.EndTransaction}
 		var calls []roachpb.Method
 		db := newDB(newTestSender(func(ba roachpb.BatchRequest) (*roachpb.BatchResponse, *roachpb.Error) {
 			calls = append(calls, ba.Methods()...)
@@ -355,7 +407,7 @@ func TestAbortMutatingTransaction(t *testing.T) {
 	}); err == nil {
 		t.Error("expected error on abort")
 	}
-	expectedCalls := []roachpb.Method{roachpb.Put, roachpb.EndTransaction}
+	expectedCalls := []roachpb.Method{roachpb.BeginTransaction, roachpb.Put, roachpb.EndTransaction}
 	if !reflect.DeepEqual(expectedCalls, calls) {
 		t.Errorf("expected %s, got %s", expectedCalls, calls)
 	}

--- a/client/txn_test.go
+++ b/client/txn_test.go
@@ -300,7 +300,9 @@ func TestTxnInsertBeginTransaction(t *testing.T) {
 		return ba.CreateReply(), nil
 	}, nil))
 	if err := db.Txn(func(txn *Txn) error {
-		txn.Get("foo")
+		if _, err := txn.Get("foo"); err != nil {
+			return err
+		}
 		return txn.Put("a", "b")
 	}); err != nil {
 		t.Errorf("unexpected error on commit: %s", err)

--- a/kv/db.go
+++ b/kv/db.go
@@ -29,17 +29,18 @@ import (
 )
 
 var allExternalMethods = [...]roachpb.Request{
-	roachpb.Get:            &roachpb.GetRequest{},
-	roachpb.Put:            &roachpb.PutRequest{},
-	roachpb.ConditionalPut: &roachpb.ConditionalPutRequest{},
-	roachpb.Increment:      &roachpb.IncrementRequest{},
-	roachpb.Delete:         &roachpb.DeleteRequest{},
-	roachpb.DeleteRange:    &roachpb.DeleteRangeRequest{},
-	roachpb.Scan:           &roachpb.ScanRequest{},
-	roachpb.ReverseScan:    &roachpb.ReverseScanRequest{},
-	roachpb.EndTransaction: &roachpb.EndTransactionRequest{},
-	roachpb.AdminSplit:     &roachpb.AdminSplitRequest{},
-	roachpb.AdminMerge:     &roachpb.AdminMergeRequest{},
+	roachpb.Get:              &roachpb.GetRequest{},
+	roachpb.Put:              &roachpb.PutRequest{},
+	roachpb.ConditionalPut:   &roachpb.ConditionalPutRequest{},
+	roachpb.Increment:        &roachpb.IncrementRequest{},
+	roachpb.Delete:           &roachpb.DeleteRequest{},
+	roachpb.DeleteRange:      &roachpb.DeleteRangeRequest{},
+	roachpb.Scan:             &roachpb.ScanRequest{},
+	roachpb.ReverseScan:      &roachpb.ReverseScanRequest{},
+	roachpb.BeginTransaction: &roachpb.BeginTransactionRequest{},
+	roachpb.EndTransaction:   &roachpb.EndTransactionRequest{},
+	roachpb.AdminSplit:       &roachpb.AdminSplitRequest{},
+	roachpb.AdminMerge:       &roachpb.AdminMergeRequest{},
 }
 
 // A DBServer provides an HTTP server endpoint serving the key-value API.

--- a/multiraft/multiraft.go
+++ b/multiraft/multiraft.go
@@ -1119,6 +1119,7 @@ func (s *state) processCommittedEntry(groupID roachpb.RangeID, g *group, entry r
 						var err error
 						switch cc.Type {
 						case raftpb.ConfChangeAddNode:
+							log.Infof("adding node %d to raft replica group for node %d", replica.NodeID, s.nodeID)
 							err = s.addNode(replica.NodeID, g)
 						case raftpb.ConfChangeRemoveNode:
 							err = s.removeNode(replica.NodeID, g)

--- a/multiraft/multiraft.go
+++ b/multiraft/multiraft.go
@@ -1119,7 +1119,6 @@ func (s *state) processCommittedEntry(groupID roachpb.RangeID, g *group, entry r
 						var err error
 						switch cc.Type {
 						case raftpb.ConfChangeAddNode:
-							log.Infof("adding node %d to raft replica group for node %d", replica.NodeID, s.nodeID)
 							err = s.addNode(replica.NodeID, g)
 						case raftpb.ConfChangeRemoveNode:
 							err = s.removeNode(replica.NodeID, g)

--- a/roachpb/api.go
+++ b/roachpb/api.go
@@ -304,6 +304,9 @@ func (*ScanRequest) Method() Method { return Scan }
 func (*ReverseScanRequest) Method() Method { return ReverseScan }
 
 // Method implements the Request interface.
+func (*BeginTransactionRequest) Method() Method { return BeginTransaction }
+
+// Method implements the Request interface.
 func (*EndTransactionRequest) Method() Method { return EndTransaction }
 
 // Method implements the Request interface.
@@ -365,6 +368,9 @@ func (*ScanRequest) CreateReply() Response { return &ScanResponse{} }
 
 // CreateReply implements the Request interface.
 func (*ReverseScanRequest) CreateReply() Response { return &ReverseScanResponse{} }
+
+// CreateReply implements the Request interface.
+func (*BeginTransactionRequest) CreateReply() Response { return &BeginTransactionResponse{} }
 
 // CreateReply implements the Request interface.
 func (*EndTransactionRequest) CreateReply() Response { return &EndTransactionResponse{} }
@@ -508,6 +514,7 @@ func (*DeleteRequest) flags() int             { return isWrite | isTxnWrite }
 func (*DeleteRangeRequest) flags() int        { return isWrite | isTxnWrite | isRange }
 func (*ScanRequest) flags() int               { return isRead | isRange }
 func (*ReverseScanRequest) flags() int        { return isRead | isRange | isReverse }
+func (*BeginTransactionRequest) flags() int   { return isWrite }
 func (*EndTransactionRequest) flags() int     { return isWrite | isAlone }
 func (*AdminSplitRequest) flags() int         { return isAdmin | isAlone }
 func (*AdminMergeRequest) flags() int         { return isAdmin | isAlone }

--- a/roachpb/api.pb.go
+++ b/roachpb/api.pb.go
@@ -32,6 +32,8 @@
 		ScanResponse
 		ReverseScanRequest
 		ReverseScanResponse
+		BeginTransactionRequest
+		BeginTransactionResponse
 		EndTransactionRequest
 		EndTransactionResponse
 		AdminSplitRequest
@@ -586,6 +588,24 @@ func (m *ReverseScanResponse) GetRows() []KeyValue {
 	}
 	return nil
 }
+
+// A BeginTransactionRequest is the argument to the BeginTransaction() method.
+type BeginTransactionRequest struct {
+	Span `protobuf:"bytes,1,opt,name=header,embedded=header" json:"header"`
+}
+
+func (m *BeginTransactionRequest) Reset()         { *m = BeginTransactionRequest{} }
+func (m *BeginTransactionRequest) String() string { return proto.CompactTextString(m) }
+func (*BeginTransactionRequest) ProtoMessage()    {}
+
+// A BeginTransactionResponse is the return value from the BeginTransaction() method.
+type BeginTransactionResponse struct {
+	ResponseHeader `protobuf:"bytes,1,opt,name=header,embedded=header" json:"header"`
+}
+
+func (m *BeginTransactionResponse) Reset()         { *m = BeginTransactionResponse{} }
+func (m *BeginTransactionResponse) String() string { return proto.CompactTextString(m) }
+func (*BeginTransactionResponse) ProtoMessage()    {}
 
 // An EndTransactionRequest is the argument to the EndTransaction() method. It
 // specifies whether to commit or roll back an extant transaction.
@@ -1171,20 +1191,21 @@ type RequestUnion struct {
 	Delete             *DeleteRequest             `protobuf:"bytes,5,opt,name=delete" json:"delete,omitempty"`
 	DeleteRange        *DeleteRangeRequest        `protobuf:"bytes,6,opt,name=delete_range" json:"delete_range,omitempty"`
 	Scan               *ScanRequest               `protobuf:"bytes,7,opt,name=scan" json:"scan,omitempty"`
-	EndTransaction     *EndTransactionRequest     `protobuf:"bytes,8,opt,name=end_transaction" json:"end_transaction,omitempty"`
-	AdminSplit         *AdminSplitRequest         `protobuf:"bytes,9,opt,name=admin_split" json:"admin_split,omitempty"`
-	AdminMerge         *AdminMergeRequest         `protobuf:"bytes,10,opt,name=admin_merge" json:"admin_merge,omitempty"`
-	HeartbeatTxn       *HeartbeatTxnRequest       `protobuf:"bytes,11,opt,name=heartbeat_txn" json:"heartbeat_txn,omitempty"`
-	Gc                 *GCRequest                 `protobuf:"bytes,12,opt,name=gc" json:"gc,omitempty"`
-	PushTxn            *PushTxnRequest            `protobuf:"bytes,13,opt,name=push_txn" json:"push_txn,omitempty"`
-	RangeLookup        *RangeLookupRequest        `protobuf:"bytes,14,opt,name=range_lookup" json:"range_lookup,omitempty"`
-	ResolveIntent      *ResolveIntentRequest      `protobuf:"bytes,15,opt,name=resolve_intent" json:"resolve_intent,omitempty"`
-	ResolveIntentRange *ResolveIntentRangeRequest `protobuf:"bytes,16,opt,name=resolve_intent_range" json:"resolve_intent_range,omitempty"`
-	Merge              *MergeRequest              `protobuf:"bytes,17,opt,name=merge" json:"merge,omitempty"`
-	TruncateLog        *TruncateLogRequest        `protobuf:"bytes,18,opt,name=truncate_log" json:"truncate_log,omitempty"`
-	LeaderLease        *LeaderLeaseRequest        `protobuf:"bytes,19,opt,name=leader_lease" json:"leader_lease,omitempty"`
-	ReverseScan        *ReverseScanRequest        `protobuf:"bytes,20,opt,name=reverse_scan" json:"reverse_scan,omitempty"`
-	Noop               *NoopRequest               `protobuf:"bytes,21,opt,name=noop" json:"noop,omitempty"`
+	BeginTransaction   *BeginTransactionRequest   `protobuf:"bytes,8,opt,name=begin_transaction" json:"begin_transaction,omitempty"`
+	EndTransaction     *EndTransactionRequest     `protobuf:"bytes,9,opt,name=end_transaction" json:"end_transaction,omitempty"`
+	AdminSplit         *AdminSplitRequest         `protobuf:"bytes,10,opt,name=admin_split" json:"admin_split,omitempty"`
+	AdminMerge         *AdminMergeRequest         `protobuf:"bytes,11,opt,name=admin_merge" json:"admin_merge,omitempty"`
+	HeartbeatTxn       *HeartbeatTxnRequest       `protobuf:"bytes,12,opt,name=heartbeat_txn" json:"heartbeat_txn,omitempty"`
+	Gc                 *GCRequest                 `protobuf:"bytes,13,opt,name=gc" json:"gc,omitempty"`
+	PushTxn            *PushTxnRequest            `protobuf:"bytes,14,opt,name=push_txn" json:"push_txn,omitempty"`
+	RangeLookup        *RangeLookupRequest        `protobuf:"bytes,15,opt,name=range_lookup" json:"range_lookup,omitempty"`
+	ResolveIntent      *ResolveIntentRequest      `protobuf:"bytes,16,opt,name=resolve_intent" json:"resolve_intent,omitempty"`
+	ResolveIntentRange *ResolveIntentRangeRequest `protobuf:"bytes,17,opt,name=resolve_intent_range" json:"resolve_intent_range,omitempty"`
+	Merge              *MergeRequest              `protobuf:"bytes,18,opt,name=merge" json:"merge,omitempty"`
+	TruncateLog        *TruncateLogRequest        `protobuf:"bytes,19,opt,name=truncate_log" json:"truncate_log,omitempty"`
+	LeaderLease        *LeaderLeaseRequest        `protobuf:"bytes,20,opt,name=leader_lease" json:"leader_lease,omitempty"`
+	ReverseScan        *ReverseScanRequest        `protobuf:"bytes,21,opt,name=reverse_scan" json:"reverse_scan,omitempty"`
+	Noop               *NoopRequest               `protobuf:"bytes,22,opt,name=noop" json:"noop,omitempty"`
 }
 
 func (m *RequestUnion) Reset()         { *m = RequestUnion{} }
@@ -1236,6 +1257,13 @@ func (m *RequestUnion) GetDeleteRange() *DeleteRangeRequest {
 func (m *RequestUnion) GetScan() *ScanRequest {
 	if m != nil {
 		return m.Scan
+	}
+	return nil
+}
+
+func (m *RequestUnion) GetBeginTransaction() *BeginTransactionRequest {
+	if m != nil {
+		return m.BeginTransaction
 	}
 	return nil
 }
@@ -1348,20 +1376,21 @@ type ResponseUnion struct {
 	Delete             *DeleteResponse             `protobuf:"bytes,5,opt,name=delete" json:"delete,omitempty"`
 	DeleteRange        *DeleteRangeResponse        `protobuf:"bytes,6,opt,name=delete_range" json:"delete_range,omitempty"`
 	Scan               *ScanResponse               `protobuf:"bytes,7,opt,name=scan" json:"scan,omitempty"`
-	EndTransaction     *EndTransactionResponse     `protobuf:"bytes,8,opt,name=end_transaction" json:"end_transaction,omitempty"`
-	AdminSplit         *AdminSplitResponse         `protobuf:"bytes,9,opt,name=admin_split" json:"admin_split,omitempty"`
-	AdminMerge         *AdminMergeResponse         `protobuf:"bytes,10,opt,name=admin_merge" json:"admin_merge,omitempty"`
-	HeartbeatTxn       *HeartbeatTxnResponse       `protobuf:"bytes,11,opt,name=heartbeat_txn" json:"heartbeat_txn,omitempty"`
-	Gc                 *GCResponse                 `protobuf:"bytes,12,opt,name=gc" json:"gc,omitempty"`
-	PushTxn            *PushTxnResponse            `protobuf:"bytes,13,opt,name=push_txn" json:"push_txn,omitempty"`
-	RangeLookup        *RangeLookupResponse        `protobuf:"bytes,14,opt,name=range_lookup" json:"range_lookup,omitempty"`
-	ResolveIntent      *ResolveIntentResponse      `protobuf:"bytes,15,opt,name=resolve_intent" json:"resolve_intent,omitempty"`
-	ResolveIntentRange *ResolveIntentRangeResponse `protobuf:"bytes,16,opt,name=resolve_intent_range" json:"resolve_intent_range,omitempty"`
-	Merge              *MergeResponse              `protobuf:"bytes,17,opt,name=merge" json:"merge,omitempty"`
-	TruncateLog        *TruncateLogResponse        `protobuf:"bytes,18,opt,name=truncate_log" json:"truncate_log,omitempty"`
-	LeaderLease        *LeaderLeaseResponse        `protobuf:"bytes,19,opt,name=leader_lease" json:"leader_lease,omitempty"`
-	ReverseScan        *ReverseScanResponse        `protobuf:"bytes,20,opt,name=reverse_scan" json:"reverse_scan,omitempty"`
-	Noop               *NoopResponse               `protobuf:"bytes,21,opt,name=noop" json:"noop,omitempty"`
+	BeginTransaction   *BeginTransactionResponse   `protobuf:"bytes,8,opt,name=begin_transaction" json:"begin_transaction,omitempty"`
+	EndTransaction     *EndTransactionResponse     `protobuf:"bytes,9,opt,name=end_transaction" json:"end_transaction,omitempty"`
+	AdminSplit         *AdminSplitResponse         `protobuf:"bytes,10,opt,name=admin_split" json:"admin_split,omitempty"`
+	AdminMerge         *AdminMergeResponse         `protobuf:"bytes,11,opt,name=admin_merge" json:"admin_merge,omitempty"`
+	HeartbeatTxn       *HeartbeatTxnResponse       `protobuf:"bytes,12,opt,name=heartbeat_txn" json:"heartbeat_txn,omitempty"`
+	Gc                 *GCResponse                 `protobuf:"bytes,13,opt,name=gc" json:"gc,omitempty"`
+	PushTxn            *PushTxnResponse            `protobuf:"bytes,14,opt,name=push_txn" json:"push_txn,omitempty"`
+	RangeLookup        *RangeLookupResponse        `protobuf:"bytes,15,opt,name=range_lookup" json:"range_lookup,omitempty"`
+	ResolveIntent      *ResolveIntentResponse      `protobuf:"bytes,16,opt,name=resolve_intent" json:"resolve_intent,omitempty"`
+	ResolveIntentRange *ResolveIntentRangeResponse `protobuf:"bytes,17,opt,name=resolve_intent_range" json:"resolve_intent_range,omitempty"`
+	Merge              *MergeResponse              `protobuf:"bytes,18,opt,name=merge" json:"merge,omitempty"`
+	TruncateLog        *TruncateLogResponse        `protobuf:"bytes,19,opt,name=truncate_log" json:"truncate_log,omitempty"`
+	LeaderLease        *LeaderLeaseResponse        `protobuf:"bytes,20,opt,name=leader_lease" json:"leader_lease,omitempty"`
+	ReverseScan        *ReverseScanResponse        `protobuf:"bytes,21,opt,name=reverse_scan" json:"reverse_scan,omitempty"`
+	Noop               *NoopResponse               `protobuf:"bytes,22,opt,name=noop" json:"noop,omitempty"`
 }
 
 func (m *ResponseUnion) Reset()         { *m = ResponseUnion{} }
@@ -1413,6 +1442,13 @@ func (m *ResponseUnion) GetDeleteRange() *DeleteRangeResponse {
 func (m *ResponseUnion) GetScan() *ScanResponse {
 	if m != nil {
 		return m.Scan
+	}
+	return nil
+}
+
+func (m *ResponseUnion) GetBeginTransaction() *BeginTransactionResponse {
+	if m != nil {
+		return m.BeginTransaction
 	}
 	return nil
 }
@@ -2279,6 +2315,58 @@ func (m *ReverseScanResponse) MarshalTo(data []byte) (int, error) {
 	return i, nil
 }
 
+func (m *BeginTransactionRequest) Marshal() (data []byte, err error) {
+	size := m.Size()
+	data = make([]byte, size)
+	n, err := m.MarshalTo(data)
+	if err != nil {
+		return nil, err
+	}
+	return data[:n], nil
+}
+
+func (m *BeginTransactionRequest) MarshalTo(data []byte) (int, error) {
+	var i int
+	_ = i
+	var l int
+	_ = l
+	data[i] = 0xa
+	i++
+	i = encodeVarintApi(data, i, uint64(m.Span.Size()))
+	n23, err := m.Span.MarshalTo(data[i:])
+	if err != nil {
+		return 0, err
+	}
+	i += n23
+	return i, nil
+}
+
+func (m *BeginTransactionResponse) Marshal() (data []byte, err error) {
+	size := m.Size()
+	data = make([]byte, size)
+	n, err := m.MarshalTo(data)
+	if err != nil {
+		return nil, err
+	}
+	return data[:n], nil
+}
+
+func (m *BeginTransactionResponse) MarshalTo(data []byte) (int, error) {
+	var i int
+	_ = i
+	var l int
+	_ = l
+	data[i] = 0xa
+	i++
+	i = encodeVarintApi(data, i, uint64(m.ResponseHeader.Size()))
+	n24, err := m.ResponseHeader.MarshalTo(data[i:])
+	if err != nil {
+		return 0, err
+	}
+	i += n24
+	return i, nil
+}
+
 func (m *EndTransactionRequest) Marshal() (data []byte, err error) {
 	size := m.Size()
 	data = make([]byte, size)
@@ -2297,11 +2385,11 @@ func (m *EndTransactionRequest) MarshalTo(data []byte) (int, error) {
 	data[i] = 0xa
 	i++
 	i = encodeVarintApi(data, i, uint64(m.Span.Size()))
-	n23, err := m.Span.MarshalTo(data[i:])
+	n25, err := m.Span.MarshalTo(data[i:])
 	if err != nil {
 		return 0, err
 	}
-	i += n23
+	i += n25
 	data[i] = 0x10
 	i++
 	if m.Commit {
@@ -2314,11 +2402,11 @@ func (m *EndTransactionRequest) MarshalTo(data []byte) (int, error) {
 		data[i] = 0x1a
 		i++
 		i = encodeVarintApi(data, i, uint64(m.InternalCommitTrigger.Size()))
-		n24, err := m.InternalCommitTrigger.MarshalTo(data[i:])
+		n26, err := m.InternalCommitTrigger.MarshalTo(data[i:])
 		if err != nil {
 			return 0, err
 		}
-		i += n24
+		i += n26
 	}
 	if len(m.Intents) > 0 {
 		for _, msg := range m.Intents {
@@ -2353,11 +2441,11 @@ func (m *EndTransactionResponse) MarshalTo(data []byte) (int, error) {
 	data[i] = 0xa
 	i++
 	i = encodeVarintApi(data, i, uint64(m.ResponseHeader.Size()))
-	n25, err := m.ResponseHeader.MarshalTo(data[i:])
+	n27, err := m.ResponseHeader.MarshalTo(data[i:])
 	if err != nil {
 		return 0, err
 	}
-	i += n25
+	i += n27
 	data[i] = 0x10
 	i++
 	i = encodeVarintApi(data, i, uint64(m.CommitWait))
@@ -2390,11 +2478,11 @@ func (m *AdminSplitRequest) MarshalTo(data []byte) (int, error) {
 	data[i] = 0xa
 	i++
 	i = encodeVarintApi(data, i, uint64(m.Span.Size()))
-	n26, err := m.Span.MarshalTo(data[i:])
+	n28, err := m.Span.MarshalTo(data[i:])
 	if err != nil {
 		return 0, err
 	}
-	i += n26
+	i += n28
 	if m.SplitKey != nil {
 		data[i] = 0x12
 		i++
@@ -2422,11 +2510,11 @@ func (m *AdminSplitResponse) MarshalTo(data []byte) (int, error) {
 	data[i] = 0xa
 	i++
 	i = encodeVarintApi(data, i, uint64(m.ResponseHeader.Size()))
-	n27, err := m.ResponseHeader.MarshalTo(data[i:])
+	n29, err := m.ResponseHeader.MarshalTo(data[i:])
 	if err != nil {
 		return 0, err
 	}
-	i += n27
+	i += n29
 	return i, nil
 }
 
@@ -2448,11 +2536,11 @@ func (m *AdminMergeRequest) MarshalTo(data []byte) (int, error) {
 	data[i] = 0xa
 	i++
 	i = encodeVarintApi(data, i, uint64(m.Span.Size()))
-	n28, err := m.Span.MarshalTo(data[i:])
+	n30, err := m.Span.MarshalTo(data[i:])
 	if err != nil {
 		return 0, err
 	}
-	i += n28
+	i += n30
 	return i, nil
 }
 
@@ -2474,11 +2562,11 @@ func (m *AdminMergeResponse) MarshalTo(data []byte) (int, error) {
 	data[i] = 0xa
 	i++
 	i = encodeVarintApi(data, i, uint64(m.ResponseHeader.Size()))
-	n29, err := m.ResponseHeader.MarshalTo(data[i:])
+	n31, err := m.ResponseHeader.MarshalTo(data[i:])
 	if err != nil {
 		return 0, err
 	}
-	i += n29
+	i += n31
 	return i, nil
 }
 
@@ -2500,11 +2588,11 @@ func (m *RangeLookupRequest) MarshalTo(data []byte) (int, error) {
 	data[i] = 0xa
 	i++
 	i = encodeVarintApi(data, i, uint64(m.Span.Size()))
-	n30, err := m.Span.MarshalTo(data[i:])
+	n32, err := m.Span.MarshalTo(data[i:])
 	if err != nil {
 		return 0, err
 	}
-	i += n30
+	i += n32
 	data[i] = 0x10
 	i++
 	i = encodeVarintApi(data, i, uint64(m.MaxRanges))
@@ -2545,11 +2633,11 @@ func (m *RangeLookupResponse) MarshalTo(data []byte) (int, error) {
 	data[i] = 0xa
 	i++
 	i = encodeVarintApi(data, i, uint64(m.ResponseHeader.Size()))
-	n31, err := m.ResponseHeader.MarshalTo(data[i:])
+	n33, err := m.ResponseHeader.MarshalTo(data[i:])
 	if err != nil {
 		return 0, err
 	}
-	i += n31
+	i += n33
 	if len(m.Ranges) > 0 {
 		for _, msg := range m.Ranges {
 			data[i] = 0x12
@@ -2583,11 +2671,11 @@ func (m *HeartbeatTxnRequest) MarshalTo(data []byte) (int, error) {
 	data[i] = 0xa
 	i++
 	i = encodeVarintApi(data, i, uint64(m.Span.Size()))
-	n32, err := m.Span.MarshalTo(data[i:])
+	n34, err := m.Span.MarshalTo(data[i:])
 	if err != nil {
 		return 0, err
 	}
-	i += n32
+	i += n34
 	return i, nil
 }
 
@@ -2609,11 +2697,11 @@ func (m *HeartbeatTxnResponse) MarshalTo(data []byte) (int, error) {
 	data[i] = 0xa
 	i++
 	i = encodeVarintApi(data, i, uint64(m.ResponseHeader.Size()))
-	n33, err := m.ResponseHeader.MarshalTo(data[i:])
+	n35, err := m.ResponseHeader.MarshalTo(data[i:])
 	if err != nil {
 		return 0, err
 	}
-	i += n33
+	i += n35
 	return i, nil
 }
 
@@ -2635,19 +2723,19 @@ func (m *GCRequest) MarshalTo(data []byte) (int, error) {
 	data[i] = 0xa
 	i++
 	i = encodeVarintApi(data, i, uint64(m.Span.Size()))
-	n34, err := m.Span.MarshalTo(data[i:])
+	n36, err := m.Span.MarshalTo(data[i:])
 	if err != nil {
 		return 0, err
 	}
-	i += n34
+	i += n36
 	data[i] = 0x12
 	i++
 	i = encodeVarintApi(data, i, uint64(m.GCMeta.Size()))
-	n35, err := m.GCMeta.MarshalTo(data[i:])
+	n37, err := m.GCMeta.MarshalTo(data[i:])
 	if err != nil {
 		return 0, err
 	}
-	i += n35
+	i += n37
 	if len(m.Keys) > 0 {
 		for _, msg := range m.Keys {
 			data[i] = 0x1a
@@ -2687,11 +2775,11 @@ func (m *GCRequest_GCKey) MarshalTo(data []byte) (int, error) {
 	data[i] = 0x12
 	i++
 	i = encodeVarintApi(data, i, uint64(m.Timestamp.Size()))
-	n36, err := m.Timestamp.MarshalTo(data[i:])
+	n38, err := m.Timestamp.MarshalTo(data[i:])
 	if err != nil {
 		return 0, err
 	}
-	i += n36
+	i += n38
 	return i, nil
 }
 
@@ -2713,11 +2801,11 @@ func (m *GCResponse) MarshalTo(data []byte) (int, error) {
 	data[i] = 0xa
 	i++
 	i = encodeVarintApi(data, i, uint64(m.ResponseHeader.Size()))
-	n37, err := m.ResponseHeader.MarshalTo(data[i:])
+	n39, err := m.ResponseHeader.MarshalTo(data[i:])
 	if err != nil {
 		return 0, err
 	}
-	i += n37
+	i += n39
 	return i, nil
 }
 
@@ -2739,43 +2827,43 @@ func (m *PushTxnRequest) MarshalTo(data []byte) (int, error) {
 	data[i] = 0xa
 	i++
 	i = encodeVarintApi(data, i, uint64(m.Span.Size()))
-	n38, err := m.Span.MarshalTo(data[i:])
-	if err != nil {
-		return 0, err
-	}
-	i += n38
-	data[i] = 0x12
-	i++
-	i = encodeVarintApi(data, i, uint64(m.PusherTxn.Size()))
-	n39, err := m.PusherTxn.MarshalTo(data[i:])
-	if err != nil {
-		return 0, err
-	}
-	i += n39
-	data[i] = 0x1a
-	i++
-	i = encodeVarintApi(data, i, uint64(m.PusheeTxn.Size()))
-	n40, err := m.PusheeTxn.MarshalTo(data[i:])
+	n40, err := m.Span.MarshalTo(data[i:])
 	if err != nil {
 		return 0, err
 	}
 	i += n40
-	data[i] = 0x22
+	data[i] = 0x12
 	i++
-	i = encodeVarintApi(data, i, uint64(m.PushTo.Size()))
-	n41, err := m.PushTo.MarshalTo(data[i:])
+	i = encodeVarintApi(data, i, uint64(m.PusherTxn.Size()))
+	n41, err := m.PusherTxn.MarshalTo(data[i:])
 	if err != nil {
 		return 0, err
 	}
 	i += n41
-	data[i] = 0x2a
+	data[i] = 0x1a
 	i++
-	i = encodeVarintApi(data, i, uint64(m.Now.Size()))
-	n42, err := m.Now.MarshalTo(data[i:])
+	i = encodeVarintApi(data, i, uint64(m.PusheeTxn.Size()))
+	n42, err := m.PusheeTxn.MarshalTo(data[i:])
 	if err != nil {
 		return 0, err
 	}
 	i += n42
+	data[i] = 0x22
+	i++
+	i = encodeVarintApi(data, i, uint64(m.PushTo.Size()))
+	n43, err := m.PushTo.MarshalTo(data[i:])
+	if err != nil {
+		return 0, err
+	}
+	i += n43
+	data[i] = 0x2a
+	i++
+	i = encodeVarintApi(data, i, uint64(m.Now.Size()))
+	n44, err := m.Now.MarshalTo(data[i:])
+	if err != nil {
+		return 0, err
+	}
+	i += n44
 	data[i] = 0x30
 	i++
 	i = encodeVarintApi(data, i, uint64(m.PushType))
@@ -2800,20 +2888,20 @@ func (m *PushTxnResponse) MarshalTo(data []byte) (int, error) {
 	data[i] = 0xa
 	i++
 	i = encodeVarintApi(data, i, uint64(m.ResponseHeader.Size()))
-	n43, err := m.ResponseHeader.MarshalTo(data[i:])
+	n45, err := m.ResponseHeader.MarshalTo(data[i:])
 	if err != nil {
 		return 0, err
 	}
-	i += n43
+	i += n45
 	if m.PusheeTxn != nil {
 		data[i] = 0x12
 		i++
 		i = encodeVarintApi(data, i, uint64(m.PusheeTxn.Size()))
-		n44, err := m.PusheeTxn.MarshalTo(data[i:])
+		n46, err := m.PusheeTxn.MarshalTo(data[i:])
 		if err != nil {
 			return 0, err
 		}
-		i += n44
+		i += n46
 	}
 	return i, nil
 }
@@ -2836,19 +2924,19 @@ func (m *ResolveIntentRequest) MarshalTo(data []byte) (int, error) {
 	data[i] = 0xa
 	i++
 	i = encodeVarintApi(data, i, uint64(m.Span.Size()))
-	n45, err := m.Span.MarshalTo(data[i:])
+	n47, err := m.Span.MarshalTo(data[i:])
 	if err != nil {
 		return 0, err
 	}
-	i += n45
+	i += n47
 	data[i] = 0x12
 	i++
 	i = encodeVarintApi(data, i, uint64(m.IntentTxn.Size()))
-	n46, err := m.IntentTxn.MarshalTo(data[i:])
+	n48, err := m.IntentTxn.MarshalTo(data[i:])
 	if err != nil {
 		return 0, err
 	}
-	i += n46
+	i += n48
 	return i, nil
 }
 
@@ -2870,11 +2958,11 @@ func (m *ResolveIntentResponse) MarshalTo(data []byte) (int, error) {
 	data[i] = 0xa
 	i++
 	i = encodeVarintApi(data, i, uint64(m.ResponseHeader.Size()))
-	n47, err := m.ResponseHeader.MarshalTo(data[i:])
+	n49, err := m.ResponseHeader.MarshalTo(data[i:])
 	if err != nil {
 		return 0, err
 	}
-	i += n47
+	i += n49
 	return i, nil
 }
 
@@ -2896,19 +2984,19 @@ func (m *ResolveIntentRangeRequest) MarshalTo(data []byte) (int, error) {
 	data[i] = 0xa
 	i++
 	i = encodeVarintApi(data, i, uint64(m.Span.Size()))
-	n48, err := m.Span.MarshalTo(data[i:])
+	n50, err := m.Span.MarshalTo(data[i:])
 	if err != nil {
 		return 0, err
 	}
-	i += n48
+	i += n50
 	data[i] = 0x12
 	i++
 	i = encodeVarintApi(data, i, uint64(m.IntentTxn.Size()))
-	n49, err := m.IntentTxn.MarshalTo(data[i:])
+	n51, err := m.IntentTxn.MarshalTo(data[i:])
 	if err != nil {
 		return 0, err
 	}
-	i += n49
+	i += n51
 	return i, nil
 }
 
@@ -2930,11 +3018,11 @@ func (m *NoopResponse) MarshalTo(data []byte) (int, error) {
 	data[i] = 0xa
 	i++
 	i = encodeVarintApi(data, i, uint64(m.ResponseHeader.Size()))
-	n50, err := m.ResponseHeader.MarshalTo(data[i:])
+	n52, err := m.ResponseHeader.MarshalTo(data[i:])
 	if err != nil {
 		return 0, err
 	}
-	i += n50
+	i += n52
 	return i, nil
 }
 
@@ -2956,11 +3044,11 @@ func (m *NoopRequest) MarshalTo(data []byte) (int, error) {
 	data[i] = 0xa
 	i++
 	i = encodeVarintApi(data, i, uint64(m.Span.Size()))
-	n51, err := m.Span.MarshalTo(data[i:])
+	n53, err := m.Span.MarshalTo(data[i:])
 	if err != nil {
 		return 0, err
 	}
-	i += n51
+	i += n53
 	return i, nil
 }
 
@@ -2982,11 +3070,11 @@ func (m *ResolveIntentRangeResponse) MarshalTo(data []byte) (int, error) {
 	data[i] = 0xa
 	i++
 	i = encodeVarintApi(data, i, uint64(m.ResponseHeader.Size()))
-	n52, err := m.ResponseHeader.MarshalTo(data[i:])
+	n54, err := m.ResponseHeader.MarshalTo(data[i:])
 	if err != nil {
 		return 0, err
 	}
-	i += n52
+	i += n54
 	return i, nil
 }
 
@@ -3008,19 +3096,19 @@ func (m *MergeRequest) MarshalTo(data []byte) (int, error) {
 	data[i] = 0xa
 	i++
 	i = encodeVarintApi(data, i, uint64(m.Span.Size()))
-	n53, err := m.Span.MarshalTo(data[i:])
+	n55, err := m.Span.MarshalTo(data[i:])
 	if err != nil {
 		return 0, err
 	}
-	i += n53
+	i += n55
 	data[i] = 0x12
 	i++
 	i = encodeVarintApi(data, i, uint64(m.Value.Size()))
-	n54, err := m.Value.MarshalTo(data[i:])
+	n56, err := m.Value.MarshalTo(data[i:])
 	if err != nil {
 		return 0, err
 	}
-	i += n54
+	i += n56
 	return i, nil
 }
 
@@ -3042,11 +3130,11 @@ func (m *MergeResponse) MarshalTo(data []byte) (int, error) {
 	data[i] = 0xa
 	i++
 	i = encodeVarintApi(data, i, uint64(m.ResponseHeader.Size()))
-	n55, err := m.ResponseHeader.MarshalTo(data[i:])
+	n57, err := m.ResponseHeader.MarshalTo(data[i:])
 	if err != nil {
 		return 0, err
 	}
-	i += n55
+	i += n57
 	return i, nil
 }
 
@@ -3068,11 +3156,11 @@ func (m *TruncateLogRequest) MarshalTo(data []byte) (int, error) {
 	data[i] = 0xa
 	i++
 	i = encodeVarintApi(data, i, uint64(m.Span.Size()))
-	n56, err := m.Span.MarshalTo(data[i:])
+	n58, err := m.Span.MarshalTo(data[i:])
 	if err != nil {
 		return 0, err
 	}
-	i += n56
+	i += n58
 	data[i] = 0x10
 	i++
 	i = encodeVarintApi(data, i, uint64(m.Index))
@@ -3097,11 +3185,11 @@ func (m *TruncateLogResponse) MarshalTo(data []byte) (int, error) {
 	data[i] = 0xa
 	i++
 	i = encodeVarintApi(data, i, uint64(m.ResponseHeader.Size()))
-	n57, err := m.ResponseHeader.MarshalTo(data[i:])
+	n59, err := m.ResponseHeader.MarshalTo(data[i:])
 	if err != nil {
 		return 0, err
 	}
-	i += n57
+	i += n59
 	return i, nil
 }
 
@@ -3123,19 +3211,19 @@ func (m *LeaderLeaseRequest) MarshalTo(data []byte) (int, error) {
 	data[i] = 0xa
 	i++
 	i = encodeVarintApi(data, i, uint64(m.Span.Size()))
-	n58, err := m.Span.MarshalTo(data[i:])
+	n60, err := m.Span.MarshalTo(data[i:])
 	if err != nil {
 		return 0, err
 	}
-	i += n58
+	i += n60
 	data[i] = 0x12
 	i++
 	i = encodeVarintApi(data, i, uint64(m.Lease.Size()))
-	n59, err := m.Lease.MarshalTo(data[i:])
+	n61, err := m.Lease.MarshalTo(data[i:])
 	if err != nil {
 		return 0, err
 	}
-	i += n59
+	i += n61
 	return i, nil
 }
 
@@ -3157,11 +3245,11 @@ func (m *LeaderLeaseResponse) MarshalTo(data []byte) (int, error) {
 	data[i] = 0xa
 	i++
 	i = encodeVarintApi(data, i, uint64(m.ResponseHeader.Size()))
-	n60, err := m.ResponseHeader.MarshalTo(data[i:])
+	n62, err := m.ResponseHeader.MarshalTo(data[i:])
 	if err != nil {
 		return 0, err
 	}
-	i += n60
+	i += n62
 	return i, nil
 }
 
@@ -3184,223 +3272,235 @@ func (m *RequestUnion) MarshalTo(data []byte) (int, error) {
 		data[i] = 0xa
 		i++
 		i = encodeVarintApi(data, i, uint64(m.Get.Size()))
-		n61, err := m.Get.MarshalTo(data[i:])
-		if err != nil {
-			return 0, err
-		}
-		i += n61
-	}
-	if m.Put != nil {
-		data[i] = 0x12
-		i++
-		i = encodeVarintApi(data, i, uint64(m.Put.Size()))
-		n62, err := m.Put.MarshalTo(data[i:])
-		if err != nil {
-			return 0, err
-		}
-		i += n62
-	}
-	if m.ConditionalPut != nil {
-		data[i] = 0x1a
-		i++
-		i = encodeVarintApi(data, i, uint64(m.ConditionalPut.Size()))
-		n63, err := m.ConditionalPut.MarshalTo(data[i:])
+		n63, err := m.Get.MarshalTo(data[i:])
 		if err != nil {
 			return 0, err
 		}
 		i += n63
 	}
-	if m.Increment != nil {
-		data[i] = 0x22
+	if m.Put != nil {
+		data[i] = 0x12
 		i++
-		i = encodeVarintApi(data, i, uint64(m.Increment.Size()))
-		n64, err := m.Increment.MarshalTo(data[i:])
+		i = encodeVarintApi(data, i, uint64(m.Put.Size()))
+		n64, err := m.Put.MarshalTo(data[i:])
 		if err != nil {
 			return 0, err
 		}
 		i += n64
 	}
-	if m.Delete != nil {
-		data[i] = 0x2a
+	if m.ConditionalPut != nil {
+		data[i] = 0x1a
 		i++
-		i = encodeVarintApi(data, i, uint64(m.Delete.Size()))
-		n65, err := m.Delete.MarshalTo(data[i:])
+		i = encodeVarintApi(data, i, uint64(m.ConditionalPut.Size()))
+		n65, err := m.ConditionalPut.MarshalTo(data[i:])
 		if err != nil {
 			return 0, err
 		}
 		i += n65
 	}
-	if m.DeleteRange != nil {
-		data[i] = 0x32
+	if m.Increment != nil {
+		data[i] = 0x22
 		i++
-		i = encodeVarintApi(data, i, uint64(m.DeleteRange.Size()))
-		n66, err := m.DeleteRange.MarshalTo(data[i:])
+		i = encodeVarintApi(data, i, uint64(m.Increment.Size()))
+		n66, err := m.Increment.MarshalTo(data[i:])
 		if err != nil {
 			return 0, err
 		}
 		i += n66
 	}
-	if m.Scan != nil {
-		data[i] = 0x3a
+	if m.Delete != nil {
+		data[i] = 0x2a
 		i++
-		i = encodeVarintApi(data, i, uint64(m.Scan.Size()))
-		n67, err := m.Scan.MarshalTo(data[i:])
+		i = encodeVarintApi(data, i, uint64(m.Delete.Size()))
+		n67, err := m.Delete.MarshalTo(data[i:])
 		if err != nil {
 			return 0, err
 		}
 		i += n67
 	}
-	if m.EndTransaction != nil {
-		data[i] = 0x42
+	if m.DeleteRange != nil {
+		data[i] = 0x32
 		i++
-		i = encodeVarintApi(data, i, uint64(m.EndTransaction.Size()))
-		n68, err := m.EndTransaction.MarshalTo(data[i:])
+		i = encodeVarintApi(data, i, uint64(m.DeleteRange.Size()))
+		n68, err := m.DeleteRange.MarshalTo(data[i:])
 		if err != nil {
 			return 0, err
 		}
 		i += n68
 	}
-	if m.AdminSplit != nil {
-		data[i] = 0x4a
+	if m.Scan != nil {
+		data[i] = 0x3a
 		i++
-		i = encodeVarintApi(data, i, uint64(m.AdminSplit.Size()))
-		n69, err := m.AdminSplit.MarshalTo(data[i:])
+		i = encodeVarintApi(data, i, uint64(m.Scan.Size()))
+		n69, err := m.Scan.MarshalTo(data[i:])
 		if err != nil {
 			return 0, err
 		}
 		i += n69
 	}
-	if m.AdminMerge != nil {
-		data[i] = 0x52
+	if m.BeginTransaction != nil {
+		data[i] = 0x42
 		i++
-		i = encodeVarintApi(data, i, uint64(m.AdminMerge.Size()))
-		n70, err := m.AdminMerge.MarshalTo(data[i:])
+		i = encodeVarintApi(data, i, uint64(m.BeginTransaction.Size()))
+		n70, err := m.BeginTransaction.MarshalTo(data[i:])
 		if err != nil {
 			return 0, err
 		}
 		i += n70
 	}
-	if m.HeartbeatTxn != nil {
-		data[i] = 0x5a
+	if m.EndTransaction != nil {
+		data[i] = 0x4a
 		i++
-		i = encodeVarintApi(data, i, uint64(m.HeartbeatTxn.Size()))
-		n71, err := m.HeartbeatTxn.MarshalTo(data[i:])
+		i = encodeVarintApi(data, i, uint64(m.EndTransaction.Size()))
+		n71, err := m.EndTransaction.MarshalTo(data[i:])
 		if err != nil {
 			return 0, err
 		}
 		i += n71
 	}
-	if m.Gc != nil {
-		data[i] = 0x62
+	if m.AdminSplit != nil {
+		data[i] = 0x52
 		i++
-		i = encodeVarintApi(data, i, uint64(m.Gc.Size()))
-		n72, err := m.Gc.MarshalTo(data[i:])
+		i = encodeVarintApi(data, i, uint64(m.AdminSplit.Size()))
+		n72, err := m.AdminSplit.MarshalTo(data[i:])
 		if err != nil {
 			return 0, err
 		}
 		i += n72
 	}
-	if m.PushTxn != nil {
-		data[i] = 0x6a
+	if m.AdminMerge != nil {
+		data[i] = 0x5a
 		i++
-		i = encodeVarintApi(data, i, uint64(m.PushTxn.Size()))
-		n73, err := m.PushTxn.MarshalTo(data[i:])
+		i = encodeVarintApi(data, i, uint64(m.AdminMerge.Size()))
+		n73, err := m.AdminMerge.MarshalTo(data[i:])
 		if err != nil {
 			return 0, err
 		}
 		i += n73
 	}
-	if m.RangeLookup != nil {
-		data[i] = 0x72
+	if m.HeartbeatTxn != nil {
+		data[i] = 0x62
 		i++
-		i = encodeVarintApi(data, i, uint64(m.RangeLookup.Size()))
-		n74, err := m.RangeLookup.MarshalTo(data[i:])
+		i = encodeVarintApi(data, i, uint64(m.HeartbeatTxn.Size()))
+		n74, err := m.HeartbeatTxn.MarshalTo(data[i:])
 		if err != nil {
 			return 0, err
 		}
 		i += n74
 	}
-	if m.ResolveIntent != nil {
-		data[i] = 0x7a
+	if m.Gc != nil {
+		data[i] = 0x6a
 		i++
-		i = encodeVarintApi(data, i, uint64(m.ResolveIntent.Size()))
-		n75, err := m.ResolveIntent.MarshalTo(data[i:])
+		i = encodeVarintApi(data, i, uint64(m.Gc.Size()))
+		n75, err := m.Gc.MarshalTo(data[i:])
 		if err != nil {
 			return 0, err
 		}
 		i += n75
 	}
-	if m.ResolveIntentRange != nil {
-		data[i] = 0x82
+	if m.PushTxn != nil {
+		data[i] = 0x72
 		i++
-		data[i] = 0x1
-		i++
-		i = encodeVarintApi(data, i, uint64(m.ResolveIntentRange.Size()))
-		n76, err := m.ResolveIntentRange.MarshalTo(data[i:])
+		i = encodeVarintApi(data, i, uint64(m.PushTxn.Size()))
+		n76, err := m.PushTxn.MarshalTo(data[i:])
 		if err != nil {
 			return 0, err
 		}
 		i += n76
 	}
-	if m.Merge != nil {
-		data[i] = 0x8a
+	if m.RangeLookup != nil {
+		data[i] = 0x7a
 		i++
-		data[i] = 0x1
-		i++
-		i = encodeVarintApi(data, i, uint64(m.Merge.Size()))
-		n77, err := m.Merge.MarshalTo(data[i:])
+		i = encodeVarintApi(data, i, uint64(m.RangeLookup.Size()))
+		n77, err := m.RangeLookup.MarshalTo(data[i:])
 		if err != nil {
 			return 0, err
 		}
 		i += n77
 	}
-	if m.TruncateLog != nil {
-		data[i] = 0x92
+	if m.ResolveIntent != nil {
+		data[i] = 0x82
 		i++
 		data[i] = 0x1
 		i++
-		i = encodeVarintApi(data, i, uint64(m.TruncateLog.Size()))
-		n78, err := m.TruncateLog.MarshalTo(data[i:])
+		i = encodeVarintApi(data, i, uint64(m.ResolveIntent.Size()))
+		n78, err := m.ResolveIntent.MarshalTo(data[i:])
 		if err != nil {
 			return 0, err
 		}
 		i += n78
 	}
-	if m.LeaderLease != nil {
-		data[i] = 0x9a
+	if m.ResolveIntentRange != nil {
+		data[i] = 0x8a
 		i++
 		data[i] = 0x1
 		i++
-		i = encodeVarintApi(data, i, uint64(m.LeaderLease.Size()))
-		n79, err := m.LeaderLease.MarshalTo(data[i:])
+		i = encodeVarintApi(data, i, uint64(m.ResolveIntentRange.Size()))
+		n79, err := m.ResolveIntentRange.MarshalTo(data[i:])
 		if err != nil {
 			return 0, err
 		}
 		i += n79
 	}
-	if m.ReverseScan != nil {
-		data[i] = 0xa2
+	if m.Merge != nil {
+		data[i] = 0x92
 		i++
 		data[i] = 0x1
 		i++
-		i = encodeVarintApi(data, i, uint64(m.ReverseScan.Size()))
-		n80, err := m.ReverseScan.MarshalTo(data[i:])
+		i = encodeVarintApi(data, i, uint64(m.Merge.Size()))
+		n80, err := m.Merge.MarshalTo(data[i:])
 		if err != nil {
 			return 0, err
 		}
 		i += n80
 	}
-	if m.Noop != nil {
-		data[i] = 0xaa
+	if m.TruncateLog != nil {
+		data[i] = 0x9a
 		i++
 		data[i] = 0x1
 		i++
-		i = encodeVarintApi(data, i, uint64(m.Noop.Size()))
-		n81, err := m.Noop.MarshalTo(data[i:])
+		i = encodeVarintApi(data, i, uint64(m.TruncateLog.Size()))
+		n81, err := m.TruncateLog.MarshalTo(data[i:])
 		if err != nil {
 			return 0, err
 		}
 		i += n81
+	}
+	if m.LeaderLease != nil {
+		data[i] = 0xa2
+		i++
+		data[i] = 0x1
+		i++
+		i = encodeVarintApi(data, i, uint64(m.LeaderLease.Size()))
+		n82, err := m.LeaderLease.MarshalTo(data[i:])
+		if err != nil {
+			return 0, err
+		}
+		i += n82
+	}
+	if m.ReverseScan != nil {
+		data[i] = 0xaa
+		i++
+		data[i] = 0x1
+		i++
+		i = encodeVarintApi(data, i, uint64(m.ReverseScan.Size()))
+		n83, err := m.ReverseScan.MarshalTo(data[i:])
+		if err != nil {
+			return 0, err
+		}
+		i += n83
+	}
+	if m.Noop != nil {
+		data[i] = 0xb2
+		i++
+		data[i] = 0x1
+		i++
+		i = encodeVarintApi(data, i, uint64(m.Noop.Size()))
+		n84, err := m.Noop.MarshalTo(data[i:])
+		if err != nil {
+			return 0, err
+		}
+		i += n84
 	}
 	return i, nil
 }
@@ -3424,223 +3524,235 @@ func (m *ResponseUnion) MarshalTo(data []byte) (int, error) {
 		data[i] = 0xa
 		i++
 		i = encodeVarintApi(data, i, uint64(m.Get.Size()))
-		n82, err := m.Get.MarshalTo(data[i:])
-		if err != nil {
-			return 0, err
-		}
-		i += n82
-	}
-	if m.Put != nil {
-		data[i] = 0x12
-		i++
-		i = encodeVarintApi(data, i, uint64(m.Put.Size()))
-		n83, err := m.Put.MarshalTo(data[i:])
-		if err != nil {
-			return 0, err
-		}
-		i += n83
-	}
-	if m.ConditionalPut != nil {
-		data[i] = 0x1a
-		i++
-		i = encodeVarintApi(data, i, uint64(m.ConditionalPut.Size()))
-		n84, err := m.ConditionalPut.MarshalTo(data[i:])
-		if err != nil {
-			return 0, err
-		}
-		i += n84
-	}
-	if m.Increment != nil {
-		data[i] = 0x22
-		i++
-		i = encodeVarintApi(data, i, uint64(m.Increment.Size()))
-		n85, err := m.Increment.MarshalTo(data[i:])
+		n85, err := m.Get.MarshalTo(data[i:])
 		if err != nil {
 			return 0, err
 		}
 		i += n85
 	}
-	if m.Delete != nil {
-		data[i] = 0x2a
+	if m.Put != nil {
+		data[i] = 0x12
 		i++
-		i = encodeVarintApi(data, i, uint64(m.Delete.Size()))
-		n86, err := m.Delete.MarshalTo(data[i:])
+		i = encodeVarintApi(data, i, uint64(m.Put.Size()))
+		n86, err := m.Put.MarshalTo(data[i:])
 		if err != nil {
 			return 0, err
 		}
 		i += n86
 	}
-	if m.DeleteRange != nil {
-		data[i] = 0x32
+	if m.ConditionalPut != nil {
+		data[i] = 0x1a
 		i++
-		i = encodeVarintApi(data, i, uint64(m.DeleteRange.Size()))
-		n87, err := m.DeleteRange.MarshalTo(data[i:])
+		i = encodeVarintApi(data, i, uint64(m.ConditionalPut.Size()))
+		n87, err := m.ConditionalPut.MarshalTo(data[i:])
 		if err != nil {
 			return 0, err
 		}
 		i += n87
 	}
-	if m.Scan != nil {
-		data[i] = 0x3a
+	if m.Increment != nil {
+		data[i] = 0x22
 		i++
-		i = encodeVarintApi(data, i, uint64(m.Scan.Size()))
-		n88, err := m.Scan.MarshalTo(data[i:])
+		i = encodeVarintApi(data, i, uint64(m.Increment.Size()))
+		n88, err := m.Increment.MarshalTo(data[i:])
 		if err != nil {
 			return 0, err
 		}
 		i += n88
 	}
-	if m.EndTransaction != nil {
-		data[i] = 0x42
+	if m.Delete != nil {
+		data[i] = 0x2a
 		i++
-		i = encodeVarintApi(data, i, uint64(m.EndTransaction.Size()))
-		n89, err := m.EndTransaction.MarshalTo(data[i:])
+		i = encodeVarintApi(data, i, uint64(m.Delete.Size()))
+		n89, err := m.Delete.MarshalTo(data[i:])
 		if err != nil {
 			return 0, err
 		}
 		i += n89
 	}
-	if m.AdminSplit != nil {
-		data[i] = 0x4a
+	if m.DeleteRange != nil {
+		data[i] = 0x32
 		i++
-		i = encodeVarintApi(data, i, uint64(m.AdminSplit.Size()))
-		n90, err := m.AdminSplit.MarshalTo(data[i:])
+		i = encodeVarintApi(data, i, uint64(m.DeleteRange.Size()))
+		n90, err := m.DeleteRange.MarshalTo(data[i:])
 		if err != nil {
 			return 0, err
 		}
 		i += n90
 	}
-	if m.AdminMerge != nil {
-		data[i] = 0x52
+	if m.Scan != nil {
+		data[i] = 0x3a
 		i++
-		i = encodeVarintApi(data, i, uint64(m.AdminMerge.Size()))
-		n91, err := m.AdminMerge.MarshalTo(data[i:])
+		i = encodeVarintApi(data, i, uint64(m.Scan.Size()))
+		n91, err := m.Scan.MarshalTo(data[i:])
 		if err != nil {
 			return 0, err
 		}
 		i += n91
 	}
-	if m.HeartbeatTxn != nil {
-		data[i] = 0x5a
+	if m.BeginTransaction != nil {
+		data[i] = 0x42
 		i++
-		i = encodeVarintApi(data, i, uint64(m.HeartbeatTxn.Size()))
-		n92, err := m.HeartbeatTxn.MarshalTo(data[i:])
+		i = encodeVarintApi(data, i, uint64(m.BeginTransaction.Size()))
+		n92, err := m.BeginTransaction.MarshalTo(data[i:])
 		if err != nil {
 			return 0, err
 		}
 		i += n92
 	}
-	if m.Gc != nil {
-		data[i] = 0x62
+	if m.EndTransaction != nil {
+		data[i] = 0x4a
 		i++
-		i = encodeVarintApi(data, i, uint64(m.Gc.Size()))
-		n93, err := m.Gc.MarshalTo(data[i:])
+		i = encodeVarintApi(data, i, uint64(m.EndTransaction.Size()))
+		n93, err := m.EndTransaction.MarshalTo(data[i:])
 		if err != nil {
 			return 0, err
 		}
 		i += n93
 	}
-	if m.PushTxn != nil {
-		data[i] = 0x6a
+	if m.AdminSplit != nil {
+		data[i] = 0x52
 		i++
-		i = encodeVarintApi(data, i, uint64(m.PushTxn.Size()))
-		n94, err := m.PushTxn.MarshalTo(data[i:])
+		i = encodeVarintApi(data, i, uint64(m.AdminSplit.Size()))
+		n94, err := m.AdminSplit.MarshalTo(data[i:])
 		if err != nil {
 			return 0, err
 		}
 		i += n94
 	}
-	if m.RangeLookup != nil {
-		data[i] = 0x72
+	if m.AdminMerge != nil {
+		data[i] = 0x5a
 		i++
-		i = encodeVarintApi(data, i, uint64(m.RangeLookup.Size()))
-		n95, err := m.RangeLookup.MarshalTo(data[i:])
+		i = encodeVarintApi(data, i, uint64(m.AdminMerge.Size()))
+		n95, err := m.AdminMerge.MarshalTo(data[i:])
 		if err != nil {
 			return 0, err
 		}
 		i += n95
 	}
-	if m.ResolveIntent != nil {
-		data[i] = 0x7a
+	if m.HeartbeatTxn != nil {
+		data[i] = 0x62
 		i++
-		i = encodeVarintApi(data, i, uint64(m.ResolveIntent.Size()))
-		n96, err := m.ResolveIntent.MarshalTo(data[i:])
+		i = encodeVarintApi(data, i, uint64(m.HeartbeatTxn.Size()))
+		n96, err := m.HeartbeatTxn.MarshalTo(data[i:])
 		if err != nil {
 			return 0, err
 		}
 		i += n96
 	}
-	if m.ResolveIntentRange != nil {
-		data[i] = 0x82
+	if m.Gc != nil {
+		data[i] = 0x6a
 		i++
-		data[i] = 0x1
-		i++
-		i = encodeVarintApi(data, i, uint64(m.ResolveIntentRange.Size()))
-		n97, err := m.ResolveIntentRange.MarshalTo(data[i:])
+		i = encodeVarintApi(data, i, uint64(m.Gc.Size()))
+		n97, err := m.Gc.MarshalTo(data[i:])
 		if err != nil {
 			return 0, err
 		}
 		i += n97
 	}
-	if m.Merge != nil {
-		data[i] = 0x8a
+	if m.PushTxn != nil {
+		data[i] = 0x72
 		i++
-		data[i] = 0x1
-		i++
-		i = encodeVarintApi(data, i, uint64(m.Merge.Size()))
-		n98, err := m.Merge.MarshalTo(data[i:])
+		i = encodeVarintApi(data, i, uint64(m.PushTxn.Size()))
+		n98, err := m.PushTxn.MarshalTo(data[i:])
 		if err != nil {
 			return 0, err
 		}
 		i += n98
 	}
-	if m.TruncateLog != nil {
-		data[i] = 0x92
+	if m.RangeLookup != nil {
+		data[i] = 0x7a
 		i++
-		data[i] = 0x1
-		i++
-		i = encodeVarintApi(data, i, uint64(m.TruncateLog.Size()))
-		n99, err := m.TruncateLog.MarshalTo(data[i:])
+		i = encodeVarintApi(data, i, uint64(m.RangeLookup.Size()))
+		n99, err := m.RangeLookup.MarshalTo(data[i:])
 		if err != nil {
 			return 0, err
 		}
 		i += n99
 	}
-	if m.LeaderLease != nil {
-		data[i] = 0x9a
+	if m.ResolveIntent != nil {
+		data[i] = 0x82
 		i++
 		data[i] = 0x1
 		i++
-		i = encodeVarintApi(data, i, uint64(m.LeaderLease.Size()))
-		n100, err := m.LeaderLease.MarshalTo(data[i:])
+		i = encodeVarintApi(data, i, uint64(m.ResolveIntent.Size()))
+		n100, err := m.ResolveIntent.MarshalTo(data[i:])
 		if err != nil {
 			return 0, err
 		}
 		i += n100
 	}
-	if m.ReverseScan != nil {
-		data[i] = 0xa2
+	if m.ResolveIntentRange != nil {
+		data[i] = 0x8a
 		i++
 		data[i] = 0x1
 		i++
-		i = encodeVarintApi(data, i, uint64(m.ReverseScan.Size()))
-		n101, err := m.ReverseScan.MarshalTo(data[i:])
+		i = encodeVarintApi(data, i, uint64(m.ResolveIntentRange.Size()))
+		n101, err := m.ResolveIntentRange.MarshalTo(data[i:])
 		if err != nil {
 			return 0, err
 		}
 		i += n101
 	}
-	if m.Noop != nil {
-		data[i] = 0xaa
+	if m.Merge != nil {
+		data[i] = 0x92
 		i++
 		data[i] = 0x1
 		i++
-		i = encodeVarintApi(data, i, uint64(m.Noop.Size()))
-		n102, err := m.Noop.MarshalTo(data[i:])
+		i = encodeVarintApi(data, i, uint64(m.Merge.Size()))
+		n102, err := m.Merge.MarshalTo(data[i:])
 		if err != nil {
 			return 0, err
 		}
 		i += n102
+	}
+	if m.TruncateLog != nil {
+		data[i] = 0x9a
+		i++
+		data[i] = 0x1
+		i++
+		i = encodeVarintApi(data, i, uint64(m.TruncateLog.Size()))
+		n103, err := m.TruncateLog.MarshalTo(data[i:])
+		if err != nil {
+			return 0, err
+		}
+		i += n103
+	}
+	if m.LeaderLease != nil {
+		data[i] = 0xa2
+		i++
+		data[i] = 0x1
+		i++
+		i = encodeVarintApi(data, i, uint64(m.LeaderLease.Size()))
+		n104, err := m.LeaderLease.MarshalTo(data[i:])
+		if err != nil {
+			return 0, err
+		}
+		i += n104
+	}
+	if m.ReverseScan != nil {
+		data[i] = 0xaa
+		i++
+		data[i] = 0x1
+		i++
+		i = encodeVarintApi(data, i, uint64(m.ReverseScan.Size()))
+		n105, err := m.ReverseScan.MarshalTo(data[i:])
+		if err != nil {
+			return 0, err
+		}
+		i += n105
+	}
+	if m.Noop != nil {
+		data[i] = 0xb2
+		i++
+		data[i] = 0x1
+		i++
+		i = encodeVarintApi(data, i, uint64(m.Noop.Size()))
+		n106, err := m.Noop.MarshalTo(data[i:])
+		if err != nil {
+			return 0, err
+		}
+		i += n106
 	}
 	return i, nil
 }
@@ -3663,27 +3775,27 @@ func (m *Header) MarshalTo(data []byte) (int, error) {
 	data[i] = 0xa
 	i++
 	i = encodeVarintApi(data, i, uint64(m.Timestamp.Size()))
-	n103, err := m.Timestamp.MarshalTo(data[i:])
+	n107, err := m.Timestamp.MarshalTo(data[i:])
 	if err != nil {
 		return 0, err
 	}
-	i += n103
+	i += n107
 	data[i] = 0x12
 	i++
 	i = encodeVarintApi(data, i, uint64(m.CmdID.Size()))
-	n104, err := m.CmdID.MarshalTo(data[i:])
+	n108, err := m.CmdID.MarshalTo(data[i:])
 	if err != nil {
 		return 0, err
 	}
-	i += n104
+	i += n108
 	data[i] = 0x2a
 	i++
 	i = encodeVarintApi(data, i, uint64(m.Replica.Size()))
-	n105, err := m.Replica.MarshalTo(data[i:])
+	n109, err := m.Replica.MarshalTo(data[i:])
 	if err != nil {
 		return 0, err
 	}
-	i += n105
+	i += n109
 	data[i] = 0x30
 	i++
 	i = encodeVarintApi(data, i, uint64(m.RangeID))
@@ -3696,11 +3808,11 @@ func (m *Header) MarshalTo(data []byte) (int, error) {
 		data[i] = 0x42
 		i++
 		i = encodeVarintApi(data, i, uint64(m.Txn.Size()))
-		n106, err := m.Txn.MarshalTo(data[i:])
+		n110, err := m.Txn.MarshalTo(data[i:])
 		if err != nil {
 			return 0, err
 		}
-		i += n106
+		i += n110
 	}
 	data[i] = 0x48
 	i++
@@ -3726,11 +3838,11 @@ func (m *BatchRequest) MarshalTo(data []byte) (int, error) {
 	data[i] = 0xa
 	i++
 	i = encodeVarintApi(data, i, uint64(m.Header.Size()))
-	n107, err := m.Header.MarshalTo(data[i:])
+	n111, err := m.Header.MarshalTo(data[i:])
 	if err != nil {
 		return 0, err
 	}
-	i += n107
+	i += n111
 	if len(m.Requests) > 0 {
 		for _, msg := range m.Requests {
 			data[i] = 0x12
@@ -3764,11 +3876,11 @@ func (m *BatchResponse) MarshalTo(data []byte) (int, error) {
 	data[i] = 0xa
 	i++
 	i = encodeVarintApi(data, i, uint64(m.BatchResponse_Header.Size()))
-	n108, err := m.BatchResponse_Header.MarshalTo(data[i:])
+	n112, err := m.BatchResponse_Header.MarshalTo(data[i:])
 	if err != nil {
 		return 0, err
 	}
-	i += n108
+	i += n112
 	if len(m.Responses) > 0 {
 		for _, msg := range m.Responses {
 			data[i] = 0x12
@@ -3803,29 +3915,29 @@ func (m *BatchResponse_Header) MarshalTo(data []byte) (int, error) {
 		data[i] = 0xa
 		i++
 		i = encodeVarintApi(data, i, uint64(m.Error.Size()))
-		n109, err := m.Error.MarshalTo(data[i:])
+		n113, err := m.Error.MarshalTo(data[i:])
 		if err != nil {
 			return 0, err
 		}
-		i += n109
+		i += n113
 	}
 	data[i] = 0x12
 	i++
 	i = encodeVarintApi(data, i, uint64(m.Timestamp.Size()))
-	n110, err := m.Timestamp.MarshalTo(data[i:])
+	n114, err := m.Timestamp.MarshalTo(data[i:])
 	if err != nil {
 		return 0, err
 	}
-	i += n110
+	i += n114
 	if m.Txn != nil {
 		data[i] = 0x1a
 		i++
 		i = encodeVarintApi(data, i, uint64(m.Txn.Size()))
-		n111, err := m.Txn.MarshalTo(data[i:])
+		n115, err := m.Txn.MarshalTo(data[i:])
 		if err != nil {
 			return 0, err
 		}
-		i += n111
+		i += n115
 	}
 	return i, nil
 }
@@ -4046,6 +4158,22 @@ func (m *ReverseScanResponse) Size() (n int) {
 			n += 1 + l + sovApi(uint64(l))
 		}
 	}
+	return n
+}
+
+func (m *BeginTransactionRequest) Size() (n int) {
+	var l int
+	_ = l
+	l = m.Span.Size()
+	n += 1 + l + sovApi(uint64(l))
+	return n
+}
+
+func (m *BeginTransactionResponse) Size() (n int) {
+	var l int
+	_ = l
+	l = m.ResponseHeader.Size()
+	n += 1 + l + sovApi(uint64(l))
 	return n
 }
 
@@ -4361,6 +4489,10 @@ func (m *RequestUnion) Size() (n int) {
 		l = m.Scan.Size()
 		n += 1 + l + sovApi(uint64(l))
 	}
+	if m.BeginTransaction != nil {
+		l = m.BeginTransaction.Size()
+		n += 1 + l + sovApi(uint64(l))
+	}
 	if m.EndTransaction != nil {
 		l = m.EndTransaction.Size()
 		n += 1 + l + sovApi(uint64(l))
@@ -4391,7 +4523,7 @@ func (m *RequestUnion) Size() (n int) {
 	}
 	if m.ResolveIntent != nil {
 		l = m.ResolveIntent.Size()
-		n += 1 + l + sovApi(uint64(l))
+		n += 2 + l + sovApi(uint64(l))
 	}
 	if m.ResolveIntentRange != nil {
 		l = m.ResolveIntentRange.Size()
@@ -4451,6 +4583,10 @@ func (m *ResponseUnion) Size() (n int) {
 		l = m.Scan.Size()
 		n += 1 + l + sovApi(uint64(l))
 	}
+	if m.BeginTransaction != nil {
+		l = m.BeginTransaction.Size()
+		n += 1 + l + sovApi(uint64(l))
+	}
 	if m.EndTransaction != nil {
 		l = m.EndTransaction.Size()
 		n += 1 + l + sovApi(uint64(l))
@@ -4481,7 +4617,7 @@ func (m *ResponseUnion) Size() (n int) {
 	}
 	if m.ResolveIntent != nil {
 		l = m.ResolveIntent.Size()
-		n += 1 + l + sovApi(uint64(l))
+		n += 2 + l + sovApi(uint64(l))
 	}
 	if m.ResolveIntentRange != nil {
 		l = m.ResolveIntentRange.Size()
@@ -4610,6 +4746,9 @@ func (this *RequestUnion) GetValue() interface{} {
 	if this.Scan != nil {
 		return this.Scan
 	}
+	if this.BeginTransaction != nil {
+		return this.BeginTransaction
+	}
 	if this.EndTransaction != nil {
 		return this.EndTransaction
 	}
@@ -4671,6 +4810,8 @@ func (this *RequestUnion) SetValue(value interface{}) bool {
 		this.DeleteRange = vt
 	case *ScanRequest:
 		this.Scan = vt
+	case *BeginTransactionRequest:
+		this.BeginTransaction = vt
 	case *EndTransactionRequest:
 		this.EndTransaction = vt
 	case *AdminSplitRequest:
@@ -4725,6 +4866,9 @@ func (this *ResponseUnion) GetValue() interface{} {
 	}
 	if this.Scan != nil {
 		return this.Scan
+	}
+	if this.BeginTransaction != nil {
+		return this.BeginTransaction
 	}
 	if this.EndTransaction != nil {
 		return this.EndTransaction
@@ -4787,6 +4931,8 @@ func (this *ResponseUnion) SetValue(value interface{}) bool {
 		this.DeleteRange = vt
 	case *ScanResponse:
 		this.Scan = vt
+	case *BeginTransactionResponse:
+		this.BeginTransaction = vt
 	case *EndTransactionResponse:
 		this.EndTransaction = vt
 	case *AdminSplitResponse:
@@ -6685,6 +6831,166 @@ func (m *ReverseScanResponse) Unmarshal(data []byte) error {
 			}
 			m.Rows = append(m.Rows, KeyValue{})
 			if err := m.Rows[len(m.Rows)-1].Unmarshal(data[iNdEx:postIndex]); err != nil {
+				return err
+			}
+			iNdEx = postIndex
+		default:
+			iNdEx = preIndex
+			skippy, err := skipApi(data[iNdEx:])
+			if err != nil {
+				return err
+			}
+			if skippy < 0 {
+				return ErrInvalidLengthApi
+			}
+			if (iNdEx + skippy) > l {
+				return io.ErrUnexpectedEOF
+			}
+			iNdEx += skippy
+		}
+	}
+
+	if iNdEx > l {
+		return io.ErrUnexpectedEOF
+	}
+	return nil
+}
+func (m *BeginTransactionRequest) Unmarshal(data []byte) error {
+	l := len(data)
+	iNdEx := 0
+	for iNdEx < l {
+		preIndex := iNdEx
+		var wire uint64
+		for shift := uint(0); ; shift += 7 {
+			if shift >= 64 {
+				return ErrIntOverflowApi
+			}
+			if iNdEx >= l {
+				return io.ErrUnexpectedEOF
+			}
+			b := data[iNdEx]
+			iNdEx++
+			wire |= (uint64(b) & 0x7F) << shift
+			if b < 0x80 {
+				break
+			}
+		}
+		fieldNum := int32(wire >> 3)
+		wireType := int(wire & 0x7)
+		if wireType == 4 {
+			return fmt.Errorf("proto: BeginTransactionRequest: wiretype end group for non-group")
+		}
+		if fieldNum <= 0 {
+			return fmt.Errorf("proto: BeginTransactionRequest: illegal tag %d (wire type %d)", fieldNum, wire)
+		}
+		switch fieldNum {
+		case 1:
+			if wireType != 2 {
+				return fmt.Errorf("proto: wrong wireType = %d for field Span", wireType)
+			}
+			var msglen int
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return ErrIntOverflowApi
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := data[iNdEx]
+				iNdEx++
+				msglen |= (int(b) & 0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			if msglen < 0 {
+				return ErrInvalidLengthApi
+			}
+			postIndex := iNdEx + msglen
+			if postIndex > l {
+				return io.ErrUnexpectedEOF
+			}
+			if err := m.Span.Unmarshal(data[iNdEx:postIndex]); err != nil {
+				return err
+			}
+			iNdEx = postIndex
+		default:
+			iNdEx = preIndex
+			skippy, err := skipApi(data[iNdEx:])
+			if err != nil {
+				return err
+			}
+			if skippy < 0 {
+				return ErrInvalidLengthApi
+			}
+			if (iNdEx + skippy) > l {
+				return io.ErrUnexpectedEOF
+			}
+			iNdEx += skippy
+		}
+	}
+
+	if iNdEx > l {
+		return io.ErrUnexpectedEOF
+	}
+	return nil
+}
+func (m *BeginTransactionResponse) Unmarshal(data []byte) error {
+	l := len(data)
+	iNdEx := 0
+	for iNdEx < l {
+		preIndex := iNdEx
+		var wire uint64
+		for shift := uint(0); ; shift += 7 {
+			if shift >= 64 {
+				return ErrIntOverflowApi
+			}
+			if iNdEx >= l {
+				return io.ErrUnexpectedEOF
+			}
+			b := data[iNdEx]
+			iNdEx++
+			wire |= (uint64(b) & 0x7F) << shift
+			if b < 0x80 {
+				break
+			}
+		}
+		fieldNum := int32(wire >> 3)
+		wireType := int(wire & 0x7)
+		if wireType == 4 {
+			return fmt.Errorf("proto: BeginTransactionResponse: wiretype end group for non-group")
+		}
+		if fieldNum <= 0 {
+			return fmt.Errorf("proto: BeginTransactionResponse: illegal tag %d (wire type %d)", fieldNum, wire)
+		}
+		switch fieldNum {
+		case 1:
+			if wireType != 2 {
+				return fmt.Errorf("proto: wrong wireType = %d for field ResponseHeader", wireType)
+			}
+			var msglen int
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return ErrIntOverflowApi
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := data[iNdEx]
+				iNdEx++
+				msglen |= (int(b) & 0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			if msglen < 0 {
+				return ErrInvalidLengthApi
+			}
+			postIndex := iNdEx + msglen
+			if postIndex > l {
+				return io.ErrUnexpectedEOF
+			}
+			if err := m.ResponseHeader.Unmarshal(data[iNdEx:postIndex]); err != nil {
 				return err
 			}
 			iNdEx = postIndex
@@ -9781,6 +10087,39 @@ func (m *RequestUnion) Unmarshal(data []byte) error {
 			iNdEx = postIndex
 		case 8:
 			if wireType != 2 {
+				return fmt.Errorf("proto: wrong wireType = %d for field BeginTransaction", wireType)
+			}
+			var msglen int
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return ErrIntOverflowApi
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := data[iNdEx]
+				iNdEx++
+				msglen |= (int(b) & 0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			if msglen < 0 {
+				return ErrInvalidLengthApi
+			}
+			postIndex := iNdEx + msglen
+			if postIndex > l {
+				return io.ErrUnexpectedEOF
+			}
+			if m.BeginTransaction == nil {
+				m.BeginTransaction = &BeginTransactionRequest{}
+			}
+			if err := m.BeginTransaction.Unmarshal(data[iNdEx:postIndex]); err != nil {
+				return err
+			}
+			iNdEx = postIndex
+		case 9:
+			if wireType != 2 {
 				return fmt.Errorf("proto: wrong wireType = %d for field EndTransaction", wireType)
 			}
 			var msglen int
@@ -9812,7 +10151,7 @@ func (m *RequestUnion) Unmarshal(data []byte) error {
 				return err
 			}
 			iNdEx = postIndex
-		case 9:
+		case 10:
 			if wireType != 2 {
 				return fmt.Errorf("proto: wrong wireType = %d for field AdminSplit", wireType)
 			}
@@ -9845,7 +10184,7 @@ func (m *RequestUnion) Unmarshal(data []byte) error {
 				return err
 			}
 			iNdEx = postIndex
-		case 10:
+		case 11:
 			if wireType != 2 {
 				return fmt.Errorf("proto: wrong wireType = %d for field AdminMerge", wireType)
 			}
@@ -9878,7 +10217,7 @@ func (m *RequestUnion) Unmarshal(data []byte) error {
 				return err
 			}
 			iNdEx = postIndex
-		case 11:
+		case 12:
 			if wireType != 2 {
 				return fmt.Errorf("proto: wrong wireType = %d for field HeartbeatTxn", wireType)
 			}
@@ -9911,7 +10250,7 @@ func (m *RequestUnion) Unmarshal(data []byte) error {
 				return err
 			}
 			iNdEx = postIndex
-		case 12:
+		case 13:
 			if wireType != 2 {
 				return fmt.Errorf("proto: wrong wireType = %d for field Gc", wireType)
 			}
@@ -9944,7 +10283,7 @@ func (m *RequestUnion) Unmarshal(data []byte) error {
 				return err
 			}
 			iNdEx = postIndex
-		case 13:
+		case 14:
 			if wireType != 2 {
 				return fmt.Errorf("proto: wrong wireType = %d for field PushTxn", wireType)
 			}
@@ -9977,7 +10316,7 @@ func (m *RequestUnion) Unmarshal(data []byte) error {
 				return err
 			}
 			iNdEx = postIndex
-		case 14:
+		case 15:
 			if wireType != 2 {
 				return fmt.Errorf("proto: wrong wireType = %d for field RangeLookup", wireType)
 			}
@@ -10010,7 +10349,7 @@ func (m *RequestUnion) Unmarshal(data []byte) error {
 				return err
 			}
 			iNdEx = postIndex
-		case 15:
+		case 16:
 			if wireType != 2 {
 				return fmt.Errorf("proto: wrong wireType = %d for field ResolveIntent", wireType)
 			}
@@ -10043,7 +10382,7 @@ func (m *RequestUnion) Unmarshal(data []byte) error {
 				return err
 			}
 			iNdEx = postIndex
-		case 16:
+		case 17:
 			if wireType != 2 {
 				return fmt.Errorf("proto: wrong wireType = %d for field ResolveIntentRange", wireType)
 			}
@@ -10076,7 +10415,7 @@ func (m *RequestUnion) Unmarshal(data []byte) error {
 				return err
 			}
 			iNdEx = postIndex
-		case 17:
+		case 18:
 			if wireType != 2 {
 				return fmt.Errorf("proto: wrong wireType = %d for field Merge", wireType)
 			}
@@ -10109,7 +10448,7 @@ func (m *RequestUnion) Unmarshal(data []byte) error {
 				return err
 			}
 			iNdEx = postIndex
-		case 18:
+		case 19:
 			if wireType != 2 {
 				return fmt.Errorf("proto: wrong wireType = %d for field TruncateLog", wireType)
 			}
@@ -10142,7 +10481,7 @@ func (m *RequestUnion) Unmarshal(data []byte) error {
 				return err
 			}
 			iNdEx = postIndex
-		case 19:
+		case 20:
 			if wireType != 2 {
 				return fmt.Errorf("proto: wrong wireType = %d for field LeaderLease", wireType)
 			}
@@ -10175,7 +10514,7 @@ func (m *RequestUnion) Unmarshal(data []byte) error {
 				return err
 			}
 			iNdEx = postIndex
-		case 20:
+		case 21:
 			if wireType != 2 {
 				return fmt.Errorf("proto: wrong wireType = %d for field ReverseScan", wireType)
 			}
@@ -10208,7 +10547,7 @@ func (m *RequestUnion) Unmarshal(data []byte) error {
 				return err
 			}
 			iNdEx = postIndex
-		case 21:
+		case 22:
 			if wireType != 2 {
 				return fmt.Errorf("proto: wrong wireType = %d for field Noop", wireType)
 			}
@@ -10524,6 +10863,39 @@ func (m *ResponseUnion) Unmarshal(data []byte) error {
 			iNdEx = postIndex
 		case 8:
 			if wireType != 2 {
+				return fmt.Errorf("proto: wrong wireType = %d for field BeginTransaction", wireType)
+			}
+			var msglen int
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return ErrIntOverflowApi
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := data[iNdEx]
+				iNdEx++
+				msglen |= (int(b) & 0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			if msglen < 0 {
+				return ErrInvalidLengthApi
+			}
+			postIndex := iNdEx + msglen
+			if postIndex > l {
+				return io.ErrUnexpectedEOF
+			}
+			if m.BeginTransaction == nil {
+				m.BeginTransaction = &BeginTransactionResponse{}
+			}
+			if err := m.BeginTransaction.Unmarshal(data[iNdEx:postIndex]); err != nil {
+				return err
+			}
+			iNdEx = postIndex
+		case 9:
+			if wireType != 2 {
 				return fmt.Errorf("proto: wrong wireType = %d for field EndTransaction", wireType)
 			}
 			var msglen int
@@ -10555,7 +10927,7 @@ func (m *ResponseUnion) Unmarshal(data []byte) error {
 				return err
 			}
 			iNdEx = postIndex
-		case 9:
+		case 10:
 			if wireType != 2 {
 				return fmt.Errorf("proto: wrong wireType = %d for field AdminSplit", wireType)
 			}
@@ -10588,7 +10960,7 @@ func (m *ResponseUnion) Unmarshal(data []byte) error {
 				return err
 			}
 			iNdEx = postIndex
-		case 10:
+		case 11:
 			if wireType != 2 {
 				return fmt.Errorf("proto: wrong wireType = %d for field AdminMerge", wireType)
 			}
@@ -10621,7 +10993,7 @@ func (m *ResponseUnion) Unmarshal(data []byte) error {
 				return err
 			}
 			iNdEx = postIndex
-		case 11:
+		case 12:
 			if wireType != 2 {
 				return fmt.Errorf("proto: wrong wireType = %d for field HeartbeatTxn", wireType)
 			}
@@ -10654,7 +11026,7 @@ func (m *ResponseUnion) Unmarshal(data []byte) error {
 				return err
 			}
 			iNdEx = postIndex
-		case 12:
+		case 13:
 			if wireType != 2 {
 				return fmt.Errorf("proto: wrong wireType = %d for field Gc", wireType)
 			}
@@ -10687,7 +11059,7 @@ func (m *ResponseUnion) Unmarshal(data []byte) error {
 				return err
 			}
 			iNdEx = postIndex
-		case 13:
+		case 14:
 			if wireType != 2 {
 				return fmt.Errorf("proto: wrong wireType = %d for field PushTxn", wireType)
 			}
@@ -10720,7 +11092,7 @@ func (m *ResponseUnion) Unmarshal(data []byte) error {
 				return err
 			}
 			iNdEx = postIndex
-		case 14:
+		case 15:
 			if wireType != 2 {
 				return fmt.Errorf("proto: wrong wireType = %d for field RangeLookup", wireType)
 			}
@@ -10753,7 +11125,7 @@ func (m *ResponseUnion) Unmarshal(data []byte) error {
 				return err
 			}
 			iNdEx = postIndex
-		case 15:
+		case 16:
 			if wireType != 2 {
 				return fmt.Errorf("proto: wrong wireType = %d for field ResolveIntent", wireType)
 			}
@@ -10786,7 +11158,7 @@ func (m *ResponseUnion) Unmarshal(data []byte) error {
 				return err
 			}
 			iNdEx = postIndex
-		case 16:
+		case 17:
 			if wireType != 2 {
 				return fmt.Errorf("proto: wrong wireType = %d for field ResolveIntentRange", wireType)
 			}
@@ -10819,7 +11191,7 @@ func (m *ResponseUnion) Unmarshal(data []byte) error {
 				return err
 			}
 			iNdEx = postIndex
-		case 17:
+		case 18:
 			if wireType != 2 {
 				return fmt.Errorf("proto: wrong wireType = %d for field Merge", wireType)
 			}
@@ -10852,7 +11224,7 @@ func (m *ResponseUnion) Unmarshal(data []byte) error {
 				return err
 			}
 			iNdEx = postIndex
-		case 18:
+		case 19:
 			if wireType != 2 {
 				return fmt.Errorf("proto: wrong wireType = %d for field TruncateLog", wireType)
 			}
@@ -10885,7 +11257,7 @@ func (m *ResponseUnion) Unmarshal(data []byte) error {
 				return err
 			}
 			iNdEx = postIndex
-		case 19:
+		case 20:
 			if wireType != 2 {
 				return fmt.Errorf("proto: wrong wireType = %d for field LeaderLease", wireType)
 			}
@@ -10918,7 +11290,7 @@ func (m *ResponseUnion) Unmarshal(data []byte) error {
 				return err
 			}
 			iNdEx = postIndex
-		case 20:
+		case 21:
 			if wireType != 2 {
 				return fmt.Errorf("proto: wrong wireType = %d for field ReverseScan", wireType)
 			}
@@ -10951,7 +11323,7 @@ func (m *ResponseUnion) Unmarshal(data []byte) error {
 				return err
 			}
 			iNdEx = postIndex
-		case 21:
+		case 22:
 			if wireType != 2 {
 				return fmt.Errorf("proto: wrong wireType = %d for field Noop", wireType)
 			}

--- a/roachpb/api.proto
+++ b/roachpb/api.proto
@@ -219,6 +219,16 @@ message ReverseScanResponse {
   repeated KeyValue rows = 2 [(gogoproto.nullable) = false];
 }
 
+// A BeginTransactionRequest is the argument to the BeginTransaction() method.
+message BeginTransactionRequest {
+  optional Span header = 1 [(gogoproto.nullable) = false, (gogoproto.embed) = true];
+}
+
+// A BeginTransactionResponse is the return value from the BeginTransaction() method.
+message BeginTransactionResponse {
+  optional ResponseHeader header = 1 [(gogoproto.nullable) = false, (gogoproto.embed) = true];
+}
+
 // An EndTransactionRequest is the argument to the EndTransaction() method. It
 // specifies whether to commit or roll back an extant transaction.
 message EndTransactionRequest {
@@ -534,20 +544,21 @@ message RequestUnion {
   optional DeleteRequest delete = 5;
   optional DeleteRangeRequest delete_range = 6;
   optional ScanRequest scan = 7;
-  optional EndTransactionRequest end_transaction = 8;
-  optional AdminSplitRequest admin_split = 9;
-  optional AdminMergeRequest admin_merge = 10;
-  optional HeartbeatTxnRequest heartbeat_txn = 11;
-  optional GCRequest gc = 12;
-  optional PushTxnRequest push_txn = 13;
-  optional RangeLookupRequest range_lookup = 14;
-  optional ResolveIntentRequest resolve_intent = 15;
-  optional ResolveIntentRangeRequest resolve_intent_range = 16;
-  optional MergeRequest merge = 17;
-  optional TruncateLogRequest truncate_log = 18;
-  optional LeaderLeaseRequest leader_lease = 19;
-  optional ReverseScanRequest reverse_scan = 20;
-  optional NoopRequest noop = 21;
+  optional BeginTransactionRequest begin_transaction = 8;
+  optional EndTransactionRequest end_transaction = 9;
+  optional AdminSplitRequest admin_split = 10;
+  optional AdminMergeRequest admin_merge = 11;
+  optional HeartbeatTxnRequest heartbeat_txn = 12;
+  optional GCRequest gc = 13;
+  optional PushTxnRequest push_txn = 14;
+  optional RangeLookupRequest range_lookup = 15;
+  optional ResolveIntentRequest resolve_intent = 16;
+  optional ResolveIntentRangeRequest resolve_intent_range = 17;
+  optional MergeRequest merge = 18;
+  optional TruncateLogRequest truncate_log = 19;
+  optional LeaderLeaseRequest leader_lease = 20;
+  optional ReverseScanRequest reverse_scan = 21;
+  optional NoopRequest noop = 22;
 }
 
 // A ResponseUnion contains exactly one of the optional responses.
@@ -562,20 +573,21 @@ message ResponseUnion {
   optional DeleteResponse delete = 5;
   optional DeleteRangeResponse delete_range = 6;
   optional ScanResponse scan = 7;
-  optional EndTransactionResponse end_transaction = 8;
-  optional AdminSplitResponse admin_split = 9;
-  optional AdminMergeResponse admin_merge = 10;
-  optional HeartbeatTxnResponse heartbeat_txn = 11;
-  optional GCResponse gc = 12;
-  optional PushTxnResponse push_txn = 13;
-  optional RangeLookupResponse range_lookup = 14;
-  optional ResolveIntentResponse resolve_intent = 15;
-  optional ResolveIntentRangeResponse resolve_intent_range = 16;
-  optional MergeResponse merge = 17;
-  optional TruncateLogResponse truncate_log = 18;
-  optional LeaderLeaseResponse leader_lease = 19;
-  optional ReverseScanResponse reverse_scan = 20;
-  optional NoopResponse noop = 21;
+  optional BeginTransactionResponse begin_transaction = 8;
+  optional EndTransactionResponse end_transaction = 9;
+  optional AdminSplitResponse admin_split = 10;
+  optional AdminMergeResponse admin_merge = 11;
+  optional HeartbeatTxnResponse heartbeat_txn = 12;
+  optional GCResponse gc = 13;
+  optional PushTxnResponse push_txn = 14;
+  optional RangeLookupResponse range_lookup = 15;
+  optional ResolveIntentResponse resolve_intent = 16;
+  optional ResolveIntentRangeResponse resolve_intent_range = 17;
+  optional MergeResponse merge = 18;
+  optional TruncateLogResponse truncate_log = 19;
+  optional LeaderLeaseResponse leader_lease = 20;
+  optional ReverseScanResponse reverse_scan = 21;
+  optional NoopResponse noop = 22;
 }
 
 // A Header is attached to a BatchRequest, encapsulating routing and auxiliary

--- a/roachpb/api_test.go
+++ b/roachpb/api_test.go
@@ -171,6 +171,7 @@ func TestBatchSplit(t *testing.T) {
 	put := &PutRequest{}
 	spl := &AdminSplitRequest{}
 	dr := &DeleteRangeRequest{}
+	bt := &BeginTransactionRequest{}
 	et := &EndTransactionRequest{}
 	rv := &ReverseScanRequest{}
 	testCases := []struct {
@@ -182,6 +183,7 @@ func TestBatchSplit(t *testing.T) {
 		{[]Request{get, scan, get, dr, rv, put, et}, []int{3, 1, 1, 1, 1}},
 		{[]Request{spl, get, scan, spl, get}, []int{1, 2, 1, 1}},
 		{[]Request{spl, spl, get, spl}, []int{1, 1, 1, 1}},
+		{[]Request{bt, put, et}, []int{2, 1}},
 	}
 
 	for i, test := range testCases {

--- a/roachpb/batch.go
+++ b/roachpb/batch.go
@@ -196,7 +196,7 @@ func (ba *BatchRequest) flags() int {
 	return flags
 }
 
-// Split separate the requests contained in a batch so that each subset of
+// Split separates the requests contained in a batch so that each subset of
 // requests can be executed by a Store (without changing order). In particular,
 // Admin and EndTransaction requests are always singled out and mutating
 // requests separated from reads.
@@ -209,11 +209,12 @@ func (ba BatchRequest) Split() [][]RequestUnion {
 		if (newFlags & isAlone) != 0 {
 			return false
 		}
-		// Otherwise, the flags below must remain the same
-		// with the new request added.
+		// Otherwise, the flags below must remain the same with the new
+		// request added.
+		//
 		// Note that we're not checking isRead: The invariants we're
 		// enforcing are that a batch can't mix non-writes with writes.
-		// Checking isRead would ConditionalPut and Put to conflict,
+		// Checking isRead would cause ConditionalPut and Put to conflict,
 		// which is not what we want.
 		const mask = isWrite | isAdmin | isReverse
 		return (mask & exFlags) == (mask & newFlags)

--- a/roachpb/data.go
+++ b/roachpb/data.go
@@ -620,6 +620,9 @@ func (t *Transaction) Update(o *Transaction) {
 		*t = *proto.Clone(o).(*Transaction)
 		return
 	}
+	if len(t.Key) == 0 {
+		t.Key = o.Key
+	}
 	if o.Status != PENDING {
 		t.Status = o.Status
 	}

--- a/roachpb/method.go
+++ b/roachpb/method.go
@@ -51,6 +51,8 @@ const (
 	// args.RequestHeader.Key and args.RequestHeader.EndKey, with
 	// the latter endpoint excluded.
 	ReverseScan
+	// BeginTransaction starts a new transaction.
+	BeginTransaction
 	// EndTransaction either commits or aborts an ongoing transaction.
 	EndTransaction
 	// AdminSplit is called to coordinate a split of a range.

--- a/roachpb/method.go
+++ b/roachpb/method.go
@@ -51,7 +51,11 @@ const (
 	// args.RequestHeader.Key and args.RequestHeader.EndKey, with
 	// the latter endpoint excluded.
 	ReverseScan
-	// BeginTransaction starts a new transaction.
+	// BeginTransaction writes a new transaction record, marking the
+	// beginning of the write-portion of a transaction. It is sent
+	// exclusively by the coordinating node along with the first
+	// transactional write and neither sent nor received by the client
+	// itself.
 	BeginTransaction
 	// EndTransaction either commits or aborts an ongoing transaction.
 	EndTransaction

--- a/roachpb/method_string.go
+++ b/roachpb/method_string.go
@@ -4,9 +4,9 @@ package roachpb
 
 import "fmt"
 
-const _Method_name = "GetPutConditionalPutIncrementDeleteDeleteRangeScanReverseScanEndTransactionAdminSplitAdminMergeHeartbeatTxnGCPushTxnRangeLookupResolveIntentResolveIntentRangeNoopMergeTruncateLogLeaderLeaseBatch"
+const _Method_name = "GetPutConditionalPutIncrementDeleteDeleteRangeScanReverseScanBeginTransactionEndTransactionAdminSplitAdminMergeHeartbeatTxnGCPushTxnRangeLookupResolveIntentResolveIntentRangeNoopMergeTruncateLogLeaderLeaseBatch"
 
-var _Method_index = [...]uint8{0, 3, 6, 20, 29, 35, 46, 50, 61, 75, 85, 95, 107, 109, 116, 127, 140, 158, 162, 167, 178, 189, 194}
+var _Method_index = [...]uint8{0, 3, 6, 20, 29, 35, 46, 50, 61, 77, 91, 101, 111, 123, 125, 132, 143, 156, 174, 178, 183, 194, 205, 210}
 
 func (i Method) String() string {
 	if i < 0 || i >= Method(len(_Method_index)-1) {

--- a/storage/client_raft_test.go
+++ b/storage/client_raft_test.go
@@ -618,7 +618,7 @@ func TestStoreRangeDownReplicate(t *testing.T) {
 			t.Fatal(err)
 		}
 	}
-
+	t.Error("foo")
 	// Replicate the new range to all five stores.
 	replica := store0.LookupReplica(rightKey, nil)
 	desc := replica.Desc()

--- a/storage/client_raft_test.go
+++ b/storage/client_raft_test.go
@@ -618,7 +618,6 @@ func TestStoreRangeDownReplicate(t *testing.T) {
 			t.Fatal(err)
 		}
 	}
-	t.Error("foo")
 	// Replicate the new range to all five stores.
 	replica := store0.LookupReplica(rightKey, nil)
 	desc := replica.Desc()

--- a/storage/engine/rocksdb/cockroach/roachpb/api.pb.cc
+++ b/storage/engine/rocksdb/cockroach/roachpb/api.pb.cc
@@ -78,6 +78,12 @@ const ::google::protobuf::internal::GeneratedMessageReflection*
 const ::google::protobuf::Descriptor* ReverseScanResponse_descriptor_ = NULL;
 const ::google::protobuf::internal::GeneratedMessageReflection*
   ReverseScanResponse_reflection_ = NULL;
+const ::google::protobuf::Descriptor* BeginTransactionRequest_descriptor_ = NULL;
+const ::google::protobuf::internal::GeneratedMessageReflection*
+  BeginTransactionRequest_reflection_ = NULL;
+const ::google::protobuf::Descriptor* BeginTransactionResponse_descriptor_ = NULL;
+const ::google::protobuf::internal::GeneratedMessageReflection*
+  BeginTransactionResponse_reflection_ = NULL;
 const ::google::protobuf::Descriptor* EndTransactionRequest_descriptor_ = NULL;
 const ::google::protobuf::internal::GeneratedMessageReflection*
   EndTransactionRequest_reflection_ = NULL;
@@ -489,7 +495,37 @@ void protobuf_AssignDesc_cockroach_2froachpb_2fapi_2eproto() {
       sizeof(ReverseScanResponse),
       GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(ReverseScanResponse, _internal_metadata_),
       -1);
-  EndTransactionRequest_descriptor_ = file->message_type(19);
+  BeginTransactionRequest_descriptor_ = file->message_type(19);
+  static const int BeginTransactionRequest_offsets_[1] = {
+    GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(BeginTransactionRequest, header_),
+  };
+  BeginTransactionRequest_reflection_ =
+    ::google::protobuf::internal::GeneratedMessageReflection::NewGeneratedMessageReflection(
+      BeginTransactionRequest_descriptor_,
+      BeginTransactionRequest::default_instance_,
+      BeginTransactionRequest_offsets_,
+      GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(BeginTransactionRequest, _has_bits_[0]),
+      -1,
+      -1,
+      sizeof(BeginTransactionRequest),
+      GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(BeginTransactionRequest, _internal_metadata_),
+      -1);
+  BeginTransactionResponse_descriptor_ = file->message_type(20);
+  static const int BeginTransactionResponse_offsets_[1] = {
+    GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(BeginTransactionResponse, header_),
+  };
+  BeginTransactionResponse_reflection_ =
+    ::google::protobuf::internal::GeneratedMessageReflection::NewGeneratedMessageReflection(
+      BeginTransactionResponse_descriptor_,
+      BeginTransactionResponse::default_instance_,
+      BeginTransactionResponse_offsets_,
+      GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(BeginTransactionResponse, _has_bits_[0]),
+      -1,
+      -1,
+      sizeof(BeginTransactionResponse),
+      GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(BeginTransactionResponse, _internal_metadata_),
+      -1);
+  EndTransactionRequest_descriptor_ = file->message_type(21);
   static const int EndTransactionRequest_offsets_[4] = {
     GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(EndTransactionRequest, header_),
     GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(EndTransactionRequest, commit_),
@@ -507,7 +543,7 @@ void protobuf_AssignDesc_cockroach_2froachpb_2fapi_2eproto() {
       sizeof(EndTransactionRequest),
       GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(EndTransactionRequest, _internal_metadata_),
       -1);
-  EndTransactionResponse_descriptor_ = file->message_type(20);
+  EndTransactionResponse_descriptor_ = file->message_type(22);
   static const int EndTransactionResponse_offsets_[3] = {
     GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(EndTransactionResponse, header_),
     GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(EndTransactionResponse, commit_wait_),
@@ -524,7 +560,7 @@ void protobuf_AssignDesc_cockroach_2froachpb_2fapi_2eproto() {
       sizeof(EndTransactionResponse),
       GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(EndTransactionResponse, _internal_metadata_),
       -1);
-  AdminSplitRequest_descriptor_ = file->message_type(21);
+  AdminSplitRequest_descriptor_ = file->message_type(23);
   static const int AdminSplitRequest_offsets_[2] = {
     GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(AdminSplitRequest, header_),
     GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(AdminSplitRequest, split_key_),
@@ -540,7 +576,7 @@ void protobuf_AssignDesc_cockroach_2froachpb_2fapi_2eproto() {
       sizeof(AdminSplitRequest),
       GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(AdminSplitRequest, _internal_metadata_),
       -1);
-  AdminSplitResponse_descriptor_ = file->message_type(22);
+  AdminSplitResponse_descriptor_ = file->message_type(24);
   static const int AdminSplitResponse_offsets_[1] = {
     GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(AdminSplitResponse, header_),
   };
@@ -555,7 +591,7 @@ void protobuf_AssignDesc_cockroach_2froachpb_2fapi_2eproto() {
       sizeof(AdminSplitResponse),
       GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(AdminSplitResponse, _internal_metadata_),
       -1);
-  AdminMergeRequest_descriptor_ = file->message_type(23);
+  AdminMergeRequest_descriptor_ = file->message_type(25);
   static const int AdminMergeRequest_offsets_[1] = {
     GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(AdminMergeRequest, header_),
   };
@@ -570,7 +606,7 @@ void protobuf_AssignDesc_cockroach_2froachpb_2fapi_2eproto() {
       sizeof(AdminMergeRequest),
       GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(AdminMergeRequest, _internal_metadata_),
       -1);
-  AdminMergeResponse_descriptor_ = file->message_type(24);
+  AdminMergeResponse_descriptor_ = file->message_type(26);
   static const int AdminMergeResponse_offsets_[1] = {
     GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(AdminMergeResponse, header_),
   };
@@ -585,7 +621,7 @@ void protobuf_AssignDesc_cockroach_2froachpb_2fapi_2eproto() {
       sizeof(AdminMergeResponse),
       GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(AdminMergeResponse, _internal_metadata_),
       -1);
-  RangeLookupRequest_descriptor_ = file->message_type(25);
+  RangeLookupRequest_descriptor_ = file->message_type(27);
   static const int RangeLookupRequest_offsets_[4] = {
     GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(RangeLookupRequest, header_),
     GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(RangeLookupRequest, max_ranges_),
@@ -603,7 +639,7 @@ void protobuf_AssignDesc_cockroach_2froachpb_2fapi_2eproto() {
       sizeof(RangeLookupRequest),
       GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(RangeLookupRequest, _internal_metadata_),
       -1);
-  RangeLookupResponse_descriptor_ = file->message_type(26);
+  RangeLookupResponse_descriptor_ = file->message_type(28);
   static const int RangeLookupResponse_offsets_[2] = {
     GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(RangeLookupResponse, header_),
     GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(RangeLookupResponse, ranges_),
@@ -619,7 +655,7 @@ void protobuf_AssignDesc_cockroach_2froachpb_2fapi_2eproto() {
       sizeof(RangeLookupResponse),
       GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(RangeLookupResponse, _internal_metadata_),
       -1);
-  HeartbeatTxnRequest_descriptor_ = file->message_type(27);
+  HeartbeatTxnRequest_descriptor_ = file->message_type(29);
   static const int HeartbeatTxnRequest_offsets_[1] = {
     GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(HeartbeatTxnRequest, header_),
   };
@@ -634,7 +670,7 @@ void protobuf_AssignDesc_cockroach_2froachpb_2fapi_2eproto() {
       sizeof(HeartbeatTxnRequest),
       GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(HeartbeatTxnRequest, _internal_metadata_),
       -1);
-  HeartbeatTxnResponse_descriptor_ = file->message_type(28);
+  HeartbeatTxnResponse_descriptor_ = file->message_type(30);
   static const int HeartbeatTxnResponse_offsets_[1] = {
     GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(HeartbeatTxnResponse, header_),
   };
@@ -649,7 +685,7 @@ void protobuf_AssignDesc_cockroach_2froachpb_2fapi_2eproto() {
       sizeof(HeartbeatTxnResponse),
       GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(HeartbeatTxnResponse, _internal_metadata_),
       -1);
-  GCRequest_descriptor_ = file->message_type(29);
+  GCRequest_descriptor_ = file->message_type(31);
   static const int GCRequest_offsets_[3] = {
     GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(GCRequest, header_),
     GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(GCRequest, gc_meta_),
@@ -682,7 +718,7 @@ void protobuf_AssignDesc_cockroach_2froachpb_2fapi_2eproto() {
       sizeof(GCRequest_GCKey),
       GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(GCRequest_GCKey, _internal_metadata_),
       -1);
-  GCResponse_descriptor_ = file->message_type(30);
+  GCResponse_descriptor_ = file->message_type(32);
   static const int GCResponse_offsets_[1] = {
     GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(GCResponse, header_),
   };
@@ -697,7 +733,7 @@ void protobuf_AssignDesc_cockroach_2froachpb_2fapi_2eproto() {
       sizeof(GCResponse),
       GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(GCResponse, _internal_metadata_),
       -1);
-  PushTxnRequest_descriptor_ = file->message_type(31);
+  PushTxnRequest_descriptor_ = file->message_type(33);
   static const int PushTxnRequest_offsets_[6] = {
     GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(PushTxnRequest, header_),
     GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(PushTxnRequest, pusher_txn_),
@@ -717,7 +753,7 @@ void protobuf_AssignDesc_cockroach_2froachpb_2fapi_2eproto() {
       sizeof(PushTxnRequest),
       GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(PushTxnRequest, _internal_metadata_),
       -1);
-  PushTxnResponse_descriptor_ = file->message_type(32);
+  PushTxnResponse_descriptor_ = file->message_type(34);
   static const int PushTxnResponse_offsets_[2] = {
     GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(PushTxnResponse, header_),
     GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(PushTxnResponse, pushee_txn_),
@@ -733,7 +769,7 @@ void protobuf_AssignDesc_cockroach_2froachpb_2fapi_2eproto() {
       sizeof(PushTxnResponse),
       GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(PushTxnResponse, _internal_metadata_),
       -1);
-  ResolveIntentRequest_descriptor_ = file->message_type(33);
+  ResolveIntentRequest_descriptor_ = file->message_type(35);
   static const int ResolveIntentRequest_offsets_[2] = {
     GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(ResolveIntentRequest, header_),
     GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(ResolveIntentRequest, intent_txn_),
@@ -749,7 +785,7 @@ void protobuf_AssignDesc_cockroach_2froachpb_2fapi_2eproto() {
       sizeof(ResolveIntentRequest),
       GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(ResolveIntentRequest, _internal_metadata_),
       -1);
-  ResolveIntentResponse_descriptor_ = file->message_type(34);
+  ResolveIntentResponse_descriptor_ = file->message_type(36);
   static const int ResolveIntentResponse_offsets_[1] = {
     GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(ResolveIntentResponse, header_),
   };
@@ -764,7 +800,7 @@ void protobuf_AssignDesc_cockroach_2froachpb_2fapi_2eproto() {
       sizeof(ResolveIntentResponse),
       GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(ResolveIntentResponse, _internal_metadata_),
       -1);
-  ResolveIntentRangeRequest_descriptor_ = file->message_type(35);
+  ResolveIntentRangeRequest_descriptor_ = file->message_type(37);
   static const int ResolveIntentRangeRequest_offsets_[2] = {
     GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(ResolveIntentRangeRequest, header_),
     GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(ResolveIntentRangeRequest, intent_txn_),
@@ -780,7 +816,7 @@ void protobuf_AssignDesc_cockroach_2froachpb_2fapi_2eproto() {
       sizeof(ResolveIntentRangeRequest),
       GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(ResolveIntentRangeRequest, _internal_metadata_),
       -1);
-  NoopResponse_descriptor_ = file->message_type(36);
+  NoopResponse_descriptor_ = file->message_type(38);
   static const int NoopResponse_offsets_[1] = {
     GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(NoopResponse, header_),
   };
@@ -795,7 +831,7 @@ void protobuf_AssignDesc_cockroach_2froachpb_2fapi_2eproto() {
       sizeof(NoopResponse),
       GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(NoopResponse, _internal_metadata_),
       -1);
-  NoopRequest_descriptor_ = file->message_type(37);
+  NoopRequest_descriptor_ = file->message_type(39);
   static const int NoopRequest_offsets_[1] = {
     GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(NoopRequest, header_),
   };
@@ -810,7 +846,7 @@ void protobuf_AssignDesc_cockroach_2froachpb_2fapi_2eproto() {
       sizeof(NoopRequest),
       GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(NoopRequest, _internal_metadata_),
       -1);
-  ResolveIntentRangeResponse_descriptor_ = file->message_type(38);
+  ResolveIntentRangeResponse_descriptor_ = file->message_type(40);
   static const int ResolveIntentRangeResponse_offsets_[1] = {
     GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(ResolveIntentRangeResponse, header_),
   };
@@ -825,7 +861,7 @@ void protobuf_AssignDesc_cockroach_2froachpb_2fapi_2eproto() {
       sizeof(ResolveIntentRangeResponse),
       GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(ResolveIntentRangeResponse, _internal_metadata_),
       -1);
-  MergeRequest_descriptor_ = file->message_type(39);
+  MergeRequest_descriptor_ = file->message_type(41);
   static const int MergeRequest_offsets_[2] = {
     GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(MergeRequest, header_),
     GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(MergeRequest, value_),
@@ -841,7 +877,7 @@ void protobuf_AssignDesc_cockroach_2froachpb_2fapi_2eproto() {
       sizeof(MergeRequest),
       GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(MergeRequest, _internal_metadata_),
       -1);
-  MergeResponse_descriptor_ = file->message_type(40);
+  MergeResponse_descriptor_ = file->message_type(42);
   static const int MergeResponse_offsets_[1] = {
     GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(MergeResponse, header_),
   };
@@ -856,7 +892,7 @@ void protobuf_AssignDesc_cockroach_2froachpb_2fapi_2eproto() {
       sizeof(MergeResponse),
       GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(MergeResponse, _internal_metadata_),
       -1);
-  TruncateLogRequest_descriptor_ = file->message_type(41);
+  TruncateLogRequest_descriptor_ = file->message_type(43);
   static const int TruncateLogRequest_offsets_[2] = {
     GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(TruncateLogRequest, header_),
     GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(TruncateLogRequest, index_),
@@ -872,7 +908,7 @@ void protobuf_AssignDesc_cockroach_2froachpb_2fapi_2eproto() {
       sizeof(TruncateLogRequest),
       GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(TruncateLogRequest, _internal_metadata_),
       -1);
-  TruncateLogResponse_descriptor_ = file->message_type(42);
+  TruncateLogResponse_descriptor_ = file->message_type(44);
   static const int TruncateLogResponse_offsets_[1] = {
     GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(TruncateLogResponse, header_),
   };
@@ -887,7 +923,7 @@ void protobuf_AssignDesc_cockroach_2froachpb_2fapi_2eproto() {
       sizeof(TruncateLogResponse),
       GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(TruncateLogResponse, _internal_metadata_),
       -1);
-  LeaderLeaseRequest_descriptor_ = file->message_type(43);
+  LeaderLeaseRequest_descriptor_ = file->message_type(45);
   static const int LeaderLeaseRequest_offsets_[2] = {
     GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(LeaderLeaseRequest, header_),
     GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(LeaderLeaseRequest, lease_),
@@ -903,7 +939,7 @@ void protobuf_AssignDesc_cockroach_2froachpb_2fapi_2eproto() {
       sizeof(LeaderLeaseRequest),
       GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(LeaderLeaseRequest, _internal_metadata_),
       -1);
-  LeaderLeaseResponse_descriptor_ = file->message_type(44);
+  LeaderLeaseResponse_descriptor_ = file->message_type(46);
   static const int LeaderLeaseResponse_offsets_[1] = {
     GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(LeaderLeaseResponse, header_),
   };
@@ -918,8 +954,8 @@ void protobuf_AssignDesc_cockroach_2froachpb_2fapi_2eproto() {
       sizeof(LeaderLeaseResponse),
       GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(LeaderLeaseResponse, _internal_metadata_),
       -1);
-  RequestUnion_descriptor_ = file->message_type(45);
-  static const int RequestUnion_offsets_[21] = {
+  RequestUnion_descriptor_ = file->message_type(47);
+  static const int RequestUnion_offsets_[22] = {
     GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(RequestUnion, get_),
     GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(RequestUnion, put_),
     GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(RequestUnion, conditional_put_),
@@ -927,6 +963,7 @@ void protobuf_AssignDesc_cockroach_2froachpb_2fapi_2eproto() {
     GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(RequestUnion, delete__),
     GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(RequestUnion, delete_range_),
     GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(RequestUnion, scan_),
+    GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(RequestUnion, begin_transaction_),
     GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(RequestUnion, end_transaction_),
     GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(RequestUnion, admin_split_),
     GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(RequestUnion, admin_merge_),
@@ -953,8 +990,8 @@ void protobuf_AssignDesc_cockroach_2froachpb_2fapi_2eproto() {
       sizeof(RequestUnion),
       GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(RequestUnion, _internal_metadata_),
       -1);
-  ResponseUnion_descriptor_ = file->message_type(46);
-  static const int ResponseUnion_offsets_[21] = {
+  ResponseUnion_descriptor_ = file->message_type(48);
+  static const int ResponseUnion_offsets_[22] = {
     GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(ResponseUnion, get_),
     GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(ResponseUnion, put_),
     GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(ResponseUnion, conditional_put_),
@@ -962,6 +999,7 @@ void protobuf_AssignDesc_cockroach_2froachpb_2fapi_2eproto() {
     GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(ResponseUnion, delete__),
     GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(ResponseUnion, delete_range_),
     GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(ResponseUnion, scan_),
+    GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(ResponseUnion, begin_transaction_),
     GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(ResponseUnion, end_transaction_),
     GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(ResponseUnion, admin_split_),
     GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(ResponseUnion, admin_merge_),
@@ -988,7 +1026,7 @@ void protobuf_AssignDesc_cockroach_2froachpb_2fapi_2eproto() {
       sizeof(ResponseUnion),
       GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(ResponseUnion, _internal_metadata_),
       -1);
-  Header_descriptor_ = file->message_type(47);
+  Header_descriptor_ = file->message_type(49);
   static const int Header_offsets_[7] = {
     GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(Header, timestamp_),
     GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(Header, cmd_id_),
@@ -1009,7 +1047,7 @@ void protobuf_AssignDesc_cockroach_2froachpb_2fapi_2eproto() {
       sizeof(Header),
       GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(Header, _internal_metadata_),
       -1);
-  BatchRequest_descriptor_ = file->message_type(48);
+  BatchRequest_descriptor_ = file->message_type(50);
   static const int BatchRequest_offsets_[2] = {
     GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(BatchRequest, header_),
     GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(BatchRequest, requests_),
@@ -1025,7 +1063,7 @@ void protobuf_AssignDesc_cockroach_2froachpb_2fapi_2eproto() {
       sizeof(BatchRequest),
       GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(BatchRequest, _internal_metadata_),
       -1);
-  BatchResponse_descriptor_ = file->message_type(49);
+  BatchResponse_descriptor_ = file->message_type(51);
   static const int BatchResponse_offsets_[2] = {
     GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(BatchResponse, header_),
     GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(BatchResponse, responses_),
@@ -1110,6 +1148,10 @@ void protobuf_RegisterTypes(const ::std::string&) {
       ReverseScanRequest_descriptor_, &ReverseScanRequest::default_instance());
   ::google::protobuf::MessageFactory::InternalRegisterGeneratedMessage(
       ReverseScanResponse_descriptor_, &ReverseScanResponse::default_instance());
+  ::google::protobuf::MessageFactory::InternalRegisterGeneratedMessage(
+      BeginTransactionRequest_descriptor_, &BeginTransactionRequest::default_instance());
+  ::google::protobuf::MessageFactory::InternalRegisterGeneratedMessage(
+      BeginTransactionResponse_descriptor_, &BeginTransactionResponse::default_instance());
   ::google::protobuf::MessageFactory::InternalRegisterGeneratedMessage(
       EndTransactionRequest_descriptor_, &EndTransactionRequest::default_instance());
   ::google::protobuf::MessageFactory::InternalRegisterGeneratedMessage(
@@ -1219,6 +1261,10 @@ void protobuf_ShutdownFile_cockroach_2froachpb_2fapi_2eproto() {
   delete ReverseScanRequest_reflection_;
   delete ReverseScanResponse::default_instance_;
   delete ReverseScanResponse_reflection_;
+  delete BeginTransactionRequest::default_instance_;
+  delete BeginTransactionRequest_reflection_;
+  delete BeginTransactionResponse::default_instance_;
+  delete BeginTransactionResponse_reflection_;
   delete EndTransactionRequest::default_instance_;
   delete EndTransactionRequest_reflection_;
   delete EndTransactionResponse::default_instance_;
@@ -1349,172 +1395,179 @@ void protobuf_AddDesc_cockroach_2froachpb_2fapi_2eproto() {
     "\001\n\023ReverseScanResponse\022;\n\006header\030\001 \001(\0132!"
     ".cockroach.roachpb.ResponseHeaderB\010\310\336\037\000\320"
     "\336\037\001\022/\n\004rows\030\002 \003(\0132\033.cockroach.roachpb.Ke"
-    "yValueB\004\310\336\037\000\"\335\001\n\025EndTransactionRequest\0221"
-    "\n\006header\030\001 \001(\0132\027.cockroach.roachpb.SpanB"
-    "\010\310\336\037\000\320\336\037\001\022\024\n\006commit\030\002 \001(\010B\004\310\336\037\000\022I\n\027inter"
-    "nal_commit_trigger\030\003 \001(\0132(.cockroach.roa"
-    "chpb.InternalCommitTrigger\0220\n\007intents\030\004 "
-    "\003(\0132\031.cockroach.roachpb.IntentB\004\310\336\037\000\"\213\001\n"
-    "\026EndTransactionResponse\022;\n\006header\030\001 \001(\0132"
-    "!.cockroach.roachpb.ResponseHeaderB\010\310\336\037\000"
-    "\320\336\037\001\022\031\n\013commit_wait\030\002 \001(\003B\004\310\336\037\000\022\031\n\010resol"
-    "ved\030\003 \003(\014B\007\372\336\037\003Key\"b\n\021AdminSplitRequest\022"
+    "yValueB\004\310\336\037\000\"L\n\027BeginTransactionRequest\022"
     "1\n\006header\030\001 \001(\0132\027.cockroach.roachpb.Span"
-    "B\010\310\336\037\000\320\336\037\001\022\032\n\tsplit_key\030\002 \001(\014B\007\372\336\037\003Key\"Q"
-    "\n\022AdminSplitResponse\022;\n\006header\030\001 \001(\0132!.c"
-    "ockroach.roachpb.ResponseHeaderB\010\310\336\037\000\320\336\037"
-    "\001\"F\n\021AdminMergeRequest\0221\n\006header\030\001 \001(\0132\027"
-    ".cockroach.roachpb.SpanB\010\310\336\037\000\320\336\037\001\"Q\n\022Adm"
-    "inMergeResponse\022;\n\006header\030\001 \001(\0132!.cockro"
-    "ach.roachpb.ResponseHeaderB\010\310\336\037\000\320\336\037\001\"\230\001\n"
-    "\022RangeLookupRequest\0221\n\006header\030\001 \001(\0132\027.co"
-    "ckroach.roachpb.SpanB\010\310\336\037\000\320\336\037\001\022\030\n\nmax_ra"
-    "nges\030\002 \001(\005B\004\310\336\037\000\022\036\n\020consider_intents\030\003 \001"
-    "(\010B\004\310\336\037\000\022\025\n\007reverse\030\004 \001(\010B\004\310\336\037\000\"\214\001\n\023Rang"
-    "eLookupResponse\022;\n\006header\030\001 \001(\0132!.cockro"
-    "ach.roachpb.ResponseHeaderB\010\310\336\037\000\320\336\037\001\0228\n\006"
-    "ranges\030\002 \003(\0132\".cockroach.roachpb.RangeDe"
-    "scriptorB\004\310\336\037\000\"H\n\023HeartbeatTxnRequest\0221\n"
-    "\006header\030\001 \001(\0132\027.cockroach.roachpb.SpanB\010"
-    "\310\336\037\000\320\336\037\001\"S\n\024HeartbeatTxnResponse\022;\n\006head"
-    "er\030\001 \001(\0132!.cockroach.roachpb.ResponseHea"
-    "derB\010\310\336\037\000\320\336\037\001\"\214\002\n\tGCRequest\0221\n\006header\030\001 "
-    "\001(\0132\027.cockroach.roachpb.SpanB\010\310\336\037\000\320\336\037\001\022>"
-    "\n\007gc_meta\030\002 \001(\0132\035.cockroach.roachpb.GCMe"
-    "tadataB\016\310\336\037\000\342\336\037\006GCMeta\0226\n\004keys\030\003 \003(\0132\".c"
-    "ockroach.roachpb.GCRequest.GCKeyB\004\310\336\037\000\032T"
-    "\n\005GCKey\022\024\n\003key\030\001 \001(\014B\007\372\336\037\003Key\0225\n\ttimesta"
-    "mp\030\002 \001(\0132\034.cockroach.roachpb.TimestampB\004"
-    "\310\336\037\000\"I\n\nGCResponse\022;\n\006header\030\001 \001(\0132!.coc"
-    "kroach.roachpb.ResponseHeaderB\010\310\336\037\000\320\336\037\001\""
-    "\326\002\n\016PushTxnRequest\0221\n\006header\030\001 \001(\0132\027.coc"
-    "kroach.roachpb.SpanB\010\310\336\037\000\320\336\037\001\0228\n\npusher_"
-    "txn\030\002 \001(\0132\036.cockroach.roachpb.Transactio"
-    "nB\004\310\336\037\000\0228\n\npushee_txn\030\003 \001(\0132\036.cockroach."
-    "roachpb.TransactionB\004\310\336\037\000\0223\n\007push_to\030\004 \001"
-    "(\0132\034.cockroach.roachpb.TimestampB\004\310\336\037\000\022/"
-    "\n\003now\030\005 \001(\0132\034.cockroach.roachpb.Timestam"
-    "pB\004\310\336\037\000\0227\n\tpush_type\030\006 \001(\0162\036.cockroach.r"
-    "oachpb.PushTxnTypeB\004\310\336\037\000\"\202\001\n\017PushTxnResp"
-    "onse\022;\n\006header\030\001 \001(\0132!.cockroach.roachpb"
-    ".ResponseHeaderB\010\310\336\037\000\320\336\037\001\0222\n\npushee_txn\030"
-    "\002 \001(\0132\036.cockroach.roachpb.Transaction\"\203\001"
-    "\n\024ResolveIntentRequest\0221\n\006header\030\001 \001(\0132\027"
-    ".cockroach.roachpb.SpanB\010\310\336\037\000\320\336\037\001\0228\n\nint"
-    "ent_txn\030\002 \001(\0132\036.cockroach.roachpb.Transa"
-    "ctionB\004\310\336\037\000\"T\n\025ResolveIntentResponse\022;\n\006"
-    "header\030\001 \001(\0132!.cockroach.roachpb.Respons"
-    "eHeaderB\010\310\336\037\000\320\336\037\001\"\210\001\n\031ResolveIntentRange"
-    "Request\0221\n\006header\030\001 \001(\0132\027.cockroach.roac"
-    "hpb.SpanB\010\310\336\037\000\320\336\037\001\0228\n\nintent_txn\030\002 \001(\0132\036"
-    ".cockroach.roachpb.TransactionB\004\310\336\037\000\"K\n\014"
-    "NoopResponse\022;\n\006header\030\001 \001(\0132!.cockroach"
-    ".roachpb.ResponseHeaderB\010\310\336\037\000\320\336\037\001\"@\n\013Noo"
-    "pRequest\0221\n\006header\030\001 \001(\0132\027.cockroach.roa"
-    "chpb.SpanB\010\310\336\037\000\320\336\037\001\"Y\n\032ResolveIntentRang"
-    "eResponse\022;\n\006header\030\001 \001(\0132!.cockroach.ro"
-    "achpb.ResponseHeaderB\010\310\336\037\000\320\336\037\001\"p\n\014MergeR"
+    "B\010\310\336\037\000\320\336\037\001\"W\n\030BeginTransactionResponse\022;"
+    "\n\006header\030\001 \001(\0132!.cockroach.roachpb.Respo"
+    "nseHeaderB\010\310\336\037\000\320\336\037\001\"\335\001\n\025EndTransactionRe"
+    "quest\0221\n\006header\030\001 \001(\0132\027.cockroach.roachp"
+    "b.SpanB\010\310\336\037\000\320\336\037\001\022\024\n\006commit\030\002 \001(\010B\004\310\336\037\000\022I"
+    "\n\027internal_commit_trigger\030\003 \001(\0132(.cockro"
+    "ach.roachpb.InternalCommitTrigger\0220\n\007int"
+    "ents\030\004 \003(\0132\031.cockroach.roachpb.IntentB\004\310"
+    "\336\037\000\"\213\001\n\026EndTransactionResponse\022;\n\006header"
+    "\030\001 \001(\0132!.cockroach.roachpb.ResponseHeade"
+    "rB\010\310\336\037\000\320\336\037\001\022\031\n\013commit_wait\030\002 \001(\003B\004\310\336\037\000\022\031"
+    "\n\010resolved\030\003 \003(\014B\007\372\336\037\003Key\"b\n\021AdminSplitR"
     "equest\0221\n\006header\030\001 \001(\0132\027.cockroach.roach"
-    "pb.SpanB\010\310\336\037\000\320\336\037\001\022-\n\005value\030\002 \001(\0132\030.cockr"
-    "oach.roachpb.ValueB\004\310\336\037\000\"L\n\rMergeRespons"
-    "e\022;\n\006header\030\001 \001(\0132!.cockroach.roachpb.Re"
-    "sponseHeaderB\010\310\336\037\000\320\336\037\001\"\\\n\022TruncateLogReq"
+    "pb.SpanB\010\310\336\037\000\320\336\037\001\022\032\n\tsplit_key\030\002 \001(\014B\007\372\336"
+    "\037\003Key\"Q\n\022AdminSplitResponse\022;\n\006header\030\001 "
+    "\001(\0132!.cockroach.roachpb.ResponseHeaderB\010"
+    "\310\336\037\000\320\336\037\001\"F\n\021AdminMergeRequest\0221\n\006header\030"
+    "\001 \001(\0132\027.cockroach.roachpb.SpanB\010\310\336\037\000\320\336\037\001"
+    "\"Q\n\022AdminMergeResponse\022;\n\006header\030\001 \001(\0132!"
+    ".cockroach.roachpb.ResponseHeaderB\010\310\336\037\000\320"
+    "\336\037\001\"\230\001\n\022RangeLookupRequest\0221\n\006header\030\001 \001"
+    "(\0132\027.cockroach.roachpb.SpanB\010\310\336\037\000\320\336\037\001\022\030\n"
+    "\nmax_ranges\030\002 \001(\005B\004\310\336\037\000\022\036\n\020consider_inte"
+    "nts\030\003 \001(\010B\004\310\336\037\000\022\025\n\007reverse\030\004 \001(\010B\004\310\336\037\000\"\214"
+    "\001\n\023RangeLookupResponse\022;\n\006header\030\001 \001(\0132!"
+    ".cockroach.roachpb.ResponseHeaderB\010\310\336\037\000\320"
+    "\336\037\001\0228\n\006ranges\030\002 \003(\0132\".cockroach.roachpb."
+    "RangeDescriptorB\004\310\336\037\000\"H\n\023HeartbeatTxnReq"
     "uest\0221\n\006header\030\001 \001(\0132\027.cockroach.roachpb"
-    ".SpanB\010\310\336\037\000\320\336\037\001\022\023\n\005index\030\002 \001(\004B\004\310\336\037\000\"R\n\023"
-    "TruncateLogResponse\022;\n\006header\030\001 \001(\0132!.co"
+    ".SpanB\010\310\336\037\000\320\336\037\001\"S\n\024HeartbeatTxnResponse\022"
+    ";\n\006header\030\001 \001(\0132!.cockroach.roachpb.Resp"
+    "onseHeaderB\010\310\336\037\000\320\336\037\001\"\214\002\n\tGCRequest\0221\n\006he"
+    "ader\030\001 \001(\0132\027.cockroach.roachpb.SpanB\010\310\336\037"
+    "\000\320\336\037\001\022>\n\007gc_meta\030\002 \001(\0132\035.cockroach.roach"
+    "pb.GCMetadataB\016\310\336\037\000\342\336\037\006GCMeta\0226\n\004keys\030\003 "
+    "\003(\0132\".cockroach.roachpb.GCRequest.GCKeyB"
+    "\004\310\336\037\000\032T\n\005GCKey\022\024\n\003key\030\001 \001(\014B\007\372\336\037\003Key\0225\n\t"
+    "timestamp\030\002 \001(\0132\034.cockroach.roachpb.Time"
+    "stampB\004\310\336\037\000\"I\n\nGCResponse\022;\n\006header\030\001 \001("
+    "\0132!.cockroach.roachpb.ResponseHeaderB\010\310\336"
+    "\037\000\320\336\037\001\"\326\002\n\016PushTxnRequest\0221\n\006header\030\001 \001("
+    "\0132\027.cockroach.roachpb.SpanB\010\310\336\037\000\320\336\037\001\0228\n\n"
+    "pusher_txn\030\002 \001(\0132\036.cockroach.roachpb.Tra"
+    "nsactionB\004\310\336\037\000\0228\n\npushee_txn\030\003 \001(\0132\036.coc"
+    "kroach.roachpb.TransactionB\004\310\336\037\000\0223\n\007push"
+    "_to\030\004 \001(\0132\034.cockroach.roachpb.TimestampB"
+    "\004\310\336\037\000\022/\n\003now\030\005 \001(\0132\034.cockroach.roachpb.T"
+    "imestampB\004\310\336\037\000\0227\n\tpush_type\030\006 \001(\0162\036.cock"
+    "roach.roachpb.PushTxnTypeB\004\310\336\037\000\"\202\001\n\017Push"
+    "TxnResponse\022;\n\006header\030\001 \001(\0132!.cockroach."
+    "roachpb.ResponseHeaderB\010\310\336\037\000\320\336\037\001\0222\n\npush"
+    "ee_txn\030\002 \001(\0132\036.cockroach.roachpb.Transac"
+    "tion\"\203\001\n\024ResolveIntentRequest\0221\n\006header\030"
+    "\001 \001(\0132\027.cockroach.roachpb.SpanB\010\310\336\037\000\320\336\037\001"
+    "\0228\n\nintent_txn\030\002 \001(\0132\036.cockroach.roachpb"
+    ".TransactionB\004\310\336\037\000\"T\n\025ResolveIntentRespo"
+    "nse\022;\n\006header\030\001 \001(\0132!.cockroach.roachpb."
+    "ResponseHeaderB\010\310\336\037\000\320\336\037\001\"\210\001\n\031ResolveInte"
+    "ntRangeRequest\0221\n\006header\030\001 \001(\0132\027.cockroa"
+    "ch.roachpb.SpanB\010\310\336\037\000\320\336\037\001\0228\n\nintent_txn\030"
+    "\002 \001(\0132\036.cockroach.roachpb.TransactionB\004\310"
+    "\336\037\000\"K\n\014NoopResponse\022;\n\006header\030\001 \001(\0132!.co"
     "ckroach.roachpb.ResponseHeaderB\010\310\336\037\000\320\336\037\001"
-    "\"v\n\022LeaderLeaseRequest\0221\n\006header\030\001 \001(\0132\027"
-    ".cockroach.roachpb.SpanB\010\310\336\037\000\320\336\037\001\022-\n\005lea"
-    "se\030\002 \001(\0132\030.cockroach.roachpb.LeaseB\004\310\336\037\000"
-    "\"R\n\023LeaderLeaseResponse\022;\n\006header\030\001 \001(\0132"
-    "!.cockroach.roachpb.ResponseHeaderB\010\310\336\037\000"
-    "\320\336\037\001\"\272\t\n\014RequestUnion\022*\n\003get\030\001 \001(\0132\035.coc"
-    "kroach.roachpb.GetRequest\022*\n\003put\030\002 \001(\0132\035"
-    ".cockroach.roachpb.PutRequest\022A\n\017conditi"
-    "onal_put\030\003 \001(\0132(.cockroach.roachpb.Condi"
-    "tionalPutRequest\0226\n\tincrement\030\004 \001(\0132#.co"
-    "ckroach.roachpb.IncrementRequest\0220\n\006dele"
-    "te\030\005 \001(\0132 .cockroach.roachpb.DeleteReque"
-    "st\022;\n\014delete_range\030\006 \001(\0132%.cockroach.roa"
-    "chpb.DeleteRangeRequest\022,\n\004scan\030\007 \001(\0132\036."
-    "cockroach.roachpb.ScanRequest\022A\n\017end_tra"
-    "nsaction\030\010 \001(\0132(.cockroach.roachpb.EndTr"
-    "ansactionRequest\0229\n\013admin_split\030\t \001(\0132$."
-    "cockroach.roachpb.AdminSplitRequest\0229\n\013a"
-    "dmin_merge\030\n \001(\0132$.cockroach.roachpb.Adm"
-    "inMergeRequest\022=\n\rheartbeat_txn\030\013 \001(\0132&."
-    "cockroach.roachpb.HeartbeatTxnRequest\022(\n"
-    "\002gc\030\014 \001(\0132\034.cockroach.roachpb.GCRequest\022"
-    "3\n\010push_txn\030\r \001(\0132!.cockroach.roachpb.Pu"
-    "shTxnRequest\022;\n\014range_lookup\030\016 \001(\0132%.coc"
-    "kroach.roachpb.RangeLookupRequest\022\?\n\016res"
-    "olve_intent\030\017 \001(\0132\'.cockroach.roachpb.Re"
-    "solveIntentRequest\022J\n\024resolve_intent_ran"
-    "ge\030\020 \001(\0132,.cockroach.roachpb.ResolveInte"
-    "ntRangeRequest\022.\n\005merge\030\021 \001(\0132\037.cockroac"
-    "h.roachpb.MergeRequest\022;\n\014truncate_log\030\022"
-    " \001(\0132%.cockroach.roachpb.TruncateLogRequ"
-    "est\022;\n\014leader_lease\030\023 \001(\0132%.cockroach.ro"
-    "achpb.LeaderLeaseRequest\022;\n\014reverse_scan"
-    "\030\024 \001(\0132%.cockroach.roachpb.ReverseScanRe"
-    "quest\022,\n\004noop\030\025 \001(\0132\036.cockroach.roachpb."
-    "NoopRequest:\004\310\240\037\001\"\320\t\n\rResponseUnion\022+\n\003g"
-    "et\030\001 \001(\0132\036.cockroach.roachpb.GetResponse"
-    "\022+\n\003put\030\002 \001(\0132\036.cockroach.roachpb.PutRes"
-    "ponse\022B\n\017conditional_put\030\003 \001(\0132).cockroa"
-    "ch.roachpb.ConditionalPutResponse\0227\n\tinc"
-    "rement\030\004 \001(\0132$.cockroach.roachpb.Increme"
-    "ntResponse\0221\n\006delete\030\005 \001(\0132!.cockroach.r"
-    "oachpb.DeleteResponse\022<\n\014delete_range\030\006 "
-    "\001(\0132&.cockroach.roachpb.DeleteRangeRespo"
-    "nse\022-\n\004scan\030\007 \001(\0132\037.cockroach.roachpb.Sc"
-    "anResponse\022B\n\017end_transaction\030\010 \001(\0132).co"
-    "ckroach.roachpb.EndTransactionResponse\022:"
-    "\n\013admin_split\030\t \001(\0132%.cockroach.roachpb."
-    "AdminSplitResponse\022:\n\013admin_merge\030\n \001(\0132"
-    "%.cockroach.roachpb.AdminMergeResponse\022>"
-    "\n\rheartbeat_txn\030\013 \001(\0132\'.cockroach.roachp"
-    "b.HeartbeatTxnResponse\022)\n\002gc\030\014 \001(\0132\035.coc"
-    "kroach.roachpb.GCResponse\0224\n\010push_txn\030\r "
-    "\001(\0132\".cockroach.roachpb.PushTxnResponse\022"
-    "<\n\014range_lookup\030\016 \001(\0132&.cockroach.roachp"
-    "b.RangeLookupResponse\022@\n\016resolve_intent\030"
-    "\017 \001(\0132(.cockroach.roachpb.ResolveIntentR"
-    "esponse\022K\n\024resolve_intent_range\030\020 \001(\0132-."
-    "cockroach.roachpb.ResolveIntentRangeResp"
-    "onse\022/\n\005merge\030\021 \001(\0132 .cockroach.roachpb."
-    "MergeResponse\022<\n\014truncate_log\030\022 \001(\0132&.co"
-    "ckroach.roachpb.TruncateLogResponse\022<\n\014l"
-    "eader_lease\030\023 \001(\0132&.cockroach.roachpb.Le"
-    "aderLeaseResponse\022<\n\014reverse_scan\030\024 \001(\0132"
-    "&.cockroach.roachpb.ReverseScanResponse\022"
-    "-\n\004noop\030\025 \001(\0132\037.cockroach.roachpb.NoopRe"
-    "sponse:\004\310\240\037\001\"\370\002\n\006Header\0225\n\ttimestamp\030\001 \001"
-    "(\0132\034.cockroach.roachpb.TimestampB\004\310\336\037\000\022="
-    "\n\006cmd_id\030\002 \001(\0132\036.cockroach.roachpb.Clien"
-    "tCmdIDB\r\310\336\037\000\342\336\037\005CmdID\022;\n\007replica\030\005 \001(\0132$"
-    ".cockroach.roachpb.ReplicaDescriptorB\004\310\336"
-    "\037\000\022,\n\010range_id\030\006 \001(\003B\032\310\336\037\000\342\336\037\007RangeID\372\336\037"
-    "\007RangeID\022\030\n\ruser_priority\030\007 \001(\005:\0011\022+\n\003tx"
-    "n\030\010 \001(\0132\036.cockroach.roachpb.Transaction\022"
-    "F\n\020read_consistency\030\t \001(\0162&.cockroach.ro"
-    "achpb.ReadConsistencyTypeB\004\310\336\037\000\"\202\001\n\014Batc"
-    "hRequest\0223\n\006header\030\001 \001(\0132\031.cockroach.roa"
-    "chpb.HeaderB\010\310\336\037\000\320\336\037\001\0227\n\010requests\030\002 \003(\0132"
-    "\037.cockroach.roachpb.RequestUnionB\004\310\336\037\000:\004"
-    "\230\240\037\000\"\253\002\n\rBatchResponse\022A\n\006header\030\001 \001(\0132\'"
-    ".cockroach.roachpb.BatchResponse.HeaderB"
-    "\010\310\336\037\000\320\336\037\001\0229\n\tresponses\030\002 \003(\0132 .cockroach"
-    ".roachpb.ResponseUnionB\004\310\336\037\000\032\225\001\n\006Header\022"
-    "\'\n\005error\030\001 \001(\0132\030.cockroach.roachpb.Error"
-    "\0225\n\ttimestamp\030\002 \001(\0132\034.cockroach.roachpb."
-    "TimestampB\004\310\336\037\000\022+\n\003txn\030\003 \001(\0132\036.cockroach"
-    ".roachpb.Transaction:\004\230\240\037\000*L\n\023ReadConsis"
-    "tencyType\022\016\n\nCONSISTENT\020\000\022\r\n\tCONSENSUS\020\001"
-    "\022\020\n\014INCONSISTENT\020\002\032\004\210\243\036\000*G\n\013PushTxnType\022"
-    "\022\n\016PUSH_TIMESTAMP\020\000\022\r\n\tABORT_TXN\020\001\022\017\n\013CL"
-    "EANUP_TXN\020\002\032\004\210\243\036\000B\031Z\007roachpb\340\342\036\001\310\342\036\001\320\342\036\001"
-    "\220\343\036\000", 8644);
+    "\"@\n\013NoopRequest\0221\n\006header\030\001 \001(\0132\027.cockro"
+    "ach.roachpb.SpanB\010\310\336\037\000\320\336\037\001\"Y\n\032ResolveInt"
+    "entRangeResponse\022;\n\006header\030\001 \001(\0132!.cockr"
+    "oach.roachpb.ResponseHeaderB\010\310\336\037\000\320\336\037\001\"p\n"
+    "\014MergeRequest\0221\n\006header\030\001 \001(\0132\027.cockroac"
+    "h.roachpb.SpanB\010\310\336\037\000\320\336\037\001\022-\n\005value\030\002 \001(\0132"
+    "\030.cockroach.roachpb.ValueB\004\310\336\037\000\"L\n\rMerge"
+    "Response\022;\n\006header\030\001 \001(\0132!.cockroach.roa"
+    "chpb.ResponseHeaderB\010\310\336\037\000\320\336\037\001\"\\\n\022Truncat"
+    "eLogRequest\0221\n\006header\030\001 \001(\0132\027.cockroach."
+    "roachpb.SpanB\010\310\336\037\000\320\336\037\001\022\023\n\005index\030\002 \001(\004B\004\310"
+    "\336\037\000\"R\n\023TruncateLogResponse\022;\n\006header\030\001 \001"
+    "(\0132!.cockroach.roachpb.ResponseHeaderB\010\310"
+    "\336\037\000\320\336\037\001\"v\n\022LeaderLeaseRequest\0221\n\006header\030"
+    "\001 \001(\0132\027.cockroach.roachpb.SpanB\010\310\336\037\000\320\336\037\001"
+    "\022-\n\005lease\030\002 \001(\0132\030.cockroach.roachpb.Leas"
+    "eB\004\310\336\037\000\"R\n\023LeaderLeaseResponse\022;\n\006header"
+    "\030\001 \001(\0132!.cockroach.roachpb.ResponseHeade"
+    "rB\010\310\336\037\000\320\336\037\001\"\201\n\n\014RequestUnion\022*\n\003get\030\001 \001("
+    "\0132\035.cockroach.roachpb.GetRequest\022*\n\003put\030"
+    "\002 \001(\0132\035.cockroach.roachpb.PutRequest\022A\n\017"
+    "conditional_put\030\003 \001(\0132(.cockroach.roachp"
+    "b.ConditionalPutRequest\0226\n\tincrement\030\004 \001"
+    "(\0132#.cockroach.roachpb.IncrementRequest\022"
+    "0\n\006delete\030\005 \001(\0132 .cockroach.roachpb.Dele"
+    "teRequest\022;\n\014delete_range\030\006 \001(\0132%.cockro"
+    "ach.roachpb.DeleteRangeRequest\022,\n\004scan\030\007"
+    " \001(\0132\036.cockroach.roachpb.ScanRequest\022E\n\021"
+    "begin_transaction\030\010 \001(\0132*.cockroach.roac"
+    "hpb.BeginTransactionRequest\022A\n\017end_trans"
+    "action\030\t \001(\0132(.cockroach.roachpb.EndTran"
+    "sactionRequest\0229\n\013admin_split\030\n \001(\0132$.co"
+    "ckroach.roachpb.AdminSplitRequest\0229\n\013adm"
+    "in_merge\030\013 \001(\0132$.cockroach.roachpb.Admin"
+    "MergeRequest\022=\n\rheartbeat_txn\030\014 \001(\0132&.co"
+    "ckroach.roachpb.HeartbeatTxnRequest\022(\n\002g"
+    "c\030\r \001(\0132\034.cockroach.roachpb.GCRequest\0223\n"
+    "\010push_txn\030\016 \001(\0132!.cockroach.roachpb.Push"
+    "TxnRequest\022;\n\014range_lookup\030\017 \001(\0132%.cockr"
+    "oach.roachpb.RangeLookupRequest\022\?\n\016resol"
+    "ve_intent\030\020 \001(\0132\'.cockroach.roachpb.Reso"
+    "lveIntentRequest\022J\n\024resolve_intent_range"
+    "\030\021 \001(\0132,.cockroach.roachpb.ResolveIntent"
+    "RangeRequest\022.\n\005merge\030\022 \001(\0132\037.cockroach."
+    "roachpb.MergeRequest\022;\n\014truncate_log\030\023 \001"
+    "(\0132%.cockroach.roachpb.TruncateLogReques"
+    "t\022;\n\014leader_lease\030\024 \001(\0132%.cockroach.roac"
+    "hpb.LeaderLeaseRequest\022;\n\014reverse_scan\030\025"
+    " \001(\0132%.cockroach.roachpb.ReverseScanRequ"
+    "est\022,\n\004noop\030\026 \001(\0132\036.cockroach.roachpb.No"
+    "opRequest:\004\310\240\037\001\"\230\n\n\rResponseUnion\022+\n\003get"
+    "\030\001 \001(\0132\036.cockroach.roachpb.GetResponse\022+"
+    "\n\003put\030\002 \001(\0132\036.cockroach.roachpb.PutRespo"
+    "nse\022B\n\017conditional_put\030\003 \001(\0132).cockroach"
+    ".roachpb.ConditionalPutResponse\0227\n\tincre"
+    "ment\030\004 \001(\0132$.cockroach.roachpb.Increment"
+    "Response\0221\n\006delete\030\005 \001(\0132!.cockroach.roa"
+    "chpb.DeleteResponse\022<\n\014delete_range\030\006 \001("
+    "\0132&.cockroach.roachpb.DeleteRangeRespons"
+    "e\022-\n\004scan\030\007 \001(\0132\037.cockroach.roachpb.Scan"
+    "Response\022F\n\021begin_transaction\030\010 \001(\0132+.co"
+    "ckroach.roachpb.BeginTransactionResponse"
+    "\022B\n\017end_transaction\030\t \001(\0132).cockroach.ro"
+    "achpb.EndTransactionResponse\022:\n\013admin_sp"
+    "lit\030\n \001(\0132%.cockroach.roachpb.AdminSplit"
+    "Response\022:\n\013admin_merge\030\013 \001(\0132%.cockroac"
+    "h.roachpb.AdminMergeResponse\022>\n\rheartbea"
+    "t_txn\030\014 \001(\0132\'.cockroach.roachpb.Heartbea"
+    "tTxnResponse\022)\n\002gc\030\r \001(\0132\035.cockroach.roa"
+    "chpb.GCResponse\0224\n\010push_txn\030\016 \001(\0132\".cock"
+    "roach.roachpb.PushTxnResponse\022<\n\014range_l"
+    "ookup\030\017 \001(\0132&.cockroach.roachpb.RangeLoo"
+    "kupResponse\022@\n\016resolve_intent\030\020 \001(\0132(.co"
+    "ckroach.roachpb.ResolveIntentResponse\022K\n"
+    "\024resolve_intent_range\030\021 \001(\0132-.cockroach."
+    "roachpb.ResolveIntentRangeResponse\022/\n\005me"
+    "rge\030\022 \001(\0132 .cockroach.roachpb.MergeRespo"
+    "nse\022<\n\014truncate_log\030\023 \001(\0132&.cockroach.ro"
+    "achpb.TruncateLogResponse\022<\n\014leader_leas"
+    "e\030\024 \001(\0132&.cockroach.roachpb.LeaderLeaseR"
+    "esponse\022<\n\014reverse_scan\030\025 \001(\0132&.cockroac"
+    "h.roachpb.ReverseScanResponse\022-\n\004noop\030\026 "
+    "\001(\0132\037.cockroach.roachpb.NoopResponse:\004\310\240"
+    "\037\001\"\370\002\n\006Header\0225\n\ttimestamp\030\001 \001(\0132\034.cockr"
+    "oach.roachpb.TimestampB\004\310\336\037\000\022=\n\006cmd_id\030\002"
+    " \001(\0132\036.cockroach.roachpb.ClientCmdIDB\r\310\336"
+    "\037\000\342\336\037\005CmdID\022;\n\007replica\030\005 \001(\0132$.cockroach"
+    ".roachpb.ReplicaDescriptorB\004\310\336\037\000\022,\n\010rang"
+    "e_id\030\006 \001(\003B\032\310\336\037\000\342\336\037\007RangeID\372\336\037\007RangeID\022\030"
+    "\n\ruser_priority\030\007 \001(\005:\0011\022+\n\003txn\030\010 \001(\0132\036."
+    "cockroach.roachpb.Transaction\022F\n\020read_co"
+    "nsistency\030\t \001(\0162&.cockroach.roachpb.Read"
+    "ConsistencyTypeB\004\310\336\037\000\"\202\001\n\014BatchRequest\0223"
+    "\n\006header\030\001 \001(\0132\031.cockroach.roachpb.Heade"
+    "rB\010\310\336\037\000\320\336\037\001\0227\n\010requests\030\002 \003(\0132\037.cockroac"
+    "h.roachpb.RequestUnionB\004\310\336\037\000:\004\230\240\037\000\"\253\002\n\rB"
+    "atchResponse\022A\n\006header\030\001 \001(\0132\'.cockroach"
+    ".roachpb.BatchResponse.HeaderB\010\310\336\037\000\320\336\037\001\022"
+    "9\n\tresponses\030\002 \003(\0132 .cockroach.roachpb.R"
+    "esponseUnionB\004\310\336\037\000\032\225\001\n\006Header\022\'\n\005error\030\001"
+    " \001(\0132\030.cockroach.roachpb.Error\0225\n\ttimest"
+    "amp\030\002 \001(\0132\034.cockroach.roachpb.TimestampB"
+    "\004\310\336\037\000\022+\n\003txn\030\003 \001(\0132\036.cockroach.roachpb.T"
+    "ransaction:\004\230\240\037\000*L\n\023ReadConsistencyType\022"
+    "\016\n\nCONSISTENT\020\000\022\r\n\tCONSENSUS\020\001\022\020\n\014INCONS"
+    "ISTENT\020\002\032\004\210\243\036\000*G\n\013PushTxnType\022\022\n\016PUSH_TI"
+    "MESTAMP\020\000\022\r\n\tABORT_TXN\020\001\022\017\n\013CLEANUP_TXN\020"
+    "\002\032\004\210\243\036\000B\031Z\007roachpb\340\342\036\001\310\342\036\001\320\342\036\001\220\343\036\000", 8954);
   ::google::protobuf::MessageFactory::InternalRegisterGeneratedFile(
     "cockroach/roachpb/api.proto", &protobuf_RegisterTypes);
   ClientCmdID::default_instance_ = new ClientCmdID();
@@ -1536,6 +1589,8 @@ void protobuf_AddDesc_cockroach_2froachpb_2fapi_2eproto() {
   ScanResponse::default_instance_ = new ScanResponse();
   ReverseScanRequest::default_instance_ = new ReverseScanRequest();
   ReverseScanResponse::default_instance_ = new ReverseScanResponse();
+  BeginTransactionRequest::default_instance_ = new BeginTransactionRequest();
+  BeginTransactionResponse::default_instance_ = new BeginTransactionResponse();
   EndTransactionRequest::default_instance_ = new EndTransactionRequest();
   EndTransactionResponse::default_instance_ = new EndTransactionResponse();
   AdminSplitRequest::default_instance_ = new AdminSplitRequest();
@@ -1588,6 +1643,8 @@ void protobuf_AddDesc_cockroach_2froachpb_2fapi_2eproto() {
   ScanResponse::default_instance_->InitAsDefaultInstance();
   ReverseScanRequest::default_instance_->InitAsDefaultInstance();
   ReverseScanResponse::default_instance_->InitAsDefaultInstance();
+  BeginTransactionRequest::default_instance_->InitAsDefaultInstance();
+  BeginTransactionResponse::default_instance_->InitAsDefaultInstance();
   EndTransactionRequest::default_instance_->InitAsDefaultInstance();
   EndTransactionResponse::default_instance_->InitAsDefaultInstance();
   AdminSplitRequest::default_instance_->InitAsDefaultInstance();
@@ -8205,6 +8262,572 @@ ReverseScanResponse::rows() const {
 ReverseScanResponse::mutable_rows() {
   // @@protoc_insertion_point(field_mutable_list:cockroach.roachpb.ReverseScanResponse.rows)
   return &rows_;
+}
+
+#endif  // PROTOBUF_INLINE_NOT_IN_HEADERS
+
+// ===================================================================
+
+#ifndef _MSC_VER
+const int BeginTransactionRequest::kHeaderFieldNumber;
+#endif  // !_MSC_VER
+
+BeginTransactionRequest::BeginTransactionRequest()
+  : ::google::protobuf::Message(), _internal_metadata_(NULL) {
+  SharedCtor();
+  // @@protoc_insertion_point(constructor:cockroach.roachpb.BeginTransactionRequest)
+}
+
+void BeginTransactionRequest::InitAsDefaultInstance() {
+  header_ = const_cast< ::cockroach::roachpb::Span*>(&::cockroach::roachpb::Span::default_instance());
+}
+
+BeginTransactionRequest::BeginTransactionRequest(const BeginTransactionRequest& from)
+  : ::google::protobuf::Message(),
+    _internal_metadata_(NULL) {
+  SharedCtor();
+  MergeFrom(from);
+  // @@protoc_insertion_point(copy_constructor:cockroach.roachpb.BeginTransactionRequest)
+}
+
+void BeginTransactionRequest::SharedCtor() {
+  _cached_size_ = 0;
+  header_ = NULL;
+  ::memset(_has_bits_, 0, sizeof(_has_bits_));
+}
+
+BeginTransactionRequest::~BeginTransactionRequest() {
+  // @@protoc_insertion_point(destructor:cockroach.roachpb.BeginTransactionRequest)
+  SharedDtor();
+}
+
+void BeginTransactionRequest::SharedDtor() {
+  if (this != default_instance_) {
+    delete header_;
+  }
+}
+
+void BeginTransactionRequest::SetCachedSize(int size) const {
+  GOOGLE_SAFE_CONCURRENT_WRITES_BEGIN();
+  _cached_size_ = size;
+  GOOGLE_SAFE_CONCURRENT_WRITES_END();
+}
+const ::google::protobuf::Descriptor* BeginTransactionRequest::descriptor() {
+  protobuf_AssignDescriptorsOnce();
+  return BeginTransactionRequest_descriptor_;
+}
+
+const BeginTransactionRequest& BeginTransactionRequest::default_instance() {
+  if (default_instance_ == NULL) protobuf_AddDesc_cockroach_2froachpb_2fapi_2eproto();
+  return *default_instance_;
+}
+
+BeginTransactionRequest* BeginTransactionRequest::default_instance_ = NULL;
+
+BeginTransactionRequest* BeginTransactionRequest::New(::google::protobuf::Arena* arena) const {
+  BeginTransactionRequest* n = new BeginTransactionRequest;
+  if (arena != NULL) {
+    arena->Own(n);
+  }
+  return n;
+}
+
+void BeginTransactionRequest::Clear() {
+  if (has_header()) {
+    if (header_ != NULL) header_->::cockroach::roachpb::Span::Clear();
+  }
+  ::memset(_has_bits_, 0, sizeof(_has_bits_));
+  if (_internal_metadata_.have_unknown_fields()) {
+    mutable_unknown_fields()->Clear();
+  }
+}
+
+bool BeginTransactionRequest::MergePartialFromCodedStream(
+    ::google::protobuf::io::CodedInputStream* input) {
+#define DO_(EXPRESSION) if (!(EXPRESSION)) goto failure
+  ::google::protobuf::uint32 tag;
+  // @@protoc_insertion_point(parse_start:cockroach.roachpb.BeginTransactionRequest)
+  for (;;) {
+    ::std::pair< ::google::protobuf::uint32, bool> p = input->ReadTagWithCutoff(127);
+    tag = p.first;
+    if (!p.second) goto handle_unusual;
+    switch (::google::protobuf::internal::WireFormatLite::GetTagFieldNumber(tag)) {
+      // optional .cockroach.roachpb.Span header = 1;
+      case 1: {
+        if (tag == 10) {
+          DO_(::google::protobuf::internal::WireFormatLite::ReadMessageNoVirtual(
+               input, mutable_header()));
+        } else {
+          goto handle_unusual;
+        }
+        if (input->ExpectAtEnd()) goto success;
+        break;
+      }
+
+      default: {
+      handle_unusual:
+        if (tag == 0 ||
+            ::google::protobuf::internal::WireFormatLite::GetTagWireType(tag) ==
+            ::google::protobuf::internal::WireFormatLite::WIRETYPE_END_GROUP) {
+          goto success;
+        }
+        DO_(::google::protobuf::internal::WireFormat::SkipField(
+              input, tag, mutable_unknown_fields()));
+        break;
+      }
+    }
+  }
+success:
+  // @@protoc_insertion_point(parse_success:cockroach.roachpb.BeginTransactionRequest)
+  return true;
+failure:
+  // @@protoc_insertion_point(parse_failure:cockroach.roachpb.BeginTransactionRequest)
+  return false;
+#undef DO_
+}
+
+void BeginTransactionRequest::SerializeWithCachedSizes(
+    ::google::protobuf::io::CodedOutputStream* output) const {
+  // @@protoc_insertion_point(serialize_start:cockroach.roachpb.BeginTransactionRequest)
+  // optional .cockroach.roachpb.Span header = 1;
+  if (has_header()) {
+    ::google::protobuf::internal::WireFormatLite::WriteMessageMaybeToArray(
+      1, *this->header_, output);
+  }
+
+  if (_internal_metadata_.have_unknown_fields()) {
+    ::google::protobuf::internal::WireFormat::SerializeUnknownFields(
+        unknown_fields(), output);
+  }
+  // @@protoc_insertion_point(serialize_end:cockroach.roachpb.BeginTransactionRequest)
+}
+
+::google::protobuf::uint8* BeginTransactionRequest::SerializeWithCachedSizesToArray(
+    ::google::protobuf::uint8* target) const {
+  // @@protoc_insertion_point(serialize_to_array_start:cockroach.roachpb.BeginTransactionRequest)
+  // optional .cockroach.roachpb.Span header = 1;
+  if (has_header()) {
+    target = ::google::protobuf::internal::WireFormatLite::
+      WriteMessageNoVirtualToArray(
+        1, *this->header_, target);
+  }
+
+  if (_internal_metadata_.have_unknown_fields()) {
+    target = ::google::protobuf::internal::WireFormat::SerializeUnknownFieldsToArray(
+        unknown_fields(), target);
+  }
+  // @@protoc_insertion_point(serialize_to_array_end:cockroach.roachpb.BeginTransactionRequest)
+  return target;
+}
+
+int BeginTransactionRequest::ByteSize() const {
+  int total_size = 0;
+
+  // optional .cockroach.roachpb.Span header = 1;
+  if (has_header()) {
+    total_size += 1 +
+      ::google::protobuf::internal::WireFormatLite::MessageSizeNoVirtual(
+        *this->header_);
+  }
+
+  if (_internal_metadata_.have_unknown_fields()) {
+    total_size +=
+      ::google::protobuf::internal::WireFormat::ComputeUnknownFieldsSize(
+        unknown_fields());
+  }
+  GOOGLE_SAFE_CONCURRENT_WRITES_BEGIN();
+  _cached_size_ = total_size;
+  GOOGLE_SAFE_CONCURRENT_WRITES_END();
+  return total_size;
+}
+
+void BeginTransactionRequest::MergeFrom(const ::google::protobuf::Message& from) {
+  if (GOOGLE_PREDICT_FALSE(&from == this)) MergeFromFail(__LINE__);
+  const BeginTransactionRequest* source = 
+      ::google::protobuf::internal::DynamicCastToGenerated<const BeginTransactionRequest>(
+          &from);
+  if (source == NULL) {
+    ::google::protobuf::internal::ReflectionOps::Merge(from, this);
+  } else {
+    MergeFrom(*source);
+  }
+}
+
+void BeginTransactionRequest::MergeFrom(const BeginTransactionRequest& from) {
+  if (GOOGLE_PREDICT_FALSE(&from == this)) MergeFromFail(__LINE__);
+  if (from._has_bits_[0 / 32] & (0xffu << (0 % 32))) {
+    if (from.has_header()) {
+      mutable_header()->::cockroach::roachpb::Span::MergeFrom(from.header());
+    }
+  }
+  if (from._internal_metadata_.have_unknown_fields()) {
+    mutable_unknown_fields()->MergeFrom(from.unknown_fields());
+  }
+}
+
+void BeginTransactionRequest::CopyFrom(const ::google::protobuf::Message& from) {
+  if (&from == this) return;
+  Clear();
+  MergeFrom(from);
+}
+
+void BeginTransactionRequest::CopyFrom(const BeginTransactionRequest& from) {
+  if (&from == this) return;
+  Clear();
+  MergeFrom(from);
+}
+
+bool BeginTransactionRequest::IsInitialized() const {
+
+  return true;
+}
+
+void BeginTransactionRequest::Swap(BeginTransactionRequest* other) {
+  if (other == this) return;
+  InternalSwap(other);
+}
+void BeginTransactionRequest::InternalSwap(BeginTransactionRequest* other) {
+  std::swap(header_, other->header_);
+  std::swap(_has_bits_[0], other->_has_bits_[0]);
+  _internal_metadata_.Swap(&other->_internal_metadata_);
+  std::swap(_cached_size_, other->_cached_size_);
+}
+
+::google::protobuf::Metadata BeginTransactionRequest::GetMetadata() const {
+  protobuf_AssignDescriptorsOnce();
+  ::google::protobuf::Metadata metadata;
+  metadata.descriptor = BeginTransactionRequest_descriptor_;
+  metadata.reflection = BeginTransactionRequest_reflection_;
+  return metadata;
+}
+
+#if PROTOBUF_INLINE_NOT_IN_HEADERS
+// BeginTransactionRequest
+
+// optional .cockroach.roachpb.Span header = 1;
+bool BeginTransactionRequest::has_header() const {
+  return (_has_bits_[0] & 0x00000001u) != 0;
+}
+void BeginTransactionRequest::set_has_header() {
+  _has_bits_[0] |= 0x00000001u;
+}
+void BeginTransactionRequest::clear_has_header() {
+  _has_bits_[0] &= ~0x00000001u;
+}
+void BeginTransactionRequest::clear_header() {
+  if (header_ != NULL) header_->::cockroach::roachpb::Span::Clear();
+  clear_has_header();
+}
+ const ::cockroach::roachpb::Span& BeginTransactionRequest::header() const {
+  // @@protoc_insertion_point(field_get:cockroach.roachpb.BeginTransactionRequest.header)
+  return header_ != NULL ? *header_ : *default_instance_->header_;
+}
+ ::cockroach::roachpb::Span* BeginTransactionRequest::mutable_header() {
+  set_has_header();
+  if (header_ == NULL) {
+    header_ = new ::cockroach::roachpb::Span;
+  }
+  // @@protoc_insertion_point(field_mutable:cockroach.roachpb.BeginTransactionRequest.header)
+  return header_;
+}
+ ::cockroach::roachpb::Span* BeginTransactionRequest::release_header() {
+  clear_has_header();
+  ::cockroach::roachpb::Span* temp = header_;
+  header_ = NULL;
+  return temp;
+}
+ void BeginTransactionRequest::set_allocated_header(::cockroach::roachpb::Span* header) {
+  delete header_;
+  header_ = header;
+  if (header) {
+    set_has_header();
+  } else {
+    clear_has_header();
+  }
+  // @@protoc_insertion_point(field_set_allocated:cockroach.roachpb.BeginTransactionRequest.header)
+}
+
+#endif  // PROTOBUF_INLINE_NOT_IN_HEADERS
+
+// ===================================================================
+
+#ifndef _MSC_VER
+const int BeginTransactionResponse::kHeaderFieldNumber;
+#endif  // !_MSC_VER
+
+BeginTransactionResponse::BeginTransactionResponse()
+  : ::google::protobuf::Message(), _internal_metadata_(NULL) {
+  SharedCtor();
+  // @@protoc_insertion_point(constructor:cockroach.roachpb.BeginTransactionResponse)
+}
+
+void BeginTransactionResponse::InitAsDefaultInstance() {
+  header_ = const_cast< ::cockroach::roachpb::ResponseHeader*>(&::cockroach::roachpb::ResponseHeader::default_instance());
+}
+
+BeginTransactionResponse::BeginTransactionResponse(const BeginTransactionResponse& from)
+  : ::google::protobuf::Message(),
+    _internal_metadata_(NULL) {
+  SharedCtor();
+  MergeFrom(from);
+  // @@protoc_insertion_point(copy_constructor:cockroach.roachpb.BeginTransactionResponse)
+}
+
+void BeginTransactionResponse::SharedCtor() {
+  _cached_size_ = 0;
+  header_ = NULL;
+  ::memset(_has_bits_, 0, sizeof(_has_bits_));
+}
+
+BeginTransactionResponse::~BeginTransactionResponse() {
+  // @@protoc_insertion_point(destructor:cockroach.roachpb.BeginTransactionResponse)
+  SharedDtor();
+}
+
+void BeginTransactionResponse::SharedDtor() {
+  if (this != default_instance_) {
+    delete header_;
+  }
+}
+
+void BeginTransactionResponse::SetCachedSize(int size) const {
+  GOOGLE_SAFE_CONCURRENT_WRITES_BEGIN();
+  _cached_size_ = size;
+  GOOGLE_SAFE_CONCURRENT_WRITES_END();
+}
+const ::google::protobuf::Descriptor* BeginTransactionResponse::descriptor() {
+  protobuf_AssignDescriptorsOnce();
+  return BeginTransactionResponse_descriptor_;
+}
+
+const BeginTransactionResponse& BeginTransactionResponse::default_instance() {
+  if (default_instance_ == NULL) protobuf_AddDesc_cockroach_2froachpb_2fapi_2eproto();
+  return *default_instance_;
+}
+
+BeginTransactionResponse* BeginTransactionResponse::default_instance_ = NULL;
+
+BeginTransactionResponse* BeginTransactionResponse::New(::google::protobuf::Arena* arena) const {
+  BeginTransactionResponse* n = new BeginTransactionResponse;
+  if (arena != NULL) {
+    arena->Own(n);
+  }
+  return n;
+}
+
+void BeginTransactionResponse::Clear() {
+  if (has_header()) {
+    if (header_ != NULL) header_->::cockroach::roachpb::ResponseHeader::Clear();
+  }
+  ::memset(_has_bits_, 0, sizeof(_has_bits_));
+  if (_internal_metadata_.have_unknown_fields()) {
+    mutable_unknown_fields()->Clear();
+  }
+}
+
+bool BeginTransactionResponse::MergePartialFromCodedStream(
+    ::google::protobuf::io::CodedInputStream* input) {
+#define DO_(EXPRESSION) if (!(EXPRESSION)) goto failure
+  ::google::protobuf::uint32 tag;
+  // @@protoc_insertion_point(parse_start:cockroach.roachpb.BeginTransactionResponse)
+  for (;;) {
+    ::std::pair< ::google::protobuf::uint32, bool> p = input->ReadTagWithCutoff(127);
+    tag = p.first;
+    if (!p.second) goto handle_unusual;
+    switch (::google::protobuf::internal::WireFormatLite::GetTagFieldNumber(tag)) {
+      // optional .cockroach.roachpb.ResponseHeader header = 1;
+      case 1: {
+        if (tag == 10) {
+          DO_(::google::protobuf::internal::WireFormatLite::ReadMessageNoVirtual(
+               input, mutable_header()));
+        } else {
+          goto handle_unusual;
+        }
+        if (input->ExpectAtEnd()) goto success;
+        break;
+      }
+
+      default: {
+      handle_unusual:
+        if (tag == 0 ||
+            ::google::protobuf::internal::WireFormatLite::GetTagWireType(tag) ==
+            ::google::protobuf::internal::WireFormatLite::WIRETYPE_END_GROUP) {
+          goto success;
+        }
+        DO_(::google::protobuf::internal::WireFormat::SkipField(
+              input, tag, mutable_unknown_fields()));
+        break;
+      }
+    }
+  }
+success:
+  // @@protoc_insertion_point(parse_success:cockroach.roachpb.BeginTransactionResponse)
+  return true;
+failure:
+  // @@protoc_insertion_point(parse_failure:cockroach.roachpb.BeginTransactionResponse)
+  return false;
+#undef DO_
+}
+
+void BeginTransactionResponse::SerializeWithCachedSizes(
+    ::google::protobuf::io::CodedOutputStream* output) const {
+  // @@protoc_insertion_point(serialize_start:cockroach.roachpb.BeginTransactionResponse)
+  // optional .cockroach.roachpb.ResponseHeader header = 1;
+  if (has_header()) {
+    ::google::protobuf::internal::WireFormatLite::WriteMessageMaybeToArray(
+      1, *this->header_, output);
+  }
+
+  if (_internal_metadata_.have_unknown_fields()) {
+    ::google::protobuf::internal::WireFormat::SerializeUnknownFields(
+        unknown_fields(), output);
+  }
+  // @@protoc_insertion_point(serialize_end:cockroach.roachpb.BeginTransactionResponse)
+}
+
+::google::protobuf::uint8* BeginTransactionResponse::SerializeWithCachedSizesToArray(
+    ::google::protobuf::uint8* target) const {
+  // @@protoc_insertion_point(serialize_to_array_start:cockroach.roachpb.BeginTransactionResponse)
+  // optional .cockroach.roachpb.ResponseHeader header = 1;
+  if (has_header()) {
+    target = ::google::protobuf::internal::WireFormatLite::
+      WriteMessageNoVirtualToArray(
+        1, *this->header_, target);
+  }
+
+  if (_internal_metadata_.have_unknown_fields()) {
+    target = ::google::protobuf::internal::WireFormat::SerializeUnknownFieldsToArray(
+        unknown_fields(), target);
+  }
+  // @@protoc_insertion_point(serialize_to_array_end:cockroach.roachpb.BeginTransactionResponse)
+  return target;
+}
+
+int BeginTransactionResponse::ByteSize() const {
+  int total_size = 0;
+
+  // optional .cockroach.roachpb.ResponseHeader header = 1;
+  if (has_header()) {
+    total_size += 1 +
+      ::google::protobuf::internal::WireFormatLite::MessageSizeNoVirtual(
+        *this->header_);
+  }
+
+  if (_internal_metadata_.have_unknown_fields()) {
+    total_size +=
+      ::google::protobuf::internal::WireFormat::ComputeUnknownFieldsSize(
+        unknown_fields());
+  }
+  GOOGLE_SAFE_CONCURRENT_WRITES_BEGIN();
+  _cached_size_ = total_size;
+  GOOGLE_SAFE_CONCURRENT_WRITES_END();
+  return total_size;
+}
+
+void BeginTransactionResponse::MergeFrom(const ::google::protobuf::Message& from) {
+  if (GOOGLE_PREDICT_FALSE(&from == this)) MergeFromFail(__LINE__);
+  const BeginTransactionResponse* source = 
+      ::google::protobuf::internal::DynamicCastToGenerated<const BeginTransactionResponse>(
+          &from);
+  if (source == NULL) {
+    ::google::protobuf::internal::ReflectionOps::Merge(from, this);
+  } else {
+    MergeFrom(*source);
+  }
+}
+
+void BeginTransactionResponse::MergeFrom(const BeginTransactionResponse& from) {
+  if (GOOGLE_PREDICT_FALSE(&from == this)) MergeFromFail(__LINE__);
+  if (from._has_bits_[0 / 32] & (0xffu << (0 % 32))) {
+    if (from.has_header()) {
+      mutable_header()->::cockroach::roachpb::ResponseHeader::MergeFrom(from.header());
+    }
+  }
+  if (from._internal_metadata_.have_unknown_fields()) {
+    mutable_unknown_fields()->MergeFrom(from.unknown_fields());
+  }
+}
+
+void BeginTransactionResponse::CopyFrom(const ::google::protobuf::Message& from) {
+  if (&from == this) return;
+  Clear();
+  MergeFrom(from);
+}
+
+void BeginTransactionResponse::CopyFrom(const BeginTransactionResponse& from) {
+  if (&from == this) return;
+  Clear();
+  MergeFrom(from);
+}
+
+bool BeginTransactionResponse::IsInitialized() const {
+
+  return true;
+}
+
+void BeginTransactionResponse::Swap(BeginTransactionResponse* other) {
+  if (other == this) return;
+  InternalSwap(other);
+}
+void BeginTransactionResponse::InternalSwap(BeginTransactionResponse* other) {
+  std::swap(header_, other->header_);
+  std::swap(_has_bits_[0], other->_has_bits_[0]);
+  _internal_metadata_.Swap(&other->_internal_metadata_);
+  std::swap(_cached_size_, other->_cached_size_);
+}
+
+::google::protobuf::Metadata BeginTransactionResponse::GetMetadata() const {
+  protobuf_AssignDescriptorsOnce();
+  ::google::protobuf::Metadata metadata;
+  metadata.descriptor = BeginTransactionResponse_descriptor_;
+  metadata.reflection = BeginTransactionResponse_reflection_;
+  return metadata;
+}
+
+#if PROTOBUF_INLINE_NOT_IN_HEADERS
+// BeginTransactionResponse
+
+// optional .cockroach.roachpb.ResponseHeader header = 1;
+bool BeginTransactionResponse::has_header() const {
+  return (_has_bits_[0] & 0x00000001u) != 0;
+}
+void BeginTransactionResponse::set_has_header() {
+  _has_bits_[0] |= 0x00000001u;
+}
+void BeginTransactionResponse::clear_has_header() {
+  _has_bits_[0] &= ~0x00000001u;
+}
+void BeginTransactionResponse::clear_header() {
+  if (header_ != NULL) header_->::cockroach::roachpb::ResponseHeader::Clear();
+  clear_has_header();
+}
+ const ::cockroach::roachpb::ResponseHeader& BeginTransactionResponse::header() const {
+  // @@protoc_insertion_point(field_get:cockroach.roachpb.BeginTransactionResponse.header)
+  return header_ != NULL ? *header_ : *default_instance_->header_;
+}
+ ::cockroach::roachpb::ResponseHeader* BeginTransactionResponse::mutable_header() {
+  set_has_header();
+  if (header_ == NULL) {
+    header_ = new ::cockroach::roachpb::ResponseHeader;
+  }
+  // @@protoc_insertion_point(field_mutable:cockroach.roachpb.BeginTransactionResponse.header)
+  return header_;
+}
+ ::cockroach::roachpb::ResponseHeader* BeginTransactionResponse::release_header() {
+  clear_has_header();
+  ::cockroach::roachpb::ResponseHeader* temp = header_;
+  header_ = NULL;
+  return temp;
+}
+ void BeginTransactionResponse::set_allocated_header(::cockroach::roachpb::ResponseHeader* header) {
+  delete header_;
+  header_ = header;
+  if (header) {
+    set_has_header();
+  } else {
+    clear_has_header();
+  }
+  // @@protoc_insertion_point(field_set_allocated:cockroach.roachpb.BeginTransactionResponse.header)
 }
 
 #endif  // PROTOBUF_INLINE_NOT_IN_HEADERS
@@ -17825,6 +18448,7 @@ const int RequestUnion::kIncrementFieldNumber;
 const int RequestUnion::kDeleteFieldNumber;
 const int RequestUnion::kDeleteRangeFieldNumber;
 const int RequestUnion::kScanFieldNumber;
+const int RequestUnion::kBeginTransactionFieldNumber;
 const int RequestUnion::kEndTransactionFieldNumber;
 const int RequestUnion::kAdminSplitFieldNumber;
 const int RequestUnion::kAdminMergeFieldNumber;
@@ -17855,6 +18479,7 @@ void RequestUnion::InitAsDefaultInstance() {
   delete__ = const_cast< ::cockroach::roachpb::DeleteRequest*>(&::cockroach::roachpb::DeleteRequest::default_instance());
   delete_range_ = const_cast< ::cockroach::roachpb::DeleteRangeRequest*>(&::cockroach::roachpb::DeleteRangeRequest::default_instance());
   scan_ = const_cast< ::cockroach::roachpb::ScanRequest*>(&::cockroach::roachpb::ScanRequest::default_instance());
+  begin_transaction_ = const_cast< ::cockroach::roachpb::BeginTransactionRequest*>(&::cockroach::roachpb::BeginTransactionRequest::default_instance());
   end_transaction_ = const_cast< ::cockroach::roachpb::EndTransactionRequest*>(&::cockroach::roachpb::EndTransactionRequest::default_instance());
   admin_split_ = const_cast< ::cockroach::roachpb::AdminSplitRequest*>(&::cockroach::roachpb::AdminSplitRequest::default_instance());
   admin_merge_ = const_cast< ::cockroach::roachpb::AdminMergeRequest*>(&::cockroach::roachpb::AdminMergeRequest::default_instance());
@@ -17888,6 +18513,7 @@ void RequestUnion::SharedCtor() {
   delete__ = NULL;
   delete_range_ = NULL;
   scan_ = NULL;
+  begin_transaction_ = NULL;
   end_transaction_ = NULL;
   admin_split_ = NULL;
   admin_merge_ = NULL;
@@ -17919,6 +18545,7 @@ void RequestUnion::SharedDtor() {
     delete delete__;
     delete delete_range_;
     delete scan_;
+    delete begin_transaction_;
     delete end_transaction_;
     delete admin_split_;
     delete admin_merge_;
@@ -17984,11 +18611,14 @@ void RequestUnion::Clear() {
     if (has_scan()) {
       if (scan_ != NULL) scan_->::cockroach::roachpb::ScanRequest::Clear();
     }
-    if (has_end_transaction()) {
-      if (end_transaction_ != NULL) end_transaction_->::cockroach::roachpb::EndTransactionRequest::Clear();
+    if (has_begin_transaction()) {
+      if (begin_transaction_ != NULL) begin_transaction_->::cockroach::roachpb::BeginTransactionRequest::Clear();
     }
   }
   if (_has_bits_[8 / 32] & 65280u) {
+    if (has_end_transaction()) {
+      if (end_transaction_ != NULL) end_transaction_->::cockroach::roachpb::EndTransactionRequest::Clear();
+    }
     if (has_admin_split()) {
       if (admin_split_ != NULL) admin_split_->::cockroach::roachpb::AdminSplitRequest::Clear();
     }
@@ -18010,11 +18640,11 @@ void RequestUnion::Clear() {
     if (has_resolve_intent()) {
       if (resolve_intent_ != NULL) resolve_intent_->::cockroach::roachpb::ResolveIntentRequest::Clear();
     }
+  }
+  if (_has_bits_[16 / 32] & 4128768u) {
     if (has_resolve_intent_range()) {
       if (resolve_intent_range_ != NULL) resolve_intent_range_->::cockroach::roachpb::ResolveIntentRangeRequest::Clear();
     }
-  }
-  if (_has_bits_[16 / 32] & 2031616u) {
     if (has_merge()) {
       if (merge_ != NULL) merge_->::cockroach::roachpb::MergeRequest::Clear();
     }
@@ -18133,182 +18763,195 @@ bool RequestUnion::MergePartialFromCodedStream(
         } else {
           goto handle_unusual;
         }
-        if (input->ExpectTag(66)) goto parse_end_transaction;
+        if (input->ExpectTag(66)) goto parse_begin_transaction;
         break;
       }
 
-      // optional .cockroach.roachpb.EndTransactionRequest end_transaction = 8;
+      // optional .cockroach.roachpb.BeginTransactionRequest begin_transaction = 8;
       case 8: {
         if (tag == 66) {
+         parse_begin_transaction:
+          DO_(::google::protobuf::internal::WireFormatLite::ReadMessageNoVirtual(
+               input, mutable_begin_transaction()));
+        } else {
+          goto handle_unusual;
+        }
+        if (input->ExpectTag(74)) goto parse_end_transaction;
+        break;
+      }
+
+      // optional .cockroach.roachpb.EndTransactionRequest end_transaction = 9;
+      case 9: {
+        if (tag == 74) {
          parse_end_transaction:
           DO_(::google::protobuf::internal::WireFormatLite::ReadMessageNoVirtual(
                input, mutable_end_transaction()));
         } else {
           goto handle_unusual;
         }
-        if (input->ExpectTag(74)) goto parse_admin_split;
+        if (input->ExpectTag(82)) goto parse_admin_split;
         break;
       }
 
-      // optional .cockroach.roachpb.AdminSplitRequest admin_split = 9;
-      case 9: {
-        if (tag == 74) {
+      // optional .cockroach.roachpb.AdminSplitRequest admin_split = 10;
+      case 10: {
+        if (tag == 82) {
          parse_admin_split:
           DO_(::google::protobuf::internal::WireFormatLite::ReadMessageNoVirtual(
                input, mutable_admin_split()));
         } else {
           goto handle_unusual;
         }
-        if (input->ExpectTag(82)) goto parse_admin_merge;
+        if (input->ExpectTag(90)) goto parse_admin_merge;
         break;
       }
 
-      // optional .cockroach.roachpb.AdminMergeRequest admin_merge = 10;
-      case 10: {
-        if (tag == 82) {
+      // optional .cockroach.roachpb.AdminMergeRequest admin_merge = 11;
+      case 11: {
+        if (tag == 90) {
          parse_admin_merge:
           DO_(::google::protobuf::internal::WireFormatLite::ReadMessageNoVirtual(
                input, mutable_admin_merge()));
         } else {
           goto handle_unusual;
         }
-        if (input->ExpectTag(90)) goto parse_heartbeat_txn;
+        if (input->ExpectTag(98)) goto parse_heartbeat_txn;
         break;
       }
 
-      // optional .cockroach.roachpb.HeartbeatTxnRequest heartbeat_txn = 11;
-      case 11: {
-        if (tag == 90) {
+      // optional .cockroach.roachpb.HeartbeatTxnRequest heartbeat_txn = 12;
+      case 12: {
+        if (tag == 98) {
          parse_heartbeat_txn:
           DO_(::google::protobuf::internal::WireFormatLite::ReadMessageNoVirtual(
                input, mutable_heartbeat_txn()));
         } else {
           goto handle_unusual;
         }
-        if (input->ExpectTag(98)) goto parse_gc;
+        if (input->ExpectTag(106)) goto parse_gc;
         break;
       }
 
-      // optional .cockroach.roachpb.GCRequest gc = 12;
-      case 12: {
-        if (tag == 98) {
+      // optional .cockroach.roachpb.GCRequest gc = 13;
+      case 13: {
+        if (tag == 106) {
          parse_gc:
           DO_(::google::protobuf::internal::WireFormatLite::ReadMessageNoVirtual(
                input, mutable_gc()));
         } else {
           goto handle_unusual;
         }
-        if (input->ExpectTag(106)) goto parse_push_txn;
+        if (input->ExpectTag(114)) goto parse_push_txn;
         break;
       }
 
-      // optional .cockroach.roachpb.PushTxnRequest push_txn = 13;
-      case 13: {
-        if (tag == 106) {
+      // optional .cockroach.roachpb.PushTxnRequest push_txn = 14;
+      case 14: {
+        if (tag == 114) {
          parse_push_txn:
           DO_(::google::protobuf::internal::WireFormatLite::ReadMessageNoVirtual(
                input, mutable_push_txn()));
         } else {
           goto handle_unusual;
         }
-        if (input->ExpectTag(114)) goto parse_range_lookup;
+        if (input->ExpectTag(122)) goto parse_range_lookup;
         break;
       }
 
-      // optional .cockroach.roachpb.RangeLookupRequest range_lookup = 14;
-      case 14: {
-        if (tag == 114) {
+      // optional .cockroach.roachpb.RangeLookupRequest range_lookup = 15;
+      case 15: {
+        if (tag == 122) {
          parse_range_lookup:
           DO_(::google::protobuf::internal::WireFormatLite::ReadMessageNoVirtual(
                input, mutable_range_lookup()));
         } else {
           goto handle_unusual;
         }
-        if (input->ExpectTag(122)) goto parse_resolve_intent;
+        if (input->ExpectTag(130)) goto parse_resolve_intent;
         break;
       }
 
-      // optional .cockroach.roachpb.ResolveIntentRequest resolve_intent = 15;
-      case 15: {
-        if (tag == 122) {
+      // optional .cockroach.roachpb.ResolveIntentRequest resolve_intent = 16;
+      case 16: {
+        if (tag == 130) {
          parse_resolve_intent:
           DO_(::google::protobuf::internal::WireFormatLite::ReadMessageNoVirtual(
                input, mutable_resolve_intent()));
         } else {
           goto handle_unusual;
         }
-        if (input->ExpectTag(130)) goto parse_resolve_intent_range;
+        if (input->ExpectTag(138)) goto parse_resolve_intent_range;
         break;
       }
 
-      // optional .cockroach.roachpb.ResolveIntentRangeRequest resolve_intent_range = 16;
-      case 16: {
-        if (tag == 130) {
+      // optional .cockroach.roachpb.ResolveIntentRangeRequest resolve_intent_range = 17;
+      case 17: {
+        if (tag == 138) {
          parse_resolve_intent_range:
           DO_(::google::protobuf::internal::WireFormatLite::ReadMessageNoVirtual(
                input, mutable_resolve_intent_range()));
         } else {
           goto handle_unusual;
         }
-        if (input->ExpectTag(138)) goto parse_merge;
+        if (input->ExpectTag(146)) goto parse_merge;
         break;
       }
 
-      // optional .cockroach.roachpb.MergeRequest merge = 17;
-      case 17: {
-        if (tag == 138) {
+      // optional .cockroach.roachpb.MergeRequest merge = 18;
+      case 18: {
+        if (tag == 146) {
          parse_merge:
           DO_(::google::protobuf::internal::WireFormatLite::ReadMessageNoVirtual(
                input, mutable_merge()));
         } else {
           goto handle_unusual;
         }
-        if (input->ExpectTag(146)) goto parse_truncate_log;
+        if (input->ExpectTag(154)) goto parse_truncate_log;
         break;
       }
 
-      // optional .cockroach.roachpb.TruncateLogRequest truncate_log = 18;
-      case 18: {
-        if (tag == 146) {
+      // optional .cockroach.roachpb.TruncateLogRequest truncate_log = 19;
+      case 19: {
+        if (tag == 154) {
          parse_truncate_log:
           DO_(::google::protobuf::internal::WireFormatLite::ReadMessageNoVirtual(
                input, mutable_truncate_log()));
         } else {
           goto handle_unusual;
         }
-        if (input->ExpectTag(154)) goto parse_leader_lease;
+        if (input->ExpectTag(162)) goto parse_leader_lease;
         break;
       }
 
-      // optional .cockroach.roachpb.LeaderLeaseRequest leader_lease = 19;
-      case 19: {
-        if (tag == 154) {
+      // optional .cockroach.roachpb.LeaderLeaseRequest leader_lease = 20;
+      case 20: {
+        if (tag == 162) {
          parse_leader_lease:
           DO_(::google::protobuf::internal::WireFormatLite::ReadMessageNoVirtual(
                input, mutable_leader_lease()));
         } else {
           goto handle_unusual;
         }
-        if (input->ExpectTag(162)) goto parse_reverse_scan;
+        if (input->ExpectTag(170)) goto parse_reverse_scan;
         break;
       }
 
-      // optional .cockroach.roachpb.ReverseScanRequest reverse_scan = 20;
-      case 20: {
-        if (tag == 162) {
+      // optional .cockroach.roachpb.ReverseScanRequest reverse_scan = 21;
+      case 21: {
+        if (tag == 170) {
          parse_reverse_scan:
           DO_(::google::protobuf::internal::WireFormatLite::ReadMessageNoVirtual(
                input, mutable_reverse_scan()));
         } else {
           goto handle_unusual;
         }
-        if (input->ExpectTag(170)) goto parse_noop;
+        if (input->ExpectTag(178)) goto parse_noop;
         break;
       }
 
-      // optional .cockroach.roachpb.NoopRequest noop = 21;
-      case 21: {
-        if (tag == 170) {
+      // optional .cockroach.roachpb.NoopRequest noop = 22;
+      case 22: {
+        if (tag == 178) {
          parse_noop:
           DO_(::google::protobuf::internal::WireFormatLite::ReadMessageNoVirtual(
                input, mutable_noop()));
@@ -18386,88 +19029,94 @@ void RequestUnion::SerializeWithCachedSizes(
       7, *this->scan_, output);
   }
 
-  // optional .cockroach.roachpb.EndTransactionRequest end_transaction = 8;
+  // optional .cockroach.roachpb.BeginTransactionRequest begin_transaction = 8;
+  if (has_begin_transaction()) {
+    ::google::protobuf::internal::WireFormatLite::WriteMessageMaybeToArray(
+      8, *this->begin_transaction_, output);
+  }
+
+  // optional .cockroach.roachpb.EndTransactionRequest end_transaction = 9;
   if (has_end_transaction()) {
     ::google::protobuf::internal::WireFormatLite::WriteMessageMaybeToArray(
-      8, *this->end_transaction_, output);
+      9, *this->end_transaction_, output);
   }
 
-  // optional .cockroach.roachpb.AdminSplitRequest admin_split = 9;
+  // optional .cockroach.roachpb.AdminSplitRequest admin_split = 10;
   if (has_admin_split()) {
     ::google::protobuf::internal::WireFormatLite::WriteMessageMaybeToArray(
-      9, *this->admin_split_, output);
+      10, *this->admin_split_, output);
   }
 
-  // optional .cockroach.roachpb.AdminMergeRequest admin_merge = 10;
+  // optional .cockroach.roachpb.AdminMergeRequest admin_merge = 11;
   if (has_admin_merge()) {
     ::google::protobuf::internal::WireFormatLite::WriteMessageMaybeToArray(
-      10, *this->admin_merge_, output);
+      11, *this->admin_merge_, output);
   }
 
-  // optional .cockroach.roachpb.HeartbeatTxnRequest heartbeat_txn = 11;
+  // optional .cockroach.roachpb.HeartbeatTxnRequest heartbeat_txn = 12;
   if (has_heartbeat_txn()) {
     ::google::protobuf::internal::WireFormatLite::WriteMessageMaybeToArray(
-      11, *this->heartbeat_txn_, output);
+      12, *this->heartbeat_txn_, output);
   }
 
-  // optional .cockroach.roachpb.GCRequest gc = 12;
+  // optional .cockroach.roachpb.GCRequest gc = 13;
   if (has_gc()) {
     ::google::protobuf::internal::WireFormatLite::WriteMessageMaybeToArray(
-      12, *this->gc_, output);
+      13, *this->gc_, output);
   }
 
-  // optional .cockroach.roachpb.PushTxnRequest push_txn = 13;
+  // optional .cockroach.roachpb.PushTxnRequest push_txn = 14;
   if (has_push_txn()) {
     ::google::protobuf::internal::WireFormatLite::WriteMessageMaybeToArray(
-      13, *this->push_txn_, output);
+      14, *this->push_txn_, output);
   }
 
-  // optional .cockroach.roachpb.RangeLookupRequest range_lookup = 14;
+  // optional .cockroach.roachpb.RangeLookupRequest range_lookup = 15;
   if (has_range_lookup()) {
     ::google::protobuf::internal::WireFormatLite::WriteMessageMaybeToArray(
-      14, *this->range_lookup_, output);
+      15, *this->range_lookup_, output);
   }
 
-  // optional .cockroach.roachpb.ResolveIntentRequest resolve_intent = 15;
+  // optional .cockroach.roachpb.ResolveIntentRequest resolve_intent = 16;
   if (has_resolve_intent()) {
     ::google::protobuf::internal::WireFormatLite::WriteMessageMaybeToArray(
-      15, *this->resolve_intent_, output);
+      16, *this->resolve_intent_, output);
   }
 
-  // optional .cockroach.roachpb.ResolveIntentRangeRequest resolve_intent_range = 16;
+  // optional .cockroach.roachpb.ResolveIntentRangeRequest resolve_intent_range = 17;
   if (has_resolve_intent_range()) {
     ::google::protobuf::internal::WireFormatLite::WriteMessageMaybeToArray(
-      16, *this->resolve_intent_range_, output);
+      17, *this->resolve_intent_range_, output);
   }
 
-  // optional .cockroach.roachpb.MergeRequest merge = 17;
+  // optional .cockroach.roachpb.MergeRequest merge = 18;
   if (has_merge()) {
     ::google::protobuf::internal::WireFormatLite::WriteMessageMaybeToArray(
-      17, *this->merge_, output);
+      18, *this->merge_, output);
   }
 
-  // optional .cockroach.roachpb.TruncateLogRequest truncate_log = 18;
+  // optional .cockroach.roachpb.TruncateLogRequest truncate_log = 19;
   if (has_truncate_log()) {
     ::google::protobuf::internal::WireFormatLite::WriteMessageMaybeToArray(
-      18, *this->truncate_log_, output);
+      19, *this->truncate_log_, output);
   }
 
-  // optional .cockroach.roachpb.LeaderLeaseRequest leader_lease = 19;
+  // optional .cockroach.roachpb.LeaderLeaseRequest leader_lease = 20;
   if (has_leader_lease()) {
     ::google::protobuf::internal::WireFormatLite::WriteMessageMaybeToArray(
-      19, *this->leader_lease_, output);
+      20, *this->leader_lease_, output);
   }
 
-  // optional .cockroach.roachpb.ReverseScanRequest reverse_scan = 20;
+  // optional .cockroach.roachpb.ReverseScanRequest reverse_scan = 21;
   if (has_reverse_scan()) {
     ::google::protobuf::internal::WireFormatLite::WriteMessageMaybeToArray(
-      20, *this->reverse_scan_, output);
+      21, *this->reverse_scan_, output);
   }
 
-  // optional .cockroach.roachpb.NoopRequest noop = 21;
+  // optional .cockroach.roachpb.NoopRequest noop = 22;
   if (has_noop()) {
     ::google::protobuf::internal::WireFormatLite::WriteMessageMaybeToArray(
-      21, *this->noop_, output);
+      22, *this->noop_, output);
   }
 
   if (_internal_metadata_.have_unknown_fields()) {
@@ -18529,102 +19178,109 @@ void RequestUnion::SerializeWithCachedSizes(
         7, *this->scan_, target);
   }
 
-  // optional .cockroach.roachpb.EndTransactionRequest end_transaction = 8;
+  // optional .cockroach.roachpb.BeginTransactionRequest begin_transaction = 8;
+  if (has_begin_transaction()) {
+    target = ::google::protobuf::internal::WireFormatLite::
+      WriteMessageNoVirtualToArray(
+        8, *this->begin_transaction_, target);
+  }
+
+  // optional .cockroach.roachpb.EndTransactionRequest end_transaction = 9;
   if (has_end_transaction()) {
     target = ::google::protobuf::internal::WireFormatLite::
       WriteMessageNoVirtualToArray(
-        8, *this->end_transaction_, target);
+        9, *this->end_transaction_, target);
   }
 
-  // optional .cockroach.roachpb.AdminSplitRequest admin_split = 9;
+  // optional .cockroach.roachpb.AdminSplitRequest admin_split = 10;
   if (has_admin_split()) {
     target = ::google::protobuf::internal::WireFormatLite::
       WriteMessageNoVirtualToArray(
-        9, *this->admin_split_, target);
+        10, *this->admin_split_, target);
   }
 
-  // optional .cockroach.roachpb.AdminMergeRequest admin_merge = 10;
+  // optional .cockroach.roachpb.AdminMergeRequest admin_merge = 11;
   if (has_admin_merge()) {
     target = ::google::protobuf::internal::WireFormatLite::
       WriteMessageNoVirtualToArray(
-        10, *this->admin_merge_, target);
+        11, *this->admin_merge_, target);
   }
 
-  // optional .cockroach.roachpb.HeartbeatTxnRequest heartbeat_txn = 11;
+  // optional .cockroach.roachpb.HeartbeatTxnRequest heartbeat_txn = 12;
   if (has_heartbeat_txn()) {
     target = ::google::protobuf::internal::WireFormatLite::
       WriteMessageNoVirtualToArray(
-        11, *this->heartbeat_txn_, target);
+        12, *this->heartbeat_txn_, target);
   }
 
-  // optional .cockroach.roachpb.GCRequest gc = 12;
+  // optional .cockroach.roachpb.GCRequest gc = 13;
   if (has_gc()) {
     target = ::google::protobuf::internal::WireFormatLite::
       WriteMessageNoVirtualToArray(
-        12, *this->gc_, target);
+        13, *this->gc_, target);
   }
 
-  // optional .cockroach.roachpb.PushTxnRequest push_txn = 13;
+  // optional .cockroach.roachpb.PushTxnRequest push_txn = 14;
   if (has_push_txn()) {
     target = ::google::protobuf::internal::WireFormatLite::
       WriteMessageNoVirtualToArray(
-        13, *this->push_txn_, target);
+        14, *this->push_txn_, target);
   }
 
-  // optional .cockroach.roachpb.RangeLookupRequest range_lookup = 14;
+  // optional .cockroach.roachpb.RangeLookupRequest range_lookup = 15;
   if (has_range_lookup()) {
     target = ::google::protobuf::internal::WireFormatLite::
       WriteMessageNoVirtualToArray(
-        14, *this->range_lookup_, target);
+        15, *this->range_lookup_, target);
   }
 
-  // optional .cockroach.roachpb.ResolveIntentRequest resolve_intent = 15;
+  // optional .cockroach.roachpb.ResolveIntentRequest resolve_intent = 16;
   if (has_resolve_intent()) {
     target = ::google::protobuf::internal::WireFormatLite::
       WriteMessageNoVirtualToArray(
-        15, *this->resolve_intent_, target);
+        16, *this->resolve_intent_, target);
   }
 
-  // optional .cockroach.roachpb.ResolveIntentRangeRequest resolve_intent_range = 16;
+  // optional .cockroach.roachpb.ResolveIntentRangeRequest resolve_intent_range = 17;
   if (has_resolve_intent_range()) {
     target = ::google::protobuf::internal::WireFormatLite::
       WriteMessageNoVirtualToArray(
-        16, *this->resolve_intent_range_, target);
+        17, *this->resolve_intent_range_, target);
   }
 
-  // optional .cockroach.roachpb.MergeRequest merge = 17;
+  // optional .cockroach.roachpb.MergeRequest merge = 18;
   if (has_merge()) {
     target = ::google::protobuf::internal::WireFormatLite::
       WriteMessageNoVirtualToArray(
-        17, *this->merge_, target);
+        18, *this->merge_, target);
   }
 
-  // optional .cockroach.roachpb.TruncateLogRequest truncate_log = 18;
+  // optional .cockroach.roachpb.TruncateLogRequest truncate_log = 19;
   if (has_truncate_log()) {
     target = ::google::protobuf::internal::WireFormatLite::
       WriteMessageNoVirtualToArray(
-        18, *this->truncate_log_, target);
+        19, *this->truncate_log_, target);
   }
 
-  // optional .cockroach.roachpb.LeaderLeaseRequest leader_lease = 19;
+  // optional .cockroach.roachpb.LeaderLeaseRequest leader_lease = 20;
   if (has_leader_lease()) {
     target = ::google::protobuf::internal::WireFormatLite::
       WriteMessageNoVirtualToArray(
-        19, *this->leader_lease_, target);
+        20, *this->leader_lease_, target);
   }
 
-  // optional .cockroach.roachpb.ReverseScanRequest reverse_scan = 20;
+  // optional .cockroach.roachpb.ReverseScanRequest reverse_scan = 21;
   if (has_reverse_scan()) {
     target = ::google::protobuf::internal::WireFormatLite::
       WriteMessageNoVirtualToArray(
-        20, *this->reverse_scan_, target);
+        21, *this->reverse_scan_, target);
   }
 
-  // optional .cockroach.roachpb.NoopRequest noop = 21;
+  // optional .cockroach.roachpb.NoopRequest noop = 22;
   if (has_noop()) {
     target = ::google::protobuf::internal::WireFormatLite::
       WriteMessageNoVirtualToArray(
-        21, *this->noop_, target);
+        22, *this->noop_, target);
   }
 
   if (_internal_metadata_.have_unknown_fields()) {
@@ -18688,102 +19344,109 @@ int RequestUnion::ByteSize() const {
           *this->scan_);
     }
 
-    // optional .cockroach.roachpb.EndTransactionRequest end_transaction = 8;
+    // optional .cockroach.roachpb.BeginTransactionRequest begin_transaction = 8;
+    if (has_begin_transaction()) {
+      total_size += 1 +
+        ::google::protobuf::internal::WireFormatLite::MessageSizeNoVirtual(
+          *this->begin_transaction_);
+    }
+
+  }
+  if (_has_bits_[8 / 32] & 65280) {
+    // optional .cockroach.roachpb.EndTransactionRequest end_transaction = 9;
     if (has_end_transaction()) {
       total_size += 1 +
         ::google::protobuf::internal::WireFormatLite::MessageSizeNoVirtual(
           *this->end_transaction_);
     }
 
-  }
-  if (_has_bits_[8 / 32] & 65280) {
-    // optional .cockroach.roachpb.AdminSplitRequest admin_split = 9;
+    // optional .cockroach.roachpb.AdminSplitRequest admin_split = 10;
     if (has_admin_split()) {
       total_size += 1 +
         ::google::protobuf::internal::WireFormatLite::MessageSizeNoVirtual(
           *this->admin_split_);
     }
 
-    // optional .cockroach.roachpb.AdminMergeRequest admin_merge = 10;
+    // optional .cockroach.roachpb.AdminMergeRequest admin_merge = 11;
     if (has_admin_merge()) {
       total_size += 1 +
         ::google::protobuf::internal::WireFormatLite::MessageSizeNoVirtual(
           *this->admin_merge_);
     }
 
-    // optional .cockroach.roachpb.HeartbeatTxnRequest heartbeat_txn = 11;
+    // optional .cockroach.roachpb.HeartbeatTxnRequest heartbeat_txn = 12;
     if (has_heartbeat_txn()) {
       total_size += 1 +
         ::google::protobuf::internal::WireFormatLite::MessageSizeNoVirtual(
           *this->heartbeat_txn_);
     }
 
-    // optional .cockroach.roachpb.GCRequest gc = 12;
+    // optional .cockroach.roachpb.GCRequest gc = 13;
     if (has_gc()) {
       total_size += 1 +
         ::google::protobuf::internal::WireFormatLite::MessageSizeNoVirtual(
           *this->gc_);
     }
 
-    // optional .cockroach.roachpb.PushTxnRequest push_txn = 13;
+    // optional .cockroach.roachpb.PushTxnRequest push_txn = 14;
     if (has_push_txn()) {
       total_size += 1 +
         ::google::protobuf::internal::WireFormatLite::MessageSizeNoVirtual(
           *this->push_txn_);
     }
 
-    // optional .cockroach.roachpb.RangeLookupRequest range_lookup = 14;
+    // optional .cockroach.roachpb.RangeLookupRequest range_lookup = 15;
     if (has_range_lookup()) {
       total_size += 1 +
         ::google::protobuf::internal::WireFormatLite::MessageSizeNoVirtual(
           *this->range_lookup_);
     }
 
-    // optional .cockroach.roachpb.ResolveIntentRequest resolve_intent = 15;
+    // optional .cockroach.roachpb.ResolveIntentRequest resolve_intent = 16;
     if (has_resolve_intent()) {
-      total_size += 1 +
+      total_size += 2 +
         ::google::protobuf::internal::WireFormatLite::MessageSizeNoVirtual(
           *this->resolve_intent_);
     }
 
-    // optional .cockroach.roachpb.ResolveIntentRangeRequest resolve_intent_range = 16;
+  }
+  if (_has_bits_[16 / 32] & 4128768) {
+    // optional .cockroach.roachpb.ResolveIntentRangeRequest resolve_intent_range = 17;
     if (has_resolve_intent_range()) {
       total_size += 2 +
         ::google::protobuf::internal::WireFormatLite::MessageSizeNoVirtual(
           *this->resolve_intent_range_);
     }
 
-  }
-  if (_has_bits_[16 / 32] & 2031616) {
-    // optional .cockroach.roachpb.MergeRequest merge = 17;
+    // optional .cockroach.roachpb.MergeRequest merge = 18;
     if (has_merge()) {
       total_size += 2 +
         ::google::protobuf::internal::WireFormatLite::MessageSizeNoVirtual(
           *this->merge_);
     }
 
-    // optional .cockroach.roachpb.TruncateLogRequest truncate_log = 18;
+    // optional .cockroach.roachpb.TruncateLogRequest truncate_log = 19;
     if (has_truncate_log()) {
       total_size += 2 +
         ::google::protobuf::internal::WireFormatLite::MessageSizeNoVirtual(
           *this->truncate_log_);
     }
 
-    // optional .cockroach.roachpb.LeaderLeaseRequest leader_lease = 19;
+    // optional .cockroach.roachpb.LeaderLeaseRequest leader_lease = 20;
     if (has_leader_lease()) {
       total_size += 2 +
         ::google::protobuf::internal::WireFormatLite::MessageSizeNoVirtual(
           *this->leader_lease_);
     }
 
-    // optional .cockroach.roachpb.ReverseScanRequest reverse_scan = 20;
+    // optional .cockroach.roachpb.ReverseScanRequest reverse_scan = 21;
     if (has_reverse_scan()) {
       total_size += 2 +
         ::google::protobuf::internal::WireFormatLite::MessageSizeNoVirtual(
           *this->reverse_scan_);
     }
 
-    // optional .cockroach.roachpb.NoopRequest noop = 21;
+    // optional .cockroach.roachpb.NoopRequest noop = 22;
     if (has_noop()) {
       total_size += 2 +
         ::google::protobuf::internal::WireFormatLite::MessageSizeNoVirtual(
@@ -18838,11 +19501,14 @@ void RequestUnion::MergeFrom(const RequestUnion& from) {
     if (from.has_scan()) {
       mutable_scan()->::cockroach::roachpb::ScanRequest::MergeFrom(from.scan());
     }
-    if (from.has_end_transaction()) {
-      mutable_end_transaction()->::cockroach::roachpb::EndTransactionRequest::MergeFrom(from.end_transaction());
+    if (from.has_begin_transaction()) {
+      mutable_begin_transaction()->::cockroach::roachpb::BeginTransactionRequest::MergeFrom(from.begin_transaction());
     }
   }
   if (from._has_bits_[8 / 32] & (0xffu << (8 % 32))) {
+    if (from.has_end_transaction()) {
+      mutable_end_transaction()->::cockroach::roachpb::EndTransactionRequest::MergeFrom(from.end_transaction());
+    }
     if (from.has_admin_split()) {
       mutable_admin_split()->::cockroach::roachpb::AdminSplitRequest::MergeFrom(from.admin_split());
     }
@@ -18864,11 +19530,11 @@ void RequestUnion::MergeFrom(const RequestUnion& from) {
     if (from.has_resolve_intent()) {
       mutable_resolve_intent()->::cockroach::roachpb::ResolveIntentRequest::MergeFrom(from.resolve_intent());
     }
+  }
+  if (from._has_bits_[16 / 32] & (0xffu << (16 % 32))) {
     if (from.has_resolve_intent_range()) {
       mutable_resolve_intent_range()->::cockroach::roachpb::ResolveIntentRangeRequest::MergeFrom(from.resolve_intent_range());
     }
-  }
-  if (from._has_bits_[16 / 32] & (0xffu << (16 % 32))) {
     if (from.has_merge()) {
       mutable_merge()->::cockroach::roachpb::MergeRequest::MergeFrom(from.merge());
     }
@@ -18919,6 +19585,7 @@ void RequestUnion::InternalSwap(RequestUnion* other) {
   std::swap(delete__, other->delete__);
   std::swap(delete_range_, other->delete_range_);
   std::swap(scan_, other->scan_);
+  std::swap(begin_transaction_, other->begin_transaction_);
   std::swap(end_transaction_, other->end_transaction_);
   std::swap(admin_split_, other->admin_split_);
   std::swap(admin_merge_, other->admin_merge_);
@@ -19250,15 +19917,58 @@ void RequestUnion::clear_scan() {
   // @@protoc_insertion_point(field_set_allocated:cockroach.roachpb.RequestUnion.scan)
 }
 
-// optional .cockroach.roachpb.EndTransactionRequest end_transaction = 8;
-bool RequestUnion::has_end_transaction() const {
+// optional .cockroach.roachpb.BeginTransactionRequest begin_transaction = 8;
+bool RequestUnion::has_begin_transaction() const {
   return (_has_bits_[0] & 0x00000080u) != 0;
 }
-void RequestUnion::set_has_end_transaction() {
+void RequestUnion::set_has_begin_transaction() {
   _has_bits_[0] |= 0x00000080u;
 }
-void RequestUnion::clear_has_end_transaction() {
+void RequestUnion::clear_has_begin_transaction() {
   _has_bits_[0] &= ~0x00000080u;
+}
+void RequestUnion::clear_begin_transaction() {
+  if (begin_transaction_ != NULL) begin_transaction_->::cockroach::roachpb::BeginTransactionRequest::Clear();
+  clear_has_begin_transaction();
+}
+ const ::cockroach::roachpb::BeginTransactionRequest& RequestUnion::begin_transaction() const {
+  // @@protoc_insertion_point(field_get:cockroach.roachpb.RequestUnion.begin_transaction)
+  return begin_transaction_ != NULL ? *begin_transaction_ : *default_instance_->begin_transaction_;
+}
+ ::cockroach::roachpb::BeginTransactionRequest* RequestUnion::mutable_begin_transaction() {
+  set_has_begin_transaction();
+  if (begin_transaction_ == NULL) {
+    begin_transaction_ = new ::cockroach::roachpb::BeginTransactionRequest;
+  }
+  // @@protoc_insertion_point(field_mutable:cockroach.roachpb.RequestUnion.begin_transaction)
+  return begin_transaction_;
+}
+ ::cockroach::roachpb::BeginTransactionRequest* RequestUnion::release_begin_transaction() {
+  clear_has_begin_transaction();
+  ::cockroach::roachpb::BeginTransactionRequest* temp = begin_transaction_;
+  begin_transaction_ = NULL;
+  return temp;
+}
+ void RequestUnion::set_allocated_begin_transaction(::cockroach::roachpb::BeginTransactionRequest* begin_transaction) {
+  delete begin_transaction_;
+  begin_transaction_ = begin_transaction;
+  if (begin_transaction) {
+    set_has_begin_transaction();
+  } else {
+    clear_has_begin_transaction();
+  }
+  // @@protoc_insertion_point(field_set_allocated:cockroach.roachpb.RequestUnion.begin_transaction)
+}
+
+// optional .cockroach.roachpb.EndTransactionRequest end_transaction = 9;
+bool RequestUnion::has_end_transaction() const {
+  return (_has_bits_[0] & 0x00000100u) != 0;
+}
+void RequestUnion::set_has_end_transaction() {
+  _has_bits_[0] |= 0x00000100u;
+}
+void RequestUnion::clear_has_end_transaction() {
+  _has_bits_[0] &= ~0x00000100u;
 }
 void RequestUnion::clear_end_transaction() {
   if (end_transaction_ != NULL) end_transaction_->::cockroach::roachpb::EndTransactionRequest::Clear();
@@ -19293,15 +20003,15 @@ void RequestUnion::clear_end_transaction() {
   // @@protoc_insertion_point(field_set_allocated:cockroach.roachpb.RequestUnion.end_transaction)
 }
 
-// optional .cockroach.roachpb.AdminSplitRequest admin_split = 9;
+// optional .cockroach.roachpb.AdminSplitRequest admin_split = 10;
 bool RequestUnion::has_admin_split() const {
-  return (_has_bits_[0] & 0x00000100u) != 0;
+  return (_has_bits_[0] & 0x00000200u) != 0;
 }
 void RequestUnion::set_has_admin_split() {
-  _has_bits_[0] |= 0x00000100u;
+  _has_bits_[0] |= 0x00000200u;
 }
 void RequestUnion::clear_has_admin_split() {
-  _has_bits_[0] &= ~0x00000100u;
+  _has_bits_[0] &= ~0x00000200u;
 }
 void RequestUnion::clear_admin_split() {
   if (admin_split_ != NULL) admin_split_->::cockroach::roachpb::AdminSplitRequest::Clear();
@@ -19336,15 +20046,15 @@ void RequestUnion::clear_admin_split() {
   // @@protoc_insertion_point(field_set_allocated:cockroach.roachpb.RequestUnion.admin_split)
 }
 
-// optional .cockroach.roachpb.AdminMergeRequest admin_merge = 10;
+// optional .cockroach.roachpb.AdminMergeRequest admin_merge = 11;
 bool RequestUnion::has_admin_merge() const {
-  return (_has_bits_[0] & 0x00000200u) != 0;
+  return (_has_bits_[0] & 0x00000400u) != 0;
 }
 void RequestUnion::set_has_admin_merge() {
-  _has_bits_[0] |= 0x00000200u;
+  _has_bits_[0] |= 0x00000400u;
 }
 void RequestUnion::clear_has_admin_merge() {
-  _has_bits_[0] &= ~0x00000200u;
+  _has_bits_[0] &= ~0x00000400u;
 }
 void RequestUnion::clear_admin_merge() {
   if (admin_merge_ != NULL) admin_merge_->::cockroach::roachpb::AdminMergeRequest::Clear();
@@ -19379,15 +20089,15 @@ void RequestUnion::clear_admin_merge() {
   // @@protoc_insertion_point(field_set_allocated:cockroach.roachpb.RequestUnion.admin_merge)
 }
 
-// optional .cockroach.roachpb.HeartbeatTxnRequest heartbeat_txn = 11;
+// optional .cockroach.roachpb.HeartbeatTxnRequest heartbeat_txn = 12;
 bool RequestUnion::has_heartbeat_txn() const {
-  return (_has_bits_[0] & 0x00000400u) != 0;
+  return (_has_bits_[0] & 0x00000800u) != 0;
 }
 void RequestUnion::set_has_heartbeat_txn() {
-  _has_bits_[0] |= 0x00000400u;
+  _has_bits_[0] |= 0x00000800u;
 }
 void RequestUnion::clear_has_heartbeat_txn() {
-  _has_bits_[0] &= ~0x00000400u;
+  _has_bits_[0] &= ~0x00000800u;
 }
 void RequestUnion::clear_heartbeat_txn() {
   if (heartbeat_txn_ != NULL) heartbeat_txn_->::cockroach::roachpb::HeartbeatTxnRequest::Clear();
@@ -19422,15 +20132,15 @@ void RequestUnion::clear_heartbeat_txn() {
   // @@protoc_insertion_point(field_set_allocated:cockroach.roachpb.RequestUnion.heartbeat_txn)
 }
 
-// optional .cockroach.roachpb.GCRequest gc = 12;
+// optional .cockroach.roachpb.GCRequest gc = 13;
 bool RequestUnion::has_gc() const {
-  return (_has_bits_[0] & 0x00000800u) != 0;
+  return (_has_bits_[0] & 0x00001000u) != 0;
 }
 void RequestUnion::set_has_gc() {
-  _has_bits_[0] |= 0x00000800u;
+  _has_bits_[0] |= 0x00001000u;
 }
 void RequestUnion::clear_has_gc() {
-  _has_bits_[0] &= ~0x00000800u;
+  _has_bits_[0] &= ~0x00001000u;
 }
 void RequestUnion::clear_gc() {
   if (gc_ != NULL) gc_->::cockroach::roachpb::GCRequest::Clear();
@@ -19465,15 +20175,15 @@ void RequestUnion::clear_gc() {
   // @@protoc_insertion_point(field_set_allocated:cockroach.roachpb.RequestUnion.gc)
 }
 
-// optional .cockroach.roachpb.PushTxnRequest push_txn = 13;
+// optional .cockroach.roachpb.PushTxnRequest push_txn = 14;
 bool RequestUnion::has_push_txn() const {
-  return (_has_bits_[0] & 0x00001000u) != 0;
+  return (_has_bits_[0] & 0x00002000u) != 0;
 }
 void RequestUnion::set_has_push_txn() {
-  _has_bits_[0] |= 0x00001000u;
+  _has_bits_[0] |= 0x00002000u;
 }
 void RequestUnion::clear_has_push_txn() {
-  _has_bits_[0] &= ~0x00001000u;
+  _has_bits_[0] &= ~0x00002000u;
 }
 void RequestUnion::clear_push_txn() {
   if (push_txn_ != NULL) push_txn_->::cockroach::roachpb::PushTxnRequest::Clear();
@@ -19508,15 +20218,15 @@ void RequestUnion::clear_push_txn() {
   // @@protoc_insertion_point(field_set_allocated:cockroach.roachpb.RequestUnion.push_txn)
 }
 
-// optional .cockroach.roachpb.RangeLookupRequest range_lookup = 14;
+// optional .cockroach.roachpb.RangeLookupRequest range_lookup = 15;
 bool RequestUnion::has_range_lookup() const {
-  return (_has_bits_[0] & 0x00002000u) != 0;
+  return (_has_bits_[0] & 0x00004000u) != 0;
 }
 void RequestUnion::set_has_range_lookup() {
-  _has_bits_[0] |= 0x00002000u;
+  _has_bits_[0] |= 0x00004000u;
 }
 void RequestUnion::clear_has_range_lookup() {
-  _has_bits_[0] &= ~0x00002000u;
+  _has_bits_[0] &= ~0x00004000u;
 }
 void RequestUnion::clear_range_lookup() {
   if (range_lookup_ != NULL) range_lookup_->::cockroach::roachpb::RangeLookupRequest::Clear();
@@ -19551,15 +20261,15 @@ void RequestUnion::clear_range_lookup() {
   // @@protoc_insertion_point(field_set_allocated:cockroach.roachpb.RequestUnion.range_lookup)
 }
 
-// optional .cockroach.roachpb.ResolveIntentRequest resolve_intent = 15;
+// optional .cockroach.roachpb.ResolveIntentRequest resolve_intent = 16;
 bool RequestUnion::has_resolve_intent() const {
-  return (_has_bits_[0] & 0x00004000u) != 0;
+  return (_has_bits_[0] & 0x00008000u) != 0;
 }
 void RequestUnion::set_has_resolve_intent() {
-  _has_bits_[0] |= 0x00004000u;
+  _has_bits_[0] |= 0x00008000u;
 }
 void RequestUnion::clear_has_resolve_intent() {
-  _has_bits_[0] &= ~0x00004000u;
+  _has_bits_[0] &= ~0x00008000u;
 }
 void RequestUnion::clear_resolve_intent() {
   if (resolve_intent_ != NULL) resolve_intent_->::cockroach::roachpb::ResolveIntentRequest::Clear();
@@ -19594,15 +20304,15 @@ void RequestUnion::clear_resolve_intent() {
   // @@protoc_insertion_point(field_set_allocated:cockroach.roachpb.RequestUnion.resolve_intent)
 }
 
-// optional .cockroach.roachpb.ResolveIntentRangeRequest resolve_intent_range = 16;
+// optional .cockroach.roachpb.ResolveIntentRangeRequest resolve_intent_range = 17;
 bool RequestUnion::has_resolve_intent_range() const {
-  return (_has_bits_[0] & 0x00008000u) != 0;
+  return (_has_bits_[0] & 0x00010000u) != 0;
 }
 void RequestUnion::set_has_resolve_intent_range() {
-  _has_bits_[0] |= 0x00008000u;
+  _has_bits_[0] |= 0x00010000u;
 }
 void RequestUnion::clear_has_resolve_intent_range() {
-  _has_bits_[0] &= ~0x00008000u;
+  _has_bits_[0] &= ~0x00010000u;
 }
 void RequestUnion::clear_resolve_intent_range() {
   if (resolve_intent_range_ != NULL) resolve_intent_range_->::cockroach::roachpb::ResolveIntentRangeRequest::Clear();
@@ -19637,15 +20347,15 @@ void RequestUnion::clear_resolve_intent_range() {
   // @@protoc_insertion_point(field_set_allocated:cockroach.roachpb.RequestUnion.resolve_intent_range)
 }
 
-// optional .cockroach.roachpb.MergeRequest merge = 17;
+// optional .cockroach.roachpb.MergeRequest merge = 18;
 bool RequestUnion::has_merge() const {
-  return (_has_bits_[0] & 0x00010000u) != 0;
+  return (_has_bits_[0] & 0x00020000u) != 0;
 }
 void RequestUnion::set_has_merge() {
-  _has_bits_[0] |= 0x00010000u;
+  _has_bits_[0] |= 0x00020000u;
 }
 void RequestUnion::clear_has_merge() {
-  _has_bits_[0] &= ~0x00010000u;
+  _has_bits_[0] &= ~0x00020000u;
 }
 void RequestUnion::clear_merge() {
   if (merge_ != NULL) merge_->::cockroach::roachpb::MergeRequest::Clear();
@@ -19680,15 +20390,15 @@ void RequestUnion::clear_merge() {
   // @@protoc_insertion_point(field_set_allocated:cockroach.roachpb.RequestUnion.merge)
 }
 
-// optional .cockroach.roachpb.TruncateLogRequest truncate_log = 18;
+// optional .cockroach.roachpb.TruncateLogRequest truncate_log = 19;
 bool RequestUnion::has_truncate_log() const {
-  return (_has_bits_[0] & 0x00020000u) != 0;
+  return (_has_bits_[0] & 0x00040000u) != 0;
 }
 void RequestUnion::set_has_truncate_log() {
-  _has_bits_[0] |= 0x00020000u;
+  _has_bits_[0] |= 0x00040000u;
 }
 void RequestUnion::clear_has_truncate_log() {
-  _has_bits_[0] &= ~0x00020000u;
+  _has_bits_[0] &= ~0x00040000u;
 }
 void RequestUnion::clear_truncate_log() {
   if (truncate_log_ != NULL) truncate_log_->::cockroach::roachpb::TruncateLogRequest::Clear();
@@ -19723,15 +20433,15 @@ void RequestUnion::clear_truncate_log() {
   // @@protoc_insertion_point(field_set_allocated:cockroach.roachpb.RequestUnion.truncate_log)
 }
 
-// optional .cockroach.roachpb.LeaderLeaseRequest leader_lease = 19;
+// optional .cockroach.roachpb.LeaderLeaseRequest leader_lease = 20;
 bool RequestUnion::has_leader_lease() const {
-  return (_has_bits_[0] & 0x00040000u) != 0;
+  return (_has_bits_[0] & 0x00080000u) != 0;
 }
 void RequestUnion::set_has_leader_lease() {
-  _has_bits_[0] |= 0x00040000u;
+  _has_bits_[0] |= 0x00080000u;
 }
 void RequestUnion::clear_has_leader_lease() {
-  _has_bits_[0] &= ~0x00040000u;
+  _has_bits_[0] &= ~0x00080000u;
 }
 void RequestUnion::clear_leader_lease() {
   if (leader_lease_ != NULL) leader_lease_->::cockroach::roachpb::LeaderLeaseRequest::Clear();
@@ -19766,15 +20476,15 @@ void RequestUnion::clear_leader_lease() {
   // @@protoc_insertion_point(field_set_allocated:cockroach.roachpb.RequestUnion.leader_lease)
 }
 
-// optional .cockroach.roachpb.ReverseScanRequest reverse_scan = 20;
+// optional .cockroach.roachpb.ReverseScanRequest reverse_scan = 21;
 bool RequestUnion::has_reverse_scan() const {
-  return (_has_bits_[0] & 0x00080000u) != 0;
+  return (_has_bits_[0] & 0x00100000u) != 0;
 }
 void RequestUnion::set_has_reverse_scan() {
-  _has_bits_[0] |= 0x00080000u;
+  _has_bits_[0] |= 0x00100000u;
 }
 void RequestUnion::clear_has_reverse_scan() {
-  _has_bits_[0] &= ~0x00080000u;
+  _has_bits_[0] &= ~0x00100000u;
 }
 void RequestUnion::clear_reverse_scan() {
   if (reverse_scan_ != NULL) reverse_scan_->::cockroach::roachpb::ReverseScanRequest::Clear();
@@ -19809,15 +20519,15 @@ void RequestUnion::clear_reverse_scan() {
   // @@protoc_insertion_point(field_set_allocated:cockroach.roachpb.RequestUnion.reverse_scan)
 }
 
-// optional .cockroach.roachpb.NoopRequest noop = 21;
+// optional .cockroach.roachpb.NoopRequest noop = 22;
 bool RequestUnion::has_noop() const {
-  return (_has_bits_[0] & 0x00100000u) != 0;
+  return (_has_bits_[0] & 0x00200000u) != 0;
 }
 void RequestUnion::set_has_noop() {
-  _has_bits_[0] |= 0x00100000u;
+  _has_bits_[0] |= 0x00200000u;
 }
 void RequestUnion::clear_has_noop() {
-  _has_bits_[0] &= ~0x00100000u;
+  _has_bits_[0] &= ~0x00200000u;
 }
 void RequestUnion::clear_noop() {
   if (noop_ != NULL) noop_->::cockroach::roachpb::NoopRequest::Clear();
@@ -19864,6 +20574,7 @@ const int ResponseUnion::kIncrementFieldNumber;
 const int ResponseUnion::kDeleteFieldNumber;
 const int ResponseUnion::kDeleteRangeFieldNumber;
 const int ResponseUnion::kScanFieldNumber;
+const int ResponseUnion::kBeginTransactionFieldNumber;
 const int ResponseUnion::kEndTransactionFieldNumber;
 const int ResponseUnion::kAdminSplitFieldNumber;
 const int ResponseUnion::kAdminMergeFieldNumber;
@@ -19894,6 +20605,7 @@ void ResponseUnion::InitAsDefaultInstance() {
   delete__ = const_cast< ::cockroach::roachpb::DeleteResponse*>(&::cockroach::roachpb::DeleteResponse::default_instance());
   delete_range_ = const_cast< ::cockroach::roachpb::DeleteRangeResponse*>(&::cockroach::roachpb::DeleteRangeResponse::default_instance());
   scan_ = const_cast< ::cockroach::roachpb::ScanResponse*>(&::cockroach::roachpb::ScanResponse::default_instance());
+  begin_transaction_ = const_cast< ::cockroach::roachpb::BeginTransactionResponse*>(&::cockroach::roachpb::BeginTransactionResponse::default_instance());
   end_transaction_ = const_cast< ::cockroach::roachpb::EndTransactionResponse*>(&::cockroach::roachpb::EndTransactionResponse::default_instance());
   admin_split_ = const_cast< ::cockroach::roachpb::AdminSplitResponse*>(&::cockroach::roachpb::AdminSplitResponse::default_instance());
   admin_merge_ = const_cast< ::cockroach::roachpb::AdminMergeResponse*>(&::cockroach::roachpb::AdminMergeResponse::default_instance());
@@ -19927,6 +20639,7 @@ void ResponseUnion::SharedCtor() {
   delete__ = NULL;
   delete_range_ = NULL;
   scan_ = NULL;
+  begin_transaction_ = NULL;
   end_transaction_ = NULL;
   admin_split_ = NULL;
   admin_merge_ = NULL;
@@ -19958,6 +20671,7 @@ void ResponseUnion::SharedDtor() {
     delete delete__;
     delete delete_range_;
     delete scan_;
+    delete begin_transaction_;
     delete end_transaction_;
     delete admin_split_;
     delete admin_merge_;
@@ -20023,11 +20737,14 @@ void ResponseUnion::Clear() {
     if (has_scan()) {
       if (scan_ != NULL) scan_->::cockroach::roachpb::ScanResponse::Clear();
     }
-    if (has_end_transaction()) {
-      if (end_transaction_ != NULL) end_transaction_->::cockroach::roachpb::EndTransactionResponse::Clear();
+    if (has_begin_transaction()) {
+      if (begin_transaction_ != NULL) begin_transaction_->::cockroach::roachpb::BeginTransactionResponse::Clear();
     }
   }
   if (_has_bits_[8 / 32] & 65280u) {
+    if (has_end_transaction()) {
+      if (end_transaction_ != NULL) end_transaction_->::cockroach::roachpb::EndTransactionResponse::Clear();
+    }
     if (has_admin_split()) {
       if (admin_split_ != NULL) admin_split_->::cockroach::roachpb::AdminSplitResponse::Clear();
     }
@@ -20049,11 +20766,11 @@ void ResponseUnion::Clear() {
     if (has_resolve_intent()) {
       if (resolve_intent_ != NULL) resolve_intent_->::cockroach::roachpb::ResolveIntentResponse::Clear();
     }
+  }
+  if (_has_bits_[16 / 32] & 4128768u) {
     if (has_resolve_intent_range()) {
       if (resolve_intent_range_ != NULL) resolve_intent_range_->::cockroach::roachpb::ResolveIntentRangeResponse::Clear();
     }
-  }
-  if (_has_bits_[16 / 32] & 2031616u) {
     if (has_merge()) {
       if (merge_ != NULL) merge_->::cockroach::roachpb::MergeResponse::Clear();
     }
@@ -20172,182 +20889,195 @@ bool ResponseUnion::MergePartialFromCodedStream(
         } else {
           goto handle_unusual;
         }
-        if (input->ExpectTag(66)) goto parse_end_transaction;
+        if (input->ExpectTag(66)) goto parse_begin_transaction;
         break;
       }
 
-      // optional .cockroach.roachpb.EndTransactionResponse end_transaction = 8;
+      // optional .cockroach.roachpb.BeginTransactionResponse begin_transaction = 8;
       case 8: {
         if (tag == 66) {
+         parse_begin_transaction:
+          DO_(::google::protobuf::internal::WireFormatLite::ReadMessageNoVirtual(
+               input, mutable_begin_transaction()));
+        } else {
+          goto handle_unusual;
+        }
+        if (input->ExpectTag(74)) goto parse_end_transaction;
+        break;
+      }
+
+      // optional .cockroach.roachpb.EndTransactionResponse end_transaction = 9;
+      case 9: {
+        if (tag == 74) {
          parse_end_transaction:
           DO_(::google::protobuf::internal::WireFormatLite::ReadMessageNoVirtual(
                input, mutable_end_transaction()));
         } else {
           goto handle_unusual;
         }
-        if (input->ExpectTag(74)) goto parse_admin_split;
+        if (input->ExpectTag(82)) goto parse_admin_split;
         break;
       }
 
-      // optional .cockroach.roachpb.AdminSplitResponse admin_split = 9;
-      case 9: {
-        if (tag == 74) {
+      // optional .cockroach.roachpb.AdminSplitResponse admin_split = 10;
+      case 10: {
+        if (tag == 82) {
          parse_admin_split:
           DO_(::google::protobuf::internal::WireFormatLite::ReadMessageNoVirtual(
                input, mutable_admin_split()));
         } else {
           goto handle_unusual;
         }
-        if (input->ExpectTag(82)) goto parse_admin_merge;
+        if (input->ExpectTag(90)) goto parse_admin_merge;
         break;
       }
 
-      // optional .cockroach.roachpb.AdminMergeResponse admin_merge = 10;
-      case 10: {
-        if (tag == 82) {
+      // optional .cockroach.roachpb.AdminMergeResponse admin_merge = 11;
+      case 11: {
+        if (tag == 90) {
          parse_admin_merge:
           DO_(::google::protobuf::internal::WireFormatLite::ReadMessageNoVirtual(
                input, mutable_admin_merge()));
         } else {
           goto handle_unusual;
         }
-        if (input->ExpectTag(90)) goto parse_heartbeat_txn;
+        if (input->ExpectTag(98)) goto parse_heartbeat_txn;
         break;
       }
 
-      // optional .cockroach.roachpb.HeartbeatTxnResponse heartbeat_txn = 11;
-      case 11: {
-        if (tag == 90) {
+      // optional .cockroach.roachpb.HeartbeatTxnResponse heartbeat_txn = 12;
+      case 12: {
+        if (tag == 98) {
          parse_heartbeat_txn:
           DO_(::google::protobuf::internal::WireFormatLite::ReadMessageNoVirtual(
                input, mutable_heartbeat_txn()));
         } else {
           goto handle_unusual;
         }
-        if (input->ExpectTag(98)) goto parse_gc;
+        if (input->ExpectTag(106)) goto parse_gc;
         break;
       }
 
-      // optional .cockroach.roachpb.GCResponse gc = 12;
-      case 12: {
-        if (tag == 98) {
+      // optional .cockroach.roachpb.GCResponse gc = 13;
+      case 13: {
+        if (tag == 106) {
          parse_gc:
           DO_(::google::protobuf::internal::WireFormatLite::ReadMessageNoVirtual(
                input, mutable_gc()));
         } else {
           goto handle_unusual;
         }
-        if (input->ExpectTag(106)) goto parse_push_txn;
+        if (input->ExpectTag(114)) goto parse_push_txn;
         break;
       }
 
-      // optional .cockroach.roachpb.PushTxnResponse push_txn = 13;
-      case 13: {
-        if (tag == 106) {
+      // optional .cockroach.roachpb.PushTxnResponse push_txn = 14;
+      case 14: {
+        if (tag == 114) {
          parse_push_txn:
           DO_(::google::protobuf::internal::WireFormatLite::ReadMessageNoVirtual(
                input, mutable_push_txn()));
         } else {
           goto handle_unusual;
         }
-        if (input->ExpectTag(114)) goto parse_range_lookup;
+        if (input->ExpectTag(122)) goto parse_range_lookup;
         break;
       }
 
-      // optional .cockroach.roachpb.RangeLookupResponse range_lookup = 14;
-      case 14: {
-        if (tag == 114) {
+      // optional .cockroach.roachpb.RangeLookupResponse range_lookup = 15;
+      case 15: {
+        if (tag == 122) {
          parse_range_lookup:
           DO_(::google::protobuf::internal::WireFormatLite::ReadMessageNoVirtual(
                input, mutable_range_lookup()));
         } else {
           goto handle_unusual;
         }
-        if (input->ExpectTag(122)) goto parse_resolve_intent;
+        if (input->ExpectTag(130)) goto parse_resolve_intent;
         break;
       }
 
-      // optional .cockroach.roachpb.ResolveIntentResponse resolve_intent = 15;
-      case 15: {
-        if (tag == 122) {
+      // optional .cockroach.roachpb.ResolveIntentResponse resolve_intent = 16;
+      case 16: {
+        if (tag == 130) {
          parse_resolve_intent:
           DO_(::google::protobuf::internal::WireFormatLite::ReadMessageNoVirtual(
                input, mutable_resolve_intent()));
         } else {
           goto handle_unusual;
         }
-        if (input->ExpectTag(130)) goto parse_resolve_intent_range;
+        if (input->ExpectTag(138)) goto parse_resolve_intent_range;
         break;
       }
 
-      // optional .cockroach.roachpb.ResolveIntentRangeResponse resolve_intent_range = 16;
-      case 16: {
-        if (tag == 130) {
+      // optional .cockroach.roachpb.ResolveIntentRangeResponse resolve_intent_range = 17;
+      case 17: {
+        if (tag == 138) {
          parse_resolve_intent_range:
           DO_(::google::protobuf::internal::WireFormatLite::ReadMessageNoVirtual(
                input, mutable_resolve_intent_range()));
         } else {
           goto handle_unusual;
         }
-        if (input->ExpectTag(138)) goto parse_merge;
+        if (input->ExpectTag(146)) goto parse_merge;
         break;
       }
 
-      // optional .cockroach.roachpb.MergeResponse merge = 17;
-      case 17: {
-        if (tag == 138) {
+      // optional .cockroach.roachpb.MergeResponse merge = 18;
+      case 18: {
+        if (tag == 146) {
          parse_merge:
           DO_(::google::protobuf::internal::WireFormatLite::ReadMessageNoVirtual(
                input, mutable_merge()));
         } else {
           goto handle_unusual;
         }
-        if (input->ExpectTag(146)) goto parse_truncate_log;
+        if (input->ExpectTag(154)) goto parse_truncate_log;
         break;
       }
 
-      // optional .cockroach.roachpb.TruncateLogResponse truncate_log = 18;
-      case 18: {
-        if (tag == 146) {
+      // optional .cockroach.roachpb.TruncateLogResponse truncate_log = 19;
+      case 19: {
+        if (tag == 154) {
          parse_truncate_log:
           DO_(::google::protobuf::internal::WireFormatLite::ReadMessageNoVirtual(
                input, mutable_truncate_log()));
         } else {
           goto handle_unusual;
         }
-        if (input->ExpectTag(154)) goto parse_leader_lease;
+        if (input->ExpectTag(162)) goto parse_leader_lease;
         break;
       }
 
-      // optional .cockroach.roachpb.LeaderLeaseResponse leader_lease = 19;
-      case 19: {
-        if (tag == 154) {
+      // optional .cockroach.roachpb.LeaderLeaseResponse leader_lease = 20;
+      case 20: {
+        if (tag == 162) {
          parse_leader_lease:
           DO_(::google::protobuf::internal::WireFormatLite::ReadMessageNoVirtual(
                input, mutable_leader_lease()));
         } else {
           goto handle_unusual;
         }
-        if (input->ExpectTag(162)) goto parse_reverse_scan;
+        if (input->ExpectTag(170)) goto parse_reverse_scan;
         break;
       }
 
-      // optional .cockroach.roachpb.ReverseScanResponse reverse_scan = 20;
-      case 20: {
-        if (tag == 162) {
+      // optional .cockroach.roachpb.ReverseScanResponse reverse_scan = 21;
+      case 21: {
+        if (tag == 170) {
          parse_reverse_scan:
           DO_(::google::protobuf::internal::WireFormatLite::ReadMessageNoVirtual(
                input, mutable_reverse_scan()));
         } else {
           goto handle_unusual;
         }
-        if (input->ExpectTag(170)) goto parse_noop;
+        if (input->ExpectTag(178)) goto parse_noop;
         break;
       }
 
-      // optional .cockroach.roachpb.NoopResponse noop = 21;
-      case 21: {
-        if (tag == 170) {
+      // optional .cockroach.roachpb.NoopResponse noop = 22;
+      case 22: {
+        if (tag == 178) {
          parse_noop:
           DO_(::google::protobuf::internal::WireFormatLite::ReadMessageNoVirtual(
                input, mutable_noop()));
@@ -20425,88 +21155,94 @@ void ResponseUnion::SerializeWithCachedSizes(
       7, *this->scan_, output);
   }
 
-  // optional .cockroach.roachpb.EndTransactionResponse end_transaction = 8;
+  // optional .cockroach.roachpb.BeginTransactionResponse begin_transaction = 8;
+  if (has_begin_transaction()) {
+    ::google::protobuf::internal::WireFormatLite::WriteMessageMaybeToArray(
+      8, *this->begin_transaction_, output);
+  }
+
+  // optional .cockroach.roachpb.EndTransactionResponse end_transaction = 9;
   if (has_end_transaction()) {
     ::google::protobuf::internal::WireFormatLite::WriteMessageMaybeToArray(
-      8, *this->end_transaction_, output);
+      9, *this->end_transaction_, output);
   }
 
-  // optional .cockroach.roachpb.AdminSplitResponse admin_split = 9;
+  // optional .cockroach.roachpb.AdminSplitResponse admin_split = 10;
   if (has_admin_split()) {
     ::google::protobuf::internal::WireFormatLite::WriteMessageMaybeToArray(
-      9, *this->admin_split_, output);
+      10, *this->admin_split_, output);
   }
 
-  // optional .cockroach.roachpb.AdminMergeResponse admin_merge = 10;
+  // optional .cockroach.roachpb.AdminMergeResponse admin_merge = 11;
   if (has_admin_merge()) {
     ::google::protobuf::internal::WireFormatLite::WriteMessageMaybeToArray(
-      10, *this->admin_merge_, output);
+      11, *this->admin_merge_, output);
   }
 
-  // optional .cockroach.roachpb.HeartbeatTxnResponse heartbeat_txn = 11;
+  // optional .cockroach.roachpb.HeartbeatTxnResponse heartbeat_txn = 12;
   if (has_heartbeat_txn()) {
     ::google::protobuf::internal::WireFormatLite::WriteMessageMaybeToArray(
-      11, *this->heartbeat_txn_, output);
+      12, *this->heartbeat_txn_, output);
   }
 
-  // optional .cockroach.roachpb.GCResponse gc = 12;
+  // optional .cockroach.roachpb.GCResponse gc = 13;
   if (has_gc()) {
     ::google::protobuf::internal::WireFormatLite::WriteMessageMaybeToArray(
-      12, *this->gc_, output);
+      13, *this->gc_, output);
   }
 
-  // optional .cockroach.roachpb.PushTxnResponse push_txn = 13;
+  // optional .cockroach.roachpb.PushTxnResponse push_txn = 14;
   if (has_push_txn()) {
     ::google::protobuf::internal::WireFormatLite::WriteMessageMaybeToArray(
-      13, *this->push_txn_, output);
+      14, *this->push_txn_, output);
   }
 
-  // optional .cockroach.roachpb.RangeLookupResponse range_lookup = 14;
+  // optional .cockroach.roachpb.RangeLookupResponse range_lookup = 15;
   if (has_range_lookup()) {
     ::google::protobuf::internal::WireFormatLite::WriteMessageMaybeToArray(
-      14, *this->range_lookup_, output);
+      15, *this->range_lookup_, output);
   }
 
-  // optional .cockroach.roachpb.ResolveIntentResponse resolve_intent = 15;
+  // optional .cockroach.roachpb.ResolveIntentResponse resolve_intent = 16;
   if (has_resolve_intent()) {
     ::google::protobuf::internal::WireFormatLite::WriteMessageMaybeToArray(
-      15, *this->resolve_intent_, output);
+      16, *this->resolve_intent_, output);
   }
 
-  // optional .cockroach.roachpb.ResolveIntentRangeResponse resolve_intent_range = 16;
+  // optional .cockroach.roachpb.ResolveIntentRangeResponse resolve_intent_range = 17;
   if (has_resolve_intent_range()) {
     ::google::protobuf::internal::WireFormatLite::WriteMessageMaybeToArray(
-      16, *this->resolve_intent_range_, output);
+      17, *this->resolve_intent_range_, output);
   }
 
-  // optional .cockroach.roachpb.MergeResponse merge = 17;
+  // optional .cockroach.roachpb.MergeResponse merge = 18;
   if (has_merge()) {
     ::google::protobuf::internal::WireFormatLite::WriteMessageMaybeToArray(
-      17, *this->merge_, output);
+      18, *this->merge_, output);
   }
 
-  // optional .cockroach.roachpb.TruncateLogResponse truncate_log = 18;
+  // optional .cockroach.roachpb.TruncateLogResponse truncate_log = 19;
   if (has_truncate_log()) {
     ::google::protobuf::internal::WireFormatLite::WriteMessageMaybeToArray(
-      18, *this->truncate_log_, output);
+      19, *this->truncate_log_, output);
   }
 
-  // optional .cockroach.roachpb.LeaderLeaseResponse leader_lease = 19;
+  // optional .cockroach.roachpb.LeaderLeaseResponse leader_lease = 20;
   if (has_leader_lease()) {
     ::google::protobuf::internal::WireFormatLite::WriteMessageMaybeToArray(
-      19, *this->leader_lease_, output);
+      20, *this->leader_lease_, output);
   }
 
-  // optional .cockroach.roachpb.ReverseScanResponse reverse_scan = 20;
+  // optional .cockroach.roachpb.ReverseScanResponse reverse_scan = 21;
   if (has_reverse_scan()) {
     ::google::protobuf::internal::WireFormatLite::WriteMessageMaybeToArray(
-      20, *this->reverse_scan_, output);
+      21, *this->reverse_scan_, output);
   }
 
-  // optional .cockroach.roachpb.NoopResponse noop = 21;
+  // optional .cockroach.roachpb.NoopResponse noop = 22;
   if (has_noop()) {
     ::google::protobuf::internal::WireFormatLite::WriteMessageMaybeToArray(
-      21, *this->noop_, output);
+      22, *this->noop_, output);
   }
 
   if (_internal_metadata_.have_unknown_fields()) {
@@ -20568,102 +21304,109 @@ void ResponseUnion::SerializeWithCachedSizes(
         7, *this->scan_, target);
   }
 
-  // optional .cockroach.roachpb.EndTransactionResponse end_transaction = 8;
+  // optional .cockroach.roachpb.BeginTransactionResponse begin_transaction = 8;
+  if (has_begin_transaction()) {
+    target = ::google::protobuf::internal::WireFormatLite::
+      WriteMessageNoVirtualToArray(
+        8, *this->begin_transaction_, target);
+  }
+
+  // optional .cockroach.roachpb.EndTransactionResponse end_transaction = 9;
   if (has_end_transaction()) {
     target = ::google::protobuf::internal::WireFormatLite::
       WriteMessageNoVirtualToArray(
-        8, *this->end_transaction_, target);
+        9, *this->end_transaction_, target);
   }
 
-  // optional .cockroach.roachpb.AdminSplitResponse admin_split = 9;
+  // optional .cockroach.roachpb.AdminSplitResponse admin_split = 10;
   if (has_admin_split()) {
     target = ::google::protobuf::internal::WireFormatLite::
       WriteMessageNoVirtualToArray(
-        9, *this->admin_split_, target);
+        10, *this->admin_split_, target);
   }
 
-  // optional .cockroach.roachpb.AdminMergeResponse admin_merge = 10;
+  // optional .cockroach.roachpb.AdminMergeResponse admin_merge = 11;
   if (has_admin_merge()) {
     target = ::google::protobuf::internal::WireFormatLite::
       WriteMessageNoVirtualToArray(
-        10, *this->admin_merge_, target);
+        11, *this->admin_merge_, target);
   }
 
-  // optional .cockroach.roachpb.HeartbeatTxnResponse heartbeat_txn = 11;
+  // optional .cockroach.roachpb.HeartbeatTxnResponse heartbeat_txn = 12;
   if (has_heartbeat_txn()) {
     target = ::google::protobuf::internal::WireFormatLite::
       WriteMessageNoVirtualToArray(
-        11, *this->heartbeat_txn_, target);
+        12, *this->heartbeat_txn_, target);
   }
 
-  // optional .cockroach.roachpb.GCResponse gc = 12;
+  // optional .cockroach.roachpb.GCResponse gc = 13;
   if (has_gc()) {
     target = ::google::protobuf::internal::WireFormatLite::
       WriteMessageNoVirtualToArray(
-        12, *this->gc_, target);
+        13, *this->gc_, target);
   }
 
-  // optional .cockroach.roachpb.PushTxnResponse push_txn = 13;
+  // optional .cockroach.roachpb.PushTxnResponse push_txn = 14;
   if (has_push_txn()) {
     target = ::google::protobuf::internal::WireFormatLite::
       WriteMessageNoVirtualToArray(
-        13, *this->push_txn_, target);
+        14, *this->push_txn_, target);
   }
 
-  // optional .cockroach.roachpb.RangeLookupResponse range_lookup = 14;
+  // optional .cockroach.roachpb.RangeLookupResponse range_lookup = 15;
   if (has_range_lookup()) {
     target = ::google::protobuf::internal::WireFormatLite::
       WriteMessageNoVirtualToArray(
-        14, *this->range_lookup_, target);
+        15, *this->range_lookup_, target);
   }
 
-  // optional .cockroach.roachpb.ResolveIntentResponse resolve_intent = 15;
+  // optional .cockroach.roachpb.ResolveIntentResponse resolve_intent = 16;
   if (has_resolve_intent()) {
     target = ::google::protobuf::internal::WireFormatLite::
       WriteMessageNoVirtualToArray(
-        15, *this->resolve_intent_, target);
+        16, *this->resolve_intent_, target);
   }
 
-  // optional .cockroach.roachpb.ResolveIntentRangeResponse resolve_intent_range = 16;
+  // optional .cockroach.roachpb.ResolveIntentRangeResponse resolve_intent_range = 17;
   if (has_resolve_intent_range()) {
     target = ::google::protobuf::internal::WireFormatLite::
       WriteMessageNoVirtualToArray(
-        16, *this->resolve_intent_range_, target);
+        17, *this->resolve_intent_range_, target);
   }
 
-  // optional .cockroach.roachpb.MergeResponse merge = 17;
+  // optional .cockroach.roachpb.MergeResponse merge = 18;
   if (has_merge()) {
     target = ::google::protobuf::internal::WireFormatLite::
       WriteMessageNoVirtualToArray(
-        17, *this->merge_, target);
+        18, *this->merge_, target);
   }
 
-  // optional .cockroach.roachpb.TruncateLogResponse truncate_log = 18;
+  // optional .cockroach.roachpb.TruncateLogResponse truncate_log = 19;
   if (has_truncate_log()) {
     target = ::google::protobuf::internal::WireFormatLite::
       WriteMessageNoVirtualToArray(
-        18, *this->truncate_log_, target);
+        19, *this->truncate_log_, target);
   }
 
-  // optional .cockroach.roachpb.LeaderLeaseResponse leader_lease = 19;
+  // optional .cockroach.roachpb.LeaderLeaseResponse leader_lease = 20;
   if (has_leader_lease()) {
     target = ::google::protobuf::internal::WireFormatLite::
       WriteMessageNoVirtualToArray(
-        19, *this->leader_lease_, target);
+        20, *this->leader_lease_, target);
   }
 
-  // optional .cockroach.roachpb.ReverseScanResponse reverse_scan = 20;
+  // optional .cockroach.roachpb.ReverseScanResponse reverse_scan = 21;
   if (has_reverse_scan()) {
     target = ::google::protobuf::internal::WireFormatLite::
       WriteMessageNoVirtualToArray(
-        20, *this->reverse_scan_, target);
+        21, *this->reverse_scan_, target);
   }
 
-  // optional .cockroach.roachpb.NoopResponse noop = 21;
+  // optional .cockroach.roachpb.NoopResponse noop = 22;
   if (has_noop()) {
     target = ::google::protobuf::internal::WireFormatLite::
       WriteMessageNoVirtualToArray(
-        21, *this->noop_, target);
+        22, *this->noop_, target);
   }
 
   if (_internal_metadata_.have_unknown_fields()) {
@@ -20727,102 +21470,109 @@ int ResponseUnion::ByteSize() const {
           *this->scan_);
     }
 
-    // optional .cockroach.roachpb.EndTransactionResponse end_transaction = 8;
+    // optional .cockroach.roachpb.BeginTransactionResponse begin_transaction = 8;
+    if (has_begin_transaction()) {
+      total_size += 1 +
+        ::google::protobuf::internal::WireFormatLite::MessageSizeNoVirtual(
+          *this->begin_transaction_);
+    }
+
+  }
+  if (_has_bits_[8 / 32] & 65280) {
+    // optional .cockroach.roachpb.EndTransactionResponse end_transaction = 9;
     if (has_end_transaction()) {
       total_size += 1 +
         ::google::protobuf::internal::WireFormatLite::MessageSizeNoVirtual(
           *this->end_transaction_);
     }
 
-  }
-  if (_has_bits_[8 / 32] & 65280) {
-    // optional .cockroach.roachpb.AdminSplitResponse admin_split = 9;
+    // optional .cockroach.roachpb.AdminSplitResponse admin_split = 10;
     if (has_admin_split()) {
       total_size += 1 +
         ::google::protobuf::internal::WireFormatLite::MessageSizeNoVirtual(
           *this->admin_split_);
     }
 
-    // optional .cockroach.roachpb.AdminMergeResponse admin_merge = 10;
+    // optional .cockroach.roachpb.AdminMergeResponse admin_merge = 11;
     if (has_admin_merge()) {
       total_size += 1 +
         ::google::protobuf::internal::WireFormatLite::MessageSizeNoVirtual(
           *this->admin_merge_);
     }
 
-    // optional .cockroach.roachpb.HeartbeatTxnResponse heartbeat_txn = 11;
+    // optional .cockroach.roachpb.HeartbeatTxnResponse heartbeat_txn = 12;
     if (has_heartbeat_txn()) {
       total_size += 1 +
         ::google::protobuf::internal::WireFormatLite::MessageSizeNoVirtual(
           *this->heartbeat_txn_);
     }
 
-    // optional .cockroach.roachpb.GCResponse gc = 12;
+    // optional .cockroach.roachpb.GCResponse gc = 13;
     if (has_gc()) {
       total_size += 1 +
         ::google::protobuf::internal::WireFormatLite::MessageSizeNoVirtual(
           *this->gc_);
     }
 
-    // optional .cockroach.roachpb.PushTxnResponse push_txn = 13;
+    // optional .cockroach.roachpb.PushTxnResponse push_txn = 14;
     if (has_push_txn()) {
       total_size += 1 +
         ::google::protobuf::internal::WireFormatLite::MessageSizeNoVirtual(
           *this->push_txn_);
     }
 
-    // optional .cockroach.roachpb.RangeLookupResponse range_lookup = 14;
+    // optional .cockroach.roachpb.RangeLookupResponse range_lookup = 15;
     if (has_range_lookup()) {
       total_size += 1 +
         ::google::protobuf::internal::WireFormatLite::MessageSizeNoVirtual(
           *this->range_lookup_);
     }
 
-    // optional .cockroach.roachpb.ResolveIntentResponse resolve_intent = 15;
+    // optional .cockroach.roachpb.ResolveIntentResponse resolve_intent = 16;
     if (has_resolve_intent()) {
-      total_size += 1 +
+      total_size += 2 +
         ::google::protobuf::internal::WireFormatLite::MessageSizeNoVirtual(
           *this->resolve_intent_);
     }
 
-    // optional .cockroach.roachpb.ResolveIntentRangeResponse resolve_intent_range = 16;
+  }
+  if (_has_bits_[16 / 32] & 4128768) {
+    // optional .cockroach.roachpb.ResolveIntentRangeResponse resolve_intent_range = 17;
     if (has_resolve_intent_range()) {
       total_size += 2 +
         ::google::protobuf::internal::WireFormatLite::MessageSizeNoVirtual(
           *this->resolve_intent_range_);
     }
 
-  }
-  if (_has_bits_[16 / 32] & 2031616) {
-    // optional .cockroach.roachpb.MergeResponse merge = 17;
+    // optional .cockroach.roachpb.MergeResponse merge = 18;
     if (has_merge()) {
       total_size += 2 +
         ::google::protobuf::internal::WireFormatLite::MessageSizeNoVirtual(
           *this->merge_);
     }
 
-    // optional .cockroach.roachpb.TruncateLogResponse truncate_log = 18;
+    // optional .cockroach.roachpb.TruncateLogResponse truncate_log = 19;
     if (has_truncate_log()) {
       total_size += 2 +
         ::google::protobuf::internal::WireFormatLite::MessageSizeNoVirtual(
           *this->truncate_log_);
     }
 
-    // optional .cockroach.roachpb.LeaderLeaseResponse leader_lease = 19;
+    // optional .cockroach.roachpb.LeaderLeaseResponse leader_lease = 20;
     if (has_leader_lease()) {
       total_size += 2 +
         ::google::protobuf::internal::WireFormatLite::MessageSizeNoVirtual(
           *this->leader_lease_);
     }
 
-    // optional .cockroach.roachpb.ReverseScanResponse reverse_scan = 20;
+    // optional .cockroach.roachpb.ReverseScanResponse reverse_scan = 21;
     if (has_reverse_scan()) {
       total_size += 2 +
         ::google::protobuf::internal::WireFormatLite::MessageSizeNoVirtual(
           *this->reverse_scan_);
     }
 
-    // optional .cockroach.roachpb.NoopResponse noop = 21;
+    // optional .cockroach.roachpb.NoopResponse noop = 22;
     if (has_noop()) {
       total_size += 2 +
         ::google::protobuf::internal::WireFormatLite::MessageSizeNoVirtual(
@@ -20877,11 +21627,14 @@ void ResponseUnion::MergeFrom(const ResponseUnion& from) {
     if (from.has_scan()) {
       mutable_scan()->::cockroach::roachpb::ScanResponse::MergeFrom(from.scan());
     }
-    if (from.has_end_transaction()) {
-      mutable_end_transaction()->::cockroach::roachpb::EndTransactionResponse::MergeFrom(from.end_transaction());
+    if (from.has_begin_transaction()) {
+      mutable_begin_transaction()->::cockroach::roachpb::BeginTransactionResponse::MergeFrom(from.begin_transaction());
     }
   }
   if (from._has_bits_[8 / 32] & (0xffu << (8 % 32))) {
+    if (from.has_end_transaction()) {
+      mutable_end_transaction()->::cockroach::roachpb::EndTransactionResponse::MergeFrom(from.end_transaction());
+    }
     if (from.has_admin_split()) {
       mutable_admin_split()->::cockroach::roachpb::AdminSplitResponse::MergeFrom(from.admin_split());
     }
@@ -20903,11 +21656,11 @@ void ResponseUnion::MergeFrom(const ResponseUnion& from) {
     if (from.has_resolve_intent()) {
       mutable_resolve_intent()->::cockroach::roachpb::ResolveIntentResponse::MergeFrom(from.resolve_intent());
     }
+  }
+  if (from._has_bits_[16 / 32] & (0xffu << (16 % 32))) {
     if (from.has_resolve_intent_range()) {
       mutable_resolve_intent_range()->::cockroach::roachpb::ResolveIntentRangeResponse::MergeFrom(from.resolve_intent_range());
     }
-  }
-  if (from._has_bits_[16 / 32] & (0xffu << (16 % 32))) {
     if (from.has_merge()) {
       mutable_merge()->::cockroach::roachpb::MergeResponse::MergeFrom(from.merge());
     }
@@ -20958,6 +21711,7 @@ void ResponseUnion::InternalSwap(ResponseUnion* other) {
   std::swap(delete__, other->delete__);
   std::swap(delete_range_, other->delete_range_);
   std::swap(scan_, other->scan_);
+  std::swap(begin_transaction_, other->begin_transaction_);
   std::swap(end_transaction_, other->end_transaction_);
   std::swap(admin_split_, other->admin_split_);
   std::swap(admin_merge_, other->admin_merge_);
@@ -21289,15 +22043,58 @@ void ResponseUnion::clear_scan() {
   // @@protoc_insertion_point(field_set_allocated:cockroach.roachpb.ResponseUnion.scan)
 }
 
-// optional .cockroach.roachpb.EndTransactionResponse end_transaction = 8;
-bool ResponseUnion::has_end_transaction() const {
+// optional .cockroach.roachpb.BeginTransactionResponse begin_transaction = 8;
+bool ResponseUnion::has_begin_transaction() const {
   return (_has_bits_[0] & 0x00000080u) != 0;
 }
-void ResponseUnion::set_has_end_transaction() {
+void ResponseUnion::set_has_begin_transaction() {
   _has_bits_[0] |= 0x00000080u;
 }
-void ResponseUnion::clear_has_end_transaction() {
+void ResponseUnion::clear_has_begin_transaction() {
   _has_bits_[0] &= ~0x00000080u;
+}
+void ResponseUnion::clear_begin_transaction() {
+  if (begin_transaction_ != NULL) begin_transaction_->::cockroach::roachpb::BeginTransactionResponse::Clear();
+  clear_has_begin_transaction();
+}
+ const ::cockroach::roachpb::BeginTransactionResponse& ResponseUnion::begin_transaction() const {
+  // @@protoc_insertion_point(field_get:cockroach.roachpb.ResponseUnion.begin_transaction)
+  return begin_transaction_ != NULL ? *begin_transaction_ : *default_instance_->begin_transaction_;
+}
+ ::cockroach::roachpb::BeginTransactionResponse* ResponseUnion::mutable_begin_transaction() {
+  set_has_begin_transaction();
+  if (begin_transaction_ == NULL) {
+    begin_transaction_ = new ::cockroach::roachpb::BeginTransactionResponse;
+  }
+  // @@protoc_insertion_point(field_mutable:cockroach.roachpb.ResponseUnion.begin_transaction)
+  return begin_transaction_;
+}
+ ::cockroach::roachpb::BeginTransactionResponse* ResponseUnion::release_begin_transaction() {
+  clear_has_begin_transaction();
+  ::cockroach::roachpb::BeginTransactionResponse* temp = begin_transaction_;
+  begin_transaction_ = NULL;
+  return temp;
+}
+ void ResponseUnion::set_allocated_begin_transaction(::cockroach::roachpb::BeginTransactionResponse* begin_transaction) {
+  delete begin_transaction_;
+  begin_transaction_ = begin_transaction;
+  if (begin_transaction) {
+    set_has_begin_transaction();
+  } else {
+    clear_has_begin_transaction();
+  }
+  // @@protoc_insertion_point(field_set_allocated:cockroach.roachpb.ResponseUnion.begin_transaction)
+}
+
+// optional .cockroach.roachpb.EndTransactionResponse end_transaction = 9;
+bool ResponseUnion::has_end_transaction() const {
+  return (_has_bits_[0] & 0x00000100u) != 0;
+}
+void ResponseUnion::set_has_end_transaction() {
+  _has_bits_[0] |= 0x00000100u;
+}
+void ResponseUnion::clear_has_end_transaction() {
+  _has_bits_[0] &= ~0x00000100u;
 }
 void ResponseUnion::clear_end_transaction() {
   if (end_transaction_ != NULL) end_transaction_->::cockroach::roachpb::EndTransactionResponse::Clear();
@@ -21332,15 +22129,15 @@ void ResponseUnion::clear_end_transaction() {
   // @@protoc_insertion_point(field_set_allocated:cockroach.roachpb.ResponseUnion.end_transaction)
 }
 
-// optional .cockroach.roachpb.AdminSplitResponse admin_split = 9;
+// optional .cockroach.roachpb.AdminSplitResponse admin_split = 10;
 bool ResponseUnion::has_admin_split() const {
-  return (_has_bits_[0] & 0x00000100u) != 0;
+  return (_has_bits_[0] & 0x00000200u) != 0;
 }
 void ResponseUnion::set_has_admin_split() {
-  _has_bits_[0] |= 0x00000100u;
+  _has_bits_[0] |= 0x00000200u;
 }
 void ResponseUnion::clear_has_admin_split() {
-  _has_bits_[0] &= ~0x00000100u;
+  _has_bits_[0] &= ~0x00000200u;
 }
 void ResponseUnion::clear_admin_split() {
   if (admin_split_ != NULL) admin_split_->::cockroach::roachpb::AdminSplitResponse::Clear();
@@ -21375,15 +22172,15 @@ void ResponseUnion::clear_admin_split() {
   // @@protoc_insertion_point(field_set_allocated:cockroach.roachpb.ResponseUnion.admin_split)
 }
 
-// optional .cockroach.roachpb.AdminMergeResponse admin_merge = 10;
+// optional .cockroach.roachpb.AdminMergeResponse admin_merge = 11;
 bool ResponseUnion::has_admin_merge() const {
-  return (_has_bits_[0] & 0x00000200u) != 0;
+  return (_has_bits_[0] & 0x00000400u) != 0;
 }
 void ResponseUnion::set_has_admin_merge() {
-  _has_bits_[0] |= 0x00000200u;
+  _has_bits_[0] |= 0x00000400u;
 }
 void ResponseUnion::clear_has_admin_merge() {
-  _has_bits_[0] &= ~0x00000200u;
+  _has_bits_[0] &= ~0x00000400u;
 }
 void ResponseUnion::clear_admin_merge() {
   if (admin_merge_ != NULL) admin_merge_->::cockroach::roachpb::AdminMergeResponse::Clear();
@@ -21418,15 +22215,15 @@ void ResponseUnion::clear_admin_merge() {
   // @@protoc_insertion_point(field_set_allocated:cockroach.roachpb.ResponseUnion.admin_merge)
 }
 
-// optional .cockroach.roachpb.HeartbeatTxnResponse heartbeat_txn = 11;
+// optional .cockroach.roachpb.HeartbeatTxnResponse heartbeat_txn = 12;
 bool ResponseUnion::has_heartbeat_txn() const {
-  return (_has_bits_[0] & 0x00000400u) != 0;
+  return (_has_bits_[0] & 0x00000800u) != 0;
 }
 void ResponseUnion::set_has_heartbeat_txn() {
-  _has_bits_[0] |= 0x00000400u;
+  _has_bits_[0] |= 0x00000800u;
 }
 void ResponseUnion::clear_has_heartbeat_txn() {
-  _has_bits_[0] &= ~0x00000400u;
+  _has_bits_[0] &= ~0x00000800u;
 }
 void ResponseUnion::clear_heartbeat_txn() {
   if (heartbeat_txn_ != NULL) heartbeat_txn_->::cockroach::roachpb::HeartbeatTxnResponse::Clear();
@@ -21461,15 +22258,15 @@ void ResponseUnion::clear_heartbeat_txn() {
   // @@protoc_insertion_point(field_set_allocated:cockroach.roachpb.ResponseUnion.heartbeat_txn)
 }
 
-// optional .cockroach.roachpb.GCResponse gc = 12;
+// optional .cockroach.roachpb.GCResponse gc = 13;
 bool ResponseUnion::has_gc() const {
-  return (_has_bits_[0] & 0x00000800u) != 0;
+  return (_has_bits_[0] & 0x00001000u) != 0;
 }
 void ResponseUnion::set_has_gc() {
-  _has_bits_[0] |= 0x00000800u;
+  _has_bits_[0] |= 0x00001000u;
 }
 void ResponseUnion::clear_has_gc() {
-  _has_bits_[0] &= ~0x00000800u;
+  _has_bits_[0] &= ~0x00001000u;
 }
 void ResponseUnion::clear_gc() {
   if (gc_ != NULL) gc_->::cockroach::roachpb::GCResponse::Clear();
@@ -21504,15 +22301,15 @@ void ResponseUnion::clear_gc() {
   // @@protoc_insertion_point(field_set_allocated:cockroach.roachpb.ResponseUnion.gc)
 }
 
-// optional .cockroach.roachpb.PushTxnResponse push_txn = 13;
+// optional .cockroach.roachpb.PushTxnResponse push_txn = 14;
 bool ResponseUnion::has_push_txn() const {
-  return (_has_bits_[0] & 0x00001000u) != 0;
+  return (_has_bits_[0] & 0x00002000u) != 0;
 }
 void ResponseUnion::set_has_push_txn() {
-  _has_bits_[0] |= 0x00001000u;
+  _has_bits_[0] |= 0x00002000u;
 }
 void ResponseUnion::clear_has_push_txn() {
-  _has_bits_[0] &= ~0x00001000u;
+  _has_bits_[0] &= ~0x00002000u;
 }
 void ResponseUnion::clear_push_txn() {
   if (push_txn_ != NULL) push_txn_->::cockroach::roachpb::PushTxnResponse::Clear();
@@ -21547,15 +22344,15 @@ void ResponseUnion::clear_push_txn() {
   // @@protoc_insertion_point(field_set_allocated:cockroach.roachpb.ResponseUnion.push_txn)
 }
 
-// optional .cockroach.roachpb.RangeLookupResponse range_lookup = 14;
+// optional .cockroach.roachpb.RangeLookupResponse range_lookup = 15;
 bool ResponseUnion::has_range_lookup() const {
-  return (_has_bits_[0] & 0x00002000u) != 0;
+  return (_has_bits_[0] & 0x00004000u) != 0;
 }
 void ResponseUnion::set_has_range_lookup() {
-  _has_bits_[0] |= 0x00002000u;
+  _has_bits_[0] |= 0x00004000u;
 }
 void ResponseUnion::clear_has_range_lookup() {
-  _has_bits_[0] &= ~0x00002000u;
+  _has_bits_[0] &= ~0x00004000u;
 }
 void ResponseUnion::clear_range_lookup() {
   if (range_lookup_ != NULL) range_lookup_->::cockroach::roachpb::RangeLookupResponse::Clear();
@@ -21590,15 +22387,15 @@ void ResponseUnion::clear_range_lookup() {
   // @@protoc_insertion_point(field_set_allocated:cockroach.roachpb.ResponseUnion.range_lookup)
 }
 
-// optional .cockroach.roachpb.ResolveIntentResponse resolve_intent = 15;
+// optional .cockroach.roachpb.ResolveIntentResponse resolve_intent = 16;
 bool ResponseUnion::has_resolve_intent() const {
-  return (_has_bits_[0] & 0x00004000u) != 0;
+  return (_has_bits_[0] & 0x00008000u) != 0;
 }
 void ResponseUnion::set_has_resolve_intent() {
-  _has_bits_[0] |= 0x00004000u;
+  _has_bits_[0] |= 0x00008000u;
 }
 void ResponseUnion::clear_has_resolve_intent() {
-  _has_bits_[0] &= ~0x00004000u;
+  _has_bits_[0] &= ~0x00008000u;
 }
 void ResponseUnion::clear_resolve_intent() {
   if (resolve_intent_ != NULL) resolve_intent_->::cockroach::roachpb::ResolveIntentResponse::Clear();
@@ -21633,15 +22430,15 @@ void ResponseUnion::clear_resolve_intent() {
   // @@protoc_insertion_point(field_set_allocated:cockroach.roachpb.ResponseUnion.resolve_intent)
 }
 
-// optional .cockroach.roachpb.ResolveIntentRangeResponse resolve_intent_range = 16;
+// optional .cockroach.roachpb.ResolveIntentRangeResponse resolve_intent_range = 17;
 bool ResponseUnion::has_resolve_intent_range() const {
-  return (_has_bits_[0] & 0x00008000u) != 0;
+  return (_has_bits_[0] & 0x00010000u) != 0;
 }
 void ResponseUnion::set_has_resolve_intent_range() {
-  _has_bits_[0] |= 0x00008000u;
+  _has_bits_[0] |= 0x00010000u;
 }
 void ResponseUnion::clear_has_resolve_intent_range() {
-  _has_bits_[0] &= ~0x00008000u;
+  _has_bits_[0] &= ~0x00010000u;
 }
 void ResponseUnion::clear_resolve_intent_range() {
   if (resolve_intent_range_ != NULL) resolve_intent_range_->::cockroach::roachpb::ResolveIntentRangeResponse::Clear();
@@ -21676,15 +22473,15 @@ void ResponseUnion::clear_resolve_intent_range() {
   // @@protoc_insertion_point(field_set_allocated:cockroach.roachpb.ResponseUnion.resolve_intent_range)
 }
 
-// optional .cockroach.roachpb.MergeResponse merge = 17;
+// optional .cockroach.roachpb.MergeResponse merge = 18;
 bool ResponseUnion::has_merge() const {
-  return (_has_bits_[0] & 0x00010000u) != 0;
+  return (_has_bits_[0] & 0x00020000u) != 0;
 }
 void ResponseUnion::set_has_merge() {
-  _has_bits_[0] |= 0x00010000u;
+  _has_bits_[0] |= 0x00020000u;
 }
 void ResponseUnion::clear_has_merge() {
-  _has_bits_[0] &= ~0x00010000u;
+  _has_bits_[0] &= ~0x00020000u;
 }
 void ResponseUnion::clear_merge() {
   if (merge_ != NULL) merge_->::cockroach::roachpb::MergeResponse::Clear();
@@ -21719,15 +22516,15 @@ void ResponseUnion::clear_merge() {
   // @@protoc_insertion_point(field_set_allocated:cockroach.roachpb.ResponseUnion.merge)
 }
 
-// optional .cockroach.roachpb.TruncateLogResponse truncate_log = 18;
+// optional .cockroach.roachpb.TruncateLogResponse truncate_log = 19;
 bool ResponseUnion::has_truncate_log() const {
-  return (_has_bits_[0] & 0x00020000u) != 0;
+  return (_has_bits_[0] & 0x00040000u) != 0;
 }
 void ResponseUnion::set_has_truncate_log() {
-  _has_bits_[0] |= 0x00020000u;
+  _has_bits_[0] |= 0x00040000u;
 }
 void ResponseUnion::clear_has_truncate_log() {
-  _has_bits_[0] &= ~0x00020000u;
+  _has_bits_[0] &= ~0x00040000u;
 }
 void ResponseUnion::clear_truncate_log() {
   if (truncate_log_ != NULL) truncate_log_->::cockroach::roachpb::TruncateLogResponse::Clear();
@@ -21762,15 +22559,15 @@ void ResponseUnion::clear_truncate_log() {
   // @@protoc_insertion_point(field_set_allocated:cockroach.roachpb.ResponseUnion.truncate_log)
 }
 
-// optional .cockroach.roachpb.LeaderLeaseResponse leader_lease = 19;
+// optional .cockroach.roachpb.LeaderLeaseResponse leader_lease = 20;
 bool ResponseUnion::has_leader_lease() const {
-  return (_has_bits_[0] & 0x00040000u) != 0;
+  return (_has_bits_[0] & 0x00080000u) != 0;
 }
 void ResponseUnion::set_has_leader_lease() {
-  _has_bits_[0] |= 0x00040000u;
+  _has_bits_[0] |= 0x00080000u;
 }
 void ResponseUnion::clear_has_leader_lease() {
-  _has_bits_[0] &= ~0x00040000u;
+  _has_bits_[0] &= ~0x00080000u;
 }
 void ResponseUnion::clear_leader_lease() {
   if (leader_lease_ != NULL) leader_lease_->::cockroach::roachpb::LeaderLeaseResponse::Clear();
@@ -21805,15 +22602,15 @@ void ResponseUnion::clear_leader_lease() {
   // @@protoc_insertion_point(field_set_allocated:cockroach.roachpb.ResponseUnion.leader_lease)
 }
 
-// optional .cockroach.roachpb.ReverseScanResponse reverse_scan = 20;
+// optional .cockroach.roachpb.ReverseScanResponse reverse_scan = 21;
 bool ResponseUnion::has_reverse_scan() const {
-  return (_has_bits_[0] & 0x00080000u) != 0;
+  return (_has_bits_[0] & 0x00100000u) != 0;
 }
 void ResponseUnion::set_has_reverse_scan() {
-  _has_bits_[0] |= 0x00080000u;
+  _has_bits_[0] |= 0x00100000u;
 }
 void ResponseUnion::clear_has_reverse_scan() {
-  _has_bits_[0] &= ~0x00080000u;
+  _has_bits_[0] &= ~0x00100000u;
 }
 void ResponseUnion::clear_reverse_scan() {
   if (reverse_scan_ != NULL) reverse_scan_->::cockroach::roachpb::ReverseScanResponse::Clear();
@@ -21848,15 +22645,15 @@ void ResponseUnion::clear_reverse_scan() {
   // @@protoc_insertion_point(field_set_allocated:cockroach.roachpb.ResponseUnion.reverse_scan)
 }
 
-// optional .cockroach.roachpb.NoopResponse noop = 21;
+// optional .cockroach.roachpb.NoopResponse noop = 22;
 bool ResponseUnion::has_noop() const {
-  return (_has_bits_[0] & 0x00100000u) != 0;
+  return (_has_bits_[0] & 0x00200000u) != 0;
 }
 void ResponseUnion::set_has_noop() {
-  _has_bits_[0] |= 0x00100000u;
+  _has_bits_[0] |= 0x00200000u;
 }
 void ResponseUnion::clear_has_noop() {
-  _has_bits_[0] &= ~0x00100000u;
+  _has_bits_[0] &= ~0x00200000u;
 }
 void ResponseUnion::clear_noop() {
   if (noop_ != NULL) noop_->::cockroach::roachpb::NoopResponse::Clear();

--- a/storage/engine/rocksdb/cockroach/roachpb/api.pb.h
+++ b/storage/engine/rocksdb/cockroach/roachpb/api.pb.h
@@ -61,6 +61,8 @@ class ScanRequest;
 class ScanResponse;
 class ReverseScanRequest;
 class ReverseScanResponse;
+class BeginTransactionRequest;
+class BeginTransactionResponse;
 class EndTransactionRequest;
 class EndTransactionResponse;
 class AdminSplitRequest;
@@ -2035,6 +2037,188 @@ class ReverseScanResponse : public ::google::protobuf::Message {
 
   void InitAsDefaultInstance();
   static ReverseScanResponse* default_instance_;
+};
+// -------------------------------------------------------------------
+
+class BeginTransactionRequest : public ::google::protobuf::Message {
+ public:
+  BeginTransactionRequest();
+  virtual ~BeginTransactionRequest();
+
+  BeginTransactionRequest(const BeginTransactionRequest& from);
+
+  inline BeginTransactionRequest& operator=(const BeginTransactionRequest& from) {
+    CopyFrom(from);
+    return *this;
+  }
+
+  inline const ::google::protobuf::UnknownFieldSet& unknown_fields() const {
+    return _internal_metadata_.unknown_fields();
+  }
+
+  inline ::google::protobuf::UnknownFieldSet* mutable_unknown_fields() {
+    return _internal_metadata_.mutable_unknown_fields();
+  }
+
+  static const ::google::protobuf::Descriptor* descriptor();
+  static const BeginTransactionRequest& default_instance();
+
+  void Swap(BeginTransactionRequest* other);
+
+  // implements Message ----------------------------------------------
+
+  inline BeginTransactionRequest* New() const { return New(NULL); }
+
+  BeginTransactionRequest* New(::google::protobuf::Arena* arena) const;
+  void CopyFrom(const ::google::protobuf::Message& from);
+  void MergeFrom(const ::google::protobuf::Message& from);
+  void CopyFrom(const BeginTransactionRequest& from);
+  void MergeFrom(const BeginTransactionRequest& from);
+  void Clear();
+  bool IsInitialized() const;
+
+  int ByteSize() const;
+  bool MergePartialFromCodedStream(
+      ::google::protobuf::io::CodedInputStream* input);
+  void SerializeWithCachedSizes(
+      ::google::protobuf::io::CodedOutputStream* output) const;
+  ::google::protobuf::uint8* SerializeWithCachedSizesToArray(::google::protobuf::uint8* output) const;
+  int GetCachedSize() const { return _cached_size_; }
+  private:
+  void SharedCtor();
+  void SharedDtor();
+  void SetCachedSize(int size) const;
+  void InternalSwap(BeginTransactionRequest* other);
+  private:
+  inline ::google::protobuf::Arena* GetArenaNoVirtual() const {
+    return _internal_metadata_.arena();
+  }
+  inline void* MaybeArenaPtr() const {
+    return _internal_metadata_.raw_arena_ptr();
+  }
+  public:
+
+  ::google::protobuf::Metadata GetMetadata() const;
+
+  // nested types ----------------------------------------------------
+
+  // accessors -------------------------------------------------------
+
+  // optional .cockroach.roachpb.Span header = 1;
+  bool has_header() const;
+  void clear_header();
+  static const int kHeaderFieldNumber = 1;
+  const ::cockroach::roachpb::Span& header() const;
+  ::cockroach::roachpb::Span* mutable_header();
+  ::cockroach::roachpb::Span* release_header();
+  void set_allocated_header(::cockroach::roachpb::Span* header);
+
+  // @@protoc_insertion_point(class_scope:cockroach.roachpb.BeginTransactionRequest)
+ private:
+  inline void set_has_header();
+  inline void clear_has_header();
+
+  ::google::protobuf::internal::InternalMetadataWithArena _internal_metadata_;
+  ::google::protobuf::uint32 _has_bits_[1];
+  mutable int _cached_size_;
+  ::cockroach::roachpb::Span* header_;
+  friend void  protobuf_AddDesc_cockroach_2froachpb_2fapi_2eproto();
+  friend void protobuf_AssignDesc_cockroach_2froachpb_2fapi_2eproto();
+  friend void protobuf_ShutdownFile_cockroach_2froachpb_2fapi_2eproto();
+
+  void InitAsDefaultInstance();
+  static BeginTransactionRequest* default_instance_;
+};
+// -------------------------------------------------------------------
+
+class BeginTransactionResponse : public ::google::protobuf::Message {
+ public:
+  BeginTransactionResponse();
+  virtual ~BeginTransactionResponse();
+
+  BeginTransactionResponse(const BeginTransactionResponse& from);
+
+  inline BeginTransactionResponse& operator=(const BeginTransactionResponse& from) {
+    CopyFrom(from);
+    return *this;
+  }
+
+  inline const ::google::protobuf::UnknownFieldSet& unknown_fields() const {
+    return _internal_metadata_.unknown_fields();
+  }
+
+  inline ::google::protobuf::UnknownFieldSet* mutable_unknown_fields() {
+    return _internal_metadata_.mutable_unknown_fields();
+  }
+
+  static const ::google::protobuf::Descriptor* descriptor();
+  static const BeginTransactionResponse& default_instance();
+
+  void Swap(BeginTransactionResponse* other);
+
+  // implements Message ----------------------------------------------
+
+  inline BeginTransactionResponse* New() const { return New(NULL); }
+
+  BeginTransactionResponse* New(::google::protobuf::Arena* arena) const;
+  void CopyFrom(const ::google::protobuf::Message& from);
+  void MergeFrom(const ::google::protobuf::Message& from);
+  void CopyFrom(const BeginTransactionResponse& from);
+  void MergeFrom(const BeginTransactionResponse& from);
+  void Clear();
+  bool IsInitialized() const;
+
+  int ByteSize() const;
+  bool MergePartialFromCodedStream(
+      ::google::protobuf::io::CodedInputStream* input);
+  void SerializeWithCachedSizes(
+      ::google::protobuf::io::CodedOutputStream* output) const;
+  ::google::protobuf::uint8* SerializeWithCachedSizesToArray(::google::protobuf::uint8* output) const;
+  int GetCachedSize() const { return _cached_size_; }
+  private:
+  void SharedCtor();
+  void SharedDtor();
+  void SetCachedSize(int size) const;
+  void InternalSwap(BeginTransactionResponse* other);
+  private:
+  inline ::google::protobuf::Arena* GetArenaNoVirtual() const {
+    return _internal_metadata_.arena();
+  }
+  inline void* MaybeArenaPtr() const {
+    return _internal_metadata_.raw_arena_ptr();
+  }
+  public:
+
+  ::google::protobuf::Metadata GetMetadata() const;
+
+  // nested types ----------------------------------------------------
+
+  // accessors -------------------------------------------------------
+
+  // optional .cockroach.roachpb.ResponseHeader header = 1;
+  bool has_header() const;
+  void clear_header();
+  static const int kHeaderFieldNumber = 1;
+  const ::cockroach::roachpb::ResponseHeader& header() const;
+  ::cockroach::roachpb::ResponseHeader* mutable_header();
+  ::cockroach::roachpb::ResponseHeader* release_header();
+  void set_allocated_header(::cockroach::roachpb::ResponseHeader* header);
+
+  // @@protoc_insertion_point(class_scope:cockroach.roachpb.BeginTransactionResponse)
+ private:
+  inline void set_has_header();
+  inline void clear_has_header();
+
+  ::google::protobuf::internal::InternalMetadataWithArena _internal_metadata_;
+  ::google::protobuf::uint32 _has_bits_[1];
+  mutable int _cached_size_;
+  ::cockroach::roachpb::ResponseHeader* header_;
+  friend void  protobuf_AddDesc_cockroach_2froachpb_2fapi_2eproto();
+  friend void protobuf_AssignDesc_cockroach_2froachpb_2fapi_2eproto();
+  friend void protobuf_ShutdownFile_cockroach_2froachpb_2fapi_2eproto();
+
+  void InitAsDefaultInstance();
+  static BeginTransactionResponse* default_instance_;
 };
 // -------------------------------------------------------------------
 
@@ -4912,127 +5096,136 @@ class RequestUnion : public ::google::protobuf::Message {
   ::cockroach::roachpb::ScanRequest* release_scan();
   void set_allocated_scan(::cockroach::roachpb::ScanRequest* scan);
 
-  // optional .cockroach.roachpb.EndTransactionRequest end_transaction = 8;
+  // optional .cockroach.roachpb.BeginTransactionRequest begin_transaction = 8;
+  bool has_begin_transaction() const;
+  void clear_begin_transaction();
+  static const int kBeginTransactionFieldNumber = 8;
+  const ::cockroach::roachpb::BeginTransactionRequest& begin_transaction() const;
+  ::cockroach::roachpb::BeginTransactionRequest* mutable_begin_transaction();
+  ::cockroach::roachpb::BeginTransactionRequest* release_begin_transaction();
+  void set_allocated_begin_transaction(::cockroach::roachpb::BeginTransactionRequest* begin_transaction);
+
+  // optional .cockroach.roachpb.EndTransactionRequest end_transaction = 9;
   bool has_end_transaction() const;
   void clear_end_transaction();
-  static const int kEndTransactionFieldNumber = 8;
+  static const int kEndTransactionFieldNumber = 9;
   const ::cockroach::roachpb::EndTransactionRequest& end_transaction() const;
   ::cockroach::roachpb::EndTransactionRequest* mutable_end_transaction();
   ::cockroach::roachpb::EndTransactionRequest* release_end_transaction();
   void set_allocated_end_transaction(::cockroach::roachpb::EndTransactionRequest* end_transaction);
 
-  // optional .cockroach.roachpb.AdminSplitRequest admin_split = 9;
+  // optional .cockroach.roachpb.AdminSplitRequest admin_split = 10;
   bool has_admin_split() const;
   void clear_admin_split();
-  static const int kAdminSplitFieldNumber = 9;
+  static const int kAdminSplitFieldNumber = 10;
   const ::cockroach::roachpb::AdminSplitRequest& admin_split() const;
   ::cockroach::roachpb::AdminSplitRequest* mutable_admin_split();
   ::cockroach::roachpb::AdminSplitRequest* release_admin_split();
   void set_allocated_admin_split(::cockroach::roachpb::AdminSplitRequest* admin_split);
 
-  // optional .cockroach.roachpb.AdminMergeRequest admin_merge = 10;
+  // optional .cockroach.roachpb.AdminMergeRequest admin_merge = 11;
   bool has_admin_merge() const;
   void clear_admin_merge();
-  static const int kAdminMergeFieldNumber = 10;
+  static const int kAdminMergeFieldNumber = 11;
   const ::cockroach::roachpb::AdminMergeRequest& admin_merge() const;
   ::cockroach::roachpb::AdminMergeRequest* mutable_admin_merge();
   ::cockroach::roachpb::AdminMergeRequest* release_admin_merge();
   void set_allocated_admin_merge(::cockroach::roachpb::AdminMergeRequest* admin_merge);
 
-  // optional .cockroach.roachpb.HeartbeatTxnRequest heartbeat_txn = 11;
+  // optional .cockroach.roachpb.HeartbeatTxnRequest heartbeat_txn = 12;
   bool has_heartbeat_txn() const;
   void clear_heartbeat_txn();
-  static const int kHeartbeatTxnFieldNumber = 11;
+  static const int kHeartbeatTxnFieldNumber = 12;
   const ::cockroach::roachpb::HeartbeatTxnRequest& heartbeat_txn() const;
   ::cockroach::roachpb::HeartbeatTxnRequest* mutable_heartbeat_txn();
   ::cockroach::roachpb::HeartbeatTxnRequest* release_heartbeat_txn();
   void set_allocated_heartbeat_txn(::cockroach::roachpb::HeartbeatTxnRequest* heartbeat_txn);
 
-  // optional .cockroach.roachpb.GCRequest gc = 12;
+  // optional .cockroach.roachpb.GCRequest gc = 13;
   bool has_gc() const;
   void clear_gc();
-  static const int kGcFieldNumber = 12;
+  static const int kGcFieldNumber = 13;
   const ::cockroach::roachpb::GCRequest& gc() const;
   ::cockroach::roachpb::GCRequest* mutable_gc();
   ::cockroach::roachpb::GCRequest* release_gc();
   void set_allocated_gc(::cockroach::roachpb::GCRequest* gc);
 
-  // optional .cockroach.roachpb.PushTxnRequest push_txn = 13;
+  // optional .cockroach.roachpb.PushTxnRequest push_txn = 14;
   bool has_push_txn() const;
   void clear_push_txn();
-  static const int kPushTxnFieldNumber = 13;
+  static const int kPushTxnFieldNumber = 14;
   const ::cockroach::roachpb::PushTxnRequest& push_txn() const;
   ::cockroach::roachpb::PushTxnRequest* mutable_push_txn();
   ::cockroach::roachpb::PushTxnRequest* release_push_txn();
   void set_allocated_push_txn(::cockroach::roachpb::PushTxnRequest* push_txn);
 
-  // optional .cockroach.roachpb.RangeLookupRequest range_lookup = 14;
+  // optional .cockroach.roachpb.RangeLookupRequest range_lookup = 15;
   bool has_range_lookup() const;
   void clear_range_lookup();
-  static const int kRangeLookupFieldNumber = 14;
+  static const int kRangeLookupFieldNumber = 15;
   const ::cockroach::roachpb::RangeLookupRequest& range_lookup() const;
   ::cockroach::roachpb::RangeLookupRequest* mutable_range_lookup();
   ::cockroach::roachpb::RangeLookupRequest* release_range_lookup();
   void set_allocated_range_lookup(::cockroach::roachpb::RangeLookupRequest* range_lookup);
 
-  // optional .cockroach.roachpb.ResolveIntentRequest resolve_intent = 15;
+  // optional .cockroach.roachpb.ResolveIntentRequest resolve_intent = 16;
   bool has_resolve_intent() const;
   void clear_resolve_intent();
-  static const int kResolveIntentFieldNumber = 15;
+  static const int kResolveIntentFieldNumber = 16;
   const ::cockroach::roachpb::ResolveIntentRequest& resolve_intent() const;
   ::cockroach::roachpb::ResolveIntentRequest* mutable_resolve_intent();
   ::cockroach::roachpb::ResolveIntentRequest* release_resolve_intent();
   void set_allocated_resolve_intent(::cockroach::roachpb::ResolveIntentRequest* resolve_intent);
 
-  // optional .cockroach.roachpb.ResolveIntentRangeRequest resolve_intent_range = 16;
+  // optional .cockroach.roachpb.ResolveIntentRangeRequest resolve_intent_range = 17;
   bool has_resolve_intent_range() const;
   void clear_resolve_intent_range();
-  static const int kResolveIntentRangeFieldNumber = 16;
+  static const int kResolveIntentRangeFieldNumber = 17;
   const ::cockroach::roachpb::ResolveIntentRangeRequest& resolve_intent_range() const;
   ::cockroach::roachpb::ResolveIntentRangeRequest* mutable_resolve_intent_range();
   ::cockroach::roachpb::ResolveIntentRangeRequest* release_resolve_intent_range();
   void set_allocated_resolve_intent_range(::cockroach::roachpb::ResolveIntentRangeRequest* resolve_intent_range);
 
-  // optional .cockroach.roachpb.MergeRequest merge = 17;
+  // optional .cockroach.roachpb.MergeRequest merge = 18;
   bool has_merge() const;
   void clear_merge();
-  static const int kMergeFieldNumber = 17;
+  static const int kMergeFieldNumber = 18;
   const ::cockroach::roachpb::MergeRequest& merge() const;
   ::cockroach::roachpb::MergeRequest* mutable_merge();
   ::cockroach::roachpb::MergeRequest* release_merge();
   void set_allocated_merge(::cockroach::roachpb::MergeRequest* merge);
 
-  // optional .cockroach.roachpb.TruncateLogRequest truncate_log = 18;
+  // optional .cockroach.roachpb.TruncateLogRequest truncate_log = 19;
   bool has_truncate_log() const;
   void clear_truncate_log();
-  static const int kTruncateLogFieldNumber = 18;
+  static const int kTruncateLogFieldNumber = 19;
   const ::cockroach::roachpb::TruncateLogRequest& truncate_log() const;
   ::cockroach::roachpb::TruncateLogRequest* mutable_truncate_log();
   ::cockroach::roachpb::TruncateLogRequest* release_truncate_log();
   void set_allocated_truncate_log(::cockroach::roachpb::TruncateLogRequest* truncate_log);
 
-  // optional .cockroach.roachpb.LeaderLeaseRequest leader_lease = 19;
+  // optional .cockroach.roachpb.LeaderLeaseRequest leader_lease = 20;
   bool has_leader_lease() const;
   void clear_leader_lease();
-  static const int kLeaderLeaseFieldNumber = 19;
+  static const int kLeaderLeaseFieldNumber = 20;
   const ::cockroach::roachpb::LeaderLeaseRequest& leader_lease() const;
   ::cockroach::roachpb::LeaderLeaseRequest* mutable_leader_lease();
   ::cockroach::roachpb::LeaderLeaseRequest* release_leader_lease();
   void set_allocated_leader_lease(::cockroach::roachpb::LeaderLeaseRequest* leader_lease);
 
-  // optional .cockroach.roachpb.ReverseScanRequest reverse_scan = 20;
+  // optional .cockroach.roachpb.ReverseScanRequest reverse_scan = 21;
   bool has_reverse_scan() const;
   void clear_reverse_scan();
-  static const int kReverseScanFieldNumber = 20;
+  static const int kReverseScanFieldNumber = 21;
   const ::cockroach::roachpb::ReverseScanRequest& reverse_scan() const;
   ::cockroach::roachpb::ReverseScanRequest* mutable_reverse_scan();
   ::cockroach::roachpb::ReverseScanRequest* release_reverse_scan();
   void set_allocated_reverse_scan(::cockroach::roachpb::ReverseScanRequest* reverse_scan);
 
-  // optional .cockroach.roachpb.NoopRequest noop = 21;
+  // optional .cockroach.roachpb.NoopRequest noop = 22;
   bool has_noop() const;
   void clear_noop();
-  static const int kNoopFieldNumber = 21;
+  static const int kNoopFieldNumber = 22;
   const ::cockroach::roachpb::NoopRequest& noop() const;
   ::cockroach::roachpb::NoopRequest* mutable_noop();
   ::cockroach::roachpb::NoopRequest* release_noop();
@@ -5054,6 +5247,8 @@ class RequestUnion : public ::google::protobuf::Message {
   inline void clear_has_delete_range();
   inline void set_has_scan();
   inline void clear_has_scan();
+  inline void set_has_begin_transaction();
+  inline void clear_has_begin_transaction();
   inline void set_has_end_transaction();
   inline void clear_has_end_transaction();
   inline void set_has_admin_split();
@@ -5093,6 +5288,7 @@ class RequestUnion : public ::google::protobuf::Message {
   ::cockroach::roachpb::DeleteRequest* delete__;
   ::cockroach::roachpb::DeleteRangeRequest* delete_range_;
   ::cockroach::roachpb::ScanRequest* scan_;
+  ::cockroach::roachpb::BeginTransactionRequest* begin_transaction_;
   ::cockroach::roachpb::EndTransactionRequest* end_transaction_;
   ::cockroach::roachpb::AdminSplitRequest* admin_split_;
   ::cockroach::roachpb::AdminMergeRequest* admin_merge_;
@@ -5243,127 +5439,136 @@ class ResponseUnion : public ::google::protobuf::Message {
   ::cockroach::roachpb::ScanResponse* release_scan();
   void set_allocated_scan(::cockroach::roachpb::ScanResponse* scan);
 
-  // optional .cockroach.roachpb.EndTransactionResponse end_transaction = 8;
+  // optional .cockroach.roachpb.BeginTransactionResponse begin_transaction = 8;
+  bool has_begin_transaction() const;
+  void clear_begin_transaction();
+  static const int kBeginTransactionFieldNumber = 8;
+  const ::cockroach::roachpb::BeginTransactionResponse& begin_transaction() const;
+  ::cockroach::roachpb::BeginTransactionResponse* mutable_begin_transaction();
+  ::cockroach::roachpb::BeginTransactionResponse* release_begin_transaction();
+  void set_allocated_begin_transaction(::cockroach::roachpb::BeginTransactionResponse* begin_transaction);
+
+  // optional .cockroach.roachpb.EndTransactionResponse end_transaction = 9;
   bool has_end_transaction() const;
   void clear_end_transaction();
-  static const int kEndTransactionFieldNumber = 8;
+  static const int kEndTransactionFieldNumber = 9;
   const ::cockroach::roachpb::EndTransactionResponse& end_transaction() const;
   ::cockroach::roachpb::EndTransactionResponse* mutable_end_transaction();
   ::cockroach::roachpb::EndTransactionResponse* release_end_transaction();
   void set_allocated_end_transaction(::cockroach::roachpb::EndTransactionResponse* end_transaction);
 
-  // optional .cockroach.roachpb.AdminSplitResponse admin_split = 9;
+  // optional .cockroach.roachpb.AdminSplitResponse admin_split = 10;
   bool has_admin_split() const;
   void clear_admin_split();
-  static const int kAdminSplitFieldNumber = 9;
+  static const int kAdminSplitFieldNumber = 10;
   const ::cockroach::roachpb::AdminSplitResponse& admin_split() const;
   ::cockroach::roachpb::AdminSplitResponse* mutable_admin_split();
   ::cockroach::roachpb::AdminSplitResponse* release_admin_split();
   void set_allocated_admin_split(::cockroach::roachpb::AdminSplitResponse* admin_split);
 
-  // optional .cockroach.roachpb.AdminMergeResponse admin_merge = 10;
+  // optional .cockroach.roachpb.AdminMergeResponse admin_merge = 11;
   bool has_admin_merge() const;
   void clear_admin_merge();
-  static const int kAdminMergeFieldNumber = 10;
+  static const int kAdminMergeFieldNumber = 11;
   const ::cockroach::roachpb::AdminMergeResponse& admin_merge() const;
   ::cockroach::roachpb::AdminMergeResponse* mutable_admin_merge();
   ::cockroach::roachpb::AdminMergeResponse* release_admin_merge();
   void set_allocated_admin_merge(::cockroach::roachpb::AdminMergeResponse* admin_merge);
 
-  // optional .cockroach.roachpb.HeartbeatTxnResponse heartbeat_txn = 11;
+  // optional .cockroach.roachpb.HeartbeatTxnResponse heartbeat_txn = 12;
   bool has_heartbeat_txn() const;
   void clear_heartbeat_txn();
-  static const int kHeartbeatTxnFieldNumber = 11;
+  static const int kHeartbeatTxnFieldNumber = 12;
   const ::cockroach::roachpb::HeartbeatTxnResponse& heartbeat_txn() const;
   ::cockroach::roachpb::HeartbeatTxnResponse* mutable_heartbeat_txn();
   ::cockroach::roachpb::HeartbeatTxnResponse* release_heartbeat_txn();
   void set_allocated_heartbeat_txn(::cockroach::roachpb::HeartbeatTxnResponse* heartbeat_txn);
 
-  // optional .cockroach.roachpb.GCResponse gc = 12;
+  // optional .cockroach.roachpb.GCResponse gc = 13;
   bool has_gc() const;
   void clear_gc();
-  static const int kGcFieldNumber = 12;
+  static const int kGcFieldNumber = 13;
   const ::cockroach::roachpb::GCResponse& gc() const;
   ::cockroach::roachpb::GCResponse* mutable_gc();
   ::cockroach::roachpb::GCResponse* release_gc();
   void set_allocated_gc(::cockroach::roachpb::GCResponse* gc);
 
-  // optional .cockroach.roachpb.PushTxnResponse push_txn = 13;
+  // optional .cockroach.roachpb.PushTxnResponse push_txn = 14;
   bool has_push_txn() const;
   void clear_push_txn();
-  static const int kPushTxnFieldNumber = 13;
+  static const int kPushTxnFieldNumber = 14;
   const ::cockroach::roachpb::PushTxnResponse& push_txn() const;
   ::cockroach::roachpb::PushTxnResponse* mutable_push_txn();
   ::cockroach::roachpb::PushTxnResponse* release_push_txn();
   void set_allocated_push_txn(::cockroach::roachpb::PushTxnResponse* push_txn);
 
-  // optional .cockroach.roachpb.RangeLookupResponse range_lookup = 14;
+  // optional .cockroach.roachpb.RangeLookupResponse range_lookup = 15;
   bool has_range_lookup() const;
   void clear_range_lookup();
-  static const int kRangeLookupFieldNumber = 14;
+  static const int kRangeLookupFieldNumber = 15;
   const ::cockroach::roachpb::RangeLookupResponse& range_lookup() const;
   ::cockroach::roachpb::RangeLookupResponse* mutable_range_lookup();
   ::cockroach::roachpb::RangeLookupResponse* release_range_lookup();
   void set_allocated_range_lookup(::cockroach::roachpb::RangeLookupResponse* range_lookup);
 
-  // optional .cockroach.roachpb.ResolveIntentResponse resolve_intent = 15;
+  // optional .cockroach.roachpb.ResolveIntentResponse resolve_intent = 16;
   bool has_resolve_intent() const;
   void clear_resolve_intent();
-  static const int kResolveIntentFieldNumber = 15;
+  static const int kResolveIntentFieldNumber = 16;
   const ::cockroach::roachpb::ResolveIntentResponse& resolve_intent() const;
   ::cockroach::roachpb::ResolveIntentResponse* mutable_resolve_intent();
   ::cockroach::roachpb::ResolveIntentResponse* release_resolve_intent();
   void set_allocated_resolve_intent(::cockroach::roachpb::ResolveIntentResponse* resolve_intent);
 
-  // optional .cockroach.roachpb.ResolveIntentRangeResponse resolve_intent_range = 16;
+  // optional .cockroach.roachpb.ResolveIntentRangeResponse resolve_intent_range = 17;
   bool has_resolve_intent_range() const;
   void clear_resolve_intent_range();
-  static const int kResolveIntentRangeFieldNumber = 16;
+  static const int kResolveIntentRangeFieldNumber = 17;
   const ::cockroach::roachpb::ResolveIntentRangeResponse& resolve_intent_range() const;
   ::cockroach::roachpb::ResolveIntentRangeResponse* mutable_resolve_intent_range();
   ::cockroach::roachpb::ResolveIntentRangeResponse* release_resolve_intent_range();
   void set_allocated_resolve_intent_range(::cockroach::roachpb::ResolveIntentRangeResponse* resolve_intent_range);
 
-  // optional .cockroach.roachpb.MergeResponse merge = 17;
+  // optional .cockroach.roachpb.MergeResponse merge = 18;
   bool has_merge() const;
   void clear_merge();
-  static const int kMergeFieldNumber = 17;
+  static const int kMergeFieldNumber = 18;
   const ::cockroach::roachpb::MergeResponse& merge() const;
   ::cockroach::roachpb::MergeResponse* mutable_merge();
   ::cockroach::roachpb::MergeResponse* release_merge();
   void set_allocated_merge(::cockroach::roachpb::MergeResponse* merge);
 
-  // optional .cockroach.roachpb.TruncateLogResponse truncate_log = 18;
+  // optional .cockroach.roachpb.TruncateLogResponse truncate_log = 19;
   bool has_truncate_log() const;
   void clear_truncate_log();
-  static const int kTruncateLogFieldNumber = 18;
+  static const int kTruncateLogFieldNumber = 19;
   const ::cockroach::roachpb::TruncateLogResponse& truncate_log() const;
   ::cockroach::roachpb::TruncateLogResponse* mutable_truncate_log();
   ::cockroach::roachpb::TruncateLogResponse* release_truncate_log();
   void set_allocated_truncate_log(::cockroach::roachpb::TruncateLogResponse* truncate_log);
 
-  // optional .cockroach.roachpb.LeaderLeaseResponse leader_lease = 19;
+  // optional .cockroach.roachpb.LeaderLeaseResponse leader_lease = 20;
   bool has_leader_lease() const;
   void clear_leader_lease();
-  static const int kLeaderLeaseFieldNumber = 19;
+  static const int kLeaderLeaseFieldNumber = 20;
   const ::cockroach::roachpb::LeaderLeaseResponse& leader_lease() const;
   ::cockroach::roachpb::LeaderLeaseResponse* mutable_leader_lease();
   ::cockroach::roachpb::LeaderLeaseResponse* release_leader_lease();
   void set_allocated_leader_lease(::cockroach::roachpb::LeaderLeaseResponse* leader_lease);
 
-  // optional .cockroach.roachpb.ReverseScanResponse reverse_scan = 20;
+  // optional .cockroach.roachpb.ReverseScanResponse reverse_scan = 21;
   bool has_reverse_scan() const;
   void clear_reverse_scan();
-  static const int kReverseScanFieldNumber = 20;
+  static const int kReverseScanFieldNumber = 21;
   const ::cockroach::roachpb::ReverseScanResponse& reverse_scan() const;
   ::cockroach::roachpb::ReverseScanResponse* mutable_reverse_scan();
   ::cockroach::roachpb::ReverseScanResponse* release_reverse_scan();
   void set_allocated_reverse_scan(::cockroach::roachpb::ReverseScanResponse* reverse_scan);
 
-  // optional .cockroach.roachpb.NoopResponse noop = 21;
+  // optional .cockroach.roachpb.NoopResponse noop = 22;
   bool has_noop() const;
   void clear_noop();
-  static const int kNoopFieldNumber = 21;
+  static const int kNoopFieldNumber = 22;
   const ::cockroach::roachpb::NoopResponse& noop() const;
   ::cockroach::roachpb::NoopResponse* mutable_noop();
   ::cockroach::roachpb::NoopResponse* release_noop();
@@ -5385,6 +5590,8 @@ class ResponseUnion : public ::google::protobuf::Message {
   inline void clear_has_delete_range();
   inline void set_has_scan();
   inline void clear_has_scan();
+  inline void set_has_begin_transaction();
+  inline void clear_has_begin_transaction();
   inline void set_has_end_transaction();
   inline void clear_has_end_transaction();
   inline void set_has_admin_split();
@@ -5424,6 +5631,7 @@ class ResponseUnion : public ::google::protobuf::Message {
   ::cockroach::roachpb::DeleteResponse* delete__;
   ::cockroach::roachpb::DeleteRangeResponse* delete_range_;
   ::cockroach::roachpb::ScanResponse* scan_;
+  ::cockroach::roachpb::BeginTransactionResponse* begin_transaction_;
   ::cockroach::roachpb::EndTransactionResponse* end_transaction_;
   ::cockroach::roachpb::AdminSplitResponse* admin_split_;
   ::cockroach::roachpb::AdminMergeResponse* admin_merge_;
@@ -7309,6 +7517,100 @@ inline ::google::protobuf::RepeatedPtrField< ::cockroach::roachpb::KeyValue >*
 ReverseScanResponse::mutable_rows() {
   // @@protoc_insertion_point(field_mutable_list:cockroach.roachpb.ReverseScanResponse.rows)
   return &rows_;
+}
+
+// -------------------------------------------------------------------
+
+// BeginTransactionRequest
+
+// optional .cockroach.roachpb.Span header = 1;
+inline bool BeginTransactionRequest::has_header() const {
+  return (_has_bits_[0] & 0x00000001u) != 0;
+}
+inline void BeginTransactionRequest::set_has_header() {
+  _has_bits_[0] |= 0x00000001u;
+}
+inline void BeginTransactionRequest::clear_has_header() {
+  _has_bits_[0] &= ~0x00000001u;
+}
+inline void BeginTransactionRequest::clear_header() {
+  if (header_ != NULL) header_->::cockroach::roachpb::Span::Clear();
+  clear_has_header();
+}
+inline const ::cockroach::roachpb::Span& BeginTransactionRequest::header() const {
+  // @@protoc_insertion_point(field_get:cockroach.roachpb.BeginTransactionRequest.header)
+  return header_ != NULL ? *header_ : *default_instance_->header_;
+}
+inline ::cockroach::roachpb::Span* BeginTransactionRequest::mutable_header() {
+  set_has_header();
+  if (header_ == NULL) {
+    header_ = new ::cockroach::roachpb::Span;
+  }
+  // @@protoc_insertion_point(field_mutable:cockroach.roachpb.BeginTransactionRequest.header)
+  return header_;
+}
+inline ::cockroach::roachpb::Span* BeginTransactionRequest::release_header() {
+  clear_has_header();
+  ::cockroach::roachpb::Span* temp = header_;
+  header_ = NULL;
+  return temp;
+}
+inline void BeginTransactionRequest::set_allocated_header(::cockroach::roachpb::Span* header) {
+  delete header_;
+  header_ = header;
+  if (header) {
+    set_has_header();
+  } else {
+    clear_has_header();
+  }
+  // @@protoc_insertion_point(field_set_allocated:cockroach.roachpb.BeginTransactionRequest.header)
+}
+
+// -------------------------------------------------------------------
+
+// BeginTransactionResponse
+
+// optional .cockroach.roachpb.ResponseHeader header = 1;
+inline bool BeginTransactionResponse::has_header() const {
+  return (_has_bits_[0] & 0x00000001u) != 0;
+}
+inline void BeginTransactionResponse::set_has_header() {
+  _has_bits_[0] |= 0x00000001u;
+}
+inline void BeginTransactionResponse::clear_has_header() {
+  _has_bits_[0] &= ~0x00000001u;
+}
+inline void BeginTransactionResponse::clear_header() {
+  if (header_ != NULL) header_->::cockroach::roachpb::ResponseHeader::Clear();
+  clear_has_header();
+}
+inline const ::cockroach::roachpb::ResponseHeader& BeginTransactionResponse::header() const {
+  // @@protoc_insertion_point(field_get:cockroach.roachpb.BeginTransactionResponse.header)
+  return header_ != NULL ? *header_ : *default_instance_->header_;
+}
+inline ::cockroach::roachpb::ResponseHeader* BeginTransactionResponse::mutable_header() {
+  set_has_header();
+  if (header_ == NULL) {
+    header_ = new ::cockroach::roachpb::ResponseHeader;
+  }
+  // @@protoc_insertion_point(field_mutable:cockroach.roachpb.BeginTransactionResponse.header)
+  return header_;
+}
+inline ::cockroach::roachpb::ResponseHeader* BeginTransactionResponse::release_header() {
+  clear_has_header();
+  ::cockroach::roachpb::ResponseHeader* temp = header_;
+  header_ = NULL;
+  return temp;
+}
+inline void BeginTransactionResponse::set_allocated_header(::cockroach::roachpb::ResponseHeader* header) {
+  delete header_;
+  header_ = header;
+  if (header) {
+    set_has_header();
+  } else {
+    clear_has_header();
+  }
+  // @@protoc_insertion_point(field_set_allocated:cockroach.roachpb.BeginTransactionResponse.header)
 }
 
 // -------------------------------------------------------------------
@@ -9777,15 +10079,58 @@ inline void RequestUnion::set_allocated_scan(::cockroach::roachpb::ScanRequest* 
   // @@protoc_insertion_point(field_set_allocated:cockroach.roachpb.RequestUnion.scan)
 }
 
-// optional .cockroach.roachpb.EndTransactionRequest end_transaction = 8;
-inline bool RequestUnion::has_end_transaction() const {
+// optional .cockroach.roachpb.BeginTransactionRequest begin_transaction = 8;
+inline bool RequestUnion::has_begin_transaction() const {
   return (_has_bits_[0] & 0x00000080u) != 0;
 }
-inline void RequestUnion::set_has_end_transaction() {
+inline void RequestUnion::set_has_begin_transaction() {
   _has_bits_[0] |= 0x00000080u;
 }
-inline void RequestUnion::clear_has_end_transaction() {
+inline void RequestUnion::clear_has_begin_transaction() {
   _has_bits_[0] &= ~0x00000080u;
+}
+inline void RequestUnion::clear_begin_transaction() {
+  if (begin_transaction_ != NULL) begin_transaction_->::cockroach::roachpb::BeginTransactionRequest::Clear();
+  clear_has_begin_transaction();
+}
+inline const ::cockroach::roachpb::BeginTransactionRequest& RequestUnion::begin_transaction() const {
+  // @@protoc_insertion_point(field_get:cockroach.roachpb.RequestUnion.begin_transaction)
+  return begin_transaction_ != NULL ? *begin_transaction_ : *default_instance_->begin_transaction_;
+}
+inline ::cockroach::roachpb::BeginTransactionRequest* RequestUnion::mutable_begin_transaction() {
+  set_has_begin_transaction();
+  if (begin_transaction_ == NULL) {
+    begin_transaction_ = new ::cockroach::roachpb::BeginTransactionRequest;
+  }
+  // @@protoc_insertion_point(field_mutable:cockroach.roachpb.RequestUnion.begin_transaction)
+  return begin_transaction_;
+}
+inline ::cockroach::roachpb::BeginTransactionRequest* RequestUnion::release_begin_transaction() {
+  clear_has_begin_transaction();
+  ::cockroach::roachpb::BeginTransactionRequest* temp = begin_transaction_;
+  begin_transaction_ = NULL;
+  return temp;
+}
+inline void RequestUnion::set_allocated_begin_transaction(::cockroach::roachpb::BeginTransactionRequest* begin_transaction) {
+  delete begin_transaction_;
+  begin_transaction_ = begin_transaction;
+  if (begin_transaction) {
+    set_has_begin_transaction();
+  } else {
+    clear_has_begin_transaction();
+  }
+  // @@protoc_insertion_point(field_set_allocated:cockroach.roachpb.RequestUnion.begin_transaction)
+}
+
+// optional .cockroach.roachpb.EndTransactionRequest end_transaction = 9;
+inline bool RequestUnion::has_end_transaction() const {
+  return (_has_bits_[0] & 0x00000100u) != 0;
+}
+inline void RequestUnion::set_has_end_transaction() {
+  _has_bits_[0] |= 0x00000100u;
+}
+inline void RequestUnion::clear_has_end_transaction() {
+  _has_bits_[0] &= ~0x00000100u;
 }
 inline void RequestUnion::clear_end_transaction() {
   if (end_transaction_ != NULL) end_transaction_->::cockroach::roachpb::EndTransactionRequest::Clear();
@@ -9820,15 +10165,15 @@ inline void RequestUnion::set_allocated_end_transaction(::cockroach::roachpb::En
   // @@protoc_insertion_point(field_set_allocated:cockroach.roachpb.RequestUnion.end_transaction)
 }
 
-// optional .cockroach.roachpb.AdminSplitRequest admin_split = 9;
+// optional .cockroach.roachpb.AdminSplitRequest admin_split = 10;
 inline bool RequestUnion::has_admin_split() const {
-  return (_has_bits_[0] & 0x00000100u) != 0;
+  return (_has_bits_[0] & 0x00000200u) != 0;
 }
 inline void RequestUnion::set_has_admin_split() {
-  _has_bits_[0] |= 0x00000100u;
+  _has_bits_[0] |= 0x00000200u;
 }
 inline void RequestUnion::clear_has_admin_split() {
-  _has_bits_[0] &= ~0x00000100u;
+  _has_bits_[0] &= ~0x00000200u;
 }
 inline void RequestUnion::clear_admin_split() {
   if (admin_split_ != NULL) admin_split_->::cockroach::roachpb::AdminSplitRequest::Clear();
@@ -9863,15 +10208,15 @@ inline void RequestUnion::set_allocated_admin_split(::cockroach::roachpb::AdminS
   // @@protoc_insertion_point(field_set_allocated:cockroach.roachpb.RequestUnion.admin_split)
 }
 
-// optional .cockroach.roachpb.AdminMergeRequest admin_merge = 10;
+// optional .cockroach.roachpb.AdminMergeRequest admin_merge = 11;
 inline bool RequestUnion::has_admin_merge() const {
-  return (_has_bits_[0] & 0x00000200u) != 0;
+  return (_has_bits_[0] & 0x00000400u) != 0;
 }
 inline void RequestUnion::set_has_admin_merge() {
-  _has_bits_[0] |= 0x00000200u;
+  _has_bits_[0] |= 0x00000400u;
 }
 inline void RequestUnion::clear_has_admin_merge() {
-  _has_bits_[0] &= ~0x00000200u;
+  _has_bits_[0] &= ~0x00000400u;
 }
 inline void RequestUnion::clear_admin_merge() {
   if (admin_merge_ != NULL) admin_merge_->::cockroach::roachpb::AdminMergeRequest::Clear();
@@ -9906,15 +10251,15 @@ inline void RequestUnion::set_allocated_admin_merge(::cockroach::roachpb::AdminM
   // @@protoc_insertion_point(field_set_allocated:cockroach.roachpb.RequestUnion.admin_merge)
 }
 
-// optional .cockroach.roachpb.HeartbeatTxnRequest heartbeat_txn = 11;
+// optional .cockroach.roachpb.HeartbeatTxnRequest heartbeat_txn = 12;
 inline bool RequestUnion::has_heartbeat_txn() const {
-  return (_has_bits_[0] & 0x00000400u) != 0;
+  return (_has_bits_[0] & 0x00000800u) != 0;
 }
 inline void RequestUnion::set_has_heartbeat_txn() {
-  _has_bits_[0] |= 0x00000400u;
+  _has_bits_[0] |= 0x00000800u;
 }
 inline void RequestUnion::clear_has_heartbeat_txn() {
-  _has_bits_[0] &= ~0x00000400u;
+  _has_bits_[0] &= ~0x00000800u;
 }
 inline void RequestUnion::clear_heartbeat_txn() {
   if (heartbeat_txn_ != NULL) heartbeat_txn_->::cockroach::roachpb::HeartbeatTxnRequest::Clear();
@@ -9949,15 +10294,15 @@ inline void RequestUnion::set_allocated_heartbeat_txn(::cockroach::roachpb::Hear
   // @@protoc_insertion_point(field_set_allocated:cockroach.roachpb.RequestUnion.heartbeat_txn)
 }
 
-// optional .cockroach.roachpb.GCRequest gc = 12;
+// optional .cockroach.roachpb.GCRequest gc = 13;
 inline bool RequestUnion::has_gc() const {
-  return (_has_bits_[0] & 0x00000800u) != 0;
+  return (_has_bits_[0] & 0x00001000u) != 0;
 }
 inline void RequestUnion::set_has_gc() {
-  _has_bits_[0] |= 0x00000800u;
+  _has_bits_[0] |= 0x00001000u;
 }
 inline void RequestUnion::clear_has_gc() {
-  _has_bits_[0] &= ~0x00000800u;
+  _has_bits_[0] &= ~0x00001000u;
 }
 inline void RequestUnion::clear_gc() {
   if (gc_ != NULL) gc_->::cockroach::roachpb::GCRequest::Clear();
@@ -9992,15 +10337,15 @@ inline void RequestUnion::set_allocated_gc(::cockroach::roachpb::GCRequest* gc) 
   // @@protoc_insertion_point(field_set_allocated:cockroach.roachpb.RequestUnion.gc)
 }
 
-// optional .cockroach.roachpb.PushTxnRequest push_txn = 13;
+// optional .cockroach.roachpb.PushTxnRequest push_txn = 14;
 inline bool RequestUnion::has_push_txn() const {
-  return (_has_bits_[0] & 0x00001000u) != 0;
+  return (_has_bits_[0] & 0x00002000u) != 0;
 }
 inline void RequestUnion::set_has_push_txn() {
-  _has_bits_[0] |= 0x00001000u;
+  _has_bits_[0] |= 0x00002000u;
 }
 inline void RequestUnion::clear_has_push_txn() {
-  _has_bits_[0] &= ~0x00001000u;
+  _has_bits_[0] &= ~0x00002000u;
 }
 inline void RequestUnion::clear_push_txn() {
   if (push_txn_ != NULL) push_txn_->::cockroach::roachpb::PushTxnRequest::Clear();
@@ -10035,15 +10380,15 @@ inline void RequestUnion::set_allocated_push_txn(::cockroach::roachpb::PushTxnRe
   // @@protoc_insertion_point(field_set_allocated:cockroach.roachpb.RequestUnion.push_txn)
 }
 
-// optional .cockroach.roachpb.RangeLookupRequest range_lookup = 14;
+// optional .cockroach.roachpb.RangeLookupRequest range_lookup = 15;
 inline bool RequestUnion::has_range_lookup() const {
-  return (_has_bits_[0] & 0x00002000u) != 0;
+  return (_has_bits_[0] & 0x00004000u) != 0;
 }
 inline void RequestUnion::set_has_range_lookup() {
-  _has_bits_[0] |= 0x00002000u;
+  _has_bits_[0] |= 0x00004000u;
 }
 inline void RequestUnion::clear_has_range_lookup() {
-  _has_bits_[0] &= ~0x00002000u;
+  _has_bits_[0] &= ~0x00004000u;
 }
 inline void RequestUnion::clear_range_lookup() {
   if (range_lookup_ != NULL) range_lookup_->::cockroach::roachpb::RangeLookupRequest::Clear();
@@ -10078,15 +10423,15 @@ inline void RequestUnion::set_allocated_range_lookup(::cockroach::roachpb::Range
   // @@protoc_insertion_point(field_set_allocated:cockroach.roachpb.RequestUnion.range_lookup)
 }
 
-// optional .cockroach.roachpb.ResolveIntentRequest resolve_intent = 15;
+// optional .cockroach.roachpb.ResolveIntentRequest resolve_intent = 16;
 inline bool RequestUnion::has_resolve_intent() const {
-  return (_has_bits_[0] & 0x00004000u) != 0;
+  return (_has_bits_[0] & 0x00008000u) != 0;
 }
 inline void RequestUnion::set_has_resolve_intent() {
-  _has_bits_[0] |= 0x00004000u;
+  _has_bits_[0] |= 0x00008000u;
 }
 inline void RequestUnion::clear_has_resolve_intent() {
-  _has_bits_[0] &= ~0x00004000u;
+  _has_bits_[0] &= ~0x00008000u;
 }
 inline void RequestUnion::clear_resolve_intent() {
   if (resolve_intent_ != NULL) resolve_intent_->::cockroach::roachpb::ResolveIntentRequest::Clear();
@@ -10121,15 +10466,15 @@ inline void RequestUnion::set_allocated_resolve_intent(::cockroach::roachpb::Res
   // @@protoc_insertion_point(field_set_allocated:cockroach.roachpb.RequestUnion.resolve_intent)
 }
 
-// optional .cockroach.roachpb.ResolveIntentRangeRequest resolve_intent_range = 16;
+// optional .cockroach.roachpb.ResolveIntentRangeRequest resolve_intent_range = 17;
 inline bool RequestUnion::has_resolve_intent_range() const {
-  return (_has_bits_[0] & 0x00008000u) != 0;
+  return (_has_bits_[0] & 0x00010000u) != 0;
 }
 inline void RequestUnion::set_has_resolve_intent_range() {
-  _has_bits_[0] |= 0x00008000u;
+  _has_bits_[0] |= 0x00010000u;
 }
 inline void RequestUnion::clear_has_resolve_intent_range() {
-  _has_bits_[0] &= ~0x00008000u;
+  _has_bits_[0] &= ~0x00010000u;
 }
 inline void RequestUnion::clear_resolve_intent_range() {
   if (resolve_intent_range_ != NULL) resolve_intent_range_->::cockroach::roachpb::ResolveIntentRangeRequest::Clear();
@@ -10164,15 +10509,15 @@ inline void RequestUnion::set_allocated_resolve_intent_range(::cockroach::roachp
   // @@protoc_insertion_point(field_set_allocated:cockroach.roachpb.RequestUnion.resolve_intent_range)
 }
 
-// optional .cockroach.roachpb.MergeRequest merge = 17;
+// optional .cockroach.roachpb.MergeRequest merge = 18;
 inline bool RequestUnion::has_merge() const {
-  return (_has_bits_[0] & 0x00010000u) != 0;
+  return (_has_bits_[0] & 0x00020000u) != 0;
 }
 inline void RequestUnion::set_has_merge() {
-  _has_bits_[0] |= 0x00010000u;
+  _has_bits_[0] |= 0x00020000u;
 }
 inline void RequestUnion::clear_has_merge() {
-  _has_bits_[0] &= ~0x00010000u;
+  _has_bits_[0] &= ~0x00020000u;
 }
 inline void RequestUnion::clear_merge() {
   if (merge_ != NULL) merge_->::cockroach::roachpb::MergeRequest::Clear();
@@ -10207,15 +10552,15 @@ inline void RequestUnion::set_allocated_merge(::cockroach::roachpb::MergeRequest
   // @@protoc_insertion_point(field_set_allocated:cockroach.roachpb.RequestUnion.merge)
 }
 
-// optional .cockroach.roachpb.TruncateLogRequest truncate_log = 18;
+// optional .cockroach.roachpb.TruncateLogRequest truncate_log = 19;
 inline bool RequestUnion::has_truncate_log() const {
-  return (_has_bits_[0] & 0x00020000u) != 0;
+  return (_has_bits_[0] & 0x00040000u) != 0;
 }
 inline void RequestUnion::set_has_truncate_log() {
-  _has_bits_[0] |= 0x00020000u;
+  _has_bits_[0] |= 0x00040000u;
 }
 inline void RequestUnion::clear_has_truncate_log() {
-  _has_bits_[0] &= ~0x00020000u;
+  _has_bits_[0] &= ~0x00040000u;
 }
 inline void RequestUnion::clear_truncate_log() {
   if (truncate_log_ != NULL) truncate_log_->::cockroach::roachpb::TruncateLogRequest::Clear();
@@ -10250,15 +10595,15 @@ inline void RequestUnion::set_allocated_truncate_log(::cockroach::roachpb::Trunc
   // @@protoc_insertion_point(field_set_allocated:cockroach.roachpb.RequestUnion.truncate_log)
 }
 
-// optional .cockroach.roachpb.LeaderLeaseRequest leader_lease = 19;
+// optional .cockroach.roachpb.LeaderLeaseRequest leader_lease = 20;
 inline bool RequestUnion::has_leader_lease() const {
-  return (_has_bits_[0] & 0x00040000u) != 0;
+  return (_has_bits_[0] & 0x00080000u) != 0;
 }
 inline void RequestUnion::set_has_leader_lease() {
-  _has_bits_[0] |= 0x00040000u;
+  _has_bits_[0] |= 0x00080000u;
 }
 inline void RequestUnion::clear_has_leader_lease() {
-  _has_bits_[0] &= ~0x00040000u;
+  _has_bits_[0] &= ~0x00080000u;
 }
 inline void RequestUnion::clear_leader_lease() {
   if (leader_lease_ != NULL) leader_lease_->::cockroach::roachpb::LeaderLeaseRequest::Clear();
@@ -10293,15 +10638,15 @@ inline void RequestUnion::set_allocated_leader_lease(::cockroach::roachpb::Leade
   // @@protoc_insertion_point(field_set_allocated:cockroach.roachpb.RequestUnion.leader_lease)
 }
 
-// optional .cockroach.roachpb.ReverseScanRequest reverse_scan = 20;
+// optional .cockroach.roachpb.ReverseScanRequest reverse_scan = 21;
 inline bool RequestUnion::has_reverse_scan() const {
-  return (_has_bits_[0] & 0x00080000u) != 0;
+  return (_has_bits_[0] & 0x00100000u) != 0;
 }
 inline void RequestUnion::set_has_reverse_scan() {
-  _has_bits_[0] |= 0x00080000u;
+  _has_bits_[0] |= 0x00100000u;
 }
 inline void RequestUnion::clear_has_reverse_scan() {
-  _has_bits_[0] &= ~0x00080000u;
+  _has_bits_[0] &= ~0x00100000u;
 }
 inline void RequestUnion::clear_reverse_scan() {
   if (reverse_scan_ != NULL) reverse_scan_->::cockroach::roachpb::ReverseScanRequest::Clear();
@@ -10336,15 +10681,15 @@ inline void RequestUnion::set_allocated_reverse_scan(::cockroach::roachpb::Rever
   // @@protoc_insertion_point(field_set_allocated:cockroach.roachpb.RequestUnion.reverse_scan)
 }
 
-// optional .cockroach.roachpb.NoopRequest noop = 21;
+// optional .cockroach.roachpb.NoopRequest noop = 22;
 inline bool RequestUnion::has_noop() const {
-  return (_has_bits_[0] & 0x00100000u) != 0;
+  return (_has_bits_[0] & 0x00200000u) != 0;
 }
 inline void RequestUnion::set_has_noop() {
-  _has_bits_[0] |= 0x00100000u;
+  _has_bits_[0] |= 0x00200000u;
 }
 inline void RequestUnion::clear_has_noop() {
-  _has_bits_[0] &= ~0x00100000u;
+  _has_bits_[0] &= ~0x00200000u;
 }
 inline void RequestUnion::clear_noop() {
   if (noop_ != NULL) noop_->::cockroach::roachpb::NoopRequest::Clear();
@@ -10684,15 +11029,58 @@ inline void ResponseUnion::set_allocated_scan(::cockroach::roachpb::ScanResponse
   // @@protoc_insertion_point(field_set_allocated:cockroach.roachpb.ResponseUnion.scan)
 }
 
-// optional .cockroach.roachpb.EndTransactionResponse end_transaction = 8;
-inline bool ResponseUnion::has_end_transaction() const {
+// optional .cockroach.roachpb.BeginTransactionResponse begin_transaction = 8;
+inline bool ResponseUnion::has_begin_transaction() const {
   return (_has_bits_[0] & 0x00000080u) != 0;
 }
-inline void ResponseUnion::set_has_end_transaction() {
+inline void ResponseUnion::set_has_begin_transaction() {
   _has_bits_[0] |= 0x00000080u;
 }
-inline void ResponseUnion::clear_has_end_transaction() {
+inline void ResponseUnion::clear_has_begin_transaction() {
   _has_bits_[0] &= ~0x00000080u;
+}
+inline void ResponseUnion::clear_begin_transaction() {
+  if (begin_transaction_ != NULL) begin_transaction_->::cockroach::roachpb::BeginTransactionResponse::Clear();
+  clear_has_begin_transaction();
+}
+inline const ::cockroach::roachpb::BeginTransactionResponse& ResponseUnion::begin_transaction() const {
+  // @@protoc_insertion_point(field_get:cockroach.roachpb.ResponseUnion.begin_transaction)
+  return begin_transaction_ != NULL ? *begin_transaction_ : *default_instance_->begin_transaction_;
+}
+inline ::cockroach::roachpb::BeginTransactionResponse* ResponseUnion::mutable_begin_transaction() {
+  set_has_begin_transaction();
+  if (begin_transaction_ == NULL) {
+    begin_transaction_ = new ::cockroach::roachpb::BeginTransactionResponse;
+  }
+  // @@protoc_insertion_point(field_mutable:cockroach.roachpb.ResponseUnion.begin_transaction)
+  return begin_transaction_;
+}
+inline ::cockroach::roachpb::BeginTransactionResponse* ResponseUnion::release_begin_transaction() {
+  clear_has_begin_transaction();
+  ::cockroach::roachpb::BeginTransactionResponse* temp = begin_transaction_;
+  begin_transaction_ = NULL;
+  return temp;
+}
+inline void ResponseUnion::set_allocated_begin_transaction(::cockroach::roachpb::BeginTransactionResponse* begin_transaction) {
+  delete begin_transaction_;
+  begin_transaction_ = begin_transaction;
+  if (begin_transaction) {
+    set_has_begin_transaction();
+  } else {
+    clear_has_begin_transaction();
+  }
+  // @@protoc_insertion_point(field_set_allocated:cockroach.roachpb.ResponseUnion.begin_transaction)
+}
+
+// optional .cockroach.roachpb.EndTransactionResponse end_transaction = 9;
+inline bool ResponseUnion::has_end_transaction() const {
+  return (_has_bits_[0] & 0x00000100u) != 0;
+}
+inline void ResponseUnion::set_has_end_transaction() {
+  _has_bits_[0] |= 0x00000100u;
+}
+inline void ResponseUnion::clear_has_end_transaction() {
+  _has_bits_[0] &= ~0x00000100u;
 }
 inline void ResponseUnion::clear_end_transaction() {
   if (end_transaction_ != NULL) end_transaction_->::cockroach::roachpb::EndTransactionResponse::Clear();
@@ -10727,15 +11115,15 @@ inline void ResponseUnion::set_allocated_end_transaction(::cockroach::roachpb::E
   // @@protoc_insertion_point(field_set_allocated:cockroach.roachpb.ResponseUnion.end_transaction)
 }
 
-// optional .cockroach.roachpb.AdminSplitResponse admin_split = 9;
+// optional .cockroach.roachpb.AdminSplitResponse admin_split = 10;
 inline bool ResponseUnion::has_admin_split() const {
-  return (_has_bits_[0] & 0x00000100u) != 0;
+  return (_has_bits_[0] & 0x00000200u) != 0;
 }
 inline void ResponseUnion::set_has_admin_split() {
-  _has_bits_[0] |= 0x00000100u;
+  _has_bits_[0] |= 0x00000200u;
 }
 inline void ResponseUnion::clear_has_admin_split() {
-  _has_bits_[0] &= ~0x00000100u;
+  _has_bits_[0] &= ~0x00000200u;
 }
 inline void ResponseUnion::clear_admin_split() {
   if (admin_split_ != NULL) admin_split_->::cockroach::roachpb::AdminSplitResponse::Clear();
@@ -10770,15 +11158,15 @@ inline void ResponseUnion::set_allocated_admin_split(::cockroach::roachpb::Admin
   // @@protoc_insertion_point(field_set_allocated:cockroach.roachpb.ResponseUnion.admin_split)
 }
 
-// optional .cockroach.roachpb.AdminMergeResponse admin_merge = 10;
+// optional .cockroach.roachpb.AdminMergeResponse admin_merge = 11;
 inline bool ResponseUnion::has_admin_merge() const {
-  return (_has_bits_[0] & 0x00000200u) != 0;
+  return (_has_bits_[0] & 0x00000400u) != 0;
 }
 inline void ResponseUnion::set_has_admin_merge() {
-  _has_bits_[0] |= 0x00000200u;
+  _has_bits_[0] |= 0x00000400u;
 }
 inline void ResponseUnion::clear_has_admin_merge() {
-  _has_bits_[0] &= ~0x00000200u;
+  _has_bits_[0] &= ~0x00000400u;
 }
 inline void ResponseUnion::clear_admin_merge() {
   if (admin_merge_ != NULL) admin_merge_->::cockroach::roachpb::AdminMergeResponse::Clear();
@@ -10813,15 +11201,15 @@ inline void ResponseUnion::set_allocated_admin_merge(::cockroach::roachpb::Admin
   // @@protoc_insertion_point(field_set_allocated:cockroach.roachpb.ResponseUnion.admin_merge)
 }
 
-// optional .cockroach.roachpb.HeartbeatTxnResponse heartbeat_txn = 11;
+// optional .cockroach.roachpb.HeartbeatTxnResponse heartbeat_txn = 12;
 inline bool ResponseUnion::has_heartbeat_txn() const {
-  return (_has_bits_[0] & 0x00000400u) != 0;
+  return (_has_bits_[0] & 0x00000800u) != 0;
 }
 inline void ResponseUnion::set_has_heartbeat_txn() {
-  _has_bits_[0] |= 0x00000400u;
+  _has_bits_[0] |= 0x00000800u;
 }
 inline void ResponseUnion::clear_has_heartbeat_txn() {
-  _has_bits_[0] &= ~0x00000400u;
+  _has_bits_[0] &= ~0x00000800u;
 }
 inline void ResponseUnion::clear_heartbeat_txn() {
   if (heartbeat_txn_ != NULL) heartbeat_txn_->::cockroach::roachpb::HeartbeatTxnResponse::Clear();
@@ -10856,15 +11244,15 @@ inline void ResponseUnion::set_allocated_heartbeat_txn(::cockroach::roachpb::Hea
   // @@protoc_insertion_point(field_set_allocated:cockroach.roachpb.ResponseUnion.heartbeat_txn)
 }
 
-// optional .cockroach.roachpb.GCResponse gc = 12;
+// optional .cockroach.roachpb.GCResponse gc = 13;
 inline bool ResponseUnion::has_gc() const {
-  return (_has_bits_[0] & 0x00000800u) != 0;
+  return (_has_bits_[0] & 0x00001000u) != 0;
 }
 inline void ResponseUnion::set_has_gc() {
-  _has_bits_[0] |= 0x00000800u;
+  _has_bits_[0] |= 0x00001000u;
 }
 inline void ResponseUnion::clear_has_gc() {
-  _has_bits_[0] &= ~0x00000800u;
+  _has_bits_[0] &= ~0x00001000u;
 }
 inline void ResponseUnion::clear_gc() {
   if (gc_ != NULL) gc_->::cockroach::roachpb::GCResponse::Clear();
@@ -10899,15 +11287,15 @@ inline void ResponseUnion::set_allocated_gc(::cockroach::roachpb::GCResponse* gc
   // @@protoc_insertion_point(field_set_allocated:cockroach.roachpb.ResponseUnion.gc)
 }
 
-// optional .cockroach.roachpb.PushTxnResponse push_txn = 13;
+// optional .cockroach.roachpb.PushTxnResponse push_txn = 14;
 inline bool ResponseUnion::has_push_txn() const {
-  return (_has_bits_[0] & 0x00001000u) != 0;
+  return (_has_bits_[0] & 0x00002000u) != 0;
 }
 inline void ResponseUnion::set_has_push_txn() {
-  _has_bits_[0] |= 0x00001000u;
+  _has_bits_[0] |= 0x00002000u;
 }
 inline void ResponseUnion::clear_has_push_txn() {
-  _has_bits_[0] &= ~0x00001000u;
+  _has_bits_[0] &= ~0x00002000u;
 }
 inline void ResponseUnion::clear_push_txn() {
   if (push_txn_ != NULL) push_txn_->::cockroach::roachpb::PushTxnResponse::Clear();
@@ -10942,15 +11330,15 @@ inline void ResponseUnion::set_allocated_push_txn(::cockroach::roachpb::PushTxnR
   // @@protoc_insertion_point(field_set_allocated:cockroach.roachpb.ResponseUnion.push_txn)
 }
 
-// optional .cockroach.roachpb.RangeLookupResponse range_lookup = 14;
+// optional .cockroach.roachpb.RangeLookupResponse range_lookup = 15;
 inline bool ResponseUnion::has_range_lookup() const {
-  return (_has_bits_[0] & 0x00002000u) != 0;
+  return (_has_bits_[0] & 0x00004000u) != 0;
 }
 inline void ResponseUnion::set_has_range_lookup() {
-  _has_bits_[0] |= 0x00002000u;
+  _has_bits_[0] |= 0x00004000u;
 }
 inline void ResponseUnion::clear_has_range_lookup() {
-  _has_bits_[0] &= ~0x00002000u;
+  _has_bits_[0] &= ~0x00004000u;
 }
 inline void ResponseUnion::clear_range_lookup() {
   if (range_lookup_ != NULL) range_lookup_->::cockroach::roachpb::RangeLookupResponse::Clear();
@@ -10985,15 +11373,15 @@ inline void ResponseUnion::set_allocated_range_lookup(::cockroach::roachpb::Rang
   // @@protoc_insertion_point(field_set_allocated:cockroach.roachpb.ResponseUnion.range_lookup)
 }
 
-// optional .cockroach.roachpb.ResolveIntentResponse resolve_intent = 15;
+// optional .cockroach.roachpb.ResolveIntentResponse resolve_intent = 16;
 inline bool ResponseUnion::has_resolve_intent() const {
-  return (_has_bits_[0] & 0x00004000u) != 0;
+  return (_has_bits_[0] & 0x00008000u) != 0;
 }
 inline void ResponseUnion::set_has_resolve_intent() {
-  _has_bits_[0] |= 0x00004000u;
+  _has_bits_[0] |= 0x00008000u;
 }
 inline void ResponseUnion::clear_has_resolve_intent() {
-  _has_bits_[0] &= ~0x00004000u;
+  _has_bits_[0] &= ~0x00008000u;
 }
 inline void ResponseUnion::clear_resolve_intent() {
   if (resolve_intent_ != NULL) resolve_intent_->::cockroach::roachpb::ResolveIntentResponse::Clear();
@@ -11028,15 +11416,15 @@ inline void ResponseUnion::set_allocated_resolve_intent(::cockroach::roachpb::Re
   // @@protoc_insertion_point(field_set_allocated:cockroach.roachpb.ResponseUnion.resolve_intent)
 }
 
-// optional .cockroach.roachpb.ResolveIntentRangeResponse resolve_intent_range = 16;
+// optional .cockroach.roachpb.ResolveIntentRangeResponse resolve_intent_range = 17;
 inline bool ResponseUnion::has_resolve_intent_range() const {
-  return (_has_bits_[0] & 0x00008000u) != 0;
+  return (_has_bits_[0] & 0x00010000u) != 0;
 }
 inline void ResponseUnion::set_has_resolve_intent_range() {
-  _has_bits_[0] |= 0x00008000u;
+  _has_bits_[0] |= 0x00010000u;
 }
 inline void ResponseUnion::clear_has_resolve_intent_range() {
-  _has_bits_[0] &= ~0x00008000u;
+  _has_bits_[0] &= ~0x00010000u;
 }
 inline void ResponseUnion::clear_resolve_intent_range() {
   if (resolve_intent_range_ != NULL) resolve_intent_range_->::cockroach::roachpb::ResolveIntentRangeResponse::Clear();
@@ -11071,15 +11459,15 @@ inline void ResponseUnion::set_allocated_resolve_intent_range(::cockroach::roach
   // @@protoc_insertion_point(field_set_allocated:cockroach.roachpb.ResponseUnion.resolve_intent_range)
 }
 
-// optional .cockroach.roachpb.MergeResponse merge = 17;
+// optional .cockroach.roachpb.MergeResponse merge = 18;
 inline bool ResponseUnion::has_merge() const {
-  return (_has_bits_[0] & 0x00010000u) != 0;
+  return (_has_bits_[0] & 0x00020000u) != 0;
 }
 inline void ResponseUnion::set_has_merge() {
-  _has_bits_[0] |= 0x00010000u;
+  _has_bits_[0] |= 0x00020000u;
 }
 inline void ResponseUnion::clear_has_merge() {
-  _has_bits_[0] &= ~0x00010000u;
+  _has_bits_[0] &= ~0x00020000u;
 }
 inline void ResponseUnion::clear_merge() {
   if (merge_ != NULL) merge_->::cockroach::roachpb::MergeResponse::Clear();
@@ -11114,15 +11502,15 @@ inline void ResponseUnion::set_allocated_merge(::cockroach::roachpb::MergeRespon
   // @@protoc_insertion_point(field_set_allocated:cockroach.roachpb.ResponseUnion.merge)
 }
 
-// optional .cockroach.roachpb.TruncateLogResponse truncate_log = 18;
+// optional .cockroach.roachpb.TruncateLogResponse truncate_log = 19;
 inline bool ResponseUnion::has_truncate_log() const {
-  return (_has_bits_[0] & 0x00020000u) != 0;
+  return (_has_bits_[0] & 0x00040000u) != 0;
 }
 inline void ResponseUnion::set_has_truncate_log() {
-  _has_bits_[0] |= 0x00020000u;
+  _has_bits_[0] |= 0x00040000u;
 }
 inline void ResponseUnion::clear_has_truncate_log() {
-  _has_bits_[0] &= ~0x00020000u;
+  _has_bits_[0] &= ~0x00040000u;
 }
 inline void ResponseUnion::clear_truncate_log() {
   if (truncate_log_ != NULL) truncate_log_->::cockroach::roachpb::TruncateLogResponse::Clear();
@@ -11157,15 +11545,15 @@ inline void ResponseUnion::set_allocated_truncate_log(::cockroach::roachpb::Trun
   // @@protoc_insertion_point(field_set_allocated:cockroach.roachpb.ResponseUnion.truncate_log)
 }
 
-// optional .cockroach.roachpb.LeaderLeaseResponse leader_lease = 19;
+// optional .cockroach.roachpb.LeaderLeaseResponse leader_lease = 20;
 inline bool ResponseUnion::has_leader_lease() const {
-  return (_has_bits_[0] & 0x00040000u) != 0;
+  return (_has_bits_[0] & 0x00080000u) != 0;
 }
 inline void ResponseUnion::set_has_leader_lease() {
-  _has_bits_[0] |= 0x00040000u;
+  _has_bits_[0] |= 0x00080000u;
 }
 inline void ResponseUnion::clear_has_leader_lease() {
-  _has_bits_[0] &= ~0x00040000u;
+  _has_bits_[0] &= ~0x00080000u;
 }
 inline void ResponseUnion::clear_leader_lease() {
   if (leader_lease_ != NULL) leader_lease_->::cockroach::roachpb::LeaderLeaseResponse::Clear();
@@ -11200,15 +11588,15 @@ inline void ResponseUnion::set_allocated_leader_lease(::cockroach::roachpb::Lead
   // @@protoc_insertion_point(field_set_allocated:cockroach.roachpb.ResponseUnion.leader_lease)
 }
 
-// optional .cockroach.roachpb.ReverseScanResponse reverse_scan = 20;
+// optional .cockroach.roachpb.ReverseScanResponse reverse_scan = 21;
 inline bool ResponseUnion::has_reverse_scan() const {
-  return (_has_bits_[0] & 0x00080000u) != 0;
+  return (_has_bits_[0] & 0x00100000u) != 0;
 }
 inline void ResponseUnion::set_has_reverse_scan() {
-  _has_bits_[0] |= 0x00080000u;
+  _has_bits_[0] |= 0x00100000u;
 }
 inline void ResponseUnion::clear_has_reverse_scan() {
-  _has_bits_[0] &= ~0x00080000u;
+  _has_bits_[0] &= ~0x00100000u;
 }
 inline void ResponseUnion::clear_reverse_scan() {
   if (reverse_scan_ != NULL) reverse_scan_->::cockroach::roachpb::ReverseScanResponse::Clear();
@@ -11243,15 +11631,15 @@ inline void ResponseUnion::set_allocated_reverse_scan(::cockroach::roachpb::Reve
   // @@protoc_insertion_point(field_set_allocated:cockroach.roachpb.ResponseUnion.reverse_scan)
 }
 
-// optional .cockroach.roachpb.NoopResponse noop = 21;
+// optional .cockroach.roachpb.NoopResponse noop = 22;
 inline bool ResponseUnion::has_noop() const {
-  return (_has_bits_[0] & 0x00100000u) != 0;
+  return (_has_bits_[0] & 0x00200000u) != 0;
 }
 inline void ResponseUnion::set_has_noop() {
-  _has_bits_[0] |= 0x00100000u;
+  _has_bits_[0] |= 0x00200000u;
 }
 inline void ResponseUnion::clear_has_noop() {
-  _has_bits_[0] &= ~0x00100000u;
+  _has_bits_[0] &= ~0x00200000u;
 }
 inline void ResponseUnion::clear_noop() {
   if (noop_ != NULL) noop_->::cockroach::roachpb::NoopResponse::Clear();
@@ -11823,6 +12211,10 @@ BatchResponse::mutable_responses() {
 }
 
 #endif  // !PROTOBUF_INLINE_NOT_IN_HEADERS
+// -------------------------------------------------------------------
+
+// -------------------------------------------------------------------
+
 // -------------------------------------------------------------------
 
 // -------------------------------------------------------------------

--- a/storage/replica_test.go
+++ b/storage/replica_test.go
@@ -778,7 +778,7 @@ func TestRangeNoGossipConfig(t *testing.T) {
 
 	txn := newTransaction("test", key, 1 /* userPriority */, roachpb.SERIALIZABLE, tc.clock)
 	h := roachpb.Header{Txn: txn}
-
+	bt, _ := beginTxnArgs(key, txn)
 	req1 := putArgs(key, []byte("foo"))
 	req2, _ := endTxnArgs(txn, true /* commit */)
 	req2.Intents = []roachpb.Intent{{Key: key}}
@@ -788,6 +788,7 @@ func TestRangeNoGossipConfig(t *testing.T) {
 		req roachpb.Request
 		h   roachpb.Header
 	}{
+		{&bt, h},
 		{&req1, h},
 		{&req2, h},
 		{&req3, roachpb.Header{}},
@@ -821,6 +822,10 @@ func TestRangeNoGossipFromNonLeader(t *testing.T) {
 	key := keys.MakeTablePrefix(keys.MaxReservedDescID)
 
 	txn := newTransaction("test", key, 1 /* userPriority */, roachpb.SERIALIZABLE, tc.clock)
+	bt, h := beginTxnArgs(key, txn)
+	if _, err := client.SendWrappedWith(tc.Sender(), nil, h, &bt); err != nil {
+		t.Fatal(err)
+	}
 	req1 := putArgs(key, nil)
 	if _, err := client.SendWrappedWith(tc.Sender(), nil, roachpb.Header{
 		Txn: txn,
@@ -919,6 +924,15 @@ func scanArgs(start, end []byte) roachpb.ScanRequest {
 			EndKey: end,
 		},
 	}
+}
+
+func beginTxnArgs(key []byte, txn *roachpb.Transaction) (_ roachpb.BeginTransactionRequest, h roachpb.Header) {
+	h.Txn = txn
+	return roachpb.BeginTransactionRequest{
+		Span: roachpb.Span{
+			Key: txn.Key,
+		},
+	}, h
 }
 
 // endTxnArgs returns a request and header for an EndTransaction RPC for the
@@ -1559,6 +1573,10 @@ func TestEndTransactionWithMalformedSplitTrigger(t *testing.T) {
 
 	key := roachpb.Key("foo")
 	txn := newTransaction("test", key, 1, roachpb.SERIALIZABLE, tc.clock)
+	bt, h := beginTxnArgs(key, txn)
+	if _, err := client.SendWrappedWith(tc.Sender(), tc.rng.context(), h, &bt); err != nil {
+		t.Fatal(err)
+	}
 	pArgs := putArgs(key, []byte("only here to make this a rw transaction"))
 	if _, err := client.SendWrappedWith(tc.Sender(), tc.rng.context(), roachpb.Header{
 		Txn: txn,
@@ -1596,8 +1614,11 @@ func TestEndTransactionBeforeHeartbeat(t *testing.T) {
 	key := []byte("a")
 	for _, commit := range []bool{true, false} {
 		txn := newTransaction("test", key, 1, roachpb.SERIALIZABLE, tc.clock)
+		bt, btH := beginTxnArgs(key, txn)
+		if _, err := client.SendWrappedWith(tc.Sender(), tc.rng.context(), btH, &bt); err != nil {
+			t.Fatal(err)
+		}
 		args, h := endTxnArgs(txn, commit)
-
 		resp, err := client.SendWrappedWith(tc.Sender(), tc.rng.context(), h, &args)
 		if err != nil {
 			t.Error(err)
@@ -1637,6 +1658,10 @@ func TestEndTransactionAfterHeartbeat(t *testing.T) {
 	key := []byte("a")
 	for _, commit := range []bool{true, false} {
 		txn := newTransaction("test", key, 1, roachpb.SERIALIZABLE, tc.clock)
+		bt, btH := beginTxnArgs(key, txn)
+		if _, err := client.SendWrappedWith(tc.Sender(), tc.rng.context(), btH, &bt); err != nil {
+			t.Fatal(err)
+		}
 
 		// Start out with a heartbeat to the transaction.
 		hBA, h := heartbeatArgs(txn)
@@ -1694,6 +1719,10 @@ func TestEndTransactionWithPushedTimestamp(t *testing.T) {
 	key := []byte("a")
 	for _, test := range testCases {
 		txn := newTransaction("test", key, 1, test.isolation, tc.clock)
+		bt, btH := beginTxnArgs(key, txn)
+		if _, err := client.SendWrappedWith(tc.Sender(), tc.rng.context(), btH, &bt); err != nil {
+			t.Fatal(err)
+		}
 		// End the transaction with args timestamp moved forward in time.
 		args, h := endTxnArgs(txn, test.commit)
 		// TODO(tschottdorf): this test is pretty dirty. It should really
@@ -1740,6 +1769,10 @@ func TestEndTransactionWithIncrementedEpoch(t *testing.T) {
 
 	key := []byte("a")
 	txn := newTransaction("test", key, 1, roachpb.SERIALIZABLE, tc.clock)
+	bt, btH := beginTxnArgs(key, txn)
+	if _, err := client.SendWrappedWith(tc.Sender(), tc.rng.context(), btH, &bt); err != nil {
+		t.Fatal(err)
+	}
 
 	// Start out with a heartbeat to the transaction.
 	hBA, h := heartbeatArgs(txn)
@@ -1846,7 +1879,12 @@ func TestEndTransactionGC(t *testing.T) {
 		// Intent inside and outside.
 		{[]roachpb.Intent{{Key: roachpb.Key("a")}, {Key: splitKey.AsRawKey()}}, false},
 	} {
-		txn := newTransaction("test", roachpb.Key("a"), 1, roachpb.SERIALIZABLE, tc.clock)
+		key := roachpb.Key("a")
+		txn := newTransaction("test", key, 1, roachpb.SERIALIZABLE, tc.clock)
+		bt, btH := beginTxnArgs(key, txn)
+		if _, err := client.SendWrappedWith(tc.Sender(), tc.rng.context(), btH, &bt); err != nil {
+			t.Fatal(err)
+		}
 		args, h := endTxnArgs(txn, true)
 		args.Intents = test.intents
 		if _, err := client.SendWrappedWith(tc.Sender(), tc.rng.context(), h, &args); err != nil {
@@ -1886,6 +1924,10 @@ func TestEndTransactionResolveOnlyLocalIntents(t *testing.T) {
 	newRng := splitTestRange(tc.store, splitKey, splitKey, t)
 
 	txn := newTransaction("test", key, 1, roachpb.SERIALIZABLE, tc.clock)
+	bt, btH := beginTxnArgs(key, txn)
+	if _, err := client.SendWrappedWith(tc.Sender(), tc.rng.context(), btH, &bt); err != nil {
+		t.Fatal(err)
+	}
 	pArgs := putArgs(key, []byte("value"))
 	h := roachpb.Header{Txn: txn}
 	if _, err := client.SendWrappedWith(tc.Sender(), tc.rng.context(), h, &pArgs); err != nil {
@@ -1951,6 +1993,11 @@ func TestPushTxnAlreadyCommittedOrAborted(t *testing.T) {
 		pusher.Priority = 1
 		pushee.Priority = 2 // pusher will lose, meaning we shouldn't push unless pushee is already ended.
 
+		// Begin the pushee's transaction.
+		btArgs, btH := beginTxnArgs(key, pushee)
+		if _, err := client.SendWrappedWith(tc.Sender(), tc.rng.context(), btH, &btArgs); err != nil {
+			t.Fatal(err)
+		}
 		// End the pushee's transaction.
 		etArgs, h := endTxnArgs(pushee, status == roachpb.COMMITTED)
 
@@ -2009,12 +2056,12 @@ func TestPushTxnUpgradeExistingTxn(t *testing.T) {
 		pushee.Priority = 1
 		pusher.Priority = 2 // Pusher will win.
 
-		// First, establish "start" of existing pushee's txn via heartbeat.
+		// First, establish "start" of existing pushee's txn via BeginTransaction.
 		pushee.Epoch = test.startEpoch
 		pushee.Timestamp = test.startTS
-		hBA, h := heartbeatArgs(pushee)
-
-		if _, err := client.SendWrappedWith(tc.Sender(), tc.rng.context(), h, &hBA); err != nil {
+		pushee.LastHeartbeat = &test.startTS
+		bt, btH := beginTxnArgs(key, pushee)
+		if _, err := client.SendWrappedWith(tc.Sender(), tc.rng.context(), btH, &bt); err != nil {
 			t.Fatal(err)
 		}
 
@@ -2086,14 +2133,13 @@ func TestPushTxnHeartbeatTimeout(t *testing.T) {
 		pushee.Priority = 2
 		pusher.Priority = 1 // Pusher won't win based on priority.
 
-		// First, establish "start" of existing pushee's txn via heartbeat.
+		// First, establish "start" of existing pushee's txn via BeginTransaction.
 		if !test.heartbeat.Equal(roachpb.ZeroTimestamp) {
-			hBA, h := heartbeatArgs(pushee)
-			h.Timestamp = test.heartbeat
-
-			if _, err := client.SendWrappedWith(tc.Sender(), tc.rng.context(), h, &hBA); err != nil {
-				t.Fatal(err)
-			}
+			pushee.LastHeartbeat = &test.heartbeat
+		}
+		bt, btH := beginTxnArgs(key, pushee)
+		if _, err := client.SendWrappedWith(tc.Sender(), tc.rng.context(), btH, &bt); err != nil {
+			t.Fatal(err)
 		}
 
 		// Now, attempt to push the transaction with Now set to our current time.
@@ -2162,6 +2208,10 @@ func TestPushTxnPriorities(t *testing.T) {
 		pusher.Timestamp = test.pusherTS
 		pushee.Timestamp = test.pusheeTS
 
+		bt, btH := beginTxnArgs(key, pushee)
+		if _, err := client.SendWrappedWith(tc.Sender(), tc.rng.context(), btH, &bt); err != nil {
+			t.Fatal(err)
+		}
 		// Now, attempt to push the transaction with intent epoch set appropriately.
 		args := pushTxnArgs(pusher, pushee, test.pushType)
 
@@ -2194,6 +2244,11 @@ func TestPushTxnPushTimestamp(t *testing.T) {
 	pushee.Priority = 1 // pusher will win
 	pusher.Timestamp = roachpb.Timestamp{WallTime: 50, Logical: 25}
 	pushee.Timestamp = roachpb.Timestamp{WallTime: 5, Logical: 1}
+
+	bt, btH := beginTxnArgs(roachpb.Key("a"), pushee)
+	if _, err := client.SendWrappedWith(tc.Sender(), tc.rng.context(), btH, &bt); err != nil {
+		t.Fatal(err)
+	}
 
 	// Now, push the transaction with args.Abort=false.
 	args := pushTxnArgs(pusher, pushee, roachpb.PUSH_TIMESTAMP)
@@ -2229,6 +2284,11 @@ func TestPushTxnPushTimestampAlreadyPushed(t *testing.T) {
 	pushee.Priority = 2 // pusher will lose
 	pusher.Timestamp = roachpb.Timestamp{WallTime: 50, Logical: 0}
 	pushee.Timestamp = roachpb.Timestamp{WallTime: 50, Logical: 1}
+
+	bt, btH := beginTxnArgs(roachpb.Key("a"), pushee)
+	if _, err := client.SendWrappedWith(tc.Sender(), tc.rng.context(), btH, &bt); err != nil {
+		t.Fatal(err)
+	}
 
 	// Now, push the transaction with args.Abort=false.
 	args := pushTxnArgs(pusher, pushee, roachpb.PUSH_TIMESTAMP)

--- a/storage/store.go
+++ b/storage/store.go
@@ -1429,6 +1429,7 @@ func (s *Store) proposeRaftCommandImpl(idKey cmdIDKey, cmd roachpb.RaftCommand) 
 			// EndTransactionRequest with a ChangeReplicasTrigger is special because raft
 			// needs to understand it; it cannot simply be an opaque command.
 			crt := etr.InternalCommitTrigger.ChangeReplicasTrigger
+			log.Infof("changing raft replica %d for range %d", crt.Replica, cmd.RangeID)
 			return s.multiraft.ChangeGroupMembership(cmd.RangeID, string(idKey),
 				changeTypeInternalToRaft[crt.ChangeType],
 				crt.Replica,
@@ -1476,6 +1477,7 @@ func (s *Store) processRaft() {
 						if err != nil {
 							log.Fatal(err)
 						}
+						log.Infof("got an event membership change committed event: %s", cmd.Cmd)
 
 					default:
 						continue


### PR DESCRIPTION
BeginTransactionRequest is automatically inserted by the KV client
immediately before the first transactional write. On execution,
BeginTransaction creates the transaction record.

If a heartbeat arrives for a txn that has no transaction record, it's
ignored. If a push txn arrives for a txn that has no transaction record,
the txn is considered aborted.

This solves the problem of errant heartbeats or pushes recreating a GC'd
transaction record, addressing #2062.
