### PR TITLE
all: custom protoc-gen binary

### DIFF
--- a/GLOCKFILE
+++ b/GLOCKFILE
@@ -1,6 +1,6 @@
 cmd github.com/cockroachdb/c-protobuf/cmd/protoc
+cmd github.com/cockroachdb/cockroach/protoc-gen-gogoroach
 cmd github.com/cockroachdb/yacc
-cmd github.com/gogo/protobuf/protoc-gen-gogo
 cmd github.com/golang/lint/golint
 cmd github.com/gordonklaus/ineffassign
 cmd github.com/jteeuwen/go-bindata/go-bindata

--- a/Makefile
+++ b/Makefile
@@ -178,6 +178,10 @@ clean:
 	find . -name '*.test' -type f -exec rm -f {} \;
 	rm -f .bootstrap
 
+.PHONY: protobuf
+protobuf:
+	$(MAKE) -C .. -f cockroach/build/protobuf.mk
+
 ifneq ($(SKIP_BOOTSTRAP),1)
 
 GITHOOKS := $(subst githooks/,.git/hooks/,$(wildcard githooks/*))

--- a/build/protobuf.mk
+++ b/build/protobuf.mk
@@ -26,13 +26,13 @@ GOGOPROTO_ROOT := $(GITHUB_ROOT)/gogo/protobuf
 NATIVE_ROOT := $(REPO_ROOT)/storage/engine/rocksdb
 
 # Ensure we have an unambiguous GOPATH
-GOPATH := $(GITHUB_ROOT)/../..
-#                        ^  ^~ GOPATH
-#                        |~ GOPATH/src
+GOPATH := $(realpath $(GITHUB_ROOT)/../..)
+#                                   ^  ^~ GOPATH
+#                                   |~ GOPATH/src
 
 GOPATH_BIN      := $(GOPATH)/bin
 PROTOC          := $(GOPATH_BIN)/protoc
-PLUGIN_SUFFIX   := gogo
+PLUGIN_SUFFIX   := gogoroach
 PROTOC_PLUGIN   := $(GOPATH_BIN)/protoc-gen-$(PLUGIN_SUFFIX)
 GOGOPROTO_PROTO := $(GOGOPROTO_ROOT)/gogoproto/gogo.proto
 GOGOPROTO_PATH  := $(GOGOPROTO_ROOT):$(GOGOPROTO_ROOT)/protobuf
@@ -56,7 +56,7 @@ protos: $(GO_SOURCES) $(CPP_HEADERS) $(CPP_SOURCES) $(ENGINE_CPP_HEADERS) $(ENGI
 REPO_NAME := cockroachdb
 IMPORT_PREFIX := github.com/$(REPO_NAME)/
 
-$(GO_SOURCES): $(PROTOC) $(GO_PROTOS) $(GOGOPROTO_PROTO) $(PROTOC_PLUGIN)
+$(GO_SOURCES): $(PROTOC) $(GO_PROTOS) $(GOGOPROTO_PROTO)
 	find $(REPO_ROOT) -not -path '*/.*' -name *.pb.go | xargs rm
 	for dir in $(sort $(dir $(GO_PROTOS))); do \
 	  $(PROTOC) -I.:$(GOGOPROTO_PATH):$(COREOS_PATH) --plugin=$(PROTOC_PLUGIN) --$(PLUGIN_SUFFIX)_out=import_prefix=$(IMPORT_PREFIX):$(ORG_ROOT) $$dir/*.proto; \

--- a/config/config.proto
+++ b/config/config.proto
@@ -23,12 +23,6 @@ import "cockroach/roachpb/metadata.proto";
 import "cockroach/roachpb/data.proto";
 import weak "gogoproto/gogo.proto";
 
-option (gogoproto.goproto_getters_all) = false;
-option (gogoproto.goproto_unrecognized_all) = false;
-option (gogoproto.marshaler_all) = true;
-option (gogoproto.sizer_all) = true;
-option (gogoproto.unmarshaler_all) = true;
-
 // GCPolicy defines garbage collection policies which apply to MVCC
 // values within a zone.
 //

--- a/gossip/gossip.proto
+++ b/gossip/gossip.proto
@@ -24,12 +24,6 @@ import "cockroach/roachpb/metadata.proto";
 import "cockroach/util/unresolved_addr.proto";
 import weak "gogoproto/gogo.proto";
 
-option (gogoproto.goproto_getters_all) = false;
-option (gogoproto.goproto_unrecognized_all) = false;
-option (gogoproto.marshaler_all) = true;
-option (gogoproto.sizer_all) = true;
-option (gogoproto.unmarshaler_all) = true;
-
 // Request is the request struct passed with the Gossip RPC.
 message Request {
   // Requesting node's ID.

--- a/main.go
+++ b/main.go
@@ -17,7 +17,7 @@
 
 package main
 
-//go:generate make -C .. -f cockroach/build/protobuf.mk
+//go:generate make protobuf
 
 import (
 	"fmt"

--- a/multiraft/rpc.proto
+++ b/multiraft/rpc.proto
@@ -23,12 +23,6 @@ import "cockroach/roachpb/metadata.proto";
 import "etcd/raft/raftpb/raft.proto";
 import weak "gogoproto/gogo.proto";
 
-option (gogoproto.goproto_getters_all) = false;
-option (gogoproto.goproto_unrecognized_all) = false;
-option (gogoproto.marshaler_all) = true;
-option (gogoproto.sizer_all) = true;
-option (gogoproto.unmarshaler_all) = true;
-
 // RaftMessageRequest is the request used to send raft messages using our
 // protobuf-based RPC codec.
 message RaftMessageRequest {

--- a/protoc-gen-gogoroach/main.go
+++ b/protoc-gen-gogoroach/main.go
@@ -1,0 +1,74 @@
+package main
+
+import (
+	"github.com/gogo/protobuf/protoc-gen-gogo/descriptor"
+	"github.com/gogo/protobuf/vanity"
+	"github.com/gogo/protobuf/vanity/command"
+)
+
+func main() {
+	req := command.Read()
+	files := req.GetProtoFile()
+	files = vanity.FilterFiles(files, vanity.NotInPackageGoogleProtobuf)
+
+	for _, opt := range []func(*descriptor.FileDescriptorProto){
+		vanity.TurnOffGoGettersAll,
+
+		// Currently harms readability.
+		// vanity.TurnOffGoEnumPrefixAll,
+
+		// `String() string` is part of gogoproto.Message, so we need this.
+		// vanity.TurnOffGoStringerAll,
+
+		// Maybe useful for tests? Not using currently.
+		// vanity.TurnOnVerboseEqualAll,
+
+		// Incompatible with oneof, and also not sure what the value is.
+		// vanity.TurnOnFaceAll,
+
+		// Requires that all child messages are generated with this, which
+		// is not the case for Raft messages which wrap raftpb (which
+		// doesn't use this).
+		// vanity.TurnOnGoStringAll,
+
+		// Not useful for us.
+		// vanity.TurnOnPopulateAll,
+
+		// Conflicts with `GoStringerAll`, which is enabled.
+		// vanity.TurnOnStringerAll,
+
+		// This generates a method that takes `interface{}`, which sucks.
+		// vanity.TurnOnEqualAll,
+
+		// Not useful for us.
+		// vanity.TurnOnDescriptionAll,
+		// vanity.TurnOnTestGenAll,
+		// vanity.TurnOnBenchGenAll,
+
+		vanity.TurnOnMarshalerAll,
+		vanity.TurnOnUnmarshalerAll,
+		vanity.TurnOnSizerAll,
+
+		// Enabling these causes `String() string` on Enums to be inlined.
+		// Not worth it.
+		// vanity.TurnOffGoEnumStringerAll,
+		// vanity.TurnOnEnumStringerAll,
+
+		// Not clear that this is worthwhile.
+		// vanity.TurnOnUnsafeUnmarshalerAll,
+		// vanity.TurnOnUnsafeMarshalerAll,
+
+		// Something something extensions; we don't use 'em currently.
+		// vanity.TurnOffGoExtensionsMapAll,
+
+		vanity.TurnOffGoUnrecognizedAll,
+
+		// Adds unnecessary dependency on golang/protobuf.
+		// vanity.TurnOffGogoImport,
+	} {
+		vanity.ForEachFile(files, opt)
+	}
+
+	resp := command.Generate(req)
+	command.Write(resp)
+}

--- a/roachpb/api.proto
+++ b/roachpb/api.proto
@@ -24,12 +24,6 @@ import "cockroach/roachpb/data.proto";
 import "cockroach/roachpb/errors.proto";
 import weak "gogoproto/gogo.proto";
 
-option (gogoproto.goproto_getters_all) = false;
-option (gogoproto.goproto_unrecognized_all) = false;
-option (gogoproto.marshaler_all) = true;
-option (gogoproto.sizer_all) = true;
-option (gogoproto.unmarshaler_all) = true;
-
 // ReadConsistencyType specifies what type of consistency is observed
 // during read operations.
 enum ReadConsistencyType {
@@ -354,6 +348,7 @@ message GCResponse {
 // TxnPushType determines what action to take when pushing a transaction.
 enum PushTxnType {
   option (gogoproto.goproto_enum_prefix) = false;
+
   // Push the timestamp forward if possible to accommodate a concurrent reader.
   PUSH_TIMESTAMP = 0;
   // Abort the transaction if possible to accommodate a concurrent writer.

--- a/roachpb/api_test.go
+++ b/roachpb/api_test.go
@@ -19,7 +19,6 @@ package roachpb
 
 import (
 	"encoding/hex"
-	"fmt"
 	"reflect"
 	"strings"
 	"testing"
@@ -59,15 +58,6 @@ func TestSetGoErrorNil(t *testing.T) {
 	if err := br.GoError(); err != nil {
 		t.Errorf("expected nil error; got %s", err)
 	}
-}
-
-type XX interface {
-	Run()
-}
-type YY int
-
-func (i YY) Run() {
-	fmt.Println(i)
 }
 
 // TestCombinable tests the correct behaviour of some types that implement

--- a/roachpb/data.proto
+++ b/roachpb/data.proto
@@ -23,12 +23,6 @@ option go_package = "roachpb";
 import "cockroach/roachpb/metadata.proto";
 import weak "gogoproto/gogo.proto";
 
-option (gogoproto.goproto_getters_all) = false;
-option (gogoproto.goproto_unrecognized_all) = false;
-option (gogoproto.marshaler_all) = true;
-option (gogoproto.sizer_all) = true;
-option (gogoproto.unmarshaler_all) = true;
-
 // Span is supplied with every storage node request.
 message Span {
   // The key for request. If the request operates on a range, this

--- a/roachpb/errors.proto
+++ b/roachpb/errors.proto
@@ -29,12 +29,6 @@ import weak "gogoproto/gogo.proto";
 // `String() string`.
 // option (gogoproto.goproto_stringer_all) = false;
 
-option (gogoproto.goproto_getters_all) = false;
-option (gogoproto.goproto_unrecognized_all) = false;
-option (gogoproto.marshaler_all) = true;
-option (gogoproto.sizer_all) = true;
-option (gogoproto.unmarshaler_all) = true;
-
 // A NotLeaderError indicates that the current range is not the
 // leader. If the leader is known, its Replica is set in the error.
 message NotLeaderError {

--- a/roachpb/internal.proto
+++ b/roachpb/internal.proto
@@ -23,12 +23,6 @@ import "cockroach/roachpb/api.proto";
 import "cockroach/roachpb/metadata.proto";
 import weak "gogoproto/gogo.proto";
 
-option (gogoproto.goproto_getters_all) = false;
-option (gogoproto.goproto_unrecognized_all) = false;
-option (gogoproto.marshaler_all) = true;
-option (gogoproto.sizer_all) = true;
-option (gogoproto.unmarshaler_all) = true;
-
 // A RaftCommand is a command which can be serialized and sent via
 // raft.
 message RaftCommand {

--- a/roachpb/metadata.proto
+++ b/roachpb/metadata.proto
@@ -23,12 +23,6 @@ option go_package = "roachpb";
 import "cockroach/util/unresolved_addr.proto";
 import weak "gogoproto/gogo.proto";
 
-option (gogoproto.goproto_getters_all) = false;
-option (gogoproto.goproto_unrecognized_all) = false;
-option (gogoproto.marshaler_all) = true;
-option (gogoproto.sizer_all) = true;
-option (gogoproto.unmarshaler_all) = true;
-
 // Attributes specifies a list of arbitrary strings describing
 // node topology, store type, and machine capabilities.
 message Attributes {

--- a/rpc/codec/message/arith.proto
+++ b/rpc/codec/message/arith.proto
@@ -8,12 +8,6 @@ option go_package = "message";
 
 import weak "gogoproto/gogo.proto";
 
-option (gogoproto.goproto_getters_all) = false;
-option (gogoproto.goproto_unrecognized_all) = false;
-option (gogoproto.marshaler_all) = true;
-option (gogoproto.sizer_all) = true;
-option (gogoproto.unmarshaler_all) = true;
-
 message ArithRequest {
 	optional int32 a = 1 [(gogoproto.nullable) = false];
 	optional int32 b = 2 [(gogoproto.nullable) = false];

--- a/rpc/codec/message/echo.proto
+++ b/rpc/codec/message/echo.proto
@@ -8,12 +8,6 @@ option go_package = "message";
 
 import weak "gogoproto/gogo.proto";
 
-option (gogoproto.goproto_getters_all) = false;
-option (gogoproto.goproto_unrecognized_all) = false;
-option (gogoproto.marshaler_all) = true;
-option (gogoproto.sizer_all) = true;
-option (gogoproto.unmarshaler_all) = true;
-
 message EchoRequest {
 	optional string msg = 1 [(gogoproto.nullable) = false];
 }

--- a/rpc/codec/wire/wire.proto
+++ b/rpc/codec/wire/wire.proto
@@ -47,12 +47,6 @@ option go_package = "wire";
 
 import weak "gogoproto/gogo.proto";
 
-option (gogoproto.goproto_getters_all) = false;
-option (gogoproto.goproto_unrecognized_all) = false;
-option (gogoproto.marshaler_all) = true;
-option (gogoproto.sizer_all) = true;
-option (gogoproto.unmarshaler_all) = true;
-
 enum CompressionType {
   NONE = 0;
   SNAPPY = 1;

--- a/rpc/heartbeat.proto
+++ b/rpc/heartbeat.proto
@@ -22,12 +22,6 @@ option go_package = "rpc";
 
 import weak "gogoproto/gogo.proto";
 
-option (gogoproto.goproto_getters_all) = false;
-option (gogoproto.goproto_unrecognized_all) = false;
-option (gogoproto.marshaler_all) = true;
-option (gogoproto.sizer_all) = true;
-option (gogoproto.unmarshaler_all) = true;
-
 // RemoteOffset keeps track of this client's estimate of its offset from a
 // remote server. Uncertainty is the maximum error in the reading of this
 // offset, so that the real offset should be in the interval

--- a/server/status/status.proto
+++ b/server/status/status.proto
@@ -23,12 +23,6 @@ import "cockroach/roachpb/metadata.proto";
 import "cockroach/storage/engine/mvcc.proto";
 import weak "gogoproto/gogo.proto";
 
-option (gogoproto.goproto_getters_all) = false;
-option (gogoproto.goproto_unrecognized_all) = false;
-option (gogoproto.marshaler_all) = true;
-option (gogoproto.sizer_all) = true;
-option (gogoproto.unmarshaler_all) = true;
-
 // NodeStatus contains the stats needed to calculate the current status of a
 // node.
 message NodeStatus {

--- a/sql/driver/wire.proto
+++ b/sql/driver/wire.proto
@@ -21,12 +21,6 @@ option go_package = "driver";
 
 import weak "gogoproto/gogo.proto";
 
-option (gogoproto.goproto_getters_all) = false;
-option (gogoproto.goproto_unrecognized_all) = false;
-option (gogoproto.marshaler_all) = true;
-option (gogoproto.sizer_all) = true;
-option (gogoproto.unmarshaler_all) = true;
-
 message Datum {
   // Timestamp represents an absolute timestamp devoid of time-zone.
   message Timestamp {

--- a/sql/privilege.proto
+++ b/sql/privilege.proto
@@ -21,12 +21,6 @@ option go_package = "sql";
 
 import weak "gogoproto/gogo.proto";
 
-option (gogoproto.goproto_getters_all) = false;
-option (gogoproto.goproto_unrecognized_all) = false;
-option (gogoproto.marshaler_all) = true;
-option (gogoproto.sizer_all) = true;
-option (gogoproto.unmarshaler_all) = true;
-
 // UserPrivileges describes the list of privileges available for a given user.
 message UserPrivileges {
   optional string user = 1 [(gogoproto.nullable) = false];

--- a/sql/session.proto
+++ b/sql/session.proto
@@ -23,12 +23,6 @@ import "cockroach/roachpb/data.proto";
 import "cockroach/sql/driver/wire.proto";
 import weak "gogoproto/gogo.proto";
 
-option (gogoproto.goproto_getters_all) = false;
-option (gogoproto.goproto_unrecognized_all) = false;
-option (gogoproto.marshaler_all) = true;
-option (gogoproto.sizer_all) = true;
-option (gogoproto.unmarshaler_all) = true;
-
 message Session {
   optional string database = 1 [(gogoproto.nullable) = false];
   optional int32 syntax = 2 [(gogoproto.nullable) = false];

--- a/sql/structured.proto
+++ b/sql/structured.proto
@@ -23,12 +23,6 @@ import "cockroach/roachpb/data.proto";
 import "cockroach/sql/privilege.proto";
 import weak "gogoproto/gogo.proto";
 
-option (gogoproto.goproto_getters_all) = false;
-option (gogoproto.goproto_unrecognized_all) = false;
-option (gogoproto.marshaler_all) = true;
-option (gogoproto.sizer_all) = true;
-option (gogoproto.unmarshaler_all) = true;
-
 message ColumnType {
   // These mirror the types supported by the sql/parser. See
   // sql/parser/types.go.

--- a/storage/engine/mvcc.proto
+++ b/storage/engine/mvcc.proto
@@ -22,12 +22,6 @@ option go_package = "engine";
 import "cockroach/roachpb/data.proto";
 import weak "gogoproto/gogo.proto";
 
-option (gogoproto.goproto_getters_all) = false;
-option (gogoproto.goproto_unrecognized_all) = false;
-option (gogoproto.marshaler_all) = true;
-option (gogoproto.sizer_all) = true;
-option (gogoproto.unmarshaler_all) = true;
-
 // MVCCMetadata holds MVCC metadata for a key. Used by storage/engine/mvcc.go.
 message MVCCMetadata {
   optional roachpb.Transaction txn = 1;

--- a/storage/engine/rocksdb/cockroach/roachpb/api.pb.cc
+++ b/storage/engine/rocksdb/cockroach/roachpb/api.pb.cc
@@ -1523,8 +1523,7 @@ void protobuf_AddDesc_cockroach_2froachpb_2fapi_2eproto() {
     "sistencyType\022\016\n\nCONSISTENT\020\000\022\r\n\tCONSENSU"
     "S\020\001\022\020\n\014INCONSISTENT\020\002\032\004\210\243\036\000*G\n\013PushTxnTy"
     "pe\022\022\n\016PUSH_TIMESTAMP\020\000\022\016\n\nPUSH_ABORT\020\001\022\016"
-    "\n\nPUSH_TOUCH\020\002\032\004\210\243\036\000B\035Z\007roachpb\310\341\036\000\220\343\036\000\310"
-    "\342\036\001\340\342\036\001\320\342\036\001X\003", 8933);
+    "\n\nPUSH_TOUCH\020\002\032\004\210\243\036\000B\tZ\007roachpbX\003", 8913);
   ::google::protobuf::MessageFactory::InternalRegisterGeneratedFile(
     "cockroach/roachpb/api.proto", &protobuf_RegisterTypes);
   ResponseHeader::default_instance_ = new ResponseHeader();

--- a/storage/engine/rocksdb/cockroach/roachpb/data.pb.cc
+++ b/storage/engine/rocksdb/cockroach/roachpb/data.pb.cc
@@ -528,8 +528,7 @@ void protobuf_AddDesc_cockroach_2froachpb_2fdata_2eproto() {
     "PLICA\020\001\032\004\210\243\036\000*5\n\rIsolationType\022\020\n\014SERIAL"
     "IZABLE\020\000\022\014\n\010SNAPSHOT\020\001\032\004\210\243\036\000*B\n\021Transact"
     "ionStatus\022\013\n\007PENDING\020\000\022\r\n\tCOMMITTED\020\001\022\013\n"
-    "\007ABORTED\020\002\032\004\210\243\036\000B\035Z\007roachpb\310\341\036\000\220\343\036\000\310\342\036\001\340"
-    "\342\036\001\320\342\036\001X\001", 3009);
+    "\007ABORTED\020\002\032\004\210\243\036\000B\tZ\007roachpbX\001", 2989);
   ::google::protobuf::MessageFactory::InternalRegisterGeneratedFile(
     "cockroach/roachpb/data.proto", &protobuf_RegisterTypes);
   Span::default_instance_ = new Span();

--- a/storage/engine/rocksdb/cockroach/roachpb/errors.pb.cc
+++ b/storage/engine/rocksdb/cockroach/roachpb/errors.pb.cc
@@ -566,8 +566,7 @@ void protobuf_AddDesc_cockroach_2froachpb_2ferrors_2eproto() {
     "achpb.TransactionRestartB\004\310\336\037\000\022.\n\006detail"
     "\030\004 \001(\0132\036.cockroach.roachpb.ErrorDetail:\004"
     "\230\240\037\000*;\n\022TransactionRestart\022\t\n\005ABORT\020\000\022\013\n"
-    "\007BACKOFF\020\001\022\r\n\tIMMEDIATE\020\002B\035Z\007roachpb\310\341\036\000"
-    "\220\343\036\000\310\342\036\001\340\342\036\001\320\342\036\001X\002", 3138);
+    "\007BACKOFF\020\001\022\r\n\tIMMEDIATE\020\002B\tZ\007roachpbX\002", 3118);
   ::google::protobuf::MessageFactory::InternalRegisterGeneratedFile(
     "cockroach/roachpb/errors.proto", &protobuf_RegisterTypes);
   NotLeaderError::default_instance_ = new NotLeaderError();

--- a/storage/engine/rocksdb/cockroach/roachpb/internal.pb.cc
+++ b/storage/engine/rocksdb/cockroach/roachpb/internal.pb.cc
@@ -248,8 +248,7 @@ void protobuf_AddDesc_cockroach_2froachpb_2finternal_2eproto() {
     "roachpb.RangeDescriptorB\004\310\336\037\000\022@\n\002KV\030\002 \003("
     "\0132,.cockroach.roachpb.RaftSnapshotData.K"
     "eyValueB\006\342\336\037\002KV\032&\n\010KeyValue\022\013\n\003key\030\001 \001(\014"
-    "\022\r\n\005value\030\002 \001(\014B\035Z\007roachpb\310\341\036\000\220\343\036\000\310\342\036\001\340\342"
-    "\036\001\320\342\036\001X\002", 968);
+    "\022\r\n\005value\030\002 \001(\014B\tZ\007roachpbX\002", 948);
   ::google::protobuf::MessageFactory::InternalRegisterGeneratedFile(
     "cockroach/roachpb/internal.proto", &protobuf_RegisterTypes);
   RaftCommand::default_instance_ = new RaftCommand();

--- a/storage/engine/rocksdb/cockroach/roachpb/metadata.pb.cc
+++ b/storage/engine/rocksdb/cockroach/roachpb/metadata.pb.cc
@@ -283,8 +283,7 @@ void protobuf_AddDesc_cockroach_2froachpb_2fmetadata_2eproto() {
     "ach.roachpb.AttributesB\004\310\336\037\000\0225\n\004node\030\003 \001"
     "(\0132!.cockroach.roachpb.NodeDescriptorB\004\310"
     "\336\037\000\0228\n\010capacity\030\004 \001(\0132 .cockroach.roachp"
-    "b.StoreCapacityB\004\310\336\037\000B\035Z\007roachpb\310\341\036\000\220\343\036\000"
-    "\310\342\036\001\340\342\036\001\320\342\036\001X\001", 1294);
+    "b.StoreCapacityB\004\310\336\037\000B\tZ\007roachpbX\001", 1274);
   ::google::protobuf::MessageFactory::InternalRegisterGeneratedFile(
     "cockroach/roachpb/metadata.proto", &protobuf_RegisterTypes);
   Attributes::default_instance_ = new Attributes();

--- a/storage/engine/rocksdb/cockroach/storage/engine/mvcc.pb.cc
+++ b/storage/engine/rocksdb/cockroach/storage/engine/mvcc.pb.cc
@@ -139,7 +139,7 @@ void protobuf_AddDesc_cockroach_2fstorage_2fengine_2fmvcc_2eproto() {
     "_bytes_age\030\n \001(\003B\022\310\336\037\000\342\336\037\nGCBytesAge\022\027\n\t"
     "sys_bytes\030\014 \001(\003B\004\310\336\037\000\022\027\n\tsys_count\030\r \001(\003"
     "B\004\310\336\037\000\022\037\n\021last_update_nanos\030\036 \001(\003B\004\310\336\037\000B"
-    "\034Z\006engine\310\341\036\000\220\343\036\000\310\342\036\001\340\342\036\001\320\342\036\001X\001", 751);
+    "\010Z\006engineX\001", 731);
   ::google::protobuf::MessageFactory::InternalRegisterGeneratedFile(
     "cockroach/storage/engine/mvcc.proto", &protobuf_RegisterTypes);
   MVCCMetadata::default_instance_ = new MVCCMetadata();

--- a/storage/engine/rocksdb/cockroach/util/unresolved_addr.pb.cc
+++ b/storage/engine/rocksdb/cockroach/util/unresolved_addr.pb.cc
@@ -85,8 +85,7 @@ void protobuf_AddDesc_cockroach_2futil_2funresolved_5faddr_2eproto() {
     "cockroach.util\032\024gogoproto/gogo.proto\"f\n\016"
     "UnresolvedAddr\022&\n\rnetwork_field\030\001 \001(\tB\017\310"
     "\336\037\000\352\336\037\007network\022&\n\raddress_field\030\002 \001(\tB\017\310"
-    "\336\037\000\352\336\037\007address:\004\230\240\037\000B\032Z\004util\310\341\036\000\220\343\036\000\310\342\036\001"
-    "\340\342\036\001\320\342\036\001X\000", 210);
+    "\336\037\000\352\336\037\007address:\004\230\240\037\000B\006Z\004utilX\000", 190);
   ::google::protobuf::MessageFactory::InternalRegisterGeneratedFile(
     "cockroach/util/unresolved_addr.proto", &protobuf_RegisterTypes);
   UnresolvedAddr::default_instance_ = new UnresolvedAddr();

--- a/storage/status.proto
+++ b/storage/status.proto
@@ -23,12 +23,6 @@ import "cockroach/roachpb/metadata.proto";
 import "cockroach/storage/engine/mvcc.proto";
 import weak "gogoproto/gogo.proto";
 
-option (gogoproto.goproto_getters_all) = false;
-option (gogoproto.goproto_unrecognized_all) = false;
-option (gogoproto.marshaler_all) = true;
-option (gogoproto.sizer_all) = true;
-option (gogoproto.unmarshaler_all) = true;
-
 // StoreStatus contains the stats needed to calculate the current status of a
 // store.
 message StoreStatus {

--- a/ts/timeseries.proto
+++ b/ts/timeseries.proto
@@ -21,12 +21,6 @@ option go_package = "ts";
 
 import weak "gogoproto/gogo.proto";
 
-option (gogoproto.goproto_getters_all) = false;
-option (gogoproto.goproto_unrecognized_all) = false;
-option (gogoproto.marshaler_all) = true;
-option (gogoproto.sizer_all) = true;
-option (gogoproto.unmarshaler_all) = true;
-
 // TimeSeriesDatapoint is a single point of time series data; a value associated
 // with a timestamp.
 message TimeSeriesDatapoint {

--- a/util/log/log.proto
+++ b/util/log/log.proto
@@ -21,12 +21,6 @@ option go_package = "log";
 
 import weak "gogoproto/gogo.proto";
 
-option (gogoproto.goproto_getters_all) = false;
-option (gogoproto.goproto_unrecognized_all) = false;
-option (gogoproto.marshaler_all) = true;
-option (gogoproto.sizer_all) = true;
-option (gogoproto.unmarshaler_all) = true;
-
 // Log represents a cockroach structured log entry.
 message LogEntry {
   // Log message severity.

--- a/util/unresolved_addr.proto
+++ b/util/unresolved_addr.proto
@@ -21,12 +21,6 @@ option go_package = "util";
 
 import weak "gogoproto/gogo.proto";
 
-option (gogoproto.goproto_getters_all) = false;
-option (gogoproto.goproto_unrecognized_all) = false;
-option (gogoproto.marshaler_all) = true;
-option (gogoproto.sizer_all) = true;
-option (gogoproto.unmarshaler_all) = true;
-
 // / UnresolvedAddr is an unresolved version of net.Addr.
 message UnresolvedAddr {
   option (gogoproto.goproto_stringer) = false;


### PR DESCRIPTION
Re-proposing #1317.

In addition to the benefits originally mentioned, this also makes `String()` faster and more descriptive, and gives us more consistent treatment of enums.

At this point, I don't really see the downsides.

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/3357)

<!-- Reviewable:end -->
