### PR TITLE
Fix 2038 bug in Timestamp.Next().

### DIFF
--- a/roachpb/data.go
+++ b/roachpb/data.go
@@ -225,7 +225,7 @@ func (t Timestamp) Add(wallTime int64, logical int32) Timestamp {
 // Next returns the timestamp with the next later timestamp.
 func (t *Timestamp) Next() Timestamp {
 	if t.Logical == math.MaxInt32 {
-		if t.WallTime == math.MaxInt32 {
+		if t.WallTime == math.MaxInt64 {
 			panic("cannot take the next value to a max timestamp")
 		}
 		return Timestamp{

--- a/roachpb/data_test.go
+++ b/roachpb/data_test.go
@@ -214,6 +214,7 @@ func TestTimestampNext(t *testing.T) {
 		{makeTS(1, 2), makeTS(1, 3)},
 		{makeTS(1, math.MaxInt32-1), makeTS(1, math.MaxInt32)},
 		{makeTS(1, math.MaxInt32), makeTS(2, 0)},
+		{makeTS(math.MaxInt32, math.MaxInt32), makeTS(math.MaxInt32+1, 0)},
 	}
 	for i, c := range testCases {
 		if next := c.ts.Next(); !next.Equal(c.expNext) {


### PR DESCRIPTION
Timestamp.WallTime is an int64, not an int32.

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/3197)

<!-- Reviewable:end -->
