### PR TITLE
put a net/trace.Trace into our util/tracer/Trace

### DIFF
--- a/gossip/client.go
+++ b/gossip/client.go
@@ -141,9 +141,9 @@ func (c *client) gossip(g *Gossip, stopper *stop.Stopper) error {
 		now := time.Now().UnixNano()
 		// Combine remote node's infostore delta with ours.
 		if infoCount := len(reply.Delta); infoCount > 0 {
-			if log.V(1) {
+			if log.V(2) {
 				log.Infof("gossip: received %s from %s", reply.Delta, c.addr)
-			} else {
+			} else if log.V(1) {
 				log.Infof("gossip: received %d info(s) from %s", infoCount, c.addr)
 			}
 		}

--- a/server/admin.go
+++ b/server/admin.go
@@ -25,6 +25,9 @@ import (
 	"fmt"
 	"net/http"
 	"time"
+
+	// Register the net/trace endpoint with http.DefaultServeMux.
+	_ "golang.org/x/net/trace"
 	// This is imported for its side-effect of registering pprof
 	// endpoints with the http.DefaultServeMux.
 	_ "net/http/pprof"

--- a/server/admin_test.go
+++ b/server/admin_test.go
@@ -93,3 +93,28 @@ func TestAdminDebugPprof(t *testing.T) {
 		t.Errorf("expected %s to contain %s", body, exp)
 	}
 }
+
+// TestAdminDebugTrace verifies that the net/trace endpoints are available
+// via /debug/{requests,events}.
+func TestAdminNetTrace(t *testing.T) {
+	defer leaktest.AfterTest(t)
+	s := StartTestServer(t)
+	defer s.Stop()
+
+	tc := []struct {
+		segment, search string
+	}{
+		{"requests", "<title>/debug/requests</title>"},
+		{"events", "<title>events</title>"},
+	}
+
+	for _, c := range tc {
+		body, err := getText(s.Ctx.HTTPRequestScheme() + "://" + s.ServingAddr() + debugEndpoint + c.segment)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if !bytes.Contains(body, []byte(c.search)) {
+			t.Errorf("expected %s to be contained in %s", c.search, body)
+		}
+	}
+}


### PR DESCRIPTION
we will obviously have to decide between one and the
other at some point, but this gives us an immediate
way of hooking up the trace machinery with a nice
status frontend and allows figuring out how long
requests spend where (by adding more tracepoints).

<img width="845" alt="screen shot 2015-10-23 at 9 19 39 pm" src="https://cloud.githubusercontent.com/assets/5076964/10708149/6f0f1eae-79cc-11e5-96e5-946b0d2a746c.png">

By the way, to use the new endpoints I had to install the `ModHeader` addon for Chromium to wipe the `Accept-Encoding` header, otherwise we'd get `gzip` and Chromium would just download it for some reason.
