### PR TITLE
Fix for #2592 and new error condition

### DIFF
--- a/multiraft/storage.go
+++ b/multiraft/storage.go
@@ -221,13 +221,6 @@ func (w *writeTask) start(stopper *stop.Stopper) {
 				}
 				groupResp := &groupWriteResponse{raftpb.HardState{}, -1, -1, groupReq.entries}
 				response.groups[groupID] = groupResp
-				if !raft.IsEmptyHardState(groupReq.state) {
-					err := group.SetHardState(groupReq.state)
-					if err != nil {
-						panic(err) // TODO(bdarnell): mark this node dead on storage errors
-					}
-					groupResp.state = groupReq.state
-				}
 				if !raft.IsEmptySnap(groupReq.snapshot) {
 					err := group.ApplySnapshot(groupReq.snapshot)
 					if err != nil {
@@ -239,6 +232,13 @@ func (w *writeTask) start(stopper *stop.Stopper) {
 					if err != nil {
 						panic(err) // TODO(bdarnell)
 					}
+				}
+				if !raft.IsEmptyHardState(groupReq.state) {
+					err := group.SetHardState(groupReq.state)
+					if err != nil {
+						panic(err) // TODO(bdarnell): mark this node dead on storage errors
+					}
+					groupResp.state = groupReq.state
 				}
 			}
 			w.out <- response

--- a/storage/store.go
+++ b/storage/store.go
@@ -254,7 +254,9 @@ type Store struct {
 	nodeDesc          *roachpb.NodeDescriptor
 	initComplete      sync.WaitGroup // Signaled by async init tasks
 
-	// Synchronizes raft group creation and range GC.
+	// Synchronizes raft group creation and range GC. Since lock ordering could
+	// be an issue, if this lock is ever required at the same time as mu, this
+	// lock should be acquired first.
 	raftGroupLocker sync.Mutex
 
 	mu             sync.RWMutex                 // Protects variables below...
@@ -943,8 +945,11 @@ func (s *Store) SplitRange(origRng, newRng *Replica) error {
 		return util.Errorf("orig range is not splittable by new range: %+v, %+v", origDesc, newDesc)
 	}
 
+	s.raftGroupLocker.Lock()
 	s.mu.Lock()
+	defer s.raftGroupLocker.Unlock()
 	defer s.mu.Unlock()
+
 	// Replace the end key of the original range with the start key of
 	// the new range. Reinsert the range since the btree is keyed by range end keys.
 	if s.replicasByKey.Delete(origRng) == nil {
@@ -960,10 +965,15 @@ func (s *Store) SplitRange(origRng, newRng *Replica) error {
 	}
 
 	// If we have an uninitialized replica of the new range, delete it to make
-	// way for the complete one created by the split.
+	// way for the complete one created by the split. We also need to prevent an
+	// uninitialized group from updating its raft state, so we remove it as well
+	// which requires the raftGroupLocker.
 	if _, ok := s.uninitReplicas[newDesc.RangeID]; ok {
 		delete(s.uninitReplicas, newDesc.RangeID)
 		delete(s.replicas, newDesc.RangeID)
+		if err := s.multiraft.RemoveGroup(newDesc.RangeID); err != nil {
+			return util.Errorf("couldn't remove uninitialized range's group %d: %s", newDesc.RangeID, err)
+		}
 	}
 	if err := s.addReplicaInternal(newRng); err != nil {
 		return util.Errorf("couldn't insert range %v in rangesByKey btree: %s", newRng, err)


### PR DESCRIPTION
#2592 was solved by rearranging the order in which raft was initialized.  The hard state has to occur after both the snapshot and entries.

Once this was solved, a new raft race started occurring in which an uninitialized group could have its state changed during a split.  This is fixed by removing the uninitialized group during the split.
This work was done with @bdarnell's help.

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/3044)

<!-- Reviewable:end -->
