### PR TITLE
Fix (hopefully) TestSnapshotMethods and other mysterious failures.

### DIFF
--- a/storage/engine/engine_test.go
+++ b/storage/engine/engine_test.go
@@ -589,6 +589,11 @@ func TestSnapshotMethods(t *testing.T) {
 			if err := engine.Put(keys[i], vals[i]); err != nil {
 				t.Fatal(err)
 			}
+			if val, err := engine.Get(keys[i]); err != nil {
+				t.Fatal(err)
+			} else if !bytes.Equal(vals[i], val) {
+				t.Fatalf("expected %s, but found %s", vals[i], val)
+			}
 		}
 		snap := engine.NewSnapshot()
 		defer snap.Close()
@@ -609,13 +614,15 @@ func TestSnapshotMethods(t *testing.T) {
 		}
 
 		// Verify Get.
-		valSnapshot, err := snap.Get(keys[0])
-		if err != nil {
-			t.Fatal(err)
-		}
-		if !bytes.Equal(vals[0], valSnapshot) {
-			t.Fatalf("the value %s in get result does not match the value %s in snapshot",
-				vals[0], valSnapshot)
+		for i := range keys {
+			valSnapshot, err := snap.Get(keys[i])
+			if err != nil {
+				t.Fatal(err)
+			}
+			if !bytes.Equal(vals[i], valSnapshot) {
+				t.Fatalf("the value %s in get result does not match the value %s in snapshot",
+					vals[i], valSnapshot)
+			}
 		}
 
 		// Verify Scan.


### PR DESCRIPTION
The string returned by EncodeKey() is a temporary, so it needs to be
stored in a string variable if it is going to outlive the statement it
was performed in.

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/3405)

<!-- Reviewable:end -->
