### PR TITLE
allow 1PC txns

### DIFF
--- a/kv/batch.go
+++ b/kv/batch.go
@@ -177,7 +177,7 @@ func (cs *chunkingSender) Send(ctx context.Context, ba roachpb.BatchRequest) (*r
 		}
 	}
 
-	parts := ba.Split()
+	parts := ba.Split(true /* canSplitET */)
 	var rplChunks []*roachpb.BatchResponse
 	for _, part := range parts {
 		ba.Requests = part

--- a/kv/batch.go
+++ b/kv/batch.go
@@ -18,9 +18,6 @@
 package kv
 
 import (
-	"math/rand"
-
-	"github.com/cockroachdb/cockroach/client"
 	"github.com/cockroachdb/cockroach/keys"
 	"github.com/cockroachdb/cockroach/roachpb"
 	"github.com/cockroachdb/cockroach/util"
@@ -133,75 +130,6 @@ type senderFn func(context.Context, roachpb.BatchRequest) (*roachpb.BatchRespons
 // Send implements batch.Sender.
 func (f senderFn) Send(ctx context.Context, ba roachpb.BatchRequest) (*roachpb.BatchResponse, *roachpb.Error) {
 	return f(ctx, ba)
-}
-
-// A ChunkingSender sends batches, subdividing them appropriately.
-type chunkingSender struct {
-	f senderFn
-}
-
-// NewChunkingSender returns a new chunking sender which sends through the supplied
-// SenderFn.
-func newChunkingSender(f senderFn) client.Sender {
-	return &chunkingSender{f: f}
-}
-
-// Send implements Sender.
-// TODO(tschottdorf): We actually don't want to chop EndTransaction off for
-// single-range requests (but that happens now since EndTransaction has the
-// isAlone flag). Whether it is one or not is unknown right now (you can only
-// find out after you've sent to the Range/looked up a descriptor that suggests
-// that you're multi-range. In those cases, the wrapped sender should return an
-// error so that we split and retry once the chunk which contains
-// EndTransaction (i.e. the last one).
-func (cs *chunkingSender) Send(ctx context.Context, ba roachpb.BatchRequest) (*roachpb.BatchResponse, *roachpb.Error) {
-	if len(ba.Requests) < 1 {
-		panic("empty batch")
-	}
-
-	// Deterministically create ClientCmdIDs for all parts of the batch if
-	// a CmdID is already set (otherwise, leave them empty).
-	var nextID func() roachpb.ClientCmdID
-	empty := roachpb.ClientCmdID{}
-	if empty == ba.CmdID {
-		nextID = func() roachpb.ClientCmdID {
-			return empty
-		}
-	} else {
-		rng := rand.New(rand.NewSource(ba.CmdID.Random))
-		id := ba.CmdID
-		nextID = func() roachpb.ClientCmdID {
-			curID := id             // copy
-			id.Random = rng.Int63() // adjust for next call
-			return curID
-		}
-	}
-
-	parts := ba.Split(true /* canSplitET */)
-	var rplChunks []*roachpb.BatchResponse
-	for _, part := range parts {
-		ba.Requests = part
-		ba.CmdID = nextID()
-		rpl, err := cs.f(ctx, ba)
-		if err != nil {
-			return nil, err
-		}
-		// Propagate transaction from last reply to next request. The final
-		// update is taken and put into the response's main header.
-		ba.Txn.Update(rpl.Header().Txn)
-
-		rplChunks = append(rplChunks, rpl)
-	}
-
-	reply := rplChunks[0]
-	for _, rpl := range rplChunks[1:] {
-		reply.Responses = append(reply.Responses, rpl.Responses...)
-	}
-	lastHeader := rplChunks[len(rplChunks)-1].BatchResponse_Header
-	reply.Error = lastHeader.Error
-	reply.Timestamp = lastHeader.Timestamp
-	reply.Txn = ba.Txn
-	return reply, nil
 }
 
 // prev gives the right boundary of the union of all requests which don't

--- a/kv/dist_sender.go
+++ b/kv/dist_sender.go
@@ -458,7 +458,6 @@ func (ds *DistSender) sendAttempt(trace *tracer.Trace, ba roachpb.BatchRequest, 
 func (ds *DistSender) Send(ctx context.Context, ba roachpb.BatchRequest) (*roachpb.BatchResponse, *roachpb.Error) {
 	// In the event that timestamp isn't set and read consistency isn't
 	// required, set the timestamp using the local clock.
-	// TODO(tschottdorf): right place for this?
 	if ba.ReadConsistency == roachpb.INCONSISTENT && ba.Timestamp.Equal(roachpb.ZeroTimestamp) {
 		ba.Timestamp = ds.clock.Now()
 	}

--- a/kv/dist_sender.go
+++ b/kv/dist_sender.go
@@ -460,10 +460,6 @@ func (ds *DistSender) Send(ctx context.Context, ba roachpb.BatchRequest) (*roach
 	// required, set the timestamp using the local clock.
 	// TODO(tschottdorf): right place for this?
 	if ba.ReadConsistency == roachpb.INCONSISTENT && ba.Timestamp.Equal(roachpb.ZeroTimestamp) {
-		// Make sure that after the call, args hasn't changed.
-		defer func(timestamp roachpb.Timestamp) {
-			ba.Timestamp = timestamp
-		}(ba.Timestamp)
 		ba.Timestamp = ds.clock.Now()
 	}
 

--- a/storage/store.go
+++ b/storage/store.go
@@ -1440,12 +1440,6 @@ func (s *Store) proposeRaftCommandImpl(idKey cmdIDKey, cmd roachpb.RaftCommand) 
 		args := union.GetInner()
 		etr, ok := args.(*roachpb.EndTransactionRequest)
 		if ok && etr.InternalCommitTrigger != nil && etr.InternalCommitTrigger.ChangeReplicasTrigger != nil {
-			// TODO(tschottdorf): the real check is that EndTransaction needs
-			// to be the last element in the batch. Any caveats to solve before
-			// changing this?
-			if len(cmd.Cmd.Requests) != 1 {
-				panic("EndTransaction should only ever occur by itself in a batch")
-			}
 			// EndTransactionRequest with a ChangeReplicasTrigger is special because raft
 			// needs to understand it; it cannot simply be an opaque command.
 			crt := etr.InternalCommitTrigger.ChangeReplicasTrigger


### PR DESCRIPTION
This change enables 1PC txns for transaction contained in a single batch and sent to a single `Range`.
I'm going to add some tests for this, but the meat is ready for review.

The interplay introduced around `sendChunk` in DistSender and is somewhat weird and passes back an extra boolean (avoiding the need for a new proto error). I'm open to suggestions for making that prettier.

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/2818)

<!-- Reviewable:end -->
