### PR TITLE
Fix a race between splits and snapshots.

### DIFF
--- a/kv/dist_sender.go
+++ b/kv/dist_sender.go
@@ -518,7 +518,8 @@ func (ds *DistSender) sendChunk(ctx context.Context, ba roachpb.BatchRequest) (*
 			// re-run as part of a transaction for consistency. The
 			// case where we don't need to re-run is if the read
 			// consistency is not required.
-			if needAnother && ba.Txn == nil && ba.ReadConsistency != roachpb.INCONSISTENT {
+			if needAnother && ba.Txn == nil && ba.IsPossibleTransaction() &&
+				ba.ReadConsistency != roachpb.INCONSISTENT {
 				return nil, roachpb.NewError(&roachpb.OpRequiresTxnError{})
 			}
 

--- a/multiraft/multiraft.go
+++ b/multiraft/multiraft.go
@@ -688,6 +688,15 @@ func (s *state) stop() {
 	}
 	s.MultiRaft.multiNode.Stop()
 	s.MultiRaft.Transport.Stop(s.storeID)
+
+	// Ensure that any remaining commands are not left hanging.
+	for _, g := range s.groups {
+		for _, p := range g.pending {
+			if p.ch != nil {
+				p.ch <- util.Errorf("shutting down")
+			}
+		}
+	}
 }
 
 // addNode creates a node and registers the given group (if not nil)

--- a/multiraft/multiraft.go
+++ b/multiraft/multiraft.go
@@ -752,9 +752,18 @@ func (s *state) handleMessage(req *RaftMessageRequest) {
 	case raftpb.MsgHeartbeat:
 		s.fanoutHeartbeat(req)
 		return
+
 	case raftpb.MsgHeartbeatResp:
 		s.fanoutHeartbeatResponse(req)
 		return
+
+	case raftpb.MsgSnap:
+		if !s.Storage.CanApplySnapshot(req.GroupID, req.Message.Snapshot) {
+			// If the storage cannot accept the snapshot, drop it before
+			// passing it to multiNode.Step, since our error handling
+			// options past that point are limited.
+			return
+		}
 	}
 
 	s.CacheReplicaDescriptor(req.GroupID, req.FromReplica)

--- a/multiraft/storage.go
+++ b/multiraft/storage.go
@@ -53,6 +53,12 @@ type Storage interface {
 	ReplicaIDForStore(groupID roachpb.RangeID, storeID roachpb.StoreID) (roachpb.ReplicaID, error)
 	ReplicasFromSnapshot(snap raftpb.Snapshot) ([]roachpb.ReplicaDescriptor, error)
 
+	// CanApplySnapshot should return false if attempting to apply the
+	// given snapshot would result in an error. This allows snapshots to
+	// be dropped cleanly since errors deep inside raft often result in
+	// panics.
+	CanApplySnapshot(groupID roachpb.RangeID, snap raftpb.Snapshot) bool
+
 	// GroupLocker returns a lock which (if non-nil) will be acquired
 	// when a group is being created (which entails multiple calls to
 	// Storage and StateMachine methods and may race with the removal of
@@ -116,6 +122,11 @@ func (m *MemoryStorage) ReplicaIDForStore(groupID roachpb.RangeID, storeID roach
 // ReplicasFromSnapshot implements the Storage interface.
 func (m *MemoryStorage) ReplicasFromSnapshot(_ raftpb.Snapshot) ([]roachpb.ReplicaDescriptor, error) {
 	return nil, nil
+}
+
+// CanApplySnapshot implements the Storage interface.
+func (m *MemoryStorage) CanApplySnapshot(_ roachpb.RangeID, _ raftpb.Snapshot) bool {
+	return true
 }
 
 // GroupLocker implements the Storage interface by returning nil.

--- a/multiraft/storage_test.go
+++ b/multiraft/storage_test.go
@@ -53,6 +53,10 @@ func (b *BlockableStorage) ReplicasFromSnapshot(snap raftpb.Snapshot) ([]roachpb
 	return b.storage.ReplicasFromSnapshot(snap)
 }
 
+func (b *BlockableStorage) CanApplySnapshot(groupID roachpb.RangeID, snap raftpb.Snapshot) bool {
+	return b.storage.CanApplySnapshot(groupID, snap)
+}
+
 func (b *BlockableStorage) GroupLocker() sync.Locker {
 	return b.storage.GroupLocker()
 }

--- a/roachpb/api.go
+++ b/roachpb/api.go
@@ -63,6 +63,7 @@ const (
 	isAdmin    = 1 << iota // admin cmds don't go through raft, but run on leader
 	isRead                 // read-only cmds don't go through raft, but may run on leader
 	isWrite                // write cmds go through raft and must be proposed on leader
+	isTxn                  // txn commands may be part of a transaction
 	isTxnWrite             // txn write cmds start heartbeat and are marked for intent resolution
 	isRange                // range commands may span multiple keys
 	isReverse              // reverse commands traverse ranges in descending direction
@@ -506,22 +507,22 @@ func NewReverseScan(key, endKey Key, maxResults int64) Request {
 	}
 }
 
-func (*GetRequest) flags() int                { return isRead }
-func (*PutRequest) flags() int                { return isWrite | isTxnWrite }
-func (*ConditionalPutRequest) flags() int     { return isRead | isWrite | isTxnWrite }
-func (*IncrementRequest) flags() int          { return isRead | isWrite | isTxnWrite }
-func (*DeleteRequest) flags() int             { return isWrite | isTxnWrite }
-func (*DeleteRangeRequest) flags() int        { return isWrite | isTxnWrite | isRange }
-func (*ScanRequest) flags() int               { return isRead | isRange }
-func (*ReverseScanRequest) flags() int        { return isRead | isRange | isReverse }
-func (*BeginTransactionRequest) flags() int   { return isWrite }
-func (*EndTransactionRequest) flags() int     { return isWrite | isAlone }
+func (*GetRequest) flags() int                { return isRead | isTxn }
+func (*PutRequest) flags() int                { return isWrite | isTxn | isTxnWrite }
+func (*ConditionalPutRequest) flags() int     { return isRead | isWrite | isTxn | isTxnWrite }
+func (*IncrementRequest) flags() int          { return isRead | isWrite | isTxn | isTxnWrite }
+func (*DeleteRequest) flags() int             { return isWrite | isTxn | isTxnWrite }
+func (*DeleteRangeRequest) flags() int        { return isWrite | isTxn | isTxnWrite | isRange }
+func (*ScanRequest) flags() int               { return isRead | isRange | isTxn }
+func (*ReverseScanRequest) flags() int        { return isRead | isRange | isReverse | isTxn }
+func (*BeginTransactionRequest) flags() int   { return isWrite | isTxn }
+func (*EndTransactionRequest) flags() int     { return isWrite | isTxn | isAlone }
 func (*AdminSplitRequest) flags() int         { return isAdmin | isAlone }
 func (*AdminMergeRequest) flags() int         { return isAdmin | isAlone }
-func (*HeartbeatTxnRequest) flags() int       { return isWrite }
+func (*HeartbeatTxnRequest) flags() int       { return isWrite | isTxn }
 func (*GCRequest) flags() int                 { return isWrite | isRange }
 func (*PushTxnRequest) flags() int            { return isWrite }
-func (*RangeLookupRequest) flags() int        { return isRead }
+func (*RangeLookupRequest) flags() int        { return isRead | isTxn }
 func (*ResolveIntentRequest) flags() int      { return isWrite }
 func (*ResolveIntentRangeRequest) flags() int { return isWrite | isRange }
 func (*NoopRequest) flags() int               { return isRead } // slightly special

--- a/roachpb/batch.go
+++ b/roachpb/batch.go
@@ -45,6 +45,12 @@ func (ba *BatchRequest) IsReverse() bool {
 	return (ba.flags() & isReverse) != 0
 }
 
+// IsPossibleTransaction returns true iff the BatchRequest contains
+// requests that can be part of a transaction.
+func (ba *BatchRequest) IsPossibleTransaction() bool {
+	return (ba.flags() & isTxn) != 0
+}
+
 // IsTransactionWrite returns true iff the BatchRequest contains a txn write.
 func (ba *BatchRequest) IsTransactionWrite() bool {
 	return (ba.flags() & isTxnWrite) != 0

--- a/storage/client_split_test.go
+++ b/storage/client_split_test.go
@@ -600,3 +600,170 @@ func TestStoreRangeSystemSplits(t *testing.T) {
 		t.Errorf("expected splits not found: %s", err)
 	}
 }
+
+// setupSplitSnapshotRace engineers a situation in which a range has
+// been split but node 3 hasn't processed it yet. There is a race
+// depending on whether node 3 learns of the split from its left or
+// right side. When this function returns most of the nodes will be
+// stopped, and depending on the order in which they are restarted, we
+// can arrange for both possible outcomes of the race.
+//
+// Range 1 is the system keyspace, located on node 0.
+// The range containing leftKey is the left side of the split, located on nodes 1, 2, and 3.
+// The range containing rightKey is the right side of the split, located on nodes 3, 4, and 5.
+// Nodes 1-5 are stopped; only node 0 is running.
+//
+// See https://github.com/cockroachdb/cockroach/issues/1644.
+func setupSplitSnapshotRace(t *testing.T) (mtc *multiTestContext, leftKey roachpb.Key, rightKey roachpb.Key) {
+	mtc = startMultiTestContext(t, 6)
+
+	leftKey = roachpb.Key("a")
+	rightKey = roachpb.Key("z")
+
+	// First, do a couple of writes; we'll use these to determine when
+	// the dust has settled.
+	incArgs := incrementArgs(leftKey, 1)
+	if _, err := client.SendWrapped(rg1(mtc.stores[0]), nil, &incArgs); err != nil {
+		t.Fatal(err)
+	}
+	incArgs = incrementArgs(rightKey, 2)
+	if _, err := client.SendWrapped(rg1(mtc.stores[0]), nil, &incArgs); err != nil {
+		t.Fatal(err)
+	}
+
+	// Split the system range from the rest of the keyspace.
+	splitArgs := adminSplitArgs(roachpb.KeyMin, keys.SystemMax)
+	if _, err := client.SendWrapped(rg1(mtc.stores[0]), nil, &splitArgs); err != nil {
+		t.Fatal(err)
+	}
+
+	// Get the left range's ID. This is currently 2, but using
+	// LookupReplica is more future-proof (and see below for
+	// rightRangeID).
+	leftRangeID := mtc.stores[0].LookupReplica(roachpb.RKey("a"), nil).Desc().RangeID
+
+	// Replicate the left range onto nodes 1-3 and remove it from node 0.
+	mtc.replicateRange(leftRangeID, 0, 1, 2, 3)
+	mtc.unreplicateRange(leftRangeID, 0, 0)
+	mtc.expireLeaderLeases()
+
+	mtc.waitForValues(leftKey, 3*time.Second, []int64{0, 1, 1, 1, 0, 0})
+	mtc.waitForValues(rightKey, 3*time.Second, []int64{0, 2, 2, 2, 0, 0})
+
+	// Stop node 3 so it doesn't hear about the split.
+	mtc.stopStore(3)
+	mtc.expireLeaderLeases()
+
+	// Split the data range.
+	splitArgs = adminSplitArgs(keys.SystemMax, roachpb.Key("m"))
+	if _, err := client.SendWrapped(mtc.distSender, nil, &splitArgs); err != nil {
+		t.Fatal(err)
+	}
+
+	// Get the right range's ID. Since the split was performed on node
+	// 1, it is currently 11 and not 3 as might be expected.
+	rightRangeID := mtc.stores[1].LookupReplica(roachpb.RKey("z"), nil).Desc().RangeID
+
+	// Relocate the right range onto nodes 3-5.
+	mtc.replicateRange(rightRangeID, 1, 4, 5)
+	mtc.unreplicateRange(rightRangeID, 1, 2)
+	mtc.unreplicateRange(rightRangeID, 1, 1)
+
+	mtc.waitForValues(rightKey, 3*time.Second, []int64{0, 0, 0, 2, 2, 2})
+
+	// Stop the remaining data stores.
+	mtc.stopStore(1)
+	mtc.stopStore(2)
+	// 3 is already stopped.
+	mtc.stopStore(4)
+	mtc.stopStore(5)
+	mtc.expireLeaderLeases()
+
+	return mtc, leftKey, rightKey
+}
+
+// TestSplitSnapshotRace_SplitWins exercises one outcome of the
+// split/snapshot race: The left side of the split propagates first,
+// so the split completes before it sees a competing snapshot. This is
+// the more common outcome in practice.
+func TestSplitSnapshotRace_SplitWins(t *testing.T) {
+	defer leaktest.AfterTest(t)
+	mtc, leftKey, rightKey := setupSplitSnapshotRace(t)
+	defer mtc.Stop()
+
+	// Bring the left range up first so that the split happens before it sees a snapshot.
+	for i := 1; i <= 3; i++ {
+		mtc.restartStore(i)
+	}
+
+	// Perform a write on the left range and wait for it to propagate.
+	incArgs := incrementArgs(leftKey, 10)
+	if _, err := client.SendWrapped(mtc.distSender, nil, &incArgs); err != nil {
+		t.Fatal(err)
+	}
+	mtc.waitForValues(leftKey, 3*time.Second, []int64{0, 11, 11, 11, 0, 0})
+
+	// Now wake the other stores up.
+	mtc.restartStore(4)
+	mtc.restartStore(5)
+
+	// Write to the right range.
+	incArgs = incrementArgs(rightKey, 20)
+	if _, err := client.SendWrapped(mtc.distSender, nil, &incArgs); err != nil {
+		t.Fatal(err)
+	}
+	mtc.waitForValues(rightKey, 3*time.Second, []int64{0, 0, 0, 22, 22, 22})
+}
+
+// TestSplitSnapshotRace_SplitWins exercises one outcome of the
+// split/snapshot race: The right side of the split replicates first,
+// so target node sees a raft snapshot before it has processed the split,
+// so it still has a conflicting range.
+func TestSplitSnapshotRace_SnapshotWins(t *testing.T) {
+	defer leaktest.AfterTest(t)
+	mtc, leftKey, rightKey := setupSplitSnapshotRace(t)
+	defer mtc.Stop()
+
+	// Bring the right range up first.
+	for i := 3; i <= 5; i++ {
+		mtc.restartStore(i)
+	}
+
+	// Perform a write on the right range.
+	incArgs := incrementArgs(rightKey, 20)
+	if _, err := client.SendWrapped(mtc.distSender, nil, &incArgs); err != nil {
+		t.Fatal(err)
+	}
+
+	// It immediately propagates between nodes 4 and 5, but node 3
+	// remains at its old value. It can't accept the right-hand range
+	// because it conflicts with its not-yet-split copy of the left-hand
+	// range. This test is not completely deterministic: we want to make
+	// sure that node 3 doesn't panic when it receives the snapshot, but
+	// since it silently drops the message there is nothing we can wait
+	// for. There is a high probability that the message will have been
+	// received by the time that nodes 4 and 5 have processed their
+	// update.
+	mtc.waitForValues(rightKey, 3*time.Second, []int64{0, 0, 0, 2, 22, 22})
+
+	// Wake up the left-hand range. This will allow the left-hand
+	// range's split to complete and unblock the right-hand range.
+	mtc.restartStore(1)
+	mtc.restartStore(2)
+
+	// Perform writes on both sides. This is not strictly necessary but
+	// it helps wake up dormant ranges that would otherwise have to wait
+	// for retry timeouts.
+	incArgs = incrementArgs(leftKey, 10)
+	if _, err := client.SendWrapped(mtc.distSender, nil, &incArgs); err != nil {
+		t.Fatal(err)
+	}
+	mtc.waitForValues(leftKey, 3*time.Second, []int64{0, 11, 11, 11, 0, 0})
+
+	incArgs = incrementArgs(rightKey, 200)
+	if _, err := client.SendWrapped(mtc.distSender, nil, &incArgs); err != nil {
+		t.Fatal(err)
+	}
+	mtc.waitForValues(rightKey, 3*time.Second, []int64{0, 0, 0, 222, 222, 222})
+
+}

--- a/storage/client_test.go
+++ b/storage/client_test.go
@@ -156,6 +156,12 @@ type multiTestContext struct {
 	// test individually. clientStopper is for 'db', transportStopper is
 	// for 'transport', and the 'stoppers' slice corresponds to the
 	// 'stores'.
+	// TODO(bdarnell): scannerStopper is a hack. The scanner is the one
+	// source of asynchronous operations that the test has no direct
+	// control over, and it is prone to an infinite retry loop during
+	// shutdown. When we have fixed our retry configurations (#2500),
+	// we should be able to remove scannerStopper.
+	scannerStopper     *stop.Stopper
 	clientStopper      *stop.Stopper
 	transportStopper   *stop.Stopper
 	engineStoppers     []*stop.Stopper
@@ -187,6 +193,9 @@ func (m *multiTestContext) Start(t *testing.T, numStores int) {
 	if m.gossip == nil {
 		rpcContext := rpc.NewContext(&base.Context{}, m.clock, nil)
 		m.gossip = gossip.New(rpcContext, gossip.TestInterval, gossip.TestBootstrap)
+	}
+	if m.scannerStopper == nil {
+		m.scannerStopper = stop.NewStopper()
 	}
 	if m.clientStopper == nil {
 		m.clientStopper = stop.NewStopper()
@@ -228,7 +237,8 @@ func (m *multiTestContext) Stop() {
 	go func() {
 		m.mu.RLock()
 		defer m.mu.RUnlock()
-		stoppers := append([]*stop.Stopper{m.clientStopper, m.transportStopper}, m.stoppers...)
+		stoppers := append([]*stop.Stopper{m.scannerStopper, m.clientStopper, m.transportStopper},
+			m.stoppers...)
 		// Quiesce all the stoppers so that we can stop all stoppers in unison.
 		for _, s := range stoppers {
 			// Stoppers may be nil if stopStore has been called without restartStore.
@@ -329,6 +339,7 @@ func (m *multiTestContext) makeContext(i int) storage.StoreContext {
 	ctx.StorePool = m.storePool
 	ctx.Transport = m.transport
 	ctx.EventFeed = m.feed
+	ctx.ScannerStopper = m.scannerStopper
 	return ctx
 }
 

--- a/storage/store.go
+++ b/storage/store.go
@@ -918,6 +918,13 @@ func (s *Store) SplitRange(origRng, newRng *Replica) error {
 	if s.replicasByKey.ReplaceOrInsert(origRng) != nil {
 		return util.Errorf("couldn't insert range %v in rangesByKey btree", origRng)
 	}
+
+	// If we have an uninitialized replica of the new range, delete it to make
+	// way for the complete one created by the split.
+	if _, ok := s.uninitReplicas[newDesc.RangeID]; ok {
+		delete(s.uninitReplicas, newDesc.RangeID)
+		delete(s.replicas, newDesc.RangeID)
+	}
 	if err := s.addReplicaInternal(newRng); err != nil {
 		return util.Errorf("couldn't insert range %v in rangesByKey btree: %s", newRng, err)
 	}
@@ -1599,6 +1606,34 @@ func (s *Store) ReplicasFromSnapshot(snap raftpb.Snapshot) ([]roachpb.ReplicaDes
 // GroupLocker implements the multiraft.Storage interface.
 func (s *Store) GroupLocker() sync.Locker {
 	return &s.raftGroupLocker
+}
+
+// CanApplySnapshot implements the multiraft.Storage interface.
+func (s *Store) CanApplySnapshot(rangeID roachpb.RangeID, snap raftpb.Snapshot) bool {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if r, ok := s.replicas[rangeID]; ok && r.isInitialized() {
+		// We have the range and it's initialized, so let the snapshot
+		// through.
+		return true
+	}
+
+	// We don't have the range (or we have an uninitialized
+	// placeholder). Will we be able to create/initialize it?
+	// TODO(bdarnell): can we avoid parsing this twice?
+	var parsedSnap roachpb.RaftSnapshotData
+	if err := parsedSnap.Unmarshal(snap.Data); err != nil {
+		return false
+	}
+
+	if s.replicasByKey.Has(rangeBTreeKey(parsedSnap.RangeDescriptor.EndKey)) {
+		// We have a conflicting range, so we must block the snapshot.
+		// When such a conflict exists, it will be resolved by one range
+		// either being split or garbage collected.
+		return false
+	}
+
+	return true
 }
 
 // AppliedIndex implements the multiraft.StateMachine interface.


### PR DESCRIPTION
When a range is split, followers of that range may receive a snapshot
from the right-hand side of the split before they have caught up and
processed the left-hand side where the split originated. This results in
a "range already exists" panic.

The solution is to silently drop any snapshots which would cause a
conflict. They will be retried and will succeed once the left-hand range
has performed its split.

Fixes #1644.

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/2944)

<!-- Reviewable:end -->
