### PR TITLE
another acceptance fix

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -32,9 +32,8 @@ deployment:
       - aws configure set region us-east-1
       - build/build-static-binaries.sh
       - mkdir -p "${CIRCLE_ARTIFACTS}/acceptance_deploy"
-      - time acceptance/acceptance.test -test.v -test.timeout 5m \
-        -i cockroachdb/cockroach -num-local 3 \
-        -l "${CIRCLE_ARTIFACTS}"/acceptance_deploy 2>&1 |
-        tr -d '\r' | tee "${CIRCLE_ARTIFACTS}/acceptance_deploy.log" |
-        grep -E "^\--- (PASS|FAIL)|^(FAIL|ok)" | awk '{print "acceptance:", $0}'
+      - time acceptance/acceptance.test -test.v -test.timeout 5m
+          -i cockroachdb/cockroach -num-local 3
+          -l "${CIRCLE_ARTIFACTS}"/acceptance_deploy 2>&1 >
+          "${CIRCLE_ARTIFACTS}/acceptance_deploy.log"
       - build/push-aws.sh


### PR DESCRIPTION
my last fix still didn't do the trick.

Doesn't work (test doesn't realize that `-num-local` is set)
`time acceptance/acceptance.test -test.v -test.timeout 5m \ -i cockroachdb/cockroach -num-local 3`

works (note the removed `\`):
`time acceptance/acceptance.test -test.v -test.timeout 5m  -i cockroachdb/cockroach -num-local 3`

I think the newlines don't count in `yaml` and so we're trying to escape a
simple space, but there's nothing to escape and we get a literal backslash.
That ends the flag parsing, and so this was broken.

Additionally, there's no condition here to fail the test run. We rely on the
file `excerpt.txt`, but that is created and checked in `circle-test.sh`.
This seems ripe for some refactoring by anyone interested.

For now, I'm just going to run the test directly and without any piping that
would obscure the exit code.

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/3430)

<!-- Reviewable:end -->
