### PR TITLE
Return immediately when a local key is found in truncate()

### DIFF
--- a/keys/keys.go
+++ b/keys/keys.go
@@ -344,7 +344,7 @@ func MakeTablePrefix(tableID uint32) []byte {
 // Range returns a key range encompassing all the keys in the Batch.
 // TODO(tschottdorf): there is no protection for doubly-local keys here;
 // maybe Range should return an error.
-func Range(ba roachpb.BatchRequest) (roachpb.RKey, roachpb.RKey) {
+func Range(ba roachpb.BatchRequest) roachpb.RSpan {
 	from := roachpb.RKeyMax
 	to := roachpb.RKeyMin
 	for _, arg := range ba.Requests {
@@ -367,5 +367,5 @@ func Range(ba roachpb.BatchRequest) (roachpb.RKey, roachpb.RKey) {
 			to = endKey
 		}
 	}
-	return from, to
+	return roachpb.RSpan{Key: from, EndKey: to}
 }

--- a/keys/keys_test.go
+++ b/keys/keys_test.go
@@ -349,8 +349,8 @@ func TestBatchRange(t *testing.T) {
 		for _, pair := range c.req {
 			ba.Add(&roachpb.ScanRequest{Span: roachpb.Span{Key: roachpb.Key(pair[0]), EndKey: roachpb.Key(pair[1])}})
 		}
-		from, to := Range(ba)
-		if actPair := [2]string{string(from), string(to)}; !reflect.DeepEqual(actPair, c.exp) {
+		rs := Range(ba)
+		if actPair := [2]string{string(rs.Key), string(rs.EndKey)}; !reflect.DeepEqual(actPair, c.exp) {
 			t.Fatalf("%d: expected [%q,%q), got [%q,%q)", i, c.exp[0], c.exp[1], actPair[0], actPair[1])
 		}
 	}

--- a/kv/dist_sender.go
+++ b/kv/dist_sender.go
@@ -535,7 +535,7 @@ func (ds *DistSender) sendChunk(ctx context.Context, ba roachpb.BatchRequest) (*
 
 			curReply, pErr = func() (*roachpb.BatchResponse, *roachpb.Error) {
 				// Truncate the request to our current key range.
-				untruncate, numActive, trErr := truncate(&ba, rs, desc)
+				untruncate, numActive, trErr := truncate(&ba, rs.Intersect(desc))
 				if numActive == 0 && trErr == nil {
 					untruncate()
 					// This shouldn't happen in the wild, but some tests

--- a/kv/dist_sender.go
+++ b/kv/dist_sender.go
@@ -28,6 +28,7 @@ import (
 
 	"github.com/cockroachdb/cockroach/client"
 	"github.com/cockroachdb/cockroach/gossip"
+	"github.com/cockroachdb/cockroach/keys"
 	"github.com/cockroachdb/cockroach/roachpb"
 	"github.com/cockroachdb/cockroach/rpc"
 	"github.com/cockroachdb/cockroach/util"
@@ -385,14 +386,14 @@ func (ds *DistSender) sendRPC(trace *tracer.Trace, rangeID roachpb.RangeID, repl
 // Note that `from` and `to` are not necessarily Key and EndKey from a
 // RequestHeader; it's assumed that they've been translated to key addresses
 // already (via KeyAddress).
-func (ds *DistSender) getDescriptors(rs rSpan, options lookupOptions) (*roachpb.RangeDescriptor, bool, func(), *roachpb.Error) {
+func (ds *DistSender) getDescriptors(rs roachpb.RSpan, options lookupOptions) (*roachpb.RangeDescriptor, bool, func(), *roachpb.Error) {
 	var desc *roachpb.RangeDescriptor
 	var err error
 	var descKey roachpb.RKey
 	if !options.useReverseScan {
-		descKey = rs.key
+		descKey = rs.Key
 	} else {
-		descKey = rs.endKey
+		descKey = rs.EndKey
 	}
 	desc, err = ds.rangeCache.LookupRangeDescriptor(descKey, options)
 
@@ -403,9 +404,9 @@ func (ds *DistSender) getDescriptors(rs rSpan, options lookupOptions) (*roachpb.
 	// Checks whether need to get next range descriptor. If so, returns true.
 	needAnother := func(desc *roachpb.RangeDescriptor, isReverse bool) bool {
 		if isReverse {
-			return rs.key.Less(desc.StartKey)
+			return rs.Key.Less(desc.StartKey)
 		}
-		return desc.EndKey.Less(rs.endKey)
+		return desc.EndKey.Less(rs.EndKey)
 	}
 
 	evict := func() {
@@ -481,7 +482,7 @@ func (ds *DistSender) sendChunk(ctx context.Context, ba roachpb.BatchRequest) (*
 	// Local addressing has already been resolved.
 	// TODO(tschottdorf): consider rudimentary validation of the batch here
 	// (for example, non-range requests with EndKey, or empty key ranges).
-	rs := newRSpan(ba)
+	rs := keys.Range(ba)
 	var br *roachpb.BatchResponse
 	// Send the request to one range per iteration.
 	for {
@@ -527,20 +528,20 @@ func (ds *DistSender) sendChunk(ctx context.Context, ba roachpb.BatchRequest) (*
 			// descriptor. Example revscan [a,g), first desc lookup for "g"
 			// returns descriptor [c,d) -> [d,g) is never scanned.
 			// We evict and retry in such a case.
-			if (isReverse && !desc.ContainsKeyRange(desc.StartKey, rs.endKey)) || (!isReverse && !desc.ContainsKeyRange(rs.key, desc.EndKey)) {
+			if (isReverse && !desc.ContainsKeyRange(desc.StartKey, rs.EndKey)) || (!isReverse && !desc.ContainsKeyRange(rs.Key, desc.EndKey)) {
 				evictDesc()
 				continue
 			}
 
 			curReply, pErr = func() (*roachpb.BatchResponse, *roachpb.Error) {
 				// Truncate the request to our current key range.
-				untruncate, numActive, trErr := truncate(&ba, desc, rs)
+				untruncate, numActive, trErr := truncate(&ba, rs, desc)
 				if numActive == 0 && trErr == nil {
 					untruncate()
 					// This shouldn't happen in the wild, but some tests
 					// exercise it.
 					return nil, roachpb.NewError(util.Errorf("truncation resulted in empty batch on [%s,%s): %s",
-						rs.key, rs.endKey, ba))
+						rs.Key, rs.EndKey, ba))
 				}
 				defer untruncate()
 				if trErr != nil {
@@ -720,7 +721,7 @@ func (ds *DistSender) sendChunk(ctx context.Context, ba roachpb.BatchRequest) (*
 			// We use the StartKey of the current descriptor as opposed to the
 			// EndKey of the previous one since that doesn't have bugs when
 			// stale descriptors come into play.
-			rs.endKey = prev(ba, desc.StartKey)
+			rs.EndKey = prev(ba, desc.StartKey)
 		} else {
 			// In next iteration, query next range.
 			// It's important that we use the EndKey of the current descriptor
@@ -729,7 +730,7 @@ func (ds *DistSender) sendChunk(ctx context.Context, ba roachpb.BatchRequest) (*
 			// one, and unless both descriptors are stale, the next descriptor's
 			// StartKey would move us to the beginning of the current range,
 			// resulting in a duplicate scan.
-			rs.key = next(ba, desc.EndKey)
+			rs.Key = next(ba, desc.EndKey)
 		}
 		trace.Event("querying next range")
 	}

--- a/kv/local_sender.go
+++ b/kv/local_sender.go
@@ -121,8 +121,8 @@ func (ls *LocalSender) Send(ctx context.Context, ba roachpb.BatchRequest) (*roac
 	if ba.RangeID == 0 || ba.Replica.StoreID == 0 {
 		var repl *roachpb.ReplicaDescriptor
 		var rangeID roachpb.RangeID
-		key, endKey := keys.Range(ba)
-		rangeID, repl, err = ls.lookupReplica(key, endKey)
+		rs := keys.Range(ba)
+		rangeID, repl, err = ls.lookupReplica(rs.Key, rs.EndKey)
 		if err == nil {
 			ba.RangeID = rangeID
 			ba.Replica = *repl

--- a/kv/truncate_test.go
+++ b/kv/truncate_test.go
@@ -112,8 +112,8 @@ func TestTruncate(t *testing.T) {
 		if len(desc.EndKey) == 0 {
 			desc.EndKey = roachpb.RKey(test.to)
 		}
-		rs := rSpan{key: roachpb.RKey(test.from), endKey: roachpb.RKey(test.to)}
-		undo, num, err := truncate(ba, desc, rs)
+		rs := roachpb.RSpan{Key: roachpb.RKey(test.from), EndKey: roachpb.RKey(test.to)}
+		undo, num, err := truncate(ba, rs, desc)
 		if err != nil || test.err != "" {
 			if test.err == "" || !testutils.IsError(err, test.err) {
 				t.Errorf("%d: %v (expected: %s)", i, err, test.err)

--- a/kv/truncate_test.go
+++ b/kv/truncate_test.go
@@ -113,7 +113,8 @@ func TestTruncate(t *testing.T) {
 			desc.EndKey = roachpb.RKey(test.to)
 		}
 		rs := roachpb.RSpan{Key: roachpb.RKey(test.from), EndKey: roachpb.RKey(test.to)}
-		undo, num, err := truncate(ba, rs, desc)
+		rs = rs.Intersect(desc)
+		undo, num, err := truncate(ba, rs)
 		if err != nil || test.err != "" {
 			if test.err == "" || !testutils.IsError(err, test.err) {
 				t.Errorf("%d: %v (expected: %s)", i, err, test.err)

--- a/roachpb/data.go
+++ b/roachpb/data.go
@@ -739,3 +739,42 @@ func (l Lease) Covers(timestamp Timestamp) bool {
 func (l Lease) OwnedBy(storeID StoreID) bool {
 	return l.Replica.StoreID == storeID
 }
+
+// RSpan is a key range with an inclusive start RKey and an exclusive end RKey.
+type RSpan struct {
+	Key, EndKey RKey
+}
+
+// ContainsKey returns whether this span contains the specified key.
+func (rs RSpan) ContainsKey(key RKey) bool {
+	return bytes.Compare(key, rs.Key) >= 0 && bytes.Compare(key, rs.EndKey) < 0
+}
+
+// ContainsKeyRange returns whether this span contains the specified
+// key range from start (inclusive) to end (exclusive).
+// If end is empty, returns ContainsKey(start).
+func (rs RSpan) ContainsKeyRange(start, end RKey) bool {
+	if len(end) == 0 {
+		return rs.ContainsKey(start)
+	}
+	if comp := bytes.Compare(end, start); comp < 0 {
+		return false
+	} else if comp == 0 {
+		return rs.ContainsKey(start)
+	}
+	return bytes.Compare(start, rs.Key) >= 0 && bytes.Compare(rs.EndKey, end) >= 0
+}
+
+// Intersect returns the intersection of the current span and the
+// descriptor's range.
+func (rs RSpan) Intersect(desc *RangeDescriptor) RSpan {
+	key := rs.Key
+	if !desc.ContainsKey(key) {
+		key = desc.StartKey
+	}
+	endKey := rs.EndKey
+	if !desc.ContainsKeyRange(desc.StartKey, endKey) || endKey == nil {
+		endKey = desc.EndKey
+	}
+	return RSpan{key, endKey}
+}

--- a/roachpb/data_test.go
+++ b/roachpb/data_test.go
@@ -461,3 +461,43 @@ func TestIsPrev(t *testing.T) {
 		}
 	}
 }
+
+// TestRSpanContains verifies methods to check whether a key
+// or key range is contained within the span.
+func TestRSpanContains(t *testing.T) {
+	rs := RSpan{Key: []byte("a"), EndKey: []byte("b")}
+
+	testData := []struct {
+		start, end []byte
+		contains   bool
+	}{
+		// Single keys.
+		{[]byte("a"), []byte("a"), true},
+		{[]byte("a"), nil, true},
+		{[]byte("aa"), []byte("aa"), true},
+		{[]byte("`"), []byte("`"), false},
+		{[]byte("b"), []byte("b"), false},
+		{[]byte("b"), nil, false},
+		{[]byte("c"), []byte("c"), false},
+		// Key ranges.
+		{[]byte("a"), []byte("b"), true},
+		{[]byte("a"), []byte("aa"), true},
+		{[]byte("aa"), []byte("b"), true},
+		{[]byte("0"), []byte("9"), false},
+		{[]byte("`"), []byte("a"), false},
+		{[]byte("b"), []byte("bb"), false},
+		{[]byte("0"), []byte("bb"), false},
+		{[]byte("aa"), []byte("bb"), false},
+		{[]byte("b"), []byte("a"), false},
+	}
+	for i, test := range testData {
+		if bytes.Compare(test.start, test.end) == 0 {
+			if rs.ContainsKey(test.start) != test.contains {
+				t.Errorf("%d: expected key %q within range", i, test.start)
+			}
+		}
+		if rs.ContainsKeyRange(test.start, test.end) != test.contains {
+			t.Errorf("%d: expected key %q within range", i, test.start)
+		}
+	}
+}

--- a/roachpb/data_test.go
+++ b/roachpb/data_test.go
@@ -501,3 +501,37 @@ func TestRSpanContains(t *testing.T) {
 		}
 	}
 }
+
+// TestRSpanIntersect verifies Intersect
+func TestRSpanIntersect(t *testing.T) {
+	rs := RSpan{Key: RKey("b"), EndKey: RKey("e")}
+
+	testData := []struct {
+		startKey, endKey RKey
+		expected         RSpan
+	}{
+		// Partially overlapping.
+		{RKey("a"), RKey("c"), RSpan{Key: RKey("b"), EndKey: RKey("c")}},
+		{RKey("d"), RKey("f"), RSpan{Key: RKey("d"), EndKey: RKey("e")}},
+		// No overlap.
+		{RKey("a"), RKey("b"), RSpan{Key: RKey("a"), EndKey: RKey("b")}},
+		// Descriptor surrounds the span.
+		{RKey("a"), RKey("f"), RSpan{Key: RKey("b"), EndKey: RKey("e")}},
+		// Descriptor has the same range as the span.
+		{RKey("b"), RKey("e"), RSpan{Key: RKey("b"), EndKey: RKey("e")}},
+	}
+
+	for i, test := range testData {
+		desc := RangeDescriptor{}
+		desc.StartKey = test.startKey
+		desc.EndKey = test.endKey
+
+		actual := rs.Intersect(&desc)
+		if bytes.Compare(actual.Key, test.expected.Key) != 0 ||
+			bytes.Compare(actual.EndKey, test.expected.EndKey) != 0 {
+			t.Errorf("%d: expected RSpan [%q,%q) but got [%q,%q)",
+				i, test.expected.Key, test.expected.EndKey,
+				actual.Key, actual.EndKey)
+		}
+	}
+}

--- a/roachpb/metadata.go
+++ b/roachpb/metadata.go
@@ -19,7 +19,6 @@
 package roachpb
 
 import (
-	"bytes"
 	"sort"
 	"strconv"
 	"strings"
@@ -107,24 +106,17 @@ func (a Attributes) SortedString() string {
 }
 
 // ContainsKey returns whether this RangeDescriptor contains the specified key.
-// TODO(tschottdorf): RKey.
 func (r *RangeDescriptor) ContainsKey(key []byte) bool {
-	return bytes.Compare(key, r.StartKey) >= 0 && bytes.Compare(key, r.EndKey) < 0
+	rs := RSpan{Key: r.StartKey, EndKey: r.EndKey}
+	return rs.ContainsKey(key)
 }
 
 // ContainsKeyRange returns whether this RangeDescriptor contains the specified
 // key range from start (inclusive) to end (exclusive).
 // If end is empty, returns ContainsKey(start).
 func (r *RangeDescriptor) ContainsKeyRange(start, end []byte) bool {
-	if len(end) == 0 {
-		return r.ContainsKey(start)
-	}
-	if comp := bytes.Compare(end, start); comp < 0 {
-		return false
-	} else if comp == 0 {
-		return r.ContainsKey(start)
-	}
-	return bytes.Compare(start, r.StartKey) >= 0 && bytes.Compare(r.EndKey, end) >= 0
+	rs := RSpan{Key: r.StartKey, EndKey: r.EndKey}
+	return rs.ContainsKeyRange(start, end)
 }
 
 // FindReplica returns the replica which matches the specified store

--- a/roachpb/metadata_test.go
+++ b/roachpb/metadata_test.go
@@ -18,7 +18,6 @@
 package roachpb
 
 import (
-	"bytes"
 	"testing"
 )
 
@@ -82,47 +81,5 @@ func TestRangeDescriptorMissingReplica(t *testing.T) {
 	i, r := desc.FindReplica(0)
 	if i >= 0 || r != nil {
 		t.Fatalf("unexpected return (%d, %s) on missing replica", i, r)
-	}
-}
-
-// TestRangeDescriptorContains verifies methods to check whether a key
-// or key range is contained within the range.
-func TestRangeDescriptorContains(t *testing.T) {
-	desc := RangeDescriptor{}
-	desc.StartKey = []byte("a")
-	desc.EndKey = []byte("b")
-
-	testData := []struct {
-		start, end []byte
-		contains   bool
-	}{
-		// Single keys.
-		{[]byte("a"), []byte("a"), true},
-		{[]byte("a"), nil, true},
-		{[]byte("aa"), []byte("aa"), true},
-		{[]byte("`"), []byte("`"), false},
-		{[]byte("b"), []byte("b"), false},
-		{[]byte("b"), nil, false},
-		{[]byte("c"), []byte("c"), false},
-		// Key ranges.
-		{[]byte("a"), []byte("b"), true},
-		{[]byte("a"), []byte("aa"), true},
-		{[]byte("aa"), []byte("b"), true},
-		{[]byte("0"), []byte("9"), false},
-		{[]byte("`"), []byte("a"), false},
-		{[]byte("b"), []byte("bb"), false},
-		{[]byte("0"), []byte("bb"), false},
-		{[]byte("aa"), []byte("bb"), false},
-		{[]byte("b"), []byte("a"), false},
-	}
-	for i, test := range testData {
-		if bytes.Compare(test.start, test.end) == 0 {
-			if desc.ContainsKey(test.start) != test.contains {
-				t.Errorf("%d: expected key %q within range", i, test.start)
-			}
-		}
-		if desc.ContainsKeyRange(test.start, test.end) != test.contains {
-			t.Errorf("%d: expected key %q within range", i, test.start)
-		}
 	}
 }

--- a/storage/store_test.go
+++ b/storage/store_test.go
@@ -101,10 +101,10 @@ func (db *testSender) Send(ctx context.Context, ba roachpb.BatchRequest) (*roach
 		return nil, roachpb.NewError(util.Errorf("%s method not supported", et.Method()))
 	}
 	// Lookup range and direct request.
-	key, endKey := keys.Range(ba)
-	rng := db.store.LookupReplica(key, endKey)
+	rs := keys.Range(ba)
+	rng := db.store.LookupReplica(rs.Key, rs.EndKey)
 	if rng == nil {
-		return nil, roachpb.NewError(roachpb.NewRangeKeyMismatchError(key.AsRawKey(), endKey.AsRawKey(), nil))
+		return nil, roachpb.NewError(roachpb.NewRangeKeyMismatchError(rs.Key.AsRawKey(), rs.EndKey.AsRawKey(), nil))
 	}
 	ba.RangeID = rng.Desc().RangeID
 	replica := rng.GetReplica()


### PR DESCRIPTION
I'm not sure this is a right fix (and whether this scenario can happen in practice), but `truncate()` currently truncates a local key to a non-local key when the key is outside of [from, to), but within the descriptor.

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/2885)

<!-- Reviewable:end -->
