### PR TITLE
Add new rpc.Client.WaitHealthy().

### DIFF
--- a/client/client_test.go
+++ b/client/client_test.go
@@ -85,7 +85,7 @@ func createTestClient(t *testing.T, stopper *stop.Stopper, addr string) *client.
 }
 
 func createTestClientForUser(t *testing.T, stopper *stop.Stopper, addr, user string) *client.DB {
-	db, err := client.Open(stopper, fmt.Sprintf("rpcs://%s@%s?certs=%s&failfast=1",
+	db, err := client.Open(stopper, fmt.Sprintf("rpcs://%s@%s?certs=%s",
 		user, addr, security.EmbeddedCertsDir))
 	if err != nil {
 		t.Fatal(err)

--- a/client/db.go
+++ b/client/db.go
@@ -234,12 +234,7 @@ func Open(stopper *stop.Stopper, addr string) (*DB, error) {
 		ctx.Certs = dir[0]
 	}
 
-	retryOpts := defaultRetryOptions
-	if failFast := q["failfast"]; len(failFast) > 0 {
-		retryOpts.MaxRetries = 1
-	}
-
-	sender, err := newSender(u, ctx, retryOpts, stopper)
+	sender, err := newSender(u, ctx, stopper)
 	if err != nil {
 		return nil, err
 	}

--- a/client/rpc_sender.go
+++ b/client/rpc_sender.go
@@ -29,14 +29,13 @@ import (
 	"github.com/cockroachdb/cockroach/rpc"
 	"github.com/cockroachdb/cockroach/util/hlc"
 	"github.com/cockroachdb/cockroach/util/log"
-	"github.com/cockroachdb/cockroach/util/retry"
 	"github.com/cockroachdb/cockroach/util/stop"
 )
 
 func init() {
-	f := func(u *url.URL, ctx *base.Context, retryOpts retry.Options, stopper *stop.Stopper) (Sender, error) {
+	f := func(u *url.URL, ctx *base.Context, stopper *stop.Stopper) (Sender, error) {
 		ctx.Insecure = (u.Scheme != "rpcs")
-		return newRPCSender(u.Host, ctx, retryOpts, stopper)
+		return newRPCSender(u.Host, ctx, stopper)
 	}
 	RegisterSender("rpc", f)
 	RegisterSender("rpcs", f)
@@ -49,12 +48,11 @@ const method = "Server.Batch"
 // via RPC to a Cockroach node. Overly-busy nodes will redirect this
 // client to other nodes.
 type rpcSender struct {
-	client    *rpc.Client
-	retryOpts retry.Options
+	client *rpc.Client
 }
 
 // newRPCSender returns a new instance of rpcSender.
-func newRPCSender(server string, context *base.Context, retryOpts retry.Options, stopper *stop.Stopper) (*rpcSender, error) {
+func newRPCSender(server string, context *base.Context, stopper *stop.Stopper) (*rpcSender, error) {
 	addr, err := net.ResolveTCPAddr("tcp", server)
 	if err != nil {
 		return nil, err
@@ -72,8 +70,7 @@ func newRPCSender(server string, context *base.Context, retryOpts retry.Options,
 	client := rpc.NewClient(addr, ctx)
 
 	return &rpcSender{
-		client:    client,
-		retryOpts: retryOpts,
+		client: client,
 	}, nil
 }
 
@@ -89,29 +86,13 @@ func (s *rpcSender) Send(ctx context.Context, ba roachpb.BatchRequest) (*roachpb
 			fmt.Errorf("failed to send RPC request %s: client is unhealthy", method))
 	}
 
-	var err error
-	var br roachpb.BatchResponse
-	for r := retry.Start(s.retryOpts); r.Next(); {
-		if err = s.client.Call(method, &ba, &br); err != nil {
-			br.Reset() // don't trust anyone.
-			// Assume all errors sending request are retryable. The actual
-			// number of things that could go wrong is vast, but we don't
-			// want to miss any which should in theory be retried with the
-			// same client command ID. We log the error here as a warning so
-			// there's visibility that this is happening. Some of the errors
-			// we'll sweep up in this net shouldn't be retried, but we can't
-			// really know for sure which.
-			log.Warningf("failed to send RPC request %s: %s", method, err)
-			continue
-		}
-
-		// On successful post, we're done with retry loop.
-		break
-	}
-	if err != nil {
+	br := &roachpb.BatchResponse{}
+	if err := s.client.Call(method, &ba, br); err != nil {
+		log.Errorf("failed to send RPC request %s: %s", method, err)
 		return nil, roachpb.NewError(err)
 	}
+
 	pErr := br.Error
 	br.Error = nil
-	return &br, pErr
+	return br, pErr
 }

--- a/client/sender.go
+++ b/client/sender.go
@@ -21,25 +21,14 @@ import (
 	"fmt"
 	"net/url"
 	"sync"
-	"time"
 
 	"golang.org/x/net/context"
 
 	"github.com/cockroachdb/cockroach/base"
 	"github.com/cockroachdb/cockroach/roachpb"
 	"github.com/cockroachdb/cockroach/util/log"
-	"github.com/cockroachdb/cockroach/util/retry"
 	"github.com/cockroachdb/cockroach/util/stop"
 )
-
-// defaultRetryOptions sets the retry options for handling retryable errors and
-// connection I/O errors.
-var defaultRetryOptions = retry.Options{
-	InitialBackoff: 250 * time.Millisecond,
-	MaxBackoff:     5 * time.Second,
-	Multiplier:     2,
-	MaxRetries:     5,
-}
 
 // Sender is the interface used to call into a Cockroach instance.
 // If the returned *roachpb.Error is not nil, no response should be returned.
@@ -56,15 +45,15 @@ func (f SenderFunc) Send(ctx context.Context, ba roachpb.BatchRequest) (*roachpb
 	return f(ctx, ba)
 }
 
-// NewSenderFunc creates a new sender for the registered scheme.
-type NewSenderFunc func(u *url.URL, ctx *base.Context, retryOpts retry.Options, stopper *stop.Stopper) (Sender, error)
+// newSenderFunc creates a new sender for the registered scheme.
+type newSenderFunc func(u *url.URL, ctx *base.Context, stopper *stop.Stopper) (Sender, error)
 
 var sendersMu sync.Mutex
-var senders = map[string]NewSenderFunc{}
+var senders = map[string]newSenderFunc{}
 
 // RegisterSender registers the specified function to be used for
 // creation of a new sender when the specified scheme is encountered.
-func RegisterSender(scheme string, f NewSenderFunc) {
+func RegisterSender(scheme string, f newSenderFunc) {
 	if f == nil {
 		log.Fatalf("unable to register nil function for \"%s\"", scheme)
 	}
@@ -76,14 +65,14 @@ func RegisterSender(scheme string, f NewSenderFunc) {
 	senders[scheme] = f
 }
 
-func newSender(u *url.URL, ctx *base.Context, retryOptions retry.Options, stopper *stop.Stopper) (Sender, error) {
+func newSender(u *url.URL, ctx *base.Context, stopper *stop.Stopper) (Sender, error) {
 	sendersMu.Lock()
 	defer sendersMu.Unlock()
 	f := senders[u.Scheme]
 	if f == nil {
 		return nil, fmt.Errorf("no sender registered for \"%s\"", u.Scheme)
 	}
-	return f(u, ctx, retryOptions, stopper)
+	return f(u, ctx, stopper)
 }
 
 // SendWrappedWith is a convenience function which wraps the request in a batch

--- a/kv/db_test.go
+++ b/kv/db_test.go
@@ -36,7 +36,7 @@ func createTestClient(t *testing.T, stopper *stop.Stopper, addr string) *client.
 }
 
 func createTestClientForUser(t *testing.T, stopper *stop.Stopper, addr, user string) *client.DB {
-	db, err := client.Open(stopper, fmt.Sprintf("rpcs://%s@%s?certs=%s&failfast=1",
+	db, err := client.Open(stopper, fmt.Sprintf("rpcs://%s@%s?certs=%s",
 		user, addr, security.EmbeddedCertsDir))
 	if err != nil {
 		t.Fatal(err)

--- a/kv/dist_sender_server_test.go
+++ b/kv/dist_sender_server_test.go
@@ -208,6 +208,7 @@ func TestMultiRangeScanReverseScanDeleteResolve(t *testing.T) {
 // using the clock local to the distributed sender.
 func TestMultiRangeScanReverseScanInconsistent(t *testing.T) {
 	defer leaktest.AfterTest(t)
+
 	s, db := setupMultipleRanges(t, "b")
 	defer s.Stop()
 
@@ -228,7 +229,7 @@ func TestMultiRangeScanReverseScanInconsistent(t *testing.T) {
 				t.Fatal(err)
 			}
 			ts[i] = b.Results[0].Rows[0].Timestamp()
-			log.Infof("%d: %s", i, b.Results[0].Rows[0].Timestamp())
+			log.Infof("%d: %d.%d", i, ts[i].Unix(), ts[i].Nanosecond())
 		}
 	}
 

--- a/kv/dist_sender_server_test.go
+++ b/kv/dist_sender_server_test.go
@@ -18,6 +18,7 @@
 package kv_test
 
 import (
+	"errors"
 	"reflect"
 	"sync/atomic"
 	"testing"
@@ -32,6 +33,7 @@ import (
 	"github.com/cockroachdb/cockroach/storage"
 	"github.com/cockroachdb/cockroach/storage/engine"
 	"github.com/cockroachdb/cockroach/testutils"
+	"github.com/cockroachdb/cockroach/util"
 	"github.com/cockroachdb/cockroach/util/hlc"
 	"github.com/cockroachdb/cockroach/util/leaktest"
 	"github.com/cockroachdb/cockroach/util/log"
@@ -216,20 +218,25 @@ func TestMultiRangeScanReverseScanInconsistent(t *testing.T) {
 	// second range.
 	keys := [2]string{"a", "b"}
 	ts := [2]time.Time{}
-	// This outer loop may seem awkward, but we've actually had issue #3122
-	// since the two timestamps ended up equal. This can happen (very rarely)
-	// since both timestamps are HLC internally and then have their logical
-	// component dropped. Lease changes can push the HLC ahead of the wall
-	// time for short amounts of time, so that losing the logical tick matters.
-	for !ts[1].After(ts[0]) {
-		for i, key := range keys {
-			b := &client.Batch{}
-			b.Put(key, "value")
-			if err := db.Run(b); err != nil {
-				t.Fatal(err)
-			}
-			ts[i] = b.Results[0].Rows[0].Timestamp()
-			log.Infof("%d: %d.%d", i, ts[i].Unix(), ts[i].Nanosecond())
+	for i, key := range keys {
+		b := &client.Batch{}
+		b.Put(key, "value")
+		if err := db.Run(b); err != nil {
+			t.Fatal(err)
+		}
+		ts[i] = b.Results[0].Rows[0].Timestamp()
+		log.Infof("%d: %d.%d", i, ts[i].Unix(), ts[i].Nanosecond())
+		if i == 0 {
+			util.SucceedsWithin(t, time.Second, func() error {
+				// Enforce that when we write the second key, it's written
+				// with a strictly higher timestamp. We're dropping logical
+				// ticks and the clock may just have been pushed into the
+				// future, so that's necessary. See #3122.
+				if !s.Clock().PhysicalTime().After(ts[0]) {
+					return errors.New("time stands still")
+				}
+				return nil
+			})
 		}
 	}
 

--- a/roachpb/data.go
+++ b/roachpb/data.go
@@ -211,7 +211,7 @@ func (t Timestamp) Equal(s Timestamp) bool {
 }
 
 func (t Timestamp) String() string {
-	return fmt.Sprintf("%.09f,%d", float64(t.WallTime)/1E9, t.Logical)
+	return fmt.Sprintf("%d.%09d,%d", t.WallTime/1E9, t.WallTime%1E9, t.Logical)
 }
 
 // Add returns a timestamp with the WallTime and Logical components increased.

--- a/rpc/client.go
+++ b/rpc/client.go
@@ -85,6 +85,8 @@ type Client struct {
 	closer, Closed chan struct{}
 	conn           unsafe.Pointer // holds a `internalConn`
 	healthy        atomic.Value   // holds a `chan struct{}` exposed in `Healthy`
+	healthWaitTime time.Time
+	healthReceived chan struct{}
 	tlsConfig      *tls.Config
 
 	clock        *hlc.Clock
@@ -132,6 +134,8 @@ func NewClient(addr net.Addr, context *Context) *Client {
 	}
 
 	c.healthy.Store(make(chan struct{}))
+	c.healthWaitTime = time.Now().Add(context.HealthWait)
+	c.healthReceived = make(chan struct{})
 
 	if !context.DisableCache {
 		clients[key] = c
@@ -191,6 +195,39 @@ func (c *Client) Healthy() <-chan struct{} {
 	return c.healthy.Load().(chan struct{})
 }
 
+func (c *Client) isHealthy() bool {
+	select {
+	case <-c.Healthy():
+		return true
+	default:
+	}
+	return false
+}
+
+// WaitHealthy returns the health of the Client. On the first connection of a
+// newly-created Client, WaitHealthy will block for up to Context.HealthWait if
+// its health has not yet been determined.
+func (c *Client) WaitHealthy() bool {
+	// If we shouldn't wait for healthy, return immediately. The healthReceived
+	// channel is closed after we receive the first health indication for the
+	// client (i.e. (un)successful heartbeat or failure to open the connection).
+	select {
+	case <-c.healthReceived:
+		return c.isHealthy()
+	default:
+	}
+
+	if delta := c.healthWaitTime.Sub(time.Now()); delta > 0 {
+		select {
+		case <-time.After(delta):
+		case <-c.healthReceived:
+			return c.isHealthy()
+		case <-c.closer:
+		}
+	}
+	return false
+}
+
 // Close closes the client, removing it from the clients cache and returning
 // when the heartbeat goroutine has exited.
 func (c *Client) Close() {
@@ -215,6 +252,14 @@ func (c *Client) close() {
 // or unhealthy and reconnecting appropriately until either the Client or the
 // supplied channel is closed.
 func (c *Client) runHeartbeat(retryOpts retry.Options) {
+	healthReceived := c.healthReceived
+	setHealthReceived := func() {
+		if healthReceived != nil {
+			close(healthReceived)
+			healthReceived = nil
+		}
+	}
+
 	isHealthy := false
 	setHealthy := func() {
 		if isHealthy {
@@ -222,12 +267,14 @@ func (c *Client) runHeartbeat(retryOpts retry.Options) {
 		}
 		isHealthy = true
 		close(c.healthy.Load().(chan struct{}))
+		setHealthReceived()
 	}
 	setUnhealthy := func() {
 		if isHealthy {
 			isHealthy = false
 			c.healthy.Store(make(chan struct{}))
 		}
+		setHealthReceived()
 	}
 
 	var err = errUnstarted // initial condition

--- a/rpc/rpc.go
+++ b/rpc/rpc.go
@@ -1,6 +1,8 @@
 package rpc
 
 import (
+	"time"
+
 	"github.com/cockroachdb/cockroach/base"
 	"github.com/cockroachdb/cockroach/util/hlc"
 	"github.com/cockroachdb/cockroach/util/stop"
@@ -15,6 +17,7 @@ type Context struct {
 	Stopper      *stop.Stopper
 	RemoteClocks *RemoteClockMonitor
 	DisableCache bool // Disable client cache when calling NewClient()
+	HealthWait   time.Duration
 }
 
 // NewContext creates an rpc Context with the supplied values.
@@ -24,6 +27,7 @@ func NewContext(context *base.Context, clock *hlc.Clock, stopper *stop.Stopper) 
 		localClock:   clock,
 		Stopper:      stopper,
 		RemoteClocks: newRemoteClockMonitor(clock),
+		HealthWait:   5 * time.Second,
 	}
 	return ctx
 }
@@ -31,11 +35,7 @@ func NewContext(context *base.Context, clock *hlc.Clock, stopper *stop.Stopper) 
 // Copy creates a copy of the rpc Context config values, but with a
 // new remote clock monitor.
 func (c *Context) Copy() *Context {
-	return &Context{
-		Context:      c.Context,
-		localClock:   c.localClock,
-		Stopper:      c.Stopper,
-		RemoteClocks: newRemoteClockMonitor(c.localClock),
-		DisableCache: c.DisableCache,
-	}
+	copy := *c
+	copy.RemoteClocks = newRemoteClockMonitor(c.localClock)
+	return &copy
 }


### PR DESCRIPTION
Various "kv" and "client" tests set "failfast=1" which reduces the
number of retries to 1. When using the default retry options, this gives
the sender 250ms in which to perform the initial connection and
heartbeat which sometimes fails to occur, especially on CircleCI. Now we
track when an rpc.Client was created and wait up to 5 seconds for the
initial heartbeat.

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/3428)

<!-- Reviewable:end -->
