### PR TITLE
Add RPC support to sql/driver.

### DIFF
--- a/multiraft/transport.go
+++ b/multiraft/transport.go
@@ -145,7 +145,7 @@ func (lt *localRPCTransport) getClient(id roachpb.StoreID) (*netrpc.Client, erro
 	address := server.Addr().String()
 
 	// If this wasn't test code we wouldn't want to call Dial while holding the lock.
-	conn, err := crpc.TLSDialHTTP("tcp", address, nil)
+	conn, err := codec.TLSDialHTTP("tcp", address, base.NetworkTimeout, nil)
 	if err != nil {
 		return nil, err
 	}

--- a/rpc/client.go
+++ b/rpc/client.go
@@ -28,6 +28,7 @@ import (
 	"time"
 	"unsafe"
 
+	"github.com/cockroachdb/cockroach/base"
 	"github.com/cockroachdb/cockroach/rpc/codec"
 	"github.com/cockroachdb/cockroach/util"
 	"github.com/cockroachdb/cockroach/util/hlc"
@@ -161,7 +162,8 @@ func (c *Client) internalConn() *internalConn {
 
 // connect attempts a single connection attempt. On success, updates `c.conn`.
 func (c *Client) connect() error {
-	conn, err := TLSDialHTTP(c.addr.NetworkField, c.addr.AddressField, c.tlsConfig)
+	conn, err := codec.TLSDialHTTP(
+		c.addr.NetworkField, c.addr.AddressField, base.NetworkTimeout, c.tlsConfig)
 	if err != nil {
 		return err
 	}

--- a/rpc/codec/tls.go
+++ b/rpc/codec/tls.go
@@ -1,0 +1,67 @@
+// Copyright 2015 The Cockroach Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+// implied. See the License for the specific language governing
+// permissions and limitations under the License. See the AUTHORS file
+// for names of contributors.
+//
+// Author: Peter Mattis (peter@cockroachlabs.com)
+
+package codec
+
+import (
+	"bufio"
+	"crypto/tls"
+	"io"
+	"net"
+	"net/http"
+	"net/rpc"
+	"time"
+
+	"github.com/cockroachdb/cockroach/util"
+)
+
+// Connected status response message for HTTP CONNECT to rpcPath.
+const Connected = "200 Connected to Go RPC"
+
+// tlsDial wraps either net.Dial or crypto/tls.Dial, depending on the contents of
+// the passed TLS Config.
+func tlsDial(network, address string, timeout time.Duration, config *tls.Config) (net.Conn, error) {
+	defaultDialer := net.Dialer{Timeout: timeout}
+	if config == nil {
+		return defaultDialer.Dial(network, address)
+	}
+	return tls.DialWithDialer(&defaultDialer, network, address, config)
+}
+
+// TLSDialHTTP connects to an HTTP RPC server at the specified address.
+func TLSDialHTTP(network, address string, timeout time.Duration, config *tls.Config) (net.Conn, error) {
+	conn, err := tlsDial(network, address, timeout, config)
+	if err != nil {
+		return conn, err
+	}
+
+	// Note: this code was adapted from net/rpc.DialHTTPPath.
+	if _, err := io.WriteString(conn, "CONNECT "+rpc.DefaultRPCPath+" HTTP/1.0\n\n"); err != nil {
+		return conn, err
+	}
+
+	// Require successful HTTP response before switching to RPC protocol.
+	resp, err := http.ReadResponse(bufio.NewReader(conn), &http.Request{Method: "CONNECT"})
+	if err == nil {
+		if resp.Status == Connected {
+			return conn, nil
+		}
+		err = util.Errorf("unexpected HTTP response: %s", resp.Status)
+	}
+	conn.Close()
+	return nil, err
+}

--- a/rpc/server.go
+++ b/rpc/server.go
@@ -150,9 +150,6 @@ func (s *Server) AddCloseCallback(cb func(conn net.Conn)) {
 	s.closeCallbacks = append(s.closeCallbacks, cb)
 }
 
-// Can connect to RPC service using HTTP CONNECT to rpcPath.
-var connected = "200 Connected to Go RPC"
-
 // ServeHTTP implements an http.Handler that answers RPC requests.
 func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	if r.URL.Path != rpc.DefaultRPCPath {
@@ -185,7 +182,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	if log.V(3) {
 		security.LogTLSState("RPC", r.TLS)
 	}
-	if _, err := io.WriteString(conn, "HTTP/1.0 "+connected+"\n\n"); err != nil {
+	if _, err := io.WriteString(conn, "HTTP/1.0 "+codec.Connected+"\n\n"); err != nil {
 		http.Error(w, err.Error(), http.StatusUnauthorized)
 		return
 	}

--- a/server/server.go
+++ b/server/server.go
@@ -68,7 +68,7 @@ type Server struct {
 	storePool     *storage.StorePool
 	db            *client.DB
 	kvDB          *kv.DBServer
-	sqlServer     sql.HTTPServer
+	sqlServer     sql.Server
 	node          *Node
 	recorder      *status.NodeStatusRecorder
 	admin         *adminServer
@@ -138,7 +138,10 @@ func NewServer(ctx *Context, stopper *stop.Stopper) (*Server, error) {
 		return nil, err
 	}
 
-	s.sqlServer = sql.MakeHTTPServer(&s.ctx.Context, *s.db, s.gossip, s.clock)
+	s.sqlServer = sql.MakeServer(&s.ctx.Context, *s.db, s.gossip, s.clock)
+	if err := s.sqlServer.RegisterRPC(s.rpc); err != nil {
+		return nil, err
+	}
 
 	// TODO(bdarnell): make StoreConfig configurable.
 	nCtx := storage.StoreContext{

--- a/sql/driver/link_test.go
+++ b/sql/driver/link_test.go
@@ -31,7 +31,9 @@ func TestNoLinkForbidden(t *testing.T) {
 		t.Skip("GOPATH isn't set")
 	}
 
-	imports, err := testutils.TransitiveImports("github.com/cockroachdb/cockroach/sql/driver", false)
+	// TODO(pmattis): Pass false instead of true for the cgo parameter once
+	// rpc/codec can be compiled without the c-lz4 and c-snappy dependencies.
+	imports, err := testutils.TransitiveImports("github.com/cockroachdb/cockroach/sql/driver", true)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/sql/driver/rpc_sender.go
+++ b/sql/driver/rpc_sender.go
@@ -1,0 +1,102 @@
+// Copyright 2015 The Cockroach Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+// implied. See the License for the specific language governing
+// permissions and limitations under the License. See the AUTHORS file
+// for names of contributors.
+//
+// Author: Peter Mattis (peter@cockroachlabs.com)
+
+package driver
+
+import (
+	"crypto/tls"
+	"net"
+	"net/rpc"
+	"net/url"
+
+	"github.com/cockroachdb/cockroach/base"
+	"github.com/cockroachdb/cockroach/rpc/codec"
+	"github.com/cockroachdb/cockroach/util/retry"
+)
+
+func init() {
+	f := func(u *url.URL, ctx *base.Context, retryOpts retry.Options) (Sender, error) {
+		ctx.Insecure = (u.Scheme != "rpcs")
+		return newRPCSender(u.Host, ctx, retryOpts)
+	}
+	RegisterSender("rpc", f)
+	RegisterSender("rpcs", f)
+}
+
+// RPCMethod is the name of the RPC method for SQL requests.
+const RPCMethod = "Server.SQL"
+
+// rpcSender is an implementation of Sender which exposes the SQL database
+// provided by a Cockroach cluster by connecting via RPC to a Cockroach node.
+type rpcSender struct {
+	user      string
+	client    *rpc.Client
+	tlsConfig *tls.Config
+	retryOpts retry.Options
+}
+
+// newRPCSender returns a new instance of rpcSender.
+func newRPCSender(server string, context *base.Context, retryOpts retry.Options) (*rpcSender, error) {
+	addr, err := net.ResolveTCPAddr("tcp", server)
+	if err != nil {
+		return nil, err
+	}
+
+	tlsConfig, err := context.GetClientTLSConfig()
+	if err != nil {
+		return nil, err
+	}
+
+	conn, err := codec.TLSDialHTTP(addr.Network(), addr.String(), base.NetworkTimeout, tlsConfig)
+	if err != nil {
+		return nil, err
+	}
+
+	client := rpc.NewClientWithCodec(codec.NewClientCodec(conn))
+	return &rpcSender{
+		user:      context.User,
+		client:    client,
+		retryOpts: retryOpts,
+	}, nil
+}
+
+// Send sends call to Cockroach via an RPC.
+func (s *rpcSender) Send(args Request) (Response, error) {
+	if args.GetUser() == "" {
+		args.User = s.user
+	}
+
+	var err error
+	var reply Response
+	for r := retry.Start(s.retryOpts); r.Next(); {
+		if err = s.client.Call(RPCMethod, &args, &reply); err != nil {
+			reply.Reset() // don't trust anyone.
+			// Assume all errors sending request are retryable. The actual
+			// number of things that could go wrong is vast, but we don't
+			// want to miss any which should in theory be retried with the
+			// same client command ID. We log the error here as a warning so
+			// there's visiblity that this is happening. Some of the errors
+			// we'll sweep up in this net shouldn't be retried, but we can't
+			// really know for sure which.
+			continue
+		}
+
+		// On successful post, we're done with retry loop.
+		break
+	}
+	return reply, err
+}

--- a/sql/server.go
+++ b/sql/server.go
@@ -26,24 +26,26 @@ import (
 	"github.com/cockroachdb/cockroach/base"
 	"github.com/cockroachdb/cockroach/client"
 	"github.com/cockroachdb/cockroach/gossip"
+	"github.com/cockroachdb/cockroach/rpc"
 	"github.com/cockroachdb/cockroach/security"
 	"github.com/cockroachdb/cockroach/sql/driver"
 	"github.com/cockroachdb/cockroach/util"
 	"github.com/cockroachdb/cockroach/util/hlc"
+	"github.com/gogo/protobuf/proto"
 )
 
 var allowedEncodings = []util.EncodingType{util.JSONEncoding, util.ProtoEncoding}
 
-// An HTTPServer provides an HTTP server endpoint serving the SQL API.
-// It accepts either JSON or serialized protobuf content types.
-type HTTPServer struct {
+// An Server provides both an HTTP and RPC server endpoint serving the SQL API.
+// The HTTP endpoint accepts either JSON or serialized protobuf content types.
+type Server struct {
 	context *base.Context
 	*Executor
 }
 
-// MakeHTTPServer creates an HTTPServer.
-func MakeHTTPServer(ctx *base.Context, db client.DB, gossip *gossip.Gossip, clock *hlc.Clock) HTTPServer {
-	return HTTPServer{context: ctx, Executor: newExecutor(db, gossip, clock)}
+// MakeServer creates a Server.
+func MakeServer(ctx *base.Context, db client.DB, gossip *gossip.Gossip, clock *hlc.Clock) Server {
+	return Server{context: ctx, Executor: newExecutor(db, gossip, clock)}
 }
 
 // ServeHTTP serves the SQL API by treating the request URL path
@@ -54,7 +56,7 @@ func MakeHTTPServer(ctx *base.Context, db client.DB, gossip *gossip.Gossip, cloc
 // encoded according to the request's Accept header, or if not
 // present, in the same format as the request's incoming Content-Type
 // header.
-func (s HTTPServer) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+func (s Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	defer r.Body.Close()
 	method := r.URL.Path
 	if !strings.HasPrefix(method, driver.Endpoint) {
@@ -109,4 +111,15 @@ func (s HTTPServer) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	if _, err := w.Write(body); err != nil {
 		http.Error(w, err.Error(), http.StatusInternalServerError)
 	}
+}
+
+// RegisterRPC registers the SQL RPC endpoint.
+func (s Server) RegisterRPC(rpcServer *rpc.Server) error {
+	return rpcServer.RegisterPublic(driver.RPCMethod, s.executeCmd, &driver.Request{})
+}
+
+func (s Server) executeCmd(argsI proto.Message) (proto.Message, error) {
+	args := argsI.(*driver.Request)
+	reply, _, err := s.Execute(*args)
+	return &reply, err
 }


### PR DESCRIPTION
RPC is significantly faster than HTTP:

```
name         old time/op     new time/op    delta
Select1-8    210us +- 1%     127us +- 1%    -39.54%  (p=0.008 n=5+5)
Select1S-8   232us +- 1%     135us +- 2%    -41.90%  (p=0.008 n=5+5)
```

The "S" suffix is for secure. This is on go1.5. I also tested go-tip and
the improvement is comparable, though the overall perf numbers are about
10% lower on tip across the board (i.e. the go-tip SSL improvements are
being drowned by something else).

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/2994)

<!-- Reviewable:end -->
