### PR TITLE
Test all static binaries for "one day" rule.

### DIFF
--- a/build/push-aws.sh
+++ b/build/push-aws.sh
@@ -39,7 +39,7 @@ function push_one_binary {
 
   if [ "${latest_date}" == "${today}" ]; then
     echo "Latest binary is from today, skipping: ${contents}"
-    exit 0
+    return 0
   fi
 
   # Latest file did not exist, was empty, or pointed to an old binary.


### PR DESCRIPTION
This allows recently-added binaries to be built right away rather than
be skipped because other binaries were built today.

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/3285)

<!-- Reviewable:end -->
