### PR TITLE
Tweak zone command.

### DIFF
--- a/cli/cli.go
+++ b/cli/cli.go
@@ -19,7 +19,6 @@ package cli
 
 import (
 	"fmt"
-	"io"
 	"os"
 	"strings"
 	"text/tabwriter"
@@ -31,7 +30,6 @@ import (
 
 // Proxies to allow overrides in tests.
 var osExit = os.Exit
-var osStdout = io.Writer(os.Stdout)
 var osStderr = os.Stderr
 
 var versionCmd = &cobra.Command{

--- a/cli/cli_test.go
+++ b/cli/cli_test.go
@@ -55,7 +55,10 @@ func newCLITest() cliTest {
 
 func (c cliTest) Run(line string) {
 	a := strings.Fields(line)
+	c.RunWithArgs(a)
+}
 
+func (c cliTest) RunWithArgs(a []string) {
 	var args []string
 	args = append(args, a[0])
 	args = append(args, fmt.Sprintf("--addr=%s", c.ServingAddr()))
@@ -64,7 +67,7 @@ func (c cliTest) Run(line string) {
 	args = append(args, a[1:]...)
 
 	fmt.Fprintf(os.Stderr, "%s\n", args)
-	fmt.Println(line)
+	fmt.Println(strings.Join(a, " "))
 	if err := Run(args); err != nil {
 		fmt.Println(err)
 	}
@@ -362,6 +365,59 @@ func Example_max_results() {
 	// node drained and shutdown: ok
 }
 */
+
+func Example_zone() {
+	c := newCLITest()
+
+	zone100 := `replicas:
+- attrs: [us-east-1a,ssd]
+- attrs: [us-east-1b,ssd]
+- attrs: [us-west-1b,ssd]
+range_min_bytes: 8388608
+range_max_bytes: 67108864
+`
+	c.Run("zone ls")
+	// Call RunWithArgs to bypass the "split-by-whitespace" arg builder.
+	c.RunWithArgs([]string{"zone", "set", "100", zone100})
+	c.Run("zone ls")
+	c.Run("zone get 100")
+	c.Run("zone rm 100")
+	c.Run("zone ls")
+	c.Run("quit")
+
+	// Output:
+	// zone ls
+	// zone set 100 replicas:
+	// - attrs: [us-east-1a,ssd]
+	// - attrs: [us-east-1b,ssd]
+	// - attrs: [us-west-1b,ssd]
+	// range_min_bytes: 8388608
+	// range_max_bytes: 67108864
+	//
+	// OK
+	// zone ls
+	// Object 100:
+	// replicas:
+	// - attrs: [us-east-1a, ssd]
+	// - attrs: [us-east-1b, ssd]
+	// - attrs: [us-west-1b, ssd]
+	// range_min_bytes: 8388608
+	// range_max_bytes: 67108864
+	//
+	// zone get 100
+	// replicas:
+	// - attrs: [us-east-1a, ssd]
+	// - attrs: [us-east-1b, ssd]
+	// - attrs: [us-west-1b, ssd]
+	// range_min_bytes: 8388608
+	// range_max_bytes: 67108864
+	//
+	// zone rm 100
+	// OK
+	// zone ls
+	// quit
+	// node drained and shutdown: ok
+}
 
 // TestFlagUsage is a basic test to make sure the fragile
 // help template does not break.

--- a/cli/sql.go
+++ b/cli/sql.go
@@ -20,6 +20,7 @@ package cli
 import (
 	"fmt"
 	"io"
+	"os"
 	"strings"
 
 	"github.com/peterh/liner"
@@ -50,13 +51,14 @@ func runTerm(cmd *cobra.Command, args []string) {
 	}
 
 	db := makeSQLClient()
+	defer func() { _ = db.Close() }()
 
 	liner := liner.NewLiner()
 	defer func() {
 		_ = liner.Close()
 	}()
 
-	fmt.Fprint(osStdout, infoMessage)
+	fmt.Print(infoMessage)
 
 	// Default prompt is "hostname> "
 	// continued statement prompt it: "        -> "
@@ -111,8 +113,8 @@ func runTerm(cmd *cobra.Command, args []string) {
 		fullStmt := strings.Join(stmt, "\n")
 		liner.AppendHistory(fullStmt)
 
-		if err := runPrettyQuery(db, fullStmt); err != nil {
-			fmt.Fprintln(osStdout, err)
+		if err := runPrettyQuery(db, os.Stdout, fullStmt); err != nil {
+			fmt.Println(err)
 		}
 
 		// Clear the saved statement.

--- a/cli/user.go
+++ b/cli/user.go
@@ -18,6 +18,8 @@
 package cli
 
 import (
+	"os"
+
 	"github.com/cockroachdb/cockroach/security"
 	"github.com/cockroachdb/cockroach/util/log"
 
@@ -40,7 +42,8 @@ func runGetUser(cmd *cobra.Command, args []string) {
 		return
 	}
 	db := makeSQLClient()
-	err := runPrettyQuery(db, `SELECT * FROM system.users WHERE username=$1`, args[0])
+	defer func() { _ = db.Close() }()
+	err := runPrettyQuery(db, os.Stdout, `SELECT * FROM system.users WHERE username=$1`, args[0])
 	if err != nil {
 		log.Error(err)
 		return
@@ -63,7 +66,8 @@ func runLsUsers(cmd *cobra.Command, args []string) {
 		return
 	}
 	db := makeSQLClient()
-	err := runPrettyQuery(db, `SELECT username FROM system.users`)
+	defer func() { _ = db.Close() }()
+	err := runPrettyQuery(db, os.Stdout, `SELECT username FROM system.users`)
 	if err != nil {
 		log.Error(err)
 		return
@@ -86,7 +90,8 @@ func runRmUser(cmd *cobra.Command, args []string) {
 		return
 	}
 	db := makeSQLClient()
-	err := runPrettyQuery(db, `DELETE FROM system.users WHERE username=$1`, args[0])
+	defer func() { _ = db.Close() }()
+	err := runPrettyQuery(db, os.Stdout, `DELETE FROM system.users WHERE username=$1`, args[0])
 	if err != nil {
 		log.Error(err)
 		return
@@ -119,8 +124,9 @@ func runSetUser(cmd *cobra.Command, args []string) {
 		return
 	}
 	db := makeSQLClient()
+	defer func() { _ = db.Close() }()
 	// TODO(marc): switch to UPSERT.
-	err = runPrettyQuery(db, `INSERT INTO system.users VALUES ($1, $2)`, args[0], hashed)
+	err = runPrettyQuery(db, os.Stdout, `INSERT INTO system.users VALUES ($1, $2)`, args[0], hashed)
 	if err != nil {
 		log.Error(err)
 		return


### PR DESCRIPTION
Fixes #3235
- column type is bytes, not string
- take input from stdin, a file was making it too annoying to test.
- adjusted help message, including a full invocation
- add basic example to ls/set/get/rm

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/3249)

<!-- Reviewable:end -->
