### PR TITLE
Always pass in updated high water timestamp map when pushing gossip

### DIFF
--- a/gossip/client.go
+++ b/gossip/client.go
@@ -120,10 +120,11 @@ func (c *client) sendGossip(g *Gossip, addr, lAddr util.UnresolvedAddr, done cha
 	}
 
 	args := Request{
-		NodeID: nodeID,
-		Addr:   addr,
-		LAddr:  lAddr,
-		Delta:  delta,
+		NodeID:          nodeID,
+		Addr:            addr,
+		LAddr:           lAddr,
+		Delta:           delta,
+		HighWaterStamps: g.is.getHighWaterStamps(),
 	}
 	reply := Response{}
 	c.rpcClient.Go("Gossip.Gossip", &args, &reply, done)

--- a/gossip/simulation/network.go
+++ b/gossip/simulation/network.go
@@ -154,6 +154,7 @@ func (n *Network) SimulateNetwork(simCallback func(cycle int, network *Network) 
 		}
 		time.Sleep(5 * time.Millisecond)
 	}
+	log.Infof("gossip network simulation: total infos sent=%d, received=%d", n.InfosSent(), n.InfosReceived())
 }
 
 // Stop all servers and gossip nodes.
@@ -191,4 +192,24 @@ func (n *Network) IsNetworkConnected() bool {
 		}
 	}
 	return true
+}
+
+// InfosSent returns the total count of infos sent from all nodes in
+// the network.
+func (n *Network) InfosSent() int {
+	var count int
+	for _, node := range n.Nodes {
+		count += node.Gossip.InfosSent()
+	}
+	return count
+}
+
+// InfosReceived returns the total count of infos received from all
+// nodes in the network.
+func (n *Network) InfosReceived() int {
+	var count int
+	for _, node := range n.Nodes {
+		count += node.Gossip.InfosReceived()
+	}
+	return count
 }


### PR DESCRIPTION
This reduces a lot of unnecessary passing of unfresh infos. By as much
as 3x, though I expect the number to be higher as the number of nodes
increases.

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/3410)

<!-- Reviewable:end -->
