### PR TITLE
Adjust the MVCC key encoding.

### DIFF
--- a/storage/engine/batch_test.go
+++ b/storage/engine/batch_test.go
@@ -243,8 +243,8 @@ func TestBatchProto(t *testing.T) {
 	if !ok || err != nil {
 		t.Fatalf("expected GetProto to success ok=%t: %s", ok, err)
 	}
-	if keySize != 8 {
-		t.Errorf("expected key size 8; got %d", keySize)
+	if keySize != 6 {
+		t.Errorf("expected key size 6; got %d", keySize)
 	}
 	data, err := val.Marshal()
 	if err != nil {

--- a/storage/engine/mvcc.go
+++ b/storage/engine/mvcc.go
@@ -94,8 +94,11 @@ func (k MVCCKey) IsValue() bool {
 
 // EncodedSize returns the size of the MVCCKey when encoded.
 func (k MVCCKey) EncodedSize() int {
-	n := len(k.Key) + 3
+	n := len(k.Key) + 1
 	if k.IsValue() {
+		// Note that this isn't quite accurate: timestamps consume between 8-13
+		// bytes. Fixing this only adjusts the accounting for timestamps, not the
+		// actual on disk storage.
 		n += int(mvccVersionTimestampSize)
 	}
 	return n

--- a/storage/engine/rocksdb.go
+++ b/storage/engine/rocksdb.go
@@ -575,11 +575,7 @@ func (r *rocksDBIterator) ValueProto(msg proto.Message) error {
 	if r.value.len <= 0 {
 		return nil
 	}
-	err := proto.Unmarshal(r.unsafeValue(), msg)
-	if err != nil {
-		fmt.Printf("ValueProto: %T: %v\n%x\n%x\n", msg, err, r.unsafeKey(), r.unsafeValue())
-	}
-	return err
+	return proto.Unmarshal(r.unsafeValue(), msg)
 }
 
 func (r *rocksDBIterator) unsafeKey() MVCCKey {

--- a/storage/engine/rocksdb/encoding.cc
+++ b/storage/engine/rocksdb/encoding.cc
@@ -18,34 +18,8 @@
 
 #include "rocksdb/slice.h"
 
-namespace {
-
-const uint8_t kEscape      = 0x00;
-const uint8_t kEscapedTerm = 0x01;
-const uint8_t kEscapedNul  = 0xff;
-const uint8_t kBytesMarker = 0x71; // util/encoding/encoding.go:bytesMarker
-
-}  // namespace
-
-void EncodeBytes(std::string* buf, const char* ptr, int n) {
-  buf->reserve(n + 3);
-  buf->push_back(kBytesMarker);
-  const char* end = ptr + n;
-  for (; ptr != end;) {
-    const char* tmp = static_cast<const char*>(memchr(ptr, kEscape, end - ptr));
-    if (!tmp) {
-      break;
-    }
-    const int i = tmp - ptr;
-    buf->append(ptr, i);
-    buf->push_back(kEscape);
-    buf->push_back(kEscapedNul);
-    ptr += i + 1;
-  }
-  buf->append(ptr, end - ptr);
-  buf->push_back(kEscape);
-  buf->push_back(kEscapedTerm);
-}
+// TODO(pmattis): These functions are not tested. Doing so is made
+// difficult by "go test" because _test.go files cannot 'import "C"'.
 
 void EncodeUint32(std::string* buf, uint32_t v) {
   const uint8_t tmp[sizeof(v)] = {
@@ -54,47 +28,12 @@ void EncodeUint32(std::string* buf, uint32_t v) {
   buf->append(reinterpret_cast<const char*>(tmp), sizeof(tmp));
 }
 
-void EncodeUint32Decreasing(std::string* buf, uint32_t v) {
-  return EncodeUint32(buf, ~v);
-}
-
 void EncodeUint64(std::string* buf, uint64_t v) {
   const uint8_t tmp[sizeof(v)] = {
     uint8_t(v >> 56), uint8_t(v >> 48), uint8_t(v >> 40), uint8_t(v >> 32),
     uint8_t(v >> 24), uint8_t(v >> 16), uint8_t(v >> 8), uint8_t(v),
   };
   buf->append(reinterpret_cast<const char*>(tmp), sizeof(tmp));
-}
-
-void EncodeUint64Decreasing(std::string* buf, uint64_t v) {
-  return EncodeUint64(buf, ~v);
-}
-
-// TODO(pmattis): These functions are not tested. Doing so is made
-// difficult by "go test" because _test.go files cannot 'import "C"'.
-bool DecodeBytes(rocksdb::Slice* buf, std::string* decoded) {
-  const uint8_t *data = reinterpret_cast<const uint8_t*>(buf->data());
-  if (buf->size() == 0 || data[0] != kBytesMarker) {
-    return false;
-  }
-  int copyStart = 1;
-  for (int i = 1, n = int(buf->size()) - 1; i < n; ++i) {
-    uint8_t v = data[i];
-    if (v == kEscape) {
-      decoded->append(buf->data() + copyStart, i-copyStart);
-      v = data[++i];
-      if (v == kEscapedTerm) {
-        buf->remove_prefix(i + 1);
-        return true;
-      }
-      if (v != kEscapedNul) {
-        return false;
-      }
-      decoded->append("\0", 1);
-      copyStart = i + 1;
-    }
-  }
-  return false;
 }
 
 bool DecodeUint32(rocksdb::Slice* buf, uint32_t* value) {
@@ -109,14 +48,6 @@ bool DecodeUint32(rocksdb::Slice* buf, uint32_t* value) {
   return true;
 }
 
-bool DecodeUint32Decreasing(rocksdb::Slice* buf, uint32_t* value) {
-  if (!DecodeUint32(buf, value)) {
-    return false;
-  }
-  *value = ~*value;
-  return true;
-}
-
 bool DecodeUint64(rocksdb::Slice* buf, uint64_t* value) {
   const int N = sizeof(*value);
   if (buf->size() < N) {
@@ -128,13 +59,5 @@ bool DecodeUint64(rocksdb::Slice* buf, uint64_t* value) {
       (uint64_t(b[4]) << 24) | (uint64_t(b[5]) << 16) |
       (uint64_t(b[6]) << 8) | uint64_t(b[7]);
   buf->remove_prefix(N);
-  return true;
-}
-
-bool DecodeUint64Decreasing(rocksdb::Slice* buf, uint64_t* value) {
-  if (!DecodeUint64(buf, value)) {
-    return false;
-  }
-  *value = ~*value;
   return true;
 }

--- a/storage/engine/rocksdb/encoding.h
+++ b/storage/engine/rocksdb/encoding.h
@@ -20,49 +20,21 @@
 
 #include <stdint.h>
 
-// EncodeBytes encodes the n bytes at ptr using an escape-based encoding. The
-// encoded value is terminated with the sequence "\x00\x01" which is guaranteed
-// to not occur elsewhere in the encoded value. The encoded bytes are appended
-// to the supplied buffer.
-void EncodeBytes(std::string* buf, const char* ptr, int n);
-
 // EncodeUint32 encodes the uint32 value using a big-endian 4 byte
 // representation. The bytes are appended to the supplied buffer.
 void EncodeUint32(std::string* buf, uint32_t v);
-
-// EncodeUint32Decreasing encodes the uint32 value so that it sorts in reverse
-// order, from largest to smallest.
-void EncodeUint32Decreasing(std::string* buf, uint32_t v);
 
 // EncodeUint64 encodes the uint64 value using a big-endian 8 byte
 // representation. The encoded bytes are appended to the supplied buffer.
 void EncodeUint64(std::string* buf, uint64_t v);
 
-// EncodeUint64Decreasing encodes the uint64 value so that it sorts in reverse
-// order, from largest to smallest.
-void EncodeUint64Decreasing(std::string* buf, uint64_t v);
-
-// DecodeBytes decodes a byte slice from a buffer, returning true on a
-// successful decode. The decoded bytes are returned in *decoded.
-bool DecodeBytes(rocksdb::Slice* buf, std::string* decoded);
-
 // DecodedUint32 decodes a fixed-length encoded uint32 from a buffer, returning
 // true on a successful decode. The decoded value is returned in *value.
 bool DecodeUint32(rocksdb::Slice* buf, uint32_t* value);
 
-// DecodedUint32Decreasing decodes a fixed-length encoded uint32 from a buffer
-// that was encoded using EncodeUint32Decreasing, returning true on a
-// successful decode. The decoded value is returned in *value.
-bool DecodeUint32Decreasing(rocksdb::Slice* buf, uint32_t* value);
-
 // DecodedUint64 decodes a fixed-length encoded uint64 from a buffer, returning
 // true on a successful decode. The decoded value is returned in *value.
 bool DecodeUint64(rocksdb::Slice* buf, uint64_t* value);
-
-// DecodedUint64Decreasing decodes a fixed-length encoded uint64 from a buffer
-// that was encoded using EncodeUint64Decreasing, returning true on a
-// successful decode. The decoded value is returned in *value.
-bool DecodeUint64Decreasing(rocksdb::Slice* buf, uint64_t* value);
 
 #endif // ROACHLIB_ENCODING_H
 

--- a/storage/replica_test.go
+++ b/storage/replica_test.go
@@ -2661,7 +2661,7 @@ func TestRangeStatsComputation(t *testing.T) {
 	if _, err := client.SendWrapped(tc.Sender(), tc.rng.context(), &pArgs); err != nil {
 		t.Fatal(err)
 	}
-	expMS := engine.MVCCStats{LiveBytes: 26, KeyBytes: 16, ValBytes: 10, IntentBytes: 0, LiveCount: 1, KeyCount: 1, ValCount: 1, IntentCount: 0, IntentAge: 0, GCBytesAge: 0, SysBytes: 57, SysCount: 1, LastUpdateNanos: 0}
+	expMS := engine.MVCCStats{LiveBytes: 24, KeyBytes: 14, ValBytes: 10, IntentBytes: 0, LiveCount: 1, KeyCount: 1, ValCount: 1, IntentCount: 0, IntentAge: 0, GCBytesAge: 0, SysBytes: 55, SysCount: 1, LastUpdateNanos: 0}
 	verifyRangeStats(tc.engine, tc.rng.Desc().RangeID, expMS, t)
 
 	// Put a 2nd value transactionally.
@@ -2671,7 +2671,7 @@ func TestRangeStatsComputation(t *testing.T) {
 	if _, err := client.SendWrappedWith(tc.Sender(), tc.rng.context(), roachpb.Header{Txn: txn}, &pArgs); err != nil {
 		t.Fatal(err)
 	}
-	expMS = engine.MVCCStats{LiveBytes: 118, KeyBytes: 32, ValBytes: 86, IntentBytes: 22, LiveCount: 2, KeyCount: 2, ValCount: 2, IntentCount: 1, IntentAge: 0, GCBytesAge: 0, SysBytes: 57, SysCount: 1, LastUpdateNanos: 0}
+	expMS = engine.MVCCStats{LiveBytes: 114, KeyBytes: 28, ValBytes: 86, IntentBytes: 22, LiveCount: 2, KeyCount: 2, ValCount: 2, IntentCount: 1, IntentAge: 0, GCBytesAge: 0, SysBytes: 55, SysCount: 1, LastUpdateNanos: 0}
 	verifyRangeStats(tc.engine, tc.rng.Desc().RangeID, expMS, t)
 
 	// Resolve the 2nd value.
@@ -2686,7 +2686,7 @@ func TestRangeStatsComputation(t *testing.T) {
 	if _, err := client.SendWrapped(tc.Sender(), tc.rng.context(), rArgs); err != nil {
 		t.Fatal(err)
 	}
-	expMS = engine.MVCCStats{LiveBytes: 52, KeyBytes: 32, ValBytes: 20, IntentBytes: 0, LiveCount: 2, KeyCount: 2, ValCount: 2, IntentCount: 0, IntentAge: 0, GCBytesAge: 0, SysBytes: 57, SysCount: 1, LastUpdateNanos: 0}
+	expMS = engine.MVCCStats{LiveBytes: 48, KeyBytes: 28, ValBytes: 20, IntentBytes: 0, LiveCount: 2, KeyCount: 2, ValCount: 2, IntentCount: 0, IntentAge: 0, GCBytesAge: 0, SysBytes: 55, SysCount: 1, LastUpdateNanos: 0}
 	verifyRangeStats(tc.engine, tc.rng.Desc().RangeID, expMS, t)
 
 	// Delete the 1st value.
@@ -2695,7 +2695,7 @@ func TestRangeStatsComputation(t *testing.T) {
 	if _, err := client.SendWrapped(tc.Sender(), tc.rng.context(), &dArgs); err != nil {
 		t.Fatal(err)
 	}
-	expMS = engine.MVCCStats{LiveBytes: 26, KeyBytes: 44, ValBytes: 20, IntentBytes: 0, LiveCount: 1, KeyCount: 2, ValCount: 3, IntentCount: 0, IntentAge: 0, GCBytesAge: 0, SysBytes: 57, SysCount: 1, LastUpdateNanos: 0}
+	expMS = engine.MVCCStats{LiveBytes: 24, KeyBytes: 40, ValBytes: 20, IntentBytes: 0, LiveCount: 1, KeyCount: 2, ValCount: 3, IntentCount: 0, IntentAge: 0, GCBytesAge: 0, SysBytes: 55, SysCount: 1, LastUpdateNanos: 0}
 	verifyRangeStats(tc.engine, tc.rng.Desc().RangeID, expMS, t)
 }
 


### PR DESCRIPTION
MVCC keys are now encoded as
`<key>[<walltime>[<logical>]]<#timestamp-bytes>`. A custom RocksDB
comparator is used since this encoding does not maintain the desire
lexicographic ordering. On the plus side, we do not need to escape NUL
characters in `<key>`, nor do we need the `\x00\x01` terminator. We are
also skip encoding the logical portion of the timestamp when it is equal
to 0.

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/3399)

<!-- Reviewable:end -->
