### PR TITLE
Tiny fix: Stop passing a value of BatchRequest when mutability is not necessary

### DIFF
--- a/storage/replica_test.go
+++ b/storage/replica_test.go
@@ -279,7 +279,7 @@ func TestRangeContains(t *testing.T) {
 }
 
 func setLeaderLease(t *testing.T, r *Replica, l *roachpb.Lease) {
-	args := &roachpb.BatchRequest{}
+	args := roachpb.BatchRequest{}
 	args.Add(&roachpb.LeaderLeaseRequest{Lease: *l})
 	errChan, pendingCmd := r.proposeRaftCommand(r.context(), args)
 	var err error
@@ -408,7 +408,7 @@ func TestApplyCmdLeaseError(t *testing.T) {
 	})
 
 	// Submit a proposal to Raft.
-	errChan, pendingCmd := tc.rng.proposeRaftCommand(tc.rng.context(), &ba)
+	errChan, pendingCmd := tc.rng.proposeRaftCommand(tc.rng.context(), ba)
 	if err := <-errChan; err != nil {
 		t.Fatal(err)
 	}
@@ -719,7 +719,7 @@ func TestRangeLeaderLeaseRejectUnknownRaftNodeID(t *testing.T) {
 			StoreID:   2,
 		},
 	}
-	args := &roachpb.BatchRequest{}
+	args := roachpb.BatchRequest{}
 	args.Add(&roachpb.LeaderLeaseRequest{Lease: *lease})
 	errChan, pendingCmd := tc.rng.proposeRaftCommand(tc.rng.context(), args)
 	var err error


### PR DESCRIPTION
I don't know exactly when we want to pass a pointer to avoid copy, but this is consistent with `addReadOnlyCmd()` and `addWriteCmd()`, which take a pointer of `BatchRequest`.
