### PR TITLE
Make Intersect() return an error when a desc and a span do not overlap

### DIFF
--- a/kv/dist_sender.go
+++ b/kv/dist_sender.go
@@ -536,7 +536,11 @@ func (ds *DistSender) sendChunk(ctx context.Context, ba roachpb.BatchRequest) (*
 
 			curReply, pErr = func() (*roachpb.BatchResponse, *roachpb.Error) {
 				// Truncate the request to our current key range.
-				untruncate, numActive, trErr := truncate(&ba, rs.Intersect(desc))
+				intersected, iErr := rs.Intersect(desc)
+				if iErr != nil {
+					return nil, roachpb.NewError(iErr)
+				}
+				untruncate, numActive, trErr := truncate(&ba, intersected)
 				if numActive == 0 && trErr == nil {
 					untruncate()
 					// This shouldn't happen in the wild, but some tests

--- a/kv/truncate_test.go
+++ b/kv/truncate_test.go
@@ -113,7 +113,11 @@ func TestTruncate(t *testing.T) {
 			desc.EndKey = roachpb.RKey(test.to)
 		}
 		rs := roachpb.RSpan{Key: roachpb.RKey(test.from), EndKey: roachpb.RKey(test.to)}
-		rs = rs.Intersect(desc)
+		rs, err := rs.Intersect(desc)
+		if err != nil {
+			t.Errorf("%d: intersection failure: %v", i, err)
+			continue
+		}
 		undo, num, err := truncate(ba, rs)
 		if err != nil || test.err != "" {
 			if test.err == "" || !testutils.IsError(err, test.err) {


### PR DESCRIPTION
This is also for #2885.

Currently `intersect()` returns desc when desc and the span do not overlap. Will fix if this is not the expected behavior here.

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/2934)

<!-- Reviewable:end -->
