### PR TITLE
Populate "updated" field in UI Topbar. Fixes #2951.

### DIFF
--- a/ui/ts/components/topbar.ts
+++ b/ui/ts/components/topbar.ts
@@ -7,10 +7,15 @@ module Components {
 
   export module Topbar {
     export function controller(): void {}
-    export function view(ctrl: any, args: {title: string; }): MithrilVirtualElement {
+    export function view(ctrl: any, args: {title: string; updated: number; }): MithrilVirtualElement {
+      let updatedStr: string = "-";
+      if (args.updated !== 0 && args.updated !== -Infinity) {
+        updatedStr = Utils.Format.Date(new Date(Utils.Convert.NanoToMilli(args.updated)));
+      }
+
       return m(".topbar", [
         m("h2", args.title),
-        m(".last-updated", [m("strong", "Updated: "), "-"]),
+        m(".last-updated", [m("strong", "Updated: "), updatedStr]),
       ]);
     }
   }

--- a/ui/ts/pages/nodes.ts
+++ b/ui/ts/pages/nodes.ts
@@ -154,8 +154,10 @@ module AdminViews {
           columns: ctrl.columns,
           rows: nodeStatuses.allStatuses,
         };
+
+        let mostRecentlyUpdated: number = _.max(_.map(nodeStatuses.allStatuses(), (s: NodeStatus) => s.updated_at ));
         return m(".page", [
-          m.component(Components.Topbar, {title: "Nodes"}),
+          m.component(Components.Topbar, {title: "Nodes", updated: mostRecentlyUpdated }),
           m(".section", ctrl.RenderPrimaryStats()),
           m(".section.table", m(".stats-table", Components.Table.create(comparisonData))),
         ]);
@@ -309,8 +311,11 @@ module AdminViews {
           primaryContent = ctrl.RenderPrimaryStats();
         }
 
+        let nodeStatus: NodeStatus = nodeStatuses.GetStatus(ctrl.GetNodeId());
+        let updated: number = (nodeStatus ? nodeStatus.updated_at : 0);
+
         return m(".page", [
-          m.component(Components.Topbar, {title: title}),
+          m.component(Components.Topbar, {title: title, updated: updated}),
           m.component(NavigationBar, {ts: ctrl.TargetSet()}),
           m(".section", primaryContent),
         ]);

--- a/ui/ts/pages/stores.ts
+++ b/ui/ts/pages/stores.ts
@@ -156,8 +156,10 @@ module AdminViews {
           columns: ctrl.columns,
           rows: storeStatuses.allStatuses,
         };
+
+        let mostRecentlyUpdated: number = _.max(_.map(storeStatuses.allStatuses(), (s: StoreStatus) => s.updated_at ));
         return m(".page", [
-          m.component(Topbar, {title: "Stores"}),
+          m.component(Topbar, {title: "Stores", updated: mostRecentlyUpdated}),
           m(".section", ctrl.RenderPrimaryStats()),
           m(".section.table", m(".stats-table", Components.Table.create(comparisonData))),
         ]);
@@ -346,8 +348,11 @@ module AdminViews {
           primaryContent = ctrl.RenderPrimaryStats();
         }
 
+        let storeStatus: StoreStatus = storeStatuses.GetStatus(ctrl.GetStoreId());
+        let updated: number = (storeStatus ? storeStatus.updated_at : 0);
+
         return m(".page", [
-          m.component(Components.Topbar, {title: title}),
+          m.component(Components.Topbar, {title: title, updated: updated}),
           m.component(NavigationBar, {ts: ctrl.TargetSet()}),
           m(".section", primaryContent),
         ]);


### PR DESCRIPTION
On the "Nodes" page (`/#/nodes`), populate the "Updated" field with the most recent node `updated_at` timestamp.

![screen shot 2015-12-01 at 2 39 44 pm](https://cloud.githubusercontent.com/assets/131967/11511878/7f571196-9839-11e5-8f07-475b0c8092a4.png)

On the "Node" pages (`/#/nodes/<node_id>`), populate the "Updated" field with the corresponding node's `updated_at` timestamp.

![screen shot 2015-12-01 at 2 40 06 pm](https://cloud.githubusercontent.com/assets/131967/11511886/84619c4c-9839-11e5-9797-0a062cd6c239.png)

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/3267)

<!-- Reviewable:end -->
