### PR TITLE
sql: hide auto-created rowid column

### DIFF
--- a/sql/backfill.go
+++ b/sql/backfill.go
@@ -151,7 +151,7 @@ func (p *planner) backfillBatch(b *client.Batch, oldTableDesc, newTableDesc *Tab
 			desc:    oldTableDesc,
 		}
 		scan.initDescDefaults()
-		rows, err := p.selectWithScan(scan, &parser.Select{Exprs: parser.SelectExprs{parser.StarSelectExpr()}})
+		rows, err := p.selectWithScan(scan, &parser.Select{Exprs: oldTableDesc.allColumnsSelector()})
 		if err != nil {
 			return err
 		}

--- a/sql/create.go
+++ b/sql/create.go
@@ -136,6 +136,7 @@ func (p *planner) CreateTable(n *parser.CreateTable) (planNode, error) {
 				Kind: ColumnType_INT,
 			},
 			DefaultExpr: &s,
+			Hidden:      true,
 		}
 		desc.AddColumn(col)
 		idx := IndexDescriptor{

--- a/sql/delete.go
+++ b/sql/delete.go
@@ -42,7 +42,7 @@ func (p *planner) Delete(n *parser.Delete) (planNode, error) {
 	// TODO(tamird,pmattis): avoid going through Select to avoid encoding
 	// and decoding keys.
 	rows, err := p.Select(&parser.Select{
-		Exprs: parser.SelectExprs{parser.StarSelectExpr()},
+		Exprs: tableDesc.allColumnsSelector(),
 		From:  parser.TableExprs{n.Table},
 		Where: n.Where,
 	})

--- a/sql/insert.go
+++ b/sql/insert.go
@@ -243,7 +243,7 @@ func (p *planner) Insert(n *parser.Insert) (planNode, error) {
 func (p *planner) processColumns(tableDesc *TableDescriptor,
 	node parser.QualifiedNames) ([]ColumnDescriptor, error) {
 	if node == nil {
-		return tableDesc.Columns, nil
+		return tableDesc.VisibleColumns(), nil
 	}
 
 	cols := make([]ColumnDescriptor, len(node))

--- a/sql/parser/select.go
+++ b/sql/parser/select.go
@@ -96,9 +96,9 @@ type SelectExpr struct {
 	As   Name
 }
 
-// StarSelectExpr is a convenience function that represents an unqualified "*"
+// starSelectExpr is a convenience function that represents an unqualified "*"
 // in a select expression.
-func StarSelectExpr() SelectExpr {
+func starSelectExpr() SelectExpr {
 	return SelectExpr{Expr: StarExpr()}
 }
 

--- a/sql/parser/sql.go
+++ b/sql/parser/sql.go
@@ -5275,7 +5275,7 @@ sqldefault:
 		//line sql.y:1675
 		{
 			sqlVAL.selectStmt = &Select{
-				Exprs:       SelectExprs{StarSelectExpr()},
+				Exprs:       SelectExprs{starSelectExpr()},
 				From:        TableExprs{&AliasedTableExpr{Expr: sqlDollar[2].qname}},
 				tableSelect: true,
 			}
@@ -7358,7 +7358,7 @@ sqldefault:
 		sqlDollar = sqlS[sqlpt-1 : sqlpt+1]
 		//line sql.y:3346
 		{
-			sqlVAL.selExpr = StarSelectExpr()
+			sqlVAL.selExpr = starSelectExpr()
 		}
 	case 659:
 		sqlDollar = sqlS[sqlpt-1 : sqlpt+1]

--- a/sql/parser/sql.y
+++ b/sql/parser/sql.y
@@ -1674,7 +1674,7 @@ simple_select:
 | TABLE relation_expr
   {
     $$ = &Select{
-      Exprs:       SelectExprs{StarSelectExpr()},
+      Exprs:       SelectExprs{starSelectExpr()},
       From:        TableExprs{&AliasedTableExpr{Expr: $2}},
       tableSelect: true,
     }
@@ -3344,7 +3344,7 @@ target_elem:
   }
 | '*'
   {
-    $$ = StarSelectExpr()
+    $$ = starSelectExpr()
   }
 
 // Names and constants.

--- a/sql/scan.go
+++ b/sql/scan.go
@@ -499,7 +499,7 @@ func (n *scanNode) addRender(target parser.SelectExpr) error {
 					n.render = append(n.render, qval)
 				}
 			} else {
-				for _, col := range n.desc.Columns {
+				for _, col := range n.desc.VisibleColumns() {
 					qval := n.getQVal(col)
 					n.columns = append(n.columns, column{name: col.Name, typ: qval.datum})
 					n.render = append(n.render, qval)

--- a/sql/structured.go
+++ b/sql/structured.go
@@ -23,6 +23,7 @@ import (
 	"strings"
 
 	"github.com/cockroachdb/cockroach/keys"
+	"github.com/cockroachdb/cockroach/sql/parser"
 	"github.com/cockroachdb/cockroach/util"
 )
 
@@ -561,6 +562,16 @@ func (desc *TableDescriptor) VisibleColumns() []ColumnDescriptor {
 		}
 	}
 	return cols
+}
+
+func (desc *TableDescriptor) allColumnsSelector() parser.SelectExprs {
+	exprs := make(parser.SelectExprs, len(desc.Columns))
+	qnames := make([]parser.QualifiedName, len(desc.Columns))
+	for i, col := range desc.Columns {
+		qnames[i].Base = parser.Name(col.Name)
+		exprs[i].Expr = &qnames[i]
+	}
+	return exprs
 }
 
 // SQLString returns the SQL string corresponding to the type.

--- a/sql/structured.go
+++ b/sql/structured.go
@@ -552,6 +552,17 @@ func (desc *TableDescriptor) addMutation(m DescriptorMutation) {
 	desc.Mutations = append(desc.Mutations, m)
 }
 
+// VisibleColumns returns all non hidden columns.
+func (desc *TableDescriptor) VisibleColumns() []ColumnDescriptor {
+	var cols []ColumnDescriptor
+	for _, col := range desc.Columns {
+		if !col.Hidden {
+			cols = append(cols, col)
+		}
+	}
+	return cols
+}
+
 // SQLString returns the SQL string corresponding to the type.
 func (c *ColumnType) SQLString() string {
 	switch c.Kind {

--- a/sql/structured.pb.go
+++ b/sql/structured.pb.go
@@ -198,6 +198,7 @@ type ColumnDescriptor struct {
 	// Default expression to use to populate the column on insert if no
 	// value is provided.
 	DefaultExpr *string `protobuf:"bytes,5,opt,name=default_expr" json:"default_expr,omitempty"`
+	Hidden      bool    `protobuf:"varint,6,opt,name=hidden" json:"hidden"`
 }
 
 func (m *ColumnDescriptor) Reset()         { *m = ColumnDescriptor{} }
@@ -763,6 +764,14 @@ func (m *ColumnDescriptor) MarshalTo(data []byte) (int, error) {
 		i = encodeVarintStructured(data, i, uint64(len(*m.DefaultExpr)))
 		i += copy(data[i:], *m.DefaultExpr)
 	}
+	data[i] = 0x30
+	i++
+	if m.Hidden {
+		data[i] = 1
+	} else {
+		data[i] = 0
+	}
+	i++
 	return i, nil
 }
 
@@ -1184,6 +1193,7 @@ func (m *ColumnDescriptor) Size() (n int) {
 		l = len(*m.DefaultExpr)
 		n += 1 + l + sovStructured(uint64(l))
 	}
+	n += 2
 	return n
 }
 
@@ -1620,6 +1630,26 @@ func (m *ColumnDescriptor) Unmarshal(data []byte) error {
 			s := string(data[iNdEx:postIndex])
 			m.DefaultExpr = &s
 			iNdEx = postIndex
+		case 6:
+			if wireType != 0 {
+				return fmt.Errorf("proto: wrong wireType = %d for field Hidden", wireType)
+			}
+			var v int
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return ErrIntOverflowStructured
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := data[iNdEx]
+				iNdEx++
+				v |= (int(b) & 0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			m.Hidden = bool(v != 0)
 		default:
 			iNdEx = preIndex
 			skippy, err := skipStructured(data[iNdEx:])

--- a/sql/structured.proto
+++ b/sql/structured.proto
@@ -54,6 +54,7 @@ message ColumnDescriptor {
   // Default expression to use to populate the column on insert if no
   // value is provided.
   optional string default_expr = 5;
+  optional bool hidden = 6 [(gogoproto.nullable) = false];
 }
 
 message IndexDescriptor {

--- a/sql/testdata/no_primary_key
+++ b/sql/testdata/no_primary_key
@@ -64,3 +64,6 @@ a INT true NULL
 b INT true NULL
 rowid INT false experimental_unique_int()
 c STRING true NULL
+
+statement ok
+CREATE INDEX a_idx ON t (a);

--- a/sql/testdata/no_primary_key
+++ b/sql/testdata/no_primary_key
@@ -35,6 +35,32 @@ SELECT count(rowid) FROM t
 statement ok
 ALTER TABLE t ADD c STRING
 
-# TODO(mjibson): should be statement ok
-statement error value type string doesn't match type INT of column "rowid"
+statement ok
 INSERT INTO t VALUES (5, 6, '7')
+
+query IIT
+select * from t rowsort
+----
+1 2 NULL
+1 2 NULL
+3 4 NULL
+5 6 7
+
+statement ok
+SELECT a, b, c, rowid FROM t
+
+statement ok
+INSERT INTO t (a, rowid) VALUES (10, 11)
+
+query I
+SELECT rowid FROM t WHERE a = 10
+----
+11
+
+query TTBT
+SHOW COLUMNS FROM t;
+----
+a INT true NULL
+b INT true NULL
+rowid INT false experimental_unique_int()
+c STRING true NULL

--- a/sql/update.go
+++ b/sql/update.go
@@ -99,8 +99,7 @@ func (p *planner) Update(n *parser.Update) (planNode, error) {
 	// expressions for tuple assignments just as we flattened the column names
 	// above. So "UPDATE t SET (a, b) = (1, 2)" translates into select targets of
 	// "*, 1, 2", not "*, (1, 2)".
-	targets := make(parser.SelectExprs, 0, len(n.Exprs)+1)
-	targets = append(targets, parser.StarSelectExpr())
+	targets := tableDesc.allColumnsSelector()
 	for _, expr := range n.Exprs {
 		if expr.Tuple {
 			switch t := expr.Expr.(type) {


### PR DESCRIPTION
Mark the rowid column (auto created for tables without primary keys) as
hidden, which is a new field of ColumnDescriptor.

Do not use any hidden columns in implied column lists (like SELECT \* or
INSERT with no column listing). The rowid column still shows up in places
like SHOW COLUMNS, and can be manually specified in any operation (SELECT
rowid from t).

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/3408)

<!-- Reviewable:end -->
