### PR TITLE
Sim: Add Replica Removal

### DIFF
--- a/storage/simulation/cluster.go
+++ b/storage/simulation/cluster.go
@@ -281,9 +281,15 @@ func (c *Cluster) performActions() {
 				usedRanges[topRangeID] = storeID
 				fmt.Fprintf(c.actionWriter, "%d:\tStore:%d\tRange:%d\tREPAIR\n", c.epoch, storeID, topRangeID)
 			case storage.AllocatorRemove:
-				// TODO(bram): implement this.
+				removeStoreID, err := r.getRemoveTarget()
+				if err != nil {
+					fmt.Fprintf(c.actionWriter, "%d:\tError: %s\n", c.epoch, err)
+					continue
+				}
+				r.removeReplica(c.stores[removeStoreID])
 				usedRanges[topRangeID] = storeID
-				fmt.Fprintf(c.actionWriter, "%d:\tStore:%d\tRange:%d\tREMOVE\n", c.epoch, storeID, topRangeID)
+				fmt.Fprintf(c.actionWriter, "%d:\tStore:%d\tRange:%d\tREMOVE:%d\n",
+					c.epoch, storeID, topRangeID, removeStoreID)
 			case storage.AllocatorNoop:
 				if topReplica.rebalance {
 					// TODO(bram): implement this.

--- a/storage/simulation/cluster.go
+++ b/storage/simulation/cluster.go
@@ -114,12 +114,11 @@ func (c *Cluster) addNewNodeWithStore() {
 func (c *Cluster) addStore(nodeID roachpb.NodeID, output bool) *Store {
 	n := c.nodes[nodeID]
 	s := n.addNewStore()
-	storeID, _ := s.getIDs()
-	c.stores[storeID] = s
+	c.stores[s.desc.StoreID] = s
 
 	// Save a sorted array of store IDs to avoid having to calculate them
 	// multiple times.
-	c.storeIDs = append(c.storeIDs, storeID)
+	c.storeIDs = append(c.storeIDs, s.desc.StoreID)
 	sort.Sort(c.storeIDs)
 
 	if output {

--- a/storage/simulation/main.go
+++ b/storage/simulation/main.go
@@ -40,13 +40,26 @@ func main() {
 	for i := 0; i < 10; i++ {
 		c.splitRangeRandom()
 	}
+	c.flush()
 
 	// TODO(bram): only flush when on manual stepping (once that enabled).
-	c.flush()
-	for i := 0; i < 100; i++ {
-		c.runEpoch()
+	// Run until stable or at the 100th epoch.
+	for c.runEpoch() != true && c.epoch < 100 {
 		c.flush()
 	}
+	c.flush()
+	fmt.Println(c)
+
+	// Split the last range 50 times.
+	for i := 0; i < 70; i++ {
+		c.splitRangeLast()
+	}
+
+	// Run until stable or at the 1000th epoch.
+	for c.runEpoch() != true && c.epoch < 1000 {
+		c.flush()
+	}
+	c.flush()
 
 	fmt.Println(c)
 }

--- a/storage/simulation/range.go
+++ b/storage/simulation/range.go
@@ -60,12 +60,11 @@ func newRange(rangeID roachpb.RangeID, allocator storage.Allocator) *Range {
 // addReplica adds a new replica on the passed in store. It adds it to
 // both the range descriptor and the store map.
 func (r *Range) addReplica(s *Store) {
-	storeID, nodeID := s.getIDs()
 	r.desc.Replicas = append(r.desc.Replicas, roachpb.ReplicaDescriptor{
-		NodeID:  nodeID,
-		StoreID: storeID,
+		NodeID:  s.desc.Node.NodeID,
+		StoreID: s.desc.StoreID,
 	})
-	r.replicas[storeID] = replica{
+	r.replicas[s.desc.StoreID] = replica{
 		store: s,
 	}
 }

--- a/storage/simulation/range.go
+++ b/storage/simulation/range.go
@@ -70,6 +70,18 @@ func (r *Range) addReplica(s *Store) {
 	}
 }
 
+// removeReplica removes an existing replica from the passed in store. It
+// removes it from both the range descriptor and the store map.
+func (r *Range) removeReplica(s *Store) {
+	for i, replica := range r.desc.Replicas {
+		if replica.StoreID == s.desc.StoreID {
+			r.desc.Replicas = append(r.desc.Replicas[:i], r.desc.Replicas[i+1:]...)
+			break
+		}
+	}
+	delete(r.replicas, s.desc.StoreID)
+}
+
 // getStoreIDs returns the list of all stores where this range has replicas.
 func (r *Range) getStoreIDs() []roachpb.StoreID {
 	var storeIDs []roachpb.StoreID
@@ -109,6 +121,16 @@ func (r *Range) getAllocateTarget() (roachpb.StoreID, error) {
 		return 0, err
 	}
 	return newStore.StoreID, nil
+}
+
+// getRemoveTarget calls removeTarget on the allocator and returns the storeID
+// that is the best candidate for removal.
+func (r *Range) getRemoveTarget() (roachpb.StoreID, error) {
+	removeTarget, err := r.allocator.RemoveTarget(r.desc.Replicas)
+	if err != nil {
+		return 0, err
+	}
+	return removeTarget.StoreID, nil
 }
 
 // String returns a human readable string with details about the range.

--- a/storage/simulation/store.go
+++ b/storage/simulation/store.go
@@ -27,8 +27,8 @@ import (
 const (
 	// TODO(bram): Do we still need these? The default zone config might be
 	// enough.
-	bytesPerRange    = 64 << 20 // 64 MiB
-	capacityPerStore = 1 << 40  // 1 TiB - 32768 ranges per store
+	bytesPerRange    = 64 << 20            // 64 MiB
+	capacityPerStore = bytesPerRange * 100 // 100 ranges
 )
 
 // Store is a simulated cockroach store. To access the replicas in a store, use

--- a/storage/simulation/store.go
+++ b/storage/simulation/store.go
@@ -50,11 +50,6 @@ func newStore(storeID roachpb.StoreID, nodeDesc roachpb.NodeDescriptor, gossip *
 	}
 }
 
-// getIDs returns the store's ID and its node's IDs.
-func (s *Store) getIDs() (roachpb.StoreID, roachpb.NodeID) {
-	return s.desc.StoreID, s.desc.Node.NodeID
-}
-
 // getDesc returns the store descriptor. The rangeCount is required to
 // determine the current capacity.
 func (s *Store) getDesc(rangeCount int) roachpb.StoreDescriptor {


### PR DESCRIPTION
Some updates to the simulator
1) replica removal (down replication)
2) a small cleanup of an unneeded function
3) collection of small changes for rebalancing
   a) adds a stability flag so we can run clusters until they're stable
   b) turns on rebalancing and determinism in the allocator
   c) reduces the max capacity of the stores
   d) updates the priority of rebalances to 1 from 0 (or they will never happen)
Note that rebalances don't happen yet, it just says they should.  They'll be in the next commit.

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/2822)

<!-- Reviewable:end -->
