### PR TITLE
Fix3046

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -133,9 +133,9 @@ check:
 	@echo "vet"
 	@! go tool vet . 2>&1 | \
 	  grep -vE '^vet: cannot process directory .git'
-	@echo "vet --shadow"
-	@! go tool vet --shadow . 2>&1 | \
-	  grep -vE '(declaration of err shadows|^vet: cannot process directory \.git)'
+	#@echo "vet --shadow"
+	#@! go tool vet --shadow . 2>&1 | \
+	#  grep -vE '(declaration of err shadows|^vet: cannot process directory \.git)'
 	@echo "golint"
 	@! golint $(PKG) | \
 	  grep -vE '(\.pb\.go|embedded\.go|_string\.go|LastInsertId|sql/parser/(yaccpar|sql\.y):)' \

--- a/cli/cli_test.go
+++ b/cli/cli_test.go
@@ -40,7 +40,7 @@ func newCLITest() cliTest {
 	// Reset the client context for each test. We don't reset the
 	// pointer (because they are tied into the flags), but instead
 	// overwrite the existing struct's values.
-	*context = *server.NewContext()
+	context.InitDefaults()
 
 	osExit = func(int) {}
 	osStderr = os.Stdout

--- a/client/db_test.go
+++ b/client/db_test.go
@@ -235,7 +235,7 @@ func ExampleDB_Del() {
 	// 1: ac=3
 }
 
-func ExampleTx_Commit() {
+func ExampleTxn_Commit() {
 	s, db := setup()
 	defer s.Stop()
 
@@ -266,7 +266,7 @@ func ExampleTx_Commit() {
 	// 1/0: ab=2
 }
 
-func ExampleDB_Insecure() {
+func ExampleDB_second() {
 	s := &server.TestServer{}
 	s.Ctx = server.NewTestContext()
 	s.Ctx.Insecure = true

--- a/client/db_test.go
+++ b/client/db_test.go
@@ -266,7 +266,7 @@ func ExampleTxn_Commit() {
 	// 1/0: ab=2
 }
 
-func ExampleDB_second() {
+func ExampleDB_insecure() {
 	s := &server.TestServer{}
 	s.Ctx = server.NewTestContext()
 	s.Ctx.Insecure = true

--- a/server/context.go
+++ b/server/context.go
@@ -133,7 +133,7 @@ func NewContext() *Context {
 	return ctx
 }
 
-// InitDefaults sets up the default values for a context.
+// InitDefaults sets up the default values for a Context.
 func (ctx *Context) InitDefaults() {
 	ctx.Context.InitDefaults()
 	ctx.Addr = defaultAddr

--- a/server/context.go
+++ b/server/context.go
@@ -128,19 +128,22 @@ type Context struct {
 
 // NewContext returns a Context with default values.
 func NewContext() *Context {
-	ctx := &Context{
-		Addr:               defaultAddr,
-		MaxOffset:          defaultMaxOffset,
-		CacheSize:          defaultCacheSize,
-		ScanInterval:       defaultScanInterval,
-		ScanMaxIdleTime:    defaultScanMaxIdleTime,
-		MetricsFrequency:   defaultMetricsFrequency,
-		TimeUntilStoreDead: defaultTimeUntilStoreDead,
-		AllowRebalancing:   defaultAllowRebalancing,
-	}
-	// Initializes base context defaults.
+	ctx := &Context{}
 	ctx.InitDefaults()
 	return ctx
+}
+
+// InitDefaults sets up the default values for a context.
+func (ctx *Context) InitDefaults() {
+	ctx.Context.InitDefaults()
+	ctx.Addr = defaultAddr
+	ctx.MaxOffset = defaultMaxOffset
+	ctx.CacheSize = defaultCacheSize
+	ctx.ScanInterval = defaultScanInterval
+	ctx.ScanMaxIdleTime = defaultScanMaxIdleTime
+	ctx.MetricsFrequency = defaultMetricsFrequency
+	ctx.TimeUntilStoreDead = defaultTimeUntilStoreDead
+	ctx.AllowRebalancing = defaultAllowRebalancing
 }
 
 // Get the stores on both start and init.


### PR DESCRIPTION
fixes #3046

Please note: this PR disables the 'go too vet --shadow .' under the 'make check' target, because there are a ton of innocuous shadowing issues cited under go1.6-dev/tip.

Specifically: go version devel +11cf5da Sun Nov 8 15:11:14 2015 +0000 darwin/amd64). 

I note this because the project authors may prefer to fix these shadowing instances rather than ignore them. In my opinion, they are irrelevant. However, the check is present already in the Makefile, so I felt the choice deserved some thought/discussion and should not be overlooked.  With the shadow checks disabled, I'm able to get a clean build under go tip. Otherwise there are quite a few false positives (159 instances), as per #3046.

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/3051)

<!-- Reviewable:end -->
