### PR TITLE
Fix an uninitialized ReplicaID.

### DIFF
--- a/multiraft/storage.go
+++ b/multiraft/storage.go
@@ -44,9 +44,9 @@ type Storage interface {
 	// GroupStorage returns an interface which can be used to access the
 	// storage for the specified group. May return ErrGroupDeleted if
 	// the group cannot be found or if the given replica ID is known to
-	// be out of date. The replicaID may be InvalidReplicaID if the
-	// replica ID is not known; replica-staleness checks should be
-	// disabled in this case.
+	// be out of date. The replicaID may be zero if the replica ID is
+	// not known; replica-staleness checks should be disabled in this
+	// case.
 	GroupStorage(groupID roachpb.RangeID, replicaID roachpb.ReplicaID) (WriteableGroupStorage, error)
 
 	ReplicaDescriptor(groupID roachpb.RangeID, replicaID roachpb.ReplicaID) (roachpb.ReplicaDescriptor, error)

--- a/roachpb/metadata.go
+++ b/roachpb/metadata.go
@@ -144,7 +144,10 @@ func (r *RangeDescriptor) Validate() error {
 		return util.Errorf("NextReplicaID must be non-zero")
 	}
 	seen := map[ReplicaID]struct{}{}
-	for _, rep := range r.Replicas {
+	for i, rep := range r.Replicas {
+		if err := rep.Validate(); err != nil {
+			return util.Errorf("replica %d is invalid: %s", i, err)
+		}
 		if _, ok := seen[rep.ReplicaID]; ok {
 			return util.Errorf("ReplicaID %d was reused", rep.ReplicaID)
 		}
@@ -153,6 +156,20 @@ func (r *RangeDescriptor) Validate() error {
 			return util.Errorf("ReplicaID %d must be less than NextReplicaID %d",
 				rep.ReplicaID, r.NextReplicaID)
 		}
+	}
+	return nil
+}
+
+// Validate performs some basic validation of the contents of a replica descriptor.
+func (r ReplicaDescriptor) Validate() error {
+	if r.NodeID == 0 {
+		return util.Errorf("NodeID must not be zero")
+	}
+	if r.StoreID == 0 {
+		return util.Errorf("StoreID must not be zero")
+	}
+	if r.ReplicaID == 0 {
+		return util.Errorf("ReplicaID must not be zero")
 	}
 	return nil
 }

--- a/storage/client_test.go
+++ b/storage/client_test.go
@@ -223,10 +223,15 @@ func (m *multiTestContext) Stop() {
 		stoppers := append([]*stop.Stopper{m.clientStopper, m.transportStopper}, m.stoppers...)
 		// Quiesce all the stoppers so that we can stop all stoppers in unison.
 		for _, s := range stoppers {
-			s.Quiesce()
+			// Stoppers may be nil if stopStore has been called without restartStore.
+			if s != nil {
+				s.Quiesce()
+			}
 		}
 		for _, s := range stoppers {
-			s.Stop()
+			if s != nil {
+				s.Stop()
+			}
 		}
 		for _, s := range m.engineStoppers {
 			s.Stop()

--- a/storage/replica_command.go
+++ b/storage/replica_command.go
@@ -1482,6 +1482,7 @@ func (r *Replica) ChangeReplicas(changeType roachpb.ReplicaChangeType, replica r
 		if existingRep.NodeID == replica.NodeID &&
 			existingRep.StoreID == replica.StoreID {
 			found = i
+			replica.ReplicaID = existingRep.ReplicaID
 			break
 		}
 	}

--- a/storage/store.go
+++ b/storage/store.go
@@ -1547,8 +1547,7 @@ func (s *Store) GroupStorage(groupID roachpb.RangeID, replicaID roachpb.ReplicaI
 		if ok, err := engine.MVCCGetProto(s.Engine(), tombstoneKey, roachpb.ZeroTimestamp, true, nil, &tombstone); err != nil {
 			return nil, err
 		} else if ok {
-			if replicaID != multiraft.InvalidReplicaID &&
-				replicaID < tombstone.NextReplicaID {
+			if replicaID != 0 && replicaID < tombstone.NextReplicaID {
 				return nil, multiraft.ErrGroupDeleted
 			}
 		}


### PR DESCRIPTION
Validate all ReplicaDescriptors passed from storage to multiraft.
Use 0 instead of -1 for the invalid ReplicaID and get rid of the
constant, since the zero value is special in many places and we
generally don't use constants for them.
