### PR TITLE
Replace variable and mutex pattern with anonymous synchronized struct pattern

### DIFF
--- a/client/sender.go
+++ b/client/sender.go
@@ -48,8 +48,10 @@ func (f SenderFunc) Send(ctx context.Context, ba roachpb.BatchRequest) (*roachpb
 // newSenderFunc creates a new sender for the registered scheme.
 type newSenderFunc func(u *url.URL, ctx *base.Context, stopper *stop.Stopper) (Sender, error)
 
-var sendersMu sync.Mutex
-var senders = map[string]newSenderFunc{}
+var senders = struct {
+	sync.Mutex
+	m map[string]newSenderFunc
+}{m: map[string]newSenderFunc{}}
 
 // RegisterSender registers the specified function to be used for
 // creation of a new sender when the specified scheme is encountered.
@@ -57,18 +59,18 @@ func RegisterSender(scheme string, f newSenderFunc) {
 	if f == nil {
 		log.Fatalf("unable to register nil function for \"%s\"", scheme)
 	}
-	sendersMu.Lock()
-	defer sendersMu.Unlock()
-	if _, ok := senders[scheme]; ok {
+	senders.Lock()
+	defer senders.Unlock()
+	if _, ok := senders.m[scheme]; ok {
 		log.Fatalf("sender already registered for \"%s\"", scheme)
 	}
-	senders[scheme] = f
+	senders.m[scheme] = f
 }
 
 func newSender(u *url.URL, ctx *base.Context, stopper *stop.Stopper) (Sender, error) {
-	sendersMu.Lock()
-	defer sendersMu.Unlock()
-	f := senders[u.Scheme]
+	senders.Lock()
+	defer senders.Unlock()
+	f := senders.m[u.Scheme]
 	if f == nil {
 		return nil, fmt.Errorf("no sender registered for \"%s\"", u.Scheme)
 	}


### PR DESCRIPTION
I saw this pattern in a talk from Andrew Gerrand and thought it was pretty neat. Personally I think it cleans up the readability of the code, but let me know what you think.

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/3467)

<!-- Reviewable:end -->
