### PR TITLE
storage/engine: benchmark MVCCDeleteRange

### DIFF
--- a/GLOCKFILE
+++ b/GLOCKFILE
@@ -41,6 +41,7 @@ github.com/shurcooL/sanitized_anchor_name 10ef21a441db47d8b13ebcc5fd2310f636973c
 github.com/spf13/cobra 2ab15e2b40dbbe9e48d556cb90fb95b8f1f3f105
 github.com/spf13/pflag 08b1a584251b5b62f458943640fc8ebd4d50aaa5
 github.com/tebeka/go2xunit d45000af2242dd0e7b8c7b07d82a1068adc5fd40
+github.com/termie/go-shutil bcacb06fecaeec8dc42af03c87c6949f4a05c74c
 golang.org/x/crypto c8b9e6388ef638d5a8a9d865c634befdc46a6784
 golang.org/x/net 2fd7f1556cc0a4aa45f8aee9626ce303433f31eb
 golang.org/x/text 0fe7e6856182a6ebfcf1e6a7aa90bead9a8e1bc0

--- a/storage/engine/rocksdb_test.go
+++ b/storage/engine/rocksdb_test.go
@@ -77,7 +77,7 @@ func TestRocksDBCompaction(t *testing.T) {
 	defer leaktest.AfterTest(t)
 	stopper := stop.NewStopper()
 	defer stopper.Stop()
-	rocksdb := newMemRocksDB(roachpb.Attributes{Attrs: []string{"ssd"}}, testCacheSize, stopper)
+	rocksdb := newMemRocksDB(roachpb.Attributes{}, testCacheSize, stopper)
 	err := rocksdb.Open()
 	if err != nil {
 		t.Fatalf("could not create new in-memory rocksdb db instance: %v", err)
@@ -145,7 +145,7 @@ func setupMVCCScanData(numVersions, numKeys, valueBytes int, b *testing.B) (*Roc
 
 	const cacheSize = 8 << 30 // 8 GB
 	stopper := stop.NewStopper()
-	rocksdb := NewRocksDB(roachpb.Attributes{Attrs: []string{"ssd"}}, loc, cacheSize, stopper)
+	rocksdb := NewRocksDB(roachpb.Attributes{}, loc, cacheSize, stopper)
 	if err := rocksdb.Open(); err != nil {
 		b.Fatalf("could not create new rocksdb db instance at %s: %v", loc, err)
 	}
@@ -348,7 +348,7 @@ func runMVCCPut(valueSize int, b *testing.B) {
 
 	stopper := stop.NewStopper()
 	defer stopper.Stop()
-	rocksdb := NewInMem(roachpb.Attributes{Attrs: []string{"ssd"}}, testCacheSize, stopper)
+	rocksdb := NewInMem(roachpb.Attributes{}, testCacheSize, stopper)
 
 	b.SetBytes(int64(valueSize))
 	b.ResetTimer()
@@ -387,7 +387,7 @@ func runMVCCBatchPut(valueSize, batchSize int, b *testing.B) {
 
 	stopper := stop.NewStopper()
 	defer stopper.Stop()
-	rocksdb := NewInMem(roachpb.Attributes{Attrs: []string{"ssd"}}, testCacheSize, stopper)
+	rocksdb := NewInMem(roachpb.Attributes{}, testCacheSize, stopper)
 
 	b.SetBytes(int64(valueSize))
 	b.ResetTimer()
@@ -438,7 +438,7 @@ func BenchmarkMVCCBatch100000Put10(b *testing.B) {
 func runMVCCMerge(value *roachpb.Value, numKeys int, b *testing.B) {
 	stopper := stop.NewStopper()
 	defer stopper.Stop()
-	rocksdb := NewInMem(roachpb.Attributes{Attrs: []string{"ssd"}}, testCacheSize, stopper)
+	rocksdb := NewInMem(roachpb.Attributes{}, testCacheSize, stopper)
 
 	// Precompute keys so we don't waste time formatting them at each iteration.
 	keys := make([]roachpb.Key, numKeys)
@@ -508,7 +508,7 @@ func runMVCCDeleteRange(valueBytes int, b *testing.B) {
 			b.Fatal(err)
 		}
 		stopper := stop.NewStopper()
-		rocksdb := NewRocksDB(roachpb.Attributes{Attrs: []string{"ssd"}}, locDirty, rocksdb.cacheSize, stopper)
+		rocksdb := NewRocksDB(roachpb.Attributes{}, locDirty, rocksdb.cacheSize, stopper)
 		if err := rocksdb.Open(); err != nil {
 			b.Fatal(err)
 		}


### PR DESCRIPTION
Motivated by #3103. cc @petermattis @mrtracy 

```
$ go test ./storage/engine -run - -bench MVCCDeleteRange 2>/dev/null
PASS
BenchmarkMVCCDeleteRange1Version8Bytes-4          10     190795633 ns/op       2.75 MB/s
BenchmarkMVCCDeleteRange1Version32Bytes-4         10     128830121 ns/op       4.07 MB/s
BenchmarkMVCCDeleteRange1Version256Bytes-4        50      38724836 ns/op      13.54 MB/s
ok      github.com/cockroachdb/cockroach/storage/engine 13.159s

$ go test ./storage/engine -run - -bench MVCCDeleteRange -memprofilerate=1 -memprofile mem.out 2>/dev/null
...
$ go tool pprof --alloc_objects engine.test mem.out
Entering interactive mode (type "help" for commands)
(pprof) top10
934147 of 1136965 total (82.16%)
Dropped 142 nodes (cum <= 5684)
Showing top 10 nodes out of 34 (cum >= 534539)
      flat  flat%   sum%        cum   cum%
    133418 11.73% 11.73%     133418 11.73%  github.com/cockroachdb/cockroach/roachpb.(*Value).Unmarshal
    133418 11.73% 23.47%     133418 11.73%  github.com/cockroachdb/cockroach/storage/engine.(*MVCCMetadata).Marshal
    133418 11.73% 35.20%     133418 11.73%  github.com/cockroachdb/cockroach/storage/engine.(*MVCCValue).Marshal
    133418 11.73% 46.94%     333545 29.34%  github.com/cockroachdb/cockroach/storage/engine.(*RocksDB).getProtoInternal
     66913  5.89% 52.82%     401833 35.34%  github.com/cockroachdb/cockroach/storage/engine.setupMVCCData
     66726  5.87% 58.69%      66726  5.87%  github.com/cockroachdb/cockroach/storage/engine.mvccEncodeTimestamp
     66709  5.87% 64.56%      66744  5.87%  github.com/cockroachdb/cockroach/roachpb.(*Value).InitChecksum
     66709  5.87% 70.43%     200127 17.60%  github.com/cockroachdb/cockroach/storage/engine.(*MVCCValue).Unmarshal
     66709  5.87% 76.29%      66709  5.87%  github.com/cockroachdb/cockroach/storage/engine.(*rocksDBBatch).GetProto
     66709  5.87% 82.16%     534539 47.01%  github.com/cockroachdb/cockroach/storage/engine.MVCCIterate
```

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/3105)

<!-- Reviewable:end -->
