### PR TITLE
Only link libgcc and libstdc++ statically for static builds.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -38,16 +38,14 @@ DUPLFLAGS    := -t 100
 
 ifeq ($(STATIC),1)
 # Static linking with glibc is a bad time; see
-# https://github.com/golang/go/issues/13470.
-# If a static build is requested, assume musl is installed (it is in
-# the cockroachdb/builder docker container) and link against it
-# instead.
-CC = /usr/local/musl/bin/musl-gcc
+# https://github.com/golang/go/issues/13470. If a static build is
+# requested, only link libgcc and libstdc++ statically.
 # `-v` so warnings from the linker aren't suppressed.
 # `-a` so dependencies are rebuilt (they may have been dynamically
 # linked).
 GOFLAGS += -a -v
-LDFLAGS += -extldflags '-static'
+# TODO(peter): Allow this only when `go env CC` reports "gcc".
+LDFLAGS += -extldflags "-static-libgcc -static-libstdc++"
 endif
 
 .PHONY: all

--- a/build/Dockerfile
+++ b/build/Dockerfile
@@ -7,8 +7,6 @@ RUN curl --silent --location https://deb.nodesource.com/setup_5.x | bash - && \
  apt-get install --no-install-recommends --auto-remove -y git build-essential file nodejs && \
  apt-get clean autoclean && \
  apt-get autoremove -y && \
- curl --silent --location http://www.musl-libc.org/releases/musl-1.1.12.tar.gz | tar -xz && \
- cd musl-1.1.12 && ./configure && make && make install && \
  rm -rf /tmp/*
 
 ENV SKIP_BOOTSTRAP=1

--- a/build/build-docker-deploy.sh
+++ b/build/build-docker-deploy.sh
@@ -14,10 +14,6 @@ set -euo pipefail
 if [ "${1-}" = "docker" ]; then
     time make STATIC=1 release
 
-    # Make sure the created binary is statically linked.  Seems
-    # awkward to do this programmatically, but this should work.
-    file cockroach | grep -F 'statically linked' > /dev/null
-
     mv cockroach build/deploy/cockroach
 
     exit 0


### PR DESCRIPTION
ldd cockroach
    linux-vdso.so.1 (0x00007ffe34163000)
    librt.so.1 => /lib/x86_64-linux-gnu/librt.so.1 (0x00007f0eef3f7000)
    libpthread.so.0 => /lib/x86_64-linux-gnu/libpthread.so.0 (0x00007f0eef1da000)
    libm.so.6 => /lib/x86_64-linux-gnu/libm.so.6 (0x00007f0eeeed9000)
    libc.so.6 => /lib/x86_64-linux-gnu/libc.so.6 (0x00007f0eeeb30000)
    /lib64/ld-linux-x86-64.so.2 (0x00007f0eef5ff000)

Fixes #3392.

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/3412)

<!-- Reviewable:end -->
