### PR TITLE
Fix missing mithril.js in UI

### DIFF
--- a/ui/Makefile
+++ b/ui/Makefile
@@ -52,8 +52,6 @@ GOBINDATA_DEBUG_DEPS    := $(TYPESCRIPT_TARGET) $(CSS_DEBUG_TARGET)
 GOBINDATA_SOURCES       := $(BOWER_COMPONENTS)/d3/d3.min.js \
                            $(BOWER_COMPONENTS)/lodash/lodash.min.js \
                            $(BOWER_COMPONENTS)/mithriljs/mithril.js \
-                           $(BOWER_COMPONENTS)/mithriljs/mithril.min.js \
-                           $(BOWER_COMPONENTS)/mithriljs/mithril.min.js.map \
                            $(BOWER_COMPONENTS)/nvd3/build/nv.d3.min.css \
                            $(BOWER_COMPONENTS)/nvd3/build/nv.d3.min.js \
                            $(GOBINDATA_FONTS)

--- a/ui/release/index.html
+++ b/ui/release/index.html
@@ -25,7 +25,7 @@ Author: Bram Gruneir (bram+code@cockroachlabs.com)
     <link rel="stylesheet" href="/build/app.css">
     <script src="/bower_components/d3/d3.min.js"></script>
     <script src="/bower_components/lodash/lodash.min.js"></script>
-    <script src="/bower_components/mithril/mithril.min.js"></script>
+    <script src="/bower_components/mithriljs/mithril.js"></script>
     <script src="/bower_components/nvd3/build/nv.d3.min.js"></script>
     <title>Cockroach</title>
   </head>


### PR DESCRIPTION
Two fixes:
- mithril.js was not being included at all in the release build of the UI, due
  to a bad link in index.html
- mithril.min.js taken from bower appears to be broken; for now, we will use the
  regular mithril.js instead.

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/2987)

<!-- Reviewable:end -->
