### PR TITLE
Updating comments to use proto var names - toward #1252

### DIFF
--- a/roachpb/api.pb.go
+++ b/roachpb/api.pb.go
@@ -173,8 +173,7 @@ func (x *ReadConsistencyType) UnmarshalJSON(data []byte) error {
 	return nil
 }
 
-// TxnPushType determines what action to take when pushing a
-// transaction.
+// TxnPushType determines what action to take when pushing a transaction.
 type PushTxnType int32
 
 const (
@@ -285,7 +284,7 @@ func (m *Span) GetEndKey() Key {
 
 // ResponseHeader is returned with every storage node response.
 type ResponseHeader struct {
-	// Timestamp specifies time at which read or write actually was
+	// timestamp specifies time at which read or write actually was
 	// performed. In the case of both reads and writes, if the timestamp
 	// supplied to the request was 0, the wall time of the node
 	// servicing the request will be set here. Additionally, in the case
@@ -293,9 +292,9 @@ type ResponseHeader struct {
 	// with the Span if the key being written was either read
 	// or written more recently.
 	Timestamp Timestamp `protobuf:"bytes,2,opt,name=timestamp" json:"timestamp"`
-	// Transaction is non-nil if the request specified a non-nil
-	// transaction. The transaction timestamp and/or priority may have
-	// been updated, depending on the outcome of the request.
+	// txn is non-nil if the request specified a non-nil transaction.
+	// The transaction timestamp and/or priority may have been updated,
+	// depending on the outcome of the request.
 	Txn *Transaction `protobuf:"bytes,3,opt,name=txn" json:"txn,omitempty"`
 }
 
@@ -372,15 +371,15 @@ func (*PutResponse) ProtoMessage()    {}
 
 // A ConditionalPutRequest is the argument to the ConditionalPut() method.
 //
-// - Returns true and sets value if ExpValue equals existing value.
-// - If key doesn't exist and ExpValue is nil, sets value.
-// - If key exists, but value is empty and ExpValue is not nil but empty, sets value.
+// - Returns true and sets value if exp_value equals existing value.
+// - If key doesn't exist and exp_value is nil, sets value.
+// - If key exists, but value is empty and exp_value is not nil but empty, sets value.
 // - Otherwise, returns error and the actual value of the key in the response.
 type ConditionalPutRequest struct {
 	Span `protobuf:"bytes,1,opt,name=header,embedded=header" json:"header"`
 	// The value to put.
 	Value Value `protobuf:"bytes,2,opt,name=value" json:"value"`
-	// ExpValue.Bytes empty to test for non-existence. Specify as nil
+	// Set exp_value.bytes empty to test for non-existence. Specify as nil
 	// to indicate there should be no existing entry. This is different
 	// from the expectation that the value exists but is empty.
 	ExpValue *Value `protobuf:"bytes,3,opt,name=exp_value" json:"exp_value,omitempty"`
@@ -477,7 +476,7 @@ func (*DeleteResponse) ProtoMessage()    {}
 // specifies the range of keys to delete.
 type DeleteRangeRequest struct {
 	Span `protobuf:"bytes,1,opt,name=header,embedded=header" json:"header"`
-	// If 0, *all* entries between Key (inclusive) and EndKey
+	// If 0, *all* entries between key (inclusive) and end_key
 	// (exclusive) are deleted. Must be >= 0.
 	MaxEntriesToDelete int64 `protobuf:"varint,2,opt,name=max_entries_to_delete" json:"max_entries_to_delete"`
 }
@@ -664,7 +663,7 @@ func (m *EndTransactionResponse) GetResolved() []Key {
 }
 
 // An AdminSplitRequest is the argument to the AdminSplit() method. The
-// existing range which contains Span.Key is split by
+// existing range which contains header.key is split by
 // split_key. If split_key is not specified, then this method will
 // determine a split key that is roughly halfway through the
 // range. The existing range is resized to cover only its start key to
@@ -714,7 +713,7 @@ func (*AdminSplitResponse) ProtoMessage()    {}
 // two consecutive ranges (i.e. the range which contains keys which
 // sort first). This range will be the subsuming range and the right
 // hand range will be subsumed. After the merge operation, the
-// subsumed_range will no longer exist and the subsuming range will
+// subsumed range will no longer exist and the subsuming range will
 // now encompass all keys from its original start key to the end key
 // of the subsumed range. If AdminMerge is called on the final range
 // in the key space, it is a noop.
@@ -750,7 +749,7 @@ func (*AdminMergeResponse) ProtoMessage()    {}
 type RangeLookupRequest struct {
 	Span      `protobuf:"bytes,1,opt,name=header,embedded=header" json:"header"`
 	MaxRanges int32 `protobuf:"varint,2,opt,name=max_ranges" json:"max_ranges"`
-	// ConsiderIntents indicates whether or not intents encountered
+	// consider_intents indicates whether or not intents encountered
 	// while looking up the range info should randomly be returned
 	// to the caller. This is intended to be used when retrying due
 	// to range addressing errors.
@@ -1519,35 +1518,35 @@ func (m *ResponseUnion) GetNoop() *NoopResponse {
 // A Header is attached to a BatchRequest, encapsulating routing and auxiliary
 // information required for executing it.
 type Header struct {
-	// Timestamp specifies time at which read or writes should be
+	// timestamp specifies time at which read or writes should be
 	// performed. If the timestamp is set to zero value, its value
 	// is initialized to the wall time of the receiving node.
 	Timestamp Timestamp `protobuf:"bytes,1,opt,name=timestamp" json:"timestamp"`
-	// CmdID is optionally specified for request idempotence
+	// cmd_id is optionally specified for request idempotence
 	// (i.e. replay protection).
 	CmdID   ClientCmdID       `protobuf:"bytes,2,opt,name=cmd_id" json:"cmd_id"`
 	Replica ReplicaDescriptor `protobuf:"bytes,5,opt,name=replica" json:"replica"`
-	// RangeID specifies the ID of the Raft consensus group which the key
+	// range_id specifies the ID of the Raft consensus group which the key
 	// range belongs to. This is used by the receiving node to route the
 	// request to the correct range.
 	RangeID RangeID `protobuf:"varint,6,opt,name=range_id,casttype=RangeID" json:"range_id"`
-	// UserPriority specifies priority multiple for non-transactional
+	// user_priority specifies priority multiple for non-transactional
 	// commands. This value should be a positive integer [1, 2^31-1).
 	// It's properly viewed as a multiple for how likely this
 	// transaction will be to prevail if a write conflict occurs.
-	// Commands with UserPriority=100 will be 100x less likely to be
+	// Commands with user_priority=100 will be 100x less likely to be
 	// aborted as conflicting transactions or non-transactional commands
-	// with UserPriority=1. This value is ignored if Txn is
-	// specified. If neither this value nor Txn is specified, the value
+	// with user_priority=1. This value is ignored if Txn is
+	// specified. If neither this value nor txn is specified, the value
 	// defaults to 1.
 	UserPriority *int32 `protobuf:"varint,7,opt,name=user_priority,def=1" json:"user_priority,omitempty"`
-	// Txn is set non-nil if a transaction is underway. To start a txn,
+	// txn is set non-nil if a transaction is underway. To start a txn,
 	// the first request should set this field to non-nil with name and
 	// isolation level set as desired. The response will contain the
 	// fully-initialized transaction with txn ID, priority, initial
 	// timestamp, and maximum timestamp.
 	Txn *Transaction `protobuf:"bytes,8,opt,name=txn" json:"txn,omitempty"`
-	// ReadConsistency specifies the consistency for read
+	// read_consistency specifies the consistency for read
 	// operations. The default is CONSISTENT. This value is ignored for
 	// write operations.
 	ReadConsistency ReadConsistencyType `protobuf:"varint,9,opt,name=read_consistency,enum=cockroach.roachpb.ReadConsistencyType" json:"read_consistency"`
@@ -1652,9 +1651,9 @@ func (m *BatchResponse) GetResponses() []ResponseUnion {
 }
 
 type BatchResponse_Header struct {
-	// Error is non-nil if an error occurred.
+	// error is non-nil if an error occurred.
 	Error *Error `protobuf:"bytes,1,opt,name=error" json:"error,omitempty"`
-	// Timestamp specifies time at which read or write actually was
+	// timestamp specifies time at which read or write actually was
 	// performed. In the case of both reads and writes, if the timestamp
 	// supplied to the request was 0, the wall time of the node
 	// servicing the request will be set here. Additionally, in the case
@@ -1662,7 +1661,7 @@ type BatchResponse_Header struct {
 	// with the Span if the key being written was either read
 	// or written more recently.
 	Timestamp Timestamp `protobuf:"bytes,2,opt,name=timestamp" json:"timestamp"`
-	// Transaction is non-nil if the request specified a non-nil
+	// txn is non-nil if the request specified a non-nil
 	// transaction. The transaction timestamp and/or priority may have
 	// been updated, depending on the outcome of the request.
 	Txn *Transaction `protobuf:"bytes,3,opt,name=txn" json:"txn,omitempty"`

--- a/roachpb/api.proto
+++ b/roachpb/api.proto
@@ -82,7 +82,7 @@ message Span {
 
 // ResponseHeader is returned with every storage node response.
 message ResponseHeader {
-  // Timestamp specifies time at which read or write actually was
+  // timestamp specifies time at which read or write actually was
   // performed. In the case of both reads and writes, if the timestamp
   // supplied to the request was 0, the wall time of the node
   // servicing the request will be set here. Additionally, in the case
@@ -90,9 +90,9 @@ message ResponseHeader {
   // with the Span if the key being written was either read
   // or written more recently.
   optional Timestamp timestamp = 2 [(gogoproto.nullable) = false];
-  // Transaction is non-nil if the request specified a non-nil
-  // transaction. The transaction timestamp and/or priority may have
-  // been updated, depending on the outcome of the request.
+  // txn is non-nil if the request specified a non-nil transaction.
+  // The transaction timestamp and/or priority may have been updated,
+  // depending on the outcome of the request.
   optional Transaction txn = 3;
 }
 
@@ -121,15 +121,15 @@ message PutResponse {
 
 // A ConditionalPutRequest is the argument to the ConditionalPut() method.
 //
-// - Returns true and sets value if ExpValue equals existing value.
-// - If key doesn't exist and ExpValue is nil, sets value.
-// - If key exists, but value is empty and ExpValue is not nil but empty, sets value.
+// - Returns true and sets value if exp_value equals existing value.
+// - If key doesn't exist and exp_value is nil, sets value.
+// - If key exists, but value is empty and exp_value is not nil but empty, sets value.
 // - Otherwise, returns error and the actual value of the key in the response.
 message ConditionalPutRequest {
   optional Span header = 1 [(gogoproto.nullable) = false, (gogoproto.embed) = true];
   // The value to put.
   optional Value value = 2 [(gogoproto.nullable) = false];
-  // ExpValue.Bytes empty to test for non-existence. Specify as nil
+  // Set exp_value.bytes empty to test for non-existence. Specify as nil
   // to indicate there should be no existing entry. This is different
   // from the expectation that the value exists but is empty.
   optional Value exp_value = 3;
@@ -174,7 +174,7 @@ message DeleteResponse {
 // specifies the range of keys to delete.
 message DeleteRangeRequest {
   optional Span header = 1 [(gogoproto.nullable) = false, (gogoproto.embed) = true];
-  // If 0, *all* entries between Key (inclusive) and EndKey
+  // If 0, *all* entries between key (inclusive) and end_key
   // (exclusive) are deleted. Must be >= 0.
   optional int64 max_entries_to_delete = 2 [(gogoproto.nullable) = false];
 }
@@ -252,7 +252,7 @@ message EndTransactionResponse {
 }
 
 // An AdminSplitRequest is the argument to the AdminSplit() method. The
-// existing range which contains Span.Key is split by
+// existing range which contains header.key is split by
 // split_key. If split_key is not specified, then this method will
 // determine a split key that is roughly halfway through the
 // range. The existing range is resized to cover only its start key to
@@ -287,7 +287,7 @@ message AdminSplitResponse {
 // two consecutive ranges (i.e. the range which contains keys which
 // sort first). This range will be the subsuming range and the right
 // hand range will be subsumed. After the merge operation, the
-// subsumed_range will no longer exist and the subsuming range will
+// subsumed range will no longer exist and the subsuming range will
 // now encompass all keys from its original start key to the end key
 // of the subsumed range. If AdminMerge is called on the final range
 // in the key space, it is a noop.
@@ -315,7 +315,7 @@ message AdminMergeResponse {
 message RangeLookupRequest {
   optional Span header = 1 [(gogoproto.nullable) = false, (gogoproto.embed) = true];
   optional int32 max_ranges = 2 [(gogoproto.nullable) = false];
-  // ConsiderIntents indicates whether or not intents encountered
+  // consider_intents indicates whether or not intents encountered
   // while looking up the range info should randomly be returned
   // to the caller. This is intended to be used when retrying due
   // to range addressing errors.
@@ -370,8 +370,7 @@ message GCResponse {
   optional ResponseHeader header = 1 [(gogoproto.nullable) = false, (gogoproto.embed) = true];
 }
 
-// TxnPushType determines what action to take when pushing a
-// transaction.
+// TxnPushType determines what action to take when pushing a transaction.
 enum PushTxnType {
   option (gogoproto.goproto_enum_prefix) = false;
   // Push the timestamp forward if possible to accommodate a concurrent reader.
@@ -582,36 +581,36 @@ message ResponseUnion {
 // A Header is attached to a BatchRequest, encapsulating routing and auxiliary
 // information required for executing it.
 message Header {
-  // Timestamp specifies time at which read or writes should be
+  // timestamp specifies time at which read or writes should be
   // performed. If the timestamp is set to zero value, its value
   // is initialized to the wall time of the receiving node.
   optional Timestamp timestamp = 1 [(gogoproto.nullable) = false];
-  // CmdID is optionally specified for request idempotence
+  // cmd_id is optionally specified for request idempotence
   // (i.e. replay protection).
   optional ClientCmdID cmd_id = 2 [(gogoproto.nullable) = false, (gogoproto.customname) = "CmdID"];
   optional ReplicaDescriptor replica = 5 [(gogoproto.nullable) = false];
-  // RangeID specifies the ID of the Raft consensus group which the key
+  // range_id specifies the ID of the Raft consensus group which the key
   // range belongs to. This is used by the receiving node to route the
   // request to the correct range.
   optional int64 range_id = 6 [(gogoproto.nullable) = false,
       (gogoproto.customname) = "RangeID", (gogoproto.casttype) = "RangeID"];
-  // UserPriority specifies priority multiple for non-transactional
+  // user_priority specifies priority multiple for non-transactional
   // commands. This value should be a positive integer [1, 2^31-1).
   // It's properly viewed as a multiple for how likely this
   // transaction will be to prevail if a write conflict occurs.
-  // Commands with UserPriority=100 will be 100x less likely to be
+  // Commands with user_priority=100 will be 100x less likely to be
   // aborted as conflicting transactions or non-transactional commands
-  // with UserPriority=1. This value is ignored if Txn is
-  // specified. If neither this value nor Txn is specified, the value
+  // with user_priority=1. This value is ignored if Txn is
+  // specified. If neither this value nor txn is specified, the value
   // defaults to 1.
   optional int32 user_priority = 7 [default = 1];
-  // Txn is set non-nil if a transaction is underway. To start a txn,
+  // txn is set non-nil if a transaction is underway. To start a txn,
   // the first request should set this field to non-nil with name and
   // isolation level set as desired. The response will contain the
   // fully-initialized transaction with txn ID, priority, initial
   // timestamp, and maximum timestamp.
   optional Transaction txn = 8;
-  // ReadConsistency specifies the consistency for read
+  // read_consistency specifies the consistency for read
   // operations. The default is CONSISTENT. This value is ignored for
   // write operations.
   optional ReadConsistencyType read_consistency = 9 [(gogoproto.nullable) = false];
@@ -638,9 +637,9 @@ message BatchRequest {
 // slice of responses, if applicable.
 message BatchResponse {
   message Header {
-    // Error is non-nil if an error occurred.
+    // error is non-nil if an error occurred.
     optional Error error = 1;
-    // Timestamp specifies time at which read or write actually was
+    // timestamp specifies time at which read or write actually was
     // performed. In the case of both reads and writes, if the timestamp
     // supplied to the request was 0, the wall time of the node
     // servicing the request will be set here. Additionally, in the case
@@ -648,7 +647,7 @@ message BatchResponse {
     // with the Span if the key being written was either read
     // or written more recently.
     optional Timestamp timestamp = 2 [(gogoproto.nullable) = false];
-    // Transaction is non-nil if the request specified a non-nil
+    // txn is non-nil if the request specified a non-nil
     // transaction. The transaction timestamp and/or priority may have
     // been updated, depending on the outcome of the request.
     optional Transaction txn = 3;

--- a/roachpb/data.pb.go
+++ b/roachpb/data.pb.go
@@ -221,9 +221,9 @@ func (m *Timestamp) GetLogical() int32 {
 // Value specifies the value at a key. Multiple values at the same key
 // are supported based on timestamp.
 type Value struct {
-	// Bytes is the byte slice value.
+	// bytes is the byte slice value.
 	Bytes []byte `protobuf:"bytes,1,opt,name=bytes" json:"bytes,omitempty"`
-	// Checksum is a CRC-32-IEEE checksum of the key + value, in that order.
+	// checksum is a CRC-32-IEEE checksum of the key + value, in that order.
 	// If this is an integer value, then the value is interpreted as an 8
 	// byte, big-endian encoded value. This value is set by the client on
 	// writes to do end-to-end integrity verification. If the checksum is
@@ -232,7 +232,7 @@ type Value struct {
 	Checksum *uint32 `protobuf:"fixed32,3,opt,name=checksum" json:"checksum,omitempty"`
 	// Timestamp of value.
 	Timestamp *Timestamp `protobuf:"bytes,4,opt,name=timestamp" json:"timestamp,omitempty"`
-	// Tag is the optional type of the value.
+	// tag is the optional type of the value.
 	Tag ValueType `protobuf:"varint,5,opt,name=tag,enum=cockroach.roachpb.ValueType" json:"tag"`
 }
 
@@ -480,7 +480,7 @@ func (m *ModifiedSpanTrigger) GetSystemDBSpan() bool {
 	return false
 }
 
-// CommitTrigger encapsulates all of the internal-only commit triggers.
+// InternalCommitTrigger encapsulates all of the internal-only commit triggers.
 // Only one may be set.
 type InternalCommitTrigger struct {
 	SplitTrigger          *SplitTrigger          `protobuf:"bytes,1,opt,name=split_trigger" json:"split_trigger,omitempty"`
@@ -549,11 +549,11 @@ func (m *NodeList) GetNodes() []int32 {
 // TODO(vivek): Remove parts of Transaction that expose internals.
 type Transaction struct {
 	Name string `protobuf:"bytes,1,opt,name=name" json:"name"`
-	// Key is the key which anchors the transaction. This is typically
+	// key is the key which anchors the transaction. This is typically
 	// the first key read or written during the transaction and determines which
 	// range in the cluster will hold the transaction record.
 	Key Key `protobuf:"bytes,2,opt,name=key,casttype=Key" json:"key,omitempty"`
-	// ID is a unique UUID value which identifies the transaction.
+	// id is a unique UUID value which identifies the transaction.
 	ID        []byte            `protobuf:"bytes,3,opt,name=id" json:"id,omitempty"`
 	Priority  int32             `protobuf:"varint,4,opt,name=priority" json:"priority"`
 	Isolation IsolationType     `protobuf:"varint,5,opt,name=isolation,enum=cockroach.roachpb.IsolationType" json:"isolation"`
@@ -570,11 +570,11 @@ type Transaction struct {
 	// transaction will retry.
 	OrigTimestamp Timestamp `protobuf:"bytes,10,opt,name=orig_timestamp" json:"orig_timestamp"`
 	// Initial Timestamp + clock skew. Reads which encounter values with
-	// timestamps between Timestamp and MaxTimestamp trigger a txn
+	// timestamps between timestamp and max_timestamp trigger a txn
 	// retry error, unless the node being read is listed in certain_nodes
 	// (in which case no more read uncertainty can occur).
-	// The case MaxTimestamp < Timestamp is possible for transactions which have
-	// been pushed; in this case, MaxTimestamp should be ignored.
+	// The case max_timestamp < timestamp is possible for transactions which have
+	// been pushed; in this case, max_timestamp should be ignored.
 	MaxTimestamp Timestamp `protobuf:"bytes,11,opt,name=max_timestamp" json:"max_timestamp"`
 	// A sorted list of ids of nodes for which a ReadWithinUncertaintyIntervalError
 	// occurred during a prior read. The purpose of keeping this information is
@@ -587,7 +587,7 @@ type Transaction struct {
 	// is either the one of the encountered future write returned in the error
 	// or (if higher, which is in the majority of cases), the time of the node
 	// serving the key at the time of the failed read.
-	// Additionally storing the node, we make sure to set MaxTimestamp=Timestamp
+	// Additionally storing the node, we make sure to set max_timestamp=timestamp
 	// at the time of the read for nodes whose clock we've taken into acount,
 	// which amounts to reading without any uncertainty.
 	//

--- a/roachpb/data.proto
+++ b/roachpb/data.proto
@@ -62,9 +62,9 @@ enum ValueType {
 // Value specifies the value at a key. Multiple values at the same key
 // are supported based on timestamp.
 message Value {
-  // Bytes is the byte slice value.
+  // bytes is the byte slice value.
   optional bytes bytes = 1;
-  // Checksum is a CRC-32-IEEE checksum of the key + value, in that order.
+  // checksum is a CRC-32-IEEE checksum of the key + value, in that order.
   // If this is an integer value, then the value is interpreted as an 8
   // byte, big-endian encoded value. This value is set by the client on
   // writes to do end-to-end integrity verification. If the checksum is
@@ -73,7 +73,7 @@ message Value {
   optional fixed32 checksum = 3;
   // Timestamp of value.
   optional Timestamp timestamp = 4;
-  // Tag is the optional type of the value.
+  // tag is the optional type of the value.
   optional ValueType tag = 5 [(gogoproto.nullable) = false];
 }
 
@@ -148,7 +148,7 @@ message ModifiedSpanTrigger {
   optional bool system_db_span = 1 [(gogoproto.nullable) = false, (gogoproto.customname) = "SystemDBSpan"];
 }
 
-// CommitTrigger encapsulates all of the internal-only commit triggers.
+// InternalCommitTrigger encapsulates all of the internal-only commit triggers.
 // Only one may be set.
 message InternalCommitTrigger {
   optional SplitTrigger split_trigger = 1;
@@ -206,11 +206,11 @@ message Transaction {
   option (gogoproto.goproto_stringer) = false;
 
   optional string name = 1 [(gogoproto.nullable) = false];
-  // Key is the key which anchors the transaction. This is typically
+  // key is the key which anchors the transaction. This is typically
   // the first key read or written during the transaction and determines which
   // range in the cluster will hold the transaction record.
   optional bytes key = 2 [(gogoproto.casttype) = "Key"];
-  // ID is a unique UUID value which identifies the transaction.
+  // id is a unique UUID value which identifies the transaction.
   optional bytes id = 3 [(gogoproto.customname) = "ID"];
   optional int32 priority = 4 [(gogoproto.nullable) = false];
   optional IsolationType isolation = 5 [(gogoproto.nullable) = false];
@@ -227,11 +227,11 @@ message Transaction {
   // transaction will retry.
   optional Timestamp orig_timestamp = 10 [(gogoproto.nullable) = false];
   // Initial Timestamp + clock skew. Reads which encounter values with
-  // timestamps between Timestamp and MaxTimestamp trigger a txn
+  // timestamps between timestamp and max_timestamp trigger a txn
   // retry error, unless the node being read is listed in certain_nodes
   // (in which case no more read uncertainty can occur).
-  // The case MaxTimestamp < Timestamp is possible for transactions which have
-  // been pushed; in this case, MaxTimestamp should be ignored.
+  // The case max_timestamp < timestamp is possible for transactions which have
+  // been pushed; in this case, max_timestamp should be ignored.
   optional Timestamp max_timestamp = 11 [(gogoproto.nullable) = false];
   // A sorted list of ids of nodes for which a ReadWithinUncertaintyIntervalError
   // occurred during a prior read. The purpose of keeping this information is
@@ -244,7 +244,7 @@ message Transaction {
   // is either the one of the encountered future write returned in the error
   // or (if higher, which is in the majority of cases), the time of the node
   // serving the key at the time of the failed read.
-  // Additionally storing the node, we make sure to set MaxTimestamp=Timestamp
+  // Additionally storing the node, we make sure to set max_timestamp=timestamp
   // at the time of the read for nodes whose clock we've taken into acount,
   // which amounts to reading without any uncertainty.
   //

--- a/roachpb/errors.pb.go
+++ b/roachpb/errors.pb.go
@@ -284,14 +284,14 @@ func (m *TransactionStatusError) GetMsg() string {
 // belonging to another transaction were encountered leading to a
 // read/write or write/write conflict. The keys at which the intent
 // was encountered are set, as are the txn records for the intents'
-// transactions. Resolved is set if the intent was successfully
+// transactions. resolved is set if the intent was successfully
 // resolved, meaning the client may retry the operation
-// immediately. If Resolved is false, the client should back off and
+// immediately. If resolved is false, the client should back off and
 // retry.
 type WriteIntentError struct {
 	Intents  []Intent `protobuf:"bytes,1,rep,name=intents" json:"intents"`
 	Resolved bool     `protobuf:"varint,2,opt,name=resolved" json:"resolved"`
-	// The Index, if given, contains the index of the request (in the batch)
+	// The index, if given, contains the index of the request (in the batch)
 	// whose execution caused the error.
 	Index *ErrPosition `protobuf:"bytes,3,opt,name=index" json:"index,omitempty"`
 }
@@ -576,7 +576,7 @@ func (m *ErrPosition) GetIndex() int32 {
 // Error is a generic representation including a string message
 // and information about retryability.
 type Error struct {
-	// Message is a human-readable error message.
+	// message is a human-readable error message.
 	Message string `protobuf:"bytes,1,opt,name=message" json:"message"`
 	// If retryable is true, the error condition may be transient and the failed
 	// operation may be retried (within the same transaction).
@@ -587,7 +587,7 @@ type Error struct {
 	// If an ErrorDetail is present, it may contain additional structured data
 	// about the error.
 	Detail *ErrorDetail `protobuf:"bytes,4,opt,name=detail" json:"detail,omitempty"`
-	// The Index, if given, contains the index of the request (in the batch)
+	// The index, if given, contains the index of the request (in the batch)
 	// whose execution caused the error.
 	Index *ErrPosition `protobuf:"bytes,5,opt,name=index" json:"index,omitempty"`
 }

--- a/roachpb/errors.proto
+++ b/roachpb/errors.proto
@@ -109,14 +109,14 @@ message TransactionStatusError {
 // belonging to another transaction were encountered leading to a
 // read/write or write/write conflict. The keys at which the intent
 // was encountered are set, as are the txn records for the intents'
-// transactions. Resolved is set if the intent was successfully
+// transactions. resolved is set if the intent was successfully
 // resolved, meaning the client may retry the operation
-// immediately. If Resolved is false, the client should back off and
+// immediately. If resolved is false, the client should back off and
 // retry.
 message WriteIntentError {
   repeated Intent intents = 1 [(gogoproto.nullable) = false];
   optional bool resolved = 2 [(gogoproto.nullable) = false];
-  // The Index, if given, contains the index of the request (in the batch)
+  // The index, if given, contains the index of the request (in the batch)
   // whose execution caused the error.
   optional ErrPosition index = 3;
 }
@@ -206,7 +206,7 @@ message ErrPosition {
 // Error is a generic representation including a string message
 // and information about retryability.
 message Error {
-  // Message is a human-readable error message.
+  // message is a human-readable error message.
   optional string message = 1 [(gogoproto.nullable) = false];
 
   // If retryable is true, the error condition may be transient and the failed
@@ -221,7 +221,7 @@ message Error {
   // about the error.
   optional ErrorDetail detail = 4;
 
-  // The Index, if given, contains the index of the request (in the batch)
+  // The index, if given, contains the index of the request (in the batch)
   // whose execution caused the error.
   optional ErrPosition index = 5;
 }

--- a/roachpb/metadata.pb.go
+++ b/roachpb/metadata.pb.go
@@ -40,9 +40,9 @@ func (m *Attributes) GetAttrs() []string {
 type ReplicaDescriptor struct {
 	NodeID  NodeID  `protobuf:"varint,1,opt,name=node_id,casttype=NodeID" json:"node_id"`
 	StoreID StoreID `protobuf:"varint,2,opt,name=store_id,casttype=StoreID" json:"store_id"`
-	// ReplicaID uniquely identifies a replica instance. If a range is removed from
+	// replica_id uniquely identifies a replica instance. If a range is removed from
 	// a store and then re-added to the same store, the new instance will have a
-	// higher ReplicaID.
+	// higher replica_id.
 	ReplicaID ReplicaID `protobuf:"varint,3,opt,name=replica_id,casttype=ReplicaID" json:"replica_id"`
 }
 
@@ -76,17 +76,17 @@ func (m *ReplicaDescriptor) GetReplicaID() ReplicaID {
 // and a list of replicas where the range is stored.
 type RangeDescriptor struct {
 	RangeID RangeID `protobuf:"varint,1,opt,name=range_id,casttype=RangeID" json:"range_id"`
-	// StartKey is the first key which may be contained by this range.
+	// start_key is the first key which may be contained by this range.
 	StartKey RKey `protobuf:"bytes,2,opt,name=start_key,casttype=RKey" json:"start_key,omitempty"`
-	// EndKey marks the end of the range's possible keys.  EndKey itself is not
+	// end_key marks the end of the range's possible keys.  EndKey itself is not
 	// contained in this range - it will be contained in the immediately
 	// subsequent range.
 	EndKey RKey `protobuf:"bytes,3,opt,name=end_key,casttype=RKey" json:"end_key,omitempty"`
-	// Replicas is the set of nodes/stores on which replicas of this
+	// replicas is the set of nodes/stores on which replicas of this
 	// range are stored, the ordering being arbitrary and subject to
 	// permutation.
 	Replicas []ReplicaDescriptor `protobuf:"bytes,4,rep,name=replicas" json:"replicas"`
-	// NextReplicaID is a counter used to generate replica IDs.
+	// next_replica_id is a counter used to generate replica IDs.
 	NextReplicaID ReplicaID `protobuf:"varint,5,opt,name=next_replica_id,casttype=ReplicaID" json:"next_replica_id"`
 }
 

--- a/roachpb/metadata.proto
+++ b/roachpb/metadata.proto
@@ -45,9 +45,9 @@ message ReplicaDescriptor {
   optional int32 store_id = 2 [(gogoproto.nullable) = false,
       (gogoproto.customname) = "StoreID", (gogoproto.casttype) = "StoreID"];
 
-  // ReplicaID uniquely identifies a replica instance. If a range is removed from
+  // replica_id uniquely identifies a replica instance. If a range is removed from
   // a store and then re-added to the same store, the new instance will have a
-  // higher ReplicaID.
+  // higher replica_id.
   optional int32 replica_id = 3 [(gogoproto.nullable) = false,
       (gogoproto.customname) = "ReplicaID", (gogoproto.casttype) = "ReplicaID"];
 }
@@ -58,18 +58,18 @@ message ReplicaDescriptor {
 message RangeDescriptor {
   optional int64 range_id = 1 [(gogoproto.nullable) = false,
       (gogoproto.customname) = "RangeID", (gogoproto.casttype) = "RangeID"];
-  // StartKey is the first key which may be contained by this range.
+  // start_key is the first key which may be contained by this range.
   optional bytes start_key = 2 [(gogoproto.casttype) = "RKey"];
-  // EndKey marks the end of the range's possible keys.  EndKey itself is not
+  // end_key marks the end of the range's possible keys.  EndKey itself is not
   // contained in this range - it will be contained in the immediately
   // subsequent range.
   optional bytes end_key = 3 [(gogoproto.casttype) = "RKey"];
-  // Replicas is the set of nodes/stores on which replicas of this
+  // replicas is the set of nodes/stores on which replicas of this
   // range are stored, the ordering being arbitrary and subject to
   // permutation.
   repeated ReplicaDescriptor replicas = 4 [(gogoproto.nullable) = false];
 
-  // NextReplicaID is a counter used to generate replica IDs.
+  // next_replica_id is a counter used to generate replica IDs.
   optional int32 next_replica_id = 5 [(gogoproto.nullable) = false,
       (gogoproto.customname) = "NextReplicaID", (gogoproto.casttype) = "ReplicaID"];
 }


### PR DESCRIPTION
Went through the proto files in the roachpb package.
