### PR TITLE
Build and push multiple binaries.

### DIFF
--- a/build/build-static-binaries.sh
+++ b/build/build-static-binaries.sh
@@ -1,7 +1,5 @@
 #!/bin/bash
-# Build a statically linked Cockroach binary
-#
-# Author: Peter Mattis (peter@cockroachlabs.com)
+# Build various statically linked binaries.
 
 set -euo pipefail
 
@@ -12,19 +10,18 @@ set -euo pipefail
 # commands in the if-branch to be executed within the docker
 # container.
 if [ "${1-}" = "docker" ]; then
-    time make STATIC=1 release
+    time make STATIC=1 build
+    time make STATIC=1 testbuild PKG=./sql
 
     # Make sure the created binary is statically linked.  Seems
     # awkward to do this programmatically, but this should work.
     file cockroach | grep -F 'statically linked' > /dev/null
+    file sql/sql.test | grep -F 'statically linked' > /dev/null
 
-    mv cockroach build/deploy/cockroach
-
+    strip -S cockroach
+    strip -S sql/sql.test
     exit 0
 fi
 
 # Build the cockroach and test binaries.
 $(dirname $0)/builder.sh $0 docker
-
-# Build the image.
-docker build --tag=cockroachdb/cockroach "$(dirname $0)/deploy"

--- a/build/push-aws.sh
+++ b/build/push-aws.sh
@@ -1,43 +1,58 @@
 #!/bin/bash
-# Push cockroach binaries to AWS.
+# Push binaries to AWS.
 # This is run by circle-ci after successful docker push.
 # Requisites:
+# - binaries must be statically linked by running build/build-static-binaries.sh
 # - circleci must have AWS credentials configured
 # - AWS credentials must have S3 write permissions on the bucket
 # - the aws cli must be installed on the machine
 # - the region must be configured
+#
+# Ask marc@cockroachlabs.com for the aws credentials file to use, then follow the
+# steps in circle.yml to configure aws and generate the binaries.
 
 set -eux
 
 BUCKET_PATH="cockroachdb/bin"
-LATEST="LATEST"
+LATEST_SUFFIX=".LATEST"
 
 now=$(date +"%Y%m%d-%H%M%S")
 today=$(echo ${now} | cut -d '-' -f1)
-binary_name="cockroach.${now}.${CIRCLE_SHA1}"
+binary_suffix=".${now}.${CIRCLE_SHA1-$(git rev-parse HEAD)}"
 
-# Fetch name of most recent binary.
-# TODO(marc): some versions of `aws s3 cp` allow - for stdin/stdout, but not all.
-tmpfile=$(mktemp /tmp/cockroach-push.XXXXXX)
-# Don't exit on errors, clearing the latest file is an easy way to force multiple uploads.
-time aws s3 cp s3://${BUCKET_PATH}/${LATEST} ${tmpfile} || true
-contents=$(cat ${tmpfile})
-rm -f ${tmpfile}
-latest_date=$(echo ${contents} | sed 's/cockroach.\([0-9]\+\)-.*/\1/')
+# push_one_binary takes the path to the binary inside the cockroach repo.
+# eg: push_one_binary sql/sql.test
+# The file will be pushed to: s3://BUCKET_PATH/sql.test.YYMMDD-HHMMSS.CIRCLESHA1
+# The S3 basename will be stored in s3://BUCKET_PATH/sql.test.LATEST
+function push_one_binary {
+  rel_path=$1
+  binary_name=$(basename $1)
 
-if [ "${latest_date}" == "${today}" ]; then
-  echo "Latest binary is from today, skipping: ${contents}"
-  exit 0
-fi
+  # Fetch name of most recent binary.
+  # TODO(marc): some versions of `aws s3 cp` allow - for stdin/stdout, but not all.
+  tmpfile=$(mktemp /tmp/cockroach-push.XXXXXX)
+  # Don't exit on errors, clearing the latest file is an easy way to force multiple uploads.
+  time aws s3 cp s3://${BUCKET_PATH}/${binary_name}${LATEST_SUFFIX} ${tmpfile} || true
+  contents=$(cat ${tmpfile})
+  rm -f ${tmpfile}
+  latest_date=$(echo ${contents} | sed 's/cockroach.\([0-9]\+\)-.*/\1/')
 
-# Latest file did not exist, was empty, or pointed to an old binary.
-# Upload binary.
-cd $(dirname $0)/..
-strip -S cockroach
-time aws s3 cp cockroach s3://${BUCKET_PATH}/${binary_name}
+  if [ "${latest_date}" == "${today}" ]; then
+    echo "Latest binary is from today, skipping: ${contents}"
+    exit 0
+  fi
 
-# Upload LATEST file.
-tmpfile=$(mktemp /tmp/cockroach-push.XXXXXX)
-echo ${binary_name} > ${tmpfile}
-time aws s3 cp ${tmpfile} s3://${BUCKET_PATH}/${LATEST}
-rm -f ${tmpfile}
+  # Latest file did not exist, was empty, or pointed to an old binary.
+  # Upload binary.
+  cd $(dirname $0)/..
+  time aws s3 cp ${rel_path} s3://${BUCKET_PATH}/${binary_name}${binary_suffix}
+
+  # Upload LATEST file.
+  tmpfile=$(mktemp /tmp/cockroach-push.XXXXXX)
+  echo ${binary_name}${binary_suffix} > ${tmpfile}
+  time aws s3 cp ${tmpfile} s3://${BUCKET_PATH}/${binary_name}${LATEST_SUFFIX}
+  rm -f ${tmpfile}
+}
+
+push_one_binary cockroach
+push_one_binary sql/sql.test

--- a/circle.yml
+++ b/circle.yml
@@ -13,8 +13,6 @@ dependencies:
   cache_directories:
     - ~/buildcache
     - ~/uicache
-  post:
-    - aws configure set region us-east-1
 
 test:
   override:
@@ -31,4 +29,6 @@ deployment:
           if [ -n "$DOCKER_EMAIL" ]; then
             build/push-docker-deploy.sh
           fi
+      - aws configure set region us-east-1
+      - build/build-static-binaries.sh
       - build/push-aws.sh


### PR DESCRIPTION
Push sql.test in addition to the cockroach binary.
This intentionally does not reuse the release binary as I'd like to be
able to decouple them at some point.

Running build/build-static-binaries.sh and build/push-aws.sh locally
works for me. I'll writeup how to setup the credentials for the latter.

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/3102)

<!-- Reviewable:end -->
