### PR TITLE
Allow truncation of previously truncated raft logs to not return an error.

### DIFF
--- a/storage/replica_test.go
+++ b/storage/replica_test.go
@@ -2573,7 +2573,6 @@ func TestTruncateLog(t *testing.T) {
 
 	// Discard the first half of the log
 	truncateArgs := truncateLogArgs(indexes[5])
-
 	if _, err := client.SendWrapped(tc.Sender(), tc.rng.context(), &truncateArgs); err != nil {
 		t.Fatal(err)
 	}
@@ -2615,6 +2614,13 @@ func TestTruncateLog(t *testing.T) {
 	_, err = tc.rng.Term(indexes[3])
 	if err != raft.ErrUnavailable {
 		t.Errorf("expected ErrUnavailable, got %s", err)
+	}
+
+	// Truncating logs that have already been truncated should not return an
+	// error.
+	truncateArgs = truncateLogArgs(indexes[3])
+	if _, err = client.SendWrapped(tc.Sender(), tc.rng.context(), &truncateArgs); err != nil {
+		t.Fatal(err)
 	}
 }
 


### PR DESCRIPTION
This will remove the noise caused by the addition of the raft log queue seen in #3030. 

There is no harm in attempting to truncate a previously truncated raft log.

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/3072)

<!-- Reviewable:end -->
