### PR TITLE
bug fix: the heartbeat goroutine maybe leak when the client is closed.

### DIFF
--- a/rpc/client.go
+++ b/rpc/client.go
@@ -221,6 +221,16 @@ func (c *Client) runHeartbeat(retryOpts retry.Options, closer <-chan struct{}) {
 	var err = errUnstarted // initial condition
 	for {
 		for r := retry.Start(retryOpts); r.Next(); {
+			// Check whether the client is closed.
+			select {
+			case <-closer:
+				c.Close()
+				return
+			case <-c.Closed:
+				return
+			default:
+			}
+
 			// Reconnect on failure.
 			if err != nil {
 				if err = c.connect(); err != nil {


### PR DESCRIPTION
If when doing the heartbeat or reconnect the client was closed, may lead to goroutine leak.

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/3194)

<!-- Reviewable:end -->
