### PR TITLE
Fix Range() to correctly handle a point request following a range request

### DIFF
--- a/keys/keys.go
+++ b/keys/keys.go
@@ -358,8 +358,8 @@ func Range(ba roachpb.BatchRequest) (roachpb.RKey, roachpb.RKey) {
 			// Key is smaller than `from`.
 			from = key
 		}
-		if to.Less(key) {
-			// Key is larger than `to`.
+		if !key.Less(to) {
+			// Key.Next() is larger than `to`.
 			to = key.Next()
 		}
 		if endKey := Addr(h.EndKey); to.Less(endKey) {

--- a/keys/keys_test.go
+++ b/keys/keys_test.go
@@ -322,6 +322,11 @@ func TestBatchRange(t *testing.T) {
 			exp: [2]string{"a", "c\x00"},
 		},
 		{
+			// Disjoint range request and point request.
+			req: [][2]string{{"a", "b"}, {"b", ""}},
+			exp: [2]string{"a", "b\x00"},
+		},
+		{
 			// Range-local point request.
 			req: [][2]string{{string(RangeDescriptorKey(roachpb.RKeyMax)), ""}},
 			exp: [2]string{"\xff\xff", "\xff\xff\x00"},


### PR DESCRIPTION
When a batch request contains `["a", "b")` and `"b"`, `Range()` should return `["a", "b\x00")`, not `["a", "b")`.
