### PR TITLE
set gossip nodeID before gossip clusterID for bootstrap node

### DIFF
--- a/gossip/client_test.go
+++ b/gossip/client_test.go
@@ -57,7 +57,7 @@ func startGossip(t *testing.T) (local, remote *Gossip, stopper *stop.Stopper) {
 		t.Fatal(err)
 	}
 	remote = New(rRPCContext, TestBootstrap)
-	if err := local.SetNodeDescriptor(&roachpb.NodeDescriptor{
+	if err := remote.SetNodeDescriptor(&roachpb.NodeDescriptor{
 		NodeID:  2,
 		Address: util.MakeUnresolvedAddr(raddr.Network(), raddr.String()),
 	}); err != nil {

--- a/gossip/client_test.go
+++ b/gossip/client_test.go
@@ -28,6 +28,7 @@ import (
 	"github.com/cockroachdb/cockroach/util/hlc"
 	"github.com/cockroachdb/cockroach/util/leaktest"
 	"github.com/cockroachdb/cockroach/util/stop"
+	"github.com/gogo/protobuf/proto"
 )
 
 // startGossip creates local and remote gossip instances.
@@ -69,6 +70,63 @@ func startGossip(t *testing.T) (local, remote *Gossip, stopper *stop.Stopper) {
 	return
 }
 
+type fakeGossipServer struct {
+	nodeAddr   util.UnresolvedAddr
+	nodeIDChan chan roachpb.NodeID
+}
+
+func newFakeGossipServer(rpcServer *rpc.Server, stopper *stop.Stopper) (*fakeGossipServer, error) {
+	s := &fakeGossipServer{
+		nodeIDChan: make(chan roachpb.NodeID),
+	}
+	if err := rpcServer.Register("Gossip.Gossip", s.Gossip, &Request{}); err != nil {
+		return nil, util.Errorf("unable to register gossip service with RPC server: %s", err)
+	}
+	return s, nil
+}
+
+func (s *fakeGossipServer) Gossip(argsI proto.Message) (proto.Message, error) {
+	args := argsI.(*Request)
+	reply := &Response{}
+	s.nodeIDChan <- args.NodeID
+
+	return reply, nil
+}
+
+// startFakeServerGossip creates local gossip instances and remote faked gossip instance.
+// The remote gossip instance launches its faked gossip service just for
+// check the client message.
+func startFakeServerGossip(t *testing.T) (local *Gossip, remote *fakeGossipServer, stopper *stop.Stopper) {
+	lclock := hlc.NewClock(hlc.UnixNano)
+	stopper = stop.NewStopper()
+	lRPCContext := rpc.NewContext(&base.Context{Insecure: true}, lclock, stopper)
+
+	laddr := util.CreateTestAddr("tcp")
+	lserver := rpc.NewServer(laddr, lRPCContext)
+	if err := lserver.Start(); err != nil {
+		t.Fatal(err)
+	}
+	local = New(lRPCContext, TestBootstrap)
+	local.start(lserver, stopper)
+
+	rclock := hlc.NewClock(hlc.UnixNano)
+	raddr := util.CreateTestAddr("tcp")
+	rRPCContext := rpc.NewContext(&base.Context{Insecure: true}, rclock, stopper)
+	rserver := rpc.NewServer(raddr, rRPCContext)
+	if err := rserver.Start(); err != nil {
+		t.Fatal(err)
+	}
+
+	remote, err := newFakeGossipServer(rserver, stopper)
+	if err != nil {
+		t.Fatal(err)
+	}
+	addr := rserver.Addr()
+	remote.nodeAddr = util.MakeUnresolvedAddr(addr.Network(), addr.String())
+	time.Sleep(time.Millisecond)
+	return
+}
+
 // TestClientGossip verifies a client can gossip a delta to the server.
 func TestClientGossip(t *testing.T) {
 	defer leaktest.AfterTest(t)
@@ -90,7 +148,7 @@ func TestClientGossip(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	// Use an insecure context. We're talking to unix socket which are not in the certs.
+	// Use an insecure context. We're talking to tcp socket which are not in the certs.
 	lclock := hlc.NewClock(hlc.UnixNano)
 	rpcContext := rpc.NewContext(&base.Context{Insecure: true}, lclock, stopper)
 	client.start(local, disconnected, rpcContext, stopper)
@@ -103,5 +161,43 @@ func TestClientGossip(t *testing.T) {
 			return err
 		}
 		return nil
+	})
+}
+
+// TestClientNodeID verifies a client's gossip request with correct NodeID.
+func TestClientNodeID(t *testing.T) {
+	defer leaktest.AfterTest(t)
+
+	local, remote, stopper := startFakeServerGossip(t)
+	disconnected := make(chan *client, 1)
+
+	// Use an insecure context. We're talking to tcp socket which are not in the certs.
+	lclock := hlc.NewClock(hlc.UnixNano)
+	rpcContext := rpc.NewContext(&base.Context{Insecure: true}, lclock, stopper)
+
+	// Start a gossip client.
+	c := newClient(remote.nodeAddr)
+	defer func() {
+		stopper.Stop()
+		if c != <-disconnected {
+			t.Errorf("expected client disconnect after remote close")
+		}
+	}()
+	c.start(local, disconnected, rpcContext, stopper)
+	// Wait for c.gossip to start.
+	receivedNodeID := <-remote.nodeIDChan
+
+	nodeID := roachpb.NodeID(1)
+	// Simulate a nodeID setting after c.gossip started.
+	local.SetNodeID(nodeID)
+	// Check if client send the correct NodeID after new nodeID take effect.
+	util.SucceedsWithin(t, time.Second, func() error {
+		select {
+		case receivedNodeID = <-remote.nodeIDChan:
+			if receivedNodeID == nodeID {
+				return nil
+			}
+		}
+		return util.Errorf("client should send NodeID with %v, got %v", nodeID, receivedNodeID)
 	})
 }

--- a/gossip/gossip.go
+++ b/gossip/gossip.go
@@ -179,6 +179,13 @@ func (g *Gossip) SetNodeDescriptor(desc *roachpb.NodeDescriptor) error {
 	return nil
 }
 
+// SetNodeID sets the infostore's node ID.
+func (g *Gossip) SetNodeID(nodeID roachpb.NodeID) {
+	g.mu.Lock()
+	g.is.NodeID = nodeID
+	g.mu.Unlock()
+}
+
 // SetResolvers initializes the set of gossip resolvers used to
 // find nodes to bootstrap the gossip network.
 func (g *Gossip) SetResolvers(resolvers []resolver.Resolver) {

--- a/gossip/gossip_test.go
+++ b/gossip/gossip_test.go
@@ -24,6 +24,7 @@ import (
 
 	"github.com/cockroachdb/cockroach/base"
 	"github.com/cockroachdb/cockroach/gossip/resolver"
+	"github.com/cockroachdb/cockroach/roachpb"
 	"github.com/cockroachdb/cockroach/rpc"
 	"github.com/cockroachdb/cockroach/util/hlc"
 	"github.com/cockroachdb/cockroach/util/leaktest"
@@ -35,6 +36,8 @@ func TestGossipInfoStore(t *testing.T) {
 	defer leaktest.AfterTest(t)
 	rpcContext := rpc.NewContext(&base.Context{}, hlc.NewClock(hlc.UnixNano), nil)
 	g := New(rpcContext, TestBootstrap)
+	// Have to call g.SetNodeID before call g.AddInfo
+	g.SetNodeID(roachpb.NodeID(1))
 	slice := []byte("b")
 	if err := g.AddInfo("s", slice, time.Hour); err != nil {
 		t.Fatal(err)

--- a/gossip/infostore.go
+++ b/gossip/infostore.go
@@ -111,6 +111,9 @@ func newInfoStore(nodeID roachpb.NodeID, nodeAddr util.UnresolvedAddr) infoStore
 // newInfo allocates and returns a new info object using specified key,
 // value, and time-to-live.
 func (is *infoStore) newInfo(val []byte, ttl time.Duration) *Info {
+	if is.NodeID == 0 {
+		panic("gossip infostore's NodeID is 0")
+	}
 	now := monotonicUnixNano()
 	ttlStamp := now + int64(ttl)
 	if ttl == 0 {

--- a/server/raft_transport_test.go
+++ b/server/raft_transport_test.go
@@ -100,6 +100,8 @@ func TestSendAndReceive(t *testing.T) {
 		defer server.Close()
 
 		addr := server.Addr()
+		// Have to call g.SetNodeID before call g.AddInfo
+		g.SetNodeID(roachpb.NodeID(nodeID))
 		if err := g.AddInfoProto(gossip.MakeNodeIDKey(nodeID),
 			&roachpb.NodeDescriptor{
 				Address: util.MakeUnresolvedAddr(addr.Network(), addr.String()),
@@ -250,6 +252,8 @@ func TestInOrderDelivery(t *testing.T) {
 		t.Fatal(err)
 	}
 	addr := server.Addr()
+	// Have to set gossip.NodeID before call gossip.AddInofXXX
+	g.SetNodeID(nodeID)
 	if err := g.AddInfoProto(gossip.MakeNodeIDKey(nodeID),
 		&roachpb.NodeDescriptor{
 			Address: util.MakeUnresolvedAddr(addr.Network(), addr.String()),

--- a/storage/allocator_test.go
+++ b/storage/allocator_test.go
@@ -167,6 +167,8 @@ func createTestAllocator() (*stop.Stopper, *gossip.Gossip, *StorePool, Allocator
 	stopper := stop.NewStopper()
 	rpcContext := rpc.NewContext(&base.Context{}, hlc.NewClock(hlc.UnixNano), stopper)
 	g := gossip.New(rpcContext, gossip.TestBootstrap)
+	// Have to call g.SetNodeID before call g.AddInfo
+	g.SetNodeID(roachpb.NodeID(1))
 	storePool := NewStorePool(g, TestTimeUntilStoreDeadOff, stopper)
 	a := MakeAllocator(storePool, AllocatorOptions{AllowRebalance: true})
 	return stopper, g, storePool, a
@@ -1077,6 +1079,8 @@ func Example_rebalancing() {
 	// Model a set of stores in a cluster,
 	// randomly adding / removing stores and adding bytes.
 	g := gossip.New(nil, nil)
+	// Have to call g.SetNodeID before call g.AddInfo
+	g.SetNodeID(roachpb.NodeID(1))
 	stopper := stop.NewStopper()
 	defer stopper.Stop()
 	sp := NewStorePool(g, TestTimeUntilStoreDeadOff, stopper)

--- a/storage/queue_test.go
+++ b/storage/queue_test.go
@@ -43,7 +43,8 @@ func gossipForTest(t *testing.T) (*gossip.Gossip, *stop.Stopper) {
 
 	rpcContext := rpc.NewContext(&base.Context{}, hlc.NewClock(hlc.UnixNano), stopper)
 	g := gossip.New(rpcContext, gossip.TestBootstrap)
-
+	// Have to call g.SetNodeID before call g.AddInfo
+	g.SetNodeID(roachpb.NodeID(1))
 	// Put an empty system config into gossip.
 	if err := g.AddInfoProto(gossip.KeySystemConfig,
 		&config.SystemConfig{}, 0); err != nil {

--- a/storage/store_pool_test.go
+++ b/storage/store_pool_test.go
@@ -57,6 +57,8 @@ func createTestStorePool(timeUntilStoreDead time.Duration) (*stop.Stopper, *goss
 	stopper := stop.NewStopper()
 	rpcContext := rpc.NewContext(&base.Context{}, hlc.NewClock(hlc.UnixNano), stopper)
 	g := gossip.New(rpcContext, gossip.TestBootstrap)
+	// Have to call g.SetNodeID before call g.AddInfo
+	g.SetNodeID(roachpb.NodeID(1))
 	storePool := NewStorePool(g, timeUntilStoreDead, stopper)
 	return stopper, g, storePool
 }

--- a/storage/store_test.go
+++ b/storage/store_test.go
@@ -149,6 +149,8 @@ func createTestStoreWithoutStart(t *testing.T) (*Store, *hlc.ManualClock, *stop.
 	if err := store.BootstrapRange(nil); err != nil {
 		t.Fatal(err)
 	}
+	// Have to call g.SetNodeID before call g.AddInfo
+	store.Gossip().SetNodeID(roachpb.NodeID(1))
 	return store, manual, stopper
 }
 


### PR DESCRIPTION
It may related to #3054.
1. When store in bootstrapped node gossip clusterID before gossip.is.NodeID is set, the gossip information sent out will carry a NodeID=0. 
1. The receiving node will try to push gossip information back in `handleGossip` in `gossip/client.go`, inside `sendGossip` it will call `g.is.delta` to find the delta information to send back. Inside `delta`, as `i.Node` for key `clusterID` is 0, so `highWaterStamps[int32(i.NodeID)]` is always 0, so key `clusterID` always will be sent back to the sending node. 
2. The sending node will do it again, so a loop happen.

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/3127)

<!-- Reviewable:end -->
