### PR TITLE
Increase timeout in TestStoreRangeUpReplicate

### DIFF
--- a/storage/client_raft_test.go
+++ b/storage/client_raft_test.go
@@ -565,7 +565,7 @@ func TestStoreRangeUpReplicate(t *testing.T) {
 			}
 		}
 		return true
-	}, 1*time.Second); err != nil {
+	}, 3*time.Second); err != nil {
 		t.Fatal(err)
 	}
 }


### PR DESCRIPTION
This matches the timeout in `multiTestContext.replicateRange`.

Fixes #3212

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/3213)

<!-- Reviewable:end -->
