### PR TITLE
fix up caller to work with coverage tests

### DIFF
--- a/sql/lease_test.go
+++ b/sql/lease_test.go
@@ -191,7 +191,7 @@ func TestLeaseManager(testingT *testing.T) {
 
 	// It is an error to acquire a lease for an old version once a new version
 	// exists and there are no local references for the old version.
-	expected = "sql/lease.go.*: table .* unable to acquire lease on old version: 1 < 2"
+	expected = "lease.go.*: table .* unable to acquire lease on old version: 1 < 2"
 	if _, err := t.acquire(1, descID, 1); !testutils.IsError(err, expected) {
 		t.Fatalf("expected %s, but found %v", expected, err)
 	}


### PR DESCRIPTION
without these changes,

```
go test -v -covermode=count ./sql
go test -v -covermode=count ./util...
```

fail.

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/3256)

<!-- Reviewable:end -->
