### PR TITLE
Use a move constructor for the key passed to DBGetter.

### DIFF
--- a/storage/engine/rocksdb/db.cc
+++ b/storage/engine/rocksdb/db.cc
@@ -901,10 +901,10 @@ struct DBGetter : public Getter {
   rocksdb::ReadOptions const options;
   std::string const key;
 
-  DBGetter(rocksdb::DB *const r, rocksdb::ReadOptions opts, const std::string &k)
+  DBGetter(rocksdb::DB *const r, rocksdb::ReadOptions opts, std::string &&k)
       : rep(r),
         options(opts),
-        key(k) {
+        key(std::move(k)) {
   }
 
   virtual DBStatus Get(DBString* value) {


### PR DESCRIPTION
This moves the memory in the string returned from EncodeKey into the
DBGetter.key field with no allocations or copying.

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/3409)

<!-- Reviewable:end -->
