### PR TITLE
Normalize subquery result tuples used in {IN,NOT IN} expressions.

### DIFF
--- a/sql/subquery.go
+++ b/sql/subquery.go
@@ -89,6 +89,7 @@ func (v *subqueryVisitor) Visit(expr parser.Expr, pre bool) (parser.Visitor, par
 				rows = append(rows, valuesCopy)
 			}
 		}
+		rows.Normalize()
 		result = rows
 	} else {
 		result = parser.DNull

--- a/sql/testdata/subquery
+++ b/sql/testdata/subquery
@@ -120,3 +120,7 @@ SELECT * FROM xyz
 4 5  6
 7 11 12
 
+query I
+SELECT 1 IN (SELECT x FROM xyz ORDER BY x DESC)
+----
+true


### PR DESCRIPTION
See #2749.
