### PR TITLE
Fix broken gossip acceptance test

### DIFF
--- a/gossip/infostore.go
+++ b/gossip/infostore.go
@@ -145,6 +145,9 @@ func (is *infoStore) getInfo(key string) *Info {
 //
 // Returns nil if info was added; error otherwise.
 func (is *infoStore) addInfo(key string, i *Info) error {
+	if i.NodeID == 0 {
+		panic("gossip info's NodeID is 0")
+	}
 	// Only replace an existing info if new timestamp is greater, or if
 	// timestamps are equal, but new hops is smaller.
 	if existingInfo, ok := is.Infos[key]; ok {

--- a/gossip/simulation/network.go
+++ b/gossip/simulation/network.go
@@ -73,6 +73,7 @@ func NewNetwork(nodeCount int, networkType string) *Network {
 
 		gossipNode := gossip.New(rpcContext, resolvers)
 		addr := leftNode.Server.Addr()
+		gossipNode.SetNodeID(roachpb.NodeID(i + 1))
 		if err := gossipNode.SetNodeDescriptor(&roachpb.NodeDescriptor{
 			NodeID:  roachpb.NodeID(i + 1),
 			Address: util.MakeUnresolvedAddr(addr.Network(), addr.String()),

--- a/kv/dist_sender_test.go
+++ b/kv/dist_sender_test.go
@@ -315,6 +315,7 @@ func TestSendRPCOrder(t *testing.T) {
 					Attrs: tc.attrs,
 				},
 			}
+			g.SetNodeID(nd.NodeID)
 			if err := g.SetNodeDescriptor(nd); err != nil {
 				t.Fatal(err)
 			}
@@ -374,6 +375,7 @@ func TestOwnNodeCertain(t *testing.T) {
 		NodeID:  expNodeID,
 		Address: util.MakeUnresolvedAddr("tcp", "foobar:1234"),
 	}
+	g.SetNodeID(nd.NodeID)
 	if err := g.SetNodeDescriptor(nd); err != nil {
 		t.Fatal(err)
 	}
@@ -662,6 +664,7 @@ func TestSendRPCRetry(t *testing.T) {
 	defer leaktest.AfterTest(t)
 	g, s := makeTestGossip(t)
 	defer s()
+	g.SetNodeID(1)
 	if err := g.SetNodeDescriptor(&roachpb.NodeDescriptor{NodeID: 1}); err != nil {
 		t.Fatal(err)
 	}
@@ -724,6 +727,7 @@ func TestGetNodeDescriptor(t *testing.T) {
 	g, s := makeTestGossip(t)
 	defer s()
 	ds := NewDistSender(&DistSenderContext{}, g)
+	g.SetNodeID(5)
 	if err := g.SetNodeDescriptor(&roachpb.NodeDescriptor{NodeID: 5}); err != nil {
 		t.Fatal(err)
 	}
@@ -857,6 +861,7 @@ func TestTruncateWithSpanAndDescriptor(t *testing.T) {
 	g, s := makeTestGossip(t)
 	defer s()
 
+	g.SetNodeID(1)
 	if err := g.SetNodeDescriptor(&roachpb.NodeDescriptor{NodeID: 1}); err != nil {
 		t.Fatal(err)
 	}

--- a/kv/local_test_cluster.go
+++ b/kv/local_test_cluster.go
@@ -124,6 +124,7 @@ func (ltc *LocalTestCluster) Start(t util.Tester) {
 	if err := ltc.Store.Start(ltc.Stopper); err != nil {
 		t.Fatalf("unable to start local test cluster: %s", err)
 	}
+	ltc.Gossip.SetNodeID(nodeDesc.NodeID)
 	if err := ltc.Gossip.SetNodeDescriptor(nodeDesc); err != nil {
 		t.Fatalf("unable to set node descriptor: %s", err)
 	}

--- a/kv/txn_test.go
+++ b/kv/txn_test.go
@@ -130,6 +130,7 @@ func BenchmarkTxnWrites(b *testing.B) {
 func disableOwnNodeCertain(tc *LocalTestCluster) {
 	desc := tc.distSender.getNodeDescriptor()
 	desc.NodeID = 999
+	tc.distSender.gossip.SetNodeID(desc.NodeID)
 	if err := tc.distSender.gossip.SetNodeDescriptor(desc); err != nil {
 		panic(err)
 	}

--- a/server/node.go
+++ b/server/node.go
@@ -208,7 +208,7 @@ func (n *Node) initNodeID(id roachpb.NodeID) {
 		if id == 0 {
 			log.Fatal("new node allocated illegal ID 0")
 		}
-
+		n.ctx.Gossip.SetNodeID(id)
 	} else {
 		log.Infof("node ID %d initialized", id)
 	}

--- a/server/raft_transport_test.go
+++ b/server/raft_transport_test.go
@@ -63,6 +63,7 @@ func TestSendAndReceive(t *testing.T) {
 	defer stopper.Stop()
 	nodeRPCContext := rpc.NewContext(nodeTestBaseContext, hlc.NewClock(hlc.UnixNano), stopper)
 	g := gossip.New(nodeRPCContext, gossip.TestBootstrap)
+	g.SetNodeID(roachpb.NodeID(1))
 
 	// Create several servers, each of which has two stores (A multiraft
 	// node ID addresses a store). Node 1 has stores 1 and 2, node 2 has
@@ -75,8 +76,8 @@ func TestSendAndReceive(t *testing.T) {
 	const numServers = 3
 	const storesPerServer = 2
 	const numStores = numServers * storesPerServer
-	nextNodeID := roachpb.NodeID(1)
-	nextStoreID := roachpb.StoreID(1)
+	nextNodeID := roachpb.NodeID(2)
+	nextStoreID := roachpb.StoreID(2)
 
 	// Per-node state.
 	transports := map[roachpb.NodeID]multiraft.Transport{}
@@ -233,6 +234,7 @@ func TestInOrderDelivery(t *testing.T) {
 	defer stopper.Stop()
 	nodeRPCContext := rpc.NewContext(nodeTestBaseContext, hlc.NewClock(hlc.UnixNano), stopper)
 	g := gossip.New(nodeRPCContext, gossip.TestBootstrap)
+	g.SetNodeID(roachpb.NodeID(1))
 
 	server := rpc.NewServer(util.CreateTestAddr("tcp"), nodeRPCContext)
 	if err := server.Start(); err != nil {
@@ -241,7 +243,7 @@ func TestInOrderDelivery(t *testing.T) {
 	defer server.Close()
 
 	const numMessages = 100
-	nodeID := roachpb.NodeID(1)
+	nodeID := roachpb.NodeID(roachpb.NodeID(2))
 	serverTransport, err := newRPCTransport(g, server, nodeRPCContext)
 	if err != nil {
 		t.Fatal(err)

--- a/storage/client_test.go
+++ b/storage/client_test.go
@@ -27,6 +27,7 @@ package storage_test
 
 import (
 	"fmt"
+	"math"
 	"net"
 	"reflect"
 	"strconv"
@@ -91,6 +92,7 @@ func createTestStoreWithEngine(t *testing.T, eng engine.Engine, clock *hlc.Clock
 	}
 	nodeDesc := &roachpb.NodeDescriptor{NodeID: 1}
 	sCtx.Gossip = gossip.New(rpcContext, gossip.TestBootstrap)
+	sCtx.Gossip.SetNodeID(nodeDesc.NodeID)
 	localSender := storage.NewStores()
 	rpcSend := func(_ rpc.Options, _ string, _ []net.Addr,
 		getArgs func(addr net.Addr) proto.Message, _ func() proto.Message,
@@ -200,6 +202,7 @@ func (m *multiTestContext) Start(t *testing.T, numStores int) {
 	if m.gossip == nil {
 		rpcContext := rpc.NewContext(&base.Context{}, m.clock, nil)
 		m.gossip = gossip.New(rpcContext, gossip.TestBootstrap)
+		m.gossip.SetNodeID(math.MaxInt32)
 	}
 	if m.scannerStopper == nil {
 		m.scannerStopper = stop.NewStopper()

--- a/storage/replica_test.go
+++ b/storage/replica_test.go
@@ -111,6 +111,7 @@ func (tc *testContext) Start(t testing.TB) {
 	if tc.gossip == nil {
 		rpcContext := rpc.NewContext(&base.Context{}, hlc.NewClock(hlc.UnixNano), tc.stopper)
 		tc.gossip = gossip.New(rpcContext, gossip.TestBootstrap)
+		tc.gossip.SetNodeID(1)
 	}
 	if tc.manualClock == nil {
 		tc.manualClock = hlc.NewManualClock(0)

--- a/storage/store.go
+++ b/storage/store.go
@@ -418,8 +418,7 @@ func (s *Store) Start(stopper *stop.Stopper) error {
 		}
 
 		// Read store ident and return a not-bootstrapped error if necessary.
-		ok, err := engine.MVCCGetProto(s.engine, keys.StoreIdentKey(), roachpb.ZeroTimestamp, true,
-			nil, &s.Ident)
+		ok, err := engine.MVCCGetProto(s.engine, keys.StoreIdentKey(), roachpb.ZeroTimestamp, true, nil, &s.Ident)
 		if err != nil {
 			return err
 		} else if !ok {
@@ -432,17 +431,8 @@ func (s *Store) Start(stopper *stop.Stopper) error {
 	if s.nodeDesc.NodeID != 0 && s.Ident.NodeID != s.nodeDesc.NodeID {
 		return util.Errorf("node id:%d does not equal the one in node descriptor:%d", s.Ident.NodeID, s.nodeDesc.NodeID)
 	}
-	// Gossip is only ever nil while bootstrapping a cluster and
-	// in unittests.
-	// Set NodeID to gossip as early as possible as NewReplica may
-	// call r.maybeGossipSystemConfig which will call gossip.AddInfo.
+	// Always set gossip NodeID before gossiping any info.
 	if s.ctx.Gossip != nil {
-		// Set Gossip NodeID for bootstrapped node, so before gossip
-		// ClusterID, gossip.is.NodeID is set. Otherwise a gossip
-		// information with NodeID=0 will cause a loop between
-		// all nodes.
-		// For non-bootstrapped node, it's redudant as node will
-		// call gossip.SetNodeDescriptor before this call.
 		s.ctx.Gossip.SetNodeID(s.Ident.NodeID)
 	}
 
@@ -621,13 +611,31 @@ func (s *Store) startGossip() {
 	})
 }
 
-// maybeGossipFirstRange checks whether the store has a replia of the first
-// range and if so, reminds it to gossip the first range descriptor and
-// sentinel gossip.
+// maybeGossipFirstRange checks whether the store has a replica of the
+// first range and if so instructs it to gossip the cluster ID,
+// sentinel gossip and first range descriptor. This is done in a retry
+// loop in the event that the returned error indicates that the state
+// of the leader lease is not known. This can happen on lease command
+// timeouts. The retry loop makes sure we try hard to keep asking for
+// the lease instead of waiting for the next clusterIDGossipInterval
+// to transpire.
 func (s *Store) maybeGossipFirstRange() error {
-	rng := s.LookupReplica(roachpb.RKeyMin, nil)
-	if rng != nil {
-		return rng.maybeGossipFirstRange()
+	retryOptions := retry.Options{
+		InitialBackoff: 100 * time.Millisecond, // first backoff at 100ms
+		MaxBackoff:     1 * time.Second,        // max backoff is 1s
+		Multiplier:     2,                      // doubles
+		Closer:         s.stopper.ShouldStop(), // stop no matter what on stopper
+	}
+	for loop := retry.Start(retryOptions); loop.Next(); {
+		rng := s.LookupReplica(roachpb.RKeyMin, nil)
+		if rng != nil {
+			err := rng.maybeGossipFirstRange()
+			if nlErr, ok := err.(*roachpb.NotLeaderError); !ok || nlErr.Leader != nil {
+				return err
+			}
+		} else {
+			return nil
+		}
 	}
 	return nil
 }

--- a/storage/store_test.go
+++ b/storage/store_test.go
@@ -133,6 +133,7 @@ func createTestStoreWithoutStart(t *testing.T) (*Store, *hlc.ManualClock, *stop.
 	rpcContext := rpc.NewContext(&base.Context{}, hlc.NewClock(hlc.UnixNano), stopper)
 	ctx := TestStoreContext
 	ctx.Gossip = gossip.New(rpcContext, gossip.TestBootstrap)
+	ctx.Gossip.SetNodeID(1)
 	manual := hlc.NewManualClock(0)
 	ctx.Clock = hlc.NewClock(manual.UnixNano)
 	ctx.StorePool = NewStorePool(ctx.Gossip, ctx.Clock, TestTimeUntilStoreDeadOff, stopper)


### PR DESCRIPTION
Restored ClientDisconnectRedundant unittest (it got lost in the shuffle).
Tweaked the usage of Gossip.SetNodeID and Gossip.SetNodeDescriptor
such that Gossip.SetNodeID MUST be called and that SetNodeDescriptor()
isn't sufficient. Previously, either would set the NodeID, which seems
wrong--there should be one way only to do it.

Changed the bootstrapper code to pause between bootstrapping attempts
to prevent busy bootstrapping if the sentinel node simply isn't
available and there's a small gossip network.

Changed Store.maybeGossipFirstRange to include a retry loop to continue
trying with a relatively tight exponential backoff (max backoff is 1s)
in the event that the leader lease is inconclusive. We don't want to be
bound by the 60s cluster ID gossip interval. This is what was tripping
up the gossip peerings test.

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/3296)

<!-- Reviewable:end -->
