### PR TITLE
prevent point requests to KeyMin

### DIFF
--- a/kv/dist_sender_server_test.go
+++ b/kv/dist_sender_server_test.go
@@ -395,12 +395,16 @@ func TestBadRequest(t *testing.T) {
 		t.Fatal(err)
 	}
 
+	if _, err := db.Scan("", "", 0); !testutils.IsError(err, "truncation resulted in empty batch") {
+		t.Fatalf("unexpected error on scan with start=end=KeyMin: %v", err)
+	}
+
 	if _, err := db.Scan("a", "a", 0); !testutils.IsError(err, "truncation resulted in empty batch") {
-		t.Fatalf("unexpected error on scan with startkey == endkey: %v", err)
+		t.Fatalf("unexpected error on scan with start=end: %v", err)
 	}
 
 	if _, err := db.ReverseScan("a", "a", 0); !testutils.IsError(err, "truncation resulted in empty batch") {
-		t.Fatalf("unexpected error on reverse scan with startkey == endkey: %v", err)
+		t.Fatalf("unexpected error on reverse scan with start=end: %v", err)
 	}
 
 	if err := db.DelRange("x", "a"); !testutils.IsError(err, "truncation resulted in empty batch") {

--- a/storage/client_merge_test.go
+++ b/storage/client_merge_test.go
@@ -43,7 +43,7 @@ func adminMergeArgs(key roachpb.Key) roachpb.AdminMergeRequest {
 }
 
 func createSplitRanges(store *storage.Store) (*roachpb.RangeDescriptor, *roachpb.RangeDescriptor, error) {
-	args := adminSplitArgs(roachpb.KeyMin, []byte("b"))
+	args := adminSplitArgs(roachpb.KeyMin.Next(), []byte("b"))
 	if _, err := client.SendWrapped(rg1(store), nil, &args); err != nil {
 		return nil, nil, err
 	}
@@ -70,7 +70,7 @@ func TestStoreRangeMergeTwoEmptyRanges(t *testing.T) {
 	}
 
 	// Merge the b range back into the a range.
-	args := adminMergeArgs(roachpb.KeyMin)
+	args := adminMergeArgs(roachpb.KeyMin.Next())
 	_, err := client.SendWrapped(rg1(store), nil, &args)
 	if err != nil {
 		t.Fatal(err)
@@ -127,7 +127,7 @@ func TestStoreRangeMergeMetadataCleanup(t *testing.T) {
 	}
 
 	// Merge the b range back into the a range.
-	args := adminMergeArgs(roachpb.KeyMin)
+	args := adminMergeArgs(roachpb.KeyMin.Next())
 	if _, err := client.SendWrapped(rg1(store), nil, &args); err != nil {
 		t.Fatal(err)
 	}
@@ -209,7 +209,7 @@ func TestStoreRangeMergeWithData(t *testing.T) {
 	}
 
 	// Merge the b range back into the a range.
-	args := adminMergeArgs(roachpb.KeyMin)
+	args := adminMergeArgs(roachpb.KeyMin.Next())
 	if _, err := client.SendWrapped(rg1(store), nil, &args); err != nil {
 		t.Fatal(err)
 	}
@@ -294,7 +294,7 @@ func TestStoreRangeMergeLastRange(t *testing.T) {
 	defer stopper.Stop()
 
 	// Merge last range.
-	args := adminMergeArgs(roachpb.KeyMin)
+	args := adminMergeArgs(roachpb.KeyMin.Next())
 	if _, err := client.SendWrapped(rg1(store), nil, &args); !testutils.IsError(err, "cannot merge final range") {
 		t.Fatalf("expected 'cannot merge final range' error; got %s", err)
 	}
@@ -310,11 +310,11 @@ func TestStoreRangeMergeNonCollocated(t *testing.T) {
 	store := mtc.stores[0]
 
 	// Split into 3 ranges
-	argsSplit := adminSplitArgs(roachpb.KeyMin, []byte("d"))
+	argsSplit := adminSplitArgs(roachpb.KeyMin.Next(), []byte("d"))
 	if _, err := client.SendWrapped(rg1(store), nil, &argsSplit); err != nil {
 		t.Fatalf("Can't split range %s", err)
 	}
-	argsSplit = adminSplitArgs(roachpb.KeyMin, []byte("b"))
+	argsSplit = adminSplitArgs(roachpb.KeyMin.Next(), []byte("b"))
 	if _, err := client.SendWrapped(rg1(store), nil, &argsSplit); err != nil {
 		t.Fatalf("Can't split range %s", err)
 	}

--- a/storage/store.go
+++ b/storage/store.go
@@ -93,6 +93,9 @@ func verifyKeys(start, end roachpb.Key, checkEndKey bool) error {
 		if len(end) != 0 {
 			return util.Errorf("end key %q should not be specified for this operation", end)
 		}
+		if bytes.Equal(start, roachpb.KeyMin) {
+			return util.Errorf("point requests to KeyMin are not allowed")
+		}
 		return nil
 	}
 	if end == nil {

--- a/storage/store.go
+++ b/storage/store.go
@@ -1173,7 +1173,7 @@ func (s *Store) Send(ctx context.Context, ba roachpb.BatchRequest) (*roachpb.Bat
 	for _, union := range ba.Requests {
 		arg := union.GetInner()
 		header := arg.Header()
-		if err := verifyKeys(header.Key, header.EndKey, roachpb.IsRange(arg)); err != nil {
+		if err := verifyKeys(header.Key, header.EndKey, roachpb.IsRange(arg)); err != nil && arg.Method() != roachpb.Noop {
 			return nil, roachpb.NewError(err)
 		}
 	}

--- a/storage/store_test.go
+++ b/storage/store_test.go
@@ -1474,6 +1474,8 @@ func TestStoreBadRequests(t *testing.T) {
 
 	txn := newTransaction("test", roachpb.Key("a"), 1 /* priority */, roachpb.SERIALIZABLE, store.ctx.Clock)
 
+	args0 := getArgs(roachpb.KeyMin)
+
 	args1 := getArgs(roachpb.Key("a"))
 	args1.EndKey = roachpb.Key("b")
 
@@ -1502,6 +1504,7 @@ func TestStoreBadRequests(t *testing.T) {
 		header *roachpb.Header
 		err    string
 	}{
+		{&args0, nil, "point requests to KeyMin are not allowed"},
 		// EndKey for non-Range is invalid.
 		{&args1, nil, "should not be specified"},
 		// Start key must be less than KeyMax.


### PR DESCRIPTION
in particular, this prevents commands which fail to
specify keys at all to go through.

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/3095)

<!-- Reviewable:end -->
