### PR TITLE
Refactor locking in `Store`

### DIFF
--- a/multiraft/multiraft.go
+++ b/multiraft/multiraft.go
@@ -806,7 +806,7 @@ func (s *state) handleMessage(req *RaftMessageRequest) {
 // messages (in which case the replicaID comes from the incoming
 // message, since nothing is on disk yet).
 func (s *state) createGroup(groupID roachpb.RangeID, replicaID roachpb.ReplicaID) error {
-	locker := s.Storage.GroupLocker()
+	locker := s.Storage.RaftLocker()
 	if locker != nil {
 		locker.Lock()
 		defer locker.Unlock()

--- a/multiraft/multiraft.go
+++ b/multiraft/multiraft.go
@@ -60,9 +60,6 @@ type Config struct {
 	Transport Transport
 	// Ticker may be nil to use real time and TickInterval.
 	Ticker Ticker
-	// StateMachine may be nil if the state machine is transient and always starts from
-	// a blank slate.
-	StateMachine StateMachine
 
 	// A new election is called if the election timeout elapses with no
 	// contact from the leader.  The actual timeout is chosen randomly
@@ -863,12 +860,9 @@ func (s *state) createGroup(groupID roachpb.RangeID, replicaID roachpb.ReplicaID
 		StoreID:   s.storeID,
 	})
 
-	var appliedIndex uint64
-	if s.StateMachine != nil {
-		appliedIndex, err = s.StateMachine.AppliedIndex(groupID)
-		if err != nil {
-			return err
-		}
+	appliedIndex, err := s.Storage.AppliedIndex(groupID)
+	if err != nil {
+		return err
 	}
 
 	raftCfg := &raft.Config{

--- a/multiraft/multiraft_test.go
+++ b/multiraft/multiraft_test.go
@@ -222,7 +222,10 @@ func TestLeaderElectionEvent(t *testing.T) {
 	// This happens while an election is in progress.
 	// This may be dirty, but it seems this is the only way to make testrace pass.
 	cluster.nodes[1].callbackChan <- func() {
-		cluster.nodes[1].maybeSendLeaderEvent(groupID, cluster.nodes[1].groups[groupID],
+		s := cluster.nodes[1]
+		s.lockStorage()
+		defer s.unlockStorage()
+		s.maybeSendLeaderEvent(groupID, s.groups[groupID],
 			&raft.Ready{
 				SoftState: &raft.SoftState{
 					Lead: 3,

--- a/multiraft/multiraft_test.go
+++ b/multiraft/multiraft_test.go
@@ -249,7 +249,10 @@ func TestLeaderElectionEvent(t *testing.T) {
 	}
 	// This may be dirty, but it seems this is the only way to make testrace pass.
 	cluster.nodes[1].callbackChan <- func() {
-		cluster.nodes[1].maybeSendLeaderEvent(groupID, cluster.nodes[1].groups[groupID],
+		s := cluster.nodes[1]
+		s.lockStorage()
+		defer s.unlockStorage()
+		s.maybeSendLeaderEvent(groupID, s.groups[groupID],
 			&raft.Ready{
 				Entries:          []raftpb.Entry{entry},
 				CommittedEntries: []raftpb.Entry{entry},

--- a/multiraft/storage.go
+++ b/multiraft/storage.go
@@ -59,21 +59,16 @@ type Storage interface {
 	// panics.
 	CanApplySnapshot(groupID roachpb.RangeID, snap raftpb.Snapshot) bool
 
-	// GroupLocker returns a lock which (if non-nil) will be acquired
-	// when a group is being created (which entails multiple calls to
-	// Storage and StateMachine methods and may race with the removal of
-	// a previous incarnation of a group). If it returns a non-nil value
-	// it must return the same value on every call.
-	GroupLocker() sync.Locker
-}
-
-// The StateMachine interface is supplied by the application to manage a persistent
-// state machine (in Cockroach the StateMachine and the Storage are the same thing
-// but they are logically distinct and systems like etcd keep them separate).
-type StateMachine interface {
 	// AppliedIndex returns the last index which has been applied to the given group's
 	// state machine.
 	AppliedIndex(groupID roachpb.RangeID) (uint64, error)
+
+	// GroupLocker returns a lock which (if non-nil) will be acquired
+	// when a group is being created (which entails multiple calls to
+	// Storage methods and may race with the removal of a previous
+	// incarnation of a group). If it returns a non-nil value it must
+	// return the same value on every call.
+	GroupLocker() sync.Locker
 }
 
 // MemoryStorage is an in-memory implementation of Storage for testing.
@@ -127,6 +122,12 @@ func (m *MemoryStorage) ReplicasFromSnapshot(_ raftpb.Snapshot) ([]roachpb.Repli
 // CanApplySnapshot implements the Storage interface.
 func (m *MemoryStorage) CanApplySnapshot(_ roachpb.RangeID, _ raftpb.Snapshot) bool {
 	return true
+}
+
+// AppliedIndex returns the last index which has been applied to the given group's
+// state machine.
+func (m *MemoryStorage) AppliedIndex(groupID roachpb.RangeID) (uint64, error) {
+	return 0, nil
 }
 
 // GroupLocker implements the Storage interface by returning nil.

--- a/multiraft/storage.go
+++ b/multiraft/storage.go
@@ -60,7 +60,8 @@ type Storage interface {
 	CanApplySnapshot(groupID roachpb.RangeID, snap raftpb.Snapshot) bool
 
 	// AppliedIndex returns the last index which has been applied to the given group's
-	// state machine.
+	// state machine. It is called when a group is created and is not called
+	// again during the lifetime of the group.
 	AppliedIndex(groupID roachpb.RangeID) (uint64, error)
 
 	// RaftLocker returns a lock which (if non-nil) will be acquired
@@ -128,6 +129,7 @@ func (m *MemoryStorage) CanApplySnapshot(_ roachpb.RangeID, _ raftpb.Snapshot) b
 // AppliedIndex returns the last index which has been applied to the given group's
 // state machine.
 func (m *MemoryStorage) AppliedIndex(groupID roachpb.RangeID) (uint64, error) {
+	// MemoryStorage always starts from an empty slate.
 	return 0, nil
 }
 

--- a/multiraft/storage.go
+++ b/multiraft/storage.go
@@ -63,12 +63,12 @@ type Storage interface {
 	// state machine.
 	AppliedIndex(groupID roachpb.RangeID) (uint64, error)
 
-	// GroupLocker returns a lock which (if non-nil) will be acquired
+	// RaftLocker returns a lock which (if non-nil) will be acquired
 	// when a group is being created (which entails multiple calls to
 	// Storage methods and may race with the removal of a previous
 	// incarnation of a group). If it returns a non-nil value it must
 	// return the same value on every call.
-	GroupLocker() sync.Locker
+	RaftLocker() sync.Locker
 }
 
 // MemoryStorage is an in-memory implementation of Storage for testing.
@@ -130,8 +130,8 @@ func (m *MemoryStorage) AppliedIndex(groupID roachpb.RangeID) (uint64, error) {
 	return 0, nil
 }
 
-// GroupLocker implements the Storage interface by returning nil.
-func (m *MemoryStorage) GroupLocker() sync.Locker {
+// RaftLocker implements the Storage interface by returning nil.
+func (m *MemoryStorage) RaftLocker() sync.Locker {
 	return nil
 }
 

--- a/multiraft/storage_test.go
+++ b/multiraft/storage_test.go
@@ -57,6 +57,10 @@ func (b *BlockableStorage) CanApplySnapshot(groupID roachpb.RangeID, snap raftpb
 	return b.storage.CanApplySnapshot(groupID, snap)
 }
 
+func (b *BlockableStorage) AppliedIndex(groupID roachpb.RangeID) (uint64, error) {
+	return b.storage.AppliedIndex(groupID)
+}
+
 func (b *BlockableStorage) GroupLocker() sync.Locker {
 	return b.storage.GroupLocker()
 }

--- a/multiraft/storage_test.go
+++ b/multiraft/storage_test.go
@@ -61,8 +61,8 @@ func (b *BlockableStorage) AppliedIndex(groupID roachpb.RangeID) (uint64, error)
 	return b.storage.AppliedIndex(groupID)
 }
 
-func (b *BlockableStorage) GroupLocker() sync.Locker {
-	return b.storage.GroupLocker()
+func (b *BlockableStorage) RaftLocker() sync.Locker {
+	return b.storage.RaftLocker()
 }
 
 type blockableGroupStorage struct {

--- a/storage/client_split_test.go
+++ b/storage/client_split_test.go
@@ -737,7 +737,6 @@ func TestSplitSnapshotRace_SplitWins(t *testing.T) {
 // so it still has a conflicting range.
 func TestSplitSnapshotRace_SnapshotWins(t *testing.T) {
 	defer leaktest.AfterTest(t)
-	t.Skip("TODO(bdarnell): https://github.com/cockroachdb/cockroach/issues/3038")
 	mtc, leftKey, rightKey := setupSplitSnapshotRace(t)
 	defer mtc.Stop()
 

--- a/storage/replica_gc_queue.go
+++ b/storage/replica_gc_queue.go
@@ -138,7 +138,7 @@ func (q *replicaGCQueue) process(now roachpb.Timestamp, rng *Replica, _ *config.
 		q.locker.Lock()
 		defer q.locker.Unlock()
 
-		if _, err := rng.store.GetReplica(desc.RangeID); err == nil {
+		if _, err := rng.store.getReplicaLocked(desc.RangeID); err == nil {
 			log.Infof("replica recreated during deletion; aborting deletion")
 			return nil
 		}

--- a/storage/store.go
+++ b/storage/store.go
@@ -455,7 +455,6 @@ func (s *Store) Start(stopper *stop.Stopper) error {
 	if s.multiraft, err = multiraft.NewMultiRaft(s.Ident.NodeID, s.Ident.StoreID, &multiraft.Config{
 		Transport:              s.ctx.Transport,
 		Storage:                s,
-		StateMachine:           s,
 		TickInterval:           s.ctx.RaftTickInterval,
 		ElectionTimeoutTicks:   s.ctx.RaftElectionTimeoutTicks,
 		HeartbeatIntervalTicks: s.ctx.RaftHeartbeatIntervalTicks,
@@ -1660,7 +1659,7 @@ func (s *Store) CanApplySnapshot(rangeID roachpb.RangeID, snap raftpb.Snapshot) 
 	return true
 }
 
-// AppliedIndex implements the multiraft.StateMachine interface.
+// AppliedIndex implements the multiraft.Storage interface.
 func (s *Store) AppliedIndex(groupID roachpb.RangeID) (uint64, error) {
 	s.mu.RLock()
 	defer s.mu.RUnlock()

--- a/storage/store.go
+++ b/storage/store.go
@@ -374,7 +374,7 @@ func NewStore(ctx StoreContext, eng engine.Engine, nodeDesc *roachpb.NodeDescrip
 	s.splitQueue = newSplitQueue(s.db, s.ctx.Gossip)
 	s.verifyQueue = newVerifyQueue(s.ctx.Gossip, s.ReplicaCount)
 	s.replicateQueue = newReplicateQueue(s.ctx.Gossip, s.allocator, s.ctx.Clock, s.ctx.AllocatorOptions)
-	s.replicaGCQueue = newReplicaGCQueue(s.db, s.ctx.Gossip, s.GroupLocker())
+	s.replicaGCQueue = newReplicaGCQueue(s.db, s.ctx.Gossip, s.RaftLocker())
 	s.raftLogQueue = newRaftLogQueue(s.db, s.ctx.Gossip)
 	s.scanner.AddQueues(s.gcQueue, s.splitQueue, s.verifyQueue, s.replicateQueue, s.replicaGCQueue, s.raftLogQueue)
 
@@ -1626,8 +1626,8 @@ func (s *Store) ReplicasFromSnapshot(snap raftpb.Snapshot) ([]roachpb.ReplicaDes
 	return parsedSnap.RangeDescriptor.Replicas, nil
 }
 
-// GroupLocker implements the multiraft.Storage interface.
-func (s *Store) GroupLocker() sync.Locker {
+// RaftLocker implements the multiraft.Storage interface.
+func (s *Store) RaftLocker() sync.Locker {
 	return &s.raftGroupLocker
 }
 


### PR DESCRIPTION
Removes `raftGroupLocker` and prevents deadlocks including the one in #3038.

The new locking semantics are better documented and hopefully easier to reason about.

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/3119)

<!-- Reviewable:end -->
