### PR TITLE
Remove usage of prettyKey(..., 0) for log messages.

### DIFF
--- a/keys/printer.go
+++ b/keys/printer.go
@@ -249,39 +249,40 @@ func decodeKeyPrint(key roachpb.Key) string {
 	return buf.String()
 }
 
-// PrettyPrint print the key in a human readable format, which organized as:
-// Key's Format												Key's Value
-// /Local/...												"\x01"+...
-// 		/Store/...											"\x01s"+...
-//		/RangeID/...										"\x01s"+[rangeid]
-//			/[rangeid]/SequenceCache/[id]/seq:[seq]			"\x01s"+[rangeid]+"res-"+[id]+[seq]
-//			/[rangeid]/RaftLeaderLease						"\x01s"+[rangeid]+"rfll"
-//			/[rangeid]/RaftTombstone						"\x01s"+[rangeid]+"rftb"
-//			/[rangeid]/RaftHardState						"\x01s"+[rangeid]+"rfth"
-//			/[rangeid]/RaftAppliedIndex						"\x01s"+[rangeid]+"rfta"
-//			/[rangeid]/RaftLog/logIndex:[logIndex]			"\x01s"+[rangeid]+"rftl"+[logIndex]
-//			/[rangeid]/RaftTruncatedState					"\x01s"+[rangeid]+"rftt"
-//			/[rangeid]/RaftLastIndex						"\x01s"+[rangeid]+"rfti"
-//			/[rangeid]/RangeGCMetadata						"\x01s"+[rangeid]+"rgcm"
-//			/[rangeid]/RangeLastVerificationTimestamp		"\x01s"+[rangeid]+"rlvt"
-//			/[rangeid]/RangeStats							"\x01s"+[rangeid]+"stat"
-//		/Range/...											"\x01k"+...
-//			/RangeDescriptor/[key]							"\x01k"+[key]+"rdsc"
-//			/RangeTreeNode/[key]							"\x01k"+[key]+"rtn-"
+// PrettyPrint prints the key in a human readable format:
+//
+// Key's Format                                   Key's Value
+// /Local/...                                     "\x01"+...
+// 		/Store/...                                  "\x01s"+...
+//		/RangeID/...                                "\x01s"+[rangeid]
+//			/[rangeid]/SequenceCache/[id]/seq:[seq]   "\x01s"+[rangeid]+"res-"+[id]+[seq]
+//			/[rangeid]/RaftLeaderLease                "\x01s"+[rangeid]+"rfll"
+//			/[rangeid]/RaftTombstone                  "\x01s"+[rangeid]+"rftb"
+//			/[rangeid]/RaftHardState						      "\x01s"+[rangeid]+"rfth"
+//			/[rangeid]/RaftAppliedIndex						    "\x01s"+[rangeid]+"rfta"
+//			/[rangeid]/RaftLog/logIndex:[logIndex]    "\x01s"+[rangeid]+"rftl"+[logIndex]
+//			/[rangeid]/RaftTruncatedState             "\x01s"+[rangeid]+"rftt"
+//			/[rangeid]/RaftLastIndex                  "\x01s"+[rangeid]+"rfti"
+//			/[rangeid]/RangeGCMetadata						    "\x01s"+[rangeid]+"rgcm"
+//			/[rangeid]/RangeLastVerificationTimestamp "\x01s"+[rangeid]+"rlvt"
+//			/[rangeid]/RangeStats                     "\x01s"+[rangeid]+"stat"
+//		/Range/...                                  "\x01k"+...
+//			/RangeDescriptor/[key]                    "\x01k"+[key]+"rdsc"
+//			/RangeTreeNode/[key]                      "\x01k"+[key]+"rtn-"
 //			/Transaction/addrKey:[key]/id:[id]				"\x01k"+[key]+"txn-"+[id]
-// /Local/Max 												"\x02"
+// /Local/Max                                     "\x02"
 //
-// /Meta1/[key]										    "\x02"+[key]
-// /Meta2/[key]										    "\x03"+[key]
-// /System/...												"\x04"
-//		/StatusStore/[key]									"\x04status-store-"+[key]
-//		/StatusNode/[key]									"\x04status-node-"+[key]
-// /System/Max												"\x05"
+// /Meta1/[key]                                   "\x02"+[key]
+// /Meta2/[key]                                   "\x03"+[key]
+// /System/...                                    "\x04"
+//		/StatusStore/[key]                          "\x04status-store-"+[key]
+//		/StatusNode/[key]                           "\x04status-node-"+[key]
+// /System/Max                                    "\x05"
 //
-// /Table/[key]												"\xff"+[key]
+// /Table/[key]                                   [key]
 //
-// /Min														""
-// /Max														"\xff\xff"
+// /Min                                           ""
+// /Max                                           "\xff\xff"
 func PrettyPrint(key roachpb.Key) string {
 	if bytes.Equal(key, MaxKey) {
 		return "/Max"

--- a/sql/backfill.go
+++ b/sql/backfill.go
@@ -132,7 +132,7 @@ func (p *planner) backfillBatch(b *client.Batch, oldTableDesc, newTableDesc *Tab
 		indexStartKey := roachpb.Key(indexPrefix)
 		indexEndKey := indexStartKey.PrefixEnd()
 		if log.V(2) {
-			log.Infof("DelRange %s - %s", prettyKey(indexStartKey, 0), prettyKey(indexEndKey, 0))
+			log.Infof("DelRange %s - %s", indexStartKey, indexEndKey)
 		}
 		b.DelRange(indexStartKey, indexEndKey)
 	}
@@ -186,7 +186,7 @@ func (p *planner) backfillBatch(b *client.Batch, oldTableDesc, newTableDesc *Tab
 
 				for _, secondaryIndexEntry := range secondaryIndexEntries {
 					if log.V(2) {
-						log.Infof("CPut %s -> %v", prettyKey(secondaryIndexEntry.key, 0),
+						log.Infof("CPut %s -> %v", secondaryIndexEntry.key,
 							secondaryIndexEntry.value)
 					}
 					b.CPut(secondaryIndexEntry.key, secondaryIndexEntry.value, nil)

--- a/sql/delete.go
+++ b/sql/delete.go
@@ -89,7 +89,7 @@ func (p *planner) Delete(n *parser.Delete) (planNode, error) {
 
 		for _, secondaryIndexEntry := range secondaryIndexEntries {
 			if log.V(2) {
-				log.Infof("Del %s", prettyKey(secondaryIndexEntry.key, 0))
+				log.Infof("Del %s", secondaryIndexEntry.key)
 			}
 			b.Del(secondaryIndexEntry.key)
 		}
@@ -98,7 +98,7 @@ func (p *planner) Delete(n *parser.Delete) (planNode, error) {
 		rowStartKey := roachpb.Key(primaryIndexKey)
 		rowEndKey := rowStartKey.PrefixEnd()
 		if log.V(2) {
-			log.Infof("DelRange %s - %s", prettyKey(rowStartKey, 0), prettyKey(rowEndKey, 0))
+			log.Infof("DelRange %s - %s", rowStartKey, rowEndKey)
 		}
 		b.DelRange(rowStartKey, rowEndKey)
 	}

--- a/sql/insert.go
+++ b/sql/insert.go
@@ -189,7 +189,7 @@ func (p *planner) Insert(n *parser.Insert) (planNode, error) {
 
 		for _, secondaryIndexEntry := range secondaryIndexEntries {
 			if log.V(2) {
-				log.Infof("CPut %s -> %v", prettyKey(secondaryIndexEntry.key, 0),
+				log.Infof("CPut %s -> %v", secondaryIndexEntry.key,
 					secondaryIndexEntry.value)
 			}
 			b.CPut(secondaryIndexEntry.key, secondaryIndexEntry.value, nil)
@@ -197,7 +197,7 @@ func (p *planner) Insert(n *parser.Insert) (planNode, error) {
 
 		// Write the row sentinel.
 		if log.V(2) {
-			log.Infof("CPut %s -> NULL", prettyKey(primaryIndexKey, 0))
+			log.Infof("CPut %s -> NULL", primaryIndexKey)
 		}
 		b.CPut(primaryIndexKey, nil, nil)
 
@@ -218,7 +218,7 @@ func (p *planner) Insert(n *parser.Insert) (planNode, error) {
 
 				key := MakeColumnKey(col.ID, primaryIndexKey)
 				if log.V(2) {
-					log.Infof("CPut %s -> %v", prettyKey(key, 0), val)
+					log.Infof("CPut %s -> %v", key, val)
 				}
 
 				b.CPut(key, marshalled[i], nil)

--- a/sql/truncate.go
+++ b/sql/truncate.go
@@ -48,7 +48,7 @@ func (p *planner) Truncate(n *parser.Truncate) (planNode, error) {
 		tableStartKey := roachpb.Key(tablePrefix)
 		tableEndKey := tableStartKey.PrefixEnd()
 		if log.V(2) {
-			log.Infof("DelRange %s - %s", prettyKey(tableStartKey, 0), prettyKey(tableEndKey, 0))
+			log.Infof("DelRange %s - %s", tableStartKey, tableEndKey)
 		}
 		b.DelRange(tableStartKey, tableEndKey)
 	}

--- a/sql/update.go
+++ b/sql/update.go
@@ -238,13 +238,13 @@ func (p *planner) Update(n *parser.Update) (planNode, error) {
 				// Do not update Indexes in the DELETE_ONLY state.
 				if _, ok := deleteOnlyIndex[i]; !ok {
 					if log.V(2) {
-						log.Infof("CPut %s -> %v", prettyKey(newSecondaryIndexEntry.key, 0),
+						log.Infof("CPut %s -> %v", newSecondaryIndexEntry.key,
 							newSecondaryIndexEntry.value)
 					}
 					b.CPut(newSecondaryIndexEntry.key, newSecondaryIndexEntry.value, nil)
 				}
 				if log.V(2) {
-					log.Infof("Del %s", prettyKey(secondaryIndexEntry.key, 0))
+					log.Infof("Del %s", secondaryIndexEntry.key)
 				}
 				b.Del(secondaryIndexEntry.key)
 			}
@@ -260,7 +260,7 @@ func (p *planner) Update(n *parser.Update) (planNode, error) {
 				// considered NULL during scanning and the row sentinel ensures we know
 				// the row exists.
 				if log.V(2) {
-					log.Infof("Put %s -> %v", prettyKey(key, 0), val)
+					log.Infof("Put %s -> %v", key, val)
 				}
 
 				b.Put(key, marshalled[i])
@@ -268,7 +268,7 @@ func (p *planner) Update(n *parser.Update) (planNode, error) {
 				// The column might have already existed but is being set to NULL, so
 				// delete it.
 				if log.V(2) {
-					log.Infof("Del %s", prettyKey(key, 0))
+					log.Infof("Del %s", key)
 				}
 
 				b.Del(key)


### PR DESCRIPTION
Formatting of roachpb.Key is now as good as using prettyKey(). Replaced
the implementation of prettyKey() with one that calls key.String() and
strips off leading fields.

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/3480)

<!-- Reviewable:end -->
