### PR TITLE
Remove unnecessary error check and improve slice/map allocation

### DIFF
--- a/kv/dist_sender.go
+++ b/kv/dist_sender.go
@@ -304,19 +304,16 @@ func (ds *DistSender) getNodeDescriptor() *roachpb.NodeDescriptor {
 func (ds *DistSender) sendRPC(trace *tracer.Trace, rangeID roachpb.RangeID, replicas replicaSlice, order rpc.OrderingPolicy,
 	ba roachpb.BatchRequest) (*roachpb.BatchResponse, error) {
 	if len(replicas) == 0 {
-		return nil, util.Errorf("replicas set is empty")
+		return nil, noNodeAddrsAvailError{}
 	}
 
-	// Build a slice of replica addresses (if gossiped).
-	var addrs []net.Addr
-	replicaMap := map[string]*roachpb.ReplicaDescriptor{}
+	// Build a slice of replica addresses.
+	addrs := make([]net.Addr, 0, len(replicas))
+	replicaMap := make(map[string]*roachpb.ReplicaDescriptor, len(replicas))
 	for i := range replicas {
 		addr := replicas[i].NodeDesc.Address
 		addrs = append(addrs, addr)
 		replicaMap[addr.String()] = &replicas[i].ReplicaDescriptor
-	}
-	if len(addrs) == 0 {
-		return nil, noNodeAddrsAvailError{}
 	}
 
 	// TODO(pmattis): This needs to be tested. If it isn't set we'll


### PR DESCRIPTION
I might have missed something, but after staring at this for a while, I couldn't figure out why the second empty slice check was needed. I figured the `noNodeAddrsAvailError` was the better error to return.

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/3383)

<!-- Reviewable:end -->
