### PR TITLE
planner.exec() accepts query params

### DIFF
--- a/sql/plan.go
+++ b/sql/plan.go
@@ -152,7 +152,7 @@ func (p *planner) makePlan(stmt parser.Statement) (planNode, error) {
 	}
 }
 
-func (p *planner) query(sql string) (planNode, error) {
+func (p *planner) query(sql string, args ...interface{}) (planNode, error) {
 	stmts, err := parser.ParseTraditional(sql)
 	if err != nil {
 		return nil, err
@@ -160,11 +160,14 @@ func (p *planner) query(sql string) (planNode, error) {
 	if len(stmts) != 1 {
 		return nil, util.Errorf("expected single statement, found %d", len(stmts))
 	}
+	if err := parser.FillArgs(stmts[0], golangParameters(args)); err != nil {
+		return nil, err
+	}
 	return p.makePlan(stmts[0])
 }
 
-func (p *planner) queryRow(sql string) (parser.DTuple, error) {
-	plan, err := p.query(sql)
+func (p *planner) queryRow(sql string, args ...interface{}) (parser.DTuple, error) {
+	plan, err := p.query(sql, args...)
 	if err != nil {
 		return nil, err
 	}
@@ -184,8 +187,8 @@ func (p *planner) queryRow(sql string) (parser.DTuple, error) {
 	return values, nil
 }
 
-func (p *planner) exec(sql string) (int, error) {
-	plan, err := p.query(sql)
+func (p *planner) exec(sql string, args ...interface{}) (int, error) {
+	plan, err := p.query(sql, args...)
 	if err != nil {
 		return 0, err
 	}


### PR DESCRIPTION
The internally used planner.exec() now supports positional parameters in
queries. Parameter values are supplied as a `golangParams` object, which is a
slice of normal Go types. This was accomplished by implementing the
parser.Args interface for golangParams.

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/3424)

<!-- Reviewable:end -->
