### PR TITLE
Remove Gossip from StorePool, and use supplied hlc.Clock in StorePool

### DIFF
--- a/server/server.go
+++ b/server/server.go
@@ -119,7 +119,7 @@ func NewServer(ctx *Context, stopper *stop.Stopper) (*Server, error) {
 	s.rpc = rpc.NewServer(util.MakeUnresolvedAddr("tcp", addr), rpcContext)
 	s.stopper.AddCloser(s.rpc)
 	s.gossip = gossip.New(rpcContext, s.ctx.GossipBootstrapResolvers)
-	s.storePool = storage.NewStorePool(s.gossip, ctx.TimeUntilStoreDead, stopper)
+	s.storePool = storage.NewStorePool(s.gossip, s.clock, ctx.TimeUntilStoreDead, stopper)
 
 	feed := util.NewFeed(stopper)
 	tracer := tracer.NewTracer(feed, addr)

--- a/storage/allocator_test.go
+++ b/storage/allocator_test.go
@@ -165,11 +165,12 @@ var multiDCStores = []*roachpb.StoreDescriptor{
 // use in tests. Stopper must be stopped by the caller.
 func createTestAllocator() (*stop.Stopper, *gossip.Gossip, *StorePool, Allocator) {
 	stopper := stop.NewStopper()
-	rpcContext := rpc.NewContext(&base.Context{}, hlc.NewClock(hlc.UnixNano), stopper)
+	clock := hlc.NewClock(hlc.UnixNano)
+	rpcContext := rpc.NewContext(&base.Context{}, clock, stopper)
 	g := gossip.New(rpcContext, gossip.TestBootstrap)
 	// Have to call g.SetNodeID before call g.AddInfo
 	g.SetNodeID(roachpb.NodeID(1))
-	storePool := NewStorePool(g, TestTimeUntilStoreDeadOff, stopper)
+	storePool := NewStorePool(g, clock, TestTimeUntilStoreDeadOff, stopper)
 	a := MakeAllocator(storePool, AllocatorOptions{AllowRebalance: true})
 	return stopper, g, storePool, a
 }
@@ -1083,7 +1084,7 @@ func Example_rebalancing() {
 	g.SetNodeID(roachpb.NodeID(1))
 	stopper := stop.NewStopper()
 	defer stopper.Stop()
-	sp := NewStorePool(g, TestTimeUntilStoreDeadOff, stopper)
+	sp := NewStorePool(g, hlc.NewClock(hlc.UnixNano), TestTimeUntilStoreDeadOff, stopper)
 	alloc := MakeAllocator(sp, AllocatorOptions{AllowRebalance: true, Deterministic: true})
 
 	var wg sync.WaitGroup

--- a/storage/client_raft_test.go
+++ b/storage/client_raft_test.go
@@ -1179,7 +1179,8 @@ func TestStoreRangeRemoveDead(t *testing.T) {
 	// This can't use SucceedsWithin as using the backoff mechanic won't work
 	// as it requires a specific cadence of re-gossiping the alive stores to
 	// maintain their alive status.
-	ticker := time.NewTicker(storage.TestTimeUntilStoreDead / 2)
+	tickerDur := storage.TestTimeUntilStoreDead / 2
+	ticker := time.NewTicker(tickerDur)
 	defer ticker.Stop()
 
 	maxTime := 5 * time.Second
@@ -1190,6 +1191,8 @@ func TestStoreRangeRemoveDead(t *testing.T) {
 		case <-maxTimeout:
 			t.Fatalf("Failed to remove the dead replica within %s", maxTime)
 		case <-ticker.C:
+			mtc.manualClock.Increment(int64(tickerDur))
+
 			// Keep gossiping the alive stores.
 			sg.GossipWithFunction(aliveStoreIDs, func() {
 				mtc.stores[0].GossipStore()

--- a/storage/client_test.go
+++ b/storage/client_test.go
@@ -214,7 +214,7 @@ func (m *multiTestContext) Start(t *testing.T, numStores int) {
 		if m.timeUntilStoreDead == 0 {
 			m.timeUntilStoreDead = storage.TestTimeUntilStoreDeadOff
 		}
-		m.storePool = storage.NewStorePool(m.gossip, m.timeUntilStoreDead, m.clientStopper)
+		m.storePool = storage.NewStorePool(m.gossip, m.clock, m.timeUntilStoreDead, m.clientStopper)
 	}
 
 	// Always create the first sender.

--- a/storage/simulation/cluster.go
+++ b/storage/simulation/cluster.go
@@ -64,7 +64,7 @@ func createCluster(stopper *stop.Stopper, nodeCount int, epochWriter, actionWrit
 	clock := hlc.NewClock(hlc.UnixNano)
 	rpcContext := rpc.NewContext(&base.Context{}, clock, stopper)
 	g := gossip.New(rpcContext, gossip.TestBootstrap)
-	storePool := storage.NewStorePool(g, storage.TestTimeUntilStoreDeadOff, stopper)
+	storePool := storage.NewStorePool(g, clock, storage.TestTimeUntilStoreDeadOff, stopper)
 	c := &Cluster{
 		stopper:   stopper,
 		clock:     clock,

--- a/storage/store_pool.go
+++ b/storage/store_pool.go
@@ -25,7 +25,6 @@ import (
 
 	"github.com/cockroachdb/cockroach/gossip"
 	"github.com/cockroachdb/cockroach/roachpb"
-	"github.com/cockroachdb/cockroach/util/hlc"
 	"github.com/cockroachdb/cockroach/util/log"
 	"github.com/cockroachdb/cockroach/util/stop"
 )
@@ -134,8 +133,6 @@ func (pq *storePoolPQ) dequeue() *storeDetail {
 // StorePool maintains a list of all known stores in the cluster and
 // information on their health.
 type StorePool struct {
-	gossip             *gossip.Gossip
-	clock              *hlc.Clock
 	timeUntilStoreDead time.Duration
 
 	// Each storeDetail is contained in both a map and a priorityQueue; pointers

--- a/storage/store_test.go
+++ b/storage/store_test.go
@@ -133,9 +133,9 @@ func createTestStoreWithoutStart(t *testing.T) (*Store, *hlc.ManualClock, *stop.
 	rpcContext := rpc.NewContext(&base.Context{}, hlc.NewClock(hlc.UnixNano), stopper)
 	ctx := TestStoreContext
 	ctx.Gossip = gossip.New(rpcContext, gossip.TestBootstrap)
-	ctx.StorePool = NewStorePool(ctx.Gossip, TestTimeUntilStoreDeadOff, stopper)
 	manual := hlc.NewManualClock(0)
 	ctx.Clock = hlc.NewClock(manual.UnixNano)
+	ctx.StorePool = NewStorePool(ctx.Gossip, ctx.Clock, TestTimeUntilStoreDeadOff, stopper)
 	eng := engine.NewInMem(roachpb.Attributes{}, 10<<20, stopper)
 	ctx.Transport = multiraft.NewLocalRPCTransport(stopper)
 	stopper.AddCloser(ctx.Transport)


### PR DESCRIPTION
Neither of the fields are being used currently. We may want to keep the Gossip pointer and actually hook it up in `NewStorePool`, in case it is needed in places outside of the constructor in the future.

Fixes #3261 

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/3331)

<!-- Reviewable:end -->
