### PR TITLE
Fix a bug with local key handling in truncate()

### DIFF
--- a/keys/keys.go
+++ b/keys/keys.go
@@ -344,7 +344,7 @@ func MakeTablePrefix(tableID uint32) []byte {
 // Range returns a key range encompassing all the keys in the Batch.
 // TODO(tschottdorf): there is no protection for doubly-local keys here;
 // maybe Range should return an error.
-func Range(ba roachpb.BatchRequest) (roachpb.RKey, roachpb.RKey) {
+func Range(ba roachpb.BatchRequest) roachpb.RSpan {
 	from := roachpb.RKeyMax
 	to := roachpb.RKeyMin
 	for _, arg := range ba.Requests {
@@ -367,5 +367,5 @@ func Range(ba roachpb.BatchRequest) (roachpb.RKey, roachpb.RKey) {
 			to = endKey
 		}
 	}
-	return from, to
+	return roachpb.RSpan{Key: from, EndKey: to}
 }

--- a/keys/keys_test.go
+++ b/keys/keys_test.go
@@ -349,8 +349,8 @@ func TestBatchRange(t *testing.T) {
 		for _, pair := range c.req {
 			ba.Add(&roachpb.ScanRequest{Span: roachpb.Span{Key: roachpb.Key(pair[0]), EndKey: roachpb.Key(pair[1])}})
 		}
-		from, to := Range(ba)
-		if actPair := [2]string{string(from), string(to)}; !reflect.DeepEqual(actPair, c.exp) {
+		rs := Range(ba)
+		if actPair := [2]string{string(rs.Key), string(rs.EndKey)}; !reflect.DeepEqual(actPair, c.exp) {
 			t.Fatalf("%d: expected [%q,%q), got [%q,%q)", i, c.exp[0], c.exp[1], actPair[0], actPair[1])
 		}
 	}

--- a/kv/batch.go
+++ b/kv/batch.go
@@ -30,20 +30,15 @@ import (
 // truncate restricts all contained requests to the given key range.
 // Even on error, the returned closure must be executed; it undoes any
 // truncations performed.
-// First, the boundaries of the truncation are obtained: This is the
-// intersection between the given span and the descriptor's range.
-// Secondly, all requests contained in the batch are "truncated" to
-// the resulting range, inserting NoopRequest appropriately to
-// replace requests which are left without a key range to operate on.
-// The number of non-noop requests after truncation is returned along
-// with a closure which must be executed to undo the truncation, even
-// in case of an error.
+// All requests contained in the batch are "truncated" to the given
+// span, inserting NoopRequest appropriately to replace requests which
+// are left without a key range to operate on. The number of non-noop
+// requests after truncation is returned along with a closure which
+// must be executed to undo the truncation, even in case of an error.
 // TODO(tschottdorf): Consider returning a new BatchRequest, which has more
 // overhead in the common case of a batch which never needs truncation but is
 // less magical.
-func truncate(br *roachpb.BatchRequest, desc *roachpb.RangeDescriptor, rs rSpan) (func(), int, error) {
-	rs = rs.Intersect(desc)
-
+func truncate(br *roachpb.BatchRequest, rs roachpb.RSpan) (func(), int, error) {
 	truncateOne := func(args roachpb.Request) (bool, []func(), error) {
 		if _, ok := args.(*roachpb.NoopRequest); ok {
 			return true, nil, nil
@@ -54,7 +49,7 @@ func truncate(br *roachpb.BatchRequest, desc *roachpb.RangeDescriptor, rs rSpan)
 			if len(header.EndKey) > 0 {
 				return false, nil, util.Errorf("%T is not a range command, but EndKey is set", args)
 			}
-			if !desc.ContainsKey(keys.Addr(header.Key)) {
+			if !rs.ContainsKey(keys.Addr(header.Key)) {
 				return true, nil, nil
 			}
 			return false, nil, nil
@@ -63,12 +58,13 @@ func truncate(br *roachpb.BatchRequest, desc *roachpb.RangeDescriptor, rs rSpan)
 		var undo []func()
 		keyAddr, endKeyAddr := keys.Addr(header.Key), keys.Addr(header.EndKey)
 		if l, r := !keyAddr.Equal(header.Key), !endKeyAddr.Equal(header.EndKey); l || r {
-			if !desc.ContainsKeyRange(keyAddr, endKeyAddr) {
+			if !rs.ContainsKeyRange(keyAddr, endKeyAddr) {
 				return false, nil, util.Errorf("local key range must not span ranges")
 			}
 			if !l || !r {
 				return false, nil, util.Errorf("local key mixed with global key in range")
 			}
+			return false, nil, nil
 		}
 		// Below, {end,}keyAddr equals header.{End,}Key, so nothing is local.
 		if keyAddr.Less(rs.Key) {

--- a/kv/dist_sender.go
+++ b/kv/dist_sender.go
@@ -536,7 +536,7 @@ func (ds *DistSender) sendChunk(ctx context.Context, ba roachpb.BatchRequest) (*
 
 			curReply, pErr = func() (*roachpb.BatchResponse, *roachpb.Error) {
 				// Truncate the request to our current key range.
-				untruncate, numActive, trErr := truncate(&ba, rs, desc)
+				untruncate, numActive, trErr := truncate(&ba, rs.Intersect(desc))
 				if numActive == 0 && trErr == nil {
 					untruncate()
 					// This shouldn't happen in the wild, but some tests

--- a/kv/dist_sender.go
+++ b/kv/dist_sender.go
@@ -28,6 +28,7 @@ import (
 
 	"github.com/cockroachdb/cockroach/client"
 	"github.com/cockroachdb/cockroach/gossip"
+	"github.com/cockroachdb/cockroach/keys"
 	"github.com/cockroachdb/cockroach/roachpb"
 	"github.com/cockroachdb/cockroach/rpc"
 	"github.com/cockroachdb/cockroach/util"
@@ -385,14 +386,14 @@ func (ds *DistSender) sendRPC(trace *tracer.Trace, rangeID roachpb.RangeID, repl
 // Note that `from` and `to` are not necessarily Key and EndKey from a
 // RequestHeader; it's assumed that they've been translated to key addresses
 // already (via KeyAddress).
-func (ds *DistSender) getDescriptors(rs rSpan, options lookupOptions) (*roachpb.RangeDescriptor, bool, func(), *roachpb.Error) {
+func (ds *DistSender) getDescriptors(rs roachpb.RSpan, options lookupOptions) (*roachpb.RangeDescriptor, bool, func(), *roachpb.Error) {
 	var desc *roachpb.RangeDescriptor
 	var err error
 	var descKey roachpb.RKey
 	if !options.useReverseScan {
-		descKey = rs.key
+		descKey = rs.Key
 	} else {
-		descKey = rs.endKey
+		descKey = rs.EndKey
 	}
 	desc, err = ds.rangeCache.LookupRangeDescriptor(descKey, options)
 
@@ -403,9 +404,9 @@ func (ds *DistSender) getDescriptors(rs rSpan, options lookupOptions) (*roachpb.
 	// Checks whether need to get next range descriptor. If so, returns true.
 	needAnother := func(desc *roachpb.RangeDescriptor, isReverse bool) bool {
 		if isReverse {
-			return rs.key.Less(desc.StartKey)
+			return rs.Key.Less(desc.StartKey)
 		}
-		return desc.EndKey.Less(rs.endKey)
+		return desc.EndKey.Less(rs.EndKey)
 	}
 
 	evict := func() {
@@ -481,7 +482,7 @@ func (ds *DistSender) sendChunk(ctx context.Context, ba roachpb.BatchRequest) (*
 	// Local addressing has already been resolved.
 	// TODO(tschottdorf): consider rudimentary validation of the batch here
 	// (for example, non-range requests with EndKey, or empty key ranges).
-	rs := newRSpan(ba)
+	rs := keys.Range(ba)
 	var br *roachpb.BatchResponse
 	// Send the request to one range per iteration.
 	for {
@@ -528,20 +529,20 @@ func (ds *DistSender) sendChunk(ctx context.Context, ba roachpb.BatchRequest) (*
 			// descriptor. Example revscan [a,g), first desc lookup for "g"
 			// returns descriptor [c,d) -> [d,g) is never scanned.
 			// We evict and retry in such a case.
-			if (isReverse && !desc.ContainsKeyRange(desc.StartKey, rs.endKey)) || (!isReverse && !desc.ContainsKeyRange(rs.key, desc.EndKey)) {
+			if (isReverse && !desc.ContainsKeyRange(desc.StartKey, rs.EndKey)) || (!isReverse && !desc.ContainsKeyRange(rs.Key, desc.EndKey)) {
 				evictDesc()
 				continue
 			}
 
 			curReply, pErr = func() (*roachpb.BatchResponse, *roachpb.Error) {
 				// Truncate the request to our current key range.
-				untruncate, numActive, trErr := truncate(&ba, desc, rs)
+				untruncate, numActive, trErr := truncate(&ba, rs, desc)
 				if numActive == 0 && trErr == nil {
 					untruncate()
 					// This shouldn't happen in the wild, but some tests
 					// exercise it.
 					return nil, roachpb.NewError(util.Errorf("truncation resulted in empty batch on [%s,%s): %s",
-						rs.key, rs.endKey, ba))
+						rs.Key, rs.EndKey, ba))
 				}
 				defer untruncate()
 				if trErr != nil {
@@ -721,7 +722,7 @@ func (ds *DistSender) sendChunk(ctx context.Context, ba roachpb.BatchRequest) (*
 			// We use the StartKey of the current descriptor as opposed to the
 			// EndKey of the previous one since that doesn't have bugs when
 			// stale descriptors come into play.
-			rs.endKey = prev(ba, desc.StartKey)
+			rs.EndKey = prev(ba, desc.StartKey)
 		} else {
 			// In next iteration, query next range.
 			// It's important that we use the EndKey of the current descriptor
@@ -730,7 +731,7 @@ func (ds *DistSender) sendChunk(ctx context.Context, ba roachpb.BatchRequest) (*
 			// one, and unless both descriptors are stale, the next descriptor's
 			// StartKey would move us to the beginning of the current range,
 			// resulting in a duplicate scan.
-			rs.key = next(ba, desc.EndKey)
+			rs.Key = next(ba, desc.EndKey)
 		}
 		trace.Event("querying next range")
 	}

--- a/kv/dist_sender_test.go
+++ b/kv/dist_sender_test.go
@@ -27,6 +27,8 @@ import (
 	"testing"
 	"time"
 
+	"golang.org/x/net/context"
+
 	"github.com/cockroachdb/cockroach/client"
 	"github.com/cockroachdb/cockroach/gossip"
 	"github.com/cockroachdb/cockroach/gossip/simulation"
@@ -346,8 +348,11 @@ func TestSendRPCOrder(t *testing.T) {
 type mockRangeDescriptorDB func(roachpb.RKey, lookupOptions) ([]roachpb.RangeDescriptor, error)
 
 func (mdb mockRangeDescriptorDB) rangeLookup(key roachpb.RKey, options lookupOptions, _ *roachpb.RangeDescriptor) ([]roachpb.RangeDescriptor, error) {
-	if bytes.HasPrefix(key, keys.Meta1Prefix) {
+	if bytes.HasPrefix(key, keys.Meta2Prefix) {
 		return mdb(key[len(keys.Meta1Prefix):], options)
+	}
+	if bytes.HasPrefix(key, keys.Meta1Prefix) {
+		return mdb(keys.MakeKey(keys.Meta2Prefix, key[len(keys.Meta1Prefix):]), options)
 	}
 	// First range.
 	return mdb(nil, options)
@@ -418,6 +423,7 @@ func TestRetryOnDescriptorLookupError(t *testing.T) {
 	errors := []error{
 		errors.New("fatal boom"),
 		&roachpb.RangeKeyMismatchError{}, // retryable
+		nil,
 		nil,
 	}
 
@@ -795,6 +801,113 @@ func TestRangeLookupOptionOnReverseScan(t *testing.T) {
 		Span: roachpb.Span{Key: roachpb.Key("a"), EndKey: roachpb.Key("b")},
 	}
 	if _, err := client.SendWrapped(ds, nil, rScan); err != nil {
+		t.Fatal(err)
+	}
+}
+
+// TestTruncateWithSpanAndDescriptor verifies that a batch request is truncated with a
+// range span and the range of a descriptor found in cache.
+func TestTruncateWithSpanAndDescriptor(t *testing.T) {
+	defer leaktest.AfterTest(t)
+	g, s := makeTestGossip(t)
+	defer s()
+
+	if err := g.SetNodeDescriptor(&roachpb.NodeDescriptor{NodeID: 1}); err != nil {
+		t.Fatal(err)
+	}
+	nd := &roachpb.NodeDescriptor{
+		NodeID:  roachpb.NodeID(1),
+		Address: util.MakeUnresolvedAddr(testAddress.Network(), testAddress.String()),
+	}
+	if err := g.AddInfoProto(gossip.MakeNodeIDKey(roachpb.NodeID(1)), nd, time.Hour); err != nil {
+		t.Fatal(err)
+	}
+
+	// Fill mockRangeDescriptorDB with two descriptors. When a
+	// range descriptor is looked up by key "b", return the second
+	// descriptor whose range is ["a", "c") and partially overlaps
+	// with the first descriptor's range.
+	var descriptor1 = roachpb.RangeDescriptor{
+		RangeID:  1,
+		StartKey: roachpb.RKeyMin,
+		EndKey:   roachpb.RKey("b"),
+		Replicas: []roachpb.ReplicaDescriptor{
+			{
+				NodeID:  1,
+				StoreID: 1,
+			},
+		},
+	}
+	var descriptor2 = roachpb.RangeDescriptor{
+		RangeID:  2,
+		StartKey: roachpb.RKey("a"),
+		EndKey:   roachpb.RKey("c"),
+		Replicas: []roachpb.ReplicaDescriptor{
+			{
+				NodeID:  1,
+				StoreID: 1,
+			},
+		},
+	}
+	descDB := mockRangeDescriptorDB(func(key roachpb.RKey, _ lookupOptions) ([]roachpb.RangeDescriptor, error) {
+		desc := descriptor1
+		if key.Equal(roachpb.RKey("b")) {
+			desc = descriptor2
+		}
+		return []roachpb.RangeDescriptor{desc}, nil
+	})
+
+	// Define our rpcSend stub which checks the span of the batch
+	// requests. The first request should be the point request on
+	// "a". The second request should be on "b".
+	first := true
+	var testFn rpcSendFn = func(_ rpc.Options, method string, addrs []net.Addr, getArgs func(addr net.Addr) proto.Message, getReply func() proto.Message, _ *rpc.Context) ([]proto.Message, error) {
+		if method != "Node.Batch" {
+			return nil, util.Errorf("unexpected method %v", method)
+		}
+
+		ba := getArgs(testAddress).(*roachpb.BatchRequest)
+		rs := keys.Range(*ba)
+		if first {
+			if !(rs.Key.Equal(roachpb.RKey("a")) && rs.EndKey.Equal(roachpb.RKey("a").Next())) {
+				t.Errorf("Unexpected span [%s,%s)", rs.Key, rs.EndKey)
+			}
+			first = false
+		} else {
+			if !(rs.Key.Equal(roachpb.RKey("b")) && rs.EndKey.Equal(roachpb.RKey("b").Next())) {
+				t.Errorf("Unexpected span [%s,%s)", rs.Key, rs.EndKey)
+			}
+		}
+
+		batchReply := getReply().(*roachpb.BatchResponse)
+		reply := &roachpb.PutResponse{}
+		batchReply.Add(reply)
+		return []proto.Message{batchReply}, nil
+	}
+
+	ctx := &DistSenderContext{
+		RPCSend:           testFn,
+		RangeDescriptorDB: descDB,
+	}
+	ds := NewDistSender(ctx, g)
+
+	// Send a batch request contains two puts. In the first
+	// attempt, the range of the descriptor found in the cache is
+	// ["a", "b"). The request is truncated to contain only the put
+	// on "a".
+	//
+	// In the second attempt, The range of the descriptor found in
+	// the cache is ["a", c"), but the put on "a" will not be
+	// resent. The request is truncated to contain only the put on "b".
+	ba := roachpb.BatchRequest{}
+	ba.CmdID = ba.GetOrCreateCmdID(0)
+	ba.Txn = &roachpb.Transaction{Name: "test"}
+	val := roachpb.MakeValueFromString("val")
+	ba.Add(roachpb.NewPut(keys.RangeTreeNodeKey(roachpb.RKey("a")), val).(*roachpb.PutRequest))
+	ba.Add(roachpb.NewPut(keys.RangeTreeNodeKey(roachpb.RKey("b")), val).(*roachpb.PutRequest))
+
+	_, pErr := ds.Send(context.Background(), ba)
+	if err := pErr.GoError(); err != nil {
 		t.Fatal(err)
 	}
 }

--- a/kv/local_sender.go
+++ b/kv/local_sender.go
@@ -121,8 +121,8 @@ func (ls *LocalSender) Send(ctx context.Context, ba roachpb.BatchRequest) (*roac
 	if ba.RangeID == 0 || ba.Replica.StoreID == 0 {
 		var repl *roachpb.ReplicaDescriptor
 		var rangeID roachpb.RangeID
-		key, endKey := keys.Range(ba)
-		rangeID, repl, err = ls.lookupReplica(key, endKey)
+		rs := keys.Range(ba)
+		rangeID, repl, err = ls.lookupReplica(rs.Key, rs.EndKey)
 		if err == nil {
 			ba.RangeID = rangeID
 			ba.Replica = *repl

--- a/kv/truncate_test.go
+++ b/kv/truncate_test.go
@@ -112,8 +112,8 @@ func TestTruncate(t *testing.T) {
 		if len(desc.EndKey) == 0 {
 			desc.EndKey = roachpb.RKey(test.to)
 		}
-		rs := rSpan{key: roachpb.RKey(test.from), endKey: roachpb.RKey(test.to)}
-		undo, num, err := truncate(ba, desc, rs)
+		rs := roachpb.RSpan{Key: roachpb.RKey(test.from), EndKey: roachpb.RKey(test.to)}
+		undo, num, err := truncate(ba, rs, desc)
 		if err != nil || test.err != "" {
 			if test.err == "" || !testutils.IsError(err, test.err) {
 				t.Errorf("%d: %v (expected: %s)", i, err, test.err)

--- a/kv/truncate_test.go
+++ b/kv/truncate_test.go
@@ -113,7 +113,8 @@ func TestTruncate(t *testing.T) {
 			desc.EndKey = roachpb.RKey(test.to)
 		}
 		rs := roachpb.RSpan{Key: roachpb.RKey(test.from), EndKey: roachpb.RKey(test.to)}
-		undo, num, err := truncate(ba, rs, desc)
+		rs = rs.Intersect(desc)
+		undo, num, err := truncate(ba, rs)
 		if err != nil || test.err != "" {
 			if test.err == "" || !testutils.IsError(err, test.err) {
 				t.Errorf("%d: %v (expected: %s)", i, err, test.err)

--- a/roachpb/data_test.go
+++ b/roachpb/data_test.go
@@ -461,3 +461,43 @@ func TestIsPrev(t *testing.T) {
 		}
 	}
 }
+
+// TestRSpanContains verifies methods to check whether a key
+// or key range is contained within the span.
+func TestRSpanContains(t *testing.T) {
+	rs := RSpan{Key: []byte("a"), EndKey: []byte("b")}
+
+	testData := []struct {
+		start, end []byte
+		contains   bool
+	}{
+		// Single keys.
+		{[]byte("a"), []byte("a"), true},
+		{[]byte("a"), nil, true},
+		{[]byte("aa"), []byte("aa"), true},
+		{[]byte("`"), []byte("`"), false},
+		{[]byte("b"), []byte("b"), false},
+		{[]byte("b"), nil, false},
+		{[]byte("c"), []byte("c"), false},
+		// Key ranges.
+		{[]byte("a"), []byte("b"), true},
+		{[]byte("a"), []byte("aa"), true},
+		{[]byte("aa"), []byte("b"), true},
+		{[]byte("0"), []byte("9"), false},
+		{[]byte("`"), []byte("a"), false},
+		{[]byte("b"), []byte("bb"), false},
+		{[]byte("0"), []byte("bb"), false},
+		{[]byte("aa"), []byte("bb"), false},
+		{[]byte("b"), []byte("a"), false},
+	}
+	for i, test := range testData {
+		if bytes.Compare(test.start, test.end) == 0 {
+			if rs.ContainsKey(test.start) != test.contains {
+				t.Errorf("%d: expected key %q within range", i, test.start)
+			}
+		}
+		if rs.ContainsKeyRange(test.start, test.end) != test.contains {
+			t.Errorf("%d: expected key %q within range", i, test.start)
+		}
+	}
+}

--- a/roachpb/metadata.go
+++ b/roachpb/metadata.go
@@ -19,7 +19,6 @@
 package roachpb
 
 import (
-	"bytes"
 	"sort"
 	"strconv"
 	"strings"
@@ -107,24 +106,18 @@ func (a Attributes) SortedString() string {
 }
 
 // ContainsKey returns whether this RangeDescriptor contains the specified key.
-// TODO(tschottdorf): RKey.
 func (r *RangeDescriptor) ContainsKey(key []byte) bool {
-	return bytes.Compare(key, r.StartKey) >= 0 && bytes.Compare(key, r.EndKey) < 0
+	rs := RSpan{Key: r.StartKey, EndKey: r.EndKey}
+	return rs.ContainsKey(key)
 }
 
 // ContainsKeyRange returns whether this RangeDescriptor contains the specified
 // key range from start (inclusive) to end (exclusive).
 // If end is empty, returns ContainsKey(start).
+// TODO(tschottdorf): RKey.
 func (r *RangeDescriptor) ContainsKeyRange(start, end []byte) bool {
-	if len(end) == 0 {
-		return r.ContainsKey(start)
-	}
-	if comp := bytes.Compare(end, start); comp < 0 {
-		return false
-	} else if comp == 0 {
-		return r.ContainsKey(start)
-	}
-	return bytes.Compare(start, r.StartKey) >= 0 && bytes.Compare(r.EndKey, end) >= 0
+	rs := RSpan{Key: r.StartKey, EndKey: r.EndKey}
+	return rs.ContainsKeyRange(start, end)
 }
 
 // FindReplica returns the replica which matches the specified store

--- a/roachpb/metadata_test.go
+++ b/roachpb/metadata_test.go
@@ -18,7 +18,6 @@
 package roachpb
 
 import (
-	"bytes"
 	"testing"
 )
 
@@ -82,47 +81,5 @@ func TestRangeDescriptorMissingReplica(t *testing.T) {
 	i, r := desc.FindReplica(0)
 	if i >= 0 || r != nil {
 		t.Fatalf("unexpected return (%d, %s) on missing replica", i, r)
-	}
-}
-
-// TestRangeDescriptorContains verifies methods to check whether a key
-// or key range is contained within the range.
-func TestRangeDescriptorContains(t *testing.T) {
-	desc := RangeDescriptor{}
-	desc.StartKey = []byte("a")
-	desc.EndKey = []byte("b")
-
-	testData := []struct {
-		start, end []byte
-		contains   bool
-	}{
-		// Single keys.
-		{[]byte("a"), []byte("a"), true},
-		{[]byte("a"), nil, true},
-		{[]byte("aa"), []byte("aa"), true},
-		{[]byte("`"), []byte("`"), false},
-		{[]byte("b"), []byte("b"), false},
-		{[]byte("b"), nil, false},
-		{[]byte("c"), []byte("c"), false},
-		// Key ranges.
-		{[]byte("a"), []byte("b"), true},
-		{[]byte("a"), []byte("aa"), true},
-		{[]byte("aa"), []byte("b"), true},
-		{[]byte("0"), []byte("9"), false},
-		{[]byte("`"), []byte("a"), false},
-		{[]byte("b"), []byte("bb"), false},
-		{[]byte("0"), []byte("bb"), false},
-		{[]byte("aa"), []byte("bb"), false},
-		{[]byte("b"), []byte("a"), false},
-	}
-	for i, test := range testData {
-		if bytes.Compare(test.start, test.end) == 0 {
-			if desc.ContainsKey(test.start) != test.contains {
-				t.Errorf("%d: expected key %q within range", i, test.start)
-			}
-		}
-		if desc.ContainsKeyRange(test.start, test.end) != test.contains {
-			t.Errorf("%d: expected key %q within range", i, test.start)
-		}
 	}
 }

--- a/storage/store_test.go
+++ b/storage/store_test.go
@@ -101,10 +101,10 @@ func (db *testSender) Send(ctx context.Context, ba roachpb.BatchRequest) (*roach
 		return nil, roachpb.NewError(util.Errorf("%s method not supported", et.Method()))
 	}
 	// Lookup range and direct request.
-	key, endKey := keys.Range(ba)
-	rng := db.store.LookupReplica(key, endKey)
+	rs := keys.Range(ba)
+	rng := db.store.LookupReplica(rs.Key, rs.EndKey)
 	if rng == nil {
-		return nil, roachpb.NewError(roachpb.NewRangeKeyMismatchError(key.AsRawKey(), endKey.AsRawKey(), nil))
+		return nil, roachpb.NewError(roachpb.NewRangeKeyMismatchError(rs.Key.AsRawKey(), rs.EndKey.AsRawKey(), nil))
 	}
 	ba.RangeID = rng.Desc().RangeID
 	replica := rng.GetReplica()


### PR DESCRIPTION
(This is ready for review now. The first commit is refactoring necessary for the second commit, which actually fixes the bug.)

First commit:
- Rename rSpan to roachpb.RSpan and define Contains{Key,KeyRange}. ContainsKey and ContainsKeyRange will be called from truncate(). rSpan is moved to the roachpb package to share the code with RangeDescriptor.Contains{Key,KeyRange}.

Second commit:
- Fix a bug with local key handling in truncate(). The code used to truncate a local key to a non-local key when the key is outside of [from, to), but within the descriptor's range. This commit fixes the bug by passing the intersection of a span and a descriptor range to truncate().

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/2981)

<!-- Reviewable:end -->
