### PR TITLE
execute replica command parallely

### DIFF
--- a/storage/store.go
+++ b/storage/store.go
@@ -1602,10 +1602,7 @@ func (s *Store) processRaft() {
 							groupID, cmd)
 						log.Error(err)
 					} else {
-						err = r.processRaftCommand(cmdIDKey(commandID), index, cmd)
-					}
-					if callback != nil {
-						callback(err)
+						r.addApplyQueue(cmdIDKey(commandID), index, cmd, callback)
 					}
 				}
 


### PR DESCRIPTION
we can execute replica command concurrency for better performance, no necessary all replicas in the store are executing in order.

I benchmark it on my server. 100 ranges split with 1~100, 100 clients insert random number key and value size is 10K. The result is below:

before modify:

```
total time(seconds): 26.001469
tps: 3545.936589
```

after modify

```
total time(seconds): 23.027841
tps: 4342.569445
```

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/3244)

<!-- Reviewable:end -->
