### PR TITLE
Re-enable TestReplicatRogueRemoveNode

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -38,7 +38,7 @@ To add or update a go dependency:
 - create a PR with all the changes
 
 ### Style guide
-We're following the [Google Go Code Review](https://code.google.com/p/go-wiki/wiki/CodeReviewComments) fairly closely. In particular, you want to watch out for proper punctuation and capitalization in comments. We use two-space indents in non-Go code (in Go, we follow `gofmt` which indents with tabs). Format your code assuming it will be read in a window 100 columns wide. Wrap code and comments at 100 characters unless doing so makes the code less legible".
+We're following the [Google Go Code Review](https://code.google.com/p/go-wiki/wiki/CodeReviewComments) fairly closely. In particular, you want to watch out for proper punctuation and capitalization in comments. We use two-space indents in non-Go code (in Go, we follow `gofmt` which indents with tabs). Format your code assuming it will be read in a window 100 columns wide. Wrap code and comments at 100 characters unless doing so makes the code less legible.
 
 ### Code review workflow
 

--- a/storage/client_raft_test.go
+++ b/storage/client_raft_test.go
@@ -1285,7 +1285,6 @@ func TestStoreRangeRebalance(t *testing.T) {
 // cannot cause other removed nodes to recreate their ranges.
 func TestReplicateRogueRemovedNode(t *testing.T) {
 	defer leaktest.AfterTest(t)
-	t.Skip("TODO(bram): https://github.com/cockroachdb/cockroach/issues/3069")
 
 	mtc := startMultiTestContext(t, 3)
 	defer mtc.Stop()


### PR DESCRIPTION
I cannot reproduce a failure in this test with `make stress` after 5000 iterations.

Fixes #2880

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/3226)

<!-- Reviewable:end -->
