### PR TITLE
client/rpc_sender: patiently wait for TLS handshake

### DIFF
--- a/client/rpc_sender.go
+++ b/client/rpc_sender.go
@@ -21,6 +21,7 @@ import (
 	"fmt"
 	"net"
 	"net/url"
+	"time"
 
 	"golang.org/x/net/context"
 
@@ -83,6 +84,13 @@ func newRPCSender(server string, context *base.Context, retryOpts retry.Options,
 // and been executed successfully. We retry here to eventually get through with
 // the same client command ID and be given the cached response.
 func (s *rpcSender) Send(ctx context.Context, ba roachpb.BatchRequest) (*roachpb.BatchResponse, *roachpb.Error) {
+	timeout := s.retryOpts.MaxBackoff
+	select {
+	case <-s.client.Dialed:
+	case <-time.After(timeout):
+		return nil, roachpb.NewError(fmt.Errorf("failed to send RPC request %s: client took longer than %s to dial", method, timeout))
+	}
+
 	var err error
 	var br roachpb.BatchResponse
 	for r := retry.Start(s.retryOpts); r.Next(); {

--- a/rpc/heartbeat_test.go
+++ b/rpc/heartbeat_test.go
@@ -129,6 +129,7 @@ func TestUpdateOffsetOnHeartbeat(t *testing.T) {
 	serverAddr := ln.Addr()
 	client := &Client{
 		Closed:       make(chan struct{}),
+		Dialed:       make(chan struct{}),
 		addr:         util.MakeUnresolvedAddr(serverAddr.Network(), serverAddr.String()),
 		tlsConfig:    tlsConfig,
 		clock:        ctx.localClock,


### PR DESCRIPTION
This should fix the flaky tests that have emerged since I increased
the key size of our testing certificates.

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/3395)

<!-- Reviewable:end -->
