### PR TITLE
Replace various rocksdb tunings with OptimizeLevelStyleCompaction.

### DIFF
--- a/cli/flags.go
+++ b/cli/flags.go
@@ -105,6 +105,10 @@ var flagUsage = map[string]string{
         high may decrease transaction performance in the presence of
         contention.
 `,
+	"memtable-budget": `
+        Total size in bytes for memtables, shared evenly if there are multiple
+        storage devices.
+`,
 	"metrics-frequency": `
         Adjust the frequency at which the server records its own internal metrics.
 `,
@@ -189,6 +193,7 @@ func initFlags(ctx *server.Context) {
 
 		// Engine flags.
 		f.Int64Var(&ctx.CacheSize, "cache-size", ctx.CacheSize, flagUsage["cache-size"])
+		f.Int64Var(&ctx.MemtableBudget, "memtable-budget", ctx.MemtableBudget, flagUsage["memtable-budget"])
 		f.DurationVar(&ctx.ScanInterval, "scan-interval", ctx.ScanInterval, flagUsage["scan-interval"])
 		f.DurationVar(&ctx.ScanMaxIdleTime, "scan-max-idle-time", ctx.ScanMaxIdleTime, flagUsage["scan-max-idle-time"])
 		f.DurationVar(&ctx.TimeUntilStoreDead, "time-until-store-dead", ctx.TimeUntilStoreDead, flagUsage["time-until-store-dead"])

--- a/client/client_test.go
+++ b/client/client_test.go
@@ -674,7 +674,8 @@ const valueSize = 1 << 10
 
 func setupClientBenchData(useSSL bool, numVersions, numKeys int, b *testing.B) (
 	*server.TestServer, *client.DB) {
-	const cacheSize = 8 << 30 // 8 GB
+	const cacheSize = 8 << 30        // 8 GB
+	const memtableBudget = 512 << 20 // 512 MB
 	loc := fmt.Sprintf("client_bench_%d_%d", numVersions, numKeys)
 
 	exists := true
@@ -689,7 +690,10 @@ func setupClientBenchData(useSSL bool, numVersions, numKeys int, b *testing.B) (
 		s.Ctx.Insecure = true
 	}
 	stopper := stop.NewStopper()
-	s.Ctx.Engines = []engine.Engine{engine.NewRocksDB(roachpb.Attributes{Attrs: []string{"ssd"}}, loc, cacheSize, stopper)}
+	s.Ctx.Engines = []engine.Engine{
+		engine.NewRocksDB(roachpb.Attributes{Attrs: []string{"ssd"}}, loc,
+			cacheSize, memtableBudget, stopper),
+	}
 	if err := s.StartWithStopper(stopper); err != nil {
 		b.Fatal(err)
 	}

--- a/storage/engine/in_mem.go
+++ b/storage/engine/in_mem.go
@@ -30,7 +30,7 @@ type InMem struct {
 // NewInMem allocates and returns a new, opened InMem engine.
 func NewInMem(attrs roachpb.Attributes, cacheSize int64, stopper *stop.Stopper) InMem {
 	db := InMem{
-		RocksDB: newMemRocksDB(attrs, cacheSize, stopper),
+		RocksDB: newMemRocksDB(attrs, cacheSize, 512<<20 /* 512 MB */, stopper),
 	}
 	if err := db.Open(); err != nil {
 		panic(err)

--- a/storage/engine/rocksdb/db.h
+++ b/storage/engine/rocksdb/db.h
@@ -55,6 +55,7 @@ typedef struct DBIterator DBIterator;
 // DBOptions contains local database options.
 typedef struct {
   int64_t cache_size;
+  int64_t memtable_budget;
   bool allow_os_buffer;
   bool logging_enabled;
 } DBOptions;


### PR DESCRIPTION
write_buffer_size changes from 64MB to 128MB. target_file_size_base and
max_bytes_for_level_base are unchanged. Also sets a few other options to
reduce write stalls. Not sure if these will have a benefit in the real
world, but at least the settings have been considered by the RocksDB
implementors.

The MVCCGet benchmarks do show a slightly improvement do to these
tunings, but that is purely due to a smaller number of sstables created
due to the larger write_buffer_size.

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/3302)

<!-- Reviewable:end -->
