### PR TITLE
Ensure that the system config is available when starting up the MultiTestContext.

### DIFF
--- a/storage/client_test.go
+++ b/storage/client_test.go
@@ -235,6 +235,14 @@ func (m *multiTestContext) Start(t *testing.T, numStores int) {
 		m.transportStopper = stop.NewStopper()
 	}
 	m.transportStopper.AddCloser(m.transport)
+
+	// Wait for gossip to startup.
+	util.SucceedsWithin(t, 100*time.Millisecond, func() error {
+		if m.gossip.GetSystemConfig() == nil {
+			return util.Errorf("system config not available")
+		}
+		return nil
+	})
 }
 
 func (m *multiTestContext) Stop() {


### PR DESCRIPTION
Fixes #3166
Also adds a wait loop in the Raft Queue Test for when the raft log queue's own thread picks up the replica for processing at exactly the wrong time.
I've now run this test over 500,000 times without failure locally.

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/3223)

<!-- Reviewable:end -->
