### PR TITLE
acceptance test: more intensive gossip testing

### DIFF
--- a/acceptance/main_test.go
+++ b/acceptance/main_test.go
@@ -73,6 +73,7 @@ func farmer(t *testing.T) *terrafarm.Farmer {
 		LogDir:  logDir,
 		KeyName: *keyName,
 	}
+	f.WaitReady(t, *duration/5)
 	log.Infof("logging to %s", logDir)
 	return f
 }
@@ -92,10 +93,7 @@ func StartCluster(t *testing.T) cluster.Cluster {
 		t.Fatal("need to either specify -num-local or -num-remote")
 	}
 	f := farmer(t)
-	if err := f.Destroy(); err != nil {
-		t.Fatal(err)
-	}
-	if err := f.Add(*numRemote, 0); err != nil {
+	if err := f.Resize(*numRemote, 0); err != nil {
 		t.Fatal(err)
 	}
 	return f

--- a/acceptance/terraform_test.go
+++ b/acceptance/terraform_test.go
@@ -25,10 +25,10 @@ import (
 	"time"
 )
 
-// TestBuildCluster resizes the cluster to one node, one writer.
+// TestBuildBabyCluster resizes the cluster to one node, one writer.
 // It does not tear down the cluster after it's done and is mostly
 // useful for testing code changes in the `terrafarm` package.
-func TestBuildCluster(t *testing.T) {
+func TestBuildBabyCluster(t *testing.T) {
 	t.Skip("only enabled during testing")
 	f := farmer(t)
 	defer f.CollectLogs()


### PR DESCRIPTION
the idea behind is to be able to run a longer loop
of gossip restarts against a real cluster (which
is where they currently fail), accommodating for
the time needed until the load balancer resolves.

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/3509)

<!-- Reviewable:end -->
