### PR TITLE
WIP: Update a batch request's txn from its response's in DistSender.sendChunk

### DIFF
--- a/kv/dist_sender.go
+++ b/kv/dist_sender.go
@@ -656,6 +656,7 @@ func (ds *DistSender) sendChunk(ctx context.Context, ba roachpb.BatchRequest) (*
 		if pErr != nil {
 			return nil, pErr
 		}
+		ba.Txn.Update(curReply.Txn)
 
 		first := br == nil
 		if first {


### PR DESCRIPTION
(Will add a test if the change makes sense.)

It seems we need this to update Txn.Writing properly. Otherwise, Writing might be set to false when a batch request fails in a middle of its chunk. For example, TestMultiRangeEmptyAfterTruncate sets Txn.Writing to true when the BeginTransaction succeeds. However, it will not be propagated to the next epoch of the transaction when a subsequent command fails. (TxnCoordSender.updateState just updates the txn from the txn stored in an error.)

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/3112)

<!-- Reviewable:end -->
