### PR TITLE
harden ChaosMonkey

### DIFF
--- a/acceptance/build_info_test.go
+++ b/acceptance/build_info_test.go
@@ -35,6 +35,8 @@ func TestBuildInfo(t *testing.T) {
 	l.Start()
 	defer l.AssertAndStop(t)
 
+	checkGossip(t, l, 20*time.Second, hasPeers(l.NumNodes()))
+
 	util.SucceedsWithin(t, 10*time.Second, func() error {
 		select {
 		case <-stopper:


### PR DESCRIPTION
while nodes are restarting, clients (now) return errors
more eagerly. Ignore those (for they're expected). The
log output has become a little more spammy, but I think
that's acceptable for the time being.

Fixes #3450.

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/3453)

<!-- Reviewable:end -->
