### PR TITLE
DTuple should not implement normalizableExpr.

### DIFF
--- a/sql/parser/normalize.go
+++ b/sql/parser/normalize.go
@@ -291,11 +291,6 @@ func (expr Row) normalize(v *normalizeVisitor) Expr {
 	return Tuple(expr)
 }
 
-func (expr DTuple) normalize(_ *normalizeVisitor) Expr {
-	expr.Normalize()
-	return expr
-}
-
 // NormalizeExpr normalizes an expression, simplifying where possible, but
 // guaranteeing that the result of evaluating the expression is
 // unchanged. Example normalizations:

--- a/sql/parser/normalize_test.go
+++ b/sql/parser/normalize_test.go
@@ -80,6 +80,7 @@ func TestNormalizeExpr(t *testing.T) {
 		{`(SELECT 1)`, `(SELECT 1)`},
 		{`(1, 2, 3) = (SELECT 1, 2, 3)`, `(1, 2, 3) = (SELECT 1, 2, 3)`},
 		{`(1, 2, 3) IN (SELECT 1, 2, 3)`, `(1, 2, 3) IN (SELECT 1, 2, 3)`},
+		{`(1, 'one')`, `(1, 'one')`},
 	}
 	for _, d := range testData {
 		q, err := ParseTraditional("SELECT " + d.expr)
@@ -92,6 +93,14 @@ func TestNormalizeExpr(t *testing.T) {
 			t.Fatalf("%s: %v", d.expr, err)
 		}
 		if s := r.String(); d.expected != s {
+			t.Errorf("%s: expected %s, but found %s", d.expr, d.expected, s)
+		}
+		// Normalizing again should be a no-op.
+		r2, err := defaultContext.NormalizeExpr(r)
+		if err != nil {
+			t.Fatalf("%s: %v", d.expr, err)
+		}
+		if s := r2.String(); d.expected != s {
 			t.Errorf("%s: expected %s, but found %s", d.expr, d.expected, s)
 		}
 	}

--- a/sql/testdata/subquery
+++ b/sql/testdata/subquery
@@ -124,3 +124,14 @@ query I
 SELECT 1 IN (SELECT x FROM xyz ORDER BY x DESC)
 ----
 true
+
+statement ok
+CREATE TABLE kv (k INT PRIMARY KEY, v STRING)
+
+statement ok
+INSERT INTO kv VALUES (1, 'one')
+
+query IT
+SELECT * FROM kv WHERE k = (SELECT k FROM kv WHERE (k, v) = (1, 'one'))
+----
+1 one


### PR DESCRIPTION
DTuples can only be normalized in certain contexts: the right-hand-side
of {IN,NOT IN} expressions. In more general, trying to normalize (sort
the values) of a DTuple is invalid. This only showed up for subqueries
because the expressions in subqueries are normalized twice. The first
normalization translates Tuple expressions to DTuple if those
expressions are constant and the second normalization tickled this bug.

Fixes #3167.

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/3173)

<!-- Reviewable:end -->
