### PR TITLE
storage: queueImpls contain their baseQueues by value

### DIFF
--- a/storage/gc_queue.go
+++ b/storage/gc_queue.go
@@ -60,23 +60,23 @@ const (
 // The shouldQueue function combines the need for both tasks into a
 // single priority. If any task is overdue, shouldQueue returns true.
 type gcQueue struct {
-	*baseQueue
+	baseQueue
 }
 
 // newGCQueue returns a new instance of gcQueue.
 func newGCQueue(gossip *gossip.Gossip) *gcQueue {
 	gcq := &gcQueue{}
-	gcq.baseQueue = newBaseQueue("gc", gcq, gossip, gcQueueMaxSize)
+	gcq.baseQueue = makeBaseQueue("gc", gcq, gossip, gcQueueMaxSize)
 	return gcq
 }
 
-func (gcq *gcQueue) needsLeaderLease() bool {
+func (*gcQueue) needsLeaderLease() bool {
 	return true
 }
 
 // acceptsUnsplitRanges is false because the proper GC
 // policy cannot be determined for ranges that span zone configs.
-func (gcq *gcQueue) acceptsUnsplitRanges() bool {
+func (*gcQueue) acceptsUnsplitRanges() bool {
 	return false
 }
 
@@ -84,7 +84,7 @@ func (gcq *gcQueue) acceptsUnsplitRanges() bool {
 // collection, and if so, at what priority. Returns true for shouldQ
 // in the event that the cumulative ages of GC'able bytes or extant
 // intents exceed thresholds.
-func (gcq *gcQueue) shouldQueue(now roachpb.Timestamp, repl *Replica,
+func (*gcQueue) shouldQueue(now roachpb.Timestamp, repl *Replica,
 	sysCfg *config.SystemConfig) (shouldQ bool, priority float64) {
 
 	desc := repl.Desc()
@@ -287,7 +287,7 @@ func (gcq *gcQueue) process(now roachpb.Timestamp, repl *Replica,
 
 // timer returns a constant duration to space out GC processing
 // for successive queued replicas.
-func (gcq *gcQueue) timer() time.Duration {
+func (*gcQueue) timer() time.Duration {
 	return gcQueueTimerDuration
 }
 
@@ -295,7 +295,7 @@ func (gcq *gcQueue) timer() time.Duration {
 // cannot be aborted, the oldestIntentNanos value is atomically
 // updated to the min of oldestIntentNanos and the intent's
 // timestamp. The wait group is signaled on completion.
-func (gcq *gcQueue) pushTxn(repl *Replica, now roachpb.Timestamp, txn *roachpb.Transaction, updateOldestIntent func(int64), wg *sync.WaitGroup) {
+func (*gcQueue) pushTxn(repl *Replica, now roachpb.Timestamp, txn *roachpb.Transaction, updateOldestIntent func(int64), wg *sync.WaitGroup) {
 	defer wg.Done() // signal wait group always on completion
 	if log.V(1) {
 		log.Infof("pushing txn %s ts=%s", txn, txn.OrigTimestamp)

--- a/storage/queue_test.go
+++ b/storage/queue_test.go
@@ -157,7 +157,7 @@ func TestBaseQueueAddUpdateAndRemove(t *testing.T) {
 			return shouldAddMap[r], priorityMap[r]
 		},
 	}
-	bq := newBaseQueue("test", testQueue, g, 2)
+	bq := makeBaseQueue("test", testQueue, g, 2)
 	bq.MaybeAdd(r1, roachpb.ZeroTimestamp)
 	bq.MaybeAdd(r2, roachpb.ZeroTimestamp)
 	if bq.Length() != 2 {
@@ -234,7 +234,7 @@ func TestBaseQueueAdd(t *testing.T) {
 			return false, 0.0
 		},
 	}
-	bq := newBaseQueue("test", testQueue, g, 1)
+	bq := makeBaseQueue("test", testQueue, g, 1)
 	bq.MaybeAdd(r, roachpb.ZeroTimestamp)
 	if bq.Length() != 0 {
 		t.Fatalf("expected length 0; got %d", bq.Length())
@@ -270,7 +270,7 @@ func TestBaseQueueProcess(t *testing.T) {
 			return
 		},
 	}
-	bq := newBaseQueue("test", testQueue, g, 2)
+	bq := makeBaseQueue("test", testQueue, g, 2)
 	mc := hlc.NewManualClock(0)
 	clock := hlc.NewClock(mc.UnixNano)
 	bq.Start(clock, stopper)
@@ -315,7 +315,7 @@ func TestBaseQueueAddRemove(t *testing.T) {
 			return
 		},
 	}
-	bq := newBaseQueue("test", testQueue, g, 2)
+	bq := makeBaseQueue("test", testQueue, g, 2)
 	mc := hlc.NewManualClock(0)
 	clock := hlc.NewClock(mc.UnixNano)
 	bq.Start(clock, stopper)
@@ -374,7 +374,7 @@ func TestAcceptsUnsplitRanges(t *testing.T) {
 		acceptUnsplit: false,
 	}
 
-	bq := newBaseQueue("test", testQueue, g, 2)
+	bq := makeBaseQueue("test", testQueue, g, 2)
 	mc := hlc.NewManualClock(0)
 	clock := hlc.NewClock(mc.UnixNano)
 	bq.Start(clock, stopper)

--- a/storage/replica_gc_queue.go
+++ b/storage/replica_gc_queue.go
@@ -46,7 +46,7 @@ const (
 // collections. The GC process asynchronously removes local data for
 // ranges that have been rebalanced away from this store.
 type replicaGCQueue struct {
-	*baseQueue
+	baseQueue
 	db     *client.DB
 	locker sync.Locker
 }
@@ -57,15 +57,15 @@ func newReplicaGCQueue(db *client.DB, gossip *gossip.Gossip, locker sync.Locker)
 		db:     db,
 		locker: locker,
 	}
-	q.baseQueue = newBaseQueue("replicaGC", q, gossip, replicaGCQueueMaxSize)
+	q.baseQueue = makeBaseQueue("replicaGC", q, gossip, replicaGCQueueMaxSize)
 	return q
 }
 
-func (q *replicaGCQueue) needsLeaderLease() bool {
+func (*replicaGCQueue) needsLeaderLease() bool {
 	return false
 }
 
-func (q *replicaGCQueue) acceptsUnsplitRanges() bool {
+func (*replicaGCQueue) acceptsUnsplitRanges() bool {
 	return true
 }
 
@@ -73,7 +73,7 @@ func (q *replicaGCQueue) acceptsUnsplitRanges() bool {
 // if so at what priority. Replicas which have been inactive for longer
 // than ReplicaGCQueueInactivityThreshold are considered for possible GC
 // at equal priority.
-func (q *replicaGCQueue) shouldQueue(now roachpb.Timestamp, rng *Replica,
+func (*replicaGCQueue) shouldQueue(now roachpb.Timestamp, rng *Replica,
 	_ *config.SystemConfig) (bool, float64) {
 
 	if l := rng.getLease(); l.Expiration.Add(ReplicaGCQueueInactivityThreshold.Nanoseconds(), 0).Less(now) {
@@ -174,6 +174,6 @@ func (q *replicaGCQueue) process(now roachpb.Timestamp, rng *Replica, _ *config.
 	return nil
 }
 
-func (q *replicaGCQueue) timer() time.Duration {
+func (*replicaGCQueue) timer() time.Duration {
 	return replicaGCQueueTimerDuration
 }

--- a/storage/split_queue.go
+++ b/storage/split_queue.go
@@ -38,7 +38,7 @@ const (
 // splitQueue manages a queue of ranges slated to be split due to size
 // or along intersecting zone config boundaries.
 type splitQueue struct {
-	*baseQueue
+	baseQueue
 	db *client.DB
 }
 
@@ -47,22 +47,22 @@ func newSplitQueue(db *client.DB, gossip *gossip.Gossip) *splitQueue {
 	sq := &splitQueue{
 		db: db,
 	}
-	sq.baseQueue = newBaseQueue("split", sq, gossip, splitQueueMaxSize)
+	sq.baseQueue = makeBaseQueue("split", sq, gossip, splitQueueMaxSize)
 	return sq
 }
 
-func (sq *splitQueue) needsLeaderLease() bool {
+func (*splitQueue) needsLeaderLease() bool {
 	return true
 }
 
-func (sq *splitQueue) acceptsUnsplitRanges() bool {
+func (*splitQueue) acceptsUnsplitRanges() bool {
 	return true
 }
 
 // shouldQueue determines whether a range should be queued for
 // splitting. This is true if the range is intersected by a zone config
 // prefix or if the range's size in bytes exceeds the limit for the zone.
-func (sq *splitQueue) shouldQueue(now roachpb.Timestamp, rng *Replica,
+func (*splitQueue) shouldQueue(now roachpb.Timestamp, rng *Replica,
 	sysCfg *config.SystemConfig) (shouldQ bool, priority float64) {
 
 	desc := rng.Desc()
@@ -122,6 +122,6 @@ func (sq *splitQueue) process(now roachpb.Timestamp, rng *Replica,
 }
 
 // timer returns interval between processing successive queued splits.
-func (sq *splitQueue) timer() time.Duration {
+func (*splitQueue) timer() time.Duration {
 	return splitQueueTimerDuration
 }

--- a/storage/store.go
+++ b/storage/store.go
@@ -240,7 +240,7 @@ type Store struct {
 	gcQueue           *gcQueue        // Garbage collection queue
 	_splitQueue       *splitQueue     // Range splitting queue
 	verifyQueue       *verifyQueue    // Checksum verification queue
-	replicateQueue    replicateQueue  // Replication queue
+	replicateQueue    *replicateQueue // Replication queue
 	_replicaGCQueue   *replicaGCQueue // Replica GC queue
 	scanner           *replicaScanner // Replica scanner
 	feed              StoreEventFeed  // Event Feed
@@ -369,7 +369,7 @@ func NewStore(ctx StoreContext, eng engine.Engine, nodeDesc *roachpb.NodeDescrip
 	s.gcQueue = newGCQueue(s.ctx.Gossip)
 	s._splitQueue = newSplitQueue(s.db, s.ctx.Gossip)
 	s.verifyQueue = newVerifyQueue(s.ctx.Gossip, s.ReplicaCount)
-	s.replicateQueue = makeReplicateQueue(s.ctx.Gossip, s.allocator(), s.ctx.Clock, s.ctx.RebalancingOptions)
+	s.replicateQueue = newReplicateQueue(s.ctx.Gossip, s.allocator(), s.ctx.Clock, s.ctx.RebalancingOptions)
 	s._replicaGCQueue = newReplicaGCQueue(s.db, s.ctx.Gossip, s.GroupLocker())
 	s.scanner.AddQueues(s.gcQueue, s._splitQueue, s.verifyQueue, s.replicateQueue, s._replicaGCQueue)
 

--- a/storage/verify_queue.go
+++ b/storage/verify_queue.go
@@ -42,22 +42,22 @@ type rangeCountFn func() int
 // bit-rot in read-only data sets. See
 // http://en.wikipedia.org/wiki/Data_degradation.
 type verifyQueue struct {
+	baseQueue
 	countFn rangeCountFn
-	*baseQueue
 }
 
 // newVerifyQueue returns a new instance of verifyQueue.
 func newVerifyQueue(gossip *gossip.Gossip, countFn rangeCountFn) *verifyQueue {
 	vq := &verifyQueue{countFn: countFn}
-	vq.baseQueue = newBaseQueue("verify", vq, gossip, verifyQueueMaxSize)
+	vq.baseQueue = makeBaseQueue("verify", vq, gossip, verifyQueueMaxSize)
 	return vq
 }
 
-func (vq *verifyQueue) needsLeaderLease() bool {
+func (*verifyQueue) needsLeaderLease() bool {
 	return false
 }
 
-func (vq *verifyQueue) acceptsUnsplitRanges() bool {
+func (*verifyQueue) acceptsUnsplitRanges() bool {
 	return true
 }
 
@@ -65,7 +65,7 @@ func (vq *verifyQueue) acceptsUnsplitRanges() bool {
 // verification scanning, and if so, at what priority. Returns true
 // for shouldQ in the event that it's been longer since the last scan
 // than the verification interval.
-func (vq *verifyQueue) shouldQueue(now roachpb.Timestamp, rng *Replica,
+func (*verifyQueue) shouldQueue(now roachpb.Timestamp, rng *Replica,
 	_ *config.SystemConfig) (shouldQ bool, priority float64) {
 
 	// Get last verification timestamp.
@@ -85,7 +85,7 @@ func (vq *verifyQueue) shouldQueue(now roachpb.Timestamp, rng *Replica,
 // process iterates through all keys and values in a range. The very
 // act of scanning keys verifies on-disk checksums, as each block
 // checksum is checked on load.
-func (vq *verifyQueue) process(now roachpb.Timestamp, rng *Replica,
+func (*verifyQueue) process(now roachpb.Timestamp, rng *Replica,
 	_ *config.SystemConfig) error {
 
 	snap := rng.rm.Engine().NewSnapshot()


### PR DESCRIPTION
All methods on queueImpls are changed to have pointer receivers because of the dangers of copying queueImpls.
