### PR TITLE
fix TestEndTransactionWithErrors

### DIFF
--- a/storage/replica_test.go
+++ b/storage/replica_test.go
@@ -1908,7 +1908,7 @@ func TestEndTransactionWithErrors(t *testing.T) {
 		{roachpb.Key("a"), roachpb.COMMITTED, txn.Epoch, txn.Timestamp, "txn \"test\" id=.*: already committed"},
 		{roachpb.Key("b"), roachpb.ABORTED, txn.Epoch, txn.Timestamp, "txn aborted \"test\" id=.*"},
 		{roachpb.Key("c"), roachpb.PENDING, txn.Epoch + 1, txn.Timestamp, "txn \"test\" id=.*: epoch regression: 0"},
-		{roachpb.Key("d"), roachpb.PENDING, txn.Epoch, regressTS, "txn \"test\" id=.*: timestamp regression: 0.000000001,0"},
+		{roachpb.Key("d"), roachpb.PENDING, txn.Epoch, regressTS, `txn "test" id=.*: timestamp regression: 0.000000001,\d+`},
 	}
 	for _, test := range testCases {
 		// Establish existing txn state by writing directly to range engine.


### PR DESCRIPTION
the timestamp it used in the assertion relied
on absence of calls to clock.Now() and hence
depended on goroutine scheduling.

fixes #3090.

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/3177)

<!-- Reviewable:end -->
