### PR TITLE
Skip a test that is currently failing ~1/3 of the time in race mode.

### DIFF
--- a/storage/client_raft_test.go
+++ b/storage/client_raft_test.go
@@ -1285,6 +1285,7 @@ func TestStoreRangeRebalance(t *testing.T) {
 // cannot cause other removed nodes to recreate their ranges.
 func TestReplicateRogueRemovedNode(t *testing.T) {
 	defer leaktest.AfterTest(t)
+	t.Skip("TODO(bdarnell): https://github.com/cockroachdb/cockroach/issues/2880")
 
 	mtc := startMultiTestContext(t, 3)
 	defer mtc.Stop()


### PR DESCRIPTION
See #2880 
