### PR TITLE
Cleanup of the C++ DB* implementation and interface.

### DIFF
--- a/storage/engine/rocksdb/db.cc
+++ b/storage/engine/rocksdb/db.cc
@@ -39,32 +39,92 @@
 extern "C" {
 #include "_cgo_export.h"
 
-struct DBBatch {
-  int updates;
-  rocksdb::WriteBatchWithIndex rep;
+struct DBEngine {
+  rocksdb::DB* const rep;
 
-  DBBatch()
-      : updates(0) {
+  DBEngine(rocksdb::DB* r)
+      : rep(r) {
   }
+  virtual ~DBEngine() { }
+
+  virtual DBStatus Put(DBSlice key, DBSlice value) = 0;
+  virtual DBStatus Merge(DBSlice key, DBSlice value) = 0;
+  virtual DBStatus Delete(DBSlice key) = 0;
+  virtual DBStatus WriteBatch() = 0;
+  virtual DBStatus Get(DBSlice key, DBString* value) = 0;
+  virtual DBIterator* NewIter() = 0;
 };
 
-struct DBEngine {
-  rocksdb::DB* rep;
-  rocksdb::Env* memenv;
+struct DBImpl : public DBEngine {
+  std::unique_ptr<rocksdb::Env> memenv;
+  std::unique_ptr<rocksdb::DB> rep_deleter;
+  rocksdb::ReadOptions const read_opts;
+
+  // Construct a new DBImpl from the specified DB and Env. Both the DB
+  // and Env will be deleted when the DBImpl is deleted. It is ok to
+  // pass NULL for the Env.
+  DBImpl(rocksdb::DB* r, rocksdb::Env* m)
+      : DBEngine(r),
+        memenv(m),
+        rep_deleter(r) {
+  }
+  virtual ~DBImpl() {
+  }
+
+  virtual DBStatus Put(DBSlice key, DBSlice value);
+  virtual DBStatus Merge(DBSlice key, DBSlice value);
+  virtual DBStatus Delete(DBSlice key);
+  virtual DBStatus WriteBatch();
+  virtual DBStatus Get(DBSlice key, DBString* value);
+  virtual DBIterator* NewIter();
+};
+
+struct DBBatch : public DBEngine {
+  int updates;
+  rocksdb::WriteBatchWithIndex batch;
+  rocksdb::ReadOptions const read_opts;
+
+  DBBatch(DBEngine* db)
+      : DBEngine(db->rep),
+        updates(0) {
+  }
+  virtual ~DBBatch() {
+  }
+
+  virtual DBStatus Put(DBSlice key, DBSlice value);
+  virtual DBStatus Merge(DBSlice key, DBSlice value);
+  virtual DBStatus Delete(DBSlice key);
+  virtual DBStatus WriteBatch();
+  virtual DBStatus Get(DBSlice key, DBString* value);
+  virtual DBIterator* NewIter();
+};
+
+struct DBSnapshot : public DBEngine {
+  const rocksdb::Snapshot* snapshot;
+  rocksdb::ReadOptions read_opts;
+
+  DBSnapshot(DBEngine *db)
+      : DBEngine(db->rep),
+        snapshot(db->rep->GetSnapshot()) {
+    read_opts.snapshot = snapshot;
+  }
+  virtual ~DBSnapshot() {
+    rep->ReleaseSnapshot(snapshot);
+  }
+
+  virtual DBStatus Put(DBSlice key, DBSlice value);
+  virtual DBStatus Merge(DBSlice key, DBSlice value);
+  virtual DBStatus Delete(DBSlice key);
+  virtual DBStatus WriteBatch();
+  virtual DBStatus Get(DBSlice key, DBString* value);
+  virtual DBIterator* NewIter();
 };
 
 struct DBIterator {
-  rocksdb::Iterator* rep;
-};
-
-struct DBSnapshot {
-  rocksdb::DB* db;
-  const rocksdb::Snapshot* rep;
+  std::unique_ptr<rocksdb::Iterator> rep;
 };
 
 }  // extern "C"
-
-using google::protobuf::StringPrintf;
 
 namespace {
 
@@ -127,14 +187,6 @@ DBStatus FmtStatus(const char *fmt, ...) {
   google::protobuf::StringAppendV(&str, fmt, ap);
   va_end(ap);
   return ToDBString(str);
-}
-
-rocksdb::ReadOptions MakeReadOptions(DBSnapshot* snap) {
-  rocksdb::ReadOptions options;
-  if (snap != NULL) {
-    options.snapshot = snap->rep;
-  }
-  return options;
 }
 
 DBIterState DBIterGetState(DBIterator* iter) {
@@ -672,37 +724,52 @@ struct Getter {
 // iterator. It is ok for the supplied iterator to be NULL in which
 // case no value will be retrieved.
 struct IteratorGetter : public Getter {
+  rocksdb::Iterator* const base;
+
   IteratorGetter(rocksdb::Iterator* iter)
-      : base_(iter) {
+      : base(iter) {
   }
 
   virtual DBStatus Get(DBString* value) {
-    if (base_ == NULL) {
+    if (base == NULL) {
       value->data = NULL;
       value->len = 0;
     } else {
-      *value = ToDBString(base_->value());
+      *value = ToDBString(base->value());
     }
     return kSuccess;
   }
-
-  rocksdb::Iterator* const base_;
 };
 
-// EngineGetter is an implementation of the Getter interface which
-// retrieves the value for the supplied key from a DBEngine.
-struct EngineGetter : public Getter {
-  EngineGetter(DBEngine* db, DBSlice key)
-      : db_(db),
-        key_(key) {
+// DBGetter is an implementation of the Getter interface which
+// retrieves the value for the supplied key from a rocksdb::DB.
+struct DBGetter : public Getter {
+  rocksdb::DB *const rep;
+  rocksdb::ReadOptions const options;
+  rocksdb::Slice const key;
+
+  DBGetter(rocksdb::DB *const r, rocksdb::ReadOptions opts, DBSlice k)
+      : rep(r),
+        options(opts),
+        key(ToSlice(k)) {
   }
 
   virtual DBStatus Get(DBString* value) {
-    return DBGet(db_, NULL, key_, value);
+    std::string tmp;
+    rocksdb::Status s = rep->Get(options, key, &tmp);
+    if (!s.ok()) {
+      if (s.IsNotFound()) {
+        // This mirrors the logic in rocksdb_get(). It doesn't seem like
+        // a good idea, but some code in engine_test.go depends on it.
+        value->data = NULL;
+        value->len = 0;
+        return kSuccess;
+      }
+      return ToDBStatus(s);
+    }
+    *value = ToDBString(tmp);
+    return kSuccess;
   }
-
-  DBEngine* const db_;
-  DBSlice const key_;
 };
 
 // ProcessDeltaKey performs the heavy lifting of processing the deltas
@@ -1026,10 +1093,10 @@ DBStatus DBOpen(DBEngine **db, DBSlice dir, DBOptions db_opts) {
   options.target_file_size_base = 64 << 20;       // 64 MB
   options.max_bytes_for_level_base = 512 << 20;   // 512 MB
 
-  rocksdb::Env* memenv = NULL;
+  std::unique_ptr<rocksdb::Env> memenv;
   if (dir.len == 0) {
-    memenv = rocksdb::NewMemEnv(rocksdb::Env::Default());
-    options.env = memenv;
+    memenv.reset(rocksdb::NewMemEnv(rocksdb::Env::Default()));
+    options.env = memenv.get();
   }
 
   rocksdb::DB *db_ptr;
@@ -1037,9 +1104,7 @@ DBStatus DBOpen(DBEngine **db, DBSlice dir, DBOptions db_opts) {
   if (!status.ok()) {
     return ToDBStatus(status);
   }
-  *db = new DBEngine;
-  (*db)->rep = db_ptr;
-  (*db)->memenv = memenv;
+  *db = new DBImpl(db_ptr, memenv.release());
   return kSuccess;
 }
 
@@ -1049,8 +1114,6 @@ DBStatus DBDestroy(DBSlice dir) {
 }
 
 void DBClose(DBEngine* db) {
-  delete db->rep;
-  delete db->memenv;
   delete db;
 }
 
@@ -1089,66 +1152,145 @@ uint64_t DBApproximateSize(DBEngine* db, DBSlice start, DBSlice end) {
   return result;
 }
 
-DBStatus DBPut(DBEngine* db, DBSlice key, DBSlice value) {
+DBStatus DBImpl::Put(DBSlice key, DBSlice value) {
   rocksdb::WriteOptions options;
-  return ToDBStatus(db->rep->Put(options, ToSlice(key), ToSlice(value)));
+  return ToDBStatus(rep->Put(options, ToSlice(key), ToSlice(value)));
 }
 
-DBStatus DBMerge(DBEngine* db, DBSlice key, DBSlice value) {
-  rocksdb::WriteOptions options;
-  return ToDBStatus(db->rep->Merge(options, ToSlice(key), ToSlice(value)));
-}
-
-DBStatus DBGet(DBEngine* db, DBSnapshot* snap, DBSlice key, DBString* value) {
-  std::string tmp;
-  rocksdb::Status s = db->rep->Get(MakeReadOptions(snap), ToSlice(key), &tmp);
-  if (!s.ok()) {
-    if (s.IsNotFound()) {
-      // This mirrors the logic in rocksdb_get(). It doesn't seem like
-      // a good idea, but some code in engine_test.go depends on it.
-      value->data = NULL;
-      value->len = 0;
-      return kSuccess;
-    }
-    return ToDBStatus(s);
-  }
-  *value = ToDBString(tmp);
+DBStatus DBBatch::Put(DBSlice key, DBSlice value) {
+  ++updates;
+  batch.Put(ToSlice(key), ToSlice(value));
   return kSuccess;
 }
 
-DBStatus DBDelete(DBEngine* db, DBSlice key) {
-  rocksdb::WriteOptions options;
-  return ToDBStatus(db->rep->Delete(options, ToSlice(key)));
+DBStatus DBSnapshot::Put(DBSlice key, DBSlice value) {
+  return FmtStatus("unsupported");
 }
 
-DBStatus DBWrite(DBEngine* db, DBBatch *batch) {
-  if (batch->updates == 0) {
+DBStatus DBPut(DBEngine* db, DBSlice key, DBSlice value) {
+  return db->Put(key, value);
+}
+
+DBStatus DBImpl::Merge(DBSlice key, DBSlice value) {
+  rocksdb::WriteOptions options;
+  return ToDBStatus(rep->Merge(options, ToSlice(key), ToSlice(value)));
+}
+
+DBStatus DBBatch::Merge(DBSlice key, DBSlice value) {
+  ++updates;
+  batch.Merge(ToSlice(key), ToSlice(value));
+  return kSuccess;
+}
+
+DBStatus DBSnapshot::Merge(DBSlice key, DBSlice value) {
+  return FmtStatus("unsupported");
+}
+
+DBStatus DBMerge(DBEngine* db, DBSlice key, DBSlice value) {
+  return db->Merge(key, value);
+}
+
+DBStatus DBImpl::Get(DBSlice key, DBString* value) {
+  DBGetter base(rep, read_opts, key);
+  return base.Get(value);
+}
+
+DBStatus DBBatch::Get(DBSlice key, DBString* value) {
+  DBGetter base(rep, read_opts, key);
+  if (updates == 0) {
+    return base.Get(value);
+  }
+  std::unique_ptr<rocksdb::WBWIIterator> iter(batch.NewIterator());
+  rocksdb::Slice rkey(ToSlice(key));
+  iter->Seek(rkey);
+  return ProcessDeltaKey(&base, iter.get(), rkey, value);
+}
+
+DBStatus DBSnapshot::Get(DBSlice key, DBString* value) {
+  DBGetter base(rep, read_opts, key);
+  return base.Get(value);
+}
+
+DBStatus DBGet(DBEngine* db, DBSlice key, DBString* value) {
+  return db->Get(key, value);
+}
+
+DBStatus DBImpl::Delete(DBSlice key) {
+  rocksdb::WriteOptions options;
+  return ToDBStatus(rep->Delete(options, ToSlice(key)));
+}
+
+DBStatus DBBatch::Delete(DBSlice key) {
+  ++updates;
+  batch.Delete(ToSlice(key));
+  return kSuccess;
+}
+
+DBStatus DBSnapshot::Delete(DBSlice key) {
+  return FmtStatus("unsupported");
+}
+
+DBStatus DBDelete(DBEngine *db, DBSlice key) {
+  return db->Delete(key);
+}
+
+DBStatus DBImpl::WriteBatch() {
+  return FmtStatus("unsupported");
+}
+
+DBStatus DBBatch::WriteBatch() {
+  if (updates == 0) {
     return kSuccess;
   }
   rocksdb::WriteOptions options;
-  return ToDBStatus(db->rep->Write(options, batch->rep.GetWriteBatch()));
+  return ToDBStatus(rep->Write(options, batch.GetWriteBatch()));
 }
 
-DBSnapshot* DBNewSnapshot(DBEngine* db)  {
-  DBSnapshot *snap = new DBSnapshot;
-  snap->db = db->rep;
-  snap->rep = db->rep->GetSnapshot();
-  return snap;
+DBStatus DBSnapshot::WriteBatch() {
+  return FmtStatus("unsupported");
 }
 
-void DBSnapshotRelease(DBSnapshot* snap) {
-  snap->db->ReleaseSnapshot(snap->rep);
-  delete snap;
+DBStatus DBWriteBatch(DBEngine* db) {
+  return db->WriteBatch();
 }
 
-DBIterator* DBNewIter(DBEngine* db, DBSnapshot* snap) {
+DBEngine* DBNewSnapshot(DBEngine* db)  {
+  return new DBSnapshot(db);
+}
+
+DBEngine* DBNewBatch(DBEngine *db) {
+  return new DBBatch(db);
+}
+
+DBIterator* DBImpl::NewIter() {
   DBIterator* iter = new DBIterator;
-  iter->rep = db->rep->NewIterator(MakeReadOptions(snap));
+  iter->rep.reset(rep->NewIterator(read_opts));
   return iter;
 }
 
+DBIterator* DBBatch::NewIter() {
+  DBIterator* iter = new DBIterator;
+  rocksdb::Iterator* base = rep->NewIterator(read_opts);
+  if (updates == 0) {
+    iter->rep.reset(base);
+  } else {
+    rocksdb::WBWIIterator* delta = batch.NewIterator();
+    iter->rep.reset(new BaseDeltaIterator(base, delta));
+  }
+  return iter;
+}
+
+DBIterator* DBSnapshot::NewIter() {
+  DBIterator* iter = new DBIterator;
+  iter->rep.reset(rep->NewIterator(read_opts));
+  return iter;
+}
+
+DBIterator* DBNewIter(DBEngine* db) {
+  return db->NewIter();
+}
+
 void DBIterDestroy(DBIterator* iter) {
-  delete iter->rep;
   delete iter;
 }
 
@@ -1181,55 +1323,6 @@ DBStatus DBIterError(DBIterator* iter) {
   return ToDBStatus(iter->rep->status());
 }
 
-DBBatch* DBNewBatch() {
-  return new DBBatch;
-}
-
-void DBBatchDestroy(DBBatch* batch) {
-  delete batch;
-}
-
-void DBBatchPut(DBBatch* batch, DBSlice key, DBSlice value) {
-  ++batch->updates;
-  batch->rep.Put(ToSlice(key), ToSlice(value));
-}
-
-void DBBatchMerge(DBBatch* batch, DBSlice key, DBSlice value) {
-  ++batch->updates;
-  batch->rep.Merge(ToSlice(key), ToSlice(value));
-}
-
-DBStatus DBBatchGet(DBEngine* db, DBBatch* batch, DBSlice key, DBString* value) {
-  if (batch->updates == 0) {
-    return DBGet(db, NULL, key, value);
-  }
-
-  std::unique_ptr<rocksdb::WBWIIterator> iter(batch->rep.NewIterator());
-  rocksdb::Slice rkey(ToSlice(key));
-  iter->Seek(rkey);
-  EngineGetter base(db, key);
-  return ProcessDeltaKey(&base, iter.get(), rkey, value);
-}
-
-void DBBatchDelete(DBBatch* batch, DBSlice key) {
-  ++batch->updates;
-  batch->rep.Delete(ToSlice(key));
-}
-
-DBIterator* DBBatchNewIter(DBEngine* db, DBBatch* batch) {
-  if (batch->updates == 0) {
-    // Don't bother to create a batch iterator if the batch contains
-    // no updates.
-    return DBNewIter(db, NULL);
-  }
-
-  DBIterator* iter = new DBIterator;
-  rocksdb::Iterator* base = db->rep->NewIterator(MakeReadOptions(NULL));
-  rocksdb::WBWIIterator *delta = batch->rep.NewIterator();
-  iter->rep = new BaseDeltaIterator(base, delta);
-  return iter;
-}
-
 DBStatus DBMergeOne(DBSlice existing, DBSlice update, DBString* new_value) {
   new_value->len = 0;
 
@@ -1249,13 +1342,14 @@ DBStatus DBMergeOne(DBSlice existing, DBSlice update, DBString* new_value) {
   return MergeResult(&meta, new_value);
 }
 
-MVCCStats MVCCComputeStats(DBIterator* iter, DBSlice start, DBSlice end, int64_t now_nanos) {
+MVCCStatsResult MVCCComputeStats(
+    DBIterator* iter, DBSlice start, DBSlice end, int64_t now_nanos) {
   const int mvcc_version_timestamp_size = 12;
 
-  MVCCStats stats;
+  MVCCStatsResult stats;
   memset(&stats, 0, sizeof(stats));
 
-  rocksdb::Iterator *const iter_rep = iter->rep;
+  rocksdb::Iterator *const iter_rep = iter->rep.get();
   iter_rep->Seek(ToSlice(start));
   const rocksdb::Slice end_key = ToSlice(end);
 


### PR DESCRIPTION
Merged the DBBatch\* functions into the DB\* equivalents. Remove the
DBSnapshot argument to DBGet() and DBNewIter(). DBNew{Batch,Snapshot}()
now returns a DBEngine. Internally, DBEngine has methods implementing
Get, Put, etc. and DB{Batch,Snapshot} override the base implementations.

This work does not change any functionality, but will make it easier to
use DBEngine, DBBatch and DBSnapshot interchangeably with the C++
code. This change enabled simplification of the Go code which interfaces
with RocksDB.

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/3180)

<!-- Reviewable:end -->
