### PR TITLE
Guard against any endless gossip forwarding loops.

### DIFF
--- a/gossip/client_test.go
+++ b/gossip/client_test.go
@@ -227,6 +227,37 @@ func TestClientNodeID(t *testing.T) {
 	})
 }
 
+func verifyServerMaps(g *Gossip, expCount int) bool {
+	g.mu.Lock()
+	defer g.mu.Unlock()
+	return len(g.lAddrMap) == expCount && len(g.nodeMap) == expCount
+}
+
+// TestClientDisconnectLoopback verifies that the gossip server
+// will drop an outgoing client connection that is already an
+// inbound client connection of another node.
+func TestClientDisconnectLoopback(t *testing.T) {
+	defer leaktest.AfterTest(t)
+	local, _, stopper := startGossip(t)
+	defer stopper.Stop()
+	// startClient requires locks are held, so acquire here.
+	local.mu.Lock()
+	lAddr := local.is.NodeAddr
+	lclock := hlc.NewClock(hlc.UnixNano)
+	rpcContext := rpc.NewContext(&base.Context{Insecure: true}, lclock, stopper)
+	rpcContext.DisableCache = true
+	local.startClient(lAddr, rpcContext, stopper)
+	local.mu.Unlock()
+	local.manage(stopper)
+	util.SucceedsWithin(t, 10*time.Second, func() error {
+		ok := local.findClient(func(c *client) bool { return c.addr.String() == lAddr.String() }) != nil
+		if !ok && verifyServerMaps(local, 0) {
+			return nil
+		}
+		return errors.New("local client still connected to itself")
+	})
+}
+
 // TestClientDisconnectRedundant verifies that the gossip server
 // will drop an outgoing client connection that is already an
 // inbound client connection of another node.
@@ -234,14 +265,15 @@ func TestClientDisconnectRedundant(t *testing.T) {
 	defer leaktest.AfterTest(t)
 	local, remote, stopper := startGossip(t)
 	defer stopper.Stop()
-	// startClient doesn't lock the underlying gossip
-	// object, so we acquire those locks here.
+	// startClient requires locks are held, so acquire here.
 	local.mu.Lock()
 	remote.mu.Lock()
+
 	rAddr := remote.is.NodeAddr
 	lAddr := local.is.NodeAddr
 	lclock := hlc.NewClock(hlc.UnixNano)
 	rpcContext := rpc.NewContext(&base.Context{Insecure: true}, lclock, stopper)
+	rpcContext.DisableCache = true
 	local.startClient(rAddr, rpcContext, stopper)
 	remote.startClient(lAddr, rpcContext, stopper)
 	local.mu.Unlock()
@@ -260,9 +292,47 @@ func TestClientDisconnectRedundant(t *testing.T) {
 			if err := local.AddInfo("local-key", nil, time.Second); err != nil {
 				t.Fatal(err)
 			}
-		} else if !ok1 && ok2 {
+		} else if !ok1 && ok2 && verifyServerMaps(local, 1) && verifyServerMaps(remote, 0) {
 			return nil
 		}
 		return errors.New("local client to remote not yet closed as redundant")
+	})
+}
+
+// TestClientDisallowMultipleConns verifies that the server disallows
+// multiple connections from the same client node ID.
+func TestClientDisallowMultipleConns(t *testing.T) {
+	defer leaktest.AfterTest(t)
+	local, remote, stopper := startGossip(t)
+	defer stopper.Stop()
+	local.mu.Lock()
+	remote.mu.Lock()
+	rAddr := remote.is.NodeAddr
+	lclock := hlc.NewClock(hlc.UnixNano)
+	rpcContext := rpc.NewContext(&base.Context{Insecure: true}, lclock, stopper)
+	rpcContext.DisableCache = true
+	// Start two clients from local to remote. RPC client cache is
+	// disabled via the context, so we'll start two different outgoing
+	// connections.
+	local.startClient(rAddr, rpcContext, stopper)
+	local.startClient(rAddr, rpcContext, stopper)
+	local.mu.Unlock()
+	remote.mu.Unlock()
+	local.manage(stopper)
+	remote.manage(stopper)
+	util.SucceedsWithin(t, 10*time.Second, func() error {
+		// Verify that the remote server has only a single incoming
+		// connection and the local server has only a single outgoing
+		// connection.
+		local.mu.Lock()
+		remote.mu.Lock()
+		outgoing := local.outgoing.len()
+		incoming := remote.incoming.len()
+		local.mu.Unlock()
+		remote.mu.Unlock()
+		if outgoing == 1 && incoming == 1 && verifyServerMaps(local, 0) && verifyServerMaps(remote, 1) {
+			return nil
+		}
+		return util.Errorf("incorrect number of incoming (%d) or outgoing (%d) connections", incoming, outgoing)
 	})
 }

--- a/gossip/gossip.go
+++ b/gossip/gossip.go
@@ -448,6 +448,13 @@ func (g *Gossip) hasIncoming(nodeID roachpb.NodeID) bool {
 	return g.incoming.hasNode(nodeID)
 }
 
+// hasOutgoing returns whether the server has an outgoing gossip
+// client matching the provided node ID. Mutex should be held by
+// caller.
+func (g *Gossip) hasOutgoing(nodeID roachpb.NodeID) bool {
+	return g.outgoing.hasNode(nodeID)
+}
+
 // filterExtant removes any nodes from the supplied nodeSet which
 // are already connected to this node, either via outgoing or incoming
 // client connections.

--- a/gossip/gossip.proto
+++ b/gossip/gossip.proto
@@ -49,11 +49,14 @@ message Response {
   // Address of the responding client.
   util.UnresolvedAddr addr = 2 [(gogoproto.nullable) = false];
   // Non-nil means client should retry with this address.
-  util.UnresolvedAddr alternate = 3;
+  util.UnresolvedAddr alternate_addr = 3;
+  // Node ID of the alternate address, if alternate_addr is not nil.
+  int32 alternate_node_id = 4 [(gogoproto.customname) = "AlternateNodeID",
+      (gogoproto.casttype) = "github.com/cockroachdb/cockroach/roachpb.NodeID"];
   // Delta of Infos originating at nodes newer than specified high water timestamps.
-  map<string, Info> delta = 4;
+  map<string, Info> delta = 5;
   // Map of all high water timestamps, by node, seen by the responder.
-  map<int32, int64> high_water_stamps = 5;
+  map<int32, int64> high_water_stamps = 6;
 }
 
 // Info is the basic unit of information traded over the

--- a/rpc/server.go
+++ b/rpc/server.go
@@ -143,8 +143,8 @@ func (s *Server) AddCloseCallback(cb func(conn net.Conn)) {
 }
 
 func (s *Server) runCloseCallbacks(conn net.Conn) {
-	s.mu.Lock()
-	defer s.mu.Unlock()
+	s.mu.RLock()
+	defer s.mu.RUnlock()
 	for _, cb := range s.closeCallbacks {
 		cb(conn)
 	}


### PR DESCRIPTION
A situation arose in AWS testing where a node received a forwards
to nodes which were already full, in large part because that node
was already connected to each. Also, gossip was not protecting
nodes from connecting to themselves. We now ignore forwarding
responses which direct to an already-connected node, either
incoming or outgoing.

Also rejiggered the logging to indicate nodes in most cases and
node addresses only where helpful. Added a unittest for the case
of a node connecting to itself.

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/3393)

<!-- Reviewable:end -->
