### PR TITLE
fix lost tsCache updates

### DIFF
--- a/kv/txn_coord_sender.go
+++ b/kv/txn_coord_sender.go
@@ -402,6 +402,7 @@ func (tc *TxnCoordSender) Send(ctx context.Context, ba roachpb.BatchRequest) (*r
 		}
 
 		if pErr := tc.updateState(ctx, ba, br, pErr); pErr != nil {
+			trace.Event(fmt.Sprintf("error: %s", pErr))
 			return nil, pErr
 		}
 	}

--- a/storage/replica.go
+++ b/storage/replica.go
@@ -1227,6 +1227,7 @@ func (r *Replica) executeBatch(batch engine.Engine, ms *engine.MVCCStats, ba roa
 		}
 
 		// Add the response to the batch, updating the timestamp.
+		reply.Header().Timestamp.Forward(ts)
 		br.Timestamp.Forward(ts)
 		br.Add(reply)
 		if isTxn {

--- a/storage/replica.go
+++ b/storage/replica.go
@@ -1081,7 +1081,9 @@ func (r *Replica) applyRaftCommandInBatch(ctx context.Context, index uint64, ori
 		}
 	}
 
-	// Execute the commands.
+	// Execute the commands. If this returns without an error, the batch must
+	// be committed (EndTransaction with a CommitTrigger may unlock
+	// readOnlyCmdMu via a batch.Defer).
 	br, intents, err := r.executeBatch(btch, ms, ba)
 
 	// Regardless of error, add result to the sequence cache if this is


### PR DESCRIPTION
previously, concurrent reads during the execution of the
splitTrigger could add updates to the timestamp cache
on the old range after it had already been copied to
the new range. With this change, reads happen atomically
with respect to commit triggers.

fixes #3148.

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/3175)

<!-- Reviewable:end -->
