### PR TITLE
Fix pgwire.Server to properly remove closed connections.

### DIFF
--- a/server/server.go
+++ b/server/server.go
@@ -70,7 +70,7 @@ type Server struct {
 	db            *client.DB
 	kvDB          *kv.DBServer
 	sqlServer     sql.Server
-	pgServer      pgwire.Server
+	pgServer      *pgwire.Server
 	node          *Node
 	recorder      *status.NodeStatusRecorder
 	admin         *adminServer

--- a/sql/bench_test.go
+++ b/sql/bench_test.go
@@ -18,6 +18,7 @@
 package sql_test
 
 import (
+	"bytes"
 	"database/sql"
 	"fmt"
 	"net"
@@ -28,6 +29,57 @@ import (
 
 	"github.com/cockroachdb/cockroach/server"
 )
+
+func benchmarkCockroach(b *testing.B, f func(b *testing.B, db *sql.DB)) {
+	s := server.StartTestServer(b)
+	defer s.Stop()
+
+	host, port, err := net.SplitHostPort(s.PGAddr())
+	if err != nil {
+		b.Fatal(err)
+	}
+	datasource := fmt.Sprintf("sslmode=disable user=root host=%s port=%s", host, port)
+
+	db, err := sql.Open("postgres", datasource)
+	if err != nil {
+		b.Fatal(err)
+	}
+	defer db.Close()
+
+	if _, err := db.Exec(`CREATE DATABASE IF NOT EXISTS bench`); err != nil {
+		b.Fatal(err)
+	}
+
+	f(b, db)
+}
+
+func benchmarkPostgres(b *testing.B, f func(b *testing.B, db *sql.DB)) {
+	db, err := sql.Open("postgres", "sslmode=disable host=localhost port=5432")
+	if err != nil {
+		b.Fatal(err)
+	}
+	defer db.Close()
+
+	if _, err := db.Exec(`CREATE SCHEMA IF NOT EXISTS bench`); err != nil {
+		b.Fatal(err)
+	}
+
+	f(b, db)
+}
+
+func benchmarkMySQL(b *testing.B, f func(b *testing.B, db *sql.DB)) {
+	db, err := sql.Open("mysql", "root@tcp(localhost:3306)/")
+	if err != nil {
+		b.Fatal(err)
+	}
+	defer db.Close()
+
+	if _, err := db.Exec(`CREATE DATABASE IF NOT EXISTS bench`); err != nil {
+		b.Fatal(err)
+	}
+
+	f(b, db)
+}
 
 func runBenchmarkSelect1(b *testing.B, db *sql.DB) {
 	b.ResetTimer()
@@ -80,41 +132,165 @@ func BenchmarkSelect1_RPCS(b *testing.B) {
 	benchmarkSelect1(b, "rpcs")
 }
 
-func BenchmarkSelect1_PGWire(b *testing.B) {
-	s := server.StartTestServer(b)
-	defer s.Stop()
-
-	host, port, err := net.SplitHostPort(s.PGAddr())
-	if err != nil {
-		b.Fatal(err)
-	}
-	datasource := fmt.Sprintf("sslmode=disable host=%s port=%s", host, port)
-
-	db, err := sql.Open("postgres", datasource)
-	if err != nil {
-		b.Fatal(err)
-	}
-	defer db.Close()
-
-	runBenchmarkSelect1(b, db)
+func BenchmarkSelect1_Cockroach(b *testing.B) {
+	benchmarkCockroach(b, runBenchmarkSelect1)
 }
 
 func BenchmarkSelect1_Postgres(b *testing.B) {
-	db, err := sql.Open("postgres", "sslmode=disable host=localhost port=5432")
-	if err != nil {
-		b.Fatal(err)
-	}
-	defer db.Close()
-
-	runBenchmarkSelect1(b, db)
+	benchmarkPostgres(b, runBenchmarkSelect1)
 }
 
 func BenchmarkSelect1_MySQL(b *testing.B) {
-	db, err := sql.Open("mysql", "tcp(localhost:3306)/test")
-	if err != nil {
+	benchmarkMySQL(b, runBenchmarkSelect1)
+}
+
+// runBenchmarkInsert benchmarks inserting count rows into a table.
+func runBenchmarkInsert(b *testing.B, db *sql.DB, count int) {
+	if _, err := db.Exec(`DROP TABLE IF EXISTS bench.insert`); err != nil {
 		b.Fatal(err)
 	}
-	defer db.Close()
+	if _, err := db.Exec(`CREATE TABLE bench.insert (k INT PRIMARY KEY)`); err != nil {
+		b.Fatal(err)
+	}
 
-	runBenchmarkSelect1(b, db)
+	b.ResetTimer()
+	var buf bytes.Buffer
+	val := 0
+	for i := 0; i < b.N; i++ {
+		buf.Reset()
+		buf.WriteString(`INSERT INTO bench.insert VALUES `)
+		for j := 0; j < count; j++ {
+			if j > 0 {
+				buf.WriteString(", ")
+			}
+			fmt.Fprintf(&buf, "(%d)", val)
+			val++
+		}
+		if _, err := db.Exec(buf.String()); err != nil {
+			b.Fatal(err)
+		}
+	}
+	b.StopTimer()
+
+	if _, err := db.Exec(`DROP TABLE bench.insert`); err != nil {
+		b.Fatal(err)
+	}
+}
+
+func runBenchmarkInsert1(b *testing.B, db *sql.DB) {
+	runBenchmarkInsert(b, db, 1)
+}
+
+func runBenchmarkInsert10(b *testing.B, db *sql.DB) {
+	runBenchmarkInsert(b, db, 10)
+}
+
+func runBenchmarkInsert100(b *testing.B, db *sql.DB) {
+	runBenchmarkInsert(b, db, 100)
+}
+
+func BenchmarkInsert1_Cockroach(b *testing.B) {
+	benchmarkCockroach(b, runBenchmarkInsert1)
+}
+
+func BenchmarkInsert1_Postgres(b *testing.B) {
+	benchmarkPostgres(b, runBenchmarkInsert1)
+}
+
+func BenchmarkInsert10_Cockroach(b *testing.B) {
+	benchmarkCockroach(b, runBenchmarkInsert10)
+}
+
+func BenchmarkInsert10_Postgres(b *testing.B) {
+	benchmarkPostgres(b, runBenchmarkInsert10)
+}
+
+func BenchmarkInsert100_Cockroach(b *testing.B) {
+	benchmarkCockroach(b, runBenchmarkInsert100)
+}
+
+func BenchmarkInsert100_Postgres(b *testing.B) {
+	benchmarkPostgres(b, runBenchmarkInsert100)
+}
+
+// runBenchmarkScan benchmarks scanning a table containing count rows.
+func runBenchmarkScan(b *testing.B, db *sql.DB, count int) {
+	if _, err := db.Exec(`DROP TABLE IF EXISTS bench.scan`); err != nil {
+		b.Fatal(err)
+	}
+	if _, err := db.Exec(`CREATE TABLE bench.scan (k INT PRIMARY KEY)`); err != nil {
+		b.Fatal(err)
+	}
+
+	var buf bytes.Buffer
+	buf.WriteString(`INSERT INTO bench.scan VALUES `)
+	for i := 0; i < count; i++ {
+		if i > 0 {
+			buf.WriteString(", ")
+		}
+		fmt.Fprintf(&buf, "(%d)", i)
+	}
+	if _, err := db.Exec(buf.String()); err != nil {
+		b.Fatal(err)
+	}
+
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		rows, err := db.Query(`SELECT * FROM bench.scan`)
+		if err != nil {
+			b.Fatal(err)
+		}
+		n := 0
+		for rows.Next() {
+			n++
+		}
+		rows.Close()
+		if err := rows.Err(); err != nil {
+			b.Fatal(err)
+		}
+		if count != n {
+			b.Fatalf("unexpected result count: %d != %d", count, n)
+		}
+	}
+	b.StopTimer()
+
+	if _, err := db.Exec(`DROP TABLE bench.scan`); err != nil {
+		b.Fatal(err)
+	}
+}
+
+func runBenchmarkScan1(b *testing.B, db *sql.DB) {
+	runBenchmarkScan(b, db, 1)
+}
+
+func runBenchmarkScan10(b *testing.B, db *sql.DB) {
+	runBenchmarkScan(b, db, 10)
+}
+
+func runBenchmarkScan100(b *testing.B, db *sql.DB) {
+	runBenchmarkScan(b, db, 100)
+}
+
+func BenchmarkScan1_Cockroach(b *testing.B) {
+	benchmarkCockroach(b, runBenchmarkScan1)
+}
+
+func BenchmarkScan1_Postgres(b *testing.B) {
+	benchmarkPostgres(b, runBenchmarkScan1)
+}
+
+func BenchmarkScan10_Cockroach(b *testing.B) {
+	benchmarkCockroach(b, runBenchmarkScan10)
+}
+
+func BenchmarkScan10_Postgres(b *testing.B) {
+	benchmarkPostgres(b, runBenchmarkScan10)
+}
+
+func BenchmarkScan100_Cockroach(b *testing.B) {
+	benchmarkCockroach(b, runBenchmarkScan100)
+}
+
+func BenchmarkScan100_Postgres(b *testing.B) {
+	benchmarkPostgres(b, runBenchmarkScan100)
 }


### PR DESCRIPTION
Added {Insert,Scan}{1,10,100} benchmarks. Didn't bother comparing
against MySQL as well because the numbers are very similar to
Postgres. We're only an order of magnitude slower.

name                  time/op
Insert1_PGWire-8       946µs ± 1%
Insert1_Postgres-8     153µs ± 2%
Insert10_PGWire-8     1.33ms ± 2%
Insert10_Postgres-8    184µs ± 3%
Insert100_PGWire-8    4.82ms ± 0%
Insert100_Postgres-8   517µs ±37%
Scan1_PGWire-8         354µs ± 1%
Scan1_Postgres-8      75.7µs ±10%
Scan10_PGWire-8        419µs ± 0%
Scan10_Postgres-8     77.3µs ± 1%
Scan100_PGWire-8       933µs ± 2%
Scan100_Postgres-8     121µs ± 1%

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/3264)

<!-- Reviewable:end -->
