### PR TITLE
fix issue #2805

### DIFF
--- a/cli/cli.go
+++ b/cli/cli.go
@@ -55,7 +55,7 @@ Output build version information.
 var cockroachCmd = &cobra.Command{
 	Use: "cockroach",
 	PersistentPreRun: func(cmd *cobra.Command, args []string) {
-		context.Addr = util.EnsureHost(context.Addr)
+		context.Addr = util.EnsureHostPort(context.Addr)
 	},
 }
 

--- a/gossip/resolver/resolver.go
+++ b/gossip/resolver/resolver.go
@@ -78,7 +78,8 @@ func NewResolver(context *base.Context, spec string) (Resolver, error) {
 
 	// For non-unix resolvers, make sure we fill in the host when not specified (eg: ":26257")
 	if typ != "unix" {
-		addr = util.EnsureHost(addr)
+		// Ensure addr has port and host set.
+		addr = util.EnsureHostPort(addr)
 	}
 
 	// Create the actual resolver.

--- a/rpc/server.go
+++ b/rpc/server.go
@@ -297,7 +297,7 @@ func updatedAddr(oldAddr, newAddr net.Addr) (net.Addr, error) {
 		// TLS certificate. But if the port is different, it should be because
 		// we asked for ":0" and got an arbitrary unused port; that needs to be
 		// reflected in our addr.
-		host, oldPort, err := net.SplitHostPort(util.EnsureHost(oldAddr.String()))
+		host, oldPort, err := net.SplitHostPort(util.EnsureHostPort(oldAddr.String()))
 		if err != nil {
 			return nil, fmt.Errorf("unable to parse original addr '%s': %v",
 				oldAddr.String(), err)

--- a/util/host.go
+++ b/util/host.go
@@ -22,18 +22,33 @@ import (
 	"os"
 )
 
-// EnsureHost takes a host:port pair, where the host portion is optional.
-// If a host is present, the output is equal to the input. Otherwise,
-// the output will contain a host portion equal to the hostname (or
-// "127.0.0.1" as a fallback).
-func EnsureHost(addr string) string {
+const (
+	defaultPort = "26257"
+)
+
+// EnsureHostPort takes a host:port pair, where the host and port are optional.
+// If host and port are present, the output is equal to the input. If port is
+// not present, use default port 26257. If host is not present, host will be
+// equal to the hostname (or "127.0.0.1" as a fallback).
+func EnsureHostPort(addr string) string {
 	host, port, err := net.SplitHostPort(addr)
 	if host != "" || err != nil {
+		if port == "" {
+			port = defaultPort
+			return net.JoinHostPort(addr, port)
+		}
+
 		return addr
 	}
+
 	host, err = os.Hostname()
 	if err != nil {
 		host = "127.0.0.1"
 	}
+
+	if port == "" {
+		port = defaultPort
+	}
+
 	return net.JoinHostPort(host, port)
 }


### PR DESCRIPTION
#2805 use default port 26257 when cockroach start for addr and gossip if user do not input it.

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/2844)

<!-- Reviewable:end -->
