### PR TITLE
Add `.editorconfig` and update style notes.

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,10 @@
+# See http://editorconfig.org
+
+[*]
+end_of_line = lf
+insert_final_newline = true
+charset = utf-8
+
+# For non-go files, we indent with two spaces. In go files we indent
+# with tabs but still set indent_size to control the github web viewer.
+indent_size=2

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -38,7 +38,7 @@ To add or update a go dependency:
 - create a PR with all the changes
 
 ### Style guide
-We're following the [Google Go Code Review](https://code.google.com/p/go-wiki/wiki/CodeReviewComments) fairly closely. In particular, you want to watch out for proper punctuation and capitalization and make sure that your lines stay well below 80 characters.
+We're following the [Google Go Code Review](https://code.google.com/p/go-wiki/wiki/CodeReviewComments) fairly closely. In particular, you want to watch out for proper punctuation and capitalization in comments. We use two-space indents in non-Go code (in Go, we follow `gofmt` which indents with tabs). Format your code assuming it will be read in a window 100 columns wide. Wrap code and comments at 100 characters unless doing so makes the code less legible".
 
 ### Code review workflow
 


### PR DESCRIPTION
We've long since abandoned an 80-column limit. `gofmt` already
standardizes most of what can be set in `.editorconfig`, but it's useful
for non-go code and for the github web viewer.

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/3190)

<!-- Reviewable:end -->
