### PR TITLE
Implement execution of schema changes through a state machine.

### DIFF
--- a/sql/descriptor_mutation_test.go
+++ b/sql/descriptor_mutation_test.go
@@ -179,6 +179,8 @@ func TestOperationsWithColumnMutation(t *testing.T) {
 	// The descriptor changes made must have an immediate effect
 	// so disable leases on tables.
 	defer csql.TestDisableTableLeases()()
+	// Disable external processing of mutations.
+	defer csql.TestDisableAsyncSchemaChangeExec()()
 	server, sqlDB, kvDB := setup(t)
 	defer cleanup(server, sqlDB)
 
@@ -357,6 +359,8 @@ func TestOperationsWithIndexMutation(t *testing.T) {
 	defer leaktest.AfterTest(t)
 	// The descriptor changes made must have an immediate effect.
 	defer csql.TestDisableTableLeases()()
+	// Disable external processing of mutations.
+	defer csql.TestDisableAsyncSchemaChangeExec()()
 	server, sqlDB, kvDB := setup(t)
 	defer cleanup(server, sqlDB)
 
@@ -486,6 +490,8 @@ func TestCommandsWithPendingMutations(t *testing.T) {
 	// The descriptor changes made must have an immediate effect
 	// so disable leases on tables.
 	defer csql.TestDisableTableLeases()()
+	// Disable external processing of mutations.
+	defer csql.TestDisableAsyncSchemaChangeExec()()
 	server, sqlDB, kvDB := setup(t)
 	defer cleanup(server, sqlDB)
 

--- a/sql/drop.go
+++ b/sql/drop.go
@@ -121,7 +121,6 @@ func (p *planner) DropIndex(n *parser.DropIndex) (planNode, error) {
 		if err := p.checkPrivilege(tableDesc, privilege.CREATE); err != nil {
 			return nil, err
 		}
-
 		idxName := indexQualifiedName.Index()
 		status, i, err := tableDesc.FindIndexByName(idxName)
 		if err != nil {
@@ -147,6 +146,8 @@ func (p *planner) DropIndex(n *parser.DropIndex) (planNode, error) {
 			}
 		}
 		tableDesc.UpVersion = true
+		mutationID := tableDesc.NextMutationID
+		tableDesc.NextMutationID++
 		if err := tableDesc.Validate(); err != nil {
 			return nil, err
 		}
@@ -154,10 +155,7 @@ func (p *planner) DropIndex(n *parser.DropIndex) (planNode, error) {
 		if err := p.txn.Put(MakeDescMetadataKey(tableDesc.GetID()), wrapDescriptor(tableDesc)); err != nil {
 			return nil, err
 		}
-		// Process mutation synchronously.
-		if err := p.applyMutations(tableDesc); err != nil {
-			return nil, err
-		}
+		p.notifySchemaChange(tableDesc.ID, mutationID)
 	}
 	return &valuesNode{}, nil
 }

--- a/sql/executor.go
+++ b/sql/executor.go
@@ -79,9 +79,9 @@ type Executor struct {
 	systemConfigCond *sync.Cond
 }
 
-// newExecutor creates an Executor and registers a callback on the
+// NewExecutor creates an Executor and registers a callback on the
 // system config.
-func newExecutor(db client.DB, gossip *gossip.Gossip, leaseMgr *LeaseManager, metaRegistry *metric.Registry, stopper *stop.Stopper) *Executor {
+func NewExecutor(db client.DB, gossip *gossip.Gossip, leaseMgr *LeaseManager, metaRegistry *metric.Registry, stopper *stop.Stopper) *Executor {
 	exec := &Executor{
 		db:       db,
 		reCache:  parser.NewRegexpCache(512),
@@ -257,19 +257,41 @@ func (e *Executor) execStmts(sql string, planMaker *planner) driver.Response {
 		if err != nil {
 			result = makeResultFromError(planMaker, err)
 		}
-		resp.Results = append(resp.Results, result)
 		// Release the leases once a transaction is complete.
 		if planMaker.txn == nil {
 			planMaker.releaseLeases(e.db)
-
-			// The previous transaction finished executing some schema changes. Wait for
-			// the schema changes to propagate to all nodes, so that once the executor
-			// returns the new schema are live everywhere. This is not needed for
-			// correctness but is done to make the UI experience/tests predictable.
-			if err := e.waitForCompletedSchemaChangesToPropagate(planMaker); err != nil {
-				log.Warning(err)
+			// Execute any schema changes that were scheduled.
+			if len(planMaker.schemaChangers) > 0 &&
+				// Disable execution in some tests.
+				!disableSyncSchemaChangeExec {
+				retryOpts := retry.Options{
+					InitialBackoff: 20 * time.Millisecond,
+					MaxBackoff:     200 * time.Millisecond,
+					Multiplier:     2,
+				}
+				for _, sc := range planMaker.schemaChangers {
+					sc.db = e.db
+					for r := retry.Start(retryOpts); r.Next(); {
+						if done, err := sc.IsDone(); err != nil {
+							log.Warning(err)
+							break
+						} else if done {
+							break
+						}
+						if err := sc.exec(); err != nil {
+							if err == errExistingSchemaChangeLease {
+								// Try again.
+								continue
+							}
+							// All other errors can be reported.
+							result = makeResultFromError(planMaker, err)
+						}
+						break
+					}
+				}
 			}
 		}
+		resp.Results = append(resp.Results, result)
 	}
 	return resp
 }
@@ -389,15 +411,17 @@ func (e *Executor) execStmt(stmt parser.Statement, planMaker *planner) (driver.R
 
 	// No transaction. Run the command as a retryable block in an
 	// auto-transaction.
-	err := e.db.Txn(func(txn *client.Txn) error {
+	if err := e.db.Txn(func(txn *client.Txn) error {
 		timestamp := time.Now()
 		planMaker.setTxn(txn, timestamp)
 		err := f(timestamp, true)
 		planMaker.resetTxn()
 		return err
-	})
+	}); err != nil {
+		return result, err
+	}
 
-	if testingWaitForMetadata && err == nil {
+	if testingWaitForMetadata {
 		if verify := planMaker.testingVerifyMetadata; verify != nil {
 			// In the case of a multi-statement request, avoid reusing this
 			// callback.
@@ -407,7 +431,7 @@ func (e *Executor) execStmt(stmt parser.Statement, planMaker *planner) (driver.R
 					e.systemConfigCond.Wait()
 				} else {
 					if i == 0 {
-						err = util.Errorf("expected %q to require a gossip update, but it did not", stmt)
+						return result, util.Errorf("expected %q to require a gossip update, but it did not", stmt)
 					} else if i > 1 {
 						log.Infof("%q unexpectedly required %d gossip updates", stmt, i)
 					}
@@ -417,24 +441,7 @@ func (e *Executor) execStmt(stmt parser.Statement, planMaker *planner) (driver.R
 		}
 	}
 
-	return result, err
-}
-
-func (e *Executor) waitForCompletedSchemaChangesToPropagate(planMaker *planner) error {
-	for _, id := range planMaker.completedSchemaChange {
-		retryOpts := retry.Options{
-			InitialBackoff: 20 * time.Millisecond,
-			MaxBackoff:     200 * time.Millisecond,
-			Multiplier:     2,
-		}
-		// Wait until there are no unexpired leases on the previous version
-		// of the table.
-		if _, err := e.leaseMgr.waitForOneVersion(id, retryOpts); err != nil {
-			return err
-		}
-	}
-	planMaker.completedSchemaChange = nil
-	return nil
+	return result, nil
 }
 
 // If we hit an error and there is a pending transaction, rollback

--- a/sql/grant.go
+++ b/sql/grant.go
@@ -43,7 +43,6 @@ func (p *planner) changePrivileges(targets parser.TargetList, grantees parser.Na
 	tableDesc, ok := descriptor.(*TableDescriptor)
 	if ok {
 		tableDesc.UpVersion = true
-		p.applyUpVersion(tableDesc)
 	}
 
 	// Now update the descriptor.
@@ -54,7 +53,7 @@ func (p *planner) changePrivileges(targets parser.TargetList, grantees parser.Na
 		return nil, err
 	}
 	if ok {
-		p.notifyCompletedSchemaChange(tableDesc.ID)
+		p.notifySchemaChange(tableDesc.ID, invalidMutationID)
 	}
 	return &valuesNode{}, nil
 }

--- a/sql/plan.go
+++ b/sql/plan.go
@@ -36,18 +36,11 @@ type planner struct {
 	leases       map[ID]*LeaseState
 	leaseMgr     *LeaseManager
 	systemConfig config.SystemConfig
-	// Keep track of tables that had schema changes that were completed.
-	// The executor has the option to wait on completed schema changes
-	// propagating to all nodes so that future commands use the latest
-	// schema. This is not required for correctness, but it makes the UI
-	// experience/tests predictable.
-	//
-	// TODO(vivek): Well, this is still needed for correctness as
-	// long as the schema change is still executed in one transaction
-	// without a staged process that takes the schema through all the state
-	// changes. Once the staged process is rolled out delete this
-	// TODO comment.
-	completedSchemaChange []ID
+	// List of schema changers (one for each outstanding
+	// schema change) created by commands in a transaction.
+	// The executor commits the transaction and then calls exec()
+	// on these schema changers to roll out the new schema.
+	schemaChangers []SchemaChanger
 
 	testingVerifyMetadata func(config.SystemConfig) error
 
@@ -223,9 +216,15 @@ func (p *planner) getAliasedTableLease(n parser.TableExpr) (*TableDescriptor, er
 	return desc, nil
 }
 
-// notify that the schema change is completed.
-func (p *planner) notifyCompletedSchemaChange(id ID) {
-	p.completedSchemaChange = append(p.completedSchemaChange, id)
+// notify that an outstanding schema change exists for the table.
+func (p *planner) notifySchemaChange(id ID, mutationID MutationID) {
+	p.schemaChangers = append(p.schemaChangers, SchemaChanger{
+		tableID:    id,
+		mutationID: mutationID,
+		nodeID:     p.evalCtx.NodeID,
+		cfg:        p.systemConfig,
+		leaseMgr:   p.leaseMgr,
+	})
 }
 
 func (p *planner) releaseLeases(db client.DB) {

--- a/sql/rename.go
+++ b/sql/rename.go
@@ -243,9 +243,8 @@ func (p *planner) RenameIndex(n *parser.RenameIndex) (planNode, error) {
 	} else {
 		tableDesc.Mutations[i].GetIndex().Name = newIdxName
 	}
-	tableDesc.UpVersion = true
-	p.applyUpVersion(tableDesc)
 
+	tableDesc.UpVersion = true
 	descKey := MakeDescMetadataKey(tableDesc.GetID())
 	if err := tableDesc.Validate(); err != nil {
 		return nil, err
@@ -253,8 +252,7 @@ func (p *planner) RenameIndex(n *parser.RenameIndex) (planNode, error) {
 	if err := p.txn.Put(descKey, wrapDescriptor(tableDesc)); err != nil {
 		return nil, err
 	}
-
-	p.notifyCompletedSchemaChange(tableDesc.ID)
+	p.notifySchemaChange(tableDesc.ID, invalidMutationID)
 	return &valuesNode{}, nil
 }
 
@@ -341,7 +339,6 @@ func (p *planner) RenameColumn(n *parser.RenameColumn) (planNode, error) {
 	}
 	column.Name = newColName
 	tableDesc.UpVersion = true
-	p.applyUpVersion(tableDesc)
 
 	descKey := MakeDescMetadataKey(tableDesc.GetID())
 	if err := tableDesc.Validate(); err != nil {
@@ -350,6 +347,6 @@ func (p *planner) RenameColumn(n *parser.RenameColumn) (planNode, error) {
 	if err := p.txn.Put(descKey, wrapDescriptor(tableDesc)); err != nil {
 		return nil, err
 	}
-	p.notifyCompletedSchemaChange(tableDesc.ID)
+	p.notifySchemaChange(tableDesc.ID, invalidMutationID)
 	return &valuesNode{}, nil
 }

--- a/sql/schema_changer.go
+++ b/sql/schema_changer.go
@@ -17,66 +17,84 @@
 package sql
 
 import (
+	"bytes"
 	"errors"
+	"math"
+	"sync"
 	"time"
 
 	"github.com/cockroachdb/cockroach/client"
+	"github.com/cockroachdb/cockroach/config"
+	"github.com/cockroachdb/cockroach/gossip"
+	"github.com/cockroachdb/cockroach/keys"
 	"github.com/cockroachdb/cockroach/roachpb"
+	"github.com/cockroachdb/cockroach/security"
 	"github.com/cockroachdb/cockroach/util"
-	"github.com/gogo/protobuf/proto"
+	"github.com/cockroachdb/cockroach/util/log"
+	"github.com/cockroachdb/cockroach/util/retry"
+	"github.com/cockroachdb/cockroach/util/stop"
 )
-
-// Future home of the asynchronous schema changer that picks up
-// queued schema changes and processes them.
-//
-// applyMutations applies the queued mutations for a table.
-func (p *planner) applyMutations(tableDesc *TableDescriptor) error {
-	if len(tableDesc.Mutations) == 0 {
-		return nil
-	}
-	newTableDesc := proto.Clone(tableDesc).(*TableDescriptor)
-	p.applyUpVersion(newTableDesc)
-	// Make all mutations active.
-	for _, mutation := range newTableDesc.Mutations {
-		newTableDesc.makeMutationComplete(mutation)
-	}
-	newTableDesc.Mutations = nil
-	if err := newTableDesc.Validate(); err != nil {
-		return err
-	}
-
-	b := client.Batch{}
-	if err := p.backfillBatch(&b, tableDesc, newTableDesc); err != nil {
-		return err
-	}
-
-	b.Put(MakeDescMetadataKey(newTableDesc.GetID()), wrapDescriptor(newTableDesc))
-
-	if err := p.txn.Run(&b); err != nil {
-		return convertBatchError(newTableDesc, b, err)
-	}
-	p.notifyCompletedSchemaChange(newTableDesc.ID)
-	return nil
-}
-
-// applyUpVersion only increments the version of the table descriptor.
-func (p *planner) applyUpVersion(tableDesc *TableDescriptor) {
-	if tableDesc.UpVersion {
-		tableDesc.UpVersion = false
-		tableDesc.Version++
-	}
-}
 
 // SchemaChanger is used to change the schema on a table.
 type SchemaChanger struct {
-	tableID ID
-	nodeID  roachpb.NodeID
-	db      client.DB
+	tableID    ID
+	mutationID MutationID
+	nodeID     roachpb.NodeID
+	db         client.DB
+	cfg        config.SystemConfig
+	leaseMgr   *LeaseManager
+	// The SchemaChangeManager can attempt to execute this schema
+	// changer after this time.
+	execAfter time.Time
+}
+
+// applyMutations runs the backfill for the mutations.
+// TODO(vivek): Merge this with backfill by moving backfill into this file.
+func (sc *SchemaChanger) applyMutations(lease *TableDescriptor_SchemaChangeLease) error {
+	l, err := sc.ExtendLease(*lease)
+	if err != nil {
+		return err
+	}
+	*lease = l
+	return sc.db.Txn(func(txn *client.Txn) error {
+		// TODO(vivek): Use the original users privileges.
+		p := planner{user: security.RootUser, systemConfig: sc.cfg, leaseMgr: sc.leaseMgr}
+		p.setTxn(txn, time.Now())
+
+		tableDesc, err := getTableDescFromID(txn, sc.tableID)
+		if err != nil {
+			return err
+		}
+
+		if len(tableDesc.Mutations) == 0 || tableDesc.Mutations[0].MutationID != sc.mutationID {
+			// Nothing to do.
+			return nil
+		}
+
+		b := client.Batch{}
+		if err := p.backfillBatch(&b, tableDesc, sc.mutationID); err != nil {
+			return err
+		}
+		if err := p.txn.Run(&b); err != nil {
+			// Locally apply mutations belonging to the same mutationID
+			// for use by convertBatchError().
+			for _, mutation := range tableDesc.Mutations {
+				if mutation.MutationID != sc.mutationID {
+					// Mutations are applied in a FIFO order. Only apply the first set of
+					// mutations if they have the mutation ID we're looking for.
+					break
+				}
+				tableDesc.makeMutationComplete(mutation)
+			}
+			return convertBatchError(tableDesc, b, err)
+		}
+		return nil
+	})
 }
 
 // NewSchemaChangerForTesting only for tests.
-func NewSchemaChangerForTesting(tableID ID, nodeID roachpb.NodeID, db client.DB) SchemaChanger {
-	return SchemaChanger{tableID: tableID, nodeID: nodeID, db: db}
+func NewSchemaChangerForTesting(tableID ID, mutationID MutationID, nodeID roachpb.NodeID, db client.DB, leaseMgr *LeaseManager) SchemaChanger {
+	return SchemaChanger{tableID: tableID, mutationID: mutationID, nodeID: nodeID, db: db, leaseMgr: leaseMgr}
 }
 
 var errExistingSchemaChangeLease = errors.New("an outstanding schema change lease exists")
@@ -103,8 +121,11 @@ func (sc *SchemaChanger) AcquireLease() (TableDescriptor_SchemaChangeLease, erro
 		// This just reduces the probability of a write collision.
 		expirationTimeUncertainty := time.Second
 
-		if tableDesc.Lease != nil && time.Unix(0, tableDesc.Lease.ExpirationTime).Add(expirationTimeUncertainty).After(time.Now()) {
-			return errExistingSchemaChangeLease
+		if tableDesc.Lease != nil {
+			if time.Unix(0, tableDesc.Lease.ExpirationTime).Add(expirationTimeUncertainty).After(time.Now()) {
+				return errExistingSchemaChangeLease
+			}
+			log.Infof("Overriding existing expired lease %v", tableDesc.Lease)
 		}
 		lease = sc.createSchemaChangeLease()
 		tableDesc.Lease = &lease
@@ -154,4 +175,436 @@ func (sc *SchemaChanger) ExtendLease(lease TableDescriptor_SchemaChangeLease) (T
 		return txn.Put(MakeDescMetadataKey(tableDesc.ID), wrapDescriptor(tableDesc))
 	})
 	return lease, err
+}
+
+// Execute the entire schema change in steps.
+func (sc SchemaChanger) exec() error {
+	// Acquire lease.
+	lease, err := sc.AcquireLease()
+	if err != nil {
+		return err
+	}
+	// Always try to release lease.
+	defer func(l *TableDescriptor_SchemaChangeLease) {
+		if err := sc.ReleaseLease(*l); err != nil {
+			log.Warning(err)
+		}
+	}(&lease)
+
+	// Increment the version and unset tableDescriptor.UpVersion.
+	if err := sc.MaybeIncrementVersion(); err != nil {
+		return err
+	}
+
+	// Wait for the schema change to propagate to all nodes after this function
+	// returns, so that the new schema is live everywhere. This is not needed for
+	// correctness but is done to make the UI experience/tests predictable.
+	defer func() {
+		if err := sc.waitToUpdateLeases(); err != nil {
+			log.Warning(err)
+		}
+	}()
+
+	if sc.mutationID == invalidMutationID {
+		// Nothing more to do.
+		return nil
+	}
+
+	// Another transaction might set the up_version bit again,
+	// but we're no longer responsible for taking care of that.
+
+	// Run through mutation state machine before backfill.
+	if err := sc.RunStateMachineBeforeBackfill(); err != nil {
+		return err
+	}
+
+	// Apply backfill.
+	if err := sc.applyMutations(&lease); err != nil {
+		// Purge the mutations if the application of the mutations fail.
+		if errPurge := sc.purgeMutations(&lease); errPurge != nil {
+			return util.Errorf("error purging mutation: %s, after error: %s", errPurge, err)
+		}
+		return err
+	}
+
+	// Mark the mutations as completed.
+	return sc.done()
+}
+
+// MaybeIncrementVersion increments the version if needed.
+func (sc *SchemaChanger) MaybeIncrementVersion() error {
+	return sc.leaseMgr.Publish(sc.tableID, func(desc *TableDescriptor) error {
+		if !desc.UpVersion {
+			// Return error so that Publish() doesn't increment the version.
+			return errDidntUpdateDescriptor
+		}
+		desc.UpVersion = false
+		// Publish() will increment the version.
+		return nil
+	})
+}
+
+// RunStateMachineBeforeBackfill moves the state machine forward
+// and wait to ensure that all nodes are seeing the latest version
+// of the table.
+func (sc *SchemaChanger) RunStateMachineBeforeBackfill() error {
+	if err := sc.leaseMgr.Publish(sc.tableID, func(desc *TableDescriptor) error {
+		var modified bool
+		// Apply mutations belonging to the same version.
+		for i, mutation := range desc.Mutations {
+			if mutation.MutationID != sc.mutationID {
+				// Mutations are applied in a FIFO order. Only apply the first set of
+				// mutations if they have the mutation ID we're looking for.
+				break
+			}
+			switch mutation.Direction {
+			case DescriptorMutation_ADD:
+				switch mutation.State {
+				case DescriptorMutation_DELETE_ONLY:
+					// TODO(vivek): while moving up the state is appropriate,
+					// it will be better to run the backfill of a unique index
+					// twice: once in the DELETE_ONLY state to confirm that
+					// the index can indeed be created, and subsequently in the
+					// WRITE_ONLY state to fill in the missing elements of the
+					// index (INSERT and UPDATE that happened in the interim).
+					desc.Mutations[i].State = DescriptorMutation_WRITE_ONLY
+					modified = true
+
+				case DescriptorMutation_WRITE_ONLY:
+					// The state change has already moved forward.
+				}
+
+			case DescriptorMutation_DROP:
+				switch mutation.State {
+				case DescriptorMutation_DELETE_ONLY:
+					// The state change has already moved forward.
+
+				case DescriptorMutation_WRITE_ONLY:
+					desc.Mutations[i].State = DescriptorMutation_DELETE_ONLY
+					modified = true
+				}
+			}
+		}
+		if !modified {
+			// Return error so that Publish() doesn't increment the version.
+			return errDidntUpdateDescriptor
+		}
+		return nil
+	}); err != nil {
+		return err
+	}
+	// wait for the state change to propagate to all leases.
+	return sc.waitToUpdateLeases()
+}
+
+// Wait until the entire cluster has been updated to the latest version
+// of the table descriptor.
+func (sc *SchemaChanger) waitToUpdateLeases() error {
+	// Aggressively retry because there might be a user waiting for the
+	// schema change to complete.
+	retryOpts := retry.Options{
+		InitialBackoff: 20 * time.Millisecond,
+		MaxBackoff:     200 * time.Millisecond,
+		Multiplier:     2,
+	}
+	_, err := sc.leaseMgr.waitForOneVersion(sc.tableID, retryOpts)
+	return err
+}
+
+func (sc *SchemaChanger) done() error {
+	return sc.leaseMgr.Publish(sc.tableID, func(desc *TableDescriptor) error {
+		i := 0
+		for _, mutation := range desc.Mutations {
+			if mutation.MutationID != sc.mutationID {
+				// Mutations are applied in a FIFO order. Only apply the first set of
+				// mutations if they have the mutation ID we're looking for.
+				break
+			}
+			desc.makeMutationComplete(mutation)
+			i++
+		}
+		if i == 0 {
+			// The table descriptor is unchanged. Don't let Publish() increment
+			// the version.
+			return errDidntUpdateDescriptor
+		}
+		desc.Mutations = desc.Mutations[i:]
+		return nil
+	})
+}
+
+// Purge all mutations with the mutationID. This is called after
+// hitting an irrecoverable error. Reverse the direction of the mutations
+// and run through the state machine until the mutations are deleted.
+func (sc *SchemaChanger) purgeMutations(lease *TableDescriptor_SchemaChangeLease) error {
+	// Reverse the flow of the state machine.
+	if err := sc.leaseMgr.Publish(sc.tableID, func(desc *TableDescriptor) error {
+		for i, mutation := range desc.Mutations {
+			if mutation.MutationID != sc.mutationID {
+				// Mutations are applied in a FIFO order. Only apply the first set of
+				// mutations if they have the mutation ID we're looking for.
+				break
+			}
+			switch mutation.Direction {
+			case DescriptorMutation_ADD:
+				desc.Mutations[i].Direction = DescriptorMutation_DROP
+
+			case DescriptorMutation_DROP:
+				desc.Mutations[i].Direction = DescriptorMutation_ADD
+			}
+		}
+		// Publish() will increment the version.
+		return nil
+	}); err != nil {
+		return err
+	}
+
+	// Run through mutation state machine before backfill.
+	if err := sc.RunStateMachineBeforeBackfill(); err != nil {
+		return err
+	}
+
+	// Apply backfill and don't run purge on hitting an error.
+	// TODO(vivek): If this fails we can get into a permanent
+	// failure with some mutations, where subsequent schema
+	// changers keep attempting to apply and purge mutations.
+	// This is a theoretical problem at this stage (2015/12).
+	if err := sc.applyMutations(lease); err != nil {
+		return err
+	}
+
+	// Mark the mutations as completed.
+	return sc.done()
+}
+
+// IsDone returns true if the work scheduled for the schema changer
+// is complete.
+func (sc *SchemaChanger) IsDone() (bool, error) {
+	var done bool
+	err := sc.db.Txn(func(txn *client.Txn) error {
+		done = true
+		tableDesc, err := getTableDescFromID(txn, sc.tableID)
+		if err != nil {
+			return err
+		}
+		if sc.mutationID == invalidMutationID {
+			if tableDesc.UpVersion {
+				done = false
+			}
+		} else {
+			for _, mutation := range tableDesc.Mutations {
+				if mutation.MutationID == sc.mutationID {
+					done = false
+					break
+				}
+			}
+		}
+		return nil
+	})
+	return done && err == nil, err
+}
+
+// SchemaChangeManager processes pending schema changes seen in gossip
+// updates. Most schema changes are executed synchronously by the node
+// that created the schema change. If the node dies while
+// processing the schema change this manager acts as a backup
+// execution mechanism.
+type SchemaChangeManager struct {
+	// System Config and mutex.
+	systemConfig   config.SystemConfig
+	systemConfigMu sync.RWMutex
+	db             client.DB
+	gossip         *gossip.Gossip
+	leaseMgr       *LeaseManager
+	// Create a schema changer for every outstanding schema change seen.
+	schemaChangers map[ID]SchemaChanger
+}
+
+// NewSchemaChangeManager returns a new SchemaChangeManager.
+func NewSchemaChangeManager(db client.DB, gossip *gossip.Gossip, leaseMgr *LeaseManager) *SchemaChangeManager {
+	return &SchemaChangeManager{db: db, gossip: gossip, leaseMgr: leaseMgr, schemaChangers: make(map[ID]SchemaChanger)}
+}
+
+// updateSystemConfig is called whenever the system config gossip entry is updated.
+func (s *SchemaChangeManager) updateSystemConfig(cfg config.SystemConfig) {
+	s.systemConfigMu.Lock()
+	defer s.systemConfigMu.Unlock()
+	s.systemConfig = cfg
+}
+
+// getSystemConfig returns a pointer to the latest system config.
+func (s *SchemaChangeManager) getSystemConfig() config.SystemConfig {
+	s.systemConfigMu.RLock()
+	defer s.systemConfigMu.RUnlock()
+	return s.systemConfig
+}
+
+var (
+	disableSyncSchemaChangeExec  = false
+	disableAsyncSchemaChangeExec = false
+	// How often does the SchemaChangeManager attempt to execute
+	// pending schema changes.
+	asyncSchemaChangeExecInterval = 60 * time.Second
+	// How old must the schema change be before the SchemaChangeManager
+	// attempts to execute it.
+	asyncSchemaChangeExecDelay = 360 * time.Second
+)
+
+// TestDisableSyncSchemaChangeExec is used in tests to
+// disable the synchronous execution of schema changes,
+// so that the asynchronous schema changer can run the
+// schema changes.
+func TestDisableSyncSchemaChangeExec() func() {
+	disableSyncSchemaChangeExec = true
+	// Attempt to execute almost immediately.
+	asyncSchemaChangeExecInterval = 20 * time.Millisecond
+	asyncSchemaChangeExecDelay = 20 * time.Millisecond
+	return func() {
+		disableSyncSchemaChangeExec = false
+		asyncSchemaChangeExecInterval = 60 * time.Second
+		asyncSchemaChangeExecDelay = 360 * time.Second
+	}
+}
+
+// TestDisableAsyncSchemaChangeExec is used in tests to
+// disable the asynchronous execution of schema changes.
+func TestDisableAsyncSchemaChangeExec() func() {
+	disableAsyncSchemaChangeExec = true
+	return func() {
+		disableAsyncSchemaChangeExec = false
+	}
+}
+
+// Creates a timer that is used by the manager to decide on
+// when to run the next schema changer.
+func (s *SchemaChangeManager) newTimer() *time.Timer {
+	waitDuration := time.Duration(math.MaxInt64)
+	now := time.Now()
+	for _, sc := range s.schemaChangers {
+		d := sc.execAfter.Sub(now)
+		if d < waitDuration {
+			waitDuration = d
+		}
+	}
+	// Create a timer if there is an existing schema changer.
+	if len(s.schemaChangers) > 0 {
+		return time.NewTimer(waitDuration)
+	}
+	return &time.Timer{}
+}
+
+// Start starts a goroutine that runs outstanding schema changes
+// for tables received in the latest system configuration via gossip.
+func (s *SchemaChangeManager) Start(stopper *stop.Stopper) {
+	if disableAsyncSchemaChangeExec {
+		return
+	}
+	stopper.RunWorker(func() {
+		descKeyPrefix := keys.MakeTablePrefix(uint32(DescriptorTable.ID))
+		gossipUpdateC := s.gossip.RegisterSystemConfigChannel()
+		timer := &time.Timer{}
+		for {
+			select {
+			case <-gossipUpdateC:
+				cfg := *s.gossip.GetSystemConfig()
+				s.updateSystemConfig(cfg)
+				// Read all tables and their versions
+				if log.V(2) {
+					log.Info("received a new config %v", cfg)
+				}
+				schemaChanger := SchemaChanger{
+					nodeID:   roachpb.NodeID(s.leaseMgr.nodeID),
+					db:       s.db,
+					leaseMgr: s.leaseMgr,
+				}
+				// Keep track of existing schema changers.
+				oldSchemaChangers := make(map[ID]struct{}, len(s.schemaChangers))
+				for k := range s.schemaChangers {
+					oldSchemaChangers[k] = struct{}{}
+				}
+				execAfter := time.Now().Add(asyncSchemaChangeExecDelay)
+				// Loop through the configuration to find all the tables.
+				for _, kv := range cfg.Values {
+					if !bytes.HasPrefix(kv.Key, descKeyPrefix) {
+						continue
+					}
+					// Attempt to unmarshal config into a table/database descriptor.
+					var descriptor Descriptor
+					if err := kv.Value.GetProto(&descriptor); err != nil {
+						log.Warningf("%s: unable to unmarshal descriptor %v", kv.Key, kv.Value)
+						continue
+					}
+					switch union := descriptor.Union.(type) {
+					case *Descriptor_Table:
+						table := union.Table
+						if err := table.Validate(); err != nil {
+							log.Errorf("%s: received invalid table descriptor: %v", kv.Key, table)
+							continue
+						}
+
+						// Keep track of outstanding schema changes.
+						// If all schema change commands always set UpVersion, why
+						// check for the presence of mutations?
+						// A schema change execution might fail soon after
+						// unsetting UpVersion, and we still want to process
+						// outstanding mutations.
+						if table.UpVersion || len(table.Mutations) > 0 {
+							if log.V(2) {
+								log.Infof("%s: queue up pending schema change; table: %d, version: %d",
+									kv.Key, table.ID, table.Version)
+							}
+
+							// Only track the first schema change. We depend on
+							// gossip to renotify us when a schema change has been
+							// completed.
+							schemaChanger.tableID = table.ID
+							if len(table.Mutations) == 0 {
+								schemaChanger.mutationID = invalidMutationID
+							} else {
+								schemaChanger.mutationID = table.Mutations[0].MutationID
+							}
+							schemaChanger.cfg = cfg
+							schemaChanger.execAfter = execAfter
+							// Keep track of this schema change.
+							// Remove from oldSchemaChangers map.
+							delete(oldSchemaChangers, table.ID)
+							if sc, ok := s.schemaChangers[table.ID]; ok {
+								if sc.mutationID == schemaChanger.mutationID {
+									// Ignore duplicate.
+									continue
+								}
+							}
+							s.schemaChangers[table.ID] = schemaChanger
+						}
+
+					case *Descriptor_Database:
+						// Ignore.
+					}
+				}
+				// Delete old schema changers.
+				for k := range oldSchemaChangers {
+					delete(s.schemaChangers, k)
+				}
+				timer = s.newTimer()
+
+			case <-timer.C:
+				for _, sc := range s.schemaChangers {
+					if time.Since(sc.execAfter) > 0 {
+						if err := sc.exec(); err != nil && err != errExistingSchemaChangeLease {
+							log.Info(err)
+						}
+						// Advance the execAfter time so that this schema changer
+						// doesn't get called again for a while.
+						sc.execAfter = time.Now().Add(asyncSchemaChangeExecDelay)
+					}
+					// Only attempt to run one schema changer.
+					break
+				}
+				timer = s.newTimer()
+
+			case <-stopper.ShouldStop():
+				return
+			}
+		}
+	})
 }

--- a/sql/schema_changer_test.go
+++ b/sql/schema_changer_test.go
@@ -17,13 +17,17 @@
 package sql_test
 
 import (
+	"fmt"
 	"testing"
 	"time"
 
 	"github.com/cockroachdb/cockroach/keys"
 	"github.com/cockroachdb/cockroach/roachpb"
-	"github.com/cockroachdb/cockroach/sql"
+	csql "github.com/cockroachdb/cockroach/sql"
+	"github.com/cockroachdb/cockroach/util/hlc"
 	"github.com/cockroachdb/cockroach/util/leaktest"
+	"github.com/cockroachdb/cockroach/util/retry"
+	"github.com/gogo/protobuf/proto"
 )
 
 func TestSchemaChangeLease(t *testing.T) {
@@ -38,11 +42,11 @@ CREATE TABLE t.test (k CHAR PRIMARY KEY, v CHAR);
 		t.Fatal(err)
 	}
 
-	var lease sql.TableDescriptor_SchemaChangeLease
-	var id = sql.ID(keys.MaxReservedDescID + 2)
+	var lease csql.TableDescriptor_SchemaChangeLease
+	var id = csql.ID(keys.MaxReservedDescID + 2)
 	var node = roachpb.NodeID(2)
 	db := server.DB()
-	changer := sql.NewSchemaChangerForTesting(id, node, *db)
+	changer := csql.NewSchemaChangerForTesting(id, 0, node, *db, nil)
 
 	// Acquire a lease.
 	lease, err := changer.AcquireLease()
@@ -55,7 +59,7 @@ CREATE TABLE t.test (k CHAR PRIMARY KEY, v CHAR);
 	}
 
 	// Acquiring another lease will fail.
-	var newLease sql.TableDescriptor_SchemaChangeLease
+	var newLease csql.TableDescriptor_SchemaChangeLease
 	newLease, err = changer.AcquireLease()
 	if err == nil {
 		t.Fatalf("acquired new lease: %v, while unexpired lease exists: %v", newLease, lease)
@@ -104,5 +108,301 @@ CREATE TABLE t.test (k CHAR PRIMARY KEY, v CHAR);
 
 func validExpirationTime(expirationTime int64) bool {
 	now := time.Now()
-	return expirationTime > now.Add(sql.LeaseDuration/2).UnixNano() && expirationTime < now.Add(sql.LeaseDuration*3/2).UnixNano()
+	return expirationTime > now.Add(csql.LeaseDuration/2).UnixNano() && expirationTime < now.Add(csql.LeaseDuration*3/2).UnixNano()
+}
+
+func TestSchemaChangeProcess(t *testing.T) {
+	defer leaktest.AfterTest(t)
+	// The descriptor changes made must have an immediate effect
+	// so disable leases on tables.
+	defer csql.TestDisableTableLeases()()
+	// Disable external processing of mutations.
+	defer csql.TestDisableAsyncSchemaChangeExec()()
+	server, sqlDB, kvDB := setup(t)
+	defer cleanup(server, sqlDB)
+	var id = csql.ID(keys.MaxReservedDescID + 2)
+	var node = roachpb.NodeID(2)
+	db := server.DB()
+	leaseMgr := csql.NewLeaseManager(0, *db, hlc.NewClock(hlc.UnixNano))
+	changer := csql.NewSchemaChangerForTesting(id, 0, node, *db, leaseMgr)
+
+	if _, err := sqlDB.Exec(`
+CREATE DATABASE t;
+CREATE TABLE t.test (k CHAR PRIMARY KEY, v CHAR, INDEX foo(v));
+INSERT INTO t.test VALUES ('a', 'b'), ('c', 'd');
+`); err != nil {
+		t.Fatal(err)
+	}
+
+	// Read table descriptor for version.
+	nameKey := csql.MakeNameMetadataKey(keys.MaxReservedDescID+1, "test")
+	gr, err := kvDB.Get(nameKey)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !gr.Exists() {
+		t.Fatalf("Name entry %q does not exist", nameKey)
+	}
+	descKey := csql.MakeDescMetadataKey(csql.ID(gr.ValueInt()))
+	desc := &csql.Descriptor{}
+
+	// Check that MaybeIncrementVersion doesn't increment the version
+	// when the up_version bit is not set.
+	if err := kvDB.GetProto(descKey, desc); err != nil {
+		t.Fatal(err)
+	}
+	expectedVersion := desc.GetTable().Version
+
+	if err := changer.MaybeIncrementVersion(); err != nil {
+		t.Fatal(err)
+	}
+	if err := kvDB.GetProto(descKey, desc); err != nil {
+		t.Fatal(err)
+	}
+	newVersion := desc.GetTable().Version
+	if newVersion != expectedVersion {
+		t.Fatalf("bad version; e = %d, v = %d", expectedVersion, newVersion)
+	}
+	isDone, err := changer.IsDone()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !isDone {
+		t.Fatalf("table expected to not have an outstanding schema change: %v", desc.GetTable())
+	}
+
+	// Check that MaybeIncrementVersion increments the version
+	// correctly.
+	expectedVersion++
+	desc.GetTable().UpVersion = true
+	if err := kvDB.Put(descKey, desc); err != nil {
+		t.Fatal(err)
+	}
+	isDone, err = changer.IsDone()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if isDone {
+		t.Fatalf("table expected to have an outstanding schema change: %v", desc.GetTable())
+	}
+	if err := changer.MaybeIncrementVersion(); err != nil {
+		t.Fatal(err)
+	}
+	if err := kvDB.GetProto(descKey, desc); err != nil {
+		t.Fatal(err)
+	}
+	newVersion = desc.GetTable().Version
+	if newVersion != expectedVersion {
+		t.Fatalf("bad version; e = %d, v = %d", expectedVersion, newVersion)
+	}
+	isDone, err = changer.IsDone()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !isDone {
+		t.Fatalf("table expected to not have an outstanding schema change: %v", desc.GetTable())
+	}
+
+	// Check that RunStateMachineBeforeBackfill doesn't do anything
+	// if there are no mutations queued.
+	if err := changer.RunStateMachineBeforeBackfill(); err != nil {
+		t.Fatal(err)
+	}
+	if err := kvDB.GetProto(descKey, desc); err != nil {
+		t.Fatal(err)
+	}
+	newVersion = desc.GetTable().Version
+	if newVersion != expectedVersion {
+		t.Fatalf("bad version; e = %d, v = %d", expectedVersion, newVersion)
+	}
+
+	// Check that RunStateMachineBeforeBackfill functions properly.
+	if err := kvDB.GetProto(descKey, desc); err != nil {
+		t.Fatal(err)
+	}
+	table := desc.GetTable()
+	expectedVersion = table.Version
+	// Make a copy of the index for use in a mutation.
+	index := proto.Clone(&table.Indexes[0]).(*csql.IndexDescriptor)
+	index.Name = "bar"
+	index.ID = table.NextIndexID
+	table.NextIndexID++
+	changer = csql.NewSchemaChangerForTesting(id, table.NextMutationID, node, *db, leaseMgr)
+	table.Mutations = append(table.Mutations, csql.DescriptorMutation{
+		Descriptor_: &csql.DescriptorMutation_Index{Index: index},
+		Direction:   csql.DescriptorMutation_ADD,
+		State:       csql.DescriptorMutation_DELETE_ONLY,
+		MutationID:  table.NextMutationID,
+	})
+	table.NextMutationID++
+
+	// Run state machine in both directions.
+	for _, direction := range []csql.DescriptorMutation_Direction{csql.DescriptorMutation_ADD, csql.DescriptorMutation_DROP} {
+		table.Mutations[0].Direction = direction
+		expectedVersion++
+		if err := kvDB.Put(descKey, desc); err != nil {
+			t.Fatal(err)
+		}
+		// The expected end state.
+		expectedState := csql.DescriptorMutation_WRITE_ONLY
+		if direction == csql.DescriptorMutation_DROP {
+			expectedState = csql.DescriptorMutation_DELETE_ONLY
+		}
+		// Run two times to ensure idempotency of operations.
+		for i := 0; i < 2; i++ {
+			if err := changer.RunStateMachineBeforeBackfill(); err != nil {
+				t.Fatal(err)
+			}
+			if err := kvDB.GetProto(descKey, desc); err != nil {
+				t.Fatal(err)
+			}
+			table = desc.GetTable()
+			newVersion = table.Version
+			if newVersion != expectedVersion {
+				t.Fatalf("bad version; e = %d, v = %d", expectedVersion, newVersion)
+			}
+			state := table.Mutations[0].State
+			if state != expectedState {
+				t.Fatalf("bad state; e = %d, v = %d", expectedState, state)
+			}
+		}
+	}
+	// RunStateMachineBeforeBackfill() doesn't complete the schema change.
+	isDone, err = changer.IsDone()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if isDone {
+		t.Fatalf("table expected to have an outstanding schema change: %v", desc.GetTable())
+	}
+
+}
+
+func TestAsyncSchemaChanger(t *testing.T) {
+	defer leaktest.AfterTest(t)
+	// Disable synchronous schema change execution so
+	// the asynchronous schema changer executes all
+	// schema changes.
+	defer csql.TestDisableSyncSchemaChangeExec()()
+	// The descriptor changes made must have an immediate effect
+	// so disable leases on tables.
+	defer csql.TestDisableTableLeases()()
+	server, sqlDB, kvDB := setup(t)
+	defer cleanup(server, sqlDB)
+
+	if _, err := sqlDB.Exec(`
+CREATE DATABASE t;
+CREATE TABLE t.test (k CHAR PRIMARY KEY, v CHAR);
+INSERT INTO t.test VALUES ('a', 'b'), ('c', 'd');
+`); err != nil {
+		t.Fatal(err)
+	}
+
+	// Read table descriptor for version.
+	nameKey := csql.MakeNameMetadataKey(keys.MaxReservedDescID+1, "test")
+	gr, err := kvDB.Get(nameKey)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !gr.Exists() {
+		t.Fatalf("Name entry %q does not exist", nameKey)
+	}
+	descKey := csql.MakeDescMetadataKey(csql.ID(gr.ValueInt()))
+	desc := &csql.Descriptor{}
+	if err := kvDB.GetProto(descKey, desc); err != nil {
+		t.Fatal(err)
+	}
+	// A long running schema change operation runs through
+	// a state machine that increments the version by 3.
+	expectedVersion := desc.GetTable().Version + 3
+
+	// Run some schema change
+	if _, err := sqlDB.Exec(`
+CREATE INDEX foo ON t.test (v)
+`); err != nil {
+		t.Fatal(err)
+	}
+
+	retryOpts := retry.Options{
+		InitialBackoff: 20 * time.Millisecond,
+		MaxBackoff:     200 * time.Millisecond,
+		Multiplier:     2,
+	}
+
+	// Wait until index is created.
+	for r := retry.Start(retryOpts); r.Next(); {
+		if err := kvDB.GetProto(descKey, desc); err != nil {
+			t.Fatal(err)
+		}
+		if len(desc.GetTable().Indexes) == 1 {
+			break
+		}
+	}
+
+	// Ensure that the indexes have been created.
+	mTest := mutationTest{
+		T:       t,
+		kvDB:    kvDB,
+		sqlDB:   sqlDB,
+		descKey: descKey,
+		desc:    desc,
+	}
+	indexQuery := `SELECT * FROM t.test@foo`
+	_ = mTest.checkQueryResponse(indexQuery, [][]string{{"b"}, {"d"}})
+
+	// Ensure that the version has been incremented.
+	if err := kvDB.GetProto(descKey, desc); err != nil {
+		t.Fatal(err)
+	}
+	newVersion := desc.GetTable().Version
+	if newVersion != expectedVersion {
+		t.Fatalf("bad version; e = %d, v = %d", expectedVersion, newVersion)
+	}
+
+	// Apply a schema change that only sets the UpVersion bit.
+	expectedVersion = newVersion + 1
+
+	if _, err := sqlDB.Exec(`
+ALTER INDEX t.test@foo RENAME TO ufo
+`); err != nil {
+		t.Fatal(err)
+	}
+
+	for r := retry.Start(retryOpts); r.Next(); {
+		// Ensure that the version gets incremented.
+		if err := kvDB.GetProto(descKey, desc); err != nil {
+			t.Fatal(err)
+		}
+		name := desc.GetTable().Indexes[0].Name
+		if name != "ufo" {
+			t.Fatalf("bad index name %s", name)
+		}
+		newVersion = desc.GetTable().Version
+		if newVersion == expectedVersion {
+			break
+		}
+	}
+
+	// Run many schema changes simultaneously and check
+	// that they all get executed.
+	count := 5
+	for i := 0; i < count; i++ {
+		cmd := fmt.Sprintf(`CREATE INDEX foo%d ON t.test (v)`, i)
+		if _, err := sqlDB.Exec(cmd); err != nil {
+			t.Fatal(err)
+		}
+	}
+	// Wait until indexes are created.
+	for r := retry.Start(retryOpts); r.Next(); {
+		if err := kvDB.GetProto(descKey, desc); err != nil {
+			t.Fatal(err)
+		}
+		if len(desc.GetTable().Indexes) == count+1 {
+			break
+		}
+	}
+	for i := 0; i < count; i++ {
+		indexQuery := fmt.Sprintf(`SELECT * FROM t.test@foo%d`, i)
+		_ = mTest.checkQueryResponse(indexQuery, [][]string{{"b"}, {"d"}})
+	}
 }

--- a/sql/server.go
+++ b/sql/server.go
@@ -23,14 +23,10 @@ import (
 	"strings"
 
 	"github.com/cockroachdb/cockroach/base"
-	"github.com/cockroachdb/cockroach/client"
-	"github.com/cockroachdb/cockroach/gossip"
 	"github.com/cockroachdb/cockroach/rpc"
 	"github.com/cockroachdb/cockroach/security"
 	"github.com/cockroachdb/cockroach/sql/driver"
 	"github.com/cockroachdb/cockroach/util"
-	"github.com/cockroachdb/cockroach/util/metric"
-	"github.com/cockroachdb/cockroach/util/stop"
 	"github.com/gogo/protobuf/proto"
 )
 
@@ -44,11 +40,8 @@ type Server struct {
 }
 
 // MakeServer creates a Server.
-func MakeServer(ctx *base.Context, db client.DB, gossip *gossip.Gossip, leaseMgr *LeaseManager, metaRegistry *metric.Registry, stopper *stop.Stopper) Server {
-	return Server{
-		context:  ctx,
-		Executor: newExecutor(db, gossip, leaseMgr, metaRegistry, stopper),
-	}
+func MakeServer(ctx *base.Context, executor *Executor) Server {
+	return Server{context: ctx, Executor: executor}
 }
 
 // ServeHTTP serves the SQL API by treating the request URL path

--- a/sql/structured.go
+++ b/sql/structured.go
@@ -42,6 +42,11 @@ type IndexID uint32
 // DescriptorVersion is a custom type for TableDescriptor Versions.
 type DescriptorVersion uint32
 
+// MutationID is custom type for TableDescriptor mutations.
+type MutationID uint32
+
+const invalidMutationID = 0
+
 const (
 	// PrimaryKeyIndexName is the name of the index for the primary key.
 	PrimaryKeyIndexName = "primary"
@@ -207,6 +212,9 @@ func (desc *TableDescriptor) AllocateIDs() error {
 	}
 	if desc.Version == 0 {
 		desc.Version = 1
+	}
+	if desc.NextMutationID == invalidMutationID {
+		desc.NextMutationID = 1
 	}
 
 	columnNames := map[string]ColumnID{}
@@ -571,6 +579,7 @@ func (desc *TableDescriptor) addMutation(m DescriptorMutation) {
 	case DescriptorMutation_DROP:
 		m.State = DescriptorMutation_WRITE_ONLY
 	}
+	m.MutationID = desc.NextMutationID
 	desc.Mutations = append(desc.Mutations, m)
 }
 

--- a/sql/structured.proto
+++ b/sql/structured.proto
@@ -145,6 +145,13 @@ message DescriptorMutation {
     DROP = 2;
   }
   optional Direction direction = 4 [(gogoproto.nullable) = false];
+
+  // The mutation id used to group mutations that should be applied together.
+  // This is used for situations like creating a unique column, which
+  // involve adding two mutations: one for the column, and another for the
+  // unique constraint index.
+  optional uint32 mutation_id = 5 [(gogoproto.nullable) = false,
+      (gogoproto.customname) = "MutationID", (gogoproto.casttype) = "MutationID"];
 }
 
 // A TableDescriptor represents a table and is stored in a structured metadata
@@ -230,7 +237,7 @@ message TableDescriptor {
   // Columns or indexes being added or deleted in a FIFO order.
   repeated DescriptorMutation mutations = 14 [(gogoproto.nullable) = false];
   // The schema update lease. A single goroutine across a cockroach cluster
-  // can own it, and will execute pending schema changes for this table. 
+  // can own it, and will execute pending schema changes for this table.
   // Since the execution of a pending schema change is through transactions,
   // it is legal for more than one goroutine to attempt to execute it. This
   // lease reduces write contention on the schema change.
@@ -242,6 +249,9 @@ message TableDescriptor {
     optional int64 expiration_time = 2 [(gogoproto.nullable) = false];
   }
   optional SchemaChangeLease lease = 15;
+  // An id for the next group of mutations to be applied together.
+  optional uint32 next_mutation_id = 16 [(gogoproto.nullable) = false,
+      (gogoproto.customname) = "NextMutationID", (gogoproto.casttype) = "MutationID"];
 }
 
 // DatabaseDescriptor represents a namespace (aka database) and is stored

--- a/sql/structured_test.go
+++ b/sql/structured_test.go
@@ -86,9 +86,10 @@ func TestAllocateIDs(t *testing.T) {
 				ColumnDirections:  []sql.IndexDescriptor_Direction{sql.IndexDescriptor_ASC},
 				ImplicitColumnIDs: []sql.ColumnID{1}},
 		},
-		Privileges:   sql.NewDefaultPrivilegeDescriptor(),
-		NextColumnID: 4,
-		NextIndexID:  4,
+		Privileges:     sql.NewDefaultPrivilegeDescriptor(),
+		NextColumnID:   4,
+		NextIndexID:    4,
+		NextMutationID: 1,
 	}
 	if !reflect.DeepEqual(expected, desc) {
 		a, _ := json.MarshalIndent(expected, "", "  ")

--- a/sql/table.go
+++ b/sql/table.go
@@ -62,6 +62,8 @@ func makeTableDesc(p *parser.CreateTable, parentID ID) (TableDescriptor, error) 
 	}
 	desc.Name = p.Table.Table()
 	desc.ParentID = parentID
+	// We don't use version 0.
+	desc.Version = 1
 
 	for _, def := range p.Defs {
 		switch d := def.(type) {


### PR DESCRIPTION
A schema change is now run through many stages, where each stage runs
as a transaction on the database. Some steps involve the uses of
LeaseManager.Publish() that publishes a new version to the schema
only after there are outstanding leases to only one version of
the schema.

Since the synchronous execution of a schema change can
fail at any time (it runs multiple transactions sequentially), a second asynchronous path is added to
move the state machine along.

closes #2845 

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/3411)

<!-- Reviewable:end -->
