### PR TITLE
Tiny comment fix: Remove the description on zero timeoutDuration

### DIFF
--- a/kv/txn_coord_sender.go
+++ b/kv/txn_coord_sender.go
@@ -80,8 +80,7 @@ type txnMetadata struct {
 
 	// timeoutDuration is the time after which the transaction should be
 	// considered abandoned by the client. That is, when
-	// current_timestamp > lastUpdateTS + timeoutDuration If this value
-	// is set to 0, a default timeout will be used.
+	// current_timestamp > lastUpdateTS + timeoutDuration.
 	timeoutDuration time.Duration
 
 	// txnEnd is closed when the transaction is aborted or committed,


### PR DESCRIPTION
The comment says that a default value is used when `txnMetadata.timeoutDuration` is 0, but it seems there is no such logic in the code. We simply use the value set from `TxnCoordSender.clientTimeout`.

[ci skip]

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/3169)

<!-- Reviewable:end -->
