### PR TITLE
no more busybox

### DIFF
--- a/build/deploy/Dockerfile
+++ b/build/deploy/Dockerfile
@@ -1,4 +1,4 @@
-FROM busybox
+FROM buildpack-deps:jessie-curl
 
 MAINTAINER Tobias Schottdorf <tobias.schottdorf@gmail.com>
 

--- a/circle.yml
+++ b/circle.yml
@@ -31,4 +31,10 @@ deployment:
           fi
       - aws configure set region us-east-1
       - build/build-static-binaries.sh
+      - mkdir -p "${CIRCLE_ARTIFACTS}/acceptance_deploy"
+      - time acceptance/acceptance.test -test.v -test.timeout 5m \
+        -i cockroachdb/cockroach -num-local 3 \
+        -l "${CIRCLE_ARTIFACTS}"/acceptance_deploy 2>&1 | \
+        tr -d '\r' | tee "${CIRCLE_ARTIFACTS}/acceptance_deploy.log" | \
+        grep -E "^\--- (PASS|FAIL)|^(FAIL|ok)" | awk '{print "acceptance:", $0}'
       - build/push-aws.sh


### PR DESCRIPTION
with an image that links `glibc`.
also reinstated running the acceptance tests
against the generated deply image. this appears
to have been lost somewhere during restructuring.

Unfortunately my changes to `circle.yml` will only
run on the merge to `master`, but I've tested the
command locally and it works.

Fixes #3426.

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/3427)

<!-- Reviewable:end -->
