### PR TITLE
Update a batch request's txn from its response's in DistSender.sendChunk

### DIFF
--- a/kv/batch.go
+++ b/kv/batch.go
@@ -153,9 +153,6 @@ func (cs *chunkingSender) Send(ctx context.Context, ba roachpb.BatchRequest) (*r
 	var rplChunks []*roachpb.BatchResponse
 	for _, part := range parts {
 		ba.Requests = part
-		// Increase the sequence counter to account for the fact that while
-		// chunking, we're likely sending multiple requests to the same Replica.
-		ba.SetNewRequest()
 		rpl, err := cs.f(ctx, ba)
 		if err != nil {
 			return nil, err

--- a/kv/dist_sender.go
+++ b/kv/dist_sender.go
@@ -647,6 +647,8 @@ func (ds *DistSender) sendChunk(ctx context.Context, ba roachpb.BatchRequest) (*
 			return nil, pErr
 		}
 
+		ba.Txn.Update(curReply.Txn)
+
 		first := br == nil
 		if first {
 			// First response from a Range.

--- a/kv/dist_sender.go
+++ b/kv/dist_sender.go
@@ -433,6 +433,13 @@ func (ds *DistSender) sendAttempt(trace *tracer.Trace, ba roachpb.BatchRequest, 
 		}
 	}
 
+	// Increase the sequence counter in the per-range loop (not
+	// outside) since we might hit the same range twice by
+	// accident. For example, we might send multiple requests to
+	// the same Replica if (1) the descriptor cache has post-split
+	// descriptors that are still write intents and (2) the split
+	// has not yet been completed.
+	ba.SetNewRequest()
 	br, err := ds.sendRPC(trace, desc.RangeID, replicas, order, ba)
 	if err != nil {
 		return nil, roachpb.NewError(err)

--- a/kv/dist_sender_server_test.go
+++ b/kv/dist_sender_server_test.go
@@ -19,6 +19,7 @@ package kv_test
 
 import (
 	"reflect"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -28,6 +29,7 @@ import (
 	"github.com/cockroachdb/cockroach/roachpb"
 	"github.com/cockroachdb/cockroach/server"
 	"github.com/cockroachdb/cockroach/sql"
+	"github.com/cockroachdb/cockroach/storage"
 	"github.com/cockroachdb/cockroach/storage/engine"
 	"github.com/cockroachdb/cockroach/testutils"
 	"github.com/cockroachdb/cockroach/util/hlc"
@@ -453,5 +455,168 @@ func TestNoSequenceCachePutOnRangeMismatchError(t *testing.T) {
 
 	if epoch != 1 {
 		t.Errorf("unexpected epoch; the txn must not be retried, but got %d retries", epoch)
+	}
+}
+
+// TestPropagateTxnOnError verifies that DistSender.sendChunk properly
+// propagates the txn data to a next iteration. Use txn.Writing field to
+// verify that.
+func TestPropagateTxnOnError(t *testing.T) {
+	defer leaktest.AfterTest(t)
+
+	// Set up a filter to so that the first CPut operation will
+	// get a ReadWithinUncertaintyIntervalError.
+	targetKey := roachpb.Key("b")
+	var numGets int32
+	storage.TestingCommandFilter = func(args roachpb.Request, h roachpb.Header) error {
+		if _, ok := args.(*roachpb.ConditionalPutRequest); ok && args.Header().Key.Equal(targetKey) {
+			if atomic.AddInt32(&numGets, 1) == 1 {
+				return &roachpb.ReadWithinUncertaintyIntervalError{
+					Timestamp:         h.Timestamp,
+					ExistingTimestamp: h.Timestamp,
+				}
+
+			}
+		}
+		return nil
+	}
+	defer func() {
+		storage.TestingCommandFilter = nil
+	}()
+
+	s, db := setupMultipleRanges(t, "b")
+	defer s.Stop()
+
+	// Set the initial value on the target key "b".
+	origVal := "val"
+	if err := db.Put(targetKey, origVal); err != nil {
+		t.Fatal(err)
+	}
+
+	// The following txn creates a batch request that is split
+	// into two requests: Put and CPut. The CPut operation will
+	// get a ReadWithinUncertaintyIntervalError and the txn will be
+	// retried.
+	epoch := 0
+	if err := db.Txn(func(txn *client.Txn) error {
+		epoch++
+		if epoch >= 2 {
+			// Writing must be true since we ran the BeginTransaction command.
+			if !txn.Proto.Writing {
+				t.Errorf("unexpected non-writing txn")
+			}
+		} else {
+			// Writing must be false since we haven't run any write command.
+			if txn.Proto.Writing {
+				t.Errorf("unexpected writing txn")
+			}
+		}
+
+		b := &client.Batch{}
+		b.Put("a", "val")
+		b.CPut(targetKey, "new_val", origVal)
+		err := txn.CommitInBatch(b)
+		if epoch == 1 {
+			if tErr, ok := err.(*roachpb.ReadWithinUncertaintyIntervalError); ok {
+				if !tErr.Txn.Writing {
+					t.Errorf("unexpected non-writing txn on error")
+				}
+			} else {
+				t.Errorf("expected ReadWithinUncertaintyIntervalError, but got: %s", err)
+			}
+		}
+		return err
+	}); err != nil {
+		t.Errorf("unexpected error on transactional Puts: %s", err)
+	}
+
+	if epoch != 2 {
+		t.Errorf("unexpected epoch; the txn must be retried exactly once, but got %d", epoch)
+	}
+}
+
+// TestDoNotPropagateTxnOnError reproduces a bug where txn data (e.g., txn ID)
+// are not propagated to a next epoch on error.
+//
+// TODO(kkaneda): Fix #743. The bug happens since not all errors carry
+// a transaction, but range-spanning writes are not atomic (and data
+// may actually have been written).
+func TestDoNotPropagateTxnOnError(t *testing.T) {
+	defer leaktest.AfterTest(t)
+	s, db := setupMultipleRanges(t, "b")
+	defer s.Stop()
+
+	waitForWriteIntent := make(chan struct{})
+	waitForTxnRestart := make(chan struct{})
+	waitForTxnCommit := make(chan struct{})
+	// Create a goroutine that creates a write intent and waits until
+	// another txn created in this test is restarted.
+	go func() {
+		if err := db.Txn(func(txn *client.Txn) error {
+			if err := txn.Put("b", "val"); err != nil {
+				return err
+			}
+			close(waitForWriteIntent)
+			// Wait until another txn in this test is
+			// restarted by a push txn error.
+			<-waitForTxnRestart
+			return txn.CommitInBatch(&client.Batch{})
+		}); err != nil {
+			t.Errorf("unexpected error on transactional Puts: %s", err)
+		}
+		close(waitForTxnCommit)
+	}()
+
+	// Wait until a write intent is created by the above goroutine.
+	<-waitForWriteIntent
+
+	// The transaction below is restarted multiple times.
+	// - The first retry is caused by the write intent created on key "b" by the above goroutine.
+	// - The subsequent retries are caused by the write conflict on key "a". Since the txn
+	//   ID is not propagated, a txn of a new epoch always has a new txn ID different
+	//   from the previous txn's. So, the write intent made by the txn of the previous epoch
+	//   is treated as a write made by some different txn.
+	epoch := 0
+	if err := db.Txn(func(txn *client.Txn) error {
+		// Set low priority so that the intent will not be pushed.
+		txn.InternalSetPriority(1)
+
+		epoch++
+
+		if epoch == 2 {
+			close(waitForTxnRestart)
+			// Wait until the txn created by the goroutine is committed.
+			<-waitForTxnCommit
+		} else if epoch > 2 {
+			// Enough number of retries.
+			return nil
+		}
+
+		if !roachpb.TxnIDEqual(txn.Proto.ID, []byte("")) {
+			t.Errorf("txn ID is set unexpectedly")
+		}
+
+		b := &client.Batch{}
+		b.Put("a", "val")
+		b.Put("b", "val")
+		// The commit returns an error, but it will not be
+		// passed to the next iteration. txnSender.Send() does
+		// not update the txn data since
+		// TransactionPushError.Transaction() returns nil.
+		err := txn.CommitInBatch(b)
+		if tErr, ok := err.(*roachpb.TransactionPushError); ok {
+			if roachpb.TxnIDEqual(tErr.Txn.ID, []byte("")) {
+				t.Errorf("txn ID is not set unexpectedly: %s", tErr.Txn.ID)
+			}
+		} else {
+			t.Errorf("expected TransactionRetryError, but got: %s", err)
+		}
+		return err
+	}); err != nil {
+		t.Errorf("unexpected error on transactional Puts: %s", err)
+	}
+
+	if epoch <= 2 {
+		t.Errorf("unexpected epoch; the txn must be retried at least twice, but got %d", epoch)
 	}
 }

--- a/kv/dist_sender_server_test.go
+++ b/kv/dist_sender_server_test.go
@@ -417,5 +417,41 @@ func TestBadRequest(t *testing.T) {
 	if err := db.DelRange("", "z"); !testutils.IsError(err, "must be greater than LocalMax") {
 		t.Fatalf("unexpected error on deletion on [KeyMin, z): %v", err)
 	}
+}
 
+// TestNoSequenceCachePutOnRangeMismatchError verifies that the
+// sequence cache is not updated with RangeKeyMismatchError. This is a
+// higher-level version of TestSequenceCacheShouldCache.
+func TestNoSequenceCachePutOnRangeMismatchError(t *testing.T) {
+	defer leaktest.AfterTest(t)
+	s, db := setupMultipleRanges(t, "b", "c")
+	defer s.Stop()
+
+	// The requests in the transaction below will be chunked and
+	// sent to replicas in the following way:
+	// 1) A batch request containing a BeginTransaction and a
+	//    put on "a" are sent to a replica owning range ["a","b").
+	// 2) A next batch request containing a put on "b" and a put
+	//    on "c" are sent to a replica owning range ["b","c").
+	//   (The range cache has a stale range descriptor.)
+	// 3) The put request on "c" causes a RangeKeyMismatchError.
+	// 4) The dist sender re-sends a request to the same replica.
+	//    This time the request contains only the put on "b" to the
+	//    same replica.
+	// 5) The command succeeds since the sequence cache has not yet been updated.
+	epoch := 0
+	if err := db.Txn(func(txn *client.Txn) error {
+		epoch++
+		b := &client.Batch{}
+		b.Put("a", "val")
+		b.Put("b", "val")
+		b.Put("c", "val")
+		return txn.CommitInBatch(b)
+	}); err != nil {
+		t.Errorf("unexpected error on transactional Puts: %s", err)
+	}
+
+	if epoch != 1 {
+		t.Errorf("unexpected epoch; the txn must not be retried, but got %d retries", epoch)
+	}
 }

--- a/kv/dist_sender_test.go
+++ b/kv/dist_sender_test.go
@@ -955,3 +955,111 @@ func TestTruncateWithSpanAndDescriptor(t *testing.T) {
 		t.Fatal(err)
 	}
 }
+
+// TestSequenceUpdateOnMultiRangeQueryLoop reproduces #3206 and
+// verifies that the sequence is updated in the DistSender
+// multi-range-query loop.
+//
+// More specifically, the issue was that DistSender might send
+// multiple batch requests to the same replica when it finds a
+// post-split range descriptor in the cache while the split has not
+// yet been fully completed. By giving a higher sequence to the second
+// request, we can avoid an infinite txn restart error (otherwise
+// caused by hitting the sequence cache).
+func TestSequenceUpdateOnMultiRangeQueryLoop(t *testing.T) {
+	defer leaktest.AfterTest(t)
+	g, s := makeTestGossip(t)
+	defer s()
+
+	if err := g.SetNodeDescriptor(&roachpb.NodeDescriptor{NodeID: 1}); err != nil {
+		t.Fatal(err)
+	}
+	nd := &roachpb.NodeDescriptor{
+		NodeID:  roachpb.NodeID(1),
+		Address: util.MakeUnresolvedAddr(testAddress.Network(), testAddress.String()),
+	}
+	if err := g.AddInfoProto(gossip.MakeNodeIDKey(roachpb.NodeID(1)), nd, time.Hour); err != nil {
+		t.Fatal(err)
+
+	}
+
+	// Fill mockRangeDescriptorDB with two descriptors.
+	var descriptor1 = roachpb.RangeDescriptor{
+		RangeID:  1,
+		StartKey: roachpb.RKeyMin,
+		EndKey:   roachpb.RKey("b"),
+		Replicas: []roachpb.ReplicaDescriptor{
+			{
+				NodeID:  1,
+				StoreID: 1,
+			},
+		},
+	}
+	var descriptor2 = roachpb.RangeDescriptor{
+		RangeID:  2,
+		StartKey: roachpb.RKey("b"),
+		EndKey:   roachpb.RKey("c"),
+		Replicas: []roachpb.ReplicaDescriptor{
+			{
+				NodeID:  1,
+				StoreID: 1,
+			},
+		},
+	}
+	descDB := mockRangeDescriptorDB(func(key roachpb.RKey, _, _ bool) ([]roachpb.RangeDescriptor, error) {
+		desc := descriptor1
+		if key.Equal(roachpb.RKey("b")) {
+			desc = descriptor2
+		}
+		return []roachpb.RangeDescriptor{desc}, nil
+	})
+
+	// Define our rpcSend stub which checks the span of the batch
+	// requests. The first request should be the point request on
+	// "a". The second request should be on "b". The sequence of the
+	// second request will be incremented by one from that of the
+	// first request.
+	first := true
+	var firstSequence uint32
+	var testFn rpcSendFn = func(_ rpc.Options, method string, addrs []net.Addr, getArgs func(addr net.Addr) proto.Message, getReply func() proto.Message, _ *rpc.Context) ([]proto.Message, error) {
+		if method != "Node.Batch" {
+			return nil, util.Errorf("unexpected method %v", method)
+		}
+
+		ba := getArgs(testAddress).(*roachpb.BatchRequest)
+		rs := keys.Range(*ba)
+		if first {
+			if !(rs.Key.Equal(roachpb.RKey("a")) && rs.EndKey.Equal(roachpb.RKey("a").Next())) {
+				t.Errorf("unexpected span [%s,%s)", rs.Key, rs.EndKey)
+			}
+			first = false
+			firstSequence = ba.Txn.Sequence
+		} else {
+			if !(rs.Key.Equal(roachpb.RKey("b")) && rs.EndKey.Equal(roachpb.RKey("b").Next())) {
+				t.Errorf("unexpected span [%s,%s)", rs.Key, rs.EndKey)
+			}
+			if ba.Txn.Sequence != firstSequence+1 {
+				t.Errorf("unexpected sequence; expected %d, but got %d", firstSequence+1, ba.Txn.Sequence)
+			}
+		}
+		return []proto.Message{ba.CreateReply()}, nil
+	}
+
+	ctx := &DistSenderContext{
+		RPCSend:           testFn,
+		RangeDescriptorDB: descDB,
+	}
+	ds := NewDistSender(ctx, g)
+
+	// Send a batch request containing two puts.
+	var ba roachpb.BatchRequest
+	ba.Txn = &roachpb.Transaction{Name: "test"}
+	val := roachpb.MakeValueFromString("val")
+	ba.Add(roachpb.NewPut(roachpb.Key("a"), val).(*roachpb.PutRequest))
+	ba.Add(roachpb.NewPut(roachpb.Key("b"), val).(*roachpb.PutRequest))
+
+	_, pErr := ds.Send(context.Background(), ba)
+	if err := pErr.GoError(); err != nil {
+		t.Fatal(err)
+	}
+}

--- a/storage/sequence_cache.go
+++ b/storage/sequence_cache.go
@@ -198,7 +198,7 @@ func (sc *SequenceCache) Put(e engine.Engine, id []byte, epoch, seq uint32, txnK
 // cache in the hopes of retrying to a successful outcome.
 func (sc *SequenceCache) shouldCacheError(err error) bool {
 	switch err.(type) {
-	case *roachpb.WriteTooOldError, *roachpb.WriteIntentError, *roachpb.NotLeaderError:
+	case *roachpb.WriteTooOldError, *roachpb.WriteIntentError, *roachpb.NotLeaderError, *roachpb.RangeKeyMismatchError:
 		return false
 	}
 	return true

--- a/storage/sequence_cache_test.go
+++ b/storage/sequence_cache_test.go
@@ -230,12 +230,12 @@ func TestSequenceCacheShouldCache(t *testing.T) {
 		{&roachpb.TransactionPushError{}, true},
 		{&roachpb.TransactionRetryError{}, true},
 		{&roachpb.RangeNotFoundError{}, true},
-		{&roachpb.RangeKeyMismatchError{}, true},
 		{&roachpb.TransactionStatusError{}, true},
 		{&roachpb.ConditionFailedError{}, true},
 		{&roachpb.WriteIntentError{}, false},
 		{&roachpb.WriteTooOldError{}, false},
 		{&roachpb.NotLeaderError{}, false},
+		{&roachpb.RangeKeyMismatchError{}, false},
 	}
 
 	reply := roachpb.PutResponse{}


### PR DESCRIPTION
The issue was initially discussed in #3112. 

This commits adds two test cases. The first one tests a fix made by this commit. The second one reproduces a case where txn data are not still propagated correctly.

The second test case is interesting. A different txn ID is assigned whenever a txn is restarted, so a write made by the same txn of two different epochs can cause a write conflict error.

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/3161)

<!-- Reviewable:end -->
