### PR TITLE
Remove the need to pass in a parser.QualifiedName to backfill

### DIFF
--- a/sql/alter_table.go
+++ b/sql/alter_table.go
@@ -190,7 +190,7 @@ func (p *planner) AlterTable(n *parser.AlterTable) (planNode, error) {
 	}
 
 	// Process mutations synchronously.
-	if err := p.applyMutations(tableDesc, n.Table); err != nil {
+	if err := p.applyMutations(tableDesc); err != nil {
 		return nil, err
 	}
 

--- a/sql/backfill.go
+++ b/sql/backfill.go
@@ -67,8 +67,7 @@ func (ids indexesByID) Swap(i, j int) {
 	ids[i], ids[j] = ids[j], ids[i]
 }
 
-func (p *planner) backfillBatch(b *client.Batch, tableName *parser.QualifiedName, oldTableDesc, newTableDesc *TableDescriptor) error {
-	table := &parser.AliasedTableExpr{Expr: tableName}
+func (p *planner) backfillBatch(b *client.Batch, oldTableDesc, newTableDesc *TableDescriptor) error {
 	var droppedColumnDescs []ColumnDescriptor
 	var droppedIndexDescs []IndexDescriptor
 	var newIndexDescs []IndexDescriptor
@@ -142,10 +141,17 @@ func (p *planner) backfillBatch(b *client.Batch, tableName *parser.QualifiedName
 		// Get all the rows affected.
 		// TODO(vivek): Avoid going through Select.
 		// TODO(tamird): Support partial indexes?
-		rows, err := p.Select(&parser.Select{
-			Exprs: parser.SelectExprs{parser.StarSelectExpr()},
-			From:  parser.TableExprs{table},
-		})
+		// Use a scanNode with SELECT to pass in a TableDescriptor
+		// to the SELECT without needing to use a parser.QualifiedName,
+		// because we want to run schema changes from a gossip feed of
+		// table IDs.
+		scan := &scanNode{
+			planner: p,
+			txn:     p.txn,
+			desc:    oldTableDesc,
+		}
+		scan.initDescDefaults()
+		rows, err := p.selectWithScan(scan, &parser.Select{Exprs: parser.SelectExprs{parser.StarSelectExpr()}})
 		if err != nil {
 			return err
 		}

--- a/sql/create.go
+++ b/sql/create.go
@@ -95,7 +95,7 @@ func (p *planner) CreateIndex(n *parser.CreateIndex) (planNode, error) {
 	}
 
 	// Process mutation synchronously.
-	if err := p.applyMutations(tableDesc, n.Table); err != nil {
+	if err := p.applyMutations(tableDesc); err != nil {
 		return nil, err
 	}
 

--- a/sql/drop.go
+++ b/sql/drop.go
@@ -155,7 +155,7 @@ func (p *planner) DropIndex(n *parser.DropIndex) (planNode, error) {
 			return nil, err
 		}
 		// Process mutation synchronously.
-		if err := p.applyMutations(tableDesc, indexQualifiedName); err != nil {
+		if err := p.applyMutations(tableDesc); err != nil {
 			return nil, err
 		}
 	}

--- a/sql/scan.go
+++ b/sql/scan.go
@@ -244,7 +244,7 @@ func (n *scanNode) ExplainPlan() (name, description string, children []planNode)
 func (n *scanNode) initFrom(p *planner, from parser.TableExprs) error {
 	switch len(from) {
 	case 0:
-		// n.desc remains nil.
+		// n.desc is nil, but can be set externally.
 		return nil
 
 	case 1:
@@ -294,8 +294,7 @@ func (n *scanNode) initFrom(p *planner, from parser.TableExprs) error {
 			}
 			n.isSecondaryIndex = true
 		} else {
-			n.index = &n.desc.PrimaryIndex
-			n.visibleCols = n.desc.Columns
+			n.initDescDefaults()
 		}
 
 		return nil
@@ -304,6 +303,11 @@ func (n *scanNode) initFrom(p *planner, from parser.TableExprs) error {
 		n.err = util.Errorf("TODO(pmattis): unsupported FROM: %s", from)
 		return n.err
 	}
+}
+
+func (n *scanNode) initDescDefaults() {
+	n.index = &n.desc.PrimaryIndex
+	n.visibleCols = n.desc.Columns
 }
 
 // initScan initializes (and performs) the key-value scan.

--- a/sql/schema_changer.go
+++ b/sql/schema_changer.go
@@ -19,7 +19,6 @@ package sql
 
 import (
 	"github.com/cockroachdb/cockroach/client"
-	"github.com/cockroachdb/cockroach/sql/parser"
 	"github.com/gogo/protobuf/proto"
 )
 
@@ -27,8 +26,7 @@ import (
 // queued schema changes and processes them.
 //
 // applyMutations applies the queued mutations for a table.
-// TODO(vivek): Eliminate the need to pass in tableName.
-func (p *planner) applyMutations(tableDesc *TableDescriptor, tableName *parser.QualifiedName) error {
+func (p *planner) applyMutations(tableDesc *TableDescriptor) error {
 	if len(tableDesc.Mutations) == 0 {
 		return nil
 	}
@@ -43,7 +41,7 @@ func (p *planner) applyMutations(tableDesc *TableDescriptor, tableName *parser.Q
 	}
 
 	b := client.Batch{}
-	if err := p.backfillBatch(&b, tableName, tableDesc, newTableDesc); err != nil {
+	if err := p.backfillBatch(&b, tableDesc, newTableDesc); err != nil {
 		return err
 	}
 	// TODO(pmattis): This is a hack. Remove when schema change operations work

--- a/sql/select.go
+++ b/sql/select.go
@@ -41,6 +41,11 @@ import (
 //          mysql requires SELECT.
 func (p *planner) Select(n *parser.Select) (planNode, error) {
 	scan := &scanNode{planner: p, txn: p.txn}
+	return p.selectWithScan(scan, n)
+}
+
+// Run select using the scan node. n.desc might have already been populated.
+func (p *planner) selectWithScan(scan *scanNode, n *parser.Select) (planNode, error) {
 	if err := scan.initFrom(p, n.From); err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
backfill will soon be called asynchronously from a table leader
that is applying a schema change. The table leader is notified via
gossip of a pending mutation on the table descriptor, and has
to also read the database descriptor in order to create a
parse.QualifiedName. This change allows it to apply a schema
change without a QualifiedName.

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/3275)

<!-- Reviewable:end -->
