### PR TITLE
Build and push all tests to AWS.

### DIFF
--- a/build/build-static-binaries.sh
+++ b/build/build-static-binaries.sh
@@ -12,17 +12,28 @@ source $(dirname $0)/build-common.sh
 # commands in the if-branch to be executed within the docker
 # container.
 if [ "${1-}" = "docker" ]; then
+    test_build_dir=$(mktemp -d test-binaries.XXXX)
     time make STATIC=1 build
+    # sql/sql.test is built standalone as well to simplify the nightly logictest runs.
     time make STATIC=1 testbuild PKG=./sql
     time make STATIC=1 testbuild PKG=./acceptance TAGS=acceptance
+    time make STATIC=1 testbuildall DIR=${test_build_dir}
 
+    # We don't check all test binaries, but one from each invocation.
     check_static cockroach
     check_static sql/sql.test
     check_static acceptance/acceptance.test
+    check_static ${test_build_dir}/github.com/cockroachdb/cockroach/sql/sql.test
 
     strip -S cockroach
     strip -S sql/sql.test
     strip -S acceptance/acceptance.test
+
+    rm -f static-tests.tar.gz
+    # Skip the project/repo part of the path inside the tarball.
+    # Even for stripped binaries, gzip results in 167MB (21s spent) vs 512MB (3s spent).
+    # It makes a big difference when fetching from outside AWS.
+    time tar cfz static-tests.tar.gz -C ${test_build_dir}/github.com/cockroachdb/ cockroach/
     exit 0
 fi
 

--- a/build/push-aws.sh
+++ b/build/push-aws.sh
@@ -40,3 +40,4 @@ function push_one_binary {
 push_one_binary cockroach
 push_one_binary sql/sql.test
 push_one_binary acceptance/acceptance.test
+push_one_binary static-tests.tar.gz


### PR DESCRIPTION
- add DIR and STRIPPED args to testbuild rule
- build all tests and tar them up

We still build sql.test by itself to make the nightly logictest easier
(it can grab that single binary as opposed to grabbing the tarball and
extracting the needed one).

Gzipping the tarball to reduce size. This is particularly critical when
running from the office.

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/3459)

<!-- Reviewable:end -->
