### PR TITLE
raft: Remove waitForCallback and centralize re-proposal logic.

### DIFF
--- a/multiraft/multiraft.go
+++ b/multiraft/multiraft.go
@@ -453,11 +453,6 @@ type group struct {
 	writing bool
 	// nodeIDs track the remote nodes associated with this group.
 	nodeIDs []roachpb.NodeID
-	// waitForCallback is a counter that is incremented when a
-	// configuration change callback is created and is decremented
-	// when the callback finishes. The positive value indicates
-	// that there is a pending callback.
-	waitForCallback int
 }
 
 type createGroupOp struct {
@@ -1034,11 +1029,6 @@ func (s *state) propose(p *proposal) {
 		}
 		return
 	}
-	// If configuration change callback is pending, wait for it.
-	if g.waitForCallback > 0 {
-		g.pending[p.commandID] = p
-		return
-	}
 
 	if log.V(3) {
 		log.Infof("group %d: new proposal %x", p.groupID, p.commandID)
@@ -1123,17 +1113,14 @@ func (s *state) processCommittedEntry(groupID roachpb.RangeID, g *group, entry r
 	var commandID string
 	switch entry.Type {
 	case raftpb.EntryNormal:
-		// etcd raft occasionally adds a nil entry (e.g. upon election); ignore these.
-		if entry.Data != nil {
-			var command []byte
-			commandID, command = decodeCommand(entry.Data)
-			s.sendEvent(&EventCommandCommitted{
-				GroupID:   groupID,
-				CommandID: commandID,
-				Command:   command,
-				Index:     entry.Index,
-			})
-		}
+		var command []byte
+		commandID, command = decodeCommand(entry.Data)
+		s.sendEvent(&EventCommandCommitted{
+			GroupID:   groupID,
+			CommandID: commandID,
+			Command:   command,
+			Index:     entry.Index,
+		})
 
 	case raftpb.EntryConfChange:
 		cc := raftpb.ConfChange{}
@@ -1157,7 +1144,6 @@ func (s *state) processCommittedEntry(groupID roachpb.RangeID, g *group, entry r
 			log.Fatalf("could not look up replica info (node %s, group %d, replica %d): %s",
 				s.nodeID, groupID, cc.NodeID, err)
 		}
-		g.waitForCallback++
 		s.sendEvent(&EventMembershipChangeCommitted{
 			GroupID:    groupID,
 			CommandID:  commandID,
@@ -1189,15 +1175,6 @@ func (s *state) processCommittedEntry(groupID roachpb.RangeID, g *group, entry r
 						log.Warningf("aborting configuration change: %s", err)
 						s.multiNode.ApplyConfChange(uint64(groupID),
 							raftpb.ConfChange{})
-					}
-
-					// Re-submit all pending proposals that were held
-					// while the config change was pending
-					g.waitForCallback--
-					if g.waitForCallback <= 0 {
-						for _, prop := range g.pending {
-							s.propose(prop)
-						}
 					}
 				}:
 				case <-s.stopper.ShouldStop():
@@ -1311,11 +1288,6 @@ func (s *state) maybeSendLeaderEvent(groupID roachpb.RangeID, g *group, ready *r
 			ReplicaID: g.leader.ReplicaID,
 			Term:      g.committedTerm,
 		})
-
-		// Re-submit all pending proposals
-		for _, prop := range g.pending {
-			s.propose(prop)
-		}
 	}
 }
 
@@ -1345,8 +1317,23 @@ func (s *state) handleWriteResponse(response *writeResponse, readyGroups map[uin
 		}
 		g.writing = false
 
-		// Process committed entries.
+		// Process committed entries. etcd raft occasionally adds a nil
+		// entry (our own commands are never empty). This happens in two
+		// situations: When a new leader is elected, and when a config
+		// change is dropped due to the "one at a time" rule. In both
+		// cases we may need to resubmit our pending proposals (In the
+		// former case we resubmit everything because we proposed them to
+		// a former leader that is no longer able to commit them. In the
+		// latter case we only need to resubmit pending config changes,
+		// but it's hard to distinguish so we resubmit everything
+		// anyway). We delay resubmission until after we have processed
+		// the entire batch of entries.
+		hasEmptyEntry := false
 		for _, entry := range ready.CommittedEntries {
+			if entry.Type == raftpb.EntryNormal && len(entry.Data) == 0 {
+				hasEmptyEntry = true
+				continue
+			}
 			commandID := s.processCommittedEntry(raftGroupID, g, entry)
 			// TODO(bdarnell): the command is now committed, but not applied until the
 			// application consumes EventCommandCommitted. Is returning via the channel
@@ -1355,6 +1342,11 @@ func (s *state) handleWriteResponse(response *writeResponse, readyGroups map[uin
 			// This could be done with a Callback as in EventMembershipChangeCommitted
 			// or perhaps we should move away from a channel to a callback-based system.
 			s.removePending(g, g.pending[commandID], nil /* err */)
+		}
+		if hasEmptyEntry {
+			for _, prop := range g.pending {
+				s.propose(prop)
+			}
 		}
 
 		if !raft.IsEmptySnap(ready.Snapshot) {

--- a/multiraft/multiraft_test.go
+++ b/multiraft/multiraft_test.go
@@ -422,7 +422,6 @@ func TestMembershipChange(t *testing.T) {
 // leader must have removed itself.
 func TestRemoveLeader(t *testing.T) {
 	defer leaktest.AfterTest(t)
-	t.Skip("TODO(bdarnell): https://github.com/cockroachdb/cockroach/issues/2639")
 	stopper := stop.NewStopper()
 	const clusterSize = 6
 	const groupSize = 3
@@ -495,7 +494,9 @@ func TestRemoveLeader(t *testing.T) {
 	}
 }
 
-func TestRapidMembershipChange(t *testing.T) {
+// TestRapidCreateRemoveGroup tests for races between CreateGroup,
+// SubmitCommand, and RemoveGroup.
+func TestRapidCreateRemoveGroup(t *testing.T) {
 	defer leaktest.AfterTest(t)
 	stopper := stop.NewStopper()
 	defer stopper.Stop()
@@ -573,6 +574,62 @@ func TestRapidMembershipChange(t *testing.T) {
 	// otherwise subject to concurrent access from our goroutine and the go
 	// testing machinery.
 	wg.Wait()
+}
+
+// TestReproposeConfigChange verifies the behavior when multiple
+// configuration changes are in flight at once. Raft prohibits this,
+// but any configuration changes that are dropped by this rule should
+// be reproposed when the previous change completes.
+func TestReproposeConfigChange(t *testing.T) {
+	defer leaktest.AfterTest(t)
+	stopper := stop.NewStopper()
+	defer stopper.Stop()
+	const clusterSize = 4
+	const groupSize = 3
+	cluster := newTestCluster(nil, clusterSize, stopper, t)
+
+	const groupID = roachpb.RangeID(1)
+	const leader = 0
+	const proposer = 1
+	cluster.createGroup(groupID, leader, groupSize)
+	cluster.elect(leader, groupID)
+
+	targetDesc := roachpb.ReplicaDescriptor{
+		NodeID:    cluster.nodes[groupSize].nodeID,
+		StoreID:   roachpb.StoreID(cluster.nodes[groupSize].nodeID),
+		ReplicaID: roachpb.ReplicaID(cluster.nodes[groupSize].nodeID),
+	}
+	// Add a node and immediately remove it without waiting for the
+	// first change to commit.
+	addErrCh := cluster.nodes[proposer].ChangeGroupMembership(groupID, makeCommandID(),
+		raftpb.ConfChangeAddNode, targetDesc, nil)
+	removeErrCh := cluster.nodes[proposer].ChangeGroupMembership(groupID, makeCommandID(),
+		raftpb.ConfChangeRemoveNode, targetDesc, nil)
+
+	// The add command will commit first; then it needs to be applied.
+	// Apply it on the proposer node before the leader.
+	e := <-cluster.events[proposer].MembershipChangeCommitted
+	e.Callback(nil)
+	e = <-cluster.events[leader].MembershipChangeCommitted
+	e.Callback(nil)
+
+	// Now wait for both commands to commit.
+	select {
+	case err := <-addErrCh:
+		if err != nil {
+			t.Errorf("add failed: %s", err)
+		}
+	case <-time.After(time.Second):
+		t.Errorf("add timed out")
+	}
+	select {
+	case err := <-removeErrCh:
+		if err != nil {
+			t.Errorf("remove failed: %s", err)
+		}
+	case <-time.After(time.Second):
+		t.Errorf("remove timed out")
+	}
 }
 
 // TestConfigValidation verifies that the validation of a Config returns


### PR DESCRIPTION
When a proposal is forwarded from a follower to a leader,
waitForCallback is incorrect: what matters is whether the _leader_ is
waiting for a pending config change callback. Instead, we need to
repropose from the follower when the leader has completed its pending
config change. This is difficult to observe directly but does have a
side effect: when a config change is dropped, it is replaced with an
empty entry. When we see such an entry, we know we have to re-propose.

Since empty entries are also used to signal leader changes, we can
remove the re-proposals in maybeSendLeaderEvent.

Fixes #2639

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/3154)

<!-- Reviewable:end -->
