### PR TITLE
quickly refresh table lease to the latest version

### DIFF
--- a/server/server.go
+++ b/server/server.go
@@ -140,7 +140,9 @@ func NewServer(ctx *Context, stopper *stop.Stopper) (*Server, error) {
 		return nil, err
 	}
 
-	s.sqlServer = sql.MakeServer(&s.ctx.Context, *s.db, s.gossip, s.clock)
+	leaseMgr := sql.NewLeaseManager(0, *s.db, s.clock)
+	leaseMgr.RefreshLeases(s.stopper, s.db, s.gossip)
+	s.sqlServer = sql.MakeServer(&s.ctx.Context, *s.db, s.gossip, leaseMgr)
 	if err := s.sqlServer.RegisterRPC(s.rpc); err != nil {
 		return nil, err
 	}

--- a/sql/executor.go
+++ b/sql/executor.go
@@ -34,7 +34,6 @@ import (
 	"github.com/cockroachdb/cockroach/sql/driver"
 	"github.com/cockroachdb/cockroach/sql/parser"
 	"github.com/cockroachdb/cockroach/util"
-	"github.com/cockroachdb/cockroach/util/hlc"
 	"github.com/cockroachdb/cockroach/util/log"
 )
 
@@ -77,11 +76,11 @@ type Executor struct {
 
 // newExecutor creates an Executor and registers a callback on the
 // system config.
-func newExecutor(db client.DB, gossip *gossip.Gossip, clock *hlc.Clock) *Executor {
+func newExecutor(db client.DB, gossip *gossip.Gossip, leaseMgr *LeaseManager) *Executor {
 	exec := &Executor{
 		db:       db,
 		reCache:  parser.NewRegexpCache(512),
-		leaseMgr: NewLeaseManager(0, db, clock),
+		leaseMgr: leaseMgr,
 	}
 	exec.systemConfigCond = sync.NewCond(&exec.systemConfigMu)
 	gossip.RegisterSystemConfigCallback(exec.updateSystemConfig)

--- a/sql/server.go
+++ b/sql/server.go
@@ -30,7 +30,6 @@ import (
 	"github.com/cockroachdb/cockroach/security"
 	"github.com/cockroachdb/cockroach/sql/driver"
 	"github.com/cockroachdb/cockroach/util"
-	"github.com/cockroachdb/cockroach/util/hlc"
 	"github.com/gogo/protobuf/proto"
 )
 
@@ -44,8 +43,8 @@ type Server struct {
 }
 
 // MakeServer creates a Server.
-func MakeServer(ctx *base.Context, db client.DB, gossip *gossip.Gossip, clock *hlc.Clock) Server {
-	return Server{context: ctx, Executor: newExecutor(db, gossip, clock)}
+func MakeServer(ctx *base.Context, db client.DB, gossip *gossip.Gossip, leaseMgr *LeaseManager) Server {
+	return Server{context: ctx, Executor: newExecutor(db, gossip, leaseMgr)}
 }
 
 // ServeHTTP serves the SQL API by treating the request URL path


### PR DESCRIPTION
Use the gossip of the system config to discover a new version of a
table, and reacquire a new lease on the table.

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/3243)

<!-- Reviewable:end -->
