### PR TITLE
sql/parser: adding tests for infinities and NaN - Fixes #2943

### DIFF
--- a/sql/parser/eval_test.go
+++ b/sql/parser/eval_test.go
@@ -312,6 +312,21 @@ func TestEval(t *testing.T) {
 		{`COALESCE(NULL, 2, 3, 4/0)`, `2`},
 		{`COALESCE(NULL, NULL, NULL, 4)`, `4`},
 		{`COALESCE(NULL, NULL, NULL, NULL)`, `NULL`},
+		// Infinities
+		{`'Infinity'::float`, `+Inf`},
+		{`'+Infinity'::float`, `+Inf`},
+		{`'-Infinity'::float`, `-Inf`},
+		{`'Inf'::float`, `+Inf`},
+		{`'+Inf'::float`, `+Inf`},
+		{`'-Inf'::float`, `-Inf`},
+		{`'Inf'::float(4)`, `+Inf`},
+		{`'-Inf'::real`, `-Inf`},
+		{`'+Infinity'::double precision`, `+Inf`},
+		// NaN
+		{`'NaN'::float`, `NaN`},
+		{`'NaN'::float(4)`, `NaN`},
+		{`'NaN'::real`, `NaN`},
+		{`'NaN'::double precision`, `NaN`},
 	}
 	for _, d := range testData {
 		q, err := ParseTraditional("SELECT " + d.expr)


### PR DESCRIPTION
It turns out that the floating point types handle these fine already. This change just adds eval tests.

An open question is timestamp infinities. They are supported by postgres, but I don't know what kind of change would be required (conversion to min/max time.Time? or expanding DTimestamp?)

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/2958)

<!-- Reviewable:end -->
