### PR TITLE
Add Range Event Table to Bootstrap Schema

### DIFF
--- a/cli/cli_test.go
+++ b/cli/cli_test.go
@@ -24,7 +24,6 @@ import (
 	"regexp"
 	"strings"
 	"testing"
-	"time"
 
 	"github.com/cockroachdb/cockroach/security"
 	"github.com/cockroachdb/cockroach/server"
@@ -194,7 +193,6 @@ func Example_insecure() {
 
 func Example_ranges() {
 	c := newCLITest()
-	c.TestServer.WaitForInitialSplits(nil, time.Second)
 
 	c.Run("kv put a 1 b 2 c 3 d 4")
 	c.Run("kv scan")

--- a/cli/cli_test.go
+++ b/cli/cli_test.go
@@ -24,6 +24,7 @@ import (
 	"regexp"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/cockroachdb/cockroach/security"
 	"github.com/cockroachdb/cockroach/server"
@@ -193,6 +194,7 @@ func Example_insecure() {
 
 func Example_ranges() {
 	c := newCLITest()
+	c.TestServer.WaitForInitialSplits(nil, time.Second)
 
 	c.Run("kv put a 1 b 2 c 3 d 4")
 	c.Run("kv scan")
@@ -227,9 +229,13 @@ func Example_ranges() {
 	// range ls
 	// /Min-"c" [1]
 	// 	0: node-id=1 store-id=1
-	// "c"-/Max [2]
+	// "c"-/Table/501 [4]
 	// 	0: node-id=1 store-id=1
-	// 2 result(s)
+	// /Table/501-/Table/502 [2]
+	// 	0: node-id=1 store-id=1
+	// /Table/502-/Max [3]
+	// 	0: node-id=1 store-id=1
+	// 4 result(s)
 	// kv scan
 	// "a"	"1"
 	// "b"	"2"
@@ -244,9 +250,13 @@ func Example_ranges() {
 	// 4 result(s)
 	// range merge b
 	// range ls
-	// /Min-/Max [1]
+	// /Min-/Table/501 [1]
 	// 	0: node-id=1 store-id=1
-	// 1 result(s)
+	// /Table/501-/Table/502 [2]
+	// 	0: node-id=1 store-id=1
+	// /Table/502-/Max [3]
+	// 	0: node-id=1 store-id=1
+	// 3 result(s)
 	// kv scan
 	// "a"	"1"
 	// "b"	"2"

--- a/config/config.go
+++ b/config/config.go
@@ -78,6 +78,14 @@ func TestingDisableTableSplits() func() {
 	}
 }
 
+// TestingTableSplitsDisabled is a testing-only function that returns true if table
+// splits are currently disabled.
+func TestingTableSplitsDisabled() bool {
+	testingLock.Lock()
+	defer testingLock.Unlock()
+	return testingDisableTableSplits
+}
+
 // Validate verifies some ZoneConfig fields.
 // This should be used to validate user input when setting a new zone config.
 func (z ZoneConfig) Validate() error {
@@ -271,10 +279,7 @@ func (s SystemConfig) getZoneConfigForID(id uint32) (*ZoneConfig, error) {
 // at which to split the span [start, end).
 // The only required splits are at each user table prefix.
 func (s SystemConfig) ComputeSplitKeys(startKey, endKey roachpb.RKey) []roachpb.RKey {
-	testingLock.Lock()
-	tableSplitsDisabled := testingDisableTableSplits
-	testingLock.Unlock()
-	if tableSplitsDisabled {
+	if TestingTableSplitsDisabled() {
 		return nil
 	}
 

--- a/kv/dist_sender.go
+++ b/kv/dist_sender.go
@@ -62,6 +62,13 @@ var defaultRPCRetryOptions = retry.Options{
 	Multiplier:     2,
 }
 
+// GetDefaultDistSenderRetryOptions returns the default retry options for a
+// DistSender. This is helpful for users that want to overwrite a subset of the
+// default options when creating a custom DistSenderContext.
+func GetDefaultDistSenderRetryOptions() retry.Options {
+	return defaultRPCRetryOptions
+}
+
 // A firstRangeMissingError indicates that the first range has not yet
 // been gossiped. This will be the case for a node which hasn't yet
 // joined the gossip network.

--- a/kv/dist_sender_server_test.go
+++ b/kv/dist_sender_server_test.go
@@ -80,9 +80,6 @@ func TestRangeLookupWithOpenTransaction(t *testing.T) {
 func setupMultipleRanges(t *testing.T, ts *server.TestServer, splitAt ...string) *client.DB {
 	db := createTestClient(t, ts.Stopper(), ts.ServingAddr())
 
-	// Wait for initial splits to finish.
-	ts.WaitForInitialSplits(t, time.Second)
-
 	// Split the keyspace at the given keys.
 	for _, key := range splitAt {
 		if err := db.AdminSplit(key); err != nil {
@@ -289,7 +286,6 @@ func TestMultiRangeScanReverseScanInconsistent(t *testing.T) {
 
 func initReverseScanTestEnv(s *server.TestServer, t *testing.T) *client.DB {
 	db := createTestClient(t, s.Stopper(), s.ServingAddr())
-	s.WaitForInitialSplits(t, time.Second)
 
 	// Set up multiple ranges:
 	// ["", "b"),["b", "e") ,["e", "g") and ["g", "\xff\xff").

--- a/kv/dist_sender_server_test.go
+++ b/kv/dist_sender_server_test.go
@@ -28,7 +28,6 @@ import (
 	"github.com/cockroachdb/cockroach/kv"
 	"github.com/cockroachdb/cockroach/roachpb"
 	"github.com/cockroachdb/cockroach/server"
-	"github.com/cockroachdb/cockroach/sql"
 	"github.com/cockroachdb/cockroach/storage"
 	"github.com/cockroachdb/cockroach/storage/engine"
 	"github.com/cockroachdb/cockroach/testutils"
@@ -78,24 +77,28 @@ func TestRangeLookupWithOpenTransaction(t *testing.T) {
 // key range at the given keys. Returns the test server and client.
 // The caller is responsible for stopping the server and
 // closing the client.
-func setupMultipleRanges(t *testing.T, splitAt ...string) (*server.TestServer, *client.DB) {
-	s := server.StartTestServer(t)
-	db := createTestClient(t, s.Stopper(), s.ServingAddr())
+func setupMultipleRanges(t *testing.T, ts *server.TestServer, splitAt ...string) *client.DB {
+	db := createTestClient(t, ts.Stopper(), ts.ServingAddr())
+
+	// Wait for initial splits to finish.
+	ts.WaitForInitialSplits(t, time.Second)
 
 	// Split the keyspace at the given keys.
 	for _, key := range splitAt {
 		if err := db.AdminSplit(key); err != nil {
+			// Don't leak server goroutines.
 			t.Fatal(err)
 		}
 	}
 
-	return s, db
+	return db
 }
 
 func TestMultiRangeBatchBounded(t *testing.T) {
 	defer leaktest.AfterTest(t)
-	s, db := setupMultipleRanges(t, "a", "b", "c", "d", "e", "f")
+	s := server.StartTestServer(t)
 	defer s.Stop()
+	db := setupMultipleRanges(t, s, "a", "b", "c", "d", "e", "f")
 	for _, key := range []string{"a", "aa", "aaa", "b", "bb", "cc", "d", "dd", "ff"} {
 		if err := db.Put(key, "value"); err != nil {
 			t.Fatal(err)
@@ -136,8 +139,9 @@ func TestMultiRangeBatchBounded(t *testing.T) {
 // truncation. In that case, the request is skipped.
 func TestMultiRangeEmptyAfterTruncate(t *testing.T) {
 	defer leaktest.AfterTest(t)
-	s, db := setupMultipleRanges(t, "c", "d")
+	s := server.StartTestServer(t)
 	defer s.Stop()
+	db := setupMultipleRanges(t, s, "c", "d")
 
 	// Delete the keys within a transaction. Implicitly, the intents are
 	// resolved via ResolveIntentRange upon completion.
@@ -156,8 +160,9 @@ func TestMultiRangeEmptyAfterTruncate(t *testing.T) {
 // DeleteRange and ResolveIntentRange work across ranges.
 func TestMultiRangeScanReverseScanDeleteResolve(t *testing.T) {
 	defer leaktest.AfterTest(t)
-	s, db := setupMultipleRanges(t, "b")
+	s := server.StartTestServer(t)
 	defer s.Stop()
+	db := setupMultipleRanges(t, s, "b")
 
 	// Write keys before, at, and after the split key.
 	for _, key := range []string{"a", "b", "c"} {
@@ -210,8 +215,9 @@ func TestMultiRangeScanReverseScanDeleteResolve(t *testing.T) {
 func TestMultiRangeScanReverseScanInconsistent(t *testing.T) {
 	defer leaktest.AfterTest(t)
 
-	s, db := setupMultipleRanges(t, "b")
+	s := server.StartTestServer(t)
 	defer s.Stop()
+	db := setupMultipleRanges(t, s, "b")
 
 	// Write keys "a" and "b", the latter of which is the first key in the
 	// second range.
@@ -281,9 +287,9 @@ func TestMultiRangeScanReverseScanInconsistent(t *testing.T) {
 	}
 }
 
-func initReverseScanTestEnv(t *testing.T) (*server.TestServer, *client.DB) {
-	s := server.StartTestServer(t)
+func initReverseScanTestEnv(s *server.TestServer, t *testing.T) *client.DB {
 	db := createTestClient(t, s.Stopper(), s.ServingAddr())
+	s.WaitForInitialSplits(t, time.Second)
 
 	// Set up multiple ranges:
 	// ["", "b"),["b", "e") ,["e", "g") and ["g", "\xff\xff").
@@ -299,15 +305,16 @@ func initReverseScanTestEnv(t *testing.T) (*server.TestServer, *client.DB) {
 			t.Fatal(err)
 		}
 	}
-	return s, db
+	return db
 }
 
 // TestSingleRangeReverseScan verifies that ReverseScan gets the right results
 // on a single range.
 func TestSingleRangeReverseScan(t *testing.T) {
 	defer leaktest.AfterTest(t)
-	s, db := initReverseScanTestEnv(t)
+	s := server.StartTestServer(t)
 	defer s.Stop()
+	db := initReverseScanTestEnv(s, t)
 
 	// Case 1: Request.EndKey is in the middle of the range.
 	if rows, err := db.ReverseScan("b", "d", 0); err != nil {
@@ -323,7 +330,7 @@ func TestSingleRangeReverseScan(t *testing.T) {
 	}
 	// Case 3: Test roachpb.KeyMax
 	// This span covers the system DB keys.
-	wanted := 1 + len(sql.MakeMetadataSchema().GetInitialValues())
+	wanted := 1 + len(server.GetBootstrapSchema().GetInitialValues())
 	if rows, err := db.ReverseScan("g", roachpb.KeyMax, 0); err != nil {
 		t.Fatalf("unexpected error on ReverseScan: %s", err)
 	} else if l := len(rows); l != wanted {
@@ -344,8 +351,9 @@ func TestSingleRangeReverseScan(t *testing.T) {
 // across multiple ranges.
 func TestMultiRangeReverseScan(t *testing.T) {
 	defer leaktest.AfterTest(t)
-	s, db := initReverseScanTestEnv(t)
+	s := server.StartTestServer(t)
 	defer s.Stop()
+	db := initReverseScanTestEnv(s, t)
 
 	// Case 1: Request.EndKey is in the middle of the range.
 	if rows, err := db.ReverseScan("a", "d", 0); err != nil {
@@ -365,14 +373,16 @@ func TestMultiRangeReverseScan(t *testing.T) {
 // across multiple ranges while range splits and merges happen.
 func TestReverseScanWithSplitAndMerge(t *testing.T) {
 	defer leaktest.AfterTest(t)
-	s, db := initReverseScanTestEnv(t)
+	s := server.StartTestServer(t)
 	defer s.Stop()
+	db := initReverseScanTestEnv(s, t)
 
 	// Case 1: An encounter with a range split.
 	// Split the range ["b", "e") at "c".
 	if err := db.AdminSplit("c"); err != nil {
 		t.Fatal(err)
 	}
+
 	// The ReverseScan will run into a stale descriptor.
 	if rows, err := db.ReverseScan("a", "d", 0); err != nil {
 		t.Fatalf("unexpected error on ReverseScan: %s", err)
@@ -425,8 +435,9 @@ func TestBadRequest(t *testing.T) {
 // higher-level version of TestSequenceCacheShouldCache.
 func TestNoSequenceCachePutOnRangeMismatchError(t *testing.T) {
 	defer leaktest.AfterTest(t)
-	s, db := setupMultipleRanges(t, "b", "c")
+	s := server.StartTestServer(t)
 	defer s.Stop()
+	db := setupMultipleRanges(t, s, "b", "c")
 
 	// The requests in the transaction below will be chunked and
 	// sent to replicas in the following way:
@@ -483,8 +494,9 @@ func TestPropagateTxnOnError(t *testing.T) {
 		storage.TestingCommandFilter = nil
 	}()
 
-	s, db := setupMultipleRanges(t, "b")
+	s := server.StartTestServer(t)
 	defer s.Stop()
+	db := setupMultipleRanges(t, s, "b")
 
 	// Set the initial value on the target key "b".
 	origVal := "val"
@@ -539,8 +551,9 @@ func TestPropagateTxnOnError(t *testing.T) {
 // TransactionPushError.
 func TestPropagateTxnOnPushError(t *testing.T) {
 	defer leaktest.AfterTest(t)
-	s, db := setupMultipleRanges(t, "b")
+	s := server.StartTestServer(t)
 	defer s.Stop()
+	db := setupMultipleRanges(t, s, "b")
 
 	waitForWriteIntent := make(chan struct{})
 	waitForTxnRestart := make(chan struct{})

--- a/server/intent_test.go
+++ b/server/intent_test.go
@@ -97,7 +97,6 @@ func TestIntentResolution(t *testing.T) {
 		func() {
 			s := StartTestServer(t)
 			defer s.Stop()
-			s.WaitForInitialSplits(t, time.Second)
 
 			go func() {
 				// Sets a timeout, cut short by the stopper having drained.

--- a/server/intent_test.go
+++ b/server/intent_test.go
@@ -77,6 +77,12 @@ func TestIntentResolution(t *testing.T) {
 			mu.Lock()
 			defer mu.Unlock()
 			header := args.Header()
+			// Ignore anything outside of the intent key range of "a" - "z"
+			// TODO: Implement "ContainsKey()" for Span, currenly only
+			// implemented for RSpan
+			if header.Key.Compare(roachpb.Key("a")) < 0 || header.Key.Compare(roachpb.Key("z")) > 0 {
+				return nil
+			}
 			switch args.(type) {
 			case *roachpb.ResolveIntentRequest:
 				result = append(result, string(header.Key))
@@ -91,6 +97,7 @@ func TestIntentResolution(t *testing.T) {
 		func() {
 			s := StartTestServer(t)
 			defer s.Stop()
+			s.WaitForInitialSplits(t, time.Second)
 
 			go func() {
 				// Sets a timeout, cut short by the stopper having drained.

--- a/server/node.go
+++ b/server/node.go
@@ -93,6 +93,14 @@ func allocateStoreIDs(nodeID roachpb.NodeID, inc int64, db *client.DB) (roachpb.
 	return roachpb.StoreID(r.ValueInt() - inc + 1), nil
 }
 
+// GetBootstrapSchema returns the schema which will be used to bootstrap a new
+// server.
+func GetBootstrapSchema() sql.MetadataSchema {
+	schema := sql.MakeMetadataSchema()
+	storage.AddEventLogToMetadataSchema(&schema)
+	return schema
+}
+
 // BootstrapCluster bootstraps a multiple stores using the provided engines and
 // cluster ID. The first bootstrapped store contains a single range spanning
 // all keys. Initial range lookup metadata is populated for the range.
@@ -132,7 +140,7 @@ func BootstrapCluster(clusterID string, engines []engine.Engine, stopper *stop.S
 		// not create the range, just its data.  Only do this if this is the
 		// first store.
 		if i == 0 {
-			initialValues := sql.MakeMetadataSchema().GetInitialValues()
+			initialValues := GetBootstrapSchema().GetInitialValues()
 			if err := s.BootstrapRange(initialValues); err != nil {
 				return nil, err
 			}

--- a/server/node_test.go
+++ b/server/node_test.go
@@ -426,7 +426,6 @@ func TestStatusSummaries(t *testing.T) {
 	}
 
 	s.WaitForInit()
-	ts.WaitForInitialSplits(t, time.Second)
 
 	content := "junk"
 	leftKey := "a"

--- a/server/node_test.go
+++ b/server/node_test.go
@@ -34,7 +34,6 @@ import (
 	"github.com/cockroachdb/cockroach/roachpb"
 	"github.com/cockroachdb/cockroach/rpc"
 	"github.com/cockroachdb/cockroach/server/status"
-	"github.com/cockroachdb/cockroach/sql"
 	"github.com/cockroachdb/cockroach/storage"
 	"github.com/cockroachdb/cockroach/storage/engine"
 	"github.com/cockroachdb/cockroach/util"
@@ -139,7 +138,7 @@ func TestBootstrapCluster(t *testing.T) {
 		roachpb.Key("\x04store-idgen"),
 	}
 	// Add the initial keys for sql.
-	for _, kv := range sql.MakeMetadataSchema().GetInitialValues() {
+	for _, kv := range GetBootstrapSchema().GetInitialValues() {
 		expectedKeys = append(expectedKeys, kv.Key)
 	}
 	// Resort the list. The sql values are not sorted.
@@ -427,12 +426,13 @@ func TestStatusSummaries(t *testing.T) {
 	}
 
 	s.WaitForInit()
+	ts.WaitForInitialSplits(t, time.Second)
 
 	content := "junk"
 	leftKey := "a"
 
-	// Write to the range to ensure that the raft machinery is running.
-	if err := ts.db.Put(leftKey, content); err != nil {
+	// Scan over all keys to "wake up" all replicas (force a leader election).
+	if _, err := ts.db.Scan(keys.MetaMax, keys.MaxKey, 0); err != nil {
 		t.Fatal(err)
 	}
 
@@ -441,15 +441,26 @@ func TestStatusSummaries(t *testing.T) {
 		t.Fatal(err)
 	}
 
+	// Wait for full replication of initial ranges.
+	initialRanges := int32(ExpectedInitialRangeCount())
+	util.SucceedsWithin(t, time.Second, func() error {
+		for i := 1; i <= int(initialRanges); i++ {
+			if s.RaftStatus(roachpb.RangeID(i)) == nil {
+				return util.Errorf("Store %d replica %d is not present in raft", s.StoreID(), i)
+			}
+		}
+		return nil
+	})
+
 	expectedNodeStatus := &status.NodeStatus{
-		RangeCount:           1,
+		RangeCount:           initialRanges,
 		StoreIDs:             []roachpb.StoreID{1, 2, 3},
 		StartedAt:            0,
 		UpdatedAt:            0,
 		Desc:                 ts.node.Descriptor,
-		LeaderRangeCount:     1,
-		AvailableRangeCount:  1,
-		ReplicatedRangeCount: 1,
+		LeaderRangeCount:     initialRanges,
+		AvailableRangeCount:  initialRanges,
+		ReplicatedRangeCount: initialRanges,
 		Stats: engine.MVCCStats{
 			LiveBytes: 1,
 			KeyBytes:  1,
@@ -462,10 +473,10 @@ func TestStatusSummaries(t *testing.T) {
 	expectedStoreStatus := &storage.StoreStatus{
 		Desc:                 *storeDesc,
 		NodeID:               1,
-		RangeCount:           1,
-		LeaderRangeCount:     1,
-		AvailableRangeCount:  1,
-		ReplicatedRangeCount: 1,
+		RangeCount:           initialRanges,
+		LeaderRangeCount:     initialRanges,
+		AvailableRangeCount:  initialRanges,
+		ReplicatedRangeCount: initialRanges,
 		Stats: engine.MVCCStats{
 			LiveBytes: 1,
 			KeyBytes:  1,
@@ -511,14 +522,14 @@ func TestStatusSummaries(t *testing.T) {
 	}
 
 	expectedNodeStatus = &status.NodeStatus{
-		RangeCount:           1,
+		RangeCount:           initialRanges,
 		StoreIDs:             []roachpb.StoreID{1, 2, 3},
 		StartedAt:            oldNodeStats.StartedAt,
 		UpdatedAt:            oldNodeStats.UpdatedAt,
 		Desc:                 ts.node.Descriptor,
-		LeaderRangeCount:     1,
-		AvailableRangeCount:  1,
-		ReplicatedRangeCount: 1,
+		LeaderRangeCount:     initialRanges,
+		AvailableRangeCount:  initialRanges,
+		ReplicatedRangeCount: initialRanges,
 		Stats: engine.MVCCStats{
 			LiveBytes: 1,
 			KeyBytes:  1,
@@ -531,10 +542,10 @@ func TestStatusSummaries(t *testing.T) {
 	expectedStoreStatus = &storage.StoreStatus{
 		Desc:                 oldStoreStats.Desc,
 		NodeID:               1,
-		RangeCount:           1,
-		LeaderRangeCount:     1,
-		AvailableRangeCount:  1,
-		ReplicatedRangeCount: 1,
+		RangeCount:           initialRanges,
+		LeaderRangeCount:     initialRanges,
+		AvailableRangeCount:  initialRanges,
+		ReplicatedRangeCount: initialRanges,
 		Stats: engine.MVCCStats{
 			LiveBytes: 1,
 			KeyBytes:  1,
@@ -564,14 +575,14 @@ func TestStatusSummaries(t *testing.T) {
 	}
 
 	expectedNodeStatus = &status.NodeStatus{
-		RangeCount:           2,
+		RangeCount:           initialRanges + 1,
 		StoreIDs:             []roachpb.StoreID{1, 2, 3},
 		StartedAt:            oldNodeStats.StartedAt,
 		UpdatedAt:            oldNodeStats.UpdatedAt,
 		Desc:                 ts.node.Descriptor,
-		LeaderRangeCount:     2,
-		AvailableRangeCount:  2,
-		ReplicatedRangeCount: 2,
+		LeaderRangeCount:     initialRanges + 1,
+		AvailableRangeCount:  initialRanges + 1,
+		ReplicatedRangeCount: initialRanges + 1,
 		Stats: engine.MVCCStats{
 			LiveBytes: 1,
 			KeyBytes:  1,
@@ -584,10 +595,10 @@ func TestStatusSummaries(t *testing.T) {
 	expectedStoreStatus = &storage.StoreStatus{
 		Desc:                 oldStoreStats.Desc,
 		NodeID:               1,
-		RangeCount:           2,
-		LeaderRangeCount:     2,
-		AvailableRangeCount:  2,
-		ReplicatedRangeCount: 2,
+		RangeCount:           initialRanges + 1,
+		LeaderRangeCount:     initialRanges + 1,
+		AvailableRangeCount:  initialRanges + 1,
+		ReplicatedRangeCount: initialRanges + 1,
 		Stats: engine.MVCCStats{
 			LiveBytes: 1,
 			KeyBytes:  1,

--- a/server/server_test.go
+++ b/server/server_test.go
@@ -147,7 +147,11 @@ func TestInitEngines(t *testing.T) {
 func TestSelfBootstrap(t *testing.T) {
 	defer leaktest.AfterTest(t)
 	s := StartTestServer(t)
-	s.Stop()
+	defer s.Stop()
+	// Wait for initial splits to finish before stopping; stopping so quickly
+	// can cause the server to momentarily hang, resulting in the test taking five
+	// seconds to complete.
+	s.WaitForInitialSplits(t, time.Second)
 }
 
 // TestHealth verifies that health endpoint return "ok".
@@ -298,6 +302,7 @@ func TestMultiRangeScanDeleteRange(t *testing.T) {
 	defer leaktest.AfterTest(t)
 	s := StartTestServer(t)
 	defer s.Stop()
+	s.WaitForInitialSplits(t, time.Second)
 	ds := kv.NewDistSender(&kv.DistSenderContext{Clock: s.Clock(), RPCContext: s.RPCContext()}, s.Gossip())
 	tds := kv.NewTxnCoordSender(ds, s.Clock(), testContext.Linearizable, nil, s.stopper)
 
@@ -389,6 +394,8 @@ func TestMultiRangeScanWithMaxResults(t *testing.T) {
 
 	for i, tc := range testCases {
 		s := StartTestServer(t)
+		defer s.Stop()
+		s.WaitForInitialSplits(t, time.Second)
 		ds := kv.NewDistSender(&kv.DistSenderContext{Clock: s.Clock(), RPCContext: s.RPCContext()}, s.Gossip())
 		tds := kv.NewTxnCoordSender(ds, s.Clock(), testContext.Linearizable, nil, s.stopper)
 
@@ -423,7 +430,6 @@ func TestMultiRangeScanWithMaxResults(t *testing.T) {
 				}
 			}
 		}
-		defer s.Stop()
 	}
 }
 

--- a/server/server_test.go
+++ b/server/server_test.go
@@ -148,10 +148,6 @@ func TestSelfBootstrap(t *testing.T) {
 	defer leaktest.AfterTest(t)
 	s := StartTestServer(t)
 	defer s.Stop()
-	// Wait for initial splits to finish before stopping; stopping so quickly
-	// can cause the server to momentarily hang, resulting in the test taking five
-	// seconds to complete.
-	s.WaitForInitialSplits(t, time.Second)
 }
 
 // TestHealth verifies that health endpoint return "ok".
@@ -302,7 +298,6 @@ func TestMultiRangeScanDeleteRange(t *testing.T) {
 	defer leaktest.AfterTest(t)
 	s := StartTestServer(t)
 	defer s.Stop()
-	s.WaitForInitialSplits(t, time.Second)
 	ds := kv.NewDistSender(&kv.DistSenderContext{Clock: s.Clock(), RPCContext: s.RPCContext()}, s.Gossip())
 	tds := kv.NewTxnCoordSender(ds, s.Clock(), testContext.Linearizable, nil, s.stopper)
 
@@ -395,7 +390,6 @@ func TestMultiRangeScanWithMaxResults(t *testing.T) {
 	for i, tc := range testCases {
 		s := StartTestServer(t)
 		defer s.Stop()
-		s.WaitForInitialSplits(t, time.Second)
 		ds := kv.NewDistSender(&kv.DistSenderContext{Clock: s.Clock(), RPCContext: s.RPCContext()}, s.Gossip())
 		tds := kv.NewTxnCoordSender(ds, s.Clock(), testContext.Linearizable, nil, s.stopper)
 

--- a/server/testserver.go
+++ b/server/testserver.go
@@ -42,6 +42,9 @@ const (
 	// TestUser is a fixed user used in unittests.
 	// It has valid embedded client certs.
 	TestUser = "testuser"
+	// initialSplitsTimeout is the amount of time to wait for initial splits to
+	// occur on a freshly started server.
+	initialSplitsTimeout = time.Second
 )
 
 // StartTestServer starts a in-memory test server.
@@ -54,7 +57,6 @@ func StartTestServer(t util.Tester) *TestServer {
 			log.Fatalf("Could not start server: %v", err)
 		}
 	}
-
 	return s
 }
 
@@ -204,6 +206,17 @@ func (ts *TestServer) StartWithStopper(stopper *stop.Stopper) error {
 		return err
 	}
 
+	// If enabled, wait for initial splits to complete before returning control.
+	// If initial splits do not complete, the server is stopped before
+	// returning.
+	if config.TestingTableSplitsDisabled() {
+		return nil
+	}
+	if err := ts.WaitForInitialSplits(); err != nil {
+		ts.Stop()
+		return err
+	}
+
 	return nil
 }
 
@@ -216,17 +229,17 @@ func ExpectedInitialRangeCount() int {
 }
 
 // WaitForInitialSplits waits for the server to complete its expected initial
-// splits at startup. If the expected range count is not reached within the
-// supplied timeout, the current test will be aborted.
-func (ts *TestServer) WaitForInitialSplits(t util.Tester, timeout time.Duration) {
+// splits at startup. If the expected range count is not reached within a
+// configured timeout, an error is returned.
+func (ts *TestServer) WaitForInitialSplits() error {
 	kvDB, err := client.Open(ts.Stopper(), fmt.Sprintf("%s://%s@%s?certs=%s",
-		ts.Ctx.RPCRequestScheme(), security.NodeUser, ts.ServingAddr(), security.EmbeddedCertsDir))
+		ts.Ctx.RPCRequestScheme(), security.NodeUser, ts.ServingAddr(), ts.Ctx.Certs))
 	if err != nil {
-		t.Fatalf("Unable to open connection to test server: %s", err)
+		return err
 	}
 
 	expectedRanges := ExpectedInitialRangeCount()
-	util.SucceedsWithin(t, timeout, func() error {
+	return util.RetryForDuration(initialSplitsTimeout, func() error {
 		// Scan all keys in the Meta2Prefix; we only need a count.
 		rows, err := kvDB.Scan(keys.Meta2Prefix, keys.MetaMax, 0)
 		if err != nil {

--- a/server/testserver.go
+++ b/server/testserver.go
@@ -17,14 +17,17 @@
 package server
 
 import (
+	"fmt"
 	"time"
 
 	"github.com/cockroachdb/cockroach/client"
 	"github.com/cockroachdb/cockroach/config"
 	"github.com/cockroachdb/cockroach/gossip"
+	"github.com/cockroachdb/cockroach/keys"
 	"github.com/cockroachdb/cockroach/roachpb"
 	"github.com/cockroachdb/cockroach/rpc"
 	"github.com/cockroachdb/cockroach/security"
+	"github.com/cockroachdb/cockroach/sql"
 	"github.com/cockroachdb/cockroach/storage"
 	"github.com/cockroachdb/cockroach/storage/engine"
 	"github.com/cockroachdb/cockroach/ts"
@@ -202,6 +205,38 @@ func (ts *TestServer) StartWithStopper(stopper *stop.Stopper) error {
 	}
 
 	return nil
+}
+
+// ExpectedInitialRangeCount returns the expected number of ranges that should
+// be on the server after initial (asynchronous) splits have been completed,
+// assuming no additional information is added outside of the normal bootstrap
+// process.
+func ExpectedInitialRangeCount() int {
+	return GetBootstrapSchema().DescriptorCount() - sql.NumSystemDescriptors + 1
+}
+
+// WaitForInitialSplits waits for the server to complete its expected initial
+// splits at startup. If the expected range count is not reached within the
+// supplied timeout, the current test will be aborted.
+func (ts *TestServer) WaitForInitialSplits(t util.Tester, timeout time.Duration) {
+	kvDB, err := client.Open(ts.Stopper(), fmt.Sprintf("%s://%s@%s?certs=%s",
+		ts.Ctx.RPCRequestScheme(), security.NodeUser, ts.ServingAddr(), security.EmbeddedCertsDir))
+	if err != nil {
+		t.Fatalf("Unable to open connection to test server: %s", err)
+	}
+
+	expectedRanges := ExpectedInitialRangeCount()
+	util.SucceedsWithin(t, timeout, func() error {
+		// Scan all keys in the Meta2Prefix; we only need a count.
+		rows, err := kvDB.Scan(keys.Meta2Prefix, keys.MetaMax, 0)
+		if err != nil {
+			return err
+		}
+		if a, e := len(rows), expectedRanges; a != e {
+			return util.Errorf("had %d ranges at startup, expected %d", a, e)
+		}
+		return nil
+	})
 }
 
 // ServingAddr returns the rpc server's address. Should be used by clients.

--- a/sql/create_test.go
+++ b/sql/create_test.go
@@ -21,6 +21,7 @@ import (
 
 	"github.com/cockroachdb/cockroach/keys"
 	"github.com/cockroachdb/cockroach/roachpb"
+	"github.com/cockroachdb/cockroach/server"
 	"github.com/cockroachdb/cockroach/sql"
 	"github.com/cockroachdb/cockroach/testutils"
 	"github.com/cockroachdb/cockroach/util/leaktest"
@@ -70,7 +71,7 @@ func TestDatabaseDescriptor(t *testing.T) {
 	if kvs, err := kvDB.Scan(start, start.PrefixEnd(), 0); err != nil {
 		t.Fatal(err)
 	} else {
-		if a, e := len(kvs), sql.NumSystemDescriptors; a != e {
+		if a, e := len(kvs), server.GetBootstrapSchema().DescriptorCount(); a != e {
 			t.Fatalf("expected %d keys to have been written, found %d keys", e, a)
 		}
 	}

--- a/sql/metadata.go
+++ b/sql/metadata.go
@@ -92,6 +92,17 @@ func (md *MetadataDatabase) AddTable(definition string, privileges *PrivilegeDes
 	})
 }
 
+// DescriptorCount returns the number of descriptors that will be created by
+// this schema. This value is needed to automate certain tests.
+func (ms MetadataSchema) DescriptorCount() int {
+	count := len(ms.systemObjects)
+	count += len(ms.databases)
+	for _, db := range ms.databases {
+		count += len(db.tables)
+	}
+	return count
+}
+
 // GetInitialValues returns the set of initial K/V values which should be added to
 // a bootstrapping CockroachDB cluster in order to create the tables contained
 // in the schema.

--- a/sql/split_test.go
+++ b/sql/split_test.go
@@ -79,13 +79,10 @@ func TestSplitOnTableBoundaries(t *testing.T) {
 	s, sqlDB, kvDB := setupWithContext(t, getFastScanContext())
 	defer cleanup(s, sqlDB)
 
-	num, err := getNumRanges(kvDB)
-	if err != nil {
-		t.Fatalf("failed to retrieve range list: %s", err)
-	}
-	if num != 1 {
-		t.Fatalf("expected no splits, but found %d ranges", num)
-	}
+	// The initial splits are happening on another thread, so it should succeed within a few
+	// milliseconds.
+	s.WaitForInitialSplits(t, time.Second)
+	expectedInitialRanges := server.ExpectedInitialRangeCount()
 
 	if _, err := sqlDB.Exec(`CREATE DATABASE test`); err != nil {
 		t.Fatal(err)
@@ -98,7 +95,7 @@ func TestSplitOnTableBoundaries(t *testing.T) {
 		if err != nil {
 			return err
 		}
-		if e := 2; num != e {
+		if e := expectedInitialRanges + 1; num != e {
 			return util.Errorf("expected %d splits, found %d", e, num)
 		}
 		return nil
@@ -111,8 +108,8 @@ func TestSplitOnTableBoundaries(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if !rangesMatchSplits(ranges, splits) {
-		t.Fatalf("Found ranges: %v\nexpected: %v", ranges, splits)
+	if a, e := ranges[expectedInitialRanges-1:], splits; !rangesMatchSplits(a, e) {
+		t.Fatalf("Found ranges: %v\nexpected: %v", a, e)
 	}
 
 	// Let's create a table.
@@ -125,7 +122,7 @@ func TestSplitOnTableBoundaries(t *testing.T) {
 		if err != nil {
 			return err
 		}
-		if e := 3; num != e {
+		if e := expectedInitialRanges + 2; num != e {
 			return util.Errorf("expected %d splits, found %d", e, num)
 		}
 		return nil
@@ -137,7 +134,7 @@ func TestSplitOnTableBoundaries(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if !rangesMatchSplits(ranges, splits) {
-		t.Fatalf("Found ranges: %v\nexpected: %v", ranges, splits)
+	if a, e := ranges[expectedInitialRanges-1:], splits; !rangesMatchSplits(a, e) {
+		t.Fatalf("Found ranges: %v\nexpected: %v", a, e)
 	}
 }

--- a/sql/split_test.go
+++ b/sql/split_test.go
@@ -79,9 +79,6 @@ func TestSplitOnTableBoundaries(t *testing.T) {
 	s, sqlDB, kvDB := setupWithContext(t, getFastScanContext())
 	defer cleanup(s, sqlDB)
 
-	// The initial splits are happening on another thread, so it should succeed within a few
-	// milliseconds.
-	s.WaitForInitialSplits(t, time.Second)
 	expectedInitialRanges := server.ExpectedInitialRangeCount()
 
 	if _, err := sqlDB.Exec(`CREATE DATABASE test`); err != nil {

--- a/sql/system_test.go
+++ b/sql/system_test.go
@@ -42,8 +42,8 @@ func TestInitialKeys(t *testing.T) {
 	db.AddTable("CREATE TABLE testdb.x (val INTEGER PRIMARY KEY)", sql.NewPrivilegeDescriptor(security.RootUser, privilege.List{privilege.ALL}))
 	ms.AddDatabase(db)
 	kv = ms.GetInitialValues()
-	// IDGenerator + 2 for each system object + 2 for testdb + 2 for test table
-	if actual, expected := len(kv), 1+2*sql.NumSystemDescriptors+4; actual != expected {
+	// IDGenerator + 2 for each descriptor in the schema.
+	if actual, expected := len(kv), 1+2*ms.DescriptorCount(); actual != expected {
 		t.Fatalf("Wrong number of initial sql kv pairs: %d, wanted %d", actual, expected)
 	}
 

--- a/sql/testdata/database
+++ b/sql/testdata/database
@@ -15,6 +15,7 @@ SHOW DATABASES
 ----
 Database
 a
+rangelog
 system
 test
 
@@ -30,6 +31,7 @@ SHOW DATABASES
 a
 b
 c
+rangelog
 system
 test
 
@@ -67,6 +69,7 @@ SHOW DATABASES
 Database
 a
 c
+rangelog
 system
 test
 

--- a/sql/testdata/rename_database
+++ b/sql/testdata/rename_database
@@ -1,6 +1,7 @@
 query T
 SHOW DATABASES
 ----
+rangelog
 system
 test
 
@@ -39,6 +40,7 @@ SHOW GRANTS ON DATABASE test
 query T
 SHOW DATABASES
 ----
+rangelog
 system
 u
 
@@ -85,6 +87,7 @@ ALTER DATABASE t RENAME TO v
 query T
 SHOW DATABASES
 ----
+rangelog
 system
 t
 u

--- a/sql/testdata/system
+++ b/sql/testdata/system
@@ -1,6 +1,7 @@
 query T
 SHOW DATABASES
 ----
+rangelog
 system
 test
 
@@ -16,17 +17,20 @@ zones
 query ITTB
 EXPLAIN (DEBUG) SELECT * FROM system.namespace
 ----
-0 /namespace/primary/0/'system'/id     1    true
-1 /namespace/primary/0/'test'/id       1000 true
-2 /namespace/primary/1/'descriptor'/id 3    true
-3 /namespace/primary/1/'lease'/id      4    true
-4 /namespace/primary/1/'namespace'/id  2    true
-5 /namespace/primary/1/'users'/id      5    true
-6 /namespace/primary/1/'zones'/id      6    true
+0 /namespace/primary/0/'rangelog'/id   501  true
+1 /namespace/primary/0/'system'/id     1    true
+2 /namespace/primary/0/'test'/id       1000 true
+3 /namespace/primary/1/'descriptor'/id 3    true
+4 /namespace/primary/1/'lease'/id      4    true
+5 /namespace/primary/1/'namespace'/id  2    true
+6 /namespace/primary/1/'users'/id      5    true
+7 /namespace/primary/1/'zones'/id      6    true
+8 /namespace/primary/501/'event'/id    502  true
 
 query ITI
 SELECT * FROM system.namespace
 ----
+0 rangelog   501
 0 system     1
 0 test       1000
 1 descriptor 3
@@ -34,6 +38,7 @@ SELECT * FROM system.namespace
 1 namespace  2
 1 users      5
 1 zones      6
+501 event    502
 
 query I
 SELECT id FROM system.descriptor
@@ -44,6 +49,8 @@ SELECT id FROM system.descriptor
 4
 5
 6
+501
+502
 1000
 
 # Verify we can read "protobuf" columns.

--- a/storage/client_split_test.go
+++ b/storage/client_split_test.go
@@ -521,7 +521,7 @@ func TestStoreZoneUpdateAndRangeSplit(t *testing.T) {
 	}
 
 	// Wait for the range to be split along table boundaries.
-	originalRange := store.LookupReplica(roachpb.RKeyMin, nil)
+	originalRange := store.LookupReplica(roachpb.RKey(keys.UserTableDataMin), nil)
 	var rng *storage.Replica
 	if err := util.IsTrueWithin(func() bool {
 		rng = store.LookupReplica(keys.MakeTablePrefix(1000), nil)

--- a/storage/log.go
+++ b/storage/log.go
@@ -1,0 +1,43 @@
+// Copyright 2015 The Cockroach Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+// implied. See the License for the specific language governing
+// permissions and limitations under the License. See the AUTHORS file
+// for names of contributors.
+//
+// Author: Matt Tracy (matt@cockroachlabs.com)
+
+package storage
+
+import (
+	"github.com/cockroachdb/cockroach/security"
+	"github.com/cockroachdb/cockroach/sql"
+	"github.com/cockroachdb/cockroach/sql/privilege"
+)
+
+// TODO(mrtracy) rangeEventTableSchema defines the schema for the range event
+// schema.  Currently there is no useful information in this table; this is a
+// work in progress.
+const rangeEventTableSchema = `
+CREATE TABLE rangelog.event (
+  timestamp     TIMESTAMP  NOT NULL,
+  rangeID       INT        NOT NULL,
+  PRIMARY KEY (timestamp, rangeID)
+);`
+
+// AddEventLogToMetadataSchema adds the range event log table to the supplied
+// MetadataSchema.
+func AddEventLogToMetadataSchema(schema *sql.MetadataSchema) {
+	allPrivileges := sql.NewPrivilegeDescriptor(security.RootUser, privilege.List{privilege.ALL})
+	db := sql.MakeMetadataDatabase("rangelog", allPrivileges)
+	db.AddTable(rangeEventTableSchema, allPrivileges)
+	schema.AddDatabase(db)
+}

--- a/util/stop/main_test.go
+++ b/util/stop/main_test.go
@@ -1,0 +1,30 @@
+// Copyright 2015 The Cockroach Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+// implied. See the License for the specific language governing
+// permissions and limitations under the License. See the AUTHORS file
+// for names of contributors.
+//
+// Author: Matt Tracy
+
+package stop_test
+
+import (
+	"testing"
+
+	"github.com/cockroachdb/cockroach/util/leaktest"
+)
+
+//go:generate ../util/leaktest/add-leaktest.sh *_test.go
+
+func TestMain(m *testing.M) {
+	leaktest.TestMainWithLeakCheck(m)
+}

--- a/util/stop/stopper.go
+++ b/util/stop/stopper.go
@@ -56,6 +56,7 @@ func (f CloserFn) Close() {
 // be added to the stopper via AddCloser(), to be closed after the
 // stopper has stopped.
 type Stopper struct {
+	drainer  chan struct{}  // Closed when draining
 	stopper  chan struct{}  // Closed when stopping
 	stopped  chan struct{}  // Closed when stopped completely
 	stop     sync.WaitGroup // Incremented for outstanding workers
@@ -70,6 +71,7 @@ type Stopper struct {
 // NewStopper returns an instance of Stopper.
 func NewStopper() *Stopper {
 	s := &Stopper{
+		drainer: make(chan struct{}),
 		stopper: make(chan struct{}),
 		stopped: make(chan struct{}),
 		tasks:   map[string]int{},
@@ -209,6 +211,16 @@ func (s *Stopper) Stop() {
 	close(s.stopped)
 }
 
+// ShouldDrain returns a channel which will be closed when Stop() has been
+// invoked and outstanding tasks should begin to drain.
+func (s *Stopper) ShouldDrain() <-chan struct{} {
+	if s == nil {
+		// A nil stopper will never signal ShouldDrain, but will also never panic.
+		return nil
+	}
+	return s.drainer
+}
+
 // ShouldStop returns a channel which will be closed when Stop() has been
 // invoked and outstanding tasks have drained.
 func (s *Stopper) ShouldStop() <-chan struct{} {
@@ -234,7 +246,10 @@ func (s *Stopper) IsStopped() <-chan struct{} {
 func (s *Stopper) Quiesce() {
 	s.mu.Lock()
 	defer s.mu.Unlock()
-	s.draining = true
+	if !s.draining {
+		s.draining = true
+		close(s.drainer)
+	}
 	for s.numTasks > 0 {
 		// Use stdlib "log" instead of "cockroach/util/log" due to import cycles.
 		log.Print("draining; tasks left:\n", s.runningTasksLocked())


### PR DESCRIPTION
This commit creates the 'rangelog.Event' table at bootstrap time. This table is
in the non-system reserved space; it is intended that the storage package will
write record to this table whenever a significant event occurs on a range (e.g.
a split or replica change).

This commit essentially just adds the table; it does not write any records to
the table, and the table's schema is incomplete. The number of testing changes
needed to support an additional table at startup were significant, so actual
usage of the table will be introduced in a subsequent commit.

Summary of necessary test changes:
- Many tests asserted that there would be a constant number of tables present on
  the server at boostrap table; in the case of some of the SQL logic tests, they
  assert very specifically on the expected set of initial tables.  All of these
  tests have been modified to account for the new tables, and where possible this
  has been done in a way that will be automatically accounted for if more tables
  are added in the future (using the new `GetBootstrapSchema()` function of the
  server package).
- Another category of tests asserted that there would be only a single _range_
  present on the server at startup; the addition of this new table causes the
  server to asychronously split the initial range as soon as the server starts up,
  which was causing these counts to be incorrect. The tests have been
  appropriately updated, in a way that will be automatically accounted for if more
  tables are added in the future.
- Another category of tests would create a TestServer, and then generate their
  own splits via the AdminSplit() function. However, the addition of the new
  table at startup means that a new TestServer will asynchronously attempt to
  split the initial range, and sometimes the calls to AdminSplit() would fail due
  to a transaction conflict, causing the tests to fail. To remedy this, these
  tests use the new function `TestServer.WaitForInitialSplits()` to wait for the
  initial splits to occur, eliminating the possibility of conflict.
- Finally, the asynchronous splitting of the initial range on TestServers was
  causing some tests to shut down incorrectly; specifically, there was an infinite
  retry loop that would cause the stopper to hang, eventually causing the test in
  question to time out. This was addressed by a combination of
  `WaitForInitialSplits()` the previous commit, which modified the server's
  DistSender to stop retrying if the server is stopping (specifically, once it is
  draining).

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/3476)

<!-- Reviewable:end -->
