### PR TITLE
prevent post-removal activity on range

### DIFF
--- a/kv/txn_coord_sender.go
+++ b/kv/txn_coord_sender.go
@@ -675,6 +675,7 @@ func (tc *TxnCoordSender) updateState(ctx context.Context, ba roachpb.BatchReque
 		newTxn.Restart(ba.GetUserPriority(), newTxn.Priority, newTxn.Timestamp)
 		t.Txn = *newTxn
 	case *roachpb.TransactionAbortedError:
+		trace.SetError()
 		newTxn.Update(&t.Txn)
 		// Increase timestamp if applicable.
 		newTxn.Timestamp.Forward(t.Txn.Timestamp)
@@ -700,6 +701,8 @@ func (tc *TxnCoordSender) updateState(ctx context.Context, ba roachpb.BatchReque
 		if pErr.Detail != nil {
 			panic(fmt.Sprintf("unhandled TransactionRestartError %T", err))
 		}
+	default:
+		trace.SetError()
 	}
 
 	return func() *roachpb.Error {

--- a/kv/txn_coord_sender.go
+++ b/kv/txn_coord_sender.go
@@ -656,8 +656,7 @@ func (tc *TxnCoordSender) updateState(ctx context.Context, ba roachpb.BatchReque
 		// timestamp regressions; consider txn dead.
 		defer tc.cleanupTxn(trace, t.Txn)
 	case *roachpb.OpRequiresTxnError:
-		// TODO(tschottdorf): range-spanning autowrap currently broken.
-		panic("TODO(tschottdorf): disabled")
+		panic("OpRequiresTxnError must not happen at this level")
 	case *roachpb.ReadWithinUncertaintyIntervalError:
 		// Mark the host as certain. See the protobuf comment for
 		// Transaction.CertainNodes for details.

--- a/multiraft/multiraft.go
+++ b/multiraft/multiraft.go
@@ -975,7 +975,7 @@ func (s *state) propose(p *proposal) {
 		s.removePending(nil, p, ErrGroupDeleted)
 		return
 	}
-	// If configration change callback is pending, wait for it.
+	// If configuration change callback is pending, wait for it.
 	if g.waitForCallback > 0 {
 		g.pending[p.commandID] = p
 		return

--- a/storage/replica.go
+++ b/storage/replica.go
@@ -555,6 +555,8 @@ func (r *Replica) Send(ctx context.Context, ba roachpb.BatchRequest) (*roachpb.B
 	}
 	// TODO(tschottdorf): assert nil reply on error.
 	if err != nil {
+		trace.SetError()
+		trace.Event(fmt.Sprintf("error: %s", err))
 		return nil, roachpb.NewError(err)
 	}
 	return br, nil
@@ -906,9 +908,6 @@ func (r *Replica) processRaftCommand(idKey cmdIDKey, index uint64, raftCmd roach
 	br, err := r.applyRaftCommand(ctx, index, raftCmd.OriginReplica, raftCmd.Cmd)
 	err = r.maybeSetCorrupt(err)
 	execDone()
-	if err != nil {
-		trace.Event(fmt.Sprintf("error: %T", err))
-	}
 
 	if cmd != nil {
 		cmd.done <- roachpb.ResponseWithError{Reply: br, Err: err}

--- a/storage/replica.go
+++ b/storage/replica.go
@@ -165,6 +165,7 @@ type Replica struct {
 	sync.RWMutex                 // Protects the following fields:
 	cmdQ         *CommandQueue   // Enforce at most one command is running per key(s)
 	tsCache      *TimestampCache // Most recent timestamps for keys / key ranges
+	quiesced     bool            // If true, removal pending and pendingCmds is nil
 	pendingCmds  map[cmdIDKey]*pendingCmd
 
 	// pendingReplica houses a replica that is not yet in the range
@@ -178,7 +179,7 @@ type Replica struct {
 		*sync.Cond
 		value roachpb.ReplicaDescriptor
 	}
-	truncatedState unsafe.Pointer // *roachpb.RaftTruancatedState
+	truncatedState unsafe.Pointer // *roachpb.RaftTruncatedState
 }
 
 var _ client.Sender = &Replica{}
@@ -864,11 +865,22 @@ func (r *Replica) proposeRaftCommand(ctx context.Context, ba roachpb.BatchReques
 	}
 	cmdID := ba.GetOrCreateCmdID(r.store.Clock().PhysicalNow())
 	idKey := makeCmdIDKey(cmdID)
-	r.Lock()
-	r.pendingCmds[idKey] = pendingCmd
-	r.Unlock()
+
 	var errChan <-chan error
-	if r.proposeRaftCommandFn != nil {
+	r.Lock()
+	if r.quiesced {
+		// Replica is about to be removed.
+		ch := make(chan error, 1)
+		ch <- multiraft.ErrGroupDeleted
+		errChan = ch
+	} else {
+		r.pendingCmds[idKey] = pendingCmd
+	}
+	r.Unlock()
+
+	if errChan != nil {
+		// already errored out; do nothing
+	} else if r.proposeRaftCommandFn != nil {
 		errChan = r.proposeRaftCommandFn(idKey, raftCmd)
 	} else {
 		errChan = r.store.ProposeRaftCommand(idKey, raftCmd)
@@ -1556,4 +1568,16 @@ func (r *Replica) maybeAddToSplitQueue() {
 	if maxBytes > 0 && r.stats.KeyBytes+r.stats.ValBytes > maxBytes {
 		r.store.splitQueue.MaybeAdd(r, r.store.Clock().Now())
 	}
+}
+
+// Quiesce drains the replica and prepares it for removal. All pending and future commands are aborted with a RangeNotFoundError.
+func (r *Replica) Quiesce() {
+	r.Lock()
+	defer r.Unlock()
+	for _, cmd := range r.pendingCmds {
+		// ErrGroupDeleted is transformed into RangeNotFound in (*Replica).Send().
+		cmd.done <- roachpb.ResponseWithError{Err: multiraft.ErrGroupDeleted}
+	}
+	r.pendingCmds = nil
+	r.quiesced = true
 }

--- a/storage/replica_test.go
+++ b/storage/replica_test.go
@@ -29,6 +29,8 @@ import (
 	"testing"
 	"time"
 
+	"golang.org/x/net/context"
+
 	"github.com/cockroachdb/cockroach/base"
 	"github.com/cockroachdb/cockroach/client"
 	"github.com/cockroachdb/cockroach/config"
@@ -3229,5 +3231,61 @@ func TestWriteWithoutCmdID(t *testing.T) {
 
 	if _, pErr := tc.rng.Send(tc.rng.context(), ba); pErr != nil {
 		t.Fatal(pErr)
+	}
+}
+
+func TestReplicaQuiesce(t *testing.T) {
+	defer leaktest.AfterTest(t)
+	tc := testContext{
+		rng: &Replica{},
+	}
+	tc.Start(t)
+	defer tc.Stop()
+
+	// Mock proposeRaftCommand to do nothing to get a pending command.
+	proposeRaftCommandFn := func(cmdIDKey, roachpb.RaftCommand) <-chan error {
+		ch := make(chan error, 1)
+		ch <- nil
+		return ch
+	}
+	rng, err := NewReplica(testRangeDescriptor(), tc.store)
+	rng.proposeRaftCommandFn = proposeRaftCommandFn
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := tc.store.AddReplicaTest(rng); err != nil {
+		t.Fatal(err)
+	}
+
+	args := putArgs(roachpb.Key("a"), nil)
+	var ba roachpb.BatchRequest
+	ba.Add(&args)
+
+	_, cmd := rng.proposeRaftCommand(context.Background(), ba)
+	rng.Quiesce()
+
+	select {
+	default:
+		t.Fatal("command was not canceled on Quiesce")
+	case rwe := <-cmd.done:
+		if rwe.Err != multiraft.ErrGroupDeleted {
+			t.Fatal(err)
+		}
+	}
+
+	rng.Lock()
+	if rng.pendingCmds != nil {
+		t.Error("expected rng.pendingCmds to be nil")
+	}
+	rng.Unlock()
+
+	errChan, _ := rng.proposeRaftCommand(context.Background(), ba)
+	select {
+	default:
+		t.Fatal("accepted new command after Quiesce")
+	case err := <-errChan:
+		if err != multiraft.ErrGroupDeleted {
+			t.Fatal(err)
+		}
 	}
 }

--- a/util/tracer/tracer.go
+++ b/util/tracer/tracer.go
@@ -99,6 +99,13 @@ func (t *Trace) Event(name string) {
 	t.Content[len(t.Content)-1].Duration = 0
 }
 
+// SetError marks the request associated to the Trace as failed.
+func (t *Trace) SetError() {
+	if t != nil {
+		t.nTrace.SetError()
+	}
+}
+
 // Epoch begins a phase in the life of the Trace, starting the measurement of
 // its duration. The returned function needs to be called when the measurement
 // is complete; failure to do so results in a panic() when Finalize() is


### PR DESCRIPTION
Scenario:
- client proposes command to raft, waits
- command commits, but hasn't gotten applied yet
- group gets removed, triggering the waiting client
- client decides the request has failed, leaves
- committed command executes
- r.pendingCmds still holds the command, so the contained trace
  panics (use-after-finalize).

The issue here is that `Replica`, `Store` and `Raft` are
moving parts, that can't fully move in lockstep with the removal.
(the store provides the Raft storage, so you can't remove the
group under the lock).

Instead, this change first "quiesces" the Replica, after which
it can be dropped from Raft, and, finally, from `Store`.

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/2977)

<!-- Reviewable:end -->
