### PR TITLE
when cleaning up txns, actually do that

### DIFF
--- a/storage/replica_command.go
+++ b/storage/replica_command.go
@@ -928,6 +928,9 @@ func (r *Replica) PushTxn(batch engine.Engine, ms *engine.MVCCStats, h roachpb.H
 			log.Infof("pushing expired txn %s", reply.PusheeTxn)
 		}
 		pusherWins = true
+		// When cleaning up, actually clean up (as opposed to simply pushing
+		// the garbage in the path of future writers).
+		args.PushType = roachpb.ABORT_TXN
 	} else if reply.PusheeTxn.Isolation == roachpb.SNAPSHOT && args.PushType == roachpb.PUSH_TIMESTAMP {
 		if log.V(1) {
 			log.Infof("pushing timestamp for snapshot isolation txn")

--- a/storage/replica_test.go
+++ b/storage/replica_test.go
@@ -2171,15 +2171,18 @@ func TestPushTxnHeartbeatTimeout(t *testing.T) {
 		args := pushTxnArgs(pusher, pushee, test.pushType)
 		args.Now = roachpb.Timestamp{WallTime: test.currentTime}
 
-		_, err := client.SendWrapped(tc.Sender(), tc.rng.context(), &args)
+		reply, err := client.SendWrapped(tc.Sender(), tc.rng.context(), &args)
 
 		if test.expSuccess != (err == nil) {
-			t.Errorf("expected success on trial %d? %t; got err %s", i, test.expSuccess, err)
+			t.Errorf("%d: expSuccess=%t; got err %s", i, test.expSuccess, err)
+			continue
 		}
 		if err != nil {
 			if _, ok := err.(*roachpb.TransactionPushError); !ok {
-				t.Errorf("expected txn push error: %s", err)
+				t.Errorf("%d: expected txn push error: %s", i, err)
 			}
+		} else if txn := reply.(*roachpb.PushTxnResponse).PusheeTxn; txn == nil || txn.Status != roachpb.ABORTED {
+			t.Errorf("%d: expected aborted transaction, got %s", i, txn)
 		}
 	}
 }


### PR DESCRIPTION
current implementations could wind up pushing abandoned transactions
into the future when touched through (*Store).resolveWriteIntentError.

this is one of the things that tripped me up during today's demo: #3031 
abandoned the transaction, so the intent wasn't removed. running the
transaction again was impossible since the pending intent would always
be pushed into the future, and #2861 kicked in and gave me a
`ReadWithinUncertaintyIntervalError` - so in fact on the console there was
no way to get rid of the intent.

With this change, at least a push after 10 seconds will actually remove the
intent, not push it into the future.

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/3032)

<!-- Reviewable:end -->
