### PR TITLE
Rework mvccGetInternal to always use an iterator.

### DIFF
--- a/storage/engine/mvcc.go
+++ b/storage/engine/mvcc.go
@@ -482,38 +482,23 @@ func MVCCGet(engine Engine, key roachpb.Key, timestamp roachpb.Timestamp, consis
 		return nil, nil, emptyKeyError()
 	}
 
-	// Create a function which scans for the first key between start and end keys.
-	getValue := func(engine Engine, start, end MVCCKey,
-		msg proto.Message) (MVCCKey, error) {
-		iter := engine.NewIterator()
-		defer iter.Close()
-		iter.Seek(start)
-		if !iter.Valid() {
-			return nil, iter.Error()
-		}
-		key := iter.Key()
-		if bytes.Compare(key, end) >= 0 {
-			return nil, iter.Error()
-		}
-		return key, iter.ValueProto(msg)
-	}
-
 	buf := getBufferPool.Get().(*getBuffer)
 	defer getBufferPool.Put(buf)
 
+	iter := engine.NewIterator()
+	defer iter.Close()
+
 	metaKey := mvccEncodeKey(buf.key[:0], key)
-	ok, _, _, err := engine.GetProto(metaKey, &buf.meta)
-	if err != nil || !ok {
+	iter.Seek(metaKey)
+	if !iter.Valid() || bytes.Compare(iter.unsafeKey(), metaKey) != 0 {
+		return nil, nil, nil
+	}
+	if err := iter.ValueProto(&buf.meta); err != nil {
 		return nil, nil, err
 	}
 
-	return mvccGetInternal(engine, key, metaKey, timestamp, consistent, txn, getValue, buf)
+	return mvccGetInternal(iter, key, metaKey, timestamp, consistent, txn, buf)
 }
-
-// getValueFunc fetches a version of a key between start and end.
-// Returns the key as an encoded byte slice, and error, if applicable.
-type getValueFunc func(engine Engine, start, end MVCCKey,
-	msg proto.Message) (MVCCKey, error)
 
 // mvccGetInternal parses the MVCCMetadata from the specified raw key
 // value, and reads the versioned value indicated by timestamp, taking
@@ -525,9 +510,9 @@ type getValueFunc func(engine Engine, start, end MVCCKey,
 // most recent non-intent value instead. In the event that an inconsistent read
 // does encounter an intent (currently there can only be one), it is returned
 // via the roachpb.Intent slice, in addition to the result.
-func mvccGetInternal(engine Engine, key roachpb.Key, metaKey MVCCKey,
+func mvccGetInternal(iter Iterator, key roachpb.Key, metaKey MVCCKey,
 	timestamp roachpb.Timestamp, consistent bool, txn *roachpb.Transaction,
-	getValue getValueFunc, buf *getBuffer) (*roachpb.Value, []roachpb.Intent, error) {
+	buf *getBuffer) (*roachpb.Value, []roachpb.Intent, error) {
 	if !consistent && txn != nil {
 		return nil, nil, util.Errorf("cannot allow inconsistent reads within a transaction")
 	}
@@ -551,9 +536,6 @@ func mvccGetInternal(engine Engine, key roachpb.Key, metaKey MVCCKey,
 		timestamp = meta.Timestamp.Prev()
 	}
 
-	var valueKey MVCCKey
-	value := &buf.value
-
 	ownIntent := meta.IsIntentOf(txn) // false if txn == nil
 	if !timestamp.Less(meta.Timestamp) && meta.Txn != nil && !ownIntent {
 		// Trying to read the last value, but it's another transaction's intent;
@@ -561,34 +543,29 @@ func mvccGetInternal(engine Engine, key roachpb.Key, metaKey MVCCKey,
 		return nil, nil, &roachpb.WriteIntentError{
 			Intents: []roachpb.Intent{{Span: roachpb.Span{Key: key}, Txn: *meta.Txn}},
 		}
-	} else if !timestamp.Less(meta.Timestamp) || ownIntent {
+	}
+
+	var seekKey MVCCKey
+	var checkValueTimestamp bool
+
+	if !timestamp.Less(meta.Timestamp) || ownIntent {
 		// We are reading the latest value, which is either an intent written
 		// by this transaction or not an intent at all (so there's no
 		// conflict). Note that when reading the own intent, the timestamp
 		// specified is irrelevant; we always want to see the intent (see
 		// TestMVCCReadWithPushedTimestamp).
-		latestKey := mvccEncodeTimestamp(metaKey, meta.Timestamp)
+		seekKey = mvccEncodeTimestamp(metaKey, meta.Timestamp)
 
 		// Check for case where we're reading our own txn's intent
 		// but it's got a different epoch. This can happen if the
 		// txn was restarted and an earlier iteration wrote the value
 		// we're now reading. In this case, we skip the intent.
-		var err error
 		if ownIntent && txn.Epoch != meta.Txn.Epoch {
 			if txn.Epoch < meta.Txn.Epoch {
 				return nil, nil, util.Errorf("failed to read with epoch %d due to a write intent with epoch %d",
 					txn.Epoch, meta.Txn.Epoch)
 			}
-			valueKey, err = getValue(engine, latestKey.Next(), MVCCEncodeKey(key.Next()), value)
-		} else {
-			var ok bool
-			ok, _, _, err = engine.GetProto(latestKey, value)
-			if ok {
-				valueKey = latestKey
-			}
-		}
-		if err != nil {
-			return nil, nil, err
+			seekKey = seekKey.Next()
 		}
 	} else if txn != nil && timestamp.Less(txn.MaxTimestamp) {
 		// In this branch, the latest timestamp is ahead, and so the read of an
@@ -609,61 +586,60 @@ func mvccGetInternal(engine Engine, key roachpb.Key, metaKey MVCCKey,
 
 		// We want to know if anything has been written ahead of timestamp, but
 		// before MaxTimestamp.
-		nextKey := MVCCEncodeVersionKey(key, txn.MaxTimestamp)
-		var err error
-		valueKey, err = getValue(engine, nextKey, MVCCEncodeKey(key.Next()), value)
-		if err != nil {
-			return nil, nil, err
-		}
-		if valueKey != nil {
-			_, ts, _, err := MVCCDecodeKey(valueKey)
-			if err != nil {
-				return nil, nil, err
-			}
-			if timestamp.Less(ts) {
-				// Third case: Our read timestamp is sufficiently behind the newest
-				// value, but there is another previous write with the same issues
-				// as in the second case, so the reader will have to come again
-				// with a higher read timestamp.
-				return nil, nil, &roachpb.ReadWithinUncertaintyIntervalError{
-					Timestamp:         timestamp,
-					ExistingTimestamp: ts,
-				}
-			}
-		}
-		// Fourth case: There's no value in our future up to MaxTimestamp, and
-		// those are the only ones that we're not certain about. The correct
-		// key has already been read above, so there's nothing left to do.
+		seekKey = MVCCEncodeVersionKey(key, txn.MaxTimestamp)
+		checkValueTimestamp = true
 	} else {
-		// Fifth case: We're reading a historic value either outside of
-		// a transaction, or in the absence of future versions that clock
-		// uncertainty would apply to.
-		var err error
-		nextKey := MVCCEncodeVersionKey(key, timestamp)
-		valueKey, err = getValue(engine, nextKey, MVCCEncodeKey(key.Next()), value)
-		if err != nil {
-			return nil, nil, err
-		}
+		// Third case: We're reading a historic value either outside of a
+		// transaction, or in the absence of future versions that clock uncertainty
+		// would apply to.
+		seekKey = MVCCEncodeVersionKey(key, timestamp)
 	}
 
-	if valueKey == nil {
+	iter.Seek(seekKey)
+	if !iter.Valid() {
+		if err := iter.Error(); err != nil {
+			return nil, nil, err
+		}
 		return nil, ignoredIntents, nil
 	}
 
-	_, ts, isValue, err := MVCCDecodeKey(valueKey)
+	valueKey, ts, isValue, err := mvccDecodeKey(iter.unsafeKey(), nil)
 	if err != nil {
 		return nil, nil, err
 	}
+	if !bytes.Equal(key, valueKey) {
+		return nil, ignoredIntents, nil
+	}
 	if !isValue {
-		return nil, nil, util.Errorf("expected scan to versioned value reading key %q; got %q", key, valueKey)
+		return nil, nil, util.Errorf("expected scan to versioned value reading key %s; got %s",
+			key, roachpb.Key(iter.unsafeKey()))
+	}
+
+	if checkValueTimestamp {
+		if timestamp.Less(ts) {
+			// Fourth case: Our read timestamp is sufficiently behind the newest
+			// value, but there is another previous write with the same issues as in
+			// the second case, so the reader will have to come again with a higher
+			// read timestamp.
+			return nil, nil, &roachpb.ReadWithinUncertaintyIntervalError{
+				Timestamp:         timestamp,
+				ExistingTimestamp: ts,
+			}
+		}
+		// Fifth case: There's no value in our future up to MaxTimestamp, and those
+		// are the only ones that we're not certain about. The correct key has
+		// already been read above, so there's nothing left to do.
+	}
+
+	value := &buf.value
+	if err := iter.ValueProto(value); err != nil {
+		return nil, nil, err
 	}
 
 	if value.Deleted {
 		value.Value = nil
-	}
-
-	// Set the timestamp if the value is not nil (i.e. not a deletion tombstone).
-	if value.Value != nil {
+	} else if value.Value != nil {
+		// Set the timestamp if the value is not nil (i.e. not a deletion tombstone).
 		value.Value.Timestamp = &ts
 		if err := value.Value.Verify(key); err != nil {
 			return nil, nil, err
@@ -1024,7 +1000,7 @@ func getReverseScanMetaKey(iter Iterator, encEndKey MVCCKey) (roachpb.Key, MVCCK
 // in descending instead of ascending order.
 func mvccScanInternal(engine Engine, key, endKey roachpb.Key, max int64, timestamp roachpb.Timestamp,
 	consistent bool, txn *roachpb.Transaction, reverse bool) ([]roachpb.KeyValue, []roachpb.Intent, error) {
-	res := []roachpb.KeyValue{}
+	var res []roachpb.KeyValue
 	intents, err := MVCCIterate(engine, key, endKey, timestamp, consistent, txn, reverse,
 		func(kv roachpb.KeyValue) (bool, error) {
 			res = append(res, kv)
@@ -1094,21 +1070,9 @@ func MVCCIterate(engine Engine, startKey, endKey roachpb.Key, timestamp roachpb.
 		getMetaKey = getScanMetaKey
 	}
 
-	// Get a new iterator and define our getter using iter.Seek.
+	// Get a new iterator.
 	iter := engine.NewIterator()
 	defer iter.Close()
-	getValue := func(engine Engine, start, end MVCCKey,
-		msg proto.Message) (MVCCKey, error) {
-		iter.Seek(start)
-		if !iter.Valid() {
-			return nil, iter.Error()
-		}
-		key := iter.Key()
-		if bytes.Compare(key, end) >= 0 {
-			return nil, iter.Error()
-		}
-		return key, iter.ValueProto(msg)
-	}
 
 	// Seeking for the first defined position.
 	if reverse {
@@ -1151,7 +1115,7 @@ func MVCCIterate(engine Engine, startKey, endKey roachpb.Key, timestamp roachpb.
 		if err := iter.ValueProto(&buf.meta); err != nil {
 			return nil, err
 		}
-		value, newIntents, err := mvccGetInternal(engine, key, metaKey, timestamp, consistent, txn, getValue, buf)
+		value, newIntents, err := mvccGetInternal(iter, key, metaKey, timestamp, consistent, txn, buf)
 		intents = append(intents, newIntents...)
 		if value != nil {
 			done, err := f(roachpb.KeyValue{Key: key, Value: *value})

--- a/storage/engine/rocksdb/db.cc
+++ b/storage/engine/rocksdb/db.cc
@@ -1080,12 +1080,15 @@ DBStatus DBOpen(DBEngine **db, DBSlice dir, DBOptions db_opts) {
   // Divide the cache space into two levels: the fast row cache
   // and the slower but more space-efficient block cache.
   // TODO(bdarnell): do we need both? how much of each?
-  const auto row_cache_size = db_opts.cache_size / 2;
+  // TODO(peter): disabled for now until benchmarks show improvement.
+  const auto row_cache_size = 0 * db_opts.cache_size;
   const auto block_cache_size = db_opts.cache_size - row_cache_size;
   const int num_cache_shard_bits = 4;
   rocksdb::BlockBasedTableOptions table_options;
-  table_options.block_cache = rocksdb::NewLRUCache(
-      block_cache_size, num_cache_shard_bits);
+  if (block_cache_size > 0) {
+    table_options.block_cache = rocksdb::NewLRUCache(
+        block_cache_size, num_cache_shard_bits);
+  }
 
   rocksdb::Options options;
   options.allow_os_buffer = db_opts.allow_os_buffer;
@@ -1098,8 +1101,10 @@ DBStatus DBOpen(DBEngine **db, DBSlice dir, DBOptions db_opts) {
   options.write_buffer_size = 64 << 20;           // 64 MB
   options.target_file_size_base = 64 << 20;       // 64 MB
   options.max_bytes_for_level_base = 512 << 20;   // 512 MB
-  options.row_cache = rocksdb::NewLRUCache(
-      row_cache_size, num_cache_shard_bits);
+  if (row_cache_size > 0) {
+    options.row_cache = rocksdb::NewLRUCache(
+        row_cache_size, num_cache_shard_bits);
+  }
 
   std::unique_ptr<rocksdb::Env> memenv;
   if (dir.len == 0) {


### PR DESCRIPTION
The big perf win was replacing the call to engine.Get with usage of the
iterator. I recall that iterators have some sort of small cache of the
block they are currently pointing at making retrieval of nearby keys
much faster than going through rocksdb::DB::Get. Replaced the getValue
function with passing an iterator to mvccGetInternal. This allowed a bit
of reorg to the code which makes it clearer (IMO).

Note that this change eliminates the benefit of the row cache (thus the
slow down in the MVCCGet1Version benchmarks). The speedup in scans seems
worth this cost.

```
name                                old time/op    new time/op     delta
MVCCScan1Version1Row-8                8.53µs ± 8%     6.10µs ± 7%   -28.44%   (p=0.000 n=10+9)
MVCCScan1Version10Rows-8              30.3µs ±20%     19.7µs ± 4%   -35.12%   (p=0.000 n=10+9)
MVCCScan1Version100Rows-8              259µs ± 3%      191µs ± 6%   -26.17%  (p=0.000 n=10+10)
MVCCScan1Version1000Rows-8            2.60ms ±11%     1.84ms ± 4%   -29.43%   (p=0.000 n=10+9)
MVCCScan10Versions1Row-8              16.2µs ± 3%     11.8µs ± 6%   -26.81%   (p=0.000 n=10+9)
MVCCScan10Versions10Rows-8            69.2µs ±15%     33.5µs ± 7%   -51.52%  (p=0.000 n=10+10)
MVCCScan10Versions100Rows-8            602µs ± 6%      298µs ± 9%   -50.49%  (p=0.000 n=10+10)
MVCCScan10Versions1000Rows-8          6.00ms ± 6%     2.87ms ±12%   -52.14%  (p=0.000 n=10+10)
MVCCScan100Versions1Row-8             37.6µs ± 3%     28.9µs ± 5%   -23.01%  (p=0.000 n=10+10)
MVCCScan100Versions10Rows-8            133µs ± 5%      116µs ±11%   -12.92%  (p=0.000 n=10+10)
MVCCScan100Versions100Rows-8          1.17ms ±13%     0.99ms ± 2%   -15.60%   (p=0.000 n=10+8)
MVCCScan100Versions1000Rows-8         11.1ms ±12%      9.4ms ± 8%   -15.13%  (p=0.000 n=10+10)
MVCCGet1Version-8                     3.86µs ± 4%     6.41µs ± 8%   +66.32%   (p=0.000 n=9+10)
MVCCGet10Versions-8                   16.9µs ± 2%     11.7µs ± 1%   -31.03%   (p=0.000 n=10+8)
MVCCGet100Versions-8                  31.2µs ± 5%     28.5µs ±11%    -8.66%  (p=0.000 n=10+10)
MVCCPut10-8                           4.43µs ± 1%     4.48µs ± 2%    +1.27%   (p=0.001 n=9+10)
MVCCPut100-8                          4.60µs ± 1%     4.65µs ± 1%    +1.13%  (p=0.000 n=10+10)
MVCCPut1000-8                         7.64µs ± 0%     7.65µs ± 0%      ~      (p=0.051 n=10+9)
MVCCPut10000-8                        23.2µs ± 1%     23.3µs ± 1%      ~      (p=0.720 n=9+10)
MVCCBatch1Put10-8                     5.14µs ± 1%     5.04µs ± 1%    -2.00%    (p=0.000 n=9+9)
MVCCBatch100Put10-8                   4.67µs ± 1%     4.65µs ± 1%      ~     (p=0.240 n=10+10)
MVCCBatch10000Put10-8                 5.96µs ± 1%     5.93µs ± 0%    -0.59%   (p=0.000 n=9+10)
MVCCBatch100000Put10-8                6.82µs ± 1%     6.82µs ± 1%      ~     (p=0.565 n=10+10)
MVCCDeleteRange1Version8Bytes-8        127ms ± 1%      117ms ± 1%    -7.64%  (p=0.000 n=10+10)
MVCCDeleteRange1Version32Bytes-8      89.6ms ± 1%     84.7ms ± 6%    -5.48%  (p=0.000 n=10+10)
MVCCDeleteRange1Version256Bytes-8     26.2ms ± 2%     24.1ms ± 1%    -8.15%  (p=0.000 n=10+10)
MVCCComputeStats1Version8Bytes-8       351ms ± 1%      358ms ± 3%    +1.89%  (p=0.000 n=10+10)
MVCCComputeStats1Version32Bytes-8      248ms ± 2%      252ms ± 3%    +1.63%  (p=0.007 n=10+10)
MVCCComputeStats1Version256Bytes-8    79.0ms ± 6%     90.3ms ± 1%   +14.27%   (p=0.000 n=10+8)
```

```
name                                old speed      new speed       delta
MVCCScan1Version1Row-8               120MB/s ± 8%    168MB/s ± 7%   +39.49%   (p=0.000 n=10+9)
MVCCScan1Version10Rows-8             341MB/s ±17%    521MB/s ± 5%   +52.82%   (p=0.000 n=10+9)
MVCCScan1Version100Rows-8            395MB/s ± 3%    536MB/s ± 6%   +35.56%  (p=0.000 n=10+10)
MVCCScan1Version1000Rows-8           395MB/s ±10%    557MB/s ± 4%   +41.28%   (p=0.000 n=10+9)
MVCCScan10Versions1Row-8            63.3MB/s ± 3%   86.5MB/s ± 5%   +36.66%   (p=0.000 n=10+9)
MVCCScan10Versions10Rows-8           149MB/s ±13%    306MB/s ± 7%  +105.37%  (p=0.000 n=10+10)
MVCCScan10Versions100Rows-8          170MB/s ± 6%    344MB/s ± 9%  +102.18%  (p=0.000 n=10+10)
MVCCScan10Versions1000Rows-8         171MB/s ± 6%    358MB/s ±11%  +109.19%  (p=0.000 n=10+10)
MVCCScan100Versions1Row-8           27.2MB/s ± 3%   35.4MB/s ± 5%   +30.05%  (p=0.000 n=10+10)
MVCCScan100Versions10Rows-8         77.0MB/s ± 5%   88.8MB/s ±11%   +15.28%  (p=0.000 n=10+10)
MVCCScan100Versions100Rows-8        87.8MB/s ±15%  103.6MB/s ± 2%   +17.98%   (p=0.000 n=10+8)
MVCCScan100Versions1000Rows-8       92.7MB/s ±11%  109.1MB/s ± 8%   +17.63%  (p=0.000 n=10+10)
MVCCGet1Version-8                    266MB/s ± 4%    160MB/s ± 8%   -39.77%   (p=0.000 n=9+10)
MVCCGet10Versions-8                 60.6MB/s ± 2%   87.8MB/s ± 1%   +44.98%   (p=0.000 n=10+8)
MVCCGet100Versions-8                32.8MB/s ± 5%   36.0MB/s ±10%    +9.70%  (p=0.000 n=10+10)
MVCCPut10-8                         2.26MB/s ± 1%   2.23MB/s ± 1%    -1.32%   (p=0.000 n=9+10)
MVCCPut100-8                        21.8MB/s ± 1%   21.5MB/s ± 1%    -1.11%  (p=0.000 n=10+10)
MVCCPut1000-8                        131MB/s ± 0%    131MB/s ± 0%      ~      (p=0.053 n=10+9)
MVCCPut10000-8                       430MB/s ± 1%    430MB/s ± 1%      ~      (p=0.720 n=9+10)
MVCCBatch1Put10-8                   1.95MB/s ± 1%   1.99MB/s ± 1%    +1.94%    (p=0.000 n=9+9)
MVCCBatch100Put10-8                 2.14MB/s ± 1%   2.15MB/s ± 1%      ~     (p=0.255 n=10+10)
MVCCBatch10000Put10-8               1.68MB/s ± 1%   1.69MB/s ± 0%    +0.66%  (p=0.004 n=10+10)
MVCCBatch100000Put10-8              1.47MB/s ± 1%   1.47MB/s ± 0%      ~     (p=1.000 n=10+10)
MVCCDeleteRange1Version8Bytes-8     4.13MB/s ± 1%   4.47MB/s ± 1%    +8.31%  (p=0.000 n=10+10)
MVCCDeleteRange1Version32Bytes-8    5.85MB/s ± 1%   6.19MB/s ± 5%    +5.86%  (p=0.000 n=10+10)
MVCCDeleteRange1Version256Bytes-8   20.0MB/s ± 2%   21.8MB/s ± 1%    +8.85%  (p=0.000 n=10+10)
MVCCComputeStats1Version8Bytes-8     191MB/s ± 1%    188MB/s ± 3%    -1.84%  (p=0.000 n=10+10)
MVCCComputeStats1Version32Bytes-8    270MB/s ± 2%    266MB/s ± 3%    -1.59%  (p=0.007 n=10+10)
MVCCComputeStats1Version256Bytes-8   850MB/s ± 5%    743MB/s ± 1%   -12.53%   (p=0.000 n=10+8)
```

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/3211)

<!-- Reviewable:end -->
