### PR TITLE
build: `vet` is part of the go distribution since 1.5

### DIFF
--- a/build/Dockerfile
+++ b/build/Dockerfile
@@ -9,8 +9,6 @@ RUN curl --silent --location https://deb.nodesource.com/setup_5.x | bash - && \
  apt-get autoremove -y && \
  rm -rf /tmp/*
 
-RUN go get golang.org/x/tools/cmd/vet
-
 ENV SKIP_BOOTSTRAP=1
 
 CMD ["/bin/bash"]

--- a/build/circle-deps.sh
+++ b/build/circle-deps.sh
@@ -48,7 +48,7 @@ buildcache_dir=~/buildcache
 # The tag for the cockroachdb/builder image. If the image is changed
 # (for example, adding "npm"), a new image should be pushed using
 # "build/builder.sh push" and the new tag value placed here.
-tag="20151030-132253"
+tag="20151108-172428"
 
 mkdir -p "${buildcache_dir}"
 du -sh "${buildcache_dir}"


### PR DESCRIPTION
<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/3048)

<!-- Reviewable:end -->
