### PR TITLE
Minor tweak to Txn.SetDebugName to reduce allocations.

### DIFF
--- a/client/txn.go
+++ b/client/txn.go
@@ -19,6 +19,7 @@ package client
 
 import (
 	"fmt"
+	"strconv"
 	"time"
 
 	"golang.org/x/net/context"
@@ -109,7 +110,7 @@ func (txn *Txn) SetDebugName(name string, depth int) {
 	if name == "" {
 		name = fun
 	}
-	txn.Proto.Name = fmt.Sprintf("%s:%d %s", file, line, name)
+	txn.Proto.Name = file + ":" + strconv.Itoa(line) + " " + name
 }
 
 // DebugName returns the debug name associated with the transaction.


### PR DESCRIPTION
Probably inconsequential in the big picture, but this showed up in a
benchmark profile and the new code is almost as readable as the old.

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/3022)

<!-- Reviewable:end -->
