### PR TITLE
Get rid of MVCCValue.

### DIFF
--- a/storage/engine/doc.go
+++ b/storage/engine/doc.go
@@ -46,20 +46,20 @@ of the most recent version's key and value for efficient stat counter
 computations.
 
 Each MVCC version key/value pair has a key which is also
-binary-encoded, but is suffixed with a decreasing, big-endian encoding
-of the timestamp (8 bytes for the nanosecond wall time, followed by 4
-bytes for the logical time). The MVCC version value is a message of
-type MVCCValue which indicates whether the version is a deletion
-timestamp and if not, contains a roachpb.Value object which holds the
-actual value. The decreasing encoding on the timestamp sorts the most
-recent version directly after the metadata key. This increases the
-likelihood that an Engine.Get() of the MVCC metadata will get the same
-block containing the most recent version, even if there are many
-versions. We rely on getting the MVCC metadata key/value and then
-using it to directly get the MVCC version using the metadata's most
-recent version timestamp. This avoids using an expensive merge
-iterator to scan the most recent version. It also allows us to
-leverage RocksDB's bloom filters.
+binary-encoded, but is suffixed with a decreasing, big-endian
+encoding of the timestamp (8 bytes for the nanosecond wall time,
+followed by 4 bytes for the logical time). The MVCC version value is
+a message of type roachpb.Value. A deletion is is indicated by an
+empty value. Note that an empty roachpb.Value will encode to a
+non-empty byte slice. The decreasing encoding on the timestamp sorts
+the most recent version directly after the metadata key. This
+increases the likelihood that an Engine.Get() of the MVCC metadata
+will get the same block containing the most recent version, even if
+there are many versions. We rely on getting the MVCC metadata
+key/value and then using it to directly get the MVCC version using
+the metadata's most recent version timestamp. This avoids using an
+expensive merge iterator to scan the most recent version. It also
+allows us to leverage RocksDB's bloom filters.
 
 The binary encoding used on the MVCC keys allows arbitrary keys to be
 stored in the map (no restrictions on intermediate nil-bytes, for

--- a/storage/engine/gc_test.go
+++ b/storage/engine/gc_test.go
@@ -40,8 +40,11 @@ var (
 	}
 )
 
-func serializedMVCCValue(deleted bool, t *testing.T) []byte {
-	data, err := proto.Marshal(&MVCCValue{Deleted: deleted})
+func serializedValue(deleted bool, t *testing.T) []byte {
+	if deleted {
+		return nil
+	}
+	data, err := proto.Marshal(&roachpb.Value{})
 	if err != nil {
 		t.Fatalf("unexpected marshal error: %v", err)
 	}
@@ -54,8 +57,8 @@ func TestGarbageCollectorFilter(t *testing.T) {
 	defer leaktest.AfterTest(t)
 	gcA := NewGarbageCollector(makeTS(0, 0), config.GCPolicy{TTLSeconds: 1})
 	gcB := NewGarbageCollector(makeTS(0, 0), config.GCPolicy{TTLSeconds: 2})
-	n := serializedMVCCValue(false, t)
-	d := serializedMVCCValue(true, t)
+	n := serializedValue(false, t)
+	d := serializedValue(true, t)
 	testData := []struct {
 		gc       *GarbageCollector
 		time     roachpb.Timestamp

--- a/storage/engine/mvcc.proto
+++ b/storage/engine/mvcc.proto
@@ -28,16 +28,6 @@ option (gogoproto.marshaler_all) = true;
 option (gogoproto.sizer_all) = true;
 option (gogoproto.unmarshaler_all) = true;
 
-// MVCCValue differentiates between normal versioned values and
-// deletion tombstones.
-message MVCCValue {
-  // True to indicate a deletion tombstone. If false, value should not
-  // be nil.
-  optional bool deleted = 1 [(gogoproto.nullable) = false];
-  // The value. Nil if deleted is true; not nil otherwise.
-  optional roachpb.Value value = 2;
-}
-
 // MVCCMetadata holds MVCC metadata for a key. Used by storage/engine/mvcc.go.
 message MVCCMetadata {
   optional roachpb.Transaction txn = 1;

--- a/storage/engine/mvcc_test.go
+++ b/storage/engine/mvcc_test.go
@@ -2215,7 +2215,7 @@ func TestMVCCStatsBasic(t *testing.T) {
 	mKeySize := int64(len(MVCCEncodeKey(key)))
 	mValSize := encodedSize(&MVCCMetadata{Timestamp: ts}, t)
 	vKeySize := mvccVersionTimestampSize
-	vValSize := encodedSize(&MVCCValue{Value: &value}, t)
+	vValSize := encodedSize(&value, t)
 
 	expMS := MVCCStats{
 		LiveBytes: mKeySize + mValSize + vKeySize + vValSize,
@@ -2235,7 +2235,7 @@ func TestMVCCStatsBasic(t *testing.T) {
 	}
 	m2ValSize := encodedSize(&MVCCMetadata{Timestamp: ts2, Deleted: true, Txn: txn}, t)
 	v2KeySize := mvccVersionTimestampSize
-	v2ValSize := encodedSize(&MVCCValue{Deleted: true}, t)
+	v2ValSize := int64(0)
 	expMS2 := MVCCStats{
 		KeyBytes:    mKeySize + vKeySize + v2KeySize,
 		KeyCount:    1,
@@ -2277,7 +2277,7 @@ func TestMVCCStatsBasic(t *testing.T) {
 	mKey2Size := int64(len(MVCCEncodeKey(key2)))
 	mVal2Size := encodedSize(&MVCCMetadata{Timestamp: ts4, Txn: txn}, t)
 	vKey2Size := mvccVersionTimestampSize
-	vVal2Size := encodedSize(&MVCCValue{Value: &value2}, t)
+	vVal2Size := encodedSize(&value2, t)
 	expMS3 := MVCCStats{
 		KeyBytes:    mKeySize + vKeySize + v2KeySize + mKey2Size + vKey2Size,
 		KeyCount:    2,

--- a/storage/engine/rocksdb/cockroach/storage/engine/mvcc.pb.cc
+++ b/storage/engine/rocksdb/cockroach/storage/engine/mvcc.pb.cc
@@ -22,9 +22,6 @@ namespace engine {
 
 namespace {
 
-const ::google::protobuf::Descriptor* MVCCValue_descriptor_ = NULL;
-const ::google::protobuf::internal::GeneratedMessageReflection*
-  MVCCValue_reflection_ = NULL;
 const ::google::protobuf::Descriptor* MVCCMetadata_descriptor_ = NULL;
 const ::google::protobuf::internal::GeneratedMessageReflection*
   MVCCMetadata_reflection_ = NULL;
@@ -41,23 +38,7 @@ void protobuf_AssignDesc_cockroach_2fstorage_2fengine_2fmvcc_2eproto() {
     ::google::protobuf::DescriptorPool::generated_pool()->FindFileByName(
       "cockroach/storage/engine/mvcc.proto");
   GOOGLE_CHECK(file != NULL);
-  MVCCValue_descriptor_ = file->message_type(0);
-  static const int MVCCValue_offsets_[2] = {
-    GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(MVCCValue, deleted_),
-    GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(MVCCValue, value_),
-  };
-  MVCCValue_reflection_ =
-    ::google::protobuf::internal::GeneratedMessageReflection::NewGeneratedMessageReflection(
-      MVCCValue_descriptor_,
-      MVCCValue::default_instance_,
-      MVCCValue_offsets_,
-      GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(MVCCValue, _has_bits_[0]),
-      -1,
-      -1,
-      sizeof(MVCCValue),
-      GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(MVCCValue, _internal_metadata_),
-      -1);
-  MVCCMetadata_descriptor_ = file->message_type(1);
+  MVCCMetadata_descriptor_ = file->message_type(0);
   static const int MVCCMetadata_offsets_[6] = {
     GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(MVCCMetadata, txn_),
     GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(MVCCMetadata, timestamp_),
@@ -77,7 +58,7 @@ void protobuf_AssignDesc_cockroach_2fstorage_2fengine_2fmvcc_2eproto() {
       sizeof(MVCCMetadata),
       GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(MVCCMetadata, _internal_metadata_),
       -1);
-  MVCCStats_descriptor_ = file->message_type(2);
+  MVCCStats_descriptor_ = file->message_type(1);
   static const int MVCCStats_offsets_[13] = {
     GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(MVCCStats, live_bytes_),
     GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(MVCCStats, key_bytes_),
@@ -117,8 +98,6 @@ inline void protobuf_AssignDescriptorsOnce() {
 void protobuf_RegisterTypes(const ::std::string&) {
   protobuf_AssignDescriptorsOnce();
   ::google::protobuf::MessageFactory::InternalRegisterGeneratedMessage(
-      MVCCValue_descriptor_, &MVCCValue::default_instance());
-  ::google::protobuf::MessageFactory::InternalRegisterGeneratedMessage(
       MVCCMetadata_descriptor_, &MVCCMetadata::default_instance());
   ::google::protobuf::MessageFactory::InternalRegisterGeneratedMessage(
       MVCCStats_descriptor_, &MVCCStats::default_instance());
@@ -127,8 +106,6 @@ void protobuf_RegisterTypes(const ::std::string&) {
 }  // namespace
 
 void protobuf_ShutdownFile_cockroach_2fstorage_2fengine_2fmvcc_2eproto() {
-  delete MVCCValue::default_instance_;
-  delete MVCCValue_reflection_;
   delete MVCCMetadata::default_instance_;
   delete MVCCMetadata_reflection_;
   delete MVCCStats::default_instance_;
@@ -146,31 +123,27 @@ void protobuf_AddDesc_cockroach_2fstorage_2fengine_2fmvcc_2eproto() {
   ::google::protobuf::DescriptorPool::InternalAddGeneratedFile(
     "\n#cockroach/storage/engine/mvcc.proto\022\030c"
     "ockroach.storage.engine\032\034cockroach/roach"
-    "pb/data.proto\032\024gogoproto/gogo.proto\"K\n\tM"
-    "VCCValue\022\025\n\007deleted\030\001 \001(\010B\004\310\336\037\000\022\'\n\005value"
-    "\030\002 \001(\0132\030.cockroach.roachpb.Value\"\344\001\n\014MVC"
-    "CMetadata\022+\n\003txn\030\001 \001(\0132\036.cockroach.roach"
-    "pb.Transaction\0225\n\ttimestamp\030\002 \001(\0132\034.cock"
-    "roach.roachpb.TimestampB\004\310\336\037\000\022\025\n\007deleted"
-    "\030\003 \001(\010B\004\310\336\037\000\022\027\n\tkey_bytes\030\004 \001(\003B\004\310\336\037\000\022\027\n"
-    "\tval_bytes\030\005 \001(\003B\004\310\336\037\000\022\'\n\005value\030\006 \001(\0132\030."
-    "cockroach.roachpb.Value\"\362\002\n\tMVCCStats\022\030\n"
-    "\nlive_bytes\030\001 \001(\003B\004\310\336\037\000\022\027\n\tkey_bytes\030\002 \001"
-    "(\003B\004\310\336\037\000\022\027\n\tval_bytes\030\003 \001(\003B\004\310\336\037\000\022\032\n\014int"
-    "ent_bytes\030\004 \001(\003B\004\310\336\037\000\022\030\n\nlive_count\030\005 \001("
-    "\003B\004\310\336\037\000\022\027\n\tkey_count\030\006 \001(\003B\004\310\336\037\000\022\027\n\tval_"
-    "count\030\007 \001(\003B\004\310\336\037\000\022\032\n\014intent_count\030\010 \001(\003B"
-    "\004\310\336\037\000\022\030\n\nintent_age\030\t \001(\003B\004\310\336\037\000\022(\n\014gc_by"
-    "tes_age\030\n \001(\003B\022\310\336\037\000\342\336\037\nGCBytesAge\022\027\n\tsys"
-    "_bytes\030\014 \001(\003B\004\310\336\037\000\022\027\n\tsys_count\030\r \001(\003B\004\310"
-    "\336\037\000\022\037\n\021last_update_nanos\030\036 \001(\003B\004\310\336\037\000B\034Z\006"
-    "engine\310\341\036\000\220\343\036\000\310\342\036\001\340\342\036\001\320\342\036\001X\001", 828);
+    "pb/data.proto\032\024gogoproto/gogo.proto\"\344\001\n\014"
+    "MVCCMetadata\022+\n\003txn\030\001 \001(\0132\036.cockroach.ro"
+    "achpb.Transaction\0225\n\ttimestamp\030\002 \001(\0132\034.c"
+    "ockroach.roachpb.TimestampB\004\310\336\037\000\022\025\n\007dele"
+    "ted\030\003 \001(\010B\004\310\336\037\000\022\027\n\tkey_bytes\030\004 \001(\003B\004\310\336\037\000"
+    "\022\027\n\tval_bytes\030\005 \001(\003B\004\310\336\037\000\022\'\n\005value\030\006 \001(\013"
+    "2\030.cockroach.roachpb.Value\"\362\002\n\tMVCCStats"
+    "\022\030\n\nlive_bytes\030\001 \001(\003B\004\310\336\037\000\022\027\n\tkey_bytes\030"
+    "\002 \001(\003B\004\310\336\037\000\022\027\n\tval_bytes\030\003 \001(\003B\004\310\336\037\000\022\032\n\014"
+    "intent_bytes\030\004 \001(\003B\004\310\336\037\000\022\030\n\nlive_count\030\005"
+    " \001(\003B\004\310\336\037\000\022\027\n\tkey_count\030\006 \001(\003B\004\310\336\037\000\022\027\n\tv"
+    "al_count\030\007 \001(\003B\004\310\336\037\000\022\032\n\014intent_count\030\010 \001"
+    "(\003B\004\310\336\037\000\022\030\n\nintent_age\030\t \001(\003B\004\310\336\037\000\022(\n\014gc"
+    "_bytes_age\030\n \001(\003B\022\310\336\037\000\342\336\037\nGCBytesAge\022\027\n\t"
+    "sys_bytes\030\014 \001(\003B\004\310\336\037\000\022\027\n\tsys_count\030\r \001(\003"
+    "B\004\310\336\037\000\022\037\n\021last_update_nanos\030\036 \001(\003B\004\310\336\037\000B"
+    "\034Z\006engine\310\341\036\000\220\343\036\000\310\342\036\001\340\342\036\001\320\342\036\001X\001", 751);
   ::google::protobuf::MessageFactory::InternalRegisterGeneratedFile(
     "cockroach/storage/engine/mvcc.proto", &protobuf_RegisterTypes);
-  MVCCValue::default_instance_ = new MVCCValue();
   MVCCMetadata::default_instance_ = new MVCCMetadata();
   MVCCStats::default_instance_ = new MVCCStats();
-  MVCCValue::default_instance_->InitAsDefaultInstance();
   MVCCMetadata::default_instance_->InitAsDefaultInstance();
   MVCCStats::default_instance_->InitAsDefaultInstance();
   ::google::protobuf::internal::OnShutdown(&protobuf_ShutdownFile_cockroach_2fstorage_2fengine_2fmvcc_2eproto);
@@ -192,354 +165,6 @@ static void MergeFromFail(int line) {
 
 }  // namespace
 
-
-// ===================================================================
-
-#ifndef _MSC_VER
-const int MVCCValue::kDeletedFieldNumber;
-const int MVCCValue::kValueFieldNumber;
-#endif  // !_MSC_VER
-
-MVCCValue::MVCCValue()
-  : ::google::protobuf::Message(), _internal_metadata_(NULL) {
-  SharedCtor();
-  // @@protoc_insertion_point(constructor:cockroach.storage.engine.MVCCValue)
-}
-
-void MVCCValue::InitAsDefaultInstance() {
-  value_ = const_cast< ::cockroach::roachpb::Value*>(&::cockroach::roachpb::Value::default_instance());
-}
-
-MVCCValue::MVCCValue(const MVCCValue& from)
-  : ::google::protobuf::Message(),
-    _internal_metadata_(NULL) {
-  SharedCtor();
-  MergeFrom(from);
-  // @@protoc_insertion_point(copy_constructor:cockroach.storage.engine.MVCCValue)
-}
-
-void MVCCValue::SharedCtor() {
-  _cached_size_ = 0;
-  deleted_ = false;
-  value_ = NULL;
-  ::memset(_has_bits_, 0, sizeof(_has_bits_));
-}
-
-MVCCValue::~MVCCValue() {
-  // @@protoc_insertion_point(destructor:cockroach.storage.engine.MVCCValue)
-  SharedDtor();
-}
-
-void MVCCValue::SharedDtor() {
-  if (this != default_instance_) {
-    delete value_;
-  }
-}
-
-void MVCCValue::SetCachedSize(int size) const {
-  GOOGLE_SAFE_CONCURRENT_WRITES_BEGIN();
-  _cached_size_ = size;
-  GOOGLE_SAFE_CONCURRENT_WRITES_END();
-}
-const ::google::protobuf::Descriptor* MVCCValue::descriptor() {
-  protobuf_AssignDescriptorsOnce();
-  return MVCCValue_descriptor_;
-}
-
-const MVCCValue& MVCCValue::default_instance() {
-  if (default_instance_ == NULL) protobuf_AddDesc_cockroach_2fstorage_2fengine_2fmvcc_2eproto();
-  return *default_instance_;
-}
-
-MVCCValue* MVCCValue::default_instance_ = NULL;
-
-MVCCValue* MVCCValue::New(::google::protobuf::Arena* arena) const {
-  MVCCValue* n = new MVCCValue;
-  if (arena != NULL) {
-    arena->Own(n);
-  }
-  return n;
-}
-
-void MVCCValue::Clear() {
-  if (_has_bits_[0 / 32] & 3u) {
-    deleted_ = false;
-    if (has_value()) {
-      if (value_ != NULL) value_->::cockroach::roachpb::Value::Clear();
-    }
-  }
-  ::memset(_has_bits_, 0, sizeof(_has_bits_));
-  if (_internal_metadata_.have_unknown_fields()) {
-    mutable_unknown_fields()->Clear();
-  }
-}
-
-bool MVCCValue::MergePartialFromCodedStream(
-    ::google::protobuf::io::CodedInputStream* input) {
-#define DO_(EXPRESSION) if (!(EXPRESSION)) goto failure
-  ::google::protobuf::uint32 tag;
-  // @@protoc_insertion_point(parse_start:cockroach.storage.engine.MVCCValue)
-  for (;;) {
-    ::std::pair< ::google::protobuf::uint32, bool> p = input->ReadTagWithCutoff(127);
-    tag = p.first;
-    if (!p.second) goto handle_unusual;
-    switch (::google::protobuf::internal::WireFormatLite::GetTagFieldNumber(tag)) {
-      // optional bool deleted = 1;
-      case 1: {
-        if (tag == 8) {
-          DO_((::google::protobuf::internal::WireFormatLite::ReadPrimitive<
-                   bool, ::google::protobuf::internal::WireFormatLite::TYPE_BOOL>(
-                 input, &deleted_)));
-          set_has_deleted();
-        } else {
-          goto handle_unusual;
-        }
-        if (input->ExpectTag(18)) goto parse_value;
-        break;
-      }
-
-      // optional .cockroach.roachpb.Value value = 2;
-      case 2: {
-        if (tag == 18) {
-         parse_value:
-          DO_(::google::protobuf::internal::WireFormatLite::ReadMessageNoVirtual(
-               input, mutable_value()));
-        } else {
-          goto handle_unusual;
-        }
-        if (input->ExpectAtEnd()) goto success;
-        break;
-      }
-
-      default: {
-      handle_unusual:
-        if (tag == 0 ||
-            ::google::protobuf::internal::WireFormatLite::GetTagWireType(tag) ==
-            ::google::protobuf::internal::WireFormatLite::WIRETYPE_END_GROUP) {
-          goto success;
-        }
-        DO_(::google::protobuf::internal::WireFormat::SkipField(
-              input, tag, mutable_unknown_fields()));
-        break;
-      }
-    }
-  }
-success:
-  // @@protoc_insertion_point(parse_success:cockroach.storage.engine.MVCCValue)
-  return true;
-failure:
-  // @@protoc_insertion_point(parse_failure:cockroach.storage.engine.MVCCValue)
-  return false;
-#undef DO_
-}
-
-void MVCCValue::SerializeWithCachedSizes(
-    ::google::protobuf::io::CodedOutputStream* output) const {
-  // @@protoc_insertion_point(serialize_start:cockroach.storage.engine.MVCCValue)
-  // optional bool deleted = 1;
-  if (has_deleted()) {
-    ::google::protobuf::internal::WireFormatLite::WriteBool(1, this->deleted(), output);
-  }
-
-  // optional .cockroach.roachpb.Value value = 2;
-  if (has_value()) {
-    ::google::protobuf::internal::WireFormatLite::WriteMessageMaybeToArray(
-      2, *this->value_, output);
-  }
-
-  if (_internal_metadata_.have_unknown_fields()) {
-    ::google::protobuf::internal::WireFormat::SerializeUnknownFields(
-        unknown_fields(), output);
-  }
-  // @@protoc_insertion_point(serialize_end:cockroach.storage.engine.MVCCValue)
-}
-
-::google::protobuf::uint8* MVCCValue::SerializeWithCachedSizesToArray(
-    ::google::protobuf::uint8* target) const {
-  // @@protoc_insertion_point(serialize_to_array_start:cockroach.storage.engine.MVCCValue)
-  // optional bool deleted = 1;
-  if (has_deleted()) {
-    target = ::google::protobuf::internal::WireFormatLite::WriteBoolToArray(1, this->deleted(), target);
-  }
-
-  // optional .cockroach.roachpb.Value value = 2;
-  if (has_value()) {
-    target = ::google::protobuf::internal::WireFormatLite::
-      WriteMessageNoVirtualToArray(
-        2, *this->value_, target);
-  }
-
-  if (_internal_metadata_.have_unknown_fields()) {
-    target = ::google::protobuf::internal::WireFormat::SerializeUnknownFieldsToArray(
-        unknown_fields(), target);
-  }
-  // @@protoc_insertion_point(serialize_to_array_end:cockroach.storage.engine.MVCCValue)
-  return target;
-}
-
-int MVCCValue::ByteSize() const {
-  int total_size = 0;
-
-  if (_has_bits_[0 / 32] & 3) {
-    // optional bool deleted = 1;
-    if (has_deleted()) {
-      total_size += 1 + 1;
-    }
-
-    // optional .cockroach.roachpb.Value value = 2;
-    if (has_value()) {
-      total_size += 1 +
-        ::google::protobuf::internal::WireFormatLite::MessageSizeNoVirtual(
-          *this->value_);
-    }
-
-  }
-  if (_internal_metadata_.have_unknown_fields()) {
-    total_size +=
-      ::google::protobuf::internal::WireFormat::ComputeUnknownFieldsSize(
-        unknown_fields());
-  }
-  GOOGLE_SAFE_CONCURRENT_WRITES_BEGIN();
-  _cached_size_ = total_size;
-  GOOGLE_SAFE_CONCURRENT_WRITES_END();
-  return total_size;
-}
-
-void MVCCValue::MergeFrom(const ::google::protobuf::Message& from) {
-  if (GOOGLE_PREDICT_FALSE(&from == this)) MergeFromFail(__LINE__);
-  const MVCCValue* source = 
-      ::google::protobuf::internal::DynamicCastToGenerated<const MVCCValue>(
-          &from);
-  if (source == NULL) {
-    ::google::protobuf::internal::ReflectionOps::Merge(from, this);
-  } else {
-    MergeFrom(*source);
-  }
-}
-
-void MVCCValue::MergeFrom(const MVCCValue& from) {
-  if (GOOGLE_PREDICT_FALSE(&from == this)) MergeFromFail(__LINE__);
-  if (from._has_bits_[0 / 32] & (0xffu << (0 % 32))) {
-    if (from.has_deleted()) {
-      set_deleted(from.deleted());
-    }
-    if (from.has_value()) {
-      mutable_value()->::cockroach::roachpb::Value::MergeFrom(from.value());
-    }
-  }
-  if (from._internal_metadata_.have_unknown_fields()) {
-    mutable_unknown_fields()->MergeFrom(from.unknown_fields());
-  }
-}
-
-void MVCCValue::CopyFrom(const ::google::protobuf::Message& from) {
-  if (&from == this) return;
-  Clear();
-  MergeFrom(from);
-}
-
-void MVCCValue::CopyFrom(const MVCCValue& from) {
-  if (&from == this) return;
-  Clear();
-  MergeFrom(from);
-}
-
-bool MVCCValue::IsInitialized() const {
-
-  return true;
-}
-
-void MVCCValue::Swap(MVCCValue* other) {
-  if (other == this) return;
-  InternalSwap(other);
-}
-void MVCCValue::InternalSwap(MVCCValue* other) {
-  std::swap(deleted_, other->deleted_);
-  std::swap(value_, other->value_);
-  std::swap(_has_bits_[0], other->_has_bits_[0]);
-  _internal_metadata_.Swap(&other->_internal_metadata_);
-  std::swap(_cached_size_, other->_cached_size_);
-}
-
-::google::protobuf::Metadata MVCCValue::GetMetadata() const {
-  protobuf_AssignDescriptorsOnce();
-  ::google::protobuf::Metadata metadata;
-  metadata.descriptor = MVCCValue_descriptor_;
-  metadata.reflection = MVCCValue_reflection_;
-  return metadata;
-}
-
-#if PROTOBUF_INLINE_NOT_IN_HEADERS
-// MVCCValue
-
-// optional bool deleted = 1;
-bool MVCCValue::has_deleted() const {
-  return (_has_bits_[0] & 0x00000001u) != 0;
-}
-void MVCCValue::set_has_deleted() {
-  _has_bits_[0] |= 0x00000001u;
-}
-void MVCCValue::clear_has_deleted() {
-  _has_bits_[0] &= ~0x00000001u;
-}
-void MVCCValue::clear_deleted() {
-  deleted_ = false;
-  clear_has_deleted();
-}
- bool MVCCValue::deleted() const {
-  // @@protoc_insertion_point(field_get:cockroach.storage.engine.MVCCValue.deleted)
-  return deleted_;
-}
- void MVCCValue::set_deleted(bool value) {
-  set_has_deleted();
-  deleted_ = value;
-  // @@protoc_insertion_point(field_set:cockroach.storage.engine.MVCCValue.deleted)
-}
-
-// optional .cockroach.roachpb.Value value = 2;
-bool MVCCValue::has_value() const {
-  return (_has_bits_[0] & 0x00000002u) != 0;
-}
-void MVCCValue::set_has_value() {
-  _has_bits_[0] |= 0x00000002u;
-}
-void MVCCValue::clear_has_value() {
-  _has_bits_[0] &= ~0x00000002u;
-}
-void MVCCValue::clear_value() {
-  if (value_ != NULL) value_->::cockroach::roachpb::Value::Clear();
-  clear_has_value();
-}
- const ::cockroach::roachpb::Value& MVCCValue::value() const {
-  // @@protoc_insertion_point(field_get:cockroach.storage.engine.MVCCValue.value)
-  return value_ != NULL ? *value_ : *default_instance_->value_;
-}
- ::cockroach::roachpb::Value* MVCCValue::mutable_value() {
-  set_has_value();
-  if (value_ == NULL) {
-    value_ = new ::cockroach::roachpb::Value;
-  }
-  // @@protoc_insertion_point(field_mutable:cockroach.storage.engine.MVCCValue.value)
-  return value_;
-}
- ::cockroach::roachpb::Value* MVCCValue::release_value() {
-  clear_has_value();
-  ::cockroach::roachpb::Value* temp = value_;
-  value_ = NULL;
-  return temp;
-}
- void MVCCValue::set_allocated_value(::cockroach::roachpb::Value* value) {
-  delete value_;
-  value_ = value;
-  if (value) {
-    set_has_value();
-  } else {
-    clear_has_value();
-  }
-  // @@protoc_insertion_point(field_set_allocated:cockroach.storage.engine.MVCCValue.value)
-}
-
-#endif  // PROTOBUF_INLINE_NOT_IN_HEADERS
 
 // ===================================================================
 

--- a/storage/engine/rocksdb/cockroach/storage/engine/mvcc.pb.h
+++ b/storage/engine/rocksdb/cockroach/storage/engine/mvcc.pb.h
@@ -40,112 +40,10 @@ void protobuf_AddDesc_cockroach_2fstorage_2fengine_2fmvcc_2eproto();
 void protobuf_AssignDesc_cockroach_2fstorage_2fengine_2fmvcc_2eproto();
 void protobuf_ShutdownFile_cockroach_2fstorage_2fengine_2fmvcc_2eproto();
 
-class MVCCValue;
 class MVCCMetadata;
 class MVCCStats;
 
 // ===================================================================
-
-class MVCCValue : public ::google::protobuf::Message {
- public:
-  MVCCValue();
-  virtual ~MVCCValue();
-
-  MVCCValue(const MVCCValue& from);
-
-  inline MVCCValue& operator=(const MVCCValue& from) {
-    CopyFrom(from);
-    return *this;
-  }
-
-  inline const ::google::protobuf::UnknownFieldSet& unknown_fields() const {
-    return _internal_metadata_.unknown_fields();
-  }
-
-  inline ::google::protobuf::UnknownFieldSet* mutable_unknown_fields() {
-    return _internal_metadata_.mutable_unknown_fields();
-  }
-
-  static const ::google::protobuf::Descriptor* descriptor();
-  static const MVCCValue& default_instance();
-
-  void Swap(MVCCValue* other);
-
-  // implements Message ----------------------------------------------
-
-  inline MVCCValue* New() const { return New(NULL); }
-
-  MVCCValue* New(::google::protobuf::Arena* arena) const;
-  void CopyFrom(const ::google::protobuf::Message& from);
-  void MergeFrom(const ::google::protobuf::Message& from);
-  void CopyFrom(const MVCCValue& from);
-  void MergeFrom(const MVCCValue& from);
-  void Clear();
-  bool IsInitialized() const;
-
-  int ByteSize() const;
-  bool MergePartialFromCodedStream(
-      ::google::protobuf::io::CodedInputStream* input);
-  void SerializeWithCachedSizes(
-      ::google::protobuf::io::CodedOutputStream* output) const;
-  ::google::protobuf::uint8* SerializeWithCachedSizesToArray(::google::protobuf::uint8* output) const;
-  int GetCachedSize() const { return _cached_size_; }
-  private:
-  void SharedCtor();
-  void SharedDtor();
-  void SetCachedSize(int size) const;
-  void InternalSwap(MVCCValue* other);
-  private:
-  inline ::google::protobuf::Arena* GetArenaNoVirtual() const {
-    return _internal_metadata_.arena();
-  }
-  inline void* MaybeArenaPtr() const {
-    return _internal_metadata_.raw_arena_ptr();
-  }
-  public:
-
-  ::google::protobuf::Metadata GetMetadata() const;
-
-  // nested types ----------------------------------------------------
-
-  // accessors -------------------------------------------------------
-
-  // optional bool deleted = 1;
-  bool has_deleted() const;
-  void clear_deleted();
-  static const int kDeletedFieldNumber = 1;
-  bool deleted() const;
-  void set_deleted(bool value);
-
-  // optional .cockroach.roachpb.Value value = 2;
-  bool has_value() const;
-  void clear_value();
-  static const int kValueFieldNumber = 2;
-  const ::cockroach::roachpb::Value& value() const;
-  ::cockroach::roachpb::Value* mutable_value();
-  ::cockroach::roachpb::Value* release_value();
-  void set_allocated_value(::cockroach::roachpb::Value* value);
-
-  // @@protoc_insertion_point(class_scope:cockroach.storage.engine.MVCCValue)
- private:
-  inline void set_has_deleted();
-  inline void clear_has_deleted();
-  inline void set_has_value();
-  inline void clear_has_value();
-
-  ::google::protobuf::internal::InternalMetadataWithArena _internal_metadata_;
-  ::google::protobuf::uint32 _has_bits_[1];
-  mutable int _cached_size_;
-  ::cockroach::roachpb::Value* value_;
-  bool deleted_;
-  friend void  protobuf_AddDesc_cockroach_2fstorage_2fengine_2fmvcc_2eproto();
-  friend void protobuf_AssignDesc_cockroach_2fstorage_2fengine_2fmvcc_2eproto();
-  friend void protobuf_ShutdownFile_cockroach_2fstorage_2fengine_2fmvcc_2eproto();
-
-  void InitAsDefaultInstance();
-  static MVCCValue* default_instance_;
-};
-// -------------------------------------------------------------------
 
 class MVCCMetadata : public ::google::protobuf::Message {
  public:
@@ -505,77 +403,6 @@ class MVCCStats : public ::google::protobuf::Message {
 // ===================================================================
 
 #if !PROTOBUF_INLINE_NOT_IN_HEADERS
-// MVCCValue
-
-// optional bool deleted = 1;
-inline bool MVCCValue::has_deleted() const {
-  return (_has_bits_[0] & 0x00000001u) != 0;
-}
-inline void MVCCValue::set_has_deleted() {
-  _has_bits_[0] |= 0x00000001u;
-}
-inline void MVCCValue::clear_has_deleted() {
-  _has_bits_[0] &= ~0x00000001u;
-}
-inline void MVCCValue::clear_deleted() {
-  deleted_ = false;
-  clear_has_deleted();
-}
-inline bool MVCCValue::deleted() const {
-  // @@protoc_insertion_point(field_get:cockroach.storage.engine.MVCCValue.deleted)
-  return deleted_;
-}
-inline void MVCCValue::set_deleted(bool value) {
-  set_has_deleted();
-  deleted_ = value;
-  // @@protoc_insertion_point(field_set:cockroach.storage.engine.MVCCValue.deleted)
-}
-
-// optional .cockroach.roachpb.Value value = 2;
-inline bool MVCCValue::has_value() const {
-  return (_has_bits_[0] & 0x00000002u) != 0;
-}
-inline void MVCCValue::set_has_value() {
-  _has_bits_[0] |= 0x00000002u;
-}
-inline void MVCCValue::clear_has_value() {
-  _has_bits_[0] &= ~0x00000002u;
-}
-inline void MVCCValue::clear_value() {
-  if (value_ != NULL) value_->::cockroach::roachpb::Value::Clear();
-  clear_has_value();
-}
-inline const ::cockroach::roachpb::Value& MVCCValue::value() const {
-  // @@protoc_insertion_point(field_get:cockroach.storage.engine.MVCCValue.value)
-  return value_ != NULL ? *value_ : *default_instance_->value_;
-}
-inline ::cockroach::roachpb::Value* MVCCValue::mutable_value() {
-  set_has_value();
-  if (value_ == NULL) {
-    value_ = new ::cockroach::roachpb::Value;
-  }
-  // @@protoc_insertion_point(field_mutable:cockroach.storage.engine.MVCCValue.value)
-  return value_;
-}
-inline ::cockroach::roachpb::Value* MVCCValue::release_value() {
-  clear_has_value();
-  ::cockroach::roachpb::Value* temp = value_;
-  value_ = NULL;
-  return temp;
-}
-inline void MVCCValue::set_allocated_value(::cockroach::roachpb::Value* value) {
-  delete value_;
-  value_ = value;
-  if (value) {
-    set_has_value();
-  } else {
-    clear_has_value();
-  }
-  // @@protoc_insertion_point(field_set_allocated:cockroach.storage.engine.MVCCValue.value)
-}
-
-// -------------------------------------------------------------------
-
 // MVCCMetadata
 
 // optional .cockroach.roachpb.Transaction txn = 1;
@@ -1096,8 +923,6 @@ inline void MVCCStats::set_last_update_nanos(::google::protobuf::int64 value) {
 }
 
 #endif  // !PROTOBUF_INLINE_NOT_IN_HEADERS
-// -------------------------------------------------------------------
-
 // -------------------------------------------------------------------
 
 

--- a/storage/replica_test.go
+++ b/storage/replica_test.go
@@ -1009,23 +1009,6 @@ func truncateLogArgs(index uint64, rangeID roachpb.RangeID) roachpb.TruncateLogR
 	}
 }
 
-// getSerializedMVCCValue produces a byte slice of the serialized
-// mvcc value. If value is nil, MVCCValue.Deleted is set to true;
-// otherwise MVCCValue.Value is set to value.
-func getSerializedMVCCValue(value *roachpb.Value) []byte {
-	mvccVal := &engine.MVCCValue{}
-	if value != nil {
-		mvccVal.Value = value
-	} else {
-		mvccVal.Deleted = true
-	}
-	data, err := proto.Marshal(&engine.MVCCValue{Value: value})
-	if err != nil {
-		panic("unexpected marshal error")
-	}
-	return data
-}
-
 // TestAcquireLeaderLease verifies that the leader lease is acquired
 // for read and write methods.
 func TestAcquireLeaderLease(t *testing.T) {
@@ -2676,7 +2659,7 @@ func TestRangeStatsComputation(t *testing.T) {
 	if _, err := client.SendWrapped(tc.Sender(), tc.rng.context(), &pArgs); err != nil {
 		t.Fatal(err)
 	}
-	expMS := engine.MVCCStats{LiveBytes: 42, KeyBytes: 16, ValBytes: 26, IntentBytes: 0, LiveCount: 1, KeyCount: 1, ValCount: 1, IntentCount: 0, SysBytes: 63, SysCount: 1}
+	expMS := engine.MVCCStats{LiveBytes: 38, KeyBytes: 16, ValBytes: 22, IntentBytes: 0, LiveCount: 1, KeyCount: 1, ValCount: 1, IntentCount: 0, SysBytes: 63, SysCount: 1}
 	verifyRangeStats(tc.engine, tc.rng.Desc().RangeID, expMS, t)
 
 	// Put a 2nd value transactionally.
@@ -2686,7 +2669,7 @@ func TestRangeStatsComputation(t *testing.T) {
 	if _, err := client.SendWrappedWith(tc.Sender(), tc.rng.context(), roachpb.Header{Txn: txn}, &pArgs); err != nil {
 		t.Fatal(err)
 	}
-	expMS = engine.MVCCStats{LiveBytes: 138, KeyBytes: 32, ValBytes: 106, IntentBytes: 26, LiveCount: 2, KeyCount: 2, ValCount: 2, IntentCount: 1, SysBytes: 63, SysCount: 1}
+	expMS = engine.MVCCStats{LiveBytes: 130, KeyBytes: 32, ValBytes: 98, IntentBytes: 22, LiveCount: 2, KeyCount: 2, ValCount: 2, IntentCount: 1, SysBytes: 63, SysCount: 1}
 	verifyRangeStats(tc.engine, tc.rng.Desc().RangeID, expMS, t)
 
 	// Resolve the 2nd value.
@@ -2701,7 +2684,7 @@ func TestRangeStatsComputation(t *testing.T) {
 	if _, err := client.SendWrapped(tc.Sender(), tc.rng.context(), rArgs); err != nil {
 		t.Fatal(err)
 	}
-	expMS = engine.MVCCStats{LiveBytes: 84, KeyBytes: 32, ValBytes: 52, IntentBytes: 0, LiveCount: 2, KeyCount: 2, ValCount: 2, IntentCount: 0, SysBytes: 63, SysCount: 1}
+	expMS = engine.MVCCStats{LiveBytes: 76, KeyBytes: 32, ValBytes: 44, IntentBytes: 0, LiveCount: 2, KeyCount: 2, ValCount: 2, IntentCount: 0, SysBytes: 63, SysCount: 1}
 	verifyRangeStats(tc.engine, tc.rng.Desc().RangeID, expMS, t)
 
 	// Delete the 1st value.
@@ -2710,7 +2693,7 @@ func TestRangeStatsComputation(t *testing.T) {
 	if _, err := client.SendWrapped(tc.Sender(), tc.rng.context(), &dArgs); err != nil {
 		t.Fatal(err)
 	}
-	expMS = engine.MVCCStats{LiveBytes: 42, KeyBytes: 44, ValBytes: 54, IntentBytes: 0, LiveCount: 1, KeyCount: 2, ValCount: 3, IntentCount: 0, SysBytes: 63, SysCount: 1}
+	expMS = engine.MVCCStats{LiveBytes: 38, KeyBytes: 44, ValBytes: 44, IntentBytes: 0, LiveCount: 1, KeyCount: 2, ValCount: 3, IntentCount: 0, SysBytes: 63, SysCount: 1}
 	verifyRangeStats(tc.engine, tc.rng.Desc().RangeID, expMS, t)
 }
 


### PR DESCRIPTION
Deletion tombstones are now indicated by an empty value. Not having to
wrap a Value with an MVCCValue gives a nice perf boost.

```
name                          old time/op    new time/op    delta
MVCCScan1Version1Row-8          5.99µs ±14%    6.11µs ±15%     ~           (p=0.796 n=10+10)
MVCCScan1Version10Rows-8        15.7µs ± 3%    15.6µs ± 1%     ~            (p=0.182 n=10+9)
MVCCScan1Version100Rows-8        176µs ±17%     144µs ± 1%  -18.13%         (p=0.000 n=9+10)
MVCCScan1Version1000Rows-8      1.49ms ± 3%    1.44ms ± 4%   -3.16%         (p=0.009 n=8+10)
MVCCScan10Versions1Row-8        8.65µs ±14%    5.91µs ± 8%  -31.72%        (p=0.000 n=10+10)
MVCCScan10Versions10Rows-8      22.0µs ± 2%    19.4µs ± 6%  -11.80%         (p=0.000 n=9+10)
MVCCScan10Versions100Rows-8      200µs ±13%     185µs ± 4%   -7.37%        (p=0.000 n=10+10)
MVCCScan10Versions1000Rows-8    1.89ms ± 5%    1.75ms ± 2%   -7.30%        (p=0.000 n=10+10)
MVCCGet1Version-8               6.16µs ±12%    6.00µs ±17%     ~           (p=0.436 n=10+10)
MVCCGet10Versions-8             7.54µs ± 5%    5.63µs ± 4%  -25.33%         (p=0.000 n=8+10)

name                          old speed      new speed      delta
MVCCScan1Version1Row-8         171MB/s ±12%   169MB/s ±13%     ~           (p=0.796 n=10+10)
MVCCScan1Version10Rows-8       651MB/s ± 3%   657MB/s ± 1%     ~            (p=0.182 n=10+9)
MVCCScan1Version100Rows-8      586MB/s ±19%   709MB/s ± 1%  +21.09%         (p=0.000 n=9+10)
MVCCScan1Version1000Rows-8     687MB/s ± 3%   710MB/s ± 4%   +3.28%         (p=0.009 n=8+10)
MVCCScan10Versions1Row-8       119MB/s ±13%   174MB/s ± 8%  +45.84%        (p=0.000 n=10+10)
MVCCScan10Versions10Rows-8     466MB/s ± 2%   529MB/s ± 6%  +13.48%         (p=0.000 n=9+10)
MVCCScan10Versions100Rows-8    514MB/s ±11%   553MB/s ± 4%   +7.70%        (p=0.000 n=10+10)
MVCCScan10Versions1000Rows-8   542MB/s ± 5%   585MB/s ± 3%   +7.83%        (p=0.000 n=10+10)
MVCCGet1Version-8              167MB/s ±12%   172MB/s ±15%     ~           (p=0.436 n=10+10)
MVCCGet10Versions-8            136MB/s ± 5%   182MB/s ± 4%  +33.97%         (p=0.000 n=8+10)
```

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/3217)

<!-- Reviewable:end -->
