### PR TITLE
Fix a rare race in StartTestServer.

### DIFF
--- a/acceptance/main_test.go
+++ b/acceptance/main_test.go
@@ -29,7 +29,6 @@ import (
 
 var duration = flag.Duration("d", 5*time.Second, "duration to run the test")
 var numNodes = flag.Int("num", 3, "the number of nodes to start (if not otherwise specified by a test)")
-var rangeMaxBytes = flag.Int64("range-max-bytes", 64<<20, "the maximum size of a range")
 var stopper = make(chan struct{})
 
 func TestMain(m *testing.M) {

--- a/acceptance/put_test.go
+++ b/acceptance/put_test.go
@@ -26,7 +26,6 @@ import (
 	"time"
 
 	"github.com/cockroachdb/cockroach/acceptance/localcluster"
-	"github.com/cockroachdb/cockroach/config"
 	"github.com/cockroachdb/cockroach/util/log"
 	"github.com/cockroachdb/cockroach/util/randutil"
 )
@@ -40,7 +39,6 @@ func TestPut(t *testing.T) {
 
 	db, dbStopper := makeDBClient(t, l, 0)
 	defer dbStopper.Stop()
-	config.DefaultZoneConfig.RangeMaxBytes = *rangeMaxBytes
 	checkRangeReplication(t, l, 20*time.Second)
 
 	errs := make(chan error, *numNodes)

--- a/cli/start.go
+++ b/cli/start.go
@@ -119,6 +119,12 @@ func runStart(_ *cobra.Command, _ []string) {
 	// Default user for servers.
 	context.User = security.NodeUser
 
+	if context.EphemeralSingleNode {
+		// TODO(marc): set this in the zones table when we have an entry
+		// for the default cluster-wide zone config.
+		config.DefaultZoneConfig.ReplicaAttrs = []roachpb.Attributes{{}}
+	}
+
 	stopper := stop.NewStopper()
 	if context.EphemeralSingleNode {
 		context.Stores = "mem=1073741824"
@@ -147,12 +153,6 @@ func runStart(_ *cobra.Command, _ []string) {
 	if err := s.Start(false); err != nil {
 		log.Errorf("cockroach server exited with error: %s", err)
 		return
-	}
-
-	if context.EphemeralSingleNode {
-		// TODO(marc): set this in the zones table when we have an entry
-		// for the default cluster-wide zone config.
-		config.DefaultZoneConfig.ReplicaAttrs = []roachpb.Attributes{{}}
 	}
 
 	signalCh := make(chan os.Signal, 1)

--- a/server/testserver.go
+++ b/server/testserver.go
@@ -150,6 +150,10 @@ func (ts *TestServer) Start() error {
 		ts.Ctx = NewTestContext()
 	}
 
+	// TODO(marc): set this in the zones table when we have an entry
+	// for the default cluster-wide zone config.
+	config.DefaultZoneConfig.ReplicaAttrs = []roachpb.Attributes{{}}
+
 	var err error
 	ts.Server, err = NewServer(ts.Ctx, stop.NewStopper())
 	if err != nil {
@@ -177,9 +181,6 @@ func (ts *TestServer) Start() error {
 		return err
 	}
 
-	// TODO(marc): set this in the zones table when we have an entry
-	// for the default cluster-wide zone config.
-	config.DefaultZoneConfig.ReplicaAttrs = []roachpb.Attributes{{}}
 	return nil
 }
 


### PR DESCRIPTION
When modifying DefaultZoneConfig, do so before starting the server.

Remove the acceptance test range-max-bytes feature, which didn't work
(because it modified the config in the client instead of the server).
