### PR TITLE
Add tightening and culling functions to gossip networks.

### DIFF
--- a/gossip/client.go
+++ b/gossip/client.go
@@ -145,7 +145,10 @@ func (c *client) handleGossip(g *Gossip, call *netrpc.Call) error {
 
 	// Combine remote node's infostore delta with ours.
 	if reply.Delta != nil {
-		freshCount := g.is.combine(reply.Delta, reply.NodeID)
+		freshCount, err := g.is.combine(reply.Delta, reply.NodeID)
+		if err != nil {
+			log.Warningf("node %d failed to fully combine delta from node %d: %s", g.is.NodeID, reply.NodeID, err)
+		}
 		if infoCount := len(reply.Delta); infoCount > 0 {
 			if log.V(1) {
 				log.Infof("received %s from node %d (%d fresh)", reply.Delta, reply.NodeID, freshCount)

--- a/gossip/client.go
+++ b/gossip/client.go
@@ -29,21 +29,21 @@ import (
 
 // client is a client-side RPC connection to a gossip peer node.
 type client struct {
-	peerID                roachpb.NodeID  // Peer node ID; 0 until first gossip response
-	addr                  net.Addr        // Peer node network address
-	rpcClient             *rpc.Client     // RPC client
-	forwardAddr           net.Addr        // Set if disconnected with an alternate addr
-	sendingGossip         bool            // True if there's an outstanding RPC to send gossip
-	remoteHighWaterStamps map[int32]int64 // High water timestamps for remote server; matches rpc Request/Response
-	closer                chan struct{}   // Client shutdown channel
+	peerID        roachpb.NodeID  // Peer node ID; 0 until first gossip response
+	addr          net.Addr        // Peer node network address
+	rpcClient     *rpc.Client     // RPC client
+	forwardAddr   net.Addr        // Set if disconnected with an alternate addr
+	sendingGossip bool            // True if there's an outstanding RPC to send gossip
+	remoteNodes   map[int32]*Node // Remote server's high water timestamps and min hops
+	closer        chan struct{}   // Client shutdown channel
 }
 
 // newClient creates and returns a client struct.
 func newClient(addr net.Addr) *client {
 	return &client{
-		addr: addr,
-		remoteHighWaterStamps: map[int32]int64{},
-		closer:                make(chan struct{}),
+		addr:        addr,
+		remoteNodes: map[int32]*Node{},
+		closer:      make(chan struct{}),
 	}
 }
 
@@ -87,24 +87,25 @@ func (c *client) close() {
 
 // getGossip requests the latest gossip from the remote server by
 // supplying a map of this node's knowledge of other nodes' high water
-// timestamps.
+// timestamps and min hops.
 func (c *client) getGossip(g *Gossip, addr, lAddr util.UnresolvedAddr, done chan *netrpc.Call) {
 	g.mu.Lock()
 	defer g.mu.Unlock()
 
 	nodeID := g.is.NodeID
 	args := Request{
-		NodeID:          nodeID,
-		Addr:            addr,
-		LAddr:           lAddr,
-		HighWaterStamps: g.is.getHighWaterStamps(),
+		NodeID: nodeID,
+		Addr:   addr,
+		LAddr:  lAddr,
+		Nodes:  g.is.getNodes(),
 	}
 	reply := Response{}
 	c.rpcClient.Go("Gossip.Gossip", &args, &reply, done)
 }
 
 // sendGossip sends the latest gossip to the remote server, based on
-// the remote server's high water timestamps map.
+// the remote server's notion of other nodes' high water timestamps
+// and min hops.
 func (c *client) sendGossip(g *Gossip, addr, lAddr util.UnresolvedAddr, done chan *netrpc.Call) {
 	g.mu.Lock()
 	defer g.mu.Unlock()
@@ -113,17 +114,17 @@ func (c *client) sendGossip(g *Gossip, addr, lAddr util.UnresolvedAddr, done cha
 		return
 	}
 	nodeID := g.is.NodeID
-	delta := g.is.delta(c.peerID, c.remoteHighWaterStamps)
+	delta := g.is.delta(c.peerID, c.remoteNodes)
 	if len(delta) == 0 {
 		return
 	}
 
 	args := Request{
-		NodeID:          nodeID,
-		Addr:            addr,
-		LAddr:           lAddr,
-		Delta:           delta,
-		HighWaterStamps: g.is.getHighWaterStamps(),
+		NodeID: nodeID,
+		Addr:   addr,
+		LAddr:  lAddr,
+		Delta:  delta,
+		Nodes:  g.is.getNodes(),
 	}
 	reply := Response{}
 	c.rpcClient.Go("Gossip.Gossip", &args, &reply, done)
@@ -149,15 +150,16 @@ func (c *client) handleGossip(g *Gossip, call *netrpc.Call) error {
 			if log.V(1) {
 				log.Infof("received %s from node %d (%d fresh)", reply.Delta, reply.NodeID, freshCount)
 			} else {
-				log.Infof("received %d (%d fresh) info(s) from node %d", infoCount, freshCount, reply.NodeID)
+				log.Infof("node %d received %d (%d fresh) info(s) from node %d", g.is.NodeID, infoCount, freshCount, reply.NodeID)
 			}
 		}
+		g.maybeTighten()
 	} else if len(args.Delta) > 0 {
 		log.Infof("sent %d info(s) to node %d", len(args.Delta), reply.NodeID)
 	}
 	c.peerID = reply.NodeID
 	g.outgoing.addNode(c.peerID)
-	c.remoteHighWaterStamps = reply.HighWaterStamps
+	c.remoteNodes = reply.Nodes
 
 	// Handle remote forwarding.
 	if reply.AlternateAddr != nil {

--- a/gossip/convergence_test.go
+++ b/gossip/convergence_test.go
@@ -26,7 +26,7 @@ import (
 // verifyConvergence verifies that info from each node is visible from
 // every node in the network within numCycles cycles of the gossip protocol.
 func verifyConvergence(numNodes, maxCycles int, t *testing.T) {
-	network := simulation.NewNetwork(numNodes, "tcp")
+	network := simulation.NewNetwork(numNodes)
 
 	if connectedCycle := network.RunUntilFullyConnected(); connectedCycle > maxCycles {
 		t.Errorf("expected a fully-connected network within %d cycles; took %d",

--- a/gossip/gossip.go
+++ b/gossip/gossip.go
@@ -82,10 +82,10 @@ const (
 	// ttlNodeDescriptorGossip is time-to-live for node ID -> address.
 	ttlNodeDescriptorGossip = 0 * time.Second
 
-	// checkInterval is the default interval for checking for bad gossip
-	// states, including a badly connected network and the least useful
-	// clients.
-	checkInterval = 60 * time.Second
+	// cullInterval is the default interval for culling the least
+	// "useful" outgoing gossip connection to free up space for a
+	// more efficiently targeted connection to the most distant node.
+	cullInterval = 60 * time.Second
 
 	// stallInterval is the default interval for checking whether the
 	// incoming and outgoing connections to the gossip network are
@@ -430,6 +430,16 @@ func (g *Gossip) Outgoing() []roachpb.NodeID {
 	return g.outgoing.asSlice()
 }
 
+// MaxHops returns the maximum number of hops to reach any other
+// node in the system, according to the infos which have reached
+// this node via gossip network.
+func (g *Gossip) MaxHops() uint32 {
+	g.mu.Lock()
+	defer g.mu.Unlock()
+	_, maxHops := g.is.mostDistant()
+	return maxHops
+}
+
 // Start launches the gossip instance, which commences joining the
 // gossip network using the supplied rpc server and the gossip
 // bootstrap addresses specified via command-line flag: --gossip.
@@ -560,15 +570,16 @@ func (g *Gossip) bootstrap(stopper *stop.Stopper) {
 // is notified via the stalled conditional variable.
 func (g *Gossip) manage(stopper *stop.Stopper) {
 	stopper.RunWorker(func() {
-		// Loop until closed and there are no remaining outgoing connections.
 		for {
 			select {
 			case <-stopper.ShouldStop():
 				return
 			case c := <-g.disconnected:
 				g.doDisconnected(stopper, c)
-			case <-time.After(g.jitteredInterval(checkInterval)):
-				g.doCheckNetwork(stopper)
+			case nodeID := <-g.tighten:
+				g.tightenNetwork(stopper, nodeID)
+			case <-time.After(g.jitteredInterval(cullInterval)):
+				g.cullNetwork()
 			case <-time.After(g.jitteredInterval(stallInterval)):
 				g.mu.Lock()
 				g.maybeSignalStalledLocked()
@@ -584,31 +595,40 @@ func (g *Gossip) jitteredInterval(interval time.Duration) time.Duration {
 	return time.Duration(float64(interval) * (0.75 + 0.5*rand.Float64()))
 }
 
-func (g *Gossip) doCheckNetwork(stopper *stop.Stopper) {
+// tightenNetwork "tightens" the network by starting a new gossip
+// client to the most distant node as measured in required gossip hops
+// to propagate info from the distant node to this node.
+func (g *Gossip) tightenNetwork(stopper *stop.Stopper, distantNodeID roachpb.NodeID) {
 	g.mu.Lock()
 	defer g.mu.Unlock()
-	// Check whether the graph needs to be tightened to
-	// accommodate distant infos.
-	distant := g.filterExtant(g.is.distant(MaxHops))
 	g.outgoing.setMaxSize(g.maxPeers())
-	// If there are distant nodes, start a client if we have space.
-	if g.outgoing.hasSpace() && distant.len() > 0 {
-		nodeID := distant.selectRandom()
-		if nodeAddr, err := g.getNodeIDAddressLocked(nodeID); err != nil {
-			log.Errorf("node %d: %s", nodeID, err)
+	if g.outgoing.hasSpace() {
+		if nodeAddr, err := g.getNodeIDAddressLocked(distantNodeID); err != nil {
+			log.Errorf("node %d: %s", distantNodeID, err)
 		} else {
+			log.Infof("starting client to distant node %d to tighten network graph", distantNodeID)
 			g.startClient(nodeAddr, stopper)
 		}
-	} else if !g.outgoing.hasSpace() {
-		// Otherwise, find least useful peer and close it. Make sure
-		// here that we only consider outgoing clients which are
-		// connected.
-		nodeID := g.is.leastUseful(g.outgoing)
-		if nodeID != 0 {
-			log.Infof("closing least useful client %d to tighten network graph", nodeID)
-			g.closeClient(nodeID)
-		}
 	}
+}
+
+// cullNetwork is called periodically to remove the least "useful"
+// outoing node to free up an outgoing spot for a more targeting
+// tightening (via tightenNetwork).
+func (g *Gossip) cullNetwork() {
+	// If there's no space, find and remove least useful peer, if possible.
+	if g.outgoing.hasSpace() {
+		return
+	}
+	leastUsefulID := g.is.leastUseful(g.outgoing)
+	if leastUsefulID == 0 {
+		if log.V(1) {
+			log.Infof("couldn't find least useful client to close")
+		}
+		return
+	}
+	log.Infof("closing least useful client to node %d to tighten network graph", leastUsefulID)
+	g.closeClient(leastUsefulID)
 }
 
 func (g *Gossip) doDisconnected(stopper *stop.Stopper, c *client) {

--- a/gossip/gossip.go
+++ b/gossip/gossip.go
@@ -25,11 +25,14 @@ the system with minimal total hops. The algorithm is as follows:
    address for its first outgoing connection. Node starts client and
    continues to step #2.
 
- 2 Node requests gossip from peer. Gossip requests contain
-   HighWaterStamps, a map from node ID to most recent timestamp of any
-   Info originating at that node. Requesting node times out at
-   checkInterval. On timeout, client is closed and GC'd. If node
-   has no outgoing connections, goto #1.
+ 2 Node requests gossip from peer. Gossip requests (and responses)
+   contain a map from node ID to info about other nodes in the
+   network. Each node maintains its own map as well as the maps of
+   each of its peers. The info for each node includes the most recent
+   timestamp of any Info originating at that node, as well as the min
+   number of hops to reach that node. Requesting node times out at
+   checkInterval. On timeout, client is closed and GC'd. If node has
+   no outgoing connections, goto #1.
 
    a. When gossip is received, infostore is augmented. If new Info was
       received, the client in question is credited. If node has no
@@ -82,11 +85,6 @@ const (
 	// ttlNodeDescriptorGossip is time-to-live for node ID -> address.
 	ttlNodeDescriptorGossip = 0 * time.Second
 
-	// cullInterval is the default interval for culling the least
-	// "useful" outgoing gossip connection to free up space for a
-	// more efficiently targeted connection to the most distant node.
-	cullInterval = 60 * time.Second
-
 	// stallInterval is the default interval for checking whether the
 	// incoming and outgoing connections to the gossip network are
 	// insufficient to keep the network connected.
@@ -99,6 +97,13 @@ const (
 )
 
 var (
+	// cullInterval is the default interval for culling the least
+	// "useful" outgoing gossip connection to free up space for a
+	// more efficiently targeted connection to the most distant node.
+	//
+	// Note: this value is a var instead of const for testing.
+	cullInterval = 60 * time.Second
+
 	// TestBootstrap is the default gossip bootstrap used for running tests.
 	TestBootstrap = []resolver.Resolver{}
 )
@@ -570,6 +575,10 @@ func (g *Gossip) bootstrap(stopper *stop.Stopper) {
 // is notified via the stalled conditional variable.
 func (g *Gossip) manage(stopper *stop.Stopper) {
 	stopper.RunWorker(func() {
+		cullTicker := time.NewTicker(g.jitteredInterval(cullInterval))
+		stallTicker := time.NewTicker(g.jitteredInterval(stallInterval))
+		defer cullTicker.Stop()
+		defer stallTicker.Stop()
 		for {
 			select {
 			case <-stopper.ShouldStop():
@@ -578,9 +587,9 @@ func (g *Gossip) manage(stopper *stop.Stopper) {
 				g.doDisconnected(stopper, c)
 			case nodeID := <-g.tighten:
 				g.tightenNetwork(stopper, nodeID)
-			case <-time.After(g.jitteredInterval(cullInterval)):
+			case <-cullTicker.C:
 				g.cullNetwork()
-			case <-time.After(g.jitteredInterval(stallInterval)):
+			case <-stallTicker.C:
 				g.mu.Lock()
 				g.maybeSignalStalledLocked()
 				g.mu.Unlock()
@@ -613,7 +622,7 @@ func (g *Gossip) tightenNetwork(stopper *stop.Stopper, distantNodeID roachpb.Nod
 }
 
 // cullNetwork is called periodically to remove the least "useful"
-// outoing node to free up an outgoing spot for a more targeting
+// outgoing node to free up an outgoing spot for a more targeted
 // tightening (via tightenNetwork).
 func (g *Gossip) cullNetwork() {
 	// If there's no space, find and remove least useful peer, if possible.

--- a/gossip/gossip.proto
+++ b/gossip/gossip.proto
@@ -23,6 +23,16 @@ import "cockroach/roachpb/metadata.proto";
 import "cockroach/util/unresolved_addr.proto";
 import weak "gogoproto/gogo.proto";
 
+// Node contains information about a gossip node.
+message Node {
+  // High_water_stamp is the most recent timestamp of any info which
+  // originated at this node.
+  int64 high_water_stamp = 1;
+  // Min_hops is the minimum number of hops seen for any info which
+  // originated at this node.
+  uint32 min_hops = 2;
+}
+
 // Request is the request struct passed with the Gossip RPC.
 message Request {
   // Requesting node's ID.
@@ -33,8 +43,8 @@ message Request {
   // Local address of client on requesting node (this is a kludge to
   // allow gossip to know when client connections are dropped).
   util.UnresolvedAddr l_addr = 3 [(gogoproto.nullable) = false];
-  // Map of all high water timestamps, by node, seen by the requester.
-  map<int32, int64> high_water_stamps = 4;
+  // Map of information about other nodes, as seen by the requester.
+  map<int32, Node> nodes = 4;
   // Delta of Infos originating at sender.
   map<string, Info> delta = 5;
 }
@@ -52,10 +62,11 @@ message Response {
   // Node ID of the alternate address, if alternate_addr is not nil.
   int32 alternate_node_id = 4 [(gogoproto.customname) = "AlternateNodeID",
       (gogoproto.casttype) = "github.com/cockroachdb/cockroach/roachpb.NodeID"];
-  // Delta of Infos originating at nodes newer than specified high water timestamps.
+  // Delta of Infos which are fresh according to the map of Node info messages
+  // passed with the request.
   map<string, Info> delta = 5;
   // Map of all high water timestamps, by node, seen by the responder.
-  map<int32, int64> high_water_stamps = 6;
+  map<int32, Node> nodes = 6;
 }
 
 // Info is the basic unit of information traded over the

--- a/gossip/gossip.proto
+++ b/gossip/gossip.proto
@@ -25,11 +25,9 @@ import weak "gogoproto/gogo.proto";
 
 // Node contains information about a gossip node.
 message Node {
-  // High_water_stamp is the most recent timestamp of any info which
-  // originated at this node.
+  // The most recent timestamp of any info which originated at this node.
   int64 high_water_stamp = 1;
-  // Min_hops is the minimum number of hops seen for any info which
-  // originated at this node.
+  // The minimum number of hops seen for any info which originated at this node.
   uint32 min_hops = 2;
 }
 
@@ -65,7 +63,7 @@ message Response {
   // Delta of Infos which are fresh according to the map of Node info messages
   // passed with the request.
   map<string, Info> delta = 5;
-  // Map of all high water timestamps, by node, seen by the responder.
+  // Map of information about other nodes, as seen by the responder.
   map<int32, Node> nodes = 6;
 }
 

--- a/gossip/gossip_test.go
+++ b/gossip/gossip_test.go
@@ -18,6 +18,7 @@ package gossip
 
 import (
 	"bytes"
+	"errors"
 	"testing"
 	"time"
 
@@ -25,9 +26,11 @@ import (
 	"github.com/cockroachdb/cockroach/gossip/resolver"
 	"github.com/cockroachdb/cockroach/roachpb"
 	"github.com/cockroachdb/cockroach/rpc"
+	"github.com/cockroachdb/cockroach/util"
 	"github.com/cockroachdb/cockroach/util/hlc"
 	"github.com/cockroachdb/cockroach/util/leaktest"
 	"github.com/cockroachdb/cockroach/util/log"
+	"github.com/cockroachdb/cockroach/util/stop"
 )
 
 // TestGossipInfoStore verifies operation of gossip instance infostore.
@@ -97,4 +100,43 @@ func TestGossipGetNextBootstrapAddress(t *testing.T) {
 			t.Errorf("%d: expected addr %s; got %s", i, expAddresses[i], addr.String())
 		}
 	}
+}
+
+// TestGossipCullNetwork verifies that a client will be culled from
+// the network periodically (at cullInterval duration intervals).
+func TestGossipCullNetwork(t *testing.T) {
+	defer leaktest.AfterTest(t)
+
+	// Set the cullInterval to a low value to guarantee it kicks in quickly.
+	origCullInterval := cullInterval
+	cullInterval = 5 * time.Millisecond
+	defer func() {
+		cullInterval = origCullInterval
+	}()
+
+	// Create the local gossip and minPeers peers.
+	stopper := stop.NewStopper()
+	defer stopper.Stop()
+	local := startGossip(1, stopper, t)
+	peers := []*Gossip{}
+	for i := 0; i < minPeers; i++ {
+		peers = append(peers, startGossip(roachpb.NodeID(i+2), stopper, t))
+	}
+
+	// Start clients to all peers and start the local gossip's manage routine.
+	local.mu.Lock()
+	for _, p := range peers {
+		pAddr := p.is.NodeAddr
+		local.startClient(pAddr, stopper)
+	}
+	local.mu.Unlock()
+	local.manage(stopper)
+
+	util.SucceedsWithin(t, 10*time.Second, func() error {
+		// Verify that a client is closed within the cull interval.
+		if len(local.Outgoing()) == minPeers-1 {
+			return nil
+		}
+		return errors.New("no network culling occurred")
+	})
 }

--- a/gossip/info.go
+++ b/gossip/info.go
@@ -16,22 +16,27 @@
 
 package gossip
 
-import (
-	"github.com/cockroachdb/cockroach/roachpb"
-)
+import "github.com/cockroachdb/cockroach/roachpb"
 
 // expired returns true if the node's time to live (TTL) has expired.
 func (i *Info) expired(now int64) bool {
 	return i.TTLStamp <= now
 }
 
-// isFresh returns true if the info has an originating timestamp newer
-// than timestamp and didn't originate from the same node.
-func (i *Info) isFresh(nodeID roachpb.NodeID, timestamp int64) bool {
-	if (nodeID != 0 && nodeID == i.NodeID) || i.OrigStamp <= timestamp {
+// isFresh returns false if the info originated at this node, or if
+// the info has an originating timestamp earlier than the latest seen
+// by this node, or if the timestamps are equal but the hops the info
+// has taken to arrive at this node is greater than the minimum seen
+// from the originating node.
+func (i *Info) isFresh(thisNodeID roachpb.NodeID, n *Node) bool {
+	if thisNodeID != 0 && thisNodeID == i.NodeID {
 		return false
 	}
-	return true
+	if n == nil || (i.OrigStamp > n.HighWaterStamp ||
+		(i.OrigStamp == n.HighWaterStamp && i.Hops+1 < n.MinHops)) {
+		return true
+	}
+	return false
 }
 
 // infoMap is a map of keys to info object pointers.

--- a/gossip/info_test.go
+++ b/gossip/info_test.go
@@ -57,20 +57,45 @@ func TestIsFresh(t *testing.T) {
 	node3 := roachpb.NodeID(3)
 	i := newInfo(float64(1))
 	i.NodeID = node1
-	if !i.isFresh(node3, i.OrigStamp-1) {
+	i.Hops = 3
+	if !i.isFresh(node3, nil) {
 		t.Error("info should be fresh:", i)
 	}
-	if i.isFresh(node3, i.OrigStamp+1) {
+	if i.isFresh(node1, nil) {
 		t.Error("info should not be fresh:", i)
 	}
-	if i.isFresh(node1, i.OrigStamp-1) {
+	if !i.isFresh(node3, &Node{i.OrigStamp - 1, 3}) {
+		t.Error("info should be fresh:", i)
+	}
+	if !i.isFresh(node3, &Node{i.OrigStamp - 1, 4}) {
+		t.Error("info should be fresh:", i)
+	}
+	if i.isFresh(node3, &Node{i.OrigStamp, 3}) {
 		t.Error("info should not be fresh:", i)
 	}
-	if !i.isFresh(node2, i.OrigStamp-1) {
+	if i.isFresh(node3, &Node{i.OrigStamp, 4}) {
+		t.Error("info should not be fresh:", i)
+	}
+	if !i.isFresh(node3, &Node{i.OrigStamp, 5}) {
+		t.Error("info should be fresh:", i)
+	}
+	if i.isFresh(node3, &Node{i.OrigStamp, 2}) {
+		t.Error("info should not be fresh (hops + 1 will not be better):", i)
+	}
+	if i.isFresh(node3, &Node{i.OrigStamp + 1, 3}) {
+		t.Error("info should not be fresh:", i)
+	}
+	if i.isFresh(node3, &Node{i.OrigStamp + 1, 2}) {
+		t.Error("info should not be fresh:", i)
+	}
+	if i.isFresh(node1, &Node{i.OrigStamp - 1, 2}) {
+		t.Error("info should not be fresh:", i)
+	}
+	if !i.isFresh(node2, &Node{i.OrigStamp - 1, 3}) {
 		t.Error("info should be fresh:", i)
 	}
 	// Using node 0 will always yield fresh data.
-	if !i.isFresh(0, 0) {
+	if !i.isFresh(0, &Node{0, 0}) {
 		t.Error("info should be fresh from node0:", i)
 	}
 }

--- a/gossip/infostore.go
+++ b/gossip/infostore.go
@@ -46,11 +46,11 @@ type callback struct {
 //
 // infoStores are not thread safe.
 type infoStore struct {
-	Infos           infoMap             `json:"infos,omitempty"` // Map from key to info
-	NodeID          roachpb.NodeID      `json:"-"`               // Owning node's ID
-	NodeAddr        util.UnresolvedAddr `json:"-"`               // Address of node owning this info store: "host:port"
-	highWaterStamps map[int32]int64     // High water timestamps for known gossip peers
-	callbacks       []*callback
+	Infos     infoMap             `json:"infos,omitempty"` // Map from key to info
+	NodeID    roachpb.NodeID      `json:"-"`               // Owning node's ID
+	NodeAddr  util.UnresolvedAddr `json:"-"`               // Address of node owning this info store: "host:port"
+	nodes     map[int32]*Node     // Per-node information for gossip peers
+	callbacks []*callback
 }
 
 var monoTime struct {
@@ -100,10 +100,10 @@ func (is *infoStore) String() string {
 // newInfoStore allocates and returns a new infoStore.
 func newInfoStore(nodeID roachpb.NodeID, nodeAddr util.UnresolvedAddr) infoStore {
 	return infoStore{
-		Infos:           make(infoMap),
-		NodeID:          nodeID,
-		NodeAddr:        nodeAddr,
-		highWaterStamps: map[int32]int64{},
+		Infos:    make(infoMap),
+		NodeID:   nodeID,
+		NodeAddr: nodeAddr,
+		nodes:    map[int32]*Node{},
 	}
 }
 
@@ -159,44 +159,37 @@ func (is *infoStore) addInfo(key string, i *Info) error {
 	if i.OrigStamp == 0 {
 		i.Value.InitChecksum([]byte(key))
 		i.OrigStamp = monotonicUnixNano()
-		if hws := is.highWaterStamps[int32(i.NodeID)]; hws >= i.OrigStamp {
-			panic(util.Errorf("high water stamp %d >= %d", hws, i.OrigStamp))
+		if n, ok := is.nodes[int32(i.NodeID)]; ok && n.HighWaterStamp >= i.OrigStamp {
+			panic(util.Errorf("high water stamp %d >= %d", n.HighWaterStamp, i.OrigStamp))
 		}
 	}
 	// Update info map.
 	is.Infos[key] = i
-	// Update the high water timestamps.
-	if i.NodeID != 0 {
-		if is.highWaterStamps[int32(i.NodeID)] < i.OrigStamp {
-			is.highWaterStamps[int32(i.NodeID)] = i.OrigStamp
+	// Update the high water timestamp & min hops for the originating node.
+	if nID := int32(i.NodeID); nID != 0 {
+		n, ok := is.nodes[nID]
+		if !ok {
+			is.nodes[nID] = &Node{i.OrigStamp, i.Hops}
+		} else {
+			if n.HighWaterStamp < i.OrigStamp {
+				n.HighWaterStamp = i.OrigStamp
+			}
+			if n.MinHops > i.Hops {
+				n.MinHops = i.Hops
+			}
 		}
 	}
 	is.processCallbacks(key, i.Value)
 	return nil
 }
 
-// maxHops returns the maximum hops across all infos in the store.
-// This is the maximum number of gossip exchanges between any
-// originator and this node.
-func (is *infoStore) maxHops() uint32 {
-	var maxHops uint32
-	if err := is.visitInfos(func(key string, i *Info) error {
-		if i.Hops > maxHops {
-			maxHops = i.Hops
-		}
-		return nil
-	}); err != nil {
-		panic(err)
-	}
-	return maxHops
-}
-
-// getHighWaterStamps returns a copy of the high water timestamps map
+// getNodes returns a copy of the nodes map of gossip peer info
 // maintained by this infostore.
-func (is *infoStore) getHighWaterStamps() map[int32]int64 {
-	copy := make(map[int32]int64, len(is.highWaterStamps))
-	for k, v := range is.highWaterStamps {
-		copy[k] = v
+func (is *infoStore) getNodes() map[int32]*Node {
+	copy := make(map[int32]*Node, len(is.nodes))
+	for k, v := range is.nodes {
+		nodeCopy := *v
+		copy[k] = &nodeCopy
 	}
 	return copy
 }
@@ -272,7 +265,7 @@ func (is *infoStore) visitInfos(visitInfo func(string, *Info) error) error {
 
 // combine combines an incremental delta with the current infoStore.
 // All hop distances on infos are incremented to indicate they've
-// arrived from an external source.  Returns the count of "fresh"
+// arrived from an external source. Returns the count of "fresh"
 // infos in the provided delta.
 func (is *infoStore) combine(infos map[string]*Info, nodeID roachpb.NodeID) int {
 	var freshCount int
@@ -292,17 +285,17 @@ func (is *infoStore) combine(infos map[string]*Info, nodeID roachpb.NodeID) int 
 	return freshCount
 }
 
-// delta returns an incremental delta of infos added to the info store
-// since (not including) the high water timestamps specified. These
-// deltas are intended for efficiently updating peer nodes. Any infos
-// passed from node requesting delta are ignored.
-//
-// Returns nil if there are no deltas.
-func (is *infoStore) delta(nodeID roachpb.NodeID, highWaterStamps map[int32]int64) map[string]*Info {
+// delta returns a map of infos which are newer or have fewer hops
+// than the values indicated by the supplied nodes map. The
+// supplied nodes map contains gossip node information from the
+// perspective of the peer asking for the delta. That is, the map
+// contains a record of the most recent info timestamp and min hops
+// which the requester has seen from each node in the network.
+func (is *infoStore) delta(nodeID roachpb.NodeID, nodes map[int32]*Node) map[string]*Info {
 	infos := make(map[string]*Info)
 	// Compute delta of infos.
 	if err := is.visitInfos(func(key string, i *Info) error {
-		if i.isFresh(nodeID, highWaterStamps[int32(i.NodeID)]) {
+		if i.isFresh(nodeID, nodes[int32(i.NodeID)]) {
 			infos[key] = i
 		}
 		return nil
@@ -313,19 +306,21 @@ func (is *infoStore) delta(nodeID roachpb.NodeID, highWaterStamps map[int32]int6
 	return infos
 }
 
-// distant returns a nodeSet for gossip peers which originated Infos
-// with info.Hops > maxHops.
-func (is *infoStore) distant(maxHops uint32) nodeSet {
-	ns := makeNodeSet(0)
+// mostDistant returns the most distant gossip node known to the
+// store as well as the number of hops to reach it.
+func (is *infoStore) mostDistant() (roachpb.NodeID, uint32) {
+	var nodeID roachpb.NodeID
+	var maxHops uint32
 	if err := is.visitInfos(func(key string, i *Info) error {
 		if i.Hops > maxHops {
-			ns.addNode(i.NodeID)
+			maxHops = i.Hops
+			nodeID = i.NodeID
 		}
 		return nil
 	}); err != nil {
 		panic(err)
 	}
-	return ns
+	return nodeID, maxHops
 }
 
 // leastUseful determines which node ID from amongst the set is

--- a/gossip/infostore_test.go
+++ b/gossip/infostore_test.go
@@ -279,6 +279,7 @@ func TestLeastUseful(t *testing.T) {
 	}
 
 	inf1 := is.newInfo(nil, time.Second)
+	inf1.NodeID = 1
 	inf1.PeerID = 1
 	if err := is.addInfo("a1", inf1); err != nil {
 		t.Fatal(err)
@@ -293,6 +294,7 @@ func TestLeastUseful(t *testing.T) {
 	}
 
 	inf2 := is.newInfo(nil, time.Second)
+	inf2.NodeID = 2
 	inf2.PeerID = 1
 	if err := is.addInfo("a2", inf2); err != nil {
 		t.Fatal(err)
@@ -307,6 +309,7 @@ func TestLeastUseful(t *testing.T) {
 	}
 
 	inf3 := is.newInfo(nil, time.Second)
+	inf3.NodeID = 2
 	inf3.PeerID = 2
 	if err := is.addInfo("a3", inf3); err != nil {
 		t.Fatal(err)

--- a/gossip/simulation/gossip.go
+++ b/gossip/simulation/gossip.go
@@ -205,6 +205,7 @@ func outputDotFile(dotFN string, cycle int, network *simulation.Network, edgeSet
 				continue // skip the node's own info
 			}
 			infoKey := otherNode.Addr.String()
+			// GetInfo returns an error if the info is missing.
 			if info, err := node.GetInfo(infoKey); err != nil {
 				missing = append(missing, otherNode.Gossip.GetNodeID())
 				quiescent = false
@@ -219,6 +220,7 @@ func outputDotFile(dotFN string, cycle int, network *simulation.Network, edgeSet
 		log.Infof("node %d: missing infos for nodes %s", node.GetNodeID(), missing)
 
 		var sentinelAge int64
+		// GetInfo returns an error if the info is missing.
 		if info, err := node.GetInfo(gossip.KeySentinel); err != nil {
 			log.Infof("error getting info for sentinel gossip key %q: %s", gossip.KeySentinel, err)
 		} else {

--- a/gossip/simulation/gossip.go
+++ b/gossip/simulation/gossip.go
@@ -29,8 +29,8 @@ Gossip
 Gossip creates a gossip network of up to 250 nodes and outputs
 successive visualization of the gossip network graph via dot.
 
-Uses unix domain or tcp sockets for connecting 3, 10, 25, 50, 100 or
-250 nodes. Generates .dot graph output files for each cycle of the
+Uses tcp sockets for connecting 3, 10, 25, 50, 100 or 250
+nodes. Generates .dot graph output files for each cycle of the
 simulation.
 
 To run:
@@ -90,8 +90,7 @@ const (
 )
 
 var (
-	size        = flag.String("size", "medium", "size of network (tiny|small|medium|large|huge|ginormous)")
-	networkType = flag.String("network", "unix", "test with network type (unix|tcp)")
+	size = flag.String("size", "medium", "size of network (tiny|small|medium|large|huge|ginormous)")
 )
 
 // edge is a helper struct which describes an edge in the dot output graph.
@@ -199,7 +198,7 @@ func outputDotFile(dotFN string, cycle int, network *simulation.Network, edgeSet
 	f.WriteString("node [shape=record];\n")
 	for _, simNode := range network.Nodes {
 		node := simNode.Gossip
-		var incomplete int
+		var missing []roachpb.NodeID
 		var totalAge int64
 		for _, otherNode := range network.Nodes {
 			if otherNode == simNode {
@@ -207,8 +206,7 @@ func outputDotFile(dotFN string, cycle int, network *simulation.Network, edgeSet
 			}
 			infoKey := otherNode.Addr.String()
 			if info, err := node.GetInfo(infoKey); err != nil {
-				log.Infof("error getting info for key %q: %s", infoKey, err)
-				incomplete++
+				missing = append(missing, otherNode.Gossip.GetNodeID())
 				quiescent = false
 			} else {
 				_, val, err := encoding.DecodeUint64(info)
@@ -218,6 +216,7 @@ func outputDotFile(dotFN string, cycle int, network *simulation.Network, edgeSet
 				totalAge += int64(cycle) - int64(val)
 			}
 		}
+		log.Infof("node %d: missing infos for nodes %s", node.GetNodeID(), missing)
 
 		var sentinelAge int64
 		if info, err := node.GetInfo(gossip.KeySentinel); err != nil {
@@ -231,19 +230,19 @@ func outputDotFile(dotFN string, cycle int, network *simulation.Network, edgeSet
 		}
 
 		var age, nodeColor string
-		if incomplete > 0 {
+		if len(missing) > 0 {
 			nodeColor = "color=red,"
-			age = fmt.Sprintf("missing %d", incomplete)
+			age = fmt.Sprintf("missing %d", len(missing))
 		} else {
-			age = strconv.FormatFloat(float64(totalAge)/float64(len(network.Nodes)-1), 'f', 4, 64)
+			age = strconv.FormatFloat(float64(totalAge)/float64(len(network.Nodes)-1-len(missing)), 'f', 4, 64)
 		}
 		fontSize := minDotFontSize
 		if maxIncoming > 0 {
 			fontSize = minDotFontSize + int(math.Floor(float64(len(node.Incoming())*
 				(maxDotFontSize-minDotFontSize))/float64(maxIncoming)))
 		}
-		f.WriteString(fmt.Sprintf("\t%s [%sfontsize=%d,label=\"{%s|AA=%s, SA=%d}\"]\n",
-			node.GetNodeID(), nodeColor, fontSize, node.GetNodeID(), age, sentinelAge))
+		f.WriteString(fmt.Sprintf("\t%s [%sfontsize=%d,label=\"{%s|AA=%s, MH=%d, SA=%d}\"]\n",
+			node.GetNodeID(), nodeColor, fontSize, node.GetNodeID(), age, node.MaxHops(), sentinelAge))
 		outgoing := outgoingMap[node.GetNodeID()]
 		for _, e := range outgoing {
 			destSimNode, ok := network.GetNodeFromID(e.dest)
@@ -305,7 +304,7 @@ func main() {
 
 	edgeSet := make(map[string]edge)
 
-	n := simulation.NewNetwork(nodeCount, *networkType)
+	n := simulation.NewNetwork(nodeCount)
 	n.SimulateNetwork(
 		func(cycle int, network *simulation.Network) bool {
 			// Output dot graph.

--- a/gossip/simulation/network.go
+++ b/gossip/simulation/network.go
@@ -43,14 +43,12 @@ type Node struct {
 
 // Network provides access to a test gossip network of nodes.
 type Network struct {
-	Nodes       []*Node
-	NetworkType string // "tcp" or "unix"
-	Stopper     *stop.Stopper
+	Nodes   []*Node
+	Stopper *stop.Stopper
 }
 
-// NewNetwork creates nodeCount gossip nodes. The networkType should
-// be set to either "tcp" or "unix".
-func NewNetwork(nodeCount int, networkType string) *Network {
+// NewNetwork creates nodeCount gossip nodes.
+func NewNetwork(nodeCount int) *Network {
 	clock := hlc.NewClock(hlc.UnixNano)
 
 	log.Infof("simulating gossip network with %d nodes", nodeCount)
@@ -67,7 +65,7 @@ func NewNetwork(nodeCount int, networkType string) *Network {
 	for i := range nodes {
 		server := rpc.NewServer(rpcContext)
 
-		testAddr := util.CreateTestAddr(networkType)
+		testAddr := util.CreateTestAddr("tcp")
 		ln, err := util.ListenAndServe(stopper, server, testAddr, tlsConfig)
 		if err != nil {
 			log.Fatal(err)
@@ -99,9 +97,8 @@ func NewNetwork(nodeCount int, networkType string) *Network {
 	}
 
 	return &Network{
-		Nodes:       nodes,
-		NetworkType: networkType,
-		Stopper:     stopper,
+		Nodes:   nodes,
+		Stopper: stopper,
 	}
 }
 

--- a/kv/dist_sender_test.go
+++ b/kv/dist_sender_test.go
@@ -55,7 +55,7 @@ var testRangeDescriptor = roachpb.RangeDescriptor{
 var testAddress = util.MakeUnresolvedAddr("tcp", "node1:26257")
 
 func makeTestGossip(t *testing.T) (*gossip.Gossip, func()) {
-	n := simulation.NewNetwork(1, "tcp")
+	n := simulation.NewNetwork(1)
 	g := n.Nodes[0].Gossip
 
 	if err := g.AddInfo(gossip.KeySentinel, nil, time.Hour); err != nil {
@@ -622,7 +622,7 @@ func TestRetryOnWrongReplicaError(t *testing.T) {
 
 func TestGetFirstRangeDescriptor(t *testing.T) {
 	defer leaktest.AfterTest(t)
-	n := simulation.NewNetwork(3, "tcp")
+	n := simulation.NewNetwork(3)
 	ds := NewDistSender(nil, n.Nodes[0].Gossip)
 	if _, err := ds.FirstRange(); err == nil {
 		t.Errorf("expected not to find first range descriptor")


### PR DESCRIPTION
Rewrote the previous recently-broken mechanism for tightening gossip
networks to achieve the required maximum number of hops between any
two nodes to communicate gossiped infos.

In the new mechanism, nodes exchange not just high water timestamps,
but also the minimum number of hops each node has seen for an info
from each node in the network. New infos are received either when
the timestamp is newer or the number of hops is smaller, to
acknowledge when "tighter" connections are made.

As new infos are received, nodes will make new connections to the
most "distant" node in the reachable network, as measured by number
of hops the info(s) needed to cross the network. Distant nodes are
defined as ones where the number of hops is greater than the constant
value for MaxHops (set to 5 currently).

Each node also periodically culls the least useful outgoing connection
in order to keep the network from getting too locked into a sub-optimal
configuration.

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/3501)

<!-- Reviewable:end -->
