### PR TITLE
table leader lease library

### DIFF
--- a/sql/executor.go
+++ b/sql/executor.go
@@ -65,7 +65,7 @@ var plannerPool = sync.Pool{
 // An Executor executes SQL statements.
 type Executor struct {
 	db       client.DB
-	nodeID   uint32
+	nodeID   roachpb.NodeID
 	reCache  *parser.RegexpCache
 	leaseMgr *LeaseManager
 
@@ -91,8 +91,8 @@ func newExecutor(db client.DB, gossip *gossip.Gossip, leaseMgr *LeaseManager) *E
 // SetNodeID sets the node ID for the SQL server. This method must be called
 // before actually using the Executor.
 func (e *Executor) SetNodeID(nodeID roachpb.NodeID) {
-	e.nodeID = uint32(nodeID)
-	e.leaseMgr.nodeID = e.nodeID
+	e.nodeID = nodeID
+	e.leaseMgr.nodeID = uint32(nodeID)
 }
 
 // updateSystemConfig is called whenever the system config gossip entry is updated.

--- a/sql/lease.go
+++ b/sql/lease.go
@@ -85,7 +85,7 @@ type LeaseStore struct {
 
 // jitteredLeaseDuration returns a randomly jittered duration from the interval
 // [0.75 * leaseDuration, 1.25 * leaseDuration].
-func (s LeaseStore) jitteredLeaseDuration() time.Duration {
+func jitteredLeaseDuration() time.Duration {
 	return time.Duration(float64(LeaseDuration) * (0.75 + 0.5*rand.Float64()))
 }
 
@@ -93,7 +93,7 @@ func (s LeaseStore) jitteredLeaseDuration() time.Duration {
 func (s LeaseStore) Acquire(txn *client.Txn, tableID ID, minVersion DescriptorVersion) (*LeaseState, error) {
 	lease := &LeaseState{}
 	lease.expiration = parser.DTimestamp{
-		Time: time.Unix(0, s.clock.Now().WallTime).Add(s.jitteredLeaseDuration()),
+		Time: time.Unix(0, s.clock.Now().WallTime).Add(jitteredLeaseDuration()),
 	}
 
 	// Use the supplied (user) transaction to look up the descriptor because the

--- a/sql/parser/builtins.go
+++ b/sql/parser/builtins.go
@@ -37,6 +37,7 @@ import (
 	"unicode"
 	"unicode/utf8"
 
+	"github.com/cockroachdb/cockroach/roachpb"
 	"github.com/cockroachdb/cockroach/util/encoding"
 	"github.com/cockroachdb/cockroach/util/uuid"
 )
@@ -1300,7 +1301,7 @@ var uniqueBytesState struct {
 	nanos uint64
 }
 
-func generateUniqueBytes(nodeID uint32) DBytes {
+func generateUniqueBytes(nodeID roachpb.NodeID) DBytes {
 	// Unique bytes are composed of the current time in nanoseconds and the
 	// node-id. If the nanosecond value is the same on two consecutive calls to
 	// time.Now() the nanoseconds value is incremented. The node-id is varint
@@ -1334,7 +1335,7 @@ var uniqueIntState struct {
 
 var uniqueIDEpoch = time.Date(2015, time.January, 1, 0, 0, 0, 0, time.UTC).UnixNano()
 
-func generateUniqueInt(nodeID uint32) DInt {
+func generateUniqueInt(nodeID roachpb.NodeID) DInt {
 	// Unique ints are composed of the current time at a 10-microsecond
 	// granularity and the node-id. The node-id is stored in the lower 15 bits of
 	// the returned value and the timestamp is stored in the upper 48 bits. The

--- a/sql/parser/eval.go
+++ b/sql/parser/eval.go
@@ -29,6 +29,7 @@ import (
 	"time"
 	"unicode/utf8"
 
+	"github.com/cockroachdb/cockroach/roachpb"
 	"github.com/cockroachdb/cockroach/util"
 )
 
@@ -552,7 +553,7 @@ func init() {
 // EvalContext defines the context in which to evaluate an expression, allowing
 // the retrieval of state such as the node ID or statement start time.
 type EvalContext struct {
-	NodeID        uint32
+	NodeID        roachpb.NodeID
 	StmtTimestamp DTimestamp
 	TxnTimestamp  DTimestamp
 	ReCache       *RegexpCache

--- a/sql/schema_changer.go
+++ b/sql/schema_changer.go
@@ -18,7 +18,12 @@
 package sql
 
 import (
+	"errors"
+	"time"
+
 	"github.com/cockroachdb/cockroach/client"
+	"github.com/cockroachdb/cockroach/roachpb"
+	"github.com/cockroachdb/cockroach/util"
 	"github.com/gogo/protobuf/proto"
 )
 
@@ -61,4 +66,93 @@ func (p *planner) applyUpVersion(tableDesc *TableDescriptor) {
 		tableDesc.UpVersion = false
 		tableDesc.Version++
 	}
+}
+
+// SchemaChanger is used to change the schema on a table.
+type SchemaChanger struct {
+	tableID ID
+	nodeID  roachpb.NodeID
+	db      client.DB
+}
+
+// NewSchemaChangerForTesting only for tests.
+func NewSchemaChangerForTesting(tableID ID, nodeID roachpb.NodeID, db client.DB) SchemaChanger {
+	return SchemaChanger{tableID: tableID, nodeID: nodeID, db: db}
+}
+
+var errExistingSchemaChangeLease = errors.New("an outstanding schema change lease exists")
+
+func (sc *SchemaChanger) createSchemaChangeLease() TableDescriptor_SchemaChangeLease {
+	return TableDescriptor_SchemaChangeLease{NodeID: sc.nodeID, ExpirationTime: time.Now().Add(jitteredLeaseDuration()).UnixNano()}
+}
+
+// AcquireLease acquires a schema change lease on the table if
+// an unexpired lease doesn't exist. It returns the lease.
+func (sc *SchemaChanger) AcquireLease() (TableDescriptor_SchemaChangeLease, error) {
+	var lease TableDescriptor_SchemaChangeLease
+	err := sc.db.Txn(func(txn *client.Txn) error {
+		txn.SetSystemDBTrigger()
+		tableDesc, err := getTableDescFromID(txn, sc.tableID)
+		if err != nil {
+			return err
+		}
+
+		// A second to deal with the time uncertainty across nodes.
+		// It is perfectly valid for two or more goroutines to hold a valid
+		// lease and execute a schema change in parallel, because schema
+		// changes are executed using transactions that run sequentially.
+		// This just reduces the probability of a write collision.
+		expirationTimeUncertainty := time.Second
+
+		if tableDesc.Lease != nil && time.Unix(0, tableDesc.Lease.ExpirationTime).Add(expirationTimeUncertainty).After(time.Now()) {
+			return errExistingSchemaChangeLease
+		}
+		lease = sc.createSchemaChangeLease()
+		tableDesc.Lease = &lease
+		return txn.Put(MakeDescMetadataKey(tableDesc.ID), wrapDescriptor(tableDesc))
+	})
+	return lease, err
+}
+
+func (sc *SchemaChanger) findTableWithLease(txn *client.Txn, lease TableDescriptor_SchemaChangeLease) (*TableDescriptor, error) {
+	tableDesc, err := getTableDescFromID(txn, sc.tableID)
+	if err != nil {
+		return nil, err
+	}
+	if tableDesc.Lease == nil {
+		return nil, util.Errorf("no lease present for tableID: %d", sc.tableID)
+	}
+	if *tableDesc.Lease != lease {
+		return nil, util.Errorf("table: %d has lease: %v, expected: %v", sc.tableID, tableDesc.Lease, lease)
+	}
+	return tableDesc, nil
+}
+
+// ReleaseLease the table lease if it is the one registered with
+// the table descriptor.
+func (sc *SchemaChanger) ReleaseLease(lease TableDescriptor_SchemaChangeLease) error {
+	return sc.db.Txn(func(txn *client.Txn) error {
+		tableDesc, err := sc.findTableWithLease(txn, lease)
+		if err != nil {
+			return err
+		}
+		tableDesc.Lease = nil
+		txn.SetSystemDBTrigger()
+		return txn.Put(MakeDescMetadataKey(tableDesc.ID), wrapDescriptor(tableDesc))
+	})
+}
+
+// ExtendLease for the current leaser.
+func (sc *SchemaChanger) ExtendLease(lease TableDescriptor_SchemaChangeLease) (TableDescriptor_SchemaChangeLease, error) {
+	err := sc.db.Txn(func(txn *client.Txn) error {
+		tableDesc, err := sc.findTableWithLease(txn, lease)
+		if err != nil {
+			return err
+		}
+		lease = sc.createSchemaChangeLease()
+		tableDesc.Lease = &lease
+		txn.SetSystemDBTrigger()
+		return txn.Put(MakeDescMetadataKey(tableDesc.ID), wrapDescriptor(tableDesc))
+	})
+	return lease, err
 }

--- a/sql/schema_changer_test.go
+++ b/sql/schema_changer_test.go
@@ -1,0 +1,109 @@
+// Copyright 2015 The Cockroach Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+// implied. See the License for the specific language governing
+// permissions and limitations under the License. See the AUTHORS file
+// for names of contributors.
+//
+// Author: Vivek Menezes (vivek@cockroachlabs.com)
+
+package sql_test
+
+import (
+	"testing"
+	"time"
+
+	"github.com/cockroachdb/cockroach/keys"
+	"github.com/cockroachdb/cockroach/roachpb"
+	"github.com/cockroachdb/cockroach/sql"
+	"github.com/cockroachdb/cockroach/util/leaktest"
+)
+
+func TestSchemaChangeLease(t *testing.T) {
+	defer leaktest.AfterTest(t)
+	server, sqlDB, _ := setup(t)
+	defer cleanup(server, sqlDB)
+
+	if _, err := sqlDB.Exec(`
+CREATE DATABASE t;
+CREATE TABLE t.test (k CHAR PRIMARY KEY, v CHAR);
+`); err != nil {
+		t.Fatal(err)
+	}
+
+	var lease sql.TableDescriptor_SchemaChangeLease
+	var id = sql.ID(keys.MaxReservedDescID + 2)
+	var node = roachpb.NodeID(2)
+	db := server.DB()
+	changer := sql.NewSchemaChangerForTesting(id, node, *db)
+
+	// Acquire a lease.
+	lease, err := changer.AcquireLease()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if !validExpirationTime(lease.ExpirationTime) {
+		t.Fatalf("invalid expiration time: %s", time.Unix(lease.ExpirationTime, 0))
+	}
+
+	// Acquiring another lease will fail.
+	var newLease sql.TableDescriptor_SchemaChangeLease
+	newLease, err = changer.AcquireLease()
+	if err == nil {
+		t.Fatalf("acquired new lease: %v, while unexpired lease exists: %v", newLease, lease)
+	}
+
+	// Extend the lease.
+	newLease, err = changer.ExtendLease(lease)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if !validExpirationTime(newLease.ExpirationTime) {
+		t.Fatalf("invalid expiration time: %s", time.Unix(newLease.ExpirationTime, 0))
+	}
+
+	// Extending an old lease fails.
+	_, err = changer.ExtendLease(lease)
+	if err == nil {
+		t.Fatal("extending an old lease succeeded")
+	}
+
+	// Releasing an old lease fails.
+	err = changer.ReleaseLease(lease)
+	if err == nil {
+		t.Fatal("releasing a old lease succeeded")
+	}
+
+	// Release lease.
+	err = changer.ReleaseLease(newLease)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Extending the lease fails.
+	_, err = changer.ExtendLease(newLease)
+	if err == nil {
+		t.Fatalf("was able to extend an already released lease: %d, %v", id, lease)
+	}
+
+	// acquiring the lease succeeds
+	lease, err = changer.AcquireLease()
+	if err != nil {
+		t.Fatal(err)
+	}
+}
+
+func validExpirationTime(expirationTime int64) bool {
+	now := time.Now()
+	return expirationTime > now.Add(sql.LeaseDuration/2).UnixNano() && expirationTime < now.Add(sql.LeaseDuration*3/2).UnixNano()
+}

--- a/sql/structured.pb.go
+++ b/sql/structured.pb.go
@@ -11,6 +11,8 @@ import cockroach_roachpb1 "github.com/cockroachdb/cockroach/roachpb"
 
 // skipping weak import gogoproto "github.com/cockroachdb/gogoproto"
 
+import github_com_cockroachdb_cockroach_roachpb "github.com/cockroachdb/cockroach/roachpb"
+
 import io "io"
 
 // Reference imports to suppress errors if they are not otherwise used.
@@ -412,7 +414,8 @@ type TableDescriptor struct {
 	NextIndexID IndexID              `protobuf:"varint,12,opt,name=next_index_id,casttype=IndexID" json:"next_index_id"`
 	Privileges  *PrivilegeDescriptor `protobuf:"bytes,13,opt,name=privileges" json:"privileges,omitempty"`
 	// Columns or indexes being added or deleted in a FIFO order.
-	Mutations []DescriptorMutation `protobuf:"bytes,14,rep,name=mutations" json:"mutations"`
+	Mutations []DescriptorMutation               `protobuf:"bytes,14,rep,name=mutations" json:"mutations"`
+	Lease     *TableDescriptor_SchemaChangeLease `protobuf:"bytes,15,opt,name=lease" json:"lease,omitempty"`
 }
 
 func (m *TableDescriptor) Reset()         { *m = TableDescriptor{} }
@@ -516,6 +519,28 @@ func (m *TableDescriptor) GetMutations() []DescriptorMutation {
 	}
 	return nil
 }
+
+func (m *TableDescriptor) GetLease() *TableDescriptor_SchemaChangeLease {
+	if m != nil {
+		return m.Lease
+	}
+	return nil
+}
+
+// The schema update lease. A single goroutine across a cockroach cluster
+// can own it, and will execute pending schema changes for this table.
+// Since the execution of a pending schema change is through transactions,
+// it is legal for more than one goroutine to attempt to execute it. This
+// lease reduces write contention on the schema change.
+type TableDescriptor_SchemaChangeLease struct {
+	NodeID github_com_cockroachdb_cockroach_roachpb.NodeID `protobuf:"varint,1,opt,name=node_id,casttype=github.com/cockroachdb/cockroach/roachpb.NodeID" json:"node_id"`
+	// Nanoseconds since the Unix epoch.
+	ExpirationTime int64 `protobuf:"varint,2,opt,name=expiration_time" json:"expiration_time"`
+}
+
+func (m *TableDescriptor_SchemaChangeLease) Reset()         { *m = TableDescriptor_SchemaChangeLease{} }
+func (m *TableDescriptor_SchemaChangeLease) String() string { return proto.CompactTextString(m) }
+func (*TableDescriptor_SchemaChangeLease) ProtoMessage()    {}
 
 // DatabaseDescriptor represents a namespace (aka database) and is stored
 // in a structured metadata key. The DatabaseDescriptor has a globally-unique
@@ -660,6 +685,7 @@ func init() {
 	proto.RegisterType((*IndexDescriptor)(nil), "cockroach.sql.IndexDescriptor")
 	proto.RegisterType((*DescriptorMutation)(nil), "cockroach.sql.DescriptorMutation")
 	proto.RegisterType((*TableDescriptor)(nil), "cockroach.sql.TableDescriptor")
+	proto.RegisterType((*TableDescriptor_SchemaChangeLease)(nil), "cockroach.sql.TableDescriptor.SchemaChangeLease")
 	proto.RegisterType((*DatabaseDescriptor)(nil), "cockroach.sql.DatabaseDescriptor")
 	proto.RegisterType((*Descriptor)(nil), "cockroach.sql.Descriptor")
 	proto.RegisterEnum("cockroach.sql.ColumnType_Kind", ColumnType_Kind_name, ColumnType_Kind_value)
@@ -984,6 +1010,40 @@ func (m *TableDescriptor) MarshalTo(data []byte) (int, error) {
 			i += n
 		}
 	}
+	if m.Lease != nil {
+		data[i] = 0x7a
+		i++
+		i = encodeVarintStructured(data, i, uint64(m.Lease.Size()))
+		n8, err := m.Lease.MarshalTo(data[i:])
+		if err != nil {
+			return 0, err
+		}
+		i += n8
+	}
+	return i, nil
+}
+
+func (m *TableDescriptor_SchemaChangeLease) Marshal() (data []byte, err error) {
+	size := m.Size()
+	data = make([]byte, size)
+	n, err := m.MarshalTo(data)
+	if err != nil {
+		return nil, err
+	}
+	return data[:n], nil
+}
+
+func (m *TableDescriptor_SchemaChangeLease) MarshalTo(data []byte) (int, error) {
+	var i int
+	_ = i
+	var l int
+	_ = l
+	data[i] = 0x8
+	i++
+	i = encodeVarintStructured(data, i, uint64(m.NodeID))
+	data[i] = 0x10
+	i++
+	i = encodeVarintStructured(data, i, uint64(m.ExpirationTime))
 	return i, nil
 }
 
@@ -1013,11 +1073,11 @@ func (m *DatabaseDescriptor) MarshalTo(data []byte) (int, error) {
 		data[i] = 0x1a
 		i++
 		i = encodeVarintStructured(data, i, uint64(m.Privileges.Size()))
-		n8, err := m.Privileges.MarshalTo(data[i:])
+		n9, err := m.Privileges.MarshalTo(data[i:])
 		if err != nil {
 			return 0, err
 		}
-		i += n8
+		i += n9
 	}
 	return i, nil
 }
@@ -1038,11 +1098,11 @@ func (m *Descriptor) MarshalTo(data []byte) (int, error) {
 	var l int
 	_ = l
 	if m.Union != nil {
-		nn9, err := m.Union.MarshalTo(data[i:])
+		nn10, err := m.Union.MarshalTo(data[i:])
 		if err != nil {
 			return 0, err
 		}
-		i += nn9
+		i += nn10
 	}
 	return i, nil
 }
@@ -1053,11 +1113,11 @@ func (m *Descriptor_Table) MarshalTo(data []byte) (int, error) {
 		data[i] = 0xa
 		i++
 		i = encodeVarintStructured(data, i, uint64(m.Table.Size()))
-		n10, err := m.Table.MarshalTo(data[i:])
+		n11, err := m.Table.MarshalTo(data[i:])
 		if err != nil {
 			return 0, err
 		}
-		i += n10
+		i += n11
 	}
 	return i, nil
 }
@@ -1067,11 +1127,11 @@ func (m *Descriptor_Database) MarshalTo(data []byte) (int, error) {
 		data[i] = 0x12
 		i++
 		i = encodeVarintStructured(data, i, uint64(m.Database.Size()))
-		n11, err := m.Database.MarshalTo(data[i:])
+		n12, err := m.Database.MarshalTo(data[i:])
 		if err != nil {
 			return 0, err
 		}
-		i += n11
+		i += n12
 	}
 	return i, nil
 }
@@ -1227,6 +1287,18 @@ func (m *TableDescriptor) Size() (n int) {
 			n += 1 + l + sovStructured(uint64(l))
 		}
 	}
+	if m.Lease != nil {
+		l = m.Lease.Size()
+		n += 1 + l + sovStructured(uint64(l))
+	}
+	return n
+}
+
+func (m *TableDescriptor_SchemaChangeLease) Size() (n int) {
+	var l int
+	_ = l
+	n += 1 + sovStructured(uint64(m.NodeID))
+	n += 1 + sovStructured(uint64(m.ExpirationTime))
 	return n
 }
 
@@ -2325,6 +2397,127 @@ func (m *TableDescriptor) Unmarshal(data []byte) error {
 				return err
 			}
 			iNdEx = postIndex
+		case 15:
+			if wireType != 2 {
+				return fmt.Errorf("proto: wrong wireType = %d for field Lease", wireType)
+			}
+			var msglen int
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return ErrIntOverflowStructured
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := data[iNdEx]
+				iNdEx++
+				msglen |= (int(b) & 0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			if msglen < 0 {
+				return ErrInvalidLengthStructured
+			}
+			postIndex := iNdEx + msglen
+			if postIndex > l {
+				return io.ErrUnexpectedEOF
+			}
+			if m.Lease == nil {
+				m.Lease = &TableDescriptor_SchemaChangeLease{}
+			}
+			if err := m.Lease.Unmarshal(data[iNdEx:postIndex]); err != nil {
+				return err
+			}
+			iNdEx = postIndex
+		default:
+			iNdEx = preIndex
+			skippy, err := skipStructured(data[iNdEx:])
+			if err != nil {
+				return err
+			}
+			if skippy < 0 {
+				return ErrInvalidLengthStructured
+			}
+			if (iNdEx + skippy) > l {
+				return io.ErrUnexpectedEOF
+			}
+			iNdEx += skippy
+		}
+	}
+
+	if iNdEx > l {
+		return io.ErrUnexpectedEOF
+	}
+	return nil
+}
+func (m *TableDescriptor_SchemaChangeLease) Unmarshal(data []byte) error {
+	l := len(data)
+	iNdEx := 0
+	for iNdEx < l {
+		preIndex := iNdEx
+		var wire uint64
+		for shift := uint(0); ; shift += 7 {
+			if shift >= 64 {
+				return ErrIntOverflowStructured
+			}
+			if iNdEx >= l {
+				return io.ErrUnexpectedEOF
+			}
+			b := data[iNdEx]
+			iNdEx++
+			wire |= (uint64(b) & 0x7F) << shift
+			if b < 0x80 {
+				break
+			}
+		}
+		fieldNum := int32(wire >> 3)
+		wireType := int(wire & 0x7)
+		if wireType == 4 {
+			return fmt.Errorf("proto: SchemaChangeLease: wiretype end group for non-group")
+		}
+		if fieldNum <= 0 {
+			return fmt.Errorf("proto: SchemaChangeLease: illegal tag %d (wire type %d)", fieldNum, wire)
+		}
+		switch fieldNum {
+		case 1:
+			if wireType != 0 {
+				return fmt.Errorf("proto: wrong wireType = %d for field NodeID", wireType)
+			}
+			m.NodeID = 0
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return ErrIntOverflowStructured
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := data[iNdEx]
+				iNdEx++
+				m.NodeID |= (github_com_cockroachdb_cockroach_roachpb.NodeID(b) & 0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+		case 2:
+			if wireType != 0 {
+				return fmt.Errorf("proto: wrong wireType = %d for field ExpirationTime", wireType)
+			}
+			m.ExpirationTime = 0
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return ErrIntOverflowStructured
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := data[iNdEx]
+				iNdEx++
+				m.ExpirationTime |= (int64(b) & 0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
 		default:
 			iNdEx = preIndex
 			skippy, err := skipStructured(data[iNdEx:])

--- a/sql/structured.proto
+++ b/sql/structured.proto
@@ -206,7 +206,7 @@ message TableDescriptor {
   // the Version is only incremented in LeaseManager.Publish().
   // Move applyMutation() and applyUpVersion() out of the transaction for
   // schema commands and into LeaseManager.Publish(), and remove
-  // Version++ from applyUpVersion(). 
+  // Version++ from applyUpVersion().
   //
   optional uint32 version = 5 [(gogoproto.nullable) = false, (gogoproto.casttype) = "DescriptorVersion"];
   // See comment above.
@@ -226,6 +226,19 @@ message TableDescriptor {
   optional PrivilegeDescriptor privileges = 13;
   // Columns or indexes being added or deleted in a FIFO order.
   repeated DescriptorMutation mutations = 14 [(gogoproto.nullable) = false];
+  // The schema update lease. A single goroutine across a cockroach cluster
+  // can own it, and will execute pending schema changes for this table. 
+  // Since the execution of a pending schema change is through transactions,
+  // it is legal for more than one goroutine to attempt to execute it. This
+  // lease reduces write contention on the schema change.
+  message SchemaChangeLease {
+    optional uint32 node_id = 1 [(gogoproto.nullable) = false,
+        (gogoproto.customname) = "NodeID",
+        (gogoproto.casttype) = "github.com/cockroachdb/cockroach/roachpb.NodeID"];
+    // Nanoseconds since the Unix epoch.
+    optional int64 expiration_time = 2 [(gogoproto.nullable) = false];
+  }
+  optional SchemaChangeLease lease = 15;
 }
 
 // DatabaseDescriptor represents a namespace (aka database) and is stored


### PR DESCRIPTION
Once schema changes are scheduled to be executed through mutations,
a goroutine on the cluster acquires the table leader lease and executes
schema changes on the table. Any goroutine can acquire the lease.
In the future, the goroutine that executes the schema change command
(RENAME, ALTER, etc) will try to acquire the lease immediately
after marking the up_version bit on the table descriptor. Additionally
goroutines on every node will wake up on gossip notifications and will
attempt to acquire the lease if they see outstanding up_version bit
or mutations on a table descriptor.

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/3339)

<!-- Reviewable:end -->
