### PR TITLE
WIP:Async snapshot

### DIFF
--- a/multiraft/events.go
+++ b/multiraft/events.go
@@ -61,6 +61,14 @@ type EventMembershipChangeCommitted struct {
 	Callback func(error)
 }
 
+// An EventSnapshot is broadcast whenever a snapshot message coming.
+type EventSnapshot struct {
+	GroupID  roachpb.RangeID
+	Snapshot raftpb.Snapshot
+	// Callback should be invoked when snapshot have been applied.
+	Callback func()
+}
+
 // Commands are encoded with a 1-byte version (currently 0), a 16-byte ID,
 // followed by the payload. This inflexible encoding is used so we can efficiently
 // parse the command id while processing the logs.

--- a/multiraft/rpc.go
+++ b/multiraft/rpc.go
@@ -20,9 +20,16 @@ package multiraft
 import "github.com/cockroachdb/cockroach/security"
 
 var _ security.RequestWithUser = &RaftMessageRequest{}
+var _ security.RequestWithUser = &MultiPackageMessageRequest{}
 
 // GetUser implements security.RequestWithUser.
 // Raft messages are always sent by the node user.
 func (*RaftMessageRequest) GetUser() string {
+	return security.NodeUser
+}
+
+// GetUser implements security.RequestWithUser.
+// Multi-Package messages are always sent by the node user.
+func (*MultiPackageMessageRequest) GetUser() string {
 	return security.NodeUser
 }

--- a/multiraft/rpc.proto
+++ b/multiraft/rpc.proto
@@ -53,3 +53,15 @@ message ConfChangeContext {
   // Replica contains full details about the replica being added or removed.
   optional roachpb.ReplicaDescriptor replica = 3 [(gogoproto.nullable) = false];
 }
+
+// MultiPackageMessageRequest is the request used to send snapshot messages splited into multi-package using our
+// protobuf-based RPC codec.
+message MultiPackageMessageRequest {
+  required uint64 group_id = 1 [(gogoproto.nullable) = false,
+      (gogoproto.customname) = "GroupID",
+      (gogoproto.casttype) = "github.com/cockroachdb/cockroach/roachpb.RangeID"];
+
+  // package id from 0 to int_max, -1 means the last package.
+  optional int32 package_id = 2 [(gogoproto.nullable) = false];
+  optional bytes raw_bytes = 3;
+}

--- a/multiraft/storage_test.go
+++ b/multiraft/storage_test.go
@@ -75,11 +75,6 @@ func (b *blockableGroupStorage) Append(entries []raftpb.Entry) error {
 	return b.s.Append(entries)
 }
 
-func (b *blockableGroupStorage) ApplySnapshot(snap raftpb.Snapshot) error {
-	b.b.wait()
-	return b.s.ApplySnapshot(snap)
-}
-
 func (b *blockableGroupStorage) SetHardState(st raftpb.HardState) error {
 	b.b.wait()
 	return b.s.SetHardState(st)

--- a/rpc/client.go
+++ b/rpc/client.go
@@ -92,6 +92,7 @@ type Client struct {
 	clock        *hlc.Clock
 	remoteClocks *RemoteClockMonitor
 	remoteOffset RemoteOffset
+	ctx          *Context
 }
 
 // NewClient returns a client RPC stub for the specified address
@@ -131,6 +132,7 @@ func NewClient(addr net.Addr, context *Context) *Client {
 		tlsConfig:    tlsConfig,
 		clock:        context.localClock,
 		remoteClocks: context.RemoteClocks,
+		ctx:          context,
 	}
 
 	c.healthy.Store(make(chan struct{}))
@@ -243,7 +245,9 @@ func (c *Client) close() {
 	case <-c.closer:
 	case <-c.Closed:
 	default:
-		delete(clients, c.key)
+		if !c.ctx.DisableCache {
+			delete(clients, c.key)
+		}
 		close(c.closer)
 	}
 }

--- a/storage/client_raft_test.go
+++ b/storage/client_raft_test.go
@@ -1021,6 +1021,9 @@ func TestRangeDescriptorSnapshotRace(t *testing.T) {
 				}
 				_, err := rng.Snapshot()
 				if err != nil {
+					if err == raft.ErrSnapshotTemporarilyUnavailable {
+						continue
+					}
 					t.Fatalf("failed to snapshot min range: %s", err)
 				}
 
@@ -1030,6 +1033,9 @@ func TestRangeDescriptorSnapshotRace(t *testing.T) {
 				}
 				_, err = rng.Snapshot()
 				if err != nil {
+					if err == raft.ErrSnapshotTemporarilyUnavailable {
+						continue
+					}
 					t.Fatalf("failed to snapshot max range: %s", err)
 				}
 			}

--- a/storage/replica.go
+++ b/storage/replica.go
@@ -44,6 +44,7 @@ import (
 	"github.com/cockroachdb/cockroach/util/encoding"
 	"github.com/cockroachdb/cockroach/util/log"
 	"github.com/cockroachdb/cockroach/util/tracer"
+	"github.com/coreos/etcd/raft/raftpb"
 	"github.com/gogo/protobuf/proto"
 )
 
@@ -137,6 +138,11 @@ type pendingCmd struct {
 	done chan roachpb.ResponseWithError // Used to signal waiting RPC handler
 }
 
+type snapshotData struct {
+	snapshot raftpb.Snapshot
+	err      error
+}
+
 type cmdIDKey string
 
 // A Replica is a contiguous keyspace with writes managed via an
@@ -186,6 +192,11 @@ type Replica struct {
 		value roachpb.ReplicaDescriptor
 	}
 	truncatedState unsafe.Pointer // *roachpb.RaftTruncatedState
+
+	snapshotData    chan snapshotData
+	snapshotLock    sync.Mutex
+	pendingSnapshot bool
+	finishSnapshot  bool
 }
 
 var _ client.Sender = &Replica{}
@@ -201,6 +212,9 @@ func NewReplica(desc *roachpb.RangeDescriptor, store *Store) (*Replica, error) {
 	}
 	r.pendingReplica.Cond = sync.NewCond(r)
 	r.setDescWithoutProcessUpdate(desc)
+	r.snapshotData = make(chan snapshotData, 1)
+	r.pendingSnapshot = false
+	r.finishSnapshot = false
 
 	lastIndex, err := r.loadLastIndex()
 	if err != nil {


### PR DESCRIPTION
@bdarnell @tamird 
As #3013 issue we discussed. I make generate snapshot, transport snapshot and apply snapshot asynchronous.

generate: Etcd had already modify Snapshot() interface, add a special error ErrSnapshotTemporarilyUnavailable to represent that replica is generating snapshot. 
transport: Start a new standalone connection to transport snapshot, separate from others.
apply: move apply snapshot from writetask to processRaft, it will not block multiraft goroutine to handle heartbeat.

But there are also some problem. When state.handleMessage receive a MsgSnap, I will make a mark "pendingsnapshot" until apply snapshot finish. During this period, all message will be ignored except heartbeat. But in etcd, it will ignore MsgSnap in some condition without any error or notify returned. So I can not get this situation to remark.
Another problem is even if we send snapshot by standalone rpc connection, but the rpc heartbeat will be timeout if sending time over 6s.

Do you have some better solution?

```
func (r *raft) handleSnapshot(m pb.Message) {
        sindex, sterm := m.Snapshot.Metadata.Index, m.Snapshot.Metadata.Term
        if r.restore(m.Snapshot) {
                r.logger.Warningf("%x [commit: %d] restored snapshot [index: %d, term: %d]",
                        r.id, r.Commit, sindex, sterm)
                r.send(pb.Message{To: m.From, Type: pb.MsgAppResp, Index: r.raftLog.lastIndex()})
        } else {
                r.logger.Warningf("%x [commit: %d] ignored snapshot [index: %d, term: %d]",
                        r.id, r.Commit, sindex, sterm)
                r.send(pb.Message{To: m.From, Type: pb.MsgAppResp, Index: r.raftLog.committed})
        }
```

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/3241)

<!-- Reviewable:end -->
