### PR TITLE
improve GCQueue comment; rename push types

### DIFF
--- a/roachpb/api.pb.go
+++ b/roachpb/api.pb.go
@@ -181,20 +181,21 @@ const (
 	// Push the timestamp forward if possible to accommodate a concurrent reader.
 	PUSH_TIMESTAMP PushTxnType = 0
 	// Abort the transaction if possible to accommodate a concurrent writer.
-	ABORT_TXN PushTxnType = 1
-	// Cleanup the transaction if already committed/aborted, or if too old.
-	CLEANUP_TXN PushTxnType = 2
+	PUSH_ABORT PushTxnType = 1
+	// Abort the transaction if it's abandoned, but don't attempt to mutate it
+	// otherwise.
+	PUSH_TOUCH PushTxnType = 2
 )
 
 var PushTxnType_name = map[int32]string{
 	0: "PUSH_TIMESTAMP",
-	1: "ABORT_TXN",
-	2: "CLEANUP_TXN",
+	1: "PUSH_ABORT",
+	2: "PUSH_TOUCH",
 }
 var PushTxnType_value = map[string]int32{
 	"PUSH_TIMESTAMP": 0,
-	"ABORT_TXN":      1,
-	"CLEANUP_TXN":    2,
+	"PUSH_ABORT":     1,
+	"PUSH_TOUCH":     2,
 }
 
 func (x PushTxnType) Enum() *PushTxnType {
@@ -678,12 +679,11 @@ type PushTxnRequest struct {
 	// necessarily advance with the node clock across retries and hence cannot
 	// detect abandoned transactions.
 	Now Timestamp `protobuf:"bytes,5,opt,name=now" json:"now"`
-	// Readers set this to PUSH_TIMESTAMP to move PusheeTxn's commit
-	// timestamp forward. Writers set this to ABORT_TXN to request that
-	// the PushTxn be aborted if possible. This is done in the event of
-	// a writer conflicting with PusheeTxn. Inconsistent readers set
-	// this to CLEANUP_TXN to determine whether dangling intents
-	// may be resolved.
+	// Readers set this to PUSH_TIMESTAMP to move pushee_txn's provisional
+	// commit timestamp forward. Writers set this to PUSH_ABORT to request
+	// that pushee_txn be aborted if possible. Inconsistent readers set
+	// this to PUSH_TOUCH to determine whether the pushee can be aborted
+	// due to inactivity (based on the now field).
 	PushType PushTxnType `protobuf:"varint,6,opt,name=push_type,enum=cockroach.roachpb.PushTxnType" json:"push_type"`
 }
 

--- a/roachpb/api.proto
+++ b/roachpb/api.proto
@@ -357,9 +357,10 @@ enum PushTxnType {
   // Push the timestamp forward if possible to accommodate a concurrent reader.
   PUSH_TIMESTAMP = 0;
   // Abort the transaction if possible to accommodate a concurrent writer.
-  ABORT_TXN = 1;
-  // Cleanup the transaction if already committed/aborted, or if too old.
-  CLEANUP_TXN = 2;
+  PUSH_ABORT = 1;
+  // Abort the transaction if it's abandoned, but don't attempt to mutate it
+  // otherwise.
+  PUSH_TOUCH = 2;
 }
 
 // A PushTxnRequest is arguments to the PushTxn() method. It's sent by
@@ -396,12 +397,11 @@ message PushTxnRequest {
   // necessarily advance with the node clock across retries and hence cannot
   // detect abandoned transactions.
   optional Timestamp now = 5 [(gogoproto.nullable) = false];
-  // Readers set this to PUSH_TIMESTAMP to move PusheeTxn's commit
-  // timestamp forward. Writers set this to ABORT_TXN to request that
-  // the PushTxn be aborted if possible. This is done in the event of
-  // a writer conflicting with PusheeTxn. Inconsistent readers set
-  // this to CLEANUP_TXN to determine whether dangling intents
-  // may be resolved.
+  // Readers set this to PUSH_TIMESTAMP to move pushee_txn's provisional
+  // commit timestamp forward. Writers set this to PUSH_ABORT to request
+  // that pushee_txn be aborted if possible. Inconsistent readers set
+  // this to PUSH_TOUCH to determine whether the pushee can be aborted
+  // due to inactivity (based on the now field).
   optional PushTxnType push_type = 6 [(gogoproto.nullable) = false];
 }
 

--- a/storage/engine/rocksdb/cockroach/roachpb/api.pb.cc
+++ b/storage/engine/rocksdb/cockroach/roachpb/api.pb.cc
@@ -1522,8 +1522,8 @@ void protobuf_AddDesc_cockroach_2froachpb_2fapi_2eproto() {
     "ach.roachpb.Transaction:\004\230\240\037\000*L\n\023ReadCon"
     "sistencyType\022\016\n\nCONSISTENT\020\000\022\r\n\tCONSENSU"
     "S\020\001\022\020\n\014INCONSISTENT\020\002\032\004\210\243\036\000*G\n\013PushTxnTy"
-    "pe\022\022\n\016PUSH_TIMESTAMP\020\000\022\r\n\tABORT_TXN\020\001\022\017\n"
-    "\013CLEANUP_TXN\020\002\032\004\210\243\036\000B\035Z\007roachpb\310\341\036\000\220\343\036\000\310"
+    "pe\022\022\n\016PUSH_TIMESTAMP\020\000\022\016\n\nPUSH_ABORT\020\001\022\016"
+    "\n\nPUSH_TOUCH\020\002\032\004\210\243\036\000B\035Z\007roachpb\310\341\036\000\220\343\036\000\310"
     "\342\036\001\340\342\036\001\320\342\036\001X\003", 8933);
   ::google::protobuf::MessageFactory::InternalRegisterGeneratedFile(
     "cockroach/roachpb/api.proto", &protobuf_RegisterTypes);

--- a/storage/engine/rocksdb/cockroach/roachpb/api.pb.h
+++ b/storage/engine/rocksdb/cockroach/roachpb/api.pb.h
@@ -117,12 +117,12 @@ inline bool ReadConsistencyType_Parse(
 }
 enum PushTxnType {
   PUSH_TIMESTAMP = 0,
-  ABORT_TXN = 1,
-  CLEANUP_TXN = 2
+  PUSH_ABORT = 1,
+  PUSH_TOUCH = 2
 };
 bool PushTxnType_IsValid(int value);
 const PushTxnType PushTxnType_MIN = PUSH_TIMESTAMP;
-const PushTxnType PushTxnType_MAX = CLEANUP_TXN;
+const PushTxnType PushTxnType_MAX = PUSH_TOUCH;
 const int PushTxnType_ARRAYSIZE = PushTxnType_MAX + 1;
 
 const ::google::protobuf::EnumDescriptor* PushTxnType_descriptor();

--- a/storage/replica.go
+++ b/storage/replica.go
@@ -1400,7 +1400,7 @@ func (r *Replica) handleSkippedIntents(intents []intentsWithArg) {
 			h := roachpb.Header{Timestamp: now}
 			resolveIntents, err := r.store.resolveWriteIntentError(ctx, &roachpb.WriteIntentError{
 				Intents: item.intents,
-			}, r, args, h, roachpb.CLEANUP_TXN)
+			}, r, args, h, roachpb.PUSH_TOUCH)
 			if wiErr, ok := err.(*roachpb.WriteIntentError); !ok || wiErr == nil || !wiErr.Resolved {
 				log.Warningc(ctx, "failed to push during intent resolution: %s", err)
 				return

--- a/storage/store.go
+++ b/storage/store.go
@@ -1319,7 +1319,7 @@ func (s *Store) Send(ctx context.Context, ba roachpb.BatchRequest) (*roachpb.Bat
 		if wiErr, ok := err.(*roachpb.WriteIntentError); ok {
 			var pushType roachpb.PushTxnType
 			if ba.IsWrite() {
-				pushType = roachpb.ABORT_TXN
+				pushType = roachpb.PUSH_ABORT
 			} else {
 				pushType = roachpb.PUSH_TIMESTAMP
 			}

--- a/storage/store_test.go
+++ b/storage/store_test.go
@@ -1554,7 +1554,7 @@ func TestStoreBadRequests(t *testing.T) {
 	tArgs3, tHeader3 := heartbeatArgs(txn)
 	tHeader3.Txn.Key = tHeader3.Txn.Key.Next()
 
-	tArgs4 := pushTxnArgs(txn, txn, roachpb.ABORT_TXN)
+	tArgs4 := pushTxnArgs(txn, txn, roachpb.PUSH_ABORT)
 	tArgs4.PusheeTxn.Key = txn.Key.Next()
 
 	testCases := []struct {


### PR DESCRIPTION
Fixes #3347: Recreating some transaction table entries while dealing
with stray intents and the response cache seems acceptable. If it
becomes an issue down the road, measures can be taken.

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/3353)

<!-- Reviewable:end -->
