### PR TITLE
roachpb: Always propagate txn data on transaction restart errors

### DIFF
--- a/roachpb/errors.go
+++ b/roachpb/errors.go
@@ -264,9 +264,9 @@ func (e *TransactionAbortedError) CanRestartTransaction() TransactionRestart {
 	return TransactionRestart_BACKOFF
 }
 
-// Transaction implements TransactionRestartError. It returns nil.
-func (*TransactionAbortedError) Transaction() *Transaction {
-	return nil
+// Transaction implements TransactionRestartError.
+func (e *TransactionAbortedError) Transaction() *Transaction {
+	return &e.Txn
 }
 
 // NewTransactionPushError initializes a new TransactionPushError.
@@ -296,8 +296,8 @@ func (e *TransactionPushError) CanRestartTransaction() TransactionRestart {
 }
 
 // Transaction implements the TransactionRestartError interface.
-func (*TransactionPushError) Transaction() *Transaction {
-	return nil // pusher's txn doesn't change on a Push.
+func (e *TransactionPushError) Transaction() *Transaction {
+	return e.Txn
 }
 
 // NewTransactionRetryError initializes a new TransactionRetryError.


### PR DESCRIPTION
Fix #743 by changing Transaction{Aborted,Push}Error.Transaction() to return txn so that txnSender.Send() always updates the txn data on a restart error. Note that TxnCoordSender.updateState() already sets txn data on every txn restart error.

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/3281)

<!-- Reviewable:end -->
