### PR TITLE
roachpb: Add an extra comment to NewTransactionPushError

### DIFF
--- a/roachpb/errors.go
+++ b/roachpb/errors.go
@@ -275,6 +275,9 @@ func (e *TransactionAbortedError) Transaction() *Transaction {
 func NewTransactionPushError(txn, pusheeTxn Transaction) *TransactionPushError {
 	err := &TransactionPushError{PusheeTxn: *pusheeTxn.Clone()}
 	if len(txn.ID) != 0 {
+		// When the pusher is non-transactional, txn will be
+		// empty but for the priority. In that case, ignore it
+		// here.
 		err.Txn = txn.Clone()
 	}
 	return err


### PR DESCRIPTION
Explain why we set err.Txn only when txn.ID is actually set. We need this since a pusher Txn can be a fake one that contains priority without ID (see Store.resolveWriteIntentError).

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/3451)

<!-- Reviewable:end -->
