### PR TITLE
Do not allow splits within rows.

### DIFF
--- a/client/db.go
+++ b/client/db.go
@@ -37,12 +37,12 @@ import (
 // timestamp. This is similar to roachpb.KeyValue except that the value may be
 // nil.
 type KeyValue struct {
-	Key   []byte
+	Key   roachpb.Key
 	Value *roachpb.Value
 }
 
 func (kv *KeyValue) String() string {
-	return string(kv.Key) + "=" + kv.PrettyValue()
+	return kv.Key.String() + "=" + kv.PrettyValue()
 }
 
 // Exists returns true iff the value exists.

--- a/client/db_test.go
+++ b/client/db_test.go
@@ -156,8 +156,8 @@ func ExampleBatch() {
 	}
 
 	// Output:
-	// aa=
-	// bb=2
+	// "aa"=
+	// "bb"=2
 }
 
 func ExampleDB_Scan() {
@@ -180,8 +180,8 @@ func ExampleDB_Scan() {
 	}
 
 	// Output:
-	// 0: aa=1
-	// 1: ab=2
+	// 0: "aa"=1
+	// 1: "ab"=2
 }
 
 func ExampleDB_ReverseScan() {
@@ -204,8 +204,8 @@ func ExampleDB_ReverseScan() {
 	}
 
 	// Output:
-	// 0: bb=3
-	// 1: ab=2
+	// 0: "bb"=3
+	// 1: "ab"=2
 }
 
 func ExampleDB_Del() {
@@ -231,8 +231,8 @@ func ExampleDB_Del() {
 	}
 
 	// Output:
-	// 0: aa=1
-	// 1: ac=3
+	// 0: "aa"=1
+	// 1: "ac"=3
 }
 
 func ExampleTxn_Commit() {
@@ -262,8 +262,8 @@ func ExampleTxn_Commit() {
 	}
 
 	// Output:
-	// 0/0: aa=1
-	// 1/0: ab=2
+	// 0/0: "aa"=1
+	// 1/0: "ab"=2
 }
 
 func ExampleDB_Put_insecure() {

--- a/config/config.go
+++ b/config/config.go
@@ -310,7 +310,7 @@ func (s SystemConfig) ComputeSplitKeys(startKey, endKey roachpb.RKey) []roachpb.
 	appendSplitKeys := func(startID, endID uint32) {
 		// endID could be smaller than startID if we don't have user tables.
 		for id := startID; id <= endID; id++ {
-			key = keys.MakeTablePrefix(id)
+			key = keys.MakeNonColumnKey(keys.MakeTablePrefix(id))
 			// Skip if this ID matches the startKey passed to ComputeSplitKeys.
 			if !startKey.Less(key) {
 				continue
@@ -323,8 +323,8 @@ func (s SystemConfig) ComputeSplitKeys(startKey, endKey roachpb.RKey) []roachpb.
 		}
 	}
 
-	// If they startKey falls within the non-system reserved range, compute
-	// those keys first.
+	// If the startKey falls within the non-system reserved range, compute those
+	// keys first.
 	if startID <= keys.MaxReservedDescID {
 		endID, err := s.GetLargestObjectID(keys.MaxReservedDescID)
 		if err != nil {

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -271,7 +271,7 @@ func TestComputeSplits(t *testing.T) {
 		{userSql, keys.MakeKey(keys.MakeTablePrefix(start), roachpb.RKey("foo")),
 			keys.MakeTablePrefix(start + 5), allUserSplits[1:5]},
 		{userSql, keys.MakeKey(keys.MakeTablePrefix(start), roachpb.RKey("foo")),
-			keys.MakeKey(keys.MakeTablePrefix(start+5), roachpb.RKey("bar")), allUserSplits[1:]},
+			keys.MakeKey(keys.MakeTablePrefix(start+5), roachpb.RKey("bar")), allUserSplits[1:5]},
 		{userSql, keys.MakeKey(keys.MakeTablePrefix(start), roachpb.RKey("foo")),
 			keys.MakeKey(keys.MakeTablePrefix(start), roachpb.RKey("morefoo")), nil},
 
@@ -293,7 +293,7 @@ func TestComputeSplits(t *testing.T) {
 		{allSql, keys.MakeTablePrefix(reservedStart), keys.MakeTablePrefix(start + 10), allSplits[1:]},
 		{allSql, roachpb.RKeyMin, keys.MakeTablePrefix(start + 2), allSplits[:5]},
 		{allSql, keys.MakeKey(keys.MakeTablePrefix(reservedStart), roachpb.RKey("foo")),
-			keys.MakeKey(keys.MakeTablePrefix(start+5), roachpb.RKey("foo")), allSplits[1:9]},
+			keys.MakeKey(keys.MakeTablePrefix(start+5), roachpb.RKey("foo")), allSplits[1:8]},
 	}
 
 	cfg := config.SystemConfig{}
@@ -307,7 +307,7 @@ func TestComputeSplits(t *testing.T) {
 		// Convert ints to actual keys.
 		expected := []roachpb.RKey{}
 		for _, s := range tc.splits {
-			expected = append(expected, keys.MakeTablePrefix(s))
+			expected = append(expected, keys.MakeNonColumnKey(keys.MakeTablePrefix(s)))
 		}
 		if !reflect.DeepEqual(splits, expected) {
 			t.Errorf("#%d: bad splits:\ngot: %v\nexpected: %v", tcNum, splits, expected)

--- a/keys/constants.go
+++ b/keys/constants.go
@@ -17,6 +17,8 @@
 package keys
 
 import (
+	"math"
+
 	"github.com/cockroachdb/cockroach/roachpb"
 	"github.com/cockroachdb/cockroach/util/encoding"
 )
@@ -163,9 +165,9 @@ var (
 	StatusNodePrefix = roachpb.Key(MakeKey(StatusPrefix, roachpb.RKey("node-")))
 
 	// TableDataMin is the start of the range of table data keys.
-	TableDataMin = roachpb.Key{encoding.IntMin}
+	TableDataMin = roachpb.Key(encoding.EncodeVarint(nil, math.MinInt64))
 	// TableDataMin is the end of the range of table data keys.
-	TableDataMax = roachpb.Key{encoding.IntMax, 0xff}
+	TableDataMax = roachpb.Key(encoding.EncodeVarint(nil, math.MaxInt64))
 
 	// ReservedTableDataMin is the start key of reserved structured data
 	// (excluding SystemDB).

--- a/sql/backfill.go
+++ b/sql/backfill.go
@@ -21,6 +21,7 @@ import (
 	"sort"
 
 	"github.com/cockroachdb/cockroach/client"
+	"github.com/cockroachdb/cockroach/keys"
 	"github.com/cockroachdb/cockroach/roachpb"
 	"github.com/cockroachdb/cockroach/sql/parser"
 	"github.com/cockroachdb/cockroach/util/log"
@@ -114,10 +115,17 @@ func (p *planner) backfillBatch(b *client.Batch, oldTableDesc, newTableDesc *Tab
 			var sentinelKey roachpb.Key
 			for _, kv := range result.Rows {
 				if sentinelKey == nil || !bytes.HasPrefix(kv.Key, sentinelKey) {
-					sentinelKey = kv.Key
+					// Sentinel keys have a 0 suffix indicating 0 bytes of column
+					// ID. Strip off that suffix to determine the prefix shared with the
+					// other keys for the row.
+					sentinelKey = stripColumnIDLength(kv.Key)
 					for _, columnDesc := range droppedColumnDescs {
 						// Delete the dropped column.
-						b.Del(MakeColumnKey(columnDesc.ID, sentinelKey))
+						colKey := keys.MakeColumnKey(sentinelKey, uint32(columnDesc.ID))
+						if log.V(2) {
+							log.Infof("Del %s", colKey)
+						}
+						b.Del(colKey)
 					}
 				}
 			}

--- a/sql/insert.go
+++ b/sql/insert.go
@@ -20,6 +20,7 @@ import (
 	"fmt"
 
 	"github.com/cockroachdb/cockroach/client"
+	"github.com/cockroachdb/cockroach/keys"
 	"github.com/cockroachdb/cockroach/sql/parser"
 	"github.com/cockroachdb/cockroach/sql/privilege"
 	"github.com/cockroachdb/cockroach/util"
@@ -195,12 +196,13 @@ func (p *planner) Insert(n *parser.Insert) (planNode, error) {
 		}
 
 		// Write the row sentinel.
+		sentinelKey := keys.MakeNonColumnKey(primaryIndexKey)
 		if log.V(2) {
-			log.Infof("CPut %s -> NULL", primaryIndexKey)
+			log.Infof("CPut %s -> NULL", sentinelKey)
 		}
 		// This is subtle: An interface{}(nil) deletes the value, so we pass in
 		// []byte{} as a non-nil value.
-		b.CPut(primaryIndexKey, []byte{}, nil)
+		b.CPut(sentinelKey, []byte{}, nil)
 
 		// Write the row columns.
 		for i, val := range rowVals {
@@ -217,7 +219,7 @@ func (p *planner) Insert(n *parser.Insert) (planNode, error) {
 				// considered NULL during scanning and the row sentinel ensures we know
 				// the row exists.
 
-				key := MakeColumnKey(col.ID, primaryIndexKey)
+				key := keys.MakeColumnKey(primaryIndexKey, uint32(col.ID))
 				if log.V(2) {
 					log.Infof("CPut %s -> %v", key, val)
 				}

--- a/sql/keys.go
+++ b/sql/keys.go
@@ -75,7 +75,7 @@ func MakeNameMetadataKey(parentID ID, name string) roachpb.Key {
 	k = encoding.EncodeUvarint(k, uint64(parentID))
 	if name != "" {
 		k = encoding.EncodeBytes(k, []byte(name))
-		k = encoding.EncodeUvarint(k, uint64(NamespaceTable.Columns[2].ID))
+		k = keys.MakeColumnKey(k, uint32(NamespaceTable.Columns[2].ID))
 	}
 	return k
 }
@@ -85,8 +85,7 @@ func MakeDescMetadataKey(descID ID) roachpb.Key {
 	k := keys.MakeTablePrefix(uint32(DescriptorTable.ID))
 	k = encoding.EncodeUvarint(k, uint64(DescriptorTable.PrimaryIndex.ID))
 	k = encoding.EncodeUvarint(k, uint64(descID))
-	k = encoding.EncodeUvarint(k, uint64(DescriptorTable.Columns[1].ID))
-	return k
+	return keys.MakeColumnKey(k, uint32(DescriptorTable.Columns[1].ID))
 }
 
 // MakeZoneKey returns the key for 'id's entry in the system.zones table.
@@ -94,20 +93,19 @@ func MakeZoneKey(id ID) roachpb.Key {
 	k := keys.MakeTablePrefix(uint32(ZonesTable.ID))
 	k = encoding.EncodeUvarint(k, uint64(ZonesTable.PrimaryIndex.ID))
 	k = encoding.EncodeUvarint(k, uint64(id))
-	k = encoding.EncodeUvarint(k, uint64(ZonesTable.Columns[1].ID))
-	return k
-}
-
-// MakeColumnKey returns the key for the column in the given row.
-func MakeColumnKey(colID ColumnID, primaryKey []byte) roachpb.Key {
-	var key []byte
-	key = append(key, primaryKey...)
-	return encoding.EncodeUvarint(key, uint64(colID))
+	return keys.MakeColumnKey(k, uint32(ZonesTable.Columns[1].ID))
 }
 
 // MakeIndexKeyPrefix returns the key prefix used for the index's data.
 func MakeIndexKeyPrefix(tableID ID, indexID IndexID) []byte {
 	key := keys.MakeTablePrefix(uint32(tableID))
 	key = encoding.EncodeUvarint(key, uint64(indexID))
+	return key
+}
+
+func stripColumnIDLength(key roachpb.Key) roachpb.Key {
+	if n := len(key); n > 0 {
+		return key[:n-1]
+	}
 	return key
 }

--- a/sql/lease.go
+++ b/sql/lease.go
@@ -632,22 +632,23 @@ func (m *LeaseManager) RefreshLeases(s *stop.Stopper, db *client.DB, gossip *gos
 					// Attempt to unmarshal config into a table/database descriptor.
 					var descriptor Descriptor
 					if err := kv.Value.GetProto(&descriptor); err != nil {
-						log.Warningf("unable to unmarshal descriptor %v", kv.Value)
+						log.Warningf("%s: unable to unmarshal descriptor %v", kv.Key, kv.Value)
 						continue
 					}
 					switch union := descriptor.Union.(type) {
 					case *Descriptor_Table:
 						table := union.Table
 						if err := table.Validate(); err != nil {
-							log.Errorf("received invalid table descriptor: %v", table)
+							log.Errorf("%s: received invalid table descriptor: %v", kv.Key, table)
 							continue
 						}
 						if log.V(2) {
-							log.Infof("refreshing lease table: %d, version: %d", table.ID, table.Version)
+							log.Infof("%s: refreshing lease table: %d, version: %d",
+								kv.Key, table.ID, table.Version)
 						}
 						// Try to refresh the table lease to one >= this version.
 						if err := m.refreshLease(db, table.ID, table.Version); err != nil {
-							log.Warning(err)
+							log.Warningf("%s: %v", kv.Key, err)
 						}
 
 					case *Descriptor_Database:

--- a/sql/update.go
+++ b/sql/update.go
@@ -21,6 +21,7 @@ import (
 	"fmt"
 
 	"github.com/cockroachdb/cockroach/client"
+	"github.com/cockroachdb/cockroach/keys"
 	"github.com/cockroachdb/cockroach/sql/parser"
 	"github.com/cockroachdb/cockroach/sql/privilege"
 	"github.com/cockroachdb/cockroach/util"
@@ -253,7 +254,7 @@ func (p *planner) Update(n *parser.Update) (planNode, error) {
 		for i, val := range newVals {
 			col := cols[i]
 
-			key := MakeColumnKey(col.ID, primaryIndexKey)
+			key := keys.MakeColumnKey(primaryIndexKey, uint32(col.ID))
 			if marshalled[i] != nil {
 				// We only output non-NULL values. Non-existent column keys are
 				// considered NULL during scanning and the row sentinel ensures we know

--- a/storage/engine/mvcc.go
+++ b/storage/engine/mvcc.go
@@ -111,27 +111,10 @@ func (k MVCCKey) String() string {
 	return fmt.Sprintf("%s/%s", k.Key, k.Timestamp)
 }
 
-type encodedSpan struct {
-	start, end MVCCKey
-}
-
 // MVCCKeyValue contains the raw bytes of the value for a key.
 type MVCCKeyValue struct {
 	Key   MVCCKey
 	Value []byte
-}
-
-// illegalSplitKeySpans lists spans of keys that should not be split.
-var illegalSplitKeySpans []encodedSpan
-
-func init() {
-	for _, r := range keys.NoSplitSpans {
-		illegalSplitKeySpans = append(illegalSplitKeySpans,
-			encodedSpan{
-				start: MakeMVCCMetadataKey(r.Key),
-				end:   MakeMVCCMetadataKey(r.EndKey),
-			})
-	}
 }
 
 // Value returns the inline value.
@@ -1519,26 +1502,17 @@ func MVCCGarbageCollect(engine Engine, ms *MVCCStats, keys []roachpb.GCRequest_G
 	return nil
 }
 
-// IsValidSplitKey returns whether the key is a valid split key.
-// Certain key ranges cannot be split; split keys chosen within
-// any of these ranges are considered invalid.
-//
-//   - \x00\x00meta1 < SplitKey < \x00\x00meta2
-//   - \x00zone < SplitKey < \x00zonf
-// And split key equal to Meta2KeyMax (\x00\x00meta2\xff\xff) is
-// considered invalid.
+// IsValidSplitKey returns whether the key is a valid split key. Certain key
+// ranges cannot be split (the meta1 span and the system DB span); split keys
+// chosen within any of these ranges are considered invalid. And a split key
+// equal to Meta2KeyMax (\x03\xff\xff) is considered invalid.
 func IsValidSplitKey(key roachpb.Key) bool {
+	// TODO(peter): What is this restriction about? Document.
 	if keys.Meta2KeyMax.Equal(key) {
 		return false
 	}
-	return isValidEncodedSplitKey(MakeMVCCMetadataKey(key))
-}
-
-// isValidEncodedSplitKey iterates through the illegal ranges and
-// returns true if the specified key falls within any; false otherwise.
-func isValidEncodedSplitKey(key MVCCKey) bool {
-	for _, rng := range illegalSplitKeySpans {
-		if rng.start.Less(key) && key.Less(rng.end) {
+	for _, span := range keys.NoSplitSpans {
+		if bytes.Compare(key, span.Key) >= 0 && bytes.Compare(key, span.EndKey) < 0 {
 			return false
 		}
 	}
@@ -1574,7 +1548,7 @@ func MVCCFindSplitKey(engine Engine, rangeID roachpb.RangeID, key, endKey roachp
 
 	if err := engine.Iterate(encStartKey, encEndKey, func(kv MVCCKeyValue) (bool, error) {
 		// Is key within a legal key range?
-		valid := isValidEncodedSplitKey(kv.Key)
+		valid := IsValidSplitKey(kv.Key.Key)
 
 		// Determine if this key would make a better split than last "best" key.
 		diff := targetSize - sizeSoFar
@@ -1606,8 +1580,8 @@ func MVCCFindSplitKey(engine Engine, rangeID roachpb.RangeID, key, endKey roachp
 		return nil, util.Errorf("the range cannot be split; considered range %q-%q has no valid splits", key, endKey)
 	}
 
-	// The key is an MVCC key, so to avoid corrupting MVCC we get the
-	// associated mvcc metadata key, which is fine to split in front of.
+	// The key is an MVCC (versioned) key, so to avoid corrupting MVCC we only
+	// return the base portion, which is fine to split in front of.
 	return bestSplitKey.Key, nil
 }
 

--- a/storage/replica_command.go
+++ b/storage/replica_command.go
@@ -1251,6 +1251,11 @@ func (r *Replica) AdminSplit(args roachpb.AdminSplitRequest, desc *roachpb.Range
 			return reply, roachpb.NewRangeKeyMismatchError(args.SplitKey, args.SplitKey, desc)
 		}
 
+		foundSplitKey, err := keys.MakeSplitKey(foundSplitKey)
+		if err != nil {
+			return reply, util.Errorf("cannot split range at key %s: %v", splitKey, err)
+		}
+
 		splitKey = keys.Addr(foundSplitKey)
 		if !splitKey.Equal(foundSplitKey) {
 			return reply, util.Errorf("cannot split range at range-local key %s", splitKey)

--- a/util/encoding/encoding.go
+++ b/util/encoding/encoding.go
@@ -168,14 +168,14 @@ func EncodeVarintDecreasing(b []byte, v int64) []byte {
 // are returned.
 func DecodeVarint(b []byte) ([]byte, int64, error) {
 	if len(b) == 0 {
-		return nil, 0, util.Errorf("insufficient bytes to decode var uint64 int value")
+		return nil, 0, util.Errorf("insufficient bytes to decode uvarint value")
 	}
 	length := int(b[0]) - intZero
 	if length < 0 {
 		length = -length
 		remB := b[1:]
 		if len(remB) < length {
-			return nil, 0, util.Errorf("insufficient bytes to decode var uint64 int value: %s", remB)
+			return nil, 0, util.Errorf("insufficient bytes to decode uvarint value: %s", remB)
 		}
 		var v int64
 		// Use the ones-complement of each encoded byte in order to build
@@ -278,7 +278,7 @@ func EncodeUvarintDecreasing(b []byte, v uint64) []byte {
 // are returned.
 func DecodeUvarint(b []byte) ([]byte, uint64, error) {
 	if len(b) == 0 {
-		return nil, 0, util.Errorf("insufficient bytes to decode var uint64 int value")
+		return nil, 0, util.Errorf("insufficient bytes to decode uvarint value")
 	}
 	length := int(b[0]) - intZero
 	b = b[1:] // skip length byte
@@ -289,7 +289,7 @@ func DecodeUvarint(b []byte) ([]byte, uint64, error) {
 	if length < 0 || length > 8 {
 		return nil, 0, util.Errorf("invalid uvarint length of %d", length)
 	} else if len(b) < length {
-		return nil, 0, util.Errorf("insufficient bytes to decode var uint64 int value: %v", b)
+		return nil, 0, util.Errorf("insufficient bytes to decode uvarint value: %v", b)
 	}
 	var v uint64
 	// It is faster to range over the elements in a slice than to index
@@ -304,14 +304,14 @@ func DecodeUvarint(b []byte) ([]byte, uint64, error) {
 // using EncodeUvarintDecreasing.
 func DecodeUvarintDecreasing(b []byte) ([]byte, uint64, error) {
 	if len(b) == 0 {
-		return nil, 0, util.Errorf("insufficient bytes to decode var uint64 int value")
+		return nil, 0, util.Errorf("insufficient bytes to decode uvarint value")
 	}
 	length := intZero - int(b[0])
 	b = b[1:] // skip length byte
 	if length < 0 || length > 8 {
 		return nil, 0, util.Errorf("invalid uvarint length of %d", length)
 	} else if len(b) < length {
-		return nil, 0, util.Errorf("insufficient bytes to decode var uint64 int value: %v", b)
+		return nil, 0, util.Errorf("insufficient bytes to decode uvarint value: %v", b)
 	}
 	var x uint64
 	for _, t := range b[:length] {


### PR DESCRIPTION
Append the column ID length to SQL generated keys. Added
keys.MakeSplitKey() which strips off the column ID from SQL table
keys. Utilize from within AdminSplit to prevent splitting within an SQL
row.

Changed the type of client.KeyValue.Key to roachpb.Key so that the Key
field pretty-prints without extra effort. Similarily, changed the type
of sql.indexEntry.key to roachpb.Key.

Fixes #3461.

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/3513)

<!-- Reviewable:end -->
