### PR TITLE
Enable bloom filters and add prefix extractor.

### DIFF
--- a/storage/engine/.gitignore
+++ b/storage/engine/.gitignore
@@ -1,1 +1,1 @@
-mvcc_scan_*
+mvcc_data_*

--- a/storage/engine/engine.go
+++ b/storage/engine/engine.go
@@ -131,10 +131,13 @@ type Engine interface {
 	// Flush causes the engine to write all in-memory data to disk
 	// immediately.
 	Flush() error
-	// NewIterator returns a new instance of an Iterator over this
-	// engine. The caller must invoke Iterator.Close() when finished with
-	// the iterator to free resources.
-	NewIterator() Iterator
+	// NewIterator returns a new instance of an Iterator over this engine. When
+	// prefix is true, Seek will use the user-key prefix of the supplied MVCC key
+	// to restrict which sstables are searched, but iteration (using Next) over
+	// keys without the same user-key prefix will not work correctly (keys may be
+	// skipped). The caller must invoke Iterator.Close() when finished with the
+	// iterator to free resources.
+	NewIterator(prefix bool) Iterator
 	// NewSnapshot returns a new instance of a read-only snapshot
 	// engine. Snapshots are instantaneous and, as long as they're
 	// released relatively quickly, inexpensive. Snapshots are released

--- a/storage/engine/engine_test.go
+++ b/storage/engine/engine_test.go
@@ -216,7 +216,7 @@ func TestEngineBatch(t *testing.T) {
 				t.Errorf("%d: expected %s, but got %s", i, expectedValue, actualValue)
 			}
 			// Try using an iterator to get the value from the batch.
-			iter := b.NewIterator()
+			iter := b.NewIterator(false)
 			iter.Seek(key)
 			if !iter.Valid() {
 				if currentBatch[len(currentBatch)-1].value != nil {
@@ -687,7 +687,7 @@ func TestSnapshotMethods(t *testing.T) {
 		}
 
 		// Verify NewIterator still iterates over original snapshot.
-		iter := snap.NewIterator()
+		iter := snap.NewIterator(false)
 		iter.Seek(newKey)
 		if iter.Valid() {
 			t.Error("expected invalid iterator when seeking to element which shouldn't be visible to snapshot")

--- a/storage/engine/mvcc.go
+++ b/storage/engine/mvcc.go
@@ -485,7 +485,7 @@ func MVCCGet(engine Engine, key roachpb.Key, timestamp roachpb.Timestamp, consis
 	buf := getBufferPool.Get().(*getBuffer)
 	defer getBufferPool.Put(buf)
 
-	iter := engine.NewIterator()
+	iter := engine.NewIterator(true /* prefix iteration */)
 	defer iter.Close()
 
 	metaKey := mvccEncodeKey(buf.key[:0], key)
@@ -1072,7 +1072,7 @@ func MVCCIterate(engine Engine, startKey, endKey roachpb.Key, timestamp roachpb.
 	}
 
 	// Get a new iterator.
-	iter := engine.NewIterator()
+	iter := engine.NewIterator(false)
 	defer iter.Close()
 
 	// Seeking for the first defined position.
@@ -1389,7 +1389,7 @@ func MVCCResolveWriteIntentRange(engine Engine, ms *MVCCStats, key, endKey roach
 // key, clearing all values with timestamps <= to expiration.
 // The timestamp parameter is used to compute the intent age on GC.
 func MVCCGarbageCollect(engine Engine, ms *MVCCStats, keys []roachpb.GCRequest_GCKey, timestamp roachpb.Timestamp) error {
-	iter := engine.NewIterator()
+	iter := engine.NewIterator(false)
 	defer iter.Close()
 	// Iterate through specified GC keys.
 	for _, gcKey := range keys {

--- a/storage/engine/mvcc_test.go
+++ b/storage/engine/mvcc_test.go
@@ -2425,7 +2425,7 @@ func TestMVCCStatsWithRandomRuns(t *testing.T) {
 		// Every 10th step, verify the stats via manual engine scan.
 		if i%10 == 0 {
 			// Compute the stats manually.
-			iter := engine.NewIterator()
+			iter := engine.NewIterator(false)
 			iter.Seek(keyMin)
 			var expMS MVCCStats
 			err := iter.ComputeStats(&expMS, roachpb.KeyMin, roachpb.KeyMax, int64(i+1)*1E9)
@@ -2543,7 +2543,7 @@ func TestMVCCGarbageCollect(t *testing.T) {
 	}
 
 	// Verify aggregated stats match computed stats after GC.
-	iter := engine.NewIterator()
+	iter := engine.NewIterator(false)
 	iter.Seek(keyMin)
 	var expMS MVCCStats
 	err = iter.ComputeStats(&expMS, roachpb.KeyMin, roachpb.KeyMax, ts3.WallTime)
@@ -2567,7 +2567,7 @@ func TestMVCCComputeStatsError(t *testing.T) {
 	}
 
 	var ms MVCCStats
-	iter := engine.NewIterator()
+	iter := engine.NewIterator(false)
 	err := iter.ComputeStats(&ms, roachpb.KeyMin, roachpb.KeyMax, 100)
 	iter.Close()
 	if e := "unable to decode MVCCMetadata"; !testutils.IsError(err, e) {

--- a/storage/engine/rocksdb/db.h
+++ b/storage/engine/rocksdb/db.h
@@ -115,9 +115,12 @@ DBEngine* DBNewSnapshot(DBEngine* db);
 // DBClose().
 DBEngine* DBNewBatch(DBEngine *db);
 
-// Creates a new database iterator. It is the callers responsibility
-// to call DBIterDestroy().
-DBIterator* DBNewIter(DBEngine* db);
+// Creates a new database iterator. When prefix is true, Seek will use the
+// user-key prefix of the supplied MVCC key to restrict which sstables are
+// searched, but iteration (using Next) over keys without the same user-key
+// prefix will not work correctly (keys may be skipped). It is the callers
+// responsibility to call DBIterDestroy().
+DBIterator* DBNewIter(DBEngine* db, bool prefix);
 
 // Destroys an iterator, freeing up any associated memory.
 void DBIterDestroy(DBIterator* iter);

--- a/storage/engine/rocksdb_test.go
+++ b/storage/engine/rocksdb_test.go
@@ -135,15 +135,15 @@ func TestRocksDBCompaction(t *testing.T) {
 // for larger numbers of versions. The database is persisted between
 // runs and stored in the current directory as
 // "mvcc_scan_<versions>_<keys>_<valueBytes>".
-func setupMVCCScanData(numVersions, numKeys, valueBytes int, b *testing.B) (*RocksDB, *stop.Stopper) {
-	loc := fmt.Sprintf("mvcc_scan_%d_%d_%d", numVersions, numKeys, valueBytes)
+func setupMVCCData(numVersions, numKeys, valueBytes int, b *testing.B) (*RocksDB, *stop.Stopper) {
+	loc := fmt.Sprintf("mvcc_data_%d_%d_%d", numVersions, numKeys, valueBytes)
 
 	exists := true
 	if _, err := os.Stat(loc); os.IsNotExist(err) {
 		exists = false
 	}
 
-	const cacheSize = 8 << 30 // 8 GB
+	const cacheSize = 0
 	stopper := stop.NewStopper()
 	rocksdb := NewRocksDB(roachpb.Attributes{}, loc, cacheSize, stopper)
 	if err := rocksdb.Open(); err != nil {
@@ -157,47 +157,53 @@ func setupMVCCScanData(numVersions, numKeys, valueBytes int, b *testing.B) (*Roc
 	log.Infof("creating mvcc data: %s", loc)
 
 	rng, _ := randutil.NewPseudoRand()
+
 	keys := make([]roachpb.Key, numKeys)
-	nvs := make([]int, numKeys)
-	for t := 1; t <= numVersions; t++ {
-		walltime := int64(5 * t)
-		ts := makeTS(walltime, 0)
-		batch := rocksdb.NewBatch()
-		for i := 0; i < numKeys; i++ {
-			if t == 1 {
-				keys[i] = roachpb.Key(encoding.EncodeUvarint([]byte("key-"), uint64(i)))
-				nvs[i] = rand.Intn(numVersions) + 1
-			}
-			// Only write values if this iteration is less than the random
-			// number of versions chosen for this key.
-			if t <= nvs[i] {
-				value := roachpb.MakeValueFromBytes(randutil.RandBytes(rng, valueBytes))
-				value.InitChecksum(keys[i])
-				if err := MVCCPut(batch, nil, keys[i], ts, value, nil); err != nil {
-					b.Fatal(err)
-				}
-			}
+	var order []int
+	for i := 0; i < numKeys; i++ {
+		keys[i] = roachpb.Key(encoding.EncodeUvarint([]byte("key-"), uint64(i)))
+		keyVersions := rng.Intn(numVersions) + 1
+		for j := 0; j < keyVersions; j++ {
+			order = append(order, i)
 		}
-		if err := batch.Commit(); err != nil {
+	}
+
+	// Randomize the order in which the keys are written.
+	for i, n := 0, len(order)-2; i < n; i++ {
+		j := i + rng.Intn(n-i)
+		order[i], order[j] = order[j], order[i]
+	}
+
+	counts := make([]int, numKeys)
+	batch := rocksdb.NewBatch()
+	for i, idx := range order {
+		// Output the keys in batches. If we used a single batch to output all of
+		// the keys rocksdb would create a single sstable. We want multiple
+		// sstables in order to exercise filtering of which sstables are examined
+		// during iterator seeking.
+		if i > 0 && i%100 == 0 {
+			if err := batch.Commit(); err != nil {
+				b.Fatal(err)
+			}
+			batch.Close()
+			batch = rocksdb.NewBatch()
+		}
+
+		key := keys[idx]
+		ts := makeTS(int64(counts[idx]+1)*5, 0)
+		counts[idx]++
+		value := roachpb.MakeValueFromBytes(randutil.RandBytes(rng, valueBytes))
+		value.InitChecksum(key)
+		if err := MVCCPut(batch, nil, key, ts, value, nil); err != nil {
 			b.Fatal(err)
 		}
-		batch.Close()
 	}
-	rocksdb.CompactRange(nil, nil)
+	if err := batch.Commit(); err != nil {
+		b.Fatal(err)
+	}
+	batch.Close()
 
 	return rocksdb, stopper
-}
-
-// prewarmCache prewarms the rocksdb cache by iterating over the
-// entire database.
-func prewarmCache(rocksdb *RocksDB) {
-	iter := rocksdb.NewIterator()
-	iter.Seek(keyMin)
-	defer iter.Close()
-
-	for iter.Valid() {
-		iter.Next()
-	}
 }
 
 // runMVCCScan first creates test data (and resets the benchmarking
@@ -211,10 +217,8 @@ func runMVCCScan(numRows, numVersions, valueSize int, b *testing.B) {
 	// datasets all fit in cache and the cache is pre-warmed.
 	const numKeys = 100000
 
-	rocksdb, stopper := setupMVCCScanData(numVersions, numKeys, valueSize, b)
+	rocksdb, stopper := setupMVCCData(numVersions, numKeys, valueSize, b)
 	defer stopper.Stop()
-
-	prewarmCache(rocksdb)
 
 	b.SetBytes(int64(numRows * valueSize))
 	b.ResetTimer()
@@ -355,37 +359,35 @@ func BenchmarkMVCCScan100Versions1000Rows512Bytes(b *testing.B) {
 // runMVCCGet first creates test data (and resets the benchmarking
 // timer). It then performs b.N MVCCGets.
 func runMVCCGet(numVersions, valueSize int, b *testing.B) {
-	// Use the same number of keys for all of the mvcc get
-	// benchmarks. Using a different number of keys per test gives
-	// preferential treatment to tests with fewer keys. Note that the
-	// datasets all fit in cache and the cache is pre-warmed.
-	const numKeys = 100000
+	const overhead = 48          // Per key/value overhead (empirically determined)
+	const targetSize = 512 << 20 // 512 MB
+	// Adjust the number of keys so that each test has approximately the same
+	// amount of data.
+	numKeys := targetSize / ((overhead + valueSize) * (1 + (numVersions-1)/2))
 
-	rocksdb, stopper := setupMVCCScanData(numVersions, numKeys, valueSize, b)
+	rocksdb, stopper := setupMVCCData(numVersions, numKeys, valueSize, b)
 	defer stopper.Stop()
-
-	prewarmCache(rocksdb)
 
 	b.SetBytes(int64(valueSize))
 	b.ResetTimer()
 
-	b.RunParallel(func(pb *testing.PB) {
-		keyBuf := append(make([]byte, 0, 64), []byte("key-")...)
-		for pb.Next() {
-			// Choose a random key to retrieve.
-			keyIdx := rand.Int31n(int32(numKeys))
-			key := roachpb.Key(encoding.EncodeUvarint(keyBuf[:4], uint64(keyIdx)))
-			walltime := int64(5 * (rand.Int31n(int32(numVersions)) + 1))
-			ts := makeTS(walltime, 0)
-			if v, _, err := MVCCGet(rocksdb, key, ts, true, nil); err != nil {
-				b.Fatalf("failed get: %s", err)
-			} else if valueBytes, err := v.GetBytes(); err != nil {
-				b.Fatal(err)
-			} else if len(valueBytes) != valueSize {
-				b.Fatalf("unexpected value size: %d", len(valueBytes))
-			}
+	keyBuf := append(make([]byte, 0, 64), []byte("key-")...)
+	for i := 0; i < b.N; i++ {
+		// Choose a random key to retrieve.
+		keyIdx := rand.Int31n(int32(numKeys))
+		key := roachpb.Key(encoding.EncodeUvarint(keyBuf[:4], uint64(keyIdx)))
+		walltime := int64(5 * (rand.Int31n(int32(numVersions)) + 1))
+		ts := makeTS(walltime, 0)
+		if v, _, err := MVCCGet(rocksdb, key, ts, true, nil); err != nil {
+			b.Fatalf("failed get: %s", err)
+		} else if v == nil {
+			b.Fatalf("failed get (key not found): %d@%d", keyIdx, walltime)
+		} else if valueBytes, err := v.GetBytes(); err != nil {
+			b.Fatal(err)
+		} else if len(valueBytes) != valueSize {
+			b.Fatalf("unexpected value size: %d", len(valueBytes))
 		}
-	})
+	}
 
 	b.StopTimer()
 }
@@ -394,36 +396,12 @@ func BenchmarkMVCCGet1Version8Bytes(b *testing.B) {
 	runMVCCGet(1, 8, b)
 }
 
-func BenchmarkMVCCGet1Version64Bytes(b *testing.B) {
-	runMVCCGet(1, 64, b)
-}
-
-func BenchmarkMVCCGet1Version512Bytes(b *testing.B) {
-	runMVCCGet(1, 512, b)
-}
-
 func BenchmarkMVCCGet10Versions8Bytes(b *testing.B) {
 	runMVCCGet(10, 8, b)
 }
 
-func BenchmarkMVCCGet10Versions64Bytes(b *testing.B) {
-	runMVCCGet(10, 64, b)
-}
-
-func BenchmarkMVCCGet10Versions512Bytes(b *testing.B) {
-	runMVCCGet(10, 512, b)
-}
-
 func BenchmarkMVCCGet100Versions8Bytes(b *testing.B) {
 	runMVCCGet(100, 8, b)
-}
-
-func BenchmarkMVCCGet100Versions64Bytes(b *testing.B) {
-	runMVCCGet(100, 64, b)
-}
-
-func BenchmarkMVCCGet100Versions512Bytes(b *testing.B) {
-	runMVCCGet(100, 512, b)
 }
 
 func runMVCCPut(valueSize int, b *testing.B) {
@@ -577,7 +555,7 @@ func runMVCCDeleteRange(valueBytes int, b *testing.B) {
 	const rangeBytes = 512 * 1024
 	const overhead = 48 // Per key/value overhead (empirically determined)
 	numKeys := rangeBytes / (overhead + valueBytes)
-	rocksdb, stopper := setupMVCCScanData(1, numKeys, valueBytes, b)
+	rocksdb, stopper := setupMVCCData(1, numKeys, valueBytes, b)
 	stopper.Stop()
 
 	b.SetBytes(rangeBytes)
@@ -626,17 +604,15 @@ func runMVCCComputeStats(valueBytes int, b *testing.B) {
 	const rangeBytes = 64 * 1024 * 1024
 	const overhead = 48 // Per key/value overhead (empirically determined)
 	numKeys := rangeBytes / (overhead + valueBytes)
-	rocksdb, stopper := setupMVCCScanData(1, numKeys, valueBytes, b)
+	rocksdb, stopper := setupMVCCData(1, numKeys, valueBytes, b)
 	defer stopper.Stop()
-
-	prewarmCache(rocksdb)
 
 	b.SetBytes(rangeBytes)
 	b.ResetTimer()
 
 	var stats MVCCStats
 	for i := 0; i < b.N; i++ {
-		iter := rocksdb.NewIterator()
+		iter := rocksdb.NewIterator(false)
 		iter.Seek(keyMin)
 		stats = MVCCStats{}
 		err := iter.ComputeStats(&stats, roachpb.KeyMin, roachpb.KeyMax, 0)

--- a/storage/replica_command.go
+++ b/storage/replica_command.go
@@ -1324,7 +1324,7 @@ func (r *Replica) AdminSplit(args roachpb.AdminSplitRequest, desc *roachpb.Range
 }
 
 func (r *Replica) computeStats(d *roachpb.RangeDescriptor, e engine.Engine, nowNanos int64) (engine.MVCCStats, error) {
-	iter := e.NewIterator()
+	iter := e.NewIterator(false)
 	defer iter.Close()
 
 	ms := &engine.MVCCStats{}

--- a/storage/replica_data_iter.go
+++ b/storage/replica_data_iter.go
@@ -68,7 +68,7 @@ func makeReplicaKeyRanges(d *roachpb.RangeDescriptor) []keyRange {
 func newReplicaDataIterator(d *roachpb.RangeDescriptor, e engine.Engine) *replicaDataIterator {
 	ri := &replicaDataIterator{
 		ranges:   makeReplicaKeyRanges(d),
-		Iterator: e.NewIterator(),
+		Iterator: e.NewIterator(false),
 	}
 	ri.Seek(ri.ranges[ri.curIndex].start)
 	return ri


### PR DESCRIPTION
The `<user-key>` portion of MVCC keys is now extracted and added to the
per table bloom filter which allows skipping of tables which do not
contain the `<user-key>` during "point" lookups (i.e. MVCCGet).

Enabled rocksdb statistics collection. We should probably bounce some of
the statistics up to Go-land. Log the bloom prefix filter utility when
closing a DB which shows if the bloom filter is being utilized or not.

Changed the way that mvcc data is generated for benchmarks. The keys are
now written in random order and the final compaction step is
disabled. The result is a series of sstable files instead of just 1 and
the keys randomly distributed through the sstables.

```
name                      old time/op    new time/op     delta
MVCCGet1Version8Bytes        104µs ± 4%       35µs ± 1%   -66.34%         (p=0.000 n=10+9)
MVCCGet10Versions8Bytes     89.6µs ± 2%     47.5µs ± 4%   -46.95%         (p=0.000 n=10+9)
MVCCGet100Versions8Bytes    82.4µs ± 7%     78.3µs ± 1%    -4.98%        (p=0.000 n=10+10)
```

The above benchmark numbers are comparing with prefix iteration disabled
vs enabled. The 100 version test shows little benefit because the
versions get spread throughout the sstables removing much of the utility
of the bloom filtering.

Removed the non-8-byte versions of the MVCCGet tests as they were simply
showing the benefit of reading more data at once. Removed parallelism
from the MVCCGet benchmarks as it was obfuscating the performance of a
single operation. Disabled the rocksdb cache in order to highlight the
performance when "reading from disk" (usually the OS buffer cache).

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/3284)

<!-- Reviewable:end -->
