### PR TITLE
Use a cheaper transport in multiraft benchmark.

### DIFF
--- a/multiraft/multiraft_test.go
+++ b/multiraft/multiraft_test.go
@@ -640,7 +640,7 @@ func TestConfigValidation(t *testing.T) {
 func runSubmitCommandBenchmark(numNodes, pendingCommands int, b *testing.B) {
 	stopper := stop.NewStopper()
 	defer stopper.Stop()
-	cluster := newTestCluster(nil, numNodes, stopper, b)
+	cluster := newTestCluster(NewLocalTransport(), numNodes, stopper, b)
 	groupID := roachpb.RangeID(1)
 	cluster.createGroup(groupID, 0, numNodes)
 	if numNodes > 1 {


### PR DESCRIPTION
LocalRPCTransport was a large part of this benchmark's running time, but
it's not representative of production. Replace it so we can benchmark
the multiraft code in isolation.

```
name                           old time/op    new time/op    delta
SubmitCommand1Node1Pending-4     23.5µs ± 3%    23.0µs ± 1%   -1.83%        (p=0.007 n=10+10)
SubmitCommand3Nodes1Pending-4     340µs ± 9%     135µs ± 1%  -60.22%        (p=0.000 n=10+10)
SubmitCommand5Nodes1Pending-4     549µs ± 7%     229µs ± 2%  -58.35%        (p=0.000 n=10+10)
SubmitCommand1Node2Pending-4     16.1µs ± 2%    15.7µs ± 2%   -2.77%         (p=0.000 n=9+10)
SubmitCommand3Nodes2Pending-4     262µs ± 5%     101µs ± 2%  -61.55%         (p=0.000 n=8+10)
SubmitCommand5Nodes2Pending-4     451µs ± 7%     170µs ± 4%  -62.36%        (p=0.000 n=10+10)
SubmitCommand1Node4Pending-4     17.8µs ± 3%    17.7µs ± 2%     ~           (p=0.481 n=10+10)
SubmitCommand3Nodes4Pending-4     216µs ± 2%      91µs ± 6%  -57.73%         (p=0.000 n=9+10)
SubmitCommand5Nodes4Pending-4     416µs ± 3%     163µs ± 6%  -60.78%        (p=0.000 n=10+10)

name                           old alloc/op   new alloc/op   delta
SubmitCommand1Node1Pending-4     2.54kB ± 1%    2.52kB ± 0%   -0.83%         (p=0.022 n=10+9)
SubmitCommand3Nodes1Pending-4    22.4kB ± 0%    16.8kB ± 0%  -25.00%          (p=0.000 n=9+9)
SubmitCommand5Nodes1Pending-4    41.4kB ± 0%    30.8kB ± 0%  -25.62%         (p=0.000 n=10+9)
SubmitCommand1Node2Pending-4     1.82kB ± 1%    1.81kB ± 2%     ~           (p=0.800 n=10+10)
SubmitCommand3Nodes2Pending-4    21.6kB ± 2%    14.3kB ± 0%  -33.76%        (p=0.000 n=10+10)
SubmitCommand5Nodes2Pending-4    40.0kB ± 1%    26.4kB ± 0%  -34.01%         (p=0.000 n=10+9)
SubmitCommand1Node4Pending-4     1.97kB ± 0%    1.96kB ± 2%     ~            (p=0.172 n=8+10)
SubmitCommand3Nodes4Pending-4    20.6kB ± 1%    14.1kB ± 0%  -31.55%         (p=0.000 n=10+9)
SubmitCommand5Nodes4Pending-4    38.5kB ± 1%    26.6kB ± 0%  -30.95%        (p=0.000 n=10+10)

name                           old allocs/op  new allocs/op  delta
SubmitCommand1Node1Pending-4       30.0 ± 0%      30.0 ± 0%     ~     (all samples are equal)
SubmitCommand3Nodes1Pending-4       271 ± 0%       180 ± 0%  -33.58%          (p=0.000 n=9+9)
SubmitCommand5Nodes1Pending-4       496 ± 0%       322 ± 0%  -35.13%         (p=0.000 n=10+8)
SubmitCommand1Node2Pending-4       23.0 ± 0%      23.0 ± 0%     ~     (all samples are equal)
SubmitCommand3Nodes2Pending-4       258 ± 1%       150 ± 0%  -41.77%        (p=0.000 n=10+10)
SubmitCommand5Nodes2Pending-4       478 ± 0%       270 ± 0%  -43.46%          (p=0.000 n=8+8)
SubmitCommand1Node4Pending-4       24.0 ± 0%      24.0 ± 0%     ~     (all samples are equal)
SubmitCommand3Nodes4Pending-4       242 ± 1%       144 ± 0%  -40.57%        (p=0.000 n=10+10)
SubmitCommand5Nodes4Pending-4       455 ± 1%       268 ± 0%  -41.05%        (p=0.000 n=10+10)
```

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/3149)

<!-- Reviewable:end -->
