### PR TITLE
Convert config change panic to a log and re-enable TestRaftRemoveRace.

### DIFF
--- a/multiraft/multiraft.go
+++ b/multiraft/multiraft.go
@@ -1158,8 +1158,8 @@ func (s *state) processCommittedEntry(groupID roachpb.RangeID, g *group, entry r
 					if !ok {
 						log.Infof("group %d no longer exists, aborting configuration change", groupID)
 					} else if gInner != g {
-						panic(fmt.Sprintf("passed in group and fetched group objects do not match\noriginal:%+v\nfetched:%+v\n",
-							g, gInner))
+						log.Infof("passed in group and fetched group objects do not match\noriginal:%+v\nfetched:%+v\n, aborting configuration change",
+							g, gInner)
 					} else if err == nil {
 						if log.V(3) {
 							log.Infof("node %v applying configuration change %v", s.nodeID, cc)

--- a/storage/client_raft_test.go
+++ b/storage/client_raft_test.go
@@ -1131,7 +1131,6 @@ func TestRaftAfterRemoveRange(t *testing.T) {
 // number of repetitions adds an unacceptable amount of test runtime).
 func TestRaftRemoveRace(t *testing.T) {
 	defer leaktest.AfterTest(t)
-	t.Skip("#3187, #3178 and others; very flaky since PR #3175")
 	mtc := startMultiTestContext(t, 3)
 	defer mtc.Stop()
 


### PR DESCRIPTION
There will still be failures, but the new one introduced in #3176 should be absent.
Fixes #3187

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/3215)

<!-- Reviewable:end -->
