### PR TITLE
acceptance: better debug output

### DIFF
--- a/acceptance/main_test.go
+++ b/acceptance/main_test.go
@@ -68,12 +68,11 @@ func farmer(t *testing.T) *terrafarm.Farmer {
 		logDir = filepath.Join(filepath.Clean(os.ExpandEnv("${PWD}")), logDir)
 	}
 	f := &terrafarm.Farmer{
-		Debug:   true,
+		Output:  os.Stderr,
 		Cwd:     *cwd,
 		LogDir:  logDir,
 		KeyName: *keyName,
 	}
-	f.WaitReady(t, *duration/5)
 	log.Infof("logging to %s", logDir)
 	return f
 }
@@ -95,6 +94,10 @@ func StartCluster(t *testing.T) cluster.Cluster {
 	f := farmer(t)
 	if err := f.Resize(*numRemote, 0); err != nil {
 		t.Fatal(err)
+	}
+	if err := f.WaitReady(5 * time.Minute); err != nil {
+		_ = f.Destroy()
+		t.Fatalf("cluster not ready in time: %v", err)
 	}
 	return f
 }

--- a/acceptance/terraform_test.go
+++ b/acceptance/terraform_test.go
@@ -45,9 +45,14 @@ func TestFiveNodesAndWriters(t *testing.T) {
 	deadline := time.After(*duration)
 	f := farmer(t)
 	defer f.MustDestroy()
-	if err := f.Resize(5, 5); err != nil {
+	const size = 5
+	if err := f.Resize(size, size); err != nil {
 		t.Fatal(err)
 	}
+	if err := f.WaitReady(3 * time.Minute); err != nil {
+		t.Fatal(err)
+	}
+	checkGossip(t, f, longWaitTime, hasPeers(size))
 
 	c := make(chan os.Signal, 1)
 	signal.Notify(c, os.Interrupt)


### PR DESCRIPTION
this pipes all the terraform-related output to stderr,
which makes it easier to separate it from the "usual"
test output (cleaning up the summary).

also fixed a bug introduced in the last PR which would
cause runs to fail due to the wrong location of the
WaitReady() call.

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/3510)

<!-- Reviewable:end -->
