### PR TITLE
increase timeout for TestStoreZoneUpdateAndRangeSplit

### DIFF
--- a/storage/client_split_test.go
+++ b/storage/client_split_test.go
@@ -466,7 +466,7 @@ func TestStoreZoneUpdateAndRangeSplit(t *testing.T) {
 	if err := util.IsTrueWithin(func() bool {
 		rng = store.LookupReplica(keys.MakeTablePrefix(1000), nil)
 		return rng.Desc().RangeID != originalRange.Desc().RangeID
-	}, 50*time.Millisecond); err != nil {
+	}, time.Second); err != nil {
 		t.Fatalf("failed to notice range max bytes update: %s", err)
 	}
 
@@ -483,12 +483,13 @@ func TestStoreZoneUpdateAndRangeSplit(t *testing.T) {
 	// Look in the range after prefix we're writing to.
 	fillRange(store, rng.Desc().RangeID, keys.MakeTablePrefix(1000), maxBytes, t)
 
-	// Verify that the range is in fact split (give it a second for very slow test machines).
+	// Verify that the range is in fact split (give it a few seconds for very
+	// slow test machines).
 	var newRng *storage.Replica
 	if err := util.IsTrueWithin(func() bool {
 		newRng = store.LookupReplica(keys.MakeTablePrefix(2000), nil)
 		return newRng.Desc().RangeID != rng.Desc().RangeID
-	}, time.Second); err != nil {
+	}, 5*time.Second); err != nil {
 		t.Errorf("expected range to split within 1s")
 	}
 


### PR DESCRIPTION
can't reproduce this locally, so maybe just CI slowness. Only one way to find out.

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/3255)

<!-- Reviewable:end -->
