### PR TITLE
Reduce allocations when using parser.Dummy* vars.

### DIFF
--- a/sql/parser/datum.go
+++ b/sql/parser/datum.go
@@ -31,37 +31,25 @@ import (
 
 var (
 	// DummyBool is a placeholder DBool value.
-	DummyBool = DBool(false)
+	DummyBool Datum = DBool(false)
 	// DummyInt is a placeholder DInt value.
-	DummyInt = DInt(0)
+	DummyInt Datum = DInt(0)
 	// DummyFloat is a placeholder DFloat value.
-	DummyFloat = DFloat(0)
+	DummyFloat Datum = DFloat(0)
 	// DummyString is a placeholder DString value.
-	DummyString = DString("")
+	DummyString Datum = DString("")
 	// DummyBytes is a placeholder DBytes value.
-	DummyBytes = DBytes("")
+	DummyBytes Datum = DBytes("")
 	// DummyDate is a placeholder DDate value.
-	DummyDate = DDate(0)
+	DummyDate Datum = DDate(0)
 	// DummyTimestamp is a placeholder DTimestamp value.
-	DummyTimestamp = DTimestamp{}
+	DummyTimestamp Datum = DTimestamp{}
 	// DummyInterval is a placeholder DInterval value.
-	DummyInterval = DInterval{}
+	DummyInterval Datum = DInterval{}
 	// dummyTuple is a placeholder DTuple value.
-	dummyTuple = DTuple{}
-
+	dummyTuple Datum = DTuple{}
 	// DNull is the NULL Datum.
-	DNull = dNull{}
-
-	_ Datum = DummyBool
-	_ Datum = DummyInt
-	_ Datum = DummyFloat
-	_ Datum = DummyString
-	_ Datum = DummyBytes
-	_ Datum = DummyDate
-	_ Datum = DummyTimestamp
-	_ Datum = DummyInterval
-	_ Datum = dummyTuple
-	_ Datum = DNull
+	DNull Datum = dNull{}
 
 	boolType      = reflect.TypeOf(DummyBool)
 	intType       = reflect.TypeOf(DummyInt)

--- a/sql/parser/eval.go
+++ b/sql/parser/eval.go
@@ -477,10 +477,10 @@ var evalTupleEQ = cmpOp{
 		for i := range left {
 			d, err := evalComparison(ctx, EQ, left[i], right[i])
 			if err != nil {
-				return DummyBool, err
+				return DBool(false), err
 			}
 			if v, err := getBool(d); err != nil {
-				return DummyBool, err
+				return DBool(false), err
 			} else if !v {
 				return v, nil
 			}
@@ -539,7 +539,7 @@ var defaultContext = EvalContext{
 func (ctx EvalContext) makeDDate(t time.Time) (DDate, error) {
 	loc, err := ctx.GetLocation()
 	if err != nil {
-		return DummyDate, err
+		return DDate(0), err
 	}
 	year, month, day := t.In(loc).Date()
 	secs := time.Date(year, month, day, 0, 0, 0, 0, time.UTC).Unix()
@@ -1247,7 +1247,7 @@ func ParseDate(s DString) (DDate, error) {
 	// No need to ParseInLocation here because we're only parsing dates.
 	t, err := time.Parse(dateFormat, string(s))
 	if err != nil {
-		return DummyDate, err
+		return DDate(0), err
 	}
 	return defaultContext.makeDDate(t)
 }
@@ -1258,7 +1258,7 @@ func (ctx EvalContext) ParseTimestamp(s DString) (DTimestamp, error) {
 	if ctx.GetLocation != nil {
 		var err error
 		if loc, err = ctx.GetLocation(); err != nil {
-			return DummyTimestamp, err
+			return DTimestamp{}, err
 		}
 	}
 
@@ -1277,7 +1277,7 @@ func (ctx EvalContext) ParseTimestamp(s DString) (DTimestamp, error) {
 		}
 	}
 
-	return DummyTimestamp, err
+	return DTimestamp{}, err
 }
 
 type likeKey string


### PR DESCRIPTION
Previously, the parser.Dummy\* variables had types corresponding to the
underlying datum type (e.g. DBool, DInt, etc). This caused an allocation
every time the variable was assigned to a parser.Datum. Now these
variables have the type parser.Datum.

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/3058)

<!-- Reviewable:end -->
