### PR TITLE
Remember the ReplicaID in multiraft.group.

### DIFF
--- a/multiraft/multiraft.go
+++ b/multiraft/multiraft.go
@@ -573,35 +573,8 @@ func (s *state) start() {
 					log.Infof("node %v: group %v got message %.200s", s.nodeID, req.GroupID,
 						raft.DescribeMessage(req.Message, s.EntryFormatter))
 				}
-				switch req.Message.Type {
-				case raftpb.MsgHeartbeat:
-					s.fanoutHeartbeat(req)
-				case raftpb.MsgHeartbeatResp:
-					s.fanoutHeartbeatResponse(req)
-				default:
-					s.CacheReplicaDescriptor(req.GroupID, req.FromReplica)
-					s.CacheReplicaDescriptor(req.GroupID, req.ToReplica)
-					// We only want to lazily create the group if it's not heartbeat-related;
-					// our heartbeats are coalesced and contain a dummy GroupID.
-					// TODO(tschottdorf) still shouldn't hurt to move this part outside,
-					// but suddenly tests will start failing. Should investigate.
-					if _, ok := s.groups[req.GroupID]; !ok {
-						if log.V(1) {
-							log.Infof("node %v: got message for unknown group %d; creating it", s.nodeID, req.GroupID)
-						}
-						if err := s.createGroup(req.GroupID, req.ToReplica.ReplicaID); err != nil {
-							log.Warningf("Error creating group %d (in response to incoming message): %s", req.GroupID, err)
-							break
-						}
-					}
+				s.handleMessage(req)
 
-					if err := s.multiNode.Step(context.Background(), uint64(req.GroupID), req.Message); err != nil {
-						if log.V(4) {
-							log.Infof("node %v: multinode step to group %v failed for message %.200s", s.nodeID, req.GroupID,
-								raft.DescribeMessage(req.Message, s.EntryFormatter))
-						}
-					}
-				}
 			case op := <-s.createGroupChan:
 				if log.V(6) {
 					log.Infof("node %v: got op %#v", s.nodeID, op)
@@ -758,6 +731,38 @@ func (s *state) removeNode(nodeID roachpb.NodeID, g *group) error {
 	}
 
 	return nil
+}
+
+func (s *state) handleMessage(req *RaftMessageRequest) {
+	switch req.Message.Type {
+	case raftpb.MsgHeartbeat:
+		s.fanoutHeartbeat(req)
+	case raftpb.MsgHeartbeatResp:
+		s.fanoutHeartbeatResponse(req)
+	default:
+		s.CacheReplicaDescriptor(req.GroupID, req.FromReplica)
+		s.CacheReplicaDescriptor(req.GroupID, req.ToReplica)
+		// We only want to lazily create the group if it's not heartbeat-related;
+		// our heartbeats are coalesced and contain a dummy GroupID.
+		// TODO(tschottdorf) still shouldn't hurt to move this part outside,
+		// but suddenly tests will start failing. Should investigate.
+		if _, ok := s.groups[req.GroupID]; !ok {
+			if log.V(1) {
+				log.Infof("node %v: got message for unknown group %d; creating it", s.nodeID, req.GroupID)
+			}
+			if err := s.createGroup(req.GroupID, req.ToReplica.ReplicaID); err != nil {
+				log.Warningf("Error creating group %d (in response to incoming message): %s", req.GroupID, err)
+				break
+			}
+		}
+
+		if err := s.multiNode.Step(context.Background(), uint64(req.GroupID), req.Message); err != nil {
+			if log.V(4) {
+				log.Infof("node %v: multinode step to group %v failed for message %.200s", s.nodeID, req.GroupID,
+					raft.DescribeMessage(req.Message, s.EntryFormatter))
+			}
+		}
+	}
 }
 
 // createGroup is called in two situations: by the application at


### PR DESCRIPTION
Whenever the ReplicaID changes, the raft group must be dropped
and recreated so raft knows about this.

Fixes TestRaftRemoveRace.
