### PR TITLE
Initial work on leaseManager.

### DIFF
--- a/keys/constants.go
+++ b/keys/constants.go
@@ -190,6 +190,7 @@ const (
 	SystemDatabaseID  = 1
 	NamespaceTableID  = 2
 	DescriptorTableID = 3
-	UsersTableID      = 4
-	ZonesTableID      = 5
+	LeaseTableID      = 4
+	UsersTableID      = 5
+	ZonesTableID      = 6
 )

--- a/roachpb/data.go
+++ b/roachpb/data.go
@@ -290,10 +290,8 @@ func (t *Timestamp) Backward(s Timestamp) {
 }
 
 // GoTime converts the timestamp to a time.Time.
-func (t *Timestamp) GoTime() time.Time {
-	sec := t.WallTime / 1e9
-	nsec := t.WallTime % 1e9
-	return time.Unix(sec, nsec)
+func (t Timestamp) GoTime() time.Time {
+	return time.Unix(0, t.WallTime)
 }
 
 // InitChecksum initializes a checksum based on the provided key and

--- a/server/server.go
+++ b/server/server.go
@@ -137,7 +137,7 @@ func NewServer(ctx *Context, stopper *stop.Stopper) (*Server, error) {
 		return nil, err
 	}
 
-	s.sqlServer = sql.MakeHTTPServer(&s.ctx.Context, *s.db, s.gossip)
+	s.sqlServer = sql.MakeHTTPServer(&s.ctx.Context, *s.db, s.gossip, s.clock)
 
 	// TODO(bdarnell): make StoreConfig configurable.
 	nCtx := storage.StoreContext{

--- a/sql/delete.go
+++ b/sql/delete.go
@@ -105,6 +105,10 @@ func (p *planner) Delete(n *parser.Delete) (planNode, error) {
 		return nil, err
 	}
 
+	if IsSystemID(tableDesc.GetID()) {
+		// Mark transaction as operating on the system DB.
+		p.txn.SetSystemDBTrigger()
+	}
 	if err := p.txn.Run(&b); err != nil {
 		return nil, err
 	}

--- a/sql/executor.go
+++ b/sql/executor.go
@@ -31,6 +31,7 @@ import (
 	"github.com/cockroachdb/cockroach/roachpb"
 	"github.com/cockroachdb/cockroach/sql/driver"
 	"github.com/cockroachdb/cockroach/sql/parser"
+	"github.com/cockroachdb/cockroach/util/hlc"
 	"github.com/gogo/protobuf/proto"
 )
 
@@ -48,9 +49,9 @@ type Executor struct {
 	systemConfigMu sync.RWMutex
 }
 
-// NewExecutor creates an Executor and registers a callback on the
+// newExecutor creates an Executor and registers a callback on the
 // system config.
-func NewExecutor(db client.DB, gossip *gossip.Gossip) *Executor {
+func newExecutor(db client.DB, gossip *gossip.Gossip, clock *hlc.Clock) *Executor {
 	exec := &Executor{db: db}
 	gossip.RegisterSystemConfigCallback(exec.updateSystemConfig)
 	return exec

--- a/sql/http_server.go
+++ b/sql/http_server.go
@@ -29,6 +29,7 @@ import (
 	"github.com/cockroachdb/cockroach/security"
 	"github.com/cockroachdb/cockroach/sql/driver"
 	"github.com/cockroachdb/cockroach/util"
+	"github.com/cockroachdb/cockroach/util/hlc"
 )
 
 var allowedEncodings = []util.EncodingType{util.JSONEncoding, util.ProtoEncoding}
@@ -41,8 +42,8 @@ type HTTPServer struct {
 }
 
 // MakeHTTPServer creates an HTTPServer.
-func MakeHTTPServer(ctx *base.Context, db client.DB, gossip *gossip.Gossip) HTTPServer {
-	return HTTPServer{context: ctx, Executor: NewExecutor(db, gossip)}
+func MakeHTTPServer(ctx *base.Context, db client.DB, gossip *gossip.Gossip, clock *hlc.Clock) HTTPServer {
+	return HTTPServer{context: ctx, Executor: newExecutor(db, gossip, clock)}
 }
 
 // ServeHTTP serves the SQL API by treating the request URL path

--- a/sql/lease.go
+++ b/sql/lease.go
@@ -1,0 +1,507 @@
+// Copyright 2015 The Cockroach Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+// implied. See the License for the specific language governing
+// permissions and limitations under the License. See the AUTHORS file
+// for names of contributors.
+//
+// Author: Peter Mattis (peter@cockroachlabs.com)
+
+package sql
+
+import (
+	"bytes"
+	"errors"
+	"fmt"
+	"math/rand"
+	"sort"
+	"sync"
+	"time"
+
+	"github.com/cockroachdb/cockroach/client"
+	"github.com/cockroachdb/cockroach/security"
+	"github.com/cockroachdb/cockroach/sql/parser"
+	"github.com/cockroachdb/cockroach/util"
+	"github.com/cockroachdb/cockroach/util/hlc"
+	"github.com/cockroachdb/cockroach/util/log"
+	"github.com/cockroachdb/cockroach/util/retry"
+	"github.com/gogo/protobuf/proto"
+)
+
+// TODO(pmattis): Periodically renew leases for tables that were used recently and
+// for which the lease will expire soon.
+
+const (
+	leaseDuration    = 5 * time.Minute
+	minLeaseDuration = time.Minute
+)
+
+var (
+	errLeaseVersionChanged = errors.New("lease version changed")
+)
+
+// LeaseState holds the state for a lease. Exported only for testing.
+type LeaseState struct {
+	TableDescriptor
+	expiration parser.DTimestamp
+	refcount   int
+}
+
+func (s *LeaseState) String() string {
+	return fmt.Sprintf("%d:%d", s.Version, s.expiration.UnixNano())
+}
+
+// Expiration returns the expiration time of the lease.
+func (s *LeaseState) Expiration() time.Time {
+	return s.expiration.Time
+}
+
+// Refcount returns the reference count of the lease.
+func (s *LeaseState) Refcount() int {
+	return s.refcount
+}
+
+// LeaseStore implements the operations for acquiring and releasing leases and
+// publishing a new version of a descriptor. Exported only for testing.
+type LeaseStore struct {
+	db     client.DB
+	clock  *hlc.Clock
+	nodeID uint32
+}
+
+// jitteredLeaseDuration returns a randomly jittered duration from the interval
+// [0.75 * leaseDuration, 1.25 * leaseDuration].
+func (s LeaseStore) jitteredLeaseDuration() time.Duration {
+	return time.Duration(float64(leaseDuration) * (0.75 + 0.5*rand.Float64()))
+}
+
+// Acquire a lease on the most recent version of a table descriptor.
+func (s LeaseStore) Acquire(tableID ID, minVersion uint32) (*LeaseState, error) {
+	lease := &LeaseState{}
+	lease.expiration = parser.DTimestamp{
+		Time: time.Unix(0, s.clock.Now().WallTime).Add(s.jitteredLeaseDuration()),
+	}
+
+	err := s.db.Txn(func(txn *client.Txn) error {
+		p := planner{txn: txn, user: security.RootUser}
+
+		const getDescriptor = `SELECT descriptor FROM system.descriptor WHERE id = %d`
+		sql := fmt.Sprintf(getDescriptor, tableID)
+		values, err := p.queryRow(sql)
+		if err != nil {
+			return err
+		}
+		if values == nil {
+			return util.Errorf("table ID %d not found", tableID)
+		}
+		if err := proto.Unmarshal([]byte(values[0].(parser.DBytes)), &lease.TableDescriptor); err != nil {
+			return err
+		}
+
+		if err := lease.Validate(); err != nil {
+			return err
+		}
+		if lease.Version < minVersion {
+			return util.Errorf("version %d of table %d does not exist yet", minVersion, tableID)
+		}
+
+		const insertLease = `INSERT INTO system.lease (descID, version, nodeID, expiration) ` +
+			`VALUES (%d, %d, %d, '%s'::timestamp)`
+		sql = fmt.Sprintf(insertLease, lease.ID, lease.Version, s.nodeID, lease.expiration)
+		count, err := p.exec(sql)
+		if err != nil {
+			return err
+		}
+		if count != 1 {
+			return util.Errorf("%s: expected 1 result, found %d", sql, count)
+		}
+		return nil
+	})
+	return lease, err
+}
+
+// Release a previously acquired table descriptor lease.
+func (s LeaseStore) Release(lease *LeaseState) error {
+	return s.db.Txn(func(txn *client.Txn) error {
+		p := planner{txn: txn, user: security.RootUser}
+
+		const deleteLease = `DELETE FROM system.lease ` +
+			`WHERE (descID, version, nodeID, expiration) = (%d, %d, %d, '%s'::timestamp)`
+		sql := fmt.Sprintf(deleteLease, lease.ID, lease.Version, s.nodeID, lease.expiration)
+		count, err := p.exec(sql)
+		if err != nil {
+			return err
+		}
+		if count != 1 {
+			return util.Errorf("%s: expected 1 result, found %d", sql, count)
+		}
+		return nil
+	})
+}
+
+// Publish a new version of a table descriptor. The update closure may be
+// called multiple times if retries occur: make sure it does not have side
+// effects.
+func (s LeaseStore) Publish(tableID ID, update func(*TableDescriptor) error) error {
+	desc := &TableDescriptor{}
+	descKey := MakeDescMetadataKey(tableID)
+
+	retryOpts := retry.Options{
+		InitialBackoff: 20 * time.Millisecond,
+		MaxBackoff:     2 * time.Second,
+		Multiplier:     2,
+	}
+
+	for r := retry.Start(retryOpts); r.Next(); {
+		// Get the current version of the table descriptor non-transactionally.
+		//
+		// TODO(pmattis): Do an inconsistent read here?
+		if err := s.db.GetProto(descKey, desc); err != nil {
+			return err
+		}
+		// Check to see if there are any leases that still exist on the previous
+		// version of the descriptor.
+		now := s.clock.Now()
+		count, err := s.countLeases(desc.ID, desc.Version-1, now.GoTime())
+		if err != nil {
+			return err
+		}
+		if count != 0 {
+			log.Infof("publish (count leases): descID=%d version=%d count=%d", desc.ID, desc.Version-1, count)
+			continue
+		}
+
+		// At this point, desc.Version is the only version of the descriptor that
+		// has leases outstanding. Lease acquisition (see acquire()) maintains the
+		// invariant that no new leases for desc.Version-1 will be granted once
+		// desc.Version exists.
+		expectedVersion := desc.Version
+		err = s.db.Txn(func(txn *client.Txn) error {
+			// Re-read the current version of the table descriptor, this time
+			// transactionally.
+			if err := txn.GetProto(descKey, desc); err != nil {
+				return err
+			}
+			if expectedVersion != desc.Version {
+				// The version changed out from under us. Someone else must be
+				// performing a schema change operation.
+				if log.V(3) {
+					log.Infof("publish (version changed): %d != %d", expectedVersion, desc.Version)
+				}
+				return errLeaseVersionChanged
+			}
+
+			// Run the update closure which is intended to perform a single step in a
+			// multi-step schema change operation.
+			if err := update(desc); err != nil {
+				return err
+			}
+
+			// Bump the version and modification time.
+			desc.Version = desc.Version + 1
+			desc.ModificationTime = now
+			if log.V(3) {
+				log.Infof("publish: descID=%d version=%d mtime=%s", desc.ID, desc.Version, now.GoTime())
+			}
+
+			// Write the updated descriptor.
+			b := &client.Batch{}
+			b.Put(descKey, desc)
+			txn.SetSystemDBTrigger()
+			return txn.CommitInBatch(b)
+		})
+
+		if err != errLeaseVersionChanged {
+			return err
+		}
+	}
+
+	panic("not reached")
+}
+
+// countLeases returns the number of unexpired leases for a particular version
+// of a descriptor.
+func (s LeaseStore) countLeases(descID ID, version uint32, expiration time.Time) (int, error) {
+	var count int
+	err := s.db.Txn(func(txn *client.Txn) error {
+		p := planner{txn: txn, user: security.RootUser}
+
+		const countLeases = `SELECT COUNT(version) FROM system.lease ` +
+			`WHERE descID = %d AND version = %d AND expiration > '%s'::timestamp`
+		sql := fmt.Sprintf(countLeases, descID, version, parser.DTimestamp{Time: expiration})
+		values, err := p.queryRow(sql)
+		if err != nil {
+			return err
+		}
+		count = int(values[0].(parser.DInt))
+		return nil
+	})
+	return count, err
+}
+
+// leaseSet maintains an ordered set of LeaseState objects. It supports
+// addition and removal of elements, finding a specific lease, finding the
+// newest lease for a particular version and finding the newest lease for the
+// most recent version.
+type leaseSet struct {
+	// The lease state data is stored in a sorted slice ordered by <version,
+	// expiration>. Ordering is maintained by insert and remove.
+	data []*LeaseState
+}
+
+func (l *leaseSet) String() string {
+	var buf bytes.Buffer
+	for i, s := range l.data {
+		if i > 0 {
+			buf.WriteString(" ")
+		}
+		buf.WriteString(s.String())
+	}
+	return buf.String()
+}
+
+func (l *leaseSet) insert(s *LeaseState) {
+	i, match := l.findIndex(s.Version, s.expiration)
+	if match {
+		panic("unable to insert duplicate lease")
+	}
+	if i == len(l.data) {
+		l.data = append(l.data, s)
+		return
+	}
+	l.data = append(l.data, nil)
+	copy(l.data[i+1:], l.data[i:])
+	l.data[i] = s
+}
+
+func (l *leaseSet) remove(s *LeaseState) {
+	i, match := l.findIndex(s.Version, s.expiration)
+	if !match {
+		return
+	}
+	l.data = append(l.data[:i], l.data[i+1:]...)
+}
+
+func (l *leaseSet) find(version uint32, expiration parser.DTimestamp) *LeaseState {
+	if i, match := l.findIndex(version, expiration); match {
+		return l.data[i]
+	}
+	return nil
+}
+
+func (l *leaseSet) findIndex(version uint32, expiration parser.DTimestamp) (int, bool) {
+	i := sort.Search(len(l.data), func(i int) bool {
+		s := l.data[i]
+		if s.Version == version {
+			// a >= b -> !a.Before(b)
+			return !s.expiration.Before(expiration.Time)
+		}
+		return s.Version > version
+	})
+	if i < len(l.data) {
+		s := l.data[i]
+		if s.Version == version && s.expiration.Equal(expiration.Time) {
+			return i, true
+		}
+	}
+	return i, false
+}
+
+func (l *leaseSet) findNewest(version uint32) *LeaseState {
+	if len(l.data) == 0 {
+		return nil
+	}
+	if version == 0 {
+		// No explicitly version, return the newest lease of the latest version.
+		return l.data[len(l.data)-1]
+	}
+	// Find the index of the first lease with version > targetVersion.
+	i := sort.Search(len(l.data), func(i int) bool {
+		return l.data[i].Version > version
+	})
+	if i == 0 {
+		return nil
+	}
+	// i-1 is the index of the newest lease for the previous version (the version
+	// we're looking for).
+	s := l.data[i-1]
+	if s.Version == version {
+		return s
+	}
+	return nil
+}
+
+type tableState struct {
+	id ID
+	// Protects both active and acquiring.
+	mu sync.Mutex
+	// The active leases for the table: sorted by their version and expiration
+	// time. There may be more than one active lease when the system is
+	// transitioning from one version of the descriptor to another or when the
+	// node preemptively acquires a new lease for a version when the old lease
+	// has not yet expired.
+	active leaseSet
+	// A channel used to indicate whether a lease is actively being acquired.
+	// nil if there is no lease acquisition in progress for the table. If
+	// non-nil, the channel will be closed when lease acquisition completes.
+	acquiring chan struct{}
+}
+
+func (t *tableState) acquire(version uint32, store LeaseStore) (*LeaseState, error) {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+
+	for {
+		s := t.active.findNewest(version)
+		if s != nil {
+			if version != 0 && s != t.active.findNewest(0) {
+				// If a lease was requested for an old version of the descriptor,
+				// return it even if there is only a short time left before it
+				// expires. We can't renew this lease as doing so would violate the
+				// invariant that we only get leases on the newest version. The
+				// transaction will either finish before the lease expires or it will
+				// abort, which is what will happen if we returned an error here.
+				s.refcount++
+				return s, nil
+			}
+			minDesiredExpiration := store.clock.Now().GoTime().Add(minLeaseDuration)
+			if s.expiration.After(minDesiredExpiration) {
+				s.refcount++
+				return s, nil
+			}
+		} else if version != 0 {
+			n := t.active.findNewest(0)
+			if n != nil && version < n.Version {
+				return nil, util.Errorf("table %d unable to acquire lease on old version: %d < %d",
+					t.id, version, n.Version)
+			}
+		}
+
+		if t.acquiring != nil {
+			// There is already a lease acquisition in progress. Wait for it to complete.
+			t.acquireWait()
+		} else {
+			// There is no active lease acquisition so we'll go ahead and perform
+			// one.
+			t.acquiring = make(chan struct{})
+			s, err := t.acquireNodeLease(version, store)
+			close(t.acquiring)
+			t.acquiring = nil
+			if err != nil {
+				return nil, err
+			}
+			t.active.insert(s)
+		}
+
+		// A new lease was added, so loop and perform the lookup again.
+	}
+}
+
+func (t *tableState) acquireWait() {
+	// We're called with mu locked, but need to unlock it while we wait for the
+	// in-progress lease acquisition to finish.
+	acquiring := t.acquiring
+	t.mu.Unlock()
+	defer t.mu.Lock()
+	<-acquiring
+}
+
+func (t *tableState) acquireNodeLease(version uint32, store LeaseStore) (*LeaseState, error) {
+	// We're called with mu locked, but need to unlock it during lease
+	// acquisition.
+	t.mu.Unlock()
+	defer t.mu.Lock()
+	return store.Acquire(t.id, version)
+}
+
+func (t *tableState) release(lease *LeaseState, store LeaseStore) error {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	s := t.active.find(lease.Version, lease.expiration)
+	if s == nil {
+		return util.Errorf("table %d version %d not found", lease.ID, lease.Version)
+	}
+	s.refcount--
+	if s.refcount == 0 {
+		n := t.active.findNewest(0)
+		if s != n {
+			if s.Version < n.Version {
+				// TODO(pmattis): If an active transaction is releasing the lease for
+				// an older version, hold on to it for a few seconds in anticipation of
+				// another operation being performed within the transaction. If we
+				// release the lease immediately the transaction will necessarily abort
+				// on the next operation due to not being able to get the lease.
+			}
+			t.active.remove(s)
+			return t.releaseNodeLease(s, store)
+		}
+	}
+	return nil
+}
+
+func (t *tableState) releaseNodeLease(lease *LeaseState, store LeaseStore) error {
+	// We're called with mu locked, but need to unlock it while releasing the
+	// lease.
+	t.mu.Unlock()
+	defer t.mu.Lock()
+	return store.Release(lease)
+}
+
+// LeaseManager manages acquiring and releasing per-table leases. Exported only
+// for testing.
+type LeaseManager struct {
+	LeaseStore
+	mu     sync.Mutex
+	tables map[ID]*tableState
+}
+
+// NewLeaseManager creates a new LeaseManager.
+func NewLeaseManager(nodeID uint32, db client.DB, clock *hlc.Clock) *LeaseManager {
+	return &LeaseManager{
+		LeaseStore: LeaseStore{
+			db:     db,
+			clock:  clock,
+			nodeID: nodeID,
+		},
+		tables: make(map[ID]*tableState),
+	}
+}
+
+// Acquire acquires a read lease for the specified table ID. If version is
+// non-zero the lease is grabbed for the specified version. Otherwise it is
+// grabbed for the most recent version of the descriptor that the lease manager
+// knows about.
+func (m *LeaseManager) Acquire(tableID ID, version uint32) (*LeaseState, error) {
+	t := m.findTableState(tableID, true)
+	return t.acquire(version, m.LeaseStore)
+}
+
+// Release releases a previously acquired read lease.
+func (m *LeaseManager) Release(lease *LeaseState) error {
+	t := m.findTableState(lease.ID, false)
+	if t == nil {
+		return util.Errorf("table %d not found", lease.ID)
+	}
+	// TODO(pmattis): Can/should we delete from LeaseManager.tables if the
+	// tableState becomes empty?
+	return t.release(lease, m.LeaseStore)
+}
+
+func (m *LeaseManager) findTableState(tableID ID, create bool) *tableState {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	t := m.tables[tableID]
+	if t == nil && create {
+		t = &tableState{id: tableID}
+		m.tables[tableID] = t
+	}
+	return t
+}

--- a/sql/lease_internal_test.go
+++ b/sql/lease_internal_test.go
@@ -1,0 +1,105 @@
+// Copyright 2015 The Cockroach Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+// implied. See the License for the specific language governing
+// permissions and limitations under the License. See the AUTHORS file
+// for names of contributors.
+//
+// Author: Peter Mattis (peter@cockroachlabs.com)
+
+package sql
+
+import (
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/cockroachdb/cockroach/util/leaktest"
+)
+
+func TestLeaseSet(t *testing.T) {
+	defer leaktest.AfterTest(t)
+
+	type data struct {
+		version    uint32
+		expiration int64
+	}
+	type insert data
+	type remove data
+
+	type newest struct {
+		version uint32
+	}
+
+	testData := []struct {
+		op       interface{}
+		expected string
+	}{
+		{newest{0}, "<nil>"},
+		{insert{2, 3}, "2:3"},
+		{newest{0}, "2:3"},
+		{newest{2}, "2:3"},
+		{newest{3}, "<nil>"},
+		{insert{2, 1}, "2:1 2:3"},
+		{newest{0}, "2:3"},
+		{newest{2}, "2:3"},
+		{newest{3}, "<nil>"},
+		{insert{2, 4}, "2:1 2:3 2:4"},
+		{newest{0}, "2:4"},
+		{newest{2}, "2:4"},
+		{newest{3}, "<nil>"},
+		{insert{2, 2}, "2:1 2:2 2:3 2:4"},
+		{insert{3, 1}, "2:1 2:2 2:3 2:4 3:1"},
+		{newest{0}, "3:1"},
+		{newest{1}, "<nil>"},
+		{newest{2}, "2:4"},
+		{newest{3}, "3:1"},
+		{newest{4}, "<nil>"},
+		{insert{1, 1}, "1:1 2:1 2:2 2:3 2:4 3:1"},
+		{newest{0}, "3:1"},
+		{newest{1}, "1:1"},
+		{newest{2}, "2:4"},
+		{newest{3}, "3:1"},
+		{newest{4}, "<nil>"},
+		{remove{0, 0}, "1:1 2:1 2:2 2:3 2:4 3:1"},
+		{remove{2, 4}, "1:1 2:1 2:2 2:3 3:1"},
+		{remove{3, 1}, "1:1 2:1 2:2 2:3"},
+		{remove{1, 1}, "2:1 2:2 2:3"},
+		{remove{2, 2}, "2:1 2:3"},
+		{remove{2, 3}, "2:1"},
+		{remove{2, 1}, ""},
+	}
+
+	set := &leaseSet{}
+	for i, d := range testData {
+		switch op := d.op.(type) {
+		case insert:
+			s := &LeaseState{}
+			s.Version = op.version
+			s.expiration.Time = time.Unix(0, op.expiration)
+			set.insert(s)
+		case remove:
+			s := &LeaseState{}
+			s.Version = op.version
+			s.expiration.Time = time.Unix(0, op.expiration)
+			set.remove(s)
+		case newest:
+			n := set.findNewest(op.version)
+			if s := fmt.Sprint(n); d.expected != s {
+				t.Fatalf("%d: expected %s, but found %s", i, d.expected, s)
+			}
+			continue
+		}
+		if s := set.String(); d.expected != s {
+			t.Fatalf("%d: expected %s, but found %s", i, d.expected, s)
+		}
+	}
+}

--- a/sql/lease_test.go
+++ b/sql/lease_test.go
@@ -1,0 +1,336 @@
+// Copyright 2015 The Cockroach Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+// implied. See the License for the specific language governing
+// permissions and limitations under the License. See the AUTHORS file
+// for names of contributors.
+//
+// Author: Peter Mattis (peter@cockroachlabs.com)
+
+package sql_test
+
+import (
+	"bytes"
+	"database/sql"
+	"fmt"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/cockroachdb/cockroach/keys"
+	"github.com/cockroachdb/cockroach/roachpb"
+	"github.com/cockroachdb/cockroach/server"
+	csql "github.com/cockroachdb/cockroach/sql"
+	"github.com/cockroachdb/cockroach/testutils"
+	"github.com/cockroachdb/cockroach/util/leaktest"
+)
+
+type leaseTest struct {
+	*testing.T
+	server *server.TestServer
+	db     *sql.DB
+	nodes  map[uint32]*csql.LeaseManager
+}
+
+func newLeaseTest(t *testing.T) *leaseTest {
+	s, db, _ := setup(t)
+	return &leaseTest{
+		T:      t,
+		server: s,
+		db:     db,
+		nodes:  map[uint32]*csql.LeaseManager{},
+	}
+}
+
+func (t *leaseTest) cleanup() {
+	cleanup(t.server, t.db)
+}
+
+func (t *leaseTest) getLeases(descID csql.ID) string {
+	sql := `
+SELECT version, nodeID FROM system.lease WHERE descID = $1 ORDER BY version, nodeID
+`
+	rows, err := t.db.Query(sql, descID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var buf bytes.Buffer
+	var prefix string
+	for rows.Next() {
+		var (
+			version int
+			nodeID  int
+		)
+		if err := rows.Scan(&version, &nodeID); err != nil {
+			t.Fatal(err)
+		}
+		fmt.Fprintf(&buf, "%s/%d/%d", prefix, version, nodeID)
+		prefix = " "
+	}
+	if err := rows.Err(); err != nil {
+		t.Fatal(err)
+	}
+	return buf.String()
+}
+
+func (t *leaseTest) expectLeases(descID csql.ID, expected string) {
+	leases := t.getLeases(descID)
+	if expected != leases {
+		t.Fatalf("expected %s, but found %s", expected, leases)
+	}
+}
+
+func (t *leaseTest) acquire(nodeID uint32, descID csql.ID, version uint32) (*csql.LeaseState, error) {
+	return t.node(nodeID).Acquire(descID, version)
+}
+
+func (t *leaseTest) mustAcquire(nodeID uint32, descID csql.ID, version uint32) *csql.LeaseState {
+	lease, err := t.acquire(nodeID, descID, version)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return lease
+}
+
+func (t *leaseTest) release(nodeID uint32, lease *csql.LeaseState) error {
+	return t.node(nodeID).Release(lease)
+}
+
+func (t *leaseTest) mustRelease(nodeID uint32, lease *csql.LeaseState) {
+	if err := t.release(nodeID, lease); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func (t *leaseTest) publish(nodeID uint32, descID csql.ID) error {
+	return t.node(nodeID).Publish(descID,
+		func(*csql.TableDescriptor) error {
+			return nil
+		})
+}
+
+func (t *leaseTest) mustPublish(nodeID uint32, descID csql.ID) {
+	if err := t.publish(nodeID, descID); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func (t *leaseTest) node(nodeID uint32) *csql.LeaseManager {
+	mgr := t.nodes[nodeID]
+	if mgr == nil {
+		mgr = csql.NewLeaseManager(nodeID, *t.server.DB(), t.server.Clock())
+		t.nodes[nodeID] = mgr
+	}
+	return mgr
+}
+
+func TestLeaseManager(testingT *testing.T) {
+	defer leaktest.AfterTest(testingT)
+	t := newLeaseTest(testingT)
+	defer t.cleanup()
+
+	const descID = keys.LeaseTableID
+
+	// We can't acquire a lease on a non-existent table.
+	expected := "table ID 10000 not found"
+	if _, err := t.acquire(1, 10000, 0); !testutils.IsError(err, expected) {
+		t.Fatalf("expected %s, but found %v", expected, err)
+	}
+
+	l1 := t.mustAcquire(1, descID, 0)
+	t.expectLeases(descID, "/1/1")
+	// Node 2 never acquired a lease on descID, so we should expect an error.
+	if err := t.release(2, l1); err == nil {
+		t.Fatalf("expected error, but found none")
+	}
+	t.mustRelease(1, l1)
+	t.expectLeases(descID, "/1/1")
+
+	// It is an error to acquire a lease for a specific version that doesn't
+	// exist yet.
+	expected = "version 2 of table .* does not exist"
+	if _, err := t.acquire(1, descID, 2); !testutils.IsError(err, expected) {
+		t.Fatalf("expected %s, but found %v", expected, err)
+	}
+
+	// Publish a new version and explicitly acquire it.
+	l2 := t.mustAcquire(1, descID, 0)
+	t.mustPublish(1, descID)
+	l3 := t.mustAcquire(1, descID, 2)
+	t.expectLeases(descID, "/1/1 /2/1")
+
+	// When the last local reference on the new version is released we don't
+	// release the node lease.
+	t.mustRelease(1, l3)
+	t.expectLeases(descID, "/1/1 /2/1")
+
+	// We can still acquire a local reference on the old version since it hasn't
+	// expired.
+	l4 := t.mustAcquire(1, descID, 1)
+	t.mustRelease(1, l4)
+	t.expectLeases(descID, "/1/1 /2/1")
+
+	// When the last local reference on the old version is released the node
+	// lease is also released.
+	t.mustRelease(1, l2)
+	t.expectLeases(descID, "/2/1")
+
+	// It is an error to acquire a lease for an old version once a new version
+	// exists and there are no local references for the old version.
+	expected = "sql/lease.go.*: table .* unable to acquire lease on old version: 1 < 2"
+	if _, err := t.acquire(1, descID, 1); !testutils.IsError(err, expected) {
+		t.Fatalf("expected %s, but found %v", expected, err)
+	}
+
+	// Acquire 2 node leases on version 2.
+	l5 := t.mustAcquire(1, descID, 2)
+	l6 := t.mustAcquire(2, descID, 2)
+	// Publish version 3. This will succeed immediately.
+	t.mustPublish(3, descID)
+
+	// Start a goroutine to publish version 4 which will block until the version
+	// 2 leases are released.
+	var wg sync.WaitGroup
+	wg.Add(1)
+	go func() {
+		t.mustPublish(3, descID)
+		wg.Done()
+	}()
+
+	// Force both nodes ahead to version 3.
+	l7 := t.mustAcquire(1, descID, 3)
+	l8 := t.mustAcquire(2, descID, 3)
+	t.expectLeases(descID, "/2/1 /2/2 /3/1 /3/2")
+
+	t.mustRelease(1, l5)
+	t.expectLeases(descID, "/2/2 /3/1 /3/2")
+	t.mustRelease(2, l6)
+	t.expectLeases(descID, "/3/1 /3/2")
+
+	// Wait for version 4 to be published.
+	wg.Wait()
+	l9 := t.mustAcquire(1, descID, 4)
+	t.mustRelease(1, l7)
+	t.mustRelease(2, l8)
+	t.expectLeases(descID, "/3/2 /4/1")
+	t.mustRelease(1, l9)
+	t.expectLeases(descID, "/3/2 /4/1")
+}
+
+func TestLeaseManagerReacquire(testingT *testing.T) {
+	defer leaktest.AfterTest(testingT)
+	t := newLeaseTest(testingT)
+	defer t.cleanup()
+
+	const descID = keys.LeaseTableID
+
+	// Acquire 2 leases from the same node. They should point to the same lease
+	// structure.
+	l1 := t.mustAcquire(1, descID, 0)
+	l2 := t.mustAcquire(1, descID, 0)
+	if l1 != l2 {
+		t.Fatalf("expected same lease, but found %p != %p", l1, l2)
+	}
+	if l1.Refcount() != 2 {
+		t.Fatalf("expected refcount of 2, but found %d", l1.Refcount())
+	}
+	t.expectLeases(descID, "/1/1")
+
+	// Push the clock up near the lease expiration. The 20s is less than
+	// minLeaseDuration.
+	t.server.Clock().Update(roachpb.Timestamp{
+		WallTime: l1.Expiration().Add(-20 * time.Second).UnixNano(),
+	})
+
+	// Another lease acquisition from the same node will result in a new lease.
+	l3 := t.mustAcquire(1, descID, 0)
+	if l1 == l3 {
+		t.Fatalf("expected different leases, but found %p", l1)
+	}
+	if l3.Refcount() != 1 {
+		t.Fatalf("expected refcount of 1, but found %d", l3.Refcount())
+	}
+	if l3.Expiration().Before(l1.Expiration()) {
+		t.Fatalf("expected new lease expiration (%s) to be after old lease expiration (%s)",
+			l3.Expiration(), l1.Expiration())
+	}
+	t.expectLeases(descID, "/1/1 /1/1")
+
+	t.mustRelease(1, l1)
+	t.mustRelease(1, l2)
+	t.mustRelease(1, l3)
+}
+
+func TestLeaseManagerPublishVersionChanged(testingT *testing.T) {
+	// This test takes ~10 seconds because of the unresolved write intents in the
+	// system DB span.
+	testingT.Skipf("TODO(tschottdorf): #2871")
+
+	defer leaktest.AfterTest(testingT)
+	t := newLeaseTest(testingT)
+	defer t.cleanup()
+
+	const descID = keys.LeaseTableID
+
+	// Start two goroutines that are concurrently trying to publish a new version
+	// of the descriptor. The first goroutine progresses to the update function
+	// and then signals the second goroutine to start which is allowed to proceed
+	// through completion. The first goroutine is then signaled and when it
+	// attempts to publish the new version it will encounter an update error and
+	// retry the transaction. Upon retry it will see that the descriptor version
+	// has changed and have to proceed to its outer retry loop and wait for the
+	// number of leases on the previous version to drop to 0.
+
+	n1 := t.node(1)
+	n2 := t.node(2)
+
+	n1update := make(chan struct{})
+	n2start := make(chan struct{})
+	var wg sync.WaitGroup
+	wg.Add(2)
+
+	go func(n1update, n2start chan struct{}) {
+		err := n1.Publish(descID, func(*csql.TableDescriptor) error {
+			if n2start != nil {
+				// Signal node 2 to start.
+				close(n2start)
+				n2start = nil
+			}
+			// Wait for node 2 signal indicating that node 2 finished publication of
+			// a new version.
+			<-n1update
+			return nil
+		})
+		if err != nil {
+			panic(err)
+		}
+		wg.Done()
+	}(n1update, n2start)
+
+	go func(n1update, n2start chan struct{}) {
+		// Wait for node 1 signal indicating that node 1 is in its update()
+		// function.
+		<-n2start
+		err := n2.Publish(descID, func(*csql.TableDescriptor) error {
+			return nil
+		})
+		if err != nil {
+			panic(err)
+		}
+		close(n1update)
+		wg.Done()
+	}(n1update, n2start)
+
+	wg.Wait()
+
+	t.mustAcquire(1, descID, 0)
+	t.expectLeases(descID, "/3/1")
+}

--- a/sql/structured.go
+++ b/sql/structured.go
@@ -138,6 +138,9 @@ func (desc *TableDescriptor) AllocateIDs() error {
 	if desc.NextIndexID == 0 {
 		desc.NextIndexID = 1
 	}
+	if desc.Version == 0 {
+		desc.Version = 1
+	}
 
 	columnNames := map[string]ColumnID{}
 	for i := range desc.Columns {

--- a/sql/structured.proto
+++ b/sql/structured.proto
@@ -20,6 +20,7 @@ package cockroach.sql;
 option go_package = "sql";
 
 import "gogoproto/gogo.proto";
+import "cockroach/roachpb/data.proto";
 import "cockroach/sql/privilege.proto";
 
 option (gogoproto.sizer_all) = true;
@@ -99,17 +100,21 @@ message TableDescriptor {
   // ID of the parent database.
   optional uint32 parent_id = 4 [(gogoproto.nullable) = false,
       (gogoproto.customname) = "ParentID", (gogoproto.casttype) = "ID"];
-  repeated ColumnDescriptor columns = 5 [(gogoproto.nullable) = false];
+  // Monotonically increasing version of the table descriptor.
+  optional uint32 version = 5 [(gogoproto.nullable) = false];
+  // Last modification time of the table descriptor.
+  optional roachpb.Timestamp modification_time = 6 [(gogoproto.nullable) = false];
+  repeated ColumnDescriptor columns = 7 [(gogoproto.nullable) = false];
   // next_column_id is used to ensure that deleted column ids are not reused.
-  optional uint32 next_column_id = 6 [(gogoproto.nullable) = false,
+  optional uint32 next_column_id = 8 [(gogoproto.nullable) = false,
       (gogoproto.customname) = "NextColumnID", (gogoproto.casttype) = "ColumnID"];
-  optional IndexDescriptor primary_index = 7 [(gogoproto.nullable) = false];
+  optional IndexDescriptor primary_index = 9 [(gogoproto.nullable) = false];
   // indexes are all the secondary indexes.
-  repeated IndexDescriptor indexes = 8 [(gogoproto.nullable) = false];
+  repeated IndexDescriptor indexes = 10 [(gogoproto.nullable) = false];
   // next_index_id is used to ensure that deleted index ids are not reused.
-  optional uint32 next_index_id = 9 [(gogoproto.nullable) = false,
+  optional uint32 next_index_id = 11 [(gogoproto.nullable) = false,
       (gogoproto.customname) = "NextIndexID", (gogoproto.casttype) = "IndexID"];
-  optional PrivilegeDescriptor privileges = 10;
+  optional PrivilegeDescriptor privileges = 12;
 }
 
 // DatabaseDescriptor represents a namespace (aka database) and is stored

--- a/sql/structured_test.go
+++ b/sql/structured_test.go
@@ -53,6 +53,7 @@ func TestAllocateIDs(t *testing.T) {
 	expected := sql.TableDescriptor{
 		ID:       keys.MaxReservedDescID + 2,
 		ParentID: keys.MaxReservedDescID + 1,
+		Version:  1,
 		Name:     "foo",
 		Columns: []sql.ColumnDescriptor{
 			{ID: 1, Name: "a"},

--- a/sql/testdata/system
+++ b/sql/testdata/system
@@ -8,6 +8,7 @@ query T
 SHOW TABLES FROM system
 ----
 descriptor
+lease
 namespace
 users
 zones
@@ -18,9 +19,10 @@ EXPLAIN (DEBUG) SELECT * FROM system.namespace
 0 /namespace/primary/0/'system'/id     1    true
 1 /namespace/primary/0/'test'/id       1000 true
 2 /namespace/primary/1/'descriptor'/id 3    true
-3 /namespace/primary/1/'namespace'/id  2    true
-4 /namespace/primary/1/'users'/id      4    true
-5 /namespace/primary/1/'zones'/id      5    true
+3 /namespace/primary/1/'lease'/id      4    true
+4 /namespace/primary/1/'namespace'/id  2    true
+5 /namespace/primary/1/'users'/id      5    true
+6 /namespace/primary/1/'zones'/id      6    true
 
 query ITI
 SELECT * FROM system.namespace
@@ -28,9 +30,10 @@ SELECT * FROM system.namespace
 0 system     1
 0 test       1000
 1 descriptor 3
+1 lease      4
 1 namespace  2
-1 users      4
-1 zones      5
+1 users      5
+1 zones      6
 
 query I
 SELECT id FROM system.descriptor
@@ -40,6 +43,7 @@ SELECT id FROM system.descriptor
 3
 4
 5
+6
 1000
 
 # Verify we can read "protobuf" columns.


### PR DESCRIPTION
Added the system.lease table. Added TableDescriptor.Version and
initialize to 1 on table creation.

Added leaseManager and associated components. Support lease acquisition
and releasing along with local ref counts. Support publication of new
table descriptor versions.

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/2872)

<!-- Reviewable:end -->
