### PR TITLE
Fix leaking LeaseRejectedError

### DIFF
--- a/storage/replica.go
+++ b/storage/replica.go
@@ -381,14 +381,25 @@ func (r *Replica) redirectOnOrAcquireLeaderLease(trace *tracer.Trace, timestamp 
 	// Otherwise, no active lease: Request renewal.
 	err := r.requestLeaderLease(timestamp)
 
-	// Getting a LeaseRejectedError back means someone else got there first;
-	// we can redirect if they cover our timestamp. Note that it can't be us,
-	// since we're holding a lock here, and even if it were it would be a rare
-	// extra round-trip.
+	// Getting a LeaseRejectedError back means someone else got there first, or
+	// the lease request was somehow invalid due to a concurrent change.
+	//
+	// In the case where another machine obtained the lease, we are certain that
+	// it can't be this replica because we're holding a lock.
+	//
+	// In all cases, the error is converted to a NotLeaderError.
 	if _, ok := err.(*roachpb.LeaseRejectedError); ok {
-		if lease := r.getLease(); lease.Covers(timestamp) {
-			return r.newNotLeaderError(lease, r.store.StoreID())
+		lease := r.getLease()
+		if !lease.Covers(timestamp) {
+			// The lease was rejected even though it was not obtained by another
+			// replica.
+			if log.V(1) {
+				log.Warningf("Lease for range %s rejected at timestamp %v: %s",
+					r, timestamp, err)
+			}
+			lease = nil
 		}
+		return r.newNotLeaderError(lease, r.store.StoreID())
 	}
 	return err
 }

--- a/storage/replica_test.go
+++ b/storage/replica_test.go
@@ -487,6 +487,24 @@ func TestRangeLeaderLease(t *testing.T) {
 	if held, expired := hasLease(tc.rng, tc.clock.Now()); held || !expired {
 		t.Errorf("expected another replica to have expired lease")
 	}
+
+	// Verify that command returns NotLeaderError when lease is rejected.
+	rng, err := NewReplica(testRangeDescriptor(), tc.store)
+	if err != nil {
+		t.Fatal(err)
+	}
+	rng.proposeRaftCommandFn = func(id cmdIDKey, cmd roachpb.RaftCommand) <-chan error {
+		errChan := make(chan error, 1)
+		errChan <- &roachpb.LeaseRejectedError{
+			Message: "replica not found",
+		}
+		return errChan
+	}
+
+	err = rng.redirectOnOrAcquireLeaderLease(nil, tc.clock.Now())
+	if lErr, ok := err.(*roachpb.NotLeaderError); !ok || lErr == nil {
+		t.Fatalf("wanted NotLeaderError, got %s", err)
+	}
 }
 
 func TestRangeNotLeaderError(t *testing.T) {


### PR DESCRIPTION
In a very particular race condition, a LeaseRejectedError could leak back to
clients. This race occurs when a replica requests the leader lease, but it is no
longer part of the range's raft group (having not yet been GCed). Due to a logic
quirk, this was not being properly converted to a "NotLeaderError" before being
passed back to the sender level.

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/2996)

<!-- Reviewable:end -->
