### PR TITLE
document a bug in unique index with NULLs

### DIFF
--- a/sql/testdata/insert
+++ b/sql/testdata/insert
@@ -56,15 +56,15 @@ EXPLAIN (DEBUG) SELECT * FROM kv
 query ITTB
 EXPLAIN (DEBUG) SELECT * FROM kv@a
 ----
-0  /kv/a/NULL /'A'     NULL
-0  /kv/a/NULL /'nil1'  NULL
-0  /kv/a/NULL /'nil2'  NULL
-0  /kv/a/NULL /'nil3'  NULL
-0  /kv/a/NULL /'nil4'  true
-1  /kv/a/''   /'g'     true
-2  /kv/a/'b'  /'a'     true
-3  /kv/a/'d'  /'c'     true
-4  /kv/a/'f'  /'e'     true
+0  /kv/a/NULL /'A'     true
+1  /kv/a/NULL /'nil1'  true
+2  /kv/a/NULL /'nil2'  true
+3  /kv/a/NULL /'nil3'  true
+4  /kv/a/NULL /'nil4'  true
+5  /kv/a/''   /'g'     true
+6  /kv/a/'b'  /'a'     true
+7  /kv/a/'d'  /'c'     true
+8  /kv/a/'f'  /'e'     true
 
 statement error duplicate key value \(v\)=\('f'\) violates unique constraint "a"
 INSERT INTO kv VALUES ('e', 'f')
@@ -89,15 +89,15 @@ EXPLAIN (DEBUG) SELECT * FROM kv
 query ITTB
 EXPLAIN (DEBUG) SELECT * FROM kv@a
 ----
-0  /kv/a/NULL /'A'     NULL
-0  /kv/a/NULL /'nil1'  NULL
-0  /kv/a/NULL /'nil2'  NULL
-0  /kv/a/NULL /'nil3'  NULL
-0  /kv/a/NULL /'nil4'  true
-1  /kv/a/''   /'g'     true
-2  /kv/a/'b'  /'a'     true
-3  /kv/a/'d'  /'c'     true
-4  /kv/a/'f'  /'e'     true
+0  /kv/a/NULL /'A'     true
+1  /kv/a/NULL /'nil1'  true
+2  /kv/a/NULL /'nil2'  true
+3  /kv/a/NULL /'nil3'  true
+4  /kv/a/NULL /'nil4'  true
+5  /kv/a/''   /'g'     true
+6  /kv/a/'b'  /'a'     true
+7  /kv/a/'d'  /'c'     true
+8  /kv/a/'f'  /'e'     true
 
 statement ok
 INSERT INTO kv VALUES ('f', 'g')
@@ -124,17 +124,16 @@ EXPLAIN (DEBUG) SELECT * FROM kv
 query ITTB
 EXPLAIN (DEBUG) SELECT * FROM kv@a
 ----
-0  /kv/a/NULL /'A'     NULL
-0  /kv/a/NULL /'nil1'  NULL
-0  /kv/a/NULL /'nil2'  NULL
-0  /kv/a/NULL /'nil3'  NULL
-0  /kv/a/NULL /'nil4'  true
-1  /kv/a/''   /'g'     true
-2  /kv/a/'b'  /'a'     true
-3  /kv/a/'d'  /'c'     true
-4  /kv/a/'f'  /'e'     true
-5  /kv/a/'g'  /'f'     true
-
+0  /kv/a/NULL /'A'     true
+1  /kv/a/NULL /'nil1'  true
+2  /kv/a/NULL /'nil2'  true
+3  /kv/a/NULL /'nil3'  true
+4  /kv/a/NULL /'nil4'  true
+5  /kv/a/''   /'g'     true
+6  /kv/a/'b'  /'a'     true
+7  /kv/a/'d'  /'c'     true
+8  /kv/a/'f'  /'e'     true
+9  /kv/a/'g'  /'f'     true
 
 statement error duplicate key value \(v\)=\('g'\) violates unique constraint "a"
 INSERT INTO kv VALUES ('h', 'g')
@@ -161,16 +160,16 @@ EXPLAIN (DEBUG) SELECT * FROM kv
 query ITTB
 EXPLAIN (DEBUG) SELECT * FROM kv@a
 ----
-0  /kv/a/NULL /'A'     NULL
-0  /kv/a/NULL /'nil1'  NULL
-0  /kv/a/NULL /'nil2'  NULL
-0  /kv/a/NULL /'nil3'  NULL
-0  /kv/a/NULL /'nil4'  true
-1  /kv/a/''   /'g'     true
-2  /kv/a/'b'  /'a'     true
-3  /kv/a/'d'  /'c'     true
-4  /kv/a/'f'  /'e'     true
-5  /kv/a/'g'  /'f'     true
+0  /kv/a/NULL /'A'     true
+1  /kv/a/NULL /'nil1'  true
+2  /kv/a/NULL /'nil2'  true
+3  /kv/a/NULL /'nil3'  true
+4  /kv/a/NULL /'nil4'  true
+5  /kv/a/''   /'g'     true
+6  /kv/a/'b'  /'a'     true
+7  /kv/a/'d'  /'c'     true
+8  /kv/a/'f'  /'e'     true
+9  /kv/a/'g'  /'f'     true
 
 query TT
 SELECT * FROM kv

--- a/sql/testdata/order_by
+++ b/sql/testdata/order_by
@@ -244,3 +244,15 @@ query I
 EXPLAIN SELECT c FROM abc WHERE b = 2 ORDER BY c DESC
 ----
 0 revscan abc@bc /2-/3
+
+statement ok
+CREATE TABLE bar (id INT PRIMARY KEY, baz STRING, UNIQUE INDEX i_bar (baz));
+
+statement ok
+INSERT INTO bar VALUES (0, NULL), (1, NULL);
+
+query IT
+SELECT * FROM bar ORDER BY baz, id;
+----
+0 NULL
+1 NULL


### PR DESCRIPTION
this branch is pushed on our main repo, so feel free to push the fix "under" the test and take over the review.

```
--- FAIL: TestLogic (1.52s)
        logic_test.go:495: testdata/order_by:254: expected:
                "0"  "NULL"
                "1"  "NULL"
                but found:
                "1"  "NULL"
```

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/3017)

<!-- Reviewable:end -->
