### PR TITLE
MVCCDeleteRange optimization.

### DIFF
--- a/storage/engine/mvcc.go
+++ b/storage/engine/mvcc.go
@@ -961,12 +961,14 @@ func MVCCDeleteRange(engine Engine, ms *MVCCStats, startKey, endKey roachpb.Key,
 		return 0, emptyKeyError()
 	}
 
-	buf := getBufferPool.Get().(*getBuffer)
-	defer getBufferPool.Put(buf)
+	buf := putBufferPool.Get().(*putBuffer)
+	defer putBufferPool.Put(buf)
+	buf.value.Reset()
+	buf.value.Deleted = true
 
 	// We store encEndKey and encKey in the same buffer to avoid memory
 	// allocations.
-	encEndKey := mvccEncodeKey(buf.key[0:0], endKey)
+	encEndKey := mvccEncodeKey(buf.key[:0], endKey)
 	keyBuf := encEndKey[len(encEndKey):]
 
 	// Get a new iterator and define our getter using iter.Seek.
@@ -997,9 +999,76 @@ func MVCCDeleteRange(engine Engine, ms *MVCCStats, startKey, endKey roachpb.Key,
 		}
 
 		if !buf.meta.Deleted {
-			if err := MVCCDelete(engine, ms, key, timestamp, txn); err != nil {
+			origMetaKeySize := int64(len(iter.unsafeKey()))
+			origMetaValSize := int64(len(iter.unsafeValue()))
+
+			// Verify we're not mixing inline and non-inline values.
+			putIsInline := timestamp.Equal(roachpb.ZeroTimestamp)
+			if putIsInline {
+				metaKeySize, metaValSize, err := int64(0), int64(0), engine.Clear(metaKey)
+				updateStatsForInline(ms, key, origMetaKeySize, origMetaValSize, metaKeySize, metaValSize)
+				if err != nil {
+					return count, err
+				}
+				count++
+				startKey = key.Next()
+				continue
+			}
+
+			// There is existing metadata for this key; ensure our write is permitted.
+			meta := &buf.meta
+			origAgeSeconds := timestamp.WallTime/1E9 - meta.Timestamp.WallTime/1E9
+
+			if meta.Txn != nil {
+				// There is an uncommitted write intent.
+
+				if txn == nil || !bytes.Equal(meta.Txn.ID, txn.ID) {
+					// The current DeleteRange operation does not come from the same
+					// transaction.
+					return count, &roachpb.WriteIntentError{Intents: []roachpb.Intent{{Span: roachpb.Span{Key: key}, Txn: *meta.Txn}}}
+				} else if txn.Epoch < meta.Txn.Epoch {
+					return count, util.Errorf("put with epoch %d came after put with epoch %d in txn %s",
+						txn.Epoch, meta.Txn.Epoch, txn.ID)
+				}
+
+				// We are replacing our own older write intent. If we are
+				// writing at the same timestamp we can simply overwrite it;
+				// otherwise we must explicitly delete the obsolete intent.
+				if !timestamp.Equal(meta.Timestamp) {
+					versionKey := mvccEncodeTimestamp(metaKey, meta.Timestamp)
+					if err := engine.Clear(versionKey); err != nil {
+						return count, err
+					}
+				}
+			} else {
+				// No pending transaction, so we can write as long as it is not
+				// in the past.
+				if !meta.Timestamp.Less(timestamp) {
+					return count, &roachpb.WriteTooOldError{Timestamp: timestamp, ExistingTimestamp: meta.Timestamp}
+				}
+			}
+			buf.newMeta = MVCCMetadata{Txn: txn, Timestamp: timestamp}
+			newMeta := &buf.newMeta
+
+			// The metaKey is always the prefix of the versionKey.
+			versionKey := mvccEncodeTimestamp(metaKey, timestamp)
+			_, valueSize, err := PutProto(engine, versionKey, &buf.value)
+			if err != nil {
 				return count, err
 			}
+
+			// Write the mvcc metadata now that we have sizes for the latest versioned value.
+			newMeta.KeyBytes = mvccVersionTimestampSize
+			newMeta.ValBytes = valueSize
+			newMeta.Deleted = true
+			metaKeySize, metaValSize, err := PutProto(engine, metaKey, newMeta)
+			if err != nil {
+				return count, err
+			}
+
+			// Update MVCC stats.
+			updateStatsOnPut(ms, key, origMetaKeySize, origMetaValSize, metaKeySize, metaValSize, meta, newMeta, origAgeSeconds)
+
 			count++
 		}
 


### PR DESCRIPTION
I'm not terribly happy with copying code from MVCCIterate and
mvccPutInternal. I'll take a look later at whether that code duplication
can be eliminated while still maintaining the performance gains.

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/3146)

<!-- Reviewable:end -->
