### PR TITLE
sql: hide auto-created rowid column

### DIFF
--- a/sql/create.go
+++ b/sql/create.go
@@ -135,6 +135,7 @@ func (p *planner) CreateTable(n *parser.CreateTable) (planNode, error) {
 				Kind: ColumnType_INT,
 			},
 			DefaultExpr: &s,
+			Hidden:      true,
 		}
 		desc.AddColumn(col)
 		idx := IndexDescriptor{

--- a/sql/insert.go
+++ b/sql/insert.go
@@ -243,7 +243,7 @@ func (p *planner) Insert(n *parser.Insert) (planNode, error) {
 func (p *planner) processColumns(tableDesc *TableDescriptor,
 	node parser.QualifiedNames) ([]ColumnDescriptor, error) {
 	if node == nil {
-		return tableDesc.Columns, nil
+		return tableDesc.VisibleColumns(), nil
 	}
 
 	cols := make([]ColumnDescriptor, len(node))

--- a/sql/scan.go
+++ b/sql/scan.go
@@ -502,7 +502,7 @@ func (n *scanNode) addRender(target parser.SelectExpr) error {
 					n.render = append(n.render, qval)
 				}
 			} else {
-				for _, col := range n.desc.Columns {
+				for _, col := range n.desc.VisibleColumns() {
 					qval := n.getQVal(col)
 					n.columns = append(n.columns, column{name: col.Name, typ: qval.datum})
 					n.render = append(n.render, qval)

--- a/sql/structured.go
+++ b/sql/structured.go
@@ -552,6 +552,17 @@ func (desc *TableDescriptor) addMutation(m DescriptorMutation) {
 	desc.Mutations = append(desc.Mutations, m)
 }
 
+// VisibleColumns returns all non hidden columns.
+func (desc *TableDescriptor) VisibleColumns() []ColumnDescriptor {
+	var cols []ColumnDescriptor
+	for _, col := range desc.Columns {
+		if !col.Hidden {
+			cols = append(cols, col)
+		}
+	}
+	return cols
+}
+
 // SQLString returns the SQL string corresponding to the type.
 func (c *ColumnType) SQLString() string {
 	switch c.Kind {

--- a/sql/structured.pb.go
+++ b/sql/structured.pb.go
@@ -196,6 +196,7 @@ type ColumnDescriptor struct {
 	// Default expression to use to populate the column on insert if no
 	// value is provided.
 	DefaultExpr *string `protobuf:"bytes,5,opt,name=default_expr" json:"default_expr,omitempty"`
+	Hidden      bool    `protobuf:"varint,6,opt,name=hidden" json:"hidden"`
 }
 
 func (m *ColumnDescriptor) Reset()         { *m = ColumnDescriptor{} }
@@ -681,6 +682,14 @@ func (m *ColumnDescriptor) MarshalTo(data []byte) (int, error) {
 		i = encodeVarintStructured(data, i, uint64(len(*m.DefaultExpr)))
 		i += copy(data[i:], *m.DefaultExpr)
 	}
+	data[i] = 0x30
+	i++
+	if m.Hidden {
+		data[i] = 1
+	} else {
+		data[i] = 0
+	}
+	i++
 	return i, nil
 }
 
@@ -1060,6 +1069,7 @@ func (m *ColumnDescriptor) Size() (n int) {
 		l = len(*m.DefaultExpr)
 		n += 1 + l + sovStructured(uint64(l))
 	}
+	n += 2
 	return n
 }
 
@@ -1483,6 +1493,26 @@ func (m *ColumnDescriptor) Unmarshal(data []byte) error {
 			s := string(data[iNdEx:postIndex])
 			m.DefaultExpr = &s
 			iNdEx = postIndex
+		case 6:
+			if wireType != 0 {
+				return fmt.Errorf("proto: wrong wireType = %d for field Hidden", wireType)
+			}
+			var v int
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return ErrIntOverflowStructured
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := data[iNdEx]
+				iNdEx++
+				v |= (int(b) & 0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			m.Hidden = bool(v != 0)
 		default:
 			iNdEx = preIndex
 			skippy, err := skipStructured(data[iNdEx:])

--- a/sql/structured.proto
+++ b/sql/structured.proto
@@ -60,6 +60,7 @@ message ColumnDescriptor {
   // Default expression to use to populate the column on insert if no
   // value is provided.
   optional string default_expr = 5;
+  optional bool hidden = 6 [(gogoproto.nullable) = false];
 }
 
 message IndexDescriptor {

--- a/sql/testdata/no_primary_key
+++ b/sql/testdata/no_primary_key
@@ -35,6 +35,32 @@ SELECT count(rowid) FROM t
 statement ok
 ALTER TABLE t ADD c STRING
 
-# TODO(mjibson): should be statement ok
-statement error value type string doesn't match type INT of column "rowid"
+statement ok
 INSERT INTO t VALUES (5, 6, '7')
+
+query IIT
+select * from t rowsort
+----
+1 2 NULL
+1 2 NULL
+3 4 NULL
+5 6 7
+
+statement ok
+SELECT a, b, c, rowid FROM t
+
+statement ok
+INSERT INTO t (a, rowid) VALUES (10, 11)
+
+query I
+SELECT rowid FROM t WHERE a = 10
+----
+11
+
+query TTBT
+SHOW COLUMNS FROM t;
+----
+a INT true NULL
+b INT true NULL
+rowid INT false experimental_unique_int()
+c STRING true NULL


### PR DESCRIPTION
Mark the rowid column (auto created for tables without primary keys)
as hidden, which is a new field of ColumnDescriptor.

Do not use any hidden columns in implied column lists (like SELECT *
or INSERT with no column listing). The rowid column still shows up
in places like SHOW COLUMNS, and can be manually specified in any
operation (SELECT rowid from t).

Fixes #3293

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/3318)

<!-- Reviewable:end -->
