### PR TITLE
ui/Makefile: linters are installed by npm

### DIFF
--- a/ui/Makefile
+++ b/ui/Makefile
@@ -83,7 +83,7 @@ all: lint $(GOBINDATA_TARGET) $(TEST_TARGET) $(PROTO_JSON_TARGET)
 	rm -f $(GOBINDATA_DEBUG_TARGET)
 
 .PHONY:
-lint:
+lint: npm.installed
 	stylint -c .stylintrc $(STYL_ROOT)
 	tslint -c $(TS_ROOT)/tslint.json $(shell find $(TS_ROOT) -name '*.ts')
 


### PR DESCRIPTION
Fixes #3456.

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/3457)

<!-- Reviewable:end -->
