### PR TITLE
sql/pgwire: reduce allocations by reusing a buffer

### DIFF
--- a/sql/pgwire/encoding.go
+++ b/sql/pgwire/encoding.go
@@ -39,28 +39,9 @@ type bufferedReader interface {
 }
 
 type readBuffer struct {
-	msg []byte
-	tmp [4]byte
-}
-
-// reset sets b.msg to exactly size, attempting to use spare capacity
-// at the end of the existing slice when possible and allocating a new
-// slice when necessary.
-func (b *readBuffer) reset(size int) {
-	if b.msg != nil {
-		b.msg = b.msg[len(b.msg):]
-	}
-
-	if cap(b.msg) >= size {
-		b.msg = b.msg[:size]
-		return
-	}
-
-	allocSize := size
-	if allocSize < 4096 {
-		allocSize = 4096
-	}
-	b.msg = make([]byte, size, allocSize)
+	msg    []byte
+	msgBuf []byte
+	tmp    [4]byte
 }
 
 // readMsg reads a length-prefixed message. It is only used directly
@@ -78,7 +59,11 @@ func (b *readBuffer) readUntypedMsg(rd io.Reader) error {
 			size, maxMessageSize)
 	}
 
-	b.reset(size)
+	if len(b.msgBuf) < size {
+		b.msgBuf = make([]byte, size)
+	}
+
+	b.msg = b.msgBuf[:size]
 	_, err := io.ReadFull(rd, b.msg)
 	return err
 }


### PR DESCRIPTION
This doesn't show up in our existing benchmarks because they don't issue enough queries.

cc @bdarnell

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/3240)

<!-- Reviewable:end -->
