### PR TITLE
Fix acceptance/.gitignore

### DIFF
--- a/acceptance/.gitignore
+++ b/acceptance/.gitignore
@@ -1,1 +1,2 @@
+.localcluster.certs.*
 .cluster.certs.*


### PR DESCRIPTION
`.localcluster.certs` was removed from gitignore, but it's still used in
the local acceptance tests.

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/3469)

<!-- Reviewable:end -->
