### PR TITLE
Remove check for static binaries.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -41,9 +41,7 @@ ifeq ($(STATIC),1)
 # https://github.com/golang/go/issues/13470. If a static build is
 # requested, only link libgcc and libstdc++ statically.
 # `-v` so warnings from the linker aren't suppressed.
-# `-a` so dependencies are rebuilt (they may have been dynamically
-# linked).
-GOFLAGS += -a -v
+GOFLAGS += -v
 # TODO(peter): Allow this only when `go env CC` reports "gcc".
 LDFLAGS += -extldflags "-static-libgcc -static-libstdc++"
 endif

--- a/build/build-common.sh
+++ b/build/build-common.sh
@@ -1,0 +1,10 @@
+# Build utility functions.
+
+function check_static() {
+    local libs=$(ldd $1 | egrep -v '(linux-vdso\.|librt\.|libpthread\.|libm\.|libc\.|ld-linux-)')
+    if [ -n "${libs}" ]; then
+        echo "$1 is not properly statically linked"
+        ldd $1
+        exit 1
+    fi
+}

--- a/build/build-docker-deploy.sh
+++ b/build/build-docker-deploy.sh
@@ -5,6 +5,8 @@
 
 set -euo pipefail
 
+source $(dirname $0)/build-common.sh
+
 # This is mildly tricky: This script runs itself recursively. The
 # first time it is run it does not take the if-branch below and
 # executes on the host computer. It uses the builder.sh script to run
@@ -13,6 +15,8 @@ set -euo pipefail
 # container.
 if [ "${1-}" = "docker" ]; then
     time make STATIC=1 release
+
+    check_static cockroach
 
     mv cockroach build/deploy/cockroach
 

--- a/build/build-static-binaries.sh
+++ b/build/build-static-binaries.sh
@@ -3,6 +3,8 @@
 
 set -euo pipefail
 
+source $(dirname $0)/build-common.sh
+
 # This is mildly tricky: This script runs itself recursively. The
 # first time it is run it does not take the if-branch below and
 # executes on the host computer. It uses the builder.sh script to run
@@ -14,11 +16,9 @@ if [ "${1-}" = "docker" ]; then
     time make STATIC=1 testbuild PKG=./sql
     time make STATIC=1 testbuild PKG=./acceptance TAGS=acceptance
 
-    # Make sure the created binary is statically linked.  Seems
-    # awkward to do this programmatically, but this should work.
-    file cockroach | grep -F 'statically linked' > /dev/null
-    file sql/sql.test | grep -F 'statically linked' > /dev/null
-    file acceptance/acceptance.test | grep -F 'statically linked' > /dev/null
+    check_static cockroach
+    check_static sql/sql.test
+    check_static acceptance/acceptance.test
 
     strip -S cockroach
     strip -S sql/sql.test


### PR DESCRIPTION
The check is no longer valid since we're linking glibc dynamically.

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/3416)

<!-- Reviewable:end -->
