### PR TITLE
Add in the missing defer to unreplicateRange.

### DIFF
--- a/storage/client_raft_test.go
+++ b/storage/client_raft_test.go
@@ -1131,7 +1131,6 @@ func TestRaftAfterRemoveRange(t *testing.T) {
 // number of repetitions adds an unacceptable amount of test runtime).
 func TestRaftRemoveRace(t *testing.T) {
 	defer leaktest.AfterTest(t)
-	t.Skip("TODO(bdarnell): https://github.com/cockroachdb/cockroach/issues/2878")
 	mtc := startMultiTestContext(t, 3)
 	defer mtc.Stop()
 

--- a/storage/client_test.go
+++ b/storage/client_test.go
@@ -508,7 +508,7 @@ func (m *multiTestContext) replicateRange(rangeID roachpb.RangeID, sourceStoreIn
 // from the dest store.
 func (m *multiTestContext) unreplicateRange(rangeID roachpb.RangeID, source, dest int) {
 	m.mu.RLock()
-	m.mu.RUnlock()
+	defer m.mu.RUnlock()
 	rng, err := m.stores[source].GetReplica(rangeID)
 	if err != nil {
 		m.t.Fatal(err)


### PR DESCRIPTION
Fixes #2878
Note that there are still failures from TestRaftRemoveRace #3010
and #2950 but not at the same rate.

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/3158)

<!-- Reviewable:end -->
