### PR TITLE
Do not use cached table descriptors on INSERT/DELETE/UPDATE.

### DIFF
--- a/sql/delete.go
+++ b/sql/delete.go
@@ -30,7 +30,7 @@ import (
 //   Notes: postgres requires DELETE. Also requires SELECT for "USING" and "WHERE" with tables.
 //          mysql requires DELETE. Also requires SELECT if a table is used in the "WHERE" clause.
 func (p *planner) Delete(n *parser.Delete) (planNode, error) {
-	tableDesc, err := p.getAliasedTableDesc(n.Table)
+	tableDesc, err := p.getAliasedTableDesc(n.Table, false /* !allowCache */)
 	if err != nil {
 		return nil, err
 	}

--- a/sql/insert.go
+++ b/sql/insert.go
@@ -32,7 +32,12 @@ import (
 //   Notes: postgres requires INSERT. No "on duplicate key update" option.
 //          mysql requires INSERT. Also requires UPDATE on "ON DUPLICATE KEY UPDATE".
 func (p *planner) Insert(n *parser.Insert) (planNode, error) {
-	tableDesc, _, err := p.getCachedTableDesc(n.Table)
+	// TODO(marcb): We can't use the cached descriptor here because a recent
+	// update of the schema (e.g. the addition of an index) might not be
+	// reflected in the cached version (yet). Perhaps schema modification
+	// routines such as CREATE INDEX should not return until the schema change
+	// has been pushed everywhere.
+	tableDesc, err := p.getTableDesc(n.Table)
 	if err != nil {
 		return nil, err
 	}

--- a/sql/plan.go
+++ b/sql/plan.go
@@ -133,7 +133,7 @@ func (p *planner) makePlan(stmt parser.Statement) (planNode, error) {
 // getAliasedTableDesc looks up the table descriptor for an alias table expression.
 // NOTE: it looks it up in the descriptor cache, so this should only be called
 // from frequent ops (INSERT, SELECT, DELETE, UPDATE).
-func (p *planner) getAliasedTableDesc(n parser.TableExpr) (*TableDescriptor, error) {
+func (p *planner) getAliasedTableDesc(n parser.TableExpr, allowCache bool) (*TableDescriptor, error) {
 	ate, ok := n.(*parser.AliasedTableExpr)
 	if !ok {
 		return nil, util.Errorf("TODO(pmattis): unsupported FROM: %s", n)
@@ -142,7 +142,13 @@ func (p *planner) getAliasedTableDesc(n parser.TableExpr) (*TableDescriptor, err
 	if !ok {
 		return nil, util.Errorf("TODO(pmattis): unsupported FROM: %s", n)
 	}
-	desc, _, err := p.getCachedTableDesc(table)
+	var desc *TableDescriptor
+	var err error
+	if allowCache {
+		desc, _, err = p.getCachedTableDesc(table)
+	} else {
+		desc, err = p.getTableDesc(table)
+	}
 	if err != nil {
 		return nil, err
 	}

--- a/sql/scan.go
+++ b/sql/scan.go
@@ -237,7 +237,7 @@ func (n *scanNode) initFrom(p *planner, from parser.TableExprs) error {
 		return nil
 
 	case 1:
-		if n.desc, n.err = p.getAliasedTableDesc(from[0]); n.err != nil {
+		if n.desc, n.err = p.getAliasedTableDesc(from[0], true /* allowCache */); n.err != nil {
 			return n.err
 		}
 

--- a/sql/update.go
+++ b/sql/update.go
@@ -33,7 +33,7 @@ import (
 //   Notes: postgres requires UPDATE. Requires SELECT with WHERE clause with table.
 //          mysql requires UPDATE. Also requires SELECT with WHERE clause with table.
 func (p *planner) Update(n *parser.Update) (planNode, error) {
-	tableDesc, err := p.getAliasedTableDesc(n.Table)
+	tableDesc, err := p.getAliasedTableDesc(n.Table, false /* !allowCache */)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
Using the cached descriptors for data manipulation can result in missing
data. Consider:

  CREATE TABLE t (a INT PRIMARY KEY, b INT)
  CREATE INDEX foo ON t (b)
  INSERT INTO t VALUES (1, 2)

If the INSERT operation uses the cached descriptor it may or may not see
the index "foo" depending on whether the descriptor cache updated before
the INSERT operation was run. If it doesn't see the index "foo" then
that value will be inserted with create the index entry for "foo". A
subsequent operation which uses "foo" will then erroneously not find
that row.

Fixes #2749.
See #2655.
