### PR TITLE
GC Txn entries through GC queue

### DIFF
--- a/roachpb/api.pb.go
+++ b/roachpb/api.pb.go
@@ -715,6 +715,9 @@ type ResolveIntentRequest struct {
 	Span `protobuf:"bytes,1,opt,name=header,embedded=header" json:"header"`
 	// The transaction whose intent is being resolved.
 	IntentTxn Transaction `protobuf:"bytes,2,opt,name=intent_txn" json:"intent_txn"`
+	// Optionally poison the sequence cache for the transaction the intent's
+	// range.
+	Poison bool `protobuf:"varint,3,opt,name=poison" json:"poison"`
 }
 
 func (m *ResolveIntentRequest) Reset()         { *m = ResolveIntentRequest{} }
@@ -739,6 +742,9 @@ type ResolveIntentRangeRequest struct {
 	Span `protobuf:"bytes,1,opt,name=header,embedded=header" json:"header"`
 	// The transaction whose intents are being resolved.
 	IntentTxn Transaction `protobuf:"bytes,2,opt,name=intent_txn" json:"intent_txn"`
+	// Optionally poison the sequence cache for the transaction on all ranges
+	// on which the intents reside.
+	Poison bool `protobuf:"varint,3,opt,name=poison" json:"poison"`
 }
 
 func (m *ResolveIntentRangeRequest) Reset()         { *m = ResolveIntentRangeRequest{} }
@@ -2255,6 +2261,14 @@ func (m *ResolveIntentRequest) MarshalTo(data []byte) (int, error) {
 		return 0, err
 	}
 	i += n49
+	data[i] = 0x18
+	i++
+	if m.Poison {
+		data[i] = 1
+	} else {
+		data[i] = 0
+	}
+	i++
 	return i, nil
 }
 
@@ -2315,6 +2329,14 @@ func (m *ResolveIntentRangeRequest) MarshalTo(data []byte) (int, error) {
 		return 0, err
 	}
 	i += n52
+	data[i] = 0x18
+	i++
+	if m.Poison {
+		data[i] = 1
+	} else {
+		data[i] = 0
+	}
+	i++
 	return i, nil
 }
 
@@ -3653,6 +3675,7 @@ func (m *ResolveIntentRequest) Size() (n int) {
 	n += 1 + l + sovApi(uint64(l))
 	l = m.IntentTxn.Size()
 	n += 1 + l + sovApi(uint64(l))
+	n += 2
 	return n
 }
 
@@ -3671,6 +3694,7 @@ func (m *ResolveIntentRangeRequest) Size() (n int) {
 	n += 1 + l + sovApi(uint64(l))
 	l = m.IntentTxn.Size()
 	n += 1 + l + sovApi(uint64(l))
+	n += 2
 	return n
 }
 
@@ -7943,6 +7967,26 @@ func (m *ResolveIntentRequest) Unmarshal(data []byte) error {
 				return err
 			}
 			iNdEx = postIndex
+		case 3:
+			if wireType != 0 {
+				return fmt.Errorf("proto: wrong wireType = %d for field Poison", wireType)
+			}
+			var v int
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return ErrIntOverflowApi
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := data[iNdEx]
+				iNdEx++
+				v |= (int(b) & 0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			m.Poison = bool(v != 0)
 		default:
 			iNdEx = preIndex
 			skippy, err := skipApi(data[iNdEx:])
@@ -8133,6 +8177,26 @@ func (m *ResolveIntentRangeRequest) Unmarshal(data []byte) error {
 				return err
 			}
 			iNdEx = postIndex
+		case 3:
+			if wireType != 0 {
+				return fmt.Errorf("proto: wrong wireType = %d for field Poison", wireType)
+			}
+			var v int
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return ErrIntOverflowApi
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := data[iNdEx]
+				iNdEx++
+				v |= (int(b) & 0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			m.Poison = bool(v != 0)
 		default:
 			iNdEx = preIndex
 			skippy, err := skipApi(data[iNdEx:])

--- a/roachpb/api.proto
+++ b/roachpb/api.proto
@@ -425,6 +425,9 @@ message ResolveIntentRequest {
   optional Span header = 1 [(gogoproto.nullable) = false, (gogoproto.embed) = true];
   // The transaction whose intent is being resolved.
   optional Transaction intent_txn = 2 [(gogoproto.nullable) = false];
+  // Optionally poison the sequence cache for the transaction the intent's
+  // range.
+  optional bool poison = 3 [(gogoproto.nullable) = false];
 }
 
 // A ResolveIntentResponse is the return value from the
@@ -441,6 +444,9 @@ message ResolveIntentRangeRequest {
   optional Span header = 1 [(gogoproto.nullable) = false, (gogoproto.embed) = true];
   // The transaction whose intents are being resolved.
   optional Transaction intent_txn = 2 [(gogoproto.nullable) = false];
+  // Optionally poison the sequence cache for the transaction on all ranges
+  // on which the intents reside.
+  optional bool poison = 3 [(gogoproto.nullable) = false];
 }
 
 // A NoopResponse is the return value from a no-op operation.

--- a/roachpb/data.go
+++ b/roachpb/data.go
@@ -666,8 +666,7 @@ func (t Transaction) Short() string {
 // nanoseconds since the Unix epoch.
 func NewGCMetadata(nowNanos int64) *GCMetadata {
 	return &GCMetadata{
-		LastScanNanos:     nowNanos,
-		OldestIntentNanos: proto.Int64(nowNanos),
+		LastScanNanos: nowNanos,
 	}
 }
 
@@ -711,6 +710,16 @@ func (l Lease) Covers(timestamp Timestamp) bool {
 // OwnedBy returns whether the given store is the lease owner.
 func (l Lease) OwnedBy(storeID StoreID) bool {
 	return l.Replica.StoreID == storeID
+}
+
+// AsIntents takes a slice of spans and returns it as a slice of intents for
+// the given transaction.
+func AsIntents(spans []Span, txn *Transaction) []Intent {
+	ret := make([]Intent, len(spans))
+	for i := range spans {
+		ret[i].Span, ret[i].Txn = spans[i], *txn
+	}
+	return ret
 }
 
 // RSpan is a key range with an inclusive start RKey and an exclusive end RKey.

--- a/roachpb/data.pb.go
+++ b/roachpb/data.pb.go
@@ -465,12 +465,11 @@ func (*Lease) ProtoMessage() {}
 
 // GCMetadata holds information about the last complete key/value
 // garbage collection scan of a range.
+// TODO(tschottdorf): can avoid an extra message unless we're planning
+// to add more content.
 type GCMetadata struct {
 	// The last GC scan timestamp in nanoseconds since the Unix epoch.
 	LastScanNanos int64 `protobuf:"varint,1,opt,name=last_scan_nanos" json:"last_scan_nanos"`
-	// The oldest unresolved write intent in nanoseconds since epoch.
-	// Null if there are no unresolved write intents.
-	OldestIntentNanos *int64 `protobuf:"varint,2,opt,name=oldest_intent_nanos" json:"oldest_intent_nanos,omitempty"`
 }
 
 func (m *GCMetadata) Reset()         { *m = GCMetadata{} }
@@ -1101,11 +1100,6 @@ func (m *GCMetadata) MarshalTo(data []byte) (int, error) {
 	data[i] = 0x8
 	i++
 	i = encodeVarintData(data, i, uint64(m.LastScanNanos))
-	if m.OldestIntentNanos != nil {
-		data[i] = 0x10
-		i++
-		i = encodeVarintData(data, i, uint64(*m.OldestIntentNanos))
-	}
 	return i, nil
 }
 
@@ -1373,9 +1367,6 @@ func (m *GCMetadata) Size() (n int) {
 	var l int
 	_ = l
 	n += 1 + sovData(uint64(m.LastScanNanos))
-	if m.OldestIntentNanos != nil {
-		n += 1 + sovData(uint64(*m.OldestIntentNanos))
-	}
 	return n
 }
 
@@ -3421,26 +3412,6 @@ func (m *GCMetadata) Unmarshal(data []byte) error {
 					break
 				}
 			}
-		case 2:
-			if wireType != 0 {
-				return fmt.Errorf("proto: wrong wireType = %d for field OldestIntentNanos", wireType)
-			}
-			var v int64
-			for shift := uint(0); ; shift += 7 {
-				if shift >= 64 {
-					return ErrIntOverflowData
-				}
-				if iNdEx >= l {
-					return io.ErrUnexpectedEOF
-				}
-				b := data[iNdEx]
-				iNdEx++
-				v |= (int64(b) & 0x7F) << shift
-				if b < 0x80 {
-					break
-				}
-			}
-			m.OldestIntentNanos = &v
 		default:
 			iNdEx = preIndex
 			skippy, err := skipData(data[iNdEx:])

--- a/roachpb/data.proto
+++ b/roachpb/data.proto
@@ -295,12 +295,11 @@ message Lease {
 
 // GCMetadata holds information about the last complete key/value
 // garbage collection scan of a range.
+// TODO(tschottdorf): can avoid an extra message unless we're planning
+// to add more content.
 message GCMetadata {
   // The last GC scan timestamp in nanoseconds since the Unix epoch.
   optional int64 last_scan_nanos = 1 [(gogoproto.nullable) = false];
-  // The oldest unresolved write intent in nanoseconds since epoch.
-  // Null if there are no unresolved write intents.
-  optional int64 oldest_intent_nanos = 2;
 }
 
 // SequenceCacheEntry holds information which together with the key at which

--- a/storage/engine/rocksdb/cockroach/roachpb/api.pb.cc
+++ b/storage/engine/rocksdb/cockroach/roachpb/api.pb.cc
@@ -733,9 +733,10 @@ void protobuf_AssignDesc_cockroach_2froachpb_2fapi_2eproto() {
       GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(PushTxnResponse, _internal_metadata_),
       -1);
   ResolveIntentRequest_descriptor_ = file->message_type(33);
-  static const int ResolveIntentRequest_offsets_[2] = {
+  static const int ResolveIntentRequest_offsets_[3] = {
     GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(ResolveIntentRequest, header_),
     GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(ResolveIntentRequest, intent_txn_),
+    GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(ResolveIntentRequest, poison_),
   };
   ResolveIntentRequest_reflection_ =
     ::google::protobuf::internal::GeneratedMessageReflection::NewGeneratedMessageReflection(
@@ -764,9 +765,10 @@ void protobuf_AssignDesc_cockroach_2froachpb_2fapi_2eproto() {
       GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(ResolveIntentResponse, _internal_metadata_),
       -1);
   ResolveIntentRangeRequest_descriptor_ = file->message_type(35);
-  static const int ResolveIntentRangeRequest_offsets_[2] = {
+  static const int ResolveIntentRangeRequest_offsets_[3] = {
     GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(ResolveIntentRangeRequest, header_),
     GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(ResolveIntentRangeRequest, intent_txn_),
+    GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(ResolveIntentRangeRequest, poison_),
   };
   ResolveIntentRangeRequest_reflection_ =
     ::google::protobuf::internal::GeneratedMessageReflection::NewGeneratedMessageReflection(
@@ -1402,126 +1404,127 @@ void protobuf_AddDesc_cockroach_2froachpb_2fapi_2eproto() {
     "\310\336\037\000\"\210\001\n\017PushTxnResponse\022;\n\006header\030\001 \001(\013"
     "2!.cockroach.roachpb.ResponseHeaderB\010\310\336\037"
     "\000\320\336\037\001\0228\n\npushee_txn\030\002 \001(\0132\036.cockroach.ro"
-    "achpb.TransactionB\004\310\336\037\000\"\203\001\n\024ResolveInten"
+    "achpb.TransactionB\004\310\336\037\000\"\231\001\n\024ResolveInten"
     "tRequest\0221\n\006header\030\001 \001(\0132\027.cockroach.roa"
     "chpb.SpanB\010\310\336\037\000\320\336\037\001\0228\n\nintent_txn\030\002 \001(\0132"
-    "\036.cockroach.roachpb.TransactionB\004\310\336\037\000\"T\n"
-    "\025ResolveIntentResponse\022;\n\006header\030\001 \001(\0132!"
-    ".cockroach.roachpb.ResponseHeaderB\010\310\336\037\000\320"
-    "\336\037\001\"\210\001\n\031ResolveIntentRangeRequest\0221\n\006hea"
-    "der\030\001 \001(\0132\027.cockroach.roachpb.SpanB\010\310\336\037\000"
-    "\320\336\037\001\0228\n\nintent_txn\030\002 \001(\0132\036.cockroach.roa"
-    "chpb.TransactionB\004\310\336\037\000\"K\n\014NoopResponse\022;"
-    "\n\006header\030\001 \001(\0132!.cockroach.roachpb.Respo"
-    "nseHeaderB\010\310\336\037\000\320\336\037\001\"@\n\013NoopRequest\0221\n\006he"
-    "ader\030\001 \001(\0132\027.cockroach.roachpb.SpanB\010\310\336\037"
-    "\000\320\336\037\001\"Y\n\032ResolveIntentRangeResponse\022;\n\006h"
-    "eader\030\001 \001(\0132!.cockroach.roachpb.Response"
-    "HeaderB\010\310\336\037\000\320\336\037\001\"p\n\014MergeRequest\0221\n\006head"
-    "er\030\001 \001(\0132\027.cockroach.roachpb.SpanB\010\310\336\037\000\320"
-    "\336\037\001\022-\n\005value\030\002 \001(\0132\030.cockroach.roachpb.V"
-    "alueB\004\310\336\037\000\"L\n\rMergeResponse\022;\n\006header\030\001 "
-    "\001(\0132!.cockroach.roachpb.ResponseHeaderB\010"
-    "\310\336\037\000\320\336\037\001\"\212\001\n\022TruncateLogRequest\0221\n\006heade"
-    "r\030\001 \001(\0132\027.cockroach.roachpb.SpanB\010\310\336\037\000\320\336"
-    "\037\001\022\023\n\005index\030\002 \001(\004B\004\310\336\037\000\022,\n\010range_id\030\003 \001("
-    "\003B\032\310\336\037\000\342\336\037\007RangeID\372\336\037\007RangeID\"R\n\023Truncat"
-    "eLogResponse\022;\n\006header\030\001 \001(\0132!.cockroach"
-    ".roachpb.ResponseHeaderB\010\310\336\037\000\320\336\037\001\"v\n\022Lea"
-    "derLeaseRequest\0221\n\006header\030\001 \001(\0132\027.cockro"
-    "ach.roachpb.SpanB\010\310\336\037\000\320\336\037\001\022-\n\005lease\030\002 \001("
-    "\0132\030.cockroach.roachpb.LeaseB\004\310\336\037\000\"R\n\023Lea"
-    "derLeaseResponse\022;\n\006header\030\001 \001(\0132!.cockr"
-    "oach.roachpb.ResponseHeaderB\010\310\336\037\000\320\336\037\001\"\201\n"
-    "\n\014RequestUnion\022*\n\003get\030\001 \001(\0132\035.cockroach."
-    "roachpb.GetRequest\022*\n\003put\030\002 \001(\0132\035.cockro"
-    "ach.roachpb.PutRequest\022A\n\017conditional_pu"
-    "t\030\003 \001(\0132(.cockroach.roachpb.ConditionalP"
-    "utRequest\0226\n\tincrement\030\004 \001(\0132#.cockroach"
-    ".roachpb.IncrementRequest\0220\n\006delete\030\005 \001("
-    "\0132 .cockroach.roachpb.DeleteRequest\022;\n\014d"
-    "elete_range\030\006 \001(\0132%.cockroach.roachpb.De"
-    "leteRangeRequest\022,\n\004scan\030\007 \001(\0132\036.cockroa"
-    "ch.roachpb.ScanRequest\022E\n\021begin_transact"
-    "ion\030\010 \001(\0132*.cockroach.roachpb.BeginTrans"
-    "actionRequest\022A\n\017end_transaction\030\t \001(\0132("
-    ".cockroach.roachpb.EndTransactionRequest"
-    "\0229\n\013admin_split\030\n \001(\0132$.cockroach.roachp"
-    "b.AdminSplitRequest\0229\n\013admin_merge\030\013 \001(\013"
-    "2$.cockroach.roachpb.AdminMergeRequest\022="
-    "\n\rheartbeat_txn\030\014 \001(\0132&.cockroach.roachp"
-    "b.HeartbeatTxnRequest\022(\n\002gc\030\r \001(\0132\034.cock"
-    "roach.roachpb.GCRequest\0223\n\010push_txn\030\016 \001("
-    "\0132!.cockroach.roachpb.PushTxnRequest\022;\n\014"
-    "range_lookup\030\017 \001(\0132%.cockroach.roachpb.R"
-    "angeLookupRequest\022\?\n\016resolve_intent\030\020 \001("
-    "\0132\'.cockroach.roachpb.ResolveIntentReque"
-    "st\022J\n\024resolve_intent_range\030\021 \001(\0132,.cockr"
-    "oach.roachpb.ResolveIntentRangeRequest\022."
-    "\n\005merge\030\022 \001(\0132\037.cockroach.roachpb.MergeR"
-    "equest\022;\n\014truncate_log\030\023 \001(\0132%.cockroach"
-    ".roachpb.TruncateLogRequest\022;\n\014leader_le"
-    "ase\030\024 \001(\0132%.cockroach.roachpb.LeaderLeas"
-    "eRequest\022;\n\014reverse_scan\030\025 \001(\0132%.cockroa"
-    "ch.roachpb.ReverseScanRequest\022,\n\004noop\030\026 "
-    "\001(\0132\036.cockroach.roachpb.NoopRequest:\004\310\240\037"
-    "\001\"\230\n\n\rResponseUnion\022+\n\003get\030\001 \001(\0132\036.cockr"
-    "oach.roachpb.GetResponse\022+\n\003put\030\002 \001(\0132\036."
-    "cockroach.roachpb.PutResponse\022B\n\017conditi"
-    "onal_put\030\003 \001(\0132).cockroach.roachpb.Condi"
-    "tionalPutResponse\0227\n\tincrement\030\004 \001(\0132$.c"
-    "ockroach.roachpb.IncrementResponse\0221\n\006de"
-    "lete\030\005 \001(\0132!.cockroach.roachpb.DeleteRes"
-    "ponse\022<\n\014delete_range\030\006 \001(\0132&.cockroach."
-    "roachpb.DeleteRangeResponse\022-\n\004scan\030\007 \001("
-    "\0132\037.cockroach.roachpb.ScanResponse\022F\n\021be"
-    "gin_transaction\030\010 \001(\0132+.cockroach.roachp"
-    "b.BeginTransactionResponse\022B\n\017end_transa"
-    "ction\030\t \001(\0132).cockroach.roachpb.EndTrans"
-    "actionResponse\022:\n\013admin_split\030\n \001(\0132%.co"
-    "ckroach.roachpb.AdminSplitResponse\022:\n\013ad"
-    "min_merge\030\013 \001(\0132%.cockroach.roachpb.Admi"
-    "nMergeResponse\022>\n\rheartbeat_txn\030\014 \001(\0132\'."
-    "cockroach.roachpb.HeartbeatTxnResponse\022)"
-    "\n\002gc\030\r \001(\0132\035.cockroach.roachpb.GCRespons"
-    "e\0224\n\010push_txn\030\016 \001(\0132\".cockroach.roachpb."
-    "PushTxnResponse\022<\n\014range_lookup\030\017 \001(\0132&."
-    "cockroach.roachpb.RangeLookupResponse\022@\n"
-    "\016resolve_intent\030\020 \001(\0132(.cockroach.roachp"
-    "b.ResolveIntentResponse\022K\n\024resolve_inten"
-    "t_range\030\021 \001(\0132-.cockroach.roachpb.Resolv"
-    "eIntentRangeResponse\022/\n\005merge\030\022 \001(\0132 .co"
-    "ckroach.roachpb.MergeResponse\022<\n\014truncat"
-    "e_log\030\023 \001(\0132&.cockroach.roachpb.Truncate"
-    "LogResponse\022<\n\014leader_lease\030\024 \001(\0132&.cock"
-    "roach.roachpb.LeaderLeaseResponse\022<\n\014rev"
-    "erse_scan\030\025 \001(\0132&.cockroach.roachpb.Reve"
-    "rseScanResponse\022-\n\004noop\030\026 \001(\0132\037.cockroac"
-    "h.roachpb.NoopResponse:\004\310\240\037\001\"\277\002\n\006Header\022"
-    "5\n\ttimestamp\030\001 \001(\0132\034.cockroach.roachpb.T"
-    "imestampB\004\310\336\037\000\022;\n\007replica\030\002 \001(\0132$.cockro"
-    "ach.roachpb.ReplicaDescriptorB\004\310\336\037\000\022,\n\010r"
-    "ange_id\030\003 \001(\003B\032\310\336\037\000\342\336\037\007RangeID\372\336\037\007RangeI"
-    "D\022\030\n\ruser_priority\030\004 \001(\005:\0011\022+\n\003txn\030\005 \001(\013"
-    "2\036.cockroach.roachpb.Transaction\022F\n\020read"
-    "_consistency\030\006 \001(\0162&.cockroach.roachpb.R"
-    "eadConsistencyTypeB\004\310\336\037\000:\004\210\240\037\001\"\202\001\n\014Batch"
-    "Request\0223\n\006header\030\001 \001(\0132\031.cockroach.roac"
-    "hpb.HeaderB\010\310\336\037\000\320\336\037\001\0227\n\010requests\030\002 \003(\0132\037"
-    ".cockroach.roachpb.RequestUnionB\004\310\336\037\000:\004\230"
-    "\240\037\000\"\253\002\n\rBatchResponse\022A\n\006header\030\001 \001(\0132\'."
-    "cockroach.roachpb.BatchResponse.HeaderB\010"
-    "\310\336\037\000\320\336\037\001\0229\n\tresponses\030\002 \003(\0132 .cockroach."
-    "roachpb.ResponseUnionB\004\310\336\037\000\032\225\001\n\006Header\022\'"
-    "\n\005error\030\001 \001(\0132\030.cockroach.roachpb.Error\022"
-    "5\n\ttimestamp\030\002 \001(\0132\034.cockroach.roachpb.T"
-    "imestampB\004\310\336\037\000\022+\n\003txn\030\003 \001(\0132\036.cockroach."
-    "roachpb.Transaction:\004\230\240\037\000*L\n\023ReadConsist"
-    "encyType\022\016\n\nCONSISTENT\020\000\022\r\n\tCONSENSUS\020\001\022"
-    "\020\n\014INCONSISTENT\020\002\032\004\210\243\036\000*G\n\013PushTxnType\022\022"
-    "\n\016PUSH_TIMESTAMP\020\000\022\r\n\tABORT_TXN\020\001\022\017\n\013CLE"
-    "ANUP_TXN\020\002\032\004\210\243\036\000B\035Z\007roachpb\310\341\036\000\220\343\036\000\310\342\036\001\340"
-    "\342\036\001\320\342\036\001X\003", 8889);
+    "\036.cockroach.roachpb.TransactionB\004\310\336\037\000\022\024\n"
+    "\006poison\030\003 \001(\010B\004\310\336\037\000\"T\n\025ResolveIntentResp"
+    "onse\022;\n\006header\030\001 \001(\0132!.cockroach.roachpb"
+    ".ResponseHeaderB\010\310\336\037\000\320\336\037\001\"\236\001\n\031ResolveInt"
+    "entRangeRequest\0221\n\006header\030\001 \001(\0132\027.cockro"
+    "ach.roachpb.SpanB\010\310\336\037\000\320\336\037\001\0228\n\nintent_txn"
+    "\030\002 \001(\0132\036.cockroach.roachpb.TransactionB\004"
+    "\310\336\037\000\022\024\n\006poison\030\003 \001(\010B\004\310\336\037\000\"K\n\014NoopRespon"
+    "se\022;\n\006header\030\001 \001(\0132!.cockroach.roachpb.R"
+    "esponseHeaderB\010\310\336\037\000\320\336\037\001\"@\n\013NoopRequest\0221"
+    "\n\006header\030\001 \001(\0132\027.cockroach.roachpb.SpanB"
+    "\010\310\336\037\000\320\336\037\001\"Y\n\032ResolveIntentRangeResponse\022"
+    ";\n\006header\030\001 \001(\0132!.cockroach.roachpb.Resp"
+    "onseHeaderB\010\310\336\037\000\320\336\037\001\"p\n\014MergeRequest\0221\n\006"
+    "header\030\001 \001(\0132\027.cockroach.roachpb.SpanB\010\310"
+    "\336\037\000\320\336\037\001\022-\n\005value\030\002 \001(\0132\030.cockroach.roach"
+    "pb.ValueB\004\310\336\037\000\"L\n\rMergeResponse\022;\n\006heade"
+    "r\030\001 \001(\0132!.cockroach.roachpb.ResponseHead"
+    "erB\010\310\336\037\000\320\336\037\001\"\212\001\n\022TruncateLogRequest\0221\n\006h"
+    "eader\030\001 \001(\0132\027.cockroach.roachpb.SpanB\010\310\336"
+    "\037\000\320\336\037\001\022\023\n\005index\030\002 \001(\004B\004\310\336\037\000\022,\n\010range_id\030"
+    "\003 \001(\003B\032\310\336\037\000\342\336\037\007RangeID\372\336\037\007RangeID\"R\n\023Tru"
+    "ncateLogResponse\022;\n\006header\030\001 \001(\0132!.cockr"
+    "oach.roachpb.ResponseHeaderB\010\310\336\037\000\320\336\037\001\"v\n"
+    "\022LeaderLeaseRequest\0221\n\006header\030\001 \001(\0132\027.co"
+    "ckroach.roachpb.SpanB\010\310\336\037\000\320\336\037\001\022-\n\005lease\030"
+    "\002 \001(\0132\030.cockroach.roachpb.LeaseB\004\310\336\037\000\"R\n"
+    "\023LeaderLeaseResponse\022;\n\006header\030\001 \001(\0132!.c"
+    "ockroach.roachpb.ResponseHeaderB\010\310\336\037\000\320\336\037"
+    "\001\"\201\n\n\014RequestUnion\022*\n\003get\030\001 \001(\0132\035.cockro"
+    "ach.roachpb.GetRequest\022*\n\003put\030\002 \001(\0132\035.co"
+    "ckroach.roachpb.PutRequest\022A\n\017conditiona"
+    "l_put\030\003 \001(\0132(.cockroach.roachpb.Conditio"
+    "nalPutRequest\0226\n\tincrement\030\004 \001(\0132#.cockr"
+    "oach.roachpb.IncrementRequest\0220\n\006delete\030"
+    "\005 \001(\0132 .cockroach.roachpb.DeleteRequest\022"
+    ";\n\014delete_range\030\006 \001(\0132%.cockroach.roachp"
+    "b.DeleteRangeRequest\022,\n\004scan\030\007 \001(\0132\036.coc"
+    "kroach.roachpb.ScanRequest\022E\n\021begin_tran"
+    "saction\030\010 \001(\0132*.cockroach.roachpb.BeginT"
+    "ransactionRequest\022A\n\017end_transaction\030\t \001"
+    "(\0132(.cockroach.roachpb.EndTransactionReq"
+    "uest\0229\n\013admin_split\030\n \001(\0132$.cockroach.ro"
+    "achpb.AdminSplitRequest\0229\n\013admin_merge\030\013"
+    " \001(\0132$.cockroach.roachpb.AdminMergeReque"
+    "st\022=\n\rheartbeat_txn\030\014 \001(\0132&.cockroach.ro"
+    "achpb.HeartbeatTxnRequest\022(\n\002gc\030\r \001(\0132\034."
+    "cockroach.roachpb.GCRequest\0223\n\010push_txn\030"
+    "\016 \001(\0132!.cockroach.roachpb.PushTxnRequest"
+    "\022;\n\014range_lookup\030\017 \001(\0132%.cockroach.roach"
+    "pb.RangeLookupRequest\022\?\n\016resolve_intent\030"
+    "\020 \001(\0132\'.cockroach.roachpb.ResolveIntentR"
+    "equest\022J\n\024resolve_intent_range\030\021 \001(\0132,.c"
+    "ockroach.roachpb.ResolveIntentRangeReque"
+    "st\022.\n\005merge\030\022 \001(\0132\037.cockroach.roachpb.Me"
+    "rgeRequest\022;\n\014truncate_log\030\023 \001(\0132%.cockr"
+    "oach.roachpb.TruncateLogRequest\022;\n\014leade"
+    "r_lease\030\024 \001(\0132%.cockroach.roachpb.Leader"
+    "LeaseRequest\022;\n\014reverse_scan\030\025 \001(\0132%.coc"
+    "kroach.roachpb.ReverseScanRequest\022,\n\004noo"
+    "p\030\026 \001(\0132\036.cockroach.roachpb.NoopRequest:"
+    "\004\310\240\037\001\"\230\n\n\rResponseUnion\022+\n\003get\030\001 \001(\0132\036.c"
+    "ockroach.roachpb.GetResponse\022+\n\003put\030\002 \001("
+    "\0132\036.cockroach.roachpb.PutResponse\022B\n\017con"
+    "ditional_put\030\003 \001(\0132).cockroach.roachpb.C"
+    "onditionalPutResponse\0227\n\tincrement\030\004 \001(\013"
+    "2$.cockroach.roachpb.IncrementResponse\0221"
+    "\n\006delete\030\005 \001(\0132!.cockroach.roachpb.Delet"
+    "eResponse\022<\n\014delete_range\030\006 \001(\0132&.cockro"
+    "ach.roachpb.DeleteRangeResponse\022-\n\004scan\030"
+    "\007 \001(\0132\037.cockroach.roachpb.ScanResponse\022F"
+    "\n\021begin_transaction\030\010 \001(\0132+.cockroach.ro"
+    "achpb.BeginTransactionResponse\022B\n\017end_tr"
+    "ansaction\030\t \001(\0132).cockroach.roachpb.EndT"
+    "ransactionResponse\022:\n\013admin_split\030\n \001(\0132"
+    "%.cockroach.roachpb.AdminSplitResponse\022:"
+    "\n\013admin_merge\030\013 \001(\0132%.cockroach.roachpb."
+    "AdminMergeResponse\022>\n\rheartbeat_txn\030\014 \001("
+    "\0132\'.cockroach.roachpb.HeartbeatTxnRespon"
+    "se\022)\n\002gc\030\r \001(\0132\035.cockroach.roachpb.GCRes"
+    "ponse\0224\n\010push_txn\030\016 \001(\0132\".cockroach.roac"
+    "hpb.PushTxnResponse\022<\n\014range_lookup\030\017 \001("
+    "\0132&.cockroach.roachpb.RangeLookupRespons"
+    "e\022@\n\016resolve_intent\030\020 \001(\0132(.cockroach.ro"
+    "achpb.ResolveIntentResponse\022K\n\024resolve_i"
+    "ntent_range\030\021 \001(\0132-.cockroach.roachpb.Re"
+    "solveIntentRangeResponse\022/\n\005merge\030\022 \001(\0132"
+    " .cockroach.roachpb.MergeResponse\022<\n\014tru"
+    "ncate_log\030\023 \001(\0132&.cockroach.roachpb.Trun"
+    "cateLogResponse\022<\n\014leader_lease\030\024 \001(\0132&."
+    "cockroach.roachpb.LeaderLeaseResponse\022<\n"
+    "\014reverse_scan\030\025 \001(\0132&.cockroach.roachpb."
+    "ReverseScanResponse\022-\n\004noop\030\026 \001(\0132\037.cock"
+    "roach.roachpb.NoopResponse:\004\310\240\037\001\"\277\002\n\006Hea"
+    "der\0225\n\ttimestamp\030\001 \001(\0132\034.cockroach.roach"
+    "pb.TimestampB\004\310\336\037\000\022;\n\007replica\030\002 \001(\0132$.co"
+    "ckroach.roachpb.ReplicaDescriptorB\004\310\336\037\000\022"
+    ",\n\010range_id\030\003 \001(\003B\032\310\336\037\000\342\336\037\007RangeID\372\336\037\007Ra"
+    "ngeID\022\030\n\ruser_priority\030\004 \001(\005:\0011\022+\n\003txn\030\005"
+    " \001(\0132\036.cockroach.roachpb.Transaction\022F\n\020"
+    "read_consistency\030\006 \001(\0162&.cockroach.roach"
+    "pb.ReadConsistencyTypeB\004\310\336\037\000:\004\210\240\037\001\"\202\001\n\014B"
+    "atchRequest\0223\n\006header\030\001 \001(\0132\031.cockroach."
+    "roachpb.HeaderB\010\310\336\037\000\320\336\037\001\0227\n\010requests\030\002 \003"
+    "(\0132\037.cockroach.roachpb.RequestUnionB\004\310\336\037"
+    "\000:\004\230\240\037\000\"\253\002\n\rBatchResponse\022A\n\006header\030\001 \001("
+    "\0132\'.cockroach.roachpb.BatchResponse.Head"
+    "erB\010\310\336\037\000\320\336\037\001\0229\n\tresponses\030\002 \003(\0132 .cockro"
+    "ach.roachpb.ResponseUnionB\004\310\336\037\000\032\225\001\n\006Head"
+    "er\022\'\n\005error\030\001 \001(\0132\030.cockroach.roachpb.Er"
+    "ror\0225\n\ttimestamp\030\002 \001(\0132\034.cockroach.roach"
+    "pb.TimestampB\004\310\336\037\000\022+\n\003txn\030\003 \001(\0132\036.cockro"
+    "ach.roachpb.Transaction:\004\230\240\037\000*L\n\023ReadCon"
+    "sistencyType\022\016\n\nCONSISTENT\020\000\022\r\n\tCONSENSU"
+    "S\020\001\022\020\n\014INCONSISTENT\020\002\032\004\210\243\036\000*G\n\013PushTxnTy"
+    "pe\022\022\n\016PUSH_TIMESTAMP\020\000\022\r\n\tABORT_TXN\020\001\022\017\n"
+    "\013CLEANUP_TXN\020\002\032\004\210\243\036\000B\035Z\007roachpb\310\341\036\000\220\343\036\000\310"
+    "\342\036\001\340\342\036\001\320\342\036\001X\003", 8933);
   ::google::protobuf::MessageFactory::InternalRegisterGeneratedFile(
     "cockroach/roachpb/api.proto", &protobuf_RegisterTypes);
   ResponseHeader::default_instance_ = new ResponseHeader();
@@ -13923,6 +13926,7 @@ void PushTxnResponse::clear_pushee_txn() {
 #ifndef _MSC_VER
 const int ResolveIntentRequest::kHeaderFieldNumber;
 const int ResolveIntentRequest::kIntentTxnFieldNumber;
+const int ResolveIntentRequest::kPoisonFieldNumber;
 #endif  // !_MSC_VER
 
 ResolveIntentRequest::ResolveIntentRequest()
@@ -13948,6 +13952,7 @@ void ResolveIntentRequest::SharedCtor() {
   _cached_size_ = 0;
   header_ = NULL;
   intent_txn_ = NULL;
+  poison_ = false;
   ::memset(_has_bits_, 0, sizeof(_has_bits_));
 }
 
@@ -13989,13 +13994,14 @@ ResolveIntentRequest* ResolveIntentRequest::New(::google::protobuf::Arena* arena
 }
 
 void ResolveIntentRequest::Clear() {
-  if (_has_bits_[0 / 32] & 3u) {
+  if (_has_bits_[0 / 32] & 7u) {
     if (has_header()) {
       if (header_ != NULL) header_->::cockroach::roachpb::Span::Clear();
     }
     if (has_intent_txn()) {
       if (intent_txn_ != NULL) intent_txn_->::cockroach::roachpb::Transaction::Clear();
     }
+    poison_ = false;
   }
   ::memset(_has_bits_, 0, sizeof(_has_bits_));
   if (_internal_metadata_.have_unknown_fields()) {
@@ -14031,6 +14037,21 @@ bool ResolveIntentRequest::MergePartialFromCodedStream(
          parse_intent_txn:
           DO_(::google::protobuf::internal::WireFormatLite::ReadMessageNoVirtual(
                input, mutable_intent_txn()));
+        } else {
+          goto handle_unusual;
+        }
+        if (input->ExpectTag(24)) goto parse_poison;
+        break;
+      }
+
+      // optional bool poison = 3;
+      case 3: {
+        if (tag == 24) {
+         parse_poison:
+          DO_((::google::protobuf::internal::WireFormatLite::ReadPrimitive<
+                   bool, ::google::protobuf::internal::WireFormatLite::TYPE_BOOL>(
+                 input, &poison_)));
+          set_has_poison();
         } else {
           goto handle_unusual;
         }
@@ -14075,6 +14096,11 @@ void ResolveIntentRequest::SerializeWithCachedSizes(
       2, *this->intent_txn_, output);
   }
 
+  // optional bool poison = 3;
+  if (has_poison()) {
+    ::google::protobuf::internal::WireFormatLite::WriteBool(3, this->poison(), output);
+  }
+
   if (_internal_metadata_.have_unknown_fields()) {
     ::google::protobuf::internal::WireFormat::SerializeUnknownFields(
         unknown_fields(), output);
@@ -14099,6 +14125,11 @@ void ResolveIntentRequest::SerializeWithCachedSizes(
         2, *this->intent_txn_, target);
   }
 
+  // optional bool poison = 3;
+  if (has_poison()) {
+    target = ::google::protobuf::internal::WireFormatLite::WriteBoolToArray(3, this->poison(), target);
+  }
+
   if (_internal_metadata_.have_unknown_fields()) {
     target = ::google::protobuf::internal::WireFormat::SerializeUnknownFieldsToArray(
         unknown_fields(), target);
@@ -14110,7 +14141,7 @@ void ResolveIntentRequest::SerializeWithCachedSizes(
 int ResolveIntentRequest::ByteSize() const {
   int total_size = 0;
 
-  if (_has_bits_[0 / 32] & 3) {
+  if (_has_bits_[0 / 32] & 7) {
     // optional .cockroach.roachpb.Span header = 1;
     if (has_header()) {
       total_size += 1 +
@@ -14123,6 +14154,11 @@ int ResolveIntentRequest::ByteSize() const {
       total_size += 1 +
         ::google::protobuf::internal::WireFormatLite::MessageSizeNoVirtual(
           *this->intent_txn_);
+    }
+
+    // optional bool poison = 3;
+    if (has_poison()) {
+      total_size += 1 + 1;
     }
 
   }
@@ -14158,6 +14194,9 @@ void ResolveIntentRequest::MergeFrom(const ResolveIntentRequest& from) {
     if (from.has_intent_txn()) {
       mutable_intent_txn()->::cockroach::roachpb::Transaction::MergeFrom(from.intent_txn());
     }
+    if (from.has_poison()) {
+      set_poison(from.poison());
+    }
   }
   if (from._internal_metadata_.have_unknown_fields()) {
     mutable_unknown_fields()->MergeFrom(from.unknown_fields());
@@ -14188,6 +14227,7 @@ void ResolveIntentRequest::Swap(ResolveIntentRequest* other) {
 void ResolveIntentRequest::InternalSwap(ResolveIntentRequest* other) {
   std::swap(header_, other->header_);
   std::swap(intent_txn_, other->intent_txn_);
+  std::swap(poison_, other->poison_);
   std::swap(_has_bits_[0], other->_has_bits_[0]);
   _internal_metadata_.Swap(&other->_internal_metadata_);
   std::swap(_cached_size_, other->_cached_size_);
@@ -14288,6 +14328,30 @@ void ResolveIntentRequest::clear_intent_txn() {
     clear_has_intent_txn();
   }
   // @@protoc_insertion_point(field_set_allocated:cockroach.roachpb.ResolveIntentRequest.intent_txn)
+}
+
+// optional bool poison = 3;
+bool ResolveIntentRequest::has_poison() const {
+  return (_has_bits_[0] & 0x00000004u) != 0;
+}
+void ResolveIntentRequest::set_has_poison() {
+  _has_bits_[0] |= 0x00000004u;
+}
+void ResolveIntentRequest::clear_has_poison() {
+  _has_bits_[0] &= ~0x00000004u;
+}
+void ResolveIntentRequest::clear_poison() {
+  poison_ = false;
+  clear_has_poison();
+}
+ bool ResolveIntentRequest::poison() const {
+  // @@protoc_insertion_point(field_get:cockroach.roachpb.ResolveIntentRequest.poison)
+  return poison_;
+}
+ void ResolveIntentRequest::set_poison(bool value) {
+  set_has_poison();
+  poison_ = value;
+  // @@protoc_insertion_point(field_set:cockroach.roachpb.ResolveIntentRequest.poison)
 }
 
 #endif  // PROTOBUF_INLINE_NOT_IN_HEADERS
@@ -14580,6 +14644,7 @@ void ResolveIntentResponse::clear_header() {
 #ifndef _MSC_VER
 const int ResolveIntentRangeRequest::kHeaderFieldNumber;
 const int ResolveIntentRangeRequest::kIntentTxnFieldNumber;
+const int ResolveIntentRangeRequest::kPoisonFieldNumber;
 #endif  // !_MSC_VER
 
 ResolveIntentRangeRequest::ResolveIntentRangeRequest()
@@ -14605,6 +14670,7 @@ void ResolveIntentRangeRequest::SharedCtor() {
   _cached_size_ = 0;
   header_ = NULL;
   intent_txn_ = NULL;
+  poison_ = false;
   ::memset(_has_bits_, 0, sizeof(_has_bits_));
 }
 
@@ -14646,13 +14712,14 @@ ResolveIntentRangeRequest* ResolveIntentRangeRequest::New(::google::protobuf::Ar
 }
 
 void ResolveIntentRangeRequest::Clear() {
-  if (_has_bits_[0 / 32] & 3u) {
+  if (_has_bits_[0 / 32] & 7u) {
     if (has_header()) {
       if (header_ != NULL) header_->::cockroach::roachpb::Span::Clear();
     }
     if (has_intent_txn()) {
       if (intent_txn_ != NULL) intent_txn_->::cockroach::roachpb::Transaction::Clear();
     }
+    poison_ = false;
   }
   ::memset(_has_bits_, 0, sizeof(_has_bits_));
   if (_internal_metadata_.have_unknown_fields()) {
@@ -14688,6 +14755,21 @@ bool ResolveIntentRangeRequest::MergePartialFromCodedStream(
          parse_intent_txn:
           DO_(::google::protobuf::internal::WireFormatLite::ReadMessageNoVirtual(
                input, mutable_intent_txn()));
+        } else {
+          goto handle_unusual;
+        }
+        if (input->ExpectTag(24)) goto parse_poison;
+        break;
+      }
+
+      // optional bool poison = 3;
+      case 3: {
+        if (tag == 24) {
+         parse_poison:
+          DO_((::google::protobuf::internal::WireFormatLite::ReadPrimitive<
+                   bool, ::google::protobuf::internal::WireFormatLite::TYPE_BOOL>(
+                 input, &poison_)));
+          set_has_poison();
         } else {
           goto handle_unusual;
         }
@@ -14732,6 +14814,11 @@ void ResolveIntentRangeRequest::SerializeWithCachedSizes(
       2, *this->intent_txn_, output);
   }
 
+  // optional bool poison = 3;
+  if (has_poison()) {
+    ::google::protobuf::internal::WireFormatLite::WriteBool(3, this->poison(), output);
+  }
+
   if (_internal_metadata_.have_unknown_fields()) {
     ::google::protobuf::internal::WireFormat::SerializeUnknownFields(
         unknown_fields(), output);
@@ -14756,6 +14843,11 @@ void ResolveIntentRangeRequest::SerializeWithCachedSizes(
         2, *this->intent_txn_, target);
   }
 
+  // optional bool poison = 3;
+  if (has_poison()) {
+    target = ::google::protobuf::internal::WireFormatLite::WriteBoolToArray(3, this->poison(), target);
+  }
+
   if (_internal_metadata_.have_unknown_fields()) {
     target = ::google::protobuf::internal::WireFormat::SerializeUnknownFieldsToArray(
         unknown_fields(), target);
@@ -14767,7 +14859,7 @@ void ResolveIntentRangeRequest::SerializeWithCachedSizes(
 int ResolveIntentRangeRequest::ByteSize() const {
   int total_size = 0;
 
-  if (_has_bits_[0 / 32] & 3) {
+  if (_has_bits_[0 / 32] & 7) {
     // optional .cockroach.roachpb.Span header = 1;
     if (has_header()) {
       total_size += 1 +
@@ -14780,6 +14872,11 @@ int ResolveIntentRangeRequest::ByteSize() const {
       total_size += 1 +
         ::google::protobuf::internal::WireFormatLite::MessageSizeNoVirtual(
           *this->intent_txn_);
+    }
+
+    // optional bool poison = 3;
+    if (has_poison()) {
+      total_size += 1 + 1;
     }
 
   }
@@ -14815,6 +14912,9 @@ void ResolveIntentRangeRequest::MergeFrom(const ResolveIntentRangeRequest& from)
     if (from.has_intent_txn()) {
       mutable_intent_txn()->::cockroach::roachpb::Transaction::MergeFrom(from.intent_txn());
     }
+    if (from.has_poison()) {
+      set_poison(from.poison());
+    }
   }
   if (from._internal_metadata_.have_unknown_fields()) {
     mutable_unknown_fields()->MergeFrom(from.unknown_fields());
@@ -14845,6 +14945,7 @@ void ResolveIntentRangeRequest::Swap(ResolveIntentRangeRequest* other) {
 void ResolveIntentRangeRequest::InternalSwap(ResolveIntentRangeRequest* other) {
   std::swap(header_, other->header_);
   std::swap(intent_txn_, other->intent_txn_);
+  std::swap(poison_, other->poison_);
   std::swap(_has_bits_[0], other->_has_bits_[0]);
   _internal_metadata_.Swap(&other->_internal_metadata_);
   std::swap(_cached_size_, other->_cached_size_);
@@ -14945,6 +15046,30 @@ void ResolveIntentRangeRequest::clear_intent_txn() {
     clear_has_intent_txn();
   }
   // @@protoc_insertion_point(field_set_allocated:cockroach.roachpb.ResolveIntentRangeRequest.intent_txn)
+}
+
+// optional bool poison = 3;
+bool ResolveIntentRangeRequest::has_poison() const {
+  return (_has_bits_[0] & 0x00000004u) != 0;
+}
+void ResolveIntentRangeRequest::set_has_poison() {
+  _has_bits_[0] |= 0x00000004u;
+}
+void ResolveIntentRangeRequest::clear_has_poison() {
+  _has_bits_[0] &= ~0x00000004u;
+}
+void ResolveIntentRangeRequest::clear_poison() {
+  poison_ = false;
+  clear_has_poison();
+}
+ bool ResolveIntentRangeRequest::poison() const {
+  // @@protoc_insertion_point(field_get:cockroach.roachpb.ResolveIntentRangeRequest.poison)
+  return poison_;
+}
+ void ResolveIntentRangeRequest::set_poison(bool value) {
+  set_has_poison();
+  poison_ = value;
+  // @@protoc_insertion_point(field_set:cockroach.roachpb.ResolveIntentRangeRequest.poison)
 }
 
 #endif  // PROTOBUF_INLINE_NOT_IN_HEADERS

--- a/storage/engine/rocksdb/cockroach/roachpb/api.pb.h
+++ b/storage/engine/rocksdb/cockroach/roachpb/api.pb.h
@@ -3703,18 +3703,28 @@ class ResolveIntentRequest : public ::google::protobuf::Message {
   ::cockroach::roachpb::Transaction* release_intent_txn();
   void set_allocated_intent_txn(::cockroach::roachpb::Transaction* intent_txn);
 
+  // optional bool poison = 3;
+  bool has_poison() const;
+  void clear_poison();
+  static const int kPoisonFieldNumber = 3;
+  bool poison() const;
+  void set_poison(bool value);
+
   // @@protoc_insertion_point(class_scope:cockroach.roachpb.ResolveIntentRequest)
  private:
   inline void set_has_header();
   inline void clear_has_header();
   inline void set_has_intent_txn();
   inline void clear_has_intent_txn();
+  inline void set_has_poison();
+  inline void clear_has_poison();
 
   ::google::protobuf::internal::InternalMetadataWithArena _internal_metadata_;
   ::google::protobuf::uint32 _has_bits_[1];
   mutable int _cached_size_;
   ::cockroach::roachpb::Span* header_;
   ::cockroach::roachpb::Transaction* intent_txn_;
+  bool poison_;
   friend void  protobuf_AddDesc_cockroach_2froachpb_2fapi_2eproto();
   friend void protobuf_AssignDesc_cockroach_2froachpb_2fapi_2eproto();
   friend void protobuf_ShutdownFile_cockroach_2froachpb_2fapi_2eproto();
@@ -3897,18 +3907,28 @@ class ResolveIntentRangeRequest : public ::google::protobuf::Message {
   ::cockroach::roachpb::Transaction* release_intent_txn();
   void set_allocated_intent_txn(::cockroach::roachpb::Transaction* intent_txn);
 
+  // optional bool poison = 3;
+  bool has_poison() const;
+  void clear_poison();
+  static const int kPoisonFieldNumber = 3;
+  bool poison() const;
+  void set_poison(bool value);
+
   // @@protoc_insertion_point(class_scope:cockroach.roachpb.ResolveIntentRangeRequest)
  private:
   inline void set_has_header();
   inline void clear_has_header();
   inline void set_has_intent_txn();
   inline void clear_has_intent_txn();
+  inline void set_has_poison();
+  inline void clear_has_poison();
 
   ::google::protobuf::internal::InternalMetadataWithArena _internal_metadata_;
   ::google::protobuf::uint32 _has_bits_[1];
   mutable int _cached_size_;
   ::cockroach::roachpb::Span* header_;
   ::cockroach::roachpb::Transaction* intent_txn_;
+  bool poison_;
   friend void  protobuf_AddDesc_cockroach_2froachpb_2fapi_2eproto();
   friend void protobuf_AssignDesc_cockroach_2froachpb_2fapi_2eproto();
   friend void protobuf_ShutdownFile_cockroach_2froachpb_2fapi_2eproto();
@@ -8785,6 +8805,30 @@ inline void ResolveIntentRequest::set_allocated_intent_txn(::cockroach::roachpb:
   // @@protoc_insertion_point(field_set_allocated:cockroach.roachpb.ResolveIntentRequest.intent_txn)
 }
 
+// optional bool poison = 3;
+inline bool ResolveIntentRequest::has_poison() const {
+  return (_has_bits_[0] & 0x00000004u) != 0;
+}
+inline void ResolveIntentRequest::set_has_poison() {
+  _has_bits_[0] |= 0x00000004u;
+}
+inline void ResolveIntentRequest::clear_has_poison() {
+  _has_bits_[0] &= ~0x00000004u;
+}
+inline void ResolveIntentRequest::clear_poison() {
+  poison_ = false;
+  clear_has_poison();
+}
+inline bool ResolveIntentRequest::poison() const {
+  // @@protoc_insertion_point(field_get:cockroach.roachpb.ResolveIntentRequest.poison)
+  return poison_;
+}
+inline void ResolveIntentRequest::set_poison(bool value) {
+  set_has_poison();
+  poison_ = value;
+  // @@protoc_insertion_point(field_set:cockroach.roachpb.ResolveIntentRequest.poison)
+}
+
 // -------------------------------------------------------------------
 
 // ResolveIntentResponse
@@ -8920,6 +8964,30 @@ inline void ResolveIntentRangeRequest::set_allocated_intent_txn(::cockroach::roa
     clear_has_intent_txn();
   }
   // @@protoc_insertion_point(field_set_allocated:cockroach.roachpb.ResolveIntentRangeRequest.intent_txn)
+}
+
+// optional bool poison = 3;
+inline bool ResolveIntentRangeRequest::has_poison() const {
+  return (_has_bits_[0] & 0x00000004u) != 0;
+}
+inline void ResolveIntentRangeRequest::set_has_poison() {
+  _has_bits_[0] |= 0x00000004u;
+}
+inline void ResolveIntentRangeRequest::clear_has_poison() {
+  _has_bits_[0] &= ~0x00000004u;
+}
+inline void ResolveIntentRangeRequest::clear_poison() {
+  poison_ = false;
+  clear_has_poison();
+}
+inline bool ResolveIntentRangeRequest::poison() const {
+  // @@protoc_insertion_point(field_get:cockroach.roachpb.ResolveIntentRangeRequest.poison)
+  return poison_;
+}
+inline void ResolveIntentRangeRequest::set_poison(bool value) {
+  set_has_poison();
+  poison_ = value;
+  // @@protoc_insertion_point(field_set:cockroach.roachpb.ResolveIntentRangeRequest.poison)
 }
 
 // -------------------------------------------------------------------

--- a/storage/engine/rocksdb/cockroach/roachpb/data.pb.cc
+++ b/storage/engine/rocksdb/cockroach/roachpb/data.pb.cc
@@ -327,9 +327,8 @@ void protobuf_AssignDesc_cockroach_2froachpb_2fdata_2eproto() {
       GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(Lease, _internal_metadata_),
       -1);
   GCMetadata_descriptor_ = file->message_type(14);
-  static const int GCMetadata_offsets_[2] = {
+  static const int GCMetadata_offsets_[1] = {
     GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(GCMetadata, last_scan_nanos_),
-    GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(GCMetadata, oldest_intent_nanos_),
   };
   GCMetadata_reflection_ =
     ::google::protobuf::internal::GeneratedMessageReflection::NewGeneratedMessageReflection(
@@ -515,19 +514,19 @@ void protobuf_AddDesc_cockroach_2froachpb_2fdata_2eproto() {
     "\034.cockroach.roachpb.TimestampB\004\310\336\037\000\0226\n\ne"
     "xpiration\030\002 \001(\0132\034.cockroach.roachpb.Time"
     "stampB\004\310\336\037\000\022;\n\007replica\030\003 \001(\0132$.cockroach"
-    ".roachpb.ReplicaDescriptorB\004\310\336\037\000:\004\230\240\037\000\"H"
+    ".roachpb.ReplicaDescriptorB\004\310\336\037\000:\004\230\240\037\000\"+"
     "\n\nGCMetadata\022\035\n\017last_scan_nanos\030\001 \001(\003B\004\310"
-    "\336\037\000\022\033\n\023oldest_intent_nanos\030\002 \001(\003\"a\n\022Sequ"
-    "enceCacheEntry\022\024\n\003key\030\001 \001(\014B\007\372\336\037\003Key\0225\n\t"
-    "timestamp\030\002 \001(\0132\034.cockroach.roachpb.Time"
-    "stampB\004\310\336\037\000*Q\n\tValueType\022\013\n\007UNKNOWN\020\000\022\007\n"
-    "\003INT\020\001\022\t\n\005FLOAT\020\002\022\t\n\005BYTES\020\003\022\010\n\004TIME\020\004\022\016"
-    "\n\nTIMESERIES\020d*>\n\021ReplicaChangeType\022\017\n\013A"
-    "DD_REPLICA\020\000\022\022\n\016REMOVE_REPLICA\020\001\032\004\210\243\036\000*5"
-    "\n\rIsolationType\022\020\n\014SERIALIZABLE\020\000\022\014\n\010SNA"
-    "PSHOT\020\001\032\004\210\243\036\000*B\n\021TransactionStatus\022\013\n\007PE"
-    "NDING\020\000\022\r\n\tCOMMITTED\020\001\022\013\n\007ABORTED\020\002\032\004\210\243\036"
-    "\000B\035Z\007roachpb\310\341\036\000\220\343\036\000\310\342\036\001\340\342\036\001\320\342\036\001X\001", 2954);
+    "\336\037\000\"a\n\022SequenceCacheEntry\022\024\n\003key\030\001 \001(\014B\007"
+    "\372\336\037\003Key\0225\n\ttimestamp\030\002 \001(\0132\034.cockroach.r"
+    "oachpb.TimestampB\004\310\336\037\000*Q\n\tValueType\022\013\n\007U"
+    "NKNOWN\020\000\022\007\n\003INT\020\001\022\t\n\005FLOAT\020\002\022\t\n\005BYTES\020\003\022"
+    "\010\n\004TIME\020\004\022\016\n\nTIMESERIES\020d*>\n\021ReplicaChan"
+    "geType\022\017\n\013ADD_REPLICA\020\000\022\022\n\016REMOVE_REPLIC"
+    "A\020\001\032\004\210\243\036\000*5\n\rIsolationType\022\020\n\014SERIALIZAB"
+    "LE\020\000\022\014\n\010SNAPSHOT\020\001\032\004\210\243\036\000*B\n\021TransactionS"
+    "tatus\022\013\n\007PENDING\020\000\022\r\n\tCOMMITTED\020\001\022\013\n\007ABO"
+    "RTED\020\002\032\004\210\243\036\000B\035Z\007roachpb\310\341\036\000\220\343\036\000\310\342\036\001\340\342\036\001\320"
+    "\342\036\001X\001", 2925);
   ::google::protobuf::MessageFactory::InternalRegisterGeneratedFile(
     "cockroach/roachpb/data.proto", &protobuf_RegisterTypes);
   Span::default_instance_ = new Span();
@@ -7305,7 +7304,6 @@ void Lease::clear_replica() {
 
 #ifndef _MSC_VER
 const int GCMetadata::kLastScanNanosFieldNumber;
-const int GCMetadata::kOldestIntentNanosFieldNumber;
 #endif  // !_MSC_VER
 
 GCMetadata::GCMetadata()
@@ -7328,7 +7326,6 @@ GCMetadata::GCMetadata(const GCMetadata& from)
 void GCMetadata::SharedCtor() {
   _cached_size_ = 0;
   last_scan_nanos_ = GOOGLE_LONGLONG(0);
-  oldest_intent_nanos_ = GOOGLE_LONGLONG(0);
   ::memset(_has_bits_, 0, sizeof(_has_bits_));
 }
 
@@ -7368,19 +7365,7 @@ GCMetadata* GCMetadata::New(::google::protobuf::Arena* arena) const {
 }
 
 void GCMetadata::Clear() {
-#define ZR_HELPER_(f) reinterpret_cast<char*>(\
-  &reinterpret_cast<GCMetadata*>(16)->f)
-
-#define ZR_(first, last) do {\
-  ::memset(&first, 0,\
-           ZR_HELPER_(last) - ZR_HELPER_(first) + sizeof(last));\
-} while (0)
-
-  ZR_(last_scan_nanos_, oldest_intent_nanos_);
-
-#undef ZR_HELPER_
-#undef ZR_
-
+  last_scan_nanos_ = GOOGLE_LONGLONG(0);
   ::memset(_has_bits_, 0, sizeof(_has_bits_));
   if (_internal_metadata_.have_unknown_fields()) {
     mutable_unknown_fields()->Clear();
@@ -7404,21 +7389,6 @@ bool GCMetadata::MergePartialFromCodedStream(
                    ::google::protobuf::int64, ::google::protobuf::internal::WireFormatLite::TYPE_INT64>(
                  input, &last_scan_nanos_)));
           set_has_last_scan_nanos();
-        } else {
-          goto handle_unusual;
-        }
-        if (input->ExpectTag(16)) goto parse_oldest_intent_nanos;
-        break;
-      }
-
-      // optional int64 oldest_intent_nanos = 2;
-      case 2: {
-        if (tag == 16) {
-         parse_oldest_intent_nanos:
-          DO_((::google::protobuf::internal::WireFormatLite::ReadPrimitive<
-                   ::google::protobuf::int64, ::google::protobuf::internal::WireFormatLite::TYPE_INT64>(
-                 input, &oldest_intent_nanos_)));
-          set_has_oldest_intent_nanos();
         } else {
           goto handle_unusual;
         }
@@ -7456,11 +7426,6 @@ void GCMetadata::SerializeWithCachedSizes(
     ::google::protobuf::internal::WireFormatLite::WriteInt64(1, this->last_scan_nanos(), output);
   }
 
-  // optional int64 oldest_intent_nanos = 2;
-  if (has_oldest_intent_nanos()) {
-    ::google::protobuf::internal::WireFormatLite::WriteInt64(2, this->oldest_intent_nanos(), output);
-  }
-
   if (_internal_metadata_.have_unknown_fields()) {
     ::google::protobuf::internal::WireFormat::SerializeUnknownFields(
         unknown_fields(), output);
@@ -7476,11 +7441,6 @@ void GCMetadata::SerializeWithCachedSizes(
     target = ::google::protobuf::internal::WireFormatLite::WriteInt64ToArray(1, this->last_scan_nanos(), target);
   }
 
-  // optional int64 oldest_intent_nanos = 2;
-  if (has_oldest_intent_nanos()) {
-    target = ::google::protobuf::internal::WireFormatLite::WriteInt64ToArray(2, this->oldest_intent_nanos(), target);
-  }
-
   if (_internal_metadata_.have_unknown_fields()) {
     target = ::google::protobuf::internal::WireFormat::SerializeUnknownFieldsToArray(
         unknown_fields(), target);
@@ -7492,22 +7452,13 @@ void GCMetadata::SerializeWithCachedSizes(
 int GCMetadata::ByteSize() const {
   int total_size = 0;
 
-  if (_has_bits_[0 / 32] & 3) {
-    // optional int64 last_scan_nanos = 1;
-    if (has_last_scan_nanos()) {
-      total_size += 1 +
-        ::google::protobuf::internal::WireFormatLite::Int64Size(
-          this->last_scan_nanos());
-    }
-
-    // optional int64 oldest_intent_nanos = 2;
-    if (has_oldest_intent_nanos()) {
-      total_size += 1 +
-        ::google::protobuf::internal::WireFormatLite::Int64Size(
-          this->oldest_intent_nanos());
-    }
-
+  // optional int64 last_scan_nanos = 1;
+  if (has_last_scan_nanos()) {
+    total_size += 1 +
+      ::google::protobuf::internal::WireFormatLite::Int64Size(
+        this->last_scan_nanos());
   }
+
   if (_internal_metadata_.have_unknown_fields()) {
     total_size +=
       ::google::protobuf::internal::WireFormat::ComputeUnknownFieldsSize(
@@ -7536,9 +7487,6 @@ void GCMetadata::MergeFrom(const GCMetadata& from) {
   if (from._has_bits_[0 / 32] & (0xffu << (0 % 32))) {
     if (from.has_last_scan_nanos()) {
       set_last_scan_nanos(from.last_scan_nanos());
-    }
-    if (from.has_oldest_intent_nanos()) {
-      set_oldest_intent_nanos(from.oldest_intent_nanos());
     }
   }
   if (from._internal_metadata_.have_unknown_fields()) {
@@ -7569,7 +7517,6 @@ void GCMetadata::Swap(GCMetadata* other) {
 }
 void GCMetadata::InternalSwap(GCMetadata* other) {
   std::swap(last_scan_nanos_, other->last_scan_nanos_);
-  std::swap(oldest_intent_nanos_, other->oldest_intent_nanos_);
   std::swap(_has_bits_[0], other->_has_bits_[0]);
   _internal_metadata_.Swap(&other->_internal_metadata_);
   std::swap(_cached_size_, other->_cached_size_);
@@ -7608,30 +7555,6 @@ void GCMetadata::clear_last_scan_nanos() {
   set_has_last_scan_nanos();
   last_scan_nanos_ = value;
   // @@protoc_insertion_point(field_set:cockroach.roachpb.GCMetadata.last_scan_nanos)
-}
-
-// optional int64 oldest_intent_nanos = 2;
-bool GCMetadata::has_oldest_intent_nanos() const {
-  return (_has_bits_[0] & 0x00000002u) != 0;
-}
-void GCMetadata::set_has_oldest_intent_nanos() {
-  _has_bits_[0] |= 0x00000002u;
-}
-void GCMetadata::clear_has_oldest_intent_nanos() {
-  _has_bits_[0] &= ~0x00000002u;
-}
-void GCMetadata::clear_oldest_intent_nanos() {
-  oldest_intent_nanos_ = GOOGLE_LONGLONG(0);
-  clear_has_oldest_intent_nanos();
-}
- ::google::protobuf::int64 GCMetadata::oldest_intent_nanos() const {
-  // @@protoc_insertion_point(field_get:cockroach.roachpb.GCMetadata.oldest_intent_nanos)
-  return oldest_intent_nanos_;
-}
- void GCMetadata::set_oldest_intent_nanos(::google::protobuf::int64 value) {
-  set_has_oldest_intent_nanos();
-  oldest_intent_nanos_ = value;
-  // @@protoc_insertion_point(field_set:cockroach.roachpb.GCMetadata.oldest_intent_nanos)
 }
 
 #endif  // PROTOBUF_INLINE_NOT_IN_HEADERS

--- a/storage/engine/rocksdb/cockroach/roachpb/data.pb.h
+++ b/storage/engine/rocksdb/cockroach/roachpb/data.pb.h
@@ -1877,25 +1877,15 @@ class GCMetadata : public ::google::protobuf::Message {
   ::google::protobuf::int64 last_scan_nanos() const;
   void set_last_scan_nanos(::google::protobuf::int64 value);
 
-  // optional int64 oldest_intent_nanos = 2;
-  bool has_oldest_intent_nanos() const;
-  void clear_oldest_intent_nanos();
-  static const int kOldestIntentNanosFieldNumber = 2;
-  ::google::protobuf::int64 oldest_intent_nanos() const;
-  void set_oldest_intent_nanos(::google::protobuf::int64 value);
-
   // @@protoc_insertion_point(class_scope:cockroach.roachpb.GCMetadata)
  private:
   inline void set_has_last_scan_nanos();
   inline void clear_has_last_scan_nanos();
-  inline void set_has_oldest_intent_nanos();
-  inline void clear_has_oldest_intent_nanos();
 
   ::google::protobuf::internal::InternalMetadataWithArena _internal_metadata_;
   ::google::protobuf::uint32 _has_bits_[1];
   mutable int _cached_size_;
   ::google::protobuf::int64 last_scan_nanos_;
-  ::google::protobuf::int64 oldest_intent_nanos_;
   friend void  protobuf_AddDesc_cockroach_2froachpb_2fdata_2eproto();
   friend void protobuf_AssignDesc_cockroach_2froachpb_2fdata_2eproto();
   friend void protobuf_ShutdownFile_cockroach_2froachpb_2fdata_2eproto();
@@ -3857,30 +3847,6 @@ inline void GCMetadata::set_last_scan_nanos(::google::protobuf::int64 value) {
   set_has_last_scan_nanos();
   last_scan_nanos_ = value;
   // @@protoc_insertion_point(field_set:cockroach.roachpb.GCMetadata.last_scan_nanos)
-}
-
-// optional int64 oldest_intent_nanos = 2;
-inline bool GCMetadata::has_oldest_intent_nanos() const {
-  return (_has_bits_[0] & 0x00000002u) != 0;
-}
-inline void GCMetadata::set_has_oldest_intent_nanos() {
-  _has_bits_[0] |= 0x00000002u;
-}
-inline void GCMetadata::clear_has_oldest_intent_nanos() {
-  _has_bits_[0] &= ~0x00000002u;
-}
-inline void GCMetadata::clear_oldest_intent_nanos() {
-  oldest_intent_nanos_ = GOOGLE_LONGLONG(0);
-  clear_has_oldest_intent_nanos();
-}
-inline ::google::protobuf::int64 GCMetadata::oldest_intent_nanos() const {
-  // @@protoc_insertion_point(field_get:cockroach.roachpb.GCMetadata.oldest_intent_nanos)
-  return oldest_intent_nanos_;
-}
-inline void GCMetadata::set_oldest_intent_nanos(::google::protobuf::int64 value) {
-  set_has_oldest_intent_nanos();
-  oldest_intent_nanos_ = value;
-  // @@protoc_insertion_point(field_set:cockroach.roachpb.GCMetadata.oldest_intent_nanos)
 }
 
 // -------------------------------------------------------------------

--- a/storage/gc_queue.go
+++ b/storage/gc_queue.go
@@ -263,7 +263,7 @@ func (gcq *gcQueue) process(now roachpb.Timestamp, repl *Replica,
 		}
 	}
 
-	if err := repl.resolveIntents(repl.context(), intents, true /* wait */); err != nil {
+	if err := repl.resolveIntents(repl.context(), intents, true /* wait */, false /* !poison */); err != nil {
 		return err
 	}
 
@@ -336,14 +336,14 @@ func processTransactionTable(r *Replica, txnMap map[string]*roachpb.Transaction,
 			// but instead by the coordinator - those will not have any intents
 			// persisted, though they still might exist in the system.
 			if err := r.resolveIntents(r.context(),
-				roachpb.AsIntents(txn.Intents, &txn), true /* wait */); err != nil {
+				roachpb.AsIntents(txn.Intents, &txn), true /* wait */, false /* !poison */); err != nil {
 				log.Warningf("failed to resolve intents of aborted txn on gc: %s", err)
 			}
 		case roachpb.COMMITTED:
 			// It's committed, so it doesn't need a push but we can only
 			// GC it after its intents are resolved.
 			if err := r.resolveIntents(r.context(),
-				roachpb.AsIntents(txn.Intents, &txn), true /* wait */); err != nil {
+				roachpb.AsIntents(txn.Intents, &txn), true /* wait */, false /* !poison */); err != nil {
 				log.Warningf("unable to resolve intents of committed txn on gc: %s", err)
 				// Returning the error here would abort the whole GC run, and
 				// we don't want that. Instead, we simply don't GC this entry.

--- a/storage/gc_queue.go
+++ b/storage/gc_queue.go
@@ -19,13 +19,13 @@ package storage
 
 import (
 	"fmt"
-	"math"
 	"sync"
 	"time"
 
 	"github.com/cockroachdb/cockroach/client"
 	"github.com/cockroachdb/cockroach/config"
 	"github.com/cockroachdb/cockroach/gossip"
+	"github.com/cockroachdb/cockroach/keys"
 	"github.com/cockroachdb/cockroach/roachpb"
 	"github.com/cockroachdb/cockroach/storage/engine"
 	"github.com/cockroachdb/cockroach/util/log"
@@ -46,6 +46,12 @@ const (
 	// intentAgeThreshold is the threshold after which an extant intent
 	// will be resolved.
 	intentAgeThreshold = 2 * time.Hour // 2 hour
+	// txnCleanupThreshold is the threshold after which a transaction is
+	// considered abandoned and fit for removal, as measured by the maximum
+	// of its last heartbeat and timestamp.
+	// TODO(tschottdorf): need to enforce at all times that this is much
+	// larger than the heartbeat interval used by the coordinator.
+	txnCleanupThreshold = time.Hour
 )
 
 // gcQueue manages a queue of replicas slated to be scanned in their
@@ -54,10 +60,12 @@ const (
 //
 //  - GC of version data via TTL expiration (and more complex schemes
 //    as implemented going forward).
-//  - Resolve extant write intents and determine oldest non-resolvable
-//    intent.
+//  - Resolve extant write intents (pushing their transactions).
+//  - GC of old transaction and sequence cache entries. This should include
+//    most committed entries almost immediately and, after a threshold on
+//    inactivity, all others.
 //
-// The shouldQueue function combines the need for both tasks into a
+// The shouldQueue function combines the need for the above tasks into a
 // single priority. If any task is overdue, shouldQueue returns true.
 type gcQueue struct {
 	baseQueue
@@ -139,14 +147,17 @@ func (gcq *gcQueue) process(now roachpb.Timestamp, repl *Replica,
 	// Compute intent expiration (intent age at which we attempt to resolve).
 	intentExp := now
 	intentExp.WallTime -= intentAgeThreshold.Nanoseconds()
+	txnExp := now
+	txnExp.WallTime -= txnCleanupThreshold.Nanoseconds()
 
-	// TODO(tschottdorf): execution will use a leader-assigned local
-	// timestamp to compute intent age. While this should be fine, could
-	// consider adding a Now timestamp to GCRequest which would be used
-	// instead.
 	gcArgs := &roachpb.GCRequest{}
-	var mu sync.Mutex
-	var oldestIntentNanos int64 = math.MaxInt64
+	// TODO(tschottdorf): This is one of these instances in which we want
+	// to be more careful that the request ends up on the correct Replica,
+	// and we might have to worry about mixing range-local and global keys
+	// in a batch which might end up spanning Ranges by the time it executes.
+	gcArgs.Key = desc.StartKey.AsRawKey()
+	gcArgs.EndKey = desc.EndKey.AsRawKey()
+
 	var expBaseKey roachpb.Key
 	var keys []engine.MVCCKey
 	var vals [][]byte
@@ -154,15 +165,6 @@ func (gcq *gcQueue) process(now roachpb.Timestamp, repl *Replica,
 	// Maps from txn ID to txn and intent key slice.
 	txnMap := map[string]*roachpb.Transaction{}
 	intentSpanMap := map[string][]roachpb.Span{}
-
-	// updateOldestIntent atomically updates the oldest intent.
-	updateOldestIntent := func(intentNanos int64) {
-		mu.Lock()
-		defer mu.Unlock()
-		if intentNanos < oldestIntentNanos {
-			oldestIntentNanos = intentNanos
-		}
-	}
 
 	// processKeysAndValues is invoked with each key and its set of
 	// values. Intents older than the intent age threshold are sent for
@@ -185,8 +187,6 @@ func (gcq *gcQueue) process(now roachpb.Timestamp, repl *Replica,
 						id := string(meta.Txn.ID)
 						txnMap[id] = meta.Txn
 						intentSpanMap[id] = append(intentSpanMap[id], roachpb.Span{Key: expBaseKey})
-					} else {
-						updateOldestIntent(meta.Txn.OrigTimestamp.WallTime)
 					}
 					// With an active intent, GC ignores MVCC metadata & intent value.
 					startIdx = 2
@@ -230,11 +230,26 @@ func (gcq *gcQueue) process(now roachpb.Timestamp, repl *Replica,
 	// Handle last collected set of keys/vals.
 	processKeysAndValues()
 
+	txnKeys, err := processTransactionTable(repl, txnMap, txnExp)
+	if err != nil {
+		return err
+	}
+
+	// From now on, all newly added keys are range-local.
+	// TODO(tschottdorf): Might need to use two requests at some point since we
+	// hard-coded the full non-local key range in the header, but that does
+	// not take into account the range-local keys. It will be OK as long as
+	// we send directly to the Replica, though.
+	gcArgs.Keys = append(gcArgs.Keys, txnKeys...)
+
 	// Process push transactions in parallel.
 	var wg sync.WaitGroup
 	for _, txn := range txnMap {
+		if txn.Status != roachpb.PENDING {
+			continue
+		}
 		wg.Add(1)
-		go gcq.pushTxn(repl, now, txn, updateOldestIntent, &wg)
+		go pushTxn(repl, now, txn, roachpb.ABORT_TXN, &wg)
 	}
 	wg.Wait()
 
@@ -248,32 +263,21 @@ func (gcq *gcQueue) process(now roachpb.Timestamp, repl *Replica,
 		}
 	}
 
-	done := true
-	if len(intents) > 0 {
-		done = false
-		if err := repl.resolveIntents(repl.context(), intents, true /* wait */); err != nil {
-			return err
-		}
+	if err := repl.resolveIntents(repl.context(), intents, true /* wait */); err != nil {
+		return err
 	}
 
-	// Set start and end keys.
-	if len(gcArgs.Keys) > 0 {
-		done = false
-		gcArgs.Key = gcArgs.Keys[0].Key
-		gcArgs.EndKey = gcArgs.Keys[len(gcArgs.Keys)-1].Key.Next()
-	}
-
-	if done {
-		return nil
-	}
+	// Deal with any leftover sequence cache keys. There shouldn't be many of
+	// them.
+	gcArgs.Keys = append(gcArgs.Keys, processSequenceCache(repl, now, txnExp, txnMap)...)
 
 	// Send GC request through range.
-	gcMeta.OldestIntentNanos = proto.Int64(oldestIntentNanos)
 	gcArgs.GCMeta = *gcMeta
 
 	var ba roachpb.BatchRequest
 	// Technically not needed since we're talking directly to the Range.
 	ba.RangeID = desc.RangeID
+	ba.Timestamp = now
 	ba.Add(gcArgs)
 	if _, pErr := repl.Send(repl.context(), ba); pErr != nil {
 		return pErr.GoError()
@@ -288,17 +292,143 @@ func (gcq *gcQueue) process(now roachpb.Timestamp, repl *Replica,
 	return nil
 }
 
+// processTransactionTable scans the transaction table and updates txnMap with
+// those transactions which are old and either PENDING or with intents
+// registered. In the first case we want to push the transaction so that it is
+// aborted, and in the second case we may have to resolve the intents success-
+// fully before GCing the entry. The transaction records which can be gc'ed are
+// returned separately and are not added to txnMap nor intentSpanMap.
+func processTransactionTable(r *Replica, txnMap map[string]*roachpb.Transaction, cutoff roachpb.Timestamp) ([]roachpb.GCRequest_GCKey, error) {
+	snap := r.store.Engine().NewSnapshot()
+	defer snap.Close()
+
+	var gcKeys []roachpb.GCRequest_GCKey
+	handleOne := func(kv roachpb.KeyValue) error {
+		var txn roachpb.Transaction
+		if err := kv.Value.GetProto(&txn); err != nil {
+			return err
+		}
+		ts := txn.Timestamp
+		if heartbeatTS := txn.LastHeartbeat; heartbeatTS != nil {
+			ts.Forward(*heartbeatTS)
+		}
+		if !ts.Less(cutoff) {
+			return nil
+		}
+
+		id := string(txn.ID)
+
+		// The transaction record should be considered for removal.
+		switch txn.Status {
+		case roachpb.PENDING:
+			// Marked as running, so we need to push it to abort it but won't
+			// try to GC it in this cycle (for convenience).
+			// TODO(tschottdorf): refactor so that we can GC PENDING entries
+			// in the same cycle, but keeping the calls to pushTxn in a central
+			// location (keeping it easy to batch them up in the future).
+			txnMap[id] = &txn
+			return nil
+		case roachpb.ABORTED:
+			// If we remove this transaction, it effectively still counts as
+			// ABORTED (by design). So this can be GC'ed even if we can't
+			// resolve the intents.
+			// Note: Most aborted transaction weren't aborted by their client,
+			// but instead by the coordinator - those will not have any intents
+			// persisted, though they still might exist in the system.
+			if err := r.resolveIntents(r.context(),
+				roachpb.AsIntents(txn.Intents, &txn), true /* wait */); err != nil {
+				log.Warningf("failed to resolve intents of aborted txn on gc: %s", err)
+			}
+		case roachpb.COMMITTED:
+			// It's committed, so it doesn't need a push but we can only
+			// GC it after its intents are resolved.
+			if err := r.resolveIntents(r.context(),
+				roachpb.AsIntents(txn.Intents, &txn), true /* wait */); err != nil {
+				log.Warningf("unable to resolve intents of committed txn on gc: %s", err)
+				// Returning the error here would abort the whole GC run, and
+				// we don't want that. Instead, we simply don't GC this entry.
+				return nil
+			}
+		default:
+			panic(fmt.Sprintf("invalid transaction state: %s", txn))
+		}
+		gcKeys = append(gcKeys, roachpb.GCRequest_GCKey{Key: kv.Key}) // zero timestamp
+		return nil
+	}
+
+	startKey := keys.TransactionKey(roachpb.KeyMin, nil)
+	endKey := keys.TransactionKey(roachpb.KeyMax, nil)
+
+	_, err := engine.MVCCIterate(snap, startKey, endKey, roachpb.ZeroTimestamp, true /* consistent */, nil /* txn */, false /* !reverse */, func(kv roachpb.KeyValue) (bool, error) {
+		return false, handleOne(kv)
+	})
+	return gcKeys, err
+}
+
+// processSequenceCache iterates through the local sequence cache entries,
+// pushing the transactions (in cleanup mode) for those entries which appear
+// to be old enough. In case the transaction indicates that it's terminated,
+// the sequence cache keys are included in the result.
+func processSequenceCache(r *Replica, now, cutoff roachpb.Timestamp, prevTxns map[string]*roachpb.Transaction) []roachpb.GCRequest_GCKey {
+	snap := r.store.Engine().NewSnapshot()
+	defer snap.Close()
+
+	txns := make(map[string]*roachpb.Transaction)
+	idToKeys := make(map[string][]roachpb.GCRequest_GCKey)
+	r.sequence.Iterate(snap, func(key, id []byte, v roachpb.SequenceCacheEntry) {
+		idStr := string(id)
+		// If we've pushed this Txn previously, attempt cleanup (in case the
+		// push was successful). Initiate new pushes only for newly discovered
+		// "old" entries.
+		if prevTxn, ok := prevTxns[idStr]; ok && prevTxn.Status != roachpb.PENDING {
+			txns[idStr] = prevTxn
+			idToKeys[idStr] = append(idToKeys[idStr], roachpb.GCRequest_GCKey{Key: key})
+		} else if !cutoff.Less(v.Timestamp) {
+			txns[idStr] = &roachpb.Transaction{ID: id, Key: v.Key, Status: roachpb.PENDING}
+			idToKeys[idStr] = append(idToKeys[idStr], roachpb.GCRequest_GCKey{Key: key})
+		}
+	})
+
+	var wg sync.WaitGroup
+	wg.Add(len(txns))
+	for _, txn := range txns {
+		// Check if the Txn is still alive. If this indicates that the Txn is
+		// aborted and old enough to guarantee that any running coordinator
+		// would have realized that the transaction wasn't running by means
+		// of a heartbeat, then we're free to remove the sequence cache entry.
+		// In the most likely case, there isn't even an entry (which will
+		// be apparent by a zero timestamp and nil last heartbeat).
+		go pushTxn(r, now, txn, roachpb.CLEANUP_TXN, &wg)
+	}
+	wg.Wait()
+
+	var gcKeys []roachpb.GCRequest_GCKey
+	for idStr, txn := range txns {
+		if txn.Status == roachpb.PENDING {
+			continue
+		}
+		ts := txn.Timestamp
+		if txn.LastHeartbeat != nil {
+			ts.Forward(*txn.LastHeartbeat)
+		}
+		if !cutoff.Less(ts) {
+			// This is it, we can delete our sequence cache entries.
+			gcKeys = append(gcKeys, idToKeys[idStr]...)
+		}
+	}
+	return gcKeys
+}
+
 // timer returns a constant duration to space out GC processing
 // for successive queued replicas.
 func (*gcQueue) timer() time.Duration {
 	return gcQueueTimerDuration
 }
 
-// pushTxn attempts to abort the txn via push. If the transaction
-// cannot be aborted, the oldestIntentNanos value is atomically
-// updated to the min of oldestIntentNanos and the intent's
-// timestamp. The wait group is signaled on completion.
-func (*gcQueue) pushTxn(repl *Replica, now roachpb.Timestamp, txn *roachpb.Transaction, updateOldestIntent func(int64), wg *sync.WaitGroup) {
+// pushTxn attempts to abort the txn via push. The wait group is signaled on
+// completion.
+func pushTxn(repl *Replica, now roachpb.Timestamp, txn *roachpb.Transaction,
+	typ roachpb.PushTxnType, wg *sync.WaitGroup) {
 	defer wg.Done() // signal wait group always on completion
 	if log.V(1) {
 		log.Infof("pushing txn %s ts=%s", txn, txn.OrigTimestamp)
@@ -312,14 +442,13 @@ func (*gcQueue) pushTxn(repl *Replica, now roachpb.Timestamp, txn *roachpb.Trans
 		Now:       now,
 		PusherTxn: roachpb.Transaction{Priority: roachpb.MaxPriority},
 		PusheeTxn: *txn,
-		PushType:  roachpb.ABORT_TXN,
+		PushType:  typ,
 	}
 	b := &client.Batch{}
 	b.InternalAddRequest(pushArgs)
 	br, err := repl.store.DB().RunWithResponse(b)
 	if err != nil {
 		log.Warningf("push of txn %s failed: %s", txn, err)
-		updateOldestIntent(txn.OrigTimestamp.WallTime)
 		return
 	}
 	// Update the supplied txn on successful push.

--- a/storage/replica.go
+++ b/storage/replica.go
@@ -1416,12 +1416,9 @@ func (r *Replica) handleSkippedIntents(intents []intentsWithArg) {
 					Span: roachpb.Span{Key: r.Desc().StartKey.AsRawKey()},
 				}
 				{
-					prefix := keys.SequenceCacheKeyPrefix(r.Desc().RangeID, txn.ID)
-					kvs, _, err := engine.MVCCScan(r.store.Engine(), prefix,
-						prefix.PrefixEnd(), 0 /* max */, roachpb.ZeroTimestamp,
-						false /* consistent */, nil /* txn */)
+					kvs, err := r.sequence.GetAllTransactionID(r.store.Engine(), txn.ID)
 					if err != nil {
-						log.Warning(err)
+						panic(err) // TODO(tschottdorf): ReplicaCorruptionError
 					}
 					// Allocate slots for the transaction key and the sequence
 					// cache keys.
@@ -1522,9 +1519,6 @@ func (r *Replica) maybeSetCorrupt(err error) error {
 // commands have been **proposed** (not executed). This ensures that if a
 // waiting client retries immediately after calling this function, it will not
 // hit the same intents again.
-// TODO(tschottdorf): once Txn records have a list of possibly open intents,
-// resolveIntents should send an RPC to update the transaction(s) as well (for
-// those intents with non-pending Txns).
 func (r *Replica) resolveIntents(ctx context.Context, intents []roachpb.Intent, wait bool) error {
 	trace := tracer.FromCtx(ctx)
 	tracer.ToCtx(ctx, nil) // we're doing async stuff below; those need new traces
@@ -1575,25 +1569,6 @@ func (r *Replica) resolveIntents(ctx context.Context, intents []roachpb.Intent, 
 			defer trace.Finalize()
 			ctx := tracer.ToCtx(ctx, trace)
 			_, err := r.addWriteCmd(ctx, baLocal, &wg)
-			if err != nil {
-				// At this point, as long as the local Replica accepts the
-				// request it should never fail. However, the replica may reject
-				// the request in certain cases (for example, if the replica has
-				// been removed from its range via a rebalancing a command).
-				// Therefore, we inspect the returned error to detect cases
-				// where the command was rejected, and can safely ignore those
-				// errors.
-				if err != multiraft.ErrGroupDeleted {
-					switch err.(type) {
-					case *roachpb.RangeKeyMismatchError:
-					case *roachpb.NotLeaderError:
-					case *roachpb.RangeNotFoundError:
-					default:
-						// TODO(tschottdorf): Does this need to be a panic?
-						panic(fmt.Sprintf("local intent resolution failed with unexpected error: %s", err))
-					}
-				}
-			}
 			return err
 		}
 		wg.Add(1)

--- a/storage/replica_command.go
+++ b/storage/replica_command.go
@@ -327,14 +327,6 @@ func (r *Replica) EndTransaction(batch engine.Engine, ms *engine.MVCCStats, h ro
 		reply.Txn.Status = roachpb.ABORTED
 	}
 
-	asSkippedIntents := func(txn *roachpb.Transaction, spans []roachpb.Span) []roachpb.Intent {
-		ret := make([]roachpb.Intent, len(spans))
-		for i := range spans {
-			ret[i].Span, ret[i].Txn = spans[i], *txn
-		}
-		return ret
-	}
-
 	if deadlineLapsed {
 		// FIXME(#3037):
 		// If the deadline has lapsed, return all the intents for
@@ -342,7 +334,7 @@ func (r *Replica) EndTransaction(batch engine.Engine, ms *engine.MVCCStats, h ro
 		// and (b) not able to write on error (see #1989), we can't write
 		// ABORTED into the master transaction record, which remains
 		// PENDING, and that's pretty bad.
-		return reply, asSkippedIntents(reply.Txn, args.IntentSpans), roachpb.NewTransactionAbortedError(reply.Txn)
+		return reply, roachpb.AsIntents(args.IntentSpans, reply.Txn), roachpb.NewTransactionAbortedError(reply.Txn)
 	}
 
 	// Verify that we can either commit it or abort it (according
@@ -356,7 +348,7 @@ func (r *Replica) EndTransaction(batch engine.Engine, ms *engine.MVCCStats, h ro
 		// that we know them, so we return them all for asynchronous
 		// resolution (we're currently not able to write on error, but
 		// see #1989).
-		return reply, asSkippedIntents(reply.Txn, args.IntentSpans), roachpb.NewTransactionAbortedError(reply.Txn)
+		return reply, roachpb.AsIntents(args.IntentSpans, reply.Txn), roachpb.NewTransactionAbortedError(reply.Txn)
 	} else if h.Txn.Epoch < reply.Txn.Epoch {
 		// TODO(tschottdorf): this leaves the Txn record (and more
 		// importantly, intents) dangling; we can't currently write on
@@ -921,9 +913,13 @@ func (r *Replica) PushTxn(batch engine.Engine, ms *engine.MVCCStats, h roachpb.H
 			reply.PusheeTxn.Priority = args.PusheeTxn.Priority
 		}
 	} else {
-		// The transaction doesn't exist yet on disk; we're allowed to abort it.
+		// The transaction doesn't exist on disk; we're allowed to abort it.
 		reply.PusheeTxn = *args.PusheeTxn.Clone()
 		reply.PusheeTxn.Status = roachpb.ABORTED
+		if args.PushType == roachpb.CLEANUP_TXN {
+			// If we're only here to clean up, no reason to persist anything.
+			return reply, nil
+		}
 		return reply, engine.MVCCPutProto(batch, ms, key, roachpb.ZeroTimestamp, nil, &reply.PusheeTxn)
 	}
 

--- a/storage/sequence_cache_test.go
+++ b/storage/sequence_cache_test.go
@@ -140,13 +140,13 @@ func TestSequenceCacheEmptyParams(t *testing.T) {
 	defer stopper.Stop()
 	sc, e := createTestSequenceCache(t, 1, stopper)
 	// Put value for test response.
-	if err := sc.Put(e, testTxnID, testTxnEpoch, 0, testTxnKey, testTxnTimestamp, nil); err != errEmptyID {
+	if err := sc.Put(e, testTxnID, testTxnEpoch, 0, testTxnKey, testTxnTimestamp, nil); err != errEmptyTxnID {
 		t.Errorf("unexpected error putting response: %v", err)
 	}
-	if err := sc.Put(e, nil, testTxnEpoch, 10, testTxnKey, testTxnTimestamp, nil); err != errEmptyID {
+	if err := sc.Put(e, nil, testTxnEpoch, 10, testTxnKey, testTxnTimestamp, nil); err != errEmptyTxnID {
 		t.Errorf("unexpected error putting response: %v", err)
 	}
-	if _, _, readErr := sc.Get(e, nil, nil); readErr != errEmptyID {
+	if _, _, readErr := sc.Get(e, nil, nil); readErr != errEmptyTxnID {
 		t.Fatalf("unxpected read error: %v", readErr)
 	}
 }

--- a/storage/store.go
+++ b/storage/store.go
@@ -1303,7 +1303,7 @@ func (s *Store) Send(ctx context.Context, ba roachpb.BatchRequest) (*roachpb.Bat
 				var resolveIntents []roachpb.Intent
 				resolveIntents, err = s.resolveWriteIntentError(ctx, wiErr, rng, args, ba.Header, pushType)
 				if len(resolveIntents) > 0 {
-					if resErr := rng.resolveIntents(ctx, resolveIntents, false /* !wait */); resErr != nil {
+					if resErr := rng.resolveIntents(ctx, resolveIntents, false /* !wait */, true /* poison */); resErr != nil {
 						// When resolving asynchronously, should never get an error
 						// back here.
 						panic(resErr)


### PR DESCRIPTION
see #2062. This is a bit of a late Friday throw-over-the-wall but should generally be ready for review.

on each run of the GC queue for a given range, the transaction
and sequence prefixes are scanned and the following actions taken:
- old pending transactions are pushed (which will succeed), effectively
  aborting them
- old aborted transactions are added to the GC request.
- aborted and committed transactions will have the intents referenced
  in their record resolved synchronously and are GCed (on success)
- sequence cache entries which are "old" and belong to "old" (or
  nonexistent) transactions are deleted.

The implementation here isn't as performant as it could be by a long shot,
but very few txn/sequence cache entries should actually persist long enough
to be observed by this queue. Normally, transaction records are eagerly
removed after commit along with their sequence cache entries (much like
intents are usually resolved).

fixes #2062.

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/3185)

<!-- Reviewable:end -->
