### PR TITLE
direct GC of Txn and Sequence entries

### DIFF
--- a/storage/engine/mvcc.go
+++ b/storage/engine/mvcc.go
@@ -1444,7 +1444,11 @@ func MVCCGarbageCollect(engine Engine, ms *MVCCStats, keys []roachpb.GCRequest_G
 			return util.Errorf("unable to marshal mvcc meta: %s", err)
 		}
 		if !gcKey.Timestamp.Less(meta.Timestamp) {
-			if !meta.Deleted {
+			// For version keys, don't allow GC'ing the meta key if it's
+			// not marked deleted. However, for inline values we allow it;
+			// they are internal and GCing them directly saves the extra
+			// deletion step.
+			if !meta.Deleted && !gcKey.Timestamp.Equal(roachpb.ZeroTimestamp) {
 				return util.Errorf("request to GC non-deleted, latest value of %q", gcKey.Key)
 			}
 			if meta.Txn != nil {

--- a/storage/gc_queue.go
+++ b/storage/gc_queue.go
@@ -251,7 +251,9 @@ func (gcq *gcQueue) process(now roachpb.Timestamp, repl *Replica,
 	done := true
 	if len(intents) > 0 {
 		done = false
-		repl.resolveIntents(repl.context(), intents)
+		if err := repl.resolveIntents(repl.context(), intents, true /* wait */); err != nil {
+			return err
+		}
 	}
 
 	// Set start and end keys.

--- a/storage/replica_test.go
+++ b/storage/replica_test.go
@@ -1924,9 +1924,17 @@ func TestEndTransactionWithErrors(t *testing.T) {
 // TestEndTransactionGC verifies that a transaction record is immediately
 // garbage-collected upon EndTransaction iff all of the supplied intents are
 // local relative to the transaction record's location.
-func TestEndTransactionGC(t *testing.T) {
+func TestEndTransactionLocalGC(t *testing.T) {
 	defer leaktest.AfterTest(t)
 	defer setTxnAutoGC(true)()
+	defer func() { TestingCommandFilter = nil }()
+	TestingCommandFilter = func(args roachpb.Request, _ roachpb.Header) error {
+		// Make sure the direct GC path doesn't interfere with this test.
+		if args.Method() == roachpb.GC {
+			return util.Errorf("boom")
+		}
+		return nil
+	}
 	tc := testContext{}
 	tc.Start(t)
 	defer tc.Stop()
@@ -1973,22 +1981,7 @@ func TestEndTransactionGC(t *testing.T) {
 	}
 }
 
-// TestEndTransactionResolveOnlyLocalIntents verifies that an end transaction
-// request resolves only local intents within the same batch.
-func TestEndTransactionResolveOnlyLocalIntents(t *testing.T) {
-	defer leaktest.AfterTest(t)
-	tc := testContext{}
-	key := roachpb.Key("a")
-	splitKey := roachpb.RKey(key).Next()
-	TestingCommandFilter = func(args roachpb.Request, _ roachpb.Header) error {
-		if args.Method() == roachpb.ResolveIntentRange && args.Header().Key.Equal(splitKey.AsRawKey()) {
-			return util.Errorf("boom")
-		}
-		return nil
-	}
-	tc.Start(t)
-	defer tc.Stop()
-
+func setupResolutionTest(t *testing.T, tc testContext, key roachpb.Key, splitKey roachpb.RKey) (*Replica, *roachpb.Transaction) {
 	// Split the range and create an intent in each range.
 	// The keys of the two intents are next to each other.
 	newRng := splitTestRange(tc.store, splitKey, splitKey, t)
@@ -2018,6 +2011,27 @@ func TestEndTransactionResolveOnlyLocalIntents(t *testing.T) {
 	if _, err := client.SendWrappedWith(tc.Sender(), tc.rng.context(), h, &args); err != nil {
 		t.Fatal(err)
 	}
+	return newRng, txn
+}
+
+// TestEndTransactionResolveOnlyLocalIntents verifies that an end transaction
+// request resolves only local intents within the same batch.
+func TestEndTransactionResolveOnlyLocalIntents(t *testing.T) {
+	defer leaktest.AfterTest(t)
+	tc := testContext{}
+	key := roachpb.Key("a")
+	splitKey := roachpb.RKey(key).Next()
+	defer func() { TestingCommandFilter = nil }()
+	TestingCommandFilter = func(args roachpb.Request, _ roachpb.Header) error {
+		if args.Method() == roachpb.ResolveIntentRange && args.Header().Key.Equal(splitKey.AsRawKey()) {
+			return util.Errorf("boom")
+		}
+		return nil
+	}
+	tc.Start(t)
+	defer tc.Stop()
+
+	newRng, txn := setupResolutionTest(t, tc, key, splitKey)
 
 	// Check if the intent in the other range has not yet been resolved.
 	gArgs := getArgs(splitKey)
@@ -2038,6 +2052,75 @@ func TestEndTransactionResolveOnlyLocalIntents(t *testing.T) {
 		t.Fatalf("expected persisted intents %v, got %v",
 			expIntents, hbResp.Txn.Intents)
 	}
+}
+
+// TestEndTransactionDirectGC verifies that after successfully resolving the
+// external intents of a transaction after EndTransaction, the transaction and
+// sequence cache records are purged.
+func TestEndTransactionDirectGC(t *testing.T) {
+	defer leaktest.AfterTest(t)
+	tc := testContext{}
+	key := roachpb.Key("a")
+	splitKey := roachpb.RKey(key).Next()
+	tc.Start(t)
+	defer tc.Stop()
+
+	_, txn := setupResolutionTest(t, tc, key, splitKey)
+
+	util.SucceedsWithin(t, 5*time.Second, func() error {
+		if gr, _, err := tc.rng.Get(tc.engine, roachpb.Header{}, roachpb.GetRequest{Span: roachpb.Span{Key: keys.TransactionKey(txn.Key, txn.ID)}}); err != nil {
+			return err
+		} else if gr.Value != nil {
+			return util.Errorf("txn entry still there: %+v", gr)
+		}
+
+		var entry roachpb.SequenceCacheEntry
+		if seq, err := tc.rng.sequence.Get(tc.engine, txn.ID, &entry); err != nil {
+			return err
+		} else if seq > 0 {
+			return util.Errorf("sequence cache still populated: %v", entry)
+		}
+
+		return nil
+	})
+}
+
+// TestEndTransactionDirectGCFailure verifies that no immediate GC takes place
+// if external intents can't be resolved (see also TestEndTransactionDirectGC).
+func TestEndTransactionDirectGCFailure(t *testing.T) {
+	defer leaktest.AfterTest(t)
+	tc := testContext{}
+	key := roachpb.Key("a")
+	splitKey := roachpb.RKey(key).Next()
+	var count int64
+	defer func() { TestingCommandFilter = nil }()
+	TestingCommandFilter = func(args roachpb.Request, _ roachpb.Header) error {
+		if args.Method() == roachpb.ResolveIntentRange && args.Header().Key.Equal(splitKey.AsRawKey()) {
+			atomic.AddInt64(&count, 1)
+			return util.Errorf("boom")
+		} else if args.Method() == roachpb.GC {
+			t.Fatalf("unexpected GCRequest: %+v", args)
+		}
+		return nil
+	}
+	tc.Start(t)
+	defer tc.Stop()
+
+	setupResolutionTest(t, tc, key, splitKey)
+
+	// Now test that no GCRequest is issued. We can't test that directly (since
+	// it's completely asynchronous), so we first make sure ResolveIntent
+	// happened and subsequently issue a bogus Put which is likely to make it
+	// into Raft only after a rogue GCRequest (at least sporadically), which
+	// would trigger a Fatal from the command filter.
+	util.SucceedsWithin(t, 5*time.Second, func() error {
+		if atomic.LoadInt64(&count) == 0 {
+			return util.Errorf("intent resolution not attempted yet")
+		} else if err := tc.store.DB().Put("panama", "banana"); err != nil {
+			return err
+		}
+		return nil
+	})
 }
 
 // TestPushTxnBadKey verifies that args.Key equals args.PusheeTxn.ID.


### PR DESCRIPTION
upon resolving successfully all the external intents
of a transaction on EndTransaction, the transaction
record and the sequence cache entries are deleted
asynchronously.

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/3140)

<!-- Reviewable:end -->
