### PR TITLE
Make constants for test timeouts

### DIFF
--- a/kv/split_test.go
+++ b/kv/split_test.go
@@ -36,6 +36,8 @@ import (
 	"github.com/cockroachdb/cockroach/util/retry"
 )
 
+const cleanMVCCScanTimeout = 500 * time.Millisecond
+
 // setTestRetryOptions sets client retry options for speedier testing.
 func setTestRetryOptions() {
 	client.DefaultTxnRetryOptions = retry.Options{
@@ -119,7 +121,7 @@ func TestRangeSplitMeta(t *testing.T) {
 			return false
 		}
 		return true
-	}, 500*time.Millisecond); err != nil {
+	}, cleanMVCCScanTimeout); err != nil {
 		t.Error("failed to verify no dangling intents within 500ms")
 	}
 }
@@ -218,7 +220,7 @@ func TestRangeSplitsWithWritePressure(t *testing.T) {
 			return false
 		}
 		return true
-	}, 500*time.Millisecond); err != nil {
+	}, cleanMVCCScanTimeout); err != nil {
 		t.Error("failed to verify no dangling intents within 500ms")
 	}
 }

--- a/sql/split_test.go
+++ b/sql/split_test.go
@@ -30,6 +30,8 @@ import (
 	"github.com/cockroachdb/cockroach/util/leaktest"
 )
 
+const rangeSplitTimeout = 10 * time.Second
+
 // getFastScanContext returns a test context with fast scan.
 func getFastScanContext() *server.Context {
 	c := server.NewTestContext()
@@ -98,7 +100,7 @@ func TestSplitOnTableBoundaries(t *testing.T) {
 			t.Fatalf("failed to retrieve range list: %s", err)
 		}
 		return num == 2
-	}, 10*time.Second); err != nil {
+	}, rangeSplitTimeout); err != nil {
 		t.Errorf("missing split: %s", err)
 	}
 
@@ -125,7 +127,7 @@ func TestSplitOnTableBoundaries(t *testing.T) {
 		}
 		t.Logf("Num ranges: %d", num)
 		return num == 3
-	}, 10*time.Second); err != nil {
+	}, rangeSplitTimeout); err != nil {
 		t.Errorf("missing split: %s", err)
 	}
 

--- a/storage/client_raft_test.go
+++ b/storage/client_raft_test.go
@@ -45,6 +45,8 @@ import (
 	"github.com/coreos/etcd/raft/raftpb"
 )
 
+const replicaReadTimeout = 1 * time.Second
+
 // mustGetInt decodes an int64 value from the bytes field of the receiver
 // and panics if the bytes field is not 0 or 8 bytes in length.
 func mustGetInt(v *roachpb.Value) int64 {
@@ -260,7 +262,7 @@ func TestReplicateRange(t *testing.T) {
 	})
 
 	// Verify that the same data is available on the replica.
-	util.SucceedsWithin(t, 1*time.Second, func() error {
+	util.SucceedsWithin(t, replicaReadTimeout, func() error {
 		getArgs := getArgs([]byte("a"))
 		if reply, err := client.SendWrappedWith(rg1(mtc.stores[1]), nil, roachpb.Header{
 			ReadConsistency: roachpb.INCONSISTENT,
@@ -341,7 +343,7 @@ func TestRestoreReplicas(t *testing.T) {
 			return false
 		}
 		return mustGetInt(reply.(*roachpb.GetResponse).Value) == 39
-	}, 1*time.Second); err != nil {
+	}, replicaReadTimeout); err != nil {
 		t.Fatal(err)
 	}
 
@@ -501,7 +503,7 @@ func TestReplicateAfterTruncation(t *testing.T) {
 			log.Infof("read value %d", mustGetInt(getResp.Value))
 		}
 		return mustGetInt(getResp.Value) == 16
-	}, 1*time.Second); err != nil {
+	}, replicaReadTimeout); err != nil {
 		t.Fatal(err)
 	}
 
@@ -531,7 +533,7 @@ func TestReplicateAfterTruncation(t *testing.T) {
 		getResp := reply.(*roachpb.GetResponse)
 		log.Infof("read value %d", mustGetInt(getResp.Value))
 		return mustGetInt(getResp.Value) == 39
-	}, 1*time.Second); err != nil {
+	}, replicaReadTimeout); err != nil {
 		t.Fatal(err)
 	}
 }
@@ -565,7 +567,7 @@ func TestStoreRangeUpReplicate(t *testing.T) {
 			}
 		}
 		return true
-	}, 3*time.Second); err != nil {
+	}, replicationTimeout); err != nil {
 		t.Fatal(err)
 	}
 }
@@ -996,7 +998,7 @@ func TestReplicateAfterSplit(t *testing.T) {
 			log.Infof("read value %d", mustGetInt(getResp.Value))
 		}
 		return mustGetInt(getResp.Value) == 11
-	}, 1*time.Second); err != nil {
+	}, replicaReadTimeout); err != nil {
 		t.Fatal(err)
 	}
 }

--- a/storage/client_test.go
+++ b/storage/client_test.go
@@ -55,6 +55,8 @@ import (
 	"github.com/gogo/protobuf/proto"
 )
 
+const replicationTimeout = 3 * time.Second
+
 // Check that Stores implements the RangeDescriptorDB interface.
 var _ kv.RangeDescriptorDB = &storage.Stores{}
 
@@ -504,7 +506,7 @@ func (m *multiTestContext) replicateRange(rangeID roachpb.RangeID, sourceStoreIn
 	}
 
 	// Wait for the replication to complete on all destination nodes.
-	util.SucceedsWithin(m.t, 3*time.Second, func() error {
+	util.SucceedsWithin(m.t, replicationTimeout, func() error {
 		for _, dest := range dests {
 			// Use LookupRange(keys) instead of GetRange(rangeID) to ensure that the
 			// snapshot has been transferred and the descriptor initialized.

--- a/storage/queue_test.go
+++ b/storage/queue_test.go
@@ -35,6 +35,8 @@ import (
 	"github.com/cockroachdb/cockroach/util/stop"
 )
 
+const queueItemProcessTimeout = 250 * time.Millisecond
+
 func gossipForTest(t *testing.T) (*gossip.Gossip, *stop.Stopper) {
 	stopper := stop.NewStopper()
 
@@ -285,14 +287,14 @@ func TestBaseQueueProcess(t *testing.T) {
 	testQueue.blocker <- struct{}{}
 	if err := util.IsTrueWithin(func() bool {
 		return atomic.LoadInt32(&testQueue.processed) == 1
-	}, 250*time.Millisecond); err != nil {
+	}, queueItemProcessTimeout); err != nil {
 		t.Error(err)
 	}
 
 	testQueue.blocker <- struct{}{}
 	if err := util.IsTrueWithin(func() bool {
 		return atomic.LoadInt32(&testQueue.processed) >= 2
-	}, 250*time.Millisecond); err != nil {
+	}, queueItemProcessTimeout); err != nil {
 		t.Error(err)
 	}
 }
@@ -399,7 +401,7 @@ func TestAcceptsUnsplitRanges(t *testing.T) {
 
 	if err := util.IsTrueWithin(func() bool {
 		return atomic.LoadInt32(&testQueue.processed) == 2
-	}, 250*time.Millisecond); err != nil {
+	}, queueItemProcessTimeout); err != nil {
 		t.Error(err)
 	}
 
@@ -425,7 +427,7 @@ func TestAcceptsUnsplitRanges(t *testing.T) {
 
 	if err := util.IsTrueWithin(func() bool {
 		return atomic.LoadInt32(&testQueue.processed) == 3
-	}, 250*time.Millisecond); err != nil {
+	}, queueItemProcessTimeout); err != nil {
 		t.Error(err)
 	}
 

--- a/storage/replica_test.go
+++ b/storage/replica_test.go
@@ -49,6 +49,8 @@ import (
 	"github.com/gogo/protobuf/proto"
 )
 
+const runUnmarshalCallbackTimeout = 100 * time.Millisecond
+
 func testRangeDescriptor() *roachpb.RangeDescriptor {
 	return &roachpb.RangeDescriptor{
 		RangeID:  1,
@@ -206,10 +208,9 @@ func (tc *testContext) initConfigs(realRange bool) error {
 		return err
 	}
 
-	// Wait for the unmarshalling callback to run.
 	if err := util.IsTrueWithin(func() bool {
 		return tc.gossip.GetSystemConfig() != nil
-	}, 100*time.Millisecond); err != nil {
+	}, runUnmarshalCallbackTimeout); err != nil {
 		return err
 	}
 
@@ -598,7 +599,7 @@ func TestRangeGossipConfigsOnLease(t *testing.T) {
 			}
 			numValues := len(cfg.Values)
 			return numValues == 1 && cfg.Values[numValues-1].Key.Equal(key)
-		}, 100*time.Millisecond) == nil
+		}, runUnmarshalCallbackTimeout) == nil
 	}
 
 	// If this actually failed, we would have gossiped from MVCCPutProto.


### PR DESCRIPTION
Add the following timeout constants:
- cleanMVCCScanTimeout
- rangeSplitTimeout
- replicaReadTimeout
- replicationTimeout
- queueItemProcessTimeout
- runUnmarshalCallbackTimeout

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/3242)

<!-- Reviewable:end -->
