### PR TITLE
Makefile: add support for STRESSFLAGS

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -33,6 +33,7 @@ TESTTIMEOUT  := 1m10s
 RACETIMEOUT  := 5m
 BENCHTIMEOUT := 5m
 TESTFLAGS    :=
+STRESSFLAGS  :=
 DUPLFLAGS    := -t 100
 
 ifeq ($(STATIC),1)
@@ -133,12 +134,12 @@ coverage:
 .PHONY: stress
 stress:
 	$(GO) test -tags '$(TAGS)' $(GOFLAGS) -i -c $(PKG) -o stress.test
-	stress ./stress.test -test.run $(TESTS) -test.timeout $(TESTTIMEOUT) $(TESTFLAGS)
+	stress $(STRESSFLAGS) ./stress.test -test.run $(TESTS) -test.timeout $(TESTTIMEOUT) $(TESTFLAGS)
 
 .PHONY: stressrace
 stressrace:
 	$(GO) test -tags '$(TAGS)' $(GOFLAGS) -race -i -c $(PKG) -o stress.test
-	stress ./stress.test -test.run $(TESTS) -test.timeout $(TESTTIMEOUT) $(TESTFLAGS)
+	stress $(STRESSFLAGS) ./stress.test -test.run $(TESTS) -test.timeout $(TESTTIMEOUT) $(TESTFLAGS)
 
 .PHONY: acceptance
 acceptance:


### PR DESCRIPTION
This is useful when you need to really stress test something, e.g.:

```
make stressrace PKG=./kv TESTS=TestMultiRangeEmptyAfterTruncate STRESSFLAGS='-p 16'
```

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/3397)

<!-- Reviewable:end -->
