### PR TITLE
Eliminate memory allocations in MVCCComputeStats.

### DIFF
--- a/storage/engine/engine.go
+++ b/storage/engine/engine.go
@@ -57,6 +57,8 @@ type Iterator interface {
 	// ValueProto unmarshals the value the iterator is currently
 	// pointing to using a protobuf decoder.
 	ValueProto(msg proto.Message) error
+	unsafeKey() MVCCKey
+	unsafeValue() []byte
 	// Error returns the error, if any, which the iterator encountered.
 	Error() error
 }

--- a/storage/engine/engine.go
+++ b/storage/engine/engine.go
@@ -57,7 +57,11 @@ type Iterator interface {
 	// ValueProto unmarshals the value the iterator is currently
 	// pointing to using a protobuf decoder.
 	ValueProto(msg proto.Message) error
+	// unsafeKey returns the same value as Key, but the memory is invalidated on
+	// the next call to {Next,Prev,Seek,SeekReverse,Close}.
 	unsafeKey() MVCCKey
+	// unsafeKey returns the same value as Value, but the memory is invalidated
+	// on the next call to {Next,Prev,Seek,SeekReverse,Close}.
 	unsafeValue() []byte
 	// Error returns the error, if any, which the iterator encountered.
 	Error() error

--- a/storage/engine/rocksdb.go
+++ b/storage/engine/rocksdb.go
@@ -798,6 +798,16 @@ func (r *rocksDBIterator) ValueProto(msg proto.Message) error {
 	return proto.Unmarshal(data, msg)
 }
 
+func (r *rocksDBIterator) unsafeKey() MVCCKey {
+	data := C.DBIterKey(r.iter)
+	return cSliceToUnsafeGoBytes(data)
+}
+
+func (r *rocksDBIterator) unsafeValue() []byte {
+	data := C.DBIterValue(r.iter)
+	return cSliceToUnsafeGoBytes(data)
+}
+
 func (r *rocksDBIterator) Error() error {
 	return statusToError(C.DBIterError(r.iter))
 }

--- a/storage/engine/rocksdb/db.cc
+++ b/storage/engine/rocksdb/db.cc
@@ -124,6 +124,21 @@ rocksdb::ReadOptions MakeReadOptions(DBSnapshot* snap) {
   return options;
 }
 
+DBIterState DBIterGetState(DBIterator* iter) {
+  DBIterState state;
+  state.valid = iter->rep->Valid();
+  if (state.valid) {
+    state.key = ToDBSlice(iter->rep->key());
+    state.value = ToDBSlice(iter->rep->value());
+  } else {
+    state.key.data = NULL;
+    state.key.len = 0;
+    state.value.data = NULL;
+    state.value.len = 0;
+  }
+  return state;
+}
+
 // DBCompactionFilter implements our garbage collection policy for
 // key/value pairs which can be considered in isolation. This
 // includes:
@@ -1124,36 +1139,29 @@ void DBIterDestroy(DBIterator* iter) {
   delete iter;
 }
 
-void DBIterSeek(DBIterator* iter, DBSlice key) {
+DBIterState DBIterSeek(DBIterator* iter, DBSlice key) {
   iter->rep->Seek(ToSlice(key));
+  return DBIterGetState(iter);
 }
 
-void DBIterSeekToFirst(DBIterator* iter) {
+DBIterState DBIterSeekToFirst(DBIterator* iter) {
   iter->rep->SeekToFirst();
+  return DBIterGetState(iter);
 }
 
-void DBIterSeekToLast(DBIterator* iter) {
+DBIterState DBIterSeekToLast(DBIterator* iter) {
   iter->rep->SeekToLast();
+  return DBIterGetState(iter);
 }
 
-int DBIterValid(DBIterator* iter) {
-  return iter->rep->Valid();
-}
-
-void DBIterNext(DBIterator* iter) {
+DBIterState DBIterNext(DBIterator* iter) {
   iter->rep->Next();
+  return DBIterGetState(iter);
 }
 
-void DBIterPrev(DBIterator* iter){
-	iter->rep->Prev();
-}
-
-DBSlice DBIterKey(DBIterator* iter) {
-  return ToDBSlice(iter->rep->key());
-}
-
-DBSlice DBIterValue(DBIterator* iter) {
-  return ToDBSlice(iter->rep->value());
+DBIterState DBIterPrev(DBIterator* iter){
+  iter->rep->Prev();
+  return DBIterGetState(iter);
 }
 
 DBStatus DBIterError(DBIterator* iter) {

--- a/storage/engine/rocksdb/db.h
+++ b/storage/engine/rocksdb/db.h
@@ -38,6 +38,12 @@ typedef struct {
   int len;
 } DBString;
 
+typedef struct {
+  int valid;
+  DBSlice key;
+  DBSlice value;
+} DBIterState;
+
 // A DBStatus is an alias for DBString and is used to indicate that
 // the return value indicates the success or failure of an
 // operation. If DBStatus.data == NULL the operation succeeded.
@@ -120,35 +126,23 @@ DBIterator* DBNewIter(DBEngine* db, DBSnapshot* snapshot);
 void DBIterDestroy(DBIterator* iter);
 
 // Positions the iterator at the first key that is >= "key".
-void DBIterSeek(DBIterator* iter, DBSlice key);
+DBIterState DBIterSeek(DBIterator* iter, DBSlice key);
 
 // Positions the iterator at the first key in the database.
-void DBIterSeekToFirst(DBIterator* iter);
+DBIterState DBIterSeekToFirst(DBIterator* iter);
 
 // Positions the iterator at the last key in the database.
-void DBIterSeekToLast(DBIterator* iter);
-
-// Returns 1 if the iterator is positioned at a valid key/value pair
-// and 0 otherwise.
-int  DBIterValid(DBIterator* iter);
+DBIterState DBIterSeekToLast(DBIterator* iter);
 
 // Advances the iterator to the next key. After this call,
 // DBIterValid() returns 1 iff the iterator was not positioned at the
 // last key.
-void DBIterNext(DBIterator* iter);
+DBIterState DBIterNext(DBIterator* iter);
 
 // Moves the iterator back to the previous key. After this call,
 // DBIterValid() returns 1 iff the iterator was not positioned at the
 // first key.
-void DBIterPrev(DBIterator* iter);
-
-// Returns the key at the current iterator position. Note that a slice
-// is returned and the memory does not have to be freed.
-DBSlice DBIterKey(DBIterator* iter);
-
-// Returns the value at the current iterator position. Note that a
-// slice is returned and the memory does not have to be freed.
-DBSlice DBIterValue(DBIterator* iter);
+DBIterState DBIterPrev(DBIterator* iter);
 
 // Returns any error associated with the iterator.
 DBStatus DBIterError(DBIterator* iter);

--- a/storage/engine/rocksdb_test.go
+++ b/storage/engine/rocksdb_test.go
@@ -485,7 +485,7 @@ func BenchmarkMVCCMergeTimeSeries(b *testing.B) {
 	runMVCCMerge(&value, 1024, b)
 }
 
-// runMVCCComputeStats merges value into numKeys separate keys.
+// runMVCCComputeStats benchmarks computing MVCC stats on a 64MB range of data.
 func runMVCCComputeStats(valueBytes int, b *testing.B) {
 	const rangeBytes = 64 * 1024 * 1024
 	const overhead = 48 // Per key/value overhead (empirically determined)


### PR DESCRIPTION
Reworked the MVCCComputeStats benchmark to use 64MB ranges. Added
Iterator.unsafe{Key,Value} to avoid copying data. Added mvccDecodeKey to
avoid allocating memory during key decoding.

```
name                                old time/op    new time/op     delta
MVCCComputeStats1Version8Bytes-8       4.05s ± 2%      2.09s ± 1%   -48.39%  (p=0.000 n=9+9)
MVCCComputeStats1Version32Bytes-8      2.85s ± 2%      1.47s ± 1%   -48.37%  (p=0.000 n=8+10)
MVCCComputeStats1Version256Bytes-8     796ms ± 1%      404ms ± 1%   -49.25%  (p=0.000 n=10+10)

name                                old speed      new speed       delta
MVCCComputeStats1Version8Bytes-8    16.6MB/s ± 1%   32.1MB/s ± 1%   +93.76%  (p=0.000 n=9+9)
MVCCComputeStats1Version32Bytes-8   23.4MB/s ± 7%   45.7MB/s ± 1%   +95.25%  (p=0.000 n=9+10)
MVCCComputeStats1Version256Bytes-8  84.3MB/s ± 1%  166.1MB/s ± 1%   +97.04%  (p=0.000 n=10+10)
```

The remaining perf issue is the overhead of individual cgo calls. Moving stats computation into C++ would give a pretty massive speedup, but would involve duplicating some of the stats computation code. 

I got rid of the multi-version benchmarks due to laziness about computing the per key/value overhead.

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/3096)

<!-- Reviewable:end -->
