### PR TITLE
Add locking between replicaGCQueue and multiraft.state.createGroup.

### DIFF
--- a/multiraft/multiraft.go
+++ b/multiraft/multiraft.go
@@ -798,6 +798,11 @@ func (s *state) handleMessage(req *RaftMessageRequest) {
 // messages (in which case the replicaID comes from the incoming
 // message, since nothing is on disk yet).
 func (s *state) createGroup(groupID roachpb.RangeID, replicaID roachpb.ReplicaID) error {
+	locker := s.Storage.GroupLocker()
+	if locker != nil {
+		locker.Lock()
+		defer locker.Unlock()
+	}
 	if g, ok := s.groups[groupID]; ok {
 		if replicaID != 0 && g.replicaID != replicaID {
 			return util.Errorf("cannot create group %s with replica ID %s; already exists with replica ID %s",

--- a/multiraft/storage.go
+++ b/multiraft/storage.go
@@ -52,6 +52,13 @@ type Storage interface {
 	ReplicaDescriptor(groupID roachpb.RangeID, replicaID roachpb.ReplicaID) (roachpb.ReplicaDescriptor, error)
 	ReplicaIDForStore(groupID roachpb.RangeID, storeID roachpb.StoreID) (roachpb.ReplicaID, error)
 	ReplicasFromSnapshot(snap raftpb.Snapshot) ([]roachpb.ReplicaDescriptor, error)
+
+	// GroupLocker returns a lock which (if non-nil) will be acquired
+	// when a group is being created (which entails multiple calls to
+	// Storage and StateMachine methods and may race with the removal of
+	// a previous incarnation of a group). If it returns a non-nil value
+	// it must return the same value on every call.
+	GroupLocker() sync.Locker
 }
 
 // The StateMachine interface is supplied by the application to manage a persistent
@@ -109,6 +116,11 @@ func (m *MemoryStorage) ReplicaIDForStore(groupID roachpb.RangeID, storeID roach
 // ReplicasFromSnapshot implements the Storage interface.
 func (m *MemoryStorage) ReplicasFromSnapshot(_ raftpb.Snapshot) ([]roachpb.ReplicaDescriptor, error) {
 	return nil, nil
+}
+
+// GroupLocker implements the Storage interface by returning nil.
+func (m *MemoryStorage) GroupLocker() sync.Locker {
+	return nil
 }
 
 // groupWriteRequest represents a set of changes to make to a group.

--- a/multiraft/storage_test.go
+++ b/multiraft/storage_test.go
@@ -53,6 +53,10 @@ func (b *BlockableStorage) ReplicasFromSnapshot(snap raftpb.Snapshot) ([]roachpb
 	return b.storage.ReplicasFromSnapshot(snap)
 }
 
+func (b *BlockableStorage) GroupLocker() sync.Locker {
+	return b.storage.GroupLocker()
+}
+
 type blockableGroupStorage struct {
 	b *BlockableStorage
 	s WriteableGroupStorage

--- a/storage/replica.go
+++ b/storage/replica.go
@@ -162,6 +162,7 @@ type RangeManager interface {
 
 	// Range and replica manipulation methods.
 	LookupReplica(start, end roachpb.RKey) *Replica
+	GetReplica(rangeID roachpb.RangeID) (*Replica, error)
 	MergeRange(subsumingRng *Replica, updatedEndKey roachpb.RKey, subsumedRangeID roachpb.RangeID) error
 	NewRangeDescriptor(start, end roachpb.RKey, replicas []roachpb.ReplicaDescriptor) (*roachpb.RangeDescriptor, error)
 	NewSnapshot() engine.Engine


### PR DESCRIPTION
This partially addresses the race seen in #2815. A similar race still
occurs but much less frequently.
