### PR TITLE
Add reserved descriptor ID range

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -58,7 +58,7 @@ var (
 
 	// testingLargestIDHook is a function used to bypass GetLargestObjectID
 	// in tests.
-	testingLargestIDHook func() uint32
+	testingLargestIDHook func(uint32) uint32
 
 	// testingDisableTableSplits is a testing-only variable that disables
 	// splits of tables into separate ranges.
@@ -142,51 +142,100 @@ func (s SystemConfig) GetIndex(key roachpb.Key) (int, bool) {
 	return index, true
 }
 
-// GetLargestObjectID returns the largest object ID found in the config.
-// This could be either a table or a database.
-func (s SystemConfig) GetLargestObjectID() (uint32, error) {
-	testingLock.Lock()
-	hook := testingLargestIDHook
-	testingLock.Unlock()
-	if hook != nil {
-		return hook(), nil
-	}
-
-	if len(s.Values) == 0 {
-		return 0, fmt.Errorf("empty system values in config")
-	}
-
-	// Search for the first key after the descriptor table.
-	// We can't use GetValue as we don't mind if there is nothing after
-	// the descriptor table.
-	key := roachpb.Key(keys.MakeTablePrefix(keys.DescriptorTableID + 1))
-	index := sort.Search(len(s.Values), func(i int) bool {
-		return bytes.Compare(s.Values[i].Key, key) >= 0
-	})
-
-	if index == 0 {
-		return 0, fmt.Errorf("descriptor table not found in system config of %d values", len(s.Values))
-	}
-
-	// This is the last key of the descriptor table.
-	key = s.Values[index-1].Key
-
+func decodeDescMetadataID(key roachpb.Key) (uint64, error) {
 	// Extract object ID from key.
 	// TODO(marc): move sql/keys.go to keys (or similar) and use a DecodeDescMetadataKey.
 	// We should also check proper encoding.
-	descriptorPrefix := keys.MakeTablePrefix(keys.DescriptorTableID)
-	remaining := bytes.TrimPrefix(key, descriptorPrefix)
-	// TrimPrefix returns the bytes unchanged if the prefix does not match.
-	if len(remaining) == len(key) {
-		return 0, fmt.Errorf("descriptor table not found in system config of %d values", len(s.Values))
+	remaining, tableID, err := keys.DecodeTablePrefix(key)
+	if err != nil {
+		return 0, err
+	}
+	if tableID != keys.DescriptorTableID {
+		return 0, util.Errorf("key is not a descriptor table entry: %v", key)
 	}
 	// DescriptorTable.PrimaryIndex.ID
-	remaining, _, err := encoding.DecodeUvarint(remaining)
+	remaining, _, err = encoding.DecodeUvarint(remaining)
 	if err != nil {
 		return 0, err
 	}
 	// descID
 	_, id, err := encoding.DecodeUvarint(remaining)
+	if err != nil {
+		return 0, err
+	}
+	return id, nil
+}
+
+// GetLargestObjectID returns the largest object ID found in the config which is
+// less than or equal to maxID. If maxID is 0, returns the largest ID in the
+// config.
+func (s SystemConfig) GetLargestObjectID(maxID uint32) (uint32, error) {
+	testingLock.Lock()
+	hook := testingLargestIDHook
+	testingLock.Unlock()
+	if hook != nil {
+		return hook(maxID), nil
+	}
+
+	// Search for the descriptor table entries within the SystemConfig.
+	highBound := roachpb.Key(keys.MakeTablePrefix(keys.DescriptorTableID + 1))
+	highIndex := sort.Search(len(s.Values), func(i int) bool {
+		return bytes.Compare(s.Values[i].Key, highBound) >= 0
+	})
+	lowBound := roachpb.Key(keys.MakeTablePrefix(keys.DescriptorTableID))
+	lowIndex := sort.Search(len(s.Values), func(i int) bool {
+		return bytes.Compare(s.Values[i].Key, lowBound) >= 0
+	})
+
+	if highIndex == lowIndex {
+		return 0, fmt.Errorf("descriptor table not found in system config of %d values", len(s.Values))
+	}
+
+	// No maximum specified; maximum ID is the last entry in the descriptor
+	// table.
+	if maxID == 0 {
+		id, err := decodeDescMetadataID(s.Values[highIndex-1].Key)
+		if err != nil {
+			return 0, err
+		}
+		return uint32(id), nil
+	}
+
+	// Maximum specified: need to search the descriptor table.  Binary search
+	// through all descriptor table values to find the first descriptor with ID
+	// >= maxID.
+	searchSlice := s.Values[lowIndex:highIndex]
+	var err error
+	maxIdx := sort.Search(len(searchSlice), func(i int) bool {
+		var id uint64
+		id, err = decodeDescMetadataID(searchSlice[i].Key)
+		if err != nil {
+			return false
+		}
+		return uint32(id) >= maxID
+	})
+	if err != nil {
+		return 0, err
+	}
+
+	// If we found an index within the list, maxIdx might point to a descriptor
+	// with exactly maxID.
+	if maxIdx < len(searchSlice) {
+		id, err := decodeDescMetadataID(searchSlice[maxIdx].Key)
+		if err != nil {
+			return 0, err
+		}
+		if uint32(id) == maxID {
+			return uint32(id), nil
+		}
+	}
+
+	if maxIdx == 0 {
+		return 0, fmt.Errorf("no descriptors present with ID < %d", maxID)
+	}
+
+	// Return ID of the immediately preceding descriptor.
+	id, err := decodeDescMetadataID(searchSlice[maxIdx-1].Key)
 	if err != nil {
 		return 0, err
 	}
@@ -230,50 +279,70 @@ func (s SystemConfig) ComputeSplitKeys(startKey, endKey roachpb.RKey) []roachpb.
 		return nil
 	}
 
-	tableStart := roachpb.RKey(keys.UserTableDataMin)
+	tableStart := roachpb.RKey(keys.ReservedTableDataMin)
 	if !tableStart.Less(endKey) {
 		// This range is before the user tables span: no required splits.
 		return nil
 	}
 
 	startID, ok := ObjectIDForKey(startKey)
-	if !ok || startID <= keys.MaxReservedDescID {
+	if !ok || startID <= keys.MaxSystemDescID {
 		// The start key is either:
 		// - not part of the structured data span
 		// - part of the system span
 		// In either case, start looking for splits at the first ID usable
 		// by the user data span.
-		startID = keys.MaxReservedDescID + 1
+		startID = keys.MaxSystemDescID + 1
 	} else {
 		// The start key is either already a split key, or after the split
 		// key for its ID. We can skip straight to the next one.
 		startID++
 	}
 
-	// Find the largest object ID.
-	// We can't keep splitting until we reach endKey as it could be roachpb.KeyMax.
-	endID, err := s.GetLargestObjectID()
+	// Build key prefixes for sequential table IDs until we reach endKey. Note
+	// that there are two disjoint sets of sequential keys: non-system reserved
+	// tables have sequential IDs, as do user tables, but the two ranges contain a
+	// gap.
+	var splitKeys []roachpb.RKey
+	var key roachpb.RKey
+
+	// appendSplitKeys generates all possible split keys between the given range
+	// of IDs and adds them to splitKeys.
+	appendSplitKeys := func(startID, endID uint32) {
+		// endID could be smaller than startID if we don't have user tables.
+		for id := startID; id <= endID; id++ {
+			key = keys.MakeTablePrefix(id)
+			// Skip if this ID matches the startKey passed to ComputeSplitKeys.
+			if !startKey.Less(key) {
+				continue
+			}
+			// Handle the case where EndKey is already a table prefix.
+			if !key.Less(endKey) {
+				break
+			}
+			splitKeys = append(splitKeys, key)
+		}
+	}
+
+	// If they startKey falls within the non-system reserved range, compute
+	// those keys first.
+	if startID <= keys.MaxReservedDescID {
+		endID, err := s.GetLargestObjectID(keys.MaxReservedDescID)
+		if err != nil {
+			log.Errorf("unable to determine largest reserved object ID from system config: %s", err)
+			return nil
+		}
+		appendSplitKeys(startID, endID)
+		startID = keys.MaxReservedDescID + 1
+	}
+
+	// Append keys in the user space.
+	endID, err := s.GetLargestObjectID(0)
 	if err != nil {
 		log.Errorf("unable to determine largest object ID from system config: %s", err)
 		return nil
 	}
-
-	// Build key prefixes for sequential table IDs until we reach endKey.
-	var splitKeys []roachpb.RKey
-	var key roachpb.RKey
-	// endID could be smaller than startID if we don't have user tables.
-	for id := startID; id <= endID; id++ {
-		key = keys.MakeTablePrefix(id)
-		// Skip if the range starts on a split key.
-		if !startKey.Less(key) {
-			continue
-		}
-		// Handle the case where EndKey is already a table prefix.
-		if !key.Less(endKey) {
-			break
-		}
-		splitKeys = append(splitKeys, key)
-	}
+	appendSplitKeys(startID, endID)
 
 	return splitKeys
 }

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -26,7 +26,9 @@ import (
 	"github.com/cockroachdb/cockroach/config"
 	"github.com/cockroachdb/cockroach/keys"
 	"github.com/cockroachdb/cockroach/roachpb"
+	"github.com/cockroachdb/cockroach/security"
 	"github.com/cockroachdb/cockroach/sql"
+	"github.com/cockroachdb/cockroach/sql/privilege"
 	"github.com/cockroachdb/cockroach/testutils"
 	"github.com/cockroachdb/cockroach/util/encoding"
 	"github.com/cockroachdb/cockroach/util/leaktest"
@@ -136,23 +138,24 @@ func TestGetLargestID(t *testing.T) {
 	testCases := []struct {
 		values  []roachpb.KeyValue
 		largest uint32
+		maxID   uint32
 		errStr  string
 	}{
 		// No data.
-		{nil, 0, "empty system values"},
+		{nil, 0, 0, "descriptor table not found"},
 
 		// Some data, but not from the system span.
-		{[]roachpb.KeyValue{plainKV("a", "b")}, 0, "descriptor table not found"},
+		{[]roachpb.KeyValue{plainKV("a", "b")}, 0, 0, "descriptor table not found"},
 
 		// Some real data, but no descriptors.
 		{[]roachpb.KeyValue{
 			sqlKV(keys.NamespaceTableID, 1, 1),
 			sqlKV(keys.NamespaceTableID, 1, 2),
 			sqlKV(keys.UsersTableID, 1, 3),
-		}, 0, "descriptor table not found"},
+		}, 0, 0, "descriptor table not found"},
 
 		// Single correct descriptor entry.
-		{[]roachpb.KeyValue{sqlKV(keys.DescriptorTableID, 1, 1)}, 1, ""},
+		{[]roachpb.KeyValue{sqlKV(keys.DescriptorTableID, 1, 1)}, 1, 0, ""},
 
 		// Surrounded by other data.
 		{[]roachpb.KeyValue{
@@ -160,7 +163,7 @@ func TestGetLargestID(t *testing.T) {
 			sqlKV(keys.NamespaceTableID, 1, 30),
 			sqlKV(keys.DescriptorTableID, 1, 8),
 			sqlKV(keys.ZonesTableID, 1, 40),
-		}, 8, ""},
+		}, 8, 0, ""},
 
 		// Descriptors with holes. Index ID does not matter.
 		{[]roachpb.KeyValue{
@@ -168,16 +171,32 @@ func TestGetLargestID(t *testing.T) {
 			sqlKV(keys.DescriptorTableID, 2, 5),
 			sqlKV(keys.DescriptorTableID, 3, 8),
 			sqlKV(keys.DescriptorTableID, 4, 12),
-		}, 12, ""},
+		}, 12, 0, ""},
 
 		// Real SQL layout.
-		{sql.MakeMetadataSchema().GetInitialValues(), keys.ZonesTableID, ""},
+		{sql.MakeMetadataSchema().GetInitialValues(), keys.ZonesTableID, 0, ""},
+
+		// Test non-zero max.
+		{[]roachpb.KeyValue{
+			sqlKV(keys.DescriptorTableID, 1, 1),
+			sqlKV(keys.DescriptorTableID, 2, 5),
+			sqlKV(keys.DescriptorTableID, 3, 8),
+			sqlKV(keys.DescriptorTableID, 4, 12),
+		}, 8, 8, ""},
+
+		// Test non-zero max.
+		{[]roachpb.KeyValue{
+			sqlKV(keys.DescriptorTableID, 1, 1),
+			sqlKV(keys.DescriptorTableID, 2, 5),
+			sqlKV(keys.DescriptorTableID, 3, 8),
+			sqlKV(keys.DescriptorTableID, 4, 12),
+		}, 5, 7, ""},
 	}
 
 	cfg := config.SystemConfig{}
 	for tcNum, tc := range testCases {
 		cfg.Values = tc.values
-		ret, err := cfg.GetLargestObjectID()
+		ret, err := cfg.GetLargestObjectID(tc.maxID)
 		if tc.errStr == "" {
 			if err != nil {
 				t.Errorf("#%d: error: %v", tcNum, err)
@@ -196,15 +215,31 @@ func TestGetLargestID(t *testing.T) {
 func TestComputeSplits(t *testing.T) {
 	defer leaktest.AfterTest(t)
 
-	const start = keys.MaxReservedDescID + 1
+	const (
+		start         = keys.MaxReservedDescID + 1
+		reservedStart = keys.MaxSystemDescID + 1
+	)
 
+	schema := sql.MakeMetadataSchema()
 	// Real SQL system tables only.
-	baseSql := sql.MakeMetadataSchema().GetInitialValues()
+	baseSql := schema.GetInitialValues()
 	// Real SQL system tables plus some user stuff.
-	userSql := append(sql.MakeMetadataSchema().GetInitialValues(),
+	userSql := append(schema.GetInitialValues(),
+		descriptor(start), descriptor(start+1), descriptor(start+5))
+	// Real SQL system with reserved non-system tables.
+	allPrivileges := sql.NewPrivilegeDescriptor(security.RootUser, privilege.List{privilege.ALL})
+	db := sql.MakeMetadataDatabase("testdb", allPrivileges)
+	db.AddTable("CREATE TABLE testdb.test (i INT PRIMARY KEY)", allPrivileges)
+	db.AddTable("CREATE TABLE testdb.test2 (i INT PRIMARY KEY)", allPrivileges)
+	schema.AddDatabase(db)
+	reservedSql := schema.GetInitialValues()
+	// Real SQL system with reserved non-system and user database.
+	allSql := append(schema.GetInitialValues(),
 		descriptor(start), descriptor(start+1), descriptor(start+5))
 
-	allSplits := []uint32{start, start + 1, start + 2, start + 3, start + 4, start + 5}
+	allUserSplits := []uint32{start, start + 1, start + 2, start + 3, start + 4, start + 5}
+	allReservedSplits := []uint32{reservedStart, reservedStart + 1, reservedStart + 2}
+	allSplits := append(allReservedSplits, allUserSplits...)
 
 	testCases := []struct {
 		values     []roachpb.KeyValue
@@ -225,21 +260,41 @@ func TestComputeSplits(t *testing.T) {
 		{baseSql, roachpb.RKeyMin, keys.MakeTablePrefix(start + 10), nil},
 
 		// User descriptors.
-		{userSql, roachpb.RKeyMin, roachpb.RKeyMax, allSplits},
-		{userSql, keys.MakeTablePrefix(start), roachpb.RKeyMax, allSplits[1:]},
-		{userSql, keys.MakeTablePrefix(start), keys.MakeTablePrefix(start + 10), allSplits[1:]},
-		{userSql, roachpb.RKeyMin, keys.MakeTablePrefix(start + 10), allSplits},
-		{userSql, keys.MakeTablePrefix(start + 4), keys.MakeTablePrefix(start + 10), allSplits[5:]},
+		{userSql, roachpb.RKeyMin, roachpb.RKeyMax, allUserSplits},
+		{userSql, keys.MakeTablePrefix(start), roachpb.RKeyMax, allUserSplits[1:]},
+		{userSql, keys.MakeTablePrefix(start), keys.MakeTablePrefix(start + 10), allUserSplits[1:]},
+		{userSql, roachpb.RKeyMin, keys.MakeTablePrefix(start + 10), allUserSplits},
+		{userSql, keys.MakeTablePrefix(start + 4), keys.MakeTablePrefix(start + 10), allUserSplits[5:]},
 		{userSql, keys.MakeTablePrefix(start + 5), keys.MakeTablePrefix(start + 10), nil},
 		{userSql, keys.MakeTablePrefix(start + 6), keys.MakeTablePrefix(start + 10), nil},
 		{userSql, keys.MakeKey(keys.MakeTablePrefix(start), roachpb.RKey("foo")),
-			keys.MakeTablePrefix(start + 10), allSplits[1:]},
+			keys.MakeTablePrefix(start + 10), allUserSplits[1:]},
 		{userSql, keys.MakeKey(keys.MakeTablePrefix(start), roachpb.RKey("foo")),
-			keys.MakeTablePrefix(start + 5), allSplits[1:5]},
+			keys.MakeTablePrefix(start + 5), allUserSplits[1:5]},
 		{userSql, keys.MakeKey(keys.MakeTablePrefix(start), roachpb.RKey("foo")),
-			keys.MakeKey(keys.MakeTablePrefix(start+5), roachpb.RKey("bar")), allSplits[1:]},
+			keys.MakeKey(keys.MakeTablePrefix(start+5), roachpb.RKey("bar")), allUserSplits[1:]},
 		{userSql, keys.MakeKey(keys.MakeTablePrefix(start), roachpb.RKey("foo")),
 			keys.MakeKey(keys.MakeTablePrefix(start), roachpb.RKey("morefoo")), nil},
+
+		// Reserved descriptors.
+		{reservedSql, roachpb.RKeyMin, roachpb.RKeyMax, allReservedSplits},
+		{reservedSql, keys.MakeTablePrefix(reservedStart), roachpb.RKeyMax, allReservedSplits[1:]},
+		{reservedSql, keys.MakeTablePrefix(start), roachpb.RKeyMax, nil},
+		{reservedSql, keys.MakeTablePrefix(reservedStart), keys.MakeTablePrefix(start + 10), allReservedSplits[1:]},
+		{reservedSql, roachpb.RKeyMin, keys.MakeTablePrefix(reservedStart + 2), allReservedSplits[:2]},
+		{reservedSql, roachpb.RKeyMin, keys.MakeTablePrefix(reservedStart + 10), allReservedSplits},
+		{reservedSql, keys.MakeTablePrefix(reservedStart), keys.MakeTablePrefix(reservedStart + 2), allReservedSplits[1:2]},
+		{reservedSql, keys.MakeKey(keys.MakeTablePrefix(reservedStart), roachpb.RKey("foo")),
+			keys.MakeKey(keys.MakeTablePrefix(start+10), roachpb.RKey("foo")), allReservedSplits[1:]},
+
+		// Reserved/User mix.
+		{allSql, roachpb.RKeyMin, roachpb.RKeyMax, allSplits},
+		{allSql, keys.MakeTablePrefix(reservedStart + 1), roachpb.RKeyMax, allSplits[2:]},
+		{allSql, keys.MakeTablePrefix(start), roachpb.RKeyMax, allSplits[4:]},
+		{allSql, keys.MakeTablePrefix(reservedStart), keys.MakeTablePrefix(start + 10), allSplits[1:]},
+		{allSql, roachpb.RKeyMin, keys.MakeTablePrefix(start + 2), allSplits[:5]},
+		{allSql, keys.MakeKey(keys.MakeTablePrefix(reservedStart), roachpb.RKey("foo")),
+			keys.MakeKey(keys.MakeTablePrefix(start+5), roachpb.RKey("foo")), allSplits[1:9]},
 	}
 
 	cfg := config.SystemConfig{}

--- a/config/testutil.go
+++ b/config/testutil.go
@@ -43,10 +43,13 @@ func TestingSetupZoneConfigHook(stopper *stop.Stopper) {
 	testingZoneConfig = map[uint32]*ZoneConfig{}
 	testingPreviousHook = ZoneConfigHook
 	ZoneConfigHook = testingZoneConfigHook
-	testingLargestIDHook = func() (max uint32) {
+	testingLargestIDHook = func(maxID uint32) (max uint32) {
 		testingLock.Lock()
 		defer testingLock.Unlock()
 		for id := range testingZoneConfig {
+			if maxID > 0 && id > maxID {
+				continue
+			}
 			if id > max {
 				max = id
 			}

--- a/keys/constants.go
+++ b/keys/constants.go
@@ -168,6 +168,10 @@ var (
 	// TableDataMin is the end of the range of table data keys.
 	TableDataMax = roachpb.Key{encoding.IntMax, 0xff}
 
+	// ReservedTableDataMin is the start key of reserved structured data
+	// (excluding SystemDB).
+	ReservedTableDataMin = roachpb.Key(MakeTablePrefix(MaxSystemDescID + 1))
+
 	// UserTableDataMin is the start key of user structured data.
 	UserTableDataMin = roachpb.Key(MakeTablePrefix(MaxReservedDescID + 1))
 
@@ -180,9 +184,22 @@ var (
 // Various IDs used by the structured data layer.
 // NOTE: these must not change during the lifetime of a cluster.
 const (
-	// MaxReservedDescID is the maximum value of the system IDs
-	// under 'TableDataPrefix'.
-	// It is here only so that we may define keys/ranges using it.
+	// MaxSystemDescID is the maximum value of the system IDs under
+	// 'TableDataPrefix'. Reserved objects with IDs in this range are considered
+	// "system" objects and have considerable special semantics.
+	//
+	// TODO: There is quite a bit of disagreement over the best way to handle
+	// the special semantics needed by these tables; in particular, there is
+	// considerable hesitance to use multiple reserved ranges to hold tables
+	// which require different levels of special support. For the immediate
+	// moment we are using multiple reserved ranges, but that may not be the
+	// case in the near future. Active discussion on github issue #3444:
+	// https://github.com/cockroachdb/cockroach/issues/3444
+	MaxSystemDescID = 500
+
+	// MaxReservedDescID is the maximum value of reserved descriptor IDs
+	// under 'TableDataPrefix'. Reserved IDs are used by namespaces and tables
+	// used internally by cockroach.
 	MaxReservedDescID = 999
 
 	// RootNamespaceID is the ID of the root namespace.
@@ -190,7 +207,7 @@ const (
 
 	// SystemDatabaseID and following are the database/table IDs for objects
 	// in the system span.
-	// NOTE: IDs should remain <= MaxReservedDescID.
+	// NOTE: IDs should remain <= MaxSystemDescID.
 	SystemDatabaseID  = 1
 	NamespaceTableID  = 2
 	DescriptorTableID = 3

--- a/keys/keys.go
+++ b/keys/keys.go
@@ -340,6 +340,16 @@ func MakeTablePrefix(tableID uint32) []byte {
 	return encoding.EncodeUvarint(nil, uint64(tableID))
 }
 
+// DecodeTablePrefix validates that the given key has a table prefix, returning
+// the remainder of the key (with the prefix removed) and the decoded descriptor
+// ID of the table.
+func DecodeTablePrefix(key roachpb.Key) ([]byte, uint64, error) {
+	if encoding.PeekType(key) != encoding.Int {
+		return key, 0, util.Errorf("invalid key prefix: %q", key)
+	}
+	return encoding.DecodeUvarint(key)
+}
+
 // Range returns a key range encompassing all the keys in the Batch.
 // TODO(tschottdorf): there is no protection for doubly-local keys here;
 // maybe Range should return an error.

--- a/keys/spans.go
+++ b/keys/spans.go
@@ -27,7 +27,7 @@ var (
 	UserDataSpan = roachpb.Span{Key: SystemMax, EndKey: TableDataMin}
 
 	// SystemDBSpan is the range of system objects for structured data.
-	SystemDBSpan = roachpb.Span{Key: TableDataMin, EndKey: UserTableDataMin}
+	SystemDBSpan = roachpb.Span{Key: TableDataMin, EndKey: ReservedTableDataMin}
 
 	// NoSplitSpans describes the ranges that should never be split.
 	// Meta1Span: needed to find other ranges.

--- a/sql/system.go
+++ b/sql/system.go
@@ -158,5 +158,5 @@ func addSystemDatabaseToSchema(target *MetadataSchema) {
 
 // IsSystemID returns true if this ID is reserved for system objects.
 func IsSystemID(id ID) bool {
-	return id > 0 && id <= keys.MaxReservedDescID
+	return id > 0 && id <= keys.MaxSystemDescID
 }

--- a/sql/system_test.go
+++ b/sql/system_test.go
@@ -67,7 +67,7 @@ func TestInitialKeys(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if a, e := i, int64(keys.MaxReservedDescID+3); a != e {
+	if a, e := i, int64(keys.MaxReservedDescID+1); a != e {
 		t.Fatalf("Expected next descriptor ID to be %d, was %d", e, a)
 	}
 }

--- a/storage/engine/mvcc_test.go
+++ b/storage/engine/mvcc_test.go
@@ -1878,8 +1878,8 @@ func TestValidSplitKeys(t *testing.T) {
 		{roachpb.Key("a"), true},
 		{roachpb.Key("\xff"), true},
 		{roachpb.Key("\xff\x01"), true},
-		{roachpb.Key(keys.MakeTablePrefix(keys.MaxReservedDescID)), false},
-		{roachpb.Key(keys.MakeTablePrefix(keys.MaxReservedDescID + 1)), true},
+		{roachpb.Key(keys.MakeTablePrefix(keys.MaxSystemDescID)), false},
+		{roachpb.Key(keys.MakeTablePrefix(keys.MaxSystemDescID + 1)), true},
 	}
 
 	for i, test := range testCases {
@@ -1953,7 +1953,7 @@ func TestFindValidSplitKeys(t *testing.T) {
 		{
 			keys: []roachpb.Key{
 				roachpb.Key(keys.MakeTablePrefix(1)),
-				roachpb.Key(keys.MakeTablePrefix(keys.MaxReservedDescID)),
+				roachpb.Key(keys.MakeTablePrefix(keys.MaxSystemDescID)),
 			},
 			expSplit: nil,
 			expError: true,

--- a/storage/queue_test.go
+++ b/storage/queue_test.go
@@ -352,7 +352,7 @@ func TestAcceptsUnsplitRanges(t *testing.T) {
 	if err := neverSplits.setDesc(&roachpb.RangeDescriptor{
 		RangeID:  1,
 		StartKey: roachpb.RKeyMin,
-		EndKey:   keys.Addr(keys.UserTableDataMin),
+		EndKey:   keys.Addr(keys.ReservedTableDataMin),
 	}); err != nil {
 		t.Fatal(err)
 	}
@@ -361,7 +361,7 @@ func TestAcceptsUnsplitRanges(t *testing.T) {
 	willSplit := &Replica{}
 	if err := willSplit.setDesc(&roachpb.RangeDescriptor{
 		RangeID:  2,
-		StartKey: keys.Addr(keys.UserTableDataMin),
+		StartKey: keys.Addr(keys.ReservedTableDataMin),
 		EndKey:   roachpb.RKeyMax,
 	}); err != nil {
 		t.Fatal(err)

--- a/storage/replica_test.go
+++ b/storage/replica_test.go
@@ -585,7 +585,7 @@ func TestRangeGossipConfigsOnLease(t *testing.T) {
 	tc.rng.setDescWithoutProcessUpdate(rngDesc)
 
 	// Write some arbitrary data in the system span (up to, but not including MaxReservedID+1)
-	key := keys.MakeTablePrefix(keys.MaxReservedDescID)
+	key := keys.MakeTablePrefix(keys.MaxSystemDescID)
 	var val roachpb.Value
 	val.SetInt(42)
 	if err := engine.MVCCPut(tc.engine, nil, key, roachpb.MinTimestamp, val, nil); err != nil {


### PR DESCRIPTION
This commit splits the existing range of "reserved" descriptor IDs into two
sets; there is now a range of "System" IDs to hold SystemDB and its tables, and
another non-system "Reserved" range which will hold tables used internally by
CockroachDB that should not be part of SystemDB.

This is being done to support upcoming log-structured tables that Cockroach will
be writing to internally; these tables must be present at cluster bootstrap, but
should also not have their contents gossiped to all nodes.

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/3425)

<!-- Reviewable:end -->
