### PR TITLE
Fix broken gossip unittest verifying redundant connections are closed.

### DIFF
--- a/gossip/server.go
+++ b/gossip/server.go
@@ -90,8 +90,8 @@ func (s *server) Gossip(argsI proto.Message) (proto.Message, error) {
 	// as a permanent peer. We always accept its input and return
 	// our delta.
 	canAccept := true
-	s.incoming.setMaxSize(s.maxPeers())
 	if !s.incoming.hasNode(args.NodeID) {
+		s.incoming.setMaxSize(s.maxPeers())
 		if !s.incoming.hasSpace() {
 			canAccept = false
 		} else {


### PR DESCRIPTION
The unittest allowed a case where node 1 connected and served gossip
to node 2 before node 2 connected to node 1. In this event, node 1
will never close its client as node 2 hasn't yet connected, so no
redundancy to notice. Since no further gossiping takes place, the
unittest would just get stuck until the timeout.

Cleaned up some miscellaneous log messages.

Fixes #3134

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/3378)

<!-- Reviewable:end -->
