### PR TITLE
client: CommitBy takes Timestamp by value

### DIFF
--- a/client/txn.go
+++ b/client/txn.go
@@ -342,8 +342,8 @@ func (txn *Txn) Commit() error {
 
 // CommitBy sends an EndTransactionRequest with Commit=true and
 // Deadline=deadline.
-func (txn *Txn) CommitBy(deadline *roachpb.Timestamp) error {
-	err := txn.commit(deadline)
+func (txn *Txn) CommitBy(deadline roachpb.Timestamp) error {
+	err := txn.commit(&deadline)
 	txn.Cleanup(err)
 	return err
 }

--- a/kv/txn_coord_sender_test.go
+++ b/kv/txn_coord_sender_test.go
@@ -327,25 +327,23 @@ func TestTxnCoordSenderEndTxn(t *testing.T) {
 			t.Fatal(err)
 		}
 
-		var deadline *roachpb.Timestamp
-		switch i {
-		case 0:
-			// No deadline.
-		case 1:
-			// Past deadline.
-			ts := txn.Proto.Timestamp.Prev()
-			deadline = &ts
-		case 2:
-			// Equal deadline.
-			deadline = &txn.Proto.Timestamp
-		case 3:
-			// Future deadline.
-			ts := txn.Proto.Timestamp.Next()
-			deadline = &ts
-		}
-
 		{
-			err := txn.CommitBy(deadline)
+			var err error
+			switch i {
+			case 0:
+				// No deadline.
+				err = txn.Commit()
+			case 1:
+				// Past deadline.
+				err = txn.CommitBy(txn.Proto.Timestamp.Prev())
+			case 2:
+				// Equal deadline.
+				err = txn.CommitBy(txn.Proto.Timestamp)
+			case 3:
+				// Future deadline.
+				err = txn.CommitBy(txn.Proto.Timestamp.Next())
+			}
+
 			switch i {
 			case 0:
 				// No deadline.


### PR DESCRIPTION
@petermattis this addresses your review comments, though in a different way than you suggested.

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/3043)

<!-- Reviewable:end -->
