### PR TITLE
default to 512MB cache for RocksDB

### DIFF
--- a/server/context.go
+++ b/server/context.go
@@ -38,7 +38,7 @@ import (
 const (
 	defaultAddr               = ":26257"
 	defaultMaxOffset          = 250 * time.Millisecond
-	defaultCacheSize          = 1 << 30 // GB
+	defaultCacheSize          = 1 << 29 // 512MB
 	defaultScanInterval       = 10 * time.Minute
 	defaultScanMaxIdleTime    = 5 * time.Second
 	defaultMetricsFrequency   = 10 * time.Second


### PR DESCRIPTION
will be refined with #2965, but for now this will avoid
the default docker containers from OOMing.

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/3093)

<!-- Reviewable:end -->
