### PR TITLE
add epoch to sequence cache keys

### DIFF
--- a/keys/keys.go
+++ b/keys/keys.go
@@ -121,11 +121,12 @@ func RangeStatsKey(rangeID roachpb.RangeID) roachpb.Key {
 
 // SequenceCacheKey returns a range-local key by Range ID for a
 // sequence cache entry, with detail specified by encoding the
-// supplied transaction ID and sequence number.
-func SequenceCacheKey(rangeID roachpb.RangeID, id []byte, seq uint32) roachpb.Key {
+// supplied transaction ID, epoch and sequence number.
+func SequenceCacheKey(rangeID roachpb.RangeID, id []byte, epoch uint32, seq uint32) roachpb.Key {
 	return MakeRangeIDKey(rangeID, LocalSequenceCacheSuffix,
 		encoding.EncodeUint32Decreasing(
-			encoding.EncodeBytes(nil, id), seq))
+			encoding.EncodeUint32Decreasing(
+				encoding.EncodeBytes(nil, id), epoch), seq))
 }
 
 // SequenceCacheKeyPrefix returns the prefix common to all sequence cache keys

--- a/kv/txn_coord_sender_test.go
+++ b/kv/txn_coord_sender_test.go
@@ -451,7 +451,7 @@ func TestTxnCoordSenderTxnUpdatedOnError(t *testing.T) {
 
 	testCases := []struct {
 		err       error
-		expEpoch  int32
+		expEpoch  uint32
 		expPri    int32
 		expTS     roachpb.Timestamp
 		expOrigTS roachpb.Timestamp

--- a/roachpb/data.pb.go
+++ b/roachpb/data.pb.go
@@ -388,7 +388,7 @@ type Transaction struct {
 	Isolation IsolationType     `protobuf:"varint,5,opt,name=isolation,enum=cockroach.roachpb.IsolationType" json:"isolation"`
 	Status    TransactionStatus `protobuf:"varint,6,opt,name=status,enum=cockroach.roachpb.TransactionStatus" json:"status"`
 	// Incremented on txn retry.
-	Epoch int32 `protobuf:"varint,7,opt,name=epoch" json:"epoch"`
+	Epoch uint32 `protobuf:"varint,7,opt,name=epoch" json:"epoch"`
 	// The last heartbeat timestamp.
 	LastHeartbeat *Timestamp `protobuf:"bytes,8,opt,name=last_heartbeat" json:"last_heartbeat,omitempty"`
 	// The proposed timestamp for the transaction. This starts as
@@ -2858,7 +2858,7 @@ func (m *Transaction) Unmarshal(data []byte) error {
 				}
 				b := data[iNdEx]
 				iNdEx++
-				m.Epoch |= (int32(b) & 0x7F) << shift
+				m.Epoch |= (uint32(b) & 0x7F) << shift
 				if b < 0x80 {
 					break
 				}

--- a/roachpb/data.proto
+++ b/roachpb/data.proto
@@ -226,7 +226,7 @@ message Transaction {
   optional IsolationType isolation = 5 [(gogoproto.nullable) = false];
   optional TransactionStatus status = 6 [(gogoproto.nullable) = false];
   // Incremented on txn retry.
-  optional int32 epoch = 7 [(gogoproto.nullable) = false];
+  optional uint32 epoch = 7 [(gogoproto.nullable) = false];
   // The last heartbeat timestamp.
   optional Timestamp last_heartbeat = 8;
   // The proposed timestamp for the transaction. This starts as

--- a/storage/engine/rocksdb/cockroach/roachpb/data.pb.cc
+++ b/storage/engine/rocksdb/cockroach/roachpb/data.pb.cc
@@ -498,7 +498,7 @@ void protobuf_AddDesc_cockroach_2froachpb_2fdata_2eproto() {
     "ority\030\004 \001(\005B\004\310\336\037\000\0229\n\tisolation\030\005 \001(\0162 .c"
     "ockroach.roachpb.IsolationTypeB\004\310\336\037\000\022:\n\006"
     "status\030\006 \001(\0162$.cockroach.roachpb.Transac"
-    "tionStatusB\004\310\336\037\000\022\023\n\005epoch\030\007 \001(\005B\004\310\336\037\000\0224\n"
+    "tionStatusB\004\310\336\037\000\022\023\n\005epoch\030\007 \001(\rB\004\310\336\037\000\0224\n"
     "\016last_heartbeat\030\010 \001(\0132\034.cockroach.roachp"
     "b.Timestamp\0225\n\ttimestamp\030\t \001(\0132\034.cockroa"
     "ch.roachpb.TimestampB\004\310\336\037\000\022:\n\016orig_times"
@@ -5102,7 +5102,7 @@ void Transaction::SharedCtor() {
   priority_ = 0;
   isolation_ = 0;
   status_ = 0;
-  epoch_ = 0;
+  epoch_ = 0u;
   last_heartbeat_ = NULL;
   timestamp_ = NULL;
   orig_timestamp_ = NULL;
@@ -5313,12 +5313,12 @@ bool Transaction::MergePartialFromCodedStream(
         break;
       }
 
-      // optional int32 epoch = 7;
+      // optional uint32 epoch = 7;
       case 7: {
         if (tag == 56) {
          parse_epoch:
           DO_((::google::protobuf::internal::WireFormatLite::ReadPrimitive<
-                   ::google::protobuf::int32, ::google::protobuf::internal::WireFormatLite::TYPE_INT32>(
+                   ::google::protobuf::uint32, ::google::protobuf::internal::WireFormatLite::TYPE_UINT32>(
                  input, &epoch_)));
           set_has_epoch();
         } else {
@@ -5504,9 +5504,9 @@ void Transaction::SerializeWithCachedSizes(
       6, this->status(), output);
   }
 
-  // optional int32 epoch = 7;
+  // optional uint32 epoch = 7;
   if (has_epoch()) {
-    ::google::protobuf::internal::WireFormatLite::WriteInt32(7, this->epoch(), output);
+    ::google::protobuf::internal::WireFormatLite::WriteUInt32(7, this->epoch(), output);
   }
 
   // optional .cockroach.roachpb.Timestamp last_heartbeat = 8;
@@ -5607,9 +5607,9 @@ void Transaction::SerializeWithCachedSizes(
       6, this->status(), target);
   }
 
-  // optional int32 epoch = 7;
+  // optional uint32 epoch = 7;
   if (has_epoch()) {
-    target = ::google::protobuf::internal::WireFormatLite::WriteInt32ToArray(7, this->epoch(), target);
+    target = ::google::protobuf::internal::WireFormatLite::WriteUInt32ToArray(7, this->epoch(), target);
   }
 
   // optional .cockroach.roachpb.Timestamp last_heartbeat = 8;
@@ -5716,10 +5716,10 @@ int Transaction::ByteSize() const {
         ::google::protobuf::internal::WireFormatLite::EnumSize(this->status());
     }
 
-    // optional int32 epoch = 7;
+    // optional uint32 epoch = 7;
     if (has_epoch()) {
       total_size += 1 +
-        ::google::protobuf::internal::WireFormatLite::Int32Size(
+        ::google::protobuf::internal::WireFormatLite::UInt32Size(
           this->epoch());
     }
 
@@ -6147,7 +6147,7 @@ void Transaction::clear_status() {
   // @@protoc_insertion_point(field_set:cockroach.roachpb.Transaction.status)
 }
 
-// optional int32 epoch = 7;
+// optional uint32 epoch = 7;
 bool Transaction::has_epoch() const {
   return (_has_bits_[0] & 0x00000040u) != 0;
 }
@@ -6158,14 +6158,14 @@ void Transaction::clear_has_epoch() {
   _has_bits_[0] &= ~0x00000040u;
 }
 void Transaction::clear_epoch() {
-  epoch_ = 0;
+  epoch_ = 0u;
   clear_has_epoch();
 }
- ::google::protobuf::int32 Transaction::epoch() const {
+ ::google::protobuf::uint32 Transaction::epoch() const {
   // @@protoc_insertion_point(field_get:cockroach.roachpb.Transaction.epoch)
   return epoch_;
 }
- void Transaction::set_epoch(::google::protobuf::int32 value) {
+ void Transaction::set_epoch(::google::protobuf::uint32 value) {
   set_has_epoch();
   epoch_ = value;
   // @@protoc_insertion_point(field_set:cockroach.roachpb.Transaction.epoch)

--- a/storage/engine/rocksdb/cockroach/roachpb/data.pb.h
+++ b/storage/engine/rocksdb/cockroach/roachpb/data.pb.h
@@ -1452,12 +1452,12 @@ class Transaction : public ::google::protobuf::Message {
   ::cockroach::roachpb::TransactionStatus status() const;
   void set_status(::cockroach::roachpb::TransactionStatus value);
 
-  // optional int32 epoch = 7;
+  // optional uint32 epoch = 7;
   bool has_epoch() const;
   void clear_epoch();
   static const int kEpochFieldNumber = 7;
-  ::google::protobuf::int32 epoch() const;
-  void set_epoch(::google::protobuf::int32 value);
+  ::google::protobuf::uint32 epoch() const;
+  void set_epoch(::google::protobuf::uint32 value);
 
   // optional .cockroach.roachpb.Timestamp last_heartbeat = 8;
   bool has_last_heartbeat() const;
@@ -1570,7 +1570,7 @@ class Transaction : public ::google::protobuf::Message {
   ::google::protobuf::int32 priority_;
   int isolation_;
   int status_;
-  ::google::protobuf::int32 epoch_;
+  ::google::protobuf::uint32 epoch_;
   ::cockroach::roachpb::Timestamp* last_heartbeat_;
   ::cockroach::roachpb::Timestamp* timestamp_;
   ::cockroach::roachpb::Timestamp* orig_timestamp_;
@@ -3291,7 +3291,7 @@ inline void Transaction::set_status(::cockroach::roachpb::TransactionStatus valu
   // @@protoc_insertion_point(field_set:cockroach.roachpb.Transaction.status)
 }
 
-// optional int32 epoch = 7;
+// optional uint32 epoch = 7;
 inline bool Transaction::has_epoch() const {
   return (_has_bits_[0] & 0x00000040u) != 0;
 }
@@ -3302,14 +3302,14 @@ inline void Transaction::clear_has_epoch() {
   _has_bits_[0] &= ~0x00000040u;
 }
 inline void Transaction::clear_epoch() {
-  epoch_ = 0;
+  epoch_ = 0u;
   clear_has_epoch();
 }
-inline ::google::protobuf::int32 Transaction::epoch() const {
+inline ::google::protobuf::uint32 Transaction::epoch() const {
   // @@protoc_insertion_point(field_get:cockroach.roachpb.Transaction.epoch)
   return epoch_;
 }
-inline void Transaction::set_epoch(::google::protobuf::int32 value) {
+inline void Transaction::set_epoch(::google::protobuf::uint32 value) {
   set_has_epoch();
   epoch_ = value;
   // @@protoc_insertion_point(field_set:cockroach.roachpb.Transaction.epoch)

--- a/storage/replica.go
+++ b/storage/replica.go
@@ -1097,7 +1097,7 @@ func (r *Replica) applyRaftCommandInBatch(ctx context.Context, index uint64, ori
 		}
 		// Only transactional requests have replay protection.
 		if ba.Txn != nil {
-			if putErr := r.sequence.PutSequence(btch, ba.Txn.ID, uint32(ba.Txn.Epoch),
+			if putErr := r.sequence.PutSequence(btch, ba.Txn.ID, ba.Txn.Epoch,
 				ba.Txn.Sequence, ba.Txn.Key, ba.Txn.Timestamp, err); putErr != nil {
 				// TODO(tschottdorf): ReplicaCorruptionError.
 				log.Fatalc(ctx, "putting a sequence cache entry in a batch should never fail: %s", putErr)

--- a/storage/replica.go
+++ b/storage/replica.go
@@ -1026,17 +1026,20 @@ func (r *Replica) applyRaftCommandInBatch(ctx context.Context, index uint64, ori
 	// Create a new batch for the command to ensure all or nothing semantics.
 	btch := r.store.Engine().NewBatch()
 
-	// Check the sequence for this batch to ensure idempotency. Only applies
-	// to transactional requests.
+	// Check the sequence for this batch. Only applies to transactional
+	// requests: on a cache hit, the transaction is instructed to restart.
+	// The epoch check allows us to poison the sequence cache to avoid
+	// anomalies when we know that the transaction has been aborted or pushed,
+	// but it itself does not.
+	// TODO(tschottdorf): should return TransactionAborted in some scenarios.
 	if ba.IsWrite() && ba.Txn != nil {
-		if sequence, readErr := r.sequence.Get(btch, ba.Txn.ID, nil); readErr != nil {
+		if epoch, sequence, readErr := r.sequence.Get(btch, ba.Txn.ID, nil); readErr != nil {
 			return btch, nil, nil, newReplicaCorruptionError(util.Errorf("could not read from sequence cache"), readErr)
-		} else if sequence >= ba.Txn.Sequence {
+		} else if sequence >= ba.Txn.Sequence || epoch > ba.Txn.Epoch {
+			// We hit the cache, so let the transaction restart.
 			if log.V(1) {
 				log.Infoc(ctx, "found sequence cache entry for %s@%d", ba.Txn.Short(), ba.Txn.Sequence)
 			}
-			// We successfully read from the sequence cache, so let the
-			// transaction restart.
 			return btch, nil, nil, roachpb.NewTransactionRetryError(ba.Txn)
 		}
 	}
@@ -1094,7 +1097,8 @@ func (r *Replica) applyRaftCommandInBatch(ctx context.Context, index uint64, ori
 		}
 		// Only transactional requests have replay protection.
 		if ba.Txn != nil {
-			if putErr := r.sequence.PutSequence(btch, ba.Txn.ID, ba.Txn.Sequence, ba.Txn.Key, ba.Txn.Timestamp, err); putErr != nil {
+			if putErr := r.sequence.PutSequence(btch, ba.Txn.ID, uint32(ba.Txn.Epoch),
+				ba.Txn.Sequence, ba.Txn.Key, ba.Txn.Timestamp, err); putErr != nil {
 				// TODO(tschottdorf): ReplicaCorruptionError.
 				log.Fatalc(ctx, "putting a sequence cache entry in a batch should never fail: %s", putErr)
 			}

--- a/storage/replica_data_iter_test.go
+++ b/storage/replica_data_iter_test.go
@@ -64,8 +64,8 @@ func createRangeData(r *Replica, t *testing.T) []engine.MVCCKey {
 		key roachpb.Key
 		ts  roachpb.Timestamp
 	}{
-		{keys.SequenceCacheKey(r.Desc().RangeID, testTxnID, 2), ts0},
-		{keys.SequenceCacheKey(r.Desc().RangeID, testTxnID, 1), ts0},
+		{keys.SequenceCacheKey(r.Desc().RangeID, testTxnID, testTxnEpoch, 2), ts0},
+		{keys.SequenceCacheKey(r.Desc().RangeID, testTxnID, testTxnEpoch, 1), ts0},
 		{keys.RaftHardStateKey(r.Desc().RangeID), ts0},
 		{keys.RaftLogKey(r.Desc().RangeID, 1), ts0},
 		{keys.RaftLogKey(r.Desc().RangeID, 2), ts0},

--- a/storage/replica_test.go
+++ b/storage/replica_test.go
@@ -1905,7 +1905,7 @@ func TestEndTransactionWithErrors(t *testing.T) {
 	testCases := []struct {
 		key          roachpb.Key
 		existStatus  roachpb.TransactionStatus
-		existEpoch   int32
+		existEpoch   uint32
 		existTS      roachpb.Timestamp
 		expErrRegexp string
 	}{
@@ -2218,7 +2218,7 @@ func TestPushTxnUpgradeExistingTxn(t *testing.T) {
 	ts1 := roachpb.Timestamp{WallTime: 1}
 	ts2 := roachpb.Timestamp{WallTime: 2}
 	testCases := []struct {
-		startEpoch, epoch, expEpoch int32
+		startEpoch, epoch, expEpoch uint32
 		startTS, ts, expTS          roachpb.Timestamp
 	}{
 		// Move epoch forward.


### PR DESCRIPTION
this allows for poisoning of response cache entries as
outlined in RFC #3100 (txn gc).

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/3144)

<!-- Reviewable:end -->
