### PR TITLE
Move MVCCKey encoding into C++.

### DIFF
--- a/client/client_test.go
+++ b/client/client_test.go
@@ -738,7 +738,7 @@ func setupClientBenchData(useSSL bool, numVersions, numKeys int, b *testing.B) (
 	}
 
 	if r, ok := s.Ctx.Engines[0].(*engine.RocksDB); ok {
-		r.CompactRange(nil, nil)
+		r.CompactRange(engine.NilKey, engine.NilKey)
 	}
 
 	return s, db

--- a/keys/constants.go
+++ b/keys/constants.go
@@ -117,11 +117,6 @@ var (
 	// (storage/engine/rocksdb/db.cc).
 	localTransactionSuffix = roachpb.RKey("txn-")
 
-	// SystemPrefix indicates the beginning of the key range for
-	// global, system data which are replicated across the cluster.
-	SystemPrefix = roachpb.Key("\x04")
-	SystemMax    = roachpb.Key("\x05")
-
 	// Meta1Prefix is the first level of key addressing. It is selected such that
 	// all range addressing records sort before any system tables which they
 	// might describe. The value is a RangeDescriptor struct.
@@ -140,6 +135,11 @@ var (
 	MetaMin = Meta1Prefix
 	// MetaMax is the end of the range of addressing keys.
 	MetaMax = roachpb.Key("\x04")
+
+	// SystemPrefix indicates the beginning of the key range for
+	// global, system data which are replicated across the cluster.
+	SystemPrefix = roachpb.Key("\x04")
+	SystemMax    = roachpb.Key("\x05")
 
 	// DescIDGenerator is the global descriptor ID generator sequence used for
 	// table and namespace IDs.

--- a/kv/txn_coord_sender_test.go
+++ b/kv/txn_coord_sender_test.go
@@ -299,7 +299,7 @@ func verifyCleanup(key roachpb.Key, coord *TxnCoordSender, eng engine.Engine, t 
 			return fmt.Errorf("expected empty transactions map; got %d", l)
 		}
 		meta := &engine.MVCCMetadata{}
-		ok, _, _, err := eng.GetProto(engine.MVCCEncodeKey(key), meta)
+		ok, _, _, err := eng.GetProto(engine.MakeMVCCMetadataKey(key), meta)
 		if err != nil {
 			return fmt.Errorf("error getting MVCC metadata: %s", err)
 		}

--- a/roachpb/internal.pb.go
+++ b/roachpb/internal.pb.go
@@ -137,8 +137,10 @@ func (m *RaftSnapshotData) String() string { return proto.CompactTextString(m) }
 func (*RaftSnapshotData) ProtoMessage()    {}
 
 type RaftSnapshotData_KeyValue struct {
-	Key   []byte `protobuf:"bytes,1,opt,name=key" json:"key,omitempty"`
-	Value []byte `protobuf:"bytes,2,opt,name=value" json:"value,omitempty"`
+	Key      []byte `protobuf:"bytes,1,opt,name=key" json:"key,omitempty"`
+	Value    []byte `protobuf:"bytes,2,opt,name=value" json:"value,omitempty"`
+	WallTime int64  `protobuf:"varint,3,opt,name=wall_time" json:"wall_time"`
+	Logical  int32  `protobuf:"varint,4,opt,name=logical" json:"logical"`
 }
 
 func (m *RaftSnapshotData_KeyValue) Reset()         { *m = RaftSnapshotData_KeyValue{} }
@@ -374,6 +376,12 @@ func (m *RaftSnapshotData_KeyValue) MarshalTo(data []byte) (int, error) {
 		i = encodeVarintInternal(data, i, uint64(len(m.Value)))
 		i += copy(data[i:], m.Value)
 	}
+	data[i] = 0x18
+	i++
+	i = encodeVarintInternal(data, i, uint64(m.WallTime))
+	data[i] = 0x20
+	i++
+	i = encodeVarintInternal(data, i, uint64(m.Logical))
 	return i, nil
 }
 
@@ -484,6 +492,8 @@ func (m *RaftSnapshotData_KeyValue) Size() (n int) {
 		l = len(m.Value)
 		n += 1 + l + sovInternal(uint64(l))
 	}
+	n += 1 + sovInternal(uint64(m.WallTime))
+	n += 1 + sovInternal(uint64(m.Logical))
 	return n
 }
 
@@ -1245,6 +1255,44 @@ func (m *RaftSnapshotData_KeyValue) Unmarshal(data []byte) error {
 			}
 			m.Value = append([]byte{}, data[iNdEx:postIndex]...)
 			iNdEx = postIndex
+		case 3:
+			if wireType != 0 {
+				return fmt.Errorf("proto: wrong wireType = %d for field WallTime", wireType)
+			}
+			m.WallTime = 0
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return ErrIntOverflowInternal
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := data[iNdEx]
+				iNdEx++
+				m.WallTime |= (int64(b) & 0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+		case 4:
+			if wireType != 0 {
+				return fmt.Errorf("proto: wrong wireType = %d for field Logical", wireType)
+			}
+			m.Logical = 0
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return ErrIntOverflowInternal
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := data[iNdEx]
+				iNdEx++
+				m.Logical |= (int32(b) & 0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
 		default:
 			iNdEx = preIndex
 			skippy, err := skipInternal(data[iNdEx:])

--- a/roachpb/internal.proto
+++ b/roachpb/internal.proto
@@ -119,6 +119,8 @@ message RaftSnapshotData {
   message KeyValue {
     optional bytes key = 1;
     optional bytes value = 2;
+    optional int64 wall_time = 3 [(gogoproto.nullable) = false];
+    optional int32 logical = 4 [(gogoproto.nullable) = false];
   }
   // The latest RangeDescriptor
   optional RangeDescriptor range_descriptor = 1 [(gogoproto.nullable) = false];

--- a/storage/engine/batch_test.go
+++ b/storage/engine/batch_test.go
@@ -19,6 +19,7 @@ package engine
 
 import (
 	"bytes"
+	"fmt"
 	"reflect"
 	"testing"
 
@@ -27,6 +28,21 @@ import (
 	"github.com/cockroachdb/cockroach/util/stop"
 	"github.com/gogo/protobuf/proto"
 )
+
+func mvccKey(k interface{}) MVCCKey {
+	switch k := k.(type) {
+	case string:
+		return MakeMVCCMetadataKey(roachpb.Key(k))
+	case []byte:
+		return MakeMVCCMetadataKey(roachpb.Key(k))
+	case roachpb.Key:
+		return MakeMVCCMetadataKey(k)
+	case roachpb.RKey:
+		return MakeMVCCMetadataKey(roachpb.Key(k))
+	default:
+		panic(fmt.Sprintf("unsupported type: %T", k))
+	}
+}
 
 // TestBatchBasics verifies that all commands work in a batch, aren't
 // visible until commit, and then are all visible after commit.
@@ -39,45 +55,45 @@ func TestBatchBasics(t *testing.T) {
 	b := e.NewBatch()
 	defer b.Close()
 
-	if err := b.Put(MVCCKey("a"), []byte("value")); err != nil {
+	if err := b.Put(mvccKey("a"), []byte("value")); err != nil {
 		t.Fatal(err)
 	}
 	// Write an engine value to be deleted.
-	if err := e.Put(MVCCKey("b"), []byte("value")); err != nil {
+	if err := e.Put(mvccKey("b"), []byte("value")); err != nil {
 		t.Fatal(err)
 	}
-	if err := b.Clear(MVCCKey("b")); err != nil {
+	if err := b.Clear(mvccKey("b")); err != nil {
 		t.Fatal(err)
 	}
 	// Write an engine value to be merged.
-	if err := e.Put(MVCCKey("c"), appender("foo")); err != nil {
+	if err := e.Put(mvccKey("c"), appender("foo")); err != nil {
 		t.Fatal(err)
 	}
-	if err := b.Merge(MVCCKey("c"), appender("bar")); err != nil {
+	if err := b.Merge(mvccKey("c"), appender("bar")); err != nil {
 		t.Fatal(err)
 	}
 
 	// Check all keys are in initial state (nothing from batch has gone
 	// through to engine until commit).
 	expValues := []MVCCKeyValue{
-		{Key: MVCCKey("b"), Value: []byte("value")},
-		{Key: MVCCKey("c"), Value: appender("foo")},
+		{Key: mvccKey("b"), Value: []byte("value")},
+		{Key: mvccKey("c"), Value: appender("foo")},
 	}
-	kvs, err := Scan(e, MVCCKey(roachpb.RKeyMin), MVCCKey(roachpb.RKeyMax), 0)
+	kvs, err := Scan(e, mvccKey(roachpb.RKeyMin), mvccKey(roachpb.RKeyMax), 0)
 	if err != nil {
 		t.Fatal(err)
 	}
 	if !reflect.DeepEqual(expValues, kvs) {
-		t.Errorf("%v != %v", kvs, expValues)
+		t.Fatalf("%v != %v", kvs, expValues)
 	}
 
 	// Now, merged values should be:
 	expValues = []MVCCKeyValue{
-		{Key: MVCCKey("a"), Value: []byte("value")},
-		{Key: MVCCKey("c"), Value: appender("foobar")},
+		{Key: mvccKey("a"), Value: []byte("value")},
+		{Key: mvccKey("c"), Value: appender("foobar")},
 	}
 	// Scan values from batch directly.
-	kvs, err = Scan(b, MVCCKey(roachpb.RKeyMin), MVCCKey(roachpb.RKeyMax), 0)
+	kvs, err = Scan(b, mvccKey(roachpb.RKeyMin), mvccKey(roachpb.RKeyMax), 0)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -89,7 +105,7 @@ func TestBatchBasics(t *testing.T) {
 	if err := b.Commit(); err != nil {
 		t.Fatal(err)
 	}
-	kvs, err = Scan(e, MVCCKey(roachpb.RKeyMin), MVCCKey(roachpb.RKeyMax), 0)
+	kvs, err = Scan(e, mvccKey(roachpb.RKeyMin), mvccKey(roachpb.RKeyMax), 0)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -108,27 +124,27 @@ func TestBatchGet(t *testing.T) {
 	defer b.Close()
 
 	// Write initial values, then write to batch.
-	if err := e.Put(MVCCKey("b"), []byte("value")); err != nil {
+	if err := e.Put(mvccKey("b"), []byte("value")); err != nil {
 		t.Fatal(err)
 	}
-	if err := e.Put(MVCCKey("c"), appender("foo")); err != nil {
+	if err := e.Put(mvccKey("c"), appender("foo")); err != nil {
 		t.Fatal(err)
 	}
 	// Write batch values.
-	if err := b.Put(MVCCKey("a"), []byte("value")); err != nil {
+	if err := b.Put(mvccKey("a"), []byte("value")); err != nil {
 		t.Fatal(err)
 	}
-	if err := b.Clear(MVCCKey("b")); err != nil {
+	if err := b.Clear(mvccKey("b")); err != nil {
 		t.Fatal(err)
 	}
-	if err := b.Merge(MVCCKey("c"), appender("bar")); err != nil {
+	if err := b.Merge(mvccKey("c"), appender("bar")); err != nil {
 		t.Fatal(err)
 	}
 
 	expValues := []MVCCKeyValue{
-		{Key: MVCCKey("a"), Value: []byte("value")},
-		{Key: MVCCKey("b"), Value: nil},
-		{Key: MVCCKey("c"), Value: appender("foobar")},
+		{Key: mvccKey("a"), Value: []byte("value")},
+		{Key: mvccKey("b"), Value: nil},
+		{Key: mvccKey("c"), Value: appender("foobar")},
 	}
 	for i, expKV := range expValues {
 		kv, err := b.Get(expKV.Key)
@@ -162,29 +178,29 @@ func TestBatchMerge(t *testing.T) {
 	defer b.Close()
 
 	// Write batch put, delete & merge.
-	if err := b.Put(MVCCKey("a"), appender("a-value")); err != nil {
+	if err := b.Put(mvccKey("a"), appender("a-value")); err != nil {
 		t.Fatal(err)
 	}
-	if err := b.Clear(MVCCKey("b")); err != nil {
+	if err := b.Clear(mvccKey("b")); err != nil {
 		t.Fatal(err)
 	}
-	if err := b.Merge(MVCCKey("c"), appender("c-value")); err != nil {
+	if err := b.Merge(mvccKey("c"), appender("c-value")); err != nil {
 		t.Fatal(err)
 	}
 
 	// Now, merge to all three keys.
-	if err := b.Merge(MVCCKey("a"), appender("append")); err != nil {
+	if err := b.Merge(mvccKey("a"), appender("append")); err != nil {
 		t.Fatal(err)
 	}
-	if err := b.Merge(MVCCKey("b"), appender("append")); err != nil {
+	if err := b.Merge(mvccKey("b"), appender("append")); err != nil {
 		t.Fatal(err)
 	}
-	if err := b.Merge(MVCCKey("c"), appender("append")); err != nil {
+	if err := b.Merge(mvccKey("c"), appender("append")); err != nil {
 		t.Fatal(err)
 	}
 
 	// Verify values.
-	val, err := b.Get(MVCCKey("a"))
+	val, err := b.Get(mvccKey("a"))
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -192,7 +208,7 @@ func TestBatchMerge(t *testing.T) {
 		t.Error("mismatch of \"a\"")
 	}
 
-	val, err = b.Get(MVCCKey("b"))
+	val, err = b.Get(mvccKey("b"))
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -200,7 +216,7 @@ func TestBatchMerge(t *testing.T) {
 		t.Error("mismatch of \"b\"")
 	}
 
-	val, err = b.Get(MVCCKey("c"))
+	val, err = b.Get(mvccKey("c"))
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -219,16 +235,16 @@ func TestBatchProto(t *testing.T) {
 	defer b.Close()
 
 	val := roachpb.MakeValueFromString("value")
-	if _, _, err := PutProto(b, MVCCKey("proto"), &val); err != nil {
+	if _, _, err := PutProto(b, mvccKey("proto"), &val); err != nil {
 		t.Fatal(err)
 	}
 	getVal := &roachpb.Value{}
-	ok, keySize, valSize, err := b.GetProto(MVCCKey("proto"), getVal)
+	ok, keySize, valSize, err := b.GetProto(mvccKey("proto"), getVal)
 	if !ok || err != nil {
 		t.Fatalf("expected GetProto to success ok=%t: %s", ok, err)
 	}
-	if keySize != 5 {
-		t.Errorf("expected key size 5; got %d", keySize)
+	if keySize != 8 {
+		t.Errorf("expected key size 8; got %d", keySize)
 	}
 	data, err := val.Marshal()
 	if err != nil {
@@ -241,14 +257,14 @@ func TestBatchProto(t *testing.T) {
 		t.Errorf("expected %v; got %v", &val, getVal)
 	}
 	// Before commit, proto will not be available via engine.
-	if ok, _, _, err := e.GetProto(MVCCKey("proto"), getVal); ok || err != nil {
+	if ok, _, _, err := e.GetProto(mvccKey("proto"), getVal); ok || err != nil {
 		t.Fatalf("expected GetProto to fail ok=%t: %s", ok, err)
 	}
 	// Commit and verify the proto can be read directly from the engine.
 	if err := b.Commit(); err != nil {
 		t.Fatal(err)
 	}
-	if ok, _, _, err := e.GetProto(MVCCKey("proto"), getVal); !ok || err != nil {
+	if ok, _, _, err := e.GetProto(mvccKey("proto"), getVal); !ok || err != nil {
 		t.Fatalf("expected GetProto to success ok=%t: %s", ok, err)
 	}
 	if !proto.Equal(getVal, &val) {
@@ -266,19 +282,19 @@ func TestBatchScan(t *testing.T) {
 	defer b.Close()
 
 	existingVals := []MVCCKeyValue{
-		{Key: MVCCKey("a"), Value: []byte("1")},
-		{Key: MVCCKey("b"), Value: []byte("2")},
-		{Key: MVCCKey("c"), Value: []byte("3")},
-		{Key: MVCCKey("d"), Value: []byte("4")},
-		{Key: MVCCKey("e"), Value: []byte("5")},
-		{Key: MVCCKey("f"), Value: []byte("6")},
-		{Key: MVCCKey("g"), Value: []byte("7")},
-		{Key: MVCCKey("h"), Value: []byte("8")},
-		{Key: MVCCKey("i"), Value: []byte("9")},
-		{Key: MVCCKey("j"), Value: []byte("10")},
-		{Key: MVCCKey("k"), Value: []byte("11")},
-		{Key: MVCCKey("l"), Value: []byte("12")},
-		{Key: MVCCKey("m"), Value: []byte("13")},
+		{Key: mvccKey("a"), Value: []byte("1")},
+		{Key: mvccKey("b"), Value: []byte("2")},
+		{Key: mvccKey("c"), Value: []byte("3")},
+		{Key: mvccKey("d"), Value: []byte("4")},
+		{Key: mvccKey("e"), Value: []byte("5")},
+		{Key: mvccKey("f"), Value: []byte("6")},
+		{Key: mvccKey("g"), Value: []byte("7")},
+		{Key: mvccKey("h"), Value: []byte("8")},
+		{Key: mvccKey("i"), Value: []byte("9")},
+		{Key: mvccKey("j"), Value: []byte("10")},
+		{Key: mvccKey("k"), Value: []byte("11")},
+		{Key: mvccKey("l"), Value: []byte("12")},
+		{Key: mvccKey("m"), Value: []byte("13")},
 	}
 	for _, kv := range existingVals {
 		if err := e.Put(kv.Key, kv.Value); err != nil {
@@ -287,16 +303,16 @@ func TestBatchScan(t *testing.T) {
 	}
 
 	batchVals := []MVCCKeyValue{
-		{Key: MVCCKey("a"), Value: []byte("b1")},
-		{Key: MVCCKey("bb"), Value: []byte("b2")},
-		{Key: MVCCKey("c"), Value: []byte("b3")},
-		{Key: MVCCKey("dd"), Value: []byte("b4")},
-		{Key: MVCCKey("e"), Value: []byte("b5")},
-		{Key: MVCCKey("ff"), Value: []byte("b6")},
-		{Key: MVCCKey("g"), Value: []byte("b7")},
-		{Key: MVCCKey("hh"), Value: []byte("b8")},
-		{Key: MVCCKey("i"), Value: []byte("b9")},
-		{Key: MVCCKey("jj"), Value: []byte("b10")},
+		{Key: mvccKey("a"), Value: []byte("b1")},
+		{Key: mvccKey("bb"), Value: []byte("b2")},
+		{Key: mvccKey("c"), Value: []byte("b3")},
+		{Key: mvccKey("dd"), Value: []byte("b4")},
+		{Key: mvccKey("e"), Value: []byte("b5")},
+		{Key: mvccKey("ff"), Value: []byte("b6")},
+		{Key: mvccKey("g"), Value: []byte("b7")},
+		{Key: mvccKey("hh"), Value: []byte("b8")},
+		{Key: mvccKey("i"), Value: []byte("b9")},
+		{Key: mvccKey("jj"), Value: []byte("b10")},
 	}
 	for _, kv := range batchVals {
 		if err := b.Put(kv.Key, kv.Value); err != nil {
@@ -309,17 +325,17 @@ func TestBatchScan(t *testing.T) {
 		max        int64
 	}{
 		// Full monty.
-		{start: MVCCKey("a"), end: MVCCKey("z"), max: 0},
+		{start: mvccKey("a"), end: mvccKey("z"), max: 0},
 		// Select ~half.
-		{start: MVCCKey("a"), end: MVCCKey("z"), max: 9},
+		{start: mvccKey("a"), end: mvccKey("z"), max: 9},
 		// Select one.
-		{start: MVCCKey("a"), end: MVCCKey("z"), max: 1},
+		{start: mvccKey("a"), end: mvccKey("z"), max: 1},
 		// Select half by end key.
-		{start: MVCCKey("a"), end: MVCCKey("f0"), max: 0},
+		{start: mvccKey("a"), end: mvccKey("f0"), max: 0},
 		// Start at half and select rest.
-		{start: MVCCKey("f"), end: MVCCKey("z"), max: 0},
+		{start: mvccKey("f"), end: mvccKey("z"), max: 0},
 		// Start at last and select max=10.
-		{start: MVCCKey("m"), end: MVCCKey("z"), max: 10},
+		{start: mvccKey("m"), end: mvccKey("z"), max: 10},
 	}
 
 	// Scan each case using the batch and store the results.
@@ -359,13 +375,13 @@ func TestBatchScanWithDelete(t *testing.T) {
 	defer b.Close()
 
 	// Write initial value, then delete via batch.
-	if err := e.Put(MVCCKey("a"), []byte("value")); err != nil {
+	if err := e.Put(mvccKey("a"), []byte("value")); err != nil {
 		t.Fatal(err)
 	}
-	if err := b.Clear(MVCCKey("a")); err != nil {
+	if err := b.Clear(mvccKey("a")); err != nil {
 		t.Fatal(err)
 	}
-	kvs, err := Scan(b, MVCCKey(roachpb.RKeyMin), MVCCKey(roachpb.RKeyMax), 0)
+	kvs, err := Scan(b, mvccKey(roachpb.RKeyMin), mvccKey(roachpb.RKeyMax), 0)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -387,22 +403,22 @@ func TestBatchScanMaxWithDeleted(t *testing.T) {
 	defer b.Close()
 
 	// Write two values.
-	if err := e.Put(MVCCKey("a"), []byte("value1")); err != nil {
+	if err := e.Put(mvccKey("a"), []byte("value1")); err != nil {
 		t.Fatal(err)
 	}
-	if err := e.Put(MVCCKey("b"), []byte("value2")); err != nil {
+	if err := e.Put(mvccKey("b"), []byte("value2")); err != nil {
 		t.Fatal(err)
 	}
 	// Now, delete "a" in batch.
-	if err := b.Clear(MVCCKey("a")); err != nil {
+	if err := b.Clear(mvccKey("a")); err != nil {
 		t.Fatal(err)
 	}
 	// A scan with max=1 should scan "b".
-	kvs, err := Scan(b, MVCCKey(roachpb.RKeyMin), MVCCKey(roachpb.RKeyMax), 1)
+	kvs, err := Scan(b, mvccKey(roachpb.RKeyMin), mvccKey(roachpb.RKeyMax), 1)
 	if err != nil {
 		t.Fatal(err)
 	}
-	if len(kvs) != 1 || !bytes.Equal(kvs[0].Key, []byte("b")) {
+	if len(kvs) != 1 || !bytes.Equal(kvs[0].Key.Key, []byte("b")) {
 		t.Errorf("expected scan of \"b\"; got %v", kvs)
 	}
 }
@@ -421,10 +437,10 @@ func TestBatchConcurrency(t *testing.T) {
 	defer b.Close()
 
 	// Write a merge to the batch.
-	if err := b.Merge(MVCCKey("a"), appender("bar")); err != nil {
+	if err := b.Merge(mvccKey("a"), appender("bar")); err != nil {
 		t.Fatal(err)
 	}
-	val, err := b.Get(MVCCKey("a"))
+	val, err := b.Get(mvccKey("a"))
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -432,11 +448,11 @@ func TestBatchConcurrency(t *testing.T) {
 		t.Error("mismatch of \"a\"")
 	}
 	// Write an engine value.
-	if err := e.Put(MVCCKey("a"), appender("foo")); err != nil {
+	if err := e.Put(mvccKey("a"), appender("foo")); err != nil {
 		t.Fatal(err)
 	}
 	// Now, read again and verify that the merge happens on top of the mod.
-	val, err = b.Get(MVCCKey("a"))
+	val, err = b.Get(mvccKey("a"))
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/storage/engine/engine.go
+++ b/storage/engine/engine.go
@@ -34,10 +34,10 @@ type Iterator interface {
 	Close()
 	// Seek advances the iterator to the first key in the engine which
 	// is >= the provided key.
-	Seek(key []byte)
+	Seek(key MVCCKey)
 	// SeekReverse advances the iterator to the first key in the engine which
 	// is <= the provided key.
-	SeekReverse(key []byte)
+	SeekReverse(key MVCCKey)
 	// Valid returns true if the iterator is currently valid. An
 	// iterator which hasn't been seeked or has gone past the end of the
 	// key range is invalid.
@@ -73,7 +73,7 @@ type Iterator interface {
 	// KeyMin). The nowNanos arg specifies the wall time in nanoseconds since the
 	// epoch and is used to compute the total age of all intents. The computed
 	// stats are accumulated (not assigned) to the ms parameter.
-	ComputeStats(ms *MVCCStats, start, end []byte, nowNanos int64) error
+	ComputeStats(ms *MVCCStats, start, end MVCCKey, nowNanos int64) error
 }
 
 // Engine is the interface that wraps the core operations of a
@@ -181,7 +181,8 @@ func PutProto(engine Engine, key MVCCKey, msg proto.Message) (keyBytes, valBytes
 		bufferPool.Put(buf)
 		return
 	}
-	keyBytes = int64(len(key))
+
+	keyBytes = int64(key.EncodedSize())
 	valBytes = int64(len(data))
 
 	bufferPool.Put(buf)

--- a/storage/engine/gc_test.go
+++ b/storage/engine/gc_test.go
@@ -26,17 +26,21 @@ import (
 	"github.com/gogo/protobuf/proto"
 )
 
+func mvccVersionKey(key roachpb.Key, ts roachpb.Timestamp) MVCCKey {
+	return MVCCKey{Key: key, Timestamp: ts}
+}
+
 var (
 	aKey  = roachpb.Key("a")
 	bKey  = roachpb.Key("b")
 	aKeys = []MVCCKey{
-		MVCCEncodeVersionKey(aKey, makeTS(2E9, 0)),
-		MVCCEncodeVersionKey(aKey, makeTS(1E9, 1)),
-		MVCCEncodeVersionKey(aKey, makeTS(1E9, 0)),
+		mvccVersionKey(aKey, makeTS(2E9, 0)),
+		mvccVersionKey(aKey, makeTS(1E9, 1)),
+		mvccVersionKey(aKey, makeTS(1E9, 0)),
 	}
 	bKeys = []MVCCKey{
-		MVCCEncodeVersionKey(bKey, makeTS(2E9, 0)),
-		MVCCEncodeVersionKey(bKey, makeTS(1E9, 0)),
+		mvccVersionKey(bKey, makeTS(2E9, 0)),
+		mvccVersionKey(bKey, makeTS(1E9, 0)),
 	}
 )
 

--- a/storage/engine/mvcc_test.go
+++ b/storage/engine/mvcc_test.go
@@ -48,13 +48,13 @@ var (
 	testKey2     = roachpb.Key("/db2")
 	testKey3     = roachpb.Key("/db3")
 	testKey4     = roachpb.Key("/db4")
-	txn1         = &roachpb.Transaction{Key: roachpb.Key("a"), ID: []byte("Txn1"), Epoch: 1}
-	txn1Commit   = &roachpb.Transaction{Key: roachpb.Key("a"), ID: []byte("Txn1"), Epoch: 1, Status: roachpb.COMMITTED}
+	txn1         = &roachpb.Transaction{Key: roachpb.Key("a"), ID: []byte("Txn1"), Epoch: 1, Timestamp: makeTS(0, 1)}
+	txn1Commit   = &roachpb.Transaction{Key: roachpb.Key("a"), ID: []byte("Txn1"), Epoch: 1, Status: roachpb.COMMITTED, Timestamp: makeTS(0, 1)}
 	txn1Abort    = &roachpb.Transaction{Key: roachpb.Key("a"), ID: []byte("Txn1"), Epoch: 1, Status: roachpb.ABORTED}
-	txn1e2       = &roachpb.Transaction{Key: roachpb.Key("a"), ID: []byte("Txn1"), Epoch: 2}
-	txn1e2Commit = &roachpb.Transaction{Key: roachpb.Key("a"), ID: []byte("Txn1"), Epoch: 2, Status: roachpb.COMMITTED}
-	txn2         = &roachpb.Transaction{Key: roachpb.Key("a"), ID: []byte("Txn2")}
-	txn2Commit   = &roachpb.Transaction{Key: roachpb.Key("a"), ID: []byte("Txn2"), Status: roachpb.COMMITTED}
+	txn1e2       = &roachpb.Transaction{Key: roachpb.Key("a"), ID: []byte("Txn1"), Epoch: 2, Timestamp: makeTS(0, 1)}
+	txn1e2Commit = &roachpb.Transaction{Key: roachpb.Key("a"), ID: []byte("Txn1"), Epoch: 2, Status: roachpb.COMMITTED, Timestamp: makeTS(0, 1)}
+	txn2         = &roachpb.Transaction{Key: roachpb.Key("a"), ID: []byte("Txn2"), Timestamp: makeTS(0, 1)}
+	txn2Commit   = &roachpb.Transaction{Key: roachpb.Key("a"), ID: []byte("Txn2"), Status: roachpb.COMMITTED, Timestamp: makeTS(0, 1)}
 	value1       = roachpb.MakeValueFromString("testValue1")
 	value2       = roachpb.MakeValueFromString("testValue2")
 	value3       = roachpb.MakeValueFromString("testValue3")
@@ -84,6 +84,12 @@ func makeTS(nanos int64, logical int32) roachpb.Timestamp {
 	}
 }
 
+type mvccKeys []MVCCKey
+
+func (n mvccKeys) Len() int           { return len(n) }
+func (n mvccKeys) Swap(i, j int)      { n[i], n[j] = n[j], n[i] }
+func (n mvccKeys) Less(i, j int) bool { return n[i].Less(n[j]) }
+
 // Verify the sort ordering of successive keys with metadata and
 // versioned values. In particular, the following sequence of keys /
 // versions:
@@ -100,19 +106,19 @@ func TestMVCCKeys(t *testing.T) {
 	defer leaktest.AfterTest(t)
 	aKey := roachpb.Key("a")
 	a0Key := roachpb.Key("a\x00")
-	keys := []string{
-		string(MVCCEncodeKey(aKey)),
-		string(MVCCEncodeVersionKey(aKey, makeTS(math.MaxInt64, 0))),
-		string(MVCCEncodeVersionKey(aKey, makeTS(1, 0))),
-		string(MVCCEncodeVersionKey(aKey, makeTS(0, 0))),
-		string(MVCCEncodeKey(a0Key)),
-		string(MVCCEncodeVersionKey(a0Key, makeTS(math.MaxInt64, 0))),
-		string(MVCCEncodeVersionKey(a0Key, makeTS(1, 0))),
-		string(MVCCEncodeVersionKey(a0Key, makeTS(0, 0))),
+	keys := mvccKeys{
+		mvccKey(aKey),
+		mvccVersionKey(aKey, makeTS(math.MaxInt64, 0)),
+		mvccVersionKey(aKey, makeTS(1, 0)),
+		mvccVersionKey(aKey, makeTS(0, 1)),
+		mvccKey(a0Key),
+		mvccVersionKey(a0Key, makeTS(math.MaxInt64, 0)),
+		mvccVersionKey(a0Key, makeTS(1, 0)),
+		mvccVersionKey(a0Key, makeTS(0, 1)),
 	}
-	sortKeys := make([]string, len(keys))
+	sortKeys := make(mvccKeys, len(keys))
 	copy(sortKeys, keys)
-	sort.Strings(sortKeys)
+	sort.Sort(sortKeys)
 	if !reflect.DeepEqual(sortKeys, keys) {
 		t.Errorf("expected keys to sort in order %s, but got %s", keys, sortKeys)
 	}
@@ -565,7 +571,7 @@ func TestMVCCDeleteMissingKey(t *testing.T) {
 		t.Fatal(err)
 	}
 	// Verify nothing is written to the engine.
-	if val, err := engine.Get(MVCCEncodeKey(testKey1)); err != nil || val != nil {
+	if val, err := engine.Get(mvccKey(testKey1)); err != nil || val != nil {
 		t.Fatalf("expected no mvcc metadata after delete of a missing key; got %q: %s", val, err)
 	}
 }
@@ -1443,7 +1449,7 @@ func TestMVCCAbortTxn(t *testing.T) {
 	if err != nil || value != nil {
 		t.Fatalf("the value should be empty: %s", err)
 	}
-	meta, err := engine.Get(MVCCEncodeKey(testKey1))
+	meta, err := engine.Get(mvccKey(testKey1))
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -1466,7 +1472,7 @@ func TestMVCCAbortTxnWithPreviousVersion(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	meta, err := engine.Get(MVCCEncodeKey(testKey1))
+	meta, err := engine.Get(mvccKey(testKey1))
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -1528,7 +1534,7 @@ func TestMVCCWriteWithDiffTimestampsAndEpochs(t *testing.T) {
 	// Attempt to read older timestamp; should fail.
 	value, _, err := MVCCGet(engine, testKey1, makeTS(0, 0), true, nil)
 	if value != nil || err != nil {
-		t.Errorf("expected value nil, err nil; got %+v, %v", value, err)
+		t.Fatalf("expected value nil, err nil; got %+v, %v", value, err)
 	}
 	// Read at correct timestamp.
 	value, _, err = MVCCGet(engine, testKey1, makeTS(1, 0), true, nil)
@@ -2182,7 +2188,7 @@ func TestMVCCStatsBasic(t *testing.T) {
 	// Verify size of mvccVersionTimestampSize.
 	ts := makeTS(1*1E9, 0)
 	key := roachpb.Key("a")
-	keySize := int64(len(MVCCEncodeVersionKey(key, ts)) - len(MVCCEncodeKey(key)))
+	keySize := int64(mvccVersionKey(key, ts).EncodedSize() - mvccKey(key).EncodedSize())
 	if keySize != mvccVersionTimestampSize {
 		t.Errorf("expected version timestamp size %d; got %d", mvccVersionTimestampSize, keySize)
 	}
@@ -2192,7 +2198,7 @@ func TestMVCCStatsBasic(t *testing.T) {
 	if err := MVCCPut(engine, ms, key, ts, value, nil); err != nil {
 		t.Fatal(err)
 	}
-	mKeySize := int64(len(MVCCEncodeKey(key)))
+	mKeySize := int64(mvccKey(key).EncodedSize())
 	vKeySize := mvccVersionTimestampSize
 	vValSize := encodedSize(&value, t)
 
@@ -2253,7 +2259,7 @@ func TestMVCCStatsBasic(t *testing.T) {
 	if err := MVCCPut(engine, ms, key2, ts4, value2, txn); err != nil {
 		t.Fatal(err)
 	}
-	mKey2Size := int64(len(MVCCEncodeKey(key2)))
+	mKey2Size := int64(mvccKey(key2).EncodedSize())
 	mVal2Size := encodedSize(&MVCCMetadata{Timestamp: ts4, Txn: txn}, t)
 	vKey2Size := mvccVersionTimestampSize
 	vVal2Size := encodedSize(&value2, t)
@@ -2308,7 +2314,7 @@ func TestMVCCStatsBasic(t *testing.T) {
 	if err := MVCCPut(engine, ms, txnKey, roachpb.ZeroTimestamp, txnVal, nil); err != nil {
 		t.Fatal(err)
 	}
-	txnKeySize := int64(len(MVCCEncodeKey(txnKey)))
+	txnKeySize := int64(mvccKey(txnKey).EncodedSize())
 	txnValSize := encodedSize(&MVCCMetadata{Value: &txnVal}, t)
 	expMS6 := expMS5
 	expMS6.SysBytes += txnKeySize + txnValSize
@@ -2335,6 +2341,9 @@ func TestMVCCStatsWithRandomRuns(t *testing.T) {
 	// either commit or abort.
 	keys := map[int32][]byte{}
 	for i := int32(0); i < int32(1000); i++ {
+		if log.V(1) {
+			log.Infof("*** cycle %d", i)
+		}
 		// Manually advance aggregate intent age based on one extra second of simulation.
 		ms.IntentAge += ms.IntentCount
 		// Same for aggregate gc'able bytes age.
@@ -2403,9 +2412,9 @@ func TestMVCCStatsWithRandomRuns(t *testing.T) {
 		if i%10 == 0 {
 			// Compute the stats manually.
 			iter := engine.NewIterator(false)
-			iter.Seek(keyMin)
 			var expMS MVCCStats
-			err := iter.ComputeStats(&expMS, roachpb.KeyMin, roachpb.KeyMax, int64(i+1)*1E9)
+			err := iter.ComputeStats(&expMS, mvccKey(roachpb.KeyMin),
+				mvccKey(roachpb.KeyMax), int64(i+1)*1E9)
 			iter.Close()
 			if err != nil {
 				t.Fatal(err)
@@ -2468,17 +2477,13 @@ func TestMVCCGarbageCollect(t *testing.T) {
 			}
 		}
 	}
-	kvsn, err := Scan(engine, MVCCEncodeKey(keyMin), MVCCEncodeKey(keyMax), 0)
+	kvsn, err := Scan(engine, mvccKey(keyMin), mvccKey(keyMax), 0)
 	if err != nil {
 		t.Fatal(err)
 	}
 	for i, kv := range kvsn {
-		key, ts, _, err := MVCCDecodeKey(kv.Key)
-		if err != nil {
-			t.Fatal(err)
-		}
 		if log.V(1) {
-			log.Infof("%d: %q, ts=%s", i, key, ts)
+			log.Infof("%d: %s", i, kv.Key)
 		}
 	}
 
@@ -2493,12 +2498,12 @@ func TestMVCCGarbageCollect(t *testing.T) {
 	}
 
 	expEncKeys := []MVCCKey{
-		MVCCEncodeVersionKey(roachpb.Key("a"), ts2),
-		MVCCEncodeVersionKey(roachpb.Key("b"), ts3),
-		MVCCEncodeVersionKey(roachpb.Key("b"), ts2),
-		MVCCEncodeVersionKey(roachpb.Key("b-del"), ts3),
+		mvccVersionKey(roachpb.Key("a"), ts2),
+		mvccVersionKey(roachpb.Key("b"), ts3),
+		mvccVersionKey(roachpb.Key("b"), ts2),
+		mvccVersionKey(roachpb.Key("b-del"), ts3),
 	}
-	kvs, err := Scan(engine, MVCCEncodeKey(keyMin), MVCCEncodeKey(keyMax), 0)
+	kvs, err := Scan(engine, mvccKey(keyMin), mvccKey(keyMax), 0)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -2513,9 +2518,9 @@ func TestMVCCGarbageCollect(t *testing.T) {
 
 	// Verify aggregated stats match computed stats after GC.
 	iter := engine.NewIterator(false)
-	iter.Seek(keyMin)
 	var expMS MVCCStats
-	err = iter.ComputeStats(&expMS, roachpb.KeyMin, roachpb.KeyMax, ts3.WallTime)
+	err = iter.ComputeStats(&expMS, mvccKey(roachpb.KeyMin),
+		mvccKey(roachpb.KeyMax), ts3.WallTime)
 	iter.Close()
 	if err != nil {
 		t.Fatal(err)
@@ -2531,13 +2536,14 @@ func TestMVCCComputeStatsError(t *testing.T) {
 
 	// Write a MVCC metadata key where the value is not an encoded MVCCMetadata
 	// protobuf.
-	if err := engine.Put(MVCCEncodeKey(roachpb.Key("garbage")), []byte("garbage")); err != nil {
+	if err := engine.Put(mvccKey(roachpb.Key("garbage")), []byte("garbage")); err != nil {
 		t.Fatal(err)
 	}
 
 	var ms MVCCStats
 	iter := engine.NewIterator(false)
-	err := iter.ComputeStats(&ms, roachpb.KeyMin, roachpb.KeyMax, 100)
+	err := iter.ComputeStats(&ms, mvccKey(roachpb.KeyMin),
+		mvccKey(roachpb.KeyMax), 100)
 	iter.Close()
 	if e := "unable to decode MVCCMetadata"; !testutils.IsError(err, e) {
 		t.Fatalf("expected %s", e)
@@ -2622,7 +2628,7 @@ func TestResovleIntentWithLowerEpoch(t *testing.T) {
 	}
 
 	// Check that the intent was not cleared.
-	metaKey := MVCCEncodeKey(testKey1)
+	metaKey := mvccKey(testKey1)
 	meta := &MVCCMetadata{}
 	ok, _, _, err := engine.GetProto(metaKey, meta)
 	if err != nil {

--- a/storage/engine/rocksdb/cockroach/roachpb/internal.pb.cc
+++ b/storage/engine/rocksdb/cockroach/roachpb/internal.pb.cc
@@ -153,9 +153,11 @@ void protobuf_AssignDesc_cockroach_2froachpb_2finternal_2eproto() {
       GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(RaftSnapshotData, _internal_metadata_),
       -1);
   RaftSnapshotData_KeyValue_descriptor_ = RaftSnapshotData_descriptor_->nested_type(0);
-  static const int RaftSnapshotData_KeyValue_offsets_[2] = {
+  static const int RaftSnapshotData_KeyValue_offsets_[4] = {
     GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(RaftSnapshotData_KeyValue, key_),
     GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(RaftSnapshotData_KeyValue, value_),
+    GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(RaftSnapshotData_KeyValue, wall_time_),
+    GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(RaftSnapshotData_KeyValue, logical_),
   };
   RaftSnapshotData_KeyValue_reflection_ =
     ::google::protobuf::internal::GeneratedMessageReflection::NewGeneratedMessageReflection(
@@ -243,12 +245,13 @@ void protobuf_AddDesc_cockroach_2froachpb_2finternal_2eproto() {
     "=\n\022RaftTruncatedState\022\023\n\005index\030\001 \001(\004B\004\310\336"
     "\037\000\022\022\n\004term\030\002 \001(\004B\004\310\336\037\000\"L\n\rRaftTombstone\022"
     ";\n\017next_replica_id\030\001 \001(\005B\"\310\336\037\000\342\336\037\rNextRe"
-    "plicaID\372\336\037\tReplicaID\"\300\001\n\020RaftSnapshotDat"
+    "plicaID\372\336\037\tReplicaID\"\360\001\n\020RaftSnapshotDat"
     "a\022B\n\020range_descriptor\030\001 \001(\0132\".cockroach."
     "roachpb.RangeDescriptorB\004\310\336\037\000\022@\n\002KV\030\002 \003("
     "\0132,.cockroach.roachpb.RaftSnapshotData.K"
-    "eyValueB\006\342\336\037\002KV\032&\n\010KeyValue\022\013\n\003key\030\001 \001(\014"
-    "\022\r\n\005value\030\002 \001(\014B\tZ\007roachpbX\002", 948);
+    "eyValueB\006\342\336\037\002KV\032V\n\010KeyValue\022\013\n\003key\030\001 \001(\014"
+    "\022\r\n\005value\030\002 \001(\014\022\027\n\twall_time\030\003 \001(\003B\004\310\336\037\000"
+    "\022\025\n\007logical\030\004 \001(\005B\004\310\336\037\000B\tZ\007roachpbX\002", 996);
   ::google::protobuf::MessageFactory::InternalRegisterGeneratedFile(
     "cockroach/roachpb/internal.proto", &protobuf_RegisterTypes);
   RaftCommand::default_instance_ = new RaftCommand();
@@ -2245,6 +2248,8 @@ void RaftTombstone::clear_next_replica_id() {
 #ifndef _MSC_VER
 const int RaftSnapshotData_KeyValue::kKeyFieldNumber;
 const int RaftSnapshotData_KeyValue::kValueFieldNumber;
+const int RaftSnapshotData_KeyValue::kWallTimeFieldNumber;
+const int RaftSnapshotData_KeyValue::kLogicalFieldNumber;
 #endif  // !_MSC_VER
 
 RaftSnapshotData_KeyValue::RaftSnapshotData_KeyValue()
@@ -2269,6 +2274,8 @@ void RaftSnapshotData_KeyValue::SharedCtor() {
   _cached_size_ = 0;
   key_.UnsafeSetDefault(&::google::protobuf::internal::GetEmptyStringAlreadyInited());
   value_.UnsafeSetDefault(&::google::protobuf::internal::GetEmptyStringAlreadyInited());
+  wall_time_ = GOOGLE_LONGLONG(0);
+  logical_ = 0;
   ::memset(_has_bits_, 0, sizeof(_has_bits_));
 }
 
@@ -2310,7 +2317,16 @@ RaftSnapshotData_KeyValue* RaftSnapshotData_KeyValue::New(::google::protobuf::Ar
 }
 
 void RaftSnapshotData_KeyValue::Clear() {
-  if (_has_bits_[0 / 32] & 3u) {
+#define ZR_HELPER_(f) reinterpret_cast<char*>(\
+  &reinterpret_cast<RaftSnapshotData_KeyValue*>(16)->f)
+
+#define ZR_(first, last) do {\
+  ::memset(&first, 0,\
+           ZR_HELPER_(last) - ZR_HELPER_(first) + sizeof(last));\
+} while (0)
+
+  if (_has_bits_[0 / 32] & 15u) {
+    ZR_(wall_time_, logical_);
     if (has_key()) {
       key_.ClearToEmptyNoArena(&::google::protobuf::internal::GetEmptyStringAlreadyInited());
     }
@@ -2318,6 +2334,10 @@ void RaftSnapshotData_KeyValue::Clear() {
       value_.ClearToEmptyNoArena(&::google::protobuf::internal::GetEmptyStringAlreadyInited());
     }
   }
+
+#undef ZR_HELPER_
+#undef ZR_
+
   ::memset(_has_bits_, 0, sizeof(_has_bits_));
   if (_internal_metadata_.have_unknown_fields()) {
     mutable_unknown_fields()->Clear();
@@ -2352,6 +2372,36 @@ bool RaftSnapshotData_KeyValue::MergePartialFromCodedStream(
          parse_value:
           DO_(::google::protobuf::internal::WireFormatLite::ReadBytes(
                 input, this->mutable_value()));
+        } else {
+          goto handle_unusual;
+        }
+        if (input->ExpectTag(24)) goto parse_wall_time;
+        break;
+      }
+
+      // optional int64 wall_time = 3;
+      case 3: {
+        if (tag == 24) {
+         parse_wall_time:
+          DO_((::google::protobuf::internal::WireFormatLite::ReadPrimitive<
+                   ::google::protobuf::int64, ::google::protobuf::internal::WireFormatLite::TYPE_INT64>(
+                 input, &wall_time_)));
+          set_has_wall_time();
+        } else {
+          goto handle_unusual;
+        }
+        if (input->ExpectTag(32)) goto parse_logical;
+        break;
+      }
+
+      // optional int32 logical = 4;
+      case 4: {
+        if (tag == 32) {
+         parse_logical:
+          DO_((::google::protobuf::internal::WireFormatLite::ReadPrimitive<
+                   ::google::protobuf::int32, ::google::protobuf::internal::WireFormatLite::TYPE_INT32>(
+                 input, &logical_)));
+          set_has_logical();
         } else {
           goto handle_unusual;
         }
@@ -2396,6 +2446,16 @@ void RaftSnapshotData_KeyValue::SerializeWithCachedSizes(
       2, this->value(), output);
   }
 
+  // optional int64 wall_time = 3;
+  if (has_wall_time()) {
+    ::google::protobuf::internal::WireFormatLite::WriteInt64(3, this->wall_time(), output);
+  }
+
+  // optional int32 logical = 4;
+  if (has_logical()) {
+    ::google::protobuf::internal::WireFormatLite::WriteInt32(4, this->logical(), output);
+  }
+
   if (_internal_metadata_.have_unknown_fields()) {
     ::google::protobuf::internal::WireFormat::SerializeUnknownFields(
         unknown_fields(), output);
@@ -2420,6 +2480,16 @@ void RaftSnapshotData_KeyValue::SerializeWithCachedSizes(
         2, this->value(), target);
   }
 
+  // optional int64 wall_time = 3;
+  if (has_wall_time()) {
+    target = ::google::protobuf::internal::WireFormatLite::WriteInt64ToArray(3, this->wall_time(), target);
+  }
+
+  // optional int32 logical = 4;
+  if (has_logical()) {
+    target = ::google::protobuf::internal::WireFormatLite::WriteInt32ToArray(4, this->logical(), target);
+  }
+
   if (_internal_metadata_.have_unknown_fields()) {
     target = ::google::protobuf::internal::WireFormat::SerializeUnknownFieldsToArray(
         unknown_fields(), target);
@@ -2431,7 +2501,7 @@ void RaftSnapshotData_KeyValue::SerializeWithCachedSizes(
 int RaftSnapshotData_KeyValue::ByteSize() const {
   int total_size = 0;
 
-  if (_has_bits_[0 / 32] & 3) {
+  if (_has_bits_[0 / 32] & 15) {
     // optional bytes key = 1;
     if (has_key()) {
       total_size += 1 +
@@ -2444,6 +2514,20 @@ int RaftSnapshotData_KeyValue::ByteSize() const {
       total_size += 1 +
         ::google::protobuf::internal::WireFormatLite::BytesSize(
           this->value());
+    }
+
+    // optional int64 wall_time = 3;
+    if (has_wall_time()) {
+      total_size += 1 +
+        ::google::protobuf::internal::WireFormatLite::Int64Size(
+          this->wall_time());
+    }
+
+    // optional int32 logical = 4;
+    if (has_logical()) {
+      total_size += 1 +
+        ::google::protobuf::internal::WireFormatLite::Int32Size(
+          this->logical());
     }
 
   }
@@ -2481,6 +2565,12 @@ void RaftSnapshotData_KeyValue::MergeFrom(const RaftSnapshotData_KeyValue& from)
       set_has_value();
       value_.AssignWithDefault(&::google::protobuf::internal::GetEmptyStringAlreadyInited(), from.value_);
     }
+    if (from.has_wall_time()) {
+      set_wall_time(from.wall_time());
+    }
+    if (from.has_logical()) {
+      set_logical(from.logical());
+    }
   }
   if (from._internal_metadata_.have_unknown_fields()) {
     mutable_unknown_fields()->MergeFrom(from.unknown_fields());
@@ -2511,6 +2601,8 @@ void RaftSnapshotData_KeyValue::Swap(RaftSnapshotData_KeyValue* other) {
 void RaftSnapshotData_KeyValue::InternalSwap(RaftSnapshotData_KeyValue* other) {
   key_.Swap(&other->key_);
   value_.Swap(&other->value_);
+  std::swap(wall_time_, other->wall_time_);
+  std::swap(logical_, other->logical_);
   std::swap(_has_bits_[0], other->_has_bits_[0]);
   _internal_metadata_.Swap(&other->_internal_metadata_);
   std::swap(_cached_size_, other->_cached_size_);
@@ -2909,6 +3001,54 @@ void RaftSnapshotData_KeyValue::clear_value() {
   }
   value_.SetAllocatedNoArena(&::google::protobuf::internal::GetEmptyStringAlreadyInited(), value);
   // @@protoc_insertion_point(field_set_allocated:cockroach.roachpb.RaftSnapshotData.KeyValue.value)
+}
+
+// optional int64 wall_time = 3;
+bool RaftSnapshotData_KeyValue::has_wall_time() const {
+  return (_has_bits_[0] & 0x00000004u) != 0;
+}
+void RaftSnapshotData_KeyValue::set_has_wall_time() {
+  _has_bits_[0] |= 0x00000004u;
+}
+void RaftSnapshotData_KeyValue::clear_has_wall_time() {
+  _has_bits_[0] &= ~0x00000004u;
+}
+void RaftSnapshotData_KeyValue::clear_wall_time() {
+  wall_time_ = GOOGLE_LONGLONG(0);
+  clear_has_wall_time();
+}
+ ::google::protobuf::int64 RaftSnapshotData_KeyValue::wall_time() const {
+  // @@protoc_insertion_point(field_get:cockroach.roachpb.RaftSnapshotData.KeyValue.wall_time)
+  return wall_time_;
+}
+ void RaftSnapshotData_KeyValue::set_wall_time(::google::protobuf::int64 value) {
+  set_has_wall_time();
+  wall_time_ = value;
+  // @@protoc_insertion_point(field_set:cockroach.roachpb.RaftSnapshotData.KeyValue.wall_time)
+}
+
+// optional int32 logical = 4;
+bool RaftSnapshotData_KeyValue::has_logical() const {
+  return (_has_bits_[0] & 0x00000008u) != 0;
+}
+void RaftSnapshotData_KeyValue::set_has_logical() {
+  _has_bits_[0] |= 0x00000008u;
+}
+void RaftSnapshotData_KeyValue::clear_has_logical() {
+  _has_bits_[0] &= ~0x00000008u;
+}
+void RaftSnapshotData_KeyValue::clear_logical() {
+  logical_ = 0;
+  clear_has_logical();
+}
+ ::google::protobuf::int32 RaftSnapshotData_KeyValue::logical() const {
+  // @@protoc_insertion_point(field_get:cockroach.roachpb.RaftSnapshotData.KeyValue.logical)
+  return logical_;
+}
+ void RaftSnapshotData_KeyValue::set_logical(::google::protobuf::int32 value) {
+  set_has_logical();
+  logical_ = value;
+  // @@protoc_insertion_point(field_set:cockroach.roachpb.RaftSnapshotData.KeyValue.logical)
 }
 
 // -------------------------------------------------------------------

--- a/storage/engine/rocksdb/cockroach/roachpb/internal.pb.h
+++ b/storage/engine/rocksdb/cockroach/roachpb/internal.pb.h
@@ -680,18 +680,38 @@ class RaftSnapshotData_KeyValue : public ::google::protobuf::Message {
   ::std::string* release_value();
   void set_allocated_value(::std::string* value);
 
+  // optional int64 wall_time = 3;
+  bool has_wall_time() const;
+  void clear_wall_time();
+  static const int kWallTimeFieldNumber = 3;
+  ::google::protobuf::int64 wall_time() const;
+  void set_wall_time(::google::protobuf::int64 value);
+
+  // optional int32 logical = 4;
+  bool has_logical() const;
+  void clear_logical();
+  static const int kLogicalFieldNumber = 4;
+  ::google::protobuf::int32 logical() const;
+  void set_logical(::google::protobuf::int32 value);
+
   // @@protoc_insertion_point(class_scope:cockroach.roachpb.RaftSnapshotData.KeyValue)
  private:
   inline void set_has_key();
   inline void clear_has_key();
   inline void set_has_value();
   inline void clear_has_value();
+  inline void set_has_wall_time();
+  inline void clear_has_wall_time();
+  inline void set_has_logical();
+  inline void clear_has_logical();
 
   ::google::protobuf::internal::InternalMetadataWithArena _internal_metadata_;
   ::google::protobuf::uint32 _has_bits_[1];
   mutable int _cached_size_;
   ::google::protobuf::internal::ArenaStringPtr key_;
   ::google::protobuf::internal::ArenaStringPtr value_;
+  ::google::protobuf::int64 wall_time_;
+  ::google::protobuf::int32 logical_;
   friend void  protobuf_AddDesc_cockroach_2froachpb_2finternal_2eproto();
   friend void protobuf_AssignDesc_cockroach_2froachpb_2finternal_2eproto();
   friend void protobuf_ShutdownFile_cockroach_2froachpb_2finternal_2eproto();
@@ -1317,6 +1337,54 @@ inline void RaftSnapshotData_KeyValue::set_allocated_value(::std::string* value)
   }
   value_.SetAllocatedNoArena(&::google::protobuf::internal::GetEmptyStringAlreadyInited(), value);
   // @@protoc_insertion_point(field_set_allocated:cockroach.roachpb.RaftSnapshotData.KeyValue.value)
+}
+
+// optional int64 wall_time = 3;
+inline bool RaftSnapshotData_KeyValue::has_wall_time() const {
+  return (_has_bits_[0] & 0x00000004u) != 0;
+}
+inline void RaftSnapshotData_KeyValue::set_has_wall_time() {
+  _has_bits_[0] |= 0x00000004u;
+}
+inline void RaftSnapshotData_KeyValue::clear_has_wall_time() {
+  _has_bits_[0] &= ~0x00000004u;
+}
+inline void RaftSnapshotData_KeyValue::clear_wall_time() {
+  wall_time_ = GOOGLE_LONGLONG(0);
+  clear_has_wall_time();
+}
+inline ::google::protobuf::int64 RaftSnapshotData_KeyValue::wall_time() const {
+  // @@protoc_insertion_point(field_get:cockroach.roachpb.RaftSnapshotData.KeyValue.wall_time)
+  return wall_time_;
+}
+inline void RaftSnapshotData_KeyValue::set_wall_time(::google::protobuf::int64 value) {
+  set_has_wall_time();
+  wall_time_ = value;
+  // @@protoc_insertion_point(field_set:cockroach.roachpb.RaftSnapshotData.KeyValue.wall_time)
+}
+
+// optional int32 logical = 4;
+inline bool RaftSnapshotData_KeyValue::has_logical() const {
+  return (_has_bits_[0] & 0x00000008u) != 0;
+}
+inline void RaftSnapshotData_KeyValue::set_has_logical() {
+  _has_bits_[0] |= 0x00000008u;
+}
+inline void RaftSnapshotData_KeyValue::clear_has_logical() {
+  _has_bits_[0] &= ~0x00000008u;
+}
+inline void RaftSnapshotData_KeyValue::clear_logical() {
+  logical_ = 0;
+  clear_has_logical();
+}
+inline ::google::protobuf::int32 RaftSnapshotData_KeyValue::logical() const {
+  // @@protoc_insertion_point(field_get:cockroach.roachpb.RaftSnapshotData.KeyValue.logical)
+  return logical_;
+}
+inline void RaftSnapshotData_KeyValue::set_logical(::google::protobuf::int32 value) {
+  set_has_logical();
+  logical_ = value;
+  // @@protoc_insertion_point(field_set:cockroach.roachpb.RaftSnapshotData.KeyValue.logical)
 }
 
 // -------------------------------------------------------------------

--- a/storage/engine/rocksdb/db.cc
+++ b/storage/engine/rocksdb/db.cc
@@ -50,11 +50,11 @@ struct DBEngine {
   }
   virtual ~DBEngine() { }
 
-  virtual DBStatus Put(DBSlice key, DBSlice value) = 0;
-  virtual DBStatus Merge(DBSlice key, DBSlice value) = 0;
-  virtual DBStatus Delete(DBSlice key) = 0;
+  virtual DBStatus Put(DBKey key, DBSlice value) = 0;
+  virtual DBStatus Merge(DBKey key, DBSlice value) = 0;
+  virtual DBStatus Delete(DBKey key) = 0;
   virtual DBStatus WriteBatch() = 0;
-  virtual DBStatus Get(DBSlice key, DBString* value) = 0;
+  virtual DBStatus Get(DBKey key, DBString* value) = 0;
   virtual DBIterator* NewIter(bool prefix) = 0;
 };
 
@@ -79,11 +79,11 @@ struct DBImpl : public DBEngine {
                   s->getTickerCount(rocksdb::BLOOM_FILTER_PREFIX_CHECKED));
   }
 
-  virtual DBStatus Put(DBSlice key, DBSlice value);
-  virtual DBStatus Merge(DBSlice key, DBSlice value);
-  virtual DBStatus Delete(DBSlice key);
+  virtual DBStatus Put(DBKey key, DBSlice value);
+  virtual DBStatus Merge(DBKey key, DBSlice value);
+  virtual DBStatus Delete(DBKey key);
   virtual DBStatus WriteBatch();
-  virtual DBStatus Get(DBSlice key, DBString* value);
+  virtual DBStatus Get(DBKey key, DBString* value);
   virtual DBIterator* NewIter(bool prefix);
 };
 
@@ -99,11 +99,11 @@ struct DBBatch : public DBEngine {
   virtual ~DBBatch() {
   }
 
-  virtual DBStatus Put(DBSlice key, DBSlice value);
-  virtual DBStatus Merge(DBSlice key, DBSlice value);
-  virtual DBStatus Delete(DBSlice key);
+  virtual DBStatus Put(DBKey key, DBSlice value);
+  virtual DBStatus Merge(DBKey key, DBSlice value);
+  virtual DBStatus Delete(DBKey key);
   virtual DBStatus WriteBatch();
-  virtual DBStatus Get(DBSlice key, DBString* value);
+  virtual DBStatus Get(DBKey key, DBString* value);
   virtual DBIterator* NewIter(bool prefix);
 };
 
@@ -120,16 +120,17 @@ struct DBSnapshot : public DBEngine {
     rep->ReleaseSnapshot(snapshot);
   }
 
-  virtual DBStatus Put(DBSlice key, DBSlice value);
-  virtual DBStatus Merge(DBSlice key, DBSlice value);
-  virtual DBStatus Delete(DBSlice key);
+  virtual DBStatus Put(DBKey key, DBSlice value);
+  virtual DBStatus Merge(DBKey key, DBSlice value);
+  virtual DBStatus Delete(DBKey key);
   virtual DBStatus WriteBatch();
-  virtual DBStatus Get(DBSlice key, DBString* value);
+  virtual DBStatus Get(DBKey key, DBString* value);
   virtual DBIterator* NewIter(bool prefix);
 };
 
 struct DBIterator {
   std::unique_ptr<rocksdb::Iterator> rep;
+  std::string key;
 };
 
 }  // extern "C"
@@ -157,6 +158,40 @@ rocksdb::Slice ToSlice(DBSlice s) {
 
 rocksdb::Slice ToSlice(DBString s) {
   return rocksdb::Slice(s.data, s.len);
+}
+
+const int kMVCCVersionTimestampSize = 12;
+
+std::string EncodeKey(DBKey k) {
+  std::string s;
+  const bool ts = k.walltime != 0 || k.logical != 0;
+  s.reserve(k.key.len + 3 + (ts ? kMVCCVersionTimestampSize : 0));
+  EncodeBytes(&s, k.key.data, k.key.len);
+  if (ts) {
+    EncodeUint64Decreasing(&s, uint64_t(k.walltime));
+    EncodeUint32Decreasing(&s, uint32_t(k.logical));
+  }
+  return s;
+}
+
+bool DecodeKey(rocksdb::Slice buf, std::string *key, int64_t *walltime, int32_t *logical) {
+  key->clear();
+  if (!DecodeBytes(&buf, key)) {
+    return false;
+  }
+  if (buf.size() == kMVCCVersionTimestampSize) {
+    uint64_t w;
+    if (!DecodeUint64Decreasing(&buf, &w)) {
+      return false;
+    }
+    uint32_t l;
+    if (!DecodeUint32Decreasing(&buf, &l)) {
+      return false;
+    }
+    *walltime = int64_t(w);
+    *logical = int32_t(l);
+  }
+  return buf.empty();
 }
 
 DBSlice ToDBSlice(const rocksdb::Slice& s) {
@@ -200,14 +235,20 @@ DBStatus FmtStatus(const char *fmt, ...) {
 DBIterState DBIterGetState(DBIterator* iter) {
   DBIterState state;
   state.valid = iter->rep->Valid();
+  state.key.key.data = NULL;
+  state.key.key.len = 0;
+  state.key.walltime = 0;
+  state.key.logical = 0;
+  state.value.data = NULL;
+  state.value.len = 0;
+
   if (state.valid) {
-    state.key = ToDBSlice(iter->rep->key());
-    state.value = ToDBSlice(iter->rep->value());
-  } else {
-    state.key.data = NULL;
-    state.key.len = 0;
-    state.value.data = NULL;
-    state.value.len = 0;
+    state.valid = DecodeKey(iter->rep->key(), &iter->key,
+                            &state.key.walltime, &state.key.logical);
+    if (state.valid) {
+      state.key.key = ToDBSlice(iter->key);
+      state.value = ToDBSlice(iter->rep->value());
+    }
   }
   return state;
 }
@@ -776,10 +817,10 @@ struct DBGetter : public Getter {
   rocksdb::ReadOptions const options;
   rocksdb::Slice const key;
 
-  DBGetter(rocksdb::DB *const r, rocksdb::ReadOptions opts, DBSlice k)
+  DBGetter(rocksdb::DB *const r, rocksdb::ReadOptions opts, rocksdb::Slice k)
       : rep(r),
         options(opts),
-        key(ToSlice(k)) {
+        key(k) {
   }
 
   virtual DBStatus Get(DBString* value) {
@@ -1178,108 +1219,114 @@ void DBSetGCTimeouts(DBEngine * db, int64_t min_txn_ts) {
   db_cff->SetGCTimeouts(min_txn_ts);
 }
 
-DBStatus DBCompactRange(DBEngine* db, DBSlice* start, DBSlice* end) {
+DBStatus DBCompactRange(DBEngine* db, DBKey* start, DBKey* end) {
+  std::string sbuf;
+  std::string ebuf;
   rocksdb::Slice s;
   rocksdb::Slice e;
   rocksdb::Slice* sPtr = NULL;
   rocksdb::Slice* ePtr = NULL;
   if (start != NULL) {
     sPtr = &s;
-    s = ToSlice(*start);
+    sbuf = EncodeKey(*start);
+    s = sbuf;
   }
   if (end != NULL) {
     ePtr = &e;
-    e = ToSlice(*end);
+    ebuf = EncodeKey(*end);
+    e = ebuf;
   }
   return ToDBStatus(db->rep->CompactRange(rocksdb::CompactRangeOptions(), sPtr, ePtr));
 }
 
-uint64_t DBApproximateSize(DBEngine* db, DBSlice start, DBSlice end) {
-  const rocksdb::Range r(ToSlice(start), ToSlice(end));
+uint64_t DBApproximateSize(DBEngine* db, DBKey start, DBKey end) {
+  std::string s = EncodeKey(start);
+  std::string e = EncodeKey(end);
+  const rocksdb::Range r(s, e);
   uint64_t result;
   db->rep->GetApproximateSizes(&r, 1, &result);
   return result;
 }
 
-DBStatus DBImpl::Put(DBSlice key, DBSlice value) {
+DBStatus DBImpl::Put(DBKey key, DBSlice value) {
   rocksdb::WriteOptions options;
-  return ToDBStatus(rep->Put(options, ToSlice(key), ToSlice(value)));
+  return ToDBStatus(rep->Put(options, EncodeKey(key), ToSlice(value)));
 }
 
-DBStatus DBBatch::Put(DBSlice key, DBSlice value) {
+DBStatus DBBatch::Put(DBKey key, DBSlice value) {
   ++updates;
-  batch.Put(ToSlice(key), ToSlice(value));
+  batch.Put(EncodeKey(key), ToSlice(value));
   return kSuccess;
 }
 
-DBStatus DBSnapshot::Put(DBSlice key, DBSlice value) {
+DBStatus DBSnapshot::Put(DBKey key, DBSlice value) {
   return FmtStatus("unsupported");
 }
 
-DBStatus DBPut(DBEngine* db, DBSlice key, DBSlice value) {
+DBStatus DBPut(DBEngine* db, DBKey key, DBSlice value) {
   return db->Put(key, value);
 }
 
-DBStatus DBImpl::Merge(DBSlice key, DBSlice value) {
+DBStatus DBImpl::Merge(DBKey key, DBSlice value) {
   rocksdb::WriteOptions options;
-  return ToDBStatus(rep->Merge(options, ToSlice(key), ToSlice(value)));
+  return ToDBStatus(rep->Merge(options, EncodeKey(key), ToSlice(value)));
 }
 
-DBStatus DBBatch::Merge(DBSlice key, DBSlice value) {
+DBStatus DBBatch::Merge(DBKey key, DBSlice value) {
   ++updates;
-  batch.Merge(ToSlice(key), ToSlice(value));
+  batch.Merge(EncodeKey(key), ToSlice(value));
   return kSuccess;
 }
 
-DBStatus DBSnapshot::Merge(DBSlice key, DBSlice value) {
+DBStatus DBSnapshot::Merge(DBKey key, DBSlice value) {
   return FmtStatus("unsupported");
 }
 
-DBStatus DBMerge(DBEngine* db, DBSlice key, DBSlice value) {
+DBStatus DBMerge(DBEngine* db, DBKey key, DBSlice value) {
   return db->Merge(key, value);
 }
 
-DBStatus DBImpl::Get(DBSlice key, DBString* value) {
-  DBGetter base(rep, read_opts, key);
+DBStatus DBImpl::Get(DBKey key, DBString* value) {
+  DBGetter base(rep, read_opts, EncodeKey(key));
   return base.Get(value);
 }
 
-DBStatus DBBatch::Get(DBSlice key, DBString* value) {
-  DBGetter base(rep, read_opts, key);
+DBStatus DBBatch::Get(DBKey key, DBString* value) {
+  std::string encoded_key = EncodeKey(key);
+  DBGetter base(rep, read_opts, encoded_key);
   if (updates == 0) {
     return base.Get(value);
   }
   std::unique_ptr<rocksdb::WBWIIterator> iter(batch.NewIterator());
-  rocksdb::Slice rkey(ToSlice(key));
-  iter->Seek(rkey);
-  return ProcessDeltaKey(&base, iter.get(), rkey, value);
+  iter->Seek(encoded_key);
+  return ProcessDeltaKey(&base, iter.get(), encoded_key, value);
 }
 
-DBStatus DBSnapshot::Get(DBSlice key, DBString* value) {
-  DBGetter base(rep, read_opts, key);
+DBStatus DBSnapshot::Get(DBKey key, DBString* value) {
+  DBGetter base(rep, read_opts, EncodeKey(key));
   return base.Get(value);
 }
 
-DBStatus DBGet(DBEngine* db, DBSlice key, DBString* value) {
+DBStatus DBGet(DBEngine* db, DBKey key, DBString* value) {
   return db->Get(key, value);
 }
 
-DBStatus DBImpl::Delete(DBSlice key) {
+DBStatus DBImpl::Delete(DBKey key) {
   rocksdb::WriteOptions options;
-  return ToDBStatus(rep->Delete(options, ToSlice(key)));
+  return ToDBStatus(rep->Delete(options, EncodeKey(key)));
 }
 
-DBStatus DBBatch::Delete(DBSlice key) {
+DBStatus DBBatch::Delete(DBKey key) {
   ++updates;
-  batch.Delete(ToSlice(key));
+  batch.Delete(EncodeKey(key));
   return kSuccess;
 }
 
-DBStatus DBSnapshot::Delete(DBSlice key) {
+DBStatus DBSnapshot::Delete(DBKey key) {
   return FmtStatus("unsupported");
 }
 
-DBStatus DBDelete(DBEngine *db, DBSlice key) {
+DBStatus DBDelete(DBEngine *db, DBKey key) {
   return db->Delete(key);
 }
 
@@ -1349,8 +1396,8 @@ void DBIterDestroy(DBIterator* iter) {
   delete iter;
 }
 
-DBIterState DBIterSeek(DBIterator* iter, DBSlice key) {
-  iter->rep->Seek(ToSlice(key));
+DBIterState DBIterSeek(DBIterator* iter, DBKey key) {
+  iter->rep->Seek(EncodeKey(key));
   return DBIterGetState(iter);
 }
 
@@ -1398,15 +1445,13 @@ DBStatus DBMergeOne(DBSlice existing, DBSlice update, DBString* new_value) {
 }
 
 MVCCStatsResult MVCCComputeStats(
-    DBIterator* iter, DBSlice start, DBSlice end, int64_t now_nanos) {
-  const int mvcc_version_timestamp_size = 12;
-
+    DBIterator* iter, DBKey start, DBKey end, int64_t now_nanos) {
   MVCCStatsResult stats;
   memset(&stats, 0, sizeof(stats));
 
   rocksdb::Iterator *const iter_rep = iter->rep.get();
-  iter_rep->Seek(ToSlice(start));
-  const rocksdb::Slice end_key = ToSlice(end);
+  iter_rep->Seek(EncodeKey(start));
+  const std::string end_key = EncodeKey(end);
 
   cockroach::storage::engine::MVCCMetadata meta;
   std::string prev_key;
@@ -1425,14 +1470,14 @@ MVCCStatsResult MVCCComputeStats(
     }
 
     const bool isSys = (rocksdb::Slice(decoded_key).compare(kKeyLocalMax) < 0);
-    const bool isValue = (buf.size() == mvcc_version_timestamp_size);
+    const bool isValue = (buf.size() == kMVCCVersionTimestampSize);
     const bool implicitMeta = isValue && decoded_key != prev_key;
     prev_key = decoded_key;
 
     if (implicitMeta) {
       // No MVCCMetadata entry for this series of keys.
       meta.Clear();
-      meta.set_key_bytes(mvcc_version_timestamp_size);
+      meta.set_key_bytes(kMVCCVersionTimestampSize);
       meta.set_val_bytes(value.size());
       meta.set_deleted(value.size() == 0);
 
@@ -1448,12 +1493,12 @@ MVCCStatsResult MVCCComputeStats(
     if (!isValue || implicitMeta) {
       if (!implicitMeta && buf.size() != 0) {
         stats.status = FmtStatus("there should be %d bytes for encoded timestamp",
-                                 mvcc_version_timestamp_size);
+                                 kMVCCVersionTimestampSize);
         break;
       }
 
       const int64_t meta_key_size =
-          key.size() - (implicitMeta ? mvcc_version_timestamp_size : 0);
+          key.size() - (implicitMeta ? kMVCCVersionTimestampSize : 0);
       const int64_t meta_val_size =
           implicitMeta ? 0 : value.size();
       const int64_t total_bytes = meta_key_size + meta_val_size;
@@ -1486,7 +1531,7 @@ MVCCStatsResult MVCCComputeStats(
       }
     }
 
-    const int64_t total_bytes = value.size() + mvcc_version_timestamp_size;
+    const int64_t total_bytes = value.size() + kMVCCVersionTimestampSize;
     if (isSys) {
       stats.sys_bytes += total_bytes;
     } else {
@@ -1502,9 +1547,9 @@ MVCCStatsResult MVCCComputeStats(
           stats.intent_count++;
           stats.intent_age += (now_nanos - meta.timestamp().wall_time()) / 1e9;
         }
-        if (meta.key_bytes() != mvcc_version_timestamp_size) {
+        if (meta.key_bytes() != kMVCCVersionTimestampSize) {
           stats.status = FmtStatus("expected mvcc metadata val bytes to equal %d; got %d",
-                                   mvcc_version_timestamp_size, int(meta.key_bytes()));
+                                   kMVCCVersionTimestampSize, int(meta.key_bytes()));
           break;
         }
         if (meta.val_bytes() != value.size()) {
@@ -1520,7 +1565,7 @@ MVCCStatsResult MVCCComputeStats(
         }
         stats.gc_bytes_age += total_bytes * ((now_nanos - wall_time) / 1e9);
       }
-      stats.key_bytes += mvcc_version_timestamp_size;
+      stats.key_bytes += kMVCCVersionTimestampSize;
       stats.val_bytes += value.size();
       stats.val_count++;
     }

--- a/storage/engine/rocksdb/db.h
+++ b/storage/engine/rocksdb/db.h
@@ -39,8 +39,14 @@ typedef struct {
 } DBString;
 
 typedef struct {
-  bool valid;
   DBSlice key;
+  int64_t walltime;
+  int32_t logical;
+} DBKey;
+
+typedef struct {
+  bool valid;
+  DBKey key;
   DBSlice value;
 } DBIterState;
 
@@ -83,23 +89,23 @@ void DBSetGCTimeouts(DBEngine * db, int64_t min_txn_ts);
 // database. end==NULL is treated as a key after all keys in the
 // database. DBCompactRange(db, NULL, NULL) will compact the entire
 // database.
-DBStatus DBCompactRange(DBEngine* db, DBSlice* start, DBSlice* end);
+DBStatus DBCompactRange(DBEngine* db, DBKey* start, DBKey* end);
 
 // Returns the approximate file system spaced used by keys in the
 // range [start,end].
-uint64_t DBApproximateSize(DBEngine* db, DBSlice start, DBSlice end);
+uint64_t DBApproximateSize(DBEngine* db, DBKey start, DBKey end);
 
 // Sets the database entry for "key" to "value".
-DBStatus DBPut(DBEngine* db, DBSlice key, DBSlice value);
+DBStatus DBPut(DBEngine* db, DBKey key, DBSlice value);
 
 // Merge the database entry (if any) for "key" with "value".
-DBStatus DBMerge(DBEngine* db, DBSlice key, DBSlice value);
+DBStatus DBMerge(DBEngine* db, DBKey key, DBSlice value);
 
 // Retrieves the database entry for "key".
-DBStatus DBGet(DBEngine* db, DBSlice key, DBString* value);
+DBStatus DBGet(DBEngine* db, DBKey key, DBString* value);
 
 // Deletes the database entry for "key".
-DBStatus DBDelete(DBEngine* db, DBSlice key);
+DBStatus DBDelete(DBEngine* db, DBKey key);
 
 // Applies a batch of operations (puts, merges and deletes) to the
 // database atomically. It is only valid to call this function on an
@@ -127,7 +133,7 @@ DBIterator* DBNewIter(DBEngine* db, bool prefix);
 void DBIterDestroy(DBIterator* iter);
 
 // Positions the iterator at the first key that is >= "key".
-DBIterState DBIterSeek(DBIterator* iter, DBSlice key);
+DBIterState DBIterSeek(DBIterator* iter, DBKey key);
 
 // Positions the iterator at the first key in the database.
 DBIterState DBIterSeekToFirst(DBIterator* iter);
@@ -170,7 +176,7 @@ typedef struct {
   int64_t last_update_nanos;
 } MVCCStatsResult;
 
-MVCCStatsResult MVCCComputeStats(DBIterator* iter, DBSlice start, DBSlice end, int64_t now_nanos);
+MVCCStatsResult MVCCComputeStats(DBIterator* iter, DBKey start, DBKey end, int64_t now_nanos);
 
 #ifdef __cplusplus
 }  // extern "C"

--- a/storage/engine/rocksdb/encoding.h
+++ b/storage/engine/rocksdb/encoding.h
@@ -20,24 +20,52 @@
 
 #include <stdint.h>
 
+// EncodeBytes encodes the n bytes at ptr using an escape-based encoding. The
+// encoded value is terminated with the sequence "\x00\x01" which is guaranteed
+// to not occur elsewhere in the encoded value. The encoded bytes are appended
+// to the supplied buffer.
+void EncodeBytes(std::string* buf, const char* ptr, int n);
+
+// EncodeUint32 encodes the uint32 value using a big-endian 4 byte
+// representation. The bytes are appended to the supplied buffer.
+void EncodeUint32(std::string* buf, uint32_t v);
+
+// EncodeUint32Decreasing encodes the uint32 value so that it sorts in reverse
+// order, from largest to smallest.
+void EncodeUint32Decreasing(std::string* buf, uint32_t v);
+
+// EncodeUint64 encodes the uint64 value using a big-endian 8 byte
+// representation. The encoded bytes are appended to the supplied buffer.
+void EncodeUint64(std::string* buf, uint64_t v);
+
+// EncodeUint64Decreasing encodes the uint64 value so that it sorts in reverse
+// order, from largest to smallest.
+void EncodeUint64Decreasing(std::string* buf, uint64_t v);
+
 // DecodeBytes decodes a byte slice from a buffer, returning true on a
 // successful decode. The decoded bytes are returned in *decoded.
 bool DecodeBytes(rocksdb::Slice* buf, std::string* decoded);
 
-// DecodeUvarint64 decodes a varint encoded uint64 from a buffer,
-// returning true on a successful decode. The decoded value is
-// returned in *value.
+// DecodeUvarint64 decodes a varint encoded uint64 from a buffer, returning
+// true on a successful decode. The decoded value is returned in *value.
 bool DecodeUvarint64(rocksdb::Slice* buf, uint64_t* value);
 
-// DecodedUint64 decodes a fixed-length encoded uint64 from a buffer,
-// returning true on a successful decode. The decoded value is
-// returned in *value.
+// DecodedUint32 decodes a fixed-length encoded uint32 from a buffer, returning
+// true on a successful decode. The decoded value is returned in *value.
+bool DecodeUint32(rocksdb::Slice* buf, uint32_t* value);
+
+// DecodedUint32Decreasing decodes a fixed-length encoded uint32 from a buffer
+// that was encoded using EncodeUint32Decreasing, returning true on a
+// successful decode. The decoded value is returned in *value.
+bool DecodeUint32Decreasing(rocksdb::Slice* buf, uint32_t* value);
+
+// DecodedUint64 decodes a fixed-length encoded uint64 from a buffer, returning
+// true on a successful decode. The decoded value is returned in *value.
 bool DecodeUint64(rocksdb::Slice* buf, uint64_t* value);
 
-// DecodedUint64Decreasing decodes a fixed-length encoded uint64 from
-// a buffer that was encoded using EncodeUint64Increasing, returning
-// true on a successful decode. The decoded value is returned in
-// *value.
+// DecodedUint64Decreasing decodes a fixed-length encoded uint64 from a buffer
+// that was encoded using EncodeUint64Decreasing, returning true on a
+// successful decode. The decoded value is returned in *value.
 bool DecodeUint64Decreasing(rocksdb::Slice* buf, uint64_t* value);
 
 #endif // ROACHLIB_ENCODING_H

--- a/storage/engine/rocksdb_test.go
+++ b/storage/engine/rocksdb_test.go
@@ -103,7 +103,7 @@ func TestRocksDBCompaction(t *testing.T) {
 	}
 
 	// Compact range and scan remaining values to compare.
-	rocksdb.CompactRange(nil, nil)
+	rocksdb.CompactRange(NilKey, NilKey)
 	actualKVs, _, err := MVCCScan(rocksdb, keyMin, keyMax, 0, roachpb.ZeroTimestamp, true, nil)
 	if err != nil {
 		t.Fatalf("could not run scan: %v", err)
@@ -640,9 +640,8 @@ func runMVCCComputeStats(valueBytes int, b *testing.B) {
 	var stats MVCCStats
 	for i := 0; i < b.N; i++ {
 		iter := rocksdb.NewIterator(false)
-		iter.Seek(keyMin)
 		stats = MVCCStats{}
-		err := iter.ComputeStats(&stats, roachpb.KeyMin, roachpb.KeyMax, 0)
+		err := iter.ComputeStats(&stats, mvccKey(roachpb.KeyMin), mvccKey(roachpb.KeyMax), 0)
 		iter.Close()
 		if err != nil {
 			b.Fatal(err)

--- a/storage/replica_command.go
+++ b/storage/replica_command.go
@@ -1105,9 +1105,10 @@ func (r *Replica) TruncateLog(batch engine.Engine, ms *engine.MVCCStats, h roach
 	}
 	start := keys.RaftLogKey(rangeID, 0)
 	end := keys.RaftLogKey(rangeID, args.Index)
-	if err = batch.Iterate(engine.MVCCEncodeKey(start), engine.MVCCEncodeKey(end), func(kv engine.MVCCKeyValue) (bool, error) {
-		return false, batch.Clear(kv.Key)
-	}); err != nil {
+	if err = batch.Iterate(engine.MakeMVCCMetadataKey(start), engine.MakeMVCCMetadataKey(end),
+		func(kv engine.MVCCKeyValue) (bool, error) {
+			return false, batch.Clear(kv.Key)
+		}); err != nil {
 		return reply, err
 	}
 	tState := roachpb.RaftTruncatedState{

--- a/storage/replica_data_iter.go
+++ b/storage/replica_data_iter.go
@@ -51,16 +51,16 @@ func makeReplicaKeyRanges(d *roachpb.RangeDescriptor) []keyRange {
 	}
 	return []keyRange{
 		{
-			start: engine.MVCCEncodeKey(keys.MakeRangeIDPrefix(d.RangeID)),
-			end:   engine.MVCCEncodeKey(keys.MakeRangeIDPrefix(d.RangeID + 1)),
+			start: engine.MakeMVCCMetadataKey(keys.MakeRangeIDPrefix(d.RangeID)),
+			end:   engine.MakeMVCCMetadataKey(keys.MakeRangeIDPrefix(d.RangeID + 1)),
 		},
 		{
-			start: engine.MVCCEncodeKey(keys.MakeRangeKeyPrefix(d.StartKey)),
-			end:   engine.MVCCEncodeKey(keys.MakeRangeKeyPrefix(d.EndKey)),
+			start: engine.MakeMVCCMetadataKey(keys.MakeRangeKeyPrefix(d.StartKey)),
+			end:   engine.MakeMVCCMetadataKey(keys.MakeRangeKeyPrefix(d.EndKey)),
 		},
 		{
-			start: engine.MVCCEncodeKey(dataStartKey),
-			end:   engine.MVCCEncodeKey(d.EndKey.AsRawKey()),
+			start: engine.MakeMVCCMetadataKey(dataStartKey),
+			end:   engine.MakeMVCCMetadataKey(d.EndKey.AsRawKey()),
 		},
 	}
 }
@@ -81,7 +81,7 @@ func (ri *replicaDataIterator) Close() {
 }
 
 // Seek seeks to the specified key.
-func (ri *replicaDataIterator) Seek(key []byte) {
+func (ri *replicaDataIterator) Seek(key engine.MVCCKey) {
 	ri.Iterator.Seek(key)
 	ri.advance()
 }

--- a/storage/store.go
+++ b/storage/store.go
@@ -748,7 +748,9 @@ func (s *Store) Bootstrap(ident roachpb.StoreIdent, stopper *stop.Stopper) error
 		return err
 	}
 	s.Ident = ident
-	kvs, err := engine.Scan(s.engine, engine.MVCCKey(roachpb.RKeyMin), engine.MVCCKey(roachpb.RKeyMax), 1)
+	kvs, err := engine.Scan(s.engine,
+		engine.MakeMVCCMetadataKey(roachpb.Key(roachpb.RKeyMin)),
+		engine.MakeMVCCMetadataKey(roachpb.Key(roachpb.RKeyMax)), 1)
 	if err != nil {
 		return util.Errorf("store %s: unable to access: %s", s.engine, err)
 	} else if len(kvs) > 0 {

--- a/storage/store_test.go
+++ b/storage/store_test.go
@@ -226,7 +226,7 @@ func TestBootstrapOfNonEmptyStore(t *testing.T) {
 	eng := engine.NewInMem(roachpb.Attributes{}, 1<<20, stopper)
 
 	// Put some random garbage into the engine.
-	if err := eng.Put(engine.MVCCKey("foo"), []byte("bar")); err != nil {
+	if err := eng.Put(engine.MakeMVCCMetadataKey(roachpb.Key("foo")), []byte("bar")); err != nil {
 		t.Errorf("failure putting key foo into engine: %s", err)
 	}
 	ctx := TestStoreContext


### PR DESCRIPTION
Changed all of the Engine/Iterator interfaces to use MVCCKeys. Moving
the MVCCKey encoding from Go to C++ simplifies the usage of
MVCCKeys. The MVCCKey type is now a structure composed of a roachpb.Key
and a timestamp. This is both more convenient to use and a minor perf
win, though the motivation behind this change was to pave the way to
using a custom RocksDB comparator.

```
name                                old time/op    new time/op    delta
MVCCScan1Version1Row8Bytes-8          4.70µs ± 2%    4.46µs ± 1%   -5.01% (p=0.000 n=9+8)
MVCCScan1Version10Rows8Bytes-8        23.7µs ± 1%    22.6µs ± 0%   -4.95% (p=0.000 n=10+9)
MVCCScan1Version100Rows8Bytes-8        200µs ± 1%     190µs ± 1%   -4.81% (p=0.000 n=9+9)
MVCCScan1Version1000Rows8Bytes-8      1.94ms ± 0%    1.85ms ± 0%   -4.39% (p=0.000 n=9+10)
```

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/3337)

<!-- Reviewable:end -->
