### PR TITLE
Tiny cleanup to txnSender.Send: Remove a null check on TransactionAbortedError.Transaction

### DIFF
--- a/client/txn.go
+++ b/client/txn.go
@@ -70,10 +70,8 @@ func (ts *txnSender) Send(ctx context.Context, ba roachpb.BatchRequest) (*roachp
 		ts.Proto = roachpb.Transaction{
 			Name:      ts.Proto.Name,
 			Isolation: ts.Proto.Isolation,
-		}
-		if abrtTxn := abrtErr.Transaction(); abrtTxn != nil {
 			// Acts as a minimum priority on restart.
-			ts.Proto.Priority = abrtTxn.Priority
+			Priority: abrtErr.Txn.Priority,
 		}
 	} else if txnErr, ok := err.(roachpb.TransactionRestartError); ok {
 		ts.Proto.Update(txnErr.Transaction())


### PR DESCRIPTION
TransactionAbortedError always sets the txn, so we don't need to do the null-check. (Note: TransactionAbortedError.Transaction() used to always return a null, but it was changed by #3281).

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/3311)

<!-- Reviewable:end -->
