### PR TITLE
sql/parser: allocate more precisely

### DIFF
--- a/sql/parser/builtins.go
+++ b/sql/parser/builtins.go
@@ -294,7 +294,7 @@ var builtins = map[string][]builtin{
 
 	"translate": {stringBuiltin3(func(s, from, to string) (Datum, error) {
 		const deletionRune = utf8.MaxRune + 1
-		translation := make(map[rune]rune, len(from))
+		translation := make(map[rune]rune, utf8.RuneCountInString(from))
 		for _, fromRune := range from {
 			toRune, size := utf8.DecodeRuneInString(to)
 			if toRune == utf8.RuneError {
@@ -305,7 +305,7 @@ var builtins = map[string][]builtin{
 			translation[fromRune] = toRune
 		}
 
-		runes := make([]rune, 0, len(s))
+		runes := make([]rune, 0, utf8.RuneCountInString(s))
 		for _, c := range s {
 			if t, ok := translation[c]; ok {
 				if t != deletionRune {


### PR DESCRIPTION
This is not a clear win, because `utf8.RuneCountInString` is O(n).

Found in the graveyard.

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/3260)

<!-- Reviewable:end -->
