### PR TITLE
Worked around the issue with build/depvers.sh not working.

### DIFF
--- a/build/cockroach.rb
+++ b/build/cockroach.rb
@@ -158,15 +158,23 @@ class Cockroach < Formula
     mv files, buildpath/"src/github.com/cockroachdb/cockroach"
     Language::Go.stage_deps resources, buildpath/"src"
 
-    # We use `xcrun make` instead of `make` to avoid homebrew mucking
-    # with the HOMEBREW_CCCFG variable which in turn causes the C
-    # compiler to behave in a way that is not supported by cgo.
-    #
-    # TODO(peter): build/depvers is returning nothing. Figure out why.
-    system "xcrun", "make", "-C",
-           "src/github.com/cockroachdb/cockroach", "build",
-           "GOFLAGS=-v", "SKIP_BOOTSTRAP=1"
-    bin.install "src/github.com/cockroachdb/cockroach/cockroach" => "cockroach"
+    # We can't use build/depvers.sh in the homebrew environment
+    # because dependencies have not had their git repos copied
+    # over. But we already have all of the revision information
+    # available, we just have to build up the same command line "make
+    # build" would create.
+    deps = format("%s:%s ", "github.com/cockroachdb/cockroach", active_spec.specs[:revision])
+    deps += resources.grep(Resource::Go) do |resource|
+      format("%s:%s", resource.name, resource.specs[:revision])
+    end.sort.join(" ")
+    tag = `git -C src/github.com/cockroachdb/cockroach describe --dirty --tags`.strip
+    date = `date -u '+%Y/%m/%d %H:%M:%S'`.strip
+
+    system "go", "build", "-v", "-o", bin/"cockroach", "-ldflags",
+           "-X \"github.com/cockroachdb/cockroach/util.buildTag=#{tag}\"" \
+           " -X \"github.com/cockroachdb/cockroach/util.buildTime=#{date}\"" \
+           " -X \"github.com/cockroachdb/cockroach/util.buildDeps=#{deps}\"",
+           "github.com/cockroachdb/cockroach"
   end
 
   test do

--- a/build/depvers.sh
+++ b/build/depvers.sh
@@ -29,12 +29,7 @@ pkgs=$(go list -f '{{printf "%s\n" .ImportPath}}{{range .Deps}}{{printf "%s\n" .
   sort -u | egrep '[^/]+\.[^/]+/')
 
 # For each package, list the package directory and package root.
-pkginfo=($(go list -f '{{.Dir}} {{.Root}}' ${pkgs} 2>/dev/null))
-
-# Loop over the package info which comes in pairs in the pkginfo
-# array.
-for (( i=0; i < ${#pkginfo[@]}; i+=2 )); do
-  dir=${pkginfo[$i]}
+go list -f '{{.Dir}} {{.Root}}' ${pkgs} 2>/dev/null | while read dir root; do
   if ! test -d "${dir}"; then
     continue
   fi
@@ -61,6 +56,5 @@ for (( i=0; i < ${#pkginfo[@]}; i+=2 )); do
     vers=$(hg --cwd "${dir}" parent --template '{node}')
   fi
 
-  root=${pkginfo[$i+1]}
   echo ${toplevel#$root/src/}:${vers}
 done


### PR DESCRIPTION
In the homebrew build environment dependencies do not have their git
repos which prevents build/depvers.sh from determining revision
information. But the formula already has this revision information baked
in. Now we generate the appropriate -ldflags within the formula
itself. A bit unfortunate that we can't use `make build`, but this does
work.

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/3500)

<!-- Reviewable:end -->
