### PR TITLE
[UI] Better stats overview for nodes and stores

### DIFF
--- a/ui/styl/modules/palette.styl
+++ b/ui/styl/modules/palette.styl
@@ -56,6 +56,8 @@ $secondary-blue   = #4E9FD1 // Text Link, Chart Color
 $secondary-teal   = #47E2AA // Chart Color
 $secondary-purple = #D77FBF // Chart Color
 
+$secondary-red    = #ED7785 // Status: Missing/Error
+
 // Secondary nav colors
 $secondary-slate-gray = #7C8495 // Secondary Navigation
 $secondary-light-gray = #A6A6B2 // Secondary Headers
@@ -75,5 +77,3 @@ $secondary-gray-6  = #5F6C87 // table headers
 $secondary-gray-7  = #F5F6F7 // table alt color
 $secondary-gray-8  = #E3E3E3 // table border
 $secondary-green-1 = #66AA26 // subnav active
-
-

--- a/ui/styl/partials/layout.styl
+++ b/ui/styl/partials/layout.styl
@@ -66,6 +66,15 @@ body
     margin 0
     padding 0
 
+  h1
+    font-family Lato-Medium
+    font-size 23px
+    color $main-navy
+    margin-top 10px
+    margin-bottom 10px
+    font-weight normal
+
+
 .topbar
   padding 0 3rem 1rem
   background-color white
@@ -119,3 +128,11 @@ a.toggle
   font-size 1rem
   color $secondary-light-gray
 
+.status
+  font-size 9px
+  &.missing
+    color $secondary-red
+  &.stale
+    color $secondary-gold
+  &.healthy
+    color $main-green

--- a/ui/styl/partials/navigation-bar.styl
+++ b/ui/styl/partials/navigation-bar.styl
@@ -90,7 +90,7 @@ header
       a
         width 100%
         height 80px
-        padding 20px
+        padding 20px 0
         display block
         color inherit
         text-decoration none
@@ -122,7 +122,7 @@ header
         color $subnav-active-color
         font-weight 600
         border-bottom $subnav-underline-height solid $subnav-active-color
-        
+
       &:hover
         color $main-nav-hover
       a

--- a/ui/styl/partials/table.styl
+++ b/ui/styl/partials/table.styl
@@ -28,7 +28,7 @@ $stats-table-th--bg     = white
 $stats-table-tr--bg     = white
 $stats-table-tr--bg-alt = $secondary-gray-7
 
-// ---- Data table ---- 
+// ---- Data table ----
 .stats-table, .sql-table
   color -color('dark')
   table
@@ -36,12 +36,20 @@ $stats-table-tr--bg-alt = $secondary-gray-7
     margin-bottom 2rem
 
   thead
-    border $stats-table-cell--border
-    border-left none
-
     tr
-      height 71px
+      border $stats-table-cell--border
+      border-left none
+      height 30px
       vertical-align top
+      &.header-section
+        height 30px
+      &.column
+        border-bottom none
+      &.rollup
+        border-top none
+      &:last-child
+        th
+          padding-bottom 15px
 
   tbody tr
       height 45px
@@ -50,6 +58,8 @@ $stats-table-tr--bg-alt = $secondary-gray-7
         background-color $stats-table-tr--bg-alt
       &:last-child
         border-bottom $stats-table-cell--border
+      &:first-child
+        border-top $stats-table-cell--border
 
   th
     color $stats-table-th--fg
@@ -59,6 +69,25 @@ $stats-table-tr--bg-alt = $secondary-gray-7
     font-weight normal
     text-align left
     background-color $stats-table-th--bg
+    white-space nowrap
+    &.column
+      border-bottom none
+
+    &.header-section
+      font-size 12px
+      font-family Lato-Medium
+      letter-spacing 2px
+      text-transform uppercase
+      color $secondary-light-gray
+      padding 10px 20px
+
+    &.rollup
+      border-top none
+      font-family Lato-Medium
+      color $main-navy
+      font-size 19px
+      padding-top 0
+
     &.sorted
       &:after
         content "▼"
@@ -71,11 +100,23 @@ $stats-table-tr--bg-alt = $secondary-gray-7
     font-family Lato-Medium
     font-size 16px
     letter-spacing .33px
+    white-space nowrap
 
   td
   th
-    padding 15px 20px
+    padding 10px 20px 0
     border-right $stats-table-cell--border
+    .missing
+      color $secondary-red
+    .stale
+      color $secondary-gold
+    .healthy
+      color $main-green
+
+table
+  a
+    color $main-green
+    text-decoration none
 
 .sql-table
   thead

--- a/ui/styl/partials/visualizations.styl
+++ b/ui/styl/partials/visualizations.styl
@@ -36,6 +36,10 @@ $viz-sides = 62px
   width 323px
   height 289px
 
+  .linegraph
+    padding 0 60px
+    height 175px
+
 .viz-top
   height $viz-top
   display block
@@ -56,8 +60,6 @@ $viz-sides = 62px
     letter-spacing 2px
     color $secondary-light-gray
 
-
-
 .visualization
   height 100%
   width 100%
@@ -72,4 +74,3 @@ $viz-sides = 62px
     width 100%
     text-align center
     display block
-

--- a/ui/ts/components/metrics.ts
+++ b/ui/ts/components/metrics.ts
@@ -54,7 +54,8 @@ module Components {
           .showLegend(true)
           .showYAxis(true)
           .showXAxis(true)
-          .xScale(d3.time.scale());
+          .xScale(d3.time.scale())
+          .margin({top: 0, right: 0, bottom: 0, left: 0});
 
         constructor(public vm: ViewModel) {
           // Set xAxis ticks to properly format.
@@ -134,11 +135,21 @@ module Components {
       }
 
       export function view(ctrl: Controller): _mithril.MithrilVirtualElement {
+        let g: _mithril.MithrilVirtualElement = null;
         if (ctrl.hasData()) {
-          return m(".linegraph", { style: "width:500px;height:300px;" }, m("svg.graph", { config: ctrl.drawGraph }));
+          g = m(".linegraph", m("svg.graph", { config: ctrl.drawGraph }));
         } else {
-          return m("", "loading...");
+          g = m("", "loading...");
         }
+        return m(
+          ".visualization-wrapper",
+          [
+            // TODO: pass in and display info icon tooltip
+            m(".viz-top", m(".viz-info-icon", m(".icon-cockroach-17"))), // Icon Cockroach 17 is the info icon.
+            g,
+            m(".viz-bottom", m(".viz-title", ctrl.vm.axis.title())),
+          ]
+        );
       }
 
       /**
@@ -157,4 +168,3 @@ module Components {
     }
   }
 }
-

--- a/ui/ts/pages/navigation.ts
+++ b/ui/ts/pages/navigation.ts
@@ -34,6 +34,11 @@ module AdminViews {
             liClass: "cockroach",
           },
           {
+            title: "Cluster",
+            route: "/cluster", // TODO: currently goes to node page, create cluster page
+            icon: SvgIcons.clusterIcon,
+          },
+          {
             title: "Nodes",
             route: "/nodes",
             icon: SvgIcons.nodesIcon,

--- a/ui/ts/pages/nodes.ts
+++ b/ui/ts/pages/nodes.ts
@@ -27,6 +27,8 @@ module AdminViews {
     import Metrics = Models.Metrics;
     import Table = Components.Table;
     import NodeStatus = Models.Proto.NodeStatus;
+    import Moment = moment.Moment;
+    import MithrilVirtualElement = _mithril.MithrilVirtualElement;
 
     let nodeStatuses: Models.Status.Nodes = new Models.Status.Nodes();
 
@@ -34,19 +36,58 @@ module AdminViews {
       return "cr.node." + metric;
     }
 
+    function _storeMetric(metric: string): string {
+      return "cr.store." + metric;
+    }
+
+    function _sysMetric(metric: string): string {
+      return "cr.node.sys." + metric;
+    }
+
     /**
      * NodesPage show a list of all the available nodes.
      */
     export module NodesPage {
       import MithrilComponent = _mithril.MithrilComponent;
+      import bytesAndCountReducer = Models.Status.bytesAndCountReducer;
+      import sumReducer = Models.Status.sumReducer;
+      import BytesAndCount = Models.Status.BytesAndCount;
+
       class Controller {
+        private static _queryEveryMS: number = 10000;
+
         private static comparisonColumns: Table.TableColumn<NodeStatus>[] = [
+          {
+            title: "",
+            view: (status: NodeStatus): MithrilVirtualElement => {
+              let lastUpdate: Moment = moment(Utils.Convert.NanoToMilli(status.stats.last_update_nanos));
+              let s: string = Models.Status.staleStatus(lastUpdate);
+              return m("div.status.icon-cockroach-15." + s); // icon 15 is a circle
+            },
+            sortable: true,
+          },
           {
             title: "Node ID",
             view: (status: NodeStatus): MithrilElement =>
               m("a", {href: "/nodes/" + status.desc.node_id, config: m.route}, status.desc.node_id.toString()),
             sortable: true,
             sortValue: (status: NodeStatus): number => status.desc.node_id,
+            rollup: function(rows: NodeStatus[]): MithrilVirtualElement {
+              interface StatusTotals {
+                missing?: number;
+                stale?: number;
+                healthy?: number;
+              }
+              let statuses: StatusTotals = _.countBy(rows, (row: NodeStatus) => Models.Status.staleStatus(moment(Utils.Convert.NanoToMilli(row.stats.last_update_nanos))));
+
+              return m("node-counts", [
+                m("span.healthy", statuses.healthy || 0),
+                m("span", "/"),
+                m("span.stale", statuses.stale || 0),
+                m("span", "/"),
+                m("span.missing", statuses.missing || 0),
+              ]);
+            },
           },
           {
             title: "Address",
@@ -63,9 +104,93 @@ module AdminViews {
           },
           {
             title: "Live Bytes",
-            view: (status: NodeStatus): string => Utils.Format.Bytes(status.stats.live_bytes),
+            view: (status: NodeStatus): string =>
+              status.stats.live_count + " (" + Utils.Format.Bytes(status.stats.live_bytes) + ")",
             sortable: true,
             sortValue: (status: NodeStatus): number => status.stats.live_bytes,
+            rollup: function(rows: NodeStatus[]): string {
+              let total: BytesAndCount = bytesAndCountReducer("stats.live_bytes", "stats.live_count", rows);
+              return Utils.Format.Bytes(total.bytes) + " (" + total.count + ")";
+            },
+            section: "storage",
+          },
+          {
+            title: "Key Bytes",
+            view: (status: NodeStatus): string =>
+              status.stats.key_count + " (" + Utils.Format.Bytes(status.stats.key_bytes) + ")",
+            sortable: true,
+            sortValue: (status: NodeStatus): number => status.stats.key_bytes,
+            rollup: function(rows: NodeStatus[]): string {
+              let total: BytesAndCount = bytesAndCountReducer("stats.key_bytes", "stats.key_count", rows);
+              return Utils.Format.Bytes(total.bytes) + " (" + total.count + ")";
+            },
+            section: "storage",
+          },
+          {
+            title: "Value Bytes",
+            view: (status: NodeStatus): string =>
+              status.stats.val_count + " (" + Utils.Format.Bytes(status.stats.val_bytes) + ")",
+            sortable: true,
+            sortValue: (status: NodeStatus): number => status.stats.val_bytes,
+            rollup: function(rows: NodeStatus[]): string {
+              let total: BytesAndCount = bytesAndCountReducer("stats.val_bytes", "stats.val_count", rows);
+              return Utils.Format.Bytes(total.bytes) + " (" + total.count + ")";
+            },
+            section: "storage",
+          },
+          {
+            title: "Intent Bytes",
+            view: (status: NodeStatus): string =>
+              status.stats.intent_count + " (" + Utils.Format.Bytes(status.stats.intent_bytes) + ")",
+            sortable: true,
+            sortValue: (status: NodeStatus): number => status.stats.intent_bytes,
+            rollup: function(rows: NodeStatus[]): string {
+              let total: BytesAndCount = bytesAndCountReducer("stats.intent_bytes", "stats.intent_count", rows);
+              return Utils.Format.Bytes(total.bytes) + " (" + total.count + ")";
+            },
+            section: "storage",
+          },
+          {
+            title: "System Bytes",
+            view: (status: NodeStatus): string =>
+              status.stats.sys_count + " (" + Utils.Format.Bytes(status.stats.sys_bytes) + ")",
+            sortable: true,
+            sortValue: (status: NodeStatus): number => status.stats.sys_bytes,
+            rollup: function(rows: NodeStatus[]): string {
+              let total: BytesAndCount = bytesAndCountReducer("stats.sys_bytes", "stats.sys_count", rows);
+              return Utils.Format.Bytes(total.bytes) + " (" + total.count + ")";
+            },
+            section: "storage",
+          },
+          {
+            title: "Leader Ranges",
+            view: (status: NodeStatus): string => status.leader_range_count.toString(),
+            sortable: true,
+            sortValue: (status: NodeStatus): number => status.leader_range_count,
+            rollup: function(rows: NodeStatus[]): string {
+              return sumReducer("leader_range_count", rows).toString();
+            },
+            section: "ranges",
+          },
+          {
+            title: "Replicated Ranges",
+            view: (status: NodeStatus): string => status.replicated_range_count.toString(),
+            sortable: true,
+            sortValue: (status: NodeStatus): number => status.replicated_range_count,
+            rollup: function(rows: NodeStatus[]): string {
+              return sumReducer("replicated_range_count", rows).toString();
+            },
+            section: "ranges",
+          },
+          {
+            title: "Available Ranges",
+            view: (status: NodeStatus): string => status.available_range_count.toString(),
+            sortable: true,
+            sortValue: (status: NodeStatus): number => status.available_range_count,
+            rollup: function(rows: NodeStatus[]): string {
+              return sumReducer("available_range_count", rows).toString();
+            },
+            section: "ranges",
           },
           {
             title: "Logs",
@@ -74,12 +199,44 @@ module AdminViews {
           },
         ];
 
-        private static _queryEveryMS: number = 10000;
-
         public columns: Utils.Property<Table.TableColumn<NodeStatus>[]> = Utils.Prop(Controller.comparisonColumns);
+        public sources: string[] = [];
+        exec: Metrics.Executor;
+        axes: Metrics.Axis[] = [];
         private _interval: number;
+        private _query: Metrics.Query;
 
         public constructor(nodeId?: string) {
+          this._query = Metrics.NewQuery();
+          this._addChart(
+            Metrics.NewAxis(
+              Metrics.Select.Avg(_storeMetric("ranges.available"))
+                .sources(this.sources)
+                .title("% Available Ranges")
+              ));
+
+          this._addChart(
+            Metrics.NewAxis(
+              Metrics.Select.AvgRate(_nodeMetric("calls.error"))
+                .sources(this.sources)
+                .title("Error Calls")
+              ));
+
+          this._addChart(
+            Metrics.NewAxis(
+              Metrics.Select.Avg(_storeMetric("livebytes"))
+                .sources(this.sources) // TODO: store sources vs node sources
+                .title("Live Bytes")
+              ));
+
+          this._addChart(
+            Metrics.NewAxis(
+              Metrics.Select.Avg(_sysMetric("cpu.user.percent"))
+                .sources(this.sources) // TODO: store sources vs node sources
+                .title("CPU User %")
+              ));
+
+          this.exec = new Metrics.Executor(this._query);
           this._refresh();
           this._interval = window.setInterval(() => this._refresh(), Controller._queryEveryMS);
         }
@@ -140,8 +297,20 @@ module AdminViews {
           return m(".primary-stats");
         }
 
+        public RenderGraphs(): MithrilElement {
+          return m(".charts", this.axes.map((axis: Metrics.Axis) => {
+            return m("", { style: "float:left" }, Components.Metrics.LineGraph.create(this.exec, axis));
+          }));
+        }
+
         private _refresh(): void {
+          this.exec.refresh();
           nodeStatuses.refresh();
+        }
+
+        private _addChart(axis: Metrics.Axis): void {
+          axis.selectors().forEach((s: Metrics.Select.Selector) => this._query.selectors().push(s));
+          this.axes.push(axis);
         }
       }
 
@@ -150,6 +319,13 @@ module AdminViews {
       }
 
       export function view(ctrl: Controller): MithrilElement {
+        // set
+        ctrl.sources = _.map(
+          nodeStatuses.allStatuses(),
+          function(v: NodeStatus): string {
+            return v.desc.node_id.toString();
+          }
+        );
         let comparisonData: Table.TableData<NodeStatus> = {
           columns: ctrl.columns,
           rows: nodeStatuses.allStatuses,
@@ -157,8 +333,11 @@ module AdminViews {
 
         let mostRecentlyUpdated: number = _.max(_.map(nodeStatuses.allStatuses(), (s: NodeStatus) => s.updated_at ));
         return m(".page", [
-          m.component(Components.Topbar, {title: "Nodes", updated: mostRecentlyUpdated }),
-          m(".section", ctrl.RenderPrimaryStats()),
+          m.component(Components.Topbar, {title: "Nodes", updated: mostRecentlyUpdated}),
+          m(".section", [
+            m(".subtitle", m("h1", "Node Overview")),
+            ctrl.RenderGraphs(),
+          ]),
           m(".section.table", m(".stats-table", Components.Table.create(comparisonData))),
         ]);
       }

--- a/ui/ts/pages/stores.ts
+++ b/ui/ts/pages/stores.ts
@@ -26,6 +26,9 @@ module AdminViews {
     import Metrics = Models.Metrics;
     import Table = Components.Table;
     import StoreStatus = Models.Proto.StoreStatus;
+    import Moment = moment.Moment;
+    import MithrilVirtualElement = _mithril.MithrilVirtualElement;
+
     let storeStatuses: Models.Status.Stores = new Models.Status.Stores();
 
     function _storeMetric(metric: string): string {
@@ -38,8 +41,21 @@ module AdminViews {
     export module StoresPage {
       import Topbar = Components.Topbar;
       import MithrilComponent = _mithril.MithrilComponent;
+      import bytesAndCountReducer = Models.Status.bytesAndCountReducer;
+      import BytesAndCount = Models.Status.BytesAndCount;
+
       class Controller {
+        private static _queryEveryMS: number = 10000;
         private static comparisonColumns: Table.TableColumn<StoreStatus>[] = [
+          {
+            title: "",
+            view: (status: StoreStatus): MithrilVirtualElement => {
+              let lastUpdate: Moment = moment(Utils.Convert.NanoToMilli(status.stats.last_update_nanos));
+              let s: string = Models.Status.staleStatus(lastUpdate);
+              return m("div.status.icon-cockroach-15." + s); // icon 15 is a circle
+            },
+            sortable: true,
+          },
           {
             title: "Store ID",
             view: (status: StoreStatus): MithrilElement => {
@@ -47,6 +63,22 @@ module AdminViews {
             },
             sortable: true,
             sortValue: (status: StoreStatus): number => status.desc.store_id,
+            rollup: function(rows: StoreStatus[]): MithrilVirtualElement {
+              interface StatusTotals {
+                missing?: number;
+                stale?: number;
+                healthy?: number;
+              }
+              let statuses: StatusTotals = _.countBy(rows, (row: StoreStatus) => Models.Status.staleStatus(moment(Utils.Convert.NanoToMilli(row.stats.last_update_nanos))));
+
+              return m("node-counts", [
+                m("span.healthy", statuses.healthy || 0),
+                m("span", "/"),
+                m("span.stale", statuses.stale || 0),
+                m("span", "/"),
+                m("span.missing", statuses.missing || 0),
+              ]);
+            },
           },
           {
             title: "Node ID",
@@ -70,18 +102,127 @@ module AdminViews {
             sortable: true,
           },
           {
-            title: "Live Bytes",
-            view: (status: StoreStatus): string => Utils.Format.Bytes(status.stats.live_bytes),
+            title: "Live Count (Bytes)",
+            view: (status: StoreStatus): string =>
+              status.stats.live_count + " (" + Utils.Format.Bytes(status.stats.live_bytes) + ")",
             sortable: true,
             sortValue: (status: StoreStatus): number => status.stats.live_bytes,
+            rollup: function(rows: StoreStatus[]): string {
+              let total: BytesAndCount = bytesAndCountReducer("stats.live_bytes", "stats.live_count", rows);
+              return Utils.Format.Bytes(total.bytes) + " (" + total.count + ")";
+            },
+            section: "storage",
+          },
+          {
+            title: "Key Count (Bytes)",
+            view: (status: StoreStatus): string =>
+              status.stats.key_count + " (" + Utils.Format.Bytes(status.stats.key_bytes) + ")",
+            sortable: true,
+            sortValue: (status: StoreStatus): number => status.stats.key_bytes,
+            rollup: function(rows: StoreStatus[]): string {
+              let total: BytesAndCount = bytesAndCountReducer("stats.key_bytes", "stats.key_count", rows);
+              return Utils.Format.Bytes(total.bytes) + " (" + total.count + ")";
+            },
+            section: "storage",
+          },
+          {
+            title: "Value Count (Bytes)",
+            view: (status: StoreStatus): string =>
+              status.stats.val_count + " (" + Utils.Format.Bytes(status.stats.val_bytes) + ")",
+            sortable: true,
+            sortValue: (status: StoreStatus): number => status.stats.val_bytes,
+            rollup: function(rows: StoreStatus[]): string {
+              let total: BytesAndCount = bytesAndCountReducer("stats.val_bytes", "stats.val_count", rows);
+              return Utils.Format.Bytes(total.bytes) + " (" + total.count + ")";
+            },
+            section: "storage",
+          },
+          {
+            title: "Intent Count (Bytes)",
+            view: (status: StoreStatus): string =>
+              status.stats.intent_count + " (" + Utils.Format.Bytes(status.stats.intent_bytes) + ")",
+            sortable: true,
+            sortValue: (status: StoreStatus): number => status.stats.intent_bytes,
+            rollup: function(rows: StoreStatus[]): string {
+              let total: BytesAndCount = bytesAndCountReducer("stats.intent_bytes", "stats.intent_count", rows);
+              return Utils.Format.Bytes(total.bytes) + " (" + total.count + ")";
+            },
+            section: "storage",
+          },
+          {
+            title: "System Count (Bytes)",
+            view: (status: StoreStatus): string =>
+              status.stats.sys_count + " (" + Utils.Format.Bytes(status.stats.sys_bytes) + ")",
+            sortable: true,
+            sortValue: (status: StoreStatus): number => status.stats.sys_bytes,
+            rollup: function(rows: StoreStatus[]): string {
+              let total: BytesAndCount = bytesAndCountReducer("stats.sys_bytes", "stats.sys_count", rows);
+              return Utils.Format.Bytes(total.bytes) + " (" + total.count + ")";
+            },
+            section: "storage",
           },
         ];
 
-        private static _queryEveryMS: number = 10000;
+        public sources: string[] = [];
         public columns: Utils.Property<Table.TableColumn<StoreStatus>[]> = Utils.Prop(Controller.comparisonColumns);
+        exec: Metrics.Executor;
+        axes: Metrics.Axis[] = [];
+        private _query: Metrics.Query;
         private _interval: number;
 
         public constructor(nodeId?: string) {
+          this._query = Metrics.NewQuery();
+          this._addChart(
+            Metrics.NewAxis(
+              Metrics.Select.Avg(_storeMetric("keycount"))
+                .sources(this.sources)
+                .title("Key Count")
+              )
+              .label("Count")
+            );
+          this._addChart(
+            Metrics.NewAxis(
+              Metrics.Select.Avg(_storeMetric("livecount"))
+                .sources(this.sources)
+                .title("Live Value Count")
+              )
+              .label("Count")
+            );
+          this._addChart(
+            Metrics.NewAxis(
+              Metrics.Select.Avg(_storeMetric("valcount"))
+                .sources(this.sources)
+                .title("Total Value Count")
+              )
+              .label("Count")
+            );
+          this._addChart(
+            Metrics.NewAxis(
+              Metrics.Select.Avg(_storeMetric("intentcount"))
+                .sources(this.sources)
+                .title("Intent Count")
+              )
+              .label("Count")
+            );
+          this._addChart(
+            Metrics.NewAxis(
+              Metrics.Select.Avg(_storeMetric("ranges"))
+                .sources(this.sources)
+                .title("Range Count")
+              )
+              .label("Count")
+            );
+          this._addChart(
+            Metrics.NewAxis(
+              Metrics.Select.Avg(_storeMetric("livebytes"))
+                .sources(this.sources)
+                .title("Live Bytes")
+              )
+              .label("Bytes")
+              .format(Utils.Format.Bytes)
+            );
+
+          this.exec = new Metrics.Executor(this._query);
           this._refresh();
           this._interval = window.setInterval(() => this._refresh(), Controller._queryEveryMS);
         }
@@ -142,8 +283,20 @@ module AdminViews {
           return m(".primary-stats");
         }
 
+        public RenderGraphs(): MithrilElement {
+          return m(".charts", this.axes.map((axis: Metrics.Axis) => {
+            return m("", { style: "float:left" }, Components.Metrics.LineGraph.create(this.exec, axis));
+          }));
+        }
+
         private _refresh(): void {
+          this.exec.refresh();
           storeStatuses.refresh();
+        }
+
+        private _addChart(axis: Metrics.Axis): void {
+          axis.selectors().forEach((s: Metrics.Select.Selector) => this._query.selectors().push(s));
+          this.axes.push(axis);
         }
       }
 
@@ -152,6 +305,12 @@ module AdminViews {
       }
 
       export function view(ctrl: Controller): MithrilElement {
+        ctrl.sources = _.map(
+          storeStatuses.allStatuses(),
+          function(v: StoreStatus): string {
+            return v.desc.node.node_id.toString();
+          }
+        );
         let comparisonData: Table.TableData<StoreStatus> = {
           columns: ctrl.columns,
           rows: storeStatuses.allStatuses,
@@ -159,8 +318,8 @@ module AdminViews {
 
         let mostRecentlyUpdated: number = _.max(_.map(storeStatuses.allStatuses(), (s: StoreStatus) => s.updated_at ));
         return m(".page", [
-          m.component(Topbar, {title: "Stores", updated: mostRecentlyUpdated}),
-          m(".section", ctrl.RenderPrimaryStats()),
+          m.component(Topbar, {title: "Stores", updated: mostRecentlyUpdated }),
+          m(".section", ctrl.RenderGraphs()),
           m(".section.table", m(".stats-table", Components.Table.create(comparisonData))),
         ]);
       }


### PR DESCRIPTION
- Added new stats and a rollup to the nodes and stores pages
- moved graphs into the nodes and stores overview pages
- added cluster icon

Old page:
![screen shot 2015-12-10 at 4 50 16 pm](https://cloud.githubusercontent.com/assets/3691886/11729648/3dcd9a84-9f5e-11e5-92ab-9276c3e13671.png)

New page:
![screen shot 2015-12-10 at 4 47 03 pm](https://cloud.githubusercontent.com/assets/3691886/11729647/3dc9db24-9f5e-11e5-87a9-3a2066db9604.png)

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/3401)

<!-- Reviewable:end -->
