### PR TITLE
Reduce allocations during SQL execution.

### DIFF
--- a/sql/group.go
+++ b/sql/group.go
@@ -39,7 +39,7 @@ func (p *planner) groupBy(n *parser.Select, s *scanNode) (*groupNode, error) {
 	// Loop over the render expressions and extract any aggregate functions.
 	var funcs []*aggregateFunc
 	for i, r := range s.render {
-		r, f, err := extractAggregateFuncs(r)
+		r, f, err := p.extractAggregateFuncs(r)
 		if err != nil {
 			return nil, err
 		}
@@ -276,10 +276,14 @@ func (v *extractAggregatesVisitor) Visit(expr parser.Expr, pre bool) (parser.Vis
 	return v, expr
 }
 
-func extractAggregateFuncs(expr parser.Expr) (parser.Expr, []*aggregateFunc, error) {
-	v := extractAggregatesVisitor{}
-	expr = parser.WalkExpr(&v, expr)
+func (v *extractAggregatesVisitor) run(expr parser.Expr) (parser.Expr, []*aggregateFunc, error) {
+	*v = extractAggregatesVisitor{}
+	expr = parser.WalkExpr(v, expr)
 	return expr, v.funcs, v.err
+}
+
+func (p *planner) extractAggregateFuncs(expr parser.Expr) (parser.Expr, []*aggregateFunc, error) {
+	return p.extractAggregatesVisitor.run(expr)
 }
 
 type checkAggregateVisitor struct {

--- a/sql/group_test.go
+++ b/sql/group_test.go
@@ -21,11 +21,17 @@ import (
 	"reflect"
 	"testing"
 
+	"github.com/cockroachdb/cockroach/sql/parser"
 	"github.com/cockroachdb/cockroach/util/leaktest"
 )
 
 func TestDesiredAggregateOrder(t *testing.T) {
 	defer leaktest.AfterTest(t)
+
+	extractAggregateFuncs := func(expr parser.Expr) (parser.Expr, []*aggregateFunc, error) {
+		var v extractAggregatesVisitor
+		return v.run(expr)
+	}
 
 	testData := []struct {
 		expr     string

--- a/sql/insert.go
+++ b/sql/insert.go
@@ -301,7 +301,7 @@ func (p *planner) makeDefaultExprs(cols []ColumnDescriptor) ([]parser.Expr, erro
 		if err != nil {
 			return nil, err
 		}
-		expr, err = p.evalCtx.NormalizeExpr(expr)
+		expr, err = p.parser.NormalizeExpr(p.evalCtx, expr)
 		if err != nil {
 			return nil, err
 		}

--- a/sql/limit.go
+++ b/sql/limit.go
@@ -51,7 +51,7 @@ func (p *planner) limit(n *parser.Select, plan planNode) (planNode, error) {
 				return nil, fmt.Errorf("argument of %s must not contain variables", datum.name)
 			}
 
-			normalized, err := p.evalCtx.NormalizeExpr(datum.src)
+			normalized, err := p.parser.NormalizeExpr(p.evalCtx, datum.src)
 			if err != nil {
 				return nil, err
 			}

--- a/sql/parser/parse.go
+++ b/sql/parser/parse.go
@@ -55,13 +55,55 @@ const (
 	Modern
 )
 
+// Parser wraps a scanner, parser and other utilities present in the parser
+// package.
+type Parser struct {
+	scanner          scanner
+	parserImpl       sqlParserImpl
+	argVisitor       argVisitor
+	normalizeVisitor normalizeVisitor
+}
+
+// Parse parses the sql and returns a list of statements.
+func (p *Parser) Parse(sql string, syntax Syntax) (StatementList, error) {
+	p.scanner.init(sql, syntax)
+	if p.parserImpl.Parse(&p.scanner) != 0 {
+		return nil, errors.New(p.scanner.lastError)
+	}
+	return p.scanner.stmts, nil
+}
+
+// FillArgs replaces any placeholder nodes in the expression with arguments
+// supplied with the query.
+func (p *Parser) FillArgs(stmt Statement, args Args) error {
+	p.argVisitor = argVisitor{args: args}
+	WalkStmt(&p.argVisitor, stmt)
+	return p.argVisitor.err
+}
+
+// NormalizeExpr is wrapper around ctx.NormalizeExpr which avoids allocation of
+// a normalizeVisitor.
+func (p *Parser) NormalizeExpr(ctx EvalContext, expr Expr) (Expr, error) {
+	p.normalizeVisitor = normalizeVisitor{ctx: ctx}
+	expr = WalkExpr(&p.normalizeVisitor, expr)
+	return expr, p.normalizeVisitor.err
+}
+
+// TypeCheckAndNormalizeExpr is a combination of TypeCheck() and
+// NormalizeExpr(). It returns an error if either of TypeCheck() or
+// NormalizeExpr() return one, and otherwise returns the Expr returned by
+// NormalizeExpr().
+func (p *Parser) TypeCheckAndNormalizeExpr(ctx EvalContext, expr Expr) (Expr, error) {
+	if _, err := expr.TypeCheck(); err != nil {
+		return nil, err
+	}
+	return p.NormalizeExpr(ctx, expr)
+}
+
 // Parse parses the sql and returns a list of statements.
 func Parse(sql string, syntax Syntax) (StatementList, error) {
-	s := newScanner(sql, syntax)
-	if sqlParse(s) != 0 {
-		return nil, errors.New(s.lastError)
-	}
-	return s.stmts, nil
+	var p Parser
+	return p.Parse(sql, syntax)
 }
 
 // ParseTraditional is short-hand for Parse(sql, Traditional)

--- a/sql/parser/scan.go
+++ b/sql/parser/scan.go
@@ -42,8 +42,15 @@ type scanner struct {
 	syntax      Syntax
 }
 
-func newScanner(str string, syntax Syntax) *scanner {
-	s := &scanner{in: str, syntax: syntax}
+func makeScanner(str string, syntax Syntax) scanner {
+	var s scanner
+	s.init(str, syntax)
+	return s
+}
+
+func (s *scanner) init(str string, syntax Syntax) {
+	s.in = str
+	s.syntax = syntax
 	switch syntax {
 	case Traditional:
 		s.identQuote = '"'
@@ -51,7 +58,6 @@ func newScanner(str string, syntax Syntax) *scanner {
 		s.identQuote = '`'
 		s.stringQuote = '"'
 	}
-	return s
 }
 
 func (s *scanner) Lex(lval *sqlSymType) int {

--- a/sql/parser/scan_test.go
+++ b/sql/parser/scan_test.go
@@ -93,7 +93,7 @@ func TestScanner(t *testing.T) {
 		{`1e-1`, []int{FCONST}},
 	}
 	for i, d := range testData {
-		s := newScanner(d.sql, Traditional)
+		s := makeScanner(d.sql, Traditional)
 		var tokens []int
 		for {
 			var lval sqlSymType
@@ -129,7 +129,7 @@ func TestScannerModern(t *testing.T) {
 		{`$1 $foo $select`, []int{PARAM, PARAM, PARAM}},
 	}
 	for i, d := range testData {
-		s := newScanner(d.sql, Modern)
+		s := makeScanner(d.sql, Modern)
 		var tokens []int
 		for {
 			var lval sqlSymType
@@ -166,7 +166,7 @@ foo`, "", "foo"},
 		{`/* /* */`, "unterminated comment", ""},
 	}
 	for i, d := range testData {
-		s := newScanner(d.sql, Traditional)
+		s := makeScanner(d.sql, Traditional)
 		var lval sqlSymType
 		present, ok := s.scanComment(&lval)
 		if d.err == "" && (!present || !ok) {
@@ -190,7 +190,7 @@ func TestScanCommentModern(t *testing.T) {
 foo`, "", "foo"},
 	}
 	for i, d := range testData {
-		s := newScanner(d.sql, Modern)
+		s := makeScanner(d.sql, Modern)
 		var lval sqlSymType
 		present, ok := s.scanComment(&lval)
 		if d.err == "" && (!present || !ok) {
@@ -206,7 +206,7 @@ foo`, "", "foo"},
 
 func TestScanKeyword(t *testing.T) {
 	for kwName, kwID := range keywords {
-		s := newScanner(kwName, Traditional)
+		s := makeScanner(kwName, Traditional)
 		var lval sqlSymType
 		id := s.Lex(&lval)
 		if kwID != id {
@@ -241,7 +241,7 @@ func TestScanNumber(t *testing.T) {
 		{`1e+3+`, `1e+3`, FCONST},
 	}
 	for _, d := range testData {
-		s := newScanner(d.sql, Traditional)
+		s := makeScanner(d.sql, Traditional)
 		var lval sqlSymType
 		id := s.Lex(&lval)
 		if d.id != id {
@@ -263,7 +263,7 @@ func TestScanParam(t *testing.T) {
 		{`$123`, 123},
 	}
 	for _, d := range testData {
-		s := newScanner(d.sql, Traditional)
+		s := makeScanner(d.sql, Traditional)
 		var lval sqlSymType
 		id := s.Lex(&lval)
 		if id != PARAM {
@@ -334,7 +334,7 @@ world'`, `hello
 world`},
 	}
 	for _, d := range testData {
-		s := newScanner(d.sql, Traditional)
+		s := makeScanner(d.sql, Traditional)
 		var lval sqlSymType
 		_ = s.Lex(&lval)
 		if d.expected != lval.str {
@@ -370,7 +370,7 @@ world`},
 world'`, `invalid syntax: embedded newline`},
 	}
 	for _, d := range testData {
-		s := newScanner(d.sql, Modern)
+		s := makeScanner(d.sql, Modern)
 		var lval sqlSymType
 		_ = s.Lex(&lval)
 		if d.expected != lval.str {
@@ -397,7 +397,7 @@ func TestScanError(t *testing.T) {
 		{`$9223372036854775809`, "integer value out of range"},
 	}
 	for _, d := range testData {
-		s := newScanner(d.sql, Traditional)
+		s := makeScanner(d.sql, Traditional)
 		var lval sqlSymType
 		id := s.Lex(&lval)
 		if id != ERROR {

--- a/sql/parser/type_check.go
+++ b/sql/parser/type_check.go
@@ -25,23 +25,6 @@ import (
 	"github.com/cockroachdb/cockroach/util"
 )
 
-// TypeCheckAndNormalizeExpr is a combination of TypeCheck() and
-// ctx.NormalizeExpr(). It returns an error if either of TypeCheck() or
-// ctx.NormalizeExpr() return one, and otherwise returns the Expr
-// returned by ctx.NormalizeExpr().
-func (ctx EvalContext) TypeCheckAndNormalizeExpr(expr Expr) (Expr, error) {
-	if _, err := expr.TypeCheck(); err != nil {
-		return nil, err
-	}
-
-	var err error
-	expr, err = ctx.NormalizeExpr(expr)
-	if err != nil {
-		return nil, err
-	}
-	return expr, nil
-}
-
 // TypeCheck implements the Expr interface.
 func (expr *AndExpr) TypeCheck() (Datum, error) {
 	return typeCheckBooleanExprs(expr.Left, expr.Right)

--- a/sql/plan.go
+++ b/sql/plan.go
@@ -46,6 +46,11 @@ type planner struct {
 	// TODO(pmattis): This is a hack to force updating to the latest version of a
 	// lease after a schema change operation such as CREATE INDEX.
 	modifiedSchemas []schemaInfo
+
+	parser                   parser.Parser
+	extractAggregatesVisitor extractAggregatesVisitor
+	params                   parameters
+	subqueryVisitor          subqueryVisitor
 }
 
 func (p *planner) setTxn(txn *client.Txn, timestamp time.Time) {

--- a/sql/scan.go
+++ b/sql/scan.go
@@ -396,7 +396,7 @@ func (n *scanNode) initWhere(where *parser.Where) error {
 	if n.err == nil {
 		// Normalize the expression (this will also evaluate any branches that are
 		// constant).
-		n.filter, n.err = n.planner.evalCtx.NormalizeExpr(n.filter)
+		n.filter, n.err = n.planner.parser.NormalizeExpr(n.planner.evalCtx, n.filter)
 	}
 	if n.err == nil {
 		n.filter, n.err = n.planner.expandSubqueries(n.filter, 1)
@@ -514,7 +514,8 @@ func (n *scanNode) addRender(target parser.SelectExpr) error {
 	}
 	// Type check the expression to memoize operators and functions.
 	var normalized parser.Expr
-	if normalized, n.err = n.planner.evalCtx.TypeCheckAndNormalizeExpr(resolved); n.err != nil {
+	normalized, n.err = n.planner.parser.TypeCheckAndNormalizeExpr(n.planner.evalCtx, resolved)
+	if n.err != nil {
 		return n.err
 	}
 	if normalized, n.err = n.planner.expandSubqueries(normalized, 1); n.err != nil {

--- a/sql/session.go
+++ b/sql/session.go
@@ -23,7 +23,7 @@ import (
 	"github.com/cockroachdb/cockroach/util"
 )
 
-func (s Session) getLocation() (*time.Location, error) {
+func (s *Session) getLocation() (*time.Location, error) {
 	switch t := s.Timezone.(type) {
 	case nil:
 		return time.UTC, nil

--- a/sql/sort.go
+++ b/sql/sort.go
@@ -44,7 +44,7 @@ func (p *planner) orderBy(n *parser.Select, s *scanNode) (*sortNode, error) {
 
 		// Normalize the expression which has the side-effect of evaluating
 		// constant expressions and unwrapping expressions like "((a))" to "a".
-		expr, err := p.evalCtx.NormalizeExpr(o.Expr)
+		expr, err := p.parser.NormalizeExpr(p.evalCtx, o.Expr)
 		if err != nil {
 			return nil, err
 		}

--- a/sql/values.go
+++ b/sql/values.go
@@ -34,7 +34,7 @@ func (p *planner) Values(n parser.Values) (planNode, error) {
 	for _, tuple := range n {
 		for i := range tuple {
 			var err error
-			tuple[i], err = p.evalCtx.TypeCheckAndNormalizeExpr(tuple[i])
+			tuple[i], err = p.parser.TypeCheckAndNormalizeExpr(p.evalCtx, tuple[i])
 			if err != nil {
 				return nil, err
 			}


### PR DESCRIPTION
Bundle a parser.scanner and parser.sqlParserImpl with some other
utilities into a parser.Parser structure. Bundling these structures
together removes the need to allocate them separately which is wasteful
when they are always used during SQL execution.

Embed parser.Parser and various visitors in sql.planner. sql.planner is
the central point of SQL execution and now it is used to minimize memory
allocations in common paths.

Use sync.Pool to allocate planner structs. Avoid an allocation for the
EvalContext.GetLocation closure.

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/3066)

<!-- Reviewable:end -->
