### PR TITLE
1PC transactions

### DIFF
--- a/kv/dist_sender_server_test.go
+++ b/kv/dist_sender_server_test.go
@@ -468,7 +468,7 @@ func TestPropagateTxnOnError(t *testing.T) {
 	// get a ReadWithinUncertaintyIntervalError.
 	targetKey := roachpb.Key("b")
 	var numGets int32
-	storage.TestingCommandFilter = func(args roachpb.Request, h roachpb.Header) error {
+	storage.TestingCommandFilter = func(_ roachpb.StoreID, args roachpb.Request, h roachpb.Header) error {
 		if _, ok := args.(*roachpb.ConditionalPutRequest); ok && args.Header().Key.Equal(targetKey) {
 			if atomic.AddInt32(&numGets, 1) == 1 {
 				return &roachpb.ReadWithinUncertaintyIntervalError{

--- a/kv/local_test_cluster.go
+++ b/kv/local_test_cluster.go
@@ -19,6 +19,7 @@ package kv
 
 import (
 	"net"
+	"time"
 
 	"golang.org/x/net/context"
 
@@ -57,6 +58,7 @@ type LocalTestCluster struct {
 	Sender     *TxnCoordSender
 	distSender *DistSender
 	Stopper    *stop.Stopper
+	Latency    time.Duration // sleep for each RPC sent
 	tester     util.Tester
 }
 
@@ -82,6 +84,9 @@ func (ltc *LocalTestCluster) Start(t util.Tester) {
 		getArgs func(addr net.Addr) proto.Message, getReply func() proto.Message,
 		_ *rpc.Context) ([]proto.Message, error) {
 		// TODO(tschottdorf): remove getReply().
+		if ltc.Latency > 0 {
+			time.Sleep(ltc.Latency)
+		}
 		br, pErr := ltc.stores.Send(context.Background(), *getArgs(nil).(*roachpb.BatchRequest))
 		if br == nil {
 			br = &roachpb.BatchResponse{}

--- a/kv/txn_coord_sender_test.go
+++ b/kv/txn_coord_sender_test.go
@@ -39,6 +39,14 @@ import (
 	"github.com/cockroachdb/cockroach/util/stop"
 )
 
+// senderFn is a function that implements a Sender.
+type senderFn func(context.Context, roachpb.BatchRequest) (*roachpb.BatchResponse, *roachpb.Error)
+
+// Send implements batch.Sender.
+func (f senderFn) Send(ctx context.Context, ba roachpb.BatchRequest) (*roachpb.BatchResponse, *roachpb.Error) {
+	return f(ctx, ba)
+}
+
 // teardownHeartbeats goes through the coordinator's active transactions and
 // has the associated heartbeat tasks quit. This is useful for tests which
 // don't finish transactions.

--- a/roachpb/api_test.go
+++ b/roachpb/api_test.go
@@ -164,16 +164,31 @@ func TestBatchSplit(t *testing.T) {
 	bt := &BeginTransactionRequest{}
 	et := &EndTransactionRequest{}
 	rv := &ReverseScanRequest{}
+	np := &NoopRequest{}
 	testCases := []struct {
-		reqs  []Request
-		sizes []int
+		reqs       []Request
+		sizes      []int
+		canSplitET bool
 	}{
-		{[]Request{get, put}, []int{1, 1}},
-		{[]Request{get, get, get, put, put, get, get}, []int{3, 2, 2}},
-		{[]Request{get, scan, get, dr, rv, put, et}, []int{3, 1, 1, 1, 1}},
-		{[]Request{spl, get, scan, spl, get}, []int{1, 2, 1, 1}},
-		{[]Request{spl, spl, get, spl}, []int{1, 1, 1, 1}},
-		{[]Request{bt, put, et}, []int{2, 1}},
+		{[]Request{get, put}, []int{1, 1}, true},
+		{[]Request{get, get, get, put, put, get, get}, []int{3, 2, 2}, true},
+		{[]Request{spl, get, scan, spl, get}, []int{1, 2, 1, 1}, true},
+		{[]Request{spl, spl, get, spl}, []int{1, 1, 1, 1}, true},
+		{[]Request{bt, put, et}, []int{2, 1}, true},
+		{[]Request{get, scan, get, dr, rv, put, et}, []int{3, 1, 1, 1, 1}, true},
+		// Same one again, but this time don't allow EndTransaction to be split.
+		{[]Request{get, scan, get, dr, rv, put, et}, []int{3, 1, 1, 2}, false},
+		// An invalid request in real life, but it demonstrates that we'll always
+		// split **after** an EndTransaction (because either the next request
+		// wants to be alone, or its flags can't match the current flags, which
+		// have isAlone set). Could be useful if we ever want to allow executing
+		// multiple batches back-to-back.
+		{[]Request{et, scan, et}, []int{1, 2}, false},
+		// Check that Noop can mix with other requests regardless of flags.
+		{[]Request{np, put, np}, []int{3}, true},
+		{[]Request{np, spl, np}, []int{3}, true},
+		{[]Request{np, rv, np}, []int{3}, true},
+		{[]Request{np, np, et}, []int{3}, true}, // et does not split off
 	}
 
 	for i, test := range testCases {
@@ -183,7 +198,7 @@ func TestBatchSplit(t *testing.T) {
 		}
 		var partLen []int
 		var recombined []RequestUnion
-		for _, part := range ba.Split() {
+		for _, part := range ba.Split(test.canSplitET) {
 			recombined = append(recombined, part...)
 			partLen = append(partLen, len(part))
 		}

--- a/roachpb/batch.go
+++ b/roachpb/batch.go
@@ -203,12 +203,16 @@ func (ba *BatchRequest) flags() int {
 
 // Split separates the requests contained in a batch so that each subset of
 // requests can be executed by a Store (without changing order). In particular,
-// Admin and EndTransaction requests are always singled out and mutating
-// requests separated from reads.
-func (ba BatchRequest) Split() [][]RequestUnion {
-	compatible := func(exFlags, newFlags int) bool {
+// Admin requests are always singled out and mutating requests separated from
+// reads. The boolean parameter indicates whether EndTransaction should be
+// special-cased: If false, an EndTransaction request will never be split into
+// a new chunk (otherwise, it is treated according to its flags). This allows
+// sending a whole transaction in a single Batch when addressing a single
+// range.
+func (ba BatchRequest) Split(canSplitET bool) [][]RequestUnion {
+	compatible := func(method Method, exFlags, newFlags int) bool {
 		// If no flags are set so far, everything goes.
-		if exFlags == 0 {
+		if exFlags == 0 || (!canSplitET && method == EndTransaction) {
 			return true
 		}
 		if (newFlags & isAlone) != 0 {
@@ -229,8 +233,14 @@ func (ba BatchRequest) Split() [][]RequestUnion {
 		part := ba.Requests
 		var gFlags int
 		for i, union := range ba.Requests {
-			flags := union.GetInner().flags()
-			if !compatible(gFlags, flags) {
+			args := union.GetInner()
+			flags := args.flags()
+			method := args.Method()
+			// Regardless of flags, a NoopRequest is always compatible.
+			if method == Noop {
+				continue
+			}
+			if !compatible(method, gFlags, flags) {
 				part = ba.Requests[:i]
 				break
 			}

--- a/server/intent_test.go
+++ b/server/intent_test.go
@@ -74,7 +74,7 @@ func TestIntentResolution(t *testing.T) {
 		var result []string
 		var mu sync.Mutex
 		closer := make(chan struct{}, 2)
-		storage.TestingCommandFilter = func(args roachpb.Request, _ roachpb.Header) error {
+		storage.TestingCommandFilter = func(_ roachpb.StoreID, args roachpb.Request, _ roachpb.Header) error {
 			mu.Lock()
 			defer mu.Unlock()
 			header := args.Header()

--- a/sql/main_test.go
+++ b/sql/main_test.go
@@ -51,7 +51,7 @@ func TestMain(m *testing.M) {
 
 // checkEndTransactionTrigger verifies that an EndTransactionRequest
 // that includes intents for the SystemDB keys sets the proper trigger.
-func checkEndTransactionTrigger(req roachpb.Request, _ roachpb.Header) error {
+func checkEndTransactionTrigger(_ roachpb.StoreID, req roachpb.Request, _ roachpb.Header) error {
 	args, ok := req.(*roachpb.EndTransactionRequest)
 	if !ok {
 		return nil

--- a/storage/client_raft_test.go
+++ b/storage/client_raft_test.go
@@ -166,7 +166,7 @@ func TestStoreRecoverWithErrors(t *testing.T) {
 
 	numIncrements := 0
 
-	storage.TestingCommandFilter = func(args roachpb.Request, _ roachpb.Header) error {
+	storage.TestingCommandFilter = func(_ roachpb.StoreID, args roachpb.Request, _ roachpb.Header) error {
 		if _, ok := args.(*roachpb.IncrementRequest); ok && args.Header().Key.Equal(roachpb.Key("a")) {
 			numIncrements++
 		}
@@ -373,7 +373,7 @@ func TestFailedReplicaChange(t *testing.T) {
 	var runFilter atomic.Value
 	runFilter.Store(true)
 
-	storage.TestingCommandFilter = func(args roachpb.Request, _ roachpb.Header) error {
+	storage.TestingCommandFilter = func(_ roachpb.StoreID, args roachpb.Request, _ roachpb.Header) error {
 		if runFilter.Load().(bool) {
 			if et, ok := args.(*roachpb.EndTransactionRequest); ok && et.Commit {
 				return util.Errorf("boom")

--- a/storage/client_replica_test.go
+++ b/storage/client_replica_test.go
@@ -187,7 +187,7 @@ func TestTxnPutOutOfOrder(t *testing.T) {
 	key := "key"
 	// Set up a filter to so that the get operation at Step 3 will return an error.
 	var numGets int32
-	storage.TestingCommandFilter = func(args roachpb.Request, h roachpb.Header) error {
+	storage.TestingCommandFilter = func(_ roachpb.StoreID, args roachpb.Request, h roachpb.Header) error {
 		if _, ok := args.(*roachpb.GetRequest); ok &&
 			args.Header().Key.Equal(roachpb.Key(key)) &&
 			h.Txn == nil {

--- a/storage/client_split_test.go
+++ b/storage/client_split_test.go
@@ -809,7 +809,7 @@ func TestStoreSplitReadRace(t *testing.T) {
 
 	getContinues := make(chan struct{})
 	var getStarted sync.WaitGroup
-	storage.TestingCommandFilter = func(args roachpb.Request, h roachpb.Header) error {
+	storage.TestingCommandFilter = func(_ roachpb.StoreID, args roachpb.Request, h roachpb.Header) error {
 		if et, ok := args.(*roachpb.EndTransactionRequest); ok {
 			st := et.InternalCommitTrigger.GetSplitTrigger()
 			if st == nil || !st.UpdatedDesc.EndKey.Equal(splitKey) {

--- a/storage/gc_queue_test.go
+++ b/storage/gc_queue_test.go
@@ -349,7 +349,7 @@ func TestGCQueueTransactionTable(t *testing.T) {
 	}
 
 	resolved := map[string][]roachpb.Span{}
-	TestingCommandFilter = func(req roachpb.Request, _ roachpb.Header) error {
+	TestingCommandFilter = func(_ roachpb.StoreID, req roachpb.Request, _ roachpb.Header) error {
 		if resArgs, ok := req.(*roachpb.ResolveIntentRequest); ok {
 			id := string(resArgs.IntentTxn.Key)
 			resolved[id] = append(resolved[id], roachpb.Span{

--- a/storage/replica.go
+++ b/storage/replica.go
@@ -82,7 +82,7 @@ const (
 // be run once for each replica and must produce consistent results
 // each time. Should only be used in tests in the storage and
 // storage_test packages.
-var TestingCommandFilter func(roachpb.Request, roachpb.Header) error
+var TestingCommandFilter func(roachpb.StoreID, roachpb.Request, roachpb.Header) error
 
 // This flag controls whether Transaction entries are automatically gc'ed
 // upon EndTransaction if they only have local intents (which can be

--- a/storage/replica_test.go
+++ b/storage/replica_test.go
@@ -1105,7 +1105,7 @@ func TestRangeCommandQueue(t *testing.T) {
 	blockingStart := make(chan struct{})
 	blockingDone := make(chan struct{})
 	defer func() { TestingCommandFilter = nil }()
-	TestingCommandFilter = func(_ roachpb.Request, h roachpb.Header) error {
+	TestingCommandFilter = func(_ roachpb.StoreID, _ roachpb.Request, h roachpb.Header) error {
 		if h.GetUserPriority() == 42 {
 			blockingStart <- struct{}{}
 			<-blockingDone
@@ -1221,7 +1221,7 @@ func TestRangeCommandQueueInconsistent(t *testing.T) {
 	key := roachpb.Key("key1")
 	blockingStart := make(chan struct{})
 	blockingDone := make(chan struct{})
-	TestingCommandFilter = func(args roachpb.Request, _ roachpb.Header) error {
+	TestingCommandFilter = func(_ roachpb.StoreID, args roachpb.Request, _ roachpb.Header) error {
 		if put, ok := args.(*roachpb.PutRequest); ok {
 			putBytes, err := put.Value.GetBytes()
 			if err != nil {
@@ -1927,7 +1927,7 @@ func TestEndTransactionLocalGC(t *testing.T) {
 	defer leaktest.AfterTest(t)
 	defer setTxnAutoGC(true)()
 	defer func() { TestingCommandFilter = nil }()
-	TestingCommandFilter = func(args roachpb.Request, _ roachpb.Header) error {
+	TestingCommandFilter = func(_ roachpb.StoreID, args roachpb.Request, _ roachpb.Header) error {
 		// Make sure the direct GC path doesn't interfere with this test.
 		if args.Method() == roachpb.GC {
 			return util.Errorf("boom")
@@ -2021,7 +2021,7 @@ func TestEndTransactionResolveOnlyLocalIntents(t *testing.T) {
 	key := roachpb.Key("a")
 	splitKey := roachpb.RKey(key).Next()
 	defer func() { TestingCommandFilter = nil }()
-	TestingCommandFilter = func(args roachpb.Request, _ roachpb.Header) error {
+	TestingCommandFilter = func(_ roachpb.StoreID, args roachpb.Request, _ roachpb.Header) error {
 		if args.Method() == roachpb.ResolveIntentRange && args.Header().Key.Equal(splitKey.AsRawKey()) {
 			return util.Errorf("boom")
 		}
@@ -2093,7 +2093,7 @@ func TestEndTransactionDirectGCFailure(t *testing.T) {
 	splitKey := roachpb.RKey(key).Next()
 	var count int64
 	defer func() { TestingCommandFilter = nil }()
-	TestingCommandFilter = func(args roachpb.Request, _ roachpb.Header) error {
+	TestingCommandFilter = func(_ roachpb.StoreID, args roachpb.Request, _ roachpb.Header) error {
 		if args.Method() == roachpb.ResolveIntentRange && args.Header().Key.Equal(splitKey.AsRawKey()) {
 			atomic.AddInt64(&count, 1)
 			return util.Errorf("boom")

--- a/storage/store.go
+++ b/storage/store.go
@@ -1539,12 +1539,6 @@ func (s *Store) proposeRaftCommandImpl(idKey cmdIDKey, cmd roachpb.RaftCommand) 
 		etr, ok := args.(*roachpb.EndTransactionRequest)
 		if ok {
 			if crt := etr.InternalCommitTrigger.GetChangeReplicasTrigger(); crt != nil {
-				// TODO(tschottdorf): the real check is that EndTransaction needs
-				// to be the last element in the batch. Any caveats to solve before
-				// changing this?
-				if len(cmd.Cmd.Requests) != 1 {
-					panic("EndTransaction should only ever occur by itself in a batch")
-				}
 				// EndTransactionRequest with a ChangeReplicasTrigger is special because raft
 				// needs to understand it; it cannot simply be an opaque command.
 				log.Infof("raft: %s %v for range %d", crt.ChangeType, crt.Replica, cmd.RangeID)

--- a/storage/store_test.go
+++ b/storage/store_test.go
@@ -1354,7 +1354,7 @@ func TestStoreScanIntents(t *testing.T) {
 	var count int32
 	countPtr := &count
 
-	TestingCommandFilter = func(args roachpb.Request, _ roachpb.Header) error {
+	TestingCommandFilter = func(_ roachpb.StoreID, args roachpb.Request, _ roachpb.Header) error {
 		if _, ok := args.(*roachpb.ScanRequest); ok {
 			atomic.AddInt32(countPtr, 1)
 		}
@@ -1470,7 +1470,7 @@ func TestStoreScanInconsistentResolvesIntents(t *testing.T) {
 	defer setTxnAutoGC(false)()
 	var intercept atomic.Value
 	intercept.Store(true)
-	TestingCommandFilter = func(args roachpb.Request, _ roachpb.Header) error {
+	TestingCommandFilter = func(_ roachpb.StoreID, args roachpb.Request, _ roachpb.Header) error {
 		if _, ok := args.(*roachpb.ResolveIntentRequest); ok && intercept.Load().(bool) {
 			return util.Errorf("error on purpose")
 		}


### PR DESCRIPTION
resuscitation of #2818.

This change enables 1PC txns for transactions contained in a single batch and
sent to a single Range.

Contrary to the previous incarnation, now the chunk of batch
containing EndTransaction is split and re-sent before any other
redundant requests have been made.

More improvement is possible: If the EndTransaction request were to end up in
the last Batch sent over the course of the multi-range request anyway, it would
not need to be split up into its own chunk. There's no way of knowing that
until the last range descriptor has been looked up though, at which point in
time we've already sent requests, complicating the code. Hence, this
optimization (which amounts to @bdarnell's suggestion in #2818) has been
omitted for now due to the amount of code changes required.

Unfortunately, the improvements here don't directly reflect in SQL
benchmarks because of the way the Txn is used there.
We need to optimize the SQL server to batch up as many commands as it
can (basically until it reads data) and commit in the same round-trip
if possible. Currently the Txn object is used deep down in the individual
operations (for example `(*planner).Insert()`) so this isn't trivial.
I will file an issue.

Instead, I reused a `kv` benchmark which runs a 1pc transaction. Without
actual latency however, the effect of this change is minimal. I added a way
to simulate latency (by means of `time.Sleep`) to `TestCluster` and benchmarked
using that. The results are, well, not surprising. See second commit.

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/3364)

<!-- Reviewable:end -->
