### PR TITLE
Handle case where configuration change is being processed for a group that no longer exists.

### DIFF
--- a/multiraft/multiraft.go
+++ b/multiraft/multiraft.go
@@ -1154,7 +1154,13 @@ func (s *state) processCommittedEntry(groupID roachpb.RangeID, g *group, entry r
 			Callback: func(err error) {
 				select {
 				case s.callbackChan <- func() {
-					if err == nil {
+					gInner, ok := s.groups[groupID]
+					if !ok {
+						log.Infof("group %d no longer exists, aborting configuration change", groupID)
+					} else if gInner != g {
+						panic(fmt.Sprintf("passed in group and fetched group objects do not match\noriginal:%+v\nfetched:%+v\n",
+							g, gInner))
+					} else if err == nil {
 						if log.V(3) {
 							log.Infof("node %v applying configuration change %v", s.nodeID, cc)
 						}


### PR DESCRIPTION
Fixes #3010
But exposes some other harder to reproduce bugs.  
I'll list them here before merging.  I've seen 3 so far.

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/3176)

<!-- Reviewable:end -->
