### PR TITLE
Remove calls to rand.Seed from individual tests.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -158,7 +158,7 @@ check:
 	@echo "checking for forbidden imports"
 	@! $(GO) list -f '{{ $$ip := .ImportPath }}{{ range .Imports}}{{ $$ip }}: {{ println . }}{{end}}' $(PKG) | \
 		grep -E ' (golang/protobuf/proto|log|path)$$' | \
-		grep -Ev '(base|security|sql/driver|util/(log|stop)): log$$'
+		grep -Ev '(base|security|sql/driver|util/(log|randutil|stop)): log$$'
 	@echo "ineffassign"
 	@! ineffassign . | grep -vF gossip/gossip.pb.go
 	@echo "errcheck"

--- a/acceptance/gossip_peerings_test.go
+++ b/acceptance/gossip_peerings_test.go
@@ -30,7 +30,6 @@ import (
 	"github.com/cockroachdb/cockroach/gossip"
 	"github.com/cockroachdb/cockroach/util"
 	"github.com/cockroachdb/cockroach/util/log"
-	"github.com/cockroachdb/cockroach/util/randutil"
 )
 
 type checkGossipFunc func(map[string]interface{}) error
@@ -111,7 +110,6 @@ func TestGossipPeerings(t *testing.T) {
 	checkGossip(t, c, 20*time.Second, hasPeers(num))
 
 	// Restart another node (if there is one).
-	rand.Seed(randutil.NewPseudoSeed())
 	var pickedNode int
 	if num > 1 {
 		pickedNode = rand.Intn(num-1) + 1

--- a/acceptance/main_test.go
+++ b/acceptance/main_test.go
@@ -28,6 +28,7 @@ import (
 	"time"
 
 	"github.com/cockroachdb/cockroach/acceptance/cluster"
+	"github.com/cockroachdb/cockroach/util/randutil"
 )
 
 var duration = flag.Duration("d", 5*time.Second, "duration to run the test")
@@ -53,6 +54,7 @@ func StartCluster(t *testing.T) cluster.Cluster {
 }
 
 func TestMain(m *testing.M) {
+	randutil.SeedForTests()
 	go func() {
 		sig := make(chan os.Signal, 1)
 		signal.Notify(sig, os.Interrupt)

--- a/gossip/simulation/gossip.go
+++ b/gossip/simulation/gossip.go
@@ -70,17 +70,16 @@ import (
 	"fmt"
 	"io/ioutil"
 	"math"
-	"math/rand"
 	"os"
 	"strconv"
 	"strings"
-	"time"
 
 	"github.com/cockroachdb/cockroach/gossip"
 	"github.com/cockroachdb/cockroach/gossip/simulation"
 	"github.com/cockroachdb/cockroach/roachpb"
 	"github.com/cockroachdb/cockroach/util/encoding"
 	"github.com/cockroachdb/cockroach/util/log"
+	"github.com/cockroachdb/cockroach/util/randutil"
 )
 
 const (
@@ -272,7 +271,7 @@ func outputDotFile(dotFN string, cycle int, network *simulation.Network, edgeSet
 func main() {
 	// Seed the random number generator for non-determinism across
 	// multiple runs.
-	rand.Seed(time.Now().UnixNano())
+	randutil.SeedForTests()
 
 	if f := flag.Lookup("alsologtostderr"); f != nil {
 		fmt.Println("Starting simulation. Add -alsologtostderr to see progress.")

--- a/storage/client_raft_test.go
+++ b/storage/client_raft_test.go
@@ -19,7 +19,6 @@ package storage_test
 
 import (
 	"fmt"
-	"math/rand"
 	"reflect"
 	"strings"
 	"sync"
@@ -39,7 +38,6 @@ import (
 	"github.com/cockroachdb/cockroach/util/hlc"
 	"github.com/cockroachdb/cockroach/util/leaktest"
 	"github.com/cockroachdb/cockroach/util/log"
-	"github.com/cockroachdb/cockroach/util/randutil"
 	"github.com/cockroachdb/cockroach/util/stop"
 	"github.com/coreos/etcd/raft"
 	"github.com/coreos/etcd/raft/raftpb"
@@ -368,9 +366,6 @@ func TestRestoreReplicas(t *testing.T) {
 func TestFailedReplicaChange(t *testing.T) {
 	defer leaktest.AfterTest(t)
 	defer func() { storage.TestingCommandFilter = nil }()
-	seed := randutil.NewPseudoSeed()
-	rand.Seed(seed)
-	log.Infof("using seed %d", seed)
 
 	mtc := startMultiTestContext(t, 2)
 	defer mtc.Stop()

--- a/storage/main_test.go
+++ b/storage/main_test.go
@@ -23,6 +23,7 @@ import (
 	"github.com/cockroachdb/cockroach/security"
 	"github.com/cockroachdb/cockroach/security/securitytest"
 	"github.com/cockroachdb/cockroach/util/leaktest"
+	"github.com/cockroachdb/cockroach/util/randutil"
 )
 
 func init() {
@@ -32,5 +33,6 @@ func init() {
 //go:generate ../util/leaktest/add-leaktest.sh *_test.go
 
 func TestMain(m *testing.M) {
+	randutil.SeedForTests()
 	leaktest.TestMainWithLeakCheck(m)
 }

--- a/util/encoding/main_test.go
+++ b/util/encoding/main_test.go
@@ -17,4 +17,14 @@
 
 package encoding_test
 
-import _ "github.com/cockroachdb/cockroach/util/log" // for flags
+import (
+	"testing"
+
+	_ "github.com/cockroachdb/cockroach/util/log" // for flags
+	"github.com/cockroachdb/cockroach/util/randutil"
+)
+
+func TestMain(m *testing.M) {
+	randutil.SeedForTests()
+	m.Run()
+}

--- a/util/encoding/varint_test.go
+++ b/util/encoding/varint_test.go
@@ -25,7 +25,6 @@ import (
 	"math/rand"
 	"sort"
 	"testing"
-	"time"
 )
 
 func TestVarint(t *testing.T) {
@@ -80,8 +79,6 @@ func (p byteSlice) Swap(i, j int)      { p[i], p[j] = p[j], p[i] }
 // TestVarintOrdering ensures that lexicographical and numeric ordering
 // for varints are the same
 func TestVarintOrdering(t *testing.T) {
-	seed := time.Now().Unix()
-	rand.Seed(seed)
 	ints := make(uint64Slice, 50)
 	varints := make(byteSlice, len(ints))
 	for i := range ints {
@@ -97,7 +94,7 @@ func TestVarintOrdering(t *testing.T) {
 	for i := range ints {
 		decoded, _ := getUvarint(varints[i])
 		if decoded != ints[i] {
-			t.Errorf("mismatched ordering at index %d: expected: %d, got %d [seed: %d]", i, ints[i], decoded, seed)
+			t.Errorf("mismatched ordering at index %d: expected: %d, got %d", i, ints[i], decoded)
 		}
 	}
 }


### PR DESCRIPTION
These tests affect not only themselves but all tests run after them.
Such a test would be non-deterministic when run as a part of the full
test suite, but become deterministic (at least with respect to the
global RNG, which defaults to a seed of 0) when run individually as in
`make stress`. This is one reason why non-deterministic tests have been
more difficult to reproduce locally if the default seed produces a
sequence of values that happens to work.

Move all test-related seeding of the global RNG to the respective
packages' main_test.go files so it will affect all tests equally no
matter how they are run or in what order. Also log the seed used and
allow it to be overridden so failures can be more easily reproduced.

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/3301)

<!-- Reviewable:end -->
