### PR TITLE
Fix for #2593

### DIFF
--- a/storage/replica_test.go
+++ b/storage/replica_test.go
@@ -30,8 +30,6 @@ import (
 	"testing"
 	"time"
 
-	"golang.org/x/net/context"
-
 	"github.com/cockroachdb/cockroach/base"
 	"github.com/cockroachdb/cockroach/client"
 	"github.com/cockroachdb/cockroach/config"
@@ -3318,62 +3316,6 @@ func TestWriteWithoutCmdID(t *testing.T) {
 
 	if _, pErr := tc.rng.Send(tc.rng.context(), ba); pErr != nil {
 		t.Fatal(pErr)
-	}
-}
-
-func TestReplicaQuiesce(t *testing.T) {
-	defer leaktest.AfterTest(t)
-	tc := testContext{
-		rng: &Replica{},
-	}
-	tc.Start(t)
-	defer tc.Stop()
-
-	// Mock proposeRaftCommand to do nothing to get a pending command.
-	proposeRaftCommandFn := func(cmdIDKey, roachpb.RaftCommand) <-chan error {
-		ch := make(chan error, 1)
-		ch <- nil
-		return ch
-	}
-	rng, err := NewReplica(testRangeDescriptor(), tc.store)
-	rng.proposeRaftCommandFn = proposeRaftCommandFn
-	if err != nil {
-		t.Fatal(err)
-	}
-	if err := tc.store.AddReplicaTest(rng); err != nil {
-		t.Fatal(err)
-	}
-
-	args := putArgs(roachpb.Key("a"), nil)
-	var ba roachpb.BatchRequest
-	ba.Add(&args)
-
-	_, cmd := rng.proposeRaftCommand(context.Background(), ba)
-	rng.Quiesce()
-
-	select {
-	default:
-		t.Fatal("command was not canceled on Quiesce")
-	case rwe := <-cmd.done:
-		if rwe.Err != multiraft.ErrGroupDeleted {
-			t.Fatal(err)
-		}
-	}
-
-	rng.Lock()
-	if rng.pendingCmds != nil {
-		t.Error("expected rng.pendingCmds to be nil")
-	}
-	rng.Unlock()
-
-	errChan, _ := rng.proposeRaftCommand(context.Background(), ba)
-	select {
-	default:
-		t.Fatal("accepted new command after Quiesce")
-	case err := <-errChan:
-		if err != multiraft.ErrGroupDeleted {
-			t.Fatal(err)
-		}
 	}
 }
 

--- a/storage/store.go
+++ b/storage/store.go
@@ -1103,13 +1103,6 @@ func (s *Store) removeReplicaImpl(rep *Replica, origDesc roachpb.RangeDescriptor
 			rep, rd.ReplicaID, origDesc.NextReplicaID)
 	}
 
-	// Silence the Replica. This clears all outstanding commands and makes
-	// sure that whatever else slips in winds up with a RangeNotFoundError.
-	// Before this change, clients would be signaled that their command had
-	// been aborted when in fact it could commit just after that, which led
-	// to #2593.
-	rep.Quiesce()
-
 	// RemoveGroup needs to access the storage, which in turn needs the
 	// lock. Some care is needed to avoid deadlocks. We remove the group
 	// from multiraft outside the scope of s.mu; this is effectively


### PR DESCRIPTION
Finally got to the bottom of this, with special thanks to Tobias, Tamir and Ben.

The test which exercises this most consistently is TestStoreRangeRebalance; however, it was only able to quickly reproduce this in the multicpu branch, where it was reproduced with reliability.

A six node cluster was able to run stably under load for well over an hour with this fix; the bug appears to be completely gone.

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/3074)

<!-- Reviewable:end -->
