### PR TITLE
deal with intents on SystemDB

### DIFF
--- a/storage/replica.go
+++ b/storage/replica.go
@@ -23,6 +23,7 @@ package storage
 import (
 	"bytes"
 	"crypto/sha1"
+	"errors"
 	"fmt"
 	"math/rand"
 	"sync"
@@ -1336,7 +1337,7 @@ func (r *Replica) maybeGossipSystemConfigLocked() {
 
 	ctx := r.context()
 	// TODO(marc): check for bad split in the middle of the SystemDB span.
-	kvs, hash, err := loadSystemDBSpan(r.store.Engine())
+	kvs, hash, err := r.loadSystemDBSpan()
 	if err != nil {
 		log.Errorc(ctx, "could not load SystemDB span: %s", err)
 		return
@@ -1571,16 +1572,28 @@ func (r *Replica) resolveIntents(ctx context.Context, intents []roachpb.Intent) 
 	wg.Wait()
 }
 
+var errSystemDBIntent = errors.New("must retry later due to intent on SystemDB")
+
 // loadSystemDBSpan scans the entire SystemDB span and returns the full list of
 // key/value pairs along with the sha1 checksum of the contents (key and value).
-func loadSystemDBSpan(eng engine.Engine) ([]roachpb.KeyValue, []byte, error) {
-	// TODO(tschottdorf): Currently this does not handle intents well.
-	kvs, _, err := engine.MVCCScan(eng, keys.SystemDBSpan.Key, keys.SystemDBSpan.EndKey,
-		0, roachpb.MaxTimestamp, true /* consistent */, nil)
+func (r *Replica) loadSystemDBSpan() ([]roachpb.KeyValue, []byte, error) {
+	ba := roachpb.BatchRequest{}
+	ba.ReadConsistency = roachpb.INCONSISTENT
+	ba.Timestamp = r.store.Clock().Now()
+	ba.Add(&roachpb.ScanRequest{Span: keys.SystemDBSpan})
+	br, intents, err := r.executeBatch(r.store.Engine(), nil, ba)
 	if err != nil {
 		return nil, nil, err
 	}
+	if len(intents) > 0 {
+		// There were intents, so what we read may not be consistent. Attempt
+		// to nudge the intents in case they're expired; next time around we'll
+		// hopefully have more luck.
+		r.handleSkippedIntents(intents)
+		return nil, nil, errSystemDBIntent
+	}
 	sha := sha1.New()
+	kvs := br.Responses[0].GetInner().(*roachpb.ScanResponse).Rows
 	for _, kv := range kvs {
 		if _, err := sha.Write(kv.Key); err != nil {
 			return nil, nil, err


### PR DESCRIPTION
The previous code did not handle these. Since a leftover intent on
this table may potentially only ever be touched by the code changed
in this PR, the previous version would stop gossipping the schema altogether.

With this change, when intents are encountered, an error is returned
but the intents are handled. This causes them to be cleaned up when
they are abandoned, but does not interfere with active writers. The
hope is that on the next iteration, the read can succeed. It is
going to be in our interest to minimize contention on that table.

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/3036)

<!-- Reviewable:end -->
