### PR TITLE
make rangeDescriptorDB and lookupOptions exportable

### DIFF
--- a/kv/local_sender.go
+++ b/kv/local_sender.go
@@ -39,7 +39,7 @@ type LocalSender struct {
 }
 
 var _ client.Sender = &LocalSender{}
-var _ rangeDescriptorDB = &LocalSender{}
+var _ RangeDescriptorDB = &LocalSender{}
 
 // NewLocalSender returns a local-only sender which directly accesses
 // a collection of stores.
@@ -189,9 +189,9 @@ func (ls *LocalSender) lookupReplica(start, end roachpb.RKey) (rangeID roachpb.R
 	return rangeID, replica, err
 }
 
-// firstRange implements the rangeDescriptorDB interface. It returns the
+// FirstRange implements the RangeDescriptorDB interface. It returns the
 // range descriptor which contains KeyMin.
-func (ls *LocalSender) firstRange() (*roachpb.RangeDescriptor, error) {
+func (ls *LocalSender) FirstRange() (*roachpb.RangeDescriptor, error) {
 	_, replica, err := ls.lookupReplica(roachpb.RKeyMin, nil)
 	if err != nil {
 		return nil, err
@@ -208,9 +208,9 @@ func (ls *LocalSender) firstRange() (*roachpb.RangeDescriptor, error) {
 	return rpl.Desc(), nil
 }
 
-// rangeLookup implements the rangeDescriptorDB interface. It looks up
+// RangeLookup implements the RangeDescriptorDB interface. It looks up
 // the descriptors for the given (meta) key.
-func (ls *LocalSender) rangeLookup(key roachpb.RKey, options lookupOptions, _ *roachpb.RangeDescriptor) ([]roachpb.RangeDescriptor, error) {
+func (ls *LocalSender) RangeLookup(key roachpb.RKey, options LookupOptions, _ *roachpb.RangeDescriptor) ([]roachpb.RangeDescriptor, error) {
 	ba := roachpb.BatchRequest{}
 	ba.ReadConsistency = roachpb.INCONSISTENT
 	ba.Add(&roachpb.RangeLookupRequest{
@@ -219,8 +219,8 @@ func (ls *LocalSender) rangeLookup(key roachpb.RKey, options lookupOptions, _ *r
 			Key: key.AsRawKey(),
 		},
 		MaxRanges:       1,
-		ConsiderIntents: options.considerIntents,
-		Reverse:         options.useReverseScan,
+		ConsiderIntents: options.ConsiderIntents,
+		Reverse:         options.UseReverseScan,
 	})
 	br, pErr := ls.Send(context.Background(), ba)
 	if pErr != nil {

--- a/kv/local_sender_test.go
+++ b/kv/local_sender_test.go
@@ -182,7 +182,7 @@ func TestLocalSenderLookupReplica(t *testing.T) {
 		t.Errorf("expected store %d; got %d: %v", s[1].Ident.StoreID, r.StoreID, err)
 	}
 
-	if desc, err := ls.firstRange(); err != nil || !reflect.DeepEqual(desc, d[0]) {
+	if desc, err := ls.FirstRange(); err != nil || !reflect.DeepEqual(desc, d[0]) {
 		t.Fatalf("first range not as expected: error=%v, desc=%+v", err, desc)
 	}
 }

--- a/kv/range_cache_test.go
+++ b/kv/range_cache_test.go
@@ -67,11 +67,11 @@ func (db *testDescriptorDB) getDescriptor(key roachpb.RKey) []roachpb.RangeDescr
 	return response
 }
 
-func (db *testDescriptorDB) firstRange() (*roachpb.RangeDescriptor, error) {
+func (db *testDescriptorDB) FirstRange() (*roachpb.RangeDescriptor, error) {
 	return nil, nil
 }
 
-func (db *testDescriptorDB) rangeLookup(key roachpb.RKey, _ lookupOptions, _ *roachpb.RangeDescriptor) ([]roachpb.RangeDescriptor, error) {
+func (db *testDescriptorDB) RangeLookup(key roachpb.RKey, _ LookupOptions, _ *roachpb.RangeDescriptor) ([]roachpb.RangeDescriptor, error) {
 	db.lookupCount++
 	if bytes.HasPrefix(key, keys.Meta2Prefix) {
 		return db.getDescriptor(key[len(keys.Meta2Prefix):]), nil
@@ -127,7 +127,7 @@ func (db *testDescriptorDB) assertLookupCount(t *testing.T, expected int, key st
 }
 
 func doLookup(t *testing.T, rc *rangeDescriptorCache, key string) *roachpb.RangeDescriptor {
-	r, err := rc.LookupRangeDescriptor(roachpb.RKey(key), lookupOptions{})
+	r, err := rc.LookupRangeDescriptor(roachpb.RKey(key), LookupOptions{})
 	if err != nil {
 		t.Fatalf("Unexpected error from LookupRangeDescriptor: %s", err.Error())
 	}


### PR DESCRIPTION
@bdarnell I believe this is what we need to do before we can move kv/local_sender into storage. It kind of stinks. Another option is to not do this and instead just move Stores into storage and have local_sender depend on it.

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/3191)

<!-- Reviewable:end -->
