### PR TITLE
add basic RemoteCluster capability

### DIFF
--- a/acceptance/cluster/docker.go
+++ b/acceptance/cluster/docker.go
@@ -34,21 +34,10 @@ import (
 	"runtime"
 	"strconv"
 
-	"github.com/cockroachdb/cockroach/base"
 	"github.com/cockroachdb/cockroach/util"
 	"github.com/cockroachdb/cockroach/util/log"
 	"github.com/samalba/dockerclient"
 )
-
-// HTTPClient is an http.Client configured for querying the running
-// local cluster.
-var HTTPClient = http.Client{
-	Timeout: base.NetworkTimeout,
-	Transport: &http.Transport{
-		TLSClientConfig: &tls.Config{
-			InsecureSkipVerify: true,
-		},
-	}}
 
 func getTLSConfig() *tls.Config {
 	certPath := os.Getenv("DOCKER_CERT_PATH")
@@ -329,25 +318,5 @@ func (c *Container) Addr(name string) *net.TCPAddr {
 // GetJSON retrieves the URL specified by https://Addr(<port>)<path>
 // and unmarshals the result as JSON.
 func (c *Container) GetJSON(port, path string, v interface{}) error {
-	resp, err := HTTPClient.Get(fmt.Sprintf("https://%s%s", c.Addr(port), path))
-	if err != nil {
-		if log.V(1) {
-			log.Info(err)
-		}
-		return err
-	}
-	defer resp.Body.Close()
-	b, err := ioutil.ReadAll(resp.Body)
-	if err != nil {
-		if log.V(1) {
-			log.Info(err)
-		}
-		return err
-	}
-	if err := json.Unmarshal(b, v); err != nil {
-		if log.V(1) {
-			log.Info(err)
-		}
-	}
-	return nil
+	return getJSON(true /* tls */, c.Addr(port).String(), path, v)
 }

--- a/acceptance/cluster/http.go
+++ b/acceptance/cluster/http.go
@@ -1,0 +1,71 @@
+// Copyright 2015 The Cockroach Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+// implied. See the License for the specific language governing
+// permissions and limitations under the License. See the AUTHORS file
+// for names of contributors.
+//
+// Author: Peter Mattis (peter@cockroachlabs.com)
+
+package cluster
+
+import (
+	"crypto/tls"
+	"encoding/json"
+	"fmt"
+	"io/ioutil"
+	"net/http"
+
+	"github.com/cockroachdb/cockroach/base"
+	"github.com/cockroachdb/cockroach/util/log"
+)
+
+// HTTPClient is an http.Client configured for querying a cluster. We need to
+// run with "InsecureSkipVerify" (at least on Docker) due to the fact that we
+// cannot use a fixed hostname to reach the cluster. This in turn means that we
+// do not have a verified server name in the certs.
+var HTTPClient = http.Client{
+	Timeout: base.NetworkTimeout,
+	Transport: &http.Transport{
+		TLSClientConfig: &tls.Config{
+			InsecureSkipVerify: true,
+		},
+	}}
+
+// getJSON retrieves the URL specified by the parameters and
+// and unmarshals the result into the supplied interface.
+func getJSON(tls bool, hostport, path string, v interface{}) error {
+	protocol := "https"
+	if !tls {
+		protocol = "http"
+	}
+	resp, err := HTTPClient.Get(fmt.Sprintf("%s://%s%s", protocol, hostport, path))
+	if err != nil {
+		if log.V(1) {
+			log.Info(err)
+		}
+		return err
+	}
+	defer resp.Body.Close()
+	b, err := ioutil.ReadAll(resp.Body)
+	if err != nil {
+		if log.V(1) {
+			log.Info(err)
+		}
+		return err
+	}
+	if err := json.Unmarshal(b, v); err != nil {
+		if log.V(1) {
+			log.Info(err)
+		}
+	}
+	return nil
+}

--- a/acceptance/cluster/remotecluster.go
+++ b/acceptance/cluster/remotecluster.go
@@ -1,0 +1,136 @@
+// Copyright 2015 The Cockroach Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+// implied. See the License for the specific language governing
+// permissions and limitations under the License. See the AUTHORS file
+// for names of contributors.
+//
+// Author: Tobias Schottdorf
+
+package cluster
+
+import (
+	"flag"
+	"fmt"
+	"os/user"
+	"path/filepath"
+
+	"github.com/cockroachdb/cockroach/client"
+	"github.com/cockroachdb/cockroach/util"
+	"github.com/cockroachdb/cockroach/util/log"
+	"github.com/cockroachdb/cockroach/util/stop"
+)
+
+func defaultKeyFile() string {
+	base := "."
+	me, err := user.Current()
+	if err == nil {
+		base = me.HomeDir
+	}
+	return filepath.Join(base, ".ssh/cockroach.pem")
+}
+
+var keyFile = flag.String("k", defaultKeyFile(), "SSH private/public key pair")
+var login = flag.String("u", "ubuntu", "SSH user name")
+
+type node struct {
+	ID   string
+	Name string
+	Addr string
+}
+
+// RemoteCluster manages a remote cluster specified by a number of hosts.
+type RemoteCluster struct {
+	nodes      []node
+	user, cert string
+}
+
+// CreateRemote connects to a remote cockroach cluster (which is required to
+// have been set up separately).
+func CreateRemote(peers []string) *RemoteCluster {
+	nodes := make([]node, len(peers))
+	for i := range nodes {
+		nodes[i].Addr = peers[i]
+		nodes[i].ID = fmt.Sprintf("roach%d", i)
+		nodes[i].Name = nodes[i].ID
+	}
+	return &RemoteCluster{
+		user:  *login,
+		cert:  *keyFile,
+		nodes: nodes,
+	}
+}
+
+// Exec executes the given command on the i-th node, returning (in that order)
+// stdout, stderr and an error.
+func (r *RemoteCluster) Exec(i int, cmd string) (string, string, error) {
+	return execute(r.user, r.nodes[i].Addr+":22", r.cert, cmd)
+}
+
+// NumNodes returns the number of nodes in the cluster, running or not.
+func (r *RemoteCluster) NumNodes() int { return len(r.nodes) }
+
+// MakeClient returns a client which is pointing at the node with the given
+// index. The given integer must be in the range [0,NumNodes()-1].
+func (r *RemoteCluster) MakeClient(t util.Tester, i int) (*client.DB, *stop.Stopper) {
+	stopper := stop.NewStopper()
+
+	// TODO(tschottdorf,mberhault): TLS all the things!
+	db, err := client.Open(stopper, "rpc://"+"root"+"@"+
+		util.EnsureHostPort(r.nodes[i].Addr)+
+		"?certs="+"certswhocares")
+
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	return db, stopper
+}
+
+// Assert verifies that the cluster state is as expected (i.e. no unexpected
+// restarts or node deaths occurred). Tests can call this periodically to
+// ascertain cluster health.
+func (r *RemoteCluster) Assert(t util.Tester) {}
+
+// AssertAndStop performs the same test as Assert but then proceeds to
+// dismantle the cluster.
+func (r *RemoteCluster) AssertAndStop(t util.Tester) {}
+
+func (r *RemoteCluster) execLauncher(i int, action string, background bool) error {
+	cmd := "./launch.sh " + action
+	if background {
+		cmd = "nohup " + cmd + " &> logs/nohup.out < /dev/null &"
+	}
+	o, e, err := r.Exec(i, cmd)
+	if err != nil {
+		log.Warningf("%s failed: %s\nstdout:\n%s\nstderr:\n%s", cmd, err, o, e)
+	}
+	return err
+}
+
+// Kill terminates the cockroach process running on the given node number.
+// The given integer must be in the range [0,NumNodes()-1].
+func (r *RemoteCluster) Kill(i int) error {
+	return r.execLauncher(i, "kill", false /* !background */)
+}
+
+// Restart terminates the cockroach process running on the given node
+// number, unless it is already stopped, and restarts it.
+// The given integer must be in the range [0,NumNodes()-1].
+func (r *RemoteCluster) Restart(i int) error {
+	return r.execLauncher(i, "restart", true /* background */)
+}
+
+// Get queries the given node's HTTP endpoint for the given path, unmarshaling
+// into the supplied interface (or returning an error).
+func (r *RemoteCluster) Get(i int, path string, v interface{}) error {
+	return getJSON(false /* !tls */, util.EnsureHostPort(r.nodes[i].Addr), path, v)
+}

--- a/acceptance/cluster/ssh.go
+++ b/acceptance/cluster/ssh.go
@@ -1,0 +1,70 @@
+// Copyright 2015 The Cockroach Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+// implied. See the License for the specific language governing
+// permissions and limitations under the License. See the AUTHORS file
+// for names of contributors.
+//
+// Author: Tobias Schottdorf
+
+package cluster
+
+import (
+	"bytes"
+	"io/ioutil"
+
+	"golang.org/x/crypto/ssh"
+)
+
+func loadKey(file string) (ssh.AuthMethod, error) {
+	buffer, err := ioutil.ReadFile(file)
+	if err != nil {
+		return nil, err
+	}
+
+	key, err := ssh.ParsePrivateKey(buffer)
+	if err != nil {
+		return nil, err
+	}
+	return ssh.PublicKeys(key), nil
+}
+
+func execute(user, hostport, keyfile, cmd string) (stdout string, stderr string, _ error) {
+	keyAuth, err := loadKey(keyfile)
+	if err != nil {
+		return "", "", err
+	}
+	sshConfig := &ssh.ClientConfig{
+		User: user,
+		Auth: []ssh.AuthMethod{keyAuth},
+	}
+
+	conn, err := ssh.Dial("tcp", hostport, sshConfig)
+	if err != nil {
+		return "", "", err
+	}
+	defer func() {
+		_ = conn.Close()
+	}()
+	session, err := conn.NewSession()
+	if err != nil {
+		return "", "", err
+	}
+	defer func() {
+		_ = session.Close()
+	}()
+
+	var errBuf, outBuf bytes.Buffer
+	session.Stdout = &outBuf
+	session.Stderr = &errBuf
+	err = session.Run(cmd)
+	return outBuf.String(), errBuf.String(), err
+}

--- a/acceptance/run.sh
+++ b/acceptance/run.sh
@@ -6,4 +6,4 @@ source $(dirname $0)/../build/init-docker.sh
 $(dirname $0)/../build/builder.sh make install
 
 set -x
-go test -tags acceptance ./acceptance ${GOFLAGS-} -run "${TESTS-.*}" -timeout ${TESTTIMEOUT-5m} ${TESTFLAGS--v}
+go test -tags acceptance ./acceptance ${GOFLAGS-} -run "${TESTS-.}" -timeout ${TESTTIMEOUT-5m} ${TESTFLAGS--v -num 3}


### PR DESCRIPTION
requires https://github.com/cockroachdb/cockroach-prod/pull/50

```
add basic RemoteCluster capability

adds the -peers flag which, if set to a comma-delimited
list of hosts, instructs the acceptance test to run
against a remote cluster.

killing/restarting nodes has basic support so that simple
tests will run:

go test ./acceptance -tags acceptance -run Gossip -v \
  -peers ec2-54-208-144-192.compute-1.amazonaws.com
go test ./acceptance -tags acceptance -run TestPut -v \
  -peers ec2-54-208-144-192.compute-1.amazonaws.com

where the host above was created by
`terraform apply --var=num_instances=1 --var=action="init"`.

Events are unsupported so far.
```

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/3229)

<!-- Reviewable:end -->
