### PR TITLE
Add support for regexp_extract and SUBSTRING builtin functions

### DIFF
--- a/sql/parser/builtins.go
+++ b/sql/parser/builtins.go
@@ -298,7 +298,7 @@ var builtins = map[string][]builtin{
 			fn: func(ctx EvalContext, args DTuple) (Datum, error) {
 				s := string(args[0].(DString))
 				pattern := string(args[1].(DString))
-				return regexpExtract(ctx, s, pattern)
+				return regexpExtract(ctx, s, pattern, `\`)
 			},
 		},
 	},
@@ -893,6 +893,25 @@ var substringImpls = []builtin{
 			return str[start:end], nil
 		},
 	},
+	{
+		types:      typeList{stringType, stringType},
+		returnType: DummyString,
+		fn: func(ctx EvalContext, args DTuple) (Datum, error) {
+			s := string(args[0].(DString))
+			pattern := string(args[1].(DString))
+			return regexpExtract(ctx, s, pattern, `\`)
+		},
+	},
+	{
+		types:      typeList{stringType, stringType, stringType},
+		returnType: DummyString,
+		fn: func(ctx EvalContext, args DTuple) (Datum, error) {
+			s := string(args[0].(DString))
+			pattern := string(args[1].(DString))
+			escape := string(args[2].(DString))
+			return regexpExtract(ctx, s, pattern, escape)
+		},
+	},
 }
 
 var ceilImpl = floatBuiltin1(func(x float64) (Datum, error) {
@@ -990,17 +1009,22 @@ func datumToString(datum Datum) (string, error) {
 	return "", fmt.Errorf("argument type unsupported: %s", datum.Type())
 }
 
-type regexpKey struct {
+type regexpEscapeKey struct {
 	sqlPattern string
-	sqlFlags   string
+	sqlEscape  string
 }
 
-func (k regexpKey) pattern() (string, error) {
-	return regexpEvalFlags(k.sqlPattern, k.sqlFlags)
+func (k regexpEscapeKey) pattern() (string, error) {
+	pattern := k.sqlPattern
+	if k.sqlEscape != `\` {
+		pattern = strings.Replace(pattern, `\`, `\\`, -1)
+		pattern = strings.Replace(pattern, k.sqlEscape, `\`, -1)
+	}
+	return pattern, nil
 }
 
-func regexpExtract(ctx EvalContext, s, pattern string) (Datum, error) {
-	patternRe, err := ctx.ReCache.GetRegexp(regexpKey{pattern, ""})
+func regexpExtract(ctx EvalContext, s, pattern, escape string) (Datum, error) {
+	patternRe, err := ctx.ReCache.GetRegexp(regexpEscapeKey{pattern, escape})
 	if err != nil {
 		return nil, err
 	}
@@ -1016,10 +1040,19 @@ func regexpExtract(ctx EvalContext, s, pattern string) (Datum, error) {
 	return DString(match[0]), nil
 }
 
+type regexpFlagKey struct {
+	sqlPattern string
+	sqlFlags   string
+}
+
+func (k regexpFlagKey) pattern() (string, error) {
+	return regexpEvalFlags(k.sqlPattern, k.sqlFlags)
+}
+
 var replaceSubRe = regexp.MustCompile(`\\[&1-9]`)
 
 func regexpReplace(ctx EvalContext, s, pattern, to, sqlFlags string) (Datum, error) {
-	patternRe, err := ctx.ReCache.GetRegexp(regexpKey{pattern, sqlFlags})
+	patternRe, err := ctx.ReCache.GetRegexp(regexpFlagKey{pattern, sqlFlags})
 	if err != nil {
 		return nil, err
 	}

--- a/sql/parser/parse_test.go
+++ b/sql/parser/parse_test.go
@@ -472,6 +472,19 @@ func TestParse2(t *testing.T) {
 			`SET TIME ZONE 'Europe/Rome'`},
 		{`SET TIME ZONE INTERVAL '-7h'`,
 			`SET TIME ZONE INTERVAL '-7h0m0s'`},
+		// Special substring syntax
+		{`SELECT SUBSTRING('RoacH' from 2 for 3)`,
+			`SELECT SUBSTRING('RoacH', 2, 3)`},
+		{`SELECT SUBSTRING('RoacH' for 2 from 3)`,
+			`SELECT SUBSTRING('RoacH', 3, 2)`},
+		{`SELECT SUBSTRING('RoacH' from 2)`,
+			`SELECT SUBSTRING('RoacH', 2)`},
+		{`SELECT SUBSTRING('RoacH' for 3)`,
+			`SELECT SUBSTRING('RoacH', 1, 3)`},
+		{`SELECT SUBSTRING('f(oabaroob' from '\(o(.)b')`,
+			`SELECT SUBSTRING('f(oabaroob', e'\\(o(.)b')`},
+		{`SELECT SUBSTRING('f(oabaroob' from '+(o(.)b' for '+')`,
+			`SELECT SUBSTRING('f(oabaroob', '+(o(.)b', '+')`},
 	}
 	for _, d := range testData {
 		stmts, err := ParseTraditional(d.sql)
@@ -488,7 +501,7 @@ func TestParse2(t *testing.T) {
 	}
 }
 
-// TestParseSyntax verifieds that parsing succeeds, though the syntax tree
+// TestParseSyntax verifies that parsing succeeds, though the syntax tree
 // likely differs. All of the test cases here should eventually be moved
 // elsewhere.
 func TestParseSyntax(t *testing.T) {

--- a/sql/parser/sql.go
+++ b/sql/parser/sql.go
@@ -578,7 +578,7 @@ const sqlEofCode = 1
 const sqlErrCode = 2
 const sqlInitialStackSize = 16
 
-//line sql.y:3701
+//line sql.y:3729
 
 //line yacctab:1
 var sqlExca = [...]int{
@@ -1031,9 +1031,9 @@ var sqlAct = [...]int{
 	1234, 1235, 380, 379, 87, 87, 837, 1355, 913, 371,
 	87, 1412, 87, 837, 87, 87, 87, 87, 1407, 79,
 	80, 1015, 1350, 1370, 764, 813, 87, 1379, 87, 1371,
-	1372, 628, 1190, 1377, 231, 1123, 87, 87, 963, 955,
-	87, 953, 332, 459, 837, 1141, 87, 87, 1427, 772,
-	358, 320, 1436, 1278, 1279, 1280, 1281, 1282, 1283, 1284,
+	1372, 628, 1190, 1377, 231, 1123, 87, 87, 955, 953,
+	87, 332, 459, 772, 837, 1141, 87, 87, 1427, 358,
+	320, 963, 1436, 1278, 1279, 1280, 1281, 1282, 1283, 1284,
 	1285, 1286, 1287, 1288, 1289, 1290, 1291, 1292, 1293, 1294,
 	1295, 858, 1299, 1457, 857, 1419, 1443, 944, 1364, 1422,
 	1363, 1459, 1365, 824, 1445, 1420, 1465, 1456, 87, 1067,
@@ -2895,12 +2895,12 @@ var sqlPgo = [...]int{
 	1412, 10, 76, 72, 1409, 37, 1408, 542, 1163, 49,
 	20, 15, 4, 1407, 1397, 1393, 29, 1391, 1390, 1389,
 	11, 40, 25, 1388, 14, 89, 1384, 1379, 74, 1373,
-	127, 42, 96, 97, 1367, 1341, 484, 1340, 12, 46,
-	1339, 24, 1333, 19, 51, 103, 1332, 499, 38, 22,
-	36, 1331, 1329, 1328, 61, 70, 43, 1325, 30, 32,
-	1324, 45, 1322, 95, 98, 1321, 1315, 1314, 1312, 1311,
-	1310, 1094, 1309, 7, 52, 41, 28, 39, 0, 215,
-	551, 1299, 56, 27, 35, 31, 1298, 77, 1293, 1292,
+	127, 42, 96, 97, 1367, 1341, 1340, 484, 1339, 12,
+	46, 1333, 24, 1332, 19, 51, 103, 1331, 499, 38,
+	22, 36, 1329, 1328, 61, 70, 43, 1325, 1324, 45,
+	1322, 95, 98, 1321, 1315, 1314, 1312, 1311, 1310, 1094,
+	1309, 7, 52, 41, 28, 39, 0, 215, 551, 1299,
+	30, 32, 56, 27, 35, 31, 1298, 77, 1293, 1292,
 	1289, 1285, 1283, 54, 1282, 44, 107, 26, 63, 69,
 	23, 101, 57, 88, 112, 84, 1281, 91, 1279, 75,
 	1278, 1277, 633, 73, 1274, 1273, 1272, 617, 614, 474,
@@ -2920,36 +2920,36 @@ var sqlR1 = [...]int{
 	32, 32, 32, 32, 32, 32, 32, 32, 32, 29,
 	29, 35, 35, 35, 34, 34, 30, 30, 5, 5,
 	5, 9, 10, 10, 10, 10, 10, 10, 62, 62,
-	61, 61, 65, 65, 11, 11, 12, 12, 12, 12,
+	61, 61, 66, 66, 11, 11, 12, 12, 12, 12,
 	138, 138, 137, 13, 17, 204, 204, 204, 208, 208,
 	209, 209, 210, 210, 210, 210, 210, 210, 210, 206,
-	206, 19, 19, 19, 101, 101, 100, 100, 100, 100,
-	102, 102, 102, 102, 162, 160, 160, 167, 167, 167,
+	206, 19, 19, 19, 99, 99, 98, 98, 98, 98,
+	100, 100, 100, 100, 162, 160, 160, 167, 167, 167,
 	44, 44, 44, 44, 44, 159, 159, 159, 159, 168,
 	168, 168, 168, 168, 168, 45, 45, 45, 166, 166,
 	20, 20, 20, 20, 20, 20, 20, 20, 20, 20,
 	161, 161, 205, 205, 207, 207, 8, 8, 46, 46,
-	47, 47, 105, 105, 105, 104, 176, 176, 177, 177,
+	47, 47, 103, 103, 103, 102, 176, 176, 177, 177,
 	177, 178, 178, 178, 178, 178, 178, 178, 175, 175,
-	173, 173, 174, 174, 174, 174, 211, 211, 103, 103,
+	173, 173, 174, 174, 174, 174, 211, 211, 101, 101,
 	50, 50, 181, 181, 181, 181, 179, 179, 179, 179,
 	179, 182, 180, 183, 183, 183, 183, 183, 126, 126,
-	126, 22, 7, 7, 90, 90, 54, 54, 130, 130,
+	126, 22, 7, 7, 88, 88, 54, 54, 130, 130,
 	130, 41, 41, 31, 31, 31, 16, 16, 16, 16,
-	16, 16, 16, 16, 16, 91, 91, 92, 92, 21,
+	16, 16, 16, 16, 16, 89, 89, 90, 90, 21,
 	21, 21, 213, 213, 36, 36, 37, 6, 6, 14,
-	43, 43, 97, 97, 97, 99, 99, 99, 98, 98,
-	98, 23, 68, 68, 69, 69, 136, 70, 70, 18,
+	43, 43, 95, 95, 95, 97, 97, 97, 96, 96,
+	96, 23, 69, 69, 70, 70, 136, 71, 71, 18,
 	18, 25, 25, 24, 24, 24, 24, 24, 24, 26,
 	26, 27, 27, 27, 27, 27, 27, 27, 189, 189,
 	189, 191, 191, 188, 15, 15, 15, 15, 190, 190,
-	212, 212, 77, 77, 77, 49, 48, 48, 52, 52,
-	51, 53, 53, 129, 75, 75, 75, 75, 93, 94,
-	94, 95, 95, 96, 96, 74, 74, 113, 113, 28,
+	212, 212, 78, 78, 78, 49, 48, 48, 52, 52,
+	51, 53, 53, 129, 76, 76, 76, 76, 91, 92,
+	92, 93, 93, 94, 94, 75, 75, 113, 113, 28,
 	28, 58, 58, 59, 59, 131, 131, 131, 131, 132,
 	132, 132, 132, 132, 132, 127, 127, 127, 127, 128,
-	128, 80, 80, 80, 80, 78, 78, 79, 79, 133,
-	133, 133, 133, 76, 76, 134, 134, 134, 106, 106,
+	128, 81, 81, 81, 81, 79, 79, 80, 80, 133,
+	133, 133, 133, 77, 77, 134, 134, 134, 104, 104,
 	139, 139, 139, 57, 57, 57, 140, 140, 140, 140,
 	140, 140, 140, 140, 140, 140, 141, 141, 141, 141,
 	143, 143, 143, 142, 142, 142, 142, 142, 142, 142,
@@ -2957,16 +2957,16 @@ var sqlR1 = [...]int{
 	152, 152, 153, 154, 145, 145, 146, 146, 147, 148,
 	155, 155, 155, 157, 157, 149, 149, 150, 85, 85,
 	85, 85, 85, 85, 85, 85, 85, 85, 85, 85,
-	85, 85, 86, 86, 108, 108, 108, 108, 108, 108,
-	108, 108, 108, 108, 108, 108, 108, 108, 108, 108,
-	108, 108, 108, 108, 108, 108, 108, 108, 108, 108,
-	108, 108, 108, 108, 108, 108, 108, 108, 108, 108,
-	108, 108, 108, 108, 108, 108, 108, 108, 108, 108,
-	108, 108, 108, 108, 108, 108, 109, 109, 109, 109,
-	109, 109, 109, 109, 109, 109, 109, 109, 109, 109,
-	109, 109, 109, 109, 109, 109, 109, 109, 109, 109,
-	109, 109, 109, 110, 110, 110, 110, 110, 110, 110,
-	110, 110, 110, 110, 110, 184, 184, 184, 184, 184,
+	85, 85, 86, 86, 106, 106, 106, 106, 106, 106,
+	106, 106, 106, 106, 106, 106, 106, 106, 106, 106,
+	106, 106, 106, 106, 106, 106, 106, 106, 106, 106,
+	106, 106, 106, 106, 106, 106, 106, 106, 106, 106,
+	106, 106, 106, 106, 106, 106, 106, 106, 106, 106,
+	106, 106, 106, 106, 106, 106, 107, 107, 107, 107,
+	107, 107, 107, 107, 107, 107, 107, 107, 107, 107,
+	107, 107, 107, 107, 107, 107, 107, 107, 107, 107,
+	107, 107, 107, 108, 108, 108, 108, 108, 108, 108,
+	108, 108, 108, 108, 108, 184, 184, 184, 184, 184,
 	184, 184, 186, 186, 187, 187, 185, 185, 185, 185,
 	185, 185, 185, 185, 185, 185, 185, 185, 185, 185,
 	185, 185, 185, 185, 185, 185, 185, 185, 185, 185,
@@ -2975,13 +2975,13 @@ var sqlR1 = [...]int{
 	200, 201, 201, 202, 202, 202, 202, 202, 117, 117,
 	117, 118, 118, 119, 63, 63, 115, 115, 114, 114,
 	114, 116, 116, 64, 156, 156, 156, 156, 156, 156,
-	156, 81, 81, 87, 82, 82, 83, 83, 83, 83,
-	83, 83, 88, 89, 84, 84, 84, 112, 112, 120,
-	124, 124, 123, 122, 122, 121, 121, 107, 107, 107,
-	107, 107, 71, 71, 214, 214, 125, 125, 72, 72,
-	73, 67, 67, 66, 66, 135, 135, 135, 135, 60,
-	60, 42, 42, 55, 55, 56, 56, 40, 40, 111,
-	111, 111, 111, 111, 111, 111, 111, 111, 111, 111,
+	156, 82, 82, 87, 83, 83, 65, 65, 65, 65,
+	65, 65, 110, 111, 84, 84, 84, 112, 112, 120,
+	124, 124, 123, 122, 122, 121, 121, 105, 105, 105,
+	105, 105, 72, 72, 214, 214, 125, 125, 73, 73,
+	74, 68, 68, 67, 67, 135, 135, 135, 135, 60,
+	60, 42, 42, 55, 55, 56, 56, 40, 40, 109,
+	109, 109, 109, 109, 109, 109, 109, 109, 109, 109,
 	158, 158, 158, 38, 38, 38, 39, 39, 164, 164,
 	164, 165, 165, 165, 165, 163, 163, 163, 163, 163,
 	169, 169, 169, 169, 169, 169, 169, 169, 169, 169,
@@ -3113,8 +3113,8 @@ var sqlChk = [...]int{
 	260, 236, 242, 187, -28, 204, 229, 263, 204, 68,
 	109, 76, 112, 223, 68, 109, 204, -12, 260, -18,
 	-14, -23, -9, -208, 18, -209, -210, 56, 81, 99,
-	187, 112, 76, 223, -208, -101, 130, 189, 212, -102,
-	-100, -162, 208, 138, -61, -38, 4, -169, -171, 16,
+	187, 112, 76, 223, -208, -99, 130, 189, 212, -100,
+	-98, -162, 208, 138, -61, -38, 4, -169, -171, 16,
 	17, 19, 28, 29, 33, 37, 39, 49, 50, 51,
 	53, 55, 58, 59, 66, 67, 68, 69, 71, 76,
 	80, 81, 87, 91, 92, 94, 100, 105, 112, 120,
@@ -3129,30 +3129,30 @@ var sqlChk = [...]int{
 	156, 160, 164, 166, 170, 182, 195, 200, 202, 209,
 	213, 214, 229, 230, 4, 68, 49, 69, 100, 109,
 	205, 208, 212, 18, -213, 212, -213, -213, -212, 204,
-	204, -90, 68, 221, -26, -27, -25, -51, -52, 220,
+	204, -88, 68, 221, -26, -27, -25, -51, -52, 220,
 	116, 85, 154, -24, -25, -189, -191, 171, -188, -38,
 	130, 138, 189, 212, 208, -191, -48, -49, 18, 78,
-	264, -133, -42, 152, -38, -73, 260, -3, -133, 106,
+	264, -133, -42, 152, -38, -74, 260, -3, -133, 106,
 	-38, -42, 106, 97, 118, -134, -133, -38, 106, -60,
 	106, -42, -62, 106, -61, -138, -137, -165, 4, -169,
 	-171, -170, 229, 47, 57, 98, 111, 119, 121, 126,
-	128, 139, 157, 159, 179, 193, 151, 264, 151, -101,
-	-101, -37, 120, 210, 245, 97, 240, -45, 6, 74,
-	-65, 262, 97, -205, 151, 97, -161, 97, 240, 120,
-	-36, -37, -76, -133, -61, 106, 109, -38, 106, -51,
-	-52, -75, -93, -94, 129, 150, -77, 18, 78, -77,
-	-77, 37, 261, 261, 264, -191, -56, 260, -67, -66,
-	-135, -108, 253, -110, 251, 252, 257, 142, 241, -117,
-	-42, -111, 9, 260, -120, -186, -25, 86, 24, -118,
+	128, 139, 157, 159, 179, 193, 151, 264, 151, -99,
+	-99, -37, 120, 210, 245, 97, 240, -45, 6, 74,
+	-66, 262, 97, -205, 151, 97, -161, 97, 240, 120,
+	-36, -37, -77, -133, -61, 106, 109, -38, 106, -51,
+	-52, -76, -91, -92, 129, 150, -78, 18, 78, -78,
+	-78, 37, 261, 261, 264, -191, -56, 260, -68, -67,
+	-135, -106, 253, -108, 251, 252, 257, 142, 241, -117,
+	-42, -109, 9, 260, -120, -186, -25, 86, 24, -118,
 	-119, 182, -38, 8, 5, 6, 7, -40, -141, -150,
 	215, 89, 144, 40, -184, -185, 4, -169, -164, -142,
 	-152, -146, -149, 117, 47, 61, 64, 62, 65, 190,
 	224, 41, 88, 160, 164, 202, 213, 214, 106, 145,
 	107, 45, 101, 125, 80, 31, 32, 34, 35, 42,
 	43, 70, 72, 73, 93, 113, 114, 115, 147, 170,
-	195, 209, 230, -170, -153, -154, -147, -148, -155, -66,
-	-73, 253, -42, 260, -71, -107, 262, 265, 258, -72,
-	-125, -108, 74, -33, 174, -32, 17, 19, 81, 227,
+	195, 209, 230, -170, -153, -154, -147, -148, -155, -67,
+	-74, 253, -42, 260, -72, -105, 262, 265, 258, -73,
+	-125, -106, 74, -33, 174, -32, 17, 19, 81, 227,
 	86, 174, 174, 86, -134, -43, -42, 191, -38, 25,
 	86, -35, 264, 39, 176, 86, 264, 86, 261, 264,
 	-204, -60, 204, 68, -210, -204, 127, -160, 74, -167,
@@ -3168,102 +3168,102 @@ var sqlChk = [...]int{
 	173, 177, 187, 190, 197, 203, 204, 207, 210, 211,
 	215, 220, 221, 224, 225, 231, 233, 234, 235, 236,
 	-162, -207, 95, -204, -162, -162, 127, -35, 264, 260,
-	142, -39, 106, -38, 142, -75, -94, -93, -95, -108,
-	18, -108, -110, -26, -26, -26, -53, -129, -108, -188,
+	142, -39, 106, -38, 142, -76, -92, -91, -93, -106,
+	18, -106, -108, -26, -26, -26, -53, -129, -106, -188,
 	25, -55, -38, -58, 97, 264, 10, 46, 28, 251,
 	252, 253, 254, 255, 248, 249, 250, 247, 243, 244,
 	245, 52, 133, 184, 12, 13, 14, 22, 153, 128,
-	241, 193, 119, 30, 108, 25, 4, -108, -108, -108,
-	-108, -108, 159, -25, -108, -63, -71, -25, -114, 258,
-	260, -71, 260, 6, 6, 260, -121, -108, -192, 237,
+	241, 193, 119, 30, 108, 25, 4, -106, -106, -106,
+	-106, -106, 159, -25, -106, -63, -72, -25, -114, 258,
+	260, -72, 260, 6, 6, 260, -121, -106, -192, 237,
 	95, 260, 260, 260, 260, 260, 260, 260, 260, 260,
 	260, 260, 260, 260, 260, 260, 166, -157, 232, -157,
 	-157, -143, 260, -143, -144, 260, -143, 260, -58, -42,
-	-107, -163, 253, -163, -108, 264, 261, 264, 210, -91,
-	54, 48, -104, 106, 48, -173, -38, 54, -174, 44,
-	221, 167, 96, -91, 54, -91, 54, 54, -133, 210,
-	210, -42, -106, 234, -97, -18, 260, 74, 25, -68,
-	-69, -136, -70, -42, 260, -38, -38, -42, -60, -61,
+	-105, -163, 253, -163, -106, 264, 261, 264, 210, -89,
+	54, 48, -102, 106, 48, -173, -38, 54, -174, 44,
+	221, 167, 96, -89, 54, -89, 54, 54, -133, 210,
+	210, -42, -104, 234, -95, -18, 260, 74, 25, -69,
+	-70, -136, -71, -42, 260, -38, -38, -42, -60, -61,
 	-62, -12, -137, 210, -60, -55, 97, -44, 169, 175,
 	196, 188, 264, 5, 8, 8, 6, -163, -206, -38,
-	-133, -46, -47, -105, -104, -175, -173, 109, 221, 86,
-	151, 142, 86, -96, 182, 183, 264, -31, 26, 77,
-	260, 264, 261, -106, -59, -131, -133, -25, -132, 260,
+	-133, -46, -47, -103, -102, -175, -173, 109, 221, 86,
+	151, 142, 86, -94, 182, 183, 264, -31, 26, 77,
+	260, 264, 261, -104, -59, -131, -133, -25, -132, 260,
 	-135, -139, -140, -142, -151, -145, -149, -150, 33, 38,
 	206, 200, 113, 114, 115, 195, 31, 170, 93, 80,
 	73, 72, 147, 35, 34, -153, -154, -147, -148, 70,
-	209, 32, 43, 42, 230, -61, 208, -108, -108, -108,
-	-108, -108, -108, -108, -108, -108, -108, -108, -108, -108,
-	-108, -108, -108, -108, -108, -108, -108, -108, 128, 193,
+	209, 32, 43, 42, 230, -61, 208, -106, -106, -106,
+	-106, -106, -106, -106, -106, -106, -106, -106, -106, -106,
+	-106, -106, -106, -106, -106, -106, -106, -106, 128, 193,
 	30, 108, 210, 144, 142, 215, 89, 222, 78, 148,
 	-214, 203, 27, -112, -25, 260, -163, -117, 182, 260,
-	261, 264, -63, -116, 259, -108, -114, -63, 261, 261,
+	261, 264, -63, -116, 259, -106, -114, -63, 261, 261,
 	-63, 231, 18, 78, 253, -85, 239, 136, 71, 105,
 	135, -86, 186, 8, -124, -123, 233, -193, 91, 102,
-	260, 261, 261, -108, -64, -156, 4, 239, 136, 71,
-	105, 135, 186, -81, -108, -82, -109, -110, 251, 252,
-	257, 260, 182, -83, -108, -63, -108, 36, 124, 211,
-	-84, -108, 97, -63, -108, -108, -108, -63, -63, -63,
-	260, 8, 8, 8, -106, 261, 259, 266, -125, -32,
-	-42, -38, -38, 142, -104, 106, -139, -38, 260, 260,
+	260, 261, 261, -106, -64, -156, 4, 239, 136, 71,
+	105, 135, 186, -82, -106, -83, -107, -108, 251, 252,
+	257, 260, 182, -65, -106, -63, -106, 36, 124, 211,
+	-84, -106, 97, -63, -106, -106, -106, -63, -63, -63,
+	260, 8, 8, 8, -104, 261, 259, 266, -125, -32,
+	-42, -38, -38, 142, -102, 106, -139, -38, 260, 260,
 	122, 122, -38, -38, 106, -38, 106, -38, -38, -33,
-	174, -38, -38, 174, -108, -99, 151, -60, 229, -38,
+	174, -38, -38, 174, -106, -97, 151, -60, 229, -38,
 	-58, 264, 245, -60, -35, -206, -206, 219, 51, 169,
 	-167, -85, 264, 261, 264, -39, 109, -61, -42, 86,
-	-38, -129, -15, -18, -14, -23, -9, -38, -74, 102,
-	264, 57, -80, 121, 139, 98, 126, 179, 111, -128,
+	-38, -129, -15, -18, -14, -23, -9, -38, -75, 102,
+	264, 57, -81, 121, 139, 98, 126, 179, 111, -128,
 	-127, 25, -38, -128, -25, -132, -131, -57, 24, -85,
-	260, 240, -108, 210, -214, 203, -112, -108, 144, 215,
-	89, 222, 78, 148, 97, 260, -109, -109, -63, 260,
-	-63, -108, 264, 259, 259, 264, 261, -52, 264, -51,
-	-108, -63, -63, 261, 210, 210, 210, 210, 260, 261,
-	-122, -123, 82, -108, -198, 158, 260, 260, -108, 25,
+	260, 240, -106, 210, -214, 203, -112, -106, 144, 215,
+	89, 222, 78, 148, 97, 260, -107, -107, -63, 260,
+	-63, -106, 264, 259, 259, 264, 261, -52, 264, -51,
+	-106, -63, -63, 261, 210, 210, 210, 210, 260, 261,
+	-122, -123, 82, -106, -198, 158, 260, 260, -106, 25,
 	261, 97, 261, -87, 163, 261, 10, 251, 252, 253,
 	254, 255, 248, 249, 250, 247, 243, 244, 245, 52,
-	133, 184, 12, 13, 14, 119, 108, -109, -109, -109,
-	-63, 260, 261, -88, -89, 97, 95, 25, -84, -84,
+	133, 184, 12, 13, 14, 119, 108, -107, -107, -107,
+	-63, 260, 261, -110, -111, 97, 95, 25, -84, -84,
 	-84, 261, 97, -63, 264, 264, 264, 261, 261, 261,
-	8, 261, 264, 261, 261, -74, -108, 210, 210, 86,
-	142, -176, -174, -108, -55, 260, 260, -29, 81, 191,
-	-92, 86, -35, 86, -35, 210, -91, 54, 210, 53,
-	261, -106, -69, -125, 261, -38, -105, 260, -39, 260,
+	8, 261, 264, 261, 261, -75, -106, 210, 210, 86,
+	142, -176, -174, -106, -55, 260, 260, -29, 81, 191,
+	-90, 86, -35, 86, -35, 210, -89, 54, 210, 53,
+	261, -104, -70, -125, 261, -38, -103, 260, -39, 260,
 	260, -38, 261, -113, 104, 37, -131, 121, 121, -131,
-	-80, 121, -78, 157, -78, -78, -38, 260, 261, 258,
-	258, 8, -108, -108, -109, -109, 97, 260, -108, -115,
-	-139, 22, 22, 261, -63, 261, 264, 261, -108, -114,
+	-81, 121, -79, 157, -79, -79, -38, 260, 261, 258,
+	258, 8, -106, -106, -107, -107, 97, 260, -106, -115,
+	-139, 22, 22, 261, -63, 261, 264, 261, -106, -114,
 	261, 231, -52, -52, -52, 136, 105, 135, -86, 135,
-	-86, -86, 8, 6, 83, -108, 207, -199, -38, 260,
-	234, -51, 261, -139, -108, -88, -108, -139, -109, -109,
-	-109, -109, -109, -109, -109, -109, -109, -109, -109, -109,
-	-109, -109, -109, -109, -109, -109, 78, 142, 148, -109,
-	264, -63, 261, -89, -88, -108, -108, -139, 261, 261,
-	261, -63, -108, -108, -108, 261, 8, -113, 259, -38,
-	-38, -104, 86, -177, 54, -178, 46, 142, 144, 221,
+	-86, -86, 8, 6, 83, -106, 207, -199, -38, 260,
+	234, -51, 261, -139, -106, -110, -106, -139, -107, -107,
+	-107, -107, -107, -107, -107, -107, -107, -107, -107, -107,
+	-107, -107, -107, -107, -107, -107, 78, 142, 148, -107,
+	264, -63, 261, -111, -110, -106, -106, -139, 261, 261,
+	261, -63, -106, -106, -106, 261, 8, -113, 259, -38,
+	-38, -102, 86, -177, 54, -178, 46, 142, 144, 221,
 	167, 44, 74, 173, 261, 261, -55, -55, 142, 74,
 	142, 74, 67, 217, -38, -38, -42, -38, -38, -38,
-	-98, 260, 151, -18, 245, -55, 260, -46, -54, -130,
-	-38, -187, 260, -184, -185, -40, 151, -194, 235, -108,
-	-63, -131, -131, -79, 225, 151, 121, -131, 260, -55,
-	-127, 259, 8, 8, 261, 22, 22, -108, -115, 261,
-	264, -108, -108, 261, -108, 6, -108, 261, 261, 261,
-	261, -108, -203, -38, -108, 261, 261, -89, 97, 78,
-	148, 260, -108, 261, 261, 264, 261, 261, 261, -194,
-	-104, -38, -61, 144, 122, 260, -109, -42, -103, -211,
-	55, 201, 261, 261, 144, 144, -108, -139, -35, -35,
-	210, 210, 79, -54, 54, -73, -25, 260, 261, -55,
-	261, 261, 264, -41, -71, 46, -41, -108, 260, -42,
-	-195, -197, -38, -79, 260, -108, -131, -55, 261, 259,
-	259, -108, -108, 261, -139, 261, -52, -196, 162, 261,
-	-109, 97, 260, -115, 261, -108, -178, -108, -50, 260,
+	-96, 260, 151, -18, 245, -55, 260, -46, -54, -130,
+	-38, -187, 260, -184, -185, -40, 151, -194, 235, -106,
+	-63, -131, -131, -80, 225, 151, 121, -131, 260, -55,
+	-127, 259, 8, 8, 261, 22, 22, -106, -115, 261,
+	264, -106, -106, 261, -106, 6, -106, 261, 261, 261,
+	261, -106, -203, -38, -106, 261, 261, -111, 97, 78,
+	148, 260, -106, 261, 261, 264, 261, 261, 261, -194,
+	-102, -38, -61, 144, 122, 260, -107, -42, -101, -211,
+	55, 201, 261, 261, 144, 144, -106, -139, -35, -35,
+	210, 210, 79, -54, 54, -74, -25, 260, 261, -55,
+	261, 261, 264, -41, -72, 46, -41, -106, 260, -42,
+	-195, -197, -38, -80, 260, -106, -131, -55, 261, 259,
+	259, -106, -106, 261, -139, 261, -52, -196, 162, 261,
+	-107, 97, 260, -115, 261, -106, -178, -106, -50, 260,
 	260, 173, -34, 46, -38, -38, 223, 143, 261, -38,
-	-103, 261, -103, -130, -31, -61, -31, 261, -63, 260,
-	264, 25, -55, 261, 261, -52, 37, -109, -115, 261,
+	-101, 261, -101, -130, -31, -61, -31, 261, -63, 260,
+	264, 25, -55, 261, 261, -52, 37, -107, -115, 261,
 	261, 261, -181, 134, -55, -55, -42, -30, 225, -61,
-	191, -106, -103, -41, -52, -54, -197, -199, 261, -200,
+	191, -104, -101, -41, -52, -54, -197, -199, 261, -200,
 	168, 183, -63, 261, -179, -182, -180, 151, 98, 161,
-	194, 261, 261, -50, -108, -68, -31, 261, 261, 261,
-	-201, -202, 30, 218, 59, -108, -201, -180, 151, -182,
-	151, 223, 76, -181, -106, -103, -202, 165, 94, 182,
+	194, 261, 261, -50, -106, -69, -31, 261, 261, 261,
+	-201, -202, 30, 218, 59, -106, -201, -180, 151, -182,
+	151, 223, 76, -181, -104, -101, -202, 165, 94, 182,
 	165, 94, -183, 141, 176, 39, 191, -183, -179, 22,
 	16, 144, 74, -202,
 }
@@ -3817,13 +3817,13 @@ sqldefault:
 
 	case 1:
 		sqlDollar = sqlS[sqlpt-1 : sqlpt+1]
-		//line sql.y:439
+		//line sql.y:440
 		{
 			sqllex.(*scanner).stmts = sqlDollar[1].stmts
 		}
 	case 2:
 		sqlDollar = sqlS[sqlpt-3 : sqlpt+1]
-		//line sql.y:445
+		//line sql.y:446
 		{
 			if sqlDollar[3].stmt != nil {
 				sqlVAL.stmts = append(sqlDollar[1].stmts, sqlDollar[3].stmt)
@@ -3831,7 +3831,7 @@ sqldefault:
 		}
 	case 3:
 		sqlDollar = sqlS[sqlpt-1 : sqlpt+1]
-		//line sql.y:451
+		//line sql.y:452
 		{
 			if sqlDollar[1].stmt != nil {
 				sqlVAL.stmts = []Statement{sqlDollar[1].stmt}
@@ -3841,309 +3841,309 @@ sqldefault:
 		}
 	case 13:
 		sqlDollar = sqlS[sqlpt-1 : sqlpt+1]
-		//line sql.y:470
+		//line sql.y:471
 		{
 			sqlVAL.stmt = sqlDollar[1].selectStmt
 		}
 	case 19:
 		sqlDollar = sqlS[sqlpt-0 : sqlpt+1]
-		//line sql.y:479
+		//line sql.y:480
 		{
 			sqlVAL.stmt = nil
 		}
 	case 20:
 		sqlDollar = sqlS[sqlpt-4 : sqlpt+1]
-		//line sql.y:485
+		//line sql.y:486
 		{
 			sqlVAL.stmt = &AlterTable{Table: sqlDollar[3].qname, IfExists: false, Cmds: sqlDollar[4].alterTableCmds}
 		}
 	case 21:
 		sqlDollar = sqlS[sqlpt-6 : sqlpt+1]
-		//line sql.y:489
+		//line sql.y:490
 		{
 			sqlVAL.stmt = &AlterTable{Table: sqlDollar[5].qname, IfExists: true, Cmds: sqlDollar[6].alterTableCmds}
 		}
 	case 22:
 		sqlDollar = sqlS[sqlpt-1 : sqlpt+1]
-		//line sql.y:495
+		//line sql.y:496
 		{
 			sqlVAL.alterTableCmds = AlterTableCmds{sqlDollar[1].alterTableCmd}
 		}
 	case 23:
 		sqlDollar = sqlS[sqlpt-3 : sqlpt+1]
-		//line sql.y:499
+		//line sql.y:500
 		{
 			sqlVAL.alterTableCmds = append(sqlDollar[1].alterTableCmds, sqlDollar[3].alterTableCmd)
 		}
 	case 24:
 		sqlDollar = sqlS[sqlpt-2 : sqlpt+1]
-		//line sql.y:506
+		//line sql.y:507
 		{
 			sqlVAL.alterTableCmd = &AlterTableAddColumn{columnKeyword: false, IfNotExists: false, ColumnDef: sqlDollar[2].colDef}
 		}
 	case 25:
 		sqlDollar = sqlS[sqlpt-5 : sqlpt+1]
-		//line sql.y:511
+		//line sql.y:512
 		{
 			sqlVAL.alterTableCmd = &AlterTableAddColumn{columnKeyword: false, IfNotExists: true, ColumnDef: sqlDollar[5].colDef}
 		}
 	case 26:
 		sqlDollar = sqlS[sqlpt-3 : sqlpt+1]
-		//line sql.y:516
+		//line sql.y:517
 		{
 			sqlVAL.alterTableCmd = &AlterTableAddColumn{columnKeyword: true, IfNotExists: false, ColumnDef: sqlDollar[3].colDef}
 		}
 	case 27:
 		sqlDollar = sqlS[sqlpt-6 : sqlpt+1]
-		//line sql.y:521
+		//line sql.y:522
 		{
 			sqlVAL.alterTableCmd = &AlterTableAddColumn{columnKeyword: true, IfNotExists: true, ColumnDef: sqlDollar[6].colDef}
 		}
 	case 28:
 		sqlDollar = sqlS[sqlpt-4 : sqlpt+1]
-		//line sql.y:525
+		//line sql.y:526
 		{
 			unimplemented()
 		}
 	case 29:
 		sqlDollar = sqlS[sqlpt-6 : sqlpt+1]
-		//line sql.y:527
+		//line sql.y:528
 		{
 			unimplemented()
 		}
 	case 30:
 		sqlDollar = sqlS[sqlpt-6 : sqlpt+1]
-		//line sql.y:529
+		//line sql.y:530
 		{
 			unimplemented()
 		}
 	case 31:
 		sqlDollar = sqlS[sqlpt-6 : sqlpt+1]
-		//line sql.y:532
+		//line sql.y:533
 		{
 			sqlVAL.alterTableCmd = &AlterTableDropColumn{columnKeyword: sqlDollar[2].boolVal, IfExists: true, Column: sqlDollar[5].str}
 		}
 	case 32:
 		sqlDollar = sqlS[sqlpt-4 : sqlpt+1]
-		//line sql.y:537
+		//line sql.y:538
 		{
 			sqlVAL.alterTableCmd = &AlterTableDropColumn{columnKeyword: sqlDollar[2].boolVal, IfExists: false, Column: sqlDollar[3].str}
 		}
 	case 33:
 		sqlDollar = sqlS[sqlpt-8 : sqlpt+1]
-		//line sql.y:542
+		//line sql.y:543
 		{
 		}
 	case 34:
 		sqlDollar = sqlS[sqlpt-2 : sqlpt+1]
-		//line sql.y:545
+		//line sql.y:546
 		{
 			sqlVAL.alterTableCmd = &AlterTableAddConstraint{ConstraintDef: sqlDollar[2].constraintDef}
 		}
 	case 35:
 		sqlDollar = sqlS[sqlpt-3 : sqlpt+1]
-		//line sql.y:549
+		//line sql.y:550
 		{
 			unimplemented()
 		}
 	case 36:
 		sqlDollar = sqlS[sqlpt-3 : sqlpt+1]
-		//line sql.y:551
+		//line sql.y:552
 		{
 			unimplemented()
 		}
 	case 37:
 		sqlDollar = sqlS[sqlpt-6 : sqlpt+1]
-		//line sql.y:554
+		//line sql.y:555
 		{
 			sqlVAL.alterTableCmd = &AlterTableDropConstraint{IfExists: true, Constraint: sqlDollar[5].str}
 		}
 	case 38:
 		sqlDollar = sqlS[sqlpt-4 : sqlpt+1]
-		//line sql.y:559
+		//line sql.y:560
 		{
 			sqlVAL.alterTableCmd = &AlterTableDropConstraint{IfExists: false, Constraint: sqlDollar[3].str}
 		}
 	case 39:
 		sqlDollar = sqlS[sqlpt-3 : sqlpt+1]
-		//line sql.y:564
+		//line sql.y:565
 		{
 			unimplemented()
 		}
 	case 40:
 		sqlDollar = sqlS[sqlpt-2 : sqlpt+1]
-		//line sql.y:565
+		//line sql.y:566
 		{
 			unimplemented()
 		}
 	case 41:
 		sqlDollar = sqlS[sqlpt-1 : sqlpt+1]
-		//line sql.y:568
+		//line sql.y:569
 		{
 			unimplemented()
 		}
 	case 42:
 		sqlDollar = sqlS[sqlpt-1 : sqlpt+1]
-		//line sql.y:569
+		//line sql.y:570
 		{
 			unimplemented()
 		}
 	case 43:
 		sqlDollar = sqlS[sqlpt-0 : sqlpt+1]
-		//line sql.y:570
+		//line sql.y:571
 		{
 		}
 	case 44:
 		sqlDollar = sqlS[sqlpt-2 : sqlpt+1]
-		//line sql.y:573
+		//line sql.y:574
 		{
 			unimplemented()
 		}
 	case 45:
 		sqlDollar = sqlS[sqlpt-0 : sqlpt+1]
-		//line sql.y:574
+		//line sql.y:575
 		{
 		}
 	case 46:
 		sqlDollar = sqlS[sqlpt-2 : sqlpt+1]
-		//line sql.y:577
+		//line sql.y:578
 		{
 			unimplemented()
 		}
 	case 47:
 		sqlDollar = sqlS[sqlpt-0 : sqlpt+1]
-		//line sql.y:578
+		//line sql.y:579
 		{
 		}
 	case 51:
 		sqlDollar = sqlS[sqlpt-5 : sqlpt+1]
-		//line sql.y:589
+		//line sql.y:590
 		{
 			sqlVAL.stmt = &Delete{Table: sqlDollar[4].tblExpr, Where: newWhere(astWhere, sqlDollar[5].expr)}
 		}
 	case 52:
 		sqlDollar = sqlS[sqlpt-3 : sqlpt+1]
-		//line sql.y:596
+		//line sql.y:597
 		{
 			sqlVAL.stmt = &DropDatabase{Name: Name(sqlDollar[3].str), IfExists: false}
 		}
 	case 53:
 		sqlDollar = sqlS[sqlpt-5 : sqlpt+1]
-		//line sql.y:600
+		//line sql.y:601
 		{
 			sqlVAL.stmt = &DropDatabase{Name: Name(sqlDollar[5].str), IfExists: true}
 		}
 	case 54:
 		sqlDollar = sqlS[sqlpt-4 : sqlpt+1]
-		//line sql.y:604
+		//line sql.y:605
 		{
 			sqlVAL.stmt = &DropIndex{Names: sqlDollar[3].qnames, IfExists: false}
 		}
 	case 55:
 		sqlDollar = sqlS[sqlpt-6 : sqlpt+1]
-		//line sql.y:608
+		//line sql.y:609
 		{
 			sqlVAL.stmt = &DropIndex{Names: sqlDollar[5].qnames, IfExists: true}
 		}
 	case 56:
 		sqlDollar = sqlS[sqlpt-3 : sqlpt+1]
-		//line sql.y:612
+		//line sql.y:613
 		{
 			sqlVAL.stmt = &DropTable{Names: sqlDollar[3].qnames, IfExists: false}
 		}
 	case 57:
 		sqlDollar = sqlS[sqlpt-5 : sqlpt+1]
-		//line sql.y:616
+		//line sql.y:617
 		{
 			sqlVAL.stmt = &DropTable{Names: sqlDollar[5].qnames, IfExists: true}
 		}
 	case 58:
 		sqlDollar = sqlS[sqlpt-1 : sqlpt+1]
-		//line sql.y:622
+		//line sql.y:623
 		{
 			sqlVAL.qnames = QualifiedNames{sqlDollar[1].qname}
 		}
 	case 59:
 		sqlDollar = sqlS[sqlpt-3 : sqlpt+1]
-		//line sql.y:626
+		//line sql.y:627
 		{
 			sqlVAL.qnames = append(sqlDollar[1].qnames, sqlDollar[3].qname)
 		}
 	case 60:
 		sqlDollar = sqlS[sqlpt-1 : sqlpt+1]
-		//line sql.y:632
+		//line sql.y:633
 		{
 			sqlVAL.qname = &QualifiedName{Base: Name(sqlDollar[1].str)}
 		}
 	case 61:
 		sqlDollar = sqlS[sqlpt-2 : sqlpt+1]
-		//line sql.y:636
+		//line sql.y:637
 		{
 			sqlVAL.qname = &QualifiedName{Base: Name(sqlDollar[1].str), Indirect: sqlDollar[2].indirect}
 		}
 	case 62:
 		sqlDollar = sqlS[sqlpt-2 : sqlpt+1]
-		//line sql.y:642
+		//line sql.y:643
 		{
 			sqlVAL.indirect = Indirection{NameIndirection(sqlDollar[2].str)}
 		}
 	case 63:
 		sqlDollar = sqlS[sqlpt-3 : sqlpt+1]
-		//line sql.y:646
+		//line sql.y:647
 		{
 			sqlVAL.indirect = append(sqlDollar[1].indirect, NameIndirection(sqlDollar[3].str))
 		}
 	case 64:
 		sqlDollar = sqlS[sqlpt-2 : sqlpt+1]
-		//line sql.y:653
+		//line sql.y:654
 		{
 			sqlVAL.stmt = &Explain{Statement: sqlDollar[2].stmt}
 		}
 	case 65:
 		sqlDollar = sqlS[sqlpt-5 : sqlpt+1]
-		//line sql.y:657
+		//line sql.y:658
 		{
 			sqlVAL.stmt = &Explain{Options: sqlDollar[3].strs, Statement: sqlDollar[5].stmt}
 		}
 	case 66:
 		sqlDollar = sqlS[sqlpt-1 : sqlpt+1]
-		//line sql.y:663
+		//line sql.y:664
 		{
 			sqlVAL.stmt = sqlDollar[1].selectStmt
 		}
 	case 70:
 		sqlDollar = sqlS[sqlpt-1 : sqlpt+1]
-		//line sql.y:672
+		//line sql.y:673
 		{
 			sqlVAL.strs = []string{sqlDollar[1].str}
 		}
 	case 71:
 		sqlDollar = sqlS[sqlpt-3 : sqlpt+1]
-		//line sql.y:676
+		//line sql.y:677
 		{
 			sqlVAL.strs = append(sqlDollar[1].strs, sqlDollar[3].str)
 		}
 	case 73:
 		sqlDollar = sqlS[sqlpt-6 : sqlpt+1]
-		//line sql.y:686
+		//line sql.y:687
 		{
 			sqlVAL.stmt = &Grant{Privileges: sqlDollar[2].privilegeList, Grantees: NameList(sqlDollar[6].strs), Targets: sqlDollar[4].targetList}
 		}
 	case 74:
 		sqlDollar = sqlS[sqlpt-6 : sqlpt+1]
-		//line sql.y:693
+		//line sql.y:694
 		{
 			sqlVAL.stmt = &Revoke{Privileges: sqlDollar[2].privilegeList, Grantees: NameList(sqlDollar[6].strs), Targets: sqlDollar[4].targetList}
 		}
 	case 75:
 		sqlDollar = sqlS[sqlpt-1 : sqlpt+1]
-		//line sql.y:700
+		//line sql.y:701
 		{
 			sqlVAL.targetList = TargetList{Tables: QualifiedNames(sqlDollar[1].qnames)}
 		}
 	case 76:
 		sqlDollar = sqlS[sqlpt-2 : sqlpt+1]
-		//line sql.y:704
+		//line sql.y:705
 		{
 			// TODO(marc): this is postgres' grammar, but do we really need
 			// both "x" and "TABLE X"?
@@ -4151,237 +4151,237 @@ sqldefault:
 		}
 	case 77:
 		sqlDollar = sqlS[sqlpt-2 : sqlpt+1]
-		//line sql.y:710
+		//line sql.y:711
 		{
 			sqlVAL.targetList = TargetList{Databases: NameList(sqlDollar[2].strs)}
 		}
 	case 78:
 		sqlDollar = sqlS[sqlpt-1 : sqlpt+1]
-		//line sql.y:717
+		//line sql.y:718
 		{
 			sqlVAL.privilegeList = privilege.List{privilege.ALL}
 		}
 	case 79:
 		sqlDollar = sqlS[sqlpt-1 : sqlpt+1]
-		//line sql.y:720
+		//line sql.y:721
 		{
 		}
 	case 80:
 		sqlDollar = sqlS[sqlpt-1 : sqlpt+1]
-		//line sql.y:724
+		//line sql.y:725
 		{
 			sqlVAL.privilegeList = privilege.List{sqlDollar[1].privilegeType}
 		}
 	case 81:
 		sqlDollar = sqlS[sqlpt-3 : sqlpt+1]
-		//line sql.y:728
+		//line sql.y:729
 		{
 			sqlVAL.privilegeList = append(sqlDollar[1].privilegeList, sqlDollar[3].privilegeType)
 		}
 	case 82:
 		sqlDollar = sqlS[sqlpt-1 : sqlpt+1]
-		//line sql.y:735
+		//line sql.y:736
 		{
 			sqlVAL.privilegeType = privilege.CREATE
 		}
 	case 83:
 		sqlDollar = sqlS[sqlpt-1 : sqlpt+1]
-		//line sql.y:739
+		//line sql.y:740
 		{
 			sqlVAL.privilegeType = privilege.DROP
 		}
 	case 84:
 		sqlDollar = sqlS[sqlpt-1 : sqlpt+1]
-		//line sql.y:743
+		//line sql.y:744
 		{
 			sqlVAL.privilegeType = privilege.GRANT
 		}
 	case 85:
 		sqlDollar = sqlS[sqlpt-1 : sqlpt+1]
-		//line sql.y:747
+		//line sql.y:748
 		{
 			sqlVAL.privilegeType = privilege.SELECT
 		}
 	case 86:
 		sqlDollar = sqlS[sqlpt-1 : sqlpt+1]
-		//line sql.y:751
+		//line sql.y:752
 		{
 			sqlVAL.privilegeType = privilege.INSERT
 		}
 	case 87:
 		sqlDollar = sqlS[sqlpt-1 : sqlpt+1]
-		//line sql.y:755
+		//line sql.y:756
 		{
 			sqlVAL.privilegeType = privilege.DELETE
 		}
 	case 88:
 		sqlDollar = sqlS[sqlpt-1 : sqlpt+1]
-		//line sql.y:759
+		//line sql.y:760
 		{
 			sqlVAL.privilegeType = privilege.UPDATE
 		}
 	case 89:
 		sqlDollar = sqlS[sqlpt-1 : sqlpt+1]
-		//line sql.y:767
+		//line sql.y:768
 		{
 			sqlVAL.strs = []string{sqlDollar[1].str}
 		}
 	case 90:
 		sqlDollar = sqlS[sqlpt-3 : sqlpt+1]
-		//line sql.y:771
+		//line sql.y:772
 		{
 			sqlVAL.strs = append(sqlDollar[1].strs, sqlDollar[3].str)
 		}
 	case 91:
 		sqlDollar = sqlS[sqlpt-2 : sqlpt+1]
-		//line sql.y:779
+		//line sql.y:780
 		{
 			sqlVAL.stmt = sqlDollar[2].stmt
 		}
 	case 92:
 		sqlDollar = sqlS[sqlpt-3 : sqlpt+1]
-		//line sql.y:783
+		//line sql.y:784
 		{
 			sqlVAL.stmt = sqlDollar[3].stmt
 		}
 	case 93:
 		sqlDollar = sqlS[sqlpt-3 : sqlpt+1]
-		//line sql.y:787
+		//line sql.y:788
 		{
 			sqlVAL.stmt = sqlDollar[3].stmt
 		}
 	case 94:
 		sqlDollar = sqlS[sqlpt-2 : sqlpt+1]
-		//line sql.y:793
+		//line sql.y:794
 		{
 			sqlVAL.stmt = &SetTransaction{Isolation: sqlDollar[2].isoLevel}
 		}
 	case 96:
 		sqlDollar = sqlS[sqlpt-3 : sqlpt+1]
-		//line sql.y:800
+		//line sql.y:801
 		{
 			sqlVAL.stmt = &Set{Name: sqlDollar[1].qname, Values: sqlDollar[3].exprs}
 		}
 	case 97:
 		sqlDollar = sqlS[sqlpt-3 : sqlpt+1]
-		//line sql.y:804
+		//line sql.y:805
 		{
 			sqlVAL.stmt = &Set{Name: sqlDollar[1].qname, Values: sqlDollar[3].exprs}
 		}
 	case 98:
 		sqlDollar = sqlS[sqlpt-3 : sqlpt+1]
-		//line sql.y:808
+		//line sql.y:809
 		{
 			sqlVAL.stmt = &Set{Name: sqlDollar[1].qname}
 		}
 	case 99:
 		sqlDollar = sqlS[sqlpt-3 : sqlpt+1]
-		//line sql.y:812
+		//line sql.y:813
 		{
 			sqlVAL.stmt = &Set{Name: sqlDollar[1].qname}
 		}
 	case 101:
 		sqlDollar = sqlS[sqlpt-3 : sqlpt+1]
-		//line sql.y:819
+		//line sql.y:820
 		{
 			unimplemented()
 		}
 	case 102:
 		sqlDollar = sqlS[sqlpt-3 : sqlpt+1]
-		//line sql.y:822
+		//line sql.y:823
 		{
 			sqlVAL.stmt = &SetTimeZone{Value: sqlDollar[3].expr}
 		}
 	case 103:
 		sqlDollar = sqlS[sqlpt-2 : sqlpt+1]
-		//line sql.y:825
+		//line sql.y:826
 		{
 			unimplemented()
 		}
 	case 105:
 		sqlDollar = sqlS[sqlpt-1 : sqlpt+1]
-		//line sql.y:832
+		//line sql.y:833
 		{
 			sqlVAL.exprs = []Expr{sqlDollar[1].expr}
 		}
 	case 106:
 		sqlDollar = sqlS[sqlpt-3 : sqlpt+1]
-		//line sql.y:836
+		//line sql.y:837
 		{
 			sqlVAL.exprs = append(sqlDollar[1].exprs, sqlDollar[3].expr)
 		}
 	case 109:
 		sqlDollar = sqlS[sqlpt-1 : sqlpt+1]
-		//line sql.y:844
+		//line sql.y:845
 		{
 			sqlVAL.expr = ValArg{name: sqlDollar[1].str}
 		}
 	case 110:
 		sqlDollar = sqlS[sqlpt-2 : sqlpt+1]
-		//line sql.y:850
+		//line sql.y:851
 		{
 			// Mapped to the closest supported isolation level.
 			sqlVAL.isoLevel = SnapshotIsolation
 		}
 	case 111:
 		sqlDollar = sqlS[sqlpt-2 : sqlpt+1]
-		//line sql.y:855
+		//line sql.y:856
 		{
 			// Mapped to the closest supported isolation level.
 			sqlVAL.isoLevel = SnapshotIsolation
 		}
 	case 112:
 		sqlDollar = sqlS[sqlpt-2 : sqlpt+1]
-		//line sql.y:860
+		//line sql.y:861
 		{
 			// Mapped to the closest supported isolation level.
 			sqlVAL.isoLevel = SnapshotIsolation
 		}
 	case 113:
 		sqlDollar = sqlS[sqlpt-1 : sqlpt+1]
-		//line sql.y:865
+		//line sql.y:866
 		{
 			sqlVAL.isoLevel = SnapshotIsolation
 		}
 	case 114:
 		sqlDollar = sqlS[sqlpt-1 : sqlpt+1]
-		//line sql.y:869
+		//line sql.y:870
 		{
 			sqlVAL.isoLevel = SerializableIsolation
 		}
 	case 115:
 		sqlDollar = sqlS[sqlpt-1 : sqlpt+1]
-		//line sql.y:875
+		//line sql.y:876
 		{
 			sqlVAL.expr = DBool(true)
 		}
 	case 116:
 		sqlDollar = sqlS[sqlpt-1 : sqlpt+1]
-		//line sql.y:879
+		//line sql.y:880
 		{
 			sqlVAL.expr = DBool(false)
 		}
 	case 117:
 		sqlDollar = sqlS[sqlpt-1 : sqlpt+1]
-		//line sql.y:883
+		//line sql.y:884
 		{
 			sqlVAL.expr = DString(sqlDollar[1].str)
 		}
 	case 119:
 		sqlDollar = sqlS[sqlpt-1 : sqlpt+1]
-		//line sql.y:898
+		//line sql.y:899
 		{
 			sqlVAL.expr = DString(sqlDollar[1].str)
 		}
 	case 120:
 		sqlDollar = sqlS[sqlpt-1 : sqlpt+1]
-		//line sql.y:902
+		//line sql.y:903
 		{
 			sqlVAL.expr = DString(sqlDollar[1].str)
 		}
 	case 121:
 		sqlDollar = sqlS[sqlpt-3 : sqlpt+1]
-		//line sql.y:906
+		//line sql.y:907
 		{
 			// TODO(pmattis): support opt_interval?
 			expr := &CastExpr{Expr: DString(sqlDollar[2].str), Type: sqlDollar[1].colType}
@@ -4399,248 +4399,248 @@ sqldefault:
 		}
 	case 123:
 		sqlDollar = sqlS[sqlpt-1 : sqlpt+1]
-		//line sql.y:923
+		//line sql.y:924
 		{
 			sqlVAL.expr = DString(sqlDollar[1].str)
 		}
 	case 124:
 		sqlDollar = sqlS[sqlpt-1 : sqlpt+1]
-		//line sql.y:927
+		//line sql.y:928
 		{
 			sqlVAL.expr = DString(sqlDollar[1].str)
 		}
 	case 125:
 		sqlDollar = sqlS[sqlpt-1 : sqlpt+1]
-		//line sql.y:932
+		//line sql.y:933
 		{
 			unimplemented()
 		}
 	case 126:
 		sqlDollar = sqlS[sqlpt-1 : sqlpt+1]
-		//line sql.y:933
+		//line sql.y:934
 		{
 			unimplemented()
 		}
 	case 127:
 		sqlDollar = sqlS[sqlpt-0 : sqlpt+1]
-		//line sql.y:934
+		//line sql.y:935
 		{
 		}
 	case 128:
 		sqlDollar = sqlS[sqlpt-1 : sqlpt+1]
-		//line sql.y:938
+		//line sql.y:939
 		{
 			sqlVAL.expr = DString(sqlDollar[1].str)
 		}
 	case 129:
 		sqlDollar = sqlS[sqlpt-1 : sqlpt+1]
-		//line sql.y:942
+		//line sql.y:943
 		{
 			sqlVAL.expr = DString(sqlDollar[1].str)
 		}
 	case 130:
 		sqlDollar = sqlS[sqlpt-2 : sqlpt+1]
-		//line sql.y:948
+		//line sql.y:949
 		{
 			sqlVAL.stmt = &Show{Name: sqlDollar[2].str}
 		}
 	case 131:
 		sqlDollar = sqlS[sqlpt-2 : sqlpt+1]
-		//line sql.y:952
+		//line sql.y:953
 		{
 			sqlVAL.stmt = &Show{Name: sqlDollar[2].str}
 		}
 	case 132:
 		sqlDollar = sqlS[sqlpt-4 : sqlpt+1]
-		//line sql.y:956
+		//line sql.y:957
 		{
 			sqlVAL.stmt = &ShowColumns{Table: sqlDollar[4].qname}
 		}
 	case 133:
 		sqlDollar = sqlS[sqlpt-2 : sqlpt+1]
-		//line sql.y:960
+		//line sql.y:961
 		{
 			sqlVAL.stmt = &ShowDatabases{}
 		}
 	case 134:
 		sqlDollar = sqlS[sqlpt-4 : sqlpt+1]
-		//line sql.y:964
+		//line sql.y:965
 		{
 			sqlVAL.stmt = &ShowGrants{Targets: sqlDollar[3].targetListPtr, Grantees: sqlDollar[4].strs}
 		}
 	case 135:
 		sqlDollar = sqlS[sqlpt-4 : sqlpt+1]
-		//line sql.y:968
+		//line sql.y:969
 		{
 			sqlVAL.stmt = &ShowIndex{Table: sqlDollar[4].qname}
 		}
 	case 136:
 		sqlDollar = sqlS[sqlpt-3 : sqlpt+1]
-		//line sql.y:972
+		//line sql.y:973
 		{
 			sqlVAL.stmt = &ShowTables{Name: sqlDollar[3].qname}
 		}
 	case 137:
 		sqlDollar = sqlS[sqlpt-3 : sqlpt+1]
-		//line sql.y:976
+		//line sql.y:977
 		{
 			sqlVAL.stmt = &Show{Name: "TIME ZONE"}
 		}
 	case 138:
 		sqlDollar = sqlS[sqlpt-4 : sqlpt+1]
-		//line sql.y:980
+		//line sql.y:981
 		{
 			sqlVAL.stmt = &Show{Name: "TRANSACTION ISOLATION LEVEL"}
 		}
 	case 139:
 		sqlDollar = sqlS[sqlpt-2 : sqlpt+1]
-		//line sql.y:984
+		//line sql.y:985
 		{
 			sqlVAL.stmt = nil
 		}
 	case 140:
 		sqlDollar = sqlS[sqlpt-2 : sqlpt+1]
-		//line sql.y:990
+		//line sql.y:991
 		{
 			sqlVAL.qname = sqlDollar[2].qname
 		}
 	case 141:
 		sqlDollar = sqlS[sqlpt-0 : sqlpt+1]
-		//line sql.y:994
+		//line sql.y:995
 		{
 			sqlVAL.qname = nil
 		}
 	case 142:
 		sqlDollar = sqlS[sqlpt-2 : sqlpt+1]
-		//line sql.y:1000
+		//line sql.y:1001
 		{
 			tmp := sqlDollar[2].targetList
 			sqlVAL.targetListPtr = &tmp
 		}
 	case 143:
 		sqlDollar = sqlS[sqlpt-0 : sqlpt+1]
-		//line sql.y:1005
+		//line sql.y:1006
 		{
 			sqlVAL.targetListPtr = nil
 		}
 	case 144:
 		sqlDollar = sqlS[sqlpt-2 : sqlpt+1]
-		//line sql.y:1011
+		//line sql.y:1012
 		{
 			sqlVAL.strs = sqlDollar[2].strs
 		}
 	case 145:
 		sqlDollar = sqlS[sqlpt-0 : sqlpt+1]
-		//line sql.y:1015
+		//line sql.y:1016
 		{
 			sqlVAL.strs = nil
 		}
 	case 146:
 		sqlDollar = sqlS[sqlpt-6 : sqlpt+1]
-		//line sql.y:1022
+		//line sql.y:1023
 		{
 			sqlVAL.stmt = &CreateTable{Table: sqlDollar[3].qname, IfNotExists: false, Defs: sqlDollar[5].tblDefs}
 		}
 	case 147:
 		sqlDollar = sqlS[sqlpt-9 : sqlpt+1]
-		//line sql.y:1026
+		//line sql.y:1027
 		{
 			sqlVAL.stmt = &CreateTable{Table: sqlDollar[6].qname, IfNotExists: true, Defs: sqlDollar[8].tblDefs}
 		}
 	case 149:
 		sqlDollar = sqlS[sqlpt-0 : sqlpt+1]
-		//line sql.y:1033
+		//line sql.y:1034
 		{
 			sqlVAL.tblDefs = nil
 		}
 	case 150:
 		sqlDollar = sqlS[sqlpt-1 : sqlpt+1]
-		//line sql.y:1039
+		//line sql.y:1040
 		{
 			sqlVAL.tblDefs = TableDefs{sqlDollar[1].tblDef}
 		}
 	case 151:
 		sqlDollar = sqlS[sqlpt-3 : sqlpt+1]
-		//line sql.y:1043
+		//line sql.y:1044
 		{
 			sqlVAL.tblDefs = append(sqlDollar[1].tblDefs, sqlDollar[3].tblDef)
 		}
 	case 152:
 		sqlDollar = sqlS[sqlpt-1 : sqlpt+1]
-		//line sql.y:1049
+		//line sql.y:1050
 		{
 			sqlVAL.tblDef = sqlDollar[1].colDef
 		}
 	case 154:
 		sqlDollar = sqlS[sqlpt-1 : sqlpt+1]
-		//line sql.y:1054
+		//line sql.y:1055
 		{
 			sqlVAL.tblDef = sqlDollar[1].constraintDef
 		}
 	case 155:
 		sqlDollar = sqlS[sqlpt-3 : sqlpt+1]
-		//line sql.y:1060
+		//line sql.y:1061
 		{
 			sqlVAL.colDef = newColumnTableDef(Name(sqlDollar[1].str), sqlDollar[2].colType, sqlDollar[3].colQuals)
 		}
 	case 156:
 		sqlDollar = sqlS[sqlpt-2 : sqlpt+1]
-		//line sql.y:1066
+		//line sql.y:1067
 		{
 			sqlVAL.colQuals = append(sqlDollar[1].colQuals, sqlDollar[2].colQual)
 		}
 	case 157:
 		sqlDollar = sqlS[sqlpt-0 : sqlpt+1]
-		//line sql.y:1070
+		//line sql.y:1071
 		{
 			sqlVAL.colQuals = nil
 		}
 	case 158:
 		sqlDollar = sqlS[sqlpt-3 : sqlpt+1]
-		//line sql.y:1076
+		//line sql.y:1077
 		{
 			// TODO(pmattis): Handle constraint name.
 			sqlVAL.colQual = sqlDollar[3].colQual
 		}
 	case 160:
 		sqlDollar = sqlS[sqlpt-2 : sqlpt+1]
-		//line sql.y:1081
+		//line sql.y:1082
 		{
 			unimplemented()
 		}
 	case 161:
 		sqlDollar = sqlS[sqlpt-2 : sqlpt+1]
-		//line sql.y:1097
+		//line sql.y:1098
 		{
 			sqlVAL.colQual = NotNullConstraint{}
 		}
 	case 162:
 		sqlDollar = sqlS[sqlpt-1 : sqlpt+1]
-		//line sql.y:1101
+		//line sql.y:1102
 		{
 			sqlVAL.colQual = NullConstraint{}
 		}
 	case 163:
 		sqlDollar = sqlS[sqlpt-1 : sqlpt+1]
-		//line sql.y:1105
+		//line sql.y:1106
 		{
 			sqlVAL.colQual = UniqueConstraint{}
 		}
 	case 164:
 		sqlDollar = sqlS[sqlpt-2 : sqlpt+1]
-		//line sql.y:1109
+		//line sql.y:1110
 		{
 			sqlVAL.colQual = PrimaryKeyConstraint{}
 		}
 	case 165:
 		sqlDollar = sqlS[sqlpt-4 : sqlpt+1]
-		//line sql.y:1112
+		//line sql.y:1113
 		{
 			unimplemented()
 		}
 	case 166:
 		sqlDollar = sqlS[sqlpt-2 : sqlpt+1]
-		//line sql.y:1114
+		//line sql.y:1115
 		{
 			if ContainsVars(sqlDollar[2].expr) {
 				sqllex.Error("default expression contains a variable")
@@ -4654,13 +4654,13 @@ sqldefault:
 		}
 	case 167:
 		sqlDollar = sqlS[sqlpt-5 : sqlpt+1]
-		//line sql.y:1125
+		//line sql.y:1126
 		{
 			unimplemented()
 		}
 	case 168:
 		sqlDollar = sqlS[sqlpt-6 : sqlpt+1]
-		//line sql.y:1129
+		//line sql.y:1130
 		{
 			sqlVAL.tblDef = &IndexTableDef{
 				Name:    Name(sqlDollar[2].str),
@@ -4670,7 +4670,7 @@ sqldefault:
 		}
 	case 169:
 		sqlDollar = sqlS[sqlpt-7 : sqlpt+1]
-		//line sql.y:1137
+		//line sql.y:1138
 		{
 			sqlVAL.tblDef = &UniqueConstraintTableDef{
 				IndexTableDef: IndexTableDef{
@@ -4682,26 +4682,26 @@ sqldefault:
 		}
 	case 170:
 		sqlDollar = sqlS[sqlpt-3 : sqlpt+1]
-		//line sql.y:1152
+		//line sql.y:1153
 		{
 			sqlVAL.constraintDef = sqlDollar[3].constraintDef
 			sqlVAL.constraintDef.setName(Name(sqlDollar[2].str))
 		}
 	case 171:
 		sqlDollar = sqlS[sqlpt-1 : sqlpt+1]
-		//line sql.y:1157
+		//line sql.y:1158
 		{
 			sqlVAL.constraintDef = sqlDollar[1].constraintDef
 		}
 	case 172:
 		sqlDollar = sqlS[sqlpt-4 : sqlpt+1]
-		//line sql.y:1162
+		//line sql.y:1163
 		{
 			unimplemented()
 		}
 	case 173:
 		sqlDollar = sqlS[sqlpt-5 : sqlpt+1]
-		//line sql.y:1164
+		//line sql.y:1165
 		{
 			sqlVAL.constraintDef = &UniqueConstraintTableDef{
 				IndexTableDef: IndexTableDef{
@@ -4712,7 +4712,7 @@ sqldefault:
 		}
 	case 174:
 		sqlDollar = sqlS[sqlpt-5 : sqlpt+1]
-		//line sql.y:1173
+		//line sql.y:1174
 		{
 			sqlVAL.constraintDef = &UniqueConstraintTableDef{
 				IndexTableDef: IndexTableDef{
@@ -4723,155 +4723,155 @@ sqldefault:
 		}
 	case 175:
 		sqlDollar = sqlS[sqlpt-10 : sqlpt+1]
-		//line sql.y:1182
+		//line sql.y:1183
 		{
 			unimplemented()
 		}
 	case 178:
 		sqlDollar = sqlS[sqlpt-4 : sqlpt+1]
-		//line sql.y:1199
+		//line sql.y:1200
 		{
 			sqlVAL.strs = sqlDollar[3].strs
 		}
 	case 179:
 		sqlDollar = sqlS[sqlpt-0 : sqlpt+1]
-		//line sql.y:1203
+		//line sql.y:1204
 		{
 			sqlVAL.strs = nil
 		}
 	case 180:
 		sqlDollar = sqlS[sqlpt-3 : sqlpt+1]
-		//line sql.y:1209
+		//line sql.y:1210
 		{
 			sqlVAL.strs = sqlDollar[2].strs
 		}
 	case 181:
 		sqlDollar = sqlS[sqlpt-0 : sqlpt+1]
-		//line sql.y:1213
+		//line sql.y:1214
 		{
 			sqlVAL.strs = nil
 		}
 	case 182:
 		sqlDollar = sqlS[sqlpt-2 : sqlpt+1]
-		//line sql.y:1218
+		//line sql.y:1219
 		{
 			unimplemented()
 		}
 	case 183:
 		sqlDollar = sqlS[sqlpt-2 : sqlpt+1]
-		//line sql.y:1219
+		//line sql.y:1220
 		{
 			unimplemented()
 		}
 	case 184:
 		sqlDollar = sqlS[sqlpt-2 : sqlpt+1]
-		//line sql.y:1220
+		//line sql.y:1221
 		{
 			unimplemented()
 		}
 	case 185:
 		sqlDollar = sqlS[sqlpt-0 : sqlpt+1]
-		//line sql.y:1221
+		//line sql.y:1222
 		{
 		}
 	case 186:
-		sqlDollar = sqlS[sqlpt-1 : sqlpt+1]
-		//line sql.y:1228
-		{
-			unimplemented()
-		}
-	case 187:
 		sqlDollar = sqlS[sqlpt-1 : sqlpt+1]
 		//line sql.y:1229
 		{
 			unimplemented()
 		}
-	case 188:
-		sqlDollar = sqlS[sqlpt-2 : sqlpt+1]
+	case 187:
+		sqlDollar = sqlS[sqlpt-1 : sqlpt+1]
 		//line sql.y:1230
 		{
 			unimplemented()
 		}
-	case 189:
+	case 188:
 		sqlDollar = sqlS[sqlpt-2 : sqlpt+1]
 		//line sql.y:1231
 		{
 			unimplemented()
 		}
+	case 189:
+		sqlDollar = sqlS[sqlpt-2 : sqlpt+1]
+		//line sql.y:1232
+		{
+			unimplemented()
+		}
 	case 190:
 		sqlDollar = sqlS[sqlpt-0 : sqlpt+1]
-		//line sql.y:1232
+		//line sql.y:1233
 		{
 		}
 	case 191:
 		sqlDollar = sqlS[sqlpt-3 : sqlpt+1]
-		//line sql.y:1235
+		//line sql.y:1236
 		{
 			unimplemented()
 		}
 	case 192:
 		sqlDollar = sqlS[sqlpt-3 : sqlpt+1]
-		//line sql.y:1238
+		//line sql.y:1239
 		{
 			unimplemented()
 		}
 	case 193:
 		sqlDollar = sqlS[sqlpt-2 : sqlpt+1]
-		//line sql.y:1241
+		//line sql.y:1242
 		{
 			unimplemented()
 		}
 	case 194:
 		sqlDollar = sqlS[sqlpt-1 : sqlpt+1]
-		//line sql.y:1242
+		//line sql.y:1243
 		{
 			unimplemented()
 		}
 	case 195:
 		sqlDollar = sqlS[sqlpt-1 : sqlpt+1]
-		//line sql.y:1243
+		//line sql.y:1244
 		{
 			unimplemented()
 		}
 	case 196:
 		sqlDollar = sqlS[sqlpt-2 : sqlpt+1]
-		//line sql.y:1244
+		//line sql.y:1245
 		{
 			unimplemented()
 		}
 	case 197:
 		sqlDollar = sqlS[sqlpt-2 : sqlpt+1]
-		//line sql.y:1245
+		//line sql.y:1246
 		{
 			unimplemented()
 		}
 	case 198:
 		sqlDollar = sqlS[sqlpt-1 : sqlpt+1]
-		//line sql.y:1249
+		//line sql.y:1250
 		{
 			sqlVAL.expr = NumVal(sqlDollar[1].str)
 		}
 	case 199:
 		sqlDollar = sqlS[sqlpt-2 : sqlpt+1]
-		//line sql.y:1253
+		//line sql.y:1254
 		{
 			sqlVAL.expr = NumVal("-" + sqlDollar[2].str)
 		}
 	case 200:
 		sqlDollar = sqlS[sqlpt-1 : sqlpt+1]
-		//line sql.y:1257
+		//line sql.y:1258
 		{
 			sqlVAL.expr = DInt(sqlDollar[1].ival)
 		}
 	case 201:
 		sqlDollar = sqlS[sqlpt-4 : sqlpt+1]
-		//line sql.y:1264
+		//line sql.y:1265
 		{
 			sqlVAL.stmt = &Truncate{Tables: sqlDollar[3].qnames}
 		}
 	case 202:
 		sqlDollar = sqlS[sqlpt-10 : sqlpt+1]
-		//line sql.y:1271
+		//line sql.y:1272
 		{
 			sqlVAL.stmt = &CreateIndex{
 				Name:    Name(sqlDollar[4].str),
@@ -4883,7 +4883,7 @@ sqldefault:
 		}
 	case 203:
 		sqlDollar = sqlS[sqlpt-13 : sqlpt+1]
-		//line sql.y:1281
+		//line sql.y:1282
 		{
 			sqlVAL.stmt = &CreateIndex{
 				Name:        Name(sqlDollar[7].str),
@@ -4896,314 +4896,314 @@ sqldefault:
 		}
 	case 204:
 		sqlDollar = sqlS[sqlpt-1 : sqlpt+1]
-		//line sql.y:1294
+		//line sql.y:1295
 		{
 			sqlVAL.boolVal = true
 		}
 	case 205:
 		sqlDollar = sqlS[sqlpt-0 : sqlpt+1]
-		//line sql.y:1298
+		//line sql.y:1299
 		{
 			sqlVAL.boolVal = false
 		}
 	case 206:
 		sqlDollar = sqlS[sqlpt-1 : sqlpt+1]
-		//line sql.y:1304
+		//line sql.y:1305
 		{
 			sqlVAL.strs = []string{sqlDollar[1].str}
 		}
 	case 207:
 		sqlDollar = sqlS[sqlpt-3 : sqlpt+1]
-		//line sql.y:1308
+		//line sql.y:1309
 		{
 			sqlVAL.strs = append(sqlDollar[1].strs, sqlDollar[3].str)
 		}
 	case 208:
 		sqlDollar = sqlS[sqlpt-3 : sqlpt+1]
-		//line sql.y:1317
+		//line sql.y:1318
 		{
 			// TODO(pmattis): Support opt_asc_desc.
 			sqlVAL.str = sqlDollar[1].str
 		}
 	case 209:
 		sqlDollar = sqlS[sqlpt-3 : sqlpt+1]
-		//line sql.y:1321
+		//line sql.y:1322
 		{
 			unimplemented()
 		}
 	case 210:
 		sqlDollar = sqlS[sqlpt-5 : sqlpt+1]
-		//line sql.y:1322
+		//line sql.y:1323
 		{
 			unimplemented()
 		}
 	case 211:
 		sqlDollar = sqlS[sqlpt-2 : sqlpt+1]
-		//line sql.y:1325
+		//line sql.y:1326
 		{
 			unimplemented()
 		}
 	case 212:
 		sqlDollar = sqlS[sqlpt-0 : sqlpt+1]
-		//line sql.y:1326
+		//line sql.y:1327
 		{
 		}
 	case 213:
 		sqlDollar = sqlS[sqlpt-1 : sqlpt+1]
-		//line sql.y:1330
+		//line sql.y:1331
 		{
 			sqlVAL.dir = Ascending
 		}
 	case 214:
 		sqlDollar = sqlS[sqlpt-1 : sqlpt+1]
-		//line sql.y:1334
+		//line sql.y:1335
 		{
 			sqlVAL.dir = Descending
 		}
 	case 215:
 		sqlDollar = sqlS[sqlpt-0 : sqlpt+1]
-		//line sql.y:1338
+		//line sql.y:1339
 		{
 			sqlVAL.dir = DefaultDirection
 		}
 	case 216:
 		sqlDollar = sqlS[sqlpt-6 : sqlpt+1]
-		//line sql.y:1345
+		//line sql.y:1346
 		{
 			sqlVAL.stmt = &RenameDatabase{Name: Name(sqlDollar[3].str), NewName: Name(sqlDollar[6].str)}
 		}
 	case 217:
 		sqlDollar = sqlS[sqlpt-6 : sqlpt+1]
-		//line sql.y:1349
+		//line sql.y:1350
 		{
 			sqlVAL.stmt = &RenameTable{Name: sqlDollar[3].qname, NewName: sqlDollar[6].qname, IfExists: false}
 		}
 	case 218:
 		sqlDollar = sqlS[sqlpt-8 : sqlpt+1]
-		//line sql.y:1353
+		//line sql.y:1354
 		{
 			sqlVAL.stmt = &RenameTable{Name: sqlDollar[5].qname, NewName: sqlDollar[8].qname, IfExists: true}
 		}
 	case 219:
 		sqlDollar = sqlS[sqlpt-6 : sqlpt+1]
-		//line sql.y:1357
+		//line sql.y:1358
 		{
 			sqlVAL.stmt = &RenameIndex{Name: sqlDollar[3].qname, NewName: Name(sqlDollar[6].str), IfExists: false}
 		}
 	case 220:
 		sqlDollar = sqlS[sqlpt-8 : sqlpt+1]
-		//line sql.y:1361
+		//line sql.y:1362
 		{
 			sqlVAL.stmt = &RenameIndex{Name: sqlDollar[5].qname, NewName: Name(sqlDollar[8].str), IfExists: true}
 		}
 	case 221:
 		sqlDollar = sqlS[sqlpt-8 : sqlpt+1]
-		//line sql.y:1365
+		//line sql.y:1366
 		{
 			sqlVAL.stmt = &RenameColumn{Table: sqlDollar[3].qname, Name: Name(sqlDollar[6].str), NewName: Name(sqlDollar[8].str), IfExists: false}
 		}
 	case 222:
 		sqlDollar = sqlS[sqlpt-10 : sqlpt+1]
-		//line sql.y:1369
+		//line sql.y:1370
 		{
 			sqlVAL.stmt = &RenameColumn{Table: sqlDollar[5].qname, Name: Name(sqlDollar[8].str), NewName: Name(sqlDollar[10].str), IfExists: true}
 		}
 	case 223:
 		sqlDollar = sqlS[sqlpt-8 : sqlpt+1]
-		//line sql.y:1373
+		//line sql.y:1374
 		{
 			sqlVAL.stmt = nil
 		}
 	case 224:
 		sqlDollar = sqlS[sqlpt-10 : sqlpt+1]
-		//line sql.y:1377
+		//line sql.y:1378
 		{
 			sqlVAL.stmt = nil
 		}
 	case 225:
 		sqlDollar = sqlS[sqlpt-1 : sqlpt+1]
-		//line sql.y:1383
+		//line sql.y:1384
 		{
 			sqlVAL.boolVal = true
 		}
 	case 226:
 		sqlDollar = sqlS[sqlpt-0 : sqlpt+1]
-		//line sql.y:1387
+		//line sql.y:1388
 		{
 			sqlVAL.boolVal = false
 		}
 	case 227:
 		sqlDollar = sqlS[sqlpt-2 : sqlpt+1]
-		//line sql.y:1392
+		//line sql.y:1393
 		{
 		}
 	case 228:
 		sqlDollar = sqlS[sqlpt-0 : sqlpt+1]
-		//line sql.y:1393
+		//line sql.y:1394
 		{
 		}
 	case 229:
 		sqlDollar = sqlS[sqlpt-3 : sqlpt+1]
-		//line sql.y:1398
+		//line sql.y:1399
 		{
 			sqlVAL.stmt = &BeginTransaction{Isolation: sqlDollar[3].isoLevel}
 		}
 	case 230:
 		sqlDollar = sqlS[sqlpt-2 : sqlpt+1]
-		//line sql.y:1402
+		//line sql.y:1403
 		{
 			sqlVAL.stmt = &CommitTransaction{}
 		}
 	case 231:
 		sqlDollar = sqlS[sqlpt-2 : sqlpt+1]
-		//line sql.y:1406
+		//line sql.y:1407
 		{
 			sqlVAL.stmt = &RollbackTransaction{}
 		}
 	case 232:
 		sqlDollar = sqlS[sqlpt-1 : sqlpt+1]
-		//line sql.y:1411
+		//line sql.y:1412
 		{
 		}
 	case 233:
 		sqlDollar = sqlS[sqlpt-0 : sqlpt+1]
-		//line sql.y:1412
+		//line sql.y:1413
 		{
 		}
 	case 235:
 		sqlDollar = sqlS[sqlpt-0 : sqlpt+1]
-		//line sql.y:1417
+		//line sql.y:1418
 		{
 			sqlVAL.isoLevel = UnspecifiedIsolation
 		}
 	case 236:
 		sqlDollar = sqlS[sqlpt-3 : sqlpt+1]
-		//line sql.y:1423
+		//line sql.y:1424
 		{
 			sqlVAL.isoLevel = sqlDollar[3].isoLevel
 		}
 	case 237:
 		sqlDollar = sqlS[sqlpt-3 : sqlpt+1]
-		//line sql.y:1429
+		//line sql.y:1430
 		{
 			sqlVAL.stmt = &CreateDatabase{Name: Name(sqlDollar[3].str)}
 		}
 	case 238:
 		sqlDollar = sqlS[sqlpt-6 : sqlpt+1]
-		//line sql.y:1433
+		//line sql.y:1434
 		{
 			sqlVAL.stmt = &CreateDatabase{IfNotExists: true, Name: Name(sqlDollar[6].str)}
 		}
 	case 239:
 		sqlDollar = sqlS[sqlpt-6 : sqlpt+1]
-		//line sql.y:1439
+		//line sql.y:1440
 		{
 			sqlVAL.stmt = sqlDollar[5].stmt
 			sqlVAL.stmt.(*Insert).Table = sqlDollar[4].qname
 		}
 	case 242:
 		sqlDollar = sqlS[sqlpt-1 : sqlpt+1]
-		//line sql.y:1455
+		//line sql.y:1456
 		{
 			sqlVAL.stmt = &Insert{Rows: sqlDollar[1].selectStmt}
 		}
 	case 243:
 		sqlDollar = sqlS[sqlpt-4 : sqlpt+1]
-		//line sql.y:1459
+		//line sql.y:1460
 		{
 			sqlVAL.stmt = &Insert{Columns: sqlDollar[2].qnames, Rows: sqlDollar[4].selectStmt}
 		}
 	case 244:
 		sqlDollar = sqlS[sqlpt-2 : sqlpt+1]
-		//line sql.y:1463
+		//line sql.y:1464
 		{
 			sqlVAL.stmt = &Insert{}
 		}
 	case 245:
 		sqlDollar = sqlS[sqlpt-8 : sqlpt+1]
-		//line sql.y:1468
+		//line sql.y:1469
 		{
 			unimplemented()
 		}
 	case 246:
 		sqlDollar = sqlS[sqlpt-5 : sqlpt+1]
-		//line sql.y:1469
+		//line sql.y:1470
 		{
 			unimplemented()
 		}
 	case 247:
 		sqlDollar = sqlS[sqlpt-0 : sqlpt+1]
-		//line sql.y:1470
+		//line sql.y:1471
 		{
 		}
 	case 248:
 		sqlDollar = sqlS[sqlpt-4 : sqlpt+1]
-		//line sql.y:1473
+		//line sql.y:1474
 		{
 			unimplemented()
 		}
 	case 249:
 		sqlDollar = sqlS[sqlpt-3 : sqlpt+1]
-		//line sql.y:1474
+		//line sql.y:1475
 		{
 			unimplemented()
 		}
 	case 250:
 		sqlDollar = sqlS[sqlpt-0 : sqlpt+1]
-		//line sql.y:1475
+		//line sql.y:1476
 		{
 		}
 	case 251:
 		sqlDollar = sqlS[sqlpt-7 : sqlpt+1]
-		//line sql.y:1480
+		//line sql.y:1481
 		{
 			sqlVAL.stmt = &Update{Table: sqlDollar[3].tblExpr, Exprs: sqlDollar[5].updateExprs, Where: newWhere(astWhere, sqlDollar[7].expr)}
 		}
 	case 252:
 		sqlDollar = sqlS[sqlpt-1 : sqlpt+1]
-		//line sql.y:1486
+		//line sql.y:1487
 		{
 			sqlVAL.updateExprs = UpdateExprs{sqlDollar[1].updateExpr}
 		}
 	case 253:
 		sqlDollar = sqlS[sqlpt-3 : sqlpt+1]
-		//line sql.y:1490
+		//line sql.y:1491
 		{
 			sqlVAL.updateExprs = append(sqlDollar[1].updateExprs, sqlDollar[3].updateExpr)
 		}
 	case 256:
 		sqlDollar = sqlS[sqlpt-3 : sqlpt+1]
-		//line sql.y:1500
+		//line sql.y:1501
 		{
 			sqlVAL.updateExpr = &UpdateExpr{Names: QualifiedNames{sqlDollar[1].qname}, Expr: sqlDollar[3].expr}
 		}
 	case 257:
 		sqlDollar = sqlS[sqlpt-5 : sqlpt+1]
-		//line sql.y:1512
+		//line sql.y:1513
 		{
 			sqlVAL.updateExpr = &UpdateExpr{Tuple: true, Names: sqlDollar[2].qnames, Expr: Tuple(sqlDollar[5].exprs)}
 		}
 	case 258:
 		sqlDollar = sqlS[sqlpt-5 : sqlpt+1]
-		//line sql.y:1516
+		//line sql.y:1517
 		{
 			sqlVAL.updateExpr = &UpdateExpr{Tuple: true, Names: sqlDollar[2].qnames, Expr: &Subquery{Select: sqlDollar[5].selectStmt}}
 		}
 	case 261:
 		sqlDollar = sqlS[sqlpt-3 : sqlpt+1]
-		//line sql.y:1563
+		//line sql.y:1564
 		{
 			sqlVAL.selectStmt = &ParenSelect{Select: sqlDollar[2].selectStmt}
 		}
 	case 262:
 		sqlDollar = sqlS[sqlpt-3 : sqlpt+1]
-		//line sql.y:1567
+		//line sql.y:1568
 		{
 			sqlVAL.selectStmt = &ParenSelect{Select: sqlDollar[2].selectStmt}
 		}
 	case 264:
 		sqlDollar = sqlS[sqlpt-2 : sqlpt+1]
-		//line sql.y:1583
+		//line sql.y:1584
 		{
 			sqlVAL.selectStmt = sqlDollar[1].selectStmt
 			if s, ok := sqlVAL.selectStmt.(*Select); ok {
@@ -5212,7 +5212,7 @@ sqldefault:
 		}
 	case 265:
 		sqlDollar = sqlS[sqlpt-3 : sqlpt+1]
-		//line sql.y:1590
+		//line sql.y:1591
 		{
 			sqlVAL.selectStmt = sqlDollar[1].selectStmt
 			if s, ok := sqlVAL.selectStmt.(*Select); ok {
@@ -5222,13 +5222,13 @@ sqldefault:
 		}
 	case 266:
 		sqlDollar = sqlS[sqlpt-2 : sqlpt+1]
-		//line sql.y:1598
+		//line sql.y:1599
 		{
 			sqlVAL.selectStmt = sqlDollar[2].selectStmt
 		}
 	case 267:
 		sqlDollar = sqlS[sqlpt-3 : sqlpt+1]
-		//line sql.y:1602
+		//line sql.y:1603
 		{
 			sqlVAL.selectStmt = sqlDollar[2].selectStmt
 			if s, ok := sqlVAL.selectStmt.(*Select); ok {
@@ -5237,7 +5237,7 @@ sqldefault:
 		}
 	case 268:
 		sqlDollar = sqlS[sqlpt-4 : sqlpt+1]
-		//line sql.y:1609
+		//line sql.y:1610
 		{
 			sqlVAL.selectStmt = sqlDollar[2].selectStmt
 			if s, ok := sqlVAL.selectStmt.(*Select); ok {
@@ -5247,7 +5247,7 @@ sqldefault:
 		}
 	case 271:
 		sqlDollar = sqlS[sqlpt-8 : sqlpt+1]
-		//line sql.y:1647
+		//line sql.y:1648
 		{
 			sqlVAL.selectStmt = &Select{
 				Exprs:   sqlDollar[3].selExprs,
@@ -5259,7 +5259,7 @@ sqldefault:
 		}
 	case 272:
 		sqlDollar = sqlS[sqlpt-8 : sqlpt+1]
-		//line sql.y:1659
+		//line sql.y:1660
 		{
 			sqlVAL.selectStmt = &Select{
 				Distinct: sqlDollar[2].boolVal,
@@ -5272,7 +5272,7 @@ sqldefault:
 		}
 	case 274:
 		sqlDollar = sqlS[sqlpt-2 : sqlpt+1]
-		//line sql.y:1671
+		//line sql.y:1672
 		{
 			sqlVAL.selectStmt = &Select{
 				Exprs:       SelectExprs{StarSelectExpr()},
@@ -5282,7 +5282,7 @@ sqldefault:
 		}
 	case 275:
 		sqlDollar = sqlS[sqlpt-4 : sqlpt+1]
-		//line sql.y:1679
+		//line sql.y:1680
 		{
 			sqlVAL.selectStmt = &Union{
 				Type:  astUnion,
@@ -5293,7 +5293,7 @@ sqldefault:
 		}
 	case 276:
 		sqlDollar = sqlS[sqlpt-4 : sqlpt+1]
-		//line sql.y:1688
+		//line sql.y:1689
 		{
 			sqlVAL.selectStmt = &Union{
 				Type:  astIntersect,
@@ -5304,7 +5304,7 @@ sqldefault:
 		}
 	case 277:
 		sqlDollar = sqlS[sqlpt-4 : sqlpt+1]
-		//line sql.y:1697
+		//line sql.y:1698
 		{
 			sqlVAL.selectStmt = &Union{
 				Type:  astExcept,
@@ -5315,140 +5315,140 @@ sqldefault:
 		}
 	case 278:
 		sqlDollar = sqlS[sqlpt-2 : sqlpt+1]
-		//line sql.y:1715
+		//line sql.y:1716
 		{
 			unimplemented()
 		}
 	case 279:
 		sqlDollar = sqlS[sqlpt-2 : sqlpt+1]
-		//line sql.y:1716
+		//line sql.y:1717
 		{
 			unimplemented()
 		}
 	case 280:
 		sqlDollar = sqlS[sqlpt-3 : sqlpt+1]
-		//line sql.y:1717
+		//line sql.y:1718
 		{
 			unimplemented()
 		}
 	case 281:
 		sqlDollar = sqlS[sqlpt-1 : sqlpt+1]
-		//line sql.y:1720
+		//line sql.y:1721
 		{
 			unimplemented()
 		}
 	case 282:
 		sqlDollar = sqlS[sqlpt-3 : sqlpt+1]
-		//line sql.y:1721
+		//line sql.y:1722
 		{
 			unimplemented()
 		}
 	case 283:
 		sqlDollar = sqlS[sqlpt-6 : sqlpt+1]
-		//line sql.y:1724
+		//line sql.y:1725
 		{
 			unimplemented()
 		}
 	case 284:
 		sqlDollar = sqlS[sqlpt-1 : sqlpt+1]
-		//line sql.y:1728
+		//line sql.y:1729
 		{
 			sqlVAL.stmt = sqlDollar[1].selectStmt
 		}
 	case 288:
 		sqlDollar = sqlS[sqlpt-1 : sqlpt+1]
-		//line sql.y:1736
+		//line sql.y:1737
 		{
 			unimplemented()
 		}
 	case 289:
 		sqlDollar = sqlS[sqlpt-0 : sqlpt+1]
-		//line sql.y:1737
+		//line sql.y:1738
 		{
 		}
 	case 290:
 		sqlDollar = sqlS[sqlpt-1 : sqlpt+1]
-		//line sql.y:1740
+		//line sql.y:1741
 		{
 		}
 	case 291:
 		sqlDollar = sqlS[sqlpt-0 : sqlpt+1]
-		//line sql.y:1741
+		//line sql.y:1742
 		{
 		}
 	case 292:
 		sqlDollar = sqlS[sqlpt-1 : sqlpt+1]
-		//line sql.y:1745
+		//line sql.y:1746
 		{
 			sqlVAL.boolVal = true
 		}
 	case 293:
 		sqlDollar = sqlS[sqlpt-1 : sqlpt+1]
-		//line sql.y:1749
+		//line sql.y:1750
 		{
 			sqlVAL.boolVal = false
 		}
 	case 294:
 		sqlDollar = sqlS[sqlpt-0 : sqlpt+1]
-		//line sql.y:1753
+		//line sql.y:1754
 		{
 			sqlVAL.boolVal = false
 		}
 	case 295:
 		sqlDollar = sqlS[sqlpt-1 : sqlpt+1]
-		//line sql.y:1759
+		//line sql.y:1760
 		{
 			sqlVAL.boolVal = true
 		}
 	case 296:
 		sqlDollar = sqlS[sqlpt-1 : sqlpt+1]
-		//line sql.y:1764
+		//line sql.y:1765
 		{
 		}
 	case 297:
 		sqlDollar = sqlS[sqlpt-0 : sqlpt+1]
-		//line sql.y:1765
+		//line sql.y:1766
 		{
 		}
 	case 298:
 		sqlDollar = sqlS[sqlpt-1 : sqlpt+1]
-		//line sql.y:1769
+		//line sql.y:1770
 		{
 			sqlVAL.orderBy = sqlDollar[1].orderBy
 		}
 	case 299:
 		sqlDollar = sqlS[sqlpt-0 : sqlpt+1]
-		//line sql.y:1773
+		//line sql.y:1774
 		{
 			sqlVAL.orderBy = nil
 		}
 	case 300:
 		sqlDollar = sqlS[sqlpt-3 : sqlpt+1]
-		//line sql.y:1779
+		//line sql.y:1780
 		{
 			sqlVAL.orderBy = OrderBy(sqlDollar[3].orders)
 		}
 	case 301:
 		sqlDollar = sqlS[sqlpt-1 : sqlpt+1]
-		//line sql.y:1785
+		//line sql.y:1786
 		{
 			sqlVAL.orders = []*Order{sqlDollar[1].order}
 		}
 	case 302:
 		sqlDollar = sqlS[sqlpt-3 : sqlpt+1]
-		//line sql.y:1789
+		//line sql.y:1790
 		{
 			sqlVAL.orders = append(sqlDollar[1].orders, sqlDollar[3].order)
 		}
 	case 303:
 		sqlDollar = sqlS[sqlpt-2 : sqlpt+1]
-		//line sql.y:1795
+		//line sql.y:1796
 		{
 			sqlVAL.order = &Order{Expr: sqlDollar[1].expr, Direction: sqlDollar[2].dir}
 		}
 	case 304:
 		sqlDollar = sqlS[sqlpt-2 : sqlpt+1]
-		//line sql.y:1803
+		//line sql.y:1804
 		{
 			if sqlDollar[1].limit == nil {
 				sqlVAL.limit = sqlDollar[2].limit
@@ -5459,7 +5459,7 @@ sqldefault:
 		}
 	case 305:
 		sqlDollar = sqlS[sqlpt-2 : sqlpt+1]
-		//line sql.y:1812
+		//line sql.y:1813
 		{
 			sqlVAL.limit = sqlDollar[1].limit
 			if sqlDollar[2].limit != nil {
@@ -5468,7 +5468,7 @@ sqldefault:
 		}
 	case 308:
 		sqlDollar = sqlS[sqlpt-2 : sqlpt+1]
-		//line sql.y:1823
+		//line sql.y:1824
 		{
 			if sqlDollar[2].expr == nil {
 				sqlVAL.limit = nil
@@ -5478,1196 +5478,1196 @@ sqldefault:
 		}
 	case 309:
 		sqlDollar = sqlS[sqlpt-2 : sqlpt+1]
-		//line sql.y:1836
+		//line sql.y:1837
 		{
 			sqlVAL.limit = &Limit{Offset: sqlDollar[2].expr}
 		}
 	case 310:
 		sqlDollar = sqlS[sqlpt-3 : sqlpt+1]
-		//line sql.y:1843
+		//line sql.y:1844
 		{
 			sqlVAL.limit = &Limit{Offset: sqlDollar[2].expr}
 		}
 	case 312:
 		sqlDollar = sqlS[sqlpt-1 : sqlpt+1]
-		//line sql.y:1850
+		//line sql.y:1851
 		{
 			sqlVAL.expr = nil
 		}
 	case 313:
 		sqlDollar = sqlS[sqlpt-1 : sqlpt+1]
-		//line sql.y:1864
+		//line sql.y:1865
 		{
 		}
 	case 314:
 		sqlDollar = sqlS[sqlpt-1 : sqlpt+1]
-		//line sql.y:1865
+		//line sql.y:1866
 		{
 		}
 	case 315:
 		sqlDollar = sqlS[sqlpt-3 : sqlpt+1]
-		//line sql.y:1891
+		//line sql.y:1892
 		{
 			sqlVAL.groupBy = GroupBy(sqlDollar[3].exprs)
 		}
 	case 316:
 		sqlDollar = sqlS[sqlpt-0 : sqlpt+1]
-		//line sql.y:1895
+		//line sql.y:1896
 		{
 			sqlVAL.groupBy = nil
 		}
 	case 317:
 		sqlDollar = sqlS[sqlpt-2 : sqlpt+1]
-		//line sql.y:1901
+		//line sql.y:1902
 		{
 			sqlVAL.expr = sqlDollar[2].expr
 		}
 	case 318:
 		sqlDollar = sqlS[sqlpt-0 : sqlpt+1]
-		//line sql.y:1905
+		//line sql.y:1906
 		{
 			sqlVAL.expr = nil
 		}
 	case 319:
 		sqlDollar = sqlS[sqlpt-2 : sqlpt+1]
-		//line sql.y:1911
+		//line sql.y:1912
 		{
 			sqlVAL.selectStmt = Values{Tuple(sqlDollar[2].exprs)}
 		}
 	case 320:
 		sqlDollar = sqlS[sqlpt-3 : sqlpt+1]
-		//line sql.y:1915
+		//line sql.y:1916
 		{
 			sqlVAL.selectStmt = append(sqlDollar[1].selectStmt.(Values), Tuple(sqlDollar[3].exprs))
 		}
 	case 321:
 		sqlDollar = sqlS[sqlpt-2 : sqlpt+1]
-		//line sql.y:1925
+		//line sql.y:1926
 		{
 			sqlVAL.tblExprs = sqlDollar[2].tblExprs
 		}
 	case 322:
 		sqlDollar = sqlS[sqlpt-0 : sqlpt+1]
-		//line sql.y:1929
+		//line sql.y:1930
 		{
 			sqlVAL.tblExprs = nil
 		}
 	case 323:
 		sqlDollar = sqlS[sqlpt-1 : sqlpt+1]
-		//line sql.y:1935
+		//line sql.y:1936
 		{
 			sqlVAL.tblExprs = TableExprs{sqlDollar[1].tblExpr}
 		}
 	case 324:
 		sqlDollar = sqlS[sqlpt-3 : sqlpt+1]
-		//line sql.y:1939
+		//line sql.y:1940
 		{
 			sqlVAL.tblExprs = append(sqlDollar[1].tblExprs, sqlDollar[3].tblExpr)
 		}
 	case 325:
 		sqlDollar = sqlS[sqlpt-2 : sqlpt+1]
-		//line sql.y:1946
+		//line sql.y:1947
 		{
 			sqlVAL.tblExpr = &AliasedTableExpr{Expr: sqlDollar[1].qname, As: Name(sqlDollar[2].str)}
 		}
 	case 326:
 		sqlDollar = sqlS[sqlpt-2 : sqlpt+1]
-		//line sql.y:1950
+		//line sql.y:1951
 		{
 			sqlVAL.tblExpr = &AliasedTableExpr{Expr: &Subquery{Select: sqlDollar[1].selectStmt}, As: Name(sqlDollar[2].str)}
 		}
 	case 328:
 		sqlDollar = sqlS[sqlpt-4 : sqlpt+1]
-		//line sql.y:1954
+		//line sql.y:1955
 		{
 			unimplemented()
 		}
 	case 329:
 		sqlDollar = sqlS[sqlpt-3 : sqlpt+1]
-		//line sql.y:1972
+		//line sql.y:1973
 		{
 			sqlVAL.tblExpr = &ParenTableExpr{Expr: sqlDollar[2].tblExpr}
 		}
 	case 330:
 		sqlDollar = sqlS[sqlpt-4 : sqlpt+1]
-		//line sql.y:1976
+		//line sql.y:1977
 		{
 			sqlVAL.tblExpr = &JoinTableExpr{Join: astCrossJoin, Left: sqlDollar[1].tblExpr, Right: sqlDollar[4].tblExpr}
 		}
 	case 331:
 		sqlDollar = sqlS[sqlpt-5 : sqlpt+1]
-		//line sql.y:1980
+		//line sql.y:1981
 		{
 			sqlVAL.tblExpr = &JoinTableExpr{Join: sqlDollar[2].str, Left: sqlDollar[1].tblExpr, Right: sqlDollar[4].tblExpr, Cond: sqlDollar[5].joinCond}
 		}
 	case 332:
 		sqlDollar = sqlS[sqlpt-4 : sqlpt+1]
-		//line sql.y:1984
+		//line sql.y:1985
 		{
 			sqlVAL.tblExpr = &JoinTableExpr{Join: astJoin, Left: sqlDollar[1].tblExpr, Right: sqlDollar[3].tblExpr, Cond: sqlDollar[4].joinCond}
 		}
 	case 333:
 		sqlDollar = sqlS[sqlpt-5 : sqlpt+1]
-		//line sql.y:1988
+		//line sql.y:1989
 		{
 			sqlVAL.tblExpr = &JoinTableExpr{Join: astNaturalJoin, Left: sqlDollar[1].tblExpr, Right: sqlDollar[5].tblExpr}
 		}
 	case 334:
 		sqlDollar = sqlS[sqlpt-4 : sqlpt+1]
-		//line sql.y:1992
+		//line sql.y:1993
 		{
 			sqlVAL.tblExpr = &JoinTableExpr{Join: astNaturalJoin, Left: sqlDollar[1].tblExpr, Right: sqlDollar[4].tblExpr}
 		}
 	case 335:
 		sqlDollar = sqlS[sqlpt-5 : sqlpt+1]
-		//line sql.y:1997
+		//line sql.y:1998
 		{
 			unimplemented()
 		}
 	case 336:
 		sqlDollar = sqlS[sqlpt-2 : sqlpt+1]
-		//line sql.y:1999
+		//line sql.y:2000
 		{
 			sqlVAL.str = sqlDollar[2].str
 		}
 	case 337:
 		sqlDollar = sqlS[sqlpt-4 : sqlpt+1]
-		//line sql.y:2002
+		//line sql.y:2003
 		{
 			unimplemented()
 		}
 	case 338:
 		sqlDollar = sqlS[sqlpt-1 : sqlpt+1]
-		//line sql.y:2004
+		//line sql.y:2005
 		{
 			sqlVAL.str = sqlDollar[1].str
 		}
 	case 340:
 		sqlDollar = sqlS[sqlpt-0 : sqlpt+1]
-		//line sql.y:2011
+		//line sql.y:2012
 		{
 			sqlVAL.str = ""
 		}
 	case 341:
 		sqlDollar = sqlS[sqlpt-2 : sqlpt+1]
-		//line sql.y:2017
+		//line sql.y:2018
 		{
 			sqlVAL.str = astFullJoin
 		}
 	case 342:
 		sqlDollar = sqlS[sqlpt-2 : sqlpt+1]
-		//line sql.y:2021
+		//line sql.y:2022
 		{
 			sqlVAL.str = astLeftJoin
 		}
 	case 343:
 		sqlDollar = sqlS[sqlpt-2 : sqlpt+1]
-		//line sql.y:2025
+		//line sql.y:2026
 		{
 			sqlVAL.str = astRightJoin
 		}
 	case 344:
 		sqlDollar = sqlS[sqlpt-1 : sqlpt+1]
-		//line sql.y:2029
+		//line sql.y:2030
 		{
 			sqlVAL.str = astInnerJoin
 		}
 	case 345:
 		sqlDollar = sqlS[sqlpt-1 : sqlpt+1]
-		//line sql.y:2035
+		//line sql.y:2036
 		{
 		}
 	case 346:
 		sqlDollar = sqlS[sqlpt-0 : sqlpt+1]
-		//line sql.y:2036
+		//line sql.y:2037
 		{
 		}
 	case 347:
 		sqlDollar = sqlS[sqlpt-4 : sqlpt+1]
-		//line sql.y:2047
+		//line sql.y:2048
 		{
 			sqlVAL.joinCond = &UsingJoinCond{Cols: NameList(sqlDollar[3].strs)}
 		}
 	case 348:
 		sqlDollar = sqlS[sqlpt-2 : sqlpt+1]
-		//line sql.y:2051
+		//line sql.y:2052
 		{
 			sqlVAL.joinCond = &OnJoinCond{Expr: sqlDollar[2].expr}
 		}
 	case 349:
 		sqlDollar = sqlS[sqlpt-1 : sqlpt+1]
-		//line sql.y:2057
+		//line sql.y:2058
 		{
 			sqlVAL.qname = sqlDollar[1].qname
 		}
 	case 350:
 		sqlDollar = sqlS[sqlpt-2 : sqlpt+1]
-		//line sql.y:2061
+		//line sql.y:2062
 		{
 			// TODO(pmattis): Handle the "*".
 			sqlVAL.qname = sqlDollar[1].qname
 		}
 	case 351:
 		sqlDollar = sqlS[sqlpt-2 : sqlpt+1]
-		//line sql.y:2066
+		//line sql.y:2067
 		{
 			// TODO(pmattis): Support ONLY.
 			sqlVAL.qname = sqlDollar[2].qname
 		}
 	case 352:
 		sqlDollar = sqlS[sqlpt-4 : sqlpt+1]
-		//line sql.y:2071
+		//line sql.y:2072
 		{
 			// TODO(pmattis): Support ONLY.
 			sqlVAL.qname = sqlDollar[3].qname
 		}
 	case 353:
 		sqlDollar = sqlS[sqlpt-1 : sqlpt+1]
-		//line sql.y:2078
+		//line sql.y:2079
 		{
 			sqlVAL.qnames = QualifiedNames{sqlDollar[1].qname}
 		}
 	case 354:
 		sqlDollar = sqlS[sqlpt-3 : sqlpt+1]
-		//line sql.y:2082
+		//line sql.y:2083
 		{
 			sqlVAL.qnames = append(sqlDollar[1].qnames, sqlDollar[3].qname)
 		}
 	case 355:
 		sqlDollar = sqlS[sqlpt-1 : sqlpt+1]
-		//line sql.y:2095
+		//line sql.y:2096
 		{
 			sqlVAL.tblExpr = &AliasedTableExpr{Expr: sqlDollar[1].qname}
 		}
 	case 356:
 		sqlDollar = sqlS[sqlpt-2 : sqlpt+1]
-		//line sql.y:2099
+		//line sql.y:2100
 		{
 			sqlVAL.tblExpr = &AliasedTableExpr{Expr: sqlDollar[1].qname, As: Name(sqlDollar[2].str)}
 		}
 	case 357:
 		sqlDollar = sqlS[sqlpt-3 : sqlpt+1]
-		//line sql.y:2103
+		//line sql.y:2104
 		{
 			sqlVAL.tblExpr = &AliasedTableExpr{Expr: sqlDollar[1].qname, As: Name(sqlDollar[3].str)}
 		}
 	case 358:
 		sqlDollar = sqlS[sqlpt-2 : sqlpt+1]
-		//line sql.y:2109
+		//line sql.y:2110
 		{
 			sqlVAL.expr = sqlDollar[2].expr
 		}
 	case 359:
 		sqlDollar = sqlS[sqlpt-0 : sqlpt+1]
-		//line sql.y:2113
+		//line sql.y:2114
 		{
 			sqlVAL.expr = nil
 		}
 	case 360:
 		sqlDollar = sqlS[sqlpt-2 : sqlpt+1]
-		//line sql.y:2125
+		//line sql.y:2126
 		{
 			sqlVAL.colType = sqlDollar[1].colType
 		}
 	case 361:
 		sqlDollar = sqlS[sqlpt-5 : sqlpt+1]
-		//line sql.y:2129
+		//line sql.y:2130
 		{
 			unimplemented()
 		}
 	case 362:
 		sqlDollar = sqlS[sqlpt-2 : sqlpt+1]
-		//line sql.y:2130
+		//line sql.y:2131
 		{
 			unimplemented()
 		}
 	case 363:
 		sqlDollar = sqlS[sqlpt-3 : sqlpt+1]
-		//line sql.y:2133
+		//line sql.y:2134
 		{
 			unimplemented()
 		}
 	case 364:
 		sqlDollar = sqlS[sqlpt-4 : sqlpt+1]
-		//line sql.y:2134
+		//line sql.y:2135
 		{
 			unimplemented()
 		}
 	case 365:
 		sqlDollar = sqlS[sqlpt-0 : sqlpt+1]
-		//line sql.y:2135
+		//line sql.y:2136
 		{
 		}
 	case 371:
 		sqlDollar = sqlS[sqlpt-4 : sqlpt+1]
-		//line sql.y:2143
+		//line sql.y:2144
 		{
 			unimplemented()
 		}
 	case 372:
 		sqlDollar = sqlS[sqlpt-1 : sqlpt+1]
-		//line sql.y:2145
+		//line sql.y:2146
 		{
 			sqlVAL.colType = &BytesType{Name: "BLOB"}
 		}
 	case 373:
 		sqlDollar = sqlS[sqlpt-1 : sqlpt+1]
-		//line sql.y:2149
+		//line sql.y:2150
 		{
 			sqlVAL.colType = &BytesType{Name: "BYTES"}
 		}
 	case 374:
 		sqlDollar = sqlS[sqlpt-1 : sqlpt+1]
-		//line sql.y:2153
+		//line sql.y:2154
 		{
 			sqlVAL.colType = &StringType{Name: "TEXT"}
 		}
 	case 375:
 		sqlDollar = sqlS[sqlpt-1 : sqlpt+1]
-		//line sql.y:2157
+		//line sql.y:2158
 		{
 			sqlVAL.colType = &StringType{Name: "STRING"}
 		}
 	case 380:
 		sqlDollar = sqlS[sqlpt-3 : sqlpt+1]
-		//line sql.y:2178
+		//line sql.y:2179
 		{
 			sqlVAL.colType = &DecimalType{Prec: int(sqlDollar[2].ival)}
 		}
 	case 381:
 		sqlDollar = sqlS[sqlpt-5 : sqlpt+1]
-		//line sql.y:2182
+		//line sql.y:2183
 		{
 			sqlVAL.colType = &DecimalType{Prec: int(sqlDollar[2].ival), Scale: int(sqlDollar[4].ival)}
 		}
 	case 382:
 		sqlDollar = sqlS[sqlpt-0 : sqlpt+1]
-		//line sql.y:2186
+		//line sql.y:2187
 		{
 			sqlVAL.colType = &DecimalType{}
 		}
 	case 383:
 		sqlDollar = sqlS[sqlpt-1 : sqlpt+1]
-		//line sql.y:2193
+		//line sql.y:2194
 		{
 			sqlVAL.colType = &IntType{Name: "INT"}
 		}
 	case 384:
 		sqlDollar = sqlS[sqlpt-1 : sqlpt+1]
-		//line sql.y:2197
+		//line sql.y:2198
 		{
 			sqlVAL.colType = &IntType{Name: "INT64"}
 		}
 	case 385:
 		sqlDollar = sqlS[sqlpt-1 : sqlpt+1]
-		//line sql.y:2201
+		//line sql.y:2202
 		{
 			sqlVAL.colType = &IntType{Name: "INTEGER"}
 		}
 	case 386:
 		sqlDollar = sqlS[sqlpt-1 : sqlpt+1]
-		//line sql.y:2205
+		//line sql.y:2206
 		{
 			sqlVAL.colType = &IntType{Name: "SMALLINT"}
 		}
 	case 387:
 		sqlDollar = sqlS[sqlpt-1 : sqlpt+1]
-		//line sql.y:2209
+		//line sql.y:2210
 		{
 			sqlVAL.colType = &IntType{Name: "BIGINT"}
 		}
 	case 388:
 		sqlDollar = sqlS[sqlpt-1 : sqlpt+1]
-		//line sql.y:2213
+		//line sql.y:2214
 		{
 			sqlVAL.colType = &FloatType{Name: "REAL"}
 		}
 	case 389:
 		sqlDollar = sqlS[sqlpt-2 : sqlpt+1]
-		//line sql.y:2217
+		//line sql.y:2218
 		{
 			sqlVAL.colType = &FloatType{Name: "FLOAT", Prec: int(sqlDollar[2].ival)}
 		}
 	case 390:
 		sqlDollar = sqlS[sqlpt-2 : sqlpt+1]
-		//line sql.y:2221
+		//line sql.y:2222
 		{
 			sqlVAL.colType = &FloatType{Name: "DOUBLE PRECISION"}
 		}
 	case 391:
 		sqlDollar = sqlS[sqlpt-2 : sqlpt+1]
-		//line sql.y:2225
+		//line sql.y:2226
 		{
 			sqlVAL.colType = sqlDollar[2].colType
 			sqlVAL.colType.(*DecimalType).Name = "DECIMAL"
 		}
 	case 392:
 		sqlDollar = sqlS[sqlpt-2 : sqlpt+1]
-		//line sql.y:2230
+		//line sql.y:2231
 		{
 			sqlVAL.colType = sqlDollar[2].colType
 			sqlVAL.colType.(*DecimalType).Name = "DEC"
 		}
 	case 393:
 		sqlDollar = sqlS[sqlpt-2 : sqlpt+1]
-		//line sql.y:2235
+		//line sql.y:2236
 		{
 			sqlVAL.colType = sqlDollar[2].colType
 			sqlVAL.colType.(*DecimalType).Name = "NUMERIC"
 		}
 	case 394:
 		sqlDollar = sqlS[sqlpt-1 : sqlpt+1]
-		//line sql.y:2240
+		//line sql.y:2241
 		{
 			sqlVAL.colType = &BoolType{Name: "BOOLEAN"}
 		}
 	case 395:
 		sqlDollar = sqlS[sqlpt-1 : sqlpt+1]
-		//line sql.y:2244
+		//line sql.y:2245
 		{
 			sqlVAL.colType = &BoolType{Name: "BOOL"}
 		}
 	case 396:
 		sqlDollar = sqlS[sqlpt-3 : sqlpt+1]
-		//line sql.y:2250
+		//line sql.y:2251
 		{
 			sqlVAL.ival = sqlDollar[2].ival
 		}
 	case 397:
 		sqlDollar = sqlS[sqlpt-0 : sqlpt+1]
-		//line sql.y:2254
+		//line sql.y:2255
 		{
 			sqlVAL.ival = 0
 		}
 	case 402:
 		sqlDollar = sqlS[sqlpt-5 : sqlpt+1]
-		//line sql.y:2272
+		//line sql.y:2273
 		{
 			sqlVAL.colType = &IntType{Name: "BIT", N: int(sqlDollar[4].ival)}
 		}
 	case 403:
 		sqlDollar = sqlS[sqlpt-2 : sqlpt+1]
-		//line sql.y:2278
+		//line sql.y:2279
 		{
 			sqlVAL.colType = &IntType{Name: "BIT"}
 		}
 	case 408:
 		sqlDollar = sqlS[sqlpt-4 : sqlpt+1]
-		//line sql.y:2294
+		//line sql.y:2295
 		{
 			sqlVAL.colType = sqlDollar[1].colType
 			sqlVAL.colType.(*StringType).N = int(sqlDollar[3].ival)
 		}
 	case 409:
 		sqlDollar = sqlS[sqlpt-1 : sqlpt+1]
-		//line sql.y:2301
+		//line sql.y:2302
 		{
 			sqlVAL.colType = sqlDollar[1].colType
 		}
 	case 410:
 		sqlDollar = sqlS[sqlpt-2 : sqlpt+1]
-		//line sql.y:2307
+		//line sql.y:2308
 		{
 			sqlVAL.colType = &StringType{Name: "CHAR"}
 		}
 	case 411:
 		sqlDollar = sqlS[sqlpt-2 : sqlpt+1]
-		//line sql.y:2311
+		//line sql.y:2312
 		{
 			sqlVAL.colType = &StringType{Name: "CHAR"}
 		}
 	case 412:
 		sqlDollar = sqlS[sqlpt-1 : sqlpt+1]
-		//line sql.y:2315
+		//line sql.y:2316
 		{
 			sqlVAL.colType = &StringType{Name: "VARCHAR"}
 		}
 	case 413:
 		sqlDollar = sqlS[sqlpt-1 : sqlpt+1]
-		//line sql.y:2320
+		//line sql.y:2321
 		{
 		}
 	case 414:
 		sqlDollar = sqlS[sqlpt-0 : sqlpt+1]
-		//line sql.y:2321
+		//line sql.y:2322
 		{
 		}
 	case 415:
 		sqlDollar = sqlS[sqlpt-1 : sqlpt+1]
-		//line sql.y:2326
+		//line sql.y:2327
 		{
 			sqlVAL.colType = &DateType{}
 		}
 	case 416:
 		sqlDollar = sqlS[sqlpt-1 : sqlpt+1]
-		//line sql.y:2330
+		//line sql.y:2331
 		{
 			sqlVAL.colType = &TimestampType{}
 		}
 	case 417:
 		sqlDollar = sqlS[sqlpt-1 : sqlpt+1]
-		//line sql.y:2335
+		//line sql.y:2336
 		{
 			sqlVAL.colType = &IntervalType{}
 		}
 	case 418:
 		sqlDollar = sqlS[sqlpt-1 : sqlpt+1]
-		//line sql.y:2340
+		//line sql.y:2341
 		{
 			unimplemented()
 		}
 	case 419:
 		sqlDollar = sqlS[sqlpt-1 : sqlpt+1]
-		//line sql.y:2341
+		//line sql.y:2342
 		{
 			unimplemented()
 		}
 	case 420:
 		sqlDollar = sqlS[sqlpt-1 : sqlpt+1]
-		//line sql.y:2342
+		//line sql.y:2343
 		{
 			unimplemented()
 		}
 	case 421:
 		sqlDollar = sqlS[sqlpt-1 : sqlpt+1]
-		//line sql.y:2343
+		//line sql.y:2344
 		{
 			unimplemented()
 		}
 	case 422:
 		sqlDollar = sqlS[sqlpt-1 : sqlpt+1]
-		//line sql.y:2344
+		//line sql.y:2345
 		{
 			unimplemented()
 		}
 	case 423:
 		sqlDollar = sqlS[sqlpt-1 : sqlpt+1]
-		//line sql.y:2345
+		//line sql.y:2346
 		{
 			unimplemented()
 		}
 	case 424:
 		sqlDollar = sqlS[sqlpt-3 : sqlpt+1]
-		//line sql.y:2346
+		//line sql.y:2347
 		{
 			unimplemented()
 		}
 	case 425:
 		sqlDollar = sqlS[sqlpt-3 : sqlpt+1]
-		//line sql.y:2347
+		//line sql.y:2348
 		{
 			unimplemented()
 		}
 	case 426:
 		sqlDollar = sqlS[sqlpt-3 : sqlpt+1]
-		//line sql.y:2348
+		//line sql.y:2349
 		{
 			unimplemented()
 		}
 	case 427:
 		sqlDollar = sqlS[sqlpt-3 : sqlpt+1]
-		//line sql.y:2349
+		//line sql.y:2350
 		{
 			unimplemented()
 		}
 	case 428:
 		sqlDollar = sqlS[sqlpt-3 : sqlpt+1]
-		//line sql.y:2350
+		//line sql.y:2351
 		{
 			unimplemented()
 		}
 	case 429:
 		sqlDollar = sqlS[sqlpt-3 : sqlpt+1]
-		//line sql.y:2351
+		//line sql.y:2352
 		{
 			unimplemented()
 		}
 	case 430:
 		sqlDollar = sqlS[sqlpt-3 : sqlpt+1]
-		//line sql.y:2352
+		//line sql.y:2353
 		{
 			unimplemented()
 		}
 	case 431:
 		sqlDollar = sqlS[sqlpt-0 : sqlpt+1]
-		//line sql.y:2353
+		//line sql.y:2354
 		{
 		}
 	case 432:
 		sqlDollar = sqlS[sqlpt-1 : sqlpt+1]
-		//line sql.y:2356
+		//line sql.y:2357
 		{
 			unimplemented()
 		}
 	case 433:
 		sqlDollar = sqlS[sqlpt-4 : sqlpt+1]
-		//line sql.y:2357
+		//line sql.y:2358
 		{
 			unimplemented()
 		}
 	case 435:
 		sqlDollar = sqlS[sqlpt-3 : sqlpt+1]
-		//line sql.y:2381
+		//line sql.y:2382
 		{
 			sqlVAL.expr = &CastExpr{Expr: sqlDollar[1].expr, Type: sqlDollar[3].colType}
 		}
 	case 436:
 		sqlDollar = sqlS[sqlpt-3 : sqlpt+1]
-		//line sql.y:2384
+		//line sql.y:2385
 		{
 			unimplemented()
 		}
 	case 437:
 		sqlDollar = sqlS[sqlpt-5 : sqlpt+1]
-		//line sql.y:2385
+		//line sql.y:2386
 		{
 			unimplemented()
 		}
 	case 438:
 		sqlDollar = sqlS[sqlpt-2 : sqlpt+1]
-		//line sql.y:2394
+		//line sql.y:2395
 		{
 			sqlVAL.expr = &UnaryExpr{Operator: UnaryPlus, Expr: sqlDollar[2].expr}
 		}
 	case 439:
 		sqlDollar = sqlS[sqlpt-2 : sqlpt+1]
-		//line sql.y:2398
+		//line sql.y:2399
 		{
 			sqlVAL.expr = &UnaryExpr{Operator: UnaryMinus, Expr: sqlDollar[2].expr}
 		}
 	case 440:
 		sqlDollar = sqlS[sqlpt-2 : sqlpt+1]
-		//line sql.y:2402
+		//line sql.y:2403
 		{
 			sqlVAL.expr = &UnaryExpr{Operator: UnaryComplement, Expr: sqlDollar[2].expr}
 		}
 	case 441:
 		sqlDollar = sqlS[sqlpt-3 : sqlpt+1]
-		//line sql.y:2406
+		//line sql.y:2407
 		{
 			sqlVAL.expr = &BinaryExpr{Operator: Plus, Left: sqlDollar[1].expr, Right: sqlDollar[3].expr}
 		}
 	case 442:
 		sqlDollar = sqlS[sqlpt-3 : sqlpt+1]
-		//line sql.y:2410
+		//line sql.y:2411
 		{
 			sqlVAL.expr = &BinaryExpr{Operator: Minus, Left: sqlDollar[1].expr, Right: sqlDollar[3].expr}
 		}
 	case 443:
 		sqlDollar = sqlS[sqlpt-3 : sqlpt+1]
-		//line sql.y:2414
+		//line sql.y:2415
 		{
 			sqlVAL.expr = &BinaryExpr{Operator: Mult, Left: sqlDollar[1].expr, Right: sqlDollar[3].expr}
 		}
 	case 444:
 		sqlDollar = sqlS[sqlpt-3 : sqlpt+1]
-		//line sql.y:2418
+		//line sql.y:2419
 		{
 			sqlVAL.expr = &BinaryExpr{Operator: Div, Left: sqlDollar[1].expr, Right: sqlDollar[3].expr}
 		}
 	case 445:
 		sqlDollar = sqlS[sqlpt-3 : sqlpt+1]
-		//line sql.y:2422
+		//line sql.y:2423
 		{
 			sqlVAL.expr = &BinaryExpr{Operator: Mod, Left: sqlDollar[1].expr, Right: sqlDollar[3].expr}
 		}
 	case 446:
 		sqlDollar = sqlS[sqlpt-3 : sqlpt+1]
-		//line sql.y:2426
+		//line sql.y:2427
 		{
 			sqlVAL.expr = &BinaryExpr{Operator: Bitxor, Left: sqlDollar[1].expr, Right: sqlDollar[3].expr}
 		}
 	case 447:
 		sqlDollar = sqlS[sqlpt-3 : sqlpt+1]
-		//line sql.y:2430
+		//line sql.y:2431
 		{
 			sqlVAL.expr = &BinaryExpr{Operator: Bitxor, Left: sqlDollar[1].expr, Right: sqlDollar[3].expr}
 		}
 	case 448:
 		sqlDollar = sqlS[sqlpt-3 : sqlpt+1]
-		//line sql.y:2434
+		//line sql.y:2435
 		{
 			sqlVAL.expr = &BinaryExpr{Operator: Bitand, Left: sqlDollar[1].expr, Right: sqlDollar[3].expr}
 		}
 	case 449:
 		sqlDollar = sqlS[sqlpt-3 : sqlpt+1]
-		//line sql.y:2438
+		//line sql.y:2439
 		{
 			sqlVAL.expr = &BinaryExpr{Operator: Bitor, Left: sqlDollar[1].expr, Right: sqlDollar[3].expr}
 		}
 	case 450:
 		sqlDollar = sqlS[sqlpt-3 : sqlpt+1]
-		//line sql.y:2442
+		//line sql.y:2443
 		{
 			sqlVAL.expr = &ComparisonExpr{Operator: LT, Left: sqlDollar[1].expr, Right: sqlDollar[3].expr}
 		}
 	case 451:
 		sqlDollar = sqlS[sqlpt-3 : sqlpt+1]
-		//line sql.y:2446
+		//line sql.y:2447
 		{
 			sqlVAL.expr = &ComparisonExpr{Operator: GT, Left: sqlDollar[1].expr, Right: sqlDollar[3].expr}
 		}
 	case 452:
 		sqlDollar = sqlS[sqlpt-3 : sqlpt+1]
-		//line sql.y:2450
+		//line sql.y:2451
 		{
 			sqlVAL.expr = &ComparisonExpr{Operator: EQ, Left: sqlDollar[1].expr, Right: sqlDollar[3].expr}
 		}
 	case 453:
 		sqlDollar = sqlS[sqlpt-3 : sqlpt+1]
-		//line sql.y:2454
+		//line sql.y:2455
 		{
 			sqlVAL.expr = &BinaryExpr{Operator: Concat, Left: sqlDollar[1].expr, Right: sqlDollar[3].expr}
 		}
 	case 454:
 		sqlDollar = sqlS[sqlpt-3 : sqlpt+1]
-		//line sql.y:2458
+		//line sql.y:2459
 		{
 			sqlVAL.expr = &BinaryExpr{Operator: LShift, Left: sqlDollar[1].expr, Right: sqlDollar[3].expr}
 		}
 	case 455:
 		sqlDollar = sqlS[sqlpt-3 : sqlpt+1]
-		//line sql.y:2462
+		//line sql.y:2463
 		{
 			sqlVAL.expr = &BinaryExpr{Operator: RShift, Left: sqlDollar[1].expr, Right: sqlDollar[3].expr}
 		}
 	case 456:
 		sqlDollar = sqlS[sqlpt-3 : sqlpt+1]
-		//line sql.y:2466
+		//line sql.y:2467
 		{
 			sqlVAL.expr = &ComparisonExpr{Operator: LE, Left: sqlDollar[1].expr, Right: sqlDollar[3].expr}
 		}
 	case 457:
 		sqlDollar = sqlS[sqlpt-3 : sqlpt+1]
-		//line sql.y:2470
+		//line sql.y:2471
 		{
 			sqlVAL.expr = &ComparisonExpr{Operator: GE, Left: sqlDollar[1].expr, Right: sqlDollar[3].expr}
 		}
 	case 458:
 		sqlDollar = sqlS[sqlpt-3 : sqlpt+1]
-		//line sql.y:2474
+		//line sql.y:2475
 		{
 			sqlVAL.expr = &ComparisonExpr{Operator: NE, Left: sqlDollar[1].expr, Right: sqlDollar[3].expr}
 		}
 	case 459:
 		sqlDollar = sqlS[sqlpt-3 : sqlpt+1]
-		//line sql.y:2478
+		//line sql.y:2479
 		{
 			sqlVAL.expr = &AndExpr{Left: sqlDollar[1].expr, Right: sqlDollar[3].expr}
 		}
 	case 460:
 		sqlDollar = sqlS[sqlpt-3 : sqlpt+1]
-		//line sql.y:2482
+		//line sql.y:2483
 		{
 			sqlVAL.expr = &OrExpr{Left: sqlDollar[1].expr, Right: sqlDollar[3].expr}
 		}
 	case 461:
 		sqlDollar = sqlS[sqlpt-2 : sqlpt+1]
-		//line sql.y:2486
+		//line sql.y:2487
 		{
 			sqlVAL.expr = &NotExpr{Expr: sqlDollar[2].expr}
 		}
 	case 462:
 		sqlDollar = sqlS[sqlpt-2 : sqlpt+1]
-		//line sql.y:2490
+		//line sql.y:2491
 		{
 			sqlVAL.expr = &NotExpr{Expr: sqlDollar[2].expr}
 		}
 	case 463:
 		sqlDollar = sqlS[sqlpt-3 : sqlpt+1]
-		//line sql.y:2494
+		//line sql.y:2495
 		{
 			sqlVAL.expr = &ComparisonExpr{Operator: Like, Left: sqlDollar[1].expr, Right: sqlDollar[3].expr}
 		}
 	case 464:
 		sqlDollar = sqlS[sqlpt-4 : sqlpt+1]
-		//line sql.y:2498
+		//line sql.y:2499
 		{
 			sqlVAL.expr = &ComparisonExpr{Operator: NotLike, Left: sqlDollar[1].expr, Right: sqlDollar[4].expr}
 		}
 	case 465:
 		sqlDollar = sqlS[sqlpt-4 : sqlpt+1]
-		//line sql.y:2502
+		//line sql.y:2503
 		{
 			sqlVAL.expr = &ComparisonExpr{Operator: SimilarTo, Left: sqlDollar[1].expr, Right: sqlDollar[4].expr}
 		}
 	case 466:
 		sqlDollar = sqlS[sqlpt-5 : sqlpt+1]
-		//line sql.y:2506
+		//line sql.y:2507
 		{
 			sqlVAL.expr = &ComparisonExpr{Operator: NotSimilarTo, Left: sqlDollar[1].expr, Right: sqlDollar[5].expr}
 		}
 	case 467:
 		sqlDollar = sqlS[sqlpt-3 : sqlpt+1]
-		//line sql.y:2510
+		//line sql.y:2511
 		{
 			sqlVAL.expr = &ComparisonExpr{Operator: Is, Left: sqlDollar[1].expr, Right: DNull}
 		}
 	case 468:
 		sqlDollar = sqlS[sqlpt-4 : sqlpt+1]
-		//line sql.y:2514
+		//line sql.y:2515
 		{
 			sqlVAL.expr = &ComparisonExpr{Operator: IsNot, Left: sqlDollar[1].expr, Right: DNull}
 		}
 	case 469:
 		sqlDollar = sqlS[sqlpt-3 : sqlpt+1]
-		//line sql.y:2517
+		//line sql.y:2518
 		{
 			unimplemented()
 		}
 	case 470:
 		sqlDollar = sqlS[sqlpt-3 : sqlpt+1]
-		//line sql.y:2519
+		//line sql.y:2520
 		{
 			sqlVAL.expr = &ComparisonExpr{Operator: Is, Left: sqlDollar[1].expr, Right: DBool(true)}
 		}
 	case 471:
 		sqlDollar = sqlS[sqlpt-4 : sqlpt+1]
-		//line sql.y:2523
+		//line sql.y:2524
 		{
 			sqlVAL.expr = &ComparisonExpr{Operator: IsNot, Left: sqlDollar[1].expr, Right: DBool(true)}
 		}
 	case 472:
 		sqlDollar = sqlS[sqlpt-3 : sqlpt+1]
-		//line sql.y:2527
+		//line sql.y:2528
 		{
 			sqlVAL.expr = &ComparisonExpr{Operator: Is, Left: sqlDollar[1].expr, Right: DBool(false)}
 		}
 	case 473:
 		sqlDollar = sqlS[sqlpt-4 : sqlpt+1]
-		//line sql.y:2531
+		//line sql.y:2532
 		{
 			sqlVAL.expr = &ComparisonExpr{Operator: IsNot, Left: sqlDollar[1].expr, Right: DBool(false)}
 		}
 	case 474:
 		sqlDollar = sqlS[sqlpt-3 : sqlpt+1]
-		//line sql.y:2535
+		//line sql.y:2536
 		{
 			sqlVAL.expr = &ComparisonExpr{Operator: Is, Left: sqlDollar[1].expr, Right: DNull}
 		}
 	case 475:
 		sqlDollar = sqlS[sqlpt-4 : sqlpt+1]
-		//line sql.y:2539
+		//line sql.y:2540
 		{
 			sqlVAL.expr = &ComparisonExpr{Operator: IsNot, Left: sqlDollar[1].expr, Right: DNull}
 		}
 	case 476:
 		sqlDollar = sqlS[sqlpt-5 : sqlpt+1]
-		//line sql.y:2543
+		//line sql.y:2544
 		{
 			sqlVAL.expr = &ComparisonExpr{Operator: IsDistinctFrom, Left: sqlDollar[1].expr, Right: sqlDollar[5].expr}
 		}
 	case 477:
 		sqlDollar = sqlS[sqlpt-6 : sqlpt+1]
-		//line sql.y:2547
+		//line sql.y:2548
 		{
 			sqlVAL.expr = &ComparisonExpr{Operator: IsNotDistinctFrom, Left: sqlDollar[1].expr, Right: sqlDollar[6].expr}
 		}
 	case 478:
 		sqlDollar = sqlS[sqlpt-6 : sqlpt+1]
-		//line sql.y:2551
+		//line sql.y:2552
 		{
 			sqlVAL.expr = &IsOfTypeExpr{Expr: sqlDollar[1].expr, Types: sqlDollar[5].colTypes}
 		}
 	case 479:
 		sqlDollar = sqlS[sqlpt-7 : sqlpt+1]
-		//line sql.y:2555
+		//line sql.y:2556
 		{
 			sqlVAL.expr = &IsOfTypeExpr{Not: true, Expr: sqlDollar[1].expr, Types: sqlDollar[6].colTypes}
 		}
 	case 480:
 		sqlDollar = sqlS[sqlpt-6 : sqlpt+1]
-		//line sql.y:2559
+		//line sql.y:2560
 		{
 			sqlVAL.expr = &RangeCond{Left: sqlDollar[1].expr, From: sqlDollar[4].expr, To: sqlDollar[6].expr}
 		}
 	case 481:
 		sqlDollar = sqlS[sqlpt-7 : sqlpt+1]
-		//line sql.y:2563
+		//line sql.y:2564
 		{
 			sqlVAL.expr = &RangeCond{Not: true, Left: sqlDollar[1].expr, From: sqlDollar[5].expr, To: sqlDollar[7].expr}
 		}
 	case 482:
 		sqlDollar = sqlS[sqlpt-6 : sqlpt+1]
-		//line sql.y:2567
+		//line sql.y:2568
 		{
 			sqlVAL.expr = &RangeCond{Left: sqlDollar[1].expr, From: sqlDollar[4].expr, To: sqlDollar[6].expr}
 		}
 	case 483:
 		sqlDollar = sqlS[sqlpt-7 : sqlpt+1]
-		//line sql.y:2571
+		//line sql.y:2572
 		{
 			sqlVAL.expr = &RangeCond{Not: true, Left: sqlDollar[1].expr, From: sqlDollar[5].expr, To: sqlDollar[7].expr}
 		}
 	case 484:
 		sqlDollar = sqlS[sqlpt-3 : sqlpt+1]
-		//line sql.y:2575
+		//line sql.y:2576
 		{
 			sqlVAL.expr = &ComparisonExpr{Operator: In, Left: sqlDollar[1].expr, Right: sqlDollar[3].expr}
 		}
 	case 485:
 		sqlDollar = sqlS[sqlpt-4 : sqlpt+1]
-		//line sql.y:2579
+		//line sql.y:2580
 		{
 			sqlVAL.expr = &ComparisonExpr{Operator: NotIn, Left: sqlDollar[1].expr, Right: sqlDollar[4].expr}
 		}
 	case 487:
 		sqlDollar = sqlS[sqlpt-3 : sqlpt+1]
-		//line sql.y:2596
+		//line sql.y:2597
 		{
 			sqlVAL.expr = &CastExpr{Expr: sqlDollar[1].expr, Type: sqlDollar[3].colType}
 		}
 	case 488:
 		sqlDollar = sqlS[sqlpt-2 : sqlpt+1]
-		//line sql.y:2600
+		//line sql.y:2601
 		{
 			sqlVAL.expr = &UnaryExpr{Operator: UnaryPlus, Expr: sqlDollar[2].expr}
 		}
 	case 489:
 		sqlDollar = sqlS[sqlpt-2 : sqlpt+1]
-		//line sql.y:2604
+		//line sql.y:2605
 		{
 			sqlVAL.expr = &UnaryExpr{Operator: UnaryMinus, Expr: sqlDollar[2].expr}
 		}
 	case 490:
 		sqlDollar = sqlS[sqlpt-2 : sqlpt+1]
-		//line sql.y:2608
+		//line sql.y:2609
 		{
 			sqlVAL.expr = &UnaryExpr{Operator: UnaryComplement, Expr: sqlDollar[2].expr}
 		}
 	case 491:
 		sqlDollar = sqlS[sqlpt-3 : sqlpt+1]
-		//line sql.y:2612
+		//line sql.y:2613
 		{
 			sqlVAL.expr = &BinaryExpr{Operator: Plus, Left: sqlDollar[1].expr, Right: sqlDollar[3].expr}
 		}
 	case 492:
 		sqlDollar = sqlS[sqlpt-3 : sqlpt+1]
-		//line sql.y:2616
+		//line sql.y:2617
 		{
 			sqlVAL.expr = &BinaryExpr{Operator: Minus, Left: sqlDollar[1].expr, Right: sqlDollar[3].expr}
 		}
 	case 493:
 		sqlDollar = sqlS[sqlpt-3 : sqlpt+1]
-		//line sql.y:2620
+		//line sql.y:2621
 		{
 			sqlVAL.expr = &BinaryExpr{Operator: Mult, Left: sqlDollar[1].expr, Right: sqlDollar[3].expr}
 		}
 	case 494:
 		sqlDollar = sqlS[sqlpt-3 : sqlpt+1]
-		//line sql.y:2624
+		//line sql.y:2625
 		{
 			sqlVAL.expr = &BinaryExpr{Operator: Div, Left: sqlDollar[1].expr, Right: sqlDollar[3].expr}
 		}
 	case 495:
 		sqlDollar = sqlS[sqlpt-3 : sqlpt+1]
-		//line sql.y:2628
+		//line sql.y:2629
 		{
 			sqlVAL.expr = &BinaryExpr{Operator: Mod, Left: sqlDollar[1].expr, Right: sqlDollar[3].expr}
 		}
 	case 496:
 		sqlDollar = sqlS[sqlpt-3 : sqlpt+1]
-		//line sql.y:2632
+		//line sql.y:2633
 		{
 			sqlVAL.expr = &BinaryExpr{Operator: Bitxor, Left: sqlDollar[1].expr, Right: sqlDollar[3].expr}
 		}
 	case 497:
 		sqlDollar = sqlS[sqlpt-3 : sqlpt+1]
-		//line sql.y:2636
+		//line sql.y:2637
 		{
 			sqlVAL.expr = &BinaryExpr{Operator: Bitxor, Left: sqlDollar[1].expr, Right: sqlDollar[3].expr}
 		}
 	case 498:
 		sqlDollar = sqlS[sqlpt-3 : sqlpt+1]
-		//line sql.y:2640
+		//line sql.y:2641
 		{
 			sqlVAL.expr = &BinaryExpr{Operator: Bitand, Left: sqlDollar[1].expr, Right: sqlDollar[3].expr}
 		}
 	case 499:
 		sqlDollar = sqlS[sqlpt-3 : sqlpt+1]
-		//line sql.y:2644
+		//line sql.y:2645
 		{
 			sqlVAL.expr = &BinaryExpr{Operator: Bitor, Left: sqlDollar[1].expr, Right: sqlDollar[3].expr}
 		}
 	case 500:
 		sqlDollar = sqlS[sqlpt-3 : sqlpt+1]
-		//line sql.y:2648
+		//line sql.y:2649
 		{
 			sqlVAL.expr = &ComparisonExpr{Operator: LT, Left: sqlDollar[1].expr, Right: sqlDollar[3].expr}
 		}
 	case 501:
 		sqlDollar = sqlS[sqlpt-3 : sqlpt+1]
-		//line sql.y:2652
+		//line sql.y:2653
 		{
 			sqlVAL.expr = &ComparisonExpr{Operator: GT, Left: sqlDollar[1].expr, Right: sqlDollar[3].expr}
 		}
 	case 502:
 		sqlDollar = sqlS[sqlpt-3 : sqlpt+1]
-		//line sql.y:2656
+		//line sql.y:2657
 		{
 			sqlVAL.expr = &ComparisonExpr{Operator: EQ, Left: sqlDollar[1].expr, Right: sqlDollar[3].expr}
 		}
 	case 503:
 		sqlDollar = sqlS[sqlpt-3 : sqlpt+1]
-		//line sql.y:2660
+		//line sql.y:2661
 		{
 			sqlVAL.expr = &BinaryExpr{Operator: Concat, Left: sqlDollar[1].expr, Right: sqlDollar[3].expr}
 		}
 	case 504:
 		sqlDollar = sqlS[sqlpt-3 : sqlpt+1]
-		//line sql.y:2664
+		//line sql.y:2665
 		{
 			sqlVAL.expr = &BinaryExpr{Operator: LShift, Left: sqlDollar[1].expr, Right: sqlDollar[3].expr}
 		}
 	case 505:
 		sqlDollar = sqlS[sqlpt-3 : sqlpt+1]
-		//line sql.y:2668
+		//line sql.y:2669
 		{
 			sqlVAL.expr = &BinaryExpr{Operator: RShift, Left: sqlDollar[1].expr, Right: sqlDollar[3].expr}
 		}
 	case 506:
 		sqlDollar = sqlS[sqlpt-3 : sqlpt+1]
-		//line sql.y:2672
+		//line sql.y:2673
 		{
 			sqlVAL.expr = &ComparisonExpr{Operator: LE, Left: sqlDollar[1].expr, Right: sqlDollar[3].expr}
 		}
 	case 507:
 		sqlDollar = sqlS[sqlpt-3 : sqlpt+1]
-		//line sql.y:2676
+		//line sql.y:2677
 		{
 			sqlVAL.expr = &ComparisonExpr{Operator: GE, Left: sqlDollar[1].expr, Right: sqlDollar[3].expr}
 		}
 	case 508:
 		sqlDollar = sqlS[sqlpt-3 : sqlpt+1]
-		//line sql.y:2680
+		//line sql.y:2681
 		{
 			sqlVAL.expr = &ComparisonExpr{Operator: NE, Left: sqlDollar[1].expr, Right: sqlDollar[3].expr}
 		}
 	case 509:
 		sqlDollar = sqlS[sqlpt-5 : sqlpt+1]
-		//line sql.y:2684
+		//line sql.y:2685
 		{
 			sqlVAL.expr = &ComparisonExpr{Operator: IsDistinctFrom, Left: sqlDollar[1].expr, Right: sqlDollar[5].expr}
 		}
 	case 510:
 		sqlDollar = sqlS[sqlpt-6 : sqlpt+1]
-		//line sql.y:2688
+		//line sql.y:2689
 		{
 			sqlVAL.expr = &ComparisonExpr{Operator: IsNotDistinctFrom, Left: sqlDollar[1].expr, Right: sqlDollar[6].expr}
 		}
 	case 511:
 		sqlDollar = sqlS[sqlpt-6 : sqlpt+1]
-		//line sql.y:2692
+		//line sql.y:2693
 		{
 			sqlVAL.expr = &IsOfTypeExpr{Expr: sqlDollar[1].expr, Types: sqlDollar[5].colTypes}
 		}
 	case 512:
 		sqlDollar = sqlS[sqlpt-7 : sqlpt+1]
-		//line sql.y:2696
+		//line sql.y:2697
 		{
 			sqlVAL.expr = &IsOfTypeExpr{Not: true, Expr: sqlDollar[1].expr, Types: sqlDollar[6].colTypes}
 		}
 	case 513:
 		sqlDollar = sqlS[sqlpt-1 : sqlpt+1]
-		//line sql.y:2708
+		//line sql.y:2709
 		{
 			sqlVAL.expr = sqlDollar[1].qname
 		}
 	case 515:
 		sqlDollar = sqlS[sqlpt-1 : sqlpt+1]
-		//line sql.y:2713
+		//line sql.y:2714
 		{
 			sqlVAL.expr = ValArg{name: sqlDollar[1].str}
 		}
 	case 516:
 		sqlDollar = sqlS[sqlpt-3 : sqlpt+1]
-		//line sql.y:2717
+		//line sql.y:2718
 		{
 			sqlVAL.expr = &ParenExpr{Expr: sqlDollar[2].expr}
 		}
 	case 519:
 		sqlDollar = sqlS[sqlpt-1 : sqlpt+1]
-		//line sql.y:2723
+		//line sql.y:2724
 		{
 			sqlVAL.expr = &Subquery{Select: sqlDollar[1].selectStmt}
 		}
 	case 520:
 		sqlDollar = sqlS[sqlpt-2 : sqlpt+1]
-		//line sql.y:2727
+		//line sql.y:2728
 		{
 			sqlVAL.expr = &Subquery{Select: sqlDollar[1].selectStmt}
 		}
 	case 521:
 		sqlDollar = sqlS[sqlpt-2 : sqlpt+1]
-		//line sql.y:2731
+		//line sql.y:2732
 		{
 			sqlVAL.expr = &ExistsExpr{Subquery: &Subquery{Select: sqlDollar[2].selectStmt}}
 		}
 	case 522:
 		sqlDollar = sqlS[sqlpt-2 : sqlpt+1]
-		//line sql.y:2737
+		//line sql.y:2738
 		{
 			sqlVAL.expr = sqlDollar[2].expr
 		}
 	case 523:
 		sqlDollar = sqlS[sqlpt-1 : sqlpt+1]
-		//line sql.y:2741
+		//line sql.y:2742
 		{
 			sqlVAL.expr = sqlDollar[1].expr
 		}
 	case 524:
 		sqlDollar = sqlS[sqlpt-1 : sqlpt+1]
-		//line sql.y:2745
+		//line sql.y:2746
 		{
 			sqlVAL.expr = sqlDollar[1].expr
 		}
 	case 525:
 		sqlDollar = sqlS[sqlpt-3 : sqlpt+1]
-		//line sql.y:2753
+		//line sql.y:2754
 		{
 			sqlVAL.expr = &FuncExpr{Name: sqlDollar[1].qname}
 		}
 	case 526:
 		sqlDollar = sqlS[sqlpt-5 : sqlpt+1]
-		//line sql.y:2757
+		//line sql.y:2758
 		{
 			// TODO(pmattis): Support opt_sort_clause or remove it?
 			sqlVAL.expr = &FuncExpr{Name: sqlDollar[1].qname, Exprs: sqlDollar[3].exprs}
 		}
 	case 527:
 		sqlDollar = sqlS[sqlpt-6 : sqlpt+1]
-		//line sql.y:2761
+		//line sql.y:2762
 		{
 			unimplemented()
 		}
 	case 528:
 		sqlDollar = sqlS[sqlpt-8 : sqlpt+1]
-		//line sql.y:2762
+		//line sql.y:2763
 		{
 			unimplemented()
 		}
 	case 529:
 		sqlDollar = sqlS[sqlpt-6 : sqlpt+1]
-		//line sql.y:2763
+		//line sql.y:2764
 		{
 			unimplemented()
 		}
 	case 530:
 		sqlDollar = sqlS[sqlpt-6 : sqlpt+1]
-		//line sql.y:2765
+		//line sql.y:2766
 		{
 			// TODO(pmattis): Support opt_sort_clause or remove it?
 			sqlVAL.expr = &FuncExpr{Name: sqlDollar[1].qname, Distinct: true, Exprs: sqlDollar[4].exprs}
 		}
 	case 531:
 		sqlDollar = sqlS[sqlpt-4 : sqlpt+1]
-		//line sql.y:2770
+		//line sql.y:2771
 		{
 			sqlVAL.expr = &FuncExpr{Name: sqlDollar[1].qname, Exprs: Exprs{StarExpr()}}
 		}
 	case 532:
 		sqlDollar = sqlS[sqlpt-4 : sqlpt+1]
-		//line sql.y:2783
+		//line sql.y:2784
 		{
 			// TODO(pmattis): Support within_group_clause, filter_clause and
 			// over_clause?
@@ -6675,831 +6675,832 @@ sqldefault:
 		}
 	case 533:
 		sqlDollar = sqlS[sqlpt-1 : sqlpt+1]
-		//line sql.y:2789
+		//line sql.y:2790
 		{
 			sqlVAL.expr = sqlDollar[1].expr
 		}
 	case 534:
 		sqlDollar = sqlS[sqlpt-1 : sqlpt+1]
-		//line sql.y:2798
+		//line sql.y:2799
 		{
 			unimplemented()
 		}
 	case 535:
 		sqlDollar = sqlS[sqlpt-1 : sqlpt+1]
-		//line sql.y:2799
+		//line sql.y:2800
 		{
 			unimplemented()
 		}
 	case 536:
 		sqlDollar = sqlS[sqlpt-5 : sqlpt+1]
-		//line sql.y:2803
+		//line sql.y:2804
 		{
 			unimplemented()
 		}
 	case 537:
 		sqlDollar = sqlS[sqlpt-1 : sqlpt+1]
-		//line sql.y:2805
+		//line sql.y:2806
 		{
 			sqlVAL.expr = &FuncExpr{Name: &QualifiedName{Base: Name(sqlDollar[1].str)}}
 		}
 	case 538:
 		sqlDollar = sqlS[sqlpt-3 : sqlpt+1]
-		//line sql.y:2809
+		//line sql.y:2810
 		{
 			sqlVAL.expr = &FuncExpr{Name: &QualifiedName{Base: Name(sqlDollar[1].str)}}
 		}
 	case 539:
 		sqlDollar = sqlS[sqlpt-1 : sqlpt+1]
-		//line sql.y:2813
+		//line sql.y:2814
 		{
 			sqlVAL.expr = &FuncExpr{Name: &QualifiedName{Base: Name(sqlDollar[1].str)}}
 		}
 	case 540:
 		sqlDollar = sqlS[sqlpt-3 : sqlpt+1]
-		//line sql.y:2817
+		//line sql.y:2818
 		{
 			sqlVAL.expr = &FuncExpr{Name: &QualifiedName{Base: Name(sqlDollar[1].str)}}
 		}
 	case 541:
 		sqlDollar = sqlS[sqlpt-1 : sqlpt+1]
-		//line sql.y:2820
+		//line sql.y:2821
 		{
 			unimplemented()
 		}
 	case 542:
 		sqlDollar = sqlS[sqlpt-1 : sqlpt+1]
-		//line sql.y:2821
+		//line sql.y:2822
 		{
 			unimplemented()
 		}
 	case 543:
 		sqlDollar = sqlS[sqlpt-1 : sqlpt+1]
-		//line sql.y:2822
+		//line sql.y:2823
 		{
 			unimplemented()
 		}
 	case 544:
 		sqlDollar = sqlS[sqlpt-1 : sqlpt+1]
-		//line sql.y:2823
+		//line sql.y:2824
 		{
 			unimplemented()
 		}
 	case 545:
 		sqlDollar = sqlS[sqlpt-6 : sqlpt+1]
-		//line sql.y:2825
+		//line sql.y:2826
 		{
 			sqlVAL.expr = &CastExpr{Expr: sqlDollar[3].expr, Type: sqlDollar[5].colType}
 		}
 	case 546:
 		sqlDollar = sqlS[sqlpt-4 : sqlpt+1]
-		//line sql.y:2829
+		//line sql.y:2830
 		{
 			sqlVAL.expr = &FuncExpr{Name: &QualifiedName{Base: Name(sqlDollar[1].str)}, Exprs: sqlDollar[3].exprs}
 		}
 	case 547:
 		sqlDollar = sqlS[sqlpt-4 : sqlpt+1]
-		//line sql.y:2832
+		//line sql.y:2833
 		{
 			unimplemented()
 		}
 	case 548:
 		sqlDollar = sqlS[sqlpt-4 : sqlpt+1]
-		//line sql.y:2833
+		//line sql.y:2834
 		{
 			unimplemented()
 		}
 	case 549:
 		sqlDollar = sqlS[sqlpt-4 : sqlpt+1]
-		//line sql.y:2834
+		//line sql.y:2836
 		{
-			unimplemented()
+			sqlVAL.expr = &FuncExpr{Name: &QualifiedName{Base: Name(sqlDollar[1].str)}, Exprs: sqlDollar[3].exprs}
 		}
 	case 550:
 		sqlDollar = sqlS[sqlpt-6 : sqlpt+1]
-		//line sql.y:2835
+		//line sql.y:2839
 		{
 			unimplemented()
 		}
 	case 551:
 		sqlDollar = sqlS[sqlpt-5 : sqlpt+1]
-		//line sql.y:2836
+		//line sql.y:2840
 		{
 			unimplemented()
 		}
 	case 552:
 		sqlDollar = sqlS[sqlpt-5 : sqlpt+1]
-		//line sql.y:2837
+		//line sql.y:2841
 		{
 			unimplemented()
 		}
 	case 553:
 		sqlDollar = sqlS[sqlpt-5 : sqlpt+1]
-		//line sql.y:2838
+		//line sql.y:2842
 		{
 			unimplemented()
 		}
 	case 554:
 		sqlDollar = sqlS[sqlpt-4 : sqlpt+1]
-		//line sql.y:2839
+		//line sql.y:2843
 		{
 			unimplemented()
 		}
 	case 555:
 		sqlDollar = sqlS[sqlpt-8 : sqlpt+1]
-		//line sql.y:2841
+		//line sql.y:2845
 		{
 			sqlVAL.expr = &IfExpr{Cond: sqlDollar[3].expr, True: sqlDollar[5].expr, Else: sqlDollar[7].expr}
 		}
 	case 556:
 		sqlDollar = sqlS[sqlpt-6 : sqlpt+1]
-		//line sql.y:2845
+		//line sql.y:2849
 		{
 			sqlVAL.expr = &NullIfExpr{Expr1: sqlDollar[3].expr, Expr2: sqlDollar[5].expr}
 		}
 	case 557:
 		sqlDollar = sqlS[sqlpt-6 : sqlpt+1]
-		//line sql.y:2849
+		//line sql.y:2853
 		{
 			sqlVAL.expr = &CoalesceExpr{Name: "IFNULL", Exprs: Exprs{sqlDollar[3].expr, sqlDollar[5].expr}}
 		}
 	case 558:
 		sqlDollar = sqlS[sqlpt-4 : sqlpt+1]
-		//line sql.y:2853
+		//line sql.y:2857
 		{
 			sqlVAL.expr = &CoalesceExpr{Name: "COALESCE", Exprs: sqlDollar[3].exprs}
 		}
 	case 559:
 		sqlDollar = sqlS[sqlpt-4 : sqlpt+1]
-		//line sql.y:2857
+		//line sql.y:2861
 		{
 			sqlVAL.expr = &FuncExpr{Name: &QualifiedName{Base: Name(sqlDollar[1].str)}, Exprs: sqlDollar[3].exprs}
 		}
 	case 560:
 		sqlDollar = sqlS[sqlpt-4 : sqlpt+1]
-		//line sql.y:2861
+		//line sql.y:2865
 		{
 			sqlVAL.expr = &FuncExpr{Name: &QualifiedName{Base: Name(sqlDollar[1].str)}, Exprs: sqlDollar[3].exprs}
 		}
 	case 561:
 		sqlDollar = sqlS[sqlpt-5 : sqlpt+1]
-		//line sql.y:2867
+		//line sql.y:2871
 		{
 			unimplemented()
 		}
 	case 562:
 		sqlDollar = sqlS[sqlpt-0 : sqlpt+1]
-		//line sql.y:2868
+		//line sql.y:2872
 		{
 		}
 	case 563:
 		sqlDollar = sqlS[sqlpt-5 : sqlpt+1]
-		//line sql.y:2871
+		//line sql.y:2875
 		{
 			unimplemented()
 		}
 	case 564:
 		sqlDollar = sqlS[sqlpt-0 : sqlpt+1]
-		//line sql.y:2872
+		//line sql.y:2876
 		{
 		}
 	case 565:
 		sqlDollar = sqlS[sqlpt-2 : sqlpt+1]
-		//line sql.y:2876
+		//line sql.y:2880
 		{
 			unimplemented()
 		}
 	case 566:
 		sqlDollar = sqlS[sqlpt-0 : sqlpt+1]
-		//line sql.y:2877
+		//line sql.y:2881
 		{
 		}
 	case 567:
 		sqlDollar = sqlS[sqlpt-1 : sqlpt+1]
-		//line sql.y:2880
+		//line sql.y:2884
 		{
 			unimplemented()
 		}
 	case 568:
 		sqlDollar = sqlS[sqlpt-3 : sqlpt+1]
-		//line sql.y:2881
+		//line sql.y:2885
 		{
 			unimplemented()
 		}
 	case 569:
 		sqlDollar = sqlS[sqlpt-3 : sqlpt+1]
-		//line sql.y:2884
+		//line sql.y:2888
 		{
 			unimplemented()
 		}
 	case 570:
 		sqlDollar = sqlS[sqlpt-2 : sqlpt+1]
-		//line sql.y:2887
+		//line sql.y:2891
 		{
 			unimplemented()
 		}
 	case 571:
 		sqlDollar = sqlS[sqlpt-2 : sqlpt+1]
-		//line sql.y:2888
+		//line sql.y:2892
 		{
 			unimplemented()
 		}
 	case 572:
 		sqlDollar = sqlS[sqlpt-0 : sqlpt+1]
-		//line sql.y:2889
+		//line sql.y:2893
 		{
 		}
 	case 573:
 		sqlDollar = sqlS[sqlpt-6 : sqlpt+1]
-		//line sql.y:2893
+		//line sql.y:2897
 		{
 			unimplemented()
 		}
 	case 574:
 		sqlDollar = sqlS[sqlpt-1 : sqlpt+1]
-		//line sql.y:2904
+		//line sql.y:2908
 		{
 			unimplemented()
 		}
 	case 575:
 		sqlDollar = sqlS[sqlpt-0 : sqlpt+1]
-		//line sql.y:2905
+		//line sql.y:2909
 		{
 		}
 	case 576:
 		sqlDollar = sqlS[sqlpt-3 : sqlpt+1]
-		//line sql.y:2908
+		//line sql.y:2912
 		{
 			unimplemented()
 		}
 	case 577:
 		sqlDollar = sqlS[sqlpt-0 : sqlpt+1]
-		//line sql.y:2909
+		//line sql.y:2913
 		{
 		}
 	case 578:
 		sqlDollar = sqlS[sqlpt-2 : sqlpt+1]
-		//line sql.y:2917
+		//line sql.y:2921
 		{
 			unimplemented()
 		}
 	case 579:
 		sqlDollar = sqlS[sqlpt-2 : sqlpt+1]
-		//line sql.y:2918
+		//line sql.y:2922
 		{
 			unimplemented()
 		}
 	case 580:
 		sqlDollar = sqlS[sqlpt-0 : sqlpt+1]
-		//line sql.y:2919
+		//line sql.y:2923
 		{
 		}
 	case 581:
 		sqlDollar = sqlS[sqlpt-1 : sqlpt+1]
-		//line sql.y:2922
+		//line sql.y:2926
 		{
 			unimplemented()
 		}
 	case 582:
 		sqlDollar = sqlS[sqlpt-4 : sqlpt+1]
-		//line sql.y:2923
+		//line sql.y:2927
 		{
 			unimplemented()
 		}
 	case 583:
 		sqlDollar = sqlS[sqlpt-2 : sqlpt+1]
-		//line sql.y:2929
+		//line sql.y:2933
 		{
 			unimplemented()
 		}
 	case 584:
 		sqlDollar = sqlS[sqlpt-2 : sqlpt+1]
-		//line sql.y:2930
+		//line sql.y:2934
 		{
 			unimplemented()
 		}
 	case 585:
 		sqlDollar = sqlS[sqlpt-2 : sqlpt+1]
-		//line sql.y:2931
+		//line sql.y:2935
 		{
 			unimplemented()
 		}
 	case 586:
 		sqlDollar = sqlS[sqlpt-2 : sqlpt+1]
-		//line sql.y:2932
+		//line sql.y:2936
 		{
 			unimplemented()
 		}
 	case 587:
 		sqlDollar = sqlS[sqlpt-2 : sqlpt+1]
-		//line sql.y:2933
+		//line sql.y:2937
 		{
 			unimplemented()
 		}
 	case 588:
 		sqlDollar = sqlS[sqlpt-4 : sqlpt+1]
-		//line sql.y:2944
+		//line sql.y:2948
 		{
 			sqlVAL.expr = Row(sqlDollar[3].exprs)
 		}
 	case 589:
 		sqlDollar = sqlS[sqlpt-3 : sqlpt+1]
-		//line sql.y:2948
+		//line sql.y:2952
 		{
 			sqlVAL.expr = Row(nil)
 		}
 	case 590:
 		sqlDollar = sqlS[sqlpt-5 : sqlpt+1]
-		//line sql.y:2952
+		//line sql.y:2956
 		{
 			sqlVAL.expr = Tuple(append(sqlDollar[2].exprs, sqlDollar[4].expr))
 		}
 	case 591:
 		sqlDollar = sqlS[sqlpt-4 : sqlpt+1]
-		//line sql.y:2958
+		//line sql.y:2962
 		{
 			sqlVAL.expr = Row(sqlDollar[3].exprs)
 		}
 	case 592:
 		sqlDollar = sqlS[sqlpt-3 : sqlpt+1]
-		//line sql.y:2962
+		//line sql.y:2966
 		{
 			sqlVAL.expr = Row(nil)
 		}
 	case 593:
 		sqlDollar = sqlS[sqlpt-5 : sqlpt+1]
-		//line sql.y:2968
+		//line sql.y:2972
 		{
 			sqlVAL.expr = Tuple(append(sqlDollar[2].exprs, sqlDollar[4].expr))
 		}
 	case 594:
 		sqlDollar = sqlS[sqlpt-1 : sqlpt+1]
-		//line sql.y:3009
+		//line sql.y:3013
 		{
 			sqlVAL.exprs = Exprs{sqlDollar[1].expr}
 		}
 	case 595:
 		sqlDollar = sqlS[sqlpt-3 : sqlpt+1]
-		//line sql.y:3013
+		//line sql.y:3017
 		{
 			sqlVAL.exprs = append(sqlDollar[1].exprs, sqlDollar[3].expr)
 		}
 	case 596:
 		sqlDollar = sqlS[sqlpt-1 : sqlpt+1]
-		//line sql.y:3019
+		//line sql.y:3023
 		{
 			sqlVAL.colTypes = []ColumnType{sqlDollar[1].colType}
 		}
 	case 597:
 		sqlDollar = sqlS[sqlpt-3 : sqlpt+1]
-		//line sql.y:3023
+		//line sql.y:3027
 		{
 			sqlVAL.colTypes = append(sqlDollar[1].colTypes, sqlDollar[3].colType)
 		}
 	case 598:
 		sqlDollar = sqlS[sqlpt-3 : sqlpt+1]
-		//line sql.y:3029
+		//line sql.y:3033
 		{
 			sqlVAL.expr = Array(sqlDollar[2].exprs)
 		}
 	case 599:
 		sqlDollar = sqlS[sqlpt-3 : sqlpt+1]
-		//line sql.y:3033
+		//line sql.y:3037
 		{
 			sqlVAL.expr = Array(sqlDollar[2].exprs)
 		}
 	case 600:
 		sqlDollar = sqlS[sqlpt-2 : sqlpt+1]
-		//line sql.y:3037
+		//line sql.y:3041
 		{
 			sqlVAL.expr = Array(nil)
 		}
 	case 601:
 		sqlDollar = sqlS[sqlpt-1 : sqlpt+1]
-		//line sql.y:3043
+		//line sql.y:3047
 		{
 			sqlVAL.exprs = Exprs{sqlDollar[1].expr}
 		}
 	case 602:
 		sqlDollar = sqlS[sqlpt-3 : sqlpt+1]
-		//line sql.y:3047
+		//line sql.y:3051
 		{
 			sqlVAL.exprs = append(sqlDollar[1].exprs, sqlDollar[3].expr)
 		}
 	case 603:
 		sqlDollar = sqlS[sqlpt-3 : sqlpt+1]
-		//line sql.y:3053
+		//line sql.y:3057
 		{
 			sqlVAL.exprs = Exprs{DString(sqlDollar[1].str), sqlDollar[3].expr}
 		}
 	case 611:
 		sqlDollar = sqlS[sqlpt-4 : sqlpt+1]
-		//line sql.y:3074
+		//line sql.y:3078
 		{
 			unimplemented()
 		}
 	case 612:
 		sqlDollar = sqlS[sqlpt-3 : sqlpt+1]
-		//line sql.y:3075
+		//line sql.y:3079
 		{
 			unimplemented()
 		}
 	case 613:
 		sqlDollar = sqlS[sqlpt-2 : sqlpt+1]
-		//line sql.y:3078
+		//line sql.y:3082
 		{
 			unimplemented()
 		}
 	case 614:
 		sqlDollar = sqlS[sqlpt-3 : sqlpt+1]
-		//line sql.y:3082
+		//line sql.y:3086
 		{
 			unimplemented()
 		}
 	case 615:
 		sqlDollar = sqlS[sqlpt-0 : sqlpt+1]
-		//line sql.y:3083
+		//line sql.y:3087
 		{
 		}
 	case 616:
 		sqlDollar = sqlS[sqlpt-3 : sqlpt+1]
-		//line sql.y:3097
+		//line sql.y:3102
 		{
-			unimplemented()
+			sqlVAL.exprs = Exprs{sqlDollar[1].expr, sqlDollar[2].expr, sqlDollar[3].expr}
 		}
 	case 617:
 		sqlDollar = sqlS[sqlpt-3 : sqlpt+1]
-		//line sql.y:3098
+		//line sql.y:3106
 		{
-			unimplemented()
+			sqlVAL.exprs = Exprs{sqlDollar[1].expr, sqlDollar[3].expr, sqlDollar[2].expr}
 		}
 	case 618:
 		sqlDollar = sqlS[sqlpt-2 : sqlpt+1]
-		//line sql.y:3099
+		//line sql.y:3110
 		{
-			unimplemented()
+			sqlVAL.exprs = Exprs{sqlDollar[1].expr, sqlDollar[2].expr}
 		}
 	case 619:
 		sqlDollar = sqlS[sqlpt-2 : sqlpt+1]
-		//line sql.y:3100
+		//line sql.y:3114
 		{
-			unimplemented()
+			sqlVAL.exprs = Exprs{sqlDollar[1].expr, DInt(1), sqlDollar[2].expr}
 		}
 	case 620:
 		sqlDollar = sqlS[sqlpt-1 : sqlpt+1]
-		//line sql.y:3101
+		//line sql.y:3118
 		{
-			unimplemented()
+			sqlVAL.exprs = sqlDollar[1].exprs
 		}
 	case 621:
 		sqlDollar = sqlS[sqlpt-0 : sqlpt+1]
-		//line sql.y:3102
+		//line sql.y:3122
 		{
+			sqlVAL.exprs = nil
 		}
 	case 622:
 		sqlDollar = sqlS[sqlpt-2 : sqlpt+1]
-		//line sql.y:3105
+		//line sql.y:3128
 		{
-			unimplemented()
+			sqlVAL.expr = sqlDollar[2].expr
 		}
 	case 623:
 		sqlDollar = sqlS[sqlpt-2 : sqlpt+1]
-		//line sql.y:3108
+		//line sql.y:3134
 		{
-			unimplemented()
+			sqlVAL.expr = sqlDollar[2].expr
 		}
 	case 624:
 		sqlDollar = sqlS[sqlpt-3 : sqlpt+1]
-		//line sql.y:3111
+		//line sql.y:3139
 		{
 			unimplemented()
 		}
 	case 625:
 		sqlDollar = sqlS[sqlpt-2 : sqlpt+1]
-		//line sql.y:3112
+		//line sql.y:3140
 		{
 			unimplemented()
 		}
 	case 626:
 		sqlDollar = sqlS[sqlpt-1 : sqlpt+1]
-		//line sql.y:3113
+		//line sql.y:3141
 		{
 			unimplemented()
 		}
 	case 627:
 		sqlDollar = sqlS[sqlpt-1 : sqlpt+1]
-		//line sql.y:3117
+		//line sql.y:3145
 		{
 			sqlVAL.expr = &Subquery{Select: sqlDollar[1].selectStmt}
 		}
 	case 628:
 		sqlDollar = sqlS[sqlpt-3 : sqlpt+1]
-		//line sql.y:3121
+		//line sql.y:3149
 		{
 			sqlVAL.expr = Tuple(sqlDollar[2].exprs)
 		}
 	case 629:
 		sqlDollar = sqlS[sqlpt-5 : sqlpt+1]
-		//line sql.y:3132
+		//line sql.y:3160
 		{
 			sqlVAL.expr = &CaseExpr{Expr: sqlDollar[2].expr, Whens: sqlDollar[3].whens, Else: sqlDollar[4].expr}
 		}
 	case 630:
 		sqlDollar = sqlS[sqlpt-1 : sqlpt+1]
-		//line sql.y:3139
+		//line sql.y:3167
 		{
 			sqlVAL.whens = []*When{sqlDollar[1].when}
 		}
 	case 631:
 		sqlDollar = sqlS[sqlpt-2 : sqlpt+1]
-		//line sql.y:3143
+		//line sql.y:3171
 		{
 			sqlVAL.whens = append(sqlDollar[1].whens, sqlDollar[2].when)
 		}
 	case 632:
 		sqlDollar = sqlS[sqlpt-4 : sqlpt+1]
-		//line sql.y:3149
+		//line sql.y:3177
 		{
 			sqlVAL.when = &When{Cond: sqlDollar[2].expr, Val: sqlDollar[4].expr}
 		}
 	case 633:
 		sqlDollar = sqlS[sqlpt-2 : sqlpt+1]
-		//line sql.y:3155
+		//line sql.y:3183
 		{
 			sqlVAL.expr = sqlDollar[2].expr
 		}
 	case 634:
 		sqlDollar = sqlS[sqlpt-0 : sqlpt+1]
-		//line sql.y:3159
+		//line sql.y:3187
 		{
 			sqlVAL.expr = nil
 		}
 	case 636:
 		sqlDollar = sqlS[sqlpt-0 : sqlpt+1]
-		//line sql.y:3166
+		//line sql.y:3194
 		{
 			sqlVAL.expr = nil
 		}
 	case 637:
 		sqlDollar = sqlS[sqlpt-2 : sqlpt+1]
-		//line sql.y:3172
+		//line sql.y:3200
 		{
 			sqlVAL.indirectElem = NameIndirection(sqlDollar[2].str)
 		}
 	case 638:
 		sqlDollar = sqlS[sqlpt-2 : sqlpt+1]
-		//line sql.y:3176
+		//line sql.y:3204
 		{
 			sqlVAL.indirectElem = qualifiedStar
 		}
 	case 639:
 		sqlDollar = sqlS[sqlpt-2 : sqlpt+1]
-		//line sql.y:3180
+		//line sql.y:3208
 		{
 			sqlVAL.indirectElem = IndexIndirection(sqlDollar[2].str)
 		}
 	case 640:
 		sqlDollar = sqlS[sqlpt-3 : sqlpt+1]
-		//line sql.y:3184
+		//line sql.y:3212
 		{
 			sqlVAL.indirectElem = &ArrayIndirection{Begin: sqlDollar[2].expr}
 		}
 	case 641:
 		sqlDollar = sqlS[sqlpt-5 : sqlpt+1]
-		//line sql.y:3188
+		//line sql.y:3216
 		{
 			sqlVAL.indirectElem = &ArrayIndirection{Begin: sqlDollar[2].expr, End: sqlDollar[4].expr}
 		}
 	case 642:
 		sqlDollar = sqlS[sqlpt-1 : sqlpt+1]
-		//line sql.y:3194
+		//line sql.y:3222
 		{
 			sqlVAL.indirect = Indirection{sqlDollar[1].indirectElem}
 		}
 	case 643:
 		sqlDollar = sqlS[sqlpt-2 : sqlpt+1]
-		//line sql.y:3198
+		//line sql.y:3226
 		{
 			sqlVAL.indirect = append(sqlDollar[1].indirect, sqlDollar[2].indirectElem)
 		}
 	case 644:
 		sqlDollar = sqlS[sqlpt-1 : sqlpt+1]
-		//line sql.y:3203
+		//line sql.y:3231
 		{
 		}
 	case 645:
 		sqlDollar = sqlS[sqlpt-0 : sqlpt+1]
-		//line sql.y:3204
+		//line sql.y:3232
 		{
 		}
 	case 647:
 		sqlDollar = sqlS[sqlpt-1 : sqlpt+1]
-		//line sql.y:3213
+		//line sql.y:3241
 		{
 			sqlVAL.expr = DefaultVal{}
 		}
 	case 648:
 		sqlDollar = sqlS[sqlpt-1 : sqlpt+1]
-		//line sql.y:3219
+		//line sql.y:3247
 		{
 			sqlVAL.exprs = []Expr{sqlDollar[1].expr}
 		}
 	case 649:
 		sqlDollar = sqlS[sqlpt-3 : sqlpt+1]
-		//line sql.y:3223
+		//line sql.y:3251
 		{
 			sqlVAL.exprs = append(sqlDollar[1].exprs, sqlDollar[3].expr)
 		}
 	case 650:
 		sqlDollar = sqlS[sqlpt-3 : sqlpt+1]
-		//line sql.y:3232
+		//line sql.y:3260
 		{
 			sqlVAL.exprs = sqlDollar[2].exprs
 		}
 	case 652:
 		sqlDollar = sqlS[sqlpt-0 : sqlpt+1]
-		//line sql.y:3240
+		//line sql.y:3268
 		{
 			sqlVAL.selExprs = nil
 		}
 	case 653:
 		sqlDollar = sqlS[sqlpt-1 : sqlpt+1]
-		//line sql.y:3246
+		//line sql.y:3274
 		{
 			sqlVAL.selExprs = SelectExprs{sqlDollar[1].selExpr}
 		}
 	case 654:
 		sqlDollar = sqlS[sqlpt-3 : sqlpt+1]
-		//line sql.y:3250
+		//line sql.y:3278
 		{
 			sqlVAL.selExprs = append(sqlDollar[1].selExprs, sqlDollar[3].selExpr)
 		}
 	case 655:
 		sqlDollar = sqlS[sqlpt-3 : sqlpt+1]
-		//line sql.y:3256
+		//line sql.y:3284
 		{
 			sqlVAL.selExpr = SelectExpr{Expr: sqlDollar[1].expr, As: Name(sqlDollar[3].str)}
 		}
 	case 656:
 		sqlDollar = sqlS[sqlpt-2 : sqlpt+1]
-		//line sql.y:3265
+		//line sql.y:3293
 		{
 			sqlVAL.selExpr = SelectExpr{Expr: sqlDollar[1].expr, As: Name(sqlDollar[2].str)}
 		}
 	case 657:
 		sqlDollar = sqlS[sqlpt-1 : sqlpt+1]
-		//line sql.y:3269
+		//line sql.y:3297
 		{
 			sqlVAL.selExpr = SelectExpr{Expr: sqlDollar[1].expr}
 		}
 	case 658:
 		sqlDollar = sqlS[sqlpt-1 : sqlpt+1]
-		//line sql.y:3273
+		//line sql.y:3301
 		{
 			sqlVAL.selExpr = StarSelectExpr()
 		}
 	case 659:
 		sqlDollar = sqlS[sqlpt-1 : sqlpt+1]
-		//line sql.y:3281
+		//line sql.y:3309
 		{
 			sqlVAL.qnames = QualifiedNames{sqlDollar[1].qname}
 		}
 	case 660:
 		sqlDollar = sqlS[sqlpt-3 : sqlpt+1]
-		//line sql.y:3285
+		//line sql.y:3313
 		{
 			sqlVAL.qnames = append(sqlDollar[1].qnames, sqlDollar[3].qname)
 		}
 	case 661:
 		sqlDollar = sqlS[sqlpt-1 : sqlpt+1]
-		//line sql.y:3296
+		//line sql.y:3324
 		{
 			sqlVAL.qname = &QualifiedName{Base: Name(sqlDollar[1].str)}
 		}
 	case 662:
 		sqlDollar = sqlS[sqlpt-2 : sqlpt+1]
-		//line sql.y:3300
+		//line sql.y:3328
 		{
 			sqlVAL.qname = &QualifiedName{Base: Name(sqlDollar[1].str), Indirect: sqlDollar[2].indirect}
 		}
 	case 663:
 		sqlDollar = sqlS[sqlpt-1 : sqlpt+1]
-		//line sql.y:3306
+		//line sql.y:3334
 		{
 			sqlVAL.strs = []string{sqlDollar[1].str}
 		}
 	case 664:
 		sqlDollar = sqlS[sqlpt-3 : sqlpt+1]
-		//line sql.y:3310
+		//line sql.y:3338
 		{
 			sqlVAL.strs = append(sqlDollar[1].strs, sqlDollar[3].str)
 		}
 	case 665:
 		sqlDollar = sqlS[sqlpt-3 : sqlpt+1]
-		//line sql.y:3316
+		//line sql.y:3344
 		{
 			sqlVAL.strs = sqlDollar[2].strs
 		}
 	case 666:
 		sqlDollar = sqlS[sqlpt-0 : sqlpt+1]
-		//line sql.y:3319
+		//line sql.y:3347
 		{
 		}
 	case 667:
 		sqlDollar = sqlS[sqlpt-1 : sqlpt+1]
-		//line sql.y:3329
+		//line sql.y:3357
 		{
 			sqlVAL.qname = &QualifiedName{Base: Name(sqlDollar[1].str)}
 		}
 	case 668:
 		sqlDollar = sqlS[sqlpt-2 : sqlpt+1]
-		//line sql.y:3333
+		//line sql.y:3361
 		{
 			sqlVAL.qname = &QualifiedName{Base: Name(sqlDollar[1].str), Indirect: sqlDollar[2].indirect}
 		}
 	case 669:
 		sqlDollar = sqlS[sqlpt-1 : sqlpt+1]
-		//line sql.y:3340
+		//line sql.y:3368
 		{
 			sqlVAL.expr = IntVal(sqlDollar[1].ival)
 		}
 	case 670:
 		sqlDollar = sqlS[sqlpt-1 : sqlpt+1]
-		//line sql.y:3344
+		//line sql.y:3372
 		{
 			sqlVAL.expr = NumVal(sqlDollar[1].str)
 		}
 	case 671:
 		sqlDollar = sqlS[sqlpt-1 : sqlpt+1]
-		//line sql.y:3348
+		//line sql.y:3376
 		{
 			sqlVAL.expr = DString(sqlDollar[1].str)
 		}
 	case 672:
 		sqlDollar = sqlS[sqlpt-1 : sqlpt+1]
-		//line sql.y:3352
+		//line sql.y:3380
 		{
 			sqlVAL.expr = DBytes(sqlDollar[1].str)
 		}
 	case 673:
 		sqlDollar = sqlS[sqlpt-6 : sqlpt+1]
-		//line sql.y:3355
+		//line sql.y:3383
 		{
 			unimplemented()
 		}
 	case 674:
 		sqlDollar = sqlS[sqlpt-2 : sqlpt+1]
-		//line sql.y:3357
+		//line sql.y:3385
 		{
 			sqlVAL.expr = &CastExpr{Expr: DString(sqlDollar[2].str), Type: sqlDollar[1].colType}
 		}
 	case 675:
 		sqlDollar = sqlS[sqlpt-3 : sqlpt+1]
-		//line sql.y:3361
+		//line sql.y:3389
 		{
 			// TODO(pmattis): support opt_interval?
 			sqlVAL.expr = &CastExpr{Expr: DString(sqlDollar[2].str), Type: sqlDollar[1].colType}
 		}
 	case 676:
 		sqlDollar = sqlS[sqlpt-5 : sqlpt+1]
-		//line sql.y:3366
+		//line sql.y:3394
 		{
 			// TODO(pmattis): Support the precision specification?
 			sqlVAL.expr = &CastExpr{Expr: DString(sqlDollar[5].str), Type: sqlDollar[1].colType}
 		}
 	case 677:
 		sqlDollar = sqlS[sqlpt-1 : sqlpt+1]
-		//line sql.y:3371
+		//line sql.y:3399
 		{
 			sqlVAL.expr = DBool(true)
 		}
 	case 678:
 		sqlDollar = sqlS[sqlpt-1 : sqlpt+1]
-		//line sql.y:3375
+		//line sql.y:3403
 		{
 			sqlVAL.expr = DBool(false)
 		}
 	case 679:
 		sqlDollar = sqlS[sqlpt-1 : sqlpt+1]
-		//line sql.y:3379
+		//line sql.y:3407
 		{
 			sqlVAL.expr = DNull
 		}
 	case 681:
 		sqlDollar = sqlS[sqlpt-2 : sqlpt+1]
-		//line sql.y:3386
+		//line sql.y:3414
 		{
 			sqlVAL.ival = +sqlDollar[2].ival
 		}
 	case 682:
 		sqlDollar = sqlS[sqlpt-2 : sqlpt+1]
-		//line sql.y:3390
+		//line sql.y:3418
 		{
 			sqlVAL.ival = -sqlDollar[2].ival
 		}
 	case 687:
 		sqlDollar = sqlS[sqlpt-0 : sqlpt+1]
-		//line sql.y:3412
+		//line sql.y:3440
 		{
 			sqlVAL.str = ""
 		}

--- a/sql/parser/type_check.go
+++ b/sql/parser/type_check.go
@@ -242,7 +242,7 @@ func (expr *FuncExpr) TypeCheck() (Datum, error) {
 	// Cache is cold, do the lookup.
 	if expr.fn.fn == nil {
 		if len(expr.Name.Indirect) > 0 {
-			// We don'expr support qualified function names (yet).
+			// We don't support qualified function names (yet).
 			return nil, fmt.Errorf("unknown function: %s", expr.Name)
 		}
 
@@ -275,7 +275,7 @@ func (expr *FuncExpr) TypeCheck() (Datum, error) {
 		return expr.fn.returnType, nil
 	}
 
-	// Function lookup succeeded but `fn` doesn'expr encode its return type.
+	// Function lookup succeeded but `fn` doesn't encode its return type.
 	// We need to call the function with dummy arguments.
 	res, err := expr.fn.fn(defaultContext, dummyArgs)
 	if err != nil {

--- a/sql/testdata/builtin_function
+++ b/sql/testdata/builtin_function
@@ -62,13 +62,28 @@ SELECT SUBSTR('RoacH', 2, 3)
 ----
 oac
 
-#query T
-#SELECT SUBSTRING('RoacH', 2, 3)
-#----
-#oac
+query T
+SELECT SUBSTRING('RoacH', 2, 3)
+----
+oac
+
+query T
+SELECT SUBSTRING('RoacH' from 2 for 3)
+----
+oac
+
+query T
+SELECT SUBSTRING('RoacH' for 3 from 2)
+----
+oac
 
 query T
 SELECT SUBSTR('RoacH', 2)
+----
+oacH
+
+query T
+SELECT SUBSTRING('RoacH' from 2)
 ----
 oacH
 
@@ -94,6 +109,32 @@ SELECT SUBSTR('12345', -2, 77)
 
 statement error SUBSTR: negative substring length -1 not allowed
 SELECT SUBSTR('12345', 2, -1)
+
+query T
+SELECT SUBSTRING('12345' for 3)
+----
+123
+
+query T
+SELECT SUBSTRING('foobar' from 'o.b')
+----
+oob
+
+query T
+SELECT SUBSTRING('f(oabaroob' from '\(o(.)b')
+----
+a
+
+query T
+SELECT SUBSTRING('f(oabaroob' from '+(o(.)b' for '+')
+----
+a
+
+query error SUBSTRING: error parsing regexp: missing closing \): `\\\\\(o\(.\)b`
+SELECT SUBSTRING('f(oabaroob' from '\(o(.)b' for '+')
+
+query error unknown signature for SUBSTRING: SUBSTRING()
+SELECT SUBSTRING()
 
 query T
 SELECT CONCAT_WS(',', 'abcde', NULL)

--- a/sql/testdata/builtin_function
+++ b/sql/testdata/builtin_function
@@ -482,6 +482,31 @@ SELECT translate('a‰ÒÁ', 'aÒ', '∏p')
 ∏‰pÁ
 
 query T
+SELECT regexp_extract('foobar', 'o.b')
+----
+oob
+
+query T
+SELECT regexp_extract('foobar', 'o(.)b')
+----
+o
+
+query T
+SELECT regexp_extract('foobar', '(o(.)b)')
+----
+oob
+
+query T
+SELECT regexp_extract('foabaroob', 'o(.)b')
+----
+a
+
+query T
+SELECT regexp_extract('foobar', 'o.x')
+----
+NULL
+
+query T
 SELECT regexp_replace('foobarbaz', 'b..', 'X')
 ----
 fooXbaz


### PR DESCRIPTION
See #2042

Note that the substring functions do not support `substring(string for int)`. `substring(string for int from int)` is also not supported (yet?) because it is not valid SQL99.

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/3049)

<!-- Reviewable:end -->
