### PR TITLE
Remove usage of homebrew-go-resources.

### DIFF
--- a/build/cockroach-template.rb
+++ b/build/cockroach-template.rb
@@ -7,25 +7,37 @@ class Cockroach < Formula
       :tag => "@VERSION@",
       :revision => "@REVISION@"
   head "https://github.com/cockroachdb/cockroach.git"
-  
+
   depends_on "go" => :build
   ### GO RESOURCES ###
+
   def install
     ENV["GOBIN"] = bin
     ENV["GOPATH"] = buildpath
     ENV["GOHOME"] = buildpath
 
-    files = Dir.glob('*')
+    files = Dir.glob("*")
     mkdir_p buildpath/"src/github.com/cockroachdb/cockroach"
     mv files, buildpath/"src/github.com/cockroachdb/cockroach"
     Language::Go.stage_deps resources, buildpath/"src"
-    
+
     # TODO(peter): We should be using the cockroach makefile so that
     # we can get the build information baked into the
     # binary. Unfortunately, this is dying with some weird dwarf
     # linker error:
     #
     #   make -C src/github.com/cockroachdb/cockroach build SKIP_BOOTSTRAP=1
+    #
+    # Something truly bizarre is going on. The error is:
+    #
+    # # github.com/cockroachdb/c-snappy
+    # cannot load DWARF output from $WORK/github.com/cockroachdb/c-snappy/_obj//_cgo_.o: decoding dwarf section info at offset 0x0: too short
+    #
+    # But that error only happens when building with make. Using go
+    # directly and everything works fine. Additionally,
+    # build/depvers.sh returns nothing when run in the homebrew build
+    # environment. But if I execute the "go list" directives inside
+    # the debugging shell it works. Wtf?
     system "go", "build", "-v", "-o", bin/"cockroach", "github.com/cockroachdb/cockroach"
   end
 

--- a/build/cockroach.rb
+++ b/build/cockroach.rb
@@ -11,9 +11,8 @@ class Cockroach < Formula
       :tag => "v0.1-alpha",
       :revision => "26088f81e5ecfb2fd63f8f15f524102c9a0c1c05"
   head "https://github.com/cockroachdb/cockroach.git"
-  
-  depends_on "go" => :build
 
+  depends_on "go" => :build
 
   go_resource "github.com/biogo/store" do
     url "https://github.com/biogo/store.git",
@@ -126,17 +125,17 @@ class Cockroach < Formula
   end
 
   go_resource "golang.org/x/crypto" do
-    url "https://go.googlesource.com/crypto.git",
+    url "https://golang.org/x/crypto.git",
       :revision => "7b85b097bf7527677d54d3220065e966a0e3b613"
   end
 
   go_resource "golang.org/x/net" do
-    url "https://go.googlesource.com/net.git",
+    url "https://golang.org/x/net.git",
       :revision => "21af302bb52737bcf1e6ce0128ec5932bf0d8ae9"
   end
 
   go_resource "golang.org/x/text" do
-    url "https://go.googlesource.com/text.git",
+    url "https://golang.org/x/text.git",
       :revision => "00e205363f74f74c3c03b7a12427ec0747a23089"
   end
 
@@ -150,17 +149,28 @@ class Cockroach < Formula
     ENV["GOPATH"] = buildpath
     ENV["GOHOME"] = buildpath
 
-    files = Dir.glob('*')
+    files = Dir.glob("*")
     mkdir_p buildpath/"src/github.com/cockroachdb/cockroach"
     mv files, buildpath/"src/github.com/cockroachdb/cockroach"
     Language::Go.stage_deps resources, buildpath/"src"
-    
+
     # TODO(peter): We should be using the cockroach makefile so that
     # we can get the build information baked into the
     # binary. Unfortunately, this is dying with some weird dwarf
     # linker error:
     #
     #   make -C src/github.com/cockroachdb/cockroach build SKIP_BOOTSTRAP=1
+    #
+    # Something truly bizarre is going on. The error is:
+    #
+    # # github.com/cockroachdb/c-snappy
+    # cannot load DWARF output from $WORK/github.com/cockroachdb/c-snappy/_obj//_cgo_.o: decoding dwarf section info at offset 0x0: too short
+    #
+    # But that error only happens when building with make. Using go
+    # directly and everything works fine. Additionally,
+    # build/depvers.sh returns nothing when run in the homebrew build
+    # environment. But if I execute the "go list" directives inside
+    # the debugging shell it works. Wtf?
     system "go", "build", "-v", "-o", bin/"cockroach", "github.com/cockroachdb/cockroach"
   end
 

--- a/build/make-brew-formula.sh
+++ b/build/make-brew-formula.sh
@@ -1,7 +1,6 @@
 #!/bin/bash
 #
-# Update the cockroach homebrew formula. Requires
-# github.com/samertm/homebrew-go-resources. Expected usage:
+# Update the cockroach homebrew formula. Expected usage:
 #
 # 1. Tag a new release on https://github.com/cockroachdb/cockroach/releases
 #   a. The tag should have a name like v0.1-alpha
@@ -29,11 +28,18 @@ line=$(grep -n '### GO RESOURCES ###' ${template} | cut -d ":" -f 1)
     echo "### DO NOT EDIT!'"
     echo
     head -n $((line-1)) ${template} | sed -e s/@VERSION@/${version}/g -e s/@REVISION@/${revision}/g
-    # homebrew-go-resources outputs some urls with "https///". We
-    # could potentially generate this section from the GLOCKFILE,
-    # though the dependencies there are more than what we need to
-    # build just the cockroach binary.
-    homebrew-go-resources . | sed 's,https///,https://,g'
+
+    build/depvers.sh | while IFS=":" read repo rev; do
+        if test "${repo}" = "github.com/cockroachdb/cockroach"; then
+            continue
+        fi
+        echo
+        echo "  go_resource \"${repo}\" do"
+        echo "    url \"https://${repo}.git\","
+        echo "      :revision => \"${rev}\""
+        echo "  end"
+    done
+
     tail -n +$(($line+1)) ${template}
 } > ${output}
 


### PR DESCRIPTION
Fix nits revealed by `brew audit --strict build/cockroach.rb`.

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/3498)

<!-- Reviewable:end -->
