### PR TITLE
Fix a race in TestReplicateReAddAfterDown

### DIFF
--- a/storage/replica_data_iter_test.go
+++ b/storage/replica_data_iter_test.go
@@ -188,7 +188,7 @@ func TestReplicaDataIterator(t *testing.T) {
 	}
 
 	// Destroy range and verify that its data has been completely cleared.
-	if err := tc.rng.Destroy(); err != nil {
+	if err := tc.rng.Destroy(*tc.rng.Desc()); err != nil {
 		t.Fatal(err)
 	}
 	iter = newReplicaDataIterator(tc.rng.Desc(), tc.rng.store.Engine())

--- a/storage/replica_gc_queue.go
+++ b/storage/replica_gc_queue.go
@@ -122,7 +122,7 @@ func (q *replicaGCQueue) process(now roachpb.Timestamp, rng *Replica, _ *config.
 		if log.V(1) {
 			log.Infof("destroying local data from range %d", desc.RangeID)
 		}
-		if err := rng.store.RemoveReplica(rng); err != nil {
+		if err := rng.store.RemoveReplica(rng, replyDesc); err != nil {
 			return err
 		}
 
@@ -143,7 +143,7 @@ func (q *replicaGCQueue) process(now roachpb.Timestamp, rng *Replica, _ *config.
 		if err := rng.Destroy(); err != nil {
 			return err
 		}
-	} else if desc.RangeID != desc.RangeID {
+	} else if desc.RangeID != replyDesc.RangeID {
 		// If we get a different  range ID back, then the range has been merged
 		// away. But currentMember is true, so we are still a member of the
 		// subsuming range. Shut down raft processing for the former range
@@ -151,7 +151,7 @@ func (q *replicaGCQueue) process(now roachpb.Timestamp, rng *Replica, _ *config.
 		if log.V(1) {
 			log.Infof("removing merged range %d", desc.RangeID)
 		}
-		if err := rng.store.RemoveReplica(rng); err != nil {
+		if err := rng.store.RemoveReplica(rng, replyDesc); err != nil {
 			return err
 		}
 

--- a/storage/replica_gc_queue.go
+++ b/storage/replica_gc_queue.go
@@ -84,6 +84,9 @@ func (*replicaGCQueue) shouldQueue(now roachpb.Timestamp, rng *Replica,
 // process performs a consistent lookup on the range descriptor to see if we are
 // still a member of the range.
 func (q *replicaGCQueue) process(now roachpb.Timestamp, rng *Replica, _ *config.SystemConfig) error {
+	// Note that the Replicas field of desc is probably out of date, so
+	// we should only use `desc` for its static fields like RangeID and
+	// StartKey (and avoid rng.GetReplica() for the same reason).
 	desc := rng.Desc()
 
 	// Calls to RangeLookup typically use inconsistent reads, but we

--- a/storage/replica_gc_queue.go
+++ b/storage/replica_gc_queue.go
@@ -109,12 +109,11 @@ func (q *replicaGCQueue) process(now roachpb.Timestamp, rng *Replica, _ *config.
 
 	replyDesc := reply.Ranges[0]
 	currentMember := false
-	if me := rng.GetReplica(); me != nil {
-		for _, rep := range replyDesc.Replicas {
-			if rep.StoreID == me.StoreID {
-				currentMember = true
-				break
-			}
+	storeID := rng.store.StoreID()
+	for _, rep := range replyDesc.Replicas {
+		if rep.StoreID == storeID {
+			currentMember = true
+			break
 		}
 	}
 

--- a/storage/replica_gc_queue.go
+++ b/storage/replica_gc_queue.go
@@ -140,7 +140,7 @@ func (q *replicaGCQueue) process(now roachpb.Timestamp, rng *Replica, _ *config.
 			return nil
 		}
 
-		if err := rng.Destroy(); err != nil {
+		if err := rng.Destroy(replyDesc); err != nil {
 			return err
 		}
 	} else if desc.RangeID != replyDesc.RangeID {


### PR DESCRIPTION
The first commit in this series makes the race too rare to consistently reproduce, but I believe the other two commits are necessary to guarantee safety.

Fixes #2873

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/3070)

<!-- Reviewable:end -->
