### PR TITLE
Create /Health endpoint on server

### DIFF
--- a/cmd/monitor/main.go
+++ b/cmd/monitor/main.go
@@ -42,12 +42,12 @@ import (
 )
 
 const (
-	// urlPath is the http path of the status server on each node.
-	urlPath = "_status/details/local"
+	// urlPath is the http path of the status endpoint at each monitored address.
+	urlPath = "health"
 )
 
-var interval = flag.Duration("interval", 10*time.Second, "Interval in which to poll each services's status.")
-var addrs = flag.String("addrs", ":26257", "Comma-separated list of host:port addressess to monitor.")
+var interval = flag.Duration("interval", 10*time.Second, "Interval in which to poll the status of each monitored address.")
+var addrs = flag.String("addrs", ":26257", "Comma-separated list of host:port addresses to monitor.")
 var insecure = flag.Bool("insecure", false, "True if using an insecure connection.")
 var user = flag.String("user", security.RootUser, "User used to connect to the cluster.")
 var certs = flag.String("certs", "certs", "Directory containing RSA key and x509 certs. This flag is required if --insecure=false.")

--- a/server/server.go
+++ b/server/server.go
@@ -220,6 +220,7 @@ func (s *Server) initHTTP() {
 	s.mux.Handle(adminEndpoint, s.admin)
 	s.mux.Handle(debugEndpoint, s.admin)
 	s.mux.Handle(statusPrefix, s.status)
+	s.mux.Handle(healthEndpoint, s.status)
 	s.mux.Handle(ts.URLPrefix, s.tsServer)
 
 	// The SQL endpoints handles its own authentication, verifying user

--- a/server/status.go
+++ b/server/status.go
@@ -90,6 +90,10 @@ const (
 	statusStoresPrefix = "/_status/stores/"
 	// statusStorePattern exposes status for a single store.
 	statusStorePattern = "/_status/stores/:store_id"
+
+	// healthEndpoint is a shortcut for local details, intended for use by
+	// monitoring processes to verify that the server is up.
+	healthEndpoint = "/health"
 )
 
 // Pattern for local used when determining the node ID.
@@ -135,6 +139,7 @@ func newStatusServer(db *client.DB, gossip *gossip.Gossip, ctx *Context) *status
 	server.router.GET(statusNodePattern, server.handleNodeStatus)
 	server.router.GET(statusStoresPrefix, server.handleStoresStatus)
 	server.router.GET(statusStorePattern, server.handleStoreStatus)
+	server.router.GET(healthEndpoint, server.handleDetailsLocal)
 
 	return server
 }

--- a/server/status_test.go
+++ b/server/status_test.go
@@ -102,6 +102,7 @@ func TestStatusJson(t *testing.T) {
     "dependencies": ""
   }
 }`, addr.Network(), addr.String(), regexp.QuoteMeta(runtime.Version()))
+	testCases = append(testCases, TestCase{"/health", expectedResult})
 	testCases = append(testCases, TestCase{"/_status/details/local", expectedResult})
 	testCases = append(testCases, TestCase{"/_status/details/1", expectedResult})
 
@@ -123,18 +124,18 @@ func TestStatusJson(t *testing.T) {
 			}
 			defer resp.Body.Close()
 			if resp.StatusCode != http.StatusOK {
-				t.Errorf("unexpected status code: %v", resp.StatusCode)
+				t.Errorf("endpoint %s unexpected status code: %v", spec.keyPrefix, resp.StatusCode)
 			}
 			returnedContentType := resp.Header.Get(util.ContentTypeHeader)
 			if returnedContentType != util.JSONContentType {
-				t.Errorf("unexpected content type: %v", returnedContentType)
+				t.Errorf("endpoint %s unexpected content type: %v", spec.keyPrefix, returnedContentType)
 			}
 			body, err := ioutil.ReadAll(resp.Body)
 			if err != nil {
 				t.Fatal(err)
 			}
 			if re := regexp.MustCompile(spec.expected); !re.Match(body) {
-				t.Errorf("expected match %s; got %s", spec.expected, body)
+				t.Errorf("endpoint %s expected match %s; got %s", spec.keyPrefix, spec.expected, body)
 			}
 		}
 	}


### PR DESCRIPTION
Establishes a new '/health' endpoint on the server, which is intended only to
indicate that a server is running. This endpoint is currently an alias of
`/_status/details/local`.

Commit also modifies the status monitor tool to point to this endpoint;
previously it was querying `/_status/nodes`, which required the server to issue
an internal lookup in the cockroach database; `/health` returns more quickly.

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/3182)

<!-- Reviewable:end -->
