### PR TITLE
fixme: index out of bounds for insert with extra columns

### DIFF
--- a/sql/insert.go
+++ b/sql/insert.go
@@ -98,6 +98,10 @@ func (p *planner) Insert(n *parser.Insert) (planNode, error) {
 		return nil, err
 	}
 
+	if expressions, columns := len(rows.Columns()), len(cols); expressions > columns {
+		return nil, fmt.Errorf("INSERT has more expressions than target columns: %d/%d", expressions, columns)
+	}
+
 	primaryIndex := tableDesc.PrimaryIndex
 	primaryIndexKeyPrefix := MakeIndexKeyPrefix(tableDesc.ID, primaryIndex.ID)
 

--- a/sql/testdata/insert
+++ b/sql/testdata/insert
@@ -290,3 +290,9 @@ query ITTB
 SELECT * FROM kv5@a
 ----
 NULL a
+
+statement ok
+CREATE TABLE boom (id INT PRIMARY KEY)
+
+statement error INSERT has more expressions than target columns: \d+/\d+
+INSERT INTO boom VALUES(1,2)


### PR DESCRIPTION
```
I1106 13:44:57.490930 90957 server.go:1934  http: panic serving 127.0.0.1:62138: runtime error: index out of range
goroutine 4122 [running]:
net/http.(*conn).serve.func1(0xc8203022c0, 0x6968898, 0xc8200d1b80)
    /usr/local/Cellar/go/1.5.1/libexec/src/net/http/server.go:1287 +0xb5
github.com/cockroachdb/cockroach/sql.(*planner).Insert(0xc8202cc680, 0xc82016a7b0, 0x0, 0x0, 0x0, 0x0)
    /Users/tschottdorf/go/src/github.com/cockroachdb/cockroach/sql/insert.go:142 +0x1f1f
github.com/cockroachdb/cockroach/sql.(*planner).makePlan(0xc8202cc680, 0x696e648, 0xc82016a7b0, 0x0, 0x0, 0x0, 0x0)
    /Users/tschottdorf/go/src/github.com/cockroachdb/cockroach/sql/plan.go:99 +0x12dd
github.com/cockroachdb/cockroach/sql.(*Executor).execStmt.func1(0xecdceec29, 0xc81d40e0e3, 0x5749e60, 0x0, 0x0)
    /Users/tschottdorf/go/src/github.com/cockroachdb/cockroach/sql/executor.go:207 +0x103
```

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/3029)

<!-- Reviewable:end -->
