### PR TITLE
Add open callbacks to the RPC server and use in Gossip.

### DIFF
--- a/gossip/client_test.go
+++ b/gossip/client_test.go
@@ -251,10 +251,7 @@ func TestClientDisconnectLoopback(t *testing.T) {
 	// startClient requires locks are held, so acquire here.
 	local.mu.Lock()
 	lAddr := local.is.NodeAddr
-	lclock := hlc.NewClock(hlc.UnixNano)
-	rpcContext := rpc.NewContext(&base.Context{Insecure: true}, lclock, stopper)
-	rpcContext.DisableCache = true
-	local.startClient(lAddr, rpcContext, stopper)
+	local.startClient(lAddr, stopper)
 	local.mu.Unlock()
 	local.manage(stopper)
 	util.SucceedsWithin(t, 10*time.Second, func() error {
@@ -279,11 +276,8 @@ func TestClientDisconnectRedundant(t *testing.T) {
 
 	rAddr := remote.is.NodeAddr
 	lAddr := local.is.NodeAddr
-	lclock := hlc.NewClock(hlc.UnixNano)
-	rpcContext := rpc.NewContext(&base.Context{Insecure: true}, lclock, stopper)
-	rpcContext.DisableCache = true
-	local.startClient(rAddr, rpcContext, stopper)
-	remote.startClient(lAddr, rpcContext, stopper)
+	local.startClient(rAddr, stopper)
+	remote.startClient(lAddr, stopper)
 	local.mu.Unlock()
 	remote.mu.Unlock()
 	local.manage(stopper)
@@ -316,14 +310,11 @@ func TestClientDisallowMultipleConns(t *testing.T) {
 	local.mu.Lock()
 	remote.mu.Lock()
 	rAddr := remote.is.NodeAddr
-	lclock := hlc.NewClock(hlc.UnixNano)
-	rpcContext := rpc.NewContext(&base.Context{Insecure: true}, lclock, stopper)
-	rpcContext.DisableCache = true
 	// Start two clients from local to remote. RPC client cache is
 	// disabled via the context, so we'll start two different outgoing
 	// connections.
-	local.startClient(rAddr, rpcContext, stopper)
-	local.startClient(rAddr, rpcContext, stopper)
+	local.startClient(rAddr, stopper)
+	local.startClient(rAddr, stopper)
 	local.mu.Unlock()
 	remote.mu.Unlock()
 	local.manage(stopper)

--- a/kv/dist_sender_server_test.go
+++ b/kv/dist_sender_server_test.go
@@ -246,7 +246,7 @@ func TestMultiRangeScanReverseScanInconsistent(t *testing.T) {
 	// the first key to verify it's used to read only key "a".
 	manual := hlc.NewManualClock(ts[1].UnixNano() - 1)
 	clock := hlc.NewClock(manual.UnixNano)
-	ds := kv.NewDistSender(&kv.DistSenderContext{Clock: clock}, s.Gossip())
+	ds := kv.NewDistSender(&kv.DistSenderContext{Clock: clock, RPCContext: s.RPCContext()}, s.Gossip())
 
 	// Scan.
 	sa := roachpb.NewScan(roachpb.Key("a"), roachpb.Key("c"), 0).(*roachpb.ScanRequest)

--- a/rpc/rpc.go
+++ b/rpc/rpc.go
@@ -13,11 +13,12 @@ type Context struct {
 	// Embed the base context.
 	base.Context
 
-	localClock   *hlc.Clock
-	Stopper      *stop.Stopper
-	RemoteClocks *RemoteClockMonitor
-	DisableCache bool // Disable client cache when calling NewClient()
-	HealthWait   time.Duration
+	localClock        *hlc.Clock
+	Stopper           *stop.Stopper
+	RemoteClocks      *RemoteClockMonitor
+	DisableCache      bool // Disable client cache when calling NewClient()
+	DisableReconnects bool // Disable client reconnects
+	HealthWait        time.Duration
 }
 
 // NewContext creates an rpc Context with the supplied values.

--- a/rpc/server.go
+++ b/rpc/server.go
@@ -61,6 +61,7 @@ type Server struct {
 
 	mu             sync.RWMutex
 	activeConns    map[net.Conn]struct{}
+	openCallbacks  []func(conn net.Conn)
 	closeCallbacks []func(conn net.Conn)
 	methods        map[string]method
 }
@@ -134,6 +135,22 @@ func (s *Server) RegisterAsync(name string, public bool,
 	return nil
 }
 
+// AddOpenCallback adds a callback to the openCallbacks slice to
+// be invoked when a connection is opened.
+func (s *Server) AddOpenCallback(cb func(conn net.Conn)) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.openCallbacks = append(s.openCallbacks, cb)
+}
+
+func (s *Server) runOpenCallbacks(conn net.Conn) {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	for _, cb := range s.openCallbacks {
+		cb(conn)
+	}
+}
+
 // AddCloseCallback adds a callback to the closeCallbacks slice to
 // be invoked when a connection is closed.
 func (s *Server) AddCloseCallback(cb func(conn net.Conn)) {
@@ -181,6 +198,9 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, req *http.Request) {
 		http.Error(w, err.Error(), http.StatusUnauthorized)
 		return
 	}
+
+	// Run open callbacks.
+	s.runOpenCallbacks(conn)
 
 	codec := codec.NewServerCodec(conn)
 	responses := make(chan serverResponse)

--- a/server/node_test.go
+++ b/server/node_test.go
@@ -75,7 +75,7 @@ func createTestNode(addr net.Addr, engines []engine.Engine, gossipBS net.Addr, t
 		g.Start(rpcServer, ln.Addr(), stopper)
 	}
 	ctx.Gossip = g
-	sender := kv.NewDistSender(&kv.DistSenderContext{Clock: ctx.Clock}, g)
+	sender := kv.NewDistSender(&kv.DistSenderContext{Clock: ctx.Clock, RPCContext: nodeRPCContext}, g)
 	ctx.DB = client.NewDB(sender)
 	// TODO(bdarnell): arrange to have the transport closed.
 	// (or attach LocalRPCTransport.Close to the stopper)

--- a/server/server_test.go
+++ b/server/server_test.go
@@ -299,7 +299,7 @@ func TestMultiRangeScanDeleteRange(t *testing.T) {
 	defer leaktest.AfterTest(t)
 	s := StartTestServer(t)
 	defer s.Stop()
-	ds := kv.NewDistSender(&kv.DistSenderContext{Clock: s.Clock()}, s.Gossip())
+	ds := kv.NewDistSender(&kv.DistSenderContext{Clock: s.Clock(), RPCContext: s.RPCContext()}, s.Gossip())
 	tds := kv.NewTxnCoordSender(ds, s.Clock(), testContext.Linearizable, nil, s.stopper)
 
 	if err := s.node.ctx.DB.AdminSplit("m"); err != nil {
@@ -390,7 +390,7 @@ func TestMultiRangeScanWithMaxResults(t *testing.T) {
 
 	for i, tc := range testCases {
 		s := StartTestServer(t)
-		ds := kv.NewDistSender(&kv.DistSenderContext{Clock: s.Clock()}, s.Gossip())
+		ds := kv.NewDistSender(&kv.DistSenderContext{Clock: s.Clock(), RPCContext: s.RPCContext()}, s.Gossip())
 		tds := kv.NewTxnCoordSender(ds, s.Clock(), testContext.Linearizable, nil, s.stopper)
 
 		for _, sk := range tc.splitKeys {

--- a/server/testserver.go
+++ b/server/testserver.go
@@ -24,6 +24,7 @@ import (
 	"github.com/cockroachdb/cockroach/config"
 	"github.com/cockroachdb/cockroach/gossip"
 	"github.com/cockroachdb/cockroach/roachpb"
+	"github.com/cockroachdb/cockroach/rpc"
 	"github.com/cockroachdb/cockroach/security"
 	"github.com/cockroachdb/cockroach/storage"
 	"github.com/cockroachdb/cockroach/storage/engine"
@@ -114,6 +115,14 @@ func (ts *TestServer) Gossip() *gossip.Gossip {
 func (ts *TestServer) Clock() *hlc.Clock {
 	if ts != nil {
 		return ts.clock
+	}
+	return nil
+}
+
+// RPCContext returns the rpc context used by the TestServer.
+func (ts *TestServer) RPCContext() *rpc.Context {
+	if ts != nil {
+		return ts.rpcContext
 	}
 	return nil
 }


### PR DESCRIPTION
This was necessary to prevent a race where two inbound gossip requests
from the same client (a "push" and a "pull") are both inflight when
the client is closed by the first request. The goroutine for the
second request gets the Server.Gossip() mutex after the close callback
is called, which again adds the client to the incoming nodes set and
the lAddrMap, despite it no longer being connected.

Fixes #3464

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/3479)

<!-- Reviewable:end -->
