### PR TITLE
Change IntVal from an int64 to a struct.

### DIFF
--- a/sql/parser/eval.go
+++ b/sql/parser/eval.go
@@ -1081,11 +1081,11 @@ func (t DefaultVal) Eval(_ EvalContext) (Datum, error) {
 }
 
 // Eval implements the Expr interface.
-func (t IntVal) Eval(_ EvalContext) (Datum, error) {
-	if t < 0 {
+func (t *IntVal) Eval(_ EvalContext) (Datum, error) {
+	if t.Val < 0 {
 		return nil, fmt.Errorf("integer value out of range: %s", t)
 	}
-	return DInt(t), nil
+	return DInt(t.Val), nil
 }
 
 // Eval implements the Expr interface.

--- a/sql/parser/expr.go
+++ b/sql/parser/expr.go
@@ -20,9 +20,7 @@ package parser
 import (
 	"bytes"
 	"fmt"
-	"math"
 	"reflect"
-	"strconv"
 )
 
 // Expr represents an expression.
@@ -233,17 +231,13 @@ func (node *CoalesceExpr) String() string {
 }
 
 // IntVal represents an integer.
-type IntVal int64
+type IntVal struct {
+	Val int64
+	Str string
+}
 
-func (node IntVal) String() string {
-	// Note that IntVal uses math.MinInt64 to represent uint64(1 << 63). This
-	// implies that IntVal cannot represent math.MinInt64, but that is ok because
-	// it is only used to store signed integers in grammar rules which do not
-	// require that range.
-	if node == math.MinInt64 {
-		return strconv.FormatUint(uint64(node), 10)
-	}
-	return strconv.FormatInt(int64(node), 10)
+func (node *IntVal) String() string {
+	return node.Str
 }
 
 // NumVal represents a number.

--- a/sql/parser/normalize.go
+++ b/sql/parser/normalize.go
@@ -279,7 +279,7 @@ func (expr *UnaryExpr) normalize(v *normalizeVisitor) Expr {
 	// traversal. Or do it during the downward traversal for const
 	// UnaryExprs.
 	if expr.Operator == UnaryMinus {
-		if d, ok := expr.Expr.(IntVal); ok && d == math.MinInt64 {
+		if d, ok := expr.Expr.(*IntVal); ok && d.Val == math.MinInt64 {
 			return DInt(math.MinInt64)
 		}
 	}

--- a/sql/parser/parse_test.go
+++ b/sql/parser/parse_test.go
@@ -194,6 +194,9 @@ func TestParse(t *testing.T) {
 		{`SELECT 'a' AS "12345"`},
 		{`SELECT 'a' AS clnm`},
 
+		{`SELECT 0xf0 FROM t`},
+		{`SELECT 0xF0 FROM t`},
+
 		// Escaping may change since the scanning process loses information
 		// (you can write e'\'' or ''''), but these are the idempotent cases.
 		// Generally, anything that needs to escape plus \ and ' leads to an
@@ -403,8 +406,6 @@ func TestParse2(t *testing.T) {
 		{`SELECT FROM t WHERE a IS UNKNOWN`, `SELECT FROM t WHERE a IS NULL`},
 		{`SELECT FROM t WHERE a IS NOT UNKNOWN`, `SELECT FROM t WHERE a IS NOT NULL`},
 
-		{`SELECT 0xf0 FROM t`, `SELECT 240 FROM t`},
-		{`SELECT 0xF0 FROM t`, `SELECT 240 FROM t`},
 		// Escaped string literals are not always escaped the same because
 		// '''' and e'\'' scan to the same token. It's more convenient to
 		// prefer escaping ' and \, so we do that.
@@ -681,9 +682,9 @@ func TestParsePrecedence(t *testing.T) {
 		return &OrExpr{Left: left, Right: right}
 	}
 
-	one := IntVal(1)
-	two := IntVal(2)
-	three := IntVal(3)
+	one := &IntVal{Val: 1, Str: "1"}
+	two := &IntVal{Val: 2, Str: "2"}
+	three := &IntVal{Val: 3, Str: "3"}
 
 	testData := []struct {
 		sql      string

--- a/sql/parser/scan.go
+++ b/sql/parser/scan.go
@@ -546,7 +546,8 @@ func (s *scanner) scanNumber(lval *sqlSymType, ch int) {
 	}
 	// uval is now in the range [0, 1<<63]. Casting to an int64 leaves the range
 	// [0, 1<<63 - 1] intact and moves 1<<63 to -1<<63 (a.k.a. math.MinInt64).
-	lval.ival = int64(uval)
+	lval.ival.Val = int64(uval)
+	lval.ival.Str = lval.str
 	if err != nil {
 		lval.id = ERROR
 		lval.str = err.Error()
@@ -569,7 +570,8 @@ func (s *scanner) scanParam(lval *sqlSymType) {
 	}
 	// uval is now in the range [0, 1<<63]. Casting to an int64 leaves the range
 	// [0, 1<<63 - 1] intact and moves 1<<63 to -1<<63 (a.k.a. math.MinInt64).
-	lval.ival = int64(uval)
+	lval.ival.Val = int64(uval)
+	lval.ival.Str = lval.str
 	if err != nil {
 		lval.id = ERROR
 		lval.str = err.Error()

--- a/sql/parser/scan_test.go
+++ b/sql/parser/scan_test.go
@@ -269,8 +269,8 @@ func TestScanParam(t *testing.T) {
 		if id != PARAM {
 			t.Errorf("%s: expected %d, but found %d", d.sql, PARAM, id)
 		}
-		if d.expected != lval.ival {
-			t.Errorf("%s: expected %d, but found %d", d.sql, d.expected, lval.ival)
+		if d.expected != lval.ival.Val {
+			t.Errorf("%s: expected %d, but found %d", d.sql, d.expected, lval.ival.Val)
 		}
 	}
 }

--- a/sql/parser/sql.go
+++ b/sql/parser/sql.go
@@ -17,7 +17,7 @@ type sqlSymType struct {
 	id             int
 	pos            int
 	empty          struct{}
-	ival           int64
+	ival           IntVal
 	boolVal        bool
 	str            string
 	strs           []string
@@ -4861,7 +4861,7 @@ sqldefault:
 		sqlDollar = sqlS[sqlpt-1 : sqlpt+1]
 		//line sql.y:1258
 		{
-			sqlVAL.expr = DInt(sqlDollar[1].ival)
+			sqlVAL.expr = DInt(sqlDollar[1].ival.Val)
 		}
 	case 201:
 		sqlDollar = sqlS[sqlpt-4 : sqlpt+1]
@@ -5832,13 +5832,13 @@ sqldefault:
 		sqlDollar = sqlS[sqlpt-3 : sqlpt+1]
 		//line sql.y:2179
 		{
-			sqlVAL.colType = &DecimalType{Prec: int(sqlDollar[2].ival)}
+			sqlVAL.colType = &DecimalType{Prec: int(sqlDollar[2].ival.Val)}
 		}
 	case 381:
 		sqlDollar = sqlS[sqlpt-5 : sqlpt+1]
 		//line sql.y:2183
 		{
-			sqlVAL.colType = &DecimalType{Prec: int(sqlDollar[2].ival), Scale: int(sqlDollar[4].ival)}
+			sqlVAL.colType = &DecimalType{Prec: int(sqlDollar[2].ival.Val), Scale: int(sqlDollar[4].ival.Val)}
 		}
 	case 382:
 		sqlDollar = sqlS[sqlpt-0 : sqlpt+1]
@@ -5886,7 +5886,7 @@ sqldefault:
 		sqlDollar = sqlS[sqlpt-2 : sqlpt+1]
 		//line sql.y:2218
 		{
-			sqlVAL.colType = &FloatType{Name: "FLOAT", Prec: int(sqlDollar[2].ival)}
+			sqlVAL.colType = &FloatType{Name: "FLOAT", Prec: int(sqlDollar[2].ival.Val)}
 		}
 	case 390:
 		sqlDollar = sqlS[sqlpt-2 : sqlpt+1]
@@ -5937,13 +5937,13 @@ sqldefault:
 		sqlDollar = sqlS[sqlpt-0 : sqlpt+1]
 		//line sql.y:2255
 		{
-			sqlVAL.ival = 0
+			sqlVAL.ival = IntVal{}
 		}
 	case 402:
 		sqlDollar = sqlS[sqlpt-5 : sqlpt+1]
 		//line sql.y:2273
 		{
-			sqlVAL.colType = &IntType{Name: "BIT", N: int(sqlDollar[4].ival)}
+			sqlVAL.colType = &IntType{Name: "BIT", N: int(sqlDollar[4].ival.Val)}
 		}
 	case 403:
 		sqlDollar = sqlS[sqlpt-2 : sqlpt+1]
@@ -5956,7 +5956,7 @@ sqldefault:
 		//line sql.y:2295
 		{
 			sqlVAL.colType = sqlDollar[1].colType
-			sqlVAL.colType.(*StringType).N = int(sqlDollar[3].ival)
+			sqlVAL.colType.(*StringType).N = int(sqlDollar[3].ival.Val)
 		}
 	case 409:
 		sqlDollar = sqlS[sqlpt-1 : sqlpt+1]
@@ -7422,7 +7422,7 @@ sqldefault:
 		sqlDollar = sqlS[sqlpt-1 : sqlpt+1]
 		//line sql.y:3368
 		{
-			sqlVAL.expr = IntVal(sqlDollar[1].ival)
+			sqlVAL.expr = &IntVal{Val: sqlDollar[1].ival.Val, Str: sqlDollar[1].ival.Str}
 		}
 	case 670:
 		sqlDollar = sqlS[sqlpt-1 : sqlpt+1]
@@ -7490,13 +7490,13 @@ sqldefault:
 		sqlDollar = sqlS[sqlpt-2 : sqlpt+1]
 		//line sql.y:3414
 		{
-			sqlVAL.ival = +sqlDollar[2].ival
+			sqlVAL.ival = sqlDollar[2].ival
 		}
 	case 682:
 		sqlDollar = sqlS[sqlpt-2 : sqlpt+1]
 		//line sql.y:3418
 		{
-			sqlVAL.ival = -sqlDollar[2].ival
+			sqlVAL.ival = IntVal{Val: -sqlDollar[2].ival.Val, Str: "-" + sqlDollar[2].ival.Str}
 		}
 	case 687:
 		sqlDollar = sqlS[sqlpt-0 : sqlpt+1]

--- a/sql/parser/sql.y
+++ b/sql/parser/sql.y
@@ -31,7 +31,7 @@ func unimplemented() {
   id             int
   pos            int
   empty          struct{}
-  ival           int64
+  ival           IntVal
   boolVal        bool
   str            string
   strs           []string
@@ -1256,7 +1256,7 @@ numeric_only:
   }
 | signed_iconst
   {
-    $$ = DInt($1)
+    $$ = DInt($1.Val)
   }
 
 // TRUNCATE table relname1, relname2, ...
@@ -2177,11 +2177,11 @@ const_typename:
 opt_numeric_modifiers:
   '(' ICONST ')'
   {
-    $$ = &DecimalType{Prec: int($2)}
+    $$ = &DecimalType{Prec: int($2.Val)}
   }
 | '(' ICONST ',' ICONST ')'
   {
-    $$ = &DecimalType{Prec: int($2), Scale: int($4)}
+    $$ = &DecimalType{Prec: int($2.Val), Scale: int($4.Val)}
   }
 | /* EMPTY */
   {
@@ -2216,7 +2216,7 @@ numeric:
   }
 | FLOAT opt_float
   {
-    $$ = &FloatType{Name: "FLOAT", Prec: int($2)}
+    $$ = &FloatType{Name: "FLOAT", Prec: int($2.Val)}
   }
 | DOUBLE PRECISION
   {
@@ -2253,7 +2253,7 @@ opt_float:
   }
 | /* EMPTY */
   {
-    $$ = 0
+    $$ = IntVal{}
   }
 
 // SQL bit-field data types
@@ -2271,7 +2271,7 @@ const_bit:
 bit_with_length:
   BIT opt_varying '(' ICONST ')'
   {
-    $$ = &IntType{Name: "BIT", N: int($4)}
+    $$ = &IntType{Name: "BIT", N: int($4.Val)}
   }
 
 bit_without_length:
@@ -2294,7 +2294,7 @@ character_with_length:
   character_base '(' ICONST ')'
   {
     $$ = $1
-    $$.(*StringType).N = int($3)
+    $$.(*StringType).N = int($3.Val)
   }
 
 character_without_length:
@@ -3366,7 +3366,7 @@ func_name:
 a_expr_const:
   ICONST
   {
-    $$ = IntVal($1)
+    $$ = &IntVal{Val: $1.Val, Str: $1.Str}
   }
 | FCONST
   {
@@ -3412,11 +3412,11 @@ signed_iconst:
   ICONST
 | '+' ICONST
   {
-    $$ = +$2
+    $$ = $2
   }
 | '-' ICONST
   {
-    $$ = -$2
+    $$ = IntVal{Val: -$2.Val, Str: "-" + $2.Str}
   }
 
 // Name classification hierarchy.

--- a/sql/values_test.go
+++ b/sql/values_test.go
@@ -37,6 +37,9 @@ func TestValues(t *testing.T) {
 
 	unsupp := &parser.RangeCond{}
 
+	intVal := func(v int64) *parser.IntVal {
+		return &parser.IntVal{Val: v}
+	}
 	asRow := func(datums ...parser.Datum) []parser.DTuple {
 		return []parser.DTuple{datums}
 	}
@@ -47,12 +50,12 @@ func TestValues(t *testing.T) {
 		ok   bool
 	}{
 		{
-			parser.Values{{parser.IntVal(vInt)}},
+			parser.Values{{intVal(vInt)}},
 			asRow(parser.DInt(vInt)),
 			true,
 		},
 		{
-			parser.Values{{parser.IntVal(vInt), parser.IntVal(vInt)}},
+			parser.Values{{intVal(vInt), intVal(vInt)}},
 			asRow(parser.DInt(vInt), parser.DInt(vInt)),
 			true,
 		},


### PR DESCRIPTION
IntVal now maintains the string that was scanned as an integer. This
removes a bit of awkwardness from IntVal.String(), removes an allocation
from IntVal.String() and round-trips non-decimal int constants.

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/3061)

<!-- Reviewable:end -->
