### PR TITLE
Change naming scheme for binaries in S3.

### DIFF
--- a/build/push-aws.sh
+++ b/build/push-aws.sh
@@ -1,6 +1,7 @@
 #!/bin/bash
 # Push binaries to AWS.
 # This is run by circle-ci after successful docker push.
+#
 # Requisites:
 # - binaries must be statically linked by running build/build-static-binaries.sh
 # - circleci must have AWS credentials configured
@@ -13,46 +14,26 @@
 
 set -eux
 
-BUCKET_PATH="cockroach/bin"
+BUCKET_NAME="cockroach"
 LATEST_SUFFIX=".LATEST"
+REPO_NAME="cockroach"
+SHA="${CIRCLE_SHA1-$(git rev-parse HEAD)}"
 
-now=$(date +"%Y%m%d-%H%M%S")
-today=$(echo ${now} | cut -d '-' -f1)
-binary_suffix=".${now}.${CIRCLE_SHA1-$(git rev-parse HEAD)}"
-
-# push_one_binary takes the path to the binary inside the cockroach repo.
+# push_one_binary takes the path to the binary inside the repo.
 # eg: push_one_binary sql/sql.test
-# The file will be pushed to: s3://BUCKET_PATH/sql.test.YYMMDD-HHMMSS.CIRCLESHA1
-# The S3 basename will be stored in s3://BUCKET_PATH/sql.test.LATEST
+# The file will be pushed to: s3://BUCKET_NAME/REPO_NAME/sql.test.SHA
+# The S3 basename will be stored in s3://BUCKET_NAME/REPO_NAME/sql.test.LATEST
 function push_one_binary {
   rel_path=$1
   binary_name=$(basename $1)
 
-  # TODO(marc): uncomment the following blocks to limit pushes to once a day.
-  # # Fetch name of most recent binary.
-  # # TODO(marc): some versions of `aws s3 cp` allow - for stdin/stdout, but not all.
-  # tmpfile=$(mktemp /tmp/cockroach-push.XXXXXX)
-  # # Don't exit on errors, clearing the latest file is an easy way to force multiple uploads.
-  # time aws s3 cp s3://${BUCKET_PATH}/${binary_name}${LATEST_SUFFIX} ${tmpfile} || true
-  # contents=$(cat ${tmpfile})
-  # rm -f ${tmpfile}
-  # latest_date=$(echo ${contents} | sed "s/${binary_name}.\([0-9]\+\)-.*/\1/")
-  #
-  # # Push binaries at most once a day.
-  # if [ "${latest_date}" == "${today}" ]; then
-  #   echo "Latest binary is from today, skipping: ${contents}"
-  #   return 0
-  # fi
-
-  # Latest file did not exist, was empty, or pointed to an old binary.
-  # Upload binary.
   cd $(dirname $0)/..
-  time aws s3 cp ${rel_path} s3://${BUCKET_PATH}/${binary_name}${binary_suffix}
+  time aws s3 cp ${rel_path} s3://${BUCKET_NAME}/${REPO_NAME}/${binary_name}.${SHA}
 
   # Upload LATEST file.
   tmpfile=$(mktemp /tmp/cockroach-push.XXXXXX)
-  echo ${binary_name}${binary_suffix} > ${tmpfile}
-  time aws s3 cp ${tmpfile} s3://${BUCKET_PATH}/${binary_name}${LATEST_SUFFIX}
+  echo ${SHA} > ${tmpfile}
+  time aws s3 cp ${tmpfile} s3://${BUCKET_NAME}/${REPO_NAME}/${binary_name}${LATEST_SUFFIX}
   rm -f ${tmpfile}
 }
 


### PR DESCRIPTION
This will allow other processes to build a link to the log for a given
sha.

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/3398)

<!-- Reviewable:end -->
