### PR TITLE
Only store the MVCCMetadata value when there is an intent.

### DIFF
--- a/storage/engine/doc.go
+++ b/storage/engine/doc.go
@@ -35,15 +35,17 @@ Notes on MVCC architecture
 
 Each MVCC value contains a metadata key/value pair and one or more
 version key/value pairs. The MVCC metadata key is the actual key for
-the value, binary encoded using the SQL binary encoding scheme which
-contains a sentinel byte of 0x25, following by a 7-bit encoding of the
-key data with 1s in the high bit and terminated by a nil byte. The
-MVCC metadata value is of type MVCCMetadata and contains the
-most recent version timestamp and an optional roachpb.Transaction
-message. If set, the most recent version of the MVCC value is a
-transactional "intent". It also contains some information on the size
-of the most recent version's key and value for efficient stat counter
-computations.
+the value, using the util/encoding.EncodeBytes scheme. The MVCC
+metadata value is of type MVCCMetadata and contains the most recent
+version timestamp and an optional roachpb.Transaction message. If
+set, the most recent version of the MVCC value is a transactional
+"intent". It also contains some information on the size of the most
+recent version's key and value for efficient stat counter
+computations. Notice that it is not necessary to explicitly store the
+MVCC metadata as its contents can be reconstructed from the most
+recent versioned value as long as an intent is not present. The
+implementation takes advantage of this and deletes the MVCC metadata
+when possible.
 
 Each MVCC version key/value pair has a key which is also
 binary-encoded, but is suffixed with a decreasing, big-endian

--- a/storage/engine/mvcc.go
+++ b/storage/engine/mvcc.go
@@ -65,7 +65,14 @@ func (k MVCCKey) Equal(l MVCCKey) bool {
 
 // String returns a string-formatted version of the key.
 func (k MVCCKey) String() string {
-	return fmt.Sprintf("%q", []byte(k))
+	key, ts, isValue, err := MVCCDecodeKey(k)
+	if err != nil {
+		return fmt.Sprint(err)
+	}
+	if !isValue {
+		return key.String()
+	}
+	return fmt.Sprintf("%s/%s", key, ts)
 }
 
 type encodedSpan struct {
@@ -297,8 +304,6 @@ func updateStatsOnResolve(ms *MVCCStats, key roachpb.Key, origMetaKeySize, origM
 	} else {
 		if !meta.Deleted {
 			ms.LiveBytes += keyDiff + valDiff
-		} else {
-			ms.GCBytesAge += MVCCComputeGCBytesAge(keyDiff+valDiff, origAgeSeconds)
 		}
 		ms.KeyBytes += keyDiff
 		ms.ValBytes += valDiff
@@ -489,11 +494,8 @@ func MVCCGet(engine Engine, key roachpb.Key, timestamp roachpb.Timestamp, consis
 	defer iter.Close()
 
 	metaKey := mvccEncodeKey(buf.key[:0], key)
-	iter.Seek(metaKey)
-	if !iter.Valid() || bytes.Compare(iter.unsafeKey(), metaKey) != 0 {
-		return nil, nil, nil
-	}
-	if err := iter.ValueProto(&buf.meta); err != nil {
+	ok, _, _, err := mvccGetMetadata(iter, metaKey, &buf.meta)
+	if !ok || err != nil {
 		return nil, nil, err
 	}
 
@@ -504,6 +506,28 @@ func MVCCGet(engine Engine, key roachpb.Key, timestamp roachpb.Timestamp, consis
 		buf.value.Reset()
 	}
 	return value, intents, err
+}
+
+func mvccGetMetadata(iter Iterator, metaKey MVCCKey,
+	meta *MVCCMetadata) (ok bool, keyBytes, valBytes int64, err error) {
+	iter.Seek(metaKey)
+	if !iter.Valid() || !bytes.HasPrefix(iter.unsafeKey(), metaKey) {
+		return false, 0, 0, nil
+	}
+
+	if len(iter.unsafeKey()) == len(metaKey) {
+		if err := iter.ValueProto(meta); err != nil {
+			return false, 0, 0, err
+		}
+		return true, int64(len(iter.unsafeKey())), int64(len(iter.unsafeValue())), nil
+	}
+
+	meta.Reset()
+	meta.KeyBytes = mvccVersionTimestampSize
+	meta.ValBytes = int64(len(iter.unsafeValue()))
+	meta.Deleted = len(iter.unsafeValue()) == 0
+	_, meta.Timestamp, _, err = mvccDecodeKey(iter.unsafeKey(), nil)
+	return err == nil, int64(len(iter.unsafeKey())) - meta.KeyBytes, 0, err
 }
 
 // mvccGetInternal parses the MVCCMetadata from the specified raw key
@@ -601,7 +625,9 @@ func mvccGetInternal(iter Iterator, key roachpb.Key, metaKey MVCCKey,
 		seekKey = MVCCEncodeVersionKey(key, timestamp)
 	}
 
-	iter.Seek(seekKey)
+	if !bytes.Equal(iter.unsafeKey(), seekKey) {
+		iter.Seek(seekKey)
+	}
 	if !iter.Valid() {
 		if err := iter.Error(); err != nil {
 			return nil, nil, err
@@ -723,8 +749,11 @@ func mvccPutInternal(engine Engine, ms *MVCCStats, key roachpb.Key, timestamp ro
 		return emptyKeyError()
 	}
 
+	iter := engine.NewIterator(true /* prefix iteration */)
+	defer iter.Close()
+
 	metaKey := mvccEncodeKey(buf.key[:0], key)
-	ok, origMetaKeySize, origMetaValSize, err := engine.GetProto(metaKey, &buf.meta)
+	ok, origMetaKeySize, origMetaValSize, err := mvccGetMetadata(iter, metaKey, &buf.meta)
 	if err != nil {
 		return err
 	}
@@ -812,9 +841,18 @@ func mvccPutInternal(engine Engine, ms *MVCCStats, key roachpb.Key, timestamp ro
 	newMeta.KeyBytes = mvccVersionTimestampSize
 	newMeta.ValBytes = valueSize
 	newMeta.Deleted = value == nil
-	metaKeySize, metaValSize, err := PutProto(engine, metaKey, newMeta)
-	if err != nil {
-		return err
+
+	var metaKeySize, metaValSize int64
+	if newMeta.Txn != nil {
+		metaKeySize, metaValSize, err = PutProto(engine, metaKey, newMeta)
+		if err != nil {
+			return err
+		}
+	} else {
+		// Per-key stats count the full-key once and mvccVersionTimestampSize for
+		// each versioned value. We maintain that accounting even when the MVCC
+		// metadata is implicit.
+		metaKeySize = int64(len(metaKey))
 	}
 
 	// Update MVCC stats.
@@ -947,22 +985,31 @@ func MVCCDeleteRange(engine Engine, ms *MVCCStats, key, endKey roachpb.Key, max 
 	return num, nil
 }
 
-func getScanMetaKey(iter Iterator, encEndKey MVCCKey) (roachpb.Key, MVCCKey, error) {
+func getScanMeta(iter Iterator, encEndKey MVCCKey, meta *MVCCMetadata) (roachpb.Key, MVCCKey, error) {
 	metaKey := iter.Key()
 	if bytes.Compare(metaKey, encEndKey) >= 0 {
 		return nil, nil, iter.Error()
 	}
-	key, _, isValue, err := MVCCDecodeKey(metaKey)
+	key, ts, isValue, err := MVCCDecodeKey(metaKey)
 	if err != nil {
 		return nil, nil, err
 	}
 	if isValue {
-		return nil, nil, util.Errorf("expected an MVCC metadata key: %q", metaKey)
+		meta.Reset()
+		meta.Timestamp = ts
+		meta.KeyBytes = int64(len(iter.unsafeKey()))
+		meta.ValBytes = int64(len(iter.unsafeValue()))
+		meta.Deleted = len(iter.unsafeValue()) == 0
+		metaKey = metaKey[:len(metaKey)-int(mvccVersionTimestampSize)]
+		return key, metaKey, nil
+	}
+	if err := iter.ValueProto(meta); err != nil {
+		return nil, nil, err
 	}
 	return key, metaKey, nil
 }
 
-func getReverseScanMetaKey(iter Iterator, encEndKey MVCCKey) (roachpb.Key, MVCCKey, error) {
+func getReverseScanMeta(iter Iterator, encEndKey MVCCKey, meta *MVCCMetadata) (roachpb.Key, MVCCKey, error) {
 	metaKey := iter.Key()
 	// The metaKey < encEndKey is exceeding the boundary.
 	if bytes.Compare(metaKey, encEndKey) < 0 {
@@ -984,14 +1031,22 @@ func getReverseScanMetaKey(iter Iterator, encEndKey MVCCKey) (roachpb.Key, MVCCK
 			return nil, nil, iter.Error()
 		}
 
+		meta.Reset()
 		metaKey = iter.Key()
-		_, _, isValue, err = MVCCDecodeKey(metaKey)
+		_, meta.Timestamp, isValue, err = MVCCDecodeKey(metaKey)
 		if err != nil {
 			return nil, nil, err
 		}
 		if isValue {
-			return nil, nil, util.Errorf("expected an MVCC metadata key: %q", metaKey)
+			meta.KeyBytes = mvccVersionTimestampSize
+			meta.ValBytes = int64(len(iter.unsafeValue()))
+			meta.Deleted = len(iter.unsafeValue()) == 0
+			metaKey = metaKey[:len(metaKey)-int(mvccVersionTimestampSize)]
+			return key, metaKey, nil
 		}
+	}
+	if err := iter.ValueProto(meta); err != nil {
+		return nil, nil, err
 	}
 	return key, metaKey, nil
 }
@@ -1049,11 +1104,12 @@ func MVCCIterate(engine Engine, startKey, endKey roachpb.Key, timestamp roachpb.
 	buf := getBufferPool.Get().(*getBuffer)
 	defer getBufferPool.Put(buf)
 
-	// getMetaKeyFunc is used to get the key and the meta key of the logic row.
-	// encEndKey is used to judge whether iterator exceeds the boundary or not.
-	type getMetaKeyFunc func(iter Iterator, encEndKey MVCCKey) (roachpb.Key,
-		MVCCKey, error)
-	var getMetaKey getMetaKeyFunc
+	// getMetaFunc is used to get the meta, key and the meta key of the current
+	// row. encEndKey is used to judge whether iterator exceeds the boundary or
+	// not.
+	type getMetaFunc func(iter Iterator, encEndKey MVCCKey,
+		meta *MVCCMetadata) (roachpb.Key, MVCCKey, error)
+	var getMeta getMetaFunc
 
 	// We store encEndKey and encKey in the same buffer to avoid memory
 	// allocations.
@@ -1063,12 +1119,12 @@ func MVCCIterate(engine Engine, startKey, endKey roachpb.Key, timestamp roachpb.
 		encEndKey = mvccEncodeKey(buf.key[:0], startKey)
 		keyBuf = encEndKey[len(encEndKey):]
 		encKey = mvccEncodeKey(keyBuf, endKey)
-		getMetaKey = getReverseScanMetaKey
+		getMeta = getReverseScanMeta
 	} else {
 		encEndKey = mvccEncodeKey(buf.key[:0], endKey)
 		keyBuf = encEndKey[len(encEndKey):]
 		encKey = mvccEncodeKey(keyBuf, startKey)
-		getMetaKey = getScanMetaKey
+		getMeta = getScanMeta
 	}
 
 	// Get a new iterator.
@@ -1104,7 +1160,7 @@ func MVCCIterate(engine Engine, startKey, endKey roachpb.Key, timestamp roachpb.
 	var wiErr error
 
 	for {
-		key, metaKey, err := getMetaKey(iter, encEndKey)
+		key, metaKey, err := getMeta(iter, encEndKey, &buf.meta)
 		if err != nil {
 			return nil, err
 		}
@@ -1113,9 +1169,6 @@ func MVCCIterate(engine Engine, startKey, endKey roachpb.Key, timestamp roachpb.
 			break
 		}
 
-		if err := iter.ValueProto(&buf.meta); err != nil {
-			return nil, err
-		}
 		value, newIntents, err := mvccGetInternal(iter, key, metaKey, timestamp, consistent, txn, buf)
 		intents = append(intents, newIntents...)
 		if value != nil {
@@ -1150,8 +1203,8 @@ func MVCCIterate(engine Engine, startKey, endKey roachpb.Key, timestamp roachpb.
 				}
 				break
 			}
-			// Move the iterator back, which gets us into the previous row
-			// (getMetaKey moves us further back to the meta key).
+			// Move the iterator back, which gets us into the previous row (getMeta
+			// moves us further back to the meta key).
 			iter.Prev()
 			if !iter.Valid() {
 				if err := iter.Error(); err != nil {
@@ -1229,15 +1282,18 @@ func MVCCResolveWriteIntent(engine Engine, ms *MVCCStats, key roachpb.Key, times
 	commit := txn.Status == roachpb.COMMITTED
 	pushed := txn.Status == roachpb.PENDING && meta.Txn.Timestamp.Less(txn.Timestamp)
 	if (commit || pushed) && meta.Txn.Epoch == txn.Epoch {
-		origTimestamp := meta.Timestamp
 		newMeta := *meta
-		newMeta.Timestamp = txn.Timestamp
-		if pushed { // keep intent if we're pushing timestamp
+		var metaKeySize, metaValSize int64
+		var err error
+		if pushed {
+			// Keep intent if we're pushing timestamp.
+			newMeta.Timestamp = txn.Timestamp
 			newMeta.Txn = txn
+			metaKeySize, metaValSize, err = PutProto(engine, metaKey, &newMeta)
 		} else {
-			newMeta.Txn = nil
+			metaKeySize = int64(len(metaKey))
+			err = engine.Clear(metaKey)
 		}
-		metaKeySize, metaValSize, err := PutProto(engine, metaKey, &newMeta)
 		if err != nil {
 			return err
 		}
@@ -1246,11 +1302,8 @@ func MVCCResolveWriteIntent(engine Engine, ms *MVCCStats, key roachpb.Key, times
 		updateStatsOnResolve(ms, key, origMetaKeySize, origMetaValSize, metaKeySize, metaValSize, &newMeta, commit, origAgeSeconds)
 
 		// If timestamp of value changed, need to rewrite versioned value.
-		// TODO(spencer,tobias): think about a new merge operator for
-		// updating key of intent value to new timestamp instead of
-		// read-then-write.
-		if !origTimestamp.Equal(txn.Timestamp) {
-			origKey := MVCCEncodeVersionKey(key, origTimestamp)
+		if !meta.Timestamp.Equal(txn.Timestamp) {
+			origKey := MVCCEncodeVersionKey(key, meta.Timestamp)
 			newKey := MVCCEncodeVersionKey(key, txn.Timestamp)
 			valBytes, err := engine.Get(origKey)
 			if err != nil {
@@ -1308,6 +1361,7 @@ func MVCCResolveWriteIntent(engine Engine, ms *MVCCStats, key roachpb.Key, times
 			return util.Errorf("expected an MVCC value key: %s", kvs[0].Key)
 		}
 		// Get the bytes for the next version so we have size for stat counts.
+		// TODO(peter): We don't actually need the value, only the value size.
 		value := roachpb.Value{}
 		var valueSize int64
 		ok, _, valueSize, err = engine.GetProto(kvs[0].Key, &value)
@@ -1316,15 +1370,15 @@ func MVCCResolveWriteIntent(engine Engine, ms *MVCCStats, key roachpb.Key, times
 		}
 		// Update the keyMetadata with the next version.
 		newMeta := &MVCCMetadata{
-			Timestamp: ts,
-			Deleted:   !ok,
-			KeyBytes:  mvccVersionTimestampSize,
-			ValBytes:  valueSize,
+			Deleted:  !ok,
+			KeyBytes: mvccVersionTimestampSize,
+			ValBytes: valueSize,
 		}
-		metaKeySize, metaValSize, err := PutProto(engine, metaKey, newMeta)
-		if err != nil {
+		if err := engine.Clear(metaKey); err != nil {
 			return err
 		}
+		metaKeySize := int64(len(metaKey))
+		metaValSize := int64(0)
 		restoredAgeSeconds := timestamp.WallTime/1E9 - ts.WallTime/1E9
 
 		// Update stat counters with older version.
@@ -1362,10 +1416,9 @@ func MVCCResolveWriteIntentRange(engine Engine, ms *MVCCStats, key, endKey roach
 		if err != nil {
 			return 0, err
 		}
-		if isValue {
-			return 0, util.Errorf("expected an MVCC metadata key: %s", kvs[0].Key)
+		if !isValue {
+			err = MVCCResolveWriteIntent(engine, ms, currentKey, timestamp, txn)
 		}
-		err = MVCCResolveWriteIntent(engine, ms, currentKey, timestamp, txn)
 		if err != nil {
 			log.Warningf("failed to resolve intent for key %q: %v", currentKey, err)
 		} else {
@@ -1392,17 +1445,18 @@ func MVCCGarbageCollect(engine Engine, ms *MVCCStats, keys []roachpb.GCRequest_G
 	iter := engine.NewIterator(false)
 	defer iter.Close()
 	// Iterate through specified GC keys.
+	meta := &MVCCMetadata{}
 	for _, gcKey := range keys {
 		encKey := MVCCEncodeKey(gcKey.Key)
-		iter.Seek(encKey)
-		if !iter.Valid() {
+		ok, metaKeySize, metaValSize, err := mvccGetMetadata(iter, encKey, meta)
+		if err != nil {
+			return err
+		}
+		if !ok {
 			return util.Errorf("could not seek to key %q", gcKey.Key)
 		}
+		implicitMeta := len(iter.Key()) > len(encKey)
 		// First, check whether all values of the key are being deleted.
-		meta := &MVCCMetadata{}
-		if err := proto.Unmarshal(iter.Value(), meta); err != nil {
-			return util.Errorf("unable to marshal mvcc meta: %s", err)
-		}
 		if !gcKey.Timestamp.Less(meta.Timestamp) {
 			// For version keys, don't allow GC'ing the meta key if it's
 			// not marked deleted. However, for inline values we allow it;
@@ -1415,16 +1469,24 @@ func MVCCGarbageCollect(engine Engine, ms *MVCCStats, keys []roachpb.GCRequest_G
 				return util.Errorf("request to GC intent at %q", gcKey.Key)
 			}
 			ageSeconds := timestamp.WallTime/1E9 - meta.Timestamp.WallTime/1E9
-			updateStatsOnGC(ms, gcKey.Key, int64(len(iter.Key())), int64(len(iter.Value())), meta, ageSeconds)
-			if err := engine.Clear(iter.Key()); err != nil {
-				return err
+			updateStatsOnGC(ms, gcKey.Key, metaKeySize, metaValSize, meta, ageSeconds)
+			if !implicitMeta {
+				if err := engine.Clear(iter.Key()); err != nil {
+					return err
+				}
 			}
 		}
 
+		if !implicitMeta {
+			// The iter is pointing at an MVCCMetadata, advance to the next entry.
+			iter.Next()
+		}
+
 		// Now, iterate through all values, GC'ing ones which have expired.
-		// Note that we start the for loop by iterating once to move past
-		// the metadata key.
-		for iter.Next(); iter.Valid(); iter.Next() {
+		for ; iter.Valid(); iter.Next() {
+			if !bytes.HasPrefix(iter.Key(), encKey) {
+				break
+			}
 			_, ts, isValue, err := MVCCDecodeKey(iter.Key())
 			if err != nil {
 				return err
@@ -1496,6 +1558,7 @@ func MVCCFindSplitKey(engine Engine, rangeID roachpb.RangeID, key, endKey roachp
 	sizeSoFar := int64(0)
 	bestSplitKey := encStartKey
 	bestSplitDiff := int64(math.MaxInt64)
+	var lastKey roachpb.Key
 
 	if err := engine.Iterate(encStartKey, encEndKey, func(kv MVCCKeyValue) (bool, error) {
 		// Is key within a legal key range?
@@ -1515,15 +1578,16 @@ func MVCCFindSplitKey(engine Engine, rangeID roachpb.RangeID, key, endKey roachp
 		done := !bestSplitKey.Equal(encStartKey) && diff > bestSplitDiff
 
 		// Add this key/value to the size scanned so far.
-		_, _, isValue, err := MVCCDecodeKey(kv.Key)
+		key, _, isValue, err := MVCCDecodeKey(kv.Key)
 		if err != nil {
 			return false, err
 		}
-		if isValue {
+		if isValue && bytes.Equal(key, lastKey) {
 			sizeSoFar += mvccVersionTimestampSize + int64(len(kv.Value))
 		} else {
 			sizeSoFar += int64(len(kv.Key) + len(kv.Value))
 		}
+		lastKey = key
 
 		return done, nil
 	}); err != nil {

--- a/storage/gc_queue.go
+++ b/storage/gc_queue.go
@@ -204,25 +204,29 @@ func (gcq *gcQueue) process(now roachpb.Timestamp, repl *Replica,
 
 	// Iterate through the keys and values of this replica's range.
 	for ; iter.Valid(); iter.Next() {
-		baseKey, ts, isValue, err := engine.MVCCDecodeKey(iter.Key())
+		baseKey, _, isValue, err := engine.MVCCDecodeKey(iter.Key())
 		if err != nil {
 			log.Errorf("unable to decode MVCC key: %q: %v", iter.Key(), err)
 			continue
 		}
-		if !isValue {
+		if !isValue || !baseKey.Equal(expBaseKey) {
 			// Moving to the next key (& values).
 			processKeysAndValues()
 			expBaseKey = baseKey
-			keys = []engine.MVCCKey{iter.Key()}
-			vals = [][]byte{iter.Value()}
-		} else {
-			if !baseKey.Equal(expBaseKey) {
-				log.Errorf("unexpectedly found a value for %q with ts=%s; expected key %q", baseKey, ts, expBaseKey)
+			if !isValue {
+				keys = []engine.MVCCKey{iter.Key()}
+				vals = [][]byte{iter.Value()}
 				continue
 			}
-			keys = append(keys, iter.Key())
-			vals = append(vals, iter.Value())
+			// An implicit metadata.
+			keys = []engine.MVCCKey{engine.MVCCEncodeKey(baseKey)}
+			// A nil value for the encoded MVCCMetadata. This will unmarshal to an
+			// empty MVCCMetadata which is sufficient for processKeysAndValues to
+			// determine that there is no intent.
+			vals = [][]byte{nil}
 		}
+		keys = append(keys, iter.Key())
+		vals = append(vals, iter.Value())
 	}
 	if iter.Error() != nil {
 		return iter.Error()

--- a/storage/gc_queue_test.go
+++ b/storage/gc_queue_test.go
@@ -235,12 +235,10 @@ func TestGCQueueProcess(t *testing.T) {
 		key roachpb.Key
 		ts  roachpb.Timestamp
 	}{
-		{key1, roachpb.ZeroTimestamp},
 		{key1, ts5},
 		{key3, roachpb.ZeroTimestamp},
 		{key3, ts5},
 		{key3, ts2},
-		{key4, roachpb.ZeroTimestamp},
 		{key4, ts2},
 		{key6, roachpb.ZeroTimestamp},
 		{key6, ts5},
@@ -248,7 +246,6 @@ func TestGCQueueProcess(t *testing.T) {
 		{key7, roachpb.ZeroTimestamp},
 		{key7, ts4},
 		{key7, ts2},
-		{key8, roachpb.ZeroTimestamp},
 		{key8, ts2},
 	}
 	// Read data directly from engine to avoid intent errors from MVCC.
@@ -419,7 +416,7 @@ func TestGCQueueTransactionTable(t *testing.T) {
 			}
 			if expGC := (sp.newStatus == -1); expGC {
 				if expGC != !ok {
-					return fmt.Errorf("%s: expected gc: %t, but found %s", strKey, expGC, txn)
+					return fmt.Errorf("%s: expected gc: %t, but found %s\n%s", strKey, expGC, txn, roachpb.Key(strKey))
 				}
 			} else if sp.newStatus != txn.Status {
 				return fmt.Errorf("%s: expected status %s, but found %s", strKey, sp.newStatus, txn.Status)

--- a/storage/replica_data_iter_test.go
+++ b/storage/replica_data_iter_test.go
@@ -91,8 +91,9 @@ func createRangeData(r *Replica, t *testing.T) []engine.MVCCKey {
 		if err := engine.MVCCPut(r.store.Engine(), nil, keyTS.key, keyTS.ts, roachpb.MakeValueFromString("value"), nil); err != nil {
 			t.Fatal(err)
 		}
-		keys = append(keys, engine.MVCCEncodeKey(keyTS.key))
-		if !keyTS.ts.Equal(ts0) {
+		if keyTS.ts.Equal(ts0) {
+			keys = append(keys, engine.MVCCEncodeKey(keyTS.key))
+		} else {
 			keys = append(keys, engine.MVCCEncodeVersionKey(keyTS.key, keyTS.ts))
 		}
 	}

--- a/storage/replica_test.go
+++ b/storage/replica_test.go
@@ -2660,7 +2660,7 @@ func TestRangeStatsComputation(t *testing.T) {
 	if _, err := client.SendWrapped(tc.Sender(), tc.rng.context(), &pArgs); err != nil {
 		t.Fatal(err)
 	}
-	expMS := engine.MVCCStats{LiveBytes: 38, KeyBytes: 16, ValBytes: 22, IntentBytes: 0, LiveCount: 1, KeyCount: 1, ValCount: 1, IntentCount: 0, SysBytes: 63, SysCount: 1}
+	expMS := engine.MVCCStats{LiveBytes: 26, KeyBytes: 16, ValBytes: 10, IntentBytes: 0, LiveCount: 1, KeyCount: 1, ValCount: 1, IntentCount: 0, IntentAge: 0, GCBytesAge: 0, SysBytes: 63, SysCount: 1, LastUpdateNanos: 0}
 	verifyRangeStats(tc.engine, tc.rng.Desc().RangeID, expMS, t)
 
 	// Put a 2nd value transactionally.
@@ -2670,7 +2670,7 @@ func TestRangeStatsComputation(t *testing.T) {
 	if _, err := client.SendWrappedWith(tc.Sender(), tc.rng.context(), roachpb.Header{Txn: txn}, &pArgs); err != nil {
 		t.Fatal(err)
 	}
-	expMS = engine.MVCCStats{LiveBytes: 130, KeyBytes: 32, ValBytes: 98, IntentBytes: 22, LiveCount: 2, KeyCount: 2, ValCount: 2, IntentCount: 1, SysBytes: 63, SysCount: 1}
+	expMS = engine.MVCCStats{LiveBytes: 118, KeyBytes: 32, ValBytes: 86, IntentBytes: 22, LiveCount: 2, KeyCount: 2, ValCount: 2, IntentCount: 1, IntentAge: 0, GCBytesAge: 0, SysBytes: 63, SysCount: 1, LastUpdateNanos: 0}
 	verifyRangeStats(tc.engine, tc.rng.Desc().RangeID, expMS, t)
 
 	// Resolve the 2nd value.
@@ -2685,7 +2685,7 @@ func TestRangeStatsComputation(t *testing.T) {
 	if _, err := client.SendWrapped(tc.Sender(), tc.rng.context(), rArgs); err != nil {
 		t.Fatal(err)
 	}
-	expMS = engine.MVCCStats{LiveBytes: 76, KeyBytes: 32, ValBytes: 44, IntentBytes: 0, LiveCount: 2, KeyCount: 2, ValCount: 2, IntentCount: 0, SysBytes: 63, SysCount: 1}
+	expMS = engine.MVCCStats{LiveBytes: 52, KeyBytes: 32, ValBytes: 20, IntentBytes: 0, LiveCount: 2, KeyCount: 2, ValCount: 2, IntentCount: 0, IntentAge: 0, GCBytesAge: 0, SysBytes: 63, SysCount: 1, LastUpdateNanos: 0}
 	verifyRangeStats(tc.engine, tc.rng.Desc().RangeID, expMS, t)
 
 	// Delete the 1st value.
@@ -2694,7 +2694,7 @@ func TestRangeStatsComputation(t *testing.T) {
 	if _, err := client.SendWrapped(tc.Sender(), tc.rng.context(), &dArgs); err != nil {
 		t.Fatal(err)
 	}
-	expMS = engine.MVCCStats{LiveBytes: 38, KeyBytes: 44, ValBytes: 44, IntentBytes: 0, LiveCount: 1, KeyCount: 2, ValCount: 3, IntentCount: 0, SysBytes: 63, SysCount: 1}
+	expMS = engine.MVCCStats{LiveBytes: 26, KeyBytes: 44, ValBytes: 20, IntentBytes: 0, LiveCount: 1, KeyCount: 2, ValCount: 3, IntentCount: 0, IntentAge: 0, GCBytesAge: 0, SysBytes: 63, SysCount: 1, LastUpdateNanos: 0}
 	verifyRangeStats(tc.engine, tc.rng.Desc().RangeID, expMS, t)
 }
 


### PR DESCRIPTION
When an intent is not present the MVCCMetadata is implicit and is
reconstructed from the most recent versioned value. This provides a very
nice performance improvement:

```
name                                old time/op    new time/op    delta
MVCCScan1Version1Row8Bytes-8          6.04µs ± 1%    4.52µs ± 2%  -25.10%  (p=0.000 n=10+10)
MVCCScan1Version10Rows8Bytes-8        34.3µs ± 0%    21.9µs ± 0%  -35.99%    (p=0.000 n=9+9)
MVCCScan1Version100Rows8Bytes-8        302µs ± 0%     183µs ± 1%  -39.17%   (p=0.000 n=9+10)
MVCCScan1Version1000Rows8Bytes-8      2.95ms ± 0%    1.78ms ± 0%  -39.48%   (p=0.000 n=10+9)
MVCCScan10Versions1Row8Bytes-8        35.4µs ± 2%    29.9µs ± 0%  -15.49%   (p=0.000 n=10+9)
MVCCScan10Versions10Rows8Bytes-8       133µs ± 1%     108µs ± 0%  -18.56%   (p=0.000 n=10+8)
MVCCScan10Versions100Rows8Bytes-8     1.05ms ± 1%    0.84ms ± 1%  -19.71%  (p=0.000 n=10+10)
MVCCScan10Versions1000Rows8Bytes-8    10.1ms ± 0%     8.1ms ± 1%  -19.76%    (p=0.000 n=9+9)
MVCCGet1Version8Bytes-8               26.5µs ± 1%    20.6µs ± 1%  -22.18%   (p=0.000 n=9+10)
MVCCGet10Versions8Bytes-8             33.0µs ± 1%    30.2µs ± 1%   -8.26%   (p=0.000 n=10+9)
```

Adjusted the scan benchmarks to operate serially instead of in
parallel. Adjusted the data generation to be deterministic.

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/3324)

<!-- Reviewable:end -->
