### PR TITLE
fix rpc block when net partitioned

### DIFF
--- a/rpc/client.go
+++ b/rpc/client.go
@@ -294,14 +294,15 @@ func (c *Client) heartbeat(closer <-chan struct{}) error {
 	response := &PingResponse{}
 	sendTime := c.clock.PhysicalNow()
 
-	call := c.Go("Heartbeat.Ping", request, response, nil)
+	done := make(chan *rpc.Call, 1)
+	go c.Go("Heartbeat.Ping", request, response, done)
 
 	select {
 	case <-closer:
 		return errClosed
 	case <-c.closer:
 		return errClosed
-	case <-call.Done:
+	case call := <-done:
 		if err := call.Error; err != nil {
 			return err
 		}


### PR DESCRIPTION
fix: when the net partitioned, rpc client will be blocked to send `Heartbeat.Ping`, so change to send heartbeat asynchronously

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/3250)

<!-- Reviewable:end -->
