### PR TITLE
transient stats prototype

### DIFF
--- a/GLOCKFILE
+++ b/GLOCKFILE
@@ -12,6 +12,7 @@ cmd github.com/tebeka/go2xunit
 cmd golang.org/x/tools/cmd/goimports
 cmd golang.org/x/tools/cmd/stress
 cmd golang.org/x/tools/cmd/stringer
+github.com/VividCortex/ewma c34099b489e4ac33ca8d8c5f9d29d6eeaf69f2ed
 github.com/agtorre/gocolorize f42b554bf7f006936130c9bb4f971afd2d87f671
 github.com/biogo/store 3b4c041f52c224ee4a44f5c8b150d003a40643a0
 github.com/cockroachdb/c-lz4 c40aaae2fc50293eb8750b34632bc3efe813e23f
@@ -19,6 +20,7 @@ github.com/cockroachdb/c-protobuf 6a18bfcdd5169966cd1235edb71d749c950216e8
 github.com/cockroachdb/c-rocksdb bf15ead80bdc205a19b3d33415b23c156a3cf371
 github.com/cockroachdb/c-snappy 5c6d0932e0adaffce4bfca7bdf2ac37f79952ccf
 github.com/cockroachdb/yacc 443154b1852a8702b07d675da6cd97cd9177a316
+github.com/codahale/hdrhistogram 954f16e8b9ef0e5d5189456aa4c1202758e04f17
 github.com/coreos/etcd 0eb46eb1457bf277a5d6093287290b2b5cd6a964
 github.com/cpuguy83/go-md2man 71acacd42f85e5e82f70a55327789582a5200a90
 github.com/docker/docker 5e0283effa73223e5528c61beb4e05b5018c5d6b

--- a/server/node_test.go
+++ b/server/node_test.go
@@ -40,6 +40,7 @@ import (
 	"github.com/cockroachdb/cockroach/util"
 	"github.com/cockroachdb/cockroach/util/hlc"
 	"github.com/cockroachdb/cockroach/util/leaktest"
+	"github.com/cockroachdb/cockroach/util/metric"
 	"github.com/cockroachdb/cockroach/util/stop"
 )
 
@@ -80,7 +81,7 @@ func createTestNode(addr net.Addr, engines []engine.Engine, gossipBS net.Addr, t
 	// (or attach LocalRPCTransport.Close to the stopper)
 	ctx.Transport = multiraft.NewLocalRPCTransport(stopper)
 	ctx.EventFeed = util.NewFeed(stopper)
-	node := NewNode(ctx)
+	node := NewNode(ctx, metric.NewRegistry(), stopper)
 	return rpcServer, ln.Addr(), ctx.Clock, node, stopper
 }
 
@@ -88,7 +89,7 @@ func createTestNode(addr net.Addr, engines []engine.Engine, gossipBS net.Addr, t
 func createAndStartTestNode(addr net.Addr, engines []engine.Engine, gossipBS net.Addr, t *testing.T) (
 	*rpc.Server, net.Addr, *Node, *stop.Stopper) {
 	rpcServer, addr, _, node, stopper := createTestNode(addr, engines, gossipBS, t)
-	if err := node.start(rpcServer, addr, engines, roachpb.Attributes{}, stopper); err != nil {
+	if err := node.start(rpcServer, addr, engines, roachpb.Attributes{}); err != nil {
 		t.Fatal(err)
 	}
 	return rpcServer, addr, node, stopper
@@ -273,7 +274,7 @@ func TestCorruptedClusterID(t *testing.T) {
 
 	engines := []engine.Engine{e}
 	server, serverAddr, _, node, stopper := createTestNode(util.CreateTestAddr("tcp"), engines, nil, t)
-	if err := node.start(server, serverAddr, engines, roachpb.Attributes{}, stopper); err == nil {
+	if err := node.start(server, serverAddr, engines, roachpb.Attributes{}); err == nil {
 		t.Errorf("unexpected success")
 	}
 	stopper.Stop()

--- a/server/server.go
+++ b/server/server.go
@@ -46,6 +46,7 @@ import (
 	"github.com/cockroachdb/cockroach/util"
 	"github.com/cockroachdb/cockroach/util/hlc"
 	"github.com/cockroachdb/cockroach/util/log"
+	"github.com/cockroachdb/cockroach/util/metric"
 	"github.com/cockroachdb/cockroach/util/stop"
 	"github.com/cockroachdb/cockroach/util/tracer"
 	assetfs "github.com/elazarl/go-bindata-assetfs"
@@ -81,6 +82,7 @@ type Server struct {
 	tsDB          *ts.DB
 	tsServer      *ts.Server
 	raftTransport multiraft.Transport
+	metaRegistry  *metric.Registry
 	stopper       *stop.Stopper
 }
 
@@ -106,10 +108,11 @@ func NewServer(ctx *Context, stopper *stop.Stopper) (*Server, error) {
 	}
 
 	s := &Server{
-		ctx:     ctx,
-		mux:     http.NewServeMux(),
-		clock:   hlc.NewClock(hlc.UnixNano),
-		stopper: stopper,
+		ctx:          ctx,
+		mux:          http.NewServeMux(),
+		clock:        hlc.NewClock(hlc.UnixNano),
+		metaRegistry: metric.NewRegistry(),
+		stopper:      stopper,
 	}
 	s.clock.SetMaxOffset(ctx.MaxOffset)
 
@@ -144,7 +147,7 @@ func NewServer(ctx *Context, stopper *stop.Stopper) (*Server, error) {
 
 	leaseMgr := sql.NewLeaseManager(0, *s.db, s.clock)
 	leaseMgr.RefreshLeases(s.stopper, s.db, s.gossip)
-	s.sqlServer = sql.MakeServer(&s.ctx.Context, *s.db, s.gossip, leaseMgr, s.stopper)
+	s.sqlServer = sql.MakeServer(&s.ctx.Context, *s.db, s.gossip, leaseMgr, s.metaRegistry, s.stopper)
 	if err := s.sqlServer.RegisterRPC(s.rpc); err != nil {
 		return nil, err
 	}
@@ -171,9 +174,8 @@ func NewServer(ctx *Context, stopper *stop.Stopper) (*Server, error) {
 			Mode:           s.ctx.BalanceMode,
 		},
 	}
-	s.node = NewNode(nCtx)
+	s.node = NewNode(nCtx, s.metaRegistry, s.stopper)
 	s.admin = newAdminServer(s.db, s.stopper)
-	s.status = newStatusServer(s.db, s.gossip, ctx)
 	s.tsDB = ts.NewDB(s.db)
 	s.tsServer = ts.NewServer(s.tsDB)
 
@@ -210,7 +212,7 @@ func (s *Server) Start(selfBootstrap bool) error {
 	}
 	s.gossip.Start(s.rpc, addr, s.stopper)
 
-	if err := s.node.start(s.rpc, addr, s.ctx.Engines, s.ctx.NodeAttributes, s.stopper); err != nil {
+	if err := s.node.start(s.rpc, addr, s.ctx.Engines, s.ctx.NodeAttributes); err != nil {
 		return err
 	}
 
@@ -226,6 +228,8 @@ func (s *Server) Start(selfBootstrap bool) error {
 	s.startWriteSummaries()
 
 	s.sqlServer.SetNodeID(s.node.Descriptor.NodeID)
+
+	s.status = newStatusServer(s.db, s.gossip, s.metaRegistry, s.ctx)
 
 	log.Infof("starting %s server at %s", s.ctx.HTTPRequestScheme(), addr)
 	s.initHTTP()

--- a/server/status.go
+++ b/server/status.go
@@ -34,6 +34,7 @@ import (
 	"github.com/cockroachdb/cockroach/storage"
 	"github.com/cockroachdb/cockroach/util"
 	"github.com/cockroachdb/cockroach/util/log"
+	"github.com/cockroachdb/cockroach/util/metric"
 	"github.com/julienschmidt/httprouter"
 )
 
@@ -90,6 +91,8 @@ const (
 	// statusStorePattern exposes status for a single store.
 	statusStorePattern = statusPrefix + "stores/:store_id"
 
+	statusMetricsPattern = statusPrefix + "metrics/:store_id"
+
 	// healthEndpoint is a shortcut for local details, intended for use by
 	// monitoring processes to verify that the server is up.
 	healthEndpoint = "/health"
@@ -100,15 +103,16 @@ var localRE = regexp.MustCompile(`(?i)local`)
 
 // A statusServer provides a RESTful status API.
 type statusServer struct {
-	db          *client.DB
-	gossip      *gossip.Gossip
-	router      *httprouter.Router
-	ctx         *Context
-	proxyClient *http.Client
+	db           *client.DB
+	gossip       *gossip.Gossip
+	metaRegistry *metric.Registry
+	router       *httprouter.Router
+	ctx          *Context
+	proxyClient  *http.Client
 }
 
 // newStatusServer allocates and returns a statusServer.
-func newStatusServer(db *client.DB, gossip *gossip.Gossip, ctx *Context) *statusServer {
+func newStatusServer(db *client.DB, gossip *gossip.Gossip, metaRegistry *metric.Registry, ctx *Context) *statusServer {
 	// Create an http client with a timeout
 	tlsConfig, err := ctx.GetClientTLSConfig()
 	if err != nil {
@@ -121,11 +125,12 @@ func newStatusServer(db *client.DB, gossip *gossip.Gossip, ctx *Context) *status
 	}
 
 	server := &statusServer{
-		db:          db,
-		gossip:      gossip,
-		router:      httprouter.New(),
-		ctx:         ctx,
-		proxyClient: httpClient,
+		db:           db,
+		gossip:       gossip,
+		metaRegistry: metaRegistry,
+		router:       httprouter.New(),
+		ctx:          ctx,
+		proxyClient:  httpClient,
 	}
 
 	server.router.GET(statusGossipPattern, server.handleGossip)
@@ -138,8 +143,9 @@ func newStatusServer(db *client.DB, gossip *gossip.Gossip, ctx *Context) *status
 	server.router.GET(statusNodePattern, server.handleNodeStatus)
 	server.router.GET(statusStoresPrefix, server.handleStoresStatus)
 	server.router.GET(statusStorePattern, server.handleStoreStatus)
-	server.router.GET(healthEndpoint, server.handleDetailsLocal)
+	server.router.GET(statusMetricsPattern, server.handleMetrics)
 
+	server.router.GET(healthEndpoint, server.handleDetailsLocal)
 	return server
 }
 
@@ -590,6 +596,20 @@ func (s *statusServer) handleStoreStatus(w http.ResponseWriter, r *http.Request,
 		return
 	}
 	respondAsJSON(w, r, storeStatus)
+}
+
+func (s *statusServer) handleMetrics(w http.ResponseWriter, r *http.Request, ps httprouter.Params) {
+	nodeID, local, err := s.extractNodeID(ps)
+	if err != nil {
+		http.Error(w, err.Error(), http.StatusBadRequest)
+		return
+	}
+
+	if !local {
+		s.proxyRequest(nodeID, w, r)
+		return
+	}
+	respondAsJSON(w, r, s.metaRegistry)
 }
 
 func respondAsJSON(w http.ResponseWriter, r *http.Request, response interface{}) {

--- a/server/status/feed_test.go
+++ b/server/status/feed_test.go
@@ -20,6 +20,7 @@ import (
 	"fmt"
 	"reflect"
 	"testing"
+	"time"
 
 	"github.com/cockroachdb/cockroach/client"
 	"github.com/cockroachdb/cockroach/roachpb"
@@ -65,7 +66,7 @@ func TestNodeEventFeed(t *testing.T) {
 		},
 		{
 			publishTo: func(nef status.NodeEventFeed) {
-				nef.CallComplete(wrap(roachpb.NewGet(roachpb.Key("abc"))), nil)
+				nef.CallComplete(wrap(roachpb.NewGet(roachpb.Key("abc"))), 0, nil)
 			},
 			expected: &status.CallSuccessEvent{
 				NodeID: roachpb.NodeID(1),
@@ -74,7 +75,7 @@ func TestNodeEventFeed(t *testing.T) {
 		},
 		{
 			publishTo: func(nef status.NodeEventFeed) {
-				nef.CallComplete(wrap(roachpb.NewPut(roachpb.Key("abc"), roachpb.MakeValueFromString("def"))), nil)
+				nef.CallComplete(wrap(roachpb.NewPut(roachpb.Key("abc"), roachpb.MakeValueFromString("def"))), 0, nil)
 			},
 			expected: &status.CallSuccessEvent{
 				NodeID: roachpb.NodeID(1),
@@ -83,7 +84,7 @@ func TestNodeEventFeed(t *testing.T) {
 		},
 		{
 			publishTo: func(nef status.NodeEventFeed) {
-				nef.CallComplete(wrap(roachpb.NewGet(roachpb.Key("abc"))), roachpb.NewError(util.Errorf("error")))
+				nef.CallComplete(wrap(roachpb.NewGet(roachpb.Key("abc"))), 0, roachpb.NewError(util.Errorf("error")))
 			},
 			expected: &status.CallErrorEvent{
 				NodeID: roachpb.NodeID(1),
@@ -92,7 +93,7 @@ func TestNodeEventFeed(t *testing.T) {
 		},
 		{
 			publishTo: func(nef status.NodeEventFeed) {
-				nef.CallComplete(wrap(roachpb.NewGet(roachpb.Key("abc"))), &roachpb.Error{
+				nef.CallComplete(wrap(roachpb.NewGet(roachpb.Key("abc"))), time.Minute, &roachpb.Error{
 					Detail: &roachpb.ErrorDetail{
 						WriteIntent: &roachpb.WriteIntentError{
 							Index: &roachpb.ErrPosition{Index: 0},
@@ -102,8 +103,9 @@ func TestNodeEventFeed(t *testing.T) {
 				})
 			},
 			expected: &status.CallErrorEvent{
-				NodeID: roachpb.NodeID(1),
-				Method: roachpb.Get,
+				NodeID:   roachpb.NodeID(1),
+				Method:   roachpb.Get,
+				Duration: time.Minute,
 			},
 		},
 	}
@@ -309,14 +311,16 @@ func TestNodeEventFeedTransactionRestart(t *testing.T) {
 	ner := nodeEventReader{}
 	ner.readEvents(feed)
 
+	d := 5 * time.Second
+
 	get := wrap(&roachpb.GetRequest{})
-	nodefeed.CallComplete(get, &roachpb.Error{
+	nodefeed.CallComplete(get, d, &roachpb.Error{
 		TransactionRestart: roachpb.TransactionRestart_BACKOFF})
-	nodefeed.CallComplete(get, &roachpb.Error{
+	nodefeed.CallComplete(get, d, &roachpb.Error{
 		TransactionRestart: roachpb.TransactionRestart_IMMEDIATE})
-	nodefeed.CallComplete(wrap(&roachpb.PutRequest{}), &roachpb.Error{
+	nodefeed.CallComplete(wrap(&roachpb.PutRequest{}), d, &roachpb.Error{
 		TransactionRestart: roachpb.TransactionRestart_ABORT})
-	nodefeed.CallComplete(wrap(&roachpb.PutRequest{}), &roachpb.Error{
+	nodefeed.CallComplete(wrap(&roachpb.PutRequest{}), d, &roachpb.Error{
 		Detail: &roachpb.ErrorDetail{
 			WriteIntent: &roachpb.WriteIntentError{
 				Index: &roachpb.ErrPosition{Index: 0},

--- a/server/status/monitor_test.go
+++ b/server/status/monitor_test.go
@@ -27,6 +27,7 @@ import (
 	"github.com/cockroachdb/cockroach/storage/engine"
 	"github.com/cockroachdb/cockroach/util"
 	"github.com/cockroachdb/cockroach/util/leaktest"
+	"github.com/cockroachdb/cockroach/util/metric"
 	"github.com/cockroachdb/cockroach/util/stop"
 )
 
@@ -58,7 +59,7 @@ func TestNodeStatusMonitor(t *testing.T) {
 
 	stopper := stop.NewStopper()
 	feed := util.NewFeed(stopper)
-	monitor := NewNodeStatusMonitor()
+	monitor := NewNodeStatusMonitor(metric.NewRegistry())
 	monitor.StartMonitorFeed(feed)
 
 	for i := 0; i < 3; i++ {
@@ -163,10 +164,10 @@ func TestNodeStatusMonitor(t *testing.T) {
 		}
 	}
 
-	if a, e := monitor.callCount.Count(), int64(6); a != e {
+	if a, e := monitor.mSuccess.Count(), int64(6); a != e {
 		t.Errorf("monitored stats for node recorded wrong number of ops %d, expected %d", a, e)
 	}
-	if a, e := monitor.callErrors.Count(), int64(3); a != e {
+	if a, e := monitor.mError.Count(), int64(3); a != e {
 		t.Errorf("monitored stats for node recorded wrong number of errors %d, expected %d", a, e)
 	}
 }

--- a/server/status/recorder.go
+++ b/server/status/recorder.go
@@ -19,13 +19,13 @@ package status
 import (
 	"strconv"
 
-	"github.com/rcrowley/go-metrics"
-
 	"github.com/cockroachdb/cockroach/roachpb"
 	"github.com/cockroachdb/cockroach/storage"
 	"github.com/cockroachdb/cockroach/ts"
 	"github.com/cockroachdb/cockroach/util/hlc"
 	"github.com/cockroachdb/cockroach/util/log"
+	"github.com/cockroachdb/cockroach/util/metric"
+	"github.com/gogo/protobuf/proto"
 )
 
 const (
@@ -39,6 +39,22 @@ const (
 	// record runtime system stats on a node.
 	runtimeStatTimeSeriesNameFmt = "cr.node.sys.%s"
 )
+
+type quantile struct {
+	suffix   string
+	quantile float64
+}
+
+var recordHistogramQuantiles = []quantile{
+	{"-max", 100},
+	{"-p99.999", 99.999},
+	{"-p99.99", 99.99},
+	{"-p99.9", 99.9},
+	{"-p99", 99},
+	{"-p90", 90},
+	{"-p75", 75},
+	{"-p50", 50},
+}
 
 // NodeStatusRecorder is used to periodically persist the status of a node as a
 // set of time series data.
@@ -165,14 +181,14 @@ func (nsr *NodeStatusRecorder) GetStatusSummaries() (*NodeStatus, []storage.Stor
 // registryRecorder is a helper class for recording time series datapoints
 // from a metrics Registry.
 type registryRecorder struct {
-	registry       metrics.Registry
+	registry       *metric.Registry
 	prefix         string
 	source         string
 	timestampNanos int64
 }
 
 func (rr registryRecorder) record(dest *[]ts.TimeSeriesData) {
-	rr.registry.Each(func(name string, metric interface{}) {
+	rr.registry.Each(func(name string, m interface{}) {
 		data := ts.TimeSeriesData{
 			Name:   rr.prefix + name,
 			Source: rr.source,
@@ -183,11 +199,28 @@ func (rr registryRecorder) record(dest *[]ts.TimeSeriesData) {
 			},
 		}
 		// The method for extracting data differs based on the type of metric.
-		switch metric := metric.(type) {
-		case metrics.Counter:
-			data.Datapoints[0].Value = float64(metric.Count())
-		case metrics.Gauge:
-			data.Datapoints[0].Value = float64(metric.Value())
+		// TODO(tschottdorf): should make this based on interfaces.
+		switch mtr := m.(type) {
+		case float64:
+			data.Datapoints[0].Value = mtr
+		case *metric.Rates:
+			data.Datapoints[0].Value = float64(mtr.Count())
+		case *metric.Counter:
+			data.Datapoints[0].Value = float64(mtr.Count())
+		case *metric.Gauge:
+			data.Datapoints[0].Value = float64(mtr.Value())
+		case *metric.Histogram:
+			h := mtr.Current()
+			for _, pt := range recordHistogramQuantiles {
+				d := *proto.Clone(&data).(*ts.TimeSeriesData)
+				d.Name += pt.suffix
+				d.Datapoints[0].Value = float64(h.ValueAtQuantile(pt.quantile))
+				*dest = append(*dest, d)
+			}
+			return
+		default:
+			log.Warningf("cannot serialize for time series: %T", mtr)
+			return
 		}
 		*dest = append(*dest, data)
 	})

--- a/server/status/runtime.go
+++ b/server/status/runtime.go
@@ -29,6 +29,19 @@ import (
 	"github.com/cockroachdb/cockroach/util/log"
 )
 
+const (
+	nameCgoCalls       = "cgocalls"
+	nameGoroutines     = "goroutines"
+	nameAllocBytes     = "allocbytes"
+	nameGCCount        = "gc.count"
+	nameGCPauseNS      = "gc.pause.ns"
+	nameGCPausePercent = "gc.pause.percent"
+	nameCPUUserNS      = "cpu.user.ns"
+	nameCPUUserPercent = "cpu.user.percent"
+	nameCPUSysNS       = "cpu.sys.ns"
+	nameCPUSysPercent  = "cpu.sys.percent"
+)
+
 // RuntimeStatRecorder is used to periodically persist useful runtime statistics
 // as time series data. "Runtime statistics" include OS-level statistics (such as
 // memory and CPU usage) and Go runtime statistics (e.g. count of Goroutines).
@@ -82,6 +95,9 @@ func (rsr *RuntimeStatRecorder) record(timestampNanos int64, name string,
 // one method because it is convenient; however, in the future querying and
 // recording can be easily separated, similar to the way that NodeStatus is
 // separated into a monitor and a recorder.
+//
+// TODO(tschottdorf): turn various things here into gauges and register them
+// with the metrics registry.
 func (rsr *RuntimeStatRecorder) GetTimeSeriesData() []ts.TimeSeriesData {
 	data := make([]ts.TimeSeriesData, 0, rsr.lastDataCount)
 
@@ -122,16 +138,16 @@ func (rsr *RuntimeStatRecorder) GetTimeSeriesData() []ts.TimeSeriesData {
 	rsr.lastCgoCall = numCgoCall
 	rsr.lastNumGC = ms.NumGC
 
-	data = append(data, rsr.record(now, "cgocalls", float64(numCgoCall)))
-	data = append(data, rsr.record(now, "goroutines", float64(numGoroutine)))
-	data = append(data, rsr.record(now, "allocbytes", float64(ms.Alloc)))
-	data = append(data, rsr.record(now, "gc.count", float64(ms.NumGC)))
-	data = append(data, rsr.record(now, "gc.pause.ns", float64(ms.PauseTotalNs)))
-	data = append(data, rsr.record(now, "gc.pause.percent", pausePerc))
-	data = append(data, rsr.record(now, "cpu.user.ns", float64(newUtime)))
-	data = append(data, rsr.record(now, "cpu.user.percent", uPerc))
-	data = append(data, rsr.record(now, "cpu.sys.ns", float64(newStime)))
-	data = append(data, rsr.record(now, "cpu.sys.percent", sPerc))
+	data = append(data, rsr.record(now, nameCgoCalls, float64(numCgoCall)))
+	data = append(data, rsr.record(now, nameGoroutines, float64(numGoroutine)))
+	data = append(data, rsr.record(now, nameAllocBytes, float64(ms.Alloc)))
+	data = append(data, rsr.record(now, nameGCCount, float64(ms.NumGC)))
+	data = append(data, rsr.record(now, nameGCPauseNS, float64(ms.PauseTotalNs)))
+	data = append(data, rsr.record(now, nameGCPausePercent, pausePerc))
+	data = append(data, rsr.record(now, nameCPUUserNS, float64(newUtime)))
+	data = append(data, rsr.record(now, nameCPUUserPercent, uPerc))
+	data = append(data, rsr.record(now, nameCPUSysNS, float64(newStime)))
+	data = append(data, rsr.record(now, nameCPUSysPercent, sPerc))
 	rsr.lastDataCount = len(data)
 	return data
 }

--- a/sql/executor.go
+++ b/sql/executor.go
@@ -34,6 +34,7 @@ import (
 	"github.com/cockroachdb/cockroach/sql/parser"
 	"github.com/cockroachdb/cockroach/util"
 	"github.com/cockroachdb/cockroach/util/log"
+	"github.com/cockroachdb/cockroach/util/metric"
 	"github.com/cockroachdb/cockroach/util/retry"
 	"github.com/cockroachdb/cockroach/util/stop"
 )
@@ -69,6 +70,8 @@ type Executor struct {
 	reCache  *parser.RegexpCache
 	leaseMgr *LeaseManager
 
+	latency metric.Histograms
+
 	// System Config and mutex.
 	systemConfig     config.SystemConfig
 	systemConfigMu   sync.RWMutex
@@ -77,11 +80,13 @@ type Executor struct {
 
 // newExecutor creates an Executor and registers a callback on the
 // system config.
-func newExecutor(db client.DB, gossip *gossip.Gossip, leaseMgr *LeaseManager, stopper *stop.Stopper) *Executor {
+func newExecutor(db client.DB, gossip *gossip.Gossip, leaseMgr *LeaseManager, metaRegistry *metric.Registry, stopper *stop.Stopper) *Executor {
 	exec := &Executor{
 		db:       db,
 		reCache:  parser.NewRegexpCache(512),
 		leaseMgr: leaseMgr,
+
+		latency: metaRegistry.Latency("sql.latency"),
 	}
 	exec.systemConfigCond = sync.NewCond(&exec.systemConfigMu)
 
@@ -225,6 +230,9 @@ func (e *Executor) ExecuteStatements(user string, session Session, stmts string,
 // Execute the statement(s) in the given request and returns a response.
 // On error, the returned integer is an HTTP error code.
 func (e *Executor) Execute(args driver.Request) (driver.Response, int, error) {
+	defer func(start time.Time) {
+		e.latency.RecordValue(time.Now().Sub(start).Nanoseconds())
+	}(time.Now())
 	var session Session
 	if err := proto.Unmarshal(args.Session, &session); err != nil {
 		return driver.Response{}, http.StatusBadRequest, err

--- a/sql/server.go
+++ b/sql/server.go
@@ -29,6 +29,7 @@ import (
 	"github.com/cockroachdb/cockroach/security"
 	"github.com/cockroachdb/cockroach/sql/driver"
 	"github.com/cockroachdb/cockroach/util"
+	"github.com/cockroachdb/cockroach/util/metric"
 	"github.com/cockroachdb/cockroach/util/stop"
 	"github.com/gogo/protobuf/proto"
 )
@@ -43,8 +44,11 @@ type Server struct {
 }
 
 // MakeServer creates a Server.
-func MakeServer(ctx *base.Context, db client.DB, gossip *gossip.Gossip, leaseMgr *LeaseManager, stopper *stop.Stopper) Server {
-	return Server{context: ctx, Executor: newExecutor(db, gossip, leaseMgr, stopper)}
+func MakeServer(ctx *base.Context, db client.DB, gossip *gossip.Gossip, leaseMgr *LeaseManager, metaRegistry *metric.Registry, stopper *stop.Stopper) Server {
+	return Server{
+		context:  ctx,
+		Executor: newExecutor(db, gossip, leaseMgr, metaRegistry, stopper),
+	}
 }
 
 // ServeHTTP serves the SQL API by treating the request URL path

--- a/ui/ts/pages/graph.ts
+++ b/ui/ts/pages/graph.ts
@@ -45,13 +45,13 @@ module AdminViews {
         };
 
         // Define selectors.
-        private successCount: Metrics.Select.Selector = Metrics.Select.Avg("cr.node.calls.success.1")
+        private successCount: Metrics.Select.Selector = Metrics.Select.Avg("cr.node.exec.success.count.1")
           .title("Successful calls");
-        private errorCount: Metrics.Select.Selector = Metrics.Select.Avg("cr.node.calls.error.1")
+        private errorCount: Metrics.Select.Selector = Metrics.Select.Avg("cr.node.exec.error.count.1")
           .title("Error calls");
-        private successRate: Metrics.Select.Selector = Metrics.Select.AvgRate("cr.node.calls.success.1")
+        private successRate: Metrics.Select.Selector = Metrics.Select.AvgRate("cr.node.exec.success.count.1")
           .title("Successful call rate");
-        private errorRate: Metrics.Select.Selector = Metrics.Select.AvgRate("cr.node.calls.error.1")
+        private errorRate: Metrics.Select.Selector = Metrics.Select.AvgRate("cr.node.exec.error.count.1")
           .title("Error call rate");
 
         // Define query.

--- a/ui/ts/pages/nodes.ts
+++ b/ui/ts/pages/nodes.ts
@@ -217,7 +217,7 @@ module AdminViews {
 
           this._addChart(
             Metrics.NewAxis(
-              Metrics.Select.AvgRate(_nodeMetric("calls.error"))
+              Metrics.Select.AvgRate(_nodeMetric("exec.error.count"))
                 .sources(this.sources)
                 .title("Error Calls")
               ));
@@ -381,14 +381,14 @@ module AdminViews {
           this._query = Metrics.NewQuery();
           this._addChart(
             Metrics.NewAxis(
-              Metrics.Select.AvgRate(_nodeMetric("calls.success"))
+              Metrics.Select.AvgRate(_nodeMetric("exec.success.count"))
                 .sources([nodeId])
                 .title("Successful Calls")
               )
               .label("Count / 10 sec."));
           this._addChart(
             Metrics.NewAxis(
-              Metrics.Select.AvgRate(_nodeMetric("calls.error"))
+              Metrics.Select.AvgRate(_nodeMetric("exec.error.count"))
                 .sources([nodeId])
                 .title("Error Calls")
               )

--- a/util/metric/metric.go
+++ b/util/metric/metric.go
@@ -1,0 +1,270 @@
+// Copyright 2015 The Cockroach Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+// implied. See the License for the specific language governing
+// permissions and limitations under the License.
+//
+// Author: Tobias Schottdorf (tobias.schottdorf@gmail.com)
+
+package metric
+
+import (
+	"encoding/json"
+	"fmt"
+	"sync"
+	"time"
+
+	"github.com/VividCortex/ewma"
+	"github.com/codahale/hdrhistogram"
+	"github.com/rcrowley/go-metrics"
+)
+
+const histWrapNum = 4 // number of histograms to keep in rolling window
+
+// A TimeScale is a named duration.
+type TimeScale struct {
+	name string
+	d    time.Duration
+}
+
+var scale1M = TimeScale{"1m", 1 * time.Minute}
+var scale10M = TimeScale{"10m", 10 * time.Minute}
+var scale1H = TimeScale{"1h", time.Hour}
+
+// Iterable provides a method for synchronized access to interior objects.
+type Iterable interface {
+	// Each calls the given closure with each contained item.
+	Each(func(string, interface{}))
+}
+
+var _ Iterable = &Gauge{}
+var _ Iterable = &Counter{}
+var _ Iterable = &Histogram{}
+var _ Iterable = &Rate{}
+
+var _ json.Marshaler = &Gauge{}
+var _ json.Marshaler = &Counter{}
+var _ json.Marshaler = &Histogram{}
+var _ json.Marshaler = &Rate{}
+var _ json.Marshaler = &Registry{}
+
+type periodic interface {
+	nextTick() time.Time
+	tick()
+}
+
+var _ periodic = &Histogram{}
+var _ periodic = &Rate{}
+
+var now = time.Now
+
+func maybeTick(m periodic) {
+	for m.nextTick().Before(now()) {
+		m.tick()
+	}
+}
+
+// A Histogram is a wrapper around an hdrhistogram.WindowedHistogram.
+type Histogram struct {
+	maxVal int64
+
+	mu       sync.Mutex
+	windowed *hdrhistogram.WindowedHistogram
+	interval time.Duration
+	nextT    time.Time
+}
+
+// NewHistogram creates a new windowed HDRHistogram with the given parameters.
+// Data is kept in the active window for approximately the given duration.
+// See the the documentation for hdrhistogram.WindowedHistogram for details.
+func NewHistogram(duration time.Duration, maxVal int64, sigFigs int) *Histogram {
+	h := &Histogram{}
+	h.maxVal = int64(maxVal)
+	h.interval = duration / histWrapNum
+	h.nextT = now()
+
+	h.windowed = hdrhistogram.NewWindowed(histWrapNum, 0, h.maxVal, sigFigs)
+	return h
+}
+
+func (h *Histogram) tick() {
+	h.nextT = h.nextT.Add(h.interval)
+	h.windowed.Rotate()
+}
+
+func (h *Histogram) nextTick() time.Time {
+	return h.nextT
+}
+
+// MarshalJSON outputs to JSON.
+func (h *Histogram) MarshalJSON() ([]byte, error) {
+	h.mu.Lock()
+	maybeTick(h)
+	m := h.windowed.Merge().CumulativeDistribution()
+	h.mu.Unlock()
+	return json.Marshal(m)
+}
+
+// RecordValue adds the given value to the histogram, truncating if necessary.
+func (h *Histogram) RecordValue(v int64) {
+	h.mu.Lock()
+	defer h.mu.Unlock()
+	maybeTick(h)
+	for h.windowed.Current.RecordValue(v) != nil {
+		v = h.maxVal
+	}
+}
+
+// Current returns a copy of the data currently in the window.
+func (h *Histogram) Current() *hdrhistogram.Histogram {
+	h.mu.Lock()
+	maybeTick(h)
+	export := h.windowed.Merge().Export()
+	h.mu.Unlock()
+	return hdrhistogram.Import(export)
+}
+
+// Each calls the closure with the empty string and the receiver.
+func (h *Histogram) Each(f func(string, interface{})) {
+	h.mu.Lock()
+	maybeTick(h)
+	h.mu.Unlock()
+	f("", h)
+}
+
+// Histograms is a slice of Histogram metrics.
+type Histograms []*Histogram
+
+// RecordValue calls through to each individual Histogram.
+func (hs Histograms) RecordValue(v int64) {
+	for _, h := range hs {
+		h.RecordValue(v)
+	}
+}
+
+// A Counter holds a single mutable atomic value.
+type Counter struct {
+	metrics.Counter
+}
+
+// NewCounter creates a counter.
+func NewCounter() *Counter {
+	return &Counter{metrics.NewCounter()}
+}
+
+// Each calls the given closure with the empty string and itself.
+func (c *Counter) Each(f func(string, interface{})) { f("", c) }
+
+// MarshalJSON marshals to JSON.
+func (c *Counter) MarshalJSON() ([]byte, error) {
+	return json.Marshal(c.Counter.Count())
+}
+
+// A Gauge atomically stores a single value.
+type Gauge struct {
+	metrics.Gauge
+}
+
+// NewGauge creates a Gauge.
+func NewGauge() *Gauge {
+	g := &Gauge{metrics.NewGauge()}
+	return g
+}
+
+// Each calls the given closure with the empty string and itself.
+func (g *Gauge) Each(f func(string, interface{})) { f("", g) }
+
+// MarshalJSON marshals to JSON.
+func (g *Gauge) MarshalJSON() ([]byte, error) {
+	return json.Marshal(g.Gauge.Value())
+}
+
+// A Rate is a exponential weighted moving average.
+type Rate struct {
+	mu       sync.Mutex // protects fields below
+	curSum   float64
+	wrapped  ewma.MovingAverage
+	interval time.Duration
+	nextT    time.Time
+}
+
+// NewRate creates an EWMA rate on the given timescale. Timescales at
+// or below 2s are illegal and will cause a panic.
+func NewRate(timescale time.Duration) *Rate {
+	const tickInterval = time.Second
+	if timescale <= 2*time.Second {
+		panic(fmt.Sprintf("EWMA with per-second ticks makes no sense on timescale %s", timescale))
+	}
+	avgAge := float64(timescale) / float64(2*tickInterval)
+
+	return &Rate{
+		interval: tickInterval,
+		nextT:    now(),
+		wrapped:  ewma.NewMovingAverage(avgAge),
+	}
+}
+
+// Value returns the current value of the Rate.
+func (e *Rate) Value() float64 {
+	e.mu.Lock()
+	defer e.mu.Unlock()
+	maybeTick(e)
+	return e.wrapped.Value()
+}
+
+func (e *Rate) nextTick() time.Time {
+	return e.nextT
+}
+
+func (e *Rate) tick() {
+	e.nextT = e.nextT.Add(e.interval)
+	e.wrapped.Add(e.curSum)
+	e.curSum = 0
+}
+
+// Add adds the given measurement to the Rate.
+func (e *Rate) Add(v float64) {
+	e.mu.Lock()
+	maybeTick(e)
+	e.curSum += v
+	e.mu.Unlock()
+}
+
+// Each calls the given closure with the empty string and the Rate's current value.
+func (e *Rate) Each(f func(string, interface{})) {
+	e.mu.Lock()
+	maybeTick(e)
+	v := e.wrapped.Value()
+	e.mu.Unlock()
+	f("", v)
+}
+
+// MarshalJSON marshals to JSON.
+func (e *Rate) MarshalJSON() ([]byte, error) {
+	e.mu.Lock()
+	defer e.mu.Unlock()
+	maybeTick(e)
+	return json.Marshal(e.wrapped.Value())
+}
+
+// Rates is a counter and associated EWMA backed rates at different time scales.
+type Rates struct {
+	*Counter
+	Rates []*Rate
+}
+
+// Add adds the given value to all contained objects.
+func (es Rates) Add(v int64) {
+	es.Counter.Inc(v)
+	for _, e := range es.Rates {
+		e.Add(float64(v))
+	}
+}

--- a/util/metric/metric_test.go
+++ b/util/metric/metric_test.go
@@ -1,0 +1,127 @@
+// Copyright 2015 The Cockroach Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+// implied. See the License for the specific language governing
+// permissions and limitations under the License.
+//
+// Author: Tobias Schottdorf (tobias.schottdorf@gmail.com)
+
+package metric
+
+import (
+	"bytes"
+	"encoding/json"
+	"testing"
+	"time"
+
+	_ "github.com/cockroachdb/cockroach/util/log" // for flags
+)
+
+func testMarshal(t *testing.T, m json.Marshaler, exp string) {
+	if b, err := m.MarshalJSON(); err != nil || !bytes.Equal(b, []byte(exp)) {
+		t.Fatalf("unexpected: err=%v\nbytes=%s\nwanted=%s\nfor:\n%+v", err, b, exp, m)
+	}
+}
+
+func TestGauge(t *testing.T) {
+	g := NewGauge()
+	g.Update(10)
+	if v := g.Value(); v != 10 {
+		t.Fatalf("unexpected value: %d", v)
+	}
+	testMarshal(t, g, "10")
+
+}
+
+func TestCounter(t *testing.T) {
+	c := NewCounter()
+	c.Inc(100)
+	c.Dec(10)
+	if v := c.Count(); v != 90 {
+		t.Fatalf("unexpected value: %d", v)
+	}
+
+	testMarshal(t, c, "90")
+}
+
+func setNow(d time.Duration) {
+	now = func() time.Time {
+		return time.Time{}.Add(d)
+	}
+}
+
+func TestHistogramRotate(t *testing.T) {
+	setNow(0)
+	h := NewHistogram(histWrapNum*time.Second, 1000+10*histWrapNum, 3)
+	var cur time.Duration
+	for i := 0; i < 3*histWrapNum; i++ {
+		v := int64(10 * i)
+		h.RecordValue(v)
+		cur += time.Second
+		setNow(cur)
+		cur := h.Current()
+
+		// When i == histWrapNum-1, we expect the entry from i==0 to move out
+		// of the window (since we rotated for the histWrapNum'th time).
+		expMin := int64((1 + i - (histWrapNum - 1)) * 10)
+		if expMin < 0 {
+			expMin = 0
+		}
+
+		if min := cur.Min(); min != expMin {
+			t.Fatalf("%d: unexpected minimum %d, expected %d", i, min, expMin)
+		}
+
+		if max, expMax := cur.Max(), v; max != expMax {
+			t.Fatalf("%d: unexpected maximum %d, expected %d", i, max, expMax)
+		}
+	}
+}
+
+func TestHistogramJSON(t *testing.T) {
+	h := NewHistogram(0, 1, 3)
+	testMarshal(t, h, `[{"Quantile":100,"Count":0,"ValueAt":0}]`)
+	h.RecordValue(1)
+	testMarshal(t, h, `[{"Quantile":0,"Count":1,"ValueAt":1},{"Quantile":100,"Count":1,"ValueAt":1}]`)
+}
+
+func TestRateRotate(t *testing.T) {
+	setNow(0)
+	const interval = 10 * time.Second
+	r := NewRate(interval)
+
+	// Skip the warmup phase of the wrapped EWMA for this test.
+	for i := 0; i < 100; i++ {
+		r.wrapped.Add(0)
+	}
+
+	// Put something nontrivial in.
+	r.Add(100)
+
+	for cur := time.Duration(0); cur < 5*interval; cur += time.Second / 2 {
+		prevVal := r.Value()
+		setNow(cur)
+		curVal := r.Value()
+		expChange := (cur % time.Second) != 0
+		hasChange := prevVal != curVal
+		if expChange != hasChange {
+			t.Fatalf("%s: expChange %t, hasChange %t (from %v to %v)",
+				cur, expChange, hasChange, prevVal, curVal)
+		}
+	}
+
+	v := r.Value()
+	if v > .1 {
+		t.Fatalf("final value implausible: %v", v)
+	}
+	expBytes, _ := json.Marshal(v)
+	testMarshal(t, r, string(expBytes))
+}

--- a/util/metric/registry.go
+++ b/util/metric/registry.go
@@ -1,0 +1,154 @@
+// Copyright 2015 The Cockroach Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+// implied. See the License for the specific language governing
+// permissions and limitations under the License.
+//
+// Author: Tobias Schottdorf (tobias.schottdorf@gmail.com)
+
+package metric
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"sync"
+	"time"
+)
+
+const sep = "-"
+
+// DefaultTimeScales are the durations used for helpers which create windowed
+// metrics in bulk (such as Latency or Rates).
+var DefaultTimeScales = []TimeScale{scale1M, scale10M, scale1H}
+
+// A Registry bundles up various iterables (i.e. typically metrics or other
+// registries) to provide a single point of access to them.
+type Registry struct {
+	sync.Mutex
+	tracked map[string]Iterable
+}
+
+// NewRegistry creates a new Registry.
+func NewRegistry() *Registry {
+	return &Registry{
+		tracked: map[string]Iterable{},
+	}
+}
+
+// Add links the given Iterable into this registry using the given format
+// string. The individual items in the registry will be formatted via
+// fmt.Sprintf(format, <name>). As a special case, *Registry implements
+// Iterable and can thus be added.
+// Metric types in this package have helpers that allow them to be created
+// and registered in a single step. Add is called manually only when adding
+// a registry to another, or when integrating metrics defined elsewhere.
+func (r *Registry) Add(format string, item Iterable) error {
+	r.Lock()
+	defer r.Unlock()
+	if _, ok := r.tracked[format]; ok {
+		return errors.New("format string already in use")
+	}
+	r.tracked[format] = item
+	return nil
+}
+
+// MustAdd calls Add and panics on error.
+func (r *Registry) MustAdd(format string, item Iterable) {
+	if err := r.Add(format, item); err != nil {
+		panic(err)
+	}
+}
+
+// Each calls the given closure for all metrics.
+func (r *Registry) Each(f func(name string, val interface{})) {
+	r.Lock()
+	defer r.Unlock()
+	for format, registry := range r.tracked {
+		registry.Each(func(name string, v interface{}) {
+			if name == "" {
+				f(format, v)
+			} else {
+				f(fmt.Sprintf(format, name), v)
+			}
+		})
+	}
+}
+
+// MarshalJSON marshals to JSON.
+func (r *Registry) MarshalJSON() ([]byte, error) {
+	m := make(map[string]interface{})
+	r.Each(func(name string, v interface{}) {
+		m[name] = v
+	})
+	return json.Marshal(m)
+}
+
+// Histogram registers a new windowed HDRHistogram with the given parameters.
+// Data is kept in the active window for approximately the given duration.
+func (r *Registry) Histogram(name string, duration time.Duration, maxVal int64,
+	sigFigs int) *Histogram {
+	h := NewHistogram(duration, maxVal, sigFigs)
+	r.MustAdd(name, h)
+	return h
+}
+
+// Latency is a convenience function which registers histograms with
+// suitable defaults for latency tracking. Values are expressed in ns,
+// are truncated into the interval [0, time.Minute] and are recorded
+// with two digits of precision (i.e. errors of <1ms at 100ms, <.6s at 1m).
+// The generated names of the metric will begin with the given prefix.
+//
+// TODO(mrtracy,tschottdorf): need to discuss roll-ups and generally how (and
+// which) information flows between metrics and time series.
+func (r *Registry) Latency(prefix string) Histograms {
+	windows := DefaultTimeScales
+	hs := make([]*Histogram, 0, 3)
+	for _, w := range windows {
+		h := r.Histogram(prefix+sep+w.name, w.d, int64(time.Minute), 2)
+		hs = append(hs, h)
+	}
+	return hs
+}
+
+// Counter registers new counter to the registry.
+func (r *Registry) Counter(name string) *Counter {
+	c := NewCounter()
+	r.MustAdd(name, c)
+	return c
+}
+
+// Gauge registers a new Gauge with the given name.
+func (r *Registry) Gauge(name string) *Gauge {
+	g := NewGauge()
+	r.MustAdd(name, g)
+	return g
+}
+
+// Rate creates an EWMA rate over the given timescale. The comments on NewRate
+// apply.
+func (r *Registry) Rate(name string, timescale time.Duration) *Rate {
+	e := NewRate(timescale)
+	r.MustAdd(name, e)
+	return e
+}
+
+// Rates returns a slice of EWMAs prefixed with the given name and
+// various "standard" timescales.
+func (r *Registry) Rates(prefix string) Rates {
+	scales := DefaultTimeScales
+	es := make([]*Rate, 0, len(scales))
+	for _, scale := range scales {
+		es = append(es, r.Rate(prefix+sep+scale.name, scale.d))
+	}
+	c := r.Counter(prefix + sep + "count")
+	return Rates{Counter: c, Rates: es}
+}

--- a/util/metric/registry_test.go
+++ b/util/metric/registry_test.go
@@ -1,0 +1,68 @@
+// Copyright 2015 The Cockroach Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+// implied. See the License for the specific language governing
+// permissions and limitations under the License.
+//
+// Author: Tobias Schottdorf (tobias.schottdorf@gmail.com)
+
+package metric
+
+import (
+	"testing"
+	"time"
+)
+
+func TestRegistry(t *testing.T) {
+	r := NewRegistry()
+	sub := NewRegistry()
+
+	_ = r.Gauge("top.gauge")
+	_ = r.Rate("top.rate", time.Minute)
+	_ = r.Rates("top.rates")
+	_ = r.Histogram("top.hist", time.Minute, 1000, 3)
+	_ = r.Latency("top.latency")
+
+	_ = sub.Gauge("gauge")
+	r.MustAdd("bottom.%s#1", sub)
+	if err := r.Add("bottom.%s#1", sub); err == nil {
+		t.Fatalf("expected failure on double-add")
+	}
+	_ = sub.Rates("rates")
+
+	expNames := map[string]struct{}{
+		"top.rate":             {},
+		"top.rates-count":      {},
+		"top.rates-1m":         {},
+		"top.rates-10m":        {},
+		"top.rates-1h":         {},
+		"top.hist":             {},
+		"top.latency-1m":       {},
+		"top.latency-10m":      {},
+		"top.latency-1h":       {},
+		"top.gauge":            {},
+		"bottom.gauge#1":       {},
+		"bottom.rates-count#1": {},
+		"bottom.rates-1m#1":    {},
+		"bottom.rates-10m#1":   {},
+		"bottom.rates-1h#1":    {},
+	}
+
+	r.Each(func(name string, _ interface{}) {
+		if _, exist := expNames[name]; !exist {
+			t.Errorf("unexpected name: %s", name)
+		}
+		delete(expNames, name)
+	})
+	if len(expNames) > 0 {
+		t.Fatalf("missed names: %v", expNames)
+	}
+}

--- a/util/randutil/rand_test.go
+++ b/util/randutil/rand_test.go
@@ -19,8 +19,8 @@ package randutil_test
 import (
 	"testing"
 
-	_ "github.com/cockroachdb/cockroach/util/log"
-	"github.com/cockroachdb/cockroach/util/randutil" // for flags
+	_ "github.com/cockroachdb/cockroach/util/log" // for flags
+	"github.com/cockroachdb/cockroach/util/randutil"
 )
 
 func TestPseudoRand(t *testing.T) {


### PR DESCRIPTION
This is a prototype for the collection of transient performance statistics.
It does not yet expose many "useful" runtime statistics, but is meant to lay
the groundwork for doing so across different parts of the system.

We were previously using the `go-metrics` package, which provides the concept
of a `Registry` bundling different metrics. Unfortunately, various limitations,
a certain amount of interface bloat (which made it annoying to provide custom
implementations) and various design choices made this unwieldy to work with
without upstream adaptations.
Instead, introduced the `util/metric` package which replaces the registry
functionality and provides light wrapper implementations around metrics.
Each registry object owns its metrics' goroutines and terminates them using
a closer channel; this allows for easy integration with `util.Stopper`.

Metric registries can be nested and in fact we do so, keeping one "global"
metrics registry and various others in it. In particular Node- and Store-level
metrics have individual registries. This is useful since this allows their
metrics to be stored to their corresponding time series with simple iterations
over a registry and with correct names globally and locally.

For now, we wrap `Counter`, `Gauge` and `EWMA` types and provide a windowed
histogram (based on Gil Tene's `HDRHistogram`s). Others (such as reservoir
backed histograms) can be added as required.

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/3504)

<!-- Reviewable:end -->
