### PR TITLE
Refactor creation of bootstrap DBs

### DIFF
--- a/config/config_test.go
+++ b/config/config_test.go
@@ -176,7 +176,7 @@ func TestGetLargestID(t *testing.T) {
 		}, 12, ""},
 
 		// Real SQL layout.
-		{sql.GetInitialSystemValues(), keys.ZonesTableID, ""},
+		{sql.MakeMetadataSchema().GetInitialValues(), keys.ZonesTableID, ""},
 	}
 
 	cfg := config.SystemConfig{}
@@ -204,9 +204,9 @@ func TestComputeSplits(t *testing.T) {
 	const start = keys.MaxReservedDescID + 1
 
 	// Real SQL system tables only.
-	baseSql := sql.GetInitialSystemValues()
+	baseSql := sql.MakeMetadataSchema().GetInitialValues()
 	// Real SQL system tables plus some user stuff.
-	userSql := append(sql.GetInitialSystemValues(),
+	userSql := append(sql.MakeMetadataSchema().GetInitialValues(),
 		descriptor(start), descriptor(start+1), descriptor(start+5))
 
 	allSplits := []uint32{start, start + 1, start + 2, start + 3, start + 4, start + 5}

--- a/kv/dist_sender_server_test.go
+++ b/kv/dist_sender_server_test.go
@@ -327,7 +327,7 @@ func TestSingleRangeReverseScan(t *testing.T) {
 	}
 	// Case 3: Test roachpb.KeyMax
 	// This span covers the system DB keys.
-	wanted := 1 + len(sql.GetInitialSystemValues())
+	wanted := 1 + len(sql.MakeMetadataSchema().GetInitialValues())
 	if rows, err := db.ReverseScan("g", roachpb.KeyMax, 0); err != nil {
 		t.Fatalf("unexpected error on ReverseScan: %s", err)
 	} else if l := len(rows); l != wanted {

--- a/roachpb/data.go
+++ b/roachpb/data.go
@@ -765,3 +765,23 @@ func (rs RSpan) Intersect(desc *RangeDescriptor) (RSpan, error) {
 	}
 	return RSpan{key, endKey}, nil
 }
+
+// KeyValueByKey implements sorting of a slice of KeyValues by key.
+type KeyValueByKey []KeyValue
+
+// Len implements sort.Interface.
+func (kv KeyValueByKey) Len() int {
+	return len(kv)
+}
+
+// Less implements sort.Interface.
+func (kv KeyValueByKey) Less(i, j int) bool {
+	return bytes.Compare(kv[i].Key, kv[j].Key) < 0
+}
+
+// Swap implements sort.Interface.
+func (kv KeyValueByKey) Swap(i, j int) {
+	kv[i], kv[j] = kv[j], kv[i]
+}
+
+var _ sort.Interface = KeyValueByKey{}

--- a/server/node.go
+++ b/server/node.go
@@ -131,9 +131,7 @@ func BootstrapCluster(clusterID string, engines []engine.Engine, stopper *stop.S
 		// not create the range, just its data.  Only do this if this is the
 		// first store.
 		if i == 0 {
-			// TODO(marc): this is better than having storage/ import sql, but still
-			// not great. Find a better place to keep those.
-			initialValues := sql.GetInitialSystemValues()
+			initialValues := sql.MakeMetadataSchema().GetInitialValues()
 			if err := s.BootstrapRange(initialValues); err != nil {
 				return nil, err
 			}

--- a/server/node_test.go
+++ b/server/node_test.go
@@ -134,7 +134,7 @@ func TestBootstrapCluster(t *testing.T) {
 		roachpb.Key("\x04store-idgen"),
 	}
 	// Add the initial keys for sql.
-	for _, kv := range sql.GetInitialSystemValues() {
+	for _, kv := range sql.MakeMetadataSchema().GetInitialValues() {
 		expectedKeys = append(expectedKeys, kv.Key)
 	}
 	// Resort the list. The sql values are not sorted.

--- a/sql/create_test.go
+++ b/sql/create_test.go
@@ -71,7 +71,7 @@ func TestDatabaseDescriptor(t *testing.T) {
 	if kvs, err := kvDB.Scan(start, start.PrefixEnd(), 0); err != nil {
 		t.Fatal(err)
 	} else {
-		if a, e := len(kvs), sql.NumUsedSystemIDs; a != e {
+		if a, e := len(kvs), sql.NumSystemDescriptors; a != e {
 			t.Fatalf("expected %d keys to have been written, found %d keys", e, a)
 		}
 	}

--- a/sql/metadata.go
+++ b/sql/metadata.go
@@ -1,0 +1,168 @@
+// Copyright 2015 The Cockroach Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+// implied. See the License for the specific language governing
+// permissions and limitations under the License. See the AUTHORS file
+// for names of contributors.
+//
+// Author: Matt Tracy (matt@cockroachlabs.com)
+
+package sql
+
+import (
+	"sort"
+
+	"github.com/cockroachdb/cockroach/keys"
+	"github.com/cockroachdb/cockroach/roachpb"
+	"github.com/cockroachdb/cockroach/util/log"
+)
+
+// MetadataSchema is used to construct the initial sql schema for a new
+// CockroachDB cluster being bootstrapped. Tables and databases must be
+// installed on the underlying persistent storage before a cockroach store can
+// start running correctly, thus requiring this special initialization.
+type MetadataSchema struct {
+	systemObjects []systemObject
+	databases     []MetadataDatabase
+}
+
+type systemObject struct {
+	parentID ID
+	desc     descriptorProto
+}
+
+// MetadataDatabase represents a database to be created on a bootstrapped
+// cockroach cluster. This structure should only be created by calling the
+// "AddDatabase()" method of a MetadataSchema object.
+type MetadataDatabase struct {
+	name       string
+	privileges *PrivilegeDescriptor
+	tables     []metadataTable
+}
+
+type metadataTable struct {
+	definition string
+	privileges *PrivilegeDescriptor
+}
+
+// MakeMetadataSchema constructs a new MetadataSchema value which contains the
+// sql SystemDB.
+func MakeMetadataSchema() MetadataSchema {
+	ms := MetadataSchema{}
+	addSystemDatabaseToSchema(&ms)
+	return ms
+}
+
+// AddSystemDescriptor adds a new system descriptor to the schema. System
+// descriptors have well-known, static descriptors; however, the MetadataSchema
+// is used to generate the KeyValue objects needed to install them on a new
+// cockroach store.
+func (ms *MetadataSchema) AddSystemDescriptor(parentID ID, desc descriptorProto) {
+	ms.systemObjects = append(ms.systemObjects, systemObject{parentID, desc})
+}
+
+// AddDatabase adds a metadata database to the initial schema. The database must
+// be fully described (via calls to MetadataDatabase.AddTable()) before adding
+// it to the MetadataSchema.
+func (ms *MetadataSchema) AddDatabase(db MetadataDatabase) {
+	ms.databases = append(ms.databases, db)
+}
+
+// MakeMetadataDatabase constructs a new MetadataDatabase value used to describe
+// a database in a MetadataSchema.
+func MakeMetadataDatabase(name string, privileges *PrivilegeDescriptor) MetadataDatabase {
+	return MetadataDatabase{
+		name:       name,
+		privileges: privileges,
+	}
+}
+
+// AddTable adds a new table to this MetadataDatabase descriptor.
+func (md *MetadataDatabase) AddTable(definition string, privileges *PrivilegeDescriptor) {
+	md.tables = append(md.tables, metadataTable{
+		definition: definition,
+		privileges: privileges,
+	})
+}
+
+// GetInitialValues returns the set of initial K/V values which should be added to
+// a bootstrapping CockroachDB cluster in order to create the tables contained
+// in the schema.
+func (ms MetadataSchema) GetInitialValues() []roachpb.KeyValue {
+	var ret []roachpb.KeyValue
+
+	// addDescriptor generates the needed KeyValue objects to install a
+	// descriptor on a new cluster.
+	addDescriptor := func(parentID ID, desc descriptorProto) {
+		// Create name metadata key.
+		value := roachpb.Value{}
+		value.SetInt(int64(desc.GetID()))
+		ret = append(ret, roachpb.KeyValue{
+			Key:   MakeNameMetadataKey(parentID, desc.GetName()),
+			Value: value,
+		})
+
+		// Create descriptor metadata key.
+		value = roachpb.Value{}
+		wrappedDesc := wrapDescriptor(desc)
+		if err := value.SetProto(wrappedDesc); err != nil {
+			log.Fatalf("could not marshal %v", desc)
+		}
+		ret = append(ret, roachpb.KeyValue{
+			Key:   MakeDescMetadataKey(desc.GetID()),
+			Value: value,
+		})
+	}
+
+	// Generate initial values for system databases and tables, which have
+	// static descriptors that were generated elsewhere.
+	for _, sysObj := range ms.systemObjects {
+		addDescriptor(sysObj.parentID, sysObj.desc)
+	}
+
+	// Initial value of descriptor ID generator. Descriptor IDs will be generated
+	// sequentially for non-system tables created as part of the initial schema.
+	initialDescID := keys.MaxReservedDescID + 1
+	nextID := func() ID {
+		next := initialDescID
+		initialDescID++
+		return ID(next)
+	}
+
+	// Generate initial values for non-system metadata tables, which do not need
+	// well-known IDs.
+	for _, db := range ms.databases {
+		dbID := nextID()
+		addDescriptor(keys.RootNamespaceID, &DatabaseDescriptor{
+			Name:       db.name,
+			ID:         dbID,
+			Privileges: db.privileges,
+		})
+
+		for _, tbl := range db.tables {
+			desc := createTableDescriptor(nextID(), dbID, tbl.definition, tbl.privileges)
+			addDescriptor(dbID, &desc)
+		}
+	}
+
+	// Save ID generator value.
+	value := roachpb.Value{}
+	value.SetInt(int64(initialDescID))
+	ret = append(ret, roachpb.KeyValue{
+		Key:   keys.DescIDGenerator,
+		Value: value,
+	})
+
+	// Sort returned key values; this is valuable because it matches the way the
+	// objects would be sorted if read from the engine.
+	sort.Sort(roachpb.KeyValueByKey(ret))
+	return ret
+}

--- a/storage/client_split_test.go
+++ b/storage/client_split_test.go
@@ -546,7 +546,7 @@ func TestStoreRangeSystemSplits(t *testing.T) {
 	store, stopper := createTestStore(t)
 	defer stopper.Stop()
 
-	initialSystemValues := sql.GetInitialSystemValues()
+	initialSystemValues := sql.MakeMetadataSchema().GetInitialValues()
 	numInitialValues := len(initialSystemValues)
 	// Write the initial sql values to the system DB as well
 	// as the equivalent of table descriptors for X user tables.

--- a/storage/client_test.go
+++ b/storage/client_test.go
@@ -128,7 +128,7 @@ func createTestStoreWithEngine(t *testing.T, eng engine.Engine, clock *hlc.Clock
 	}
 	localSender.AddStore(store)
 	if bootstrap {
-		if err := store.BootstrapRange(sql.GetInitialSystemValues()); err != nil {
+		if err := store.BootstrapRange(sql.MakeMetadataSchema().GetInitialValues()); err != nil {
 			t.Fatal(err)
 		}
 	}
@@ -413,7 +413,7 @@ func (m *multiTestContext) addStore() {
 
 		// Bootstrap the initial range on the first store
 		if idx == 0 {
-			if err := store.BootstrapRange(sql.GetInitialSystemValues()); err != nil {
+			if err := store.BootstrapRange(sql.MakeMetadataSchema().GetInitialValues()); err != nil {
 				m.t.Fatal(err)
 			}
 		}


### PR DESCRIPTION
This commit refactors the way that the SystemDB and its associated tables are
created, in order to allow for additional arbitrary tables to be created on a
cluster which is being bootstrapped.

Commit creates a new "MetadataSchema" to which databases and tables can be
added; MetadataSchema exposes a "GetInitialValues()" method which returns the
necessary KeyValue objects to bootstrap the schema onto a new Cockroach cluster.

The descriptors for SystemDB tables are still created statically, as some of
them (such as DescriptorTable) are needed during the bootstrap process. These
descriptors are added directly to the MetadataSchema.

Non-System tables can also be added; in the case of these tables, the SQL schema
definition is provided to SystemDB rather than a descriptor.

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/3322)

<!-- Reviewable:end -->
