### PR TITLE
executor waits for a completed schema change to propagate.

### DIFF
--- a/sql/executor.go
+++ b/sql/executor.go
@@ -35,6 +35,7 @@ import (
 	"github.com/cockroachdb/cockroach/sql/parser"
 	"github.com/cockroachdb/cockroach/util"
 	"github.com/cockroachdb/cockroach/util/log"
+	"github.com/cockroachdb/cockroach/util/retry"
 )
 
 var testingWaitForMetadata bool
@@ -190,6 +191,15 @@ func (e *Executor) execStmts(sql string, planMaker *planner) driver.Response {
 		// TODO(pmattis): Need to record the leases used by a transaction within
 		// the transaction state and restore it when the transaction is restored.
 		planMaker.releaseLeases(e.db)
+
+		// The previous statement finished executing a schema change. Wait for
+		// the schema change to propagate to all nodes, so that once the executor
+		// returns the new schema is live everywhere. This is not needed for
+		// correctness but is done to make the UI experience/tests predictable.
+		if err := e.waitForCompletedSchemaChangesToPropagate(planMaker); err != nil {
+			log.Warning(err)
+		}
+
 	}
 	return resp
 }
@@ -338,6 +348,23 @@ func (e *Executor) execStmt(stmt parser.Statement, planMaker *planner) (driver.R
 	}
 
 	return result, err
+}
+
+func (e *Executor) waitForCompletedSchemaChangesToPropagate(planMaker *planner) error {
+	for _, id := range planMaker.completedSchemaChange {
+		retryOpts := retry.Options{
+			InitialBackoff: 20 * time.Millisecond,
+			MaxBackoff:     200 * time.Millisecond,
+			Multiplier:     2,
+		}
+		// Wait until there are no unexpired leases on the previous version
+		// of the table.
+		if _, err := e.leaseMgr.waitForOneVersion(id, retryOpts); err != nil {
+			return err
+		}
+	}
+	planMaker.completedSchemaChange = nil
+	return nil
 }
 
 // If we hit an error and there is a pending transaction, rollback

--- a/sql/lease.go
+++ b/sql/lease.go
@@ -175,13 +175,47 @@ func (s LeaseStore) Release(lease *LeaseState) error {
 	})
 }
 
+// waitForOneVersion returns once there are no unexpired leases on the
+// previous version of the table descriptor. It returns the current version.
+// After returning there can only be versions of the descriptor >= to the
+// returned verson. Lease acquisition (see acquire()) maintains the
+// invariant that no new leases for desc.Version-1 will be granted once
+// desc.Version exists.
+func (s LeaseStore) waitForOneVersion(tableID ID, retryOpts retry.Options) (DescriptorVersion, error) {
+	desc := &Descriptor{}
+	descKey := MakeDescMetadataKey(tableID)
+	var tableDesc *TableDescriptor
+	for r := retry.Start(retryOpts); r.Next(); {
+		// Get the current version of the table descriptor non-transactionally.
+		//
+		// TODO(pmattis): Do an inconsistent read here?
+		if err := s.db.GetProto(descKey, desc); err != nil {
+			return 0, err
+		}
+		tableDesc = desc.GetTable()
+		if tableDesc == nil {
+			return 0, util.Errorf("ID %d is not a table", tableID)
+		}
+		// Check to see if there are any leases that still exist on the previous
+		// version of the descriptor.
+		now := s.clock.Now()
+		count, err := s.countLeases(tableDesc.ID, tableDesc.Version-1, now.GoTime())
+		if err != nil {
+			return 0, err
+		}
+		if count == 0 {
+			break
+		}
+		log.Infof("publish (count leases): descID=%d version=%d count=%d",
+			tableDesc.ID, tableDesc.Version-1, count)
+	}
+	return tableDesc.Version, nil
+}
+
 // Publish a new version of a table descriptor. The update closure may be
 // called multiple times if retries occur: make sure it does not have side
 // effects.
 func (s LeaseStore) Publish(tableID ID, update func(*TableDescriptor) error) error {
-	desc := &Descriptor{}
-	descKey := MakeDescMetadataKey(tableID)
-
 	retryOpts := retry.Options{
 		InitialBackoff: 20 * time.Millisecond,
 		MaxBackoff:     2 * time.Second,
@@ -189,35 +223,19 @@ func (s LeaseStore) Publish(tableID ID, update func(*TableDescriptor) error) err
 	}
 
 	for r := retry.Start(retryOpts); r.Next(); {
-		// Get the current version of the table descriptor non-transactionally.
-		//
-		// TODO(pmattis): Do an inconsistent read here?
-		if err := s.db.GetProto(descKey, desc); err != nil {
-			return err
-		}
-		tableDesc := desc.GetTable()
-		if tableDesc == nil {
-			return util.Errorf("ID %d is not a table", tableID)
-		}
-		// Check to see if there are any leases that still exist on the previous
-		// version of the descriptor.
-		now := s.clock.Now()
-		count, err := s.countLeases(tableDesc.ID, tableDesc.Version-1, now.GoTime())
+		// Wait until there are no unexpired leases on the previous version
+		// of the table.
+		expectedVersion, err := s.waitForOneVersion(tableID, retryOpts)
 		if err != nil {
 			return err
 		}
-		if count != 0 {
-			log.Infof("publish (count leases): descID=%d version=%d count=%d",
-				tableDesc.ID, tableDesc.Version-1, count)
-			continue
-		}
 
-		// At this point, desc.Version is the only version of the descriptor that
-		// has leases outstanding. Lease acquisition (see acquire()) maintains the
-		// invariant that no new leases for desc.Version-1 will be granted once
-		// desc.Version exists.
-		expectedVersion := tableDesc.Version
+		// There should be only one version of the descriptor, but it's
+		// a race now to update to the next version.
 		err = s.db.Txn(func(txn *client.Txn) error {
+			desc := &Descriptor{}
+			descKey := MakeDescMetadataKey(tableID)
+
 			// Re-read the current version of the table descriptor, this time
 			// transactionally.
 			if err := txn.GetProto(descKey, desc); err != nil {
@@ -244,6 +262,7 @@ func (s LeaseStore) Publish(tableID ID, update func(*TableDescriptor) error) err
 
 			// Bump the version and modification time.
 			tableDesc.Version = tableDesc.Version + 1
+			now := s.clock.Now()
 			tableDesc.ModificationTime = now
 			if log.V(3) {
 				log.Infof("publish: descID=%d version=%d mtime=%s",

--- a/sql/schema_changer.go
+++ b/sql/schema_changer.go
@@ -44,14 +44,13 @@ func (p *planner) applyMutations(tableDesc *TableDescriptor) error {
 	if err := p.backfillBatch(&b, tableDesc, newTableDesc); err != nil {
 		return err
 	}
-	// TODO(pmattis): This is a hack. Remove when schema change operations work
-	// properly.
-	p.hackNoteSchemaChange(newTableDesc)
+	newTableDesc.Version++
 
 	b.Put(MakeDescMetadataKey(newTableDesc.GetID()), wrapDescriptor(newTableDesc))
 
 	if err := p.txn.Run(&b); err != nil {
 		return convertBatchError(newTableDesc, b, err)
 	}
+	p.notifyCompletedSchemaChange(newTableDesc.ID)
 	return nil
 }


### PR DESCRIPTION
notify sql planner when a schema change is completed.

This was originally a hack to allow the executor to wait
until the schema change propagated to all nodes. The code is now
modified to separate out version update from the schema
change completion notification. This is done because we
want to be able to change the schema version in the
middle of a schema change to reflect changes in state
without suggesting that the schema change is complete.
It just happens that in the current code the schema
change is executed in a single transaction, but that is
going to change soon.

There are legitimate reasons for the executor to
wait until a completed schema change has propagated: the
predictability of the UI experience and predictable
serial execution of tests. Removed the "hack" designation
of wait for completed schema changes to propagate.

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/3287)

<!-- Reviewable:end -->
