### PR TITLE
Rebalance by default

### DIFF
--- a/cli/flags.go
+++ b/cli/flags.go
@@ -139,9 +139,10 @@ var flagUsage = map[string]string{
 	"allow-rebalancing": `
         Enables this server to rebalance replicas to other stores on the cluster.
 `,
-	"rebalance-mode": `
-		Determines the criteria used by nodes to make rebalancing decisions.
-		Valid options are "usage" (default), "rangecount", or "none".
+	"balance-mode": `
+		Determines the criteria used by nodes to make balanced allocation
+		decisions.  Valid options are "usage" (default), "rangecount", or
+		"none".
 `,
 }
 
@@ -179,7 +180,7 @@ func initFlags(ctx *server.Context) {
 		f.DurationVar(&ctx.MaxOffset, "max-offset", ctx.MaxOffset, flagUsage["max-offset"])
 		f.DurationVar(&ctx.MetricsFrequency, "metrics-frequency", ctx.MetricsFrequency, flagUsage["metrics-frequency"])
 		f.BoolVar(&ctx.AllowRebalancing, "allow-rebalancing", ctx.AllowRebalancing, flagUsage["allow-rebalancing"])
-		f.Var(&ctx.RebalanceMode, "rebalance-mode", flagUsage["rebalance-mode"])
+		f.Var(&ctx.BalanceMode, "balance-mode", flagUsage["balance-mode"])
 
 		// Security flags.
 		f.StringVar(&ctx.Certs, "certs", ctx.Certs, flagUsage["certs"])

--- a/cli/flags.go
+++ b/cli/flags.go
@@ -139,6 +139,10 @@ var flagUsage = map[string]string{
 	"allow-rebalancing": `
         Enables this server to rebalance replicas to other stores on the cluster.
 `,
+	"rebalance-mode": `
+		Determines the criteria used by nodes to make rebalancing decisions.
+		Valid options are "usage" (default), "rangecount", or "none".
+`,
 }
 
 func normalizeStdFlagName(s string) string {
@@ -175,6 +179,7 @@ func initFlags(ctx *server.Context) {
 		f.DurationVar(&ctx.MaxOffset, "max-offset", ctx.MaxOffset, flagUsage["max-offset"])
 		f.DurationVar(&ctx.MetricsFrequency, "metrics-frequency", ctx.MetricsFrequency, flagUsage["metrics-frequency"])
 		f.BoolVar(&ctx.AllowRebalancing, "allow-rebalancing", ctx.AllowRebalancing, flagUsage["allow-rebalancing"])
+		f.Var(&ctx.RebalanceMode, "rebalance-mode", flagUsage["rebalance-mode"])
 
 		// Security flags.
 		f.StringVar(&ctx.Certs, "certs", ctx.Certs, flagUsage["certs"])

--- a/cli/flags.go
+++ b/cli/flags.go
@@ -136,13 +136,9 @@ var flagUsage = map[string]string{
 	"max-results": `
         Define the maximum number of results that will be retrieved.
 `,
-	"allow-rebalancing": `
-        Enables this server to rebalance replicas to other stores on the cluster.
-`,
 	"balance-mode": `
 		Determines the criteria used by nodes to make balanced allocation
-		decisions.  Valid options are "usage" (default), "rangecount", or
-		"none".
+		decisions.  Valid options are "usage" (default) or "rangecount".
 `,
 }
 
@@ -179,7 +175,6 @@ func initFlags(ctx *server.Context) {
 		f.StringVar(&ctx.Stores, "stores", ctx.Stores, flagUsage["stores"])
 		f.DurationVar(&ctx.MaxOffset, "max-offset", ctx.MaxOffset, flagUsage["max-offset"])
 		f.DurationVar(&ctx.MetricsFrequency, "metrics-frequency", ctx.MetricsFrequency, flagUsage["metrics-frequency"])
-		f.BoolVar(&ctx.AllowRebalancing, "allow-rebalancing", ctx.AllowRebalancing, flagUsage["allow-rebalancing"])
 		f.Var(&ctx.BalanceMode, "balance-mode", flagUsage["balance-mode"])
 
 		// Security flags.

--- a/server/context.go
+++ b/server/context.go
@@ -44,7 +44,7 @@ const (
 	defaultScanMaxIdleTime    = 5 * time.Second
 	defaultMetricsFrequency   = 10 * time.Second
 	defaultTimeUntilStoreDead = 5 * time.Minute
-	defaultAllowRebalancing   = false
+	defaultAllowRebalancing   = true
 	defaultBalanceMode        = storage.BalanceModeUsage
 )
 

--- a/server/context.go
+++ b/server/context.go
@@ -44,7 +44,6 @@ const (
 	defaultScanMaxIdleTime    = 5 * time.Second
 	defaultMetricsFrequency   = 10 * time.Second
 	defaultTimeUntilStoreDead = 5 * time.Minute
-	defaultAllowRebalancing   = true
 	defaultBalanceMode        = storage.BalanceModeUsage
 )
 
@@ -94,9 +93,6 @@ type Context struct {
 	// CacheSize is the amount of memory in bytes to use for caching data.
 	// The value is split evenly between the stores if there are more than one.
 	CacheSize int64
-
-	// Enables this server to rebalance replicas to other servers.
-	AllowRebalancing bool
 
 	// BalanceMode determines how this node makes balancing decisions.
 	BalanceMode storage.BalanceMode
@@ -148,7 +144,6 @@ func (ctx *Context) InitDefaults() {
 	ctx.ScanMaxIdleTime = defaultScanMaxIdleTime
 	ctx.MetricsFrequency = defaultMetricsFrequency
 	ctx.TimeUntilStoreDead = defaultTimeUntilStoreDead
-	ctx.AllowRebalancing = defaultAllowRebalancing
 	ctx.BalanceMode = defaultBalanceMode
 }
 

--- a/server/context.go
+++ b/server/context.go
@@ -45,7 +45,7 @@ const (
 	defaultMetricsFrequency   = 10 * time.Second
 	defaultTimeUntilStoreDead = 5 * time.Minute
 	defaultAllowRebalancing   = false
-	defaultRebalanceMode      = storage.RebalanceModeUsage
+	defaultBalanceMode        = storage.BalanceModeUsage
 )
 
 // Context holds parameters needed to setup a server.
@@ -98,8 +98,8 @@ type Context struct {
 	// Enables this server to rebalance replicas to other servers.
 	AllowRebalancing bool
 
-	// RebalanceMode determines how this node makes rebalancing decisions.
-	RebalanceMode storage.RebalanceMode
+	// BalanceMode determines how this node makes balancing decisions.
+	BalanceMode storage.BalanceMode
 
 	// Parsed values.
 
@@ -149,7 +149,7 @@ func (ctx *Context) InitDefaults() {
 	ctx.MetricsFrequency = defaultMetricsFrequency
 	ctx.TimeUntilStoreDead = defaultTimeUntilStoreDead
 	ctx.AllowRebalancing = defaultAllowRebalancing
-	ctx.RebalanceMode = defaultRebalanceMode
+	ctx.BalanceMode = defaultBalanceMode
 }
 
 // Get the stores on both start and init.

--- a/server/context.go
+++ b/server/context.go
@@ -28,6 +28,7 @@ import (
 	"github.com/cockroachdb/cockroach/base"
 	"github.com/cockroachdb/cockroach/gossip/resolver"
 	"github.com/cockroachdb/cockroach/roachpb"
+	"github.com/cockroachdb/cockroach/storage"
 	"github.com/cockroachdb/cockroach/storage/engine"
 	"github.com/cockroachdb/cockroach/util"
 	"github.com/cockroachdb/cockroach/util/log"
@@ -44,6 +45,7 @@ const (
 	defaultMetricsFrequency   = 10 * time.Second
 	defaultTimeUntilStoreDead = 5 * time.Minute
 	defaultAllowRebalancing   = false
+	defaultRebalanceMode      = storage.RebalanceModeUsage
 )
 
 // Context holds parameters needed to setup a server.
@@ -96,6 +98,9 @@ type Context struct {
 	// Enables this server to rebalance replicas to other servers.
 	AllowRebalancing bool
 
+	// RebalanceMode determines how this node makes rebalancing decisions.
+	RebalanceMode storage.RebalanceMode
+
 	// Parsed values.
 
 	// Engines is the storage instances specified by Stores.
@@ -144,6 +149,7 @@ func (ctx *Context) InitDefaults() {
 	ctx.MetricsFrequency = defaultMetricsFrequency
 	ctx.TimeUntilStoreDead = defaultTimeUntilStoreDead
 	ctx.AllowRebalancing = defaultAllowRebalancing
+	ctx.RebalanceMode = defaultRebalanceMode
 }
 
 // Get the stores on both start and init.

--- a/server/server.go
+++ b/server/server.go
@@ -155,7 +155,7 @@ func NewServer(ctx *Context, stopper *stop.Stopper) (*Server, error) {
 		Tracer:          tracer,
 		StorePool:       s.storePool,
 		AllocatorOptions: storage.AllocatorOptions{
-			AllowRebalance: s.ctx.AllowRebalancing,
+			AllowRebalance: true,
 			Mode:           s.ctx.BalanceMode,
 		},
 	}

--- a/server/server.go
+++ b/server/server.go
@@ -154,9 +154,9 @@ func NewServer(ctx *Context, stopper *stop.Stopper) (*Server, error) {
 		EventFeed:       feed,
 		Tracer:          tracer,
 		StorePool:       s.storePool,
-		RebalancingOptions: storage.RebalancingOptions{
+		AllocatorOptions: storage.AllocatorOptions{
 			AllowRebalance: s.ctx.AllowRebalancing,
-			Mode:           s.ctx.RebalanceMode,
+			Mode:           s.ctx.BalanceMode,
 		},
 	}
 	s.node = NewNode(nCtx)

--- a/server/server.go
+++ b/server/server.go
@@ -156,6 +156,7 @@ func NewServer(ctx *Context, stopper *stop.Stopper) (*Server, error) {
 		StorePool:       s.storePool,
 		RebalancingOptions: storage.RebalancingOptions{
 			AllowRebalance: s.ctx.AllowRebalancing,
+			Mode:           s.ctx.RebalanceMode,
 		},
 	}
 	s.node = NewNode(nCtx)

--- a/storage/allocator.go
+++ b/storage/allocator.go
@@ -186,7 +186,7 @@ func MakeAllocator(storePool *StorePool, options AllocatorOptions) Allocator {
 	case BalanceModeRangeCount:
 		a.balancer = rangeCountBalancer{randGen}
 	default:
-		panic(fmt.Sprintf("AllocatorOptions specified invalid BalanceMode %s", options.Mode))
+		panic(fmt.Sprintf("AllocatorOptions specified invalid BalanceMode %s", options.Mode.String()))
 	}
 
 	return a

--- a/storage/allocator.go
+++ b/storage/allocator.go
@@ -71,69 +71,69 @@ const (
 	AllocatorRemoveDead
 )
 
-// A RebalanceMode is a configurable mode which effects how the allocator makes
+// A BalanceMode is a configurable mode which effects how the allocator makes
 // rebalancing decisions.
-type RebalanceMode int
+type BalanceMode int
 
 const (
-	// RebalanceModeUsage balances ranges between stores by primarily
+	// BalanceModeUsage balances ranges between stores by primarily
 	// considering disk space usage, but also considers range counts in nascent
 	// clusters.
-	RebalanceModeUsage RebalanceMode = iota
-	// RebalanceModeRangeCount balances ranges by considering the total range
+	BalanceModeUsage BalanceMode = iota
+	// BalanceModeRangeCount balances ranges by considering the total range
 	// count of each node.
-	RebalanceModeRangeCount
+	BalanceModeRangeCount
 )
 
-// rebalanceModeMap is used to map RebalanceMode values to strings, used for
+// balanceModeMap is used to map BalanceMode values to strings, used for
 // accepting command line options.
-var rebalanceModeMap = map[string]RebalanceMode{
-	"usage":      RebalanceModeUsage,
-	"rangecount": RebalanceModeRangeCount,
+var balanceModeMap = map[string]BalanceMode{
+	"usage":      BalanceModeUsage,
+	"rangecount": BalanceModeRangeCount,
 }
 
 // String is needed to implement the pflag.Value interface, allowing this to be
 // set from the command line.
-func (r *RebalanceMode) String() string {
-	for k, v := range rebalanceModeMap {
+func (r *BalanceMode) String() string {
+	for k, v := range balanceModeMap {
 		if *r == v {
 			return k
 		}
 	}
-	panic(fmt.Sprintf("invalid value %d of RebalanceMode variable", int(*r)))
+	panic(fmt.Sprintf("invalid value %d of BalanceMode variable", int(*r)))
 }
 
-// Set configures the given RebalanceMode from a string provided from the
+// Set configures the given BalanceMode from a string provided from the
 // command line. It returns an error if the provided string value is not
 // recognized. Needed to implement pflag.Value.
-func (r *RebalanceMode) Set(value string) error {
-	if v, ok := rebalanceModeMap[value]; ok {
+func (r *BalanceMode) Set(value string) error {
+	if v, ok := balanceModeMap[value]; ok {
 		*r = v
 		return nil
 	}
-	return fmt.Errorf("%s is not a valid rebalancing mode", value)
+	return fmt.Errorf("%s is not a valid balance mode", value)
 }
 
 // Type is needed by the pflag.Value interface.
-func (r *RebalanceMode) Type() string {
+func (r *BalanceMode) Type() string {
 	return "string"
 }
 
-var _ pflag.Value = new(RebalanceMode)
+var _ pflag.Value = new(BalanceMode)
 
-// RebalancingOptions are configurable options which effect the way that the
+// AllocatorOptions are configurable options which effect the way that the
 // replicate queue will handle rebalancing opportunities.
-type RebalancingOptions struct {
+type AllocatorOptions struct {
 	// AllowRebalance allows this store to attempt to rebalance its own
 	// replicas to other stores.
 	AllowRebalance bool
 
 	// Mode determines the strategy that will be used to locate stores for
-	// allocation decisions.
-	Mode RebalanceMode
+	// allocation decisions in a way that balances load across the cluster.
+	Mode BalanceMode
 
-	// Deterministic makes rebalance decisions deterministic, based on
-	// current cluster statistics. If this flag is not set, rebalance operations
+	// Deterministic makes allocation decisions deterministic, based on
+	// current cluster statistics. If this flag is not set, allocation operations
 	// will have random behavior. This flag is intended to be set for testing
 	// purposes only.
 	Deterministic bool
@@ -158,12 +158,12 @@ type RebalancingOptions struct {
 type Allocator struct {
 	storePool *StorePool
 	randGen   *rand.Rand
-	options   RebalancingOptions
+	options   AllocatorOptions
 	balancer  balancer
 }
 
 // MakeAllocator creates a new allocator using the specified StorePool.
-func MakeAllocator(storePool *StorePool, options RebalancingOptions) Allocator {
+func MakeAllocator(storePool *StorePool, options AllocatorOptions) Allocator {
 	var randSource rand.Source
 	if options.Deterministic {
 		randSource = rand.NewSource(777)
@@ -179,9 +179,9 @@ func MakeAllocator(storePool *StorePool, options RebalancingOptions) Allocator {
 
 	// Instantiate balancer based on provided options.
 	switch options.Mode {
-	case RebalanceModeUsage:
-		a.balancer = defaultBalancer{randGen}
-	case RebalanceModeRangeCount:
+	case BalanceModeUsage:
+		a.balancer = usageBalancer{randGen}
+	case BalanceModeRangeCount:
 		a.balancer = rangeCountBalancer{randGen}
 	}
 

--- a/storage/allocator_test.go
+++ b/storage/allocator_test.go
@@ -168,7 +168,7 @@ func createTestAllocator() (*stop.Stopper, *gossip.Gossip, *StorePool, Allocator
 	rpcContext := rpc.NewContext(&base.Context{}, hlc.NewClock(hlc.UnixNano), stopper)
 	g := gossip.New(rpcContext, gossip.TestBootstrap)
 	storePool := NewStorePool(g, TestTimeUntilStoreDeadOff, stopper)
-	a := MakeAllocator(storePool, RebalancingOptions{AllowRebalance: true})
+	a := MakeAllocator(storePool, AllocatorOptions{AllowRebalance: true})
 	return stopper, g, storePool, a
 }
 
@@ -1080,7 +1080,7 @@ func Example_rebalancing() {
 	stopper := stop.NewStopper()
 	defer stopper.Stop()
 	sp := NewStorePool(g, TestTimeUntilStoreDeadOff, stopper)
-	alloc := MakeAllocator(sp, RebalancingOptions{AllowRebalance: true, Deterministic: true})
+	alloc := MakeAllocator(sp, AllocatorOptions{AllowRebalance: true, Deterministic: true})
 
 	var wg sync.WaitGroup
 	g.RegisterCallback(gossip.MakePrefixPattern(gossip.KeyStorePrefix), func(_ string, _ roachpb.Value) { wg.Done() })

--- a/storage/balancer.go
+++ b/storage/balancer.go
@@ -168,15 +168,15 @@ func (ucb usedCapacityBalancer) improve(store *roachpb.StoreDescriptor, sl Store
 	return nil
 }
 
-// defaultBalancer is the default rebalancer currently used by Cockroach. It
-// multiplexes RangeCountBalancer and UsedCapacityBalancer, preferring the
-// latter but using RangeCountBalancer on clusters with very low average disk
+// usageBalancer is the default rebalancer currently used by Cockroach. It
+// multiplexes rangeCountBalancer and usedCapacityBalancer, preferring the
+// latter but using rangeCountBalancer on clusters with very low average disk
 // usage.
-type defaultBalancer struct {
+type usageBalancer struct {
 	rand *rand.Rand
 }
 
-func (db defaultBalancer) selectGood(sl StoreList, excluded nodeIDSet) *roachpb.StoreDescriptor {
+func (db usageBalancer) selectGood(sl StoreList, excluded nodeIDSet) *roachpb.StoreDescriptor {
 	if sl.used.mean < minFractionUsedThreshold {
 		rcb := rangeCountBalancer{db.rand}
 		return rcb.selectGood(sl, excluded)
@@ -185,7 +185,7 @@ func (db defaultBalancer) selectGood(sl StoreList, excluded nodeIDSet) *roachpb.
 	return ucb.selectGood(sl, excluded)
 }
 
-func (db defaultBalancer) selectBad(sl StoreList) *roachpb.StoreDescriptor {
+func (db usageBalancer) selectBad(sl StoreList) *roachpb.StoreDescriptor {
 	if sl.used.mean < minFractionUsedThreshold {
 		rcb := rangeCountBalancer{db.rand}
 		return rcb.selectBad(sl)
@@ -194,7 +194,7 @@ func (db defaultBalancer) selectBad(sl StoreList) *roachpb.StoreDescriptor {
 	return ucb.selectBad(sl)
 }
 
-func (db defaultBalancer) improve(store *roachpb.StoreDescriptor, sl StoreList, excluded nodeIDSet) *roachpb.StoreDescriptor {
+func (db usageBalancer) improve(store *roachpb.StoreDescriptor, sl StoreList, excluded nodeIDSet) *roachpb.StoreDescriptor {
 	if sl.used.mean < minFractionUsedThreshold {
 		rcb := rangeCountBalancer{db.rand}
 		return rcb.improve(store, sl, excluded)

--- a/storage/client_raft_test.go
+++ b/storage/client_raft_test.go
@@ -1216,7 +1216,7 @@ func TestStoreRangeRebalance(t *testing.T) {
 		storeContext: &storage.StoreContext{},
 	}
 	*mtc.storeContext = storage.TestStoreContext
-	mtc.storeContext.RebalancingOptions = storage.RebalancingOptions{
+	mtc.storeContext.AllocatorOptions = storage.AllocatorOptions{
 		AllowRebalance: true,
 		Deterministic:  true,
 	}

--- a/storage/replicate_queue.go
+++ b/storage/replicate_queue.go
@@ -47,7 +47,7 @@ type replicateQueue struct {
 
 // newReplicateQueue returns a new instance of replicateQueue.
 func newReplicateQueue(gossip *gossip.Gossip, allocator Allocator, clock *hlc.Clock,
-	options RebalancingOptions) *replicateQueue {
+	options AllocatorOptions) *replicateQueue {
 	rq := &replicateQueue{
 		allocator: allocator,
 		clock:     clock,

--- a/storage/simulation/cluster.go
+++ b/storage/simulation/cluster.go
@@ -71,7 +71,7 @@ func createCluster(stopper *stop.Stopper, nodeCount int, epochWriter, actionWrit
 		rpc:       rpcContext,
 		gossip:    g,
 		storePool: storePool,
-		allocator: storage.MakeAllocator(storePool, storage.RebalancingOptions{
+		allocator: storage.MakeAllocator(storePool, storage.AllocatorOptions{
 			AllowRebalance: true,
 			Deterministic:  true,
 		}),

--- a/storage/store.go
+++ b/storage/store.go
@@ -305,9 +305,9 @@ type StoreContext struct {
 	// information about a store, it can be considered dead.
 	TimeUntilStoreDead time.Duration
 
-	// RebalancingOptions configures how the store will attempt to rebalance its
+	// AllocatorOptions configures how the store will attempt to rebalance its
 	// replicas to other stores.
-	RebalancingOptions RebalancingOptions
+	AllocatorOptions AllocatorOptions
 
 	// EventFeed is a feed to which this store will publish events.
 	EventFeed *util.Feed
@@ -359,7 +359,7 @@ func NewStore(ctx StoreContext, eng engine.Engine, nodeDesc *roachpb.NodeDescrip
 		ctx:               ctx,
 		db:                ctx.DB, // TODO(tschottdorf) remove redundancy.
 		engine:            eng,
-		allocator:         MakeAllocator(ctx.StorePool, ctx.RebalancingOptions),
+		allocator:         MakeAllocator(ctx.StorePool, ctx.AllocatorOptions),
 		replicas:          map[roachpb.RangeID]*Replica{},
 		replicasByKey:     btree.New(64 /* degree */),
 		uninitReplicas:    map[roachpb.RangeID]*Replica{},
@@ -373,7 +373,7 @@ func NewStore(ctx StoreContext, eng engine.Engine, nodeDesc *roachpb.NodeDescrip
 	s.gcQueue = newGCQueue(s.ctx.Gossip)
 	s.splitQueue = newSplitQueue(s.db, s.ctx.Gossip)
 	s.verifyQueue = newVerifyQueue(s.ctx.Gossip, s.ReplicaCount)
-	s.replicateQueue = newReplicateQueue(s.ctx.Gossip, s.allocator, s.ctx.Clock, s.ctx.RebalancingOptions)
+	s.replicateQueue = newReplicateQueue(s.ctx.Gossip, s.allocator, s.ctx.Clock, s.ctx.AllocatorOptions)
 	s.replicaGCQueue = newReplicaGCQueue(s.db, s.ctx.Gossip, s.GroupLocker())
 	s.raftLogQueue = newRaftLogQueue(s.db, s.ctx.Gossip)
 	s.scanner.AddQueues(s.gcQueue, s.splitQueue, s.verifyQueue, s.replicateQueue, s.replicaGCQueue, s.raftLogQueue)


### PR DESCRIPTION
Three commits which enable rebalancing by default.  I think the server has reached a sufficient level of stability that this is now preferable.
- First commit adds a "balance-mode" flag, which allows users to select a non-default balancing strategy from the command line.  For instance, I will use this to select the RangeCountRebalancer when running multiple nodes on the same machine, since the usage-based balancer will not work very well in that scenario.  I'm assuming that this will also be useful in the future to test experimental balancing strategies.
- Second commit is just some mechanical renames for clarity.
- Third commit enables rebalancing by default.

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/3098)

<!-- Reviewable:end -->
