### PR TITLE
Fixes #3404. We need to specify `netgo`

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -37,6 +37,9 @@ STRESSFLAGS  :=
 DUPLFLAGS    := -t 100
 
 ifeq ($(STATIC),1)
+# The Go resolver should work well enough for now; better than musl, anyway.
+# See #3404.
+TAGS += netgo
 # Static linking with glibc is a bad time; see
 # https://github.com/golang/go/issues/13470.
 # If a static build is requested, assume musl is installed (it is in


### PR DESCRIPTION
since `musl` does not read /etc/resolv.conf (at least
not properly enough to look up $(hostname) on docker).

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/3413)

<!-- Reviewable:end -->
