### PR TITLE
Push built binaries to AWS bucket after docker deploy.

### DIFF
--- a/build/build-docker-deploy.sh
+++ b/build/build-docker-deploy.sh
@@ -18,7 +18,7 @@ if [ "${1-}" = "docker" ]; then
     # awkward to do this programmatically, but this should work.
     file cockroach | grep -F 'statically linked' > /dev/null
 
-    mv cockroach build/deploy/cockroach
+    cp cockroach build/deploy/cockroach
 
     exit 0
 fi

--- a/build/push_aws.sh
+++ b/build/push_aws.sh
@@ -1,0 +1,17 @@
+#!/bin/bash
+# Push cockroach binaries to AWS.
+# This is run by circle-ci after successful docker push.
+# Requisites:
+# - circleci must have AWS credentials configured
+# - AWS credentials must have S3 write permissions on the bucket
+# - the aws cli must be installed on the machine
+# - the region must be configured
+
+set -eux
+
+BUCKET_PATH="cockroachdb/bin"
+BINARY_NAME="cockroach.$(date +"%Y%m%d-%H:%M:%S").${CIRCLE_SHA1}"
+
+cd $(dirname $0)/..
+strip -S cockroach
+time aws cp cockroach s3://${BUCKET_PATH}/${BINARY_NAME}

--- a/circle.yml
+++ b/circle.yml
@@ -13,6 +13,8 @@ dependencies:
   cache_directories:
     - ~/buildcache
     - ~/uicache
+  post:
+    - aws configure set region us-east-1
 
 test:
   override:
@@ -29,3 +31,4 @@ deployment:
           if [ -n "$DOCKER_EMAIL" ]; then
             build/push-docker-deploy.sh
           fi
+      - build/push_aws.sh


### PR DESCRIPTION
I've tested parts of it manually and configured the bucket and
credentials.
Once this is verified on circle-ci, I'll need to hook up limits (eg:
once daily), pointer to most recent, fetching, etc...

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/3065)

<!-- Reviewable:end -->
