### PR TITLE
Copied EncodedKey and RawKeyValue to storage/engine - Issue #2925

### DIFF
--- a/roachpb/data.go
+++ b/roachpb/data.go
@@ -31,6 +31,7 @@ import (
 
 	"github.com/biogo/store/interval"
 	"github.com/cockroachdb/cockroach/util/encoding"
+	"github.com/cockroachdb/cockroach/util/keys"
 	"github.com/cockroachdb/cockroach/util/uuid"
 	"github.com/gogo/protobuf/proto"
 )
@@ -74,7 +75,7 @@ func (rk RKey) Equal(other []byte) bool {
 
 // Next returns the RKey that sorts immediately after the given one.
 func (rk RKey) Next() RKey {
-	return RKey(bytesNext(rk))
+	return RKey(keys.BytesNext(rk))
 }
 
 // PrefixEnd determines the end key given key as a prefix, that is the
@@ -110,12 +111,6 @@ func MakeKey(keys ...[]byte) []byte {
 	return bytes.Join(byteSlices, nil)
 }
 
-// Returns the next possible byte by appending an \x00.
-func bytesNext(b []byte) []byte {
-	// TODO(spencer): Do we need to enforce KeyMaxLength here?
-	return append(append([]byte(nil), b...), 0)
-}
-
 func bytesPrefixEnd(b []byte) []byte {
 	end := append([]byte(nil), b...)
 	for i := len(end) - 1; i >= 0; i-- {
@@ -131,7 +126,7 @@ func bytesPrefixEnd(b []byte) []byte {
 
 // Next returns the next key in lexicographic sort order.
 func (k Key) Next() Key {
-	return Key(bytesNext(k))
+	return Key(keys.BytesNext(k))
 }
 
 // IsPrev is a more efficient version of k.Next().Equal(m).
@@ -142,7 +137,7 @@ func (k Key) IsPrev(m Key) bool {
 
 // Next returns the next key in lexicographic sort order.
 func (k EncodedKey) Next() EncodedKey {
-	return EncodedKey(bytesNext(k))
+	return EncodedKey(keys.BytesNext(k))
 }
 
 // PrefixEnd determines the end key given key as a prefix, that is the

--- a/storage/engine/batch_test.go
+++ b/storage/engine/batch_test.go
@@ -39,31 +39,31 @@ func TestBatchBasics(t *testing.T) {
 	b := e.NewBatch()
 	defer b.Close()
 
-	if err := b.Put(roachpb.EncodedKey("a"), []byte("value")); err != nil {
+	if err := b.Put(EncodedKey("a"), []byte("value")); err != nil {
 		t.Fatal(err)
 	}
 	// Write an engine value to be deleted.
-	if err := e.Put(roachpb.EncodedKey("b"), []byte("value")); err != nil {
+	if err := e.Put(EncodedKey("b"), []byte("value")); err != nil {
 		t.Fatal(err)
 	}
-	if err := b.Clear(roachpb.EncodedKey("b")); err != nil {
+	if err := b.Clear(EncodedKey("b")); err != nil {
 		t.Fatal(err)
 	}
 	// Write an engine value to be merged.
-	if err := e.Put(roachpb.EncodedKey("c"), appender("foo")); err != nil {
+	if err := e.Put(EncodedKey("c"), appender("foo")); err != nil {
 		t.Fatal(err)
 	}
-	if err := b.Merge(roachpb.EncodedKey("c"), appender("bar")); err != nil {
+	if err := b.Merge(EncodedKey("c"), appender("bar")); err != nil {
 		t.Fatal(err)
 	}
 
 	// Check all keys are in initial state (nothing from batch has gone
 	// through to engine until commit).
-	expValues := []roachpb.RawKeyValue{
-		{Key: roachpb.EncodedKey("b"), Value: []byte("value")},
-		{Key: roachpb.EncodedKey("c"), Value: appender("foo")},
+	expValues := []RawKeyValue{
+		{Key: EncodedKey("b"), Value: []byte("value")},
+		{Key: EncodedKey("c"), Value: appender("foo")},
 	}
-	kvs, err := Scan(e, roachpb.EncodedKey(roachpb.RKeyMin), roachpb.EncodedKey(roachpb.RKeyMax), 0)
+	kvs, err := Scan(e, EncodedKey(roachpb.RKeyMin), EncodedKey(roachpb.RKeyMax), 0)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -72,12 +72,12 @@ func TestBatchBasics(t *testing.T) {
 	}
 
 	// Now, merged values should be:
-	expValues = []roachpb.RawKeyValue{
-		{Key: roachpb.EncodedKey("a"), Value: []byte("value")},
-		{Key: roachpb.EncodedKey("c"), Value: appender("foobar")},
+	expValues = []RawKeyValue{
+		{Key: EncodedKey("a"), Value: []byte("value")},
+		{Key: EncodedKey("c"), Value: appender("foobar")},
 	}
 	// Scan values from batch directly.
-	kvs, err = Scan(b, roachpb.EncodedKey(roachpb.RKeyMin), roachpb.EncodedKey(roachpb.RKeyMax), 0)
+	kvs, err = Scan(b, EncodedKey(roachpb.RKeyMin), EncodedKey(roachpb.RKeyMax), 0)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -89,7 +89,7 @@ func TestBatchBasics(t *testing.T) {
 	if err := b.Commit(); err != nil {
 		t.Fatal(err)
 	}
-	kvs, err = Scan(e, roachpb.EncodedKey(roachpb.RKeyMin), roachpb.EncodedKey(roachpb.RKeyMax), 0)
+	kvs, err = Scan(e, EncodedKey(roachpb.RKeyMin), EncodedKey(roachpb.RKeyMax), 0)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -108,27 +108,27 @@ func TestBatchGet(t *testing.T) {
 	defer b.Close()
 
 	// Write initial values, then write to batch.
-	if err := e.Put(roachpb.EncodedKey("b"), []byte("value")); err != nil {
+	if err := e.Put(EncodedKey("b"), []byte("value")); err != nil {
 		t.Fatal(err)
 	}
-	if err := e.Put(roachpb.EncodedKey("c"), appender("foo")); err != nil {
+	if err := e.Put(EncodedKey("c"), appender("foo")); err != nil {
 		t.Fatal(err)
 	}
 	// Write batch values.
-	if err := b.Put(roachpb.EncodedKey("a"), []byte("value")); err != nil {
+	if err := b.Put(EncodedKey("a"), []byte("value")); err != nil {
 		t.Fatal(err)
 	}
-	if err := b.Clear(roachpb.EncodedKey("b")); err != nil {
+	if err := b.Clear(EncodedKey("b")); err != nil {
 		t.Fatal(err)
 	}
-	if err := b.Merge(roachpb.EncodedKey("c"), appender("bar")); err != nil {
+	if err := b.Merge(EncodedKey("c"), appender("bar")); err != nil {
 		t.Fatal(err)
 	}
 
-	expValues := []roachpb.RawKeyValue{
-		{Key: roachpb.EncodedKey("a"), Value: []byte("value")},
-		{Key: roachpb.EncodedKey("b"), Value: nil},
-		{Key: roachpb.EncodedKey("c"), Value: appender("foobar")},
+	expValues := []RawKeyValue{
+		{Key: EncodedKey("a"), Value: []byte("value")},
+		{Key: EncodedKey("b"), Value: nil},
+		{Key: EncodedKey("c"), Value: appender("foobar")},
 	}
 	for i, expKV := range expValues {
 		kv, err := b.Get(expKV.Key)
@@ -162,29 +162,29 @@ func TestBatchMerge(t *testing.T) {
 	defer b.Close()
 
 	// Write batch put, delete & merge.
-	if err := b.Put(roachpb.EncodedKey("a"), appender("a-value")); err != nil {
+	if err := b.Put(EncodedKey("a"), appender("a-value")); err != nil {
 		t.Fatal(err)
 	}
-	if err := b.Clear(roachpb.EncodedKey("b")); err != nil {
+	if err := b.Clear(EncodedKey("b")); err != nil {
 		t.Fatal(err)
 	}
-	if err := b.Merge(roachpb.EncodedKey("c"), appender("c-value")); err != nil {
+	if err := b.Merge(EncodedKey("c"), appender("c-value")); err != nil {
 		t.Fatal(err)
 	}
 
 	// Now, merge to all three keys.
-	if err := b.Merge(roachpb.EncodedKey("a"), appender("append")); err != nil {
+	if err := b.Merge(EncodedKey("a"), appender("append")); err != nil {
 		t.Fatal(err)
 	}
-	if err := b.Merge(roachpb.EncodedKey("b"), appender("append")); err != nil {
+	if err := b.Merge(EncodedKey("b"), appender("append")); err != nil {
 		t.Fatal(err)
 	}
-	if err := b.Merge(roachpb.EncodedKey("c"), appender("append")); err != nil {
+	if err := b.Merge(EncodedKey("c"), appender("append")); err != nil {
 		t.Fatal(err)
 	}
 
 	// Verify values.
-	val, err := b.Get(roachpb.EncodedKey("a"))
+	val, err := b.Get(EncodedKey("a"))
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -192,7 +192,7 @@ func TestBatchMerge(t *testing.T) {
 		t.Error("mismatch of \"a\"")
 	}
 
-	val, err = b.Get(roachpb.EncodedKey("b"))
+	val, err = b.Get(EncodedKey("b"))
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -200,7 +200,7 @@ func TestBatchMerge(t *testing.T) {
 		t.Error("mismatch of \"b\"")
 	}
 
-	val, err = b.Get(roachpb.EncodedKey("c"))
+	val, err = b.Get(EncodedKey("c"))
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -218,12 +218,12 @@ func TestBatchProto(t *testing.T) {
 	b := e.NewBatch()
 	defer b.Close()
 
-	kv := &roachpb.RawKeyValue{Key: roachpb.EncodedKey("a"), Value: []byte("value")}
-	if _, _, err := PutProto(b, roachpb.EncodedKey("proto"), kv); err != nil {
+	kv := &RawKeyValue{Key: EncodedKey("a"), Value: []byte("value")}
+	if _, _, err := PutProto(b, EncodedKey("proto"), kv); err != nil {
 		t.Fatal(err)
 	}
-	getKV := &roachpb.RawKeyValue{}
-	ok, keySize, valSize, err := b.GetProto(roachpb.EncodedKey("proto"), getKV)
+	getKV := &RawKeyValue{}
+	ok, keySize, valSize, err := b.GetProto(EncodedKey("proto"), getKV)
 	if !ok || err != nil {
 		t.Fatalf("expected GetProto to success ok=%t: %s", ok, err)
 	}
@@ -241,14 +241,14 @@ func TestBatchProto(t *testing.T) {
 		t.Errorf("expected %v; got %v", kv, getKV)
 	}
 	// Before commit, proto will not be available via engine.
-	if ok, _, _, err = e.GetProto(roachpb.EncodedKey("proto"), getKV); ok || err != nil {
+	if ok, _, _, err = e.GetProto(EncodedKey("proto"), getKV); ok || err != nil {
 		t.Fatalf("expected GetProto to fail ok=%t: %s", ok, err)
 	}
 	// Commit and verify the proto can be read directly from the engine.
 	if err := b.Commit(); err != nil {
 		t.Fatal(err)
 	}
-	if ok, _, _, err = e.GetProto(roachpb.EncodedKey("proto"), getKV); !ok || err != nil {
+	if ok, _, _, err = e.GetProto(EncodedKey("proto"), getKV); !ok || err != nil {
 		t.Fatalf("expected GetProto to success ok=%t: %s", ok, err)
 	}
 	if !reflect.DeepEqual(getKV, kv) {
@@ -265,20 +265,20 @@ func TestBatchScan(t *testing.T) {
 	b := e.NewBatch()
 	defer b.Close()
 
-	existingVals := []roachpb.RawKeyValue{
-		{Key: roachpb.EncodedKey("a"), Value: []byte("1")},
-		{Key: roachpb.EncodedKey("b"), Value: []byte("2")},
-		{Key: roachpb.EncodedKey("c"), Value: []byte("3")},
-		{Key: roachpb.EncodedKey("d"), Value: []byte("4")},
-		{Key: roachpb.EncodedKey("e"), Value: []byte("5")},
-		{Key: roachpb.EncodedKey("f"), Value: []byte("6")},
-		{Key: roachpb.EncodedKey("g"), Value: []byte("7")},
-		{Key: roachpb.EncodedKey("h"), Value: []byte("8")},
-		{Key: roachpb.EncodedKey("i"), Value: []byte("9")},
-		{Key: roachpb.EncodedKey("j"), Value: []byte("10")},
-		{Key: roachpb.EncodedKey("k"), Value: []byte("11")},
-		{Key: roachpb.EncodedKey("l"), Value: []byte("12")},
-		{Key: roachpb.EncodedKey("m"), Value: []byte("13")},
+	existingVals := []RawKeyValue{
+		{Key: EncodedKey("a"), Value: []byte("1")},
+		{Key: EncodedKey("b"), Value: []byte("2")},
+		{Key: EncodedKey("c"), Value: []byte("3")},
+		{Key: EncodedKey("d"), Value: []byte("4")},
+		{Key: EncodedKey("e"), Value: []byte("5")},
+		{Key: EncodedKey("f"), Value: []byte("6")},
+		{Key: EncodedKey("g"), Value: []byte("7")},
+		{Key: EncodedKey("h"), Value: []byte("8")},
+		{Key: EncodedKey("i"), Value: []byte("9")},
+		{Key: EncodedKey("j"), Value: []byte("10")},
+		{Key: EncodedKey("k"), Value: []byte("11")},
+		{Key: EncodedKey("l"), Value: []byte("12")},
+		{Key: EncodedKey("m"), Value: []byte("13")},
 	}
 	for _, kv := range existingVals {
 		if err := e.Put(kv.Key, kv.Value); err != nil {
@@ -286,17 +286,17 @@ func TestBatchScan(t *testing.T) {
 		}
 	}
 
-	batchVals := []roachpb.RawKeyValue{
-		{Key: roachpb.EncodedKey("a"), Value: []byte("b1")},
-		{Key: roachpb.EncodedKey("bb"), Value: []byte("b2")},
-		{Key: roachpb.EncodedKey("c"), Value: []byte("b3")},
-		{Key: roachpb.EncodedKey("dd"), Value: []byte("b4")},
-		{Key: roachpb.EncodedKey("e"), Value: []byte("b5")},
-		{Key: roachpb.EncodedKey("ff"), Value: []byte("b6")},
-		{Key: roachpb.EncodedKey("g"), Value: []byte("b7")},
-		{Key: roachpb.EncodedKey("hh"), Value: []byte("b8")},
-		{Key: roachpb.EncodedKey("i"), Value: []byte("b9")},
-		{Key: roachpb.EncodedKey("jj"), Value: []byte("b10")},
+	batchVals := []RawKeyValue{
+		{Key: EncodedKey("a"), Value: []byte("b1")},
+		{Key: EncodedKey("bb"), Value: []byte("b2")},
+		{Key: EncodedKey("c"), Value: []byte("b3")},
+		{Key: EncodedKey("dd"), Value: []byte("b4")},
+		{Key: EncodedKey("e"), Value: []byte("b5")},
+		{Key: EncodedKey("ff"), Value: []byte("b6")},
+		{Key: EncodedKey("g"), Value: []byte("b7")},
+		{Key: EncodedKey("hh"), Value: []byte("b8")},
+		{Key: EncodedKey("i"), Value: []byte("b9")},
+		{Key: EncodedKey("jj"), Value: []byte("b10")},
 	}
 	for _, kv := range batchVals {
 		if err := b.Put(kv.Key, kv.Value); err != nil {
@@ -305,25 +305,25 @@ func TestBatchScan(t *testing.T) {
 	}
 
 	scans := []struct {
-		start, end roachpb.EncodedKey
+		start, end EncodedKey
 		max        int64
 	}{
 		// Full monty.
-		{start: roachpb.EncodedKey("a"), end: roachpb.EncodedKey("z"), max: 0},
+		{start: EncodedKey("a"), end: EncodedKey("z"), max: 0},
 		// Select ~half.
-		{start: roachpb.EncodedKey("a"), end: roachpb.EncodedKey("z"), max: 9},
+		{start: EncodedKey("a"), end: EncodedKey("z"), max: 9},
 		// Select one.
-		{start: roachpb.EncodedKey("a"), end: roachpb.EncodedKey("z"), max: 1},
+		{start: EncodedKey("a"), end: EncodedKey("z"), max: 1},
 		// Select half by end key.
-		{start: roachpb.EncodedKey("a"), end: roachpb.EncodedKey("f0"), max: 0},
+		{start: EncodedKey("a"), end: EncodedKey("f0"), max: 0},
 		// Start at half and select rest.
-		{start: roachpb.EncodedKey("f"), end: roachpb.EncodedKey("z"), max: 0},
+		{start: EncodedKey("f"), end: EncodedKey("z"), max: 0},
 		// Start at last and select max=10.
-		{start: roachpb.EncodedKey("m"), end: roachpb.EncodedKey("z"), max: 10},
+		{start: EncodedKey("m"), end: EncodedKey("z"), max: 10},
 	}
 
 	// Scan each case using the batch and store the results.
-	results := map[int][]roachpb.RawKeyValue{}
+	results := map[int][]RawKeyValue{}
 	for i, scan := range scans {
 		kvs, err := Scan(b, scan.start, scan.end, scan.max)
 		if err != nil {
@@ -359,13 +359,13 @@ func TestBatchScanWithDelete(t *testing.T) {
 	defer b.Close()
 
 	// Write initial value, then delete via batch.
-	if err := e.Put(roachpb.EncodedKey("a"), []byte("value")); err != nil {
+	if err := e.Put(EncodedKey("a"), []byte("value")); err != nil {
 		t.Fatal(err)
 	}
-	if err := b.Clear(roachpb.EncodedKey("a")); err != nil {
+	if err := b.Clear(EncodedKey("a")); err != nil {
 		t.Fatal(err)
 	}
-	kvs, err := Scan(b, roachpb.EncodedKey(roachpb.RKeyMin), roachpb.EncodedKey(roachpb.RKeyMax), 0)
+	kvs, err := Scan(b, EncodedKey(roachpb.RKeyMin), EncodedKey(roachpb.RKeyMax), 0)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -387,18 +387,18 @@ func TestBatchScanMaxWithDeleted(t *testing.T) {
 	defer b.Close()
 
 	// Write two values.
-	if err := e.Put(roachpb.EncodedKey("a"), []byte("value1")); err != nil {
+	if err := e.Put(EncodedKey("a"), []byte("value1")); err != nil {
 		t.Fatal(err)
 	}
-	if err := e.Put(roachpb.EncodedKey("b"), []byte("value2")); err != nil {
+	if err := e.Put(EncodedKey("b"), []byte("value2")); err != nil {
 		t.Fatal(err)
 	}
 	// Now, delete "a" in batch.
-	if err := b.Clear(roachpb.EncodedKey("a")); err != nil {
+	if err := b.Clear(EncodedKey("a")); err != nil {
 		t.Fatal(err)
 	}
 	// A scan with max=1 should scan "b".
-	kvs, err := Scan(b, roachpb.EncodedKey(roachpb.RKeyMin), roachpb.EncodedKey(roachpb.RKeyMax), 1)
+	kvs, err := Scan(b, EncodedKey(roachpb.RKeyMin), EncodedKey(roachpb.RKeyMax), 1)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -421,10 +421,10 @@ func TestBatchConcurrency(t *testing.T) {
 	defer b.Close()
 
 	// Write a merge to the batch.
-	if err := b.Merge(roachpb.EncodedKey("a"), appender("bar")); err != nil {
+	if err := b.Merge(EncodedKey("a"), appender("bar")); err != nil {
 		t.Fatal(err)
 	}
-	val, err := b.Get(roachpb.EncodedKey("a"))
+	val, err := b.Get(EncodedKey("a"))
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -432,11 +432,11 @@ func TestBatchConcurrency(t *testing.T) {
 		t.Error("mismatch of \"a\"")
 	}
 	// Write an engine value.
-	if err := e.Put(roachpb.EncodedKey("a"), appender("foo")); err != nil {
+	if err := e.Put(EncodedKey("a"), appender("foo")); err != nil {
 		t.Fatal(err)
 	}
 	// Now, read again and verify that the merge happens on top of the mod.
-	val, err = b.Get(roachpb.EncodedKey("a"))
+	val, err = b.Get(EncodedKey("a"))
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/storage/engine/data.go
+++ b/storage/engine/data.go
@@ -49,4 +49,3 @@ func (k EncodedKey) Equal(l EncodedKey) bool {
 func (k EncodedKey) String() string {
 	return fmt.Sprintf("%q", []byte(k))
 }
-

--- a/storage/engine/data.go
+++ b/storage/engine/data.go
@@ -1,0 +1,52 @@
+// Copyright 2014 The Cockroach Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+// implied. See the License for the specific language governing
+// permissions and limitations under the License. See the AUTHORS file
+// for names of contributors.
+//
+// Author: Andrew Bonventre (andybons@gmail.com)
+// Author: Spencer Kimball (spencer.kimball@gmail.com)
+// Author: Jiang-Ming Yang (jiangming.yang@gmail.com)
+
+package engine
+
+import (
+	"bytes"
+	"fmt"
+
+	"github.com/cockroachdb/cockroach/util/keys"
+)
+
+// EncodedKey is an encoded key, distinguished from Key in that it is
+// an encoded version.
+type EncodedKey []byte
+
+// Next returns the next key in lexicographic sort order.
+func (k EncodedKey) Next() EncodedKey {
+	return EncodedKey(keys.BytesNext(k))
+}
+
+// Less compares two keys.
+func (k EncodedKey) Less(l EncodedKey) bool {
+	return bytes.Compare(k, l) < 0
+}
+
+// Equal returns whether two keys are identical.
+func (k EncodedKey) Equal(l EncodedKey) bool {
+	return bytes.Equal(k, l)
+}
+
+// String returns a string-formatted version of the key.
+func (k EncodedKey) String() string {
+	return fmt.Sprintf("%q", []byte(k))
+}
+

--- a/storage/engine/engine.go
+++ b/storage/engine/engine.go
@@ -51,7 +51,7 @@ type Iterator interface {
 	// iterator was not positioned at the first key.
 	Prev()
 	// Key returns the current key as a byte slice.
-	Key() roachpb.EncodedKey
+	Key() EncodedKey
 	// Value returns the current value as a byte slice.
 	Value() []byte
 	// ValueProto unmarshals the value the iterator is currently
@@ -71,24 +71,24 @@ type Engine interface {
 	// Attrs returns the engine/store attributes.
 	Attrs() roachpb.Attributes
 	// Put sets the given key to the value provided.
-	Put(key roachpb.EncodedKey, value []byte) error
+	Put(key EncodedKey, value []byte) error
 	// Get returns the value for the given key, nil otherwise.
-	Get(key roachpb.EncodedKey) ([]byte, error)
+	Get(key EncodedKey) ([]byte, error)
 	// GetProto fetches the value at the specified key and unmarshals it
 	// using a protobuf decoder. Returns true on success or false if the
 	// key was not found. On success, returns the length in bytes of the
 	// key and the value.
-	GetProto(key roachpb.EncodedKey, msg proto.Message) (ok bool, keyBytes, valBytes int64, err error)
+	GetProto(key EncodedKey, msg proto.Message) (ok bool, keyBytes, valBytes int64, err error)
 	// Iterate scans from start to end keys, visiting at most max
 	// key/value pairs. On each key value pair, the function f is
 	// invoked. If f returns an error or if the scan itself encounters
 	// an error, the iteration will stop and return the error.
 	// If the first result of f is true, the iteration stops.
-	Iterate(start, end roachpb.EncodedKey, f func(roachpb.RawKeyValue) (bool, error)) error
+	Iterate(start, end EncodedKey, f func(RawKeyValue) (bool, error)) error
 	// Clear removes the item from the db with the given key.
 	// Note that clear actually removes entries from the storage
 	// engine, rather than inserting tombstones.
-	Clear(key roachpb.EncodedKey) error
+	Clear(key EncodedKey) error
 	// Merge is a high-performance write operation used for values which are
 	// accumulated over several writes. Multiple values can be merged
 	// sequentially into a single key; a subsequent read will return a "merged"
@@ -102,7 +102,7 @@ type Engine interface {
 	// combined with specialized logic beyond that of simple byte slices.
 	//
 	// The logic for merges is written in db.cc in order to be compatible with RocksDB.
-	Merge(key roachpb.EncodedKey, value []byte) error
+	Merge(key EncodedKey, value []byte) error
 	// Capacity returns capacity details for the engine's available storage.
 	Capacity() (roachpb.StoreCapacity, error)
 	// SetGCTimeouts sets timeout values for GC of transaction and
@@ -114,7 +114,7 @@ type Engine interface {
 	SetGCTimeouts(minTxnTS, minRCacheTS int64)
 	// ApproximateSize returns the approximate number of bytes the engine is
 	// using to store data for the given range of keys.
-	ApproximateSize(start, end roachpb.EncodedKey) (uint64, error)
+	ApproximateSize(start, end EncodedKey) (uint64, error)
 	// Flush causes the engine to write all in-memory data to disk
 	// immediately.
 	Flush() error
@@ -152,7 +152,7 @@ var bufferPool = sync.Pool{
 // PutProto sets the given key to the protobuf-serialized byte string
 // of msg and the provided timestamp. Returns the length in bytes of
 // key and the value.
-func PutProto(engine Engine, key roachpb.EncodedKey, msg proto.Message) (keyBytes, valBytes int64, err error) {
+func PutProto(engine Engine, key EncodedKey, msg proto.Message) (keyBytes, valBytes int64, err error) {
 	buf := bufferPool.Get().(*proto.Buffer)
 	buf.Reset()
 
@@ -175,9 +175,9 @@ func PutProto(engine Engine, key roachpb.EncodedKey, msg proto.Message) (keyByte
 // Scan returns up to max key/value objects starting from
 // start (inclusive) and ending at end (non-inclusive).
 // Specify max=0 for unbounded scans.
-func Scan(engine Engine, start, end roachpb.EncodedKey, max int64) ([]roachpb.RawKeyValue, error) {
-	var kvs []roachpb.RawKeyValue
-	err := engine.Iterate(start, end, func(kv roachpb.RawKeyValue) (bool, error) {
+func Scan(engine Engine, start, end EncodedKey, max int64) ([]RawKeyValue, error) {
+	var kvs []RawKeyValue
+	err := engine.Iterate(start, end, func(kv RawKeyValue) (bool, error) {
 		if max != 0 && int64(len(kvs)) >= max {
 			return true, nil
 		}
@@ -193,11 +193,11 @@ func Scan(engine Engine, start, end roachpb.EncodedKey, max int64) ([]roachpb.Ra
 // none, and an error will be returned. Note that this function
 // actually removes entries from the storage engine, rather than
 // inserting tombstones, as with deletion through the MVCC.
-func ClearRange(engine Engine, start, end roachpb.EncodedKey) (int, error) {
+func ClearRange(engine Engine, start, end EncodedKey) (int, error) {
 	b := engine.NewBatch()
 	defer b.Close()
 	count := 0
-	if err := engine.Iterate(start, end, func(kv roachpb.RawKeyValue) (bool, error) {
+	if err := engine.Iterate(start, end, func(kv RawKeyValue) (bool, error) {
 		if err := b.Clear(kv.Key); err != nil {
 			return false, err
 		}

--- a/storage/engine/engine_test.go
+++ b/storage/engine/engine_test.go
@@ -34,7 +34,7 @@ import (
 	"github.com/gogo/protobuf/proto"
 )
 
-func ensureRangeEqual(t *testing.T, sortedKeys []string, keyMap map[string][]byte, keyvals []roachpb.RawKeyValue) {
+func ensureRangeEqual(t *testing.T, sortedKeys []string, keyMap map[string][]byte, keyvals []RawKeyValue) {
 	if len(keyvals) != len(sortedKeys) {
 		t.Errorf("length mismatch. expected %s, got %s", sortedKeys, keyvals)
 	}
@@ -68,7 +68,7 @@ func runWithAllEngines(test func(e Engine, t *testing.T), t *testing.T) {
 func TestEngineBatchCommit(t *testing.T) {
 	defer leaktest.AfterTest(t)
 	numWrites := 10000
-	key := roachpb.EncodedKey("a")
+	key := EncodedKey("a")
 	finalVal := []byte(strconv.Itoa(numWrites - 1))
 
 	runWithAllEngines(func(e Engine, t *testing.T) {
@@ -120,10 +120,10 @@ func TestEngineBatch(t *testing.T) {
 	defer leaktest.AfterTest(t)
 	runWithAllEngines(func(engine Engine, t *testing.T) {
 		numShuffles := 100
-		key := roachpb.EncodedKey("a")
+		key := EncodedKey("a")
 		// Those are randomized below.
 		type data struct {
-			key   roachpb.EncodedKey
+			key   EncodedKey
 			value []byte
 			merge bool
 		}
@@ -162,7 +162,7 @@ func TestEngineBatch(t *testing.T) {
 			return eng.Put(d.key, d.value)
 		}
 
-		get := func(eng Engine, key roachpb.EncodedKey) []byte {
+		get := func(eng Engine, key EncodedKey) []byte {
 			b, err := eng.Get(key)
 			if err != nil {
 				t.Fatal(err)
@@ -324,12 +324,12 @@ func TestEngineMerge(t *testing.T) {
 	defer leaktest.AfterTest(t)
 	runWithAllEngines(func(engine Engine, t *testing.T) {
 		testcases := []struct {
-			testKey  roachpb.EncodedKey
+			testKey  EncodedKey
 			merges   [][]byte
 			expected []byte
 		}{
 			{
-				roachpb.EncodedKey("haste not in life"),
+				EncodedKey("haste not in life"),
 				[][]byte{
 					appender("x"),
 					appender("y"),
@@ -338,7 +338,7 @@ func TestEngineMerge(t *testing.T) {
 				appender("xyz"),
 			},
 			{
-				roachpb.EncodedKey("timeseriesmerged"),
+				EncodedKey("timeseriesmerged"),
 				[][]byte{
 					timeSeries(testtime, 1000, []tsSample{
 						{1, 1, 5, 5, 5},
@@ -433,9 +433,9 @@ func TestEngineScan1(t *testing.T) {
 		// Should return all key/value pairs in lexicographic order.
 		// Note that []byte("") is the lowest key possible and is
 		// a special case in engine.scan, that's why we test it here.
-		startKeys := []roachpb.EncodedKey{roachpb.EncodedKey("cat"), roachpb.EncodedKey("")}
+		startKeys := []EncodedKey{EncodedKey("cat"), EncodedKey("")}
 		for _, startKey := range startKeys {
-			keyvals, err = Scan(engine, startKey, roachpb.EncodedKey(roachpb.RKeyMax), 0)
+			keyvals, err = Scan(engine, startKey, EncodedKey(roachpb.RKeyMax), 0)
 			if err != nil {
 				t.Fatalf("could not run scan: %v", err)
 			}
@@ -444,7 +444,7 @@ func TestEngineScan1(t *testing.T) {
 	}, t)
 }
 
-func verifyScan(start, end roachpb.EncodedKey, max int64, expKeys []roachpb.EncodedKey, engine Engine, t *testing.T) {
+func verifyScan(start, end EncodedKey, max int64, expKeys []EncodedKey, engine Engine, t *testing.T) {
 	kvs, err := Scan(engine, start, end, max)
 	if err != nil {
 		t.Errorf("scan %q-%q: expected no error, but got %s", string(start), string(end), err)
@@ -466,53 +466,53 @@ func TestEngineScan2(t *testing.T) {
 	// TODO(Tobias): Merge this with TestEngineScan1 and remove
 	// either verifyScan or the other helper function.
 	runWithAllEngines(func(engine Engine, t *testing.T) {
-		keys := []roachpb.EncodedKey{
-			roachpb.EncodedKey("a"),
-			roachpb.EncodedKey("aa"),
-			roachpb.EncodedKey("aaa"),
-			roachpb.EncodedKey("ab"),
-			roachpb.EncodedKey("abc"),
-			roachpb.EncodedKey(roachpb.RKeyMax),
+		keys := []EncodedKey{
+			EncodedKey("a"),
+			EncodedKey("aa"),
+			EncodedKey("aaa"),
+			EncodedKey("ab"),
+			EncodedKey("abc"),
+			EncodedKey(roachpb.RKeyMax),
 		}
 
 		insertKeys(keys, engine, t)
 
 		// Scan all keys (non-inclusive of final key).
-		verifyScan(roachpb.EncodedKey(roachpb.RKeyMin), roachpb.EncodedKey(roachpb.RKeyMax), 10, keys[0:5], engine, t)
-		verifyScan(roachpb.EncodedKey("a"), roachpb.EncodedKey(roachpb.RKeyMax), 10, keys[0:5], engine, t)
+		verifyScan(EncodedKey(roachpb.RKeyMin), EncodedKey(roachpb.RKeyMax), 10, keys[0:5], engine, t)
+		verifyScan(EncodedKey("a"), EncodedKey(roachpb.RKeyMax), 10, keys[0:5], engine, t)
 
 		// Scan sub range.
-		verifyScan(roachpb.EncodedKey("aab"), roachpb.EncodedKey("abcc"), 10, keys[3:5], engine, t)
-		verifyScan(roachpb.EncodedKey("aa0"), roachpb.EncodedKey("abcc"), 10, keys[2:5], engine, t)
+		verifyScan(EncodedKey("aab"), EncodedKey("abcc"), 10, keys[3:5], engine, t)
+		verifyScan(EncodedKey("aa0"), EncodedKey("abcc"), 10, keys[2:5], engine, t)
 
 		// Scan with max values.
-		verifyScan(roachpb.EncodedKey(roachpb.RKeyMin), roachpb.EncodedKey(roachpb.RKeyMax), 3, keys[0:3], engine, t)
-		verifyScan(roachpb.EncodedKey("a0"), roachpb.EncodedKey(roachpb.RKeyMax), 3, keys[1:4], engine, t)
+		verifyScan(EncodedKey(roachpb.RKeyMin), EncodedKey(roachpb.RKeyMax), 3, keys[0:3], engine, t)
+		verifyScan(EncodedKey("a0"), EncodedKey(roachpb.RKeyMax), 3, keys[1:4], engine, t)
 
 		// Scan with max value 0 gets all values.
-		verifyScan(roachpb.EncodedKey(roachpb.RKeyMin), roachpb.EncodedKey(roachpb.RKeyMax), 0, keys[0:5], engine, t)
+		verifyScan(EncodedKey(roachpb.RKeyMin), EncodedKey(roachpb.RKeyMax), 0, keys[0:5], engine, t)
 	}, t)
 }
 
 func TestEngineDeleteRange(t *testing.T) {
 	defer leaktest.AfterTest(t)
 	runWithAllEngines(func(engine Engine, t *testing.T) {
-		keys := []roachpb.EncodedKey{
-			roachpb.EncodedKey("a"),
-			roachpb.EncodedKey("aa"),
-			roachpb.EncodedKey("aaa"),
-			roachpb.EncodedKey("ab"),
-			roachpb.EncodedKey("abc"),
-			roachpb.EncodedKey(roachpb.RKeyMax),
+		keys := []EncodedKey{
+			EncodedKey("a"),
+			EncodedKey("aa"),
+			EncodedKey("aaa"),
+			EncodedKey("ab"),
+			EncodedKey("abc"),
+			EncodedKey(roachpb.RKeyMax),
 		}
 
 		insertKeys(keys, engine, t)
 
 		// Scan all keys (non-inclusive of final key).
-		verifyScan(roachpb.EncodedKey(roachpb.RKeyMin), roachpb.EncodedKey(roachpb.RKeyMax), 10, keys[0:5], engine, t)
+		verifyScan(EncodedKey(roachpb.RKeyMin), EncodedKey(roachpb.RKeyMax), 10, keys[0:5], engine, t)
 
 		// Delete a range of keys
-		numDeleted, err := ClearRange(engine, roachpb.EncodedKey("aa"), roachpb.EncodedKey("abc"))
+		numDeleted, err := ClearRange(engine, EncodedKey("aa"), EncodedKey("abc"))
 		// Verify what was deleted
 		if err != nil {
 			t.Error("Not expecting an error")
@@ -521,8 +521,8 @@ func TestEngineDeleteRange(t *testing.T) {
 			t.Errorf("Expected to delete 3 entries; was %v", numDeleted)
 		}
 		// Verify what's left
-		verifyScan(roachpb.EncodedKey(roachpb.RKeyMin), roachpb.EncodedKey(roachpb.RKeyMax), 10,
-			[]roachpb.EncodedKey{roachpb.EncodedKey("a"), roachpb.EncodedKey("abc")}, engine, t)
+		verifyScan(EncodedKey(roachpb.RKeyMin), EncodedKey(roachpb.RKeyMax), 10,
+			[]EncodedKey{EncodedKey("a"), EncodedKey("abc")}, engine, t)
 	}, t)
 }
 
@@ -561,8 +561,8 @@ func TestSnapshot(t *testing.T) {
 				valSnapshot, val1)
 		}
 
-		keyvals, _ := Scan(engine, key, roachpb.EncodedKey(roachpb.RKeyMax), 0)
-		keyvalsSnapshot, error := Scan(snap, key, roachpb.EncodedKey(roachpb.RKeyMax), 0)
+		keyvals, _ := Scan(engine, key, EncodedKey(roachpb.RKeyMax), 0)
+		keyvalsSnapshot, error := Scan(snap, key, EncodedKey(roachpb.RKeyMax), 0)
 		if error != nil {
 			t.Fatalf("error : %s", error)
 		}
@@ -618,8 +618,8 @@ func TestSnapshotMethods(t *testing.T) {
 		}
 
 		// Verify Scan.
-		keyvals, _ := Scan(engine, roachpb.EncodedKey(roachpb.RKeyMin), roachpb.EncodedKey(roachpb.RKeyMax), 0)
-		keyvalsSnapshot, err := Scan(snap, roachpb.EncodedKey(roachpb.RKeyMin), roachpb.EncodedKey(roachpb.RKeyMax), 0)
+		keyvals, _ := Scan(engine, EncodedKey(roachpb.RKeyMin), EncodedKey(roachpb.RKeyMax), 0)
+		keyvalsSnapshot, err := Scan(snap, EncodedKey(roachpb.RKeyMin), EncodedKey(roachpb.RKeyMax), 0)
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -630,7 +630,7 @@ func TestSnapshotMethods(t *testing.T) {
 
 		// Verify Iterate.
 		index := 0
-		if err := snap.Iterate(roachpb.EncodedKey(roachpb.RKeyMin), roachpb.EncodedKey(roachpb.RKeyMax), func(kv roachpb.RawKeyValue) (bool, error) {
+		if err := snap.Iterate(EncodedKey(roachpb.RKeyMin), EncodedKey(roachpb.RKeyMax), func(kv RawKeyValue) (bool, error) {
 			if !bytes.Equal(kv.Key, keys[index]) || !bytes.Equal(kv.Value, vals[index]) {
 				t.Errorf("%d: key/value not equal between expected and snapshot: %s/%s, %s/%s",
 					index, keys[index], vals[index], kv.Key, kv.Value)
@@ -667,11 +667,11 @@ func TestSnapshotMethods(t *testing.T) {
 		}
 
 		// Verify ApproximateSize.
-		approx, err := engine.ApproximateSize(roachpb.EncodedKey(roachpb.RKeyMin), roachpb.EncodedKey(roachpb.RKeyMax))
+		approx, err := engine.ApproximateSize(EncodedKey(roachpb.RKeyMin), EncodedKey(roachpb.RKeyMax))
 		if err != nil {
 			t.Fatal(err)
 		}
-		approxSnapshot, err := snap.ApproximateSize(roachpb.EncodedKey(roachpb.RKeyMin), roachpb.EncodedKey(roachpb.RKeyMax))
+		approxSnapshot, err := snap.ApproximateSize(EncodedKey(roachpb.RKeyMin), EncodedKey(roachpb.RKeyMax))
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -736,7 +736,7 @@ func TestApproximateSize(t *testing.T) {
 	runWithAllEngines(func(engine Engine, t *testing.T) {
 		var (
 			count    = 10000
-			keys     = make([]roachpb.EncodedKey, count)
+			keys     = make([]EncodedKey, count)
 			values   = make([][]byte, count) // Random values to prevent compression
 			rand, _  = randutil.NewPseudoRand()
 			valueLen = 10
@@ -759,11 +759,11 @@ func TestApproximateSize(t *testing.T) {
 	}, t)
 }
 
-func insertKeys(keys []roachpb.EncodedKey, engine Engine, t *testing.T) {
+func insertKeys(keys []EncodedKey, engine Engine, t *testing.T) {
 	insertKeysAndValues(keys, nil, engine, t)
 }
 
-func insertKeysAndValues(keys []roachpb.EncodedKey, values [][]byte, engine Engine, t *testing.T) {
+func insertKeysAndValues(keys []EncodedKey, values [][]byte, engine Engine, t *testing.T) {
 	// Add keys to store in random order (make sure they sort!).
 	order := rand.Perm(len(keys))
 	for _, idx := range order {
@@ -779,7 +779,7 @@ func insertKeysAndValues(keys []roachpb.EncodedKey, values [][]byte, engine Engi
 	}
 }
 
-func verifyApproximateSize(keys []roachpb.EncodedKey, engine Engine, sizePerRecord int, ratio float64, t *testing.T) {
+func verifyApproximateSize(keys []EncodedKey, engine Engine, sizePerRecord int, ratio float64, t *testing.T) {
 	sz, err := engine.ApproximateSize(keys[0], keys[len(keys)-1])
 	if err != nil {
 		t.Errorf("Error from ApproximateSize(): %s", err)

--- a/storage/engine/gc.go
+++ b/storage/engine/gc.go
@@ -47,7 +47,7 @@ func NewGarbageCollector(now roachpb.Timestamp, policy config.GCPolicy) *Garbage
 // Returns the timestamp including, and after which, all values should
 // be garbage collected. If no values should be GC'd, returns
 // roachpb.ZeroTimestamp.
-func (gc *GarbageCollector) Filter(keys []roachpb.EncodedKey, values [][]byte) roachpb.Timestamp {
+func (gc *GarbageCollector) Filter(keys []EncodedKey, values [][]byte) roachpb.Timestamp {
 	if gc.policy.TTLSeconds <= 0 {
 		return roachpb.ZeroTimestamp
 	}

--- a/storage/engine/gc_test.go
+++ b/storage/engine/gc_test.go
@@ -29,12 +29,12 @@ import (
 var (
 	aKey  = roachpb.Key("a")
 	bKey  = roachpb.Key("b")
-	aKeys = []roachpb.EncodedKey{
+	aKeys = []EncodedKey{
 		MVCCEncodeVersionKey(aKey, makeTS(2E9, 0)),
 		MVCCEncodeVersionKey(aKey, makeTS(1E9, 1)),
 		MVCCEncodeVersionKey(aKey, makeTS(1E9, 0)),
 	}
-	bKeys = []roachpb.EncodedKey{
+	bKeys = []EncodedKey{
 		MVCCEncodeVersionKey(bKey, makeTS(2E9, 0)),
 		MVCCEncodeVersionKey(bKey, makeTS(1E9, 0)),
 	}
@@ -59,7 +59,7 @@ func TestGarbageCollectorFilter(t *testing.T) {
 	testData := []struct {
 		gc       *GarbageCollector
 		time     roachpb.Timestamp
-		keys     []roachpb.EncodedKey
+		keys     []EncodedKey
 		values   [][]byte
 		expDelTS roachpb.Timestamp
 	}{

--- a/storage/engine/mvcc.go
+++ b/storage/engine/mvcc.go
@@ -44,7 +44,7 @@ var (
 )
 
 type encodedSpan struct {
-	start, end roachpb.EncodedKey
+	start, end EncodedKey
 }
 
 // illegalSplitKeySpans lists spans of keys that should not be split.
@@ -458,8 +458,8 @@ func MVCCGet(engine Engine, key roachpb.Key, timestamp roachpb.Timestamp, consis
 	}
 
 	// Create a function which scans for the first key between start and end keys.
-	getValue := func(engine Engine, start, end roachpb.EncodedKey,
-		msg proto.Message) (roachpb.EncodedKey, error) {
+	getValue := func(engine Engine, start, end EncodedKey,
+		msg proto.Message) (EncodedKey, error) {
 		iter := engine.NewIterator()
 		defer iter.Close()
 		iter.Seek(start)
@@ -487,8 +487,8 @@ func MVCCGet(engine Engine, key roachpb.Key, timestamp roachpb.Timestamp, consis
 
 // getValueFunc fetches a version of a key between start and end.
 // Returns the key as an encoded byte slice, and error, if applicable.
-type getValueFunc func(engine Engine, start, end roachpb.EncodedKey,
-	msg proto.Message) (roachpb.EncodedKey, error)
+type getValueFunc func(engine Engine, start, end EncodedKey,
+	msg proto.Message) (EncodedKey, error)
 
 // mvccGetInternal parses the MVCCMetadata from the specified raw key
 // value, and reads the versioned value indicated by timestamp, taking
@@ -500,7 +500,7 @@ type getValueFunc func(engine Engine, start, end roachpb.EncodedKey,
 // most recent non-intent value instead. In the event that an inconsistent read
 // does encounter an intent (currently there can only be one), it is returned
 // via the roachpb.Intent slice, in addition to the result.
-func mvccGetInternal(engine Engine, key roachpb.Key, metaKey roachpb.EncodedKey,
+func mvccGetInternal(engine Engine, key roachpb.Key, metaKey EncodedKey,
 	timestamp roachpb.Timestamp, consistent bool, txn *roachpb.Transaction,
 	getValue getValueFunc, buf *getBuffer) (*roachpb.Value, []roachpb.Intent, error) {
 	if !consistent && txn != nil {
@@ -526,7 +526,7 @@ func mvccGetInternal(engine Engine, key roachpb.Key, metaKey roachpb.EncodedKey,
 		timestamp = meta.Timestamp.Prev()
 	}
 
-	var valueKey roachpb.EncodedKey
+	var valueKey EncodedKey
 	value := &buf.value
 
 	if !timestamp.Less(meta.Timestamp) && meta.HasWriteIntentError(txn) {
@@ -972,7 +972,7 @@ func MVCCDeleteRange(engine Engine, ms *MVCCStats, key, endKey roachpb.Key, max 
 	return num, nil
 }
 
-func getScanMetaKey(iter Iterator, encEndKey roachpb.EncodedKey) (roachpb.Key, roachpb.EncodedKey, error) {
+func getScanMetaKey(iter Iterator, encEndKey EncodedKey) (roachpb.Key, EncodedKey, error) {
 	metaKey := iter.Key()
 	if bytes.Compare(metaKey, encEndKey) >= 0 {
 		return nil, nil, iter.Error()
@@ -987,7 +987,7 @@ func getScanMetaKey(iter Iterator, encEndKey roachpb.EncodedKey) (roachpb.Key, r
 	return key, metaKey, nil
 }
 
-func getReverseScanMetaKey(iter Iterator, encEndKey roachpb.EncodedKey) (roachpb.Key, roachpb.EncodedKey, error) {
+func getReverseScanMetaKey(iter Iterator, encEndKey EncodedKey) (roachpb.Key, EncodedKey, error) {
 	metaKey := iter.Key()
 	// The metaKey < encEndKey is exceeding the boundary.
 	if bytes.Compare(metaKey, encEndKey) < 0 {
@@ -1076,13 +1076,13 @@ func MVCCIterate(engine Engine, startKey, endKey roachpb.Key, timestamp roachpb.
 
 	// getMetaKeyFunc is used to get the key and the meta key of the logic row.
 	// encEndKey is used to judge whether iterator exceeds the boundary or not.
-	type getMetaKeyFunc func(iter Iterator, encEndKey roachpb.EncodedKey) (roachpb.Key,
-		roachpb.EncodedKey, error)
+	type getMetaKeyFunc func(iter Iterator, encEndKey EncodedKey) (roachpb.Key,
+		EncodedKey, error)
 	var getMetaKey getMetaKeyFunc
 
 	// We store encEndKey and encKey in the same buffer to avoid memory
 	// allocations.
-	var encKey, encEndKey roachpb.EncodedKey
+	var encKey, encEndKey EncodedKey
 	var keyBuf []byte
 	if reverse {
 		encEndKey = mvccEncodeKey(buf.key[0:0], startKey)
@@ -1099,8 +1099,8 @@ func MVCCIterate(engine Engine, startKey, endKey roachpb.Key, timestamp roachpb.
 	// Get a new iterator and define our getter using iter.Seek.
 	iter := engine.NewIterator()
 	defer iter.Close()
-	getValue := func(engine Engine, start, end roachpb.EncodedKey,
-		msg proto.Message) (roachpb.EncodedKey, error) {
+	getValue := func(engine Engine, start, end EncodedKey,
+		msg proto.Message) (EncodedKey, error) {
 		iter.Seek(start)
 		if !iter.Valid() {
 			return nil, iter.Error()
@@ -1495,7 +1495,7 @@ func IsValidSplitKey(key roachpb.Key) bool {
 
 // isValidEncodedSplitKey iterates through the illegal ranges and
 // returns true if the specified key falls within any; false otherwise.
-func isValidEncodedSplitKey(key roachpb.EncodedKey) bool {
+func isValidEncodedSplitKey(key EncodedKey) bool {
 	for _, rng := range illegalSplitKeySpans {
 		if rng.start.Less(key) && key.Less(rng.end) {
 			return false
@@ -1530,7 +1530,7 @@ func MVCCFindSplitKey(engine Engine, rangeID roachpb.RangeID, key, endKey roachp
 	bestSplitKey := encStartKey
 	bestSplitDiff := int64(math.MaxInt64)
 
-	if err := engine.Iterate(encStartKey, encEndKey, func(kv roachpb.RawKeyValue) (bool, error) {
+	if err := engine.Iterate(encStartKey, encEndKey, func(kv RawKeyValue) (bool, error) {
 		// Is key within a legal key range?
 		valid := isValidEncodedSplitKey(kv.Key)
 
@@ -1659,27 +1659,27 @@ func MVCCComputeStats(iter Iterator, nowNanos int64) (MVCCStats, error) {
 // MVCCEncodeKey makes an MVCC key for storing MVCC metadata or
 // for storing raw values directly. Use MVCCEncodeVersionValue for
 // storing timestamped version values.
-func MVCCEncodeKey(key roachpb.Key) roachpb.EncodedKey {
+func MVCCEncodeKey(key roachpb.Key) EncodedKey {
 	return mvccEncodeKey(nil, key)
 }
 
 // mvccEncodeKey is the internal version of MVCCEncodeKey and takes a
 // buffer to append the encoded key to.
-func mvccEncodeKey(buf []byte, key roachpb.Key) roachpb.EncodedKey {
+func mvccEncodeKey(buf []byte, key roachpb.Key) EncodedKey {
 	return encoding.EncodeBytes(buf, key)
 }
 
 // MVCCEncodeVersionKey makes an MVCC version key, which consists
 // of a binary-encoding of key, followed by a decreasing encoding
 // of the timestamp, so that more recent versions sort first.
-func MVCCEncodeVersionKey(key roachpb.Key, timestamp roachpb.Timestamp) roachpb.EncodedKey {
+func MVCCEncodeVersionKey(key roachpb.Key, timestamp roachpb.Timestamp) EncodedKey {
 	k := encoding.EncodeBytes(nil, key)
 	return mvccEncodeTimestamp(k, timestamp)
 }
 
 // mvccEncodeTimestamp encodes the MVCC version info onto an existing
 // MVCC key (created using MVCCEncodeKey).
-func mvccEncodeTimestamp(key roachpb.EncodedKey, timestamp roachpb.Timestamp) roachpb.EncodedKey {
+func mvccEncodeTimestamp(key EncodedKey, timestamp roachpb.Timestamp) EncodedKey {
 	if timestamp.WallTime < 0 || timestamp.Logical < 0 {
 		panic(fmt.Sprintf("negative values disallowed in timestamps: %+v", timestamp))
 	}
@@ -1695,7 +1695,7 @@ func mvccEncodeTimestamp(key roachpb.EncodedKey, timestamp roachpb.Timestamp) ro
 // exactly 12 trailing bytes and they're decoded into a timestamp.
 // The decoded key, timestamp and true are returned to indicate the
 // key is for an MVCC versioned value.
-func MVCCDecodeKey(encodedKey roachpb.EncodedKey) (roachpb.Key, roachpb.Timestamp, bool, error) {
+func MVCCDecodeKey(encodedKey EncodedKey) (roachpb.Key, roachpb.Timestamp, bool, error) {
 	tsBytes, key, err := encoding.DecodeBytes(encodedKey, nil)
 	if err != nil {
 		return nil, roachpb.Timestamp{}, false, err

--- a/storage/engine/mvcc.pb.go
+++ b/storage/engine/mvcc.pb.go
@@ -12,6 +12,7 @@
 		MVCCValue
 		MVCCMetadata
 		MVCCStats
+		RawKeyValue
 */
 package engine
 
@@ -95,6 +96,16 @@ type MVCCStats struct {
 func (m *MVCCStats) Reset()         { *m = MVCCStats{} }
 func (m *MVCCStats) String() string { return proto.CompactTextString(m) }
 func (*MVCCStats) ProtoMessage()    {}
+
+// RawKeyValue contains the raw bytes of the value for a key.
+type RawKeyValue struct {
+	Key   EncodedKey `protobuf:"bytes,1,opt,name=key,casttype=EncodedKey" json:"key,omitempty"`
+	Value []byte     `protobuf:"bytes,2,opt,name=value" json:"value,omitempty"`
+}
+
+func (m *RawKeyValue) Reset()         { *m = RawKeyValue{} }
+func (m *RawKeyValue) String() string { return proto.CompactTextString(m) }
+func (*RawKeyValue) ProtoMessage()    {}
 
 func (m *MVCCValue) Marshal() (data []byte, err error) {
 	size := m.Size()
@@ -251,6 +262,36 @@ func (m *MVCCStats) MarshalTo(data []byte) (int, error) {
 	return i, nil
 }
 
+func (m *RawKeyValue) Marshal() (data []byte, err error) {
+	size := m.Size()
+	data = make([]byte, size)
+	n, err := m.MarshalTo(data)
+	if err != nil {
+		return nil, err
+	}
+	return data[:n], nil
+}
+
+func (m *RawKeyValue) MarshalTo(data []byte) (int, error) {
+	var i int
+	_ = i
+	var l int
+	_ = l
+	if m.Key != nil {
+		data[i] = 0xa
+		i++
+		i = encodeVarintMvcc(data, i, uint64(len(m.Key)))
+		i += copy(data[i:], m.Key)
+	}
+	if m.Value != nil {
+		data[i] = 0x12
+		i++
+		i = encodeVarintMvcc(data, i, uint64(len(m.Value)))
+		i += copy(data[i:], m.Value)
+	}
+	return i, nil
+}
+
 func encodeFixed64Mvcc(data []byte, offset int, v uint64) int {
 	data[offset] = uint8(v)
 	data[offset+1] = uint8(v >> 8)
@@ -324,6 +365,20 @@ func (m *MVCCStats) Size() (n int) {
 	n += 1 + sovMvcc(uint64(m.SysBytes))
 	n += 1 + sovMvcc(uint64(m.SysCount))
 	n += 2 + sovMvcc(uint64(m.LastUpdateNanos))
+	return n
+}
+
+func (m *RawKeyValue) Size() (n int) {
+	var l int
+	_ = l
+	if m.Key != nil {
+		l = len(m.Key)
+		n += 1 + l + sovMvcc(uint64(l))
+	}
+	if m.Value != nil {
+		l = len(m.Value)
+		n += 1 + l + sovMvcc(uint64(l))
+	}
 	return n
 }
 
@@ -923,6 +978,112 @@ func (m *MVCCStats) Unmarshal(data []byte) error {
 					break
 				}
 			}
+		default:
+			iNdEx = preIndex
+			skippy, err := skipMvcc(data[iNdEx:])
+			if err != nil {
+				return err
+			}
+			if skippy < 0 {
+				return ErrInvalidLengthMvcc
+			}
+			if (iNdEx + skippy) > l {
+				return io.ErrUnexpectedEOF
+			}
+			iNdEx += skippy
+		}
+	}
+
+	if iNdEx > l {
+		return io.ErrUnexpectedEOF
+	}
+	return nil
+}
+func (m *RawKeyValue) Unmarshal(data []byte) error {
+	l := len(data)
+	iNdEx := 0
+	for iNdEx < l {
+		preIndex := iNdEx
+		var wire uint64
+		for shift := uint(0); ; shift += 7 {
+			if shift >= 64 {
+				return ErrIntOverflowMvcc
+			}
+			if iNdEx >= l {
+				return io.ErrUnexpectedEOF
+			}
+			b := data[iNdEx]
+			iNdEx++
+			wire |= (uint64(b) & 0x7F) << shift
+			if b < 0x80 {
+				break
+			}
+		}
+		fieldNum := int32(wire >> 3)
+		wireType := int(wire & 0x7)
+		if wireType == 4 {
+			return fmt.Errorf("proto: RawKeyValue: wiretype end group for non-group")
+		}
+		if fieldNum <= 0 {
+			return fmt.Errorf("proto: RawKeyValue: illegal tag %d (wire type %d)", fieldNum, wire)
+		}
+		switch fieldNum {
+		case 1:
+			if wireType != 2 {
+				return fmt.Errorf("proto: wrong wireType = %d for field Key", wireType)
+			}
+			var byteLen int
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return ErrIntOverflowMvcc
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := data[iNdEx]
+				iNdEx++
+				byteLen |= (int(b) & 0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			if byteLen < 0 {
+				return ErrInvalidLengthMvcc
+			}
+			postIndex := iNdEx + byteLen
+			if postIndex > l {
+				return io.ErrUnexpectedEOF
+			}
+			m.Key = append([]byte{}, data[iNdEx:postIndex]...)
+			iNdEx = postIndex
+		case 2:
+			if wireType != 2 {
+				return fmt.Errorf("proto: wrong wireType = %d for field Value", wireType)
+			}
+			var byteLen int
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return ErrIntOverflowMvcc
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := data[iNdEx]
+				iNdEx++
+				byteLen |= (int(b) & 0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			if byteLen < 0 {
+				return ErrInvalidLengthMvcc
+			}
+			postIndex := iNdEx + byteLen
+			if postIndex > l {
+				return io.ErrUnexpectedEOF
+			}
+			m.Value = append([]byte{}, data[iNdEx:postIndex]...)
+			iNdEx = postIndex
 		default:
 			iNdEx = preIndex
 			skippy, err := skipMvcc(data[iNdEx:])

--- a/storage/engine/mvcc.proto
+++ b/storage/engine/mvcc.proto
@@ -82,3 +82,9 @@ message MVCCStats {
   optional int64 sys_count = 13 [(gogoproto.nullable) = false];
   optional int64 last_update_nanos = 30 [(gogoproto.nullable) = false];
 }
+
+// RawKeyValue contains the raw bytes of the value for a key.
+message RawKeyValue {
+  optional bytes key = 1 [(gogoproto.casttype) = "EncodedKey"];
+  optional bytes value = 2;
+}

--- a/storage/engine/mvcc_test.go
+++ b/storage/engine/mvcc_test.go
@@ -799,11 +799,11 @@ func TestMVCCGetProtoInconsistent(t *testing.T) {
 	defer stopper.Stop()
 	engine := createTestEngine(stopper)
 
-	value1, err := proto.Marshal(&roachpb.RawKeyValue{Value: []byte("value1")})
+	value1, err := proto.Marshal(&RawKeyValue{Value: []byte("value1")})
 	if err != nil {
 		t.Fatal(err)
 	}
-	value2, err := proto.Marshal(&roachpb.RawKeyValue{Value: []byte("value2")})
+	value2, err := proto.Marshal(&RawKeyValue{Value: []byte("value2")})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -820,7 +820,7 @@ func TestMVCCGetProtoInconsistent(t *testing.T) {
 	}
 
 	// A get with consistent=false should fail in a txn.
-	val := &roachpb.RawKeyValue{}
+	val := &RawKeyValue{}
 	_, err = MVCCGetProto(engine, testKey1, makeTS(1, 0), false, txn1, val)
 	if err == nil {
 		t.Error("expected an error getting with consistent=false in txn")
@@ -859,7 +859,7 @@ func TestMVCCGetProtoInconsistent(t *testing.T) {
 		t.Errorf("expected no result; got %+v", val)
 	}
 
-	// Write a malformed value (not an encoded roachpb.RawKeyValue) and a
+	// Write a malformed value (not an encoded RawKeyValue) and a
 	// write intent to key 3; the parse error is returned instead of the
 	// write intent.
 	if err := MVCCPut(engine, nil, testKey3, makeTS(1, 0), value3, nil); err != nil {
@@ -2493,7 +2493,7 @@ func TestMVCCGarbageCollect(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	expEncKeys := []roachpb.EncodedKey{
+	expEncKeys := []EncodedKey{
 		MVCCEncodeKey(roachpb.Key("a")),
 		MVCCEncodeVersionKey(roachpb.Key("a"), ts2),
 		MVCCEncodeKey(roachpb.Key("b")),

--- a/storage/engine/rocksdb.go
+++ b/storage/engine/rocksdb.go
@@ -156,7 +156,7 @@ func emptyKeyError() error {
 //
 // The key and value byte slices may be reused safely. put takes a copy of
 // them before returning.
-func (r *RocksDB) Put(key roachpb.EncodedKey, value []byte) error {
+func (r *RocksDB) Put(key EncodedKey, value []byte) error {
 	if len(key) == 0 {
 		return emptyKeyError()
 	}
@@ -175,7 +175,7 @@ func (r *RocksDB) Put(key roachpb.EncodedKey, value []byte) error {
 //
 // The key and value byte slices may be reused safely. merge takes a copy
 // of them before returning.
-func (r *RocksDB) Merge(key roachpb.EncodedKey, value []byte) error {
+func (r *RocksDB) Merge(key EncodedKey, value []byte) error {
 	if len(key) == 0 {
 		return emptyKeyError()
 	}
@@ -187,12 +187,12 @@ func (r *RocksDB) Merge(key roachpb.EncodedKey, value []byte) error {
 }
 
 // Get returns the value for the given key.
-func (r *RocksDB) Get(key roachpb.EncodedKey) ([]byte, error) {
+func (r *RocksDB) Get(key EncodedKey) ([]byte, error) {
 	return r.getInternal(key, nil)
 }
 
 // getInternal returns the value for the given key.
-func (r *RocksDB) getInternal(key roachpb.EncodedKey, snapshotHandle *C.DBSnapshot) ([]byte, error) {
+func (r *RocksDB) getInternal(key EncodedKey, snapshotHandle *C.DBSnapshot) ([]byte, error) {
 	if len(key) == 0 {
 		return nil, emptyKeyError()
 	}
@@ -205,12 +205,12 @@ func (r *RocksDB) getInternal(key roachpb.EncodedKey, snapshotHandle *C.DBSnapsh
 }
 
 // GetProto fetches the value at the specified key and unmarshals it.
-func (r *RocksDB) GetProto(key roachpb.EncodedKey, msg proto.Message) (
+func (r *RocksDB) GetProto(key EncodedKey, msg proto.Message) (
 	ok bool, keyBytes, valBytes int64, err error) {
 	return r.getProtoInternal(key, msg, nil)
 }
 
-func (r *RocksDB) getProtoInternal(key roachpb.EncodedKey, msg proto.Message,
+func (r *RocksDB) getProtoInternal(key EncodedKey, msg proto.Message,
 	snapshotHandle *C.DBSnapshot) (ok bool, keyBytes, valBytes int64, err error) {
 	if len(key) == 0 {
 		err = emptyKeyError()
@@ -239,7 +239,7 @@ func (r *RocksDB) getProtoInternal(key roachpb.EncodedKey, msg proto.Message,
 }
 
 // Clear removes the item from the db with the given key.
-func (r *RocksDB) Clear(key roachpb.EncodedKey) error {
+func (r *RocksDB) Clear(key EncodedKey) error {
 	if len(key) == 0 {
 		return emptyKeyError()
 	}
@@ -248,11 +248,11 @@ func (r *RocksDB) Clear(key roachpb.EncodedKey) error {
 
 // Iterate iterates from start to end keys, invoking f on each
 // key/value pair. See engine.Iterate for details.
-func (r *RocksDB) Iterate(start, end roachpb.EncodedKey, f func(roachpb.RawKeyValue) (bool, error)) error {
+func (r *RocksDB) Iterate(start, end EncodedKey, f func(RawKeyValue) (bool, error)) error {
 	return r.iterateInternal(start, end, f, nil)
 }
 
-func (r *RocksDB) iterateInternal(start, end roachpb.EncodedKey, f func(roachpb.RawKeyValue) (bool, error),
+func (r *RocksDB) iterateInternal(start, end EncodedKey, f func(RawKeyValue) (bool, error),
 	snapshotHandle *C.DBSnapshot) error {
 	if bytes.Compare(start, end) >= 0 {
 		return nil
@@ -266,7 +266,7 @@ func (r *RocksDB) iterateInternal(start, end roachpb.EncodedKey, f func(roachpb.
 		if !it.Key().Less(end) {
 			break
 		}
-		if done, err := f(roachpb.RawKeyValue{Key: k, Value: it.Value()}); done || err != nil {
+		if done, err := f(RawKeyValue{Key: k, Value: it.Value()}); done || err != nil {
 			return err
 		}
 	}
@@ -300,7 +300,7 @@ func (r *RocksDB) SetGCTimeouts(minTxnTS, minRCacheTS int64) {
 // Similarly, specifying nil for the end key will compact through the
 // last key. Note that the use of the word "Range" here does not refer
 // to Cockroach ranges, just to a generalized key range.
-func (r *RocksDB) CompactRange(start, end roachpb.EncodedKey) {
+func (r *RocksDB) CompactRange(start, end EncodedKey) {
 	var (
 		s, e       C.DBSlice
 		sPtr, ePtr *C.DBSlice
@@ -326,7 +326,7 @@ func (r *RocksDB) Destroy() error {
 
 // ApproximateSize returns the approximate number of bytes on disk that RocksDB
 // is using to store data for the given range of keys.
-func (r *RocksDB) ApproximateSize(start, end roachpb.EncodedKey) (uint64, error) {
+func (r *RocksDB) ApproximateSize(start, end EncodedKey) (uint64, error) {
 	return uint64(C.DBApproximateSize(r.rdb, goToCSlice(start), goToCSlice(end))), nil
 }
 
@@ -463,17 +463,17 @@ func (r *rocksDBSnapshot) Attrs() roachpb.Attributes {
 }
 
 // Put is illegal for snapshot and returns an error.
-func (r *rocksDBSnapshot) Put(key roachpb.EncodedKey, value []byte) error {
+func (r *rocksDBSnapshot) Put(key EncodedKey, value []byte) error {
 	return util.Errorf("cannot Put to a snapshot")
 }
 
 // Get returns the value for the given key, nil otherwise using
 // the snapshot handle.
-func (r *rocksDBSnapshot) Get(key roachpb.EncodedKey) ([]byte, error) {
+func (r *rocksDBSnapshot) Get(key EncodedKey) ([]byte, error) {
 	return r.parent.getInternal(key, r.handle)
 }
 
-func (r *rocksDBSnapshot) GetProto(key roachpb.EncodedKey, msg proto.Message) (
+func (r *rocksDBSnapshot) GetProto(key EncodedKey, msg proto.Message) (
 	ok bool, keyBytes, valBytes int64, err error) {
 	return r.parent.getProtoInternal(key, msg, r.handle)
 }
@@ -481,17 +481,17 @@ func (r *rocksDBSnapshot) GetProto(key roachpb.EncodedKey, msg proto.Message) (
 // Iterate iterates over the keys between start inclusive and end
 // exclusive, invoking f() on each key/value pair using the snapshot
 // handle.
-func (r *rocksDBSnapshot) Iterate(start, end roachpb.EncodedKey, f func(roachpb.RawKeyValue) (bool, error)) error {
+func (r *rocksDBSnapshot) Iterate(start, end EncodedKey, f func(RawKeyValue) (bool, error)) error {
 	return r.parent.iterateInternal(start, end, f, r.handle)
 }
 
 // Clear is illegal for snapshot and returns an error.
-func (r *rocksDBSnapshot) Clear(key roachpb.EncodedKey) error {
+func (r *rocksDBSnapshot) Clear(key EncodedKey) error {
 	return util.Errorf("cannot Clear from a snapshot")
 }
 
 // Merge is illegal for snapshot and returns an error.
-func (r *rocksDBSnapshot) Merge(key roachpb.EncodedKey, value []byte) error {
+func (r *rocksDBSnapshot) Merge(key EncodedKey, value []byte) error {
 	return util.Errorf("cannot Merge to a snapshot")
 }
 
@@ -506,7 +506,7 @@ func (r *rocksDBSnapshot) SetGCTimeouts(minTxnTS, minRCacheTS int64) {
 
 // ApproximateSize returns the approximate number of bytes the engine is
 // using to store data for the given range of keys.
-func (r *rocksDBSnapshot) ApproximateSize(start, end roachpb.EncodedKey) (uint64, error) {
+func (r *rocksDBSnapshot) ApproximateSize(start, end EncodedKey) (uint64, error) {
 	return r.parent.ApproximateSize(start, end)
 }
 
@@ -569,7 +569,7 @@ func (r *rocksDBBatch) Attrs() roachpb.Attributes {
 	return r.parent.Attrs()
 }
 
-func (r *rocksDBBatch) Put(key roachpb.EncodedKey, value []byte) error {
+func (r *rocksDBBatch) Put(key EncodedKey, value []byte) error {
 	if len(key) == 0 {
 		return emptyKeyError()
 	}
@@ -577,7 +577,7 @@ func (r *rocksDBBatch) Put(key roachpb.EncodedKey, value []byte) error {
 	return nil
 }
 
-func (r *rocksDBBatch) Merge(key roachpb.EncodedKey, value []byte) error {
+func (r *rocksDBBatch) Merge(key EncodedKey, value []byte) error {
 	if len(key) == 0 {
 		return emptyKeyError()
 	}
@@ -585,7 +585,7 @@ func (r *rocksDBBatch) Merge(key roachpb.EncodedKey, value []byte) error {
 	return nil
 }
 
-func (r *rocksDBBatch) Get(key roachpb.EncodedKey) ([]byte, error) {
+func (r *rocksDBBatch) Get(key EncodedKey) ([]byte, error) {
 	if len(key) == 0 {
 		return nil, emptyKeyError()
 	}
@@ -597,7 +597,7 @@ func (r *rocksDBBatch) Get(key roachpb.EncodedKey) ([]byte, error) {
 	return cStringToGoBytes(result), nil
 }
 
-func (r *rocksDBBatch) GetProto(key roachpb.EncodedKey, msg proto.Message) (
+func (r *rocksDBBatch) GetProto(key EncodedKey, msg proto.Message) (
 	ok bool, keyBytes, valBytes int64, err error) {
 	if len(key) == 0 {
 		err = emptyKeyError()
@@ -624,7 +624,7 @@ func (r *rocksDBBatch) GetProto(key roachpb.EncodedKey, msg proto.Message) (
 	return
 }
 
-func (r *rocksDBBatch) Iterate(start, end roachpb.EncodedKey, f func(roachpb.RawKeyValue) (bool, error)) error {
+func (r *rocksDBBatch) Iterate(start, end EncodedKey, f func(RawKeyValue) (bool, error)) error {
 	if bytes.Compare(start, end) >= 0 {
 		return nil
 	}
@@ -639,7 +639,7 @@ func (r *rocksDBBatch) Iterate(start, end roachpb.EncodedKey, f func(roachpb.Raw
 		if !it.Key().Less(end) {
 			break
 		}
-		if done, err := f(roachpb.RawKeyValue{Key: k, Value: it.Value()}); done || err != nil {
+		if done, err := f(RawKeyValue{Key: k, Value: it.Value()}); done || err != nil {
 			return err
 		}
 	}
@@ -647,7 +647,7 @@ func (r *rocksDBBatch) Iterate(start, end roachpb.EncodedKey, f func(roachpb.Raw
 	return it.Error()
 }
 
-func (r *rocksDBBatch) Clear(key roachpb.EncodedKey) error {
+func (r *rocksDBBatch) Clear(key EncodedKey) error {
 	if len(key) == 0 {
 		return emptyKeyError()
 	}
@@ -663,7 +663,7 @@ func (r *rocksDBBatch) SetGCTimeouts(minTxnTS, minRCacheTS int64) {
 	// no-op
 }
 
-func (r *rocksDBBatch) ApproximateSize(start, end roachpb.EncodedKey) (uint64, error) {
+func (r *rocksDBBatch) ApproximateSize(start, end EncodedKey) (uint64, error) {
 	return r.parent.ApproximateSize(start, end)
 }
 
@@ -763,7 +763,7 @@ func (r *rocksDBIterator) SeekReverse(key []byte) {
 		}
 		// Make sure the current key is <= the provided key.
 		curKey := r.Key()
-		if roachpb.EncodedKey(key).Less(curKey) {
+		if EncodedKey(key).Less(curKey) {
 			r.Prev()
 		}
 	}
@@ -773,7 +773,7 @@ func (r *rocksDBIterator) Prev() {
 	C.DBIterPrev(r.iter)
 }
 
-func (r *rocksDBIterator) Key() roachpb.EncodedKey {
+func (r *rocksDBIterator) Key() EncodedKey {
 	// The data returned by rocksdb_iter_{key,value} is not meant to be
 	// freed by the client. It is a direct reference to the data managed
 	// by the iterator, so it is copied instead of freed.

--- a/storage/engine/rocksdb/cockroach/storage/engine/mvcc.pb.cc
+++ b/storage/engine/rocksdb/cockroach/storage/engine/mvcc.pb.cc
@@ -31,6 +31,9 @@ const ::google::protobuf::internal::GeneratedMessageReflection*
 const ::google::protobuf::Descriptor* MVCCStats_descriptor_ = NULL;
 const ::google::protobuf::internal::GeneratedMessageReflection*
   MVCCStats_reflection_ = NULL;
+const ::google::protobuf::Descriptor* RawKeyValue_descriptor_ = NULL;
+const ::google::protobuf::internal::GeneratedMessageReflection*
+  RawKeyValue_reflection_ = NULL;
 
 }  // namespace
 
@@ -104,6 +107,22 @@ void protobuf_AssignDesc_cockroach_2fstorage_2fengine_2fmvcc_2eproto() {
       sizeof(MVCCStats),
       GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(MVCCStats, _internal_metadata_),
       -1);
+  RawKeyValue_descriptor_ = file->message_type(3);
+  static const int RawKeyValue_offsets_[2] = {
+    GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(RawKeyValue, key_),
+    GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(RawKeyValue, value_),
+  };
+  RawKeyValue_reflection_ =
+    ::google::protobuf::internal::GeneratedMessageReflection::NewGeneratedMessageReflection(
+      RawKeyValue_descriptor_,
+      RawKeyValue::default_instance_,
+      RawKeyValue_offsets_,
+      GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(RawKeyValue, _has_bits_[0]),
+      -1,
+      -1,
+      sizeof(RawKeyValue),
+      GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(RawKeyValue, _internal_metadata_),
+      -1);
 }
 
 namespace {
@@ -122,6 +141,8 @@ void protobuf_RegisterTypes(const ::std::string&) {
       MVCCMetadata_descriptor_, &MVCCMetadata::default_instance());
   ::google::protobuf::MessageFactory::InternalRegisterGeneratedMessage(
       MVCCStats_descriptor_, &MVCCStats::default_instance());
+  ::google::protobuf::MessageFactory::InternalRegisterGeneratedMessage(
+      RawKeyValue_descriptor_, &RawKeyValue::default_instance());
 }
 
 }  // namespace
@@ -133,6 +154,8 @@ void protobuf_ShutdownFile_cockroach_2fstorage_2fengine_2fmvcc_2eproto() {
   delete MVCCMetadata_reflection_;
   delete MVCCStats::default_instance_;
   delete MVCCStats_reflection_;
+  delete RawKeyValue::default_instance_;
+  delete RawKeyValue_reflection_;
 }
 
 void protobuf_AddDesc_cockroach_2fstorage_2fengine_2fmvcc_2eproto() {
@@ -163,16 +186,20 @@ void protobuf_AddDesc_cockroach_2fstorage_2fengine_2fmvcc_2eproto() {
     "\004\310\336\037\000\022\030\n\nintent_age\030\t \001(\003B\004\310\336\037\000\022(\n\014gc_by"
     "tes_age\030\n \001(\003B\022\310\336\037\000\342\336\037\nGCBytesAge\022\027\n\tsys"
     "_bytes\030\014 \001(\003B\004\310\336\037\000\022\027\n\tsys_count\030\r \001(\003B\004\310"
-    "\336\037\000\022\037\n\021last_update_nanos\030\036 \001(\003B\004\310\336\037\000B\034Z\006"
-    "engine\310\341\036\000\220\343\036\000\310\342\036\001\340\342\036\001\320\342\036\001", 826);
+    "\336\037\000\022\037\n\021last_update_nanos\030\036 \001(\003B\004\310\336\037\000\"9\n\013"
+    "RawKeyValue\022\033\n\003key\030\001 \001(\014B\016\372\336\037\nEncodedKey"
+    "\022\r\n\005value\030\002 \001(\014B\034Z\006engine\310\341\036\000\220\343\036\000\310\342\036\001\340\342\036"
+    "\001\320\342\036\001", 885);
   ::google::protobuf::MessageFactory::InternalRegisterGeneratedFile(
     "cockroach/storage/engine/mvcc.proto", &protobuf_RegisterTypes);
   MVCCValue::default_instance_ = new MVCCValue();
   MVCCMetadata::default_instance_ = new MVCCMetadata();
   MVCCStats::default_instance_ = new MVCCStats();
+  RawKeyValue::default_instance_ = new RawKeyValue();
   MVCCValue::default_instance_->InitAsDefaultInstance();
   MVCCMetadata::default_instance_->InitAsDefaultInstance();
   MVCCStats::default_instance_->InitAsDefaultInstance();
+  RawKeyValue::default_instance_->InitAsDefaultInstance();
   ::google::protobuf::internal::OnShutdown(&protobuf_ShutdownFile_cockroach_2fstorage_2fengine_2fmvcc_2eproto);
 }
 
@@ -2222,6 +2249,401 @@ void MVCCStats::clear_last_update_nanos() {
   set_has_last_update_nanos();
   last_update_nanos_ = value;
   // @@protoc_insertion_point(field_set:cockroach.storage.engine.MVCCStats.last_update_nanos)
+}
+
+#endif  // PROTOBUF_INLINE_NOT_IN_HEADERS
+
+// ===================================================================
+
+#ifndef _MSC_VER
+const int RawKeyValue::kKeyFieldNumber;
+const int RawKeyValue::kValueFieldNumber;
+#endif  // !_MSC_VER
+
+RawKeyValue::RawKeyValue()
+  : ::google::protobuf::Message(), _internal_metadata_(NULL) {
+  SharedCtor();
+  // @@protoc_insertion_point(constructor:cockroach.storage.engine.RawKeyValue)
+}
+
+void RawKeyValue::InitAsDefaultInstance() {
+}
+
+RawKeyValue::RawKeyValue(const RawKeyValue& from)
+  : ::google::protobuf::Message(),
+    _internal_metadata_(NULL) {
+  SharedCtor();
+  MergeFrom(from);
+  // @@protoc_insertion_point(copy_constructor:cockroach.storage.engine.RawKeyValue)
+}
+
+void RawKeyValue::SharedCtor() {
+  ::google::protobuf::internal::GetEmptyString();
+  _cached_size_ = 0;
+  key_.UnsafeSetDefault(&::google::protobuf::internal::GetEmptyStringAlreadyInited());
+  value_.UnsafeSetDefault(&::google::protobuf::internal::GetEmptyStringAlreadyInited());
+  ::memset(_has_bits_, 0, sizeof(_has_bits_));
+}
+
+RawKeyValue::~RawKeyValue() {
+  // @@protoc_insertion_point(destructor:cockroach.storage.engine.RawKeyValue)
+  SharedDtor();
+}
+
+void RawKeyValue::SharedDtor() {
+  key_.DestroyNoArena(&::google::protobuf::internal::GetEmptyStringAlreadyInited());
+  value_.DestroyNoArena(&::google::protobuf::internal::GetEmptyStringAlreadyInited());
+  if (this != default_instance_) {
+  }
+}
+
+void RawKeyValue::SetCachedSize(int size) const {
+  GOOGLE_SAFE_CONCURRENT_WRITES_BEGIN();
+  _cached_size_ = size;
+  GOOGLE_SAFE_CONCURRENT_WRITES_END();
+}
+const ::google::protobuf::Descriptor* RawKeyValue::descriptor() {
+  protobuf_AssignDescriptorsOnce();
+  return RawKeyValue_descriptor_;
+}
+
+const RawKeyValue& RawKeyValue::default_instance() {
+  if (default_instance_ == NULL) protobuf_AddDesc_cockroach_2fstorage_2fengine_2fmvcc_2eproto();
+  return *default_instance_;
+}
+
+RawKeyValue* RawKeyValue::default_instance_ = NULL;
+
+RawKeyValue* RawKeyValue::New(::google::protobuf::Arena* arena) const {
+  RawKeyValue* n = new RawKeyValue;
+  if (arena != NULL) {
+    arena->Own(n);
+  }
+  return n;
+}
+
+void RawKeyValue::Clear() {
+  if (_has_bits_[0 / 32] & 3u) {
+    if (has_key()) {
+      key_.ClearToEmptyNoArena(&::google::protobuf::internal::GetEmptyStringAlreadyInited());
+    }
+    if (has_value()) {
+      value_.ClearToEmptyNoArena(&::google::protobuf::internal::GetEmptyStringAlreadyInited());
+    }
+  }
+  ::memset(_has_bits_, 0, sizeof(_has_bits_));
+  if (_internal_metadata_.have_unknown_fields()) {
+    mutable_unknown_fields()->Clear();
+  }
+}
+
+bool RawKeyValue::MergePartialFromCodedStream(
+    ::google::protobuf::io::CodedInputStream* input) {
+#define DO_(EXPRESSION) if (!(EXPRESSION)) goto failure
+  ::google::protobuf::uint32 tag;
+  // @@protoc_insertion_point(parse_start:cockroach.storage.engine.RawKeyValue)
+  for (;;) {
+    ::std::pair< ::google::protobuf::uint32, bool> p = input->ReadTagWithCutoff(127);
+    tag = p.first;
+    if (!p.second) goto handle_unusual;
+    switch (::google::protobuf::internal::WireFormatLite::GetTagFieldNumber(tag)) {
+      // optional bytes key = 1;
+      case 1: {
+        if (tag == 10) {
+          DO_(::google::protobuf::internal::WireFormatLite::ReadBytes(
+                input, this->mutable_key()));
+        } else {
+          goto handle_unusual;
+        }
+        if (input->ExpectTag(18)) goto parse_value;
+        break;
+      }
+
+      // optional bytes value = 2;
+      case 2: {
+        if (tag == 18) {
+         parse_value:
+          DO_(::google::protobuf::internal::WireFormatLite::ReadBytes(
+                input, this->mutable_value()));
+        } else {
+          goto handle_unusual;
+        }
+        if (input->ExpectAtEnd()) goto success;
+        break;
+      }
+
+      default: {
+      handle_unusual:
+        if (tag == 0 ||
+            ::google::protobuf::internal::WireFormatLite::GetTagWireType(tag) ==
+            ::google::protobuf::internal::WireFormatLite::WIRETYPE_END_GROUP) {
+          goto success;
+        }
+        DO_(::google::protobuf::internal::WireFormat::SkipField(
+              input, tag, mutable_unknown_fields()));
+        break;
+      }
+    }
+  }
+success:
+  // @@protoc_insertion_point(parse_success:cockroach.storage.engine.RawKeyValue)
+  return true;
+failure:
+  // @@protoc_insertion_point(parse_failure:cockroach.storage.engine.RawKeyValue)
+  return false;
+#undef DO_
+}
+
+void RawKeyValue::SerializeWithCachedSizes(
+    ::google::protobuf::io::CodedOutputStream* output) const {
+  // @@protoc_insertion_point(serialize_start:cockroach.storage.engine.RawKeyValue)
+  // optional bytes key = 1;
+  if (has_key()) {
+    ::google::protobuf::internal::WireFormatLite::WriteBytesMaybeAliased(
+      1, this->key(), output);
+  }
+
+  // optional bytes value = 2;
+  if (has_value()) {
+    ::google::protobuf::internal::WireFormatLite::WriteBytesMaybeAliased(
+      2, this->value(), output);
+  }
+
+  if (_internal_metadata_.have_unknown_fields()) {
+    ::google::protobuf::internal::WireFormat::SerializeUnknownFields(
+        unknown_fields(), output);
+  }
+  // @@protoc_insertion_point(serialize_end:cockroach.storage.engine.RawKeyValue)
+}
+
+::google::protobuf::uint8* RawKeyValue::SerializeWithCachedSizesToArray(
+    ::google::protobuf::uint8* target) const {
+  // @@protoc_insertion_point(serialize_to_array_start:cockroach.storage.engine.RawKeyValue)
+  // optional bytes key = 1;
+  if (has_key()) {
+    target =
+      ::google::protobuf::internal::WireFormatLite::WriteBytesToArray(
+        1, this->key(), target);
+  }
+
+  // optional bytes value = 2;
+  if (has_value()) {
+    target =
+      ::google::protobuf::internal::WireFormatLite::WriteBytesToArray(
+        2, this->value(), target);
+  }
+
+  if (_internal_metadata_.have_unknown_fields()) {
+    target = ::google::protobuf::internal::WireFormat::SerializeUnknownFieldsToArray(
+        unknown_fields(), target);
+  }
+  // @@protoc_insertion_point(serialize_to_array_end:cockroach.storage.engine.RawKeyValue)
+  return target;
+}
+
+int RawKeyValue::ByteSize() const {
+  int total_size = 0;
+
+  if (_has_bits_[0 / 32] & 3) {
+    // optional bytes key = 1;
+    if (has_key()) {
+      total_size += 1 +
+        ::google::protobuf::internal::WireFormatLite::BytesSize(
+          this->key());
+    }
+
+    // optional bytes value = 2;
+    if (has_value()) {
+      total_size += 1 +
+        ::google::protobuf::internal::WireFormatLite::BytesSize(
+          this->value());
+    }
+
+  }
+  if (_internal_metadata_.have_unknown_fields()) {
+    total_size +=
+      ::google::protobuf::internal::WireFormat::ComputeUnknownFieldsSize(
+        unknown_fields());
+  }
+  GOOGLE_SAFE_CONCURRENT_WRITES_BEGIN();
+  _cached_size_ = total_size;
+  GOOGLE_SAFE_CONCURRENT_WRITES_END();
+  return total_size;
+}
+
+void RawKeyValue::MergeFrom(const ::google::protobuf::Message& from) {
+  if (GOOGLE_PREDICT_FALSE(&from == this)) MergeFromFail(__LINE__);
+  const RawKeyValue* source = 
+      ::google::protobuf::internal::DynamicCastToGenerated<const RawKeyValue>(
+          &from);
+  if (source == NULL) {
+    ::google::protobuf::internal::ReflectionOps::Merge(from, this);
+  } else {
+    MergeFrom(*source);
+  }
+}
+
+void RawKeyValue::MergeFrom(const RawKeyValue& from) {
+  if (GOOGLE_PREDICT_FALSE(&from == this)) MergeFromFail(__LINE__);
+  if (from._has_bits_[0 / 32] & (0xffu << (0 % 32))) {
+    if (from.has_key()) {
+      set_has_key();
+      key_.AssignWithDefault(&::google::protobuf::internal::GetEmptyStringAlreadyInited(), from.key_);
+    }
+    if (from.has_value()) {
+      set_has_value();
+      value_.AssignWithDefault(&::google::protobuf::internal::GetEmptyStringAlreadyInited(), from.value_);
+    }
+  }
+  if (from._internal_metadata_.have_unknown_fields()) {
+    mutable_unknown_fields()->MergeFrom(from.unknown_fields());
+  }
+}
+
+void RawKeyValue::CopyFrom(const ::google::protobuf::Message& from) {
+  if (&from == this) return;
+  Clear();
+  MergeFrom(from);
+}
+
+void RawKeyValue::CopyFrom(const RawKeyValue& from) {
+  if (&from == this) return;
+  Clear();
+  MergeFrom(from);
+}
+
+bool RawKeyValue::IsInitialized() const {
+
+  return true;
+}
+
+void RawKeyValue::Swap(RawKeyValue* other) {
+  if (other == this) return;
+  InternalSwap(other);
+}
+void RawKeyValue::InternalSwap(RawKeyValue* other) {
+  key_.Swap(&other->key_);
+  value_.Swap(&other->value_);
+  std::swap(_has_bits_[0], other->_has_bits_[0]);
+  _internal_metadata_.Swap(&other->_internal_metadata_);
+  std::swap(_cached_size_, other->_cached_size_);
+}
+
+::google::protobuf::Metadata RawKeyValue::GetMetadata() const {
+  protobuf_AssignDescriptorsOnce();
+  ::google::protobuf::Metadata metadata;
+  metadata.descriptor = RawKeyValue_descriptor_;
+  metadata.reflection = RawKeyValue_reflection_;
+  return metadata;
+}
+
+#if PROTOBUF_INLINE_NOT_IN_HEADERS
+// RawKeyValue
+
+// optional bytes key = 1;
+bool RawKeyValue::has_key() const {
+  return (_has_bits_[0] & 0x00000001u) != 0;
+}
+void RawKeyValue::set_has_key() {
+  _has_bits_[0] |= 0x00000001u;
+}
+void RawKeyValue::clear_has_key() {
+  _has_bits_[0] &= ~0x00000001u;
+}
+void RawKeyValue::clear_key() {
+  key_.ClearToEmptyNoArena(&::google::protobuf::internal::GetEmptyStringAlreadyInited());
+  clear_has_key();
+}
+ const ::std::string& RawKeyValue::key() const {
+  // @@protoc_insertion_point(field_get:cockroach.storage.engine.RawKeyValue.key)
+  return key_.GetNoArena(&::google::protobuf::internal::GetEmptyStringAlreadyInited());
+}
+ void RawKeyValue::set_key(const ::std::string& value) {
+  set_has_key();
+  key_.SetNoArena(&::google::protobuf::internal::GetEmptyStringAlreadyInited(), value);
+  // @@protoc_insertion_point(field_set:cockroach.storage.engine.RawKeyValue.key)
+}
+ void RawKeyValue::set_key(const char* value) {
+  set_has_key();
+  key_.SetNoArena(&::google::protobuf::internal::GetEmptyStringAlreadyInited(), ::std::string(value));
+  // @@protoc_insertion_point(field_set_char:cockroach.storage.engine.RawKeyValue.key)
+}
+ void RawKeyValue::set_key(const void* value, size_t size) {
+  set_has_key();
+  key_.SetNoArena(&::google::protobuf::internal::GetEmptyStringAlreadyInited(),
+      ::std::string(reinterpret_cast<const char*>(value), size));
+  // @@protoc_insertion_point(field_set_pointer:cockroach.storage.engine.RawKeyValue.key)
+}
+ ::std::string* RawKeyValue::mutable_key() {
+  set_has_key();
+  // @@protoc_insertion_point(field_mutable:cockroach.storage.engine.RawKeyValue.key)
+  return key_.MutableNoArena(&::google::protobuf::internal::GetEmptyStringAlreadyInited());
+}
+ ::std::string* RawKeyValue::release_key() {
+  clear_has_key();
+  return key_.ReleaseNoArena(&::google::protobuf::internal::GetEmptyStringAlreadyInited());
+}
+ void RawKeyValue::set_allocated_key(::std::string* key) {
+  if (key != NULL) {
+    set_has_key();
+  } else {
+    clear_has_key();
+  }
+  key_.SetAllocatedNoArena(&::google::protobuf::internal::GetEmptyStringAlreadyInited(), key);
+  // @@protoc_insertion_point(field_set_allocated:cockroach.storage.engine.RawKeyValue.key)
+}
+
+// optional bytes value = 2;
+bool RawKeyValue::has_value() const {
+  return (_has_bits_[0] & 0x00000002u) != 0;
+}
+void RawKeyValue::set_has_value() {
+  _has_bits_[0] |= 0x00000002u;
+}
+void RawKeyValue::clear_has_value() {
+  _has_bits_[0] &= ~0x00000002u;
+}
+void RawKeyValue::clear_value() {
+  value_.ClearToEmptyNoArena(&::google::protobuf::internal::GetEmptyStringAlreadyInited());
+  clear_has_value();
+}
+ const ::std::string& RawKeyValue::value() const {
+  // @@protoc_insertion_point(field_get:cockroach.storage.engine.RawKeyValue.value)
+  return value_.GetNoArena(&::google::protobuf::internal::GetEmptyStringAlreadyInited());
+}
+ void RawKeyValue::set_value(const ::std::string& value) {
+  set_has_value();
+  value_.SetNoArena(&::google::protobuf::internal::GetEmptyStringAlreadyInited(), value);
+  // @@protoc_insertion_point(field_set:cockroach.storage.engine.RawKeyValue.value)
+}
+ void RawKeyValue::set_value(const char* value) {
+  set_has_value();
+  value_.SetNoArena(&::google::protobuf::internal::GetEmptyStringAlreadyInited(), ::std::string(value));
+  // @@protoc_insertion_point(field_set_char:cockroach.storage.engine.RawKeyValue.value)
+}
+ void RawKeyValue::set_value(const void* value, size_t size) {
+  set_has_value();
+  value_.SetNoArena(&::google::protobuf::internal::GetEmptyStringAlreadyInited(),
+      ::std::string(reinterpret_cast<const char*>(value), size));
+  // @@protoc_insertion_point(field_set_pointer:cockroach.storage.engine.RawKeyValue.value)
+}
+ ::std::string* RawKeyValue::mutable_value() {
+  set_has_value();
+  // @@protoc_insertion_point(field_mutable:cockroach.storage.engine.RawKeyValue.value)
+  return value_.MutableNoArena(&::google::protobuf::internal::GetEmptyStringAlreadyInited());
+}
+ ::std::string* RawKeyValue::release_value() {
+  clear_has_value();
+  return value_.ReleaseNoArena(&::google::protobuf::internal::GetEmptyStringAlreadyInited());
+}
+ void RawKeyValue::set_allocated_value(::std::string* value) {
+  if (value != NULL) {
+    set_has_value();
+  } else {
+    clear_has_value();
+  }
+  value_.SetAllocatedNoArena(&::google::protobuf::internal::GetEmptyStringAlreadyInited(), value);
+  // @@protoc_insertion_point(field_set_allocated:cockroach.storage.engine.RawKeyValue.value)
 }
 
 #endif  // PROTOBUF_INLINE_NOT_IN_HEADERS

--- a/storage/engine/rocksdb/cockroach/storage/engine/mvcc.pb.h
+++ b/storage/engine/rocksdb/cockroach/storage/engine/mvcc.pb.h
@@ -43,6 +43,7 @@ void protobuf_ShutdownFile_cockroach_2fstorage_2fengine_2fmvcc_2eproto();
 class MVCCValue;
 class MVCCMetadata;
 class MVCCStats;
+class RawKeyValue;
 
 // ===================================================================
 
@@ -498,6 +499,115 @@ class MVCCStats : public ::google::protobuf::Message {
 
   void InitAsDefaultInstance();
   static MVCCStats* default_instance_;
+};
+// -------------------------------------------------------------------
+
+class RawKeyValue : public ::google::protobuf::Message {
+ public:
+  RawKeyValue();
+  virtual ~RawKeyValue();
+
+  RawKeyValue(const RawKeyValue& from);
+
+  inline RawKeyValue& operator=(const RawKeyValue& from) {
+    CopyFrom(from);
+    return *this;
+  }
+
+  inline const ::google::protobuf::UnknownFieldSet& unknown_fields() const {
+    return _internal_metadata_.unknown_fields();
+  }
+
+  inline ::google::protobuf::UnknownFieldSet* mutable_unknown_fields() {
+    return _internal_metadata_.mutable_unknown_fields();
+  }
+
+  static const ::google::protobuf::Descriptor* descriptor();
+  static const RawKeyValue& default_instance();
+
+  void Swap(RawKeyValue* other);
+
+  // implements Message ----------------------------------------------
+
+  inline RawKeyValue* New() const { return New(NULL); }
+
+  RawKeyValue* New(::google::protobuf::Arena* arena) const;
+  void CopyFrom(const ::google::protobuf::Message& from);
+  void MergeFrom(const ::google::protobuf::Message& from);
+  void CopyFrom(const RawKeyValue& from);
+  void MergeFrom(const RawKeyValue& from);
+  void Clear();
+  bool IsInitialized() const;
+
+  int ByteSize() const;
+  bool MergePartialFromCodedStream(
+      ::google::protobuf::io::CodedInputStream* input);
+  void SerializeWithCachedSizes(
+      ::google::protobuf::io::CodedOutputStream* output) const;
+  ::google::protobuf::uint8* SerializeWithCachedSizesToArray(::google::protobuf::uint8* output) const;
+  int GetCachedSize() const { return _cached_size_; }
+  private:
+  void SharedCtor();
+  void SharedDtor();
+  void SetCachedSize(int size) const;
+  void InternalSwap(RawKeyValue* other);
+  private:
+  inline ::google::protobuf::Arena* GetArenaNoVirtual() const {
+    return _internal_metadata_.arena();
+  }
+  inline void* MaybeArenaPtr() const {
+    return _internal_metadata_.raw_arena_ptr();
+  }
+  public:
+
+  ::google::protobuf::Metadata GetMetadata() const;
+
+  // nested types ----------------------------------------------------
+
+  // accessors -------------------------------------------------------
+
+  // optional bytes key = 1;
+  bool has_key() const;
+  void clear_key();
+  static const int kKeyFieldNumber = 1;
+  const ::std::string& key() const;
+  void set_key(const ::std::string& value);
+  void set_key(const char* value);
+  void set_key(const void* value, size_t size);
+  ::std::string* mutable_key();
+  ::std::string* release_key();
+  void set_allocated_key(::std::string* key);
+
+  // optional bytes value = 2;
+  bool has_value() const;
+  void clear_value();
+  static const int kValueFieldNumber = 2;
+  const ::std::string& value() const;
+  void set_value(const ::std::string& value);
+  void set_value(const char* value);
+  void set_value(const void* value, size_t size);
+  ::std::string* mutable_value();
+  ::std::string* release_value();
+  void set_allocated_value(::std::string* value);
+
+  // @@protoc_insertion_point(class_scope:cockroach.storage.engine.RawKeyValue)
+ private:
+  inline void set_has_key();
+  inline void clear_has_key();
+  inline void set_has_value();
+  inline void clear_has_value();
+
+  ::google::protobuf::internal::InternalMetadataWithArena _internal_metadata_;
+  ::google::protobuf::uint32 _has_bits_[1];
+  mutable int _cached_size_;
+  ::google::protobuf::internal::ArenaStringPtr key_;
+  ::google::protobuf::internal::ArenaStringPtr value_;
+  friend void  protobuf_AddDesc_cockroach_2fstorage_2fengine_2fmvcc_2eproto();
+  friend void protobuf_AssignDesc_cockroach_2fstorage_2fengine_2fmvcc_2eproto();
+  friend void protobuf_ShutdownFile_cockroach_2fstorage_2fengine_2fmvcc_2eproto();
+
+  void InitAsDefaultInstance();
+  static RawKeyValue* default_instance_;
 };
 // ===================================================================
 
@@ -1095,7 +1205,119 @@ inline void MVCCStats::set_last_update_nanos(::google::protobuf::int64 value) {
   // @@protoc_insertion_point(field_set:cockroach.storage.engine.MVCCStats.last_update_nanos)
 }
 
+// -------------------------------------------------------------------
+
+// RawKeyValue
+
+// optional bytes key = 1;
+inline bool RawKeyValue::has_key() const {
+  return (_has_bits_[0] & 0x00000001u) != 0;
+}
+inline void RawKeyValue::set_has_key() {
+  _has_bits_[0] |= 0x00000001u;
+}
+inline void RawKeyValue::clear_has_key() {
+  _has_bits_[0] &= ~0x00000001u;
+}
+inline void RawKeyValue::clear_key() {
+  key_.ClearToEmptyNoArena(&::google::protobuf::internal::GetEmptyStringAlreadyInited());
+  clear_has_key();
+}
+inline const ::std::string& RawKeyValue::key() const {
+  // @@protoc_insertion_point(field_get:cockroach.storage.engine.RawKeyValue.key)
+  return key_.GetNoArena(&::google::protobuf::internal::GetEmptyStringAlreadyInited());
+}
+inline void RawKeyValue::set_key(const ::std::string& value) {
+  set_has_key();
+  key_.SetNoArena(&::google::protobuf::internal::GetEmptyStringAlreadyInited(), value);
+  // @@protoc_insertion_point(field_set:cockroach.storage.engine.RawKeyValue.key)
+}
+inline void RawKeyValue::set_key(const char* value) {
+  set_has_key();
+  key_.SetNoArena(&::google::protobuf::internal::GetEmptyStringAlreadyInited(), ::std::string(value));
+  // @@protoc_insertion_point(field_set_char:cockroach.storage.engine.RawKeyValue.key)
+}
+inline void RawKeyValue::set_key(const void* value, size_t size) {
+  set_has_key();
+  key_.SetNoArena(&::google::protobuf::internal::GetEmptyStringAlreadyInited(),
+      ::std::string(reinterpret_cast<const char*>(value), size));
+  // @@protoc_insertion_point(field_set_pointer:cockroach.storage.engine.RawKeyValue.key)
+}
+inline ::std::string* RawKeyValue::mutable_key() {
+  set_has_key();
+  // @@protoc_insertion_point(field_mutable:cockroach.storage.engine.RawKeyValue.key)
+  return key_.MutableNoArena(&::google::protobuf::internal::GetEmptyStringAlreadyInited());
+}
+inline ::std::string* RawKeyValue::release_key() {
+  clear_has_key();
+  return key_.ReleaseNoArena(&::google::protobuf::internal::GetEmptyStringAlreadyInited());
+}
+inline void RawKeyValue::set_allocated_key(::std::string* key) {
+  if (key != NULL) {
+    set_has_key();
+  } else {
+    clear_has_key();
+  }
+  key_.SetAllocatedNoArena(&::google::protobuf::internal::GetEmptyStringAlreadyInited(), key);
+  // @@protoc_insertion_point(field_set_allocated:cockroach.storage.engine.RawKeyValue.key)
+}
+
+// optional bytes value = 2;
+inline bool RawKeyValue::has_value() const {
+  return (_has_bits_[0] & 0x00000002u) != 0;
+}
+inline void RawKeyValue::set_has_value() {
+  _has_bits_[0] |= 0x00000002u;
+}
+inline void RawKeyValue::clear_has_value() {
+  _has_bits_[0] &= ~0x00000002u;
+}
+inline void RawKeyValue::clear_value() {
+  value_.ClearToEmptyNoArena(&::google::protobuf::internal::GetEmptyStringAlreadyInited());
+  clear_has_value();
+}
+inline const ::std::string& RawKeyValue::value() const {
+  // @@protoc_insertion_point(field_get:cockroach.storage.engine.RawKeyValue.value)
+  return value_.GetNoArena(&::google::protobuf::internal::GetEmptyStringAlreadyInited());
+}
+inline void RawKeyValue::set_value(const ::std::string& value) {
+  set_has_value();
+  value_.SetNoArena(&::google::protobuf::internal::GetEmptyStringAlreadyInited(), value);
+  // @@protoc_insertion_point(field_set:cockroach.storage.engine.RawKeyValue.value)
+}
+inline void RawKeyValue::set_value(const char* value) {
+  set_has_value();
+  value_.SetNoArena(&::google::protobuf::internal::GetEmptyStringAlreadyInited(), ::std::string(value));
+  // @@protoc_insertion_point(field_set_char:cockroach.storage.engine.RawKeyValue.value)
+}
+inline void RawKeyValue::set_value(const void* value, size_t size) {
+  set_has_value();
+  value_.SetNoArena(&::google::protobuf::internal::GetEmptyStringAlreadyInited(),
+      ::std::string(reinterpret_cast<const char*>(value), size));
+  // @@protoc_insertion_point(field_set_pointer:cockroach.storage.engine.RawKeyValue.value)
+}
+inline ::std::string* RawKeyValue::mutable_value() {
+  set_has_value();
+  // @@protoc_insertion_point(field_mutable:cockroach.storage.engine.RawKeyValue.value)
+  return value_.MutableNoArena(&::google::protobuf::internal::GetEmptyStringAlreadyInited());
+}
+inline ::std::string* RawKeyValue::release_value() {
+  clear_has_value();
+  return value_.ReleaseNoArena(&::google::protobuf::internal::GetEmptyStringAlreadyInited());
+}
+inline void RawKeyValue::set_allocated_value(::std::string* value) {
+  if (value != NULL) {
+    set_has_value();
+  } else {
+    clear_has_value();
+  }
+  value_.SetAllocatedNoArena(&::google::protobuf::internal::GetEmptyStringAlreadyInited(), value);
+  // @@protoc_insertion_point(field_set_allocated:cockroach.storage.engine.RawKeyValue.value)
+}
+
 #endif  // !PROTOBUF_INLINE_NOT_IN_HEADERS
+// -------------------------------------------------------------------
+
 // -------------------------------------------------------------------
 
 // -------------------------------------------------------------------

--- a/storage/gc_queue.go
+++ b/storage/gc_queue.go
@@ -148,7 +148,7 @@ func (gcq *gcQueue) process(now roachpb.Timestamp, repl *Replica,
 	var mu sync.Mutex
 	var oldestIntentNanos int64 = math.MaxInt64
 	var expBaseKey roachpb.Key
-	var keys []roachpb.EncodedKey
+	var keys []engine.EncodedKey
 	var vals [][]byte
 
 	// Maps from txn ID to txn and intent key slice.
@@ -213,7 +213,7 @@ func (gcq *gcQueue) process(now roachpb.Timestamp, repl *Replica,
 			// Moving to the next key (& values).
 			processKeysAndValues()
 			expBaseKey = baseKey
-			keys = []roachpb.EncodedKey{iter.Key()}
+			keys = []engine.EncodedKey{iter.Key()}
 			vals = [][]byte{iter.Value()}
 		} else {
 			if !baseKey.Equal(expBaseKey) {

--- a/storage/gc_queue_test.go
+++ b/storage/gc_queue_test.go
@@ -362,7 +362,7 @@ func TestGCQueueIntentResolution(t *testing.T) {
 
 	// Iterate through all values to ensure intents have been fully resolved.
 	meta := &engine.MVCCMetadata{}
-	err := tc.store.Engine().Iterate(engine.MVCCEncodeKey(roachpb.KeyMin), engine.MVCCEncodeKey(roachpb.KeyMax), func(kv roachpb.RawKeyValue) (bool, error) {
+	err := tc.store.Engine().Iterate(engine.MVCCEncodeKey(roachpb.KeyMin), engine.MVCCEncodeKey(roachpb.KeyMax), func(kv engine.RawKeyValue) (bool, error) {
 		if key, _, isValue, err := engine.MVCCDecodeKey(kv.Key); err != nil {
 			return false, err
 		} else if !isValue {

--- a/storage/replica_command.go
+++ b/storage/replica_command.go
@@ -1016,7 +1016,7 @@ func (r *Replica) TruncateLog(batch engine.Engine, ms *engine.MVCCStats, h roach
 	rangeID := r.Desc().RangeID
 	start := keys.RaftLogKey(rangeID, 0)
 	end := keys.RaftLogKey(rangeID, args.Index)
-	if err = batch.Iterate(engine.MVCCEncodeKey(start), engine.MVCCEncodeKey(end), func(kv roachpb.RawKeyValue) (bool, error) {
+	if err = batch.Iterate(engine.MVCCEncodeKey(start), engine.MVCCEncodeKey(end), func(kv engine.RawKeyValue) (bool, error) {
 		return false, batch.Clear(kv.Key)
 	}); err != nil {
 		return reply, err

--- a/storage/replica_data_iter.go
+++ b/storage/replica_data_iter.go
@@ -26,7 +26,7 @@ import (
 
 // keyRange is a helper struct for the rangeDataIterator.
 type keyRange struct {
-	start, end roachpb.EncodedKey
+	start, end engine.EncodedKey
 }
 
 // replicaDataIterator provides a complete iteration over all key / value
@@ -97,7 +97,7 @@ func (ri *replicaDataIterator) Next() {
 }
 
 // Key returns the current Key for the iteration if valid.
-func (ri *replicaDataIterator) Key() roachpb.EncodedKey {
+func (ri *replicaDataIterator) Key() engine.EncodedKey {
 	return ri.iter.Key()
 }
 

--- a/storage/replica_data_iter_test.go
+++ b/storage/replica_data_iter_test.go
@@ -57,7 +57,7 @@ func fakePrevKey(k []byte) roachpb.Key {
 // createRangeData creates sample range data in all possible areas of
 // the key space. Returns a slice of the encoded keys of all created
 // data.
-func createRangeData(r *Replica, t *testing.T) []roachpb.EncodedKey {
+func createRangeData(r *Replica, t *testing.T) []engine.EncodedKey {
 	ts0 := roachpb.ZeroTimestamp
 	ts := roachpb.Timestamp{WallTime: 1}
 	keyTSs := []struct {
@@ -86,7 +86,7 @@ func createRangeData(r *Replica, t *testing.T) []roachpb.EncodedKey {
 		{fakePrevKey(r.Desc().EndKey), ts},
 	}
 
-	keys := []roachpb.EncodedKey{}
+	keys := []engine.EncodedKey{}
 	for _, keyTS := range keyTSs {
 		if err := engine.MVCCPut(r.store.Engine(), nil, keyTS.key, keyTS.ts, roachpb.MakeValueFromString("value"), nil); err != nil {
 			t.Fatal(err)
@@ -202,7 +202,7 @@ func TestReplicaDataIterator(t *testing.T) {
 	// Verify the keys in pre & post ranges.
 	for _, test := range []struct {
 		r    *Replica
-		keys []roachpb.EncodedKey
+		keys []engine.EncodedKey
 	}{
 		{preRng, preKeys},
 		{postRng, postKeys},

--- a/storage/response_cache.go
+++ b/storage/response_cache.go
@@ -105,7 +105,7 @@ func (rc *ResponseCache) CopyInto(e engine.Engine, destRangeID roachpb.RangeID) 
 	start := engine.MVCCEncodeKey(prefix)
 	end := engine.MVCCEncodeKey(prefix.PrefixEnd())
 
-	return e.Iterate(start, end, func(kv roachpb.RawKeyValue) (bool, error) {
+	return e.Iterate(start, end, func(kv engine.RawKeyValue) (bool, error) {
 		// Decode the key into a cmd, skipping on error. Otherwise,
 		// write it to the corresponding key in the new cache.
 		cmdID, err := rc.decodeResponseCacheKey(kv.Key)
@@ -138,7 +138,7 @@ func (rc *ResponseCache) CopyFrom(e engine.Engine, originRangeID roachpb.RangeID
 	start := engine.MVCCEncodeKey(prefix)
 	end := engine.MVCCEncodeKey(prefix.PrefixEnd())
 
-	return e.Iterate(start, end, func(kv roachpb.RawKeyValue) (bool, error) {
+	return e.Iterate(start, end, func(kv engine.RawKeyValue) (bool, error) {
 		// Decode the key into a cmd, skipping on error. Otherwise,
 		// write it to the corresponding key in the new cache.
 		cmdID, err := rc.decodeResponseCacheKey(kv.Key)
@@ -199,7 +199,7 @@ func (rc *ResponseCache) shouldCacheResponse(replyWithErr roachpb.ResponseWithEr
 	return true
 }
 
-func (rc *ResponseCache) decodeResponseCacheKey(encKey roachpb.EncodedKey) (roachpb.ClientCmdID, error) {
+func (rc *ResponseCache) decodeResponseCacheKey(encKey engine.EncodedKey) (roachpb.ClientCmdID, error) {
 	ret := roachpb.ClientCmdID{}
 	key, _, isValue, err := engine.MVCCDecodeKey(encKey)
 	if err != nil {

--- a/storage/store.go
+++ b/storage/store.go
@@ -703,7 +703,7 @@ func (s *Store) Bootstrap(ident roachpb.StoreIdent, stopper *stop.Stopper) error
 		return err
 	}
 	s.Ident = ident
-	kvs, err := engine.Scan(s.engine, roachpb.EncodedKey(roachpb.RKeyMin), roachpb.EncodedKey(roachpb.RKeyMax), 1)
+	kvs, err := engine.Scan(s.engine, engine.EncodedKey(roachpb.RKeyMin), engine.EncodedKey(roachpb.RKeyMax), 1)
 	if err != nil {
 		return util.Errorf("store %s: unable to access: %s", s.engine, err)
 	} else if len(kvs) > 0 {

--- a/storage/store_test.go
+++ b/storage/store_test.go
@@ -223,7 +223,7 @@ func TestBootstrapOfNonEmptyStore(t *testing.T) {
 	eng := engine.NewInMem(roachpb.Attributes{}, 1<<20, stopper)
 
 	// Put some random garbage into the engine.
-	if err := eng.Put(roachpb.EncodedKey("foo"), []byte("bar")); err != nil {
+	if err := eng.Put(engine.EncodedKey("foo"), []byte("bar")); err != nil {
 		t.Errorf("failure putting key foo into engine: %s", err)
 	}
 	ctx := TestStoreContext

--- a/util/keys/bytes.go
+++ b/util/keys/bytes.go
@@ -17,7 +17,7 @@
 
 package keys 
 
-// Returns the next possible byte by appending an \x00.
+// BytesNext returns the next possible byte by appending an \x00.
 func BytesNext(b []byte) []byte {
 	// TODO(spencer): Do we need to enforce KeyMaxLength here?
 	return append(append([]byte(nil), b...), 0)

--- a/util/keys/bytes.go
+++ b/util/keys/bytes.go
@@ -1,0 +1,24 @@
+// Copyright 2014 The Cockroach Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+// implied. See the License for the specific language governing
+// permissions and limitations under the License. See the AUTHORS file
+// for names of contributors.
+//
+// Author: Spencer Kimball (spencer.kimball@gmail.com)
+
+package keys 
+
+// Returns the next possible byte by appending an \x00.
+func BytesNext(b []byte) []byte {
+	// TODO(spencer): Do we need to enforce KeyMaxLength here?
+	return append(append([]byte(nil), b...), 0)
+}

--- a/util/keys/bytes.go
+++ b/util/keys/bytes.go
@@ -15,7 +15,7 @@
 //
 // Author: Spencer Kimball (spencer.kimball@gmail.com)
 
-package keys 
+package keys
 
 // BytesNext returns the next possible byte by appending an \x00.
 func BytesNext(b []byte) []byte {


### PR DESCRIPTION
I copied EncodedKey and RawKeyValue to storage/engine leaving original types from roachpb in place. Tests pass. Please let me know if there are better destination files for my changes or whenever I missed something. I'll be happy to fix that.

Also, the issue mentions a clarification for those types. Any suggestions on what can help to get an idea about that? Since I'm very new to the project, I'm not confident on how to proceed with this.

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/2979)

<!-- Reviewable:end -->
